### PR TITLE
Fix upstream packager issues with msfupdate, etc.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ source 'https://rubygems.org'
 #   spec.add_runtime_dependency '<name>', [<version requirements>]
 gemspec name: 'metasploit-framework'
 
-gem 'bit-struct', git: 'https://github.com/busterb/bit-struct', branch: 'ruby-2.4'
 gem 'method_source', git: 'https://github.com/banister/method_source', branch: 'master'
 
 # separate from test as simplecov is not run on travis-ci

--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,6 @@ source 'https://rubygems.org'
 #   spec.add_runtime_dependency '<name>', [<version requirements>]
 gemspec name: 'metasploit-framework'
 
-gem 'method_source', git: 'https://github.com/banister/method_source', branch: 'master'
-
 # separate from test as simplecov is not run on travis-ci
 group :coverage do
   # code coverage for tests
@@ -17,7 +15,7 @@ group :development do
   # generating documentation
   gem 'yard'
   # for development and testing purposes
-  gem 'pry', git: 'https://github.com/pry/pry', branch: 'master'
+  gem 'pry'
   # module documentation
   gem 'octokit'
   # metasploit-aggregator as a framework only option for now

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,19 +1,3 @@
-GIT
-  remote: https://github.com/banister/method_source
-  revision: 0cc6cc8e15d08880585e8cb0c54e13c3cf937c54
-  branch: master
-  specs:
-    method_source (0.8.1)
-
-GIT
-  remote: https://github.com/pry/pry
-  revision: f19d3e2ae86a677e1e926016fa1a5763675e3659
-  branch: master
-  specs:
-    pry (0.10.4)
-      coderay (~> 1.1.0)
-      method_source (~> 0.8.1)
-
 PATH
   remote: .
   specs:
@@ -223,6 +207,7 @@ GEM
       railties (~> 4.2.6)
       recog (~> 2.0)
     metasploit_payloads-mettle (0.1.9)
+    method_source (0.8.2)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
@@ -253,6 +238,10 @@ GEM
       activerecord (>= 4.0.0)
       arel (>= 4.0.1)
       pg_array_parser (~> 0.0.9)
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
     public_suffix (2.0.5)
     rack (1.6.8)
     rack-test (0.6.3)
@@ -360,6 +349,7 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.1)
+    slop (3.6.0)
     sqlite3 (1.3.13)
     sshkey (1.9.0)
     thor (0.19.4)
@@ -385,9 +375,8 @@ DEPENDENCIES
   fivemat
   metasploit-aggregator
   metasploit-framework!
-  method_source!
   octokit
-  pry!
+  pry
   rake
   redcarpet
   rspec-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,13 +6,6 @@ GIT
     method_source (0.8.1)
 
 GIT
-  remote: https://github.com/busterb/bit-struct
-  revision: 707133ae6af5420be6fbe29be6baa5fbc929da2e
-  branch: ruby-2.4
-  specs:
-    bit-struct (0.15.0)
-
-GIT
   remote: https://github.com/pry/pry
   revision: f19d3e2ae86a677e1e926016fa1a5763675e3659
   branch: master
@@ -130,6 +123,7 @@ GEM
     backports (3.8.0)
     bcrypt (3.1.11)
     bindata (2.4.0)
+    bit-struct (0.16)
     builder (3.2.3)
     capybara (2.14.0)
       addressable
@@ -386,7 +380,6 @@ PLATFORMS
 
 DEPENDENCIES
   aruba
-  bit-struct!
   cucumber-rails
   factory_girl_rails
   fivemat

--- a/LICENSE_GEMS
+++ b/LICENSE_GEMS
@@ -6,20 +6,21 @@ activerecord, 4.2.8, MIT
 activesupport, 4.2.8, MIT
 addressable, 2.5.1, "Apache 2.0"
 arel, 6.0.4, MIT
-arel-helpers, 2.3.0, unknown
+arel-helpers, 2.4.0, unknown
 aruba, 0.14.2, MIT
+backports, 3.8.0, MIT
 bcrypt, 3.1.11, MIT
 bindata, 2.4.0, ruby
-bit-struct, 0.15.0, ruby
+bit-struct, 0.16, ruby
 builder, 3.2.3, MIT
-bundler, 1.14.6, MIT
+bundler, 1.15.0, MIT
 capybara, 2.14.0, MIT
 childprocess, 0.5.9, MIT
 coderay, 1.1.1, MIT
 contracts, 0.16.0, "Simplified BSD"
 cucumber, 2.4.0, MIT
 cucumber-core, 1.5.0, MIT
-cucumber-rails, 1.4.5, MIT
+cucumber-rails, 1.5.0, MIT
 cucumber-wire, 0.0.1, MIT
 diff-lcs, 1.3, "MIT, Artistic-2.0, GPL-2.0+"
 docile, 1.1.5, MIT
@@ -31,9 +32,9 @@ ffi, 1.9.18, "New BSD"
 filesize, 0.1.1, MIT
 fivemat, 1.3.3, MIT
 gherkin, 4.1.3, MIT
-google-protobuf, 3.2.0.2, "New BSD"
+google-protobuf, 3.3.0, "New BSD"
 googleauth, 0.5.1, "Apache 2.0"
-grpc, 1.2.5, "New BSD"
+grpc, 1.3.4, "New BSD"
 i18n, 0.8.1, MIT
 jsobfu, 0.4.2, "New BSD"
 json, 2.1.0, ruby
@@ -43,19 +44,19 @@ logging, 2.2.2, MIT
 loofah, 2.0.3, MIT
 memoist, 0.15.0, MIT
 metasm, 1.0.3, LGPL
-metasploit-aggregator, 0.1.3, "New BSD"
-metasploit-concern, 2.0.3, "New BSD"
-metasploit-credential, 2.0.8, "New BSD"
-metasploit-framework, 4.14.17, "New BSD"
-metasploit-model, 2.0.3, "New BSD"
-metasploit-payloads, 1.2.28, "3-clause (or ""modified"") BSD"
+metasploit-aggregator, 0.2.1, "New BSD"
+metasploit-concern, 2.0.4, "New BSD"
+metasploit-credential, 2.0.9, "New BSD"
+metasploit-framework, 4.14.23, "New BSD"
+metasploit-model, 2.0.4, "New BSD"
+metasploit-payloads, 1.2.29, "3-clause (or ""modified"") BSD"
 metasploit_data_models, 2.0.14, "New BSD"
 metasploit_payloads-mettle, 0.1.9, "3-clause (or ""modified"") BSD"
-method_source, 0.8.1, MIT
+method_source, 0.8.2, MIT
 mime-types, 3.1, MIT
 mime-types-data, 3.2016.0521, MIT
 mini_portile2, 2.1.0, MIT
-minitest, 5.10.1, MIT
+minitest, 5.10.2, MIT
 msgpack, 1.1.0, "Apache 2.0"
 multi_json, 1.12.1, MIT
 multi_test, 0.1.2, MIT
@@ -64,7 +65,7 @@ nessus_rest, 0.1.6, MIT
 net-ssh, 4.1.0, MIT
 network_interface, 0.0.1, MIT
 nexpose, 6.0.0, BSD
-nokogiri, 1.7.1, MIT
+nokogiri, 1.7.2, MIT
 octokit, 4.7.0, MIT
 openssl-ccm, 1.2.1, MIT
 openvas-omp, 0.0.4, MIT
@@ -77,7 +78,7 @@ pg_array_parser, 0.0.9, unknown
 postgres_ext, 3.0.0, MIT
 pry, 0.10.4, MIT
 public_suffix, 2.0.5, MIT
-rack, 1.6.5, MIT
+rack, 1.6.8, MIT
 rack-test, 0.6.3, MIT
 rails-deprecated_sanitizer, 1.0.3, MIT
 rails-dom-testing, 1.0.8, MIT
@@ -85,26 +86,26 @@ rails-html-sanitizer, 1.0.3, MIT
 railties, 4.2.8, MIT
 rake, 12.0.0, MIT
 rb-readline, 0.5.4, BSD
-recog, 2.1.6, unknown
+recog, 2.1.8, unknown
 redcarpet, 3.4.0, MIT
 rex-arch, 0.1.4, "New BSD"
-rex-bin_tools, 0.1.2, "New BSD"
-rex-core, 0.1.9, "New BSD"
-rex-encoder, 0.1.3, "New BSD"
-rex-exploitation, 0.1.13, "New BSD"
-rex-java, 0.1.4, "New BSD"
-rex-mime, 0.1.4, "New BSD"
-rex-nop, 0.1.0, unknown
-rex-ole, 0.1.5, "New BSD"
-rex-powershell, 0.1.71, "New BSD"
+rex-bin_tools, 0.1.3, "New BSD"
+rex-core, 0.1.10, "New BSD"
+rex-encoder, 0.1.4, "New BSD"
+rex-exploitation, 0.1.14, "New BSD"
+rex-java, 0.1.5, "New BSD"
+rex-mime, 0.1.5, "New BSD"
+rex-nop, 0.1.1, "New BSD"
+rex-ole, 0.1.6, "New BSD"
+rex-powershell, 0.1.72, "New BSD"
 rex-random_identifier, 0.1.2, "New BSD"
-rex-registry, 0.1.2, "New BSD"
-rex-rop_builder, 0.1.2, "New BSD"
-rex-socket, 0.1.5, "New BSD"
-rex-sslscan, 0.1.3, "New BSD"
-rex-struct2, 0.1.1, "New BSD"
-rex-text, 0.2.14, "New BSD"
-rex-zip, 0.1.2, "New BSD"
+rex-registry, 0.1.3, "New BSD"
+rex-rop_builder, 0.1.3, "New BSD"
+rex-socket, 0.1.6, "New BSD"
+rex-sslscan, 0.1.4, "New BSD"
+rex-struct2, 0.1.2, "New BSD"
+rex-text, 0.2.15, "New BSD"
+rex-zip, 0.1.3, "New BSD"
 rkelly-remix, 0.0.7, MIT
 robots, 0.10.1, MIT
 rspec-core, 3.6.0, MIT
@@ -112,14 +113,15 @@ rspec-expectations, 3.6.0, MIT
 rspec-mocks, 3.6.0, MIT
 rspec-rails, 3.6.0, MIT
 rspec-support, 3.6.0, MIT
-ruby_smb, 0.0.12, "New BSD"
+ruby_smb, 0.0.17, "New BSD"
 rubyntlm, 0.6.2, MIT
 rubyzip, 1.2.1, "Simplified BSD"
 sawyer, 0.8.1, MIT
 shoulda-matchers, 3.1.1, MIT
 signet, 0.7.3, "Apache 2.0"
 simplecov, 0.14.1, MIT
-simplecov-html, 0.10.0, MIT
+simplecov-html, 0.10.1, MIT
+slop, 3.6.0, MIT
 sqlite3, 1.3.13, "New BSD"
 sshkey, 1.9.0, MIT
 thor, 0.19.4, MIT
@@ -127,7 +129,7 @@ thread_safe, 0.3.6, "Apache 2.0"
 timecop, 0.8.1, MIT
 tzinfo, 1.2.3, MIT
 tzinfo-data, 1.2017.2, MIT
-windows_error, 0.1.1, BSD
+windows_error, 0.1.2, BSD
 xmlrpc, 0.3.0, ruby
-xpath, 2.0.0, unknown
+xpath, 2.1.0, MIT
 yard, 0.9.9, MIT

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,8 +17,6 @@ RUN apk update && \
       nmap-scripts \
       nmap-nselibs \
       postgresql-libs \
-      # needed as long as metasploit-framework.gemspec contains a 'git ls'
-      git \
       ncurses \
       libcap \
     && apk add --virtual .ruby-builddeps \

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -24,9 +24,11 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://www.metasploit.com'
   spec.license       = 'BSD-3-clause'
 
-  spec.files         = `git ls-files`.split($/).reject { |file|
-    file =~ /^documentation|^data\/gui|^external/
-  }
+  if File.directory?(File.join(__FILE__, ".git"))
+    spec.files         = `git ls-files`.split($/).reject { |file|
+      file =~ /^documentation|^data\/gui|^external/
+    }
+  end
   spec.bindir = '.'
   if ENV['CREATE_BINSTUBS']
     spec.executables   = [

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
 
   if File.directory?(File.join(__FILE__, ".git"))
     spec.files         = `git ls-files`.split($/).reject { |file|
-      file =~ /^documentation|^data\/gui|^external/
+      file =~ /^documentation|^external/
     }
   end
   spec.bindir = '.'

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -34,7 +34,6 @@ Gem::Specification.new do |spec|
       'msfd',
       'msfrpc',
       'msfrpcd',
-      'msfupdate',
       'msfvenom'
     ]
   end

--- a/msfupdate
+++ b/msfupdate
@@ -86,7 +86,7 @@ class Msfupdate
 
   def validate_args
     valid = true
-    if binary_install? || apt?
+    if binary_install?
       if @git_branch
         stderr.puts "[-] ERROR: git-branch is not supported on this installation"
         valid = false
@@ -96,7 +96,7 @@ class Msfupdate
         valid = false
       end
     end
-    if apt? || git?
+    if git?
       if @offline_file
         stderr.puts "[-] ERROR: offline-file option is not supported on this installation"
         valid = false
@@ -135,8 +135,8 @@ class Msfupdate
 
     Dir.chdir(@msfbase_dir) do
       if apt?
-        stderr.puts "msfupdate is not supported on Kali Linux, since it is a normal OS package."
-        stderr.puts "Please use 'apt update; apt install metasploit-framework' instead."
+        stderr.puts "[-] ERROR: msfupdate is not supported on Kali Linux."
+        stderr.puts "[-] Please run 'apt update; apt install metasploit-framework' instead."
       elsif binary_install?
         update_binary_install!
       elsif git?

--- a/msfupdate
+++ b/msfupdate
@@ -13,6 +13,8 @@ while File.symlink?(msfbase)
   msfbase = File.expand_path(File.readlink(msfbase), File.dirname(msfbase))
 end
 
+require 'backports'
+
 class Msfupdate
   attr_reader :stdin
   attr_reader :stdout
@@ -132,12 +134,12 @@ class Msfupdate
     end
 
     Dir.chdir(@msfbase_dir) do
-      if git?
-        update_git!
+      if apt?
+        raise "msfupdate is not supported when Metasploit is part of the operating system. Please use 'apt update; apt install metasploit-framework'"
       elsif binary_install?
         update_binary_install!
-      elsif apt?
-        update_apt!
+      elsif git?
+        update_git!
       else
         raise "Cannot determine checkout type: `#{@msfbase_dir}'"
       end
@@ -264,23 +266,6 @@ class Msfupdate
       stderr.puts "[-] (Note: Metasploit Community Edition is totally"
       stderr.puts "[-] free and takes just a few seconds to register!)"
       maybe_wait_and_exit 11
-    end
-  end
-
-  def update_apt!
-    # For more information, see here:
-    #   	https://community.rapid7.com/community/metasploit/blog/2013/01/17/metasploit-updates-and-msfupdate
-    stdout.puts "[*] Checking for updates via the APT repository"
-    stdout.puts "[*] Note: expect weekly(ish) updates using this method"
-    system("apt-get", "-qq", "update")
-
-    framework_version = apt_upgrade_available('metasploit-framework')
-
-    if framework_version.blank?
-      stdout.puts "[*] No updates available"
-    else
-      stdout.puts "[*] Updating to version #{framework_version}"
-      system("apt-get", "install", "--assume-yes", "metasploit-framework")
     end
   end
 

--- a/msfupdate
+++ b/msfupdate
@@ -135,7 +135,8 @@ class Msfupdate
 
     Dir.chdir(@msfbase_dir) do
       if apt?
-        raise "msfupdate is not supported when Metasploit is part of the operating system. Please use 'apt update; apt install metasploit-framework'"
+        stderr.puts "msfupdate is not supported on Kali Linux, since it is a normal OS package."
+        stderr.puts "Please use 'apt update; apt install metasploit-framework' instead."
       elsif binary_install?
         update_binary_install!
       elsif git?


### PR DESCRIPTION
This fixes a few upstream-packaging related bugs in msfconsole.

First, if Metasploit is not a git checkout, it skips the gemspec files scan. This causes a marginal speed increase as well. This fixes a reported bug in ParrotSec's packaging from #8398 and #8443

Second, if this removes msfupdate from the standard list of binaries (this should not be packaged by a distributor), and throws an error when run from Kali, instructing the user to update it like any other Debian package instead. Since Kali isn't packaging Ruby 2.4, we were hit by multiple reports of issues from #8469, #8464  and #8463. This also adds the backports package so anyone running a reasonably up-to-date version of Ruby won't get hit by backward compatibility bugs.

With this fix, Omnibus and Kali Linux both neither have to patch metasploit-framework.gemspec anymore to disable the git scan on startup too.