### PR TITLE
remove special case check for invalid options

### DIFF
--- a/lib/msf/ui/console/module_command_dispatcher.rb
+++ b/lib/msf/ui/console/module_command_dispatcher.rb
@@ -240,9 +240,6 @@ module ModuleCommandDispatcher
     rescue ::RuntimeError => e
       # Some modules raise RuntimeError but we don't necessarily care about those when we run check()
       elog("#{e.message}\n#{e.backtrace.join("\n")}")
-    rescue Msf::OptionValidateError => e
-      print_error("{peer} - Check failed: #{e.message}")
-      elog("#{e.message}\n#{e.backtrace.join("\n")}")
     rescue ::Exception => e
       print_error("Check failed: #{e.class} #{e}")
       elog("#{e.message}\n#{e.backtrace.join("\n")}")


### PR DESCRIPTION
When validating the result of a remote check method, we have invalid code to print the peer info when a datastore parameter fails validation. At that point, we might as well just follow the normal Exception handler path instead of special-casing it.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use exploit/windows/smb/ms08_067_netapi`
- [x]  type `check`
- [x] **Verify** that an exception like this appears:
```
[-] Check failed: Msf::OptionValidateError The following options failed to validate: RHOST.
```
