### PR TITLE
more httpClient modules use store_valid_credential

### DIFF
--- a/modules/exploits/linux/http/atutor_filemanager_traversal.rb
+++ b/modules/exploits/linux/http/atutor_filemanager_traversal.rb
@@ -293,37 +293,10 @@ class MetasploitModule < Msf::Exploit::Remote
     return nil
   end
 
-  def report_cred(opts)
-    service_data = {
-      address: rhost,
-      port: rport,
-      service_name: ssl ? 'https' : 'http',
-      protocol: 'tcp',
-      workspace_id: myworkspace_id
-    }
-
-    credential_data = {
-      module_fullname: fullname,
-      post_reference_name: self.refname,
-      private_data: opts[:password],
-      origin_type: :service,
-      private_type: :password,
-      username: opts[:user]
-    }.merge(service_data)
-
-    login_data = {
-      core: create_credential(credential_data),
-      status: Metasploit::Model::Login::Status::SUCCESSFUL,
-      last_attempted_at: Time.now
-    }.merge(service_data)
-
-    create_credential_login(login_data)
-  end
-
   def exploit
     # login if needed
     if (not datastore['USERNAME'].empty? and not datastore['PASSWORD'].empty?)
-      report_cred(user: datastore['USERNAME'], password: datastore['PASSWORD'])
+      store_valid_credential(user: datastore['USERNAME'], private: datastore['PASSWORD'])
       student_cookie = login(datastore['USERNAME'], datastore['PASSWORD'])
       print_good("Logged in as #{datastore['USERNAME']}")
     # else, we reset the students password via a type juggle vulnerability
@@ -350,6 +323,10 @@ class MetasploitModule < Msf::Exploit::Remote
        end
     end
   end
+end
+
+def service_details
+  super.merge({ post_reference_name: self.refname })
 end
 
 =begin

--- a/modules/exploits/linux/http/cisco_firepower_useradd.rb
+++ b/modules/exploits/linux/http/cisco_firepower_useradd.rb
@@ -158,33 +158,6 @@ class MetasploitModule < Msf::Exploit::Remote
     datastore['NEWSSHPASS'] || Rex::Text.rand_text_alpha(5)
   end
 
-  def report_cred(opts)
-    service_data = {
-      address: rhost,
-      port: rport,
-      service_name: 'cisco',
-      protocol: 'tcp',
-      workspace_id: myworkspace_id
-    }
-
-    credential_data = {
-      origin_type: :service,
-      module_fullname: fullname,
-      username: opts[:user],
-      private_data: opts[:password],
-      private_type: :password
-    }.merge(service_data)
-
-    login_data = {
-      last_attempted_at: DateTime.now,
-      core: create_credential(credential_data),
-      status: Metasploit::Model::Login::Status::SUCCESSFUL,
-      proof: opts[:proof]
-    }.merge(service_data)
-
-    create_credential_login(login_data)
-  end
-
   def do_login
     console_user = datastore['USERNAME']
     console_pass = datastore['PASSWORD']
@@ -211,7 +184,7 @@ class MetasploitModule < Msf::Exploit::Remote
       cgi_sid = res_cookie.scan(/CGISESSID=(\w+);/).flatten.first
       print_status("CGI Session ID: #{cgi_sid}")
       print_good("Authenticated as #{console_user}:#{console_pass}")
-      report_cred(username: console_user, password: console_pass)
+      store_valid_credential(user: console_user, private: console_pass) # changes service_name to http || https
       return cgi_sid
     end
 

--- a/modules/exploits/linux/http/kloxo_sqli.rb
+++ b/modules/exploits/linux/http/kloxo_sqli.rb
@@ -71,33 +71,6 @@ class MetasploitModule < Msf::Exploit::Remote
       ])
   end
 
-  def report_cred(opts)
-    service_data = {
-      address: opts[:ip],
-      port: opts[:port],
-      service_name: opts[:service_name],
-      protocol: 'tcp',
-      workspace_id: myworkspace_id
-    }
-
-    credential_data = {
-      module_fullname: fullname,
-      post_reference_name: self.refname,
-      private_data: opts[:password],
-      origin_type: :service,
-      private_type: :password,
-      username: opts[:user]
-    }.merge(service_data)
-
-    login_data = {
-      core: create_credential(credential_data),
-      status: Metasploit::Model::Login::Status::SUCCESSFUL,
-      last_attempted_at: opts[:attempt_time]
-    }.merge(service_data)
-
-    create_credential_login(login_data)
-  end
-
   def check
     return Exploit::CheckCode::Safe unless webcommand_exists?
     return Exploit::CheckCode::Safe if exploit_sqli(1, bad_char(0))
@@ -119,14 +92,7 @@ class MetasploitModule < Msf::Exploit::Remote
     @session = send_login
     fail_with(Failure::NoAccess, "#{peer} - Login with admin/#{@password} failed...") if @session.nil?
 
-    report_cred(
-      ip: rhost,
-      port: rport,
-      user: 'admin',
-      service_name: 'http',
-      password: @password,
-      attempt_time: DateTime.now
-    )
+    store_valid_credential(user: 'admin', private: @password)
 
     print_status("Retrieving the server name...")
     @server = server_info

--- a/modules/exploits/linux/http/riverbed_netprofiler_netexpress_exec.rb
+++ b/modules/exploits/linux/http/riverbed_netprofiler_netexpress_exec.rb
@@ -156,48 +156,16 @@ class MetasploitModule < Msf::Exploit::Remote
          'encode_params' => false,
          'data'     => post_data
        })
-
-       sessid_cookie = (res.get_cookies || '').scan(/SESSID=(\w+);/).flatten[0] || ''
-       print_status("Saving login credentials into Metasploit DB")
-       report_cred(uname, passwd)
     else
        print_status("Valid login credentials provided. Successfully logged in")
-       sessid_cookie = (res.get_cookies || '').scan(/SESSID=(\w+);/).flatten[0] || ''
-       print_status("Saving login credentials into Metasploit DB")
-       report_cred(uname, passwd)
     end
+
+    sessid_cookie = (res.get_cookies || '').scan(/SESSID=(\w+);/).flatten[0] || ''
+    print_status("Saving login credentials into Metasploit DB")
+    store_valid_credential(user: uname, private: passwd)
 
     return sessid_cookie
 
-  end
-
-  def report_cred(username, password)
-    # Function used to save login credentials into Metasploit database
-    service_data = {
-      address: rhost,
-      port: rport,
-      service_name: ssl ? 'https' : 'http',
-      protocol: 'tcp',
-      workspace_id: myworkspace_id
-    }
-
-    credential_data = {
-      module_fullname: self.fullname,
-      origin_type: :service,
-      username: username,
-      private_data: password,
-      private_type: :password
-    }.merge(service_data)
-
-    credential_core = create_credential(credential_data)
-
-    login_data = {
-      core: credential_core,
-      last_attempted_at: DateTime.now,
-      status: Metasploit::Model::Login::Status::SUCCESSFUL
-    }.merge(service_data)
-
-    create_credential_login(login_data)
   end
 
   def create_user

--- a/modules/exploits/linux/http/symantec_web_gateway_restore.rb
+++ b/modules/exploits/linux/http/symantec_web_gateway_restore.rb
@@ -187,34 +187,6 @@ class MetasploitModule < Msf::Exploit::Remote
     })
   end
 
-  def save_cred(username, password)
-    service_data = {
-      address: rhost,
-      port: rport,
-      service_name: protocol,
-      protocol: 'tcp',
-      workspace_id: myworkspace_id
-    }
-
-    credential_data = {
-      module_fullname: self.fullname,
-      origin_type: :service,
-      username: username,
-      private_data: password,
-      private_type: :password
-    }.merge(service_data)
-
-    credential_core = create_credential(credential_data)
-
-    login_data = {
-      core: credential_core,
-      last_attempted_at: DateTime.now,
-      status: Metasploit::Model::Login::Status::SUCCESSFUL
-    }.merge(service_data)
-
-    create_credential_login(login_data)
-  end
-
   def exploit
     print_status("Getting the PHPSESSID...")
     sid = get_sid
@@ -230,7 +202,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return
     else
       # Good password, keep it
-      save_cred(datastore['USERNAME'], datastore['PASSWORD'])
+      store_valid_credential(user: datastore['USERNAME'], private: datastore['PASSWORD'])
     end
 
     print_status("Trying restore.php...")

--- a/modules/exploits/linux/http/tp_link_sc2020n_authenticated_telnet_injection.rb
+++ b/modules/exploits/linux/http/tp_link_sc2020n_authenticated_telnet_injection.rb
@@ -89,7 +89,7 @@ class MetasploitModule < Msf::Exploit::Remote
             fail_with(Failure::Unknown, "Could not connect to web service - invalid credentials (response code: #{res.code}")
           else
             print_good("Successful login #{user} : #{pass}")
-            save_cred(user, pass)
+            store_valid_credential(user: user, private: pass) # service_name becomes http || https, a conflicting service_details could occur in future. Telnet lib does not yet provide service_details.
           end
         rescue ::Rex::ConnectionError
           fail_with(Failure::Unknown, "Could not connect to the web service")
@@ -172,32 +172,4 @@ class MetasploitModule < Msf::Exploit::Remote
         return nil
       end
     end
-
-  def save_cred(username, password)
-    service_data = {
-      address: rhost,
-      port: rport,
-      service_name: 'telnet',
-      protocol: 'tcp',
-      workspace_id: myworkspace_id
-    }
-
-    credential_data = {
-      module_fullname: self.fullname,
-      origin_type: :service,
-      username: username,
-      private_data: password,
-      private_type: :password
-    }.merge(service_data)
-
-    credential_core = create_credential(credential_data)
-
-    login_data = {
-      core: credential_core,
-      last_attempted_at: DateTime.now,
-      status: Metasploit::Model::Login::Status::SUCCESSFUL
-    }.merge(service_data)
-
-    create_credential_login(login_data)
-  end
 end

--- a/modules/exploits/linux/http/trendmicro_sps_exec.rb
+++ b/modules/exploits/linux/http/trendmicro_sps_exec.rb
@@ -154,44 +154,11 @@ class MetasploitModule < Msf::Exploit::Remote
           sid = res.get_cookies.scan(/([^=]*)=[^;]*;/).last.first
           sid_value = res.get_cookies.scan(/#{sid}=([^;]*);/).last.first
         end
-        report_cred(
-            ip: datastore['RHOST'],
-            port: datastore['RPORT'],
-            service_name: (ssl ? "https" : "http"),
-            user: datastore['ADMINACCOUNT'],
-            password: datastore['ADMINPASS'],
-            proof: "#{sid}=#{sid_value}"
-        )
+        store_valid_credential(user: datastore['ADMINACCOUNT'], private: datastore['ADMINPASS'], proof: "#{sid}=#{sid_value}")
         return {"sid" => sid, "sid_value" => sid_value}
       end
     end
     nil
-  end
-
-  def report_cred(opts)
-    service_data = {
-        address: opts[:ip],
-        port: opts[:port],
-        service_name: opts[:service_name],
-        protocol: 'tcp',
-        workspace_id: myworkspace_id
-    }
-
-    credential_data = {
-        origin_type: :service,
-        module_fullname: fullname,
-        username: opts[:user],
-        private_data: opts[:password],
-        private_type: :password
-    }.merge(service_data)
-
-    login_data = {
-        core: create_credential(credential_data),
-        status: Metasploit::Model::Login::Status::SUCCESSFUL,
-        proof: opts[:proof]
-    }.merge(service_data)
-
-    create_credential_login(login_data)
   end
 
   def exploit

--- a/modules/exploits/multi/http/atutor_sqli.rb
+++ b/modules/exploits/multi/http/atutor_sqli.rb
@@ -136,7 +136,7 @@ class MetasploitModule < Msf::Exploit::Remote
     cookie = "ATutorID=#{$4};" if res.get_cookies =~ /ATutorID=(.*); ATutorID=(.*); ATutorID=(.*); ATutorID=(.*);/
     if res && res.code == 302 && res.redirection.to_s.include?('admin/index.php')
       # if we made it here, we are admin
-      report_cred(user: username, password: hash)
+      store_valid_credential(user: username, private: hash, private_type: :nonreplayable_hash)
       return cookie
     end
     # auth failed if we land here, bail
@@ -227,32 +227,8 @@ class MetasploitModule < Msf::Exploit::Remote
     return false
   end
 
-  def report_cred(opts)
-    service_data = {
-      address: rhost,
-      port: rport,
-      service_name: ssl ? 'https' : 'http',
-      protocol: 'tcp',
-      workspace_id: myworkspace_id
-    }
-
-    credential_data = {
-      module_fullname: fullname,
-      post_reference_name: self.refname,
-      private_data: opts[:password],
-      origin_type: :service,
-      private_type: :nonreplayable_hash,
-      jtr_format: 'sha512',
-      username: opts[:user]
-    }.merge(service_data)
-
-    login_data = {
-      core: create_credential(credential_data),
-      status: Metasploit::Model::Login::Status::SUCCESSFUL,
-      last_attempted_at: Time.now
-    }.merge(service_data)
-
-    create_credential_login(login_data)
+  def service_details
+    super.merge({ post_reference_name: self.refname, jtr_format: 'sha512' })
   end
 
   def exploit

--- a/modules/exploits/multi/http/glassfish_deployer.rb
+++ b/modules/exploits/multi/http/glassfish_deployer.rb
@@ -718,35 +718,12 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def my_target_host
-    my_target_host = "http://#{rhost.to_s}:#{rport.to_s}#{normalize_uri(target_uri.path)}"
+    "http://#{rhost.to_s}:#{rport.to_s}#{normalize_uri(target_uri.path)}"
   end
 
 
-  def report_cred(opts)
-    service_data = {
-      address: rhost,
-      port: rport,
-      service_name: 'glassfish',
-      protocol: 'tcp',
-      workspace_id: myworkspace_id
-    }
-
-    credential_data = {
-      module_fullname: fullname,
-      post_reference_name: self.refname,
-      private_data: opts[:password],
-      origin_type: :service,
-      private_type: :password,
-      username: opts[:user]
-    }.merge(service_data)
-
-    login_data = {
-      core: create_credential(credential_data),
-      status: Metasploit::Model::Login::Status::SUCCESSFUL,
-      last_attempted_at: DateTime.now
-    }.merge(service_data)
-
-    create_credential_login(login_data)
+  def service_details
+    super.merge({ post_reference_name: self.refname })
   end
 
   def try_normal_login(version)
@@ -783,7 +760,7 @@ class MetasploitModule < Msf::Exploit::Remote
       print_status("Trying to login as #{cred.public}:#{cred.private}")
       result = @scanner.attempt_login(cred)
       if result.status == Metasploit::Model::Login::Status::SUCCESSFUL
-        report_cred(user: cred.public, password: cred.private)
+        store_valid_credential(user: cred.public, private: cred.private) # changes service_name to http || https
         return @scanner.jsession
       end
     end

--- a/modules/exploits/multi/http/jira_hipchat_template.rb
+++ b/modules/exploits/multi/http/jira_hipchat_template.rb
@@ -193,38 +193,8 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
 
-  # Reports username and password to the database.
-  #
-  # @param opts [Hash]
-  # @option opts [String] :user
-  # @option opts [String] :password
-  #
-  # @return [void]
-  def report_cred(opts)
-    service_data = {
-      address: rhost,
-      port: rport,
-      service_name: ssl ? 'https' : 'http',
-      protocol: 'tcp',
-      workspace_id: myworkspace_id
-    }
-
-    credential_data = {
-      module_fullname: fullname,
-      post_reference_name: self.refname,
-      private_data: opts[:password],
-      origin_type: :service,
-      private_type: :password,
-      username: opts[:user]
-    }.merge(service_data)
-
-    login_data = {
-      core: create_credential(credential_data),
-      status: Metasploit::Model::Login::Status::SUCCESSFUL,
-      last_attempted_at: Time.now
-    }.merge(service_data)
-
-    create_credential_login(login_data)
+  def service_details
+      super.merge({ post_reference_name: self.refname })
   end
 
 
@@ -269,10 +239,7 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::NoAccess, 'Incorrect username or password')
     end
 
-    report_cred(
-      user: jira_username,
-      password: jira_password
-    )
+    store_valid_credential(user: jira_username, private: jira_password, proof: cookie) # expands to store cookie
 
     cookie
   end

--- a/modules/exploits/multi/http/sonicwall_scrutinizer_methoddetail_sqli.rb
+++ b/modules/exploits/multi/http/sonicwall_scrutinizer_methoddetail_sqli.rb
@@ -179,46 +179,11 @@ class MetasploitModule < Msf::Exploit::Remote
     elsif res['loginfailed']
       fail_with(Failure::NoAccess, "Password '#{datastore['PASSWORD']}' is incorrect.")
     elsif res['sessionid']
-      report_cred(datastore['USERNAME'], datastore['PASSWORD'])
+      store_valid_credential(user: datastore['USERNAME'], private: datastore['PASSWORD'])
     end
 
     res
   end
-
-
-  # Saves a valid username/password to database.
-  #
-  # @param username [String]
-  # @param password [String]
-  # @return [void]
-  def report_cred(username, password)
-    service_data = {
-      address: rhost,
-      port: rport,
-      service_name: ssl ? 'https' : 'http',
-      protocol: 'tcp',
-      workspace_id: myworkspace_id
-    }
-
-    credential_data = {
-      module_fullname: self.fullname,
-      origin_type: :service,
-      username: username,
-      private_data: password,
-      private_type: :password
-    }.merge(service_data)
-
-    credential_core = create_credential(credential_data)
-
-    login_data = {
-      core: credential_core,
-      last_attempted_at: DateTime.now,
-      status: Metasploit::Model::Login::Status::SUCCESSFUL
-    }.merge(service_data)
-
-    create_credential_login(login_data)
-  end
-
 
   # Injects malicious SQL string to the methodDetail parameter against the target machine.
   #

--- a/modules/exploits/multi/http/tomcat_mgr_deploy.rb
+++ b/modules/exploits/multi/http/tomcat_mgr_deploy.rb
@@ -116,7 +116,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Unknown
     end
 
-    report_tomcat_credential
+    store_valid_credential(user: datastore['HttpUsername'], private: datastore['HttpPassword'])
 
     vprint_status("Target is #{detect_platform(res.body)} #{detect_arch(res.body)}")
     return CheckCode::Appears
@@ -199,7 +199,7 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::Unknown, "Upload failed on #{path_tmp} [#{res.code} #{res.message}]")
     end
 
-    report_tomcat_credential
+    store_valid_credential(user: datastore['HttpUsername'], private: datastore['HttpPassword'])
 
     #
     # EXECUTE
@@ -297,35 +297,8 @@ class MetasploitModule < Msf::Exploit::Remote
     }
   end
 
-  def report_tomcat_credential
-    service_data = {
-        address: ::Rex::Socket.getaddress(datastore['RHOST'],true),
-        port: datastore['RPORT'],
-        service_name: (ssl ? "https" : "http"),
-        protocol: 'tcp',
-        workspace_id: myworkspace_id
-    }
-
-    credential_data = {
-        origin_type: :service,
-        module_fullname: self.fullname,
-        private_type: :password,
-        private_data: datastore['HttpPassword'],
-        username: datastore['HttpUsername']
-    }
-
-    credential_data.merge!(service_data)
-
-    credential_core = create_credential(credential_data)
-
-    login_data = {
-        access_level: 'Admin',
-        core: credential_core,
-        last_attempted_at: DateTime.now,
-        status: Metasploit::Model::Login::Status::SUCCESSFUL
-    }
-    login_data.merge!(service_data)
-    create_credential_login(login_data)
+  def service_details
+    super.merge({ access_level: 'Admin' })
   end
 
 end

--- a/modules/exploits/multi/http/tomcat_mgr_upload.rb
+++ b/modules/exploits/multi/http/tomcat_mgr_upload.rb
@@ -124,7 +124,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     vprint_status("Tomcat Manager found running on #{plat} platform and #{arch} architecture")
 
-    report_tomcat_credential
+    store_valid_credential(user: datastore['HttpUsername'], private: datastore['HttpPassword'])
 
     return CheckCode::Appears
   end
@@ -146,7 +146,7 @@ class MetasploitModule < Msf::Exploit::Remote
     #
     print_status("Uploading and deploying #{@app_base}...")
     if upload_payload
-      report_tomcat_credential
+      store_valid_credential(user: datastore['HttpUsername'], private: datastore['HttpPassword'])
     else
       fail_with(Failure::Unknown, "Upload failed")
     end
@@ -404,35 +404,8 @@ class MetasploitModule < Msf::Exploit::Remote
     return true
   end
 
-  def report_tomcat_credential
-    service_data = {
-        address: ::Rex::Socket.getaddress(datastore['RHOST'],true),
-        port: datastore['RPORT'],
-        service_name: (ssl ? "https" : "http"),
-        protocol: 'tcp',
-        workspace_id: myworkspace_id
-    }
-
-    credential_data = {
-        origin_type: :service,
-        module_fullname: self.fullname,
-        private_type: :password,
-        private_data: datastore['HttpPassword'],
-        username: datastore['HttpUsername']
-    }
-
-    credential_data.merge!(service_data)
-
-    credential_core = create_credential(credential_data)
-
-    login_data = {
-        access_level: 'Admin',
-        core: credential_core,
-        last_attempted_at: DateTime.now,
-        status: Metasploit::Model::Login::Status::SUCCESSFUL
-    }
-    login_data.merge!(service_data)
-    create_credential_login(login_data)
+  def service_details
+    super.merge({ access_level: 'Admin' })
   end
 
 end

--- a/modules/exploits/unix/webapp/actualanalyzer_ant_cookie_exec.rb
+++ b/modules/exploits/unix/webapp/actualanalyzer_ant_cookie_exec.rb
@@ -188,29 +188,7 @@ class MetasploitModule < Msf::Exploit::Remote
     elsif res.code == 200 && /alt='ActualAnalyzer' src='https?:\/\/(?<analytics_host>[^\/^']+)/ =~ res.body
       vprint_good("Found analytics host: #{analytics_host}")
       print_good("Login successful! (#{user}:#{pass})")
-      service_data = {
-        address: Rex::Socket.getaddress(rhost, true),
-        port: rport,
-        service_name: (ssl ? 'https' : 'http'),
-        protocol: 'tcp',
-        workspace_id: myworkspace_id
-      }
-      credential_data = {
-        origin_type: :service,
-        module_fullname: fullname,
-        private_type: :password,
-        private_data: pass,
-        username: user
-      }
-      credential_data.merge!(service_data)
-      credential_core = create_credential(credential_data)
-      login_data = {
-        core: credential_core,
-        last_attempted_at: DateTime.now,
-        status: Metasploit::Model::Login::Status::SUCCESSFUL
-      }
-      login_data.merge!(service_data)
-      create_credential_login(login_data)
+      store_valid_credential(user: user, private: pass)
       return analytics_host
     else
       vprint_status("Could not find any hosts on admin.php")

--- a/modules/exploits/unix/webapp/vbulletin_vote_sqli_exec.rb
+++ b/modules/exploits/unix/webapp/vbulletin_vote_sqli_exec.rb
@@ -369,33 +369,6 @@ class MetasploitModule < Msf::Exploit::Remote
     end
   end
 
-  def report_cred(opts)
-    service_data = {
-      address: opts[:ip],
-      port: opts[:port],
-      service_name: opts[:service_name],
-      protocol: 'tcp',
-      workspace_id: myworkspace_id
-    }
-
-    credential_data = {
-      origin_type: :service,
-      module_fullname: fullname,
-      username: opts[:user],
-      private_data: opts[:password],
-      private_type: :nonreplayable_hash,
-      jtr_format: 'md5,raw-md5'
-    }.merge(service_data)
-
-    login_data = {
-      core: create_credential(credential_data),
-      status: Metasploit::Model::Login::Status::UNTRIED,
-      proof: opts[:proof]
-    }.merge(service_data)
-
-    create_credential_login(login_data)
-  end
-
   def exploit
     print_status("Checking for a valid node id...")
     node_id = get_node
@@ -416,14 +389,18 @@ class MetasploitModule < Msf::Exploit::Remote
 
     for i in 0..count_users - 1
       user = get_user_data(node_id, i)
-      report_cred(
-        ip: rhost,
-        port: rport,
-        user: user[0],
-        password: user[1],
-        service_name: (ssl ? "https" : "http"),
-        proof: "salt: #{user[2]}"
-      )
+      connection_details = {
+          module_fullname: self.fullname,
+          username: user[0],
+          private_data: user[1],
+          private_type: :nonreplayable_hash,
+          jtr_format: 'md5,raw-md5',
+          proof: "salt: #{user[2]}",
+          status: Metasploit::Model::Login::Status::UNTRIED
+      }.merge(service_details)
+      create_credential_and_login(connection_details)
+
+      # why is this stored another way?
       report_auth_info({
         :host => rhost,
         :port => rport,

--- a/modules/exploits/windows/http/ca_arcserve_rpc_authbypass.rb
+++ b/modules/exploits/windows/http/ca_arcserve_rpc_authbypass.rb
@@ -56,31 +56,13 @@ class MetasploitModule < Msf::Exploit::Remote
       ])
   end
 
-  def report_cred(opts)
-    service_data = {
-      address: opts[:ip],
-      port: opts[:port],
-      service_name: opts[:service_name],
-      protocol: 'tcp',
-      workspace_id: myworkspace_id
-    }
-
-    credential_data = {
-      module_fullname: fullname,
+  def service_details
+    super.merge({
+      port: 445,
+      service_name: 'smb',
       post_reference_name: self.refname,
-      private_data: opts[:password],
-      origin_type: :service,
-      private_type: :password,
-      username: opts[:user]
-    }.merge(service_data)
-
-    login_data = {
-      core: create_credential(credential_data),
-      status: opts[:status],
       last_attempted_at: DateTime.now
-    }.merge(service_data)
-
-    create_credential_login(login_data)
+    })
   end
 
   def exploit
@@ -172,14 +154,12 @@ class MetasploitModule < Msf::Exploit::Remote
         'RunAsJob' => true
       )
     rescue
-      report_cred(
-        ip: datastore['RHOST'],
-        port: 445,
-        service_name: 'smb',
+      credential_data = {
         user: user,
-        password: pass,
+        private_data: pass,
         status: Metasploit::Model::Login::Status::INCORRECT
-      )
+      }.merge(service_details)
+      create_credential_and_login(credential_data)
 
       print_status("Login attempt using windows/smb/psexec failed")
       print_status("Credentials have been stored and may be useful for authentication against other services.")
@@ -188,14 +168,12 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     # report the auth
-    report_cred(
-      ip: datastore['RHOST'],
-      port: 445,
-      service_name: 'smb',
-      user: user,
-      password: pass,
-      status: Metasploit::Model::Login::Status::SUCCESSFUL
-    )
+    credential_data = {
+        user: user,
+        private_data: pass,
+        status: Metasploit::Model::Login::Status::SUCCESSFUL
+    }.merge(service_details)
+    create_credential_and_login(credential_data)
 
     handler
   end

--- a/modules/exploits/windows/http/octopusdeploy_deploy.rb
+++ b/modules/exploits/windows/http/octopusdeploy_deploy.rb
@@ -349,7 +349,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if !res || (res.code != 200)
       print_error("Login failed")
     elsif res.code == 200
-      report_octopusdeploy_credential
+      store_valid_credential(user: datestore['USERNAME'], private: datastore['PASSWORD'])
     end
 
     res
@@ -373,34 +373,7 @@ class MetasploitModule < Msf::Exploit::Remote
     res
   end
 
-  def report_octopusdeploy_credential
-    service_data = {
-      address: ::Rex::Socket.getaddress(datastore['RHOST'], true),
-      port: datastore['RPORT'],
-      service_name: (ssl ? "https" : "http"),
-      protocol: 'tcp',
-      workspace_id: myworkspace_id
-    }
-
-    credential_data = {
-      origin_type: :service,
-      module_fullname: fullname,
-      private_type: :password,
-      private_data: datastore['PASSWORD'].downcase,
-      username: datastore['USERNAME']
-    }
-
-    credential_data.merge!(service_data)
-
-    credential_core = create_credential(credential_data)
-
-    login_data = {
-      access_level: 'Admin',
-      core: credential_core,
-      last_attempted_at: DateTime.now,
-      status: Metasploit::Model::Login::Status::SUCCESSFUL
-    }
-    login_data.merge!(service_data)
-    create_credential_login(login_data)
+  def service_details
+    super.merge({ access_level: 'Admin' })
   end
 end

--- a/modules/exploits/windows/http/octopusdeploy_deploy.rb
+++ b/modules/exploits/windows/http/octopusdeploy_deploy.rb
@@ -349,7 +349,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if !res || (res.code != 200)
       print_error("Login failed")
     elsif res.code == 200
-      store_valid_credential(user: datestore['USERNAME'], private: datastore['PASSWORD'])
+      store_valid_credential(user: datastore['USERNAME'], private: datastore['PASSWORD'])
     end
 
     res


### PR DESCRIPTION
Convert multiple modules using ```Msf::Exploit::Remote::HttpClient``` to use new functionality for ```store_valid_credential```.

Note: ```service_name``` is made more consistent to the method of auth used vs software provider and ```modules/exploits/multi/http/glassfish_deployer.rb``` addresses an method name what was also being used as a variable name inside that method.

Testing of all modules has not been preformed due to standardized refactor here.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use <modified exploit>`
- [ ] **Verify** the credentials are stored correctly
- [ ] **Verify** only commented changes to reported credential details occur.

