### PR TITLE
fixing a busted -R on creds search

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/creds.rb
+++ b/lib/msf/ui/console/command_dispatcher/creds.rb
@@ -3,6 +3,7 @@
 require 'rexml/document'
 require 'rex/parser/nmap_xml'
 require 'msf/core/db_export'
+require 'msf/ui/console/command_dispatcher/db_common'
 
 module Msf
 module Ui
@@ -14,6 +15,7 @@ class Creds
 
   include Msf::Ui::Console::CommandDispatcher
   include Metasploit::Credential::Creation
+  include Msf::Ui::Console::CommandDispatcher::DbCommon
   
   #
   # The dispatcher's name.

--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -3,6 +3,7 @@
 require 'rexml/document'
 require 'rex/parser/nmap_xml'
 require 'msf/core/db_export'
+require 'msf/ui/console/command_dispatcher/db_common'
 
 module Msf
 module Ui
@@ -14,7 +15,8 @@ class Db
   require 'tempfile'
 
   include Msf::Ui::Console::CommandDispatcher
-
+  include Msf::Ui::Console::CommandDispatcher::DbCommon
+  
   #
   # The dispatcher's name.
   #
@@ -1712,43 +1714,6 @@ class Db
     print_line "Usage: db_rebuild_cache"
     print_line
     print_line "Purge and rebuild the SQL module cache."
-    print_line
-  end
-
-  #
-  # Set RHOSTS in the +active_module+'s (or global if none) datastore from an array of addresses
-  #
-  # This stores all the addresses to a temporary file and utilizes the
-  # <pre>file:/tmp/filename</pre> syntax to confer the addrs.  +rhosts+
-  # should be an Array.  NOTE: the temporary file is *not* deleted
-  # automatically.
-  #
-  def set_rhosts_from_addrs(rhosts)
-    if rhosts.empty?
-      print_status("The list is empty, cowardly refusing to set RHOSTS")
-      return
-    end
-    if active_module
-      mydatastore = active_module.datastore
-    else
-      # if there is no module in use set the list to the global variable
-      mydatastore = self.framework.datastore
-    end
-
-    if rhosts.length > 5
-      # Lots of hosts makes 'show options' wrap which is difficult to
-      # read, store to a temp file
-      rhosts_file = Rex::Quickfile.new("msf-db-rhosts-")
-      mydatastore['RHOSTS'] = 'file:'+rhosts_file.path
-      # create the output file and assign it to the RHOSTS variable
-      rhosts_file.write(rhosts.join("\n")+"\n")
-      rhosts_file.close
-    else
-      # For short lists, just set it directly
-      mydatastore['RHOSTS'] = rhosts.join(" ")
-    end
-
-    print_line "RHOSTS => #{mydatastore['RHOSTS']}"
     print_line
   end
 

--- a/lib/msf/ui/console/command_dispatcher/db_common.rb
+++ b/lib/msf/ui/console/command_dispatcher/db_common.rb
@@ -1,0 +1,57 @@
+# -*- coding: binary -*-
+
+require 'rexml/document'
+require 'rex/parser/nmap_xml'
+require 'msf/core/db_export'
+
+module Msf
+module Ui
+module Console
+module CommandDispatcher
+
+module DbCommon
+  
+  #
+  # Set RHOSTS in the +active_module+'s (or global if none) datastore from an array of addresses
+  #
+  # This stores all the addresses to a temporary file and utilizes the
+  # <pre>file:/tmp/filename</pre> syntax to confer the addrs.  +rhosts+
+  # should be an Array.  NOTE: the temporary file is *not* deleted
+  # automatically.
+  #
+  def set_rhosts_from_addrs(rhosts)
+    if rhosts.empty?
+      print_status("The list is empty, cowardly refusing to set RHOSTS")
+      return
+    end
+    if active_module
+      mydatastore = active_module.datastore
+    else
+      # if there is no module in use set the list to the global variable
+      mydatastore = self.framework.datastore
+    end
+
+    if rhosts.length > 5
+      # Lots of hosts makes 'show options' wrap which is difficult to
+      # read, store to a temp file
+      rhosts_file = Rex::Quickfile.new("msf-db-rhosts-")
+      mydatastore['RHOSTS'] = 'file:'+rhosts_file.path
+      # create the output file and assign it to the RHOSTS variable
+      rhosts_file.write(rhosts.join("\n")+"\n")
+      rhosts_file.close
+    else
+      # For short lists, just set it directly
+      mydatastore['RHOSTS'] = rhosts.join(" ")
+    end
+
+    print_line "RHOSTS => #{mydatastore['RHOSTS']}"
+    print_line
+  end
+
+  
+end
+
+end
+end
+end
+end


### PR DESCRIPTION
I broke this when moving creds to its own file.

Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

## Verification
### From Master
- [x] Start `msfconsole`
- [x] exploit a host an loot some credentials
- [x] `creds -R <IP of host where you got some creds>`
- [x] **Verify** this throws an error
### Without cleaning the database, checkout this branch
- [x] `creds -R <IP of host where you got some creds>`
- [x] **Verify** this doesn't have raise any errors
- [x] **Verify** it lists all of the expected creds on the searched for IP. 
