### PR TITLE
store more specific credential wordpress_directory_traversal_dos

### DIFF
--- a/modules/auxiliary/dos/http/wordpress_directory_traversal_dos.rb
+++ b/modules/auxiliary/dos/http/wordpress_directory_traversal_dos.rb
@@ -69,7 +69,7 @@ class MetasploitModule < Msf::Auxiliary
   def user_exists(user)
     exists = wordpress_user_exists?(user)
     if exists
-      print_good("Username \"#{username}\" is valid")
+      print_good("Username \"#{user}\" is valid")
       return true
     else
       print_error("\"#{user}\" is not a valid username")
@@ -88,7 +88,7 @@ class MetasploitModule < Msf::Auxiliary
       starting_thread = 1
 
       cookie  = wordpress_login(username, password)
-      store_valid_credential(user: user, private: password, proof: cookie)
+      store_valid_credential(user: username, private: password, proof: cookie)
       if cookie.nil?
         print_error('Aborting operation - failed to authenticate')
         return

--- a/modules/auxiliary/dos/http/wordpress_directory_traversal_dos.rb
+++ b/modules/auxiliary/dos/http/wordpress_directory_traversal_dos.rb
@@ -66,43 +66,10 @@ class MetasploitModule < Msf::Auxiliary
     datastore['DEPTH']
   end
 
-  def report_cred(opts)
-    service_data = {
-      address: opts[:ip],
-      port: opts[:port],
-      service_name: opts[:service_name],
-      protocol: 'tcp',
-      workspace_id: myworkspace_id
-    }
-
-    credential_data = {
-      origin_type: :service,
-      module_fullname: fullname,
-      username: opts[:user]
-    }.merge(service_data)
-
-    login_data = {
-      last_attempted_at: DateTime.now,
-      core: create_credential(credential_data),
-      status: Metasploit::Model::Login::Status::SUCCESSFUL,
-      proof: opts[:proof]
-    }.merge(service_data)
-
-    create_credential_login(login_data)
-  end
-
   def user_exists(user)
     exists = wordpress_user_exists?(user)
     if exists
       print_good("Username \"#{username}\" is valid")
-      report_cred(
-        ip: rhost,
-        port: rport,
-        user: user,
-        service_name: (ssl ? 'https' : 'http'),
-        proof: "WEBAPP=\"Wordpress\", VHOST=#{vhost}"
-      )
-
       return true
     else
       print_error("\"#{user}\" is not a valid username")
@@ -121,6 +88,7 @@ class MetasploitModule < Msf::Auxiliary
       starting_thread = 1
 
       cookie  = wordpress_login(username, password)
+      store_valid_credential(user: user, private: password, proof: cookie)
       if cookie.nil?
         print_error('Aborting operation - failed to authenticate')
         return


### PR DESCRIPTION
Use new storage method and capture the password used.

@JulienPlas, updating for recent simple cred storage method, this also changes the proof to use the cookie from login, happy to hold your proof value if you prefer that be kept.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use auxiliary/dos/http/wordpress_directory_traversal_dos.rb`
- [x] `set RHOST <ip target site>`
- [x] `set TARGETURI <WordPress path>`
- [x] `set USERNAME <Valid Username>`
- [x] `set PASSWORD <Valid Password>`
- [x] `exploit`
- [x] *Verify* credential stored contains password
