### PR TITLE
docs consistency fixes

### DIFF
--- a/documentation/modules/auxiliary/admin/chromecast/chromecast_youtube.md
+++ b/documentation/modules/auxiliary/admin/chromecast/chromecast_youtube.md
@@ -14,9 +14,9 @@ Naturally, audio should be cranked to 11 before running this module.
 
   The YouTube video to be played.  Defaults to [kxopViU98Xo](https://www.youtube.com/watch?v=kxopViU98Xo)
 
-## Sample Output
+## Scenarios
 
-Of note, this was played on a 1st generation Google Chromecast (USB stick looking, not circular)
+### 1st generation Google Chromecast (USB stick looking, not circular)
 
 ```
 msf > auxiliary/admin/chromecast/chromecast_youtube

--- a/documentation/modules/auxiliary/admin/http/scadabr_credential_dump.md
+++ b/documentation/modules/auxiliary/admin/http/scadabr_credential_dump.md
@@ -27,7 +27,7 @@
   7. You should get credentials
 
 
-## Sample Output
+## Scenarios
 
   ```
   [+] 172.16.191.166:8080 Authenticated successfully as 'admin'

--- a/documentation/modules/auxiliary/gather/censys_search.md
+++ b/documentation/modules/auxiliary/gather/censys_search.md
@@ -9,9 +9,9 @@ The module use the Censys REST API to access the same data accessible through we
 5: Do: `set CENSYS_DORK rapid7`
 6: Do: `run`
 
-## Sample Output
+## Scenarios
 
-#### Certificates Search
+### Certificates Search
 
 ```
 msf auxiliary(censys_search) > set CENSYS_DORK rapid7

--- a/documentation/modules/auxiliary/scanner/ftp/anonymous.md
+++ b/documentation/modules/auxiliary/scanner/ftp/anonymous.md
@@ -57,9 +57,9 @@ This module allows us to scan through a series of IP Addresses and provide detai
 3. Do: ```set RPORT [IP]```
 4. Do: ```run```
 
-## Sample Output
+## Scenarios
 
-### On vsFTPd 3.0.3 on Kali
+### vsFTPd 3.0.3 on Kali
 
 ```
 msf > use auxiliary/scanner/ftp/anonymous

--- a/documentation/modules/auxiliary/scanner/ftp/ftp_login.md
+++ b/documentation/modules/auxiliary/scanner/ftp/ftp_login.md
@@ -47,7 +47,8 @@ This module will test FTP logins on a range of machines and report successful lo
 3. Do: ```set RPORT [IP]```
 4. Do: ```run```
 
-## Sample Output
+## Scenarios
+
 ```
 msf> use auxiliary/scanner/ftp/ftp_login
 msf auxiliary(ftp_login) > set RHOSTS ftp.openbsd.org

--- a/documentation/modules/auxiliary/scanner/ftp/ftp_version.md
+++ b/documentation/modules/auxiliary/scanner/ftp/ftp_version.md
@@ -47,9 +47,9 @@ This module allows us to scan through a series of IP Addresses and provide detai
 3. Do: ```set RPORT [IP]```
 4. Do: ```run```
 
-## Sample Output
+## Scenarios
 
-### On vsFTPd 3.0.3 on Kali
+### vsFTPd 3.0.3 on Kali
 
 ```
 msf > use auxiliary/scanner/ftp/ftp_version

--- a/documentation/modules/auxiliary/scanner/http/binom3_login_config_pass_dump.md
+++ b/documentation/modules/auxiliary/scanner/http/binom3_login_config_pass_dump.md
@@ -1,4 +1,13 @@
-This module scans for Binom3 Multifunctional Revenue Energy Meter and Power Quality Analyzer management login portal(s), and attempts to identify valid credentials. There are four (4) default accounts - 'root'/'root', 'admin'/'1', 'alg'/'1', 'user'/'1'. In addition to device config, 'root' user can also access password file. Other users - admin, alg, user - can only access configuration file. The module attempts to download configuration and password files depending on the login user credentials found.
+This module scans for Binom3 Multifunctional Revenue Energy Meter and Power Quality Analyzer management login portal(s), and attempts to identify valid credentials.
+There are four (4) default accounts:
+
+1. root/root
+2. admin/1
+3. alg/1
+4. user/1
+
+In addition to device config, 'root' user can also access password file. Other users - admin, alg, user - can only access configuration file.
+The module attempts to download configuration and password files depending on the login user credentials found.
 
 ## Verification Steps
 
@@ -7,7 +16,7 @@ This module scans for Binom3 Multifunctional Revenue Energy Meter and Power Qual
 3. Do: ```set RPORT [PORT]```
 4. Do: ```run```
 
-## Sample Output
+## Scenarios
 
   ```
 msf > use auxiliary/scanner/http/binom3_login_config_pass_dump

--- a/documentation/modules/auxiliary/scanner/http/chromecast_webserver.md
+++ b/documentation/modules/auxiliary/scanner/http/chromecast_webserver.md
@@ -6,9 +6,9 @@ This module is a scanner which enumerates Google Chromecast via its HTTP interfa
 2. Do: ```set RHOSTS [IP]```
 3. Do: ```run```
 
-## Sample Output
+## Scenarios
 
-Of note, all 3 of the devices are the 1st generation Google Chromecast (USB stick looking, not circular)
+### All 3 of the devices are the 1st generation Google Chromecast (USB stick looking, not circular)
 
 ```
 msf > use auxiliary/scanner/http/chromecast_webserver 

--- a/documentation/modules/auxiliary/scanner/http/chromecast_wifi.md
+++ b/documentation/modules/auxiliary/scanner/http/chromecast_wifi.md
@@ -6,9 +6,9 @@ This module is a scanner which enumerates WiFi access points visible from a Goog
 2. Do: ```set RHOSTS [IP]```
 3. Do: ```run```
 
-## Sample Output
+## Scenarios
 
-Of note, all 3 of the devices are the 1st generation Google Chromecast (USB stick looking, not circular)
+### All 3 of the devices are the 1st generation Google Chromecast (USB stick looking, not circular)
 
 ```
 msf > use auxiliary/scanner/http/chromecast_wifi 

--- a/documentation/modules/auxiliary/scanner/http/crawler.md
+++ b/documentation/modules/auxiliary/scanner/http/crawler.md
@@ -34,9 +34,10 @@ You can use any web application to test the crawler.
 4. Do: ```set URI [PATH]```
 4. Do: ```run```
 
-## Sample Output
+## Scenarios
 
 ### Example against [WebGoat](https://github.com/WebGoat/WebGoat)
+
 ```
 msf> use auxiliary/scanner/http/crawler
 msf auxiliary(crawler) > set RHOST 127.0.0.1

--- a/documentation/modules/auxiliary/scanner/http/epmp1000_cmd_exec.md
+++ b/documentation/modules/auxiliary/scanner/http/epmp1000_cmd_exec.md
@@ -1,4 +1,9 @@
-This module exploits an OS Command Injection vulnerability in Cambium ePMP 1000 (<v2.5) device management portal. It requires any one of the following login credentials - admin/admin, installer/installer, home/home - to execute arbitrary system commands.
+This module exploits an OS Command Injection vulnerability in Cambium ePMP 1000 (<v2.5) device management portal.
+It requires any one of the following login credentials to execute arbitrary system commands:
+
+1. admin/admin
+2. installer/installer
+3. home/home
 
 ## Verification Steps
 
@@ -7,7 +12,7 @@ This module exploits an OS Command Injection vulnerability in Cambium ePMP 1000 
 3. Do: ```set RPORT [PORT]```
 4. Do: ```run```
 
-## Sample Output
+## Scenarios
 
   ```
 msf > use auxiliary/scanner/http/epmp1000_cmd_exec

--- a/documentation/modules/auxiliary/scanner/http/epmp1000_dump_config.md
+++ b/documentation/modules/auxiliary/scanner/http/epmp1000_dump_config.md
@@ -1,4 +1,5 @@
-This module dumps Cambium ePMP 1000 device configuration file. An ePMP 1000 box has four (4) login accounts - admin/admin, installer/installer, home/home, and readonly/readonly. This module requires any one of the following login credentials - admin / installer / home - to dump device configuration file.
+This module dumps Cambium ePMP 1000 device configuration file. An ePMP 1000 box has four (4) login accounts - admin/admin, installer/installer, home/home, and readonly/readonly.
+This module requires any one of the following login credentials - admin / installer / home - to dump device configuration file.
 
 ## Verification Steps
 
@@ -7,7 +8,7 @@ This module dumps Cambium ePMP 1000 device configuration file. An ePMP 1000 box 
 3. Do: ```set RPORT [PORT]```
 4. Do: ```run```
 
-## Sample Output
+## Scenarios
 
   ```
 msf > use auxiliary/scanner/http/epmp1000_dump_config

--- a/documentation/modules/auxiliary/scanner/http/epmp1000_dump_hashes.md
+++ b/documentation/modules/auxiliary/scanner/http/epmp1000_dump_hashes.md
@@ -1,4 +1,9 @@
-This module exploits an OS Command Injection vulnerability in Cambium ePMP 1000 (<v2.5) device management portal. It requires any one of the following login credentials - admin/admin, installer/installer, home/home - to dump system hashes.
+This module exploits an OS Command Injection vulnerability in Cambium ePMP 1000 (<v2.5) device management portal.
+It requires any one of the following login credentials to dump system hashes:
+
+1. admin/admin
+2. installer/installer
+3. home/home
 
 ## Verification Steps
 
@@ -7,7 +12,7 @@ This module exploits an OS Command Injection vulnerability in Cambium ePMP 1000 
 3. Do: ```set RPORT [PORT]```
 4. Do: ```run```
 
-## Sample Output
+## Scenarios
 
   ```
 msf > use auxiliary/scanner/http/epmp1000_dump_hashes

--- a/documentation/modules/auxiliary/scanner/http/epmp1000_web_login.md
+++ b/documentation/modules/auxiliary/scanner/http/epmp1000_web_login.md
@@ -1,4 +1,5 @@
-This module scans for Cambium ePMP 1000 management login portal(s), and attempts to identify valid credentials. Default login credentials are - admin/admin, installer/installer, home/home and readonly/readonly.
+This module scans for Cambium ePMP 1000 management login portal(s), and attempts to identify valid credentials.
+Default login credentials are - admin/admin, installer/installer, home/home and readonly/readonly.
 
 ## Verification Steps
 
@@ -7,7 +8,7 @@ This module scans for Cambium ePMP 1000 management login portal(s), and attempts
 3. Do: ```set RPORT [PORT]```
 4. Do: ```run```
 
-## Sample Output
+## Scenarios
 
   ```
 msf > use auxiliary/scanner/http/epmp1000_web_login

--- a/documentation/modules/auxiliary/scanner/http/gavazzi_em_login_loot.md
+++ b/documentation/modules/auxiliary/scanner/http/gavazzi_em_login_loot.md
@@ -1,11 +1,13 @@
-This module scans for Carlo Gavazzi Energy Meters login portals, performs a login brute force attack, enumerates device firmware version, and attempt to extract the SMTP configuration. A valid, admin privileged user is required to extract the SMTP password. In some older firmware versions, the SMTP config can be retrieved without any authentication.
+This module scans for Carlo Gavazzi Energy Meters login portals, performs a login brute force attack, enumerates device firmware version, and attempt to extract the SMTP configuration.
+A valid, admin privileged user is required to extract the SMTP password. In some older firmware versions, the SMTP config can be retrieved without any authentication.
 
-The module also exploits an access control vulnerability which allows an unauthenticated user to remotely dump the database file EWplant.db. This db file contains information such as power/energy utilization data, tariffs, and revenue statistics.
+The module also exploits an access control vulnerability which allows an unauthenticated user to remotely dump the database file EWplant.db.
+This db file contains information such as power/energy utilization data, tariffs, and revenue statistics.
 
 Vulnerable firmware versions include:
 
-VMU-C EM prior to firmware Version A11_U05
-VMU-C PV prior to firmware Version A17.
+* VMU-C EM prior to firmware Version A11_U05
+* VMU-C PV prior to firmware Version A17.
 
 ## Verification Steps
 
@@ -14,7 +16,7 @@ VMU-C PV prior to firmware Version A17.
 3. Do: ```set RPORT [PORT]```
 4. Do: ```run```
 
-## Sample Output
+## Scenarios
 
   ```
 msf > use auxiliary/scanner/http/gavazzi_em_login_loot

--- a/documentation/modules/auxiliary/scanner/http/meteocontrol_weblog_extractadmin.md
+++ b/documentation/modules/auxiliary/scanner/http/meteocontrol_weblog_extractadmin.md
@@ -1,4 +1,5 @@
-Meteocontrol WEB'Log Data Loggers are affected with an authentication bypass vulnerability. The module exploits this vulnerability to remotely extract Administrator password for the device management portal.
+Meteocontrol WEB'Log Data Loggers are affected with an authentication bypass vulnerability.
+The module exploits this vulnerability to remotely extract Administrator password for the device management portal.
 
 Note: In some versions, 'Website password' page is renamed or not present. Therefore, password can not be extracted. Manual verification will be required in such cases.
 
@@ -9,7 +10,7 @@ Note: In some versions, 'Website password' page is renamed or not present. There
 3. Do: ```set RPORT [PORT]```
 4. Do: ```run```
 
-## Sample Output
+## Scenarios
 
   ```
 msf > use auxiliary/scanner/http/meteocontrol_weblog_extractadmin

--- a/documentation/modules/auxiliary/scanner/http/ms15_034_http_sys_memory_dump.md
+++ b/documentation/modules/auxiliary/scanner/http/ms15_034_http_sys_memory_dump.md
@@ -11,7 +11,8 @@ This module dumps memory contents using a crafted Range header and affects only 
 3. Do: ```set RPORT [PORT]```
 4. Do: ```run```
 
-## Sample Output
+## Scenarios
+
 ```
 msf > use auxiliary/scanner/http/ms15_034_http_sys_memory_dump
 msf auxiliary(ms15_034_http_sys_memory_dump) > set RHOSTS 10.1.1.125

--- a/documentation/modules/auxiliary/scanner/http/owa_ews_login.md
+++ b/documentation/modules/auxiliary/scanner/http/owa_ews_login.md
@@ -1,4 +1,5 @@
-This module is for password guessing against OWA's EWS service which often exposes NTLM authentication over HTTPS. It is typically faster than the traditional form-based OWA login method.
+This module is for password guessing against OWA's EWS service which often exposes NTLM authentication over HTTPS.
+It is typically faster than the traditional form-based OWA login method.
 
 ## Verification Steps
 
@@ -7,7 +8,7 @@ This module is for password guessing against OWA's EWS service which often expos
 3. Set TARGETURI if necessary.
 4. Do: ```run```
 
-## Sample Output
+## Scenarios
 
 ```
 msf auxiliary(owa_ews_login) > run

--- a/documentation/modules/auxiliary/scanner/http/robots_txt.md
+++ b/documentation/modules/auxiliary/scanner/http/robots_txt.md
@@ -25,7 +25,8 @@ is extremely common.
 You can set the test path where the scanner will try to find `robots.txt` file.
 Default is `/`
 
-## Sample Output
+## Scenarios
+
 ```
 msf> use auxiliary/scanner/http/robots_txt
 msf auxiliary(robots_txt) > set RHOSTS 172.217.19.238

--- a/documentation/modules/auxiliary/scanner/ike/cisco_ike_benigncertain.md
+++ b/documentation/modules/auxiliary/scanner/ike/cisco_ike_benigncertain.md
@@ -9,7 +9,7 @@ The vulnerability is due to insufficient condition checks in the part of the cod
 3. Do: ```set RPORT [PORT]```
 4. Do: ```run```
 
-## Sample Output
+## Scenarios
 
 ```
 msf auxiliary(cisco_ike_benigncertain) > show options

--- a/documentation/modules/auxiliary/scanner/snmp/cambium_snmp_loot.md
+++ b/documentation/modules/auxiliary/scanner/snmp/cambium_snmp_loot.md
@@ -1,6 +1,8 @@
-Cambium devices (ePMP, PMP, Force, others) can be administered using SNMP. The device configuration contains IP addresses, keys, and passwords, amongst other information. This module uses SNMP to extract Cambium ePMP device configuration. On certain software versions, specific device configuration values can be accessed using SNMP RO string, even though only SNMP RW string should be able to access them, according to MIB documentation.
+Cambium devices (ePMP, PMP, Force, others) can be administered using SNMP. The device configuration contains IP addresses, keys, and passwords, amongst other information.
+This module uses SNMP to extract Cambium ePMP device configuration. On certain software versions, specific device configuration values can be accessed using SNMP RO string, even though only SNMP RW string should be able to access them, according to MIB documentation.
 
-The module also triggers full configuration backup, and retrieves the backup url. The configuration file can then be downloaded without authentication. The module has been tested primarily on Cambium ePMP current version (3.2.x, as of today), PMP, and Force units.
+The module also triggers full configuration backup, and retrieves the backup url. The configuration file can then be downloaded without authentication.
+The module has been tested primarily on Cambium ePMP current version (3.2.x, as of today), PMP, and Force units.
 
 Note: If the backup url is not retrieved, it is recommended to increase the TIMEOUT and reduce the THREADS. Backup url can also be retrieved by quering the OID as follows:
 
@@ -16,7 +18,7 @@ snmpget -v2c -c public 1.3.3.7 1.3.6.1.4.1.17713.21.6.4.13.0
 3. Do: ```set RPORT [PORT]```
 4. Do: ```run```
 
-## Sample Output
+## Scenarios
 
   ```
 msf > use auxiliary/scanner/snmp/epmp_snmp_loot

--- a/documentation/modules/exploit/multi/browser/adobe_flash_hacking_team_uaf.md
+++ b/documentation/modules/exploit/multi/browser/adobe_flash_hacking_team_uaf.md
@@ -17,7 +17,7 @@ This module exploits an use after free on Adobe Flash Player. The vulnerability,
 3. Do: ```set URIPATH / [PATH]```
 4. Do: ```run```
 
-## Sample Output
+## Scenarios
 
 ### IE 11 and Flash 18.0.0.194
 

--- a/documentation/modules/exploit/multi/http/axis2_deployer.md
+++ b/documentation/modules/exploit/multi/http/axis2_deployer.md
@@ -17,7 +17,7 @@ The Apache Axis2 Web application has three main sections:'Services' lists all th
 4. Do: ```set PASSWORD [Password]```
 5. Do: ```run```
 
-## Sample Output
+## Scenarios
 
 ```
 msf > use exploit/multi/http/axis2_deployer
@@ -56,7 +56,5 @@ OS          : Windows 2003 5.2 (x86)
 Meterpreter : java/java
 meterpreter > exit
 [*] Shutting down Meterpreter...
-
-[*] 10.10.155.37 - Meterpreter session 3 closed.  Reason: User exit
 
 ```

--- a/documentation/modules/exploit/multi/http/glassfish_deployer.md
+++ b/documentation/modules/exploit/multi/http/glassfish_deployer.md
@@ -34,7 +34,7 @@ If you are on a different platform (such as Windows), the installation should be
 4. Do: ```set PASSWORD [Password]```
 5. Do: ```run```
 
-## Sample Output
+## Scenarios
 
 ```
 msf > use exploit/multi/http/glassfish_deployer

--- a/documentation/modules/exploit/multi/http/mediawiki_syntaxhighlight.md
+++ b/documentation/modules/exploit/multi/http/mediawiki_syntaxhighlight.md
@@ -1,6 +1,7 @@
 ## Vulnerable Application
 
-  Any MediaWiki installation with SyntaxHighlight version 2.0 installed & enabled. This extension ships with the AIO package of MediaWiki 1.27.x & 1.28.x. A fix for this issue is included in MediaWiki version 1.28.2 and version 1.27.3.
+  Any MediaWiki installation with SyntaxHighlight version 2.0 installed & enabled. This extension ships with the AIO package of MediaWiki 1.27.x & 1.28.x.
+  A fix for this issue is included in MediaWiki version 1.28.2 and version 1.27.3.
 
 ## Vulnerable Setup
 
@@ -47,7 +48,7 @@ To set up the vulnerable environment, please do:
 
   In case the wiki is configured as private, a read-only (or better) account is needed to exploit this issue. Provide the password of that account here.
 
-## Sample Output
+## Scenarios
 
 ### The Check command
 

--- a/documentation/modules/exploit/multi/http/rails_web_console_v2_code_exec.md
+++ b/documentation/modules/exploit/multi/http/rails_web_console_v2_code_exec.md
@@ -1,6 +1,7 @@
 ## Description
 
- This module exploits an IP whitelist bypass vulnerability in the developer web console included with Ruby on Rails 4.0.x and 4.1.x. This module will also achieve code execution on Rails 4.2.x if the attack is launched from a whitelisted IP range.
+ This module exploits an IP whitelist bypass vulnerability in the developer web console included with Ruby on Rails 4.0.x and 4.1.x.
+ This module will also achieve code execution on Rails 4.2.x if the attack is launched from a whitelisted IP range.
 
 ## Verification Steps
 
@@ -12,8 +13,6 @@ rails new taco
 cd taco
 vim config/environments/development.rb
 ```
-
-
 
 Add the following line just before the final `end` tag:
 
@@ -38,7 +37,7 @@ sudo apt-get install nodejs
 3. Do: ```set RPORT [Port]```
 4. Do: ```run```
 
-## Sample Output
+## Scenarios
 
 ### Rails version 4.2.6
 

--- a/documentation/modules/exploit/windows/http/manageengine_connectionid_write.md
+++ b/documentation/modules/exploit/windows/http/manageengine_connectionid_write.md
@@ -1,6 +1,7 @@
 ## Description
 
-This module exploits a vulnerability found in ManageEngine Desktop Central 9. When uploading a 7z file, the FileUploadServlet class does not check the user-controlled ConnectionId parameter in the FileUploadServlet class. This allows a remote attacker to inject a null byte at the end of the value to create a malicious file with an arbitrary file type, and then place it under a directory that allows server-side scripts to run, which results in remote code execution under the context of SYSTEM. This exploit was successfully tested on version 9, build 90109 and build 91084.
+This module exploits a vulnerability found in ManageEngine Desktop Central 9. When uploading a 7z file, the FileUploadServlet class does not check the user-controlled ConnectionId parameter in the FileUploadServlet class. This allows a remote attacker to inject a null byte at the end of the value to create a malicious file with an arbitrary file type, and then place it under a directory that allows server-side scripts to run, which results in remote code execution under the context of SYSTEM.
+This exploit was successfully tested on version 9, build 90109 and build 91084.
 
 **NOTE:** By default, some ManageEngine Desktop Central versions run on port 8020, but older ones run on port 8040. Also, using this exploit will leave debugging information produced by FileUploadServlet in file `rdslog0.txt`.
        
@@ -21,7 +22,7 @@ Desktop Central is integrated desktop and mobile device management software that
 3. Do: ```check```
 4. Do: ```run```
 
-## Sample Output
+## Scenarios
 
 ```
 $ msfconsole

--- a/documentation/modules/exploit/windows/http/serviio_checkstreamurl_cmd_exec.md
+++ b/documentation/modules/exploit/windows/http/serviio_checkstreamurl_cmd_exec.md
@@ -30,7 +30,7 @@
   4. Do: `run`
   5. You should get a session
 
-## Sample Output
+## Scenarios
 
   ```
   msf > use exploit/windows/http/serviio_checkstreamurl_cmd_exec 

--- a/documentation/modules/exploit/windows/iis/iis_webdav_upload_asp.md
+++ b/documentation/modules/exploit/windows/iis/iis_webdav_upload_asp.md
@@ -21,7 +21,7 @@ Web Distributed Authoring and Versioning (WebDAV) is an extension of the Hyperte
 3. Do: ```set PATH / [PATH]```
 4. Do: ```run```
 
-## Sample Output
+## Scenarios
 
 ```
 msf > use exploit/windows/iis/iis_webdav_upload_asp

--- a/documentation/modules/module_doc_template.md
+++ b/documentation/modules/module_doc_template.md
@@ -27,6 +27,8 @@ functioning in 5+ years, so giving links or specific examples can be VERY helpfu
 
 ## Scenarios
 
+### Version of software and OS as applicable
+
   Specific demo of using the module that might be useful in a real world scenario.
 
   ```


### PR DESCRIPTION
Fixes #8490

This change does 3 things:

1. Adds a L3 header under scenarios to the doc template to suggest that scenarios say what exactly they are showing being exploited
2. Change `## Sample Output` to `## Scenarios`
3. A few more consistency things like line length, lists, newlines etc.