### PR TITLE
update java_rmi_server modules with CVE

### DIFF
--- a/modules/auxiliary/scanner/misc/java_rmi_server.rb
+++ b/modules/auxiliary/scanner/misc/java_rmi_server.rb
@@ -21,8 +21,8 @@ class MetasploitModule < Msf::Auxiliary
         [
           # RMI protocol specification
           [ 'URL', 'http://download.oracle.com/javase/1.3/docs/guide/rmi/spec/rmi-protocol.html'],
-          # Placeholder reference for matching
-          [ 'MSF', 'java_rmi_server']
+          [ 'URL', 'http://www.securitytracker.com/id?1026215'],
+          [ 'CVE', '2011-3556']
         ],
       'DisclosureDate' => 'Oct 15 2011'
     )

--- a/modules/exploits/multi/misc/java_rmi_server.rb
+++ b/modules/exploits/multi/misc/java_rmi_server.rb
@@ -31,8 +31,8 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           # RMI protocol specification
           [ 'URL', 'http://download.oracle.com/javase/1.3/docs/guide/rmi/spec/rmi-protocol.html'],
-          # Placeholder reference for matching
-          [ 'MSF', 'java_rmi_server']
+          [ 'URL', 'http://www.securitytracker.com/id?1026215'],
+          [ 'CVE', '2011-3556']
         ],
       'DisclosureDate' => 'Oct 15 2011',
       'Platform'       => %w{ java linux osx solaris win },


### PR DESCRIPTION
Update references in `java_rmi_server` modules to reference CVE also link to an expanded description of issue with RMI.

## Verification

List the steps needed to make sure this thing works

- [x] Validate link and CVE match module function.

