### PR TITLE
Change ipmi_dumphashes to have non-verbose output, ever

### DIFF
--- a/modules/auxiliary/scanner/ipmi/ipmi_dumphashes.rb
+++ b/modules/auxiliary/scanner/ipmi/ipmi_dumphashes.rb
@@ -58,7 +58,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def ipmi_good(msg)
-    vprint_good("#{rhost}:#{rport} - IPMI - #{msg}")
+    print_good("#{rhost}:#{rport} - IPMI - #{msg}")
   end
 
   def run_host(ip)


### PR DESCRIPTION
The current state of ipmi_dumphashes is that it literally outputs no output unless you have VERBOSE true. That's not very obvious or useful. This pull request changes it so that it prints messages to the console when it dumps hashes.

Old and busted: http://imgur.com/a/VrxkW
The new hotness: http://imgur.com/a/NSecT

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use auxilliary/scanner/ipmi/ipmi_dumphashes`
- [x] `set RHOSTS [a host that has RAKP hash disclosure]`
- [x] `run`
- [x] Note that it outputs something, instead of nothing
