### PR TITLE
Upstream console search additions and fixes

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -51,6 +51,7 @@ class Core
     "-r"  => [ false, "Reset the ring buffer for the session given with -i, or all"    ],
     "-u"  => [ true,  "Upgrade a shell to a meterpreter session on many platforms"     ],
     "-t"  => [ true,  "Set a response timeout (default: 15)"                           ],
+    "-S"  => [ true, "Row search filter."                                              ],
     "-x" =>  [ false, "Show extended information in the session table"                 ])
 
   @@threads_opts = Rex::Parser::Arguments.new(
@@ -85,6 +86,10 @@ class Core
     "-k" => [ true,  "Keep (include) arg lines at start of output."   ],
     "-c" => [ false, "Only print a count of matching lines."          ])
 
+  @@search_opts = Rex::Parser::Arguments.new(
+    "-h" => [ false, "Help banner."                                   ],
+    "-S" => [ true, "Row search filter."                              ])
+
   @@history_opts = Rex::Parser::Arguments.new(
     "-h" => [ false, "Help banner."                                   ],
     "-a" => [ false, "Show all commands in history."                  ],
@@ -94,7 +99,6 @@ class Core
   @@irb_opts = Rex::Parser::Arguments.new(
     "-h" => [ false, "Help banner."                                   ],
     "-e" => [ true,  "Expression to evaluate."                        ])
-
 
   # Returns the list of commands supported by this command dispatcher
   def commands
@@ -170,9 +174,6 @@ class Core
     end
     driver.update_prompt
   end
-
-
-
 
   def cmd_cd_help
     print_line "Usage: cd <directory>"
@@ -869,10 +870,12 @@ class Core
 
     when "add", "remove", "del"
       subnet = args.shift
-      netmask = nil
-      if subnet
-        subnet, cidr_mask = subnet.split("/")
-        netmask = Rex::Socket.addr_ctoa(cidr_mask.to_i) if cidr_mask
+      subnet,cidr_mask = subnet.split("/")
+      if Rex::Socket.is_ipv4?(args.first)
+        netmask = args.shift
+      else
+        cidr_mask = '32' if cidr_mask.nil?
+        netmask = Rex::Socket.addr_ctoa(cidr_mask.to_i)
       end
 
       netmask = args.shift if netmask.nil?
@@ -1074,7 +1077,6 @@ class Core
     print_line("Saved configuration to: #{Msf::Config.config_file}")
   end
 
-
   def cmd_spool_help
     print_line "Usage: spool <off>|<filename>"
     print_line
@@ -1139,6 +1141,7 @@ class Core
     script   = nil
     reset_ring = false
     response_timeout = 15
+    search_term = nil
 
     # any arguments that don't correspond to an option or option arg will
     # be put in here
@@ -1151,53 +1154,58 @@ class Core
       # Parse the command options
       @@sessions_opts.parse(args) do |opt, idx, val|
         case opt
-        when '-q'
+        when "-q"
           quiet = true
         # Run a command on all sessions, or the session given with -i
-        when '-c'
+        when "-c"
           method = 'cmd'
           cmds << val if val
-        when '-C'
+        when "-C"
             method = 'meterp-cmd'
             cmds << val if val
-        when '-x'
+        when "-x"
           show_extended = true
-        when '-v'
+        when "-v"
           verbose = true
         # Do something with the supplied session identifier instead of
         # all sessions.
-        when '-i'
+        when "-i"
           sid = val
         # Display the list of active sessions
-        when '-l'
+        when "-l"
           method = 'list'
-        when '-k'
+        when "-k"
           method = 'kill'
           sid = val || false
-        when '-K'
+        when "-K"
           method = 'killall'
         # Run a script on all meterpreter sessions
-        when '-s'
+        when "-s"
           unless script
             method = 'scriptall'
             script = val
           end
         # Upload and exec to the specific command session
-        when '-u'
+        when "-u"
           method = 'upexec'
           sid = val || false
+        # Search for specific session
+        when "-S", "--search"
+          search_term = val
         # Reset the ring buffer read pointer
-        when '-r'
+        when "-r"
           reset_ring = true
           method = 'reset_ring'
         # Display help banner
-        when '-h'
+        when "-h"
           cmd_sessions_help
           return false
-        when '-t'
+        when "-t"
           if val.to_s =~ /^\d+$/
             response_timeout = val.to_i
           end
+        when "-S", "--search"
+          search_term = val
         else
           extra << val
         end
@@ -1463,7 +1471,7 @@ class Core
       end
     when 'list',nil
       print_line
-      print(Serializer::ReadableText.dump_sessions(framework, :show_extended => show_extended, :verbose => verbose))
+      print(Serializer::ReadableText.dump_sessions(framework, :show_extended => show_extended, :verbose => verbose, :search_term => search_term))
       print_line
     end
 
@@ -1952,7 +1960,6 @@ class Core
 
   alias cmd_unsetg_help cmd_unset_help
 
-
   #
   # Returns the revision of the framework and console library
   #
@@ -2410,7 +2417,6 @@ class Core
     ]
     return binary_paths.include? Msf::Config.install_root
   end
-
 
   #
   # Returns an array of lines at the provided line number plus any before and/or after lines requested

--- a/lib/msf/ui/console/command_dispatcher/creds.rb
+++ b/lib/msf/ui/console/command_dispatcher/creds.rb
@@ -15,7 +15,7 @@ class Creds
   include Msf::Ui::Console::CommandDispatcher
   include Metasploit::Credential::Creation
   include Msf::Ui::Console::CommandDispatcher::Common
-  
+
   #
   # The dispatcher's name.
   #
@@ -31,11 +31,11 @@ class Creds
       "creds" => "List all credentials in the database"
     }
   end
-  
+
   def allowed_cred_types
     %w(password ntlm hash)
   end
-  
+
   #
   # Returns true if the db is connected, prints an error and returns
   # false if not.
@@ -51,22 +51,55 @@ class Creds
     end
     true
   end
-  
+
+  #
+  # Miscellaneous option helpers
+  #
+
+  # Parse +arg+ into a {Rex::Socket::RangeWalker} and append the result into +host_ranges+
+  #
+  # @note This modifies +host_ranges+ in place
+  #
+  # @param arg [String] The thing to turn into a RangeWalker
+  # @param host_ranges [Array] The array of ranges to append
+  # @param required [Boolean] Whether an empty +arg+ should be an error
+  # @return [Boolean] true if parsing was successful or false otherwise
+  def arg_host_range(arg, host_ranges, required=false)
+    if (!arg and required)
+      print_error("Missing required host argument")
+      return false
+    end
+    begin
+      rw = Rex::Socket::RangeWalker.new(arg)
+    rescue
+      print_error("Invalid host parameter, #{arg}.")
+      return false
+    end
+
+    if rw.valid?
+      host_ranges << rw
+    else
+      print_error("Invalid host parameter, #{arg}.")
+      return false
+    end
+    return true
+  end
+
   #
   # Can return return active or all, on a certain host or range, on a
   # certain port or range, and/or on a service name.
   #
   def cmd_creds(*args)
     return unless active?
-    
+
     # Short-circuit help
     if args.delete "-h"
       cmd_creds_help
       return
     end
-    
+
     subcommand = args.shift
-    
+
     case subcommand
     when 'help'
       cmd_creds_help
@@ -79,7 +112,7 @@ class Creds
     end
 
   end
-  
+
   #
   # TODO: this needs to be cleaned up to use the new syntax
   #
@@ -126,7 +159,7 @@ class Creds
     print_line "   creds add user:other hash:d19c32489b870735b5f587d76b934283"
     print_line "   # Add a NonReplayableHash"
     print_line "   creds add hash:d19c32489b870735b5f587d76b934283"
-    
+
     print_line
     print_line "General options"
     print_line "  -h,--help             Show this help information"
@@ -156,7 +189,7 @@ class Creds
     print_line "  creds -d -s smb"
     print_line
   end
-  
+
   # @param private_type [Symbol] See `Metasploit::Credential::Creation#create_credential`
   # @param username [String]
   # @param password [String]
@@ -168,35 +201,35 @@ class Creds
       hsh[opt[0]] = opt[1..-1].join(':') # everything before the first : is the key, reasembling everything after the colon. why ntlm hashes
       hsh
     end
-    
+
     begin
       params.assert_valid_keys('user','password','realm','realm-type','ntlm','ssh-key','hash','address','port','protocol', 'service-name')
     rescue ArgumentError => e
       print_error(e.message)
     end
-    
+
     # Verify we only have one type of private
     if params.slice('password','ntlm','ssh-key','hash').length > 1
       private_keys = params.slice('password','ntlm','ssh-key','hash').keys
       print_error("You can only specify a single Private type. Private types given: #{private_keys.join(', ')}")
       return
     end
-    
+
     login_keys = params.slice('address','port','protocol','service-name')
     if login_keys.any? and login_keys.length < 3
       missing_login_keys = ['host','port','proto','service-name'] - login_keys.keys
       print_error("Creating a login requires a address, a port, and a protocol. Missing params: #{missing_login_keys}")
       return
     end
-   
+
     data = {
       workspace_id: framework.db.workspace,
       origin_type: :import,
       filename: 'msfconsole'
     }
-    
+
     data[:username] = params['user'] if params.key? 'user'
-    
+
     if params.key? 'realm'
       if params.key? 'realm-type'
         if Metasploit::Model::Realm::Key::SHORT_NAMES.key? params['realm-type']
@@ -235,7 +268,7 @@ class Creds
       data[:private_type] = :nonreplayable_hash
       data[:private_data] = params['hash']
     end
-        
+
     begin
       if login_keys.any?
         data[:address] = params['address']
@@ -250,7 +283,7 @@ class Creds
       print_error("Failed to add #{data['private_type']}: #{e}")
     end
   end
-  
+
   def creds_search(*args)
     host_ranges   = []
     origin_ranges = []
@@ -264,6 +297,7 @@ class Creds
     cred_table_columns = [ 'host', 'origin' , 'service', 'public', 'private', 'realm', 'private_type' ]
     user = nil
     delete_count = 0
+    search_term = nil
 
     while (arg = args.shift)
       case arg
@@ -314,6 +348,8 @@ class Creds
           return
         end
         arg_host_range(hosts, origin_ranges)
+      when '-S', '--search-term'
+        search_term = args.shift
       else
         # Anything that wasn't an option is a host to search for
         unless (arg_host_range(arg, host_ranges))
@@ -343,7 +379,8 @@ class Creds
     svcs.flatten!
     tbl_opts = {
       'Header'  => "Credentials",
-      'Columns' => cred_table_columns
+      'Columns' => cred_table_columns,
+      'SearchTerm' => search_term
     }
 
     tbl = Rex::Text::Table.new(tbl_opts)
@@ -481,8 +518,8 @@ class Creds
     end
     return tabs
   end
-  
-  
+
+
 end
 
 end end end end

--- a/lib/msf/ui/console/command_dispatcher/jobs.rb
+++ b/lib/msf/ui/console/command_dispatcher/jobs.rb
@@ -34,7 +34,8 @@ module Msf
             "-K" => [ false, "Terminate all running jobs."                    ],
             "-i" => [ true,  "Lists detailed information about a running job."],
             "-l" => [ false, "List all running jobs."                         ],
-            "-v" => [ false, "Print more detailed info.  Use with -i and -l"  ]
+            "-v" => [ false, "Print more detailed info.  Use with -i and -l"  ],
+            "-S" => [ true, "Row search filter."                              ],
           )
 
           def commands
@@ -151,6 +152,9 @@ module Msf
                 # so we can check for the verbose flag.
                 dump_info = true
                 job_id = val
+              when "-S", "--search"
+                search_term = val
+                dump_list = true
               when "-h"
                 cmd_jobs_help
                 return false

--- a/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
@@ -288,7 +288,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Db do
       it "should list default workspace" do
         db.cmd_workspace
         expect(@output).to match_array [
-          "* default"
+          "%red* default%clr"
         ]
       end
 
@@ -298,7 +298,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Db do
         db.cmd_workspace
         expect(@output).to match_array [
           "  default",
-          "* foo"
+          "%red* foo%clr"
         ]
       end
     end

--- a/spec/lib/msf/ui/console/command_dispatcher/modules_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/modules_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Modules do
     end
 
     it 'should generate Matching Modules table' do
-      expect(core).to receive(:generate_module_table).with('Matching Modules').and_call_original
+      expect(core).to receive(:generate_module_table).with('Matching Modules', nil).and_call_original
 
       search_modules_sql
     end


### PR DESCRIPTION
The -S flag for console commands, backed by search functionality
in Rex' tables, originally pushed upstream in #1604 (iirc), lacks
coverage for a number of commands which benefit a good deal from
inline filtering of the potentially large number of results.

Push more -S flags and surrounding table functionality upstream
to provide coverage for the console commands included in framework.

Include a fix for deleting hosts when DB references are a problem.

Include a fix for the upstream route command wherein scope must be
defined for the routing target by assuming a /32 without explicit
definition.

Note:
  With this in place, console behavior when filtering results is
roughly analagous to the R7 filtering in web UI, which should help
those of us trying to use both maintain corresponding workflows.

Testing:
  Used in-house for years, though changes to the diff from upstream
and our fork (expunging some internal code) are untested, so would
appreciate eyes and hands on.


Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] use console commands with `-S` flag and a search term
- [ ] get filtered results
- [ ] **Verify** proper function with the -S flag passed - filtered lists, proper -R function (yeah, thats why it was done in the Rex Table, in case someone wants to know), correct console output
- [ ] **Verify** proper function without the -S flag passed - correct console output as before patch
- [ ] **Verify** proper function of the `route add` command with no CIDR/mask passed
- [ ] **Verify** hackaround for `hosts -d` when the DB has broken refs (some of us have databases older than your first grader)
