### PR TITLE
fix #8199, check extapi commands for dependencies

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher.rb
@@ -52,18 +52,10 @@ module Console::CommandDispatcher
   #
   # Returns the commands that meet the requirements
   #
-  def check_commands(all, reqs=nil)
+  def filter_commands(all, reqs)
     all.delete_if do |cmd, _desc|
-      del = false
-      reqs[cmd].each do |req|
-        next if client.commands.include? req
-        del = true
-        break
-      end
-      del
+      reqs[cmd].any? { |req| !client.commands.include?(req) }
     end
-
-    all
   end
 
   #

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher.rb
@@ -50,6 +50,23 @@ module Console::CommandDispatcher
   end
 
   #
+  # Returns the commands that meet the requirements
+  #
+  def check_commands(all, reqs=nil)
+    all.delete_if do |cmd, _desc|
+      del = false
+      reqs[cmd].each do |req|
+        next if client.commands.include? req
+        del = true
+        break
+      end
+      del
+    end
+
+    all
+  end
+
+  #
   # Returns true if the client has a framework object.
   #
   # Used for firing framework session events

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/android.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/android.rb
@@ -36,7 +36,6 @@ class Console::CommandDispatcher::Android
       'set_audio_mode'    => 'Set Ringer Mode',
       'wakelock'          => 'Enable/Disable Wakelock',
     }
-
     reqs = {
       'dump_sms'         => ['android_dump_sms'],
       'dump_contacts'    => ['android_dump_contacts'],
@@ -53,11 +52,7 @@ class Console::CommandDispatcher::Android
       'set_audio_mode'   => ['android_set_audio_mode'],
       'wakelock'         => ['android_wakelock'],
     }
-
-    # Ensure any requirements of the command are met
-    all.delete_if do |cmd, _desc|
-      reqs[cmd].any? { |req| !client.commands.include?(req) }
-    end
+    check_commands(all, reqs)
   end
 
   def interval_collect_usage

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/android.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/android.rb
@@ -52,7 +52,7 @@ class Console::CommandDispatcher::Android
       'set_audio_mode'   => ['android_set_audio_mode'],
       'wakelock'         => ['android_wakelock'],
     }
-    check_commands(all, reqs)
+    filter_commands(all, reqs)
   end
 
   def interval_collect_usage

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/extapi/adsi.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/extapi/adsi.rb
@@ -41,7 +41,7 @@ class Console::CommandDispatcher::Extapi::Adsi
       "adsi_dc_enum"                => [ "extapi_adsi_domain_query" ],
       "adsi_domain_query"           => [ "extapi_adsi_domain_query" ],
     }
-    check_commands(all, reqs)
+    filter_commands(all, reqs)
   end
 
   #

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/extapi/adsi.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/extapi/adsi.rb
@@ -25,7 +25,7 @@ class Console::CommandDispatcher::Extapi::Adsi
   # List of supported commands.
   #
   def commands
-    {
+    all = {
       'adsi_user_enum'              => 'Enumerate all users on the specified domain.',
       'adsi_group_enum'             => 'Enumerate all groups on the specified domain.',
       'adsi_nested_group_user_enum' => 'Recursively enumerate users who are effectively members of the group specified.',
@@ -33,6 +33,15 @@ class Console::CommandDispatcher::Extapi::Adsi
       'adsi_dc_enum'                => 'Enumerate all domain controllers on the specified domain.',
       'adsi_domain_query'           => 'Enumerate all objects on the specified domain that match a filter.'
     }
+    reqs = {
+      "adsi_user_enum"              => [ "extapi_adsi_domain_query" ],
+      "adsi_group_enum"             => [ "extapi_adsi_domain_query" ],
+      "adsi_nested_group_user_enum" => [ "extapi_adsi_domain_query" ],
+      "adsi_computer_enum"          => [ "extapi_adsi_domain_query" ],
+      "adsi_dc_enum"                => [ "extapi_adsi_domain_query" ],
+      "adsi_domain_query"           => [ "extapi_adsi_domain_query" ],
+    }
+    check_commands(all, reqs)
   end
 
   #

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/extapi/clipboard.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/extapi/clipboard.rb
@@ -40,7 +40,7 @@ class Console::CommandDispatcher::Extapi::Clipboard
       "clipboard_monitor_purge"  => [ "extapi_clipboard_monitor_purge" ],
       "clipboard_monitor_stop"   => [ "extapi_clipboard_monitor_stop" ],
     }
-    check_commands(all, reqs)
+    filter_commands(all, reqs)
   end
 
   #

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/extapi/clipboard.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/extapi/clipboard.rb
@@ -20,7 +20,7 @@ class Console::CommandDispatcher::Extapi::Clipboard
   # List of supported commands.
   #
   def commands
-    {
+    all = {
       "clipboard_get_data"       => "Read the target's current clipboard (text, files, images)",
       "clipboard_set_text"       => "Write text to the target's clipboard",
       "clipboard_monitor_start"  => "Start the clipboard monitor",
@@ -30,6 +30,17 @@ class Console::CommandDispatcher::Extapi::Clipboard
       "clipboard_monitor_purge"  => "Delete all captured cilpboard content without dumping it",
       "clipboard_monitor_stop"   => "Stop the clipboard monitor"
     }
+    reqs = {
+      "clipboard_get_data"       => [ "extapi_clipboard_get_data" ],
+      "clipboard_set_text"       => [ "extapi_clipboard_set_data" ],
+      "clipboard_monitor_start"  => [ "extapi_clipboard_monitor_start" ],
+      "clipboard_monitor_pause"  => [ "extapi_clipboard_monitor_pause" ],
+      "clipboard_monitor_resume" => [ "extapi_clipboard_monitor_resume" ],
+      "clipboard_monitor_dump"   => [ "extapi_clipboard_monitor_dump" ],
+      "clipboard_monitor_purge"  => [ "extapi_clipboard_monitor_purge" ],
+      "clipboard_monitor_stop"   => [ "extapi_clipboard_monitor_stop" ],
+    }
+    check_commands(all, reqs)
   end
 
   #

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/extapi/service.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/extapi/service.rb
@@ -31,7 +31,7 @@ class Console::CommandDispatcher::Extapi::Service
       "service_query"   => [ "extapi_service_query" ],
       "service_control" => [ "extapi_service_control" ],
     }
-    check_commands(all, reqs)
+    filter_commands(all, reqs)
   end
 
   #

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/extapi/service.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/extapi/service.rb
@@ -21,11 +21,17 @@ class Console::CommandDispatcher::Extapi::Service
   # List of supported commands.
   #
   def commands
-    {
+    all = {
       "service_enum"    => "Enumerate all registered Windows services",
       "service_query"   => "Query more detail about a specific Windows service",
       "service_control" => "Control a single service (start/pause/resume/stop/restart)"
     }
+    reqs = {
+      "service_enum"    => [ "extapi_service_enum" ],
+      "service_query"   => [ "extapi_service_query" ],
+      "service_control" => [ "extapi_service_control" ],
+    }
+    check_commands(all, reqs)
   end
 
   #

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/extapi/window.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/extapi/window.rb
@@ -27,7 +27,7 @@ class Console::CommandDispatcher::Extapi::Window
     reqs = {
       "window_enum" => [ "extapi_window_enum" ],
     }
-    check_commands(all, reqs)
+    filter_commands(all, reqs)
   end
 
   #

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/extapi/window.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/extapi/window.rb
@@ -21,9 +21,13 @@ class Console::CommandDispatcher::Extapi::Window
   # List of supported commands.
   #
   def commands
-    {
+    all = {
       "window_enum" => "Enumerate all current open windows"
     }
+    reqs = {
+      "window_enum" => [ "extapi_window_enum" ],
+    }
+    check_commands(all, reqs)
   end
 
   #

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/extapi/wmi.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/extapi/wmi.rb
@@ -31,7 +31,7 @@ class Console::CommandDispatcher::Extapi::Wmi
     reqs = {
       "wmi_query" => [ "extapi_wmi_query" ],
     }
-    check_commands(all, reqs)
+    filter_commands(all, reqs)
   end
 
   #

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/extapi/wmi.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/extapi/wmi.rb
@@ -25,9 +25,13 @@ class Console::CommandDispatcher::Extapi::Wmi
   # List of supported commands.
   #
   def commands
-    {
-      "wmi_query" => "Perform a generic WMI query and return the results"
+    all = {
+      "wmi_query" => "Perform a generic WMI query and return the results",
     }
+    reqs = {
+      "wmi_query" => [ "extapi_wmi_query" ],
+    }
+    check_commands(all, reqs)
   end
 
   #

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/lanattacks/dhcp.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/lanattacks/dhcp.rb
@@ -29,7 +29,6 @@ class Console::CommandDispatcher::Lanattacks::Dhcp
       "dhcp_load_options" => "Load DHCP optionis from a datastore",
       "dhcp_log"          => "Log DHCP server activity"
     }
-
     reqs = {
       "dhcp_start"        => [ "lanattacks_start_dhcp" ],
       "dhcp_stop"         => [ "lanattacks_stop_dhcp" ],
@@ -38,19 +37,7 @@ class Console::CommandDispatcher::Lanattacks::Dhcp
       "dhcp_load_options" => [ "lanattacks_set_dhcp_option" ],
       "dhcp_log"          => [ "lanattacks_dhcp_log" ]
     }
-
-    all.delete_if do |cmd, desc|
-      del = false
-      reqs[cmd].each do |req|
-        next if client.commands.include? req
-        del = true
-        break
-      end
-
-      del
-    end
-
-    all
+    filter_commands(all, reqs)
   end
 
   #

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/lanattacks/tftp.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/lanattacks/tftp.rb
@@ -27,26 +27,13 @@ class Console::CommandDispatcher::Lanattacks::Tftp
       "tftp_reset"    => "Reset the TFTP server",
       "tftp_add_file" => "Add a file to the TFTP server"
     }
-
     reqs = {
       "tftp_start"    => [ "lanattacks_start_tftp" ],
       "tftp_stop"     => [ "lanattacks_stop_tftp" ],
       "tftp_reset"    => [ "lanattacks_reset_tftp" ],
       "tftp_add_file" => [ "lanattacks_add_tftp_file" ],
     }
-
-    all.delete_if do |cmd, desc|
-      del = false
-      reqs[cmd].each do |req|
-        next if client.commands.include? req
-        del = true
-        break
-      end
-
-      del
-    end
-
-    all
+    filter_commands(all, reqs)
   end
 
   #

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
@@ -102,18 +102,7 @@ class Console::CommandDispatcher::Stdapi::Fs
       'show_mount' => ['stdapi_fs_mount_show'],
     }
 
-    all.delete_if do |cmd, desc|
-      del = false
-      reqs[cmd].each do |req|
-        next if client.commands.include? req
-        del = true
-        break
-      end
-
-      del
-    end
-
-    all
+    filter_commands(all, reqs)
   end
 
   #

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/net.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/net.rb
@@ -108,18 +108,7 @@ class Console::CommandDispatcher::Stdapi::Net
       'resolve'  => ['stdapi_net_resolve_host'],
     }
 
-    all.delete_if do |cmd, desc|
-      del = false
-      reqs[cmd].each do |req|
-        next if client.commands.include? req
-        del = true
-        break
-      end
-
-      del
-    end
-
-    all
+    filter_commands(all, reqs)
   end
 
   #

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
@@ -143,19 +143,7 @@ class Console::CommandDispatcher::Stdapi::Sys
       "sysinfo"     => [ "stdapi_sys_config_sysinfo" ],
       "localtime"   => [ "stdapi_sys_config_localtime" ],
     }
-
-    all.delete_if do |cmd, desc|
-      del = false
-      reqs[cmd].each do |req|
-        next if client.commands.include? req
-        del = true
-        break
-      end
-
-      del
-    end
-
-    all
+    filter_commands(all, reqs)
   end
 
   #

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/ui.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/ui.rb
@@ -49,19 +49,7 @@ class Console::CommandDispatcher::Stdapi::Ui
         "stdapi_ui_enable_keyboard"
       ]
     }
-
-    all.delete_if do |cmd, desc|
-      del = false
-      reqs[cmd].each do |req|
-        next if client.commands.include? req
-        del = true
-        break
-      end
-
-      del
-    end
-
-    all
+    filter_commands(all, reqs)
   end
 
   #

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/webcam.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/webcam.rb
@@ -34,18 +34,7 @@ class Console::CommandDispatcher::Stdapi::Webcam
       "webcam_stream" => [ "webcam_start", "webcam_get_frame", "webcam_stop" ],
       "record_mic"    => [ "webcam_audio_record" ]
     }
-
-    all.delete_if do |cmd, _desc|
-      del = false
-      reqs[cmd].each do |req|
-        next if client.commands.include? req
-        del = true
-        break
-      end
-      del
-    end
-
-    all
+    filter_commands(all, reqs)
   end
 
   #


### PR DESCRIPTION
Fixes #8199 

- [x] Start `msfconsole`
- [x] Get a windows meterpreter session, and type `load extapi`
- [x] **Verify** all the extapi commands are loaded as before
- [x] Get an android meterpreter session, and type `load extapi`
- [x] **Verify** only the clipboard commands are shown
- [ ] (Optional)
- [x] Get an OSX meterpreter session, and type `load extapi`
- [x] **Verify** only the clipboard get/set commands are shown
