### PR TITLE
bump metasploit-credential to allow handling string addresses gracefully

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -183,12 +183,13 @@ GEM
       activemodel (~> 4.2.6)
       activesupport (~> 4.2.6)
       railties (~> 4.2.6)
-    metasploit-credential (2.0.9)
+    metasploit-credential (2.0.10)
       metasploit-concern
       metasploit-model
       metasploit_data_models
       pg
       railties
+      rex-socket
       rubyntlm
       rubyzip
     metasploit-model (2.0.4)


### PR DESCRIPTION
This fixes #8522 and a few other issues with modules breaking due to metasploit_data_model being unable to store hosts without knowing their IP address first. This is only a partial solution, in that it simply causes credential to return a nil, rather than throwing an exception. After auditing the work required to make every module trap the exception, vs. making metasploit_data_model be able to deal with hosts without known IPs, vs. this, the winner was here.

## Verification

- [x] Import the below test module
- [x] Set rhosts and run the module
- [x] Verify that it runs without any errors

```
class MetasploitModule < Msf::Auxiliary
  include Msf::Auxiliary::Report
  include Msf::Auxiliary::Scanner

  def initialize(info = {})
    super(update_info(info,
      'Name'        => 'blah',
      'Description' => %q{
          blah
        },
      'Author'      =>
        [
          'Brent Cook',
        ],
      'License'     => MSF_LICENSE
    ))
  end

  def run_host(ip)
    credential_data = {
      origin_type: :service,
      module_fullname: self.fullname,
      workspace_id: myworkspace.id,
      private_data: "blah",
      private_type: :password,
      username: "blah"
    }

    service_data = {
      address: 'localhost',
      port: 1234,
      service_name: "blah",
      protocol: 'tcp',
      workspace_id: myworkspace.id
    }

    credential_data.merge!(service_data)
    credential_core = create_credential(credential_data)

    login_data = {
      core: credential_core,
      status: Metasploit::Model::Login::Status::UNTRIED,
      workspace_id: myworkspace.id
    }

    login_data.merge!(service_data)
    create_credential_login(login_data)
  end
end
```