### PR TITLE
MSGRPC module minor fixes

### DIFF
--- a/lib/msf/core/rpc/v10/service.rb
+++ b/lib/msf/core/rpc/v10/service.rb
@@ -76,6 +76,7 @@ class Service
 
   def stop
     self.service.stop
+    self.service.deref
   end
 
   def wait

--- a/plugins/msgrpc.rb
+++ b/plugins/msgrpc.rb
@@ -21,12 +21,12 @@ class Plugin::MSGRPC < Msf::Plugin
   #
   # The default local hostname that the server listens on.
   #
-  DefaultHost = "127.0.0.1"
+  DefaultHost ||= "127.0.0.1"
 
   #
   # The default local port that the server listens on.
   #
-  DefaultPort = 55552
+  DefaultPort ||= 55552
 
   #
   # ServerPort


### PR DESCRIPTION
This PR takes care of two issues that are currently present with the MSGRPC module when loading, unloading, then reloading:

1. Current behavior produces two warnings upon reloading about the already initialized constants DefaultHost and DefaultPort from the first load. This has been corrected using OR Equal.
2. Current behavior does not start the HTTP server upon reloading. The HTTP server is never dereferenced from the ServiceManager, so it thinks that the service still exists and doesn't run the HTTP server instance. This has been corrected by explicitly calling service.deref.

In short, go ahead and load/unload msgrpc as many times as you want now :)