### PR TITLE
Clean up cmd_ps table output for Mettle

### DIFF
--- a/lib/rex/post/meterpreter/extensions/stdapi/sys/process.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/sys/process.rb
@@ -391,13 +391,9 @@ class ProcessList < Array
     end
 
     cols = [ "PID", "PPID", "Name", "Arch", "Session", "User", "Path" ]
-    # Arch and Session are specific to native Windows, PHP and Java can't do
-    # ppid.  Cut columns from the list if they aren't there.  It is conceivable
-    # that processes might have different columns, but for now assume that the
-    # first one is representative.
     cols.delete_if do |c|
-      !(any? {|r| r.has_key?(c.downcase)}) or
-        all? {|r| r[c.downcase].nil?}
+      none? {|r| r.has_key?(c.downcase)} ||
+      all? {|r| r[c.downcase].nil?}
     end
 
     opts = {

--- a/lib/rex/post/meterpreter/extensions/stdapi/sys/process.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/sys/process.rb
@@ -395,7 +395,10 @@ class ProcessList < Array
     # ppid.  Cut columns from the list if they aren't there.  It is conceivable
     # that processes might have different columns, but for now assume that the
     # first one is representative.
-    cols.delete_if { |c| !( first.has_key?(c.downcase) ) or first[c.downcase].nil? }
+    cols.delete_if do |c|
+      !(any? {|r| r.has_key?(c.downcase)}) or
+        all? {|r| r[c.downcase].nil?}
+    end
 
     opts = {
       'Header' => 'Process List',
@@ -406,6 +409,7 @@ class ProcessList < Array
     tbl = Rex::Text::Table.new(opts)
     each { |process|
       tbl << cols.map { |c|
+        next unless cols.any? {|h| h.downcase == c.downcase}
         col = c.downcase
         val = process[col]
         if col == 'session'
@@ -413,7 +417,7 @@ class ProcessList < Array
         else
           val
         end
-      }.compact
+      }
     }
 
     tbl

--- a/lib/rex/post/meterpreter/extensions/stdapi/sys/process.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/sys/process.rb
@@ -390,31 +390,31 @@ class ProcessList < Array
       return Rex::Text::Table.new(opts)
     end
 
-    cols = [ "PID", "PPID", "Name", "Arch", "Session", "User", "Path" ]
-    cols.delete_if do |c|
-      none? {|r| r.has_key?(c.downcase)} ||
-      all? {|r| r[c.downcase].nil?}
+    column_headers = [ "PID", "PPID", "Name", "Arch", "Session", "User", "Path" ]
+    column_headers.delete_if do |h|
+      none? { |process| process.has_key?(h.downcase) } ||
+      all? { |process| process[h.downcase].nil? }
     end
 
     opts = {
       'Header' => 'Process List',
       'Indent' => 1,
-      'Columns' => cols
+      'Columns' => column_headers
     }.merge(opts)
 
     tbl = Rex::Text::Table.new(opts)
-    each { |process|
-      tbl << cols.map { |c|
-        next unless cols.any? {|h| h.downcase == c.downcase}
-        col = c.downcase
+    each do |process|
+      tbl << column_headers.map do |header|
+        col = header.downcase
+        next unless process.keys.any? { |process_header| process_header == col }
         val = process[col]
         if col == 'session'
           val == 0xFFFFFFFF ? '' : val.to_s
         else
           val
         end
-      }
-    }
+      end
+    end
 
     tbl
   end


### PR DESCRIPTION
Mettle can run in all sorts of environments where some colums of a
process table will be nil. The existing implementation compacts
rows going into the table while providing filtering for the colum
contents only by checking the output of the first row in the proc
table.

Check column filters against all rows to ensure proper table init.
Check columns going into table for match against header.
Do not compact nil values in the table rows - some things, like
kthreads/workers dont have a path while other PIDs will.


Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Get a mettle session in current stable Linux system
- [x] Run ps, get:
```
meterpreter > ps
[-] Error running command ps: Rex::RuntimeError Invalid number of columns
```
- [x] Add this PR to framework
- [x] **Verify** That under the above conditions, a nice table is printed
- [x] **Verify** That other session types still work as intended

