### PR TITLE
Fix AMT scanner for mangled HTML (no </p>)

### DIFF
--- a/modules/auxiliary/scanner/http/intel_amt_digest_bypass.rb
+++ b/modules/auxiliary/scanner/http/intel_amt_digest_bypass.rb
@@ -76,7 +76,7 @@ class MetasploitModule < Msf::Auxiliary
       proof = res.body.to_s
       proof_hash = nil
 
-      info_keys = res.body.scan(/<td class=r1><p>([^\<]+)<\/p>/).map{|x| x.first.to_s.gsub("&#x2F;", "/") }
+      info_keys = res.body.scan(/<td class=r1><p>([^\<]+)(?:<\/p>)?/).map{|x| x.first.to_s.gsub("&#x2F;", "/") }
       if info_keys.length > 0
         proof_hash = {}
         proof = ""
@@ -106,7 +106,7 @@ class MetasploitModule < Msf::Auxiliary
         :proto => 'tcp',
         :name  => "Intel AMT Digest Authentication Bypass",
         :refs  => self.references,
-        :proof => proof
+        :info => proof
       })
 
     rescue ::Timeout::Error, ::Errno::EPIPE


### PR DESCRIPTION
This expands the Intel Advanced Management Technology (AMT) module to deal with the HTML output from more ME firmware versions. Not all present well-formed HTML, leading to missing data.

Props to @busterb for helping. Unfixed output below.

```
msf auxiliary(intel_amt_digest_bypass) > run

[*] [redacted]:16992 - Found an Intel AMT endpoint: Intel(R) Active Management Technology [redacted]
[+] [redacted]:16992 - Vulnerable to CVE-2017-5869 nil
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(intel_amt_digest_bypass) > 
```

#8353