### PR TITLE
Make active window tracking in keyscan subsystem discretionary

### DIFF
--- a/lib/rex/post/meterpreter/extensions/stdapi/ui.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/ui.rb
@@ -214,6 +214,15 @@ class UI < Rex::Post::UI
   end
 
   #
+  # Start the keyboard sniffer with active window tracking
+  #
+  def keyscan_start_aw
+    request  = Packet.create_request('stdapi_ui_start_keyscan_actwin')
+    response = client.send_request(request)
+    return true
+  end
+
+  #
   # Stop the keyboard sniffer
   #
   def keyscan_stop

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/ui.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/ui.rb
@@ -41,6 +41,7 @@ class Console::CommandDispatcher::Stdapi::Ui
       "idletime"      => [ "stdapi_ui_get_idle_time" ],
       "keyscan_dump"  => [ "stdapi_ui_get_keys_utf8" ],
       "keyscan_start" => [ "stdapi_ui_start_keyscan" ],
+      "keyscan_start_aw" => [ "stdapi_ui_start_keyscan_actwin"],
       "keyscan_stop"  => [ "stdapi_ui_stop_keyscan" ],
       "screenshot"    => [ "stdapi_ui_desktop_screenshot" ],
       "setdesktop"    => [ "stdapi_ui_desktop_set" ],

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/ui.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/ui.rb
@@ -27,6 +27,7 @@ class Console::CommandDispatcher::Stdapi::Ui
       "idletime"      => "Returns the number of seconds the remote user has been idle",
       "keyscan_dump"  => "Dump the keystroke buffer",
       "keyscan_start" => "Start capturing keystrokes",
+      "keyscan_start_aw" => "Start capturing keystrokes with active window enumeration",
       "keyscan_stop"  => "Stop capturing keystrokes",
       "screenshot"    => "Grab a screenshot of the interactive desktop",
       "setdesktop"    => "Change the meterpreters current desktop",
@@ -296,6 +297,15 @@ class Console::CommandDispatcher::Stdapi::Ui
   def cmd_keyscan_start(*args)
     print_line("Starting the keystroke sniffer...")
     client.ui.keyscan_start
+    return true
+  end
+
+  #
+  # Start the keyboard sniffer with active window enumeration
+  #
+  def cmd_keyscan_start_aw(*args)
+    print_line("Starting the keystroke sniffer...")
+    client.ui.keyscan_start_aw
     return true
   end
 


### PR DESCRIPTION
These are the framework changes needed to test https://github.com/rapid7/metasploit-payloads/pull/206 
The combined changes break out the active window tracking in the keyscan subsystem into a new, separate function, `keyscan_start_aw`

This will resolve https://github.com/rapid7/metasploit-framework/issues/8359

## Verification

List the steps needed to make sure this thing works

- [ ] Build the code from [https://github.com/rapid7/metasploit-payloads/pull/206](https://github.com/rapid7/metasploit-payloads/pull/206)
- [ ] Throw the resulting `ext_server_stdapi.xXX.dll` into data/meterpreter/
- [ ] Get a Meterpreter session going on your target and interact with it 
- [ ] `keyscan_start_aw`
- [ ] For testing purposes, make sure you get the warning about your local stdapi DLL file being used 
- [ ] Type a lot of stuff on the target
- [ ] Back on your host, run `keyscan_dump`
- [ ] **Verify** that it returns the stuff you typed
- [ ] **Verify** that it correctly logs the application that was in focus and the time the typing started
- [ ] Return to the target, switch applications, and type more stuff
- [ ] run `keyscan_dump` on your host again
- [ ] **Verify** that it returns what you typed and notated the new application in focus
- [ ] Start over, except this time use `keyscan_start`
- [ ] **Verify** that it records the keystrokes you typed and _doesn't_ log anything regarding the window in focus 
