### PR TITLE
Move php_preamble before $ipaddr and $port

### DIFF
--- a/modules/payloads/singles/php/reverse_php.rb
+++ b/modules/payloads/singles/php/reverse_php.rb
@@ -63,9 +63,9 @@ module MetasploitModule
     end
 
     shell=<<-END_OF_PHP_CODE
+    #{php_preamble(disabled_varname: "$dis")}
     $ipaddr='#{ipaddr}';
     $port=#{port};
-    #{php_preamble(disabled_varname: "$dis")}
 
     if(!function_exists('#{exec_funcname}')){
       function #{exec_funcname}($c){


### PR DESCRIPTION
`php_preamble` contains a `<?php` tag now, so we need to move it to the top.

Thanks to **CuChulaind** and **\0** on IRC for noting this.

#7469, https://github.com/rapid7/metasploit-framework/commit/8800372e462e3513942396f25c3686d12d9067a8