### PR TITLE
Adapted the authentitcity_token scheme

### DIFF
--- a/lib/metasploit/framework/login_scanner/gitlab.rb
+++ b/lib/metasploit/framework/login_scanner/gitlab.rb
@@ -61,6 +61,10 @@ module Metasploit
             local_session_cookie = res.get_cookies.scan(/(_gitlab_session=[A-Za-z0-9%-]+)/).flatten[0]
             auth_token = res.body.scan(/<input name="authenticity_token" type="hidden" value="(.*?)"/).flatten[0]
 
+            # New versions of GitLab use an alternative scheme
+            # Try it, if the old one was not successfull
+            auth_token = res.body.scan(/<input type="hidden" name="authenticity_token" value="(.*?)"/).flatten[0] unless auth_token
+
             fail RuntimeError, 'Unable to get Session Cookie' unless local_session_cookie
             fail RuntimeError, 'Unable to get Authentication Token' unless auth_token
 


### PR DESCRIPTION
In new versions of GitLab, the attributes of the authenticity-token have a new order. The old expression which extracts the token will fail.

```
[*] GitLab v7 login page
[-] Auxiliary failed: RuntimeError Unable to get Authentication Token
[-] Call stack:
[-]   /usr/share/metasploit-framework/lib/metasploit/framework/login_scanner/gitlab.rb:65:in `attempt_login'
[-]   /usr/share/metasploit-framework/lib/metasploit/framework/login_scanner/base.rb:231:in `block in scan!'
[-]   /usr/share/metasploit-framework/lib/metasploit/framework/login_scanner/base.rb:179:in `block in each_credential'
[-]   /usr/share/metasploit-framework/lib/metasploit/framework/credential_collection.rb:121:in `each'
[-]   /usr/share/metasploit-framework/lib/metasploit/framework/login_scanner/base.rb:141:in `each_credential'
[-]   /usr/share/metasploit-framework/lib/metasploit/framework/login_scanner/base.rb:205:in `scan!'
[-]   /usr/share/metasploit-framework/modules/auxiliary/scanner/http/gitlab_login.rb:77:in `run_host'
[-]   /usr/share/metasploit-framework/lib/msf/core/auxiliary/scanner.rb:135:in `block (2 levels) in run'
[-]   /usr/share/metasploit-framework/lib/msf/core/thread_manager.rb:100:in `block in spawn'
[*] Auxiliary module execution completed
```
The new token in the "Sign in" form looks like this:
```
<input type="hidden" name="authenticity_token" value="IDtuf5XBI/...==">
```
## Verification

Tested on GitLab Community Edition 9.2.5
- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/http/gitlab_login`
- [x] `set HttpUsername test`
- [x] `set HttpPassword test`
- [x] `set RHOSTS 192.168.10.1`
- [x] `set RPORT 443`
- [x] `set SSL true`
- [x] `run`

```
[*] GitLab v7 login page
[-] 192.168.10.1:443 - LOGIN FAILED: test:test (Incorrect)
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```


