### PR TITLE
Avoid cachedump module crash on ruby 2.4

### DIFF
--- a/modules/post/windows/gather/cachedump.rb
+++ b/modules/post/windows/gather/cachedump.rb
@@ -253,7 +253,7 @@ class MetasploitModule < Msf::Post
 
   def decrypt_hash_vista(edata, nlkm, ch)
     aes = OpenSSL::Cipher.new('aes-128-cbc')
-    aes.key = nlkm[16...-1]
+    aes.key = nlkm[16...32]
     aes.padding = 0
     aes.decrypt
     aes.iv = ch


### PR DESCRIPTION
See #8525.

OpenSSL stops accepting too long keys since [r55146](https://bugs.ruby-lang.org/projects/ruby-trunk/repository/revisions/55146).
Since aes-128-cbc is used, the key should be 16 bytes long. 

This PR has been tested on:
 * Windows XP (was not affected by the issue)
 * Windows Vista
 * Windows 7
 * Windows 10

## Verification

- Get a meterpreter session with System privileges on a Windows machine (> Vista) having joined a domain
- `run post/windows/gather/cachedump`
- The module should output the cached hashes of domain users (and not crash anymore)

