### PR TITLE
Downgrade ruby pg to a non-whiny version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,7 +30,7 @@ PATH
       packetfu
       patch_finder
       pcaprub
-      pg
+      pg (= 0.20.0)
       railties
       rb-readline
       recog
@@ -233,7 +233,7 @@ GEM
       pcaprub
     patch_finder (1.0.2)
     pcaprub (0.12.4)
-    pg (0.21.0)
+    pg (0.20.0)
     pg_array_parser (0.0.9)
     postgres_ext (3.0.0)
       activerecord (>= 4.0.0)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -83,7 +83,9 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'packetfu'
   # For sniffer and raw socket modules
   spec.add_runtime_dependency 'pcaprub'
-  # Needed for module caching in Mdm::ModuleDetails
+  # Used by the Metasploit data model, etc.
+  # bound to 0.20 for Activerecord 4.2.8 deprecation warnings:
+  # https://github.com/ged/ruby-pg/commit/c90ac644e861857ae75638eb6954b1cb49617090
   spec.add_runtime_dependency 'pg', '0.20.0'
   # Run initializers for metasploit-concern, metasploit-credential, metasploit_data_models Rails::Engines
   spec.add_runtime_dependency 'railties'

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -84,7 +84,7 @@ Gem::Specification.new do |spec|
   # For sniffer and raw socket modules
   spec.add_runtime_dependency 'pcaprub'
   # Needed for module caching in Mdm::ModuleDetails
-  spec.add_runtime_dependency 'pg'
+  spec.add_runtime_dependency 'pg', '0.20.0'
   # Run initializers for metasploit-concern, metasploit-credential, metasploit_data_models Rails::Engines
   spec.add_runtime_dependency 'railties'
   # required for OS fingerprinting


### PR DESCRIPTION
The latest version of ruby-pg appears to only enable a complaint message about deprecated constants. These are in activerecord, which we don't control (well, we could update to 5.1, but...), so for now avoid the whining and use 0.20 instead.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] **Verify** that pg doesn't complain in startup
