### PR TITLE
enhance module info to be on par with pro RPC interface

### DIFF
--- a/lib/msf/core/rpc/v10/rpc_module.rb
+++ b/lib/msf/core/rpc/v10/rpc_module.rb
@@ -101,23 +101,24 @@ class RPC_Module < RPC_Base
     m = _find_module(mtype,mname)
     res = {}
 
+    res['type'] = m.type
     res['name'] = m.name
-    res['description'] = m.description
+    res['fullname'] = m.fullname
+    res['rank'] = m.rank.to_i
+    res['description'] = Rex::Text.compress(m.description)
     res['license'] = m.license
     res['filepath'] = m.file_path
-    res['rank'] = m.rank.to_i
+    res['arch'] = m.arch.map { |x| x.to_s }
+    res['platform'] = m.platform.platforms.map { |x| x.to_s }
+    res['authors'] = m.author.map { |a| a.to_s }
+    res['privileged'] = m.privileged?
 
     res['references'] = []
     m.references.each do |r|
       res['references'] << [r.ctx_id, r.ctx_val]
     end
 
-    res['authors'] = []
-    m.each_author do |a|
-      res['authors'] << a.to_s
-    end
-
-    if(m.type == "exploit")
+    if m.type == 'exploit'
       res['targets'] = {}
       m.targets.each_index do |i|
         res['targets'][i] = m.targets[i].name
@@ -126,18 +127,40 @@ class RPC_Module < RPC_Base
       if (m.default_target)
         res['default_target'] = m.default_target
       end
+
+      # Some modules are a combination, which means they are actually aggressive
+      res['stance'] = m.stance.to_s.index('aggressive') ? 'aggressive' : 'passive'
     end
 
-    if(m.type == "auxiliary")
+    if m.type == 'auxiliary' || m.type == 'post'
       res['actions'] = {}
       m.actions.each_index do |i|
         res['actions'][i] = m.actions[i].name
       end
 
-      if (m.default_action)
+      if m.default_action
         res['default_action'] = m.default_action
       end
+
+      if m.type == 'auxiliary'
+        res['stance'] = m.passive? ? 'passive' : 'aggressive'
+      end
     end
+
+    opts = {}
+    m.options.each_key do |k|
+      o = m.options[k]
+      opts[k] = {
+        'type'     => o.type,
+        'required' => o.required,
+        'advanced' => o.advanced,
+        'desc'     => o.desc
+      }
+
+      opts[k]['default'] = o.default unless o.default.nil?
+      opts[k]['enums'] = o.enums if o.enums.length > 1
+    end
+    res['options'] = opts
 
     res
   end
@@ -386,7 +409,7 @@ class RPC_Module < RPC_Base
 
       # How to warn?
       #if exeopts[:fellback]
-      #	$stderr.puts(OutError + "Warning: Falling back to default template: #{exeopts[:fellback]}")
+      #  $stderr.puts(OutError + "Warning: Falling back to default template: #{exeopts[:fellback]}")
       #end
 
       { "encoded" => output.to_s }


### PR DESCRIPTION
This enhances the module metadata that the Metasploit RPC interface emits to be a superset of what the Metasploit Pro interface emits. This is the first part in a series of enhancements to support a consistent RPC interface between the two, the next step being adding proper module search functionality at the framework level.

I did leave out the 'evasion' parameter since it was not clear what its purpose was.

## Note

This does not remove or rename any pre-existing information in the results hash, only adds it. A goal is to ensure that any existing automation built on these interfaces continues working without any changes.

## Verification

List the steps needed to make sure this thing works

- [ ] Make an RPC client connection and get module info.
- [ ] Verify that querying different module types works and returns all of the available metadata.

Prior to this change:
```
[*] The RPC client is available in variable 'rpc'
[*] Starting IRB shell...
>> rpc.login('blah', 'blah')
=> true
>> pp rpc.call('module.info', "exploit", "linux/local/docker_daemon_privilege_escalation")
{"name"=>"Docker Daemon Privilege Escalation",
 "description"=>
  "\n" +
  "        This module obtains root privileges from any host account with access to the\n" +
  "        Docker daemon. Usually this includes accounts in the `docker` group.\n" +
  "      ",
 "license"=>"Metasploit Framework License (BSD)",
 "filepath"=>
  "/Users/bcook/rapid7/metasploit-framework/modules/exploits/linux/local/docker_daemon_privilege_escalation.rb",
 "rank"=>600,
 "references"=>[],
 "authors"=>["forzoni"],
 "targets"=>{0=>"Automatic"},
 "default_target"=>0}
```

After this change:
```
[*] The RPC client is available in variable 'rpc'
[*] Starting IRB shell...
>> rpc.login('blah', 'blah')
=> true
>> pp rpc.call('module.info', "exploit", "linux/local/docker_daemon_privilege_escalation")
{"type"=>"exploit",
 "name"=>"Docker Daemon Privilege Escalation",
 "fullname"=>"exploit/linux/local/docker_daemon_privilege_escalation",
 "rank"=>600,
 "description"=>
  "This module obtains root privileges from any host account with access to the Docker daemon. Usually this includes accounts in the `docker` group.",
 "license"=>"Metasploit Framework License (BSD)",
 "filepath"=>
  "/Users/bcook/rapid7/metasploit-framework/modules/exploits/linux/local/docker_daemon_privilege_escalation.rb",
 "arch"=>["x86", "x64", "armle", "mipsle", "mipsbe"],
 "platform"=>["Msf::Module::Platform::Linux"],
 "authors"=>["forzoni"],
 "privileged"=>false,
 "references"=>[],
 "targets"=>{0=>"Automatic"},
 "default_target"=>0,
 "stance"=>"aggressive",
 "options"=>
  {"WORKSPACE"=>
    {"type"=>"string",
     "required"=>false,
     "advanced"=>true,
     "desc"=>"Specify the workspace for this module"},
   "VERBOSE"=>
    {"type"=>"bool",
     "required"=>false,
     "advanced"=>true,
     "desc"=>"Enable detailed status messages",
     "default"=>false},
   "WfsDelay"=>
    {"type"=>"integer",
     "required"=>false,
     "advanced"=>true,
     "desc"=>"Additional delay when waiting for a session",
     "default"=>0},
   "EnableContextEncoding"=>
    {"type"=>"bool",
     "required"=>false,
     "advanced"=>true,
     "desc"=>"Use transient context when encoding payloads",
     "default"=>false},
   "ContextInformationFile"=>
    {"type"=>"path",
     "required"=>false,
     "advanced"=>true,
     "desc"=>"The information file that contains context information"},
   "DisablePayloadHandler"=>
    {"type"=>"bool",
     "required"=>false,
     "advanced"=>true,
     "desc"=>"Disable the handler code for the selected payload",
     "default"=>false},
   "SESSION"=>
    {"type"=>"integer",
     "required"=>true,
     "advanced"=>false,
     "desc"=>"The session to run this module on."},
   "EXE::EICAR"=>
    {"type"=>"bool",
     "required"=>false,
     "advanced"=>true,
     "desc"=>"Generate an EICAR file instead of regular payload exe"},
   "EXE::Custom"=>
    {"type"=>"path",
     "required"=>false,
     "advanced"=>true,
     "desc"=>
      "Use custom exe instead of automatically generating a payload exe"},
   "EXE::Path"=>
    {"type"=>"path",
     "required"=>false,
     "advanced"=>true,
     "desc"=>"The directory in which to look for the executable template"},
   "EXE::Template"=>
    {"type"=>"path",
     "required"=>false,
     "advanced"=>true,
     "desc"=>"The executable template file name."},
   "EXE::Inject"=>
    {"type"=>"bool",
     "required"=>false,
     "advanced"=>true,
     "desc"=>"Set to preserve the original EXE function"},
   "EXE::OldMethod"=>
    {"type"=>"bool",
     "required"=>false,
     "advanced"=>true,
     "desc"=>"Set to use the substitution EXE generation method."},
   "EXE::FallBack"=>
    {"type"=>"bool",
     "required"=>false,
     "advanced"=>true,
     "desc"=>"Use the default template in case the specified one is missing"},
   "MSI::EICAR"=>
    {"type"=>"bool",
     "required"=>false,
     "advanced"=>true,
     "desc"=>"Generate an EICAR file instead of regular payload msi"},
   "MSI::Custom"=>
    {"type"=>"path",
     "required"=>false,
     "advanced"=>true,
     "desc"=>
      "Use custom msi instead of automatically generating a payload msi"},
   "MSI::Path"=>
    {"type"=>"path",
     "required"=>false,
     "advanced"=>true,
     "desc"=>"The directory in which to look for the msi template"},
   "MSI::Template"=>
    {"type"=>"path",
     "required"=>false,
     "advanced"=>true,
     "desc"=>"The msi template file name"},
   "MSI::UAC"=>
    {"type"=>"bool",
     "required"=>false,
     "advanced"=>true,
     "desc"=>
      "Create an MSI with a UAC prompt (elevation to SYSTEM if accepted)"},
   "FileDropperDelay"=>
    {"type"=>"integer",
     "required"=>false,
     "advanced"=>true,
     "desc"=>"Delay in seconds before attempting file cleanup"},
   "WritableDir"=>
    {"type"=>"string",
     "required"=>true,
     "advanced"=>true,
     "desc"=>"A directory where we can write files",
     "default"=>"/tmp"}}}
```
