### PR TITLE
fix rex arguments parser to handle adjacent flags, update accordingly

### DIFF
--- a/lib/rex/parser/arguments.rb
+++ b/lib/rex/parser/arguments.rb
@@ -43,20 +43,20 @@ module Rex
             next
           end
 
-          if arg[0] == '-'
-            cfs = arg[0..2]
+          if arg.length > 1 && arg[0] == '-' && arg[1] != '-'
+            arg.split('').each do |flag|
+              fmt.each_pair do |fmtspec, val|
+                next if fmtspec != "-#{flag}"
 
-            fmt.each_pair do |fmtspec, val|
-              next if fmtspec != cfs
+                param = nil
 
-              param = nil
+                if val[0]
+                  param = args[idx + 1]
+                  skip_next = true
+                end
 
-              if val[0]
-                param = args[idx + 1]
-                skip_next = true
+                yield fmtspec, idx, param
               end
-
-              yield fmtspec, idx, param
             end
           else
             yield nil, idx, arg


### PR DESCRIPTION
This is something I overlooked with the pkill PR, I fixed the argument parser to support adjacent arguments in the gnu style. Rather than treating `-ab` as argument 'ab', it treats it as two arguments 'a' and 'b'.

This also implements proper help support to pgrep, and implements a number of usual flags.