### PR TITLE
Session logging bugfix and small improvement

### DIFF
--- a/lib/msf/core/session.rb
+++ b/lib/msf/core/session.rb
@@ -214,8 +214,9 @@ module Session
 
     dstr  = sprintf("%.4d%.2d%.2d", dt.year, dt.mon, dt.mday)
     rhost = session_host.gsub(':', '_')
+    sname = name.to_s.gsub(/\W+/,'_')
 
-    "#{dstr}_#{rhost}_#{type}"
+    "#{dstr}_#{sname}_#{rhost}_#{type}"
   end
 
   #

--- a/lib/rex/logging/sinks/timestamp_flatfile.rb
+++ b/lib/rex/logging/sinks/timestamp_flatfile.rb
@@ -13,7 +13,7 @@ class TimestampFlatfile < Flatfile
 
   def log(sev, src, level, msg, from) # :nodoc:
     return unless msg.present?
-    msg = msg.chop.gsub(/\x1b\[[0-9;]*[mG]/,'').gsub(/[\x01-\x02]/, " ")
+    msg = msg.gsub(/\x1b\[[0-9;]*[mG]/,'').gsub(/[\x01-\x02]/, ' ').gsub(/\s+$/,'')
     fd.write("[#{get_current_timestamp}] #{msg}\n")
     fd.flush
   end


### PR DESCRIPTION
This fixes #8597 by only stripping newline characters from the string instead of stripping the last character no matter what (which cuts short user commands).

It also adds the session name (usually the number) to the file, to prevent multiple sessions to the same IP writing to the same file and making things confusing.

## Verification

- [x] Start `msfconsole`
- [x] Enable session logging `setg SessionLogging true`
- [x] Spawn a meterpreter
- [x] The session log file is created, and the commands in there do not get cut off
- [x] The filename contains the session ID
- [x] Spawn a second meterpreter on the same host
- [x] A second session file gets generated, instead of output from both sessions being written to the same file

