### PR TITLE
bump metasploit_data_models, speedup workspace deletion

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -197,7 +197,7 @@ GEM
       activesupport (~> 4.2.6)
       railties (~> 4.2.6)
     metasploit-payloads (1.2.33)
-    metasploit_data_models (2.0.14)
+    metasploit_data_models (2.0.15)
       activerecord (~> 4.2.6)
       activesupport (~> 4.2.6)
       arel-helpers


### PR DESCRIPTION
This fixes an issue where a workspace can take a long time to delete even when there are few hosts or services. Rather than instantiating a ruby object for each object deleted, it lets the database do more of the work. This is a special problem when there are lots of event or session objects in the database.

This follows from https://github.com/rapid7/metasploit_data_models/pull/169

## Verification

- [x] start with a database that is full of activity - lots of sessions and module runs
- [x] run `./msfconsole'
- [x] run `workspace -D` it should delete in a few seconds