### PR TITLE
RSS feed plugin

### DIFF
--- a/plugins/rssfeed.rb
+++ b/plugins/rssfeed.rb
@@ -1,8 +1,3 @@
-#
-# $Id$
-# $Revision$
-#
-
 module Msf
 
 ###

--- a/plugins/rssfeed.rb
+++ b/plugins/rssfeed.rb
@@ -1,0 +1,123 @@
+#
+# $Id$
+# $Revision$
+#
+
+module Msf
+
+###
+#
+# This class hooks all session events and puts it into an RSS feed
+#
+###
+
+class Plugin::EventRSS < Msf::Plugin
+
+  attr_accessor :items, :queue, :queue_thread
+
+  include Msf::SessionEvent
+
+  def add_event(event)
+    self.queue.push(event)
+  end
+
+  def generate_feed(newitem)
+    items.unshift(newitem)
+    feed = RSS::Maker.make("atom") do |maker|
+      maker.channel.author = "msfconsole"
+      maker.channel.updated = Time.new.to_s
+      maker.channel.about = "https://metasploit.com"
+      maker.channel.title = "msfconsole rss feed"
+      
+      items.each do |rssitem|
+        maker.items.new_item do |item|
+          item.link = rssitem[:link]
+          item.title = rssitem[:title]
+          item.updated = rssitem[:date]
+          item.summary = rssitem[:content]
+        end
+      end
+    end
+    File.open("feed.rss", 'w') {|f| f.write(feed) }
+  end
+
+  def create_session_item(session, status)
+    status = "created" ? select(nil, nil, nil, 25) : ""
+    title = "#{session.type} session - #{session.sid} #{status}."
+    content = ""
+    session.workspace ? content << "Workspace:\t#{session.workspace}\n" : ""
+    content << "Session Information: #{session.info}"
+    add_event({title: title, date: Time.now.to_s, link: "https://metasploit.com", content: content})
+  end
+
+  def on_session_open(session)
+    create_session_item(session, "created")
+  end
+
+  def on_session_close(session, reason='')
+    create_session_item(session, "closed")
+  end
+
+  def on_session_fail(reason='')
+  end
+
+  def on_plugin_load
+    add_event({title: "RSS Plugin Loaded", date: Time.now.to_s, link: "https://metasploit.com/", content: "N/A"})
+  end
+
+  def on_plugin_unload
+    generate_feed({title: "RSS Plugin Unloaded", date: Time.now.to_s, link: "https:/metasploit.com/", content: "N/A"})
+  end
+
+  def start_event_queue
+    self.queue_thread = Thread.new do
+      begin
+      while(true)
+        while(event = self.queue.shift)
+          generate_feed(event)
+        end
+        select(nil, nil, nil, 0.25)
+      end
+      rescue ::Exception => e
+        print_status("RSS plugin: fatal error #{e} #{e.backtrace}")
+      end
+    end
+  end
+
+  def stop_event_queue
+    self.queue_thread.kill if self.queue_thread
+    self.queue_thread = nil
+    self.queue = []
+  end
+
+
+  def initialize(framework, opts)
+    require 'rss'
+    super
+
+    @items = []
+    self.queue = []
+    self.framework.events.add_session_subscriber(self)
+    start_event_queue
+
+    self.on_plugin_load
+  end
+
+  def cleanup
+    self.on_plugin_unload
+    self.framework.events.remove_session_subscriber(self)
+    stop_event_queue
+  end
+
+  def name
+    "rss"
+  end
+
+  def desc
+    "Create an RSS feed of events"
+  end
+
+end
+end
+
+


### PR DESCRIPTION
## Loading

```
msf exploit(web_delivery) > load rss
[*] Successfully loaded plugin: rss
```

## Serving the file
```
root at debian in ~/metasploit-framework on master [!?]
$ ruby -run -ehttpd . -p 80
[2017-06-25 18:42:51] INFO  WEBrick 1.3.1
[2017-06-25 18:42:51] INFO  ruby 2.4.1 (2017-03-22) [x86_64-linux]
[2017-06-25 18:42:51] INFO  WEBrick::HTTPServer#start: pid=11590 port=80
54.152.136.21 - - [25/Jun/2017:18:45:20 UTC] "GET /feed.rss HTTP/1.1" 200 920
- -> /feed.rss
```
But can obviously be done with Apache, or Nginx or python

The RSS feed is loaded in the current working directory as `feed.rss`. Making this modifiable by the user is v2, as well as serving out the RSS feed using Metasploit's HTTP server.

But it can be used for cool stuff like IFTTT:

<img width="534" alt="screen shot 2017-06-25 at 1 38 48 pm" src="https://user-images.githubusercontent.com/679319/27518769-047bb22e-59ad-11e7-931e-3adae67dc296.png">

<img width="510" alt="screen shot 2017-06-25 at 1 40 23 pm" src="https://user-images.githubusercontent.com/679319/27518771-0f7a992e-59ad-11e7-8254-fa0fb6648cf7.png">

![2017-06-25 13 46 08](https://user-images.githubusercontent.com/679319/27519229-d0215d28-59b4-11e7-96da-da6b41afe1f1.png)
