### PR TITLE
Remove uses of multi-char args for meterpreter commands

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/android.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/android.rb
@@ -512,7 +512,7 @@ class Console::CommandDispatcher::Android
       '-h' => [ false, 'Help Banner' ],
       '-d' => [ true, 'Destination number' ],
       '-t' => [ true, 'SMS body text' ],
-      '-dr' => [ false, 'Wait for delivery report' ]
+      '-r' => [ false, 'Wait for delivery report' ]
     )
 
     dest = ''
@@ -530,7 +530,7 @@ class Console::CommandDispatcher::Android
         dest = val
       when '-t'
         body = val
-      when '-dr'
+      when '-r'
         dr = true
       end
     end

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
@@ -604,25 +604,24 @@ class Console::CommandDispatcher::Core
   # Arguments for transport switching
   #
   @@transport_opts = Rex::Parser::Arguments.new(
-    '-t'  => [true, "Transport type: #{Rex::Post::Meterpreter::ClientCore::VALID_TRANSPORTS.keys.join(', ')}"],
-    '-l'  => [true, 'LHOST parameter (for reverse transports)'],
-    '-p'  => [true, 'LPORT parameter'],
-    '-i'  => [true, 'Specify transport by index (currently supported: remove)'],
-    '-u'  => [true, 'Custom URI for HTTP/S transports (used when removing transports)'],
-    '-lu' => [true, 'Local URI for HTTP/S transports (used when adding/changing transports with a custom LURI)'],
-    '-ua' => [true, 'User agent for HTTP/S transports (optional)'],
-    '-ph' => [true, 'Proxy host for HTTP/S transports (optional)'],
-    '-pp' => [true, 'Proxy port for HTTP/S transports (optional)'],
-    '-pu' => [true, 'Proxy username for HTTP/S transports (optional)'],
-    '-ps' => [true, 'Proxy password for HTTP/S transports (optional)'],
-    '-pt' => [true, 'Proxy type for HTTP/S transports (optional: http, socks; default: http)'],
-    '-c'  => [true, 'SSL certificate path for https transport verification (optional)'],
-    '-to' => [true, 'Comms timeout (seconds) (default: same as current session)'],
-    '-ex' => [true, 'Expiration timout (seconds) (default: same as current session)'],
-    '-rt' => [true, 'Retry total time (seconds) (default: same as current session)'],
-    '-rw' => [true, 'Retry wait time (seconds) (default: same as current session)'],
-    '-v'  => [false, 'Show the verbose format of the transport list'],
-    '-h'  => [false, 'Help menu'])
+    '-t' => [true, "Transport type: #{Rex::Post::Meterpreter::ClientCore::VALID_TRANSPORTS.keys.join(', ')}"],
+    '-l' => [true, 'LHOST parameter (for reverse transports)'],
+    '-p' => [true, 'LPORT parameter'],
+    '-i' => [true, 'Specify transport by index (currently supported: remove)'],
+    '-u' => [true, 'Local URI for HTTP/S transports (used when adding/changing transports with a custom LURI)'],
+    '-c' => [true, 'SSL certificate path for https transport verification (optional)'],
+    '-A' => [true, 'User agent for HTTP/S transports (optional)'],
+    '-H' => [true, 'Proxy host for HTTP/S transports (optional)'],
+    '-P' => [true, 'Proxy port for HTTP/S transports (optional)'],
+    '-U' => [true, 'Proxy username for HTTP/S transports (optional)'],
+    '-N' => [true, 'Proxy password for HTTP/S transports (optional)'],
+    '-B' => [true, 'Proxy type for HTTP/S transports (optional: http, socks; default: http)'],
+    '-C' => [true, 'Comms timeout (seconds) (default: same as current session)'],
+    '-X' => [true, 'Expiration timout (seconds) (default: same as current session)'],
+    '-T' => [true, 'Retry total time (seconds) (default: same as current session)'],
+    '-W' => [true, 'Retry wait time (seconds) (default: same as current session)'],
+    '-v' => [false, 'Show the verbose format of the transport list'],
+    '-h' => [false, 'Help menu'])
 
   #
   # Display help for transport management.
@@ -666,7 +665,6 @@ class Console::CommandDispatcher::Core
       :transport    => nil,
       :lhost        => nil,
       :lport        => nil,
-      :uri          => nil,
       :ua           => nil,
       :proxy_host   => nil,
       :proxy_port   => nil,
@@ -687,31 +685,29 @@ class Console::CommandDispatcher::Core
       case opt
       when '-c'
         opts[:cert] = val
-      when '-u'
-        opts[:uri] = val
       when '-i'
         transport_index = val.to_i
-      when '-lu'
+      when '-u'
         opts[:luri] = val
-      when '-ph'
+      when '-H'
         opts[:proxy_host] = val
-      when '-pp'
+      when '-P'
         opts[:proxy_port] = val.to_i
-      when '-pt'
+      when '-B'
         opts[:proxy_type] = val
-      when '-pu'
+      when '-U'
         opts[:proxy_user] = val
-      when '-ps'
+      when '-N'
         opts[:proxy_pass] = val
-      when '-ua'
+      when '-A'
         opts[:ua] = val
-      when '-to'
+      when '-C'
         opts[:comm_timeout] = val.to_i if val
-      when '-ex'
+      when '-X'
         opts[:session_exp] = val.to_i if val
-      when '-rt'
+      when '-T'
         opts[:retry_total] = val.to_i if val
-      when '-rw'
+      when '-W'
         opts[:retry_wait] = val.to_i if val
       when '-p'
         opts[:lport] = val.to_i if val

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/kiwi.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/kiwi.rb
@@ -90,10 +90,10 @@ class Console::CommandDispatcher::Kiwi
     '-h'  => [false, 'Help banner'],
     '-u'  => [true,  'User name of the password to change.'],
     '-s'  => [true,  'Server to perform the action on (eg. Domain Controller).'],
-    '-op' => [true,  'The known existing/old password (do not use with -oh).'],
-    '-oh' => [true,  'The known existing/old hash (do not use with -op).'],
-    '-np' => [true,  'The new password to set for the account (do not use with -nh).'],
-    '-nh' => [true,  'The new hash to set for the account (do not use with -np).']
+    '-p' => [true,  'The known existing/old password (do not use with -n).'],
+    '-n' => [true,  'The known existing/old hash (do not use with -p).'],
+    '-P' => [true,  'The new password to set for the account (do not use with -N).'],
+    '-N' => [true,  'The new hash to set for the account (do not use with -P).']
   )
 
   def cmd_password_change_usage
@@ -116,35 +116,35 @@ class Console::CommandDispatcher::Kiwi
         opts[:user] = val
       when '-s'
         opts[:server] = val
-      when '-op'
+      when '-p'
         opts[:old_pass] = val
-      when '-oh'
+      when '-n'
         opts[:old_hash] = val
-      when '-np'
+      when '-P'
         opts[:new_pass] = val
-      when '-nh'
+      when '-N'
         opts[:new_hash] = val
       end
     }
 
     valid = true
     if opts[:old_pass] && opts[:old_hash]
-      print_error('Options -op and -oh cannot be used together.')
+      print_error('Options -p and -n cannot be used together.')
       valid = false
     end
 
     if opts[:new_pass] && opts[:new_hash]
-      print_error('Options -np and -nh cannot be used together.')
+      print_error('Options -P and -N cannot be used together.')
       valid = false
     end
 
     unless opts[:old_pass] || opts[:old_hash]
-      print_error('At least one of -op and -oh must be specified.')
+      print_error('At least one of -p and -n must be specified.')
       valid = false
     end
 
     unless opts[:new_pass] || opts[:new_hash]
-      print_error('At least one of -np and -nh must be specified.')
+      print_error('At least one of -P and -N must be specified.')
       valid = false
     end
 


### PR DESCRIPTION
Fixes #8617 (and more).

This PR contains changes that remove all multi-char command options for Meterpreter. Recent changes to the argument parser requires that all commands be single character, and so this change makes sure that Meterpreter commands work within that constraint.

## Verification
- [x] Create a Windows Meterpreter session.
- [x] Make sure the `transport` command works with all the given options.
- [x] `use kiwi`
- [x] Make sure the `password_change` command works with all the given options.
- [x] Create an Android Meterpreter session.
- [x] Make sure the `send_sms` command works with all the given options.