### PR TITLE
Handle ArgumentError when previous gets args

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -687,7 +687,7 @@ module Msf
           #
           # Command to take to the previously active module
           #
-          def cmd_previous()
+          def cmd_previous(*args)
             if @previous_module
               self.cmd_use(@previous_module.fullname)
             else


### PR DESCRIPTION
Dumb patch. Noticed while testing #8455.

```
msf post(vmdk_mount) > previous blahhhhhhhhhh
[-] Error while running command previous: wrong number of arguments (given 1, expected 0)

Call stack:
/Users/wvu/metasploit-framework/lib/msf/ui/console/command_dispatcher/modules.rb:690:in `cmd_previous'
/Users/wvu/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:430:in `run_command'
/Users/wvu/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:392:in `block in run_single'
/Users/wvu/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:386:in `each'
/Users/wvu/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:386:in `run_single'
/Users/wvu/metasploit-framework/lib/rex/ui/text/shell.rb:205:in `run'
/Users/wvu/metasploit-framework/lib/metasploit/framework/command/console.rb:48:in `start'
/Users/wvu/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'
./msfconsole:48:in `<main>'
msf post(vmdk_mount) > 
```