### PR TITLE
Fix output of MSV creds dumping in Kiwi

### DIFF
--- a/lib/rex/post/meterpreter/extensions/kiwi/kiwi.rb
+++ b/lib/rex/post/meterpreter/extensions/kiwi/kiwi.rb
@@ -308,11 +308,18 @@ class Kiwi < Extension
       # did we find something?
       next if line.blank?
 
-      # the next 4 lines should be interesting
       msv = {}
-      4.times do
-        k, v = read_value(lines.shift)
-        msv[k.strip] = v if k
+      # loop until we find a line that doesn't start with
+      # an asterisk, as this is the next credential set
+      loop do
+        line = lines.shift
+        if line.strip.start_with?('*')
+          k, v = read_value(line)
+          msv[k.strip] = v if k
+        else
+          lines.unshift(line)
+          break
+        end
       end
 
       if msv.length > 0

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/kiwi.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/kiwi.rb
@@ -567,18 +567,44 @@ protected
     output = ""
 
     accounts.keys.each do |k|
-
       next if accounts[k].length == 0
+
+      # Keep track of the columns that we were given, in
+      # the order we are given them, while removing duplicates
+      columns = []
+      existing = Set.new
+      accounts[k].each do |acct|
+        acct.keys.each do |k|
+          unless existing.include?(k)
+            columns << k
+            existing.add(k)
+          end
+        end
+      end
 
       table = Rex::Text::Table.new(
         'Header'    => "#{k} credentials",
         'Indent'    => 0,
         'SortIndex' => 0,
-        'Columns'   => accounts[k][0].keys
+        'Columns'   => columns
       )
 
       accounts[k].each do |acct|
-        table << acct.values
+        values = []
+        # Iterate through the given columns and match the values up
+        # correctly based on the index of the column header.
+        columns.each do |c|
+          col_idx = acct.keys.index(c)
+          # If the column exists, we'll use the value that is associated
+          # with the column based on its index
+          if col_idx
+            values << acct.values[col_idx]
+          else
+            # Otherwise, just add a blank value
+            values << ''
+          end
+        end
+        table << values
       end
 
       output << table.to_s + "\n"


### PR DESCRIPTION
The data being pulled out of the MSV credential dump was not being rendered propertly because it was assumed that all accounts would provide the same set of hashes/details for each entry found. However, this was not the case. Some have NTLM & SHA1, others have LM & NTLM,
some have DPAPI when others don't.

This code generates tables based on the values found, and renders those values in the appropriate columns, and if the values don't exist for a given account, the column is left blank.

Fixes #8620

## Verification

- [ ] Create a meterpreter session running as SYSTEM on a machine with various accounts on it (preferably a DC).
- [ ] Run `creds_all` or `creds_msv`.
- [ ] Note that the output contains all the appropriate values in the MSV dump, with the values in the correct columns.
