### PR TITLE
Updated client_request.rb to ensure that the host header is formatted

### DIFF
--- a/lib/rex/proto/http/client_request.rb
+++ b/lib/rex/proto/http/client_request.rb
@@ -173,7 +173,10 @@ class ClientRequest
     req << set_version
 
     # Set a default Host header if one wasn't passed in
-    unless opts['headers'] && opts['headers'].keys.map { |x| x.downcase }.include?('host')
+    if opts['headers'] && opts['headers'].keys.map(&:downcase).include?('host')
+      host = opts['headers'].keys.each { |k| break opts['headers'][k] if k =~ /host/i }
+      req << set_formatted_header('Host', host)
+    else
       req << set_host_header
     end
 


### PR DESCRIPTION
When using post/multi/escalate/aws_create_iam_user I was getting errors from AWS since the Host header was not being sent properly.  This change ensures that set_formatted_header is called if a Host header is passed in with the request.
