### PR TITLE
bump rex-socket, add client cert, mac address matching support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -304,7 +304,7 @@ GEM
       metasm
       rex-core
       rex-text
-    rex-socket (0.1.6)
+    rex-socket (0.1.8)
       rex-core
     rex-sslscan (0.1.4)
       rex-socket


### PR DESCRIPTION
This rolls up https://github.com/rapid7/rex-socket/pull/6 and https://github.com/rapid7/rex-socket/pull/5 and bumps the version of rex-socket in framework. Nothing uses these bits _yet_ but will soon.