### PR TITLE
Improve compatibility with Rubinius (alternate Ruby implementation)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,7 +182,7 @@ GEM
     metasploit-aggregator (0.2.1)
       grpc
       rex-arch
-    metasploit-concern (2.0.4)
+    metasploit-concern (2.0.5)
       activemodel (~> 4.2.6)
       activesupport (~> 4.2.6)
       railties (~> 4.2.6)


### PR DESCRIPTION
This just manually bumps metasploit-concern to include https://github.com/rapid7/metasploit-concern/pull/28. The refinement was added to Metasploit originally to preserve deprecated functionality from Ruby on Rails, but this is is no longer needed.

Removing this provides a path for running Metasploit on the higher-performance https://rubinius.com/ virtual machine in the future.