### PR TITLE
Pretty-print fail_with for aux and post modules

### DIFF
--- a/lib/msf/base/simple/auxiliary.rb
+++ b/lib/msf/base/simple/auxiliary.rb
@@ -138,6 +138,9 @@ protected
       mod.setup
       mod.framework.events.on_module_run(mod)
       mod.run
+    rescue Msf::Auxiliary::Complete
+      mod.cleanup
+      return
     rescue Msf::Auxiliary::Failed => e
       mod.error = e
       mod.print_error("Auxiliary aborted due to failure: #{e.message}")

--- a/lib/msf/base/simple/auxiliary.rb
+++ b/lib/msf/base/simple/auxiliary.rb
@@ -138,6 +138,11 @@ protected
       mod.setup
       mod.framework.events.on_module_run(mod)
       mod.run
+    rescue Msf::Auxiliary::Failed => e
+      mod.error = e
+      mod.print_error("Auxiliary aborted due to failure: #{e.message}")
+      mod.cleanup
+      return
     rescue ::Timeout::Error => e
       mod.error = e
       mod.print_error("Auxiliary triggered a timeout exception")

--- a/lib/msf/base/simple/post.rb
+++ b/lib/msf/base/simple/post.rb
@@ -108,6 +108,11 @@ protected
         mod.cleanup
         return
       end
+    rescue Msf::Post::Failed => e
+      mod.error = e
+      mod.print_error("Post aborted due to failure: #{e.message}")
+      mod.cleanup
+      return
     rescue ::Timeout::Error => e
       mod.error = e
       mod.print_error("Post triggered a timeout exception")

--- a/lib/msf/base/simple/post.rb
+++ b/lib/msf/base/simple/post.rb
@@ -108,6 +108,9 @@ protected
         mod.cleanup
         return
       end
+    rescue Msf::Post::Complete
+      mod.cleanup
+      return
     rescue Msf::Post::Failed => e
       mod.error = e
       mod.print_error("Post aborted due to failure: #{e.message}")

--- a/lib/msf/core/auxiliary.rb
+++ b/lib/msf/core/auxiliary.rb
@@ -15,6 +15,9 @@ class Auxiliary < Msf::Module
 
   require 'msf/core/auxiliary/mixins'
 
+  class Failed < RuntimeError
+  end
+
   include HasActions
 
   #
@@ -150,6 +153,11 @@ class Auxiliary < Msf::Module
       end
       true
     }
+  end
+
+  # Override Msf::Module#fail_with for Msf::Simple::Auxiliary::job_run_proc
+  def fail_with(reason, msg = nil)
+    raise Msf::Auxiliary::Failed, "#{reason.to_s}: #{msg}"
   end
 
   attr_accessor :queue

--- a/lib/msf/core/auxiliary.rb
+++ b/lib/msf/core/auxiliary.rb
@@ -15,6 +15,9 @@ class Auxiliary < Msf::Module
 
   require 'msf/core/auxiliary/mixins'
 
+  class Complete < RuntimeError
+  end
+
   class Failed < RuntimeError
   end
 

--- a/lib/msf/core/post.rb
+++ b/lib/msf/core/post.rb
@@ -19,6 +19,9 @@ class Msf::Post < Msf::Module
   require 'msf/core/post/android'
   require 'msf/core/post/hardware'
 
+  class Failed < RuntimeError
+  end
+
   include Msf::PostMixin
 
   def setup
@@ -66,4 +69,10 @@ class Msf::Post < Msf::Module
       nil
     end
   end
+
+  # Override Msf::Module#fail_with for Msf::Simple::Post::job_run_proc
+  def fail_with(reason, msg = nil)
+    raise Msf::Post::Failed, "#{reason.to_s}: #{msg}"
+  end
+
 end

--- a/lib/msf/core/post.rb
+++ b/lib/msf/core/post.rb
@@ -19,6 +19,9 @@ class Msf::Post < Msf::Module
   require 'msf/core/post/android'
   require 'msf/core/post/hardware'
 
+  class Complete < RuntimeError
+  end
+
   class Failed < RuntimeError
   end
 


### PR DESCRIPTION
This patch used to be bigger, but it ultimately wasn't worth the code duplication or rearrangement.

- [x] Test `fail_with` for aux modules
- [x] Test `fail_with` for post modules
- [x] Compare to `fail_with` for exploits

**tl;dr No more stack trace for `fail_with` in aux and post.**

#5200