### PR TITLE
secure-auth wrong wording (negated meaning)

### DIFF
--- a/modules/auxiliary/admin/mysql/mysql_enum.rb
+++ b/modules/auxiliary/admin/mysql/mysql_enum.rb
@@ -82,7 +82,7 @@ class MetasploitModule < Msf::Auxiliary
 
     print_status("\tOld Password Hashing Algorithm #{vparm["old_passwords"]}")
     print_status("\tLoading of local files: #{vparm["local_infile"]}")
-    print_status("\tLogins with old Pre-4.1 Passwords: #{vparm["secure_auth"]}")
+    print_status("\tDeny logins with old Pre-4.1 Passwords: #{vparm["secure_auth"]}")
     print_status("\tSkipping of GRANT TABLE: #{vparm["skip_grant_tables"]}") if vparm["skip_grant_tables"]
     print_status("\tAllow Use of symlinks for Database Files: #{vparm["have_symlink"]}")
     print_status("\tAllow Table Merge: #{vparm["have_merge_engine"]}")


### PR DESCRIPTION
According to the mysql docs the "secure-auth" variable means the opposite:
https://dev.mysql.com/doc/refman/5.5/en/mysql-command-options.html#option_mysql_secure-auth
[..]This prevents connections except for servers that use the newer password format[..]

OFF     ->      insecure    (legacy auth is allowed)
ON      ->      secure       (legacy auth is not allowed)