### PR TITLE
pass logger conditionally to common search function

### DIFF
--- a/lib/msf/core/framework.rb
+++ b/lib/msf/core/framework.rb
@@ -229,20 +229,16 @@ class Framework
     }
   end
 
-  def search(match, verbose: false)
+  def search(match, logger: nil)
     # Check if the database is usable
     use_db = true
     if self.db
       if !(self.db.migrated && self.db.modules_cached)
-        if verbose
-          print_warning("Module database cache not built yet, using slow search")
-        end
+        logger.print_warning("Module database cache not built yet, using slow search") if logger
         use_db = false
       end
     else
-      if verbose
-        print_warning("Database not connected, using slow search")
-      end
+      logger.print_warning("Database not connected, using slow search") if logger
       use_db = false
     end
 

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -400,7 +400,7 @@ module Msf
 
             # Display the table of matches
             tbl = generate_module_table("Matching Modules", search_term)
-            framework.search(match, verbose: true).each do |m|
+            framework.search(match, logger: self).each do |m|
               tbl << [
                 m.fullname,
                 m.disclosure_date.nil? ? "" : m.disclosure_date.strftime("%Y-%m-%d"),


### PR DESCRIPTION
This fixes #8645 by passing the local logable instance into the common search method in framework.

## Verification

- [x] Start `msfconsole`
- [x] **Verify** that 'search blah' works with _and_ without the database