### PR TITLE
HTTP Proxy - class, mixin, and module

### DIFF
--- a/lib/msf/core/exploit/http/proxy.rb
+++ b/lib/msf/core/exploit/http/proxy.rb
@@ -1,0 +1,139 @@
+# -*- coding: binary -*-
+require 'rex/service_manager'
+require 'rex/proto/http/proxy'
+require 'msf/core/exploit/http/server'
+
+###
+# This module provides an HTTP proxy server
+# By default the proxy functions in MITM mode
+# forwarding all requests along the switchboard.
+# Settings RHOST, RPORT, and VHOST will restrict
+# the proxy connections to those settings making
+# it an "http-connect" proxy.
+##
+
+module Msf
+module Exploit::Remote::HttpServer::Proxy
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::HttpServer
+
+  def initialize(info = {})
+    super(
+      'Actions'     =>
+        [
+          [ 'WebServer' ]
+        ],
+      'PassiveActions' =>
+        [
+          'WebServer'
+        ],
+      'DefaultAction'  => 'WebServer'
+    )
+
+    # We handle these differently depending on how we use the proxy
+    deregister_options('RHOSTS', 'RPORT')
+    register_options(
+      [
+        OptString.new('VHOST', [ true, "HTTP virtual host for proxy requests", "*" ]),
+        OptString.new('RHOST', [ false, "Set this to direct all traffic to a specific host"]),
+        OptInt.new('RPORT', [ false, "Set this in conjunction with RHOST to direct all traffic to specific port"]),
+        OptString.new('URIPATH', [ true,  "The base URI at which the proxy will begin to forward requests", '/']),
+      ], Exploit::Remote::HttpServer::Proxy
+    )
+    register_advanced_options(
+      [
+        OptBool.new('HTTP::proxy::rewrite_proxy_headers', [true, 'Rewrite proxy-specific headers from client', true]),
+        OptInt.new('HTTP::proxy::redirect_limit', [false, 'Maximum number of redirects for proxied client request', 0]),
+      ], Exploit::Remote::HttpServer::Proxy
+    )
+  end
+
+  def start_service(opts = {})
+
+    check_dependencies
+
+    comm = datastore['ListenerComm']
+    if (comm.to_s == "local")
+      comm = ::Rex::Socket::Comm::Local
+    else
+      comm = nil
+    end
+
+    # Default the server host and port to what is required by the mixin.
+    opts = {
+      'ServerHost' => datastore['SRVHOST'],
+      'ServerPort' => datastore['SRVPORT'],
+      'Comm'       => comm
+    }.update(opts)
+
+    # Start a new HTTP server service.
+    self.service = Rex::ServiceManager.start(
+      Rex::Proto::Http::Proxy,
+      opts['ServerPort'].to_i,
+      opts['ServerHost'],
+      datastore['SSL'],
+      {
+        'Msf'        => framework,
+        'MsfExploit' => self,
+      },
+      opts['Comm'],
+      datastore['SSLCert'],
+      datastore['Proxies'],
+      datastore['HTTP::proxy::rewrite_proxy_headers'],
+      datastore['RHOST'],
+      datastore['RPORT']
+    )
+
+    # Add request and response hooks
+    service.req_handler = Proc.new { |cli,request|
+      proxy_action_request(cli,request)
+    }
+
+    service.res_handler = Proc.new { |cli,response|
+      proxy_action_response(cli,response)
+    }
+    proto = (datastore["SSL"] ? "https" : "http")
+
+    print_status("Using URL: #{proto}://#{opts['ServerHost']}:#{opts['ServerPort']}/")
+
+    if (opts['ServerHost'] == '0.0.0.0')
+      print_status(" Local IP: #{proto}://#{Rex::Socket.source_address('1.2.3.4')}:#{opts['ServerPort']}/")
+    end
+
+  end
+
+  # Overload this to work wtih initial request
+  def proxy_action_request(cli, request)
+    nil # MITM or logging can go here
+  end
+
+  # Overload this to work with response
+  def proxy_action_response(cli, response)
+    nil
+  end
+
+  # Rewrite referer for HTTP request as needed
+  def set_referer(cli,request)
+    request.headers.select {|k,v| k =~ /referer/i}.each do |key, ref|
+      substr = ref.scan(/http.*\:\/\/(.*?)\//).flatten.first
+      newsub = datastore['VHOST'] unless datastore['VHOST'].strip == '*'
+      newsub ||= datastore['RHOST']
+      # Only pass non-default ports
+      if datastore['RPORT'] != 0
+        case datastore['RPORT']
+        when 443
+          newsub << ":#{datastore['RPORT']}" unless ref.match(/https/i)
+        when 80
+          newsub << ":#{datastore['RPORT']}" unless ref.match(/http\:/i)
+        else
+          newsub << ":#{datastore['RPORT']}" if newsub
+        end
+        headers[key] = ref.sub(substr,newsub)
+      end
+    end
+  end
+
+end
+
+end

--- a/lib/msf/core/exploit/http/proxy.rb
+++ b/lib/msf/core/exploit/http/proxy.rb
@@ -93,6 +93,11 @@ module Exploit::Remote::HttpServer::Proxy
     service.res_handler = Proc.new { |cli,response|
       proxy_action_response(cli,response)
     }
+
+    service.connect_permit_cb = Proc.new { |saddr, sport, daddr, dport|
+      permit_connect?(saddr, sport, daddr, dport)
+    }
+
     proto = (datastore["SSL"] ? "https" : "http")
 
     print_status("Using URL: #{proto}://#{opts['ServerHost']}:#{opts['ServerPort']}/")
@@ -111,6 +116,11 @@ module Exploit::Remote::HttpServer::Proxy
   # Overload this to work with response
   def proxy_action_response(cli, response)
     nil
+  end
+
+  # Overload this to define CONNECT permissions
+  def permit_connect?(saddr, sport, daddr, dport)
+    true
   end
 
   # Rewrite referer for HTTP request as needed

--- a/lib/rex/proto/http/proxy.rb
+++ b/lib/rex/proto/http/proxy.rb
@@ -525,7 +525,9 @@ protected
       # self.ssl_version,
       self.proxies
       # TODO: Add user/pass for HTTP auth
-    ) unless cli.session and cli.session.conn? and cli.session.send(:hostname).strip == opts['Vhost'].strip
+    ) unless cli.session and cli.session.conn? and (
+      opts['Vhost'].nil? or cli.session.send(:hostname).strip == opts['Vhost'].strip
+    )
 
     # Configure the session
     cli.session.set_config(
@@ -549,11 +551,26 @@ protected
     return response
   end
 
+  #
+  # Internal stub for checking if HTTP CONNECT is permitted
+  #
+  # @param saddr [Object] source IP
+  # @param sport [Object] source port
+  # @param daddr [Object] destination IP
+  # @param dport [Object] destination port
+  #
+  # @return [TrueClass,FalseClass] permission status
   def permit_connect?(saddr, sport, daddr, dport)
     return false if self.connect_permit_cb.nil?
     self.connect_permit_cb.call(saddr, sport, daddr, dport)
   end
 
+  #
+  # Create an SSL context for a specific CN
+  #
+  # @param host [String] Common Name for which to create context
+  #
+  # @return [OpenSSL::SSL::SSLContext] resulting SSL context
   def generate_ssl_context(host)
     key, cert, chain = Rex::Socket::Ssl::CertProvider.ssl_generate_certificate(host)
     ctx = OpenSSL::SSL::SSLContext.new()

--- a/lib/rex/proto/http/proxy.rb
+++ b/lib/rex/proto/http/proxy.rb
@@ -572,7 +572,7 @@ protected
   #
   # @return [OpenSSL::SSL::SSLContext] resulting SSL context
   def generate_ssl_context(host)
-    key, cert, chain = Rex::Socket::Ssl::CertProvider.ssl_generate_certificate(host)
+    key, cert, chain = Rex::Socket::Ssl::CertProvider.ssl_generate_certificate({cert_vars:{cn: host}})
     ctx = OpenSSL::SSL::SSLContext.new()
     ctx.key = key
     ctx.cert = cert

--- a/lib/rex/proto/http/proxy.rb
+++ b/lib/rex/proto/http/proxy.rb
@@ -2,6 +2,7 @@
 require 'rex/socket'
 require 'rex/proto/http'
 require 'rex/proto/http/handler'
+require 'rex/proto/proxy/relay'
 
 module Rex
 module Proto
@@ -69,61 +70,7 @@ module ProxyClient
 end
 
 module ConnectProxyRelay
-  #
-  # Relay data coming in from relay_sock to this socket.
-  #
-  def relay( relay_client, relay_sock )
-    @relay_client = relay_client
-    @relay_sock   = relay_sock
-    # start the relay thread (modified from Rex::IO::StreamAbstraction)
-    @relay_thread = Rex::ThreadFactory.spawn("HTTPConnectProxyRelay", false) do
-      loop do
-        closed = false
-        buf    = nil
-
-        begin
-          s = Rex::ThreadSafe.select( [ @relay_sock ], nil, nil, 0.2 )
-          if( s == nil || s[0] == nil )
-            next
-          end
-        rescue
-          closed = true
-        end
-
-        if( closed == false )
-          begin
-            buf = @relay_sock.sysread( 32768 )
-            closed = true if( buf == nil )
-          rescue
-            closed = true
-          end
-        end
-
-        if( closed == false )
-          total_sent   = 0
-          total_length = buf.length
-          while( total_sent < total_length )
-            begin
-              data = buf[total_sent, buf.length]
-              sent = self.write( data )
-              if( sent > 0 )
-                total_sent += sent
-              end
-            rescue
-              closed = true
-              break
-            end
-          end
-        end
-
-        if( closed )
-          @relay_client.stop
-          ::Thread.exit
-        end
-
-      end
-    end
-  end
+  include Rex::Proto::Proxy::Relay
 end
 
 ###
@@ -523,7 +470,7 @@ protected
       end
       cli.keepalive = true
       cli.extend(ConnectProxyRelay)
-      cli.relay(cli, cli.session)
+      cli.relay(cli, cli.session, "HTTPConnectProxyRelay")
       resp = Rex::Proto::Http::Response.new(204)
       resp.auto_cl = false
       return resp

--- a/lib/rex/proto/http/proxy.rb
+++ b/lib/rex/proto/http/proxy.rb
@@ -1,0 +1,577 @@
+# -*- coding: binary -*-
+require 'rex/socket'
+require 'rex/proto/http'
+require 'rex/proto/http/handler'
+
+module Rex
+module Proto
+module Http
+
+###
+#
+# Runtime extension of the HTTP clients that connect to the server.
+#
+###
+module ProxyClient
+
+  #
+  # Initialize a new request instance.
+  #
+  def init_cli(server,resp_proc = nil)
+    self.request   = Request.new
+    self.server    = server
+    self.keepalive = false
+    self.session   = nil
+  end
+
+  #
+  # Resets the parsing state.
+  #
+  def reset_cli
+    self.request.reset
+  end
+
+  #
+  # Transmits a response and adds the appropriate headers.
+  #
+  def send_response(response)
+    # Set the connection to close or keep-alive depending on what the client
+    # can support.
+    response['Connection'] = (keepalive) ? 'Keep-Alive' : 'Close'
+
+    # Send it off.
+    put(response.to_s)
+    close_session unless keepalive
+  end
+
+  def close_session
+    self.session.close if self.session
+    self.session = nil
+  end
+
+  #
+  # The current request context.
+  #
+  attr_accessor :request
+  #
+  # Boolean that indicates whether or not the connection supports keep-alive.
+  #
+  attr_accessor :keepalive
+  #
+  # A reference to the server the client is associated with.
+  #
+  attr_accessor :server
+  #
+  # Reusable session for client
+  #
+  attr_accessor :session
+
+end
+
+module ConnectProxyRelay
+  #
+  # Relay data coming in from relay_sock to this socket.
+  #
+  def relay( relay_client, relay_sock )
+    @relay_client = relay_client
+    @relay_sock   = relay_sock
+    # start the relay thread (modified from Rex::IO::StreamAbstraction)
+    @relay_thread = Rex::ThreadFactory.spawn("HTTPConnectProxyRelay", false) do
+      loop do
+        closed = false
+        buf    = nil
+
+        begin
+          s = Rex::ThreadSafe.select( [ @relay_sock ], nil, nil, 0.2 )
+          if( s == nil || s[0] == nil )
+            next
+          end
+        rescue
+          closed = true
+        end
+
+        if( closed == false )
+          begin
+            buf = @relay_sock.sysread( 32768 )
+            closed = true if( buf == nil )
+          rescue
+            closed = true
+          end
+        end
+
+        if( closed == false )
+          total_sent   = 0
+          total_length = buf.length
+          while( total_sent < total_length )
+            begin
+              data = buf[total_sent, buf.length]
+              sent = self.write( data )
+              if( sent > 0 )
+                total_sent += sent
+              end
+            rescue
+              closed = true
+              break
+            end
+          end
+        end
+
+        if( closed )
+          @relay_client.stop
+          ::Thread.exit
+        end
+
+      end
+    end
+  end
+end
+
+###
+#
+# Acts as an HTTP server, processing requests and dispatching them to
+# registered procs.  Some of this server was modeled after webrick.
+#
+###
+class Proxy
+
+  include Proto
+
+  #
+  # Initializes an HTTP proxy as listening on the provided port and
+  # hostname.
+  #
+  def initialize(listen_port = 80, listen_host = '0.0.0.0', ssl = false, context = {},
+    comm = nil, ssl_cert = nil, proxies = nil, rewrite_proxy_headers = true,
+    connect_host = nil, connect_port = nil
+  )
+    self.listen_host            = listen_host
+    self.listen_port            = listen_port
+    self.ssl                    = ssl
+    self.context                = context
+    self.comm                   = comm
+    self.ssl_cert               = ssl_cert
+    self.proxies                = proxies
+    self.rewrite_proxy_headers  = rewrite_proxy_headers
+    self.connect_host           = connect_host
+    self.connect_port           = connect_port
+
+    self.clients                = []
+    self.listener               = nil
+    self.req_handler            = nil
+    self.res_handler            = nil
+    self.redirect_limit         = 0
+    self.request_timeout        = 30
+    # If the keep-alive session is pushing to the client, monitor and forward the traffic
+    # self.monitor_thread         = Rex::ThreadFactory.spawn("HTTP Proxy Monitor Thread", true) { monitor_clients }
+  end
+
+  #
+  # Returns the hardcore alias for the HTTP proxy service
+  #
+  def self.hardcore_alias(*args)
+    "#{args[0]}#{args[1]}"
+  end
+
+  #
+  # HTTP server.
+  #
+  def alias
+    super || "HTTP Proxy"
+  end
+
+  #
+  # Listens on the defined port and host and starts monitoring for clients.
+  #
+  def start
+
+    self.listener = Rex::Socket::TcpServer.create(
+      'LocalHost' => self.listen_host,
+      'LocalPort' => self.listen_port,
+      'Context'   => self.context,
+      'SSL'       => self.ssl,
+      'SSLCert'   => self.ssl_cert,
+      'Comm'      => self.comm
+    )
+
+    # Register callbacks
+    self.listener.on_client_connect_proc = Proc.new { |cli|
+      on_client_connect(cli)
+    }
+    self.listener.on_client_data_proc = Proc.new { |cli|
+      on_client_data(cli)
+    }
+
+    self.listener.start
+  end
+
+  #
+  # Terminates the monitor thread and turns off the listener.
+  #
+  def stop
+    self.clients.map {|cli| cli.close_session}
+    self.listener.stop
+    self.listener.close
+  end
+
+  #
+  # Waits for the HTTP service to terminate
+  #
+  def wait
+    self.listener.wait if self.listener
+  end
+
+  #
+  # Closes the supplied client, if valid.
+  #
+  def close_client(cli)
+    cli.close_session
+    listener.close_client(cli)
+    self.clients.select! {|x| x != cli}
+  end
+
+  ##
+  # Convenience methods for headers
+  ##
+
+  #
+  # Adds Server headers if they dont exist
+  #
+  def add_headers(resp,headers)
+    headers.each do |k,v|
+      resp[k] = v unless resp[k]
+    end
+  end
+
+  #
+  # Replaces server headers only if exist
+  #
+  def sub_headers(resp,headers)
+    headers.each do |k,v|
+      resp[k] = v if resp[k]
+    end
+  end
+
+  #
+  # Puts in all headers, whether existing or not
+  #
+  def force_headers(resp,headers)
+    add_response_headers(resp,headers)
+    sub_response_headers(resp,headers)
+  end
+
+  #
+  # Sends a 404 error to the client for a given request.
+  #
+  def send_e404(cli, request)
+    resp = Response::E404.new
+
+    resp['Content-Type'] = 'text/html'
+
+    resp.body =
+      "<html><head>" +
+      "<title>404 Not Found</title>" +
+      "</head><body>" +
+      "<h1>Not found</h1>" +
+      "The requested URL #{html_escape(request.resource)} was not found on this server.<p><hr>" +
+      "</body></html>"
+
+    # Send the response to the client like what
+    cli.send_response(resp)
+  end
+
+  # Rewrite proxy elements of request to target request
+  # Determine whether or not to use SSL for outbound
+  def proxy_header_rewrite(request)
+    return unless request.uri.match(/^http/i)
+
+    # Determine if we need to use SSL
+    request.headers['SSL'] = [443, 8443].any? {|e| request.headers['Host'] == e }
+    # Rewrite URI HTTP request to headers and proper URI
+    proxy_keys = request.headers.select {|key,val| key.match(/^proxy/i)}
+    # Remove the proxy header info
+    request.headers - proxy_keys
+    # Rewrite the proxy specific options to our direct headers
+    proxy_keys.each do |k,v|
+      request.headers[k.sub(/^proxy-/i,'')] = v
+    end
+    normalize_request_target(request)
+  end
+
+  def normalize_request_target(request)
+    # Extract host port and URI, map as appropriate, account for emtpy
+    target = request.uri[/\/([\w\d\.:]+)/, 1]
+
+    host,port = target.split(':')
+    targ_uri = request.uri[/\/[\w\d\.]+(\/.*)/,1]
+    request.uri = targ_uri || '/'
+
+    # Check for DNS hostname
+    if host.match(/\w+\.\w+/)
+      request.headers['Vhost'] = host
+      host = Rex::Socket.addr_itoa(
+       Rex::Socket.gethostbyname( host )[3].unpack( 'N' ).first
+      )
+      request.headers['Host'] = port.nil? ? host : "#{host}:#{port}"
+    else
+      # Try an IPv6 configuration if host is not an IPv4 addr
+      if !Rex::Socket.is_ipv4?(host)
+        host = request.headers['Host'].reverse.split(':',2).last.reverse
+        if !Rex::socket.is_ipv6?(host)
+          raise ::Rex::ConnectionError('Cannot determine request target')
+        end
+      end
+      # If we're here our host is valid, write the headers
+      request.headers['Host'] = port.nil? ? host : "#{host}:#{port}"
+    end
+  end
+
+  # Determine if redirect is valid
+  def valid_redirect?(response)
+    return ([301,302].any? {response.code} and response.headers['Location'])
+  end
+
+  attr_accessor :listen_port, :listen_host, :context, :ssl, :comm, :ssl_cert
+  attr_accessor :listener, :proxies, :clients, :req_handler, :res_handler
+  attr_accessor :redirect_limit, :rewrite_proxy_headers, :request_timeout
+  attr_accessor :connect_host, :connect_port
+
+protected
+
+  #
+  # Watches client connections for data, forwards back to client
+  #
+  def monitor_clients
+    self.clients.each do |client|
+      if client.session && (resp = client.session.read_response(2))
+        client.send_response(resp)
+      end
+    end if
+    Rex::ThreadSafe.sleep(2)
+  end
+
+
+  #
+  # Extends new clients with the ServerClient module and initializes them.
+  #
+  def on_client_connect(cli)
+    cli.extend(ProxyClient)
+
+    cli.init_cli(self)
+    self.clients << cli
+  end
+
+  #
+  # Processes data coming in from a client.
+  #
+  def on_client_data(cli)
+    begin
+      # Handle CONNECT data
+      if cli.is_a?(ConnectProxyRelay)
+        while cli.has_read_data?(0.05)
+          data = cli.read(65535)
+          cli.session.put(data)
+        end
+        return
+      end
+      # Get our headers
+      data = cli.read(65535)
+
+      raise ::EOFError if (not data || data.empty?)
+
+      case cli.request.parse(data)
+        when Packet::ParseCode::Completed
+          dispatch_request(cli, cli.request)
+          cli.reset_cli
+
+        when Packet::ParseCode::Partial
+          # The proxy needs the whole request
+          content_len = cli.request.headers['Content-Length'] || 0
+          loop do
+            line = cli.readline
+            if line =~ /^Content-Length:\s+(\d+)\s*$/
+              content_len = $1.to_i
+            end
+
+            if line.strip.empty?
+              # Read and parse the content length into our request
+              if content_len >= 0
+                cli.request.parse(cli.read(content_len))
+              end
+
+              break
+            else
+              cli.request.parse(line)
+            end
+          end
+          cli.reset_cli
+
+        when Packet::ParseCode::Error
+          close_client(cli)
+      end
+    rescue EOFError
+      if (cli.request.completed?)
+        dispatch_request(cli, cli.request)
+
+        cli.reset_cli
+      end
+
+      close_client(cli)
+      self.clients.delete(cli)
+    end
+  end
+
+  #
+  # Dispatches the supplied request for a given connection.
+  # Provides hooks for actions on data, returns if action closed client
+  #
+  def dispatch_request(cli, request)
+
+    # Is the client requesting keep-alive?
+    %w{Proxy-Connection Connection}.each do |key|
+      if request[key] and request[key].downcase == 'Keep-Alive'.downcase
+        cli.keepalive = true
+      end
+    end
+
+    # Proxy header rewrite
+    if self.rewrite_proxy_headers
+      proxy_header_rewrite(request)
+    end
+
+    # Do something with the request before we pass it on
+    if self.req_handler
+      self.req_handler.call(cli, request)
+      return if cli.closed?
+    end
+
+    # Get server response to client request
+    begin
+      response = proxy_request(cli,request.dup)
+      # Follow redirects if allowed
+      if valid_redirect?(response) and self.redirect_limit > 0
+        count_redir = self.redirect_limit
+        while valid_redirect?(response) and count_redir > 0 do
+
+          re_request = request.dup
+          re_request.headers
+
+          re_request.uri = response.headers['Location']
+          # Set cookie as needed
+          if response.headers['Set-Cookie']
+            re_request.headers['Cookie'] = response.headers['Set-Cookie']
+          end
+          normalize_request_target(request)
+
+          if response.headers['Location'].scan(/^\w+/).first.downcase == 'https'
+            re_request.headers['SSL'] = true
+          end
+
+          response = proxy_request(cli,re_request)
+          count_redir -= 1
+        end
+      end
+
+    rescue ::Rex::ConnectionError
+      send_e404(cli)
+      close_client(cli)
+      return
+    end
+
+    # Do something with the response before returning it
+    if self.res_handler
+      self.res_handler.call(cli,response)
+      return if cli.closed?
+    end
+
+    cli.send_response(response)
+
+    # If keep-alive isn't enabled for this client, close the connection
+    if (cli.keepalive == false)
+      close_client(cli)
+    end
+  end
+
+  #
+  # Send request to server, return response
+  # Attempt to use existing session
+  # Final header modifications on rewrite
+  #
+  def proxy_request(cli, request, timeout = nil)
+
+    timeout ||= self.request_timeout
+    opts = request.headers
+    host,port = opts['Host'].split(':')
+    host = self.connect_host if self.connect_host
+    port = self.connect_port if self.connect_port
+    if port.nil? or port == 0
+      port = (opts['SSL'] || self.ssl) ? 443 : 80
+    end
+
+    # Address TCP tunnels over the proxy
+    if request.method == 'CONNECT'
+      begin
+        cli.session = Rex::Socket::Tcp.create(
+          'PeerHost' => host,
+          'PeerPort' => port,
+          'Context'  => self.context,
+          'Proxies'  => self.proxies
+        )
+      rescue => e
+        cli.close_session
+        send_e404(cli)
+        raise ::Rex::ConnectionError(e)
+      end
+      cli.keepalive = true
+      cli.extend(ConnectProxyRelay)
+      cli.relay(cli, cli.session)
+      resp = Rex::Proto::Http::Response.new(204)
+      resp.auto_cl = false
+      return resp
+    end
+    # Remove encoding mechanisms we dont support
+    if opts['Accept-Encoding']
+      acc_enc = opts['Accept-Encoding'].split(',').select {|x| x =~ /gzip|deflate|none/i}.join(',')
+      opts['Accept-Encoding'] = acc_enc
+    end
+
+    ssl = opts.delete('SSL')
+    ssl ||= self.ssl
+    # Build client session unless we have a live one
+    cli.session =  Rex::Proto::Http::Client.new(
+      host,
+      port,
+      self.context,
+      # TODO: allow proxying of SSL -> Plain Text and reverse
+      ssl,
+      # self.ssl_version,
+      self.proxies
+      # TODO: Add user/pass for HTTP auth
+    ) unless cli.session and cli.session.conn? and cli.session.send(:hostname).strip == opts['Vhost'].strip
+
+    # Configure the session
+    cli.session.set_config(
+      'vhost'             => opts['Vhost'],
+      'agent'             => opts['UserAgent'],
+      'transfer_chunked'  => opts['Transfer-Encoding'],
+      'read_max_data'     => (1024*1024)
+    )
+    # Dont send confusing IPs to reverse proxies at the edge
+    opts['Host'] = opts['Vhost'] if opts['Vhost'] and !opts['Vhost'].strip.empty?
+    # Send request to the server, get response
+    # Persist request if keep-alive
+    # Send 404 if we fail
+    begin
+      response = cli.session.send_recv(request, opts[:timeout] ? opts[:timeout] : timeout, cli.keepalive)
+    rescue => e
+      cli.close_session
+      send_e404(cli)
+      raise ::Rex::ConnectionError(e)
+    end
+    return response
+  end
+
+end
+
+end
+end
+end

--- a/lib/rex/proto/proxy/relay.rb
+++ b/lib/rex/proto/proxy/relay.rb
@@ -1,0 +1,60 @@
+require 'rex/logging'
+require 'rex/socket'
+
+module Rex
+module Proto
+module Proxy
+
+  module Relay
+    #
+    # Relay data coming in from relay_sock to this socket.
+    #
+    def relay(relay_client, relay_sock, relay_name = "#{self.class.to_s.split('::')[-2..-1].join}Relay")
+      @relay_client = relay_client
+      @relay_sock   = relay_sock
+      # start the relay thread (modified from Rex::IO::StreamAbstraction)
+      @relay_thread = Rex::ThreadFactory.spawn(relay_name, false) do
+        loop do
+          closed = false
+          buf    = nil
+
+          begin
+            s = Rex::ThreadSafe.select([@relay_sock], nil, nil, 0.2)
+            next if s.nil? || s[0].nil?
+          rescue
+            closed = true
+          end
+
+          unless closed
+            begin
+              buf = @relay_sock.sysread( 32768 )
+              closed = buf.nil?
+            rescue
+              closed = true
+            end
+          end
+
+          unless closed
+            total_sent   = 0
+            total_length = buf.length
+            while total_sent < total_length
+              begin
+                data = buf[total_sent, buf.length]
+                sent = self.write(data)
+                total_sent += sent if sent > 0
+              rescue
+                closed = true
+                break
+              end
+            end
+          end
+
+          if closed
+            @relay_client.stop
+            ::Thread.exit
+          end
+        end
+      end
+    end
+  end
+end; end; end;

--- a/lib/rex/proto/proxy/socks4a.rb
+++ b/lib/rex/proto/proxy/socks4a.rb
@@ -5,6 +5,7 @@
 require 'thread'
 require 'rex/logging'
 require 'rex/socket'
+require 'rex/proto/proxy/relay'
 
 module Rex
 module Proto
@@ -157,65 +158,7 @@ class Socks4a
     #
     # A mixin for a socket to perform a relay to another socket.
     #
-    module Relay
-
-      #
-      # Relay data coming in from relay_sock to this socket.
-      #
-      def relay( relay_client, relay_sock )
-        @relay_client = relay_client
-        @relay_sock   = relay_sock
-        # start the relay thread (modified from Rex::IO::StreamAbstraction)
-        @relay_thread = Rex::ThreadFactory.spawn("SOCKS4AProxyServerRelay", false) do
-          loop do
-            closed = false
-            buf    = nil
-
-            begin
-              s = Rex::ThreadSafe.select( [ @relay_sock ], nil, nil, 0.2 )
-              if( s == nil || s[0] == nil )
-                next
-              end
-            rescue
-              closed = true
-            end
-
-            if( closed == false )
-              begin
-                buf = @relay_sock.sysread( 32768 )
-                closed = true if( buf == nil )
-              rescue
-                closed = true
-              end
-            end
-
-            if( closed == false )
-              total_sent   = 0
-              total_length = buf.length
-              while( total_sent < total_length )
-                begin
-                  data = buf[total_sent, buf.length]
-                  sent = self.write( data )
-                  if( sent > 0 )
-                    total_sent += sent
-                  end
-                rescue
-                  closed = true
-                  break
-                end
-              end
-            end
-
-            if( closed )
-              @relay_client.stop
-              ::Thread.exit
-            end
-          end
-        end
-
-      end
-
-    end
+    include Relay
 
     #
     # Create a new client connected to the server.
@@ -312,8 +255,8 @@ class Socks4a
           @lsock.extend( Relay )
           @rsock.extend( Relay )
           # start the socket relays...
-          @lsock.relay( self, @rsock )
-          @rsock.relay( self, @lsock )
+          @lsock.relay( self, @rsock, "SOCKS4AProxyServerRelay (l2r)")
+          @rsock.relay( self, @lsock, "SOCKS4AProxyServerRelay (r2l)")
         rescue
           wlog( "Client.start - #{$!}" )
           self.stop
@@ -438,4 +381,3 @@ class Socks4a
 end
 
 end; end; end
-

--- a/modules/auxiliary/server/http_proxy.rb
+++ b/modules/auxiliary/server/http_proxy.rb
@@ -1,0 +1,147 @@
+require 'msf/core/exploit/http/proxy'
+
+class MetasploitModule < Msf::Auxiliary
+
+  include Msf::Auxiliary::Report
+  include Msf::Exploit::Remote::HttpServer::Proxy
+
+  def initialize
+    super(
+      'Name'        => 'HTTP Proxy',
+      'Description' => %q{
+        This module creates an HTTP proxy using Rex' HTTP modules.
+        Requests follow the switchboard through configured upstream proxies
+        and pivots. This module is responsible for performing work on  the
+        requests and responses passing through the proxy.
+        This PoC implementation allows MITM and logging. Setting RPORT and RHOST
+        configures the proxy to forward to a single host. Leaving these options
+        blank will pass requests to the original target.
+        The underlying proxy service can operate as a standard or transparent
+        HTTP proxy, rewriting proxy request headers as needed.
+      },
+      'Author'      => 'RageLtMan <rageltman[at]sempervictus>',
+      'License'     => MSF_LICENSE,
+    )
+
+    # Clients make requests to all UIRs
+    deregister_options('URI')
+
+    register_options(
+      [
+        OptString.new('SUBSTITUTIONS', [
+          false,
+          'Response subs in gsub format - original,sub;original,sub. Regex supported.'
+        ]),
+        OptBool.new('HTTP::proxy::MITM::request', [false, 'MITM requests with substitutions']),
+        OptBool.new('HTTP::proxy::MITM::response', [false, 'MITM responses with substitutions']),
+        OptBool.new('HTTP::proxy::MITM::headers', [false, 'MITM headers with substitutions']),
+        OptBool.new('HTTP::proxy::report', [false, 'Report sites and pages']),
+      ])
+
+  end
+
+  # Do stuff with responses
+  def proxy_action_response(cli,res)
+    vprint_good "\nClient's (#{cli.peerhost}:#{cli.peerport}:) original response:\n#{res.to_s}"
+    if datastore['HTTP::proxy::MITM::response']
+      make_subs(res) if datastore['SUBSTITUTIONS']
+    end
+    if datastore['HTTP::proxy::report'] and ([200,401,403] + (500..599).to_a).include?(res.code)
+      log_response(cli,res)
+    end
+  end
+
+  # Do stuff with requests
+  def proxy_action_request(cli,req)
+    vprint_good "\nClient #{cli.peerhost}:#{cli.peerport} requested:\n#{req.to_s}"
+    if datastore['HTTP::proxy::MITM::request']
+      make_subs(req) if datastore['SUBSTITUTIONS']
+    end
+  end
+
+
+  def run
+    @substitutions = process_subs(datastore['SUBSTITUTIONS'])
+    exploit
+  end
+
+
+  # Borrows heavily from crawler.rb to log web sites and pages
+  # based on client request and response instead of Anemone's page
+  # class. This wont work unless the client request is still valid
+  def log_response(cli,res)
+    return unless cli.request
+    t = Msf::Auxiliary::HttpCrawler::WebTarget.new
+
+    # Build site report information
+    cli.request.headers.map do |k,v|
+      t[k.downcase.intern] = v
+    end if cli.request
+
+    t[:port] ||= t[:ssl] ? 443 : 80
+    t[:site] = report_web_site(:wait => true, :host => t[:host], :port => t[:port], :vhost => t[:vhost], :ssl => t[:ssl])
+
+    # Build page report information, from crawler.rb
+    info = {
+      :web_site => t[:site],
+      :path     => cli.request.uri,
+      :query    => cli.request.param_string,
+      :code     => res.code,
+      :body     => res.body,
+      :headers  => res.headers,
+      :cookie   => cli.request.headers['cookie']
+    }
+
+    if res.headers['content-type']
+      info[:ctype] = res.headers['content-type']
+    end
+
+    if res.get_cookies and not res.get_cookies.empty?
+      info[:cookie] = res.get_cookies
+    end
+
+    if res.headers['authorization']
+      info[:auth] = res.headers['authorization']
+    end
+
+    if res.headers['location']
+      info[:location] = res.headers['location']
+    end
+
+    if res.headers['last-modified']
+      info[:mtime] = res.headers['last-modified']
+    end
+
+    report_web_page(info) unless res.code == 404
+  end
+
+  # Run substitution sets through response
+  def make_subs(resp)
+    @substitutions.each do |sub_set|
+      resp.body.gsub!(sub_set[0],sub_set[1])
+      if datastore['HTTP::proxy::MITM::headers']
+        # In-place alteration of hashes during iteration can be bad
+        hdr_dup = resp.headers.dup
+        hdr_dup.each do |key, val|
+          resp.headers[key] = val.to_s.gsub(sub_set[0],sub_set[1]) if val
+        end
+      end
+    end
+  end
+
+  # Convert substitution definition strings to gsub compatible format
+  def process_subs(subs = nil)
+    return [] if subs.nil? or subs.empty?
+    new_subs = []
+    subs.split(';').each do |substitutions|
+      new_subs << substitutions.split(',', 2).map do |sub|
+        if sub.scan(/\/.*\//).empty?
+          sub
+        else
+          sub = Regexp.new(sub[1..-2])
+        end
+      end
+    end
+    return new_subs
+  end
+end


### PR DESCRIPTION
Add HTTP Proxy class to Rex::Proto::Http
Add Msf::Exploit::Remote::Http::Proxy mixin
Add auxiliary HTTP proxy server

The Rex proxy is capable of keeping sessions alive, rewriting headers
from proxy requests, and exposes callbacks for higher level
operations on request and response data, with the client available
for redirect or other activities. This proxy can function as a
transparent, standard HTTP, or direct-connected (routing all
traffic to a specific host:port) forwarder. Encoding is restricted
to Rex supported types.

Request and response callbacks allow for any action to be taken
during the proxying process and will gracefully return from the
proxy's callbacks if the client is no longer connected.

The mixin provides convenience methods for managing the service
and mixing into modules.

The http_proxy module provides options for performing MITM on
requests and/or responses, with an option to MITM headers as well
as the request body. Substitutions can be entered as semi-colon
separated strings to deal with varying requests during runtime.
Additionally, the proxy can be used to log successful page hits
to the DB, providing crawler, and other web-oriented modules
with targets which are not discovered by our native mechanisms.

Everything runs on Rex, so proxies can be started on pivoted hosts
facing into a compromised network and connecting anywhere on the
switchboard. The same instance will handle directed requests
as well as MITM victims.

Testing:
start the module, configure your browser to use the proxy on your
machine, browse pages. Configure HTTP::proxy::MITM options and
rexploit. Configure HTTP::proxy::report true and run arachni
or your favorite crawler through the proxy to build up a target
list.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use auxiliary/server/http_proxy`
- [ ] `exploit`
- [ ] **Verify** that `curl -x localhost:8080 google.com -v -L` works
- [ ] **Verify** that setting substitutions work as described in the module info
- [ ] **Verify** that applications using chunked encoding and asynchronous semantics work


