### PR TITLE
WIP - The road to DCOM

### DIFF
--- a/lib/msf/core/exploit/dcerpc.rb
+++ b/lib/msf/core/exploit/dcerpc.rb
@@ -63,14 +63,14 @@ module Exploit::Remote::DCERPC
     self.handle = Rex::Proto::DCERPC::Handle.new([uuid, version], protocol, rhost, opts)
   end
 
-  def dcerpc_bind(h)
+  def dcerpc_bind(h, auth_type=nil, auth_level=nil, auth_client = nil)
     opts = { 'Msf' => framework, 'MsfExploit' => self }
 
     if datastore['DCERPC::max_frag_size']
       opts['frag_size'] = datastore['DCERPC::max_frag_size']
     end
 
-    if datastore['DCERPC::fake_bind_multi']
+    if datastore['DCERPC::fake_bind_multi'] and datastore['DCERPC::fake_bind_multi'] == true
       opts['fake_multi_bind'] = 1
 
       if datastore['DCERPC::fake_bind_multi_prepend']
@@ -86,7 +86,6 @@ module Exploit::Remote::DCERPC
 
     opts['read_timeout']    = (datastore['DCERPC::ReadTimeout'] || 10).to_i
 
-
     # Configure the SMB evasion options
 
     if (datastore['SMBUser'])
@@ -95,6 +94,14 @@ module Exploit::Remote::DCERPC
 
     if (datastore['SMBPass'])
       opts['smb_pass'] = datastore['SMBPass']
+    end
+
+    if datastore['SMBDomain']
+      opts['smb_domain'] = datastore['SMBDomain']
+    end
+
+    if datastore['SMBName']
+      opts['smb_name'] = datastore['SMBName']
     end
 
     if (datastore['DCERPC::smb_pipeio'])
@@ -121,10 +128,22 @@ module Exploit::Remote::DCERPC
       opts['smb_client'] = self.simple
     end
 
+    if auth_type
+      opts['auth_type'] = auth_type
+    end
+
+    if auth_level
+      opts['auth_level'] = auth_level
+    end
+
+    if auth_client
+      opts['auth_client'] = auth_client
+    end
+
     # Create the DCERPC client
     self.dcerpc = Rex::Proto::DCERPC::Client.new(h, self.sock, opts)
 
-    if (self.handle.protocol == 'ncacn_np' and not self.simple)
+    if self.handle and (self.handle.protocol == 'ncacn_np' and not self.simple)
       self.simple = self.dcerpc.smb  # expose the simple client if we have access to it
     end
   end

--- a/lib/rex/proto/dcerpc/authentication.rb
+++ b/lib/rex/proto/dcerpc/authentication.rb
@@ -1,0 +1,155 @@
+# -*- coding: binary -*-
+
+require 'rex/proto/dcerpc/uuid'
+require 'rex/proto/dcerpc/response'
+require 'rex/text'
+
+module Rex
+module Proto
+module DCERPC
+class Authentication
+
+  attr_accessor :signing_key, :sealing_key, :auth_type, :auth_level, :handle, :seq_num
+
+  def initialize(atype=nil, alevel=nil)
+    self.handle = OpenSSL::Cipher::Cipher.new('rc4')
+    # self.handle.encrypt
+    self.signing_key = ''
+    self.sealing_key = ''
+    self.seq_num = 0
+    self.auth_type = atype
+    self.auth_level = alevel
+  end
+
+  def ntlmssp_verifier(message = '')
+    ver = Rex::Proto::NTLM::Crypt.make_ess_message_signature(
+      self.signing_key,
+      self.sealing_key,
+      message,
+      self.seq_num,
+      self.handle)
+    self.seq_num += 1 # May need to do this in the client itself
+    return ver
+  end
+
+  def auth_buff(pad_length=0)
+    buff =
+                [
+                        auth_type,     		# 9: SPNEGO 10: NTLMSSP
+                        auth_level,    		# 2: Connect 5: PacketIntegrity
+                        pad_length,      	# Auth pad len
+                        0,      		 	# Auth rsrvd
+                        0x6B8B4567, 	 	# Auth context id
+                ].pack('CCCCV')
+
+    return buff
+  end
+
+  def auth_ntlm_1(domain, name, ntlm_options)
+    flags = Rex::Proto::NTLM::Utils.make_ntlm_flags(ntlm_options)
+    if auth_type == 9
+      ntlm_1 = Rex::Proto::NTLM::Utils.make_ntlmssp_secblob_init(domain, name, flags)
+    else
+      ntlm_1 = Rex::Proto::NTLM::Utils.make_ntlmssp_blob_init(domain, name, flags)
+    end
+    return auth_buff+ntlm_1, ntlm_1.length
+  end	
+
+  def auth_ntlm_3(last_response, opts, ntlm_options)
+    flags = Rex::Proto::NTLM::Utils.make_ntlm_flags(ntlm_options)
+    # flags = 0x60088215
+    start = last_response.raw.index("NTLMSSP")
+        ntlmssp = last_response.raw[start..-1]
+       	ntlm_2 = Rex::Proto::NTLM::Utils.parse_ntlm_type_2_blob(ntlmssp)
+       	
+        spnopt = {}
+        if ntlm_options[:sealing] # TODO
+        	spnopt[:use_spn] = true
+        	spnopt[:name] = opts[:name] || 'unknown'
+        end
+
+    resp_lm, resp_ntlm, client_challenge, ntlm_cli_challenge = Rex::Proto::NTLM::Utils.create_lm_ntlm_responses(
+      opts[:user],
+      opts[:password],
+      ntlm_2[:challenge_key],
+      opts[:domain],
+      opts[:name],
+      ntlm_2[:default_domain],
+      ntlm_2[:dns_host_name],
+      ntlm_2[:dns_domain_name],
+      ntlm_2[:chall_MsvAvTimestamp],
+      spnopt,
+      ntlm_options
+    )
+
+    self.signing_key, self.sealing_key, ntlmssp_flags = Rex::Proto::NTLM::Utils.create_session_key(
+      flags,
+      opts[:server_ntlmssp_flags],
+      opts[:user],
+      opts[:password],
+      opts[:domain],
+      ntlm_2[:challenge_key],
+      client_challenge,
+      ntlm_cli_challenge,
+      ntlm_options
+    )
+    # Initialize the cipher with newly negotiated key
+    self.handle.update(self.signing_key)		
+    
+    if auth_type == 9
+      ntlm_3 = Rex::Proto::NTLM::Utils.make_ntlmssp_secblob_auth(
+        opts[:domain],
+        opts[:name],
+        opts[:user],
+        resp_lm,
+        resp_ntlm,
+        self.signing_key,
+        flags)
+    else
+      ntlm_3 = Rex::Proto::NTLM::Utils.make_ntlmssp_blob_auth(
+              opts[:domain],
+              opts[:name],
+              opts[:user],
+              resp_lm,
+              resp_ntlm,
+              self.signing_key,
+              flags)
+    end
+
+    # buff = self.class.auth_buff(auth_type, auth_level)
+    return auth_buff+ntlm_3, ntlm_3.length
+  end
+
+  ##
+  # Class methods, stateless
+  ##
+
+  def self.auth_buff(auth_type, auth_level, pad_length=0)
+    buff =
+                [
+                        auth_type ,		    # 9: SPNEGO 10: NTLMSSP
+                        auth_level,		    # 2: Connect 5: PacketIntegrity
+                        pad_length,      	# Auth pad len
+                        0,      		 	# Auth rsrvd
+                        0x6B8B4567, 	 	# Auth context id
+                ].pack('CCCCV')
+
+    return buff
+  end
+
+  def self.auth_ntlm_1(auth_type, auth_level, domain, name, ntlm_options)
+    flags = Rex::Proto::NTLM::Utils.make_ntlm_flags(ntlm_options)
+    if auth_type == 9
+      ntlm_1 = Rex::Proto::NTLM::Utils.make_ntlmssp_secblob_init(domain, name, flags)
+    else
+      ntlm_1 = Rex::Proto::NTLM::Utils.make_ntlmssp_blob_init(domain, name, flags)
+    end
+    buff = self.auth_buff(auth_type, auth_level)
+
+    return buff+ntlm_1, ntlm_1.length
+  end
+
+end
+end
+end
+end

--- a/lib/rex/proto/dcerpc/client.rb
+++ b/lib/rex/proto/dcerpc/client.rb
@@ -7,6 +7,7 @@ class Client
 require 'rex/proto/dcerpc/uuid'
 require 'rex/proto/dcerpc/response'
 require 'rex/proto/dcerpc/exceptions'
+require 'rex/proto/dcerpc/authentication'
 require 'rex/text'
 require 'rex/proto/smb/exceptions'
 

--- a/lib/rex/proto/dcerpc/dcom.rb
+++ b/lib/rex/proto/dcerpc/dcom.rb
@@ -1,0 +1,121 @@
+# -*- coding: binary -*-
+module Rex
+module Proto
+module DCERPC
+class Dcom
+
+require 'rex/text'
+  
+  def self.parse(data)
+    orpcthat_flags,
+    orpcthat_extent_array,
+    oxid,
+    pad,
+    unknown,
+    pad1,
+    unknown = data.unpack('VVa8vvvv')
+
+    string_bindings, security_bindings, e = parse_dualstringarray(data[24..-1])
+    data = data[e+30..-1]
+
+
+    ipid,
+    auth_hint,
+    version_major,
+    version_minor,
+    hresult = data.unpack('a16VvvV')
+    ipid = Rex::Proto::DCERPC::UUID.uuid_unpack(ipid)
+
+    interface_data = data[36..-1]
+    #puts interface_data.inspect
+    cntdata,
+    cntdata,
+    objref_meow,
+    objref_flags,
+    objref_iid,
+    # StdObjRef
+    stdobjref_flags,
+    stdobjref_publicrefs,
+    stdobjref_oxid,
+    stdobjref_oid,
+    stdobjref_ipid = interface_data.unpack('VVa4Va16VVa8a8a16')
+
+    objref_iid = Rex::Proto::DCERPC::UUID.uuid_unpack(objref_iid)
+    stdobjref_ipid = Rex::Proto::DCERPC::UUID.uuid_unpack(stdobjref_ipid)
+
+    istring_bindings, isecurity_bindings, ie = parse_dualstringarray(interface_data[72..-1])
+    hresult_data = interface_data[ie+82..-1]
+
+    port = nil
+    for towerid, netaddr in string_bindings
+      if towerid == 7
+        port = /\[(\d+)\]/.match(netaddr)[1]
+        break
+      end
+    end
+
+    return objref_iid, port, stdobjref_ipid
+  end
+
+  def self.parse_dualstringarray(data)
+    num_entries,
+                security_offset = data.unpack('vv')
+
+                offset = 4
+
+                string_binding_end = offset + security_offset*2
+                security_offset_end = offset + num_entries*2
+                string_binding = data[offset..string_binding_end]
+                $stdout.puts("#{string_binding}")
+                security_binding = data[string_binding_end..security_offset_end]
+
+                string_bindings = []
+                while string_binding.length > 0
+                        towerid = string_binding.unpack('v').first
+                        if towerid == 0
+                                break
+                        end
+                        e = string_binding.index("\x00\x00") || -2
+                        sb = Rex::Text.to_ascii(string_binding[2..e])
+                        string_bindings << [towerid, sb]
+                        string_binding = string_binding[e+3..-1]
+
+                end
+
+                security_bindings = []
+                while security_binding.length > 0
+                        authn_svc, reserved = security_binding.unpack('vv')
+                        if authn_svc == 0
+                                break
+                        end
+                        e = security_binding.index("\x00\x00") || -1
+                        so = Rex::Text.to_ascii(security_binding[4..e])
+                        security_bindings << [authn_svc, so]
+                        security_binding = security_binding[e+3..-1]
+                end
+    
+    return string_bindings, security_bindings, num_entries*2
+  end
+
+  #
+  # http://msdn.microsoft.com/en-us/library/cc226801.aspx
+  #
+ 	
+  def create_stub_header(uuid='61eb59f1-1efb-11d1-bcd9-00609792d26c',ext='',flags=0)
+    binuuid = Rex::Text.hex_to_raw(UUID.uuid_pack(uuid)) # ORPCTHIS
+    # ext  ||= Rex::Text.hex_to_raw('605e0d00') # Extensions
+
+    hdr = [
+      5,     # Version High
+      1,     # Version Low
+      flags, # Flags
+      0,     # Reserved
+    ].pack('vvVV') << binuuid << ext
+
+    return hdr
+  end
+
+end
+end
+end
+end


### PR DESCRIPTION
This squashes commits by @meatballs and myself from 2013 which
permit authenticated DCERPC sessions with NTLMv3 SSP signing.

Modules and scripts used for development are not included yet.

This is WIP - there are debug prints, sharp edges, and probable
mistakes here.

-----

Squashed commits from 2013 with retab and change adjustments:

commit 6c0ffd8470ebaba644045eb9784fd97fde6d99a7
Author: RageLtMan <rageltman [at] sempervictus>
Date:   Tue Sep 3 16:08:07 2013 -0400

dcom headers

commit 9a25a5dede587e03dff2740f4bc4b7286c4f74df
Author: RageLtMan <rageltman [at] sempervictus>
Date:   Sat Aug 31 02:43:05 2013 -0400

refactoring

commit f48ada18cfed8f7c737bff2a22139db233af110a (origin/wmis)
Author: RageLtMan <rageltman [at] sempervictus>
Date:   Wed Aug 28 04:07:22 2013 -0400

Resolve alter_context_auth

NTLMSSP negotiation alters instance variables in the Authentication
class. The auth_ntlm_3 method was being called as a class method
by Packet and failing to set nonexistent class variables.

Rewire auth_ntlm_3 as an instance method, call as such from Packet.

Current error: "Exploit failed: ArgumentError bad value for range."
The streak of informative stack traces may be over.

commit dc4936a5e5a23db7d088b348321acd9098fa36df
Author: RageLtMan <rageltman [at] sempervictus>
Date:   Wed Aug 28 03:33:29 2013 -0400

Identify NTLMSSP response properly

DCERPC response is binary, so the comparison between the "substr"
of the raw response and hex string was failing.
Additionally the string used to check the result had the first
byte in last position.

Convert response segment to hex, and compare to the correct
response reference hex string.

Now failing during signing in DCERPC Authentication class with
NoMethodError undefined method `signing_key='

commit 2f2c3810bd8158dacf52ed16815e2d540c6498f7
Author: RageLtMan <rageltman [at] sempervictus>
Date:   Wed Aug 28 03:12:45 2013 -0400

Resolve inability to initiate DCERPC auth session

msf/core/exploit/dcerpc was always setting fake_bind_multi to 1.
This prevented any attempts to initiate the authenticated session.

rex/proto/dcerpc/authentication always expects to receive an auth
type and level, but not all calls made from msf to dcerpc_bind will
be attempting to access dcerpc over TCP with auth. Defaulted
auth_buff generation to use speno/connect when no options are
passed.
Interesting to note that if setting these values in the method
call definition, that passing a NiClass object to the method call
does not result in a value being assigned, but passes the nil to
the array which then gets packed.

At present, wireshark says "DCERPC 451 Bind_ack: call_id: 0,
Fragment: Single, max_xmit: 5840 max_recv: 5840, 1 results:
Acceptance, NTLMSSP_CHALLENGE"

commit aaa945ec957062186dcf730e3dc6a7cf4176d147 (meatballs/wmis)
Merge: 30c1b78893 a8a1bd53f0
Author: Meatballs1 <campbell_ab@hotmail.com>
Date:   Sat Aug 24 03:23:04 2013 -0700

Merge pull request #7 from sempervictus/wmis

Minor typo

commit a8a1bd53f07fe332185f72c9232fae21762cda89
Author: RageLtMan <rageltman [at] sempervictus>
Date:   Mon Aug 5 20:25:06 2013 -0400

fix typo

commit 30c1b78893751e68275ed595b68ec11ac6e4580c
Author: Meatballs <eat_meatballs@hotmail.co.uk>
Date:   Sun Jul 28 21:50:29 2013 +0100

some signing

commit 11eba4661602889bf1d49f87806ca55e3d0ed320
Author: Meatballs <eat_meatballs@hotmail.co.uk>
Date:   Sun Jul 21 00:40:33 2013 +0100

Initial auth comms working

commit 05449c6d88b70ae1f6aebbf234f5372a6f6744cc
Author: Meatballs <eat_meatballs@hotmail.co.uk>
Date:   Sat Jul 20 11:39:11 2013 +0100

Initial commit

-----

Ping @meatballs @OJ @bcook-r7 @egypt - please take a look over these changes.
@meatballs: any additional attribution i should provide for your efforts here? Any updates you may have on your end (provided you are able to submit them of course)?