### PR TITLE
Cleanup auxiliary/scanner/msf/msf_rpc_login

### DIFF
--- a/modules/auxiliary/scanner/msf/msf_rpc_login.rb
+++ b/modules/auxiliary/scanner/msf/msf_rpc_login.rb
@@ -98,7 +98,7 @@ class MetasploitModule < Msf::Auxiliary
       end
     rescue Rex::ConnectionRefused => e
       print_error("#{peer} - Connection refused")
-      return :next_user
+      return :abort
     rescue => e
       vprint_status("#{peer} - Bad login")
       return :skip_pass

--- a/modules/auxiliary/scanner/msf/msf_rpc_login.rb
+++ b/modules/auxiliary/scanner/msf/msf_rpc_login.rb
@@ -3,23 +3,26 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
+require 'msf/core/rpc/v10/client'
+
 class MetasploitModule < Msf::Auxiliary
 
+  include Msf::Exploit::Remote::Tcp
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::AuthBrute
   include Msf::Auxiliary::Scanner
 
-  def initialize
-    super(
+  def initialize(info = {})
+    super(update_info(info,
       'Name'          => 'Metasploit RPC Interface Login Utility',
       'Description'   => %q{
         This module simply attempts to login to a
         Metasploit RPC interface using a specific
         user/pass.
       },
-      'Author'         => [ 'Vlatko Kosturjak <kost[at]linux.hr>' ],
-      'License'        => MSF_LICENSE
-    )
+      'Author'        => [ 'Vlatko Kosturjak <kost[at]linux.hr>' ],
+      'License'       => MSF_LICENSE
+    ))
 
     register_options(
       [
@@ -28,34 +31,21 @@ class MetasploitModule < Msf::Auxiliary
         OptBool.new('BLANK_PASSWORDS', [false, "Try blank passwords for all users", false]),
         OptBool.new('SSL', [ true, "Negotiate SSL for outgoing connections", true])
       ])
+
     register_autofilter_ports([3790])
-
-  end
-
-  @@loaded_msfrpc = false
-  begin
-    require 'msf/core/rpc/v10/client'
-    @@loaded_msfrpc = true
-  rescue LoadError
   end
 
   def run_host(ip)
-
-    unless @@loaded_msfrpc
-      print_error("You don't have 'msgpack', please install that gem manually.")
-      return
-    end
-
     begin
       @rpc = Msf::RPC::Client.new(
-        :host => datastore['RHOST'],
-        :port => datastore['RPORT'],
-        :ssl  => datastore['SSL']
+        :host => rhost,
+        :port => rport,
+        :ssl  => ssl
       )
     rescue ::Interrupt
       raise $!
-    rescue ::Exception => e
-      vprint_error("#{datastore['SSL'].to_s} Cannot create RPC client : #{e.to_s}")
+    rescue => e
+      vprint_error("#{peer} Cannot create RPC client : #{e}")
       return
     end
 
@@ -91,27 +81,29 @@ class MetasploitModule < Msf::Auxiliary
     create_credential_login(login_data)
   end
 
-  def do_login(user='msf', pass='msf')
+  def do_login(user = 'msf', pass = 'msf')
     vprint_status("Trying username:'#{user}' with password:'#{pass}'")
     begin
       res = @rpc.login(user, pass)
       if res
         print_good("SUCCESSFUL LOGIN. '#{user}' : '#{pass}'")
         report_cred(
-          ip: datastore['RHOST'],
-          port: datastore['RPORT'],
+          ip: rhost,
+          port: rport,
           service_name: 'msf-rpc',
           user: user,
-          password: pass,
-          proof: res.body
+          password: pass
         )
-        @rpc.close
         return :next_user
       end
-    rescue  => e
-      vprint_status("#{datastore['SSL'].to_s} - Bad login")
-      @rpc.close
+    rescue Rex::ConnectionRefused => e
+      print_error("#{peer} - Connection refused")
+      return :next_user
+    rescue => e
+      vprint_status("#{peer} - Bad login")
       return :skip_pass
     end
+  ensure
+    @rpc.close
   end
 end


### PR DESCRIPTION
This PR includes a couple of bug fixes and minor code clean up for the Metasploit RPC Interface Login Utility module.

Output before and after this patch is shown below.

### Changes

* Libraries:
  * The RPC library loading has been moved to the top of the file. This is cleaner and *should* be safe, given that the `msf/core/rpc/v10/client` library is packaged with Metasploit, and that the `msgpack` Gem requirement is included in `Gemfile.lock`.
  * The `include Msf::Exploit::Remote::Tcp` library has been included, for no other reason than to allow access to `peer`, `rhost`, `rport`, `ssl` variables.

* Output
  * When scanning more than one host the output made no sense. This has been cleaned up with the use of `peer` in output.

* Bug Fixes
  * If the connection is refused, the module will now skip the host, instead of needlessly continuing login attempts with all passwords against all users.
  * The `proof` has been removed from the reported credentials. The proof was `res.body` which was raising ```undefined method `body' for true:TrueClass``` which was triggering the `rescue`, causing the call to `report_cred` to fail, resulting in credentials being reported to console, but never to the database.


### Output (Before)

```
msf auxiliary(msf_rpc_login) > set rhosts 127.0.0.1 172.16.191.181
rhosts => 127.0.0.1 172.16.191.181
rmsf auxiliary(msf_rpc_login) > run

[*] Trying username:'msf' with password:'test'
[*] true - Bad login
[*] Trying username:'msf' with password:'12345'
[*] true - Bad login
[*] Trying username:'msf' with password:'123456'
[*] true - Bad login
[*] Trying username:'msf' with password:'password'
[*] true - Bad login
[*] Trying username:'msf' with password:'abc123'
[*] true - Bad login
[*] Trying username:'msf' with password:'msfchangeme'
[*] true - Bad login
[*] Scanned 1 of 2 hosts (50% complete)
[*] Trying username:'msf' with password:'test'
[*] true - Bad login
[*] Trying username:'msf' with password:'12345'
[*] true - Bad login
[*] Trying username:'msf' with password:'123456'
[*] true - Bad login
[*] Trying username:'msf' with password:'password'
[*] true - Bad login
[*] Trying username:'msf' with password:'abc123'
[+] SUCCESSFUL LOGIN. 'msf' : 'abc123'
[*] true - Bad login
[*] Trying username:'msf' with password:'msfchangeme'
[*] true - Bad login
[*] Scanned 2 of 2 hosts (100% complete)
[*] Auxiliary module execution completed
```

### Output (After)

```
msf auxiliary(msf_rpc_login) > set rhosts 127.0.0.1 172.16.191.181
rhosts => 127.0.0.1 172.16.191.181
msf auxiliary(msf_rpc_login) > run

[*] 127.0.0.1:55553       - Trying username:'msf' with password:'test'
[-] 127.0.0.1:55553       - 127.0.0.1:55553       - Connection refused
[*] Scanned 1 of 2 hosts (50% complete)
[*] 172.16.191.181:55553  - Trying username:'msf' with password:'test'
[*] 172.16.191.181:55553  - 172.16.191.181:55553 - [1/6] - Bad login
[*] 172.16.191.181:55553  - Trying username:'msf' with password:'12345'
[*] 172.16.191.181:55553  - 172.16.191.181:55553 - [2/6] - Bad login
[*] 172.16.191.181:55553  - Trying username:'msf' with password:'123456'
[*] 172.16.191.181:55553  - 172.16.191.181:55553 - [3/6] - Bad login
[*] 172.16.191.181:55553  - Trying username:'msf' with password:'password'
[*] 172.16.191.181:55553  - 172.16.191.181:55553 - [4/6] - Bad login
[*] 172.16.191.181:55553  - Trying username:'msf' with password:'abc123'
[+] 172.16.191.181:55553  - SUCCESSFUL LOGIN. 'msf' : 'abc123'
[!] 172.16.191.181:55553  - No active DB -- Credential data will not be saved!
[*] Scanned 2 of 2 hosts (100% complete)
[*] Auxiliary module execution completed
```
