### PR TITLE
Fixed typo

### DIFF
--- a/modules/auxiliary/gather/zoomeye_search.rb
+++ b/modules/auxiliary/gather/zoomeye_search.rb
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Auxiliary
         [
           OptString.new('USERNAME', [true, 'The ZoomEye username']),
           OptString.new('PASSWORD', [true, 'The ZoomEye password']),
-          OptString.new('ZOOMEYE_DORK', [true, 'The ZoomEye Dock']),
+          OptString.new('ZOOMEYE_DORK', [true, 'The ZoomEye dork']),
           OptEnum.new('RESOURCE', [true, 'ZoomEye Resource Type', 'host', ['host', 'web']]),
           OptInt.new('MAXPAGE', [true, 'Max amount of pages to collect', 1])
         ])


### PR DESCRIPTION
Fixed a small typo in `auxiliary/gather/zoomeye_search`.