### PR TITLE
Add PDF link scraping to http_pdf_authors module

### DIFF
--- a/documentation/modules/auxiliary/gather/http_pdf_authors.md
+++ b/documentation/modules/auxiliary/gather/http_pdf_authors.md
@@ -1,22 +1,34 @@
-This module downloads PDF files and extracts the author's name from the document metadata.
+This module downloads PDF documents and extracts the author's name from the document metadata.
+
 
 ## Verification Steps
 
   1. Start `msfconsole`
   2. Do: `use auxiliary/gather/http_pdf_authors`
   3. Do: `set URL [URL]`
-  4. Do: `run`
+  4. Do: `set URL_TYPE [pdf|html]`
+  5. Do: `run`
 
 
 ## Options
 
 **URL**
 
-The URL of a PDF to analyse.
+The target URL.
 
 **URL_LIST**
 
-File containing a list of PDF URLs to analyze.
+File containing a list of URLs.
+
+If both a `URL` and `URL_LIST` options are specified, the module will favor the URL. To use the `URL_LIST`, clear the `URL` with `unset URL`.
+
+**URL_TYPE**
+
+The type of URL(s) specified (Accepted: `pdf`, `html`)
+
+By specifying `pdf` for the `URL_TYPE`, the module will treat the specified URL(s) as PDF documents. The module will download the documents and extract the author's name from the document metadata.
+
+By specifying `html` for the `URL_TYPE`, the module will treat the specified URL(s) as HTML pages. The module will scrape the pages for links to PDF documents, download the PDF documents, and extract the author's name from the document metadata.
 
 **OUTFILE**
 
@@ -25,54 +37,37 @@ File to store extracted author names.
 
 ## Scenarios
 
-### URL
+### Extracting author names from PDF URLs
 
   ```
-  msf auxiliary(http_pdf_authors) > set url http://127.0.0.1/test4.pdf
-  url => http://127.0.0.1/test4.pdf
-  msf auxiliary(http_pdf_authors) > run
-
-  [*] Processing 1 URLs...
-  [*] Downloading 'http://127.0.0.1/test4.pdf'
-  [*] HTTP 200 -- Downloaded PDF (38867 bytes)
-  [+] PDF Author: Administrator
-  [*] 100.00% done (1/1 files)
-
-  [+] Found 1 authors: Administrator
-  [*] Auxiliary module execution completed
-  ```
-
-### URL_LIST with OUTFILE
-
-  ```
-  msf auxiliary(http_pdf_authors) > set outfile /root/output
-  outfile => /root/output
+  msf auxiliary(http_pdf_authors) > set url_type pdf
+  url_type => pdf
   msf auxiliary(http_pdf_authors) > set url_list /root/urls
   url_list => /root/urls
   msf auxiliary(http_pdf_authors) > run
 
   [*] Processing 8 URLs...
   [*] Downloading 'http://127.0.0.1:80/test.pdf'
-  [*] HTTP 200 -- Downloaded PDF (89283 bytes)
+  [*] - HTTP 200 - 89283 bytes
   [*]  12.50% done (1/8 files)
   [*] Downloading 'http://127.0.0.1/test2.pdf'
-  [*] HTTP 200 -- Downloaded PDF (636661 bytes)
+  [*] - HTTP 200 - 636661 bytes
   [+] PDF Author: sqlmap developers
   [*]  25.00% done (2/8 files)
   [*] Downloading 'http://127.0.0.1/test3.pdf'
-  [*] HTTP 200 -- Downloaded PDF (167478 bytes)
+  [*] - HTTP 200 - 167478 bytes
   [+] PDF Author: Evil1
   [*]  37.50% done (3/8 files)
   [*] Downloading 'http://127.0.0.1/test4.pdf'
-  [*] HTTP 200 -- Downloaded PDF (38867 bytes)
+  [*] - HTTP 200 - 38867 bytes
   [+] PDF Author: Administrator
   [*]  50.00% done (4/8 files)
   [*] Downloading 'http://127.0.0.1/test5.pdf'
-  [*] HTTP 200 -- Downloaded PDF (34312 bytes)
+  [*] - HTTP 200 - 34312 bytes
   [+] PDF Author: ekama
   [*]  62.50% done (5/8 files)
   [*] Downloading 'http://127.0.0.1/doesnotexist.pdf'
-  [*] HTTP 404 -- Downloaded PDF (289 bytes)
+  [*] - HTTP 404 - 289 bytes
   [-] Could not parse PDF: PDF is malformed
   [*]  75.00% done (6/8 files)
   [*] Downloading 'https://127.0.0.1/test.pdf'
@@ -81,7 +76,66 @@ File to store extracted author names.
   [-] Connection failed: SSL_connect returned=1 errno=0 state=unknown state: unknown protocol
 
   [+] Found 4 authors: sqlmap developers, Evil1, Administrator, ekama
-  [*] Writing data to /root/output...
+  [*] Auxiliary module execution completed
+  ```
+
+### Extracting PDF links from HTML
+
+  ```
+  msf auxiliary(http_pdf_authors) > set url_type html
+  url_type => html
+  msf auxiliary(http_pdf_authors) > set url_list /root/urls2
+  url_list => /root/urls2
+  msf auxiliary(http_pdf_authors) > run
+
+  [*] Processing 2 URLs...
+  [*] Downloading 'http://127.0.0.1/test/links.html'
+  [*] - HTTP 200 - 310 bytes
+  [*]  50.00% done (1/2 files)
+  [*] Downloading 'http://127.0.0.1/index.html'
+  [*] - HTTP 200 - 177 bytes
+  [*] 100.00% done (2/2 files)
+
+  [+] Found links to 7 PDF files:
+  http://127.0.0.1/test1.pdf
+  http://127.0.0.1/test2.pdf
+  http://127.0.0.1/test3.pdf
+  http://127.0.0.1/test4.pdf
+  http://127.0.0.1/test5.pdf
+  http://127.0.0.1/test5.pdf?query=string&
+  http://127.0.0.1/test/doesnotexist.pdf
+
+  [*] Processing 7 URLs...
+  [*] Downloading 'http://127.0.0.1/test1.pdf'
+  [*] - HTTP 404 - 282 bytes
+  [-] Could not parse PDF: PDF is malformed
+  [*]  14.29% done (1/7 files)
+  [*] Downloading 'http://127.0.0.1/test2.pdf'
+  [*] - HTTP 200 - 636661 bytes
+  [+] PDF Author: sqlmap developers
+  [*]  28.57% done (2/7 files)
+  [*] Downloading 'http://127.0.0.1/test3.pdf'
+  [*] - HTTP 200 - 167478 bytes
+  [+] PDF Author: Evil1
+  [*]  42.86% done (3/7 files)
+  [*] Downloading 'http://127.0.0.1/test4.pdf'
+  [*] - HTTP 200 - 38867 bytes
+  [+] PDF Author: Administrator
+  [*]  57.14% done (4/7 files)
+  [*] Downloading 'http://127.0.0.1/test5.pdf'
+  [*] - HTTP 200 - 34312 bytes
+  [+] PDF Author: ekama
+  [*]  71.43% done (5/7 files)
+  [*] Downloading 'http://127.0.0.1/test5.pdf?query=string&'
+  [*] - HTTP 200 - 34312 bytes
+  [+] PDF Author: ekama
+  [*]  85.71% done (6/7 files)
+  [*] Downloading 'http://127.0.0.1/test/doesnotexist.pdf'
+  [*] - HTTP 404 - 294 bytes
+  [-] Could not parse PDF: PDF is malformed
+  [*] 100.00% done (7/7 files)
+
+  [+] Found 4 authors: sqlmap developers, Evil1, Administrator, ekama
   [*] Auxiliary module execution completed
   ```
 

--- a/modules/auxiliary/gather/http_pdf_authors.rb
+++ b/modules/auxiliary/gather/http_pdf_authors.rb
@@ -11,15 +11,32 @@ class MetasploitModule < Msf::Auxiliary
     super(update_info(info,
       'Name'        => 'Gather PDF Authors',
       'Description' => %q{
-        This module downloads PDF files and extracts the author's
+        This module downloads PDF documents and extracts the author's
         name from the document metadata.
+
+        This module expects a URL to be provided using the URL option.
+        Alternatively, multiple URLs can be provided by supplying the
+        path to a file containing a list of URLs in the URL_LIST option.
+
+        The URL_TYPE option is used to specify the type of URLs supplied.
+
+        By specifying 'pdf' for the URL_TYPE, the module will treat
+        the specified URL(s) as PDF documents. The module will
+        download the documents and extract the author's name from the
+        document metadata.
+
+        By specifying 'html' for the URL_TYPE, the module will treat
+        the specified URL(s) as HTML pages. The module will scrape the
+        pages for links to PDF documents, download the PDF documents,
+        and extract the author's name from the document metadata.
       },
       'License'     => MSF_LICENSE,
       'Author'      => 'Brendan Coles <bcoles[at]gmail.com>'))
     register_options(
       [
-        OptString.new('URL', [ false, 'The URL of a PDF to analyse', '' ]),
-        OptString.new('URL_LIST', [ false, 'File containing a list of PDF URLs to analyze', '' ]),
+        OptString.new('URL', [ false, 'The target URL', '' ]),
+        OptString.new('URL_LIST', [ false, 'File containing a list of target URLs', '' ]),
+        OptEnum.new('URL_TYPE', [ true, 'The type of URL(s) specified', 'html', [ 'pdf', 'html' ] ]),
         OptString.new('OUTFILE', [ false, 'File to store output', '' ])
       ])
     register_advanced_options(
@@ -118,26 +135,9 @@ class MetasploitModule < Msf::Auxiliary
       return
     end
 
-    print_status "HTTP #{res.code} -- Downloaded PDF (#{res.body.length} bytes)"
+    print_status "- HTTP #{res.code} - #{res.body.length} bytes"
 
-    contents = StringIO.new
-    contents.puts res.body
-    contents
-  end
-
-  def write_output(data)
-    return if datastore['OUTFILE'].to_s.eql? ''
-
-    print_status "Writing data to #{datastore['OUTFILE']}..."
-    file_name = datastore['OUTFILE']
-
-    if FileTest::exist?(file_name)
-      print_status 'OUTFILE already exists, appending..'
-    end
-
-    File.open(file_name, 'ab') do |fd|
-      fd.write(data)
-    end
+    res.body
   end
 
   def run
@@ -150,14 +150,50 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     urls = load_urls
+    if datastore['URL_TYPE'].eql? 'html'
+      urls = extract_pdf_links urls
+
+      if urls.empty?
+        print_error 'Found no links to PDF files'
+        return
+      end
+
+      print_line
+      print_good "Found links to #{urls.size} PDF files:"
+      print_line urls.join "\n"
+      print_line
+    end
+
+    extract_authors urls
+  end
+
+  def extract_pdf_links urls
+    print_status "Processing #{urls.size} URLs..."
+    pdf_urls = []
+    urls.each_with_index do |url, index|
+      next if url.blank?
+      html = download url
+      next if html.blank?
+      doc = Nokogiri::HTML html
+      doc.search('a[href]').select { |n| n['href'][/(\.pdf$|\.pdf\?)/] }.map do |n|
+        pdf_urls << URI.join( url, n['href'] ).to_s
+      end
+      progress(index + 1, urls.size)
+    end
+    pdf_urls.uniq!
+  end
+
+  def extract_authors urls
     print_status "Processing #{urls.size} URLs..."
     authors = []
     max_len = 256
     urls.each_with_index do |url, index|
       next if url.blank?
-      contents = download url
-      next if contents.blank?
-      author = read contents
+      file = download url
+      next if file.blank?
+      pdf = StringIO.new
+      pdf.puts file
+      author = read pdf
       unless author.blank?
         print_good "PDF Author: #{author}"
         if author.length > max_len
@@ -169,6 +205,7 @@ class MetasploitModule < Msf::Auxiliary
       end
       progress(index + 1, urls.size)
     end
+    authors.uniq!
 
     print_line
 
@@ -179,5 +216,20 @@ class MetasploitModule < Msf::Auxiliary
 
     print_good "Found #{authors.size} authors: #{authors.join ', '}"
     write_output authors.join "\n"
+  end
+
+  def write_output(data)
+    file_name = datastore['OUTFILE'].to_s
+    return if file_name.eql? ''
+
+    print_status "Writing data to #{file_name}..."
+
+    if FileTest::exist? file_name
+      print_status 'OUTFILE already exists, appending..'
+    end
+
+    File.open(file_name, 'ab') do |fd|
+      fd.write data
+    end
   end
 end

--- a/modules/auxiliary/gather/http_pdf_authors.rb
+++ b/modules/auxiliary/gather/http_pdf_authors.rb
@@ -180,7 +180,7 @@ class MetasploitModule < Msf::Auxiliary
       end
       progress(index + 1, urls.size)
     end
-    pdf_urls.uniq!
+    pdf_urls.uniq
   end
 
   def extract_authors urls


### PR DESCRIPTION
Updated as per discussion in #8658

```
msf auxiliary(http_pdf_authors) > set url_type html
url_type => html
msf auxiliary(http_pdf_authors) > set url http://www.pdf995.com/samples/
url => http://www.pdf995.com/samples/
msf auxiliary(http_pdf_authors) > run

[*] Processing 1 URLs...
[*] Downloading 'http://www.pdf995.com/samples/'
[*] - HTTP 200 - 1068 bytes
[*] 100.00% done (1/1 files)

[+] Found links to 3 PDF files:
http://www.pdf995.com/samples/pdf.pdf
http://www.pdf995.com/samples/pdfeditsample.pdf
http://www.pdf995.com/samples/widgets.pdf

[*] Processing 3 URLs...
[*] Downloading 'http://www.pdf995.com/samples/pdf.pdf'
[*] - HTTP 200 - 433994 bytes
[+] PDF Author: Software 995
[*]  33.33% done (1/3 files)
[*] Downloading 'http://www.pdf995.com/samples/pdfeditsample.pdf'
[*] - HTTP 200 - 386729 bytes
[*]  66.67% done (2/3 files)
[*] Downloading 'http://www.pdf995.com/samples/widgets.pdf'
[*] - HTTP 200 - 59165 bytes
[*] 100.00% done (3/3 files)

[+] Found 1 authors: Software 995
[*] Auxiliary module execution completed
```