### PR TITLE
Remove duplicate setting of suhosin.simulation in php_cgi_arg_injection

### DIFF
--- a/modules/exploits/multi/http/php_cgi_arg_injection.rb
+++ b/modules/exploits/multi/http/php_cgi_arg_injection.rb
@@ -114,7 +114,6 @@ class MetasploitModule < Msf::Exploit::Remote
         create_arg("-d","auto_prepend_file=php://input"),
         create_arg("-d", "cgi.force_redirect=#{rand_php_ini_false}"),
         create_arg("-d", "cgi.redirect_status_env=0"),
-        create_arg("-d", "suhosin.simulation=#{rand_php_ini_true}"),
         rand_opt_equiv("-n")
       ]
 


### PR DESCRIPTION
There is already call for disabling suhosin.simulation:
`create_arg("-d","suhosin.simulation=#{rand_php_ini_true}"),`
after 
`create_arg("-d","safe_mode=#{rand_php_ini_false}"),`
thus remove the duplicate line after
`create_arg("-d", "cgi.redirect_status_env=0"),`