### PR TITLE
HTTP PDF Authors Gather Module: Use Msf::Exploit::Remote::HttpClient

### DIFF
--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -528,7 +528,7 @@ module Exploit::Remote::HttpClient
   #
   # Returns response from a simple URL call
   def request_url(url, keepalive = false)
-    res = send_request_raw(request_options_from_url(url))
+    res = send_request_raw(request_opts_from_url(url))
     disconnect unless keepalive
     return res
   end

--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -525,6 +525,14 @@ module Exploit::Remote::HttpClient
     return opts
   end
 
+  #
+  # Returns response from a simple URL call
+  def request_url(url, keepalive = false)
+    res = send_request_raw(request_options_from_url(url))
+    disconnect unless keepalive
+    return res
+  end
+
   # removes HTML tags from a provided string.
   # The string is html-unescaped before the tags are removed
   # Leading whitespaces and double linebreaks are removed too

--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -508,6 +508,23 @@ module Exploit::Remote::HttpClient
     end
   end
 
+  #
+  # Returns a hash of request opts from a URL string
+  def request_opts_from_url(url)
+    tgt = URI.parse(url)
+    opts = { 'rhost' => tgt.host, 'rport' => tgt.port, 'uri' => tgt.request_uri }
+    opts['SSL'] = true if tgt.scheme == 'https'
+    if tgt.query and tgt.query.size > 13
+      # Assming that this is going to be mostly used for GET requests as string -> req
+      opts['vars_get'] = {}
+      tgt.query.split('&').each do |pair|
+        k,v = pair.split('=',2)
+        opts['vars_get'][k] = v
+      end
+    end
+    return opts
+  end
+
   # removes HTML tags from a provided string.
   # The string is html-unescaped before the tags are removed
   # Leading whitespaces and double linebreaks are removed too

--- a/modules/auxiliary/gather/http_pdf_authors.rb
+++ b/modules/auxiliary/gather/http_pdf_authors.rb
@@ -86,12 +86,9 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def download(url)
-    print_status "Downloading '#{url}'"
+    print_status "Downloading PDF from '#{url}'"
 
-
-    res = send_request_raw(request_options_from_url(url))
-    disconnect
-
+    res = request_url(url)
     print_status "HTTP #{res.code} -- Downloaded PDF (#{res.body.length} bytes)"
 
     return res.code == 200 ? StringIO.new(res.body) : StringIO.new

--- a/modules/auxiliary/gather/http_pdf_authors.rb
+++ b/modules/auxiliary/gather/http_pdf_authors.rb
@@ -88,25 +88,8 @@ class MetasploitModule < Msf::Auxiliary
   def download(url)
     print_status "Downloading '#{url}'"
 
-    begin
-      target = URI.parse url
-      raise 'Invalid URL' unless target.scheme =~ %r{https?}
-      raise 'Invalid URL' if target.host.to_s.eql? ''
-    rescue => e
-      print_error "Could not parse URL: #{e}"
-      return
-    end
 
-    options = {
-      'rhost'  =>  target.host,
-      'rport'  => target.port,
-      'method' => 'GET',
-      'uri'    => target.request_uri
-    }
-
-    options['SSL'] = true if target.scheme.eql? 'https'
-
-    res = send_request_raw(options)
+    res = send_request_raw(request_options_from_url(url))
     disconnect
 
     print_status "HTTP #{res.code} -- Downloaded PDF (#{res.body.length} bytes)"


### PR DESCRIPTION
Replace Net::HTTP usage with proper Rex::Proto::Http::Client via
the Msf module mixin. Generate the request opts from the same URI
parsed URL string, execute a one shot GET request, disconencting
after reciept of results. Depending on the response code, either
pass back an empty StringIO or if its 200, a StringIO(res.body).

## Verification

Before this commit:
```
(2017-07-10)03:42 (S:1 J:6)msf  auxiliary(http_pdf_authors) > exploit

[*] [2017.07.10-03:42:03] Processing 1 URLs...
[*] [2017.07.10-03:42:03] Downloading 'https://www.rapid7.com/docs/Product-Brief-Metasploit.pdf'
[*] [2017.07.10-03:42:03] HTTP 200 -- Downloaded PDF (99167 bytes)
[*] [2017.07.10-03:42:03] 100.00% done (1/1 files)

[*] [2017.07.10-03:42:03] Found no authors
[*] Auxiliary module execution completed
```
After:
```
(2017-07-10)03:42 (S:1 J:6)msf  auxiliary(http_pdf_authors) > reload
[*] Reloading module...
(2017-07-10)03:42 (S:1 J:6)msf  auxiliary(http_pdf_authors) > exploit

[*] [2017.07.10-03:42:18] Processing 1 URLs...
[*] [2017.07.10-03:42:18] Downloading 'https://www.rapid7.com/docs/Product-Brief-Metasploit.pdf'
[*] [2017.07.10-03:42:18] HTTP 200 -- Downloaded PDF (99167 bytes)
[*] [2017.07.10-03:42:18] 100.00% done (1/1 files)

[*] [2017.07.10-03:42:18] Found no authors
[*] Auxiliary module execution completed
```