### PR TITLE
update docker stuff

### DIFF
--- a/docker/bin/msfvenom-dev
+++ b/docker/bin/msfvenom-dev
@@ -17,9 +17,10 @@ if [[ -z "$MSF_PATH" ]]; then
   MSF_PATH=$(dirname $(dirname $path))
 fi
 
+cd $MSF_PATH
+
 if [[ -n "$MSF_BUILD" ]]; then
-  docker-compose -f $MSF_PATH/docker-compose.yml build
+  docker-compose -f $MSF_PATH/docker-compose.yml -f $MSF_PATH/docker/docker-compose.development.override.yml build
 fi
 
-cd $MSF_PATH
-docker-compose run --rm --service-ports ms ./msfvenom "$@"
+docker-compose -f $MSF_PATH/docker-compose.yml -f $MSF_PATH/docker/docker-compose.development.override.yml run --rm --service-ports ms ./msfvenom "$@"

--- a/lib/msf/util.rb
+++ b/lib/msf/util.rb
@@ -21,3 +21,4 @@ end
 
 # Executable generation and encoding
 require 'msf/util/exe'
+require 'msf/util/helper'

--- a/lib/msf/util/helper.rb
+++ b/lib/msf/util/helper.rb
@@ -1,0 +1,19 @@
+# -*- coding: binary -*-
+
+module Msf
+module Util
+class Helper
+  # Cross-platform way of finding an executable in the $PATH.
+  #
+  #   which('ruby') #=> /usr/bin/ruby
+  def self.which(cmd)
+    exts = ENV['PATHEXT'] ? ENV['PATHEXT'].split(';') : ['']
+    ENV['PATH'].split(File::PATH_SEPARATOR).each do |path|
+      exts.each { |ext|
+        exe = File.join(path, "#{cmd}#{ext}")
+        return exe if File.executable?(exe) && !File.directory?(exe)
+      }
+    end
+    return nil
+  end
+end

--- a/lib/msf/util/helper.rb
+++ b/lib/msf/util/helper.rb
@@ -17,3 +17,5 @@ class Helper
     return nil
   end
 end
+end
+end

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -13,6 +13,7 @@ end
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'metasploit/framework/version'
 require 'metasploit/framework/rails_version_constraint'
+require 'msf/util/helper'
 
 Gem::Specification.new do |spec|
   spec.name          = 'metasploit-framework'

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -25,8 +25,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'BSD-3-clause'
 
   # only do a git ls-files if the .git folder exists and we have a git binary in PATH
-  if File.directory?(File.join(File.dirname(__FILE__), ".git")) &&
-      ENV['PATH'].split(':').collect {|d| Dir.entries d if Dir.exists? d}.flatten.include?("git")
+  if File.directory?(File.join(File.dirname(__FILE__), ".git")) && Msf::Util::Helper.which("git")
     spec.files         = `git ls-files`.split($/).reject { |file|
       file =~ /^documentation|^external/
     }

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -24,7 +24,9 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://www.metasploit.com'
   spec.license       = 'BSD-3-clause'
 
-  if File.directory?(File.join(File.dirname(__FILE__), ".git"))
+  # only do a git ls-files if the .git folder exists and we have a git binary in PATH
+  if File.directory?(File.join(File.dirname(__FILE__), ".git")) &&
+      ENV['PATH'].split(':').collect {|d| Dir.entries d if Dir.exists? d}.flatten.include?("git")
     spec.files         = `git ls-files`.split($/).reject { |file|
       file =~ /^documentation|^external/
     }


### PR DESCRIPTION
This PR changes the following:
* Add the rebuild parameter to msfvenom
* Add a msfvenom-dev binstub so the local directory gets mounted
* Fix a bug in the gemspec. Currently we have no git binary in the Dockerfile but when running a `*-dev` binstub the local directory including the `.git` dir is added so we hit this if branch and ruby tries to execute git. This change searches the `PATH` environment variable for a git binary.

Error message before this change (run `MSF_BUILD=1 msfconsole-dev`):
```
[!] There was an error parsing `Gemfile`: 
[!] There was an error while loading `metasploit-framework.gemspec`: No such file or directory - git. Bundler cannot continue.

 #  from /usr/src/metasploit-framework/metasploit-framework.gemspec:28
 #  -------------------------------------------
 #    if File.directory?(File.join(File.dirname(__FILE__), ".git"))
 >      spec.files         = `git ls-files`.split($/).reject { |file|
 #        file =~ /^documentation|^external/
 #  -------------------------------------------
. Bundler cannot continue.

 #  from /usr/src/metasploit-framework/Gemfile:4
 #  -------------------------------------------
 #  #   spec.add_runtime_dependency '<name>', [<version requirements>]
 >  gemspec name: 'metasploit-framework'
 #  
 #  -------------------------------------------
```