### PR TITLE
Fix #8636, [] for NilClass in session.fs.file.download_file

### DIFF
--- a/lib/rex/post/meterpreter/extensions/stdapi/fs/file.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/fs/file.rb
@@ -373,7 +373,7 @@ class File < Rex::Post::Meterpreter::Extensions::Stdapi::Fs::IO
     end
 
     # Keep transferring until EOF is reached...
-    block_size = opts['block_size'] || 1024 * 1024
+    block_size = (opts && opts['block_size']) || 1024 * 1024
     begin
       if tries
         # resume when timeouts encountered


### PR DESCRIPTION
## Description

This fixes a [] for NilClass bug in the download_file API. The opts argument is not checked for nil before the code looks for the block_size key. Multiple post modules are affected by this.

Fix #8636

## Verification

- [x] Start a Windows VM for testing (in this case, I am using XP)
- [x] Obtain a Meterpreter session from the VM
- [x] At the meterpreter prompt, enter ```irb``` to switch to IRB mode
- [x] Download a file: ```client.fs.file.download_file('/tmp/boot.ini', 'C:\\boot.ini')```
- [x] C:\boot.ini should download to /tmp/boot.ini. Without this patch, you should get a ```NoMethodError: undefined method `[]' for nil:NilClass``` error