### PR TITLE
Fix #8685, Check nil condition for #wordlist_file in jtr modules

### DIFF
--- a/modules/auxiliary/analyze/jtr_aix.rb
+++ b/modules/auxiliary/analyze/jtr_aix.rb
@@ -32,6 +32,11 @@ class MetasploitModule < Msf::Auxiliary
 
     # generate our wordlist and close the file handle
     wordlist = wordlist_file
+    unless wordlist
+      print_error('This module cannot run without a database connected. Use db_connect to connect to a database.')
+      return
+    end
+
     wordlist.close
     print_status "Wordlist file written out to #{wordlist.path}"
     cracker.wordlist = wordlist.path

--- a/modules/auxiliary/analyze/jtr_crack_fast.rb
+++ b/modules/auxiliary/analyze/jtr_crack_fast.rb
@@ -31,6 +31,11 @@ class MetasploitModule < Msf::Auxiliary
 
     # generate our wordlist and close the file handle
     wordlist = wordlist_file
+    unless wordlist
+      print_error('This module cannot run without a database connected. Use db_connect to connect to a database.')
+      return
+    end
+
     wordlist.close
     print_status "Wordlist file written out to #{wordlist.path}"
     cracker.wordlist = wordlist.path

--- a/modules/auxiliary/analyze/jtr_linux.rb
+++ b/modules/auxiliary/analyze/jtr_linux.rb
@@ -46,6 +46,11 @@ class MetasploitModule < Msf::Auxiliary
 
     # generate our wordlist and close the file handle
     wordlist = wordlist_file
+    unless wordlist
+      print_error('This module cannot run without a database connected. Use db_connect to connect to a database.')
+      return
+    end
+
     wordlist.close
     print_status "Wordlist file written out to #{wordlist.path}"
     cracker.wordlist = wordlist.path

--- a/modules/auxiliary/analyze/jtr_mssql_fast.rb
+++ b/modules/auxiliary/analyze/jtr_mssql_fast.rb
@@ -33,6 +33,11 @@ class MetasploitModule < Msf::Auxiliary
 
     # generate our wordlist and close the file handle
     wordlist = wordlist_file
+    unless wordlist
+      print_error('This module cannot run without a database connected. Use db_connect to connect to a database.')
+      return
+    end
+
     wordlist.close
     print_status "Wordlist file written out to #{wordlist.path}"
     cracker.wordlist = wordlist.path

--- a/modules/auxiliary/analyze/jtr_mysql_fast.rb
+++ b/modules/auxiliary/analyze/jtr_mysql_fast.rb
@@ -32,6 +32,11 @@ class MetasploitModule < Msf::Auxiliary
 
     # generate our wordlist and close the file handle
     wordlist = wordlist_file
+    unless wordlist
+      print_error('This module cannot run without a database connected. Use db_connect to connect to a database.')
+      return
+    end
+
     wordlist.close
     print_status "Wordlist file written out to #{wordlist.path}"
     cracker.wordlist = wordlist.path

--- a/modules/auxiliary/analyze/jtr_postgres_fast.rb
+++ b/modules/auxiliary/analyze/jtr_postgres_fast.rb
@@ -36,6 +36,11 @@ class MetasploitModule < Msf::Auxiliary
 
     # generate our wordlist and close the file handle
     wordlist = wordlist_file
+    unless wordlist
+      print_error('This module cannot run without a database connected. Use db_connect to connect to a database.')
+      return
+    end
+
     wordlist.close
 
 


### PR DESCRIPTION
## Description

JTR modules should never assume there is always a database connected while using #wordlist_file, considering a database is an optional component for Framework.

Fix #8685

## Verification

- [x] Start msfconsole
- [x] Do: ```db_disconnect```
- [x] Run ```auxiliary/analyze/jtr_linux```
- [x] You should get the error: ```This module cannot run without a database connected. Use db_connect to connect to a database.```