### PR TITLE
Fix #8675, Add Cache-Control header, also meta tag for BAP2

### DIFF
--- a/lib/msf/core/exploit/browser_autopwn2.rb
+++ b/lib/msf/core/exploit/browser_autopwn2.rb
@@ -810,6 +810,7 @@ module Msf
 
       %Q|<html>
       <head>
+      <meta http-equiv="cache-control" content="no-cache" />
       <script>
       #{js}
       </script>

--- a/lib/msf/core/exploit/http/server.rb
+++ b/lib/msf/core/exploit/http/server.rb
@@ -32,6 +32,7 @@ module Exploit::Remote::HttpServer
 
     register_evasion_options(
       [
+        OptBool.new('HTTP::no_cache', [false, 'Disallow the browser to cache HTTP content', false]),
         OptBool.new('HTTP::chunked', [false, 'Enable chunking of HTTP responses via "Transfer-Encoding: chunked"', false]),
         OptBool.new('HTTP::header_folding', [false, 'Enable folding of HTTP headers', false]),
         OptBool.new('HTTP::junk_headers', [false, 'Enable insertion of random junk HTTP headers', false]),
@@ -556,6 +557,10 @@ module Exploit::Remote::HttpServer
 
     if datastore['HTTP::junk_headers']
       response.headers.junk_headers = 1
+    end
+
+    if datastore['HTTP::no_cache']
+      response.headers['Cache-Control'] = 'no-store, no-cache, must-revalidate'
     end
 
     headers.each_pair { |k,v| response[k] = v }

--- a/modules/auxiliary/gather/browser_info.rb
+++ b/modules/auxiliary/gather/browser_info.rb
@@ -74,7 +74,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def on_request_exploit(cli, req, target_info)
     print_target_info(cli, target_info)
-    send_not_found(cli)
+    send_response(cli, '')
   end
 
   def run


### PR DESCRIPTION
## Description

This adds the Cache-Control header and meta tag as an attempt to avoid caching by browsers.

Fix #8675

## Verification

- [x] Start Firefox
- [x] Clear caching for Firefox. You can check it's clear by visiting ```about:cache?storage=disk&context=```
- [x] Start msfconsole
- [x] Do ```use auxiliary/gather/browser_info```
- [x] Do ```set HTTP::no_cache true```
- [x] Do ```run```, the module should give you an URL that firefox should go to
- [x] Visit the URL with firefox
- [x] Open ```about:cache?storage=disk&context=``` again.
- [x] You should see that your malicious URL isn't on the cache list.