### PR TITLE
Fix #8694, Install gnupg2 package instead of gnupg

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,7 +26,7 @@ Vagrant.configure(2) do |config|
   [ #"echo 127.0.1.1 `cat /etc/hostname` >> /etc/hosts", work around a bug in official Ubuntu Xenial cloud images
     "apt-get update",
     "apt-get dist-upgrade -y",
-    "apt-get -y install curl build-essential git tig vim john nmap libpq-dev libpcap-dev gnupg fortune postgresql postgresql-contrib",
+    "apt-get -y install curl build-essential git tig vim john nmap libpq-dev libpcap-dev gnupg2 fortune postgresql postgresql-contrib",
   ].each do |step|
     config.vm.provision "shell", inline: step
   end


### PR DESCRIPTION
This install gnupg2 package (gpg 2) instead of gnupg (gpg 1) package, which currently necessary for rvm GPG verification.
 
Fix #8694

## Verification

List the steps needed to make sure this thing works

- [x] Start `vagrant up`
- [x] **Verify** GPG verification of rvm works by message 'GPG verified':
```
==> default: Downloading https://github.com/rvm/rvm/archive/1.29.2.tar.gz
==> default: Downloading https://github.com/rvm/rvm/releases/download/1.29.2/1.29.2.tar.gz.asc
==> default: gpg: Signature made Thu 22 Jun 2017 04:18:38 PM UTC using RSA key ID BF04FF17
==> default: gpg: Good signature from "Michal Papis (RVM signing) <mpapis@gmail.com>"
==> default: gpg:                 aka "Michal Papis <michal.papis@toptal.com>"
==> default: gpg:                 aka "[jpeg image of size 5015]"
==> default: gpg: WARNING: This key is not certified with a trusted signature!
==> default: gpg:          There is no indication that the signature belongs to the owner.
==> default: Primary key fingerprint: 409B 6B17 96C2 7546 2A17  0311 3804 BB82 D39D C0E3
==> default:      Subkey fingerprint: 62C9 E5F4 DA30 0D94 AC36  166B E206 C29F BF04 FF17
==> default: GPG verified '/home/vagrant/.rvm/archives/rvm-1.29.2.tgz'
```
