### PR TITLE
Lock xpath version to 2.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,32 +66,33 @@ PATH
       windows_error
       xdr
       xmlrpc
+      xpath (= 2.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
     Ascii85 (1.0.2)
-    actionpack (4.2.8)
-      actionview (= 4.2.8)
-      activesupport (= 4.2.8)
+    actionpack (4.2.9)
+      actionview (= 4.2.9)
+      activesupport (= 4.2.9)
       rack (~> 1.6)
       rack-test (~> 0.6.2)
       rails-dom-testing (~> 1.0, >= 1.0.5)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
-    actionview (4.2.8)
-      activesupport (= 4.2.8)
+    actionview (4.2.9)
+      activesupport (= 4.2.9)
       builder (~> 3.1)
       erubis (~> 2.7.0)
       rails-dom-testing (~> 1.0, >= 1.0.5)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
-    activemodel (4.2.8)
-      activesupport (= 4.2.8)
+    activemodel (4.2.9)
+      activesupport (= 4.2.9)
       builder (~> 3.1)
-    activerecord (4.2.8)
-      activemodel (= 4.2.8)
-      activesupport (= 4.2.8)
+    activerecord (4.2.9)
+      activemodel (= 4.2.9)
+      activesupport (= 4.2.9)
       arel (~> 6.0)
-    activesupport (4.2.8)
+    activesupport (4.2.9)
       i18n (~> 0.7)
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
@@ -114,7 +115,7 @@ GEM
     bindata (2.4.0)
     bit-struct (0.16)
     builder (3.2.3)
-    capybara (2.14.3)
+    capybara (2.14.4)
       addressable
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -166,11 +167,11 @@ GEM
       multi_json (~> 1.11)
       os (~> 0.9)
       signet (~> 0.7)
-    grpc (1.4.0)
+    grpc (1.4.1)
       google-protobuf (~> 3.1)
       googleauth (~> 0.5.1)
     hashery (2.1.2)
-    i18n (0.8.4)
+    i18n (0.8.6)
     jsobfu (0.4.2)
       rkelly-remix
     json (2.1.0)
@@ -268,14 +269,14 @@ GEM
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
-    railties (4.2.8)
-      actionpack (= 4.2.8)
-      activesupport (= 4.2.8)
+    railties (4.2.9)
+      actionpack (= 4.2.9)
+      activesupport (= 4.2.9)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (12.0.0)
     rb-readline (0.5.4)
-    recog (2.1.10)
+    recog (2.1.11)
       nokogiri
     redcarpet (3.4.0)
     rex-arch (0.1.9)
@@ -286,7 +287,7 @@ GEM
       rex-core
       rex-struct2
       rex-text
-    rex-core (0.1.10)
+    rex-core (0.1.11)
     rex-encoder (0.1.4)
       metasm
       rex-arch
@@ -375,7 +376,7 @@ GEM
     sshkey (1.9.0)
     thor (0.19.4)
     thread_safe (0.3.6)
-    timecop (0.9.0)
+    timecop (0.9.1)
     ttfunk (1.5.1)
     tzinfo (1.2.3)
       thread_safe (~> 0.1)
@@ -386,7 +387,7 @@ GEM
       activemodel (>= 4.2.7)
       activesupport (>= 4.2.7)
     xmlrpc (0.3.0)
-    xpath (2.1.0)
+    xpath (2.0.0)
       nokogiri (~> 1.3)
     yard (0.9.9)
 

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -184,4 +184,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'nexpose'
   # Needed for NDMP sockets
   spec.add_runtime_dependency 'xdr'
+  # Needed for the xpath
+  spec.add_runtime_dependency 'xpath', '2.0'
 end


### PR DESCRIPTION
This PR locks xpath to version 2.0. Current Pro-Framework integration tests are failing due to versioning issues with xpath. This should resolve the issue.

## Verification

- [ ] Verify tests pass