### PR TITLE
Rex::Encoder::XDR conflicts with the XDR gem

### DIFF
--- a/lib/msf/core/exploit/sunrpc.rb
+++ b/lib/msf/core/exploit/sunrpc.rb
@@ -16,8 +16,6 @@ module Msf
 module Exploit::Remote::SunRPC
   include Exploit::Remote::Tcp
 
-  XDR = Rex::Encoder::XDR
-
   MSG_ACCEPTED = 0
   SUCCESS = 0		# RPC executed successfully
   PROG_UMAVAIL = 1	# Remote hasn't exported program
@@ -72,7 +70,7 @@ module Exploit::Remote::SunRPC
     ret = rpcobj.create
     raise ::Rex::Proto::SunRPC::RPCError, "#{rhost}:#{rport} - SunRPC - No response to Portmap request" unless ret
 
-    arr = XDR.decode!(ret, Integer, Integer, Integer, String, Integer, Integer)
+    arr = Rex::Encoder::XDR.decode!(ret, Integer, Integer, Integer, String, Integer, Integer)
     if arr[1] != MSG_ACCEPTED || arr[4] != SUCCESS || arr[5] == 0
       err = "#{rhost}:#{rport} - SunRPC - Portmap request failed: "
       err << 'Message not accepted'  if arr[1] != MSG_ACCEPTED

--- a/modules/auxiliary/admin/sunrpc/solaris_kcms_readfile.rb
+++ b/modules/auxiliary/admin/sunrpc/solaris_kcms_readfile.rb
@@ -66,14 +66,14 @@ class MetasploitModule < Msf::Auxiliary
 
     # Prepare the traversing request for kcms_server
     trav = 'TT_DB/' + ('../' * 5) + path
-    buf = XDR.encode(
+    buf = Rex::Encoder::XDR.encode(
       [trav, 1024],
       0, # O_RDONLY
       0755) # mode
 
     # Make the request
     ret = sunrpc_call(1003, buf)
-    ack, fsize, fd = XDR.decode!(ret, Integer, Integer, Integer)
+    ack, fsize, fd = Rex::Encoder::XDR.decode!(ret, Integer, Integer, Integer)
 
     if (ack != 0)
       print_error("KCMS open() failed (ack: 0x%x != 0)" % ack)
@@ -88,13 +88,13 @@ class MetasploitModule < Msf::Auxiliary
     print_status("fd: #{fd}, file size #{fsize}")
 
     print_status("Making read() request to the kcms_server...")
-    buf = XDR.encode(
+    buf = Rex::Encoder::XDR.encode(
       fd,
       0,
       fsize)
 
     ret = sunrpc_call(1005, buf)
-    x, data = XDR.decode!(ret, Integer, [Integer])
+    x, data = Rex::Encoder::XDR.decode!(ret, Integer, [Integer])
 
     # If we got something back...
     if (data)
@@ -118,7 +118,7 @@ class MetasploitModule < Msf::Auxiliary
 
     # Close it regardless if it returned anything..
     print_status("Making close() request to the kcms_server...")
-    buf = XDR.encode(fd)
+    buf = Rex::Encoder::XDR.encode(fd)
     sunrpc_call(1004, buf)
 
     # done
@@ -138,7 +138,7 @@ class MetasploitModule < Msf::Auxiliary
   def ttdb_build(path)
     sunrpc_create('tcp', 100083, 1)
     sunrpc_authunix('localhost', 0, 0, [])
-    msg = XDR.encode(
+    msg = Rex::Encoder::XDR.encode(
       [path, 1024],
       path.length,
       1, # KEY (VArray head?)
@@ -152,7 +152,7 @@ class MetasploitModule < Msf::Auxiliary
       0x10002,
       path.length)
     ret = sunrpc_call(3, msg)
-    arr = XDR.decode!(ret, Integer, Integer)
+    arr = Rex::Encoder::XDR.decode!(ret, Integer, Integer)
     print_status("TTDB reply: 0x%x, %d" % arr)
     sunrpc_destroy
   end

--- a/modules/auxiliary/scanner/misc/sunrpc_portmapper.rb
+++ b/modules/auxiliary/scanner/misc/sunrpc_portmapper.rb
@@ -40,8 +40,8 @@ class MetasploitModule < Msf::Auxiliary
       progs = resp[3, 1].unpack('C')[0]
       maps = []
       if (progs == 0x01)
-        while XDR.decode_int!(resp) == 1
-          maps << XDR.decode!(resp, Integer, Integer, Integer, Integer)
+        while Rex::Encoder::XDR.decode_int!(resp) == 1
+          maps << Rex::Encoder::XDR.decode!(resp, Integer, Integer, Integer, Integer)
         end
       end
       sunrpc_destroy

--- a/modules/auxiliary/scanner/nfs/nfsmount.rb
+++ b/modules/auxiliary/scanner/nfs/nfsmount.rb
@@ -56,11 +56,11 @@ class MetasploitModule < Msf::Auxiliary
       exports = resp[3,1].unpack('C')[0]
       if (exports == 0x01)
         shares = []
-        while XDR.decode_int!(resp) == 1 do
-          dir = XDR.decode_string!(resp)
+        while Rex::Encoder::XDR.decode_int!(resp) == 1 do
+          dir = Rex::Encoder::XDR.decode_string!(resp)
           grp = []
-          while XDR.decode_int!(resp) == 1 do
-            grp << XDR.decode_string!(resp)
+          while Rex::Encoder::XDR.decode_int!(resp) == 1 do
+            grp << Rex::Encoder::XDR.decode_string!(resp)
           end
           print_good("#{ip} NFS Export: #{dir} [#{grp.join(", ")}]")
           shares << [dir, grp]

--- a/modules/exploits/aix/rpc_cmsd_opcode21.rb
+++ b/modules/exploits/aix/rpc_cmsd_opcode21.rb
@@ -83,7 +83,7 @@ class MetasploitModule < Msf::Exploit::Remote
       # spray the heap a bit (work around powerpc cache issues)
       buf = make_nops(1024 - @aixpayload.length)
       buf << @aixpayload
-      xdr = XDR.encode(buf, buf)
+      xdr = Rex::Encoder::XDR.encode(buf, buf)
       10.times {
         sunrpc_call(7, xdr, 2)
       }
@@ -93,7 +93,7 @@ class MetasploitModule < Msf::Exploit::Remote
       buf = rand_text_alphanumeric(payload_space)
       buf << [brute_target['Ret']].pack('N')
 
-      xdr = XDR.encode(buf, "")
+      xdr = Rex::Encoder::XDR.encode(buf, "")
       sunrpc_authunix('localhost', 0, 0, [])
       sunrpc_call(21, xdr, 2)
 

--- a/modules/exploits/aix/rpc_ttdbserverd_realpath.rb
+++ b/modules/exploits/aix/rpc_ttdbserverd_realpath.rb
@@ -262,7 +262,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
       buf << "\x7f\xff\xfb\x78" * 1920
       buf << @aixpayload
-      buf = XDR.encode(buf, 2, 0x78000000, 2, 0x78000000)
+      buf = Rex::Encoder::XDR.encode(buf, 2, 0x78000000, 2, 0x78000000)
 
       print_status('Sending procedure 15 call message...')
       sunrpc_call(15, buf)

--- a/modules/exploits/solaris/sunrpc/sadmind_adm_build_path.rb
+++ b/modules/exploits/solaris/sunrpc/sadmind_adm_build_path.rb
@@ -121,8 +121,8 @@ class MetasploitModule < Msf::Exploit::Remote
     buf2 = @nops + payload.encoded
 
     header =
-      XDR.encode(0) * 7 +
-      XDR.encode(6, 0, 0, 0, 4, 0, 4, 0x7f000001, 100232, 10,
+      Rex::Encoder::XDR.encode(0) * 7 +
+      Rex::Encoder::XDR.encode(6, 0, 0, 0, 4, 0, 4, 0x7f000001, 100232, 10,
         4, 0x7f000001, 100232, 10, 17, 30, 0, 0, 0, 0,
         hostname, 'system', rand_text_alpha(16))
 
@@ -139,9 +139,9 @@ class MetasploitModule < Msf::Exploit::Remote
       do_string('ADM_TIMEOUT_PARMS', 'TTL=0 PTO=20 PCNT=2 PDLY=30') +
       do_int('ADM_FENCE', 0) +
       do_string('X', buf2) +
-      XDR.encode('netmgt_endofargs')
+      Rex::Encoder::XDR.encode('netmgt_endofargs')
 
-    request = header + XDR.encode(header.length + body.length - 326) + body
+    request = header + Rex::Encoder::XDR.encode(header.length + body.length - 326) + body
 
     begin
       # two seconds timeout for brute force
@@ -157,11 +157,11 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def do_string(str1, str2)
-    XDR.encode(str1, 9, str2.length + 1, str2, 0, 0)
+    Rex::Encoder::XDR.encode(str1, 9, str2.length + 1, str2, 0, 0)
   end
 
   def do_int(str, int)
-    XDR.encode(str, 3, 4, int, 0, 0)
+    Rex::Encoder::XDR.encode(str, 3, 4, int, 0, 0)
   end
 
 end

--- a/modules/exploits/solaris/sunrpc/sadmind_exec.rb
+++ b/modules/exploits/solaris/sunrpc/sadmind_exec.rb
@@ -97,8 +97,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def sadmind_request(host, command)
     header =
-      XDR.encode(0) * 7 +
-      XDR.encode(6, 0, 0, 0, 4, 0, 4, 0x7f000001, 100232, 10,
+      Rex::Encoder::XDR.encode(0) * 7 +
+      Rex::Encoder::XDR.encode(6, 0, 0, 0, 4, 0, 4, 0x7f000001, 100232, 10,
         4, 0x7f000001, 100232, 10, 17, 30, 0, 0, 0, 0,
         host, 'system', '../../../bin/sh')
 
@@ -116,19 +116,19 @@ class MetasploitModule < Msf::Exploit::Remote
       do_int('ADM_FENCE', 0) +
       do_string('X', '-c') +
       do_string('Y', command) +
-      XDR.encode('netmgt_endofargs')
+      Rex::Encoder::XDR.encode('netmgt_endofargs')
 
-    request = header + XDR.encode(header.length + body.length - 326) + body
+    request = header + Rex::Encoder::XDR.encode(header.length + body.length - 326) + body
 
     ret = sunrpc_call(1, request)
-    return XDR.decode!(ret, Integer, Integer, String)[2]
+    return Rex::Encoder::XDR.decode!(ret, Integer, Integer, String)[2]
   end
 
   def do_string(str1, str2)
-    XDR.encode(str1, 9, str2.length + 1, str2, 0, 0)
+    Rex::Encoder::XDR.encode(str1, 9, str2.length + 1, str2, 0, 0)
   end
 
   def do_int(str, int)
-    XDR.encode(str, 3, 4, int, 0, 0)
+    Rex::Encoder::XDR.encode(str, 3, 4, int, 0, 0)
   end
 end

--- a/modules/exploits/solaris/sunrpc/ypupdated_exec.rb
+++ b/modules/exploits/solaris/sunrpc/ypupdated_exec.rb
@@ -69,7 +69,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status('Waiting for response...')
     sunrpc_authunix(hostname, datastore['UID'], datastore['GID'], [])
     command = '|' + payload.encoded
-    msg = XDR.encode(command, 2, 0x78000000, 2, 0x78000000)
+    msg = Rex::Encoder::XDR.encode(command, 2, 0x78000000, 2, 0x78000000)
     sunrpc_call(procedure, msg)
 
     sunrpc_destroy

--- a/modules/exploits/windows/brightstor/mediasrv_sunrpc.rb
+++ b/modules/exploits/windows/brightstor/mediasrv_sunrpc.rb
@@ -262,7 +262,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     data = "_" + data + "_1_1_1_1_1_1_1_1_1"
 
-    request = XDR.encode(1, 1, 2, 2, 2, data, 3, 3)
+    request = Rex::Encoder::XDR.encode(1, 1, 2, 2, 2, data, 3, 3)
 
     print_status("Trying target #{target.name}...")
 

--- a/modules/exploits/windows/emc/networker_format_string.rb
+++ b/modules/exploits/windows/emc/networker_format_string.rb
@@ -108,7 +108,7 @@ class MetasploitModule < Msf::Exploit::Remote
       end
       fs << payload.encoded
 
-      xdr = XDR.encode(0, 2, rand_text_alpha(10), XDR.encode(fs, rand_text_alpha(10)), 2)
+      xdr = Rex::Encoder::XDR.encode(0, 2, rand_text_alpha(10), Rex::Encoder::XDR.encode(fs, rand_text_alpha(10)), 2)
       sunrpc_call(6, xdr)
       sunrpc_destroy
 


### PR DESCRIPTION
The XDR gem that came along for the ride with the Backupexec module conflicts with the SunRPC mixin (which also tries to define XDR), and thus ever module that uses that mixin fails. This explicitly spells out Rex::Encoder::XDR to disambiguate.

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/nfs/nfsmount`
- [x] **Verify** that you are able to scan for an nfsmount without failures

