### PR TITLE
Update stdin processing in resource scripting

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/resource.rb
+++ b/lib/msf/ui/console/command_dispatcher/resource.rb
@@ -37,8 +37,8 @@ module Msf
           def cmd_resource_help
             print_line "Usage: resource path1 [path2 ...]"
             print_line
-            print_line "Run the commands stored in the supplied files.  Resource files may also contain"
-            print_line "ruby code between <ruby></ruby> tags."
+            print_line "Run the commands stored in the supplied files (- for stdin)."
+            print_line "Resource files may also contain ERB or Ruby code between <ruby></ruby> tags."
             print_line
             print_line "See also: makerc"
             print_line
@@ -52,20 +52,22 @@ module Msf
 
             args.each do |res|
               good_res = nil
-              if ::File.exist?(res)
+              if res == '-'
+                good_res = res
+              elsif ::File.exist?(res)
                 good_res = res
               elsif
                 # let's check to see if it's in the scripts/resource dir (like when tab completed)
-              [
-                ::Msf::Config.script_directory + ::File::SEPARATOR + "resource",
-                ::Msf::Config.user_script_directory + ::File::SEPARATOR + "resource"
-              ].each do |dir|
-                res_path = dir + ::File::SEPARATOR + res
-                if ::File.exist?(res_path)
-                  good_res = res_path
-                  break
+                [
+                  ::Msf::Config.script_directory + ::File::SEPARATOR + "resource",
+                  ::Msf::Config.user_script_directory + ::File::SEPARATOR + "resource"
+                ].each do |dir|
+                  res_path = dir + ::File::SEPARATOR + res
+                  if ::File.exist?(res_path)
+                    good_res = res_path
+                    break
+                  end
                 end
-              end
               end
               if good_res
                 driver.load_resource(good_res)


### PR DESCRIPTION
Originally in #4674, I wanted to add `stdin` to `msfconsole -r`, but I purposefully left off support for `stdin` in the console. Now it works.

- [x] Test `resource -` in the console
- [x] Test for ERB
- [x] Test for `<ruby></ruby>`

**Before:**

```
msf > help resource 
Usage: resource path1 [path2 ...]

Run the commands stored in the supplied files.  Resource files may also contain
ruby code between <ruby></ruby> tags.

See also: makerc

msf > resource -
[-] - is not a valid resource file
msf > 
```

**After:**

```
msf > help resource 
Usage: resource path1 [path2 ...]

Run the commands stored in the supplied files (- for stdin).
Resource files may also contain ERB or Ruby code between <ruby></ruby> tags.

See also: makerc

msf > resource -
use <%= 'exploit/windows/smb/ms08_067_netapi'.sub('ms08_067_netapi', 'ms17_010_eternalblue') %>
<ruby>
print_status('MS17-010 is the new MS08-067')
</ruby>
[*] Processing stdin for ERB directives.
resource (stdin)> use exploit/windows/smb/ms17_010_eternalblue
[*] resource (stdin)> Ruby Code (45 bytes)
[*] MS17-010 is the new MS08-067
msf exploit(ms17_010_eternalblue) > 
```