### PR TITLE
Default opts to an empty hash instead of nil

### DIFF
--- a/lib/rex/post/meterpreter/extensions/stdapi/fs/dir.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/fs/dir.rb
@@ -195,19 +195,15 @@ class Dir < Rex::Post::Dir
   # Downloads the contents of a remote directory a
   # local directory, optionally in a recursive fashion.
   #
-  def Dir.download(dst, src, opts, force = true, glob = nil, &stat)
-    recursive = false
-    continue = false
-    tries = false
-    tries_no = 0
+  def Dir.download(dst, src, opts = {}, force = true, glob = nil, &stat)
     tries_cnt = 0
-    if opts
-      timestamp = opts["timestamp"]
-      recursive = true if opts["recursive"]
-      continue = true if opts["continue"]
-      tries = true if opts["tries"]
-      tries_no = opts["tries_no"]
-    end
+
+    continue =  opts["continue"]
+    recursive = opts["recursive"]
+    timestamp = opts["timestamp"]
+    tries_no = opts["tries_no"] || 0
+    tries = opts["tries"]
+
     begin
       dir_files = self.entries(src, glob)
     rescue Rex::TimeoutError

--- a/lib/rex/post/meterpreter/extensions/stdapi/fs/file.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/fs/file.rb
@@ -301,8 +301,8 @@ class File < Rex::Post::Meterpreter::Extensions::Stdapi::Fs::IO
   # If a block is given, it will be called before each file is downloaded and
   # again when each download is complete.
   #
-  def File.download(dest, src_files, opts = nil, &stat)
-    timestamp = opts["timestamp"] if opts
+  def File.download(dest, src_files, opts = {}, &stat)
+    timestamp = opts["timestamp"]
     [*src_files].each { |src|
       if (::File.basename(dest) != File.basename(src))
         # The destination when downloading is a local file so use this
@@ -324,18 +324,15 @@ class File < Rex::Post::Meterpreter::Extensions::Stdapi::Fs::IO
   #
   # Download a single file.
   #
-  def File.download_file(dest_file, src_file, opts = nil, &stat)
-    continue=false
-    tries=false
-    tries_no=0
+  def File.download_file(dest_file, src_file, opts = {}, &stat)
     stat ||= lambda { |a,b,c| }
 
-    if opts
-      continue = true if opts["continue"]
-      adaptive = true if opts['adaptive']
-      tries = true if opts["tries"]
-      tries_no = opts["tries_no"]
-    end
+    adaptive = opts["adaptive"]
+    block_size = opts["block_size"] || 1024 * 1024
+    continue = opts["continue"]
+    tries_no = opts["tries_no"]
+    tries = opts["tries"]
+
     src_fd = client.fs.file.new(src_file, "rb")
 
     # Check for changes
@@ -373,7 +370,6 @@ class File < Rex::Post::Meterpreter::Extensions::Stdapi::Fs::IO
     end
 
     # Keep transferring until EOF is reached...
-    block_size = (opts && opts['block_size']) || 1024 * 1024
     begin
       if tries
         # resume when timeouts encountered


### PR DESCRIPTION
Fixes #8709

Mentioned here: https://www.reddit.com/r/metasploit/comments/6mwhqb/help_with_post_exploitation/

## Verification

- [x] Start `msfconsole`
- [x] get a windows meterpreter shell on a box with chrome installed
- [x] Make sure the `download` command still works
  - [x] put a file somewhere you can find it
  - [x] `download` the file
  - [x] **Verify** local copy of file is correct
- [x] Make sure the module mentioned in the ticket works
  - [x] migrate to a process owned by the user who installed chrome
  - [x] `use post/windows/gather/enum_chrome`
  - [x] `run`
  - [x] **Verify** no stack trace

