### PR TITLE
Psexec via PSH related fixes

### DIFF
--- a/lib/msf/core/exploit/powershell.rb
+++ b/lib/msf/core/exploit/powershell.rb
@@ -18,7 +18,6 @@ module Exploit::Powershell
         OptBool.new('Powershell::noninteractive', [true, 'Execute powershell without interaction', true]),
         OptBool.new('Powershell::encode_final_payload', [true, 'Encode final payload for -EncodedCommand', false]),
         OptBool.new('Powershell::encode_inner_payload', [true, 'Encode inner payload for -EncodedCommand', false]),
-        OptBool.new('Powershell::use_single_quotes', [true, 'Wraps the -Command argument in single quotes', false]),
         OptBool.new('Powershell::no_equals', [true, 'Pad base64 until no "=" remains', false]),
         OptEnum.new('Powershell::method', [true, 'Payload delivery method', 'reflection', %w[net reflection old msil]])
       ]
@@ -223,7 +222,7 @@ module Exploit::Powershell
   # @return [String] Powershell command line with payload
   def cmd_psh_payload(pay, payload_arch, opts = {})
     %i[persist prepend_sleep exec_in_place encode_final_payload encode_inner_payload
-    remove_comspec noninteractive use_single_quotes no_equals method].map do |opt|
+    remove_comspec noninteractive no_equals method].map do |opt|
       opts[opt] ||= datastore["Powershell::#{opt}"]
     end
 

--- a/lib/msf/core/exploit/powershell.rb
+++ b/lib/msf/core/exploit/powershell.rb
@@ -18,6 +18,7 @@ module Exploit::Powershell
         OptBool.new('Powershell::noninteractive', [true, 'Execute powershell without interaction', true]),
         OptBool.new('Powershell::encode_final_payload', [true, 'Encode final payload for -EncodedCommand', false]),
         OptBool.new('Powershell::encode_inner_payload', [true, 'Encode inner payload for -EncodedCommand', false]),
+        OptBool.new('Powershell::wrap_double_quotes', [true, 'Wraps the -Command argument in single quotes', true]),
         OptBool.new('Powershell::no_equals', [true, 'Pad base64 until no "=" remains', false]),
         OptEnum.new('Powershell::method', [true, 'Payload delivery method', 'reflection', %w[net reflection old msil]])
       ]
@@ -216,13 +217,13 @@ module Exploit::Powershell
   #   powershell script
   # @option opts [Boolean] :remove_comspec Removes the %COMSPEC%
   #   environment variable at the start of the command line
-  # @option opts [Boolean] :use_single_quotes Wraps the -Command
-  #   argument in single quotes unless :encode_final_payload
+  # @option opts [Boolean] :wrap_double_quotes Wraps the -Command
+  #   argument in double quotes unless :encode_final_payload
   #
   # @return [String] Powershell command line with payload
   def cmd_psh_payload(pay, payload_arch, opts = {})
     %i[persist prepend_sleep exec_in_place encode_final_payload encode_inner_payload
-    remove_comspec noninteractive no_equals method].map do |opt|
+    remove_comspec noninteractive wrap_double_quotes no_equals method].map do |opt|
       opts[opt] ||= datastore["Powershell::#{opt}"]
     end
 

--- a/lib/msf/core/exploit/powershell.rb
+++ b/lib/msf/core/exploit/powershell.rb
@@ -14,6 +14,8 @@ module Exploit::Powershell
         OptBool.new('Powershell::sub_vars', [true, 'Substitute variable names', false]),
         OptBool.new('Powershell::sub_funcs', [true, 'Substitute function names', false]),
         OptBool.new('Powershell::exec_in_place', [true, 'Produce PSH without executable wrapper', false]),
+        OptBool.new('Powershell::remove_comspec', [true, 'Produce script calling powershell directly', false]),
+        OptBool.new('Powershell::noninteractive', [true, 'Execute powershell without interaction', true]),
         OptBool.new('Powershell::encode_final_payload', [true, 'Encode final payload for -EncodedCommand', false]),
         OptBool.new('Powershell::encode_inner_payload', [true, 'Encode inner payload for -EncodedCommand', false]),
         OptBool.new('Powershell::use_single_quotes', [true, 'Wraps the -Command argument in single quotes', false]),
@@ -220,9 +222,8 @@ module Exploit::Powershell
   #
   # @return [String] Powershell command line with payload
   def cmd_psh_payload(pay, payload_arch, opts = {})
-    options.validate(datastore)
-
-    %i[persist prepend_sleep exec_in_place encode_final_payload encode_inner_payload use_single_quotes no_equals method].map do |opt|
+    %i[persist prepend_sleep exec_in_place encode_final_payload encode_inner_payload
+    remove_comspec noninteractive use_single_quotes no_equals method].map do |opt|
       opts[opt] ||= datastore["Powershell::#{opt}"]
     end
 

--- a/spec/lib/msf/core/exploit/powershell_spec.rb
+++ b/spec/lib/msf/core/exploit/powershell_spec.rb
@@ -276,11 +276,13 @@ RSpec.describe Msf::Exploit::Powershell do
       end
       it 'shouldnt shorten args' do
         code = subject.cmd_psh_payload(payload, arch)
-        expect(code.include?('-NoProfile -WindowStyle hidden -Command')).to be_truthy
+        expect(code.include?('-NoProfile ')).to be_truthy
+        expect(code.include?('-WindowStyle hidden')).to be_truthy
+        expect(code.include?('-Command ')).to be_truthy
       end
       it 'should include -NoExit' do
         code = subject.cmd_psh_payload(payload, arch)
-        expect(code.include?('-NoProfile -WindowStyle hidden -NoExit -Command')).to be_truthy
+        expect(code.include?('-NoExit ')).to be_truthy
       end
     end
 


### PR DESCRIPTION
Implement removal of comspec and use of the noninteractive option
in powershell payloads.

This is the Msf side of #6 for [rex-powershell.](https://github.com/rapid7/rex-powershell/pull/6)

Testing:
  In-house testing on 2016 standard edition and win10, 201707 revs.

## Verification

List the steps needed to make sure this thing works

- [ ] Pull in [Rex PR](https://github.com/rapid7/rex-powershell/pull/6) and this one
- [ ] Start `msfconsole`
- [ ] `use exploit/windows/smb/psexec`
- [ ] set RHOST to a 2016 server, use valid administrator credentials (.\administrator)
- [ ] **Verify** The module authenticates, executes, and returns a shell
- [ ] **Verify** the thing does not get caught for invoke-expression or other malicious text

