### PR TITLE
Fix a php warning

### DIFF
--- a/lib/msf/core/payload/php.rb
+++ b/lib/msf/core/payload/php.rb
@@ -103,7 +103,7 @@ module Msf::Payload::Php
       }else"
     proc_open = "
       if(#{is_callable}('proc_open')and!#{in_array}('proc_open',#{dis})){
-        $handle=proc_open(#{cmd},array(array(pipe,'r'),array(pipe,'w'),array(pipe,'w')),$pipes);
+        $handle=proc_open(#{cmd},array(array('pipe','r'),array('pipe','w'),array('pipe','w')),$pipes);
         #{output}=NULL;
         while(!feof($pipes[1])){
           #{output}.=fread($pipes[1],1024);


### PR DESCRIPTION
This should close #8670

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Use whatever exploit to uses a `php` payload
- [x] `exploit`
- [x] Check that no warning appears anymore in the web server logs.
