### PR TITLE
bump prerelease gems to fix specific issues with Framework

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,12 @@ source 'https://rubygems.org'
 #   spec.add_runtime_dependency '<name>', [<version requirements>]
 gemspec name: 'metasploit-framework'
 
+# These pull in pre-release gems in order to fix specific issues.
+# XXX https://github.com/alexdalitz/dnsruby/pull/134
+gem 'dnsruby', git: 'https://github.com/alexdalitz/dnsruby'
+# XXX https://github.com/ConnorAtherton/rb-readline/commit/fd882edcd145c26681f9971be5f6675c7f6d1970
+gem 'rb-readline', git: 'https://github.com/ConnorAtherton/rb-readline'
+
 # separate from test as simplecov is not run on travis-ci
 group :coverage do
   # code coverage for tests

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,15 @@
+GIT
+  remote: https://github.com/ConnorAtherton/rb-readline
+  revision: fd882edcd145c26681f9971be5f6675c7f6d1970
+  specs:
+    rb-readline (0.5.4)
+
+GIT
+  remote: https://github.com/alexdalitz/dnsruby
+  revision: 09c3890ccfaedb7fd4951f56575d5c53651e0140
+  specs:
+    dnsruby (1.60.1)
+
 PATH
   remote: .
   specs:
@@ -109,7 +121,6 @@ GEM
     builder (3.2.3)
     coderay (1.1.1)
     diff-lcs (1.3)
-    dnsruby (1.60.1)
     docile (1.1.5)
     erubis (2.7.0)
     factory_girl (4.8.0)
@@ -234,7 +245,6 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (12.0.0)
-    rb-readline (0.5.4)
     recog (2.1.11)
       nokogiri
     redcarpet (3.4.0)
@@ -350,6 +360,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  dnsruby!
   factory_girl_rails
   fivemat
   metasploit-aggregator
@@ -357,6 +368,7 @@ DEPENDENCIES
   octokit
   pry
   rake
+  rb-readline!
   redcarpet
   rspec-rails
   rspec-rerun

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,6 +35,7 @@ RUN apk update && \
       yaml-dev \
       zlib-dev \
       ncurses-dev \
+      git \
     && echo "gem: --no-ri --no-rdoc" > /etc/gemrc \
     && bundle install --system $BUNDLER_ARGS \
     && apk del .ruby-builddeps \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,7 +24,6 @@ RUN apk update && \
       bison \
       build-base \
       ruby-dev \
-      libffi-dev\
       openssl-dev \
       readline-dev \
       sqlite-dev \


### PR DESCRIPTION
rb-readline has an issue with the latest curses release, which causes `\r` characters to appear after every line

Fix #8725: dnsruby changes the global thread behavior to abort on exception, this pulls in the head version to undo this.
