### PR TITLE
added robots.txt support for http exploit server

### DIFF
--- a/lib/msf/core/exploit/http/server.rb
+++ b/lib/msf/core/exploit/http/server.rb
@@ -629,9 +629,9 @@ module Exploit::Remote::HttpServer
   # Sends a canned robots.txt file
   #
   def send_robots(cli, request)
-	print_status("sending robots.txt")
+    print_status("sending robots.txt")
     robots = create_response(200, 'Success')
-	robots['Content-Type'] = "text/plain"
+    robots['Content-Type'] = "text/plain"
 
     robots.body = %Q{\
 User-agent: *

--- a/lib/msf/core/exploit/http/server.rb
+++ b/lib/msf/core/exploit/http/server.rb
@@ -42,7 +42,8 @@ module Exploit::Remote::HttpServer
 
     register_advanced_options([
       OptAddress.new('URIHOST', [false, 'Host to use in URI (useful for tunnels)']),
-      OptPort.new('URIPORT', [false, 'Port to use in URI (useful for tunnels)'])
+      OptPort.new('URIPORT', [false, 'Port to use in URI (useful for tunnels)']),
+      OptBool.new('SendRobots', [ false, "Return a robots.txt file if asked for one", false]),
     ])
 
     # Used to keep track of resources added to the service manager by
@@ -179,7 +180,26 @@ module Exploit::Remote::HttpServer
       print_status("Local IP: #{proto}://#{Rex::Socket.source_address('1.2.3.4')}:#{opts['ServerPort']}#{uopts['Path']}")
     end
 
+    if datastore['SendRobots']
+      add_robots_resource()
+    end
+
     add_resource(uopts)
+
+  end
+
+  def add_robots_resource()
+    proc = Proc.new do |cli, req|
+      self.cli = cli
+      send_robots(cli, req)
+    end
+
+    vprint_status("Adding hardcoded uri /robots.txt")
+    begin
+      add_resource({'Path' => "/robots.txt", 'Proc' => proc})
+    rescue RuntimeError => e
+      print_warning(e.message)
+    end
   end
 
   # Set {#on_request_uri} to handle the given +uri+ in addition to the one
@@ -603,6 +623,22 @@ module Exploit::Remote::HttpServer
 }
 
     cli.send_response(resp_404)
+  end
+
+  #
+  # Sends a canned robots.txt file
+  #
+  def send_robots(cli, request)
+	print_status("sending robots.txt")
+    robots = create_response(200, 'Success')
+	robots['Content-Type'] = "text/plain"
+
+    robots.body = %Q{\
+User-agent: *
+Disallow: /
+}
+
+    cli.send_response(robots)
   end
 
 


### PR DESCRIPTION
Fixes #8701

This pull request adds an advanced option, sendrobots, to return a robots.txt file when one is requested at /robots.txt. This change affects all exploits that use the http server module to serve up content. It has been tested to ensure that running multiple exploits at the same time will work properly. However, if the sendrobots option is set in one exploit and turned off in another, the option in effect with the server module was started will have precedence.

The feature is  off by default but I think there is room for debate about whether it should default to on. I left it off so that the new feature doesn't break the existing behavior of the server.
 
I also intentionally left out the request for adding the robots meta tag. Exploits that use this module are responsible for building the entire body of the html returned. Trying to implement this feature in every exploit the uses the module seemed like an overly intrusive solution. In normal usage, where a random URI is generated, I'm not sure that adding the header will increase the opsec of the server much anyway.  

## Verification

- [x] Start exploit/multi/browser/firefox_xpi_bootstrapped_addon using the default options.

```
msf > use exploit/multi/browser/firefox_xpi_bootstrapped_addon
msf exploit(firefox_xpi_bootstrapped_addon) > set disablepayloadhandler true
disablepayloadhandler => true
msf exploit(firefox_xpi_bootstrapped_addon) > set verbose true
verbose => true
msf exploit(firefox_xpi_bootstrapped_addon) > set sendrobots
sendrobots => false
msf exploit(firefox_xpi_bootstrapped_addon) > run
[*] Exploit running as background job.
msf exploit(firefox_xpi_bootstrapped_addon) >
[*] Using URL: http://0.0.0.0:8080/1fpbKdz95SdjFm
[*] Local IP: http://192.168.24.10:8080/1fpbKdz95SdjFm
[*] Server started.

msf exploit(firefox_xpi_bootstrapped_addon) > 
```

- [x] Try to load /robots.txt from the exploit server. You should get a 404 error.

```
tools [~/opt//metasploit-framework]: wget http://192.168.24.10:8080/robots.txt
--2017-07-17 18:31:40--  http://192.168.24.10:8080/robots.txt
Connecting to 192.168.24.10:8080... connected.
HTTP request sent, awaiting response... 404 File not found
2017-07-17 18:31:40 ERROR 404: File not found.
```

- [x] Try to load / from the exploit server. You should get a 404 error.

```
tools [~/opt/metasploit-framework/]: wget http://192.168.24.10:8080/
--2017-07-17 18:31:50--  http://192.168.24.10:8080/  
Connecting to 192.168.24.10:8080... connected.      
HTTP request sent, awaiting response... 404 File not found
2017-07-17 18:31:50 ERROR 404: File not found.                                              
```

- [x] Try to load /<uripath> from the exploit server. You should get a 200 response.

```
tools [~/opt/metasploit-framework/]: wget http://192.168.24.10:8080/1fpbKdz95SdjFm
--2017-07-17 18:32:09--  http://192.168.24.10:8080/1fpbKdz95SdjFm
Connecting to 192.168.24.10:8080... connected.
HTTP request sent, awaiting response... 302 Moved 
Location: /1fpbKdz95SdjFm/ [following]                        
--2017-07-17 18:32:09--  http://192.168.24.10:8080/1fpbKdz95SdjFm/
Reusing existing connection to 192.168.24.10:8080.  
HTTP request sent, awaiting response... 200 OK 
Length: 221 [text/html]                        
Saving to: '1fpbKdz95SdjFm'                                             
                                                   
1fpbKdz95SdjFm                                 100%[==================================================================================================>]     221  --.-KB/s    in 0s
                                                
2017-07-17 18:32:09 (46.6 MB/s) - '1fpbKdz95SdjFm' saved [221/221]
                                                   
```
notice http server responding...

```
msf exploit(firefox_xpi_bootstrapped_addon) > 
[*] 192.168.24.10    firefox_xpi_bootstrapped_addon - Redirecting request.
[*] 192.168.24.10    firefox_xpi_bootstrapped_addon - Sending HTML response.
```

- [x] Set sendrobots.txt to true, restart the exploit. Notice the status line indicating that a hardcoded uri /robots.txt has been added.

```
msf exploit(firefox_xpi_bootstrapped_addon) > jobs -K
Stopping all jobs...

[*] Server stopped.
msf exploit(firefox_xpi_bootstrapped_addon) > set sendrobots true
sendrobots => true
msf exploit(firefox_xpi_bootstrapped_addon) > run
[*] Exploit running as background job.
msf exploit(firefox_xpi_bootstrapped_addon) >
[*] Using URL: http://0.0.0.0:8080/rC6LY5gJgpJ8F
[*] Local IP: http://192.168.24.10:8080/rC6LY5gJgpJ8F
[*] Adding hardcoded uri /robots.txt
[*] Server started.
```

- [x] Try loading robots.txt again. You should get valid robots.txt file contents

```
tools [~/opt/metasploit-framework]: curl !$
curl http://192.168.24.10:8080/robots.txt
User-agent: *
Disallow: /
```

- [x] Start exploit/windows/browser/ms10\_002\_aurora. The exploit should start without generating any conflict with the other exploit.

```
msf exploit(firefox_xpi_bootstrapped_addon) > use exploit/windows/browser/ms10_002_aurora
msf exploit(ms10_002_aurora) > set verbose true
verbose => true
msf exploit(ms10_002_aurora) > set disablepayloadhandler true                   
disablepayloadhandler => true                                                   
msf exploit(ms10_002_aurora) > set sendrobots true
sendrobots => true
msf exploit(ms10_002_aurora) > run
[*] Exploit running as background job.
msf exploit(ms10_002_aurora) >
[*] Using URL: http://0.0.0.0:8080/9MWkssaCeTqX
[*] Local IP: http://192.168.24.10:8080/9MWkssaCeTqX
[*] Adding hardcoded uri /robots.txt
[!] The supplied resource '/robots.txt' is already added.
[*] Server started.

msf exploit(ms10_002_aurora) >
```



