### PR TITLE
Fix SE campaign exception.

### DIFF
--- a/lib/msf/core/exploit/smtp_deliver.rb
+++ b/lib/msf/core/exploit/smtp_deliver.rb
@@ -184,7 +184,7 @@ module Exploit::Remote::SMTPDeliver
 
     raw_send_recv("MAIL FROM: <#{mailfrom}>\r\n", nsock)
     res = raw_send_recv("RCPT TO: <#{mailto}>\r\n", nsock)
-    if res[0..2] == '250'
+    if res && res[0..2] == '250'
       resp = raw_send_recv("DATA\r\n", nsock)
 
       # If the user supplied a Date field, use that, else use the current
@@ -242,10 +242,12 @@ module Exploit::Remote::SMTPDeliver
       # to dump it all.
       vprint_status("C: #{((cmd.length > 120) ? cmd[0,120] + "..." : cmd).strip}")
     end
-
-    nsock.put(cmd)
-    res = nsock.get_once
-
+	begin
+		nsock.put(cmd)
+		res = nsock.get_once
+	rescue
+		return nil
+	end
     # Don't truncate the server output because it might be helpful for
     # debugging.
     vprint_status("S: #{res.strip}") if res

--- a/lib/msf/core/exploit/smtp_deliver.rb
+++ b/lib/msf/core/exploit/smtp_deliver.rb
@@ -242,12 +242,12 @@ module Exploit::Remote::SMTPDeliver
       # to dump it all.
       vprint_status("C: #{((cmd.length > 120) ? cmd[0,120] + "..." : cmd).strip}")
     end
-	begin
-		nsock.put(cmd)
-		res = nsock.get_once
-	rescue
-		return nil
-	end
+    begin
+      nsock.put(cmd)
+      res = nsock.get_once
+    rescue
+      return nil
+    end
     # Don't truncate the server output because it might be helpful for
     # debugging.
     vprint_status("S: #{res.strip}") if res


### PR DESCRIPTION
MS-2705, SE_campaign will generate stacktrace when RCPT command got socket closure as a response. Thanks to Pearce for the triage.


## Verification

- [x] Start Metasploit Pro
- [x] Run a SE campaign against a SMTP server that closes socket when processing "RCPT" command
- [x] Verify that there is no stacktrace.


