### PR TITLE
HWBRIDGE RFTRANSCEIVER ADD LOWBALL SUPPORT

### DIFF
--- a/lib/msf/core/post/hardware/rftransceiver/rftransceiver.rb
+++ b/lib/msf/core/post/hardware/rftransceiver/rftransceiver.rb
@@ -279,6 +279,16 @@ module RFTransceiver
   end
 
   #
+  # Sets lowball.  Ensure you set the frequency first before using this
+  # @return [Boolean] success value
+  def set_lowball
+    return false unless is_rf?
+    self.index ||= 0
+    r = client.rftransceiver.set_lowball(self.index)
+    return_success(r)
+  end
+
+  #
   # Set power level
   # @param level [Integer] Power level
   # @return [Boolean] success value

--- a/lib/rex/post/hwbridge/extensions/rftransceiver/rftransceiver.rb
+++ b/lib/rex/post/hwbridge/extensions/rftransceiver/rftransceiver.rb
@@ -186,6 +186,10 @@ class RFTransceiver < Extension
     client.send_request("/rftransceiver/#{idx}/set_number_preamble?num=#{num}")
   end
 
+  def set_lowball(idx)
+    client.send_request("/rftransceiver/#{idx}/set_lowball")
+  end
+
   def set_maxpower(idx)
     client.send_request("/rftransceiver/#{idx}/set_maxpower")
   end

--- a/lib/rex/post/hwbridge/ui/console/command_dispatcher/rftransceiver.rb
+++ b/lib/rex/post/hwbridge/ui/console/command_dispatcher/rftransceiver.rb
@@ -34,6 +34,7 @@ class Console::CommandDispatcher::RFtransceiver
       'deviation'         => 'sets the deviation',
       'sync_word'         => 'sets the sync word',
       'preamble'          => 'sets the preamble number',
+      'lowball'          => 'sets lowball'
       'power'             => 'sets the power level',
       'maxpower'          => 'sets max power'
     }
@@ -525,6 +526,20 @@ class Console::CommandDispatcher::RFtransceiver
       return
     end
     r = client.rftransceiver.set_number_preamble(idx, preamble)
+    print_success(r)
+  end
+
+  def cmd_lowball_help
+    print_line("Lowball is frequency dependent.  Set frequency first")
+  end
+
+  def cmd_lowball(*args)
+    self.idx ||= 0
+    if args.length.positive?
+      cmd_lowball_help
+      return
+    end
+    r = client.rftransceiver.set_lowball(idx)
     print_success(r)
   end
 

--- a/lib/rex/post/hwbridge/ui/console/command_dispatcher/rftransceiver.rb
+++ b/lib/rex/post/hwbridge/ui/console/command_dispatcher/rftransceiver.rb
@@ -34,7 +34,7 @@ class Console::CommandDispatcher::RFtransceiver
       'deviation'         => 'sets the deviation',
       'sync_word'         => 'sets the sync word',
       'preamble'          => 'sets the preamble number',
-      'lowball'          => 'sets lowball'
+      'lowball'           => 'sets lowball',
       'power'             => 'sets the power level',
       'maxpower'          => 'sets max power'
     }


### PR DESCRIPTION
This will add support for setting lowball through the rfcat transceiver hwbridge.

In your module use set_lowball

ZombieCraig should look at this one.