### PR TITLE
bump rex-core, reverting threadsafe select changes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -256,7 +256,7 @@ GEM
       rex-core
       rex-struct2
       rex-text
-    rex-core (0.1.11)
+    rex-core (0.1.12)
     rex-encoder (0.1.4)
       metasm
       rex-arch


### PR DESCRIPTION
There appear to be too many things in framework like cmd_exec that require the chunky behavior of Rex::ThreadSafe.select to work properly, so while reviewing those callers continues, let's revert https://github.com/rapid7/rex-core/commit/2d268bc4823b9deddd6e4ea087e5e4610d04f800. This fixes #8721 and #8725, as well as hopefully issues detected in a few other places.

## Verification

See #8721, #8725 for verification steps.