### PR TITLE
openssl_heartbleed fix, use ruby 2.4 OpenSSL::PKey::RSA API

### DIFF
--- a/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
+++ b/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
@@ -631,19 +631,19 @@ class MetasploitModule < Msf::Auxiliary
   def key_from_pqe(p, q, e)
     # Returns an RSA Private Key from Factors
     key = OpenSSL::PKey::RSA.new()
+    key.set_factors(p, q)
 
-    key.p = p
-    key.q = q
-
-    key.n = key.p*key.q
-    key.e = e
-
+    n = key.p * key.q
     phi = (key.p - 1) * (key.q - 1 )
-    key.d = key.e.mod_inverse(phi)
+    d = OpenSSL::BN.new(e).mod_inverse(phi)
 
-    key.dmp1 = key.d % (key.p - 1)
-    key.dmq1 = key.d % (key.q - 1)
-    key.iqmp = key.q.mod_inverse(key.p)
+    key.set_key(n, e, d)
+
+    dmp1 = key.d % (key.p - 1)
+    dmq1 = key.d % (key.q - 1)
+    iqmp = key.q.mod_inverse(key.p)
+
+    key.set_crt_params(dmp1, dmq1, iqmp)
 
     return key
   end


### PR DESCRIPTION
auxiliary/scanner/ssl/openssl_heartbleed currently crashes with

```
[*] 10.11.1.238:443       - 2017-07-21 20:04:17 UTC - Attempt 0...
NoMethodError undefined method `p=' for #<OpenSSL::PKey::RSA:0x00000007f87bc0>
```

because of an OpenSSL API change. This is a fix for that issue, and produces expected output on a vulnerable system:

```
[+] 10.11.1.238:443       - 2017-07-21 20:04:35 UTC - Got the private key
[*] 10.11.1.238:443       - -----BEGIN RSA PRIVATE KEY-----
...
```
