### PR TITLE
Hide errors in Windows Meterpreter sessions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,7 +28,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 1.2.37)
+      metasploit-payloads (= 1.2.38)
       metasploit_data_models
       metasploit_payloads-mettle (= 0.1.14)
       msgpack
@@ -178,7 +178,7 @@ GEM
       activemodel (~> 4.2.6)
       activesupport (~> 4.2.6)
       railties (~> 4.2.6)
-    metasploit-payloads (1.2.37)
+    metasploit-payloads (1.2.38)
     metasploit_data_models (2.0.15)
       activerecord (~> 4.2.6)
       activesupport (~> 4.2.6)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -70,7 +70,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '1.2.37'
+  spec.add_runtime_dependency 'metasploit-payloads', '1.2.38'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '0.1.14'
   # Needed by msfgui and other rpc components


### PR DESCRIPTION
In Windows Meterpreter sessions, set newly created threads via SetThreadErrorMode to not display error popups when there are failures.

This just pulls in https://github.com/rapid7/metasploit-payloads/pull/210