### PR TITLE
only pin rb-readline on linux/osx

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,8 +6,10 @@ gemspec name: 'metasploit-framework'
 # These pull in pre-release gems in order to fix specific issues.
 # XXX https://github.com/alexdalitz/dnsruby/pull/134
 gem 'dnsruby', git: 'https://github.com/alexdalitz/dnsruby'
+
 # XXX https://github.com/ConnorAtherton/rb-readline/commit/fd882edcd145c26681f9971be5f6675c7f6d1970
-gem 'rb-readline', git: 'https://github.com/ConnorAtherton/rb-readline'
+gem 'rb-readline', git: 'https://github.com/ConnorAtherton/rb-readline' if [
+ 'x86_64-linux', 'x86-linux', 'darwin'].include?(RUBY_PLATFORM.gsub(/.*darwin.*/, 'darwin'))
 
 # separate from test as simplecov is not run on travis-ci
 group :coverage do


### PR DESCRIPTION
While rb-readline is waiting for a release on https://github.com/ConnorAtherton/rb-readline/commit/fd882edcd145c26681f9971be5f6675c7f6d1970 we should only pin rb-readline on Linux / OSX because the pin breaks things on Windows builds.