### PR TITLE
Add eval alternative to PHP Meterpreter to bypass suhosin

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,7 +28,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 1.2.40)
+      metasploit-payloads (= 1.2.41)
       metasploit_data_models
       metasploit_payloads-mettle (= 0.1.14)
       msgpack
@@ -178,7 +178,7 @@ GEM
       activemodel (~> 4.2.6)
       activesupport (~> 4.2.6)
       railties (~> 4.2.6)
-    metasploit-payloads (1.2.40)
+    metasploit-payloads (1.2.41)
     metasploit_data_models (2.0.15)
       activerecord (~> 4.2.6)
       activesupport (~> 4.2.6)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -70,7 +70,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '1.2.40'
+  spec.add_runtime_dependency 'metasploit-payloads', '1.2.41'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '0.1.14'
   # Needed by msfgui and other rpc components

--- a/modules/payloads/singles/php/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/php/meterpreter_reverse_tcp.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/meterpreter_options'
 
 module MetasploitModule
 
-  CachedSize = 27602
+  CachedSize = 27735
 
   include Msf::Payload::Single
   include Msf::Payload::Php::ReverseTcp


### PR DESCRIPTION
See https://suhosin.org/stories/index.html for more information on this system.

This pulls in https://github.com/rapid7/metasploit-payloads/pull/217
which fixes https://github.com/rapid7/metasploit-framework/issues/8630