### PR TITLE
make exploit/multi/handler passive

### DIFF
--- a/modules/exploits/multi/handler.rb
+++ b/modules/exploits/multi/handler.rb
@@ -12,49 +12,53 @@ class MetasploitModule < Msf::Exploit::Remote
   #
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Generic Payload Handler',
-      'Description'    => %q{
-        This module is a stub that provides all of the
-        features of the Metasploit payload system to exploits
-        that have been launched outside of the framework.
-      },
-      'License'        => MSF_LICENSE,
-      'Author'         =>  ['hdm'],
-      'References'     =>  [ ],
-      'Payload'        =>
-        {
-          'Space'       => 10000000,
-          'BadChars'    => '',
-          'DisableNops' => true,
-        },
-      'Platform'       => %w{ android bsd java js linux osx nodejs php python ruby solaris unix win mainframe multi },
-      'Arch'           => ARCH_ALL,
-      'Targets'        => [ [ 'Wildcard Target', { } ] ],
-      'DefaultTarget'  => 0
-      ))
+    super(
+      update_info(
+        info,
+        'Name'           => 'Generic Payload Handler',
+        'Description'    => %q(
+          This module is a stub that provides all of the
+          features of the Metasploit payload system to exploits
+          that have been launched outside of the framework.
+        ),
+        'License'        => MSF_LICENSE,
+        'Author'         =>  [ 'hdm', 'bcook-r7' ],
+        'References'     =>  [ ],
+        'Payload'        =>
+          {
+            'Space'       => 10000000,
+            'BadChars'    => '',
+            'DisableNops' => true
+          },
+        'Platform'       => %w[android bsd java js linux osx nodejs php python ruby solaris unix win mainframe multi],
+        'Arch'           => ARCH_ALL,
+        'Targets'        => [ [ 'Wildcard Target', {} ] ],
+        'DefaultTarget'  => 0,
+        'Stance'         => Msf::Exploit::Stance::Passive
+      )
+    )
 
     register_advanced_options(
       [
-        OptBool.new("ExitOnSession", [ false, "Return from the exploit after a session has been created", true ]),
-        OptInt.new("ListenerTimeout", [ false, "The maximum number of seconds to wait for new sessions", 0])
-      ])
+        OptBool.new(
+          "ExitOnSession",
+          [ true, "Return from the exploit after a session has been created", false ]
+        ),
+        OptInt.new(
+          "ListenerTimeout",
+          [ false, "The maximum number of seconds to wait for new sessions", 0 ]
+        )
+      ]
+    )
   end
 
   def exploit
-    if not datastore['ExitOnSession'] and not job_id
-      fail_with(Failure::Unknown, "Setting ExitOnSession to false requires running as a job (exploit -j)")
-    end
-
     stime = Time.now.to_f
-    print_status "Starting the payload handler..."
-    while(true)
-      break if session_created? and datastore['ExitOnSession']
-      break if ( datastore['ListenerTimeout'].to_i > 0 and (stime + datastore['ListenerTimeout'].to_i < Time.now.to_f) )
-
-      select(nil,nil,nil,1)
+    timeout = datastore['ListenerTimeout'].to_i
+    loop do
+      break if session_created? && datastore['ExitOnSession']
+      break if timeout.positive? && (stime + timeout < Time.now.to_f)
+      sleep(1)
     end
   end
-
-
 end


### PR DESCRIPTION
This gives exploit/multi/handler a makeover, updating to use more-or-less
standard Ruby, and removing any mystical hacks at the same time (like select
instead of sleep).

This also gives it a Passive stance, and sets ExitOnSession to be false by
default, which is the setting that people use 99% of the time anyway.

## Verification

- [x] Start `msfconsole`
- [x] Use `exploit/multi/handler` with and without ExitOnSession set
- [x] Verify that it always starts as a background job

```
msf exploit(java_rmi_server) > use exploit/multi/handler
msf exploit(handler) > set payload windows/meterpreter/reverse_tcp
payload => windows/meterpreter/reverse_tcp
msf exploit(handler) > set lhost 192.168.56.1
lhost => 192.168.56.1
msf exploit(handler) > run
[*] Exploit running as background job.

[*] Started reverse TCP handler on 192.168.56.1:4444
msf exploit(handler) > jobs

Jobs
====

  Id  Name                    Payload                          Payload opts
  --  ----                    -------                          ------------
  0   Exploit: multi/handler  windows/meterpreter/reverse_tcp  tcp://192.168.56.1:4444

```