### PR TITLE
swizzle parameters in generate to match msfvenom

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/payload.rb
+++ b/lib/msf/ui/console/command_dispatcher/payload.rb
@@ -18,18 +18,17 @@ module Msf
             Msf::Util::EXE.to_executable_fmt_formats
 
           @@generate_opts = Rex::Parser::Arguments.new(
-            "-b" => [ true,  "The list of characters to avoid: '\\x00\\xff'"        ],
-            "-E" => [ false, "Force encoding."                                      ],
-            "-e" => [ true,  "The name of the encoder module to use."               ],
-            "-h" => [ false, "Help banner."                                         ],
-            "-o" => [ true,  "A comma separated list of options in VAR=VAL format." ],
-            "-s" => [ true,  "NOP sled length."                                     ],
-            "-f" => [ true,  "The output file name (otherwise stdout)"              ],
-            "-t" => [ true,  "The output format: #{supported_formats.join(',')}"    ],
-            "-p" => [ true,  "The Platform for output."                             ],
-            "-k" => [ false, "Keep the template executable functional"              ],
-            "-x" => [ true,  "The executable template to use"                       ],
-            "-i" => [ true,  "the number of encoding iterations."                   ]
+            "-p" => [ true,  "The platform of the payload" ],
+            "-n" => [ true,  "Prepend a nopsled of [length] size on to the payload" ],
+            "-f" => [ true,  "Output format: #{supported_formats.join(',')}" ],
+            "-E" => [ false, "Force encoding" ],
+            "-e" => [ true,  "The encoder to use" ],
+            "-b" => [ true,  "The list of characters to avoid example: '\\x00\\xff'" ],
+            "-i" => [ true,  "The number of times to encode the payload" ],
+            "-x" => [ true,  "Specify a custom executable file to use as a template" ],
+            "-k" => [ false, "Preserve the template behavior and inject the payload as a new thread" ],
+            "-o" => [ true,  "The output file name (otherwise stdout)" ],
+            "-h" => [ false, "Show this message" ],
           )
 
           #
@@ -76,7 +75,7 @@ module Msf
             sled_size    = nil
             option_str   = nil
             badchars     = nil
-            type         = "ruby"
+            format       = "ruby"
             ofile        = nil
             iter         = 1
             force        = nil
@@ -92,13 +91,15 @@ module Msf
                 encoder_name = val
               when '-E'
                 force = true
-              when '-o'
-                option_str = val
-              when '-s'
+              when '-n'
                 sled_size = val.to_i
-              when '-t'
-                type = val
               when '-f'
+                format = val
+              when '-o'
+                if val.include?('=')
+                  print("The -o parameter of 'generate' is now the output file. Specify options with the 'set' command")
+                  return true
+                end
                 ofile = val
               when '-i'
                 iter = val
@@ -126,7 +127,7 @@ module Msf
               buf = mod.generate_simple(
                 'BadChars'    => badchars,
                 'Encoder'     => encoder_name,
-                'Format'      => type,
+                'Format'      => format,
                 'NopSledSize' => sled_size,
                 'OptionStr'   => option_str,
                 'ForceEncode' => force,


### PR DESCRIPTION
For silly reasons, msfvenom slightly varies from the payload generate command in its parameters. Let's make them match! This is still a bit of a WiP, but curious to get feedback about who I'm going to break as a result of this change. I think it's a better result, even if it does require forgetting a little muscle memory.

I also completely whacked the `-o LHOST=blah,BAR=foo` functionality because this is a normal module, so 'set' should be preferred. Though, it might be interesting to implement msfvenom style option parsing for setting transient module parameters _in general_. Imagine the possibilities!

```
exploit -j RHOST=1.2.3.4
exploit -j RHOST=1.2.3.5
```