### PR TITLE
Add space after comma in f5_bigip_known_privkey module to coincide wi…

### DIFF
--- a/modules/exploits/linux/ssh/f5_bigip_known_privkey.rb
+++ b/modules/exploits/linux/ssh/f5_bigip_known_privkey.rb
@@ -70,7 +70,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def do_login(user)
-    factory = Rex::Socket::SSHFactory.new(framework,self, datastore['Proxies'])
+    factory = Rex::Socket::SSHFactory.new(framework, self, datastore['Proxies'])
     opt_hash = {
       auth_methods:    ['publickey'],
       port:            rport,


### PR DESCRIPTION
### Overview
This commit introduces a minor, stylistic change to the f5_bigip_known_privkey exploit module.  A single space operator was added to improve the readability of the SSHFactory instantiation inside the do_login method.

### Reference
Ruby Style Guide Reference: https://github.com/bbatsov/ruby-style-guide#spaces-operators

