### PR TITLE
Adding error handler for ms17-010 exploit where SMBv1 is disabled

### DIFF
--- a/modules/exploits/windows/smb/ms17_010_eternalblue.rb
+++ b/modules/exploits/windows/smb/ms17_010_eternalblue.rb
@@ -164,7 +164,7 @@ class MetasploitModule < Msf::Exploit::Remote
       # Step 1: Connect to IPC$ share
       print_status("Connecting to target for exploitation.")
       client, tree, sock, os = smb1_anonymous_connect_ipc()
-    rescue
+    rescue RubySMB::Error::CommunicationError
       # Error handler in case SMBv1 disabled on target
       raise EternalBlueError, 'Could not make SMBv1 connection'
     else

--- a/modules/exploits/windows/smb/ms17_010_eternalblue.rb
+++ b/modules/exploits/windows/smb/ms17_010_eternalblue.rb
@@ -164,6 +164,10 @@ class MetasploitModule < Msf::Exploit::Remote
       # Step 1: Connect to IPC$ share
       print_status("Connecting to target for exploitation.")
       client, tree, sock, os = smb1_anonymous_connect_ipc()
+    rescue
+      # Error handler in case SMBv1 disabled on target
+      raise EternalBlueError, 'Could not make SMBv1 connection'
+    else
       print_good("Connection established for exploitation.")
 
       if verify_target(os)


### PR DESCRIPTION
This PR is to address issue `https://github.com/rapid7/ruby_smb/issues/93`

## Verification
To disable SMBv1 on a target Windows 7 host, run the following powershell cmdlet:
`Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\LanmanServer\Parameters" SMB1 -Type DWORD -Value 0 -Force`


When using the ms17_010_eternalblue exploit against a target with SMBv1 disabled, the following error is produced:


```
msf exploit(ms17_010_eternalblue) > exploit

[*] Started HTTPS reverse handler on https://192.168.1.140:8080
[*] 10.2.2.104:445 - Connecting to target for exploitation.
[-] 10.2.2.104:445 - RubySMB::Error::CommunicationError
[-] 10.2.2.104:445 - An error occured reading from the Socket
[-] 10.2.2.104:445 - /Users/multiplex3r/.rvm/gems/ruby-2.4.1@metasploit-framework/gems/ruby_smb-0.0.18/lib/ruby_smb/dispatcher/socket.rb:59:in `rescue in recv_packet'
/Users/multiplex3r/.rvm/gems/ruby-2.4.1@metasploit-framework/gems/ruby_smb-0.0.18/lib/ruby_smb/dispatcher/socket.rb:45:in `recv_packet'
/Users/multiplex3r/.rvm/gems/ruby-2.4.1@metasploit-framework/gems/ruby_smb-0.0.18/lib/ruby_smb/client.rb:229:in `send_recv'
/Users/multiplex3r/.rvm/gems/ruby-2.4.1@metasploit-framework/gems/ruby_smb-0.0.18/lib/ruby_smb/client/negotiation.rb:36:in `negotiate_request'
/Users/multiplex3r/.rvm/gems/ruby-2.4.1@metasploit-framework/gems/ruby_smb-0.0.18/lib/ruby_smb/client/negotiation.rb:14:in `negotiate'
/Users/multiplex3r/.rvm/gems/ruby-2.4.1@metasploit-framework/gems/ruby_smb-0.0.18/lib/ruby_smb/client.rb:186:in `login'
/Users/multiplex3r/metasploit-framework/modules/exploits/windows/smb/ms17_010_eternalblue.rb:360:in `smb1_anonymous_connect_ipc'
/Users/multiplex3r/metasploit-framework/modules/exploits/windows/smb/ms17_010_eternalblue.rb:166:in `smb_eternalblue'
/Users/multiplex3r/metasploit-framework/modules/exploits/windows/smb/ms17_010_eternalblue.rb:118:in `block in exploit'
/Users/multiplex3r/.rvm/gems/ruby-2.4.1@metasploit-framework/gems/activesupport-4.2.9/lib/active_support/core_ext/range/each.rb:7:in `each'
/Users/multiplex3r/.rvm/gems/ruby-2.4.1@metasploit-framework/gems/activesupport-4.2.9/lib/active_support/core_ext/range/each.rb:7:in `each_with_time_with_zone'
/Users/multiplex3r/metasploit-framework/modules/exploits/windows/smb/ms17_010_eternalblue.rb:114:in `exploit'
/Users/multiplex3r/metasploit-framework/lib/msf/core/exploit_driver.rb:206:in `job_run_proc'
/Users/multiplex3r/metasploit-framework/lib/msf/core/exploit_driver.rb:167:in `run'
/Users/multiplex3r/metasploit-framework/lib/msf/base/simple/exploit.rb:136:in `exploit_simple'
/Users/multiplex3r/metasploit-framework/lib/msf/base/simple/exploit.rb:161:in `exploit_simple'
/Users/multiplex3r/metasploit-framework/lib/msf/ui/console/command_dispatcher/exploit.rb:110:in `cmd_exploit'
/Users/multiplex3r/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:430:in `run_command'
/Users/multiplex3r/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:392:in `block in run_single'
/Users/multiplex3r/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:386:in `each'
/Users/multiplex3r/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:386:in `run_single'
/Users/multiplex3r/metasploit-framework/lib/rex/ui/text/shell.rb:205:in `run'
/Users/multiplex3r/metasploit-framework/lib/metasploit/framework/command/console.rb:48:in `start'
/Users/multiplex3r/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'
./msfconsole:48:in `<main>'
```


By adding this exception handler the exploit will not dump a stack trace if `smb1_anonymous_connect_ipc()` doesn't return with valid results.


```
msf exploit(ms17_010_eternalblue) > rexploit
[*] Reloading module...

[*] Started HTTPS reverse handler on https://192.168.1.140:8080
[*] 10.2.2.104:445 - Connecting to target for exploitation.
[-] 10.2.2.104:445 - Did not get SMBv1 connection
[*] Exploit completed, but no session was created.
```


To re-enable SMBv1 on a target Windows 7 host, run the following powershell cmdlet:
`Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\LanmanServer\Parameters" SMB1 -Type DWORD -Value 1 -Force`