### PR TITLE
enable Ruby 2.2 compat checks in Rubocop, correct multi/handler compat

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,9 @@
 
 # inherit_from: .rubocop_todo.yml
 
+AllCops:
+  TargetRubyVersion: 2.2
+
 Metrics/ClassLength:
   Description: 'Most Metasploit modules are quite large. This is ok.'
   Enabled: true

--- a/lib/msf/core/post/hardware/automotive/uds.rb
+++ b/lib/msf/core/post/hardware/automotive/uds.rb
@@ -33,7 +33,7 @@ module UDS
       end
       left2combine = hash["Packets"].size
       counter = 0
-      while left2combine.positive? && (bad_count < (hash["Packets"].size * 2))
+      while left2combine > 0 && (bad_count < (hash["Packets"].size * 2))
         # print_line("DEBUG Current status combine=#{left2combine} data=#{data.inspect}")
         hash["Packets"].each do |pkt|
           if (pkt.key? "ID") && pkt["ID"].hex == id.hex

--- a/lib/rex/post/hwbridge/ui/console/command_dispatcher/automotive.rb
+++ b/lib/rex/post/hwbridge/ui/console/command_dispatcher/automotive.rb
@@ -269,7 +269,7 @@ class Console::CommandDispatcher::Automotive
       return
     end
     if id.blank? && !stop
-      if self.tpjobs.size.positive?
+      if self.tpjobs.size > 0
         print_line("TesterPresent is currently active")
         self.tpjobs.each_index do |jid|
           if self.tpjobs[jid]

--- a/lib/rex/post/hwbridge/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/hwbridge/ui/console/command_dispatcher/core.rb
@@ -185,7 +185,7 @@ class Console::CommandDispatcher::Core
     if mod
       print_line(::Msf::Serializer::ReadableText.dump_module(mod))
       mod_opt = ::Msf::Serializer::ReadableText.dump_options(mod, '   ')
-      print_line("\nModule options (#{mod.fullname}):\n\n#{mod_opt}") if mod_opt && mod_opt.length.positive?
+      print_line("\nModule options (#{mod.fullname}):\n\n#{mod_opt}") if mod_opt && mod_opt.length > 0
     end
   end
 
@@ -204,7 +204,7 @@ class Console::CommandDispatcher::Core
   # Get the HW bridge devices status
   #
   def cmd_status(*args)
-    if args.length.positive?
+    if args.length > 0
       cmd_status_help
       return true
     end
@@ -235,7 +235,7 @@ class Console::CommandDispatcher::Core
   # Get the Hardware specialty
   #
   def cmd_specialty(*args)
-    if args.length.positive?
+    if args.length > 0
       cmd_specialty_help
       return true
     end
@@ -251,7 +251,7 @@ class Console::CommandDispatcher::Core
   # Performs a device reset or factory reset
   #
   def cmd_reset(*args)
-    if args.length.positive?
+    if args.length > 0
       cmd_reset_help
       return
     end
@@ -268,7 +268,7 @@ class Console::CommandDispatcher::Core
   # Perform a device reboot
   #
   def cmd_reboot(*args)
-    if args.length.positive?
+    if args.length > 0
       cmd_reboot_help
       return
     end
@@ -286,7 +286,7 @@ class Console::CommandDispatcher::Core
   # Loads custom methods if any exist
   #
   def cmd_load_custom_methods(*args)
-    if args.length.positive?
+    if args.length > 0
       cmd_load_custom_methods_help
       return true
     end

--- a/lib/rex/post/hwbridge/ui/console/command_dispatcher/rftransceiver.rb
+++ b/lib/rex/post/hwbridge/ui/console/command_dispatcher/rftransceiver.rb
@@ -49,7 +49,7 @@ class Console::CommandDispatcher::RFtransceiver
       return
     end
     indexes = indexes['indexes']
-    unless indexes.size.positive?
+    unless indexes.size > 0
       print_line('none')
       return
     end
@@ -535,7 +535,7 @@ class Console::CommandDispatcher::RFtransceiver
 
   def cmd_lowball(*args)
     self.idx ||= 0
-    if args.length.positive?
+    if args.length > 0
       cmd_lowball_help
       return
     end
@@ -552,7 +552,7 @@ class Console::CommandDispatcher::RFtransceiver
   #
   def cmd_maxpower(*args)
     self.idx ||= 0
-    if args.length.positive?
+    if args.length > 0
       cmd_maxpower_help
       return
     end

--- a/lib/rex/post/hwbridge/ui/console/command_dispatcher/zigbee.rb
+++ b/lib/rex/post/hwbridge/ui/console/command_dispatcher/zigbee.rb
@@ -44,7 +44,7 @@ class Console::CommandDispatcher::Zigbee
       return
     end
     devices = devices["devices"]
-    unless devices.size.positive?
+    unless devices.size > 0
       print_line("none")
       return
     end

--- a/modules/exploits/multi/handler.rb
+++ b/modules/exploits/multi/handler.rb
@@ -57,7 +57,7 @@ class MetasploitModule < Msf::Exploit::Remote
     timeout = datastore['ListenerTimeout'].to_i
     loop do
       break if session_created? && datastore['ExitOnSession']
-      break if timeout.positive? && (stime + timeout < Time.now.to_f)
+      break if timeout > 0 && (stime + timeout < Time.now.to_f)
       sleep(1)
     end
   end

--- a/plugins/aggregator.rb
+++ b/plugins/aggregator.rb
@@ -124,7 +124,7 @@ module Msf
 
         group = "default"
 
-        if (@host && @host.length.positive?) && (@port && @port.length.positive? && @port.to_i > 0)
+        if (@host && @host.length > 0) && (@port && @port.length > 0 && @port.to_i > 0)
           config = { "#{group}" => { 'server' => @host, 'port' => @port } }
           ::File.open("#{Aggregator_yaml}", "wb") { |f| f.puts YAML.dump(config) }
           print_good("#{Aggregator_yaml} created.")
@@ -376,7 +376,7 @@ module Msf
 
       def aggregator_login
 
-        if !((@host && @host.length.positive?) && (@port && @port.length.positive? && @port.to_i > 0))
+        if !((@host && @host.length > 0) && (@port && @port.length > 0 && @port.to_i > 0))
           usage_connect
           return
         end


### PR DESCRIPTION
This fixes #8790 and tells Rubocop to stop suggesting Ruby 2.3/2.4-specific things.

## Verification

- [ ] Start `msfconsole` with Ruby 2.2
- [ ] `use exploit/multi/handler`
- [ ] `set payload windows/meterpreter/reverse_tcp`
- [ ] `set lhost 127.0.0.1`
- [ ] **Verify** no errors and the handler starts correctly

