### PR TITLE
Add module to detect Docker and LXC containers

### DIFF
--- a/lib/msf/core/db_manager/host.rb
+++ b/lib/msf/core/db_manager/host.rb
@@ -135,7 +135,7 @@ module Msf::DBManager::Host
   # +:arch+::         -- one of the ARCH_* constants
   # +:mac+::          -- the host's MAC address
   # +:scope+::        -- interface identifier for link-local IPv6
-  # +:virtual_host+:: -- the name of the VM host software, eg "VMWare", "QEMU", "Xen", etc.
+  # +:virtual_host+:: -- the name of the virtualization software, eg "VMWare", "QEMU", "Xen", "Docker", etc.
   #
   def report_host(opts)
 

--- a/lib/msf/core/post/common.rb
+++ b/lib/msf/core/post/common.rb
@@ -167,19 +167,19 @@ module Msf::Post::Common
   end
 
   #
-  # Reports to the database that the host is a virtual machine and reports
-  # the type of virtual machine it is (e.g VirtualBox, VMware, Xen)
+  # Reports to the database that the host is using virtualization and reports
+  # the type of virtualization it is (e.g VirtualBox, VMware, Xen, Docker)
   #
-  def report_vm(vm)
+  def report_virtualization(virt)
     return unless session
-    return unless vm
-    vm_normal = vm.to_s.strip
-    return if vm_normal.empty?
-    vm_data = {
+    return unless virt
+    virt_normal = virt.to_s.strip
+    return if virt_normal.empty?
+    virt_data = {
       :host => session.target_host,
-      :virtual_host => vm_normal
+      :virtual_host => virt_normal
     }
-    report_host(vm_data)
+    report_host(virt_data)
   end
 
   #

--- a/modules/post/linux/gather/checkcontainer.rb
+++ b/modules/post/linux/gather/checkcontainer.rb
@@ -1,0 +1,52 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Post
+  include Msf::Post::File
+
+  def initialize(info={})
+    super( update_info( info,
+        'Name'          => 'Linux Gather Container Detection',
+        'Description'   => %q{
+          This module attempts to determine whether the system is running
+          inside of a container and if so, which one. This module supports
+          detection of LXC, and Docker.},
+        'License'       => MSF_LICENSE,
+        'Author'        => [ 'James Otten <jamesotten1[at]gmail.com>'],
+        'Platform'      => [ 'linux' ],
+        'SessionTypes'  => [ 'shell', 'meterpreter' ]
+      ))
+  end
+
+  # Run Method for when run command is issued
+  def run
+    container = nil
+
+    # Check for .dockerenv file
+    if container.nil?
+      if file?("/.dockerenv")
+        container = "Docker"
+      end
+    end
+
+    # Check cgroup on PID 1
+    if container.nil?
+      cgroup = read_file("/proc/1/cgroup") rescue ""
+      case cgroup.gsub("\n", " ")
+      when /docker/i
+        container = "Docker"
+      when /lxc/i
+        container = "LXC"
+      end
+    end
+
+    if container
+      print_good("This appears to be a '#{container}' container")
+      report_virtualization(container)
+    else
+      print_status("This does not appear to be a container")
+    end
+  end
+end

--- a/modules/post/linux/gather/checkvm.rb
+++ b/modules/post/linux/gather/checkvm.rb
@@ -150,7 +150,7 @@ class MetasploitModule < Msf::Post
 
     if vm
       print_good("This appears to be a '#{vm}' virtual machine")
-      report_vm(vm)
+      report_virtulization(vm)
     else
       print_status("This does not appear to be a virtual machine")
     end

--- a/modules/post/windows/gather/checkvm.rb
+++ b/modules/post/windows/gather/checkvm.rb
@@ -324,7 +324,7 @@ class MetasploitModule < Msf::Post
     found ||= xenchk(session)
     found ||= qemuchk(session)
     if found
-      report_vm(found)
+      report_virtualization(found)
     else
       print_status("#{sysinfo['Computer']} appears to be a Physical Machine")
     end


### PR DESCRIPTION
Add module to detect Docker and LXC containers. Resolves #8682 Detect docker by the presence of `.dockerenv` file or finding "docker" in `/proc/1/cgroup`. Detect LXC by finding "lxc" in `/proc/1/cgroup`.

## Verification

- [ ] Start `msfconsole`
- [ ] Pop a shell in a docker container using web delivery and the [official python container](https://hub.docker.com/_/python/), the process described in #8667, or any other way that you see fit.
- [ ] `run post/linux/gather/checkcontainer`
- [ ] **Verify** the module detects docker
- [ ] In the same session, `rm /.dockerenv`
- [ ] `run post/linux/gather/checkcontainer`
- [ ] **Verify** the module still detects docker
- [ ] Pop a shell in a LXC container any way that you see fit (can likely use the same process as before).
- [ ] `run post/linux/gather/checkcontainer`
- [ ] **Verify** the module detects LXC
- [ ] Pop a shell in a non-virtual linux environment any way that you see fit (can likely use the same process as before).
- [ ] `run post/linux/gather/checkcontainer`
- [ ] **Verify** the module does not detect a virtual environment

## Scenarios
### Detect docker
```
meterpreter > run post/linux/gather/checkcontainer

[+] This appears to be a 'Docker' container
```
### Detect LXC
```
meterpreter > run post/linux/gather/checkcontainer

[+] This appears to be a 'LXC' container
```
### Detect nothing
```
meterpreter > run post/linux/gather/checkcontainer 

[*] This does not appear to be a container
```