### PR TITLE
Remove uses of multi-char args for Meterpreter Scripts

### DIFF
--- a/documentation/modules/post/windows/manage/priv_migrate.md
+++ b/documentation/modules/post/windows/manage/priv_migrate.md
@@ -56,7 +56,7 @@ set PAYLOAD windows/meterpreter/reverse_https
 set LHOST 192.168.1.101
 set LPORT 13002
 set ExitOnSession false
-set AutoRunScript multi_console_command -rc /home/user/auto.rc
+set AutoRunScript multi_console_command -r /home/user/auto.rc
 exploit -j
 ```
 

--- a/scripts/meterpreter/getgui.rb
+++ b/scripts/meterpreter/getgui.rb
@@ -176,7 +176,7 @@ if client.platform == 'windows'
         print_status("Starting the port forwarding at local port #{lport}")
         client.run_cmd("portfwd add -L 0.0.0.0 -l #{lport} -p 3389 -r 127.0.0.1")
       end
-      print_status("For cleanup use command: run multi_console_command -rc #{@dest}")
+      print_status("For cleanup use command: run multi_console_command -r #{@dest}")
     else
       usage
     end

--- a/scripts/meterpreter/gettelnet.rb
+++ b/scripts/meterpreter/gettelnet.rb
@@ -166,7 +166,7 @@ if enbl or (usr!= nil && pass != nil)
   if (usr!= nil && pass != nil)
     addrdpusr(usr, pass)
   end
-  print_status("For cleanup use command: run multi_console_command -rc #{@dest}")
+  print_status("For cleanup use command: run multi_console_command -r #{@dest}")
 
 else
   usage

--- a/scripts/meterpreter/multi_console_command.rb
+++ b/scripts/meterpreter/multi_console_command.rb
@@ -17,9 +17,9 @@
 # Setting Arguments
 @@exec_opts = Rex::Parser::Arguments.new(
   "-h" => [ false,"Help menu."                        ],
-  "-sl" => [ false,"Hide commands output for work in background sessions"],
-  "-cl" => [ true,"Commands to execute. The command must be enclosed in double quotes and separated by a comma."],
-  "-rc" => [ true,"Text file with list of commands, one per line."]
+  "-s" => [ false,"Hide commands output for work in background sessions"],
+  "-c" => [ true,"Commands to execute. The command must be enclosed in double quotes and separated by a comma."],
+  "-r" => [ true,"Text file with list of commands, one per line."]
 )
 
 commands = nil
@@ -36,9 +36,9 @@ end
 @@exec_opts.parse(args) { |opt, idx, val|
   case opt
 
-  when "-cl"
+  when "-c"
     commands = val.split(",")
-  when "-rc"
+  when "-r"
     script = val
     if not ::File.exist?(script)
       raise "Command List File does not exists!"
@@ -51,7 +51,7 @@ end
 
   when "-h"
     help = true
-  when "-sl"
+  when "-s"
     silence = true
   end
 }

--- a/scripts/meterpreter/multi_meter_inject.rb
+++ b/scripts/meterpreter/multi_meter_inject.rb
@@ -22,9 +22,9 @@ start_handler = nil
   "-h"  => [ false,  "Help menu." ],
   "-p"  => [ true,   "The port on the remote host where Metasploit is listening (default: 4444)."],
   "-m"  => [ false,  "Start exploit/multi/handler for return connection."],
-  "-pt" => [ true,   "Specify reverse connection Meterpreter payload. Default: windows/meterpreter/reverse_tcp"],
-  "-mr" => [ true,   "Provide multiple IP addresses for connections separated by comma."],
-  "-mp" => [ true,   "Provide multiple PID for connections separated by comma one per IP."]
+  "-P" => [ true,   "Specify reverse connection Meterpreter payload. Default: windows/meterpreter/reverse_tcp"],
+  "-I" => [ true,   "Provide multiple IP addresses for connections separated by comma."],
+  "-d" => [ true,   "Provide multiple PID for connections separated by comma one per IP."]
 )
 meter_type = client.platform
 
@@ -112,11 +112,11 @@ end
     lport = val.to_i
   when "-m"
     start_handler = true
-  when "-pt"
+  when "-P"
     payload_type = val
-  when "-mr"
+  when "-I"
     multi_ip = val.split(",")
-  when "-mp"
+  when "-d"
     multi_pid = val.split(",")
   end
 }

--- a/scripts/meterpreter/multicommand.rb
+++ b/scripts/meterpreter/multicommand.rb
@@ -16,9 +16,9 @@ wininfo = client.sys.config.sysinfo
 # Setting Arguments
 @@exec_opts = Rex::Parser::Arguments.new(
   "-h" => [ false,"Help menu."                        ],
-  "-cl" => [ true,"Commands to execute. The command must be enclosed in double quotes and separated by a comma."],
+  "-c" => [ true,"Commands to execute. The command must be enclosed in double quotes and separated by a comma."],
   "-f" => [ true,"File where to saved output of command."],
-  "-rc" => [ true,"Text file with list of commands, one per line."]
+  "-r" => [ true,"Text file with list of commands, one per line."]
 )
 #Setting Argument variables
 commands = []
@@ -77,9 +77,9 @@ end
 @@exec_opts.parse(args) { |opt, idx, val|
   case opt
 
-  when "-cl"
+  when "-c"
     commands = val.split(",")
-  when "-rc"
+  when "-r"
     script = val
     if not ::File.exist?(script)
       raise "Command List File does not exists!"

--- a/scripts/meterpreter/multiscript.rb
+++ b/scripts/meterpreter/multiscript.rb
@@ -15,8 +15,8 @@ session = client
 
 @@exec_opts = Rex::Parser::Arguments.new(
   "-h" => [ false,"Help menu."                        ],
-  "-cl" => [ true,"Collection of scripts to execute. Each script command must be enclosed in double quotes and separated by a semicolon."],
-  "-rc" => [ true,"Text file with list of commands, one per line."]
+  "-c" => [ true,"Collection of scripts to execute. Each script command must be enclosed in double quotes and separated by a semicolon."],
+  "-r" => [ true,"Text file with list of commands, one per line."]
 )
 #Setting Argument variables
 commands = ""
@@ -53,9 +53,9 @@ end
 @@exec_opts.parse(args) do |opt, idx, val|
   case opt
 
-  when "-cl"
+  when "-c"
     commands = val.gsub(/;/,"\n")
-  when "-rc"
+  when "-r"
     script = val
     if not ::File.exist?(script)
       raise "Script List File does not exists!"

--- a/scripts/meterpreter/netenum.rb
+++ b/scripts/meterpreter/netenum.rb
@@ -15,13 +15,13 @@
 @@exec_opts = Rex::Parser::Arguments.new(
   "-h"  => [ false, "Help menu." ],
   "-r"  => [ true,  "The target address range or CIDR identifier" ],
-  "-ps" => [ false, "To Perform Ping Sweep on IP Range" ],
-  "-rl" => [ false, "To Perform DNS Reverse Lookup on IP Range" ],
-  "-fl" => [ false, "To Perform DNS Forward Lookup on host list and domain" ],
-  "-hl" => [ true,  "File with Host List for DNS Forward Lookup" ],
+  "-p" => [ false, "To Perform Ping Sweep on IP Range" ],
+  "-l" => [ false, "To Perform DNS Reverse Lookup on IP Range" ],
+  "-f" => [ false, "To Perform DNS Forward Lookup on host list and domain" ],
+  "-H" => [ true,  "File with Host List for DNS Forward Lookup" ],
   "-d"  => [ true,  "Domain Name for DNS Forward Lookup" ],
-  "-st" => [ false, "To Perform DNS lookup of MX and NS records for a domain" ],
-  "-sr" => [ false, "To Perform Service Record DNS lookup for a domain" ]
+  "-x" => [ false, "To Perform DNS lookup of MX and NS records for a domain" ],
+  "-s" => [ false, "To Perform Service Record DNS lookup for a domain" ]
 )
 session = client
 host,port = session.session_host, session.session_port
@@ -285,19 +285,19 @@ srvrc = nil
 # Parsing of Options
 @@exec_opts.parse(args) { |opt, idx, val|
   case opt
-  when "-sr"
+  when "-s"
     srvrc = 1
-  when "-rl"
+  when "-l"
     rvrslkp = 1
-  when "-fl"
+  when "-f"
     frdlkp = 1
-  when "-ps"
+  when "-p"
     pngsp = 1
-  when "-st"
+  when "-x"
     stdlkp = 1
   when "-d"
     dom = val
-  when "-hl"
+  when "-H"
     hostlist = val
   when "-r"
     range = val
@@ -354,9 +354,9 @@ if client.platform == 'windows'
   else
     print("Network Enumerator Meterpreter Script\n" +
       "Usage:\n" +
-      "\tnetenum -r <value> (-ps | -rl)\n" +
-      "\tnetenum -d <value> (-st | -sr)\n" +
-      "\tnetenum -d <value> -lh <value> -fl\n" +
+      "\tnetenum -r <value> (-p | -l)\n" +
+      "\tnetenum -d <value> (-x | -s)\n" +
+      "\tnetenum -d <value> -H <value> -fl\n" +
       @@exec_opts.usage)
   end
 else

--- a/scripts/meterpreter/packetrecorder.rb
+++ b/scripts/meterpreter/packetrecorder.rb
@@ -26,7 +26,7 @@ log_dest = nil
   "-h"  => [ false, "Help menu."],
   "-t"  => [ true,  "Time interval in seconds between recollection of packet, default 30 seconds."],
   "-i"  => [ true,  "Interface ID number where all packet capture will be done."],
-  "-li" => [ false, "List interfaces that can be used for capture."],
+  "-L" => [ false, "List interfaces that can be used for capture."],
   "-l"  => [ true,  "Specify and alternate folder to save PCAP file."]
 )
 meter_type = client.platform
@@ -192,7 +192,7 @@ end
     int_id = val.to_i
   when "-l"
     log_dest = val
-  when "-li"
+  when "-L"
     list_int = 1
   when "-t"
     rec_time = val

--- a/scripts/meterpreter/scheduleme.rb
+++ b/scripts/meterpreter/scheduleme.rb
@@ -21,7 +21,7 @@ session = client
   "-h" => [ false,"Help menu." ],
   "-c" => [ true,"Command to execute at the given time. If options for execution needed use double quotes"],
   "-d" => [ false,"Daily." ],
-  "-hr" => [ true,"Every specified hours 1-23."],
+  "-H" => [ true,"Every specified hours 1-23."],
   "-m" => [ true, "Every specified amount of minutes 1-1439"],
   "-e" => [ true, "Executable or script to upload to target host, will not work with remote schedule"],
   "-l" => [ false,"When a user logs on."],
@@ -214,7 +214,7 @@ password = nil
   when "-d"
     tmmod = val
     schtype = "daily"
-  when "-hr"
+  when "-H"
     tmmod = val
     schtype = "hourly"
   when "-m"

--- a/scripts/meterpreter/winbf.rb
+++ b/scripts/meterpreter/winbf.rb
@@ -12,7 +12,7 @@
   "-h"  => [ false,  "\tHelp menu."],
   "-t"  => [ true,  "\tTarget IP Address"],
   "-p"  => [ true,  "\tPassword List"],
-  "-cp" => [ false,  "\tCheck Local Machine Password Policy"],
+  "-c" => [ false,  "\tCheck Local Machine Password Policy"],
   "-L"  => [ true,  "\tUsername List to be brute forced"],
   "-l"  => [ true,  "\tLogin name to be brute forced"]
 )
@@ -164,7 +164,7 @@ unsupported if client.platform != 'windows'
     userlist = val
     ulopt = 1
 
-  when "-cp"
+  when "-c"
     chkpolicy(session)
     exit
   when "-p"


### PR DESCRIPTION
# Overview
This PR addresses the same issue as PR #8622 where changes to the Meterpreter argument parser causes multi-char arguments to fail. This lead to issues #8703 and #8773 being reported. This PR replaces all of the multi-char arguments in Meterpreter scripts that contained them with single-char arguments. I tried to use single-char arguments that made sense.

I know that Meterpreter scrips are no longer supported and that the functions of many of the scripts can be replicated using post modules. However, the use of multi_console_command is fairly pervasive and should probably be fixed.

## Verification
- [ ] Get a Meterpreter shell started that can test the scripts
Use single the new single-char arguments to test:
- [ ] multi_console_command.
- [ ] multicommand
- [ ] multi_meter_inject
- [ ] multiscript
- [ ] netenum
- [ ] packetrecorder
- [ ] scheduleme
- [ ] winbf