### PR TITLE
Add external module template for capture servers

### DIFF
--- a/lib/msf/core/module/external.rb
+++ b/lib/msf/core/module/external.rb
@@ -1,23 +1,72 @@
+include Msf::Auxiliary::Report
+
 module Msf::Module::External
   def wait_status(mod)
     while mod.running
       m = mod.get_status
       if m
-        case m['level']
-        when 'error'
-          print_error m['message']
-        when 'warning'
-          print_warning m['message']
-        when 'good'
-          print_good m['message']
-        when 'info'
-          print_status m['message']
-        when 'debug'
-          vprint_status m['message']
-        else
-          print_status m['message']
+        case m.method
+        when :message
+          log_output(m)
+        when :report
+          process_report(m)
+        when :reply
+          # we're done
+          break
         end
       end
+    end
+  end
+
+  def log_output(m)
+    message = m.params['message']
+
+    case m.params['level']
+    when 'error'
+      print_error message
+    when 'warning'
+      print_warning message
+    when 'good'
+      print_good message
+    when 'info'
+      print_status message
+    when 'debug'
+      vprint_status message
+    else
+      print_status message
+    end
+  end
+
+  def process_report(m)
+    data = m.params['data']
+
+    case m.params['type']
+    when 'host'
+      # Required
+      host = {host: data['host']}
+
+      # Optional
+      host[:state] = data['state'] if data['state'] # TODO: validate -- one of the Msf::HostState constants (unknown, alive, dead)
+      host[:os_name] = data['os_name'] if data['os_name']
+      host[:os_flavor] = data['os_flavor'] if data['os_flavor']
+      host[:os_sp] = data['os_sp'] if data['os_sp']
+      host[:os_lang] = data['os_lang'] if data['os_lang']
+      host[:arch] = data['arch'] if data['arch'] # TODO: validate -- one of the ARCH_* constants
+      host[:mac] = data['mac'] if data['mac']
+      host[:scope] = data['scope'] if data['scope']
+      host[:virtual_host] = data['virtual_host'] if data['virtual_host']
+
+      report_host(host)
+    when 'service'
+      # Required
+      service = {host: data['host'], port: data['port'], proto: data['proto']}
+
+      # Optional
+      service[:name] = data['name'] if data['name']
+
+      report_service(service)
+    else
+      print_warning "Skipping unrecognized report type #{m.params['type']}"
     end
   end
 end

--- a/lib/msf/core/module_manager/loading.rb
+++ b/lib/msf/core/module_manager/loading.rb
@@ -116,8 +116,8 @@ module Msf::ModuleManager::Loading
 
     loaders.each do |loader|
       if loader.loadable?(path)
-        count_by_type.merge!(loader.load_modules(path, options)) do |key, old, new|
-          old + new
+        count_by_type.merge!(loader.load_modules(path, options)) do |key, prev, now|
+          prev + now
         end
       end
     end

--- a/lib/msf/core/modules/external/message.rb
+++ b/lib/msf/core/modules/external/message.rb
@@ -2,11 +2,25 @@
 require 'msf/core/modules/external'
 require 'base64'
 require 'json'
+require 'securerandom'
 
 class Msf::Modules::External::Message
 
-  attr_reader :method, :id
-  attr_accessor :params
+  attr_reader :method
+  attr_accessor :params, :id
+
+  def self.from_module(j)
+    if j['method']
+      m = self.new(j['method'].to_sym)
+      m.params = j['params']
+      m
+    elsif j['response']
+      m = self.new(:reply)
+      m.params = j['response']
+      m.id = j['id']
+      m
+    end
+  end
 
   def initialize(m)
     self.method = m
@@ -20,5 +34,5 @@ class Msf::Modules::External::Message
 
   protected
 
-  attr_writer :method, :id
+  attr_writer :method
 end

--- a/lib/msf/core/modules/external/python/metasploit/module.py
+++ b/lib/msf/core/modules/external/python/metasploit/module.py
@@ -1,20 +1,37 @@
 import sys, os, json
 
 def log(message, level='info'):
-    print(json.dumps({'jsonrpc': '2.0', 'method': 'message', 'params': {
+    rpc_send({'jsonrpc': '2.0', 'method': 'message', 'params': {
         'level': level,
         'message': message
-    }}))
-    sys.stdout.flush()
+    }})
+
+def report_host(ip, opts={}):
+    host = opts.copy()
+    host.update({'host': ip})
+    rpc_send({'jsonrpc': '2.0', 'method': 'report', 'params': {
+        'type': 'host', 'data': host
+    }})
+
+def report_service(ip, opts={}):
+    service = opts.copy()
+    service.update({'host': ip})
+    rpc_send({'jsonrpc': '2.0', 'method': 'report', 'params': {
+        'type': 'service', 'data': service
+    }})
+
 
 def run(metadata, exploit):
     req = json.loads(os.read(0, 10000))
     if req['method'] == 'describe':
-        print(json.dumps({'jsonrpc': '2.0', 'id': req['id'], 'response': metadata}))
+        rpc_send({'jsonrpc': '2.0', 'id': req['id'], 'response': metadata})
     elif req['method'] == 'run':
         args = req['params']
         exploit(args)
-        print(json.dumps({'jsonrpc': '2.0', 'id': req['id'], 'response': {
+        rpc_send({'jsonrpc': '2.0', 'id': req['id'], 'response': {
             'message': 'Exploit completed'
-        }}))
-        sys.stdout.flush()
+        }})
+
+def rpc_send(req):
+    print(json.dumps(req))
+    sys.stdout.flush()

--- a/lib/msf/core/modules/external/shim.rb
+++ b/lib/msf/core/modules/external/shim.rb
@@ -9,6 +9,8 @@ class Msf::Modules::External::Shim
     case mod.meta['type']
     when 'remote_exploit_cmd_stager'
       remote_exploit_cmd_stager(mod)
+    when 'capture_server'
+      capture_server(mod)
     end
   end
 
@@ -26,10 +28,6 @@ class Msf::Modules::External::Shim
     meta[:name]        = mod.meta['name'].dump
     meta[:description] = mod.meta['description'].dump
     meta[:authors]     = mod.meta['authors'].map(&:dump).join(",\n          ")
-    meta[:date]        = mod.meta['date'].dump
-    meta[:references]  = mod.meta['references'].map do |r|
-      "[#{r['type'].upcase.dump}, #{r['ref'].dump}]"
-    end.join(",\n          ")
 
     meta[:options]     = mod.meta['options'].map do |n, o|
       "Opt#{o['type'].capitalize}.new(#{n.dump},
@@ -39,11 +37,15 @@ class Msf::Modules::External::Shim
   end
 
   def self.mod_meta_exploit(mod, meta = {})
+    meta[:date]        = mod.meta['date'].dump
     meta[:wfsdelay]    = mod.meta['wfsdelay'] || 5
     meta[:privileged]  = mod.meta['privileged'].inspect
     meta[:platform]    = mod.meta['targets'].map do |t|
       t['platform'].dump
     end.uniq.join(",\n          ")
+    meta[:references]  = mod.meta['references'].map do |r|
+      "[#{r['type'].upcase.dump}, #{r['ref'].dump}]"
+    end.join(",\n          ")
     meta[:targets]     = mod.meta['targets'].map do |t|
       "[#{t['platform'].dump} + ' ' + #{t['arch'].dump}, {'Arch' => ARCH_#{t['arch'].upcase}, 'Platform' => #{t['platform'].dump} }]"
     end.join(",\n          ")
@@ -55,5 +57,10 @@ class Msf::Modules::External::Shim
     meta = mod_meta_exploit(mod, meta)
     meta[:command_stager_flavor] = mod.meta['payload']['command_stager_flavor'].dump
     render_template('remote_exploit_cmd_stager.erb', meta)
+  end
+
+  def self.capture_server(mod)
+    meta = mod_meta_common(mod)
+    render_template('capture_server.erb', meta)
   end
 end

--- a/lib/msf/core/modules/external/shim.rb
+++ b/lib/msf/core/modules/external/shim.rb
@@ -11,6 +11,9 @@ class Msf::Modules::External::Shim
       remote_exploit_cmd_stager(mod)
     when 'capture_server'
       capture_server(mod)
+    else
+      # TODO have a nice load error show up in the logs
+      ''
     end
   end
 

--- a/lib/msf/core/modules/external/templates/capture_server.erb
+++ b/lib/msf/core/modules/external/templates/capture_server.erb
@@ -2,7 +2,6 @@ require 'msf/core/modules/external/bridge'
 require 'msf/core/module/external'
 
 class MetasploitModule < Msf::Auxiliary
-  # include Msf::Auxiliary::Report
   include Msf::Module::External
 
   def initialize

--- a/lib/msf/core/modules/external/templates/capture_server.erb
+++ b/lib/msf/core/modules/external/templates/capture_server.erb
@@ -1,0 +1,27 @@
+require 'msf/core/modules/external/bridge'
+require 'msf/core/module/external'
+
+class MetasploitModule < Msf::Auxiliary
+  # include Msf::Auxiliary::Report
+  include Msf::Module::External
+
+  def initialize
+    super({
+	  <%= common_metadata meta %>
+      'Actions'     => [ ['Capture'] ],
+      'PassiveActions' => ['Capture'],
+      'DefaultAction'  => 'Capture'
+      })
+
+      register_options([
+        <%= meta[:options] %>
+      ])
+  end
+
+  def run
+    print_status("Starting server...")
+    mod = Msf::Modules::External::Bridge.open(<%= meta[:path] %>)
+    mod.run(datastore)
+    wait_status(mod)
+  end
+end


### PR DESCRIPTION
Adds a template for writing external servers along the lines of `auxiliary/server/capture/*`. DB reporting is still TODO.

- [ ] Drop [capture_test.py](https://gist.github.com/acammack-r7/aac49ba6c2af1bd3132aee8d76ed6b68) into `modules/auxiliary/server/capture/` and `chmod +x`
- [ ] `./msfconsole`
- [ ] `use auxiliary/server/capture/capture_test`
- [ ] `run`
- [ ] `[*] TEST` should print once every 5 seconds for 5 times (or whatever you set it to)
- [ ] The module should run backgrounded