### PR TITLE
Fix annoying print_brute messages in ssh_login

### DIFF
--- a/lib/msf/core/auxiliary/auth_brute.rb
+++ b/lib/msf/core/auxiliary/auth_brute.rb
@@ -362,7 +362,6 @@ module Auxiliary::AuthBrute
   # Note, these special username/passwords should get deprecated
   # some day. Note2: Don't use with SMB and FTP at the same time!
   def translate_proto_datastores
-    switched = false
     ['SMBUser','FTPUSER'].each do |u|
       if datastore[u] and !datastore[u].empty?
         datastore['USERNAME'] = datastore[u]
@@ -547,6 +546,20 @@ module Auxiliary::AuthBrute
     end
   end
 
+  def vprint_status(msg='')
+    print_brute :level => :vstatus
+  end
+
+  def vprint_error(msg='')
+    print_brute :level => :verror
+  end
+
+  alias_method :vprint_bad, :vprint_error
+
+  def vprint_good(msg='')
+    print_brute :level => :vgood
+  end
+
   # Provides a consistant way to display messages about AuthBrute-mixed modules.
   # Acceptable opts are fairly self-explanatory, but :level can be tricky.
   #
@@ -568,10 +581,10 @@ module Auxiliary::AuthBrute
     end
     host_ip = opts[:ip] || opts[:rhost] || opts[:host] || (rhost rescue nil) || datastore['RHOST']
     host_port = opts[:port] || opts[:rport] || (rport rescue nil) || datastore['RPORT']
-    msg = opts[:msg] || opts[:message] || opts[:legacy_msg]
+    msg = opts[:msg] || opts[:message]
     proto = opts[:proto] || opts[:protocol] || proto_from_fullname
 
-    complete_message = build_brute_message(host_ip,host_port,proto,msg,!!opts[:legacy_msg])
+    complete_message = build_brute_message(host_ip,host_port,proto,msg)
 
     print_method = "print_#{level}"
     if self.respond_to? print_method
@@ -582,34 +595,24 @@ module Auxiliary::AuthBrute
   end
 
   # Depending on the non-nil elements, build up a standardized
-  # auth_brute message, but support the old style used by
-  # vprint_status and friends as well.
-  def build_brute_message(host_ip,host_port,proto,msg,legacy)
+  # auth_brute message.
+  def build_brute_message(host_ip,host_port,proto,msg)
     ip = host_ip.to_s.strip if host_ip
     port = host_port.to_s.strip if host_port
     complete_message = nil
-    extracted_message = nil
-    if legacy # TODO: This is all a workaround until I get a chance to get rid of the legacy messages
-      old_msg = msg.to_s.strip
-      msg_regex = /(#{ip})(:#{port})?(\s*-?\s*)(#{proto.to_s})?(\s*-?\s*)(.*)/ni
-      if old_msg.match(msg_regex) and !old_msg.match(msg_regex)[6].to_s.strip.empty?
-        complete_message = ''
-        unless ip.blank? && port.blank?
-          complete_message << "#{ip}:#{rport}"
-        else
-          complete_message << (old_msg.match(msg_regex)[4] || proto).to_s
-        end
-
-        complete_message << " - "
-        progress = tried_over_total(ip,port)
-        complete_message << progress if progress
-        complete_message << old_msg.match(msg_regex)[6].to_s.strip
-      else
-        complete_message = msg.to_s.strip
-      end
+    old_msg = msg.to_s.strip
+    msg_regex = /(#{ip})(:#{port})?(\s*-?\s*)(#{proto.to_s})?(\s*-?\s*)(.*)/ni
+    if old_msg.match(msg_regex)
+      complete_message = msg.to_s.strip
     else
       complete_message = ''
-      complete_message << "#{proto.to_s.strip} - " if proto
+      unless ip.blank? && port.blank?
+        complete_message << "#{ip}:#{rport}"
+      else
+        complete_message << proto || 'Bruteforce'
+      end
+
+      complete_message << " - "
       progress = tried_over_total(ip,port)
       complete_message << progress if progress
       complete_message << msg.to_s.strip
@@ -655,23 +658,6 @@ module Auxiliary::AuthBrute
   # smb_auth.
   def proto_from_fullname
     File.split(self.fullname).last.match(/^(.*)_(login|auth|identify)/)[1].upcase rescue nil
-  end
-
-  # Legacy vprint
-  def vprint_status(msg='')
-    print_brute :level => :vstatus, :legacy_msg => msg
-  end
-
-  # Legacy vprint
-  def vprint_error(msg='')
-    print_brute :level => :verror, :legacy_msg => msg
-  end
-
-  alias_method :vprint_bad, :vprint_error
-
-  # Legacy vprint
-  def vprint_good(msg='')
-    print_brute :level => :vgood, :legacy_msg => msg
   end
 
   # This method deletes the dictionary files if requested

--- a/modules/auxiliary/scanner/ssh/ssh_login.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login.rb
@@ -17,19 +17,20 @@ class MetasploitModule < Msf::Auxiliary
 
   def initialize
     super(
-      'Name'        => 'SSH Login Check Scanner',
-      'Description' => %q{
+      'Name'           => 'SSH Login Check Scanner',
+      'Description'    => %q{
         This module will test ssh logins on a range of machines and
         report successful logins.  If you have loaded a database plugin
         and connected to a database this module will record successful
         logins and hosts so you can track your access.
       },
-      'Author'      => ['todb'],
+      'Author'         => ['todb'],
       'References'     =>
         [
           [ 'CVE', '1999-0502'] # Weak password
         ],
-      'License'     => MSF_LICENSE
+      'License'        => MSF_LICENSE,
+      'DefaultOptions' => {'VERBOSE' => false} # Disable annoying connect errors
     )
 
     register_options(
@@ -95,7 +96,6 @@ class MetasploitModule < Msf::Auxiliary
 
   def run_host(ip)
     @ip = ip
-    print_brute :ip => ip, :msg => "Starting bruteforce"
 
     cred_collection = Metasploit::Framework::CredentialCollection.new(
       blank_passwords: datastore['BLANK_PASSWORDS'],
@@ -138,16 +138,12 @@ class MetasploitModule < Msf::Auxiliary
         session_setup(result, scanner.ssh_socket)
         :next_user
       when Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
-        if datastore['VERBOSE']
-          print_brute :level => :verror, :ip => ip, :msg => "Could not connect: #{result.proof}"
-        end
+        vprint_brute :level => :verror, :ip => ip, :msg => "Could not connect: #{result.proof}"
         scanner.ssh_socket.close if scanner.ssh_socket && !scanner.ssh_socket.closed?
         invalidate_login(credential_data)
         :abort
       when Metasploit::Model::Login::Status::INCORRECT
-        if datastore['VERBOSE']
-          print_brute :level => :verror, :ip => ip, :msg => "Failed: '#{result.credential}'"
-        end
+        vprint_brute :level => :verror, :ip => ip, :msg => "Failed: '#{result.credential}'"
         invalidate_login(credential_data)
         scanner.ssh_socket.close if scanner.ssh_socket && !scanner.ssh_socket.closed?
       else

--- a/modules/auxiliary/scanner/ssh/ssh_login.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login.rb
@@ -131,19 +131,19 @@ class MetasploitModule < Msf::Auxiliary
       )
       case result.status
       when Metasploit::Model::Login::Status::SUCCESSFUL
-        print_brute :level => :good, :ip => ip, :msg => "Success: '#{result.credential}' '#{result.proof.to_s.gsub(/[\r\n\e\b\a]/, ' ')}'"
+        print_brute :level => :good, :ip => ip, :msg => "#{ip}:#{rport} - Success: '#{result.credential}' '#{result.proof.to_s.gsub(/[\r\n\e\b\a]/, ' ')}'"
         credential_core = create_credential(credential_data)
         credential_data[:core] = credential_core
         create_credential_login(credential_data)
         session_setup(result, scanner.ssh_socket)
         :next_user
       when Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
-        vprint_brute :level => :verror, :ip => ip, :msg => "Could not connect: #{result.proof}"
+        vprint_brute :level => :verror, :ip => ip, :msg => "#{ip}:#{rport} - Could not connect: #{result.proof}"
         scanner.ssh_socket.close if scanner.ssh_socket && !scanner.ssh_socket.closed?
         invalidate_login(credential_data)
         :abort
       when Metasploit::Model::Login::Status::INCORRECT
-        vprint_brute :level => :verror, :ip => ip, :msg => "Failed: '#{result.credential}'"
+        vprint_brute :level => :verror, :ip => ip, :msg => "#{ip}:#{rport} - Failed: '#{result.credential}'"
         invalidate_login(credential_data)
         scanner.ssh_socket.close if scanner.ssh_socket && !scanner.ssh_socket.closed?
       else

--- a/modules/auxiliary/scanner/ssh/ssh_login.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login.rb
@@ -131,19 +131,19 @@ class MetasploitModule < Msf::Auxiliary
       )
       case result.status
       when Metasploit::Model::Login::Status::SUCCESSFUL
-        print_brute :level => :good, :ip => ip, :msg => "#{ip}:#{rport} - Success: '#{result.credential}' '#{result.proof.to_s.gsub(/[\r\n\e\b\a]/, ' ')}'"
+        print_brute :level => :good, :ip => ip, :msg => "Success: '#{result.credential}' '#{result.proof.to_s.gsub(/[\r\n\e\b\a]/, ' ')}'"
         credential_core = create_credential(credential_data)
         credential_data[:core] = credential_core
         create_credential_login(credential_data)
         session_setup(result, scanner.ssh_socket)
         :next_user
       when Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
-        vprint_brute :level => :verror, :ip => ip, :msg => "#{ip}:#{rport} - Could not connect: #{result.proof}"
+        vprint_brute :level => :verror, :ip => ip, :msg => "Could not connect: #{result.proof}"
         scanner.ssh_socket.close if scanner.ssh_socket && !scanner.ssh_socket.closed?
         invalidate_login(credential_data)
         :abort
       when Metasploit::Model::Login::Status::INCORRECT
-        vprint_brute :level => :verror, :ip => ip, :msg => "#{ip}:#{rport} - Failed: '#{result.credential}'"
+        vprint_brute :level => :verror, :ip => ip, :msg => "Failed: '#{result.credential}'"
         invalidate_login(credential_data)
         scanner.ssh_socket.close if scanner.ssh_socket && !scanner.ssh_socket.closed?
       else


### PR DESCRIPTION
Testing `ssh_login`:

- [x] Test the module
- [x] See conservative printing (no "starting bruteforce" message)
- [x] Test the module with `VERBOSE` enabled
- [x] See the expected verbose messages

Testing `AuthBrute`:

- [x] Test `ssh_login` using the existing `print_brute` messages
- [x] See that they're rebuilt to the "legacy" (superior) format
- [x] Test with a message matching the newly inverted regex in `build_brute_message`
- [x] See the message isn't doubled