### PR TITLE
Expose session naming to console users

### DIFF
--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -539,6 +539,7 @@ class ReadableText
 
     columns = []
     columns << 'Id'
+    columns << 'Name'
     columns << 'Type'
     columns << 'Checkin?' if show_extended
     columns << 'Local URI' if show_extended
@@ -561,6 +562,7 @@ class ReadableText
 
       row = []
       row << session.sid.to_s
+      row << session.sname.to_s
       row << session.type.to_s
       if session.respond_to?(:session_type)
         row[-1] << (" " + session.session_type)
@@ -610,6 +612,7 @@ class ReadableText
 
       sess_info    = session.info.to_s
       sess_id      = session.sid.to_s
+      sess_name    = session.sname.to_s
       sess_tunnel  = session.tunnel_to_s + " (#{session.session_host})"
       sess_via     = session.via_exploit.to_s
       sess_type    = session.type.to_s
@@ -636,6 +639,7 @@ class ReadableText
       end
 
       out << "  Session ID: #{sess_id}\n"
+      out << "        Name: #{sess_name}\n"
       out << "        Type: #{sess_type}\n"
       out << "        Info: #{sess_info}\n"
       out << "      Tunnel: #{sess_tunnel}\n"

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1477,7 +1477,7 @@ class Core
       print(Serializer::ReadableText.dump_sessions(framework, :show_extended => show_extended, :verbose => verbose, :search_term => search_term))
       print_line
     when 'name'
-      if session_name.nil? || session_name.blank?
+      if session_name.blank?
         print_error('Please specify a valid session name')
         return false
       end


### PR DESCRIPTION
# WIP

**TODO:** Continue refactoring other options to take names instead of just IDs.

- [x] `sessions -n name -i id`
- [x] `sessions`
- [x] See name(s)
- [x] `sessions -v`
- [x] See name(s)