### PR TITLE
Fix post/linux/gather/hashdump NoMethodError

### DIFF
--- a/modules/post/linux/gather/hashdump.rb
+++ b/modules/post/linux/gather/hashdump.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Post
       p1 = store_loot("linux.shadow", "text/plain", session, shadow_file, "shadow.tx", "Linux Password Shadow File")
       p2 = store_loot("linux.passwd", "text/plain", session, passwd_file, "passwd.tx", "Linux Passwd File")
       vprint_good("Shadow saved in: #{p1.to_s}")
-      vprint_goo("passwd saved in: #{p2.to_s}")
+      vprint_good("passwd saved in: #{p2.to_s}")
 
       # Unshadow the files
       john_file = unshadow(passwd_file, shadow_file)


### PR DESCRIPTION
This PR fixes a NoMethodError in post/linux/gather/hashdump
where it attempts to call the nonexistent vprint_goo where it
should call vprint_good.

## Verification

- [x] Get a `shell` or `meterpreter` session on some host.
- [x] `use post/linux/gather/hashdump`
- [x] `set SESSION [SESSION_ID]`, replacing `[SESSION_ID]` with the 
session number you wish to run this on.
- [x] `run`
- [x] **Verify** No errors and the module runs successfully

