### PR TITLE
don't override standard string 'encode' methods with metasm_shell

### DIFF
--- a/tools/exploit/metasm_shell.rb
+++ b/tools/exploit/metasm_shell.rb
@@ -91,15 +91,15 @@ class String
   end
 
   # encodes the current string as a Shellcode, returns the resulting EncodedData
-  def encode_edata
+  def metasm_encode_edata
     s = Metasm::Shellcode.assemble @@cpu, self
     s.encoded
   end
 
   # encodes the current string as a Shellcode, returns the resulting binary String
   # outputs warnings on unresolved relocations
-  def encode
-    ed = encode_edata
+  def metasm_encode
+    ed = metasm_encode_edata
     if not ed.reloc.empty?
       puts 'W: encoded string has unresolved relocations: ' + ed.reloc.map { |o, r| r.target.inspect }.join(', ')
     end
@@ -147,9 +147,9 @@ def parse_gas_file(filename)
   end
 
   begin
-    encoded = shellcode.encode
+    encoded = shellcode.metasm_encode
     puts Rex::Text.to_ruby(encoded)
-    puts encoded.disassemble(shellcode.encode)
+    puts encoded.disassemble(shellcode.metasm_encode)
   rescue Metasm::Exception => e
     puts "Error: #{e.class} #{e.message}"
   end
@@ -179,7 +179,7 @@ shell.run { |l|
   next if l.strip.empty?
 
   begin
-    l = l.encode
+    l = l.metasm_encode
     puts '"' + l.unpack('C*').map { |c| '\\x%02x' % c }.join + '"'
   rescue Metasm::Exception => e
     puts "Error: #{e.class} #{e.message}"

--- a/tools/exploit/metasm_shell.rb
+++ b/tools/exploit/metasm_shell.rb
@@ -109,20 +109,20 @@ class String
 
   # decodes the current string as a Shellcode, with specified base address
   # returns the resulting Disassembler
-  def decode_blocks(base_addr=0, eip=base_addr)
-    sc = Metasm::Shellcode.decode(self, @@cpu)
+  def metasm_decode_blocks(base_addr=0, eip=base_addr)
+    sc = Metasm::Shellcode.metasm_decode(self, @@cpu)
     sc.base_addr = base_addr
-    sc.disassemble(eip)
+    sc.metasm_disassemble(eip)
   end
 
   # decodes the current string as a Shellcode, with specified base address
   # returns the asm source equivallent
-  def decode(base_addr=0, eip=base_addr)
-    decode_blocks(base_addr, eip).to_s
+  def metasm_decode(base_addr=0, eip=base_addr)
+    metasm_decode_blocks(base_addr, eip).to_s
   end
 
-  def disassemble(str, eip=0)
-    Metasm::Shellcode.disassemble(@@cpu, str, eip)
+  def metasm_disassemble(str, eip=0)
+    Metasm::Shellcode.metasm_disassemble(@@cpu, str, eip)
   end
 
 end
@@ -149,7 +149,7 @@ def parse_gas_file(filename)
   begin
     encoded = shellcode.metasm_encode
     puts Rex::Text.to_ruby(encoded)
-    puts encoded.disassemble(shellcode.metasm_encode)
+    puts encoded.metasm_disassemble(shellcode.metasm_encode)
   rescue Metasm::Exception => e
     puts "Error: #{e.class} #{e.message}"
   end


### PR DESCRIPTION
this fixes metasm_shell.rb to go from:

```
$ ./tools/exploit/metasm_shell.rb
type "exit" or "quit" to quit
use ";" or "\n" for newline
type "file <file>" to parse a GAS assembler source file

metasm > push 1
./tools/exploit/metasm_shell.rb:101:in `encode': wrong number of arguments (given 2, expected 0) (ArgumentError)
	from /Users/bcook/rapid7/metasploit-framework/vendor/bundle/ruby/2.4.0/gems/rb-readline-0.5.5/lib/rbreadline.rb:6135:in `alloc_history_entry'
	from /Users/bcook/rapid7/metasploit-framework/vendor/bundle/ruby/2.4.0/gems/rb-readline-0.5.5/lib/rbreadline.rb:6168:in `add_history'
	from /Users/bcook/rapid7/metasploit-framework/lib/rex/ui/text/input/readline.rb:171:in `readline_with_output'
	from /Users/bcook/rapid7/metasploit-framework/lib/rex/ui/text/input/readline.rb:100:in `pgets'
	from /Users/bcook/rapid7/metasploit-framework/lib/rex/ui/text/shell.rb:188:in `run'
	from ./tools/exploit/metasm_shell.rb:169:in `<main>'
```

```
$ ./tools/exploit/metasm_shell.rb
type "exit" or "quit" to quit
use ";" or "\n" for newline
type "file <file>" to parse a GAS assembler source file

metasm > push 1
"\x6a\x01"
metasm >
```

Unfortunately it doesn't also flog the person who thought monkey-patching the standard Ruby String object was a good idea, but I understand Ruby 1.x was crazy times :)