### PR TITLE
Fix youtube urls

### DIFF
--- a/modules/post/multi/manage/play_youtube.rb
+++ b/modules/post/multi/manage/play_youtube.rb
@@ -28,11 +28,13 @@ class MetasploitModule < Msf::Post
       ])
   end
 
+  YOUTUBE_BASE_URL = "https://youtube.com/embed/"
+
   #
   # The OSX version uses an apple script to do this
   #
   def osx_start_video(id)
-    url = "https://youtube.googleapis.com/v/#{id}?fs=1&#{PLAY_OPTIONS}"
+    url = "#{YOUTUBE_BASE_URL}#{id}?#{PLAY_OPTIONS}"
     script = ''
     script << %Q|osascript -e 'tell application "Safari" to open location "#{url}"' |
     script << %Q|-e 'activate application "Safari"' |
@@ -53,7 +55,7 @@ class MetasploitModule < Msf::Post
   def win_start_video(id)
     iexplore_path = "C:\\Program Files\\Internet Explorer\\iexplore.exe"
     begin
-      session.sys.process.execute(iexplore_path, "-k https://www.youtube.com/embed/#{id}?#{PLAY_OPTIONS}")
+      session.sys.process.execute(iexplore_path, "-k #{YOUTUBE_BASE_URL}#{id}?#{PLAY_OPTIONS}")
     rescue Rex::Post::Meterpreter::RequestError => e
       return false
     end
@@ -80,7 +82,7 @@ class MetasploitModule < Msf::Post
       write_file("/tmp/#{profile_name}/prefs.js", s)
 
       # Start the video
-      url = "https://youtube.googleapis.com/v/#{id}?fs=1&#{PLAY_OPTIONS}"
+      url = "#{YOUTUBE_BASE_URL}#{id}?#{PLAY_OPTIONS}"
       data_js = %Q|"data:text/html,<script>window.open('#{url}','','width:100000px;height:100000px');</script>"|
       joe = "firefox --display :0 -p #{profile_name} #{data_js} &"
       cmd_exec("/bin/sh -c #{joe.shellescape}")

--- a/modules/post/multi/manage/play_youtube.rb
+++ b/modules/post/multi/manage/play_youtube.rb
@@ -56,7 +56,7 @@ class MetasploitModule < Msf::Post
     iexplore_path = "C:\\Program Files\\Internet Explorer\\iexplore.exe"
     begin
       session.sys.process.execute(iexplore_path, "-k #{YOUTUBE_BASE_URL}#{id}?#{PLAY_OPTIONS}")
-    rescue Rex::Post::Meterpreter::RequestError => e
+    rescue Rex::Post::Meterpreter::RequestError
       return false
     end
 
@@ -100,7 +100,7 @@ class MetasploitModule < Msf::Post
     intenturl = "intent://youtube.com/watch?v=#{id}&autoplay=1#Intent;scheme=http;action=android.intent.action.VIEW;end"
     begin
       session.android.activity_start(intenturl)
-    rescue Rex::Post::Meterpreter::RequestError => e
+    rescue Rex::Post::Meterpreter::RequestError
       return false
     end
     true


### PR DESCRIPTION
This fixes the youtube post exploit module to properly display fullscreen when run on OS X and Linux.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`, get a session on OS X or Linux
- [x] `use post/multi/manage/play_youtube`
- [x] **Verify** the video plays fullscreen
