### PR TITLE
Revert passive stance for multi/handler

### DIFF
--- a/modules/exploits/multi/handler.rb
+++ b/modules/exploits/multi/handler.rb
@@ -33,8 +33,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Platform'       => %w[android bsd java js linux osx nodejs php python ruby solaris unix win mainframe multi],
         'Arch'           => ARCH_ALL,
         'Targets'        => [ [ 'Wildcard Target', {} ] ],
-        'DefaultTarget'  => 0,
-        'Stance'         => Msf::Exploit::Stance::Passive
+        'DefaultTarget'  => 0
       )
     )
 


### PR DESCRIPTION
```
18:12 < sednawk> anybody around to answer a quick question about a potential bug in metasploit v4.15.5-dev?
18:12 <@wvu> sednawk: Go ahead and ask :)
18:12 < sednawk> when you issue the run/exploit commands, it would seem it defaults to using the -j option sending it immediately to the background.
18:13 <@wvu> Passive module
18:13 <@wvu> sednawk: What module is it?
18:13 < sednawk> multi handler
18:13 <@wvu> I want to roll that back, busterbcook 
18:13 < sednawk> with a windows/meterpreter/reverse_tcp payload
18:14 <@wvu> It's been bugging me, too
18:14 <@wvu> I thought it would be a good idea at first
18:14 <@wvu> But run -j is easy to type
18:14 <@wvu> The real change was setting ExitOnSession to false
18:14 < sednawk> when i'm only going after one system, it's inconvenient to deal with sessions.
18:14 < sednawk> the default for exitonsession is now false?
18:14 <@wvu> It is
18:15 <@wvu> So you can get multiple sessions at your multi/handler
18:15 <@wvu> *That* makes sense
18:15 <@wvu> Making the handler background automatically was too far, I think
18:15 <@wvu> sednawk: Are you on a Git checkout?
18:15 < sednawk> i am not
18:15 <@wvu> Or Kali or something?
18:15 <@wvu> Welp
18:15 < sednawk> kali
18:15 <@wvu> Can't help there
18:15 < sednawk> kali rolling
18:15 <@wvu> You'd have to wait for a new release
18:15 < sednawk> the latest update made this change
18:15 <@wvu> But I'm gonna fix it in Git
18:15 < sednawk> thank you very much!
18:15 <@wvu> You'll see it in the next update
18:16 < sednawk> thats great news
```

cc @busterb