### PR TITLE
update references to sourceforge ML

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,4 +119,4 @@ already way ahead of the curve, so keep it up!
 [YARD]:http://yardoc.org
 [Issues]:https://github.com/rapid7/metasploit-framework/issues
 [Freenode IRC channel]:http://webchat.freenode.net/?channels=%23metasploit&uio=d4
-[metasploit-hackers]:https://lists.sourceforge.net/lists/listinfo/metasploit-hackers
+[metasploit-hackers]:https://groups.google.com/forum/#!forum/metasploit-hackers

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Questions and suggestions can be sent to: Freenode IRC channel or e-mail the met
 Installing
 --
 
-Generally, you should use [the free installer](https://www.metasploit.com/download),
+Generally, you should use [the free installer](https://github.com/rapid7/metasploit-framework/wiki/Nightly-Installers),
 which contains all of the dependencies and will get you up and running with a
 few clicks. See the [Dev Environment Setup](https://r-7.co/MSF-DEV) if
 you'd like to deal with dependencies on your own.

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.name          = 'metasploit-framework'
   spec.version       = Metasploit::Framework::GEM_VERSION
   spec.authors       = ['Metasploit Hackers']
-  spec.email         = ['metasploit-hackers@lists.sourceforge.net']
+  spec.email         = ['msfdev@metasploit.com']
   spec.summary       = 'metasploit-framework'
   spec.description   = 'metasploit-framework'
   spec.homepage      = 'https://www.metasploit.com'


### PR DESCRIPTION
This fixes #8691 by removing sourceforge mailing list links, and fixes an outdated link to the installer.
