### PR TITLE
Fix payload specs

### DIFF
--- a/lib/rex/post/meterpreter/packet.rb
+++ b/lib/rex/post/meterpreter/packet.rb
@@ -659,7 +659,7 @@ class Packet < GroupTlv
   PACKET_LENGTH_SIZE = 4
   PACKET_TYPE_SIZE = 4
   PACKET_HEADER_SIZE = XOR_KEY_SIZE + SESSION_GUID_SIZE + ENCRYPTED_FLAGS_SIZE + PACKET_LENGTH_SIZE + PACKET_TYPE_SIZE
-  
+
   AES_IV_SIZE = 16
 
   ENC_FLAG_NONE   = 0x0
@@ -783,10 +783,10 @@ class Packet < GroupTlv
   # the serialized TLV content, and then returns the key plus the
   # scrambled data as the payload.
   #
-  def to_r(session_guid=nil, key=nil)
+  def to_r(session_guid = nil, key = nil)
     xor_key = (rand(254) + 1).chr + (rand(254) + 1).chr + (rand(254) + 1).chr + (rand(254) + 1).chr
 
-    raw = [(session_guid || "0"*32).gsub(/-/, '')].pack('H*')
+    raw = [(session_guid || "0" * SESSION_GUID_SIZE).gsub(/-/, '')].pack('H*')
     tlv_data = GroupTlv.instance_method(:to_r).bind(self).call
 
     if key && key[:key] && key[:type] == ENC_FLAG_AES256

--- a/lib/rex/post/meterpreter/packet.rb
+++ b/lib/rex/post/meterpreter/packet.rb
@@ -786,7 +786,7 @@ class Packet < GroupTlv
   def to_r(session_guid = nil, key = nil)
     xor_key = (rand(254) + 1).chr + (rand(254) + 1).chr + (rand(254) + 1).chr + (rand(254) + 1).chr
 
-    raw = [(session_guid || "0" * SESSION_GUID_SIZE).gsub(/-/, '')].pack('H*')
+    raw = [(session_guid || '00' * SESSION_GUID_SIZE).gsub(/-/, '')].pack('H*')
     tlv_data = GroupTlv.instance_method(:to_r).bind(self).call
 
     if key && key[:key] && key[:type] == ENC_FLAG_AES256

--- a/spec/lib/rex/post/meterpreter/packet_parser_spec.rb
+++ b/spec/lib/rex/post/meterpreter/packet_parser_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Rex::Post::Meterpreter::PacketParser do
     begin
       parsed_packet = parser.recv(@sock)
     end while parsed_packet.nil?
+    parsed_packet.from_r
     expect(parsed_packet).to be_a Rex::Post::Meterpreter::Packet
     expect(parsed_packet.type).to eq Rex::Post::Meterpreter::PACKET_TYPE_REQUEST
     expect(parsed_packet.method?("test_method")).to eq true

--- a/spec/lib/rex/post/meterpreter/packet_parser_spec.rb
+++ b/spec/lib/rex/post/meterpreter/packet_parser_spec.rb
@@ -1,33 +1,21 @@
 # -*- coding:binary -*-
 require 'rex/post/meterpreter/packet'
 require 'rex/post/meterpreter/packet_parser'
-
+require 'stringio'
 
 RSpec.describe Rex::Post::Meterpreter::PacketParser do
   subject(:parser){
     Rex::Post::Meterpreter::PacketParser.new
   }
   before(:example) do
-    @req_packt = Rex::Post::Meterpreter::Packet.new(
-          Rex::Post::Meterpreter::PACKET_TYPE_REQUEST,
-          "test_method")
-    @raw = @req_packt.to_r
-    @sock = double('Socket')
-    allow(@sock).to receive(:read) do |arg|
-      @raw.slice!(0,arg)
-    end
-  end
-
-  it "should initialise with expected defaults" do
-    expect(parser.send(:raw)).to eq ""
-    expect(parser.send(:hdr_length_left)).to eq 12
-    expect(parser.send(:payload_length_left)).to eq 0
+    @request_packet = Rex::Post::Meterpreter::Packet.create_request("test_method")
+    @sock = StringIO.new(@request_packet.to_r)
   end
 
   it "should parse valid raw data into a packet object" do
-    while @raw.length >0
+    begin
       parsed_packet = parser.recv(@sock)
-    end
+    end while parsed_packet.nil?
     expect(parsed_packet).to be_a Rex::Post::Meterpreter::Packet
     expect(parsed_packet.type).to eq Rex::Post::Meterpreter::PACKET_TYPE_REQUEST
     expect(parsed_packet.method?("test_method")).to eq true

--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -1819,6 +1819,36 @@ RSpec.describe 'modules/payloads', :content do
                           reference_name: 'osx/x64/exec'
   end
 
+  context 'osx/x64/meterpreter_reverse_http' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                            'singles/osx/x64/meterpreter_reverse_http'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'osx/x64/meterpreter_reverse_http'
+  end
+
+  context 'osx/x64/meterpreter_reverse_https' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                            'singles/osx/x64/meterpreter_reverse_https'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'osx/x64/meterpreter_reverse_https'
+  end
+
+  context 'osx/x64/meterpreter_reverse_tcp' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                            'singles/osx/x64/meterpreter_reverse_tcp'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'osx/x64/meterpreter_reverse_tcp'
+  end
+
   context 'osx/x64/say' do
     it_should_behave_like 'payload cached size is consistent',
                           ancestor_reference_names: [


### PR DESCRIPTION
This updates the packet parser specs for the latest sematics with crypttlv (from_r is no longer implicit since we may need a crypto key). It may look like I removed half of the spec, largely because StringIO is a nicer way to mock a socket than what we had.

## Verification Steps

 - [x] Passes specs
 - [x] Actually still works with real payloads