### PR TITLE
Fix typo s/rport/port/ in build_brute_message

### DIFF
--- a/lib/msf/core/auxiliary/auth_brute.rb
+++ b/lib/msf/core/auxiliary/auth_brute.rb
@@ -607,7 +607,7 @@ module Auxiliary::AuthBrute
     else
       complete_message = ''
       unless ip.blank? && port.blank?
-        complete_message << "#{ip}:#{rport}"
+        complete_message << "#{ip}:#{port}"
       else
         complete_message << proto || 'Bruteforce'
       end


### PR DESCRIPTION
I missed this in #7202.