### PR TITLE
fix Windows server 2016 support for domain_hashdump

### DIFF
--- a/modules/post/windows/gather/credentials/domain_hashdump.rb
+++ b/modules/post/windows/gather/credentials/domain_hashdump.rb
@@ -12,6 +12,7 @@ class MetasploitModule < Msf::Post
   include Msf::Post::Windows::Priv
   include Msf::Post::Windows::ShadowCopy
   include Msf::Post::File
+  include Msf::Post::Windows::ExtAPI
 
   def initialize(info={})
     super(update_info(info,
@@ -115,6 +116,7 @@ class MetasploitModule < Msf::Post
     unless session_compat?
       return false
     end
+    load_extapi
     return true
   end
 

--- a/modules/post/windows/gather/credentials/domain_hashdump.rb
+++ b/modules/post/windows/gather/credentials/domain_hashdump.rb
@@ -108,7 +108,7 @@ class MetasploitModule < Msf::Post
       return false
     end
     if is_domain_controller?
-      print_status "Sessions is on a Domain Controller"
+      print_status "Session is on a Domain Controller"
     else
       print_error "This does not appear to be an AD Domain Controller"
       return false


### PR DESCRIPTION
The domain hashdump post module should now work
against Server 2016 DCs.


Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

## Verification

List the steps needed to make sure this thing works

- [ ] Get a shell on a Windows Server 2016 Domain Controller
- [ ] `use post/windows/gather/credentials/domain_hashdump`
- [ ]  `set SESSION <id>`
- [ ] run
- [ ] **Verify** you do not get a permissions error
- [ ] **Verify** you do not get an error that the OS is unspported


