### PR TITLE
Add ./ to cmd_use for paths and simplify cases

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -573,11 +573,11 @@ module Msf
             mod_name = args[0]
 
             # Ensure we have a reference name and not a path
-            if mod_name.start_with?('modules/', '/')
-              mod_name.sub!(/^(?:modules)?\//, '')
+            if mod_name.start_with?('./', 'modules/')
+              mod_name.sub!(/^(?:\.\/)?modules\//, '')
             end
-            if mod_name.end_with?('.', '.r', '.rb')
-              mod_name.sub!(/\.(?:rb?)?$/, '')
+            if mod_name.end_with?('.rb')
+              mod_name.sub!(/\.rb$/, '')
             end
 
             begin


### PR DESCRIPTION
Don't accommodate typos. For #7734.

**tl;dr** This lets you do something like `use ./modules/exploits/linux/misc/qnap_transcode_server.rb`.