### PR TITLE
Follow 301 re-direct

### DIFF
--- a/modules/exploits/multi/http/phpmailer_arg_injection.rb
+++ b/modules/exploits/multi/http/phpmailer_arg_injection.rb
@@ -68,10 +68,9 @@ class MetasploitModule < Msf::Exploit::Remote
     while wait_time > 0
       sleep(sleep_time)
       wait_time -= sleep_time
-      res = send_request_cgi!({
+      res = send_request_cgi!(
         'method'   => 'GET',
         'uri'      => trigger_uri
-        }, redirect_depth = 1
       )
 
       if res.nil?

--- a/modules/exploits/multi/http/phpmailer_arg_injection.rb
+++ b/modules/exploits/multi/http/phpmailer_arg_injection.rb
@@ -68,9 +68,10 @@ class MetasploitModule < Msf::Exploit::Remote
     while wait_time > 0
       sleep(sleep_time)
       wait_time -= sleep_time
-      res = send_request_cgi(
+      res = send_request_cgi!({
         'method'   => 'GET',
         'uri'      => trigger_uri
+        }, redirect_depth = 1
       )
 
       if res.nil?


### PR DESCRIPTION
I found that in some cases, the trigger URL cannot be accessed directly.  For example, if the uploaded file was example.php, browsing to "example.php" would hit a 301 re-direct to "/example".  It isn't until hitting "/example" that the php is executed.  This small change will just allow the trigger to follow one 301 redirect.


Output from hitting a target URI with redirect:

```
GET /6VbRJ4Ie.php HTTP/1.1
Host: 172.16.155.198
User-Agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)
Content-Type: application/x-www-form-urlencoded

HTTP/1.1 301 Moved Permanently
Date: Wed, 23 Aug 2017 18:43:40 GMT
Server: Apache/2.4.10 (Debian)
Location: http://172.16.155.198/6VbRJ4Ie
Content-Length: 318
Content-Type: text/html; charset=iso-8859-1

<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>301 Moved Permanently</title>
</head><body>
<h1>Moved Permanently</h1>
<p>The document has moved <a href="http://172.16.155.198/6VbRJ4Ie">here</a>.</p>
<hr>
<address>Apache/2.4.10 (Debian) Server at 172.16.155.198 Port 80</address>
</body></html>


```