### PR TITLE
Add Inedo BuildMaster login scanner module

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/buildmaster_login.md
+++ b/documentation/modules/auxiliary/scanner/http/buildmaster_login.md
@@ -14,13 +14,13 @@ This module allows you to authenticate to Inedo BuildMaster, an application rele
 Attempt to login with the default credentials.
 ```
 msf > use auxiliary/scanner/http/buildmaster_login
-msf auxiliary(buildmaster_login) > set RHOSTS 10.0.0.8
-RHOSTS => 10.0.0.8
+msf auxiliary(buildmaster_login) > set RHOSTS 10.0.0.39
+RHOSTS => 10.0.0.39
 msf auxiliary(buildmaster_login) > run
 
-[+] 10.0.0.8:81 - Identified BuildMaster 5.7.3 (Build 1)
-[*] 10.0.0.8:81 - Trying username:"Admin" with password:"Admin"
-[+] SUCCESSFUL LOGIN - 10.0.0.8:81 - "Admin":"Admin"
+[+] 10.0.0.39:81          - Identified BuildMaster 5.7.3 (Build 1)
+[*] 10.0.0.39:81          - Trying username:"Admin" with password:"Admin"
+[+] SUCCESSFUL LOGIN - 10.0.0.39:81          - "Admin":"Admin"
 [*] Scanned 1 of 1 hosts (100% complete)
 [*] Auxiliary module execution completed
 msf auxiliary(buildmaster_login) >
@@ -54,19 +54,19 @@ Module options (auxiliary/scanner/http/buildmaster_login):
    VERBOSE           true             yes       Whether to print output for all attempts
    VHOST                              no        HTTP server virtual host
 
-msf auxiliary(buildmaster_login) > set RHOSTS 10.0.0.8
-RHOSTS => 10.0.0.8
+msf auxiliary(buildmaster_login) > set RHOSTS 10.0.0.39
+RHOSTS => 10.0.0.39
 msf auxiliary(buildmaster_login) > set USERPASS_FILE ~/BuildMasterCreds.txt
 USERPASS_FILE => ~/BuildMasterCreds.txt
 msf auxiliary(buildmaster_login) > run
 
-[+] 10.0.0.8:81 - Identified BuildMaster 5.7.3 (Build 1)
-[*] 10.0.0.8:81 - Trying username:"Admin" with password:"test"
-[-] FAILED LOGIN - 10.0.0.8:81 - "Admin":"test"
-[*] 10.0.0.8:81 - Trying username:"Admin" with password:"wrong"
-[-] FAILED LOGIN - 10.0.0.8:81 - "Admin":"wrong"
-[*] 10.0.0.8:81 - Trying username:"Admin" with password:"Admin"
-[+] SUCCESSFUL LOGIN - 10.0.0.8:81 - "Admin":"Admin"
+[+] 10.0.0.39:81          - Identified BuildMaster 5.7.3 (Build 1)
+[*] 10.0.0.39:81          - Trying username:"Admin" with password:"test"
+[-] FAILED LOGIN - 10.0.0.39:81          - "Admin":"test"
+[*] 10.0.0.39:81          - Trying username:"Admin" with password:"wrong"
+[-] FAILED LOGIN - 10.0.0.39:81          - "Admin":"wrong"
+[*] 10.0.0.39:81          - Trying username:"Admin" with password:"Admin"
+[+] SUCCESSFUL LOGIN - 10.0.0.39:81          - "Admin":"Admin"
 [*] Scanned 1 of 1 hosts (100% complete)
 [*] Auxiliary module execution completed
 msf auxiliary(buildmaster_login) > 

--- a/documentation/modules/auxiliary/scanner/http/buildmaster_login.md
+++ b/documentation/modules/auxiliary/scanner/http/buildmaster_login.md
@@ -1,0 +1,72 @@
+This module allows you to authenticate to Inedo BuildMaster, an application release automation tool. The default credentials for BuildMaster are Admin/Admin. Gaining privileged access to a BuildMaster can lead to remote code execution.
+
+## Verification Steps
+
+1. Do: ```use auxiliary/scanner/http/buildmaster_login```
+2. Do: ```set RHOSTS [IP]```
+3. Do: ```set RPORT [PORT]```
+4. Do: Set credentials
+5. Do: ```run```
+6. You should see the module attempting to log in.
+
+## Scenarios
+
+Attempt to login with the default credentials.
+```
+msf > use auxiliary/scanner/http/buildmaster_login 
+msf auxiliary(buildmaster_login) > set RHOSTS 10.0.0.8
+RHOSTS => 10.0.0.8
+msf auxiliary(buildmaster_login) > run
+
+[+] 10.0.0.8:81 - Identified BuildMaster 5.7.3 (Build 1)
+[*] 10.0.0.8:81 - Trying username:"Admin" with password:"Admin"
+[+] SUCCESSFUL LOGIN - 10.0.0.8:81 - "Admin":"Admin"
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+msf auxiliary(buildmaster_login) >
+```
+Brute force with credentials from file.
+```msf > use auxiliary/scanner/http/buildmaster_login 
+msf auxiliary(buildmaster_login) > options
+
+Module options (auxiliary/scanner/http/buildmaster_login):
+
+   Name              Current Setting  Required  Description
+   ----              ---------------  --------  -----------
+   BLANK_PASSWORDS   false            no        Try blank passwords for all users
+   BRUTEFORCE_SPEED  5                yes       How fast to bruteforce, from 0 to 5
+   DB_ALL_CREDS      false            no        Try each user/password couple stored in the current database
+   DB_ALL_PASS       false            no        Add all passwords in the current database to the list
+   DB_ALL_USERS      false            no        Add all users in the current database to the list
+   PASSWORD          Admin            no        Password to authenticate with
+   PASS_FILE                          no        File containing passwords, one per line
+   Proxies                            no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                             yes       The target address range or CIDR identifier
+   RPORT             81               yes       The target port (TCP)
+   SSL               false            no        Negotiate SSL/TLS for outgoing connections
+   STOP_ON_SUCCESS   false            yes       Stop guessing when a credential works for a host
+   THREADS           1                yes       The number of concurrent threads
+   USERNAME          Admin            no        Username to authenticate as
+   USERPASS_FILE                      no        File containing users and passwords separated by space, one pair per line
+   USER_AS_PASS      false            no        Try the username as the password for all users
+   USER_FILE                          no        File containing usernames, one per line
+   VERBOSE           true             yes       Whether to print output for all attempts
+   VHOST                              no        HTTP server virtual host
+
+msf auxiliary(buildmaster_login) > set RHOSTS 10.0.0.8
+RHOSTS => 10.0.0.8
+msf auxiliary(buildmaster_login) > set USERPASS_FILE ~/BuildMasterCreds.txt
+USERPASS_FILE => ~/BuildMasterCreds.txt
+msf auxiliary(buildmaster_login) > run
+
+[+] 10.0.0.8:81 - Identified BuildMaster 5.7.3 (Build 1)
+[*] 10.0.0.8:81 - Trying username:"Admin" with password:"test"
+[-] FAILED LOGIN - 10.0.0.8:81 - "Admin":"test"
+[*] 10.0.0.8:81 - Trying username:"Admin" with password:"wrong"
+[-] FAILED LOGIN - 10.0.0.8:81 - "Admin":"wrong"
+[*] 10.0.0.8:81 - Trying username:"Admin" with password:"Admin"
+[+] SUCCESSFUL LOGIN - 10.0.0.8:81 - "Admin":"Admin"
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+msf auxiliary(buildmaster_login) > 
+```

--- a/documentation/modules/auxiliary/scanner/http/buildmaster_login.md
+++ b/documentation/modules/auxiliary/scanner/http/buildmaster_login.md
@@ -13,7 +13,7 @@ This module allows you to authenticate to Inedo BuildMaster, an application rele
 
 Attempt to login with the default credentials.
 ```
-msf > use auxiliary/scanner/http/buildmaster_login 
+msf > use auxiliary/scanner/http/buildmaster_login
 msf auxiliary(buildmaster_login) > set RHOSTS 10.0.0.8
 RHOSTS => 10.0.0.8
 msf auxiliary(buildmaster_login) > run
@@ -26,7 +26,8 @@ msf auxiliary(buildmaster_login) > run
 msf auxiliary(buildmaster_login) >
 ```
 Brute force with credentials from file.
-```msf > use auxiliary/scanner/http/buildmaster_login 
+```
+msf > use auxiliary/scanner/http/buildmaster_login 
 msf auxiliary(buildmaster_login) > options
 
 Module options (auxiliary/scanner/http/buildmaster_login):

--- a/documentation/modules/auxiliary/scanner/http/buildmaster_login.md
+++ b/documentation/modules/auxiliary/scanner/http/buildmaster_login.md
@@ -1,4 +1,4 @@
-This module allows you to authenticate to Inedo BuildMaster, an application release automation tool. The default credentials for BuildMaster are Admin/Admin. Gaining privileged access to a BuildMaster can lead to remote code execution.
+This module allows you to authenticate to Inedo BuildMaster, an application release automation tool. The default credentials for BuildMaster are Admin/Admin. Gaining privileged access to BuildMaster can lead to remote code execution.
 
 ## Verification Steps
 

--- a/modules/auxiliary/scanner/http/buildmaster_login.rb
+++ b/modules/auxiliary/scanner/http/buildmaster_login.rb
@@ -1,0 +1,139 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::AuthBrute
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::Scanner
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'        => 'Inedo BuildMaster Login Scanner',
+      'Description' => %{
+          This module will attempt to authenticate to BuildMaster. There is a default user 'Admin'
+          which has the default password 'Admin'.
+      },
+      'Author'         => [ 'James Otten <jamesotten1[at]gmail.com>' ],
+      'License'        => MSF_LICENSE,
+      'DefaultOptions' => { 'VERBOSE' => true })
+    )
+
+    register_options(
+      [
+        Opt::RPORT(81),
+        OptString.new('USERNAME', [false, 'Username to authenticate as', 'Admin']),
+        OptString.new('PASSWORD', [false, 'Password to authenticate with', 'Admin'])
+      ], self.class
+    )
+  end
+
+  def run_host(ip)
+    return unless buildmaster?
+
+    each_user_pass do |user, pass|
+      do_login(user, pass)
+    end
+  end
+
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      last_attempted_at: Time.now,
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::SUCCESSFUL,
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
+  def buildmaster?
+    begin
+      res = send_request_cgi(
+        {
+          'uri' => '/log-in',
+          'method' => 'GET'
+        }
+      )
+    rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionError, ::Errno::EPIPE
+      print_error("#{rhost}:#{rport} - HTTP Connection Failed")
+      return false
+    end
+
+    if res && res.code == 200 && res.body.include?('BuildMaster_Version')
+      version = res.body.scan(/<span id="BuildMaster_Version">(.*)<\/span>/).flatten[0]
+      print_good("#{rhost}:#{rport} - Identified BuildMaster #{version}")
+      return true
+    else
+      print_error("#{rhost}:#{rport} - Application does not appear to be BuildMaster")
+      return false
+    end
+  end
+
+  def login_succeeded?(res)
+    if res && res.code == 200
+      body = JSON.parse(res.body)
+      return body.key?('succeeded') && body['succeeded']
+    end
+    return false
+  end
+
+  def service_name
+    if ssl
+      'https'
+    end
+    'http'
+  end
+
+  def do_login(user, pass)
+    print_status("#{rhost}:#{rport} - Trying username:#{user.inspect} with password:#{pass.inspect}")
+    begin
+      res = send_request_cgi(
+        {
+          'uri' => '/0x44/BuildMaster.Web.WebApplication/Inedo.BuildMaster.Web.WebApplication.Pages.LogInPage/LogIn',
+          'method' => 'POST',
+          'headers' => { 'Content-Type' => 'application/x-www-form-urlencoded' },
+          'vars_post' =>
+            {
+              'userName' => user,
+              'password' => pass
+            }
+        }
+      )
+    rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionError, ::Errno::EPIPE
+      vprint_error("#{rhost}:#{rport} - HTTP Connection Failed...")
+      return :abort
+    end
+
+    if login_succeeded?(res)
+      print_good("SUCCESSFUL LOGIN - #{rhost}:#{rport} - #{user.inspect}:#{pass.inspect}")
+      report_cred(
+        ip: rhost,
+        port: rport,
+        service_name: service_name,
+        user: user,
+        password: pass
+      )
+    else
+      print_error("FAILED LOGIN - #{rhost}:#{rport} - #{user.inspect}:#{pass.inspect}")
+    end
+  end
+end

--- a/modules/auxiliary/scanner/http/buildmaster_login.rb
+++ b/modules/auxiliary/scanner/http/buildmaster_login.rb
@@ -38,33 +38,6 @@ class MetasploitModule < Msf::Auxiliary
     end
   end
 
-  def report_cred(opts)
-    service_data = {
-      address: opts[:ip],
-      port: opts[:port],
-      service_name: opts[:service_name],
-      protocol: 'tcp',
-      workspace_id: myworkspace_id
-    }
-
-    credential_data = {
-      origin_type: :service,
-      module_fullname: fullname,
-      username: opts[:user],
-      private_data: opts[:password],
-      private_type: :password
-    }.merge(service_data)
-
-    login_data = {
-      last_attempted_at: Time.now,
-      core: create_credential(credential_data),
-      status: Metasploit::Model::Login::Status::SUCCESSFUL,
-      proof: opts[:proof]
-    }.merge(service_data)
-
-    create_credential_login(login_data)
-  end
-
   def buildmaster?
     begin
       res = send_request_cgi('uri' => '/log-in')
@@ -115,13 +88,7 @@ class MetasploitModule < Msf::Auxiliary
 
     if login_succeeded?(res)
       print_good("SUCCESSFUL LOGIN - #{peer} - #{user.inspect}:#{pass.inspect}")
-      report_cred(
-        ip: rhost,
-        port: rport,
-        service_name: ssl ? 'https' : 'http',
-        user: user,
-        password: pass
-      )
+      store_valid_credential(user: user, private: pass)
     else
       print_error("FAILED LOGIN - #{peer} - #{user.inspect}:#{pass.inspect}")
     end

--- a/modules/auxiliary/scanner/http/buildmaster_login.rb
+++ b/modules/auxiliary/scanner/http/buildmaster_login.rb
@@ -69,16 +69,16 @@ class MetasploitModule < Msf::Auxiliary
     begin
       res = send_request_cgi('uri' => '/log-in')
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionError, ::Errno::EPIPE
-      print_error("#{rhost}:#{rport} - HTTP Connection Failed")
+      print_error("#{peer} - HTTP Connection Failed")
       return false
     end
 
     if res && res.code == 200 && res.body.include?('BuildMaster_Version')
       version = res.body.scan(%r{<span id="BuildMaster_Version">(.*)</span>}).flatten.first
-      print_good("#{rhost}:#{rport} - Identified BuildMaster #{version}")
+      print_good("#{peer} - Identified BuildMaster #{version}")
       return true
     else
-      print_error("#{rhost}:#{rport} - Application does not appear to be BuildMaster")
+      print_error("#{peer} - Application does not appear to be BuildMaster")
       return false
     end
   end
@@ -94,7 +94,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def do_login(user, pass)
-    print_status("#{rhost}:#{rport} - Trying username:#{user.inspect} with password:#{pass.inspect}")
+    print_status("#{peer} - Trying username:#{user.inspect} with password:#{pass.inspect}")
     begin
       res = send_request_cgi(
         {
@@ -109,12 +109,12 @@ class MetasploitModule < Msf::Auxiliary
         }
       )
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionError, ::Errno::EPIPE
-      vprint_error("#{rhost}:#{rport} - HTTP Connection Failed...")
+      vprint_error("#{peer} - HTTP Connection Failed...")
       return :abort
     end
 
     if login_succeeded?(res)
-      print_good("SUCCESSFUL LOGIN - #{rhost}:#{rport} - #{user.inspect}:#{pass.inspect}")
+      print_good("SUCCESSFUL LOGIN - #{peer} - #{user.inspect}:#{pass.inspect}")
       report_cred(
         ip: rhost,
         port: rport,
@@ -123,7 +123,7 @@ class MetasploitModule < Msf::Auxiliary
         password: pass
       )
     else
-      print_error("FAILED LOGIN - #{rhost}:#{rport} - #{user.inspect}:#{pass.inspect}")
+      print_error("FAILED LOGIN - #{peer} - #{user.inspect}:#{pass.inspect}")
     end
   end
 end


### PR DESCRIPTION
This module attempts to log into Inedo BuildMaster. BuildMaster is an application release automation tool. The default credentials for BuildMaster are Admin/Admin. Gaining privileged access to BuildMaster can lead to remote code execution.

[Installation guide](http://inedo.com/support/documentation/buildmaster/installation/windows-guide)
[Inedo website](http://inedo.com/)

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/http/buildmaster_login`
- [x] `set RHOSTS [IP]`
- [x] `set RPORT [PORT]`
- [x] Set credentials
- [x] `run`
- [x] **Verify** that valid login attempts are reported as correct.

## Sample Output
Attempt to login with the default credentials.
```
msf > use auxiliary/scanner/http/buildmaster_login 
msf auxiliary(buildmaster_login) > set RHOSTS 10.0.0.8
RHOSTS => 10.0.0.8
msf auxiliary(buildmaster_login) > run

[+] 10.0.0.8:81 - Identified BuildMaster 5.7.3 (Build 1)
[*] 10.0.0.8:81 - Trying username:"Admin" with password:"Admin"
[+] SUCCESSFUL LOGIN - 10.0.0.8:81 - "Admin":"Admin"
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(buildmaster_login) >
```
Brute force with credentials from file.

```
msf > use auxiliary/scanner/http/buildmaster_login 
msf auxiliary(buildmaster_login) > options

Module options (auxiliary/scanner/http/buildmaster_login):

   Name              Current Setting  Required  Description
   ----              ---------------  --------  -----------
   BLANK_PASSWORDS   false            no        Try blank passwords for all users
   BRUTEFORCE_SPEED  5                yes       How fast to bruteforce, from 0 to 5
   DB_ALL_CREDS      false            no        Try each user/password couple stored in the current database
   DB_ALL_PASS       false            no        Add all passwords in the current database to the list
   DB_ALL_USERS      false            no        Add all users in the current database to the list
   PASSWORD          Admin            no        Password to authenticate with
   PASS_FILE                          no        File containing passwords, one per line
   Proxies                            no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS                             yes       The target address range or CIDR identifier
   RPORT             81               yes       The target port (TCP)
   SSL               false            no        Negotiate SSL/TLS for outgoing connections
   STOP_ON_SUCCESS   false            yes       Stop guessing when a credential works for a host
   THREADS           1                yes       The number of concurrent threads
   USERNAME          Admin            no        Username to authenticate as
   USERPASS_FILE                      no        File containing users and passwords separated by space, one pair per line
   USER_AS_PASS      false            no        Try the username as the password for all users
   USER_FILE                          no        File containing usernames, one per line
   VERBOSE           true             yes       Whether to print output for all attempts
   VHOST                              no        HTTP server virtual host

msf auxiliary(buildmaster_login) > set RHOSTS 10.0.0.8
RHOSTS => 10.0.0.8
msf auxiliary(buildmaster_login) > set USERPASS_FILE ~/BuildMasterCreds.txt
USERPASS_FILE => ~/BuildMasterCreds.txt
msf auxiliary(buildmaster_login) > run

[+] 10.0.0.8:81 - Identified BuildMaster 5.7.3 (Build 1)
[*] 10.0.0.8:81 - Trying username:"Admin" with password:"test"
[-] FAILED LOGIN - 10.0.0.8:81 - "Admin":"test"
[*] 10.0.0.8:81 - Trying username:"Admin" with password:"wrong"
[-] FAILED LOGIN - 10.0.0.8:81 - "Admin":"wrong"
[*] 10.0.0.8:81 - Trying username:"Admin" with password:"Admin"
[+] SUCCESSFUL LOGIN - 10.0.0.8:81 - "Admin":"Admin"
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(buildmaster_login) > 
```