### PR TITLE
Fix uneven quotes in various documentation files

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/cisco_firepower_login.md
+++ b/documentation/modules/auxiliary/scanner/http/cisco_firepower_login.md
@@ -17,7 +17,7 @@ https://software.cisco.com/download/release.html?mdfid=286259687&softwareid=2862
 
 1. Make sure Cisco Firepower Management console's HTTPS service is running
 2. Start ```msfconsole```
-3. ```use auxiliary/scanner/http/cisco_firepower_login.rb
+3. ```use auxiliary/scanner/http/cisco_firepower_login.rb```
 4. ```set RHOSTS [IP]```
 5. Set credentials
 6. ```run```

--- a/documentation/modules/auxiliary/scanner/ssh/ssh_login.md
+++ b/documentation/modules/auxiliary/scanner/ssh/ssh_login.md
@@ -14,7 +14,7 @@
   5. Do: `run`
   6. You will hopefully see something similar to, followed by a session:
 
-  ````[+] SSH - Success: 'msfadmin:msfadmin' 'uid=1000(msfadmin) gid=1000(msfadmin) groups=4(adm),20(dialout),24(cdrom),25(floppy),29(audio),30(dip),44(video),46(plugdev),107(fuse),111(lpadmin),112(admin),119(sambashare),1000(msfadmin) Linux metasploitable 2.6.24-16-server #1 SMP Thu Apr 10 13:58:00 UTC 2008 i686 GNU/Linux '```
+  ```[+] SSH - Success: 'msfadmin:msfadmin' 'uid=1000(msfadmin) gid=1000(msfadmin) groups=4(adm),20(dialout),24(cdrom),25(floppy),29(audio),30(dip),44(video),46(plugdev),107(fuse),111(lpadmin),112(admin),119(sambashare),1000(msfadmin) Linux metasploitable 2.6.24-16-server #1 SMP Thu Apr 10 13:58:00 UTC 2008 i686 GNU/Linux '```
 
 ## Options
 

--- a/documentation/modules/exploit/linux/http/centreon_useralias_exec.md
+++ b/documentation/modules/exploit/linux/http/centreon_useralias_exec.md
@@ -187,7 +187,7 @@ finish
 ## Scenarios
 
 Just a standard run.
-
+```
     msf > use exploit/linux/http/centreon_useralias_exec
     msf exploit(centreon_useralias_exec) > set payload cmd/unix/reverse_python
     payload => cmd/unix/reverse_python

--- a/documentation/modules/exploit/linux/http/logsign_exec.md
+++ b/documentation/modules/exploit/linux/http/logsign_exec.md
@@ -56,7 +56,7 @@ dns-nameservers 8.8.8.8
   1. Install the software as documented above
   2. Start `msfconsole`
   3. `use exploit/linux/http/logsign_exec`
-  4. `set rhost 12.0.0.10
+  4. `set rhost 12.0.0.10`
   6. `python/meterpreter/reverse_tcp` is configured as a default payload. Change it if you need. Most of the case, you're okay go with default payload type.
   7. `set LHOST 12.0.0.1`
   8. `check` and validate that you are seeing following output.

--- a/documentation/modules/exploit/windows/browser/firefox_smil_uaf.md
+++ b/documentation/modules/exploit/windows/browser/firefox_smil_uaf.md
@@ -17,7 +17,7 @@ The module includes an option named UsePostHTML which is turned off by default. 
 
 1. Start msfconsole
 2. Do: ```use exploit/windows/browser/firefox_smil_uaf```
-3. Do: ```set payload [PREFERRED PAYLOAD]
+3. Do: ```set payload [PREFERRED PAYLOAD]```
 4. Do: ```set PAYLOAD [PAYLOAD NAME]```
 5. Set payload options as needed
 6. Do: ```run```, and have a target browse to the generated URL


### PR DESCRIPTION
Even out the quotes in several files so they render correctly.

## Verification

- [ ] **Verify** quotes have been evened out in the modified files
- [ ] **Verify** the modified files render as expected

