### PR TITLE
Update README

### DIFF
--- a/external/source/meterpreter/README
+++ b/external/source/meterpreter/README
@@ -1,2 +1,2 @@
-Meterpreter source code has moved to its own repository, hosted at
-https://github.com/rapid7/meterpreter
+Meterpreter source code is part of the metasploit-payloads repository, hosted at
+https://github.com/rapid7/metasploit-payloads


### PR DESCRIPTION
Meterpreter repo now redirects to metasploit-payloads.
