### PR TITLE
Output job id when jobifying exploit

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/exploit.rb
+++ b/lib/msf/ui/console/command_dispatcher/exploit.rb
@@ -147,7 +147,7 @@ class Exploit
     # wonder what's up.
     elsif (jobify)
       if mod.job_id
-        print_status("Exploit running as background job.")
+        print_status("Exploit running as background job #{mod.job_id}.")
       end
     # Worst case, the exploit ran but we got no session, bummer.
     else


### PR DESCRIPTION
This change adds the specific job_id to the string printed to the console when jobifying an exploit. The current behavior outputs "Exploit is running as a background job", and the new behavior will output "Exploit is running as background job $id", where $id is the job_id.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use exploit/multi/handler`
- [x] `set LHOST 127.0.0.1`
- [x] `set LPORT 443`
- [x] `run -j`
- [x] **Verify** the outputted string includes the job number: "[*] Exploit running as background job 0."

