### PR TITLE
rewrite timestomp command dispatcher to deal with file args properly

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/priv/timestomp.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/priv/timestomp.rb
@@ -13,7 +13,6 @@ module Ui
 #
 ###
 class Console::CommandDispatcher::Priv::Timestomp
-
   Klass = Console::CommandDispatcher::Priv::Timestomp
 
   include Console::CommandDispatcher
@@ -28,7 +27,8 @@ class Console::CommandDispatcher::Priv::Timestomp
     "-b" => [ false, "Set the MACE timestamps so that EnCase shows blanks" ],
     "-r" => [ false, "Set the MACE timestamps recursively on a directory" ],
     "-v" => [ false, "Display the UTC MACE values of the file" ],
-    "-h" => [ false, "Help banner" ])
+    "-h" => [ false, "Help banner" ]
+  )
 
   #
   # List of supported commands.
@@ -51,91 +51,110 @@ class Console::CommandDispatcher::Priv::Timestomp
   # line timestomp interface provides with a similar argument set.
   #
   def cmd_timestomp(*args)
-    if (args.length < 2)
-      print_line("\nUsage: timestomp OPTIONS file_path\n" +
+    if args.length < 2
+      print_line("\nUsage: timestomp <file(s)> OPTIONS\n" +
         @@timestomp_opts.usage)
       return
     end
 
-    file_path = nil
-    args.each { |a| file_path = a unless a[0] == "-" }
-
-    if file_path.nil?
-      print_line("\nNo file_path specified.")
-      return
-    end
-
-    args.delete(file_path)
+    paths = []
 
     modified  = nil
     accessed  = nil
     creation  = nil
     emodified = nil
 
-    @@timestomp_opts.parse(args) { |opt, idx, val|
+    blank_file_mace = false
+    blank_directory_mace = false
+    get_file_mace = false
+
+    @@timestomp_opts.parse(args) do |opt, _idx, val|
       case opt
-        when "-m"
-          modified  = str_to_time(val)
-        when "-a"
-          accessed  = str_to_time(val)
-        when "-c"
-          creation  = str_to_time(val)
-        when "-e"
-          emodified = str_to_time(val)
-        when "-z"
-          print_line("#{val}")
-          modified  = str_to_time(val)
-          accessed  = str_to_time(val)
-          creation  = str_to_time(val)
-          emodified = str_to_time(val)
-        when "-f"
-          print_status("Setting MACE attributes on #{file_path} from #{val}")
-          client.priv.fs.set_file_mace_from_file(file_path, val)
-        when "-b"
-          print_status("Blanking file MACE attributes on #{file_path}")
-          client.priv.fs.blank_file_mace(file_path)
-        when "-r"
-          print_status("Blanking directory MACE attributes on #{file_path}")
-          client.priv.fs.blank_directory_mace(file_path)
-        when "-v"
-          hash = client.priv.fs.get_file_mace(file_path)
-
-          print_line("Modified      : #{hash['Modified']}")
-          print_line("Accessed      : #{hash['Accessed']}")
-          print_line("Created       : #{hash['Created']}")
-          print_line("Entry Modified: #{hash['Entry Modified']}")
-        when "-h"
-          print_line("\nUsage: timestomp file_path OPTIONS\n" +
-            @@timestomp_opts.usage)
-          return
+      when "-m"
+        modified  = str_to_time(val)
+      when "-a"
+        accessed  = str_to_time(val)
+      when "-c"
+        creation  = str_to_time(val)
+      when "-e"
+        emodified = str_to_time(val)
+      when "-z"
+        modified  = str_to_time(val)
+        accessed  = str_to_time(val)
+        creation  = str_to_time(val)
+        emodified = str_to_time(val)
+      when "-f"
+        print_status("Setting MACE attributes on #{path} from #{val}")
+        hash = client.priv.fs.get_file_mace(path)
+        if hash
+          modified = str_to_time(hash['Modified'])
+          accessed = str_to_time(hash['Accessed'])
+          creation = str_to_time(hash['Created'])
+          emodified = str_to_time(hash['Entry Modified'])
+        end
+      when "-b"
+        blank_file_mace = true
+      when "-r"
+        blank_directory_mace = true
+      when "-v"
+        get_file_mace = true
+      when "-h"
+        print_line("\nUsage: timestomp <file(s)> OPTIONS\n" +
+          @@timestomp_opts.usage)
+        return nil
+      when nil
+        paths << val
       end
-    }
+    end
 
-    # If any one of the four times were specified, change them.
-    if (modified or accessed or creation or emodified)
-      print_status("Setting specific MACE attributes on #{file_path}")
-      client.priv.fs.set_file_mace(file_path, modified, accessed,
-        creation, emodified)
+    if paths.empty?
+      print_line("\nNo paths specified.")
+      return
+    end
+
+    paths.uniq.each do |path|
+      # If any one of the four times were specified, change them.
+      if modified || accessed || creation || emodified
+        print_status("Setting specific MACE attributes on #{path}")
+        client.priv.fs.set_file_mace(path, modified, accessed, creation, emodified)
+      end
+
+      if blank_file_mace
+        print_status("Blanking file MACE attributes on #{path}")
+        client.priv.fs.blank_file_mace(path)
+      end
+
+      if blank_directory_mace
+        print_status("Blanking directory MACE attributes on #{path}")
+        client.priv.fs.blank_directory_mace(path)
+      end
+
+      if get_file_mace
+        hash = client.priv.fs.get_file_mace(path)
+        print_status("Showing MACE attributes for #{path}")
+        print_line("Modified      : #{hash['Modified']}")
+        print_line("Accessed      : #{hash['Accessed']}")
+        print_line("Created       : #{hash['Created']}")
+        print_line("Entry Modified: #{hash['Entry Modified']}")
+      end
     end
   end
 
-protected
+  protected
 
   #
   # Converts a date/time in the form of MM/DD/YYYY HH24:MI:SS
   #
   def str_to_time(str) # :nodoc:
-    r, mon, day, year, hour, min, sec = str.match("^(\\d+?)/(\\d+?)/(\\d+?) (\\d+?):(\\d+?):(\\d+?)$").to_a
+    _r, mon, day, year, hour, min, sec = str.match("^(\\d+?)/(\\d+?)/(\\d+?) (\\d+?):(\\d+?):(\\d+?)$").to_a
 
-    if (mon == nil)
+    if mon.nil?
       raise ArgumentError, "Invalid date format, expected MM/DD/YYYY HH24:MI:SS (got #{str})"
     end
 
     Time.mktime(year, mon, day, hour, min, sec, 0)
   end
-
 end
-
 end
 end
 end

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/priv/timestomp.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/priv/timestomp.rb
@@ -2,160 +2,162 @@
 require 'rex/post/meterpreter'
 
 module Rex
-module Post
-module Meterpreter
-module Ui
+  module Post
+    module Meterpreter
+      module Ui
+        ###
+        #
+        # This class provides commands that interact with the timestomp feature set of
+        # the privilege escalation extension.
+        #
+        ###
+        class Console::CommandDispatcher::Priv::Timestomp
+          Klass = Console::CommandDispatcher::Priv::Timestomp
 
-###
-#
-# This class provides commands that interact with the timestomp feature set of
-# the privilege escalation extension.
-#
-###
-class Console::CommandDispatcher::Priv::Timestomp
-  Klass = Console::CommandDispatcher::Priv::Timestomp
+          include Console::CommandDispatcher
 
-  include Console::CommandDispatcher
+          @@timestomp_opts = Rex::Parser::Arguments.new(
+            "-m" => [ true,  "Set the \"last written\" time of the file" ],
+            "-a" => [ true,  "Set the \"last accessed\" time of the file" ],
+            "-c" => [ true,  "Set the \"creation\" time of the file" ],
+            "-e" => [ true,  "Set the \"mft entry modified\" time of the file" ],
+            "-z" => [ true,  "Set all four attributes (MACE) of the file" ],
+            "-f" => [ true,  "Set the MACE of attributes equal to the supplied file" ],
+            "-b" => [ false, "Set the MACE timestamps so that EnCase shows blanks" ],
+            "-r" => [ false, "Set the MACE timestamps recursively on a directory" ],
+            "-v" => [ false, "Display the UTC MACE values of the file" ],
+            "-h" => [ false, "Help banner" ]
+          )
 
-  @@timestomp_opts = Rex::Parser::Arguments.new(
-    "-m" => [ true,  "Set the \"last written\" time of the file" ],
-    "-a" => [ true,  "Set the \"last accessed\" time of the file" ],
-    "-c" => [ true,  "Set the \"creation\" time of the file" ],
-    "-e" => [ true,  "Set the \"mft entry modified\" time of the file" ],
-    "-z" => [ true,  "Set all four attributes (MACE) of the file" ],
-    "-f" => [ true,  "Set the MACE of attributes equal to the supplied file" ],
-    "-b" => [ false, "Set the MACE timestamps so that EnCase shows blanks" ],
-    "-r" => [ false, "Set the MACE timestamps recursively on a directory" ],
-    "-v" => [ false, "Display the UTC MACE values of the file" ],
-    "-h" => [ false, "Help banner" ]
-  )
+          #
+          # List of supported commands.
+          #
+          def commands
+            {
+              "timestomp" => "Manipulate file MACE attributes"
+            }
+          end
 
-  #
-  # List of supported commands.
-  #
-  def commands
-    {
-      "timestomp" => "Manipulate file MACE attributes"
-    }
-  end
+          #
+          # Name for this dispatcher.
+          #
+          def name
+            "Priv: Timestomp"
+          end
 
-  #
-  # Name for this dispatcher.
-  #
-  def name
-    "Priv: Timestomp"
-  end
+          #
+          # This command provides the same level of features that vinnie's command
+          # line timestomp interface provides with a similar argument set.
+          #
+          def cmd_timestomp(*args)
+            paths = []
 
-  #
-  # This command provides the same level of features that vinnie's command
-  # line timestomp interface provides with a similar argument set.
-  #
-  def cmd_timestomp(*args)
-    if args.length < 2
-      print_line("\nUsage: timestomp <file(s)> OPTIONS\n" +
-        @@timestomp_opts.usage)
-      return
-    end
+            modified  = nil
+            accessed  = nil
+            creation  = nil
+            emodified = nil
 
-    paths = []
+            blank_file_mace = false
+            blank_directory_mace = false
+            get_file_mace = false
+            help = false
 
-    modified  = nil
-    accessed  = nil
-    creation  = nil
-    emodified = nil
+            @@timestomp_opts.parse(args) do |opt, _idx, val|
+              case opt
+              when "-m"
+                modified  = str_to_time(val)
+              when "-a"
+                accessed  = str_to_time(val)
+              when "-c"
+                creation  = str_to_time(val)
+              when "-e"
+                emodified = str_to_time(val)
+              when "-z"
+                modified  = str_to_time(val)
+                accessed  = str_to_time(val)
+                creation  = str_to_time(val)
+                emodified = str_to_time(val)
+              when "-f"
+                print_status("Setting MACE attributes on #{path} from #{val}")
+                hash = client.priv.fs.get_file_mace(path)
+                if hash
+                  modified = str_to_time(hash['Modified'])
+                  accessed = str_to_time(hash['Accessed'])
+                  creation = str_to_time(hash['Created'])
+                  emodified = str_to_time(hash['Entry Modified'])
+                end
+              when "-b"
+                blank_file_mace = true
+              when "-r"
+                blank_directory_mace = true
+              when "-v"
+                get_file_mace = true
+              when "-h"
+                help = true
+              when nil
+                paths << val
+              end
+            end
 
-    blank_file_mace = false
-    blank_directory_mace = false
-    get_file_mace = false
+            if paths.empty?
+              print_line("\nNo paths specified.")
+              return nil
+            end
 
-    @@timestomp_opts.parse(args) do |opt, _idx, val|
-      case opt
-      when "-m"
-        modified  = str_to_time(val)
-      when "-a"
-        accessed  = str_to_time(val)
-      when "-c"
-        creation  = str_to_time(val)
-      when "-e"
-        emodified = str_to_time(val)
-      when "-z"
-        modified  = str_to_time(val)
-        accessed  = str_to_time(val)
-        creation  = str_to_time(val)
-        emodified = str_to_time(val)
-      when "-f"
-        print_status("Setting MACE attributes on #{path} from #{val}")
-        hash = client.priv.fs.get_file_mace(path)
-        if hash
-          modified = str_to_time(hash['Modified'])
-          accessed = str_to_time(hash['Accessed'])
-          creation = str_to_time(hash['Created'])
-          emodified = str_to_time(hash['Entry Modified'])
+            if !(modified || accessed || creation || emodified ||
+                 blank_file_mace || blank_directory_mace || get_file_mace) || help
+              print_line("\nUsage: timestomp <file(s)> OPTIONS\n" +
+                @@timestomp_opts.usage)
+              return nil
+            end
+
+            paths.uniq.each do |path|
+              # If any one of the four times were specified, change them.
+              if modified || accessed || creation || emodified
+                print_status("Setting specific MACE attributes on #{path}")
+                client.priv.fs.set_file_mace(path, modified, accessed, creation, emodified)
+              end
+
+              if blank_file_mace
+                print_status("Blanking file MACE attributes on #{path}")
+                client.priv.fs.blank_file_mace(path)
+              end
+
+              if blank_directory_mace
+                print_status("Blanking directory MACE attributes on #{path}")
+                client.priv.fs.blank_directory_mace(path)
+              end
+
+              if get_file_mace
+                hash = client.priv.fs.get_file_mace(path)
+                print_status("Showing MACE attributes for #{path}")
+                print_line("Modified      : #{hash['Modified']}")
+                print_line("Accessed      : #{hash['Accessed']}")
+                print_line("Created       : #{hash['Created']}")
+                print_line("Entry Modified: #{hash['Entry Modified']}")
+              end
+            end
+          end
+
+          protected
+
+          #
+          # Converts a date/time in the form of MM/DD/YYYY HH24:MI:SS
+          #
+          def str_to_time(str) # :nodoc:
+            unless str.nil?
+              _r, mon, day, year, hour, min, sec =
+                str.match("^(\\d+?)/(\\d+?)/(\\d+?) (\\d+?):(\\d+?):(\\d+?)$").to_a
+            end
+
+            if str.nil? || mon.nil?
+              raise ArgumentError, "Invalid date format, expected MM/DD/YYYY HH24:MI:SS (got #{str})"
+            end
+
+            Time.mktime(year, mon, day, hour, min, sec, 0)
+          end
         end
-      when "-b"
-        blank_file_mace = true
-      when "-r"
-        blank_directory_mace = true
-      when "-v"
-        get_file_mace = true
-      when "-h"
-        print_line("\nUsage: timestomp <file(s)> OPTIONS\n" +
-          @@timestomp_opts.usage)
-        return nil
-      when nil
-        paths << val
-      end
-    end
-
-    if paths.empty?
-      print_line("\nNo paths specified.")
-      return
-    end
-
-    paths.uniq.each do |path|
-      # If any one of the four times were specified, change them.
-      if modified || accessed || creation || emodified
-        print_status("Setting specific MACE attributes on #{path}")
-        client.priv.fs.set_file_mace(path, modified, accessed, creation, emodified)
-      end
-
-      if blank_file_mace
-        print_status("Blanking file MACE attributes on #{path}")
-        client.priv.fs.blank_file_mace(path)
-      end
-
-      if blank_directory_mace
-        print_status("Blanking directory MACE attributes on #{path}")
-        client.priv.fs.blank_directory_mace(path)
-      end
-
-      if get_file_mace
-        hash = client.priv.fs.get_file_mace(path)
-        print_status("Showing MACE attributes for #{path}")
-        print_line("Modified      : #{hash['Modified']}")
-        print_line("Accessed      : #{hash['Accessed']}")
-        print_line("Created       : #{hash['Created']}")
-        print_line("Entry Modified: #{hash['Entry Modified']}")
       end
     end
   end
-
-  protected
-
-  #
-  # Converts a date/time in the form of MM/DD/YYYY HH24:MI:SS
-  #
-  def str_to_time(str) # :nodoc:
-    _r, mon, day, year, hour, min, sec = str.match("^(\\d+?)/(\\d+?)/(\\d+?) (\\d+?):(\\d+?):(\\d+?)$").to_a
-
-    if mon.nil?
-      raise ArgumentError, "Invalid date format, expected MM/DD/YYYY HH24:MI:SS (got #{str})"
-    end
-
-    Time.mktime(year, mon, day, hour, min, sec, 0)
-  end
-end
-end
-end
-end
 end


### PR DESCRIPTION
This fixes #8588 by making timestomp argument parsing work like it actually documents as:

`Usage: timestomp file_path OPTIONS`

Rather than a hacky 'the last thing that doesn't start with - is assumed to be a file' code path, accumulate file paths based on what Rex::Parser finds in the argument string.

This also teaches timestamp to deal with multiple files, and updates the Ruby code style.

## Verification

- [x] Get a Windows meterpreter session
- [x] `timestomp test.txt -z "01/01/2001 01:01:01"` should work as expected
- [x] `timestomp -z "01/01/2001 01:01:01" test.txt` should also work
- [x] `timestomp -z "01/01/2001 01:01:01" test.txt test.txt test2.txt` should set MACE on 2 files

Poke around at it to make sure I didn't break anything as well.
