### PR TITLE
Make backgrounding messages more consistent

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/auxiliary.rb
+++ b/lib/msf/ui/console/command_dispatcher/auxiliary.rb
@@ -96,7 +96,7 @@ class Auxiliary
     }
 
     # Always run passive modules in the background
-    if (mod.passive or mod.passive_action?(action))
+    if (mod.passive || mod.passive_action?(action || mod.default_action))
       jobify = true
     end
 
@@ -131,8 +131,8 @@ class Auxiliary
       return false
     end
 
-    if (jobify)
-      print_status("Auxiliary module running as background job")
+    if (jobify && mod.job_id)
+      print_status("Auxiliary module running as background job #{mod.job_id}.")
     else
       print_status("Auxiliary module execution completed")
     end

--- a/lib/msf/ui/console/command_dispatcher/exploit.rb
+++ b/lib/msf/ui/console/command_dispatcher/exploit.rb
@@ -145,10 +145,8 @@ class Exploit
       end
     # If we ran the exploit as a job, indicate such so the user doesn't
     # wonder what's up.
-    elsif (jobify)
-      if mod.job_id
-        print_status("Exploit running as background job #{mod.job_id}.")
-      end
+    elsif (jobify && mod.job_id)
+      print_status("Exploit running as background job #{mod.job_id}.")
     # Worst case, the exploit ran but we got no session, bummer.
     else
       # If we didn't run a payload handler for this exploit it doesn't

--- a/lib/msf/ui/console/command_dispatcher/jobs.rb
+++ b/lib/msf/ui/console/command_dispatcher/jobs.rb
@@ -339,7 +339,7 @@ module Msf
               framework.jobs[job_id.to_s].send(:name=, job_name)
             end
 
-            print_status "Payload Handler Started as Job #{job_id}"
+            print_status "Payload handler running as background job #{job_id}."
           end
         end
       end

--- a/lib/msf/ui/console/command_dispatcher/post.rb
+++ b/lib/msf/ui/console/command_dispatcher/post.rb
@@ -131,8 +131,8 @@ class Post
       return false
     end
 
-    if (jobify)
-      print_status("Post module running as background job")
+    if (jobify && mod.job_id)
+      print_status("Post module running as background job #{mod.job_id}.")
     else
       print_status("Post module execution completed")
     end


### PR DESCRIPTION
Inspired by the work in #8896

Also fixes a bug where the default action of an aux module was not checked when printing run status.

Verification
=========
- [x] Use an aux module with a passive default action (e.g. `auxiliary/server/capture/vnc`)
- [x] `run`
- [x] The first line of output should be like `[*] Auxiliary module running as background job 0.`
- [x] Ditto for other aux modules started with `run -j`
- [x] Ditto for passive post modules, or ones started with `run -j`
- [x] Ditto for the `handler` command