### PR TITLE
update nessus v2 import for consistent proto case

### DIFF
--- a/lib/msf/core/db_manager/import/nessus/xml/v2.rb
+++ b/lib/msf/core/db_manager/import/nessus/xml/v2.rb
@@ -74,7 +74,7 @@ module Msf::DBManager::Import::Nessus::XML::V2
         nasl = item['nasl'].to_s
         nasl_name = item['nasl_name'].to_s
         port = item['port'].to_s
-        proto = item['proto'] || "tcp"
+        proto = item['proto'] ? item['proto'].downcase : "tcp"
         sname = item['svc_name']
         severity = item['severity']
         description = item['description']


### PR DESCRIPTION
Set string case for `proto` from nessus v2 import to be consitent with `metasploit-framework` expectations for lower case protocols.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `db_import <path_to_nessus_v2_import>`
- [x] **Verify** successful import with `ReportItem` containing variations on `tcp`/`TCP`

