### PR TITLE
Inline robots.rb gem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,10 +42,6 @@ RUN apk update && \
     && apk del .ruby-builddeps \
     && rm -rf /var/cache/apk/*
 
-# fix for robots gem not readable (known bug)
-# https://github.com/rapid7/metasploit-framework/issues/6068
-RUN chmod o+r /usr/local/bundle/gems/robots-*/lib/robots.rb
-
 RUN adduser -g msfconsole -D $MSF_USER
 
 RUN /usr/sbin/setcap cap_net_raw,cap_net_bind_service=+eip $(which ruby)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,7 +58,6 @@ PATH
       rex-struct2
       rex-text
       rex-zip
-      robots
       ruby_smb
       rubyntlm
       rubyzip
@@ -271,7 +270,6 @@ GEM
     rex-zip (0.1.3)
       rex-text
     rkelly-remix (0.0.7)
-    robots (0.10.1)
     rspec (3.6.0)
       rspec-core (~> 3.6.0)
       rspec-expectations (~> 3.6.0)

--- a/lib/robots.rb
+++ b/lib/robots.rb
@@ -1,0 +1,137 @@
+require "open-uri"
+require "uri"
+require "rubygems"
+require "timeout"
+
+class Robots
+  
+  DEFAULT_TIMEOUT = 3
+  
+  class ParsedRobots
+    
+    def initialize(uri, user_agent)
+      @last_accessed = Time.at(1)
+      
+      io = Robots.get_robots_txt(uri, user_agent)
+      
+      if !io || io.content_type != "text/plain" || io.status != ["200", "OK"]
+        io = StringIO.new("User-agent: *\nAllow: /\n")
+      end
+
+      @other = {}
+      @disallows = {}
+      @allows = {}
+      @delays = {} # added delays to make it work
+      agent = /.*/
+      io.each do |line|
+        next if line =~ /^\s*(#.*|$)/
+        arr = line.split(":")
+        key = arr.shift
+        value = arr.join(":").strip
+        value.strip!
+        case key
+        when "User-agent"
+          agent = to_regex(value)
+        when "Allow"
+          @allows[agent] ||= []
+          @allows[agent] << to_regex(value)
+        when "Disallow"
+          @disallows[agent] ||= []
+          @disallows[agent] << to_regex(value)
+        when "Crawl-delay"
+          @delays[agent] = value.to_i
+        else
+          @other[key] ||= []
+          @other[key] << value
+        end
+      end
+      
+      @parsed = true
+    end
+    
+    def allowed?(uri, user_agent)
+      return true unless @parsed
+      allowed = true
+      path = uri.request_uri
+      
+      @disallows.each do |key, value|
+        if user_agent =~ key
+          value.each do |rule|
+            if path =~ rule
+              allowed = false
+            end
+          end
+        end
+      end
+      
+      @allows.each do |key, value|
+        unless allowed      
+          if user_agent =~ key
+            value.each do |rule|
+              if path =~ rule
+                allowed = true
+              end
+            end
+          end
+        end
+      end
+      
+      if allowed && @delays[user_agent]
+        sleep @delays[user_agent] - (Time.now - @last_accessed)
+        @last_accessed = Time.now
+      end
+      
+      return allowed
+    end
+    
+    def other_values
+      @other
+    end
+    
+  protected
+    
+    def to_regex(pattern)
+      return /should-not-match-anything-123456789/ if pattern.strip.empty?
+      pattern = Regexp.escape(pattern)
+      pattern.gsub!(Regexp.escape("*"), ".*")
+      Regexp.compile("^#{pattern}")
+    end
+  end
+  
+  def self.get_robots_txt(uri, user_agent)
+    begin
+      Timeout::timeout(Robots.timeout) do
+        io = URI.join(uri.to_s, "/robots.txt").open("User-Agent" => user_agent) rescue nil
+      end 
+    rescue Timeout::Error
+      STDERR.puts "robots.txt request timed out"
+    end
+  end
+  
+  def self.timeout=(t)
+    @timeout = t
+  end
+  
+  def self.timeout
+    @timeout || DEFAULT_TIMEOUT
+  end
+  
+  def initialize(user_agent)
+    @user_agent = user_agent
+    @parsed = {}
+  end
+  
+  def allowed?(uri)
+    uri = URI.parse(uri.to_s) unless uri.is_a?(URI)
+    host = uri.host
+    @parsed[host] ||= ParsedRobots.new(uri, @user_agent)
+    @parsed[host].allowed?(uri, @user_agent)
+  end
+  
+  def other_values(uri)
+    uri = URI.parse(uri.to_s) unless uri.is_a?(URI)
+    host = uri.host
+    @parsed[host] ||= ParsedRobots.new(uri, @user_agent)
+    @parsed[host].other_values
+  end
+end

--- a/lib/robots.rb
+++ b/lib/robots.rb
@@ -26,19 +26,19 @@ class Robots
       io.each do |line|
         next if line =~ /^\s*(#.*|$)/
         arr = line.split(":")
-        key = arr.shift
+        key = arr.shift.to_s.downcase
         value = arr.join(":").strip
         value.strip!
         case key
-        when "User-agent"
+        when "user-agent"
           agent = to_regex(value)
-        when "Allow"
+        when "allow"
           @allows[agent] ||= []
           @allows[agent] << to_regex(value)
-        when "Disallow"
+        when "disallow"
           @disallows[agent] ||= []
           @disallows[agent] << to_regex(value)
-        when "Crawl-delay"
+        when "crawl-delay"
           @delays[agent] = value.to_i
         else
           @other[key] ||= []

--- a/lib/robots.rb
+++ b/lib/robots.rb
@@ -1,19 +1,44 @@
+#
+#  Copyright (c) 2008 Kyle Maxwell, contributors
+#
+#  Permission is hereby granted, free of charge, to any person
+#  obtaining a copy of this software and associated documentation
+#  files (the "Software"), to deal in the Software without
+#  restriction, including without limitation the rights to use,
+#  copy, modify, merge, publish, distribute, sublicense, and/or sell
+#  copies of the Software, and to permit persons to whom the
+#  Software is furnished to do so, subject to the following
+#  conditions:
+#
+#  The above copyright notice and this permission notice shall be
+#  included in all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+#  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+#  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+#  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+#  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+#  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+#  OTHER DEALINGS IN THE SOFTWARE.
+#
+
 require "open-uri"
 require "uri"
-require "rubygems"
 require "timeout"
+require 'rex/logging/log_dispatcher'
 
+# https://github.com/fizx/robots
 class Robots
-  
   DEFAULT_TIMEOUT = 3
-  
+
+  # Represents a parsed robots.txt file
   class ParsedRobots
-    
     def initialize(uri, user_agent)
       @last_accessed = Time.at(1)
-      
+
       io = Robots.get_robots_txt(uri, user_agent)
-      
+
       if !io || io.content_type != "text/plain" || io.status.first != "200"
         io = StringIO.new("User-agent: *\nAllow: /\n")
       end
@@ -45,27 +70,25 @@ class Robots
           @other[key] << value
         end
       end
-      
+
       @parsed = true
     end
-    
+
     def allowed?(uri, user_agent)
       return true unless @parsed
       allowed = true
       path = uri.request_uri
-      
+
       @disallows.each do |key, value|
         if user_agent =~ key
           value.each do |rule|
-            if path =~ rule
-              allowed = false
-            end
+            allowed = false if path =~ rule
           end
         end
       end
-      
+
       @allows.each do |key, value|
-        unless allowed      
+        unless allowed
           if user_agent =~ key
             value.each do |rule|
               if path =~ rule
@@ -75,21 +98,21 @@ class Robots
           end
         end
       end
-      
+
       if allowed && @delays[user_agent]
         sleep @delays[user_agent] - (Time.now - @last_accessed)
         @last_accessed = Time.now
       end
-      
+
       return allowed
     end
-    
+
     def other_values
       @other
     end
-    
-  protected
-    
+
+    protected
+
     def to_regex(pattern)
       return /should-not-match-anything-123456789/ if pattern.strip.empty?
       pattern = Regexp.escape(pattern)
@@ -97,37 +120,39 @@ class Robots
       Regexp.compile("^#{pattern}")
     end
   end
-  
+
   def self.get_robots_txt(uri, user_agent)
     begin
-      Timeout::timeout(Robots.timeout) do
-        io = URI.join(uri.to_s, "/robots.txt").open("User-Agent" => user_agent) rescue nil
-      end 
+      Timeout.timeout(Robots.timeout) do
+        begin
+          URI.join(uri.to_s, "/robots.txt").open("User-Agent" => user_agent)
+        rescue StandardError
+          nil
+        end
+      end
     rescue Timeout::Error
-      STDERR.puts "robots.txt request timed out"
+      dlog("robots.txt request timed out")
     end
   end
-  
-  def self.timeout=(t)
-    @timeout = t
-  end
-  
+
+  attr_writer :timeout
+
   def self.timeout
     @timeout || DEFAULT_TIMEOUT
   end
-  
+
   def initialize(user_agent)
     @user_agent = user_agent
     @parsed = {}
   end
-  
+
   def allowed?(uri)
     uri = URI.parse(uri.to_s) unless uri.is_a?(URI)
     host = uri.host
     @parsed[host] ||= ParsedRobots.new(uri, @user_agent)
     @parsed[host].allowed?(uri, @user_agent)
   end
-  
+
   def other_values(uri)
     uri = URI.parse(uri.to_s) unless uri.is_a?(URI)
     host = uri.host

--- a/lib/robots.rb
+++ b/lib/robots.rb
@@ -14,7 +14,7 @@ class Robots
       
       io = Robots.get_robots_txt(uri, user_agent)
       
-      if !io || io.content_type != "text/plain" || io.status != ["200", "OK"]
+      if !io || io.content_type != "text/plain" || io.status.first != "200"
         io = StringIO.new("User-agent: *\nAllow: /\n")
       end
 

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -171,8 +171,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'rex-exploitation'
   # Command line editing, history, and tab completion in msfconsole
   spec.add_runtime_dependency 'rb-readline'
-  # Needed by anemone crawler
-  spec.add_runtime_dependency 'robots'
   # Needed by some modules
   spec.add_runtime_dependency 'rubyzip'
   # Needed for some post modules


### PR DESCRIPTION
This takes us down one gem, which is a special case. Normally we want to use upstream as much as possible, but this one:

 - has a bug in the packaged gem that installs with the wrong permissions (most metasploit-framework packagers have workarounds for this one file)
 - has not had an update in 7 years, but there are a few minor bugs
 - is only about 100 lines of relatively simple code, which we don't really need a whole gem for

So, this incorporates the one file, applies all of the outstanding PRs, and makes it log nicely with dlog vs straight to STDERR.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Use something that requires Robots, e.g. web crawler
- [x] **Verify** things work mildly better than before, or at least no worse