### PR TITLE
Avoid some ActiveRecord validation errors.

### DIFF
--- a/modules/auxiliary/admin/http/dlink_dir_645_password_extractor.rb
+++ b/modules/auxiliary/admin/http/dlink_dir_645_password_extractor.rb
@@ -49,7 +49,6 @@ class MetasploitModule < Msf::Auxiliary
     }.merge(service_data)
 
     login_data = {
-      last_attempted_at: DateTime.now,
       core: create_credential(credential_data),
       status: Metasploit::Model::Login::Status::UNTRIED,
       proof: opts[:proof]

--- a/modules/auxiliary/admin/http/dlink_dsl320b_password_extractor.rb
+++ b/modules/auxiliary/admin/http/dlink_dsl320b_password_extractor.rb
@@ -46,7 +46,6 @@ class MetasploitModule < Msf::Auxiliary
     }.merge(service_data)
 
     login_data = {
-      last_attempted_at: DateTime.now,
       core: create_credential(credential_data),
       status: Metasploit::Model::Login::Status::UNTRIED,
       proof: opts[:proof]

--- a/modules/auxiliary/admin/http/nexpose_xxe_file_read.rb
+++ b/modules/auxiliary/admin/http/nexpose_xxe_file_read.rb
@@ -61,7 +61,6 @@ class MetasploitModule < Msf::Auxiliary
     }.merge(service_data)
 
     login_data = {
-      last_attempted_at: DateTime.now,
       core: create_credential(credential_data),
       status: Metasploit::Model::Login::Status::UNTRIED
     }.merge(service_data)

--- a/modules/auxiliary/gather/asterisk_creds.rb
+++ b/modules/auxiliary/gather/asterisk_creds.rb
@@ -116,7 +116,6 @@ class MetasploitModule < Msf::Auxiliary
     }.merge service_data
 
     login_data = {
-      last_attempted_at: DateTime.now,
       core:              create_credential(credential_data),
       status:            Metasploit::Model::Login::Status::UNTRIED,
       proof:             opts[:proof]


### PR DESCRIPTION
Per discussion with @bcoles in [PR 8759](https://github.com/rapid7/metasploit-framework/pull/8759#issuecomment-325028479), setting a login data's last_attempted_at value while also setting the status to UNTRIED will cause a validation error when there's a running+connected MSF DB.

This PR removes the handful of existing cases we're doing this (thx, @bcoles!).

## Verification

List the steps needed to make sure this thing works

- [x] Ensure your framework PostgreSQL DB is running
- [x] Start `msfconsole`
- [x] `use <one of the four modules that were updated in this PR>`
- [x] do the thing with the module that will have it execute the code path containing `create_credential_login` 
- [x] **Verify** you don't encounter an ActiveRecord validation error

