### PR TITLE
Fix MS2715, false positive when telneting against web server

### DIFF
--- a/lib/msf/core/auxiliary/login.rb
+++ b/lib/msf/core/auxiliary/login.rb
@@ -44,6 +44,7 @@ module Auxiliary::Login
         Unable    | Error    | Denied    | Reject   |
         Refuse    | Close    | Closing   | %\ Bad   |
         Sorry     |
+        \<\/body\>\<\/html\> |
         Not\ on\ system\ console |
         Enter\ username\ and\ password |
         Auto\ Apply\ On |


### PR DESCRIPTION
Add a condition to identify when server returned HTML as login failure

The fix is to add an entry to `failure_regex` so that it recognize HTML text returned from server as login failure.

## Verification

List the steps needed to make sure this thing works

- [x] Verified using MS Pro
- [x] Follow the steps in MS 2715
- [x] Notice now that when validating a user/password, the result is "Not Validated".  It used to be "Validated"
