### PR TITLE
Add additional error checking to mssql_clr_payload module

### DIFF
--- a/modules/exploits/windows/mssql/mssql_clr_payload.rb
+++ b/modules/exploits/windows/mssql/mssql_clr_payload.rb
@@ -96,7 +96,10 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def set_trustworthy(on)
-      mssql_query("ALTER DATABASE [#{datastore['DATABASE']}] SET TRUSTWORTHY #{on ? 'ON' : 'OFF'}", false)
+    result = mssql_query("ALTER DATABASE [#{datastore['DATABASE']}] SET TRUSTWORTHY #{on ? 'ON' : 'OFF'}", false)
+    unless result[:errors].empty?
+      fail_with(Failure::Unknown, "Failed to change Trustworthy setting")
+    end
   end
 
   def is_trustworthy
@@ -112,7 +115,10 @@ RECONFIGURE;
 EXEC sp_configure 'clr enabled', #{enable ? 1 : 0};
 RECONFIGURE;
     ^
-    mssql_query(query, false)
+    result = mssql_query(query, false)
+    unless result[:errors].empty?
+      fail_with(Failure::Unknown, "Failed to change CLR setting")
+    end
   end
 
   def is_clr_enabled

--- a/modules/exploits/windows/mssql/mssql_clr_payload.rb
+++ b/modules/exploits/windows/mssql/mssql_clr_payload.rb
@@ -98,6 +98,9 @@ class MetasploitModule < Msf::Exploit::Remote
   def set_trustworthy(on)
     result = mssql_query("ALTER DATABASE [#{datastore['DATABASE']}] SET TRUSTWORTHY #{on ? 'ON' : 'OFF'}", false)
     unless result[:errors].empty?
+      result[:errors].each do |err|
+        vprint_error(err)
+      end
       fail_with(Failure::Unknown, "Failed to change Trustworthy setting")
     end
   end
@@ -117,6 +120,9 @@ RECONFIGURE;
     ^
     result = mssql_query(query, false)
     unless result[:errors].empty?
+      result[:errors].each do |err|
+        vprint_error(err)
+      end
       fail_with(Failure::Unknown, "Failed to change CLR setting")
     end
   end


### PR DESCRIPTION
Add additional error checking to `exploit/windows/mssql/mssql_clr_payload`
If an error is encountered when changing the trustworthy or clr setting, the exploit fails with a message.
Resolves #8123

## Verification

- [x] Start `msfconsole`
- [x] `use exploit/windows/mssql/mssql_clr_payload`
- [x] `set USERNAME`, `PASSWORD`, `RHOST`
- [x] `run`
- [x] **Verify** you still get a shell
- [x] **Verify** if an error occurs when setting trustworthy or clr, the exploit fails with a message

