### PR TITLE
Add output to options when DisablePayloadHandler is enabled

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/common.rb
+++ b/lib/msf/ui/console/command_dispatcher/common.rb
@@ -119,6 +119,7 @@ module Common
       if (p)
         p_opt = Serializer::ReadableText.dump_options(p, '   ')
         print("\nPayload options (#{mod.datastore['PAYLOAD']}):\n\n#{p_opt}\n") if (p_opt and p_opt.length > 0)
+        print("   **DisablePayloadHandler: True   (RHOST and RPORT settings will be ignored!)**\n\n") if mod.datastore['DisablePayloadHandler']
       end
     end
 

--- a/lib/msf/ui/console/command_dispatcher/common.rb
+++ b/lib/msf/ui/console/command_dispatcher/common.rb
@@ -12,7 +12,7 @@ module CommandDispatcher
   # These are functions that are used in two or more command dispatchers.
 
 module Common
-  
+
   # Parse +arg+ into a {Rex::Socket::RangeWalker} and append the result into +host_ranges+
   #
   # @note This modifies +host_ranges+ in place
@@ -41,7 +41,7 @@ module Common
     end
     return true
   end
-  
+
   #
   # Parse +arg+ into an array of ports and append the result into +port_ranges+
   #
@@ -62,7 +62,7 @@ module Common
     end
     return true
   end
-  
+
   #
   # Set RHOSTS in the +active_module+'s (or global if none) datastore from an array of addresses
   #
@@ -138,8 +138,8 @@ module Common
     # Uncomment this line if u want target like msf2 format
     #print("\nTarget: #{mod.target.name}\n\n")
   end
-  
-  
+
+
 end
 
 end


### PR DESCRIPTION
A quick message on `options` (aka `show options`), saying that RHOST and RPORT will not be used if `DisablePayloadHandler` is enabled.
Normally this would only been shown during the exploitation stage (and could be overlooked).

```
root@kali:~/metasploit-framework# ./msfconsole -q -x 'use exploit/multi/script/web_delivery;
set target 2;
set payload windows/shell/reverse_tcp;
options;
set DisablePayloadHandler true;
options;
exit;'
target => 2
payload => windows/shell/reverse_tcp

Module options (exploit/multi/script/web_delivery):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   SRVHOST  0.0.0.0          yes       The local host to listen on. This must be an address on the local machine or 0.0.0.0
   SRVPORT  8080             yes       The local port to listen on.
   SSL      false            no        Negotiate SSL for incoming connections
   SSLCert                   no        Path to a custom SSL certificate (default is randomly generated)
   URIPATH                   no        The URI to use for this exploit (default is random)


Payload options (windows/shell/reverse_tcp):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   EXITFUNC  process          yes       Exit technique (Accepted: '', seh, thread, process, none)
   LHOST                      yes       The listen address
   LPORT     4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   2   PSH


DisablePayloadHandler => true

Module options (exploit/multi/script/web_delivery):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   SRVHOST  0.0.0.0          yes       The local host to listen on. This must be an address on the local machine or 0.0.0.0
   SRVPORT  8080             yes       The local port to listen on.
   SSL      false            no        Negotiate SSL for incoming connections
   SSLCert                   no        Path to a custom SSL certificate (default is randomly generated)
   URIPATH                   no        The URI to use for this exploit (default is random)


Payload options (windows/shell/reverse_tcp):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   EXITFUNC  process          yes       Exit technique (Accepted: '', seh, thread, process, none)
   LHOST                      yes       The listen address
   LPORT     4444             yes       The listen port

   **DisablePayloadHandler: True   (RHOST and RPORT settings will be ignored!)**


Exploit target:

   Id  Name
   --  ----
   2   PSH


root@kali:~/metasploit-framework#
```