### PR TITLE
bump payloads, add shell expansion for java/android payloads

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 1.3.6)
+      metasploit-payloads (= 1.3.7)
       metasploit_data_models
       metasploit_payloads-mettle (= 0.2.2)
       msgpack
@@ -150,7 +150,7 @@ GEM
       activemodel (~> 4.2.6)
       activesupport (~> 4.2.6)
       railties (~> 4.2.6)
-    metasploit-payloads (1.3.6)
+    metasploit-payloads (1.3.7)
     metasploit_data_models (2.0.15)
       activerecord (~> 4.2.6)
       activesupport (~> 4.2.6)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -70,7 +70,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '1.3.6'
+  spec.add_runtime_dependency 'metasploit-payloads', '1.3.7'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '0.2.2'
   # Needed by msfgui and other rpc components


### PR DESCRIPTION
This fixes https://github.com/rapid7/metasploit-payloads/pull/233 by allowing full shell expansion when doing cmd_exec on java and android payloads.