### PR TITLE
Bug - HTTP Client can call :shutdown on closed IO

### DIFF
--- a/lib/rex/proto/http/client.rb
+++ b/lib/rex/proto/http/client.rb
@@ -191,9 +191,9 @@ class Client
   # Closes the connection to the remote server.
   #
   def close
-    if (self.conn)
+    if (self.conn and !self.conn.closed?)
       self.conn.shutdown
-      self.conn.close unless self.conn.closed?
+      self.conn.close
     end
 
     self.conn = nil


### PR DESCRIPTION
When running Rex HTTP client calls across pivots, pivot sockets
can get closed by the remote server, resulting in a closed :conn
object within the client object. The clients :close method calls
self.conn.shutdown which raises an 'IOError closed stream' on what
is effectively a TCPSocket object in a closed state (under the Rex
abstraction).

Resolve by moving the self.conn.closed? check into the conditional
just above the :shutdown call, and remove if from the underlying
:close call as calling :close on an already closed TCPSocket
returns nil as opposed to throwing an exception like the :shutdown
method.


Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/http/fingerprint`
- [x] start a meterpreter session and route traffic to the target over it (aim at something which closes the connection after every request)
- [x] **Verify** the scanner is able to make multiple requests without throwing an _IOError closed stream_ exception

