### PR TITLE
fix #8879, fix APK injection edge cases

### DIFF
--- a/lib/msf/core/payload/apk.rb
+++ b/lib/msf/core/payload/apk.rb
@@ -41,7 +41,10 @@ class Msf::Payload::Apk
     application = amanifest.xpath('//application')
     application_name = application.attribute("name")
     if application_name
-      return application_name.to_s
+      application_str = application_name.to_s
+      unless application_str == 'android.app.Application'
+        return application_str
+      end
     end
     activities = amanifest.xpath("//activity|//activity-alias")
     for activity in activities
@@ -221,7 +224,7 @@ class Msf::Payload::Apk
     FileUtils.rm Dir.glob("#{tempdir}/payload/smali/com/metasploit/stage/R*.smali")
 
     package = amanifest.xpath("//manifest").first['package']
-    package = package + ".#{Rex::Text::rand_text_alpha_lower(5)}"
+    package = package.downcase + ".#{Rex::Text::rand_text_alpha_lower(5)}"
     classes = {}
     classes['Payload'] = Rex::Text::rand_text_alpha_lower(5).capitalize
     classes['MainService'] = Rex::Text::rand_text_alpha_lower(5).capitalize


### PR DESCRIPTION
This fixes two issues in APK injection reported in #8879 
1. In the manifest the Application class extends `android.app.Application`, which is the default class and not actually injectable.
2. Fix injecting into packagename that contain uppercase characters (I didn't know this was allowed).