### PR TITLE
restore clear opts on current connection staging

### DIFF
--- a/lib/msf/core/payload/stager.rb
+++ b/lib/msf/core/payload/stager.rb
@@ -165,6 +165,7 @@ module Msf::Payload::Stager
     # If the stage should be sent over the client connection that is
     # established (which is the default), then go ahead and transmit it.
     if (stage_over_connection?)
+      opts = {}
       if respond_to? :include_send_uuid
         if include_send_uuid
           uuid_raw = conn.get_once(16, 1)


### PR DESCRIPTION
This restores the fresh set of opts containing only the new uuid
passed to generate_stage() that was removed in commit fdc9864.

Further impact of this change on new pivoting code updates are
still being evaluated.

Addresses Pro issue MS-2829 impacting rerun of exploits

## Verification

Evaluate tests from https://github.com/rapid7/metasploit-payloads/pull/226 that will need to be executed to determine further impacts