### PR TITLE
spelling/grammar fixes part 3

### DIFF
--- a/modules/exploits/windows/browser/safari_xslt_output.rb
+++ b/modules/exploits/windows/browser/safari_xslt_output.rb
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Exploit::Remote
         rendering engine. It is possible to redirect the output of a XSLT
         transformation to an arbitrary file. The content of the created file must be
         ASCII or UTF-8. The destination path can be relative or absolute. This module
-        has been tested on Safari and Maxthon. Code execution can be acheived by first
+        has been tested on Safari and Maxthon. Code execution can be achieved by first
         uploading the payload to the remote machine in VBS format, and then upload a MOF
         file, which enables Windows Management Instrumentation service to execute the VBS.
       },

--- a/modules/exploits/windows/browser/teechart_pro.rb
+++ b/modules/exploits/windows/browser/teechart_pro.rb
@@ -12,9 +12,9 @@ class MetasploitModule < Msf::Exploit::Remote
     super( update_info(info,
       'Name'           => 'TeeChart Professional ActiveX Control Trusted Integer Dereference',
       'Description'    => %q{
-          This module exploits a integer overflow in TeeChart Pro ActiveX control. When
+          This module exploits an integer overflow in TeeChart Pro ActiveX control. When
         sending an overly large/negative integer value to the AddSeries() property of
-        TeeChart2010.ocx, the code will perform an arithemetic operation that wraps the
+        TeeChart2010.ocx, the code will perform an arithmetic operation that wraps the
         value and is later directly trusted and called upon.
 
         This module has been designed to bypass DEP only under IE8 with Java support. Multiple

--- a/modules/exploits/windows/browser/tom_sawyer_tsgetx71ex552.rb
+++ b/modules/exploits/windows/browser/tom_sawyer_tsgetx71ex552.rb
@@ -27,7 +27,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ActiveX control installed with Tom Sawyer GET Extension Factory due to an incorrect
         initialization under Internet Explorer.
 
-        While the Tom Sawyer GET Extension Factory is installed with some versions of  VMware
+        While the Tom Sawyer GET Extension Factory is installed with some versions of VMware
         Infrastructure Client, this module has been tested only with the versions installed
         with Embarcadero Technologies ER/Studio XE2 / Embarcadero Studio Portal 1.6. The ActiveX
         control tested is tsgetx71ex553.dll, version 5.5.3.238.

--- a/modules/exploits/windows/browser/webex_ucf_newobject.rb
+++ b/modules/exploits/windows/browser/webex_ucf_newobject.rb
@@ -14,7 +14,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Name'           => 'WebEx UCF atucfobj.dll ActiveX NewObject Method Buffer Overflow',
       'Description'    => %q{
           This module exploits a stack-based buffer overflow in WebEx's WebexUCFObject
-        ActiveX Control. If an long string is passed to the 'NewObject' method, a stack-
+        ActiveX Control. If a long string is passed to the 'NewObject' method, a stack-
         based buffer overflow will occur when copying attacker-supplied data using the
         sprintf function.
 

--- a/modules/exploits/windows/browser/winamp_playlist_unc.rb
+++ b/modules/exploits/windows/browser/winamp_playlist_unc.rb
@@ -16,7 +16,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Name'           => 'Winamp Playlist UNC Path Computer Name Overflow',
       'Description'    => %q{
           This module exploits a vulnerability in the Winamp media player.
-        This flaw is triggered when a audio file path is specified, inside a
+        This flaw is triggered when an audio file path is specified, inside a
         playlist, that consists of a UNC path with a long computer name. This
         module delivers the playlist via the browser. This module has only
         been successfully tested on Winamp 5.11 and 5.12.

--- a/modules/exploits/windows/browser/winamp_ultravox.rb
+++ b/modules/exploits/windows/browser/winamp_ultravox.rb
@@ -15,7 +15,7 @@ class MetasploitModule < Msf::Exploit::Remote
           This module exploits a stack buffer overflow in Winamp 5.24. By
         sending an overly long artist tag, a remote attacker may
         be able to execute arbitrary code. This vulnerability can be
-        exploited from the browser or the winamp client itself.
+        exploited from the browser or the Winamp client itself.
       },
       'Author'         => 'MC',
       'License'        => MSF_LICENSE,

--- a/modules/exploits/windows/browser/windvd7_applicationtype.rb
+++ b/modules/exploits/windows/browser/windvd7_applicationtype.rb
@@ -13,8 +13,8 @@ class MetasploitModule < Msf::Exploit::Remote
     super(update_info(info,
       'Name'           => 'WinDVD7 IASystemInfo.DLL ActiveX Control Buffer Overflow',
       'Description'    => %q{
-          This module exploits an stack buffer overflow in IASystemInfo.dll ActiveX
-        control in InterVideo WinDVD 7. By sending a overly long string
+          This module exploits a stack buffer overflow in IASystemInfo.dll ActiveX
+        control in InterVideo WinDVD 7. By sending an overly long string
         to the "ApplicationType()" property, an attacker may be able to
         execute arbitrary code.
       },

--- a/modules/exploits/windows/browser/windvd7_applicationtype.rb
+++ b/modules/exploits/windows/browser/windvd7_applicationtype.rb
@@ -13,7 +13,7 @@ class MetasploitModule < Msf::Exploit::Remote
     super(update_info(info,
       'Name'           => 'WinDVD7 IASystemInfo.DLL ActiveX Control Buffer Overflow',
       'Description'    => %q{
-          This module exploits a stack buffer overflow in IASystemInfo.dll ActiveX
+          This module exploits an stack buffer overflow in IASystemInfo.dll ActiveX
         control in InterVideo WinDVD 7. By sending a overly long string
         to the "ApplicationType()" property, an attacker may be able to
         execute arbitrary code.

--- a/modules/exploits/windows/browser/wmi_admintools.rb
+++ b/modules/exploits/windows/browser/wmi_admintools.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Exploit::Remote
         opt-in to ASLR. As such, this module should be reliable on all Windows
         versions.
 
-        The WMI Adminsitrative Tools are a standalone download & install (linked in the
+        The WMI Administrative Tools are a standalone download & install (linked in the
         references).
 
       },

--- a/modules/exploits/windows/browser/x360_video_player_set_text_bof.rb
+++ b/modules/exploits/windows/browser/x360_video_player_set_text_bof.rb
@@ -13,7 +13,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Name'                => "X360 VideoPlayer ActiveX Control Buffer Overflow",
       'Description'         => %q{
         This module exploits a buffer overflow in the VideoPlayer.ocx ActiveX installed with the
-        X360 Software. By setting an overly long value to 'ConvertFile()',an attacker can overrun
+        X360 Software. By setting an overly long value to 'ConvertFile()', an attacker can overrun
         a .data buffer to bypass ASLR/DEP and finally execute arbitrary code.
       },
       'License'             => MSF_LICENSE,

--- a/modules/exploits/windows/browser/yahoomessenger_fvcom.rb
+++ b/modules/exploits/windows/browser/yahoomessenger_fvcom.rb
@@ -13,7 +13,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Name'           => 'Yahoo! Messenger YVerInfo.dll ActiveX Control Buffer Overflow',
       'Description'    => %q{
           This module exploits a stack buffer overflow in the Yahoo! Messenger ActiveX
-        Control (YVerInfo.dll <= 2006.8.24.1). By sending a overly long string
+        Control (YVerInfo.dll <= 2006.8.24.1). By sending an overly long string
         to the "fvCom()" method from a yahoo.com domain, an attacker may be able
         to execute arbitrary code.
       },

--- a/modules/exploits/windows/browser/yahoomessenger_server.rb
+++ b/modules/exploits/windows/browser/yahoomessenger_server.rb
@@ -14,7 +14,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Description'    => %q{
           This module exploits a stack buffer overflow in the Yahoo! Webcam Upload ActiveX
         Control (ywcupl.dll) provided by Yahoo! Messenger version 8.1.0.249.
-        By sending a overly long string to the "Server()" method, and then calling
+        By sending an overly long string to the "Server()" method, and then calling
         the "Send()" method, an attacker may be able to execute arbitrary code.
         Using the payloads "windows/shell_bind_tcp" and "windows/shell_reverse_tcp"
         yield for the best results.

--- a/modules/exploits/windows/email/ms10_045_outlook_ref_only.rb
+++ b/modules/exploits/windows/email/ms10_045_outlook_ref_only.rb
@@ -24,9 +24,9 @@ class MetasploitModule < Msf::Exploit::Remote
         streams with certain MAPI attachment properties, it is possible to set a path name
         to files to be executed. When a user double clicks on such an attachment or message,
         Outlook will proceed to execute the file that is set by the path name value. These
-        files can be local files, but also file stored remotely for example on a file share.
-        Exploitation is limited by the fact that it is not possible for attackers to supply
-        command line options.
+        files can be local files, but also files stored remotely (on a file share, for example)
+        can be used. Exploitation is limited by the fact that it is not possible for attackers
+        to supply command line options.
       },
       'Author'		=> 'Yorick Koster <yorick[at]akitasecurity.nl>',
       'References'	=>

--- a/modules/exploits/windows/email/ms10_045_outlook_ref_only.rb
+++ b/modules/exploits/windows/email/ms10_045_outlook_ref_only.rb
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Exploit::Remote
         to files to be executed. When a user double clicks on such an attachment or message,
         Outlook will proceed to execute the file that is set by the path name value. These
         files can be local files, but also file stored remotely for example on a file share.
-        Exploitation is limited by the fact that its is not possible for attackers to supply
+        Exploitation is limited by the fact that it is not possible for attackers to supply
         command line options.
       },
       'Author'		=> 'Yorick Koster <yorick[at]akitasecurity.nl>',

--- a/modules/exploits/windows/fileformat/abbs_amp_lst.rb
+++ b/modules/exploits/windows/fileformat/abbs_amp_lst.rb
@@ -14,7 +14,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Description'    => %q{
           This module exploits a buffer overflow in ABBS Audio Media Player. The vulnerability
         occurs when adding a specially crafted .lst file, allowing arbitrary code execution with the privileges
-        of the user running the application . This module has been tested successfully on
+        of the user running the application. This module has been tested successfully on
         ABBS Audio Media Player 3.1 over Windows XP SP3 and Windows 7 SP1.
       },
       'License'        => MSF_LICENSE,

--- a/modules/exploits/windows/fileformat/adobe_flashplayer_button.rb
+++ b/modules/exploits/windows/fileformat/adobe_flashplayer_button.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
         NOTE: This module uses a similar DEP bypass method to that used within the
         adobe_libtiff module. This method is unlikely to work across various
-        Windows versions due a the hardcoded syscall number.
+        Windows versions due to a hardcoded syscall number.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>

--- a/modules/exploits/windows/fileformat/adobe_toolbutton.rb
+++ b/modules/exploits/windows/fileformat/adobe_toolbutton.rb
@@ -13,7 +13,7 @@ class MetasploitModule < Msf::Exploit::Remote
     super(update_info(info,
       'Name'           => 'Adobe Reader ToolButton Use After Free',
       'Description'    => %q{
-        This module exploits an use after free condition on Adobe Reader versions 11.0.2, 10.1.6
+        This module exploits a use after free condition on Adobe Reader versions 11.0.2, 10.1.6
         and 9.5.4 and prior. The vulnerability exists while handling the ToolButton object, where
         the cEnable callback can be used to early free the object memory. Later use of the object
         allows triggering the use after free condition. This module has been tested successfully

--- a/modules/exploits/windows/fileformat/apple_quicktime_rdrf.rb
+++ b/modules/exploits/windows/fileformat/apple_quicktime_rdrf.rb
@@ -13,8 +13,8 @@ class MetasploitModule < Msf::Exploit::Remote
     super(update_info(info,
       'Name'           => "Apple Quicktime 7 Invalid Atom Length Buffer Overflow",
       'Description'    => %q{
-        This module exploits a vulnerability found in Apple Quicktime. The flaw is
-        triggered when Quicktime fails to properly handle the data length for certain
+        This module exploits a vulnerability found in Apple QuickTime. The flaw is
+        triggered when QuickTime fails to properly handle the data length for certain
         atoms such as 'rdrf' or 'dref' in the Alis record, which may result a buffer
         overflow by loading a specially crafted .mov file, and allows arbitrary
         code execution under the context of the current user. Please note: Since an egghunter

--- a/modules/exploits/windows/fileformat/audiotran_pls.rb
+++ b/modules/exploits/windows/fileformat/audiotran_pls.rb
@@ -16,7 +16,7 @@ class MetasploitModule < Msf::Exploit::Remote
           This module exploits a stack-based buffer overflow in Audiotran 1.4.1.
         An attacker must send the file to victim and the victim must open the file.
         Alternatively it may be possible to execute code remotely via an embedded
-        PLS file within a browser, when the PLS extention is registered to Audiotran.
+        PLS file within a browser, when the PLS extension is registered to Audiotran.
         This functionality has not been tested in this module.
       },
       'License'        => MSF_LICENSE,

--- a/modules/exploits/windows/fileformat/audiotran_pls_1424.rb
+++ b/modules/exploits/windows/fileformat/audiotran_pls_1424.rb
@@ -16,7 +16,7 @@ class MetasploitModule < Msf::Exploit::Remote
           This module exploits a stack-based buffer overflow in Audiotran 1.4.2.4.
         An attacker must send the file to victim and the victim must open the file.
         Alternatively, it may be possible to execute code remotely via an embedded
-        PLS file within a browser when the PLS extention is registered to Audiotran.
+        PLS file within a browser when the PLS extension is registered to Audiotran.
         This alternate vector has not been tested and cannot be exercised directly
         with this module.
       },

--- a/modules/exploits/windows/fileformat/aviosoft_plf_buf.rb
+++ b/modules/exploits/windows/fileformat/aviosoft_plf_buf.rb
@@ -14,7 +14,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Description'    => %q{
             This module exploits a vulnerability found in Aviosoft Digital TV Player
           Pro version 1.x.  An overflow occurs when the process copies the content of a
-          playlist file on to the stack, which may result aribitrary code execution under
+          playlist file on to the stack, which may result arbitrary code execution under
           the context of the user.
         },
       'License'        => MSF_LICENSE,

--- a/modules/exploits/windows/fileformat/beetel_netconfig_ini_bof.rb
+++ b/modules/exploits/windows/fileformat/beetel_netconfig_ini_bof.rb
@@ -14,7 +14,7 @@ class MetasploitModule < Msf::Exploit
       'Name'    => "Beetel Connection Manager NetConfig.ini Buffer Overflow",
       'Description' => %q{
         This module exploits a stack-based buffer overflow on Beetel Connection Manager. The
-        vulnerability exists in the parising of the UserName parameter in the NetConfig.ini
+        vulnerability exists in the parsing of the UserName parameter in the NetConfig.ini
         file. The module has been tested successfully on PCW_BTLINDV1.0.0B04 over Windows XP
         SP3 and Windows 7 SP1.
       },

--- a/modules/exploits/windows/fileformat/ca_cab.rb
+++ b/modules/exploits/windows/fileformat/ca_cab.rb
@@ -13,7 +13,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Name'           => 'CA Antivirus Engine CAB Buffer Overflow',
       'Description'    => %q{
           This module exploits a stack buffer overflow in CA eTrust Antivirus 8.1.637.
-          By creating a specially crafted CAB file, an an attacker may be able
+          By creating a specially crafted CAB file, an attacker may be able
           to execute arbitrary code.
       },
       'License'        => MSF_LICENSE,

--- a/modules/exploits/windows/fileformat/ccmplayer_m3u_bof.rb
+++ b/modules/exploits/windows/fileformat/ccmplayer_m3u_bof.rb
@@ -15,7 +15,7 @@ class MetasploitModule < Msf::Exploit::Remote
           This module exploits a stack based buffer overflow in CCMPlayer 1.5. Opening
         a m3u playlist with a long track name, a SEH exception record can be overwritten
         with parts of the controllable buffer. SEH execution is triggered after an
-        invalid read of an injectible address, thus allowing arbitrary code execution.
+        invalid read of an injectable address, thus allowing arbitrary code execution.
         This module works on multiple Windows platforms including: Windows XP SP3,
         Windows Vista, and Windows 7.
       },

--- a/modules/exploits/windows/fileformat/chasys_draw_ies_bmp_bof.rb
+++ b/modules/exploits/windows/fileformat/chasys_draw_ies_bmp_bof.rb
@@ -15,7 +15,7 @@ class MetasploitModule < Msf::Exploit::Remote
           This module exploits a buffer overflow vulnerability found in Chasys Draw IES
         (version 4.10.01). The vulnerability exists in the module flt_BMP.dll, while
         parsing BMP files, where the ReadFile function is used to store user provided data
-        on the  stack in a insecure way. It results in arbitrary code execution under the
+        on the stack in an insecure way. It results in arbitrary code execution under the
         context of the user viewing a specially crafted BMP file. This module has been
         tested successfully with Chasys Draw IES 4.10.01 on Windows XP SP3 and Windows 7
         SP1.

--- a/modules/exploits/windows/fileformat/cve_2017_8464_lnk_rce.rb
+++ b/modules/exploits/windows/fileformat/cve_2017_8464_lnk_rce.rb
@@ -21,7 +21,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
           This vulnerability is a variant of MS15-020 (CVE-2015-0096). The created LNK file is
           similar except an additional SpecialFolderDataBlock is included. The folder ID set
-          in this SpecialFolderDataBlock is set to the Control Panel. This is enought to bypass
+          in this SpecialFolderDataBlock is set to the Control Panel. This is enough to bypass
           the CPL whitelist. This bypass can be used to trick Windows into loading an arbitrary
           DLL file.
         },

--- a/modules/exploits/windows/fileformat/deepburner_path.rb
+++ b/modules/exploits/windows/fileformat/deepburner_path.rb
@@ -17,7 +17,7 @@ class MetasploitModule < Msf::Exploit::Remote
         1.8.0, and possibly other versions of AstonSoft's DeepBurner (Pro, Lite, etc).
         An attacker must send the file to victim and the victim must open the file.
         Alternatively it may be possible to execute code remotely via an embedded
-        DBR file within a browser, since the DBR extention is registered to DeepBurner.
+        DBR file within a browser, since the DBR extension is registered to DeepBurner.
       },
       'License'        => MSF_LICENSE,
       'Author' 	 =>

--- a/modules/exploits/windows/fileformat/dvdx_plf_bof.rb
+++ b/modules/exploits/windows/fileformat/dvdx_plf_bof.rb
@@ -15,7 +15,7 @@ class MetasploitModule < Msf::Exploit::Remote
           This module exploits a stack-based buffer overflow on DVD X Player 5.5 Pro and
         Standard.  By supplying a long string of data in a plf file (playlist), the
         MediaPlayerCtrl.dll component will attempt to extract a filename out of the string,
-        and then copy it on the stack without any proper bounds checking, which casues a
+        and then copy it on the stack without any proper bounds checking, which causes a
         buffer overflow, and results arbitrary code execution under the context of the user.
 
           This module has been designed to target common Windows systems such as:

--- a/modules/exploits/windows/fileformat/dvdx_plf_bof.rb
+++ b/modules/exploits/windows/fileformat/dvdx_plf_bof.rb
@@ -16,7 +16,7 @@ class MetasploitModule < Msf::Exploit::Remote
         Standard.  By supplying a long string of data in a plf file (playlist), the
         MediaPlayerCtrl.dll component will attempt to extract a filename out of the string,
         and then copy it on the stack without any proper bounds checking, which causes a
-        buffer overflow, and results arbitrary code execution under the context of the user.
+        buffer overflow, and results in arbitrary code execution under the context of the user.
 
           This module has been designed to target common Windows systems such as:
         Windows XP SP2/SP3, Windows Vista, and Windows 7.

--- a/modules/exploits/windows/fileformat/emc_appextender_keyworks.rb
+++ b/modules/exploits/windows/fileformat/emc_appextender_keyworks.rb
@@ -12,8 +12,8 @@ class MetasploitModule < Msf::Exploit::Remote
     super(update_info(info,
       'Name'           => 'EMC ApplicationXtender (KeyWorks) ActiveX Control Buffer Overflow',
       'Description'    => %q{
-          This module exploits a stack buffer overflow in the KeyWorks KeyHelp Activex Control
-        (KeyHelp.ocx 1.2.3120.0). This Activex Control comes bundled with EMC's
+          This module exploits a stack buffer overflow in the KeyWorks KeyHelp ActiveX Control
+        (KeyHelp.ocx 1.2.3120.0). This ActiveX Control comes bundled with EMC's
         Documentation ApplicationXtender 5.4.
       },
       'License'        => MSF_LICENSE,

--- a/modules/exploits/windows/fileformat/erdas_er_viewer_bof.rb
+++ b/modules/exploits/windows/fileformat/erdas_er_viewer_bof.rb
@@ -14,7 +14,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Description'    => %q{
           This module exploits a buffer overflow vulnerability found in ERS Viewer 2011
         (version 11.04). The vulnerability exists in the module ermapper_u.dll where the
-        function ERM_convert_to_correct_webpath handles user provided data in a insecure
+        function ERM_convert_to_correct_webpath handles user provided data in an insecure
         way. It results in arbitrary code execution under the context of the user viewing
         a specially crafted .ers file. This module has been tested successfully with ERS
         Viewer 2011 (version 11.04) on Windows XP SP3 and Windows 7 SP1.

--- a/modules/exploits/windows/fileformat/erdas_er_viewer_rf_report_error.rb
+++ b/modules/exploits/windows/fileformat/erdas_er_viewer_rf_report_error.rb
@@ -15,7 +15,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Description'    => %q{
           This module exploits a buffer overflow vulnerability found in ERS Viewer 2013.
         The vulnerability exists in the module ermapper_u.dll, where the function
-        rf_report_error handles user provided data in a insecure way. It results in
+        rf_report_error handles user provided data in an insecure way. It results in
         arbitrary code execution under the context of the user viewing a specially crafted
         .ers file. This module has been tested successfully with ERS Viewer 2013 (versions
         13.0.0.1151) on Windows XP SP3 and Windows 7 SP1.

--- a/modules/exploits/windows/fileformat/hhw_hhp_compiledfile_bof.rb
+++ b/modules/exploits/windows/fileformat/hhw_hhp_compiledfile_bof.rb
@@ -14,7 +14,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Name'           => 'HTML Help Workshop 4.74 (hhp Project File) Buffer Overflow',
       'Description'    => %q{
           This module exploits a stack buffer overflow in HTML Help Workshop 4.74
-        By creating a specially crafted hhp file, an an attacker may be able
+        By creating a specially crafted hhp file, an attacker may be able
         to execute arbitrary code.
       },
       'License'        => MSF_LICENSE,

--- a/modules/exploits/windows/fileformat/homm3_h3m.rb
+++ b/modules/exploits/windows/fileformat/homm3_h3m.rb
@@ -14,9 +14,9 @@ class MetasploitModule < Msf::Exploit::Remote
     super(update_info(info,
       'Name'           => 'Heroes of Might and Magic III .h3m Map file Buffer Overflow',
       'Description'    => %q{
-          This module embeds an exploit into an ucompressed map file (.h3m) for
+          This module embeds an exploit into an uncompressed map file (.h3m) for
         Heroes of Might and Magic III. Once the map is started in-game, a
-        buffer overflow occuring when loading object sprite names leads to
+        buffer overflow occurring when loading object sprite names leads to
         shellcode execution.
       },
       'License'        => MSF_LICENSE,

--- a/modules/exploits/windows/fileformat/ibm_pcm_ws.rb
+++ b/modules/exploits/windows/fileformat/ibm_pcm_ws.rb
@@ -32,9 +32,9 @@ class MetasploitModule < Msf::Exploit::Remote
       saved RETURN address at offset 0x6c is overwritten by the data written past the buffer.
 
       To ensure we can perform arbitrary code execution we must we provide a valid pointer at
-      0x74 which is used as a argument for the called function at 0x675751ED as a id file
+      0x74 which is used as an argument for the called function at 0x675751ED as an id file
       extension parameter. Once the caller regains control we will reach our RETURN. The Ret
-      instruction will be used to pop the overwritten saved return address which was currupted.
+      instruction will be used to pop the overwritten saved return address which was corrupted.
 
       This exploit has been written to bypass 2 mitigations DEP and ASLR on a Windows platform.
 

--- a/modules/exploits/windows/fileformat/icofx_bof.rb
+++ b/modules/exploits/windows/fileformat/icofx_bof.rb
@@ -13,7 +13,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Name'           => 'IcoFX Stack Buffer Overflow',
       'Description'    => %q{
         This module exploits a stack-based buffer overflow vulnerability in version 2.1
-        of IcoFX. The vulnerability exists while parsing .ICO files, where an specially
+        of IcoFX. The vulnerability exists while parsing .ICO files, where a specially
         crafted ICONDIR header providing an arbitrary long number of images in the file
         can be used to trigger the overflow when reading the ICONDIRENTRY structures.
       },

--- a/modules/exploits/windows/fileformat/ideal_migration_ipj.rb
+++ b/modules/exploits/windows/fileformat/ideal_migration_ipj.rb
@@ -15,7 +15,7 @@ class MetasploitModule < Msf::Exploit::Remote
           This module exploits a stack buffer overflow in versions v9.7
         through v10.5 of IDEAL Administration and versions 4.5 and 4.51 of
         IDEAL Migration. All versions are suspected to be vulnerable.
-        By creating a specially crafted ipj file, an an attacker may be able
+        By creating a specially crafted ipj file, an attacker may be able
         to execute arbitrary code.
 
         NOTE: IDEAL Administration 10.5 is compiled with /SafeSEH

--- a/modules/exploits/windows/fileformat/mcafee_showreport_exec.rb
+++ b/modules/exploits/windows/fileformat/mcafee_showreport_exec.rb
@@ -18,8 +18,8 @@ class MetasploitModule < Msf::Exploit::Remote
         The ShowReport() function (located in the myCIOScn.dll ActiveX component) fails
         to check the FileName argument, and passes it on to a ShellExecuteW() function,
         therefore allows any malicious attacker to execute any process that's on the
-        local system.  However, if the victim machine is connected to a remote share (
-        or something similiar), then it's also possible to execute arbitrary code.
+        local system.  However, if the victim machine is connected to a remote share
+        (or something similar), then it's also possible to execute arbitrary code.
         Please note that a custom template is required for the payload, because the
         default Metasploit template is detectable by McAfee -- any Windows binary, such
         as calc.exe or notepad.exe, should bypass McAfee fine.

--- a/modules/exploits/windows/fileformat/millenium_mp3_pls.rb
+++ b/modules/exploits/windows/fileformat/millenium_mp3_pls.rb
@@ -16,7 +16,7 @@ class MetasploitModule < Msf::Exploit::Remote
           This module exploits a stack-based buffer overflow in Millenium MP3 Studio 2.0.
           An attacker must send the file to victim and the victim must open the file.
           Alternatively it may be possible to execute code remotely via an embedded
-          PLS file within a browser, when the PLS extention is registered to Millenium MP3 Studio.
+          PLS file within a browser, when the PLS extension is registered to Millenium MP3 Studio.
           This functionality has not been tested in this module.
       },
       'License'        => MSF_LICENSE,

--- a/modules/exploits/windows/fileformat/mjm_coreplayer2011_s3m.rb
+++ b/modules/exploits/windows/fileformat/mjm_coreplayer2011_s3m.rb
@@ -13,7 +13,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Name'           => 'MJM Core Player 2011 .s3m Stack Buffer Overflow',
       'Description'    => %q{
           This module exploits a stack buffer overflow in MJM Core Player 2011
-        When opening a malicious s3m file in this applications, a stack buffer overflow can be
+        When opening a malicious s3m file in this application, a stack buffer overflow can be
         triggered, resulting in arbitrary code execution.
         This exploit bypasses DEP & ASLR, and works on XP, Vista & Windows 7.
       },

--- a/modules/exploits/windows/fileformat/mplayer_sami_bof.rb
+++ b/modules/exploits/windows/fileformat/mplayer_sami_bof.rb
@@ -14,11 +14,11 @@ class MetasploitModule < Msf::Exploit::Remote
       'Description'    => %q{
           This module exploits a stack-based buffer overflow found in the handling
         of SAMI subtitles files in MPlayer SVN Versions before 33471. It currently
-        targets SMPlayer 0.6.8, which is distributed with a vulnerable version of mplayer.
+        targets SMPlayer 0.6.8, which is distributed with a vulnerable version of MPlayer.
 
         The overflow is triggered when an unsuspecting victim opens a movie file first,
         followed by loading the malicious SAMI subtitles file from the GUI. Or, it can also
-        be done from the console with the mplayer "-sub" option.
+        be done from the console with the MPlayer "-sub" option.
       },
       'License'        => MSF_LICENSE,
       'Author'         => [

--- a/modules/exploits/windows/fileformat/ms09_067_excel_featheader.rb
+++ b/modules/exploits/windows/fileformat/ms09_067_excel_featheader.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Exploit::Remote
           structure from the file to calculate a pointer offset without doing proper
           validation. Attacker supplied data is then used to calculate the location of an
           object, and in turn a virtual function call. This results in arbitrary code
-          exection.
+          execution.
 
           NOTE: On some versions of Office, the user will need to dismiss a warning dialog
           prior to the payload executing.

--- a/modules/exploits/windows/fileformat/ms10_038_excel_obj_bof.rb
+++ b/modules/exploits/windows/fileformat/ms10_038_excel_obj_bof.rb
@@ -14,7 +14,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Description'    => %q{
           This module exploits a vulnerability found in Excel 2002 of Microsoft Office XP.
         By supplying a .xls file with a malformed OBJ (recType 0x5D) record an attacker
-        can get the control of the excution flow. This results aribrary code execution under
+        can get the control of the execution flow. This results in arbitrary code execution under
         the context of the user.
       },
       'License'        => MSF_LICENSE,

--- a/modules/exploits/windows/fileformat/ms11_021_xlb_bof.rb
+++ b/modules/exploits/windows/fileformat/ms11_021_xlb_bof.rb
@@ -16,7 +16,7 @@ class MetasploitModule < Msf::Exploit::Remote
         By supplying a malformed .xlb file, an attacker can control the content (source)
         of a memcpy routine, and the number of bytes to copy, therefore causing a stack-
         based buffer overflow.  This results in arbitrary code execution under the context of
-        user the user.
+        the user.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>

--- a/modules/exploits/windows/fileformat/ms11_021_xlb_bof.rb
+++ b/modules/exploits/windows/fileformat/ms11_021_xlb_bof.rb
@@ -15,7 +15,7 @@ class MetasploitModule < Msf::Exploit::Remote
           This module exploits a vulnerability found in Excel of Microsoft Office 2007.
         By supplying a malformed .xlb file, an attacker can control the content (source)
         of a memcpy routine, and the number of bytes to copy, therefore causing a stack-
-        based buffer overflow.  This results aribrary code execution under the context of
+        based buffer overflow.  This results in arbitrary code execution under the context of
         user the user.
       },
       'License'        => MSF_LICENSE,

--- a/modules/exploits/windows/fileformat/ms_visual_basic_vbp.rb
+++ b/modules/exploits/windows/fileformat/ms_visual_basic_vbp.rb
@@ -12,7 +12,7 @@ class MetasploitModule < Msf::Exploit::Remote
     super(update_info(info,
       'Name'           => 'Microsoft Visual Basic VBP Buffer Overflow',
       'Description'    => %q{
-          This module exploits a stack oveflow in Microsoft Visual
+          This module exploits a stack overflow in Microsoft Visual
         Basic 6.0. When a specially crafted vbp file containing a long
         reference line, an attacker may be able to execute arbitrary
         code.

--- a/modules/exploits/windows/fileformat/mswin_tiff_overflow.rb
+++ b/modules/exploits/windows/fileformat/mswin_tiff_overflow.rb
@@ -41,8 +41,8 @@ class MetasploitModule < Msf::Exploit::Remote
           The flaw is due to a DWORD value extracted from the TIFF file that is embedded as a
           drawing in Microsoft Office, and how it gets calculated with user-controlled inputs,
           and stored in the EAX register. The 32-bit register will run out of storage space to
-          represent the large vlaue, which ends up being 0, but it still gets pushed as a
-          dwBytes argumenet (size) for a HeapAlloc call. The HeapAlloc function will allocate a
+          represent the large value, which ends up being 0, but it still gets pushed as a
+          dwBytes argument (size) for a HeapAlloc call. The HeapAlloc function will allocate a
           chunk anyway with size 0, and the address of this chunk is used as the destination buffer
           of a memcpy function, where the source buffer is the EXIF data (an extended image format
           supported by TIFF), and is also user-controlled. A function pointer in the chunk returned

--- a/modules/exploits/windows/fileformat/orbit_download_failed_bof.rb
+++ b/modules/exploits/windows/fileformat/orbit_download_failed_bof.rb
@@ -13,7 +13,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Name'           => 'Orbit Downloader URL Unicode Conversion Overflow',
       'Description'    => %q{
           This module exploits a stack-based buffer overflow in Orbit Downloader.
-        The vulnerability is due to Orbit converting an URL ascii string to unicode
+        The vulnerability is due to Orbit converting a URL ascii string to unicode
         in an insecure way with MultiByteToWideChar.
         The vulnerability is exploited with a specially crafted metalink file that
         should be opened with Orbit through the "File->Add Metalink..." option.

--- a/modules/exploits/windows/fileformat/orbit_download_failed_bof.rb
+++ b/modules/exploits/windows/fileformat/orbit_download_failed_bof.rb
@@ -14,7 +14,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Description'    => %q{
           This module exploits a stack-based buffer overflow in Orbit Downloader.
         The vulnerability is due to Orbit converting an URL ascii string to unicode
-        in a insecure way with MultiByteToWideChar.
+        in an insecure way with MultiByteToWideChar.
         The vulnerability is exploited with a specially crafted metalink file that
         should be opened with Orbit through the "File->Add Metalink..." option.
       },

--- a/modules/exploits/windows/fileformat/shaper_pdf_bof.rb
+++ b/modules/exploits/windows/fileformat/shaper_pdf_bof.rb
@@ -15,8 +15,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'Name'            => 'PDF Shaper Buffer Overflow',
       'Description'     => %q{
           PDF Shaper is prone to a security vulnerability when processing PDF files.
-        The vulnerability appear when we use Convert PDF to Image and use a specially
-        crafted PDF file. This module has been tested successfully on Win Xp, Win 7,
+        The vulnerability appears when we use Convert PDF to Image and use a specially
+        crafted PDF file. This module has been tested successfully on Win XP, Win 7,
         Win 8, Win 10.
       },
       'License'         => MSF_LICENSE,

--- a/modules/exploits/windows/fileformat/total_video_player_ini_bof.rb
+++ b/modules/exploits/windows/fileformat/total_video_player_ini_bof.rb
@@ -14,7 +14,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Name'    => 'Total Video Player 1.3.1 (Settings.ini) - SEH Buffer Overflow',
       'Description'  => %q{
         This module exploits a buffer overflow in Total Video Player 1.3.1. The vulnerability
-        occurs opening malformed Settings.ini file e.g."C:\Program Files\Total Video Player\".
+        occurs opening malformed Settings.ini file e.g. "C:\Program Files\Total Video Player\".
         This module has been tested successfully on Windows WinXp-Sp3-EN, Windows 7, and Windows 8.
       },
       'License'    => MSF_LICENSE,

--- a/modules/exploits/windows/fileformat/visiwave_vwr_type.rb
+++ b/modules/exploits/windows/fileformat/visiwave_vwr_type.rb
@@ -21,7 +21,7 @@ class MetasploitModule < Msf::Exploit::Remote
         execution.  A patch is available at visiwave.com; the fix is done by XORing the return value as
         null if no match is found, and then it is validated before use.
 
-        NOTE: During installation, the application will register two file handle's, VWS and VWR and allows a
+        NOTE: During installation, the application will register two file handles, VWS and VWR, which allows a
         victim user to 'double click' the malicious VWR file and execute code.  This module was also built
         to bypass ASLR and DEP.
       },

--- a/modules/exploits/windows/fileformat/vlc_smb_uri.rb
+++ b/modules/exploits/windows/fileformat/vlc_smb_uri.rb
@@ -13,7 +13,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Name'           => 'VideoLAN Client (VLC) Win32 smb:// URI Buffer Overflow',
       'Description'    => %q{
           This module exploits a stack-based buffer overflow in the Win32AddConnection
-        function of the VideoLAN VLC media player. Versions 0.9.9 throught 1.0.1 are
+        function of the VideoLAN VLC media player. Versions 0.9.9 through 1.0.1 are
         reportedly affected.
 
         This vulnerability is only present in Win32 builds of VLC.

--- a/modules/exploits/windows/fileformat/vuplayer_cue.rb
+++ b/modules/exploits/windows/fileformat/vuplayer_cue.rb
@@ -12,8 +12,8 @@ class MetasploitModule < Msf::Exploit::Remote
     super(update_info(info,
       'Name'           => 'VUPlayer CUE Buffer Overflow',
       'Description'    => %q{
-          This module exploits a stack over flow in VUPlayer <= 2.49. When
-        the application is used to open a specially crafted cue file, an buffer is overwritten allowing
+          This module exploits a stack based overflow in VUPlayer <= 2.49. When
+        the application is used to open a specially crafted cue file, a buffer is overwritten allowing
         for the execution of arbitrary code.
       },
       'License'        => MSF_LICENSE,

--- a/modules/exploits/windows/fileformat/winamp_maki_bof.rb
+++ b/modules/exploits/windows/fileformat/winamp_maki_bof.rb
@@ -15,7 +15,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Description'    => %q{
           This module exploits a stack based buffer overflow in Winamp 5.55. The flaw
         exists in the gen_ff.dll and occurs while parsing a specially crafted MAKI file,
-        where memmove is used with in a insecure way with user controlled data.
+        where memmove is used with in an insecure way with user controlled data.
 
         To exploit the vulnerability the attacker must convince the attacker to install the
         generated mcvcore.maki file in the "scripts" directory of the default "Bento" skin,

--- a/modules/exploits/windows/fileformat/winamp_maki_bof.rb
+++ b/modules/exploits/windows/fileformat/winamp_maki_bof.rb
@@ -15,9 +15,9 @@ class MetasploitModule < Msf::Exploit::Remote
       'Description'    => %q{
           This module exploits a stack based buffer overflow in Winamp 5.55. The flaw
         exists in the gen_ff.dll and occurs while parsing a specially crafted MAKI file,
-        where memmove is used with in an insecure way with user controlled data.
+        where memmove is used in an insecure way with user controlled data.
 
-        To exploit the vulnerability the attacker must convince the attacker to install the
+        To exploit the vulnerability the attacker must convince the victim to install the
         generated mcvcore.maki file in the "scripts" directory of the default "Bento" skin,
         or generate a new skin using the crafted mcvcore.maki file. The module has been
         tested successfully on Windows XP SP3 and Windows 7 SP1.

--- a/modules/exploits/windows/fileformat/wireshark_mpeg_overflow.rb
+++ b/modules/exploits/windows/fileformat/wireshark_mpeg_overflow.rb
@@ -14,7 +14,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Name'           => 'Wireshark wiretap/mpeg.c Stack Buffer Overflow',
       'Description'    => %q{
           This module triggers a stack buffer overflow in Wireshark <= 1.8.12/1.10.5
-          by generating an malicious file.)
+          by generating a malicious file.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>

--- a/modules/exploits/windows/fileformat/zinfaudioplayer221_pls.rb
+++ b/modules/exploits/windows/fileformat/zinfaudioplayer221_pls.rb
@@ -16,7 +16,7 @@ class MetasploitModule < Msf::Exploit::Remote
           This module exploits a stack-based buffer overflow in the Zinf Audio Player 2.2.1.
         An attacker must send the file to victim and the victim must open the file.
         Alternatively it may be possible to execute code remotely via an embedded
-        PLS file within a browser, when the PLS extention is registered to Zinf.
+        PLS file within a browser, when the PLS extension is registered to Zinf.
         This functionality has not been tested in this module.
       },
       'License'        => MSF_LICENSE,

--- a/modules/exploits/windows/ftp/comsnd_ftpd_fmtstr.rb
+++ b/modules/exploits/windows/ftp/comsnd_ftpd_fmtstr.rb
@@ -13,7 +13,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Name'          => 'ComSndFTP v1.3.7 Beta USER Format String (Write4) Vulnerability',
       'Description'   => %q{
           This module exploits the ComSndFTP FTP Server version 1.3.7 beta by sending a specially
-        crafted format string specifier as a username. The crafted username is sent to to the server to
+        crafted format string specifier as a username. The crafted username is sent to the server to
         overwrite the hardcoded function pointer from Ws2_32.dll!WSACleanup. Once this function pointer
         is triggered, the code bypasses dep and then repairs the pointer to execute arbitrary code.
         The SEH exit function is preferred so that the administrators are not left with an unhandled

--- a/modules/exploits/windows/ftp/freeftpd_pass.rb
+++ b/modules/exploits/windows/ftp/freeftpd_pass.rb
@@ -17,7 +17,7 @@ class MetasploitModule < Msf::Exploit::Remote
         PASS command. This may allow a remote attacker to cause a buffer overflow,
         resulting in a denial of service or allow the execution of arbitrary code.
 
-        FreeFTPd must have an account set to authorization anonymous user account.
+        freeFTPd must have an account set to authorization anonymous user account.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>

--- a/modules/exploits/windows/ftp/ftpshell51_pwd_reply.rb
+++ b/modules/exploits/windows/ftp/ftpshell51_pwd_reply.rb
@@ -14,7 +14,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Name'           => 'FTPShell 5.1 Stack Buffer Overflow',
       'Description'    => %q{
           This module exploits a stack buffer overflow in FTPShell 5.1. The overflow gets
-        triggered when the ftp clients tries to process an overly response to a PWD command.
+        triggered when the ftp client tries to process an overly response to a PWD command.
         This will overwrite the saved EIP and structured exception handler.
       },
       'Author' 	 =>

--- a/modules/exploits/windows/ftp/ftpshell51_pwd_reply.rb
+++ b/modules/exploits/windows/ftp/ftpshell51_pwd_reply.rb
@@ -14,8 +14,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'Name'           => 'FTPShell 5.1 Stack Buffer Overflow',
       'Description'    => %q{
           This module exploits a stack buffer overflow in FTPShell 5.1. The overflow gets
-        triggered when the ftp client tries to process an overly response to a PWD command.
-        This will overwrite the saved EIP and structured exception handler.
+        triggered when the ftp client tries to process an overly long response to a PWD
+        command. This will overwrite the saved EIP and structured exception handler.
       },
       'Author' 	 =>
         [

--- a/modules/exploits/windows/ftp/httpdx_tolog_format.rb
+++ b/modules/exploits/windows/ftp/httpdx_tolog_format.rb
@@ -15,7 +15,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Name'           => 'HTTPDX tolog() Function Format String Vulnerability',
       'Description'    => %q{
           This module exploits a format string vulnerability in HTTPDX FTP server.
-        By sending an specially crafted FTP command containing format specifiers, an
+        By sending a specially crafted FTP command containing format specifiers, an
         attacker can corrupt memory and execute arbitrary code.
 
         By default logging is off for HTTP, but enabled for the 'moderator' user

--- a/modules/exploits/windows/ftp/pcman_put.rb
+++ b/modules/exploits/windows/ftp/pcman_put.rb
@@ -14,7 +14,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Description'    => %q{
           This module exploits a buffer overflow vulnerability found in the PUT command of the
           PCMAN FTP v2.0.7 Server. This requires authentication but by default anonymous
-          credientials are enabled.
+          credentials are enabled.
       },
       'Author'         =>
           [

--- a/modules/exploits/windows/ftp/scriptftp_list.rb
+++ b/modules/exploits/windows/ftp/scriptftp_list.rb
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Exploit::Remote
         vulnerability that is triggered when processing a sufficiently long
         filename during a FTP LIST command resulting in overwriting the
         exception handler. Social engineering of executing a specially crafted
-        ftp file by double click will result in connecting to our malcious
+        ftp file by double click will result in connecting to our malicious
         server and perform arbitrary code execution which allows the attacker to
         gain the same rights as the user running ScriptFTP. This vulnerability
         affects versions 3.3 and earlier.

--- a/modules/exploits/windows/ftp/seagull_list_reply.rb
+++ b/modules/exploits/windows/ftp/seagull_list_reply.rb
@@ -14,7 +14,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Name'           => 'Seagull FTP v3.3 Build 409 Stack Buffer Overflow',
       'Description'    => %q{
           This module exploits a buffer overflow in the Seagull FTP client that gets
-        triggered when the ftp clients processes a response to a LIST command. If the
+        triggered when the ftp client processes a response to a LIST command. If the
         response contains an overly long file/folder name, a buffer overflow occurs,
         overwriting a structured exception handler.
       },

--- a/modules/exploits/windows/ftp/vermillion_ftpd_port.rb
+++ b/modules/exploits/windows/ftp/vermillion_ftpd_port.rb
@@ -13,7 +13,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Name'           => 'Vermillion FTP Daemon PORT Command Memory Corruption',
       'Description'    => %q{
           This module exploits an out-of-bounds array access in the Arcane Software
-        Vermillion FTP server. By sending an specially crafted FTP PORT command,
+        Vermillion FTP server. By sending a specially crafted FTP PORT command,
         an attacker can corrupt stack memory and execute arbitrary code.
 
         This particular issue is caused by processing data bound by attacker
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Exploit::Remote
         Processing is done using a source ptr (p) and a destination pointer (q).
         The vulnerable function walks the input string and continues while the
         source byte is non-null. If a comma is encountered, the function increments
-        the the destination pointer. If an ascii digit [0-9] is encountered, the
+        the destination pointer. If an ascii digit [0-9] is encountered, the
         following occurs:
 
           *q = (*q * 10) + (*p - '0');

--- a/modules/exploits/windows/ftp/xlink_client.rb
+++ b/modules/exploits/windows/ftp/xlink_client.rb
@@ -14,7 +14,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Description'    => %q{
           This module exploits a stack buffer overflow in Xlink FTP Client 32
         Version 3.01 that comes bundled with Omni-NFS Enterprise 5.2.
-        When a overly long FTP server response is recieved by a client,
+        When an overly long FTP server response is received by a client,
         arbitrary code may be executed.
       },
       'Author' 	 => [ 'MC' ],

--- a/modules/exploits/windows/http/bea_weblogic_jsessionid.rb
+++ b/modules/exploits/windows/http/bea_weblogic_jsessionid.rb
@@ -15,7 +15,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Description'    => %q{
           This module exploits a buffer overflow in BEA's WebLogic plugin. The vulnerable
         code is only accessible when clustering is configured. A request containing a
-        long JSESSION cookie value can lead to arbirtary code execution.
+        long JSESSION cookie value can lead to arbitrary code execution.
       },
       'Author'         => 'pusscat',
       'References'     =>

--- a/modules/exploits/windows/http/hp_autopass_license_traversal.rb
+++ b/modules/exploits/windows/http/hp_autopass_license_traversal.rb
@@ -15,7 +15,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Description' => %q{
         This module exploits a code execution flaw in HP AutoPass License Server. It abuses two
         weaknesses in order to get its objective. First, the AutoPass application doesn't enforce
-        authentication in the CommunicationServlet component. Seond, it's possible to abuse a
+        authentication in the CommunicationServlet component. Second, it's possible to abuse a
         directory traversal when uploading files thorough the same component, allowing to upload
         an arbitrary payload embedded in a JSP. The module has been tested successfully on
         HP AutoPass License Server 8.01 as installed with HP Service Virtualization 3.50.

--- a/modules/exploits/windows/http/hp_imc_mibfileupload.rb
+++ b/modules/exploits/windows/http/hp_imc_mibfileupload.rb
@@ -17,7 +17,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Description' => %q{
           This module exploits a code execution flaw in HP Intelligent Management Center.
         The vulnerability exists in the mibFileUpload which is accepting unauthenticated
-        file uploads and handling zip contents in a insecure way. Combining both weaknesses
+        file uploads and handling zip contents in an insecure way. Combining both weaknesses
         a remote attacker can accomplish arbitrary file upload. This module has been tested
         successfully on HP Intelligent Management Center 5.1 E0202 over Windows 2003 SP2.
       },

--- a/modules/exploits/windows/http/hp_nnm_ovalarm_lang.rb
+++ b/modules/exploits/windows/http/hp_nnm_ovalarm_lang.rb
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Exploit::Remote
         1. An "Accept-Language" header longer than 100 bytes
         2. An "OVABverbose" URI variable set to "on", "true" or "1"
 
-        The vulnerability is related to "_WebSession::GetWebLocale()" ..
+        The vulnerability is related to "_WebSession::GetWebLocale()".
 
         NOTE: This exploit has been tested successfully with a reverse_ord_tcp payload.
       },

--- a/modules/exploits/windows/http/hp_nnm_ovbuildpath_textfile.rb
+++ b/modules/exploits/windows/http/hp_nnm_ovbuildpath_textfile.rb
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Exploit::Remote
         address.
 
         The vulnerability is due to the use of the function "_OVConcatPath" which finally
-        uses "strcat" in a insecure way. User controlled data is concatenated to a string
+        uses "strcat" in an insecure way. User controlled data is concatenated to a string
         which contains the OpenView installation path.
 
         To achieve reliable exploitation a directory traversal in OpenView5.exe

--- a/modules/exploits/windows/http/hp_nnm_ovwebsnmpsrv_uro.rb
+++ b/modules/exploits/windows/http/hp_nnm_ovwebsnmpsrv_uro.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Exploit::Remote
         timestamp prior to April 7th, 2010.
 
         Reaching the vulnerable code requires a 'POST' request with an 'arg' parameter that, when combined
-        with a some static text, exceeds 10240 bytes. The parameter must begin with a dash. It is
+        with some static text, exceeds 10240 bytes. The parameter must begin with a dash. It is
         important to note that this vulnerability must be exploited by overwriting SEH. This is since
         overflowing the buffer with controllable data always triggers an access violation when
         attempting to write static text beyond the end of the stack.

--- a/modules/exploits/windows/http/hp_nnm_snmpviewer_actapp.rb
+++ b/modules/exploits/windows/http/hp_nnm_snmpviewer_actapp.rb
@@ -20,7 +20,7 @@ class MetasploitModule < Msf::Exploit::Remote
         CGI program, an attacker can cause a stack-based buffer overflow and execute arbitrary
         code.
 
-        The vulnerable code lies within the a function within "snmpviewer.exe" with a
+        The vulnerable code lies within a function within "snmpviewer.exe" with a
         timestamp prior to April 7th, 2010. This vulnerability is triggerable via either a GET
         or POST request. The request must contain 'act' and 'app' parameters which, when
         combined, total more than the 1024 byte stack buffer can hold.

--- a/modules/exploits/windows/http/hp_nnm_toolbar_02.rb
+++ b/modules/exploits/windows/http/hp_nnm_toolbar_02.rb
@@ -15,7 +15,7 @@ class MetasploitModule < Msf::Exploit::Remote
           This module exploits a stack buffer overflow in HP OpenView Network Node Manager 7.0
         and 7.53.  By sending a CGI request with a specially OvOSLocale cookie to Toolbar.exe, an
         attacker may be able to execute arbitrary code.  Please note that this module only works
-        against a specific build (ie. NNM 7.53_01195)
+        against a specific build (i.e. NNM 7.53_01195)
       },
       'License'        => MSF_LICENSE,
       'Author'         =>

--- a/modules/exploits/windows/http/hp_nnm_webappmon_execvp.rb
+++ b/modules/exploits/windows/http/hp_nnm_webappmon_execvp.rb
@@ -21,7 +21,7 @@ class MetasploitModule < Msf::Exploit::Remote
         cause a stack-based buffer overflow and execute arbitrary code.
 
         This vulnerability is not triggerable via a GET request due to limitations on the
-        request size. The buffer being targetted is 16384 bytes in size. There are actually two
+        request size. The buffer being targeted is 16384 bytes in size. There are actually two
         adjacent buffers that both get overflowed (one into the other), and strcat is used.
 
         The vulnerable code is within the "execvp_nc" function within "ov.dll" prior to

--- a/modules/exploits/windows/http/hp_nnm_webappmon_ovjavalocale.rb
+++ b/modules/exploits/windows/http/hp_nnm_webappmon_ovjavalocale.rb
@@ -15,7 +15,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Name'        => "HP NNM CGI webappmon.exe OvJavaLocale Buffer Overflow",
       'Description' => %q{
           This module exploits a stack buffer overflow in HP OpenView Network Node Manager 7.53.
-        By sending a request continaing a cookie longer than 5120 bytes, an attacker can overflow
+        By sending a request containing a cookie longer than 5120 bytes, an attacker can overflow
         a stack buffer and execute arbitrary code.
 
         The vulnerable code is within the OvWwwDebug function. The static-sized stack buffer is
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Exploit::Remote
         like the following:
 
           #0 ...
-          #1 sprintf_new(local_stack_buf, fmt, cooke);
+          #1 sprintf_new(local_stack_buf, fmt, cookie);
           #2 OvWwwDebug("   HTTP_COOKIE=%s\n", cookie);
           #3 ?OvWwwInit@@YAXAAHQAPADPBD@Z(x, x, x);
           #4 sub_405ee0("nnm", "webappmon");
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Exploit::Remote
         is easily achieved by overwriting the saved return address or SEH frame.
 
         The original advisory detailed an attack vector using the "OvJavaLocale" cookie being
-        passed in a request ot "webappmon.exe". Further research shows that several different
+        passed in a request to "webappmon.exe". Further research shows that several different
         cookie values, as well as several different CGI applications, can be used.
       '},
       'License'	  => MSF_LICENSE,

--- a/modules/exploits/windows/http/hp_openview_insight_backdoor.rb
+++ b/modules/exploits/windows/http/hp_openview_insight_backdoor.rb
@@ -16,8 +16,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'Description'    => %q{
           This module exploits a hidden account in the com.trinagy.security.XMLUserManager Java
         class. When using this account, an attacker can abuse the
-        com.trinagy.servlet.HelpManagerServlet class and write arbitary files to the system
-        allowing the execution of arbitary code.
+        com.trinagy.servlet.HelpManagerServlet class and write arbitrary files to the system
+        allowing the execution of arbitrary code.
 
         NOTE: This module has only been tested against HP OpenView Performance Insight Server 5.41.0
       },

--- a/modules/exploits/windows/http/hp_power_manager_filename.rb
+++ b/modules/exploits/windows/http/hp_power_manager_filename.rb
@@ -16,7 +16,7 @@ class MetasploitModule < Msf::Exploit::Remote
           This module exploits a buffer overflow in HP Power Manager's 'formExportDataLogs'.
         By creating a malformed request specifically for the fileName parameter, a stack-based
         buffer overflow occurs due to a long error message (which contains the fileName),
-        which may result aribitrary remote code execution under the context of 'SYSTEM'.
+        which may result in arbitrary remote code execution under the context of 'SYSTEM'.
       },
       'License'         => MSF_LICENSE,
       'Author'          =>

--- a/modules/exploits/windows/http/httpdx_tolog_format.rb
+++ b/modules/exploits/windows/http/httpdx_tolog_format.rb
@@ -15,7 +15,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Name'           => 'HTTPDX tolog() Function Format String Vulnerability',
       'Description'    => %q{
           This module exploits a format string vulnerability in HTTPDX HTTP server.
-        By sending an specially crafted HTTP request containing format specifiers, an
+        By sending a specially crafted HTTP request containing format specifiers, an
         attacker can corrupt memory and execute arbitrary code.
 
         By default logging is off for HTTP, but enabled for the 'moderator' user

--- a/modules/exploits/windows/http/ibm_tivoli_endpoint_bof.rb
+++ b/modules/exploits/windows/http/ibm_tivoli_endpoint_bof.rb
@@ -19,7 +19,7 @@ class MetasploitModule < Msf::Exploit::Remote
         This issue can be triggered by sending a specially crafted HTTP POST request to
       the service (lcfd.exe) listening on TCP port 9495. To trigger this issue authorization
       is required. This exploit makes use of a second vulnerability, a hardcoded account
-      (Tivoli/boss) is used to bypass the authorization restriction.
+      (tivoli/boss) is used to bypass the authorization restriction.
       },
       'Author'         =>
         [

--- a/modules/exploits/windows/http/ibm_tivoli_endpoint_bof.rb
+++ b/modules/exploits/windows/http/ibm_tivoli_endpoint_bof.rb
@@ -19,7 +19,7 @@ class MetasploitModule < Msf::Exploit::Remote
         This issue can be triggered by sending a specially crafted HTTP POST request to
       the service (lcfd.exe) listening on TCP port 9495. To trigger this issue authorization
       is required. This exploit makes use of a second vulnerability, a hardcoded account
-      (tivoli/boss) is used to bypass the authorization restriction.
+      (Tivoli/boss) is used to bypass the authorization restriction.
       },
       'Author'         =>
         [

--- a/modules/exploits/windows/http/integard_password_bof.rb
+++ b/modules/exploits/windows/http/integard_password_bof.rb
@@ -17,7 +17,7 @@ class MetasploitModule < Msf::Exploit::Remote
           vulnerable.
 
           The administration web page on port 18881 is vulnerable to a remote buffer overflow
-          attack. By sending an long character string in the password field, both the structured
+          attack. By sending a long character string in the password field, both the structured
           exception handler and the saved extended instruction pointer are over written, allowing
           an attacker to gain control of the application and the underlying operating system
           remotely.

--- a/modules/exploits/windows/http/mailenable_auth_header.rb
+++ b/modules/exploits/windows/http/mailenable_auth_header.rb
@@ -16,7 +16,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Description'    => %q{
           This module exploits a remote buffer overflow in the MailEnable web service.
         The vulnerability is triggered when a large value is placed into the Authorization
-        header of the web request. MailEnable Enterprise Edition versions priot to 1.0.5 and
+        header of the web request. MailEnable Enterprise Edition versions prior to 1.0.5 and
         MailEnable Professional versions prior to 1.55 are affected.
       },
       'Author'         => 'David Maciejak <david.maciejak[at]kyxar.fr>',

--- a/modules/exploits/windows/http/manage_engine_opmanager_rce.rb
+++ b/modules/exploits/windows/http/manage_engine_opmanager_rce.rb
@@ -16,7 +16,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Description'    => %q{
         This module exploits a default credential vulnerability in ManageEngine OpManager, where a
         default hidden account "IntegrationUser" with administrator privileges exists. The account
-        has a default password of "plugin" which can not be reset through the user interface. By
+        has a default password of "plugin" which cannot be reset through the user interface. By
         log-in and abusing the default administrator's SQL query functionality, it's possible to
         write a WAR payload to disk and trigger an automatic deployment of this payload. This
         module has been tested successfully on OpManager v11.0 and v11.4-v11.6 for Windows.

--- a/modules/exploits/windows/http/manageengine_apps_mngr.rb
+++ b/modules/exploits/windows/http/manageengine_apps_mngr.rb
@@ -13,7 +13,7 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       'Name'           => 'ManageEngine Applications Manager Authenticated Code Execution',
       'Description'    => %q{
-            This module logs into the Manage Engine Appplications Manager to upload a
+            This module logs into the Manage Engine Applications Manager to upload a
           payload to the file system and a batch script that executes the payload. },
       'Author'         => 'Jacob Giannantonio <JGiannan[at]gmail.com>',
       'Platform'       => 'win',

--- a/modules/exploits/windows/http/octopusdeploy_deploy.rb
+++ b/modules/exploits/windows/http/octopusdeploy_deploy.rb
@@ -17,7 +17,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Name'        => 'Octopus Deploy Authenticated Code Execution',
       'Description' => %q{
           This module can be used to execute a payload on an Octopus Deploy server given
-          valid credentials or an API key. The payload is execued as a powershell script step
+          valid credentials or an API key. The payload is executed as a powershell script step
           on the Octopus Deploy server during a deployment.
       },
       'License'     => MSF_LICENSE,

--- a/modules/exploits/windows/http/oracle_btm_writetofile.rb
+++ b/modules/exploits/windows/http/oracle_btm_writetofile.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Exploit::Remote
         root. If a new Domain has been used to deploy the Oracle application, the Windows
         Management Instrumentation service can be used to execute arbitrary code.
 
-        Both techniques has been successfully tested on default installs of Oracle BTM
+        Both techniques have been successfully tested on default installs of Oracle BTM
         12.1.0.7, Weblogic 12.1.1 and Windows 2003 SP2. Default path traversal depths are
         provided, but the user can configure the traversal depth using the DEPTH option.
       },

--- a/modules/exploits/windows/http/osb_uname_jlist.rb
+++ b/modules/exploits/windows/http/osb_uname_jlist.rb
@@ -15,7 +15,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Name'           => 'Oracle Secure Backup Authentication Bypass/Command Injection Vulnerability',
       'Description'    => %q{
           This module exploits an authentication bypass vulnerability
-        in login.php. In conjuction with the authentication bypass issue,
+        in login.php. In conjunction with the authentication bypass issue,
         the 'jlist' parameter in property_box.php can be used to execute
         arbitrary system commands.
         This module was tested against Oracle Secure Backup version 10.3.0.1.0

--- a/modules/exploits/windows/http/savant_31_overflow.rb
+++ b/modules/exploits/windows/http/savant_31_overflow.rb
@@ -16,7 +16,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Description' => %q{
           This module exploits a stack buffer overflow in Savant 3.1 Web Server. The service
         supports a maximum of 10 threads (for a default install). Each exploit attempt
-        generally causes a thread to die whether sucessful or not. Therefore, in a default
+        generally causes a thread to die whether successful or not. Therefore, in a default
         configuration, you only have 10 chances.
 
         Due to the limited space available for the payload in this exploit module, use of the

--- a/modules/exploits/windows/http/umbraco_upload_aspx.rb
+++ b/modules/exploits/windows/http/umbraco_upload_aspx.rb
@@ -15,7 +15,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Description'   => %q{
           This module can be used to execute a payload on Umbraco CMS 4.7.0.378.
         The payload is uploaded as an ASPX script by sending a specially crafted
-        SOAP request to codeEditorSave.asmx, which permits unauthorised file upload
+        SOAP request to codeEditorSave.asmx, which permits unauthorized file upload
         via the SaveDLRScript operation. SaveDLRScript is also subject to a path
         traversal vulnerability, allowing code to be placed into the web-accessible
         /umbraco/ directory.

--- a/modules/exploits/windows/iis/ms02_018_htr.rb
+++ b/modules/exploits/windows/iis/ms02_018_htr.rb
@@ -14,7 +14,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Description'    => %q{
           This exploits a buffer overflow in the ISAPI ISM.DLL used to
         process HTR scripting in IIS 4.0. This module works against
-        Windows NT 4 Service Packs  3, 4, and 5. The server will
+        Windows NT 4 Service Packs 3, 4, and 5. The server will
         continue to process requests until the payload being
         executed has exited. If you've set EXITFUNC to 'seh', the
         server will continue processing requests, but you will have

--- a/modules/exploits/windows/imap/imail_delete.rb
+++ b/modules/exploits/windows/imap/imail_delete.rb
@@ -13,7 +13,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Name'           => 'IMail IMAP4D Delete Overflow',
       'Description'    => %q{
           This module exploits a buffer overflow in the 'DELETE'
-        command of the the IMail IMAP4D service. This vulnerability
+        command of the IMail IMAP4D service. This vulnerability
         can only be exploited with a valid username and password.
         This flaw was patched in version 8.14.
       },

--- a/modules/exploits/windows/imap/novell_netmail_status.rb
+++ b/modules/exploits/windows/imap/novell_netmail_status.rb
@@ -12,7 +12,7 @@ class MetasploitModule < Msf::Exploit::Remote
     super(update_info(info,
       'Name'           => 'Novell NetMail IMAP STATUS Buffer Overflow',
       'Description'    => %q{
-          This module exploits a stack buffer overflow in Novell's Netmail 3.52 IMAP STATUS
+          This module exploits a stack buffer overflow in Novell's NetMail 3.52 IMAP STATUS
         verb. By sending an overly long string, an attacker can overwrite the
         buffer and control program execution.
       },

--- a/modules/exploits/windows/license/calicclnt_getconfig.rb
+++ b/modules/exploits/windows/license/calicclnt_getconfig.rb
@@ -12,7 +12,7 @@ class MetasploitModule < Msf::Exploit::Remote
     super(update_info(info,
       'Name'		=> 'Computer Associates License Client GETCONFIG Overflow',
       'Description'	=> %q{
-          This module exploits an vulnerability in the CA License Client
+          This module exploits a vulnerability in the CA License Client
         service. This exploit will only work if your IP address can be
         resolved from the target system point of view. This can be
         accomplished on a local network by running the 'nmbd' service

--- a/modules/exploits/windows/local/applocker_bypass.rb
+++ b/modules/exploits/windows/local/applocker_bypass.rb
@@ -13,7 +13,7 @@ class MetasploitModule < Msf::Exploit::Local
     super(update_info(info,
       'Name'          => 'AppLocker Execution Prevention Bypass',
       'Description'   => %q{
-        This module will generate a .NET service executable on the target and utilise
+        This module will generate a .NET service executable on the target and utilize
         InstallUtil to run the payload bypassing the AppLocker protection.
 
         Currently only the InstallUtil method is provided, but future methods can be

--- a/modules/exploits/windows/local/bypassuac_injection.rb
+++ b/modules/exploits/windows/local/bypassuac_injection.rb
@@ -22,11 +22,11 @@ class MetasploitModule < Msf::Exploit::Local
         This module will bypass Windows UAC by utilizing the trusted publisher
         certificate through process injection. It will spawn a second shell that
         has the UAC flag turned off. This module uses the Reflective DLL Injection
-        technique to drop only the DLL payload binary instead of three seperate
+        technique to drop only the DLL payload binary instead of three separate
         binaries in the standard technique. However, it requires the correct
         architecture to be selected, (use x64 for SYSWOW64 systems also).
         If specifying EXE::Custom your DLL should call ExitProcess() after starting
-        your payload in a seperate process.
+        your payload in a separate process.
       },
       'License'       => MSF_LICENSE,
       'Author'        => [

--- a/modules/exploits/windows/local/ms10_015_kitrap0d.rb
+++ b/modules/exploits/windows/local/ms10_015_kitrap0d.rb
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Exploit::Local
       'Name'          => 'Windows SYSTEM Escalation via KiTrap0D',
       'Description'   => %q{
         This module will create a new session with SYSTEM privileges via the
-        KiTrap0D exlpoit by Tavis Ormandy. If the session is use is already
+        KiTrap0D exploit by Tavis Ormandy. If the session is use is already
         elevated then the exploit will not run. The module relies on kitrap0d.x86.dll,
         and is not supported on x64 editions of Windows.
       },

--- a/modules/exploits/windows/local/ms10_015_kitrap0d.rb
+++ b/modules/exploits/windows/local/ms10_015_kitrap0d.rb
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Exploit::Local
       'Name'          => 'Windows SYSTEM Escalation via KiTrap0D',
       'Description'   => %q{
         This module will create a new session with SYSTEM privileges via the
-        KiTrap0D exploit by Tavis Ormandy. If the session is use is already
+        KiTrap0D exploit by Tavis Ormandy. If the session in use is already
         elevated then the exploit will not run. The module relies on kitrap0d.x86.dll,
         and is not supported on x64 editions of Windows.
       },

--- a/modules/exploits/windows/local/ms11_080_afdjoinleaf.rb
+++ b/modules/exploits/windows/local/ms11_080_afdjoinleaf.rb
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Exploit::Local
         with a call to NtQueryIntervalProfile will execute shellcode.
 
         This module will elevate itself to SYSTEM, then inject the payload
-        into another SYSTEM process before restoring it's own token to
+        into another SYSTEM process before restoring its own token to
         avoid causing system instability.
       ),
       'License'       => MSF_LICENSE,

--- a/modules/exploits/windows/local/ms15_078_atmfd_bof.rb
+++ b/modules/exploits/windows/local/ms15_078_atmfd_bof.rb
@@ -35,8 +35,8 @@ class MetasploitModule < Msf::Exploit::Local
       'Name'            => 'MS15-078 Microsoft Windows Font Driver Buffer Overflow',
       'Description'     => %q{
         This module exploits a pool based buffer overflow in the atmfd.dll driver when parsing
-        a malformed font. The vulnerability was exploited by the hacking team and disclosed on
-        the july data leak. This module has been tested successfully on vulnerable builds of
+        a malformed font. The vulnerability was exploited by the hacking team and disclosed in
+        the July data leak. This module has been tested successfully on vulnerable builds of
         Windows 8.1 x64.
       },
       'License'         => MSF_LICENSE,

--- a/modules/exploits/windows/local/ms16_016_webdav.rb
+++ b/modules/exploits/windows/local/ms16_016_webdav.rb
@@ -19,7 +19,7 @@ class MetasploitModule < Msf::Exploit::Local
       'Name'           => 'MS16-016 mrxdav.sys WebDav Local Privilege Escalation',
       'Description'    => %q{
         This module exploits the vulnerability in mrxdav.sys described by MS16-016.  The module will spawn
-        a process on the target system and elevate it's privileges to NT AUTHORITY\SYSTEM before executing
+        a process on the target system and elevate its privileges to NT AUTHORITY\SYSTEM before executing
         the specified payload within the context of the elevated process.
       },
       'License'        => MSF_LICENSE,

--- a/modules/exploits/windows/local/panda_psevents.rb
+++ b/modules/exploits/windows/local/panda_psevents.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Exploit::Local
         Vulnerable Products:
         Panda Global Protection 2016 (<=16.1.2)
         Panda Antivirus Pro 2016 (<=16.1.2)
-        Panda Small Busines Protetion (<=16.1.2)
+        Panda Small Business Protection (<=16.1.2)
         Panda Internet Security 2016 (<=16.1.2)
       },
       'License'       => MSF_LICENSE,

--- a/modules/exploits/windows/local/run_as.rb
+++ b/modules/exploits/windows/local/run_as.rb
@@ -14,7 +14,7 @@ class MetasploitModule < Msf::Exploit::Local
       'Description'          => %q{
         This module will login with the specified username/password and execute the
         supplied command as a hidden process. Output is not returned by default.
-        Unless targetting a local user either set the DOMAIN, or specify a UPN user
+        Unless targeting a local user either set the DOMAIN, or specify a UPN user
         format (e.g. user@domain). This uses the CreateProcessWithLogonW WinAPI function.
 
         A custom command line can be sent instead of uploading an executable.

--- a/modules/exploits/windows/local/virtual_box_opengl_escape.rb
+++ b/modules/exploits/windows/local/virtual_box_opengl_escape.rb
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Exploit::Local
         vulnerability exists in the remote rendering of OpenGL-based 3D graphics. By sending a
         sequence of specially crafted rendering messages, a virtual machine can exploit an out
         of bounds array access to corrupt memory and escape to the host. This module has been
-        tested successfully on Windows 7 SP1 (64 bits) as Host running  Virtual Box 4.3.6.
+        tested successfully on Windows 7 SP1 (64 bits) as Host running Virtual Box 4.3.6.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>

--- a/modules/exploits/windows/local/wmi_persistence.rb
+++ b/modules/exploits/windows/local/wmi_persistence.rb
@@ -27,8 +27,8 @@ class MetasploitModule < Msf::Exploit::Local
           The INTERVAL method will create an event filter that triggers the payload after the specified CALLBACK_INTERVAL. The LOGON
           method will create an event filter that will trigger the payload after the system has an uptime of 4 minutes. The PROCESS
           method will create an event filter that triggers the payload when the specified process is started. The WAITFOR method
-          creates an event filter that utilises the Microsoft binary waitfor.exe to wait for a signal specified by WAITFOR_TRIGGER
-          before executing the payload. The signal can be sent from a windows host on a LAN utilising the waitfor.exe command
+          creates an event filter that utilizes the Microsoft binary waitfor.exe to wait for a signal specified by WAITFOR_TRIGGER
+          before executing the payload. The signal can be sent from a windows host on a LAN utilizing the waitfor.exe command
           (note: requires target to have port 445 open). Additionally a custom command can be specified to run once the trigger is
           activated using the advanced option CUSTOM_PS_COMMAND. This module requires administrator level privileges as well as a
           high integrity process. It is also recommended not to use stageless payloads due to powershell script length limitations.

--- a/modules/exploits/windows/lpd/wincomlpd_admin.rb
+++ b/modules/exploits/windows/lpd/wincomlpd_admin.rb
@@ -14,7 +14,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Description'    => %q{
           This module exploits a stack buffer overflow in WinComLPD <= 3.0.2.
         By sending an overly long authentication packet to the remote
-        adminstration service, an attacker may be able to execute arbitrary
+        administration service, an attacker may be able to execute arbitrary
         code.
       },
       'Author'         => 'MC',

--- a/modules/exploits/windows/misc/allmediaserver_bof.rb
+++ b/modules/exploits/windows/misc/allmediaserver_bof.rb
@@ -17,7 +17,7 @@ class MetasploitModule < Msf::Exploit::Remote
         is caused due to a boundary error within the handling of HTTP request.
 
         While the exploit supports DEP bypass via ROP, on Windows 7 the stack pivoting isn't
-        reliable across virtual (VMWare, VirtualBox) and physical  environments. Because of
+        reliable across virtual (VMWare, VirtualBox) and physical environments. Because of
         this the module isn't using DEP bypass on the Windows 7 SP1 target, where by default
         DEP is OptIn and AllMediaServer won't run with DEP.
       },

--- a/modules/exploits/windows/misc/bigant_server_dupf_upload.rb
+++ b/modules/exploits/windows/misc/bigant_server_dupf_upload.rb
@@ -20,7 +20,7 @@ class MetasploitModule < Msf::Exploit::Remote
         command. Additionally the filename option in the same command can be used to launch
         a directory traversal attack and achieve arbitrary file upload.
 
-        The module uses uses the Windows Management Instrumentation service to execute an
+        The module uses the Windows Management Instrumentation service to execute an
         arbitrary payload on vulnerable installations of BigAnt on Windows XP and 2003. It
         has been successfully tested on BigAnt Server 2.97 SP7 over Windows XP SP3 and 2003
         SP2.

--- a/modules/exploits/windows/misc/fb_cnct_group.rb
+++ b/modules/exploits/windows/misc/fb_cnct_group.rb
@@ -21,7 +21,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
         This module uses an existing call to memcpy, just prior to the vulnerable code,
         which allows a small amount of data to be written to the stack. A two-phases
-        stackpivot allows to execute the ROP chain which ultimately is used to execute
+        stack pivot allows to execute the ROP chain which ultimately is used to execute
         VirtualAlloc and bypass DEP.
       },
       'Author'      => 'Spencer McIntyre',

--- a/modules/exploits/windows/misc/hp_dataprotector_cmd_exec.rb
+++ b/modules/exploits/windows/misc/hp_dataprotector_cmd_exec.rb
@@ -15,8 +15,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'Name'           => 'HP Data Protector 8.10 Remote Command Execution',
       'Description'    => %q{
         This module exploits a remote command execution on HP Data Protector 8.10. Arbitrary
-        commands can be execute by sending crafted requests with opcode 28 to the OmniInet
-        service listening on the TCP/5555 port. Since there is an strict length limitation on
+        commands can be executed by sending crafted requests with opcode 28 to the OmniInet
+        service listening on the TCP/5555 port. Since there is a strict length limitation on
         the command, rundll32.exe is executed, and the payload is provided through a DLL by a
         fake SMB server. This module has been tested successfully on HP Data Protector 8.1 on
         Windows 7 SP1.

--- a/modules/exploits/windows/misc/hp_dataprotector_install_service.rb
+++ b/modules/exploits/windows/misc/hp_dataprotector_install_service.rb
@@ -14,7 +14,7 @@ class MetasploitModule < Msf::Exploit::Remote
     super(update_info(info,
       'Name'           => 'HP Data Protector 6.10/6.11/6.20 Install Service',
       'Description'    => %q{
-        This module exploits HP Data Protector Omniinet process on Windows only.
+        This module exploits HP Data Protector OmniInet process on Windows only.
         This exploit invokes the install service function which allows an attacker to create a
         custom payload in the format of an executable.
 

--- a/modules/exploits/windows/misc/hp_omniinet_3.rb
+++ b/modules/exploits/windows/misc/hp_omniinet_3.rb
@@ -13,7 +13,7 @@ class MetasploitModule < Msf::Exploit::Remote
     super(update_info(info,
       'Name'           => 'HP OmniInet.exe Opcode 27 Buffer Overflow',
       'Description'    => %q{
-          This module exploits a  buffer overflow in the Hewlett-Packard
+          This module exploits a buffer overflow in the Hewlett-Packard
         OmniInet NT Service. By sending a specially crafted opcode 27 packet,
         a remote attacker may be able to execute arbitrary code.
       },

--- a/modules/exploits/windows/misc/mini_stream.rb
+++ b/modules/exploits/windows/misc/mini_stream.rb
@@ -13,7 +13,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Name' => 'Mini-Stream 3.0.1.1 Buffer Overflow',
       'Description' => %q{
           This module exploits a stack buffer overflow in Mini-Stream 3.0.1.1
-        By creating a specially crafted pls file, an an attacker may be able
+        By creating a specially crafted pls file, an attacker may be able
         to execute arbitrary code.
       },
       'License' => MSF_LICENSE,

--- a/modules/exploits/windows/misc/splayer_content_type.rb
+++ b/modules/exploits/windows/misc/splayer_content_type.rb
@@ -12,7 +12,7 @@ class MetasploitModule < Msf::Exploit::Remote
     super(update_info(info,
       'Name'           => "SPlayer 3.7 Content-Type Buffer Overflow",
       'Description'    => %q{
-          This module exploits a vulnerability in SPlayer v3.7 or piror.  When SPlayer
+          This module exploits a vulnerability in SPlayer v3.7 or prior.  When SPlayer
         requests the URL of a media file (video or audio), it is possible to gain arbitrary
         remote code execution due to a buffer overflow caused by an exceeding length of data
         as the 'Content-Type' parameter.

--- a/modules/exploits/windows/misc/stream_down_bof.rb
+++ b/modules/exploits/windows/misc/stream_down_bof.rb
@@ -13,7 +13,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Name'           => 'CoCSoft StreamDown 6.8.0 Buffer Overflow',
       'Description'    => %q{
         Stream Down 6.8.0 seh based buffer overflow triggered when processing
-        the server reponse packet.During the overflow a structured exception
+        the server response packet. During the overflow a structured exception
         handler is overwritten.
       },
       'Author'         => 'Fady Mohamed Osman <fady.mohamed.osman[at]gmail.com>',

--- a/modules/exploits/windows/misc/windows_rsh.rb
+++ b/modules/exploits/windows/misc/windows_rsh.rb
@@ -12,7 +12,7 @@ class MetasploitModule < Msf::Exploit::Remote
     super(update_info(info,
       'Name'           => 'Windows RSH Daemon Buffer Overflow',
       'Description'    => %q{
-          This module exploits a vulnerabliltiy in Windows RSH daemon 1.8.
+          This module exploits a vulnerability in Windows RSH daemon 1.8.
         The vulnerability is due to a failure to check for the length of input sent
         to the RSH server. A CPORT of 512 -> 1023 must be configured for the exploit
         to be successful.

--- a/modules/exploits/windows/misc/wireshark_lua.rb
+++ b/modules/exploits/windows/misc/wireshark_lua.rb
@@ -13,7 +13,7 @@ class MetasploitModule < Msf::Exploit::Remote
     super(update_info(info,
       'Name'           => "Wireshark console.lua Pre-Loading Script Execution",
       'Description'    => %q{
-          This modules exploits a vulnerability in Wireshark 1.6 or less. When opening a
+          This module exploits a vulnerability in Wireshark 1.6 or less. When opening a
         pcap file, Wireshark will actually check if there's a 'console.lua' file in the same
         directory, and then parse/execute the script if found.  Versions affected by this
         vulnerability: 1.6.0 to 1.6.1, 1.4.0 to 1.4.8

--- a/modules/exploits/windows/misc/wireshark_packet_dect.rb
+++ b/modules/exploits/windows/misc/wireshark_packet_dect.rb
@@ -13,7 +13,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Name'           => 'Wireshark packet-dect.c Stack Buffer Overflow',
       'Description'    => %q{
           This module exploits a stack buffer overflow in Wireshark <= 1.4.4
-        by sending an malicious packet.
+        by sending a malicious packet.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>

--- a/modules/exploits/windows/motorola/timbuktu_fileupload.rb
+++ b/modules/exploits/windows/motorola/timbuktu_fileupload.rb
@@ -13,7 +13,7 @@ class MetasploitModule < Msf::Exploit::Remote
     super(update_info(info,
       'Name'           => 'Timbuktu Pro Directory Traversal/File Upload',
       'Description'    => %q{
-        This module exploits a directory traversal vulnerablity in Motorola's
+        This module exploits a directory traversal vulnerability in Motorola's
         Timbuktu Pro for Windows 8.6.5.
       },
       'Author'         => [ 'MC' ],

--- a/modules/exploits/windows/mssql/ms09_004_sp_replwritetovarbin.rb
+++ b/modules/exploits/windows/mssql/ms09_004_sp_replwritetovarbin.rb
@@ -27,7 +27,7 @@ class MetasploitModule < Msf::Exploit::Remote
         This exploit smashes several pointers, as shown below.
 
         1. pointer to a 32-bit value that is set to 0
-        2. pointer to a 32-bit value that is set to a length influcenced by the buffer
+        2. pointer to a 32-bit value that is set to a length influenced by the buffer
           length.
         3. pointer to a 32-bit value that is used as a vtable pointer. In MSSQL 2000,
           this value is referenced with a displacement of 0x38. For MSSQL 2005, the

--- a/modules/exploits/windows/mssql/ms09_004_sp_replwritetovarbin_sqli.rb
+++ b/modules/exploits/windows/mssql/ms09_004_sp_replwritetovarbin_sqli.rb
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Exploit::Remote
         This exploit smashes several pointers, as shown below.
 
         1. pointer to a 32-bit value that is set to 0
-        2. pointer to a 32-bit value that is set to a length influcenced by the buffer
+        2. pointer to a 32-bit value that is set to a length influenced by the buffer
           length.
         3. pointer to a 32-bit value that is used as a vtable pointer. In MSSQL 2000,
           this value is referenced with a displacement of 0x38. For MSSQL 2005, the

--- a/modules/exploits/windows/mssql/mssql_linkcrawler.rb
+++ b/modules/exploits/windows/mssql/mssql_linkcrawler.rb
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Exploit::Remote
         up a exploit/multi/handler to run in the background as a job to support multiple incoming
         shells.
 
-          If you are interested in deploying payloads to spefic servers this module also
+          If you are interested in deploying payloads to specific servers this module also
         supports that functionality via the "DEPLOYLIST" option.
 
           Currently, the module is capable of delivering payloads to both 32bit and 64bit

--- a/modules/exploits/windows/mssql/mssql_payload.rb
+++ b/modules/exploits/windows/mssql/mssql_payload.rb
@@ -20,7 +20,7 @@ class MetasploitModule < Msf::Exploit::Remote
         the "xp_cmdshell" stored procedure. Currently, three delivery methods are supported.
 
         First, the original method uses Windows 'debug.com'. File size restrictions are
-        avoidied by incorporating the debug bypass method presented by SecureStat at
+        avoided by incorporating the debug bypass method presented by SecureStat at
         Defcon 17. Since this method invokes ntvdm, it is not available on x64 systems.
 
         A second method takes advantage of the Command Stager subsystem. This allows using

--- a/modules/exploits/windows/mssql/mssql_payload_sqli.rb
+++ b/modules/exploits/windows/mssql/mssql_payload_sqli.rb
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Exploit::Remote
         Currently, three delivery methods are supported.
 
         First, the original method uses Windows 'debug.com'. File size restrictions are
-        avoidied by incorporating the debug bypass method presented by SecureStat at
+        avoided by incorporating the debug bypass method presented by SecureStat at
         Defcon 17. Since this method invokes ntvdm, it is not available on x64 systems.
 
         A second method takes advantage of the Command Stager subsystem. This allows using

--- a/modules/exploits/windows/oracle/tns_arguments.rb
+++ b/modules/exploits/windows/oracle/tns_arguments.rb
@@ -13,7 +13,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Name'           => 'Oracle 8i TNS Listener (ARGUMENTS) Buffer Overflow',
       'Description'    => %q{
           This module exploits a stack buffer overflow in Oracle 8i. When
-        sending a specially crafted packet containing a overly long
+        sending a specially crafted packet containing an overly long
         ARGUMENTS string to the TNS service, an attacker may be able
         to execute arbitrary code.
       },

--- a/modules/exploits/windows/scada/daq_factory_bof.rb
+++ b/modules/exploits/windows/scada/daq_factory_bof.rb
@@ -14,7 +14,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Name'           => 'DaqFactory HMI NETB Request Overflow',
       'Description'    => %q{
           This module exploits a stack buffer overflow in Azeotech's DaqFactory
-        product. The specfic vulnerability is triggered when sending a specially crafted
+        product. The specific vulnerability is triggered when sending a specially crafted
         'NETB' request to port 20034. Exploitation of this vulnerability may take a few
         seconds due to the use of egghunter.  This vulnerability was one of the 14
         releases discovered by researcher Luigi Auriemma.

--- a/modules/exploits/windows/scada/ge_proficy_cimplicity_gefebt.rb
+++ b/modules/exploits/windows/scada/ge_proficy_cimplicity_gefebt.rb
@@ -17,7 +17,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Description'   => %q{
         This module abuses the gefebt.exe component in GE Proficy CIMPLICITY, reachable through the
         CIMPLICIY CimWebServer. The vulnerable component allows to execute remote BCL files in
-        shared resources. An attacker can abuse this behaviour to execute a malicious BCL and
+        shared resources. An attacker can abuse this behavior to execute a malicious BCL and
         drop an arbitrary EXE. The last one can be executed remotely through the WebView server.
         This module has been tested successfully in GE Proficy CIMPLICITY 7.5 with the embedded
         CimWebServer. This module starts a WebDAV server to provide the malicious BCL files. If

--- a/modules/exploits/windows/scada/indusoft_webstudio_exec.rb
+++ b/modules/exploits/windows/scada/indusoft_webstudio_exec.rb
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Exploit::Remote
         Web Studio Remote Agent, that allows a remote attacker to write arbitrary files to
         the filesystem, by abusing the functions provided by the software.
 
-        The module uses uses the Windows Management Instrumentation service to execute an
+        The module uses the Windows Management Instrumentation service to execute an
         arbitrary payload on vulnerable installations of InduSoft Web Studio on Windows pre
         Vista. It has been successfully tested on InduSoft Web Studio 6.1 SP6 over Windows
         XP SP3 and Windows 2003 SP2.

--- a/modules/exploits/windows/scada/realwin_on_fc_binfile_a.rb
+++ b/modules/exploits/windows/scada/realwin_on_fc_binfile_a.rb
@@ -17,7 +17,7 @@ class MetasploitModule < Msf::Exploit::Remote
         SCADA Server 2.1 and below. By supplying a specially crafted On_FC_BINFILE_FCS_*FILE
         packet via port 910, RealWin will try to create a file (which would be saved to
         C:\Program Files\DATAC\Real Win\RW-version\filename) by first copying the user-
-        supplied filename with a inline memcpy routine without proper bounds checking, which
+        supplied filename with an inline memcpy routine without proper bounds checking, which
         results a stack-based buffer overflow, allowing arbitrary remote code execution.
 
         Tested version: 2.0 (Build 6.1.8.10)

--- a/modules/exploits/windows/scada/scadapro_cmdexe.rb
+++ b/modules/exploits/windows/scada/scadapro_cmdexe.rb
@@ -14,7 +14,7 @@ class MetasploitModule < Msf::Exploit::Remote
     super(update_info(info,
       'Name'           => 'Measuresoft ScadaPro Remote Command Execution',
       'Description'    => %q{
-        This module allows remote attackers to execute arbitray commands on the
+        This module allows remote attackers to execute arbitrary commands on the
         affected system by abusing via Directory Traversal attack when using the
         'xf' command (execute function). An attacker can execute system() from
         msvcrt.dll to upload a backdoor and gain remote code execution. This


### PR DESCRIPTION
Large spelling/grammar fixes in module descriptions.

This is ready to land (dont wait for another commit with the last 80 pages) in celebration of @wvu-r7 and my UNITED 2017 talk.  I swear at dinner one night @wchen-r7 said he wanted a ticket to 'get back into the framework'.  Here's your softball!

## Verification
- [x] Check i didn't screw things up worserer

This is grouped with #8888 and #8940 