### PR TITLE
msftidy - fix missing newline

### DIFF
--- a/modules/nops/aarch64/simple.rb
+++ b/modules/nops/aarch64/simple.rb
@@ -41,3 +41,4 @@ class MetasploitModule < Msf::Nop
     return ([nops[0]].pack("V*") * (length/4))
   end
 end
+


### PR DESCRIPTION
Running msftify against the module folder yields the following info:
```
modules/nops/aarch64/simple.rb - [INFO] Please add a newline at the end of the file
```

This PR fixes the missing newline.