### PR TITLE
rework msftidy exit codes

### DIFF
--- a/tools/dev/msftidy.rb
+++ b/tools/dev/msftidy.rb
@@ -43,9 +43,10 @@ end
 class Msftidy
 
   # Status codes
-  OK       = 0x00
-  WARNINGS = 0x10
-  ERRORS   = 0x20
+  OK       = 0
+  INFO     = 1
+  WARNING  = 2
+  ERROR    = 3
 
   # Some compiles regexes
   REGEX_MSF_EXPLOIT = / \< Msf::Exploit/
@@ -73,7 +74,7 @@ class Msftidy
   # error.
   def warn(txt, line=0) line_msg = (line>0) ? ":#{line}" : ''
     puts "#{@full_filepath}#{line_msg} - [#{'WARNING'.yellow}] #{cleanup_text(txt)}"
-    @status == ERRORS ? @status = ERRORS : @status = WARNINGS
+    @status += WARNING
   end
 
   #
@@ -85,7 +86,7 @@ class Msftidy
   def error(txt, line=0)
     line_msg = (line>0) ? ":#{line}" : ''
     puts "#{@full_filepath}#{line_msg} - [#{'ERROR'.red}] #{cleanup_text(txt)}"
-    @status = ERRORS
+    @status += ERROR
   end
 
   # Currently unused, but some day msftidy will fix errors for you.
@@ -101,6 +102,7 @@ class Msftidy
     return if SUPPRESS_INFO_MESSAGES
     line_msg = (line>0) ? ":#{line}" : ''
     puts "#{@full_filepath}#{line_msg} - [#{'INFO'.cyan}] #{cleanup_text(txt)}"
+    @status += INFO
   end
 
   ##


### PR DESCRIPTION
Found in https://github.com/rapid7/metasploit-framework/pull/8967

msftidy does not set a exit code on INFO messages. Currently there are no errors so it's safe to add an exit code to info messages. This makes a commit with a pre-commit fail when an info is found and travis should also fail.

Here is an example of travis not failing on an INFO element: https://travis-ci.org/rapid7/metasploit-framework/jobs/270364296#L554

With the new change travis will fail.

This PR also reworks the exit status codes to add all values together. So more errors/warnings/infos result in a higher exit status.