### PR TITLE
Rename METERPRETER_TRANSPORT_SSL to ..._TCP

### DIFF
--- a/lib/rex/post/meterpreter/client_core.rb
+++ b/lib/rex/post/meterpreter/client_core.rb
@@ -37,7 +37,7 @@ class ClientCore < Extension
   UNIX_PATH_MAX = 108
   DEFAULT_SOCK_PATH = "/tmp/meterpreter.sock"
 
-  METERPRETER_TRANSPORT_SSL   = 0
+  METERPRETER_TRANSPORT_TCP   = 0
   METERPRETER_TRANSPORT_HTTP  = 1
   METERPRETER_TRANSPORT_HTTPS = 2
 
@@ -47,10 +47,10 @@ class ClientCore < Extension
   TIMEOUT_RETRY_WAIT = 10      # 10 seconds
 
   VALID_TRANSPORTS = {
-    'reverse_tcp'   => METERPRETER_TRANSPORT_SSL,
+    'reverse_tcp'   => METERPRETER_TRANSPORT_TCP,
     'reverse_http'  => METERPRETER_TRANSPORT_HTTP,
     'reverse_https' => METERPRETER_TRANSPORT_HTTPS,
-    'bind_tcp'      => METERPRETER_TRANSPORT_SSL
+    'bind_tcp'      => METERPRETER_TRANSPORT_TCP
   }
 
   include Rex::Payloads::Meterpreter::UriChecksum


### PR DESCRIPTION
Since OpenSSL is no longer packages with meterpreter, and transport
secrecy is handled at L7, the SSL cons name doesn't apply anymore.
Rename METERPRETER_TRANSPORT_SSL to METERPRETER_TRANSPORT_TCP for
consistency with wire-level implementation.

-----
@OJ: this used to be used as a string in some places ages ago, which IIRC was inspected upon during the dark ages, but i'm pretty sure we're just down to the const name in Ruby now. Could you check this and give your blessing before we merge something which could break stuff through metaprogramming indirection?