### PR TITLE
bump metasploit-payloads to 1.3.8

### DIFF
--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -70,7 +70,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '1.3.7'
+  spec.add_runtime_dependency 'metasploit-payloads', '1.3.8'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '0.2.2'
   # Needed by msfgui and other rpc components


### PR DESCRIPTION
Required to pick up https://github.com/rapid7/metasploit-payloads/pull/235

## Verification

- [x] Make sure 1.3.8 exists at https://rubygems.org/gems/metasploit-payloads/versions I guess