### PR TITLE
Fix opening non-existant files on unix

### DIFF
--- a/lib/msf/core/post/unix.rb
+++ b/lib/msf/core/post/unix.rb
@@ -40,14 +40,17 @@ module Msf::Post::Unix
   #
   def get_groups
     groups = []
-    cmd_out = read_file("/etc/group").split("\n")
-    cmd_out.each do |l|
-      entry = {}
-      user_field = l.split(":")
-      entry[:name] = user_field[0]
-      entry[:gid] = user_field[2]
-      entry[:users] = user_field[3]
-      groups << entry
+    group = '/etc/group'
+    if file_exist?(group)
+      cmd_out = read_file(group).split("\n")
+      cmd_out.each do |l|
+        entry = {}
+        user_field = l.split(":")
+        entry[:name] = user_field[0]
+        entry[:gid] = user_field[2]
+        entry[:users] = user_field[3]
+        groups << entry
+      end
     end
     return groups
   end
@@ -59,8 +62,11 @@ module Msf::Post::Unix
     user_dirs = []
 
     # get all user directories from /etc/passwd
-    read_file("/etc/passwd").each_line do |passwd_line|
-      user_dirs << passwd_line.split(/:/)[5]
+    passwd = '/etc/passwd'
+    if file_exist?(passwd)
+      read_file(passwd).each_line do |passwd_line|
+        user_dirs << passwd_line.split(/:/)[5]
+      end
     end
 
     # also list other common places for home directories in the event that


### PR DESCRIPTION
Fixes #8556 where if you run `post/multi/gather/ssh_creds` on a box w/o a passwd file (cisco, juniper, etc) the module throws an error.  Just added a check that the file exists before opening it.

I'm going to guess this will fix lots of other issues as well.  Yes, you shouldn't run something that obviously won't work... however, when you have 50 shells mixed between linux and infrastructure, its easy to say 'run against all' in PRO and then see crashes all over the place.  Plus, error handling is what the cool kids do.

## Verification

- [x] Start `msfconsole`
- [x] get a shell on a device w/o `/etc/passwd`
- [x] run `post/multi/gather/ssh_creds`
- [x] **Verify** it doesn't crash
- [x] Get a shell on a box w/ `/etc/passwd`
- [x] **Verify** everything still works