### PR TITLE
post/windows/manage/persistence_exe: fix service creation

### DIFF
--- a/modules/post/windows/manage/persistence_exe.rb
+++ b/modules/post/windows/manage/persistence_exe.rb
@@ -140,7 +140,7 @@ class MetasploitModule < Msf::Post
       print_status("Installing as service..")
       nam = Rex::Text.rand_text_alpha(rand(8) + 8)
       print_status("Creating service #{nam}")
-      service_create(nam, nam, "cmd /c \"#{script_on_target}\"")
+      service_create(nam, :path=>"cmd /c \"#{script_on_target}\"")
       @clean_up_rc << "execute -H -f sc -a \"delete #{nam}\"\n"
     else
       print_error("Insufficient privileges to create service")


### PR DESCRIPTION
Running `post/windows/manage/persistence_exe` with `STARTUP=SERVICE` results in the following error message:

```
[*] Installing as service..
[*] Creating service npEiRmiIkrG
[-] Post failed: RuntimeError Unable to open service manager: FormatMessage failed to retrieve the error.
[-] Call stack:
[-]   /usr/share/metasploit-framework/lib/msf/core/post/windows/services.rb:81:in `open_sc_manager'
[-]   /usr/share/metasploit-framework/lib/msf/core/post/windows/services.rb:335:in `service_create'
[-]   /usr/share/metasploit-framework/modules/post/windows/manage/persistence_exe.rb:143:in `install_as_service'
[-]   /usr/share/metasploit-framework/modules/post/windows/manage/persistence_exe.rb:68:in `run'
```

This PR fixes this behavior by adjusting how the `service_create` is called. ref: https://github.com/rapid7/metasploit-framework/blob/master/lib/msf/core/post/windows/services.rb#L333

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use post/windows/manage/persistence_exe`
- [x] `set STARTUP SERVICE`
- [x] `run`
- [x] Verify the module runs as expected, resulting in successful service creation.

