### PR TITLE
Add "lls" command to Meterpreter 

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
@@ -57,7 +57,10 @@ class Console::CommandDispatcher::Stdapi::Fs
   # Options for the ls command
   #
   @@lls_opts = Rex::Parser::Arguments.new(
-    "-h" => [ false, "Help banner." ])
+    "-h" => [ false, "Help banner." ],
+    "-t" => [ false, "Sort by time" ],
+    "-s" => [ false, "Sort by size" ],
+    "-r" => [ false, "Reverse sort order" ])
 
   #
   # List of supported commands.
@@ -686,12 +689,12 @@ class Console::CommandDispatcher::Stdapi::Fs
   #
   # Get list local path information for lls command
   #
-  def list_local_path(path)
+  def list_local_path(path, sort, order)
     columns = [ 'Mode', 'Size', 'Type', 'Last modified', 'Name' ]
     tbl = Rex::Text::Table.new(
       'Header'  => "Listing Local: #{path}",
-      'SortIndex' => columns.index("Name"),
-      'SortOrder' => :forward,
+      'SortIndex' => columns.index(sort),
+      'SortOrder' => order,
       'Columns' => columns)
 
     items = 0
@@ -740,10 +743,20 @@ class Console::CommandDispatcher::Stdapi::Fs
   #
   def cmd_lls(*args)
     path = ::Dir.pwd
+    sort = 'Name'
+    order = :forward
 
     # Parse the args
     @@lls_opts.parse(args) { |opt, idx, val|
       case opt
+      # Sort options
+      when '-s'
+        sort = 'Size'
+      when '-t'
+        sort = 'Last modified'
+      # Output options
+      when '-r'
+        order = :reverse
       # Help and path
       when "-h"
         cmd_lls_help
@@ -753,7 +766,7 @@ class Console::CommandDispatcher::Stdapi::Fs
       end
     }
 
-    list_local_path(path)
+    list_local_path(path, sort, order)
   end
 
   #

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
@@ -691,13 +691,16 @@ class Console::CommandDispatcher::Stdapi::Fs
   # Get list local path information for lls command
   #
   def list_local_path(path, sort, order, search_term = nil)
+    # Single file as path
     if !::File.directory?(path)
       perms = pretty_perms(path)
       stat = ::File.stat(path)
       print_line("#{perms}  #{stat.size}  #{stat.ftype[0,3]}  #{stat.mtime}  #{path}")
       return
     end
- 
+
+    # Enumerate each item...
+    # No need to sort as Table will do it for us
     columns = [ 'Mode', 'Size', 'Type', 'Last modified', 'Name' ]
     tbl = Rex::Text::Table.new(
       'Header'  => "Listing Local: #{path}",


### PR DESCRIPTION
# Overview
This PR adds the `lls` command to Meterpreter to list local directories and files. The lack of the `lls` command is something that has been bugging me for quite a while especially since `lcd` and `lpwd` were included. It shall bug me no longer!

The implementation of `lls` uses the same table structure as `ls` does in Meterpreter, and most of the same option switches were included as well. I did not include short vs long filename or recursive options since they did not seem necessary for local file system listings.

I did not include `.` and `..` directories since they were not included in the listing with Meterpreter's `ls` command. It is an easy change if these should be included.

## Verification

- [x] Start `msfconsole`
- [x] Get a meterpreter session going on something
- [x] Test `lls`. It should list files and directories in the local working directory.
- [x] Change local working directory and test again.
- [x] Test `lls` with a specific directory such as `lls /etc`. It should list that directory
- [x] Test `lls` with a specific file such as `lls /etc/hosts` It should list that file.
- [x] Test `lls` with the different sort options `-r`,  `-s`, and `-t`. They should work accordingly.
- [x] Test `lls` with a search string using the `-S` switch. It should only list files/directories with that string.

## Output Examples
### Previous Functionality
```
meterpreter > lls
[-] Unknown command: lls.
```

### New Functionality
```
meterpreter > lls
Listing Local: /
================

Mode              Size      Type  Last modified              Name
----              ----      ----  -------------              ----
40700/rwx------   4096      dir   2017-08-10 23:18:34 -0500  .cache
100644/rw-r--r--  0         fil   2017-04-15 20:46:05 -0500  0
40755/rwxr-xr-x   4096      dir   2017-09-20 00:12:23 -0500  bin
40755/rwxr-xr-x   4096      dir   2017-09-20 00:15:34 -0500  boot
40755/rwxr-xr-x   3240      dir   2017-09-23 15:39:53 -0500  dev
40755/rwxr-xr-x   12288     dir   2017-09-23 15:40:05 -0500  etc
40755/rwxr-xr-x   4096      dir   2017-08-31 18:41:22 -0500  home
100644/rw-r--r--  27780416  fil   2017-09-20 00:14:47 -0500  initrd.img
100644/rw-r--r--  27373850  fil   2017-09-09 18:51:35 -0500  initrd.img.old
40755/rwxr-xr-x   4096      dir   2017-09-08 19:44:47 -0500  lib
40755/rwxr-xr-x   4096      dir   2017-09-08 19:44:46 -0500  lib64
40700/rwx------   16384     dir   2017-08-10 23:14:05 -0500  lost+found
...
```

```
meterpreter > lls /home
Listing Local: /home
====================

Mode             Size  Type  Last modified              Name
----             ----  ----  -------------              ----
40755/rwxr-xr-x  4096  dir   2017-09-23 15:40:41 -0500  sn0wfa11
```

```
meterpreter > lls /etc/hosts
100644/rw-r--r--  452  fil  2017-08-31 18:14:01 -0500  /etc/hosts
```

```
meterpreter > lls -h
Usage: lls [options]

Lists contents of a local directory or file info

OPTIONS:

    -S <opt>  Search string.
    -h        Help banner.
    -r        Reverse sort order
    -s        Sort by size
    -t        Sort by time
```

```
meterpreter > lls -S hosts /etc
Listing Local: /etc
===================

Mode              Size  Type  Last modified              Name
----              ----  ----  -------------              ----
40755/rwxr-xr-x   4096  dir   2017-08-10 23:14:10 -0500  ghostscript
100644/rw-r--r--  452   fil   2017-08-31 18:14:01 -0500  hosts
100644/rw-r--r--  411   fil   2017-04-15 20:49:26 -0500  hosts.allow
100644/rw-r--r--  711   fil   2017-04-15 20:49:26 -0500  hosts.deny
```