### PR TITLE
make 'generate' command parameters match 'msfvenom', add inline datastore assignment parsing

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/auxiliary.rb
+++ b/lib/msf/ui/console/command_dispatcher/auxiliary.rb
@@ -74,7 +74,7 @@ class Auxiliary
   # Executes an auxiliary module
   #
   def cmd_run(*args)
-    opt_str = nil
+    opts    = []
     action  = mod.datastore['ACTION']
     jobify  = false
     quiet   = false
@@ -84,7 +84,7 @@ class Auxiliary
       when '-j'
         jobify = true
       when '-o'
-        opt_str = val
+        opts.push(val)
       when '-a'
         action = val
       when '-q'
@@ -93,9 +93,8 @@ class Auxiliary
         cmd_run_help
         return false
       else
-        (key, val) = val.split('=')
-        if key && val
-          mod.datastore[key] = val
+        if val[0] != '-' && val.match?('=')
+          opts.push(val)
         else
           cmd_run_help
           return false
@@ -112,7 +111,7 @@ class Auxiliary
     begin
       mod.run_simple(
         'Action'         => action,
-        'OptionStr'      => opt_str,
+        'OptionStr'      => opts.join(','),
         'LocalInput'     => driver.input,
         'LocalOutput'    => driver.output,
         'RunAsJob'       => jobify,

--- a/lib/msf/ui/console/command_dispatcher/auxiliary.rb
+++ b/lib/msf/ui/console/command_dispatcher/auxiliary.rb
@@ -79,21 +79,29 @@ class Auxiliary
     jobify  = false
     quiet   = false
 
-    @@auxiliary_opts.parse(args) { |opt, idx, val|
+    @@auxiliary_opts.parse(args) do |opt, idx, val|
       case opt
-        when '-j'
-          jobify = true
-        when '-o'
-          opt_str = val
-        when '-a'
-          action = val
-        when '-q'
-          quiet  = true
-        when '-h'
+      when '-j'
+        jobify = true
+      when '-o'
+        opt_str = val
+      when '-a'
+        action = val
+      when '-q'
+        quiet  = true
+      when '-h'
+        cmd_run_help
+        return false
+      else
+        (key, val) = val.split('=')
+        if key && val
+          mod.datastore[key] = val
+        else
           cmd_run_help
           return false
+        end
       end
-    }
+    end
 
     # Always run passive modules in the background
     if mod.is_a?(Msf::Module::HasActions) &&

--- a/lib/msf/ui/console/command_dispatcher/exploit.rb
+++ b/lib/msf/ui/console/command_dispatcher/exploit.rb
@@ -121,6 +121,7 @@ class Exploit
   #
   def cmd_exploit(*args)
     force = false
+    module_opts = []
     opts = {
       'Encoder'     => mod.datastore['ENCODER'],
       'Payload'     => mod.datastore['PAYLOAD'],
@@ -138,31 +139,42 @@ class Exploit
       opts['RunAsJob'] = true
     end
 
-    @@exploit_opts.parse(args) { |opt, idx, val|
+    @@exploit_opts.parse(args) do |opt, idx, val|
       case opt
-        when '-e'
-          opts['Encoder'] = val
-        when '-f'
-          force = true
-        when '-j'
-          opts['RunAsJob'] = true
-        when '-J'
-          opts['RunAsJob'] = false
-        when '-n'
-          opts['Nop'] = val
-        when '-o'
-          opts['OpttionStr'] = val
-        when '-p'
-          opts['Payload'] = val
-        when '-t'
-          opts['Target'] = val.to_i
-        when '-z'
-          opts['Background'] = true
-        when '-h'
+      when '-e'
+        opts['Encoder'] = val
+      when '-f'
+        force = true
+      when '-j'
+        opts['RunAsJob'] = true
+      when '-J'
+        opts['RunAsJob'] = false
+      when '-n'
+        opts['Nop'] = val
+      when '-o'
+        module_opts.push(val)
+      when '-p'
+        opts['Payload'] = val
+      when '-t'
+        opts['Target'] = val.to_i
+      when '-z'
+        opts['Background'] = true
+      when '-h'
+        cmd_exploit_help
+        return false
+      else
+        if val[0] != '-' && val.match?('=')
+          module_opts.push(val)
+        else
           cmd_exploit_help
           return false
+        end
       end
-    }
+    end
+
+    unless module_opts.empty?
+      opts['OptionStr'] = module_opts.join(',')
+    end
 
     minrank = RankingName.invert[framework.datastore['MinimumRank']] || 0
     if minrank > mod.rank

--- a/lib/msf/ui/console/command_dispatcher/payload.rb
+++ b/lib/msf/ui/console/command_dispatcher/payload.rb
@@ -117,6 +117,11 @@ module Msf
                   @@generate_opts.usage
                 )
                 return true
+              else
+                (key, val) = val.split('=')
+                if key && val
+                  mod.datastore[key] = val
+                end
               end
             end
             if encoder_name.nil? && mod.datastore['ENCODER']

--- a/lib/msf/ui/console/command_dispatcher/payload.rb
+++ b/lib/msf/ui/console/command_dispatcher/payload.rb
@@ -20,7 +20,7 @@ module Msf
           @@generate_opts = Rex::Parser::Arguments.new(
             "-p" => [ true,  "The platform of the payload" ],
             "-n" => [ true,  "Prepend a nopsled of [length] size on to the payload" ],
-            "-f" => [ true,  "Output format: #{supported_formats.join(',')}" ],
+            "-f" => [ true,  "Output format: #{@@supported_formats.join(',')}" ],
             "-E" => [ false, "Force encoding" ],
             "-e" => [ true,  "The encoder to use" ],
             "-s" => [ true,  "NOP sled length."                                     ],
@@ -67,6 +67,13 @@ module Msf
             "Payload"
           end
 
+          def cmd_generate_help
+            print_line "Usage: generate [options]"
+            print_line
+            print_line "Generates a payload."
+            print @@generate_opts.usage
+          end
+
           #
           # Generates a payload.
           #
@@ -111,16 +118,15 @@ module Msf
               when '-x'
                 template = val
               when '-h'
-                print(
-                  "Usage: generate [options]\n\n" \
-                  "Generates a payload.\n" +
-                  @@generate_opts.usage
-                )
-                return true
+                cmd_generate_help
+                return false
               else
                 (key, val) = val.split('=')
                 if key && val
                   mod.datastore[key] = val
+                else
+                  cmd_generate_help
+                  return false
                 end
               end
             end

--- a/lib/msf/ui/console/command_dispatcher/payload.rb
+++ b/lib/msf/ui/console/command_dispatcher/payload.rb
@@ -18,18 +18,18 @@ module Msf
             Msf::Util::EXE.to_executable_fmt_formats
 
           @@generate_opts = Rex::Parser::Arguments.new(
-            "-b" => [ true,  "The list of characters to avoid: '\\x00\\xff'"        ],
-            "-E" => [ false, "Force encoding."                                      ],
-            "-e" => [ true,  "The name of the encoder module to use."               ],
-            "-h" => [ false, "Help banner."                                         ],
-            "-o" => [ true,  "A comma separated list of options in VAR=VAL format." ],
+            "-p" => [ true,  "The platform of the payload" ],
+            "-n" => [ true,  "Prepend a nopsled of [length] size on to the payload" ],
+            "-f" => [ true,  "Output format: #{supported_formats.join(',')}" ],
+            "-E" => [ false, "Force encoding" ],
+            "-e" => [ true,  "The encoder to use" ],
             "-s" => [ true,  "NOP sled length."                                     ],
-            "-f" => [ true,  "The output file name (otherwise stdout)"              ],
-            "-t" => [ true,  "The output format: #{@@supported_formats.join(',')}"    ],
-            "-p" => [ true,  "The Platform for output."                             ],
-            "-k" => [ false, "Keep the template executable functional"              ],
-            "-x" => [ true,  "The executable template to use"                       ],
-            "-i" => [ true,  "the number of encoding iterations."                   ]
+            "-b" => [ true,  "The list of characters to avoid example: '\\x00\\xff'" ],
+            "-i" => [ true,  "The number of times to encode the payload" ],
+            "-x" => [ true,  "Specify a custom executable file to use as a template" ],
+            "-k" => [ false, "Preserve the template behavior and inject the payload as a new thread" ],
+            "-o" => [ true,  "The output file name (otherwise stdout)" ],
+            "-h" => [ false, "Show this message" ],
           )
 
           #
@@ -76,7 +76,7 @@ module Msf
             sled_size    = nil
             option_str   = nil
             badchars     = nil
-            type         = "ruby"
+            format       = "ruby"
             ofile        = nil
             iter         = 1
             force        = nil
@@ -92,13 +92,15 @@ module Msf
                 encoder_name = val
               when '-E'
                 force = true
-              when '-o'
-                option_str = val
-              when '-s'
+              when '-n'
                 sled_size = val.to_i
-              when '-t'
-                type = val
               when '-f'
+                format = val
+              when '-o'
+                if val.include?('=')
+                  print("The -o parameter of 'generate' is now the output file. Specify options with the 'set' command")
+                  return true
+                end
                 ofile = val
               when '-i'
                 iter = val
@@ -126,7 +128,7 @@ module Msf
               buf = mod.generate_simple(
                 'BadChars'    => badchars,
                 'Encoder'     => encoder_name,
-                'Format'      => type,
+                'Format'      => format,
                 'NopSledSize' => sled_size,
                 'OptionStr'   => option_str,
                 'ForceEncode' => force,

--- a/lib/msf/ui/console/command_dispatcher/payload.rb
+++ b/lib/msf/ui/console/command_dispatcher/payload.rb
@@ -29,6 +29,7 @@ module Msf
             "-x" => [ true,  "Specify a custom executable file to use as a template" ],
             "-k" => [ false, "Preserve the template behavior and inject the payload as a new thread" ],
             "-o" => [ true,  "The output file name (otherwise stdout)" ],
+            "-O" => [ true,  "Deprecated: alias for the '-o' option" ],
             "-h" => [ false, "Show this message" ],
           )
 
@@ -105,9 +106,13 @@ module Msf
                 format = val
               when '-o'
                 if val.include?('=')
-                  print("The -o parameter of 'generate' is now the output file. Specify options with the 'set' command")
-                  return true
+                  print("The -o parameter of 'generate' is now preferred to indicate the output file, like with msfvenom")
+                  mod.datastore[key] = val
+                else
+                  ofile = val
                 end
+              when '-O'
+                print("Usage of the '-O' parameter is deprecated, prefer '-o' to indicate the output file")
                 ofile = val
               when '-i'
                 iter = val

--- a/lib/msf/ui/console/command_dispatcher/post.rb
+++ b/lib/msf/ui/console/command_dispatcher/post.rb
@@ -74,6 +74,13 @@ class Post
 
   alias cmd_rexploit cmd_rerun
 
+  def cmd_run_help
+    print_line "Usage: run [options]"
+    print_line
+    print_line "Launches a post exploitation module."
+    print @@auxiliary_opts.usage
+  end
+
   #
   # Executes a post module
   #
@@ -82,24 +89,29 @@ class Post
     jobify  = false
     quiet   = false
 
-    @@post_opts.parse(args) { |opt, idx, val|
+    @@post_opts.parse(args) do |opt, idx, val|
       case opt
-        when '-j'
-          jobify = true
-        when '-o'
-          opt_str = val
-        when '-a'
-          action = val
-        when '-q'
-          quiet  = true
-        when '-h'
-          print(
-            "Usage: run [options]\n\n" +
-            "Launches a post module.\n" +
-            @@post_opts.usage)
+      when '-j'
+        jobify = true
+      when '-o'
+        opt_str = val
+      when '-a'
+        action = val
+      when '-q'
+        quiet  = true
+      when '-h'
+        cmd_run_help
+        return false
+      else
+        (key, val) = val.split('=')
+        if key && val
+          mod.datastore[key] = val
+        else
+          cmd_run_help
           return false
+        end
       end
-    }
+    end
 
     # Always run passive modules in the background
     if (mod.passive)


### PR DESCRIPTION
This makes it so you can run:

`msf> generate -f raw -o test.py -p python/meterpreter/reverse_tcp LHOST=192.168.56.1`

and the parameters you specify here will also work directly with msfvenom as well.

Since adding inline datastore parsing really wasn't too hard, I also added it to the `exploit` / `run` commands, so you can also do:

```
msf exploit(handler) > run PAYLOAD=windows/meterpreter/reverse_tcp LHOST=127.0.0.1
[*] Exploit running as background job 1.
msf exploit(handler) > 
[!] You are binding to a loopback address by setting LHOST to 127.0.0.1. Did you want ReverseListenerBindAddress?
[*] Started reverse TCP handler on 127.0.0.1:4444
```

No need for explicit 'set' commands at all, and the assignments are not permanent. This is rather nice for efficiency/scripting, etc.

## Verification Steps

 - [ ] Run an aux module with inline datastore options
 - [ ] Run an exploit module "" ""
 - [ ] Run a post module "" "" 
 - [ ] Generate a payload using 'msfvenom' and 'generate' and verify that expected options work