### PR TITLE
usability improvements with how base options are registered

### DIFF
--- a/lib/msf/core/opt.rb
+++ b/lib/msf/core/opt.rb
@@ -1,7 +1,6 @@
 # -*- coding: binary -*-
 
 module Msf
-
   #
   # Builtin framework options with shortcut methods
   #
@@ -59,17 +58,6 @@ module Msf
       )
     end
 
-    # These are unused but remain for historical reasons
-    class << self
-      alias builtin_chost CHOST
-      alias builtin_cport CPORT
-      alias builtin_lhost LHOST
-      alias builtin_lport LPORT
-      alias builtin_proxies Proxies
-      alias builtin_rhost RHOST
-      alias builtin_rport RPORT
-    end
-
     CHOST = CHOST()
     CPORT = CPORT()
     LHOST = LHOST()
@@ -79,5 +67,4 @@ module Msf
     RPORT = RPORT()
     SSLVersion = SSLVersion()
   end
-
 end

--- a/lib/msf/core/opt.rb
+++ b/lib/msf/core/opt.rb
@@ -50,11 +50,18 @@ module Msf
       Msf::OptPort.new(__method__.to_s, [ required, desc, default ])
     end
 
+    def self.ssl_supported_options
+      @m ||= ['Auto', 'TLS'] + OpenSSL::SSL::SSLContext::METHODS \
+             .select{|m| !m.to_s.include?('client') && !m.to_s.include?('server')} \
+             .select{|m| OpenSSL::SSL::SSLContext.new(m) && true rescue false} \
+             .map{|m| m.to_s.sub(/v/, '').sub('_', '.')}
+    end
+
     # @return [OptEnum]
     def self.SSLVersion
       Msf::OptEnum.new('SSLVersion',
         'Specify the version of SSL/TLS to be used (Auto, TLS and SSL23 are auto-negotiate)',
-        enums: ['Auto', 'SSL2', 'SSL3', 'SSL23', 'TLS', 'TLS1', 'TLS1.1', 'TLS1.2']
+        enums: self.ssl_supported_options
       )
     end
 

--- a/lib/msf/core/opt.rb
+++ b/lib/msf/core/opt.rb
@@ -53,9 +53,10 @@ module Msf
 
     # @return [OptEnum]
     def self.SSLVersion
-      Msf::OptEnum.new('SSLVersion', [ false,
-        'Specify the version of SSL/TLS to be used (Auto, TLS and SSL23 are auto-negotiate)', 'Auto',
-        ['Auto', 'SSL2', 'SSL3', 'SSL23', 'TLS', 'TLS1', 'TLS1.1', 'TLS1.2']])
+      Msf::OptEnum.new('SSLVersion',
+        'Specify the version of SSL/TLS to be used (Auto, TLS and SSL23 are auto-negotiate)',
+        enums: ['Auto', 'SSL2', 'SSL3', 'SSL23', 'TLS', 'TLS1', 'TLS1.1', 'TLS1.2']
+      )
     end
 
     # These are unused but remain for historical reasons

--- a/lib/msf/core/opt_base.rb
+++ b/lib/msf/core/opt_base.rb
@@ -36,14 +36,14 @@ module Msf
         self.required = required
         self.desc     = attrs.is_a?(String) ? attrs : desc
         self.enums    = [ *(enums) ].map { |x| x.to_s }
-        if default.nil? && enums.length > 0
-          self.default  = enums[0]
-        else
-          self.default = default
-        end
+        self.default  = default
         regex_temp    = regex
       else
-        self.required = attrs[0] || required
+        if attrs[0].nil?
+          self.required = required
+        else
+          self.required = attrs[0]
+        end
         self.desc     = attrs[1] || desc
         self.default  = attrs[2] || default
         self.enums    = attrs[3] || enums

--- a/lib/msf/core/opt_base.rb
+++ b/lib/msf/core/opt_base.rb
@@ -22,15 +22,31 @@ module Msf
     # attrs[3] = possible enum values
     # attrs[4] = Regex to validate the option
     #
-    def initialize(in_name, attrs = [], aliases: [])
+    # Attrs can also be specified explicitly via named parameters, or attrs can
+    # also be a string as standin for the required description field.
+    #
+    def initialize(in_name, attrs = [],
+                   required: false, desc: nil, default: nil, enums: [], regex: nil, aliases: [])
       self.name     = in_name
       self.advanced = false
       self.evasion  = false
-      self.required = attrs[0] || false
-      self.desc     = attrs[1]
-      self.default  = attrs[2]
-      self.enums    = [ *(attrs[3]) ].map { |x| x.to_s }
-      regex_temp    = attrs[4] || nil
+      self.aliases  = aliases
+
+      if attrs.is_a?(String) || attrs.length == 0
+        self.required = required
+        self.desc     = attrs.is_a?(String) ? attrs : desc
+        self.enums    = [ *(enums) ].map { |x| x.to_s }
+        self.default  = default || enums[0]
+        regex_temp    = regex
+      else
+        self.required = attrs[0] || required
+        self.desc     = attrs[1] || desc
+        self.default  = attrs[2] || default
+        self.enums    = attrs[3] || enums
+        self.enums    = [ *(self.enums) ].map { |x| x.to_s }
+        regex_temp    = attrs[4] || regex
+      end
+
       if regex_temp
         # convert to string
         regex_temp = regex_temp.to_s if regex_temp.is_a? Regexp
@@ -45,35 +61,34 @@ module Msf
           raise("Invalid Regex #{regex_temp}: #{e}")
         end
       end
-      self.aliases = aliases
     end
 
     #
     # Returns true if this is a required option.
     #
     def required?
-      return required
+      required
     end
 
     #
     # Returns true if this is an advanced option.
     #
     def advanced?
-      return advanced
+      advanced
     end
 
     #
     # Returns true if this is an evasion option.
     #
     def evasion?
-      return evasion
+      evasion
     end
 
     #
     # Returns true if the supplied type is equivalent to this option's type.
     #
     def type?(in_type)
-      return (type == in_type)
+      type == in_type
     end
 
     #
@@ -94,7 +109,7 @@ module Msf
       if regex
         return !!value.match(regex)
       end
-      return true
+      true
     end
 
     #
@@ -102,7 +117,7 @@ module Msf
     # a valid value
     #
     def empty_required_value?(value)
-      return (required? and value.nil?)
+      required? && value.nil?
     end
 
     #
@@ -169,6 +184,4 @@ module Msf
 
     attr_writer   :required, :desc, :default # :nodoc:
   end
-
 end
-

--- a/lib/msf/core/opt_base.rb
+++ b/lib/msf/core/opt_base.rb
@@ -36,7 +36,11 @@ module Msf
         self.required = required
         self.desc     = attrs.is_a?(String) ? attrs : desc
         self.enums    = [ *(enums) ].map { |x| x.to_s }
-        self.default  = default || enums[0]
+        if default.nil? && enums.length > 0
+          self.default  = enums[0]
+        else
+          self.default = default
+        end
         regex_temp    = regex
       else
         self.required = attrs[0] || required

--- a/lib/msf/core/opt_base.rb
+++ b/lib/msf/core/opt_base.rb
@@ -36,8 +36,12 @@ module Msf
         self.required = required
         self.desc     = attrs.is_a?(String) ? attrs : desc
         self.enums    = [ *(enums) ].map { |x| x.to_s }
-        self.default  = default
-        regex_temp    = regex
+        if default.nil? && enums.length > 0
+          self.default = enums[0]
+        else
+          self.default = default
+        end
+        regex_temp = regex
       else
         if attrs[0].nil?
           self.required = required

--- a/lib/msf/core/opt_bool.rb
+++ b/lib/msf/core/opt_bool.rb
@@ -1,48 +1,31 @@
 # -*- coding: binary -*-
 
 module Msf
+  # Boolean option type
+  class OptBool < OptBase
+    TRUE_REGEX = /^(y|yes|t|1|true)$/i
+    ANY_REGEX = /^(y|yes|n|no|t|f|0|1|true|false)$/i
 
-###
-#
-# Boolean option.
-#
-###
-class OptBool < OptBase
-
-  TrueRegex = /^(y|yes|t|1|true)$/i
-
-  def type
-    return 'bool'
-  end
-
-  def valid?(value, check_empty: true)
-    return false if empty_required_value?(value)
-
-    if ((value != nil and
-        (value.to_s.empty? == false) and
-        (value.to_s.match(/^(y|yes|n|no|t|f|0|1|true|false)$/i) == nil)))
-      return false
+    # This overrides default from 'nil' to 'false'
+    def initialize(in_name, attrs = [],
+                   required: true, desc: nil, default: false, aliases: [])
+      super
     end
 
-    true
-  end
+    def type
+      return 'bool'
+    end
 
-  def normalize(value)
-    if(value.nil? or value.to_s.match(TrueRegex).nil?)
-      false
-    else
-      true
+    def valid?(value, check_empty: true)
+      return false if check_empty && empty_required_value?(value)
+      !(value.nil? ||
+        value.to_s.empty? ||
+        value.to_s.match(ANY_REGEX).nil?)
+    end
+
+    def normalize(value)
+      !(value.nil? ||
+        value.to_s.match(TRUE_REGEX).nil?)
     end
   end
-
-  def is_true?(value)
-    return normalize(value)
-  end
-
-  def is_false?(value)
-    return !is_true?(value)
-  end
-
-end
-
 end

--- a/lib/msf/core/opt_bool.rb
+++ b/lib/msf/core/opt_bool.rb
@@ -18,6 +18,8 @@ module Msf
 
     def valid?(value, check_empty: true)
       return false if check_empty && empty_required_value?(value)
+      return true if value.nil? && !required?
+
       !(value.nil? ||
         value.to_s.empty? ||
         value.to_s.match(ANY_REGEX).nil?)

--- a/lib/msf/core/opt_enum.rb
+++ b/lib/msf/core/opt_enum.rb
@@ -1,48 +1,45 @@
 # -*- coding: binary -*-
 
 module Msf
-
-###
-#
-# Enum option.
-#
-###
-class OptEnum < OptBase
-
-  def type
-    return 'enum'
-  end
-
-  def valid?(value=self.value, check_empty: true)
-    return false if check_empty && empty_required_value?(value)
-    return true if value.nil? and !required?
-
-    (value and self.enums.include?(value.to_s))
-  end
-
-  def normalize(value=self.value)
-    return nil if not self.valid?(value)
-    return value.to_s
-  end
-
-  def desc=(value)
-    self.desc_string = value
-
-    self.desc
-  end
-
-  def desc
-    if self.enums
-      str = self.enums.join(', ')
+  ###
+  #
+  # Enum option.
+  #
+  ###
+  class OptEnum < OptBase
+    def type
+      return 'enum'
     end
-    "#{self.desc_string || ''} (Accepted: #{str})"
+
+    # This overrides required default from 'false' to 'true'
+    def initialize(in_name, attrs = [],
+                   required: true, desc: nil, default: nil, enums: [], aliases: [])
+      super
+    end
+
+    def valid?(value = self.value, check_empty: true)
+      return false if check_empty && empty_required_value?(value)
+      return true if value.nil? && !required?
+
+      (value && enums.include?(value.to_s))
+    end
+
+    def normalize(value = self.value)
+      !valid?(value) ? nil : value.to_s
+    end
+
+    def desc=(value)
+      self.desc_string = value
+      desc
+    end
+
+    def desc
+      str = enums.join(', ') if enums
+      "#{desc_string || ''} (Accepted: #{str})"
+    end
+
+    protected
+
+    attr_accessor :desc_string # :nodoc:
   end
-
-
-protected
-
-  attr_accessor :desc_string # :nodoc:
-
-end
-
 end

--- a/lib/msf/core/opt_enum.rb
+++ b/lib/msf/core/opt_enum.rb
@@ -21,7 +21,7 @@ module Msf
       return false if check_empty && empty_required_value?(value)
       return true if value.nil? && !required?
 
-      (value && enums.include?(value.to_s))
+      !value.nil? && enums.include?(value.to_s)
     end
 
     def normalize(value = self.value)

--- a/lib/msf/core/opt_enum.rb
+++ b/lib/msf/core/opt_enum.rb
@@ -25,7 +25,11 @@ module Msf
     end
 
     def normalize(value = self.value)
-      !valid?(value) ? nil : value.to_s
+      if valid?(value)
+        value.to_s
+      else
+        nil
+      end
     end
 
     def desc=(value)


### PR DESCRIPTION
This adds named parameters for all of the current array-index based options. It also allows specifying the description as the 2nd parameter, allowing the 'required' parameter to be implicitly false (the most common value).

A simple parameter like:

```
     OptAddress.new('ReverseListenerBindAddress',
       [false, 'The specific IP address to bind to on the local system']),
```

Can now be rewritten as:

```
     OptAddress.new('ReverseListenerBindAddress',
       'The specific IP address to bind to on the local system'),
```

More complex options are also now easier to read:

```
     OptString.new(
       'HttpUserAgent',
       'The user-agent that the payload should use',
       default: Rex::UserAgent.shortest,
       aliases: ['MeterpreterUserAgent']
     ),
```

This also makes dealing with enums easier because default is implicitly the first element, unless specified. This:

```
      OptEnum.new('PayloadProxyType',
        [true, 'The proxy type, HTTP or SOCKS', 'HTTP', ['HTTP', 'SOCKS']]),
```

    becomes:

```
      OptEnum.new('HttpProxyType',
        'The proxy type, HTTP or SOCKS', required: true, enums: ['HTTP', 'SOCKS'])
```

This maintains full backward compatibility with existing code, so you don't have to use this (and to convert everything would be a rather unrealistic task!)

Note there are some whitespace changes here, which you can filter out with https://github.com/rapid7/metasploit-framework/pull/9000/files?w=1