### PR TITLE
update modules to use inherited SSLVersion option

### DIFF
--- a/modules/auxiliary/gather/emc_cta_xxe.rb
+++ b/modules/auxiliary/gather/emc_cta_xxe.rb
@@ -30,10 +30,10 @@ class MetasploitModule < Msf::Auxiliary
       [
         Opt::RPORT(443),
         OptBool.new('SSL', [true, 'Use SSL', true]),
-        OptString.new('SSLVersion', [true, 'SSL version', 'TLS1']),
         OptString.new('TARGETURI', [ true, "Base directory path", '/']),
         OptString.new('FILEPATH', [true, "The filepath to read on the server", "/etc/shadow"]),
-      ])
+      ]
+    )
   end
 
   def run

--- a/modules/auxiliary/scanner/nessus/nessus_ntp_login.rb
+++ b/modules/auxiliary/scanner/nessus/nessus_ntp_login.rb
@@ -13,23 +13,18 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::AuthBrute
 
   def initialize
-  super(
-    'Name'        => 'Nessus NTP Login Utility',
-    'Description' => 'This module attempts to authenticate to a Nessus NTP service.',
-    'Author'         => [ 'Vlatko Kosturjak <kost[at]linux.hr>' ],
-    'License'        => MSF_LICENSE
-  )
-  register_options(
-    [
-      Opt::RPORT(1241),
-      OptBool.new('BLANK_PASSWORDS', [false, "Try blank passwords for all users", false])
-    ])
-
-  register_advanced_options(
-  [
-    OptBool.new('SSL', [ true, "Negotiate SSL for outgoing connections", true]),
-    OptString.new('SSLVersion', [ true, " Specify the version of SSL that should be used", "TLS1"])
-  ])
+    super(
+      'Name'        => 'Nessus NTP Login Utility',
+      'Description' => 'This module attempts to authenticate to a Nessus NTP service.',
+      'Author'      => [ 'Vlatko Kosturjak <kost[at]linux.hr>' ],
+      'License'     => MSF_LICENSE
+    )
+    register_options(
+      [
+        Opt::RPORT(1241),
+        OptBool.new('BLANK_PASSWORDS', "Try blank passwords for all users")
+      ]
+    )
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/openvas/openvas_omp_login.rb
+++ b/modules/auxiliary/scanner/openvas/openvas_omp_login.rb
@@ -10,23 +10,18 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::AuthBrute
 
   def initialize
-  super(
-    'Name'        => 'OpenVAS OMP Login Utility',
-    'Description' => 'This module attempts to authenticate to an OpenVAS OMP service.',
-    'Author'         => [ 'Vlatko Kosturjak <kost[at]linux.hr>' ],
-    'License'        => MSF_LICENSE
-  )
-  register_options(
-    [
-      Opt::RPORT(9390),
-      OptBool.new('BLANK_PASSWORDS', [false, "Try blank passwords for all users", false])
-    ])
-
-  register_advanced_options(
-  [
-    OptBool.new('SSL', [ true, "Negotiate SSL for outgoing connections", true]),
-    OptString.new('SSLVersion', [ true, " Specify the version of SSL that should be used", "TLS1"])
-  ])
+    super(
+      'Name'        => 'OpenVAS OMP Login Utility',
+      'Description' => 'This module attempts to authenticate to an OpenVAS OMP service.',
+      'Author'         => [ 'Vlatko Kosturjak <kost[at]linux.hr>' ],
+      'License'        => MSF_LICENSE
+    )
+    register_options(
+      [
+        Opt::RPORT(9390),
+        OptBool.new('BLANK_PASSWORDS', [false, "Try blank passwords for all users", false])
+      ]
+    )
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/openvas/openvas_omp_login.rb
+++ b/modules/auxiliary/scanner/openvas/openvas_omp_login.rb
@@ -13,8 +13,8 @@ class MetasploitModule < Msf::Auxiliary
     super(
       'Name'        => 'OpenVAS OMP Login Utility',
       'Description' => 'This module attempts to authenticate to an OpenVAS OMP service.',
-      'Author'         => [ 'Vlatko Kosturjak <kost[at]linux.hr>' ],
-      'License'        => MSF_LICENSE
+      'Author'      => [ 'Vlatko Kosturjak <kost[at]linux.hr>' ],
+      'License'     => MSF_LICENSE
     )
     register_options(
       [

--- a/modules/auxiliary/scanner/openvas/openvas_otp_login.rb
+++ b/modules/auxiliary/scanner/openvas/openvas_otp_login.rb
@@ -13,8 +13,8 @@ class MetasploitModule < Msf::Auxiliary
     super(
       'Name'        => 'OpenVAS OTP Login Utility',
       'Description' => 'This module attempts to authenticate to an OpenVAS OTP service.',
-      'Author'         => [ 'Vlatko Kosturjak <kost[at]linux.hr>' ],
-      'License'        => MSF_LICENSE
+      'Author'      => [ 'Vlatko Kosturjak <kost[at]linux.hr>' ],
+      'License'     => MSF_LICENSE
     )
     register_options(
       [

--- a/modules/auxiliary/scanner/openvas/openvas_otp_login.rb
+++ b/modules/auxiliary/scanner/openvas/openvas_otp_login.rb
@@ -10,23 +10,18 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::AuthBrute
 
   def initialize
-  super(
-    'Name'        => 'OpenVAS OTP Login Utility',
-    'Description' => 'This module attempts to authenticate to an OpenVAS OTP service.',
-    'Author'         => [ 'Vlatko Kosturjak <kost[at]linux.hr>' ],
-    'License'        => MSF_LICENSE
-  )
-  register_options(
-    [
-      Opt::RPORT(9391),
-      OptBool.new('BLANK_PASSWORDS', [false, "Try blank passwords for all users", false])
-    ])
-
-  register_advanced_options(
-  [
-    OptBool.new('SSL', [ true, "Negotiate SSL for outgoing connections", true]),
-    OptString.new('SSLVersion', [ true, " Specify the version of SSL that should be used", "TLS1"])
-  ])
+    super(
+      'Name'        => 'OpenVAS OTP Login Utility',
+      'Description' => 'This module attempts to authenticate to an OpenVAS OTP service.',
+      'Author'         => [ 'Vlatko Kosturjak <kost[at]linux.hr>' ],
+      'License'        => MSF_LICENSE
+    )
+    register_options(
+      [
+        Opt::RPORT(9391),
+        OptBool.new('BLANK_PASSWORDS', [false, "Try blank passwords for all users", false])
+      ]
+    )
   end
 
   def run_host(ip)


### PR DESCRIPTION
I found a few modules that implement their own implementations of SSLVersion, of which 3 appear to be plain-old copypasta. Update them to all use the common definition.

## Verification

- [x] Start `msfconsole`
- [x] use each affected module
- [x] **Verify** they still have an SSLVersion option

Also, is this PR... Over 9000!?