### PR TITLE
Bug payload param EXITFUNC

### DIFF
--- a/lib/msf/core/payload/linux/bind_tcp.rb
+++ b/lib/msf/core/payload/linux/bind_tcp.rb
@@ -31,7 +31,7 @@ module Payload::Linux::BindTcp
 
     # Generate the more advanced stager if we have the space
     if self.available_space && required_space <= self.available_space
-      conf[:exitfunk] = datastore['EXITFUNC'],
+      conf[:exitfunk] = datastore['EXITFUNC']
       conf[:reliable] = true
     end
 

--- a/lib/msf/core/payload/windows/bind_tcp.rb
+++ b/lib/msf/core/payload/windows/bind_tcp.rb
@@ -35,7 +35,7 @@ module Payload::Windows::BindTcp
 
     # Generate the more advanced stager if we have the space
     if self.available_space && required_space <= self.available_space
-      conf[:exitfunk] = datastore['EXITFUNC'],
+      conf[:exitfunk] = datastore['EXITFUNC']
       conf[:reliable] = true
     end
 

--- a/lib/msf/core/payload/windows/bind_tcp_rc4.rb
+++ b/lib/msf/core/payload/windows/bind_tcp_rc4.rb
@@ -33,7 +33,7 @@ module Payload::Windows::BindTcpRc4
 
     # Generate the more advanced stager if we have the space
     if self.available_space && required_space <= self.available_space
-      conf[:exitfunk] = datastore['EXITFUNC'],
+      conf[:exitfunk] = datastore['EXITFUNC']
       conf[:reliable] = true
     end
 

--- a/lib/msf/core/payload/windows/x64/bind_tcp.rb
+++ b/lib/msf/core/payload/windows/x64/bind_tcp.rb
@@ -33,7 +33,7 @@ module Payload::Windows::BindTcp_x64
 
     # Generate the more advanced stager if we have the space
     if self.available_space && required_space <= self.available_space
-      conf[:exitfunk] = datastore['EXITFUNC'],
+      conf[:exitfunk] = datastore['EXITFUNC']
       conf[:reliable] = true
     end
 


### PR DESCRIPTION

Fixes #9004
Syntax error in files(extra comma)

lib/msf/core/payload/windows/bind_tcp.rb:
conf[:exitfunk] = datastore['EXITFUNC'],
lib/msf/core/payload/windows/bind_tcp_rc4.rb:
conf[:exitfunk] = datastore['EXITFUNC'],
lib/msf/core/payload/windows/x64/bind_tcp.rb:
conf[:exitfunk] = datastore['EXITFUNC'],
lib/msf/core/payload/linux/bind_tcp.rb:
conf[:exitfunk] = datastore['EXITFUNC'],

