### PR TITLE
remove checks for hardcoded SYSTEM Account name

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/mimikatz.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/mimikatz.rb
@@ -159,7 +159,7 @@ class Console::CommandDispatcher::Mimikatz
   end
 
   def system_check
-    unless (client.sys.config.is_system?)
+    unless client.sys.config.is_system?
       print_warning("Not currently running as SYSTEM")
       return false
     end

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/mimikatz.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/mimikatz.rb
@@ -159,7 +159,7 @@ class Console::CommandDispatcher::Mimikatz
   end
 
   def system_check
-    unless (client.sys.config.getuid == "NT AUTHORITY\\SYSTEM")
+    unless (client.sys.config.is_system?)
       print_warning("Not currently running as SYSTEM")
       return false
     end

--- a/modules/exploits/windows/local/ps_persist.rb
+++ b/modules/exploits/windows/local/ps_persist.rb
@@ -80,7 +80,7 @@ class MetasploitModule < Msf::Exploit::Local
       return
     end
     # Havent figured this one out yet, but we need a PID owned by a user, cant steal tokens either
-    if client.sys.config.getuid == 'NT AUTHORITY\SYSTEM'
+    if client.sys.config.is_system?
       print_error("Cannot run as system")
       return
     end

--- a/modules/post/windows/gather/enum_chrome.rb
+++ b/modules/post/windows/gather/enum_chrome.rb
@@ -151,7 +151,7 @@ class MetasploitModule < Msf::Post
 
       rows.map! do |row|
         res = Hash[*columns.zip(row).flatten]
-        if item[:encrypted_fields] && session.sys.config.getuid != "NT AUTHORITY\\SYSTEM"
+        if item[:encrypted_fields] && !session.sys.config.is_system?
 
           item[:encrypted_fields].each do |field|
             name = (res["name_on_card"] == nil) ? res["username_value"] : res["name_on_card"]

--- a/modules/post/windows/manage/powershell/build_net_code.rb
+++ b/modules/post/windows/manage/powershell/build_net_code.rb
@@ -59,7 +59,7 @@ class MetasploitModule < Msf::Post
     end
 
     # Havent figured this one out yet, but we need a PID owned by a user, can't steal tokens either
-    if client.sys.config.getuid == 'NT AUTHORITY\SYSTEM'
+    if client.sys.config.is_system?
       print_error "Cannot run as system"
       return 0
     end

--- a/scripts/meterpreter/dumplinks.rb
+++ b/scripts/meterpreter/dumplinks.rb
@@ -66,7 +66,6 @@ end
 def enum_users(os)
   users = []
   userinfo = {}
-  user = @client.sys.config.getuid
   userpath = nil
   useroffcpath = nil
   sysdrv = @client.sys.config.getenv('SystemDrive')
@@ -79,7 +78,7 @@ def enum_users(os)
     lnkpath = "\\Recent\\"
     officelnkpath = "\\Application Data\\Microsoft\\Office\\Recent\\"
   end
-  if user == "NT AUTHORITY\\SYSTEM"
+  if @client.sys.config.is_system?
     print_status("Running as SYSTEM extracting user list...")
     @client.fs.dir.foreach(userpath) do |u|
       next if u =~ /^(\.|\.\.|All Users|Default|Default User|Public|desktop.ini)$/

--- a/scripts/meterpreter/enum_chrome.rb
+++ b/scripts/meterpreter/enum_chrome.rb
@@ -145,7 +145,7 @@ def process_files(username)
       db.close
       rows.map! do |row|
         res = Hash[*columns.zip(row).flatten]
-        if item[:encrypted_fields] && client.sys.config.getuid != "NT AUTHORITY\\SYSTEM"
+        if item[:encrypted_fields] && !client.sys.config.is_system?
           if @host_info['Architecture'] !~ /x64/
             item[:encrypted_fields].each do |field|
               print_good("decrypting field '#{field}'...")

--- a/scripts/meterpreter/enum_vmware.rb
+++ b/scripts/meterpreter/enum_vmware.rb
@@ -228,7 +228,6 @@ end
 def enum_users
   os = @client.sys.config.sysinfo['OS']
   users = []
-  user = @client.sys.config.getuid
   path4users = ""
   sysdrv = @client.sys.config.getenv('SystemDrive')
 
@@ -240,7 +239,7 @@ def enum_users
     profilepath = "\\Application Data\\VMware\\"
   end
 
-  if user == "NT AUTHORITY\\SYSTEM"
+  if @client.sys.config.is_system?
     print_status("Running as SYSTEM extracting user list..")
     @client.fs.dir.foreach(path4users) do |u|
       userinfo = {}


### PR DESCRIPTION
Followup for #9007

This change removes all checks against a hardcoded SYSTEM Account name which fails on non english windows version (eg a german windows where it is called `NT AUTHORITÄT\SYSTEM`