### PR TITLE
Fix nil bug in loot -a and nix hostless loot

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -479,7 +479,7 @@ class Db
         'SortIndex' => order_by
       })
 
-    # Sentinal value meaning all
+    # Sentinel value meaning all
     host_ranges.push(nil) if host_ranges.empty?
 
     case
@@ -717,7 +717,7 @@ class Db
         'SortIndex' => order_by
       })
 
-    # Sentinal value meaning all
+    # Sentinel value meaning all
     host_ranges.push(nil) if host_ranges.empty?
     ports = nil if ports.empty?
 
@@ -1115,7 +1115,7 @@ class Db
   def cmd_loot_help
     print_line "Usage: loot <options>"
     print_line " Info: loot [-h] [addr1 addr2 ...] [-t <type1,type2>]"
-    print_line "  Add: loot -f [fname] -i [info] -a [addr1 addr2 ...] [-t [type]"
+    print_line "  Add: loot -f [fname] -i [info] -a [addr1 addr2 ...] -t [type]"
     print_line "  Del: loot -d [addr1 addr2 ...]"
     print_line
     print_line "  -a,--add          Add loot to the list of addresses, instead of listing"
@@ -1187,34 +1187,38 @@ class Db
         'Columns' => [ 'host', 'service', 'type', 'name', 'content', 'info', 'path' ],
       })
 
-    # Sentinal value meaning all
+    # Sentinel value meaning all
     host_ranges.push(nil) if host_ranges.empty?
 
-  if mode == :add
-    if info.nil?
-      print_error("Info required")
-      return
-    end
-    if filename.nil?
-      print_error("Loot file required")
-      return
-    end
-    if types.nil? or types.size != 1
-      print_error("Exactly one loot type is required")
-      return
-    end
-    type = types.first
-    name = File.basename(filename)
-    host_ranges.each do |range|
-      range.each do |host|
-        file = File.open(filename, "rb")
-        contents = file.read
-        lootfile = framework.db.find_or_create_loot(:type => type, :host => host, :info => info, :data => contents, :path => filename, :name => name)
-        print_status("Added loot for #{host} (#{lootfile})")
+    if mode == :add
+      if host_ranges.compact.empty?
+        print_error('Address list required')
+        return
       end
+      if info.nil?
+        print_error("Info required")
+        return
+      end
+      if filename.nil?
+        print_error("Loot file required")
+        return
+      end
+      if types.nil? or types.size != 1
+        print_error("Exactly one loot type is required")
+        return
+      end
+      type = types.first
+      name = File.basename(filename)
+      file = File.open(filename, "rb")
+      contents = file.read
+      host_ranges.each do |range|
+        range.each do |host|
+          lootfile = framework.db.find_or_create_loot(:type => type, :host => host, :info => info, :data => contents, :path => filename, :name => name)
+          print_status("Added loot for #{host} (#{lootfile})")
+        end
+      end
+      return
     end
-    return
-  end
 
     each_host_range_chunk(host_ranges) do |host_search|
       framework.db.hosts(framework.db.workspace, false, host_search).each do |host|
@@ -1245,26 +1249,6 @@ class Db
             loot.destroy
             delete_count += 1
           end
-        end
-      end
-    end
-
-    # Handle hostless loot
-    if host_ranges.compact.empty? # Wasn't a host search
-      hostless_loot = framework.db.loots.where(host_id: nil)
-      hostless_loot.each do |loot|
-        row = []
-        row.push("")
-        row.push("")
-        row.push(loot.ltype)
-        row.push(loot.name || "")
-        row.push(loot.content_type)
-        row.push(loot.info || "")
-        row.push(loot.path)
-        tbl << row
-        if (mode == :delete)
-          loot.destroy
-          delete_count += 1
         end
       end
     end

--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -1253,6 +1253,26 @@ class Db
       end
     end
 
+    # Handle hostless loot
+    if host_ranges.compact.empty? # Wasn't a host search
+      hostless_loot = framework.db.loots.where(host_id: nil)
+      hostless_loot.each do |loot|
+        row = []
+        row.push("")
+        row.push("")
+        row.push(loot.ltype)
+        row.push(loot.name || "")
+        row.push(loot.content_type)
+        row.push(loot.info || "")
+        row.push(loot.path)
+        tbl << row
+        if (mode == :delete)
+          loot.destroy
+          delete_count += 1
+        end
+      end
+    end
+
     print_line
     print_line(tbl.to_s)
     print_status("Deleted #{delete_count} loots") if delete_count > 0

--- a/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Db do
         expect(@output).to match_array [
           "Usage: loot <options>",
           " Info: loot [-h] [addr1 addr2 ...] [-t <type1,type2>]",
-          "  Add: loot -f [fname] -i [info] -a [addr1 addr2 ...] [-t [type]",
+          "  Add: loot -f [fname] -i [info] -a [addr1 addr2 ...] -t [type]",
           "  Del: loot -d [addr1 addr2 ...]",
           "  -a,--add          Add loot to the list of addresses, instead of listing",
           "  -d,--delete       Delete *all* loot matching host and type",


### PR DESCRIPTION
So, hostless loot doesn't actually store. At least I can't ever retrieve it. Making a host required now.

- [x] Test `loot -a`
- [x] See that all the bugs in `CommandDispatcher` have been fixed