### PR TITLE
Fix cache invalidation bug in tab completion

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -139,10 +139,8 @@ class Core
   def initialize(driver)
     super
 
-    @dscache = {}
     @cache_payloads = nil
     @previous_module = nil
-    @module_name_stack = []
     @history_limit = 100
   end
 
@@ -2288,7 +2286,11 @@ class Core
   # Provide valid payload options for the current exploit
   #
   def option_values_payloads
-    return @cache_payloads if @cache_payloads
+    if @cache_payloads && active_module == @previous_module
+      return @cache_payloads
+    else
+      @previous_module = active_module
+    end
 
     @cache_payloads = active_module.compatible_payloads.map { |refname, payload|
       refname

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -2288,9 +2288,9 @@ class Core
   def option_values_payloads
     if @cache_payloads && active_module == @previous_module
       return @cache_payloads
-    else
-      @previous_module = active_module
     end
+
+    @previous_module = active_module
 
     @cache_payloads = active_module.compatible_payloads.map { |refname, payload|
       refname

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -141,6 +141,7 @@ class Core
 
     @cache_payloads = nil
     @previous_module = nil
+    @previous_target = nil
     @history_limit = 100
   end
 
@@ -1625,12 +1626,6 @@ class Core
     # Set the supplied name to the supplied value
     name  = args[0]
     value = args[1, args.length-1].join(' ')
-    if (name.upcase == "TARGET")
-      # Different targets can have different architectures and platforms
-      # so we need to rebuild the payload list whenever the target
-      # changes.
-      @cache_payloads = nil
-    end
 
     # If the driver indicates that the value is not valid, bust out.
     if (driver.on_variable_set(global, name, value) == false)
@@ -2286,15 +2281,16 @@ class Core
   # Provide valid payload options for the current exploit
   #
   def option_values_payloads
-    if @cache_payloads && active_module == @previous_module
+    if @cache_payloads && active_module == @previous_module && active_module.target == @previous_target
       return @cache_payloads
     end
 
     @previous_module = active_module
+    @previous_target = active_module.target
 
-    @cache_payloads = active_module.compatible_payloads.map { |refname, payload|
+    @cache_payloads = active_module.compatible_payloads.map do |refname, payload|
       refname
-    }
+    end
 
     @cache_payloads
   end

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -48,7 +48,6 @@ module Msf
             super
 
             @dscache = {}
-            @cache_payloads = nil
             @previous_module = nil
             @module_name_stack = []
             @dangerzone_map = nil
@@ -645,7 +644,6 @@ module Msf
               active_module.datastore.update(@dscache[active_module.fullname])
             end
 
-            @cache_payloads = nil
             mod.init_ui(driver.input, driver.output)
 
             # Update the command prompt


### PR DESCRIPTION
We use `active_module` instead of `cmd_use` to invalidate `@cache_payloads`, since the ivar is no longer shared between `cmd_set` and `cmd_use`.

Fixes #8483. See #7655.