### PR TITLE
Fix File Read Assumptions and Other Bugs

### DIFF
--- a/modules/post/linux/gather/mount_cifs_creds.rb
+++ b/modules/post/linux/gather/mount_cifs_creds.rb
@@ -38,6 +38,7 @@ class MetasploitModule < Msf::Post
     ])
 
     # parse each line from /etc/fstab
+    fail_with(Failure::NotFound, '/etc/fstab not found on system') unless file_exist?('/etc/fstab')
     read_file("/etc/fstab").each_line do |fstab_line|
       fstab_line.strip!
       # where we'll store the current parsed credentials, if any

--- a/modules/post/multi/escalate/metasploit_pcaplog.rb
+++ b/modules/post/multi/escalate/metasploit_pcaplog.rb
@@ -61,6 +61,7 @@ class MetasploitModule < Msf::Post
 
   def run
     print_status "Setting up the victim's /tmp dir"
+    fail_with(Failure::NotFound, '/etc/passwd not found on system') unless file_exist?('/etc/passwd')
     initial_size = read_file("/etc/passwd").lines.count
     print_status "/etc/passwd is currently #{initial_size} lines long"
     i = 0

--- a/modules/post/multi/gather/enum_vbox.rb
+++ b/modules/post/multi/gather/enum_vbox.rb
@@ -55,6 +55,7 @@ class MetasploitModule < Msf::Post
       end
     end
 
+    return nil unless res
     vprint_status(res)
     store_path = store_loot('virtualbox_vms', "text/plain", session, res, "virtualbox_vms.txt", "Virtualbox Virtual Machines")
     print_good("#{peer} - File successfully retrieved and saved on #{store_path}")

--- a/modules/post/multi/gather/lastpass_creds.rb
+++ b/modules/post/multi/gather/lastpass_creds.rb
@@ -194,7 +194,7 @@ class MetasploitModule < Msf::Post
     when /windows/
       user_profiles |= grab_user_profiles
     else
-      print_error "OS not recognized: #{os}"
+      print_error "OS not recognized: #{session.platform}"
     end
     user_profiles
   end

--- a/modules/post/multi/gather/remmina_creds.rb
+++ b/modules/post/multi/gather/remmina_creds.rb
@@ -67,7 +67,7 @@ class MetasploitModule < Msf::Post
     user_dirs = enum_user_directories
     if user_dirs.empty?
       print_error('No user directories found')
-      return
+      return creds
     end
 
     vprint_status("Searching for Remmina creds in #{user_dirs.size} user directories")


### PR DESCRIPTION
Similar to #8987 I put an `ssh_login` shell (which defaults to linux) on my Juniper SSG 5.  Then went through all the linux/multi post modules to see which ones crashes.
This should catch:

- Assuming a file can be read without verifying it will be there first
- Force "Else" cases since this is a non-standard platform
- Check cases are handled where a command returns nil or empty (since the command wont run on the juniper)

## Verification

- [x] Try the modules and make sure they dont crash any more on something (like a cisco)

### Details
The basic format of this is load module, run it, see crash. (fix it in a different window) rexploit to prove fix worked.

#### post/linux/gather/mount_cifs_creds 
```
msf post(hashdump) > use post/linux/gather/mount_cifs_creds 
msf post(mount_cifs_creds) > run

[-] Post failed: NoMethodError undefined method `each_line' for nil:NilClass
[-] Call stack:
[-]   metasploit-framework/modules/post/linux/gather/mount_cifs_creds.rb:41:in `run'
[*] Post module execution completed
msf post(mount_cifs_creds) > rexploit

[-] Post aborted due to failure: not-found: /etc/fstab not found on system
[*] Post module execution completed
```
#### post/multi/escalate/metasploit_pcaplog 
```
msf post(cups_root_file_read) > use post/multi/escalate/metasploit_pcaplog 
msf post(metasploit_pcaplog) > run

[*] Setting up the victim's /tmp dir
[-] Post failed: NoMethodError undefined method `lines' for nil:NilClass
[-] Call stack:
[-]   metasploit-framework/modules/post/multi/escalate/metasploit_pcaplog.rb:64:in `run'
[*] Post module execution completed
msf post(metasploit_pcaplog) > rexploit
[*] Reloading module...

[*] Setting up the victim's /tmp dir
[-] Post aborted due to failure: not-found: /etc/passwd not found on system
[*] Post module execution completed
msf post(metasploit_pcaplog) > 
```
#### post/multi/gather/enum_vbox
```
msf post(docker_creds) > use post/multi/gather/enum_vbox 
msf post(enum_vbox) > run

[-] Post failed: TypeError no implicit conversion of nil into String
[-] Call stack:
[-]   metasploit-framework/lib/msf/core/module/ui/message.rb:34:in `+'
[-]   metasploit-framework/lib/msf/core/module/ui/message.rb:34:in `print_status'
[-]   metasploit-framework/lib/msf/core/module/ui/message/verbose.rb:16:in `vprint_status'
[-]   metasploit-framework/modules/post/multi/gather/enum_vbox.rb:58:in `run'
[*] Post module execution completed
msf post(enum_vbox) > rexploit
[*] Reloading module...
[*] Post module execution completed
```
#### post/multi/gather/lastpass_creds 
```
msf post(jenkins_gather) > use post/multi/gather/lastpass_creds 
rumsf post(lastpass_creds) > run

[*] Searching for LastPass databases
[-] Post failed: NameError undefined local variable or method `os' for #<Msf::Modules::Mod706f73742f6d756c74692f6761746865722f6c617374706173735f6372656473::MetasploitModule:0x0056486e8c4e68>
[-] Call stack:
[-]   metasploit-framework/modules/post/multi/gather/lastpass_creds.rb:197:in `user_profiles'
[-]   metasploit-framework/modules/post/multi/gather/lastpass_creds.rb:69:in `build_account_map'
[-]   metasploit-framework/modules/post/multi/gather/lastpass_creds.rb:46:in `run'
[*] Post module execution completed
msf post(lastpass_creds) > rexploit
[*] Reloading module...

[*] Searching for LastPass databases
[-] OS not recognized: 
[*] No databases found
[*] Post module execution completed
```