### PR TITLE
fix transport and sleep commands on java/osx

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
@@ -97,8 +97,9 @@ class Console::CommandDispatcher::Core
     # the OS platform rather than the meterpreter arch. When we've properly implemented
     # the platform update feature we can remove some of these conditions
     if client.platform == 'windows' || client.platform == 'linux' ||
-        client.platform == 'python' || client.platform == 'java' ||
-        client.arch == ARCH_PYTHON || client.platform == 'android'
+        client.platform == 'python' || client.arch == ARCH_PYTHON ||
+        client.platform == 'java' || client.arch == ARCH_JAVA ||
+        client.platform == 'android' || client.arch == ARCH_DALVIK
       # Yet to implement transport hopping for other meterpreters.
       c['transport'] = 'Change the current transport mechanism'
 


### PR DESCRIPTION
Quick fix for the transport command showing on java meterpreter, running on OSX.
If you run java meterpreter on OSX, the client.platform is OSX, so the command wasn't being shown.
