### PR TITLE
Add CVE and Vendor article URL to the denyall_waf_exec module

### DIFF
--- a/modules/exploits/linux/http/denyall_waf_exec.rb
+++ b/modules/exploits/linux/http/denyall_waf_exec.rb
@@ -22,7 +22,9 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'References'     =>
         [
-          ['URL', 'https://pentest.blog/advisory-denyall-web-application-firewall-unauthenticated-remote-code-execution/']
+          ['CVE', '2017-14706'],
+          ['URL', 'https://pentest.blog/advisory-denyall-web-application-firewall-unauthenticated-remote-code-execution/'],
+          ['URL', 'https://www.denyall.com/blog/advisories/advisory-unauthenticated-remote-code-execution-denyall-web-application-firewall/']
         ],
       'DefaultOptions'  =>
         {


### PR DESCRIPTION
I just wanted to add CVE number and vendor article url into the module.