### PR TITLE
tlv response to ID based request with original ID

### DIFF
--- a/lib/rex/post/meterpreter/packet.rb
+++ b/lib/rex/post/meterpreter/packet.rb
@@ -705,6 +705,7 @@ class Packet < GroupTlv
   def Packet.create_response(request = nil)
     response_type = PACKET_TYPE_RESPONSE
     method = nil
+    id = nil
 
     if (request)
       if (request.type?(PACKET_TYPE_PLAIN_REQUEST))
@@ -712,9 +713,19 @@ class Packet < GroupTlv
       end
 
       method = request.method
+
+      if request.has_tlv?(TLV_TYPE_REQUEST_ID)
+        id = request.get_tlv_value(TLV_TYPE_REQUEST_ID)
+      end
     end
 
-    Packet.new(response_type, method)
+    packet = Packet.new(response_type, method)
+
+    if id
+      packet.add_tlv(TLV_TYPE_REQUEST_ID, id)
+    end
+
+    packet
   end
 
   ##


### PR DESCRIPTION
When a tlv response is created the request ID being responded to
needs to be copied into response created.


## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] **Verify** spot check various payload
