### PR TITLE
Linux Post check file exists before read

### DIFF
--- a/lib/msf/core/post/linux/system.rb
+++ b/lib/msf/core/post/linux/system.rb
@@ -86,12 +86,18 @@ module System
       version = read_file("/etc/gentoo-release").gsub(/\n|\\n|\\l/,'')
       system_data[:distro] = "gentoo"
       system_data[:version] = version
-    else
 
-      # Others
+    # Generic
+    elsif etc_files.include?("issue")
       version = read_file("/etc/issue").gsub(/\n|\\n|\\l/,'')
       system_data[:distro] = "linux"
       system_data[:version] = version
+
+    # Others, could be a mismatch like ssh_login to cisco device
+    else
+      system_data[:distro] = "linux"
+      system_data[:version] = ''
+
     end
     return system_data
   end


### PR DESCRIPTION
Fixes #8557 
This work was ENTIRELY done by @bcoles , I take NO credit for it.  Just PRing his changes since he's been super busy lately.
When exploiting a router via `ssh_login` or other similar module, the Post system will try to read the issues file, which wont exist on a router, and crash.
This is just like #9029 and #8987 

## Verification

- [x] Start `msfconsole`
- [x] pop a shell on a router type device
- [x] try any of the modules described as broken in #8557 (top or last posts shows them)
- [x] **Verify** crashes don't happen anymore (or at least in the same line of code)


