### PR TITLE
Make smb_login scanner proxy-aware again

### DIFF
--- a/modules/auxiliary/scanner/smb/smb_login.rb
+++ b/modules/auxiliary/scanner/smb/smb_login.rb
@@ -71,6 +71,7 @@ class MetasploitModule < Msf::Auxiliary
       port: rport,
       local_port: datastore['CPORT'],
       stop_on_success: datastore['STOP_ON_SUCCESS'],
+      proxies: datastore['PROXIES'],
       bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
       connection_timeout: 5,
       max_send_size: datastore['TCP::max_send_size'],


### PR DESCRIPTION
This PR makes the `smb_login` scanner module obey proxy settings. It fixes issue #9057. The following steps should trigger either a connection originating from the local system (without PR, unexpected) or a connection originating from the remote system (with PR, expected):

```
$ ssh -D 5555 jumphost
[switch window]
$ ./msfconsole
[...]
msf > use auxiliary/scanner/smb/smb_login
msf auxiliary(smb_login) > setg Proxies socks4:127.0.0.1:5555
Proxies => socks4:127.0.0.1:5555
msf auxiliary(smb_login) > set smbpass foobar
smbpass => foobar
msf auxiliary(smb_login) > set smbuser administrator
smbuser => administrator
msf auxiliary(smb_login) > set rhosts 10.0.0.233
rhosts => 10.0.0.233
msf auxiliary(smb_login) > run
```