### PR TITLE
add aggregator >= 1.0.0 with cryptTLV packet format

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,10 @@ group :development do
   # module documentation
   gem 'octokit'
   # Metasploit::Aggregator external session proxy
-  gem 'metasploit-aggregator'
+  gem 'metasploit-aggregator' if [
+    'x86-mingw32', 'x64-mingw32',
+    'x86_64-linux', 'x86-linux',
+    'darwin'].include?(RUBY_PLATFORM.gsub(/.*darwin.*/, 'darwin'))
 end
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -19,8 +19,7 @@ group :development do
   # module documentation
   gem 'octokit'
   # Metasploit::Aggregator external session proxy
-  # Disabled for now for crypttlv updates
-  # gem 'metasploit-aggregator'
+  gem 'metasploit-aggregator'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -363,7 +363,7 @@ PLATFORMS
 DEPENDENCIES
   factory_girl_rails
   fivemat
-  metasploit-aggregator (~> 1.0.0)
+  metasploit-aggregator
   metasploit-framework!
   octokit
   pry

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,15 +126,39 @@ GEM
     ffi (1.9.18)
     filesize (0.1.1)
     fivemat (1.3.5)
+    google-protobuf (3.4.1.1)
+    googleapis-common-protos-types (1.0.0)
+      google-protobuf (~> 3.0)
+    googleauth (0.5.3)
+      faraday (~> 0.12)
+      jwt (~> 1.4)
+      logging (~> 2.0)
+      memoist (~> 0.12)
+      multi_json (~> 1.11)
+      os (~> 0.9)
+      signet (~> 0.7)
+    grpc (1.6.6)
+      google-protobuf (~> 3.1)
+      googleapis-common-protos-types (~> 1.0.0)
+      googleauth (~> 0.5.1)
     hashery (2.1.2)
     i18n (0.8.6)
     jsobfu (0.4.2)
       rkelly-remix
     json (2.1.0)
+    jwt (1.5.6)
+    little-plugger (1.1.4)
+    logging (2.2.2)
+      little-plugger (~> 1.1)
+      multi_json (~> 1.10)
     loofah (2.1.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
+    memoist (0.16.0)
     metasm (1.0.3)
+    metasploit-aggregator (1.0.0)
+      grpc
+      rex-arch
     metasploit-concern (2.0.5)
       activemodel (~> 4.2.6)
       activesupport (~> 4.2.6)
@@ -168,6 +192,7 @@ GEM
     mini_portile2 (2.3.0)
     minitest (5.10.3)
     msgpack (1.1.0)
+    multi_json (1.12.2)
     multipart-post (2.0.0)
     nessus_rest (0.1.6)
     net-ssh (4.2.0)
@@ -179,6 +204,7 @@ GEM
       sawyer (~> 0.8.0, >= 0.5.3)
     openssl-ccm (1.2.1)
     openvas-omp (0.0.4)
+    os (0.9.6)
     packetfu (1.1.13)
       pcaprub
     patch_finder (1.0.2)
@@ -304,6 +330,11 @@ GEM
     sawyer (0.8.1)
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)
+    signet (0.7.3)
+      addressable (~> 2.3)
+      faraday (~> 0.9)
+      jwt (~> 1.5)
+      multi_json (~> 1.10)
     simplecov (0.15.1)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
@@ -332,6 +363,7 @@ PLATFORMS
 DEPENDENCIES
   factory_girl_rails
   fivemat
+  metasploit-aggregator (~> 1.0.0)
   metasploit-framework!
   octokit
   pry


### PR DESCRIPTION
Restore aggregator functionality with cryptTLV suppression add in metasploit-aggregator gem version 1.0.0.

When using an aggregator to share sessions fallback to TLV XOR obfuscation method in the transport layer to gain benefits of sharing across consoles.  This is reflected in the console session details showing the session is not encrypted even when the target meterpreter is capable of negotiating end to end encryption on TLV transport.

## Verification

List the steps needed to make sure this thing works

Verification from https://github.com/rapid7/metasploit-framework/pull/7902 for newly built meterpreter_reverse_https payloads including windows.

