### PR TITLE
Fixing undefined local variable in timestomp.rb and the passing of Time object instances to string function 

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/priv/timestomp.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/priv/timestomp.rb
@@ -113,7 +113,6 @@ module Rex
 
             paths.uniq.each do |path|
 
-              print_status("Setting MACE attributes on #{path}")
               # If any one of the four times were specified, change them.
               if modified || accessed || creation || emodified
                 print_status("Setting specific MACE attributes on #{path}")

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/priv/timestomp.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/priv/timestomp.rb
@@ -78,13 +78,13 @@ module Rex
                 creation  = str_to_time(val)
                 emodified = str_to_time(val)
               when "-f"
-                print_status("Setting MACE attributes on #{path} from #{val}")
-                hash = client.priv.fs.get_file_mace(path)
+                print_status("Pulling MACE attributes from #{val}")
+                hash = client.priv.fs.get_file_mace(val)
                 if hash
-                  modified = str_to_time(hash['Modified'])
-                  accessed = str_to_time(hash['Accessed'])
-                  creation = str_to_time(hash['Created'])
-                  emodified = str_to_time(hash['Entry Modified'])
+                  modified = hash['Modified']
+                  accessed = hash['Accessed']
+                  creation = hash['Created']
+                  emodified = hash['Entry Modified']
                 end
               when "-b"
                 blank_file_mace = true
@@ -112,6 +112,8 @@ module Rex
             end
 
             paths.uniq.each do |path|
+
+              print_status("Setting MACE attributes on #{path}")
               # If any one of the four times were specified, change them.
               if modified || accessed || creation || emodified
                 print_status("Setting specific MACE attributes on #{path}")


### PR DESCRIPTION
This pull request fixes an undefined local variable error for the "path" variable in timestomp.rb when utilizing the "-f" command line parameter. I believe the bug was introduced in #8897 when it was merged on Sept 1.

Additionally `client.priv.fs.get_file_mace` already returns a Time object instance, so no need to pass the values to `str_to_time`

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Obtain a meterpreter session
- [x] `timestomp file1.txt -f "c:\\path\\to\\file2.txt"`
- [x] There should no longer be an undefined local variable error or a Method error

## Original bug screenshots

![bug](https://user-images.githubusercontent.com/12598313/31444076-21ab83b8-ae69-11e7-9d3b-686848e0e15c.PNG)

![bug2](https://user-images.githubusercontent.com/12598313/31444165-68781982-ae69-11e7-8f6c-c2d2feb8a348.PNG)

## Fixed screenshot

![fixed](https://user-images.githubusercontent.com/12598313/31445653-74b7708c-ae6c-11e7-8b53-1fd1f6778894.PNG)

