### PR TITLE
gopher protocol scanner

### DIFF
--- a/documentation/modules/auxiliary/scanner/gopher/gopher_gophermap.md
+++ b/documentation/modules/auxiliary/scanner/gopher/gopher_gophermap.md
@@ -3,6 +3,35 @@
   Any gopher server will work.  There seems to only be [a few left](https://en.wikipedia.org/wiki/Gopher_(protocol)#Server_software)
    in 2017.
 
+  A few options for local installation and testing are below.
+
+### Docker Install
+
+A dockerized gopher server, written in Go of all things, is available.  To install and run this, with content being
+served out of a temporary directory in which you'll be left:
+
+```
+$  docker pull prodhe/gopher
+Using default tag: latest
+latest: Pulling from prodhe/gopher
+627beaf3eaaf: Already exists
+8800e3417eb1: Pull complete
+d9f3bcdad0eb: Pull complete
+c018073abd26: Pull complete
+b2855f535c50: Pull complete
+23480a2f73d8: Pull complete
+1555a5435ec5: Pull complete
+0728d289e0fc: Pull complete
+6f6f265b58ee: Pull complete
+Digest: sha256:69931d56946d192d9bd155a88b6f365cb276e9edf453129d374e64d244d1edaa
+Status: Downloaded newer image for prodhe/gopher:latest
+$  cd `mktemp -d`;
+$  sudo docker run --rm -d -it --name gopher_test -v `pwd -P`:/public  -p 70:70  prodhe/gopher
+2017/10/20 16:45:01 Serving /public/ at localhost:70
+$ date > test.txt
+$ echo HELLO > README.md
+```
+
 ### Ubuntu 16.04 Install
 
 First we need to install the server:
@@ -67,15 +96,26 @@ The following table contains the file types associated with the characters:
 
   **PATH**
 
-  It is possible to view content within a directory of the gophermap.  If the intial run shows directory `Directory: foobar`, 
+  It is possible to view content within a directory of the gophermap.  If the intial run shows directory `Directory: foobar`,
   setting **path** to `/foobar` will enumerate the contents of that folder.  Default: [empty string].
 
 ## Scenarios
 
+### Docker Gopher Server
+```
+msf auxiliary(gopher_gophermap) > run
+
+[+] 127.0.0.1:70          -   Text file: README.md
+[+] 127.0.0.1:70          -     Path: localhost:70/README.md
+[+] 127.0.0.1:70          -   Text file: test.txt
+[+] 127.0.0.1:70          -     Path: localhost:70/test.txt
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```
 ### Gopher-server on Ubuntu 16.04
 
 ```
-msf > use auxiliary/scanner/gopher/gopher_gophermap 
+msf > use auxiliary/scanner/gopher/gopher_gophermap
 msf auxiliary(gopher_gophermap) > set rhosts 1.1.1.1
 rhosts => 1.1.1.1
 msf auxiliary(gopher_gophermap) > set verbose true
@@ -83,7 +123,7 @@ verbose => true
 msf auxiliary(gopher_gophermap) > run
 
 [+] 1.1.1.1:70      - gopher custom gophermap
-[+] 1.1.1.1:70      - 
+[+] 1.1.1.1:70      -
 [+] 1.1.1.1:70      -   HTML: Hello World
 [+] 1.1.1.1:70      -     Path: 1.1.1.1:70/example.html
 [+] 1.1.1.1:70      -   Text file: Foo File

--- a/documentation/modules/auxiliary/scanner/gopher/gopher_gophermap.md
+++ b/documentation/modules/auxiliary/scanner/gopher/gopher_gophermap.md
@@ -1,0 +1,98 @@
+## Vulnerable Application
+
+  Any gopher server will work.  There seems to only be [a few left](https://en.wikipedia.org/wiki/Gopher_(protocol)#Server_software)
+   in 2017.
+
+### Ubuntu 16.04 Install
+
+First we need to install the server:
+
+```
+sudo apt-get install gopher-server
+```
+Next, we need to build content for the scanner to find.  Gopher works off of a `gophermap`, somewhat similar
+to a content index page, where files are listed in a menu type system.
+
+```
+echo "<html><h1>hello world</h1></html>" | sudo tee /var/gopher/example.html
+echo "foobarbaz" | sudo tee /var/gopher/foobar.txt
+sudo mkdir /var/gopher/msf
+echo "meterpreter rules" | sudo tee /var/gopher/msf/meterp.txt
+sudo wget "https://pbs.twimg.com/profile_images/580131056629735424/2ENTk2K2.png" -O /var/gopher/msf/logo.png
+
+echo -ne "gopher custom gophermap\n\nhHello World\t/example.html\t1.1.1.1\t70\n0Foo File\t/foobar.txt\t1.1.1.1\t70\n1msf\t/msf\t1.1.1.1\t70\nhmetasploit homepage\tURL:http://metasploit.com/\n" | sudo tee /var/gopher/gophermap
+sudo chmod +r -R /var/gopher
+```
+
+In this case we create an html file, text file, a directory with a text file and png file in it.  Enough content so its nice to look at.
+Next we write our `gophermap` file.  The first line is just an intro.  After that, we list our files that the client can access.
+
+The format of these lines is: `XSome text here[TAB]/path/to/content[TAB]example.org[TAB]port`.  The first character, `X` is the file type
+which can be referenced in the table below.  The final address (example.org) and PORT are optional.
+
+The following table contains the file types associated with the characters:
+
+| Itemtype | Content                         |
+|----------|---------------------------------|
+| 0        | Text file                       |
+| 1        | Directory                       |
+| 2        | CSO name server                 |
+| 3        | Error                           |
+| 4        | Mac HQX filer                   |
+| 5        | PC binary                       |
+| 6        | UNIX uuencoded file             |
+| 7        | Search server                   |
+| 8        | Telnet Session                  |
+| 9        | Binary File                     |
+| c        | Calendar (not in 2.06)          |
+| e        | Event (not in 2.06)             |
+| g        | GIF image                       |
+| h        | HTML, Hypertext Markup Language |
+| i        | inline text type              |
+| s        | Sound                           |
+| I        | Image (other than GIF)          |
+| M        | MIME multipart/mixed message    |
+| T        | TN3270 Session                  |
+
+## Verification Steps
+
+  1. Install the application
+  2. Start msfconsole
+  3. Do: ```use auxiliary/scanner/gopher/gopher_gophermap```
+  4. Do: ```set rhosts [IPs]```
+  5. Do: ```run```
+  6. You should see the gophermap file printed in a parsed format
+
+## Options
+
+  **PATH**
+
+  It is possible to view content within a directory of the gophermap.  If the intial run shows directory `Directory: foobar`, 
+  setting **path** to `/foobar` will enumerate the contents of that folder.  Default: [empty string].
+
+## Scenarios
+
+### Gopher-server on Ubuntu 16.04
+
+```
+msf > use auxiliary/scanner/gopher/gopher_gophermap 
+msf auxiliary(gopher_gophermap) > set rhosts 192.168.2.137
+rhosts => 192.168.2.137
+msf auxiliary(gopher_gophermap) > set verbose true
+verbose => true
+msf auxiliary(gopher_gophermap) > run
+
+[+] 1.1.1.1:70      - gopher custom gophermap
+[+] 1.1.1.1:70      - 
+[+] 1.1.1.1:70      -   HTML: Hello World
+[+] 1.1.1.1:70      -     Path: 1.1.1.1:70/example.html
+[+] 1.1.1.1:70      -   Text file: Foo File
+[+] 1.1.1.1:70      -     Path: 1.1.1.1:70/foobar.txt
+[+] 1.1.1.1:70      -   Directory: msf
+[+] 1.1.1.1:70      -     Path: 1.1.1.1:70/msf
+[+] 1.1.1.1:70      -   HTML: metasploit homepage
+[+] 1.1.1.1:70      -     Path: 1.1.1.1:70/URL:http://metasploit.com/
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+
+```

--- a/documentation/modules/auxiliary/scanner/gopher/gopher_gophermap.md
+++ b/documentation/modules/auxiliary/scanner/gopher/gopher_gophermap.md
@@ -103,6 +103,9 @@ The following table contains the file types associated with the characters:
 
 ### Docker Gopher Server
 ```
+msf > use auxiliary/scanner/gopher/gopher_gophermap
+msf auxiliary(gopher_gophermap) > set RHOSTS localhost
+RHOSTS => localhost
 msf auxiliary(gopher_gophermap) > run
 
 [+] 127.0.0.1:70          -   Text file: README.md

--- a/documentation/modules/auxiliary/scanner/gopher/gopher_gophermap.md
+++ b/documentation/modules/auxiliary/scanner/gopher/gopher_gophermap.md
@@ -76,8 +76,8 @@ The following table contains the file types associated with the characters:
 
 ```
 msf > use auxiliary/scanner/gopher/gopher_gophermap 
-msf auxiliary(gopher_gophermap) > set rhosts 192.168.2.137
-rhosts => 192.168.2.137
+msf auxiliary(gopher_gophermap) > set rhosts 1.1.1.1
+rhosts => 1.1.1.1
 msf auxiliary(gopher_gophermap) > set verbose true
 verbose => true
 msf auxiliary(gopher_gophermap) > run

--- a/documentation/modules/auxiliary/scanner/gopher/gopher_gophermap.md
+++ b/documentation/modules/auxiliary/scanner/gopher/gopher_gophermap.md
@@ -7,7 +7,7 @@
 
 ### Docker Install
 
-A dockerized gopher server, written in Go of all things, is available.  To install and run this, with content being
+A [dockerized gopher server written in Go](https://hub.docker.com/r/prodhe/gopher/) is available.  To install and run this, with content being
 served out of a temporary directory in which you'll be left:
 
 ```

--- a/documentation/modules/auxiliary/scanner/gopher/gopher_gophermap.md
+++ b/documentation/modules/auxiliary/scanner/gopher/gopher_gophermap.md
@@ -32,6 +32,13 @@ $ date > test.txt
 $ echo HELLO > README.md
 ```
 
+*NOTE*: Don't forget to `docker stop` the container ID returned from the `docker run` command just run above:
+```
+$ docker stop X
+X
+```
+
+
 ### Ubuntu 16.04 Install
 
 First we need to install the server:

--- a/modules/auxiliary/scanner/gopher/gopher_gophermap.rb
+++ b/modules/auxiliary/scanner/gopher/gopher_gophermap.rb
@@ -1,0 +1,99 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::Scanner
+
+  def initialize
+    super(
+      'Name'        => 'Gopher gophermap Scanner',
+      'Description' => %q{
+        This module identifies Gopher servers, and processes the gophermap
+        file which lists all the files on the server.
+      },
+      'References'  =>
+        [
+          ['URL', 'https://sdfeu.org/w/tutorials:gopher'],
+        ],
+      'Author'      => 'h00die',
+      'License'     => MSF_LICENSE
+    )
+
+    register_options([
+      Opt::RPORT(70),
+      OptString.new('PATH',[false,'Path to enumerate',''])
+    ])
+
+  end
+
+  def get_type(char)
+    return {'0' => 'Text file',
+            '1' => 'Directory',
+            '2' => 'CSO name server',
+            '3' => 'Error',
+            '4' => 'Mac HQX filer',
+            '5' => 'PC binary',
+            '6' => 'UNIX uuencoded file',
+            '7' => 'Search server',
+            '8' => 'Telnet Session',
+            '9' => 'Binary File',
+            'c' => 'Calendar',
+            'e' => 'Event',
+            'g' => 'GIF image',
+            'h' => 'HTML',
+            'i' => 'inline text',
+            's' => 'Sound',
+            'I' => 'Image',
+            'M' => 'MIME multipart/mixed message',
+            'T' => 'TN3270 Session'}.fetch(char.chomp)
+  end
+
+  def run_host(ip)
+    begin
+      connect
+      sock.put("#{datastore['path']}\r\n")
+      gophermap = sock.get_once
+      if gophermap
+        gophermap.split("\r\n").each do |line|
+          if line.split("\t").length >= 2
+            # syntax: [type_character]description[tab]path[tab, after this is optional]server[tab]port
+            line = line.split("\t")
+            desc = line[0]
+            type_char = desc.slice!(0) #remove first character which is the file type
+            file_type = get_type(type_char)
+            if file_type && file_type == 'inline text'
+              print_good(desc)
+              next
+            end
+            if file_type
+              print_good("  #{file_type}: #{desc}")
+            else
+              print_good("  Invalid File Type (#{type_char}): #{desc}")
+            end
+            if line.length >= 3
+              print_good("    Path: #{line[2]}:#{line[3]}#{line[1]}")
+            elsif line.length >= 2
+              print_good("    Path: #{line[2]}#{line[1]}")
+            else
+              print_good("    Path: #{line[1]}")
+
+            end
+          end
+        end
+        report_service(:host => ip, :port => rport, :name => 'gopher', :info => gophermap)
+      else
+        print_error('No gophermap')
+      end
+    rescue ::Rex::ConnectionError, ::IOError, ::Errno::ECONNRESET
+    rescue ::Exception => e
+      print_error("#{ip}: #{e} #{e.backtrace}")
+    ensure
+      disconnect
+    end
+  end
+
+end

--- a/modules/auxiliary/scanner/gopher/gopher_gophermap.rb
+++ b/modules/auxiliary/scanner/gopher/gopher_gophermap.rb
@@ -11,45 +11,50 @@ class MetasploitModule < Msf::Auxiliary
   def initialize
     super(
       'Name'        => 'Gopher gophermap Scanner',
-      'Description' => %q{
+      'Description' => %q(
         This module identifies Gopher servers, and processes the gophermap
         file which lists all the files on the server.
-      },
+      ),
       'References'  =>
         [
-          ['URL', 'https://sdfeu.org/w/tutorials:gopher'],
+          ['URL', 'https://sdfeu.org/w/tutorials:gopher']
         ],
       'Author'      => 'h00die',
       'License'     => MSF_LICENSE
     )
 
-    register_options([
-      Opt::RPORT(70),
-      OptString.new('PATH',[false,'Path to enumerate',''])
-    ])
-
+    register_options(
+      [
+        Opt::RPORT(70),
+        OptString.new('PATH', [false, 'Path to enumerate', ''])
+      ]
+    )
   end
 
+  TYPE_MAP = {
+    '0' => 'Text file',
+    '1' => 'Directory',
+    '2' => 'CSO name server',
+    '3' => 'Error',
+    '4' => 'Mac HQX filer',
+    '5' => 'PC binary',
+    '6' => 'UNIX uuencoded file',
+    '7' => 'Search server',
+    '8' => 'Telnet Session',
+    '9' => 'Binary File',
+    'c' => 'Calendar',
+    'e' => 'Event',
+    'g' => 'GIF image',
+    'h' => 'HTML',
+    'i' => 'inline text',
+    's' => 'Sound',
+    'I' => 'Image',
+    'M' => 'MIME multipart/mixed message',
+    'T' => 'TN3270 Session'
+  }.freeze
+
   def get_type(char)
-    return {'0' => 'Text file',
-            '1' => 'Directory',
-            '2' => 'CSO name server',
-            '3' => 'Error',
-            '4' => 'Mac HQX filer',
-            '5' => 'PC binary',
-            '6' => 'UNIX uuencoded file',
-            '7' => 'Search server',
-            '8' => 'Telnet Session',
-            '9' => 'Binary File',
-            'c' => 'Calendar',
-            'e' => 'Event',
-            'g' => 'GIF image',
-            'h' => 'HTML',
-            'i' => 'inline text',
-            's' => 'Sound',
-            'I' => 'Image',
-            'M' => 'MIME multipart/mixed message',
-            'T' => 'TN3270 Session'}.fetch(char.chomp)
+    TYPE_MAP.fetch(char.chomp)
   end
 
   def run_host(ip)
@@ -59,32 +64,32 @@ class MetasploitModule < Msf::Auxiliary
       gophermap = sock.get_once
       if gophermap
         gophermap.split("\r\n").each do |line|
-          if line.split("\t").length >= 2
-            # syntax: [type_character]description[tab]path[tab, after this is optional]server[tab]port
-            line = line.split("\t")
-            desc = line[0]
-            type_char = desc.slice!(0) #remove first character which is the file type
-            file_type = get_type(type_char)
-            if file_type && file_type == 'inline text'
-              print_good(desc)
-              next
-            end
-            if file_type
-              print_good("  #{file_type}: #{desc}")
-            else
-              print_good("  Invalid File Type (#{type_char}): #{desc}")
-            end
-            if line.length >= 3
-              print_good("    Path: #{line[2]}:#{line[3]}#{line[1]}")
-            elsif line.length >= 2
-              print_good("    Path: #{line[2]}#{line[1]}")
-            else
-              print_good("    Path: #{line[1]}")
+          line_parts = line.split("\t")
+          next unless line_parts.length >= 2
+          # syntax: [type_character]description[tab]path[tab, after this is optional]server[tab]port
+          line_parts = line.split("\t")
+          desc = line_parts[0]
+          type_char = desc.slice!(0) # remove first character which is the file type
+          file_type = get_type(type_char)
+          if file_type && file_type == 'inline text'
+            print_good(desc)
+            next
+          end
+          if file_type
+            print_good("  #{file_type}: #{desc}")
+          else
+            print_good("  Invalid File Type (#{type_char}): #{desc}")
+          end
+          if line_parts.length >= 3
+            print_good("    Path: #{line_parts[2]}:#{line_parts[3]}#{line_parts[1]}")
+          elsif line.length >= 2
+            print_good("    Path: #{line_parts[2]}#{line_parts[1]}")
+          else
+            print_good("    Path: #{line_parts[1]}")
 
-            end
           end
         end
-        report_service(:host => ip, :port => rport, :name => 'gopher', :info => gophermap)
+        report_service(host: ip, port: rport, service: 'gopher', info: gophermap)
       else
         print_error('No gophermap')
       end
@@ -95,5 +100,4 @@ class MetasploitModule < Msf::Auxiliary
       disconnect
     end
   end
-
 end


### PR DESCRIPTION
Um, yes.  [gopher](https://en.wikipedia.org/wiki/Gopher_(protocol)) from 1991, you know the thing that lost out to http.  Well, there seems to still be ~150 servers known in the world, so we may as well have a scanner.  I didn't bother making a lib since its VERY unlikely any other module will ever need any of this.

This module connects to the gopher server and retrieves the gophermap, which is similar to a document index.  it is also possible to "browse" to other directories via the path variable.

Docs contain info on setting up a server w/ content.

## Verification

- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/gopher/gopher_gophermap`
- [x] `set rhosts [ips]`
- [x] `run`
- [x] **Verify** You see the contents of the gophermap
- [x] **Verify** if your DB is connected, the service shows up 
- [x] **Document** make sure the docs are good and clear