### PR TITLE
ensure we do autoruns for all session types

### DIFF
--- a/lib/msf/core/handler.rb
+++ b/lib/msf/core/handler.rb
@@ -247,6 +247,10 @@ protected
     if session.respond_to?(:bootstrap)
       session.bootstrap(datastore, self)
     else
+      # Process the auto-run scripts for this session
+      if self.respond_to?(:process_autoruns)
+        self.process_autoruns(datastore)
+      end
       on_session(session)
     end
 


### PR DESCRIPTION
This should fixup automatic script running for all non-Meterpreter session types. This fixes #8704 and probably others. CC @wvu and @sinn3r 

## Verification

List the steps needed to make sure this thing works

- [x] Get a non-meterpreter session
- [x] Setup autorun scripts
- [x] **Verify** that autoruns work as expected
