### PR TITLE
Bug Fix ftp.rb so it closes all data sockets

### DIFF
--- a/lib/msf/core/exploit/ftp.rb
+++ b/lib/msf/core/exploit/ftp.rb
@@ -96,8 +96,14 @@ module Exploit::Remote::Ftp
   # This method handles disconnecting our data channel
   #
   def data_disconnect
-    self.datasocket.shutdown if self.datasocket
-    self.datasocket = nil
+    begin
+      if datasocket
+        datasocket.shutdown
+        datasocket.close
+      end
+    rescue IOError
+    end
+    datasocket = nil if datasocket
   end
 
   #


### PR DESCRIPTION
## Summary
lib/msf/core/exploit/ftp.rb was doing a shutdown without a close on data (not command) sockets.  This can cause CLOSE_WAIT for extended periods in certain circumstances-ending
only when msf itself is closed.

This is a bug fix, however no bug report was opened - can do so if needed.

Issue presented itself after implementing change in other [PR# 9081](https://github.com/rapid7/metasploit-framework/pull/9081).  That PR changes method of getting data via ftp from  Rex::Socket::TCP method "get_once" to "get" method in send_cmd_data in lib/msf/core/exploits/ftp.rb
After that change, I noticed a couple CLOSE_WAIT data sockets that would not end until I exited msfconsole - not good.  

Dug in and realized that the data sockets are not being killed correctly.  They're being shutdown (fine) but also need to be closed to properly terminate.

## Issue generated by "get" vs "get_once" OR Delay from FIN to Shutdown
- The issue comes in the delay between the client data socket getting the FIN from the server (triggers CLOSE_WAIT per RFC) and when the data is actually read from the socket, socket shutdown, then data read from socket.  In a very brief interaction such as an FTP "ls" or "get" of very small file - the socket will close normally - this is more of luck/timing.
- However, if the shutdown occurs and the subsequent read of the socket takes longer, multiple blocks, or if time introduced via debugger (below) then the socket never closes normally until msf exit (stuck in CLOSE_WAIT).
- Shutdown, per documentation [link to Socket Shutdown vs Close](http://beej.us/guide/bgnet/output/html/singlepage/bgnet.html#closedown) doesn't actually close the fd - only close does that.  See line 173 in tcp.rb in msf for example (that's also the basis for this PR's code)


## To recreate issue with a debugger

- [x] add debugger gem for this operation `bundle add pry-byebug`
- [x] add require `require 'pry-byebug` to ftp.rb (this file)
```
  2 module Msf
  3
  4 require 'msf/core/exploit/tcp'
  5 require 'pry-byebug'
  6
  7 ###
```
- [x] Insert a `binding.pry` in the ftp.rb at the beginning of the `def data_disconnect` function
```
 98:   def data_disconnect
   ---> binding.pry
 99:     begin
100:       if datasocket
101:         datasocket.shutdown
102:         datasocket.close
```
- [x] Set up a watcher for socket/status on the os, in my mac I do something like:
 `while true; do clear;lsof -i4 -n -P|grep -E "10.10.10\.17"|awk '{ print $9 $10 }'; sleep 1; done`
- [x] This will yield output like (at various points into running the exploit):
```
10.10.10.250:51761->10.10.10.17:21(ESTABLISHED)
```
- [x] Start `msfconsole`
- [x] Load an exploit which uses ftp (I'm  using `exploit/mainframe/ftp/ftp_jcl_creds`)
- [x] Set up the options, payloads and `run`
- [x] First stop at breakpoint is a "put" so this will not trigger the condition, type `continue`
- [x] Running the exploit, when the code stops at the breakpoint just continue
- [x] Second stop does a get (FTP RETR) and yields the condition in our monitor.
```
10.10.10.250:51761->10.10.10.17:21(ESTABLISHED)
10.10.10.250:51780->10.10.10.17:1663(CLOSE_WAIT)
```
- [x] Type `break 104` then `continue`
- [ ] Now here:     **Notice you're past the shutdown and the socket monitor is still "CLOSE_WAIT"
```
>> break 104
     99: def data_disconnect
    100:   binding.pry
    101:   begin
    102:     if datasocket
    103:       datasocket.shutdown
 => 104:       datasocket.close
    105:     end
    106:   rescue IOError
    107:   end
    108:   datasocket = nil if datasocket
    109: end
```
- [x] Type `next` to advance past the datasocket.close and you'll notice the datasocket is gone on your monitor script.
- [x] At this point continue or quit.

### Last, here's a video of the above in action
![close](https://user-images.githubusercontent.com/13771080/31558381-3f2c7906-b012-11e7-8398-50e38c41f85a.gif)
