### PR TITLE
Make pop3_login scanner proxy-aware again

### DIFF
--- a/modules/auxiliary/scanner/pop3/pop3_login.rb
+++ b/modules/auxiliary/scanner/pop3/pop3_login.rb
@@ -65,6 +65,7 @@ class MetasploitModule < Msf::Auxiliary
     scanner = Metasploit::Framework::LoginScanner::POP3.new(
       host: ip,
       port: rport,
+      proxies: datastore['PROXIES'],
       ssl: datastore['SSL'],
       cred_details: cred_collection,
       stop_on_success: datastore['STOP_ON_SUCCESS'],


### PR DESCRIPTION
This PR makes the `pop3_login` scanner module obey proxy settings. It fixes an issue tracked in #9057. Please see #9057 on how to reproduce this.