### PR TITLE
Make nessus_rest_login scanner proxy-aware again

### DIFF
--- a/modules/auxiliary/scanner/nessus/nessus_rest_login.rb
+++ b/modules/auxiliary/scanner/nessus/nessus_rest_login.rb
@@ -51,6 +51,7 @@ class MetasploitModule < Msf::Auxiliary
         host: ip,
         port: datastore['RPORT'],
         uri: datastore['TARGETURI'],
+        proxies: datastore['PROXIES'],
         cred_details:       @cred_collection,
         stop_on_success:    datastore['STOP_ON_SUCCESS'],
         bruteforce_speed:   datastore['BRUTEFORCE_SPEED'],


### PR DESCRIPTION
This PR makes the `nessus_rest_login` scanner module obey proxy settings. It fixes an issue tracked in #9057. Please see #9057 on how to reproduce this.