### PR TITLE
add missing method to_linux_x86_elf_dll

### DIFF
--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -1100,6 +1100,17 @@ require 'msf/core/exe/segment_appender'
     to_exe_elf(framework, opts, "template_x64_linux.bin", code)
   end
 
+  # Create a 32-bit Linux ELF_DYN containing the payload provided in +code+
+  #
+  # @param framework [Msf::Framework]
+  # @param code       [String]
+  # @param opts       [Hash]
+  # @option           [String] :template
+  # @return           [String] Returns an elf
+  def self.to_linux_x86_elf_dll(framework, code, opts = {})
+    to_exe_elf(framework, opts, "template_x86_linux_dll.bin", code)
+  end
+
   # Create a 64-bit Linux ELF_DYN containing the payload provided in +code+
   #
   # @param framework [Msf::Framework]


### PR DESCRIPTION
I was using msfvenom as follows:
`msfvenom -a x86 --platform linux -f elf-so -p linux/x86/adduser`
It failed with:
```
Error: undefined method `to_linux_x86_elf_dll' for Msf::Util::EXE:Class
Did you mean?  to_linux_x64_elf_dll
               to_linux_x86_elf
```
It looked like the formulaic method definition for `to_linux_x86_elf_dll` was missing, even though the template file `template_x86_linux_dll.bin` was there. Therefore, I added the method.



## Verification

After this change, the command above seems to produce a valid ELF-32 shared object.

- [x] Start `msfconsole`
- [x] Start `msfvenom -a x86 --platform linux -f elf-so -p linux/x86/adduser `
- [x] **Verify** the thing does what it should

