### PR TITLE
Provide disconnect option to send_request_cgi

### DIFF
--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -334,7 +334,7 @@ module Exploit::Remote::HttpClient
   # Passes `opts` through directly to {Rex::Proto::Http::Client#request_cgi}.
   #
   # @return (see Rex::Proto::Http::Client#send_recv))
-  def send_request_cgi(opts={}, timeout = 20)
+  def send_request_cgi(opts={}, timeout = 20, disconnect = true)
     if datastore['HttpClientTimeout'] && datastore['HttpClientTimeout'] > 0
       actual_timeout = datastore['HttpClientTimeout']
     else
@@ -362,7 +362,7 @@ module Exploit::Remote::HttpClient
         print_line('#' * 20)
         print_line(res.to_terminal_output)
       end
-      disconnect(c)
+      disconnect(c) if disconnect
       res
     rescue ::Errno::EPIPE, ::Timeout::Error => e
       print_line(e.message) if datastore['HttpTrace']


### PR DESCRIPTION
The HTTP client mixin provides a #send_request_cgi method which
forcibly disconnects the client after receiving a response. This
terminates certain types of resulting sessions which depend on the
connection from the client to maintain a subprocess housing the
shell invocation.

Provide a disconnect boolean option to #send_request_cgi which
is checked in the disconnect(c) call after receiving the response.

Testing:
  Locally tested on in-house exploit module written for disclosure
report.

TODO:
  Discuss possibility of implementing fully asynchronous methods
like #send_request_cgi_async which won't bother getting a response
for cases such as the module mentioned above which is a command
injection via unfiltered POST var.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] pry any module which has send_request_cgi
- [ ] make the request with the new last parameter set to false
- [ ] **Verify** the client is still connected after the method returns

