### PR TITLE
add MinRID to complement MaxRID, allowing continuing or starting from a higher value

### DIFF
--- a/modules/auxiliary/scanner/smb/smb_lookupsid.rb
+++ b/modules/auxiliary/scanner/smb/smb_lookupsid.rb
@@ -39,6 +39,7 @@ class MetasploitModule < Msf::Auxiliary
 
     register_options(
       [
+        OptInt.new('MinRID', [ false, "Starting RID to check", 500 ]),
         OptInt.new('MaxRID', [ false, "Maximum RID to check", 4000 ])
       ],
       self.class
@@ -140,7 +141,6 @@ class MetasploitModule < Msf::Auxiliary
 
   # Fingerprint a single host
   def run_host(ip)
-
     [[139, false], [445, true]].each do |info|
 
     @rport = info[0]
@@ -227,8 +227,10 @@ class MetasploitModule < Msf::Auxiliary
         domain_sid || host_sid
       end
 
+      min_rid = datastore['MinRID']
       # Brute force through a common RID range
-      500.upto(datastore['MaxRID'].to_i) do |rid|
+
+      min_rid.upto(datastore['MaxRID']) do |rid|
 
         stub =
           phandle +
@@ -243,7 +245,6 @@ class MetasploitModule < Msf::Auxiliary
           NDR.long(0) +
           NDR.long(1) +
           NDR.long(0)
-
 
         dcerpc.call(15, stub)
         resp = dcerpc.last_response ? dcerpc.last_response.stub_data : nil
@@ -295,6 +296,4 @@ class MetasploitModule < Msf::Auxiliary
     end
     end
   end
-
-
 end


### PR DESCRIPTION
from @lvarela-r7, this adds a minRID option to allow performing partial scans, and then later resuming them from the previous maxRID value.

## Verification

- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/smb/smb_lookupsid`
- [x] Connect to a domain and scan
- [x] **Verify** that the min and maxRID values work as expected
