### PR TITLE
Fix #8436, allow session upgrading on meterpreter sessions

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1443,14 +1443,9 @@ class Core
             session.response_timeout = response_timeout
           end
           begin
-            if ['shell', 'powershell'].include?(session.type)
-              session.init_ui(driver.input, driver.output)
-              session.execute_script('post/multi/manage/shell_to_meterpreter')
-              session.reset_ui
-            else
-              print_error("Session #{sess_id} is not a command shell session, it is #{session.type}, skipping...")
-              next
-            end
+            session.init_ui(driver.input, driver.output)
+            session.execute_script('post/multi/manage/shell_to_meterpreter')
+            session.reset_ui
           ensure
             if session.respond_to?(:response_timeout) && last_known_timeout
               session.response_timeout = last_known_timeout

--- a/modules/post/multi/manage/shell_to_meterpreter.rb
+++ b/modules/post/multi/manage/shell_to_meterpreter.rb
@@ -52,11 +52,6 @@ class MetasploitModule < Msf::Post
   def run
     print_status("Upgrading session ID: #{datastore['SESSION']}")
 
-    if session.type =~ /meterpreter/
-      print_error("Shell is already Meterpreter.")
-      return nil
-    end
-
     # Try hard to find a valid LHOST value in order to
     # make running 'sessions -u' as robust as possible.
     if datastore['LHOST']


### PR DESCRIPTION
This removes the shell check for `sessions -u`, which should allow you to upgrade, e.g a python meterpreter to a native linux/windows meterpreter.
There is likely to be reasons why this won't work, e.g on Windows I think we need to remove the %COMSPEC%, and on Android we need to use a different directory.
Perhaps we can land this and address those issues separately.
This may also allow you to duplicate a session by upgrading it.