### PR TITLE
Bump rex-socket to pick up better certs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -288,7 +288,7 @@ GEM
       metasm
       rex-core
       rex-text
-    rex-socket (0.1.8)
+    rex-socket (0.1.9)
       rex-core
     rex-sslscan (0.1.5)
       rex-core


### PR DESCRIPTION
Bump rex-socket to take advantage of improved (fake) ssl certs from https://github.com/rapid7/rex-socket/pull/7


## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use exploit/multi/handler`
- [x] `set payload multi/meterpreter/reverse_https`
- [x] `set LHOST 127.0.0.1`
- [x] `set LPORT 4444`
- [x] `openssl s_client -connect 127.0.0.1:4444`
- [x] **Verify** more magical cert details
