### PR TITLE
New resource script to check for development-related vulns.

### DIFF
--- a/scripts/resource/dev_checks.rc
+++ b/scripts/resource/dev_checks.rc
@@ -91,7 +91,7 @@ def main
           'multi/http/vbulletin_unserialize':     [ Exploit::CheckCode::Appears ],
           'unix/webapp/vbulletin_vote_sqli_exec': [ Exploit::CheckCode::Appears ],
           'multi/misc/java_jmx_server':           [ Exploit::CheckCode::Appears,
-						    Exploit::CheckCode::Detected ] }.each do |mod,ret_val|
+                                                    Exploit::CheckCode::Detected ] }.each do |mod,ret_val|
             check_exploit(host: host,
                 mod_name: mod.to_s,
                 vuln_check_ret_val: ret_val)

--- a/scripts/resource/dev_checks.rc
+++ b/scripts/resource/dev_checks.rc
@@ -20,7 +20,7 @@
 @job_ids = []
 
 def wait_until_jobs_done
-    while true
+    loop do
         @job_ids.each do |job_id|
             current_job_ids = framework.jobs.keys.map { |e| e.to_i }
             sleep 1 if current_job_ids.include?(job_id)

--- a/scripts/resource/dev_checks.rc
+++ b/scripts/resource/dev_checks.rc
@@ -12,8 +12,9 @@
 # It is worth noting that ONLY CHECKS are performed, no active exploiting.
 # This makes it safe to run in many environments.
 #
-# Author:
-# pbarry-r7
+# Authors:
+# * pbarry-r7
+# * dmohanty-r7
 #
 
 @job_ids = []
@@ -26,6 +27,17 @@ def wait_until_jobs_done
         end
 
         return
+    end
+end
+
+def run_scanner(host:, mod_name:)
+    begin
+        mod = framework.auxiliary.create(mod_name)
+        mod.datastore['RHOSTS'] = host.address
+        print_line("Running the #{mod.name}...")
+        result = mod.run_simple({'RunAsJob': true, 'LocalOutput': self.output})
+    rescue ::Exception => e
+        print_error(e.message)
     end
 end
 
@@ -53,9 +65,7 @@ end
 
 def setup
     # Test and see if we have a database connected
-    begin
-        framework.db.hosts
-    rescue ::ActiveRecord::ConnectionNotEstablished
+    if not (framework.db and framework.db.active)
         print_error("Database connection isn't established")
         return false
     end
@@ -69,45 +79,28 @@ def main
     framework.db.workspace.hosts.each do |host|
         print_line("Checking IP: #{host.address}, OS: #{host.os_name}...")
 
-        check_exploit(host: host,
-            mod_name: 'multi/misc/nodejs_v8_debugger',
-            vuln_check_ret_val: [ Exploit::CheckCode::Appears ])
+        # Modules
+        { 'multi/misc/nodejs_v8_debugger':        [ Exploit::CheckCode::Appears ],
+          'unix/misc/distcc_exec':                [ Exploit::CheckCode::Vulnerable ],
+          'unix/misc/qnx_qconn_exec':             [ Exploit::CheckCode::Vulnerable ],
+          'linux/misc/jenkins_java_deserialize':  [ Exploit::CheckCode::Vulnerable ],
+          'linux/http/github_enterprise_secret':  [ Exploit::CheckCode::Vulnerable ],
+          'multi/http/traq_plugin_exec':          [ Exploit::CheckCode::Appears ],
+          'multi/http/builderengine_upload_exec': [ Exploit::CheckCode::Appears ],
+          'multi/http/mantisbt_php_exec':         [ Exploit::CheckCode::Appears ],
+          'multi/http/vbulletin_unserialize':     [ Exploit::CheckCode::Appears ],
+          'unix/webapp/vbulletin_vote_sqli_exec': [ Exploit::CheckCode::Appears ],
+          'multi/misc/java_jmx_server':           [ Exploit::CheckCode::Appears,
+						    Exploit::CheckCode::Detected ] }.each do |mod,ret_val|
+            check_exploit(host: host,
+                mod_name: mod.to_s,
+                vuln_check_ret_val: ret_val)
+        end
 
-        check_exploit(host: host,
-            mod_name: 'unix/misc/distcc_exec',
-            vuln_check_ret_val: [ Exploit::CheckCode::Vulnerable ])
-
-        check_exploit(host: host,
-            mod_name: 'unix/misc/qnx_qconn_exec',
-            vuln_check_ret_val: [ Exploit::CheckCode::Vulnerable ])
-
-        check_exploit(host: host,
-            mod_name: 'linux/misc/jenkins_java_deserialize',
-            vuln_check_ret_val: [ Exploit::CheckCode::Vulnerable ])
-
-        check_exploit(host: host,
-            mod_name: 'linux/http/github_enterprise_secret',
-            vuln_check_ret_val: [ Exploit::CheckCode::Vulnerable ])
-
-        check_exploit(host: host,
-            mod_name: 'multi/http/traq_plugin_exec',
-            vuln_check_ret_val: [ Exploit::CheckCode::Appears ])
-
-        check_exploit(host: host,
-            mod_name: 'multi/http/builderengine_upload_exec',
-            vuln_check_ret_val: [ Exploit::CheckCode::Appears ])
-
-        check_exploit(host: host,
-            mod_name: 'multi/http/mantisbt_php_exec',
-            vuln_check_ret_val: [ Exploit::CheckCode::Appears ])
-
-        check_exploit(host: host,
-            mod_name: 'multi/http/vbulletin_unserialize',
-            vuln_check_ret_val: [ Exploit::CheckCode::Appears ])
-
-        check_exploit(host: host,
-            mod_name: 'unix/webapp/vbulletin_vote_sqli_exec',
-            vuln_check_ret_val: [ Exploit::CheckCode::Appears ])
+        # Scanners
+        [ 'scanner/misc/java_rmi_server' ].each do |mod|
+            run_scanner(host: host, mod_name: mod.to_s)
+        end
     end
 
     wait_until_jobs_done

--- a/scripts/resource/dev_checks.rc
+++ b/scripts/resource/dev_checks.rc
@@ -70,45 +70,46 @@ def main
         print_line("Checking IP: #{host.address}, OS: #{host.os_name}...")
 
         check_exploit(host: host,
-        mod_name: 'multi/misc/nodejs_v8_debugger',
-        vuln_check_ret_val: [ Exploit::CheckCode::Appears ])
+            mod_name: 'multi/misc/nodejs_v8_debugger',
+            vuln_check_ret_val: [ Exploit::CheckCode::Appears ])
 
         check_exploit(host: host,
-        mod_name: 'unix/misc/distcc_exec',
-        vuln_check_ret_val: [ Exploit::CheckCode::Vulnerable ])
+            mod_name: 'unix/misc/distcc_exec',
+            vuln_check_ret_val: [ Exploit::CheckCode::Vulnerable ])
 
         check_exploit(host: host,
-        mod_name: 'unix/misc/qnx_qconn_exec',
-        vuln_check_ret_val: [ Exploit::CheckCode::Vulnerable ])
+            mod_name: 'unix/misc/qnx_qconn_exec',
+            vuln_check_ret_val: [ Exploit::CheckCode::Vulnerable ])
 
         check_exploit(host: host,
-        mod_name: 'linux/misc/jenkins_java_deserialize',
-        vuln_check_ret_val: [ Exploit::CheckCode::Vulnerable ])
+            mod_name: 'linux/misc/jenkins_java_deserialize',
+            vuln_check_ret_val: [ Exploit::CheckCode::Vulnerable ])
 
         check_exploit(host: host,
-        mod_name: 'linux/http/github_enterprise_secret',
-        vuln_check_ret_val: [ Exploit::CheckCode::Vulnerable ])
+            mod_name: 'linux/http/github_enterprise_secret',
+            vuln_check_ret_val: [ Exploit::CheckCode::Vulnerable ])
 
         check_exploit(host: host,
-        mod_name: 'multi/http/traq_plugin_exec',
-        vuln_check_ret_val: [ Exploit::CheckCode::Appears ])
+            mod_name: 'multi/http/traq_plugin_exec',
+            vuln_check_ret_val: [ Exploit::CheckCode::Appears ])
 
         check_exploit(host: host,
-        mod_name: 'multi/http/builderengine_upload_exec',
-        vuln_check_ret_val: [ Exploit::CheckCode::Appears ])
+            mod_name: 'multi/http/builderengine_upload_exec',
+            vuln_check_ret_val: [ Exploit::CheckCode::Appears ])
 
         check_exploit(host: host,
-        mod_name: 'multi/http/mantisbt_php_exec',
-        vuln_check_ret_val: [ Exploit::CheckCode::Appears ])
+            mod_name: 'multi/http/mantisbt_php_exec',
+            vuln_check_ret_val: [ Exploit::CheckCode::Appears ])
 
         check_exploit(host: host,
-        mod_name: 'multi/http/vbulletin_unserialize',
-        vuln_check_ret_val: [ Exploit::CheckCode::Appears ])
+            mod_name: 'multi/http/vbulletin_unserialize',
+            vuln_check_ret_val: [ Exploit::CheckCode::Appears ])
 
         check_exploit(host: host,
-        mod_name: 'unix/webapp/vbulletin_vote_sqli_exec',
-        vuln_check_ret_val: [ Exploit::CheckCode::Appears ])
+            mod_name: 'unix/webapp/vbulletin_vote_sqli_exec',
+            vuln_check_ret_val: [ Exploit::CheckCode::Appears ])
     end
+
     wait_until_jobs_done
 end
 

--- a/scripts/resource/dev_checks.rc
+++ b/scripts/resource/dev_checks.rc
@@ -1,0 +1,118 @@
+<ruby>
+
+#
+# This resource script will check for vulnerabilities related to
+# programs and services used by developers, including the following:
+#
+# * NodeJS debug (multi/misc/nodejs_v8_debugger)
+# * distcc (unix/misc/distcc_exe)
+# * Jenkins (linux/misc/jenkins_java_deserialize)
+# * GitHub Enterprise (linux/http/github_enterprise_secret)
+#
+# It is worth noting that ONLY CHECKS are performed, no active exploiting.
+# This makes it safe to run in many environments.
+#
+# Author:
+# pbarry-r7
+#
+
+@job_ids = []
+
+def wait_until_jobs_done
+    while true
+        @job_ids.each do |job_id|
+            current_job_ids = framework.jobs.keys.map { |e| e.to_i }
+            sleep 1 if current_job_ids.include?(job_id)
+        end
+
+        return
+    end
+end
+
+def check_exploit(host:, mod_name:, vuln_check_ret_val:)
+    begin
+        mod = framework.exploits.create(mod_name)
+        mod.datastore['RHOST'] = host.address
+        print_line("Looking for #{mod.name}...")
+        result = mod.check_simple({'RunAsJob': true, 'LocalOutput': self.output})
+        @job_ids << mod.job_id if mod.job_id
+        if vuln_check_ret_val.index(result)
+            print_line("HOST #{host.address} APPEARS VULNERABLE TO #{mod.name}")
+            framework.db.report_vuln(
+                workspace: mod.workspace,
+                host: mod.rhost,
+                name: mod.name,
+                info: "This was flagged as likely vulnerable by the explicit check of #{mod.fullname}.",
+                refs: mod.references
+            )
+        end
+    rescue ::Exception => e
+        print_error(e.message)
+    end
+end
+
+def setup
+    # Test and see if we have a database connected
+    begin
+        framework.db.hosts
+    rescue ::ActiveRecord::ConnectionNotEstablished
+        print_error("Database connection isn't established")
+        return false
+    end
+
+    run_single("setg verbose true")
+
+    true
+end
+
+def main
+    framework.db.workspace.hosts.each do |host|
+        print_line("Checking IP: #{host.address}, OS: #{host.os_name}...")
+
+        check_exploit(host: host,
+        mod_name: 'multi/misc/nodejs_v8_debugger',
+        vuln_check_ret_val: [ Exploit::CheckCode::Appears ])
+
+        check_exploit(host: host,
+        mod_name: 'unix/misc/distcc_exec',
+        vuln_check_ret_val: [ Exploit::CheckCode::Vulnerable ])
+
+        check_exploit(host: host,
+        mod_name: 'unix/misc/qnx_qconn_exec',
+        vuln_check_ret_val: [ Exploit::CheckCode::Vulnerable ])
+
+        check_exploit(host: host,
+        mod_name: 'linux/misc/jenkins_java_deserialize',
+        vuln_check_ret_val: [ Exploit::CheckCode::Vulnerable ])
+
+        check_exploit(host: host,
+        mod_name: 'linux/http/github_enterprise_secret',
+        vuln_check_ret_val: [ Exploit::CheckCode::Vulnerable ])
+
+        check_exploit(host: host,
+        mod_name: 'multi/http/traq_plugin_exec',
+        vuln_check_ret_val: [ Exploit::CheckCode::Appears ])
+
+        check_exploit(host: host,
+        mod_name: 'multi/http/builderengine_upload_exec',
+        vuln_check_ret_val: [ Exploit::CheckCode::Appears ])
+
+        check_exploit(host: host,
+        mod_name: 'multi/http/mantisbt_php_exec',
+        vuln_check_ret_val: [ Exploit::CheckCode::Appears ])
+
+        check_exploit(host: host,
+        mod_name: 'multi/http/vbulletin_unserialize',
+        vuln_check_ret_val: [ Exploit::CheckCode::Appears ])
+
+        check_exploit(host: host,
+        mod_name: 'unix/webapp/vbulletin_vote_sqli_exec',
+        vuln_check_ret_val: [ Exploit::CheckCode::Appears ])
+    end
+    wait_until_jobs_done
+end
+
+abort("Error during setup, exiting.") unless setup
+main
+
+</ruby>


### PR DESCRIPTION

## Verification

- [x] Spin up a vulnerable target for testing (if you have a Linux VM handy that has nodejs installed, you can run `nodejs --debug` and that should work for this verification process!)
- [x] Start `msfconsole`
- [x] Create a new workspace:`workspace -a dev_checks`
- [x] Scan your target to populate the host in the database: `db_nmap <IP of target system>`
- [x] Run the resource script: `resource dev_checks.rc`
- [x] **Verify** that `vulns` shows the vuln(s) you were expecting

Example run:

```
msf > workspace -a dev_checks
[*] Added workspace: dev_checks
msf > hosts

Hosts
=====

address  mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------  ---  ----  -------  ---------  -----  -------  ----  --------

msf > db_nmap 10.0.2.4
[*] Nmap: Starting Nmap 7.01 ( https://nmap.org ) at 2017-10-25 10:31 CDT
[*] Nmap: Nmap scan report for 10.0.2.4
[*] Nmap: Host is up (0.000068s latency).
[*] Nmap: Not shown: 999 closed ports
[*] Nmap: PORT   STATE SERVICE
[*] Nmap: 22/tcp open  ssh
[*] Nmap: Nmap done: 1 IP address (1 host up) scanned in 16.55 seconds
msf > hosts

Hosts
=====

address   mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------   ---  ----  -------  ---------  -----  -------  ----  --------
10.0.2.4             Unknown                    device         

msf > vulns
msf > resource dev_checks.rc 
[*] Processing /home/pbarry/metasploit-framework/scripts/resource/dev_checks.rc for ERB directives.
[*] resource (/home/pbarry/metasploit-framework/scripts/resource/dev_checks.rc)> Ruby Code (3604 bytes)
verbose => true
Checking IP: 10.0.2.4, OS: Unknown...
Looking for NodeJS Debugger Command Injection...
HOST 10.0.2.4 APPEARS VULNERABLE TO NodeJS Debugger Command Injection
Looking for DistCC Daemon Command Execution...
[-] The connection was refused by the remote host (10.0.2.4:3632).
Looking for QNX QCONN Remote Command Execution Vulnerability...
[-] The connection was refused by the remote host (10.0.2.4:8000).
Looking for Jenkins CLI RMI Java Deserialization Vulnerability...
[-] The connection was refused by the remote host (10.0.2.4:8080).
Looking for Github Enterprise Default Session Secret And Deserialization Vulnerability...
[-] The connection was refused by the remote host (10.0.2.4:8443).
Looking for Traq admincp/common.php Remote Code Execution...
[-] The connection was refused by the remote host (10.0.2.4:80).
Looking for BuilderEngine Arbitrary File Upload Vulnerability and execution...
[-] The connection was refused by the remote host (10.0.2.4:80).
Looking for MantisBT XmlImportExport Plugin PHP Code Injection Vulnerability...
[-] The connection was refused by the remote host (10.0.2.4:80).
Looking for vBulletin 5.1.2 Unserialize Code Execution...
Looking for vBulletin index.php/ajax/api/reputation/vote nodeid Parameter SQL Injection...
[-] The connection was refused by the remote host (10.0.2.4:80).
msf > vulns
[*] Time: 2017-10-25 15:31:59 UTC Vuln: host=10.0.2.4 name=NodeJS Debugger Command Injection refs=URL-https://github.com/buggerjs/bugger-v8-client/blob/master/PROTOCOL.md,URL-https://github.com/nodejs/node/pull/8106
```
