### PR TITLE
fix buggy handling of partial ingress packet data

### DIFF
--- a/lib/msf/base/sessions/meterpreter.rb
+++ b/lib/msf/base/sessions/meterpreter.rb
@@ -147,9 +147,9 @@ class Meterpreter < Rex::Post::Meterpreter::Client
         guid = [SecureRandom.uuid.gsub(/-/, '')].pack('H*')
         session.core.set_session_guid(guid)
         session.session_guid = guid
-        # TODO: New statgeless session, do some account in the DB so we can track it later.
+        # TODO: New stageless session, do some account in the DB so we can track it later.
       else
-        # TODO: This session was either staged or previously known, and so we shold do some accounting here!
+        # TODO: This session was either staged or previously known, and so we should do some accounting here!
       end
 
       unless datastore['AutoLoadStdapi'] == false

--- a/lib/rex/post/meterpreter/packet_parser.rb
+++ b/lib/rex/post/meterpreter/packet_parser.rb
@@ -30,24 +30,20 @@ class PacketParser
   # Reads data from the wire and parse as much of the packet as possible.
   #
   def recv(sock)
-    bytes_left = self.packet.raw_bytes_required
-
-    if bytes_left > 0
-      raw = sock.read(bytes_left)
-      if raw
+    if self.packet.raw_bytes_required
+      while (raw = sock.read(self.packet.raw_bytes_required))
         self.packet.add_raw(raw)
-      else
-        raise EOFError
+        break if self.packet.raw_bytes_required == 0
       end
     end
 
-    if self.packet.raw_bytes_required == 0
-      packet = self.packet
-      reset
-      return packet
+    if self.packet.raw_bytes_required > 0
+      return nil
     end
 
-    nil
+    packet = self.packet
+    reset
+    packet
   end
 
 protected

--- a/lib/rex/post/meterpreter/packet_parser.rb
+++ b/lib/rex/post/meterpreter/packet_parser.rb
@@ -27,10 +27,11 @@ class PacketParser
   end
 
   #
-  # Reads data from the wire and parse as much of the packet as possible.
+  # Reads data from the socket and parses as much of the packet as possible.
   #
   def recv(sock)
-    if self.packet.raw_bytes_required
+    raw = nil
+    if self.packet.raw_bytes_required > 0
       while (raw = sock.read(self.packet.raw_bytes_required))
         self.packet.add_raw(raw)
         break if self.packet.raw_bytes_required == 0
@@ -38,7 +39,11 @@ class PacketParser
     end
 
     if self.packet.raw_bytes_required > 0
-      return nil
+      if raw == nil
+        raise EOFError
+      else
+        return nil
+      end
     end
 
     packet = self.packet


### PR DESCRIPTION
If we have more data, and the packet parser needs more data, connect the two together rather than bailing. This fixes https://github.com/rapid7/metasploit-payloads/issues/246 reverse_tcp_ssl along with probably a lot of other higher-latency corner cases when a payload doesn't seem to stage stdapi or other initial components.

## Verification

Passes all of the payload tests, namely @bwatters-r7 test case for reverse_tcp_ssl 