### PR TITLE
Added host and port to output in jenkins_enum

### DIFF
--- a/modules/auxiliary/scanner/http/jenkins_enum.rb
+++ b/modules/auxiliary/scanner/http/jenkins_enum.rb
@@ -51,7 +51,7 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     version = res.headers['X-Jenkins']
-    print_good("Jenkins Version - #{version}")
+    print_good("#{rhost}:#{rport} Jenkins Version - #{version}")
     report_service(
       :host  => rhost,
       :port  => rport,


### PR DESCRIPTION
I added the host and port number to reporting when instances are found.


Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/windows/smb/ms08_067_netapi`
- [ ] ...
- [ ] **Verify** the thing does what it should
- [ ] **Verify** the thing does not do what it should not
- [ ] **Document** the thing and how it works ([Example](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/post/multi/gather/aws_keys.md))

