### PR TITLE
Spelling error: sid vs side

### DIFF
--- a/lib/msf/core/post/windows/priv.rb
+++ b/lib/msf/core/post/windows/priv.rb
@@ -194,7 +194,7 @@ module Msf::Post::Windows::Priv
   #
   def is_high_integrity?
     il = get_integrity_level
-    (il == INTEGRITY_LEVEL_SID[:high] || il == INTEGRITY_LEVEL_SIDE[:system])
+    (il == INTEGRITY_LEVEL_SID[:high] || il == INTEGRITY_LEVEL_SID[:system])
   end
 
   #


### PR DESCRIPTION
Fixes #9141 

Looks to be a simple spelling error of `side` vs `sid`.

You could run `exploit/windows/local/wmi_persistence` to verify, but this is obvious so you could just accept it :)