### PR TITLE
bump mettle, update toolchain, add e500v2 and reduce size of x86_64

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -252,7 +252,7 @@ GEM
     recog (2.1.16)
       nokogiri
     redcarpet (3.4.0)
-    rex-arch (0.1.11)
+    rex-arch (0.1.13)
       rex-text
     rex-bin_tools (0.1.4)
       metasm

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,7 +19,7 @@ PATH
       metasploit-model
       metasploit-payloads (= 1.3.13)
       metasploit_data_models
-      metasploit_payloads-mettle (= 0.2.2)
+      metasploit_payloads-mettle (= 0.2.5)
       msgpack
       nessus_rest
       net-ssh
@@ -189,7 +189,7 @@ GEM
       postgres_ext
       railties (~> 4.2.6)
       recog (~> 2.0)
-    metasploit_payloads-mettle (0.2.2)
+    metasploit_payloads-mettle (0.2.5)
     method_source (0.9.0)
     mini_portile2 (2.3.0)
     minitest (5.10.3)

--- a/lib/msf/base/sessions/meterpreter_ppce500v2_linux.rb
+++ b/lib/msf/base/sessions/meterpreter_ppce500v2_linux.rb
@@ -1,0 +1,29 @@
+# -*- coding: binary -*-
+
+require 'msf/base/sessions/meterpreter'
+
+module Msf
+module Sessions
+
+###
+#
+# This class creates a platform-specific meterpreter session type
+#
+###
+class Meterpreter_ppce500v2_Linux < Msf::Sessions::Meterpreter
+  def supports_ssl?
+    false
+  end
+  def supports_zlib?
+    false
+  end
+  def initialize(rstream, opts={})
+    super
+    self.base_platform = 'linux'
+    self.base_arch = ARCH_PPCE500V2
+  end
+end
+
+end
+end
+

--- a/lib/msf/core/payload/uuid.rb
+++ b/lib/msf/core/payload/uuid.rb
@@ -43,7 +43,8 @@ class Msf::Payload::UUID
     24 => ARCH_AARCH64,
     25 => ARCH_MIPS64,
     26 => ARCH_PPC64LE,
-    27 => ARCH_R
+    27 => ARCH_R,
+    28 => ARCH_PPCE500V2
   }
 
   Platforms = {

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -72,7 +72,7 @@ Gem::Specification.new do |spec|
   # Needed for Meterpreter
   spec.add_runtime_dependency 'metasploit-payloads', '1.3.13'
   # Needed for the next-generation POSIX Meterpreter
-  spec.add_runtime_dependency 'metasploit_payloads-mettle', '0.2.2'
+  spec.add_runtime_dependency 'metasploit_payloads-mettle', '0.2.5'
   # Needed by msfgui and other rpc components
   spec.add_runtime_dependency 'msgpack'
   # get list of network interfaces, like eth* from OS.

--- a/modules/payloads/singles/linux/aarch64/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/aarch64/meterpreter_reverse_http.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_aarch64_linux'
 
 module MetasploitModule
 
-  CachedSize = 675112
+  CachedSize = 692384
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/aarch64/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/aarch64/meterpreter_reverse_http.rb
@@ -24,7 +24,8 @@ module MetasploitModule
         'Description'   => 'Run the Meterpreter / Mettle server payload (stageless)',
         'Author'        => [
           'Adam Cammack <adam_cammack[at]rapid7.com>',
-          'Brent Cook <brent_cook[at]rapid7.com>'
+          'Brent Cook <brent_cook[at]rapid7.com>',
+          'timwr'
         ],
         'Platform'      => 'linux',
         'Arch'          => ARCH_AARCH64,

--- a/modules/payloads/singles/linux/aarch64/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/aarch64/meterpreter_reverse_https.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_aarch64_linux'
 
 module MetasploitModule
 
-  CachedSize = 675112
+  CachedSize = 692384
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/aarch64/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/aarch64/meterpreter_reverse_https.rb
@@ -24,7 +24,8 @@ module MetasploitModule
         'Description'   => 'Run the Meterpreter / Mettle server payload (stageless)',
         'Author'        => [
           'Adam Cammack <adam_cammack[at]rapid7.com>',
-          'Brent Cook <brent_cook[at]rapid7.com>'
+          'Brent Cook <brent_cook[at]rapid7.com>',
+          'timwr'
         ],
         'Platform'      => 'linux',
         'Arch'          => ARCH_AARCH64,

--- a/modules/payloads/singles/linux/aarch64/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/aarch64/meterpreter_reverse_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_aarch64_linux'
 
 module MetasploitModule
 
-  CachedSize = 675112
+  CachedSize = 692384
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/aarch64/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/aarch64/meterpreter_reverse_tcp.rb
@@ -24,7 +24,8 @@ module MetasploitModule
         'Description'   => 'Run the Meterpreter / Mettle server payload (stageless)',
         'Author'        => [
           'Adam Cammack <adam_cammack[at]rapid7.com>',
-          'Brent Cook <brent_cook[at]rapid7.com>'
+          'Brent Cook <brent_cook[at]rapid7.com>',
+          'timwr'
         ],
         'Platform'      => 'linux',
         'Arch'          => ARCH_AARCH64,

--- a/modules/payloads/singles/linux/armbe/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/armbe/meterpreter_reverse_http.rb
@@ -24,7 +24,8 @@ module MetasploitModule
         'Description'   => 'Run the Meterpreter / Mettle server payload (stageless)',
         'Author'        => [
           'Adam Cammack <adam_cammack[at]rapid7.com>',
-          'Brent Cook <brent_cook[at]rapid7.com>'
+          'Brent Cook <brent_cook[at]rapid7.com>',
+          'timwr'
         ],
         'Platform'      => 'linux',
         'Arch'          => ARCH_ARMBE,

--- a/modules/payloads/singles/linux/armbe/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/armbe/meterpreter_reverse_http.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_armbe_linux'
 
 module MetasploitModule
 
-  CachedSize = 668392
+  CachedSize = 678568
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/armbe/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/armbe/meterpreter_reverse_https.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_armbe_linux'
 
 module MetasploitModule
 
-  CachedSize = 668392
+  CachedSize = 678568
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/armbe/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/armbe/meterpreter_reverse_tcp.rb
@@ -24,7 +24,8 @@ module MetasploitModule
         'Description'   => 'Run the Meterpreter / Mettle server payload (stageless)',
         'Author'        => [
           'Adam Cammack <adam_cammack[at]rapid7.com>',
-          'Brent Cook <brent_cook[at]rapid7.com>'
+          'Brent Cook <brent_cook[at]rapid7.com>',
+          'timwr'
         ],
         'Platform'      => 'linux',
         'Arch'          => ARCH_ARMBE,

--- a/modules/payloads/singles/linux/armbe/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/armbe/meterpreter_reverse_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_armbe_linux'
 
 module MetasploitModule
 
-  CachedSize = 668392
+  CachedSize = 678568
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/armle/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/armle/meterpreter_reverse_http.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_armle_linux'
 
 module MetasploitModule
 
-  CachedSize = 666984
+  CachedSize = 677296
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/armle/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/armle/meterpreter_reverse_http.rb
@@ -24,7 +24,8 @@ module MetasploitModule
         'Description'   => 'Run the Meterpreter / Mettle server payload (stageless)',
         'Author'        => [
           'Adam Cammack <adam_cammack[at]rapid7.com>',
-          'Brent Cook <brent_cook[at]rapid7.com>'
+          'Brent Cook <brent_cook[at]rapid7.com>',
+          'timwr'
         ],
         'Platform'      => 'linux',
         'Arch'          => ARCH_ARMLE,

--- a/modules/payloads/singles/linux/armle/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/armle/meterpreter_reverse_https.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_armle_linux'
 
 module MetasploitModule
 
-  CachedSize = 666984
+  CachedSize = 677296
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/armle/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/armle/meterpreter_reverse_https.rb
@@ -24,7 +24,8 @@ module MetasploitModule
         'Description'   => 'Run the Meterpreter / Mettle server payload (stageless)',
         'Author'        => [
           'Adam Cammack <adam_cammack[at]rapid7.com>',
-          'Brent Cook <brent_cook[at]rapid7.com>'
+          'Brent Cook <brent_cook[at]rapid7.com>',
+          'timwr'
         ],
         'Platform'      => 'linux',
         'Arch'          => ARCH_ARMLE,

--- a/modules/payloads/singles/linux/armle/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/armle/meterpreter_reverse_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_armle_linux'
 
 module MetasploitModule
 
-  CachedSize = 666984
+  CachedSize = 677296
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/armle/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/armle/meterpreter_reverse_tcp.rb
@@ -24,7 +24,8 @@ module MetasploitModule
         'Description'   => 'Run the Meterpreter / Mettle server payload (stageless)',
         'Author'        => [
           'Adam Cammack <adam_cammack[at]rapid7.com>',
-          'Brent Cook <brent_cook[at]rapid7.com>'
+          'Brent Cook <brent_cook[at]rapid7.com>',
+          'timwr'
         ],
         'Platform'      => 'linux',
         'Arch'          => ARCH_ARMLE,

--- a/modules/payloads/singles/linux/mips64/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/mips64/meterpreter_reverse_http.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_mips64_linux'
 
 module MetasploitModule
 
-  CachedSize = 1059368
+  CachedSize = 1077640
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/mips64/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/mips64/meterpreter_reverse_http.rb
@@ -24,7 +24,8 @@ module MetasploitModule
         'Description'   => 'Run the Meterpreter / Mettle server payload (stageless)',
         'Author'        => [
           'Adam Cammack <adam_cammack[at]rapid7.com>',
-          'Brent Cook <brent_cook[at]rapid7.com>'
+          'Brent Cook <brent_cook[at]rapid7.com>',
+          'timwr'
         ],
         'Platform'      => 'linux',
         'Arch'          => ARCH_MIPS64,

--- a/modules/payloads/singles/linux/mips64/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/mips64/meterpreter_reverse_https.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_mips64_linux'
 
 module MetasploitModule
 
-  CachedSize = 1059368
+  CachedSize = 1077640
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/mips64/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/mips64/meterpreter_reverse_https.rb
@@ -24,7 +24,8 @@ module MetasploitModule
         'Description'   => 'Run the Meterpreter / Mettle server payload (stageless)',
         'Author'        => [
           'Adam Cammack <adam_cammack[at]rapid7.com>',
-          'Brent Cook <brent_cook[at]rapid7.com>'
+          'Brent Cook <brent_cook[at]rapid7.com>',
+          'timwr'
         ],
         'Platform'      => 'linux',
         'Arch'          => ARCH_MIPS64,

--- a/modules/payloads/singles/linux/mips64/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/mips64/meterpreter_reverse_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_mips64_linux'
 
 module MetasploitModule
 
-  CachedSize = 1059368
+  CachedSize = 1077640
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/mips64/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/mips64/meterpreter_reverse_tcp.rb
@@ -24,7 +24,8 @@ module MetasploitModule
         'Description'   => 'Run the Meterpreter / Mettle server payload (stageless)',
         'Author'        => [
           'Adam Cammack <adam_cammack[at]rapid7.com>',
-          'Brent Cook <brent_cook[at]rapid7.com>'
+          'Brent Cook <brent_cook[at]rapid7.com>',
+          'timwr'
         ],
         'Platform'      => 'linux',
         'Arch'          => ARCH_MIPS64,

--- a/modules/payloads/singles/linux/mipsbe/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/mipsbe/meterpreter_reverse_http.rb
@@ -24,7 +24,8 @@ module MetasploitModule
         'Description'   => 'Run the Meterpreter / Mettle server payload (stageless)',
         'Author'        => [
           'Adam Cammack <adam_cammack[at]rapid7.com>',
-          'Brent Cook <brent_cook[at]rapid7.com>'
+          'Brent Cook <brent_cook[at]rapid7.com>',
+          'timwr'
         ],
         'Platform'      => 'linux',
         'Arch'          => ARCH_MIPSBE,

--- a/modules/payloads/singles/linux/mipsbe/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/mipsbe/meterpreter_reverse_http.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_mipsbe_linux'
 
 module MetasploitModule
 
-  CachedSize = 1037512
+  CachedSize = 1053924
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/mipsbe/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/mipsbe/meterpreter_reverse_https.rb
@@ -24,7 +24,8 @@ module MetasploitModule
         'Description'   => 'Run the Meterpreter / Mettle server payload (stageless)',
         'Author'        => [
           'Adam Cammack <adam_cammack[at]rapid7.com>',
-          'Brent Cook <brent_cook[at]rapid7.com>'
+          'Brent Cook <brent_cook[at]rapid7.com>',
+          'timwr'
         ],
         'Platform'      => 'linux',
         'Arch'          => ARCH_MIPSBE,

--- a/modules/payloads/singles/linux/mipsbe/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/mipsbe/meterpreter_reverse_https.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_mipsbe_linux'
 
 module MetasploitModule
 
-  CachedSize = 1037512
+  CachedSize = 1053924
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/mipsbe/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/mipsbe/meterpreter_reverse_tcp.rb
@@ -24,7 +24,8 @@ module MetasploitModule
         'Description'   => 'Run the Meterpreter / Mettle server payload (stageless)',
         'Author'        => [
           'Adam Cammack <adam_cammack[at]rapid7.com>',
-          'Brent Cook <brent_cook[at]rapid7.com>'
+          'Brent Cook <brent_cook[at]rapid7.com>',
+          'timwr'
         ],
         'Platform'      => 'linux',
         'Arch'          => ARCH_MIPSBE,

--- a/modules/payloads/singles/linux/mipsbe/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/mipsbe/meterpreter_reverse_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_mipsbe_linux'
 
 module MetasploitModule
 
-  CachedSize = 1037512
+  CachedSize = 1053924
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/mipsle/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/mipsle/meterpreter_reverse_http.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_mipsle_linux'
 
 module MetasploitModule
 
-  CachedSize = 1036808
+  CachedSize = 1053540
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/mipsle/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/mipsle/meterpreter_reverse_http.rb
@@ -24,7 +24,8 @@ module MetasploitModule
         'Description'   => 'Run the Meterpreter / Mettle server payload (stageless)',
         'Author'        => [
           'Adam Cammack <adam_cammack[at]rapid7.com>',
-          'Brent Cook <brent_cook[at]rapid7.com>'
+          'Brent Cook <brent_cook[at]rapid7.com>',
+          'timwr'
         ],
         'Platform'      => 'linux',
         'Arch'          => ARCH_MIPSLE,

--- a/modules/payloads/singles/linux/mipsle/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/mipsle/meterpreter_reverse_https.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_mipsle_linux'
 
 module MetasploitModule
 
-  CachedSize = 1036808
+  CachedSize = 1053540
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/mipsle/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/mipsle/meterpreter_reverse_https.rb
@@ -24,7 +24,8 @@ module MetasploitModule
         'Description'   => 'Run the Meterpreter / Mettle server payload (stageless)',
         'Author'        => [
           'Adam Cammack <adam_cammack[at]rapid7.com>',
-          'Brent Cook <brent_cook[at]rapid7.com>'
+          'Brent Cook <brent_cook[at]rapid7.com>',
+          'timwr'
         ],
         'Platform'      => 'linux',
         'Arch'          => ARCH_MIPSLE,

--- a/modules/payloads/singles/linux/mipsle/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/mipsle/meterpreter_reverse_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_mipsle_linux'
 
 module MetasploitModule
 
-  CachedSize = 1036808
+  CachedSize = 1053540
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/mipsle/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/mipsle/meterpreter_reverse_tcp.rb
@@ -24,7 +24,8 @@ module MetasploitModule
         'Description'   => 'Run the Meterpreter / Mettle server payload (stageless)',
         'Author'        => [
           'Adam Cammack <adam_cammack[at]rapid7.com>',
-          'Brent Cook <brent_cook[at]rapid7.com>'
+          'Brent Cook <brent_cook[at]rapid7.com>',
+          'timwr'
         ],
         'Platform'      => 'linux',
         'Arch'          => ARCH_MIPSLE,

--- a/modules/payloads/singles/linux/ppc/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/ppc/meterpreter_reverse_http.rb
@@ -24,7 +24,8 @@ module MetasploitModule
         'Description'   => 'Run the Meterpreter / Mettle server payload (stageless)',
         'Author'        => [
           'Adam Cammack <adam_cammack[at]rapid7.com>',
-          'Brent Cook <brent_cook[at]rapid7.com>'
+          'Brent Cook <brent_cook[at]rapid7.com>',
+          'timwr'
         ],
         'Platform'      => 'linux',
         'Arch'          => ARCH_PPC,

--- a/modules/payloads/singles/linux/ppc/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/ppc/meterpreter_reverse_http.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_ppc_linux'
 
 module MetasploitModule
 
-  CachedSize = 789196
+  CachedSize = 854692
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/ppc/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/ppc/meterpreter_reverse_https.rb
@@ -24,7 +24,8 @@ module MetasploitModule
         'Description'   => 'Run the Meterpreter / Mettle server payload (stageless)',
         'Author'        => [
           'Adam Cammack <adam_cammack[at]rapid7.com>',
-          'Brent Cook <brent_cook[at]rapid7.com>'
+          'Brent Cook <brent_cook[at]rapid7.com>',
+          'timwr'
         ],
         'Platform'      => 'linux',
         'Arch'          => ARCH_PPC,

--- a/modules/payloads/singles/linux/ppc/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/ppc/meterpreter_reverse_https.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_ppc_linux'
 
 module MetasploitModule
 
-  CachedSize = 789196
+  CachedSize = 854692
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/ppc/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/ppc/meterpreter_reverse_tcp.rb
@@ -24,7 +24,8 @@ module MetasploitModule
         'Description'   => 'Run the Meterpreter / Mettle server payload (stageless)',
         'Author'        => [
           'Adam Cammack <adam_cammack[at]rapid7.com>',
-          'Brent Cook <brent_cook[at]rapid7.com>'
+          'Brent Cook <brent_cook[at]rapid7.com>',
+          'timwr'
         ],
         'Platform'      => 'linux',
         'Arch'          => ARCH_PPC,

--- a/modules/payloads/singles/linux/ppc/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/ppc/meterpreter_reverse_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_ppc_linux'
 
 module MetasploitModule
 
-  CachedSize = 789196
+  CachedSize = 854692
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/ppc64le/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/ppc64le/meterpreter_reverse_http.rb
@@ -24,7 +24,8 @@ module MetasploitModule
         'Description'   => 'Run the Meterpreter / Mettle server payload (stageless)',
         'Author'        => [
           'Adam Cammack <adam_cammack[at]rapid7.com>',
-          'Brent Cook <brent_cook[at]rapid7.com>'
+          'Brent Cook <brent_cook[at]rapid7.com>',
+          'timwr'
         ],
         'Platform'      => 'linux',
         'Arch'          => ARCH_PPC64LE,

--- a/modules/payloads/singles/linux/ppc64le/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/ppc64le/meterpreter_reverse_http.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_ppc64le_linux'
 
 module MetasploitModule
 
-  CachedSize = 855928
+  CachedSize = 856312
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/ppc64le/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/ppc64le/meterpreter_reverse_https.rb
@@ -24,7 +24,8 @@ module MetasploitModule
         'Description'   => 'Run the Meterpreter / Mettle server payload (stageless)',
         'Author'        => [
           'Adam Cammack <adam_cammack[at]rapid7.com>',
-          'Brent Cook <brent_cook[at]rapid7.com>'
+          'Brent Cook <brent_cook[at]rapid7.com>',
+          'timwr'
         ],
         'Platform'      => 'linux',
         'Arch'          => ARCH_PPC64LE,

--- a/modules/payloads/singles/linux/ppc64le/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/ppc64le/meterpreter_reverse_https.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_ppc64le_linux'
 
 module MetasploitModule
 
-  CachedSize = 855928
+  CachedSize = 856312
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/ppc64le/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/ppc64le/meterpreter_reverse_tcp.rb
@@ -24,7 +24,8 @@ module MetasploitModule
         'Description'   => 'Run the Meterpreter / Mettle server payload (stageless)',
         'Author'        => [
           'Adam Cammack <adam_cammack[at]rapid7.com>',
-          'Brent Cook <brent_cook[at]rapid7.com>'
+          'Brent Cook <brent_cook[at]rapid7.com>',
+          'timwr'
         ],
         'Platform'      => 'linux',
         'Arch'          => ARCH_PPC64LE,

--- a/modules/payloads/singles/linux/ppc64le/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/ppc64le/meterpreter_reverse_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_ppc64le_linux'
 
 module MetasploitModule
 
-  CachedSize = 855928
+  CachedSize = 856312
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/ppce500v2/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/ppce500v2/meterpreter_reverse_http.rb
@@ -3,14 +3,12 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'msf/core/handler/reverse_https'
+require 'msf/core/handler/reverse_http'
 require 'msf/base/sessions/meterpreter_options'
 require 'msf/base/sessions/mettle_config'
-require 'msf/base/sessions/meterpreter_armbe_linux'
+require 'msf/base/sessions/meterpreter_ppce500v2_linux'
 
 module MetasploitModule
-
-  CachedSize = 678568
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions
@@ -20,7 +18,7 @@ module MetasploitModule
     super(
       update_info(
         info,
-        'Name'          => 'Linux Meterpreter, Reverse HTTPS Inline',
+        'Name'          => 'Linux Meterpreter, Reverse HTTP Inline',
         'Description'   => 'Run the Meterpreter / Mettle server payload (stageless)',
         'Author'        => [
           'Adam Cammack <adam_cammack[at]rapid7.com>',
@@ -28,19 +26,19 @@ module MetasploitModule
           'timwr'
         ],
         'Platform'      => 'linux',
-        'Arch'          => ARCH_ARMBE,
+        'Arch'          => ARCH_PPCE500V2,
         'License'       => MSF_LICENSE,
-        'Handler'       => Msf::Handler::ReverseHttps,
-        'Session'       => Msf::Sessions::Meterpreter_armbe_Linux
+        'Handler'       => Msf::Handler::ReverseHttp,
+        'Session'       => Msf::Sessions::Meterpreter_ppce500v2_Linux
       )
     )
   end
 
   def generate
     opts = {
-      scheme: 'https',
+      scheme: 'http',
       stageless: true
     }
-    MetasploitPayloads::Mettle.new('armv5b-linux-musleabi', generate_config(opts)).to_binary :exec
+    MetasploitPayloads::Mettle.new('powerpc-e500v2-linux-musl', generate_config(opts)).to_binary :exec
   end
 end

--- a/modules/payloads/singles/linux/ppce500v2/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/ppce500v2/meterpreter_reverse_https.rb
@@ -6,11 +6,9 @@
 require 'msf/core/handler/reverse_https'
 require 'msf/base/sessions/meterpreter_options'
 require 'msf/base/sessions/mettle_config'
-require 'msf/base/sessions/meterpreter_armbe_linux'
+require 'msf/base/sessions/meterpreter_ppce500v2_linux'
 
 module MetasploitModule
-
-  CachedSize = 678568
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions
@@ -28,10 +26,10 @@ module MetasploitModule
           'timwr'
         ],
         'Platform'      => 'linux',
-        'Arch'          => ARCH_ARMBE,
+        'Arch'          => ARCH_PPCE500V2,
         'License'       => MSF_LICENSE,
         'Handler'       => Msf::Handler::ReverseHttps,
-        'Session'       => Msf::Sessions::Meterpreter_armbe_Linux
+        'Session'       => Msf::Sessions::Meterpreter_ppce500v2_Linux
       )
     )
   end
@@ -41,6 +39,6 @@ module MetasploitModule
       scheme: 'https',
       stageless: true
     }
-    MetasploitPayloads::Mettle.new('armv5b-linux-musleabi', generate_config(opts)).to_binary :exec
+    MetasploitPayloads::Mettle.new('powerpc-e500v2-linux-musl', generate_config(opts)).to_binary :exec
   end
 end

--- a/modules/payloads/singles/linux/ppce500v2/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/ppce500v2/meterpreter_reverse_tcp.rb
@@ -3,14 +3,12 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'msf/core/handler/reverse_https'
+require 'msf/core/handler/reverse_tcp'
 require 'msf/base/sessions/meterpreter_options'
 require 'msf/base/sessions/mettle_config'
-require 'msf/base/sessions/meterpreter_armbe_linux'
+require 'msf/base/sessions/meterpreter_ppce500v2_linux'
 
 module MetasploitModule
-
-  CachedSize = 678568
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions
@@ -20,7 +18,7 @@ module MetasploitModule
     super(
       update_info(
         info,
-        'Name'          => 'Linux Meterpreter, Reverse HTTPS Inline',
+        'Name'          => 'Linux Meterpreter, Reverse TCP Inline',
         'Description'   => 'Run the Meterpreter / Mettle server payload (stageless)',
         'Author'        => [
           'Adam Cammack <adam_cammack[at]rapid7.com>',
@@ -28,19 +26,19 @@ module MetasploitModule
           'timwr'
         ],
         'Platform'      => 'linux',
-        'Arch'          => ARCH_ARMBE,
+        'Arch'          => ARCH_PPCE500V2,
         'License'       => MSF_LICENSE,
-        'Handler'       => Msf::Handler::ReverseHttps,
-        'Session'       => Msf::Sessions::Meterpreter_armbe_Linux
+        'Handler'       => Msf::Handler::ReverseTcp,
+        'Session'       => Msf::Sessions::Meterpreter_ppce500v2_Linux
       )
     )
   end
 
   def generate
     opts = {
-      scheme: 'https',
+      scheme: 'tcp',
       stageless: true
     }
-    MetasploitPayloads::Mettle.new('armv5b-linux-musleabi', generate_config(opts)).to_binary :exec
+    MetasploitPayloads::Mettle.new('powerpc-e500v2-linux-musl', generate_config(opts)).to_binary :exec
   end
 end

--- a/modules/payloads/singles/linux/x64/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/x64/meterpreter_reverse_http.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_x64_linux'
 
 module MetasploitModule
 
-  CachedSize = 729184
+  CachedSize = 745472
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/x64/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/x64/meterpreter_reverse_http.rb
@@ -24,7 +24,8 @@ module MetasploitModule
         'Description'   => 'Run the Meterpreter / Mettle server payload (stageless)',
         'Author'        => [
           'Adam Cammack <adam_cammack[at]rapid7.com>',
-          'Brent Cook <brent_cook[at]rapid7.com>'
+          'Brent Cook <brent_cook[at]rapid7.com>',
+          'timwr'
         ],
         'Platform'      => 'linux',
         'Arch'          => ARCH_X64,

--- a/modules/payloads/singles/linux/x64/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/x64/meterpreter_reverse_https.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_x64_linux'
 
 module MetasploitModule
 
-  CachedSize = 729184
+  CachedSize = 745472
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/x64/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/x64/meterpreter_reverse_https.rb
@@ -24,7 +24,8 @@ module MetasploitModule
         'Description'   => 'Run the Meterpreter / Mettle server payload (stageless)',
         'Author'        => [
           'Adam Cammack <adam_cammack[at]rapid7.com>',
-          'Brent Cook <brent_cook[at]rapid7.com>'
+          'Brent Cook <brent_cook[at]rapid7.com>',
+          'timwr'
         ],
         'Platform'      => 'linux',
         'Arch'          => ARCH_X64,

--- a/modules/payloads/singles/linux/x64/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/x64/meterpreter_reverse_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_x64_linux'
 
 module MetasploitModule
 
-  CachedSize = 729184
+  CachedSize = 745472
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/x64/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/x64/meterpreter_reverse_tcp.rb
@@ -24,7 +24,8 @@ module MetasploitModule
         'Description'   => 'Run the Meterpreter / Mettle server payload (stageless)',
         'Author'        => [
           'Adam Cammack <adam_cammack[at]rapid7.com>',
-          'Brent Cook <brent_cook[at]rapid7.com>'
+          'Brent Cook <brent_cook[at]rapid7.com>',
+          'timwr'
         ],
         'Platform'      => 'linux',
         'Arch'          => ARCH_X64,

--- a/modules/payloads/singles/linux/x86/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/x86/meterpreter_reverse_http.rb
@@ -24,7 +24,8 @@ module MetasploitModule
         'Description'   => 'Run the Meterpreter / Mettle server payload (stageless)',
         'Author'        => [
           'Adam Cammack <adam_cammack[at]rapid7.com>',
-          'Brent Cook <brent_cook[at]rapid7.com>'
+          'Brent Cook <brent_cook[at]rapid7.com>',
+          'timwr'
         ],
         'Platform'      => 'linux',
         'Arch'          => ARCH_X86,

--- a/modules/payloads/singles/linux/x86/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/x86/meterpreter_reverse_http.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_x86_linux'
 
 module MetasploitModule
 
-  CachedSize = 772828
+  CachedSize = 793296
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/x86/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/x86/meterpreter_reverse_https.rb
@@ -24,7 +24,8 @@ module MetasploitModule
         'Description'   => 'Run the Meterpreter / Mettle server payload (stageless)',
         'Author'        => [
           'Adam Cammack <adam_cammack[at]rapid7.com>',
-          'Brent Cook <brent_cook[at]rapid7.com>'
+          'Brent Cook <brent_cook[at]rapid7.com>',
+          'timwr'
         ],
         'Platform'      => 'linux',
         'Arch'          => ARCH_X86,

--- a/modules/payloads/singles/linux/x86/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/x86/meterpreter_reverse_https.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_x86_linux'
 
 module MetasploitModule
 
-  CachedSize = 772828
+  CachedSize = 793296
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/x86/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/x86/meterpreter_reverse_tcp.rb
@@ -24,7 +24,8 @@ module MetasploitModule
         'Description'   => 'Run the Meterpreter / Mettle server payload (stageless)',
         'Author'        => [
           'Adam Cammack <adam_cammack[at]rapid7.com>',
-          'Brent Cook <brent_cook[at]rapid7.com>'
+          'Brent Cook <brent_cook[at]rapid7.com>',
+          'timwr'
         ],
         'Platform'      => 'linux',
         'Arch'          => ARCH_X86,

--- a/modules/payloads/singles/linux/x86/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/x86/meterpreter_reverse_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_x86_linux'
 
 module MetasploitModule
 
-  CachedSize = 772828
+  CachedSize = 793296
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/zarch/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/zarch/meterpreter_reverse_http.rb
@@ -24,7 +24,8 @@ module MetasploitModule
         'Description'   => 'Run the Meterpreter / Mettle server payload (stageless)',
         'Author'        => [
           'Adam Cammack <adam_cammack[at]rapid7.com>',
-          'Brent Cook <brent_cook[at]rapid7.com>'
+          'Brent Cook <brent_cook[at]rapid7.com>',
+          'timwr'
         ],
         'Platform'      => 'linux',
         'Arch'          => ARCH_ZARCH,

--- a/modules/payloads/singles/linux/zarch/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/zarch/meterpreter_reverse_http.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_zarch_linux'
 
 module MetasploitModule
 
-  CachedSize = 893560
+  CachedSize = 905864
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/zarch/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/zarch/meterpreter_reverse_https.rb
@@ -24,7 +24,8 @@ module MetasploitModule
         'Description'   => 'Run the Meterpreter / Mettle server payload (stageless)',
         'Author'        => [
           'Adam Cammack <adam_cammack[at]rapid7.com>',
-          'Brent Cook <brent_cook[at]rapid7.com>'
+          'Brent Cook <brent_cook[at]rapid7.com>',
+          'timwr'
         ],
         'Platform'      => 'linux',
         'Arch'          => ARCH_ZARCH,

--- a/modules/payloads/singles/linux/zarch/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/zarch/meterpreter_reverse_https.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_zarch_linux'
 
 module MetasploitModule
 
-  CachedSize = 893560
+  CachedSize = 905864
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/zarch/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/zarch/meterpreter_reverse_tcp.rb
@@ -24,7 +24,8 @@ module MetasploitModule
         'Description'   => 'Run the Meterpreter / Mettle server payload (stageless)',
         'Author'        => [
           'Adam Cammack <adam_cammack[at]rapid7.com>',
-          'Brent Cook <brent_cook[at]rapid7.com>'
+          'Brent Cook <brent_cook[at]rapid7.com>',
+          'timwr'
         ],
         'Platform'      => 'linux',
         'Arch'          => ARCH_ZARCH,

--- a/modules/payloads/singles/linux/zarch/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/zarch/meterpreter_reverse_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_zarch_linux'
 
 module MetasploitModule
 
-  CachedSize = 893560
+  CachedSize = 905864
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/osx/x64/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/osx/x64/meterpreter_reverse_http.rb
@@ -24,7 +24,8 @@ module MetasploitModule
         'Description'   => 'Run the Meterpreter / Mettle server payload (stageless)',
         'Author'        => [
           'Adam Cammack <adam_cammack[at]rapid7.com>',
-          'Brent Cook <brent_cook[at]rapid7.com>'
+          'Brent Cook <brent_cook[at]rapid7.com>',
+          'timwr'
         ],
         'Platform'      => 'osx',
         'Arch'          => ARCH_X64,

--- a/modules/payloads/singles/osx/x64/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/osx/x64/meterpreter_reverse_http.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_x64_osx'
 
 module MetasploitModule
 
-  CachedSize = 618412
+  CachedSize = 789068
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/osx/x64/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/osx/x64/meterpreter_reverse_https.rb
@@ -24,7 +24,8 @@ module MetasploitModule
         'Description'   => 'Run the Meterpreter / Mettle server payload (stageless)',
         'Author'        => [
           'Adam Cammack <adam_cammack[at]rapid7.com>',
-          'Brent Cook <brent_cook[at]rapid7.com>'
+          'Brent Cook <brent_cook[at]rapid7.com>',
+          'timwr'
         ],
         'Platform'      => 'osx',
         'Arch'          => ARCH_X64,

--- a/modules/payloads/singles/osx/x64/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/osx/x64/meterpreter_reverse_https.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_x64_osx'
 
 module MetasploitModule
 
-  CachedSize = 618412
+  CachedSize = 789068
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/osx/x64/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/osx/x64/meterpreter_reverse_tcp.rb
@@ -24,7 +24,8 @@ module MetasploitModule
         'Description'   => 'Run the Meterpreter / Mettle server payload (stageless)',
         'Author'        => [
           'Adam Cammack <adam_cammack[at]rapid7.com>',
-          'Brent Cook <brent_cook[at]rapid7.com>'
+          'Brent Cook <brent_cook[at]rapid7.com>',
+          'timwr'
         ],
         'Platform'      => 'osx',
         'Arch'          => ARCH_X64,

--- a/modules/payloads/singles/osx/x64/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/osx/x64/meterpreter_reverse_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_x64_osx'
 
 module MetasploitModule
 
-  CachedSize = 618412
+  CachedSize = 789068
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/tools/modules/generate_mettle_payloads.rb
+++ b/tools/modules/generate_mettle_payloads.rb
@@ -12,18 +12,19 @@ schemes = [
 ]
 
 arches = [
-  ['aarch64','Linux', 'aarch64-linux-musl'],
-  ['armbe',  'Linux', 'armv5b-linux-musleabi'],
-  ['armle',  'Linux', 'armv5l-linux-musleabi'],
-  ['mips64', 'Linux', 'mips64-linux-muslsf'],
-  ['mipsbe', 'Linux', 'mips-linux-muslsf'],
-  ['mipsle', 'Linux', 'mipsel-linux-muslsf'],
-  ['ppc',    'Linux', 'powerpc-linux-muslsf'],
-  ['ppc64le','Linux', 'powerpc64le-linux-musl'],
-  ['x64',    'Linux', 'x86_64-linux-musl'],
-  ['x86',    'Linux', 'i486-linux-musl'],
-  ['zarch',  'Linux', 's390x-linux-musl'],
-  ['x64',    'OSX',   'x86_64-apple-darwin'],
+  ['aarch64',   'Linux', 'aarch64-linux-musl'],
+  ['armbe',     'Linux', 'armv5b-linux-musleabi'],
+  ['armle',     'Linux', 'armv5l-linux-musleabi'],
+  ['mips64',    'Linux', 'mips64-linux-muslsf'],
+  ['mipsbe',    'Linux', 'mips-linux-muslsf'],
+  ['mipsle',    'Linux', 'mipsel-linux-muslsf'],
+  ['ppc',       'Linux', 'powerpc-linux-muslsf'],
+  ['ppce500v2', 'Linux', 'powerpc-e500v2-linux-musl'],
+  ['ppc64le',   'Linux', 'powerpc64le-linux-musl'],
+  ['x64',       'Linux', 'x86_64-linux-musl'],
+  ['x86',       'Linux', 'i486-linux-musl'],
+  ['zarch',     'Linux', 's390x-linux-musl'],
+  ['x64',       'OSX',   'x86_64-apple-darwin'],
 ]
 
 arch = ''


### PR DESCRIPTION
Bump the mettle gem to bring in:
  - Reduced x64 size from 3MB to < 800KB (https://github.com/rapid7/mettle/pull/96)
  - add e500v2 build (https://github.com/rapid7/mettle/pull/93)