### PR TITLE
Fix several broken raise RuntimeError calls in error paths

### DIFF
--- a/lib/metasploit/framework/mssql/client.rb
+++ b/lib/metasploit/framework/mssql/client.rb
@@ -634,8 +634,7 @@ module Metasploit
           if idx > 0
             encryption_mode = resp[idx, 1].unpack("C")[0]
           else
-            raise RunTimeError, "Unable to parse encryption req. "\
-              "from server during prelogin"
+            raise "Unable to parse encryption req during pre-login, this may not be a MSSQL server"
             encryption_mode = ENCRYPT_NOT_SUP
           end
 
@@ -682,8 +681,7 @@ module Metasploit
             if idx > 0
               encryption_mode = resp[idx, 1].unpack("C")[0]
             else
-              raise RuntimeError, "Unable to parse encryption "\
-                "req during pre-login"
+              raise "Unable to parse encryption req during pre-login, this may not be a MSSQL server"
             end
           end
           encryption_mode

--- a/lib/msf/core/auxiliary/nmap.rb
+++ b/lib/msf/core/auxiliary/nmap.rb
@@ -165,7 +165,7 @@ def nmap_add_ports
   if nmap_validate_arg(port_arg)
     self.nmap_args << port_arg
   else
-    raise RunTimeError, "Argument is invalid"
+    raise "Argument is invalid"
   end
 end
 

--- a/lib/msf/core/auxiliary/nmap.rb
+++ b/lib/msf/core/auxiliary/nmap.rb
@@ -43,7 +43,7 @@ def rport
 end
 
 def set_nmap_cmd
-  self.nmap_bin || (raise RuntimeError, "Cannot locate nmap binary")
+  self.nmap_bin || (raise "Cannot locate nmap binary")
   nmap_set_log
   nmap_add_ports
   nmap_cmd = [self.nmap_bin]
@@ -54,7 +54,7 @@ def set_nmap_cmd
 end
 
 def get_nmap_ver
-  self.nmap_bin || (raise RuntimeError, "Cannot locate nmap binary")
+  self.nmap_bin || (raise "Cannot locate nmap binary")
   res = ""
   nmap_cmd = [self.nmap_bin]
   nmap_cmd << "--version"
@@ -84,7 +84,7 @@ def nmap_version_at_least?(test_ver=nil)
 end
 
 def nmap_build_args
-  raise RuntimeError, "nmap_build_args() not defined by #{self.refname}"
+  raise "nmap_build_args() not defined by #{self.refname}"
 end
 
 def nmap_run
@@ -159,7 +159,7 @@ end
 # A helper to add in rport or rports as a -p argument
 def nmap_add_ports
   if not nmap_validate_rports
-    raise RuntimeError, "Cannot continue without a valid port list."
+    raise "Cannot continue without a valid port list."
   end
   port_arg = "-p \"#{datastore['RPORT'] || rports}\""
   if nmap_validate_arg(port_arg)
@@ -237,7 +237,7 @@ end
 # module to ferret out whatever's interesting in this host
 # object.
 def nmap_hosts(&block)
-  @nmap_bin || (raise RuntimeError, "Cannot locate the nmap binary.")
+  @nmap_bin || (raise "Cannot locate the nmap binary.")
   fh = self.nmap_log[0]
   nmap_data = fh.read(fh.stat.size)
   # fh.unlink

--- a/lib/msf/core/db_manager/report.rb
+++ b/lib/msf/core/db_manager/report.rb
@@ -44,7 +44,7 @@ module Msf::DBManager::Report
 
     unless artifact.valid?
       errors = artifact.errors.full_messages.join('; ')
-      raise RuntimeError "Artifact to be imported is not valid: #{errors}"
+      raise RuntimeError, "Artifact to be imported is not valid: #{errors}"
     end
     artifact.save
   end
@@ -66,7 +66,7 @@ module Msf::DBManager::Report
 
     unless report.valid?
       errors = report.errors.full_messages.join('; ')
-      raise RuntimeError "Report to be imported is not valid: #{errors}"
+      raise RuntimeError, "Report to be imported is not valid: #{errors}"
     end
     report.state = :complete # Presume complete since it was exported
     report.save

--- a/lib/msf/core/db_manager/report.rb
+++ b/lib/msf/core/db_manager/report.rb
@@ -44,7 +44,7 @@ module Msf::DBManager::Report
 
     unless artifact.valid?
       errors = artifact.errors.full_messages.join('; ')
-      raise RuntimeError, "Artifact to be imported is not valid: #{errors}"
+      raise "Artifact to be imported is not valid: #{errors}"
     end
     artifact.save
   end
@@ -66,7 +66,7 @@ module Msf::DBManager::Report
 
     unless report.valid?
       errors = report.errors.full_messages.join('; ')
-      raise RuntimeError, "Report to be imported is not valid: #{errors}"
+      raise "Report to be imported is not valid: #{errors}"
     end
     report.state = :complete # Presume complete since it was exported
     report.save

--- a/modules/auxiliary/scanner/discovery/arp_sweep.rb
+++ b/modules/auxiliary/scanner/discovery/arp_sweep.rb
@@ -46,11 +46,11 @@ class MetasploitModule < Msf::Auxiliary
     @interface = datastore['INTERFACE'] || Pcap.lookupdev
     shost = datastore['SHOST']
     shost ||= get_ipv4_addr(@interface) if @netifaces
-    raise RuntimeError, 'SHOST should be defined' unless shost
+    raise 'SHOST should be defined' unless shost
 
     smac  = datastore['SMAC']
     smac ||= get_mac(@interface) if @netifaces
-    raise RuntimeError, 'SMAC should be defined' unless smac
+    raise 'SMAC should be defined' unless smac
 
     begin
 

--- a/modules/auxiliary/scanner/discovery/arp_sweep.rb
+++ b/modules/auxiliary/scanner/discovery/arp_sweep.rb
@@ -46,11 +46,11 @@ class MetasploitModule < Msf::Auxiliary
     @interface = datastore['INTERFACE'] || Pcap.lookupdev
     shost = datastore['SHOST']
     shost ||= get_ipv4_addr(@interface) if @netifaces
-    raise RuntimeError ,'SHOST should be defined' unless shost
+    raise RuntimeError, 'SHOST should be defined' unless shost
 
     smac  = datastore['SMAC']
     smac ||= get_mac(@interface) if @netifaces
-    raise RuntimeError ,'SMAC should be defined' unless smac
+    raise RuntimeError, 'SMAC should be defined' unless smac
 
     begin
 

--- a/modules/auxiliary/scanner/discovery/ipv6_neighbor.rb
+++ b/modules/auxiliary/scanner/discovery/ipv6_neighbor.rb
@@ -49,11 +49,11 @@ class MetasploitModule < Msf::Auxiliary
     @interface = datastore['INTERFACE'] || Pcap.lookupdev
     @shost = datastore['SHOST']
     @shost ||= get_ipv4_addr(@interface) if @netifaces
-    raise RuntimeError ,'SHOST should be defined' unless @shost
+    raise RuntimeError, 'SHOST should be defined' unless @shost
 
     @smac  = datastore['SMAC']
     @smac ||= get_mac(@interface) if @netifaces
-    raise RuntimeError ,'SMAC should be defined' unless @smac
+    raise RuntimeError, 'SMAC should be defined' unless @smac
 
     addrs = []
 

--- a/modules/auxiliary/scanner/discovery/ipv6_neighbor.rb
+++ b/modules/auxiliary/scanner/discovery/ipv6_neighbor.rb
@@ -49,11 +49,11 @@ class MetasploitModule < Msf::Auxiliary
     @interface = datastore['INTERFACE'] || Pcap.lookupdev
     @shost = datastore['SHOST']
     @shost ||= get_ipv4_addr(@interface) if @netifaces
-    raise RuntimeError, 'SHOST should be defined' unless @shost
+    raise 'SHOST should be defined' unless @shost
 
     @smac  = datastore['SMAC']
     @smac ||= get_mac(@interface) if @netifaces
-    raise RuntimeError, 'SMAC should be defined' unless @smac
+    raise 'SMAC should be defined' unless @smac
 
     addrs = []
 

--- a/modules/auxiliary/scanner/discovery/ipv6_neighbor_router_advertisement.rb
+++ b/modules/auxiliary/scanner/discovery/ipv6_neighbor_router_advertisement.rb
@@ -161,12 +161,12 @@ class MetasploitModule < Msf::Auxiliary
     @interface = datastore['INTERFACE'] || Pcap.lookupdev
     @shost = datastore['SHOST']
     @shost ||= get_ipv4_addr(@interface) if @netifaces
-    raise RuntimeError, 'SHOST should be defined' unless @shost
+    raise 'SHOST should be defined' unless @shost
 
     @smac  = datastore['SMAC']
     @smac ||= get_mac(@interface) if @netifaces
     @smac ||= ipv6_mac
-    raise RuntimeError, 'SMAC should be defined' unless @smac
+    raise 'SMAC should be defined' unless @smac
 
     # Send router advertisement
     print_status("Sending router advertisement...")

--- a/modules/auxiliary/scanner/discovery/ipv6_neighbor_router_advertisement.rb
+++ b/modules/auxiliary/scanner/discovery/ipv6_neighbor_router_advertisement.rb
@@ -161,12 +161,12 @@ class MetasploitModule < Msf::Auxiliary
     @interface = datastore['INTERFACE'] || Pcap.lookupdev
     @shost = datastore['SHOST']
     @shost ||= get_ipv4_addr(@interface) if @netifaces
-    raise RuntimeError ,'SHOST should be defined' unless @shost
+    raise RuntimeError, 'SHOST should be defined' unless @shost
 
     @smac  = datastore['SMAC']
     @smac ||= get_mac(@interface) if @netifaces
     @smac ||= ipv6_mac
-    raise RuntimeError ,'SMAC should be defined' unless @smac
+    raise RuntimeError, 'SMAC should be defined' unless @smac
 
     # Send router advertisement
     print_status("Sending router advertisement...")

--- a/modules/auxiliary/server/icmp_exfil.rb
+++ b/modules/auxiliary/server/icmp_exfil.rb
@@ -153,7 +153,7 @@ class MetasploitModule < Msf::Auxiliary
           icmp_response, contents = icmp_packet(packet, datastore['RESP_START'])
 
           if not icmp_response
-            raise RuntimeError, "Could not build ICMP response"
+            raise "Could not build ICMP response"
           else
             # send response packet icmp_pkt
             send_icmp(icmp_response, contents)
@@ -172,7 +172,7 @@ class MetasploitModule < Msf::Auxiliary
             icmp_response, contents = icmp_packet(packet, datastore['RESP_END'])
 
             if not icmp_response
-              raise RuntimeError, "Could not build ICMP response"
+              raise "Could not build ICMP response"
             else
               # send response packet icmp_pkt
               send_icmp(icmp_response, contents)
@@ -192,7 +192,7 @@ class MetasploitModule < Msf::Auxiliary
             icmp_response, contents = icmp_packet(packet, datastore['RESP_CONT'])
 
             if not icmp_response
-              raise RuntimeError, "Could not build ICMP response"
+              raise "Could not build ICMP response"
             else
               # send response packet icmp_pkt
               send_icmp(icmp_response, contents)

--- a/modules/auxiliary/server/icmp_exfil.rb
+++ b/modules/auxiliary/server/icmp_exfil.rb
@@ -153,7 +153,7 @@ class MetasploitModule < Msf::Auxiliary
           icmp_response, contents = icmp_packet(packet, datastore['RESP_START'])
 
           if not icmp_response
-            raise RuntimeError ,"Could not build ICMP response"
+            raise RuntimeError, "Could not build ICMP response"
           else
             # send response packet icmp_pkt
             send_icmp(icmp_response, contents)
@@ -172,7 +172,7 @@ class MetasploitModule < Msf::Auxiliary
             icmp_response, contents = icmp_packet(packet, datastore['RESP_END'])
 
             if not icmp_response
-              raise RuntimeError , "Could not build ICMP response"
+              raise RuntimeError, "Could not build ICMP response"
             else
               # send response packet icmp_pkt
               send_icmp(icmp_response, contents)
@@ -192,7 +192,7 @@ class MetasploitModule < Msf::Auxiliary
             icmp_response, contents = icmp_packet(packet, datastore['RESP_CONT'])
 
             if not icmp_response
-              raise RuntimeError , "Could not build ICMP response"
+              raise RuntimeError, "Could not build ICMP response"
             else
               # send response packet icmp_pkt
               send_icmp(icmp_response, contents)

--- a/modules/auxiliary/spoof/arp/arp_poisoning.rb
+++ b/modules/auxiliary/spoof/arp/arp_poisoning.rb
@@ -72,8 +72,8 @@ class MetasploitModule < Msf::Auxiliary
       @interface = get_interface_guid(@interface)
       @smac = datastore['SMAC']
       @smac ||= get_mac(@interface) if @netifaces
-      raise RuntimeError, 'SMAC is not defined and can not be guessed' unless @smac
-      raise RuntimeError, 'Source MAC is not in correct format' unless is_mac?(@smac)
+      raise 'SMAC is not defined and can not be guessed' unless @smac
+      raise 'Source MAC is not in correct format' unless is_mac?(@smac)
 
       @sip = datastore['LOCALSIP']
       @sip ||= get_ipv4_addr(@interface) if @netifaces
@@ -162,7 +162,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def arp_poisoning
     lsmac = datastore['LOCALSMAC'] || @smac
-    raise RuntimeError, 'Local Source Mac is not in correct format' unless is_mac?(lsmac)
+    raise 'Local Source Mac is not in correct format' unless is_mac?(lsmac)
 
     dhosts_range = Rex::Socket::RangeWalker.new(datastore['DHOSTS'])
     @dhosts = []
@@ -199,7 +199,7 @@ class MetasploitModule < Msf::Auxiliary
       end
       Kernel.select(nil, nil, nil, 0.50)
     end
-    raise RuntimeError, "No hosts found" unless @dsthosts_cache.length > 0
+    raise "No hosts found" unless @dsthosts_cache.length > 0
 
     # Build the local src hosts cache
     if datastore['BIDIRECTIONAL']
@@ -236,7 +236,7 @@ class MetasploitModule < Msf::Auxiliary
         end
         Kernel.select(nil, nil, nil, 0.50)
       end
-      raise RuntimeError, "No hosts found" unless @srchosts_cache.length > 0
+      raise "No hosts found" unless @srchosts_cache.length > 0
     end
 
     if datastore['AUTO_ADD']

--- a/modules/auxiliary/spoof/arp/arp_poisoning.rb
+++ b/modules/auxiliary/spoof/arp/arp_poisoning.rb
@@ -72,8 +72,8 @@ class MetasploitModule < Msf::Auxiliary
       @interface = get_interface_guid(@interface)
       @smac = datastore['SMAC']
       @smac ||= get_mac(@interface) if @netifaces
-      raise RuntimeError ,'SMAC is not defined and can not be guessed' unless @smac
-      raise RuntimeError ,'Source MAC is not in correct format' unless is_mac?(@smac)
+      raise RuntimeError, 'SMAC is not defined and can not be guessed' unless @smac
+      raise RuntimeError, 'Source MAC is not in correct format' unless is_mac?(@smac)
 
       @sip = datastore['LOCALSIP']
       @sip ||= get_ipv4_addr(@interface) if @netifaces
@@ -162,7 +162,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def arp_poisoning
     lsmac = datastore['LOCALSMAC'] || @smac
-    raise RuntimeError ,'Local Source Mac is not in correct format' unless is_mac?(lsmac)
+    raise RuntimeError, 'Local Source Mac is not in correct format' unless is_mac?(lsmac)
 
     dhosts_range = Rex::Socket::RangeWalker.new(datastore['DHOSTS'])
     @dhosts = []


### PR DESCRIPTION
This came up while testing the mssql_login scanner against a non-MS SQL server. The exception path was hit, and it became clear there was a typo in the error path. This PR fixes a number of other incorrect calls to RuntimeError in error paths.

I considered removing them all from the whole tree, and just using the implicit 'raise "Message"' form everywhere, but Ruby is inconsistent about implicit RuntimeError, and the trailing caller was easy to miss. Of the following, only one is incorrect:

```
raise RuntimeError
raise "Cow"
raise RuntimeError, "Cow"
raise RuntimeError, "Cow", caller
raise "Cow", caller
```

So, I restricted updates to the areas where we already were getting it wrong.