### PR TITLE
Add OWA 2016 support

### DIFF
--- a/modules/auxiliary/scanner/http/owa_login.rb
+++ b/modules/auxiliary/scanner/http/owa_login.rb
@@ -16,7 +16,7 @@ class MetasploitModule < Msf::Auxiliary
     super(
       'Name'           => 'Outlook Web App (OWA) Brute Force Utility',
       'Description'    => %q{
-        This module tests credentials on OWA 2003, 2007, 2010, and 2013 servers.
+        This module tests credentials on OWA 2003, 2007, 2010, 2013, and 2016 servers.
       },
       'Author'         =>
         [
@@ -64,6 +64,15 @@ class MetasploitModule < Msf::Auxiliary
             'OWA_2013',
             {
               'Description' => 'OWA version 2013',
+              'AuthPath'    => '/owa/auth.owa',
+              'InboxPath'   => '/owa/',
+              'InboxCheck'  => /Inbox|logoff\.owa/
+            }
+          ],
+          [
+            'OWA_2016',
+            {
+              'Description' => 'OWA version 2016',
               'AuthPath'    => '/owa/auth.owa',
               'InboxPath'   => '/owa/',
               'InboxCheck'  => /Inbox|logoff\.owa/
@@ -158,13 +167,13 @@ class MetasploitModule < Msf::Auxiliary
     }
 
     if datastore['SSL']
-      if action.name == "OWA_2013"
+      if ["OWA_2013", "OWA_2016"].include?(action.name)
         data = 'destination=https://' << vhost << '/owa&flags=4&forcedownlevel=0&username=' << user << '&password=' << pass << '&isUtf8=1'
       else
         data = 'destination=https://' << vhost << '&flags=0&trusted=0&username=' << user << '&password=' << pass
       end
     else
-      if action.name == "OWA_2013"
+      if ["OWA_2013", "OWA_2016"].include?(action.name)
         data = 'destination=http://' << vhost << '/owa&flags=4&forcedownlevel=0&username=' << user << '&password=' << pass << '&isUtf8=1'
       else
         data = 'destination=http://' << vhost << '&flags=0&trusted=0&username=' << user << '&password=' << pass
@@ -201,12 +210,12 @@ class MetasploitModule < Msf::Auxiliary
       vprint_status("#{msg} Resolved hostname '#{datastore['RHOST']}' to address #{res.peerinfo['addr']}")
     end
 
-    if action.name != "OWA_2013" and res.get_cookies.empty?
+    if !["OWA_2013", "OWA_2016"].include?(action.name) && res.get_cookies.empty?
         print_error("#{msg} Received invalid repsonse due to a missing cookie (possibly due to invalid version), aborting")
         return :abort
     end
-    if action.name == "OWA_2013"
-      # Check for a response code to make sure login was valid. Changes from 2010 to 2013.
+    if ["OWA_2013", "OWA_2016"].include?(action.name)
+      # Check for a response code to make sure login was valid. Changes from 2010 to 2013 / 2016
       # Check if the password needs to be changed.
       if res.headers['location'] =~ /expiredpassword/
         print_good("#{msg} SUCCESSFUL LOGIN. #{elapsed_time} '#{user}' : '#{pass}': NOTE password change required")
@@ -222,8 +231,9 @@ class MetasploitModule < Msf::Auxiliary
 
       # No password change required moving on.
       # Check for valid login but no mailbox setup
-      if res.headers['location'] =~ /owa/ and res.headers['location'] !~ /reason/
-        print_good("#{msg} SUCCESSFUL LOGIN. #{elapsed_time} '#{user}' : '#{pass}': NOTE a mailbox is not setup")
+      print_good("server type: #{res.headers["X-FEServer"]}")
+      if res.headers['location'] =~ /owa/
+        print_good("#{msg} SUCCESSFUL LOGIN. #{elapsed_time} '#{user}' : '#{pass}'")
         report_cred(
           ip: res.peerinfo['addr'],
           port: datastore['RPORT'],
@@ -235,7 +245,7 @@ class MetasploitModule < Msf::Auxiliary
       end
 
       unless location = res.headers['location']
-        print_error("#{msg} No HTTP redirect.  This is not OWA 2013, aborting.")
+        print_error("#{msg} No HTTP redirect.  This is not OWA 2013 / 2016 system, aborting.")
         return :abort
       end
       reason = location.split('reason=')[1]


### PR DESCRIPTION
This adds OWA 2016 support explicitly to auxiliary/scanner/http/owa_login

## Verification

It seems to be very similar to 2013 from what I can tell. I added a print of the server HTTP header to verify that the user is actually connecting to an Exchange 2016 server.

- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/http/owa_login`
- [x] connect to a exchange 2016 OWA interface (contact me for an example)
- [x] **Verify** that it finds the user credentials as expected
- [x] **Verify** the thing does not fail against such a server

I wonder if the `action` parameter could be unified for auto-detection. Seems that following some redirects would remove the requirement for separate actions for different server types.
