### PR TITLE
Revert passive handler

### DIFF
--- a/modules/exploits/multi/handler.rb
+++ b/modules/exploits/multi/handler.rb
@@ -34,7 +34,6 @@ class MetasploitModule < Msf::Exploit::Remote
         'Arch'           => ARCH_ALL,
         'Targets'        => [ [ 'Wildcard Target', {} ] ],
         'DefaultTarget'  => 0,
-        'Stance'         => Msf::Exploit::Stance::Passive
       )
     )
 
@@ -42,7 +41,7 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         OptBool.new(
           "ExitOnSession",
-          [ true, "Return from the exploit after a session has been created", false ]
+          [ true, "Return from the exploit after a session has been created", true ]
         ),
         OptInt.new(
           "ListenerTimeout",

--- a/modules/exploits/multi/handler.rb
+++ b/modules/exploits/multi/handler.rb
@@ -57,7 +57,7 @@ class MetasploitModule < Msf::Exploit::Remote
     loop do
       break if session_created? && datastore['ExitOnSession']
       break if timeout > 0 && (stime + timeout < Time.now.to_f)
-      sleep(1)
+      Rex::ThreadSafe.sleep(1)
     end
   end
 end


### PR DESCRIPTION
Based on beginner user observations at Black Hat 2017 Metasploit training, I thought that optimizing multi/handler to the most common use-case would be a good thing. That is, making it run in the background without exiting as a passive stance module.

However, there have been a few problems in practice in changing this behavior:

  * There is no way to run a passive handler in the foreground
  * Bind payloads operate strangely
  * Running this default mode causes CPU usage to spike
  * And most importantly, it broke 10 years of blog/wiki/stack overflow canon, and a lot of sites do not explain how Passive exploits or the `jobs` command works. So it wasn't helpful for new users anyway 😞 

With an upcoming Metasploit 5 development branch, I think we have the ability to do something better than making this module swim against the stream. So, I'm reverting it. Fixes #8982