### PR TITLE
Add More Tab Completion Support

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -2198,16 +2198,7 @@ class Core
         if rh and not rh.empty?
           res << Rex::Socket.source_address(rh)
         else
-          res << Rex::Socket.source_address
-          # getifaddrs was introduced in 2.1.2
-          if Socket.respond_to?(:getifaddrs)
-            ifaddrs = Socket.getifaddrs.find_all do |ifaddr|
-              ((ifaddr.flags & Socket::IFF_LOOPBACK) == 0) &&
-                ifaddr.addr &&
-                ifaddr.addr.ip?
-            end
-            res += ifaddrs.map { |ifaddr| ifaddr.addr.ip_address }
-          end
+          res += tab_complete_source_address
         end
       else
       end

--- a/lib/msf/ui/console/command_dispatcher/exploit.rb
+++ b/lib/msf/ui/console/command_dispatcher/exploit.rb
@@ -164,6 +164,21 @@ class Exploit
     end
   end
 
+  def cmd_exploit_tabs(str, words)
+    fmt = {
+      '-e' => [ framework.encoders.map { |refname, mod| refname } ],
+      '-f' => [ nil                                               ],
+      '-h' => [ nil                                               ],
+      '-j' => [ nil                                               ],
+      '-n' => [ framework.nops.map { |refname, mod| refname }     ],
+      '-o' => [ true                                              ],
+      '-p' => [ framework.payloads.map { |refname, mod| refname } ],
+      '-t' => [ true                                              ],
+      '-z' => [ nil                                               ]
+    }
+    tab_complete_generic(fmt, str, words)
+  end
+
   alias cmd_run cmd_exploit
 
   def cmd_exploit_help

--- a/lib/msf/ui/console/command_dispatcher/jobs.rb
+++ b/lib/msf/ui/console/command_dispatcher/jobs.rb
@@ -341,6 +341,19 @@ module Msf
 
             print_status "Payload handler running as background job #{job_id}."
           end
+
+          def cmd_handler_tabs(str, words)
+            fmt = {
+              '-h' => [ nil                                               ],
+              '-x' => [ nil                                               ],
+              '-p' => [ framework.payloads.map { |refname, mod| refname } ],
+              '-P' => [ true                                              ],
+              '-H' => [ :address                                          ],
+              '-e' => [ framework.encoders.map { |refname, mod| refname } ],
+              '-n' => [ true                                              ]
+            }
+            tab_complete_generic(fmt, str, words)
+          end
         end
       end
     end

--- a/lib/msf/ui/console/command_dispatcher/payload.rb
+++ b/lib/msf/ui/console/command_dispatcher/payload.rb
@@ -155,17 +155,17 @@ module Msf
           def cmd_generate_tabs(str, words)
             fmt = {
               '-b' => [ true                                              ],
-              '-E' => [ nil,                                              ],
+              '-E' => [ nil                                               ],
               '-e' => [ framework.encoders.map { |refname, mod| refname } ],
-              '-h' => [ nil,                                              ],
-              '-o' => [ true,                                             ],
-              '-s' => [ true,                                             ],
-              '-f' => [ :file,                                            ],
-              '-t' => [ @@supported_formats,                              ],
-              '-p' => [ true,                                             ],
-              '-k' => [ nil,                                              ],
-              '-x' => [ :file,                                            ],
-              '-i' => [ true,                                             ]
+              '-h' => [ nil                                               ],
+              '-o' => [ true                                              ],
+              '-s' => [ true                                              ],
+              '-f' => [ :file                                             ],
+              '-t' => [ @@supported_formats                               ],
+              '-p' => [ true                                              ],
+              '-k' => [ nil                                               ],
+              '-x' => [ :file                                             ],
+              '-i' => [ true                                              ]
             }
             tab_complete_generic(fmt, str, words)
           end

--- a/lib/msf/ui/console/command_dispatcher/payload.rb
+++ b/lib/msf/ui/console/command_dispatcher/payload.rb
@@ -153,22 +153,39 @@ module Msf
           end
 
           def cmd_generate_tabs(str, words)
+            fmt = {
+              '-b' => [ true                                              ],
+              '-E' => [ nil,                                              ],
+              '-e' => [ framework.encoders.map { |refname, mod| refname } ],
+              '-h' => [ nil,                                              ],
+              '-o' => [ true,                                             ],
+              '-s' => [ true,                                             ],
+              '-f' => [ :file,                                            ],
+              '-t' => [ @@supported_formats,                              ],
+              '-p' => [ true,                                             ],
+              '-k' => [ nil,                                              ],
+              '-x' => [ :file,                                            ],
+              '-i' => [ true,                                             ]
+            }
+            tab_complete_spec(fmt, str, words)
+          end
+
+          def tab_complete_spec(fmt, str, words)
             last_word = words[-1]
-            fmt = @@generate_opts.fmt
             fmt = fmt.select { |key, value| last_word == key || !words.include?(key) }
 
-            option = fmt[last_word]
-            return fmt.keys if !option || !option[0]
+            val = fmt[last_word]
+            return fmt.keys if !val  # the last word does not look like a fmtspec
+            arg = val[0]
+            return fmt.keys if !arg  # the last word is a fmtspec that takes no argument
 
             tabs = []
-            case last_word
-              when '-e'
-                tabs = framework.encoders.map { |refname, mod| refname }
-              when '-f'
-                tabs = tab_complete_filenames(str, words)
-              when '-t'
-                tabs = @@supported_formats
+            if arg.to_s.to_sym == :file
+              tabs = tab_complete_filenames(str, words)
+            elsif arg.kind_of?(Array)
+              tabs = arg.map {|a| a.to_s}
             end
+            tabs
           end
         end
       end

--- a/lib/msf/ui/console/command_dispatcher/payload.rb
+++ b/lib/msf/ui/console/command_dispatcher/payload.rb
@@ -13,7 +13,7 @@ module Msf
           include Msf::Ui::Console::ModuleCommandDispatcher
 
           # Load supported formats
-          supported_formats = \
+          @@supported_formats = \
             Msf::Simple::Buffer.transform_formats + \
             Msf::Util::EXE.to_executable_fmt_formats
 
@@ -25,7 +25,7 @@ module Msf
             "-o" => [ true,  "A comma separated list of options in VAR=VAL format." ],
             "-s" => [ true,  "NOP sled length."                                     ],
             "-f" => [ true,  "The output file name (otherwise stdout)"              ],
-            "-t" => [ true,  "The output format: #{supported_formats.join(',')}"    ],
+            "-t" => [ true,  "The output format: #{@@supported_formats.join(',')}"    ],
             "-p" => [ true,  "The Platform for output."                             ],
             "-k" => [ false, "Keep the template executable functional"              ],
             "-x" => [ true,  "The executable template to use"                       ],
@@ -150,6 +150,25 @@ module Msf
               fd.close
             end
             true
+          end
+
+          def cmd_generate_tabs(str, words)
+            last_word = words[-1]
+            fmt = @@generate_opts.fmt
+            fmt = fmt.select { |key, value| last_word == key || !words.include?(key) }
+
+            option = fmt[last_word]
+            return fmt.keys if !option || !option[0]
+
+            tabs = []
+            case last_word
+              when '-e'
+                tabs = framework.encoders.map { |refname, mod| refname }
+              when '-f'
+                tabs = tab_complete_filenames(str, words)
+              when '-t'
+                tabs = @@supported_formats
+            end
           end
         end
       end

--- a/lib/msf/ui/console/command_dispatcher/payload.rb
+++ b/lib/msf/ui/console/command_dispatcher/payload.rb
@@ -167,25 +167,7 @@ module Msf
               '-x' => [ :file,                                            ],
               '-i' => [ true,                                             ]
             }
-            tab_complete_spec(fmt, str, words)
-          end
-
-          def tab_complete_spec(fmt, str, words)
-            last_word = words[-1]
-            fmt = fmt.select { |key, value| last_word == key || !words.include?(key) }
-
-            val = fmt[last_word]
-            return fmt.keys if !val  # the last word does not look like a fmtspec
-            arg = val[0]
-            return fmt.keys if !arg  # the last word is a fmtspec that takes no argument
-
-            tabs = []
-            if arg.to_s.to_sym == :file
-              tabs = tab_complete_filenames(str, words)
-            elsif arg.kind_of?(Array)
-              tabs = arg.map {|a| a.to_s}
-            end
-            tabs
+            tab_complete_generic(fmt, str, words)
           end
         end
       end

--- a/lib/rex/ui/text/dispatcher_shell.rb
+++ b/lib/rex/ui/text/dispatcher_shell.rb
@@ -248,6 +248,41 @@ module DispatcherShell
       matches
     end
 
+    def tab_complete_generic(fmt, str, words)
+      last_word = words[-1]
+      fmt = fmt.select { |key, value| last_word == key || !words.include?(key) }
+
+      val = fmt[last_word]
+      return fmt.keys if !val  # the last word does not look like a fmtspec
+      arg = val[0]
+      return fmt.keys if !arg  # the last word is a fmtspec that takes no argument
+
+      tabs = []
+      if arg.to_s.to_sym == :address
+        tabs = tab_complete_source_addresses
+      elsif arg.to_s.to_sym == :bool
+        tabs = ['true', 'false']
+      elsif arg.to_s.to_sym == :file
+        tabs = tab_complete_filenames(str, words)
+      elsif arg.kind_of?(Array)
+        tabs = arg.map {|a| a.to_s}
+      end
+      tabs
+    end
+
+    def tab_complete_source_address
+      addresses = [Rex::Socket.source_address]
+      # getifaddrs was introduced in 2.1.2
+      if Socket.respond_to?(:getifaddrs)
+        ifaddrs = Socket.getifaddrs.find_all do |ifaddr|
+          ((ifaddr.flags & Socket::IFF_LOOPBACK) == 0) &&
+            ifaddr.addr &&
+            ifaddr.addr.ip?
+        end
+        addresses += ifaddrs.map { |ifaddr| ifaddr.addr.ip_address }
+      end
+      addresses
+    end
   end
 
   #

--- a/lib/rex/ui/text/dispatcher_shell.rb
+++ b/lib/rex/ui/text/dispatcher_shell.rb
@@ -248,6 +248,18 @@ module DispatcherShell
       matches
     end
 
+    #
+    # Provide a generic tab completion function based on the specification
+    # pass as fmt. The fmt argument in a hash where values are an array
+    # defining how the command should be completed. The first element of the
+    # array can be one of:
+    #   nil      - This argument is a flag and takes no option.
+    #   true     - This argument takes an option with no suggestions.
+    #   :address - This option is a source address.
+    #   :bool    - This option is a boolean.
+    #   :file    - This option is a file path.
+    #   Array    - This option is an array of possible values.
+    #
     def tab_complete_generic(fmt, str, words)
       last_word = words[-1]
       fmt = fmt.select { |key, value| last_word == key || !words.include?(key) }
@@ -270,6 +282,9 @@ module DispatcherShell
       tabs
     end
 
+    #
+    # Return a list of possible source addresses for tab completion.
+    #
     def tab_complete_source_address
       addresses = [Rex::Socket.source_address]
       # getifaddrs was introduced in 2.1.2

--- a/lib/rex/ui/text/dispatcher_shell.rb
+++ b/lib/rex/ui/text/dispatcher_shell.rb
@@ -259,7 +259,7 @@ module DispatcherShell
 
       tabs = []
       if arg.to_s.to_sym == :address
-        tabs = tab_complete_source_addresses
+        tabs = tab_complete_source_address
       elsif arg.to_s.to_sym == :bool
         tabs = ['true', 'false']
       elsif arg.to_s.to_sym == :file


### PR DESCRIPTION
This pull request adds tab completion to the `exploit`, `generate`, and `handler` commands. This is accomplished using a new function that allows generic completion based on a specification passed as an argument similar to opt parse. Many of them need to list out modules, which is why the generation needs to be done in the method rather than at the class level. Additionally the specification format which is documented in the function `tab_complete_generic` utilizes an array so that additional options can be supported in the future.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Use a payload module and set all of the appropriate options
- [x] Type in `generate -t` and hit tab, see all of the supported types
- [x] Check that the `generate -f` flag completions file paths of where the payload shall go
- [x] Use an exploit module and set all of the appropriate options
- [x] Type in `exploit` and see that the `-n`, '-e', and `-p` flags are all tab completable
- [x] Type in `exploit -j` and see that since it's a flag the tab completion suggests the remaining unused flags
- [x] Check the options in a similar fashion for the `handler` command