### PR TITLE
Expose more uuid attributes

### DIFF
--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -634,7 +634,6 @@ class ReadableText
       sess_via     = session.via_exploit.to_s
       sess_type    = session.type.to_s
       sess_uuid    = session.payload_uuid.to_s
-      sess_puid    = session.payload_uuid.respond_to?(:puid_hex) ? session.payload_uuid.puid_hex : nil
       sess_luri    = session.exploit_datastore['LURI'] || "" if session.exploit_datastore
       sess_enc     = false
       if session.respond_to?(:tlv_enc_key) && session.tlv_enc_key && session.tlv_enc_key[:key]

--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -652,10 +652,10 @@ class ReadableText
         sess_checkin = "#{(Time.now.to_i - session.last_checkin.to_i)}s ago @ #{session.last_checkin.to_s}"
       end
 
-      if session.payload_uuid.respond_to?(:puid_hex) && (uuid_info = framework.uuid_db[sess_puid])
+      if session.payload_uuid.registered
         sess_registration = "Yes"
-        if uuid_info['name']
-          sess_registration << " - Name=\"#{uuid_info['name']}\""
+        if session.payload_uuid.name
+          sess_registration << " - Name=\"#{session.payload_uuid.name}\""
         end
       end
 

--- a/lib/msf/core/handler.rb
+++ b/lib/msf/core/handler.rb
@@ -222,7 +222,13 @@ protected
       s.set_from_exploit(assoc_exploit)
 
       # Pass along any associated payload uuid if specified
-      s.payload_uuid = opts[:payload_uuid] if opts[:payload_uuid]
+      if opts[:payload_uuid]
+        s.payload_uuid = opts[:payload_uuid]
+        if s.payload_uuid.respond_to?(:puid_hex) && (uuid_info = framework.uuid_db[sess_puid])
+          s.payload_uuid.name = uuid_info['name']
+          s.payload_uuid.timestamp = uuid_info['timestamp']
+        end
+      end
 
       # If the session is valid, register it with the framework and
       # notify any waiters we may have.

--- a/lib/msf/core/handler.rb
+++ b/lib/msf/core/handler.rb
@@ -224,7 +224,7 @@ protected
       # Pass along any associated payload uuid if specified
       if opts[:payload_uuid]
         s.payload_uuid = opts[:payload_uuid]
-        if s.payload_uuid.respond_to?(:puid_hex) && (uuid_info = framework.uuid_db[sess_puid])
+        if s.payload_uuid.respond_to?(:puid_hex) && (uuid_info = framework.uuid_db[session.payload_uuid.puid_hex])
           s.payload_uuid.registered = true
           s.payload_uuid.name = uuid_info['name']
           s.payload_uuid.timestamp = uuid_info['timestamp']

--- a/lib/msf/core/handler.rb
+++ b/lib/msf/core/handler.rb
@@ -224,7 +224,7 @@ protected
       # Pass along any associated payload uuid if specified
       if opts[:payload_uuid]
         s.payload_uuid = opts[:payload_uuid]
-        if s.payload_uuid.respond_to?(:puid_hex) && (uuid_info = framework.uuid_db[session.payload_uuid.puid_hex])
+        if s.payload_uuid.respond_to?(:puid_hex) && (uuid_info = framework.uuid_db[s.payload_uuid.puid_hex])
           s.payload_uuid.registered = true
           s.payload_uuid.name = uuid_info['name']
           s.payload_uuid.timestamp = uuid_info['timestamp']

--- a/lib/msf/core/handler.rb
+++ b/lib/msf/core/handler.rb
@@ -225,8 +225,11 @@ protected
       if opts[:payload_uuid]
         s.payload_uuid = opts[:payload_uuid]
         if s.payload_uuid.respond_to?(:puid_hex) && (uuid_info = framework.uuid_db[sess_puid])
+          s.payload_uuid.registered = true
           s.payload_uuid.name = uuid_info['name']
           s.payload_uuid.timestamp = uuid_info['timestamp']
+        else
+          s.payload_uuid.registered = false
         end
       end
 

--- a/lib/msf/core/payload/uuid.rb
+++ b/lib/msf/core/payload/uuid.rb
@@ -254,6 +254,10 @@ class Msf::Payload::UUID
     self.xor1      = opts[:xor1]
     self.xor2      = opts[:xor2]
 
+    self.timestamp  = nil
+    self.name       = nil
+    self.registered = false
+
     if opts[:seed]
       self.puid = self.class.seed_to_puid(opts[:seed])
     end
@@ -366,6 +370,10 @@ class Msf::Payload::UUID
     self.xor1 = self.xor2 = nil
     self
   end
+
+  attr_accessor :registered
+  attr_accessor :timestamp
+  attr_accessor :name
 
   attr_reader :arch
   attr_reader :platform


### PR DESCRIPTION
Make it easier to see registered UUID attributes from ruby simply by examining the session object.

requested by loki on #metasploit

Note - reverse_http/s works, reverse_tcp_uuid doesn't for some reason.

## Verification

- [ ] Start a Meterpreter session with a named registered payload
- [ ] **Verify** that `sessions -l -v` displays the name properly