### PR TITLE
Make external module read loop more robust

### DIFF
--- a/lib/msf/core/module/external.rb
+++ b/lib/msf/core/module/external.rb
@@ -2,19 +2,24 @@ include Msf::Auxiliary::Report
 
 module Msf::Module::External
   def wait_status(mod)
-    while mod.running
-      m = mod.get_status
-      if m
-        case m.method
-        when :message
-          log_output(m)
-        when :report
-          process_report(m)
-        when :reply
-          # we're done
-          break
+    begin
+      while mod.running
+        m = mod.get_status
+        if m
+          case m.method
+          when :message
+            log_output(m)
+          when :report
+            process_report(m)
+          when :reply
+            # we're done
+            break
+          end
         end
       end
+    rescue Exception => e #Msf::Modules::External::Bridge::Error => e
+      elog e.backtrace.join("\n")
+      fail_with Failure::UNKNOWN, e.message
     end
   end
 

--- a/modules/exploits/linux/smtp/haraka.py
+++ b/modules/exploits/linux/smtp/haraka.py
@@ -72,6 +72,7 @@ def send_mail(to, mailserver, cmd, mfrom, port):
     except smtplib.SMTPDataError as err:
       if err[0] == 450:
         module.log("Triggered bug in target server (%s)"%err[1], 'good')
+        s.close()
         return(True)
     module.log("Bug not triggered in target server", 'error')
     module.log("it may not be vulnerable or have the attachment plugin activated", 'error')


### PR DESCRIPTION
Changes from a "hope we get at most one message at a time" model to
something beginning to resemble a state machine. Also logs error output
and fails the MSF module when the external module fails.

Verification
========

- [ ] Your favorite external module (either `haraka` or [capture_test.py](https://gist.github.com/acammack-r7/aac49ba6c2af1bd3132aee8d76ed6b68) should still work.
- [ ] Anything logged to stderr from the external module should show up in `~/.msf4/logs/framework.log`