### PR TITLE
handle interrupt and unknown exceptions properly with external modules

### DIFF
--- a/lib/msf/core/module/external.rb
+++ b/lib/msf/core/module/external.rb
@@ -17,9 +17,11 @@ module Msf::Module::External
           end
         end
       end
-    rescue Exception => e #Msf::Modules::External::Bridge::Error => e
+    rescue Interrupt => e
+      raise e
+    rescue Exception => e
       elog e.backtrace.join("\n")
-      fail_with Failure::UNKNOWN, e.message
+      fail_with Msf::Module::Failure::Unknown, e.message
     end
   end
 


### PR DESCRIPTION
This fixes a bug handling interrupts with external modules. Rather than showing this when hitting Ctrl-C:

```
[*] Creating sockets...
^C[-] Auxiliary failed: NameError uninitialized constant Msf::Module::External::Failure
[-] Call stack:
[-]   /Users/bcook/rapid7/metasploit-framework/lib/msf/core/module/external.rb:22:in `rescue in wait_status'
[-]   /Users/bcook/rapid7/metasploit-framework/lib/msf/core/module/external.rb:5:in `wait_status'
[-]   /Users/bcook/rapid7/metasploit-framework/modules/auxiliary/dos/http/slowloris.py:51:in `run'
[*] Auxiliary module execution completed
```

It shows this instead:

```
[*] Creating sockets...
^C[-] Auxiliary interrupted by the console user
[*] Auxiliary module execution completed
msf auxiliary(slowloris) >
```