### PR TITLE
typo fixed in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Installing
 --
 
 Generally, you should use [the free installer](https://github.com/rapid7/metasploit-framework/wiki/Nightly-Installers),
-which contains all of the dependencies and will get you up and running with a
+which contains all of the dependencies and will get you up and run with a
 few clicks. See the [Dev Environment Setup](https://r-7.co/MSF-DEV) if
 you'd like to deal with dependencies on your own.
 


### PR DESCRIPTION
grammar fixed

The verb running after the modal verb `will` does not appear to be in the correct form. Consider changing the verb form

Metasploit is running without errors 😄 

Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use exploit/windows/smb/ms08_067_netapi`
- [x] ...
- [x] **Verify** the thing does what it should
- [x] **Verify** the thing does not do what it should not
- [x] **Document** the thing and how it works ([Example](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/post/multi/gather/aws_keys.md))

