### PR TITLE
Print the generated command stager for debugging

### DIFF
--- a/lib/msf/core/exploit/cmdstager.rb
+++ b/lib/msf/core/exploit/cmdstager.rb
@@ -137,6 +137,8 @@ module Exploit::CmdStager
       raise ArgumentError, 'The command stager could not be generated'
     end
 
+    vprint_status("Generated command stager: #{cmd_list.join}")
+
     cmd_list
   end
 


### PR DESCRIPTION
I can't believe this wasn't a thing.

- [x] `set verbose true`
- [x] Run an exploit that generates a command stager
- [x] See something useful for once