### PR TITLE
Fix include scope in external module mixin

### DIFF
--- a/lib/msf/core/module/external.rb
+++ b/lib/msf/core/module/external.rb
@@ -1,6 +1,6 @@
-include Msf::Auxiliary::Report
-
 module Msf::Module::External
+  include Msf::Auxiliary::Report
+
   def wait_status(mod)
     begin
       while mod.running


### PR DESCRIPTION
The auxiliary report mixin overrides some of the methods in
Metasploit::Credential, which is fine in framework, but causes issues in
projects relying on the base behavior of Metasploit::Credential. This
changes the include scope from global to just whatever includes the
external module mixin.