### PR TITLE
Make Metasploit 5 Development Branch

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    metasploit-framework (4.16.32)
+    metasploit-framework (5.0.0)
       actionpack (~> 4.2.6)
       activerecord (~> 4.2.6)
       activesupport (~> 4.2.6)
@@ -182,13 +182,13 @@ GEM
       activesupport (~> 4.2.6)
       railties (~> 4.2.6)
     metasploit-payloads (1.3.25)
-    metasploit_data_models (2.0.15)
+    metasploit_data_models (2.0.16)
       activerecord (~> 4.2.6)
       activesupport (~> 4.2.6)
       arel-helpers
       metasploit-concern
       metasploit-model
-      pg
+      pg (= 0.20.0)
       postgres_ext
       railties (~> 4.2.6)
       recog (~> 2.0)
@@ -203,7 +203,7 @@ GEM
     nessus_rest (0.1.6)
     net-ssh (4.2.0)
     network_interface (0.0.2)
-    nexpose (7.1.1)
+    nexpose (7.2.0)
     nokogiri (1.8.1)
       mini_portile2 (~> 2.3.0)
     octokit (4.8.0)

--- a/data/logos/under-construction-v5.txt
+++ b/data/logos/under-construction-v5.txt
@@ -1,0 +1,25 @@
+%clr%red               .;lxO0KXXXK0Oxl:.
+           ,o0WMMMMMMMMMMMMMMMMMMKd,
+        'xNMMMMMMMMMMMMMMMMMMMMMMMMMWx,
+      :KMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMK:
+    .KMMMMMMMMMMMMMMMWNNNWMMMMMMMMMMMMMMMX,
+   lWMMMMMMMMMMMXd:..     ..;dKMMMMMMMMMMMMo
+  xMMMMMMMMMMWd.               .oNMMMMMMMMMMk
+ oMMMMMMMMMMx.                    dMMMMMMMMMMx
+.WMMMMMMMMM:                       :MMMMMMMMMM,
+xMMMMMMMMMo                         lMMMMMMMMMO
+NMMMMMMMMW                    ,cccccoMMMMMMMMMWlccccc;
+MMMMMMMMMX                     ;KMMMMMMMMMMMMMMMMMMX:
+NMMMMMMMMW.                      ;KMMMMMMMMMMMMMMX:
+xMMMMMMMMMd                        ,0MMMMMMMMMMK;
+.WMMMMMMMMMc                         'OMMMMMM0,
+ lMMMMMMMMMMk.                         .kMMO'
+  dMMMMMMMMMMWd'                         ..
+   cWMMMMMMMMMMMNxc'.%clr%whi                ##########%clr
+%red    .0MMMMMMMMMMMMMMMMWc%clr%whi            #+#    #+#%clr
+%red      ;0MMMMMMMMMMMMMMMo.%clr%whi          +:+%clr
+%red        .dNMMMMMMMMMMMMo%clr          +%whi#+%clr+:++#+
+%red           'oOWMMMMMMMMo%clr                +:+
+%red               .,cdkO0K;%clr        :+:    :+:                                
+                                :::::::+:
+           %whiMetasploit%clr %yelUnder Construction%clr

--- a/lib/metasploit/framework/version.rb
+++ b/lib/metasploit/framework/version.rb
@@ -30,7 +30,7 @@ module Metasploit
         end
       end
 
-      VERSION = "4.16.32"
+      VERSION = "5.0.0"
       MAJOR, MINOR, PATCH = VERSION.split('.').map { |x| x.to_i }
       PRERELEASE = 'dev'
       HASH = get_hash

--- a/lib/msf/base/config.rb
+++ b/lib/msf/base/config.rb
@@ -33,20 +33,24 @@ class Config < Hash
       return val
     end
 
+    # XXX Update this when there is a need to break compatibility
+    config_dir_major = 4
+    config_dir = ".msf#{config_dir_major}"
+
     # Windows-specific environment variables
     ['HOME', 'LOCALAPPDATA', 'APPDATA', 'USERPROFILE'].each do |dir|
       val = Rex::Compat.getenv(dir)
       if (val and File.directory?(val))
-        return File.join(val, ".msf#{Metasploit::Framework::Version::MAJOR}")
+        return File.join(val, config_dir)
       end
     end
 
     begin
       # First we try $HOME/.msfx
-      File.expand_path("~#{FileSep}.msf#{Metasploit::Framework::Version::MAJOR}")
+      File.expand_path("~#{FileSep}#{config_dir}")
     rescue ::ArgumentError
       # Give up and install root + ".msfx"
-      InstallRoot + ".msf#{Metasploit::Framework::Version::MAJOR}"
+      InstallRoot + config_dir
     end
   end
 

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -231,22 +231,17 @@ class Core
 
     avdwarn = nil
 
-    banner_trailers = {
-      :version     => "%yelmetasploit v#{Metasploit::Framework::VERSION}%clr",
-      :exp_aux_pos => "#{framework.stats.num_exploits} exploits - #{framework.stats.num_auxiliary} auxiliary - #{framework.stats.num_post} post",
-      :pay_enc_nop => "#{framework.stats.num_payloads} payloads - #{framework.stats.num_encoders} encoders - #{framework.stats.num_nops} nops",
-      :free_trial  => "Free Metasploit Pro trial: http://r-7.co/trymsp",
-      :padding     => 48
-    }
+    stats       = framework.stats
+    version     = "%yelmetasploit v#{Metasploit::Framework::VERSION}%clr",
+    exp_aux_pos = "#{stats.num_exploits} exploits - #{stats.num_auxiliary} auxiliary - #{stats.num_post} post",
+    pay_enc_nop = "#{stats.num_payloads} payloads - #{stats.num_encoders} encoders - #{stats.num_nops} nops",
+    dev_note    = "** This is Metasploit 5 development branch **"
+    padding     = 48
 
-    banner << ("       =[ %-#{banner_trailers[:padding]+8}s]\n" % banner_trailers[:version])
-    banner << ("+ -- --=[ %-#{banner_trailers[:padding]}s]\n" % banner_trailers[:exp_aux_pos])
-    banner << ("+ -- --=[ %-#{banner_trailers[:padding]}s]\n" % banner_trailers[:pay_enc_nop])
-
-    # TODO: People who are already on a Pro install shouldn't see this.
-    # It's hard for Framework to tell the difference though since
-    # license details are only in Pro -- we can't see them from here.
-    banner << ("+ -- --=[ %-#{banner_trailers[:padding]}s]\n" % banner_trailers[:free_trial])
+    banner << ("       =[ %-#{padding+8}s]\n" % version)
+    banner << ("+ -- --=[ %-#{padding}s]\n" % exp_aux_pos)
+    banner << ("+ -- --=[ %-#{padding}s]\n" % pay_enc_nop)
+    banner << ("+ -- --=[ %-#{padding}s]\n" % dev_note)
 
     if ::Msf::Framework::EICARCorrupted
       avdwarn = []

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -23,7 +23,7 @@ class Driver < Msf::Ui::Driver
   ConfigCore  = "framework/core"
   ConfigGroup = "framework/ui/console"
 
-  DefaultPrompt     = "%undmsf%clr"
+  DefaultPrompt     = "%undmsf5%clr"
   DefaultPromptChar = "%clr>"
 
   #


### PR DESCRIPTION
It has been a long, long time coming, but I would like to convert the *master* branch in git into the Metasploit 5 development branch, maintaining the '4.x' branch in git as the Metasploit 4 stable branch.

This PR bumps the major version as a signifier that we will be landing things that are not 100% compatible with 4.x. Major items that we plan ship in this branch over the next year are:

 - ~Removal of the current database-backed module cache~ - [Complete](https://github.com/rapid7/metasploit-framework/pull/9220)
 - Replacing the builtin ActiveRecord-based database layer with a service-oriented version that allows for easier sharing of data (project 'Goliath')
 - Promoting listeners to first class objects (rather than only as side-effects of exploits)
 - Asynchronous session support
 - Improved direct integration with other offensive security tools
 - Improvements in the model for modules
 - Removal of deprecated features
 - Expanding support for module isolation, external modules (project 'Coldstone')
 - Improvements in usability, and some deviations from how Metasploit works today.

PRs that will be going into the 5.x branch will all have the *msf5* tag, all others will be cherry picked into the 4.x branch as well.

Good luck everyone!