### PR TITLE
add 'promptname' that expands the module path a bit more

### DIFF
--- a/lib/msf/core/module/full_name.rb
+++ b/lib/msf/core/module/full_name.rb
@@ -24,6 +24,11 @@ module Msf::Module::FullName
       type + '/' + refname
     end
 
+    def promptname
+      elements = refname.split('/')
+      "#{elements[-2]}/#{elements[-1]}"
+    end
+
     def shortname
       refname.split('/').last
     end
@@ -55,9 +60,16 @@ module Msf::Module::FullName
   end
 
   #
-  # Returns the module's framework short name.  This is a
-  # possibly conflicting name used for things like console
-  # prompts.
+  # Returns the module's framework prompt-friendly name.
+  #
+  # reverse_tcp
+  #
+  def promptname
+    self.class.promptname
+  end
+
+  #
+  # Returns the module's framework short name.
   #
   # reverse_tcp
   #

--- a/lib/msf/core/module/full_name.rb
+++ b/lib/msf/core/module/full_name.rb
@@ -25,8 +25,7 @@ module Msf::Module::FullName
     end
 
     def promptname
-      elements = refname.split('/')
-      "#{elements[-2]}/#{elements[-1]}"
+      refname
     end
 
     def shortname

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1107,7 +1107,7 @@ class Core
     if active_module
       # intentionally += and not << because we don't want to modify
       # datastore or the constant DefaultPrompt
-      prompt += " #{active_module.type}(%bld%red#{active_module.shortname}%clr)"
+      prompt += " #{active_module.type}(%bld%red#{active_module.promptname}%clr)"
     end
     prompt_char = framework.datastore['PromptChar'] || Msf::Ui::Console::Driver::DefaultPromptChar
     driver.update_prompt("#{prompt} ", prompt_char, true)

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -661,7 +661,7 @@ module Msf
             # Update the command prompt
             prompt = framework.datastore['Prompt'] || Msf::Ui::Console::Driver::DefaultPrompt
             prompt_char = framework.datastore['PromptChar'] || Msf::Ui::Console::Driver::DefaultPromptChar
-            driver.update_prompt("#{prompt} #{mod.type}(%bld%red#{mod.shortname}%clr) ", prompt_char, true)
+            driver.update_prompt("#{prompt} #{mod.type}(%bld%red#{mod.promptname}%clr) ", prompt_char, true)
           end
 
           #


### PR DESCRIPTION
This allows the user to see more of the module context by default, which is much more likely to make it possible to understand where you are in the module hierarchy.

See #9257

## Verification

- [ ] Start `msfconsole`
- [ ] `use exploit/windows/smb/ms08_067_netapi`
- [ ] **Verify** that the prompt now shows `exploit(windows/smb/ms08_067_netapi)`
- [ ] `use auxiliary/scanner/mdns/query`
- [ ] **Verify** that the prompt now shows `auxiliary(scanner/mdns/query)`

```
msf > use exploit/windows/smb/ms08_067_netapi
msf exploit(windows/smb/ms08_067_netapi) > use auxiliary/scanner/mdns/query
msf auxiliary(scanner/mdns/query) >
```

Check any other module too to verify that we don't have any with < 2 levels deep.