### PR TITLE
Add data type to creds in ssh_login.rb so they are saved to the database and accessible with the creds command.

### DIFF
--- a/modules/auxiliary/scanner/ssh/ssh_login.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login.rb
@@ -132,6 +132,7 @@ class MetasploitModule < Msf::Auxiliary
       case result.status
       when Metasploit::Model::Login::Status::SUCCESSFUL
         print_brute :level => :good, :ip => ip, :msg => "Success: '#{result.credential}' '#{result.proof.to_s.gsub(/[\r\n\e\b\a]/, ' ')}'"
+        credential_data[:private_type] = :password
         credential_core = create_credential(credential_data)
         credential_data[:core] = credential_core
         create_credential_login(credential_data)


### PR DESCRIPTION
Added credential data type so password is stored in the database and can be accessed with the creds command.

The ssh_login auxiliary wasn't storing a password to the database to access later with the creds command. The added line adds that functionality. There is not a reported bug or issue number that I could find.


## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use use auxiliary/scanner/ssh/ssh_login
- [x] set options needed for a successful login 
- [ ]  
```msf auxiliary(ssh_login) > set username root
username => root
msf auxiliary(ssh_login) > set password root
password => root
msf auxiliary(ssh_login) > run

[+] 192.168.59.223:22 - Success: 'root:root' 'uid=0(root) gid=0(root) groups=0(root) Linux metasploitable 2.6.24-16-server #1 SMP Thu Apr 10 13:58:00 UTC 2008 i686 GNU/Linux '
[*] Command shell session 2 opened (192.168.59.1:51067 -> 192.168.59.223:22) at 2017-11-30 12:22:21 -0600
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(ssh_login) > creds
Credentials
===========

host            origin          service       public  private  realm  private_type
----            ------          -------       ------  -------  -----  ------------
192.168.59.223  192.168.59.223  22/tcp (ssh)  root    root            Password
```
- [x] **Verify** the thing does not do what it should not
Does not break functionality of the aux ssh login scanner.
- [x] **Document**  - no new functionality to document.
