### PR TITLE
axe errant spaces at EOL

### DIFF
--- a/modules/exploits/windows/fileformat/office_ms17_11882.rb
+++ b/modules/exploits/windows/fileformat/office_ms17_11882.rb
@@ -16,9 +16,9 @@ class MetasploitModule < Msf::Exploit::Remote
     super(update_info(info,
       'Name' => 'Microsoft Office CVE-2017-11882',
       'Description' => %q{
-        Module exploits a flaw in how the Equation Editor that 
-        allows an attacker to execute arbitrary code in RTF files without 
-        interaction. The vulnerability is caused by the Equation Editor, 
+        Module exploits a flaw in how the Equation Editor that
+        allows an attacker to execute arbitrary code in RTF files without
+        interaction. The vulnerability is caused by the Equation Editor,
         to which fails to properly handle OLE objects in memory.
       },
       'Author' => ['mumbai', 'embedi'],


### PR DESCRIPTION
I missed the CI build failure caused by spaces at EOL in updates the original author made on my request when I landed it.  This corrects that.

## Verification

List the steps needed to make sure this thing works

- [x] Make sure the build passes
- [x] Make sure I haven't screwed something else up

