### PR TITLE
add initial module automation tests

### DIFF
--- a/test/modules/auxiliary/scanner/smb/smb_login.json
+++ b/test/modules/auxiliary/scanner/smb/smb_login.json
@@ -1,0 +1,68 @@
+{
+	"TEST_NAME": 			"smb_login test",
+	"REPORT_PREFIX":		"SmbLoginTest",
+	"FRAMEWORK_BRANCH": 		"upstream/master",
+	"HTTP_PORT":			5309,
+	"STARTING_LISTENER":		30000,
+	"CREDS_FILE":			"../JSON/creds.json",
+	"MSF_HOSTS":
+	[
+		{
+			"TYPE":			"VIRTUAL",
+			"METHOD":		"VM_TOOLS_UPLOAD",
+			"HYPERVISOR_CONFIG":    "../JSON/esxi_config.json",
+			"NAME": 		"APT_MSF_HOST",
+			"MSF_ARTIFACT_PATH":	"/home/msfuser/rapid7/test_artifacts",
+			"MSF_PATH":		"/home/msfuser/rapid7/metasploit-framework"
+		}
+	],
+
+	"TARGETS":
+	[
+		{
+			"TYPE":			"VIRTUAL",
+			"METHOD":		"EXPLOIT",
+			"NAME": 		"Win2008r2x64sp1",
+			"MODULES":	
+			[
+				{
+					"NAME":		"auxiliary/scanner/smb/smb_login",
+					"SETTINGS":	[
+								"smbuser=vagrant",
+								"smbpass=vagrant"
+							]
+				}
+			]
+		},
+		{
+			"TYPE":			"VIRTUAL",
+			"METHOD":		"EXPLOIT",
+			"NAME": 		"Win2012x64",
+			"MODULES":	
+			[
+				{
+					"NAME":		"auxiliary/scanner/smb/smb_login",
+					"SETTINGS":	[
+								"smbuser=vagrant",
+								"smbpass=vagrant"
+							]
+				}
+			]
+		}
+	],
+	"TARGET_GLOBALS":
+	{
+			"TYPE":			"VIRTUAL",
+			"HYPERVISOR_CONFIG":	"../JSON/esxi_config.json",
+			"METHOD":		"VM_TOOLS_UPLOAD",
+			"PAYLOAD_DIRECTORY":	"C:\\payload_test",
+			"TESTING_SNAPSHOT":	"TESTING_BASE",
+			"PYTHON":		"C:\\software\\x86\\python27\\python.exe",
+			"METERPRETER_PYTHON":	"C:\\software\\x86\\python27\\python.exe",
+			"METERPRETER_JAVA":	"C:\\software\\x86\\java\\bin\\java.exe"
+	},
+	"COMMAND_LIST": [],
+	"SUCCESS_LIST": [
+		"- Success:"
+	]
+}

--- a/test/modules/exploits/windows/smb/ms17_010_eternalblue.json
+++ b/test/modules/exploits/windows/smb/ms17_010_eternalblue.json
@@ -1,0 +1,99 @@
+{
+	"FRAMEWORK_BRANCH": 		"upstream/master",
+	"HTTP_PORT":			5309,
+	"STARTING_LISTENER":		30000,
+	"CREDS_FILE":                   "../JSON/creds.json",
+	"MSF_HOSTS":
+	[
+		{
+			"TYPE":			"VIRTUAL",
+			"METHOD":		"VM_TOOLS_UPLOAD",
+			"HYPERVISOR_CONFIG":	"../JSON/esxi_config.json",
+			"NAME": 		"APT_MSF_HOST",
+			"MSF_PATH":		"/home/msfuser/rapid7/metasploit-framework",
+			"MSF_ARTIFACT_PATH":	"/home/msfuser/rapid7/test_artifacts"
+		}
+	],
+        "TARGET_GLOBALS":
+        {
+                        "TYPE":                 "VIRTUAL",
+                        "HYPERVISOR_CONFIG":    "../JSON/esxi_config.json",
+                        "METHOD":               "VM_TOOLS_UPLOAD",
+                        "PAYLOAD_DIRECTORY":    "C:\\payload_test",
+                        "TESTING_SNAPSHOT":     "TESTING_BASE",
+                        "PYTHON":               "C:\\software\\x86\\python27\\python.exe",
+                        "METERPRETER_PYTHON":   "C:\\software\\x86\\python27\\python.exe",
+                        "METERPRETER_JAVA":     "C:\\software\\x86\\java\\bin\\java.exe"
+        },
+	"TARGETS":
+	[
+		{
+			"TYPE":                 "VIRTUAL",
+			"METHOD":		"EXPLOIT",
+			"NAME": 		"Win7x64"
+		}
+	],
+        "MODULES":
+        [
+                {
+                        "NAME":         "exploit/windows/smb/ms17_010_eternalblue",
+                        "SETTINGS":
+                        [
+                                "SMBUser=vagrant",
+                                "SMBPass=vagrant"
+                        ]
+                }
+        ],
+	"PAYLOADS": 
+	[
+		{	
+			"NAME":		"windows/x64/meterpreter/reverse_tcp",
+			"SETTINGS":	[]
+		}
+	],
+	"COMMAND_LIST": [
+		"<ruby>",
+		"sleep(60)",
+		"</ruby>",
+		"sessions -C sessions -l",
+		"<ruby>",
+		"sleep(60)",
+		"</ruby>",
+		"sessions -C sysinfo",
+		"<ruby>",
+		"sleep(10)",
+		"</ruby>",
+		"sessions -C sysinfo",
+		"<ruby>",
+		"sleep(10)",
+		"</ruby>",
+		"sessions -C sysinfo",
+		"<ruby>",
+		"sleep(10)",
+		"</ruby>",
+		"sessions -C sysinfo",
+		"<ruby>",
+		"sleep(10)",
+		"</ruby>",
+		"sessions -C sysinfo",
+		"<ruby>",
+		"sleep(10)",
+		"</ruby>",
+		"sessions -C sysinfo",
+		"<ruby>",
+		"sleep(10)",
+		"</ruby>",
+		"sessions -C sysinfo",
+		"<ruby>",
+		"sleep(10)",
+		"</ruby>",
+		"sessions -C sysinfo",
+		"sessions -C ifconfig",
+		"sessions -C sessions -l",
+		"sessions -C getuid",
+		"sessions -C exit"
+	],
+	"SUCCESS_LIST": [
+		"Session 1 created in the background"
+	]
+}


### PR DESCRIPTION
Add some initial automation test configurations.

For some time we have a been working on getting payload and module testing automation in place for end to end integration testing for Metasploit Framework.  This PR represents out first couple tests of module functionality attached to a PR with automated execution results.

As we proceed all PRs containing new `.json` test configuration provide in paths to mirror the msfconsole's structure will have tests executed in a sandbox when the PR is opened or new commits are added to the PR.

This PR provides some important initial values for configuration of automated tests run by our sandbox.

`"CREDS_FILE":			"../JSON/creds.json"`
`"HYPERVISOR_CONFIG":    "../JSON/esxi_config.json"`
`"FRAMEWORK_BRANCH": 		"upstream/master"`

These values when set in a test are standardized and will be overridden during execution to match the sandbox.  All tests merged in a PR should have these default values in place when landed.

## Verification

List the steps needed to make sure this thing works

- [ ] PR builder for `Metasploit Automation - Test Execution` success
