### PR TITLE
Handle IPv6 addresses in full_uri (add brackets)

### DIFF
--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -474,7 +474,13 @@ module Exploit::Remote::HttpClient
 
     uri = normalize_uri(custom_uri || target_uri.to_s)
 
-    "#{uri_scheme}://#{rhost}#{uri_port}#{uri}"
+    if Rex::Socket.is_ipv6?(rhost)
+      uri_host = "[#{rhost}]"
+    else
+      uri_host = rhost
+    end
+
+    "#{uri_scheme}://#{uri_host}#{uri_port}#{uri}"
   end
 
   #


### PR DESCRIPTION
We're not ready for IPv6.

```
[12/07/2017 18:48:05] [e(0)] core: Error running against host [redacted]: bad URI(is not URI?): http://[redacted]/
/opt/metasploit-framework/embedded/lib/ruby/2.4.0/uri/rfc3986_parser.rb:67:in `split'
/opt/metasploit-framework/embedded/lib/ruby/2.4.0/uri/rfc3986_parser.rb:73:in `parse'
/opt/metasploit-framework/embedded/lib/ruby/2.4.0/uri/common.rb:231:in `parse'
/opt/metasploit-framework/embedded/framework/modules/auxiliary/scanner/http/ms15_034_http_sys_memory_dump.rb:59:in `potential_static_files_uris'
/opt/metasploit-framework/embedded/framework/modules/auxiliary/scanner/http/ms15_034_http_sys_memory_dump.rb:78:in `check_host'
/opt/metasploit-framework/embedded/framework/modules/auxiliary/scanner/http/ms15_034_http_sys_memory_dump.rb:164:in `run_host'
/opt/metasploit-framework/embedded/framework/lib/msf/core/auxiliary/scanner.rb:135:in `block (2 levels) in run'
/opt/metasploit-framework/embedded/framework/lib/msf/core/thread_manager.rb:100:in `block in spawn'
```

- [x] `use auxiliary/scanner/http/ms15_034_http_sys_memory_dump`
- [x] `set rhost` to an IPv6 address
- [x] *Ensure* a web server is running on the address and port specified
- [x] Make sure you don't receive a `URI::InvalidURIError` from missing brackets

Via jabberwock on IRC. Thanks to @acammack-r7.