### PR TITLE
Fixed a spelling error in SysGauge Client buffer overflow documentation

### DIFF
--- a/documentation/modules/exploit/windows/smtp/sysgauge_client_bof.md
+++ b/documentation/modules/exploit/windows/smtp/sysgauge_client_bof.md
@@ -4,7 +4,7 @@
 via its SMTP server validation. The module sends a malicious response along in the
 220 service ready response and exploits the client, resulting in an unprivileged shell.
 
-  he software is available for download from [SysGauge](http://www.sysgauge.com/setups/sysgauge_setup_v1.5.18.exe).
+  The software is available for download from [SysGauge](http://www.sysgauge.com/setups/sysgauge_setup_v1.5.18.exe).
 
 ## Verification Steps
 


### PR DESCRIPTION
Found a spelling error while looking through some previous documentation, nothing major, this just fixes the error.