### PR TITLE
Fix OverrideLHOST/LPORT with http/s Meterpreter payloads.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 1.3.19)
+      metasploit-payloads (= 1.3.20)
       metasploit_data_models
       metasploit_payloads-mettle (= 0.2.8)
       msgpack
@@ -178,7 +178,7 @@ GEM
       activemodel (~> 4.2.6)
       activesupport (~> 4.2.6)
       railties (~> 4.2.6)
-    metasploit-payloads (1.3.19)
+    metasploit-payloads (1.3.20)
     metasploit_data_models (2.0.15)
       activerecord (~> 4.2.6)
       activesupport (~> 4.2.6)

--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -369,6 +369,8 @@ protected
           blob = self.generate_stage(
             url:   url,
             uuid:  uuid,
+            lhost: uri.host,
+            lport: uri.port,
             uri:   conn_id
           )
 

--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -369,8 +369,6 @@ protected
           blob = self.generate_stage(
             url:   url,
             uuid:  uuid,
-            lhost: uri.host,
-            lport: uri.port,
             uri:   conn_id
           )
 

--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -360,7 +360,6 @@ protected
 
         # Damn you, python! Ruining my perfect world!
         url += "\x00" unless uuid.arch == ARCH_PYTHON
-        uri = URI(payload_uri(req) + conn_id)
 
         # TODO: does this have to happen just for windows, or can we set it for all?
         resp['Content-Type'] = 'application/octet-stream' if uuid.platform == 'windows'

--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -339,6 +339,13 @@ protected
 
     self.pending_connections += 1
 
+    resp.body = ''
+    resp.code = 200
+    resp.message = 'OK'
+
+    url = payload_uri(req) + conn_id
+    url << '/' unless url[-1] == '/'
+
     # Process the requested resource.
     case info[:mode]
       when :init_connect
@@ -354,58 +361,27 @@ protected
         pkt.add_tlv(Rex::Post::Meterpreter::TLV_TYPE_TRANS_URL, conn_id + "/")
         resp.body = pkt.to_r
 
-      when :init_python, :init_native, :init_java
+      when :init_python, :init_native, :init_java, :connect
         # TODO: at some point we may normalise these three cases into just :init
-        url = payload_uri(req) + conn_id + '/'
 
-        # Damn you, python! Ruining my perfect world!
-        url += "\x00" unless uuid.arch == ARCH_PYTHON
+        if info[:mode] == :connect
+          print_status("Attaching orphaned/stageless session...")
+        else
+          begin
+            blob = self.generate_stage(url: url, uuid: uuid, uri: conn_id)
+            blob = encode_stage(blob) if self.respond_to?(:encode_stage)
 
-        # TODO: does this have to happen just for windows, or can we set it for all?
-        resp['Content-Type'] = 'application/octet-stream' if uuid.platform == 'windows'
+            print_status("Staging #{uuid.arch} payload (#{blob.length} bytes) ...")
 
-        begin
-          blob = self.generate_stage(
-            url:   url,
-            uuid:  uuid,
-            uri:   conn_id
-          )
+            resp['Content-Type'] = 'application/octet-stream'
+            resp.body = blob
 
-          blob = encode_stage(blob) if self.respond_to?(:encode_stage)
-
-          print_status("Staging #{uuid.arch} payload (#{blob.length} bytes) ...")
-
-          resp.body = blob
-
-          # Short-circuit the payload's handle_connection processing for create_session
-          create_session(cli, {
-            :passive_dispatcher => self.service,
-            :conn_id            => conn_id,
-            :url                => url,
-            :expiration         => datastore['SessionExpirationTimeout'].to_i,
-            :comm_timeout       => datastore['SessionCommunicationTimeout'].to_i,
-            :retry_total        => datastore['SessionRetryTotal'].to_i,
-            :retry_wait         => datastore['SessionRetryWait'].to_i,
-            :ssl                => ssl?,
-            :payload_uuid       => uuid
-          })
-        rescue NoMethodError
-          print_error("Staging failed. This can occur when stageless listeners are used with staged payloads.")
-          return
+          rescue NoMethodError
+            print_error("Staging failed. This can occur when stageless listeners are used with staged payloads.")
+            return
+          end
         end
 
-      when :connect
-        print_status("Attaching orphaned/stageless session...")
-
-        resp.body = ''
-
-        url = payload_uri(req) + conn_id
-        url << '/' unless url[-1] == '/'
-
-        # Damn you, python! Ruining my perfect world!
-        url += "\x00" unless uuid.arch == ARCH_PYTHON
-
-        # Short-circuit the payload's handle_connection processing for create_session
         create_session(cli, {
           :passive_dispatcher => self.service,
           :conn_id            => conn_id,
@@ -422,8 +398,6 @@ protected
         unless [:unknown_uuid, :unknown_uuid_url].include?(info[:mode])
           print_status("Unknown request to #{request_summary}")
         end
-        resp.code    = 200
-        resp.message = 'OK'
         resp.body    = datastore['HttpUnknownRequestResponse'].to_s
         self.pending_connections -= 1
     end
@@ -435,6 +409,5 @@ protected
   end
 
 end
-
 end
 end

--- a/lib/msf/core/payload/python/meterpreter_loader.rb
+++ b/lib/msf/core/payload/python/meterpreter_loader.rb
@@ -110,9 +110,9 @@ module Payload::Python::MeterpreterLoader
       callback_url = [
         opts[:url].to_s.split(':')[0],
         '://',
-        (ds['OverrideRequestHost'] == true ? ds['OverrideRequestLHOST'] : ds['LHOST']).to_s,
+        (ds['OverrideRequestHost'] ? ds['OverrideRequestLHOST'] : ds['LHOST']).to_s,
         ':',
-        (ds['OverrideRequestHost'] == true ? ds['OverrideRequestLPORT'] : ds['LPORT']).to_s,
+        (ds['OverrideRequestHost'] ? ds['OverrideRequestLPORT'] : ds['LPORT']).to_s,
         ds['LURI'].to_s,
         uri,
         '/'

--- a/lib/msf/core/payload/python/meterpreter_loader.rb
+++ b/lib/msf/core/payload/python/meterpreter_loader.rb
@@ -119,8 +119,6 @@ module Payload::Python::MeterpreterLoader
 
       callback_url = "#{scheme}://#{lhost}:#{lport}#{ds['LURI']}#{uri}/"
 
-      $stderr.puts callback_url
-
       # patch in the various payload related configuration
       met.sub!('HTTP_CONNECTION_URL = None', "HTTP_CONNECTION_URL = '#{var_escape.call(callback_url)}'")
       met.sub!('HTTP_USER_AGENT = None', "HTTP_USER_AGENT = '#{var_escape.call(http_user_agent)}'") if http_user_agent.to_s != ''

--- a/lib/msf/core/payload/transport_config.rb
+++ b/lib/msf/core/payload/transport_config.rb
@@ -37,10 +37,9 @@ module Msf::Payload::TransportConfig
   def transport_config_reverse_https(opts={})
     ds = opts[:datastore] || datastore
     config = transport_config_reverse_http(opts)
+    config[:scheme] = 'https'
     if ds['OverrideRequestHost']
-      config[:scheme] = ds['OverrideScheme'] || 'https'
-    else
-      config[:scheme] = 'https'
+      config[:scheme] = ds['OverrideScheme'] || config[:scheme]
     end
     config[:ssl_cert_hash] = get_ssl_cert_hash(ds['StagerVerifySSLCert'],
                                                ds['HandlerSSLCert'])
@@ -64,9 +63,9 @@ module Msf::Payload::TransportConfig
     lhost = ds['LHOST']
     lport = ds['LPORT']
     if ds['OverrideRequestHost']
-      scheme = ds['OverrideScheme'] || 'http'
-      lhost = ds['OverrideLHOST'] || ds['LHOST']
-      lport = ds['OverrideLPORT'] || ds['LPORT']
+      scheme = ds['OverrideScheme'] || scheme
+      lhost = ds['OverrideLHOST'] || lhost
+      lport = ds['OverrideLPORT'] || lport
     end
 
     {

--- a/lib/msf/core/payload/transport_config.rb
+++ b/lib/msf/core/payload/transport_config.rb
@@ -37,7 +37,11 @@ module Msf::Payload::TransportConfig
   def transport_config_reverse_https(opts={})
     ds = opts[:datastore] || datastore
     config = transport_config_reverse_http(opts)
-    config[:scheme] = ds['OverrideScheme'] || 'https'
+    if ds['OverrideRequestHost']
+      config[:scheme] = ds['OverrideScheme'] || 'https'
+    else
+      config[:scheme] = 'https'
+    end
     config[:ssl_cert_hash] = get_ssl_cert_hash(ds['StagerVerifySSLCert'],
                                                ds['HandlerSSLCert'])
     config
@@ -55,10 +59,20 @@ module Msf::Payload::TransportConfig
     end
 
     ds = opts[:datastore] || datastore
+
+    scheme = 'http'
+    lhost = ds['LHOST']
+    lport = ds['LPORT']
+    if ds['OverrideRequestHost']
+      scheme = ds['OverrideScheme'] || 'http'
+      lhost = ds['OverrideLHOST'] || ds['LHOST']
+      lport = ds['OverrideLPORT'] || ds['LPORT']
+    end
+
     {
-      scheme:          ds['OverrideScheme'] || 'http',
-      lhost:           opts[:lhost] || ds['LHOST'],
-      lport:           (opts[:lport] || ds['LPORT']).to_i,
+      scheme:          scheme,
+      lhost:           lhost,
+      lport:           lport.to_i,
       uri:             uri,
       ua:              ds['HttpUserAgent'],
       proxy_host:      ds['HttpProxyHost'],

--- a/lib/msf/core/payload/transport_config.rb
+++ b/lib/msf/core/payload/transport_config.rb
@@ -37,10 +37,6 @@ module Msf::Payload::TransportConfig
   def transport_config_reverse_https(opts={})
     ds = opts[:datastore] || datastore
     config = transport_config_reverse_http(opts)
-    config[:scheme] = 'https'
-    if ds['OverrideRequestHost']
-      config[:scheme] = ds['OverrideScheme'] || config[:scheme]
-    end
     config[:ssl_cert_hash] = get_ssl_cert_hash(ds['StagerVerifySSLCert'],
                                                ds['HandlerSSLCert'])
     config
@@ -59,7 +55,7 @@ module Msf::Payload::TransportConfig
 
     ds = opts[:datastore] || datastore
 
-    scheme = 'http'
+    scheme = opts[:url].to_s.split(':')[0]
     lhost = ds['LHOST']
     lport = ds['LPORT']
     if ds['OverrideRequestHost']

--- a/lib/msf/core/payload/transport_config.rb
+++ b/lib/msf/core/payload/transport_config.rb
@@ -36,10 +36,24 @@ module Msf::Payload::TransportConfig
 
   def transport_config_reverse_https(opts={})
     ds = opts[:datastore] || datastore
+    opts[:scheme] ||= 'https'
     config = transport_config_reverse_http(opts)
     config[:ssl_cert_hash] = get_ssl_cert_hash(ds['StagerVerifySSLCert'],
                                                ds['HandlerSSLCert'])
     config
+  end
+
+  def transport_uri_components(opts={})
+    ds = opts[:datastore] || datastore
+    scheme = opts[:scheme]
+    lhost = ds['LHOST']
+    lport = ds['LPORT']
+    if ds['OverrideRequestHost']
+      scheme = ds['OverrideScheme'] || scheme
+      lhost = ds['OverrideLHOST'] || lhost
+      lport = ds['OverrideLPORT'] || lport
+    end
+    [scheme, lhost, lport]
   end
 
   def transport_config_reverse_http(opts={})
@@ -54,15 +68,8 @@ module Msf::Payload::TransportConfig
     end
 
     ds = opts[:datastore] || datastore
-
-    scheme = opts[:url].to_s.split(':')[0]
-    lhost = ds['LHOST']
-    lport = ds['LPORT']
-    if ds['OverrideRequestHost']
-      scheme = ds['OverrideScheme'] || scheme
-      lhost = ds['OverrideLHOST'] || lhost
-      lport = ds['OverrideLPORT'] || lport
-    end
+    opts[:scheme] ||= 'http'
+    scheme, lhost, lport = transport_uri_components(opts)
 
     {
       scheme:          scheme,

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -70,7 +70,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '1.3.19'
+  spec.add_runtime_dependency 'metasploit-payloads', '1.3.20'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '0.2.8'
   # Needed by msfgui and other rpc components

--- a/modules/payloads/singles/python/meterpreter_bind_tcp.rb
+++ b/modules/payloads/singles/python/meterpreter_bind_tcp.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/meterpreter_python'
 
 module MetasploitModule
 
-  CachedSize = 57798
+  CachedSize = 58390
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/singles/python/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_http.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/meterpreter_python'
 
 module MetasploitModule
 
-  CachedSize = 57762
+  CachedSize = 58354
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/singles/python/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_https.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/meterpreter_python'
 
 module MetasploitModule
 
-  CachedSize = 57762
+  CachedSize = 58354
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/singles/python/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_tcp.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/meterpreter_python'
 
 module MetasploitModule
 
-  CachedSize = 57714
+  CachedSize = 58306
 
   include Msf::Payload::Single
   include Msf::Payload::Python


### PR DESCRIPTION
It looks like in #8948 we lost the ability for overriding lport/lhost when the stage is generated. This patch fixes the behavior, but I'm not entirely sure why this change was made in the original PR (looks like the intent was to derive more from uri). I'm likely wrong in this patch and the fix needs to be further in.

@OJ could you help me with this one?

## Verification

- [x] Follow the steps with #9258  (setting up a proxy is optional, you can just observe traffic with multiple handler ports)
- [x] **Verify** that reverse_http meterpreters connect back on OverrideLHOST / LPORT instead of LHOST/LPORT