### PR TITLE
Update wp_slideshowgallery_upload.rb

### DIFF
--- a/modules/exploits/unix/webapp/wp_slideshowgallery_upload.rb
+++ b/modules/exploits/unix/webapp/wp_slideshowgallery_upload.rb
@@ -64,7 +64,7 @@ class MetasploitModule < Msf::Exploit::Remote
       print_error("Unable to login as #{user}")
       return
     end
-    store_valid_credential(user: username, private: password, proof: cookie)
+    store_valid_credential(user: user, private: password, proof: cookie)
 
     print_status("Trying to upload payload")
     filename = "#{rand_text_alpha_lower(8)}.php"


### PR DESCRIPTION
Variable on line 67 needs to be changed to "user" from "username" which was undefined and causing error during exploit execution.

[-] Exploit failed: NameError undefined local variable or method `username' for #<Msf::Modules::Mod6578706c6f69742f756e69782f7765626170702f77705f736c69646573686f7767616c6c6572795f75706c6f6164::MetasploitModule:0x0055c61ab093f8>

After changing the incorrect variable name from "username" to "user", the exploit completes.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use exploit/windows/smb/ms08_067_netapi`
- [ ] ...
- [ ] **Verify** the thing does what it should
- [ ] **Verify** the thing does not do what it should not
- [ ] **Document** the thing and how it works ([Example](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/post/multi/gather/aws_keys.md))

