### PR TITLE
Allow local_editor in cmd_edit to take arguments

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -92,7 +92,7 @@ module Msf
               end
 
               print_status("Launching #{editor} #{path}")
-              system(editor, path)
+              system(*editor.split, path)
 
               # XXX: This will try to reload *any* .rb and break on modules
               if args.length > 0 && path.end_with?('.rb')


### PR DESCRIPTION
Such as `vim -i NONE`. This may allow command injection via arguments. However, you can already start an arbitrary program by setting `LocalEditor` or escaping the editor.

```
msf > setg LocalEditor /bin/sh
LocalEditor => /bin/sh
msf > edit -i
[*] Launching /bin/sh -i
$
```

**Edit:** `vim -u` would be a more common use case, such as when sharing a box with another pentester. Also, this functionality aligns with how `$EDITOR` or `$VISUAL` can be used with arguments.