### PR TITLE
Ensure tab completion in HWBridge sessions works as expected.

### DIFF
--- a/lib/msf/base/sessions/hwbridge.rb
+++ b/lib/msf/base/sessions/hwbridge.rb
@@ -1,7 +1,7 @@
 # -*- coding: binary -*-
 
 require 'msf/base'
-
+require 'msf/base/sessions/scriptable'
 require 'rex/post/hwbridge'
 
 module Msf
@@ -24,6 +24,7 @@ class HWBridge  < Rex::Post::HWBridge::Client
   # This interface supports interactive commands.
   #
   include Msf::Session::Interactive
+  include Msf::Session::Scriptable
 
   #
   # Initialize the HWBridge console

--- a/lib/rex/post/hwbridge/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/hwbridge/ui/console/command_dispatcher/core.rb
@@ -414,11 +414,11 @@ class Console::CommandDispatcher::Core
     if !words[1] || !words[1].match(/^\//)
       begin
         if msf_loaded?
-          tabs << tab_complete_postmods
+          tabs = tab_complete_postmods
         end
         [  # We can just use Meterpreters script path
-          ::Msf::Sessions::Meterpreter.script_base,
-          ::Msf::Sessions::Meterpreter.user_script_base
+          ::Msf::Sessions::HWBridge.script_base,
+          ::Msf::Sessions::HWBridge.user_script_base
         ].each do |dir|
           next unless ::File.exist? dir
           tabs += ::Dir.new(dir).find_all { |e|


### PR DESCRIPTION
Talking with @zombieCraig, it came up that tab completion wasn't working as-expected for HWBridge sessions.  This PR rectifies that, now tab completion works as it does in a Meterpreter session.

## Verification

Do this:

- [x] Start `msfconsole`
- [x] `use auxiliary/server/local_hwbridge`
- [x] `set uripath /`
- [x] `run` <press ENTER a few times to get the msfconsole prompt back>
- [x] `use auxiliary/client/hwbridge/connect`
- [x] `run`
- [x] `sessions -i 1` (you should now be at a `hwbridge` prompt)
- [x] type `run post/hwbridge/automotive/` and hit TAB a few times
- [x] **Verify** you see a list of available post modules

![tab-completion](https://user-images.githubusercontent.com/19912177/34056198-a63092a2-e197-11e7-93d2-be6cdb010ef8.gif)