### PR TITLE
Fix #8972, Remove libsodium until packaged better

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,7 +37,6 @@ PATH
       railties
       rb-readline
       rbnacl (< 5.0.0)
-      rbnacl-libsodium
       recog
       redcarpet
       rex-arch
@@ -247,8 +246,6 @@ GEM
     rb-readline (0.5.5)
     rbnacl (4.0.2)
       ffi
-    rbnacl-libsodium (1.0.16)
-      rbnacl (>= 3.0.1)
     recog (2.1.17)
       nokogiri
     redcarpet (3.4.0)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -125,7 +125,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'dnsruby'
   spec.add_runtime_dependency 'net-ssh'
   spec.add_runtime_dependency 'rbnacl', ['< 5.0.0']
-  spec.add_runtime_dependency 'rbnacl-libsodium'
   spec.add_runtime_dependency 'bcrypt_pbkdf'
   spec.add_runtime_dependency 'ruby_smb'
 


### PR DESCRIPTION
Due to issues with packaging for multiple platforms libsodium as an optional dependency for 'rbnacl' is being removed.  Once packaging issue are resolved this will be restored.  This removes support for `ed25519` keys used with ssh for the time being however manual installation of this gem allows user to workaround this limitation.


## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [ ] interact with some ssh module or package
