### PR TITLE
Fix #7779, fix multi/meterpreter/reverse_http with web_delivery

### DIFF
--- a/lib/msf/core/payload/windows/reverse_http.rb
+++ b/lib/msf/core/payload/windows/reverse_http.rb
@@ -128,7 +128,7 @@ module Payload::Windows::ReverseHttp
   # Generate the URI for the initial stager
   #
   def generate_small_uri
-    generate_uri_uuid_mode(:init_native, 5)
+    generate_uri_uuid_mode(:init_native, 30)
   end
 
   #


### PR DESCRIPTION
This change fixes #7779 but I'm not if it's the right fix. I've been meaning to submit for a while.
The original ticket has better steps to reproduce than I can provide here, but basically you need to use the web_delivery module (with `windows/meterpreter/reverse_http` payload) to deliver a session to a `multi/meterpreter/reverse_http` handler.
Before:
`Exception handling request: Invalid platform:`
After:
`Session :)`