### PR TITLE
Add new method for fetching parsed cookies from an HTTP response

### DIFF
--- a/lib/rex/proto/http/response.rb
+++ b/lib/rex/proto/http/response.rb
@@ -1,4 +1,5 @@
 # -*- coding: binary -*-
+require 'cgi'
 require 'uri'
 require 'rex/proto/http'
 require 'nokogiri'
@@ -82,6 +83,18 @@ class Response < Packet
     end
 
     return cookies.strip
+  end
+
+  #
+  # Gets cookies from the Set-Cookie header in a parsed format
+  #
+  def get_cookies_parsed
+    if (self.headers.include?('Set-Cookie'))
+      ret = CGI::Cookie::parse(self.headers['Set-Cookie'])
+    else
+      ret = {}
+    end
+    ret
   end
 
 

--- a/spec/lib/rex/proto/http/response_spec.rb
+++ b/spec/lib/rex/proto/http/response_spec.rb
@@ -133,6 +133,14 @@ RSpec.describe Rex::Proto::Http::Response do
     HEREDOC
   end
 
+  let (:get_cookies_spaces_and_missing_semicolon) do
+    <<-HEREDOC.gsub(/^ {6}/, '')
+      HTTP/1.1 200 OK
+      Set-Cookie: k1=v1; k2=v2;k3=v3
+
+    HEREDOC
+  end
+
   let (:meta_name) do
     'META_NAME'
   end
@@ -176,7 +184,7 @@ RSpec.describe Rex::Proto::Http::Response do
       <genre>Computer</genre>
       <price>44.95</price>
       <publish_date>2000-10-01</publish_date>
-      <description>An in-depth look at creating applications 
+      <description>An in-depth look at creating applications
       with XML.</description>
    </book>
 </catalog>
@@ -394,6 +402,22 @@ RSpec.describe Rex::Proto::Http::Response do
       }
       expected_cookies.shuffle!
       expect(cookies_array).to include(*expected_cookies)
+    end
+
+    it 'parses cookies with inconsistent spacing and a missing trailing semicolons' do
+      resp = described_class.new()
+      resp.parse(self.send :get_cookies_spaces_and_missing_semicolon)
+      cookies = resp.get_cookies_parsed
+      names = cookies.keys.sort
+      values = []
+      cookies.each do |_, parsed|
+        parsed.value.each do |value|
+          values << value
+        end
+      end
+      values.sort!
+      expect(names).to eq(%w(k1 k2 k3))
+      expect(values).to eq(%w(v1 v2 v3))
     end
 
   end


### PR DESCRIPTION
This fixes #9332.

Rather than continuing to add quirk support to `get_cookies`, I've simply added a new method for HTTP handling that allows you to get at the parsed version of the cookies.  This is useful when you need to inspect the cookies or extract data from them.  Contrast this with `get_cookies`, which is designed to return a string representation of the cookies from a given message suitable for *sending* in a `Set-Cookie` header.  

## Verification

 - [x] See that the new spec passes