### PR TITLE
Only use basic auth in couchdb_enum when credentials are provided

### DIFF
--- a/modules/auxiliary/scanner/couchdb/couchdb_enum.rb
+++ b/modules/auxiliary/scanner/couchdb/couchdb_enum.rb
@@ -34,12 +34,13 @@ class MetasploitModule < Msf::Auxiliary
   def run
     username = datastore['HttpUsername']
     password = datastore['HttpPassword']
+    auth = basic_auth(username, password) if username && password
 
     begin
       res = send_request_cgi(
         'uri'           => normalize_uri(target_uri.path),
         'method'        => 'GET',
-        'authorization' => basic_auth(username, password)
+        'authorization' => auth
       )
 
       temp = JSON.parse(res.body)


### PR DESCRIPTION
Resolves #9320

## Verification

- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/couchdb/couchdb_enum`
- [x] `set RHOST`
- [x] `run`
- [x] **Verify** results are printed to screen and saved as loot

Example Output
```
msf > use auxiliary/scanner/couchdb/couchdb_enum 
msf auxiliary(scanner/couchdb/couchdb_enum) > set RHOST 10.0.0.11
RHOST => 10.0.0.11
msf auxiliary(scanner/couchdb/couchdb_enum) > options

Module options (auxiliary/scanner/couchdb/couchdb_enum):

   Name          Current Setting  Required  Description
   ----          ---------------  --------  -----------
   HttpPassword                   no        The password to login with
   HttpUsername                   no        The username to login as
   Proxies                        no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOST         10.0.0.11        yes       The target address
   RPORT         5984             yes       The target port (TCP)
   SSL           false            no        Negotiate SSL/TLS for outgoing connections
   TARGETURI     /_all_dbs        yes       Path to list all the databases
   VHOST                          no        HTTP server virtual host

msf auxiliary(scanner/couchdb/couchdb_enum) > run

[*] Enumerating...
[+] Found:

[
  "_global_changes",
  "_replicator",
  "_users",
  "verifytestdb"
]

[+] File saved in: /home/james/.msf4/loot/20171227195204_default_10.0.0.11_couchdb.enum_064953.txt
[*] Auxiliary module execution completed
```