### PR TITLE
Refactor packet dispatcher callbacks

### DIFF
--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -384,6 +384,7 @@ protected
 
         create_session(cli, {
           :passive_dispatcher => self.service,
+          :dispatch_ext       => [Rex::Post::Meterpreter::HttpPacketDispatcher],
           :conn_id            => conn_id,
           :url                => url,
           :expiration         => datastore['SessionExpirationTimeout'].to_i,

--- a/lib/rex/post/meterpreter/client.rb
+++ b/lib/rex/post/meterpreter/client.rb
@@ -165,6 +165,8 @@ class Client
       end
     end
 
+    # Protocol specific dispatch mixins go here, this may be neader with explicit Client classes
+    opts[:dispatch_ext].each {|dx| self.extend(dx)} if opts[:dispatch_ext]
     initialize_passive_dispatcher if opts[:passive_dispatcher]
 
     register_extension_alias('core', ClientCore.new(self))


### PR DESCRIPTION
**Pull out HTTP-specific code from PacketDispatcher**

PacketDispatcher has some hardcoded assumptions about utilizing
HTTP services as the async resource. With C2 and DNS tunnels in
the pipeline, these elements need to be separated from the core
functions of async packet dispatch and moved into their own module.

This creates a new namespace for Meterpreter::HttpPacketDispatcher,
meant to be mixed in after PacketDispatcher. The module implements
only three of the original module's methods - init, shutdown, and
the :on_passive_request callback; with the first two using :super,
with the expectation of having a PacketDispatcher mixin or API
compatible namespace already in the mix.

----


**Implement specific dispatch extensions for tunnels**

All meterpreter Clients are created equal, and as such they all
include the PacketDispatcher mixin and call its init methods when
a passive dispatcher is needed. However, since tunneling protocols
have different requirements for implementation, the methods which
provide protocol-specific functionality need to be mixed into the
Client before it attempts to initialize the dispatcher.

Provide a dispatch_ext option in the has passed to the client on
init from the session handler which is an Array containing mixin
references which are sent to :extend calls in the :init_meterpreter
method just prior to calling :initialize_passive_dispatcher.

Each handler implementation can thus push chains of mixins to the
client in order to provide middleware specific to the tunnel. Down
the road, this should permit stacking C2 encapsulations or tunnel
protocols/permutators to create unique session transports on the
fly.