### PR TITLE
Implement a method for command shells to register a post-session cleanup

### DIFF
--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -47,10 +47,13 @@ class CommandShell
     "shell"
   end
 
-  def initialize(*args)
+  def initialize(conn, opts = {})
     self.platform ||= ""
     self.arch     ||= ""
     self.max_threads = 1
+    if !opts[:datastore]["CommandShellCleanupCommand"].blank?
+      @cleanup_command = opts[:datastore]["CommandShellCleanupCommand"]
+    end
     super
   end
 
@@ -193,10 +196,26 @@ class CommandShell
   # :category: Msf::Session::Provider::SingleCommandShell implementors
   #
   # Closes the shell.
+  # Note: parent's 'self.kill' method calls cleanup below.
   #
   def shell_close()
-    rstream.close rescue nil
     self.kill
+  end
+
+  ##
+  # :category: Msf::Session implementors
+  #
+  # Closes the shell.
+  #
+  def cleanup
+    if rstream
+      if !@cleanup_command.blank?
+        shell_command_token(@cleanup_command, 0)
+      end
+      rstream.close
+      rstream = nil
+    end
+    super
   end
 
   #

--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -51,7 +51,8 @@ class CommandShell
     self.platform ||= ""
     self.arch     ||= ""
     self.max_threads = 1
-    if !opts[:datastore]["CommandShellCleanupCommand"].blank?
+    datastore = opts[:datastore]
+    if datastore && !datastore["CommandShellCleanupCommand"].blank?
       @cleanup_command = opts[:datastore]["CommandShellCleanupCommand"]
     end
     super

--- a/lib/msf/base/sessions/command_shell_options.rb
+++ b/lib/msf/base/sessions/command_shell_options.rb
@@ -19,7 +19,7 @@ module CommandShellOptions
       [
         OptString.new('InitialAutoRunScript', "An initial script to run on session creation (before AutoRunScript)"),
         OptString.new('AutoRunScript', "A script to run automatically on session creation."),
-        OptString.new('ShellCleanupCommand', "A command to run before the session is closed")
+        OptString.new('CommandShellCleanupCommand', "A command to run before the session is closed")
       ]
     )
   end

--- a/lib/msf/base/sessions/command_shell_options.rb
+++ b/lib/msf/base/sessions/command_shell_options.rb
@@ -17,9 +17,11 @@ module CommandShellOptions
 
     register_advanced_options(
       [
-        OptString.new('InitialAutoRunScript', [false, "An initial script to run on session creation (before AutoRunScript)", '']),
-        OptString.new('AutoRunScript', [false, "A script to run automatically on session creation.", ''])
-      ], self.class)
+        OptString.new('InitialAutoRunScript', "An initial script to run on session creation (before AutoRunScript)"),
+        OptString.new('AutoRunScript', "A script to run automatically on session creation."),
+        OptString.new('ShellCleanupCommand', "A command to run before the session is closed")
+      ]
+    )
   end
 
   def on_session(session)


### PR DESCRIPTION
This adds a way for a method for a payload module to register a post-session command that gets run after a the session has ended, but before the connection is actually closed. This is useful for when a payload needs to cleanup after it executes (for instance, killing a telnetd after the session completes).

Example usage:

`./msfconsole -qx 'use multi/handler; set payload linux/x86/shell_reverse_tcp; set lhost 127.0.0.1; set CommandShellCleanupCommand pkill telnetd; run'`

Created to support a new payload type from @mkienow-r7 