### PR TITLE
remove ring buffer function from command shells / channels, use streams exclusively

### DIFF
--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -165,9 +165,15 @@ class CommandShell
   def cleanup
     if rstream
       if !@cleanup_command.blank?
-        shell_command_token(@cleanup_command, 10)
+        # this is a best effort, since the session is possibly already dead
+        shell_command_token(@cleanup_command) rescue nil
+
+        # we should only ever cleanup once
+        @cleanup_command = nil
       end
-      rstream.close
+
+      # this is also a best-effort
+      rstream.close rescue nil
       rstream = nil
     end
     super

--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -51,9 +51,10 @@ class CommandShell
     self.platform ||= ""
     self.arch     ||= ""
     self.max_threads = 1
+    @cleanup = false
     datastore = opts[:datastore]
     if datastore && !datastore["CommandShellCleanupCommand"].blank?
-      @cleanup_command = opts[:datastore]["CommandShellCleanupCommand"]
+      @cleanup_command = datastore["CommandShellCleanupCommand"]
     end
     super
   end
@@ -163,6 +164,9 @@ class CommandShell
   # Closes the shell.
   #
   def cleanup
+    return if @cleanup
+
+    @cleanup = true
     if rstream
       if !@cleanup_command.blank?
         # this is a best effort, since the session is possibly already dead

--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -118,8 +118,6 @@ class CommandShell
   # Read from the command shell.
   #
   def shell_read(length=-1, timeout=1)
-    return shell_read_ring(length,timeout) if self.respond_to?(:ring)
-
     begin
       rv = rstream.get_once(length, timeout)
       framework.events.on_session_output(self, rv) if rv
@@ -129,50 +127,6 @@ class CommandShell
       shell_close
       raise e
     end
-  end
-
-  #
-  # Read from the command shell.
-  #
-  def shell_read_ring(length=-1, timeout=1)
-    self.ring_buff ||= ""
-
-    # Short-circuit bad length values
-    return "" if length == 0
-
-    # Return data from the stored buffer if available
-    if self.ring_buff.length >= length and length > 0
-      buff = self.ring_buff.slice!(0,length)
-      return buff
-    end
-
-    buff = self.ring_buff
-    self.ring_buff = ""
-
-    begin
-      ::Timeout.timeout(timeout) do
-        while( (length > 0 and buff.length < length) or (length == -1 and buff.length == 0))
-          ring.select
-          nseq,data = ring.read_data(self.ring_seq)
-          if data
-            self.ring_seq = nseq
-            buff << data
-          end
-        end
-      end
-    rescue ::Timeout::Error
-    rescue ::Rex::SocketError, ::EOFError, ::IOError, ::Errno::EPIPE => e
-      shell_close
-      raise e
-    end
-
-    # Store any leftovers in the ring buffer backlog
-    if length > 0 and buff.length > length
-      self.ring_buff = buff[length, buff.length - length]
-      buff = buff[0,length]
-    end
-
-    buff
   end
 
   ##
@@ -211,7 +165,7 @@ class CommandShell
   def cleanup
     if rstream
       if !@cleanup_command.blank?
-        shell_command_token(@cleanup_command, 0)
+        shell_command_token(@cleanup_command, 10)
       end
       rstream.close
       rstream = nil
@@ -248,10 +202,6 @@ class CommandShell
       print_status("Session ID #{sid} (#{tunnel_to_s}) processing AutoRunScript '#{datastore['AutoRunScript']}'")
       execute_script(args.shift, *args)
     end
-  end
-
-  def reset_ring_sequence
-    self.ring_seq = 0
   end
 
   attr_accessor :arch
@@ -292,48 +242,6 @@ protected
       Thread.pass
     end
   end
-
-  def _interact_ring
-
-    begin
-
-    rdr = framework.threads.spawn("RingMonitor", false) do
-      seq = nil
-      while self.interacting
-
-        # Look for any pending data from the remote ring
-        nseq,data = ring.read_data(seq)
-
-        # Update the sequence number if necessary
-        seq = nseq || seq
-
-        # Write output to the local stream if successful
-        user_output.print(data) if data
-
-        begin
-          # Wait for new data to arrive on this session
-          ring.wait(seq)
-        rescue EOFError => e
-          break
-        end
-      end
-    end
-
-    while self.interacting
-      # Look for any pending input or errors from the local stream
-      sd = Rex::ThreadSafe.select([ _local_fd ], nil, [_local_fd], 5.0)
-
-      # Write input to the ring's input mechanism
-      shell_write(user_input.gets) if sd
-    end
-
-    ensure
-      rdr.kill
-    end
-  end
-
-  attr_accessor :ring_seq    # This tracks the last seen ring buffer sequence (for shell_read)
-  attr_accessor :ring_buff   # This tracks left over read data to maintain a compatible API
 end
 
 class CommandShellWindows < CommandShell

--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -217,11 +217,7 @@ protected
   # shell_write instead of operating on rstream directly.
   def _interact
     framework.events.on_session_interact(self)
-    if self.respond_to?(:ring)
-      _interact_ring
-    else
-      _interact_stream
-    end
+    _interact_stream
   end
 
   ##

--- a/lib/msf/core/rpc/v10/rpc_session.rb
+++ b/lib/msf/core/rpc/v10/rpc_session.rb
@@ -76,12 +76,6 @@ class RPC_Session < RPC_Base
 
   # Reads the output of a shell session (such as a command output).
   #
-  # @note Shell read is now a positon-aware reader of the shell's associated
-  #       ring buffer. For more direct control of the pointer into a ring
-  #       buffer, a client can instead use ring_read, and note the returned
-  #       sequence number on their own (making multiple views into the same
-  #       session possible, regardless of position in the stream)
-  # @see #rpc_ring_read
   # @param [Integer] sid Session ID.
   # @param [Integer] ptr Pointer.
   # @raise [Msf::RPC::Exception] An error that could be one of these:
@@ -94,17 +88,13 @@ class RPC_Session < RPC_Base
   # @example Here's how you would use this from the client:
   #  rpc.call('session.shell_read', 2)
   def rpc_shell_read( sid, ptr=nil)
-    _valid_session(sid,"shell")
-    # @session_sequence tracks the pointer into the ring buffer
-    # data of sessions (by sid) in order to emulate the old behavior
-    # of shell_read
-    @session_sequence ||= {}
-    @session_sequence[sid] ||= 0
-    ring_buffer = rpc_ring_read(sid,(ptr || @session_sequence[sid]))
-    if not (ring_buffer["seq"].nil? || ring_buffer["seq"].empty?)
-      @session_sequence[sid] = ring_buffer["seq"].to_i
+    s = _valid_session(sid,"shell")
+    begin
+      res = s.shell_read(data)
+      { "write_count" => res.to_s}
+    rescue ::Exception => e
+      error(500, "Session Disconnected: #{e.class} #{e}")
     end
-    return ring_buffer
   end
 
 
@@ -112,8 +102,6 @@ class RPC_Session < RPC_Base
   # enf of your input so the system will process it.
   # You may want to use #rpc_shell_read to retrieve the output.
   #
-  # @note shell_write is a wrapper of #rpc_ring_put.
-  # @see #rpc_ring_put
   # @raise [Msf::RPC::Exception] An error that could be one of these:
   #                              * 500 Session ID is unknown.
   #                              * 500 Invalid session type.
@@ -125,8 +113,13 @@ class RPC_Session < RPC_Base
   # @example Here's how you would use this from the client:
   #  rpc.call('session.shell_write', 2, "DATA")
   def rpc_shell_write( sid, data)
-    _valid_session(sid,"shell")
-    rpc_ring_put(sid,data)
+    s = _valid_session(sid,"shell")
+    begin
+      res = s.shell_write(data)
+      { "write_count" => res.to_s}
+    rescue ::Exception => e
+      error(500, "Session Disconnected: #{e.class} #{e}")
+    end
   end
 
 
@@ -177,7 +170,7 @@ class RPC_Session < RPC_Base
   # Reads from a session (such as a command output).
   #
   # @param [Integer] sid Session ID.
-  # @param [Integer] ptr Pointer.
+  # @param [Integer] ptr Pointer (ignored)
   # @raise [Msf::RPC::Exception] An error that could be one of these:
   #                              * 500 Session ID is unknown.
   #                              * 500 Invalid session type.
@@ -187,11 +180,11 @@ class RPC_Session < RPC_Base
   #  * 'data' [String] Read data.
   # @example Here's how you would use this from the client:
   #  rpc.call('session.ring_read', 2)
-  def rpc_ring_read( sid, ptr=nil)
+  def rpc_ring_read(sid, ptr = nil)
     s = _valid_session(sid,"ring")
     begin
-      res = s.ring.read_data(ptr)
-      { "seq" => res[0].to_s, "data" => res[1].to_s }
+      res = s.shell_read()
+      { "seq" => 0, "data" => res.to_s }
     rescue ::Exception => e
       error(500, "Session Disconnected: #{e.class} #{e}")
     end
@@ -210,7 +203,7 @@ class RPC_Session < RPC_Base
   #  * 'write_count' [String] Number of bytes written.
   # @example Here's how you would use this from the client:
   #  rpc.call('session.ring_put', 2, "DATA")
-  def rpc_ring_put( sid, data)
+  def rpc_ring_put(sid, data)
     s = _valid_session(sid,"ring")
     begin
       res = s.shell_write(data)
@@ -230,9 +223,9 @@ class RPC_Session < RPC_Base
   #  * 'seq' [String] Sequence.
   # @example Here's how you would use this from the client:
   #  rpc.call('session.ring_last', 2)
-  def rpc_ring_last( sid)
+  def rpc_ring_last(sid)
     s = _valid_session(sid,"ring")
-    { "seq" => s.ring.last_sequence.to_s }
+    { "seq" => 0 }
   end
 
 
@@ -246,14 +239,8 @@ class RPC_Session < RPC_Base
   #  * 'result' [String] Either 'success' or 'failure'.
   # @example Here's how you would use this from the client:
   #  rpc.call('session.ring_clear', 2)
-  def rpc_ring_clear( sid)
-    s = _valid_session(sid,"ring")
-    res = s.ring.clear_data
-    if res.compact.empty?
-      { "result" => "success"}
-    else # Doesn't seem like this can fail. Maybe a race?
-      { "result" => "failure"}
-    end
+  def rpc_ring_clear(sid)
+    { "result" => "success" }
   end
 
 

--- a/lib/msf/core/session/basic.rb
+++ b/lib/msf/core/session/basic.rb
@@ -35,11 +35,7 @@ protected
   #
   def _interact
     framework.events.on_session_interact(self)
-    if self.respond_to?(:ring)
-      interact_ring(ring)
-    else
-      interact_stream(rstream)
-    end
+    interact_stream(rstream)
   end
 
 end

--- a/lib/msf/core/session/interactive.rb
+++ b/lib/msf/core/session/interactive.rb
@@ -1,6 +1,5 @@
 # -*- coding: binary -*-
 require 'rex/ui'
-require 'rex/io/ring_buffer'
 
 module Msf
 module Session
@@ -26,8 +25,6 @@ module Interactive
     # A nil is passed in the case of non-stream interactive sessions (Meterpreter)
     if rstream
       self.rstream = rstream
-      klass = opts[:udp_session] ? Rex::IO::RingBufferUdp : Rex::IO::RingBuffer
-      self.ring    = klass.new(rstream, {:size => opts[:ring_size] || 100 })
     end
     super()
   end
@@ -97,11 +94,6 @@ module Interactive
   # The remote stream handle.  Must inherit from Rex::IO::Stream.
   #
   attr_accessor :rstream
-
-  #
-  # The RingBuffer object used to allow concurrent access to this session
-  #
-  attr_accessor :ring
 
 protected
 

--- a/lib/msf/core/session/provider/single_command_shell.rb
+++ b/lib/msf/core/session/provider/single_command_shell.rb
@@ -45,7 +45,7 @@ module SingleCommandShell
   def shell_read_until_token(token, wanted_idx=0, timeout=10)
     return if timeout.to_i == 0
 
-    if (wanted_idx == 0)
+    if wanted_idx == 0
       parts_needed = 2
     else
       parts_needed = 1 + (wanted_idx * 2)
@@ -57,12 +57,13 @@ module SingleCommandShell
         buf = ''
         idx = nil
         loop do
-          if (tmp = shell_read(-1, 2))
+          if (tmp = shell_read(-1))
             buf << tmp
 
             # see if we have the wanted idx
             parts = buf.split(token, -1)
-            if (parts.length == parts_needed)
+
+            if parts.length == parts_needed
               # cause another prompt to appear (just in case)
               shell_write("\n")
               return parts[wanted_idx]

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -48,7 +48,6 @@ class Core
     "-k"  => [ true,  "Terminate sessions by session ID and/or range"                  ],
     "-K"  => [ false, "Terminate all sessions"                                         ],
     "-s"  => [ true,  "Run a script or module on the session given with -i, or all"    ],
-    "-r"  => [ false, "Reset the ring buffer for the session given with -i, or all"    ],
     "-u"  => [ true,  "Upgrade a shell to a meterpreter session on many platforms"     ],
     "-t"  => [ true,  "Set a response timeout (default: 15)"                           ],
     "-S"  => [ true,  "Row search filter."                                             ],
@@ -1131,7 +1130,6 @@ class Core
     sid      = nil
     cmds     = []
     script   = nil
-    reset_ring = false
     response_timeout = 15
     search_term = nil
     session_name = nil
@@ -1185,10 +1183,6 @@ class Core
         # Search for specific session
         when "-S", "--search"
           search_term = val
-        # Reset the ring buffer read pointer
-        when "-r"
-          reset_ring = true
-          method = 'reset_ring'
         # Display help banner
         when "-h"
           cmd_sessions_help
@@ -1443,14 +1437,6 @@ class Core
           print_status("Sleeping 5 seconds to allow the previous handler to finish..")
           sleep(5)
         end
-      end
-    when 'reset_ring'
-      sessions = sid ? [sid] : framework.sessions.keys
-      sessions.each do |sidx|
-        s = framework.sessions[sidx]
-        next unless (s && s.respond_to?(:ring_seq))
-        s.reset_ring_sequence
-        print_status("Reset the ring buffer pointer for Session #{sidx}")
       end
     when 'list',nil
       print_line

--- a/lib/rex/ui/interactive.rb
+++ b/lib/rex/ui/interactive.rb
@@ -217,49 +217,6 @@ protected
 
 
   #
-  # Interacts between a local stream and a remote ring buffer. This has to use
-  # a secondary thread to prevent the select on the local stream from blocking
-  #
-  def interact_ring(ring)
-    begin
-
-    rdr = Rex::ThreadFactory.spawn("RingMonitor", false) do
-      seq = nil
-      while self.interacting
-
-        # Look for any pending data from the remote ring
-        nseq,data = ring.read_data(seq)
-
-        # Update the sequence number if necessary
-        seq = nseq || seq
-
-        # Write output to the local stream if successful
-        user_output.print(data) if data
-
-        # Wait for new data to arrive on this session
-        ring.wait(seq)
-      end
-    end
-
-    while self.interacting
-
-      # Look for any pending input from the local stream
-      sd = Rex::ThreadSafe.select([ _local_fd ], nil, [_local_fd], 5.0)
-
-      # Write input to the ring's input mechanism
-      if sd
-        data = user_input.gets
-        ring.put(data)
-      end
-    end
-
-    ensure
-      rdr.kill
-    end
-  end
-
-
-  #
   # Installs a signal handler to monitor suspend signal notifications.
   #
   def handle_suspend


### PR DESCRIPTION
For reasons not explained in the original commit d5d9d56081cf0c190c432071004c5de43ec8a1d4 interacting with a command shell can either involve just reading and writing from the data stream, or having a separate monitor thread run, copy all of the data into an in-memory buffer, and then interacting with that buffer.

The primary problem with the buffer is it doesn't work reliably at all. Often data isn't there when you check for it, or it is and is read by the wrong thing. This leads to a lot of inconsistency with performing post exploitation on command shells. For instance, 'shell_command_token' reliably waits for the entire duration of 'timeout' for a command to return because it almost always misses the return data from the ring buffer.

I'm happy to see who or what actually uses this functionality. I looked in Metasploit Pro and it is entirely unused. I found some metasploit wrapper libraries that expose it as an API, but again could not find any real consumers of it. How about we just delete it, and make shell interactions work again?

With this change, `shell_command_token` now returns as soon as the command it is running is complete.