### PR TITLE
Fix early termination of auxiliary/scanner/dcerpc/hidden

### DIFF
--- a/modules/auxiliary/scanner/dcerpc/hidden.rb
+++ b/modules/auxiliary/scanner/dcerpc/hidden.rb
@@ -55,7 +55,7 @@ class MetasploitModule < Msf::Auxiliary
         print_status("Looking for services on #{ip}:#{rport}...")
 
         ids = dcerpc_mgmt_inq_if_ids(rport)
-        return if not ids
+        next if not ids
 
         ids.each do |id|
           if (not servs.has_key?(id[0]+'_'+id[1]))


### PR DESCRIPTION
Resolves Issue [#9357](https://github.com/rapid7/metasploit-framework/issues/9357)

This commit fixes an issue, where auxiliary/scanner/dcerpc/hidden terminates directly, once an endpoint can't be reached or access is denied. Normally the next endpoint in list should be checked, instead of terminating directly.

The commit replaces a "return" statement in a loop with a "next" statement. This ensures that once an error occurs, the next iteration step will be followed instead of leaving the loop.

## Example Output

```
resource (rpc_hidden.conf)> use auxiliary/scanner/dcerpc/hidden
resource (rpc_hidden.conf)> set rhosts TARGET
resource (rpc_hidden.conf)> run
[*] TARGET:         - Connecting to the endpoint mapper service...
[*] TARGET:         - Looking for services on TARGET:49152...
[*] TARGET:         - Remote Management Interface Error: The connection timed out (TARGET:49152).
[*] TARGET:         - Looking for services on TARGET:49159...
[*] TARGET:         - Remote Management Interface Error: The connection timed out (TARGET:49159).
[*] TARGET:         - Looking for services on TARGET:49158...
[*] TARGET:         -     HIDDEN: UUID 00000134-0000-0000-c000-000000000046 v0.0 
[*] TARGET:         -             CONN BIND ERROR=DCERPC FAULT => nca_s_fault_access_denied
[*] TARGET:         -
[*] TARGET:         -     HIDDEN: UUID 18f70770-8e64-11cf-9af1-0020af6e72f4 v0.0 
[*] TARGET:         -             CONN BIND ERROR=DCERPC FAULT => nca_s_fault_access_denied
[*] TARGET:         -
[*] TARGET:         -     HIDDEN: UUID 00000131-0000-0000-c000-000000000046 v0.0 
[*] TARGET:         -             CONN BIND ERROR=DCERPC FAULT => nca_s_fault_access_denied
[*] TARGET:         -
[*] TARGET:         -     HIDDEN: UUID 00000143-0000-0000-c000-000000000046 v0.0 
[*] TARGET:         -             CONN BIND ERROR=DCERPC FAULT => nca_s_fault_access_denied
[*] TARGET:         -
[*] TARGET:         - Looking for services on TARGET:49157...
[*] TARGET:         -     HIDDEN: UUID 41208ee0-e970-11d1-9b9e-00e02c064c39 v1.0 
[*] TARGET:         -             CONN BIND ERROR=DCERPC FAULT => nca_s_fault_access_denied
[*] TARGET:         -
[*] TARGET:         -     HIDDEN: UUID fc13257d-5567-4dea-898d-c6f9c48415a0 v1.0
[*] TARGET:         -             CONN BIND ERROR=DCERPC FAULT => nca_s_fault_access_denied
[*] TARGET:         -
[*] TARGET:         -     HIDDEN: UUID 00000134-0000-0000-c000-000000000046 v0.0
[*] TARGET:         -             CONN BIND ERROR=DCERPC FAULT => nca_s_fault_access_denied
[...]
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

(More details can be found in the original issue description)

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/dcerpc/hidden`
- [x] `set RHOSTS`
- [x] `run`
- [x] *Verify that all endpoints, identified by the endpoint mapper are processed

