### PR TITLE
Fix markdown premature less-than sign escape

### DIFF
--- a/lib/msf/util/document_generator/normalizer.rb
+++ b/lib/msf/util/document_generator/normalizer.rb
@@ -78,7 +78,7 @@ module Msf
             File.open(path, 'rb') { |f| template = f.read }
             return template
           }.call
-          md_to_html(ERB.new(@md_template).result(binding()), kb.gsub(/</, '&#x3c;'))
+          md_to_html(ERB.new(@md_template).result(binding()), kb)
         end
 
 
@@ -104,14 +104,18 @@ module Msf
         # @param kb [String] Additional information to add.
         # @return [String] HTML document.
         def md_to_html(md, kb)
-          opts = {
+          extensions = {
+              escape_html: true
+          }
+
+          render_options = {
             fenced_code_blocks: true,
             no_intra_emphasis: true,
-            escape_html: true,
             tables: true
           }
 
-          r = Redcarpet::Markdown.new(Redcarpet::Render::MsfMdHTML, opts)
+          html_renderer = Redcarpet::Render::MsfMdHTML.new(extensions)
+          r = Redcarpet::Markdown.new(html_renderer, render_options)
           ERB.new(@html_template ||= lambda {
             html_template = ''
             path = File.expand_path(File.join(Msf::Config.data_directory, 'markdown_doc', HTML_TEMPLATE))


### PR DESCRIPTION
Fixes issue where the premature escaping of the less-than sign causes the less-than sign to be incorrectly rendered inside inline code or code block.

## Verification

- [x] Temporarily edit `documentation/modules/payload/windows/meterpreter/reverse_tcp.md` or module documentation file of your choice, and add the example Markdown seen below to the document.
- [x] Start `msfconsole`
- [x] `info -d payload/windows/meterpreter/reverse_tcp` or `info -d <module name>`
- [x] **Verify** the generated HTML documentation for the markdown is correctly escaped by viewing the HTML source

## Demonstration

* Example Markdown:
```
<h1>Test HTML Escape</h1>

`<h1>Test HTML Escape</h1> in code block`
```
* HTML currently produced by upstream:
```
<p>&#x3c;h1&gt;Test HTML Escape&#x3c;/h1&gt;</p>

<p><code>&amp;#x3c;h1&gt;Test HTML Escape&amp;#x3c;/h1&gt; in code block</code></p>
```
* Appears in browser as: `&#x3c;h1>Test HTML Escape&#x3c;/h1> in code block`
* Output is incorrect after simply changing the second parameter to the `md_to_html` method from `kb.gsub(/</, '&#x3c;')` to `kb`:
```
<h1>Test HTML Escape</h1>

<p><code>&lt;h1&gt;Test HTML Escape&lt;/h1&gt; in code block</code></p>
```
* HTML produced with these changes:
```
<p>&lt;h1&gt;Test HTML Escape&lt;/h1&gt;</p>

<p><code>&lt;h1&gt;Test HTML Escape&lt;/h1&gt; in code block</code></p>
```
  