### PR TITLE
Detect and return on bad VNC negotiations

### DIFF
--- a/lib/rex/proto/rfb/client.rb
+++ b/lib/rex/proto/rfb/client.rb
@@ -215,11 +215,30 @@ class Client
 
   def negotiate_ard_auth(username = nil, password = nil)
     generator = @sock.get_once(2)
+    if not generator or generator.length != 2
+      @error = "Unable to obtain ARD challenge: invalid generator value"
+      return false
+    end
     generator = generator.unpack("n").first
+
     key_length = @sock.get_once(2)
+    if not key_length or key_length.length != 2
+      @error = "Unable to obtain ARD challenge: invalid key length"
+      return false
+    end
     key_length = key_length.unpack("n").first
+
     prime_modulus = @sock.get_once(key_length)
+    if not prime_modulus or prime_modulus.length != key_length
+      @error = "Unable to obtain ARD challenge: invalid prime modulus"
+      return false
+    end
+
     peer_public_key = @sock.get_once(key_length)
+    if not peer_public_key or peer_public_key.length != key_length
+      @error = "Unable to obtain ARD challenge: invalid public key"
+      return false
+    end
 
     response = Cipher.encrypt_ard(username, password, generator, key_length, prime_modulus, peer_public_key)
     @sock.put(response)

--- a/modules/auxiliary/scanner/vnc/ard_root_pw.rb
+++ b/modules/auxiliary/scanner/vnc/ard_root_pw.rb
@@ -81,6 +81,9 @@ class MetasploitModule < Msf::Auxiliary
           log_credential(password)
           return
         end
+      else
+        print_error("VNC handshake failed.")
+        return
       end
       disconnect
 
@@ -92,6 +95,9 @@ class MetasploitModule < Msf::Auxiliary
           log_credential(password)
           return
         end
+      else
+        print_error("VNC handshake failed.")
+        return
       end
       disconnect
 
@@ -103,6 +109,9 @@ class MetasploitModule < Msf::Auxiliary
           log_credential('')
           return
         end
+      else
+        print_error("VNC handshake failed.")
+        return
       end
 
     ensure


### PR DESCRIPTION
Adds some missing error handling to the Apple Remote Desktop code committed in PR #9302:

- scanner/vnc/ard_root_pw now bails as soon as it sees a VNC handshake fail
- ARD auth negotiation now detects and gracefully fails if it gets unexpected values during negotiation, rather than crashing.

## Verification
test host = unpatched macOS High Sierra vm with System Preferences > Sharing > Screen Sharing enabled, legitimate login is user:password.
```
msf > use auxiliary/scanner/vnc/vnc_login
msf auxiliary(scanner/vnc/vnc_login) > set RHOSTS 172.16.143.129
RHOSTS => 172.16.143.129
msf auxiliary(scanner/vnc/vnc_login) > set USERNAME user
USERNAME => user
msf auxiliary(scanner/vnc/vnc_login) > run

[*] 172.16.143.129:5900   - 172.16.143.129:5900 - Starting VNC login sweep
[+] 172.16.143.129:5900   - 172.16.143.129:5900 - Login Successful: user:password
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

```
msf > use auxiliary/scanner/vnc/ard_root_pw
msf auxiliary(scanner/vnc/ard_root_pw) > set RHOSTS 172.16.143.129
RHOSTS => 172.16.143.129
msf auxiliary(scanner/vnc/ard_root_pw) > run

[*] 172.16.143.129:5900   - Attempting authentication as root.
[*] 172.16.143.129:5900   - Testing login as root with chosen password.
[+] 172.16.143.129:5900   - Login succeeded - root:HvdPOSfAPWOQmWmu
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

