### PR TITLE
Check exploit stance for array as well as string

### DIFF
--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -672,14 +672,14 @@ class Exploit < Msf::Module
   # Returns true if the exploit has an aggressive stance.
   #
   def aggressive?
-    (stance == Stance::Aggressive)
+    stance.include?(Stance::Aggressive)
   end
 
   #
   # Returns if the exploit has a passive stance.
   #
   def passive?
-    (stance == Stance::Passive)
+    stance.include?(Stance::Passive)
   end
 
   #


### PR DESCRIPTION
```
14:00 < lacx> im using a module you wrote (multi/http/struts2_rest_xstream) and trying to add the WfsDelay option but it seems to have no effect
```

An exploit can be both aggressive and passive.

```
msf > use exploit/multi/http/struts2_rest_xstream
msf exploit(multi/http/struts2_rest_xstream) > pry
[1] pry(#<Msf::Modules::Mod6578706c6f69742f6d756c74692f687474702f737472757473325f726573745f7873747265616d::MetasploitModule>)> self.stance
=> ["aggressive", "passive"]
[2] pry(#<Msf::Modules::Mod6578706c6f69742f6d756c74692f687474702f737472757473325f726573745f7873747265616d::MetasploitModule>)> self.aggressive?
=> false
[3] pry(#<Msf::Modules::Mod6578706c6f69742f6d756c74692f687474702f737472757473325f726573745f7873747265616d::MetasploitModule>)>
```

- [x] Apply this patch
- [x] Use a module with dual stances
- [x] See that `WfsDelay` is registered in `advanced`
- [x] See that it's tab-completable