### PR TITLE
allow UTF-8 module names and authors

### DIFF
--- a/tools/dev/msftidy.rb
+++ b/tools/dev/msftidy.rb
@@ -529,10 +529,6 @@ class Msftidy
       src_ended = true if ln =~ /^__END__$/
       next if src_ended
 
-      if ln =~ /[\x00-\x08\x0b\x0c\x0e-\x19\x7f-\xff]/
-        error("Unicode detected: #{ln.inspect}", idx)
-      end
-
       if ln =~ /[ \t]$/
         warn("Spaces at EOL", idx)
       end

--- a/tools/dev/msftidy.rb
+++ b/tools/dev/msftidy.rb
@@ -34,10 +34,6 @@ class String
   def cyan
     "\e[1;36;40m#{self}\e[0m"
   end
-
-  def ascii_only?
-    self =~ Regexp.new('[\x00-\x08\x0b\x0c\x0e-\x19\x7f-\xff]', nil, 'n') ? false : true
-  end
 end
 
 class Msftidy
@@ -318,10 +314,6 @@ class Msftidy
           end
         end
 
-        if not mod_title.ascii_only?
-          error("Please avoid unicode or non-printable characters in module title.")
-        end
-
         # Since we're looking at the module title, this line clearly cannot be
         # the author block, so no point to run more code below.
         next
@@ -353,10 +345,6 @@ class Msftidy
 
         if author_name =~ /^@.+$/
           error("No Twitter handles, please. Try leaving it in a comment instead.")
-        end
-
-        if not author_name.ascii_only?
-          error("Please avoid unicode or non-printable characters in Author")
         end
 
         unless author_name.empty?


### PR DESCRIPTION
It seems that 5 years ago (acdce4c876e4c669f9cbf528b08797565975aae6), the ecosystem wasn't ready for UTF-8 module names or author fields. As of last year, we possibly converted the last ASCII holdout (Metasploit Pro database) to use and assume UTF-8 encoding.

This PR removes the MSFtidy check forbidding UTF-8. It seems to work fine in light testing:

https://imgur.com/a/ffVlA

## Verification

- [x] Start `msfconsole`
- [x] Edit and reload a module with UTF-8 in its title and author fields
- [x] **Verify** you can reload and view the info hash for the module
- [x] **Verify** `info -d` renders correctly.
- [x] **Verify** https://www.rapid7.com/db doesn't explode (CC @rchapman-r7)

@wchen-r7 you may have some historical context on this