### PR TITLE
umlaut

### DIFF
--- a/modules/auxiliary/scanner/http/apache_optionsbleed.rb
+++ b/modules/auxiliary/scanner/http/apache_optionsbleed.rb
@@ -17,7 +17,7 @@ class MetasploitModule < Msf::Auxiliary
         server has a .htaccess file with an invalid Limit method defined.
       },
       'Author' => [
-        'Hanno Boeck', # Vulnerability discovery
+        'Hanno Böck', # Vulnerability discovery
         'h00die', # Metasploit module
       ],
       'References' => [


### PR DESCRIPTION
This module updates the Apache OptionsBleed module with the correct author's name.

Once #9398 is merged, UTF8 characters will be acceptable in module names and author names.
