### PR TITLE
Fix java_jmx_server exploit

### DIFF
--- a/modules/exploits/multi/misc/java_jmx_server.rb
+++ b/modules/exploits/multi/misc/java_jmx_server.rb
@@ -193,20 +193,22 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def discover_endpoint
-    rmi_classes = [
-      'RMIConnectionImpl',
-      'RMIConnectionImpl_Stub',
-      'RMIConnector',
-      'RMIConnectorServer',
-      'RMIIIOPServerImpl',
-      'RMIJRMPServerImpl',
-      'RMIServerImpl',
-      'RMIServerImpl_Stub'
+    rmi_classes_and_interfaces = [
+      'javax.management.remote.rmi.RMIConnectionImpl',
+      'javax.management.remote.rmi.RMIConnectionImpl_Stub',
+      'javax.management.remote.rmi.RMIConnector',
+      'javax.management.remote.rmi.RMIConnectorServer',
+      'javax.management.remote.rmi.RMIIIOPServerImpl',
+      'javax.management.remote.rmi.RMIJRMPServerImpl',
+      'javax.management.remote.rmi.RMIServerImpl',
+      'javax.management.remote.rmi.RMIServerImpl_Stub',
+      'javax.management.remote.rmi.RMIConnection',
+      'javax.management.remote.rmi.RMIServer'
     ]
     ref = send_registry_lookup(name: datastore['JMXRMI'])
     return nil if ref.nil?
 
-    unless rmi_classes.include? ref[:object]
+    unless rmi_classes_and_interfaces.include? ref[:object]
       vprint_error("JMXRMI discovery returned unexpected object #{ref[:object]}")
       return nil
     end

--- a/modules/exploits/multi/misc/java_jmx_server.rb
+++ b/modules/exploits/multi/misc/java_jmx_server.rb
@@ -193,10 +193,20 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def discover_endpoint
+    rmi_classes = [
+      'RMIConnectionImpl',
+      'RMIConnectionImpl_Stub',
+      'RMIConnector',
+      'RMIConnectorServer',
+      'RMIIIOPServerImpl',
+      'RMIJRMPServerImpl',
+      'RMIServerImpl',
+      'RMIServerImpl_Stub'
+    ]
     ref = send_registry_lookup(name: datastore['JMXRMI'])
     return nil if ref.nil?
 
-    unless ref[:object] == 'javax.management.remote.rmi.RMIServer' || ref[:object] == 'javax.management.remote.rmi.RMIServerImpl_Stub'
+    unless rmi_classes.include? ref[:object]
       vprint_error("JMXRMI discovery returned unexpected object #{ref[:object]}")
       return nil
     end

--- a/modules/exploits/multi/misc/java_jmx_server.rb
+++ b/modules/exploits/multi/misc/java_jmx_server.rb
@@ -196,7 +196,7 @@ class MetasploitModule < Msf::Exploit::Remote
     ref = send_registry_lookup(name: datastore['JMXRMI'])
     return nil if ref.nil?
 
-    unless ref[:object] == 'javax.management.remote.rmi.RMIServerImpl_Stub'
+    unless ref[:object] == 'javax.management.remote.rmi.RMIServer' || ref[:object] == 'javax.management.remote.rmi.RMIServerImpl_Stub'
       vprint_error("JMXRMI discovery returned unexpected object #{ref[:object]}")
       return nil
     end


### PR DESCRIPTION
Add test case when discovering RMI endpoint as the previous one was not complete

During a security assessment I encountered a problem with the "java_jmx_server" exploit. After looking at the code I found that the property "javax.management.remote.rmi.RMIServerImpl_Stub" was different than the object that I had: "javax.management.remote.rmi.RMIServer". After adding this test case, the exploit worked.

Here are some additional information about the environment :
- Virtual Machine: IBM J9 VM version 2.6
- Operating System: AIX 7.1
- Java: Version 7 - 64bits