### PR TITLE
Improved checkvm module: Hyper-V checks and documentation

### DIFF
--- a/documentation/modules/post/windows/gather/checkvm.md
+++ b/documentation/modules/post/windows/gather/checkvm.md
@@ -1,0 +1,47 @@
+This is a post-exploitation module that checks several known registry keys and process names, as a simple way to determine if your target is running inside of a virtual machine.  While many of these are easy to change, triggering a false negative, this script services as a simple pre-check.
+
+The script has been tested on a variety of Windows 10 targets, but changes to hypervisors and VM-related drivers are common.  If you identify misleading output from this tool, please [file an issue](https://github.com/rapid7/metasploit-framework/issues/new) or, even better, [submit a pull request](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md#contributing-to-metasploit).
+
+The script can be run from within a Meterpreter session or from the Metasploit shell:
+
+### Within Meterpreter
+```
+meterpreter > run post/windows/gather/checkvm
+```
+
+### From the Metasploit console
+```
+msf > use post/windows/gather/checkvm
+msf post(windows/gather/checkvm) > set SESSION 1
+SESSION => 1
+msf post(windows/gather/checkvm) > run
+
+[*] Checking if DESKTOP-Q05UKIU is a Virtual Machine .....
+[+] This is a VMware Virtual Machine
+[*] Post module execution completed
+```
+
+# Example Output
+
+### On a Windows 10 x64 physical machine
+```
+[*] Checking if DESKTOP-Q05UKIU is a Virtual Machine .....
+[*] DESKTOP-Q05UKIU appears to be a Physical Machine
+```
+
+### On a Windows 10 x64 VMware VM
+```
+[*] Checking if DESKTOP-Q05UKIU is a Virtual Machine .....
+[+] This is a VMware Virtual Machine
+```
+
+### On a Windows 10 x64 Hyper-V VM
+```
+[*] Checking if DESKTOP-Q05UKIU is a Virtual Machine .....
+[+] This is a Hyper-V Virtual Machine running on physical host ASOTO-HYPERV-SERVER
+
+msf > notes
+
+[*] Time: 2018-01-17 18:31:24 UTC Note: host=192.168.77.2 type=host.hypervisor data={:hypervisor=>"MS Hyper-V"}
+[*] Time: 2018-01-17 18:31:24 UTC Note: host=192.168.77.2 type=host.physicalHost data={:hypervisor=>"ASOTO-HYPERV-SERVER"}
+```

--- a/modules/post/windows/gather/checkvm.rb
+++ b/modules/post/windows/gather/checkvm.rb
@@ -19,7 +19,10 @@ class MetasploitModule < Msf::Post
         VirtualBox, Xen, and QEMU.
       },
       'License'       => MSF_LICENSE,
-      'Author'        => [ 'Carlos Perez <carlos_perez[at]darkoperator.com>'],
+      'Author'        => [
+        'Carlos Perez <carlos_perez[at]darkoperator.com>',
+        'Aaron Soto <aaron_soto[at]rapid7.com>'
+      ],
       'Platform'      => [ 'win' ],
       'SessionTypes'  => [ 'meterpreter' ]
     ))

--- a/modules/post/windows/gather/checkvm.rb
+++ b/modules/post/windows/gather/checkvm.rb
@@ -28,41 +28,61 @@ class MetasploitModule < Msf::Post
   # Method for detecting if it is a Hyper-V VM
   def hypervchk(session)
     vm = false
-    sfmsvals = registry_enumkeys('HKLM\SOFTWARE\Microsoft')
-    if sfmsvals and sfmsvals.include?("Hyper-V")
-      vm = true
-    elsif sfmsvals and sfmsvals.include?("VirtualMachine")
-      vm = true
+
+    physicalHost = registry_getvaldata('HKLM\SOFTWARE\Microsoft\Virtual Machine\Guest\Parameters','PhysicalHostNameFullyQualified')
+    if physicalHost
+      vm=true
+      report_note(
+        :host   => session,
+        :type   => 'host.physicalHost',
+        :data   => { :physicalHost => physicalHost },
+        :update => :unique_data
+        )
     end
+
     if not vm
-      if registry_getvaldata('HKLM\HARDWARE\DESCRIPTION\System','SystemBiosVersion') =~ /vrtual/i
+      sfmsvals = registry_enumkeys('HKLM\SOFTWARE\Microsoft')
+      if sfmsvals and sfmsvals.include?("Hyper-V")
+        vm = true
+      elsif sfmsvals and sfmsvals.include?("VirtualMachine")
+        vm = true
+      elsif registry_getvaldata('HKLM\HARDWARE\DESCRIPTION\System','SystemBiosVersion') =~ /vrtual/i
         vm = true
       end
     end
+
     if not vm
       srvvals = registry_enumkeys('HKLM\HARDWARE\ACPI\FADT')
       if srvvals and srvvals.include?("VRTUAL")
         vm = true
+      else
+        srvvals = registry_enumkeys('HKLM\HARDWARE\ACPI\RSDT')
+        if srvvals and srvvals.include?("VRTUAL")
+          vm = true
+        end
       end
     end
-    if not vm
-      srvvals = registry_enumkeys('HKLM\HARDWARE\ACPI\RSDT')
-      if srvvals and srvvals.include?("VRTUAL")
-        vm = true
-      end
-    end
+
     if not vm
       srvvals = registry_enumkeys('HKLM\SYSTEM\ControlSet001\Services')
-      if srvvals and srvvals.include?("vmicheartbeat")
+      if srvvals and srvvals.include?("vmicexchange")
         vm = true
-      elsif srvvals and srvvals.include?("vmicvss")
-        vm = true
-      elsif srvvals and srvvals.include?("vmicshutdown")
-        vm = true
-      elsif srvvals and srvvals.include?("vmicexchange")
+      else
+        key_path = 'HKLM\HARDWARE\DESCRIPTION\System'
+        systemBiosVersion = registry_getvaldata(key_path,'SystemBiosVersion')
+        if systemBiosVersion.unpack("s<*").reduce('', :<<).include? "Hyper-V"
+          vm = true
+        end
+      end
+    end
+
+    if not vm
+      key_path = 'HKLM\HARDWARE\DEVICEMAP\Scsi\Scsi Port 0\Scsi Bus 0\Target Id 0\Logical Unit Id 0'
+      if registry_getvaldata(key_path,'Identifier') =~ /Msft    Virtual Disk    1.0/i
         vm = true
       end
     end
+
     if vm
       report_note(
         :host   => session,
@@ -70,7 +90,11 @@ class MetasploitModule < Msf::Post
         :data   => { :hypervisor => "MS Hyper-V" },
         :update => :unique_data
         )
-      print_good("This is a Hyper-V Virtual Machine")
+      if physicalHost
+        print_good("This is a Hyper-V Virtual Machine running on physical host #{physicalHost}")
+      else
+        print_good("This is a Hyper-V Virtual Machine")
+      end
       return "MS Hyper-V"
     end
   end


### PR DESCRIPTION
All Win10 machines, physical and virtual, were being reported as 'Hyper-V' (false positives).  This PR is to rework existing checks, remove false positives, and add functionality to extract the hostname of physical hypervisor from VM registry.

Also, documentation!

## Verification

- [ ] Start `msfconsole`
- [ ] Get a meterpreter on a physical Win10 workstation
- [ ] `run post/windows/gather/checkvm`
- [ ] Observe the following output:
```
[*] Checking if DESKTOP-Q05UKIU is a Virtual Machine .....
[*] DESKTOP-Q05UKIU appears to be a Physical Machine
```
- [ ] Get a meterpreter on a VMware-based VM (I used Fusion with a Win10 VM with VMtools installed)
- [ ] `run post/windows/gather/checkvm`
- [ ] Observe the following output:
```
[*] Checking if DESKTOP-Q05UKIU is a Virtual Machine .....
[+] This is a VMware Virtual Machine
```
- [ ] Get a meterpreter on a HyperV-based VM (I used Win2k8 R2 Enterprise with a Win7 VM)
- [ ] `run post/windows/gather/checkvm`
- [ ] Observe the following output:
```
[*] Checking if DESKTOP-Q05UKIU is a Virtual Machine .....
[+] This is a Hyper-V Virtual Machine running on physical host ASOTO-HYPERV-SERVER
```
- [ ] Ogle the documentation and point out typos.