### PR TITLE
Auto-resolve target if it's a hostname (owa_login).

### DIFF
--- a/lib/rex/proto/http/client.rb
+++ b/lib/rex/proto/http/client.rb
@@ -634,11 +634,13 @@ class Client
   #
   def peerinfo
     if self.conn
-      pi = self.conn.peerinfo
-      return {
-        'addr' => pi.split(':')[0],
-        'port' => pi.split(':')[1].to_i
-      }
+      pi = self.conn.peerinfo || nil
+      if pi
+        return {
+          'addr' => pi.split(':')[0],
+          'port' => pi.split(':')[1].to_i
+        }
+      end
     end
     nil
   end

--- a/lib/rex/proto/http/client.rb
+++ b/lib/rex/proto/http/client.rb
@@ -229,6 +229,7 @@ class Client
     send_request(req, t)
     res = read_response(t)
     res.request = req.to_s if res
+    res.peerinfo = peerinfo if res
     res
   end
 
@@ -626,6 +627,20 @@ class Client
   #
   def pipelining?
     pipeline
+  end
+
+  #
+  # Target host addr and port for this connection
+  #
+  def peerinfo
+    if self.conn
+      pi = self.conn.peerinfo
+      return {
+        'addr' => pi.split(':')[0],
+        'port' => pi.split(':')[1].to_i
+      }
+    end
+    nil
   end
 
   #

--- a/lib/rex/proto/http/response.rb
+++ b/lib/rex/proto/http/response.rb
@@ -238,6 +238,10 @@ class Response < Packet
   #
   attr_accessor :request
 
+  #
+  # Host address:port associated with this request/response
+  #
+  attr_accessor :peerinfo
 
   attr_accessor :code
   attr_accessor :message

--- a/spec/lib/rex/proto/http/client_spec.rb
+++ b/spec/lib/rex/proto/http/client_spec.rb
@@ -119,6 +119,7 @@ RSpec.describe Rex::Proto::Http::Client do
     it "should send creds after receiving a 401" do
       conn = double
       allow(conn).to receive(:put)
+      allow(conn).to receive(:peerinfo)
       allow(conn).to receive(:shutdown)
       allow(conn).to receive(:close)
       allow(conn).to receive(:closed?).and_return(false)


### PR DESCRIPTION
Ensures the module does save the creds which it claims to be saving.  See MS-2968.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/http/owa_login`
- [x] `set RHOST <hostname of target mail server>`
- [x] `set USERNAME <valid username>`
- [x] `set PASSWORD <can be valid or invalid password>`
- [x] `set VERBOSE true`
- [x] `run`
- [x] **Verify** you see an output line indicating that the RHOST hostname was resolved to an IP address
- [x] **Verify** `creds` does show an entry for this run

Example run:

```
$ ./msfconsole -q
msf > use auxiliary/scanner/http/owa_login
msf auxiliary(scanner/http/owa_login) > set USERNAME bob.jones
USERNAME => bob.jones
msf auxiliary(scanner/http/owa_login) > set PASSWORD wrongpass
PASSWORD => wrongpass
msf auxiliary(scanner/http/owa_login) > set RHOST mail.mydomain.com
RHOST => mail.mydomain.com
msf auxiliary(scanner/http/owa_login) > set VERBOSE true
VERBOSE => true
msf auxiliary(scanner/http/owa_login) > run

[*] mail.mydomain.com:443 OWA - Testing version OWA_2013
[+] Found target domain: XXX
[*] mail.mydomain.com:443 OWA - Trying bob.jones : wrongpass
[*] mail.mydomain.com::443 OWA - Resolved hostname 'mail.mydomain.com' to address 1.2.3.4
[*] mail.mydomain.com:443 OWA - FAILED LOGIN, BUT USERNAME IS VALID. 0.716424642 'XXX\bob.jones' : 'wrongpass': SAVING TO CREDS
[*] Auxiliary module execution completed
msf auxiliary(scanner/http/owa_login) > creds
Credentials
===========

host     origin   service        public         private realm private_type
----     ------   -------        ------         ------- ----- ------------
1.2.3.4  1.2.3.4  443/tcp (owa)  XXX\bob.jones

msf auxiliary(scanner/http/owa_login) >
```