### PR TITLE
fix library-specific error messages to not appear with modules

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -77,9 +77,11 @@ module Msf
           # Edit the currently active module or a local file
           #
           def cmd_edit(*args)
+            editing_module = false
             if args.length > 0
               path = args[0]
             elsif active_module
+              editing_module = true
               path = active_module.file_path
             end
 
@@ -95,14 +97,16 @@ module Msf
               system(*editor.split, path)
 
               # XXX: This will try to reload *any* .rb and break on modules
-              if args.length > 0 && path.end_with?('.rb')
-                print_status("Reloading #{path}")
-                load path
-              else
-                print_error('Only Ruby files can be reloaded (use reload/rerun for modules)')
+              if !editing_module
+                if path.end_with?('.rb')
+                  print_status("Reloading #{path}")
+                  load path
+                else
+                  print_error("Only library files can be reloaded after editing (use reload/rerun for modules)")
+                end
               end
             else
-              print_error('Nothing to edit -- try using a module first.')
+              print_error('Nothing to edit -- try using a module first, or specifying a library file to edit.')
             end
           end
 


### PR DESCRIPTION
I was concerned when editing a module in msfconsole to get this error message:

```
msf5 exploit(linux/misc/drb_remote_codeexec) > edit 
[*] Launching vim /Users/bcook/rapid7/metasploit-framework/modules/exploits/linux/misc/drb_remote_codeexec.rb
[-] Only Ruby files can be reloaded (use reload/rerun for modules)
```

Looks like the check we added to avoid foot-shooting with library files is too aggressive with modules. This just wraps it with a check that doesn't trigger with modules.

```
msf5 exploit(linux/misc/drb_remote_codeexec) > edit 
[*] Launching vim /Users/bcook/rapid7/metasploit-framework/modules/exploits/linux/misc/drb_remote_codeexec.rb
```

👍 