### PR TITLE
unconfirmed fix - cerberus_sftp_enumusers - Auxiliary failed: NoMethodError undefined method `start' for nil:NilClas

### DIFF
--- a/modules/auxiliary/scanner/ssh/cerberus_sftp_enumusers.rb
+++ b/modules/auxiliary/scanner/ssh/cerberus_sftp_enumusers.rb
@@ -81,7 +81,10 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     auth = Net::SSH::Authentication::Session.new(transport, opt_hash)
-    auth.authenticate("ssh-connection", Rex::Text.rand_text_alphanumeric(8), Rex::Text.rand_text_alphanumeric(8))
+    begin
+      auth.authenticate("ssh-connection", Rex::Text.rand_text_alphanumeric(8), Rex::Text.rand_text_alphanumeric(8))
+    rescue NoMethodError
+    end
     auth_method = auth.allowed_auth_methods.join('|')
     print_good "#{peer(ip)} Server Version: #{auth.transport.server_version.version}"
     report_service(
@@ -116,7 +119,10 @@ class MetasploitModule < Msf::Auxiliary
 
     begin
       ::Timeout.timeout(datastore['SSH_TIMEOUT']) do
-        auth.authenticate("ssh-connection", user, pass)
+        begin
+          auth.authenticate("ssh-connection", user, pass)
+        rescue NoMethodError
+        end
         auth_method = auth.allowed_auth_methods.join('|')
         if auth_method != ''
           :success


### PR DESCRIPTION
Possible fix for https://github.com/rapid7/metasploit-framework/issues/8970
I've tested against other servers and it does remove the error without unexpected side effects, but I don't have access to the vulnerable software anymore to confirm it works as expected.

Needs confirmation before pulling but I thought I'd better put this here in case. Feel free to close if inappropriate to create untested requests.

## Verification

```
[*] 192.168.0.119:22 SSH - Checking for vulnerability
[+] 192.168.0.119:22 SSH - Server Version: SSH-2.0-OpenSSH_6.0p1 Debian-4+deb7u5
[-] 192.168.0.119:22 SSH - Not vulnerable
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```
Note the error is no longer returned.

I've tested these changes in isolation to make sure that the exception handling still returns the correct allowed authentication methods, so I think this should work.
