### PR TITLE
Remove NoMethod Rescue for cerberus_sftp_enumusers

### DIFF
--- a/modules/auxiliary/scanner/ssh/cerberus_sftp_enumusers.rb
+++ b/modules/auxiliary/scanner/ssh/cerberus_sftp_enumusers.rb
@@ -118,10 +118,7 @@ class MetasploitModule < Msf::Auxiliary
 
     begin
       ::Timeout.timeout(datastore['SSH_TIMEOUT']) do
-        begin
-          auth.authenticate("ssh-connection", user, pass)
-        rescue NoMethodError
-        end
+        auth.authenticate("ssh-connection", user, pass)
         auth_method = auth.allowed_auth_methods.join('|')
         if auth_method != ''
           :success


### PR DESCRIPTION
When I was handling #9436, I forgot to remove another `rescue` that is no longer needed.

It's not needed because instead of `rescue`, the module should pass the options net/ssh needs (which was implemented in #9436)

