### PR TITLE
bump metasploit-payloads

### DIFF
--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -70,7 +70,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '1.3.25'
+  spec.add_runtime_dependency 'metasploit-payloads', '1.3.27'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '0.3.6'
   # Needed by msfgui and other rpc components


### PR DESCRIPTION
This bumps payloads to 1.3.27 from 1.3.25, incorporating payloads PRs:
https://github.com/rapid7/metasploit-payloads/pull/264 (License Update)
https://github.com/rapid7/metasploit-payloads/pull/263 (Update delete command to handle read-only files)

It is here to help track and to make automated testing easier.  I'll launch some automated tests and land it when they complete.

