### PR TITLE
Adding Payload Tests in spec/modules/payloads_spec.rb

### DIFF
--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -141,6 +141,46 @@ RSpec.describe 'modules/payloads', :content do
                           reference_name: 'android/shell/reverse_tcp'
   end
 
+  context 'apple_ios/aarch64/meterpreter_reverse_http' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                            'singles/apple_ios/aarch64/meterpreter_reverse_http'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'apple_ios/aarch64/meterpreter_reverse_http'
+  end
+
+  context 'apple_ios/aarch64/meterpreter_reverse_https' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                            'singles/apple_ios/aarch64/meterpreter_reverse_https'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'apple_ios/aarch64/meterpreter_reverse_https'
+  end
+
+  context 'apple_ios/aarch64/meterpreter_reverse_tcp' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                            'singles/apple_ios/aarch64/meterpreter_reverse_tcp'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'apple_ios/aarch64/meterpreter_reverse_tcp'
+  end
+
+  context 'apple_ios/aarch64/shell_reverse_tcp' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                            'singles/apple_ios/aarch64/shell_reverse_tcp'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'apple_ios/aarch64/shell_reverse_tcp'
+  end
+
   context 'bsd/sparc/shell_bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
                           ancestor_reference_names: [
@@ -588,6 +628,16 @@ RSpec.describe 'modules/payloads', :content do
                           reference_name: 'cmd/unix/bind_ruby_ipv6'
   end
 
+  context 'cmd/unix/bind_stub' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                            'singles/cmd/unix/bind_stub'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'cmd/unix/bind_stub'
+  end
+
   context 'cmd/unix/bind_zsh' do
     it_should_behave_like 'payload cached size is consistent',
                           ancestor_reference_names: [
@@ -806,6 +856,16 @@ RSpec.describe 'modules/payloads', :content do
                           dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/reverse_ssl_double_telnet'
+  end
+
+  context 'cmd/unix/reverse_stub' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                            'singles/cmd/unix/reverse_stub'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'cmd/unix/reverse_stub'
   end
 
   context 'cmd/unix/reverse_zsh' do


### PR DESCRIPTION
Six payload tests are added in spec/modules/payloads_spec.rb for there is a prompt when running rake in the source directory:

Add the following context to `spec/modules/payloads_spec.rb` by inserting them in lexical order between the pre-existing contexts:

  context 'apple_ios/aarch64/meterpreter_reverse_http' do
    it_should_behave_like 'payload cached size is consistent',
                          ancestor_reference_names: [
                            'singles/apple_ios/aarch64/meterpreter_reverse_http'
                          ],
                          dynamic_size: false,
                          modules_pathname: modules_pathname,
                          reference_name: 'apple_ios/aarch64/meterpreter_reverse_http'
  end

  context 'apple_ios/aarch64/meterpreter_reverse_https' do
    it_should_behave_like 'payload cached size is consistent',
                          ancestor_reference_names: [
                            'singles/apple_ios/aarch64/meterpreter_reverse_https'
                          ],
                          dynamic_size: false,
                          modules_pathname: modules_pathname,
                          reference_name: 'apple_ios/aarch64/meterpreter_reverse_https'
  end

  context 'apple_ios/aarch64/meterpreter_reverse_tcp' do
    it_should_behave_like 'payload cached size is consistent',
                          ancestor_reference_names: [
                            'singles/apple_ios/aarch64/meterpreter_reverse_tcp'
                          ],
                          dynamic_size: false,
                          modules_pathname: modules_pathname,
                          reference_name: 'apple_ios/aarch64/meterpreter_reverse_tcp'
  end

  context 'apple_ios/aarch64/shell_reverse_tcp' do
    it_should_behave_like 'payload cached size is consistent',
                          ancestor_reference_names: [
                            'singles/apple_ios/aarch64/shell_reverse_tcp'
                          ],
                          dynamic_size: false,
                          modules_pathname: modules_pathname,
                          reference_name: 'apple_ios/aarch64/shell_reverse_tcp'
  end

  context 'cmd/unix/bind_stub' do
    it_should_behave_like 'payload cached size is consistent',
                          ancestor_reference_names: [
                            'singles/cmd/unix/bind_stub'
                          ],
                          dynamic_size: false,
                          modules_pathname: modules_pathname,
                          reference_name: 'cmd/unix/bind_stub'
  end

  context 'cmd/unix/reverse_stub' do
    it_should_behave_like 'payload cached size is consistent',
                          ancestor_reference_names: [
                            'singles/cmd/unix/reverse_stub'
                          ],
                          dynamic_size: false,
                          modules_pathname: modules_pathname,
                          reference_name: 'cmd/unix/reverse_stub'
  end


Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use exploit/windows/smb/ms08_067_netapi`
- [x] ...
- [x] **Verify** the thing does what it should
- [x] **Verify** the thing does not do what it should not
- [x] **Document** the thing and how it works ([Example](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/post/multi/gather/aws_keys.md))

