### PR TITLE
bump payloads, fix php meterpreter

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,7 +18,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 1.3.27)
+      metasploit-payloads (= 1.3.28)
       metasploit_data_models
       metasploit_payloads-mettle (= 0.3.6)
       mqtt
@@ -181,7 +181,7 @@ GEM
       activemodel (~> 4.2.6)
       activesupport (~> 4.2.6)
       railties (~> 4.2.6)
-    metasploit-payloads (1.3.27)
+    metasploit-payloads (1.3.28)
     metasploit_data_models (2.0.16)
       activerecord (~> 4.2.6)
       activesupport (~> 4.2.6)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -70,7 +70,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '1.3.27'
+  spec.add_runtime_dependency 'metasploit-payloads', '1.3.28'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '0.3.6'
   # Needed by msfgui and other rpc components


### PR DESCRIPTION
a syntax error slipped in, let's fix it

## Verification

- [x] `./msfconsole -qx 'use multi/handler; set payload python/meterpreter/reverse_tcp; set lhost 127.0.0.1; run`
- [x] **Verify** that PHP meterpreter stages and loads stdapi properly

