### PR TITLE
Update native DNS spoofer for Dnsruby

### DIFF
--- a/modules/auxiliary/spoof/dns/native_spoofer.rb
+++ b/modules/auxiliary/spoof/dns/native_spoofer.rb
@@ -100,7 +100,7 @@ class MetasploitModule < Msf::Auxiliary
     peer = "#{cli.ip_daddr}:" << (cli.is_udp? ? "#{cli.udp_dst}" : "#{cli.tcp_dst}")
     # Deal with non DNS traffic
     begin
-      req = Packet.encode_net(data)
+      req = Packet.encode_drb(data)
     rescue => e
       print_error("Could not decode payload segment of packet from #{peer}, check log")
       dlog e.backtrace
@@ -109,7 +109,7 @@ class MetasploitModule < Msf::Auxiliary
     answered = []
     # Find cached items, remove request from forwarded packet
     req.question.each do |ques|
-      cached = service.cache.find(ques.qName, ques.qType.to_s)
+      cached = service.cache.find(ques.qname, ques.qtype.to_s)
       if cached.empty?
         next
       else
@@ -154,7 +154,7 @@ class MetasploitModule < Msf::Auxiliary
   def sent_info(cli,data)
     net = Packet.encode_net(data)
     peer = "#{cli.ip_daddr}:" << (cli.is_udp? ? "#{cli.udp_dst}" : "#{cli.tcp_dst}")
-    asked = net.question.map(&:qName).join(', ')
+    asked = net.question.map(&:qname).join(', ')
     vprint_good("Sent packet with header:\n#{cli.inspect}")
     vprint_good("Spoofed records for #{asked} to #{peer}")
   end


### PR DESCRIPTION
Fix methods relating to answer/question data structures which were
set up for Net::DNS objects in the original implementation
utilizing uppercase letters in the exact same method names.

Change the encoding call from :encode_net to :encode_drb, which
wraps the Dnsruby format instead of the Net::DNS version.

Testing:
  None yet, completely forgot i even wrote this module till i saw
it in my merge conflicts after upstream merged the PR.


Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use auxiliary/spoof/dns/native_spoofer`
- [x] Configure for your environment and run it
- [x] **Verify** Spoofing works
- [x] **Verify** Exceptions arent raised by improper calling conventions
