### PR TITLE
fix html escaping for UTF-8 module metadata

### DIFF
--- a/data/markdown_doc/default_template.erb
+++ b/data/markdown_doc/default_template.erb
@@ -5,7 +5,7 @@
 
 ## Module Name
 
-<%= Rex::Text.html_encode(items[:mod_fullname]) %>
+<%= CGI::escapeHTML(items[:mod_fullname]) %>
 
 ## Authors
 

--- a/lib/msf/util/document_generator/normalizer.rb
+++ b/lib/msf/util/document_generator/normalizer.rb
@@ -183,7 +183,7 @@ module Msf
         # @return [String]
         def normalize_authors(authors)
           if authors.kind_of?(Array)
-            authors.collect { |a| "* #{Rex::Text.html_encode(a)}" } * "\n"
+            authors.collect { |a| "* #{CGI::escapeHTML(a)}" } * "\n"
           else
             authors
           end


### PR DESCRIPTION
Right now, it is bÃ¶rked, when it should be börked

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/http/apache_optionsbleed`
- [x] `info -d`
- [x] **Verify** the unicode
