### PR TITLE
Fix pivot handler to not consume all packets

### DIFF
--- a/lib/rex/post/meterpreter/pivot.rb
+++ b/lib/rex/post/meterpreter/pivot.rb
@@ -45,11 +45,14 @@ class Pivot
     # Class request handler for all channels that dispatches requests
     # to the appropriate class instance's DIO handler
     def request_handler(client, packet)
+      handled = false
       if packet.method == 'core_pivot_session_new'
+        handled = true
         session_guid = packet.get_tlv_value(TLV_TYPE_SESSION_GUID)
         listener_id = packet.get_tlv_value(TLV_TYPE_PIVOT_ID)
         client.add_pivot_session(Pivot.new(client, session_guid, listener_id))
       elsif packet.method == 'core_pivot_session_died'
+        handled = true
         session_guid = packet.get_tlv_value(TLV_TYPE_SESSION_GUID)
         pivot = client.find_pivot_session(session_guid)
         if pivot
@@ -57,7 +60,7 @@ class Pivot
           client.remove_pivot_session(session_guid)
         end
       end
-      true
+      handled
     end
   end
 


### PR DESCRIPTION
Packet handlers should only return true if they consume a packet. Otherwise, they should return false so something else can consume it. This fixes port forwards by allowing the socket handler to see packets
that were otherwise being discarded in the pivot handler.

Fixes #9479

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Start a listener and get any Meterpreter session type. I primarily tested with:

`./msfconsole -qx 'use multi/handler; set payload linux/x86/meterpreter_reverse_tcp; set lhost 192.168.56.1; run'`

- [ ] At the Meterpreter prompt add a reverse listener: `portfwd add -R -L 127.0.0.1 -l 8080 -p 8081
`
- [ ] In another terminal, start netcat listening on port 8080: `nc -lk 8080`
- [ ] In another terminal, connect to port 8081 and send/receive some bytes on port 8081: `nc 127.0.0.1 8081`
 - [ ] **Verify** that bytes are sent and received.

Alternately, do anything that uses pivot functionality.