### PR TITLE
Support local knowledge base documents

### DIFF
--- a/lib/msf/util/document_generator.rb
+++ b/lib/msf/util/document_generator.rb
@@ -32,10 +32,10 @@ module Msf
         kb_path = nil
         kb = ''
 
-        if File.exists?(File.join(PullRequestFinder::MANUAL_BASE_PATH, "#{mod.fullname}.md"))
-          kb_path = File.join(PullRequestFinder::MANUAL_BASE_PATH, "#{mod.fullname}.md")
-        elsif File.exists?(File.join(PullRequestFinder::USER_MANUAL_BASE_PATH, "#{mod.fullname}.md"))
+        if File.exists?(File.join(PullRequestFinder::USER_MANUAL_BASE_PATH, "#{mod.fullname}.md"))
           kb_path = File.join(PullRequestFinder::USER_MANUAL_BASE_PATH, "#{mod.fullname}.md")
+        elsif File.exists?(File.join(PullRequestFinder::MANUAL_BASE_PATH, "#{mod.fullname}.md"))
+          kb_path = File.join(PullRequestFinder::MANUAL_BASE_PATH, "#{mod.fullname}.md")
         end
 
         unless kb_path.nil?

--- a/lib/msf/util/document_generator.rb
+++ b/lib/msf/util/document_generator.rb
@@ -29,12 +29,16 @@ module Msf
       # @param mod [Msf::Module] Module to create document for.
       # @return [void]
       def self.get_module_document(mod)
-        md = ''
-
-        kb_path = File.join(PullRequestFinder::MANUAL_BASE_PATH, "#{mod.fullname}.md")
+        kb_path = nil
         kb = ''
 
-        if File.exist?(kb_path)
+        if File.exists?(File.join(PullRequestFinder::MANUAL_BASE_PATH, "#{mod.fullname}.md"))
+          kb_path = File.join(PullRequestFinder::MANUAL_BASE_PATH, "#{mod.fullname}.md")
+        elsif File.exists?(File.join(PullRequestFinder::USER_MANUAL_BASE_PATH, "#{mod.fullname}.md"))
+          kb_path = File.join(PullRequestFinder::USER_MANUAL_BASE_PATH, "#{mod.fullname}.md")
+        end
+
+        unless kb_path.nil?
           File.open(kb_path, 'rb') { |f| kb = f.read }
         end
 

--- a/lib/msf/util/document_generator/pull_request_finder.rb
+++ b/lib/msf/util/document_generator/pull_request_finder.rb
@@ -11,6 +11,7 @@ module Msf
         class Exception < RuntimeError; end
 
         MANUAL_BASE_PATH = File.expand_path(File.join(Msf::Config.module_directory, '..', 'documentation', 'modules' ))
+        USER_MANUAL_BASE_PATH = File.expand_path(File.join(Msf::Config.user_module_directory, '..', 'documentation', 'modules' ))
 
         # @return [Octokit::Client] Git client
         attr_accessor :git_client


### PR DESCRIPTION
This pull request adds support for markdown documentation for local-only modules. More specifically, markdown documentation files can be created in `~/.msf4/documentation` to document corresponding local-only modules in `~/.msf4/modules`.

## Verification

To test this, we'll make a hello-world markdown document for a module that does not currently have documentation. It needs to not currently have documentation as the core documents take priority.

- [x] Create the directory `~/.msf4/documentation/modules/exploit/windows/local/`
- [x] Copy the markdown contents below into the file `payload_inject.md` in the new directory
- [x] Start msfconsole
- [x] `use exploit/windows/local/payload_inject`
- [x] Generate docs with `info -d`
- [x] In your browser see "Hello World, this is a local only document" under the Knowledge Base section

### Example Markdown
```
# Example
Hello World, this is a local only document
```
