### PR TITLE
Expand paths for meterpreter's cp, mv, and rm commands

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
@@ -689,10 +689,10 @@ class Console::CommandDispatcher::Stdapi::Fs
       return true
     end
 
-    args.each { |dir|
-      print_line("Creating directory: #{dir}")
-
-      client.fs.dir.mkdir(dir)
+    args.each { |dir_path|
+      dir_path = client.fs.file.expand_path(dir_path) if dir_path =~ PATH_EXPAND_REGEX
+      print_line("Creating directory: #{dir_path}")
+      client.fs.dir.mkdir(dir_path)
     }
 
     return true

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
@@ -308,7 +308,10 @@ class Console::CommandDispatcher::Stdapi::Fs
       return true
     end
 
-    args.each { |f| client.fs.file.rm(f) }
+    args.each do |file_path|
+      file_path = client.fs.file.expand_path(file_path) if file_path =~ /\%(\w*)\%/
+      client.fs.file.rm(file_path)
+    end
 
     return true
   end
@@ -323,7 +326,11 @@ class Console::CommandDispatcher::Stdapi::Fs
       print_line("Usage: mv oldfile newfile")
       return true
     end
-    client.fs.file.mv(args[0],args[1])
+    old_path = args[0]
+    old_path = client.fs.file.expand_path(old_path) if old_path =~ /\%(\w*)\%/
+    new_path = args[1]
+    new_path = client.fs.file.expand_path(new_path) if new_path =~ /\%(\w*)\%/
+    client.fs.file.mv(old_path, new_path)
     return true
   end
 
@@ -338,7 +345,11 @@ class Console::CommandDispatcher::Stdapi::Fs
       print_line("Usage: cp oldfile newfile")
       return true
     end
-    client.fs.file.cp(args[0],args[1])
+    old_path = args[0]
+    old_path = client.fs.file.expand_path(old_path) if old_path =~ /\%(\w*)\%/
+    new_path = args[1]
+    new_path = client.fs.file.expand_path(new_path) if new_path =~ /\%(\w*)\%/
+    client.fs.file.cp(old_path, new_path)
     return true
   end
 

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
@@ -21,6 +21,8 @@ class Console::CommandDispatcher::Stdapi::Fs
 
   CHECKSUM_ALGORITHMS = %w{ md5 sha1 }
   private_constant :CHECKSUM_ALGORITHMS
+  PATH_EXPAND_REGEX = /\%(\w*)\%/
+  private_constant :PATH_EXPAND_REGEX
 
   #
   # Options for the download command.
@@ -246,7 +248,7 @@ class Console::CommandDispatcher::Stdapi::Fs
       print_line("Usage: cd directory")
       return true
     end
-    if args[0] =~ /\%(\w*)\%/
+    if args[0] =~ PATH_EXPAND_REGEX
       client.fs.dir.chdir(client.fs.file.expand_path(args[0].upcase))
     else
       client.fs.dir.chdir(args[0])
@@ -309,7 +311,7 @@ class Console::CommandDispatcher::Stdapi::Fs
     end
 
     args.each do |file_path|
-      file_path = client.fs.file.expand_path(file_path) if file_path =~ /\%(\w*)\%/
+      file_path = client.fs.file.expand_path(file_path) if file_path =~ PATH_EXPAND_REGEX
       client.fs.file.rm(file_path)
     end
 
@@ -327,9 +329,9 @@ class Console::CommandDispatcher::Stdapi::Fs
       return true
     end
     old_path = args[0]
-    old_path = client.fs.file.expand_path(old_path) if old_path =~ /\%(\w*)\%/
+    old_path = client.fs.file.expand_path(old_path) if old_path =~ PATH_EXPAND_REGEX
     new_path = args[1]
-    new_path = client.fs.file.expand_path(new_path) if new_path =~ /\%(\w*)\%/
+    new_path = client.fs.file.expand_path(new_path) if new_path =~ PATH_EXPAND_REGEX
     client.fs.file.mv(old_path, new_path)
     return true
   end
@@ -346,9 +348,9 @@ class Console::CommandDispatcher::Stdapi::Fs
       return true
     end
     old_path = args[0]
-    old_path = client.fs.file.expand_path(old_path) if old_path =~ /\%(\w*)\%/
+    old_path = client.fs.file.expand_path(old_path) if old_path =~ PATH_EXPAND_REGEX
     new_path = args[1]
-    new_path = client.fs.file.expand_path(new_path) if new_path =~ /\%(\w*)\%/
+    new_path = client.fs.file.expand_path(new_path) if new_path =~ PATH_EXPAND_REGEX
     client.fs.file.cp(old_path, new_path)
     return true
   end
@@ -714,9 +716,10 @@ class Console::CommandDispatcher::Stdapi::Fs
       return true
     end
 
-    args.each { |dir|
-      print_line("Removing directory: #{dir}")
-      client.fs.dir.rmdir(dir)
+    args.each { |dir_path|
+      dir_path = client.fs.file.expand_path(dir_path) if dir_path =~ PATH_EXPAND_REGEX
+      print_line("Removing directory: #{dir_path}")
+      client.fs.dir.rmdir(dir_path)
     }
 
     return true


### PR DESCRIPTION
This will expand the path arguments in Meterpreter's `cp`, `mkdir`, `mv`, `rm` and `rmdir` commands. This then allows environment variables such as `%APPDATA%` to be used in those commands.

At this time, it doesn't look like either the Python Meterpreter, or the Mettle implementation expand paths the same was as Windows does, so the regex is strictly for Windows % style variables.

## Verification
For testing purposes `%APPDATA%\Microsoft\Windows\Start Menu\Programs\Maintenance\Desktop.ini` was selected as a generic test case and needs to exist on the compromised host.

- [x] Start `msfconsole`
- [x] Get a meterpreter session on a Windows system
- [x] Run through the following commands, noting the middle one to show the presence of the file and the directory
  - [x] `mkdir '%APPDATA%\Microsoft\Windows\Start Menu\Programs\Maintenance - Test'`
  - [ ] `cp '%APPDATA%\Microsoft\Windows\Start Menu\Programs\Maintenance\Desktop.ini' 
 '%APPDATA%\Microsoft\Windows\Start Menu\Programs\Maintenance - Test\Desktop.ini'`
  - [ ] `ls '%APPDATA%\Microsoft\Windows\Start Menu\Programs\Maintenance - Test'` and see the `Desktop.ini` file
  - [ ] `rm '%APPDATA%\Microsoft\Windows\Start Menu\Programs\Maintenance - Test\Desktop.ini'`
  - [ ] `rmdir '%APPDATA%\Microsoft\Windows\Start Menu\Programs\Maintenance - Test'`
- [ ] See no error messages

### Example Output
```
meterpreter > sysinfo
Computer        : WINDOWS8VM
OS              : Windows 8.1 (Build 9600).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x64/windows
meterpreter > mkdir '%APPDATA%\Microsoft\Windows\Start Menu\Programs\Maintenance - Test'
Creating directory: C:\Users\Spencer\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Maintenance - Test
meterpreter > cp '%APPDATA%\Microsoft\Windows\Start Menu\Programs\Maintenance\Desktop.ini' '%APPDATA%\Microsoft\Windows\Start Menu\Programs\Maintenance - Test\Desktop.ini'
meterpreter > ls '%APPDATA%\Microsoft\Windows\Start Menu\Programs\Maintenance - Test'
Listing: %APPDATA%\Microsoft\Windows\Start Menu\Programs\Maintenance - Test
===========================================================================

Mode            Size  Type  Last modified              Name
----            ----  ----  -------------              ----
0000/---------  214   fif   1969-12-31 19:00:00 -0500  Desktop.ini

meterpreter > rm '%APPDATA%\Microsoft\Windows\Start Menu\Programs\Maintenance - Test\Desktop.ini'
meterpreter > rmdir '%APPDATA%\Microsoft\Windows\Start Menu\Programs\Maintenance - Test'
Removing directory: C:\Users\Spencer\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Maintenance - Test
meterpreter > 
```