### PR TITLE
prefer 'shell' channels over 'exec' channels for ssh CommandStream

### DIFF
--- a/modules/auxiliary/scanner/ssh/ssh_login.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login.rb
@@ -57,7 +57,7 @@ class MetasploitModule < Msf::Auxiliary
     return unless ssh_socket
 
     # Create a new session
-    conn = Net::SSH::CommandStream.new(ssh_socket, '/bin/sh', true)
+    conn = Net::SSH::CommandStream.new(ssh_socket)
 
     merge_me = {
       'USERPASS_FILE' => nil,

--- a/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
@@ -72,7 +72,7 @@ class MetasploitModule < Msf::Auxiliary
     return unless ssh_socket
 
     # Create a new session from the socket
-    conn = Net::SSH::CommandStream.new(ssh_socket, '/bin/sh', true)
+    conn = Net::SSH::CommandStream.new(ssh_socket)
 
     # Clean up the stored data - need to stash the keyfile into
     # a datastore for later reuse.

--- a/modules/exploits/apple_ios/ssh/cydia_default_ssh.rb
+++ b/modules/exploits/apple_ios/ssh/cydia_default_ssh.rb
@@ -110,7 +110,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     if ssh
-      conn = Net::SSH::CommandStream.new(ssh, '/bin/sh', true)
+      conn = Net::SSH::CommandStream.new(ssh)
       ssh = nil
       return conn
     end

--- a/modules/exploits/linux/ssh/ceragon_fibeair_known_privkey.rb
+++ b/modules/exploits/linux/ssh/ceragon_fibeair_known_privkey.rb
@@ -106,7 +106,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if ssh_socket
 
       # Create a new session from the socket, then dump it.
-      conn = Net::SSH::CommandStream.new(ssh_socket, '/bin/sh', true)
+      conn = Net::SSH::CommandStream.new(ssh_socket)
       ssh_socket = nil
 
       return conn

--- a/modules/exploits/linux/ssh/exagrid_known_privkey.rb
+++ b/modules/exploits/linux/ssh/exagrid_known_privkey.rb
@@ -94,7 +94,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if ssh_socket
 
       # Create a new session from the socket, then dump it.
-      conn = Net::SSH::CommandStream.new(ssh_socket, '/bin/bash -i', true)
+      conn = Net::SSH::CommandStream.new(ssh_socket)
       ssh_socket = nil
 
       return conn

--- a/modules/exploits/linux/ssh/f5_bigip_known_privkey.rb
+++ b/modules/exploits/linux/ssh/f5_bigip_known_privkey.rb
@@ -109,7 +109,7 @@ class MetasploitModule < Msf::Exploit::Remote
     return false unless ssh_socket
 
     # Create a new session from the socket, then dump it.
-    conn = Net::SSH::CommandStream.new(ssh_socket, '/bin/sh', true)
+    conn = Net::SSH::CommandStream.new(ssh_socket)
     ssh_socket = nil
     conn
   end

--- a/modules/exploits/linux/ssh/loadbalancerorg_enterprise_known_privkey.rb
+++ b/modules/exploits/linux/ssh/loadbalancerorg_enterprise_known_privkey.rb
@@ -103,7 +103,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if ssh_socket
 
       # Create a new session from the socket, then dump it.
-      conn = Net::SSH::CommandStream.new(ssh_socket, '/bin/bash', true)
+      conn = Net::SSH::CommandStream.new(ssh_socket)
       ssh_socket = nil
 
       return conn

--- a/modules/exploits/linux/ssh/quantum_dxi_known_privkey.rb
+++ b/modules/exploits/linux/ssh/quantum_dxi_known_privkey.rb
@@ -102,7 +102,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if ssh_socket
 
       # Create a new session from the socket, then dump it.
-      conn = Net::SSH::CommandStream.new(ssh_socket, '/bin/bash', true)
+      conn = Net::SSH::CommandStream.new(ssh_socket)
       ssh_socket = nil
 
       return conn

--- a/modules/exploits/linux/ssh/quantum_vmpro_backdoor.rb
+++ b/modules/exploits/linux/ssh/quantum_vmpro_backdoor.rb
@@ -114,7 +114,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     if ssh
-      conn = Net::SSH::CommandStream.new(ssh, 'shell-escape', true)
+      conn = Net::SSH::CommandStream.new(ssh, 'shell-escape')
       return conn
     end
 

--- a/modules/exploits/linux/ssh/symantec_smg_ssh.rb
+++ b/modules/exploits/linux/ssh/symantec_smg_ssh.rb
@@ -117,7 +117,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     if ssh
-      conn = Net::SSH::CommandStream.new(ssh, '/bin/sh', true)
+      conn = Net::SSH::CommandStream.new(ssh)
       ssh = nil
       return conn
     end

--- a/modules/exploits/linux/ssh/ubiquiti_airos_file_upload.rb
+++ b/modules/exploits/linux/ssh/ubiquiti_airos_file_upload.rb
@@ -153,7 +153,7 @@ class MetasploitModule < Msf::Exploit::Remote
         private:      private_key,
         private_type: :ssh_key
       )
-      return Net::SSH::CommandStream.new(ssh, '/bin/sh', true)
+      return Net::SSH::CommandStream.new(ssh)
     end
 
     nil

--- a/modules/exploits/linux/ssh/vmware_vdp_known_privkey.rb
+++ b/modules/exploits/linux/ssh/vmware_vdp_known_privkey.rb
@@ -102,7 +102,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if ssh_socket
 
       # Create a new session from the socket, then dump it.
-      conn = Net::SSH::CommandStream.new(ssh_socket, '/bin/sh', true)
+      conn = Net::SSH::CommandStream.new(ssh_socket)
       self.sockets.delete(ssh_socket.transport.socket)
 
       return conn

--- a/modules/exploits/unix/ssh/array_vxag_vapv_privkey_privesc.rb
+++ b/modules/exploits/unix/ssh/array_vxag_vapv_privkey_privesc.rb
@@ -186,6 +186,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Make the SSH connection and execute our commands + payload
     print_status("#{rhost}:#{rport} - Sending and executing payload to gain root privileges!")
-    Net::SSH::CommandStream.new(ssh, build_command, true)
+    Net::SSH::CommandStream.new(ssh, build_command)
   end
 end

--- a/modules/exploits/unix/ssh/tectia_passwd_changereq.rb
+++ b/modules/exploits/unix/ssh/tectia_passwd_changereq.rb
@@ -177,7 +177,7 @@ class MetasploitModule < Msf::Exploit::Remote
       message = transport.next_message.type
 
       if message.to_i == 6 #SSH2_MSG_SERVICE_ACCEPT
-        shell = Net::SSH::CommandStream.new(connection, '/bin/sh', true)
+        shell = Net::SSH::CommandStream.new(connection)
         connection = nil
         return shell
       end


### PR DESCRIPTION
If a command is not specified to CommandStream, request a "shell" session rather than running exec. This allows targets that do not have a true "shell" which supports exec to instead return a raw shell session. This fixes #9519 

This also modifies the API for the CommandStream constructor, so if you don't specify a command, you get the default shell for the target. Along the way, I saw a lot more copy-pasta to cleanup, but to avoid obscuring the actual fix here, I held back for a later PR. I also switched 'cleanup' to be true by default, which every single module already enabled.

@h00die would you mind verifying this helps for your test range?

## Verification

List the steps needed to make sure this thing works

- [ ] Use `scanner/ssh/ssh_login` to log into regular and embedded targets without a real shell
- [ ] **Verify** that you can interact with the command shells for anything that regular `ssh` can

## Targets:

- [x] Linux
- [x] macOS
- [x] Sun ILOM
- [x] Juniper JunOS Router
- [ ] Juniper ScreenOS Router
- [x] Cisco Router
- [x] Fortinet backdoor

## Example

```
msf5 auxiliary(scanner/ssh/ssh_login) > set rhosts 192.168.1.2
rhosts => 192.168.1.2
msf5 auxiliary(scanner/ssh/ssh_login) > run

[+] 192.168.86.1.1 - Success: 'root:password' 'Waiting for daemons to initialize...  Daemons ready shell: Invalid credentials   Waiting for daemons to initialize...  Daemons ready shell: Invalid credentials   '
[*] Command shell session 1 opened (192.168.1.1:45211 -> 192.168.1.2:22) at 2018-02-08 02:20:44 -0600
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf5 auxiliary(scanner/ssh/ssh_login) > sessions 

Active sessions
===============

  Id  Name  Type     Information                           Connection
  --  ----  ----     -----------                           ----------
  1         shell /  SSH root:password (192.168.1.2:22)  192.168.1.1:45211 -> 192.168.1.2:22 (192.168.1.2)

msf5 auxiliary(scanner/ssh/ssh_login) > sessions -1
[*] Starting interaction with 1...

Waiting for daemons to initialize...

Daemons ready

Oracle(R) Integrated Lights Out Manager

Version 3.0.12.4.ze r101136

Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.

-> ls
ls

 /
    Targets:
        HOST
        SYS
        SP

    Properties:

    Commands:
        cd
        show

-> exit
exit

[*] 192.168.1.2 - Command shell session 1 closed.  Reason: Died from EOFError
```