### PR TITLE
Update for MySQL 5.7 and above

### DIFF
--- a/modules/auxiliary/scanner/mysql/mysql_hashdump.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_hashdump.rb
@@ -57,7 +57,12 @@ class MetasploitModule < Msf::Auxiliary
     create_credential_login(login_data)
 
     #Grabs the username and password hashes and stores them as loot
-    res = mysql_query("SELECT user,password from mysql.user")
+    version = mysql_get_variable("@@version")
+    if (5.6 < version[0..2].to_f)
+        res = mysql_query("SELECT user,authentication_string from mysql.user")
+    else 
+        res = mysql_query("SELECT user,password from mysql.user")
+    end
     if res.nil?
       print_error("There was an error reading the MySQL User Table")
       return


### PR DESCRIPTION
Starting from MySQL 5.7 the 'password' column was changed to 'authentication_string'. I've added a check to determine the version. If the version is higher than 5.6 the column 'authentication_string' will be used instead of 'password'. Tested on both MySQL 5.6 and 5.7.

The bug due to non existence of 'password' column in MySQL 5.7:

![hashdump](https://user-images.githubusercontent.com/4497190/35975810-ee43b16e-0cd5-11e8-9c52-9a07b94f48e6.png)
