### PR TITLE
Fix a bug in the markdown docs references

### DIFF
--- a/lib/msf/util/document_generator/normalizer.rb
+++ b/lib/msf/util/document_generator/normalizer.rb
@@ -204,9 +204,24 @@ module Msf
         # @param refs [Array] Module references.
         # @return [String]
         def normalize_references(refs)
-          refs.collect { |r| "* <a href=\"#{r}\">#{r}</a>" } * "\n"
+          normalized = ''
+          refs.each do |ref|
+            case ref.ctx_id
+            when 'AKA'
+              normalized << "* *Also known as:* #{ref.ctx_val}"
+            when 'MSB'
+              normalized << "* [#{ref.ctx_val}](#{ref.site})"
+            when 'URL'
+              normalized << "* [#{ref.site}](#{ref.site})"
+            when 'US-CERT-VU'
+              normalized << "* [VU##{ref.ctx_val}](#{ref.site})"
+            else
+              normalized << "* [#{ref.ctx_id}-#{ref.ctx_val}](#{ref.site})"
+            end
+            normalized << "\n"
+          end
+          normalized
         end
-
 
         # Returns the markdown format for module platforms.
         #

--- a/lib/msf/util/document_generator/normalizer.rb
+++ b/lib/msf/util/document_generator/normalizer.rb
@@ -144,7 +144,7 @@ module Msf
           formatted_pr = []
 
           pull_requests.each_pair do |number, pr|
-            formatted_pr << "* <a href=\"https://github.com/rapid7/metasploit-framework/pull/#{number}\">##{number}</a> - #{pr[:title]}"
+            formatted_pr << "* [##{number} #{pr[:title]}](https://github.com/rapid7/metasploit-framework/pull/#{number})"
           end
 
           formatted_pr * "\n"
@@ -222,6 +222,7 @@ module Msf
           end
           normalized
         end
+
 
         # Returns the markdown format for module platforms.
         #

--- a/spec/lib/msf/util/document_generator/normalizer_spec.rb
+++ b/spec/lib/msf/util/document_generator/normalizer_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe Msf::Util::DocumentGenerator::DocumentNormalizer do
   describe 'normalize_pull_requests' do
     context 'when a hash of pull requests are given' do
       it 'returns HTML links' do
-        expect(subject.send(:normalize_pull_requests, good_pull_requests)).to include('* <a href=')
+        expect(subject.send(:normalize_pull_requests, good_pull_requests)).to include('](https://github.com/')
       end
     end
 

--- a/spec/lib/msf/util/document_generator/normalizer_spec.rb
+++ b/spec/lib/msf/util/document_generator/normalizer_spec.rb
@@ -1,4 +1,5 @@
 require 'rex'
+require 'msf/core/module/reference'
 require 'msf/util/document_generator'
 require 'msf/util/document_generator/pull_request_finder'
 
@@ -10,7 +11,7 @@ RSpec.describe Msf::Util::DocumentGenerator::DocumentNormalizer do
   let(:mod_shortname)     { 'ms08_067_netapi' }
   let(:mod_name)          { 'MS08-067' }
   let(:mod_pull_requests) { good_pull_requests }
-  let(:mod_refs)          { ['URL', 'http://example.com'] }
+  let(:mod_refs)          { [Msf::Module::SiteReference.new('URL', 'http://example.com')] }
   let(:mod_platforms)     { 'win' }
   let(:mod_options)       { { 'RHOST' => rhost_option } }
   let(:mod_normal_rank)   { 300 }
@@ -159,7 +160,7 @@ RSpec.describe Msf::Util::DocumentGenerator::DocumentNormalizer do
   describe 'normalize_references' do
     context 'when an array of references is given' do
       it 'returns the reference list in HTML' do
-        expect(subject.send(:normalize_references, msf_mod.references)).to include('* <a href=')
+        expect(subject.send(:normalize_references, msf_mod.references)).to include('* [http://')
       end
     end
   end


### PR DESCRIPTION
This Pull Request fixes a bug in how the `info -d` command generates documents with broken links in the References section. It would appear that all links are being inserted as escaped HTML, including AKA links (which for some reason are instances of `SiteReference` despite not having a valid URI).

This fixes this issue by checking the `SiteReference.ctx_id` and generating a link as appropriate with reasonable link text. If the logic should be moved to the `SiteReference` class in maybe a `to_md_link` method or something just let me know.

## Verification

The new `ms17_010_psexec` module is a good use case for testing this bug because it has multiple references of different types.

- [x] Start `msfconsole`
- [x] `use exploit/windows/smb/ms17_010_psexec`
- [x] `info -d`
- [x] When the documentation HTML file appears in the browser, select Overview then examine the References section
  - [x] See pretty references, not raw HTML

### Example Output

**Before**
![before](https://user-images.githubusercontent.com/2058303/36044193-d9a9c3f4-0d9f-11e8-929e-d7457cf6db2d.png)

**After**
![after](https://user-images.githubusercontent.com/2058303/36044200-de0d5834-0d9f-11e8-83c0-1776a7af91e3.png)

