### PR TITLE
Fix #9522, Add output file support to the vulns command

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -907,7 +907,7 @@ class Db
       end
     end
 
-    if out_file
+    if output_file
       File.write(output_file, tbl.to_csv)
       print_status("Wrote vulnerability information to #{output_file}")
     end

--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -777,6 +777,7 @@ class Db
     print_line "Usage: vulns [addr range]"
     print_line
     print_line "  -h,--help             Show this help information"
+    print_line "  -o <file>             Send output to a file in csv format"
     print_line "  -p,--port <portspec>  List vulns matching this port spec"
     print_line "  -s <svc names>        List vulns matching these service names"
     print_line "  -R,--rhosts           Set RHOSTS from the results of the search"
@@ -801,6 +802,7 @@ class Db
     search_term = nil
     show_info   = false
     set_rhosts  = false
+    output_file = nil
 
     # Short-circuit help
     if args.delete "-h"
@@ -817,6 +819,14 @@ class Db
       when "-h","--help"
         cmd_vulns_help
         return
+      when "-o", "--output"
+        output_file = args.shift
+        if output_file
+          output_file = File.expand_path(output_file)
+        else
+          print_error("Invalid output filename")
+          return
+        end
       when "-p","--port"
         unless (arg_port_range(args.shift, port_ranges, true))
           return
@@ -846,6 +856,10 @@ class Db
     host_ranges.push(nil) if host_ranges.empty?
     ports = port_ranges.flatten.uniq
     svcs.flatten!
+    tbl = Rex::Text::Table.new(
+        'Header' => 'Vulnerabilities',
+        'Columns' => ['Timestamp', 'Host', 'Name', 'References', 'Information']
+      )
 
     each_host_range_chunk(host_ranges) do |host_search|
       framework.db.hosts(framework.db.workspace, false, host_search).each do |host|
@@ -857,25 +871,45 @@ class Db
             )
           end
           reflist = vuln.refs.map { |r| r.name }
+
           if(vuln.service)
             # Skip this one if the user specified a port and it
             # doesn't match.
             next unless ports.empty? or ports.include? vuln.service.port
             # Same for service names
             next unless svcs.empty? or svcs.include?(vuln.service.name)
-            print_status("Time: #{vuln.created_at} Vuln: host=#{host.address} name=#{vuln.name} refs=#{reflist.join(',')} #{(show_info && vuln.info) ? "info=#{vuln.info}" : ""}")
-
           else
             # This vuln has no service, so it can't match
             next unless ports.empty? and svcs.empty?
-            print_status("Time: #{vuln.created_at} Vuln: host=#{host.address} name=#{vuln.name} refs=#{reflist.join(',')} #{(show_info && vuln.info) ? "info=#{vuln.info}" : ""}")
           end
+
+          print_status("Time: #{vuln.created_at} Vuln: host=#{host.address} name=#{vuln.name} refs=#{reflist.join(',')} #{(show_info && vuln.info) ? "info=#{vuln.info}" : ""}")
+
+          if output_file
+            row = []
+            row << vuln.created_at
+            row << host.address
+            row << vuln.name
+            row << reflist * ","
+            if show_info && vuln.info
+              row << "info=#{vuln.info}"
+            else
+              row << ''
+            end
+            tbl << row
+          end
+
           if set_rhosts
             addr = (host.scope ? host.address + '%' + host.scope : host.address)
             rhosts << addr
           end
         end
       end
+    end
+
+    unless tbl.rows.empty?
+      File.write(output_file, tbl.to_csv)
+      print_status("Wrote vulnerability information to #{output_file}")
     end
 
     # Finally, handle the case where the user wants the resulting list

--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -907,7 +907,7 @@ class Db
       end
     end
 
-    unless tbl.rows.empty?
+    if out_file
       File.write(output_file, tbl.to_csv)
       print_status("Wrote vulnerability information to #{output_file}")
     end

--- a/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
@@ -265,6 +265,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Db do
           "Print all vulnerabilities in the database",
           "Usage: vulns [addr range]",
           "  -h,--help             Show this help information",
+          "  -o <file>             Send output to a file in csv format",
           "  -p,--port <portspec>  List vulns matching this port spec",
           "  -s <svc names>        List vulns matching these service names",
           "  -R,--rhosts           Set RHOSTS from the results of the search",


### PR DESCRIPTION
# Description

This adds a new feature for the vulns command for msfconsole. It allows the user to be able to save the vulnerability information as a CSV file.

Fix #9522

# Verification Steps

- [x] Start msfconsole
- [x] Make sure you are connected to a database (do `db_connect` if you are not)
- [x] Make sure you have some vulnerability data in the workspace you're on (do `workspace` to switch or create a new workspace)
- [x] Do `vulns`, you should be able to see some vulnerability information
- [x] Do `vulns -h`, you should be able to see the help menu for the vulns command. You should also see `-o` as an option.
- [x] Do `vulns -o /tmp/vuln_info.csv`, you should be able to dump the vulnerability information to /tmp/vuln_info.csv
- [x] Open /tmp/vuln_info.csv, the content of the file should be in CSV format.