### PR TITLE
bump gems, remove rbnacl/ffi since unneeded

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,7 +38,6 @@ PATH
       pg (= 0.20.0)
       railties
       rb-readline
-      rbnacl (< 5.0.0)
       recog
       redcarpet
       rex-arch
@@ -73,7 +72,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    Ascii85 (1.0.2)
+    Ascii85 (1.0.3)
     actionpack (4.2.10)
       actionview (= 4.2.10)
       activesupport (= 4.2.10)
@@ -103,12 +102,12 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     afm (0.2.2)
     arel (6.0.4)
-    arel-helpers (2.5.0)
+    arel-helpers (2.6.1)
       activerecord (>= 3.1.0, < 6)
-    backports (3.11.0)
+    backports (3.11.1)
     bcrypt (3.1.11)
     bcrypt_pbkdf (1.0.0)
-    bindata (2.4.1)
+    bindata (2.4.2)
     bit-struct (0.16)
     builder (3.2.3)
     coderay (1.1.2)
@@ -127,7 +126,6 @@ GEM
       i18n (>= 0.7)
     faraday (0.13.1)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.18)
     filesize (0.1.1)
     fivemat (1.3.5)
     google-protobuf (3.5.1)
@@ -249,8 +247,6 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rake (12.3.0)
     rb-readline (0.5.5)
-    rbnacl (4.0.2)
-      ffi
     recog (2.1.17)
       nokogiri
     redcarpet (3.4.0)
@@ -352,7 +348,7 @@ GEM
     ttfunk (1.5.1)
     tzinfo (1.2.4)
       thread_safe (~> 0.1)
-    tzinfo-data (1.2017.3)
+    tzinfo-data (1.2018.3)
       tzinfo (>= 1.0.0)
     windows_error (0.1.2)
     xdr (2.0.0)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -125,7 +125,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'dnsruby'
   spec.add_runtime_dependency 'mqtt'
   spec.add_runtime_dependency 'net-ssh'
-  spec.add_runtime_dependency 'rbnacl', ['< 5.0.0']
   spec.add_runtime_dependency 'bcrypt_pbkdf'
   spec.add_runtime_dependency 'ruby_smb'
 


### PR DESCRIPTION
This does an update of gems on master for msf5, not to be landed on 4.x