### PR TITLE
Fix #9513, Add private_type to be able to store password for Tomcat

### DIFF
--- a/modules/auxiliary/scanner/http/tomcat_mgr_login.rb
+++ b/modules/auxiliary/scanner/http/tomcat_mgr_login.rb
@@ -120,7 +120,8 @@ class MetasploitModule < Msf::Auxiliary
       credential_data = result.to_h
       credential_data.merge!(
           module_fullname: self.fullname,
-          workspace_id: myworkspace_id
+          workspace_id: myworkspace_id,
+          private_type: :password
       )
       if result.success?
         credential_core = create_credential(credential_data)


### PR DESCRIPTION
# Description

This PR fixes a credential reporting issue with auxiliary/scanner/http/tomcat_mgr_login.

If there is no :private_type, the create_credential method in Metasploit::Credential::Creation will quietly skip the password, which makes it look like a bug when the user is trying to view
the password from the creds command.

Fix #9513

# Verification

- [x] Set up a Tomcat instance (make sure you have Java installed): [apache-tomcat-9.0.1.zip](https://github.com/rapid7/metasploit-framework/files/1721602/apache-tomcat-9.0.1.zip)
- [x] Save a new username/password in data/wordlists/tomcat_mgr_default_userpass.txt. Make sure the new user/pass is the last on the list.
- [x] Start msfconsole
- [x] Do: `use auxiliary/scanner/http/tomcat_mgr_login`
- [x] Do: `set rhosts [ip]`
- [x] Do: `run`
- [x] Do: `creds`
- [x] Make sure you can see your new user/pass, also the private_type on the list.