### PR TITLE
Fix #9417, map timeout exp to a var for telnet_encrypt_overflow

### DIFF
--- a/modules/auxiliary/scanner/telnet/telnet_encrypt_overflow.rb
+++ b/modules/auxiliary/scanner/telnet/telnet_encrypt_overflow.rb
@@ -127,7 +127,7 @@ class MetasploitModule < Msf::Auxiliary
     rescue ::Rex::ConnectionError, ::Errno::ECONNRESET => e
       print_error("A network issue has occurred: #{e.message}")
       elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
-    rescue Timeout::Error
+    rescue Timeout::Error => e
       print_error("#{target_host}:#{rport} Timed out after #{to} seconds")
       elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
     rescue ::Exception => e


### PR DESCRIPTION
# Description

This maps the Timeout exception to a variable in module auxiliary/scanner/telnet/telnet/encrypt__overflow, so that we can print the error message when timeout occurs. 

Fix #9417

# Verification

- [x] I believe a simple code review is sufficient to verify this fix. Please do that.