### PR TITLE
Fix #8120, Fix undef method 'gsub' in bavision_cam_login

### DIFF
--- a/lib/metasploit/framework/login_scanner/bavision_cameras.rb
+++ b/lib/metasploit/framework/login_scanner/bavision_cameras.rb
@@ -5,6 +5,8 @@ module Metasploit
   module Framework
     module LoginScanner
 
+      class BavisionCamerasException < Exception; end
+
       class BavisionCameras < HTTP
 
         DEFAULT_PORT  = 80
@@ -59,7 +61,13 @@ module Metasploit
           nonce_count = 1
           cnonce = Digest::MD5.hexdigest("%x" % (Time.now.to_i + rand(65535)))
 
-          response['www-authenticate'] =~ /^(\w+) (.*)/
+          i = (response['www-authenticate'] =~ /^(\w+) (.*)/)
+
+          # The www-authenticate header does not return in the format we like,
+          # so let's bail.
+          unless i
+            raise BavisionCamerasException, 'www-authenticate header is not in the right format'
+          end
 
           params = {}
           $2.gsub(/(\w+)="(.*?)"/) { params[$1] = $2 }
@@ -104,7 +112,7 @@ module Metasploit
 
           begin
             result_opts.merge!(try_digest_auth(credential))
-          rescue ::Rex::ConnectionError => e
+          rescue ::Rex::ConnectionError, BavisionCamerasException => e
             # Something went wrong during login. 'e' knows what's up.
             result_opts.merge!(status: LOGIN_STATUS::UNABLE_TO_CONNECT, proof: e.message)
           end


### PR DESCRIPTION
# Description

This patch will check if the web server's www-authenticate is in the format we like for digest-auth. If not, it will raise an exception, and then treat the server as UNABLE_TO_CONNECT.

Fix #8120 

# Verification

- [x] Since you would need the hardware to test, and that you're not supposed to fire this module against a random Bavision camera on the Internet, your best bet is through code review.