### PR TITLE
Aux command dispatcher in exploit ctx with action

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/auxiliary.rb
+++ b/lib/msf/ui/console/command_dispatcher/auxiliary.rb
@@ -98,7 +98,7 @@ class Auxiliary
     # Always run passive modules in the background
     if (mod.passive || mod.passive_action?(action || mod.default_action))
       jobify = true
-    end
+    end if mod.is_a?(Msf::Module::HasActions)
 
     begin
       mod.run_simple(


### PR DESCRIPTION
The Auxiliary command dispatcher checks modules for passive actions
expecting them to have included Msf::Module::HasActions mixin. The
mixin is included in post and aux modules already, but not in
exploits. When the aux dispatcher handles an exploit module, it
may get upset along the lines of:
```
[-] Error while running command exploit: undefined method 'passive'
for #<Msf::Modules::M...3::MetasploitModule:0x0000000d83de0428>
Did you mean?  passive?

Call stack:
/opt/metasploit4/msf4/lib/msf/ui/console/command_dispatcher/
auxiliary.rb:106:in `cmd_run'
```

Avoid this mess by having the conditional which checks the methods
included by that mixin depend on the module having included the
mixin in the first place.

Testing:
  In local fork (hence the lineno) it seems to fix the problem.
  The problem condition and fix should be independently tested
upstream.