### PR TITLE
Upload tweak

### DIFF
--- a/lib/rex/post/meterpreter/extensions/stdapi/fs/file.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/fs/file.rb
@@ -275,17 +275,23 @@ class File < Rex::Post::Meterpreter::Extensions::Stdapi::Fs::IO
     # Open the file on the remote side for writing and read
     # all of the contents of the local file
     stat.call('uploading', src_file, dest_file) if (stat)
-    dest_fd = client.fs.file.new(dest_file, "wb")
-    src_buf = ''
-
-    ::File.open(src_file, 'rb') { |f|
-      src_buf = f.read(f.stat.size)
-    }
+    dest_fd = nil
+    src_fd = nil
+    buf_size = 8 * 1024 * 1024
 
     begin
-      dest_fd.write(src_buf)
+      dest_fd = client.fs.file.new(dest_file, "wb")
+      src_fd = ::File.open(src_file, "rb")
+      src_size = src_fd.stat.size
+      while (buf = src_fd.read(buf_size))
+        dest_fd.write(buf)
+        percent = dest_fd.pos.to_f / src_size.to_f * 100.0
+        msg = "Uploaded #{Filesize.new(dest_fd.pos).pretty} of #{src_size} (#{percent.round(2)}%)"
+        stat.call(msg, src_file, dest_file)
+      end
     ensure
-      dest_fd.close
+      src_fd.close unless src_fd.nil?
+      dest_fd.close unless dest_fd.nil?
     end
     stat.call('uploaded', src_file, dest_file) if (stat)
   end

--- a/lib/rex/post/meterpreter/extensions/stdapi/fs/file.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/fs/file.rb
@@ -286,7 +286,8 @@ class File < Rex::Post::Meterpreter::Extensions::Stdapi::Fs::IO
       while (buf = src_fd.read(buf_size))
         dest_fd.write(buf)
         percent = dest_fd.pos.to_f / src_size.to_f * 100.0
-        msg = "Uploaded #{Filesize.new(dest_fd.pos).pretty} of #{src_size} (#{percent.round(2)}%)"
+        msg = "Uploaded #{Filesize.new(dest_fd.pos).pretty} of " \
+          "#{Filesize.new(src_size).pretty} (#{percent.round(2)}%)"
         stat.call(msg, src_file, dest_file)
       end
     ensure

--- a/lib/rex/post/meterpreter/packet.rb
+++ b/lib/rex/post/meterpreter/packet.rb
@@ -874,9 +874,12 @@ class Packet < GroupTlv
   # Xor a set of bytes with a given XOR key.
   #
   def xor_bytes(xor_key, bytes)
+    xor_key = xor_key.bytes
     result = ''
-    bytes.bytes.zip(xor_key.bytes.cycle).each do |b|
-      result << (b[0].ord ^ b[1].ord).chr
+    i = 0
+    bytes.each_byte do |b|
+      result << (b ^ xor_key[i % xor_key.length]).chr
+      i += 1
     end
     result
   end


### PR DESCRIPTION
Meterpreter `upload` extension use too much memory. For uploading 60M file framework eat about **5.5G**  memory, while at start it use about 200M.

For solve this problem I optimize `xor_bytes` method of class `Packet` (usage of `bytes.bytes.zip(xor_key.bytes.cycle)` need much memory if length of bytes is big) and make some changes in `upload_file` to upload file by small parts. Also, I make output of `upload` more verbosity, as in `download`:

```
[*] uploading  : big_file -> C:big_file
[*] Uploaded 8.00 MiB of 60.00 MiB (13.33%): big_file -> C:big_file
[*] Uploaded 16.00 MiB of 60.00 MiB (26.67%): big_file -> C:big_file
[*] Uploaded 24.00 MiB of 60.00 MiB (40.0%): big_file -> C:big_file
[*] Uploaded 32.00 MiB of 60.00 MiB (53.33%): big_file -> C:big_file
[*] Uploaded 40.00 MiB of 60.00 MiB (66.67%): big_file -> C:big_file
[*] Uploaded 48.00 MiB of 60.00 MiB (80.0%): big_file -> C:big_file
[*] Uploaded 56.00 MiB of 60.00 MiB (93.33%): big_file -> C:big_file
[*] Uploaded 60.00 MiB of 60.00 MiB (100.0%): big_file -> C:big_file
[*] uploaded   : big_file -> C:big_file
```

For testing I use follows scripts:

**upload_test.sh**
```sh
#!/bin/bash

for i in `seq 10`; do
    /usr/bin/time -f "%E %M" ./msfconsole -q -o output$i.txt -r upload_test.rc
    sleep 5
done
```
Resource file **upload_test.rc**:
```
use exploit/windows/smb/ms17_010_psexec
set RHOST 192.168.56.4
run -z
sleep 1
sessions -i 1 -C "upload big_file C:\\big_file"
sessions -i 1 -C "checksum sha1 C:\\big_file"
sessions -i 1 -C "exit"
sleep 1
exit
```

Results (elasped time and memory usage in kbytes) of testing before tweak (used about 5.5G of memory):
```
0:52.76 5780740
0:54.73 5716760
0:52.93 5908664
0:50.68 5777884
0:54.67 5692332
0:55.04 5777448
0:50.95 5717024
0:52.49 6542364
0:55.07 5822672
0:52.71 5715156
```

Results after tweak (used about 445M of memory):
```
0:38.06 459908
0:38.14 448076
0:39.04 436964
0:38.06 463636
0:39.87 463276
0:40.44 456572
0:39.74 459508
0:39.97 461484
0:38.49 457848
0:38.71 455080
```

## Verification

- [x] Prepare some vulnerable PC
- [x] On host: `dd if=/dev/urandom of=big_file bs=1M count=60`
- [x] Start `msfconsole`
- [x] `use exploit/windows/smb/ms17_010_psexec`
- [x] `set RHOST a.b.c.d` (put vuln. PC address)
- [x] `run`
- [x] `upload big_file C:\\big_file`
- [x] `checksum sha1 C:\\big_file`
- [x] **Verify** check that `sha1` is identical to file on host
