### PR TITLE
docker error workaround

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ LABEL maintainer="Rapid7"
 
 ARG BUNDLER_ARGS="--jobs=8 --without development test coverage"
 ENV APP_HOME /usr/src/metasploit-framework/
-ENV MSF_USER msf
 ENV NMAP_PRIVILEGED=""
 ENV BUNDLE_IGNORE_MESSAGES="true"
 WORKDIR $APP_HOME
@@ -15,6 +14,7 @@ COPY lib/msf/util/helper.rb $APP_HOME/lib/msf/util/helper.rb
 
 RUN apk update && \
     apk add \
+      bash \
       sqlite-libs \
       nmap \
       nmap-scripts \
@@ -24,6 +24,7 @@ RUN apk update && \
       python3 \
       ncurses \
       libcap \
+      su-exec \
     && apk add --virtual .ruby-builddeps \
       autoconf \
       bison \
@@ -47,13 +48,16 @@ RUN apk update && \
     && apk del .ruby-builddeps \
     && rm -rf /var/cache/apk/*
 
-RUN adduser -g msfconsole -D $MSF_USER -u 1000
-
 RUN /usr/sbin/setcap cap_net_raw,cap_net_bind_service=+eip $(which ruby)
 RUN /usr/sbin/setcap cap_net_raw,cap_net_bind_service=+eip $(which nmap)
 
-USER $MSF_USER
-
 ADD ./ $APP_HOME
+
+# we need this entrypoint to dynamically create a user
+# matching the hosts UID and GID so we can mount something
+# from the users home directory. If the IDs don't match
+# it results in access denied errors. Once docker has
+# a solution for this we can revert it back to normal
+ENTRYPOINT ["docker/entrypoint.sh"]
 
 CMD ["./msfconsole", "-r", "docker/msfconsole.rc"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN apk update && \
     && apk del .ruby-builddeps \
     && rm -rf /var/cache/apk/*
 
-RUN adduser -g msfconsole -D $MSF_USER
+RUN adduser -g msfconsole -D $MSF_USER -u 1000
 
 RUN /usr/sbin/setcap cap_net_raw,cap_net_bind_service=+eip $(which ruby)
 RUN /usr/sbin/setcap cap_net_raw,cap_net_bind_service=+eip $(which nmap)

--- a/docker/README.md
+++ b/docker/README.md
@@ -3,22 +3,25 @@
 
 To run `msfconsole`
 ```bash
-docker-compose build
-docker-compose run --rm --service-ports ms
-```
-or
-```bash
 ./docker/bin/msfconsole
 ```
 
-To run `msfvenom`
+or
+
 ```bash
 docker-compose build
-docker-compose run --rm --no-deps ms ./msfvenom
+docker-compose run --rm --service-ports -e MSF_UID=$(id -u) -e MSF_GID=$(id -g) ms
 ```
-or
+To run `msfvenom`
 ```bash
 ./docker/bin/msfvenom
+```
+
+or
+
+```bash
+docker-compose build
+docker-compose run --rm --no-deps -e MSF_UID=$(id -u) -e MSF_GID=$(id -g) ms ./msfvenom
 ```
 
 You can pass any command line arguments to the binstubs or the docker-compose command and they will be passed to `msfconsole` or `msfvenom`. If you need to rebuild an image (for example when the Gemfile changes) you need to build the docker image using `docker-compose build` or supply the `--rebuild` parameter to the binstubs.

--- a/docker/bin/msfconsole
+++ b/docker/bin/msfconsole
@@ -27,10 +27,4 @@ if [[ $PARAMS == *"--rebuild"* ]]; then
   exit $?
 fi
 
-# workaround if current user id is not the same as in the container.
-# Otherwise the ~/.msf4 folder is not writeable
-if [[ $EUID -ne 1000 ]]; then
-  docker-compose run --rm -u root --service-ports ms ./msfconsole -r docker/msfconsole.rc "$PARAMS"
-else
-  docker-compose run --rm --service-ports ms ./msfconsole -r docker/msfconsole.rc "$PARAMS"
-fi
+docker-compose run --rm --service-ports -e MSF_UID=$(id -u) -e MSF_GID=$(id -g) ms ./msfconsole -r docker/msfconsole.rc "$PARAMS"

--- a/docker/bin/msfconsole
+++ b/docker/bin/msfconsole
@@ -27,4 +27,10 @@ if [[ $PARAMS == *"--rebuild"* ]]; then
   exit $?
 fi
 
-docker-compose run --rm --service-ports ms ./msfconsole -r docker/msfconsole.rc "$PARAMS"
+# workaround if current user id is not the same as in the container.
+# Otherwise the ~/.msf4 folder is not writeable
+if [[ $EUID -ne 1000 ]]; then
+  docker-compose run --rm -u root --service-ports ms ./msfconsole -r docker/msfconsole.rc "$PARAMS"
+else
+  docker-compose run --rm --service-ports ms ./msfconsole -r docker/msfconsole.rc "$PARAMS"
+fi

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+MSF_USER=msf
+MSF_GROUP=msf
+TMP=${MSF_UID:=1000}
+TMP=${MSF_GID:=1000}
+
+# don't recreate system users like root
+if [ "$MSF_UID" -lt "1000" ]; then
+  MSF_UID=1000
+fi
+
+if [ "$MSF_GID" -lt "1000" ]; then
+  MSF_GID=1000
+fi
+
+addgroup -g $MSF_GID $MSF_GROUP
+adduser -u $MSF_UID -D $MSF_USER -g $MSF_USER -G $MSF_GROUP $MSF_USER
+
+su-exec $MSF_USER "$@"


### PR DESCRIPTION
See https://github.com/rapid7/metasploit-framework/issues/9287

This provides a workaround when the local user does not match the UID in the container. Currently it seems there is no way to modify it when mounting a local folder.
So if the current user id does not match the one in the container we simply run it as root.

Ugly as hell, but it should prevent the permission denied errors

Maybe anyone has a better solution for this problem?