### PR TITLE
specify a python encoding for the claymore DoS module

### DIFF
--- a/modules/auxiliary/dos/tcp/claymore_dos.py
+++ b/modules/auxiliary/dos/tcp/claymore_dos.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -
 # Note, works with both python 2.7 and 3
 
 
@@ -11,8 +12,8 @@ metadata = {
     'name': 'Claymore Dual GPU Miner  Format String dos attack',
 
     'description': '''
-    Claymore’s Dual GPU Miner 10.5 and below is vulnerable to a format strings vulnerability. This allows an 
-    unauthenticated attacker to read memory addresses, or immediately terminate the mining process causing 
+    Claymore’s Dual GPU Miner 10.5 and below is vulnerable to a format strings vulnerability. This allows an
+    unauthenticated attacker to read memory addresses, or immediately terminate the mining process causing
     a denial of service.
     ''',
 


### PR DESCRIPTION
Probably another thing to add to the msftidy.py wishlist, the claymore GPU module from #9512 didn't specify an encoding and failed on some systems with this message:

```
[02/16/2018 16:11:11] [e(0)] core: Unexpected output running /home/bcook/projects/metasploit-framework/modules/auxiliary/dos/tcp/claymore_dos.py:
  File "/home/bcook/projects/metasploit-framework/modules/auxiliary/dos/tcp/claymore_dos.py", line 14
SyntaxError: Non-ASCII character '\xe2' in file /home/bcook/projects/metasploit-framework/modules/auxiliary/dos/tcp/claymore_dos.py on line 15, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details

[02/16/2018 16:11:11] [e(0)] core: Unable to load module /home/bcook/projects/metasploit-framework/modules/auxiliary/dos/tcp/claymore_dos.py NoMethodError undefined method `params' for nil:NilClass
```

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Ensure ~/.msf4/logs/framework.log is clean
