### PR TITLE
add missing payload tests for bind_named_pipe

### DIFF
--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -2857,6 +2857,16 @@ RSpec.describe 'modules/payloads', :content do
                           reference_name: 'windows/messagebox'
   end
 
+  context 'windows/meterpreter_bind_named_pipe' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'singles/windows/meterpreter_bind_named_pipe'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'windows/meterpreter_bind_named_pipe'
+  end
+
   context 'windows/meterpreter_bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
                           ancestor_reference_names: [
@@ -4042,6 +4052,17 @@ RSpec.describe 'modules/payloads', :content do
                           reference_name: 'windows/x64/meterpreter/bind_ipv6_tcp_uuid'
   end
 
+  context 'windows/x64/meterpreter/bind_named_pipe' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'stagers/windows/x64/bind_named_pipe',
+                              'stages/windows/x64/meterpreter'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'windows/x64/meterpreter/bind_named_pipe'
+  end
+
   context 'windows/x64/meterpreter/bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
                           ancestor_reference_names: [
@@ -4141,6 +4162,16 @@ RSpec.describe 'modules/payloads', :content do
                           reference_name: 'windows/x64/meterpreter/reverse_winhttps'
   end
 
+  context 'windows/x64/meterpreter_bind_named_pipe' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'singles/windows/x64/meterpreter_bind_named_pipe'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'windows/x64/meterpreter_bind_named_pipe'
+  end
+
   context 'windows/x64/meterpreter_bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
                           ancestor_reference_names: [
@@ -4211,6 +4242,17 @@ RSpec.describe 'modules/payloads', :content do
                           reference_name: 'windows/x64/powershell_reverse_tcp'
   end
 
+  context 'windows/x64/shell/bind_named_pipe' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'stagers/windows/x64/bind_named_pipe',
+                              'stages/windows/x64/shell'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'windows/x64/shell/bind_named_pipe'
+  end
+
   context 'windows/x64/shell/bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
                           ancestor_reference_names: [
@@ -4251,6 +4293,17 @@ RSpec.describe 'modules/payloads', :content do
                           dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/x64/shell_reverse_tcp'
+  end
+
+  context 'windows/x64/vncinject/bind_named_pipe' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'stagers/windows/x64/bind_named_pipe',
+                              'stages/windows/x64/vncinject'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'windows/x64/vncinject/bind_named_pipe'
   end
 
   context 'windows/x64/vncinject/bind_tcp' do


### PR DESCRIPTION
Adds the new tests needed to ensure bind_named_pipe payload sizes are known and consistent.

## Verification

List the steps needed to make sure this thing works

- [x] payload unit tests pass
