### PR TITLE
bind_named_pipe fixes

### DIFF
--- a/lib/rex/proto/smb/simpleclient.rb
+++ b/lib/rex/proto/smb/simpleclient.rb
@@ -23,7 +23,7 @@ XCEPT = Rex::Proto::SMB::Exceptions
 EVADE = Rex::Proto::SMB::Evasions
 
 # Public accessors
-attr_accessor :last_error
+attr_accessor :last_error, :server_max_buffer_size
 
 # Private accessors
 attr_accessor :socket, :client, :direct, :shares, :last_share
@@ -34,6 +34,7 @@ attr_accessor :socket, :client, :direct, :shares, :last_share
     self.direct = direct
     self.client = Rex::Proto::SMB::Client.new(socket)
     self.shares = { }
+    self.server_max_buffer_size = 1024 # 4356 (workstation) or 16644 (server) expected
   end
 
   def login(name = '', user = '', pass = '', domain = '',
@@ -55,7 +56,8 @@ attr_accessor :socket, :client, :direct, :shares, :last_share
       self.client.use_lanman_key =  use_lanman_key
       self.client.send_ntlm = send_ntlm
 
-      self.client.negotiate
+      ok = self.client.negotiate
+      self.server_max_buffer_size = ok['Payload'].v['MaxBuff']
 
       # Disable NTLMv2 Session for Windows 2000 (breaks authentication on some systems)
       # XXX: This in turn breaks SMB auth for Windows 2000 configured to enforce NTLMv2


### PR DESCRIPTION
Fixes known issues with the bind_named_pipe payload.
This is a follow up to https://github.com/rapid7/metasploit-framework/pull/9539

1. Fixed 5 second delay in stager by removing StagerRetryWait option. Should no longer get "[-] Unknown command:" on startup. WAIT_TIMEOUT option was added instead.

2. Fixed issue that caused peek_named_pipe to incorrectly report 0 bytes available when more than MaxBufferSize bytes were buffered on the server.

3. Added thread in handler to send SMB echo request after a timeout to force select() to return in the packet dispatcher. Without this, data may remain buffered on the server. Having data available on the server alone does not put the socket in a readable state so we must force a peek/read on the pipe.

4. Read operations now grab all available data on the pipe.

5. "channel -i" now works as expected due to fixes 2 and 3.
