### PR TITLE
WDS update to add deploymentshare$ and customsettings.ini

### DIFF
--- a/modules/auxiliary/gather/windows_deployment_services_shares.rb
+++ b/modules/auxiliary/gather/windows_deployment_services_shares.rb
@@ -193,7 +193,7 @@ class MetasploitModule < Msf::Auxiliary
         domain = ini[group]['DomainAdminDomain']
         username = ini[group]['DomainAdmin']
         password = ini[group]['DomainAdminPassword']
-      
+
     if domain.to_s.length > 0 && username.to_s.length > 0 && password.to_s.length > 0
           loot_file(data,file_path)
           print_good("Credentials: " +
@@ -204,7 +204,6 @@ class MetasploitModule < Msf::Auxiliary
         end
       end
     end
-
 
     unattend_results.each do |file_path|
       file = simple.open(file_path, 'o').read()

--- a/modules/auxiliary/gather/windows_deployment_services_shares.rb
+++ b/modules/auxiliary/gather/windows_deployment_services_shares.rb
@@ -161,7 +161,7 @@ class MetasploitModule < Msf::Auxiliary
         deploy_shares << "DeploymentShare$"
         deploy_shares.each do |deploy_share|
           query_share(deploy_share)
-	end
+        end
       end
 
     rescue ::Interrupt
@@ -194,12 +194,12 @@ class MetasploitModule < Msf::Auxiliary
         username = ini[group]['DomainAdmin']
         password = ini[group]['DomainAdminPassword']
       
-	if domain.to_s.length > 0 && username.to_s.length > 0 && password.to_s.length > 0
+    if domain.to_s.length > 0 && username.to_s.length > 0 && password.to_s.length > 0
           loot_file(data,file_path)
           print_good("Credentials: " +
             "Path=#{share_path}#{file_path} " +
-	    "Username=#{domain}\\#{username} " +
-	    "Password=#{password}"
+            "Username=#{domain}\\#{username} " +
+            "Password=#{password}"
           )
         end
       end


### PR DESCRIPTION
On MDT there is an additional share which may be useful to search for credentials. deploymentshare$ is created when you create a deployment share in MDT. It is possible to add a machine to the domain after imaging using customsettings.ini. This adds both the addition of  deploymentshare$, and the search and ini parsing needed to pull credentials from customsettings.ini.

