### PR TITLE
handle 'ctrl-d' exiting msfconsole again

### DIFF
--- a/lib/rex/ui/text/shell.rb
+++ b/lib/rex/ui/text/shell.rb
@@ -128,7 +128,7 @@ module Shell
 
       while true
         # If the stop flag was set or we've hit EOF, break out
-        break if (self.stop_flag or self.stop_count > 1)
+        break if self.stop_flag || self.stop_count > 1
 
         init_tab_complete
 
@@ -378,6 +378,8 @@ protected
         output.input = nil
         log_output(input.prompt)
       else
+        self.stop_count += 1
+        next if self.stop_count > 1
         run_single("quit")
       end
     end

--- a/lib/rex/ui/text/shell.rb
+++ b/lib/rex/ui/text/shell.rb
@@ -190,17 +190,18 @@ module Shell
 
         line = get_input_line
 
-        # If a block was passed in, pass the line to it.  If it returns true,
-        # break out of the shell loop.
-        if block
-          break if line == nil || block.call(line)
-
         # If you have sessions active, this will give you a shot to exit
         # gracefully. If you really are ambitious, 2 eofs will kick this out
-        elsif input.eof? || line == nil
+        if input.eof? || line == nil
           self.stop_count += 1
           next if self.stop_count > 1
           run_single("quit")
+
+        # If a block was passed in, pass the line to it.  If it returns true,
+        # break out of the shell loop.
+        elsif block
+          break if line == nil || block.call(line)
+
 
         # Otherwise, call what should be an overriden instance method to
         # process the line.
@@ -375,13 +376,12 @@ protected
       str = input.pgets
       if str
         line << str
-        output.input = nil
-        log_output(input.prompt)
       else
-        self.stop_count += 1
-        next if self.stop_count > 1
-        run_single("quit")
+        line = nil
       end
+
+      output.input = nil
+      log_output(input.prompt)
     end
     self.cont_flag = false
 

--- a/lib/rex/ui/text/shell.rb
+++ b/lib/rex/ui/text/shell.rb
@@ -200,8 +200,7 @@ module Shell
         # If a block was passed in, pass the line to it.  If it returns true,
         # break out of the shell loop.
         elsif block
-          break if line == nil || block.call(line)
-
+          break if block.call(line)
 
         # Otherwise, call what should be an overriden instance method to
         # process the line.

--- a/lib/rex/ui/text/shell.rb
+++ b/lib/rex/ui/text/shell.rb
@@ -192,17 +192,19 @@ module Shell
 
         # If a block was passed in, pass the line to it.  If it returns true,
         # break out of the shell loop.
-        if (block)
-          break if (line == nil or block.call(line))
-        elsif(input.eof? or line == nil)
-        # If you have sessions active, this will give you a shot to exit gracefully
-        # If you really are ambitious, 2 eofs will kick this out
+        if block
+          break if line == nil || block.call(line)
+
+        # If you have sessions active, this will give you a shot to exit
+        # gracefully. If you really are ambitious, 2 eofs will kick this out
+        elsif input.eof? || line == nil
           self.stop_count += 1
-          next if(self.stop_count > 1)
+          next if self.stop_count > 1
           run_single("quit")
-        else
+
         # Otherwise, call what should be an overriden instance method to
         # process the line.
+        else
           ret = run_single(line)
           # don't bother saving lines that couldn't be found as a
           # command, create the file if it doesn't exist

--- a/lib/rex/ui/text/shell.rb
+++ b/lib/rex/ui/text/shell.rb
@@ -370,9 +370,14 @@ protected
       end
 
       output.input = input
-      line << input.pgets
-      output.input = nil
-      log_output(input.prompt)
+      str = input.pgets
+      if str
+        line << str
+        output.input = nil
+        log_output(input.prompt)
+      else
+        run_single("quit")
+      end
     end
     self.cont_flag = false
 


### PR DESCRIPTION
If we have no more input from the console, quit. The handler looks a little different with line continuation support.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Hit 'Ctrl-D'
- [ ] **Verify** console exits
- [ ] Start `msfconsole` again
- [ ] Get a session, hit 'Ctrl-D'
- [ ] **Verify** console tells you to type 'exit -y' to exit with live sessions open
