### PR TITLE
fix #9112, improve android screenshot error message on failure

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/ui.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/ui.rb
@@ -152,7 +152,7 @@ class Console::CommandDispatcher::Stdapi::Ui
 
     data = client.ui.screenshot( quality )
 
-    if( data )
+    if data
       ::File.open( path, 'wb' ) do |fd|
         fd.write( data )
       end
@@ -162,6 +162,11 @@ class Console::CommandDispatcher::Stdapi::Ui
       print_line( "Screenshot saved to: #{path}" )
 
       Rex::Compat.open_file( path ) if view
+    else
+      print_error("No screenshot data was returned.")
+      if client.platform == 'android'
+        print_error("On Android this command can only capture the application's own framebuffer.")
+      end
     end
 
     return true


### PR DESCRIPTION
## Verification

List the steps needed to make sure this thing works

- [x] Land https://github.com/rapid7/metasploit-payloads/pull/272
- [x] Get an android meterpreter session
- [x] `meterpreter> screenshot`
- [ ] ...
- [x] **Verify** the error message makes sense

