### PR TITLE
Support for Ruby 2.5.0 fixing OpenSSL warning #9576

### DIFF
--- a/lib/msf/core/opt.rb
+++ b/lib/msf/core/opt.rb
@@ -51,7 +51,7 @@ module Msf
     end
 
     def self.ssl_supported_options
-      @m ||= ['Auto', 'TLS'] + OpenSSL::SSL::SSLContext::METHODS \
+      @m ||= ['Auto', 'TLS'] + [:TLSv1_2, :TLSv1_1, :TLSv1, :SSLv3, :SSLv23, :SSLv2] \
              .select{|m| !m.to_s.include?('client') && !m.to_s.include?('server')} \
              .select{|m| OpenSSL::SSL::SSLContext.new(m) && true rescue false} \
              .map{|m| m.to_s.sub(/v/, '').sub('_', '.')}


### PR DESCRIPTION
This change removes the SSL warning with [Ruby 2.5.0](https://ruby-doc.org/stdlib-2.5.0/libdoc/openssl/rdoc/OpenSSL/SSL/SSLContext.html) that was referenced from [issue #9576](https://github.com/rapid7/metasploit-framework/issues/9576) 

Warning:
`/opt/metasploit/lib/msf/core/opt.rb:55: warning: constant OpenSSL::SSL::SSLContext::METHODS is deprecated`

Replaced:
`OpenSSL::SSL::SSLContext::METHODS`

With
`[:TLSv1_2, :TLSv1_1, :TLSv1, :SSLv3, :SSLv23, :SSLv2]`