### PR TITLE
Fix a couple of logged errors when running without Python 3.6 / gmpy2

### DIFF
--- a/lib/msf/core/modules/external/python/metasploit/module.py
+++ b/lib/msf/core/modules/external/python/metasploit/module.py
@@ -29,7 +29,7 @@ def report_vuln(ip, name, **opts):
 
 
 def run(metadata, module_callback):
-    req = json.loads(os.read(0, 10000))
+    req = json.loads(os.read(0, 10000).decode("utf-8"))
     if req['method'] == 'describe':
         rpc_send({'jsonrpc': '2.0', 'id': req['id'], 'response': metadata})
     elif req['method'] == 'run':

--- a/modules/auxiliary/scanner/ssl/bleichenbacher_oracle.py
+++ b/modules/auxiliary/scanner/ssl/bleichenbacher_oracle.py
@@ -9,9 +9,13 @@ import os
 import ssl
 
 # extra modules
-import gmpy2
-from cryptography import x509
-from cryptography.hazmat.backends import default_backend
+dependencies_missing = False
+try:
+    import gmpy2
+    from cryptography import x509
+    from cryptography.hazmat.backends import default_backend
+except ImportError:
+    dependencies_missing = True
 
 from metasploit import module
 
@@ -151,6 +155,10 @@ def oracle(target, pms, cke_2nd_prefix, cipher_handshake=ch_def, messageflow=Fal
 
 
 def run(args):
+    if dependencies_missing:
+        module.log("Module dependencies (gmpy2 and cryptography python libraries) missing, cannot continue", level='error')
+        return
+
     target = (args['rhost'], int(args['rport']))
     timeout = float(args['timeout'])
     cipher_handshake = cipher_handshakes[args['cipher_group']]


### PR DESCRIPTION
This fixes a couple of issues using Python modules on stock Ubuntu 16.04 and potentially other systems. First it adds general compatibility with Python 3.5, which returns binary from stdin rather than a utf-8 string. Second, it modifies bleichenbacker_oracle to fail gracefully if dependencies are missing. Fixes #9603 

## Verification

List the steps needed to make sure this thing works

- [x] Start with a stock Ubuntu 16.04 installation
- [x] Clear the console log ~/.msf4/logs/framework.log, and run `msfconsole`
- [x] Look at ~/.msf4/logs/framework.log and ensure there are no errors.
- [x] `use scanner/ssl/bleichenbacher_oracle`
- [x] If python3-gmpy2 is not installed, you should see:

```
msf5 auxiliary(scanner/ssl/bleichenbacher_oracle) > run

[*] Running for 192.168.22.27...
[-] Module dependencies (gmpy2 and cryptography python libraries) missing, cannot continue
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```
 - [x] Install python3-gmpy2
 - [x] Verify that the module now works (you don't have to restart framework)
