### PR TITLE
Add some tests for cmd_exec

### DIFF
--- a/test/modules/post/test/cmd_exec.rb
+++ b/test/modules/post/test/cmd_exec.rb
@@ -1,4 +1,3 @@
-require 'msf/core'
 require 'rex'
 
 lib = File.join(Msf::Config.install_root, "test", "lib")
@@ -21,7 +20,7 @@ class MetasploitModule < Msf::Post
   end
 
   def test_cmd_exec
-    print_status("Starting cmd_exec tests")
+    vprint_status("Starting cmd_exec tests")
 
     it "should return the result of echo" do
       test_string = Rex::Text.rand_text_alpha(4)
@@ -39,9 +38,35 @@ class MetasploitModule < Msf::Post
       test_string = Rex::Text.rand_text_alpha(4)
       test_string2 = Rex::Text.rand_text_alpha(4)
       output = cmd_exec("echo #{test_string}; sleep 1; echo #{test_string2}")
-      output == "#{test_string}\n#{test_string2}"
+      output.delete("\r") == "#{test_string}\n#{test_string2}"
     end
 
-    print_status("Finished cmd_exec tests")
+    it "should return the result of echo 10 times" do
+      10.times do
+        test_string = Rex::Text.rand_text_alpha(4)
+        output = cmd_exec("echo #{test_string}")
+        return false unless output == test_string
+      end
+      true
+    end
+
+    vprint_status("Finished cmd_exec tests")
   end
+
+  def test_cmd_exec_quotes
+    vprint_status("Starting cmd_exec quote tests")
+
+    it "should return the result of echo with single quotes" do
+      test_string = Rex::Text.rand_text_alpha(4)
+      output = cmd_exec("echo '#{test_string}'")
+      output == test_string
+    end
+
+    it "should return the result of echo with double quotes" do
+      test_string = Rex::Text.rand_text_alpha(4)
+      output = cmd_exec("echo \"#{test_string}\"")
+      output == test_string
+    end
+  end
+
 end

--- a/test/modules/post/test/cmd_exec.rb
+++ b/test/modules/post/test/cmd_exec.rb
@@ -1,0 +1,47 @@
+require 'msf/core'
+require 'rex'
+
+lib = File.join(Msf::Config.install_root, "test", "lib")
+$:.push(lib) unless $:.include?(lib)
+require 'module_test'
+
+class MetasploitModule < Msf::Post
+
+  include Msf::ModuleTest::PostTest
+  include Msf::Post::File
+
+  def initialize(info={})
+    super( update_info( info,
+        'Name'          => 'Meterpreter cmd_exec test',
+        'Description'   => %q{ This module will test the meterpreter cmd_exec API },
+        'License'       => MSF_LICENSE,
+        'Platform'      => [ 'windows', 'linux', 'unix' ],
+        'SessionTypes'  => [ 'meterpreter' ]
+      ))
+  end
+
+  def test_cmd_exec
+    print_status("Starting cmd_exec tests")
+
+    it "should return the result of echo" do
+      test_string = Rex::Text.rand_text_alpha(4)
+      output = cmd_exec("echo #{test_string}")
+      output == test_string
+    end
+
+    it "should return the result after sleeping" do
+      test_string = Rex::Text.rand_text_alpha(4)
+      output = cmd_exec("sleep 1; echo #{test_string}")
+      output == test_string
+    end
+
+    it "should return the full response after sleeping" do
+      test_string = Rex::Text.rand_text_alpha(4)
+      test_string2 = Rex::Text.rand_text_alpha(4)
+      output = cmd_exec("echo #{test_string}; sleep 1; echo #{test_string2}")
+      output == "#{test_string}\n#{test_string2}"
+    end
+
+    print_status("Finished cmd_exec tests")
+  end
+end

--- a/test/modules/post/test/cmd_exec.rb
+++ b/test/modules/post/test/cmd_exec.rb
@@ -24,7 +24,11 @@ class MetasploitModule < Msf::Post
 
     it "should return the result of echo" do
       test_string = Rex::Text.rand_text_alpha(4)
-      output = cmd_exec("echo #{test_string}")
+      if session.platform.eql?'windows'
+        output = cmd_exec('cmd.exe', "/c echo #{test_string}")
+      else
+        output = cmd_exec("echo #{test_string}")
+      end
       output == test_string
     end
 
@@ -37,14 +41,22 @@ class MetasploitModule < Msf::Post
     it "should return the full response after sleeping" do
       test_string = Rex::Text.rand_text_alpha(4)
       test_string2 = Rex::Text.rand_text_alpha(4)
-      output = cmd_exec("echo #{test_string}; sleep 1; echo #{test_string2}")
+      if session.platform.eql?'windows'
+        output = cmd_exec('cmd.exe', "/c echo #{test_string} & timeout 1 > null & echo #{test_string2}")
+      else
+        output = cmd_exec("echo #{test_string}; sleep 1; echo #{test_string2}")
+      end
       output.delete("\r") == "#{test_string}\n#{test_string2}"
     end
 
     it "should return the result of echo 10 times" do
       10.times do
         test_string = Rex::Text.rand_text_alpha(4)
-        output = cmd_exec("echo #{test_string}")
+	    if session.platform.eql?'windows'
+          output = cmd_exec("cmd.exe", "/c echo #{test_string}")
+        else
+          output = cmd_exec("echo #{test_string}")
+        end
         return false unless output == test_string
       end
       true
@@ -58,14 +70,24 @@ class MetasploitModule < Msf::Post
 
     it "should return the result of echo with single quotes" do
       test_string = Rex::Text.rand_text_alpha(4)
-      output = cmd_exec("echo '#{test_string}'")
-      output == test_string
+      if session.platform.eql?'windows'
+        output = cmd_exec("cmd.exe", "/c echo '#{test_string}'")
+        output == "'" + test_string + "'"
+      else
+        output = cmd_exec("echo '#{test_string}'")
+        output == test_string
+      end
     end
 
     it "should return the result of echo with double quotes" do
       test_string = Rex::Text.rand_text_alpha(4)
-      output = cmd_exec("echo \"#{test_string}\"")
-      output == test_string
+      if session.platform.eql?'windows'
+        output = cmd_exec("cmd.exe", "/c echo \"#{test_string}\"")
+        output == "\"" + test_string + "\""
+      else
+        output = cmd_exec("echo \"#{test_string}\"")
+        output == test_string
+      end
     end
   end
 


### PR DESCRIPTION
This change adds some tests for various cmd_exec scenario fails.
e.g
https://github.com/rapid7/metasploit-framework/issues/8722
https://github.com/rapid7/metasploit-framework/issues/9497
https://github.com/rapid7/mettle/issues/64

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Get any meterpreter session
- [x] Run the tests:
```
loadpath test/modules
use post/test/cmd_exec
set SESSION -1
exploit
```
- [ ] **Verify** the tests pass

