### PR TITLE
bump gems, lock ruby_smb for now

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,7 +59,7 @@ PATH
       rex-text
       rex-zip
       ruby-macho
-      ruby_smb
+      ruby_smb (= 0.0.18)
       rubyntlm
       rubyzip
       sqlite3
@@ -125,11 +125,11 @@ GEM
       railties (>= 3.0.0)
     faker (1.8.7)
       i18n (>= 0.7)
-    faraday (0.13.1)
+    faraday (0.14.0)
       multipart-post (>= 1.2, < 3)
     filesize (0.1.1)
     fivemat (1.3.5)
-    google-protobuf (3.5.1)
+    google-protobuf (3.5.1.2)
     googleapis-common-protos-types (1.0.1)
       google-protobuf (~> 3.0)
     googleauth (0.6.2)
@@ -140,12 +140,12 @@ GEM
       multi_json (~> 1.11)
       os (~> 0.9)
       signet (~> 0.7)
-    grpc (1.8.3)
+    grpc (1.9.1)
       google-protobuf (~> 3.1)
       googleapis-common-protos-types (~> 1.0.0)
       googleauth (>= 0.5.1, < 0.7)
     hashery (2.1.2)
-    i18n (0.9.1)
+    i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     jsobfu (0.4.2)
       rkelly-remix
@@ -155,7 +155,7 @@ GEM
     logging (2.2.2)
       little-plugger (~> 1.1)
       multi_json (~> 1.10)
-    loofah (2.1.1)
+    loofah (2.2.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     memoist (0.16.0)
@@ -167,7 +167,7 @@ GEM
       activemodel (~> 4.2.6)
       activesupport (~> 4.2.6)
       railties (~> 4.2.6)
-    metasploit-credential (2.0.12)
+    metasploit-credential (2.0.13)
       metasploit-concern
       metasploit-model
       metasploit_data_models
@@ -194,7 +194,7 @@ GEM
     metasploit_payloads-mettle (0.3.7)
     method_source (0.9.0)
     mini_portile2 (2.3.0)
-    minitest (5.11.1)
+    minitest (5.11.3)
     mqtt (0.5.0)
     msgpack (1.2.2)
     multi_json (1.13.1)
@@ -203,7 +203,7 @@ GEM
     net-ssh (4.2.0)
     network_interface (0.0.2)
     nexpose (7.2.0)
-    nokogiri (1.8.1)
+    nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
     octokit (4.8.0)
       sawyer (~> 0.8.0, >= 0.5.3)
@@ -214,7 +214,7 @@ GEM
       pcaprub
     patch_finder (1.0.2)
     pcaprub (0.12.4)
-    pdf-reader (2.0.0)
+    pdf-reader (2.1.0)
       Ascii85 (~> 1.0.0)
       afm (~> 0.2.1)
       hashery (~> 2.0)
@@ -229,7 +229,7 @@ GEM
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
-    public_suffix (3.0.1)
+    public_suffix (3.0.2)
     rack (1.6.8)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -320,7 +320,7 @@ GEM
       rspec-support (~> 3.7.0)
     rspec-rerun (1.1.0)
       rspec (~> 3.0)
-    rspec-support (3.7.0)
+    rspec-support (3.7.1)
     ruby-macho (1.1.0)
     ruby-rc4 (0.1.5)
     ruby_smb (0.0.18)
@@ -348,7 +348,7 @@ GEM
     thread_safe (0.3.6)
     timecop (0.9.1)
     ttfunk (1.5.1)
-    tzinfo (1.2.4)
+    tzinfo (1.2.5)
       thread_safe (~> 0.1)
     tzinfo-data (1.2018.3)
       tzinfo (>= 1.0.0)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -127,7 +127,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'mqtt'
   spec.add_runtime_dependency 'net-ssh'
   spec.add_runtime_dependency 'bcrypt_pbkdf'
-  spec.add_runtime_dependency 'ruby_smb'
+  spec.add_runtime_dependency 'ruby_smb', '0.0.18'
 
   #
   # REX Libraries


### PR DESCRIPTION
This is just some prep work for bumping ruby_smb in PR #9365 