### PR TITLE
Support Windows 2008/7 and above

### DIFF
--- a/modules/post/windows/gather/enum_ms_product_keys.rb
+++ b/modules/post/windows/gather/enum_ms_product_keys.rb
@@ -31,6 +31,7 @@ class MetasploitModule < Msf::Post
 
     keys = [
       [ "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion", "DigitalProductId" ],
+      [ "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion", "DigitalProductId4" ],
       [ "HKLM\\SOFTWARE\\Microsoft\\Office\\11.0\\Registration\\{91110409-6000-11D3-8CFE-0150048383C9}", "DigitalProductId" ],
       [ "HKLM\\SOFTWARE\\Microsoft\\Office\\12.0\\Registration\\{91120000-00CA-0000-0000-0000000FF1CE}", "DigitalProductId" ],
       [ "HKLM\\SOFTWARE\\Microsoft\\Office\\12.0\\Registration\\{91120000-0014-0000-0000-0000000FF1CE}", "DigitalProductId" ],


### PR DESCRIPTION
Probably about time that we supported versions less than 10 years old :)

References: 
- https://www.lansweeper.com/Forum/yaf_postsm18159_Keys-not-decryptiong-for-DigitalProductID.aspx#post18159
- https://social.technet.microsoft.com/Forums/office/en-US/8f7718dd-a639-499f-8006-02b378924d14/fetch-windows-product-activation-key-info?forum=ITCG

Before:
```
msf5 post(windows/gather/enum_ms_product_keys) > run

[*] Finding Microsoft key on WIN-2K8MACHINE

Keys
====

 Product                          Registered Owner  Registered Organization  License Key
 -------                          ----------------  -----------------------  -----------
 Windows Server 2008 R2 Standard  Windows User                               BBBBB-BBBBB-BBBBB-BBBBB-BBBBB
```

After:
```
msf5 post(windows/gather/enum_ms_product_keys) > run

[*] Finding Microsoft key on WIN-2K8MACHINE

Keys
====

 Product                          Registered Owner  Registered Organization  License Key
 -------                          ----------------  -----------------------  -----------
 Windows Server 2008 R2 Standard  Windows User                               BBBBB-BBBBB-BBBBB-BBBBB-BBBBB
 Windows Server 2008 R2 Standard  Windows User                               MY-REAL-KEY-HERE
```