### PR TITLE
decouple hosts and targets for tests

### DIFF
--- a/test/modules/auxiliary/scanner/smb/smb_login.json
+++ b/test/modules/auxiliary/scanner/smb/smb_login.json
@@ -11,7 +11,7 @@
 			"TYPE":			"VIRTUAL",
 			"METHOD":		"VM_TOOLS_UPLOAD",
 			"HYPERVISOR_CONFIG":    "../JSON/esxi_config.json",
-			"NAME": 		"APT_MSF_HOST",
+			"CPE":			"cpe:/a:rapid7:metasploit:::",
 			"MSF_ARTIFACT_PATH":	"/home/msfuser/rapid7/test_artifacts",
 			"MSF_PATH":		"/home/msfuser/rapid7/metasploit-framework"
 		}
@@ -22,7 +22,7 @@
 		{
 			"TYPE":			"VIRTUAL",
 			"METHOD":		"EXPLOIT",
-			"NAME": 		"Win2008r2x64sp1",
+			"CPE":			"cpe:/o:microsoft:windows_server_2008:r2:sp1:x64",
 			"MODULES":	
 			[
 				{
@@ -37,7 +37,7 @@
 		{
 			"TYPE":			"VIRTUAL",
 			"METHOD":		"EXPLOIT",
-			"NAME": 		"Win2012x64",
+			"CPE":			"cpe:/o:microsoft:windows_server_2016:::x64",
 			"MODULES":	
 			[
 				{

--- a/test/modules/exploits/windows/smb/ms17_010_eternalblue.json
+++ b/test/modules/exploits/windows/smb/ms17_010_eternalblue.json
@@ -9,7 +9,7 @@
 			"TYPE":			"VIRTUAL",
 			"METHOD":		"VM_TOOLS_UPLOAD",
 			"HYPERVISOR_CONFIG":	"../JSON/esxi_config.json",
-			"NAME": 		"APT_MSF_HOST",
+			"CPE":			"cpe:/a:rapid7:metasploit:::",
 			"MSF_PATH":		"/home/msfuser/rapid7/metasploit-framework",
 			"MSF_ARTIFACT_PATH":	"/home/msfuser/rapid7/test_artifacts"
 		}
@@ -30,7 +30,7 @@
 		{
 			"TYPE":                 "VIRTUAL",
 			"METHOD":		"EXPLOIT",
-			"NAME": 		"Win7x64"
+			"NAME": 		"SATA_Win7x64"
 		}
 	],
         "MODULES":


### PR DESCRIPTION
Update initial example integration tests to use `CPE` and decouple host and target systems from the infrastructure used to build them.

This will also be used to test the new payload sanity check PR builder.

## Verification

List the steps needed to make sure this thing works

- [x] New Automation PR builder passes

