### PR TITLE
treat 'password must change' as a successful login

### DIFF
--- a/lib/metasploit/framework/login_scanner/smb.rb
+++ b/lib/metasploit/framework/login_scanner/smb.rb
@@ -118,14 +118,14 @@ module Metasploit
             end
 
             case status_code.name
-              when *StatusCodes::CORRECT_CREDENTIAL_STATUS_CODES
-                status = Metasploit::Model::Login::Status::DENIED_ACCESS
-              when 'STATUS_SUCCESS', 'STATUS_PASSWORD_MUST_CHANGE'
+              when 'STATUS_SUCCESS', 'STATUS_PASSWORD_MUST_CHANGE', 'STATUS_PASSWORD_EXPIRED'
                 status = Metasploit::Model::Login::Status::SUCCESSFUL
               when 'STATUS_ACCOUNT_LOCKED_OUT'
                 status = Metasploit::Model::Login::Status::LOCKED_OUT
               when 'STATUS_LOGON_FAILURE', 'STATUS_ACCESS_DENIED'
                 status = Metasploit::Model::Login::Status::INCORRECT
+              when *StatusCodes::CORRECT_CREDENTIAL_STATUS_CODES
+                status = Metasploit::Model::Login::Status::DENIED_ACCESS
               else
                 status = Metasploit::Model::Login::Status::INCORRECT
             end

--- a/lib/metasploit/framework/login_scanner/smb.rb
+++ b/lib/metasploit/framework/login_scanner/smb.rb
@@ -120,7 +120,7 @@ module Metasploit
             case status_code.name
               when *StatusCodes::CORRECT_CREDENTIAL_STATUS_CODES
                 status = Metasploit::Model::Login::Status::DENIED_ACCESS
-              when 'STATUS_SUCCESS'
+              when 'STATUS_SUCCESS', 'STATUS_PASSWORD_MUST_CHANGE'
                 status = Metasploit::Model::Login::Status::SUCCESSFUL
               when 'STATUS_ACCOUNT_LOCKED_OUT'
                 status = Metasploit::Model::Login::Status::LOCKED_OUT


### PR DESCRIPTION
We currently treat the SMB status where a password needs to be changed as an unsuccessful login, while this is actually a positive result. Sniped this change from a conversation with @jmartin-r7 and @caleBot (I think) about http://rewtdance.blogspot.com/2012/09/is-your-smb-bruteforcer-lying-to-you.html

## Verification

- [ ] Run the `smb_login` module with credentials that require a change in password
- [ ] **Verify** success and not failure to login
