### PR TITLE
if multi/handler is disabled, exit

### DIFF
--- a/modules/exploits/multi/handler.rb
+++ b/modules/exploits/multi/handler.rb
@@ -52,6 +52,11 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
+    if datastore['DisablePayloadHandler']
+      print_error "DisablePayloadHandler is enabled, so there is nothing to do. Exiting!"
+      return
+    end
+
     stime = Time.now.to_f
     timeout = datastore['ListenerTimeout'].to_i
     loop do


### PR DESCRIPTION
This prevents mult/handler from sitting catatonic if it has been told to actually do nothing at all. This just burned me again, and I know @acompton-r7 has run into this as well.

## Verification

- [x] Start `msfconsole`
- [x] `use multi/handler`
- [x] `set DisablePayloadHandler true`
- [x] **Verify** that if you run the module, it exits like follows instead of hanging:

```
payload => php/meterpreter/reverse_tcp
lhost => 127.0.0.1
[-] DisablePayloadHandler is enabled, so there is nothing to do. Exiting!
```
