### PR TITLE
Add Memcached amplification scanner

### DIFF
--- a/documentation/modules/auxiliary/scanner/memcached/memcached_amp.md
+++ b/documentation/modules/auxiliary/scanner/memcached/memcached_amp.md
@@ -1,0 +1,95 @@
+## Vulnerable Application
+
+Any instance of memcached with the UDP listener enabled will suffice.
+
+Instructions for testing against Ubuntu 16.04, CentOS 7 and a Dockerized endpoint are provided below.
+
+### Ubuntu 16.04
+
+To a desktop or server Ubuntu 16.04 instance, simply install memcached:
+
+```
+apt-get install memcached
+```
+
+Then configure it to listen on something other than the loopback interface:
+
+```
+sed -i 's/-l 127.0.0.1/#-l 127.0.0.1/g' /etc/memcached.conf
+service memcached restart
+```
+
+### CentOS 7
+
+To a CentOS 7 instance, simply install and start memcached, as it listens on 0.0.0.0 by default'
+
+```
+yum -y install memcached
+systemctl start memcached
+```
+
+### Docker Install
+
+In memcached 1.5.5 and earlier, the daemon is vulnerable by default.  As such, we can use the
+community supported memcached container and simply expose it:
+
+```
+docker run -ti --rm -p 11211:11211/udp memcached:1.5.5
+```
+
+## Verification Steps
+
+
+  1. Install the application
+  2. Start msfconsole
+  3. Do: `use auxiliary/scanner/memcached/memcached_amp`
+  4. Do: `set rhosts [IPs]`
+  5. Do: `run`
+  6. Confirm that the endpoint is discovered vulnerable to the memcached amplification vulnerability.
+
+## Scenarios
+
+### Ubuntu 16.04
+
+Configure memcached as described above.
+
+```
+msf5 > use auxiliary/scanner/memcached/memcached_amp
+msf5 auxiliary(scanner/memcached/memcached_amp) > set RHOSTS a.b.c.d
+RHOSTS => a.b.c.d
+msf5 auxiliary(scanner/memcached/memcached_amp) > run
+
+[+] a.b.c.d:11211 - Vulnerable to MEMCACHED amplification: No packet amplification and a 78x, 1163-byte bandwidth amplification
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```
+
+### CentOS 7
+
+Configure memcached as described above.
+
+```
+msf5 > use auxiliary/scanner/memcached/memcached_amp
+msf5 auxiliary(scanner/memcached/memcached_amp) > set RHOSTS a.b.c.d
+RHOSTS => a.b.c.d
+msf5 auxiliary(scanner/memcached/memcached_amp) > run
+
+[+] a.b.c.d:11211 - Vulnerable to MEMCACHED amplification: No packet amplification and a 68x, 1015-byte bandwidth amplification
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```
+
+### Docker
+
+Configure memcached in docker as described above.
+
+```
+msf5 > use auxiliary/scanner/memcached/memcached_amp
+msf5 auxiliary(scanner/memcached/memcached_amp) > set RHOSTS a.b.c.d
+RHOSTS => a.b.c.d
+msf5 auxiliary(scanner/memcached/memcached_amp) > run
+
+[+] a.b.c.d:11211 - Vulnerable to MEMCACHED amplification: 2x packet amplification and a 126x, 1880-byte bandwidth amplification
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```

--- a/modules/auxiliary/scanner/memcached/memcached_amp.rb
+++ b/modules/auxiliary/scanner/memcached/memcached_amp.rb
@@ -1,0 +1,77 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Auxiliary::Report
+  include Msf::Exploit::Capture
+  include Msf::Auxiliary::UDPScanner
+  include Msf::Auxiliary::DRDoS
+
+  def initialize
+    super(
+      'Name'        => 'Memcached Amplification Scanner',
+      'Description' => %q{
+          This module can be used to discover Memcached servers which expose the
+          unrestricted UDP port 11211. A basic "stats" request is executed to check
+          if an amplification attack is possible against a third party.
+      },
+      'Author'      =>
+        [
+          'Marek Majkowski', # Cloudflare blog and base payload
+          'xistence <xistence[at]0x90.nl>' # Metasploit scanner module
+        ],
+      'License'     => MSF_LICENSE,
+      'References'  =>
+          [
+            ['URL', 'https://blog.cloudflare.com/memcrashed-major-amplification-attacks-from-port-11211/']
+          ]
+    )
+
+    register_options( [
+      Opt::RPORT(11211),
+    ])
+  end
+
+  def rport
+    datastore['RPORT']
+  end
+
+  def setup
+    super
+
+    # Memcached stats probe
+    @memcached_probe = "\x00\x00\x00\x00\x00\x01\x00\x00stats\r\n"
+  end
+
+  def scanner_prescan(batch)
+    print_status("Sending Memcached stats probes to #{batch[0]}->#{batch[-1]} (#{batch.length} hosts)")
+    @results = {}
+  end
+
+  def scan_host(ip)
+    if spoofed?
+      datastore['ScannerRecvWindow'] = 0
+      scanner_spoof_send(@memcached_probe, ip, datastore['RPORT'], datastore['SRCIP'], datastore['NUM_REQUESTS'])
+    else
+      scanner_send(@memcached_probe, ip, datastore['RPORT'])
+    end
+  end
+
+  def scanner_process(data, shost, sport)
+
+    # Check the response data for a "STAT" repsonse
+    if data =~/\x00\x00\x00\x00\x00\x01\x00\x00STAT\x20/
+      amp = data.length / @memcached_probe.length.to_f
+      print_good("#{shost}:#{datastore['RPORT']} - Response is #{data.length} bytes [#{amp.round(2)}x Amplification]")
+      report_service(:host => shost, :port => datastore['RPORT'], :proto => 'udp', :name => "memcached")
+      report_vuln(
+        :host => shost,
+        :port => datastore['RPORT'],
+        :proto => 'udp', :name => "MEMCACHED",
+        :info => "MEMCACHED amplification -  #{data.length} bytes [#{amp.round(2)}x Amplification]",
+        :refs => self.references)
+    end
+  end
+end


### PR DESCRIPTION
This module will scan Memcached instances for UDP amplification possibilities using a "stats" request  packet.

All details for reproducing and testing are in the provided documentation.
