### PR TITLE
Fix problem with stale module cache

### DIFF
--- a/lib/msf/core/modules/metadata/cache.rb
+++ b/lib/msf/core/modules/metadata/cache.rb
@@ -107,11 +107,12 @@ class Cache
   #######
 
   def remove_from_cache(module_name)
-    removed = @module_metadata_cache.delete_if {|_, module_metadata|
+    old_cache_size = @module_metadata_cache.size
+    @module_metadata_cache.delete_if {|_, module_metadata|
       module_metadata.ref_name.eql? module_name
     }
 
-    return !removed.empty?
+    return old_cache_size !=  @module_metadata_cache.size
   end
 
   def wait_for_load

--- a/lib/msf/core/modules/metadata/cache.rb
+++ b/lib/msf/core/modules/metadata/cache.rb
@@ -87,7 +87,7 @@ class Cache
 
     @module_metadata_cache.each_value do |module_metadata|
 
-      if !module_metadata.path || !::File.exist?(module_metadata.path)
+      unless module_metadata.path && ::File.exist?(module_metadata.path)
         next
       end
 

--- a/lib/msf/core/modules/metadata/cache.rb
+++ b/lib/msf/core/modules/metadata/cache.rb
@@ -53,7 +53,7 @@ class Cache
         begin
           module_instance = mt[1].create(mn)
         rescue Exception => e
-          elog "Unable to create module: #{mn}"
+          elog "Unable to create module: #{mn}. #{e.message}"
         end
 
         unless module_instance


### PR DESCRIPTION
This fixes problems with stale module cache elements when developers go between incorrectly typed modules

## Verification

- [x] Create an 'Auxilary' module in the auxilary directory
- [x] restart metasploit
- [x] Change the type of the created module to 'Exploit'
- [x] restart metaploit
- [x] **Verify** that only one result is returned when a search for a key specific to the module is done
- [x] Change the type of the created module to 'Auxilary'
- [x] restart metaploit
- [x] **Verify** that only one result is returned when a search for a key specific to the module is done
