### PR TITLE
lock protobuf version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,10 @@ group :development do
     'x86-mingw32', 'x64-mingw32',
     'x86_64-linux', 'x86-linux',
     'darwin'].include?(RUBY_PLATFORM.gsub(/.*darwin.*/, 'darwin'))
+  gem 'google-protobuf', "3.5.1" if [
+    'x86-mingw32', 'x64-mingw32',
+    'x86_64-linux', 'x86-linux',
+    'darwin'].include?(RUBY_PLATFORM.gsub(/.*darwin.*/, 'darwin'))
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,7 +129,7 @@ GEM
       multipart-post (>= 1.2, < 3)
     filesize (0.1.1)
     fivemat (1.3.5)
-    google-protobuf (3.5.1.2)
+    google-protobuf (3.5.1)
     googleapis-common-protos-types (1.0.1)
       google-protobuf (~> 3.0)
     googleauth (0.6.2)


### PR DESCRIPTION
Lock the version for google-protobuf gem due to oddities in latest released gems for dependency checking in omnibus builder.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Start and interact with `metasploit-aggregator`

