### PR TITLE
workaround Y2k38 issues in java certificate generation

### DIFF
--- a/lib/msf/core/payload/android.rb
+++ b/lib/msf/core/payload/android.rb
@@ -78,7 +78,7 @@ module Msf::Payload::Android
     cert.public_key = key.public_key
 
     # Some time within the last 3 years
-    cert.not_before = Time.now - rand(3600*24*365*3)
+    cert.not_before = Time.now - rand(3600 * 24 * 365 * 3)
 
     # From http://developer.android.com/tools/publishing/app-signing.html
     # """
@@ -89,7 +89,14 @@ module Msf::Payload::Android
     # requirement. You cannot upload an application if it is signed
     # with a key whose validity expires before that date.
     # """
-    cert.not_after = cert.not_before + 3600*24*365*20 # 20 years
+    #
+    # 32-bit Ruby (and 64-bit Ruby on Windows) cannot deal with
+    # certificate not_after times later than Jan 1st 2038, since long is 32-bit.
+    # Set not_after to a random time 2~ years before the first bad date.
+    #
+    # FIXME: this will break again in 2031, hopefully all 32-bit systems will
+    # be dead by then...
+    cert.not_after = Time.new("2034/01/01") + rand(3600 * 24 * 365 * 2)
 
     # If this line is left out, signature verification fails on OSX.
     cert.sign(key, OpenSSL::Digest::SHA1.new)

--- a/lib/msf/core/payload/android.rb
+++ b/lib/msf/core/payload/android.rb
@@ -94,9 +94,11 @@ module Msf::Payload::Android
     # certificate not_after times later than Jan 1st 2038, since long is 32-bit.
     # Set not_after to a random time 2~ years before the first bad date.
     #
-    # FIXME: this will break again in 2031, hopefully all 32-bit systems will
-    # be dead by then...
-    cert.not_after = Time.new("2034/01/01") + rand(3600 * 24 * 365 * 2)
+    # FIXME: this will break again randomly starting in late 2033, hopefully
+    # all 32-bit systems will be dead by then...
+    #
+    # The timestamp 0x78045d81 equates to 2033-10-22 00:00:01 UTC
+    cert.not_after = Time.at(0x78045d81 + rand(0x7fffffff - 0x78045d81))
 
     # If this line is left out, signature verification fails on OSX.
     cert.sign(key, OpenSSL::Digest::SHA1.new)

--- a/modules/exploits/multi/browser/java_signed_applet.rb
+++ b/modules/exploits/multi/browser/java_signed_applet.rb
@@ -216,7 +216,8 @@ class MetasploitModule < Msf::Exploit::Remote
       @cert.issuer = x509_name
       @cert.public_key = @key.public_key
       @cert.not_before = Time.now
-      @cert.not_after = @cert.not_before + 3600*24*365*3 # 3 years
+      # FIXME: this will break in the year 2037 on 32-bit systems
+      @cert.not_after = @cert.not_before + 3600 * 24 * 365 # 1 year
     end
   end
 


### PR DESCRIPTION
It appears that 32-bit Ruby 2.3 and all version of Ruby 2.3 on Windows at least (I haven't tested others) do a 'long' conversion when setting the expiration date on an SSL certificate.

Modules and library code that attempt to set a date after Jan 1 2038 will throw an exception and in some cases that exception will prevent msfconsole from starting entirely.

This Fixes #9556 by making the not_after date in a few places a bit more deterministic. It began failing with increasing frequency on Jan 1st 2018.

## Verification

The original problem was random, so verification is by code review and by confirming that msfconsole starts on systems with Ruby 2.3 and 32-bit long.