### PR TITLE
Changeing links to HTTPS

### DIFF
--- a/modules/auxiliary/gather/darkcomet_filedownloader.rb
+++ b/modules/auxiliary/gather/darkcomet_filedownloader.rb
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'     =>
         [
           [ 'URL', 'https://www.nccgroup.trust/globalassets/our-research/us/whitepapers/PEST-CONTROL.pdf' ],
-          [ 'URL', 'http://samvartaka.github.io/exploitation/2016/06/03/dead-rats-exploiting-malware' ]
+          [ 'URL', 'https://samvartaka.github.io/exploitation/2016/06/03/dead-rats-exploiting-malware' ]
         ],
       'DisclosureDate' => 'Oct 08 2012',
       'Platform'       => 'win'

--- a/modules/exploits/windows/misc/poisonivy_21x_bof.rb
+++ b/modules/exploits/windows/misc/poisonivy_21x_bof.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'References'     =>
         [
-          [ 'URL', 'http://samvartaka.github.io/exploitation/2016/06/03/dead-rats-exploiting-malware' ],
+          [ 'URL', 'https://samvartaka.github.io/exploitation/2016/06/03/dead-rats-exploiting-malware' ],
         ],
       'DisclosureDate' => 'Jun 03 2016',
       'DefaultOptions' =>

--- a/modules/exploits/windows/misc/poisonivy_bof.rb
+++ b/modules/exploits/windows/misc/poisonivy_bof.rb
@@ -27,7 +27,7 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           [ 'OSVDB', '83774' ],
           [ 'EDB', '19613' ],
-          [ 'URL', 'https://www.signal11.eu/en/research/articles/targeted_2010.pdf' ],
+          [ 'URL', 'http://www.signal11.eu/en/research/articles/targeted_2010.pdf' ],
           [ 'URL', 'https://samvartaka.github.io/malware/2015/09/07/poison-ivy-reliable-exploitation/' ],
         ],
       'DisclosureDate' => 'Jun 24 2012',

--- a/modules/exploits/windows/misc/poisonivy_bof.rb
+++ b/modules/exploits/windows/misc/poisonivy_bof.rb
@@ -27,8 +27,8 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           [ 'OSVDB', '83774' ],
           [ 'EDB', '19613' ],
-          [ 'URL', 'http://www.signal11.eu/en/research/articles/targeted_2010.pdf' ],
-          [ 'URL', 'http://samvartaka.github.io/malware/2015/09/07/poison-ivy-reliable-exploitation/' ],
+          [ 'URL', 'https://www.signal11.eu/en/research/articles/targeted_2010.pdf' ],
+          [ 'URL', 'https://samvartaka.github.io/malware/2015/09/07/poison-ivy-reliable-exploitation/' ],
         ],
       'DisclosureDate' => 'Jun 24 2012',
       'DefaultOptions' =>


### PR DESCRIPTION
Some of the links in the modules were `HTTP`. Since `HTTPs` is more secure we should use this. 