### PR TITLE
fix SSL certificate provider

### DIFF
--- a/lib/msf/core/cert_provider.rb
+++ b/lib/msf/core/cert_provider.rb
@@ -57,7 +57,7 @@ module Ssl
 
       cert.version    = opts[:version] || 2
       cert.serial     = opts[:serial]  || (rand(0xFFFFFFFF) << 32) + rand(0xFFFFFFFF)
-      cert.subject    = OpenSSL::X509::Name.new([["C", subject]])
+      cert.subject    = OpenSSL::X509::Name.parse(subject)
       cert.issuer     = opts[:ca_cert] || cert.subject
       cert.not_before = vf
       cert.not_after  = vt
@@ -90,7 +90,7 @@ module Ssl
       if ekuse and !ekuse.empty?
         cert.extensions << ef.create_extension("extendedKeyUsage", ekuse)
       end
-  
+
       cert.sign(key, OpenSSL::Digest::SHA256.new)
 
       [key, cert, nil]


### PR DESCRIPTION
Fix SSL certificate generation for msfrpcd

## Observation 

Calling msfrpcd from golang shows that the generated SSL certificate contains invalid caracters. After investigation, this resullts that the generated certificate is not well formated. 

I use [this](https://www.sslchecker.com/certdecoder) SSL certificate decoder to see it.

## Correction 

This is due to the `cert_provider.rb` that does not parse the generated subject. 

## Verification 

- [x] Start `msfrpcd`
- [x] Go to `https://127.0.0.1:55553/api`
- [x] Extract SSL certificate with web browser 
- [x] Put it in the online SSL checker 
- [x] **Verifiy** that it is well formated 