### PR TITLE
Fix #9650, missed code from TelnetEnable refactor

### DIFF
--- a/modules/exploits/linux/telnet/netgear_telnetenable.rb
+++ b/modules/exploits/linux/telnet/netgear_telnetenable.rb
@@ -85,14 +85,16 @@ class MetasploitModule < Msf::Exploit::Remote
     @proto = target[:proto]
     detect_proto if @proto == :auto
 
-    # Use supplied or ARP-cached MAC address
-    configure_mac if @do_exploit
+    if @do_exploit
+      # Use supplied or ARP-cached MAC address
+      configure_mac
+      # Use supplied or default creds
+      configure_creds
+      # Shell it
+      exploit_telnetenabled
+    end
 
-    # Use supplied or default creds
-    configure_creds if @do_exploit
-
-    # Shell it
-    exploit_telnetenabled if @do_exploit
+    # Connect to the shell
     connect_telnetd
   end
 
@@ -134,8 +136,8 @@ class MetasploitModule < Msf::Exploit::Remote
     begin
       open_pcap
       @mac = lookup_eth(rhost).first
-    rescue RuntimeError
-      fail_with(Failure::BadConfig, 'Superuser access required')
+    rescue RuntimeError => e
+      fail_with(Failure::BadConfig, "#{e}. Are you root?")
     ensure
       close_pcap
     end


### PR DESCRIPTION
# I DID THIS PR FOR YOU, JEFFREY

1. Functionality was added incrementally, and I missed an opportunity to consolidate a few methods under `@do_exploit`.
2. The `Capture` mixin can raise `RuntimeError` for a number of different reasons, not just a lack of root privileges.

tl;dr Fix my incompetence and laziness. :-)

I don't think EDB and friends usually get these updates. :(

- [x] Test the thing

For #9650.