### PR TITLE
Fix docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,7 @@
 docker-compose*.yml
 docker/
 !docker/msfconsole.rc
+!docker/entrypoint.sh
 README.md
 .git/
 .github/


### PR DESCRIPTION
Fix docker build 

## Observation 

`docker run -ti --rm --network=host metasploitframework/metasploit-framework`

results in : 

```docker: Error response from daemon: OCI runtime create failed: container_linux.go:296: starting container process caused "exec: \"docker/entrypoint.sh\": stat docker/entrypoint.sh: no such file or directory": unknown.```

This is due to the .dockerignore file that ignore the `docker` directory except the `msfconsole.rc`(forgetting to except `entrypoint.sh`)

## Verification

- [ ] Start `docker build -t msf .`
- [ ] Start `docker run -ti --rm --network=host msf`
- [ ]  **Verify** that msfconsole is starting and behaving as expected

