### PR TITLE
Tying together goliath server and client

### DIFF
--- a/lib/msf/base/sessions/meterpreter.rb
+++ b/lib/msf/base/sessions/meterpreter.rb
@@ -501,14 +501,17 @@ class Meterpreter < Rex::Post::Meterpreter::Client
             end
           end
 
+          sysinfo = sys.config.sysinfo
+          host = Msf::Util::Host.normalize_host(self)
+
           framework.db.report_note({
             :type => "host.os.session_fingerprint",
-            :host => self,
+            :host => host,
             :workspace => wspace,
             :data => {
-              :name => sys.config.sysinfo["Computer"],
-              :os => sys.config.sysinfo["OS"],
-              :arch => sys.config.sysinfo["Architecture"],
+              :name => sysinfo["Computer"],
+              :os => sysinfo["OS"],
+              :arch => sysinfo["Architecture"],
             }
           })
 

--- a/lib/msf/core/auxiliary/report.rb
+++ b/lib/msf/core/auxiliary/report.rb
@@ -31,7 +31,8 @@ module Auxiliary::Report
 
   def create_credential(opts={})
     if active_db?
-      super(opts)
+      framework.db.create_credential(opts)
+      #super(opts)
     elsif !db_warning_given?
       vprint_warning('No active DB -- Credential data will not be saved!')
     end
@@ -389,7 +390,7 @@ module Auxiliary::Report
       ext = "txt"
     end
     # This method is available even if there is no database, don't bother checking
-    host = framework.db.normalize_host(host)
+    host = Msf::Util::Host.normalize_host(host)
 
     ws = (db ? myworkspace.name[0,16] : 'default')
     name =
@@ -416,6 +417,7 @@ module Auxiliary::Report
       conf[:workspace] = myworkspace
       conf[:name] = filename if filename
       conf[:info] = info if info
+      conf[:data] = data if data
 
       if service and service.kind_of?(::Mdm::Service)
         conf[:service] = service if service

--- a/lib/msf/core/db_manager.rb
+++ b/lib/msf/core/db_manager.rb
@@ -9,7 +9,6 @@ require 'rex/socket'
 #
 # Project
 #
-
 require 'metasploit/framework/require'
 require 'msf/base/config'
 require 'msf/core'
@@ -17,6 +16,8 @@ require 'msf/core/database_event'
 require 'msf/core/db_import_error'
 require 'msf/core/host_state'
 require 'msf/core/service_state'
+require 'metasploit/framework/data_service'
+
 
 # The db module provides persistent storage and events. This class should be instantiated LAST
 # as the active_suppport library overrides Kernel.require, slowing down all future code loads.
@@ -60,6 +61,9 @@ class Msf::DBManager
 
   optionally_include_metasploit_credential_creation
 
+  # Interface must be included first
+  include Metasploit::Framework::DataService
+
   include Msf::DBManager::Adapter
   include Msf::DBManager::Client
   include Msf::DBManager::Connection
@@ -93,6 +97,10 @@ class Msf::DBManager
   # Provides :framework and other accessors
   include Msf::Framework::Offspring
 
+  def name
+    'local_db_service'
+  end
+
   #
   # Attributes
   #
@@ -122,7 +130,7 @@ class Msf::DBManager
       return
     end
 
-    initialize_database_support
+    return initialize_database_support
   end
 
   #
@@ -162,5 +170,62 @@ class Msf::DBManager
     initialize_adapter
 
     true
+  end
+
+  def init_db(opts)
+
+    init_success = false
+
+    # Append any migration paths necessary to bring the database online
+    if opts['DatabaseMigrationPaths']
+      opts['DatabaseMigrationPaths'].each do |migrations_path|
+        ActiveRecord::Migrator.migrations_paths << migrations_path
+      end
+    end
+
+    if connection_established?
+      after_establish_connection
+    else
+      configuration_pathname = Metasploit::Framework::Database.configurations_pathname(path: opts['DatabaseYAML'])
+
+      unless configuration_pathname.nil?
+        if configuration_pathname.readable?
+          dbinfo = YAML.load_file(configuration_pathname) || {}
+          dbenv  = opts['DatabaseEnv'] || Rails.env
+          db     = dbinfo[dbenv]
+        else
+          elog("Warning, #{configuration_pathname} is not readable. Try running as root or chmod.")
+        end
+
+        if not db
+          elog("No database definition for environment #{dbenv}")
+        else
+          init_success = connect(db)
+        end
+      end
+    end
+
+    # framework.db.active will be true if after_establish_connection ran directly when connection_established? was
+    # already true or if framework.db.connect called after_establish_connection.
+    if !! error
+      if error.to_s =~ /RubyGem version.*pg.*0\.11/i
+        elog("***")
+        elog("*")
+        elog("* Metasploit now requires version 0.11 or higher of the 'pg' gem for database support")
+        elog("* There a three ways to accomplish this upgrade:")
+        elog("* 1. If you run Metasploit with your system ruby, simply upgrade the gem:")
+        elog("*    $ rvmsudo gem install pg ")
+        elog("* 2. Use the Community Edition web interface to apply a Software Update")
+        elog("* 3. Uninstall, download the latest version, and reinstall Metasploit")
+        elog("*")
+        elog("***")
+        elog("")
+        elog("")
+      end
+
+      elog("Failed to connect to the database: #{error}")
+    end
+
+    return init_success
   end
 end

--- a/lib/msf/core/db_manager/connection.rb
+++ b/lib/msf/core/db_manager/connection.rb
@@ -18,7 +18,7 @@ module Msf::DBManager::Connection
       migrate
 
       # Set the default workspace
-      framework.db.workspace = framework.db.default_workspace
+      self.workspace = self.default_workspace
     rescue ::Exception => exception
       self.error = exception
       elog("DB.connect threw an exception: #{exception}")

--- a/lib/msf/core/db_manager/event.rb
+++ b/lib/msf/core/db_manager/event.rb
@@ -8,7 +8,7 @@ module Msf::DBManager::Event
   def report_event(opts = {})
     return if not active
   ::ActiveRecord::Base.connection_pool.with_connection {
-    wspace = opts.delete(:workspace) || workspace
+    wspace = get_workspace(opts)
     return if not wspace # Temp fix?
     uname  = opts.delete(:username)
 

--- a/lib/msf/core/db_manager/host.rb
+++ b/lib/msf/core/db_manager/host.rb
@@ -1,4 +1,5 @@
 module Msf::DBManager::Host
+  # TODO: doesn't appear to have any callers. How is this used?
   # Deletes a host and associated data matching this address/comm
   def del_host(wspace, address, comm='')
   ::ActiveRecord::Base.connection_pool.with_connection {
@@ -6,6 +7,29 @@ module Msf::DBManager::Host
     host = wspace.hosts.find_by_address_and_comm(address, comm)
     host.destroy if host
   }
+  end
+
+  # Deletes Host entries based on the IDs passed in.
+  #
+  # @param opts[:ids] [Array] Array containing Integers corresponding to the IDs of the Loot entries to delete.
+  # @return [Array] Array containing the Mdm::Loot objects that were successfully deleted.
+  def delete_host(opts)
+    raise ArgumentError.new("The following options are required: :ids") if opts[:ids].nil?
+
+    ::ActiveRecord::Base.connection_pool.with_connection {
+      deleted = []
+      opts[:ids].each do |host_id|
+        host = Mdm::Host.find(host_id)
+        begin
+          deleted << host.destroy
+        rescue # refs suck
+          elog("Forcibly deleting #{host.address}")
+          deleted << host.delete
+        end
+      end
+
+      return deleted
+    }
   end
 
   #
@@ -22,7 +46,58 @@ module Msf::DBManager::Host
 
   # Exactly like report_host but waits for the database to create a host and returns it.
   def find_or_create_host(opts)
+    host = get_host(opts.clone)
+    return host unless host.nil?
+
     report_host(opts)
+  end
+
+  def add_host_tag(opts)
+    workspace = opts[:workspace]
+    if workspace.kind_of? String
+      workspace = find_workspace(workspace)
+    end
+
+    ip = opts[:ip]
+    tag_name = opts[:tag_name]
+
+    host = framework.db.get_host(:workspace => workspace, :address => ip)
+    if host
+      possible_tags = Mdm::Tag.joins(:hosts).where("hosts.workspace_id = ? and hosts.address = ? and tags.name = ?", workspace.id, ip, tag_name).order("tags.id DESC").limit(1)
+      tag = (possible_tags.blank? ? Mdm::Tag.new : possible_tags.first)
+      tag.name = tag_name
+      tag.hosts = [host]
+      tag.save! if tag.changed?
+    end
+  end
+
+  def delete_host_tag(opts)
+    workspace = opts[:workspace]
+    if workspace.kind_of? String
+      workspace = find_workspace(workspace)
+    end
+
+    ip = opts[:rws]
+    tag_name = opts[:tag_name]
+
+    tag_ids = []
+    if ip.nil?
+      found_tags = Mdm::Tag.joins(:hosts).where("hosts.workspace_id = ? and tags.name = ?", workspace.id, tag_name)
+      found_tags.each do |t|
+        tag_ids << t.id
+      end
+    else
+      found_tags = Mdm::Tag.joins(:hosts).where("hosts.workspace_id = ? and hosts.address = ? and tags.name = ?", workspace.id, ip, tag_name)
+      found_tags.each do |t|
+        tag_ids << t.id
+      end
+    end
+
+    tag_ids.each do |id|
+      tag = Mdm::Tag.find_by_id(id)
+      tag.hosts.delete
+      tag.destroy
+    end
   end
 
   #
@@ -43,7 +118,7 @@ module Msf::DBManager::Host
       wspace = find_workspace(wspace)
     end
 
-    address = normalize_host(address)
+    address = Msf::Util::Host.normalize_host(address)
     return wspace.hosts.find_by_address(address)
   }
   end
@@ -57,67 +132,28 @@ module Msf::DBManager::Host
   end
 
   # Returns a list of all hosts in the database
-  def hosts(wspace = workspace, only_up = false, addresses = nil)
-  ::ActiveRecord::Base.connection_pool.with_connection {
-    conditions = {}
-    conditions[:state] = [Msf::HostState::Alive, Msf::HostState::Unknown] if only_up
-    conditions[:address] = addresses if addresses
-    wspace.hosts.where(conditions).order(:address)
-  }
-  end
+  def hosts(opts)
+    wspace = opts[:workspace] || opts[:wspace] || workspace
+    if wspace.kind_of? String
+      wspace = find_workspace(wspace)
+    end
 
-  #
-  # Returns something suitable for the +:host+ parameter to the various report_* methods
-  #
-  # Takes a Host object, a Session object, an Msf::Session object or a String
-  # address
-  #
-  def normalize_host(host)
-    return host if defined?(::Mdm) && host.kind_of?(::Mdm::Host)
-    norm_host = nil
+    ::ActiveRecord::Base.connection_pool.with_connection {
 
-    if (host.kind_of? String)
+      conditions = {}
+      conditions[:state] = [Msf::HostState::Alive, Msf::HostState::Unknown] if opts[:non_dead]
+      conditions[:address] = opts[:address] if opts[:address] && !opts[:address].empty?
+      conditions[:id] = opts[:id] if opts[:id] && !opts[:id].empty?
 
-      if Rex::Socket.is_ipv4?(host)
-        # If it's an IPv4 addr with a port on the end, strip the port
-        if host =~ /((\d{1,3}\.){3}\d{1,3}):\d+/
-          norm_host = $1
-        else
-          norm_host = host
-        end
-      elsif Rex::Socket.is_ipv6?(host)
-        # If it's an IPv6 addr, drop the scope
-        address, scope = host.split('%', 2)
-        norm_host = address
+      if opts[:search_term] && !opts[:search_term].empty?
+        column_search_conditions = Msf::Util::DBManager.create_all_column_search_conditions(Mdm::Host, opts[:search_term])
+        tag_conditions = Arel::Nodes::Regexp.new(Mdm::Tag.arel_table[:name], Arel::Nodes.build_quoted("(?mi)#{opts[:search_term]}"))
+        search_conditions = column_search_conditions.or(tag_conditions)
+        wspace.hosts.where(conditions).where(search_conditions).includes(:tags).references(:tags).order(:address)
       else
-        norm_host = Rex::Socket.getaddress(host, true)
+        wspace.hosts.where(conditions).order(:address)
       end
-    elsif defined?(::Mdm) && host.kind_of?(::Mdm::Session)
-      norm_host = host.host
-    elsif host.respond_to?(:session_host)
-      # Then it's an Msf::Session object
-      norm_host = host.session_host
-    end
-
-    # If we got here and don't have a norm_host yet, it could be a
-    # Msf::Session object with an empty or nil tunnel_host and tunnel_peer;
-    # see if it has a socket and use its peerhost if so.
-    if (
-        norm_host.nil? &&
-        host.respond_to?(:sock) &&
-        host.sock.respond_to?(:peerhost) &&
-        host.sock.peerhost.to_s.length > 0
-      )
-      norm_host = session.sock.peerhost
-    end
-    # If We got here and still don't have a real host, there's nothing left
-    # to try, just log it and return what we were given
-    if !norm_host
-      dlog("Host could not be normalized: #{host.inspect}")
-      norm_host = host
-    end
-
-    norm_host
+    }
   end
 
   def host_state_changed(host, ostate)
@@ -165,7 +201,7 @@ module Msf::DBManager::Host
     ret = { }
 
     if !addr.kind_of? ::Mdm::Host
-      addr = normalize_host(addr)
+      addr = Msf::Util::Host.normalize_host(addr)
 
       unless ipv46_validator(addr)
         raise ::ArgumentError, "Invalid IP address in report_host(): #{addr}"
@@ -243,6 +279,20 @@ module Msf::DBManager::Host
   }
   end
 
+  def update_host(opts)
+    # process workspace string for update if included in opts
+    wspace = opts.delete(:workspace)
+    if wspace.kind_of? String
+      wspace = find_workspace(wspace)
+      opts[:workspace] = wspace
+    end
+
+    ::ActiveRecord::Base.connection_pool.with_connection {
+      id = opts.delete(:id)
+      Mdm::Host.update(id, opts)
+    }
+  end
+
   def split_windows_os_name(os_name)
     return [] if os_name.nil?
     flavor_match = os_name.match(/Windows\s+(.*)/)
@@ -282,7 +332,7 @@ module Msf::DBManager::Host
     end
 
     if !addr.kind_of? ::Mdm::Host
-      addr = normalize_host(addr)
+      addr = Msf::Util::Host.normalize_host(addr)
       addr, scope = addr.split('%', 2)
       opts[:scope] = scope if scope
 

--- a/lib/msf/core/db_manager/loot.rb
+++ b/lib/msf/core/db_manager/loot.rb
@@ -24,16 +24,28 @@ module Msf::DBManager::Loot
   #
   # This methods returns a list of all loot in the database
   #
-  def loots(wspace=workspace)
-  ::ActiveRecord::Base.connection_pool.with_connection {
-    wspace.loots
-  }
+  def loots(opts)
+    wspace = opts.delete(:workspace) || opts.delete(:wspace) || workspace
+    if wspace.kind_of? String
+      wspace = find_workspace(wspace)
+    end
+    opts[:workspace_id] = wspace.id
+
+    ::ActiveRecord::Base.connection_pool.with_connection {
+      search_term = opts.delete(:search_term)
+      column_search_conditions = Msf::Util::DBManager.create_all_column_search_conditions(Mdm::Loot, search_term)
+      Mdm::Loot.includes(:host).where(opts).where(column_search_conditions)
+    }
   end
+  alias_method :loot, :loots
 
   def report_loot(opts)
     return if not active
   ::ActiveRecord::Base.connection_pool.with_connection {
     wspace = opts.delete(:workspace) || workspace
+    if wspace.kind_of? String
+      wspace = find_workspace(wspace)
+    end
     path = opts.delete(:path) || (raise RuntimeError, "A loot :path is required")
 
     host = nil
@@ -45,7 +57,7 @@ module Msf::DBManager::Loot
         host = opts[:host]
       else
         host = report_host({:workspace => wspace, :host => opts[:host]})
-        addr = normalize_host(opts[:host])
+        addr = Msf::Util::Host.normalize_host(opts[:host])
       end
     end
 
@@ -77,5 +89,46 @@ module Msf::DBManager::Loot
 
     ret[:loot] = loot
   }
+  end
+
+  # Update the attributes of a Loot entry with the values in opts.
+  # The values in opts should match the attributes to update.
+  #
+  # @param opts [Hash] Hash containing the updated values. Key should match the attribute to update. Must contain :id of record to update.
+  # @return [Mdm::Loot] The updated Mdm::Loot object.
+  def update_loot(opts)
+    wspace = opts.delete(:workspace)
+    if wspace.kind_of? String
+      wspace = find_workspace(wspace)
+      opts[:workspace] = wspace
+    end
+
+    ::ActiveRecord::Base.connection_pool.with_connection {
+      id = opts.delete(:id)
+      Mdm::Loot.update(id, opts)
+    }
+  end
+
+  # Deletes Loot entries based on the IDs passed in.
+  #
+  # @param opts[:ids] [Array] Array containing Integers corresponding to the IDs of the Loot entries to delete.
+  # @return [Array] Array containing the Mdm::Loot objects that were successfully deleted.
+  def delete_loot(opts)
+    raise ArgumentError.new("The following options are required: :ids") if opts[:ids].nil?
+
+    ::ActiveRecord::Base.connection_pool.with_connection {
+      deleted = []
+      opts[:ids].each do |loot_id|
+        loot = Mdm::Loot.find(loot_id)
+        begin
+          deleted << loot.destroy
+        rescue # refs suck
+          elog("Forcibly deleting #{loot}")
+          deleted << loot.delete
+        end
+      end
+
+      return deleted
+    }
   end
 end

--- a/lib/msf/core/db_manager/note.rb
+++ b/lib/msf/core/db_manager/note.rb
@@ -68,7 +68,7 @@ module Msf::DBManager::Note
       if opts[:host].kind_of? ::Mdm::Host
         host = opts[:host]
       else
-        addr = normalize_host(opts[:host])
+        addr = Msf::Util::Host.normalize_host(opts[:host])
         host = report_host({:workspace => wspace, :host => addr})
       end
       # Do the same for a service if that's also included.

--- a/lib/msf/core/db_manager/session.rb
+++ b/lib/msf/core/db_manager/session.rb
@@ -1,4 +1,13 @@
 module Msf::DBManager::Session
+
+  def get_all_sessions()
+    return if not active
+    ::ActiveRecord::Base.connection_pool.with_connection {
+      ::Mdm::Session.all
+    }
+  end
+
+
   # Returns a session based on opened_time, host address, and workspace
   # (or returns nil)
   def get_session(opts)
@@ -41,7 +50,7 @@ module Msf::DBManager::Session
   #     created, but the Mdm::Host will have been.   (There is no transaction
   #       to rollback the Mdm::Host creation.)
   #   @see #find_or_create_host
-  #   @see #normalize_host
+  #   @see #Msf::Util::Host.normalize_host
   #   @see #report_exploit_success
   #   @see #report_vuln
   #
@@ -101,7 +110,74 @@ module Msf::DBManager::Session
   }
   end
 
+  def report_session_host_dto(host_dto)
+    host_dto[:host] = get_host(host_dto)
+    create_mdm_session_from_host(host_dto)
+  end
+
+  def report_session_dto(session_dto)
+    return if not active
+
+    ::ActiveRecord::Base.connection_pool.with_connection {
+      workspace = find_workspace(session_dto[:workspace])
+      host_data = session_dto[:host_data]
+      h_opts = {}
+      h_opts[:host]      = host_data[:host]
+      h_opts[:arch]      = host_data[:arch]
+      h_opts[:workspace] = workspace
+      host = find_or_create_host(h_opts)
+
+      session_data = session_dto[:session_data]
+      sess_data = {
+          datastore: session_data[:datastore],
+          desc: session_data[:desc],
+          host_id: host.id,
+          last_seen: session_dto[:time_stamp],
+          local_id: session_data[:local_id],
+          opened_at: session_dto[:time_stamp],
+          platform: session_data[:platform],
+          port: session_data[:port],
+          routes: [],
+          stype: session_data[:stype],
+          via_exploit: session_data[:via_exploit],
+          via_payload: session_data[:via_payload],
+      }
+
+      if sess_data[:via_exploit] == 'exploit/multi/handler' and sess_data[:datastore] and sess_data[:datastore]['ParentModule']
+        sess_data[:via_exploit] = sess_data[:datastore]['ParentModule']
+      end
+
+      session_db_record = ::Mdm::Session.create!(sess_data)
+
+      # TODO: Figure out task stuff
+
+
+      if sess_data[:via_exploit]
+        # This is a live session, we know the host is vulnerable to something.
+        infer_vuln_from_session_dto(session_dto, session_db_record, workspace)
+      end
+      session_db_record
+    }
+  end
+
+  # Clean out any stale sessions that have been orphaned by a dead framework instance.
+  # @param last_seen_interval [Integer] interval, in seconds, open sessions are marked as alive
+  def remove_stale_sessions(last_seen_interval)
+    return unless active
+
+    ::ActiveRecord::Base.connection_pool.with_connection {
+      ::Mdm::Session.where(closed_at: nil).each do |db_session|
+        next unless db_session.last_seen.nil? or ((Time.now.utc - db_session.last_seen) > (2 * last_seen_interval))
+        db_session.closed_at    = db_session.last_seen || Time.now.utc
+        db_session.close_reason = "Orphaned"
+        db_session.save
+      end
+    }
+  end
+
+  #########
   protected
+  #########
 
   # @param session [Msf::Session] A session with a db_record Msf::Session#db_record
   # @param wspace [Mdm::Workspace]
@@ -117,10 +193,17 @@ module Msf::DBManager::Session
         mod_fullname = session.via_exploit
       end
       mod_detail = ::Mdm::Module::Detail.find_by_fullname(mod_fullname)
+
+      # temp fix: mod_detail.refs will throw exception if mod_detail.nil?
+      vuln_refs = []
       if mod_detail.nil?
         # Then the cache isn't built yet, take the hit for instantiating the
         # module
         mod_detail = framework.modules.create(mod_fullname)
+        refs = []
+      else
+        vuln_refs = mod_detail.refs.map(&:name)
+        refs = mod_detail.refs
       end
       mod_name = mod_detail.name
 
@@ -129,7 +212,7 @@ module Msf::DBManager::Session
         host: host,
         info: "Exploited by #{mod_fullname} to create Session #{s.id}",
         name: mod_name,
-        refs: mod_detail.refs.map(&:name),
+        refs: vuln_refs,
         workspace: wspace,
       }
 
@@ -143,7 +226,7 @@ module Msf::DBManager::Session
       attempt_info = {
         host: host,
         module: mod_fullname,
-        refs: mod_detail.refs,
+        refs: refs,
         service: service,
         session_id: s.id,
         timestamp: Time.now.utc,
@@ -166,7 +249,7 @@ module Msf::DBManager::Session
 
       wspace = opts[:workspace] || find_workspace(session.workspace)
       h_opts = { }
-      h_opts[:host]      = normalize_host(session)
+      h_opts[:host]      = Msf::Util::Host.normalize_host(session)
       h_opts[:arch]      = session.arch if session.respond_to?(:arch) and session.arch
       h_opts[:workspace] = wspace
       host = find_or_create_host(h_opts)
@@ -230,4 +313,63 @@ module Msf::DBManager::Session
     }
   end
 
+  def infer_vuln_from_session_dto(session_dto, session_db_record, workspace)
+    ::ActiveRecord::Base.connection_pool.with_connection {
+
+      vuln_info_dto = session_dto[:vuln_info]
+      host = session_db_record.host
+      mod_detail = ::Mdm::Module::Detail.find_by_fullname(vuln_info_dto[:mod_name])
+
+      # temp fix: mod_detail.refs will throw exception if mod_detail.nil?
+      vuln_refs = []
+      if mod_detail.nil?
+        # Then the cache isn't built yet, take the hit for instantiating the
+        # module
+        mod_detail = framework.modules.create(vuln_info_dto[:mod_name])
+      else
+        vuln_refs = mod_detail.refs.map(&:name)
+      end
+
+      if (mod_detail.nil?)
+        mod_name = 'unknown'
+        refs = []
+      else
+        mod_name = mod_detail.name
+        refs = mod_detail.refs
+      end
+
+      vuln_info = {
+          exploited_at: session_dto[:time_stamp],
+          host: host,
+          info: "Exploited by #{vuln_info_dto[:mod_name]} to create Session #{session_db_record.id}",
+          name: mod_name,
+          refs: vuln_refs,
+          workspace: workspace,
+      }
+
+      port    = vuln_info_dto[:remote_port]
+      service = (port ? host.services.find_by_port(port.to_i) : nil)
+
+      vuln_info[:service] = service if service
+
+      vuln = framework.db.report_vuln(vuln_info)
+
+      attempt_info = {
+          host: host,
+          module: vuln_info_dto[:mod_name],
+          refs: refs,
+          service: service,
+          session_id: session_db_record.id,
+          timestamp: session_dto[:time_stamp],
+          username: vuln_info_dto[:username],
+          vuln: vuln,
+          workspace: workspace,
+          run_id: vuln_info_dto[:run_id]
+      }
+
+      framework.db.report_exploit_success(attempt_info)
+
+      vuln
+    }
+  end
 end

--- a/lib/msf/core/db_manager/session_event.rb
+++ b/lib/msf/core/db_manager/session_event.rb
@@ -1,4 +1,17 @@
 module Msf::DBManager::SessionEvent
+
+  def session_events(opts)
+    wspace = opts[:workspace] || opts[:wspace] || workspace
+    if wspace.kind_of? String
+      wspace = find_workspace(wspace)
+    end
+
+    ::ActiveRecord::Base.connection_pool.with_connection {
+      conditions = {}
+
+      Mdm::SessionEvent.all
+    }
+  end
   #
   # Record a session event in the database
   #

--- a/lib/msf/core/db_manager/vuln.rb
+++ b/lib/msf/core/db_manager/vuln.rb
@@ -105,6 +105,8 @@ module Msf::DBManager::Vuln
       opts[:refs].each do |r|
         if (r.respond_to?(:ctx_id)) and (r.respond_to?(:ctx_val))
           r = "#{r.ctx_id}-#{r.ctx_val}"
+        elsif (r.is_a?(Hash) and r[:ctx_id] and r[:ctx_val])
+          r = "#{r[:ctx_id]}-#{r[:ctx_val]}"
         end
         rids << find_or_create_ref(:name => r)
       end
@@ -116,7 +118,7 @@ module Msf::DBManager::Vuln
       host = opts[:host]
     else
       host = report_host({:workspace => wspace, :host => opts[:host]})
-      addr = normalize_host(opts[:host])
+      addr = Msf::Util::Host.normalize_host(opts[:host])
     end
 
     ret = {}

--- a/lib/msf/core/db_manager/workspace.rb
+++ b/lib/msf/core/db_manager/workspace.rb
@@ -33,4 +33,90 @@ module Msf::DBManager::Workspace
     ::Mdm::Workspace.order('updated_at asc').load
   }
   end
+
+  #
+  # Returns an array of all the associated workspace records counts.
+  #
+  def workspace_associations_counts()
+    results = Array.new()
+
+    ::ActiveRecord::Base.connection_pool.with_connection {
+      workspaces.each do |ws|
+        results << {
+            :name  => ws.name,
+            :hosts_count => ws.hosts.count,
+            :services_count => ws.services.count,
+            :vulns_count => ws.vulns.count,
+            :creds_count => ws.core_credentials.count,
+            :loots_count => ws.loots.count,
+            :notes_count => ws.notes.count
+        }
+      end
+    }
+
+    return results
+  end
+
+  def delete_all_workspaces()
+    return delete_workspaces(workspaces.map(&:name))
+  end
+
+  def delete_workspaces(names)
+    status_msg = []
+    error_msg = []
+
+    switched = false
+    # Delete workspaces
+    names.each do |name|
+      workspace = framework.db.find_workspace(name)
+      if workspace.nil?
+        error << "Workspace not found: #{name}"
+      elsif workspace.default?
+        workspace.destroy
+        workspace = framework.db.add_workspace(name)
+        status_msg << 'Deleted and recreated the default workspace'
+      else
+        # switch to the default workspace if we're about to delete the current one
+        if framework.db.workspace.name == workspace.name
+          framework.db.workspace = framework.db.default_workspace
+          switched = true
+        end
+        # now destroy the named workspace
+        workspace.destroy
+        status_msg << "Deleted workspace: #{name}"
+      end
+    end
+    (status_msg << "Switched workspace: #{framework.db.workspace.name}") if switched
+    return status_msg, error_msg
+  end
+
+  #
+  # Renames a workspace
+  #
+  def rename_workspace(from_name, to_name)
+    raise "Workspace exists: #{to_name}" if framework.db.find_workspace(to_name)
+
+    workspace = find_workspace(from_name)
+    raise "Workspace not found: #{name}" if workspace.nil?
+
+    workspace.name = new
+    workspace.save!
+
+    # Recreate the default workspace to avoid errors
+    if workspace.default?
+      framework.db.add_workspace(from_name)
+      #print_status("Recreated default workspace after rename")
+    end
+
+    # Switch to new workspace if old name was active
+    if (@workspace_name == workspace.name)
+      framework.db.workspace = workspace
+      #print_status("Switched workspace: #{framework.db.workspace.name}")
+    end
+  end
+
+  def get_workspace(opts)
+    workspace = opts.delete(:wspace) || opts.delete(:workspace) || workspace
+    find_workspace(workspace) if (workspace.is_a?(String))
+  end
 end

--- a/lib/msf/core/session_manager.rb
+++ b/lib/msf/core/session_manager.rb
@@ -20,7 +20,7 @@ class SessionManager < Hash
 
   include Framework::Offspring
 
-  LAST_SEEN_INTERVAL  = 60 * 2.5
+  LAST_SEEN_INTERVAL = 60 * 2.5
   SCHEDULER_THREAD_COUNT = 5
 
   def initialize(framework)
@@ -99,6 +99,11 @@ class SessionManager < Hash
         end
 
         #
+        # Skip the database cleanup code below if there is no database
+        #
+        next unless framework.db && framework.db.active && framework.db.is_local?
+
+        #
         # Mark all open session as alive every LAST_SEEN_INTERVAL
         #
         if (Time.now.utc - last_seen_timer) >= LAST_SEEN_INTERVAL
@@ -107,40 +112,26 @@ class SessionManager < Hash
           # processing time for large session lists from skewing our update interval.
 
           last_seen_timer = Time.now.utc
-          if framework.db.active
-            ::ActiveRecord::Base.connection_pool.with_connection do
-              values.each do |s|
-                # Update the database entry on a regular basis, marking alive threads
-                # as recently seen.  This notifies other framework instances that this
-                # session is being maintained.
-                if s.db_record
-                  s.db_record.last_seen = Time.now.utc
-                  s.db_record.save
-                end
+
+          ::ActiveRecord::Base.connection_pool.with_connection do
+            values.each do |s|
+              # Update the database entry on a regular basis, marking alive threads
+              # as recently seen.  This notifies other framework instances that this
+              # session is being maintained.
+              if s.db_record
+                s.db_record.last_seen = Time.now.utc
+                s.db_record.save
               end
             end
           end
         end
 
-
-        #
-        # Skip the database cleanup code below if there is no database
-        #
-        next if not (framework.db and framework.db.active)
-
         #
         # Clean out any stale sessions that have been orphaned by a dead
         # framework instance.
         #
-        ::ActiveRecord::Base.connection_pool.with_connection do |conn|
-          ::Mdm::Session.where(closed_at: nil).each do |db_session|
-            if db_session.last_seen.nil? or ((Time.now.utc - db_session.last_seen) > (2*LAST_SEEN_INTERVAL))
-              db_session.closed_at    = db_session.last_seen || Time.now.utc
-              db_session.close_reason = "Orphaned"
-              db_session.save
-            end
-          end
-        end
+        framework.db.remove_stale_sessions(LAST_SEEN_INTERVAL)
+
       end
 
       #

--- a/lib/msf/core/thread_manager.rb
+++ b/lib/msf/core/thread_manager.rb
@@ -108,7 +108,7 @@ class ThreadManager < Array
           elog("Call Stack\n#{e.backtrace.join("\n")}")
           raise e
         ensure
-          if framework.db and framework.db.active
+          if framework.db && framework.db.active && framework.db.is_local?
             # NOTE: despite the Deprecation Warning's advice, this should *NOT*
             # be ActiveRecord::Base.connection.close which causes unrelated
             # threads to raise ActiveRecord::StatementInvalid exceptions at

--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -1,8 +1,11 @@
 # -*- coding: binary -*-
 
+require 'json'
 require 'rexml/document'
 require 'rex/parser/nmap_xml'
 require 'msf/core/db_export'
+require 'metasploit/framework/data_service'
+require 'metasploit/framework/data_service/remote/http/core'
 
 module Msf
 module Ui
@@ -15,7 +18,7 @@ class Db
 
   include Msf::Ui::Console::CommandDispatcher
   include Msf::Ui::Console::CommandDispatcher::Common
- 
+
   #
   # The dispatcher's name.
   #
@@ -43,7 +46,8 @@ class Db
       "db_import"     => "Import a scan result file (filetype will be auto-detected)",
       "db_export"     => "Export a file containing the contents of the database",
       "db_nmap"       => "Executes nmap and records the output automatically",
-      "db_rebuild_cache" => "Rebuilds the database-stored module cache"
+      "db_rebuild_cache" => "Rebuilds the database-stored module cache",
+      "data_services" => "Command to add, list and set a data service",
     }
 
     # Always include commands that only make sense when connected.
@@ -78,6 +82,25 @@ class Db
     true
   end
 
+  def cmd_data_services(*args)
+    while (arg = args.shift)
+      case arg
+        when '-h', '--help'
+          data_service_help
+          return
+        when '-a', '--add'
+          add_data_service(*args)
+          return
+        when '-s', '--set'
+          set_data_service(args.shift)
+          return
+      end
+    end
+
+    list_data_services
+  end
+
+
   def cmd_workspace_help
     print_line "Usage:"
     print_line "    workspace                  List workspaces"
@@ -93,8 +116,6 @@ class Db
 
   def cmd_workspace(*args)
     return unless active?
-    search_term = nil
-  ::ActiveRecord::Base.connection_pool.with_connection {
     search_term = nil
     while (arg = args.shift)
       case arg
@@ -128,45 +149,19 @@ class Db
       end
       framework.db.workspace = workspace
     elsif deleting and names
-      delete_workspaces(names)
+      status_msg, error_msg = framework.db.delete_workspaces(names)
+      print_msgs(status_msg, error_msg)
     elsif delete_all
-      delete_workspaces(framework.db.workspaces.map(&:name))
+      status_msg, error_msg = framework.db.delete_all_workspaces()
+      print_msgs(status_msg, error_msg)
     elsif renaming
       if names.length != 2
         print_error("Wrong number of arguments to rename")
         return
       end
+
       old, new = names
-
-      workspace = framework.db.find_workspace(old)
-
-      old_is_active = (framework.db.workspace == workspace)
-      recreate_default = workspace.default?
-
-      if workspace.nil?
-        print_error("Workspace not found: #{name}")
-        return
-      end
-
-      if framework.db.find_workspace(new)
-        print_error("Workspace exists: #{new}")
-        return
-      end
-
-      workspace.name = new
-      workspace.save!
-
-      # Recreate the default workspace to avoid errors
-      if recreate_default
-        framework.db.add_workspace(old)
-        print_status("Recreated default workspace after rename")
-      end
-
-      # Switch to new workspace if old name was active
-      if old_is_active
-        framework.db.workspace = workspace
-        print_status("Switched workspace: #{framework.db.workspace.name}")
-      end
+      framework.db.rename_workspace(old, new)
     elsif names
       name = names.last
       # Switch workspace
@@ -205,48 +200,22 @@ class Db
       )
 
       # List workspaces
-      framework.db.workspaces.each do |ws|
+      framework.db.workspace_associations_counts.each do |ws|
         tbl << [
-          ws == workspace ? '*' : '',
-          ws.name,
-          ws.hosts.count,
-          ws.services.count,
-          ws.vulns.count,
-          ws.core_credentials.count,
-          ws.loots.count,
-          ws.notes.count
+          ws[:name] == workspace.name ? '*' : '',
+          ws[:name],
+          ws[:hosts_count],
+          ws[:services_count],
+          ws[:vulns_count],
+          ws[:creds_count],
+          ws[:loots_count],
+          ws[:notes_count]
         ]
       end
 
       print_line
       print_line(tbl.to_s)
     end
-  }
-  end
-
-  def delete_workspaces(names)
-    switched = false
-    # Delete workspaces
-    names.each do |name|
-      workspace = framework.db.find_workspace(name)
-      if workspace.nil?
-        print_error("Workspace not found: #{name}")
-      elsif workspace.default?
-        workspace.destroy
-        workspace = framework.db.add_workspace(name)
-        print_status("Deleted and recreated the default workspace")
-      else
-        # switch to the default workspace if we're about to delete the current one
-        if framework.db.workspace.name == workspace.name
-          framework.db.workspace = framework.db.default_workspace
-          switched = true
-        end
-        # now destroy the named workspace
-        workspace.destroy
-        print_status("Deleted workspace: #{name}")
-      end
-    end
-    print_status("Switched workspace: #{framework.db.workspace.name}") if switched
   end
 
   def cmd_workspace_tabs(str, words)
@@ -262,47 +231,28 @@ class Db
     cmd_hosts("-h")
   end
 
-  def change_host_info(rws, data)
-    if rws == [nil]
-      print_error("In order to change the host info, you must provide a range of hosts")
+  # Changes the specified host data
+  #
+  # @param host_ranges - range of hosts to process
+  # @param host_data - hash of host data to be updated
+  def change_host_data(host_ranges, host_data)
+    if !host_data || host_data.length != 1
+      print_error("A single key-value data hash is required to change the host data")
+      return
+    end
+    attribute = host_data.keys[0]
+
+    if host_ranges == [nil]
+      print_error("In order to change the host #{attribute}, you must provide a range of hosts")
       return
     end
 
-    rws.each do |rw|
-      rw.each do |ip|
-        id = framework.db.get_host(:address => ip).id
-        framework.db.hosts.update(id, :info => data)
-        framework.db.report_note(:host => ip, :type => 'host.info', :data => data)
-      end
-    end
-  end
+    each_host_range_chunk(host_ranges) do |host_search|
+      break if !host_search.nil? && host_search.empty?
 
-  def change_host_name(rws, data)
-    if rws == [nil]
-      print_error("In order to change the host name, you must provide a range of hosts")
-      return
-    end
-
-    rws.each do |rw|
-      rw.each do |ip|
-        id = framework.db.get_host(:address => ip).id
-        framework.db.hosts.update(id, :name => data)
-        framework.db.report_note(:host => ip, :type => 'host.name', :data => data)
-      end
-    end
-  end
-
-  def change_host_comment(rws, data)
-    if rws == [nil]
-      print_error("In order to change the comment, you must provide a range of hosts")
-      return
-    end
-
-    rws.each do |rw|
-      rw.each do |ip|
-        id = framework.db.get_host(:address => ip).id
-        framework.db.hosts.update(id, :comments => data)
-        framework.db.report_note(:host => ip, :type => 'host.comments', :data => data)
+      framework.db.hosts(framework.db.workspace, false, host_search).each do |host|
+        framework.db.update_host(host_data.merge(id: host.id))
+        framework.db.report_note(host: host.address, type: "host.#{attribute}", data: host_data[attribute])
       end
     end
   end
@@ -313,52 +263,57 @@ class Db
       return
     end
 
+    opts = Hash.new()
+    opts[:workspace] = framework.db.workspace
+    opts[:tag_name] = tag_name
+
     rws.each do |rw|
       rw.each do |ip|
-        wspace = framework.db.workspace
-        host = framework.db.get_host(:workspace => wspace, :address => ip)
-        if host
-          possible_tags = Mdm::Tag.joins(:hosts).where("hosts.workspace_id = ? and hosts.address = ? and tags.name = ?", wspace.id, ip, tag_name).order("tags.id DESC").limit(1)
-          tag = (possible_tags.blank? ? Mdm::Tag.new : possible_tags.first)
-          tag.name = tag_name
-          tag.hosts = [host]
-          tag.save! if tag.changed?
-        end
+        opts[:ip] = ip
+        framework.db.add_host_tag(opts)
       end
     end
   end
 
+  def find_hosts_with_tag(workspace_id, host_address, tag_name)
+    opts = Hash.new()
+    opts[:workspace_id] = workspace_id
+    opts[:host_address] = host_address
+    opts[:tag_name] = tag_name
+
+    framework.db.find_hosts_with_tag(opts)
+  end
+
+  def find_host_tags(workspace_id, host_address)
+    opts = Hash.new()
+    opts[:workspace_id] = workspace_id
+    opts[:host_address] = host_address
+
+    framework.db.find_host_tags(opts)
+  end
+
   def delete_host_tag(rws, tag_name)
-    wspace = framework.db.workspace
-    tag_ids = []
+    opts = Hash.new()
+    opts[:workspace] = framework.db.workspace
+    opts[:tag_name] = tag_name
+
     if rws == [nil]
-      found_tags = Mdm::Tag.joins(:hosts).where("hosts.workspace_id = ? and tags.name = ?", wspace.id, tag_name)
-      found_tags.each do |t|
-        tag_ids << t.id
-      end
+      framework.db.delete_host_tag(opts)
     else
       rws.each do |rw|
         rw.each do |ip|
-          found_tags = Mdm::Tag.joins(:hosts).where("hosts.workspace_id = ? and hosts.address = ? and tags.name = ?", wspace.id, ip, tag_name)
-            found_tags.each do |t|
-            tag_ids << t.id
-          end
+          opts[:ip] = ip
+          framework.db.delete_host_tag(opts)
         end
       end
     end
 
-    tag_ids.each do |id|
-      tag = Mdm::Tag.find_by_id(id)
-      tag.hosts.delete
-      tag.destroy
-    end
   end
 
   @@hosts_columns = [ 'address', 'mac', 'name', 'os_name', 'os_flavor', 'os_sp', 'purpose', 'info', 'comments']
 
   def cmd_hosts(*args)
     return unless active?
-  ::ActiveRecord::Base.connection_pool.with_connection {
     onlyup = false
     set_rhosts = false
     mode = []
@@ -369,7 +324,34 @@ class Db
     search_term = nil
 
     output = nil
-    default_columns = ::Mdm::Host.column_names.sort
+    default_columns = [
+        'address',
+        'arch',
+        'comm',
+        'comments',
+        'created_at',
+        'cred_count',
+        'detected_arch',
+        'exploit_attempt_count',
+        'host_detail_count',
+        'info',
+        'mac',
+        'name',
+        'note_count',
+        'os_family',
+        'os_flavor',
+        'os_lang',
+        'os_name',
+        'os_sp',
+        'purpose',
+        'scope',
+        'service_count',
+        'state',
+        'updated_at',
+        'virtual_host',
+        'vuln_count',
+        'workspace_id']
+
     default_columns << 'tags' # Special case
     virtual_columns = [ 'svcs', 'vulns', 'workspace', 'tags' ]
 
@@ -399,7 +381,7 @@ class Db
         if (arg == '-C')
           @@hosts_columns = col_search
         end
- 
+
       when '-u','--up'
         onlyup = true
       when '-o'
@@ -412,7 +394,7 @@ class Db
       when '-R', '--rhosts'
         set_rhosts = true
       when '-S', '--search'
-        search_term = /#{args.shift}/nmi
+        search_term = args.shift
       when '-i', '--info'
         mode << :new_info
         info_data = args.shift
@@ -491,13 +473,13 @@ class Db
 
     case
     when mode == [:new_info]
-      change_host_info(host_ranges, info_data)
+        change_host_data(host_ranges, info: info_data)
       return
     when mode == [:new_name]
-      change_host_name(host_ranges, name_data)
+        change_host_data(host_ranges, name: name_data)
       return
     when mode == [:new_comment]
-      change_host_comment(host_ranges, comment_data)
+        change_host_data(host_ranges, comments: comment_data)
       return
     when mode == [:tag]
       begin
@@ -515,31 +497,28 @@ class Db
       return
     end
 
+    matched_host_ids = []
     each_host_range_chunk(host_ranges) do |host_search|
-      framework.db.hosts(framework.db.workspace, onlyup, host_search).each do |host|
-        if search_term
-          next unless (
-            host.attribute_names.any? { |a| host[a.intern].to_s.match(search_term) } ||
-            !Mdm::Tag.joins(:hosts).where("hosts.workspace_id = ? and hosts.address = ? and tags.name = ?", framework.db.workspace.id, host.address, search_term.source).references(:hosts).order("tags.id DESC").empty?
-          )
-        end
+      break if !host_search.nil? && host_search.empty?
 
+      framework.db.hosts(framework.db.workspace, onlyup, host_search, search_term = search_term).each do |host|
+        matched_host_ids << host.id
         columns = col_names.map do |n|
           # Deal with the special cases
           if virtual_columns.include?(n)
             case n
-            when "svcs";      host.services.length
-            when "vulns";     host.vulns.length
+            when "svcs";      host.service_count
+            when "vulns";     host.vuln_count
             when "workspace"; host.workspace.name
             when "tags"
-              found_tags = Mdm::Tag.joins(:hosts).where("hosts.workspace_id = ? and hosts.address = ?", framework.db.workspace.id, host.address).order("tags.id DESC")
+              found_tags = find_host_tags(framework.db.workspace.id, host.address)
               tag_names = []
               found_tags.each { |t| tag_names << t.name }
               found_tags * ", "
             end
           # Otherwise, it's just an attribute
           else
-            host.attributes[n] || ""
+            host[n] || ""
           end
         end
 
@@ -548,15 +527,11 @@ class Db
           addr = (host.scope ? host.address + '%' + host.scope : host.address)
           rhosts << addr
         end
-        if mode == [:delete]
-          begin
-            host.destroy
-          rescue # refs suck
-            print_error("Forcibly deleting #{host.address}")
-            host.delete
-          end
-          delete_count += 1
-        end
+      end
+
+      if mode == [:delete]
+        result = framework.db.delete_host(ids: matched_host_ids)
+        delete_count += result.size
       end
     end
 
@@ -575,7 +550,6 @@ class Db
     set_rhosts_from_addrs(rhosts.uniq) if set_rhosts
 
     print_status("Deleted #{delete_count} hosts") if delete_count > 0
-  }
   end
 
   def cmd_services_help
@@ -586,14 +560,19 @@ class Db
 
   def cmd_services(*args)
     return unless active?
-  ::ActiveRecord::Base.connection_pool.with_connection {
     mode = :search
     onlyup = false
     output_file = nil
     set_rhosts = false
     col_search = ['port', 'proto', 'name', 'state', 'info']
-    default_columns = ::Mdm::Service.column_names.sort
-    default_columns.delete_if {|v| (v[-2,2] == "id")}
+    default_columns = [
+        'created_at',
+        'info',
+        'name',
+        'port',
+        'proto',
+        'state',
+        'updated_at']
 
     host_ranges  = []
     port_ranges  = []
@@ -734,7 +713,7 @@ class Db
         host = service.host
         if search_term
           next unless(
-            host.attribute_names.any? { |a| host[a.intern].to_s.match(search_term)} or
+          host.attribute_names.any? { |a| host[a.intern].to_s.match(search_term)} or
             service.attribute_names.any? { |a| service[a.intern].to_s.match(search_term)}
           )
         end
@@ -768,7 +747,6 @@ class Db
 
     print_status("Deleted #{delete_count} services") if delete_count > 0
 
-  }
   end
 
   def cmd_vulns_help
@@ -792,7 +770,6 @@ class Db
 
   def cmd_vulns(*args)
     return unless active?
-  ::ActiveRecord::Base.connection_pool.with_connection {
 
     host_ranges = []
     port_ranges = []
@@ -859,25 +836,25 @@ class Db
     tbl = Rex::Text::Table.new(
         'Header' => 'Vulnerabilities',
         'Columns' => ['Timestamp', 'Host', 'Name', 'References', 'Information']
-      )
+    )
 
     each_host_range_chunk(host_ranges) do |host_search|
       framework.db.hosts(framework.db.workspace, false, host_search).each do |host|
         host.vulns.each do |vuln|
           if search_term
             next unless(
-              vuln.host.attribute_names.any? { |a| vuln.host[a.intern].to_s.match(search_term) } or
+            vuln.host.attribute_names.any? { |a| vuln.host[a.intern].to_s.match(search_term) } or
               vuln.attribute_names.any? { |a| vuln[a.intern].to_s.match(search_term) }
             )
           end
           reflist = vuln.refs.map { |r| r.name }
-
           if(vuln.service)
             # Skip this one if the user specified a port and it
             # doesn't match.
             next unless ports.empty? or ports.include? vuln.service.port
             # Same for service names
             next unless svcs.empty? or svcs.include?(vuln.service.name)
+
           else
             # This vuln has no service, so it can't match
             next unless ports.empty? and svcs.empty?
@@ -915,7 +892,6 @@ class Db
     # Finally, handle the case where the user wants the resulting list
     # of hosts to go into RHOSTS.
     set_rhosts_from_addrs(rhosts.uniq) if set_rhosts
-  }
   end
 
   def cmd_notes_help
@@ -1171,7 +1147,7 @@ class Db
 
   def cmd_loot(*args)
     return unless active?
-  ::ActiveRecord::Base.connection_pool.with_connection {
+
     mode = :search
     host_ranges = []
     types = nil
@@ -1203,7 +1179,7 @@ class Db
             print_error("Can't make loot with no info")
             return
           end
-        when '-t'
+        when '-t', '--type'
           typelist = args.shift
           if(!typelist)
             print_error("Invalid type list")
@@ -1211,7 +1187,9 @@ class Db
           end
           types = typelist.strip().split(",")
         when '-S', '--search'
-          search_term = /#{args.shift}/nmi
+          search_term = args.shift
+        when '-u', '--update' # TODO: This is currently undocumented because it's not officially supported.
+          mode = :update
         when '-h','--help'
           cmd_loot_help
           return
@@ -1261,63 +1239,61 @@ class Db
       return
     end
 
-    each_host_range_chunk(host_ranges) do |host_search|
-      framework.db.hosts(framework.db.workspace, false, host_search).each do |host|
-        host.loots.each do |loot|
-          next if(types and types.index(loot.ltype).nil?)
-          if search_term
-          next unless(
-            loot.attribute_names.any? { |a| loot[a.intern].to_s.match(search_term) } or
-            loot.host.attribute_names.any? { |a| loot.host[a.intern].to_s.match(search_term) }
-          )
-          end
-          row = []
-          row.push( (loot.host ? loot.host.address : "") )
-          if (loot.service)
-            svc = (loot.service.name ? loot.service.name : "#{loot.service.port}/#{loot.service.proto}")
-            row.push svc
-          else
-            row.push ""
-          end
-          row.push(loot.ltype)
-          row.push(loot.name || "")
-          row.push(loot.content_type)
-          row.push(loot.info || "")
-          row.push(loot.path)
+    matched_loot_ids = []
+    loots = []
+    if host_ranges.compact.empty?
+      loots = loots + framework.db.loots(framework.db.workspace, {:search_term => search_term})
+    else
+      each_host_range_chunk(host_ranges) do |host_search|
+        break if !host_search.nil? && host_search.empty?
 
-          tbl << row
-          if (mode == :delete)
-            loot.destroy
-            delete_count += 1
-          end
-        end
+        loots = loots + framework.db.loots(framework.db.workspace, { :hosts => { :address => host_search }, :search_term => search_term })
       end
     end
 
-    # Handle hostless loot
-    if host_ranges.compact.empty? # Wasn't a host search
-      hostless_loot = framework.db.loots.where(host_id: nil)
-      hostless_loot.each do |loot|
-        row = []
-        row.push("")
-        row.push("")
-        row.push(loot.ltype)
-        row.push(loot.name || "")
-        row.push(loot.content_type)
-        row.push(loot.info || "")
-        row.push(loot.path)
-        tbl << row
-        if (mode == :delete)
-          loot.destroy
-          delete_count += 1
+    loots.each do |loot|
+      row = []
+      # TODO: This is just a temp implementation of update for the time being since it did not exist before.
+      # It should be updated to not pass all of the attributes attached to the object, only the ones being updated.
+      if mode == :update
+        begin
+          loot.info = info if info
+          if types && types.size > 1
+            print_error "May only pass 1 type when performing an update."
+            next
+          end
+          loot.ltype = types.first if types
+          framework.db.update_loot(loot.as_json.symbolize_keys)
+        rescue Exception => e
+          elog "There was an error updating loot with ID #{loot.id}: #{e.message}"
+          next
         end
       end
+      row.push (loot.host && loot.host.address) ? loot.host.address : ""
+      if (loot.service)
+        svc = (loot.service.name ? loot.service.name : "#{loot.service.port}/#{loot.service.proto}")
+        row.push svc
+      else
+        row.push ""
+      end
+      row.push(loot.ltype)
+      row.push(loot.name || "")
+      row.push(loot.content_type)
+      row.push(loot.info || "")
+      row.push(loot.path)
+
+      tbl << row
+      matched_loot_ids << loot.id
+    end
+
+    if (mode == :delete)
+      result = framework.db.delete_loot(ids: matched_loot_ids)
+      delete_count = result.size
     end
 
     print_line
     print_line(tbl.to_s)
     print_status("Deleted #{delete_count} loots") if delete_count > 0
-  }
   end
 
   # :category: Deprecated Commands
@@ -1891,7 +1867,7 @@ class Db
     # Chunk it up and do the query in batches. The naive implementation
     # uses so much memory for a /8 that it's basically unusable (1.6
     # billion IP addresses take a rather long time to allocate).
-    # Chunking has roughly the same perfomance for small batches, so
+    # Chunking has roughly the same performance for small batches, so
     # don't worry about it too much.
     host_ranges.each do |range|
       if range.nil? or range.length.nil?
@@ -1917,6 +1893,88 @@ class Db
       # Restart the loop with the same RangeWalker if we didn't get
       # to the end of it in this chunk.
       redo unless end_of_range
+    end
+  end
+
+  #######
+  private
+  #######
+
+  def add_data_service(*args)
+    protocol = "http"
+    port = 8080
+    https_opts = {}
+    while (arg = args.shift)
+      case arg
+        when '-p'
+          port = args.shift
+        when '-s', '--ssl'
+          protocol = "https"
+        when '-c', '--cert'
+          https_opts[:cert] = args.shift
+        when '--skip-verify'
+          https_opts[:skip_verify] = true
+        else
+          host = arg
+      end
+    end
+
+    if host.nil? || port.nil?
+      print_error "Host and port are required."
+      return
+    end
+
+    endpoint = "#{protocol}://#{host}:#{port}"
+    remote_data_service = Metasploit::Framework::DataService::RemoteHTTPDataService.new(endpoint, https_opts)
+    begin
+      framework.db.register_data_service(remote_data_service)
+      print_line "Registered data service: #{remote_data_service.name}"
+    rescue Exception => e
+      print_error "There was a problem registering the remote data service: #{e.message}"
+    end
+  end
+
+  def set_data_service(service_id)
+    begin
+      framework.db.set_data_service(service_id)
+    rescue Exception => e
+      print_error "Unable to set data service: #{e.message}"
+    end
+  end
+
+  def list_data_services()
+    framework.db.get_services_metadata.each {|metadata|
+      out = "id: #{metadata.id}, name: #{metadata.name}"
+      if metadata.active
+        out += " [active]"
+      end
+      print_line out
+    }
+  end
+
+  def data_service_help
+    print_line "Usage: data_services [ options ] - list data services by default"
+    print_line
+    print_line "OPTIONS:"
+
+    print_line "  -h, --help                  Show this help information."
+    print_line "  -s, --set <id>              Set the data service by identifier."
+    print_line "  -a, --add [ options ] host  Adds data service"
+    print_line "  Add Data Service Options:"
+    print_line "  -p <port>         The port the data service is listening on. Default is 8080."
+    print_line "  -s, --ssl         Enable SSL. Required for HTTPS data services."
+    print_line "  -c, --cert        Certificate file matching the server's certificate. Needed when using self-signed SSL cert."
+    print_line "  --skip-verify     Skip validating authenticity of server's certificate. NOT RECOMMENDED."
+    print_line
+  end
+
+  def print_msgs(status_msg, error_msg)
+    status_msg.each do |s|
+      print_status(s)
+    end
+
+    error_msg.each do |e|
+      print_error(e)
     end
   end
 

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -122,12 +122,11 @@ class Driver < Msf::Ui::Driver
       enstack_dispatcher(dispatcher)
     end
 
-    # Add the database dispatcher if it is usable
-    if (framework.db.usable)
-      require 'msf/ui/console/command_dispatcher/db'
-      enstack_dispatcher(CommandDispatcher::Db)
-      require 'msf/ui/console/command_dispatcher/creds'
-      enstack_dispatcher(CommandDispatcher::Creds)
+    if framework.db && framework.db.active
+        require 'msf/ui/console/command_dispatcher/db'
+        enstack_dispatcher(CommandDispatcher::Db)
+        require 'msf/ui/console/command_dispatcher/creds'
+        enstack_dispatcher(CommandDispatcher::Creds)
     else
       print_error("***")
       if framework.db.error == "disabled"
@@ -196,7 +195,7 @@ class Driver < Msf::Ui::Driver
       self.framework.init_module_paths(module_paths: opts['ModulePath'])
     end
 
-    if !opts['DeferModuleLoads']
+    if framework.db && framework.db.active && framework.db.is_local? && !opts['DeferModuleLoads']
       framework.threads.spawn("ModuleCacheRebuild", true) do
         framework.modules.refresh_cache_from_module_files
       end

--- a/lib/msf/util.rb
+++ b/lib/msf/util.rb
@@ -22,3 +22,9 @@ end
 # Executable generation and encoding
 require 'msf/util/exe'
 require 'msf/util/helper'
+
+# Host helpers
+require 'msf/util/host'
+
+# DBManager helpers
+require 'msf/util/db_manager'

--- a/lib/msf/util/db_manager.rb
+++ b/lib/msf/util/db_manager.rb
@@ -1,0 +1,19 @@
+module Msf
+  module Util
+    module DBManager
+      # Creates search conditions to match the specified search string against all of the model's columns.
+      #
+      # @param model - An ActiveRecord model object
+      # @param search - A string regex search
+      # @return Arel::Nodes::Or object that represents a search of all of the model's columns
+      def self.create_all_column_search_conditions(model, search)
+        search = "(?mi)#{search}"
+        condition_set = model.columns.map do |column|
+          Arel::Nodes::Regexp.new(Arel::Nodes::NamedFunction.new("CAST", [model.arel_table[column.name].as("TEXT")]),
+                                  Arel::Nodes.build_quoted(search))
+        end
+        condition_set.reduce { |conditions, condition| conditions.or(condition).expr }
+      end
+    end
+  end
+end

--- a/lib/msf/util/host.rb
+++ b/lib/msf/util/host.rb
@@ -1,0 +1,62 @@
+# -*- coding: binary -*-
+
+module Msf
+  module Util
+    module Host
+
+      #
+      # Returns something suitable for the +:host+ parameter to the various report_* methods
+      #
+      # Takes a Host object, a Session object, an Msf::Session object or a String
+      # address
+      #
+      def self.normalize_host(host)
+        return host if defined?(::Mdm) && host.kind_of?(::Mdm::Host)
+        norm_host = nil
+
+        if (host.kind_of? String)
+
+          if Rex::Socket.is_ipv4?(host)
+            # If it's an IPv4 addr with a port on the end, strip the port
+            if host =~ /((\d{1,3}\.){3}\d{1,3}):\d+/
+              norm_host = $1
+            else
+              norm_host = host
+            end
+          elsif Rex::Socket.is_ipv6?(host)
+            # If it's an IPv6 addr, drop the scope
+            address, scope = host.split('%', 2)
+            norm_host = address
+          else
+            norm_host = Rex::Socket.getaddress(host, true)
+          end
+        elsif defined?(::Mdm) && host.kind_of?(::Mdm::Session)
+          norm_host = host.host
+        elsif host.respond_to?(:session_host)
+          # Then it's an Msf::Session object
+          norm_host = host.session_host
+        end
+
+        # If we got here and don't have a norm_host yet, it could be a
+        # Msf::Session object with an empty or nil tunnel_host and tunnel_peer;
+        # see if it has a socket and use its peerhost if so.
+        if (
+        norm_host.nil? &&
+            host.respond_to?(:sock) &&
+            host.sock.respond_to?(:peerhost) &&
+            host.sock.peerhost.to_s.length > 0
+        )
+          norm_host = session.sock.peerhost
+        end
+        # If We got here and still don't have a real host, there's nothing left
+        # to try, just log it and return what we were given
+        if !norm_host
+          dlog("Host could not be normalized: #{host.inspect}")
+          norm_host = host
+        end
+
+        norm_host
+      end
+    end
+  end
+end

--- a/spec/lib/msf/core/auxiliary/cisco_spec.rb
+++ b/spec/lib/msf/core/auxiliary/cisco_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
   
   context '#cisco_ios_config_eater' do
     before(:example) do
-      expect(aux_cisco).to receive(:myworkspace).and_return(workspace)
+      expect(aux_cisco).to receive(:myworkspace).at_least(:once).and_return(workspace)
     end
     
     it 'deals with udp ports' do

--- a/spec/support/shared/contexts/msf/db_manager.rb
+++ b/spec/support/shared/contexts/msf/db_manager.rb
@@ -6,12 +6,12 @@ RSpec.shared_context 'Msf::DBManager' do
   end
 
   let(:db_manager) do
-    framework.db
+    framework.db.get_data_service
   end
 
   before(:example) do
     # already connected due to use_transactional_fixtures, but need some of the side-effects of #connect
-    framework.db.workspace = framework.db.default_workspace
+    db_manager.workspace = db_manager.default_workspace
     allow(db_manager).to receive(:active).and_return(active)
   end
 end

--- a/spec/support/shared/examples/msf/db_manager/host.rb
+++ b/spec/support/shared/examples/msf/db_manager/host.rb
@@ -5,7 +5,6 @@ RSpec.shared_examples_for 'Msf::DBManager::Host' do
   it { is_expected.to respond_to :get_host }
   it { is_expected.to respond_to :has_host? }
   it { is_expected.to respond_to :hosts }
-  it { is_expected.to respond_to :normalize_host }
   it { is_expected.to respond_to :report_host }
   it { is_expected.to respond_to :update_host_via_sysinfo }
 end

--- a/spec/support/shared/examples/msf/db_manager/session.rb
+++ b/spec/support/shared/examples/msf/db_manager/session.rb
@@ -172,20 +172,6 @@ RSpec.shared_examples_for 'Msf::DBManager::Session' do
             end
 
             context 'with workspace from either :workspace or session' do
-              it 'should pass normalized host from session as :host to #find_or_create_host' do
-                normalized_host = double('Normalized Host')
-                expect(db_manager).to receive(:normalize_host).with(session).and_return(normalized_host)
-                # stub report_vuln so its use of find_or_create_host and normalize_host doesn't interfere.
-                expect(db_manager).to receive(:report_vuln)
-
-                expect(db_manager).to receive(:find_or_create_host).with(
-                  hash_including(
-                    :host => normalized_host
-                  )
-                ).and_return(host)
-
-                report_session
-              end
 
               context 'with session responds to arch' do
                 let(:arch) do
@@ -515,20 +501,6 @@ RSpec.shared_examples_for 'Msf::DBManager::Session' do
             end
 
             context 'with workspace from either :workspace or session' do
-              it 'should pass normalized host from session as :host to #find_or_create_host' do
-                normalized_host = double('Normalized Host')
-                allow(db_manager).to receive(:normalize_host).with(session).and_return(normalized_host)
-                # stub report_vuln so its use of find_or_create_host and normalize_host doesn't interfere.
-                allow(db_manager).to receive(:report_vuln)
-
-                expect(db_manager).to receive(:find_or_create_host).with(
-                    hash_including(
-                        :host => normalized_host
-                    )
-                ).and_return(host)
-
-                report_session
-              end
 
               context 'with session responds to arch' do
                 let(:arch) do


### PR DESCRIPTION
This is patch 3 of 3 which represents the code that ties in the goliath server and client. These patches should be merged in numerical order.

patch 1: #9673
patch 2: #9674

After this patch is merged users should be able to test out goliath, see the link below for detais
For more information on Goliath: https://github.com/rapid7/metasploit-framework/wiki/Metasploit-Data-Service-Enhancements-(Goliath)

# Verification Steps

 - [ ] Start a remote database using `msfdb_ws`. Note this requires all the same steps as a normal Metasploit database, msfdb_ws is just a service in front of that.
 - [ ] Note that `msfdb_ws` is now listening on port 8080 by default, unencrypted. There is no authentication as well, so you can query the service directly. Note, do not have important database data in your local datadabase when testing because.
 - [ ] Start msfconsole, try to connect to via the `data_services -a 127.0.0.1` command