### PR TITLE
Add disclosure date and correct CVE for memcached amp

### DIFF
--- a/modules/auxiliary/scanner/memcached/memcached_amp.rb
+++ b/modules/auxiliary/scanner/memcached/memcached_amp.rb
@@ -24,10 +24,11 @@ class MetasploitModule < Msf::Auxiliary
           'Jon Hart <jon_hart@rapid7.com>', # Metasploit scanner module
         ],
       'License'     => MSF_LICENSE,
+      'DisclosureDate' => 'Feb 27, 2018',
       'References'  =>
           [
             ['URL', 'https://blog.cloudflare.com/memcrashed-major-amplification-attacks-from-port-11211/'],
-            ['CVE', '2018-100015']
+            ['CVE', '2018-1000115']
           ]
     )
 


### PR DESCRIPTION
This corrects the CVE that I originally botched and adds a disclosure date, which is useful/required for other things.

## Verification

- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/memcached/memcached_amp`
- [ ] `info`
- [ ] **Verify** that the correct CVE URL is shown for CVE-2018-1000115
- [ ] **Verify** that the disclosure date of 2018-02-27 is displayed

