### PR TITLE
Add memcached UDP version scanner

### DIFF
--- a/documentation/modules/auxiliary/scanner/memcached/memcached_udp_version.md
+++ b/documentation/modules/auxiliary/scanner/memcached/memcached_udp_version.md
@@ -1,0 +1,65 @@
+## Vulnerable Application
+
+Any instance of memcached with the UDP listener enabled will suffice.
+
+Instructions for testing against CentOS 7 and a Dockerized endpoint are provided below.
+
+### CentOS 7
+
+To a CentOS 7 instance, simply install and start memcached, as it listens on 0.0.0.0 by default'
+
+```
+yum -y install memcached
+systemctl start memcached
+```
+
+### Docker Install
+
+In memcached 1.5.5 and earlier, the daemon is affected by default.  As such, we can use the
+community supported memcached container and simply expose it:
+
+```
+docker run -ti --rm -p 11211:11211/udp memcached:1.5.5
+```
+
+## Verification Steps
+
+
+  1. Install the application
+  2. Start msfconsole
+  3. Do: `use auxiliary/scanner/memcached/memcached_udp_version`
+  4. Do: `set rhosts [IPs]`
+  5. Do: `run`
+  6. Confirm that the endpoint is discovered to be running memcached and the version is displayed
+
+## Scenarios
+
+### CentOS 7
+
+Configure memcached as described above.
+
+```
+msf5 > use auxiliary/scanner/memcached/memcached_udp_version
+msf5 auxiliary(scanner/memcached/memcached_udp_version) > set RHOSTS a.b.c.d
+RHOSTS => a.b.c.d
+msf5 auxiliary(scanner/memcached/memcached_udp_version) > run
+
+[+] a.b.c.d:11211/udp memcached version 1.4.15
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```
+
+### Docker
+
+Configure memcached in docker as described above.
+
+```
+msf5 > use auxiliary/scanner/memcached/memcached_udp_version
+msf5 auxiliary(scanner/memcached/memcached_udp_version) > set RHOSTS a.b.c.d
+RHOSTS => a.b.c.d
+msf5 auxiliary(scanner/memcached/memcached_udp_version) > run
+
+[+] a.b.c.d:11211/udp memcached version 1.5.5
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```

--- a/modules/auxiliary/scanner/memcached/memcached_udp_version.rb
+++ b/modules/auxiliary/scanner/memcached/memcached_udp_version.rb
@@ -22,15 +22,17 @@ class MetasploitModule < Msf::Auxiliary
         ],
       'License'     => MSF_LICENSE,
       'DisclosureDate' => 'Jul 23, 2003',
-      'References'  =>
+      'References' =>
           [
-            ['URL', 'https://github.com/memcached/memcached/blob/master/doc/protocol.txt'],
+            ['URL', 'https://github.com/memcached/memcached/blob/master/doc/protocol.txt']
           ]
     )
 
-    register_options([
-      Opt::RPORT(11211)
-    ])
+    register_options(
+      [
+        Opt::RPORT(11211)
+      ]
+    )
   end
 
   def build_probe

--- a/modules/auxiliary/scanner/memcached/memcached_udp_version.rb
+++ b/modules/auxiliary/scanner/memcached/memcached_udp_version.rb
@@ -1,0 +1,60 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Auxiliary::Report
+  include Msf::Exploit::Capture
+  include Msf::Auxiliary::UDPScanner
+
+  def initialize
+    super(
+      'Name'        => 'Memcached UDP Version Scanner',
+      'Description' => %q(
+          This module can be used to discover Memcached servers which expose the
+          unrestricted UDP port 11211. A basic "version" request is executed to obtain
+          the version of memcached.
+      ),
+      'Author'      =>
+        [
+          'Jon Hart <jon_hart@rapid7.com>' # Metasploit scanner module
+        ],
+      'License'     => MSF_LICENSE,
+      'DisclosureDate' => 'Jul 23, 2003',
+      'References'  =>
+          [
+            ['URL', 'https://github.com/memcached/memcached/blob/master/doc/protocol.txt'],
+          ]
+    )
+
+    register_options([
+      Opt::RPORT(11211)
+    ])
+  end
+
+  def build_probe
+    # Memcached version probe, per https://github.com/memcached/memcached/blob/master/doc/protocol.txt
+    @memcached_probe ||= [
+      rand(2**16), # random request ID
+      0, # sequence number
+      1, # number of datagrams in this sequence
+      0, # reserved; must be 0
+      "version\r\n"
+    ].pack("nnnna*")
+  end
+
+  def scanner_process(data, shost, sport)
+    # Check the response data for a "STAT" repsonse
+    if /VERSION (?<version>[\d\.]+)\r\n/ =~ data
+      print_good("#{shost}:#{sport}/udp memcached version #{version}")
+      report_service(
+        host: shost,
+        proto: 'udp',
+        port: rport,
+        info: version,
+        name: 'memcached'
+      )
+    end
+  end
+end

--- a/modules/auxiliary/scanner/memcached/memcached_udp_version.rb
+++ b/modules/auxiliary/scanner/memcached/memcached_udp_version.rb
@@ -47,7 +47,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def scanner_process(data, shost, sport)
-    # Check the response data for a "STAT" repsonse
+    # Check the response data for a "VERSION" repsonse
     if /VERSION (?<version>[\d\.]+)\r\n/ =~ data
       print_good("#{shost}:#{sport}/udp memcached version #{version}")
       report_service(


### PR DESCRIPTION
This adds a memcached UDP version scanner.

See verification steps in the provided documentation, but simply:

```
msf5 auxiliary(scanner/memcached/memcached_udp_version) > run

[+] a.b.c.d:11211/udp memcached version 1.4.15
```