### PR TITLE
Minor external module fixes

### DIFF
--- a/lib/msf/core/modules/external/shim.rb
+++ b/lib/msf/core/modules/external/shim.rb
@@ -32,7 +32,7 @@ class Msf::Modules::External::Shim
     render_template('common_metadata.erb', meta)
   end
 
-  def self.mod_meta_common(mod, meta = {}, drop_rhost: true)
+  def self.mod_meta_common(mod, meta = {}, drop_rhost: false)
     meta[:path]        = mod.path.dump
     meta[:name]        = mod.meta['name'].dump
     meta[:description] = mod.meta['description'].dump

--- a/modules/auxiliary/dos/http/slowloris.py
+++ b/modules/auxiliary/dos/http/slowloris.py
@@ -76,13 +76,11 @@ def create_random_header_name(size=8, seq=string.ascii_uppercase + string.ascii_
 
 
 def init_socket(host, port, use_ssl=False, rand_user_agent=True):
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s = socket.create_connection((host, port), 10)
     s.settimeout(4)
 
     if use_ssl:
         s = ssl.wrap_socket(s)
-
-    s.connect((host, port))
 
     s.send("GET /?{} HTTP/1.1\r\n".format(random.randint(0, 2000)).encode("utf-8"))
 


### PR DESCRIPTION
This PR has two fixes:
* Add IPv6 to slowloris
* Add the rhost option back to non-scanner external modules

Verification
========

- [x] `./msfconsole`
- [x] `use auxiliary/dos/http/slowloris`
- [x] `options` should contain `RHOST`
- [x] the module should run against an IPv6 host without errors (even if it can't take it down)