### PR TITLE
bump payloads, fix PHP meterpreter message parsing

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,7 +18,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 1.3.29)
+      metasploit-payloads (= 1.3.30)
       metasploit_data_models
       metasploit_payloads-mettle (= 0.3.7)
       mqtt
@@ -180,7 +180,7 @@ GEM
       activemodel (~> 4.2.6)
       activesupport (~> 4.2.6)
       railties (~> 4.2.6)
-    metasploit-payloads (1.3.29)
+    metasploit-payloads (1.3.30)
     metasploit_data_models (2.0.16)
       activerecord (~> 4.2.6)
       activesupport (~> 4.2.6)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -70,7 +70,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '1.3.29'
+  spec.add_runtime_dependency 'metasploit-payloads', '1.3.30'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '0.3.7'
   # Needed by msfgui and other rpc components

--- a/modules/payloads/singles/php/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/php/meterpreter_reverse_tcp.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/meterpreter_options'
 
 module MetasploitModule
 
-  CachedSize = 30096
+  CachedSize = 30195
 
   include Msf::Payload::Single
   include Msf::Payload::Php::ReverseTcp

--- a/modules/payloads/singles/php/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/php/meterpreter_reverse_tcp.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/meterpreter_options'
 
 module MetasploitModule
 
-  CachedSize = 30195
+  CachedSize = 30306
 
   include Msf::Payload::Single
   include Msf::Payload::Php::ReverseTcp


### PR DESCRIPTION
Grab the fix for https://github.com/rapid7/metasploit-payloads/pull/273 