### PR TITLE
move ssh platforms to lib

### DIFF
--- a/lib/metasploit/framework/login_scanner/ssh.rb
+++ b/lib/metasploit/framework/login_scanner/ssh.rb
@@ -146,6 +146,33 @@ module Metasploit
           self.verbosity = :fatal if self.verbosity.nil?
         end
 
+        public
+
+        def get_platform(proof)
+          case proof
+          when /Linux/
+            'linux'
+          when /Darwin/
+            'osx'
+          when /SunOS/
+            'solaris'
+          when /BSD/
+            'bsd'
+          when /HP-UX/
+            'hpux'
+          when /AIX/
+            'aix'
+          when /Win32|Windows/
+            'windows'
+          when /Unknown command or computer name/
+            'cisco-ios'
+          when /unknown keyword/ # ScreenOS
+            'juniper'
+          when /JUNOS Base OS/ #JunOS
+            'juniper'
+          end
+        end
+
       end
 
     end

--- a/modules/auxiliary/scanner/ssh/ssh_login.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login.rb
@@ -53,11 +53,11 @@ class MetasploitModule < Msf::Auxiliary
     datastore['RPORT']
   end
 
-  def session_setup(result, ssh_socket)
-    return unless ssh_socket
+  def session_setup(result, scanner)
+    return unless scanner.ssh_socket
 
     # Create a new session
-    conn = Net::SSH::CommandStream.new(ssh_socket)
+    conn = Net::SSH::CommandStream.new(scanner.ssh_socket)
 
     merge_me = {
       'USERPASS_FILE' => nil,
@@ -68,31 +68,10 @@ class MetasploitModule < Msf::Auxiliary
     }
     info = "#{proto_from_fullname} #{result.credential} (#{@ip}:#{rport})"
     s = start_session(self, info, merge_me, false, conn.lsock)
-    self.sockets.delete(ssh_socket.transport.socket)
+    self.sockets.delete(scanner.ssh_socket.transport.socket)
 
     # Set the session platform
-    case result.proof
-    when /Linux/
-      s.platform = "linux"
-    when /Darwin/
-      s.platform = "osx"
-    when /SunOS/
-      s.platform = "solaris"
-    when /BSD/
-      s.platform = "bsd"
-    when /HP-UX/
-      s.platform = "hpux"
-    when /AIX/
-      s.platform = "aix"
-    when /Win32|Windows/
-      s.platform = "windows"
-    when /Unknown command or computer name/
-      s.platform = "cisco-ios"
-    when /unknown keyword/ # ScreenOS
-      s.platform = "juniper"
-    when /JUNOS Base OS/ #JunOS
-      s.platform = "juniper"
-    end
+    s.platform = scanner.get_platform(result.proof)
 
     s
   end
@@ -140,7 +119,7 @@ class MetasploitModule < Msf::Auxiliary
         credential_core = create_credential(credential_data)
         credential_data[:core] = credential_core
         create_credential_login(credential_data)
-        session_setup(result, scanner.ssh_socket)
+        session_setup(result, scanner)
         :next_user
       when Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
         vprint_brute :level => :verror, :ip => ip, :msg => "Could not connect: #{result.proof}"

--- a/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
@@ -68,7 +68,7 @@ class MetasploitModule < Msf::Auxiliary
     datastore['RHOST']
   end
 
-  def session_setup(result, scanner.ssh_socket, fingerprint)
+  def session_setup(result, scanner, fingerprint)
     return unless scanner.ssh_socket
 
     # Create a new session from the socket

--- a/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
@@ -68,11 +68,11 @@ class MetasploitModule < Msf::Auxiliary
     datastore['RHOST']
   end
 
-  def session_setup(result, ssh_socket, fingerprint)
-    return unless ssh_socket
+  def session_setup(result, scanner.ssh_socket, fingerprint)
+    return unless scanner.ssh_socket
 
     # Create a new session from the socket
-    conn = Net::SSH::CommandStream.new(ssh_socket)
+    conn = Net::SSH::CommandStream.new(scanner.ssh_socket)
 
     # Clean up the stored data - need to stash the keyfile into
     # a datastore for later reuse.
@@ -87,31 +87,10 @@ class MetasploitModule < Msf::Auxiliary
 
     info = "SSH #{result.credential.public}:#{fingerprint} (#{ip}:#{rport})"
     s = start_session(self, info, merge_me, false, conn.lsock)
-    self.sockets.delete(ssh_socket.transport.socket)
+    self.sockets.delete(scanner.ssh_socket.transport.socket)
 
     # Set the session platform
-    case result.proof
-    when /Linux/
-      s.platform = "linux"
-    when /Darwin/
-      s.platform = "osx"
-    when /SunOS/
-      s.platform = "solaris"
-    when /BSD/
-      s.platform = "bsd"
-    when /HP-UX/
-      s.platform = "hpux"
-    when /AIX/
-      s.platform = "aix"
-    when /Win32|Windows/
-      s.platform = "windows"
-    when /Unknown command or computer name/
-      s.platform = "cisco-ios"
-    when /unknown keyword/ # ScreenOS
-      s.platform = "juniper"
-    when /JUNOS Base OS/ #JunOS
-      s.platform = "juniper"
-    end
+    s.platform = scanner.get_platform(result.proof)
 
     s
   end
@@ -164,7 +143,7 @@ class MetasploitModule < Msf::Auxiliary
           create_credential_login(credential_data)
           tmp_key = result.credential.private
           ssh_key = SSHKey.new tmp_key
-          session_setup(result, scanner.ssh_socket, ssh_key.fingerprint)
+          session_setup(result, scanner, ssh_key.fingerprint)
           :next_user
         when Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
           if datastore['VERBOSE']


### PR DESCRIPTION
`ssh_login` and `ssh_login_pubkey` contain the same case statement for setting the platform.  Moved that to a function call in the ssh lib to prevent duplication and the two lists from getting out of sync.

## Verification

- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/ssh/ssh_login` and `use auxiliary/scanner/ssh/ssh_login_pubkey`
- [x] set rhosts/username/password
- [x] `run`
- [x] `sessions`
- [x] **Verify** the type field has the right OS/platform set


I ran this for `ssh_login`, and not pubkey but the changes were the same.  Attempted against linux (ubuntu 16.04) and solaris (10).
```
msf5 auxiliary(scanner/ssh/ssh_login) > sessions

Active sessions
===============

  Id  Name  Type            Information                           Connection
  --  ----  ----            -----------                           ----------
  1         shell /linux    SSH ubuntu:ubuntu (1.2.3.4:22)  9.9.9.9:37057 -> 1.2.3.4:22 (1.2.3.4)
  2         shell /solaris  SSH root:solaris (6.6.6.6:22)    9.9.9.9:44851 -> 6.6.6.6:22 (6.6.6.6)
```