### PR TITLE
Updating rubocop rules

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -92,9 +92,10 @@ Style/NumericLiterals:
   Enabled: false
   Description: 'This often hurts readability for exploit-ish code.'
 
-Layout/SpaceInsideBrackets:
-  Enabled: false
-  Description: 'Until module template are final, most modules will fail this.'
+Layout/AlignParameters:
+  Enabled: true
+  EnforcedStyle: 'with_fixed_indentation'
+  Description: 'initialize method of every module has fixed indentation for Name, Description, etc'
 
 Style/StringLiterals:
   Enabled: false


### PR DESCRIPTION
This PR does two thing.

1. It removes `Layout/SpaceInsideBrackets`. because it's not supported anymore. 

```
➜  metasploit-framework git:(manageengine_appmanager_0day) ✗ rubocop modules/exploits/windows/http/manageengine_appmanager_exec.rb
Warning: unrecognized cop Layout/SpaceInsideBrackets found in .rubocop.yml
```

2. It adds `AlignParameters` by enforcing `with_fixed_indentation`. I've added this because as far as I can see, metasploit wants to following format for initialize method of every module. ([Layout/AlignParameters](https://rubocop.readthedocs.io/en/latest/cops_layout/#layoutclosingparenthesisindentation))

```
    super(update_info(info,
      'Name'           => 'Xplico Remote Code Execution',
      'Description'    => %q{
        Description goes here.
      },
      'License'         => MSF_LICENSE,
      'Author'          =>
        [
          'Mehmet Ince <mehmet@mehmetince.net>'  # author & msf module
        ],
      'References'      =>
        [
          ['CVE', '2017-1337'],
          ['URL', 'https://someurl']
        ],
      'Privileged'      => true,
      'Platform'        => ['unix'],
      'Arch'            => ARCH_CMD,
      'Targets'         => [ ['Automatic', {}] ],
      'DisclosureDate'  => '',
      'DefaultTarget'   => 0
    ))
```

I'm not an expert of ruby. So please comment on this pr. If these changes haven't done before because of a reason that I don't know/see, maybe we can add .rubocop.yml file into to .gitignore so pple like me can update it in way they want  :-)