### PR TITLE
Add a reload_lib command

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -65,6 +65,15 @@ module Msf
             framework.datastore['LocalEditor'] || Rex::Compat.getenv('VISUAL') || Rex::Compat.getenv('EDITOR')
           end
 
+          def reload_file(path, err_msg = 'Only library files can be loaded.')
+            if path.end_with?('.rb')
+              print_status("Reloading #{path}")
+              load path
+            else
+              print_error(err_msg)
+            end
+          end
+
           def cmd_reload_lib_help
             print_line 'Usage: reload_lib [lib/to/load.rb]'
             print_line
@@ -87,12 +96,7 @@ module Msf
               print_error('Nothing to load.')
               return
             end
-            if path.end_with?('.rb')
-              print_status("Reloading #{path}")
-              load path
-            else
-              print_error('Only library files can be loaded.')
-            end
+            reload_file(path)
           end
 
           def cmd_reload_lib_tabs(str, words)
@@ -139,12 +143,7 @@ module Msf
             return if editing_module
 
             # XXX: This will try to reload *any* .rb and break on modules
-            if path.end_with?('.rb')
-              print_status("Reloading #{path}")
-              load path
-            else
-              print_error('Only library files can be reloaded after editing.')
-            end
+            reload_file(path)
           end
 
           #

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -38,7 +38,7 @@ module Msf
               "search"     => "Searches module names and descriptions",
               "show"       => "Displays modules of a given type, or all modules",
               "use"        => "Selects a module by name",
-              "loadlib"    => "Load a library file from specified path",
+              "reload_lib"    => "Load a library file from specified path",
             }
           end
 
@@ -65,8 +65,8 @@ module Msf
             framework.datastore['LocalEditor'] || Rex::Compat.getenv('VISUAL') || Rex::Compat.getenv('EDITOR')
           end
 
-          def cmd_loadlib_help
-            print_line 'Usage: loadlib [lib/to/load.rb]'
+          def cmd_reload_lib_help
+            print_line 'Usage: reload_lib [lib/to/load.rb]'
             print_line
             print_line 'Load a library from specified path'
           end
@@ -75,12 +75,12 @@ module Msf
           # Load a library file from given path
           #
 
-          def cmd_loadlib(*args)
+          def cmd_reload_lib(*args)
             if args.length > 0
               path = args[0]
             end
             if args.include?('-h')  || args.include?('--help')
-              cmd_loadlib_help
+              cmd_reload_lib_help
               return
             end
             if path.nil?
@@ -95,7 +95,7 @@ module Msf
             end
           end
 
-          def cmd_loadlib_tabs(str, words)
+          def cmd_reload_lib_tabs(str, words)
             tab_complete_filenames(str, words)
           end
 

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -38,6 +38,7 @@ module Msf
               "search"     => "Searches module names and descriptions",
               "show"       => "Displays modules of a given type, or all modules",
               "use"        => "Selects a module by name",
+              "loadlib"    => "Load a library file from specified path",
             }
           end
 
@@ -62,6 +63,40 @@ module Msf
 
           def local_editor
             framework.datastore['LocalEditor'] || Rex::Compat.getenv('VISUAL') || Rex::Compat.getenv('EDITOR')
+          end
+
+          def cmd_loadlib_help
+            print_line 'Usage: loadlib [lib/to/load.rb]'
+            print_line
+            print_line 'Load a library from specified path'
+          end
+
+          #
+          # Load a library file from given path
+          #
+
+          def cmd_loadlib(*args)
+            if args.length > 0
+              path = args[0]
+            end
+            if args.include?('-h')  || args.include?('--help')
+              cmd_loadlib_help
+              return
+            end
+            if path.nil?
+              print_error('Nothing to load.')
+              return
+            end
+            if path.end_with?('.rb')
+              print_status("Reloading #{path}")
+              load path
+            else
+              print_error('Only library files can be loaded.')
+            end
+          end
+
+          def cmd_loadlib_tabs(str, words)
+            tab_complete_filenames(str, words)
           end
 
           def cmd_edit_help


### PR DESCRIPTION
This PR adds a `loadlib` command that takes a ruby file as a parameter and then loads it. During the development of libraries while using msf module, `reload|rerun` commands does not reload included libraries. For this reason, it would be handy to be able to reload a single rb file while flying between different libraries and doing minor changes by using IDE.

```
msf5 > loadlib 
[-] Nothing to load.
msf5 > loadlib -h
Usage: loadlib [lib/to/load.rb]

Load a library from specified path
msf5 >
```

But I need a help for one issue. While on module usage, I'm getting following errors and have no clue how to fix em.

I've edited snmp.rb libraries and successfully reloaded it.
```
msf5 auxiliary(scanner/snmp/snmp_login) > loadlib lib/metasploit/framework/login_scanner/snmp.rb
[*] Reloading lib/metasploit/framework/login_scanner/snmp.rb
lib/metasploit/framework/login_scanner/snmp.rb:16: warning: already initialized constant Metasploit::Framework::LoginScanner::SNMP::DEFAULT_TIMEOUT
/Users/mince/Desktop/pentest/metasploit-framework/lib/metasploit/framework/login_scanner/snmp.rb:16: warning: previous definition of DEFAULT_TIMEOUT was here
lib/metasploit/framework/login_scanner/snmp.rb:17: warning: already initialized constant Metasploit::Framework::LoginScanner::SNMP::DEFAULT_PORT
/Users/mince/Desktop/pentest/metasploit-framework/lib/metasploit/framework/login_scanner/snmp.rb:17: warning: previous definition of DEFAULT_PORT was here
lib/metasploit/framework/login_scanner/snmp.rb:18: warning: already initialized constant Metasploit::Framework::LoginScanner::SNMP::DEFAULT_VERSION
/Users/mince/Desktop/pentest/metasploit-framework/lib/metasploit/framework/login_scanner/snmp.rb:18: warning: previous definition of DEFAULT_VERSION was here
lib/metasploit/framework/login_scanner/snmp.rb:19: warning: already initialized constant Metasploit::Framework::LoginScanner::SNMP::DEFAULT_QUEUE_SIZE
/Users/mince/Desktop/pentest/metasploit-framework/lib/metasploit/framework/login_scanner/snmp.rb:19: warning: previous definition of DEFAULT_QUEUE_SIZE was here
lib/metasploit/framework/login_scanner/snmp.rb:20: warning: already initialized constant Metasploit::Framework::LoginScanner::SNMP::LIKELY_PORTS
/Users/mince/Desktop/pentest/metasploit-framework/lib/metasploit/framework/login_scanner/snmp.rb:20: warning: previous definition of LIKELY_PORTS was here
lib/metasploit/framework/login_scanner/snmp.rb:21: warning: already initialized constant Metasploit::Framework::LoginScanner::SNMP::LIKELY_SERVICE_NAMES
/Users/mince/Desktop/pentest/metasploit-framework/lib/metasploit/framework/login_scanner/snmp.rb:21: warning: previous definition of LIKELY_SERVICE_NAMES was here
lib/metasploit/framework/login_scanner/snmp.rb:22: warning: already initialized constant Metasploit::Framework::LoginScanner::SNMP::PRIVATE_TYPES
/Users/mince/Desktop/pentest/metasploit-framework/lib/metasploit/framework/login_scanner/snmp.rb:22: warning: previous definition of PRIVATE_TYPES was here
lib/metasploit/framework/login_scanner/snmp.rb:23: warning: already initialized constant Metasploit::Framework::LoginScanner::SNMP::REALM_KEY
/Users/mince/Desktop/pentest/metasploit-framework/lib/metasploit/framework/login_scanner/snmp.rb:23: warning: previous definition of REALM_KEY was here
msf5 auxiliary(scanner/snmp/snmp_login) > run
```

Of course this feature most probably will be used by msf devs or maybe only me :)

Thanks to @timwr for their awesome help on IRC.