### PR TITLE
updated juniper docs

### DIFF
--- a/documentation/modules/post/juniper/gather/enum_juniper.md
+++ b/documentation/modules/post/juniper/gather/enum_juniper.md
@@ -11,6 +11,11 @@
   This module will look for the follow parameters which contain credentials:
 
   * ScreenOS
+    * admin
+    * user
+    * SNMP
+    * ppp
+    * ike
   * JunOS
     * root-authentication
     * user


### PR DESCRIPTION
Adds a few lines of documentation for the juniper config eater for screenos.

I'll land this myself.