### PR TITLE
vncinject needs a socket, disable http/s stages

### DIFF
--- a/modules/payloads/stages/windows/vncinject.rb
+++ b/modules/payloads/stages/windows/vncinject.rb
@@ -25,7 +25,9 @@ module MetasploitModule
       'Description'   => 'Inject a VNC Dll via a reflective loader (staged)',
       'Author'        => [ 'sf' ],
       'Session'       => Msf::Sessions::VncInject,
-      'Convention'    => 'sockedi -http -https'))
+      'PayloadCompat' => { 'Convention' => 'sockedi -http -https'},
+      )
+    )
 
   end
 

--- a/modules/payloads/stages/windows/x64/vncinject.rb
+++ b/modules/payloads/stages/windows/x64/vncinject.rb
@@ -22,7 +22,10 @@ module MetasploitModule
       'Name'          => 'Windows x64 VNC Server (Reflective Injection)',
       'Description'   => 'Inject a VNC Dll via a reflective loader (Windows x64) (staged)',
       'Author'        => [ 'sf' ],
-      'Session'       => Msf::Sessions::VncInject ))
+      'Session'       => Msf::Sessions::VncInject,
+      'PayloadCompat' => { 'Convention' => 'sockedi -http -https'},
+      )
+    )
 
   end
 


### PR DESCRIPTION
vncinject needs a socket to tunnel through. Disable some unusable stages. It seems there was a commit a89926b6634043caa7a42727bf87170e225c858b that tried to fix this, but I'm not sure if it worked. It was not sufficient currently.

This prevents issues like #9720 where a user is allowed to generate an unusable payload.

## Verification Steps

 - [ ] Verify reverse_http* payloads cannot be generated with vncinject:
```
./msfvenom -p windows/x64/vncinject/reverse_winhttp -f exe lhost=192.168.56.1 -o test.exe
Error: The selected platform is incompatible with the payload
```

 - [ ] Verify reverse_tcp payloads can
```
$ ./msfvenom -p windows/x64/vncinject/reverse_tcp -f exe lhost=192.168.56.1 -o test.exe
Error: The selected platform is incompatible with the payload
```