### PR TITLE
Require dependencies conditionally in msfvenom

### DIFF
--- a/msfvenom
+++ b/msfvenom
@@ -4,8 +4,6 @@
 class MsfVenomError < StandardError; end
 class HelpError < StandardError; end
 class UsageError < MsfVenomError; end
-class NoTemplateError < MsfVenomError; end
-class IncompatibleError < MsfVenomError; end
 
 require 'optparse'
 

--- a/msfvenom
+++ b/msfvenom
@@ -283,7 +283,7 @@ begin
 rescue HelpError => e
   $stderr.puts e.message
   exit(1)
-rescue MsfVenomError, Msf::OptionValidateError => e
+rescue MsfVenomError => e
   $stderr.puts "Error: #{e.message}"
   exit(1)
 end

--- a/msfvenom
+++ b/msfvenom
@@ -188,6 +188,7 @@ def parse_args(args)
       datastore[k.upcase] = v.to_s
     end
     if opts[:payload].to_s =~ /[\_\/]reverse/ and datastore['LHOST'].nil?
+      init_framework
       datastore['LHOST'] = Rex::Socket.source_address
     end
   end

--- a/msfvenom
+++ b/msfvenom
@@ -1,21 +1,6 @@
 #!/usr/bin/env ruby
 # -*- coding: binary -*-
 
-msfbase = __FILE__
-while File.symlink?(msfbase)
-  msfbase = File.expand_path(File.readlink(msfbase), File.dirname(msfbase))
-end
-
-$:.unshift(File.expand_path(File.join(File.dirname(msfbase), 'lib')))
-require 'msfenv'
-
-$:.unshift(ENV['MSF_LOCAL_LIB']) if ENV['MSF_LOCAL_LIB']
-
-require 'rex'
-require 'msf/ui'
-require 'msf/base'
-require 'msf/core/payload_generator'
-
 class MsfVenomError < StandardError; end
 class HelpError < StandardError; end
 class UsageError < MsfVenomError; end
@@ -24,12 +9,33 @@ class IncompatibleError < MsfVenomError; end
 
 require 'optparse'
 
+def require_deps
+  msfbase = __FILE__
+  while File.symlink?(msfbase)
+    msfbase = File.expand_path(File.readlink(msfbase), File.dirname(msfbase))
+  end
+
+  $:.unshift(File.expand_path(File.join(File.dirname(msfbase), 'lib')))
+  require 'msfenv'
+
+  $:.unshift(ENV['MSF_LOCAL_LIB']) if ENV['MSF_LOCAL_LIB']
+
+  require 'rex'
+  require 'msf/ui'
+  require 'msf/base'
+  require 'msf/core/payload_generator'
+
+  @framework_loaded = true
+end
+
 # Creates a new framework object.
 #
 # @note Ignores any previously cached value.
 # @param (see ::Msf::Simple::Framework.create)
 # @return [Msf::Framework]
 def init_framework(create_opts={})
+  require_deps unless @framework_loaded
+
   create_opts[:module_types] ||= [
     ::Msf::MODULE_PAYLOAD, ::Msf::MODULE_ENCODER, ::Msf::MODULE_NOP
   ]

--- a/msfvenom
+++ b/msfvenom
@@ -6,6 +6,7 @@ class HelpError < StandardError; end
 class UsageError < MsfVenomError; end
 
 require 'optparse'
+require 'timeout'
 
 def require_deps
   msfbase = __FILE__

--- a/msfvenom
+++ b/msfvenom
@@ -38,6 +38,11 @@ def init_framework(create_opts={})
   create_opts[:module_types] ||= [
     ::Msf::MODULE_PAYLOAD, ::Msf::MODULE_ENCODER, ::Msf::MODULE_NOP
   ]
+
+  create_opts[:module_types].map! do |type|
+    type = Msf.const_get("MODULE_#{type.upcase}")
+  end
+
   @framework = ::Msf::Simple::Framework.create(create_opts.merge('DisableDatabase' => true))
 end
 
@@ -219,7 +224,7 @@ def payload_stdin
 end
 
 def dump_payloads
-  init_framework(:module_types => [ ::Msf::MODULE_PAYLOAD ])
+  init_framework(:module_types => [ :payload ])
   tbl = Rex::Text::Table.new(
     'Indent'  => 4,
     'Header'  => "Framework Payloads (#{framework.stats.num_payloads} total)",
@@ -237,7 +242,7 @@ def dump_payloads
 end
 
 def dump_encoders(arch = nil)
-  init_framework(:module_types => [ ::Msf::MODULE_ENCODER ])
+  init_framework(:module_types => [ :encoder ])
   tbl = Rex::Text::Table.new(
     'Indent'  => 4,
     'Header'  => "Framework Encoders" + ((arch) ? " (architectures: #{arch})" : ""),
@@ -260,7 +265,7 @@ def dump_encoders(arch = nil)
 end
 
 def dump_nops
-  init_framework(:module_types => [ ::Msf::MODULE_NOP ])
+  init_framework(:module_types => [ :nop ])
   tbl = Rex::Text::Table.new(
     'Indent'  => 4,
     'Header'  => "Framework NOPs (#{framework.stats.num_nops} total)",


### PR DESCRIPTION
This avoids the long wait time while showing help for `msfvenom`.

- [x] Test `master` with `time ./msfvenom --help` (you can leave `--help` off)
- [x] Apply this patch
- [x] Test this branch with the same command
- [x] Make `msfvenom` fast again!

```
wvu@hiigara:~/metasploit-framework:bug/msfvenom$ time ./msfvenom --help
MsfVenom - a Metasploit standalone payload generator.
Also a replacement for msfpayload and msfencode.
Usage: ./msfvenom [options] <var=val>

Options:
    -p, --payload       <payload>    Payload to use. Specify a '-' or stdin to use custom payloads
        --payload-options            List the payload's standard options
    -l, --list          [type]       List a module type. Options are: payloads, encoders, nops, all
    -n, --nopsled       <length>     Prepend a nopsled of [length] size on to the payload
    -f, --format        <format>     Output format (use --help-formats for a list)
        --help-formats               List available formats
    -e, --encoder       <encoder>    The encoder to use
    -a, --arch          <arch>       The architecture to use
        --platform      <platform>   The platform of the payload
        --help-platforms             List available platforms
    -s, --space         <length>     The maximum size of the resulting payload
        --encoder-space <length>     The maximum size of the encoded payload (defaults to the -s value)
    -b, --bad-chars     <list>       The list of characters to avoid example: '\x00\xff'
    -i, --iterations    <count>      The number of times to encode the payload
    -c, --add-code      <path>       Specify an additional win32 shellcode file to include
    -x, --template      <path>       Specify a custom executable file to use as a template
    -k, --keep                       Preserve the template behavior and inject the payload as a new thread
    -o, --out           <path>       Save the payload
    -v, --var-name      <name>       Specify a custom variable name to use for certain output formats
        --smallest                   Generate the smallest possible payload
    -h, --help                       Show this message

real    0m0.161s
user    0m0.141s
sys     0m0.019s
wvu@hiigara:~/metasploit-framework:bug/msfvenom$
```