### PR TITLE
Add Rex::Tar

### DIFF
--- a/lib/rex.rb
+++ b/lib/rex.rb
@@ -48,8 +48,10 @@ require 'rex/text'
 require 'rex/random_identifier'
 # library for creating Powershell scripts for exploitation purposes
 require 'rex/powershell'
-# Library for processing and creating Zip compatbile archives
+# Library for processing and creating Zip compatible archives
 require 'rex/zip'
+# Library for processing and creating tar compatible archives (not really a gem)
+require 'rex/tar'
 # Library for parsing offline Windows Registry files
 require 'rex/registry'
 # Library for parsing Java serialized streams

--- a/lib/rex/tar.rb
+++ b/lib/rex/tar.rb
@@ -1,0 +1,8 @@
+# -*- coding: binary -*-
+
+require 'rubygems/package'
+
+module Rex::Tar
+  class Reader < Gem::Package::TarReader; end
+  class Writer < Gem::Package::TarWriter; end
+end

--- a/modules/auxiliary/admin/http/telpho10_credential_dump.rb
+++ b/modules/auxiliary/admin/http/telpho10_credential_dump.rb
@@ -3,8 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'rubygems/package'
-
 class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Report
   include Msf::Exploit::Remote::HttpClient
@@ -41,7 +39,7 @@ class MetasploitModule < Msf::Auxiliary
     destination = tarfile.split('.tar').first
     FileUtils.mkdir_p(destination)
     File.open(tarfile, 'rb') do |file|
-      Gem::Package::TarReader.new(file) do |tar|
+      Rex::Tar::Reader.new(file) do |tar|
         tar.each do |entry|
           dest = File.join destination, entry.full_name
           if entry.file?


### PR DESCRIPTION
# ~WIP~

This just inherits from `Gem::Package::Tar{Reader,Writer}` at the moment. We may want to build out higher-level methods than what the inherited code already provides. Or don't inherit at all.

This resolves #9651 eventually. #8539 will want this, too.