### PR TITLE
Remove unwanted 'pop RAX' from windows/x64/reverse_(win)http

### DIFF
--- a/lib/msf/core/payload/windows/x64/reverse_http.rb
+++ b/lib/msf/core/payload/windows/x64/reverse_http.rb
@@ -481,7 +481,6 @@ module Payload::Windows::ReverseHttp_x64
         test eax, eax                 ; are we done?
         jnz download_more             ; keep going
         pop rax                       ; clear up reserved space
-        pop rax                       ; realign again
 
       execute_stage:
         ret                           ; return to the stored stage address

--- a/lib/msf/core/payload/windows/x64/reverse_winhttp.rb
+++ b/lib/msf/core/payload/windows/x64/reverse_winhttp.rb
@@ -602,7 +602,6 @@ module Payload::Windows::ReverseWinHttp_x64
         test eax, eax                 ; are we done?
         jnz download_more             ; keep going
         pop rax                       ; clear up reserved space
-        pop rax                       ; realign again
 
       execute_stage:
         ret                           ; return to the stored stage address

--- a/modules/payloads/stagers/windows/x64/reverse_http.rb
+++ b/modules/payloads/stagers/windows/x64/reverse_http.rb
@@ -8,7 +8,7 @@ require 'msf/core/payload/windows/x64/reverse_http'
 
 module MetasploitModule
 
-  CachedSize = 529
+  CachedSize = 528
 
   include Msf::Payload::Stager
   include Msf::Payload::Windows

--- a/modules/payloads/stagers/windows/x64/reverse_https.rb
+++ b/modules/payloads/stagers/windows/x64/reverse_https.rb
@@ -8,7 +8,7 @@ require 'msf/core/payload/windows/x64/reverse_https'
 
 module MetasploitModule
 
-  CachedSize = 563
+  CachedSize = 562
 
   include Msf::Payload::Stager
   include Msf::Payload::Windows

--- a/modules/payloads/stagers/windows/x64/reverse_winhttp.rb
+++ b/modules/payloads/stagers/windows/x64/reverse_winhttp.rb
@@ -8,7 +8,7 @@ require 'msf/core/payload/windows/x64/reverse_winhttp'
 
 module MetasploitModule
 
-  CachedSize = 746
+  CachedSize = 745
 
   include Msf::Payload::Stager
   include Msf::Payload::Windows

--- a/modules/payloads/stagers/windows/x64/reverse_winhttps.rb
+++ b/modules/payloads/stagers/windows/x64/reverse_winhttps.rb
@@ -8,7 +8,7 @@ require 'msf/core/payload/windows/x64/reverse_winhttps'
 
 module MetasploitModule
 
-  CachedSize = 782
+  CachedSize = 781
 
   include Msf::Payload::Stager
   include Msf::Payload::Windows


### PR DESCRIPTION
This PR is related to the issue #9719.

These removed '*pop RAX*' were deleting the second and last saved addr in the stack.
Luckily, VirtualAlloc use the (not cleaned) reserved stack to stock the also returned value (addr of the allocation).
This (not cleaned) value is used by the *ret*.