### PR TITLE
Change External Module Type Names

### DIFF
--- a/lib/msf/core/modules/external/shim.rb
+++ b/lib/msf/core/modules/external/shim.rb
@@ -13,9 +13,9 @@ class Msf::Modules::External::Shim
       capture_server(mod)
     when 'dos'
       dos(mod)
-    when 'scanner.single'
+    when 'single_scanner'
       single_scanner(mod)
-    when 'scanner.multi'
+    when 'multi_scanner'
       multi_scanner(mod)
     else
       # TODO have a nice load error show up in the logs

--- a/modules/auxiliary/scanner/ssl/bleichenbacher_oracle.py
+++ b/modules/auxiliary/scanner/ssl/bleichenbacher_oracle.py
@@ -60,7 +60,7 @@ metadata = {
         {'type': 'aka', 'ref': 'ROBOT'},
         {'type': 'aka', 'ref': 'Adaptive chosen-ciphertext attack'}
      ],
-    'type': 'scanner.single',
+    'type': 'single_scanner',
     'options': {
         'rhost': {'type': 'address', 'description': 'The target address', 'required': True, 'default': None},
         'rport': {'type': 'port', 'description': 'The target port', 'required': True, 'default': 443},

--- a/modules/auxiliary/scanner/wproxy/att_open_proxy.py
+++ b/modules/auxiliary/scanner/wproxy/att_open_proxy.py
@@ -23,7 +23,7 @@ metadata = {
         {'type': 'aka', 'ref': 'SharknAT&To'},
         {'type': 'aka', 'ref': 'sharknatto'}
      ],
-    'type': 'scanner.multi',
+    'type': 'multi_scanner',
     'options': {
         'rhosts': {'type': 'address_range', 'description': 'The target address', 'required': True, 'default': None},
         'rport': {'type': 'port', 'description': 'The target port', 'required': True, 'default': 49152},


### PR DESCRIPTION
Change the a couple of external module type names
to be consistent with the template files.

## Verification

List the steps needed to make sure this thing works

- [ ] `./msfconsole`
- [ ] `use auxiliary/scanner/ssl/bleichenbacher_oracle`
- [ ] `set rhosts <rhost>`
- [ ] `run`
- [ ] **Verify** the thing does what it should
- [ ] **Verify** the thing does not do what it should not