### PR TITLE
Add batch_size option for external multi_scanner

### DIFF
--- a/lib/msf/core/modules/external/templates/multi_scanner.erb
+++ b/lib/msf/core/modules/external/templates/multi_scanner.erb
@@ -16,12 +16,13 @@ class MetasploitModule < Msf::Auxiliary
       })
 
       register_options([
+        OptInt.new('batch_size', [false, 'Number of hosts to run in each batch', 200]),
         <%= meta[:options] %>
       ])
   end
 
   def run_batch_size
-    200
+    datastore['batch_size']
   end
 
   def run_batch(ips)


### PR DESCRIPTION
Registers `batch_size` as an option for external mutli_scanner modules.

## Verification

- [x] `./msfconsole`
- [x] `use auxiliary/scanner/wproxy/att_open_proxy`
- [x] `set rhosts <rhosts>`
- [x] `set rport <rport>`
- [x] `run`
- [x] **Verify** the thing does what it's supposed to do
