### PR TITLE
msfconsole: Improve handling of CTRL-C interrupts and command-line parameters

### DIFF
--- a/lib/metasploit/framework/parsed_options/base.rb
+++ b/lib/metasploit/framework/parsed_options/base.rb
@@ -39,7 +39,13 @@ class Metasploit::Framework::ParsedOptions::Base
   #
 
   def initialize(arguments=ARGV)
-    @positional = option_parser.parse(arguments)
+    begin
+      @positional = option_parser.parse(arguments)
+    rescue OptionParser::InvalidOption
+      puts "ERROR: Invalid command line option provided."
+      puts option_parser
+      exit(1)
+    end
   end
 
   # Translates {#options} to the `application`'s config
@@ -102,20 +108,19 @@ class Metasploit::Framework::ParsedOptions::Base
   def option_parser
     @option_parser ||= OptionParser.new { |option_parser|
       option_parser.separator ''
-      option_parser.separator 'Common options'
+      option_parser.separator 'Common options:'
 
       option_parser.on(
           '-E',
           '--environment ENVIRONMENT',
           %w{development production test},
-          "The Rails environment. Will use RAIL_ENV environment variable if that is set.  " \
-          "Defaults to production if neither option not RAILS_ENV environment variable is set."
+          "Set Rails environment, defaults to RAIL_ENV environment variable or 'production'"
       ) do |environment|
         options.environment = environment
       end
 
       option_parser.separator ''
-      option_parser.separator 'Database options'
+      option_parser.separator 'Database options:'
 
       option_parser.on(
           '-M',
@@ -138,7 +143,7 @@ class Metasploit::Framework::ParsedOptions::Base
       end
 
       option_parser.separator ''
-      option_parser.separator 'Framework options'
+      option_parser.separator 'Framework options:'
 
 
       option_parser.on('-c', '-c FILE', 'Load the specified configuration file') do |file|
@@ -146,7 +151,7 @@ class Metasploit::Framework::ParsedOptions::Base
       end
 
       option_parser.on(
-          '-v',
+          '-v','-V',
           '--version',
           'Show version'
       ) do
@@ -154,7 +159,7 @@ class Metasploit::Framework::ParsedOptions::Base
       end
 
       option_parser.separator ''
-      option_parser.separator 'Module options'
+      option_parser.separator 'Module options:'
 
       option_parser.on(
           '--defer-module-loads',
@@ -166,7 +171,7 @@ class Metasploit::Framework::ParsedOptions::Base
       option_parser.on(
           '-m',
           '--module-path DIRECTORY',
-          'An additional module path'
+          'Load an additional module path'
       ) do |directory|
         options.modules.path = directory
       end

--- a/lib/metasploit/framework/parsed_options/console.rb
+++ b/lib/metasploit/framework/parsed_options/console.rb
@@ -33,7 +33,6 @@ class Metasploit::Framework::ParsedOptions::Console < Metasploit::Framework::Par
       super.tap { |option_parser|
         option_parser.banner = "Usage: #{option_parser.program_name} [options]"
 
-        option_parser.separator ''
         option_parser.separator 'Console options:'
 
         option_parser.on('-a', '--ask', "Ask before exiting Metasploit or accept 'exit -y'") do
@@ -67,7 +66,7 @@ class Metasploit::Framework::ParsedOptions::Console < Metasploit::Framework::Par
         option_parser.on(
             '-x',
             '--execute-command COMMAND',
-            'Execute the specified string as console commands (use ; for multiples)'
+            'Execute the specified console commands (use ; for multiples)'
         ) do |commands|
           options.console.commands += commands.split(/\s*;\s*/)
         end

--- a/msfconsole
+++ b/msfconsole
@@ -42,7 +42,12 @@ end
 #
 
 # @see https://github.com/rails/rails/blob/v3.2.17/railties/lib/rails/generators/rails/app/templates/script/rails#L3-L5
-require Pathname.new(__FILE__).realpath.expand_path.parent.join('config', 'boot')
-require 'metasploit/framework/command/console'
-require 'msf/core/payload_generator'
-Metasploit::Framework::Command::Console.start
+begin
+  require Pathname.new(__FILE__).realpath.expand_path.parent.join('config', 'boot')
+  require 'metasploit/framework/command/console'
+  require 'msf/core/payload_generator'
+  Metasploit::Framework::Command::Console.start
+rescue Interrupt
+  puts "\nAborting..."
+  exit(1)
+end


### PR DESCRIPTION
Inspired by @wvu, one of the trivial things that's always bugged me was `msfconsole`'s lack of command-line parameter friendliness.  If you use `-V`, you don't get a version (that was actually `-v`), but you do get an ugly error.  And if you CTRL-C, you get a really ugly, really long error.  And `-h` could do with some cleaning up.

## Verification

- [x] Run `msfconsole -V` and see the version, rather than an InvalidOption traceback.
- [x] Run `msfconsole -h` and see the slightly cleaner output (better spacing, clearer wording)
- [x] Run `msfconsole`, hit CTRL-C during loading, and notice the clean "Aborting..." message, rather than a really long traceback.