### PR TITLE
Add a log handler for external Python modules

### DIFF
--- a/lib/msf/core/modules/external/python/metasploit/module.py
+++ b/lib/msf/core/modules/external/python/metasploit/module.py
@@ -1,6 +1,41 @@
 import json
+import logging
 import os
 import sys
+
+
+class LogFormatter(logging.Formatter):
+    def __init__(self, prefix, *args, **kwargs):
+        super(LogFormatter, self).__init__(*args, **kwargs)
+        self.prefix = prefix
+
+    def format(self, record):
+        return self.prefix + record.msg
+
+
+class LogHandler(logging.Handler):
+    def emit(self, record):
+        level = 'debug'
+        if record.levelno >= logging.ERROR:
+            level = 'error'
+        elif record.levelno >= logging.WARNING:
+            level = 'warning'
+        elif record.levelno >= logging.INFO:
+            level = 'info'
+        log(self.format(record), level)
+        return
+
+    @classmethod
+    def setup(cls, level=logging.DEBUG, name=None, msg_prefix=None):
+        logger = logging.getLogger(name)
+        handler = cls()
+
+        if level is not None:
+            logger.setLevel(level)
+        if msg_prefix is not None:
+            handler.setFormatter(LogFormatter(msg_prefix))
+        logger.addHandler(handler)
+        return handler
 
 
 def log(message, level='info'):


### PR DESCRIPTION
This adds a `LogHandler` and `LogFormatter` class to the `metasploit.module` Python module. This allows external modules written in Python to keep existing logging statements from their code or imported libraries and have the information properly relayed to the Metasploit Framework.

Setup is simple, one of these two options should fit most of the use cases:
```
# Configure the Metasploit log handler for the root logger at the DEBUG level
module.LogHandler.setup()
# Do the same, but this time include the rhost:rport prefix (as commonly seen in scanner modules)
module.LogHandler.setup(msg_prefix="{0} - ".format(args['rhost']))
```

The `LogFormatter` class takes a prefix argument which is not a format string like typical `logging.Formatter` arguments are. This means we don't have to worry about escaping it or anything like that.

## Verification

- [x] Create a module for testing at `~/.msf4/modules/auxiliary/test/scanner/python_logging.py`
  - [x] Use the "Testing Module" contents below and ensure that the file is executable
- [x] Start `msfconsole`
- [x] `use auxiliary/test/scanner/python_logging`
- [x] `set RHOSTS 1.2.3.4`
- [x] Run the module and see "Hello World!" from Python's builtin logging module

### Testing Module
```
#!/usr/bin/env python
import logging
import metasploit.module as module

metadata = {
    'name': 'Test Python Logging',
    'description': '''
        Test Python's ability to utilize the builtin logging module from the
        metasploit framework.
     ''',
    'authors': ['Spencer McIntyre'],
    'date': '2018-03-20',
    'references': [],
    'type': 'single_scanner',
    'options': {},
}

def run(args):
    module.LogHandler.setup(msg_prefix="{0} - ".format(args['rhost']))
    logging.info('Hello World!')

if __name__ == '__main__':
    module.run(metadata, run)
```

### Example Output
```
metasploit-framework (S:0 J:1) > use auxiliary/test/scanner/python_logging
metasploit-framework (S:0 J:1) auxiliary(test/scanner/python_logging) > set RHOSTS 1.2.3.4
RHOSTS => 1.2.3.4
metasploit-framework (S:0 J:1) auxiliary(test/scanner/python_logging) > run

[*] [2018.03.21-10:37:32] Running for 1.2.3.4...
[*] [2018.03.21-10:37:32] 1.2.3.4 - Hello World!
[*] [2018.03.21-10:37:32] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
metasploit-framework (S:0 J:1) auxiliary(test/scanner/python_logging) > 
```