### PR TITLE
Add rank to external exploit modules

### DIFF
--- a/lib/msf/core/modules/external/shim.rb
+++ b/lib/msf/core/modules/external/shim.rb
@@ -59,6 +59,7 @@ class Msf::Modules::External::Shim
   def self.mod_meta_exploit(mod, meta = {})
     meta[:date]        = mod.meta['date'].dump
     meta[:wfsdelay]    = mod.meta['wfsdelay'] || 5
+    meta[:rank]        = mod.meta['rank'] || 'NormalRanking'
     meta[:privileged]  = mod.meta['privileged'].inspect
     meta[:platform]    = mod.meta['targets'].map do |t|
       t['platform'].dump

--- a/lib/msf/core/modules/external/templates/remote_exploit_cmd_stager.erb
+++ b/lib/msf/core/modules/external/templates/remote_exploit_cmd_stager.erb
@@ -2,7 +2,7 @@ require 'msf/core/modules/external/bridge'
 require 'msf/core/module/external'
 
 class MetasploitModule < Msf::Exploit::Remote
-  Rank = ExcellentRanking
+  Rank = <%= meta[:rank] %>
 
   include Msf::Module::External
   include Msf::Exploit::CmdStager


### PR DESCRIPTION
Adds rank information to external modules.
Changes the default to NormalRanking

## Verification

- [ ] `./msfconsole`
- [ ] `use use exploit/linux/smtp/haraka`
- [ ] `info`
- [ ] Verify module ranking
