### PR TITLE
Add synchronization around public module metadata cache methods

### DIFF
--- a/lib/msf/core/modules/metadata/store.rb
+++ b/lib/msf/core/modules/metadata/store.rb
@@ -19,6 +19,10 @@ module Msf::Modules::Metadata::Store
     load_metadata
   end
 
+  #######
+  private
+  #######
+
   #
   # Update the module meta cache disk store
   #
@@ -31,10 +35,6 @@ module Msf::Modules::Metadata::Store
       elog("Unable to update metadata store: #{e.message}")
     end
   end
-
-  #######
-  private
-  #######
 
   def load_metadata
     begin


### PR DESCRIPTION
synchronize calls to module metadata cache methods to prevent race conditions

## Verification

#### Proper metadata generation
- [x] remove file ~/.msf<version>/store/modules_metadata.pstore
- [x] Start 'msfconsole'
- [x] **Verify** that the file is generated without error

#### Proper metadata update
- [x] Stop 'msfconsole'
- [x] Add 1 or more exploit/aux modules
- [x] Start 'msfconsole'
- [x] **Verify** that there are no startup exceptions
- [x] Search for the added module
- [x] **Verify** that the modules are found
- [x] Remove the added modules and restart 'msfconsole'
- [x] Search for the added module
- [x] **Verify** that the modules are NOT found


