### PR TITLE
Make vulns and notes with -o similar to services and hosts

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -753,7 +753,6 @@ class Db
       end
     end
 
-    print_line
     if (output_file == nil)
       print_line(tbl.to_s)
     else

--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -15,7 +15,7 @@ class Db
 
   include Msf::Ui::Console::CommandDispatcher
   include Msf::Ui::Console::CommandDispatcher::Common
- 
+
   #
   # The dispatcher's name.
   #
@@ -399,7 +399,7 @@ class Db
         if (arg == '-C')
           @@hosts_columns = col_search
         end
- 
+
       when '-u','--up'
         onlyup = true
       when '-o'
@@ -883,8 +883,6 @@ class Db
             next unless ports.empty? and svcs.empty?
           end
 
-          print_status("Time: #{vuln.created_at} Vuln: host=#{host.address} name=#{vuln.name} refs=#{reflist.join(',')} #{(show_info && vuln.info) ? "info=#{vuln.info}" : ""}")
-
           if output_file
             row = []
             row << vuln.created_at
@@ -897,6 +895,8 @@ class Db
               row << ''
             end
             tbl << row
+          else
+            print_status("Time: #{vuln.created_at} Vuln: host=#{host.address} name=#{vuln.name} refs=#{reflist.join(',')} #{(show_info && vuln.info) ? "info=#{vuln.info}" : ""}")
           end
 
           if set_rhosts
@@ -1104,9 +1104,10 @@ class Db
         csv_note << note.ntype
         csv_note << note.data.inspect
       end
-      print_status(msg)
       if out_file
         csv_table << csv_note
+      else
+        print_status(msg)
       end
       if mode == :delete
         note.destroy


### PR DESCRIPTION
Now all of them will simply save the requested information to an output file if specified and will let you know where the file is when done. Previously, notes would also print out all of the notes, which just felt weird and inconsistent.  So, I fixed it.


Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Create a new workspace with `workspace -a `
- [x] scan with some module that reports notes
- [x] Run `notes` to confirm that it lists notes, and `notes -o /tmp/notes` and simply says that it saved the notes to /tmp/notes but didn't print them out.

```
msf5 > notes
[*] Time: 2018-03-07 18:22:37 UTC Note: host=10.4.29.171 type=host.virtual_machine data={:vendor=>"VMWare", :method=>"netbios"}
msf5 > notes -o /tmp/notes
[*] Notes saved as /tmp/notes
msf5 > services -o /tmp/services
[*] Wrote services to /tmp/services

```

