### PR TITLE
Formatted reg binary type to hex when displaying query results.

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
@@ -840,12 +840,16 @@ class Console::CommandDispatcher::Stdapi::Sys
           end
 
           v = open_key.query_value(value)
+          data = v.data
+          if v.type == REG_BINARY
+            data = data.unpack('H*')[0]
+          end
 
           print(
             "Key: #{key}\n" +
             "Name: #{v.name}\n" +
             "Type: #{v.type_to_s}\n" +
-            "Data: #{v.data}\n")
+            "Data: #{data}\n")
 
         when "queryclass"
           open_key = nil


### PR DESCRIPTION
Added hex formatting to registry values of type REG_BINARY that are returned with reg queryval. This was done for two reasons. The first because the returned binary value is completely unusable when printed to the screen. The second because if you are using teamserver/armitage and you return a binary registry value, teamserver may crash when it parses it.

## Verification

List the steps needed to make sure this thing works

- [x] Connect to meterpreter session `sessions -i <num>`
- [x] Run `reg queryval -k <Registry Key> -v <Binary Type Registry Value>`
- [x] Checkout readable hex values for the data

