### PR TITLE
fix -b as only options when calling msfvenom

### DIFF
--- a/msfvenom
+++ b/msfvenom
@@ -135,6 +135,7 @@ def parse_args(args)
   end
 
   opt.on('-b', '--bad-chars     <list>', String, 'The list of characters to avoid example: \'\x00\xff\'') do |b|
+    require 'rex/text'
     opts[:badchars] = Rex::Text.hex_to_raw(b)
   end
 


### PR DESCRIPTION
Fix #9763 

When parsing args for msfvemon load only `rex/text` when `-b` is found.

This addresses an issue introduced by the shift to limit the dependencies loaded early during msfvenom execution.

## Verification

List the steps needed to make sure this thing works

- [x] execute `msfvemon -b test`
- [x] **Verify** this passes thru to "reading from stdin...."
- [x] **Verify** each `--help` option can be called without code exceptions thrown
- [x] **Verify** each `--help` option taking a parameter can be called without code exceptions thrown


