### PR TITLE
Use a better error in scriptable sessions

### DIFF
--- a/lib/msf/base/sessions/scriptable.rb
+++ b/lib/msf/base/sessions/scriptable.rb
@@ -165,7 +165,7 @@ module Scriptable
       full_path = self.class.find_script_path(script_name)
 
       if full_path.nil?
-        print_error("The specified script could not be found: #{script_name}")
+        print_error("The specified #{self.type} session script could not be found: #{script_name}")
         return
       end
 


### PR DESCRIPTION
The most bizarre thing is that adding any kind of Framework print statement like `print_status` in the `find_script_path` loop causes Framework to hang indefinitely?

I've updated only the most relevant error as a result. It has been verified against both Meterpreter and a normal shell.

Resolves #9680.