### PR TITLE
detect the whitespace needed when patching meterpreter

### DIFF
--- a/lib/msf/core/payload/python/meterpreter_loader.rb
+++ b/lib/msf/core/payload/python/meterpreter_loader.rb
@@ -130,11 +130,13 @@ module Payload::Python::MeterpreterLoader
 
     # patch in any optional stageless tcp socket setup
     unless opts[:stageless_tcp_socket_setup].nil?
+      offset_string = ""
+      /(?<offset_string>\s+)# PATCH-SETUP-STAGELESS-TCP-SOCKET #/ =~ met
       socket_setup = opts[:stageless_tcp_socket_setup]
       socket_setup = socket_setup.split("\n")
-      socket_setup.map! {|line| "        #{line}\n"}
+      socket_setup.map! {|line| "#{offset_string}#{line}\n"}
       socket_setup = socket_setup.join
-      met.sub!("        # PATCH-SETUP-STAGELESS-TCP-SOCKET #", socket_setup)
+      met.sub!("#{offset_string}# PATCH-SETUP-STAGELESS-TCP-SOCKET #", socket_setup)
     end
 
     met

--- a/modules/payloads/singles/python/meterpreter_bind_tcp.rb
+++ b/modules/payloads/singles/python/meterpreter_bind_tcp.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/meterpreter_python'
 
 module MetasploitModule
 
-  CachedSize = 67206
+  CachedSize = 67210
 
   include Msf::Payload::Single
   include Msf::Payload::Python


### PR DESCRIPTION
Improve the python whitespace detection when patching the meterpreter during payload generation.

## Verification

List the steps needed to make sure this thing works

- [x] `./msfvenom -p python/meterpreter_reverse_tcp LHOST=127.0.0.1 LPORT=4444 > metPyStageless_127_4444`
- [x] `./msfvenom -p python/meterpreter/reverse_tcp LHOST=127.0.0.1 LPORT=4444 > metPy_127_4444`
- [x] Start `./msfconsole`
- [x] `use exploit/multi/handler`
- [x] `set payload python/meterpreter/reverse_tcp`
- [x] `set LHOST 127.0.0.1`
- [x] `set LPORT 4444`
- [x] `set exitonsession false`
- [x] `run -j`
- [x] `python ./metPyStageless_127_4444`
- [x] `metPy_127_4444`
- [x] **Verify** both python processes create usable sessions (Note: There is a known issue where first session connects on TCP handler from python will fail and subsequent sessions will succeed.)

