### PR TITLE
if data is nil stop reading the heartbleed socket

### DIFF
--- a/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
+++ b/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
@@ -695,7 +695,7 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     len = hdr.unpack('Cnn')[2]
-    data = get_data(len)
+    data = get_data(len) unless len.nil?
 
     unless data
       vprint_error("No SSL record contents received after #{response_timeout} seconds...")


### PR DESCRIPTION
Fix #9770, the ssl socket reads once empty may return `nil`

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use scanner/ssl/openssl_heartbleed`
- [x] `set RHOSTS 192.30.253.113` (github lets see how mad they get)
- [x] `set RPORT 443`
- [x]  `run`
- [x] **Verify** no exception is seen and not reported vulnerable
- [x]  Setup a vulnerable host and update `RHOSTS` and `RPORT`
- [x] **Verify** vulnerable is reported correctly
