### PR TITLE
Return CheckCode::Safe for unsupported x64 systems

### DIFF
--- a/modules/exploits/windows/local/ms_ndproxy.rb
+++ b/modules/exploits/windows/local/ms_ndproxy.rb
@@ -156,7 +156,8 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     if sysinfo['Architecture'] == ARCH_X64
-      return Exploit::CheckCode::Detected
+      vprint_error 'Running against 64-bit systems is not supported'
+      return CheckCode::Safe
     end
 
     handle = open_device('\\\\.\\NDProxy', 0x0, 0x0, 0x3)


### PR DESCRIPTION
This PR patches the `check` method in `modules/exploits/windows/local/ms_ndproxy.rb` to return `CheckCode::Safe` if the target system architecture is x64. The module supports x86 targets only.

Fix #9781
