### PR TITLE
Fix adding IPv6 routes with subnets or cidr masks

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -862,15 +862,14 @@ class Core
 
     action = args.shift
     case action
-
     when "add", "remove", "del"
       subnet = args.shift
-      subnet,cidr_mask = subnet.split("/")
-      if Rex::Socket.is_ipv4?(args.first)
+      subnet, cidr_mask = subnet.split("/")
+
+      if Rex::Socket.is_ip_addr?(args.first)
         netmask = args.shift
-      else
-        cidr_mask = '32' if cidr_mask.nil?
-        netmask = Rex::Socket.addr_ctoa(cidr_mask.to_i)
+      elsif Rex::Socket.is_ip_addr?(subnet)
+        netmask = Rex::Socket.addr_ctoa(cidr_mask, v6=Rex::Socket.is_ipv6?(subnet))
       end
 
       netmask = args.shift if netmask.nil?
@@ -880,8 +879,6 @@ class Core
         print_error("Missing arguments to route #{action}.")
         return false
       end
-
-      gateway = nil
 
       case gateway_name
       when /local/i
@@ -2433,8 +2430,6 @@ class Core
     finish = line_num + after
     all_lines.slice(start..finish)
   end
-
-
 
 end
 

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -869,7 +869,7 @@ class Core
       if Rex::Socket.is_ip_addr?(args.first)
         netmask = args.shift
       elsif Rex::Socket.is_ip_addr?(subnet)
-        netmask = Rex::Socket.addr_ctoa(cidr_mask, v6=Rex::Socket.is_ipv6?(subnet))
+        netmask = Rex::Socket.addr_ctoa(cidr_mask, v6: Rex::Socket.is_ipv6?(subnet))
       end
 
       netmask = args.shift if netmask.nil?


### PR DESCRIPTION
This pull request fixes the logic within the `route` command to allow IPv6 addresses to be added with either subnet or cidr masks. This requires changes introduced in rapid7/rex-socket#12 to be accepted first for the new supporting functions.

## Verification

IPv6 support for Meterpreter channels is a bit spotty, so verification simply ensures the route exists with the `local` comm.

- [x] Start `msfconsole`
- [x] `route print` See there are currently no routes defined
- [x] Check that IPv4 routes can be added by subnet or cidr mask
  - [x] `route add 192.168.0.0/16 local`
  - [x] `route add 10.0.0.0 255.0.0.0 local`
  - [x] See both IPv4 routes were added to the table successfully
- [x] Check that IPv6 routes can be added by subnet or cidr mask
  - [x] `route add fe80::/64 local`
  - [x] `route add fc00:: ffff:ffff:ffff:ffff:: local`
  - [x] See both IPv6 routes were added to the table successfully

## Prior Behavior

This PR aims to fix the errors that occur when trying to add IPv6 routes as seen in the following example.

```
metasploit-framework (S:0 J:1) > route add fe80::/64 local
[-] Missing arguments to route add.
metasploit-framework (S:0 J:1) > route add fc00:: ffff:ffff:ffff:ffff:: local
[-] Invalid gateway
metasploit-framework (S:0 J:1) > 
```