### PR TITLE
Fix #9790 exception trace

### DIFF
--- a/lib/msf/core/payload/transport_config.rb
+++ b/lib/msf/core/payload/transport_config.rb
@@ -17,7 +17,7 @@ module Msf::Payload::TransportConfig
     config
   end
 
-  def transport_config_reverse_udp(upts={})
+  def transport_config_reverse_udp(opts={})
     config =transport_config_reverse_tcp(opts)
     config[:scheme] = 'udp'
     config


### PR DESCRIPTION
Fixes variable typo.

## Verification

Same as #9790 - you'll now see a meterpreter prompt show up. It may not function which I'm blaming on UDP packet losses for now.