### PR TITLE
Fix native 'readline' (msfconsole -L) support for Ruby 2.5 onward

### DIFF
--- a/lib/rex/ui/text/input/readline.rb
+++ b/lib/rex/ui/text/input/readline.rb
@@ -26,7 +26,7 @@ begin
       self.extend(::Readline)
 
       if (tab_complete_proc)
-        ::Readline.basic_word_break_characters = "\x00"
+        ::Readline.basic_word_break_characters = ""
         ::Readline.completion_proc = tab_complete_proc
         @rl_saved_proc = tab_complete_proc
       end


### PR DESCRIPTION
This fixes native readline support for Ruby 2.5 and onward. It seems like msfconsole attempts to disable readline's basic_word_break_characters function by setting it to a null character, which now is an invalid argument. Instead just set it to empty string.

Fixes #9805

## Verification

- [x] Start `msfconsole -L`
- [x] **Verify** msfconsole starts
- [x] **Verify** tab completion works
