### PR TITLE
Add Msf::Post::Linux::Kernel lib

### DIFF
--- a/lib/msf/core/post/linux.rb
+++ b/lib/msf/core/post/linux.rb
@@ -2,5 +2,6 @@
 module Msf::Post::Linux
   require 'msf/core/post/linux/priv'
   require 'msf/core/post/linux/system'
+  require 'msf/core/post/linux/kernel'
   require 'msf/core/post/linux/busy_box'
 end

--- a/lib/msf/core/post/linux/kernel.rb
+++ b/lib/msf/core/post/linux/kernel.rb
@@ -8,14 +8,50 @@ module Kernel
   include ::Msf::Post::Common
 
   #
+  # Returns uname output
+  #
+  # @return [String]
+  #
+  def uname(opts='-a')
+    cmd_exec("uname #{opts}").to_s
+  rescue
+    raise "Failed to run uname #{opts}"
+  end
+
+  #
+  # Returns the kernel release
+  #
+  # @return [String]
+  #
+  def kernel_release
+    uname('-r')
+  end
+
+  #
   # Returns the kernel version
   #
   # @return [String]
   #
   def kernel_version
-    cmd_exec('uname -r').to_s
-  rescue
-    raise 'Could not determine kernel version'
+    uname('-v')
+  end
+
+  #
+  # Returns the kernel name
+  #
+  # @return [String]
+  #
+  def kernel_name
+    uname('-s')
+  end
+
+  #
+  # Returns the kernel hardware
+  #
+  # @return [String]
+  #
+  def kernel_hardware
+    uname('-m')
   end
 
   #

--- a/lib/msf/core/post/linux/kernel.rb
+++ b/lib/msf/core/post/linux/kernel.rb
@@ -21,10 +21,10 @@ module Kernel
   #
   # Returns the kernel modules
   #
-  # @return [String]
+  # @return [Array]
   #
   def kernel_modules
-    cmd_exec('cat /proc/modules').to_s
+    cmd_exec('cat /proc/modules').to_s.scan(/^[^ ]+/)
   rescue
     raise 'Could not determine kernel modules'
   end

--- a/lib/msf/core/post/linux/kernel.rb
+++ b/lib/msf/core/post/linux/kernel.rb
@@ -19,6 +19,17 @@ module Kernel
   end
 
   #
+  # Returns the kernel modules
+  #
+  # @return [String]
+  #
+  def kernel_modules
+    cmd_exec('cat /proc/modules').to_s
+  rescue
+    raise 'Could not determine kernel modules'
+  end
+
+  #
   # Returns true if kernel and hardware supports Supervisor Mode Access Prevention (SMAP), false if not.
   #
   # @return [Boolean]

--- a/lib/msf/core/post/linux/kernel.rb
+++ b/lib/msf/core/post/linux/kernel.rb
@@ -1,0 +1,58 @@
+# -*- coding: binary -*-
+require 'msf/core/post/common'
+
+module Msf
+class Post
+module Linux
+module Kernel
+  include ::Msf::Post::Common
+
+  #
+  # Returns the kernel version
+  #
+  # @return [String]
+  #
+  def kernel_version
+    cmd_exec('uname -r').to_s
+  rescue
+    raise 'Could not determine kernel version'
+  end
+
+  #
+  # Returns true if kernel and hardware supports Supervisor Mode Access Prevention (SMAP), false if not.
+  #
+  # @return [Boolean]
+  #
+  def smap_enabled?
+    cmd_exec('cat /proc/cpuinfo').to_s.include? 'smap'
+  rescue
+    raise 'Could not determine SMAP status'
+  end
+
+  #
+  # Returns true if kernel and hardware supports Supervisor Mode Execution Protection (SMEP), false if not.
+  #
+  # @return [Boolean]
+  #
+  def smep_enabled?
+    cmd_exec('cat /proc/cpuinfo').to_s.include? 'smep'
+  rescue
+    raise 'Could not determine SMEP status'
+  end
+
+  #
+  # Returns true if user namespaces are enabled, false if not.
+  #
+  # @return [Boolean]
+  #
+  def userns_enabled?
+    return false if cmd_exec('cat /proc/sys/user/max_user_namespaces').to_s.eql? '0'
+    cmd_exec('cat /proc/sys/kernel/unprivileged_userns_clone').to_s.eql? '1'
+  rescue
+    raise 'Could not determine userns status'
+  end
+
+end # Kernel
+end # Linux
+end # Post
+end # Msf


### PR DESCRIPTION
Since @h00die and I have been tag teaming *nix privesc lately, it was about time we also improved the *nix post libs.

This PR is largely untested. Work in progress.

Open for review.

* Should we `raise` in the unlikely event that `cmd_exec` fails? This appears to be common practice in the post libs.
* Should we use `grep` (as opposed to `cat`) to increase accuracy? `grep` isn't always in `$PATH`...
* Are there other checks which would be particularly useful?
* Some other methods such as `symlink`, `mkdir`, `protected_hardlinks?` could be useful, but would belong in the `Msf::Post::File` lib.

- [x] centos 6.5
- [x] centos 7.1
- [x] fedora 24
- [x] fedora 13
- [x] Ubuntu 14.04.5
- [x] QNX 6.5.0 SP1
- [x] Debian 8