### PR TITLE
Fix error handling when trying to delete non-existent workspace

### DIFF
--- a/lib/msf/core/db_manager/workspace.rb
+++ b/lib/msf/core/db_manager/workspace.rb
@@ -70,7 +70,7 @@ module Msf::DBManager::Workspace
     names.each do |name|
       workspace = framework.db.find_workspace(name)
       if workspace.nil?
-        error << "Workspace not found: #{name}"
+        error_msg << "Workspace not found: #{name}"
       elsif workspace.default?
         workspace.destroy
         workspace = framework.db.add_workspace(name)


### PR DESCRIPTION
At some point the handling of deleting non-existent workspaces broke:

```
$  cat > /tmp/workspace.rc
workspace -a test
workspace -d test
workspace -d test
$  ./msfconsole -qr /tmp/workspace.rc                                           
[*] Processing /tmp/workspace.rc for ERB directives.
resource (/tmp/workspace.rc)> workspace -a test
[*] Added workspace: test
resource (/tmp/workspace.rc)> workspace -d test
[*] Deleted workspace: test
[*] Switched workspace: default
resource (/tmp/workspace.rc)> workspace -d test
[-] Error while running command workspace: undefined method `<<' for nil:NilClass

Call stack:
/Users/jhart/rapid7/metasploit-framework/lib/msf/core/db_manager/workspace.rb:73:in `block in delete_workspaces'
/Users/jhart/rapid7/metasploit-framework/lib/msf/core/db_manager/workspace.rb:70:in `each'
/Users/jhart/rapid7/metasploit-framework/lib/msf/core/db_manager/workspace.rb:70:in `delete_workspaces'
/Users/jhart/rapid7/metasploit-framework/lib/metasploit/framework/data_service/proxy/core.rb:101:in `method_missing'
/Users/jhart/rapid7/metasploit-framework/lib/msf/ui/console/command_dispatcher/db.rb:152:in `cmd_workspace'
/Users/jhart/rapid7/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:548:in `run_command'
/Users/jhart/rapid7/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:510:in `block in run_single'
/Users/jhart/rapid7/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:504:in `each'
/Users/jhart/rapid7/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:504:in `run_single'
/Users/jhart/rapid7/metasploit-framework/lib/msf/ui/console/driver.rb:359:in `load_resource'
/Users/jhart/rapid7/metasploit-framework/lib/msf/ui/console/driver.rb:217:in `block in initialize'
/Users/jhart/rapid7/metasploit-framework/lib/msf/ui/console/driver.rb:216:in `each'
/Users/jhart/rapid7/metasploit-framework/lib/msf/ui/console/driver.rb:216:in `initialize'
/Users/jhart/rapid7/metasploit-framework/lib/metasploit/framework/command/console.rb:62:in `new'
/Users/jhart/rapid7/metasploit-framework/lib/metasploit/framework/command/console.rb:62:in `driver'
/Users/jhart/rapid7/metasploit-framework/lib/metasploit/framework/command/console.rb:48:in `start'
/Users/jhart/rapid7/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'
./msfconsole:49:in `<main>'
```

This PR fixes that.

## Verification

Use the RC provided in the description.  Confirm that it does not show a stack trace, and that the simple error is gracefully handled.

```
$  cat > /tmp/workspace.rc
workspace -a test
workspace -d test
workspace -d test
$  ./msfconsole -qr /tmp/workspace.rc          
[*] Processing /tmp/workspace.rc for ERB directives.
resource (/tmp/workspace.rc)> workspace -a test
[*] Added workspace: test
resource (/tmp/workspace.rc)> workspace -d test
[*] Deleted workspace: test
[*] Switched workspace: default
resource (/tmp/workspace.rc)> workspace -d test
[-] Workspace not found: test
msf5 > 
```
