### PR TITLE
Fix backgrounded aggressive exploits

### DIFF
--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -676,10 +676,10 @@ class Exploit < Msf::Module
   end
 
   #
-  # Returns if the exploit has a passive stance.
+  # Returns if the exploit has a passive stance. Aggressive exploits are always aggressive.
   #
   def passive?
-    stance.include?(Stance::Passive)
+    stance.include?(Stance::Passive) && !stance.include?(Stance::Aggressive)
   end
 
   #

--- a/lib/msf/core/exploit_driver.rb
+++ b/lib/msf/core/exploit_driver.rb
@@ -131,7 +131,7 @@ class ExploitDriver
 
     # If we are being instructed to run as a job then let's create that job
     # like a good person.
-    if (use_job or exploit.stance == Msf::Exploit::Stance::Passive)
+    if (use_job or exploit.passive?)
       # Since references to the exploit and payload will hang around for
       # awhile in the job, make sure we copy them so further changes to
       # the datastore don't alter settings in existing jobs


### PR DESCRIPTION
# ~WIP~

```
msf5 exploit(multi/misc/java_rmi_server) > pry
[1] pry(#<Msf::Modules::Mod6578706c6f69742f6d756c74692f6d6973632f6a6176615f726d695f736572766572::MetasploitModule>)> stance

=> ["aggressive", "passive"]
[2] pry(#<Msf::Modules::Mod6578706c6f69742f6d756c74692f6d6973632f6a6176615f726d695f736572766572::MetasploitModule>)> aggressive?

=> true
[3] pry(#<Msf::Modules::Mod6578706c6f69742f6d756c74692f6d6973632f6a6176615f726d695f736572766572::MetasploitModule>)> passive?

=> false
[4] pry(#<Msf::Modules::Mod6578706c6f69742f6d756c74692f6d6973632f6a6176615f726d695f736572766572::MetasploitModule>)>
```

```
msf5 exploit(multi/misc/java_rmi_server) > run

[!] You are binding to a loopback address by setting LHOST to 127.0.0.1. Did you want ReverseListenerBindAddress?
[*] Started reverse TCP handler on 127.0.0.1:4444
[*] 127.0.0.1:1099 - Using URL: http://0.0.0.0:8080/PD4c7NO8y0H
[*] 127.0.0.1:1099 - Local IP: http://192.168.1.13:8080/PD4c7NO8y0H
[*] 127.0.0.1:1099 - Server started.
[*] 127.0.0.1:1099 - Sending RMI Header...

```

Fixes #9771, a regression from #9387.