### PR TITLE
delete old feature detection code from exploit base

### DIFF
--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -599,41 +599,6 @@ class Exploit < Msf::Module
 
   ##
   #
-  # Feature detection
-  #
-  # These methods check to see if there is a derived implementation of
-  # various methods as a way of inferring whether or not a given exploit
-  # supports the feature.
-  #
-  ##
-
-  #
-  # Returns true if the exploit module supports the check method.
-  #
-  def supports_check?
-    derived_implementor?(Msf::Exploit, 'check')
-  end
-
-  #
-  # Returns true if the exploit module supports the exploit method.
-  #
-  def supports_exploit?
-    derived_implementor?(Msf::Exploit, 'exploit')
-  end
-
-  #
-  # Returns a hash of the capabilities this exploit module has support for,
-  # such as whether or not it supports check and exploit.
-  #
-  def capabilities
-    {
-      'check'       => supports_check?,
-      'exploit'     => supports_exploit?
-    }
-  end
-
-  ##
-  #
   # Getters/Setters
   #
   # Querying and set interfaces for some of the exploit's attributes.

--- a/lib/msf/core/module.rb
+++ b/lib/msf/core/module.rb
@@ -359,15 +359,6 @@ class Module
     self.module_store = {}
   end
 
-  #
-  # Checks to see if a derived instance of a given module implements a method
-  # beyond the one that is provided by a base class.  This is a pretty lame
-  # way of doing it, but I couldn't find a better one, so meh.
-  #
-  def derived_implementor?(parent, method_name)
-    (self.method(method_name).to_s.match(/#{parent}[^:]/)) ? false : true
-  end
-
   attr_writer   :platform, :references # :nodoc:
   attr_writer   :privileged # :nodoc:
   attr_writer   :license # :nodoc:

--- a/lib/msf/core/payload/stager.rb
+++ b/lib/msf/core/payload/stager.rb
@@ -215,15 +215,6 @@ module Msf::Payload::Stager
       conn.put(p)
     end
 
-    # If the stage implements the handle connection method, sleep before
-    # handling it.
-    if (derived_implementor?(Msf::Payload::Stager, 'handle_connection_stage'))
-      print_status("Sleeping before handling stage...")
-
-      # Sleep before processing the stage
-      Rex::ThreadSafe.sleep(1.5)
-    end
-
     # Give the stages a chance to handle the connection
     handle_connection_stage(conn, opts)
   end

--- a/spec/lib/msf/core/module_spec.rb
+++ b/spec/lib/msf/core/module_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe Msf::Module do
 
   it { is_expected.to respond_to :check }
   it { is_expected.to respond_to :debugging? }
-  it { is_expected.to respond_to_protected :derived_implementor? }
   it { is_expected.to respond_to :fail_with }
   it { is_expected.to respond_to :file_path }
   it { is_expected.to respond_to :framework }


### PR DESCRIPTION
This deletes some old code that apparently has been broken and somewhat unused for many years. The update to Ruby 2.5 made some of this code suddenly activate, breaking payload staging.

The 'derived_implementor?' method for modules relies on the debug output from Ruby in order to tell of a class implements a method, but the regex it used didn't work properly with any modern Ruby version until 2.5.x. This caused a random sleep to get inserted into certain payload staging operations, which actively breaks staging in certain scenarios.

This also removes some ancient module feature detection code, which appears to be entirely unused today.

## Verification

- [x] Start with Ruby 2.5 being configured in your environment
- [x] Start `./msfconsole -qx 'use multi/handler; set payload python/meterpreter/reverse_tcp; set lhost 127.0.0.1; run'`
- [x] Connect a staged python meterpreter and verify that you get a `meterpreter>` prompt.
- [x] **Verify** there are no callers for supports_check?, supports_exploit? and capabilities in the pro or msf code bases. It appears that today we assume the methods are implemented in the base class always, e.g. from lib/msf/core/module.rb:

```
  def check
    Msf::Exploit::CheckCode::Unsupported
  end
```

'check' existing is even part of the test suite apparently.