### PR TITLE
sanity check that external modules start with #! before executing

### DIFF
--- a/lib/msf/core/modules/loader/directory.rb
+++ b/lib/msf/core/modules/loader/directory.rb
@@ -43,8 +43,9 @@ class Msf::Modules::Loader::Directory < Msf::Modules::Loader::Base
           relative_entry_descendant_pathname = entry_descendant_pathname.relative_path_from(full_entry_pathname)
           relative_entry_descendant_path = relative_entry_descendant_pathname.to_s
           next if File::basename(relative_entry_descendant_path) == "example.rb"
-          next if File.executable?(entry_descendant_path) && !File.directory?(entry_descendant_path)
-
+          next if File.executable?(entry_descendant_path) &&
+            !File.directory?(entry_descendant_path) &&
+            File.read(entry_descendant_path, 2) == "#!"
           # The module_reference_name doesn't have a file extension
           module_reference_name = module_reference_name_from_path(relative_entry_descendant_path)
 

--- a/lib/msf/core/modules/loader/executable.rb
+++ b/lib/msf/core/modules/loader/executable.rb
@@ -40,7 +40,11 @@ class Msf::Modules::Loader::Executable < Msf::Modules::Loader::Base
 
       # Try to load modules from all the files in the supplied path
       Rex::Find.find(full_entry_path) do |entry_descendant_path|
-        if File.executable?(entry_descendant_path) && !File.directory?(entry_descendant_path)
+        if File.executable?(entry_descendant_path) &&
+            !File.directory?(entry_descendant_path) &&
+            # Assume that all modules are scripts for now, workaround
+            # filesystems where all files are labeled as executable.
+            File.read(entry_descendant_path, 2) == "#!"
           entry_descendant_pathname = Pathname.new(entry_descendant_path)
           relative_entry_descendant_pathname = entry_descendant_pathname.relative_path_from(full_entry_pathname)
           relative_entry_descendant_path = relative_entry_descendant_pathname.to_s


### PR DESCRIPTION
This addresses #9835 by sanity-checking that an executable module starts with a hash-bang before executing it.

## Verification

- [x] Start `msfconsole` from a filesystem where all modules are marked as executable (fat32 ?)
- [x] Verify that startup times are normal and that external modules still load, e.g.:

```
modules/exploits/linux/smtp/haraka.py
modules/auxiliary/gather/get_user_spns.py
modules/auxiliary/dos/http/slowloris.py
modules/auxiliary/dos/tcp/claymore_dos.py
modules/auxiliary/dos/smb/smb_loris.rb
modules/auxiliary/scanner/ssl/bleichenbacher_oracle.py
modules/auxiliary/scanner/wproxy/att_open_proxy.py
```

