### PR TITLE
Fix unsupported check_simple method for modules

### DIFF
--- a/lib/msf/ui/console/module_command_dispatcher.rb
+++ b/lib/msf/ui/console/module_command_dispatcher.rb
@@ -217,9 +217,16 @@ module ModuleCommandDispatcher
     end
 
     begin
-      code = instance.check_simple(
-        'LocalInput'  => driver.input,
-        'LocalOutput' => driver.output)
+      if instance.respond_to?(:check_simple)
+        code = instance.check_simple(
+          'LocalInput'  => driver.input,
+          'LocalOutput' => driver.output
+        )
+      else
+        msg = "Check failed: #{instance.type.capitalize} modules do not support check."
+        raise NotImplementedError, msg
+      end
+
       if (code and code.kind_of?(Array) and code.length > 1)
         if (code == Msf::Exploit::CheckCode::Vulnerable)
           print_good("#{peer} #{code[1]}")
@@ -239,6 +246,9 @@ module ModuleCommandDispatcher
       elog("#{e.message}\n#{e.backtrace.join("\n")}")
     rescue ::RuntimeError => e
       # Some modules raise RuntimeError but we don't necessarily care about those when we run check()
+      elog("#{e.message}\n#{e.backtrace.join("\n")}")
+    rescue ::NotImplementedError => e
+      print_error(e.message)
       elog("#{e.message}\n#{e.backtrace.join("\n")}")
     rescue ::Exception => e
       print_error("Check failed: #{e.class} #{e}")


### PR DESCRIPTION
```
17:33 < gnugnugnu> hi, I got this error when trying to check exploit, Check failed: NoMethodError undefined method `check_simple'.
17:45 < gnugnugnu> it was a payload/linux/x86/shell_reverse_tcp
```

The module command dispatcher has been modified to check if modules support `check_simple` before running it.

```
msf5 payload(linux/x86/shell_reverse_tcp) > check
[-] Check failed: Payload modules do not support check.
msf5 payload(linux/x86/shell_reverse_tcp) >
```

- [x] Test `check` with all module types
- [x] See a better error