### PR TITLE
Remove stray dlog filling framework.log

### DIFF
--- a/lib/metasploit/framework/data_service/proxy/core.rb
+++ b/lib/metasploit/framework/data_service/proxy/core.rb
@@ -96,7 +96,6 @@ class DataProxy
   # Used to bridge the local db
   #
   def method_missing(method, *args, &block)
-    dlog ("Attempting to delegate method: #{method}")
     unless @current_data_service.nil?
       @current_data_service.send(method, *args, &block)
     end


### PR DESCRIPTION
```
[04/09/2018 13:49:06] [d(0)] core: Attempting to delegate method: remove_stale_sessions
[04/09/2018 13:49:06] [d(0)] core: Attempting to delegate method: remove_stale_sessions
[04/09/2018 13:49:07] [d(0)] core: Attempting to delegate method: remove_stale_sessions
[04/09/2018 13:49:07] [d(0)] core: Attempting to delegate method: remove_stale_sessions
[04/09/2018 13:49:08] [d(0)] core: Attempting to delegate method: remove_stale_sessions
[04/09/2018 13:49:08] [d(0)] core: Attempting to delegate method: remove_stale_sessions
[04/09/2018 13:49:09] [d(0)] core: Attempting to delegate method: remove_stale_sessions
[04/09/2018 13:49:09] [d(0)] core: Attempting to delegate method: remove_stale_sessions
[04/09/2018 13:49:10] [d(0)] core: Attempting to delegate method: remove_stale_sessions
[04/09/2018 13:49:10] [d(0)] core: Attempting to delegate method: remove_stale_sessions
```