### PR TITLE
Restore services Command Functionality

### DIFF
--- a/lib/msf/core/db_manager/service.rb
+++ b/lib/msf/core/db_manager/service.rb
@@ -141,7 +141,10 @@ module Msf::DBManager::Service
 
   # Returns a list of all services in the database
   def services(opts)
-    opts.delete(:workspace) # Mdm::Service apparently doesn't have an upstream Mdm::Workspace association
+    wspace = opts.delete(:workspace) || workspace
+    if wspace.kind_of? String
+      wspace = find_workspace(wspace)
+    end
     search_term = opts.delete(:search_term)
     opts["hosts.address"] = opts.delete(:addresses)
     opts.compact!
@@ -149,9 +152,9 @@ module Msf::DBManager::Service
   ::ActiveRecord::Base.connection_pool.with_connection {
     if search_term && !search_term.empty?
       column_search_conditions = Msf::Util::DBManager.create_all_column_search_conditions(Mdm::Service, search_term)
-      Mdm::Service.includes(:host).where(opts).where(column_search_conditions).order("hosts.address, port")
+      wspace.services.includes(:host).where(opts).where(column_search_conditions).order("hosts.address, port")
     else
-      Mdm::Service.includes(:host).where(opts).order("hosts.address, port")
+      wspace.services.includes(:host).where(opts).order("hosts.address, port")
     end
   }
   end

--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -649,7 +649,7 @@ class Db
           print_line "  -c <col1,col2>    Only show the given columns"
           print_line "  -h,--help         Show this help information"
           print_line "  -s <name>         Name of the service to add"
-          print_line "  -p <port>         Port number of the service being added"
+          print_line "  -p <port>         Search for a list of ports"
           print_line "  -r <protocol>     Protocol type of the service being added [tcp|udp]"
           print_line "  -u,--up           Only show services which are up"
           print_line "  -o <file>         Send output to a file in csv format"
@@ -717,6 +717,7 @@ class Db
     each_host_range_chunk(host_ranges) do |host_search|
       break if !host_search.nil? && host_search.empty?
       opts[:addresses] = host_search
+      opts[:port] = ports if ports
       framework.db.services(framework.db.workspace, opts).each do |service|
 
         host = service.host

--- a/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
@@ -201,7 +201,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Db do
           "  -c <col1,col2>    Only show the given columns",
           "  -h,--help         Show this help information",
           "  -s <name>         Name of the service to add",
-          "  -p <port>         Port number of the service being added",
+          "  -p <port>         Search for a list of ports",
           "  -r <protocol>     Protocol type of the service being added [tcp|udp]",
           "  -u,--up           Only show services which are up",
           "  -o <file>         Send output to a file in csv format",


### PR DESCRIPTION
This PR restores the previous functionality of the services command. It will again only display the services that exist in the current workspace (#9814). It also will once again support listing specific services by port number or range with `-p` (#9852).

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Add services using `services -a -r tcp -p 80 127.0.0.1` or running `db_nmap`
- [x] Use `services` and verify the correct services are displayed
- [x] Change workspaces `workspace -a test` and run `services` again. Only the services for that workspace should be displayed.
- [x] Go back to the default workspace `workspace default`. Use the `services -p 80` flag. Only services on that port should be displayed
- [x] Search for a range of ports `services -p 1-100` or multiple ports `services -p 80,443`. Only services on those ports should be displayed.


