### PR TITLE
Fix DBManager::Service each_service method use of services method

### DIFF
--- a/lib/msf/core/db_manager/service.rb
+++ b/lib/msf/core/db_manager/service.rb
@@ -23,7 +23,7 @@ module Msf::DBManager::Service
   # service instance of each entry.
   def each_service(wspace=workspace, &block)
   ::ActiveRecord::Base.connection_pool.with_connection {
-    services(wspace).each do |service|
+    wspace.services.each do |service|
       block.call(service)
     end
   }


### PR DESCRIPTION
The services method was previously modified for Goliath to use a hash as the parameter, but the `each_service` method was passing a workspace object. These changes make the `each_service` method consistent with other `DBManager` module's `each_*` method.

The issue manifests itself when the user attempts tab-completion of options, such as rhosts.
```
msf5 > use auxiliary/scanner/smb/smb_login
msf5 auxiliary(scanner/smb/smb_login) > set rhosts
set rhosts  
msf5 auxiliary(scanner/smb/smb_login) > set rhosts Traceback (most recent call last):
    31: from ./msfconsole:49:in `<main>'
    30: from /home/msfdev/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'
    29: from /home/msfdev/metasploit-framework/lib/metasploit/framework/command/console.rb:48:in `start'
    28: from /home/msfdev/metasploit-framework/lib/rex/ui/text/shell.rb:191:in `run'
    27: from /home/msfdev/metasploit-framework/lib/rex/ui/text/shell.rb:375:in `get_input_line'
    26: from /home/msfdev/metasploit-framework/lib/rex/ui/text/input/readline.rb:100:in `pgets'
    25: from /home/msfdev/metasploit-framework/lib/rex/ui/text/input/readline.rb:162:in `readline_with_output'
    24: from /home/msfdev/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rb-readline-0.5.5/lib/rbreadline.rb:4875:in `readline'
    23: from /home/msfdev/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rb-readline-0.5.5/lib/rbreadline.rb:4853:in `readline_internal'
    22: from /home/msfdev/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rb-readline-0.5.5/lib/rbreadline.rb:4779:in `readline_internal_charloop'
    21: from /home/msfdev/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rb-readline-0.5.5/lib/rbreadline.rb:4363:in `_rl_dispatch'
    20: from /home/msfdev/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rb-readline-0.5.5/lib/rbreadline.rb:4374:in `_rl_dispatch_subseq'
    19: from /home/msfdev/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rb-readline-0.5.5/lib/rbreadline.rb:6903:in `rl_complete'
    18: from /home/msfdev/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rb-readline-0.5.5/lib/rbreadline.rb:6813:in `rl_complete_internal'
    17: from /home/msfdev/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rb-readline-0.5.5/lib/rbreadline.rb:6329:in `gen_completion_matches'
    16: from /home/msfdev/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rb-readline-0.5.5/lib/readline.rb:136:in `readline_attempted_completion_function'
    15: from /home/msfdev/metasploit-framework/lib/rex/ui/text/shell.rb:62:in `block in init_tab_complete'
    14: from /home/msfdev/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:345:in `tab_complete'
    13: from /home/msfdev/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:360:in `tab_complete_stub'
    12: from /home/msfdev/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:360:in `each'
    11: from /home/msfdev/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:371:in `block in tab_complete_stub'
    10: from /home/msfdev/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:411:in `tab_complete_helper'
     9: from /home/msfdev/metasploit-framework/lib/msf/ui/console/command_dispatcher/core.rb:1644:in `cmd_set_tabs'
     8: from /home/msfdev/metasploit-framework/lib/msf/ui/console/command_dispatcher/core.rb:2157:in `tab_complete_option'
     7: from /home/msfdev/metasploit-framework/lib/msf/ui/console/command_dispatcher/core.rb:2210:in `option_values_dispatch'
     6: from /home/msfdev/metasploit-framework/lib/msf/ui/console/command_dispatcher/core.rb:2327:in `option_values_target_addrs'
     5: from /home/msfdev/metasploit-framework/lib/metasploit/framework/data_service/proxy/core.rb:100:in `method_missing'
     4: from /home/msfdev/metasploit-framework/lib/msf/core/db_manager/service.rb:25:in `each_service'
     3: from /home/msfdev/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activerecord-4.2.10/lib/active_record/connection_adapters/abstract/connection_pool.rb:292:in `with_connection'
     2: from /home/msfdev/metasploit-framework/lib/msf/core/db_manager/service.rb:26:in `block in each_service'
     1: from /home/msfdev/metasploit-framework/lib/msf/core/db_manager/service.rb:144:in `services'
/home/msfdev/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activerecord-4.2.10/lib/active_record/persistence.rb:155:in `delete': wrong number of arguments (given 1, expected 0) (ArgumentError)
```

Thanks to @wvu-r7 for reporting the issue!

## Verification

- [x] Start `msfconsole`
- [x] **Verify** database contains one or more services using the `services` command
  - [x] If database doesn't contain any services, run commands to create service records, for example, `db_nmap -sV <host>`
- [x] `use auxiliary/scanner/smb/smb_login`
- [x] Type `set rhosts ` with a space character at the end and press the tab key
- [x] **Verify** `msfconsole` does not crash and values appear for tab-completion
