### PR TITLE
show help when no arguments are provided to `search`

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -436,6 +436,11 @@ module Msf
           # Searches modules for specific keywords
           #
           def cmd_search(*args)
+            if args.empty?
+              print_error("Argument required")
+              cmd_search_help
+              return
+            end
             match   = ''
             search_term = nil
             @@search_opts.parse(args) { |opt, idx, val|


### PR DESCRIPTION
atm if `search` is used without any argument, it prints out all the modules.
these changes will show help for search command then no arguments are provided.