### PR TITLE
Conform to JSONRPC 2.0 spec in external modules

### DIFF
--- a/lib/msf/core/modules/external/message.rb
+++ b/lib/msf/core/modules/external/message.rb
@@ -14,9 +14,9 @@ class Msf::Modules::External::Message
       m = self.new(j['method'].to_sym)
       m.params = j['params']
       m
-    elsif j['response']
+    elsif j['result']
       m = self.new(:reply)
-      m.params = j['response']
+      m.params = j['result']
       m.id = j['id']
       m
     end

--- a/lib/msf/core/modules/external/python/metasploit/module.py
+++ b/lib/msf/core/modules/external/python/metasploit/module.py
@@ -66,11 +66,11 @@ def report_vuln(ip, name, **opts):
 def run(metadata, module_callback):
     req = json.loads(os.read(0, 10000).decode("utf-8"))
     if req['method'] == 'describe':
-        rpc_send({'jsonrpc': '2.0', 'id': req['id'], 'response': metadata})
+        rpc_send({'jsonrpc': '2.0', 'id': req['id'], 'result': metadata})
     elif req['method'] == 'run':
         args = req['params']
         module_callback(args)
-        rpc_send({'jsonrpc': '2.0', 'id': req['id'], 'response': {
+        rpc_send({'jsonrpc': '2.0', 'id': req['id'], 'result': {
             'message': 'Module completed'
         }})
 

--- a/lib/msf/core/modules/external/ruby/metasploit.rb
+++ b/lib/msf/core/modules/external/ruby/metasploit.rb
@@ -30,12 +30,12 @@ module Metasploit
       req = JSON.parse($stdin.readpartial(10000), symbolize_names: true)
       if req[:method] == 'describe'
         rpc_send({
-          jsonrpc: '2.0', id: req[:id], response: metadata
+          jsonrpc: '2.0', id: req[:id], result: metadata
         })
       elsif req[:method] == 'run'
         callback.call req[:params]
         rpc_send({
-          jsonrpc: '2.0', id: req[:id], response: {
+          jsonrpc: '2.0', id: req[:id], result: {
             message: 'Module completed'
           }
         })


### PR DESCRIPTION
Responses to queries had a `response` field instead of the required
`result` field.

http://www.jsonrpc.org/specification#response_object

Verification
========

- [x] External modules should still load and run ex:
- [x] Follow the steps in #8178
- [x] Follow the steps in #9748