### PR TITLE
Remote notes create, read, update and delete

### DIFF
--- a/lib/metasploit/framework/data_service/proxy/note_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/note_data_proxy.rb
@@ -9,6 +9,11 @@ module NoteDataProxy
     end
   end
 
+  # TODO: like other *DataProxy modules this currently skips the "find" part
+  def find_or_create_note(opts)
+    report_note(opts)
+  end
+
   def report_note(opts)
     begin
       data_service = self.get_data_service()

--- a/lib/metasploit/framework/data_service/proxy/note_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/note_data_proxy.rb
@@ -1,10 +1,38 @@
 module NoteDataProxy
+
+  def notes(opts)
+    begin
+      data_service = self.get_data_service()
+      data_service.notes(opts)
+    rescue Exception => e
+      self.log_error(e, "Problem retrieving notes")
+    end
+  end
+
   def report_note(opts)
     begin
       data_service = self.get_data_service()
       data_service.report_note(opts)
     rescue  Exception => e
       self.log_error(e, "Problem reporting note")
+    end
+  end
+
+  def update_note(opts)
+    begin
+      data_service = self.get_data_service()
+      data_service.update_note(opts)
+    rescue Exception => e
+      self.log_error(e, "Problem updating note")
+    end
+  end
+
+  def delete_note(opts)
+    begin
+      data_service = self.get_data_service()
+      data_service.delete_note(opts)
+    rescue Exception => e
+      self.log_error(e, "Problem deleting note")
     end
   end
 end

--- a/lib/metasploit/framework/data_service/remote/http/remote_note_data_service.rb
+++ b/lib/metasploit/framework/data_service/remote/http/remote_note_data_service.rb
@@ -4,8 +4,27 @@ module RemoteNoteDataService
   include ResponseDataHelper
 
   NOTE_API_PATH = '/api/v1/notes'
+  NOTE_MDM_CLASS = 'Mdm::Note'
+
+  def notes(opts)
+    json_to_mdm_object(self.get_data(NOTE_API_PATH, nil, opts), NOTE_MDM_CLASS, [])
+  end
 
   def report_note(opts)
-    self.post_data_async(NOTE_API_PATH, opts)
+    # self.post_data_async(NOTE_API_PATH, opts)
+    json_to_mdm_object(self.post_data(NOTE_API_PATH, opts), NOTE_MDM_CLASS, []).first
+  end
+
+  def update_note(opts)
+    path = NOTE_API_PATH
+    if opts && opts[:id]
+      id = opts.delete(:id)
+      path = "#{NOTE_API_PATH}/#{id}"
+    end
+    json_to_mdm_object(self.put_data(path, opts), NOTE_MDM_CLASS, [])
+  end
+
+  def delete_note(opts)
+    json_to_mdm_object(self.delete_data(NOTE_API_PATH, opts), NOTE_MDM_CLASS, [])
   end
 end

--- a/lib/metasploit/framework/data_service/remote/http/remote_note_data_service.rb
+++ b/lib/metasploit/framework/data_service/remote/http/remote_note_data_service.rb
@@ -11,7 +11,6 @@ module RemoteNoteDataService
   end
 
   def report_note(opts)
-    # self.post_data_async(NOTE_API_PATH, opts)
     json_to_mdm_object(self.post_data(NOTE_API_PATH, opts), NOTE_MDM_CLASS, []).first
   end
 

--- a/lib/metasploit/framework/data_service/stubs/note_data_service.rb
+++ b/lib/metasploit/framework/data_service/stubs/note_data_service.rb
@@ -1,7 +1,19 @@
 module NoteDataService
 
+  def notes(opts)
+    raise 'NoteDataService#notes is not implemented'
+  end
+
   def report_note(opts)
     raise 'NoteDataService#report_note is not implemented'
+  end
+
+  def update_note(opts)
+    raise 'NoteDataService#update_note is not implemented'
+  end
+
+  def delete_note(opts)
+    raise 'NoteDataService#delete_note is not implemented'
   end
 
 end

--- a/lib/metasploit/framework/data_service/stubs/note_data_service.rb
+++ b/lib/metasploit/framework/data_service/stubs/note_data_service.rb
@@ -1,19 +1,19 @@
 module NoteDataService
 
   def notes(opts)
-    raise 'NoteDataService#notes is not implemented'
+    raise NotImplementedError, 'NoteDataService#notes is not implemented'
   end
 
   def report_note(opts)
-    raise 'NoteDataService#report_note is not implemented'
+    raise NotImplementedError, 'NoteDataService#report_note is not implemented'
   end
 
   def update_note(opts)
-    raise 'NoteDataService#update_note is not implemented'
+    raise NotImplementedError, 'NoteDataService#update_note is not implemented'
   end
 
   def delete_note(opts)
-    raise 'NoteDataService#delete_note is not implemented'
+    raise NotImplementedError, 'NoteDataService#delete_note is not implemented'
   end
 
 end

--- a/lib/msf/core/db_manager/http/servlet/note_servlet.rb
+++ b/lib/msf/core/db_manager/http/servlet/note_servlet.rb
@@ -4,18 +4,70 @@ module NoteServlet
     '/api/v1/notes'
   end
 
+  def self.api_path_with_id
+    "#{NoteServlet.api_path}/?:id?"
+  end
+
   def self.registered(app)
+    app.get NoteServlet.api_path_with_id, &get_note
     app.post NoteServlet.api_path, &report_note
+    app.put NoteServlet.api_path_with_id, &update_note
+    app.delete NoteServlet.api_path, &delete_note
   end
 
   #######
   private
   #######
 
+  def self.get_note
+    lambda {
+      begin
+        opts = parse_json_request(request, false)
+        data = get_db.notes(params.symbolize_keys)
+        includes = [:host]
+        set_json_response(data, includes)
+      rescue Exception => e
+        set_error_on_response(e)
+      end
+    }
+  end
+
   def self.report_note
     lambda {
-        job = lambda { |opts|  get_db().report_note(opts) }
+      begin
+        job = lambda { |opts|
+          get_db.report_note(opts)
+        }
         exec_report_job(request, &job)
+      rescue Exception => e
+        set_error_on_response(e)
+      end
+    }
+  end
+
+  def self.update_note
+    lambda {
+      begin
+        opts = parse_json_request(request, false)
+        tmp_params = params.symbolize_keys
+        opts[:id] = tmp_params[:id] if tmp_params[:id]
+        data = get_db.update_note(opts)
+        set_json_response(data)
+      rescue Exception => e
+        set_error_on_response(e)
+      end
+    }
+  end
+
+  def self.delete_note
+    lambda {
+      begin
+        opts = parse_json_request(request, false)
+        data = get_db.delete_note(opts)
+        set_json_response(data)
+      rescue Exception => e
+        set_error_on_response(e)
+      end
     }
   end
 

--- a/lib/msf/core/db_manager/note.rb
+++ b/lib/msf/core/db_manager/note.rb
@@ -31,8 +31,27 @@ module Msf::DBManager::Note
 
       search_term = opts.delete(:search_term)
       if search_term && !search_term.empty?
-        column_search_conditions = Msf::Util::DBManager.create_all_column_search_conditions(Mdm::Note, search_term)
-        wspace.notes.includes(:host).where(opts).where(column_search_conditions)
+        all_columns_except_data_expression = Msf::Util::DBManager.create_all_column_search_conditions(Mdm::Note, search_term, ["data"])
+
+        # The data column is serialized so an Arel regex-based search is created following
+        # somewhat from the Mdm search scope. If data appears to be serialized it is decoded for the regex match.
+        # The Mdm search scope used 'BAh7%' which doesn't appears to result in matches against simple string
+        # values that have been serialized, so this was changed to 'BAh%'. The decoded binary data is then
+        # converted to a text value to be used for the regex match.
+        serialized_prefix = 'BAh%'
+        re_search_term = "(?mi)#{search_term}"
+        arel_table = Mdm::Note.arel_table
+        regex_data = Arel::Nodes::Regexp.new(arel_table[:data], Arel::Nodes.build_quoted(re_search_term))
+        data_no_base64_expression = arel_table.grouping(arel_table[:data].does_not_match(serialized_prefix).and(regex_data))
+
+        decode_func = Arel::Nodes::NamedFunction.new("decode", [arel_table[:data], Arel::Nodes.build_quoted('base64')])
+        convert_from_func = Arel::Nodes::NamedFunction.new("convert_from", [decode_func, Arel::Nodes.build_quoted('UTF8')])
+        regex_data_base64 = Arel::Nodes::Regexp.new(convert_from_func, Arel::Nodes.build_quoted(re_search_term))
+        data_base64_expression = arel_table.grouping(arel_table[:data].matches(serialized_prefix).and(regex_data_base64))
+
+        data_column_expression = data_no_base64_expression.or(data_base64_expression)
+        column_search_expression = all_columns_except_data_expression.or(data_column_expression)
+        wspace.notes.includes(:host).where(opts).where(column_search_expression)
       else
         wspace.notes.includes(:host).where(opts)
       end

--- a/lib/msf/core/db_manager/note.rb
+++ b/lib/msf/core/db_manager/note.rb
@@ -124,13 +124,7 @@ module Msf::DBManager::Note
     elsif opts[:service] and opts[:service].kind_of? ::Mdm::Service
       service = opts[:service]
     end
-=begin
-    if host
-      host.updated_at = host.created_at
-      host.state      = HostState::Alive
-      host.save!
-    end
-=end
+
     ntype  = opts.delete(:type) || opts.delete(:ntype) || (raise RuntimeError, "A note :type or :ntype is required")
     data   = opts[:data]
     note   = nil

--- a/lib/msf/core/db_manager/note.rb
+++ b/lib/msf/core/db_manager/note.rb
@@ -30,31 +30,14 @@ module Msf::DBManager::Note
     ::ActiveRecord::Base.connection_pool.with_connection {
 
       search_term = opts.delete(:search_term)
+      results = wspace.notes.includes(:host).where(opts)
       if search_term && !search_term.empty?
-        all_columns_except_data_expression = Msf::Util::DBManager.create_all_column_search_conditions(Mdm::Note, search_term, ["data"])
-
-        # The data column is serialized so an Arel regex-based search is created following
-        # somewhat from the Mdm search scope. If data appears to be serialized it is decoded for the regex match.
-        # The Mdm search scope used 'BAh7%' which doesn't appears to result in matches against simple string
-        # values that have been serialized, so this was changed to 'BAh%'. The decoded binary data is then
-        # converted to a text value to be used for the regex match.
-        serialized_prefix = 'BAh%'
-        re_search_term = "(?mi)#{search_term}"
-        arel_table = Mdm::Note.arel_table
-        regex_data = Arel::Nodes::Regexp.new(arel_table[:data], Arel::Nodes.build_quoted(re_search_term))
-        data_no_base64_expression = arel_table.grouping(arel_table[:data].does_not_match(serialized_prefix).and(regex_data))
-
-        decode_func = Arel::Nodes::NamedFunction.new("decode", [arel_table[:data], Arel::Nodes.build_quoted('base64')])
-        convert_from_func = Arel::Nodes::NamedFunction.new("convert_from", [decode_func, Arel::Nodes.build_quoted('UTF8')])
-        regex_data_base64 = Arel::Nodes::Regexp.new(convert_from_func, Arel::Nodes.build_quoted(re_search_term))
-        data_base64_expression = arel_table.grouping(arel_table[:data].matches(serialized_prefix).and(regex_data_base64))
-
-        data_column_expression = data_no_base64_expression.or(data_base64_expression)
-        column_search_expression = all_columns_except_data_expression.or(data_column_expression)
-        wspace.notes.includes(:host).where(opts).where(column_search_expression)
-      else
-        wspace.notes.includes(:host).where(opts)
+        re_search_term = /#{search_term}/mi
+        results = results.select { |note|
+          note.attribute_names.any? { |a| note[a.intern].to_s.match(re_search_term) }
+        }
       end
+      results
     }
   end
 

--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -1010,7 +1010,7 @@ class Db
         range.each { |addr|
           note = framework.db.find_or_create_note(host: addr, type: type, data: data)
           break if not note
-          print_status("Time: #{note.created_at} Note: host=#{note.host.address} type=#{note.ntype} data=#{note.data}")
+          print_status("Time: #{note.created_at} Note: host=#{addr} type=#{note.ntype} data=#{note.data}")
         }
       }
       return

--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -923,6 +923,7 @@ class Db
     print_line "  -R,--rhosts               Set RHOSTS from the results of the search"
     print_line "  -S,--search               Search string to filter by"
     print_line "  -o,--output               Save the notes to a csv file"
+    print_line "  -O <column>               Order rows by specified column number"
     print_line
     print_line "Examples:"
     print_line "  notes --add -t apps -n 'winzip' 10.1.1.34 10.1.20.41"
@@ -970,6 +971,11 @@ class Db
         search_term = args.shift
       when '-o', '--output'
         output_file = args.shift
+      when '-O'
+        if (order_by = args.shift.to_i - 1) < 0
+          print_error('Please specify a column number starting from 1')
+          return
+        end
       when '-u', '--update'  # TODO: This is currently undocumented because it's not officially supported.
         mode = :update
       when '-h', '--help'
@@ -1043,7 +1049,8 @@ class Db
     table = Rex::Text::Table.new(
       'Header'  => 'Notes',
       'Indent'  => 1,
-      'Columns' => ['Time', 'Host', 'Service', 'Port', 'Protocol', 'Type', 'Data']
+      'Columns' => ['Time', 'Host', 'Service', 'Port', 'Protocol', 'Type', 'Data'],
+      'SortIndex' => order_by
     )
 
     matched_note_ids = []

--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -923,12 +923,11 @@ class Db
     print_line "  -R,--rhosts               Set RHOSTS from the results of the search"
     print_line "  -S,--search               Search string to filter by"
     print_line "  -o,--output               Save the notes to a csv file"
-    print_line "  --sort <field1,field2>    Fields to sort by (case sensitive)"
     print_line
     print_line "Examples:"
     print_line "  notes --add -t apps -n 'winzip' 10.1.1.34 10.1.20.41"
     print_line "  notes -t smb.fingerprint 10.1.1.34 10.1.20.41"
-    print_line "  notes -S 'nmap.nse.(http|rtsp)' --sort type,output"
+    print_line "  notes -S 'nmap.nse.(http|rtsp)'"
     print_line
   end
 
@@ -969,8 +968,6 @@ class Db
         set_rhosts = true
       when '-S', '--search'
         search_term = args.shift
-      when '--sort'
-        sort_term = args.shift
       when '-o', '--output'
         output_file = args.shift
       when '-u', '--update'  # TODO: This is currently undocumented because it's not officially supported.
@@ -1039,42 +1036,6 @@ class Db
         opts = {hosts: {address: host_search}, workspace: framework.db.workspace, search_term: search_term}
         opts[:ntype] = types if mode != :update && types && !types.empty?
         note_list.concat(framework.db.notes(opts))
-      end
-    end
-
-    # Sort the notes based on the sort_term provided
-    if sort_term != nil
-      sort_terms = sort_term.split(",")
-      note_list.sort_by! do |note|
-        orderlist = []
-        sort_terms.each do |term|
-          term = "ntype" if term == "type"
-          term = "created_at" if term == "Time"
-          if term == nil
-            orderlist << ""
-          elsif term == "service"
-            if note.service != nil
-              orderlist << make_sortable(note.service.name)
-            end
-          elsif term == "port"
-            if note.service != nil
-              orderlist << make_sortable(note.service.port)
-            end
-          elsif term == "output"
-            orderlist << make_sortable(note.data["output"])
-          elsif note.respond_to?(term, true)
-            orderlist << make_sortable(note.send(term))
-          elsif note.respond_to?(term.to_sym, true)
-            orderlist << make_sortable(note.send(term.to_sym))
-          elsif note.respond_to?("data", true) && note.send("data").respond_to?(term, true)
-            orderlist << make_sortable(note.send("data").send(term))
-          elsif note.respond_to?("data", true) && note.send("data").respond_to?(term.to_sym, true)
-            orderlist << make_sortable(note.send("data").send(term.to_sym))
-          else
-            orderlist << ""
-          end
-        end
-        orderlist
       end
     end
 

--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -1130,22 +1130,6 @@ class Db
     end
   end
 
-  def make_sortable(input)
-    case input
-    when String
-      input = input.downcase
-    when Integer
-      input = "%016" % input
-    when Time
-      input = input.strftime("%Y%m%d%H%M%S%L")
-    when NilClass
-      input = ""
-    else
-      input = input.inspect.downcase
-    end
-    input
-  end
-
   def cmd_loot_help
     print_line "Usage: loot <options>"
     print_line " Info: loot [-h] [addr1 addr2 ...] [-t <type1,type2>]"

--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -947,11 +947,11 @@ class Db
 
     while (arg = args.shift)
       case arg
-      when '-a','--add'
+      when '-a', '--add'
         mode = :add
-      when '-d','--delete'
+      when '-d', '--delete'
         mode = :delete
-      when '-n','--note'
+      when '-n', '--note'
         data = args.shift
         if(!data)
           print_error("Can't make a note with no data")
@@ -967,12 +967,12 @@ class Db
       when '-R', '--rhosts'
         set_rhosts = true
       when '-S', '--search'
-        search_term = /#{args.shift}/nmi
+        search_term = args.shift
       when '--sort'
         sort_term = args.shift
       when '-o', '--output'
         out_file = args.shift
-      when '-h','--help'
+      when '-h', '--help'
         cmd_notes_help
         return
       else

--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -918,10 +918,10 @@ class Db
     print_line "  -a,--add                  Add a note to the list of addresses, instead of listing"
     print_line "  -d,--delete               Delete the hosts instead of searching"
     print_line "  -n,--note <data>          Set the data for a new note (only with -a)"
-    print_line "  -t <type1,type2>          Search for a list of types"
+    print_line "  -t,--type <type1,type2>   Search for a list of types, or set single type for add"
     print_line "  -h,--help                 Show this help information"
     print_line "  -R,--rhosts               Set RHOSTS from the results of the search"
-    print_line "  -S,--search               Regular expression to match for search"
+    print_line "  -S,--search               Search string to filter by"
     print_line "  -o,--output               Save the notes to a csv file"
     print_line "  --sort <field1,field2>    Fields to sort by (case sensitive)"
     print_line
@@ -943,7 +943,8 @@ class Db
     host_ranges = []
     rhosts      = []
     search_term = nil
-    out_file    = nil
+    output_file = nil
+    delete_count = 0
 
     while (arg = args.shift)
       case arg
@@ -957,7 +958,7 @@ class Db
           print_error("Can't make a note with no data")
           return
         end
-      when '-t'
+      when '-t', '--type'
         typelist = args.shift
         if(!typelist)
           print_error("Invalid type list")
@@ -971,7 +972,9 @@ class Db
       when '--sort'
         sort_term = args.shift
       when '-o', '--output'
-        out_file = args.shift
+        output_file = args.shift
+      when '-u', '--update'  # TODO: This is currently undocumented because it's not officially supported.
+        mode = :update
       when '-h', '--help'
         cmd_notes_help
         return
@@ -984,39 +987,58 @@ class Db
     end
 
     if mode == :add
-      if types.nil? or types.size != 1
-        print_error("Exactly one note type is required")
+      if host_ranges.compact.empty?
+        print_error("Host address or range required")
         return
       end
+
+      if types && types.size != 1
+        print_error("Exactly one type is required")
+        return
+      end
+
+      if data.nil?
+        print_error("Data required")
+        return
+      end
+
       type = types.first
       host_ranges.each { |range|
         range.each { |addr|
-          host = framework.db.find_or_create_host(:host => addr)
-          break if not host
-          note = framework.db.find_or_create_note(:host => host, :type => type, :data => data)
+          note = framework.db.find_or_create_note(host: addr, type: type, data: data)
           break if not note
-          print_status("Time: #{note.created_at} Note: host=#{host.address} type=#{note.ntype} data=#{note.data}")
+          print_status("Time: #{note.created_at} Note: host=#{note.host.address} type=#{note.ntype} data=#{note.data}")
         }
       }
       return
     end
 
-    note_list = []
-    delete_count = 0
-    # No host specified - collect all notes
-    if host_ranges.empty?
-      note_list = framework.db.notes.dup
-    # Collect notes of specified hosts
-    else
-      each_host_range_chunk(host_ranges) do |host_search|
-        framework.db.hosts(framework.db.workspace, false, host_search).each do |host|
-          note_list.concat(host.notes)
-        end
+    if mode == :update
+      if types && types.size != 1
+        print_error("Exactly one type is required")
+        return
+      end
+
+      if !types && !data
+        print_error("Update requires data or type")
+        return
       end
     end
-    if search_term
-      note_list = note_list.select do |n|
-        n.attribute_names.any? { |a| n[a.intern].to_s.match(search_term) }
+
+    note_list = []
+    if host_ranges.compact.empty?
+      # No host specified - collect all notes
+      opts = {search_term: search_term}
+      opts[:ntype] = types if mode != :update && types && !types.empty?
+      note_list = framework.db.notes(opts)
+    else
+      # Collect notes of specified hosts
+      each_host_range_chunk(host_ranges) do |host_search|
+        break if !host_search.nil? && host_search.empty?
+
+        opts = {hosts: {address: host_search}, workspace: framework.db.workspace, search_term: search_term}
+        opts[:ntype] = types if mode != :update && types && !types.empty?
+        note_list.concat(framework.db.notes(opts))
       end
     end
 
@@ -1057,60 +1079,75 @@ class Db
     end
 
     # Now display them
-    csv_table = Rex::Text::Table.new(
+    table = Rex::Text::Table.new(
       'Header'  => 'Notes',
       'Indent'  => 1,
       'Columns' => ['Time', 'Host', 'Service', 'Port', 'Protocol', 'Type', 'Data']
     )
 
+    matched_note_ids = []
     note_list.each do |note|
-      next if(types and types.index(note.ntype).nil?)
-      csv_note = []
-      msg = "Time: #{note.created_at} Note:"
-      csv_note << note.created_at if out_file
-      if (note.host)
+      if mode == :update
+        begin
+          update_opts = {id: note.id}
+          if types
+            note.ntype = types.first
+            update_opts[:ntype] = types.first
+          end
+
+          if data
+            note.data = data
+            update_opts[:data] = data
+          end
+
+          framework.db.update_note(update_opts)
+        rescue Exception => e
+          elog "There was an error updating note with ID #{note.id}: #{e.message}"
+          next
+        end
+      end
+
+      matched_note_ids << note.id
+
+      row = []
+      row << note.created_at
+
+      if note.host
         host = note.host
-        msg << " host=#{note.host.address}"
-        csv_note << note.host.address if out_file
+        row << host.address
         if set_rhosts
-          addr = (host.scope ? host.address + '%' + host.scope : host.address )
+          addr = (host.scope ? host.address + '%' + host.scope : host.address)
           rhosts << addr
         end
       else
-        csv_note << ''
+        row << ''
       end
-      if (note.service)
-        msg << " service=#{note.service.name}" if note.service.name
-        csv_note << note.service.name || '' if out_file
-        msg << " port=#{note.service.port}" if note.service.port
-        csv_note << note.service.port || '' if out_file
-        msg << " protocol=#{note.service.proto}" if note.service.proto
-        csv_note << note.service.proto || '' if out_file
+
+      if note.service
+        row << note.service.name || ''
+        row << note.service.port || ''
+        row << note.service.proto || ''
       else
-        if out_file
-          csv_note << '' # For the Service field
-          csv_note << '' # For the Port field
-          csv_note << '' # For the Protocol field
-        end
+        row << '' # For the Service field
+        row << '' # For the Port field
+        row << '' # For the Protocol field
       end
-      msg << " type=#{note.ntype} data=#{note.data.inspect}"
-      if out_file
-        csv_note << note.ntype
-        csv_note << note.data.inspect
-      end
-      if out_file
-        csv_table << csv_note
-      else
-        print_status(msg)
-      end
-      if mode == :delete
-        note.destroy
-        delete_count += 1
-      end
+
+      row << note.ntype
+      row << note.data.inspect
+      table << row
     end
 
-    if out_file
-      save_csv_notes(out_file, csv_table)
+    if mode == :delete
+      result = framework.db.delete_note(ids: matched_note_ids)
+      delete_count = result.size
+    end
+
+    if output_file
+      save_csv_notes(output_file, table)
+    else
+      print_line
+      print_line(table.to_s)
     end
 
     # Finally, handle the case where the user wants the resulting list
@@ -1121,12 +1158,12 @@ class Db
   }
   end
 
-  def save_csv_notes(fpath, csv_table)
+  def save_csv_notes(fpath, table)
     begin
       File.open(fpath, 'wb') do |f|
-        f.write(csv_table.to_csv)
+        f.write(table.to_csv)
       end
-      print_status("Notes saved as #{fpath}")
+      print_status("Wrote notes to #{fpath}")
     rescue Errno::EACCES => e
       print_error("Unable to save notes. #{e.message}")
     end

--- a/lib/msf/util/db_manager.rb
+++ b/lib/msf/util/db_manager.rb
@@ -5,13 +5,19 @@ module Msf
       #
       # @param model - An ActiveRecord model object
       # @param search - A string regex search
+      # @param column_name_skip_list - An array of strings containing column names to skip
       # @return Arel::Nodes::Or object that represents a search of all of the model's columns
-      def self.create_all_column_search_conditions(model, search)
+      def self.create_all_column_search_conditions(model, search, column_name_skip_list=nil)
         search = "(?mi)#{search}"
-        condition_set = model.columns.map do |column|
+        # remove skip columns
+        columns = model.columns.reject { |column|
+          column_name_skip_list && column_name_skip_list.include?(column.name)
+        }
+
+        condition_set = columns.map { |column|
           Arel::Nodes::Regexp.new(Arel::Nodes::NamedFunction.new("CAST", [model.arel_table[column.name].as("TEXT")]),
                                   Arel::Nodes.build_quoted(search))
-        end
+        }
         condition_set.reduce { |conditions, condition| conditions.or(condition).expr }
       end
     end

--- a/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
@@ -51,7 +51,6 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Db do
   it { is_expected.to respond_to :db_parse_db_uri_postgresql }
   it { is_expected.to respond_to :deprecated_commands }
   it { is_expected.to respond_to :each_host_range_chunk }
-  it { is_expected.to respond_to :make_sortable }
   it { is_expected.to respond_to :name }
   it { is_expected.to respond_to :set_rhosts_from_addrs }
 

--- a/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
@@ -177,6 +177,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Db do
           "  -R,--rhosts               Set RHOSTS from the results of the search",
           "  -S,--search               Search string to filter by",
           "  -o,--output               Save the notes to a csv file",
+          "  -O <column>               Order rows by specified column number",
           "Examples:",
           "  notes --add -t apps -n 'winzip' 10.1.1.34 10.1.20.41",
           "  notes -t smb.fingerprint 10.1.1.34 10.1.20.41",

--- a/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
@@ -173,16 +173,15 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Db do
           "  -a,--add                  Add a note to the list of addresses, instead of listing",
           "  -d,--delete               Delete the hosts instead of searching",
           "  -n,--note <data>          Set the data for a new note (only with -a)",
-          "  -t <type1,type2>          Search for a list of types",
+          "  -t,--type <type1,type2>   Search for a list of types, or set single type for add",
           "  -h,--help                 Show this help information",
           "  -R,--rhosts               Set RHOSTS from the results of the search",
-          "  -S,--search               Regular expression to match for search",
+          "  -S,--search               Search string to filter by",
           "  -o,--output               Save the notes to a csv file",
-          "  --sort <field1,field2>    Fields to sort by (case sensitive)",
           "Examples:",
           "  notes --add -t apps -n 'winzip' 10.1.1.34 10.1.20.41",
           "  notes -t smb.fingerprint 10.1.1.34 10.1.20.41",
-          "  notes -S 'nmap.nse.(http|rtsp)' --sort type,output"
+          "  notes -S 'nmap.nse.(http|rtsp)'"
         ]
 
       end


### PR DESCRIPTION
Adds support for notes create, read, update and delete operations when using a remote data store. An undocumented `notes` command option for update was added:

* `notes --update` - Update notes type and data for those that match the address range and search term

The `notes` sort option was removed as it has failed to work for a awhile (in branch 4.x `undefined method 'sort_by!' for #<Mdm::Note::ActiveRecord_Associations_CollectionProxy:0x00007fd1d9c27bc8>`), in addition, there doesn't seem to be a universal approach to sorting the complex data that might appear in the data field. This option was replaced with the `-O` option that allows for a simple ordering of rows by the specified column number.

Task: MS-3061

## Verification

- [x] Start `msfconsole`
- [x] Start `msfdb_ws` on a remote system
- [x] Connect to the remote data service `data_services --add <address>`
- [x] Create notes using the `notes --add` command. For example, `notes --add --note <data> --type <type> <address>`
- [x] Create a note via a module or operation that calls the `report_note` method. For example, `db_import <xml>` using the XML output from an Nmap Scripting Engine (NSE) script (`nmap -oX <xml> --script http-trace -d <address>`)
- [x] **Verify** the output of `notes` command show the newly added notes
- [x] Update notes
  - [x] Update one or more note's type: `notes --search <original-type> --update --type <new-type>`
  - [x] Update one or more note's data: `notes --search <search-term> --update --note <new-note-data>`
  - [x] Update one or more note's type and data: `notes --search <search-term> --update --type <new-type> --note <new-note-data>`
- [x] **Verify** the output of `notes` shows the correct note data after the update operation
- [x] Delete a specific note by using the search (`notes --delete --search <search-term>`) or delete all notes (`notes --delete`)
- [x] **Verify** the output of `notes` shows the correct notes after the delete operation
- [x] **Verify** all of the above operation work after setting the active data service to the local_db_service using `data_services --set <id>`