### PR TITLE
Lock rex-text due to compatibility issues

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,7 +56,7 @@ PATH
       rex-socket
       rex-sslscan
       rex-struct2
-      rex-text
+      rex-text (< 0.2.18)
       rex-zip
       ruby-macho
       ruby_smb
@@ -107,7 +107,7 @@ GEM
     arel (6.0.4)
     arel-helpers (2.6.1)
       activerecord (>= 3.1.0, < 6)
-    backports (3.11.1)
+    backports (3.11.2)
     bcrypt (3.1.11)
     bcrypt_pbkdf (1.0.0)
     bindata (2.4.3)
@@ -245,7 +245,7 @@ GEM
       metasm
       rex-arch
       rex-text
-    rex-exploitation (0.1.17)
+    rex-exploitation (0.1.19)
       jsobfu
       metasm
       rex-arch

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -138,7 +138,7 @@ Gem::Specification.new do |spec|
   # Core of the Ruby Exploitation Library
   spec.add_runtime_dependency 'rex-core'
   # Text manipulation library for things like generating random string
-  spec.add_runtime_dependency 'rex-text'
+  spec.add_runtime_dependency 'rex-text', ["< 0.2.18"]
   # Library for Generating Randomized strings valid as Identifiers such as variable names
   spec.add_runtime_dependency 'rex-random_identifier'
   # library for creating Powershell scripts for exploitation purposes


### PR DESCRIPTION
The new depndency on the openssl gem creates compatibility issues
in some of the currently supported enviornments.  Lock version until
this is sorted out.


## Verification

List the steps needed to make sure this thing works

- [ ] Travis CI and R7 internal testing pass
