### PR TITLE
Add new methods to Msf::Post::Linux::Kernel lib

### DIFF
--- a/lib/msf/core/post/linux/kernel.rb
+++ b/lib/msf/core/post/linux/kernel.rb
@@ -99,6 +99,86 @@ module Kernel
     raise 'Could not determine userns status'
   end
 
+  #
+  # Returns true if ASLR is enabled
+  #
+  # @return [Boolean]
+  #
+  def aslr_enabled?
+    aslr = cmd_exec('cat /proc/sys/kernel/randomize_va_space').to_s
+    (aslr.eql?('1') || aslr.eql?('2'))
+  rescue
+    raise 'Could not determine ASLR status'
+  end
+
+  #
+  # Returns true if unprivileged bpf is disabled
+  #
+  # @return [Boolean]
+  #
+  def unprivileged_bpf_disabled?
+    cmd_exec('cat /proc/sys/kernel/unprivileged_bpf_disabled').to_s.eql? '1' 
+  rescue
+    raise 'Could not determine kernel.unprivileged_bpf_disabled status'
+  end
+
+  #
+  # Returns true if kernel pointer restriction is enabled
+  #
+  # @return [Boolean]
+  #
+  def kptr_restrict?
+    cmd_exec('cat /proc/sys/kernel/kptr_restrict').to_s.eql? '1' 
+  rescue
+    raise 'Could not determine kernel.kptr_restrict status'
+  end
+
+  #
+  # Returns true if dmesg restriction is enabled
+  #
+  # @return [Boolean]
+  #
+  def dmesg_restrict?
+    cmd_exec('cat /proc/sys/kernel/dmesg_restrict').to_s.eql? '1' 
+  rescue
+    raise 'Could not determine kernel.dmesg_restrict status'
+  end
+
+  #
+  # Returns mmap minimum address
+  #
+  # @return [Integer]
+  #
+  def mmap_min_addr
+    mmap_min_addr = cmd_exec('cat /proc/sys/vm/mmap_min_addr').to_s
+    return 0 unless mmap_min_addr =~ /\A\d+\z/
+    mmap_min_addr
+  rescue
+    raise 'Could not determine system mmap_min_addr'
+  end
+
+  #
+  # Returns true if SELinux is installed
+  #
+  # @return [Boolean]
+  #
+  def selinux_installed?
+    cmd_exec('id').to_s.include? 'context='
+  rescue
+    raise 'Could not determine SELinux status'
+  end
+
+  #
+  # Returns true if SELinux is in enforcing mode
+  #
+  # @return [Boolean]
+  #
+  def selinux_enforcing?
+    cmd_exec('/usr/sbin/getenforce').to_s.include? 'Enforcing'
+  rescue
+    raise 'Could not determine SELinux encforcing status'
+  end
+
 end # Kernel
 end # Linux
 end # Post

--- a/lib/msf/core/post/linux/kernel.rb
+++ b/lib/msf/core/post/linux/kernel.rb
@@ -178,6 +178,48 @@ module Kernel
   rescue
     raise 'Could not determine SELinux status'
   end
+
+  #
+  # Returns true if SELinux is in enforcing mode
+  #
+  # @return [Boolean]
+  #
+  def selinux_enforcing?
+    return false unless selinux_installed?
+
+    sestatus = cmd_exec('/usr/sbin/sestatus').to_s.strip
+    raise unless sestatus.include?('SELinux')
+
+    return true if sestatus =~ /Current mode:\s*enforcing/
+    false
+  rescue
+    raise 'Could not determine SELinux status'
+  end
+
+  #
+  # Returns true if Yama is installed
+  #
+  # @return [Boolean]
+  #
+  def yama_installed?
+    ptrace_scope = cmd_exec('cat /proc/sys/kernel/yama/ptrace_scope').to_s.strip
+    return true if ptrace_scope =~ /\A\d\z/
+    false
+  rescue
+    raise 'Could not determine Yama status'
+  end
+
+  #
+  # Returns true if Yama is enabled
+  #
+  # @return [Boolean]
+  #
+  def yama_enabled?
+    return false unless yama_installed?
+    !cmd_exec('cat /proc/sys/kernel/yama/ptrace_scope').to_s.strip.eql? '0'
+  rescue
+    raise 'Could not determine Yama status'
+  end
 end # Kernel
 end # Linux
 end # Post

--- a/lib/msf/core/post/linux/kernel.rb
+++ b/lib/msf/core/post/linux/kernel.rb
@@ -111,17 +111,6 @@ module Kernel
   end
 
   #
-  # Returns true if Kernel Address Space Layout Randomization (KASLR) is enabled
-  #
-  # @return [Boolean]
-  #
-  def kaslr_enabled?
-    cmd_exec('cat /proc/cmdline').include? 'kaslr'
-  rescue
-    raise 'Could not determine KASLR status'
-  end
-
-  #
   # Returns true if Address Space Layout Randomization (ASLR) is enabled
   #
   # @return [Boolean]

--- a/lib/msf/core/post/linux/kernel.rb
+++ b/lib/msf/core/post/linux/kernel.rb
@@ -178,18 +178,6 @@ module Kernel
   rescue
     raise 'Could not determine SELinux status'
   end
-
-  #
-  # Returns true if SELinux is in enforcing mode
-  #
-  # @return [Boolean]
-  #
-  def selinux_enforcing?
-    cmd_exec('/usr/sbin/getenforce').to_s.include? 'Enforcing'
-  rescue
-    raise 'Could not determine SELinux encforcing status'
-  end
-
 end # Kernel
 end # Linux
 end # Post

--- a/lib/msf/core/post/linux/kernel.rb
+++ b/lib/msf/core/post/linux/kernel.rb
@@ -13,7 +13,7 @@ module Kernel
   # @return [String]
   #
   def uname(opts='-a')
-    cmd_exec("uname #{opts}").to_s
+    cmd_exec("uname #{opts}").to_s.strip
   rescue
     raise "Failed to run uname #{opts}"
   end
@@ -104,8 +104,8 @@ module Kernel
   # @return [Boolean]
   #
   def userns_enabled?
-    return false if cmd_exec('cat /proc/sys/user/max_user_namespaces').to_s.eql? '0'
-    cmd_exec('cat /proc/sys/kernel/unprivileged_userns_clone').to_s.eql? '1'
+    return false if cmd_exec('cat /proc/sys/user/max_user_namespaces').to_s.strip.eql? '0'
+    cmd_exec('cat /proc/sys/kernel/unprivileged_userns_clone').to_s.strip.eql? '1'
   rescue
     raise 'Could not determine userns status'
   end
@@ -127,7 +127,7 @@ module Kernel
   # @return [Boolean]
   #
   def aslr_enabled?
-    aslr = cmd_exec('cat /proc/sys/kernel/randomize_va_space').to_s
+    aslr = cmd_exec('cat /proc/sys/kernel/randomize_va_space').to_s.strip
     (aslr.eql?('1') || aslr.eql?('2'))
   rescue
     raise 'Could not determine ASLR status'
@@ -139,7 +139,7 @@ module Kernel
   # @return [Boolean]
   #
   def unprivileged_bpf_disabled?
-    cmd_exec('cat /proc/sys/kernel/unprivileged_bpf_disabled').to_s.eql? '1' 
+    cmd_exec('cat /proc/sys/kernel/unprivileged_bpf_disabled').to_s.strip.eql? '1' 
   rescue
     raise 'Could not determine kernel.unprivileged_bpf_disabled status'
   end
@@ -150,7 +150,7 @@ module Kernel
   # @return [Boolean]
   #
   def kptr_restrict?
-    cmd_exec('cat /proc/sys/kernel/kptr_restrict').to_s.eql? '1' 
+    cmd_exec('cat /proc/sys/kernel/kptr_restrict').to_s.strip.eql? '1' 
   rescue
     raise 'Could not determine kernel.kptr_restrict status'
   end
@@ -161,7 +161,7 @@ module Kernel
   # @return [Boolean]
   #
   def dmesg_restrict?
-    cmd_exec('cat /proc/sys/kernel/dmesg_restrict').to_s.eql? '1' 
+    cmd_exec('cat /proc/sys/kernel/dmesg_restrict').to_s.strip.eql? '1' 
   rescue
     raise 'Could not determine kernel.dmesg_restrict status'
   end
@@ -172,7 +172,7 @@ module Kernel
   # @return [Integer]
   #
   def mmap_min_addr
-    mmap_min_addr = cmd_exec('cat /proc/sys/vm/mmap_min_addr').to_s
+    mmap_min_addr = cmd_exec('cat /proc/sys/vm/mmap_min_addr').to_s.strip
     return 0 unless mmap_min_addr =~ /\A\d+\z/
     mmap_min_addr
   rescue

--- a/lib/msf/core/post/linux/kernel.rb
+++ b/lib/msf/core/post/linux/kernel.rb
@@ -88,6 +88,17 @@ module Kernel
   end
 
   #
+  # Returns true if Kernel Address Isolation (KAISER) is enabled
+  #
+  # @return [Boolean]
+  #
+  def kaiser_enabled?
+    cmd_exec('cat /proc/cpuinfo').to_s.include? 'kaiser'
+  rescue
+    raise 'Could not determine KAISER status'
+  end
+
+  #
   # Returns true if user namespaces are enabled, false if not.
   #
   # @return [Boolean]
@@ -100,7 +111,18 @@ module Kernel
   end
 
   #
-  # Returns true if ASLR is enabled
+  # Returns true if Kernel Address Space Layout Randomization (KASLR) is enabled
+  #
+  # @return [Boolean]
+  #
+  def kaslr_enabled?
+    cmd_exec('cat /proc/cmdline').include? 'kaslr'
+  rescue
+    raise 'Could not determine KASLR status'
+  end
+
+  #
+  # Returns true if Address Space Layout Randomization (ASLR) is enabled
   #
   # @return [Boolean]
   #


### PR DESCRIPTION
This PR adds the following methods to `Msf::Post::Linux::Kernel` :

* aslr_enabled?
* kaiser_enabled?
* unprivileged_bpf_disabled?
* kptr_restrict?
* dmesg_restrict?
* mmap_min_addr
* selinux_installed?
* selinux_enforcing?

```ruby
  def check
    print_status "aslr_enabled?: #{aslr_enabled?}"
    print_status "unprivileged_bpf_disabled?: #{unprivileged_bpf_disabled?}"
    print_status "kptr_restrict?: #{kptr_restrict?}"
    print_status "dmesg_restrict?: #{dmesg_restrict?}"
    print_status "selinux_installed?: #{selinux_installed?}"
    print_status "selinux_enforcing?: #{selinux_enforcing?}"
    print_status "mmap_min_addr: #{mmap_min_addr}"
    CheckCode::Unknown
  end
```
