### PR TITLE
when datastore options are merged, also merge the alias and imported* hashes

### DIFF
--- a/lib/msf/core/data_store.rb
+++ b/lib/msf/core/data_store.rb
@@ -219,6 +219,21 @@ class DataStore < Hash
     end
   end
 
+  #
+  # Return a deep copy of this datastore.
+  #
+  def copy
+    clone = self.class.new
+    self.keys.each do |k|
+      clone.import_option(k, self[k].kind_of?(String) ? self[k].dup : self[k], @imported[k], @imported_by[k])
+    end
+    clone.aliases = self.aliases.dup
+    clone
+  end
+
+  #
+  # Override merge! so that we merge the aliases and imported hashes
+  #
   def merge!(other)
     super
     self.aliases.merge!(other.aliases) if other.respond_to?(:aliases)
@@ -226,6 +241,9 @@ class DataStore < Hash
     self.imported_by.merge!(other.imported_by) if other.respond_to?(:imported_by)
   end
 
+  #
+  # Override merge to ensure we merge the aliases and imported hashes
+  #
   def merge(other)
     ds = self.copy
     ds.merge!(other)
@@ -273,18 +291,6 @@ class DataStore < Hash
       list << [sidx, self[sidx]]
     end
     list.each(&block)
-  end
-
-  #
-  # Return a deep copy of this datastore.
-  #
-  def copy
-    clone = self.class.new
-    self.keys.each do |k|
-      clone.import_option(k, self[k].kind_of?(String) ? self[k].dup : self[k], @imported[k], @imported_by[k])
-    end
-    clone.aliases = self.aliases.dup
-    clone
   end
 
 protected

--- a/lib/msf/core/data_store.rb
+++ b/lib/msf/core/data_store.rb
@@ -220,19 +220,15 @@ class DataStore < Hash
   end
 
   def merge!(other)
-    self.options.merge!(other.options)
-    self.aliases.merge!(other.aliases)
-    self.imported.merge!(other.imported)
-    self.imported_by.merge!(other.imported_by)
+    super
+    self.aliases.merge!(other.aliases) if other.respond_to?(:aliases)
+    self.imported.merge!(other.imported) if other.respond_to?(:imported)
+    self.imported_by.merge!(other.imported_by) if other.respond_to?(:imported_by)
   end
 
   def merge(other)
-    ds = copy
-    ds.options.merge!(other.options)
-    ds.aliases.merge!(other.aliases)
-    ds.imported.merge!(other.imported)
-    ds.imported_by.merge!(other.imported_by)
-    ds
+    ds = self.copy
+    ds.merge!(other)
   end
 
   #

--- a/lib/msf/core/data_store.rb
+++ b/lib/msf/core/data_store.rb
@@ -19,7 +19,10 @@ class DataStore < Hash
     @imported_by = Hash.new
   end
 
+  attr_accessor :options
   attr_accessor :aliases
+  attr_accessor :imported
+  attr_accessor :imported_by
 
   #
   # Clears the imported flag for the supplied key since it's being set
@@ -216,6 +219,22 @@ class DataStore < Hash
     end
   end
 
+  def merge!(other)
+    @options.merge!(other.options)
+    @aliases.merge!(other.aliases)
+    @imported.merge!(other.imported)
+    @imported_by.merge!(other.imported_by)
+  end
+
+  def merge(other)
+    ds = clone
+    ds.options.merge!(other.options)
+    ds.aliases.merge!(other.aliases)
+    ds.imported.merge!(other.imported)
+    ds.imported_by.merge!(other.imported_by)
+    ds
+  end
+
   #
   # Returns a hash of user-defined datastore values.  The returned hash does
   # not include default option values.
@@ -345,7 +364,7 @@ class ModuleDataStore < DataStore
     self.keys.each do |k|
       clone.import_option(k, self[k].kind_of?(String) ? self[k].dup : self[k], @imported[k], @imported_by[k])
     end
-    clone.aliases = self.aliases
+    clone.aliases = @aliases
     clone
   end
 end

--- a/lib/msf/core/data_store.rb
+++ b/lib/msf/core/data_store.rb
@@ -372,7 +372,7 @@ class ModuleDataStore < DataStore
     self.keys.each do |k|
       clone.import_option(k, self[k].kind_of?(String) ? self[k].dup : self[k], @imported[k], @imported_by[k])
     end
-    clone.aliases = self.aliases
+    clone.aliases = self.aliases.dup
     clone
   end
 end

--- a/lib/msf/core/data_store.rb
+++ b/lib/msf/core/data_store.rb
@@ -227,7 +227,7 @@ class DataStore < Hash
   end
 
   def merge(other)
-    ds = clone
+    ds = copy
     ds.options.merge!(other.options)
     ds.aliases.merge!(other.aliases)
     ds.imported.merge!(other.imported)

--- a/lib/msf/core/data_store.rb
+++ b/lib/msf/core/data_store.rb
@@ -220,10 +220,10 @@ class DataStore < Hash
   end
 
   def merge!(other)
-    @options.merge!(other.options)
-    @aliases.merge!(other.aliases)
-    @imported.merge!(other.imported)
-    @imported_by.merge!(other.imported_by)
+    self.options.merge!(other.options)
+    self.aliases.merge!(other.aliases)
+    self.imported.merge!(other.imported)
+    self.imported_by.merge!(other.imported_by)
   end
 
   def merge(other)
@@ -288,8 +288,8 @@ protected
 
     # Scan each alias looking for a key
     search_k = k.downcase
-    if @aliases.has_key?(search_k)
-      search_k = @aliases[search_k]
+    if self.aliases.has_key?(search_k)
+      search_k = self.aliases[search_k]
     end
 
     # Scan each key looking for a match
@@ -364,7 +364,7 @@ class ModuleDataStore < DataStore
     self.keys.each do |k|
       clone.import_option(k, self[k].kind_of?(String) ? self[k].dup : self[k], @imported[k], @imported_by[k])
     end
-    clone.aliases = @aliases
+    clone.aliases = self.aliases
     clone
   end
 end

--- a/lib/msf/core/data_store.rb
+++ b/lib/msf/core/data_store.rb
@@ -236,9 +236,11 @@ class DataStore < Hash
   #
   def merge!(other)
     super
-    self.aliases.merge!(other.aliases) if other.respond_to?(:aliases)
-    self.imported.merge!(other.imported) if other.respond_to?(:imported)
-    self.imported_by.merge!(other.imported_by) if other.respond_to?(:imported_by)
+    if other.is_a? DataStore
+      self.aliases.merge!(other.aliases)
+      self.imported.merge!(other.imported)
+      self.imported_by.merge!(other.imported_by)
+    end
   end
 
   #

--- a/lib/msf/core/data_store.rb
+++ b/lib/msf/core/data_store.rb
@@ -275,6 +275,18 @@ class DataStore < Hash
     list.each(&block)
   end
 
+  #
+  # Return a deep copy of this datastore.
+  #
+  def copy
+    clone = self.class.new
+    self.keys.each do |k|
+      clone.import_option(k, self[k].kind_of?(String) ? self[k].dup : self[k], @imported[k], @imported_by[k])
+    end
+    clone.aliases = self.aliases.dup
+    clone
+  end
+
 protected
 
   #

--- a/lib/msf/core/data_store.rb
+++ b/lib/msf/core/data_store.rb
@@ -223,12 +223,12 @@ class DataStore < Hash
   # Return a deep copy of this datastore.
   #
   def copy
-    clone = self.class.new
+    ds = self.class.new
     self.keys.each do |k|
-      clone.import_option(k, self[k].kind_of?(String) ? self[k].dup : self[k], @imported[k], @imported_by[k])
+      ds.import_option(k, self[k].kind_of?(String) ? self[k].dup : self[k], @imported[k], @imported_by[k])
     end
-    clone.aliases = self.aliases.dup
-    clone
+    ds.aliases = self.aliases.dup
+    ds
   end
 
   #
@@ -374,12 +374,12 @@ class ModuleDataStore < DataStore
   # Return a deep copy of this datastore.
   #
   def copy
-    clone = self.class.new(@_module)
+    ds = self.class.new(@_module)
     self.keys.each do |k|
-      clone.import_option(k, self[k].kind_of?(String) ? self[k].dup : self[k], @imported[k], @imported_by[k])
+      ds.import_option(k, self[k].kind_of?(String) ? self[k].dup : self[k], @imported[k], @imported_by[k])
     end
-    clone.aliases = self.aliases.dup
-    clone
+    ds.aliases = self.aliases.dup
+    ds
   end
 end
 

--- a/lib/msf/core/payload/linux/x64/reverse_tcp.rb
+++ b/lib/msf/core/payload/linux/x64/reverse_tcp.rb
@@ -25,7 +25,7 @@ module Payload::Linux::ReverseTcp_x64
     conf = {
       port:        datastore['LPORT'],
       host:        datastore['LHOST'],
-      retry_count: datastore['ReverseConnectRetries'],
+      retry_count:   datastore['StagerRetryCount'],
       sleep_seconds: datastore['StagerRetryWait'],
     }
 


### PR DESCRIPTION
This fixes #9879 by using the same datastore option for retries for x86 and x64 linux stagers.

~(why we have both 'ReverseConnectRetries' and 'StagerRetryCount' sees to be the left hand not agreeing with the right hand, which an intrepid fellow could fix with parameter aliases at some point after this PR).~

The core problem here wasn't that the stagers weren't using the same option. We had addressed that earlier by adding aliases to the datastore for specifically this `ReverseConnectRetries` vs `StagerRetryCount` issue. The problem was that when two datastores are merged, the aliases from the right-hand datastore did not copy to the left-hand. When `to_handler` is invoked, it calls merge! which killed the aliases for the payload datastore. Had we merged the opposite direction, it would have worked. Stagers that had fallback code when the datastore option wasn't set were silently falling-back to their hardcoded options on merge.

This also adds some missing accessors that would have been handy the other day when I was doing some code walkthroughs with others.

## Verification

- [ ] Run through the steps for #9879 
- [ ] **Verify** it works as expected
- [ ] Revert the change to reverse_tcp.rb, verify that it works either way

```
--- a/lib/msf/core/payload/linux/x64/reverse_tcp.rb
+++ b/lib/msf/core/payload/linux/x64/reverse_tcp.rb
@@ -25,7 +25,7 @@ module Payload::Linux::ReverseTcp_x64
     conf = {
       port:        datastore['LPORT'],
       host:        datastore['LHOST'],
-      retry_count:   datastore['StagerRetryCount'],
+      retry_count:   datastore['ReverseConnectRetries'],
       sleep_seconds: datastore['StagerRetryWait'],
     }
```

- [ ] Modify the `to_handler` command with a change like this to verify that `merge` also works

```
--- a/lib/msf/ui/console/command_dispatcher/payload.rb
+++ b/lib/msf/ui/console/command_dispatcher/payload.rb
@@ -54,6 +54,8 @@ module Msf
             }
 
             handler.datastore.merge!(mod.datastore)
+            a = handler.datastore.merge(mod.datastore)
+            handler.datastore.merge!(a)
             handler.exploit_simple(handler_opts)
             job_id = handler.job_id
```

 - [ ] Verify that the the RHS of merge operations can be a Hash, DataStore, ModuleDataStore