### PR TITLE
Fix Bug When Importing XML File

### DIFF
--- a/lib/msf/core/db_manager/import/metasploit_framework/xml.rb
+++ b/lib/msf/core/db_manager/import/metasploit_framework/xml.rb
@@ -243,7 +243,7 @@ module Msf::DBManager::Import::MetasploitFramework::XML
         when 'host'
           parse_host(Nokogiri::XML(node.outer_xml).at("./#{node.name}"), wspace, bl, allow_yaml, btag, args, &block)
         when 'web_site'
-          parse_web_site(Nokogiri::XML(node.outer_xml).at("./#{node.name}"), wspace, bl, allow_yaml, btag, args, &block)
+          parse_web_site(Nokogiri::XML(node.outer_xml).at("./#{node.name}"), wspace, allow_yaml, &block)
         when 'web_page', 'web_form', 'web_vuln'
           send(
               "import_msf_#{node.name}_element",
@@ -260,7 +260,7 @@ module Msf::DBManager::Import::MetasploitFramework::XML
   private
 
   # Parses website Nokogiri::XML::Element
-  def parse_web_site(web, wspace, bl, allow_yaml, btag, args, &block)
+  def parse_web_site(web, wspace, allow_yaml, &block)
     # Import web sites
     info = {}
     info[:workspace] = wspace
@@ -285,7 +285,7 @@ module Msf::DBManager::Import::MetasploitFramework::XML
   end
 
   # Parses host Nokogiri::XML::Element
-  def parse_host(host, wspace, bl, allow_yaml, btag, args, &block)
+  def parse_host(host, wspace, blacklist, allow_yaml, btag, args, &block)
 
     host_data = {}
     host_data[:task] = args[:task]
@@ -302,7 +302,7 @@ module Msf::DBManager::Import::MetasploitFramework::XML
     end
 
     host_data[:host] = addr
-    if bl.include? host_data[:host]
+    if blacklist.include? host_data[:host]
       return 0
     else
       yield(:address,host_data[:host]) if block
@@ -322,7 +322,7 @@ module Msf::DBManager::Import::MetasploitFramework::XML
     host.xpath("host_details/host_detail").each do |hdet|
       hdet_data = {}
       hdet.elements.each do |det|
-        return 0 if ["id", "host-id"].include?(det.name)
+        next if ["id", "host-id"].include?(det.name)
         if det.text
           hdet_data[det.name.gsub('-','_')] = nils_for_nulls(det.text.to_s.strip)
         end
@@ -333,7 +333,7 @@ module Msf::DBManager::Import::MetasploitFramework::XML
     host.xpath("exploit_attempts/exploit_attempt").each do |hdet|
       hdet_data = {}
       hdet.elements.each do |det|
-        return 0 if ["id", "host-id", "session-id", "vuln-id", "service-id", "loot-id"].include?(det.name)
+        next if ["id", "host-id", "session-id", "vuln-id", "service-id", "loot-id"].include?(det.name)
         if det.text
           hdet_data[det.name.gsub('-','_')] = nils_for_nulls(det.text.to_s.strip)
         end
@@ -415,7 +415,7 @@ module Msf::DBManager::Import::MetasploitFramework::XML
       vuln.xpath("vuln_details/vuln_detail").each do |vdet|
         vdet_data = {}
         vdet.elements.each do |det|
-          return 0 if ["id", "vuln-id"].include?(det.name)
+          next if ["id", "vuln-id"].include?(det.name)
           if det.text
             vdet_data[det.name.gsub('-','_')] = nils_for_nulls(det.text.to_s.strip)
           end
@@ -426,7 +426,7 @@ module Msf::DBManager::Import::MetasploitFramework::XML
       vuln.xpath("vuln_attempts/vuln_attempt").each do |vdet|
         vdet_data = {}
         vdet.elements.each do |det|
-          return 0 if ["id", "vuln-id", "loot-id", "session-id"].include?(det.name)
+          next if ["id", "vuln-id", "loot-id", "session-id"].include?(det.name)
           if det.text
             vdet_data[det.name.gsub('-','_')] = nils_for_nulls(det.text.to_s.strip)
           end
@@ -498,7 +498,7 @@ module Msf::DBManager::Import::MetasploitFramework::XML
           :time => sess_data[:opened_at]
       )
       this_session = existing_session || report_session(sess_data)
-      return 0 if existing_session
+      next if existing_session
       sess.xpath('events/event').each do |sess_event|
         sess_event_data = {}
         sess_event_data[:session] = this_session


### PR DESCRIPTION
This PR fixes a bug in the import logic for XML files. It was completely abandoning import of the host if any one of a number of unused tags were found, instead of just discarding that tag and moving on. This was preventing the host and any related items from being imported at all.

I also clarified one of the variable names and removed some unused attributes from one of the method signatures.

## Verification

List the steps needed to make sure this thing works

- [x] Create an XML export from Metasploit Pro that contains a host that has been successfully exploited. I have a file that can be used, contact me if needed.
- [x] Start `msfconsole`. It's best to start with an empty database or switch to a new workspace.
- [x] Run `db_import <export_file_name.xml>`
- [x] Run `workspace -v` You should see an accurate count of imported items.

