### PR TITLE
remove rex-text version lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,7 +56,7 @@ PATH
       rex-socket
       rex-sslscan
       rex-struct2
-      rex-text (< 0.2.18)
+      rex-text
       rex-zip
       ruby-macho
       ruby_smb
@@ -275,7 +275,7 @@ GEM
       rex-socket
       rex-text
     rex-struct2 (0.1.2)
-    rex-text (0.2.17)
+    rex-text (0.2.20)
     rex-zip (0.1.3)
       rex-text
     rkelly-remix (0.0.7)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -138,7 +138,7 @@ Gem::Specification.new do |spec|
   # Core of the Ruby Exploitation Library
   spec.add_runtime_dependency 'rex-core'
   # Text manipulation library for things like generating random string
-  spec.add_runtime_dependency 'rex-text', ["< 0.2.18"]
+  spec.add_runtime_dependency 'rex-text'
   # Library for Generating Randomized strings valid as Identifiers such as variable names
   spec.add_runtime_dependency 'rex-random_identifier'
   # library for creating Powershell scripts for exploitation purposes


### PR DESCRIPTION
Dependency issue that required version lock on rex-text has been mitigated.  We can now release the lock and proceed with rex-text updates per normal process.

## Verification

List the steps needed to make sure this thing works

- [ ] Test tools pass for R7 internal tools
- [ ] Public test automation succeeds.

