### PR TITLE
Fix target encoder not being passed to payload

### DIFF
--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -550,8 +550,8 @@ class Exploit < Msf::Module
     reqs['AppendEncoder']   = payload_append_encoder(explicit_target)
     reqs['MaxNops']         = payload_max_nops(explicit_target)
     reqs['MinNops']         = payload_min_nops(explicit_target)
-    reqs['Encoder']         = datastore['ENCODER']
-    reqs['Nop']             = datastore['NOP']
+    reqs['Encoder']         = datastore['ENCODER'] || payload_encoder(explicit_target)
+    reqs['Nop']             = datastore['NOP'] # TODO: Make like the others
     reqs['EncoderType']     = payload_encoder_type(explicit_target)
     reqs['EncoderOptions']  = payload_encoder_options(explicit_target)
     reqs['ExtendedOptions'] = payload_extended_options(explicit_target)
@@ -917,8 +917,22 @@ class Exploit < Msf::Module
   end
 
   #
+  # Returns the payload encoder that is associated with either the
+  # current target or the exploit in general.
+  #
+  def payload_encoder(explicit_target = nil)
+    explicit_target ||= target
+
+    if (explicit_target and explicit_target.payload_encoder)
+      explicit_target.payload_encoder
+    else
+      payload_info['Encoder']
+    end
+  end
+
+  #
   # Returns the payload encoder type that is associated with either the
-  # current target of the exploit in general.
+  # current target or the exploit in general.
   #
   def payload_encoder_type(explicit_target = nil)
     explicit_target ||= target

--- a/lib/msf/core/module/target.rb
+++ b/lib/msf/core/module/target.rb
@@ -234,6 +234,14 @@ class Msf::Module::Target
   end
 
   #
+  # The payload encoder or encoders that can be used when generating the
+  # encoded payload (such as x86/shikata_ga_nai and so on).
+  #
+  def payload_encoder
+    opts['Payload'] ? opts['Payload']['Encoder'] : nil
+  end
+
+  #
   # The payload encoder type or types that can be used when generating the
   # encoded payload (such as alphanum, unicode, xor, and so on).
   #


### PR DESCRIPTION
Datastore functionality has been preserved as an override.

- [x] Set an encoder in a target (example: `'Payload' => {'Encoder' => 'php/base64'}`)
- [x] Test to see that it's used
- [x] Set the `ENCODER` option
- [x] See that it overrides the target's encoder
- [x] Set `ENCODER` to something wildly incompatible
- [x] Laugh as your exploit fails predictably

~Required~ Desired by #9876.