### PR TITLE
Fix #8404 ListenerComm Support For Exploit::Remote::TcpServer

### DIFF
--- a/lib/msf/core/exploit/socket_server.rb
+++ b/lib/msf/core/exploit/socket_server.rb
@@ -164,6 +164,20 @@ protected
     comm
   end
 
+  def via_string_for_ip(ip, comm)
+    comm_used = comm
+    comm_used ||= Rex::Socket::SwitchBoard.best_comm(ip)
+    comm_used ||= Rex::Socket::Comm::Local
+
+    if comm_used.respond_to?(:type) && comm_used.respond_to?(:sid)
+      via = "via the #{comm_used.type} on session #{comm_used.sid}"
+    else
+      via = ""
+    end
+
+    via
+  end
+
   attr_accessor :service # :nodoc:
 
 end

--- a/lib/msf/core/exploit/socket_server.rb
+++ b/lib/msf/core/exploit/socket_server.rb
@@ -83,7 +83,7 @@ module Exploit::Remote::SocketServer
     if (service)
       begin
         self.service.deref if self.service.kind_of?(Rex::Service)
-        if self.service.kind_of?(Rex::Socket)
+        if self.service.kind_of?(Rex::Socket) || self.service.kind_of?(Rex::Post::Meterpreter::Channel)
           self.service.close
           self.service.stop
         end

--- a/lib/msf/core/exploit/tcp_server.rb
+++ b/lib/msf/core/exploit/tcp_server.rb
@@ -104,6 +104,10 @@ module Exploit::Remote::TcpServer
       end
       raise e
     end
+
+    via = via_string_for_ip(srvhost, comm)
+    hoststr = Rex::Socket.is_ipv6?(srvhost) ? "[#{srvhost}]" : srvhost
+    print_status("Started service listener on #{hoststr}:#{srvport} #{via}")
   end
 
   #

--- a/lib/rex/post/meterpreter/extensions/stdapi/net/socket_subsystem/tcp_server_channel.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/net/socket_subsystem/tcp_server_channel.rb
@@ -16,6 +16,8 @@ module SocketSubsystem
 
 class TcpServerChannel < Rex::Post::Meterpreter::Channel
 
+  include Rex::IO::StreamServer
+
   #
   # This is a class variable to store all pending client tcp connections which have not been passed
   # off via a call to the respective server tcp channels accept method. The dictionary key is the
@@ -87,7 +89,7 @@ class TcpServerChannel < Rex::Post::Meterpreter::Channel
   end
 
   #
-  # Simply initilize this instance.
+  # Simply initialize this instance.
   #
   def initialize(client, cid, type, flags)
     super(client, cid, type, flags)
@@ -104,7 +106,7 @@ class TcpServerChannel < Rex::Post::Meterpreter::Channel
   end
 
   #
-  # Accept a new tcp client connection form this tcp server channel. This method will block indefinatly
+  # Accept a new tcp client connection form this tcp server channel. This method will block indefinitely
   # if no timeout is specified.
   #
   def accept(opts = {})

--- a/modules/auxiliary/server/capture/ftp.rb
+++ b/modules/auxiliary/server/capture/ftp.rb
@@ -39,7 +39,6 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    print_status("Listening on #{datastore['SRVHOST']}:#{datastore['SRVPORT']}...")
     exploit()
   end
 

--- a/modules/auxiliary/server/capture/http.rb
+++ b/modules/auxiliary/server/capture/http.rb
@@ -70,7 +70,6 @@ class MetasploitModule < Msf::Auxiliary
       @myautopwn = true
     end
 
-    print_status("Listening on #{datastore['SRVHOST']}:#{datastore['SRVPORT']}...")
     exploit()
   end
 

--- a/modules/auxiliary/server/capture/http_basic.rb
+++ b/modules/auxiliary/server/capture/http_basic.rb
@@ -51,7 +51,6 @@ class MetasploitModule < Msf::Auxiliary
     @myport   = datastore['SRVPORT']
     @realm    = datastore['REALM']
 
-    print_status("Listening on #{datastore['SRVHOST']}:#{datastore['SRVPORT']}...")
     exploit
   end
 

--- a/modules/auxiliary/server/capture/http_javascript_keylogger.rb
+++ b/modules/auxiliary/server/capture/http_javascript_keylogger.rb
@@ -37,7 +37,6 @@ class MetasploitModule < Msf::Auxiliary
     @client_cache = {}
 
     # Starts Web Server
-    print_status("Listening on #{datastore['SRVHOST']}:#{datastore['SRVPORT']}...")
     exploit
   end
 

--- a/modules/auxiliary/server/capture/imap.rb
+++ b/modules/auxiliary/server/capture/imap.rb
@@ -39,7 +39,6 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    print_status("Listening on #{datastore['SRVHOST']}:#{datastore['SRVPORT']}...")
     exploit()
   end
 

--- a/modules/auxiliary/server/capture/mssql.rb
+++ b/modules/auxiliary/server/capture/mssql.rb
@@ -77,8 +77,6 @@ class MetasploitModule < Msf::Auxiliary
     @previous_lm_hash="none"
     @previous_ntlm_hash="none"
 
-    print_status("Listening on #{datastore['SRVHOST']}:#{datastore['SRVPORT']}...")
-
     exploit()
   end
 

--- a/modules/auxiliary/server/capture/mysql.rb
+++ b/modules/auxiliary/server/capture/mysql.rb
@@ -45,7 +45,6 @@ class MetasploitModule < Msf::Auxiliary
       return
     end
     @version = datastore['SRVVERSION']
-    print_status("Listening on #{datastore['SRVHOST']}:#{datastore['SRVPORT']}...")
     exploit()
   end
 

--- a/modules/auxiliary/server/capture/pop3.rb
+++ b/modules/auxiliary/server/capture/pop3.rb
@@ -42,7 +42,6 @@ class MetasploitModule < Msf::Auxiliary
   def run
     @myhost = datastore['SRVHOST']
     @myport = datastore['SRVPORT']
-    print_status("Listening on #{datastore['SRVHOST']}:#{datastore['SRVPORT']}...")
     exploit()
   end
 

--- a/modules/auxiliary/server/capture/postgresql.rb
+++ b/modules/auxiliary/server/capture/postgresql.rb
@@ -35,7 +35,6 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    print_status("Listening on #{datastore['SRVHOST']}:#{datastore['SRVPORT']}...")
     exploit()
   end
 

--- a/modules/auxiliary/server/capture/smtp.rb
+++ b/modules/auxiliary/server/capture/smtp.rb
@@ -40,7 +40,6 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    print_status("Listening on #{datastore['SRVHOST']}:#{datastore['SRVPORT']}...")
     exploit()
   end
 

--- a/modules/auxiliary/server/capture/telnet.rb
+++ b/modules/auxiliary/server/capture/telnet.rb
@@ -42,7 +42,6 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    print_status("Listening on #{datastore['SRVHOST']}:#{datastore['SRVPORT']}...")
     exploit()
   end
 

--- a/modules/auxiliary/server/capture/vnc.rb
+++ b/modules/auxiliary/server/capture/vnc.rb
@@ -41,7 +41,6 @@ class MetasploitModule < Msf::Auxiliary
       print_error("CHALLENGE syntax must match 00112233445566778899AABBCCDDEEFF")
       return
     end
-    print_status("Listening on #{datastore['SRVHOST']}:#{datastore['SRVPORT']}...")
     exploit()
   end
 


### PR DESCRIPTION
This fixes #8404 by updating `Rex::Post::Meterpreter::Extensions::Stdapi::Net::SocketSubsystem::TcpServerChannel` to support the `Rex::IO::StreamServer` interface, most notably the proc callbacks. By including this, modules which include the `Exploit::Remote::TcpServer` mixin can now specify a `ListenerComm` argument which will be properly honored. This in turn allows users to have modules other than payload listeners bind sockets via established Meterpreter sessions.

Many `auxiliary/server/capture/*` modules were refactored to remove the now redundant "Listening on..." message since the mixin properly handles it, IPv6 addresses, sessions and all. The output is meant to be familiar to anyone used to setting up reverse listeners over Meterpreter sessions.

## Verification

- [x] Start `msfconsole`
- [x] Establish a meterpreter session through some means, Windows, Mettle, Python etc.
- [x] `use` a module which includes the `Exploit::Remote::TcpServer` mixin (there's 52 of them)
- [x] `set ListenerComm` (note that for this argument `-1` will not work for referencing the last opened session)
- [x] `set` the other options as appropriate, making sure the session has the privileges to bind to the `SRVPORT`
- [x] `run` the module, and see the `...via the meterpreter on session...` message
- [x] Verify that the service is running on the remote host, connect to it and ensure things are functioning
- [x] Stop the service / module and make sure that the channel was cleaned up (the remote socket is no longer listening)

## Example Output
This example usage shows the `auxiliary/server/capture/telnet` module binding to `0.0.0.0:23` via meterpreter session 1 (in this case a Python Meterpreter session but any which support TCP server channels should work).
```
metasploit-framework (S:1 J:2) payload(python/meterpreter/reverse_tcp) > use auxiliary/server/capture/telnet 
metasploit-framework (S:1 J:2) auxiliary(server/capture/telnet) > set ListenerComm 1
ListenerComm => 1
metasploit-framework (S:1 J:2) auxiliary(server/capture/telnet) > run
[*] Auxiliary module running as background job 2.
metasploit-framework (S:1 J:3) auxiliary(server/capture/telnet) > 
[*] [2018.04.20-16:38:43] Started service listener on 0.0.0.0:23 via the meterpreter on session 1
[*] [2018.04.20-16:38:43] Server started.

metasploit-framework (S:1 J:3) auxiliary(server/capture/telnet) > 
[+] [2018.04.20-16:39:02] TELNET LOGIN :41912 metasploit! / itsworking!
[!] [2018.04.20-16:39:02] No active DB -- Credential data will not be saved!

metasploit-framework (S:1 J:3) auxiliary(server/capture/telnet) > sessions -i -1
[*] Starting interaction with 1...

meterpreter > shell
Process 2061 created.
Channel 3 created.
/bin/sh: 0: can't access tty; job control turned off
# netstat -antp | grep 23
tcp        0      0 0.0.0.0:23              0.0.0.0:*               LISTEN      2044/python         
tcp        0      0 127.0.0.1:23            127.0.0.1:41912         TIME_WAIT   -                   
# exit
meterpreter > background 
[*] Backgrounding session 1...
metasploit-framework (S:1 J:3) auxiliary(server/capture/telnet) > jobs -K
Stopping all jobs...

[*] [2018.04.20-16:39:39] Stopping the socks4a proxy server
[*] [2018.04.20-16:39:39] Server stopped.
[*] [2018.04.20-16:39:39] Server stopped.
metasploit-framework (S:1 J:0) auxiliary(server/capture/telnet) > sessions -i -1
[*] Starting interaction with 1...

meterpreter > shell
Process 2067 created.
Channel 4 created.
/bin/sh: 0: can't access tty; job control turned off
# netstat -antp | grep 23
tcp        0      0 127.0.0.1:23            127.0.0.1:41912         TIME_WAIT   -                   
# exit
meterpreter > 
```
