### PR TITLE
Fix target NOP generator not passed to payload

### DIFF
--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -551,7 +551,7 @@ class Exploit < Msf::Module
     reqs['MaxNops']         = payload_max_nops(explicit_target)
     reqs['MinNops']         = payload_min_nops(explicit_target)
     reqs['Encoder']         = datastore['ENCODER'] || payload_encoder(explicit_target)
-    reqs['Nop']             = datastore['NOP'] # TODO: Make like the others
+    reqs['Nop']             = datastore['NOP'] || payload_nop(explicit_target)
     reqs['EncoderType']     = payload_encoder_type(explicit_target)
     reqs['EncoderOptions']  = payload_encoder_options(explicit_target)
     reqs['ExtendedOptions'] = payload_extended_options(explicit_target)
@@ -927,6 +927,20 @@ class Exploit < Msf::Module
       explicit_target.payload_encoder
     else
       payload_info['Encoder']
+    end
+  end
+
+  #
+  # Returns the payload NOP generator that is associated with either the
+  # current target or the exploit in general.
+  #
+  def payload_nop(explicit_target = nil)
+    explicit_target ||= target
+
+    if (explicit_target and explicit_target.payload_nop)
+      explicit_target.payload_nop
+    else
+      payload_info['Nop']
     end
   end
 

--- a/lib/msf/core/module/target.rb
+++ b/lib/msf/core/module/target.rb
@@ -246,7 +246,7 @@ class Msf::Module::Target
   # encoded payload (such as x86/opty2 and so on).
   #
   def payload_nop
-    opts['Nop'] ? opts['Payload']['Nop'] : nil
+    opts['Payload'] ? opts['Payload']['Nop'] : nil
   end
 
   #

--- a/lib/msf/core/module/target.rb
+++ b/lib/msf/core/module/target.rb
@@ -242,6 +242,14 @@ class Msf::Module::Target
   end
 
   #
+  # The payload NOP generator or generators that can be used when generating the
+  # encoded payload (such as x86/opty2 and so on).
+  #
+  def payload_nop
+    opts['Nop'] ? opts['Payload']['Nop'] : nil
+  end
+
+  #
   # The payload encoder type or types that can be used when generating the
   # encoded payload (such as alphanum, unicode, xor, and so on).
   #


### PR DESCRIPTION
- [x] Set a NOP generator in a target (example: `'Payload' => {'Nop' => 'php/generic'}`)
- [x] Test to see that it's used
- [x] Set the `NOP` option
- [x] See that it overrides the target's NOP generator
- [x] Set `NOP` to something wildly incompatible
- [x] Laugh as your exploit fails predictably

This completes #9892.