### PR TITLE
Pass NOP generator to exploit_simple

### DIFF
--- a/lib/msf/base/simple/exploit.rb
+++ b/lib/msf/base/simple/exploit.rb
@@ -98,6 +98,11 @@ module Exploit
       # best encoder.
       exploit.datastore['ENCODER'] = opts['Encoder'] if opts['Encoder']
 
+      # Use the supplied NOP generator, if any.  If one was not specified, then
+      # nil will be assigned causing the exploit to default to picking a
+      # compatible NOP generator.
+      exploit.datastore['NOP'] = opts['Nop'] if opts['Nop']
+
       # Force the payload to share the exploit's datastore
       driver.payload.share_datastore(driver.exploit.datastore)
 


### PR DESCRIPTION
This also makes `exploit_simple` consistent with its documentation.

Before:

```
[1] pry(#<Msf::Modules::Mod6578706c6f69742f77696e646f77732f736d622f6d7330385f3036375f6e6574617069::MetasploitModule>)> exploit_simple('Payload' => 'windows/meterpreter/reverse_tcp', 'Encoder' => 'generic/eicar', 'Nop' => 'tty/generic')


From: /home/wvu/metasploit-framework/lib/msf/core/exploit.rb @ line 555 Msf::Exploit#generate_single_payload:

    550:     reqs['AppendEncoder']   = payload_append_encoder(explicit_target)
    551:     reqs['MaxNops']         = payload_max_nops(explicit_target)
    552:     reqs['MinNops']         = payload_min_nops(explicit_target)
    553:     reqs['Encoder']         = datastore['ENCODER'] || payload_encoder(explicit_target)
    554:     reqs['Nop']             = datastore['NOP'] || payload_nop(explicit_target)
 => 555:     require 'pry'; binding.pry
    556:     reqs['EncoderType']     = payload_encoder_type(explicit_target)
    557:     reqs['EncoderOptions']  = payload_encoder_options(explicit_target)
    558:     reqs['ExtendedOptions'] = payload_extended_options(explicit_target)
    559:     reqs['Exploit']         = self
    560:

[1] pry(#<Msf::Modules::Mod6578706c6f69742f77696e646f77732f736d622f6d7330385f3036375f6e6574617069::MetasploitModule>)> reqs
=> {"Space"=>408,
 "SaveRegisters"=>["esp", "ebp"],
 "Prepend"=>"",
 "PrependEncoder"=>"",
 "BadChars"=>nil,
 "Append"=>"",
 "AppendEncoder"=>"",
 "MaxNops"=>nil,
 "MinNops"=>nil,
 "Encoder"=>"generic/eicar",
 "Nop"=>nil}
[2] pry(#<Msf::Modules::Mod6578706c6f69742f77696e646f77732f736d622f6d7330385f3036375f6e6574617069::MetasploitModule>)>

[!] You are binding to a loopback address by setting LHOST to 127.0.0.1. Did you want ReverseListenerBindAddress?
[*] Started reverse TCP handler on 127.0.0.1:4444
"\x93\xFDN\x9B7FC\x9F?BA\xFD\xF5\x90\x98\x93\x98H\x99\x90I\x99I\xD6F\x99G\x90\xF9\xD6@@\x91\xFC\xFC\xF5\x90\xF8\xFD\x9F\x9FAI\xD6\x92A\x99\x9FO\xF9JNF\x97\x9B\x90\x93\x9BFK\xF9\x91?J\x91\x96NJN\x97IJ\x92IGB/\xF5\x90H\x93\xD6BA\xD6K@\x9B\x9FI\xD6\x96H\x96\xFC\x91\x93\x90\xF9N\x91\x96I\xF9N\x96\xD6G\xF8@\x91\x93'?/'?@AKI\xD6\x92\xF5AJN\xD6GK\x96\x97'\x98?I\x93K\x93\xFDKJ\x9B\x98\x92F\xFCC'\x90\x92\x9F\xD6A\x97N\xF97FNF\x9B?IG\x907A\x98\x91\xF8AF\x93I\xF9O\x93\x99?@\xD6\x93\x93\x98\x91'\x98KC\xFCA/H\xF9N\x90\xFCA\xF5I\x9BAGK/AK\x9B\x99KKJ\x96\xF5'\x93/\x97\x90\x90\xFC\x97/\x96\xFD\x90J\x9B\x93K\x98KJ@B\xF5\x98\x91CF'?/\x97ABG\x90N@O\xF8\xD6\xFD'\x9B\x99A\x98HH\x91\xD6\xD6H?7\x92A/\xFD/\x96F\x90CJ\x97\x93''J\x96\x9F@\x97\x91H'GGFO\xF9\xFC\x90\x93@@\x9F'\x99\x98F'\x91\x96\x93J\x99\xFD\x92FC@\x93N\x92F\x97\x92G\x98\x99\x9F\xD6'\x92\xF9\xF8\x91H\x92\xF8'@\xF9\x9F'X5O!P%@AP[4\\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*"
=> nil
[2] pry(#<Msf::Modules::Mod6578706c6f69742f77696e646f77732f736d622f6d7330385f3036375f6e6574617069::MetasploitModule>)>
```

After:

```
[1] pry(#<Msf::Modules::Mod6578706c6f69742f77696e646f77732f736d622f6d7330385f3036375f6e6574617069::MetasploitModule>)> exploit_simple('Payload' => 'windows/meterpreter/reverse_tcp', 'Encoder' => 'generic/eicar', 'Nop' => 'tty/generic')


From: /home/wvu/metasploit-framework/lib/msf/core/exploit.rb @ line 555 Msf::Exploit#generate_single_payload:

    550:     reqs['AppendEncoder']   = payload_append_encoder(explicit_target)
    551:     reqs['MaxNops']         = payload_max_nops(explicit_target)
    552:     reqs['MinNops']         = payload_min_nops(explicit_target)
    553:     reqs['Encoder']         = datastore['ENCODER'] || payload_encoder(explicit_target)
    554:     reqs['Nop']             = datastore['NOP'] || payload_nop(explicit_target)
 => 555:     require 'pry'; binding.pry
    556:     reqs['EncoderType']     = payload_encoder_type(explicit_target)
    557:     reqs['EncoderOptions']  = payload_encoder_options(explicit_target)
    558:     reqs['ExtendedOptions'] = payload_extended_options(explicit_target)
    559:     reqs['Exploit']         = self
    560:

[1] pry(#<Msf::Modules::Mod6578706c6f69742f77696e646f77732f736d622f6d7330385f3036375f6e6574617069::MetasploitModule>)> reqs
=> {"Space"=>408,
 "SaveRegisters"=>["esp", "ebp"],
 "Prepend"=>"",
 "PrependEncoder"=>"",
 "BadChars"=>nil,
 "Append"=>"",
 "AppendEncoder"=>"",
 "MaxNops"=>nil,
 "MinNops"=>nil,
 "Encoder"=>"generic/eicar",
 "Nop"=>"tty/generic"}
[2] pry(#<Msf::Modules::Mod6578706c6f69742f77696e646f77732f736d622f6d7330385f3036375f6e6574617069::MetasploitModule>)>

[!] You are binding to a loopback address by setting LHOST to 127.0.0.1. Did you want ReverseListenerBindAddress?
[*] Started reverse TCP handler on 127.0.0.1:4444
"
                                                                                                                                                   X5O!P%@AP[4\\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*"
=> nil
[2] pry(#<Msf::Modules::Mod6578706c6f69742f77696e646f77732f736d622f6d7330385f3036375f6e6574617069::MetasploitModule>)>
```

Updates #9898 and #9892.