### PR TITLE
Fix Crash On Startup When No DB Configured

### DIFF
--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -378,7 +378,7 @@ class Driver < Msf::Ui::Driver
         print_warning("\t#{path}: #{error}")
       end
     end
-    framework.db.workspace = framework.db.default_workspace
+    framework.db.workspace = framework.db.default_workspace if framework.db && framework.db.active
 
     framework.events.on_ui_start(Msf::Framework::Revision)
 


### PR DESCRIPTION
Fixes a bug introduced by #9859 when attempting to startup msfconsole without a database configured. It was attempting to set the default workspace even though there was no DB to set that value in. It will now only attempt to set the active workspace if there is a DB active.

## Verification

List the steps needed to make sure this thing works

- [x] `mv config/database.yml config/database.yml.disabled`
- [x] Start `msfconsole`. It should show a warning that there is no database, but start up correctly.
- [x] `mv config/database.yml.disabled config/database.yml`
- [x] Start `msfconsole`. It should start up correctly, verify you can perform database operations.


