### PR TITLE
Fix type validation in the notes add operation

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -1056,7 +1056,7 @@ class Db
         return
       end
 
-      if types && types.size != 1
+      if types.nil? || types.size != 1
         print_error("Exactly one type is required")
         return
       end
@@ -1078,12 +1078,12 @@ class Db
     end
 
     if mode == :update
-      if types && types.size != 1
+      if !types.nil? && types.size != 1
         print_error("Exactly one type is required")
         return
       end
 
-      if !types && !data
+      if types.nil? && data.nil?
         print_error("Update requires data or type")
         return
       end
@@ -1119,12 +1119,12 @@ class Db
       if mode == :update
         begin
           update_opts = {id: note.id}
-          if types
+          unless types.nil?
             note.ntype = types.first
             update_opts[:ntype] = types.first
           end
 
-          if data
+          unless data.nil?
             note.data = data
             update_opts[:data] = data
           end


### PR DESCRIPTION
Fix issue with type validation in the notes add operation that was introduced in #9873. This also makes variable nil checks explicit for better style.

Example error output:
```
msf5 > notes --add --note "note data" 127.0.0.1
[-] Error while running command notes: undefined method `first' for nil:NilClass

Call stack:
/home/msfdev/metasploit-framework/lib/msf/ui/console/command_dispatcher/db.rb:1069:in `block in cmd_notes'
/Users/mkienow/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activerecord-4.2.10/lib/active_record/connection_adapters/abstract/connection_pool.rb:292:in `with_connection'
/home/msfdev/metasploit-framework/lib/msf/ui/console/command_dispatcher/db.rb:998:in `cmd_notes'
/home/msfdev/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:548:in `run_command'
/home/msfdev/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:510:in `block in run_single'
/home/msfdev/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:504:in `each'
/home/msfdev/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:504:in `run_single'
/home/msfdev/metasploit-framework/lib/rex/ui/text/shell.rb:208:in `run'
/home/msfdev/metasploit-framework/lib/metasploit/framework/command/console.rb:48:in `start'
/home/msfdev/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'
./msfconsole:49:in `<main>'
```

## Verification

- [x] Start `msfconsole`
- [x] Create a note with the note option, but without any type option: `notes --add --note "note data" <address>`
- [x] **Verify**  the `notes` command outputs the error "Exactly one type is required"
- [x] Create a note with the note option, but with the type option specifying two or more types: `notes --add --note "note data" --type test1,test2 <address>`
- [x] **Verify**  the `notes` command outputs the error "Exactly one type is required"
- [x] Create a note with a type option but without a note option: `notes --add --type "note type" <address>`
- [x] **Verify**  the `notes` command outputs the error "Data required"
- [x] Create a note with the note option and the type option specifying a single type: `notes --add --note "note data" --type "note type" <address>`
- [x] **Verify**  the output of the `notes` shows the newly added note
- [x] Update the note without note or type options: `notes --update <address>`
- [x] **Verify**  the `notes` command outputs the error "Update requires data or type"
- [x] Update the note with the type option specifying two or more types: `notes --update --type test1,test2 <address>`
- [x] **Verify**  the `notes` command outputs the error "Exactly one type is required"
- [x] Update the note's data: `notes --update --note "data update" <address>`
- [x] **Verify**  the output of the `notes` command shows the note's updated data
- [x] Update the note's type: `notes --update --type "type update" <address>`
- [x] **Verify**  the output of the `notes` command shows the note's updated type
- [x] Update the note's data and type: `notes --update --note "data update 2" --type "type update 2" <address>`
- [x] **Verify**  the output of the `notes` command shows the note's updated data and type