### PR TITLE
Improve printing in ETERNALBLUE's verify_arch

### DIFF
--- a/modules/exploits/windows/smb/ms17_010_eternalblue.rb
+++ b/modules/exploits/windows/smb/ms17_010_eternalblue.rb
@@ -277,8 +277,20 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def verify_arch
+    ret = false
+
     return true unless datastore['VerifyArch']
-    (dcerpc_getarch == target_arch.first) ? true : false
+
+    # XXX: This sends a new DCE/RPC packet
+    arch = dcerpc_getarch
+
+    if arch && arch == target_arch.first
+      ret = true
+    else
+      print_error("Target arch is #{target_arch.first}, but server returned #{arch.inspect}")
+    end
+
+    ret
   end
 
   def print_core_buffer(os)

--- a/modules/exploits/windows/smb/ms17_010_eternalblue.rb
+++ b/modules/exploits/windows/smb/ms17_010_eternalblue.rb
@@ -287,7 +287,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if arch && arch == target_arch.first
       ret = true
     else
-      print_error("Target arch is #{target_arch.first}, but server returned #{arch.inspect}")
+      print_warning("Target arch is #{target_arch.first}, but server returned #{arch.inspect}")
     end
 
     ret


### PR DESCRIPTION
Now shows the invalid arch instead of showing nothing.

- [x] Test with valid arch
- [x] Get a shell
- [x] Test with invalid arch
- [x] See what it is
- [x] Test with `VerifyArch` disabled
- [x]  Get a shell (or don't)

```
msf5 exploit(windows/smb/ms17_010_eternalblue) > run

[*] Started reverse TCP handler on 192.168.212.1:4444
[*] 192.168.212.130:445 - Connecting to target for exploitation.
[+] 192.168.212.130:445 - Connection established for exploitation.
[+] 192.168.212.130:445 - Target OS selected valid for OS indicated by SMB reply
[*] 192.168.212.130:445 - CORE raw buffer dump (51 bytes)
[*] 192.168.212.130:445 - 0x00000000  57 69 6e 64 6f 77 73 20 53 65 72 76 65 72 20 32  Windows Server 2
[*] 192.168.212.130:445 - 0x00000010  30 30 38 20 52 32 20 53 74 61 6e 64 61 72 64 20  008 R2 Standard
[*] 192.168.212.130:445 - 0x00000020  37 36 30 31 20 53 65 72 76 69 63 65 20 50 61 63  7601 Service Pac
[*] 192.168.212.130:445 - 0x00000030  6b 20 31                                         k 1

[!] 192.168.212.130:445 - Target arch is x64, but server returned "x86"
[!] 192.168.212.130:445 - Target arch selected not valid for arch indicated by DCE/RPC reply
[!] 192.168.212.130:445 - Disable VerifyArch option to proceed manually...
[-] 192.168.212.130:445 - Unable to continue with improper OS Arch.
[*] Exploit completed, but no session was created.
msf5 exploit(windows/smb/ms17_010_eternalblue) >
```

Fixes #9894.