### PR TITLE
Fix Missing :workspace Attribute On db_import Command

### DIFF
--- a/lib/metasploit/framework/data_service/proxy/data_proxy_auto_loader.rb
+++ b/lib/metasploit/framework/data_service/proxy/data_proxy_auto_loader.rb
@@ -17,6 +17,7 @@ module DataProxyAutoLoader
   autoload :CredentialDataProxy, 'metasploit/framework/data_service/proxy/credential_data_proxy'
   autoload :NmapDataProxy, 'metasploit/framework/data_service/proxy/nmap_data_proxy'
   autoload :DbExportDataProxy, 'metasploit/framework/data_service/proxy/db_export_data_proxy'
+  autoload :DbImportDataProxy, 'metasploit/framework/data_service/proxy/db_import_data_proxy'
   autoload :VulnAttemptDataProxy, 'metasploit/framework/data_service/proxy/vuln_attempt_data_proxy'
 
   include ServiceDataProxy
@@ -33,5 +34,6 @@ module DataProxyAutoLoader
   include CredentialDataProxy
   include NmapDataProxy
   include DbExportDataProxy
+  include DbImportDataProxy
   include VulnAttemptDataProxy
 end

--- a/lib/metasploit/framework/data_service/proxy/db_import_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/db_import_data_proxy.rb
@@ -1,0 +1,21 @@
+module DbImportDataProxy
+  def import(opts, &block)
+    begin
+      data_service = self.get_data_service
+      add_opts_workspace(opts)
+      data_service.import(opts, &block)
+    rescue Exception => e
+      self.log_error(e, "Problem generating DB Export")
+    end
+  end
+
+  def import_file(opts, &block)
+    begin
+      data_service = self.get_data_service
+      add_opts_workspace(opts)
+      data_service.import_file(opts, &block)
+    rescue Exception => e
+      self.log_error(e, "Problem generating DB Export")
+    end
+  end
+end

--- a/lib/metasploit/framework/data_service/stubs/db_export_service.rb
+++ b/lib/metasploit/framework/data_service/stubs/db_export_service.rb
@@ -1,0 +1,5 @@
+module DbExportDataService
+  def run_db_export(path, format)
+    raise 'DbExportDataService#run_db_export is not implemented'
+  end
+end

--- a/lib/metasploit/framework/data_service/stubs/db_import_service.rb
+++ b/lib/metasploit/framework/data_service/stubs/db_import_service.rb
@@ -1,0 +1,9 @@
+module DbImportDataService
+  def import(opts, &block)
+    raise 'DbImportDataService#import is not implemented'
+  end
+
+  def import_file(opts, &block)
+    raise 'DbImportDataService#import_file is not implemented'
+  end
+end


### PR DESCRIPTION
This PR fixes the issue described in #9921. It was introduced in #9859 and caused by DBManager actions now requiring the `:workspace` value to be passed in everywhere. These changes add a proxy for db_import methods, which also ensure the `:workspace` value is included in `opts`.

## Verification

List the steps needed to make sure this thing works

- [x] Scan some hosts using `nmap` or `masscan` and export the results to XML.
- [x] Start `msfconsole`
- [x] `db_import <scan_file.xml>`
- [x] Verify the data was inserted correctly

