### PR TITLE
Fix #9876, minor updates to Drupalgeddon 2

### DIFF
--- a/modules/exploits/unix/webapp/drupal_drupalgeddon2.rb
+++ b/modules/exploits/unix/webapp/drupal_drupalgeddon2.rb
@@ -19,8 +19,6 @@ class MetasploitModule < Msf::Exploit::Remote
         This module exploits a Drupal property injection in the Forms API.
 
         Drupal 6.x, < 7.58, 8.2.x, < 8.3.9, < 8.4.6, and < 8.5.1 are vulnerable.
-
-        Tested on 7.57 and 8.4.5.
       },
       'Author'         => [
         'Jasper Mattsson', # Vulnerability discovery
@@ -199,16 +197,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
       dropper_exec
     end
-  end
-
-  # XXX: Ivars are being preserved
-  def cleanup
-    begin
-      remove_instance_variable(:@version)
-    rescue NameError
-    end
-
-    super
   end
 
   def dropper_assert


### PR DESCRIPTION
1. Tested versions are already listed in the module doc, and we've tested more than just 7.57 and 8.4.5 now. Removing a source of potential inconsistency in the future.
2. No problem with ivars anymore. No idea what happened, but maybe I was just too tired to code. Removing `cleanup` method.

For #9876.