### PR TITLE
Revert NoteDataService to raise RuntimeError

### DIFF
--- a/lib/metasploit/framework/data_service/stubs/note_data_service.rb
+++ b/lib/metasploit/framework/data_service/stubs/note_data_service.rb
@@ -1,19 +1,19 @@
 module NoteDataService
 
   def notes(opts)
-    raise NotImplementedError, 'NoteDataService#notes is not implemented'
+    raise 'NoteDataService#notes is not implemented'
   end
 
   def report_note(opts)
-    raise NotImplementedError, 'NoteDataService#report_note is not implemented'
+    raise 'NoteDataService#report_note is not implemented'
   end
 
   def update_note(opts)
-    raise NotImplementedError, 'NoteDataService#update_note is not implemented'
+    raise 'NoteDataService#update_note is not implemented'
   end
 
   def delete_note(opts)
-    raise NotImplementedError, 'NoteDataService#delete_note is not implemented'
+    raise 'NoteDataService#delete_note is not implemented'
   end
 
 end


### PR DESCRIPTION
It was suggested in a [comment](https://github.com/rapid7/metasploit-framework/pull/9873#discussion_r181427092) on #9873, that `raise NotImplementedError` be used in place of the simple `raise` (a `RuntimeError`). I ran with the suggestion from Python/Java experience with similar such exceptions. However, upon further investigation `NotImplementedError` doesn't seem appropriate since it doesn't sit under `StandardError` in the exception hierarchy and thus will not be handled by a simple `rescue`.