### PR TITLE
Narrow rescue scope to StandardError

### DIFF
--- a/lib/metasploit/framework/data_service/proxy/credential_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/credential_data_proxy.rb
@@ -4,7 +4,7 @@ module CredentialDataProxy
     begin
       data_service = self.get_data_service
       data_service.create_credential(opts)
-    rescue Exception => e
+    rescue => e
       self.log_error(e, "Problem creating credential")
     end
   end
@@ -14,7 +14,7 @@ module CredentialDataProxy
       data_service = self.get_data_service
       add_opts_workspace(opts)
       data_service.creds(opts)
-    rescue Exception => e
+    rescue => e
       self.log_error(e, "Problem retrieving credentials")
     end
   end

--- a/lib/metasploit/framework/data_service/proxy/db_export_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/db_export_data_proxy.rb
@@ -8,7 +8,7 @@ module DbExportDataProxy
       }
       add_opts_workspace(opts)
       data_service.run_db_export(opts)
-    rescue Exception => e
+    rescue => e
       self.log_error(e, "Problem generating DB Export")
     end
   end

--- a/lib/metasploit/framework/data_service/proxy/event_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/event_data_proxy.rb
@@ -5,7 +5,7 @@ module EventDataProxy
       data_service = self.get_data_service
       add_opts_workspace(opts)
       data_service.report_event(opts)
-    rescue  Exception => e
+    rescue => e
       self.log_error(e, "Problem reporting event")
     end
   end

--- a/lib/metasploit/framework/data_service/proxy/exploit_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/exploit_data_proxy.rb
@@ -4,7 +4,7 @@ module ExploitDataProxy
     begin
       data_service = self.get_data_service
       data_service.report_exploit_attempt(host, opts)
-    rescue  Exception => e
+    rescue => e
       self.log_error(e, "Problem reporting exploit attempt")
     end
   end
@@ -14,7 +14,7 @@ module ExploitDataProxy
       data_service = self.get_data_service
       add_opts_workspace(opts)
       data_service.report_exploit_failure(opts)
-    rescue  Exception => e
+    rescue => e
       self.log_error(e, "Problem reporting exploit failure")
     end
   end
@@ -24,7 +24,7 @@ module ExploitDataProxy
       data_service = self.get_data_service
       add_opts_workspace(opts)
       data_service.report_exploit_success(opts)
-    rescue  Exception => e
+    rescue => e
       self.log_error(e, "Problem reporting exploit success")
     end
   end

--- a/lib/metasploit/framework/data_service/proxy/host_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/host_data_proxy.rb
@@ -9,7 +9,7 @@ module HostDataProxy
       opts[:address] = addresses
       opts[:search_term] = search_term
       data_service.hosts(opts)
-    rescue Exception => e
+    rescue => e
       self.log_error(e, "Problem retrieving hosts")
     end
   end
@@ -27,7 +27,7 @@ module HostDataProxy
       data_service = self.get_data_service
       add_opts_workspace(opts)
       data_service.report_host(opts)
-    rescue Exception => e
+    rescue => e
       self.log_error(e, "Problem reporting host")
     end
   end
@@ -37,7 +37,7 @@ module HostDataProxy
       data_service = self.get_data_service
       add_opts_workspace(hosts)
       data_service.report_hosts(hosts)
-    rescue Exception => e
+    rescue => e
       self.log_error(e, "Problem reporting hosts")
     end
   end
@@ -46,7 +46,7 @@ module HostDataProxy
     begin
       data_service = self.get_data_service
       data_service.update_host(opts)
-    rescue Exception => e
+    rescue => e
       self.log_error(e, "Problem updating host")
     end
   end
@@ -55,7 +55,7 @@ module HostDataProxy
     begin
       data_service = self.get_data_service
       data_service.delete_host(opts)
-    rescue Exception => e
+    rescue => e
       self.log_error(e, "Problem deleting host")
     end
   end

--- a/lib/metasploit/framework/data_service/proxy/loot_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/loot_data_proxy.rb
@@ -8,7 +8,7 @@ module LootDataProxy
       end
       add_opts_workspace(opts)
       data_service.report_loot(opts)
-    rescue Exception => e
+    rescue => e
       self.log_error(e, "Problem reporting loot")
     end
   end
@@ -24,7 +24,7 @@ module LootDataProxy
       data_service = self.get_data_service
       add_opts_workspace(opts, wspace)
       data_service.loot(opts)
-    rescue Exception => e
+    rescue => e
       self.log_error(e, "Problem retrieving loot")
     end
   end
@@ -35,7 +35,7 @@ module LootDataProxy
     begin
       data_service = self.get_data_service
       data_service.update_loot(opts)
-    rescue Exception => e
+    rescue => e
       self.log_error(e, "Problem updating loot")
     end
   end

--- a/lib/metasploit/framework/data_service/proxy/nmap_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/nmap_data_proxy.rb
@@ -5,7 +5,7 @@ module NmapDataProxy
       data_service = self.get_data_service
       add_opts_workspace(args)
       data_service.import_nmap_xml_file(args)
-    rescue Exception => e
+    rescue => e
       self.log_error(e, "Problem importing Nmap XML file")
     end
   end

--- a/lib/metasploit/framework/data_service/proxy/note_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/note_data_proxy.rb
@@ -5,7 +5,7 @@ module NoteDataProxy
       data_service = self.get_data_service
       add_opts_workspace(opts)
       data_service.notes(opts)
-    rescue Exception => e
+    rescue => e
       self.log_error(e, "Problem retrieving notes")
     end
   end
@@ -20,7 +20,7 @@ module NoteDataProxy
       data_service = self.get_data_service
       add_opts_workspace(opts)
       data_service.report_note(opts)
-    rescue  Exception => e
+    rescue => e
       self.log_error(e, "Problem reporting note")
     end
   end
@@ -29,7 +29,7 @@ module NoteDataProxy
     begin
       data_service = self.get_data_service
       data_service.update_note(opts)
-    rescue Exception => e
+    rescue => e
       self.log_error(e, "Problem updating note")
     end
   end
@@ -38,7 +38,7 @@ module NoteDataProxy
     begin
       data_service = self.get_data_service
       data_service.delete_note(opts)
-    rescue Exception => e
+    rescue => e
       self.log_error(e, "Problem deleting note")
     end
   end

--- a/lib/metasploit/framework/data_service/proxy/service_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/service_data_proxy.rb
@@ -5,7 +5,7 @@ module ServiceDataProxy
       data_service = self.get_data_service
       add_opts_workspace(opts, wspace)
       data_service.services(opts)
-    rescue Exception => e
+    rescue => e
       self.log_error(e, 'Problem retrieving services')
     end
   end
@@ -19,7 +19,7 @@ module ServiceDataProxy
       data_service = self.get_data_service
       add_opts_workspace(opts)
       data_service.report_service(opts)
-    rescue  Exception => e
+    rescue => e
       self.log_error(e, 'Problem reporting service')
     end
   end
@@ -28,7 +28,7 @@ module ServiceDataProxy
     begin
       data_service = self.get_data_service
       data_service.update_service(opts)
-    rescue Exception => e
+    rescue => e
       self.log_error(e, 'Problem updating service')
     end
   end
@@ -37,7 +37,7 @@ module ServiceDataProxy
     begin
       data_service = self.get_data_service
       data_service.delete_service(opts)
-    rescue Exception => e
+    rescue => e
       self.log_error(e, 'Problem deleting service')
     end
   end

--- a/lib/metasploit/framework/data_service/proxy/session_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/session_data_proxy.rb
@@ -3,7 +3,7 @@ module SessionDataProxy
     begin
       data_service = self.get_data_service
       data_service.report_session(opts)
-    rescue  Exception => e
+    rescue => e
       self.log_error(e, "Problem reporting session")
     end
   end

--- a/lib/metasploit/framework/data_service/proxy/session_event_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/session_event_data_proxy.rb
@@ -4,7 +4,7 @@ module SessionEventDataProxy
     begin
       data_service = self.get_data_service()
       data_service.report_session_event(opts)
-    rescue Exception => e
+    rescue => e
       self.log_error(e, "Problem reporting session event")
     end
   end

--- a/lib/metasploit/framework/data_service/proxy/vuln_attempt_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/vuln_attempt_data_proxy.rb
@@ -4,7 +4,7 @@ module VulnAttemptDataProxy
     begin
       data_service = self.get_data_service
       data_service.vuln_attempts(opts)
-    rescue Exception => e
+    rescue => e
       self.log_error(e, "Problem retrieving vulnerability attempts")
     end
   end
@@ -14,7 +14,7 @@ module VulnAttemptDataProxy
       data_service = self.get_data_service
       add_opts_workspace(opts)
       data_service.report_vuln_attempt(vuln, opts)
-    rescue Exception => e
+    rescue => e
       self.log_error(e, "Problem reporting vulnerability attempts")
     end
   end

--- a/lib/metasploit/framework/data_service/proxy/vuln_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/vuln_data_proxy.rb
@@ -6,7 +6,7 @@ module VulnDataProxy
       data_service = self.get_data_service
       add_opts_workspace(opts)
       data_service.vulns(opts)
-    rescue Exception => e
+    rescue => e
       self.log_error(e, "Problem retrieving vulns")
     end
   end
@@ -16,7 +16,7 @@ module VulnDataProxy
       data_service = self.get_data_service
       add_opts_workspace(opts)
       data_service.report_vuln(opts)
-    rescue Exception => e
+    rescue => e
       self.log_error(e, "Problem reporting vuln")
     end
   end
@@ -25,7 +25,7 @@ module VulnDataProxy
     begin
       data_service = self.get_data_service
       data_service.update_vuln(opts)
-    rescue Exception => e
+    rescue => e
       self.log_error(e, "Problem updating vuln")
     end
   end
@@ -34,7 +34,7 @@ module VulnDataProxy
     begin
       data_service = self.get_data_service
       data_service.delete_vuln(opts)
-    rescue Exception => e
+    rescue => e
       self.log_error(e, "Problem deleting vuln")
     end
   end

--- a/lib/metasploit/framework/data_service/proxy/web_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/web_data_proxy.rb
@@ -3,7 +3,7 @@ module WebDataProxy
     begin
       data_service = self.get_data_service()
       data_service.report_web_site(opts)
-    rescue  Exception => e
+    rescue => e
       self.log_error(e, "Problem reporting website")
     end
   end

--- a/lib/metasploit/framework/data_service/proxy/workspace_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/workspace_data_proxy.rb
@@ -5,7 +5,7 @@ module WorkspaceDataProxy
       data_service = self.get_data_service
       opts = { name: workspace_name }
       data_service.workspaces(opts).first
-    rescue  Exception => e
+    rescue => e
       self.log_error(e, "Problem finding workspace")
     end
   end
@@ -15,7 +15,7 @@ module WorkspaceDataProxy
       data_service = self.get_data_service
       opts = { name: workspace_name }
       data_service.add_workspace(opts)
-    rescue  Exception => e
+    rescue => e
       self.log_error(e, "Problem adding workspace")
     end
   end
@@ -27,7 +27,7 @@ module WorkspaceDataProxy
         ws = add_workspace(Msf::DBManager::Workspace::DEFAULT_WORKSPACE_NAME)
       end
       ws
-    rescue  Exception => e
+    rescue => e
       self.log_error(e, "Problem finding default workspace")
     end
   end
@@ -42,7 +42,7 @@ module WorkspaceDataProxy
         warn "@current_workspace was not set. Setting to default_workspace: #{default_workspace.name}"
         @current_workspace = default_workspace
       end
-    rescue  Exception => e
+    rescue => e
       self.log_error(e, "Problem retrieving workspace")
     end
   end
@@ -51,7 +51,7 @@ module WorkspaceDataProxy
   def workspace=(workspace)
     begin
       @current_workspace = workspace
-    rescue  Exception => e
+    rescue => e
       self.log_error(e, "Problem setting workspace")
     end
   end
@@ -60,7 +60,7 @@ module WorkspaceDataProxy
     begin
       data_service = self.get_data_service
       data_service.workspaces(opts)
-    rescue  Exception => e
+    rescue => e
       self.log_error(e, "Problem retrieving workspaces")
     end
   end
@@ -69,7 +69,7 @@ module WorkspaceDataProxy
     begin
       data_service = self.get_data_service
       data_service.delete_workspaces(opts)
-    rescue Exception => e
+    rescue => e
       self.log_error(e, "Problem deleting workspaces")
     end
   end
@@ -78,7 +78,7 @@ module WorkspaceDataProxy
     begin
       data_service = self.get_data_service
       data_service.update_workspace(opts)
-    rescue Exception => e
+    rescue => e
       self.log_error(e, "Problem updating workspace")
     end
   end

--- a/lib/metasploit/framework/data_service/remote/http/response_data_helper.rb
+++ b/lib/metasploit/framework/data_service/remote/http/response_data_helper.rb
@@ -20,7 +20,7 @@ module ResponseDataHelper
           return JSON.parse(body).symbolize_keys
         end
       end
-    rescue Exception => e
+    rescue => e
       elog "Error parsing response: #{e.message}"
       e.backtrace.each { |line| elog line }
     end
@@ -36,7 +36,7 @@ module ResponseDataHelper
         if !body.nil? && !body.empty?
           return JSON.parse(body, object_class: OpenStruct)
         end
-      rescue Exception => e
+      rescue => e
         elog "open struct conversion failed #{e.message}"
       end
     end
@@ -64,7 +64,7 @@ module ResponseDataHelper
           end
           return rv
         end
-      rescue Exception => e
+      rescue => e
         elog "Mdm Object conversion failed #{e.message}"
         e.backtrace.each { |line| elog "#{line}\n" }
       end
@@ -87,7 +87,7 @@ module ResponseDataHelper
       unless File.exists?(save_path) && File.read(save_path) == decoded_file
         File.open(save_path, 'w+') { |file| file.write(decoded_file) }
       end
-    rescue Exception => e
+    rescue => e
       elog "There was an error writing the file: #{e}"
       e.backtrace.each { |line| elog "#{line}\n"}
     end

--- a/lib/metasploit/framework/login_scanner/bavision_cameras.rb
+++ b/lib/metasploit/framework/login_scanner/bavision_cameras.rb
@@ -5,7 +5,7 @@ module Metasploit
   module Framework
     module LoginScanner
 
-      class BavisionCamerasException < Exception; end
+      class BavisionCamerasException < StandardError; end
 
       class BavisionCameras < HTTP
 

--- a/lib/msf/core/db_manager/http/job_processor.rb
+++ b/lib/msf/core/db_manager/http/job_processor.rb
@@ -20,7 +20,7 @@ class JobProcessor
         wrapper = @job_queue.pop()
         begin
           wrapper.job.call(wrapper.job_args)
-        rescue Exception => e
+        rescue => e
           print_error "Error executing job #{e.message}", e
         end
       end

--- a/lib/msf/core/db_manager/http/servlet/credential_servlet.rb
+++ b/lib/msf/core/db_manager/http/servlet/credential_servlet.rb
@@ -27,7 +27,7 @@ module CredentialServlet
           response << json
         end
         set_json_response(response)
-      rescue Exception => e
+      rescue => e
         set_error_on_response(e)
       end
     }

--- a/lib/msf/core/db_manager/http/servlet/db_export_servlet.rb
+++ b/lib/msf/core/db_manager/http/servlet/db_export_servlet.rb
@@ -24,7 +24,7 @@ module DbExportServlet
         response = {}
         response[:db_export_file] = encoded_file
         set_json_response(response)
-      rescue Exception => e
+      rescue => e
         set_error_on_response(e)
       ensure
         # Ensure the temporary file gets cleaned up

--- a/lib/msf/core/db_manager/http/servlet/host_servlet.rb
+++ b/lib/msf/core/db_manager/http/servlet/host_servlet.rb
@@ -27,7 +27,7 @@ module HostServlet
         data = get_db.hosts(sanitized_params)
         includes = [:loots]
         set_json_response(data, includes)
-      rescue Exception => e
+      rescue => e
         set_error_on_response(e)
       end
     }
@@ -40,7 +40,7 @@ module HostServlet
           data = get_db.report_host(opts)
         }
         exec_report_job(request, &job)
-      rescue Exception => e
+      rescue => e
         set_error_on_response(e)
       end
     }
@@ -54,7 +54,7 @@ module HostServlet
         opts[:id] = tmp_params[:id] if tmp_params[:id]
         data = get_db.update_host(opts)
         set_json_response(data)
-      rescue Exception => e
+      rescue => e
         set_error_on_response(e)
       end
     }
@@ -66,7 +66,7 @@ module HostServlet
         opts = parse_json_request(request, false)
         data = get_db.delete_host(opts)
         set_json_response(data)
-      rescue Exception => e
+      rescue => e
         set_error_on_response(e)
       end
     }

--- a/lib/msf/core/db_manager/http/servlet/loot_servlet.rb
+++ b/lib/msf/core/db_manager/http/servlet/loot_servlet.rb
@@ -30,7 +30,7 @@ module LootServlet
           loot.data = Base64.urlsafe_encode64(loot.data) if loot.data
         end
         set_json_response(data, includes)
-      rescue Exception => e
+      rescue => e
         set_error_on_response(e)
       end
     }
@@ -60,7 +60,7 @@ module LootServlet
         opts[:id] = tmp_params[:id] if tmp_params[:id]
         data = get_db.update_loot(opts)
         set_json_response(data)
-      rescue Exception => e
+      rescue => e
         set_error_on_response(e)
       end
     }
@@ -72,7 +72,7 @@ module LootServlet
         opts = parse_json_request(request, false)
         data = get_db.delete_loot(opts)
         set_json_response(data)
-      rescue Exception => e
+      rescue => e
         set_error_on_response(e)
       end
     }

--- a/lib/msf/core/db_manager/http/servlet/note_servlet.rb
+++ b/lib/msf/core/db_manager/http/servlet/note_servlet.rb
@@ -27,7 +27,7 @@ module NoteServlet
         data = get_db.notes(sanitized_params)
         includes = [:host]
         set_json_response(data, includes)
-      rescue Exception => e
+      rescue => e
         set_error_on_response(e)
       end
     }
@@ -40,7 +40,7 @@ module NoteServlet
           get_db.report_note(opts)
         }
         exec_report_job(request, &job)
-      rescue Exception => e
+      rescue => e
         set_error_on_response(e)
       end
     }
@@ -54,7 +54,7 @@ module NoteServlet
         opts[:id] = tmp_params[:id] if tmp_params[:id]
         data = get_db.update_note(opts)
         set_json_response(data)
-      rescue Exception => e
+      rescue => e
         set_error_on_response(e)
       end
     }
@@ -66,7 +66,7 @@ module NoteServlet
         opts = parse_json_request(request, false)
         data = get_db.delete_note(opts)
         set_json_response(data)
-      rescue Exception => e
+      rescue => e
         set_error_on_response(e)
       end
     }

--- a/lib/msf/core/db_manager/http/servlet/service_servlet.rb
+++ b/lib/msf/core/db_manager/http/servlet/service_servlet.rb
@@ -26,7 +26,7 @@ module ServiceServlet
         data = get_db.services(opts)
         includes = [:host]
         set_json_response(data, includes)
-      rescue Exception => e
+      rescue => e
         set_error_on_response(e)
       end
     }
@@ -48,7 +48,7 @@ module ServiceServlet
         opts[:id] = tmp_params[:id] if tmp_params[:id]
         data = get_db.update_service(opts)
         set_json_response(data)
-      rescue Exception => e
+      rescue => e
         set_error_on_response(e)
       end
     }
@@ -60,7 +60,7 @@ module ServiceServlet
         opts = parse_json_request(request, false)
         data = get_db.delete_service(opts)
         set_json_response(data)
-      rescue Exception => e
+      rescue => e
         set_error_on_response(e)
       end
     }

--- a/lib/msf/core/db_manager/http/servlet/session_event_servlet.rb
+++ b/lib/msf/core/db_manager/http/servlet/session_event_servlet.rb
@@ -19,7 +19,7 @@ module SessionEventServlet
         opts = parse_json_request(request, false)
         data = get_db().session_events(opts)
         set_json_response(data)
-      rescue Exception => e
+      rescue => e
         set_error_on_response(e)
       end
     }

--- a/lib/msf/core/db_manager/http/servlet/session_servlet.rb
+++ b/lib/msf/core/db_manager/http/servlet/session_servlet.rb
@@ -18,7 +18,7 @@ module SessionServlet
         #opts = parse_json_request(request, false)
         data = get_db().get_all_sessions()
         set_json_response(data)
-      rescue Exception => e
+      rescue => e
         set_error_on_response(e)
       end
     }

--- a/lib/msf/core/db_manager/http/servlet/vuln_attempt_servlet.rb
+++ b/lib/msf/core/db_manager/http/servlet/vuln_attempt_servlet.rb
@@ -23,7 +23,7 @@ module VulnAttemptServlet
         opts = parse_json_request(request, false)
         data = get_db.vuln_attempts(params.symbolize_keys)
         set_json_response(data)
-      rescue Exception => e
+      rescue => e
         set_error_on_response(e)
       end
     }
@@ -39,7 +39,7 @@ module VulnAttemptServlet
           get_db.report_vuln_attempt(vuln, opts)
         }
         exec_report_job(request, &job)
-      rescue Exception => e
+      rescue => e
         set_error_on_response(e)
       end
     }

--- a/lib/msf/core/db_manager/http/servlet/vuln_servlet.rb
+++ b/lib/msf/core/db_manager/http/servlet/vuln_servlet.rb
@@ -27,7 +27,7 @@ module VulnServlet
         data = get_db.vulns(sanitized_params)
         includes = [:host, :vulns_refs, :refs, :module_refs]
         set_json_response(data, includes)
-      rescue Exception => e
+      rescue => e
         set_error_on_response(e)
       end
     }
@@ -40,7 +40,7 @@ module VulnServlet
           get_db.report_vuln(opts)
         }
         exec_report_job(request, &job)
-      rescue Exception => e
+      rescue => e
         set_error_on_response(e)
       end
     }
@@ -54,7 +54,7 @@ module VulnServlet
         opts[:id] = tmp_params[:id] if tmp_params[:id]
         data = get_db.update_vuln(opts)
         set_json_response(data)
-      rescue Exception => e
+      rescue => e
         set_error_on_response(e)
       end
     }
@@ -66,7 +66,7 @@ module VulnServlet
         opts = parse_json_request(request, false)
         data = get_db.delete_vuln(opts)
         set_json_response(data)
-      rescue Exception => e
+      rescue => e
         set_error_on_response(e)
       end
     }

--- a/lib/msf/core/db_manager/http/servlet/workspace_servlet.rb
+++ b/lib/msf/core/db_manager/http/servlet/workspace_servlet.rb
@@ -28,7 +28,7 @@ module WorkspaceServlet
           data = get_db.workspaces(sanitized_params)
 
           set_json_response(data, includes)
-        rescue Exception => e
+        rescue => e
           set_error_on_response(e)
         end
       }
@@ -40,7 +40,7 @@ module WorkspaceServlet
           opts = parse_json_request(request, true)
           workspace = get_db.add_workspace(opts)
           set_json_response(workspace)
-        rescue Exception => e
+        rescue => e
           set_error_on_response(e)
         end
       }
@@ -54,7 +54,7 @@ module WorkspaceServlet
         opts[:id] = tmp_params[:id] if tmp_params[:id]
         data = get_db.update_workspace(opts)
         set_json_response(data)
-      rescue Exception => e
+      rescue => e
         set_error_on_response(e)
       end
     }
@@ -66,7 +66,7 @@ module WorkspaceServlet
           opts = parse_json_request(request, false)
           data = get_db.delete_workspaces(opts)
           set_json_response(data)
-        rescue Exception => e
+        rescue => e
           set_error_on_response(e)
         end
       }

--- a/lib/msf/core/db_manager/http/servlet_helper.rb
+++ b/lib/msf/core/db_manager/http/servlet_helper.rb
@@ -47,7 +47,7 @@ module ServletHelper
         return set_json_response(data, includes)
       end
 
-    rescue Exception => e
+    rescue => e
       set_error_on_response(e)
     end
   end

--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -207,7 +207,7 @@ class Db
         if names.first == Msf::DBManager::Workspace::DEFAULT_WORKSPACE_NAME
           print_status("Recreated default workspace")
         end
-      rescue Exception => e
+      rescue => e
         print_error "Failed to rename workspace: #{e.message}"
         e.backtrace.each { |line| print_error "#{line}"}
       end
@@ -544,7 +544,7 @@ class Db
     when mode == [:tag]
       begin
         add_host_tag(host_ranges, tag_name)
-      rescue ::Exception => e
+      rescue => e
         if e.message.include?('Validation failed')
           print_error(e.message)
         else
@@ -1130,7 +1130,7 @@ class Db
           end
 
           framework.db.update_note(update_opts)
-        rescue Exception => e
+        rescue => e
           elog "There was an error updating note with ID #{note.id}: #{e.message}"
           next
         end
@@ -1333,7 +1333,7 @@ class Db
           end
           loot.ltype = types.first if types
           framework.db.update_loot(loot.as_json.symbolize_keys)
-        rescue Exception => e
+        rescue => e
           elog "There was an error updating loot with ID #{loot.id}: #{e.message}"
           next
         end


### PR DESCRIPTION
This narrows the rescue scope to `StandardError` for almost entirely Goliath code per @bcoles [comment](https://github.com/rapid7/metasploit-framework/pull/9873#discussion_r181313654) in #9873. The deeper dive into MSF with regard to exceptions revealed some concerns that need more time, and I decided to reduce the scope in order to time box the task.

Ticket: MS-3131

## Verification

- [x] Start `msfconsole`
- [x] Start `msfdb_ws` on a remote system
- [x] Connect to the remote data service `data_services --add <address>`
- [x] **Verify** Various data model CRUD operations work