### PR TITLE
enable autofilter on tp-link camera exploit

### DIFF
--- a/modules/exploits/linux/http/tp_link_sc2020n_authenticated_telnet_injection.rb
+++ b/modules/exploits/linux/http/tp_link_sc2020n_authenticated_telnet_injection.rb
@@ -55,6 +55,11 @@ class MetasploitModule < Msf::Exploit::Remote
           ])
     end
 
+    # This module returns false positives for credentialed logins
+    def autofilter
+      true
+    end
+
     def telnet_timeout
       (datastore['TelnetTimeout'] || 10).to_i
     end


### PR DESCRIPTION
This disables auto exploitation for tp_link_sc2020n_authenticated_telnet_injection, since it returns false-positives for basic authentication of credentials if not targeting an actual camera.

## Verification

- [ ] Target a host on port 80, run MS Pro autoexploitation
- [ ] **Verify** this module doesn't run
