### PR TITLE
bump payloads, ipv6 channel fixes

### DIFF
--- a/modules/payloads/singles/osx/x64/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/osx/x64/meterpreter_reverse_http.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_x64_osx'
 
 module MetasploitModule
 
-  CachedSize = 1086788
+  CachedSize = 802816
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/osx/x64/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/osx/x64/meterpreter_reverse_https.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_x64_osx'
 
 module MetasploitModule
 
-  CachedSize = 1086788
+  CachedSize = 802816
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/osx/x64/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/osx/x64/meterpreter_reverse_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_x64_osx'
 
 module MetasploitModule
 
-  CachedSize = 1086788
+  CachedSize = 802816
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions


### PR DESCRIPTION
This includes assorted fixes from @zeroSteiner for IPv6 channel support on Mettle and Python Meterpreter.

See:
https://github.com/rapid7/mettle/pull/124
https://github.com/rapid7/metasploit-payloads/pull/279