### PR TITLE
move super call in merge! so that it returns the proper value

### DIFF
--- a/lib/msf/core/data_store.rb
+++ b/lib/msf/core/data_store.rb
@@ -235,12 +235,13 @@ class DataStore < Hash
   # Override merge! so that we merge the aliases and imported hashes
   #
   def merge!(other)
-    super
     if other.is_a? DataStore
       self.aliases.merge!(other.aliases)
       self.imported.merge!(other.imported)
       self.imported_by.merge!(other.imported_by)
     end
+    # call super last so that we return a reference to ourselves
+    super
   end
 
   #


### PR DESCRIPTION
The merge! call on datastore should return a reference to self, but after refactor, if you merge! two datastores it does not. This does not appear to affect anything in framework, but does affect some usage patterns in MS Pro.

## Verification steps

 - [ ] Modify the code as such:
```
--- a/lib/msf/ui/console/command_dispatcher/payload.rb
+++ b/lib/msf/ui/console/command_dispatcher/payload.rb
@@ -53,7 +53,9 @@ module Msf
               'RunAsJob'       => true
             }
 
-            handler.datastore.merge!(mod.datastore)
+#            handler.datastore.merge!(mod.datastore)
+            a = handler.datastore.merge(mod.datastore)
+            handler.datastore.merge!(a)
             handler.exploit_simple(handler_opts)
             job_id = handler.job_id
```
 - [ ] Run `./msfconsole -qx 'use payload/linux/x64/meterpreter/reverse_tcp; set LHOST 192.168.56.1; to_handler'`
 - [ ] **Verify** that things start normally.