### PR TITLE
remove unnecessary object allocation and regex to speedup str_to_sec

### DIFF
--- a/lib/rex/time.rb
+++ b/lib/rex/time.rb
@@ -37,25 +37,22 @@ module ExtTime
   # Converts a string in the form n years g days x hours y mins z secs.
   #
   def self.str_to_sec(str)
-    fields = str.split(/ /)
+    fields = str.split
     secs   = 0
 
     fields.each_with_index { |f, idx|
-      val = 0
       case f
-        when /^year/
-          val = 31536000
-        when /^day/
-          val = 86400
-        when /^hour/
-          val = 3600
-        when /^min/
-          val = 60
-        when /^sec/
-          val = 1
+      when /^year/
+        secs += 31536000 * fields[idx-1].to_i
+      when /^day/
+        secs += 86400 * fields[idx-1].to_i
+      when /^hour/
+        secs += 3600 * fields[idx-1].to_i
+      when /^min/
+        secs += 60 * fields[idx-1].to_i
+      when /^sec/
+        secs += 1 * fields[idx-1].to_i
       end
-
-      secs += val * fields[idx-1].to_i
     }
 
     secs


### PR DESCRIPTION
The regex can be removed with the default split method. The `val` object can be removed by adding to the secs object directly on the result of the case statement. 

Yields a ~`1.2x` speed bump ( in my benchmarks ) 👍 

## Verification

List the steps needed to make sure this thing works
- [x] Start `msfconsole`
- [x] `irb`
- [x] `>> Rex::ExtTime.str_to_sec("1 year 1 day 1 hour 1 min 1 sec")
=> 31626061`

## Benchmark
```ruby
require "benchmark/ips"

def fast
  str = "1 year 1 day 1 hour 1 min 1 sec"
  fields = str.split
  secs   = 0

  fields.each_with_index { |f, idx|
    case f
    when /^year/
      secs += 31536000 * fields[idx-1].to_i
    when /^day/
      secs += 86400 * fields[idx-1].to_i
    when /^hour/
      secs += 3600 * fields[idx-1].to_i
    when /^min/
      secs += 60 * fields[idx-1].to_i
    when /^sec/
      secs += 1 * fields[idx-1].to_i
    end
  }

  secs
end

def slow
  str = "1 year 1 day 1 hour 1 min 1 sec"
  fields = str.split(/ /)
  secs   = 0

  fields.each_with_index { |f, idx|
    val = 0
    case f
    when /^year/
      val = 31536000
    when /^day/
      val = 86400
    when /^hour/
      val = 3600
    when /^min/
      val = 60
    when /^sec/
      val = 1
    end

    secs += val * fields[idx-1].to_i
  }

  secs
end

puts fast == slow

Benchmark.ips do |x|
  x.report("slower") { slow }
  x.report("faster") { fast }
  x.compare!
end
```
```
true
Warming up --------------------------------------
              slower     4.016k i/100ms
              faster     4.652k i/100ms
Calculating -------------------------------------
              slower     41.666k (± 6.3%) i/s -    208.832k in   5.038092s
              faster     50.397k (± 3.7%) i/s -    255.860k in   5.083712s

Comparison:
              faster:    50397.2 i/s
              slower:    41665.8 i/s - 1.21x  slower
```
