### PR TITLE
psexec native upload argument

### DIFF
--- a/modules/exploits/windows/smb/psexec.rb
+++ b/modules/exploits/windows/smb/psexec.rb
@@ -122,7 +122,7 @@ class MetasploitModule < Msf::Exploit::Remote
     when 'PowerShell'
       execute_powershell_payload
     when 'Native upload'
-      native_upload
+      native_upload(datastore['SHARE'])
     when 'MOF upload'
       mof_upload(datastore['SHARE'])
     end


### PR DESCRIPTION
Fixes error when using target native upload.
Pass smb share name to native_upload.

## Verification

- [x] `./msfconsole`
- [x] `use exploit/windows/smb/psexec`
- [x] `set target 2`
- [x] `run -o rhost=<rhost>,smbuser=<user>,smbpass=<pass>,lhost=<lhost>`

