### PR TITLE
Add author name to the wlan_probe_request post-exploitation module

### DIFF
--- a/modules/post/windows/wlan/wlan_probe_request.rb
+++ b/modules/post/windows/wlan/wlan_probe_request.rb
@@ -13,7 +13,7 @@ class MetasploitModule < Msf::Post
         The ESSID field will be use to set a custom message.
         },
       'License'       => MSF_LICENSE,
-      'Author'        => [ 'bmerinofe@gmail.com' ],
+      'Author'        => [ 'Borja Merino <bmerinofe[at]gmail.com>' ],
       'Platform'      => [ 'win' ],
       'SessionTypes'  => [ 'meterpreter' ]
     ))


### PR DESCRIPTION
It does not matter much but I forgot to put the name to the author field