### PR TITLE
Check if the data is nil before passing to store_loot

### DIFF
--- a/modules/post/linux/gather/enum_network.rb
+++ b/modules/post/linux/gather/enum_network.rb
@@ -74,7 +74,7 @@ class MetasploitModule < Msf::Post
 
   # Save enumerated data
   def save(msg, data, ctype="text/plain")
-    unless data.nil?
+    if data.nil?
       print_bad("Unable to get data for #{msg}")
       return
     end

--- a/modules/post/linux/gather/enum_network.rb
+++ b/modules/post/linux/gather/enum_network.rb
@@ -74,7 +74,7 @@ class MetasploitModule < Msf::Post
 
   # Save enumerated data
   def save(msg, data, ctype="text/plain")
-    if data.nil?
+    if data.nil? || data =~ /not found/ || data =~ /cannot access/
       print_bad("Unable to get data for #{msg}")
       return
     end

--- a/modules/post/linux/gather/enum_network.rb
+++ b/modules/post/linux/gather/enum_network.rb
@@ -74,6 +74,10 @@ class MetasploitModule < Msf::Post
 
   # Save enumerated data
   def save(msg, data, ctype="text/plain")
+    unless data.nil?
+      print_bad("Unable to get data for #{msg}")
+      return
+    end
     ltype = "linux.enum.network"
     loot = store_loot(ltype, ctype, session, data, nil, msg)
     print_good("#{msg} stored in #{loot.to_s}")


### PR DESCRIPTION
when I ran this module for linux/aarch64/meterpreter_reverse_tcp for payload running in termux, it was obvious that without root the commands will return error, It still created empty files in `.msf4/loot`

```
msf5 post(linux/gather/enum_network) > run
                                                                                                  
[*] Running module against localhost.localdomain
[*] Module running as /system/bin/sh: /usr/bin/whoami: not found
[+] Info:
[+]
[+]     Linux localhost 3.10.84-perf+ #1 SMP PREEMPT Tue Oct 24 01:07:25 CST 2017 aarch64 Android
[*] Collecting data...
[+] /system/bin/sh: /sbin/route: not found
[-] Failed to open file: /etc/ssh/sshd_config: core_channel_open: Operation failed: 1
[-] unable to get data for Network config
[+] Network config stored in /data/data/com.termux/files/home/.msf4/loot/20180505105107_default_127.0.0.1_linux.enum.netwo_735775.txt
[-] unable to get data for Route table                                                            
[+] Route table stored in /data/data/com.termux/files/home/.msf4/loot/20180505105107_default_127.0.0.1_linux.enum.netwo_599334.txt
[-] unable to get data for Firewall config
[+] Firewall config stored in /data/data/com.termux/files/home/.msf4/loot/20180505105107_default_127.0.0.1_linux.enum.netwo_790893.txt
[-] unable to get data for DNS config
[+] DNS config stored in /data/data/com.termux/files/home/.msf4/loot/20180505105107_default_127.0.0.1_linux.enum.netwo_867340.txt
[-] unable to get data for SSHD config                                                           
[+] SSHD config stored in /data/data/com.termux/files/home/.msf4/loot/20180505105107_default_127.0.0.1_linux.enum.netwo_900906.txt                                                                  [-] unable to get data for Host file
[+] Host file stored in /data/data/com.termux/files/home/.msf4/loot/20180505105107_default_127.0.0.1_linux.enum.netwo_179877.txt
[-] unable to get data for Active connections                                                     
[+] Active connections stored in /data/data/com.termux/files/home/.msf4/loot/20180505105107_default_127.0.0.1_linux.enum.netwo_656035.txt                                                           [-] unable to get data for Wireless information
[+] Wireless information stored in /data/data/com.termux/files/home/.msf4/loot/20180505105107_default_127.0.0.1_linux.enum.netwo_168144.txt
[-] unable to get data for Listening ports                                                        
[+] Listening ports stored in /data/data/com.termux/files/home/.msf4/loot/20180505105107_default_127.0.0.1_linux.enum.netwo_999548.txt                                                              [-] unable to get data for If-Up/If-Down
[+] If-Up/If-Down stored in /data/data/com.termux/files/home/.msf4/loot/20180505105107_default_127.0.0.1_linux.enum.netwo_860869.txt
[*] Post module execution completed                                                               
msf5 post(linux/gather/enum_network) >
```
checking for nil value of data should prevent creating empty loot files