### PR TITLE
Add inactive list option to sessions command

### DIFF
--- a/lib/metasploit/framework/data_service/proxy/session_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/session_data_proxy.rb
@@ -1,7 +1,18 @@
 module SessionDataProxy
+  def sessions(opts={})
+    begin
+      data_service = self.get_data_service
+      add_opts_workspace(opts)
+      data_service.sessions(opts)
+    rescue => e
+      self.log_error(e, "Problem retrieving sessions")
+    end
+  end
+
   def report_session(opts)
     begin
       data_service = self.get_data_service
+      add_opts_workspace(opts)
       data_service.report_session(opts)
     rescue => e
       self.log_error(e, "Problem reporting session")

--- a/lib/metasploit/framework/data_service/remote/http/remote_session_data_service.rb
+++ b/lib/metasploit/framework/data_service/remote/http/remote_session_data_service.rb
@@ -1,7 +1,14 @@
+require 'metasploit/framework/data_service/remote/http/response_data_helper'
+
 module RemoteSessionDataService
+  include ResponseDataHelper
 
   SESSION_API_PATH = '/api/v1/sessions'
   SESSION_MDM_CLASS = 'Mdm::Session'
+
+  def sessions(opts)
+    json_to_mdm_object(self.get_data(SESSION_API_PATH, nil, opts), SESSION_MDM_CLASS, [])
+  end
 
   def report_session(opts)
     session = opts[:session]

--- a/lib/metasploit/framework/data_service/stubs/session_data_service.rb
+++ b/lib/metasploit/framework/data_service/stubs/session_data_service.rb
@@ -1,4 +1,8 @@
 module SessionDataService
+  def sessions(opts)
+    raise 'SessionDataService#sessions is not implemented'
+  end
+
   def report_session(opts)
     raise 'SessionDataService#report_session is not implemented'
   end

--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -717,7 +717,7 @@ class ReadableText
         sess_checkin = "#{(Time.now.to_i - session.last_checkin.to_i)}s ago @ #{session.last_checkin.to_s}"
       end
 
-      if session.payload_uuid.registered
+      if !session.payload_uuid.nil? && session.payload_uuid.registered
         sess_registration = "Yes"
         if session.payload_uuid.name
           sess_registration << " - Name=\"#{session.payload_uuid.name}\""

--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -532,7 +532,7 @@ class ReadableText
     return ds.length > 0 ? tbl.to_s : "#{tbl.header_to_s}No entries in data store.\n"
   end
 
-  # Dumps the list of active sessions.
+  # Dumps the list of sessions.
   #
   # @param framework [Msf::Framework] the framework to dump.
   # @param opts [Hash] the options to dump with.
@@ -541,73 +541,139 @@ class ReadableText
   # @option opts :indent [Integer] set the indentation amount.
   # @return [String] the formatted list of sessions.
   def self.dump_sessions(framework, opts={})
+    output = ""
     verbose = opts[:verbose] || false
+    show_active = opts[:show_active] || false
+    show_inactive = opts[:show_inactive] || false
+    # if show_active and show_inactive are false the caller didn't
+    # specify either flag; default to displaying active sessions
+    show_active = true if !(show_active || show_inactive)
     show_extended = opts[:show_extended] || false
     indent = opts[:indent] || DefaultIndent
 
     return dump_sessions_verbose(framework, opts) if verbose
 
-    columns = []
-    columns << 'Id'
-    columns << 'Name'
-    columns << 'Type'
-    columns << 'Checkin?' if show_extended
-    columns << 'Enc?' if show_extended
-    columns << 'Local URI' if show_extended
-    columns << 'Information'
-    columns << 'Connection'
+    if show_active
+      columns = []
+      columns << 'Id'
+      columns << 'Name'
+      columns << 'Type'
+      columns << 'Checkin?' if show_extended
+      columns << 'Enc?' if show_extended
+      columns << 'Local URI' if show_extended
+      columns << 'Information'
+      columns << 'Connection'
 
-    tbl = Rex::Text::Table.new(
-      'Indent'  => indent,
-      'Header'  => "Active sessions",
-      'Columns' => columns)
+      tbl = Rex::Text::Table.new(
+          'Header' => "Active sessions",
+          'Columns' => columns,
+          'Indent' => indent)
+      framework.sessions.each_sorted { |k|
+        session = framework.sessions[k]
+        row = create_msf_session_row(session, show_extended)
+        tbl << row
+      }
 
-    framework.sessions.each_sorted { |k|
-      session = framework.sessions[k]
+      output << (tbl.rows.count > 0 ? tbl.to_s : "#{tbl.header_to_s}No active sessions.\n")
+    end
 
-      sinfo = session.info.to_s
-      # Arbitrarily cut it at 80 columns
-      if sinfo.length > 80
-        sinfo = sinfo[0,77] + "..."
-      end
+    if show_inactive
+      output << "\n" if show_active
 
-      row = []
-      row << session.sid.to_s
-      row << session.sname.to_s
-      row << session.type.to_s
-      if session.respond_to?(:session_type)
-        row[-1] << (" " + session.session_type)
-      elsif session.respond_to?(:platform)
-        row[-1] << (" " + session.platform)
-      end
+      columns = []
+      columns << 'Closed'
+      columns << 'Opened'
+      columns << 'Reason Closed'
+      columns << 'Type'
+      columns << 'Address'
 
-      if show_extended
-        if session.respond_to?(:last_checkin) && session.last_checkin
-          row << "#{(Time.now.to_i - session.last_checkin.to_i)}s ago"
-        else
-          row << '?'
-        end
+      tbl = Rex::Text::Table.new(
+          'Header' => "Inactive sessions",
+          'Columns' => columns,
+          'Indent' => indent,
+          'SortIndex' => 1)
 
-        if session.respond_to?(:tlv_enc_key) && session.tlv_enc_key && session.tlv_enc_key[:key]
-          row << "Y"
-        else
-          row << 'N'
-        end
-
-        if session.exploit_datastore && session.exploit_datastore.has_key?('LURI') && !session.exploit_datastore['LURI'].empty?
-          row << " (#{session.exploit_datastore['LURI']})"
-        else
-          row << '?'
+      framework.db.sessions.each do |session|
+        unless session.closed_at.nil?
+          row = create_mdm_session_row(session, show_extended)
+          tbl << row
         end
       end
 
-      row << sinfo
-      row << session.tunnel_to_s + " (#{session.session_host})"
+      output << (tbl.rows.count > 0 ? tbl.to_s : "#{tbl.header_to_s}No inactive sessions.\n")
+    end
 
-      tbl << row
-    }
+    # return formatted listing of sessions
+    output
+  end
 
-    return framework.sessions.length > 0 ? tbl.to_s : "#{tbl.header_to_s}No active sessions.\n"
+  # Creates a table row that represents the specified session.
+  #
+  # @param session [Msf::Session] session used to create a table row.
+  # @param show_extended [Boolean] Indicates if extended information will be included in the row.
+  # @return [Array] table row of session data.
+  def self.create_msf_session_row(session, show_extended)
+    row = []
+    row << session.sid.to_s
+    row << session.sname.to_s
+    row << session.type.to_s
+    if session.respond_to?(:session_type)
+      row[-1] << " #{session.session_type}"
+    elsif session.respond_to?(:platform)
+      row[-1] << " #{session.platform}"
+    end
+
+    if show_extended
+      if session.respond_to?(:last_checkin) && session.last_checkin
+        row << "#{(Time.now.to_i - session.last_checkin.to_i)}s ago"
+      else
+        row << '?'
+      end
+
+      if session.respond_to?(:tlv_enc_key) && session.tlv_enc_key && session.tlv_enc_key[:key]
+        row << 'Y'
+      else
+        row << 'N'
+      end
+
+      if session.exploit_datastore && session.exploit_datastore.has_key?('LURI') && !session.exploit_datastore['LURI'].empty?
+        row << "(#{exploit_datastore['LURI']})"
+      else
+        row << '?'
+      end
+    end
+
+    sinfo = session.info.to_s
+    # Arbitrarily cut info at 80 columns
+    if sinfo.length > 80
+      sinfo = "#{sinfo[0,77]}..."
+    end
+    row << sinfo
+
+    row << "#{session.tunnel_to_s} (#{session.session_host})"
+
+    # return complete row
+    row
+  end
+
+  # Creates a table row that represents the specified session.
+  #
+  # @param session [Mdm::Session] session used to create a table row.
+  # @param show_extended [Boolean] Indicates if extended information will be included in the row.
+  # @return [Array] table row of session data.
+  def self.create_mdm_session_row(session, show_extended)
+    row = []
+    row << session.closed_at.to_s
+    row << session.opened_at.to_s
+    row << session.close_reason
+    row << session.stype
+    if session.respond_to?(:platform) && !session.platform.nil?
+      row[-1] << " #{session.platform}"
+    end
+    row << (!session.host.nil? ? session.host.address : nil)
+
+    # return complete row
+    row
   end
 
   # Dumps the list of active sessions in verbose mode

--- a/lib/msf/core/db_manager/http/servlet/session_servlet.rb
+++ b/lib/msf/core/db_manager/http/servlet/session_servlet.rb
@@ -1,11 +1,16 @@
 module SessionServlet
+
   def self.api_path
     '/api/v1/sessions'
   end
 
+  def self.api_path_with_id
+    "#{SessionServlet.api_path}/?:id?"
+  end
+
   def self.registered(app)
+    app.get SessionServlet.api_path_with_id, &get_session
     app.post SessionServlet.api_path, &report_session
-    app.get SessionServlet.api_path, &get_session
   end
 
   #######
@@ -15,9 +20,11 @@ module SessionServlet
   def self.get_session
     lambda {
       begin
-        #opts = parse_json_request(request, false)
-        data = get_db().get_all_sessions()
-        set_json_response(data)
+        opts = parse_json_request(request, false)
+        sanitized_params = sanitize_params(params)
+        data = get_db.sessions(sanitized_params)
+        includes = [:host]
+        set_json_response(data, includes)
       rescue => e
         set_error_on_response(e)
       end
@@ -26,14 +33,19 @@ module SessionServlet
 
   def self.report_session
     lambda {
-      job = lambda { |opts|
-        if (opts[:session_data])
-          get_db().report_session_dto(opts)
-        else
-          get_db().report_session_host_dto(opts)
-        end
-      }
-      exec_report_job(request, &job)
+      begin
+        job = lambda { |opts|
+          if opts[:session_data]
+            get_db.report_session_dto(opts)
+          else
+            get_db.report_session_host_dto(opts)
+          end
+        }
+        exec_report_job(request, &job)
+      rescue => e
+        set_error_on_response(e)
+      end
     }
   end
+
 end

--- a/lib/msf/core/session.rb
+++ b/lib/msf/core/session.rb
@@ -327,7 +327,14 @@ module Session
   # Get an arch/platform combination
   #
   def session_type
-    "#{self.arch}/#{self.platform}"
+    # avoid unnecessary slash separator
+    if !self.arch.nil? && !self.arch.empty? && !self.platform.nil? && !self.platform.empty?
+      separator =  '/'
+    else
+      separator = ''
+    end
+
+    "#{self.arch}#{separator}#{self.platform}"
   end
 
 

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -43,7 +43,8 @@ class Core
     "-h"  => [ false, "Help banner"                                                    ],
     "-i"  => [ true,  "Interact with the supplied session ID"                          ],
     "-l"  => [ false, "List all active sessions"                                       ],
-    "-v"  => [ false, "List sessions in verbose mode"                                  ],
+    "-v"  => [ false, "List all active sessions in verbose mode"                       ],
+    "-d" =>  [ false, "List all inactive sessions"                                     ],
     "-q"  => [ false, "Quiet mode"                                                     ],
     "-k"  => [ true,  "Terminate sessions by session ID and/or range"                  ],
     "-K"  => [ false, "Terminate all sessions"                                         ],
@@ -54,6 +55,7 @@ class Core
     "-S"  => [ true,  "Row search filter."                                             ],
     "-x" =>  [ false, "Show extended information in the session table"                 ],
     "-n" =>  [ true,  "Name or rename a session by ID"                                 ])
+
 
   @@threads_opts = Rex::Parser::Arguments.new(
     "-h" => [ false, "Help banner."                                   ],
@@ -1131,6 +1133,8 @@ class Core
     begin
     method   = nil
     quiet    = false
+    show_active = false
+    show_inactive = false
     show_extended = false
     verbose  = false
     sid      = nil
@@ -1161,6 +1165,10 @@ class Core
         when "-C"
             method = 'meterp-cmd'
             cmds << val if val
+        # Display the list of inactive sessions
+        when "-d"
+          show_inactive = true
+          method = 'list_inactive'
         when "-x"
           show_extended = true
         when "-v"
@@ -1171,6 +1179,7 @@ class Core
           sid = val
         # Display the list of active sessions
         when "-l"
+          show_active = true
           method = 'list'
         when "-k"
           method = 'kill'
@@ -1457,9 +1466,9 @@ class Core
         s.reset_ring_sequence
         print_status("Reset the ring buffer pointer for Session #{sidx}")
       end
-    when 'list',nil
+    when 'list', 'list_inactive', nil
       print_line
-      print(Serializer::ReadableText.dump_sessions(framework, :show_extended => show_extended, :verbose => verbose, :search_term => search_term))
+      print(Serializer::ReadableText.dump_sessions(framework, show_active: show_active, show_inactive: show_inactive, show_extended: show_extended, verbose: verbose, search_term: search_term))
       print_line
     when 'name'
       if session_name.blank?


### PR DESCRIPTION
Add an option (`-d`) to the sessions command to list information about inactive (dead) sessions.

This also fixes an existing issue where the `sessions -v` command results in an exception with the message "undefined method 'registered' for nil:NilClass".

Example inactive sessions (`sessions -d`) output:
```
Inactive sessions
=================

  Closed                   Opened                   Reason Closed  Type                   Address
  ------                   ------                   -------------  ----                   -------
  2018-05-05 14:39:25 UTC  2018-05-05 14:38:36 UTC                 meterpreter x64/linux  x.x.x.x
  2018-05-05 14:42:22 UTC  2018-05-05 14:40:52 UTC                 shell                  y.y.y.y
```

Example active and inactive sessions (`sessions -l -d`) output:
```
Active sessions
===============

  Id  Name  Type                   Information                                              Connection
  --  ----  ----                   -----------                                              ----------
  1         meterpreter x64/linux  uid=1000, gid=1000, euid=1000, egid=1000 @ x.x.x.x  y.y.y.y:8080 -> x.x.x.x:37870 (x.x.x.x)

Inactive sessions
=================

  Closed                   Opened                   Reason Closed  Type                   Address
  ------                   ------                   -------------  ----                   -------
  2018-05-05 14:39:25 UTC  2018-05-05 14:38:36 UTC                 meterpreter x64/linux  x.x.x.x
  2018-05-05 14:42:22 UTC  2018-05-05 14:40:52 UTC                 shell                  y.y.y.y
```

Active sessions verbose mode (`sessions -v`) error that is fixed in this PR:
```
[-] Session manipulation failed: undefined method `registered' for nil:NilClass [...EDITED: removed stack trace...]
```

## Verification

- [x] Start `msfconsole`
- [x] Create a few new sessions via your preferred method
- [x] Kill or orphan a few of those sessions
- [x] **Verify** `sessions` and `sessions -l` displays the active sessions as it has before
- [x] **Verify** `sessions -d` displays inactive sessions
- [x] **Verify** `sessions -l -d` displays both active and inactive sessions
- [x] Test fix for list active sessions verbose mode issue
  - [x] Create a session that uses a command shell, for example, use `exploit/unix/irc/unreal_ircd_3281_backdoor` against Metasploitable
  - [x] **Verify**  `sessions -v` does not result in an exception with the message "undefined method 'registered' for nil:NilClass" and the active sessions are listed in verbose mode
