### PR TITLE
tidy tests, add ms17_010_psexec

### DIFF
--- a/test/modules/exploits/windows/smb/ms17_010_psexec.json
+++ b/test/modules/exploits/windows/smb/ms17_010_psexec.json
@@ -11,7 +11,7 @@
     "HTTP_PORT": 5309,
     "MODULES": [
         {
-            "NAME": "exploit/windows/smb/ms17_010_eternalblue",
+            "NAME": "exploit/windows/smb/ms17_010_psexec",
             "SETTINGS": [
                 "SMBUser=vagrant",
                 "SMBPass=vagrant"


### PR DESCRIPTION
This makes sure that both ms17_010 exploit modules run tests, so it's easy to see if something breaks them right away.

## Validation Steps

 - [x] The checkboxes are green, which indicates that all of the modules worked properly