### PR TITLE
include example of why PRs from master are bad

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,8 +36,13 @@ and Metasploit's [Common Coding Mistakes].
 * **Do** get [Rubocop] relatively quiet against the code you are adding or modifying.
 * **Do** follow the [50/72 rule] for Git commit messages.
 * **Don't** use the default merge messages when merging from other branches.
-* **Do** create a [topic branch] to work on instead of working directly on `master`.
 * **Do** license your code as BSD 3-clause, BSD 2-clause, or MIT.
+* **Do** create a [topic branch] to work on instead of working directly on `master`.
+ If you do not send a PR from a topic branch, the history of your PR will be
+ lost as soon as you update your own master branch. See
+ https://github.com/rapid7/metasploit-framework/pull/8000 for an example of
+ this in action.
+
 
 ### Pull Requests
 


### PR DESCRIPTION
We were going down memory lane and found #8000 had not aged well. This is why PRs need to be from branches. This notes it in the contributor docs.

## Verification Steps

 - [ ] This makes sense