### PR TITLE
Customization of Golden Ticket Duration

### DIFF
--- a/lib/rex/post/meterpreter/extensions/kiwi/kiwi.rb
+++ b/lib/rex/post/meterpreter/extensions/kiwi/kiwi.rb
@@ -388,6 +388,9 @@ class Kiwi < Extension
       opts[:domain_name],
       " /sid:",
       opts[:domain_sid],
+      " /startoffset:0",
+      " /endin:",
+      opts[:end_in] * 60,
       " /krbtgt:",
       opts[:krbtgt_hash],
       "\""
@@ -510,4 +513,3 @@ class Kiwi < Extension
 end
 
 end; end; end; end; end
-

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/kiwi.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/kiwi.rb
@@ -237,7 +237,8 @@ class Console::CommandDispatcher::Kiwi
     '-d' => [ true,  'FQDN of the target domain (required)' ],
     '-k' => [ true,  'krbtgt domain user NTLM hash' ],
     '-t' => [ true,  'Local path of the file to store the ticket in (required)' ],
-    '-s' => [ true,  'SID of the domain' ]
+    '-s' => [ true,  'SID of the domain' ],
+    '-e' => [ true,  'End in ... Duration in hours (ex: -e 10 for 10 hours), default 10 YEARS']
   )
 
   #
@@ -267,7 +268,8 @@ class Console::CommandDispatcher::Kiwi
       domain_sid: nil,
       krbtgt_hash: nil,
       user_id: nil,
-      group_ids: nil
+      group_ids: nil,
+      end_in: 87608
     }
 
     @@golden_ticket_create_opts.parse(args) { |opt, idx, val|
@@ -286,6 +288,8 @@ class Console::CommandDispatcher::Kiwi
         opts[:group_ids] = val
       when '-s'
         opts[:domain_sid] = val
+      when '-e'
+        opts[:end_in] = val.to_i
       end
     }
 
@@ -647,4 +651,3 @@ end
 end
 end
 end
-

--- a/modules/post/windows/escalate/golden_ticket.rb
+++ b/modules/post/windows/escalate/golden_ticket.rb
@@ -43,7 +43,8 @@ class MetasploitModule < Msf::Post
         OptString.new('KRBTGT_HASH', [false, 'KRBTGT NTLM Hash']),
         OptString.new('Domain SID', [false, 'Domain SID']),
         OptInt.new('ID', [false, 'Target User ID']),
-        OptString.new('GROUPS', [false, 'ID of Groups (Comma Seperated)'])
+        OptString.new('GROUPS', [false, 'ID of Groups (Comma Seperated)']),
+        OptInt.new('END_IN', [true, 'End in ... Duration in hours, default 10 YEARS (~87608 hours)', 87608])
       ])
   end
 
@@ -55,6 +56,7 @@ class MetasploitModule < Msf::Post
     krbtgt_hash = datastore['KRBTGT_HASH']
     domain_sid = datastore['SID']
     id = datastore['ID'] || 0
+    end_in = datastore['END_IN'] || 87608
 
     unless domain
       print_status('Searching for the domain...')
@@ -110,7 +112,8 @@ class MetasploitModule < Msf::Post
       domain_sid:  domain_sid,
       krbtgt_hash: krbtgt_hash,
       id:          id,
-      group_ids:   datastore['GROUPS']
+      group_ids:   datastore['GROUPS'],
+      end_in:     end_in
     })
 
     if ticket


### PR DESCRIPTION
- Post exploitation module updated
- Kiwi extention updated

Using mimikatz /startoffset and /endin params
Duration in hours, default already 10 years

Theses modifications are linking existing features only.

## Verification


- [ ] Start `msfconsole`
- [ ] `use post/windows/escalate/golden_ticket`
- [ ] `set END_IN 48` <-- END OF GOLDEN TICKET IN 48 /!\ HOURS /!\
- [ ] `set your stuff, SESSION ID, KRBTGT_HASH ....`
- [ ] run

Or directly in Meterpreter session with kiwi extension loaded (no admin right needed to load golden ticket):
- [ ] meterpreter> `golden_ticket_create -e 48 -k krbtgt_hash...`

Screenshots of 48h valid ticket:

![golden](https://user-images.githubusercontent.com/25591433/39825615-7d49bc0a-53b2-11e8-9405-7319e2c1d9e0.png)

Hope you enjoy :)


