### PR TITLE
Optionally test empty group in cisco_ssl_vpn

### DIFF
--- a/modules/auxiliary/scanner/http/cisco_ssl_vpn.rb
+++ b/modules/auxiliary/scanner/http/cisco_ssl_vpn.rb
@@ -36,6 +36,10 @@ class MetasploitModule < Msf::Auxiliary
         Opt::RPORT(443),
         OptString.new('GROUP', [false, "A specific VPN group to use", ''])
       ])
+    register_advanced_options(
+      [
+        OptBool.new('EmptyGroup', [true, "Use an empty group with authentication requests", false])
+      ])
   end
 
   def run_host(ip)
@@ -52,7 +56,9 @@ class MetasploitModule < Msf::Auxiliary
     vprint_good("Application appears to be Cisco SSL VPN. Module will continue.")
 
     groups = Set.new
-    if datastore['GROUP'].empty?
+    if datastore['EmptyGroup'] == true
+      groups << ""
+    elsif datastore['GROUP'].empty?
       vprint_status("Attempt to Enumerate VPN Groups...")
       groups = enumerate_vpn_groups
 

--- a/modules/auxiliary/scanner/http/cisco_ssl_vpn.rb
+++ b/modules/auxiliary/scanner/http/cisco_ssl_vpn.rb
@@ -67,7 +67,6 @@ class MetasploitModule < Msf::Auxiliary
     else
       groups << datastore['GROUP']
     end
-    groups << ""
 
     vprint_status("Starting login brute force...")
     groups.each do |group|


### PR DESCRIPTION
Remove empty group from cisco_ssl_vpn module that's added by default.
Put an advanced option for EmptyGroup in case it is needed

## Verification Steps

- [x] `./msfconsole -q`
- [x] `use auxiliary/scanner/http/cisco_ssl_vpn`
- [x] `set rhosts <rhosts>`
- [x] `set username <username>`
- [x] `set password <password>`
- [x] `run`
- [x] Verify enumerated groups are used during authentication attempts
- [x] `set emptygroup true`
- [x] `run`
- [x] Verify empty group `""` is used for authentication attempt