### PR TITLE
Add password reporting API to external modules

### DIFF
--- a/lib/msf/core/auxiliary/auth_brute.rb
+++ b/lib/msf/core/auxiliary/auth_brute.rb
@@ -551,8 +551,8 @@ module Auxiliary::AuthBrute
     end
   end
 
-  def userpass_sleep_interval
-    sleep_time = case datastore['BRUTEFORCE_SPEED'].to_i
+  def userpass_interval
+    case datastore['BRUTEFORCE_SPEED'].to_i
       when 0; 60 * 5
       when 1; 15
       when 2; 1
@@ -560,7 +560,10 @@ module Auxiliary::AuthBrute
       when 4; 0.1
       else; 0
     end
-    ::IO.select(nil,nil,nil,sleep_time) unless sleep_time == 0
+  end
+
+  def userpass_sleep_interval
+    ::IO.select(nil,nil,nil,userpass_interval) unless userpass_interval == 0
   end
 
   # See #print_brute

--- a/lib/msf/core/data_store.rb
+++ b/lib/msf/core/data_store.rb
@@ -176,10 +176,19 @@ class DataStore < Hash
   # Hack on a hack for the external modules
   def to_nested_values
     datastore_hash = {}
+
+    array_nester = ->(arr) do
+      if arr.first.is_a? Array
+        arr.map &array_nester
+      else
+        arr.map &:to_s
+      end
+    end
+
     self.keys.each do |k|
       # TODO arbitrary depth
       if self[k].is_a? Array
-        datastore_hash[k.to_s] = self[k].map(&:to_s)
+        datastore_hash[k.to_s] = array_nester.call(self[k])
       else
         datastore_hash[k.to_s] = self[k].to_s
       end

--- a/lib/msf/core/module/auth.rb
+++ b/lib/msf/core/module/auth.rb
@@ -1,7 +1,6 @@
 module Msf::Module::Auth
-  def store_valid_credential(user:, private:, private_type: :password, proof: nil)
-    service_data = {}
-    if self.respond_to? ("service_details")
+  def store_valid_credential(user:, private:, private_type: :password, proof: nil, service_data: {})
+    if !service_data.empty? && self.respond_to?("service_details")
       service_data = service_details
     end
 

--- a/lib/msf/core/modules/external.rb
+++ b/lib/msf/core/modules/external.rb
@@ -1,7 +1,50 @@
 # -*- coding: binary -*-
 # Namespace for loading external Metasploit modules
 
-module Msf::Modules::External
+class Msf::Modules::External
 
+  autoload :Bridge, 'msf/core/modules/external/bridge'
+  autoload :Message, 'msf/core/modules/external/message'
+
+  attr_reader :path
+
+  def meta
+    @meta ||= describe
+  end
+
+  def initialize(module_path, framework: nil)
+    self.path = module_path
+    self.framework = framework
+  end
+
+  def exec(method: :run, args: {}, &block)
+    req = Message.new(method)
+    req.params = args.dup
+
+    b = Bridge.open(self.path, framework: self.framework).exec(req)
+
+    if block
+      begin
+        while m = b.messages.pop
+          block.call m
+        end
+      ensure
+        b.close
+      end
+      return b.success?
+    else
+      return b
+    end
+  end
+
+  protected
+
+  attr_writer :path
+  attr_accessor :framework
+
+  def describe
+    exec method: :describe do |msg|
+      return msg.params if msg.method == :reply
+    end
+  end
 end
-

--- a/lib/msf/core/modules/external/bridge.rb
+++ b/lib/msf/core/modules/external/bridge.rb
@@ -1,169 +1,164 @@
 # -*- coding: binary -*-
-require 'msf/core/modules/external'
-require 'msf/core/modules/external/message'
 require 'open3'
 require 'json'
 
-class Msf::Modules::External::Bridge
+module Msf::Modules
+  class External
+    class Bridge
 
-  attr_reader :path, :running
+      attr_reader :path, :running, :messages, :exit_status
 
-  def self.applies?(module_name)
-    File::executable? module_name
-  end
+      def self.applies?(module_name)
+        File::executable? module_name
+      end
 
-  def meta
-    @meta ||= describe
-  end
+      def exec(req)
+        unless self.running
+          self.running = true
+          send(req)
+          self.read_thread = threadme do
+            begin
+              while self.running && m = next_message
+                self.messages.push m
+              end
+            ensure
+              cleanup
+            end
+          end
 
-  def run(datastore)
-    unless self.running
-      m = Msf::Modules::External::Message.new(:run)
-      m.params = datastore.dup
-      send(m)
-      self.running = true
-    end
-  end
+          self
+        end
+      end
 
-  def get_status
-    if self.running || !self.messages.empty?
-      m = receive_notification
-      if m.nil?
-        close_ios
-        self.messages.close
+      def close
         self.running = false
+        self.read_thread.join
+
+        self
       end
 
-      return m
-    end
-  end
+      def success?
+        self.exit_status && self.exit_status.success?
+      end
 
-  def initialize(module_path)
-    self.env = {}
-    self.running = false
-    self.path = module_path
-    self.cmd = [[self.path, self.path]]
-    self.messages = Queue.new
-    self.buf = ''
-  end
+      def initialize(module_path, framework: nil)
+        self.env = {}
+        self.running = false
+        self.path = module_path
+        self.cmd = [[self.path, self.path]]
+        self.messages = Queue.new
+        self.buf = ''
+        self.framework = framework
+      end
 
-  protected
+      protected
 
-  attr_writer :path, :running
-  attr_accessor :cmd, :env, :ios, :buf, :messages, :wait_thread
+      attr_writer :path, :running, :messages, :exit_status
+      attr_accessor :cmd, :env, :ios, :buf, :read_thread, :wait_thread, :framework
 
-  def describe
-    resp = send_receive(Msf::Modules::External::Message.new(:describe))
-    close_ios
-    resp.params
-  end
+      # XXX TODO non-blocking writes, check write lengths
 
-  # XXX TODO non-blocking writes, check write lengths
-
-  def send_receive(message)
-    send(message)
-    recv(message.id)
-  end
-
-  def send(message)
-    input, output, err, status = ::Open3.popen3(self.env, *self.cmd)
-    self.ios = [input, output, err]
-    self.wait_thread = status
-    # We would call Rex::Threadsafe directly, but that would require rex for standalone use
-    case select(nil, [input], nil, 0.1)
-    when nil
-      raise "Cannot run module #{self.path}"
-    when [[], [input], []]
-      m = message.to_json
-      write_message(input, m)
-    else
-      raise "Error running module #{self.path}"
-    end
-  end
-
-  def receive_notification
-    if self.messages.empty?
-      recv
-    else
-      self.messages.pop
-    end
-  end
-
-  def write_message(fd, json)
-    fd.write(json)
-  end
-
-  def recv(filter_id=nil, timeout=600)
-    _, out, err = self.ios
-    message = ''
-
-    # Multiple messages can come over the wire all at once, and since yajl
-    # doesn't play nice with windows, we have to emulate a state machine to
-    # read just enough off the wire to get one request at a time. Since
-    # Windows cannot do a nonblocking read on a pipe, we are forced to do a
-    # whole lot of `select` syscalls and keep a buffer ourselves :(
-    begin
-      loop do
-        # This is so we don't end up calling JSON.parse on every char and
-        # catch an exception. Windows can't do nonblock on pipes, so we
-        # still have to do the select if we are not at the end of object
-        # and don't have any buffer left
-        parts = self.buf.split '}', 2
-        if parts.length == 2 # [part, rest]
-          message << parts[0] << '}'
-          self.buf = parts[1]
-          break
-        elsif parts.length == 1 # [part]
-          if self.buf[-1] == '}'
-            message << parts[0] << '}'
-            self.buf = ''
-            break
-          else
-            message << parts[0]
-            self.buf = ''
-          end
-        end
-
-        # We would call Rex::Threadsafe directly, but that would require Rex for standalone use
-        res = select([out, err], nil, nil, timeout)
-        if res == nil
-          # This is what we would have gotten without Rex and what `readpartial` can also raise
-          raise EOFError.new
+      def send(message)
+        input, output, err, status = ::Open3.popen3(self.env, *self.cmd)
+        self.ios = [input, output, err]
+        self.wait_thread = status
+        # We would call Rex::Threadsafe directly, but that would require rex for standalone use
+        case select(nil, [input], nil, 0.1)
+        when nil
+          raise "Cannot run module #{self.path}"
+        when [[], [input], []]
+          m = message.to_json
+          write_message(input, m)
         else
-          fds = res[0]
-          # Preferentially drain and log stderr, EOF counts as activity, but
-          # stdout might have some buffered data left, so carry on
-          if fds.include?(err) && !err.eof?
-            errbuf = err.readpartial(4096)
-            elog "Unexpected output running #{self.path}:\n#{errbuf}"
-          end
-          if fds.include? out
-            self.buf << out.readpartial(4096)
-          end
+          raise "Error running module #{self.path}"
         end
       end
 
-      m = Msf::Modules::External::Message.from_module(JSON.parse(message))
-      if filter_id && m.id != filter_id
-        # We are filtering for a response to a particular message, but we got
-        # something else, store the message and try again
-        self.messages.push m
-        recv(filter_id, timeout)
-      else
-        # Either we weren't filtering, or we got what we were looking for
-        m
+      def write_message(fd, json)
+        fd.write(json)
       end
-    rescue JSON::ParserError
-      # Probably an incomplete response, but no way to really tell. Keep trying
-      # until EOF
-      retry
-    rescue EOFError => e
-      nil
-    end
-  end
 
-  def close_ios
-    self.ios.each {|fd| fd.close rescue nil} # Yeah, yeah. I know.
+      def next_message(timeout=600)
+        _, out, err = self.ios
+        message = ''
+
+        # Multiple messages can come over the wire all at once, and since yajl
+        # doesn't play nice with windows, we have to emulate a state machine to
+        # read just enough off the wire to get one request at a time. Since
+        # Windows cannot do a nonblocking read on a pipe, we are forced to do a
+        # whole lot of `select` syscalls and keep a buffer ourselves :(
+        begin
+          loop do
+            # This is so we don't end up calling JSON.parse on every char and
+            # catch an exception. Windows can't do nonblock on pipes, so we
+            # still have to do the select if we are not at the end of object
+            # and don't have any buffer left
+            parts = self.buf.split '}', 2
+            if parts.length == 2 # [part, rest]
+              message << parts[0] << '}'
+              self.buf = parts[1]
+              break
+            elsif parts.length == 1 # [part]
+              message << parts[0]
+              self.buf = ''
+            end
+
+            # We would call Rex::Threadsafe directly, but that would require Rex for standalone use
+            res = select([out, err], nil, nil, timeout)
+            if res == nil
+              # This is what we would have gotten without Rex and what `readpartial` can also raise
+              raise EOFError.new
+            else
+              fds = res[0]
+              # Preferentially drain and log stderr, EOF counts as activity, but
+              # stdout might have some buffered data left, so carry on
+              if fds.include?(err) && !err.eof?
+                errbuf = err.readpartial(4096)
+                elog "Unexpected output running #{self.path}:\n#{errbuf}"
+              end
+              if fds.include? out
+                self.buf << out.readpartial(4096)
+              end
+            end
+          end
+
+          Message.from_module(JSON.parse(message))
+        rescue JSON::ParserError
+          # Probably an incomplete response, but no way to really tell. Keep trying
+          # until EOF
+          retry
+        rescue EOFError => e
+          self.running = false
+        end
+      end
+
+      def harvest_process
+        if self.wait_thread.join(10)
+          self.exit_status = self.wait_thread.value
+        elsif Process.kill('TERM', self.wait_thread.pid) && self.wait_thread.join(10)
+          self.exit_status = self.wait_thread.value
+        else
+          Procoess.kill('KILL', self.wait_thread.pid)
+          self.exit_status = self.wait_thread.value
+        end
+      end
+
+      def cleanup
+        self.running = false
+        self.messages.close
+        harvest_process
+        self.ios.each {|fd| fd.close rescue nil} # Yeah, yeah. I know.
+      end
+
+      def threadme(&block)
+        if self.framework
+          # Leak as few connections as possible
+          self.framework.threads.spawn("External Module #{self.path}", false, &block)
+        else
+          ::Thread.new &block
+        end
+      end
+    end
   end
 end
 
@@ -172,7 +167,7 @@ class Msf::Modules::External::PyBridge < Msf::Modules::External::Bridge
     module_name.match? /\.py$/
   end
 
-  def initialize(module_path)
+  def initialize(module_path, framework: nil)
     super
     pythonpath = ENV['PYTHONPATH'] || ''
     self.env = self.env.merge({ 'PYTHONPATH' => pythonpath + File::PATH_SEPARATOR + File.expand_path('../python', __FILE__) })
@@ -184,7 +179,7 @@ class Msf::Modules::External::RbBridge < Msf::Modules::External::Bridge
     module_name.match? /\.rb$/
   end
 
-  def initialize(module_path)
+  def initialize(module_path, framework: nil)
     super
 
     ruby_path = File.expand_path('../ruby', __FILE__)
@@ -200,9 +195,9 @@ class Msf::Modules::External::Bridge
     Msf::Modules::External::Bridge
   ]
 
-  def self.open(module_path)
+  def self.open(module_path, framework: nil)
     LOADERS.each do |klass|
-      return klass.new module_path if klass.applies? module_path
+      return klass.new module_path, framework: framework if klass.applies? module_path
     end
 
     nil

--- a/lib/msf/core/modules/external/python/metasploit/login_scanner.py
+++ b/lib/msf/core/modules/external/python/metasploit/login_scanner.py
@@ -1,0 +1,39 @@
+import time
+
+from metasploit import module
+
+
+def make_scanner(login_callback):
+    return lambda args: run_scanner(args, login_callback)
+
+
+def run_scanner(args, login_callback):
+    userpass = args['userpass']
+    rhost = args['rhost']
+    rport = int(args['rport'])
+    sleep_interval = float(args['sleep_interval'])
+
+    if isinstance(userpass, str):
+        userpass = [ attempt.split(' ', 1) for attempt in userpass.splitlines() ]
+
+    curr = 0
+    total = len(userpass)
+    pad_to = len(str(total))
+
+    for [username, password] in userpass:
+        try:
+            # Call per-combo login function
+            curr += 1
+            if login_callback(rhost, rport, username, password):
+                module.log('{}:{} - [{:>{pad_to}}/{}] - {}:{} - Success'
+                        .format(rhost, rport, curr, total, username, password, pad_to=pad_to), level='good')
+                module.report_correct_password(username, password)
+            else:
+                module.log('{}:{} - [{:>{pad_to}}/{}] - {}:{} - Failure'
+                        .format(rhost, rport, curr, total, username, password, pad_to=pad_to), level='info')
+                module.report_wrong_password(username, password)
+
+            time.sleep(sleep_interval)
+        except Exception as e:
+            module.log('{}:{} - [{:>{pad_to}}/{}] - {}:{} - Error: {}'
+                    .format(rhost, rport, curr, total, username, password, e, pad_to=pad_to), level='error')

--- a/lib/msf/core/modules/external/python/metasploit/module.py
+++ b/lib/msf/core/modules/external/python/metasploit/module.py
@@ -63,6 +63,18 @@ def report_vuln(ip, name, **opts):
     report('vuln', vuln)
 
 
+def report_correct_password(username, password, **opts):
+    info = opts.copy()
+    info.update({'username': username, 'password': password})
+    report('correct_password', info)
+
+
+def report_wrong_password(username, password, **opts):
+    info = opts.copy()
+    info.update({'username': username, 'password': password})
+    report('wrong_password', info)
+
+
 def run(metadata, module_callback):
     req = json.loads(os.read(0, 10000).decode("utf-8"))
     if req['method'] == 'describe':

--- a/lib/msf/core/modules/external/ruby/metasploit.rb
+++ b/lib/msf/core/modules/external/ruby/metasploit.rb
@@ -25,6 +25,14 @@ module Metasploit
       report(:vuln, opts.merge(host: ip, name: name))
     end
 
+    def report_correct_password(username, password, **opts)
+      report(:correct_password, opts.merge(username: username, password: password))
+    end
+
+    def report_wrong_password(username, password, **opts)
+      report(:wrong_password, opts.merge(username: username, password: password))
+    end
+
     def run(metadata, callback)
       self.logging_prefix = ''
       req = JSON.parse($stdin.readpartial(10000), symbolize_names: true)

--- a/lib/msf/core/modules/external/shim.rb
+++ b/lib/msf/core/modules/external/shim.rb
@@ -1,10 +1,9 @@
 # -*- coding: binary -*-
 require 'msf/core/modules/external'
-require 'msf/core/modules/external/bridge'
 
 class Msf::Modules::External::Shim
   def self.generate(module_path)
-    mod = Msf::Modules::External::Bridge.open(module_path)
+    mod = Msf::Modules::External.new(module_path)
     return '' unless mod.meta
     case mod.meta['type']
     when 'remote_exploit_cmd_stager'

--- a/lib/msf/core/modules/external/shim.rb
+++ b/lib/msf/core/modules/external/shim.rb
@@ -15,6 +15,8 @@ class Msf::Modules::External::Shim
       dos(mod)
     when 'single_scanner'
       single_scanner(mod)
+    when 'single_host_login_scanner'
+      single_host_login_scanner(mod)
     when 'multi_scanner'
       multi_scanner(mod)
     else
@@ -92,6 +94,16 @@ class Msf::Modules::External::Shim
     end.join(",\n          ")
 
     render_template('single_scanner.erb', meta)
+  end
+
+  def self.single_host_login_scanner(mod)
+    meta = mod_meta_common(mod, drop_rhost: true)
+    meta[:date] = mod.meta['date'].dump
+    meta[:references] = mod.meta['references'].map do |r|
+      "[#{r['type'].upcase.dump}, #{r['ref'].dump}]"
+    end.join(",\n          ")
+
+    render_template('single_host_login_scanner.erb', meta)
   end
 
   def self.multi_scanner(mod)

--- a/lib/msf/core/modules/external/shim.rb
+++ b/lib/msf/core/modules/external/shim.rb
@@ -18,8 +18,7 @@ class Msf::Modules::External::Shim
     when 'multi_scanner'
       multi_scanner(mod)
     else
-      # TODO have a nice load error show up in the logs
-      ''
+      nil
     end
   end
 

--- a/lib/msf/core/modules/external/templates/capture_server.erb
+++ b/lib/msf/core/modules/external/templates/capture_server.erb
@@ -19,8 +19,6 @@ class MetasploitModule < Msf::Auxiliary
 
   def run
     print_status("Starting server...")
-    mod = Msf::Modules::External::Bridge.open(<%= meta[:path] %>)
-    mod.run(datastore)
-    wait_status(mod)
+    execute_module(<%= meta[:path] %>)
   end
 end

--- a/lib/msf/core/modules/external/templates/dos.erb
+++ b/lib/msf/core/modules/external/templates/dos.erb
@@ -22,8 +22,6 @@ class MetasploitModule < Msf::Auxiliary
 
   def run
     print_status("Starting server...")
-    mod = Msf::Modules::External::Bridge.open(<%= meta[:path] %>)
-    mod.run(datastore)
-    wait_status(mod)
+    execute_module(<%= meta[:path] %>)
   end
 end

--- a/lib/msf/core/modules/external/templates/multi_scanner.erb
+++ b/lib/msf/core/modules/external/templates/multi_scanner.erb
@@ -26,10 +26,9 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run_batch(ips)
-    mod = Msf::Modules::External::Bridge.open(<%= meta[:path] %>)
     datastore.delete('RHOSTS')
     datastore['rhosts'] = ips
-    mod.run(datastore)
-    wait_status(mod)
+
+    execute_module(<%= meta[:path] %>)
   end
 end

--- a/lib/msf/core/modules/external/templates/remote_exploit_cmd_stager.erb
+++ b/lib/msf/core/modules/external/templates/remote_exploit_cmd_stager.erb
@@ -35,10 +35,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def execute_command(cmd, opts)
-    mod = Msf::Modules::External::Bridge.open(<%= meta[:path] %>)
-    mod.run(datastore.merge(command: cmd))
-    wait_status(mod)
-    true
+    execute_module(<%= meta[:path] %>, args: datastore.merge(command: cmd))
   end
 
   def exploit

--- a/lib/msf/core/modules/external/templates/single_host_login_scanner.erb
+++ b/lib/msf/core/modules/external/templates/single_host_login_scanner.erb
@@ -1,0 +1,35 @@
+require 'msf/core/modules/external/bridge'
+require 'msf/core/module/external'
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Auxiliary::Scanner
+  include Msf::Auxiliary::AuthBrute
+  include Msf::Module::External
+
+  def initialize
+    super({
+	  <%= common_metadata meta %>
+      'References'  =>
+        [
+          <%= meta[:references] %>
+        ],
+      'DisclosureDate' => <%= meta[:date] %>,
+      })
+
+      register_options([
+        <%= meta[:options] %>
+      ])
+  end
+
+  def run_host(ip)
+    print_status("Running for #{ip}...")
+    mod = Msf::Modules::External::Bridge.open(<%= meta[:path] %>)
+    rhost = datastore.delete('RHOST')
+    datastore['rhost'] = rhost
+    datastore['userpass'] ||= build_credentials_array
+    datastore['sleep_interval'] ||= userpass_interval
+
+    mod.run(datastore)
+    wait_status(mod)
+  end
+end

--- a/lib/msf/core/modules/external/templates/single_host_login_scanner.erb
+++ b/lib/msf/core/modules/external/templates/single_host_login_scanner.erb
@@ -23,13 +23,11 @@ class MetasploitModule < Msf::Auxiliary
 
   def run_host(ip)
     print_status("Running for #{ip}...")
-    mod = Msf::Modules::External::Bridge.open(<%= meta[:path] %>)
     rhost = datastore.delete('RHOST')
     datastore['rhost'] = rhost
     datastore['userpass'] ||= build_credentials_array
     datastore['sleep_interval'] ||= userpass_interval
 
-    mod.run(datastore)
-    wait_status(mod)
+    execute_module(<%= meta[:path] %>)
   end
 end

--- a/lib/msf/core/modules/external/templates/single_scanner.erb
+++ b/lib/msf/core/modules/external/templates/single_scanner.erb
@@ -22,10 +22,8 @@ class MetasploitModule < Msf::Auxiliary
 
   def run_host(ip)
     print_status("Running for #{ip}...")
-    mod = Msf::Modules::External::Bridge.open(<%= meta[:path] %>)
     rhost = datastore.delete('RHOST')
     datastore['rhost'] = rhost
-    mod.run(datastore)
-    wait_status(mod)
+    execute_module(<%= meta[:path] %>)
   end
 end

--- a/lib/msf/core/modules/loader/executable.rb
+++ b/lib/msf/core/modules/loader/executable.rb
@@ -85,7 +85,13 @@ class Msf::Modules::Loader::Executable < Msf::Modules::Loader::Base
       return ''
     end
     begin
-      Msf::Modules::External::Shim.generate(full_path)
+      content = Msf::Modules::External::Shim.generate(full_path)
+      if content
+        return content
+      else
+        elog "Unable to load module #{full_path}, unknown module type"
+        return ''
+      end
     rescue ::Exception => e
       elog "Unable to load module #{full_path} #{e.class} #{e} #{e.backtrace.join "\n"}"
       # XXX migrate this to a full load_error when we can tell the user why the


### PR DESCRIPTION
This adds an API to the external module interface capable of reporting correct and incorrect passwords. Also, some refactoring of the API was done to make some things easier to use and (hopefully) more reliable.

Verification (creds)
========
- [x] Throw `populate_creds.py` into `~/.msf4/modules/auxiliary/test/scanner/load_creds.py` and `chmod +x`. https://gist.github.com/acammack-r7/06fc0ede7869d5b28497805bc0e11718
- [x] Throw `creds.txt` into `/tmp`
- [x] `./msfconsole`
- [x] `workspace -a pr10002`
- [x] `use auxiliary/test/scanner/load_creds`
- [x] `set rhosts 127.0.0.1`
- [x] `set user_file /tmp/creds.txt`
- [x] `set pass_file /tmp/creds.txt`
- [x] `run`
- [x] All password combinations should be tried and fail with duplicates not attempted
- [x] `creds` should be empty
- [x] `edit` and change `False` to `True` in the `valid_login` function
- [x] `run`
- [x] All password combinations should be tried and work with duplicates not attempted
- [x] `creds` should have all the passwords

Verification (refactor)
=========
- [x] Make sure your favorite external modules still works as expected
- [ ] ex, the Haraka steps from https://github.com/rapid7/metasploit-framework/pull/8178
- [ ] or ROBOT: https://github.com/rapid7/metasploit-framework/pull/9489
- [x] or SharknAT&To https://github.com/rapid7/metasploit-framework/pull/9424