### PR TITLE
remove "require 'os'", it is not needed or available

### DIFF
--- a/msfupdate
+++ b/msfupdate
@@ -150,7 +150,6 @@ class Msfupdate
   # We could also do this by running `git config --global user.name` and `git config --global user.email`
   # and check the output of those. (it's a bit quieter)
   def git_globals_okay?
-    require 'os'
     output = ''
     begin
       output = `git config --list`


### PR DESCRIPTION
Fixes #10018, removing the unnecessary `require 'os'` That apparently Ruby 2.4 exposed, but other versions didn't (and it was unneeded at all apparently).

## Verification

- [x] Start `msfupdate` with a few different versions of Ruby
- [x] Verify that it doesn't fail