### PR TITLE
Add post/multi/recon/sudo_commands

### DIFF
--- a/documentation/modules/post/multi/recon/sudo_commands.md
+++ b/documentation/modules/post/multi/recon/sudo_commands.md
@@ -1,0 +1,92 @@
+## Description
+
+  This module examines the sudoers configuration for the session user
+  and lists the commands executable via `sudo`.
+ 
+  This module also inspects each command and reports potential avenues
+  for privileged code execution due to poor file system permissions or
+  permitting execution of executables known to be useful for privesc,
+  such as utilities designed for file read/write, user modification,
+  or execution of arbitrary operating system commands.
+
+  Note, you may need to provide the password for the session user.
+
+
+## Verification Steps
+ 
+  1. Start `msfconsole`
+  2. Get a session
+  3. `use post/multi/recon/sudo_commands`
+  4. `set SESSION [SESSION]`
+  5. `run`
+  6. You should receive a list of available `sudo` commands
+
+
+## Options
+
+  **SESSION**
+
+  Which session to use, which can be viewed with `sessions`
+
+  **SUDO_PATH**
+
+  Path to sudo executable (default: `/usr/bin/sudo`)
+
+  **PASSWORD**
+
+  Password for the session user
+
+
+## Scenarios
+
+  ```
+  msf5 > use post/multi/recon/sudo_commands
+  msf5 post(multi/recon/sudo_commands) > set session 1
+  session => 1
+  msf5 post(multi/recon/sudo_commands) > set verbose true
+  verbose => true
+  msf5 post(multi/recon/sudo_commands) > run
+
+  [*] Executing: /usr/bin/sudo -n -l
+  Matching Defaults entries for wvu on localhost:
+      !visiblepw, always_set_home, match_group_by_gid, env_reset, env_keep="COLORS DISPLAY HOSTNAME HISTSIZE KDEDIR LS_COLORS", env_keep+="MAIL PS1 PS2 QTDIR USERNAME LANG LC_ADDRESS LC_CTYPE", env_keep+="LC_COLLATE LC_IDENTIFICATION LC_MEASUREMENT LC_MESSAGES", env_keep+="LC_MONETARY LC_NAME LC_NUMERIC LC_PAPER LC_TELEPHONE", env_keep+="LC_TIME LC_ALL LANGUAGE LINGUAS _XKB_CHARSET XAUTHORITY", secure_path=/sbin\:/bin\:/usr/sbin\:/usr/bin
+
+  User wvu may run the following commands on localhost:
+      (ALL) ALL
+      (ALL) NOPASSWD: ALL
+      (root) /sbin/mount /mnt/cdrom, /sbin/umount /mnt/cdrom
+      (root) /sbin/shutdown -h now
+
+  [*] Command: "ALL" RunAsUsers: ALL
+  [+] sudo any command!
+  [*] Command: "ALL" RunAsUsers: ALL without providing a password
+  [+] sudo any command!
+  [*] Command: "/sbin/mount /mnt/cdrom" RunAsUsers: root
+  [*] Command: "/sbin/umount /mnt/cdrom" RunAsUsers: root
+  [*] Command: "/sbin/shutdown -h now" RunAsUsers: root
+
+  Sudo Commands
+  =============
+
+    Command                  RunAsUsers  RunAsGroups  Password?  Privesc?
+    -------                  ----------  -----------  ---------  --------
+    /sbin/mount /mnt/cdrom   root                     True
+    /sbin/shutdown -h now    root                     True
+    /sbin/umount /mnt/cdrom  root                     True
+    ALL                      ALL                      True       True
+    ALL                      ALL                                 True
+
+  [+] Output stored in: /Users/user/.msf4/loot/20180613134731_default_192.168.56.101_sudo.commands_305964.txt
+  [*] Post module execution completed
+  msf5 post(multi/recon/sudo_commands) > cat /Users/user/.msf4/loot/20180613134731_default_192.168.56.101_sudo.commands_305964.txt
+  [*] exec: cat /Users/user/.msf4/loot/20180613134731_default_192.168.56.101_sudo.commands_305964.txt
+
+  Command,RunAsUsers,RunAsGroups,Password?,Privesc?
+  "/sbin/mount /mnt/cdrom","root","","True",""
+  "/sbin/shutdown -h now","root","","True",""
+  "/sbin/umount /mnt/cdrom","root","","True",""
+  "ALL","ALL","","True","True"
+  "ALL","ALL","","","True"
+  msf5 post(multi/recon/sudo_commands) >
+  ```
+

--- a/modules/post/multi/recon/sudo_commands.rb
+++ b/modules/post/multi/recon/sudo_commands.rb
@@ -1,0 +1,251 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Post
+
+  include Msf::Post::File
+  include Msf::Post::Linux::Priv
+  include Msf::Auxiliary::Report
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'          => 'Sudo Commands',
+      'Description'   => %q{
+        This module examines the sudoers configuration for the session user
+        and lists the commands executable via sudo.
+
+        This module also inspects each command and reports potential avenues
+        for privileged code execution due to poor file system permissions or
+        permitting execution of executables known to be useful for privesc,
+        such as utilities designed for file read/write, user modification,
+        or execution of arbitrary operating system commands.
+
+        Note, you may need to provide the password for the session user.
+      },
+      'License'       => MSF_LICENSE,
+      'Author'        => [ 'bcoles' ],
+      'Platform'      => [ 'bsd', 'linux', 'osx', 'solaris', 'unix' ],
+      'SessionTypes'  => [ 'meterpreter', 'shell' ]
+    ))
+    register_options [
+      OptString.new('SUDO_PATH', [ true, 'Path to sudo executable', '/usr/bin/sudo' ]),
+      OptString.new('PASSWORD', [ false, 'Password for the current user', '' ])
+    ]
+  end
+
+  def sudo_path
+    datastore['SUDO_PATH'].to_s
+  end
+
+  def password
+    datastore['PASSWORD'] ? datastore['PASSWORD'].to_s : session.exploit_datastore['PASSWORD']
+  end
+
+  def is_writable?(path)
+    cmd_exec("test -w '#{path}' && echo true").include? 'true'
+  end
+
+  def is_executable?(path)
+    cmd_exec("test -x '#{path}' && echo true").include? 'true'
+  end
+
+  def eop_bins
+    %w[
+      cat chgrp chmod chown cp echo find less ln mkdir more mv tail tar
+      usermod useradd userdel
+      crontab
+      awk gawk perl python ruby irb lua
+      netcat netcat.traditional nc nc.traditional openssl telnetd
+      sh ash bash ksh zsh
+      su sudo
+      wget curl
+      nmap
+      man emacs nano vi vim visudo
+    ]
+  end
+
+  def check_eop(cmd)
+    # drop args for simplicity at the risk of false positives
+    cmd = cmd.split(/\s/).first
+
+    if cmd.eql? 'ALL'
+      print_good 'sudo any command!'
+      return true
+    end
+
+    base_dir  = File.dirname cmd
+    base_name = File.basename cmd
+
+    if file_exist? cmd
+      if is_writable? cmd
+        print_good "#{cmd} is writable!"
+        return true
+      end
+    elsif is_writable? base_dir
+      print_good "#{cmd} does not exist and #{base_dir} is writable!"
+      return true
+    end
+
+    if eop_bins.include? base_name
+      print_good "#{cmd} matches known privesc executable '#{base_name}' !"
+      return true
+    end
+
+    false
+  end
+
+  #
+  # Retrieve list of sudo commands for current session user
+  #
+  def sudo_list
+    # try non-interactive (-n) without providing a password
+    cmd = "#{sudo_path} -l -l -n"
+    vprint_status "Executing: #{cmd}"
+    output = cmd_exec(cmd).to_s
+
+    if output.start_with?('usage:') || output.include?('a password is required')
+      # try with a password from stdin (-S)
+      cmd = "echo #{password} | #{sudo_path} -S -l -l"
+      vprint_status "Executing: #{cmd}"
+      output = cmd_exec(cmd).to_s
+    end
+
+    output
+  end
+
+  def parse_sudo(entry)
+    entry.split(/^\s*RunAsUsers: /).flatten.each { |s| parse_segment(s) }
+  rescue => e
+    print_error "Could not parse sudoers entry: #{e.message}"
+  end
+
+  def parse_segment(segment)
+    users = segment.split("\n").first.strip
+
+    if users.eql? ''
+      print_warning 'Could not parse sudoers entry'
+      return
+    end
+
+    groups = segment.scan(/^\s*RunAsGroups: (.*)$/).flatten.first || ''
+    options = segment.scan(/^\s*Options: (.*)$/).flatten.first || ''
+
+    commands = []
+    # Assuming the entirety of the remainder of the segment
+    # following the 'Commands:' directive contains only commands.
+    # This appears to be a safe assumption in testing.
+    segment.scan(/^\s*Commands:\s*(.*)\z/m).flatten.each do |cmd_data|
+      # Long commands may linewrap on older versions of sudo.
+      # Preventing the linewrap requires a proper TTY,
+      # so we rely on the whitespace indentation instead:
+      # - 8 spaces for start of a new command
+      # - 4 spaces for continuation of a linewrapped command
+      # first we'll remove all indentation for lines with 8 spaces of indentation
+      cmd_data = cmd_data.gsub(/^\s{8}/, '')
+      # now we'll remove the wrap by replacing all newlines followed by 4 spaces of indentation with a space
+      cmd_data = cmd_data.gsub(/\n\s{4}/, ' ')
+      # now we'll split by line, hoping the linewraps have been fixed
+      cmd_data.split(/\n/).each do |cmd|
+        # Commands are separated by commas but may also contain commas (escaped with a backslash)
+        # so we temporarily replace escaped commas with some junk
+        # later, we'll replace each instance of the junk with a comma
+        junk = Rex::Text.rand_text_alpha(10)
+        cmd = cmd.gsub('\,', junk)
+        cmd.split(',').each do |csv|
+          commands << csv.gsub(junk, ',').strip
+        end
+      end
+    end
+
+    commands.each do |cmd|
+      no_passwd = false
+
+      if cmd.start_with? 'NOPASSWD:'
+        no_passwd = true
+        cmd = cmd.gsub(/^NOPASSWD:\s*/, '')
+      end
+
+      if options.include? '!authenticate'
+        no_passwd = true
+      end
+
+      msg = "Command: #{cmd.inspect}"
+      msg << " RunAsUsers: #{users}" unless users.eql? ''
+      msg << " RunAsGroups: #{groups}" unless groups.eql? ''
+      msg << ' without providing a password' if no_passwd
+      vprint_status msg
+
+      eop = check_eop cmd
+
+      @results << [cmd, users, groups, !no_passwd, eop]
+    end
+  end
+
+  def run
+    if is_root?
+      fail_with Failure::BadConfig, 'Session already has root privileges'
+    end
+
+    unless is_executable? sudo_path
+      print_error 'Could not find sudo executable'
+      return
+    end
+
+    output = sudo_list
+    vprint_status 'Output:'
+    vprint_line output
+    vprint_line
+
+    if output.include? 'Sorry, try again'
+      fail_with Failure::NoAccess, 'Incorrect password'
+    end
+
+    if output.eql? ''
+      fail_with Failure::NoAccess, 'Incorrect password, or the session user is not permitted to execute any commands with sudo'
+    end
+
+    entries = output.split("\n\n").select { |e| e.start_with? 'Sudoers entry' }
+
+    if entries.empty?
+      fail_with Failure::NoAccess, 'Found no sudo entries for the session user'
+    end
+
+    print_good "Found #{entries.length} sudo entries for current user"
+
+    @results = Rex::Text::Table.new(
+      'Header'  => 'Sudo Commands',
+      'Indent'  => 2,
+      'Columns' =>
+        [
+          'Command',
+          'RunAsUsers',
+          'RunAsGroups',
+          'Password?',
+          'Privesc?'
+        ]
+    )
+
+    entries.each { |entry| parse_sudo entry }
+
+    if @results.rows.empty?
+      print_status 'Found no sudo commands for the session user'
+      return
+    end
+
+    print_line
+    print_line @results.to_s
+
+    path = store_loot(
+      'sudo.commands',
+      'text/csv',
+      session,
+      @results.to_csv,
+      'sudo.commands.txt',
+      'Sudo Commands'
+    )
+
+    print_good "Output stored in: #{path}"
+  end
+end

--- a/modules/post/multi/recon/sudo_commands.rb
+++ b/modules/post/multi/recon/sudo_commands.rb
@@ -55,14 +55,16 @@ class MetasploitModule < Msf::Post
     %w[
       cat chgrp chmod chown cp echo find less ln mkdir more mv tail tar
       usermod useradd userdel
-      crontab
-      awk gawk perl python ruby irb lua
-      netcat netcat.traditional nc nc.traditional openssl telnetd
-      sh ash bash ksh zsh
+      env crontab
+      awk gdb gawk lua irb ld node perl php python python2 python3 ruby tclsh wish
+      ncat netcat netcat.traditional nc nc.traditional openssl socat telnet telnetd
+      ash bash csh dash ksh sh zsh
       su sudo
-      wget curl
+      expect ionice nice script setarch strace taskset time
+      wget curl ftp scp sftp ssh tftp
       nmap
-      man emacs nano vi vim visudo
+      ed emacs man nano vi vim visudo
+      dpkg rpm rpmquery
     ]
   end
 


### PR DESCRIPTION
Add `post/multi/recon/sudo_commands`.

        This module examines the sudoers configuration for the session user
        and lists the commands executable via sudo.

        This module also inspects each command and reports potential avenues
        for privileged code execution due to poor file system permissions or
        permitting execution of executables known to be useful for privesc,
        such as utilities designed for file read/write, user modification,
        or execution of arbitrary operating system commands.

        Note, you may need to provide the password for the session user.


## Verification

- [x] Start `msfconsole`
- [x] Get a session
- [x] `use post/multi/recon/sudo_commands`
- [x] `set SESSION <ID>`
- [x] `run`
- [x] **Verify** available sudo commands are displayed

Tested on:

* CentOS 5.6
* Solaris 11.1
* Debian 9.0.0
* Fedora 11
* RHEL 5.11
* Linux Mint 18.3
* HardenedBSD 10  - (requires `SUDO_PATH` to be changed to `/usr/bin/local/sudo`)
* Mac OSX Lion 10.7


## Example Output

```
msf5 post(multi/recon/sudo_commands) > set session 3
session => 3
msf5 post(multi/recon/sudo_commands) > set verbose false
verbose => false
msf5 post(multi/recon/sudo_commands) > run

[+] Found 1 sudo entries for current user
[+] sudo any command!

Sudo Commands
=============

  Command  RunAsUsers  RunAsGroups  Password?  Privesc?
  -------  ----------  -----------  ---------  --------
  ALL      ALL                      false      true

[+] Output stored in: /root/.msf4/loot/20180514141941_default_172.16.191.169_sudo.commands_870128.txt
[*] Post module execution completed
msf5 post(multi/recon/sudo_commands) > set verbose true
verbose => true
msf5 post(multi/recon/sudo_commands) > run

[*] Executing: /usr/bin/sudo -l -l -n
[*] Executing: echo password1 | /usr/bin/sudo -S -l -l
[*] Output:
Matching Defaults entries for centos on this host:
    requiretty, !visiblepw, env_reset, env_keep="COLORS DISPLAY HOSTNAME
    HISTSIZE INPUTRC KDEDIR LS_COLORS MAIL PS1 PS2 QTDIR USERNAME LANG
    LC_ADDRESS LC_CTYPE LC_COLLATE LC_IDENTIFICATION LC_MEASUREMENT LC_MESSAGES
    LC_MONETARY LC_NAME LC_NUMERIC LC_PAPER LC_TELEPHONE LC_TIME LC_ALL
    LANGUAGE LINGUAS _XKB_CHARSET XAUTHORITY"

User centos may run the following commands on this host:

Sudoers entry:
    RunAsUsers: ALL
    Commands: 
	NOPASSWD: ALL

[+] Found 1 sudo entries for current user
[*] Command: "ALL" RunAsUsers: ALL without providing a password
[+] sudo any command!

Sudo Commands
=============

  Command  RunAsUsers  RunAsGroups  Password?  Privesc?
  -------  ----------  -----------  ---------  --------
  ALL      ALL                      false      true

[+] Output stored in: /root/.msf4/loot/20180514141951_default_172.16.191.169_sudo.commands_992679.txt
[*] Post module execution completed
msf5 post(multi/recon/sudo_commands) > cat /root/.msf4/loot/20180514141951_default_172.16.191.169_sudo.commands_992679.txt
[*] exec: cat /root/.msf4/loot/20180514141951_default_172.16.191.169_sudo.commands_992679.txt

Command,RunAsUsers,RunAsGroups,Password?,Privesc?
"ALL","ALL","","false","true"
msf5 post(multi/recon/sudo_commands) > set session 5
session => 5
msf5 post(multi/recon/sudo_commands) > set verbose false
verbose => false
msf5 post(multi/recon/sudo_commands) > run

[+] Found 4 sudo entries for current user
[+] sudo any command!
[+] /usr/bin/echo matches known privesc executable 'echo' !
[+] /usr/bin/echo matches known privesc executable 'echo' !
[+] /usr/bin/echo matches known privesc executable 'echo' !

Sudo Commands
=============

  Command                                                                                                         RunAsUsers  RunAsGroups  Password?  Privesc?
  -------                                                                                                         ----------  -----------  ---------  --------
  /usr/bin/echo \"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA this is a really long line that will totally line wrap\"        ALL                      true       true
  /usr/bin/echo \"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA this is another really long line that will totally line wrap\"  ALL                      true       true
  /usr/bin/echo \"this, line, contains, commas\"                                                                  ALL                      true       true
  ALL                                                                                                             ALL                      true       true

[+] Output stored in: /root/.msf4/loot/20180514142005_default_172.16.191.220_sudo.commands_378763.txt
[*] Post module execution completed
msf5 post(multi/recon/sudo_commands) > set verbose true
verbose => true
msf5 post(multi/recon/sudo_commands) > run

[*] Executing: /usr/bin/sudo -l -l -n
[*] Executing: echo password1 | /usr/bin/sudo -S -l -l
[*] Output:
Password: User jack may run the following commands on this host:

Sudoers entry:
    RunAsUsers: ALL
    Commands:
	ALL

Sudoers entry:
    RunAsUsers: ALL
    Commands:
	/usr/bin/echo \"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA this is a really long line
    that will totally line wrap\"

Sudoers entry:
    RunAsUsers: ALL
    Commands:
	/usr/bin/echo \"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA this is another really long
    line that will totally line wrap\"

Sudoers entry:
    RunAsUsers: ALL
    Commands:
	/usr/bin/echo \"this\, line\, contains\, commas\"

[+] Found 4 sudo entries for current user
[*] Command: "ALL" RunAsUsers: ALL
[+] sudo any command!
[*] Command: "/usr/bin/echo \\\"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA this is a really long line that will totally line wrap\\\"" RunAsUsers: ALL
[+] /usr/bin/echo matches known privesc executable 'echo' !
[*] Command: "/usr/bin/echo \\\"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA this is another really long line that will totally line wrap\\\"" RunAsUsers: ALL
[+] /usr/bin/echo matches known privesc executable 'echo' !
[*] Command: "/usr/bin/echo \\\"this, line, contains, commas\\\"" RunAsUsers: ALL
[+] /usr/bin/echo matches known privesc executable 'echo' !

Sudo Commands
=============

  Command                                                                                                         RunAsUsers  RunAsGroups  Password?  Privesc?
  -------                                                                                                         ----------  -----------  ---------  --------
  /usr/bin/echo \"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA this is a really long line that will totally line wrap\"        ALL                      true       true
  /usr/bin/echo \"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA this is another really long line that will totally line wrap\"  ALL                      true       true
  /usr/bin/echo \"this, line, contains, commas\"                                                                  ALL                      true       true
  ALL                                                                                                             ALL                      true       true

[+] Output stored in: /root/.msf4/loot/20180514142012_default_172.16.191.220_sudo.commands_578611.txt
[*] Post module execution completed
msf5 post(multi/recon/sudo_commands) > cat /root/.msf4/loot/20180514142012_default_172.16.191.220_sudo.commands_578611.txt
[*] exec: cat /root/.msf4/loot/20180514142012_default_172.16.191.220_sudo.commands_578611.txt

Command,RunAsUsers,RunAsGroups,Password?,Privesc?
"/usr/bin/echo \""AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA this is a really long line that will totally line wrap\""","ALL","","true","true"
"/usr/bin/echo \""AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA this is another really long line that will totally line wrap\""","ALL","","true","true"
"/usr/bin/echo \""this, line, contains, commas\""","ALL","","true","true"
"ALL","ALL","","true","true"
msf5 post(multi/recon/sudo_commands) > set session 7
session => 7
msf5 post(multi/recon/sudo_commands) > set verbose false
verbose => false
msf5 post(multi/recon/sudo_commands) > run

[+] Found 3 sudo entries for current user
[+] /bin/cat matches known privesc executable 'cat' !
[+] /bin/sh matches known privesc executable 'sh' !
[+] /bin/cp matches known privesc executable 'cp' !
[+] /tmp/echo does not exist and /tmp is writable!
[+] /bin/echo matches known privesc executable 'echo' !

Sudo Commands
=============

  Command                                    RunAsUsers  RunAsGroups  Password?  Privesc?
  -------                                    ----------  -----------  ---------  --------
  /bin/cat                                   ALL                      false      true
  /bin/cp /tmp/source /tmp/destination       ALL         ALL          true       true
  /bin/echo sudo's output sucks for parsing  ALL         ALL          true       true
  /bin/ping                                  ALL         ALL          true       false
  /bin/sh                                    ALL                      true       true
  /sbin/dhclient                             ALL         ALL          true       false
  /sbin/ifconfig                             ALL         ALL          true       false
  /sbin/iptables                             ALL         ALL          true       false
  /sbin/iwconfig                             ALL         ALL          true       false
  /sbin/mii-tool                             ALL         ALL          true       false
  /sbin/route                                ALL         ALL          true       false
  /tmp/echo sudo's output sucks for parsing  ALL         ALL          true       true
  /usr/bin/net                               ALL         ALL          true       false
  /usr/bin/rfcomm                            ALL         ALL          true       false
  /usr/bin/wvdial                            ALL         ALL          true       false

[+] Output stored in: /root/.msf4/loot/20180514142037_default_172.16.191.169_sudo.commands_087764.txt
[*] Post module execution completed
msf5 post(multi/recon/sudo_commands) > set verbose true
rverbose => true
umsf5 post(multi/recon/sudo_commands) > run

[*] Executing: /usr/bin/sudo -l -l -n
[*] Executing: echo password1 | /usr/bin/sudo -S -l -l
[*] Output:
Matching Defaults entries for test on this host:
    requiretty, !visiblepw, env_reset, env_keep="COLORS DISPLAY HOSTNAME
    HISTSIZE INPUTRC KDEDIR LS_COLORS MAIL PS1 PS2 QTDIR USERNAME LANG
    LC_ADDRESS LC_CTYPE LC_COLLATE LC_IDENTIFICATION LC_MEASUREMENT LC_MESSAGES
    LC_MONETARY LC_NAME LC_NUMERIC LC_PAPER LC_TELEPHONE LC_TIME LC_ALL
    LANGUAGE LINGUAS _XKB_CHARSET XAUTHORITY"

User test may run the following commands on this host:

Sudoers entry:
    RunAsUsers: ALL
    Commands: 
	NOPASSWD: /bin/cat
    RunAsUsers: ALL
    Commands: 
	/bin/sh

Sudoers entry:
    RunAsUsers: ALL
    RunAsGroups: ALL
    Commands: 
	/sbin/route, /sbin/ifconfig, /bin/ping, /sbin/dhclient, /usr/bin/net,
    /sbin/iptables, /usr/bin/rfcomm, /usr/bin/wvdial, /sbin/iwconfig,
    /sbin/mii-tool

Sudoers entry:
    RunAsUsers: ALL
    RunAsGroups: ALL
    Commands: 
	/bin/cp /tmp/source /tmp/destination, /tmp/echo sudo's output sucks for
    parsing, /bin/echo sudo's output sucks for parsing

[+] Found 3 sudo entries for current user
[*] Command: "/bin/cat" RunAsUsers: ALL without providing a password
[+] /bin/cat matches known privesc executable 'cat' !
[*] Command: "/bin/sh" RunAsUsers: ALL
[+] /bin/sh matches known privesc executable 'sh' !
[*] Command: "/sbin/route" RunAsUsers: ALL RunAsGroups: ALL
[*] Command: "/sbin/ifconfig" RunAsUsers: ALL RunAsGroups: ALL
[*] Command: "/bin/ping" RunAsUsers: ALL RunAsGroups: ALL
[*] Command: "/sbin/dhclient" RunAsUsers: ALL RunAsGroups: ALL
[*] Command: "/usr/bin/net" RunAsUsers: ALL RunAsGroups: ALL
[*] Command: "/sbin/iptables" RunAsUsers: ALL RunAsGroups: ALL
[*] Command: "/usr/bin/rfcomm" RunAsUsers: ALL RunAsGroups: ALL
[*] Command: "/usr/bin/wvdial" RunAsUsers: ALL RunAsGroups: ALL
[*] Command: "/sbin/iwconfig" RunAsUsers: ALL RunAsGroups: ALL
[*] Command: "/sbin/mii-tool" RunAsUsers: ALL RunAsGroups: ALL
[*] Command: "/bin/cp /tmp/source /tmp/destination" RunAsUsers: ALL RunAsGroups: ALL
[+] /bin/cp matches known privesc executable 'cp' !
[*] Command: "/tmp/echo sudo's output sucks for parsing" RunAsUsers: ALL RunAsGroups: ALL
[+] /tmp/echo does not exist and /tmp is writable!
[*] Command: "/bin/echo sudo's output sucks for parsing" RunAsUsers: ALL RunAsGroups: ALL
[+] /bin/echo matches known privesc executable 'echo' !

Sudo Commands
=============

  Command                                    RunAsUsers  RunAsGroups  Password?  Privesc?
  -------                                    ----------  -----------  ---------  --------
  /bin/cat                                   ALL                      false      true
  /bin/cp /tmp/source /tmp/destination       ALL         ALL          true       true
  /bin/echo sudo's output sucks for parsing  ALL         ALL          true       true
  /bin/ping                                  ALL         ALL          true       false
  /bin/sh                                    ALL                      true       true
  /sbin/dhclient                             ALL         ALL          true       false
  /sbin/ifconfig                             ALL         ALL          true       false
  /sbin/iptables                             ALL         ALL          true       false
  /sbin/iwconfig                             ALL         ALL          true       false
  /sbin/mii-tool                             ALL         ALL          true       false
  /sbin/route                                ALL         ALL          true       false
  /tmp/echo sudo's output sucks for parsing  ALL         ALL          true       true
  /usr/bin/net                               ALL         ALL          true       false
  /usr/bin/rfcomm                            ALL         ALL          true       false
  /usr/bin/wvdial                            ALL         ALL          true       false

[+] Output stored in: /root/.msf4/loot/20180514142050_default_172.16.191.169_sudo.commands_880368.txt
[*] Post module execution completed
msf5 post(multi/recon/sudo_commands) > cat /root/.msf4/loot/20180514142050_default_172.16.191.169_sudo.commands_880368.txt
[*] exec: cat /root/.msf4/loot/20180514142050_default_172.16.191.169_sudo.commands_880368.txt

Command,RunAsUsers,RunAsGroups,Password?,Privesc?
"/bin/cat","ALL","","false","true"
"/bin/cp /tmp/source /tmp/destination","ALL","ALL","true","true"
"/bin/echo sudo's output sucks for parsing","ALL","ALL","true","true"
"/bin/ping","ALL","ALL","true","false"
"/bin/sh","ALL","","true","true"
"/sbin/dhclient","ALL","ALL","true","false"
"/sbin/ifconfig","ALL","ALL","true","false"
"/sbin/iptables","ALL","ALL","true","false"
"/sbin/iwconfig","ALL","ALL","true","false"
"/sbin/mii-tool","ALL","ALL","true","false"
"/sbin/route","ALL","ALL","true","false"
"/tmp/echo sudo's output sucks for parsing","ALL","ALL","true","true"
"/usr/bin/net","ALL","ALL","true","false"
"/usr/bin/rfcomm","ALL","ALL","true","false"
"/usr/bin/wvdial","ALL","ALL","true","false"
msf5 post(multi/recon/sudo_commands) > set session 8
session => 8
msf5 post(multi/recon/sudo_commands) > set verbose false
verbose => false
msf5 post(multi/recon/sudo_commands) > run

[+] Found 4 sudo entries for current user
[+] /bin/cat matches known privesc executable 'cat' !
[+] /tmp/asdf does not exist and /tmp is writable!
[+] /bin/echo matches known privesc executable 'echo' !
[+] /bin/echo matches known privesc executable 'echo' !

Sudo Commands
=============

  Command                                                                                             RunAsUsers  RunAsGroups  Password?  Privesc?
  -------                                                                                             ----------  -----------  ---------  --------
  /bin/cat                                                                                            ALL         ALL          true       true
  /bin/echo \"AAAAAAAAAAAAAAAAAAAAAAAA this is a really long line that will totally linewrap\"        ALL                      true       true
  /bin/echo \"AAAAAAAAAAAAAAAAAAAAAAAA this is another really long line that will totally linewrap\"  ALL                      true       true
  /tmp/asdf                                                                                           ALL                      true       true
  /usr/bin/id                                                                                         ALL         ALL          true       false

[+] Output stored in: /root/.msf4/loot/20180514142114_default_172.16.191.236_sudo.commands_177614.txt
[*] Post module execution completed
msf5 post(multi/recon/sudo_commands) > set verbose true
verbose => true
msf5 post(multi/recon/sudo_commands) > run

[*] Executing: /usr/bin/sudo -l -l -n
[*] Output:
Matching Defaults entries for user on debian-9-0-x64:
    env_reset, mail_badpass, secure_path=/usr/local/sbin\:/usr/local/bin\:/usr/sbin\:/usr/bin\:/sbin\:/bin

User user may run the following commands on debian-9-0-x64:

Sudoers entry:
    RunAsUsers: ALL
    RunAsGroups: ALL
    Commands:
	/usr/bin/id
	/bin/cat

Sudoers entry:
    RunAsUsers: ALL
    Commands:
	/tmp/asdf

Sudoers entry:
    RunAsUsers: ALL
    Commands:
	/bin/echo \"AAAAAAAAAAAAAAAAAAAAAAAA this is a really long line that will totally linewrap\"

Sudoers entry:
    RunAsUsers: ALL
    Commands:
	/bin/echo \"AAAAAAAAAAAAAAAAAAAAAAAA this is another really long line that will totally linewrap\"

[+] Found 4 sudo entries for current user
[*] Command: "/usr/bin/id" RunAsUsers: ALL RunAsGroups: ALL
[*] Command: "/bin/cat" RunAsUsers: ALL RunAsGroups: ALL
[+] /bin/cat matches known privesc executable 'cat' !
[*] Command: "/tmp/asdf" RunAsUsers: ALL
[+] /tmp/asdf does not exist and /tmp is writable!
[*] Command: "/bin/echo \\\"AAAAAAAAAAAAAAAAAAAAAAAA this is a really long line that will totally linewrap\\\"" RunAsUsers: ALL
[+] /bin/echo matches known privesc executable 'echo' !
[*] Command: "/bin/echo \\\"AAAAAAAAAAAAAAAAAAAAAAAA this is another really long line that will totally linewrap\\\"" RunAsUsers: ALL
[+] /bin/echo matches known privesc executable 'echo' !

Sudo Commands
=============

  Command                                                                                             RunAsUsers  RunAsGroups  Password?  Privesc?
  -------                                                                                             ----------  -----------  ---------  --------
  /bin/cat                                                                                            ALL         ALL          true       true
  /bin/echo \"AAAAAAAAAAAAAAAAAAAAAAAA this is a really long line that will totally linewrap\"        ALL                      true       true
  /bin/echo \"AAAAAAAAAAAAAAAAAAAAAAAA this is another really long line that will totally linewrap\"  ALL                      true       true
  /tmp/asdf                                                                                           ALL                      true       true
  /usr/bin/id                                                                                         ALL         ALL          true       false

[+] Output stored in: /root/.msf4/loot/20180514142121_default_172.16.191.236_sudo.commands_096538.txt
[*] Post module execution completed
msf5 post(multi/recon/sudo_commands) > cat /root/.msf4/loot/20180514142121_default_172.16.191.236_sudo.commands_096538.txt
[*] exec: cat /root/.msf4/loot/20180514142121_default_172.16.191.236_sudo.commands_096538.txt

Command,RunAsUsers,RunAsGroups,Password?,Privesc?
"/bin/cat","ALL","ALL","true","true"
"/bin/echo \""AAAAAAAAAAAAAAAAAAAAAAAA this is a really long line that will totally linewrap\""","ALL","","true","true"
"/bin/echo \""AAAAAAAAAAAAAAAAAAAAAAAA this is another really long line that will totally linewrap\""","ALL","","true","true"
"/tmp/asdf","ALL","","true","true"
"/usr/bin/id","ALL","ALL","true","false"
msf5 post(multi/recon/sudo_commands) > set session 9
session => 9
msf5 post(multi/recon/sudo_commands) > set verbose false
verbose => false
msf5 post(multi/recon/sudo_commands) > run

[+] Found 2 sudo entries for current user
[+] sudo any command!

Sudo Commands
=============

  Command                                    RunAsUsers  RunAsGroups  Password?  Privesc?
  -------                                    ----------  -----------  ---------  --------
  /usr/lib/linuxmint/mintUpdate/checkAPT.py  root                     false      false
  ALL                                        ALL         ALL          true       true

[+] Output stored in: /root/.msf4/loot/20180514143453_default_172.16.191.225_sudo.commands_046411.txt
[*] Post module execution completed
msf5 post(multi/recon/sudo_commands) > set verbose true
verbose => true
rmsf5 post(multi/recon/sudo_commands) > run

[*] Executing: /usr/bin/sudo -l -l -n
[*] Output:
Matching Defaults entries for user on linux-mint-18-3:
    env_reset, mail_badpass, secure_path=/usr/local/sbin\:/usr/local/bin\:/usr/sbin\:/usr/bin\:/sbin\:/bin\:/snap/bin

User user may run the following commands on linux-mint-18-3:

Sudoers entry:
    RunAsUsers: ALL
    RunAsGroups: ALL
    Commands:
	ALL

Sudoers entry:
    RunAsUsers: root
    Options: !authenticate
    Commands:
	/usr/lib/linuxmint/mintUpdate/checkAPT.py

[+] Found 2 sudo entries for current user
[*] Command: "ALL" RunAsUsers: ALL RunAsGroups: ALL
[+] sudo any command!
[*] Command: "/usr/lib/linuxmint/mintUpdate/checkAPT.py" RunAsUsers: root without providing a password

Sudo Commands
=============

  Command                                    RunAsUsers  RunAsGroups  Password?  Privesc?
  -------                                    ----------  -----------  ---------  --------
  /usr/lib/linuxmint/mintUpdate/checkAPT.py  root                     false      false
  ALL                                        ALL         ALL          true       true

[+] Output stored in: /root/.msf4/loot/20180514143458_default_172.16.191.225_sudo.commands_523002.txt
[*] Post module execution completed
msf5 post(multi/recon/sudo_commands) > cat /root/.msf4/loot/20180514143458_default_172.16.191.225_sudo.commands_523002.txt
[*] exec: cat /root/.msf4/loot/20180514143458_default_172.16.191.225_sudo.commands_523002.txt

Command,RunAsUsers,RunAsGroups,Password?,Privesc?
"/usr/lib/linuxmint/mintUpdate/checkAPT.py","root","","false","false"
"ALL","ALL","ALL","true","true"
msf5 post(multi/recon/sudo_commands) > 
```