### PR TITLE
Reorder msfvenom options and add more --list types

### DIFF
--- a/lib/msf/core/payload_generator.rb
+++ b/lib/msf/core/payload_generator.rb
@@ -198,7 +198,7 @@ module Msf
 
       if chosen_platform.platforms.empty?
         chosen_platform = mod.platform
-        cli_print "[-] No --platform was selected, choosing #{chosen_platform.platforms.first} from the payload"
+        cli_print "[-] No platform was selected, choosing #{chosen_platform.platforms.first} from the payload"
         @platform = mod.platform.platforms.first.to_s.split("::").last
       elsif (chosen_platform & mod.platform).empty?
         chosen_platform = Msf::Module::PlatformList.new

--- a/lib/msf/core/payload_generator.rb
+++ b/lib/msf/core/payload_generator.rb
@@ -176,7 +176,7 @@ module Msf
     def choose_arch(mod)
       if arch.blank?
         @arch = mod.arch.first
-        cli_print "[-] No --arch selected, selecting arch: #{arch} from the payload"
+        cli_print "[-] No arch selected, selecting arch: #{arch} from the payload"
         datastore['ARCH'] = arch if mod.kind_of?(Msf::Payload::Generic)
         return mod.arch.first
       elsif mod.arch.include? arch

--- a/lib/msf/core/payload_generator.rb
+++ b/lib/msf/core/payload_generator.rb
@@ -171,12 +171,12 @@ module Msf
     # This method takes a payload module and tries to reconcile a chosen
     # arch with the arches supported by the module.
     # @param mod [Msf::Payload] The module class to choose an arch for
-    # @return [String] String form of the Arch if a valid arch found
+    # @return [String] String form of the arch if a valid arch found
     # @return [Nil] if no valid arch found
     def choose_arch(mod)
       if arch.blank?
         @arch = mod.arch.first
-        cli_print "No Arch selected, selecting Arch: #{arch} from the payload"
+        cli_print "[-] No --arch selected, selecting arch: #{arch} from the payload"
         datastore['ARCH'] = arch if mod.kind_of?(Msf::Payload::Generic)
         return mod.arch.first
       elsif mod.arch.include? arch
@@ -198,7 +198,7 @@ module Msf
 
       if chosen_platform.platforms.empty?
         chosen_platform = mod.platform
-        cli_print "No platform was selected, choosing #{chosen_platform.platforms.first} from the payload"
+        cli_print "[-] No --platform was selected, choosing #{chosen_platform.platforms.first} from the payload"
         @platform = mod.platform.platforms.first.to_s.split("::").last
       elsif (chosen_platform & mod.platform).empty?
         chosen_platform = Msf::Module::PlatformList.new
@@ -429,11 +429,15 @@ module Msf
         encoder.split(',').each do |chosen_encoder|
           e = framework.encoders.create(chosen_encoder)
           if e.nil?
-            cli_print "Skipping invalid encoder #{chosen_encoder}"
+            cli_print "[-] Skipping invalid encoder #{chosen_encoder}"
             next
           end
           e.datastore.import_options_from_hash(datastore)
           encoders << e if e
+        end
+        if encoders.empty?
+          cli_print "[!] Couldn't find encoder to use"
+          exit(1)
         end
         encoders.sort_by { |my_encoder| my_encoder.rank }.reverse
       elsif !badchars.empty? && !badchars.nil?

--- a/msfvenom
+++ b/msfvenom
@@ -77,7 +77,7 @@ def parse_args(args)
   end
 
   opt.on('-p', '--payload         <payload>', String,
-         'Payload to use (--list payloads to list, --list-options for arguments). Specify \'-\' or STDIN for custom') do |p|
+         "Payload to use (--list payloads to list, --list-options for arguments). Specify '-' or STDIN for custom") do |p|
     if p == '-'
       opts[:payload] = 'stdin'
     else
@@ -85,7 +85,7 @@ def parse_args(args)
     end
   end
 
-  opt.on('--list-options', "List --payload <value>'s standard, advanced and encryption options") do
+  opt.on('--list-options', "List --payload <value>'s standard, advanced and evasion options") do
     opts[:list_options] = true
   end
 
@@ -187,7 +187,7 @@ def parse_args(args)
       k,v = x.split('=', 2)
       datastore[k.upcase] = v.to_s
     end
-    if opts[:payload].to_s =~ /[\_\/]reverse/ and datastore['LHOST'].nil?
+    if opts[:payload].to_s =~ /[\_\/]reverse/ && datastore['LHOST'].nil?
       init_framework()
       datastore['LHOST'] = Rex::Socket.source_address
     end
@@ -197,7 +197,7 @@ def parse_args(args)
     opts[:payload] = "stdin"
   end
 
-  if opts[:payload].downcase == 'stdin' and not opts[:list]
+  if opts[:payload].downcase == 'stdin' && !opts[:list]
     $stderr.puts "Attempting to read payload from STDIN..."
     begin
       opts[:timeout] ||= 30
@@ -228,7 +228,7 @@ end
 def dump_platforms
   init_framework(:module_types => [])
   supported_platforms = []
-  Msf::Module::Platform.subclasses.each {|c| supported_platforms << "#{c.realname.downcase}"}
+  Msf::Module::Platform.subclasses.each {|c| supported_platforms << c.realname.downcase}
 
   tbl = Rex::Text::Table.new(
     'Indent'  => 4,
@@ -365,8 +365,6 @@ if generator_opts[:list]
     case mod.downcase
     when "payloads", "payload", "p"
       $stdout.puts dump_payloads
-#    when "options", "option", "o"
-#      opts[:list_options] = true
     when "encoders", "encoder", "e"
       $stdout.puts dump_encoders(generator_opts[:arch])
     when "nops", "nop", "n"
@@ -411,8 +409,6 @@ if generator_opts[:list_options]
   $stderr.puts "\nEvasion options for #{payload_mod.fullname}:\n" + "="*25 + "\n\n"
   $stdout.puts ::Msf::Serializer::ReadableText.dump_evasion_options(payload_mod, '    ')
 
-  #$stderr.puts "\nEncryption options for #{payload_mod.fullname}:\n" + "="*25 + "\n\n"
-  #$stdout.puts ::Msf::Serializer::ReadableText.dump_encrypt_options(payload_mod, '    ')
   exit(0)
 end
 

--- a/msfvenom
+++ b/msfvenom
@@ -69,8 +69,15 @@ def parse_args(args)
   opt.separator('')
   opt.separator('Options:')
 
+  opt.on('-l', '--list            <type>', Array, 'List all module for [type]. Types are: payloads, encoders, nops, platforms, encrypt, formats, all') do |l|
+    if l.nil? or l.empty?
+      l = ["all"]
+    end
+    opts[:list] = l
+  end
+
   opt.on('-p', '--payload         <payload>', String,
-         'Payload to use. Specify a \'-\' or stdin to use custom payloads') do |p|
+         'Payload to use (--list payloads to list, --list-options for arguments). Specify \'-\' or STDIN for custom') do |p|
     if p == '-'
       opts[:payload] = 'stdin'
     else
@@ -78,72 +85,53 @@ def parse_args(args)
     end
   end
 
-  opt.on('--payload-options', "List the payload's standard options") do
+  opt.on('--list-options', "List --payload <value>'s standard, advanced and encryption options") do
     opts[:list_options] = true
   end
 
-  opt.on('-l', '--list            [type]', Array, 'List a module type. Options are: payloads, encoders, nops, all') do |l|
-    if l.nil? or l.empty?
-      l = ["all"]
-    end
-    opts[:list] = l
+  opt.on('-f', '--format          <format>', String, "Output format (use --list formats to list)") do |f|
+    opts[:format] = f
+  end
+
+  opt.on('-e', '--encoder         <encoder>', String, 'The encoder to use (use --list encoders to list)') do |e|
+    opts[:encoder] = e
+  end
+
+  opt.on('--smallest', 'Generate the smallest possible payload using all available encoders') do
+    opts[:smallest] = true
+  end
+
+  opt.on('--encrypt         <value>', String, 'The type of encryption or encoding to apply to the shellcode (use --list encrypt to list)') do |e|
+    opts[:encryption_format] = e
+  end
+
+  opt.on('--encrypt-key     <value>', String, 'A key to be used for --encrypt') do |e|
+    opts[:encryption_key] = e
+  end
+
+  opt.on('--encrypt-iv      <value>', String, 'An initialization vector for --encrypt') do |e|
+    opts[:encryption_iv] = e
+  end
+
+  opt.on('-a', '--arch            <arch>', String, 'The architecture to use for --payload and --encoders') do |a|
+    opts[:arch] = a
+  end
+
+  opt.on('--platform        <platform>', String, 'The platform for --payload (use --list platforms to list)') do |l|
+    opts[:platform] = l
+  end
+
+  opt.on('-o', '--out             <path>', 'Save the payload to a file') do |x|
+    opts[:out] = x
+  end
+
+  opt.on('-b', '--bad-chars       <list>', String, 'Characters to avoid example: \'\x00\xff\'') do |b|
+    init_framework()
+    opts[:badchars] = Rex::Text.hex_to_raw(b)
   end
 
   opt.on('-n', '--nopsled         <length>', Integer, 'Prepend a nopsled of [length] size on to the payload') do |n|
     opts[:nops] = n.to_i
-  end
-
-  opt.on('-f', '--format          <format>', String, "Output format (use --help-formats for a list)") do |f|
-    opts[:format] = f
-  end
-
-  opt.on('--help-formats', String, "List available formats") do
-    init_framework(:module_types => [])
-    msg = "Executable formats\n" +
-      "\t" + ::Msf::Util::EXE.to_executable_fmt_formats.join(", ") + "\n" +
-      "Transform formats\n" +
-      "\t" + ::Msf::Simple::Buffer.transform_formats.join(", ")
-    raise HelpError, msg
-  end
-
-  opt.on('--encrypt         <value>', String, 'The type of encryption or encoding to apply to the shellcode') do |e|
-    opts[:encryption_format] = e
-  end
-
-  opt.on('--encrypt-formats', String, 'List Available encryption formats') do
-    init_framework(:module_types => [])
-    msg = "Encryption formats:\n" +
-          "\t" + ::Msf::Simple::Buffer.encryption_formats.join(", ")
-    raise HelpError, msg
-  end
-
-  opt.on('--encrypt-key     <value>', String, 'A key to be used for the encryptor') do |e|
-    opts[:encryption_key] = e
-  end
-
-  opt.on('--encrypt-iv      <value>', String, 'An initialization vector for the encryption') do |e|
-    opts[:encryption_iv] = e
-  end
-
-  opt.on('-e', '--encoder         <encoder>', String, 'The encoder to use') do |e|
-    opts[:encoder] = e
-  end
-
-  opt.on('-a', '--arch            <arch>', String, 'The architecture to use') do |a|
-    opts[:arch] = a
-  end
-
-  opt.on('--platform        <platform>', String, 'The platform of the payload') do |l|
-    opts[:platform] = l
-  end
-
-  opt.on('--help-platforms', String, 'List available platforms') do
-    init_framework(:module_types => [])
-    supported_platforms = []
-    Msf::Module::Platform.subclasses.each {|c| supported_platforms << "#{c.realname.downcase}"}
-    msg = "Platforms\n" +
-      "\t" + supported_platforms.sort * ", "
-    raise HelpError, msg
   end
 
   opt.on('-s', '--space           <length>', Integer, 'The maximum size of the resulting payload') do |s|
@@ -152,11 +140,6 @@ def parse_args(args)
 
   opt.on('--encoder-space   <length>', Integer, 'The maximum size of the encoded payload (defaults to the -s value)') do |s|
     opts[:encoder_space] = s
-  end
-
-  opt.on('-b', '--bad-chars       <list>', String, 'The list of characters to avoid example: \'\x00\xff\'') do |b|
-    init_framework()
-    opts[:badchars] = Rex::Text.hex_to_raw(b)
   end
 
   opt.on('-i', '--iterations      <count>', Integer, 'The number of times to encode the payload') do |i|
@@ -171,23 +154,15 @@ def parse_args(args)
     opts[:template] = x
   end
 
-  opt.on('-k', '--keep', 'Preserve the template behavior and inject the payload as a new thread') do
+  opt.on('-k', '--keep', 'Preserve the --template behaviour and inject the payload as a new thread') do
     opts[:keep] = true
   end
 
-  opt.on('-o', '--out             <path>', 'Save the payload') do |x|
-    opts[:out] = x
-  end
-
-  opt.on('-v', '--var-name        <name>', String, 'Specify a custom variable name to use for certain output formats') do |x|
+  opt.on('-v', '--var-name        <value>', String, 'Specify a custom variable name to use for certain output formats') do |x|
     opts[:var_name] = x
   end
 
-  opt.on('--smallest', 'Generate the smallest possible payload') do
-    opts[:smallest] = true
-  end
-
-  opt.on('-t', '--timeout       <second>', Integer, "The number of seconds to wait when reading the payload from STDIN (default 30, 0 to disable).") do |x|
+  opt.on('-t', '--timeout         <second>', Integer, "The number of seconds to wait when reading the payload from STDIN (default 30, 0 to disable)") do |x|
     opts[:timeout] = x
   end
 
@@ -222,7 +197,7 @@ def parse_args(args)
     opts[:payload] = "stdin"
   end
 
-  if opts[:payload] == 'stdin' and not opts[:list]
+  if opts[:payload].downcase == 'stdin' and not opts[:list]
     $stderr.puts "Attempting to read payload from STDIN..."
     begin
       opts[:timeout] ||= 30
@@ -250,11 +225,77 @@ def payload_stdin
   payload
 end
 
+def dump_platforms
+  init_framework(:module_types => [])
+  supported_platforms = []
+  Msf::Module::Platform.subclasses.each {|c| supported_platforms << "#{c.realname.downcase}"}
+
+  tbl = Rex::Text::Table.new(
+    'Indent'  => 4,
+    'Header'  => "Framework Platforms [--platform <value>]",
+    'Columns' =>
+    [
+      "Name",
+    ])
+
+  supported_platforms.sort.each do |name|
+    tbl << [ name]
+  end
+
+  "\n" + tbl.to_s + "\n"
+end
+
+def dump_encrypt
+  init_framework(:module_types => [])
+  tbl = Rex::Text::Table.new(
+    'Indent'  => 4,
+    'Header'  => "Framework Encryption Formats [--encrypt <value>]",
+    'Columns' =>
+    [
+      "Name",
+    ])
+
+  ::Msf::Simple::Buffer.encryption_formats.each do |name|
+    tbl << [ name]
+  end
+
+  "\n" + tbl.to_s + "\n"
+end
+
+def dump_formats
+  init_framework(:module_types => [])
+  tbl1 = Rex::Text::Table.new(
+    'Indent'  => 4,
+    'Header'  => "Framework Executable Formats [--format <value>]",
+    'Columns' =>
+    [
+      "Name"
+    ])
+
+  ::Msf::Util::EXE.to_executable_fmt_formats.each do |name|
+    tbl1 << [ name ]
+  end
+
+  tbl2 = Rex::Text::Table.new(
+    'Indent'  => 4,
+    'Header'  => "Framework Transform Formats [--format <value>]",
+    'Columns' =>
+    [
+      "Name"
+    ])
+
+  ::Msf::Simple::Buffer.transform_formats.each do |name|
+    tbl2 << [ name ]
+  end
+
+  "\n" + tbl1.to_s + "\n" + tbl2.to_s + "\n"
+end
+
 def dump_payloads
   init_framework(:module_types => [ :payload ])
   tbl = Rex::Text::Table.new(
     'Indent'  => 4,
-    'Header'  => "Framework Payloads (#{framework.stats.num_payloads} total)",
+    'Header'  => "Framework Payloads (#{framework.stats.num_payloads} total) [--payload <value>]",
     'Columns' =>
     [
       "Name",
@@ -272,7 +313,7 @@ def dump_encoders(arch = nil)
   init_framework(:module_types => [ :encoder ])
   tbl = Rex::Text::Table.new(
     'Indent'  => 4,
-    'Header'  => "Framework Encoders" + ((arch) ? " (architectures: #{arch})" : ""),
+    'Header'  => "Framework Encoders" + ((arch) ? " (architectures: #{arch})" : "") + " [--encoder <value>]",
     'Columns' =>
     [
       "Name",
@@ -324,19 +365,30 @@ if generator_opts[:list]
     case mod.downcase
     when "payloads", "payload", "p"
       $stdout.puts dump_payloads
+#    when "options", "option", "o"
+#      opts[:list_options] = true
     when "encoders", "encoder", "e"
       $stdout.puts dump_encoders(generator_opts[:arch])
     when "nops", "nop", "n"
       $stdout.puts dump_nops
-    when "all"
+    when "platforms", "dump_platform"
+      $stdout.puts dump_platforms
+    when "encrypts", "encrypt", "encryption"
+      $stdout.puts dump_encrypt
+    when "formats", "format", "f"
+      $stdout.puts dump_formats
+    when "all", "a"
       # Init here so #dump_payloads doesn't create a framework with
       # only payloads, etc.
       init_framework
       $stdout.puts dump_payloads
       $stdout.puts dump_encoders
       $stdout.puts dump_nops
+      $stdout.puts dump_platforms
+      $stdout.puts dump_encrypt
+      $stdout.puts dump_formats
     else
-      $stderr.puts "Invalid module type. These are valid: payloads, encoders, nops, all"
+      $stderr.puts "Invalid type (#{mod}). These are valid: payloads, encoders, nops, platforms, encrypt, formats, all"
     end
   end
   exit(0)
@@ -347,17 +399,20 @@ if generator_opts[:list_options]
 
   if payload_mod.nil?
     $stderr.puts "Invalid payload: #{generator_opts[:payload]}"
-    exit
+    exit(1)
   end
 
-  $stderr.puts "Options for #{payload_mod.fullname}:\n\n"
+  $stderr.puts "Options for #{payload_mod.fullname}:\n" + "="*25 + "\n\n"
   $stdout.puts ::Msf::Serializer::ReadableText.dump_module(payload_mod, '    ')
 
-  $stderr.puts "Advanced options for #{payload_mod.fullname}:\n\n"
+  $stderr.puts "\nAdvanced options for #{payload_mod.fullname}:\n" + "="*25 + "\n\n"
   $stdout.puts ::Msf::Serializer::ReadableText.dump_advanced_options(payload_mod, '    ')
 
-  $stderr.puts "Encryption options for #{payload_mod.fullname}:\n\n"
-  $stdout.puts ::Msf::Serializer::ReadableText.dump_encrypt_options(payload_mod, '    ')
+  $stderr.puts "\nEvasion options for #{payload_mod.fullname}:\n" + "="*25 + "\n\n"
+  $stdout.puts ::Msf::Serializer::ReadableText.dump_evasion_options(payload_mod, '    ')
+
+  #$stderr.puts "\nEncryption options for #{payload_mod.fullname}:\n" + "="*25 + "\n\n"
+  #$stdout.puts ::Msf::Serializer::ReadableText.dump_encrypt_options(payload_mod, '    ')
   exit(0)
 end
 


### PR DESCRIPTION
- `--list [platforms,encrypt, formats]` now is an option
- Reorder the menu, so items are now group'd together.

```
$ ./msfvenom --help
MsfVenom - a Metasploit standalone payload generator.
Also a replacement for msfpayload and msfencode.
Usage: ./msfvenom [options] <var=val>
Example: ./msfvenom -p windows/meterpreter/reverse_tcp LHOST=<IP> -f exe -o payload.exe

Options:
    -l, --list            <type>     List all module for [type]. Types are: payloads, encoders, nops, platforms, encrypt, formats, all
    -p, --payload         <payload>  Payload to use (--list payloads to list, --list-options for arguments). Specify '-' or STDIN for custom
        --list-options               List --payload <value>'s standard, advanced and encryption options
    -f, --format          <format>   Output format (use --list formats to list)
    -e, --encoder         <encoder>  The encoder to use (use --list encoders to list)
        --smallest                   Generate the smallest possible payload using all available encoders
        --encrypt         <value>    The type of encryption or encoding to apply to the shellcode (use --list encrypt to list)
        --encrypt-key     <value>    A key to be used for --encrypt
        --encrypt-iv      <value>    An initialization vector for --encrypt
    -a, --arch            <arch>     The architecture to use for --payload and --encoders
        --platform        <platform> The platform for --payload (use --list platforms to list)
    -o, --out             <path>     Save the payload to a file
    -b, --bad-chars       <list>     Characters to avoid example: '\x00\xff'
    -n, --nopsled         <length>   Prepend a nopsled of [length] size on to the payload
    -s, --space           <length>   The maximum size of the resulting payload
        --encoder-space   <length>   The maximum size of the encoded payload (defaults to the -s value)
    -i, --iterations      <count>    The number of times to encode the payload
    -c, --add-code        <path>     Specify an additional win32 shellcode file to include
    -x, --template        <path>     Specify a custom executable file to use as a template
    -k, --keep                       Preserve the --template behaviour and inject the payload as a new thread
    -v, --var-name        <value>    Specify a custom variable name to use for certain output formats
    -t, --timeout         <second>   The number of seconds to wait when reading the payload from STDIN (default 30, 0 to disable)
    -h, --help                       Show this message
$
```