### PR TITLE
Fix is_system? in Msf::Post::Windows::Priv for non-English systems

### DIFF
--- a/lib/msf/core/post/windows/priv.rb
+++ b/lib/msf/core/post/windows/priv.rb
@@ -106,12 +106,7 @@ module Msf::Post::Windows::Priv
   #
   def is_system?
     if session_has_ext
-      local_sys = resolve_sid(SYSTEM_SID)
-      if session.sys.config.getuid == "#{local_sys[:domain]}\\#{local_sys[:name]}"
-        return true
-      else
-        return false
-      end
+      return session.sys.config.is_system?
     else
       results = registry_enumkeys('HKLM\SAM\SAM')
       if results

--- a/modules/post/windows/gather/win_privs.rb
+++ b/modules/post/windows/gather/win_privs.rb
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Post
     admin       = is_admin? ? 'True' : 'False'
     admin_group = is_in_admin_group? ? 'True' : 'False'
     sys         = is_system? ? 'True' : 'False'
-    uid         = client.sys.config.getuid.inspect
+    uid         = client.sys.config.getuid
     begin
       # Older OS might not have this (min support is XP)
       fid = client.railgun.kernel32.WTSGetActiveConsoleSessionId["return"]


### PR DESCRIPTION
Observation: on a French Windows system, I used the `post/windows/gather/win_privs` module that told me "Is System: False" whereas my meterpreter session was actually running as SYSTEM.
I found that it uses `is_system?` from Msf::Post::Windows::Priv which code is:
```ruby
  def is_system?
    if session_has_ext
      local_sys = resolve_sid(SYSTEM_SID)
      if session.sys.config.getuid == "#{local_sys[:domain]}\\#{local_sys[:name]}"
        return true
      else
        return false
      end
    else
 [...]
```
The problem is that `session.sys.config.getuid` returns "AUTORITE NT\Système" (which is the French for "NT AUTHORITY\SYSTEM") whereas `"#{local_sys[:domain]}\\#{local_sys[:name]}"` returns "AUTORITE NT\Syst?me" (I printed it to check).
Therefore the comparison fails...

I suggest two fixes:
- (in this PR) instead of comparing the resolved user name, we can compare the SID (`SYSTEM_SID = 'S-1-5-18'`) which doesn't change with the language. This is properly done with `session.sys.config.is_system?` which code is `getsid == SYSTEM_SID`.

- the `resolve_sid` function should be fixed to properly handle the accent: I don't have a fix for this. I suppose this could be a Unicode issue. FYI:
```shell
meterpreter > irb
[*] Starting IRB shell
[*] The "client" variable holds the meterpreter client

>> client.sys.config.getuid
=> "AUTORITE NT\\Syst\xC3\xA8me"
```
By the way, it is not printed correctly:
```shell
meterpreter > run post/windows/gather/win_privs

Current User
============
 Is Admin  Is System  Is In Local Admin Group  UAC Enabled  Foreground ID  UID
 --------  ---------  -----------------------  -----------  -------------  ---
 True      False      True                     False        1              "AUTORITE NT\\Syst\xC3\xA8me"
```
`\xC3\xA8` is the UTF-8 for the "è" character.

And also this code:
```ruby
      local_sys = resolve_sid(SYSTEM_SID)
      puts local_sys
```
Prints:
```shell
{:name=>"Syst\xE8me", :domain=>"AUTORITE NT", :type=>:user, :mapped=>true}
```
`\xE8` is the ASCII code for the "è" character.

## Version
```shell
msf > version
Framework: 4.16.55-dev
Console  : 4.16.55-dev
```
## Related to
- PR #9010
- PR #4150 (`is_system?` implementation)

## Verification
- [ ] Start `msfconsole`
- [ ] Get a SYSTEM meterpreter on a French (or German, or...) Windows system
- [ ] Run `run post/windows/gather/win_privs`
- [ ] Observed before patch: `Is System: False`
- [ ] **Verify** after patch: `Is System: True`
