### PR TITLE
Sap Bruteforce support to new versions and anti-XSRF mechanisms

### DIFF
--- a/modules/auxiliary/scanner/sap/sap_web_gui_brute_login.rb
+++ b/modules/auxiliary/scanner/sap/sap_web_gui_brute_login.rb
@@ -213,6 +213,9 @@ class MetasploitModule < Msf::Auxiliary
         })
         if res.code == 302
           return true
+        elsif res.code == 200 and res.body =~ /too&#x20;many&#x20;failed&#x20;attempts/
+          print_error("[SAP] #{rhost}:#{rport} - #{user} locked in client #{cli}")
+          return false
         else
           return false
         end

--- a/modules/auxiliary/scanner/sap/sap_web_gui_brute_login.rb
+++ b/modules/auxiliary/scanner/sap/sap_web_gui_brute_login.rb
@@ -95,7 +95,7 @@ class MetasploitModule < Msf::Auxiliary
         end
       end
     end
-    
+
     stop_on_success = false
 
     each_user_pass do |u, p|
@@ -109,11 +109,11 @@ class MetasploitModule < Msf::Auxiliary
             saptbl << [ rhost, rport, cli, u, p]
             if datastore['STOP_ON_SUCCESS'] == true
               stop_on_success = true
-            end  
+            end
           end
         end
     end
-    
+
     print(saptbl.to_s)
 
   end
@@ -148,7 +148,6 @@ class MetasploitModule < Msf::Auxiliary
   def bruteforce(uri,user,pass,cli)
     begin
       path = "sap/bc/gui/sap/its/webgui/"
-         
 
       cookie = "Active=true; sap-usercontext=sap-language=EN&sap-client=#{cli}"
       res = send_request_cgi({


### PR DESCRIPTION
This change adds support to new SAP Web GUI's and to Anti-XSRF mechanisms, getting the XSRF values from the cookies and hidden values in the response and use it in another request.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use scanner/sap/sap_web_gui_brute_login_v2`
- [ ] `set USERNAME user`
- [ ] `set PASSWORD password`
- [ ] `set RHOSTS ip`
- [ ] `run`