### PR TITLE
[GSOC] Implement AudioOutput API

### DIFF
--- a/lib/rex/post/meterpreter/extensions/stdapi/audio_output/audio_output.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/audio_output/audio_output.rb
@@ -1,0 +1,55 @@
+# -*- coding: binary -*-
+
+require 'rex/post/meterpreter/channel'
+require 'rex/post/meterpreter/channels/pools/stream_pool'
+
+module Rex
+  module Post
+    module Meterpreter
+      module Extensions
+        module Stdapi
+          module AudioOutput
+
+            ###
+            #
+            # Play an audio file
+            #
+            ###
+            class AudioOutput
+              def initialize(client)
+                @client = client
+              end
+
+              def session
+                @client
+              end
+
+              # Upload file and play it
+              def play_file(path)
+                channel = Channel.create(client, 'audio_output', Rex::Post::Meterpreter::Channels::Pools::StreamPool, CHANNEL_FLAG_SYNCHRONOUS)
+
+                # Read file buffers after buffers and upload
+                buf_size = 8 * 1024 * 1024
+                src_fd = nil
+
+                begin
+                    src_fd = ::File.open(path, "rb")
+                    src_size = src_fd.stat.size
+                    while (buf = src_fd.read(buf_size))
+                      channel.write(buf)
+                      percent = src_size / src_fd.pos.to_f * 100.0
+                    end
+                ensure src_fd.close unless src_fd.nil?
+                end
+
+                channel.close()
+              end
+
+              attr_accessor :client
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rex/post/meterpreter/extensions/stdapi/audio_output/audio_output.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/audio_output/audio_output.rb
@@ -4,52 +4,53 @@ require 'rex/post/meterpreter/channel'
 require 'rex/post/meterpreter/channels/pools/stream_pool'
 
 module Rex
-  module Post
-    module Meterpreter
-      module Extensions
-        module Stdapi
-          module AudioOutput
+module Post
+module Meterpreter
+module Extensions
+module Stdapi
+module AudioOutput
 
-            ###
-            #
-            # Play an audio file
-            #
-            ###
-            class AudioOutput
-              def initialize(client)
-                @client = client
-              end
-
-              def session
-                @client
-              end
-
-              # Upload file and play it
-              def play_file(path)
-                channel = Channel.create(client, 'audio_output', Rex::Post::Meterpreter::Channels::Pools::StreamPool, CHANNEL_FLAG_SYNCHRONOUS)
-
-                # Read file buffers after buffers and upload
-                buf_size = 8 * 1024 * 1024
-                src_fd = nil
-
-                begin
-                    src_fd = ::File.open(path, "rb")
-                    src_size = src_fd.stat.size
-                    while (buf = src_fd.read(buf_size))
-                      channel.write(buf)
-                      percent = src_size / src_fd.pos.to_f * 100.0
-                    end
-                ensure src_fd.close unless src_fd.nil?
-                end
-
-                channel.close()
-              end
-
-              attr_accessor :client
-            end
-          end
-        end
-      end
-    end
+###
+#
+# Play an audio file
+#
+###
+class AudioOutput
+  def initialize(client)
+    @client = client
   end
+
+  def session
+    @client
+  end
+
+  # Upload file and play it
+  def play_file(path)
+    channel = Channel.create(client, 'audio_output', Rex::Post::Meterpreter::Channels::Pools::StreamPool, CHANNEL_FLAG_SYNCHRONOUS)
+
+    # Read file buffers after buffers and upload
+    buf_size = 8 * 1024 * 1024
+    src_fd = nil
+
+    begin
+      src_fd = ::File.open(path, 'rb')
+      src_size = src_fd.stat.size
+      while (buf = src_fd.read(buf_size))
+        channel.write(buf)
+        percent = src_size / src_fd.pos.to_f * 100.0
+      end
+    ensure src_fd.close unless src_fd.nil?
+    end
+
+    channel.close()
+  end
+
+  attr_accessor :client
+end
+
+end
+end
+end
+end
+end
 end

--- a/lib/rex/post/meterpreter/extensions/stdapi/stdapi.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/stdapi.rb
@@ -20,6 +20,7 @@ require 'rex/post/meterpreter/extensions/stdapi/railgun/railgun'
 require 'rex/post/meterpreter/extensions/stdapi/ui'
 require 'rex/post/meterpreter/extensions/stdapi/webcam/webcam'
 require 'rex/post/meterpreter/extensions/stdapi/mic/mic'
+require 'rex/post/meterpreter/extensions/stdapi/audio_output/audio_output'
 
 module Rex
 module Post
@@ -87,6 +88,10 @@ class Stdapi < Extension
         {
           'name' => 'mic',
           'ext'  => Rex::Post::Meterpreter::Extensions::Stdapi::Mic::Mic.new(client)
+        },
+        {
+          'name' => 'audio_output',
+          'ext'  => Rex::Post::Meterpreter::Extensions::Stdapi::AudioOutput::AudioOutput.new(client)
         },
         {
           'name' => 'ui',

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi.rb
@@ -19,6 +19,7 @@ class Console::CommandDispatcher::Stdapi
   require 'rex/post/meterpreter/ui/console/command_dispatcher/stdapi/ui'
   require 'rex/post/meterpreter/ui/console/command_dispatcher/stdapi/webcam'
   require 'rex/post/meterpreter/ui/console/command_dispatcher/stdapi/mic'
+  require 'rex/post/meterpreter/ui/console/command_dispatcher/stdapi/audio_output'
 
   Klass = Console::CommandDispatcher::Stdapi
 
@@ -29,7 +30,8 @@ class Console::CommandDispatcher::Stdapi
       Klass::Sys,
       Klass::Ui,
       Klass::Webcam,
-      Klass::Mic
+      Klass::Mic,
+      Klass::AudioOutput
     ]
 
   include Console::CommandDispatcher

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/audio_output.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/audio_output.rb
@@ -58,6 +58,11 @@ module Rex
               end
             end
 
+            if audio_path == nil
+              print_line("Please specify a path to an audio file via the '-f' option or use '-h'")
+              return
+            end
+
             print_status("Playing #{audio_path}...")
             client.audio_output.play_file(audio_path)
             print_status("Done")

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/audio_output.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/audio_output.rb
@@ -59,7 +59,7 @@ class Console::CommandDispatcher::Stdapi::AudioOutput
     end
 
     if audio_path == nil
-      print_line('Please specify a path to an audio file via the '-f' option or use '-h'')
+      print_line('Please specify a path to an audio file via the -f option or use -h')
       return
     end
 

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/audio_output.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/audio_output.rb
@@ -1,5 +1,4 @@
-class Mic
-end# -*- coding: binary -*-
+# -*- coding: binary -*-
 require 'rex/post/meterpreter'
 require 'bindata'
 
@@ -23,7 +22,7 @@ module Rex
           #
           def commands
             all = {
-              'play' => 'play an audio file on target\'s system, nothing written on disk'
+              'play' => 'play an audio file on target system, nothing written on disk'
             }
             reqs = {
               'play'    => []

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/audio_output.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/audio_output.rb
@@ -1,0 +1,70 @@
+class Mic
+end# -*- coding: binary -*-
+require 'rex/post/meterpreter'
+require 'bindata'
+
+module Rex
+  module Post
+    module Meterpreter
+      module Ui
+
+        ###
+        #
+        # Play audio on remote system
+        #
+        ###
+        class Console::CommandDispatcher::Stdapi::AudioOutput
+          Klass = Console::CommandDispatcher::Stdapi::AudioOutput
+
+          include Console::CommandDispatcher
+
+          #
+          # List of supported commands.
+          #
+          def commands
+            all = {
+              'play' => 'play an audio file on target\'s system, nothing written on disk'
+            }
+            reqs = {
+              'play'    => []
+            }
+
+            filter_commands(all, reqs)
+          end
+
+          #
+          # Name for this dispatcher
+          #
+          def name
+            "Stdapi: Audio Output"
+          end
+
+          def cmd_play(*args)
+            audio_path = nil
+
+            play_start_opts = Rex::Parser::Arguments.new(
+              "-h" => [ false, "Help Banner" ],
+              "-f" => [ true, "The audio file path (warning: will be copied to memory)" ]
+            )
+
+            play_start_opts.parse(args) do |opt, _idx, val|
+              case opt
+              when "-h"
+                print_line("Usage: audio_play [options]\n")
+                print_line("Upload file to targets memory and play it from memory")
+                print_line(play_start_opts.usage)
+                return
+              when "-f"
+                audio_path = val
+              end
+            end
+
+            print_status("Playing #{audio_path}...")
+            client.audio_output.play_file(audio_path)
+            print_status("Done")
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/audio_output.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/audio_output.rb
@@ -3,72 +3,73 @@ require 'rex/post/meterpreter'
 require 'bindata'
 
 module Rex
-  module Post
-    module Meterpreter
-      module Ui
+module Post
+module Meterpreter
+module Ui
 
-        ###
-        #
-        # Play audio on remote system
-        #
-        ###
-        class Console::CommandDispatcher::Stdapi::AudioOutput
-          Klass = Console::CommandDispatcher::Stdapi::AudioOutput
+###
+#
+# Play audio on remote system
+#
+###
+class Console::CommandDispatcher::Stdapi::AudioOutput
+  Klass = Console::CommandDispatcher::Stdapi::AudioOutput
 
-          include Console::CommandDispatcher
+  include Console::CommandDispatcher
 
-          #
-          # List of supported commands.
-          #
-          def commands
-            all = {
-              'play' => 'play an audio file on target system, nothing written on disk'
-            }
-            reqs = {
-              'play'    => []
-            }
+  #
+  # List of supported commands.
+  #
+  def commands
+    all = {
+      'play' => 'play an audio file on target system, nothing written on disk'
+    }
+    reqs = {
+      'play' => []
+    }
 
-            filter_commands(all, reqs)
-          end
+    filter_commands(all, reqs)
+  end
 
-          #
-          # Name for this dispatcher
-          #
-          def name
-            "Stdapi: Audio Output"
-          end
+  #
+  # Name for this dispatcher
+  #
+  def name
+    'Stdapi: Audio Output'
+  end
 
-          def cmd_play(*args)
-            audio_path = nil
+  def cmd_play(*args)
+    audio_path = nil
 
-            play_start_opts = Rex::Parser::Arguments.new(
-              "-h" => [ false, "Help Banner" ],
-              "-f" => [ true, "The audio file path (warning: will be copied to memory)" ]
-            )
+    play_start_opts = Rex::Parser::Arguments.new(
+      '-h' => [ false, "Help Banner" ],
+      '-f' => [ true, "The audio file path (warning: will be copied to memory)" ]
+    )
 
-            play_start_opts.parse(args) do |opt, _idx, val|
-              case opt
-              when "-h"
-                print_line("Usage: audio_play [options]\n")
-                print_line("Upload file to targets memory and play it from memory")
-                print_line(play_start_opts.usage)
-                return
-              when "-f"
-                audio_path = val
-              end
-            end
-
-            if audio_path == nil
-              print_line("Please specify a path to an audio file via the '-f' option or use '-h'")
-              return
-            end
-
-            print_status("Playing #{audio_path}...")
-            client.audio_output.play_file(audio_path)
-            print_status("Done")
-          end
-        end
+    play_start_opts.parse(args) do |opt, _idx, val|
+      case opt
+      when '-h'
+        print_line('Usage: audio_play [options]\n')
+        print_line('Upload file to targets memory and play it from memory')
+        print_line(play_start_opts.usage)
+        return
+      when '-f'
+        audio_path = val
       end
     end
+
+    if audio_path == nil
+      print_line('Please specify a path to an audio file via the '-f' option or use '-h'')
+      return
+    end
+
+    print_status('Playing #{audio_path}...')
+    client.audio_output.play_file(audio_path)
+    print_status('Done')
   end
+end
+
+end
+end
+end
 end

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/audio_output.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/audio_output.rb
@@ -63,7 +63,7 @@ class Console::CommandDispatcher::Stdapi::AudioOutput
       return
     end
 
-    print_status('Playing #{audio_path}...')
+    print_status("Playing #{audio_path}...")
     client.audio_output.play_file(audio_path)
     print_status('Done')
   end


### PR DESCRIPTION
As part of my GSOC proposal I have implemented a way to play audio files *from memory* on a `mettle` implant.

## Verification

- [ ] Get a session with a `mettle` implant connected
- [ ] Issue `play -f <path to test.wav>`
- [ ] If the implant can execute `aplay` you should hear your file playing.