### PR TITLE
update kiwi plugin, add dcsync and powershell streaming support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,7 +18,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 1.3.34)
+      metasploit-payloads (= 1.3.37)
       metasploit_data_models
       metasploit_payloads-mettle (= 0.3.8)
       mqtt
@@ -161,7 +161,7 @@ GEM
       activemodel (~> 4.2.6)
       activesupport (~> 4.2.6)
       railties (~> 4.2.6)
-    metasploit-payloads (1.3.34)
+    metasploit-payloads (1.3.37)
     metasploit_data_models (3.0.0)
       activerecord (~> 4.2.6)
       activesupport (~> 4.2.6)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -70,7 +70,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '1.3.34'
+  spec.add_runtime_dependency 'metasploit-payloads', '1.3.37'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '0.3.8'
   # Needed by msfgui and other rpc components


### PR DESCRIPTION
This does a few things:

 1. Updates the kiwi plugin to mimikatz 2.1.1 20180502
 2. Adds ability to dcsync & hashdump via Powershell
 3. Adds streaming support to powershell commands (no more timeouts)

It also adds the following powershell functions to make things more convenient:

 * Invoke-DcSync
 * Invoke-DcSyncAll
 * Invoke-DcSyncHashDump

See https://github.com/rapid7/metasploit-payloads/pull/284 for details
