### PR TITLE
Add correct filename for `/etc/group`

### DIFF
--- a/data/wordlists/sensitive_files.txt
+++ b/data/wordlists/sensitive_files.txt
@@ -1,5 +1,6 @@
 /etc/passwd
 /etc/shadow
+/etc/group
 /etc/groups
 /etc/mysql.conf
 /etc/mysql/my.cnf


### PR DESCRIPTION
AFAICT the correct filename is the singular form `group` not `groups` (e.g. [see](https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/4/html/Introduction_To_System_Administration/s3-acctspgrps-group.html) & [see](https://linux.die.net/man/5/group)).

Rather than just correcting the filename in place I'm adding the correct form because when even [official Red Hat documentation](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/7.3_release_notes/bug_fixes_authentication_and_interoperability#idm140113937457168) sometimes gets it wrong, maybe one day someone will get lucky with the misspelling.

## Verification

List the steps needed to make sure this thing works

- [x] N/A (I was using the file independently of metasploit)
