### PR TITLE
Fixed bug in module cache

### DIFF
--- a/lib/msf/core/modules/metadata/cache.rb
+++ b/lib/msf/core/modules/metadata/cache.rb
@@ -131,7 +131,7 @@ class Cache
     # Remove all instances of modules pointing to the same path. This prevents stale data hanging
     # around when modules are incorrectly typed (eg: Auxilary that should be Exploit)
     @module_metadata_cache.delete_if {|_, module_metadata|
-      module_metadata.path.eql? metadata_obj.path
+      module_metadata.path.eql? metadata_obj.path && module_metadata.type != module_metadata.type
     }
 
     @module_metadata_cache[get_cache_key(module_instance)] = metadata_obj


### PR DESCRIPTION
Added logic to only remove cache entity when module types are different

- [x] Start `msfconsole`
- [x] `irb`
- [x] `framework.modules.refresh_cache_from_module_files`
- [x] **Verify** that the file ~/.msf4/store/modules_metadata.pstore was regenerated (timestamp)
- [x] `framework.modules.refresh_cache_from_module_files`
- [x] **Verify** if nothing else has changed that  ~/.msf4/store/modules_metadata.pstore no longer changes

