### PR TITLE
Add Msf::Post::OSX::Priv mixin

### DIFF
--- a/lib/msf/core/post/osx.rb
+++ b/lib/msf/core/post/osx.rb
@@ -1,6 +1,7 @@
 # -*- coding: binary -*-
 
 module Msf::Post::OSX
+  require 'msf/core/post/osx/priv'
   require 'msf/core/post/osx/system'
   require 'msf/core/post/osx/ruby_dl'
 end

--- a/lib/msf/core/post/osx/priv.rb
+++ b/lib/msf/core/post/osx/priv.rb
@@ -1,0 +1,26 @@
+# -*- coding: binary -*-
+require 'msf/core/post/common'
+
+module Msf
+class Post
+module OSX
+module Priv
+  include ::Msf::Post::Common
+
+  #
+  # Returns true if running as root, false if not.
+  #
+  def is_root?
+    cmd_exec('/usr/bin/id -ru').eql? '0'
+  end
+
+  #
+  # Returns true if session user is in the admin group, false if not.
+  #
+  def is_admin?
+    cmd_exec('groups | grep -wq admin && echo true').eql? 'true'
+  end
+end
+end
+end
+end

--- a/modules/exploits/osx/local/rootpipe.rb
+++ b/modules/exploits/osx/local/rootpipe.rb
@@ -6,6 +6,7 @@
 class MetasploitModule < Msf::Exploit::Local
   Rank = GreatRanking
 
+  include Msf::Post::OSX::Priv
   include Msf::Post::OSX::System
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
@@ -57,10 +58,14 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    (ver? && admin?) ? Exploit::CheckCode::Appears : Exploit::CheckCode::Safe
+    (ver? && is_admin?) ? CheckCode::Appears : CheckCode::Safe
   end
 
   def exploit
+    if is_root?
+      fail_with Failure::BadConfig, 'Session already has root privileges'
+    end
+
     print_status("Writing exploit to `#{exploit_file}'")
     write_file(exploit_file, python_exploit)
     register_file_for_cleanup(exploit_file)
@@ -79,10 +84,6 @@ class MetasploitModule < Msf::Exploit::Local
     Gem::Version.new(get_sysinfo['ProductVersion']).between?(
       Gem::Version.new('10.9'), Gem::Version.new('10.10.2')
     )
-  end
-
-  def admin?
-    cmd_exec('groups | grep -wq admin && echo true') == 'true'
   end
 
   def sploit

--- a/modules/exploits/osx/local/rootpipe_entitlements.rb
+++ b/modules/exploits/osx/local/rootpipe_entitlements.rb
@@ -6,6 +6,7 @@
 class MetasploitModule < Msf::Exploit::Local
   Rank = GreatRanking
 
+  include Msf::Post::OSX::Priv
   include Msf::Post::OSX::System
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
@@ -48,7 +49,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    if ver? && admin?
+    if ver? && is_admin?
       vprint_status("Version is between 10.9 and 10.10.3, and is admin.")
       return Exploit::CheckCode::Appears
     else
@@ -57,6 +58,10 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
+    if is_root?
+      fail_with Failure::BadConfig, 'Session already has root privileges'
+    end
+
     print_status("Copying Directory Utility.app to #{new_app}")
     cmd_exec("cp -R '/System/Library/CoreServices/Applications/Directory Utility.app' '#{new_app}'")
     cmd_exec("mkdir -p '#{new_app}/Contents/PlugIns/RootpipeBundle.daplug/Contents/MacOS'")
@@ -85,10 +90,6 @@ class MetasploitModule < Msf::Exploit::Local
     Gem::Version.new(get_sysinfo['ProductVersion']).between?(
       Gem::Version.new('10.9'), Gem::Version.new('10.10.3')
     )
-  end
-
-  def admin?
-    cmd_exec('groups | grep -wq admin && echo true') == 'true'
   end
 
   def sploit

--- a/modules/exploits/osx/local/sudo_password_bypass.rb
+++ b/modules/exploits/osx/local/sudo_password_bypass.rb
@@ -13,12 +13,12 @@ class MetasploitModule < Msf::Exploit::Local
   # it at his own risk
   Rank = NormalRanking
 
+  include Msf::Post::OSX::Priv
   include Msf::Post::File
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
 
   SYSTEMSETUP_PATH = "/usr/sbin/systemsetup"
-  SUDOER_GROUP = "admin"
   VULNERABLE_VERSION_RANGES = [['1.6.0', '1.7.10p6'], ['1.8.0', '1.8.6p6']]
   CMD_TIMEOUT = 45
 
@@ -113,7 +113,8 @@ class MetasploitModule < Msf::Exploit::Local
       return Exploit::CheckCode::Safe
     end
 
-    if not user_in_admin_group?
+    # check that the user is in OSX's admin group, necessary to change sys clock
+    unless is_admin?
       vprint_error "sudo version is vulnerable, but user is not in the admin group (necessary to change the date)."
       return Exploit::CheckCode::Safe
     end
@@ -122,9 +123,14 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    if not user_in_admin_group?
-      fail_with(Failure::NotFound, "User is not in the 'admin' group, bailing.")
+    if is_root?
+      fail_with Failure::BadConfig, 'Session already has root privileges'
     end
+
+    unless is_admin?
+      fail_with(Failure::NoAccess, "User is not in the 'admin' group, bailing.")
+    end
+
     # "remember" the current system time/date/network/zone
     print_good("User is an admin, continuing...")
 
@@ -232,11 +238,6 @@ class MetasploitModule < Msf::Exploit::Local
 
   def drop_path
     @_drop_path ||= datastore['TMP_FILE'].gsub('<random>') { Rex::Text.rand_text_alpha(10) }
-  end
-
-  # checks that the user is in OSX's admin group, necessary to change sys clock
-  def user_in_admin_group?
-    cmd_exec("groups `whoami`").split(/\s+/).include?(SUDOER_GROUP)
   end
 
   # helper methods for dealing with sudo's vn num

--- a/modules/post/osx/gather/autologin_password.rb
+++ b/modules/post/osx/gather/autologin_password.rb
@@ -5,6 +5,7 @@
 
 class MetasploitModule < Msf::Post
   include Msf::Post::File
+  include Msf::Post::OSX::Priv
 
   # extract/verify by by XORing your kcpassword with your password
   AUTOLOGIN_XOR_KEY = [0x7D, 0x89, 0x52, 0x23, 0xD2, 0xBC, 0xDD, 0xEA, 0xA3, 0xB9, 0x1F]
@@ -35,7 +36,7 @@ class MetasploitModule < Msf::Post
 
   def run
     # ensure the user is root (or can read the kcpassword)
-    unless user == 'root'
+    unless is_root?
       fail_with(Failure::NoAccess, "Root privileges are required to read kcpassword file")
     end
 

--- a/modules/post/osx/gather/hashdump.rb
+++ b/modules/post/osx/gather/hashdump.rb
@@ -11,6 +11,7 @@ class MetasploitModule < Msf::Post
   OSX_IGNORE_ACCOUNTS = ["Shared", ".localized"]
 
   include Msf::Post::File
+  include Msf::Post::OSX::Priv
   include Msf::Auxiliary::Report
 
   def initialize(info={})
@@ -38,7 +39,9 @@ class MetasploitModule < Msf::Post
 
   # Run Method for when run command is issued
   def run
-    fail_with(Failure::BadConfig, "Insufficient Privileges: must be running as root to dump the hashes") unless root?
+    unless is_root?
+      fail_with(Failure::BadConfig, 'Insufficient Privileges: must be running as root to dump the hashes')
+    end
 
     # iterate over all users
     users.each do |user|
@@ -189,12 +192,6 @@ class MetasploitModule < Msf::Post
     print_status("Credential saved in database.")
   end
 
-  # Checks if running as root on the target
-  # @return [Bool] current user is root
-  def root?
-    whoami == 'root'
-  end
-
   # @return [String] containing blob for ShadowHashData in user's plist
   # @return [nil] if shadow is invalid
   def grab_shadow_blob(user)
@@ -212,10 +209,5 @@ class MetasploitModule < Msf::Post
   # @return [String] version string (e.g. 10.8.5)
   def ver_num
     @version ||= cmd_exec("/usr/bin/sw_vers -productVersion").chomp
-  end
-
-  # @return [String] name of current user
-  def whoami
-    @whoami ||= cmd_exec('/usr/bin/whoami').chomp
   end
 end


### PR DESCRIPTION
This PR adds `is_root?` and `is_admin?` methods to a new `Msf::Post::OSX::Priv` mixin, and updates several of the OSX post and local exploit modules to make use of these new methods.

The mixin has been tested on OSX Lion 10.7 with:

* post/osx/gather/enum_osx
* exploit/osx/local/sudo_password_bypass

The remaining modules updated in this PR have not been tested.

Note that the existing OSX modules are ancient and have many bugs, outdated code style, and outdated code patterns. These are outside the scope of this PR and will be addressed in separate PRs.
