### PR TITLE
automatically set LHOST if provided LHOST fails to bind

### DIFF
--- a/lib/msf/core/handler/reverse.rb
+++ b/lib/msf/core/handler/reverse.rb
@@ -43,6 +43,7 @@ module Msf
       #   be the INADDR_ANY address for IPv4 or IPv6, depending on the version
       #   of the first element.
       def bind_addresses
+        @@addr_auto = ''
         # Switch to IPv6 ANY address if the LHOST is also IPv6
         addr = Rex::Socket.resolv_nbo(datastore['LHOST'])
 
@@ -61,7 +62,7 @@ module Msf
           print_warning("You are binding to a loopback address by setting LHOST to #{addr}. Did you want ReverseListenerBindAddress?")
         end
 
-        if datastore['AutoLHOST']
+        if datastore['AutoLHOST'] && @@addr_auto =~ /\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/
           addrs = [ @@addr_auto, addr, any ]
         else
           addrs = [ addr, any ]
@@ -117,7 +118,7 @@ module Msf
           else
             ex = false
             via = via_string_for_ip(ip, comm)
-            if ip == @@addr_auto && datastore['AutoLHOST']
+            if datastore['AutoLHOST'] && ip == @@addr_auto
               print_error("Privided LHOST failed to bind")
               print_status("LHOST automatically set to #{ip}")
             end


### PR DESCRIPTION
this PR adds a new option `AutoLHOST` which if set and if provided LHOST fails to bind, will get the IP from Socket.ip_address_list.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/multi/handler`
- [ ] `set payload <payload>`
- [ ] `set AutoLHOST true`
- [ ] *set LHOST to random IP* 
- [ ] **verify** that it sets currect LHOST and you get a session with that

try using it while changing interfaces