### PR TITLE
MS-3222 remove single-entry OptEnum from exploit/windows/local/applocker_bypass

### DIFF
--- a/modules/exploits/windows/local/applocker_bypass.rb
+++ b/modules/exploits/windows/local/applocker_bypass.rb
@@ -37,25 +37,18 @@ class MetasploitModule < Msf::Exploit::Local
         ]
     ))
 
-    register_options([
-      OptEnum.new('TECHNIQUE', [true, 'Technique to use to bypass AppLocker',
-                               'INSTALLUTIL', %w(INSTALLUTIL)])])
   end
 
   # Run Method for when run command is issued
   def exploit
-    if datastore['TECHNIQUE'] == 'INSTALLUTIL'
-      if payload.arch.first == ARCH_X64 && sysinfo['Architecture'] !~ /64/
-        fail_with(Failure::NoTarget, 'The target platform is x86. 64-bit payloads are not supported.')
-      end
+    if payload.arch.first == ARCH_X64 && sysinfo['Architecture'] !~ /64/
+      fail_with(Failure::NoTarget, 'The target platform is x86. 64-bit payloads are not supported.')
     end
 
     # sysinfo is only on meterpreter sessions
     print_status("Running module against #{sysinfo['Computer']}") if not sysinfo.nil?
 
-    if datastore['TECHNIQUE'] == 'INSTALLUTIL'
-      execute_installutil
-    end
+    execute_installutil
   end
 
   def execute_installutil


### PR DESCRIPTION
Because there is only one possible Technique, there is no need for an enum to set it. This also causes problems with some GUIs, since having one option in a dropdown doesn't make a lot of sense?

If we want to add more techniques later, they should be implemented as a target option instead.

Fixes MS-3222