### PR TITLE
Fix session event issue when connected to remote data service

### DIFF
--- a/lib/metasploit/framework/data_service/remote/http/response_data_helper.rb
+++ b/lib/metasploit/framework/data_service/remote/http/response_data_helper.rb
@@ -1,4 +1,3 @@
-require 'ostruct'
 require 'digest'
 
 #
@@ -24,24 +23,6 @@ module ResponseDataHelper
       elog "Error parsing response: #{e.message}"
       e.backtrace.each { |line| elog line }
     end
-  end
-
-  #
-  # Converts an HTTP response to an OpenStruct object
-  #
-  def json_to_open_struct_object(response_wrapper, returns_on_error = nil)
-    if response_wrapper.expected
-      begin
-        body = response_wrapper.response.body
-        if !body.nil? && !body.empty?
-          return JSON.parse(body, object_class: OpenStruct)
-        end
-      rescue => e
-        elog "open struct conversion failed #{e.message}"
-      end
-    end
-
-    return returns_on_error
   end
 
   #
@@ -147,13 +128,6 @@ module ResponseDataHelper
       end
     end
     obj
-  end
-
-  #
-  # Converts a hash to an open struct
-  #
-  def open_struct(hash)
-    OpenStruct.new(hash)
   end
 
 end

--- a/lib/msf/core/db_manager/http/servlet/session_event_servlet.rb
+++ b/lib/msf/core/db_manager/http/servlet/session_event_servlet.rb
@@ -17,7 +17,7 @@ module SessionEventServlet
     lambda {
       begin
         opts = parse_json_request(request, false)
-        data = get_db().session_events(opts)
+        data = get_db.session_events(opts)
         set_json_response(data)
       rescue => e
         set_error_on_response(e)
@@ -27,10 +27,14 @@ module SessionEventServlet
 
   def self.report_session_event
     lambda {
-      job = lambda { |opts|
-        opts[:session] = open_struct(opts[:session][:table])
-        get_db().report_session_event(opts) }
-      exec_report_job(request, &job)
+      begin
+        job = lambda { |opts|
+          get_db.report_session_event(opts)
+        }
+        exec_report_job(request, &job)
+      rescue => e
+        set_error_on_response(e)
+      end
     }
   end
 end

--- a/lib/msf/core/db_manager/session_event.rb
+++ b/lib/msf/core/db_manager/session_event.rb
@@ -47,7 +47,7 @@ module Msf::DBManager::SessionEvent
     end
 
     session_id = nil
-    if session.kind_of?(Mdm::Session)
+    if session.is_a?(Mdm::Session)
       session_id = session.id
     elsif session.is_a?(Hash) && session.key?(:id)
       session_id = session[:id]

--- a/lib/msf/core/db_manager/session_event.rb
+++ b/lib/msf/core/db_manager/session_event.rb
@@ -11,7 +11,7 @@ module Msf::DBManager::SessionEvent
   # Record a session event in the database
   #
   # opts MUST contain one of:
-  # +:session+:: the Msf::Session OR the ::Mdm::Session we are reporting
+  # +:session+:: the Msf::Session, Mdm::Session or Hash representation of Mdm::Session we are reporting
   # +:etype+::   event type, enum: command, output, upload, download, filedelete
   #
   # opts may contain
@@ -46,7 +46,14 @@ module Msf::DBManager::SessionEvent
       event_data = { :created_at => opts[:created_at] }
     end
 
-    event_data[:session_id] = session.id
+    session_id = nil
+    if session.kind_of?(Mdm::Session)
+      session_id = session.id
+    elsif session.is_a?(Hash) && session.key?(:id)
+      session_id = session[:id]
+    end
+
+    event_data[:session_id] = session_id
     [:remote_path, :local_path, :output, :command, :etype].each do |attr|
       event_data[attr] = opts[attr] if opts[attr]
     end


### PR DESCRIPTION
Fixes an issue triggered when interacting with a session or when upgrading a shell to a meterpreter session (`sessions -u <opt>`) while connected to a remote data service. The issue was resolved by fixing the `report_session_event` method to handle being used with a remote data service.

Ticket: MS-2963

**Example msfdb_ws console error output:**
```
[-] Error executing job undefined method `[]' for nil:NilClass
    Call Stack:
     /home/msfdev/metasploit-framework/lib/msf/core/db_manager/http/servlet/session_event_servlet.rb:31:in `block (2 levels) in report_session_event'
     /home/msfdev/metasploit-framework/lib/msf/core/db_manager/http/job_processor.rb:22:in `block (2 levels) in start_processor_thread'
     /home/msfdev/metasploit-framework/lib/msf/core/db_manager/http/job_processor.rb:19:in `loop'
     /home/msfdev/metasploit-framework/lib/msf/core/db_manager/http/job_processor.rb:19:in `block in start_processor_thread'
```

Note: There is a known issue (ticket MS-3220) that occurs when connected to the remote data service and performing a session upgrade. The `load_session_info` method in `lib/msf/base/sessions/meterpreter.rb` is directly saving to the DB causing validation errors.

## Verification

- [x] Start `msfconsole`
- [x] Start `msfdb_ws` on a remote system
- [x] Connect to the remote data service `data_services --add <address>`
- [x] Create a command shell session for a host that is not yet in the database. For example, `use exploit/unix/irc/unreal_ircd_3281_backdoor` against Metasploitable3 VM.
- [x] **Verify** that the output of the `sessions` command show an entry for the command shell session
- [x] Select the command shell session: `sessions [id]`
- [x] Interact with the command shell session (`whoami`, `id`, `ls`, etc.)
- [x] Press Ctrl-Z and respond Y when asked if you want background the session
- [x] Upgrade the shell to a Meterpreter session: `sessions -u <opt>`
- [x] **Verify** that the output of the `sessions` command show an entry for the Meterpreter session
- [x] Select Meterpreter session: `sessions [id]`
- [x] Interact with the Meterpreter session (`getuid`, `getpid`, `ls`, etc.)
- [x] Background the active session `background`, and then terminate all sessions `sessions -K`
- [x] **Verify** no errors are reported on `msfdb_ws` console
- [x] Wipe the database and repeat the above steps except do not connect to a remote data service