### PR TITLE
Improve network interface support for LHOST (OptAddressLocal)

### DIFF
--- a/lib/msf/core/opt.rb
+++ b/lib/msf/core/opt.rb
@@ -25,7 +25,7 @@ module Msf
       Msf::OptPort.new(__method__.to_s, [ required, desc, default ])
     end
 
-    # @return [OptAddress]
+    # @return [OptAddressLocal]
     def self.LHOST(default=nil, required=true, desc="The listen address")
       Msf::OptAddressLocal.new(__method__.to_s, [ required, desc, default ])
     end
@@ -40,7 +40,7 @@ module Msf
       Msf::OptString.new(__method__.to_s, [ required, desc, default ])
     end
 
-    # @return [OptAddress]
+    # @return [OptAddressRange]
     def self.RHOST(default=nil, required=true, desc="The target address")
       Msf::OptAddressRange.new('RHOSTS', [ required, desc, default ], aliases: [ 'RHOST' ])
     end

--- a/lib/msf/core/opt.rb
+++ b/lib/msf/core/opt.rb
@@ -26,7 +26,7 @@ module Msf
     end
 
     # @return [OptAddressLocal]
-    def self.LHOST(default=nil, required=true, desc="The listen address")
+    def self.LHOST(default=nil, required=true, desc="The listen address (an interface may be specified)")
       Msf::OptAddressLocal.new(__method__.to_s, [ required, desc, default ])
     end
 

--- a/lib/msf/core/opt_address_local.rb
+++ b/lib/msf/core/opt_address_local.rb
@@ -28,9 +28,7 @@ class OptAddressLocal < OptAddress
       end
     end
 
-    return '' if addrs.empty?
-
-    addrs.first
+    addrs.any? ? addrs.first : ''
   end
 
   def valid?(value, check_empty: true)

--- a/lib/msf/core/opt_address_local.rb
+++ b/lib/msf/core/opt_address_local.rb
@@ -5,7 +5,7 @@ module Msf
 
 ###
 #
-# Network address option.
+# Local network address option.
 #
 ###
 class OptAddressLocal < OptAddress
@@ -17,7 +17,7 @@ class OptAddressLocal < OptAddress
     return unless value.kind_of?(String)
     return value unless interfaces.include?(value)
 
-    ip_address = NetworkInterface.addresses(value).values.flatten.map{|x| x['addr']}.select do |addr|
+    addrs = NetworkInterface.addresses(value).values.flatten.map { |x| x['addr'] }.select do |addr|
       begin
         IPAddr.new(addr).ipv4?
       rescue IPAddr::InvalidAddressError
@@ -25,9 +25,9 @@ class OptAddressLocal < OptAddress
       end
     end
 
-    return if ip_address.blank?
+    return '' if addrs.empty?
 
-    ip_address.first
+    addrs.first
   end
 
   def valid?(value, check_empty: true)

--- a/lib/msf/core/opt_address_local.rb
+++ b/lib/msf/core/opt_address_local.rb
@@ -21,7 +21,7 @@ class OptAddressLocal < OptAddress
       begin
         IPAddr.new(addr).ipv4?
       rescue IPAddr::InvalidAddressError
-        nil
+        false
       end
     end
 

--- a/lib/msf/core/opt_address_local.rb
+++ b/lib/msf/core/opt_address_local.rb
@@ -17,9 +17,12 @@ class OptAddressLocal < OptAddress
     return unless value.kind_of?(String)
     return value unless interfaces.include?(value)
 
-    addrs = NetworkInterface.addresses(value).values.flatten.map { |x| x['addr'] }.select do |addr|
+    addrs = NetworkInterface.addresses(value).values.flatten
+
+    # Strip interface name from address (see getifaddrs(3))
+    addrs = addrs.map { |x| x['addr'].split('%').first }.select do |addr|
       begin
-        IPAddr.new(addr).ipv4?
+        IPAddr.new(addr)
       rescue IPAddr::InvalidAddressError
         false
       end

--- a/lib/msf/core/opt_address_local.rb
+++ b/lib/msf/core/opt_address_local.rb
@@ -15,21 +15,19 @@ class OptAddressLocal < OptAddress
 
   def normalize(value)
     return unless value.kind_of?(String)
+    return value unless interfaces.include?(value)
 
-    if interfaces.include?(value)
-      ip_address = NetworkInterface.addresses(value).values.flatten.map{|x| x['addr']}.select do |addr|
-        begin
-          IPAddr.new(addr).ipv4?
-        rescue IPAddr::InvalidAddressError
-          nil
-        end
+    ip_address = NetworkInterface.addresses(value).values.flatten.map{|x| x['addr']}.select do |addr|
+      begin
+        IPAddr.new(addr).ipv4?
+      rescue IPAddr::InvalidAddressError
+        nil
       end
-
-      return if ip_address.blank?
-      return ip_address.first
     end
 
-    value
+    return if ip_address.blank?
+
+    ip_address.first
   end
 
   def valid?(value, check_empty: true)

--- a/lib/msf/core/opt_address_local.rb
+++ b/lib/msf/core/opt_address_local.rb
@@ -9,32 +9,36 @@ module Msf
 #
 ###
 class OptAddressLocal < OptAddress
+  def interfaces
+    NetworkInterface.interfaces || []
+  end
+
   def normalize(value)
-    return nil unless value.kind_of?(String)
-    
-    if NetworkInterface.interfaces.include?(value)
-      ip_address = NetworkInterface.addresses(value).values.flatten.collect{|x| x['addr']}.select do |addr|
+    return unless value.kind_of?(String)
+
+    if interfaces.include?(value)
+      ip_address = NetworkInterface.addresses(value).values.flatten.map{|x| x['addr']}.select do |addr|
         begin
           IPAddr.new(addr).ipv4?
-        rescue IPAddr::InvalidAddressError => e
-          false
+        rescue IPAddr::InvalidAddressError
+          nil
         end
       end
 
-      return false if ip_address.blank?
+      return if ip_address.blank?
       return ip_address.first
     end
-    
-    return value
+
+    value
   end
-  
+
   def valid?(value, check_empty: true)
     return false if check_empty && empty_required_value?(value)
-    return false unless value.kind_of?(String) or value.kind_of?(NilClass)
-   
-    return true if NetworkInterface.interfaces.include?(value)
+    return false unless value.kind_of?(String) || value.kind_of?(NilClass)
 
-    return super
+    return true if interfaces.include?(value)
+
+    super
   end
 end
 

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -2161,8 +2161,7 @@ class Core
   # XXX: We repurpose OptAddressLocal#interfaces, so we can't put this in Rex
   def tab_complete_source_interface(o)
     return [] unless o.is_a?(Msf::OptAddressLocal)
-    # Exclude loopback generically
-    o.interfaces - %w{lo lo0}
+    o.interfaces
   end
 
   #

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -2158,6 +2158,13 @@ class Core
     return res
   end
 
+  # XXX: We repurpose OptAddressLocal#interfaces, so we can't put this in Rex
+  def tab_complete_source_interface(o)
+    return [] unless o.is_a?(Msf::OptAddressLocal)
+    # Exclude loopback generically
+    o.interfaces - %w{lo lo0}
+  end
+
   #
   # Provide possible option values based on type
   #
@@ -2179,8 +2186,8 @@ class Core
           res << Rex::Socket.source_address(rh)
         else
           res += tab_complete_source_address
+          res += tab_complete_source_interface(o)
         end
-      else
       end
 
     when Msf::OptAddressRange

--- a/lib/rex/ui/text/dispatcher_shell.rb
+++ b/lib/rex/ui/text/dispatcher_shell.rb
@@ -290,10 +290,8 @@ module DispatcherShell
       addresses = [Rex::Socket.source_address]
       # getifaddrs was introduced in 2.1.2
       if ::Socket.respond_to?(:getifaddrs)
-        ifaddrs = ::Socket.getifaddrs.find_all do |ifaddr|
-          ((ifaddr.flags & ::Socket::IFF_LOOPBACK) == 0) &&
-            ifaddr.addr &&
-            ifaddr.addr.ip?
+        ifaddrs = ::Socket.getifaddrs.select do |ifaddr|
+          ifaddr.addr && ifaddr.addr.ip?
         end
         addresses += ifaddrs.map { |ifaddr| ifaddr.addr.ip_address }
       end

--- a/lib/rex/ui/text/dispatcher_shell.rb
+++ b/lib/rex/ui/text/dispatcher_shell.rb
@@ -289,9 +289,9 @@ module DispatcherShell
     def tab_complete_source_address
       addresses = [Rex::Socket.source_address]
       # getifaddrs was introduced in 2.1.2
-      if Socket.respond_to?(:getifaddrs)
-        ifaddrs = Socket.getifaddrs.find_all do |ifaddr|
-          ((ifaddr.flags & Socket::IFF_LOOPBACK) == 0) &&
+      if ::Socket.respond_to?(:getifaddrs)
+        ifaddrs = ::Socket.getifaddrs.find_all do |ifaddr|
+          ((ifaddr.flags & ::Socket::IFF_LOOPBACK) == 0) &&
             ifaddr.addr &&
             ifaddr.addr.ip?
         end


### PR DESCRIPTION
# ~WIP~ Test me!

~Do we really want to exclude loopback? It's occasionally useful, and there's already a warning when setting it.~ No longer excluded.

- [x] Test tab completion of IPv4 and IPv6 by address
- [x] Note that the full list of addresses is displayed now (fixed regression)
- [x] Test tab completion of IPv4 and IPv6 by interface
- [x] Test setting of IPv4 and IPv6 by address
- [x] Test setting of IPv4 and IPv6 by interface

#8336, #10086