### PR TITLE
Expand tilde in resource file path

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/resource.rb
+++ b/lib/msf/ui/console/command_dispatcher/resource.rb
@@ -55,7 +55,7 @@ module Msf
               good_res = nil
               if res == '-'
                 good_res = res
-              elsif ::File.exist?(res_expand)
+              elsif ::File.file?(res_expand) && File.readable?(res_expand)
                 good_res = res_expand
               else
                 # let's check to see if it's in the scripts/resource dir (like when tab completed)
@@ -64,7 +64,7 @@ module Msf
                   ::Msf::Config.user_script_directory + ::File::SEPARATOR + 'resource'
                 ].each do |dir|
                   res_path = dir + ::File::SEPARATOR + res
-                  if ::File.exist?(res_path)
+                  if ::File.file?(res_path) && File.readable?(res_path)
                     good_res = res_path
                     break
                   end
@@ -100,13 +100,13 @@ module Msf
                   ::Msf::Config.user_script_directory + File::SEPARATOR + "resource",
                   '.'
                 ].each do |dir|
-                  next if not ::File.exist? dir
+                  next unless ::File.exist?(dir)
                   tabs += ::Dir.new(dir).find_all { |e|
                     path = dir + File::SEPARATOR + e
-                    ::File.file?(path) and File.readable?(path)
+                    ::File.file?(path) && File.readable?(path)
                   }
                 end
-              rescue Exception
+              rescue
               end
             else
               tabs += tab_complete_filenames(str,words)

--- a/lib/msf/ui/console/command_dispatcher/resource.rb
+++ b/lib/msf/ui/console/command_dispatcher/resource.rb
@@ -89,9 +89,9 @@ module Msf
           def cmd_resource_tabs(str, words)
             tabs = []
             #return tabs if words.length > 1
-            if ( str and str =~ /^#{Regexp.escape(File::SEPARATOR)}/ )
+            if !str.nil? && (str.start_with?('~') || str =~ /^#{Regexp.escape(File::SEPARATOR)}/)
               # then you are probably specifying a full path so let's just use normal file completion
-              return tab_complete_filenames(str,words)
+              return tab_complete_filenames(str, words)
             elsif (not words[1] or not words[1].match(/^\//))
               # then let's start tab completion in the scripts/resource directories
               begin

--- a/lib/msf/ui/console/command_dispatcher/resource.rb
+++ b/lib/msf/ui/console/command_dispatcher/resource.rb
@@ -57,7 +57,7 @@ module Msf
                 good_res = res
               elsif ::File.exist?(res_expand)
                 good_res = res_expand
-              elsif
+              else
                 # let's check to see if it's in the scripts/resource dir (like when tab completed)
                 [
                   ::Msf::Config.script_directory + ::File::SEPARATOR + 'resource',

--- a/lib/msf/ui/console/command_dispatcher/resource.rb
+++ b/lib/msf/ui/console/command_dispatcher/resource.rb
@@ -51,11 +51,12 @@ module Msf
             end
 
             args.each do |res|
+              res_expand = ::File.expand_path(res)
               good_res = nil
               if res == '-'
                 good_res = res
-              elsif ::File.exist?(res)
-                good_res = res
+              elsif ::File.exist?(res_expand)
+                good_res = res_expand
               elsif
                 # let's check to see if it's in the scripts/resource dir (like when tab completed)
                 [


### PR DESCRIPTION
If the resource file path starts with a "~" it will be expanded to the process owner's home directory (the environment variable HOME must be set correctly). Calling the `resource` command with a path that started with a tilde would previously result in an error that the "$FILENAME is not a valid resource file".

## Verification

- [x] Create a simple resource file: `echo "workspace -v" > ~/Downloads/res_test.rc`
- [x] Start `msfconsole`
- [x] Run the command `resource ~/Downloads/res_test.rc`
- [x] **Verify** that the resource script commands are run and that workspaces are listed verbosely
- [x] Run the `resource` command again using the absolute path to the resource file
- [x] **Verify** that the resource script commands are run and that workspaces are listed verbosely