### PR TITLE
Re-add RHOSTS option to scanner mixin

### DIFF
--- a/lib/msf/core/auxiliary/nmap.rb
+++ b/lib/msf/core/auxiliary/nmap.rb
@@ -24,7 +24,7 @@ def initialize(info = {})
   super
 
   register_options([
-    OptAddressRange.new('RHOSTS', [ true, "The target address range or CIDR identifier"]),
+    Opt::RHOSTS,
     OptBool.new('NMAP_VERBOSE', [ false, 'Display nmap output', true]),
     OptString.new('RPORTS', [ false, 'Ports to target']), # RPORT supersedes RPORTS
   ], Auxiliary::Nmap)

--- a/lib/msf/core/auxiliary/scanner.rb
+++ b/lib/msf/core/auxiliary/scanner.rb
@@ -17,6 +17,7 @@ def initialize(info = {})
   super
 
   register_options([
+      Opt::RHOSTS,
       OptInt.new('THREADS', [ true, "The number of concurrent threads", 1 ] )
     ], Auxiliary::Scanner)
 

--- a/lib/msf/core/opt.rb
+++ b/lib/msf/core/opt.rb
@@ -40,8 +40,12 @@ module Msf
       Msf::OptString.new(__method__.to_s, [ required, desc, default ])
     end
 
-    # @return [OptAddress]
-    def self.RHOST(default=nil, required=true, desc="The target address")
+    # @return [OptAddressRange]
+    def self.RHOSTS(default=nil, required=true, desc="The target address range or CIDR identifier")
+      Msf::OptAddressRange.new('RHOSTS', [ required, desc, default ])
+    end
+
+    def self.RHOST(default=nil, required=true, desc="The target address range or CIDR identifier")
       Msf::OptAddressRange.new('RHOSTS', [ required, desc, default ], aliases: [ 'RHOST' ])
     end
 
@@ -107,6 +111,7 @@ module Msf
     LPORT = LPORT()
     Proxies = Proxies()
     RHOST = RHOST()
+    RHOSTS = RHOSTS()
     RPORT = RPORT()
     SSLVersion = SSLVersion()
   end


### PR DESCRIPTION
Somehow this got dropped as part of a different bug fix (0d51ba80214172acae758a50c673f03d513621ce) so this PR re-adds the registration. Fixes #10051 

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Use a scanner module that uses only a UDPScanner, Scanner, etc. mixin
- [x] **Verify** the module has RHOSTS and works on a single host or range.

Example:

```
msf5 exploit(multi/handler) > use auxiliary/scanner/ipmi/ipmi_version 
msf5 auxiliary(scanner/ipmi/ipmi_version) > set rhosts 192.168.1.0/24
rhosts => 192.168.1.0/24
msf5 auxiliary(scanner/ipmi/ipmi_version) > run

[*] Sending IPMI requests to 192.168.1.0->192.168.1.255 (256 hosts)
[+] 192.168.1.43:623 - IPMI - IPMI-2.0 OEMID:180010 UserAuth(auth_msg, auth_user, non_null_user) PassAuth(password, md5, md2) Level(1.5, 2.0) 
[*] Scanned 256 of 256 hosts (100% complete)
[*] Auxiliary module execution completed
```