### PR TITLE
add port to keywords

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -427,6 +427,7 @@ module Msf
               'edb'      => 'Modules with a matching Exploit-DB ID',
               'name'     => 'Modules with a matching descriptive name',
               'platform' => 'Modules affecting this platform',
+              'port'     => 'Modules with a matching port',
               'ref'      => 'Modules with a matching ref',
               'type'     => 'Modules of a specific type (exploit, auxiliary, or post)',
             }.each_pair do |keyword, description|


### PR DESCRIPTION
searching with `search port:23` already works, it was not listed. 