### PR TITLE
Added Teradata ODBC Login and SQL modules and documentation

### DIFF
--- a/documentation/modules/auxiliary/admin/teradata/teradata_odbc_sql.md
+++ b/documentation/modules/auxiliary/admin/teradata/teradata_odbc_sql.md
@@ -1,0 +1,101 @@
+The teradata_odbc_sql module is used to run SQL queries for Teradata databases.
+
+## Vulnerable Application
+
+* Teradata Database
+* Teradata Express
+
+Teradata databases can be identified by scanning for TCP port 1025. An Nmap version scan can confirm if the service is recognized as Teradata.
+
+The teradata_odbc_login module can be used to brute-force credentials.
+
+## Extra Requirements
+
+This module requires the Teradata ODBC driver and the Teradata python library.
+
+### ODBC Driver for Kali Linux 2017.3
+1. Download the Teradata ODBC driver for Ubuntu from [downloads.teradata.com](https://downloads.teradata.com/download/connectivity/odbc-driver/linux).
+2. Refer to the Ubuntu package README for up-to-date instructions.
+   1. Install **lib32stdc++6** if necessary.
+   2. Install the ODBC drivers: `dpkg -i [package].deb`
+   3. Copy **/opt/teradata/client/ODBC_64/odbc.ini** to **/root/.odbc.ini** .
+      * Or your home directory if not root.
+      * Make sure **odbc.ini** has been renamed to **.obdc.ini** .
+
+### Python Package
+```
+pip install teradata
+```
+## Verification Steps
+1. Deploy a [Teradata Express](https://www.teradata.com/products-and-services/teradata-express) test environment.
+2. Install the OBCD driver and python package.
+3. Start msfconsole.
+4. Do: `use auxiliary/admin/teradata/teradata_odbc_sql`
+5. Do: `set RHOSTS [IPs]`
+6. Do: `set USERNAME [username to try]`
+7. Do: `set PASSWORD [password to try]`
+   * The default Teradata credentials are the matching username and password 'DBC'.
+8. Set a SQL query for the 'SQL' option.
+   * The default is `SELECT DATABASENAME FROM DBC.DATABASES`
+9. Do: `run`
+
+```
+msf > use auxiliary/admin/teradata/teradata_odbc_sql 
+msf auxiliary(admin/teradata/teradata_odbc_sql) > show options
+
+Module options (auxiliary/admin/teradata/teradata_odbc_sql):
+
+   Name      Current Setting                         Required  Description
+   ----      ---------------                         --------  -----------
+   PASSWORD  dbc                                     yes       Password
+   RHOSTS                                            yes       The target address range or CIDR identifier
+   SQL       SELECT DATABASENAME FROM DBC.DATABASES  yes       SQL query to perform
+   THREADS   1                                       yes       The number of concurrent threads
+   USERNAME  dbc                                     yes       Username
+
+msf auxiliary(admin/teradata/teradata_odbc_sql) > set RHOSTS 192.168.0.2
+RHOSTS => 192.168.0.2
+msf auxiliary(admin/teradata/teradata_odbc_sql) > run
+
+[*] Running for 192.168.0.2...
+[*] 192.168.0.2 - dbc:dbc - Starting
+[*] 192.168.0.2 - Creating connection: %s
+[*] 192.168.0.2 - Loading ODBC Library: %s
+[*] 192.168.0.2 - Available drivers: Teradata Database ODBC Driver 16.20, 
+[*] 192.168.0.2 - Connection successful. Duration: %.3f seconds. Details: %s
+[+] 192.168.0.2 - dbc:dbc - Login Successful
+[*] 192.168.0.2 - Starting - SELECT DATABASENAME FROM DBC.DATABASES
+[*] 192.168.0.2 - Query Successful. Duration: %.3f seconds,%sQuery: %s%s
+[+] 192.168.0.2 - Row 1: [DatabaseUser                  ]
+[+] 192.168.0.2 - Row 2: [All                           ]
+[+] 192.168.0.2 - Row 3: [SYSJDBC                       ]
+[+] 192.168.0.2 - Row 4: [TDStats                       ]
+[+] 192.168.0.2 - Row 5: [TD_SYSXML                     ]
+[+] 192.168.0.2 - Row 6: [PUBLIC                        ]
+[+] 192.168.0.2 - Row 7: [DBC                           ]
+[+] 192.168.0.2 - Row 8: [SYSBAR                        ]
+[+] 192.168.0.2 - Row 9: [TD_SYSGPL                     ]
+[+] 192.168.0.2 - Row 10: [SYSLIB                        ]
+[+] 192.168.0.2 - Row 11: [SQLJ                          ]
+[+] 192.168.0.2 - Row 12: [LockLogShredder               ]
+[+] 192.168.0.2 - Row 13: [Default                       ]
+[+] 192.168.0.2 - Row 14: [TDPUSER                       ]
+[+] 192.168.0.2 - Row 15: [TD_SYSFNLIB                   ]
+[+] 192.168.0.2 - Row 16: [EXTUSER                       ]
+[+] 192.168.0.2 - Row 17: [tdwm                          ]
+[+] 192.168.0.2 - Row 18: [SystemFe                      ]
+[+] 192.168.0.2 - Row 19: [External_AP                   ]
+[+] 192.168.0.2 - Row 20: [TDQCD                         ]
+[+] 192.168.0.2 - Row 21: [dbcmngr                       ]
+[+] 192.168.0.2 - Row 22: [Sys_Calendar                  ]
+[+] 192.168.0.2 - Row 23: [SysAdmin                      ]
+[+] 192.168.0.2 - Row 24: [TD_SERVER_DB                  ]
+[+] 192.168.0.2 - Row 25: [TDMaps                        ]
+[+] 192.168.0.2 - Row 26: [SYSUDTLIB                     ]
+[+] 192.168.0.2 - Row 27: [Crashdumps                    ]
+[+] 192.168.0.2 - Row 28: [SYSSPATIAL                    ]
+[+] 192.168.0.2 - Row 29: [MyUser                        ]
+[+] 192.168.0.2 - Row 30: [SYSUIF                        ]
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```

--- a/documentation/modules/auxiliary/scanner/teradata/teradata_odbc_login.md
+++ b/documentation/modules/auxiliary/scanner/teradata/teradata_odbc_login.md
@@ -1,0 +1,70 @@
+The teradata_odbc_login module is used to brute-force credentials for Teradata databases.
+
+## Vulnerable Application
+
+* Teradata Database
+* Teradata Express
+
+Teradata databases can be identified by scanning for TCP port 1025. An Nmap version scan can confirm if the service is recognized as Teradata.
+
+## Extra Requirements
+
+This module requires the Teradata ODBC driver and the Teradata python library.
+
+### ODBC Driver for Kali Linux 2017.3
+1. Download the Teradata ODBC driver for Ubuntu from [downloads.teradata.com](https://downloads.teradata.com/download/connectivity/odbc-driver/linux).
+2. Refer to the Ubuntu package README for up-to-date instructions.
+   1. Install **lib32stdc++6** if necessary.
+   2. Install the ODBC drivers: `dpkg -i [package].deb`
+   3. Copy **/opt/teradata/client/ODBC_64/odbc.ini** to **/root/.odbc.ini** .
+      * Or your home directory if not root.
+      * Make sure **odbc.ini** has been renamed to **.obdc.ini** .
+
+### Python Package
+```
+pip install teradata
+```
+## Verification Steps
+1. Deploy a [Teradata Express](https://www.teradata.com/products-and-services/teradata-express) test environment.
+2. Install the OBCD driver and python package.
+3. Start msfconsole.
+4. Do: `use auxiliary/scanner/teradata/teradata_odbc_login`
+5. Do: `set RHOSTS [IPs]`
+6. Do: `set USERNAME [username to try]`
+7. Do: `set PASSWORD [password to try]`
+   * The default Teradata credentials are the matching username and password 'dbc'.
+8. Do: `run`
+
+```
+msf > use auxiliary/scanner/teradata/teradata_odbc_login
+msf auxiliary(scanner/teradata/teradata_odbc_login) > set RHOSTS 192.168.0.2
+RHOSTS => 192.168.0.2
+msf auxiliary(scanner/teradata/teradata_odbc_login) > set USERNAME dbc
+USERNAME => dbc
+msf auxiliary(scanner/teradata/teradata_odbc_login) > set PASSWORD dbc
+PASSWORD => dbc
+msf auxiliary(scanner/teradata/teradata_odbc_login) > run
+
+[*] Running for 192.168.0.2...
+[*] 192.168.0.2:1025 - Creating connection: %s
+[*] 192.168.0.2:1025 - Loading ODBC Library: %s
+[*] 192.168.0.2:1025 - Method succeeded with info:  [26] 523 24
+[*] 192.168.0.2:1025 - Method succeeded with info:  [26] 523 24
+[*] 192.168.0.2:1025 - Available drivers: Teradata Database ODBC Driver 16.20, 
+[*] 192.168.0.2:1025 - Creating connection using ODBC ConnectString: %s
+[*] 192.168.0.2:1025 - Setting AUTOCOMMIT to %s
+[*] 192.168.0.2:1025 - FETCH_SIZE: 1
+[*] 192.168.0.2:1025 - Buffer size for column %s: %s
+[*] 192.168.0.2:1025 - SELECT SESSION returned %s
+[*] 192.168.0.2:1025 - Executing query on session %s using SQLExecDirectW: %s
+[*] 192.168.0.2:1025 - Committing transaction...
+[*] 192.168.0.2:1025 - Created session %s.
+[*] 192.168.0.2:1025 - Creating cursor %s for session %s.
+[*] 192.168.0.2:1025 - Connection successful. Duration: %.3f seconds. Details: %s
+[*] 192.168.0.2:1025 - Closing cursor %s for session %s.
+[*] 192.168.0.2:1025 - Closing session %s...
+[*] 192.168.0.2:1025 - Session %s closed.
+[+] 192.168.0.2:1025 - [1/1] - dbc:dbc - Success
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```

--- a/modules/auxiliary/admin/teradata/teradata_odbc_sql.py
+++ b/modules/auxiliary/admin/teradata/teradata_odbc_sql.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python2.7
+# -*- coding: utf-8 -*-
+#2018-05-09 14-15
+
+# Standard Modules
+import logging
+
+# Extra Modules
+dependencies_missing = False
+try:
+    import teradata
+except ImportError:
+    dependencies_missing = True
+
+from metasploit import module
+
+
+# Metasploit Metadata
+metadata = {
+    'name': 'Teradata ODBC SQL Query Module',
+    'description': '''
+        SQL query module for ODBC connections to local Teradata databases.
+
+        Port specification (TCP 1025 by default) is not necessary for ODBC connections.
+
+        Requires ODBC driver and Python Teradata module.
+    ''',
+    'authors': [
+        'Ted Raffle (actuated)'
+    ],
+    'date': '2018-03-29',
+    'license': 'MSF_LICENSE',
+    'references': [
+        {'type': 'url', 'ref': 'https://developer.teradata.com/tools/reference/teradata-python-module'},
+        {'type': 'url', 'ref': 'https://downloads.teradata.com/download/connectivity/odbc-driver/linux'},
+        {'type': 'aka', 'ref': 'Teradata ODBC Authentication Scanner'}
+    ],
+    'type': 'single_scanner',
+    'options': {
+        'USERNAME': {'type': 'string', 'description': 'Username', 'required': True, 'default': 'dbc'},
+        'PASSWORD': {'type': 'string', 'description': 'Password', 'required': True, 'default': 'dbc'},
+        'SQL': {'type': 'string', 'description': 'SQL query to perform', 'required': True, 'default': 'SELECT DATABASENAME FROM DBC.DATABASES'},
+    }
+}
+
+
+# Run function
+def run(args):
+
+    # Define UdaExec ODBC connection "application", must be before LogHandler
+    udaExec = teradata.UdaExec(appName="Auth", version="1.0", logConsole=False, configureLogging=False)
+
+    # Metasploit LogHandler
+    module.LogHandler.setup(msg_prefix='{} - '.format(args['rhost']))
+
+    # Return error for missing dependency
+    if dependencies_missing:
+        logging.error('Python Teradata module missing, cannot continue')
+        return
+
+    # Set variables to current RHOST, and USERNAME and PASSWORD options
+    host = args['rhost']
+    user = args['USERNAME']
+    password = args['PASSWORD']
+
+    # Perform login attempt
+    module.log(host + ' - ' + user + ':' + password + ' - Starting')
+    try: 
+        session = udaExec.connect(method="odbc", system=host, username=user, password=password);
+    except teradata.api.Error as e:
+        logging.error(user + ':' + password + ' - ' + format(e))
+        return
+    else:
+        module.log(host + ' - ' + user + ':' + password + ' - Login Successful', level='good')
+        try:
+            query = args['SQL']
+            module.log(host + ' - Starting - ' + query)
+            for row in session.execute(query):
+                outputRow=str(row)
+                module.log(host + ' - ' + outputRow, level='good')
+        except teradata.api.Error as e:
+            logging.error(format(e))
+            return
+
+
+if __name__ == '__main__':
+    module.run(metadata, run)

--- a/modules/auxiliary/scanner/teradata/teradata_odbc_login.py
+++ b/modules/auxiliary/scanner/teradata/teradata_odbc_login.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python2.7
+# -*- coding: utf-8 -*-
+#2018-05-29 08-49
+
+# Standard Modules
+import logging
+
+# Extra Modules
+dependencies_missing = False
+try:
+    import teradata
+except ImportError:
+    dependencies_missing = True
+
+from metasploit import module, login_scanner
+
+
+# Metasploit Metadata
+metadata = {
+  'name': 'Teradata ODBC Login Scanner Module',
+  'description': '''
+    Login scanner module for ODBC connections to Teradata databases.
+
+    Port specification (TCP 1025 by default) is not necessary for ODBC connections.
+
+    Blank passwords are not supported by ODBC connections.
+
+    Requires ODBC driver and Python Teradata module.
+  ''',
+  'authors': [
+    'Ted Raffle (actuated)'
+  ],
+  'date': '2018-03-30',
+  'license': 'MSF_LICENSE',
+  'references': [
+    {'type': 'url', 'ref': 'https://developer.teradata.com/tools/reference/teradata-python-module'},
+    {'type': 'url', 'ref': 'https://downloads.teradata.com/download/connectivity/odbc-driver/linux'},
+    {'type': 'aka', 'ref': 'Teradata ODBC Login Scanner'}
+  ],
+  'type': 'single_host_login_scanner',
+  'options': {
+    'rhost': {'type': 'address', 'description': 'Host to target', 'required': True},
+    'rport': {'type': 'port', 'description': 'Port to target, ignored by the ODBC driver', 'required': True, 'default': 1025},
+    'sleep_interval': {'type': 'float', 'description': 'Time in seconds to wait between login attempts', 'required': False}
+  },
+  'service_name': 'teradata'
+}
+
+
+def valid_login(udaExec, host, user, password):
+    try:
+        udaExec.connect(method="odbc", system=host, username=user, password=password)
+    except teradata.api.Error as e:
+        return False
+    else:
+        return True
+
+
+def run(args):
+    if dependencies_missing:
+        module.log('Python Teradata module missing, cannot continue', level=error)
+        return
+
+    # Define UdaExec ODBC connection "application" globally, must be before LogHandler
+    udaExec = teradata.UdaExec(appName="Auth", version="1.0", logConsole=False, configureLogging=False)
+    module.LogHandler.setup(msg_prefix='{}:{} - '.format(args['rhost'], 1025))
+    scanner = login_scanner.make_scanner(lambda host, port, username, password: valid_login(udaExec, host, username, password))
+    scanner(args)
+
+
+if __name__ == '__main__':
+    module.run(metadata, run)


### PR DESCRIPTION
Adds teradata_odbc_login and teradata_odbc_sql modules and documentation for performing Teradata Database login attacks and running SQL queries.

## Requirements

- [x] Teradata ODBC drivers
- [x] Python Teradata module

#### ODBC Driver for Kali Linux 2017.3
1. Download the Teradata ODBC driver for Ubuntu from [downloads.teradata.com](https://downloads.teradata.com/download/connectivity/odbc-driver/linux).
2. Refer to the Ubuntu package README for up-to-date instructions.
   1. Install **lib32stdc++6** if necessary.
   2. Install the ODBC drivers: `dpkg -i [package].deb`
   3. Copy **/opt/teradata/client/ODBC_64/odbc.ini** to **/root/.odbc.ini** .
      * Or your home directory if not root.
      * Make sure **odbc.ini** has been renamed to **.obdc.ini** .

#### Python Package
```
pip install teradata
```
## Verification for teradata_odbc_login

1. Deploy a [Teradata Express](https://www.teradata.com/products-and-services/teradata-express) test environment.
2. Install the OBCD driver and python package.
3. Start msfconsole.
4. Do: `use auxiliary/scanner/teradata/teradata_odbc_login`
5. Do: `set RHOSTS [IPs]`
6. Do: `set USERNAME [username to try]`
7. Do: `set PASSWORD [password to try]`
   * The default Teradata credentials are the matching username and password 'dbc'.
8. Do: `run`

```
msf > use auxiliary/scanner/teradata/teradata_odbc_login
msf auxiliary(scanner/teradata/teradata_odbc_login) > set RHOSTS 192.168.0.2
RHOSTS => 192.168.0.2
msf auxiliary(scanner/teradata/teradata_odbc_login) > set USERNAME dbc
USERNAME => dbc
msf auxiliary(scanner/teradata/teradata_odbc_login) > set PASSWORD dbc
PASSWORD => dbc
msf auxiliary(scanner/teradata/teradata_odbc_login) > run

[*] Running for 192.168.0.2...
[*] 192.168.0.2:1025 - Creating connection: %s
[*] 192.168.0.2:1025 - Loading ODBC Library: %s
[*] 192.168.0.2:1025 - Method succeeded with info:  [26] 523 24
[*] 192.168.0.2:1025 - Method succeeded with info:  [26] 523 24
[*] 192.168.0.2:1025 - Available drivers: Teradata Database ODBC Driver 16.20, 
[*] 192.168.0.2:1025 - Creating connection using ODBC ConnectString: %s
[*] 192.168.0.2:1025 - Setting AUTOCOMMIT to %s
[*] 192.168.0.2:1025 - FETCH_SIZE: 1
[*] 192.168.0.2:1025 - Buffer size for column %s: %s
[*] 192.168.0.2:1025 - SELECT SESSION returned %s
[*] 192.168.0.2:1025 - Executing query on session %s using SQLExecDirectW: %s
[*] 192.168.0.2:1025 - Committing transaction...
[*] 192.168.0.2:1025 - Created session %s.
[*] 192.168.0.2:1025 - Creating cursor %s for session %s.
[*] 192.168.0.2:1025 - Connection successful. Duration: %.3f seconds. Details: %s
[*] 192.168.0.2:1025 - Closing cursor %s for session %s.
[*] 192.168.0.2:1025 - Closing session %s...
[*] 192.168.0.2:1025 - Session %s closed.
[+] 192.168.0.2:1025 - [1/1] - dbc:dbc - Success
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

## Verification for teradata_odbc_sql
1. Deploy a [Teradata Express](https://www.teradata.com/products-and-services/teradata-express) test environment.
2. Install the OBCD driver and python package.
3. Start msfconsole.
4. Do: `use auxiliary/admin/teradata/teradata_odbc_sql`
5. Do: `set RHOSTS [IPs]`
6. Do: `set USERNAME [username to try]`
7. Do: `set PASSWORD [password to try]`
   * The default Teradata credentials are the matching username and password 'DBC'.
8. Set a SQL query for the 'SQL' option.
   * The default is `SELECT DATABASENAME FROM DBC.DATABASES`
9. Do: `run`

```
msf > use auxiliary/admin/teradata/teradata_odbc_sql 
msf auxiliary(admin/teradata/teradata_odbc_sql) > show options

Module options (auxiliary/admin/teradata/teradata_odbc_sql):

   Name      Current Setting                         Required  Description
   ----      ---------------                         --------  -----------
   PASSWORD  dbc                                     yes       Password
   RHOSTS                                            yes       The target address range or CIDR identifier
   SQL       SELECT DATABASENAME FROM DBC.DATABASES  yes       SQL query to perform
   THREADS   1                                       yes       The number of concurrent threads
   USERNAME  dbc                                     yes       Username

msf auxiliary(admin/teradata/teradata_odbc_sql) > set RHOSTS 192.168.0.2
RHOSTS => 192.168.0.2
msf auxiliary(admin/teradata/teradata_odbc_sql) > run

[*] Running for 192.168.0.2...
[*] 192.168.0.2 - dbc:dbc - Starting
[*] 192.168.0.2 - Creating connection: %s
[*] 192.168.0.2 - Loading ODBC Library: %s
[*] 192.168.0.2 - Available drivers: Teradata Database ODBC Driver 16.20, 
[*] 192.168.0.2 - Connection successful. Duration: %.3f seconds. Details: %s
[+] 192.168.0.2 - dbc:dbc - Login Successful
[*] 192.168.0.2 - Starting - SELECT DATABASENAME FROM DBC.DATABASES
[*] 192.168.0.2 - Query Successful. Duration: %.3f seconds,%sQuery: %s%s
[+] 192.168.0.2 - Row 1: [DatabaseUser                  ]
[+] 192.168.0.2 - Row 2: [All                           ]
[+] 192.168.0.2 - Row 3: [SYSJDBC                       ]
[+] 192.168.0.2 - Row 4: [TDStats                       ]
[+] 192.168.0.2 - Row 5: [TD_SYSXML                     ]
[+] 192.168.0.2 - Row 6: [PUBLIC                        ]
[+] 192.168.0.2 - Row 7: [DBC                           ]
[+] 192.168.0.2 - Row 8: [SYSBAR                        ]
[+] 192.168.0.2 - Row 9: [TD_SYSGPL                     ]
[+] 192.168.0.2 - Row 10: [SYSLIB                        ]
[+] 192.168.0.2 - Row 11: [SQLJ                          ]
[+] 192.168.0.2 - Row 12: [LockLogShredder               ]
[+] 192.168.0.2 - Row 13: [Default                       ]
[+] 192.168.0.2 - Row 14: [TDPUSER                       ]
[+] 192.168.0.2 - Row 15: [TD_SYSFNLIB                   ]
[+] 192.168.0.2 - Row 16: [EXTUSER                       ]
[+] 192.168.0.2 - Row 17: [tdwm                          ]
[+] 192.168.0.2 - Row 18: [SystemFe                      ]
[+] 192.168.0.2 - Row 19: [External_AP                   ]
[+] 192.168.0.2 - Row 20: [TDQCD                         ]
[+] 192.168.0.2 - Row 21: [dbcmngr                       ]
[+] 192.168.0.2 - Row 22: [Sys_Calendar                  ]
[+] 192.168.0.2 - Row 23: [SysAdmin                      ]
[+] 192.168.0.2 - Row 24: [TD_SERVER_DB                  ]
[+] 192.168.0.2 - Row 25: [TDMaps                        ]
[+] 192.168.0.2 - Row 26: [SYSUDTLIB                     ]
[+] 192.168.0.2 - Row 27: [Crashdumps                    ]
[+] 192.168.0.2 - Row 28: [SYSSPATIAL                    ]
[+] 192.168.0.2 - Row 29: [MyUser                        ]
[+] 192.168.0.2 - Row 30: [SYSUIF                        ]
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```