### PR TITLE
Fix bug and enhance tab completion

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -2148,19 +2148,16 @@ class Core
     end
 
     # Is this option used by the active module?
-    if (mod.options.include?(opt))
-      res.concat(option_values_dispatch(mod.options[opt], str, words))
-    elsif (mod.options.include?(opt.upcase))
-      res.concat(option_values_dispatch(mod.options[opt.upcase], str, words))
+    mod.options.each_key do |key|
+      res.concat(option_values_dispatch(mod.options[key], str, words)) if key.downcase == opt.downcase
     end
 
     # How about the selected payload?
     if (mod.exploit? and mod.datastore['PAYLOAD'])
-      p = framework.payloads.create(mod.datastore['PAYLOAD'])
-      if (p and p.options.include?(opt))
-        res.concat(option_values_dispatch(p.options[opt], str, words))
-      elsif (p and p.options.include?(opt.upcase))
-        res.concat(option_values_dispatch(p.options[opt.upcase], str, words))
+      if p = framework.payloads.create(mod.datastore['PAYLOAD'])
+        p.options.each_key do |key|
+          res.concat(option_values_dispatch(p.options[key], str, words)) if key.downcase == opt.downcase
+        end
       end
     end
 

--- a/lib/rex/ui/text/dispatcher_shell.rb
+++ b/lib/rex/ui/text/dispatcher_shell.rb
@@ -380,7 +380,7 @@ module DispatcherShell
 
     # Verify that our search string is a valid regex
     begin
-      Regexp.compile(str)
+      Regexp.compile(str,Regexp::IGNORECASE)
     rescue RegexpError
       str = Regexp.escape(str)
     end
@@ -390,7 +390,7 @@ module DispatcherShell
 
     # Match based on the partial word
     items.find_all { |e|
-      e =~ /^#{str}/
+      e =~ /^#{str}/i
     # Prepend the rest of the command (or it all gets replaced!)
     }.map { |e|
       tab_words.dup.push(e).join(' ')


### PR DESCRIPTION
I found when I want to use `tab` to auto complete command, there is no action, such as `set exitonsession <double tab>`. 
I want it would prompt me for available value.
And also, the command  `get/unset/setg autoloadst <tab>`  didn't complete the whole command to `autoloadstdapi`.
So I fixed the bug.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use exploit/multi/handler`
- [x] `set payload windows/meterpreter/reverse_tcp`
- [x] `set exitonsession <tab>`   

output:  `set exitonsession false  set exitonsession true`
- [x] `get autol <tab>`  

output: `get AutoLoadStdapi `
