### PR TITLE
Add Lync Subdomain Wordlist

### DIFF
--- a/data/wordlists/lync_subdomains.txt
+++ b/data/wordlists/lync_subdomains.txt
@@ -1,0 +1,11 @@
+dialin
+meet
+lyncdiscover
+dialin
+access
+lync
+lyncext
+lyncaccess01
+lyncaccess
+lync10
+lyncweb

--- a/data/wordlists/lync_subdomains.txt
+++ b/data/wordlists/lync_subdomains.txt
@@ -1,11 +1,10 @@
-dialin
-meet
-lyncdiscover
-dialin
 access
+dialin
 lync
-lyncext
-lyncaccess01
-lyncaccess
 lync10
+lyncaccess
+lyncaccess01
+lyncdiscover
+lyncext
 lyncweb
+meet


### PR DESCRIPTION
Adds a wordlist for possible Lync subdomains.
The list is from the [lyncsmash](https://github.com/nyxgeek/lyncsmash) tool and can be used in framework with the enum_dns module.

## Verification

- [x] `./msfconsole`
- [x] `use auxiliary/gather/enum_dns`
- [x] `set domain <domain>`
- [x] `set enum_brt true`
- [x] `set wordlist data/wordlists/lync_subdomains.txt`
- [x] `run`