### PR TITLE
Fix typos and spacing

### DIFF
--- a/lib/anemone/core.rb
+++ b/lib/anemone/core.rb
@@ -298,10 +298,10 @@ module Anemone
     #
     # Kills all active threads
     #
-  def shutdown
-      @tentacles.each {|t| t.kill rescue nil }
-      @pages = nil
-  end
+    def shutdown
+        @tentacles.each {|t| t.kill rescue nil }
+        @pages = nil
+    end
 
   end
 end

--- a/lib/anemone/core.rb
+++ b/lib/anemone/core.rb
@@ -299,8 +299,8 @@ module Anemone
     # Kills all active threads
     #
     def shutdown
-        @tentacles.each {|t| t.kill rescue nil }
-        @pages = nil
+      @tentacles.each {|t| t.kill rescue nil }
+      @pages = nil
     end
 
   end

--- a/lib/rbmysql/charset.rb
+++ b/lib/rbmysql/charset.rb
@@ -164,7 +164,7 @@ class RbMysql
 
     if defined? Encoding
 
-      # MySQL Charset -> Ruby's Encodeing
+      # MySQL Charset -> Ruby's Encoding
       CHARSET_ENCODING = {
         "armscii8" => nil,
         "ascii"    => Encoding::US_ASCII,
@@ -208,7 +208,7 @@ class RbMysql
         value.dup.force_encoding Encoding::ASCII_8BIT
       end
 
-      # retrun corresponding Ruby encoding
+      # return corresponding Ruby encoding
       # === Return
       # encoding [Encoding]
       def encoding
@@ -217,7 +217,7 @@ class RbMysql
         enc
       end
 
-      # convert encoding to corrensponding to MySQL charset
+      # convert encoding corresponding to MySQL charset
       def convert(value)
         if value.is_a? String and value.encoding != Encoding::ASCII_8BIT
           value = value.encode encoding


### PR DESCRIPTION
1. Fixed a few typos in `lib/rbmysql/charset.rb`
2. Fixed the spacing of the last method in `lib/anemone/core.rb`

I know these are super minor things, especially No. 2, but I thought I'd fix them.
Concerning No. 1, I also changed the sentence a little at line No. 220 (It talks about using the charset encoding that is returned when called the method #encoding which is right before it)
