### PR TITLE
Fix bug when use command load and migrate.

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
@@ -1059,6 +1059,12 @@ class Console::CommandDispatcher::Core
       end
     end
 
+    # we cannot migrate to another process until loaded stdapi
+    unless extensions.include?('stdapi')
+      print_error('Stdapi extension must be loaded.')
+      return
+    end
+
     unless pid
       unless (pid = args.first)
         print_error('A process ID or name argument must be provided')
@@ -1147,7 +1153,7 @@ class Console::CommandDispatcher::Core
       case opt
       when '-l'
         exts = SortedSet.new
-        if !client.sys.config.sysinfo['BuildTuple'].blank?
+        if extensions.include?('stdapi') && !client.sys.config.sysinfo['BuildTuple'].blank?
           # Use API to get list of extensions from the gem
           exts.merge(MetasploitPayloads::Mettle.available_extensions(client.sys.config.sysinfo['BuildTuple']))
         else
@@ -1217,7 +1223,7 @@ class Console::CommandDispatcher::Core
 
   def cmd_load_tabs(str, words)
     tabs = SortedSet.new
-    if !client.sys.config.sysinfo['BuildTuple'].blank?
+    if extensions.include?('stdapi') && !client.sys.config.sysinfo['BuildTuple'].blank?
       # Use API to get list of extensions from the gem
       MetasploitPayloads::Mettle.available_extensions(client.sys.config.sysinfo['BuildTuple']).each { |f|
         if !extensions.include?(f.split('.').first)


### PR DESCRIPTION
I fix a bug that meterpreter would crash or report some error, when it didn't load `stdapi` extension module.

## Details  

Got a meterpreter session, but it didn't load `stdapi` because of the bad network or something else.
So I want to see the extension list which it could load  via `load <double tab>` command. 
Oops, the msf throw a exception and meterpreter session crashed.

![image](https://user-images.githubusercontent.com/22535454/41147255-7c4a5df8-6b38-11e8-8163-fdc6862bfe3f.png)

I check the resource code and want to found the reason.

```
line 1218 in file lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb

 def cmd_load_tabs(str, words)
    tabs = SortedSet.new
    if !client.sys.config.sysinfo['BuildTuple'].blank?
      # Use API to get list of extensions from the gem
      MetasploitPayloads::Mettle.available_extensions(client.sys.config.sysinfo['BuildTuple']).each { |f|
        if !extensions.include?(f.split('.').first)
          tabs.add(f)
        end
      }
```
The method `client.sys.config` depends on `stdapi` extension, no code here to check if it have loaded it.

And command `load -l` and `migrate -P xxxx` have the same problem.

## Verification

- [x] Start `msfconsole`
- [x] `set lhost x.x.x.x`
- [x] `set payload windows/meterpreter/reverse_tcp`
- [x] `set autoloadstdapi false`
- [x] `exploit -j` 

Got a meterpreter session. 

- [x] `session -i 1`

`meterpreter > load <double tab>` 

Crashed.


