### PR TITLE
Improve #sec_to_s in Rex::ExtTime

### DIFF
--- a/lib/rex/time.rb
+++ b/lib/rex/time.rb
@@ -11,6 +11,7 @@ module Rex
     # minutes, and second.
     #
     def self.sec_to_s(seconds)
+      return "0 secs" if seconds.to_i <= 0
       [[31536000, 'year'], [86400, 'day'], [3600, 'hour'], [60, 'min'], [1, 'sec']].map! { |count, name|
         if (c = seconds / count) > 0
           c = c.truncate

--- a/lib/rex/time.rb
+++ b/lib/rex/time.rb
@@ -11,24 +11,17 @@ module Rex
     # minutes, and second.
     #
     def self.sec_to_s(seconds)
-      parts = [31536000, 86400, 3600, 60, 1].map do |d|
-        if (c = seconds / d) > 0
-          seconds -= c.truncate * d
-          c.truncate
-        else
-          0
+      [[31536000, 'year'], [86400, 'day'], [3600, 'hour'], [60, 'min'], [1, 'sec']].map! { |count, name|
+        if (c = seconds / count) > 0
+          c = c.truncate
+          seconds -= c * count
+          if c == 1
+            "#{c} #{name}"
+          elsif c > 1
+            "#{c} #{name}s"
+          end
         end
-      end
-
-      str = ''
-
-      ['year', 'day', 'hour', 'min', 'sec'].each_with_index do |name, idx|
-        next if !parts[idx] || parts[idx].zero?
-
-        str << "#{parts[idx]} #{name + ((parts[idx] != 1) ? 's' : '')} "
-      end
-
-      str.empty? ? "0 secs" : str.strip
+      }.compact.join(' ')
     end
   end
 end


### PR DESCRIPTION
Using the following implementation yields roughly ~1.5x speedup in my tests.

## Benchmark
```ruby
require "benchmark/ips"

def fast(seconds)
  return "0 secs" if seconds.to_i <= 0
  [[31536000, 'year'], [86400, 'day'], [3600, 'hour'], [60, 'min'], [1, 'sec']].map! { |count, name|
    if (c = seconds / count) > 0
      c = c.truncate
      seconds -= c * count
      if c == 1
        "#{c} #{name}"
      elsif c > 1
        "#{c} #{name}s"
      end
    end
  }.compact.join(' ')
end

def slow(seconds)
  parts = [31536000, 86400, 3600, 60, 1].map do |d|
    if (c = seconds / d) > 0
      seconds -= c.truncate * d
      c.truncate
    else
      0
    end
  end

  str = ''

  ['year', 'day', 'hour', 'min', 'sec'].each_with_index do |name, idx|
    next if !parts[idx] || parts[idx].zero?

    str << "#{parts[idx]} #{name + ((parts[idx] != 1) ? 's' : '')} "
  end

  str.empty? ? "0 secs" : str.strip
end

Benchmark.ips do |x|
  x.report("faster") { fast(1000) }
  x.report("slower") { slow(1000) }
  x.compare!
end
```

## Results
```
Warming up --------------------------------------
              faster    21.604k i/100ms
              slower    13.744k i/100ms
Calculating -------------------------------------
              faster    229.276k (± 6.7%) i/s -      1.145M in   5.015618s
              slower    152.041k (± 8.7%) i/s -    755.920k in   5.012683s

Comparison:
              faster:   229275.6 i/s
              slower:   152041.2 i/s - 1.51x  slower
```
