### PR TITLE
Fix missing RequestError in a few post modules

### DIFF
--- a/modules/post/linux/gather/pptpd_chap_secrets.rb
+++ b/modules/post/linux/gather/pptpd_chap_secrets.rb
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Post
   def load_file(fname)
     begin
       data = cmd_exec("cat #{fname}")
-    rescue RequestError => e
+    rescue Rex::Post::Meterpreter::RequestError => e
       print_error("Failed to retrieve file. #{e.message}")
       data = ''
     end

--- a/modules/post/windows/gather/screen_spy.rb
+++ b/modules/post/windows/gather/screen_spy.rb
@@ -75,7 +75,7 @@ class MetasploitModule < Msf::Post
         select(nil, nil, nil, datastore['DELAY'])
         begin
           data = session.espia.espia_image_get_dev_screen
-        rescue RequestError => e
+        rescue Rex::Post::Meterpreter::RequestError => e
           print_error("Error taking the screenshot: #{e.class} #{e} #{e.backtrace}")
           return false
         end

--- a/modules/post/windows/manage/inject_host.rb
+++ b/modules/post/windows/manage/inject_host.rb
@@ -43,7 +43,7 @@ class MetasploitModule < Msf::Post
     begin
       # Download the remote file to the temporary file
       client.fs.file.download_file(temp_path, 'C:\\WINDOWS\\System32\\drivers\\etc\\hosts')
-    rescue RequestError => re
+    rescue Rex::Post::Meterpreter::RequestError => re
       # If the file doesn't exist, then it's okay.  Otherwise, throw the
       # error.
       if re.result != 2


### PR DESCRIPTION
Should be `Rex::Post::Meterpreter::RequestError`.

- [x] `pry` a module
- [x] `RequestError` returns `NameError`
- [x] `Rex::Post::Meterpreter::RequestError` doesn't
- [x] Test it for real if you can

Fixes #10161.