### PR TITLE
bump and unlock rex-powershell, fix Windows 10 support for rex-powershell

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,7 +49,7 @@ PATH
       rex-mime
       rex-nop
       rex-ole
-      rex-powershell (< 0.1.78)
+      rex-powershell
       rex-random_identifier
       rex-registry
       rex-rop_builder
@@ -258,7 +258,7 @@ GEM
       rex-arch
     rex-ole (0.1.6)
       rex-text
-    rex-powershell (0.1.77)
+    rex-powershell (0.1.78)
       rex-random_identifier
       rex-text
     rex-random_identifier (0.1.4)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -142,7 +142,7 @@ Gem::Specification.new do |spec|
   # Library for Generating Randomized strings valid as Identifiers such as variable names
   spec.add_runtime_dependency 'rex-random_identifier'
   # library for creating Powershell scripts for exploitation purposes
-  spec.add_runtime_dependency 'rex-powershell', ["< 0.1.78"]
+  spec.add_runtime_dependency 'rex-powershell'
   # Library for processing and creating Zip compatbile archives
   spec.add_runtime_dependency 'rex-zip'
   # Library for parsing offline Windows Registry files


### PR DESCRIPTION
This fixes #10032 updating rex-powershell with https://github.com/rapid7/rex-powershell/pull/12, updating GetMethod for GetProcAddress for Windows 10 1803

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `payload windows/powershell_reverse_tcp` works on Windows 10 1803
- [x] `payload windows/x64/powershell_reverse_tcp` works on Windows 10 1803
