### PR TITLE
Add command for persistent job handler when msf restart

### DIFF
--- a/lib/msf/base/config.rb
+++ b/lib/msf/base/config.rb
@@ -202,6 +202,13 @@ class Config < Hash
     self.new.history_file
   end
 
+  # Returns the full path to the handler file.
+  #
+  # @return [String] path the handler file.
+  def self.persist_file
+    self.new.persist_file
+  end
+
   # Initializes configuration, creating directories as necessary.
   #
   # @return [void]
@@ -276,6 +283,13 @@ class Config < Hash
   # @return [String] path the history file.
   def history_file
     config_directory + FileSep + "history"
+  end
+
+  # Returns the full path to the handler file.
+  #
+  # @return [String] path the handler file.
+  def persist_file
+    config_directory + FileSep + "persist"
   end
 
   # Returns the global module directory.

--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -768,7 +768,11 @@ class ReadableText
 
     # Get the persistent job info.
     if verbose
-      persist_list = JSON.parse(File.read(Msf::Config.persist_file)) rescue []
+      begin
+        persist_list = JSON.parse(File.read(Msf::Config.persist_file))
+      rescue Errno::ENOENT, JSON::ParserError
+        persist_list = []
+      end
     end
 
     # jobs are stored as a hash with the keys being a numeric String job_id.

--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -768,8 +768,7 @@ class ReadableText
 
     # Get the persistent job info.
     if verbose
-      persist_list = File.open(Msf::Config.persist_file,"r").readlines.map!(&:chomp) rescue nil
-      persist_list.map!{|handler|JSON.parse(handler)}
+      persist_list = JSON.parse(File.read(Msf::Config.persist_file)) rescue []
     end
 
     # jobs are stored as a hash with the keys being a numeric String job_id.

--- a/lib/msf/ui/console/command_dispatcher/jobs.rb
+++ b/lib/msf/ui/console/command_dispatcher/jobs.rb
@@ -38,12 +38,20 @@ module Msf
             "-S" => [ true, "Row search filter."                              ],
           )
 
+          @@persist_opts = Rex::Parser::Arguments.new(
+            "-h" => [ false, "Help banner."                                   ],
+            "-C" => [ false, "Clean all persistent jobs."                     ],
+            "-a" => [ true,  "Add a persistent job by job ID"                 ],
+            "-l" => [ false, "List all persistent jobs."                      ]
+          )
+
           def commands
             {
               "jobs"       => "Displays and manages jobs",
               "rename_job" => "Rename a job",
               "kill"       => "Kill a job",
-              "handler"    => "Start a payload handler as job"
+              "handler"    => "Start a payload handler as job",
+              "persist"    => "Displays and manages persistent jobs"
             }
           end
 
@@ -159,6 +167,7 @@ module Msf
                 cmd_jobs_help
                 return false
               end
+
             end
 
             if dump_list
@@ -354,6 +363,110 @@ module Msf
             }
             tab_complete_generic(fmt, str, words)
           end
+
+          def cmd_persist_help
+            print_line "Usage: persist [options]"
+            print_line
+            print_line "Persist job manipulation and interaction."
+            print @@persist_opts.usage
+          end
+
+          #
+          # Displays and manages persistent jobs for the framework.
+          #
+
+          def cmd_persist(*args)
+            # Make the default behavior listing all jobs if there were no options
+            # or the only option is the verbose flag
+            args.unshift("-l") if args.empty?
+
+            persist_file = Msf::Config.persist_file
+            verbose = false
+            dump_list = false
+            dump_info = false
+            job_id = nil
+            persistence = false
+
+            # Parse the command options
+            @@persist_opts.parse(args) do |opt, _idx, val|
+              case opt
+              when "-l"
+                dump_list = true
+              # Cleaning all persistent jobs
+              when "-C"
+                print_line("Cleaning all persistent jobs...")
+                File.truncate(persist_file,0)
+              # Add persistent job
+              when "-a"
+                job_id = val
+                persistence = true
+              when "-h"
+                cmd_persist_help
+                return false
+              end
+            end
+
+            if dump_list
+              persistent_jobs = File.open(persist_file,"r").readlines.map!(&:chomp) rescue nil
+              print_line("\nPersistent Jobs\n===============\n")
+
+              unless persistent_jobs.blank?
+                persistent_jobs.map!{|job|JSON.parse(job)}
+
+                persistent_jobs.each do |job|
+                  print_line("#{job['mod_name']} - #{job['mod_options']['Payload']} - #{job['mod_options']["Options"]["lhost"]}:#{job['mod_options']["Options"]["LPORT"]}")
+                  print_line
+                end
+              else
+                print_line("No persistent jobs.\n")
+              end
+            end
+
+            if persistence
+              if job_id && framework.jobs.has_key?(job_id.to_s)
+                mod     = framework.jobs[job_id.to_s].ctx[0].replicant
+                payload = framework.jobs[job_id.to_s].ctx[1].replicant
+
+                payload_opts = {
+                  'Payload'        => payload.refname,
+                  'Options'        => payload.datastore,
+                  #'LocalInput'     => driver.input,
+                  #'LocalOutput'    => driver.output,
+                  'RunAsJob'       => true
+                }
+
+                mod_opts =  {
+                  'mod_name'       => mod.fullname,
+                  'mod_options'        => payload_opts
+                }
+
+                File.open(persist_file,"a+"){|file|file.puts(mod_opts.to_json)}
+                print_line("Added job #{job_id} as a persistent_job.")
+              else
+                print_line("Invalid Job ID")
+              end
+              #handler.exploit_simple(payload_opts)
+            end
+          end
+
+
+          #
+          # Tab completion for the persist command
+          #
+          # @param str [String] the string currently being typed before tab was hit
+          # @param words [Array<String>] the previously completed words on the command line.  words is always
+          # at least 1 when tab completion has reached this stage since the command itself has been completed
+
+          def cmd_persist_tabs(_str, words)
+            return @@persist_opts.fmt.keys if words.length == 1
+
+            if words.length == 2 && (@@persist_opts.fmt[words[1]] || [false])[0]
+              return framework.jobs.keys
+            end
+
+            []
+          end
+
         end
       end
     end

--- a/lib/msf/ui/console/command_dispatcher/jobs.rb
+++ b/lib/msf/ui/console/command_dispatcher/jobs.rb
@@ -147,11 +147,17 @@ module Msf
                 job_id = val
               when "-p"
                 job_list = build_range_array(val)
-                job_list.each{|job_id| add_persist_job(job_id)}
+                job_list.each do |job_id|
+                  add_persist_job(job_id)
+                end
               when "-P"
                 print_line("Making all jobs persistent ...")
-                job_list = framework.jobs.map{|k,v|v.jid.to_s}
-                job_list.each{|job_id| add_persist_job(job_id)}
+                job_list = framework.jobs.map do |k,v|
+                  v.jid.to_s
+                end
+                job_list.each do |job_id|
+                  add_persist_job(job_id)
+                end
               when "-S", "--search"
                 search_term = val
                 dump_list = true
@@ -208,7 +214,9 @@ module Msf
                 persist_list.delete_if{|pjob|pjob['mod_options']['Options'] == payload_option}
               end
               # Write persist job back to config file.
-              File.open(Msf::Config.persist_file,"w"){|file| file.puts(JSON.pretty_generate(persist_list))}
+              File.open(Msf::Config.persist_file,"w") do |file|
+                file.puts(JSON.pretty_generate(persist_list))
+              end
 
               # Stop the job by job id.
               job_list.map(&:to_s).each do |job|
@@ -243,9 +251,15 @@ module Msf
                 'mod_options'    => payload_opts
               }
 
-              persist_list = JSON.parse(File.read(Msf::Config.persist_file)) rescue []
+              begin
+                persist_list = JSON.parse(File.read(Msf::Config.persist_file))
+              rescue Errno::ENOENT, JSON::ParserError
+                persist_list = []
+              end
               persist_list << mod_opts
-              File.open(Msf::Config.persist_file,"w"){|file| file.puts(JSON.pretty_generate(persist_list))}
+              File.open(Msf::Config.persist_file,"w") do |file|
+                file.puts(JSON.pretty_generate(persist_list))
+              end
               print_line("Added persistence to job #{job_id}.")
             else
               print_line("Invalid Job ID")

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -189,7 +189,7 @@ class Driver < Msf::Ui::Driver
 
       persistent_handler.each do |handler_opts|
         handler = framework.modules.create(handler_opts['mod_name'])
-        handler.exploit_simple(handler_opts['options'])
+        handler.exploit_simple(handler_opts['mod_options'])
       end
     end
 

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -178,6 +178,22 @@ class Driver < Msf::Ui::Driver
       }
     end
 
+    # Process persistent job handler
+
+    persist_file = Msf::Config.persist_file
+    persistent_handler = File.open(persist_file,"r").readlines.map!(&:chomp) rescue nil
+
+    unless persistent_handler.blank?
+      persistent_handler.map!{|handler|JSON.parse(handler)}
+      print_status("Starting persistent handler...")
+
+      persistent_handler.each do |handler_opts|
+        handler = framework.modules.create(handler_opts['mod_name'])
+        handler.exploit_simple(handler_opts['options'])
+      end
+    end
+
+
     # Process any additional startup commands
     if opts['XCommands'] and opts['XCommands'].kind_of? Array
       opts['XCommands'].each { |c|

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -179,15 +179,13 @@ class Driver < Msf::Ui::Driver
     end
 
     # Process persistent job handler
+    persist_handler = File.open(Msf::Config.persist_file,"r").readlines.map!(&:chomp) rescue nil
 
-    persist_file = Msf::Config.persist_file
-    persistent_handler = File.open(persist_file,"r").readlines.map!(&:chomp) rescue nil
-
-    unless persistent_handler.blank?
-      persistent_handler.map!{|handler|JSON.parse(handler)}
+    unless persist_handler.blank?
+      persist_handler.map!{|handler|JSON.parse(handler)}
       print_status("Starting persistent handler...")
 
-      persistent_handler.each do |handler_opts|
+      persist_handler.each do |handler_opts|
         handler = framework.modules.create(handler_opts['mod_name'])
         handler.exploit_simple(handler_opts['mod_options'])
       end


### PR DESCRIPTION
~## Working in process~

~Add the command `persist`~
According to https://github.com/rapid7/metasploit-framework/projects/6 to update the command `jobs` to support for persistent jobs when console restart.
```
Enable the ability to create a handler description that's persistent, so that when MSF restarts those handlers come alive again.

This is currently "emulated" via the CLI using -r blerp.rc.
```

I know there are many problems to be solved.
I'm glad to receive some suggestions.

## Verification(updated)

```
msf5 exploit(multi/handler) > jobs 

Jobs
====

  Id  Name                    Payload                          Payload opts
  --  ----                    -------                          ------------
  1   Exploit: multi/handler  windows/meterpreter/reverse_tcp  tcp://192.168.77.136:4444

msf5 exploit(multi/handler) > jobs -P
Making all jobs persistent ...
Added job 1 as a persistent_job.
msf5 exploit(multi/handler) > jobs -l

Jobs
====

  Id  Name                    Payload                          Payload opts
  --  ----                    -------                          ------------
  1   Exploit: multi/handler  windows/meterpreter/reverse_tcp  tcp://192.168.77.136:4444

msf5 exploit(multi/handler) > jobs -l -v

Jobs
====

  Id  Name                    Payload                          Payload opts               URIPATH  Start Time                 Handler opts  Persist
  --  ----                    -------                          ------------               -------  ----------                 ------------  -------
  1   Exploit: multi/handler  windows/meterpreter/reverse_tcp  tcp://192.168.77.136:4444           2018-08-07 05:10:41 -0400                true

msf5 exploit(multi/handler) > kill 1 
[*] Stopping the following job(s) and remove their persistence: 1
[*] Stopping job 1
msf5 exploit(multi/handler) > jobs -l -v

Jobs
====

No active jobs.

msf5 exploit(multi/handler) > exploit -j
[*] Exploit running as background job 2.

[*] Started reverse TCP handler on 192.168.77.136:4444 
msf5 exploit(multi/handler) > jobs -l -v

Jobs
====

  Id  Name                    Payload                          Payload opts               URIPATH  Start Time                 Handler opts  Persist
  --  ----                    -------                          ------------               -------  ----------                 ------------  -------
  2   Exploit: multi/handler  windows/meterpreter/reverse_tcp  tcp://192.168.77.136:4444           2018-08-07 05:35:59 -0400                false

```

## Verification(obsolete)

List the steps needed to make sure this thing works

```
[*] Processing ../multi_handler.txt for ERB directives.
resource (../multi_handler.txt)> use exploit/multi/handler
resource (../multi_handler.txt)> set lhost 192.168.77.141
lhost => 192.168.77.141
resource (../multi_handler.txt)> set payload windows/meterpreter/reverse_tcp
payload => windows/meterpreter/reverse_tcp
resource (../multi_handler.txt)> set exitonsession false
exitonsession => false
msf5 exploit(multi/handler) > exploit -j
[*] Exploit running as background job 0.

[*] Started reverse TCP handler on 192.168.77.141:4444 
msf5 exploit(multi/handler) > jobs 

Jobs
====

  Id  Name                    Payload                          Payload opts
  --  ----                    -------                          ------------
  0   Exploit: multi/handler  windows/meterpreter/reverse_tcp  tcp://192.168.77.141:4444

msf5 exploit(multi/handler) > persist 

Persistent Jobs
===============

No persistent jobs.

msf5 exploit(multi/handler) > persist -a 0 
Added job 0 as a persistent_job.
msf5 exploit(multi/handler) > persist 

Persistent Jobs
===============

exploit/multi/handler - windows/meterpreter/reverse_tcp - 192.168.77.141:4444

msf5 exploit(multi/handler) > exit

$ ./msfconsole                        
[-] ***rting the Metasploit Framework console...|
[-] * WARNING: No database support: No database YAML file
[-] ***
                                                 

       =[ metasploit v5.0.0-dev-0145744255                ]
+ -- --=[ 1778 exploits - 1011 auxiliary - 308 post       ]
+ -- --=[ 538 payloads - 41 encoders - 10 nops            ]
+ -- --=[ ** This is Metasploit 5 development branch **   ]

[*] Starting persistent handler...
msf5 > jobs 

Jobs
====

  Id  Name                    Payload                          Payload opts
  --  ----                    -------                          ------------
  0   Exploit: multi/handler  windows/meterpreter/reverse_tcp  tcp://192.168.77.141:4444

msf5 > 

```


