### PR TITLE
Update cached payload size update to support IPv6

### DIFF
--- a/modules/payloads/singles/linux/x86/shell_reverse_tcp_ipv6.rb
+++ b/modules/payloads/singles/linux/x86/shell_reverse_tcp_ipv6.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 167
+  CachedSize = 158
 
   include Msf::Payload::Single
   include Msf::Payload::Linux


### PR DESCRIPTION
At time of writing, a payload module has a `6` in the name if and only if it uses IPv6. We can use this to make the cached size updater use IPv6 addresses when generating those payloads while we think of more long-term solution to requiring/coercing certain address formats (`OptAddress` subclasses?)

## Verification
- [ ] `./tools/modules/update_payload_cached_sizes.rb` should run without errors