### PR TITLE
bind_named_pipe fixed for simpleclient versions param

### DIFF
--- a/lib/msf/core/payload/windows/bind_named_pipe.rb
+++ b/lib/msf/core/payload/windows/bind_named_pipe.rb
@@ -286,11 +286,11 @@ module Payload::Windows::BindNamedPipe
 
       ; something failed so free up memory
         pop ecx
-        push 0x4000             ; MEM_DECOMMIT
+        push 0x8000             ; MEM_RELEASE
         push 0                  ; dwSize, 0 to decommit whole block
         push ecx                ; lpAddress
         push #{Rex::Text.block_api_hash('kernel32.dll', 'VirtualFree')}
-        call ebp                ; VirtualFree(payload, 0, MEM_DECOMMIT)
+        call ebp                ; VirtualFree(payload, 0, MEM_RELEASE)
 
       cleanup_file:
       ; cleanup the pipe handle

--- a/lib/msf/core/payload/windows/x64/bind_named_pipe.rb
+++ b/lib/msf/core/payload/windows/x64/bind_named_pipe.rb
@@ -296,12 +296,12 @@ module Payload::Windows::BindNamedPipe_x64
       ; something failed so free up memory
         push r15
         pop rcx                 ; lpAddress
-        push 0x4000             ; MEM_DECOMMIT
+        push 0x8000             ; MEM_RELEASE
         pop r8                  ; dwFreeType
         push 0                  ; 0 to decommit whole block
         pop rdx                 ; dwSize
         mov r10d, #{Rex::Text.block_api_hash('kernel32.dll', 'VirtualFree')}
-        call rbp                ; VirtualFree(payload, 0, MEM_DECOMMIT)
+        call rbp                ; VirtualFree(payload, 0, MEM_RELEASE)
 
       cleanup_file:
       ; clean up the pipe handle


### PR DESCRIPTION
Update to bind_named_pipe handler to work with latest simpleclient. Adding the versions parameter broke the payload and it has been added to force SMB1 (module requires rex).

This also adds a fix for not properly releasing stage 2 shellcode on error.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use exploit/windows/smb/psexec`
- [x] `set payload windows/meterpreter/bind_named_pipe`
- [x] Set options and run
- [x] `meterpreter>`

Fixes #10173