### PR TITLE
Rescue RubySMB Error that occurs when scanning a macOS SMB server

### DIFF
--- a/lib/metasploit/framework/login_scanner/smb.rb
+++ b/lib/metasploit/framework/login_scanner/smb.rb
@@ -134,6 +134,9 @@ module Metasploit
             proof = e
           rescue RubySMB::Error::UnexpectedStatusCode => e
             status = Metasploit::Model::Login::Status::INCORRECT
+          rescue RubySMB::Error::NetBiosSessionService => e
+            status = Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
+            proof = e
           ensure
             client.disconnect!
           end

--- a/lib/metasploit/framework/login_scanner/smb.rb
+++ b/lib/metasploit/framework/login_scanner/smb.rb
@@ -129,14 +129,11 @@ module Metasploit
               else
                 status = Metasploit::Model::Login::Status::INCORRECT
             end
-          rescue ::Rex::ConnectionError, Errno::EINVAL => e
+          rescue ::Rex::ConnectionError, Errno::EINVAL, RubySMB::Error::NetBiosSessionService => e
             status = Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
             proof = e
           rescue RubySMB::Error::UnexpectedStatusCode => e
             status = Metasploit::Model::Login::Status::INCORRECT
-          rescue RubySMB::Error::NetBiosSessionService => e
-            status = Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
-            proof = e
           ensure
             client.disconnect!
           end


### PR DESCRIPTION
This catches a ruby_smb error that is thrown when scanning an OSX SMB server.

## Verification

- [x] `./msfconsole`
- [x] `use use auxiliary/scanner/smb/smb_login`
- [x] `set rhosts <rhosts>`
- [x] `set smbuser <user>`
- [x] `set smbpass <pass>`
- [x] `run`