### PR TITLE
don't call print_error from rex context, use elog instead

### DIFF
--- a/lib/rex/proto/dcerpc/svcctl/packet.rb
+++ b/lib/rex/proto/dcerpc/svcctl/packet.rb
@@ -56,7 +56,7 @@ class Client
         end
       end
     rescue Rex::Proto::DCERPC::Exceptions::Fault => e
-      print_error("Error getting scm handle: #{e}")
+      elog("Error getting scm handle: #{e}")
     end
 
     [scm_handle, scm_status]
@@ -120,7 +120,7 @@ class Client
     begin
       response = dcerpc_client.call(CREATE_SERVICE_W, stubdata)
     rescue Rex::Proto::DCERPC::Exceptions::Fault => e
-      print_error("Error creating service: #{e}")
+      elog("Error creating service: #{e}")
     end
 
     if response
@@ -152,7 +152,7 @@ class Client
       response = dcerpc_client.call(CHANGE_SERVICE_CONFIG2_W, stubdata) # ChangeServiceConfig2
       svc_status = error_code(response)
     rescue Rex::Proto::DCERPC::Exceptions::Fault => e
-      print_error("Error changing service description : #{e}")
+      elog("Error changing service description : #{e}")
     end
 
     svc_status
@@ -172,7 +172,7 @@ class Client
         svc_status = error_code(response)
       end
     rescue Rex::Proto::DCERPC::Exceptions::Fault => e
-      print_error("Error closing service handle: #{e}")
+      elog("Error closing service handle: #{e}")
     end
 
     svc_status
@@ -198,7 +198,7 @@ class Client
         end
       end
     rescue Rex::Proto::DCERPC::Exceptions::Fault => e
-      print_error("Error opening service handle: #{e}")
+      elog("Error opening service handle: #{e}")
     end
 
     svc_handle
@@ -222,7 +222,7 @@ class Client
         svc_status = error_code(response)
       end
     rescue Rex::Proto::DCERPC::Exceptions::Fault => e
-      print_error("Error starting service: #{e}")
+      elog("Error starting service: #{e}")
     end
 
     svc_status
@@ -252,7 +252,7 @@ class Client
        svc_status =  error_code(response[28,4])
       end
     rescue Rex::Proto::DCERPC::Exceptions::Fault => e
-      print_error("Error controlling service: #{e}")
+      elog("Error controlling service: #{e}")
     end
 
     svc_status
@@ -271,7 +271,7 @@ class Client
         svc_status = error_code(response)
       end
     rescue Rex::Proto::DCERPC::Exceptions::Fault => e
-      print_error("Error deleting service: #{e}")
+      elog("Error deleting service: #{e}")
     end
 
     svc_status
@@ -295,7 +295,7 @@ class Client
         ret = 2
       end
     rescue Rex::Proto::DCERPC::Exceptions::Fault => e
-      print_error("Error deleting service: #{e}")
+      elog("Error deleting service: #{e}")
     end
 
     ret


### PR DESCRIPTION
This prevents exception handlers in dcerpc client from actually logging their errors. Change them to elog instead. Noted while debugging a different issue.

## Verification 

- [x] Start `msfconsole`
- [x] Encounter an exception in DCERPC client (for instance, monkey with disabling the SCM Handler)
- [x] **Verify** that an exception gets logged to framework.log

Not this:
```
[*] 192.168.56.103:445 - Creating the service...
[-] 192.168.56.103:445 - Exploit failed: NoMethodError undefined method `print_error' for #<Rex::Proto::DCERPC::SVCCTL::Client:0x00007fb6b92c8428>
[*] Exploit completed, but no session was created.
```

But this:
```
[*] 192.168.56.103:445 - Creating the service...
[-] 192.168.56.103:445 - Exploit failed: ArgumentError Cannot compare a WindowsError::ErrorCode to a NilClass
[*] Exploit completed, but no session was created.
```
