### PR TITLE
Increase read depth for smb pipes

### DIFF
--- a/lib/rex/proto/smb/simpleclient/open_file.rb
+++ b/lib/rex/proto/smb/simpleclient/open_file.rb
@@ -50,7 +50,7 @@ module Rex::Proto::SMB
           begin
             data = client.read(file_id, offset, length).pack('C*')
           rescue RubySMB::Error::UnexpectedStatusCode => e
-            if e.message == 'STATUS_PIPE_EMPTY' && depth < 2
+            if e.message == 'STATUS_PIPE_EMPTY' && depth < 20
               data = read_ruby_smb(length, offset, depth + 1)
             else
               raise e


### PR DESCRIPTION
Increase tolerance for STATUS_PIPE_EMPTY messages when reading over smb.

## Verification

- [x] `./msfconsole -q`
- [x] `use exploit/windows/smb/psexec`
- [x] `set rhosts <rhost>`
- [x] `set smbuser <user>`
- [x] `set smbpass <pass>`
- [x] `run`
- [x] Might get a failed error because of STATUS_PIPE_EMPTY.
- [x] Increase depth should make the exploit more reliable.