### PR TITLE
Add more verbose printing to bind handlers

### DIFF
--- a/lib/msf/core/handler/bind_named_pipe.rb
+++ b/lib/msf/core/handler/bind_named_pipe.rb
@@ -282,10 +282,9 @@ module Msf
         # Start a new handling thread
         self.listener_threads << framework.threads.spawn("BindNamedPipeHandlerListener-#{pipe_name}", false) {
           sock = nil
-          print_status("Started bind pipe handler")
+          print_status("Started #{human_name} handler against #{rhost}:#{lport}")
 
           # First, create a socket and connect to the SMB service
-          vprint_status("Connecting to #{rhost}:#{lport}")
           begin
             sock = Rex::Socket::Tcp.create(
               'PeerHost' => rhost,
@@ -297,8 +296,9 @@ module Msf
                 'MsfPayload' => self,
                 'MsfExploit' => assoc_exploit
               })
-          rescue Rex::ConnectionRefused
-          rescue ::Exception
+          rescue Rex::ConnectionError => e
+            vprint_error(e.message)
+          rescue
             wlog("Exception caught in bind handler: #{$!.class} #{$!}")
           end
 

--- a/lib/msf/core/handler/bind_tcp.rb
+++ b/lib/msf/core/handler/bind_tcp.rb
@@ -30,6 +30,13 @@ module BindTcp
     "bind"
   end
 
+  # A string suitable for displaying to the user
+  #
+  # @return [String]
+  def human_name
+    "bind TCP"
+  end
+
   #
   # Initializes a bind handler and adds the options common to all bind
   # payloads, such as local port.
@@ -102,7 +109,7 @@ module BindTcp
     self.listener_threads << framework.threads.spawn("BindTcpHandlerListener-#{lport}", false) {
       client = nil
 
-      print_status("Started bind handler")
+      print_status("Started #{human_name} handler against #{rhost}:#{lport}")
 
       if (rhost == nil)
         raise ArgumentError,
@@ -124,9 +131,9 @@ module BindTcp
                 'MsfPayload' => self,
                 'MsfExploit' => assoc_exploit
               })
-        rescue Rex::ConnectionRefused
-          # Connection refused is a-okay
-        rescue ::Exception
+        rescue Rex::ConnectionError => e
+          vprint_error(e.message)
+        rescue
           wlog("Exception caught in bind handler: #{$!.class} #{$!}")
         end
 

--- a/lib/msf/core/handler/bind_udp.rb
+++ b/lib/msf/core/handler/bind_udp.rb
@@ -30,6 +30,13 @@ module BindUdp
     "bind"
   end
 
+  # A string suitable for displaying to the user
+  #
+  # @return [String]
+  def human_name
+    "bind UDP"
+  end
+
   #
   # Initializes a bind handler and adds the options common to all bind
   # payloads, such as local port.
@@ -105,7 +112,7 @@ module BindUdp
     self.listener_threads << framework.threads.spawn("BindUdpHandlerListener-#{lport}", false) {
       client = nil
 
-      print_status("Started bind handler")
+      print_status("Started #{human_name} handler against #{rhost}:#{lport}")
 
       if (rhost == nil)
         raise ArgumentError,
@@ -127,9 +134,9 @@ module BindUdp
                 'MsfPayload' => self,
                 'MsfExploit' => assoc_exploit
               })
-        rescue Rex::ConnectionRefused
-          # Connection refused is a-okay
-        rescue ::Exception
+        rescue Rex::ConnectionError => e
+          vprint_error(e.message)
+        rescue
           wlog("Exception caught in bind handler: #{$!.class} #{$!}")
         end
 


### PR DESCRIPTION
Not sure how good this is, but I'm giving it a shot. I want `print_debug` back.

- [x] Test `bind_tcp`
- [x] Test `bind_udp`
- [x] Test `bind_named_pipe`

Thanks to @busterb for prompting this!

# BIG TO-DO

~Find a way to defer starting the handler so we don't get spammed by messages.~ #10267