### PR TITLE
fix undefined method capitalize error for array

### DIFF
--- a/modules/post/multi/gather/jenkins_gather.rb
+++ b/modules/post/multi/gather/jenkins_gather.rb
@@ -20,7 +20,7 @@ class MetasploitModule < Msf::Post
       'License' => MSF_LICENSE,
       'Author' => [ 'thesubtlety' ],
       'Platform' => [ 'linux', 'win' ],
-      'SessionTypes' => [ %w[shell meterpreter] ]
+      'SessionTypes' => %w[shell meterpreter]
     ))
     register_options(
       [  OptBool.new('STORE_LOOT', [false, 'Store files in loot (will simply output file to console if set to false).', true]),


### PR DESCRIPTION
This PR simply removes wrapping array brackets.

Ran into a really dumb issue when I went to use this in an assessment recently. When I wrote this I wrapped the SessionTypes in an array and now that something's trying to capitalize each method, the issue surfaced.

## Issue
```
msf > use multi/gather/jenkins_gather
msf post(multi/gather/jenkins_gather) > info
[-] Error while running command info: undefined method `capitalize' for ["shell", "meterpreter"]:Array

Call stack:
/opt/metasploit-framework/embedded/framework/lib/msf/base/serializer/readable_text.rb:288:in `block in dump_post_module'
/opt/metasploit-framework/embedded/framework/lib/msf/base/serializer/readable_text.rb:287:in `each'
/opt/metasploit-framework/embedded/framework/lib/msf/base/serializer/readable_text.rb:287:in `dump_post_module'
/opt/metasploit-framework/embedded/framework/lib/msf/base/serializer/readable_text.rb:34:in `dump_module'
/opt/metasploit-framework/embedded/framework/lib/msf/ui/console/command_dispatcher/modules.rb:228:in `cmd_info'
/opt/metasploit-framework/embedded/framework/lib/rex/ui/text/dispatcher_shell.rb:546:in `run_command'
/opt/metasploit-framework/embedded/framework/lib/rex/ui/text/dispatcher_shell.rb:508:in `block in run_single'
/opt/metasploit-framework/embedded/framework/lib/rex/ui/text/dispatcher_shell.rb:502:in `each'
/opt/metasploit-framework/embedded/framework/lib/rex/ui/text/dispatcher_shell.rb:502:in `run_single'
/opt/metasploit-framework/embedded/framework/lib/rex/ui/text/shell.rb:208:in `run'
/opt/metasploit-framework/embedded/framework/lib/metasploit/framework/command/console.rb:48:in `start'
/opt/metasploit-framework/embedded/framework/lib/metasploit/framework/command/base.rb:82:in `start'
/opt/metasploit-framework/bin/../embedded/framework/msfconsole:49:in `<main>'
```

## Verification
- [x] Start `msfconsole`
- [x] Run `use multi/gather/jenkins_gather`
- [x] Run `info`

### After Fix
```
msf > use multi/gather/jenkins_gather
msf post(multi/gather/jenkins_gather) > info

       Name: Jenkins Credential Collector
       Module: post/multi/gather/jenkins_gather
       Platform: Linux, Windows
       Arch: 
       Rank: Normal

Provided by:
  thesubtlety

Compatible session types:
  Meterpreter
  Shell

etc
```

