### PR TITLE
Make sure module_reference is able to continue loading rb modules

### DIFF
--- a/tools/modules/module_reference.rb
+++ b/tools/modules/module_reference.rb
@@ -212,6 +212,11 @@ tbl = Rex::Text::Table.new(
 bad_refs_count  = 0
 
 $framework.modules.each { |name, mod|
+  if mod.nil?
+    elog("module_reference.rb is unable to load #{name}")
+    next
+  end
+
   next if match and not name =~ match
 
   x = mod.new


### PR DESCRIPTION
# Description

The module_reference tool is not able to read Metasploit python modules. If the tool runs into one, it will actually cause a backtrace. This condition should at least be handled.

# Verification

- [x] Run ```ruby module_reference.rb```, make sure it completes without a backtrace.