### PR TITLE
Update missing CVE references for exploit modules

### DIFF
--- a/modules/exploits/linux/http/fritzbox_echo_exec.rb
+++ b/modules/exploits/linux/http/fritzbox_echo_exec.rb
@@ -28,6 +28,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'     => MSF_LICENSE,
       'References'  =>
         [
+          [ 'CVE', '2014-9727' ],
           [ 'OSVDB', '103289' ],
           [ 'BID', '65520' ],
           [ 'URL', 'http://www.kapple.de/?p=75' ],                       # vulnerability details with PoC

--- a/modules/exploits/multi/http/rails_secret_deserialization.rb
+++ b/modules/exploits/multi/http/rails_secret_deserialization.rb
@@ -111,6 +111,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'References'  =>
         [
+          ['CVE', '2013-3709'],
           ['URL', 'http://robertheaton.com/2013/07/22/how-to-hack-a-rails-app-using-its-secret-token/']
         ],
       'DisclosureDate' => 'Apr 11 2013',

--- a/modules/exploits/multi/http/rails_secret_deserialization.rb
+++ b/modules/exploits/multi/http/rails_secret_deserialization.rb
@@ -111,7 +111,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'References'  =>
         [
-          ['CVE', '2013-3709'],
+          ['CVE', '2013-0156'],
           ['URL', 'http://robertheaton.com/2013/07/22/how-to-hack-a-rails-app-using-its-secret-token/']
         ],
       'DisclosureDate' => 'Apr 11 2013',

--- a/modules/exploits/multi/http/vbseo_proc_deutf.rb
+++ b/modules/exploits/multi/http/vbseo_proc_deutf.rb
@@ -23,6 +23,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'References'     =>
         [
+          ['CVE', '2012-5223'],
           ['OSVDB', '78508'],
           ['BID', '51647'],
           ['EDB', '18424']

--- a/modules/exploits/unix/webapp/basilic_diff_exec.rb
+++ b/modules/exploits/unix/webapp/basilic_diff_exec.rb
@@ -25,6 +25,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'References'     =>
         [
+          [ 'CVE', '2012-3399' ],
           [ 'OSVDB', '83719' ],
           [ 'BID', '54234' ]
         ],

--- a/modules/exploits/unix/webapp/openemr_upload_exec.rb
+++ b/modules/exploits/unix/webapp/openemr_upload_exec.rb
@@ -27,6 +27,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'References'     =>
         [
+          [ 'CVE', '2009-4140' ],
           [ 'OSVDB', '90222' ],
           [ 'BID', '37314' ],
           [ 'EBD', '24492' ],

--- a/modules/exploits/unix/webapp/wp_easycart_unrestricted_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_easycart_unrestricted_file_upload.rb
@@ -41,6 +41,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'References'      =>
         [
+          ['CVE', '2014-9308'],
           ['OSVDB', '116806'],
           ['WPVDB', '7745']
         ],

--- a/modules/exploits/unix/webapp/wp_reflexgallery_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_reflexgallery_file_upload.rb
@@ -24,6 +24,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'References'     =>
         [
+          ['CVE', '2015-4133'],
           ['EDB', '36374'],
           ['OSVDB', '88853'],
           ['WPVDB', '7867']

--- a/modules/exploits/windows/fileformat/allplayer_m3u_bof.rb
+++ b/modules/exploits/windows/fileformat/allplayer_m3u_bof.rb
@@ -13,7 +13,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Name'           => 'ALLPlayer M3U Buffer Overflow',
       'Description'    => %q{
           This module exploits a stack-based buffer overflow vulnerability in
-        ALLPlayer 2.8.1, caused by a long string in a playlist entry.
+        ALLPlayer 5.8.1, caused by a long string in a playlist entry.
         By persuading the victim to open a specially-crafted .M3U file, a
         remote attacker could execute arbitrary code on the system or cause
         the application to crash. This module has been tested successfully on

--- a/modules/exploits/windows/fileformat/allplayer_m3u_bof.rb
+++ b/modules/exploits/windows/fileformat/allplayer_m3u_bof.rb
@@ -28,6 +28,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'References'     =>
         [
+          [ 'CVE', '2013-7409' ],
           [ 'BID', '62926' ],
           [ 'BID', '63896' ],
           [ 'EDB', '28855' ],

--- a/modules/exploits/windows/fileformat/bacnet_csv.rb
+++ b/modules/exploits/windows/fileformat/bacnet_csv.rb
@@ -21,6 +21,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Author'         => [ 'Jeremy Brown', 'MC' ],
       'References'     =>
         [
+          [ 'CVE', '2010-4740' ],
           [ 'OSVDB', '68096'],
           [ 'BID', '43289' ],
           [ 'URL', 'http://www.us-cert.gov/control_systems/pdf/ICSA-10-264-01.pdf' ],

--- a/modules/exploits/windows/fileformat/ccmplayer_m3u_bof.rb
+++ b/modules/exploits/windows/fileformat/ccmplayer_m3u_bof.rb
@@ -23,6 +23,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Author'         => ['Rh0'],	# discovery and metasploit module
       'References'     =>
         [
+          ['CVE', '2011-5170'],
           ['OSVDB', '77453'],
           ['EDB', '18178']
         ],

--- a/modules/exploits/windows/fileformat/cyberlink_p2g_bof.rb
+++ b/modules/exploits/windows/fileformat/cyberlink_p2g_bof.rb
@@ -25,6 +25,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'References'      =>
         [
+          ['CVE', '2011-5171'],
           ['BID', '50997'],
           ['OSVDB', '77600'],
           ['EDB', '18220'],

--- a/modules/exploits/windows/fileformat/emc_appextender_keyworks.rb
+++ b/modules/exploits/windows/fileformat/emc_appextender_keyworks.rb
@@ -20,6 +20,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Author'         => [ 'MC' ],
       'References'     =>
         [
+          [ 'CVE', '2012-2515' ],
           [ 'OSVDB', '58423'],
           [ 'BID', '36546' ],
         ],

--- a/modules/exploits/windows/fileformat/free_mp3_ripper_wav.rb
+++ b/modules/exploits/windows/fileformat/free_mp3_ripper_wav.rb
@@ -27,6 +27,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'References'     =>
         [
+          [ 'CVE', '2011-5165' ],
           [ 'OSVDB', '63349' ],
           [ 'EDB', '11975' ], #Initial disclosure
           [ 'EDB', '17727' ] #This exploit is based on this poc

--- a/modules/exploits/windows/fileformat/microp_mppl.rb
+++ b/modules/exploits/windows/fileformat/microp_mppl.rb
@@ -21,6 +21,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Author'         => [ 'James Fitts <fitts.james[at]gmail.com>' ],
       'References'     =>
         [
+          [ 'CVE', '2010-5299' ],
           [ 'OSVDB', '73627'],
           [ 'EDB', '14720' ],
         ],

--- a/modules/exploits/windows/fileformat/mini_stream_pls_bof.rb
+++ b/modules/exploits/windows/fileformat/mini_stream_pls_bof.rb
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'References'     =>
         [
-          [ 'CVE', '2009-1330' ],
+          [ 'CVE', '2010-5081' ],
           [ 'OSVDB', '78078' ],
           [ 'EDB', '14373' ],
           [ 'BID', '34514' ]

--- a/modules/exploits/windows/fileformat/mini_stream_pls_bof.rb
+++ b/modules/exploits/windows/fileformat/mini_stream_pls_bof.rb
@@ -25,6 +25,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'References'     =>
         [
+          [ 'CVE', '2009-1330' ],
           [ 'OSVDB', '78078' ],
           [ 'EDB', '14373' ],
           [ 'BID', '34514' ]

--- a/modules/exploits/windows/fileformat/shadow_stream_recorder_bof.rb
+++ b/modules/exploits/windows/fileformat/shadow_stream_recorder_bof.rb
@@ -25,6 +25,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'References'      =>
         [
+          [ 'CVE', '2009-1641' ],
           [ 'OSVDB', '81487' ],
           [ 'EDB', '11957' ],
           [ 'BID', '34864' ]

--- a/modules/exploits/windows/ftp/pcman_put.rb
+++ b/modules/exploits/windows/ftp/pcman_put.rb
@@ -24,6 +24,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'References'     =>
         [
+          [ 'CVE', '2013-4730' ],
           [ 'EDB',   '37731'],
           [ 'OSVDB',   '94624']
         ],

--- a/modules/exploits/windows/ftp/pcman_stor.rb
+++ b/modules/exploits/windows/ftp/pcman_stor.rb
@@ -25,6 +25,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'References'     =>
         [
+          [ 'CVE', '2013-4730' ],
           [ 'OSVDB', '94624'],
           [ 'EDB',   '27703']
         ],

--- a/modules/exploits/windows/http/cogent_datahub_request_headers_bof.rb
+++ b/modules/exploits/windows/http/cogent_datahub_request_headers_bof.rb
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'References'     =>
         [
-          [ 'CVE', '2012-2329' ],
+          [ 'CVE', '2013-0680' ],
           [ 'OSVDB', '95819'],
           [ 'BID', '53455'],
           [ 'ZDI', '13-178' ],

--- a/modules/exploits/windows/http/cogent_datahub_request_headers_bof.rb
+++ b/modules/exploits/windows/http/cogent_datahub_request_headers_bof.rb
@@ -26,6 +26,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'References'     =>
         [
+          [ 'CVE', '2012-2329' ],
           [ 'OSVDB', '95819'],
           [ 'BID', '53455'],
           [ 'ZDI', '13-178' ],

--- a/modules/exploits/windows/http/zenworks_uploadservlet.rb
+++ b/modules/exploits/windows/http/zenworks_uploadservlet.rb
@@ -23,6 +23,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'     => MSF_LICENSE,
       'References'  =>
         [
+          [ 'CVE', '2010-5324' ],
           [ 'OSVDB', '63412' ],
           [ 'BID', '39114' ],
           [ 'ZDI', '10-078' ],

--- a/modules/exploits/windows/local/novell_client_nwfs.rb
+++ b/modules/exploits/windows/local/novell_client_nwfs.rb
@@ -49,6 +49,7 @@ class MetasploitModule < Msf::Exploit::Local
         ],
       'References'    =>
         [
+          [ 'CVE', '2008-3158' ],
           [ 'OSVDB', '46578' ],
           [ 'BID', '30001' ]
         ],


### PR DESCRIPTION
These are based on cross references by EDB, OSVDB, module short name, blog post and BID, etc.