### PR TITLE
Update missing CVE references for auxiliary modules

### DIFF
--- a/modules/auxiliary/admin/edirectory/edirectory_dhost_cookie.rb
+++ b/modules/auxiliary/admin/edirectory/edirectory_dhost_cookie.rb
@@ -17,7 +17,8 @@ class MetasploitModule < Msf::Auxiliary
       },
       'References'     =>
         [
-          ['OSVDB', '60035'],
+          ['CVE', '2009-4655'],
+          ['OSVDB', '60035']
         ],
       'Author'         => 'hdm',
       'License'        => MSF_LICENSE

--- a/modules/auxiliary/admin/http/intersil_pass_reset.rb
+++ b/modules/auxiliary/admin/http/intersil_pass_reset.rb
@@ -29,6 +29,7 @@ class MetasploitModule < Msf::Auxiliary
       'License'        => MSF_LICENSE,
       'References'     =>
         [
+          [ 'CVE', '2007-4915' ],
           [ 'BID', '25676'],
           [ 'PACKETSTORM', '59347']
         ],

--- a/modules/auxiliary/admin/scada/yokogawa_bkbcopyd_client.rb
+++ b/modules/auxiliary/admin/scada/yokogawa_bkbcopyd_client.rb
@@ -20,6 +20,7 @@ class MetasploitModule < Msf::Auxiliary
         [ 'Unknown' ],
       'References'     =>
         [
+          [ 'CVE', '2014-5208' ],
           [ 'URL', 'https://community.rapid7.com/community/metasploit/blog/2014/08/09/r7-2014-10-disclosure-yokogawa-centum-cs3000-bkbcopydexe-file-system-access']
         ],
       'Actions'     =>

--- a/modules/auxiliary/scanner/ftp/titanftp_xcrc_traversal.rb
+++ b/modules/auxiliary/scanner/ftp/titanftp_xcrc_traversal.rb
@@ -32,6 +32,7 @@ class MetasploitModule < Msf::Auxiliary
       'License'        => MSF_LICENSE,
       'References'     =>
         [
+          [ 'CVE', '2010-2426' ],
           [ 'OSVDB', '65533'],
           [ 'URL', 'http://seclists.org/bugtraq/2010/Jun/160' ]
         ],

--- a/modules/auxiliary/scanner/http/support_center_plus_directory_traversal.rb
+++ b/modules/auxiliary/scanner/http/support_center_plus_directory_traversal.rb
@@ -23,6 +23,7 @@ class MetasploitModule < Msf::Auxiliary
       'Author'         => 'xistence <xistence[at]0x90.nl>', # Discovery, Metasploit module
       'References'     =>
         [
+          ['CVE', '2014-100002'],
           ['EDB', '31262'],
           ['OSVDB', '102656'],
           ['BID', '65199'],

--- a/modules/auxiliary/scanner/snmp/arris_dg950.rb
+++ b/modules/auxiliary/scanner/snmp/arris_dg950.rb
@@ -17,6 +17,7 @@ class MetasploitModule < Msf::Auxiliary
       },
       'References'  =>
         [
+          ['CVE','2014-4862'],
           ['URL', 'https://community.rapid7.com/community/metasploit/blog/2014/08/21/more-snmp-information-leaks-cve-2014-4862-and-cve-2014-4863']
         ],
       'Author'      => ['Deral "Percent_X" Heiland'],

--- a/modules/auxiliary/scanner/snmp/arris_dg950.rb
+++ b/modules/auxiliary/scanner/snmp/arris_dg950.rb
@@ -17,7 +17,7 @@ class MetasploitModule < Msf::Auxiliary
       },
       'References'  =>
         [
-          ['CVE','2014-4862'],
+          ['CVE','2014-4863'],
           ['URL', 'https://community.rapid7.com/community/metasploit/blog/2014/08/21/more-snmp-information-leaks-cve-2014-4862-and-cve-2014-4863']
         ],
       'Author'      => ['Deral "Percent_X" Heiland'],


### PR DESCRIPTION
Based on existing references such as BID, OSVDB, blog posts, etc