### PR TITLE
Return CheckCode::Unsupported in ETERNALBLUE

### DIFF
--- a/modules/exploits/windows/smb/ms17_010_eternalblue.rb
+++ b/modules/exploits/windows/smb/ms17_010_eternalblue.rb
@@ -106,10 +106,7 @@ class MetasploitModule < Msf::Exploit::Remote
   class EternalBlueError < StandardError
   end
 
-  def check
-    # todo: create MS17-010 mixin, and hook up auxiliary/scanner/smb/smb_ms17_010
-    CheckCode::Unsupported
-  end
+  # todo: create MS17-010 mixin, and hook up auxiliary/scanner/smb/smb_ms17_010
 
   def exploit
     begin

--- a/modules/exploits/windows/smb/ms17_010_eternalblue.rb
+++ b/modules/exploits/windows/smb/ms17_010_eternalblue.rb
@@ -108,6 +108,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     # todo: create MS17-010 mixin, and hook up auxiliary/scanner/smb/smb_ms17_010
+    CheckCode::Unsupported
   end
 
   def exploit


### PR DESCRIPTION
Defining a `check` method in the module overrides it.

- [x] `use` the module
- [x] `set RHOSTS` to anything
- [x] `check`
- [x] See the corrected message

```
msf5 exploit(windows/smb/ms17_010_eternalblue) > check
[-] 192.168.33.11:445 Check failed: The state could not be determined.
msf5 exploit(windows/smb/ms17_010_eternalblue) >
```

```
msf5 exploit(windows/smb/ms17_010_eternalblue) > check
[*] 192.168.33.11:445 This module does not support check.
msf5 exploit(windows/smb/ms17_010_eternalblue) >
```

Via @egypt on IRC.