### PR TITLE
Inform the user about not having a CVE

### DIFF
--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -497,10 +497,26 @@ class ReadableText
   def self.dump_references(mod, indent = '')
     output = ''
 
+
     if (mod.respond_to?(:references) && mod.references && mod.references.length > 0)
       output << "References:\n"
+
+      cve_collection = mod.references.select { |r| r.ctx_id.match(/^cve$/i) }
+      if cve_collection.empty?
+        output << "#{indent}CVE: Not available\n"
+      end
+
       mod.references.each { |ref|
-        output << indent + ref.to_s + "\n"
+        case ref.ctx_id
+        when 'CVE', 'cve'
+          if !cve_collection.empty? && ref.ctx_val.blank?
+            output << "#{indent}CVE: Not available\n"
+          else
+            output << indent + ref.to_s + "\n"
+          end
+        else
+          output << indent + ref.to_s + "\n"
+        end
       }
       output << "\n"
     end

--- a/lib/msf/util/document_generator/normalizer.rb
+++ b/lib/msf/util/document_generator/normalizer.rb
@@ -65,6 +65,9 @@ module Msf
         AUXILIARY_SCANNER_DEMO_TEMPLATE = 'auxiliary_scanner_template.erb'
         PAYLOAD_DEMO_TEMPLATE           = 'payload_demo_template.erb'
 
+        # Special messages
+        NO_CVE_MESSAGE = %Q|CVE: [Not available](https://github.com/rapid7/metasploit-framework/wiki/Why-is-a-CVE-Not-Available%3F)|
+
 
         # Returns the module document in HTML form.
         #
@@ -207,7 +210,7 @@ module Msf
           normalized = ''
           cve_collection = refs.select { |r| r.ctx_id.match(/^cve$/i) }
           if cve_collection.empty?
-            normalized << "* CVE: Not available\n"
+            normalized << "* #{NO_CVE_MESSAGE}\n"
           end
 
           refs.each do |ref|
@@ -222,7 +225,7 @@ module Msf
               normalized << "* [VU##{ref.ctx_val}](#{ref.site})"
             when 'CVE', 'cve'
               if !cve_collection.empty? && ref.ctx_val.blank?
-                normalized << "* CVE: Not available"
+                normalized << "* #{NO_CVE_MESSAGE}"
               end
             else
               normalized << "* [#{ref.ctx_id}-#{ref.ctx_val}](#{ref.site})"

--- a/lib/msf/util/document_generator/normalizer.rb
+++ b/lib/msf/util/document_generator/normalizer.rb
@@ -205,6 +205,11 @@ module Msf
         # @return [String]
         def normalize_references(refs)
           normalized = ''
+          cve_collection = refs.select { |r| r.ctx_id.match(/^cve$/i) }
+          if cve_collection.empty?
+            normalized << "* CVE: Not available\n"
+          end
+
           refs.each do |ref|
             case ref.ctx_id
             when 'AKA'
@@ -215,6 +220,10 @@ module Msf
               normalized << "* [#{ref.site}](#{ref.site})"
             when 'US-CERT-VU'
               normalized << "* [VU##{ref.ctx_val}](#{ref.site})"
+            when 'CVE', 'cve'
+              if !cve_collection.empty? && ref.ctx_val.blank?
+                normalized << "* CVE: Not available"
+              end
             else
               normalized << "* [#{ref.ctx_id}-#{ref.ctx_val}](#{ref.site})"
             end


### PR DESCRIPTION
# Description

People rely on CVE information a lot, and we want to be able tell the user why sometimes a module does not have a CVE. So this PR basically allows the module documentation and msfconsole to be more informative about that.

# Verification

- [x] Find a module without a CVE, and do ```info```. You should see a message that says "CVE: Not available"
- [x] Do ```info -d``` for the same module in msfconsole, the module documentation should also say "CVE: Not available", and it takes you to a Framework wiki explaining why there is no CVE assigned.