### PR TITLE
Add Auxiliary module to enumerate the Docker Server Version

### DIFF
--- a/modules/auxiliary/scanner/http/docker_enum.rb
+++ b/modules/auxiliary/scanner/http/docker_enum.rb
@@ -27,7 +27,7 @@ class MetasploitModule < Msf::Auxiliary
     res = send_request_cgi({
       'uri'    => normalize_uri(datastore['URI'], "/version"),
       'method' => 'GET'})
-    if not res or res.code != 200
+    if res.nil? || res.code != 200
       print_error("[Docker Version] failed to identify version")
       return
     end
@@ -36,13 +36,11 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def parse_body(body)
-    result = JSON.parse(body)
-    print_status("Identifying Docker Server Version on #{rhost}:#{rport}")
+    result = res.get_json_document
+    print_status("Identifying Docker Server Version on #{ip}:#{rport}")
     print_good("[Docker Server] Version: #{result['Version']}")
     if datastore['VERBOSE']
         print_status ("All info: #{result.to_s}")
     end
-    return
   end
-
 end

--- a/modules/auxiliary/scanner/http/docker_enum.rb
+++ b/modules/auxiliary/scanner/http/docker_enum.rb
@@ -11,7 +11,7 @@ class MetasploitModule < Msf::Auxiliary
   def initialize
     super(
       'Name'        => 'Docker Server Version Scanner',
-      'Description' => 'This module attempts identify the version of the Docker Server running.',
+      'Description' => 'This module attempts to identify the version of the Docker Server running on a host.',
       'Author'      => [ 'Agora-Security' ],
       'License'     => MSF_LICENSE
     )

--- a/modules/auxiliary/scanner/http/docker_enum.rb
+++ b/modules/auxiliary/scanner/http/docker_enum.rb
@@ -1,0 +1,49 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Scanner
+  include Msf::Auxiliary::Report
+
+  def initialize
+    super(
+      'Name'        => 'Docker Server Version Scanner',
+      'Description' => 'This module attempts identify the version of the Docker Server running.',
+      'Author'     => [ 'Agora-Security' ],
+      'License'   => MSF_LICENSE
+    )
+    register_options(
+      [
+        Opt::RPORT(2375),
+      ])
+    register_autofilter_ports([ 2375 ])
+    deregister_options('RHOST')
+  end
+
+  def run_host(ip)
+    res = send_request_cgi({
+      'uri'    => normalize_uri(datastore['URI'], "/version"),
+      'method' => 'GET'
+    }, 25)
+    if not res or res.code != 200
+      print_error("[Docker Version] failed to identify version")
+      return
+    end
+
+    parse_body(res.body)
+  end
+
+  def parse_body(body)
+    result = JSON.parse(body)
+    print_status("Identifying Docker Server Version on #{rhost}:#{rport}")
+    print_good("[Docker Server] Version: #{result['Version']}")
+    if datastore['VERBOSE']
+        print_status ("All info: #{result.to_s}")
+    end
+    return
+  end
+
+end

--- a/modules/auxiliary/scanner/http/docker_enum.rb
+++ b/modules/auxiliary/scanner/http/docker_enum.rb
@@ -19,8 +19,6 @@ class MetasploitModule < Msf::Auxiliary
       [
         Opt::RPORT(2375),
       ])
-    register_autofilter_ports([ 2375 ])
-    deregister_options('RHOST')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/http/docker_enum.rb
+++ b/modules/auxiliary/scanner/http/docker_enum.rb
@@ -17,7 +17,7 @@ class MetasploitModule < Msf::Auxiliary
       },
       'Author'      => [ 'Agora-Security' ],
       'License'     => MSF_LICENSE
-    )
+    ))
     register_options(
       [
         Opt::RPORT(2375)

--- a/modules/auxiliary/scanner/http/docker_enum.rb
+++ b/modules/auxiliary/scanner/http/docker_enum.rb
@@ -42,7 +42,16 @@ class MetasploitModule < Msf::Auxiliary
         :port  => datastore['RPORT'],
         :proto => 'tcp',
         :ntype => 'docker_version',
-        :data  => result['Version']
+        :data  => result['Version'],
+        :info  => "Docker Server v.#{result['Version']}"
+    )
+    print_status("Saving host information.")
+    report_host(
+        :host           => ip,
+        :arch           => result['Arch'],
+        :detected_arch  => result['Arch'],
+        :os_family      => result['Os'],
+        :info           =>  "Docker Server v.#{result['Version']} Kernel Version: #{result['KernelVersion']}"
     )
   end
 end

--- a/modules/auxiliary/scanner/http/docker_enum.rb
+++ b/modules/auxiliary/scanner/http/docker_enum.rb
@@ -23,17 +23,13 @@ class MetasploitModule < Msf::Auxiliary
 
   def run_host(ip)
     res = send_request_cgi({
-      'uri'    => normalize_uri(datastore['URI'], "/version"),
+      'uri' => normalize_uri("/version"),
       'method' => 'GET'})
     if res.nil? || res.code != 200
       print_error("[Docker Version] failed to identify version")
       return
     end
 
-    parse_body(res.body)
-  end
-
-  def parse_body(body)
     result = res.get_json_document
     print_status("Identifying Docker Server Version on #{ip}:#{rport}")
     print_good("[Docker Server] Version: #{result['Version']}")

--- a/modules/auxiliary/scanner/http/docker_enum.rb
+++ b/modules/auxiliary/scanner/http/docker_enum.rb
@@ -34,5 +34,12 @@ class MetasploitModule < Msf::Auxiliary
     print_status("Identifying Docker Server Version on #{peer}")
     print_good("[Docker Server] Version: #{result['Version']}")
     print_status ("All info: #{result.to_s}") if datastore['VERBOSE']
+    report_note(
+        :host  => ip,
+        :port  => datastore['RPORT'],
+        :proto => 'tcp',
+        :ntype => 'docker_version',
+        :data  => result['Version']
+    )
   end
 end

--- a/modules/auxiliary/scanner/http/docker_enum.rb
+++ b/modules/auxiliary/scanner/http/docker_enum.rb
@@ -11,7 +11,10 @@ class MetasploitModule < Msf::Auxiliary
   def initialize
     super(
       'Name'        => 'Docker Server Version Scanner',
-      'Description' => 'This module attempts to identify the version of the Docker Server running on a host.',
+      'Description' => %q{
+        This module attempts to identify the version of the Docker Server running on a
+        host. If you wish to see all the information available, set VERBOSE to true.
+      },
       'Author'      => [ 'Agora-Security' ],
       'License'     => MSF_LICENSE
     )

--- a/modules/auxiliary/scanner/http/docker_enum.rb
+++ b/modules/auxiliary/scanner/http/docker_enum.rb
@@ -8,8 +8,8 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::Report
 
-  def initialize
-    super(
+  def initialize(info = {})
+    super(update_info(info,
       'Name'        => 'Docker Server Version Scanner',
       'Description' => %q{
         This module attempts to identify the version of the Docker Server running on a

--- a/modules/auxiliary/scanner/http/docker_enum.rb
+++ b/modules/auxiliary/scanner/http/docker_enum.rb
@@ -26,8 +26,7 @@ class MetasploitModule < Msf::Auxiliary
   def run_host(ip)
     res = send_request_cgi({
       'uri'    => normalize_uri(datastore['URI'], "/version"),
-      'method' => 'GET'
-    }, 25)
+      'method' => 'GET'})
     if not res or res.code != 200
       print_error("[Docker Version] failed to identify version")
       return

--- a/modules/auxiliary/scanner/http/docker_enum.rb
+++ b/modules/auxiliary/scanner/http/docker_enum.rb
@@ -12,8 +12,8 @@ class MetasploitModule < Msf::Auxiliary
     super(
       'Name'        => 'Docker Server Version Scanner',
       'Description' => 'This module attempts identify the version of the Docker Server running.',
-      'Author'     => [ 'Agora-Security' ],
-      'License'   => MSF_LICENSE
+      'Author'      => [ 'Agora-Security' ],
+      'License'     => MSF_LICENSE
     )
     register_options(
       [

--- a/modules/auxiliary/scanner/http/docker_enum.rb
+++ b/modules/auxiliary/scanner/http/docker_enum.rb
@@ -17,7 +17,7 @@ class MetasploitModule < Msf::Auxiliary
     )
     register_options(
       [
-        Opt::RPORT(2375),
+        Opt::RPORT(2375)
       ])
   end
 
@@ -31,10 +31,8 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     result = res.get_json_document
-    print_status("Identifying Docker Server Version on #{ip}:#{rport}")
+    print_status("Identifying Docker Server Version on #{peer}")
     print_good("[Docker Server] Version: #{result['Version']}")
-    if datastore['VERBOSE']
-        print_status ("All info: #{result.to_s}")
-    end
+    print_status ("All info: #{result.to_s}") if datastore['VERBOSE']
   end
 end


### PR DESCRIPTION
It's a simple script to enumerate information about a Docker Server.
It will give the version, if verbose mode is enabled all the information obtained will be presented.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/http/docker_enum `
- [ ] `set RHOSTS 192.168.37.189`
- [ ] `exploit`
```
[*] Identifying Docker Server Version on 192.168.37.189:2375
[+] [Docker Server] Version: 18.03.1-ce
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```
