### PR TITLE
Add WPCHECK (Bool) advanced option to Exploit::Remote::HTTP::Wordpress

### DIFF
--- a/lib/msf/core/exploit/http/wordpress.rb
+++ b/lib/msf/core/exploit/http/wordpress.rb
@@ -38,7 +38,8 @@ module Msf
 
             register_advanced_options(
               [
-                Msf::OptString.new('WPCONTENTDIR', [true, 'The name of the wp-content directory', 'wp-content'])
+                Msf::OptString.new('WPCONTENTDIR', [true, 'The name of the wp-content directory', 'wp-content']),
+                Msf::OptBool.new('WPCHECK', [true, 'Check if the website is a valid WordPress install', true]),
               ], Msf::Exploit::Remote::HTTP::Wordpress
             )
           end

--- a/lib/msf/core/exploit/http/wordpress/base.rb
+++ b/lib/msf/core/exploit/http/wordpress/base.rb
@@ -5,6 +5,11 @@ module Msf::Exploit::Remote::HTTP::Wordpress::Base
   #
   # @return [Rex::Proto::Http::Response,nil] Returns the HTTP response if the site is online and running wordpress, nil otherwise
   def wordpress_and_online?
+    unless datastore['WPCHECK']
+      vprint_status 'Skipping WordPress check...'
+      return true
+    end
+
     wordpress_detect_regexes = [
         /["'][^"']*\/#{Regexp.escape(wp_content_dir)}\/[^"']*["']/i,
         /<link rel=["']wlwmanifest["'].*href=["'].*\/wp-includes\/wlwmanifest\.xml["'] \/>/i,


### PR DESCRIPTION
This PR adds a `WPCHECK` Boolean advanced option to `Exploit::Remote::HTTP::Wordpress` (defaults to `true`), and augments `wordpress_and_online?` to make use of this option, allowing users to disable the check for a valid WordPress website.

See issue #10190 for background info.

Using an advanced option seems like the best approach, as it provides this option to all modules which make use of the WordPress mixin. One instance where this presents a problem is WordPress DoS modules, which use the `wordpress_and_online?` method upon completion to verify whether the host is still online. If the `WPCHECK` is disabled, the DoS modules will now return `[-] FAILED: / appears to still be online`.

**Warning: spoilers for [MrRobot vuln lab](https://www.vulnhub.com/entry/mr-robot-1,151/) ahead.**


## Verification

- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/http/wordpress_login_enum`
- [x] `set rhosts <IP>`
- [x] `set WPCHECK true`
- [x] `set username elliot`
- [x] `set password ER28-0652`
- [x] `run`
- [x] **Verify** the module fails, as no WordPress website is detected
- [x] `set WPCHECK false`
- [x] `run`
- [x] **Verify**:
  - [x] the WordPress check is skipped - `Skipping WordPress check...`
  - [x] the *elliot* user is confirmed to exist - `[+] / - WordPress User-Validation - Username: 'elliot' - is VALID`
  - [x] valid credentials are identified - `[+] / - WordPress Brute Force - SUCCESSFUL login for 'elliot' : 'ER28-0652'`


### Output

```
msf5 > use auxiliary/scanner/http/wordpress_login_enum 
msf5 auxiliary(scanner/http/wordpress_login_enum) > set rhosts 10.1.1.151
rhosts => 10.1.1.151
msf5 auxiliary(scanner/http/wordpress_login_enum) > set user_file /root/users
user_file => /root/users
msf5 auxiliary(scanner/http/wordpress_login_enum) > set pass_file /root/pw
pass_file => /root/pw
msf5 auxiliary(scanner/http/wordpress_login_enum) > run

[-] / does not seem to be WordPress site
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf5 auxiliary(scanner/http/wordpress_login_enum) > set wpcheck 
wpcheck => true
msf5 auxiliary(scanner/http/wordpress_login_enum) > set wpcheck false
wpcheck => false
msf5 auxiliary(scanner/http/wordpress_login_enum) > run

[*] 10.1.1.151:80 - Skipping WordPress check...
[*] / - WordPress Version 4.3.17 detected
[*] 10.1.1.151:80 - / - WordPress User-Enumeration - Running User Enumeration
[*] 10.1.1.151:80 - / - WordPress User-Validation - Running User Validation
[*] / - WordPress User-Validation - Checking Username:'admin'
[-] 10.1.1.151:80 - [1/6] - / - WordPress User-Validation - Invalid Username: 'admin'
[*] / - WordPress User-Validation - Checking Username:'elliot'
[+] / - WordPress User-Validation - Username: 'elliot' - is VALID
[+] / - WordPress User-Validation - Found 1 valid user
[*] 10.1.1.151:80 - [3/6] - / - WordPress Brute Force - Running Bruteforce
[*] 10.1.1.151:80 - [3/6] - / - WordPress Brute Force - Skipping all but 1 valid user
[*] 10.1.1.151:80 - [4/6] - / - WordPress Brute Force - Trying username:'elliot' with password:'admin'
[-] 10.1.1.151:80 - [4/6] - / - WordPress Brute Force - Failed to login as 'elliot'
[*] 10.1.1.151:80 - [5/6] - / - WordPress Brute Force - Trying username:'elliot' with password:'password'
[-] 10.1.1.151:80 - [5/6] - / - WordPress Brute Force - Failed to login as 'elliot'
[*] 10.1.1.151:80 - [6/6] - / - WordPress Brute Force - Trying username:'elliot' with password:'ER28-0652'
[+] / - WordPress Brute Force - SUCCESSFUL login for 'elliot' : 'ER28-0652'
[!] No active DB -- Credential data will not be saved!
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```
