### PR TITLE
Fixups for php/base64 and cmd/unix/reverse_bash

### DIFF
--- a/modules/encoders/php/base64.rb
+++ b/modules/encoders/php/base64.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Encoder
   def encode_block(state, buf)
     # Have to have these for the decoder stub, so if they're not available,
     # there's nothing we can do here.
-    ["(",")",".","_","c","h","r","e","v","a","l","b","s","6","4","d","o"].each do |c|
+    %w{( ) . _ c h r e v a l b s 6 4 d o}.each do |c|
       raise BadcharError if state.badchars.include?(c)
     end
 

--- a/modules/encoders/php/base64.rb
+++ b/modules/encoders/php/base64.rb
@@ -38,6 +38,8 @@ class MetasploitModule < Msf::Encoder
     # characters, only part of the payload gets unencoded on the victim,
     # presumably due to a limitation in PHP identifier name lengths, so we
     # break the encoded payload into roughly 900-byte chunks.
+    #
+    # https://wiki.php.net/rfc/deprecate-bareword-strings
 
     b64 = Rex::Text.encode_base64(buf)
 

--- a/modules/encoders/php/base64.rb
+++ b/modules/encoders/php/base64.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Encoder
   def encode_block(state, buf)
     # Have to have these for the decoder stub, so if they're not available,
     # there's nothing we can do here.
-    %w{( ) . _ c h r e v a l b s 6 4 d o}.each do |c|
+    %w{c h r ( ) . e v a l b a s e 6 4 _ d e c o d e ;}.uniq.each do |c|
       raise BadcharError if state.badchars.include?(c)
     end
 

--- a/modules/payloads/singles/cmd/unix/reverse_bash.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_bash.rb
@@ -19,10 +19,11 @@ module MetasploitModule
       'Name'          => 'Unix Command Shell, Reverse TCP (/dev/tcp)',
       'Description'   => %q{
         Creates an interactive shell via bash's builtin /dev/tcp.
-        This will not work on most Debian-based Linux distributions
-        (including Ubuntu) because they compile bash without the
-        /dev/tcp feature.
-        },
+
+        This will not work on circa 2009 and older Debian-based Linux
+        distributions (including Ubuntu) because they compile bash
+        without the /dev/tcp feature.
+      },
       'Author'        => 'hdm',
       'License'       => MSF_LICENSE,
       'Platform'      => 'unix',


### PR DESCRIPTION
1. Prefer `%w` array over quoted array in `php/base64`
2. Document bareword string deprecation in `php/base64`
3. Update documentation in `cmd/unix/reverse_bash`

#3880