### PR TITLE
Add missed ARCH_CMD to top-level Arch array

### DIFF
--- a/modules/exploits/linux/http/hp_van_sdn_cmd_inject.rb
+++ b/modules/exploits/linux/http/hp_van_sdn_cmd_inject.rb
@@ -38,7 +38,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DisclosureDate' => 'Jun 25 2018',
       'License'        => MSF_LICENSE,
       'Platform'       => ['unix', 'linux'],
-      'Arch'           => [ARCH_X86, ARCH_X64],
+      'Arch'           => [ARCH_CMD, ARCH_X86, ARCH_X64],
       'Privileged'     => true,
       'Targets'        => [
         ['Unix In-Memory',


### PR DESCRIPTION
It's not necessary because of targets, but it's required for printing.

```diff
--- before	2018-07-12 17:43:03.000000000 -0500
+++ after	2018-07-12 17:42:38.000000000 -0500
@@ -3,7 +3,7 @@
        Name: HP VAN SDN Controller Root Command Injection
      Module: exploit/linux/http/hp_van_sdn_cmd_inject
    Platform: Unix, Linux
-       Arch: x86, x64
+       Arch: cmd, x86, x64
  Privileged: Yes
     License: Metasploit Framework License (BSD)
        Rank: Excellent
@@ -44,6 +44,7 @@
   additional login request will be sent.

 References:
+  CVE: Not available
   https://www.exploit-db.com/exploits/44951
   https://korelogic.com/Resources/Advisories/KL-001-2018-008.txt

```

#10219