### PR TITLE
Add 88 CVEs to various auxiliary and exploit modules

### DIFF
--- a/modules/auxiliary/admin/http/typo3_sa_2009_001.rb
+++ b/modules/auxiliary/admin/http/typo3_sa_2009_001.rb
@@ -17,6 +17,7 @@ class MetasploitModule < Msf::Auxiliary
       },
       'References'     =>
         [
+          ['CVE', '2009-0255'],
           ['OSVDB', '51536'],
           ['URL', 'http://blog.c22.cc/advisories/typo3-sa-2009-001'],
           ['URL', 'http://typo3.org/teams/security/security-bulletins/typo3-sa-2009-001/'],

--- a/modules/auxiliary/admin/http/typo3_sa_2010_020.rb
+++ b/modules/auxiliary/admin/http/typo3_sa_2010_020.rb
@@ -19,6 +19,7 @@ class MetasploitModule < Msf::Auxiliary
       },
       'References'     =>
         [
+          ['CVE', '2010-3714'],
           ['URL', 'http://typo3.org/teams/security/security-bulletins/typo3-sa-2010-020'],
           ['URL', 'http://gregorkopf.de/slides_berlinsides_2010.pdf'],
         ],

--- a/modules/auxiliary/admin/http/vbulletin_upgrade_admin.rb
+++ b/modules/auxiliary/admin/http/vbulletin_upgrade_admin.rb
@@ -23,6 +23,7 @@ class MetasploitModule < Msf::Auxiliary
       'License'        => MSF_LICENSE,
       'References'     =>
         [
+          [ 'CVE', '2013-6129' ],
           [ 'URL', 'http://blog.imperva.com/2013/10/threat-advisory-a-vbulletin-exploit-administrator-injection.html'],
           [ 'OSVDB', '98370' ],
           [ 'URL', 'http://www.vbulletin.com/forum/forum/vbulletin-announcements/vbulletin-announcements_aa/3991423-potential-vbulletin-exploit-vbulletin-4-1-vbulletin-5']

--- a/modules/auxiliary/admin/smb/samba_symlink_traversal.rb
+++ b/modules/auxiliary/admin/smb/samba_symlink_traversal.rb
@@ -30,6 +30,7 @@ class MetasploitModule < Msf::Auxiliary
         ],
       'References'  =>
         [
+          ['CVE', '2010-0926'],
           ['OSVDB', '62145'],
           ['URL', 'http://www.samba.org/samba/news/symlink_attack.html']
         ],

--- a/modules/auxiliary/dos/http/ua_parser_js_redos.rb
+++ b/modules/auxiliary/dos/http/ua_parser_js_redos.rb
@@ -19,6 +19,7 @@ class MetasploitModule < Msf::Auxiliary
       },
       'References'  =>
         [
+          ['CVE', '2017-16086'],
           ['URL', 'https://github.com/faisalman/ua-parser-js/commit/25e143ee7caba78c6405a57d1d06b19c1e8e2f79'],
           ['CWE', '400'],
         ],

--- a/modules/auxiliary/dos/http/wordpress_long_password_dos.rb
+++ b/modules/auxiliary/dos/http/wordpress_long_password_dos.rb
@@ -24,6 +24,7 @@ class MetasploitModule < Msf::Auxiliary
         ],
       'References'      =>
         [
+          ['CVE', '2014-9016'],
           ['URL', 'http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-9034'],
           ['OSVDB', '114857'],
           ['WPVDB', '7681']

--- a/modules/auxiliary/dos/http/wordpress_xmlrpc_dos.rb
+++ b/modules/auxiliary/dos/http/wordpress_xmlrpc_dos.rb
@@ -23,6 +23,7 @@ class MetasploitModule < Msf::Auxiliary
       'License'       => MSF_LICENSE,
       'References'    =>
         [
+          ['CVE', '2014-5266'],
           ['URL', 'http://wordpress.org/news/2014/08/wordpress-3-9-2/'],
           ['URL', 'http://www.breaksec.com/?p=6362'],
           ['URL', 'http://mashable.com/2014/08/06/wordpress-xml-blowup-dos/'],

--- a/modules/auxiliary/gather/advantech_webaccess_creds.rb
+++ b/modules/auxiliary/gather/advantech_webaccess_creds.rb
@@ -23,6 +23,7 @@ class MetasploitModule < Msf::Auxiliary
         ],
       'References'     =>
         [
+          ['CVE', '2016-5810'],
           ['URL', 'https://github.com/rapid7/metasploit-framework/pull/7859#issuecomment-274305229']
         ],
       'DisclosureDate' => "Jan 21 2017"

--- a/modules/auxiliary/gather/alienvault_newpolicyform_sqli.rb
+++ b/modules/auxiliary/gather/alienvault_newpolicyform_sqli.rb
@@ -22,6 +22,7 @@ class MetasploitModule < Msf::Auxiliary
         ],
       'References'     =>
         [
+          ['CVE', '2014-5383'],
           ['OSVDB', '106815'],
           ['EDB', '33317'],
           ['URL', 'http://forums.alienvault.com/discussion/2690/security-advisories-v4-6-1-and-lower']

--- a/modules/auxiliary/gather/coldfusion_pwd_props.rb
+++ b/modules/auxiliary/gather/coldfusion_pwd_props.rb
@@ -18,6 +18,7 @@ class MetasploitModule < Msf::Auxiliary
       },
       'References'     =>
         [
+          [ 'CVE', '2013-3336' ],
           [ 'OSVDB', '93114' ],
           [ 'EDB', '25305' ]
         ],

--- a/modules/auxiliary/gather/emc_cta_xxe.rb
+++ b/modules/auxiliary/gather/emc_cta_xxe.rb
@@ -21,6 +21,7 @@ class MetasploitModule < Msf::Auxiliary
         ],
       'References'     =>
         [
+          ['CVE', '2014-0644'],
           ['EDB', '32623']
         ],
       'DisclosureDate' => 'Mar 31 2014'

--- a/modules/auxiliary/gather/zabbix_toggleids_sqli.rb
+++ b/modules/auxiliary/gather/zabbix_toggleids_sqli.rb
@@ -17,6 +17,7 @@ class MetasploitModule < Msf::Auxiliary
       },
       'References'     =>
         [
+          ['CVE', '2016-10134'],
           ['URL', 'http://seclists.org/fulldisclosure/2016/Aug/60']
         ],
       'Author'         =>

--- a/modules/auxiliary/scanner/http/netdecision_traversal.rb
+++ b/modules/auxiliary/scanner/http/netdecision_traversal.rb
@@ -18,6 +18,7 @@ class MetasploitModule < Msf::Auxiliary
       },
       'References'     =>
         [
+          [ 'CVE', '2012-1465' ],
           [ 'OSVDB', '79863' ],
           [ 'URL', 'http://aluigi.altervista.org/adv/netdecision_1-adv.txt' ],
         ],

--- a/modules/auxiliary/scanner/http/simple_webserver_traversal.rb
+++ b/modules/auxiliary/scanner/http/simple_webserver_traversal.rb
@@ -17,6 +17,7 @@ class MetasploitModule < Msf::Auxiliary
       },
       'References'     =>
         [
+          [ 'CVE', '2002-1864' ],
           [ 'OSVDB', '88877' ],
           [ 'EDB', '23886' ],
           [ 'URL', 'http://seclists.org/bugtraq/2013/Jan/12' ]

--- a/modules/auxiliary/scanner/http/wangkongbao_traversal.rb
+++ b/modules/auxiliary/scanner/http/wangkongbao_traversal.rb
@@ -20,6 +20,7 @@ class MetasploitModule < Msf::Auxiliary
       },
       'References'     =>
         [
+          ['CVE', '2012-4031'],
           ['EDB', '19526']
         ],
       'Author'         =>

--- a/modules/auxiliary/scanner/http/webdav_internal_ip.rb
+++ b/modules/auxiliary/scanner/http/webdav_internal_ip.rb
@@ -16,8 +16,12 @@ class MetasploitModule < Msf::Auxiliary
     super(
       'Name'        => 'HTTP WebDAV Internal IP Scanner',
       'Description' => 'Detect webservers internal IPs though WebDAV',
-      'Author'       => ['et'],
-      'License'     => MSF_LICENSE
+      'Author'      => ['et'],
+      'License'     => MSF_LICENSE,
+      'References'  =>
+        [
+          [ 'CVE', '2002-0422' ]
+        ]
     )
 
     register_options(

--- a/modules/auxiliary/scanner/http/wordpress_content_injection.rb
+++ b/modules/auxiliary/scanner/http/wordpress_content_injection.rb
@@ -19,6 +19,7 @@ class MetasploitModule < Msf::Auxiliary
         'wvu'           # Metasploit module
       ],
       'References'     => [
+        ['CVE' , '2017-5612'],
         ['WPVDB', '8734'],
         ['URL',   'https://blog.sucuri.net/2017/02/content-injection-vulnerability-wordpress-rest-api.html'],
         ['URL',   'https://secure.php.net/manual/en/language.types.type-juggling.php'],

--- a/modules/auxiliary/scanner/http/wordpress_cp_calendar_sqli.rb
+++ b/modules/auxiliary/scanner/http/wordpress_cp_calendar_sqli.rb
@@ -25,7 +25,8 @@ class MetasploitModule < Msf::Auxiliary
       'License'     => MSF_LICENSE,
       'References'  =>
         [
-          [ 'EDB', '36243'],
+          [ 'CVE' , '2014-8586' ],
+          [ 'EDB', '36243' ],
           [ 'WPVDB', '7910' ]
         ],
       'DisclosureDate' => 'Mar 03 2015'))

--- a/modules/auxiliary/scanner/http/wordpress_pingback_access.rb
+++ b/modules/auxiliary/scanner/http/wordpress_pingback_access.rb
@@ -27,6 +27,7 @@ class MetasploitModule < Msf::Auxiliary
       'License' => MSF_LICENSE,
       'References'  =>
         [
+          [ 'CVE', '2013-0235' ],
           [ 'URL', 'http://www.securityfocus.com/archive/1/525045/30/30/threaded'],
           [ 'URL', 'http://www.ethicalhack3r.co.uk/security/introduction-to-the-wordpress-xml-rpc-api/'],
           [ 'URL', 'https://github.com/FireFart/WordpressPingbackPortScanner']

--- a/modules/auxiliary/scanner/http/wp_mobile_pack_info_disclosure.rb
+++ b/modules/auxiliary/scanner/http/wp_mobile_pack_info_disclosure.rb
@@ -18,6 +18,7 @@ class MetasploitModule < Msf::Auxiliary
       },
       'References'     =>
         [
+          ['CVE' , '2014-5337'],
           ['WPVDB', '8107'],
           ['PACKETSTORM', '132750']
         ],

--- a/modules/auxiliary/scanner/lotus/lotus_domino_hashes.rb
+++ b/modules/auxiliary/scanner/lotus/lotus_domino_hashes.rb
@@ -13,7 +13,11 @@ class MetasploitModule < Msf::Auxiliary
       'Name'           => 'Lotus Domino Password Hash Collector',
       'Description'    => 'Get users passwords hashes from names.nsf page',
       'Author'         => 'Tiago Ferreira <tiago.ccna[at]gmail.com>',
-      'License'        => MSF_LICENSE
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          ['CVE' , '2007-0977']
+        ]
     )
 
   register_options(

--- a/modules/auxiliary/scanner/scada/sielco_winlog_fileaccess.rb
+++ b/modules/auxiliary/scanner/scada/sielco_winlog_fileaccess.rb
@@ -25,6 +25,7 @@ class MetasploitModule < Msf::Auxiliary
         ],
       'References'     =>
         [
+          [ 'CVE', '2012-4356' ],
           [ 'OSVDB', '83275' ],
           [ 'BID', '54212' ],
           [ 'EDB', '19409'],

--- a/modules/auxiliary/server/webkit_xslt_dropper.rb
+++ b/modules/auxiliary/server/webkit_xslt_dropper.rb
@@ -17,6 +17,10 @@ class MetasploitModule < Msf::Auxiliary
       },
       'Author'      => [ 'Nicolas Gregoire' ],
       'License'     => MSF_LICENSE,
+      'References'  =>
+        [
+          [ 'CVE', '2011-1774' ]
+        ],
       'Actions'     =>
         [
           [ 'WebServer' ]

--- a/modules/exploits/freebsd/http/watchguard_cmd_exec.rb
+++ b/modules/exploits/freebsd/http/watchguard_cmd_exec.rb
@@ -28,6 +28,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'References'     =>
         [
+          ['CVE', '2015-5453'],
           ['URL', 'http://security-assessment.com/files/documents/advisory/Watchguard-XCS-final.pdf']
         ],
       'Platform'       => 'bsd',

--- a/modules/exploits/linux/http/airties_login_cgi_bof.rb
+++ b/modules/exploits/linux/http/airties_login_cgi_bof.rb
@@ -30,6 +30,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Arch'           => ARCH_MIPSBE,
       'References'     =>
         [
+          ['CVE', '2015-2797'],
           ['EDB', '36577'],
           ['URL', 'http://www.bmicrosystems.com/exploits/airties5650tt.txt'] #PoC
         ],

--- a/modules/exploits/linux/http/alienvault_exec.rb
+++ b/modules/exploits/linux/http/alienvault_exec.rb
@@ -34,6 +34,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'References'     =>
         [
+          ['CVE', '2016-8582'],
           ['URL', 'https://pentest.blog/unexpected-journey-into-the-alienvault-ossimusm-during-engagement/'],
           ['EDB', '40682']
         ],

--- a/modules/exploits/linux/http/alienvault_sqli_exec.rb
+++ b/modules/exploits/linux/http/alienvault_sqli_exec.rb
@@ -25,6 +25,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'References'     =>
         [
+          ['CVE', '2016-8581'],
           ['OSVDB', '106252'],
           ['EDB', '33006']
         ],

--- a/modules/exploits/linux/http/dlink_diagnostic_exec_noauth.rb
+++ b/modules/exploits/linux/http/dlink_diagnostic_exec_noauth.rb
@@ -36,6 +36,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'     => MSF_LICENSE,
       'References'  =>
         [
+          [ 'CVE', '2014-100005' ],
           [ 'OSVDB', '92144' ],
           [ 'BID', '58938' ],
           [ 'EDB', '24926' ],

--- a/modules/exploits/linux/http/dlink_upnp_exec_noauth.rb
+++ b/modules/exploits/linux/http/dlink_upnp_exec_noauth.rb
@@ -25,6 +25,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'     => MSF_LICENSE,
       'References'  =>
         [
+          ['CVE', '2014-8361'],
           ['OSVDB', '94924'],
           ['BID', '61005'],
           ['EDB', '26664'],

--- a/modules/exploits/linux/http/ipfire_oinkcode_exec.rb
+++ b/modules/exploits/linux/http/ipfire_oinkcode_exec.rb
@@ -24,6 +24,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ],
         'References'  =>
           [
+            [ 'CVE', '2017-9757' ],
             [ 'EDB', '42149' ]
           ],
         'License'        => MSF_LICENSE,

--- a/modules/exploits/linux/http/linksys_wrt54gl_apply_exec.rb
+++ b/modules/exploits/linux/http/linksys_wrt54gl_apply_exec.rb
@@ -31,6 +31,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'     => MSF_LICENSE,
       'References'  =>
         [
+          [ 'CVE', '2005-2799' ],
           [ 'OSVDB', '89912' ],
           [ 'BID', '57459' ],
           [ 'EDB', '24202' ],

--- a/modules/exploits/linux/http/pineapp_test_li_conn_exec.rb
+++ b/modules/exploits/linux/http/pineapp_test_li_conn_exec.rb
@@ -25,8 +25,9 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'References'     =>
         [
-          [ 'ZDI', '13-188'],
-          [ 'OSVDB', '95782']
+          [ 'CVE', '2013-6829' ],
+          [ 'ZDI', '13-188' ],
+          [ 'OSVDB', '95782' ]
         ],
       'Platform'       => ['unix'],
       'Arch'           => ARCH_CMD,

--- a/modules/exploits/linux/http/pineapple_bypass_cmdinject.rb
+++ b/modules/exploits/linux/http/pineapple_bypass_cmdinject.rb
@@ -18,7 +18,10 @@ class MetasploitModule < Msf::Exploit::Remote
       },
       'Author'         => ['catatonicprime'],
       'License'        => MSF_LICENSE,
-      'References'     => [ ],
+      'References'     =>
+        [
+          [ 'CVE', '2015-4624' ]
+        ],
       'Platform'       => ['unix'],
       'Arch'           => ARCH_CMD,
       'Privileged'     => false,

--- a/modules/exploits/linux/http/sophos_wpa_iface_exec.rb
+++ b/modules/exploits/linux/http/sophos_wpa_iface_exec.rb
@@ -28,6 +28,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'References'     =>
         [
+          ['CVE', '2014-2849'],
+          ['CVE', '2014-2850'],
           ['URL', 'http://www.zerodayinitiative.com/advisories/ZDI-14-069/']
         ],
       'Platform'       => ['unix'],

--- a/modules/exploits/linux/http/tp_link_sc2020n_authenticated_telnet_injection.rb
+++ b/modules/exploits/linux/http/tp_link_sc2020n_authenticated_telnet_injection.rb
@@ -35,6 +35,10 @@ class MetasploitModule < Msf::Exploit::Remote
               },
             },
           'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/interact' },
+          'References'      =>
+            [
+              [ 'CVE', '2013-2578']
+            ],
           'Targets'        =>
             [
               [  'Automatic',     { } ],

--- a/modules/exploits/linux/http/tr064_ntpserver_cmdinject.rb
+++ b/modules/exploits/linux/http/tr064_ntpserver_cmdinject.rb
@@ -32,6 +32,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'     => MSF_LICENSE,
       'References'  =>
         [
+          [ 'CVE', '2016-10372' ],
           [ 'EDB', '40740' ],
           [ 'URL', 'https://devicereversing.wordpress.com/2016/11/07/eirs-d1000-modem-is-wide-open-to-being-hacked/'],
           [ 'URL', 'https://isc.sans.edu/forums/diary/Port+7547+SOAP+Remote+Code+Execution+Attack+Against+DSL+Modems/21759'],

--- a/modules/exploits/linux/http/trendmicro_sps_exec.rb
+++ b/modules/exploits/linux/http/trendmicro_sps_exec.rb
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'References'     =>
         [
-          ['CVE-ID', 'CVE-2016-6267']
+          ['CVE', '2016-6267']
         ],
       'Platform'        => 'linux',
       'Targets'         => [ [ 'Linux', {} ] ],

--- a/modules/exploits/linux/misc/opennms_java_serialize.rb
+++ b/modules/exploits/linux/misc/opennms_java_serialize.rb
@@ -24,6 +24,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'License'        => MSF_LICENSE,
         'References'     =>
           [
+            [ 'CVE', '2015-8103' ],
             [ 'URL', 'http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/' ]
           ],
         'Targets'        =>

--- a/modules/exploits/linux/misc/qnap_transcode_server.rb
+++ b/modules/exploits/linux/misc/qnap_transcode_server.rb
@@ -31,6 +31,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Platform'   => 'linux',
       'References' =>
         [
+          [ 'CVE', '2017-13067' ],
           [ 'URL', 'https://www.exploitee.rs/index.php/QNAP_TS-131' ],
           [ 'URL', 'http://docs.qnap.com/nas/4.1/Home/en/index.html?transcode_management.htm' ]
         ],

--- a/modules/exploits/linux/postgres/postgres_payload.rb
+++ b/modules/exploits/linux/postgres/postgres_payload.rb
@@ -37,6 +37,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'References'     =>
         [
+          [ 'CVE', '2007-3280' ],
           [ 'URL', 'http://www.leidecker.info/pgshell/Having_Fun_With_PostgreSQL.txt' ]
         ],
       'Platform'       => 'linux',

--- a/modules/exploits/linux/ssh/mercurial_ssh_exec.rb
+++ b/modules/exploits/linux/ssh/mercurial_ssh_exec.rb
@@ -23,6 +23,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'References'     =>
         [
+          [ 'CVE', '2017-9462' ],
           ['URL',   'https://www.mercurial-scm.org/wiki/WhatsNew#Mercurial_4.1.3_.282017-4-18.29']
         ],
       'DefaultOptions' =>

--- a/modules/exploits/linux/ssh/solarwinds_lem_exec.rb
+++ b/modules/exploits/linux/ssh/solarwinds_lem_exec.rb
@@ -25,7 +25,8 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'References'     =>
         [
-          ['URL',   'http://pentest.blog/unexpected-journey-4-escaping-from-restricted-shell-and-gaining-root-access-to-solarwinds-log-event-manager-siem-product/']
+          ['CVE', '2017-7722'],
+          ['URL', 'http://pentest.blog/unexpected-journey-4-escaping-from-restricted-shell-and-gaining-root-access-to-solarwinds-log-event-manager-siem-product/']
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/multi/fileformat/swagger_param_inject.rb
+++ b/modules/exploits/multi/fileformat/swagger_param_inject.rb
@@ -39,6 +39,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'References'     =>
         [
+          [ 'CVE', '2016-5641' ],
           [ 'URL', 'http://github.com/swagger-api/swagger-codegen' ],
           [ 'URL', 'https://community.rapid7.com/community/infosec/blog/2016/06/23/r7-2016-06-remote-code-execution-via-swagger-parameter-injection-cve-2016-5641' ]
         ],

--- a/modules/exploits/multi/http/bolt_file_upload.rb
+++ b/modules/exploits/multi/http/bolt_file_upload.rb
@@ -26,6 +26,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'References'      =>
         [
+          ['CVE', '2015-7309'],
           ['URL', 'http://blog.curesec.com/article/blog/Bolt-224-Code-Execution-44.html']
         ],
       'DisclosureDate'  => 'Aug 17 2015',

--- a/modules/exploits/multi/http/clipbucket_fileupload_exec.rb
+++ b/modules/exploits/multi/http/clipbucket_fileupload_exec.rb
@@ -26,6 +26,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'References'      =>
         [
+          [ 'CVE', '2018-7665' ],
           [ 'EDB', '44250' ]
         ],
       'DefaultOptions' =>

--- a/modules/exploits/multi/http/gitlist_arg_injection.rb
+++ b/modules/exploits/multi/http/gitlist_arg_injection.rb
@@ -24,6 +24,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'References'     =>
         [
+          [ 'CVE', '2018-1000533' ],
           [ 'EDB', '44548' ],
           [ 'URL', 'https://security.szurek.pl/exploit-bypass-php-escapeshellarg-escapeshellcmd.html']
         ],

--- a/modules/exploits/multi/http/hp_sitescope_uploadfileshandler.rb
+++ b/modules/exploits/multi/http/hp_sitescope_uploadfileshandler.rb
@@ -31,6 +31,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'     => MSF_LICENSE,
       'References'  =>
         [
+          [ 'CVE', '2012-3260' ],
+          [ 'CVE', '2012-3261' ],
           [ 'OSVDB', '85121' ],
           [ 'OSVDB', '85151' ],
           [ 'BID', '55269' ],

--- a/modules/exploits/multi/http/lcms_php_exec.rb
+++ b/modules/exploits/multi/http/lcms_php_exec.rb
@@ -31,6 +31,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'References'     =>
         [
+          [ 'CVE', '2011-0518' ],
           [ 'OSVDB', '75095' ],
           [ 'URL', 'http://secunia.com/secunia_research/2011-21/' ]
         ],

--- a/modules/exploits/multi/http/nibbleblog_file_upload.rb
+++ b/modules/exploits/multi/http/nibbleblog_file_upload.rb
@@ -26,6 +26,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'References'      =>
         [
+          ['CVE', '2015-6967'],
           ['URL', 'http://blog.curesec.com/article/blog/NibbleBlog-403-Code-Execution-47.html']
         ],
       'DisclosureDate'  => 'Sep 01 2015',

--- a/modules/exploits/multi/http/orientdb_exec.rb
+++ b/modules/exploits/multi/http/orientdb_exec.rb
@@ -24,6 +24,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'References'     =>
         [
+          ['CVE', '2017-11467'],
           ['URL', 'https://blogs.securiteam.com/index.php/archives/3318'],
           ['URL', 'http://www.palada.net/index.php/2017/07/13/news-2112/'],
           ['URL', 'https://github.com/orientechnologies/orientdb/wiki/OrientDB-2.2-Release-Notes#2223---july-11-2017']

--- a/modules/exploits/multi/http/phpfilemanager_rce.rb
+++ b/modules/exploits/multi/http/phpfilemanager_rce.rb
@@ -23,6 +23,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'References'     =>
         [
+          [ 'CVE', '2015-5958' ],
           [ 'EDB', '37709' ],
           [ 'URL', 'http://phpfm.sourceforge.net/' ] # Official Website
         ],

--- a/modules/exploits/multi/http/solarwinds_store_manager_auth_filter.rb
+++ b/modules/exploits/multi/http/solarwinds_store_manager_auth_filter.rb
@@ -28,6 +28,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'     => MSF_LICENSE,
       'References'  =>
         [
+          ['CVE', '2015-5371'],
           ['ZDI', '14-299']
         ],
       'Privileged'  => true,

--- a/modules/exploits/multi/http/testlink_upload_exec.rb
+++ b/modules/exploits/multi/http/testlink_upload_exec.rb
@@ -25,6 +25,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'References'     =>
         [
+          [ 'CVE', '2012-0938' ],
           [ 'OSVDB', '85446' ],
           [ 'EDB',   '20500' ],
           [ 'URL', 'http://itsecuritysolutions.org/2012-08-13-TestLink-1.9.3-multiple-vulnerabilities/' ]

--- a/modules/exploits/multi/http/x7chat2_php_exec.rb
+++ b/modules/exploits/multi/http/x7chat2_php_exec.rb
@@ -26,6 +26,8 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'References'     =>
         [
+          [ 'BID', '71014' ],
+          [ 'CVE', '2014-8998' ],
           # Using this URL because isn't nothing else atm
           ['URL', 'https://github.com/rapid7/metasploit-framework/pull/4076']
         ],

--- a/modules/exploits/osx/local/dyld_print_to_file_root.rb
+++ b/modules/exploits/osx/local/dyld_print_to_file_root.rb
@@ -26,6 +26,7 @@ class MetasploitModule < Msf::Exploit::Local
         'joev'          # Copy/paste monkey
       ],
       'References'     => [
+        ['CVE', '2015-3760'],
         ['URL', 'https://www.sektioneins.de/en/blog/15-07-07-dyld_print_to_file_lpe.html'],
         ['URL', 'https://www.reddit.com/r/netsec/comments/3e34i2/os_x_1010_dyld_print_to_file_local_privilege/']
       ],

--- a/modules/exploits/osx/local/root_no_password.rb
+++ b/modules/exploits/osx/local/root_no_password.rb
@@ -21,6 +21,7 @@ class MetasploitModule < Msf::Exploit::Local
       'License'       => MSF_LICENSE,
       'References'    =>
         [
+          [ 'CVE', '2017-13872' ],
           [ 'URL', 'https://twitter.com/lemiorhan/status/935578694541770752' ],
           [ 'URL', 'https://news.ycombinator.com/item?id=15800676' ],
           [ 'URL', 'https://forums.developer.apple.com/thread/79235' ],

--- a/modules/exploits/unix/http/epmp1000_ping_cmd_shell.rb
+++ b/modules/exploits/unix/http/epmp1000_ping_cmd_shell.rb
@@ -24,6 +24,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'References' =>
         [
+          ['CVE', '2017-5255'],
           ['URL', 'http://ipositivesecurity.com/2015/11/28/cambium-epmp-1000-multiple-vulnerabilities/'],
           ['URL', 'https://support.cambiumnetworks.com/file/476262a0256fdd8be0e595e51f5112e0f9700f83']
         ],

--- a/modules/exploits/unix/http/pfsense_clickjacking.rb
+++ b/modules/exploits/unix/http/pfsense_clickjacking.rb
@@ -27,6 +27,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'License'         => MSF_LICENSE,
         'References'      =>
           [
+            ['CVE', '2017-1000479'],
             ['URL', 'https://securify.nl/en/advisory/SFY20171101/clickjacking-vulnerability-in-csrf-error-page-pfsense.html'],
             ['URL', 'https://doc.pfsense.org/index.php/2.4.2_New_Features_and_Changes']
           ],

--- a/modules/exploits/unix/http/pfsense_graph_injection_exec.rb
+++ b/modules/exploits/unix/http/pfsense_graph_injection_exec.rb
@@ -30,6 +30,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ],
         'References'  =>
           [
+            [ 'CVE', '2016-10709' ],
             [ 'EDB', '39709' ],
             [ 'URL', 'http://www.security-assessment.com/files/documents/advisory/pfsenseAdvisory.pdf']
           ],

--- a/modules/exploits/unix/webapp/wp_optimizepress_upload.rb
+++ b/modules/exploits/unix/webapp/wp_optimizepress_upload.rb
@@ -29,6 +29,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'         => MSF_LICENSE,
       'References'      =>
         [
+          [ 'CVE', '2013-7102' ],
           [ 'URL', "http://www.osirt.com/2013/11/wordpress-optimizepress-hack-file-upload-vulnerability/" ],
           [ 'WPVDB', '7441' ]
         ],

--- a/modules/exploits/unix/webapp/wp_pixabay_images_upload.rb
+++ b/modules/exploits/unix/webapp/wp_pixabay_images_upload.rb
@@ -26,6 +26,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'References'     =>
         [
+          ['CVE', '2015-1376'],
           ['URL', 'https://www.mogwaisecurity.de/advisories/MSA-2015-01.txt'],
           ['OSVDB', '117145'],
           ['OSVDB', '117146'],

--- a/modules/exploits/unix/webapp/wp_revslider_upload_execute.rb
+++ b/modules/exploits/unix/webapp/wp_revslider_upload_execute.rb
@@ -25,6 +25,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'References'     =>
         [
+          ['CVE', '2014-9735'],
           ['OSVDB', '115118'],
           ['EDB', '35385'],
           ['WPVDB', '7954'],

--- a/modules/exploits/unix/webapp/zeroshell_exec.rb
+++ b/modules/exploits/unix/webapp/zeroshell_exec.rb
@@ -29,6 +29,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'References'      =>
         [
+          [ 'CVE', '2009-0545' ],
           [ 'PACKETSTORM', '122799' ]
         ],
       'Platform'        => ['linux'],

--- a/modules/exploits/windows/browser/cisco_playerpt_setsource.rb
+++ b/modules/exploits/windows/browser/cisco_playerpt_setsource.rb
@@ -40,6 +40,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'References'     =>
         [
+          [ 'CVE', '2012-0284' ],
           [ 'OSVDB', '80297' ],
           [ 'EDB', '18641' ]
         ],

--- a/modules/exploits/windows/browser/imgeviewer_tifmergemultifiles.rb
+++ b/modules/exploits/windows/browser/imgeviewer_tifmergemultifiles.rb
@@ -30,6 +30,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'References'     =>
         [
+          [ 'CVE', '2010-5193' ],
           [ 'OSVDB', '78102' ],
           [ 'EDB', '15668' ],
           [ 'URL', 'http://secunia.com/advisories/42445/' ],

--- a/modules/exploits/windows/fileformat/audio_coder_m3u.rb
+++ b/modules/exploits/windows/fileformat/audio_coder_m3u.rb
@@ -26,6 +26,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'References'     =>
         [
+          [ 'CVE', '2017-8870' ],
           [ 'OSVDB', '92939' ],
           [ 'EDB', '25141' ]
         ],

--- a/modules/exploits/windows/fileformat/gsm_sim.rb
+++ b/modules/exploits/windows/fileformat/gsm_sim.rb
@@ -25,6 +25,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'References'      =>
         [
+          [ 'CVE', '2015-1171' ],
           [ 'OSVDB', '81161' ],
           [ 'EDB', '14258' ]
         ],

--- a/modules/exploits/windows/fileformat/mediacoder_m3u.rb
+++ b/modules/exploits/windows/fileformat/mediacoder_m3u.rb
@@ -27,6 +27,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'References'     =>
         [
+          [ 'CVE', '2017-8869' ],
           [ 'OSVDB', '94522' ],
           [ 'EDB', '26403' ]
         ],

--- a/modules/exploits/windows/fileformat/tfm_mmplayer_m3u_ppl_bof.rb
+++ b/modules/exploits/windows/fileformat/tfm_mmplayer_m3u_ppl_bof.rb
@@ -26,6 +26,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'References'     =>
         [
+          [ 'CVE', '2009-2566' ],
           [ 'OSVDB', '80532' ],
           [ 'BID', '52698' ],
           [ 'EDB', '18656' ], # .m3u

--- a/modules/exploits/windows/ftp/kmftp_utility_cwd.rb
+++ b/modules/exploits/windows/ftp/kmftp_utility_cwd.rb
@@ -26,6 +26,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'License' => MSF_LICENSE,
       'References' =>
         [
+          [ 'CVE', '2015-7768' ],
           [ 'EBD', '37908' ]
         ],
       'Privileged' => false,

--- a/modules/exploits/windows/ftp/labf_nfsaxe.rb
+++ b/modules/exploits/windows/ftp/labf_nfsaxe.rb
@@ -25,6 +25,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'References'     =>
         [
+          [ 'CVE', '2017-18047' ],
           [ 'EDB', '42011' ]
         ],
       'Payload'        =>

--- a/modules/exploits/windows/http/disksavvy_get_bof.rb
+++ b/modules/exploits/windows/http/disksavvy_get_bof.rb
@@ -28,6 +28,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'References'     =>
         [
+          ['CVE', '2017-6187'],
           ['EDB', '40869']
         ],
       'DefaultOptions' =>

--- a/modules/exploits/windows/http/disksorter_bof.rb
+++ b/modules/exploits/windows/http/disksorter_bof.rb
@@ -35,6 +35,10 @@ class MetasploitModule < Msf::Exploit::Remote
           'BadChars'   => "\x00\x09\x0a\x0d\x20\x26",
           'Space'      => 500
         },
+      'References'     =>
+        [
+          [ 'CVE', '2017-7230' ]
+        ],
       'Targets'        =>
         [
           [ 'Disk Sorter Enterprise v9.5.12',

--- a/modules/exploits/windows/http/dup_scout_enterprise_login_bof.rb
+++ b/modules/exploits/windows/http/dup_scout_enterprise_login_bof.rb
@@ -24,6 +24,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'References'     =>
         [
+          [ 'CVE', '2017-13696' ],
           [ 'EDB', '43145' ]
         ],
       'DefaultOptions' =>

--- a/modules/exploits/windows/http/efs_fmws_userid_bof.rb
+++ b/modules/exploits/windows/http/efs_fmws_userid_bof.rb
@@ -26,6 +26,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'References'     =>
         [
+          ['CVE',   '2014-3791'],
           ['OSVDB', '107241'],
           ['EDB',   '33610'],
           ['BID',   '67542'],

--- a/modules/exploits/windows/http/syncbreeze_bof.rb
+++ b/modules/exploits/windows/http/syncbreeze_bof.rb
@@ -38,6 +38,10 @@ class MetasploitModule < Msf::Exploit::Remote
           'BadChars'   => "\x00\x09\x0a\x0d\x20\x26",
           'Space'      => 500
         },
+      'References'     =>
+        [
+          [ 'CVE', '2017-14980' ],
+        ],
       'Targets'        =>
         [
           [

--- a/modules/exploits/windows/http/trendmicro_officescan_widget_exec.rb
+++ b/modules/exploits/windows/http/trendmicro_officescan_widget_exec.rb
@@ -30,6 +30,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'References'     =>
         [
+          ['CVE', '2017-11394'],
           ['URL', 'https://pentest.blog/one-ring-to-rule-them-all-same-rce-on-multiple-trend-micro-products/'],
           ['URL', 'http://www.zerodayinitiative.com/advisories/ZDI-17-521/'],
         ],

--- a/modules/exploits/windows/local/ipass_launch_app.rb
+++ b/modules/exploits/windows/local/ipass_launch_app.rb
@@ -43,6 +43,7 @@ class MetasploitModule < Msf::Exploit::Local
         },
       'References'      =>
         [
+          ['CVE', '2015-0925'],
           ['URL', 'https://www.mogwaisecurity.de/advisories/MSA-2015-03.txt']
         ],
       'DisclosureDate' => 'Mar 12 2015',

--- a/modules/exploits/windows/local/novell_client_nicm.rb
+++ b/modules/exploits/windows/local/novell_client_nicm.rb
@@ -53,6 +53,7 @@ class MetasploitModule < Msf::Exploit::Local
         },
       'References'     =>
         [
+          [ 'CVE', '2013-3956' ],
           [ 'OSVDB', '93718' ],
           [ 'URL', 'http://www.novell.com/support/kb/doc.php?id=7012497' ],
           [ 'URL', 'http://pastebin.com/GB4iiEwR' ]

--- a/modules/exploits/windows/misc/allmediaserver_bof.rb
+++ b/modules/exploits/windows/misc/allmediaserver_bof.rb
@@ -30,6 +30,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'References'     =>
         [
+          [ 'CVE', '2017-17932' ],
           [ 'OSVDB', '83889' ],
           [ 'EDB', '19625' ]
         ],

--- a/modules/exploits/windows/misc/bigant_server_usv.rb
+++ b/modules/exploits/windows/misc/bigant_server_usv.rb
@@ -28,6 +28,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'References'     =>
         [
+          [ 'CVE', '2009-4660' ],
           [ 'OSVDB', '61386' ],
           [ 'EDB', '10765' ],
           [ 'EDB', '10973' ]

--- a/modules/exploits/windows/misc/commvault_cmd_exec.rb
+++ b/modules/exploits/windows/misc/commvault_cmd_exec.rb
@@ -29,6 +29,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'References'     =>
         [
+          ['CVE', '2017-18044'],
           ['URL', 'https://www.securifera.com/advisories/sec-2017-0001/']
         ],
       'Platform'       => 'win',

--- a/modules/exploits/windows/misc/disk_savvy_adm.rb
+++ b/modules/exploits/windows/misc/disk_savvy_adm.rb
@@ -33,6 +33,10 @@ class MetasploitModule < Msf::Exploit::Remote
           'BadChars'   => "\x00\x02\x0a\x0d\xf8",
           'Space'      => 800
         },
+      'Referencess'        =>
+        [
+          [ 'CVE', '2018-6481' ]
+        ],
       'Targets'        =>
         [
           [ 'Disk Savvy Enterprise v10.4.18',

--- a/modules/exploits/windows/misc/nettransport.rb
+++ b/modules/exploits/windows/misc/nettransport.rb
@@ -26,6 +26,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'References'     =>
         [
+          [ 'CVE', '2017-17968' ],
           [ 'OSVDB', '61435' ],
           [ 'EDB', '10911'],
         ],

--- a/modules/exploits/windows/misc/solidworks_workgroup_pdmwservice_file_write.rb
+++ b/modules/exploits/windows/misc/solidworks_workgroup_pdmwservice_file_write.rb
@@ -37,6 +37,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'References'     =>
         [
+          ['CVE',   '2014-100015'],
           ['EDB',   '31831'],
           ['OSVDB', '103671']
         ],

--- a/modules/exploits/windows/novell/netiq_pum_eval.rb
+++ b/modules/exploits/windows/novell/netiq_pum_eval.rb
@@ -29,7 +29,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'References'     =>
         [
-          [ 'OSVDB', '87334'],
+          [ 'CVE', '2012-5932' ],
+          [ 'OSVDB', '87334' ],
           [ 'BID', '56539' ],
           [ 'EDB', '22738' ]
         ],

--- a/modules/exploits/windows/novell/zenworks_preboot_op21_bof.rb
+++ b/modules/exploits/windows/novell/zenworks_preboot_op21_bof.rb
@@ -28,6 +28,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'References'     =>
         [
+          [ 'CVE', '2012-2215' ],
           [ 'OSVDB', '65361' ],
           [ 'BID', '40486' ],
           [ 'ZDI', '10-090' ],

--- a/modules/exploits/windows/smtp/sysgauge_client_bof.rb
+++ b/modules/exploits/windows/smtp/sysgauge_client_bof.rb
@@ -24,6 +24,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'References'     =>
       [
+        [ 'CVE', '2017-6416' ],
         [ 'EDB', '41479' ],
       ],
       'DefaultOptions' =>


### PR DESCRIPTION
This PR is the culmination of work by @wchen-r7, @jrobles-r7 and myself, in which we painstakingly combed through every exploit and auxiliary module to provide as many CVE references as possible.

## Verification

Not much verification here, but I did use an `.rc` script to load each module to check for typos that would cause the module to crash at runtime.  If you'd like to use that work:

- [x] Grab the `.rc` file [from this gist](https://gist.github.com/asoto-r7/35469e68a0ec882ab0553b90eb8deb68):

```
wget https://gist.githubusercontent.com/asoto-r7/35469e68a0ec882ab0553b90eb8deb68/raw/f31cc3587569126cbf16cfe861ef3b3ab0e3bfed/load_all_aux_and_exploit_modules.rc
./msfconsole -qr load_all_aux_and_exploit_modules.rc
```

- [x] You should get a lot of output, but no errors.  

```
$
└──╼ $ ./msfconsole -qr load_all_aux_and_exploit_modules.rc
[*] Processing load_all_aux_and_exploit_modules.rc for ERB directives.
resource (load_all_aux_and_exploit_modules.rc)> use exploit/freebsd/http/watchguard_cmd_exec
...
resource (load_all_aux_and_exploit_modules.rc)> use auxiliary/vsploit/pii/web_pii
resource (load_all_aux_and_exploit_modules.rc)> exit
$
```

- [x] Scroll back through the output and make sure you don't see anything like:

```
resource (load_all_aux_and_exploit_modules.rc)> use auxiliary/asoto_screwed_it_up
[-] Failed to load module: auxiliary/asoto_screwed_it_up
resource (load_all_aux_and_exploit_modules.rc)> use auxiliary/parser/unattend
```