### PR TITLE
Fix issue that the check would swallow exceptions 

### DIFF
--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -325,6 +325,9 @@ module Exploit::Remote::HttpClient
     rescue ::Errno::EPIPE, ::Timeout::Error => e
       print_line(e.message) if datastore['HttpTrace']
       nil
+    rescue Rex::ConnectionError => e
+      vprint_error(e.to_s)
+      nil
     rescue ::Exception => e
       print_line(e.message) if datastore['HttpTrace']
       raise e

--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -375,6 +375,9 @@ module Exploit::Remote::HttpClient
     rescue ::Errno::EPIPE, ::Timeout::Error => e
       print_line(e.message) if datastore['HttpTrace']
       nil
+    rescue Rex::ConnectionError => e
+      vprint_error(e.to_s)
+      nil
     rescue ::Exception => e
       print_line(e.message) if datastore['HttpTrace']
       raise e


### PR DESCRIPTION
~relevant : https://github.com/rapid7/metasploit-framework/issues/10229~ This PR is not related to the issue. 


In many `exploit` modules the `check` is writed like this:
```
    res = send_request_cgi(
      'method'  => 'POST',
      'uri'     => '/',
      'headers' => xxx,
      'ctype'   => xxx,
      'data'    => xxx
    )
    if res.nil?
      checkcode = CheckCode::Unknown
    elsif res && res.code == 400 && res.body.include?('xxxx')
      checkcode = CheckCode::Appears
    elsif res && res.code == 401 && res.body =~ xxxx
      checkcode = CheckCode::Safe
    end
    checkcode
```

Most scenarios no problems, except the connection cann't be established, the excetions wouldn't be catched and handled, so the `check` would exit right away with nothing output.

For example module `linux/http/hp_van_sdn_cmd_inject`
```
msf5 exploit(linux/http/hp_van_sdn_cmd_inject) > options 

Module options (exploit/linux/http/hp_van_sdn_cmd_inject):

   Name      Current Setting   Required  Description
   ----      ---------------   --------  -----------
   PASSWORD  skyline           no        Service password
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS    192.168.77.141    yes       The target address range or CIDR identifier
   RPORT     8081              yes       The target port (TCP)
   SSL       true              no        Negotiate SSL/TLS for outgoing connections
   TOKEN     AuroraSdnToken37  no        Service token
   USERNAME  sdn               no        Service username
   VHOST                       no        HTTP server virtual host


Exploit target:

   Id  Name
   --  ----
   0   Unix In-Memory


msf5 exploit(linux/http/hp_van_sdn_cmd_inject) > set verbose
verbose => true
msf5 exploit(linux/http/hp_van_sdn_cmd_inject) > check 

[*] Authenticating with service token AuroraSdnToken37

```

And there are many other modules have the same problems, so I update the `send_request_cgi/raw` to fix it.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use exploit/linux/http/hp_van_sdn_cmd_inject`
- [x] `set rhost 192.168.77.141`
- [x] `check`


