### PR TITLE
show error if server.pid == pid

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
@@ -1113,7 +1113,11 @@ class Console::CommandDispatcher::Core
         print_status("#{existing_relays.length} TCP relay(s) removed.")
       end
     end
-
+    
+    if server.pid == pid
+      print_error("Process already running at PID #{pid}")
+      return
+    end
     server ? print_status("Migrating from #{server.pid} to #{pid}...") : print_status("Migrating to #{pid}")
 
     # Do this thang.


### PR DESCRIPTION
This PR adds changes to catch error when `server.pid` and `pid` are the same

currently doing `migrate <PID>` where PID is same as obtained from `getpid` shows unhandled exception 