### PR TITLE
Add support for HTTP POST and Basic Auth to psnuffle

### DIFF
--- a/data/exploits/psnuffle/url.rb
+++ b/data/exploits/psnuffle/url.rb
@@ -1,22 +1,24 @@
-# Psnuffle password sniffer add-on class for HTTP GET URL's
+# Psnuffle password sniffer add-on class for HTTP URLs
 # part of psnuffle sniffer auxiliary module
-#
-# Very simple example how to write sniffer extensions
-#
 
-# Sniffer class for GET URL's
+#
+# Sniffer class for GET/POST URLs.
+# Also extracts HTTP Basic authentication credentials.
+#
 class SnifferURL < BaseProtocolParser
   def register_sigs
     self.sigs = {
-      :get		=> /^GET\s+([^\n]+)\s+HTTP\/\d\.\d/i,
-      :webhost	=> /^HOST\:\s+([^\n\r]+)/i,
+      :get        => /^GET\s+([^\n]+)\s+HTTP\/\d\.\d/i,
+      :post       => /^POST\s+([^\n]+)\s+HTTP\/\d\.\d/i,
+      :webhost	  => /^HOST:\s+([^\n\r]+)/i,
+      :basic_auth => /^Authorization:\s+Basic\s+([^\n\r]+)/i,
     }
   end
 
   def parse(pkt)
-    # We want to return immediantly if	we do not have a packet which is handled by us
+    # We want to return immediatly if	we do not have a packet which is handled by us
     return unless pkt.is_tcp?
-    return if (pkt.tcp_sport != 80 and pkt.tcp_dport != 80)
+    return if (pkt.tcp_sport != 80 && pkt.tcp_dport != 80)
     s = find_session((pkt.tcp_sport == 80) ? get_session_src(pkt) : get_session_dst(pkt))
 
     self.sigs.each_key do |k|
@@ -34,10 +36,16 @@ class SnifferURL < BaseProtocolParser
       case matched
       when :webhost
         sessions[s[:session]].merge!({k => matches})
-        if(s[:get])
+        if s[:get]
           print_status("HTTP GET: #{s[:session]} http://#{s[:webhost]}#{s[:get]}")
-          sessions.delete(s[:session])
-          return
+        end
+        if s[:post]
+          print_status("HTTP POST: #{s[:session]} http://#{s[:webhost]}#{s[:post]}")
+        end
+        if s[:basic_auth]
+          s[:user], s[:pass] = Rex::Text.decode_base64(s[:basic_auth]).split(':', 2)
+          report_auth_info s
+          print_status "HTTP Basic Authentication: #{s[:session]} >> #{s[:user]} / #{s[:pass]}"
         end
       when nil
         # No matches, no saved state
@@ -45,4 +53,3 @@ class SnifferURL < BaseProtocolParser
     end # end of each_key
   end # end of parse
 end # end of URL sniffer
-


### PR DESCRIPTION
This PR adds support for HTTP POST and Basic Authentication to psnuffle.

From the does-anyone-even-use-this department.

This code is pretty bad. It's probably not even correct. The psnuffle codebase did not age well, the code comments are a lie, and the documentation does not exist.

Also, I removed `sessions.delete(s[:session])`. Seems like that was probably important to prevent using tonnes of memory. `¯\_(ツ)_/¯`

**Test**

```
wget 'https://github.com/LiamRandall/BsidesDC-Training/raw/master/http-auth/http-basic-auth.pcap' -O /tmp/http-basic-auth.pcap

msf5 > use auxiliary/sniffer/psnuffle 
msf5 auxiliary(sniffer/psnuffle) > # use undocumented feature to load pcap file
msf5 auxiliary(sniffer/psnuffle) > set pcapfile /tmp/http-basic-auth.pcap
pcapfile => /tmp/http-basic-auth.pcap
```

**HTTP Basic Authentication**

Marvel at this beautiful output.

```
msf5 auxiliary(sniffer/psnuffle) > rexploit 
[*] Stopping existing job...
[*] Reloading module...
[*] Auxiliary module running as background job 86.

[*] Loaded protocol FTP from /pentest/exploit/metasploit-framework/data/exploits/psnuffle/ftp.rb...
[*] Loaded protocol IMAP from /pentest/exploit/metasploit-framework/data/exploits/psnuffle/imap.rb...
[*] Loaded protocol POP3 from /pentest/exploit/metasploit-framework/data/exploits/psnuffle/pop3.rb...
[*] Loaded protocol SMB from /pentest/exploit/metasploit-framework/data/exploits/psnuffle/smb.rb...
[*] Loaded protocol URL from /pentest/exploit/metasploit-framework/data/exploits/psnuffle/url.rb...
[*] Sniffing traffic.....
[*] HTTP GET: 192.168.0.4:54317-192.254.189.169:80 http://browserspy.dk/password-ok.php
[*] HTTP GET: 192.168.0.4:54318-192.254.189.169:80 http://browserspy.dk/password-ok.php
[*] HTTP GET: 192.168.0.4:54337-192.254.189.169:80 http://browserspy.dk/password-ok.php
[*] HTTP GET: 192.168.0.4:54338-192.254.189.169:80 http://browserspy.dk/password-ok.php
[*] HTTP GET: 192.168.0.4:54338-192.254.189.169:80 http://browserspy.dk/password-ok.php
[!] *** auxiliary/sniffer/psnuffle is still calling the deprecated report_auth_info method! This needs to be updated!
[!] *** For detailed information about LoginScanners and the Credentials objects see:
[!]      https://github.com/rapid7/metasploit-framework/wiki/Creating-Metasploit-Framework-LoginScanners
[!]      https://github.com/rapid7/metasploit-framework/wiki/How-to-write-a-HTTP-LoginScanner-Module
[!] *** For examples of modules converted to just report credentials without report_auth_info, see:
[!]      https://github.com/rapid7/metasploit-framework/pull/5376
[!]      https://github.com/rapid7/metasploit-framework/pull/5377
[*] HTTP Basic Authentication: 192.168.0.4:54338-192.254.189.169:80 >> test / fail3
[*] HTTP GET: 192.168.0.4:54338-192.254.189.169:80 http://browserspy.dk/theme/reset.css
[!] *** auxiliary/sniffer/psnuffle is still calling the deprecated report_auth_info method! This needs to be updated!
[!] *** For detailed information about LoginScanners and the Credentials objects see:
[!]      https://github.com/rapid7/metasploit-framework/wiki/Creating-Metasploit-Framework-LoginScanners
[!]      https://github.com/rapid7/metasploit-framework/wiki/How-to-write-a-HTTP-LoginScanner-Module
[!] *** For examples of modules converted to just report credentials without report_auth_info, see:
[!]      https://github.com/rapid7/metasploit-framework/pull/5376
[!]      https://github.com/rapid7/metasploit-framework/pull/5377
[*] HTTP Basic Authentication: 192.168.0.4:54338-192.254.189.169:80 >> test / test
[*] HTTP GET: 192.168.0.4:54340-192.254.189.169:80 http://browserspy.dk/theme/default.css
[*] HTTP GET: 192.168.0.4:54341-192.254.189.169:80 http://browserspy.dk/js/jquery.js
[*] HTTP GET: 192.168.0.4:54342-192.254.189.169:80 http://browserspy.dk/pics/logo.png
[*] HTTP GET: 192.168.0.4:54342-192.254.189.169:80 http://browserspy.dk/theme/header.gif
[!] *** auxiliary/sniffer/psnuffle is still calling the deprecated report_auth_info method! This needs to be updated!
[!] *** For detailed information about LoginScanners and the Credentials objects see:
msf5 auxiliary(sniffer/psnuffle) > [!]      https://github.com/rapid7/metasploit-framework/wiki/Creating-Metasploit-Framework-LoginScanners
[!]      https://github.com/rapid7/metasploit-framework/wiki/How-to-write-a-HTTP-LoginScanner-Module
[!] *** For examples of modules converted to just report credentials without report_auth_info, see:
[!]      https://github.com/rapid7/metasploit-framework/pull/5376
[!]      https://github.com/rapid7/metasploit-framework/pull/5377
[*] HTTP Basic Authentication: 192.168.0.4:54342-192.254.189.169:80 >> test / test
[*] HTTP GET: 192.168.0.4:54341-192.254.189.169:80 http://browserspy.dk/pics/beta.png
[!] *** auxiliary/sniffer/psnuffle is still calling the deprecated report_auth_info method! This needs to be updated!
[!] *** For detailed information about LoginScanners and the Credentials objects see:
[!]      https://github.com/rapid7/metasploit-framework/wiki/Creating-Metasploit-Framework-LoginScanners
[!]      https://github.com/rapid7/metasploit-framework/wiki/How-to-write-a-HTTP-LoginScanner-Module
[!] *** For examples of modules converted to just report credentials without report_auth_info, see:
[!]      https://github.com/rapid7/metasploit-framework/pull/5376
[!]      https://github.com/rapid7/metasploit-framework/pull/5377
[*] HTTP Basic Authentication: 192.168.0.4:54341-192.254.189.169:80 >> test / test
[*] HTTP GET: 192.168.0.4:54340-192.254.189.169:80 http://browserspy.dk/theme/background.gif
[!] *** auxiliary/sniffer/psnuffle is still calling the deprecated report_auth_info method! This needs to be updated!
[!] *** For detailed information about LoginScanners and the Credentials objects see:
[!]      https://github.com/rapid7/metasploit-framework/wiki/Creating-Metasploit-Framework-LoginScanners
[!]      https://github.com/rapid7/metasploit-framework/wiki/How-to-write-a-HTTP-LoginScanner-Module
[!] *** For examples of modules converted to just report credentials without report_auth_info, see:
[!]      https://github.com/rapid7/metasploit-framework/pull/5376
[!]      https://github.com/rapid7/metasploit-framework/pull/5377
[*] HTTP Basic Authentication: 192.168.0.4:54340-192.254.189.169:80 >> test / test
[*] HTTP GET: 192.168.0.4:54338-192.254.189.169:80 http://browserspy.dk/theme/bullet_black.png
[!] *** auxiliary/sniffer/psnuffle is still calling the deprecated report_auth_info method! This needs to be updated!
[!] *** For detailed information about LoginScanners and the Credentials objects see:
[!]      https://github.com/rapid7/metasploit-framework/wiki/Creating-Metasploit-Framework-LoginScanners
[!]      https://github.com/rapid7/metasploit-framework/wiki/How-to-write-a-HTTP-LoginScanner-Module
[!] *** For examples of modules converted to just report credentials without report_auth_info, see:
[!]      https://github.com/rapid7/metasploit-framework/pull/5376
[!]      https://github.com/rapid7/metasploit-framework/pull/5377
[*] HTTP Basic Authentication: 192.168.0.4:54338-192.254.189.169:80 >> test / test
[*] HTTP GET: 192.168.0.4:54343-192.254.189.169:80 http://browserspy.dk/pics/menunew.png
[*] HTTP GET: 192.168.0.4:54342-192.254.189.169:80 http://browserspy.dk/theme/tr_back.jpg
[!] *** auxiliary/sniffer/psnuffle is still calling the deprecated report_auth_info method! This needs to be updated!
[!] *** For detailed information about LoginScanners and the Credentials objects see:
[!]      https://github.com/rapid7/metasploit-framework/wiki/Creating-Metasploit-Framework-LoginScanners
[!]      https://github.com/rapid7/metasploit-framework/wiki/How-to-write-a-HTTP-LoginScanner-Module
[!] *** For examples of modules converted to just report credentials without report_auth_info, see:
[!]      https://github.com/rapid7/metasploit-framework/pull/5376
[!]      https://github.com/rapid7/metasploit-framework/pull/5377
[*] HTTP Basic Authentication: 192.168.0.4:54342-192.254.189.169:80 >> test / test
[*] HTTP GET: 192.168.0.4:54341-192.254.189.169:80 http://browserspy.dk/theme/link_internal.png
[!] *** auxiliary/sniffer/psnuffle is still calling the deprecated report_auth_info method! This needs to be updated!
[!] *** For detailed information about LoginScanners and the Credentials objects see:
[!]      https://github.com/rapid7/metasploit-framework/wiki/Creating-Metasploit-Framework-LoginScanners
[!]      https://github.com/rapid7/metasploit-framework/wiki/How-to-write-a-HTTP-LoginScanner-Module
[!] *** For examples of modules converted to just report credentials without report_auth_info, see:
[!]      https://github.com/rapid7/metasploit-framework/pull/5376
[!]      https://github.com/rapid7/metasploit-framework/pull/5377
[*] HTTP Basic Authentication: 192.168.0.4:54341-192.254.189.169:80 >> test / test
[*] HTTP GET: 192.168.0.4:54340-192.254.189.169:80 http://browserspy.dk/theme/link_external.png
[!] *** auxiliary/sniffer/psnuffle is still calling the deprecated report_auth_info method! This needs to be updated!
[!] *** For detailed information about LoginScanners and the Credentials objects see:
[!]      https://github.com/rapid7/metasploit-framework/wiki/Creating-Metasploit-Framework-LoginScanners
[!]      https://github.com/rapid7/metasploit-framework/wiki/How-to-write-a-HTTP-LoginScanner-Module
[!] *** For examples of modules converted to just report credentials without report_auth_info, see:
[!]      https://github.com/rapid7/metasploit-framework/pull/5376
[!]      https://github.com/rapid7/metasploit-framework/pull/5377
[*] HTTP Basic Authentication: 192.168.0.4:54340-192.254.189.169:80 >> test / test
[*] HTTP GET: 192.168.0.4:54340-192.254.189.169:80 http://browserspy.dk/password.php
[!] *** auxiliary/sniffer/psnuffle is still calling the deprecated report_auth_info method! This needs to be updated!
[!] *** For detailed information about LoginScanners and the Credentials objects see:
[!]      https://github.com/rapid7/metasploit-framework/wiki/Creating-Metasploit-Framework-LoginScanners
[!]      https://github.com/rapid7/metasploit-framework/wiki/How-to-write-a-HTTP-LoginScanner-Module
[!] *** For examples of modules converted to just report credentials without report_auth_info, see:
[!]      https://github.com/rapid7/metasploit-framework/pull/5376
[!]      https://github.com/rapid7/metasploit-framework/pull/5377
[*] HTTP Basic Authentication: 192.168.0.4:54340-192.254.189.169:80 >> test / test
[*] HTTP GET: 192.168.0.4:54340-192.254.189.169:80 http://browserspy.dk/password-ok.php
[!] *** auxiliary/sniffer/psnuffle is still calling the deprecated report_auth_info method! This needs to be updated!
[!] *** For detailed information about LoginScanners and the Credentials objects see:
[!]      https://github.com/rapid7/metasploit-framework/wiki/Creating-Metasploit-Framework-LoginScanners
[!]      https://github.com/rapid7/metasploit-framework/wiki/How-to-write-a-HTTP-LoginScanner-Module
[!] *** For examples of modules converted to just report credentials without report_auth_info, see:
[!]      https://github.com/rapid7/metasploit-framework/pull/5376
[!]      https://github.com/rapid7/metasploit-framework/pull/5377
[*] HTTP Basic Authentication: 192.168.0.4:54340-192.254.189.169:80 >> test / test
[*] HTTP GET: 192.168.0.4:54340-192.254.189.169:80 http://browserspy.dk/password.php
[!] *** auxiliary/sniffer/psnuffle is still calling the deprecated report_auth_info method! This needs to be updated!
[!] *** For detailed information about LoginScanners and the Credentials objects see:
[!]      https://github.com/rapid7/metasploit-framework/wiki/Creating-Metasploit-Framework-LoginScanners
[!]      https://github.com/rapid7/metasploit-framework/wiki/How-to-write-a-HTTP-LoginScanner-Module
[!] *** For examples of modules converted to just report credentials without report_auth_info, see:
[!]      https://github.com/rapid7/metasploit-framework/pull/5376
[!]      https://github.com/rapid7/metasploit-framework/pull/5377
[*] HTTP Basic Authentication: 192.168.0.4:54340-192.254.189.169:80 >> test / test
[*] HTTP GET: 192.168.0.4:54340-192.254.189.169:80 http://browserspy.dk/password-ok.php
[!] *** auxiliary/sniffer/psnuffle is still calling the deprecated report_auth_info method! This needs to be updated!
[!] *** For detailed information about LoginScanners and the Credentials objects see:
[!]      https://github.com/rapid7/metasploit-framework/wiki/Creating-Metasploit-Framework-LoginScanners
[!]      https://github.com/rapid7/metasploit-framework/wiki/How-to-write-a-HTTP-LoginScanner-Module
[!] *** For examples of modules converted to just report credentials without report_auth_info, see:
[!]      https://github.com/rapid7/metasploit-framework/pull/5376
[!]      https://github.com/rapid7/metasploit-framework/pull/5377
[*] HTTP Basic Authentication: 192.168.0.4:54340-192.254.189.169:80 >> test / test
[*] HTTP GET: 192.168.0.4:54340-192.254.189.169:80 http://browserspy.dk/password.php
[!] *** auxiliary/sniffer/psnuffle is still calling the deprecated report_auth_info method! This needs to be updated!
[!] *** For detailed information about LoginScanners and the Credentials objects see:
[!]      https://github.com/rapid7/metasploit-framework/wiki/Creating-Metasploit-Framework-LoginScanners
[!]      https://github.com/rapid7/metasploit-framework/wiki/How-to-write-a-HTTP-LoginScanner-Module
[!] *** For examples of modules converted to just report credentials without report_auth_info, see:
[!]      https://github.com/rapid7/metasploit-framework/pull/5376
[!]      https://github.com/rapid7/metasploit-framework/pull/5377
[*] HTTP Basic Authentication: 192.168.0.4:54340-192.254.189.169:80 >> test / test
[*] HTTP GET: 192.168.0.4:54487-192.254.189.169:80 http://browserspy.dk/password.php
[*] HTTP GET: 192.168.0.4:54505-192.254.189.169:80 http://browserspy.dk/password.php
[*] HTTP GET: 192.168.0.4:54505-192.254.189.169:80 http://browserspy.dk/password-ok.php
[!] *** auxiliary/sniffer/psnuffle is still calling the deprecated report_auth_info method! This needs to be updated!
[!] *** For detailed information about LoginScanners and the Credentials objects see:
[!]      https://github.com/rapid7/metasploit-framework/wiki/Creating-Metasploit-Framework-LoginScanners
[!]      https://github.com/rapid7/metasploit-framework/wiki/How-to-write-a-HTTP-LoginScanner-Module
[!] *** For examples of modules converted to just report credentials without report_auth_info, see:
[!]      https://github.com/rapid7/metasploit-framework/pull/5376
[!]      https://github.com/rapid7/metasploit-framework/pull/5377
[*] HTTP Basic Authentication: 192.168.0.4:54505-192.254.189.169:80 >> test / test
[*] HTTP GET: 192.168.0.4:54506-192.254.189.169:80 http://browserspy.dk/?_=1381844104551
[*] HTTP GET: 192.168.0.4:54580-192.254.189.169:80 http://browserspy.dk/password-ok.php
[*] HTTP GET: 192.168.0.4:54581-192.254.189.169:80 http://browserspy.dk/theme/reset.css
[*] HTTP GET: 192.168.0.4:54582-192.254.189.169:80 http://browserspy.dk/theme/default.css
[*] HTTP GET: 192.168.0.4:54583-192.254.189.169:80 http://browserspy.dk/js/jquery.js
[*] HTTP GET: 192.168.0.4:54584-192.254.189.169:80 http://browserspy.dk/pics/logo.png
[*] HTTP GET: 192.168.0.4:54584-192.254.189.169:80 http://browserspy.dk/password.php
[!] *** auxiliary/sniffer/psnuffle is still calling the deprecated report_auth_info method! This needs to be updated!
[!] *** For detailed information about LoginScanners and the Credentials objects see:
[!]      https://github.com/rapid7/metasploit-framework/wiki/Creating-Metasploit-Framework-LoginScanners
[!]      https://github.com/rapid7/metasploit-framework/wiki/How-to-write-a-HTTP-LoginScanner-Module
[!] *** For examples of modules converted to just report credentials without report_auth_info, see:
[!]      https://github.com/rapid7/metasploit-framework/pull/5376
[!]      https://github.com/rapid7/metasploit-framework/pull/5377
[*] HTTP Basic Authentication: 192.168.0.4:54584-192.254.189.169:80 >> test / test
[*] HTTP GET: 192.168.0.4:54584-192.254.189.169:80 http://browserspy.dk/password-ok.php
[!] *** auxiliary/sniffer/psnuffle is still calling the deprecated report_auth_info method! This needs to be updated!
[!] *** For detailed information about LoginScanners and the Credentials objects see:
[!]      https://github.com/rapid7/metasploit-framework/wiki/Creating-Metasploit-Framework-LoginScanners
[!]      https://github.com/rapid7/metasploit-framework/wiki/How-to-write-a-HTTP-LoginScanner-Module
[!] *** For examples of modules converted to just report credentials without report_auth_info, see:
[!]      https://github.com/rapid7/metasploit-framework/pull/5376
[!]      https://github.com/rapid7/metasploit-framework/pull/5377
[*] HTTP Basic Authentication: 192.168.0.4:54584-192.254.189.169:80 >> test / test
[*] Finished sniffing
```


**HTTP POST**

```
msf5 auxiliary(sniffer/psnuffle) > run
[*] Auxiliary module running as background job 88.

[*] Loaded protocol FTP from /pentest/exploit/metasploit-framework/data/exploits/psnuffle/ftp.rb...
[*] Loaded protocol IMAP from /pentest/exploit/metasploit-framework/data/exploits/psnuffle/imap.rb...
[*] Loaded protocol POP3 from /pentest/exploit/metasploit-framework/data/exploits/psnuffle/pop3.rb...
[*] Loaded protocol SMB from /pentest/exploit/metasploit-framework/data/exploits/psnuffle/smb.rb...
[*] Loaded protocol URL from /pentest/exploit/metasploit-framework/data/exploits/psnuffle/url.rb...
[*] Sniffing traffic.....
[*] HTTP GET: 172.16.191.188:41741-10.1.1.1:80 http://10.1.1.1/
[*] HTTP GET: 172.16.191.188:45321-93.184.216.34:80 http://example.com/
[*] HTTP GET: 172.16.191.188:45321-93.184.216.34:80 http://example.com/favicon.ico
[*] HTTP GET: 172.16.191.188:45321-93.184.216.34:80 http://example.com/favicon.ico
[*] HTTP GET: 172.16.191.188:45321-93.184.216.34:80 http://example.com/favicon.ico
[*] HTTP POST: 172.16.191.188:45321-93.184.216.34:80 http://example.com/form
[*] Finished sniffing
```
