### PR TITLE
Check if IPRANGE was supplied - Fix #10316

### DIFF
--- a/modules/auxiliary/gather/enum_dns.rb
+++ b/modules/auxiliary/gather/enum_dns.rb
@@ -138,6 +138,11 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def dns_reverse(cidr, threads)
+    unless cidr
+      print_error 'ENUM_RVL enabled, but no IPRANGE specified'
+      return
+    end
+
     iplst = []
     ipadd = Rex::Socket::RangeWalker.new(cidr)
     numip = ipadd.num_ips


### PR DESCRIPTION
Check if `IPRANGE` was supplied - Fix #10316

```
msf5 auxiliary(gather/enum_dns) > rexploit 
[*] Reloading module...

[*] querying DNS MX records for google.it
[+] google.it MX: alt2.aspmx.l.google.com.
[+] google.it MX: aspmx.l.google.com.
[+] google.it MX: alt3.aspmx.l.google.com.
[+] google.it MX: alt1.aspmx.l.google.com.
[+] google.it MX: alt4.aspmx.l.google.com.
[*] #<Rex::Socket::RangeWalker:0x00000018b18830 @ranges=nil>
[*] iplst.length: 0
[*] numip: 
[-] Auxiliary failed: ArgumentError comparison of Fixnum with nil failed
[-] Call stack:
[-]   /pentest/exploit/metasploit-framework/modules/auxiliary/gather/enum_dns.rb:147:in `<'
[-]   /pentest/exploit/metasploit-framework/modules/auxiliary/gather/enum_dns.rb:147:in `dns_reverse'
[-]   /pentest/exploit/metasploit-framework/modules/auxiliary/gather/enum_dns.rb:73:in `run'
[*] Auxiliary module execution completed
```

```
msf5 auxiliary(gather/enum_dns) > rexploit 
[*] Reloading module...

[*] querying DNS MX records for google.it
[+] google.it MX: alt2.aspmx.l.google.com.
[+] google.it MX: alt1.aspmx.l.google.com.
[+] google.it MX: aspmx.l.google.com.
[+] google.it MX: alt4.aspmx.l.google.com.
[+] google.it MX: alt3.aspmx.l.google.com.
[-] ENUM_RVL enabled, but no IPRANGE specified
[*] Auxiliary module execution completed
```

```
msf5 auxiliary(gather/enum_dns) > set iprange 127.0.
iprange => 127.0.
msf5 auxiliary(gather/enum_dns) > run
[-] Auxiliary failed: Msf::OptionValidateError The following options failed to validate: IPRANGE.
msf5 auxiliary(gather/enum_dns) > set iprange 127.0.0.1
iprange => 127.0.0.1
msf5 auxiliary(gather/enum_dns) > run

[*] querying DNS MX records for google.it
[+] google.it MX: alt4.aspmx.l.google.com.
[+] google.it MX: aspmx.l.google.com.
[+] google.it MX: alt2.aspmx.l.google.com.
[+] google.it MX: alt1.aspmx.l.google.com.
[+] google.it MX: alt3.aspmx.l.google.com.
[+] 127.0.0.1: PTR: localhost. 
[*] Auxiliary module execution completed
```