### PR TITLE
Update ms15_034_http_sys_memory_dump.rb with VHOST

### DIFF
--- a/modules/auxiliary/scanner/http/ms15_034_http_sys_memory_dump.rb
+++ b/modules/auxiliary/scanner/http/ms15_034_http_sys_memory_dump.rb
@@ -23,7 +23,9 @@ class MetasploitModule < Msf::Auxiliary
       'Author'      =>
         [
           'Rich Whitcroft <rwhitcroft[at]gmail.com>', # Msf module
-          'sinn3r'                                    # Some more Metasploit stuff
+          'sinn3r',                                   # Some more Metasploit stuff
+          'Sunny Neo <sunny.neo[at]centurioninfosec.sg>' #Added VHOST option
+
         ],
       'License'     => MSF_LICENSE,
       'References'  =>
@@ -43,7 +45,6 @@ class MetasploitModule < Msf::Auxiliary
       OptBool.new('SUPPRESS_REQUEST', [ true, 'Suppress output of the requested resource', true ])
     ])
 
-    deregister_options('VHOST')
   end
 
   def potential_static_files_uris
@@ -186,6 +187,7 @@ class MetasploitModule < Msf::Auxiliary
       req = cli.request_raw(
         'uri' => target_uri.path,
         'method' => 'GET',
+        'vhost' => "#{datastore['VHOST']}",
         'headers' => {
         'Range' => ranges
         }


### PR DESCRIPTION
Added VHOST to cater to targets that require virtual hostname to be defined

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/http/ms15_034_http_sys_memory_dump`
- [x] Set the parameters you need to set
- [x] `exploit`
