### PR TITLE
Add support for Windows 2016 to Msf::Post::Windows::Priv.is_uac_enabled

### DIFF
--- a/lib/msf/core/post/windows/priv.rb
+++ b/lib/msf/core/post/windows/priv.rb
@@ -124,7 +124,7 @@ module Msf::Post::Windows::Priv
   # if running on a system that does not have UAC
   #
   def is_uac_enabled?
-    return false unless is_system?
+    return false if is_system?
 
     winversion = session.sys.config.sysinfo['OS']
     return false unless winversion =~ /Windows (Vista|7|8|10|2008|2012|2016)/

--- a/lib/msf/core/post/windows/priv.rb
+++ b/lib/msf/core/post/windows/priv.rb
@@ -124,23 +124,19 @@ module Msf::Post::Windows::Priv
   # if running on a system that does not have UAC
   #
   def is_uac_enabled?
-    uac = false
-    winversion = session.sys.config.sysinfo['OS']
+    return false unless is_system?
 
-    if winversion =~ /Windows (Vista|7|8|2008|2012|10)/
-      unless is_system?
-        begin
-          enable_lua = registry_getvaldata(
-              'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System',
-              'EnableLUA'
-          )
-          uac = (enable_lua == 1)
-        rescue Rex::Post::Meterpreter::RequestError => e
-          print_error("Error Checking if UAC is Enabled: #{e.class} #{e}")
-        end
-      end
-    end
-    return uac
+    winversion = session.sys.config.sysinfo['OS']
+    return false unless winversion =~ /Windows (Vista|7|8|10|2008|2012|2016)/
+
+    enable_lua = registry_getvaldata(
+      'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System',
+      'EnableLUA'
+    )
+    (enable_lua == 1)
+  rescue Rex::Post::Meterpreter::RequestError => e
+    print_error("Error Checking if UAC is Enabled: #{e.class} #{e}")
+    return false
   end
 
   #

--- a/lib/msf/core/post/windows/priv.rb
+++ b/lib/msf/core/post/windows/priv.rb
@@ -129,11 +129,10 @@ module Msf::Post::Windows::Priv
     winversion = session.sys.config.sysinfo['OS']
     return false unless winversion =~ /Windows (Vista|7|8|10|2008|2012|2016)/
 
-    enable_lua = registry_getvaldata(
+    registry_getvaldata(
       'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System',
       'EnableLUA'
-    )
-    (enable_lua == 1)
+    ).eql?(1)
   rescue Rex::Post::Meterpreter::RequestError => e
     print_error("Error Checking if UAC is Enabled: #{e.class} #{e}")
     return false


### PR DESCRIPTION
This PR adds support for Windows 2016 to `Msf::Post::Windows::Priv.is_uac_enabled`.

The `is_uac_enabled` Post API method used the following regex match: `/Windows (Vista|7|8|2008|2012|10)/`

This obviously ignores Windows 2016. The method returns a Boolean, and will return `false` by default.

I've fixed the regex and golfed the code a bit while I was at it.

Also, note the following code segment from `modules/exploits/windows/local/bypassuac_comhijack.rb`, which would never work as expected without this patch, preventing the module from executing on Windows 2016.

```ruby
  def exploit
    # ... snip ...
    check_permissions!
    # ... snip ...
  end

  def check_permissions!
    # ... snip ...
    unless check == Exploit::CheckCode::Appears                                                                 
      fail_with(Failure::NotVulnerable, "Target is not vulnerable.")
    end
    # ... snip ...
  end

  def check
    if sysinfo['OS'] =~ /Windows (7|8|10|2008|2012|2016)/ && is_uac_enabled?
      Exploit::CheckCode::Appears
    else
      Exploit::CheckCode::Safe
    end
  end
```

**I haven't tested this at all.** However, the regex change is trivial, and the UAC bypass module leads me to believe that `Windows 2016` is in fact a valid value for `sysinfo['OS']`, and the code golfing is functionally identical.
