### PR TITLE
bind_named_pipe payload for ruby_smb

### DIFF
--- a/lib/msf/core/handler/bind_named_pipe.rb
+++ b/lib/msf/core/handler/bind_named_pipe.rb
@@ -9,7 +9,6 @@ require 'rex/proto/smb/simpleclient'
 # 1) A peek named pipe operation is carried out before every read to prevent blocking. This
 #    generates extra traffic. SMB echo requests are also generated to force the packet
 #    dispatcher to perform a read.
-# 2) SMB1 only. Switch to ruby_smb.
 #
 
 #
@@ -41,29 +40,6 @@ class OpenPipeSock < Rex::Proto::SMB::SimpleClient::OpenPipe
     self.read_buff = ''
     self.server_max_buffer_size = server_max_buffer_size # max transaction size
     self.chunk_size = server_max_buffer_size - 260       # max read/write size
-  end
-
-  # Check if there are any bytes to read and return number available. Access must be synchronized.
-  def peek_named_pipe
-    # 0x23 is the PeekNamedPipe operation. Last 16 bits is our pipes file id (FID).
-    setup = [0x23, self.file_id].pack('vv')
-    # Must ignore errors since we expect STATUS_BUFFER_OVERFLOW
-    pkt = self.client.trans_maxzero('\\PIPE\\', '', '', 2, setup, false, true, true)
-    if pkt['Payload']['SMB'].v['ErrorClass'] == STATUS_PIPE_BROKEN
-      raise IOError
-    end
-    avail = 0
-    begin
-      avail = pkt.to_s[pkt['Payload'].v['ParamOffset']+4, 2].unpack('v')[0]
-      self.last_comm = Time.now
-    rescue
-    end
-
-    if (avail == 0) and (pkt['Payload']['SMB'].v['ErrorClass'] == STATUS_BUFFER_OVERFLOW)
-      avail = self.client.default_max_buffer_size
-    end
-
-    avail
   end
 
   # Send echo request to force select() to return in the packet dispatcher and read from the socket.
@@ -125,7 +101,8 @@ class OpenPipeSock < Rex::Proto::SMB::SimpleClient::OpenPipe
     if count > self.read_buff.length
       # need more data to satisfy request
       self.mutex.synchronize do
-        avail = peek_named_pipe
+        avail = peek
+        self.last_comm = Time.now
         if avail > 0
           left = [count-self.read_buff.length, avail].max
           while left > 0
@@ -164,15 +141,15 @@ class OpenPipeSock < Rex::Proto::SMB::SimpleClient::OpenPipe
   # connection.
   #
   def fd
-    self.client.socket.fd
+    self.simple.socket.fd
   end
 
   def localinfo
-    self.client.socket.localinfo
+    self.simple.socket.localinfo
   end
 
   def peerinfo
-    self.client.socket.peerinfo
+    self.simple.socket.peerinfo
   end
 
 end
@@ -184,19 +161,17 @@ end
 class SimpleClientPipe < Rex::Proto::SMB::SimpleClient
   attr_accessor :pipe
 
-  def initialize(*args)
-    super(*args)
+  def initialize(socket, direct, versions = [1, 2])
+    super(socket, direct, versions)
     self.pipe = nil
   end
 
   # Copy of SimpleClient.create_pipe except OpenPipeSock is used instead of OpenPipe.
   # This is because we need to implement our own read/write.
   def create_pipe(path)
-    pkt = self.client.create_pipe(path, Rex::Proto::SMB::Constants::CREATE_ACCESS_EXIST)
-    file_id = pkt['Payload'].v['FileID']
-    versions = [1]              # requires rex so SMB1 only
-    self.pipe = OpenPipeSock.new(self.client, path, self.client.last_tree_id, file_id, versions, simple: self,
-                                 server_max_buffer_size: self.server_max_buffer_size)
+    self.client.create_pipe(path)
+    self.pipe = OpenPipeSock.new(self.client, path, self.client.last_tree_id, self.client.last_file_id, self.versions,
+                                 simple: self, server_max_buffer_size: self.server_max_buffer_size)
   end
 end
 
@@ -336,7 +311,13 @@ module Msf
               unless ['STATUS_OBJECT_NAME_NOT_FOUND', 'STATUS_PIPE_NOT_AVAILABLE'].include? error_name
                 print_error("Error connecting to #{pipe_name}: #{error_name}")
                 exit
+              else
+                # Stager pipe may not be ready
+                vprint_status("Error connecting to #{pipe_name}: #{error_name}")
               end
+              Rex::ThreadSafe.sleep(1.0)
+            rescue RubySMB::Error::RubySMBError => e
+              print_error("Error connecting to #{pipe_name}: #{e.message}")
               Rex::ThreadSafe.sleep(1.0)
             end
             break if pipe

--- a/lib/msf/core/handler/bind_named_pipe.rb
+++ b/lib/msf/core/handler/bind_named_pipe.rb
@@ -220,6 +220,7 @@ module Msf
 
         self.conn_threads = []
         self.listener_threads = []
+        self.listener_pairs = {}
       end
 
       # A string suitable for displaying to the user
@@ -253,6 +254,11 @@ module Msf
         # Ignore this if one of the required options is missing
         return if not rhost
         return if not lport
+
+        # dont spawn multiple handlers for same host and pipe
+        pair = rhost + ":" + lport.to_s + ":" + pipe_name
+        return if self.listener_pairs[pair]
+        self.listener_pairs[pair] = true
 
         # Start a new handling thread
         self.listener_threads << framework.threads.spawn("BindNamedPipeHandlerListener-#{pipe_name}", false) {
@@ -360,6 +366,7 @@ module Msf
           t.kill
         end
         self.listener_threads = []
+        self.listener_pairs = {}
       end
 
       #
@@ -375,7 +382,7 @@ module Msf
 
       attr_accessor :conn_threads
       attr_accessor :listener_threads
-
+      attr_accessor :listener_pairs
     end
   end
 end

--- a/lib/rex/proto/smb/simpleclient/open_pipe.rb
+++ b/lib/rex/proto/smb/simpleclient/open_pipe.rb
@@ -50,6 +50,41 @@ class OpenPipe < OpenFile
     dlen = ack['Payload'].v['DataCount']
     @buff << ack.to_s[4+doff, dlen]
   end
+
+  def peek_ruby_smb
+    self.client.last_file.peek_available
+  end
+
+  # This will only return the bytes available and does not receive available data
+  STATUS_BUFFER_OVERFLOW = 0x80000005
+  STATUS_PIPE_BROKEN     = 0xc000014b
+  def peek_rex_smb
+    setup = [0x23, self.file_id].pack('vv')
+    # Must ignore errors since we expect STATUS_BUFFER_OVERFLOW
+    pkt = self.client.trans_maxzero('\\PIPE\\', '', '', 2, setup, false, true, true)
+    if pkt['Payload']['SMB'].v['ErrorClass'] == STATUS_PIPE_BROKEN
+      raise IOError
+    end
+    avail = 0
+    begin
+      avail = pkt.to_s[pkt['Payload'].v['ParamOffset']+4, 2].unpack('v')[0]
+    rescue
+    end
+
+    if (avail == 0) and (pkt['Payload']['SMB'].v['ErrorClass'] == STATUS_BUFFER_OVERFLOW)
+      avail = self.client.default_max_buffer_size
+    end
+    avail
+  end
+
+  def peek
+    if versions.include?(2)
+      avail = peek_ruby_smb
+    else
+      avail = peek_rex_smb
+    end
+    avail
+  end
 end
 end
 end


### PR DESCRIPTION
Modifies bind_named_pipe payload handler to work with ruby_smb for SMB1 and 2 support. Added required peek-named-pipe functionality to simpleclient's OpenPipe.

Adds to #10217

## Verification
The pipe comms are a bit slow so you may need to wait a few seconds for meterpreter to initialize before sending commands.
- [x] Start `msfconsole`
- [x] `use exploit/windows/smb/psexec`
- [x] `set payload windows/x64/meterpreter/bind_named_pipe`
- [x] set remaining params...
- [x] `meterpreter>`
