### PR TITLE
Add grep -C to msfconsole and fix prompt rewriting

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -2048,7 +2048,7 @@ class Core
     prompt_char = framework.datastore['PromptChar'] || Msf::Ui::Console::Driver::DefaultPromptChar
     mod = active_module
     if mod # if there is an active module, give them the fanciness they have come to expect
-      driver.update_prompt("#{prompt} #{mod.type}(%bld%red#{mod.shortname}%clr) ", prompt_char, true)
+      driver.update_prompt("#{prompt} #{mod.type}(%bld%red#{mod.promptname}%clr) ", prompt_char, true)
     else
       driver.update_prompt("#{prompt} ", prompt_char, true)
     end

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -83,8 +83,9 @@ class Core
     "-i" => [ false, "Ignore case."                                   ],
     "-m" => [ true,  "Stop after arg matches."                        ],
     "-v" => [ false, "Invert match."                                  ],
-    "-A" => [ true,  "Show arg lines of output After a match."        ],
-    "-B" => [ true,  "Show arg lines of output Before a match."       ],
+    "-A" => [ true,  "Show arg lines of output after a match."        ],
+    "-B" => [ true,  "Show arg lines of output before a match."       ],
+    "-C" => [ true,  "Show arg lines of output around a match."       ],
     "-s" => [ true,  "Skip arg lines of output before attempting match."],
     "-k" => [ true,  "Keep (include) arg lines at start of output."   ],
     "-c" => [ false, "Only print a count of matching lines."          ])
@@ -1986,6 +1987,12 @@ class Core
         when "-B"
           # also return arg lines before a match
           output_mods[:before] = val.to_i
+          # delete opt and val from args list
+          args.shift(2)
+        when "-C"
+          # also return arg lines around a match
+          output_mods[:before] = val.to_i
+          output_mods[:after] = val.to_i
           # delete opt and val from args list
           args.shift(2)
         when "-v"


### PR DESCRIPTION
~**NOTE:** This does not fix `grep`'s prompt rewriting.~ Now it does (#9261).

- [x] Test `help grep`
- [x] Test `grep -A`
- [x] Test `grep -B`
- [x] Test `grep -C`
- [x] Make sure the prompt isn't fscked

```
msf5 exploit(windows/smb/ms17_010_eternalblue) > grep -C 3 "Check supported" info
  --  ----
  0   Windows 7 and Server 2008 R2 (x64) All Service Packs

Check supported:
  No

Basic options:
msf5 exploit(windows/smb/ms17_010_eternalblue) >
```

@kernelsmith