### PR TITLE
String matching and handling fixes in aws_ec2_instance_metadata module

### DIFF
--- a/modules/post/multi/gather/aws_ec2_instance_metadata.rb
+++ b/modules/post/multi/gather/aws_ec2_instance_metadata.rb
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Post
 
   def check_aws_metadata
     resp = simple_get(@target_uri)
-    unless resp =~ /^instance-id.$/m
+    unless resp =~ /instance-id/m
       fail_with(Failure::BadConfig, "Session does not appear to be on an AWS EC2 instance")
     end
     resp
@@ -50,14 +50,14 @@ class MetasploitModule < Msf::Post
 
   def get_aws_metadata(base_uri, base_resp)
     r = {}
-    base_resp.split(/\r\n/).each do |l|
-      new_uri = base_uri.merge("./#{l}")
-      if l =~ %r{/$}
+    base_resp.split(/\n/).each do |l|
+      new_uri = "#{base_uri}#{l}"
+      if l =~/\/$/
         # handle a directory
-        r[l.gsub(%r{/$}, '')] = get_aws_metadata(new_uri, simple_get(new_uri))
-      elsif new_uri.to_s =~ %r{/public-keys/} && /^(?<key_id>\d+)=/ =~ l
+        r[l.gsub(/\/$/, '')] = get_aws_metadata(new_uri, simple_get(new_uri))
+      elsif new_uri.to_s =~ /\/public-keys/ && /^(?<key_id>\d+)=/ =~ l
         # special case handling of the public-keys endpoint
-        key_uri = new_uri.merge("./#{key_id}/")
+        key_uri = "#{new_uri}#{key_id}/"
         key_resp = simple_get(key_uri)
         r[key_id] = get_aws_metadata(key_uri, key_resp)
       else
@@ -94,6 +94,7 @@ class MetasploitModule < Msf::Post
 
   def simple_get(url)
     vprint_status("Fetching #{url}")
+    puts("Fetching #{url}")
     cmd_exec("curl #{url}")
   end
 end


### PR DESCRIPTION
Fixes for Kali linux 4.14 with ruby 2.3.


Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/windows/smb/ms08_067_netapi`
- [ ] ...
- [ ] **Verify** the thing does what it should
- [ ] **Verify** the thing does not do what it should not
- [ ] **Document** the thing and how it works ([Example](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/post/multi/gather/aws_keys.md))

