### PR TITLE
Fix fake_function_collection_spec

### DIFF
--- a/spec/lib/metasploit/framework/obfuscation/crandomizer/code_factory/fake_function_collection_spec.rb
+++ b/spec/lib/metasploit/framework/obfuscation/crandomizer/code_factory/fake_function_collection_spec.rb
@@ -29,8 +29,7 @@ RSpec.describe Metasploit::Framework::Obfuscation::CRandomizer::CodeFactory::Fak
   describe '#to_s' do
     it 'converts function objects to a string' do
       str = subject.to_s
-      expect(str).to match(/function/)
-      expect(str).to match(/return/)
+      expect(str).to match(/function\d+.+\(.*\)\s*{.*}/)
     end
   end
 


### PR DESCRIPTION
Sometimes, if the function is void, there is no return statement, which causes the rspec to fail. This improves the regex to address that issue.

Verification:

- [ ] Make sure Travis is green