### PR TITLE
Add check method Boolean to module cache and info and search commands

### DIFF
--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -183,6 +183,10 @@ class ReadableText
     output << "Available targets:\n"
     output << dump_exploit_targets(mod, indent)
 
+    # Check
+    output << "Check supported:\n"
+    output << "#{indent}#{mod.respond_to?(:check) ? 'Yes' : 'No'}\n\n"
+
     # Options
     if (mod.options.has_options?)
       output << "Basic options:\n"
@@ -240,6 +244,10 @@ class ReadableText
       output << "Available actions:\n"
       output << dump_module_actions(mod, indent)
     end
+
+    # Check
+    output << "Check supported:\n"
+    output << "#{indent}#{mod.respond_to?(:check) ? 'Yes' : 'No'}\n\n"
 
     # Options
     if (mod.options.has_options?)

--- a/lib/msf/base/simple/auxiliary.rb
+++ b/lib/msf/base/simple/auxiliary.rb
@@ -116,7 +116,7 @@ module Auxiliary
     mod.setup
 
     # Run check if it exists
-    mod.respond_to?(:check) ? check : Msf::Exploit::CheckCode::Unsupported
+    mod.respond_to?(:check) ? mod.check : Msf::Exploit::CheckCode::Unsupported
   end
 
   #

--- a/lib/msf/base/simple/auxiliary.rb
+++ b/lib/msf/base/simple/auxiliary.rb
@@ -115,8 +115,8 @@ module Auxiliary
 
     mod.setup
 
-    # Run check
-    mod.check
+    # Run check if it exists
+    mod.respond_to?(:check) ? check : Msf::Exploit::CheckCode::Unsupported
   end
 
   #

--- a/lib/msf/base/simple/exploit.rb
+++ b/lib/msf/base/simple/exploit.rb
@@ -186,7 +186,7 @@ module Exploit
     mod.setup
 
     # Run check if it exists
-    mod.respond_to?(:check) ? check : Msf::Exploit::CheckCode::Unsupported
+    mod.respond_to?(:check) ? mod.check : Msf::Exploit::CheckCode::Unsupported
   end
 
   #

--- a/lib/msf/base/simple/exploit.rb
+++ b/lib/msf/base/simple/exploit.rb
@@ -185,8 +185,8 @@ module Exploit
 
     mod.setup
 
-    # Run check
-    mod.check
+    # Run check if it exists
+    mod.respond_to?(:check) ? check : Msf::Exploit::CheckCode::Unsupported
   end
 
   #

--- a/lib/msf/core/module.rb
+++ b/lib/msf/core/module.rb
@@ -204,16 +204,6 @@ class Module
   end
 
   #
-  # Checks to see if the target is vulnerable, returning unsupported if it's
-  # not supported.
-  #
-  # This method is designed to be overriden by exploit modules.
-  #
-  def check
-    Msf::Exploit::CheckCode::Unsupported
-  end
-
-  #
   # Returns the current workspace
   #
   def workspace

--- a/lib/msf/core/modules/metadata/obj.rb
+++ b/lib/msf/core/modules/metadata/obj.rb
@@ -26,6 +26,7 @@ class Obj
   attr_reader :mod_time
   attr_reader :is_install_path
   attr_reader :ref_name
+  attr_reader :check
 
   def initialize(module_instance, obj_hash = nil)
     unless obj_hash.nil?
@@ -49,7 +50,7 @@ class Obj
     sort_platform_string
 
     @arch = module_instance.arch_to_s
-    @rport = module_instance.datastore['RPORT'].to_s
+    @rport = module_instance.datastore['RPORT']
     @path = module_instance.file_path
     @mod_time = ::File.mtime(@path) rescue Time.now
     @ref_name = module_instance.refname
@@ -62,6 +63,9 @@ class Obj
     if module_instance.respond_to?(:targets) and module_instance.targets
       @targets = module_instance.targets.map{|x| x.name}
     end
+
+    # Store whether a module has a check method
+    @check = module_instance.respond_to?(:check) ? true : false
 
     # Due to potentially non-standard ASCII we force UTF-8 to ensure no problem with JSON serialization
     force_encoding(Encoding::UTF_8)
@@ -89,7 +93,8 @@ class Obj
       'mod_time' => @mod_time.to_s,
       'path' => @path,
       'is_install_path' => @is_install_path,
-      'ref_name' => @ref_name
+      'ref_name' => @ref_name,
+      'check' => @check
     }.to_json(*args)
   end
 
@@ -135,6 +140,7 @@ class Obj
     @path = obj_hash['path']
     @is_install_path = obj_hash['is_install_path']
     @targets = obj_hash['targets'].nil? ? [] : obj_hash['targets']
+    @check = obj_hash['check'] ? true : false
   end
 
   def sort_platform_string

--- a/lib/msf/core/modules/metadata/search.rb
+++ b/lib/msf/core/modules/metadata/search.rb
@@ -88,7 +88,7 @@ module Msf::Modules::Metadata::Search
                 match = [t,w] if module_metadata.targets.any? { |t| t =~ r }
               end
             when 'port'
-              match = [t,w] if module_metadata.rport =~ r
+              match = [t,w] if module_metadata.rport.to_s =~ r
             when 'type'
               match = [t,w] if Msf::MODULE_TYPES.any? { |modt| w == modt and module_metadata.type == modt }
             when 'app'

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -385,6 +385,7 @@ module Msf
                   m.full_name,
                   m.disclosure_date.nil? ? '' : m.disclosure_date.strftime("%Y-%m-%d"),
                   RankingName[m.rank].to_s,
+                  m.check ? 'Yes' : 'No',
                   m.name
               ]
             end
@@ -1101,6 +1102,7 @@ module Msf
                       refname,
                       o.disclosure_date.nil? ? "" : o.disclosure_date.strftime("%Y-%m-%d"),
                       o.rank_to_s,
+                      o.respond_to?(:check) ? 'Yes' : 'No',
                       o.name
                     ]
                   end
@@ -1117,7 +1119,7 @@ module Msf
               'Header'     => type,
               'Prefix'     => "\n",
               'Postfix'    => "\n",
-              'Columns'    => [ 'Name', 'Disclosure Date', 'Rank', 'Description' ],
+              'Columns'    => [ 'Name', 'Disclosure Date', 'Rank', 'Check', 'Description' ],
               'SearchTerm' => search_term
             )
           end

--- a/spec/lib/msf/core/module_spec.rb
+++ b/spec/lib/msf/core/module_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe Msf::Module do
     described_class.new
   }
 
-  it { is_expected.to respond_to :check }
   it { is_expected.to respond_to :debugging? }
   it { is_expected.to respond_to :fail_with }
   it { is_expected.to respond_to :file_path }


### PR DESCRIPTION
1. The module cache JSON file(s) will record whether a module has a `check` method
2. The `info` command's output now contains a section denoting the same
3. The `search` command's output now contains a column denoting the same

- [x] **Regenerate** module cache and **verify** it updated correctly
  - [x] `rm db/modules_metadata_base.json ~/.msf4/store/modules_metadata.json`
  - [x] `./msfconsole -qx 'irb -e framework.modules.refresh_cache_from_module_files; exit'`
  - [x] **Verify** `~/.msf4/store/modules_metadata.json` is correct
  - [x] `cp ~/.msf4/store/modules_metadata.json db/modules_metadata_base.json`
  - [x] **Verify** `search` works as intended and displays the new column
  - [x] **Verify** `show` works as intended and displays the new column
  - [x] `git checkout db/modules_metadata_base.json`
  - [x] **DO NOT** commit any module cache changes
- [x] `use` a module that **has** `check`
  - [x] Run `info`
  - [x] See that `check` is **supported**
  - [x] Run `check`
  - [x] See that it **works**
- [x] `use` a module that has **no** `check`
  - [x] Run `info`
  - [x] See that `check` is **not supported**
  - [x] Run `check`
  - [x] See that it tells you `check` is **not supported**

Note that `RPORT` is now an integer. It can also be `null`, but that's more correct than an empty string.

```
wvu@kharak:~/metasploit-framework:feature/check$ jq '.["exploit_windows/smb/ms17_010_eternalblue", "exploit_linux/http/hp_van_sdn_cmd_inject"].check' ~/.msf4/store/modules_metadata.json
false
true
wvu@kharak:~/metasploit-framework:feature/check$
```

```
msf5 > grep -A 1 "Check supported" info exploit/windows/smb/ms17_010_eternalblue exploit/linux/http/hp_van_sdn_cmd_inject
Check supported:
  No
Check supported:
  Yes
msf5 >
```

```
msf5 > search ms17_010_eternalblue hp_van_sdn_cmd_inject

Matching Modules
================

   Name                                           Disclosure Date  Rank       Check  Description
   ----                                           ---------------  ----       -----  -----------
   exploit/linux/http/hp_van_sdn_cmd_inject       2018-06-25       excellent  Yes    HP VAN SDN Controller Root Command Injection
   exploit/windows/smb/ms17_010_eternalblue       2017-03-14       average    No     MS17-010 EternalBlue SMB Remote Windows Kernel Pool Corruption
   exploit/windows/smb/ms17_010_eternalblue_win8  2017-03-14       average    No     MS17-010 EternalBlue SMB Remote Windows Kernel Pool Corruption for Win8+


msf5 >
```

```
msf5 exploit(windows/smb/ms17_010_eternalblue) > check
[*] 127.0.0.1:445 This module does not support check.
msf5 exploit(windows/smb/ms17_010_eternalblue) >
```

Thanks to @busterb for assisting with module cache regeneration. :)

#10307 