### PR TITLE
Add decryption and decoding support for Metasploit C compiler

### DIFF
--- a/data/headers/windows/base64.h
+++ b/data/headers/windows/base64.h
@@ -1,0 +1,114 @@
+/* from https://github.com/mdornseif/didentd */
+/* public domain
+ * BASE64 on stdin -> converted data on stdout */
+
+/* arbitrary data on stdin -> BASE64 data on stdout
+ * UNIX's newline convention is used, i.e. one ASCII control-j (10 decimal).
+ *
+ * public domain
+ */
+
+/* Hacked by drt@un.bewaff.net to be a library function working on memory blocks
+ *
+ */
+
+static unsigned char alphabet[64] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+int base64decode(char *dest, const char *src, int l)
+{
+  static char inalphabet[256], decoder[256];
+  static bool table_initialized = false;
+  int i, bits, c, char_count;
+  int rpos;
+  int wpos = 0;
+
+  if (!table_initialized) {
+    for (i = (sizeof alphabet) - 1; i >= 0; i--) {
+      inalphabet[alphabet[i]] = 1;
+      decoder[alphabet[i]] = i;
+    }
+    table_initialized = true;
+  }
+
+  char_count = 0;
+  bits = 0;
+  for (rpos = 0; rpos < l; rpos++) {
+    c = src[rpos];
+
+    if (c == '=') {
+      break;
+    }
+
+    if (c > 255 || !inalphabet[c]) {
+      return -1;
+    }
+
+    bits += decoder[c];
+    char_count++;
+    if (char_count < 4) {
+      bits <<= 6;
+    } else {
+      dest[wpos++] = bits >> 16;
+      dest[wpos++] = (bits >> 8) & 0xff;
+      dest[wpos++] = bits & 0xff;
+      bits = 0;
+      char_count = 0;
+    }
+  }
+
+  switch (char_count) {
+  case 1:
+    return -1;
+    break;
+  case 2:
+    dest[wpos++] = bits >> 10;
+    break;
+  case 3:
+    dest[wpos++] = bits >> 16;
+    dest[wpos++] = (bits >> 8) & 0xff;
+    break;
+  }
+
+  return wpos;
+}
+
+int base64encode(char *dest, const char *src, int l)
+{
+  int bits, c, char_count;
+  int rpos;
+  int wpos = 0;
+
+  char_count = 0;
+  bits = 0;
+
+  for (rpos = 0; rpos < l; rpos++) {
+    c = src[rpos];
+
+    bits += c;
+    char_count++;
+    if (char_count < 3) {
+      bits <<= 8;
+    } else {
+      dest[wpos++] = alphabet[bits >> 18];
+      dest[wpos++] = alphabet[(bits >> 12) & 0x3f];
+      dest[wpos++] = alphabet[(bits >> 6) & 0x3f];
+      dest[wpos++] = alphabet[bits & 0x3f];
+      bits = 0;
+      char_count = 0;
+    }
+  }
+
+  if (char_count != 0) {
+    bits <<= 16 - (8 * char_count);
+    dest[wpos++] = alphabet[bits >> 18];
+    dest[wpos++] = alphabet[(bits >> 12) & 0x3f];
+    if (char_count == 1) {
+      dest[wpos++] = '=';
+      dest[wpos++] = '=';
+    } else {
+      dest[wpos++] = alphabet[(bits >> 6) & 0x3f];
+      dest[wpos++] = '=';
+    }
+  }
+  return wpos;
+}

--- a/data/headers/windows/rc4.h
+++ b/data/headers/windows/rc4.h
@@ -1,0 +1,54 @@
+//
+// License:
+// https://github.com/rapid7/metasploit-framework/blob/master/LICENSE
+//
+
+// This code was originally obtained and modified from the following source
+// by Bobin Verton:
+// https://gist.github.com/rverton/a44fc8ca67ab9ec32089
+
+#define N 256   // 2^8
+
+void swap(unsigned char *a, unsigned char *b) {
+  int tmp = *a;
+  *a = *b;
+  *b = tmp;
+}
+
+int KSA(char *key, unsigned char *S) {
+  int len = strlen(key);
+  int j = 0;
+
+  for (int i = 0; i < N; i++) {
+    S[i] = i;
+  }
+
+  for (int i = 0; i < N; i++) {
+    j = (j + S[i] + key[i % len]) % N;
+    swap(&S[i], &S[j]);
+  }
+
+  return 0;
+}
+
+int PRGA(unsigned char *S, char *plaintext, unsigned char *ciphertext, int plainTextSize) {
+  int i = 0;
+  int j = 0;
+
+  for (size_t n = 0, len = plainTextSize; n < len; n++) {
+    i = (i + 1) % N;
+    j = (j + S[i]) % N;
+    swap(&S[i], &S[j]);
+    int rnd = S[(S[i] + S[j]) % N];
+    ciphertext[n] = rnd ^ plaintext[n];
+  }
+
+  return 0;
+}
+
+int RC4(char *key, char *plaintext, unsigned char *ciphertext, int plainTextSize) {
+  unsigned char S[N];
+  KSA(key, S);
+  PRGA(S, plaintext, ciphertext, plainTextSize);
+  return 0;
+}

--- a/data/headers/windows/stddef.h
+++ b/data/headers/windows/stddef.h
@@ -6,6 +6,8 @@
 #define NULL ((void *)0)
 #define TRUE 1
 #define FALSE 0
+#define true 1
+#define false 0
 #define VOID void
 #define _tWinMain WinMain
 #define CALLBACK __stdcall
@@ -104,6 +106,7 @@ typedef void* LPCVOID;
 typedef ULONG_PTR DWORD_PTR;
 typedef void* HWND;
 typedef int BOOL;
+typedef int bool;
 typedef BOOL* PBOOL;
 typedef LONG_PTR LRESULT;
 typedef UINT_PTR WPARAM;

--- a/data/headers/windows/xor.h
+++ b/data/headers/windows/xor.h
@@ -1,3 +1,8 @@
+//
+// License:
+// https://github.com/rapid7/metasploit-framework/blob/master/LICENSE
+//
+
 void xor(char* dest, char* src, char key, int len) {
   for (int i = 0; i < len; i++) {
     char c = src[i] ^ key;

--- a/data/headers/windows/xor.h
+++ b/data/headers/windows/xor.h
@@ -1,0 +1,6 @@
+void xor(char* dest, char* src, char key, int len) {
+  for (int i = 0; i < len; i++) {
+    char c = src[i] ^ key;
+    dest[i] = c;
+  }
+}

--- a/lib/metasploit/framework/compiler/headers/windows.rb
+++ b/lib/metasploit/framework/compiler/headers/windows.rb
@@ -22,7 +22,8 @@ module Metasploit
               'String.h'   => ['stddef.h'],
               'Winsock2.h' => ['stddef.h', 'Windows.h'],
               'rc4.h'      => ['String.h', 'stdlib.h'],
-              'base64.h'   => ['stddef.h']
+              'base64.h'   => ['stddef.h'],
+              'xor.h'      => ['stddef.h']
             }
           end
 

--- a/lib/metasploit/framework/compiler/headers/windows.rb
+++ b/lib/metasploit/framework/compiler/headers/windows.rb
@@ -21,7 +21,8 @@ module Metasploit
               'stdio.h'    => ['stddef.h'],
               'String.h'   => ['stddef.h'],
               'Winsock2.h' => ['stddef.h', 'Windows.h'],
-              'rc4.h'      => ['String.h', 'stdlib.h']
+              'rc4.h'      => ['String.h', 'stdlib.h'],
+              'base64.h'   => ['stddef.h']
             }
           end
 

--- a/lib/metasploit/framework/compiler/headers/windows.rb
+++ b/lib/metasploit/framework/compiler/headers/windows.rb
@@ -20,7 +20,8 @@ module Metasploit
               'stdlib.h'   => ['stddef.h'],
               'stdio.h'    => ['stddef.h'],
               'String.h'   => ['stddef.h'],
-              'Winsock2.h' => ['stddef.h', 'Windows.h']
+              'Winsock2.h' => ['stddef.h', 'Windows.h'],
+              'rc4.h'      => ['String.h', 'stdlib.h']
             }
           end
 

--- a/lib/metasploit/framework/compiler/windows.rb
+++ b/lib/metasploit/framework/compiler/windows.rb
@@ -40,7 +40,7 @@ module Metasploit
         # @param cpu [Metasm::CPU] A Metasm cpu object, for example: Metasm::Ia32.new
         # @return [Integer] The number of bytes written.
         def self.compile_c_to_file(out_file, c_template, type=:exe, cpu=Metasm::Ia32.new)
-          pe = self.compile(c_template, type)
+          pe = self.compile_c(c_template, type)
           File.write(out_file, pe)
         end
 

--- a/lib/metasploit/framework/obfuscation/crandomizer/utility.rb
+++ b/lib/metasploit/framework/obfuscation/crandomizer/utility.rb
@@ -12,7 +12,7 @@ module Metasploit
           #
           # @return [Integer]
           def self.rand_int
-            SecureRandom.random_number(100)
+            SecureRandom.random_number(100000000)
           end
 
           # Returns a random string.


### PR DESCRIPTION
## Description

This adds decryption and decoding support for the C compiler in Metasploit Framework, including: RC4, Base64, and XOR.

This PR also fixes two minor issues:

* The `compile_random_c_to_file` method uses the wrong function name for compiling code.
* Max random number is larger to avoid collision.

## Things to prepare before testing

- [x] A Windows box (I use Win 10 for testing)

## Verification

- [x] Save the following A files, they are your test cases:

* [rc4_example.c](https://gist.github.com/wchen-r7/11d7b7884feedde3f33dfe9a5314b94b)
* [base64_example.c](https://gist.github.com/wchen-r7/12e0fd4a177ddc6f1203a37408e4a23a)
* [xor_example.c](https://gist.github.com/wchen-r7/63941089b83b8c6a4ca8f53291e16b63)

- [x] In your msf folder, start `tools/exploit/msf_irb_shell.rb` in the terminal
- [x] Enter the following code. Make sure you modify the source paths for the C files. This code should generate 3 EXEs in `/tmp`: rc4_example.exe, base64_example.exe, xor_example.exe.

```ruby
require 'msf/core'
require 'metasploit/framework/compiler/windows'

test_cases =
  [
    { dest: '/tmp/xor_example.exe', source: '/Users/wchen/Desktop/metasm_decryption/xor_example.c' },
    { dest: '/tmp/rc4_example.exe', source: '/Users/wchen/Desktop/metasm_decryption/rc4_example.c' },
    { dest: '/tmp/base64_example.exe', source: '/Users/wchen/Desktop/metasm_decryption/base64_example.c' }
  ]

test_cases.each do |test_case|
  dest = test_case[:dest]
  source = File.read(test_case[:source])
  Metasploit::Framework::Compiler::Windows.compile_random_c_to_file(dest, source)
  puts "#{dest} saved"
end
```

- [x] Move the 3 executables to the Windows machine
- [x] Double-click on the executables, these are the messages you should see:

* rc4_example.exe : `Hello World`
* base64_example.exe: `hello world`
* xor_example.exe: `AAAA`