### PR TITLE
Added check and response for CVE-2017-12149 in jboss_vulnscan.rb

### DIFF
--- a/modules/auxiliary/scanner/http/jboss_vulnscan.rb
+++ b/modules/auxiliary/scanner/http/jboss_vulnscan.rb
@@ -59,7 +59,7 @@ class MetasploitModule < Msf::Auxiliary
         # apps added per Patrick Hof
         '/web-console/Invoker',
         '/invoker/JMXInvokerServlet',
-        '/invoker/readonlys'
+        '/invoker/readonly'
       ]
 
       print_status("#{rhost}:#{rport} Checking http...")

--- a/modules/auxiliary/scanner/http/jboss_vulnscan.rb
+++ b/modules/auxiliary/scanner/http/jboss_vulnscan.rb
@@ -23,7 +23,8 @@ class MetasploitModule < Msf::Auxiliary
         ],
       'References'            =>
         [
-          [ 'CVE', '2010-0738' ] # VERB auth bypass
+          [ 'CVE', '2010-0738' ], # VERB auth bypass
+          [ 'CVE', '2017-12149' ]
         ],
       'License'               => BSD_LICENSE
       ))
@@ -57,7 +58,8 @@ class MetasploitModule < Msf::Auxiliary
         '/web-console/ServerInfo.jsp',
         # apps added per Patrick Hof
         '/web-console/Invoker',
-        '/invoker/JMXInvokerServlet'
+        '/invoker/JMXInvokerServlet',
+        '/invoker/readonly'
       ]
 
       print_status("#{rhost}:#{rport} Checking http...")
@@ -103,6 +105,9 @@ class MetasploitModule < Msf::Auxiliary
       when res.code == 301, res.code == 302
         print_status("#{rhost}:#{rport} #{app} is redirected (#{res.code}) to #{res.headers['Location']} (not following)")
       else
+        if res.code == 500 && app == "/invoker/readonly"
+          print_good("#{rhost}:#{rport} #{app} responded (#{res.code})")
+        end
         print_status("#{rhost}:#{rport} Don't know how to handle response code #{res.code}")
       end
     else

--- a/modules/auxiliary/scanner/http/jboss_vulnscan.rb
+++ b/modules/auxiliary/scanner/http/jboss_vulnscan.rb
@@ -59,7 +59,7 @@ class MetasploitModule < Msf::Auxiliary
         # apps added per Patrick Hof
         '/web-console/Invoker',
         '/invoker/JMXInvokerServlet',
-        '/invoker/readonly'
+        '/invoker/readonlys'
       ]
 
       print_status("#{rhost}:#{rport} Checking http...")
@@ -90,28 +90,30 @@ class MetasploitModule < Msf::Auxiliary
       'ctype'     => 'text/plain'
     })
 
-    if res
-      case
-      when res.code == 200
-        print_good("#{rhost}:#{rport} #{app} does not require authentication (200)")
-      when res.code == 403
-        print_status("#{rhost}:#{rport} #{app} restricted (403)")
-      when res.code == 401
-        print_status("#{rhost}:#{rport} #{app} requires authentication (401): #{res.headers['WWW-Authenticate']}")
-        bypass_auth(app)
-        basic_auth_default_creds(app)
-      when res.code == 404
-        print_status("#{rhost}:#{rport} #{app} not found (404)")
-      when res.code == 301, res.code == 302
-        print_status("#{rhost}:#{rport} #{app} is redirected (#{res.code}) to #{res.headers['Location']} (not following)")
-      else
-        if res.code == 500 && app == "/invoker/readonly"
-          print_good("#{rhost}:#{rport} #{app} responded (#{res.code})")
-        end
-        print_status("#{rhost}:#{rport} Don't know how to handle response code #{res.code}")
-      end
-    else
+
+
+    unless res
       print_status("#{rhost}:#{rport} #{app} not found")
+      return
+    end
+
+    case
+    when res.code == 200
+      print_good("#{rhost}:#{rport} #{app} does not require authentication (200)")
+    when res.code == 403
+      print_status("#{rhost}:#{rport} #{app} restricted (403)")
+    when res.code == 401
+      print_status("#{rhost}:#{rport} #{app} requires authentication (401): #{res.headers['WWW-Authenticate']}")
+      bypass_auth(app)
+      basic_auth_default_creds(app)
+    when res.code == 404
+      print_status("#{rhost}:#{rport} #{app} not found (404)")
+    when res.code == 301, res.code == 302
+      print_status("#{rhost}:#{rport} #{app} is redirected (#{res.code}) to #{res.headers['Location']} (not following)")
+    when res.code == 500 && app == "/invoker/readonly"
+      print_good("#{rhost}:#{rport} #{app} responded (#{res.code})")
+    else
+      print_status("#{rhost}:#{rport} Don't know how to handle response code #{res.code}")
     end
   end
 


### PR DESCRIPTION
This change adds an additional vulnerability check to auxiliary/scanner/http/jboss_vulnscan
The addition was a check for CVE-2017-12149, a deserialization RCE vulnerability in Red Hat JBoss EAP 5.

```
It was found that the doFilter method in the ReadOnlyAccessFilter of the HTTP Invoker does not restrict classes for which it performs deserialization. This allows an attacker to execute arbitrary code via crafted serialized data.
```

Changes made: 
Added the URL to check
print_good() in case of the URL is accessible 


## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/http/jboss_vulnscan`
- [x] set Host of a vulnerable JBoss EAP5 server
- [x] **Verify* `[+] 192.168.0.244:8080 /invoker/readonly responded (500)` is displayed
- [x] set Host of a not vulnerable JBoss server version
- [x] **Verify** `[*] 192.168.0.244:8080 /invoker/readonly not found (404)` is displayed

