### PR TITLE
Specify address family in shell_reverse_tcp_ipv6

### DIFF
--- a/modules/payloads/singles/linux/x86/shell_reverse_tcp_ipv6.rb
+++ b/modules/payloads/singles/linux/x86/shell_reverse_tcp_ipv6.rb
@@ -39,7 +39,7 @@ def generate_stage
 
       # ipv6 address conversion
       # converts user's input into ipv6 hex representation
-      words = IPAddr.new(datastore['LHOST']).hton.scan(/..../).map {|i| i.unpack('V').first.to_s(16)}
+      words = IPAddr.new(datastore['LHOST'], Socket::AF_INET6).hton.scan(/..../).map {|i| i.unpack('V').first.to_s(16)}
       payload_data =<<-EOS
         xor  ebx,ebx
         mul  ebx


### PR DESCRIPTION
We're hitting this because `LHOST` is `nil` when showing module info, and if `IPAddr.new` doesn't get a string, it requires an address family to be specified.

- [x] Test `msfvenom -p linux/x86/shell_reverse_tcp_ipv6 --list-options`
- [x] Test `info` in `msfconsole`

Fixes #10360.