### PR TITLE
Pass a framework instance to external module shims

### DIFF
--- a/lib/metasploit/framework/spec/threads/suite.rb
+++ b/lib/metasploit/framework/spec/threads/suite.rb
@@ -12,7 +12,7 @@ module Metasploit
           #
 
           # Number of allowed threads when threads are counted in `after(:suite)` or `before(:suite)`
-          EXPECTED_THREAD_COUNT_AROUND_SUITE = if ENV['REMOTE_DB'] then 2 else 1 end
+          EXPECTED_THREAD_COUNT_AROUND_SUITE = 2
 
           # `caller` for all Thread.new calls
           LOG_PATHNAME = Pathname.new('log/metasploit/framework/spec/threads/suite.log')

--- a/lib/msf/core/modules/external/shim.rb
+++ b/lib/msf/core/modules/external/shim.rb
@@ -2,8 +2,8 @@
 require 'msf/core/modules/external'
 
 class Msf::Modules::External::Shim
-  def self.generate(module_path)
-    mod = Msf::Modules::External.new(module_path)
+  def self.generate(module_path, framework)
+    mod = Msf::Modules::External.new(module_path, framework: framework)
     return '' unless mod.meta
     case mod.meta['type']
     when 'remote_exploit'

--- a/lib/msf/core/modules/loader/executable.rb
+++ b/lib/msf/core/modules/loader/executable.rb
@@ -85,7 +85,7 @@ class Msf::Modules::Loader::Executable < Msf::Modules::Loader::Base
       return ''
     end
     begin
-      content = Msf::Modules::External::Shim.generate(full_path)
+      content = Msf::Modules::External::Shim.generate(full_path, @module_manager.framework)
       if content
         return content
       else


### PR DESCRIPTION
An oversight in #10282 left shims for external modules generated with the context of the loading `framework` instance. This shows up as leaking `stderr` through to the console and leaking ActiveRecord connections since we no longer assume we play by all of Framework's rules. We will always need a `framework` when making a shim, so it is not a keyword argument.

Verification
========
- [ ] Edit `lib/msf/core/modules/external/python/metasploit/module.py` to have a line like `cli.eprint("Python module load")` right after the `cli` import.
- [ ] `./msfconsole`
- [ ] Any `Python module load` messages should be in `~/.msf4/logs/framework.log` and not on `stderr` (mostly for `4.x`)
- [ ] `use exploit/linux/smtp/haraka` (or any other Python module)
- [ ] Exactly one `Python module load` message should be in `~/.msf4/logs/framework.log` and nothing unusual (including that message) should be displayed in the console