### PR TITLE
Add PhpMyAdmin Login Scanner and Auxiliary Module

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/phpmyadmin_login.md
+++ b/documentation/modules/auxiliary/scanner/http/phpmyadmin_login.md
@@ -15,7 +15,7 @@
 
 ## Scenarios
 
-### Tested on PhpMyAdmin Versions 4.8.2, 4.8.1, 4.0.10.20
+### Tested on PhpMyAdmin Versions 4.0.10.20, 4.5.0, 4.8.1, 4.8.2, 5.0
 
   ```
   msf5 > use auxiliary/scanner/http/phpmyadmin_login
@@ -26,11 +26,8 @@
   msf5 auxiliary(scanner/http/phpmyadmin_login) > set password password
   password => password
   msf5 auxiliary(scanner/http/phpmyadmin_login) > run
-  PhpMyAdmin Version: 4.8.2
-  Token here: !il&>s3]t28i34x7
-  Session ID: sruks7tm3bnh6jljb8h1q9gh6u
-  Cookies: pma_lang=en; phpMyAdmin=anttidd9jgc8c2qnhn0kq4sshu;
 
+  [*] PhpMyAdmin Version: 4.8.2
   [+] 192.168.37.151:80 - Success: 'root:password'
   [*] Scanned 1 of 1 hosts (100% complete)
   [*] Auxiliary module execution completed

--- a/documentation/modules/auxiliary/scanner/http/phpmyadmin_login.md
+++ b/documentation/modules/auxiliary/scanner/http/phpmyadmin_login.md
@@ -1,0 +1,39 @@
+
+## Vulnerable Application
+
+  This module is a brute-force login scanner for PhpMyAdmin 
+
+## Verification Steps
+
+  1. Start msfconsole
+  2. Do: ```use [auxiliary/scanner/http/phpmyadmin_login]```
+  3. Do: ```set RHOSTS [IP]```
+  4. Do: ```set TARGETURI [URI]```
+  5. Do: ```set PASSWORD [PASSWORD]```
+  6. Do: ```run```
+  7. You should get a successful login status
+
+## Scenarios
+
+### Tested on PhpMyAdmin Versions 4.8.2, 4.8.1, 4.0.10.20
+
+  ```
+  msf5 > use auxiliary/scanner/http/phpmyadmin_login
+  msf5 auxiliary(scanner/http/phpmyadmin_login) > set rhosts 192.168.37.151
+  rhosts => 192.168.37.151
+  msf5 auxiliary(scanner/http/phpmyadmin_login) > set targeturi phpmyadmin-4.8.2/index.php
+  targeturi => phpmyadmin-4.8.2/index.php
+  msf5 auxiliary(scanner/http/phpmyadmin_login) > set password password
+  password => password
+  msf5 auxiliary(scanner/http/phpmyadmin_login) > run
+  PhpMyAdmin Version: 4.8.2
+  Token here: !il&>s3]t28i34x7
+  Session ID: sruks7tm3bnh6jljb8h1q9gh6u
+  Cookies: pma_lang=en; phpMyAdmin=anttidd9jgc8c2qnhn0kq4sshu;
+
+  [+] 192.168.37.151:80 - Success: 'root:password'
+  [*] Scanned 1 of 1 hosts (100% complete)
+  [*] Auxiliary module execution completed
+  msf5 auxiliary(scanner/http/phpmyadmin_login) > 
+
+  ```

--- a/lib/metasploit/framework/login_scanner/phpmyadmin.rb
+++ b/lib/metasploit/framework/login_scanner/phpmyadmin.rb
@@ -9,14 +9,14 @@ module Metasploit
         LOGIN_STATUS = Metasploit::Model::Login::Status
 
         def check_setup
+          version = "Not Detected"
           res = send_request({ 'uri' => uri })
 
           if res && res.body.include?('phpMyAdmin')
             if res.body =~ /PMA_VERSION:"(\d+\.\d+\.\d+)"/
               version = Gem::Version.new($1)
-              puts "PhpMyAdmin Version: #{version.to_s}"
             end
-            return true
+            return version.to_s
           end
 
           false
@@ -32,9 +32,6 @@ module Metasploit
           token = Rex::Text.html_decode(res.body.scan(/token"\s*value="(.*?)"/).flatten[0])
           cookies = res.get_cookies.split[-2..-1].join(' ')
           
-          puts "Token here: #{token}"
-          puts "Session ID: #{session_id}"
-          puts "Cookies: #{cookies}"
           info = [session_id, token, cookies]
           return no_connect if (info.empty? || session_id.empty? || token.empty? || cookies.empty?)
 

--- a/lib/metasploit/framework/login_scanner/phpmyadmin.rb
+++ b/lib/metasploit/framework/login_scanner/phpmyadmin.rb
@@ -1,0 +1,78 @@
+require 'metasploit/framework/login_scanner/http'
+
+module Metasploit
+  module Framework
+    module LoginScanner
+      class PhpMyAdmin < HTTP
+
+        PRIVATE_TYPES = [ :password ]
+        LOGIN_STATUS = Metasploit::Model::Login::Status
+
+        def check_setup
+          login_uri = normalize_uri("#{uri}/index.php")
+          res = send_request({ 'uri' => login_uri })
+          return res && res.body.include?('phpMyAdmin')
+        end
+
+        def get_session_info
+          login_uri = normalize_uri("#{uri}/index.php")
+          res = send_request({'uri' => login_uri})
+          return {status: LOGIN_STATUS::UNABLE_TO_CONNECT, proof: 'Unable to access PhpMyAdmin login page'} unless res
+
+          session_id = res.get_cookies.scan(/phpMyAdmin=(\w+);*/).flatten[0]
+          token = Rex::Text.html_decode(res.body.scan(/token"\s*value="(.*?)"/).flatten[0])
+          
+          puts "Token here: #{token}"
+          puts "Session ID: #{session_id}"
+          info = [session_id, token, res.get_cookies.split[-2..-1].join(' ')]
+          return info unless session_id.empty? || token.empty?
+        end
+
+        def do_login(username, password)
+          session_info = get_session_info
+
+          protocol  = ssl ? 'https' : 'http'
+          peer      = "#{host}:#{port}"
+          login_uri = normalize_uri("#{uri}")
+
+          res = send_request(
+            'uri'     => login_uri,
+            'method'  => 'POST',
+            'cookie'  => session_info.last,
+            'vars_post' => {
+              'set_session'   => session_info[0],
+              'pma_username'  => username,
+              'pma_password'  => password,
+              'target'        => 'index.php',
+              'server'        => 1,
+              'token'         => session_info[1]
+            }
+          )
+
+          puts res.to_s
+          # check for redirect in location header, otherwise, can check for result code with regex
+          if res && res.code == 302 && res.headers['Location'].to_s.include?('index.php')
+            return { :status => LOGIN_STATUS::SUCCESSFUL, :proof => res.to_s }
+          end
+
+          { :proof => res.to_s }
+        end
+
+        def attempt_login(credential)
+          result_opts = {
+            credential: credential,   
+            status: LOGIN_STATUS::INCORRECT,
+            proof: nil,
+            host: host,
+            port: port,
+            protocol: 'tcp'
+          }
+
+          result_opts.merge!(do_login(credential.public, credential.private))
+
+          Result.new(result_opts)
+        end
+      end
+    end
+  end
+end

--- a/modules/auxiliary/scanner/http/phpmyadmin_login.rb
+++ b/modules/auxiliary/scanner/http/phpmyadmin_login.rb
@@ -1,0 +1,125 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'metasploit/framework/login_scanner/phpmyadmin'
+require 'metasploit/framework/credential_collection'
+
+class MetasploitModule < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::AuthBrute
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::Scanner
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'        => 'PhpMyAdmin Login Scanner Test',
+      'Description' => %q{
+        This module will attempt to authenticate to PhpMyAdmin.
+      },
+      'Author'      => [ 'Shelby Pace' ],
+      'License'     => MSF_LICENSE,
+      'DefaultOptions' =>
+        {
+          'RPORT'      => 80,
+          'USERNAME'   => 'root'
+        }
+    ))
+
+    register_options(
+      [
+        OptString.new('USERNAME', [true, 'The username to PhpMyAdmin', 'root']),
+        OptString.new('PASSWORD', [false, 'The password to PhpMyAdmin', '']),
+        OptString.new('TARGETURI', [true, 'The path to PhpMyAdmin', '/index.php'])
+      ])
+  end
+
+  def scanner(ip)
+    @scanner ||= lambda {
+      cred_collection = Metasploit::Framework::CredentialCollection.new(
+        blank_passwords: datastore['BLANK_PASSWORDS'],
+        pass_file:       datastore['PASS_FILE'],
+        password:        datastore['PASSWORD'],
+        user_file:       datastore['USER_FILE'],
+        userpass_file:   datastore['USERPASS_FILE'],
+        username:        datastore['USERNAME'],
+        user_as_pass:    datastore['USER_AS_PASS']
+      )
+
+      return Metasploit::Framework::LoginScanner::PhpMyAdmin.new(
+        configure_http_login_scanner(
+          host: ip,
+          port: datastore['RPORT'],
+          cred_details:       cred_collection,
+          stop_on_success:    datastore['STOP_ON_SUCCESS'],
+          bruteforce_speed:   datastore['BRUTEFORCE_SPEED'],
+          uri: normalize_uri(datastore['TARGETURI']),
+          connection_timeout: 5
+        ))
+      }.call
+  end
+
+  def report_good_cred(ip, port, result)
+    service_data = {
+      address: ip,
+      port: port,
+      service_name: 'http',
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      module_fullname: self.fullname,
+      origin_type: :service,
+      private_data: result.credential.private,
+      private_type: :password,
+      username: result.credential.public,
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      last_attempted_at: DateTime.now,
+      status: result.status,
+      proof: result.proof
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
+  def report_bad_cred(ip, rport, result)
+    invalidate_login(
+      address: ip,
+      port: rport,
+      protocol: 'tcp',
+      public: result.credential.public,
+      private: result.credential.private,
+      realm_key: result.credential.realm_key,
+      realm_value: result.credential.realm,
+      status: result.status,
+      proof: result.proof
+    )
+  end
+
+  def run_host(ip)
+    unless scanner(ip).check_setup
+      print_brute(:level => :error, :ip => ip, :msg => "PhpMyAdmin is not available")
+      return
+    end
+
+    scanner(ip).scan! do |result|
+        case result.status
+        when Metasploit::Model::Login::Status::SUCCESSFUL
+          print_brute(:level => :good, :ip => ip, :msg => "Success: '#{result.credential}'")
+          report_good_cred(ip, rport, result)
+        when Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
+          vprint_brute(:level => :verror, :ip => ip, :msg => result.proof)
+          report_bad_cred(ip, rport, result)
+        when Metasploit::Model::Login::Status::INCORRECT
+          vprint_brute(:level => :verror, :ip => ip, :msg => "Failed: '#{result.credential}'")
+          report_bad_cred(ip, rport, result)
+        end
+    end
+  end
+end

--- a/modules/auxiliary/scanner/http/phpmyadmin_login.rb
+++ b/modules/auxiliary/scanner/http/phpmyadmin_login.rb
@@ -15,7 +15,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def initialize(info={})
     super(update_info(info,
-      'Name'        => 'PhpMyAdmin Login Scanner Test',
+      'Name'        => 'PhpMyAdmin Login Scanner',
       'Description' => %q{
         This module will attempt to authenticate to PhpMyAdmin.
       },

--- a/modules/auxiliary/scanner/http/phpmyadmin_login.rb
+++ b/modules/auxiliary/scanner/http/phpmyadmin_login.rb
@@ -103,10 +103,13 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run_host(ip)
-    unless scanner(ip).check_setup
+    phpmyadmin_res = scanner(ip).check_setup
+    unless phpmyadmin_res
       print_brute(:level => :error, :ip => ip, :msg => "PhpMyAdmin is not available")
       return
     end
+
+    print_status("PhpMyAdmin Version: #{phpmyadmin_res}")
 
     scanner(ip).scan! do |result|
         case result.status

--- a/spec/lib/metasploit/framework/login_scanner/phpmyadmin_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/phpmyadmin_spec.rb
@@ -51,20 +51,33 @@ RSpec.describe Metasploit::Framework::LoginScanner::PhpMyAdmin do
   describe '#check_setup' do
     let(:phpMyAdmin_res) do
       res = Rex::Proto::Http::Response.new(200, 'OK')
-      res.body = '<h1>Welcome to <bdo dir="ltr" lang="en">phpMyAdmin</bdo></h1>'
+      res.body = '<h1>Welcome to <bdo dir="ltr" lang="en">phpMyAdmin</bdo></h1> PMA_VERSION:"4.8.2"'
       res
     end
 
-    context 'when the target is PhpMyAdmin' do
-      let(:response) { phpMyAdmin_res }
-      it 'should return true' do
-        expect(subject.check_setup).to eql(true)
-      end
+    let(:phpMyAdmin_no_vers) do
+      res = Rex::Proto::Http::Response.new(200, 'OK')
+      res.body = '<h1>Welcome to <bdo dir="ltr" lang="en">phpMyAdmin</bdo></h1>'
+      res
     end
 
     context 'when the target is not PhpMyAdmin' do
       it 'should return false' do
         expect(subject.check_setup).to eql(false)
+      end
+    end
+
+    context 'when the version of PhpMyAdmin is detected' do
+      let(:response) { phpMyAdmin_res }
+      it 'should return the version' do
+        expect(subject.check_setup).to eql("4.8.2")
+      end
+    end
+
+    context 'when the version of PhpMyAdmin is not detected' do
+      let(:response) { phpMyAdmin_no_vers }
+      it 'should return "Not Detected"' do
+        expect(subject.check_setup).to eql("Not Detected")
       end
     end
   end

--- a/spec/lib/metasploit/framework/login_scanner/phpmyadmin_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/phpmyadmin_spec.rb
@@ -2,11 +2,53 @@ require 'spec_helper'
 require 'metasploit/framework/login_scanner/phpmyadmin'
 
 RSpec.describe Metasploit::Framework::LoginScanner::PhpMyAdmin do
-  describe '#check_setup' do
+  it_behaves_like 'Metasploit::Framework::LoginScanner::Base',  has_realm_key: true, has_default_realm: false
+  it_behaves_like 'Metasploit::Framework::LoginScanner::RexSocket'
 
+  subject do
+    described_class.new
+  end
+
+  let(:response) do
+    Rex::Proto::Http::Response.new(200, 'OK')
+  end
+
+  before(:each) do
+    allow_any_instance_of(Rex::Proto::Http::Client).to receive(:request_cgi).with(any_args)
+    allow_any_instance_of(Rex::Proto::Http::Client).to receive(:send_recv).with(any_args).and_return(response)
+    allow_any_instance_of(Rex::Proto::Http::Client).to receive(:set_config).with(any_args)
+    allow_any_instance_of(Rex::Proto::Http::Client).to receive(:close)
+    allow_any_instance_of(Rex::Proto::Http::Client).to receive(:connect)
+  end
+
+  describe '#check_setup' do
+    let(:phpMyAdmin_res) do
+      res = Rex::Proto::Http::Response.new(200, 'OK')
+      res.body = '<h1>Welcome to <bdo dir="ltr" lang="en">phpMyAdmin</bdo></h1>'
+      res
+    end
+
+    context 'when the target is PhpMyAdmin' do
+      let(:response) { phpMyAdmin_res }
+        it 'should return true' do
+          expect(subject.check_setup).to eql(true)
+        end
+    end
+
+    context 'when the target is not PhpMyAdmin' do
+      it 'should return false' do
+        expect(subject.check_setup).to eql(false)
+      end
+    end
   end
 
   describe '#get_session_info' do
+    let(:response) { nil }
+      context 'when a bad request is sent' do
+        it 'should return an unable to connect status' do
+          expect(subject.get_session_info).to eql({ status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT, proof: 'Unable to access PhpMyAdmin login page' })
+      end
+    end
 
   end
 
@@ -14,4 +56,7 @@ RSpec.describe Metasploit::Framework::LoginScanner::PhpMyAdmin do
 
   end
 
+  describe '#attempt_login' do
+
+  end
 end

--- a/spec/lib/metasploit/framework/login_scanner/phpmyadmin_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/phpmyadmin_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+require 'metasploit/framework/login_scanner/phpmyadmin'
+
+RSpec.describe Metasploit::Framework::LoginScanner::PhpMyAdmin do
+  describe '#check_setup' do
+
+  end
+
+  describe '#get_session_info' do
+
+  end
+
+  describe '#do_login' do
+
+  end
+
+end


### PR DESCRIPTION
This module is a brute-force login scanner for PhpMyAdmin. 

## Verification

- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/http/phpmyadmin_login`
- [x] `set RHOSTS [IP]`
- [x] `set TARGETURI [URI]`
- [x] `set PASSWORD [PASSWORD]`
- [x] `run`
- [x] You should get a successful login status

