### PR TITLE
Fix #10357, minor change to service info

### DIFF
--- a/modules/auxiliary/scanner/couchdb/couchdb_enum.rb
+++ b/modules/auxiliary/scanner/couchdb/couchdb_enum.rb
@@ -92,7 +92,7 @@ class MetasploitModule < Msf::Auxiliary
         port: rport,
         name: 'couchdb',
         proto: 'tcp',
-        info: res
+        info: res.body
       )
     else
       print_error("#{peer} Unable to enum, received \"#{res.code}\"")


### PR DESCRIPTION
This is a little noisy and breaks up the table:

```
msf5 auxiliary(scanner/couchdb/couchdb_enum) > services
Services
========

host        port  proto  name     state  info
----        ----  -----  ----     -----  ----
172.18.0.2  5984  tcp    couchdb  open   HTTP/1.1 200 OK
X-CouchDB-Body-Time: 0
X-Couch-Request-ID: 0c319bca71
Server: CouchDB/2.1.0 (Erlang OTP/17)
Date: Wed, 25 Jul 2018 06:01:35 GMT
Content-Type: application/json
Content-Length: 116
Cache-Control: must-revalidate

{"couchdb":"Welcome","version":"2.1.0","features":["scheduler"],"vendor":{"name":"The Apache Software Foundation"}}


msf5 auxiliary(scanner/couchdb/couchdb_enum) >
```

I've changed it to `res.body`:

```
msf5 auxiliary(scanner/couchdb/couchdb_enum) > services
Services
========

host        port  proto  name     state  info
----        ----  -----  ----     -----  ----
172.18.0.2  5984  tcp    couchdb  open   {"couchdb":"Welcome","version":"2.1.0","features":["scheduler"],"vendor":{"name":"The Apache Software Foundation"}}


msf5 auxiliary(scanner/couchdb/couchdb_enum) >
```

#10357