### PR TITLE
Net::SSH::CommandStream fixes implemented

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -271,7 +271,7 @@ GEM
       metasm
       rex-core
       rex-text
-    rex-socket (0.1.14)
+    rex-socket (0.1.15)
       rex-core
     rex-sslscan (0.1.5)
       rex-core

--- a/modules/exploits/apple_ios/ssh/cydia_default_ssh.rb
+++ b/modules/exploits/apple_ios/ssh/cydia_default_ssh.rb
@@ -4,6 +4,7 @@
 ##
 
 require 'net/ssh'
+require 'net/ssh/command_stream'
 
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking

--- a/modules/exploits/linux/ssh/ceragon_fibeair_known_privkey.rb
+++ b/modules/exploits/linux/ssh/ceragon_fibeair_known_privkey.rb
@@ -4,6 +4,7 @@
 ##
 
 require 'net/ssh'
+require 'net/ssh/command_stream'
 
 class MetasploitModule < Msf::Exploit::Remote
   include Msf::Auxiliary::Report

--- a/modules/exploits/linux/ssh/exagrid_known_privkey.rb
+++ b/modules/exploits/linux/ssh/exagrid_known_privkey.rb
@@ -4,6 +4,7 @@
 ##
 
 require 'net/ssh'
+require 'net/ssh/command_stream'
 
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking

--- a/modules/exploits/linux/ssh/f5_bigip_known_privkey.rb
+++ b/modules/exploits/linux/ssh/f5_bigip_known_privkey.rb
@@ -4,6 +4,7 @@
 ##
 
 require 'net/ssh'
+require 'net/ssh/command_stream'
 
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking

--- a/modules/exploits/linux/ssh/loadbalancerorg_enterprise_known_privkey.rb
+++ b/modules/exploits/linux/ssh/loadbalancerorg_enterprise_known_privkey.rb
@@ -4,6 +4,7 @@
 ##
 
 require 'net/ssh'
+require 'net/ssh/command_stream'
 
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking

--- a/modules/exploits/linux/ssh/quantum_dxi_known_privkey.rb
+++ b/modules/exploits/linux/ssh/quantum_dxi_known_privkey.rb
@@ -4,6 +4,7 @@
 ##
 
 require 'net/ssh'
+require 'net/ssh/command_stream'
 
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking

--- a/modules/exploits/linux/ssh/quantum_vmpro_backdoor.rb
+++ b/modules/exploits/linux/ssh/quantum_vmpro_backdoor.rb
@@ -4,6 +4,7 @@
 ##
 
 require 'net/ssh'
+require 'net/ssh/command_stream'
 
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking

--- a/modules/exploits/linux/ssh/symantec_smg_ssh.rb
+++ b/modules/exploits/linux/ssh/symantec_smg_ssh.rb
@@ -4,6 +4,7 @@
 ##
 
 require 'net/ssh'
+require 'net/ssh/command_stream'
 
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking

--- a/modules/exploits/linux/ssh/ubiquiti_airos_file_upload.rb
+++ b/modules/exploits/linux/ssh/ubiquiti_airos_file_upload.rb
@@ -3,6 +3,9 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
+require 'net/ssh'
+require 'net/ssh/command_stream'
+
 class MetasploitModule < Msf::Exploit::Remote
 
   # See note about overwritten files

--- a/modules/exploits/unix/ssh/array_vxag_vapv_privkey_privesc.rb
+++ b/modules/exploits/unix/ssh/array_vxag_vapv_privkey_privesc.rb
@@ -4,6 +4,7 @@
 ##
 
 require 'net/ssh'
+require 'net/ssh/command_stream'
 
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking

--- a/modules/exploits/unix/ssh/tectia_passwd_changereq.rb
+++ b/modules/exploits/unix/ssh/tectia_passwd_changereq.rb
@@ -4,6 +4,7 @@
 ##
 
 require 'net/ssh'
+require 'net/ssh/command_stream'
 
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking


### PR DESCRIPTION
This PR addresses the following:

- `Net::SSH::CommandStream` typos fixed
- `Net::SSH::CommandStream` cleanup made more robust and refactored
- `require 'net/ssh/command_stream'` added to SSH modules, which fixes #10331 

## Verification
- [x] **Verify** SSH modules can be run without the following error: `Exploit failed: NameError uninitialized constant Net::SSH::CommandStream`