### PR TITLE
Modify options for smb_login

### DIFF
--- a/modules/auxiliary/scanner/smb/smb_login.rb
+++ b/modules/auxiliary/scanner/smb/smb_login.rb
@@ -56,7 +56,8 @@ class MetasploitModule < Msf::Auxiliary
         OptBool.new('ABORT_ON_LOCKOUT', [ true, "Abort the run when an account lockout is detected", false ]),
         OptBool.new('PRESERVE_DOMAINS', [ false, "Respect a username that contains a domain name.", true ]),
         OptBool.new('RECORD_GUEST', [ false, "Record guest-privileged random logins to the database", false ]),
-        OptBool.new('DETECT_ANY_AUTH', [false, 'Enable detection of systems accepting any authentication', true])
+        OptBool.new('DETECT_ANY_AUTH', [false, 'Enable detection of systems accepting any authentication', false]),
+        OptBool.new('DETECT_ANY_DOMAIN', [false, 'Enable detection of systems accepting any domain for authentication', false])
       ])
 
   end
@@ -202,7 +203,7 @@ class MetasploitModule < Msf::Auxiliary
       username: result.credential.public,
     }.merge(service_data)
 
-    if domain.present?
+    if datastore['DETECT_ANY_DOMAIN'] && domain.present?
       if accepts_bogus_domains?(result.credential.public, result.credential.private)
         print_brute(:level => :vstatus, :ip => ip, :msg => "Domain is ignored for user #{result.credential.public}")
       else

--- a/modules/auxiliary/scanner/smb/smb_login.rb
+++ b/modules/auxiliary/scanner/smb/smb_login.rb
@@ -57,7 +57,7 @@ class MetasploitModule < Msf::Auxiliary
         OptBool.new('PRESERVE_DOMAINS', [ false, "Respect a username that contains a domain name.", true ]),
         OptBool.new('RECORD_GUEST', [ false, "Record guest-privileged random logins to the database", false ]),
         OptBool.new('DETECT_ANY_AUTH', [false, 'Enable detection of systems accepting any authentication', false]),
-        OptBool.new('DETECT_ANY_DOMAIN', [false, 'Enable detection of systems accepting any domain for authentication', false])
+        OptBool.new('DETECT_ANY_DOMAIN', [false, 'Detect if domain is required for the specified user', false])
       ])
 
   end


### PR DESCRIPTION
Change default value for DETECT_ANY_AUTH
and add option for DETECT_ANY_DOMAIN

## Verification

- [x] `./msfconsole -q`
- [x] `use auxiliary/scanner/smb/smb_login`
- [x] `set rhosts <rhosts>`
- [x] `set smbuser <user>`
- [x] `set smbpass <pass>`
- [x] `set DETECT_ANY_AUTH true`
- [x] Random username should be sent in authentication request
- [x] `set DETECT_ANY_AUTH false`
- [x] `set DETECT_ANY_DOMAIN true`
- [x] Login attempt with random domain should be sent