### PR TITLE
Handle connection errors and fail_with in check

### DIFF
--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -117,6 +117,9 @@ module Exploit::Remote::HttpClient
             fail_with(::Msf::Module::Failure::NotFound, err)
           end
         end
+      elsif info.nil?
+        err = "The target server did not respond to fingerprinting, use 'set FingerprintCheck false' to disable this check."
+        fail_with(::Msf::Module::Failure::Unreachable, err)
       end
     end
   end

--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -733,7 +733,7 @@ module Exploit::Remote::HttpClient
         {
           'uri'     => uri,
           'method'  => method
-        })
+        }) rescue nil
     end
 
     # Bail if the request did not receive a readable response

--- a/lib/msf/ui/console/module_command_dispatcher.rb
+++ b/lib/msf/ui/console/module_command_dispatcher.rb
@@ -139,13 +139,20 @@ module ModuleCommandDispatcher
         last_rhosts_opt = mod.datastore['RHOSTS']
         mod.datastore['RHOSTS'] = ip_range_arg
         begin
-          check_multiple(hosts)
+          if hosts.length > 1
+            check_multiple(hosts)
+          # Short-circuit check_multiple if it's a single host
+          else
+            mod.datastore['RHOST'] = hosts.next_ip
+            check_simple
+          end
         ensure
           # Restore the original rhost if set
           mod.datastore['RHOST'] = last_rhost_opt
           mod.datastore['RHOSTS'] = last_rhosts_opt
           mod.cleanup
         end
+      # XXX: This is basically dead code now that exploits use RHOSTS
       else
         # Check a single rhost
         unless Msf::OptAddress.new('RHOST').valid?(mod.datastore['RHOST'])

--- a/lib/msf/ui/console/module_command_dispatcher.rb
+++ b/lib/msf/ui/console/module_command_dispatcher.rb
@@ -243,6 +243,11 @@ module ModuleCommandDispatcher
       end
     rescue ::Rex::ConnectionError, ::Rex::ConnectionProxyError, ::Errno::ECONNRESET, ::Errno::EINTR, ::Rex::TimeoutError, ::Timeout::Error => e
       # Connection issues while running check should be handled by the module
+      print_error("Check failed: #{e.class} #{e}")
+      elog("#{e.message}\n#{e.backtrace.join("\n")}")
+    rescue ::Msf::Exploit::Failed => e
+      # Handle fail_with and other designated exploit failures
+      print_error("Check failed: #{e.class} #{e}")
       elog("#{e.message}\n#{e.backtrace.join("\n")}")
     rescue ::RuntimeError => e
       # Some modules raise RuntimeError but we don't necessarily care about those when we run check()


### PR DESCRIPTION
Also fix `FingerprintCheck` to tell us when it doesn't receive a response.

- [x] Test a module that doesn't use `HttpClient`, such as `exploit/unix/misc/distcc_exec`
- [x] Test a module that uses `FingerprintCheck`, such as `exploit/linux/http/hp_van_sdn_cmd_inject`
- [x] Test `check` with `RHOSTS` vs. an argument and a single host vs. a range of hosts

Resolves #10229. Mostly. #10303 resolves the issue for `HttpClient`, mostly.