### PR TITLE
Add PTY option for Meterpreter shell command

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
@@ -305,21 +305,20 @@ class Console::CommandDispatcher::Stdapi::Sys
   # Spawn a python pty /bin/bash or /bin/sh shell 
   #
   def pybash_shell
-    if client.fs.file.exist?("/usr/bin/python")
-      path = "/usr/bin/python"
-      if client.fs.file.exist?("/bin/bash")
-        ags = "-c \'import pty;pty.spawn(\"/bin/bash\")\'"
-      else
-        ags = "-c \'import pty;pty.spawn(\"/bin/sh\")\'"
-      end
-      begin
-        cmd_execute("-f", path, "-a", ags, "-c", "-i")
-      rescue
-        return false
-      end
-      return true
-    end
-    return false
+    path = nil
+    path = '/usr/bin/python'  if client.fs.file.exist?('/usr/bin/python')
+    path = '/usr/bin/python2' if client.fs.file.exist?('/usr/bin/python2') && !path
+    path = '/usr/bin/python3' if client.fs.file.exist?('/usr/bin/python3') && !path
+
+    return false unless path
+
+    sh_path = client.fs.file.exist?('/bin/bash') ? '/bin/bash' : '/bin/sh'
+    ags = "-c \'import pty;pty.spawn(\"#{sh_path}\")\'"
+    cmd_execute('-f', path, '-a', ags, '-c', '-i')
+
+    true
+  rescue
+    false
   end
 
   #

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
@@ -293,10 +293,10 @@ class Console::CommandDispatcher::Stdapi::Sys
       # must special-case COMSPEC to return the system-specific shell.
       path = client.fs.file.expand_path("%COMSPEC%")
       # If that failed for whatever reason, guess it's unix
-      if pybash
+      path = (path and not path.empty?) ? path : "/bin/sh"
+      if pybash && path == "/bin/sh"
         return true if pybash_shell
       end
-      path = (path and not path.empty?) ? path : "/bin/sh"
       cmd_execute("-f", path, "-c", "-i")
     end
   end

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
@@ -346,11 +346,11 @@ class Console::CommandDispatcher::Stdapi::Sys
     path = '/usr/bin/expect'  if client.fs.file.exist?('/usr/bin/expect')  && !path
     return false unless path
 
-    # Commands for methods - "export TERM=xterm" provides colors, "clear" command, etc. as available on the target.
-    cmd = "export TERM=xterm; #{path} - exec:'#{sh_path} -li',pty,stderr,setsid,sigint,sane" if path =~ /socat/
-    cmd = "export TERM=xterm; #{path} -qc #{sh_path} /dev/null || #{path} -q /dev/null #{sh_path}" if path =~ /script/
-    cmd = "export TERM=xterm; #{path} -c \'import pty;pty.spawn(\"#{sh_path}\")\'" if path =~ /python/
-    cmd = "export TERM=xterm; #{path} -c 'spawn #{sh_path}; interact'" if path =~ /expect/
+    # Commands for methods - "env TERM=xterm" provides colors, "clear" command, etc. as available on the target.
+    cmd = "env TERM=xterm #{path} - exec:'#{sh_path} -li',pty,stderr,setsid,sigint,sane" if path =~ /socat/
+    cmd = "env TERM=xterm #{path} -qc #{sh_path} /dev/null || #{path} -q /dev/null #{sh_path}" if path =~ /script/
+    cmd = "env TERM=xterm #{path} -c \'import pty;pty.spawn(\"#{sh_path}\")\'" if path =~ /python/
+    cmd = "env TERM=xterm #{path} -c 'spawn #{sh_path}; interact'" if path =~ /expect/
     cmd_execute('-if', cmd)
 
     true

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
@@ -319,7 +319,7 @@ class Console::CommandDispatcher::Stdapi::Sys
     path = '/usr/bin/python2' if client.fs.file.exist?('/usr/bin/python2') && !path
     path = '/usr/bin/python3' if client.fs.file.exist?('/usr/bin/python3') && !path
     return false unless path
-    
+
     cmd = "export TERM=xterm; #{path} - exec:'#{sh_path} -li',pty,stderr,setsid,sigint,sane" if path =~ /socat/
     cmd = "export TERM=xterm; #{path} -qc #{sh_path} /dev/null" if path =~ /script/
     cmd = "export TERM=xterm; #{path} -c \'import pty;pty.spawn(\"#{sh_path}\")\'" if path =~ /python/


### PR DESCRIPTION
## Overview
This PR adds a pybash option to the Meterpreter `shell` command to provide a little bit nicer pty shell on NX machines that have python installed. Some Meterpreter flavors (python and php) even produce a color pty depending on target settings.

I like to drop to a shell to manually work on machines and got tired of having to type or paste in the pybash line. Having the option to go straight to this is rather nice. It is not a full tty with tab completion and command history, but it's better than a raw /bin/sh from the standard `shell` command.

Decided to make this an option instead of the default behavior. However, it would be easy to make it the default action, if people like the idea.

### Example Output: (From a Kali target)
```
meterpreter > shell -h
Usage: shell [options]

Opens an interactive native shell.

OPTIONS:

    -b        NX Bash PTY via pybash, requires python
    -h        Help menu.

meterpreter > shell
Process 2398 created.
Channel 3 created.
/bin/sh: 0: can't access tty; job control turned off
# 

meterpreter > shell -b
Process 2404 created.
Channel 4 created.
root@sn0wfa11:/# 
```

### Screenshot: (From a CentOS target)
![shell_b](https://user-images.githubusercontent.com/12484685/43361891-ca53d95c-92a2-11e8-96fb-491f2f744025.jpg)

## Verification
- [ ] Start up some Meterpreter shells on various systems:
- [ ] `shell -b` should produce a pty bash on NX machines with python
- [ ] `shell -b` should act just like `shell` on NX machines without python
- [ ] `shell -b` should act just like `shell` on Windows or other non-NX machines