### PR TITLE
Fixes in aws_ec2_instance_metadata module

### DIFF
--- a/modules/post/multi/gather/aws_ec2_instance_metadata.rb
+++ b/modules/post/multi/gather/aws_ec2_instance_metadata.rb
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Post
 
   def check_aws_metadata
     resp = simple_get(@target_uri)
-    unless resp =~ /^instance-id.$/m
+    unless resp =~ /instance-id/m
       fail_with(Failure::BadConfig, "Session does not appear to be on an AWS EC2 instance")
     end
     resp
@@ -50,14 +50,14 @@ class MetasploitModule < Msf::Post
 
   def get_aws_metadata(base_uri, base_resp)
     r = {}
-    base_resp.split(/\r\n/).each do |l|
-      new_uri = base_uri.merge("./#{l}")
-      if l =~ %r{/$}
+    base_resp.split(/\n/).each do |l|
+      new_uri = "#{base_uri}#{l}"
+      if l =~/\/$/
         # handle a directory
-        r[l.gsub(%r{/$}, '')] = get_aws_metadata(new_uri, simple_get(new_uri))
-      elsif new_uri.to_s =~ %r{/public-keys/} && /^(?<key_id>\d+)=/ =~ l
+        r[l.gsub(/\/$/, '')] = get_aws_metadata(new_uri, simple_get(new_uri))
+      elsif new_uri.to_s =~ /\/public-keys/ && /^(?<key_id>\d+)=/ =~ l
         # special case handling of the public-keys endpoint
-        key_uri = new_uri.merge("./#{key_id}/")
+        key_uri = "#{new_uri}#{key_id}/"
         key_resp = simple_get(key_uri)
         r[key_id] = get_aws_metadata(key_uri, key_resp)
       else
@@ -94,6 +94,7 @@ class MetasploitModule < Msf::Post
 
   def simple_get(url)
     vprint_status("Fetching #{url}")
+    puts("Fetching #{url}")
     cmd_exec("curl #{url}")
   end
 end

--- a/modules/post/multi/gather/aws_ec2_instance_metadata.rb
+++ b/modules/post/multi/gather/aws_ec2_instance_metadata.rb
@@ -94,7 +94,6 @@ class MetasploitModule < Msf::Post
 
   def simple_get(url)
     vprint_status("Fetching #{url}")
-    puts("Fetching #{url}")
     cmd_exec("curl #{url}")
   end
 end

--- a/modules/post/multi/gather/aws_ec2_instance_metadata.rb
+++ b/modules/post/multi/gather/aws_ec2_instance_metadata.rb
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Post
 
   def check_aws_metadata
     resp = simple_get(@target_uri)
-    unless resp =~ /^instance-id.$/m
+    unless resp =~ /^instance-id$/m
       fail_with(Failure::BadConfig, "Session does not appear to be on an AWS EC2 instance")
     end
     resp
@@ -50,15 +50,16 @@ class MetasploitModule < Msf::Post
 
   def get_aws_metadata(base_uri, base_resp)
     r = {}
-    base_resp.split(/\r\n/).each do |l|
-      new_uri = base_uri.merge("./#{l}")
+    base_resp.split(/\r?\n/).each do |l|
+      new_uri = "#{base_uri}#{l}"
       if l =~ %r{/$}
         # handle a directory
         r[l.gsub(%r{/$}, '')] = get_aws_metadata(new_uri, simple_get(new_uri))
       elsif new_uri.to_s =~ %r{/public-keys/} && /^(?<key_id>\d+)=/ =~ l
         # special case handling of the public-keys endpoint
-        key_uri = new_uri.merge("./#{key_id}/")
-        key_resp = simple_get(key_uri)
+	new_uri = new_uri.slice(0..(new_uri.index(%r{/public-keys/})+'/public-keys'.length))
+	key_uri = "#{new_uri}#{key_id}/"
+	key_resp = simple_get(key_uri)
         r[key_id] = get_aws_metadata(key_uri, key_resp)
       else
         r[l] = simple_get(new_uri)
@@ -94,6 +95,6 @@ class MetasploitModule < Msf::Post
 
   def simple_get(url)
     vprint_status("Fetching #{url}")
-    cmd_exec("curl #{url}")
+    cmd_exec("curl -s #{url}")
   end
 end

--- a/modules/post/multi/gather/aws_ec2_instance_metadata.rb
+++ b/modules/post/multi/gather/aws_ec2_instance_metadata.rb
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Post
 
   def check_aws_metadata
     resp = simple_get(@target_uri)
-    unless resp =~ /^instance-id$/m
+    unless resp =~ /^instance-id$/
       fail_with(Failure::BadConfig, "Session does not appear to be on an AWS EC2 instance")
     end
     resp

--- a/modules/post/multi/gather/aws_ec2_instance_metadata.rb
+++ b/modules/post/multi/gather/aws_ec2_instance_metadata.rb
@@ -57,9 +57,9 @@ class MetasploitModule < Msf::Post
         r[l.gsub(%r{/$}, '')] = get_aws_metadata(new_uri, simple_get(new_uri))
       elsif new_uri.to_s =~ %r{/public-keys/} && /^(?<key_id>\d+)=/ =~ l
         # special case handling of the public-keys endpoint
-	new_uri = new_uri.slice(0..(new_uri.index(%r{/public-keys/})+'/public-keys'.length))
-	key_uri = "#{new_uri}#{key_id}/"
-	key_resp = simple_get(key_uri)
+        new_uri = new_uri.slice(0..(new_uri.index(%r{/public-keys/})+'/public-keys'.length))
+        key_uri = "#{new_uri}#{key_id}/"
+        key_resp = simple_get(key_uri)
         r[key_id] = get_aws_metadata(key_uri, key_resp)
       else
         r[l] = simple_get(new_uri)


### PR DESCRIPTION
#Using ruby 2.3.6

@@ -36,7 +36,7 @@ def initialize(info = {})

    - unless resp =~ /^instance-id.$/m
    + unless resp =~ /^instance-id$/m
The original regex requires one character after 'instance-id' which is not present in the instance.

@@ -50,15 +50,16 @@ def check_curl

    - base_resp.split(/\r\n/).each do |l|
    -    new_uri = base_uri.merge("./#{l}")
    + base_resp.split(/\r?\n/).each do |l|
    +   new_uri = "#{base_uri}#{l}"

    - key_uri = new_uri.merge("./#{key_id}/")
    - key_resp = simple_get(key_uri)
    + new_uri = new_uri.slice(0..(new_uri.index(%r{/public-keys/})+'/public-keys'.length))
    + key_uri = "#{new_uri}#{key_id}/"
    + key_resp = simple_get(key_uri)

1. merge function was causing 'rescue in merge' errors
2. the split function could not succeed, there were no '\r\n' between the lines but '\n' only
3. the special case was not handled correctly 
was trying to curl http://169.254.169.254/latest/meta-data/public-keys/0=Key0/ instead of http://169.254.169.254/latest/meta-data/public-keys/0/

@@ -94,6 +95,6 @@ def setup

    - cmd_exec("curl #{url}")
    + cmd_exec("curl -s #{url}")
Curl was causing issues when not in silent mode.