### PR TITLE
remove unused juniper options

### DIFF
--- a/modules/post/juniper/gather/enum_juniper.rb
+++ b/modules/post/juniper/gather/enum_juniper.rb
@@ -18,13 +18,6 @@ class MetasploitModule < Msf::Post
       'Platform'      => [ 'juniper'],
       'SessionTypes'  => [ 'shell' ]
     ))
-
-    register_options(
-      [
-        OptString.new('ENABLE', [ false, 'Enable password for changing privilege level.']),
-        OptPath.new('WORDLIST', [false, 'Wordlist of possible enable passwords to try.'])
-      ])
-
   end
 
   def run


### PR DESCRIPTION
This PR removes the unused options in the post juniper module.  Very simple change, just been on my to do list for a while!