### PR TITLE
Show IP and Port in joomla page scanner output

### DIFF
--- a/modules/auxiliary/scanner/http/joomla_pages.rb
+++ b/modules/auxiliary/scanner/http/joomla_pages.rb
@@ -68,7 +68,7 @@ class MetasploitModule < Msf::Auxiliary
 
       report_note(
         :host  => ip,
-        :port  => datastore['RPORT'],
+        :port  => port,
         :proto => 'http',
         :ntype => 'joomla_page',
         :data  => "#{note}: #{ip}:#{port}#{tpath}#{page}",

--- a/modules/auxiliary/scanner/http/joomla_pages.rb
+++ b/modules/auxiliary/scanner/http/joomla_pages.rb
@@ -62,15 +62,16 @@ class MetasploitModule < Msf::Auxiliary
       elsif (res.body =~/Registration/ and res.body =~/class="validate">Register<\/button>/)
         note = "Registration Page"
       end
-
-      print_good("#{note}: #{tpath}#{page}")
+      
+      port = datastore['RPORT']
+      print_good("#{note}: #{ip}:#{port}#{tpath}#{page}")
 
       report_note(
         :host  => ip,
         :port  => datastore['RPORT'],
         :proto => 'http',
         :ntype => 'joomla_page',
-        :data  => "#{note}: #{tpath}#{page}",
+        :data  => "#{note}: #{ip}:#{port}#{tpath}#{page}",
         :update => :unique_data
       )
     elsif (res.code == 403)


### PR DESCRIPTION
Better output added to joomla_pages to also show IP and Port in output to console, since the output is useless without, when scanning multiple hosts. Also changed the output in the notes to match console output.

Issue #10396

## Verification

List the steps needed to make sure this thing works

- [X] Start `msfconsole`
- [X] `use auxiliary/scanner/http/joomla_pages`
- [X] **Verify** the thing does what it should
- [X] **Verify** the thing does not do what it should not