### PR TITLE
Fix missing service, port, and protocol columns in notes

### DIFF
--- a/lib/msf/core/db_manager/note.rb
+++ b/lib/msf/core/db_manager/note.rb
@@ -94,12 +94,16 @@ module Msf::DBManager::Note
         when 'tcp','udp'
           proto = proto_lower
           sname = opts[:sname] if opts[:sname]
+        # XXX: These normalizations are lazy af
+        when 'http', 'smb'
+          proto = 'tcp'
+          sname = proto_lower
         when 'dns','snmp','dhcp'
           proto = 'udp'
-          sname = opts[:proto]
+          sname = proto_lower
         else
           proto = 'tcp'
-          sname = opts[:proto]
+          sname = proto_lower
         end
         sopts = {
           :workspace => wspace,
@@ -119,8 +123,8 @@ module Msf::DBManager::Note
     if addr and not host
       host = get_host(:workspace => wspace, :host => addr)
     end
-    if host and (opts[:port] and opts[:proto])
-      service = get_service(wspace, host, opts[:proto], opts[:port])
+    if host and (opts[:port] and proto)
+      service = get_service(wspace, host, proto, opts[:port])
     elsif opts[:service] and opts[:service].kind_of? ::Mdm::Service
       service = opts[:service]
     end

--- a/modules/auxiliary/scanner/http/joomla_pages.rb
+++ b/modules/auxiliary/scanner/http/joomla_pages.rb
@@ -69,7 +69,8 @@ class MetasploitModule < Msf::Auxiliary
       report_note(
         :host   => ip,
         :port   => rport,
-        :proto  => 'http',
+        :proto  => 'tcp',
+        :sname  => 'http',
         :ntype  => 'joomla_page',
         :data   => msg,
         :update => :unique_data


### PR DESCRIPTION
We also normalize for HTTP and SMB and correct the protocol and service in #10403.

- [x] `mkdir -p joomla/administrator`
- [x] `cd joomla`
- [x] `echo $'Administration Login\nadministration console' > administrator/index.php`
- [x] `python -m SimpleHTTPServer 8080`
- [x] Test `auxiliary/scanner/http/joomla_pages` or similar

```
msf5 auxiliary(scanner/http/joomla_pages) > notes

Notes
=====

 Time                     Host       Service  Port  Protocol  Type         Data
 ----                     ----       -------  ----  --------  ----         ----
 2018-07-31 16:13:48 UTC  127.0.0.1                           joomla_page  "Administrator Login
Page: /administrator/index.php"
 2018-07-31 16:13:48 UTC  127.0.0.2                           joomla_page  "Administrator Login
Page: /administrator/index.php"

msf5 auxiliary(scanner/http/joomla_pages) >
```

```
msf5 auxiliary(scanner/http/joomla_pages) > notes

Notes
=====

 Time                     Host       Service  Port  Protocol  Type         Data
 ----                     ----       -------  ----  --------  ----         ----
 2018-07-31 16:32:08 UTC  127.0.0.1  http     8080  tcp       joomla_page  "Administrator Login
Page: /administrator/index.php"
 2018-07-31 16:32:10 UTC  127.0.0.2  http     8080  tcp       joomla_page  "Administrator Login
Page: /administrator/index.php"

msf5 auxiliary(scanner/http/joomla_pages) >
```