### PR TITLE
Update check method of Hadoop exploit 

### DIFF
--- a/modules/exploits/linux/http/hadoop_unauth_exec.rb
+++ b/modules/exploits/linux/http/hadoop_unauth_exec.rb
@@ -53,7 +53,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     if res && res.code == 200 && res.body.include?('application-id')
-      return CheckCode::Detected
+      return CheckCode::Appears
     end
 
     CheckCode::Safe


### PR DESCRIPTION
A quick fix for the `check` method of the hadoop_unauth_exec.

Now I test it, the check method output is :
The target service is running, but could not be validated.

I don't think it's a good and helpful message, it should be `CheckCode::Appears`

