### PR TITLE
Fix use -h to call cmd_use_help

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -595,7 +595,7 @@ module Msf
           # Uses a module.
           #
           def cmd_use(*args)
-            if (args.length == 0)
+            if args.length == 0 || args.first == '-h'
               cmd_use_help
               return false
             end


### PR DESCRIPTION
It really shouldn't try to load it as a module.

- [x] Test `help use`
- [x] Test `use` with no arguments
- [x] Test `use -h`
- [x] Test `use` with a module

```
msf5 > use -h
[-] Failed to load module: -h
msf5 >
```

```
msf5 > use -h
Usage: use module_name

The use command is used to interact with a module of a given name.

msf5 >
```

From Metasploit Basics at Black Hat.