### PR TITLE
Make msfdb_ws help fast like msfvenom's

### DIFF
--- a/msfdb_ws
+++ b/msfdb_ws
@@ -3,10 +3,6 @@
 #
 # Starts the HTTP DB Service interface
 
-
-require 'pathname'
-require Pathname.new(__FILE__).realpath.expand_path.parent.join('config', 'boot')
-require 'msf/core/db_manager/http/http_db_manager_service'
 require 'optparse'
 
 class HelpError < StandardError; end
@@ -15,6 +11,12 @@ class SwitchError < StandardError
   def initialize(msg="Missing required switch.")
     super(msg)
   end
+end
+
+def require_deps
+  require 'pathname'
+  require Pathname.new(__FILE__).realpath.expand_path.parent.join('config', 'boot')
+  require 'msf/core/db_manager/http/http_db_manager_service'
 end
 
 def parse_args(args)
@@ -71,6 +73,7 @@ end
 begin
   opts = parse_args(ARGV)
   raise SwitchError.new("certificate file must be specified when using -s") if opts[:ssl] && (opts[:ssl_cert].nil?)
+  require_deps
   HttpDBManagerService.new.start(:Port => opts[:port],
                                  :Host => opts[:interface],
                                  :ssl => opts[:ssl],


### PR DESCRIPTION
Hopefully I didn't miss anything like last time.

- [x] Test `msfdb_ws` help
- [x] See that it displays quickly
- [x] Make sure it still works

```
wvu@hiigara:~/metasploit-framework:bug/help$ time ./msfdb_ws --help
msfdb_ws - Metasploit data store as a web service.
Usage: ./msfdb_ws [options] <var=val>

Options:
    -i, --interface  <interface>     Interface to listen on
    -p, --port       <port number>   Port to listen on
    -s, --ssl                        Enable SSL on the server
    -c      <path/to/cert.pem>,      Path to SSL Certificate file
        --cert
    -k       <path/to/key.pem>,      Path to SSL Key file
        --key
    -h, --help                       Show this message

real    0m0.378s
user    0m0.285s
sys     0m0.092s
wvu@hiigara:~/metasploit-framework:bug/help$
```

#9723

From Metasploit Basics at Black Hat.