### PR TITLE
Prevent adding the same command to history

### DIFF
--- a/lib/rex/ui/text/input/readline.rb
+++ b/lib/rex/ui/text/input/readline.rb
@@ -168,7 +168,8 @@ begin
         end
 
         if add_history && line
-          RbReadline.add_history(line)
+          index = ::Readline::HISTORY.length - 1
+          RbReadline.add_history(line) if not (line == ::Readline::HISTORY[index])
         end
 
         line.try(:dup)


### PR DESCRIPTION
These changes will check if the current command is same as the last one and won't add it to the history if it's the same command as the last one.

this comes in handy when you have series of commands executed before and bunch of `exploit` after that in the history (while testing an exploit maybe). and now you gotta keep pressing the up button to execute those series of commands :p 