### PR TITLE
Reimplement and refactor history clearing

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -87,7 +87,8 @@ class Core
   @@history_opts = Rex::Parser::Arguments.new(
     "-h" => [ false, "Help banner."                                   ],
     "-a" => [ false, "Show all commands in history."                  ],
-    "-n" => [ true,  "Show the last n commands."                      ])
+    "-n" => [ true,  "Show the last n commands."                      ],
+    "-c" => [ false, "Clear command history."                         ])
 
   @@irb_opts = Rex::Parser::Arguments.new(
     "-h" => [ false, "Help banner."                                   ],
@@ -487,6 +488,9 @@ class Core
         else
           limit = val.to_i
         end
+      when "-c"
+        Readline::HISTORY.clear
+        return
       when "-h"
         cmd_history_help
         return false
@@ -507,7 +511,6 @@ class Core
     print_line
     print_line "Shows the command history."
     print_line "If -n is not set, only the last #{@history_limit} commands will be shown."
-    print_line
     print @@history_opts.usage
   end
 

--- a/lib/rex/ui/text/input/readline.rb
+++ b/lib/rex/ui/text/input/readline.rb
@@ -176,7 +176,15 @@ begin
 
         line.try(:dup)
       else
-        ::Readline.readline(reset_sequence + prompt, true)
+        # The line that's read is immediately added to history
+        line = ::Readline.readline(reset_sequence + prompt, true)
+
+        # Don't add duplicate lines to history
+        if ::Readline::HISTORY.length > 1 && line == ::Readline::HISTORY[-2]
+          ::Readline::HISTORY.pop
+        end
+
+        line
       end
     end
 

--- a/lib/rex/ui/text/shell.rb
+++ b/lib/rex/ui/text/shell.rb
@@ -207,7 +207,7 @@ module Shell
         else
           ret = run_single(line)
           # don't bother saving lines that couldn't be found as a
-          # command, create the file if it doesn't exist
+          # command, create the file if it doesn't exist, don't save dupes
           if ret && self.histfile && line != @last_line
             File.open(self.histfile, "a+") { |f| f.puts(line) }
             @last_line = line


### PR DESCRIPTION
This is for you, @Auxilus. :)

- [x] Test with `RbReadline` (no `-L`)
  - [x] See that history is cleared
  - [x] See that the history file is truncated
- [x] Test with system Readline (`-L`)
  - [x] See that history is cleared
  - [x] See that the history file is truncated

Note that the current line is still stored in the history file.

#7771, #10423, #10424