### PR TITLE
Move pry and irb commands to developer dispatcher

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -90,10 +90,6 @@ class Core
     "-n" => [ true,  "Show the last n commands."                      ],
     "-c" => [ false, "Clear command history and history file."        ])
 
-  @@irb_opts = Rex::Parser::Arguments.new(
-    "-h" => [ false, "Help banner."                                   ],
-    "-e" => [ true,  "Expression to evaluate."                        ])
-
   # Returns the list of commands supported by this command dispatcher
   def commands
     {
@@ -108,7 +104,6 @@ class Core
       "grep"       => "Grep the output of another command",
       "help"       => "Help menu",
       "history"    => "Show command history",
-      "irb"        => "Drop into irb scripting mode",
       "load"       => "Load a framework plugin",
       "quit"       => "Exit the console",
       "route"      => "Route traffic through a session",
@@ -544,48 +539,6 @@ class Core
   def cmd_sleep(*args)
     return if not (args and args.length == 1)
     Rex::ThreadSafe.sleep(args[0].to_f)
-  end
-
-  def cmd_irb_help
-    print_line "Usage: irb"
-    print_line
-    print_line "Execute commands in a Ruby environment"
-    print @@irb_opts.usage
-  end
-
-  #
-  # Goes into IRB scripting mode
-  #
-  def cmd_irb(*args)
-    expressions = []
-
-    # Parse the command options
-    @@irb_opts.parse(args) do |opt, idx, val|
-      case opt
-      when '-e'
-        expressions << val
-      when '-h'
-        cmd_irb_help
-        return false
-      end
-    end
-
-    if expressions.empty?
-      print_status("Starting IRB shell...\n")
-
-      begin
-        Rex::Ui::Text::IrbShell.new(binding).run
-      rescue
-        print_error("Error during IRB: #{$!}\n\n#{$@.join("\n")}")
-      end
-
-      # Reset tab completion
-      if (driver.input.supports_readline)
-        driver.input.reset_tab_completion
-      end
-    else
-      expressions.each { |expression| eval(expression, binding) }
-    end
   end
 
   def cmd_threads_help

--- a/lib/msf/ui/console/command_dispatcher/developer.rb
+++ b/lib/msf/ui/console/command_dispatcher/developer.rb
@@ -14,6 +14,7 @@ class Msf::Ui::Console::CommandDispatcher::Developer
 
   def commands
     {
+      'pry'        => 'Open a Pry session on the current module or Framework',
       'edit'       => 'Edit the current module or a file with the preferred editor',
       'reload_lib' => 'Reload one or more library files from specified paths',
       'log'        => 'Displays framework.log starting at the bottom if possible'
@@ -37,12 +38,33 @@ class Msf::Ui::Console::CommandDispatcher::Developer
 
     # The file must exist to reach this, so we try our best here
     if path =~ %r{^(?:\./)?modules/}
-      print_error('Reloading Metasploit modules is not supported (try "reload")')
+      print_error("Reloading Metasploit modules is not supported (try 'reload')")
       return
     end
 
     print_status("Reloading #{path}")
     load path
+  end
+
+  def cmd_pry_help
+    print_line 'Usage: pry'
+    print_line
+    print_line 'Open a Pry session on the current module or Framework.'
+    print_line
+  end
+
+  #
+  # Open a Pry session on the current module or Framework
+  #
+  def cmd_pry(*args)
+    begin
+      require 'pry'
+    rescue LoadError
+      print_error("Failed to load Pry, try 'gem install pry'")
+      return
+    end
+
+    active_module ? active_module.pry : framework.pry
   end
 
   def cmd_edit_help

--- a/lib/msf/ui/console/module_command_dispatcher.rb
+++ b/lib/msf/ui/console/module_command_dispatcher.rb
@@ -16,7 +16,6 @@ module ModuleCommandDispatcher
 
   def commands
     {
-      "pry"    => "Open a Pry session on the current module",
       "reload" => "Reload the current module from disk",
       "check"  => "Check to see if a target is vulnerable"
     }
@@ -266,24 +265,6 @@ module ModuleCommandDispatcher
       print_error("Check failed: #{e.class} #{e}")
       elog("#{e.message}\n#{e.backtrace.join("\n")}")
     end
-  end
-
-  def cmd_pry_help
-    print_line "Usage: pry"
-    print_line
-    print_line "Open a pry session on the current module.  Be careful, you"
-    print_line "can break things."
-    print_line
-  end
-
-  def cmd_pry(*args)
-    begin
-      require 'pry'
-    rescue LoadError
-      print_error("Failed to load pry, try 'gem install pry'")
-      return
-    end
-    mod.pry
   end
 
   #


### PR DESCRIPTION
We also fall back on prying Framework if a module isn't active.

This fixes the following bad behavior:

```
msf5 > pry
[*] exec: pry
```

And then your input gets stolen.

- [x] Test `help` and see `pry` listed
- [x] Test `help pry` and see `pry` help
- [x] Test `pry` in a module context
- [x] Test `pry` in any other context

```
msf5 > use exploit/linux/http/hp_van_sdn_cmd_inject
msf5 exploit(linux/http/hp_van_sdn_cmd_inject) > pry
[1] pry(#<Msf::Modules::Mod6578706c6f69742f6c696e75782f687474702f68705f76616e5f73646e5f636d645f696e6a656374::MetasploitModule>)>
msf5 exploit(linux/http/hp_van_sdn_cmd_inject) > back
msf5 > pry
[1] pry(#<Msf::Framework>)>
```