### PR TITLE
sync some linux local libraries to solaris

### DIFF
--- a/lib/msf/core/post/solaris.rb
+++ b/lib/msf/core/post/solaris.rb
@@ -2,4 +2,5 @@
 module Msf::Post::Solaris
   require 'msf/core/post/solaris/priv'
   require 'msf/core/post/solaris/system'
+  require 'msf/core/post/solaris/kernel'
 end

--- a/lib/msf/core/post/solaris/kernel.rb
+++ b/lib/msf/core/post/solaris/kernel.rb
@@ -1,0 +1,60 @@
+# -*- coding: binary -*-
+require 'msf/core/post/common'
+
+module Msf
+class Post
+module Linux
+module Kernel
+  include ::Msf::Post::Common
+
+  #
+  # Returns uname output
+  #
+  # @return [String]
+  #
+  def uname(opts='-a')
+    cmd_exec("uname #{opts}").to_s.strip
+  rescue
+    raise "Failed to run uname #{opts}"
+  end
+
+  #
+  # Returns the kernel release
+  #
+  # @return [String]
+  #
+  def kernel_release
+    uname('-r')
+  end
+
+  #
+  # Returns the kernel version
+  #
+  # @return [String]
+  #
+  def kernel_version
+    uname('-v')
+  end
+
+  #
+  # Returns the kernel name
+  #
+  # @return [String]
+  #
+  def kernel_name
+    uname('-s')
+  end
+
+  #
+  # Returns the kernel hardware
+  #
+  # @return [String]
+  #
+  def kernel_hardware
+    uname('-m')
+  end
+
+end # Kernel
+end # Linux
+end # Post
+end # Msf

--- a/lib/msf/core/post/solaris/system.rb
+++ b/lib/msf/core/post/solaris/system.rb
@@ -25,6 +25,114 @@ module System
     return system_data
   end
 
+  #
+  # Gathers all SUID files on the filesystem.
+  # NOTE: This uses the Linux `find` command. It will most likely take a while to get all files.
+  # Consider specifying a more narrow find path.
+  # @param findpath The path on the system to start searching
+  # @return [Array]
+  def get_suid_files(findpath = '/')
+    out = cmd_exec("find #{findpath} -perm -4000 -print -xdev").to_s.split("\n")
+    out.delete_if {|i| i.include?'Permission denied'}
+  rescue
+    raise "Could not retrieve all SUID files"
+  end
+
+  #
+  # Gets the $PATH environment variable
+  #
+  def get_path
+    cmd_exec('echo $PATH').to_s
+  rescue
+    raise "Unable to determine path"
+  end
+
+  #
+  # Gets basic information about the system's CPU.
+  # @return [Hash]
+  #
+  def get_cpu_info
+    info = {}
+    orig = cmd_exec('kstat -m cpu_info -p').to_s
+    cpuinfo = orig.split("\n")
+    # This is probably a more platform independent way to parse the results (compared to splitting and assigning preset indices to values)
+    cpuinfo.each do |l|
+      info[:speed_mhz]   = l.split(':')[3].split("\t")[1].to_i if l.include? 'clock_MHz'
+      info[:product]     = l.split(':')[3].split("\t")[1]      if l.include? 'brand'
+      info[:vendor]      = l.split(':')[3].split("\t")[1]      if l.include? 'vendor_id'
+      info[:cores]       = l.split(':')[3].split("\t")[1].to_i if l.include? 'ncore_per_chip'
+    end
+    return info
+  rescue
+    raise "Could not get CPU information"
+  end
+
+  #
+  # Gets the hostname of the system
+  # @return [String]
+  #
+  def get_hostname
+    cmd_exec('uname -n').to_s
+  rescue
+    raise 'Unable to retrieve hostname'
+  end
+
+  #
+  # Gets the name of the current shell
+  # @return [String]
+  #
+  def get_shell_name
+    psout = cmd_exec('ps -p $$').to_s
+    psout.split("\n").last.split(' ')[3]
+  rescue
+    raise 'Unable to gather shell name'
+  end
+
+  #
+  # Checks if the system has gcc installed
+  # @return [Boolean]
+  #
+  def has_gcc?
+    command_exists? 'gcc'
+  rescue
+    raise 'Unable to check for gcc'
+  end
+
+  #
+  # Checks if the `cmd` is installed on the system
+  # @return [Boolean]
+  #
+  def command_exists?(cmd)
+    cmd_exec("command -v #{cmd} && echo true").to_s.include? 'true'
+  rescue
+    raise "Unable to check if command `#{cmd}` exists"
+  end
+
+  #
+  # Gets the process id(s) of `program`
+  # @return [Array]
+  #
+  def pidof(program)
+    pids = []
+    full = cmd_exec('ps aux').to_s
+    full.split("\n").each do |pid|
+      pids << pid.split(' ')[1].to_i if pid.include? program
+    end
+    pids
+  end
+
+  #
+  # Gets the mount point of `filepath`
+  # @param [String] filepath The filepath to get the mount point
+  # @return [String]
+  #
+  def get_mount_path(filepath)
+    cmd_exec("df \"#{filepath}\" | tail -1").split(' ')[0]
+  rescue
+    raise "Unable to get mount path of #{filepath}"
+  end
+
+
 end # System
 end # Solaris
 end # Post


### PR DESCRIPTION
Remember in #9812 when @bcoles did awesome things for libs on the linux local side?  This is an attempt to copy some of that functionality to the solaris side in prep for 2 or 3 solaris priv escalations that are on edb.  Keep in mind the most recent solaris exploits are 2007/2008.  10yrs of no <3

I only tested these on solaris 11.3 x86.  It would be a good idea to them on sparc and maybe solaris 8?

## Verification

Here is a test script I wrote that will run through all the added functions:
`cat modules/exploits/solaris/local/test.rb`
```
##
# This module requires Metasploit: https://metasploit.com/download
# Current source: https://github.com/rapid7/metasploit-framework
##

class MetasploitModule < Msf::Exploit::Local
  Rank = ExcellentRanking

  include Msf::Post::Solaris::System

  def initialize(info = {})
    super(update_info(info,
      'Name'           => 'Solaris System Tester',
      'Description'    => %q{
        Tests the lib/msf/core/post/solaris/system file.
      },
      'License'        => MSF_LICENSE,
      'Author'         =>
        [
          'h00die',
        ],
      'DisclosureDate' => 'Apr 14 2015',
      'Platform'       => [ 'solaris' ],
      'Arch'           => [ ARCH_X86, ARCH_X64 ],
      'SessionTypes'   => [ 'shell' ],
      'Targets'        => [[ 'Auto', {} ]],
    ))
  end

  def exploit
    print_status('get_sysinfo')
    print_status(get_sysinfo.to_s)

    print_status('get_suid_files')
    print_status(get_suid_files.to_s)

    print_status('get_path')
    print_status(get_path.to_s)

    print_status('get_cpu_info')
    print_status(get_cpu_info.to_s)

    print_status('get_hostname')
    print_status(get_hostname.to_s)

    print_status('get_shell_name')
    print_status(get_shell_name.to_s)

    print_status('has_gcc?')
    print_status(has_gcc?.to_s)

    print_status('pidof(\'sshd\')')
    print_status(pidof('sshd').to_s)

    print_status('get_mount_path("/etc/passwd")')
    print_status(get_mount_path('/etc/passwd').to_s)

  end
end
```

And my results on Solaris 11.3 x86:
```
[*] get_sysinfo
[*] {:version=>"Oracle Solaris 11.3 X86", :kernel=>"SunOS solaris11.3 5.11 11.3 i86pc i386 i86pc", :hostname=>"solaris11.3"}
[*] get_suid_files
[*] ["/usr/bin/pfedit", "/usr/bin/at", "/usr/bin/sys-suspend", "/usr/bin/atq", "/usr/bin/tip", "/usr/bin/rcp", "/usr/bin/chkey", "/usr/bin/su", "/usr/bin/Xorg", "/usr/bin/pppd", "/usr/bin/passwd", "/usr/bin/xlock", "/usr/bin/uptime", "/usr/bin/stclient", "/usr/bin/atrm", "/usr/bin/rsh", "/usr/bin/xscreensaver", "/usr/bin/sudo", "/usr/bin/amd64/w", "/usr/bin/amd64/uptime", "/usr/bin/amd64/newtask", "/usr/bin/w", "/usr/bin/crontab", "/usr/bin/rlogin", "/usr/bin/newtask", "/usr/bin/newgrp", "/usr/bin/rmformat", "/usr/bin/cdrw", "/usr/sbin/amd64/whodo", "/usr/sbin/traceroute", "/usr/sbin/quota", "/usr/sbin/ping", "/usr/sbin/whodo", "/usr/xpg6/bin/crontab", "/usr/lib/acct/accton", "/usr/lib/vmware-tools/bin/i86/vmware-user-suid-wrapper", "/usr/lib/inet/mailq", "/usr/lib/fs/ufs/ufsrestore", "/usr/lib/fs/ufs/ufsdump", "/usr/lib/fs/smbfs/umount", "/usr/lib/fs/smbfs/mount", "/usr/lib/sunssh/lib/ssh-keysign", "/usr/lib/utmp_update", "/usr/xpg4/bin/at", "/usr/xpg4/bin/crontab"]
[*] get_path
[*] /usr/bin:/usr/sbin
[*] get_cpu_info
[*] {:product=>"Intel(r) Core(tm) i7-2600 CPU @ 3.40GHz", :speed_mhz=>3392, :cores=>1, :vendor=>"GenuineIntel"}
[*] get_hostname
[*] solaris11.3
[*] get_shell_name
[*] bash
[*] has_gcc?
[*] false
[*] pidof('sshd')
[*] [1657, 680, 1241, 1242, 1310, 1311, 1656]
[*] get_mount_path("/etc/passwd")
[*] /
```

For comparison sake, here is the linux system module run with the same functions against ubuntu 16.04 vs solaris 11.3

|                               | Linux | Solaris                 |
|-------------------------------|-------|-------------------------|
| get_sysinfo                   |  ``` {:kernel=>"Linux ubuntu 4.4.0-130-generic #156-Ubuntu SMP Thu Jun 14 08:53:28 UTC 2018 x86_64 x86_64 x86_64 GNU/Linux", :distro=>"ubuntu", :version=>"Ubuntu 16.04.4 LTS  "} ```   | ```{:version=>"Oracle Solaris 11.3 X86", :kernel=>"SunOS solaris11.3 5.11 11.3 i86pc i386 i86pc", :hostname=>"solaris11.3"} ```  |
| get_suid_files                | ``` ["/usr/bin/pkexec", "/usr/bin/chsh", "/usr/bin/chfn", "/usr/bin/passwd", "/usr/bin/at", "/usr/bin/newgrp", "/usr/bin/newuidmap", "/usr/bin/sudo", "/usr/bin/gpasswd", "/usr/bin/newgidmap", "/usr/lib/dbus-1.0/dbus-daemon-launch-helper", "/usr/lib/snapd/snap-confine", "/usr/lib/eject/dmcrypt-get-device", "/usr/lib/x86_64-linux-gnu/lxc/lxc-user-nic", "/usr/lib/policykit-1/polkit-agent-helper-1", "/usr/lib/openssh/ssh-keysign", "find: \xE2\x80\x98/var/tmp/systemd-private-53636c27861d455b94662cd7003a9ebc-systemd-timesyncd.service-naZMaX\xE2\x80\x99: Permission denied", "find: \xE2\x80\x98/var/cache/ldconfig\xE2\x80\x99: Permission denied", "find: \xE2\x80\x98/var/cache/apt/archives/partial\xE2\x80\x99: Permission denied", "find: \xE2\x80\x98/var/log/couchdb\xE2\x80\x99: Permission denied", "find: \xE2\x80\x98/var/spool/cron/crontabs\xE2\x80\x99: Permission denied", "find: \xE2\x80\x98/var/spool/cron/atspool\xE2\x80\x99: Permission denied", "find: \xE2\x80\x98/var/spool/cron/atjobs\xE2\x80\x99: Permission denied", "find: \xE2\x80\x98/var/spool/rsyslog\xE2\x80\x99: Permission denied", "find: \xE2\x80\x98/var/lib/apt/lists/partial\xE2\x80\x99: Permission denied", "find: \xE2\x80\x98/var/lib/snapd/cookie\xE2\x80\x99: Permission denied", "find: \xE2\x80\x98/var/lib/polkit-1\xE2\x80\x99: Permission denied", "find: \xE2\x80\x98/var/lib/couchdb\xE2\x80\x99: Permission denied", "find: \xE2\x80\x98/var/lib/update-notifier/package-data-downloads/partial\xE2\x80\x99: Permission denied", "find: \xE2\x80\x98/lost+found\xE2\x80\x99: Permission denied", "find: \xE2\x80\x98/tmp/vmware-root\xE2\x80\x99: Permission denied", "find: \xE2\x80\x98/tmp/systemd-private-53636c27861d455b94662cd7003a9ebc-systemd-timesyncd.service-JucPs6\xE2\x80\x99: Permission denied", "find: \xE2\x80\x98/etc/ssl/private\xE2\x80\x99: Permission denied", "find: \xE2\x80\x98/etc/polkit-1/localauthority\xE2\x80\x99: Permission denied", "find: \xE2\x80\x98/etc/couchdb/local.d\xE2\x80\x99: Permission denied", "find: \xE2\x80\x98/root\xE2\x80\x99: Permission denied", "/bin/ntfs-3g", "/bin/mount", "/bin/fusermount", "/bin/su", "/bin/ping", "/bin/umount", "/bin/ping6"]```     | ```["/usr/bin/pfedit", "/usr/bin/at", "/usr/bin/sys-suspend", "/usr/bin/atq", "/usr/bin/tip", "/usr/bin/rcp", "/usr/bin/chkey", "/usr/bin/su", "/usr/bin/Xorg", "/usr/bin/pppd", "/usr/bin/passwd", "/usr/bin/xlock", "/usr/bin/uptime", "/usr/bin/stclient", "/usr/bin/atrm", "/usr/bin/rsh", "/usr/bin/xscreensaver", "/usr/bin/sudo", "/usr/bin/amd64/w", "/usr/bin/amd64/uptime", "/usr/bin/amd64/newtask", "/usr/bin/w", "/usr/bin/crontab", "/usr/bin/rlogin", "/usr/bin/newtask", "/usr/bin/newgrp", "/usr/bin/rmformat", "/usr/bin/cdrw", "/usr/sbin/amd64/whodo", "/usr/sbin/traceroute", "/usr/sbin/quota", "/usr/sbin/ping", "/usr/sbin/whodo", "/usr/xpg6/bin/crontab", "/usr/lib/acct/accton", "/usr/lib/vmware-tools/bin/i86/vmware-user-suid-wrapper", "/usr/lib/inet/mailq", "/usr/lib/fs/ufs/ufsrestore", "/usr/lib/fs/ufs/ufsdump", "/usr/lib/fs/smbfs/umount", "/usr/lib/fs/smbfs/mount", "/usr/lib/sunssh/lib/ssh-keysign", "/usr/lib/utmp_update", "/usr/xpg4/bin/at", "/usr/xpg4/bin/crontab"] ```    |
| get_path                      |    /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin   | /usr/bin:/usr/sbin      |
| get_cpu_info                  |    {:vendor=>"GenuineIntel", :product=>"Intel(R) Core(TM) i7-2600 CPU @ 3.40GHz", :speed_mhz=>3392, :cores=>1}   | {:product=>"Intel(r) Core(tm) i7-2600 CPU @ 3.40GHz", :speed_mhz=>3392, :cores=>1, :vendor=>"GenuineIntel"} |
| get_hostname                  |   ubuntu    | solaris11.3             |
| get_shell_name                |    bash   | bash                    |
| has_gcc?                      |     false  | false                   |
| pidof('sshd')                 |    [1070, 2133, 2163]   | [1657, 680, 1241, 1242, 1310, 1311, 1656] |
| get_mount_path("/etc/passwd") |    /   | /                       |

I think the only thing of note here is I stripped the "Permission denied" when listing suid files.  Also I noticed the Ubuntu version on get_sysinfo may need to be trimmed.