### PR TITLE
Bump payloads to 1.3.42

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,7 +18,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 1.3.40)
+      metasploit-payloads (= 1.3.42)
       metasploit_data_models
       metasploit_payloads-mettle (= 0.4.1)
       mqtt
@@ -164,7 +164,7 @@ GEM
       activemodel (~> 4.2.6)
       activesupport (~> 4.2.6)
       railties (~> 4.2.6)
-    metasploit-payloads (1.3.40)
+    metasploit-payloads (1.3.42)
     metasploit_data_models (3.0.0)
       activerecord (~> 4.2.6)
       activesupport (~> 4.2.6)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -70,7 +70,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '1.3.40'
+  spec.add_runtime_dependency 'metasploit-payloads', '1.3.42'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '0.4.1'
   # Needed by msfgui and other rpc components


### PR DESCRIPTION
This bumps payloads to 1.3.42 to include changes made in https://github.com/rapid7/metasploit-payloads/pull/293 and https://github.com/rapid7/metasploit-payloads/pull/295

- [ ] Make sure tests pass