### PR TITLE
Fix missing payloads

### DIFF
--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -718,6 +718,16 @@ RSpec.describe 'modules/payloads', :content do
                           reference_name: 'cmd/unix/reverse_bash_telnet_ssl'
   end
 
+  context 'cmd/unix/reverse_ksh' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'singles/cmd/unix/reverse_ksh'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'cmd/unix/reverse_ksh'
+  end
+
   context 'cmd/unix/reverse_lua' do
     it_should_behave_like 'payload cached size is consistent',
                           ancestor_reference_names: [
@@ -1737,6 +1747,16 @@ RSpec.describe 'modules/payloads', :content do
                           dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/shell_reverse_tcp'
+  end
+
+  context 'linux/x86/shell_reverse_tcp_ipv6' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'singles/linux/x86/shell_reverse_tcp_ipv6'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'linux/x86/shell_reverse_tcp_ipv6'
   end
 
   context 'mainframe/shell_reverse_tcp' do

--- a/spec/support/shared/examples/payload_cached_size_is_consistent.rb
+++ b/spec/support/shared/examples/payload_cached_size_is_consistent.rb
@@ -108,6 +108,29 @@ RSpec.shared_examples_for 'payload cached size is consistent' do |options|
     'DisableNops' => true
   }
 
+  opts6 = {
+      'Format'      => 'raw',
+      'Options'     => {
+          'CPORT' => 4444,
+          'LPORT' => 4444,
+          'LHOST' => 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff',
+          'KHOST' => 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff',
+          'AHOST' => 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff',
+          'CMD' => '/bin/sh',
+          'URL' => 'http://a.com',
+          'PATH' => '/',
+          'BUNDLE' => 'data/isight.bundle',
+          'DLL' => 'external/source/byakugan/bin/XPSP2/detoured.dll',
+          'RC4PASSWORD' => 'Metasploit',
+          'DNSZONE' => 'corelan.eu',
+          'PEXEC' => '/bin/sh',
+          'StagerURILength' => 5
+      },
+      'Encoder'     => nil,
+      'DisableNops' => true
+  }
+
+
   #
   # lets
   #
@@ -157,7 +180,11 @@ RSpec.shared_examples_for 'payload cached size is consistent' do |options|
         )
         expect(pinst.cached_size).to_not(be_nil)
         expect(pinst.dynamic_size?).to be(false)
-        expect(pinst.cached_size).to eq(pinst.generate_simple(opts).size)
+        if pinst.shortname =~ /6/
+          expect(pinst.cached_size).to eq(pinst.generate_simple(opts6).size)
+        else
+          expect(pinst.cached_size).to eq(pinst.generate_simple(opts).size)
+        end
       end
     end
   end


### PR DESCRIPTION
Add payloads currently reported missing from rspec, as well as support for setting IPv6 options during testing when need for size verification.

## Verification

List the steps needed to make sure this thing works

- [x] run `rake spec` / check Travis results
- [x] **Verify** all tests pass and no missing payloads are reported

