### PR TITLE
Add payload to cmd_search_help type

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -345,7 +345,7 @@ module Msf
               'ref'         => 'Modules with a matching ref',
               'reference'   => 'Modules with a matching reference',
               'target'      => 'Modules affecting this target',
-              'type'        => 'Modules of a specific type (exploit, auxiliary, or post)',
+              'type'        => 'Modules of a specific type (exploit, payload, auxiliary, or post)',
             }.each_pair do |keyword, description|
               print_line "  #{keyword.ljust 12}:  #{description}"
             end


### PR DESCRIPTION
`search type:payload` already works, just wasn't included in help msg