### PR TITLE
Remove SSH scanner using known_hosts

### DIFF
--- a/lib/metasploit/framework/login_scanner/ssh.rb
+++ b/lib/metasploit/framework/login_scanner/ssh.rb
@@ -55,7 +55,8 @@ module Metasploit
             :config          => false,
             :verbose         => verbosity,
             :proxy           => factory,
-            :non_interactive => true
+            :non_interactive => true,
+            :verify_host_key => :never
           }
           case credential.private_type
           when :password, nil

--- a/modules/auxiliary/scanner/ssh/apache_karaf_command_execution.rb
+++ b/modules/auxiliary/scanner/ssh/apache_karaf_command_execution.rb
@@ -70,13 +70,14 @@ class MetasploitModule < Msf::Auxiliary
   def do_login(user, pass, ip)
     factory = ssh_socket_factory
     opts = {
-      auth_methods:    ['password'],
-      port:            rport,
-      config:          false,
-      use_agent:       false,
-      password:        pass,
-      proxy:           factory,
-      non_interactive: true
+      :auth_methods    => ['password'],
+      :port            => rport,
+      :config          => false,
+      :use_agent       => false,
+      :password        => pass,
+      :proxy           => factory,
+      :non_interactive => true,
+      :verify_host_key => :never
     }
 
     opts.merge!(verbose: :debug) if datastore['SSH_DEBUG']

--- a/modules/auxiliary/scanner/ssh/cerberus_sftp_enumusers.rb
+++ b/modules/auxiliary/scanner/ssh/cerberus_sftp_enumusers.rb
@@ -67,13 +67,14 @@ class MetasploitModule < Msf::Auxiliary
 
   def check_vulnerable(ip)
     opt_hash = {
-      port:          rport,
-      auth_methods:  ['password', 'keyboard-interactive'],
-      use_agent:     false,
-      config:        false,
-      password_prompt: Net::SSH::Prompt.new,
-      non_interactive: true,
-      proxies:       datastore['Proxies']
+      :port            => rport,
+      :auth_methods    => ['password', 'keyboard-interactive'],
+      :use_agent       => false,
+      :config          => false,
+      :password_prompt => Net::SSH::Prompt.new,
+      :non_interactive => true,
+      :proxies         => datastore['Proxies'],
+      :verify_host_key => :never
     }
 
     begin
@@ -105,11 +106,12 @@ class MetasploitModule < Msf::Auxiliary
     pass = Rex::Text.rand_text_alphanumeric(8)
 
     opt_hash = {
-      auth_methods: ['password', 'keyboard-interactive'],
-      port:         port,
-      use_agent:    false,
-      config:       false,
-      proxies:      datastore['Proxies']
+      :auth_methods    => ['password', 'keyboard-interactive'],
+      :port            => port,
+      :use_agent       => false,
+      :config          => false,
+      :proxies         => datastore['Proxies'],
+      :verify_host_key => :never
     }
 
     opt_hash.merge!(verbose: :debug) if datastore['SSH_DEBUG']

--- a/modules/auxiliary/scanner/ssh/fortinet_backdoor.rb
+++ b/modules/auxiliary/scanner/ssh/fortinet_backdoor.rb
@@ -48,14 +48,15 @@ class MetasploitModule < Msf::Auxiliary
     factory = ssh_socket_factory
 
     ssh_opts = {
-      port:            rport,
+      :port            => rport,
       # The auth method is converted into a class name for instantiation,
       # so fortinet-backdoor here becomes FortinetBackdoor from the mixin
-      auth_methods:    ['fortinet-backdoor'],
-      non_interactive: true,
-      config:          false,
-      use_agent:       false,
-      proxy:           factory
+      :auth_methods    => ['fortinet-backdoor'],
+      :non_interactive => true,
+      :config          => false,
+      :use_agent       => false,
+      :proxy           => factory,
+      :verify_host_key => :never
     }
 
     ssh_opts.merge!(verbose: :debug) if datastore['SSH_DEBUG']

--- a/modules/auxiliary/scanner/ssh/juniper_backdoor.rb
+++ b/modules/auxiliary/scanner/ssh/juniper_backdoor.rb
@@ -43,11 +43,12 @@ class MetasploitModule < Msf::Auxiliary
   def run_host(ip)
     factory = ssh_socket_factory
     ssh_opts = {
-      port:         rport,
-      auth_methods: ['password', 'keyboard-interactive'],
-      password:     %q{<<< %s(un='%s') = %u},
-      proxy: factory,
-      :non_interactive => true
+      :port            => rport,
+      :auth_methods    => ['password', 'keyboard-interactive'],
+      :password        => %q{<<< %s(un='%s') = %u},
+      :proxy           => factory,
+      :non_interactive => true,
+      :verify_host_key => :never
     }
 
     ssh_opts.merge!(verbose: :debug) if datastore['SSH_DEBUG']

--- a/modules/auxiliary/scanner/ssh/ssh_enumusers.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_enumusers.rb
@@ -86,7 +86,8 @@ class MetasploitModule < Msf::Auxiliary
       :password      => pass,
       :config        => false,
       :proxy         => factory,
-      :non_interactive => true
+      :non_interactive => true,
+      :verify_host_key => :never
     }
 
     opt_hash.merge!(:verbose => :debug) if datastore['SSH_DEBUG']

--- a/modules/auxiliary/scanner/ssh/ssh_identify_pubkeys.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_identify_pubkeys.rb
@@ -210,7 +210,8 @@ class MetasploitModule < Msf::Auxiliary
         :use_agent     => false,
         :config =>false,
         :proxy	  => factory,
-        :non_interactive => true
+        :non_interactive => true,
+	:verify_host_key => :never
       }
 
       opt_hash.merge!(:verbose => :debug) if datastore['SSH_DEBUG']

--- a/modules/auxiliary/scanner/ssh/ssh_identify_pubkeys.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_identify_pubkeys.rb
@@ -208,7 +208,7 @@ class MetasploitModule < Msf::Auxiliary
         :port            => port,
         :key_data        => key_data[:public],
         :use_agent       => false,
-        :config          =>false,
+        :config          => false,
         :proxy           => factory,
         :non_interactive => true,
         :verify_host_key => :never

--- a/modules/auxiliary/scanner/ssh/ssh_identify_pubkeys.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_identify_pubkeys.rb
@@ -204,14 +204,14 @@ class MetasploitModule < Msf::Auxiliary
 
       factory = ssh_socket_factory
       opt_hash = {
-        :auth_methods => ['publickey'],
-        :port         => port,
-        :key_data     => key_data[:public],
-        :use_agent     => false,
-        :config =>false,
-        :proxy	  => factory,
+        :auth_methods    => ['publickey'],
+        :port            => port,
+        :key_data        => key_data[:public],
+        :use_agent       => false,
+        :config          =>false,
+        :proxy           => factory,
         :non_interactive => true,
-	:verify_host_key => :never
+        :verify_host_key => :never
       }
 
       opt_hash.merge!(:verbose => :debug) if datastore['SSH_DEBUG']

--- a/modules/exploits/apple_ios/ssh/cydia_default_ssh.rb
+++ b/modules/exploits/apple_ios/ssh/cydia_default_ssh.rb
@@ -79,13 +79,14 @@ class MetasploitModule < Msf::Exploit::Remote
   def do_login(user, pass)
     factory = ssh_socket_factory
     opts = {
-      auth_methods:    ['password', 'keyboard-interactive'],
-      port:            rport,
-      use_agent:       false,
-      config:          false,
-      password:        pass,
-      proxy:           factory,
-      non_interactive: true
+      :auth_methods    => ['password', 'keyboard-interactive'],
+      :port            => rport,
+      :use_agent       => false,
+      :config          => false,
+      :password        => pass,
+      :proxy           => factory,
+      :non_interactive => true,
+      :verify_host_key => :never
     }
 
     opts.merge!(:verbose => :debug) if datastore['SSH_DEBUG']

--- a/modules/exploits/linux/ssh/ceragon_fibeair_known_privkey.rb
+++ b/modules/exploits/linux/ssh/ceragon_fibeair_known_privkey.rb
@@ -74,13 +74,14 @@ class MetasploitModule < Msf::Exploit::Remote
   def do_login(user)
     factory = Rex::Socket::SSHFactory.new(framework,self, datastore['Proxies'])
     opt_hash = {
-      auth_methods:       ['publickey'],
-      port:               rport,
-      key_data:           [ key_data ],
-      use_agent:          false,
-      config:             false,
-      proxy:              factory,
-      non_interactive:    true
+      :auth_methods       => ['publickey'],
+      :port               => rport,
+      :key_data           => [ key_data ],
+      :use_agent          => false,
+      :config             => false,
+      :proxy              => factory,
+      :non_interactive    => true,
+      :verify_host_key    => :never
     }
     opt_hash.merge!(:verbose => :debug) if datastore['SSH_DEBUG']
     begin

--- a/modules/exploits/linux/ssh/exagrid_known_privkey.rb
+++ b/modules/exploits/linux/ssh/exagrid_known_privkey.rb
@@ -118,13 +118,14 @@ class MetasploitModule < Msf::Exploit::Remote
     factory = ssh_socket_factory
 
     ssh_options = {
-      auth_methods: ['publickey'],
-      config: false,
-      use_agent: false,
-      key_data: [ key_data ],
-      port: rport,
-      proxy: factory,
-      non_interactive:  true
+      :auth_methods     => ['publickey'],
+      :config           => false,
+      :use_agent        => false,
+      :key_data         => [ key_data ],
+      :port             => rport,
+      :proxy            => factory,
+      :non_interactive  => true,
+      :verify_host_key  => :never
     }
     ssh_options.merge!(verbose: :debug) if datastore['SSH_DEBUG']
 

--- a/modules/exploits/linux/ssh/f5_bigip_known_privkey.rb
+++ b/modules/exploits/linux/ssh/f5_bigip_known_privkey.rb
@@ -77,13 +77,14 @@ class MetasploitModule < Msf::Exploit::Remote
     factory = Rex::Socket::SSHFactory.new(framework, self, datastore['Proxies'])
 
     opt_hash = {
-      auth_methods:    ['publickey'],
-      port:            rport,
-      key_data:        [ key_data ],
-      use_agent:       false,
-      config:          false,
-      proxy:           factory,
-      non_interactive: true
+      :auth_methods     => ['publickey'],
+      :port             => rport,
+      :key_data         => [ key_data ],
+      :use_agent        => false,
+      :config           => false,
+      :proxy            => factory,
+      :non_interactive  => true,
+      :verify_host_key  => :never
     }
     opt_hash[:verbose] = :debug if datastore['SSH_DEBUG']
 

--- a/modules/exploits/linux/ssh/loadbalancerorg_enterprise_known_privkey.rb
+++ b/modules/exploits/linux/ssh/loadbalancerorg_enterprise_known_privkey.rb
@@ -71,13 +71,14 @@ class MetasploitModule < Msf::Exploit::Remote
   def do_login(user)
     factory = ssh_socket_factory
     opt_hash = {
-      :auth_methods => ['publickey'],
-      :port         => rport,
-      :key_data     => [ key_data ],
-      :use_agent => false,
-      :config => false,
-      :proxy => factory,
-      :non_interactive => true
+      :auth_methods    => ['publickey'],
+      :port            => rport,
+      :key_data        => [ key_data ],
+      :use_agent       => false,
+      :config          => false,
+      :proxy           => factory,
+      :non_interactive => true,
+      :verify_host_key => :never
     }
     opt_hash.merge!(:verbose => :debug) if datastore['SSH_DEBUG']
     begin

--- a/modules/exploits/linux/ssh/mercurial_ssh_exec.rb
+++ b/modules/exploits/linux/ssh/mercurial_ssh_exec.rb
@@ -74,13 +74,14 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     factory = ssh_socket_factory
     ssh_options = {
-      auth_methods: ['publickey'],
-      config: false,
-      use_agent: false,
-      key_data: [ ssh_priv_key ],
-      port: rport,
-      proxy: factory,
-      non_interactive:  true
+      :auth_methods     => ['publickey'],
+      :config           => false,
+      :use_agent        => false,
+      :key_data         => [ ssh_priv_key ],
+      :port             => rport,
+      :proxy            => factory,
+      :non_interactive  => true,
+      :verify_host_key  => :never
     }
 
     ssh_options.merge!(:verbose => :debug) if datastore['SSH_DEBUG']

--- a/modules/exploits/linux/ssh/quantum_dxi_known_privkey.rb
+++ b/modules/exploits/linux/ssh/quantum_dxi_known_privkey.rb
@@ -70,13 +70,14 @@ class MetasploitModule < Msf::Exploit::Remote
   def do_login(user)
     factory = ssh_socket_factory
     opt_hash = {
-      :auth_methods => ['publickey'],
-      :port         => rport,
-      :key_data     => [ key_data ],
-      :use_agent => false,
-      :config => false,
-      :proxy => factory,
-      :non_interactive => true
+      :auth_methods     => ['publickey'],
+      :port             => rport,
+      :key_data         => [ key_data ],
+      :use_agent        => false,
+      :config           => false,
+      :proxy            => factory,
+      :non_interactive  => true,
+      :verify_host_key  => :never
     }
     opt_hash.merge!(:verbose => :debug) if datastore['SSH_DEBUG']
     begin

--- a/modules/exploits/linux/ssh/quantum_vmpro_backdoor.rb
+++ b/modules/exploits/linux/ssh/quantum_vmpro_backdoor.rb
@@ -82,13 +82,14 @@ class MetasploitModule < Msf::Exploit::Remote
   def do_login(user, pass)
     factory = ssh_socket_factory
     opts = {
-      :auth_methods => ['password', 'keyboard-interactive'],
-      :port         => rport,
-      :use_agent => false,
-      :config => true,
-      :password => pass,
-      :proxy => factory,
-      :non_interactive => true
+      :auth_methods     => ['password', 'keyboard-interactive'],
+      :port             => rport,
+      :use_agent        => false,
+      :config           => true,
+      :password         => pass,
+      :proxy            => factory,
+      :non_interactive  => true,
+      :verify_host_key  => :never
     }
 
     opts.merge!(:verbose => :debug) if datastore['SSH_DEBUG']

--- a/modules/exploits/linux/ssh/solarwinds_lem_exec.rb
+++ b/modules/exploits/linux/ssh/solarwinds_lem_exec.rb
@@ -75,13 +75,14 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     factory = ssh_socket_factory
     opts = {
-      :auth_methods => ['keyboard-interactive'],
-      :port         => rport,
-      :use_agent => false,
-      :config => false,
-      :password => password,
-      :proxy => factory,
-      :non_interactive => true
+      :auth_methods     => ['keyboard-interactive'],
+      :port             => rport,
+      :use_agent        => false,
+      :config           => false,
+      :password         => password,
+      :proxy            => factory,
+      :non_interactive  => true,
+      :verify_host_key  => :never
     }
 
     opts.merge!(:verbose => :debug) if datastore['SSH_DEBUG']

--- a/modules/exploits/linux/ssh/symantec_smg_ssh.rb
+++ b/modules/exploits/linux/ssh/symantec_smg_ssh.rb
@@ -86,13 +86,14 @@ class MetasploitModule < Msf::Exploit::Remote
   def do_login(user, pass)
     factory = ssh_socket_factory
     opts = {
-      :auth_methods => ['password', 'keyboard-interactive'],
-      :port         => rport,
-      :use_agent => false,
-      :config => false,
-      :password => pass,
-      :proxy => factory,
-      :non_interactive => true
+      :auth_methods     => ['password', 'keyboard-interactive'],
+      :port             => rport,
+      :use_agent        => false,
+      :config           => false,
+      :password         => pass,
+      :proxy            => factory,
+      :non_interactive  => true,
+      :verify_host_key  => :never
     }
 
     opts.merge!(:verbose => :debug) if datastore['SSH_DEBUG']

--- a/modules/exploits/linux/ssh/ubiquiti_airos_file_upload.rb
+++ b/modules/exploits/linux/ssh/ubiquiti_airos_file_upload.rb
@@ -124,13 +124,14 @@ class MetasploitModule < Msf::Exploit::Remote
     factory = ssh_socket_factory
 
     ssh_opts = {
-      port:            datastore['SSH_PORT'],
-      auth_methods:    %w{publickey password},
-      key_data:        [private_key],
-      non_interactive: true,
-      config:          false,
-      use_agent:       false,
-      proxy:           factory
+      :port             => datastore['SSH_PORT'],
+      :auth_methods     => %w{publickey password},
+      :key_data         => [private_key],
+      :non_interactive  => true,
+      :config           => false,
+      :use_agent        => false,
+      :proxy            => factory,
+      :verify_host_key  => :never
     }
 
     ssh_opts.merge!(verbose: :debug) if datastore['SSH_DEBUG']

--- a/modules/exploits/linux/ssh/vmware_vdp_known_privkey.rb
+++ b/modules/exploits/linux/ssh/vmware_vdp_known_privkey.rb
@@ -70,13 +70,14 @@ class MetasploitModule < Msf::Exploit::Remote
   def do_login()
     factory = Rex::Socket::SSHFactory.new(framework,self, datastore['Proxies'])
     opt_hash = {
-      auth_methods:    ['publickey'],
-      port:            rport,
-      key_data:        [ key_data ],
-      use_agent:       false,
-      config:          false,
-      proxy:           factory,
-      non_interactive: true
+      :auth_methods     => ['publickey'],
+      :port             => rport,
+      :key_data         => [ key_data ],
+      :use_agent        => false,
+      :config           => false,
+      :proxy            => factory,
+      :non_interactive  => true,
+      :verify_host_key  => :never
     }
     opt_hash.merge!(:verbose => :debug) if datastore['SSH_DEBUG']
     begin

--- a/modules/exploits/multi/ssh/sshexec.rb
+++ b/modules/exploits/multi/ssh/sshexec.rb
@@ -147,13 +147,14 @@ class MetasploitModule < Msf::Exploit::Remote
   def do_login(ip, user, pass, port)
     factory = ssh_socket_factory
     opt_hash = {
-      auth_methods:    ['password', 'keyboard-interactive'],
-      port:            port,
-      use_agent:       false,
-      config:          false,
-      password:        pass,
-      proxy:           factory,
-      non_interactive: true
+      :auth_methods     => ['password', 'keyboard-interactive'],
+      :port             => port,
+      :use_agent        => false,
+      :config           => false,
+      :password         => pass,
+      :proxy            => factory,
+      :non_interactive  => true,
+      :verify_host_key  => :never
     }
 
     opt_hash[:verbose] = :debug if (datastore['SSH_DEBUG'])

--- a/modules/exploits/unix/ssh/array_vxag_vapv_privkey_privesc.rb
+++ b/modules/exploits/unix/ssh/array_vxag_vapv_privkey_privesc.rb
@@ -101,13 +101,14 @@ class MetasploitModule < Msf::Exploit::Remote
 
     factory = ssh_socket_factory
     opts = {
-      :auth_methods => ['publickey'],
-      :port         => rport,
-      :use_agent => false,
-      :config => true,
-      :key_data     => key_data,
-      :proxy => factory,
-      :non_interactive => true
+      :auth_methods     => ['publickey'],
+      :port             => rport,
+      :use_agent        => false,
+      :config           => true,
+      :key_data         => key_data,
+      :proxy            => factory,
+      :non_interactive  => true,
+      :verify_host_key  => :never
     }
 
     opts
@@ -117,13 +118,14 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("#{rhost}:#{rport} - Attempting to login with '#{user}:#{pass}'")
     factory = ssh_socket_factory
     opts = {
-      :auth_methods => ['password', 'keyboard-interactive'],
-      :port         => rport,
-      :use_agent => false,
-      :config => true,
-      :password => pass,
-      :proxy => factory,
-      :non_interactive => true
+      :auth_methods     => ['password', 'keyboard-interactive'],
+      :port             => rport,
+      :use_agent        => false,
+      :config           => true,
+      :password         => pass,
+      :proxy            => factory,
+      :non_interactive  => true,
+      :verify_host_key  => :never
     }
 
     opts

--- a/modules/exploits/unix/ssh/tectia_passwd_changereq.rb
+++ b/modules/exploits/unix/ssh/tectia_passwd_changereq.rb
@@ -186,7 +186,11 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def init_ssh(user)
-    opts       = {:user=>user, :port=>rport}
+    opts       = {
+      :user             => user,
+      :port             => rport,
+      :verify_host_key  => :never
+    }
     options    = Net::SSH::Config.for(rhost, Net::SSH::Config.default_files).merge(opts)
     transport  = Net::SSH::Transport::Session.new(rhost, options)
     connection = Net::SSH::Connection::Session.new(transport, options)

--- a/modules/exploits/windows/ssh/freesshd_authbypass.rb
+++ b/modules/exploits/windows/ssh/freesshd_authbypass.rb
@@ -80,12 +80,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def setup_ssh_options
     {
-      password: rand_text_alpha(8),
-      port: datastore['RPORT'],
-      timeout: 1,
-      proxies: datastore['Proxies'],
-      key_data: OpenSSL::PKey::RSA.new(2048).to_pem,
-      auth_methods: ['publickey']
+      :password         => rand_text_alpha(8),
+      :port             => datastore['RPORT'],
+      :timeout          => 1,
+      :proxies          => datastore['Proxies'],
+      :key_data         => OpenSSL::PKey::RSA.new(2048).to_pem,
+      :auth_methods     => ['publickey'],
+      :verify_host_key  => :never
     }
   end
 

--- a/modules/exploits/windows/ssh/sysax_ssh_username.rb
+++ b/modules/exploits/windows/ssh/sysax_ssh_username.rb
@@ -202,7 +202,8 @@ class MetasploitModule < Msf::Exploit::Remote
         timeout: 1,
         proxy: factory,
         config: false,
-        non_interactive: true
+        non_interactive: true,
+        verify_host_key: :never
       )
 
       ::Timeout.timeout(1) { ssh.close }

--- a/spec/lib/metasploit/framework/login_scanner/ssh_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/ssh_spec.rb
@@ -161,13 +161,14 @@ RSpec.describe Metasploit::Framework::LoginScanner::SSH do
       it 'calls Net::SSH with the correct arguments' do
         factory = Rex::Socket::SSHFactory.new(nil,nil,nil)
         opt_hash = {
-            :auth_methods  => ['publickey'],
-            :port          => ssh_scanner.port,
-            :use_agent     => false,
-            :key_data      => key,
-            :config        => false,
-            :verbose       => ssh_scanner.verbosity,
-            :proxy         => factory
+            :auth_methods    => ['publickey'],
+            :port            => ssh_scanner.port,
+            :use_agent       => false,
+            :key_data        => key,
+            :config          => false,
+            :verbose         => ssh_scanner.verbosity,
+            :proxy           => factory,
+            :verify_host_key => :never
         }
         allow(Rex::Socket::SSHFactory).to receive(:new).and_return factory
         expect(Net::SSH).to receive(:start).with(

--- a/spec/lib/metasploit/framework/login_scanner/ssh_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/ssh_spec.rb
@@ -145,7 +145,8 @@ RSpec.describe Metasploit::Framework::LoginScanner::SSH do
             :proxy         => factory,
             :auth_methods  => ['password','keyboard-interactive'],
             :password      => private,
-            :non_interactive => true
+            :non_interactive => true,
+            :verify_host_key => :never
         }
         allow(Rex::Socket::SSHFactory).to receive(:new).and_return factory
         expect(Net::SSH).to receive(:start).with(


### PR DESCRIPTION
Fix #10266 

This disables writing to the `known_hosts` file when performing auxiliary ssh scans.


Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

## Verification

List the steps needed to make sure this thing works. This is described assuming a hackthebox.eu VIP membership. Replication can be made without this and a different RHOSTS value.

- [ ] Connect to HackTheBox VPN
- [x] Delete `~/.ssh/known_hosts`
- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/ssh/ssh_login`
- [x] `set USERNAME test`
- [x] `set PASSWORD test`
- [x] `set RHOSTS 10.10.10.6`
- [x] `exploit`
- [x] **Verify** that the `~/.ssh/known_hosts` file was not created. 
- [x] **Verify** that the scan still occurred. This can be done via valid login credentials instead of invalid
- [ ] **Document** Documentation is not applicable to this change, I believe.

Tested via HackTheBox retired machine Popcorn using Kali distributed MSF.

ssh.rc:

```
use auxiliary/scanner/ssh/ssh_login
set USERNAME test
set PASSWORD test
set RHOSTS 10.10.10.6
exploit
```

## Before:

```
~ $ rm ~/.ssh/known_hosts 
rm: remove regular file '/root/.ssh/known_hosts'? y
 ~ $ cat ~/.ssh/known_hosts 
cat: /root/.ssh/known_hosts: No such file or directory
 ~ $ msfconsole -r ssh.rc
                                                  
                                   ____________
 [%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%| $a,        |%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%]
 [%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%| $S`?a,     |%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%]
 [%%%%%%%%%%%%%%%%%%%%__%%%%%%%%%%|       `?a, |%%%%%%%%__%%%%%%%%%__%%__ %%%%]
 [% .--------..-----.|  |_ .---.-.|       .,a$%|.-----.|  |.-----.|__||  |_ %%]
 [% |        ||  -__||   _||  _  ||  ,,aS$""`  ||  _  ||  ||  _  ||  ||   _|%%]
 [% |__|__|__||_____||____||___._||%$P"`       ||   __||__||_____||__||____|%%]
 [%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%| `"a,       ||__|%%%%%%%%%%%%%%%%%%%%%%%%%%]
 [%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%|____`"a,$$__|%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%]
 [%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%        `"$   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%]
 [%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%]


       =[ metasploit v4.17.3-dev                          ]
+ -- --=[ 1795 exploits - 1019 auxiliary - 310 post       ]
+ -- --=[ 538 payloads - 41 encoders - 10 nops            ]
+ -- --=[ Free Metasploit Pro trial: http://r-7.co/trymsp ]

[*] Processing ssh.rc for ERB directives.
resource (ssh.rc)> use auxiliary/scanner/ssh/ssh_login
resource (ssh.rc)> set USERNAME test
USERNAME => test
resource (ssh.rc)> set PASSWORD test
PASSWORD => test
resource (ssh.rc)> set RHOSTS 10.10.10.6
RHOSTS => 10.10.10.6
resource (ssh.rc)> exploit
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/ssh/ssh_login) > exit
 ~ $ cat .ssh/known_hosts 
10.10.10.6 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAyBXr3xI9cjrxMH2+DB7lZ6ctfgrek3xenkLLv2vJhQQpQ2ZfBrvkXLsSjQHHwgEbNyNUL+M1OmPFaUPTKiPVP9co0DEzq0RAC+/T4shxnYmxtACC0hqRVQ1HpE4AVjSagfFAmqUvyvSdbGvOeX7WC00SZWPgavL6pVq0qdRm3H22zIVw/Ty9SKxXGmN0qOBq6Lqs2FG8A14fJS9F8GcN9Q7CVGuSIO+UUH53KDOI+vzZqrFbvfz5dwClD19ybduWo95sdUUq/ECtoZ3zuFb6ROI5JJGNWFb6NqfTxAM43+ffZfY28AjB1QntYkezb1Bs04k8FYxb5H7JwhWewoe8xQ==
```

## After:

```
 ~ $ rm ~/.ssh/known_hosts 
rm: cannot remove '/root/.ssh/known_hosts': No such file or directory
 ~ $ cat ~/.ssh/known_hosts
cat: /root/.ssh/known_hosts: No such file or directory
 ~ $ msfconsole -r ssh.rc
                                                  

 ______________________________________________________________________________
|                                                                              |
|                          3Kom SuperHack II Logon                             |
|______________________________________________________________________________|
|                                                                              |
|                                                                              |
|                                                                              |
|                 User Name:          [   security    ]                        |
|                                                                              |
|                 Password:           [               ]                        |
|                                                                              |
|                                                                              |
|                                                                              |
|                                   [ OK ]                                     |
|______________________________________________________________________________|
|                                                                              |
|                                                       https://metasploit.com |
|______________________________________________________________________________|


       =[ metasploit v4.17.3-dev                          ]
+ -- --=[ 1795 exploits - 1019 auxiliary - 310 post       ]
+ -- --=[ 538 payloads - 41 encoders - 10 nops            ]
+ -- --=[ Free Metasploit Pro trial: http://r-7.co/trymsp ]

[*] Processing ssh.rc for ERB directives.
resource (ssh.rc)> use auxiliary/scanner/ssh/ssh_login
resource (ssh.rc)> set USERNAME test
USERNAME => test
resource (ssh.rc)> set PASSWORD test
PASSWORD => test
resource (ssh.rc)> set RHOSTS 10.10.10.6
RHOSTS => 10.10.10.6
resource (ssh.rc)> exploit
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/ssh/ssh_login) > exit
 ~ $ cat ~/.ssh/known_hosts 
cat: /root/.ssh/known_hosts: No such file or directory
 ~ $ ls ~/.ssh
id_rsa  id_rsa.pub
```