### PR TITLE
PMA Scanner Check Error Condition

### DIFF
--- a/lib/metasploit/framework/login_scanner/phpmyadmin.rb
+++ b/lib/metasploit/framework/login_scanner/phpmyadmin.rb
@@ -40,6 +40,8 @@ module Metasploit
 
         def do_login(username, password)
           session_info = get_session_info
+          # Failed to retrieve session info
+          return session_info if session_info.is_a?(Hash)
 
           protocol  = ssl ? 'https' : 'http'
           peer      = "#{host}:#{port}"


### PR DESCRIPTION
Fix issue mattfeury mentioned in metasploit slack.
```
[-] [2018.08.14-00:13:38] Auxiliary failed: NoMethodError undefined method `last' for #<Hash:0x007f2b84db7ed0>
[-] [2018.08.14-00:13:38] Call stack:
[-] [2018.08.14-00:13:38]   /opt/metasploit/apps/pro/vendor/bundle/ruby/2.3.0/gems/metasploit-framework-4.17.3/lib/metasploit/framework/login_scanner/phpmyadmin.rb:50:in `do_login'
[-] [2018.08.14-00:13:38]   /opt/metasploit/apps/pro/vendor/bundle/ruby/2.3.0/gems/metasploit-framework-4.17.3/lib/metasploit/framework/login_scanner/phpmyadmin.rb:78:in `attempt_login'
```


## Verification

- [x] Bruteforce module in msfpro trial can be used to test.
- [x] Scan host with non-phpmyadmin web page.
