### PR TITLE
Swagger documentation for user authentication

### DIFF
--- a/documentation/api/v1/auth_api_doc.rb
+++ b/documentation/api/v1/auth_api_doc.rb
@@ -47,14 +47,14 @@ module AuthApiDoc
       end
 
       response 401 do
-        key :description, 'Invalid username or password. Authenticate to access this resource.'
+        key :description, 'Invalid username or password. ' + RootApiDoc::DEFAULT_RESPONSE_401
         schema do
           key :'$ref', :AuthErrorModel
         end
       end
 
       response 500 do
-        key :description, 'An error occurred during the operation. See the message for more details.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
         schema do
           key :'$ref', :ErrorModel
         end

--- a/documentation/api/v1/auth_api_doc.rb
+++ b/documentation/api/v1/auth_api_doc.rb
@@ -24,7 +24,7 @@ module AuthApiDoc
       parameter do
         key :name, :username
         key :in, :query
-        key :description, ''
+        key :description, 'The username for the user you want to authenticate.'
         key :required, true
         key :type, :string
       end
@@ -32,7 +32,7 @@ module AuthApiDoc
       parameter do
         key :name, :password
         key :in, :query
-        key :description, ''
+        key :description, 'The password for the user you want to authenticate.'
         key :required, true
         key :type, :string
       end

--- a/documentation/api/v1/auth_api_doc.rb
+++ b/documentation/api/v1/auth_api_doc.rb
@@ -15,7 +15,7 @@ module AuthApiDoc
   end
 
   swagger_path '/api/v1/auth/generate-token' do
-    # Swagger documentation for /api/v1/auth/generate-tokenGET
+    # Swagger documentation for /api/v1/auth/generate-token GET
     operation :get do
 
       key :description, 'Return a valid Authorization Bearer token.'

--- a/documentation/api/v1/auth_api_doc.rb
+++ b/documentation/api/v1/auth_api_doc.rb
@@ -1,0 +1,65 @@
+require 'swagger/blocks'
+
+module AuthApiDoc
+  include Swagger::Blocks
+
+  MESSAGE_DESC = 'The status of the authentication request.'
+  MESSAGE_EXAMPLE = 'Generated new API token.'
+  TOKEN_DESC = 'The Authentication Bearer token'
+  TOKEN_EXAMPLE = '899d2f45e12429d07427230289400a4594bcffe32169ebb826b4ffa9b90e1d1586f15fa42f069bb7'
+
+  # Swagger documentation for auth model
+  swagger_schema :Auth do
+    property :message, type: :string, description: MESSAGE_DESC, example: MESSAGE_EXAMPLE
+    property :token, type: :string, description: TOKEN_DESC, example: TOKEN_EXAMPLE
+  end
+
+  swagger_path '/api/v1/auth/generate-token' do
+    # Swagger documentation for /api/v1/auth/generate-tokenGET
+    operation :get do
+
+      key :description, 'Return a valid Authorization Bearer token.'
+      key :tags, [ 'auth' ]
+
+      parameter do
+        key :name, :username
+        key :in, :query
+        key :description, ''
+        key :required, true
+        key :type, :string
+      end
+
+      parameter do
+        key :name, :password
+        key :in, :query
+        key :description, ''
+        key :required, true
+        key :type, :string
+      end
+
+      response 200 do
+        key :description, 'Returns a valid auth token.'
+        schema do
+          property :data do
+            key :'$ref', :Auth
+          end
+        end
+      end
+
+      response 500 do
+        key :description, 'An error occurred during the operation. See the message for more details.'
+        schema do
+          key :'$ref', :ErrorModel
+        end
+      end
+
+      response 401 do
+        key :description, 'Invalid username or password. Authenticate to access this resource.'
+        schema do
+          key :'$ref', :AuthErrorModel
+        end
+      end
+
+    end
+  end
+end

--- a/documentation/api/v1/auth_api_doc.rb
+++ b/documentation/api/v1/auth_api_doc.rb
@@ -46,6 +46,13 @@ module AuthApiDoc
         end
       end
 
+      response 401 do
+        key :description, 'Invalid username or password. Authenticate to access this resource.'
+        schema do
+          key :'$ref', :AuthErrorModel
+        end
+      end
+
       response 500 do
         key :description, 'An error occurred during the operation. See the message for more details.'
         schema do
@@ -53,12 +60,6 @@ module AuthApiDoc
         end
       end
 
-      response 401 do
-        key :description, 'Invalid username or password. Authenticate to access this resource.'
-        schema do
-          key :'$ref', :AuthErrorModel
-        end
-      end
 
     end
   end

--- a/documentation/api/v1/credential_api_doc.rb
+++ b/documentation/api/v1/credential_api_doc.rb
@@ -168,14 +168,14 @@ module CredentialApiDoc
       end
 
       response 401 do
-        key :description, 'Authenticate to access this resource.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
         schema do
           key :'$ref', :AuthErrorModel
         end
       end
 
       response 500 do
-        key :description, 'An error occurred during the operation. See the message for more details.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
         schema do
           key :'$ref', :ErrorModel
         end
@@ -211,7 +211,7 @@ module CredentialApiDoc
       end
 
       response 200 do
-        key :description, 'Successful operation.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_200
         schema do
           property :data do
             key :'$ref', :Credential
@@ -220,14 +220,14 @@ module CredentialApiDoc
       end
 
       response 401 do
-        key :description, 'Authenticate to access this resource.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
         schema do
           key :'$ref', :AuthErrorModel
         end
       end
 
       response 500 do
-        key :description, 'An error occurred during the operation. See the message for more details.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
         schema do
           key :'$ref', :ErrorModel
         end
@@ -252,14 +252,14 @@ module CredentialApiDoc
       end
 
       response 401 do
-        key :description, 'Authenticate to access this resource.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
         schema do
           key :'$ref', :AuthErrorModel
         end
       end
 
       response 500 do
-        key :description, 'An error occurred during the operation. See the message for more details.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
         schema do
           key :'$ref', :ErrorModel
         end
@@ -296,14 +296,14 @@ module CredentialApiDoc
       end
 
       response 401 do
-        key :description, 'Authenticate to access this resource.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
         schema do
           key :'$ref', :AuthErrorModel
         end
       end
 
       response 500 do
-        key :description, 'An error occurred during the operation. See the message for more details.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
         schema do
           key :'$ref', :ErrorModel
         end
@@ -328,7 +328,7 @@ module CredentialApiDoc
       end
 
       response 200 do
-        key :description, 'Successful operation.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_200
         schema do
           property :data do
             key :'$ref', :Credential
@@ -337,14 +337,14 @@ module CredentialApiDoc
       end
 
       response 401 do
-        key :description, 'Authenticate to access this resource.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
         schema do
           key :'$ref', :AuthErrorModel
         end
       end
 
       response 500 do
-        key :description, 'An error occurred during the operation. See the message for more details.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
         schema do
           key :'$ref', :ErrorModel
         end

--- a/documentation/api/v1/credential_api_doc.rb
+++ b/documentation/api/v1/credential_api_doc.rb
@@ -167,6 +167,13 @@ module CredentialApiDoc
         end
       end
 
+      response 401 do
+        key :description, 'Authenticate to access this resource.'
+        schema do
+          key :'$ref', :AuthErrorModel
+        end
+      end
+
       response 500 do
         key :description, 'An error occurred during the operation. See the message for more details.'
         schema do
@@ -212,6 +219,13 @@ module CredentialApiDoc
         end
       end
 
+      response 401 do
+        key :description, 'Authenticate to access this resource.'
+        schema do
+          key :'$ref', :AuthErrorModel
+        end
+      end
+
       response 500 do
         key :description, 'An error occurred during the operation. See the message for more details.'
         schema do
@@ -234,6 +248,13 @@ module CredentialApiDoc
           items do
             key :'$ref', :Credential
           end
+        end
+      end
+
+      response 401 do
+        key :description, 'Authenticate to access this resource.'
+        schema do
+          key :'$ref', :AuthErrorModel
         end
       end
 
@@ -274,6 +295,13 @@ module CredentialApiDoc
         end
       end
 
+      response 401 do
+        key :description, 'Authenticate to access this resource.'
+        schema do
+          key :'$ref', :AuthErrorModel
+        end
+      end
+
       response 500 do
         key :description, 'An error occurred during the operation. See the message for more details.'
         schema do
@@ -305,6 +333,13 @@ module CredentialApiDoc
           property :data do
             key :'$ref', :Credential
           end
+        end
+      end
+
+      response 401 do
+        key :description, 'Authenticate to access this resource.'
+        schema do
+          key :'$ref', :AuthErrorModel
         end
       end
 

--- a/documentation/api/v1/db_export_api_doc.rb
+++ b/documentation/api/v1/db_export_api_doc.rb
@@ -37,14 +37,14 @@ module DbExportApiDoc
       end
 
       response 401 do
-        key :description, 'Authenticate to access this resource.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
         schema do
           key :'$ref', :AuthErrorModel
         end
       end
 
       response 500 do
-        key :description, 'An error occurred during the operation. See the message for more details.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
         schema do
           key :'$ref', :ErrorModel
         end

--- a/documentation/api/v1/db_export_api_doc.rb
+++ b/documentation/api/v1/db_export_api_doc.rb
@@ -36,6 +36,13 @@ module DbExportApiDoc
         end
       end
 
+      response 401 do
+        key :description, 'Authenticate to access this resource.'
+        schema do
+          key :'$ref', :AuthErrorModel
+        end
+      end
+
       response 500 do
         key :description, 'An error occurred during the operation. See the message for more details.'
         schema do

--- a/documentation/api/v1/event_api_doc.rb
+++ b/documentation/api/v1/event_api_doc.rb
@@ -48,7 +48,7 @@ module EventApiDoc
       end
 
       response 200 do
-        key :description, 'Successful operation.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_200
         schema do
           property :data do
             key :'$ref', :Event
@@ -57,14 +57,14 @@ module EventApiDoc
       end
 
       response 401 do
-        key :description, 'Authenticate to access this resource.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
         schema do
           key :'$ref', :AuthErrorModel
         end
       end
 
       response 500 do
-        key :description, 'An error occurred during the operation. See the message for more details.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
         schema do
           key :'$ref', :ErrorModel
         end

--- a/documentation/api/v1/event_api_doc.rb
+++ b/documentation/api/v1/event_api_doc.rb
@@ -56,6 +56,13 @@ module EventApiDoc
         end
       end
 
+      response 401 do
+        key :description, 'Authenticate to access this resource.'
+        schema do
+          key :'$ref', :AuthErrorModel
+        end
+      end
+
       response 500 do
         key :description, 'An error occurred during the operation. See the message for more details.'
         schema do

--- a/documentation/api/v1/exploit_api_doc.rb
+++ b/documentation/api/v1/exploit_api_doc.rb
@@ -64,6 +64,13 @@ module ExploitApiDoc
         end
       end
 
+      response 401 do
+        key :description, 'Authenticate to access this resource.'
+        schema do
+          key :'$ref', :AuthErrorModel
+        end
+      end
+
       response 500 do
         key :description, 'An error occurred during the operation. See the message for more details.'
         schema do

--- a/documentation/api/v1/exploit_api_doc.rb
+++ b/documentation/api/v1/exploit_api_doc.rb
@@ -56,7 +56,7 @@ module ExploitApiDoc
       end
 
       response 200 do
-        key :description, 'Successful operation.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_200
         schema do
           property :data do
             key :'$ref', :Exploit
@@ -65,14 +65,14 @@ module ExploitApiDoc
       end
 
       response 401 do
-        key :description, 'Authenticate to access this resource.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
         schema do
           key :'$ref', :AuthErrorModel
         end
       end
 
       response 500 do
-        key :description, 'An error occurred during the operation. See the message for more details.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
         schema do
           key :'$ref', :ErrorModel
         end

--- a/documentation/api/v1/host_api_doc.rb
+++ b/documentation/api/v1/host_api_doc.rb
@@ -114,14 +114,14 @@ module HostApiDoc
       end
 
       response 401 do
-        key :description, 'Authenticate to access this resource.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
         schema do
           key :'$ref', :AuthErrorModel
         end
       end
 
       response 500 do
-        key :description, 'An error occurred during the operation. See the message for more details.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
         schema do
           key :'$ref', :ErrorModel
         end
@@ -167,7 +167,7 @@ module HostApiDoc
       end
 
       response 200 do
-        key :description, 'Successful operation.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_200
         schema do
           property :data do
             key :'$ref', :Host
@@ -176,14 +176,14 @@ module HostApiDoc
       end
 
       response 401 do
-        key :description, 'Authenticate to access this resource.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
         schema do
           key :'$ref', :AuthErrorModel
         end
       end
 
       response 500 do
-        key :description, 'An error occurred during the operation. See the message for more details.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
         schema do
           key :'$ref', :ErrorModel
         end
@@ -210,14 +210,14 @@ module HostApiDoc
       end
 
       response 401 do
-        key :description, 'Authenticate to access this resource.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
         schema do
           key :'$ref', :AuthErrorModel
         end
       end
 
       response 500 do
-        key :description, 'An error occurred during the operation. See the message for more details.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
         schema do
           key :'$ref', :ErrorModel
         end
@@ -250,14 +250,14 @@ module HostApiDoc
       end
 
       response 401 do
-        key :description, 'Authenticate to access this resource.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
         schema do
           key :'$ref', :AuthErrorModel
         end
       end
 
       response 500 do
-        key :description, 'An error occurred during the operation. See the message for more details.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
         schema do
           key :'$ref', :ErrorModel
         end
@@ -291,14 +291,14 @@ module HostApiDoc
       end
 
       response 401 do
-        key :description, 'Authenticate to access this resource.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
         schema do
           key :'$ref', :AuthErrorModel
         end
       end
 
       response 500 do
-        key :description, 'An error occurred during the operation. See the message for more details.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
         schema do
           key :'$ref', :ErrorModel
         end

--- a/documentation/api/v1/host_api_doc.rb
+++ b/documentation/api/v1/host_api_doc.rb
@@ -113,6 +113,13 @@ module HostApiDoc
         end
       end
 
+      response 401 do
+        key :description, 'Authenticate to access this resource.'
+        schema do
+          key :'$ref', :AuthErrorModel
+        end
+      end
+
       response 500 do
         key :description, 'An error occurred during the operation. See the message for more details.'
         schema do
@@ -168,6 +175,13 @@ module HostApiDoc
         end
       end
 
+      response 401 do
+        key :description, 'Authenticate to access this resource.'
+        schema do
+          key :'$ref', :AuthErrorModel
+        end
+      end
+
       response 500 do
         key :description, 'An error occurred during the operation. See the message for more details.'
         schema do
@@ -192,6 +206,13 @@ module HostApiDoc
               key :'$ref', :Host
             end
           end
+        end
+      end
+
+      response 401 do
+        key :description, 'Authenticate to access this resource.'
+        schema do
+          key :'$ref', :AuthErrorModel
         end
       end
 
@@ -228,6 +249,13 @@ module HostApiDoc
         end
       end
 
+      response 401 do
+        key :description, 'Authenticate to access this resource.'
+        schema do
+          key :'$ref', :AuthErrorModel
+        end
+      end
+
       response 500 do
         key :description, 'An error occurred during the operation. See the message for more details.'
         schema do
@@ -259,6 +287,13 @@ module HostApiDoc
           property :data do
             key :'$ref', :Host
           end
+        end
+      end
+
+      response 401 do
+        key :description, 'Authenticate to access this resource.'
+        schema do
+          key :'$ref', :AuthErrorModel
         end
       end
 

--- a/documentation/api/v1/login_api_doc.rb
+++ b/documentation/api/v1/login_api_doc.rb
@@ -62,14 +62,14 @@ module LoginApiDoc
       end
 
       response 401 do
-        key :description, 'Authenticate to access this resource.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
         schema do
           key :'$ref', :AuthErrorModel
         end
       end
 
       response 500 do
-        key :description, 'An error occurred during the operation. See the message for more details.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
         schema do
           key :'$ref', :ErrorModel
         end
@@ -100,7 +100,7 @@ module LoginApiDoc
       end
 
       response 200 do
-        key :description, 'Successful operation.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_200
         schema do
           property :data do
             key :'$ref', :Login
@@ -109,14 +109,14 @@ module LoginApiDoc
       end
 
       response 401 do
-        key :description, 'Authenticate to access this resource.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
         schema do
           key :'$ref', :AuthErrorModel
         end
       end
 
       response 500 do
-        key :description, 'An error occurred during the operation. See the message for more details.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
         schema do
           key :'$ref', :ErrorModel
         end
@@ -143,7 +143,7 @@ module LoginApiDoc
       end
 
       response 401 do
-        key :description, 'Authenticate to access this resource.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
         schema do
           key :'$ref', :AuthErrorModel
         end
@@ -177,14 +177,14 @@ module LoginApiDoc
       end
 
       response 401 do
-        key :description, 'Authenticate to access this resource.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
         schema do
           key :'$ref', :AuthErrorModel
         end
       end
 
       response 500 do
-        key :description, 'An error occurred during the operation. See the message for more details.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
         schema do
           key :'$ref', :ErrorModel
         end
@@ -209,7 +209,7 @@ module LoginApiDoc
       end
 
       response 200 do
-        key :description, 'Successful operation.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_200
         schema do
           property :data do
             key :'$ref', :Login
@@ -218,14 +218,14 @@ module LoginApiDoc
       end
 
       response 401 do
-        key :description, 'Authenticate to access this resource.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
         schema do
           key :'$ref', :AuthErrorModel
         end
       end
 
       response 500 do
-        key :description, 'An error occurred during the operation. See the message for more details.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
         schema do
           key :'$ref', :ErrorModel
         end

--- a/documentation/api/v1/login_api_doc.rb
+++ b/documentation/api/v1/login_api_doc.rb
@@ -61,6 +61,13 @@ module LoginApiDoc
         end
       end
 
+      response 401 do
+        key :description, 'Authenticate to access this resource.'
+        schema do
+          key :'$ref', :AuthErrorModel
+        end
+      end
+
       response 500 do
         key :description, 'An error occurred during the operation. See the message for more details.'
         schema do
@@ -101,6 +108,13 @@ module LoginApiDoc
         end
       end
 
+      response 401 do
+        key :description, 'Authenticate to access this resource.'
+        schema do
+          key :'$ref', :AuthErrorModel
+        end
+      end
+
       response 500 do
         key :description, 'An error occurred during the operation. See the message for more details.'
         schema do
@@ -127,6 +141,14 @@ module LoginApiDoc
           end
         end
       end
+
+      response 401 do
+        key :description, 'Authenticate to access this resource.'
+        schema do
+          key :'$ref', :AuthErrorModel
+        end
+      end
+
     end
   end
 
@@ -151,6 +173,13 @@ module LoginApiDoc
           property :data do
             key :'$ref', :Login
           end
+        end
+      end
+
+      response 401 do
+        key :description, 'Authenticate to access this resource.'
+        schema do
+          key :'$ref', :AuthErrorModel
         end
       end
 
@@ -185,6 +214,13 @@ module LoginApiDoc
           property :data do
             key :'$ref', :Login
           end
+        end
+      end
+
+      response 401 do
+        key :description, 'Authenticate to access this resource.'
+        schema do
+          key :'$ref', :AuthErrorModel
         end
       end
 

--- a/documentation/api/v1/loot_api_doc.rb
+++ b/documentation/api/v1/loot_api_doc.rb
@@ -58,14 +58,14 @@ module LootApiDoc
       end
 
       response 401 do
-        key :description, 'Authenticate to access this resource.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
         schema do
           key :'$ref', :AuthErrorModel
         end
       end
 
       response 500 do
-        key :description, 'An error occurred during the operation. See the message for more details.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
         schema do
           key :'$ref', :ErrorModel
         end
@@ -96,7 +96,7 @@ module LootApiDoc
       end
 
       response 200 do
-        key :description, 'Successful operation.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_200
         schema do
           property :data do
             key :'$ref', :Loot
@@ -105,14 +105,14 @@ module LootApiDoc
       end
 
       response 401 do
-        key :description, 'Authenticate to access this resource.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
         schema do
           key :'$ref', :AuthErrorModel
         end
       end
 
       response 500 do
-        key :description, 'An error occurred during the operation. See the message for more details.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
         schema do
           key :'$ref', :ErrorModel
         end
@@ -139,14 +139,14 @@ module LootApiDoc
       end
 
       response 401 do
-        key :description, 'Authenticate to access this resource.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
         schema do
           key :'$ref', :AuthErrorModel
         end
       end
 
       response 500 do
-        key :description, 'An error occurred during the operation. See the message for more details.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
         schema do
           key :'$ref', :ErrorModel
         end
@@ -179,14 +179,14 @@ module LootApiDoc
       end
 
       response 401 do
-        key :description, 'Authenticate to access this resource.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
         schema do
           key :'$ref', :AuthErrorModel
         end
       end
 
       response 500 do
-        key :description, 'An error occurred during the operation. See the message for more details.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
         schema do
           key :'$ref', :ErrorModel
         end
@@ -211,7 +211,7 @@ module LootApiDoc
       end
 
       response 200 do
-        key :description, 'Successful operation.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_200
         schema do
           property :data do
             key :'$ref', :Loot
@@ -220,14 +220,14 @@ module LootApiDoc
       end
 
       response 401 do
-        key :description, 'Authenticate to access this resource.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
         schema do
           key :'$ref', :AuthErrorModel
         end
       end
 
       response 500 do
-        key :description, 'An error occurred during the operation. See the message for more details.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
         schema do
           key :'$ref', :ErrorModel
         end

--- a/documentation/api/v1/loot_api_doc.rb
+++ b/documentation/api/v1/loot_api_doc.rb
@@ -57,6 +57,13 @@ module LootApiDoc
         end
       end
 
+      response 401 do
+        key :description, 'Authenticate to access this resource.'
+        schema do
+          key :'$ref', :AuthErrorModel
+        end
+      end
+
       response 500 do
         key :description, 'An error occurred during the operation. See the message for more details.'
         schema do
@@ -97,6 +104,13 @@ module LootApiDoc
         end
       end
 
+      response 401 do
+        key :description, 'Authenticate to access this resource.'
+        schema do
+          key :'$ref', :AuthErrorModel
+        end
+      end
+
       response 500 do
         key :description, 'An error occurred during the operation. See the message for more details.'
         schema do
@@ -121,6 +135,13 @@ module LootApiDoc
               key :'$ref', :Loot
             end
           end
+        end
+      end
+
+      response 401 do
+        key :description, 'Authenticate to access this resource.'
+        schema do
+          key :'$ref', :AuthErrorModel
         end
       end
 
@@ -157,6 +178,13 @@ module LootApiDoc
         end
       end
 
+      response 401 do
+        key :description, 'Authenticate to access this resource.'
+        schema do
+          key :'$ref', :AuthErrorModel
+        end
+      end
+
       response 500 do
         key :description, 'An error occurred during the operation. See the message for more details.'
         schema do
@@ -188,6 +216,13 @@ module LootApiDoc
           property :data do
             key :'$ref', :Loot
           end
+        end
+      end
+
+      response 401 do
+        key :description, 'Authenticate to access this resource.'
+        schema do
+          key :'$ref', :AuthErrorModel
         end
       end
 

--- a/documentation/api/v1/module_search_api_doc.rb
+++ b/documentation/api/v1/module_search_api_doc.rb
@@ -167,6 +167,13 @@ module ModuleSearchApiDoc
         end
       end
 
+      response 401 do
+        key :description, 'Authenticate to access this resource.'
+        schema do
+          key :'$ref', :AuthErrorModel
+        end
+      end
+
       response 500 do
         key :description, 'An error occurred during the operation. See the message for more details.'
         schema do

--- a/documentation/api/v1/module_search_api_doc.rb
+++ b/documentation/api/v1/module_search_api_doc.rb
@@ -168,14 +168,14 @@ module ModuleSearchApiDoc
       end
 
       response 401 do
-        key :description, 'Authenticate to access this resource.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
         schema do
           key :'$ref', :AuthErrorModel
         end
       end
 
       response 500 do
-        key :description, 'An error occurred during the operation. See the message for more details.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
         schema do
           key :'$ref', :ErrorModel
         end

--- a/documentation/api/v1/msf_api_doc.rb
+++ b/documentation/api/v1/msf_api_doc.rb
@@ -18,6 +18,13 @@ module MsfApiDoc
         end
       end
 
+      response 401 do
+        key :description, 'Authenticate to access this resource.'
+        schema do
+          key :'$ref', :AuthErrorModel
+        end
+      end
+
       response 500 do
         key :description, 'An error occurred during the operation. See the message for more details.'
         schema do

--- a/documentation/api/v1/msf_api_doc.rb
+++ b/documentation/api/v1/msf_api_doc.rb
@@ -19,14 +19,14 @@ module MsfApiDoc
       end
 
       response 401 do
-        key :description, 'Authenticate to access this resource.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
         schema do
           key :'$ref', :AuthErrorModel
         end
       end
 
       response 500 do
-        key :description, 'An error occurred during the operation. See the message for more details.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
         schema do
           key :'$ref', :ErrorModel
         end

--- a/documentation/api/v1/nmap_api_doc.rb
+++ b/documentation/api/v1/nmap_api_doc.rb
@@ -30,14 +30,14 @@ module NmapApiDoc
       end
 
       response 401 do
-        key :description, 'Authenticate to access this resource.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
         schema do
           key :'$ref', :AuthErrorModel
         end
       end
 
       response 500 do
-        key :description, 'An error occurred during the operation. See the message for more details.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
         schema do
           key :'$ref', :ErrorModel
         end

--- a/documentation/api/v1/nmap_api_doc.rb
+++ b/documentation/api/v1/nmap_api_doc.rb
@@ -29,6 +29,13 @@ module NmapApiDoc
         end
       end
 
+      response 401 do
+        key :description, 'Authenticate to access this resource.'
+        schema do
+          key :'$ref', :AuthErrorModel
+        end
+      end
+
       response 500 do
         key :description, 'An error occurred during the operation. See the message for more details.'
         schema do

--- a/documentation/api/v1/note_api_doc.rb
+++ b/documentation/api/v1/note_api_doc.rb
@@ -49,6 +49,13 @@ module NoteApiDoc
         end
       end
 
+      response 401 do
+        key :description, 'Authenticate to access this resource.'
+        schema do
+          key :'$ref', :AuthErrorModel
+        end
+      end
+
       response 500 do
         key :description, 'An error occurred during the operation. See the message for more details.'
         schema do
@@ -86,6 +93,13 @@ module NoteApiDoc
         end
       end
 
+      response 401 do
+        key :description, 'Authenticate to access this resource.'
+        schema do
+          key :'$ref', :AuthErrorModel
+        end
+      end
+
       response 500 do
         key :description, 'An error occurred during the operation. See the message for more details.'
         schema do
@@ -110,6 +124,13 @@ module NoteApiDoc
               key :'$ref', :Note
             end
           end
+        end
+      end
+
+      response 401 do
+        key :description, 'Authenticate to access this resource.'
+        schema do
+          key :'$ref', :AuthErrorModel
         end
       end
 
@@ -146,6 +167,13 @@ module NoteApiDoc
         end
       end
 
+      response 401 do
+        key :description, 'Authenticate to access this resource.'
+        schema do
+          key :'$ref', :AuthErrorModel
+        end
+      end
+
       response 500 do
         key :description, 'An error occurred during the operation. See the message for more details.'
         schema do
@@ -177,6 +205,13 @@ module NoteApiDoc
           property :data do
             key :'$ref', :Note
           end
+        end
+      end
+
+      response 401 do
+        key :description, 'Authenticate to access this resource.'
+        schema do
+          key :'$ref', :AuthErrorModel
         end
       end
 

--- a/documentation/api/v1/note_api_doc.rb
+++ b/documentation/api/v1/note_api_doc.rb
@@ -50,14 +50,14 @@ module NoteApiDoc
       end
 
       response 401 do
-        key :description, 'Authenticate to access this resource.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
         schema do
           key :'$ref', :AuthErrorModel
         end
       end
 
       response 500 do
-        key :description, 'An error occurred during the operation. See the message for more details.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
         schema do
           key :'$ref', :ErrorModel
         end
@@ -85,7 +85,7 @@ module NoteApiDoc
       end
 
       response 200 do
-        key :description, 'Successful operation.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_200
         schema do
           property :data do
             key :'$ref', :Note
@@ -94,14 +94,14 @@ module NoteApiDoc
       end
 
       response 401 do
-        key :description, 'Authenticate to access this resource.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
         schema do
           key :'$ref', :AuthErrorModel
         end
       end
 
       response 500 do
-        key :description, 'An error occurred during the operation. See the message for more details.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
         schema do
           key :'$ref', :ErrorModel
         end
@@ -128,14 +128,14 @@ module NoteApiDoc
       end
 
       response 401 do
-        key :description, 'Authenticate to access this resource.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
         schema do
           key :'$ref', :AuthErrorModel
         end
       end
 
       response 500 do
-        key :description, 'An error occurred during the operation. See the message for more details.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
         schema do
           key :'$ref', :ErrorModel
         end
@@ -168,14 +168,14 @@ module NoteApiDoc
       end
 
       response 401 do
-        key :description, 'Authenticate to access this resource.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
         schema do
           key :'$ref', :AuthErrorModel
         end
       end
 
       response 500 do
-        key :description, 'An error occurred during the operation. See the message for more details.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
         schema do
           key :'$ref', :ErrorModel
         end
@@ -200,7 +200,7 @@ module NoteApiDoc
       end
 
       response 200 do
-        key :description, 'Successful operation.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_200
         schema do
           property :data do
             key :'$ref', :Note
@@ -209,14 +209,14 @@ module NoteApiDoc
       end
 
       response 401 do
-        key :description, 'Authenticate to access this resource.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
         schema do
           key :'$ref', :AuthErrorModel
         end
       end
 
       response 500 do
-        key :description, 'An error occurred during the operation. See the message for more details.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
         schema do
           key :'$ref', :ErrorModel
         end

--- a/documentation/api/v1/root_api_doc.rb
+++ b/documentation/api/v1/root_api_doc.rb
@@ -63,6 +63,7 @@ module RootApiDoc
     tag name: 'service', description: 'Service operations.'
     tag name: 'session', description: 'Session operations.'
     tag name: 'session_event', description: 'Session Event operations.'
+    tag name: 'user', description: 'User operations.'
     tag name: 'vuln', description: 'Vuln operations.'
     tag name: 'vuln_attempt', description: 'Vuln Attempt operations.'
     tag name: 'workspace', description: 'Workspace operations.'

--- a/documentation/api/v1/root_api_doc.rb
+++ b/documentation/api/v1/root_api_doc.rb
@@ -17,7 +17,10 @@ module RootApiDoc
   AUTH_CODE_DESC = 'The authentication error code that was generated.'
   AUTH_CODE_EXAMPLE = 401
   AUTH_MESSAGE_DESC = 'A message describing the authentication error that occurred.'
-  AUTH_MESSAGE_EXAMPLE = 'Authenticate to access this resource'
+
+  DEFAULT_RESPONSE_200 = 'Successful operation.'
+  DEFAULT_RESPONSE_401 = 'Authenticate to access this resource.'
+  DEFAULT_RESPONSE_500 = 'An error occurred during the operation. See the message for more details.'
 
   swagger_root do
     key :swagger, '2.0'
@@ -155,7 +158,7 @@ module RootApiDoc
       property :message do
         key :type, :string
         key :description, AUTH_MESSAGE_DESC
-        key :example, AUTH_MESSAGE_EXAMPLE
+        key :example, DEFAULT_RESPONSE_401
       end
     end
   end

--- a/documentation/api/v1/root_api_doc.rb
+++ b/documentation/api/v1/root_api_doc.rb
@@ -14,6 +14,10 @@ module RootApiDoc
   CODE_EXAMPLE = 500
   MESSAGE_DESC = 'A message describing the error that occurred.'
   MESSAGE_EXAMPLE = 'Undefined method \'empty?\' for nil:NilClass'
+  AUTH_CODE_DESC = 'The authentication error code that was generated.'
+  AUTH_CODE_EXAMPLE = 401
+  AUTH_MESSAGE_DESC = 'A message describing the authentication error that occurred.'
+  AUTH_MESSAGE_EXAMPLE = 'Authenticate to access this resource'
 
   swagger_root do
     key :swagger, '2.0'
@@ -29,11 +33,22 @@ module RootApiDoc
     key :consumes, ['application/json']
     key :produces, ['application/json']
 
+    security_definition :api_key do
+      key :type, :apiKey
+      key :name, :Authorization
+      key :in, :header
+    end
+
+    security do
+      key :api_key, []
+    end
+
     #################################
     #
     # Documentation Tags
     #
     #################################
+    tag name: 'auth', description: 'Authorization operations.'
     tag name: 'credential', description: 'Credential operations.'
     tag name: 'db_export', description: 'Endpoint for generating and retrieving a database backup.'
     tag name: 'event', description: 'Event operations.'
@@ -127,4 +142,21 @@ module RootApiDoc
       end
     end
   end
+
+  swagger_schema :AuthErrorModel do
+    key :required, [:message]
+    property :error do
+      property :code do
+        key :type, :int32
+        key :description, AUTH_CODE_DESC
+        key :example, AUTH_CODE_EXAMPLE
+      end
+      property :message do
+        key :type, :string
+        key :description, AUTH_MESSAGE_DESC
+        key :example, AUTH_MESSAGE_EXAMPLE
+      end
+    end
+  end
+
 end

--- a/documentation/api/v1/service_api_doc.rb
+++ b/documentation/api/v1/service_api_doc.rb
@@ -50,6 +50,13 @@ module ServiceApiDoc
         end
       end
 
+      response 401 do
+        key :description, 'Authenticate to access this resource.'
+        schema do
+          key :'$ref', :AuthErrorModel
+        end
+      end
+
       response 500 do
         key :description, 'An error occurred during the operation. See the message for more details.'
         schema do
@@ -88,6 +95,13 @@ module ServiceApiDoc
         end
       end
 
+      response 401 do
+        key :description, 'Authenticate to access this resource.'
+        schema do
+          key :'$ref', :AuthErrorModel
+        end
+      end
+
       response 500 do
         key :description, 'An error occurred during the operation. See the message for more details.'
         schema do
@@ -112,6 +126,13 @@ module ServiceApiDoc
               key :'$ref', :Service
             end
           end
+        end
+      end
+
+      response 401 do
+        key :description, 'Authenticate to access this resource.'
+        schema do
+          key :'$ref', :AuthErrorModel
         end
       end
 
@@ -149,6 +170,13 @@ module ServiceApiDoc
         end
       end
 
+      response 401 do
+        key :description, 'Authenticate to access this resource.'
+        schema do
+          key :'$ref', :AuthErrorModel
+        end
+      end
+
       response 500 do
         key :description, 'An error occurred during the operation. See the message for more details.'
         schema do
@@ -180,6 +208,13 @@ module ServiceApiDoc
           property :data do
             key :'$ref', :Service
           end
+        end
+      end
+
+      response 401 do
+        key :description, 'Authenticate to access this resource.'
+        schema do
+          key :'$ref', :AuthErrorModel
         end
       end
 

--- a/documentation/api/v1/service_api_doc.rb
+++ b/documentation/api/v1/service_api_doc.rb
@@ -51,14 +51,14 @@ module ServiceApiDoc
       end
 
       response 401 do
-        key :description, 'Authenticate to access this resource.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
         schema do
           key :'$ref', :AuthErrorModel
         end
       end
 
       response 500 do
-        key :description, 'An error occurred during the operation. See the message for more details.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
         schema do
           key :'$ref', :ErrorModel
         end
@@ -87,7 +87,7 @@ module ServiceApiDoc
       end
 
       response 200 do
-        key :description, 'Successful operation.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_200
         schema do
           property :data do
             key :'$ref', :Service
@@ -96,14 +96,14 @@ module ServiceApiDoc
       end
 
       response 401 do
-        key :description, 'Authenticate to access this resource.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
         schema do
           key :'$ref', :AuthErrorModel
         end
       end
 
       response 500 do
-        key :description, 'An error occurred during the operation. See the message for more details.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
         schema do
           key :'$ref', :ErrorModel
         end
@@ -130,14 +130,14 @@ module ServiceApiDoc
       end
 
       response 401 do
-        key :description, 'Authenticate to access this resource.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
         schema do
           key :'$ref', :AuthErrorModel
         end
       end
 
       response 500 do
-        key :description, 'An error occurred during the operation. See the message for more details.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
         schema do
           key :'$ref', :ErrorModel
         end
@@ -171,14 +171,14 @@ module ServiceApiDoc
       end
 
       response 401 do
-        key :description, 'Authenticate to access this resource.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
         schema do
           key :'$ref', :AuthErrorModel
         end
       end
 
       response 500 do
-        key :description, 'An error occurred during the operation. See the message for more details.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
         schema do
           key :'$ref', :ErrorModel
         end
@@ -203,7 +203,7 @@ module ServiceApiDoc
       end
 
       response 200 do
-        key :description, 'Successful operation.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_200
         schema do
           property :data do
             key :'$ref', :Service
@@ -212,14 +212,14 @@ module ServiceApiDoc
       end
 
       response 401 do
-        key :description, 'Authenticate to access this resource.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
         schema do
           key :'$ref', :AuthErrorModel
         end
       end
 
       response 500 do
-        key :description, 'An error occurred during the operation. See the message for more details.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
         schema do
           key :'$ref', :ErrorModel
         end

--- a/documentation/api/v1/session_api_doc.rb
+++ b/documentation/api/v1/session_api_doc.rb
@@ -42,14 +42,14 @@ module SessionApiDoc
       end
 
       response 401 do
-        key :description, 'Authenticate to access this resource.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
         schema do
           key :'$ref', :AuthErrorModel
         end
       end
 
       response 500 do
-        key :description, 'An error occurred during the operation. See the message for more details.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
         schema do
           key :'$ref', :ErrorModel
         end
@@ -76,7 +76,7 @@ module SessionApiDoc
     #   end
     #
     #   response 200 do
-    #     key :description, 'Successful operation.'
+    #     key :description, RootApiDoc::DEFAULT_RESPONSE_200
     #     schema do
     #       key :type, :object
     #       key :'$ref', :Session
@@ -110,14 +110,14 @@ module SessionApiDoc
       end
 
       response 401 do
-        key :description, 'Authenticate to access this resource.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
         schema do
           key :'$ref', :AuthErrorModel
         end
       end
 
       response 500 do
-        key :description, 'An error occurred during the operation. See the message for more details.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
         schema do
           key :'$ref', :ErrorModel
         end

--- a/documentation/api/v1/session_api_doc.rb
+++ b/documentation/api/v1/session_api_doc.rb
@@ -41,6 +41,13 @@ module SessionApiDoc
         end
       end
 
+      response 401 do
+        key :description, 'Authenticate to access this resource.'
+        schema do
+          key :'$ref', :AuthErrorModel
+        end
+      end
+
       response 500 do
         key :description, 'An error occurred during the operation. See the message for more details.'
         schema do
@@ -99,6 +106,13 @@ module SessionApiDoc
           property :data do
             key :'$ref', :Session
           end
+        end
+      end
+
+      response 401 do
+        key :description, 'Authenticate to access this resource.'
+        schema do
+          key :'$ref', :AuthErrorModel
         end
       end
 

--- a/documentation/api/v1/session_event_api_doc.rb
+++ b/documentation/api/v1/session_event_api_doc.rb
@@ -44,6 +44,13 @@ module SessionEventApiDoc
         end
       end
 
+      response 401 do
+        key :description, 'Authenticate to access this resource.'
+        schema do
+          key :'$ref', :AuthErrorModel
+        end
+      end
+
       response 500 do
         key :description, 'An error occurred during the operation. See the message for more details.'
         schema do
@@ -81,6 +88,13 @@ module SessionEventApiDoc
         end
       end
 
+      response 401 do
+        key :description, 'Authenticate to access this resource.'
+        schema do
+          key :'$ref', :AuthErrorModel
+        end
+      end
+
       response 500 do
         key :description, 'An error occurred during the operation. See the message for more details.'
         schema do
@@ -111,6 +125,13 @@ module SessionEventApiDoc
           property :data do
             key :'$ref', :SessionEvent
           end
+        end
+      end
+
+      response 401 do
+        key :description, 'Authenticate to access this resource.'
+        schema do
+          key :'$ref', :AuthErrorModel
         end
       end
 

--- a/documentation/api/v1/session_event_api_doc.rb
+++ b/documentation/api/v1/session_event_api_doc.rb
@@ -45,14 +45,14 @@ module SessionEventApiDoc
       end
 
       response 401 do
-        key :description, 'Authenticate to access this resource.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
         schema do
           key :'$ref', :AuthErrorModel
         end
       end
 
       response 500 do
-        key :description, 'An error occurred during the operation. See the message for more details.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
         schema do
           key :'$ref', :ErrorModel
         end
@@ -80,7 +80,7 @@ module SessionEventApiDoc
       end
 
       response 200 do
-        key :description, 'Successful operation.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_200
         schema do
           property :data do
             key :'$ref', :SessionEvent
@@ -89,14 +89,14 @@ module SessionEventApiDoc
       end
 
       response 401 do
-        key :description, 'Authenticate to access this resource.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
         schema do
           key :'$ref', :AuthErrorModel
         end
       end
 
       response 500 do
-        key :description, 'An error occurred during the operation. See the message for more details.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
         schema do
           key :'$ref', :ErrorModel
         end
@@ -129,14 +129,14 @@ module SessionEventApiDoc
       end
 
       response 401 do
-        key :description, 'Authenticate to access this resource.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
         schema do
           key :'$ref', :AuthErrorModel
         end
       end
 
       response 500 do
-        key :description, 'An error occurred during the operation. See the message for more details.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
         schema do
           key :'$ref', :ErrorModel
         end

--- a/documentation/api/v1/user_api_doc.rb
+++ b/documentation/api/v1/user_api_doc.rb
@@ -4,7 +4,9 @@ module UserApiDoc
   include Swagger::Blocks
 
   USERNAME_DESC = 'The username of the user.'
+  USERNAME_EXAMPLE = 'bmoose'
   PASSWORD_DESC = 'The password of the user.'
+  PASSWORD_EXAMPLE = 'pass123'
   CRYPTED_PASSWORD_DESC = 'The encrypted password of the user.'
   CRYPTED_PASSWORD_EXAMPLE = '$2a$10$ZOmd0VVkcVLTKW/0Cw0BMeqVITeVN4tPQvRvwBizNyM1NIz45oxda'
   PASSWORD_SALT_DESC = 'The password salt for the user\'s password.'
@@ -28,7 +30,7 @@ module UserApiDoc
   swagger_schema :User do
     key :required, [:username, :password]
     property :id, type: :integer, format: :int32, description: RootApiDoc::ID_DESC
-    property :username, type: :string, description: USERNAME_DESC
+    property :username, type: :string, description: USERNAME_DESC, example: USERNAME_EXAMPLE
     property :crypted_password, type: :string, description: CRYPTED_PASSWORD_DESC, example: CRYPTED_PASSWORD_EXAMPLE
     property :password_salt, type: :string, description: PASSWORD_SALT_DESC
     property :persistence_token, type: :string, description: PERSISTENCE_TOKEN_DESC, example: PERSISTENCE_TOKEN_EXAMPLE
@@ -86,8 +88,8 @@ module UserApiDoc
         key :description, 'The attributes to assign to the user.'
         key :required, true
         schema do
-          property :username, type: :string, required: true, description: USERNAME_DESC
-          property :password, type: :string, required: true, description: PASSWORD_DESC
+          property :username, type: :string, required: true, description: USERNAME_DESC, example: USERNAME_EXAMPLE
+          property :password, type: :string, required: true, description: PASSWORD_DESC, example: PASSWORD_EXAMPLE
           property :fullname, type: :string, description: FULLNAME_DESC, example: FULLNAME_EXAMPLE
           property :email, type: :string, description: EMAIL_DESC, example: EMAIL_EXAMPLE
           property :phone, type: :string, description: PHONE_DESC, example: PHONE_EXAMPLE

--- a/documentation/api/v1/user_api_doc.rb
+++ b/documentation/api/v1/user_api_doc.rb
@@ -60,6 +60,17 @@ module UserApiDoc
         end
       end
 
+      response 200 do
+        key :description, 'Authenticate to access this resource'
+      end
+
+      response 401 do
+        key :description, 'Authenticate to access this resource.'
+        schema do
+          key :'$ref', :AuthErrorModel
+        end
+      end
+
       response 500 do
         key :description, 'An error occurred during the operation. See the message for more details.'
         schema do
@@ -98,6 +109,13 @@ module UserApiDoc
               key :'$ref', :User
             end
           end
+        end
+      end
+
+      response 401 do
+        key :description, 'Authenticate to access this resource.'
+        schema do
+          key :'$ref', :AuthErrorModel
         end
       end
 

--- a/documentation/api/v1/user_api_doc.rb
+++ b/documentation/api/v1/user_api_doc.rb
@@ -61,14 +61,14 @@ module UserApiDoc
       end
 
       response 401 do
-        key :description, 'Authenticate to access this resource.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
         schema do
           key :'$ref', :AuthErrorModel
         end
       end
 
       response 500 do
-        key :description, 'An error occurred during the operation. See the message for more details.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
         schema do
           key :'$ref', :ErrorModel
         end
@@ -97,7 +97,7 @@ module UserApiDoc
       end
 
       response 200 do
-        key :description, 'Successful operation.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_200
         schema do
           property :data do
             key :type, :array
@@ -109,14 +109,14 @@ module UserApiDoc
       end
 
       response 401 do
-        key :description, 'Authenticate to access this resource.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
         schema do
           key :'$ref', :AuthErrorModel
         end
       end
 
       response 500 do
-        key :description, 'An error occurred during the operation. See the message for more details.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
         schema do
           key :'$ref', :ErrorModel
         end

--- a/documentation/api/v1/user_api_doc.rb
+++ b/documentation/api/v1/user_api_doc.rb
@@ -1,0 +1,113 @@
+require 'swagger/blocks'
+
+module UserApiDoc
+  include Swagger::Blocks
+
+  USERNAME_DESC = 'The username of the user.'
+  PASSWORD_DESC = 'The password of the user.'
+  CRYPTED_PASSWORD_DESC = 'The encrypted password of the user.'
+  CRYPTED_PASSWORD_EXAMPLE = '$2a$10$ZOmd0VVkcVLTKW/0Cw0BMeqVITeVN4tPQvRvwBizNyM1NIz45oxda'
+  PASSWORD_SALT_DESC = 'The password salt for the user\'s password.'
+  PERSISTENCE_TOKEN_DESC = 'The persistence token for the user.'
+  PERSISTENCE_TOKEN_EXAMPLE = '1a6347561b72aff163b4c1b8324cfdf9ccca37caa681e29d348677afe0cb56927e2e3ab4dc612723'
+  FULLNAME_DESC = 'The user\'s full name.'
+  FULLNAME_EXAMPLE = 'Bullwinkle J. Moose'
+  EMAIL_DESC = 'The user\'s email address.'
+  EMAIL_EXAMPLE = 'bullwinkle_moose@rapid7.com'
+  PHONE_DESC = 'The user\'s phone number.'
+  PHONE_EXAMPLE = '555-555-5555'
+  COMPANY_DESC = 'The user\'s company.'
+  COMPANY_EXAMPLE = 'Rapid7'
+  PREFS_DESC = 'The user\'s preferences.'
+  PREFS_EXAMPLE = {}
+  ADMIN_DESC = 'A boolean indicating whether the user is an admin.'
+  ADMIN_EXAMPLE = false
+
+
+# Swagger documentation for User model
+  swagger_schema :User do
+    key :required, [:username, :password]
+    property :id, type: :integer, format: :int32, description: RootApiDoc::ID_DESC
+    property :username, type: :string, description: USERNAME_DESC
+    property :crypted_password, type: :string, description: CRYPTED_PASSWORD_DESC, example: CRYPTED_PASSWORD_EXAMPLE
+    property :password_salt, type: :string, description: PASSWORD_SALT_DESC
+    property :persistence_token, type: :string, description: PERSISTENCE_TOKEN_DESC, example: PERSISTENCE_TOKEN_EXAMPLE
+    property :created_at, type: :string, description: RootApiDoc::CREATED_AT_DESC
+    property :updated_at, type: :string, description: RootApiDoc::UPDATED_AT_DESC
+    property :fullname, type: :string, description: FULLNAME_DESC, example: FULLNAME_EXAMPLE
+    property :email, type: :string, description: EMAIL_DESC, example: EMAIL_EXAMPLE
+    property :phone, type: :string, description: PHONE_DESC, example: PHONE_EXAMPLE
+    property :company, type: :string, description: COMPANY_DESC, example: COMPANY_EXAMPLE
+    property :prefs, type: :string, description: PREFS_DESC, example: PREFS_EXAMPLE
+    property :admin, type: :string, description: ADMIN_DESC, example: ADMIN_EXAMPLE
+  end
+
+  swagger_path '/api/v1/users' do
+    # Swagger documentation for /api/v1/users GET
+    operation :get do
+      key :description, 'Return users that are stored in the database.'
+      key :tags, [ 'user' ]
+
+      response 200 do
+        key :description, 'Returns user data.'
+        schema do
+          property :data do
+            key :type, :array
+            items do
+              key :'$ref', :User
+            end
+          end
+        end
+      end
+
+      response 500 do
+        key :description, 'An error occurred during the operation. See the message for more details.'
+        schema do
+          key :'$ref', :ErrorModel
+        end
+      end
+    end
+
+    # Swagger documentation for /api/v1/users GET
+    operation :post do
+      key :description, 'Create a user.'
+      key :tags, [ 'user' ]
+
+      parameter do
+        key :in, :body
+        key :name, :body
+        key :description, 'The attributes to assign to the user.'
+        key :required, true
+        schema do
+          property :username, type: :string, required: true, description: USERNAME_DESC
+          property :password, type: :string, required: true, description: PASSWORD_DESC
+          property :fullname, type: :string, description: FULLNAME_DESC, example: FULLNAME_EXAMPLE
+          property :email, type: :string, description: EMAIL_DESC, example: EMAIL_EXAMPLE
+          property :phone, type: :string, description: PHONE_DESC, example: PHONE_EXAMPLE
+          property :company, type: :string, description: COMPANY_DESC, example: COMPANY_EXAMPLE
+          property :prefs, type: :string, description: PREFS_DESC, example: PREFS_EXAMPLE
+        end
+      end
+
+      response 200 do
+        key :description, 'Successful operation.'
+        schema do
+          property :data do
+            key :type, :array
+            items do
+              key :'$ref', :User
+            end
+          end
+        end
+      end
+
+      response 500 do
+        key :description, 'An error occurred during the operation. See the message for more details.'
+        schema do
+          key :'$ref', :ErrorModel
+        end
+      end
+
+    end
+  end
+end

--- a/documentation/api/v1/user_api_doc.rb
+++ b/documentation/api/v1/user_api_doc.rb
@@ -60,10 +60,6 @@ module UserApiDoc
         end
       end
 
-      response 200 do
-        key :description, 'Authenticate to access this resource'
-      end
-
       response 401 do
         key :description, 'Authenticate to access this resource.'
         schema do

--- a/documentation/api/v1/vuln_api_doc.rb
+++ b/documentation/api/v1/vuln_api_doc.rb
@@ -99,14 +99,14 @@ module VulnApiDoc
       end
 
       response 401 do
-        key :description, 'Authenticate to access this resource.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
         schema do
           key :'$ref', :AuthErrorModel
         end
       end
 
       response 500 do
-        key :description, 'An error occurred during the operation. See the message for more details.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
         schema do
           key :'$ref', :ErrorModel
         end
@@ -149,14 +149,14 @@ module VulnApiDoc
       end
 
       response 401 do
-        key :description, 'Authenticate to access this resource.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
         schema do
           key :'$ref', :AuthErrorModel
         end
       end
 
       response 500 do
-        key :description, 'An error occurred during the operation. See the message for more details.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
         schema do
           key :'$ref', :ErrorModel
         end
@@ -183,14 +183,14 @@ module VulnApiDoc
       end
 
       response 401 do
-        key :description, 'Authenticate to access this resource.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
         schema do
           key :'$ref', :AuthErrorModel
         end
       end
 
       response 500 do
-        key :description, 'An error occurred during the operation. See the message for more details.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
         schema do
           key :'$ref', :ErrorModel
         end
@@ -223,14 +223,14 @@ module VulnApiDoc
       end
 
       response 401 do
-        key :description, 'Authenticate to access this resource.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
         schema do
           key :'$ref', :AuthErrorModel
         end
       end
 
       response 500 do
-        key :description, 'An error occurred during the operation. See the message for more details.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
         schema do
           key :'$ref', :ErrorModel
         end
@@ -264,14 +264,14 @@ module VulnApiDoc
       end
 
       response 401 do
-        key :description, 'Authenticate to access this resource.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
         schema do
           key :'$ref', :AuthErrorModel
         end
       end
 
       response 500 do
-        key :description, 'An error occurred during the operation. See the message for more details.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
         schema do
           key :'$ref', :ErrorModel
         end

--- a/documentation/api/v1/vuln_api_doc.rb
+++ b/documentation/api/v1/vuln_api_doc.rb
@@ -98,6 +98,13 @@ module VulnApiDoc
         end
       end
 
+      response 401 do
+        key :description, 'Authenticate to access this resource.'
+        schema do
+          key :'$ref', :AuthErrorModel
+        end
+      end
+
       response 500 do
         key :description, 'An error occurred during the operation. See the message for more details.'
         schema do
@@ -141,6 +148,13 @@ module VulnApiDoc
         end
       end
 
+      response 401 do
+        key :description, 'Authenticate to access this resource.'
+        schema do
+          key :'$ref', :AuthErrorModel
+        end
+      end
+
       response 500 do
         key :description, 'An error occurred during the operation. See the message for more details.'
         schema do
@@ -165,6 +179,13 @@ module VulnApiDoc
               key :'$ref', :Vuln
             end
           end
+        end
+      end
+
+      response 401 do
+        key :description, 'Authenticate to access this resource.'
+        schema do
+          key :'$ref', :AuthErrorModel
         end
       end
 
@@ -201,6 +222,13 @@ module VulnApiDoc
         end
       end
 
+      response 401 do
+        key :description, 'Authenticate to access this resource.'
+        schema do
+          key :'$ref', :AuthErrorModel
+        end
+      end
+
       response 500 do
         key :description, 'An error occurred during the operation. See the message for more details.'
         schema do
@@ -232,6 +260,13 @@ module VulnApiDoc
           property :data do
             key :'$ref', :Vuln
           end
+        end
+      end
+
+      response 401 do
+        key :description, 'Authenticate to access this resource.'
+        schema do
+          key :'$ref', :AuthErrorModel
         end
       end
 

--- a/documentation/api/v1/vuln_attempt_api_doc.rb
+++ b/documentation/api/v1/vuln_attempt_api_doc.rb
@@ -51,14 +51,14 @@ module VulnAttemptApiDoc
       end
 
       response 401 do
-        key :description, 'Authenticate to access this resource.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
         schema do
           key :'$ref', :AuthErrorModel
         end
       end
 
       response 500 do
-        key :description, 'An error occurred during the operation. See the message for more details.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
         schema do
           key :'$ref', :ErrorModel
         end
@@ -88,7 +88,7 @@ module VulnAttemptApiDoc
       end
 
       response 200 do
-        key :description, 'Successful operation.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_200
         schema do
           property :data do
             key :'$ref', :VulnAttempt
@@ -97,14 +97,14 @@ module VulnAttemptApiDoc
       end
 
       response 401 do
-        key :description, 'Authenticate to access this resource.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
         schema do
           key :'$ref', :AuthErrorModel
         end
       end
 
       response 500 do
-        key :description, 'An error occurred during the operation. See the message for more details.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
         schema do
           key :'$ref', :ErrorModel
         end
@@ -137,14 +137,14 @@ module VulnAttemptApiDoc
       end
 
       response 401 do
-        key :description, 'Authenticate to access this resource.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
         schema do
           key :'$ref', :AuthErrorModel
         end
       end
 
       response 500 do
-        key :description, 'An error occurred during the operation. See the message for more details.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
         schema do
           key :'$ref', :ErrorModel
         end

--- a/documentation/api/v1/vuln_attempt_api_doc.rb
+++ b/documentation/api/v1/vuln_attempt_api_doc.rb
@@ -50,6 +50,13 @@ module VulnAttemptApiDoc
         end
       end
 
+      response 401 do
+        key :description, 'Authenticate to access this resource.'
+        schema do
+          key :'$ref', :AuthErrorModel
+        end
+      end
+
       response 500 do
         key :description, 'An error occurred during the operation. See the message for more details.'
         schema do
@@ -89,6 +96,13 @@ module VulnAttemptApiDoc
         end
       end
 
+      response 401 do
+        key :description, 'Authenticate to access this resource.'
+        schema do
+          key :'$ref', :AuthErrorModel
+        end
+      end
+
       response 500 do
         key :description, 'An error occurred during the operation. See the message for more details.'
         schema do
@@ -119,6 +133,13 @@ module VulnAttemptApiDoc
           property :data do
             key :'$ref', :VulnAttempt
           end
+        end
+      end
+
+      response 401 do
+        key :description, 'Authenticate to access this resource.'
+        schema do
+          key :'$ref', :AuthErrorModel
         end
       end
 

--- a/documentation/api/v1/workspace_api_doc.rb
+++ b/documentation/api/v1/workspace_api_doc.rb
@@ -43,6 +43,13 @@ module WorkspaceApiDoc
         end
       end
 
+      response 401 do
+        key :description, 'Authenticate to access this resource.'
+        schema do
+          key :'$ref', :AuthErrorModel
+        end
+      end
+
       response 500 do
         key :description, 'An error occurred during the operation. See the message for more details.'
         schema do
@@ -75,6 +82,13 @@ module WorkspaceApiDoc
         end
       end
 
+      response 401 do
+        key :description, 'Authenticate to access this resource.'
+        schema do
+          key :'$ref', :AuthErrorModel
+        end
+      end
+
       response 500 do
         key :description, 'An error occurred during the operation. See the message for more details.'
         schema do
@@ -99,6 +113,13 @@ module WorkspaceApiDoc
               key :'$ref', :Workspace
             end
           end
+        end
+      end
+
+      response 401 do
+        key :description, 'Authenticate to access this resource.'
+        schema do
+          key :'$ref', :AuthErrorModel
         end
       end
 
@@ -135,6 +156,13 @@ module WorkspaceApiDoc
         end
       end
 
+      response 401 do
+        key :description, 'Authenticate to access this resource.'
+        schema do
+          key :'$ref', :AuthErrorModel
+        end
+      end
+
       response 500 do
         key :description, 'An error occurred during the operation. See the message for more details.'
         schema do
@@ -166,6 +194,13 @@ module WorkspaceApiDoc
           property :data do
             key :'$ref', :Workspace
           end
+        end
+      end
+
+      response 401 do
+        key :description, 'Authenticate to access this resource.'
+        schema do
+          key :'$ref', :AuthErrorModel
         end
       end
 

--- a/documentation/api/v1/workspace_api_doc.rb
+++ b/documentation/api/v1/workspace_api_doc.rb
@@ -44,14 +44,14 @@ module WorkspaceApiDoc
       end
 
       response 401 do
-        key :description, 'Authenticate to access this resource.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
         schema do
           key :'$ref', :AuthErrorModel
         end
       end
 
       response 500 do
-        key :description, 'An error occurred during the operation. See the message for more details.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
         schema do
           key :'$ref', :ErrorModel
         end
@@ -74,7 +74,7 @@ module WorkspaceApiDoc
       end
 
       response 200 do
-        key :description, 'Successful operation.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_200
         schema do
           property :data do
             key :'$ref', :Workspace
@@ -83,14 +83,14 @@ module WorkspaceApiDoc
       end
 
       response 401 do
-        key :description, 'Authenticate to access this resource.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
         schema do
           key :'$ref', :AuthErrorModel
         end
       end
 
       response 500 do
-        key :description, 'An error occurred during the operation. See the message for more details.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
         schema do
           key :'$ref', :ErrorModel
         end
@@ -117,14 +117,14 @@ module WorkspaceApiDoc
       end
 
       response 401 do
-        key :description, 'Authenticate to access this resource.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
         schema do
           key :'$ref', :AuthErrorModel
         end
       end
 
       response 500 do
-        key :description, 'An error occurred during the operation. See the message for more details.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
         schema do
           key :'$ref', :ErrorModel
         end
@@ -157,14 +157,14 @@ module WorkspaceApiDoc
       end
 
       response 401 do
-        key :description, 'Authenticate to access this resource.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
         schema do
           key :'$ref', :AuthErrorModel
         end
       end
 
       response 500 do
-        key :description, 'An error occurred during the operation. See the message for more details.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
         schema do
           key :'$ref', :ErrorModel
         end
@@ -189,7 +189,7 @@ module WorkspaceApiDoc
       end
 
       response 200 do
-        key :description, 'Successful operation.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_200
         schema do
           property :data do
             key :'$ref', :Workspace
@@ -198,14 +198,14 @@ module WorkspaceApiDoc
       end
 
       response 401 do
-        key :description, 'Authenticate to access this resource.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
         schema do
           key :'$ref', :AuthErrorModel
         end
       end
 
       response 500 do
-        key :description, 'An error occurred during the operation. See the message for more details.'
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
         schema do
           key :'$ref', :ErrorModel
         end

--- a/lib/msf/core/db_manager/http/servlet/api_docs_servlet.rb
+++ b/lib/msf/core/db_manager/http/servlet/api_docs_servlet.rb
@@ -1,5 +1,6 @@
 require 'swagger/blocks'
 load 'documentation/api/v1/root_api_doc.rb'
+load 'documentation/api/v1/auth_api_doc.rb'
 load 'documentation/api/v1/credential_api_doc.rb'
 load 'documentation/api/v1/db_export_api_doc.rb'
 load 'documentation/api/v1/event_api_doc.rb'
@@ -43,6 +44,7 @@ module ApiDocsServlet
     lambda {
       swaggered_classes = [
           RootApiDoc,
+          AuthApiDoc,
           CredentialApiDoc,
           DbExportApiDoc,
           EventApiDoc,

--- a/lib/msf/core/db_manager/http/servlet/api_docs_servlet.rb
+++ b/lib/msf/core/db_manager/http/servlet/api_docs_servlet.rb
@@ -15,6 +15,7 @@ load 'documentation/api/v1/note_api_doc.rb'
 load 'documentation/api/v1/service_api_doc.rb'
 load 'documentation/api/v1/session_api_doc.rb'
 load 'documentation/api/v1/session_event_api_doc.rb'
+load 'documentation/api/v1/user_api_doc.rb'
 load 'documentation/api/v1/vuln_api_doc.rb'
 load 'documentation/api/v1/vuln_attempt_api_doc.rb'
 load 'documentation/api/v1/workspace_api_doc.rb'
@@ -59,6 +60,7 @@ module ApiDocsServlet
           ServiceApiDoc,
           SessionApiDoc,
           SessionEventApiDoc,
+          UserApiDoc,
           VulnApiDoc,
           VulnAttemptApiDoc,
           WorkspaceApiDoc

--- a/lib/msf/core/db_manager/http/views/api_docs.erb
+++ b/lib/msf/core/db_manager/http/views/api_docs.erb
@@ -79,9 +79,13 @@
                 SwaggerUIBundle.presets.apis,
                 SwaggerUIStandalonePreset
             ],
-            layout: "StandaloneLayout"
-        })
-
+            layout: "StandaloneLayout",
+            requestInterceptor: function (request) {
+                let token = request.headers.Authorization;
+                request.headers.Authorization = "Bearer " + token;
+                return request;
+            }
+        });
         window.ui = ui
     }
 </script>


### PR DESCRIPTION
Adds swagger api documentation for new user authentication functionality
MS-3294

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfdb_ws`
- [x] Click the ![Try it out](https://user-images.githubusercontent.com/41024958/44111802-0e3b74b2-9fc9-11e8-835f-9cbafd2ebdad.png) button on any endpoint, and Execute the function
- [x] **Verify** that you get a 401 Unauthorized Error
- [x] **Verify** that the new Swagger entry for `auth` displays near the top of the page
- [x] Click the ![Try it out](https://user-images.githubusercontent.com/41024958/44111802-0e3b74b2-9fc9-11e8-835f-9cbafd2ebdad.png) button on the auth endpoint, enter your username and password, then click "Execute"
- [x] **Verify** that you get a 200 response that returns an API token
- [x] Click the ![Authorize](https://user-images.githubusercontent.com/41024958/44111826-1eaa72d0-9fc9-11e8-8c10-573630db6ed5.png) button at the top-right of the page, and paste in the API token you just generated
- [x] **Verify** that any API endpoint is now authorized, and returns a 200 response
- [x] **Verify** that the new `user` GET and POST methods display along with their proper request/response models
- [x] **Verify** that all endpoints display the new 401 response model

