### PR TITLE
Prompt to use module when given plain module name

### DIFF
--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -506,12 +506,10 @@ protected
         return
       elsif framework.modules.create(method)
         super
-        print_error("This is a module we can load. Do you want to use #{method}?")
-        old_p = self.prompt.sub /#{self.prompt_char} $/, ''
-        update_prompt "(y/N) ", nil, true
-        resp = get_input_line
-        update_prompt old_p, nil, true
-        run_single "use #{method}" if resp =~ /^y/i
+        if prompt_yesno "This is a module we can load. Do you want to use #{method}?"
+          run_single "use #{method}"
+        end
+
         return
       end
     end

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -504,6 +504,15 @@ protected
         end
         self.busy = false
         return
+      elsif framework.modules.create(method)
+        super
+        print_error("This is a module we can load. Do you want to use #{method}?")
+        old_p = self.prompt.sub /#{self.prompt_char} $/, ''
+        update_prompt "(y/N) ", nil, true
+        resp = get_input_line
+        update_prompt old_p, nil, true
+        run_single "use #{method}" if resp =~ /^y/i
+        return
       end
     end
 

--- a/lib/rex/ui/text/shell.rb
+++ b/lib/rex/ui/text/shell.rb
@@ -429,6 +429,18 @@ protected
     rlog(buf, log_source) if (log_source)
   end
 
+  #
+  # Prompt the user for input if possible. Special edition for use inside commands.
+  #
+  def prompt_yesno(query)
+    p = "#{query} [y/N]"
+    old_p = [self.prompt.sub(/#{self.prompt_char} $/, ''), self.prompt_char]
+    update_prompt p, ' ', true
+    /^y/ === get_input_line
+  ensure
+    update_prompt *old_p, true
+  end
+
   attr_writer   :input, :output # :nodoc:
   attr_accessor :stop_flag, :init_prompt, :cont_prompt # :nodoc:
   attr_accessor :prompt # :nodoc:


### PR DESCRIPTION
During the mini Metasploitable3 CTF, I noticed a lot of people who had trouble getting a module loaded. I have added a piece of fallback code for when just a module name is given on the command line that will prompt the user to see if they wanted to load that module.

## Verification

- [x] Start `msfconsole`
- [x] `exploit/windows/smb/ms08_067_netapi`
- [x] Get prompted
- [x] **Verify** that `y` (and equivalent) loads the module
- [x] **Verify** anything else does not load the module and does not mess up your prompt