### PR TITLE
Fix lurking bugs in the shell's prompt_yesno

### DIFF
--- a/lib/rex/ui/text/shell.rb
+++ b/lib/rex/ui/text/shell.rb
@@ -434,9 +434,9 @@ protected
   #
   def prompt_yesno(query)
     p = "#{query} [y/N]"
-    old_p = [self.prompt.sub(/#{self.prompt_char} $/, ''), self.prompt_char]
+    old_p = [self.prompt.sub(/#{Regexp.escape(self.prompt_char)} $/, ''), self.prompt_char]
     update_prompt p, ' ', true
-    /^y/ === get_input_line
+    /^y/i === get_input_line
   ensure
     update_prompt *old_p, true
   end


### PR DESCRIPTION
Answer regexp was case-sensitive, and if your `promp_char` was `$` (or another regexp special character) hilarity would ensue.

## Verification

- [x] Start `msfconsole`
- [x] `set -g PromptChar $`
- [x] `exploit/windows/smb/ms08_067_netapi`
- [x] Decline to load
- [x] **Verify** your prompt looks normal
- [x] `exploit/windows/smb/ms08_067_netapi`
- [x] `Yes`
- [x] **Verify** The module loads

Fixes #10464.