### PR TITLE
Import target DefaultOptions into the datastore

### DIFF
--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -321,6 +321,9 @@ class Exploit < Msf::Module
       self.active_timeout = info['Payload']['ActiveTimeout'].to_i
     end
 
+    # Initialize exploit datastore with target information
+    import_target_datastore
+
     # All exploits can increase the delay when waiting for a session.
     # However, this only applies to aggressive exploits.
     if aggressive?
@@ -691,6 +694,14 @@ class Exploit < Msf::Module
     end
 
     return (target_idx) ? target_idx.to_i : nil
+  end
+
+  #
+  # Import the target's DefaultOptions hash into the datastore.
+  #
+  def import_target_datastore
+    return unless target && target.default_options
+    datastore.import_options_from_hash(target.default_options)
   end
 
   #

--- a/lib/msf/core/module/target.rb
+++ b/lib/msf/core/module/target.rb
@@ -129,22 +129,29 @@ class Msf::Module::Target
   # 	Payload-specific options, such as append, prepend, and other values that
   # 	can be set on a per-exploit or per-target basis.
   #
+  # DefaultOptions
+  #
+  #   DefaultOptions hash to be imported into the datastore.
+  #
   def initialize(name, opts)
-    opts = {} if (!opts)
+    opts = {} unless opts
 
-    self.name           = name
-    self.platform       = opts['Platform'] ? Msf::Module::PlatformList.transform(opts['Platform']) : nil
-    self.save_registers = opts['SaveRegisters']
-    self.ret            = opts['Ret']
-    self.opts           = opts
+    self.name            = name
+    self.opts            = opts
+    self.save_registers  = opts['SaveRegisters']
+    self.ret             = opts['Ret'],
+    self.default_options = opts['DefaultOptions']
 
-    if (opts['Arch'])
-      self.arch = Rex::Transformer.transform(opts['Arch'], Array,
-        [ String ], 'Arch')
+    if opts['Platform']
+      self.platform = Msf::Module::PlatformList.transform(opts['Platform'])
+    end
+
+    if opts['Arch']
+      self.arch = Rex::Transformer.transform(opts['Arch'], Array, [String], 'Arch')
     end
 
     # Does this target have brute force information?
-    if (opts['Bruteforce'])
+    if opts['Bruteforce']
       self.bruteforce = Bruteforce.new(opts['Bruteforce'])
     end
   end
@@ -305,10 +312,15 @@ class Msf::Module::Target
   # option is passed to the constructor of the class.
   #
   attr_reader :bruteforce
+  #
+  # DefaultOptions hash to be imported into the datastore.
+  #
+  attr_reader :default_options
 
 protected
 
   attr_writer :name, :platform, :arch, :opts, :ret, :save_registers # :nodoc:
   attr_writer :bruteforce # :nodoc:
+  attr_writer :default_options # :nodoc:
 
 end

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1553,7 +1553,7 @@ class Core
     # If the driver indicates that the value is not valid, bust out.
     if (driver.on_variable_set(global, name, value) == false)
       print_error("The value specified for #{name} is not valid.")
-      return true
+      return false
     end
 
     begin
@@ -1565,6 +1565,11 @@ class Core
     rescue OptionValidateError => e
       print_error(e.message)
       elog(e.message)
+    end
+
+    # Set PAYLOAD from TARGET
+    if name.upcase == 'TARGET' && active_module && active_module.exploit?
+      active_module.import_target_datastore
     end
 
     print_line("#{name} => #{datastore[name]}")

--- a/modules/exploits/linux/http/hp_van_sdn_cmd_inject.rb
+++ b/modules/exploits/linux/http/hp_van_sdn_cmd_inject.rb
@@ -16,8 +16,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'HP VAN SDN Controller Root Command Injection',
-      'Description'    => %q{
+      'Name'              => 'HP VAN SDN Controller Root Command Injection',
+      'Description'       => %q{
         This module exploits a hardcoded service token or default credentials
         in HPE VAN SDN Controller <= 2.7.18.0503 to execute a payload as root.
 
@@ -27,34 +27,36 @@ class MetasploitModule < Msf::Exploit::Remote
         If the service token option TOKEN is blank, USERNAME and PASSWORD will
         be used for authentication. An additional login request will be sent.
       },
-      'Author'         => [
+      'Author'            => [
         'Matt Bergin', # Vulnerability discovery and Python exploit
         'wvu'          # Metasploit module and additional ~research~
       ],
-      'References'     => [
+      'References'        => [
         ['EDB', '44951'],
         ['URL', 'https://korelogic.com/Resources/Advisories/KL-001-2018-008.txt']
       ],
-      'DisclosureDate' => 'Jun 25 2018',
-      'License'        => MSF_LICENSE,
-      'Platform'       => ['unix', 'linux'],
-      'Arch'           => [ARCH_CMD, ARCH_X86, ARCH_X64],
-      'Privileged'     => true,
-      'Targets'        => [
+      'DisclosureDate'    => 'Jun 25 2018',
+      'License'           => MSF_LICENSE,
+      'Platform'          => ['unix', 'linux'],
+      'Arch'              => [ARCH_CMD, ARCH_X86, ARCH_X64],
+      'Privileged'        => true,
+      'Targets'           => [
         ['Unix In-Memory',
-         'Platform'    => 'unix',
-         'Arch'        => ARCH_CMD,
-         'Type'        => :unix_memory,
-         'Payload'     => {'BadChars' => ' '}
+         'Platform'       => 'unix',
+         'Arch'           => ARCH_CMD,
+         'Type'           => :unix_memory,
+         'Payload'        => {'BadChars' => ' '},
+         'DefaultOptions' => {'PAYLOAD'  => 'cmd/unix/reverse_netcat_gaping'}
         ],
         ['Linux Dropper',
-         'Platform'    => 'linux',
-         'Arch'        => [ARCH_X86, ARCH_X64],
-         'Type'        => :linux_dropper
+         'Platform'       => 'linux',
+         'Arch'           => [ARCH_X86, ARCH_X64],
+         'Type'           => :linux_dropper,
+         'DefaultOptions' => {'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'}
         ]
       ],
-      'DefaultTarget'  => 0,
-      'DefaultOptions' => {'RPORT' => 8081, 'SSL' => true}
+      'DefaultTarget'     => 0,
+      'DefaultOptions'    => {'RPORT' => 8081, 'SSL' => true}
     ))
 
     register_options([


### PR DESCRIPTION
Now exploits can specify a default payload per target, and when you change the target, you don't necessarily have to change the payload, too.

Note that if you manually set `PAYLOAD`, it'll be reset with the default payload when you change the target. While this might seem undesirable, usually your set `PAYLOAD` wouldn't even be compatible with the new target.

- [x] Test exploit initialization
- [x] Test target setting
- [x] Test manual payload

```
msf5 > use exploit/linux/http/hp_van_sdn_cmd_inject
msf5 exploit(linux/http/hp_van_sdn_cmd_inject) > options

Module options (exploit/linux/http/hp_van_sdn_cmd_inject):

   Name      Current Setting   Required  Description
   ----      ---------------   --------  -----------
   PASSWORD  skyline           no        Service password
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS                      yes       The target address range or CIDR identifier
   RPORT     8081              yes       The target port (TCP)
   SSL       true              no        Negotiate SSL/TLS for outgoing connections
   TOKEN     AuroraSdnToken37  no        Service token
   USERNAME  sdn               no        Service username
   VHOST                       no        HTTP server virtual host


Payload options (cmd/unix/reverse_netcat_gaping):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST                   yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Unix In-Memory


msf5 exploit(linux/http/hp_van_sdn_cmd_inject) > set target 1
target => 1
msf5 exploit(linux/http/hp_van_sdn_cmd_inject) > options

Module options (exploit/linux/http/hp_van_sdn_cmd_inject):

   Name      Current Setting   Required  Description
   ----      ---------------   --------  -----------
   PASSWORD  skyline           no        Service password
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS                      yes       The target address range or CIDR identifier
   RPORT     8081              yes       The target port (TCP)
   SSL       true              no        Negotiate SSL/TLS for outgoing connections
   TOKEN     AuroraSdnToken37  no        Service token
   USERNAME  sdn               no        Service username
   VHOST                       no        HTTP server virtual host


Payload options (linux/x64/meterpreter/reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST                   yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   1   Linux Dropper


msf5 exploit(linux/http/hp_van_sdn_cmd_inject) >
```

Resolves #8676.