### PR TITLE
add. new auxiliary module: behind_cloudflare

### DIFF
--- a/documentation/modules/auxiliary/gather/behind_cloudflare.md
+++ b/documentation/modules/auxiliary/gather/behind_cloudflare.md
@@ -2,9 +2,7 @@
 This module can be useful if you need to test the security of your server and your
 website behind CloudFlare by discovering the real IP address.
 
-More precisely, it is an "hatcloud" implementation for metasploit-framework. With the
-difference that this module operates the verification itself because the Crimeflare databases
-does not seem up to date.
+More precisely, it is an simple "cloudflair" implementation for metasploit-framework.
 
 ## Verification Steps
 
@@ -40,7 +38,23 @@ does not seem up to date.
 
   A proxy chain of format type:host:port[,type:host:port][...]. It's optional.
 
+  **THREADS**
+
+  Number of concurent threads needed for DNS enumeration. Default: 15
+
+  **WORDLIST**
+
+  Name list required for DNS enumeration. Default: ~/metasploit-framework/data/wordlists/namelist.txt
+
 ## Advanced options
+
+  **COMPSTR**
+
+  You can use a custom string to perform the comparison. Default: HOSTNAME if it's empty.
+
+  **NS**
+
+  Specify the nameserver to use for queries. Default: is system DNS
 
   **VERBOSE**
 
@@ -50,15 +64,32 @@ does not seem up to date.
 
 ### For auditing purpose
 
-  If successful, you must be able to obtain the IP address of the website as follows:
+  If successful, you must be able to obtain the IP(s) address of the website as follows:
 
   ```
-  [*] Previous lookups from Crimeflare...
-  [*]  * 2018-08-20 | XXX.XXX.XXX.XXX
+  msf auxiliary(gather/behind_cloudflare) > set verbose true
+  verbose => true
+  msf auxiliary(gather/behind_cloudflare) > run
+
+  [*] Passive gathering information...
+  [*]  * PrePost SEO: 3 IP address found(s).
+  [*]  * DNS Enumeration: 12 IP address found(s).
+  [*] Clean cloudflare server(s)...
+  [+]  * TOTAL: 13 IP address found(s) after cleaning.
   [*] 
-  [*] Bypass Cloudflare is in progress...
-  [*]  * Initial request to the original server for comparison
+  [*] Bypass cloudflare is in progress...
+  [*]  * Trying: XXX.XXX.XXX.XXX:80
   [+] A direct-connect IP address was found: XXX.XXX.XXX.XXX
+  [*]  * Trying: XXX.XXX.XXX.XXX:443
+        --> responded with an unexpected HTTP status code: 302
+  [*]  * Trying: XXX.XXX.XXX.XXX:80
+        --> responded with an unexpected HTTP status code: 301
+  [*]  * Trying: XXX.XXX.XXX.XXX:443
+        --> responded with an unexpected HTTP status code: 404
+  [*]  * Trying: XXX.XXX.XXX.XXX:80
+        --> responded with an unexpected HTTP status code: 302
+  [*]  * Trying: XXX.XXX.XXX.XXX:443
+        --> responded with an unexpected HTTP status code: 404
   [*] Auxiliary module execution completed
   ```
 
@@ -70,19 +101,17 @@ does not seem up to date.
   ```
   msf > use auxiliary/gather/behind_cloudflare
   msf auxiliary(gather/behind_cloudflare) > set HOSTNAME www.zataz.com
-  hostname => adopteunartiste.com
+  hostname => www.zataz.com
   msf auxiliary(gather/behind_cloudflare) > set URIPATH /contacter/
   uripath => /contacter/
+  msf auxiliary(gather/behind_cloudflare) > set compstr Contacter ZATAZ
+  compstr => Contacter ZATAZ
   msf auxiliary(gather/behind_cloudflare) > run
   ...
   ```
-
-## TOTO list
-
-  1. Add other data sources (enumeration DNS, censys, ...)
 
 ## References
 
   1. <http://www.crimeflare.us:82/cfs.html#box>
   2. <https://github.com/HatBashBR>
-
+  3. <https://github.com/christophetd/CloudFlair>

--- a/documentation/modules/auxiliary/gather/behind_cloudflare.md
+++ b/documentation/modules/auxiliary/gather/behind_cloudflare.md
@@ -14,6 +14,19 @@ More precisely, it is an simple "cloudflair" implementation for metasploit-frame
 
 ## Options
 
+  **CENSYS_SECRET**
+
+  Your Censys API SECRET.
+
+  **CENSYS_UID**
+
+  Your Censys API UID.
+
+  **COMPSTR**
+
+  You can use a custom string to perform the comparison. Default: TITLE or HOSTNAME if it's empty.
+  The best way is always to use COMPSTR for a better result.
+
   **HOSTNAME**
 
   This is the hostname [fqdn] on which the website responds. But this can also be a domain.
@@ -21,6 +34,10 @@ More precisely, it is an simple "cloudflair" implementation for metasploit-frame
     msf auxiliary(gather/behind_cloudflare) > set hostname www.zataz.com
     --or--
     msf auxiliary(gather/behind_cloudflare) > set hostname discordapp.com
+
+  **Poxies**
+
+  A proxy chain of format type:host:port[,type:host:port][...]. It's optional.
 
   **RPORT**
 
@@ -30,17 +47,13 @@ More precisely, it is an simple "cloudflair" implementation for metasploit-frame
 
   Negotiate SSL/TLS for outgoing connections. Default: true
 
+  **THREADS**
+
+  Number of concurent threads needed for DNS enumeration. Default: 8
+
   **URIPATH**
 
   The URI path on which to perform the page comparison. Default: '/'
-
-  **Poxies**
-
-  A proxy chain of format type:host:port[,type:host:port][...]. It's optional.
-
-  **THREADS**
-
-  Number of concurent threads needed for DNS enumeration. Default: 15
 
   **WORDLIST**
 
@@ -48,13 +61,17 @@ More precisely, it is an simple "cloudflair" implementation for metasploit-frame
 
 ## Advanced options
 
-  **COMPSTR**
+  **DNSENUM**
 
-  You can use a custom string to perform the comparison. Default: HOSTNAME if it's empty.
+  Set DNS enumeration as optional. Default: true
 
   **NS**
 
   Specify the nameserver to use for queries. Default: is system DNS
+
+  **TIMEOUT**
+
+  HTTP(s) request timeout. Default: 15
 
   **VERBOSE**
 
@@ -67,30 +84,25 @@ More precisely, it is an simple "cloudflair" implementation for metasploit-frame
   If successful, you must be able to obtain the IP(s) address of the website as follows:
 
   ```
-  msf auxiliary(gather/behind_cloudflare) > set verbose true
-  verbose => true
-  msf auxiliary(gather/behind_cloudflare) > run
+msf auxiliary(gather/behind_cloudflare) > set verbose true 
+verbose => true
+msf auxiliary(gather/behind_cloudflare) > run
 
-  [*] Passive gathering information...
-  [*]  * PrePost SEO: 3 IP address found(s).
-  [*]  * DNS Enumeration: 12 IP address found(s).
-  [*] Clean cloudflare server(s)...
-  [+]  * TOTAL: 13 IP address found(s) after cleaning.
-  [*] 
-  [*] Bypass cloudflare is in progress...
-  [*]  * Trying: XXX.XXX.XXX.XXX:80
-  [+] A direct-connect IP address was found: XXX.XXX.XXX.XXX
-  [*]  * Trying: XXX.XXX.XXX.XXX:443
-        --> responded with an unexpected HTTP status code: 302
-  [*]  * Trying: XXX.XXX.XXX.XXX:80
-        --> responded with an unexpected HTTP status code: 301
-  [*]  * Trying: XXX.XXX.XXX.XXX:443
-        --> responded with an unexpected HTTP status code: 404
-  [*]  * Trying: XXX.XXX.XXX.XXX:80
-        --> responded with an unexpected HTTP status code: 302
-  [*]  * Trying: XXX.XXX.XXX.XXX:443
-        --> responded with an unexpected HTTP status code: 404
-  [*] Auxiliary module execution completed
+[*] Passive gathering information...
+[*]  * ViewDNS.info: 36 IP address found(s).
+[*]  * DNS Enumeration: 4 IP address found(s).
+[*]  * Censys IPv4: 2 IP address found(s).
+[*] 
+[*] Clean cloudflare server(s)...
+[+]  * TOTAL: 7 IP address found(s) after cleaning.
+[*] 
+[*] Bypass cloudflare is in progress...
+[*]  * Trying: http://XXX.XXX.XXX.XXX:80/
+      --> responded with an unexpected HTTP status code: 500
+[*]  * Trying: https://XXX.XXX.XXX.XXX:443/
+      --> responded with an unexpected HTTP status code: 500
+[-] No direct-connect IP address found :-(
+[*] Auxiliary module execution completed
   ```
 
   For example:

--- a/documentation/modules/auxiliary/gather/behind_cloudflare.md
+++ b/documentation/modules/auxiliary/gather/behind_cloudflare.md
@@ -2,7 +2,7 @@
 This module can be useful if you need to test the security of your server and your
 website behind CloudFlare by discovering the real IP address.
 
-More precisely, it is an simple "cloudflair" implementation for metasploit-framework.
+More precisely, it is a simple "cloudflair" implementation for metasploit-framework.
 
 ## Verification Steps
 
@@ -35,7 +35,7 @@ More precisely, it is an simple "cloudflair" implementation for metasploit-frame
     --or--
     msf auxiliary(gather/behind_cloudflare) > set hostname discordapp.com
 
-  **Poxies**
+  **Proxies**
 
   A proxy chain of format type:host:port[,type:host:port][...]. It's optional.
 

--- a/documentation/modules/auxiliary/gather/behind_cloudflare.md
+++ b/documentation/modules/auxiliary/gather/behind_cloudflare.md
@@ -1,0 +1,88 @@
+
+This module can be useful if you need to test the security of your server and your
+website behind CloudFlare by discovering the real IP address.
+
+More precisely, it is an "hatcloud" implementation for metasploit-framework. With the
+difference that this module operates the verification itself because the Crimeflare databases
+does not seem up to date.
+
+## Verification Steps
+
+  1. Install the module as usual
+  2. Start msfconsole
+  3. Do: `use auxiliary/gather/behind_cloudflare`
+  4. Do: `set hostname www.zataz.com`
+  5. Do: `run`
+
+## Options
+
+  **HOSTNAME**
+
+  This is the hostname [fqdn] on which the website responds. But this can also be a domain.
+
+    msf auxiliary(gather/behind_cloudflare) > set hostname www.zataz.com
+    --or--
+    msf auxiliary(gather/behind_cloudflare) > set hostname discordapp.com
+
+  **RPORT**
+
+  The target TCP port on which the protected website responds. Default: 443
+
+  **SSL**
+
+  Negotiate SSL/TLS for outgoing connections. Default: true
+
+  **URIPATH**
+
+  The URI path on which to perform the page comparison. Default: '/'
+
+  **Poxies**
+
+  A proxy chain of format type:host:port[,type:host:port][...]. It's optional.
+
+## Advanced options
+
+  **VERBOSE**
+
+  You can also enable the verbose mode to have more information displayed in the console.
+
+## Scenarios
+
+### For auditing purpose
+
+  If successful, you must be able to obtain the IP address of the website as follows:
+
+  ```
+  [*] Previous lookups from Crimeflare...
+  [*]  * 2018-08-20 | XXX.XXX.XXX.XXX
+  [*] 
+  [*] Bypass Cloudflare is in progress...
+  [*]  * Initial request to the original server for comparison
+  [+] A direct-connect IP address was found: XXX.XXX.XXX.XXX
+  [*] Auxiliary module execution completed
+  ```
+
+  For example:
+
+  For some reason you may need to change the URI path to interoperate with other than the index page.
+  To do this specific thing:
+
+  ```
+  msf > use auxiliary/gather/behind_cloudflare
+  msf auxiliary(gather/behind_cloudflare) > set HOSTNAME www.zataz.com
+  hostname => adopteunartiste.com
+  msf auxiliary(gather/behind_cloudflare) > set URIPATH /contacter/
+  uripath => /contacter/
+  msf auxiliary(gather/behind_cloudflare) > run
+  ...
+  ```
+
+## TOTO list
+
+  1. Add other data sources (enumeration DNS, censys, ...)
+
+## References
+
+  1. <http://www.crimeflare.us:82/cfs.html#box>
+  2. <https://github.com/HatBashBR>
+

--- a/modules/auxiliary/gather/behind_cloudflare.rb
+++ b/modules/auxiliary/gather/behind_cloudflare.rb
@@ -2,7 +2,7 @@
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
-# rev: 1.1.6
+# rev: 1.1.7
 
 class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Report
@@ -199,7 +199,8 @@ class MetasploitModule < Msf::Auxiliary
 
       request = http.request_raw({
         'uri'     => uri,
-        'method'  => 'GET'
+        'method'  => 'GET',
+        'agent'   => 'Mozilla/5.0 (Windows NT 10.0; WOW64; rv:56.0) Gecko/20100101 Firefox/56.0'
       })
       response = http.send_recv(request)
       http.close

--- a/modules/auxiliary/gather/behind_cloudflare.rb
+++ b/modules/auxiliary/gather/behind_cloudflare.rb
@@ -1,7 +1,8 @@
 ##
-# This module requires Metasploit: http://metasploit.com/download
+# This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
+# rev: 1.1.4
 
 class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Report
@@ -9,7 +10,6 @@ class MetasploitModule < Msf::Auxiliary
   def initialize(info = {})
     super(update_info(info,
       'Name'           => 'Behind CloudFlare',
-      'Version'        => '$Release: 1.1.2',
       'Description'    => %q{
         This module can be useful if you need to test
         the security of your server and your website
@@ -29,22 +29,23 @@ class MetasploitModule < Msf::Auxiliary
 
     register_options(
       [
+        OptString.new('CENSYS_SECRET', [false, 'The Censys API SECRET']),
+        OptString.new('CENSYS_UID', [false, 'The Censys API UID']),
+        OptString.new('COMPSTR', [false, 'You can use a custom string to perform the comparison (read documentation)']),
         OptString.new('HOSTNAME', [true, 'The hostname or domain name where we want to find the real IP address']),
-        OptString.new('URIPATH', [true, 'The URI path on which to perform the page comparison', '/']),
+        OptString.new('Proxies', [false, 'A proxy chain of format type:host:port[,type:host:port][...]']),
         OptInt.new('RPORT', [true, 'The target TCP port on which the protected website responds', 443]),
         OptBool.new('SSL', [true, 'Negotiate SSL/TLS for outgoing connections', true]),
-        OptString.new('Proxies', [false, 'A proxy chain of format type:host:port[,type:host:port][...]']),
         OptInt.new('THREADS', [true, 'Threads for DNS enumeration', 15]),
-        OptPath.new('WORDLIST', [true, 'Wordlist of subdomains', ::File.join(Msf::Config.data_directory, 'wordlists', 'namelist.txt')]),
-        OptString.new('CENSYS_UID', [false, 'The Censys API UID']),
-        OptString.new('CENSYS_SECRET', [false, 'The Censys API SECRET'])
+        OptString.new('URIPATH', [true, 'The URI path on which to perform the page comparison', '/']),
+        OptPath.new('WORDLIST', [false, 'Wordlist of subdomains', ::File.join(Msf::Config.data_directory, 'wordlists', 'namelist.txt')])
       ])
 
-      register_advanced_options(
-        [
-          OptString.new('COMPSTR', [false, 'You can use a custom string to perform the comparison (default is HOSTNAME).']),
-          OptAddress.new('NS', [false, 'Specify the nameserver to use for queries (default is system DNS)'])
-        ])
+    register_advanced_options(
+      [
+        OptBool.new('DNSENUM', [true, 'Set DNS enumeration as optional', true]),
+        OptAddress.new('NS', [false, 'Specify the nameserver to use for queries (default is system DNS)'])
+      ])
   end
 
   def do_check_tcp_port(ip, port, proxies)
@@ -63,35 +64,36 @@ class MetasploitModule < Msf::Auxiliary
 
   def do_grab_domain_ip_history(hostname, proxies)
     begin
-      cli = Rex::Proto::Http::Client.new('www.prepostseo.com', 443, {}, true, nil, proxies)
+      cli = Rex::Proto::Http::Client.new('viewdns.info', 443, {}, true, nil, proxies)
       cli.connect
 
       request = cli.request_cgi({
-        'uri'    => '/domain-ip-history-checker',
-        'method' => 'POST',
-        'data'   => "url=#{hostname}&submit=Check+Reverse+Ip+Domains"
+        'uri'    => "/iphistory/?domain=#{hostname}",
+        'method' => 'GET'
       })
       response = cli.send_recv(request)
       cli.close
 
     rescue ::Rex::ConnectionError, Errno::ECONNREFUSED, Errno::ETIMEDOUT
-      print_error('HTTP connection failed to PrePost SEO website.')
+      print_error('HTTP connection failed to ViewDNS.info website.')
       return false
     end
 
     html  = response.get_html_document
-    table = html.css('table.table').first
-    rows  = table.css('tr')
+    table = html.css('table')[3]
 
-    ar_ips = []
-    rows.each_with_index.map do | row, index |
-      row = /(\d*\.\d*\.\d*\.\d*)/.match(row.css('td').map(&:text).to_s)
-      unless row.nil?
-        ar_ips.push(row)
+    unless table.nil?
+      rows   = table.css('tr')
+      ar_ips = []
+      rows.each.map do | row |
+        row = /(\d*\.\d*\.\d*\.\d*)/.match(row.css('td').map(&:text).to_s)
+        unless row.nil?
+          ar_ips.push(row)
+        end
       end
     end
 
-    if ar_ips.empty?
+    if ar_ips.nil?
       print_bad('No domain IP(s) history founds.')
       return false
     end
@@ -156,24 +158,22 @@ class MetasploitModule < Msf::Auxiliary
 
   ## auxiliary/gather/enum_dns.rb
   def do_dns_query(domain, type)
-    begin
-      nameserver         = datastore['NS']
+    nameserver         = datastore['NS']
 
-      if nameserver.blank?
-        dns = Net::DNS::Resolver.new
-      else
-        dns = Net::DNS::Resolver.new(nameservers: ::Rex::Socket.resolv_to_dotted(nameserver))
-      end
-
-      dns.use_tcp        = false
-      dns.udp_timeout    = 8
-      dns.retry_number   = 2
-      dns.retry_interval = 2
-      dns.query(domain, type)
-    rescue ResolverArgumentError, Errno::ETIMEDOUT, ::NoResponseError, ::Timeout::Error => e
-      print_error("Query #{domain} DNS #{type} - exception: #{e}")
-      return nil
+    if nameserver.blank?
+      dns = Net::DNS::Resolver.new
+    else
+      dns = Net::DNS::Resolver.new(nameservers: ::Rex::Socket.resolv_to_dotted(nameserver))
     end
+
+    dns.use_tcp        = false
+    dns.udp_timeout    = 8
+    dns.retry_number   = 2
+    dns.retry_interval = 2
+    dns.query(domain, type)
+  rescue ResolverArgumentError, Errno::ETIMEDOUT, ::NoResponseError, ::Timeout::Error => e
+    print_error("Query #{domain} DNS #{type} - exception: #{e}")
+    return nil
   end
 
   ## auxiliary/gather/enum_dns.rb
@@ -235,7 +235,7 @@ class MetasploitModule < Msf::Auxiliary
 
     # Check for "misconfigured" web server on TCP/80.
     if do_check_tcp_port(ip, 80, proxies)
-      vprint_status(" * Trying: #{ip}:80")
+      vprint_status(" * Trying: http://#{ip}:80/")
       response = do_simple_get_request_raw(ip, 80, false, host, uri, proxies)
       if response != false
 
@@ -243,7 +243,7 @@ class MetasploitModule < Msf::Auxiliary
           html = response.get_html_document
 
           if html.at(tag).to_s.include? fingerprint.to_s
-            print_good("A direct-connect IP address was found: #{ip}")
+            print_good("A direct-connect IP address was found: http://#{ip}:80/")
             do_save_note(host, ip, 'http')
             ret_value = true
           end
@@ -255,7 +255,7 @@ class MetasploitModule < Msf::Auxiliary
 
     # Check for "misconfigured" web server on TCP/443.
     if do_check_tcp_port(ip, 443, proxies)
-      vprint_status(" * Trying: #{ip}:443")
+      vprint_status(" * Trying: https://#{ip}:443/")
       response = do_simple_get_request_raw(ip, 443, true, host, uri, proxies)
       if response != false
 
@@ -263,7 +263,7 @@ class MetasploitModule < Msf::Auxiliary
           if response != false
             html = response.get_html_document
             if html.at(tag).to_s.include? fingerprint.to_s
-              print_good("A direct-connect IP address was found: #{ip}")
+              print_good("A direct-connect IP address was found: https://#{ip}:443/")
               do_save_note(host, ip, 'https')
               ret_value = true
             end
@@ -338,18 +338,20 @@ class MetasploitModule < Msf::Auxiliary
     domain_name   = PublicSuffix.parse(datastore['HOSTNAME']).domain
     ip_list       = []
 
-    # PrePost SEO
+    # ViewDNS.info
     ip_records    = do_grab_domain_ip_history(domain_name, datastore['Proxies'])
     ip_list      |= ip_records unless ip_records.eql? false
     unless ip_records.eql? false
-      print_status(" * PrePost SEO: #{ip_records.count.to_s} IP address found(s).")
+      print_status(" * ViewDNS.info: #{ip_records.count.to_s} IP address found(s).")
     end
 
     # DNS Enum.
-    ip_records   = do_dns_enumeration(domain_name, datastore['THREADS'])
-    ip_list     |= ip_records unless ip_records.eql? false
-    unless ip_records.eql? false
-      print_status(" * DNS Enumeration: #{ip_records.count.to_s} IP address found(s).")
+    if datastore['DNSENUM'].eql? true
+      ip_records   = do_dns_enumeration(domain_name, datastore['THREADS'])
+      ip_list     |= ip_records unless ip_records.eql? false
+      unless ip_records.eql? false
+        print_status(" * DNS Enumeration: #{ip_records.count.to_s} IP address found(s).")
+      end
     end
 
     # Censys search.
@@ -362,79 +364,82 @@ class MetasploitModule < Msf::Auxiliary
       end
     end
 
-    unless ip_list.empty?
+    if ip_list.empty?
+      print_bad('No IP address found :-(')
+      return
+    end
 
-      # Cleaning the results.
-      print_status("Clean cloudflare server(s)...")
-      ip_blacklist = get_cloudflare_ips
-      records      = []
-      ip_list.uniq.each do | ip |
-        is_listed = false
+    # Cleaning the results.
+    print_status("Clean cloudflare server(s)...")
+    ip_blacklist = get_cloudflare_ips
+    records      = []
+    ip_list.uniq.each do | ip |
+      is_listed = false
 
-        ip_blacklist.each do | ip_range |
-          if IPAddr.new(ip_range).include? ip.to_s
-            is_listed = true
-            break
-          end
-        end
-
-        unless is_listed.eql? true
-          records << ip.to_s
+      ip_blacklist.each do | ip_range |
+        if IPAddr.new(ip_range).include? ip.to_s
+          is_listed = true
+          break
         end
       end
 
-      if records.empty?
-        print_bad(" * TOTAL: #{records.count.to_s} IP address found(s) after cleaning.")
-      else
-        print_good(" * TOTAL: #{records.uniq.count.to_s} IP address found(s) after cleaning.")
-        print_status()
-
-        # Processing bypass...
-        print_status('Bypass cloudflare is in progress...')
-
-        if datastore['COMPSTR'].nil?
-          tag         = 'title'
-
-          # Initial HTTP request to the server (for <title> comparison).
-          print_status(' * Initial request to the original server for comparison')
-          response    = do_simple_get_request_raw(
-            datastore['HOSTNAME'],
-            datastore['RPORT'],
-            datastore['SSL'],
-            nil,
-            datastore['URIPATH'],
-            datastore['PROXIES']
-          )
-          html        = response.get_html_document
-          fingerprint = html.at(tag).text
-          if fingerprint.eql? 'Attention Required! | Cloudflare'
-            tag         = 'html'
-            fingerprint = datastore['HOSTNAME']
-          end
-        else
-          tag         = 'html'
-          fingerprint = datastore['COMPSTR']
-        end
-
-        ret_val  = false
-        records.uniq.each do | ip |
-
-          found = do_check_bypass(
-            fingerprint,
-            tag,
-            datastore['HOSTNAME'],
-            ip,
-            datastore['URIPATH'],
-            datastore['PROXIES']
-          )
-          ret_val = true if found.eql? true
-        end
-      end
-
-      unless ret_val.eql? true
-        print_bad('No direct-connect IP address found :-(')
+      unless is_listed.eql? true
+        records << ip.to_s
       end
     end
-  end
 
+    if records.empty?
+      print_bad("No IP address found after cleaning.")
+      return
+    end
+
+    print_good(" * TOTAL: #{records.uniq.count.to_s} IP address found(s) after cleaning.")
+    print_status()
+
+    # Processing bypass...
+    print_status('Bypass cloudflare is in progress...')
+
+    if datastore['COMPSTR'].nil?
+      tag         = 'title'
+
+      # Initial HTTP request to the server (for <title> comparison).
+      print_status(' * Initial request to the original server for comparison')
+      response    = do_simple_get_request_raw(
+        datastore['HOSTNAME'],
+        datastore['RPORT'],
+        datastore['SSL'],
+        nil,
+        datastore['URIPATH'],
+        datastore['PROXIES']
+      )
+      html        = response.get_html_document
+      fingerprint = html.at(tag).text
+      if fingerprint.eql? 'Attention Required! | Cloudflare'
+        tag         = 'html'
+        fingerprint = datastore['HOSTNAME']
+      end
+    else
+      tag         = 'html'
+      fingerprint = datastore['COMPSTR']
+    end
+
+    ret_val  = false
+    records.uniq.each do | ip |
+
+      found = do_check_bypass(
+        fingerprint,
+        tag,
+        datastore['HOSTNAME'],
+        ip,
+        datastore['URIPATH'],
+        datastore['PROXIES']
+      )
+      ret_val = true if found.eql? true
+    end
+
+    unless ret_val.eql? true
+      print_bad('No direct-connect IP address found :-(')
+    end
+
+  end
 end

--- a/modules/auxiliary/gather/behind_cloudflare.rb
+++ b/modules/auxiliary/gather/behind_cloudflare.rb
@@ -8,7 +8,7 @@ class MetasploitModule < Msf::Auxiliary
   def initialize(info = {})
     super(update_info(info,
       'Name'           => 'Behind CloudFlare',
-      'Version' => '$Release: 1.0.1',
+      'Version'        => '$Release: 1.0.2',
       'Description'    => %q{
         This module can be useful if you need to test
         the security of your server and your website
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Auxiliary
         'mekhalleh',
         'RAMELLA Sébastien <sebastien.ramella[at]Pirates.RE>'
       ],
-      'References' => [
+      'References'     => [
         ['URL', 'http://www.crimeflare.com/cfs.html'],
         ['URL', 'https://github.com/HatBashBR/HatCloud']
       ],
@@ -50,60 +50,60 @@ class MetasploitModule < Msf::Auxiliary
 
     rescue ::Rex::ConnectionError, Errno::ECONNREFUSED, Errno::ETIMEDOUT
       print_error('HTTP connection failed to Crimflare website.')
-      return(false)
+      return false
     end
 
     html  = response.get_html_document
     unless /No working nameservers are registered/.match(html).nil? then
       print_bad('No working nameservers are registered! :(')
-      return(false)
+      return false
     end
 
-    arIps = Array.new
+    arIps = []
     rows  = html.search('li')
     rows.each_with_index do | row, index |
       date = /(\d*\-\d*\-\d*)/.match(row)
       arIps.push(/(\d*\.\d*\.\d*\.\d*)/.match(row))
-      print_status("  * #{date} | #{arIps[index]}")
+      print_status(" * #{date} | #{arIps[index]}")
     end
 
-    if arIps.empty? then
+    if arIps.empty?
       print_bad('No previous lookups founds.')
-      return(false)
+      return false
     end
 
-    return(arIps)
+    return arIps
   end
 
   def do_check_bypass(fingerprint, host, ip, uri, proxies)
 
     # Check for "misconfigured" web server on TCP/80.
-    if do_check_tcp_port(ip, 80, proxies) then
+    if do_check_tcp_port(ip, 80, proxies)
       response = do_simple_get_request_raw(ip, 80, false, host, uri, proxies)
 
-      if response != false then
+      if response != false
         html = response.get_html_document
-        if fingerprint.to_s.eql? html.at('head').to_s then
+        if fingerprint.to_s.eql? html.at('head').to_s
           print_good("A direct-connect IP address was found: #{ip}")
-          return(true)
+          return true
         end
       end
     end
 
     # Check for "misconfigured" web server on TCP/443.
-    if do_check_tcp_port(ip, 443, proxies) then
+    if do_check_tcp_port(ip, 443, proxies)
       response = do_simple_get_request_raw(ip, 443, true, host, uri, proxies)
 
-      if response != false then
+      if response != false
         html = response.get_html_document
-        if fingerprint.to_s.eql? html.at('head').to_s then
+        if fingerprint.to_s.eql? html.at('head').to_s
           print_good("A direct-connect IP address was found: #{ip}")
-          return(true)
+          return true
         end
       end
     end
 
-    return(false)
+    return false
   end
 
   def do_check_tcp_port(ip, port, proxies)
@@ -114,10 +114,10 @@ class MetasploitModule < Msf::Auxiliary
         'Proxies'  => proxies
       )
     rescue ::Rex::ConnectionRefused, Rex::ConnectionError
-      return(false)
+      return false
     end
     sock.close
-    return(true)
+    return true
   end
 
   ## TODO: Improve on-demand response (send_recv? Timeout).
@@ -126,7 +126,7 @@ class MetasploitModule < Msf::Auxiliary
       http    = Rex::Proto::Http::Client.new(host, port, {}, ssl, nil, proxies)
       http.connect
 
-      unless host_header.eql? nil then
+      unless host_header.eql? nil
         http.set_config({ 'vhost' => host_header })
       end
 
@@ -139,10 +139,10 @@ class MetasploitModule < Msf::Auxiliary
 
     rescue ::Rex::ConnectionError, Errno::ECONNREFUSED, Errno::ETIMEDOUT
       print_error('HTTP Connection Failed')
-      return(false)
+      return false
     end
 
-    return(response)
+    return response
   end
 
   ## TODO: Improve the efficiency by mixing the sources (dnsenum, censys, shodan, ...).
@@ -153,7 +153,7 @@ class MetasploitModule < Msf::Auxiliary
     ip_list     = do_crimflare_request(datastore['HOSTNAME'], datastore['PROXIES'])
     print_status()
 
-    unless ip_list.eql? false then
+    unless ip_list.eql? false
       print_status('Bypass Cloudflare is in progress...')
 
       # Initial HTTP request to the server (for <head> comparison).
@@ -185,7 +185,7 @@ class MetasploitModule < Msf::Auxiliary
       end
     end
 
-    if ret_val.eql? false then
+    if ret_val.eql? false
       print_bad('No direct-connect IP address found :-(')
     end
   end

--- a/modules/auxiliary/gather/behind_cloudflare.rb
+++ b/modules/auxiliary/gather/behind_cloudflare.rb
@@ -2,7 +2,7 @@
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
-# rev: 1.1.5
+# rev: 1.1.6
 
 class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Report

--- a/modules/auxiliary/gather/behind_cloudflare.rb
+++ b/modules/auxiliary/gather/behind_cloudflare.rb
@@ -2,7 +2,7 @@
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
-# rev: 1.1.4
+# rev: 1.1.5
 
 class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Report
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('Proxies', [false, 'A proxy chain of format type:host:port[,type:host:port][...]']),
         OptInt.new('RPORT', [true, 'The target TCP port on which the protected website responds', 443]),
         OptBool.new('SSL', [true, 'Negotiate SSL/TLS for outgoing connections', true]),
-        OptInt.new('THREADS', [true, 'Threads for DNS enumeration', 15]),
+        OptInt.new('THREADS', [true, 'Threads for DNS enumeration', 8]),
         OptString.new('URIPATH', [true, 'The URI path on which to perform the page comparison', '/']),
         OptPath.new('WORDLIST', [false, 'Wordlist of subdomains', ::File.join(Msf::Config.data_directory, 'wordlists', 'namelist.txt')])
       ])
@@ -44,7 +44,8 @@ class MetasploitModule < Msf::Auxiliary
     register_advanced_options(
       [
         OptBool.new('DNSENUM', [true, 'Set DNS enumeration as optional', true]),
-        OptAddress.new('NS', [false, 'Specify the nameserver to use for queries (default is system DNS)'])
+        OptAddress.new('NS', [false, 'Specify the nameserver to use for queries (default is system DNS)']),
+        OptInt.new('TIMEOUT', [true, 'HTTP(s) request timeout', 15])
       ])
   end
 
@@ -190,7 +191,7 @@ class MetasploitModule < Msf::Auxiliary
   def do_simple_get_request_raw(host, port, ssl, host_header=nil, uri, proxies)
     begin
       http    = Rex::Proto::Http::Client.new(host, port, {}, ssl, nil, proxies)
-      http.connect
+      http.connect(datastore['TIMEOUT'])
 
       unless host_header.eql? nil
         http.set_config({ 'vhost' => host_header })

--- a/modules/auxiliary/gather/behind_cloudflare.rb
+++ b/modules/auxiliary/gather/behind_cloudflare.rb
@@ -1,0 +1,182 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Behind CloudFlare',
+      'Version' => '$Release: 1.0',
+      'Description'    => %q{
+        This module can be useful if you need to test
+        the security of your server and your website
+        behind CloudFlare by discovering the real IP address.
+      },
+      'Author'         => [
+        'mekhalleh',
+        'RAMELLA Sébastien <sebastien.ramella[at]Pirates.RE>'
+      ],
+      'References' => [
+        ['URL', 'http://www.crimeflare.com/cfs.html'],
+        ['URL', 'https://github.com/HatBashBR/HatCloud']
+      ],
+      'License'        => MSF_LICENSE
+    ))
+
+    register_options(
+      [
+        OptString.new('HOSTNAME', [true, 'The hostname to find real IP', 'discordapp.com']),
+        OptString.new('URIPATH', [true, 'The URI path (for custom comparison)', '/']),
+        OptString.new('RPORT', [true, 'The target port (for custom comparison)', '443']),
+        OptString.new('SSL', [true, 'Negotiate SSL/TLS for outgoing connections (for custom comparison)', true]),
+        OptString.new('Proxies', [false, 'A proxy chain of format type:host:port[,type:host:port][...]'])
+      ])
+  end
+
+  def do_crimflare_request(hostname, proxies)
+    begin
+      cli = Rex::Proto::Http::Client.new('www.crimeflare.us', 82, {}, false, nil, proxies)
+      cli.connect
+
+      request = cli.request_cgi({
+        'uri'    => '/cgi-bin/cfsearch.cgi',
+        'method' => 'POST',
+        'data'   => "cfS=#{hostname}"
+      })
+      response = cli.send_recv(request)
+      cli.close
+
+    rescue ::Rex::ConnectionError, Errno::ECONNREFUSED, Errno::ETIMEDOUT
+      print_error('HTTP connection failed to Crimflare website.')
+      return(false)
+    end
+
+    html  = response.get_html_document
+    unless /No working nameservers are registered/.match(html).nil? then
+      print_bad('No working nameservers are registered! :(')
+      return(false)
+    end
+
+    print_status('Previous lookups for this domain')
+    arIps = Array.new
+    rows  = html.search('li')
+    rows.each_with_index do | row, index |
+      date = /(\d*\-\d*\-\d*)/.match(row)
+      arIps.push(/(\d*\.\d*\.\d*\.\d*)/.match(row))
+      print_line("  * #{index} | #{date} | #{arIps[index]}")
+    end
+
+    if arIps.empty? then
+      print_bad('No previous lookups founds.')
+      return(false)
+    end
+
+    return(arIps)
+  end
+
+  ## TODO: Improve the comparison module (more efficient).
+  def do_check_bypass(host, ip, port, ssl, uri, proxies)
+
+    # Initial HTTP request to the server (for <title> comparison).
+    response = do_simple_get_request_raw(host, port, ssl, nil, uri, proxies)
+    html     = response.get_html_document
+    web_sign = html.at('title')
+
+    # Check for "misconfigured" web server on TCP/80.
+    if do_check_tcp_port(ip, port, proxies) then
+      response = do_simple_get_request_raw(ip, 80, false, host, uri, proxies)
+
+      if response != false then
+        html = response.get_html_document
+        sign = html.at('title')
+        if web_sign.to_s.eql? sign.to_s then
+          print_good("A direct-connect IP address was found: #{ip}")
+          return(true)
+        end
+      end
+    end
+
+    # Check for "misconfigured" web server on TCP/443.
+    if do_check_tcp_port(ip, 443, proxies) then
+      response = do_simple_get_request_raw(ip, 443, true, host, uri, proxies)
+
+      if response != false then
+        html = response.get_html_document
+        sign = html.at('title')
+        if web_sign.to_s.eql? sign.to_s then
+          print_good("A direct-connect IP address was found: #{ip}")
+          return(true)
+        end
+      end
+    end
+
+    return(false)
+  end
+
+  def do_check_tcp_port(ip, port, proxies)
+    begin
+      sock = Rex::Socket::Tcp.create(
+        'PeerHost' => ip,
+        'PeerPort' => port,
+        'Proxies'  => proxies
+      )
+    rescue ::Rex::ConnectionRefused, Rex::ConnectionError
+      return(false)
+    end
+    sock.close
+    return(true)
+  end
+
+  ## TODO: Improve on-demand response (send_recv? Timeout).
+  def do_simple_get_request_raw(host, port, ssl, host_header=nil, uri, proxies)
+    begin
+      http    = Rex::Proto::Http::Client.new(host, port, {}, ssl, nil, proxies)
+      http.connect
+
+      unless host_header.eql? nil then
+        http.set_config({ 'vhost' => host_header })
+      end
+
+      request = http.request_raw({
+        'uri'     => uri,
+        'method'  => 'GET'
+      })
+      response = http.send_recv(request)
+      http.close
+
+    rescue ::Rex::ConnectionError, Errno::ECONNREFUSED, Errno::ETIMEDOUT
+      print_error('HTTP Connection Failed')
+      return(false)
+    end
+
+    return(response)
+  end
+
+  ## TODO: Improve the efficiency by mixing the sources (dnsenum, censys, shodan, ...).
+  def run
+    ip_list = do_crimflare_request(datastore['HOSTNAME'], datastore['PROXIES'])
+    unless ip_list.eql? false then
+      print_status('Bypass Cloudflare is in progress...')
+
+      ret_val = false
+      ip_list.each_with_index do | ip, index |
+        ret_val = do_check_bypass(
+          datastore['HOSTNAME'],
+          ip[index].to_s,
+          datastore['RPORT'].to_i,
+          datastore['SSL'],
+          datastore['URIPATH'],
+          datastore['PROXIES']
+        )
+        break if ret_val.eql? true
+      end
+    end
+
+    if ret_val.eql? false then
+      print_bad('No direct-connect IP address found :-(')
+    end
+  end
+
+end


### PR DESCRIPTION
This module can help you to discover the real IP address behind the Cloudflare service.

More precisely, it is an simple "cloudflair" implementation for metasploit-framework.

## Verification Steps

  1. Install the module as usual
  2. Start msfconsole
  3. Do: `use auxiliary/gather/behind_cloudflare`
  4. Do: `set hostname www.zataz.com`
  5. Do: `run`

## Options

  **HOSTNAME**

  This is the hostname [fqdn] on which the website responds. But this can also be a domain.

    msf auxiliary(gather/behind_cloudflare) > set hostname www.zataz.com
    --or--
    msf auxiliary(gather/behind_cloudflare) > set hostname discordapp.com

  **RPORT**

  The target TCP port on which the protected website responds. Default: 443

  **SSL**

  Negotiate SSL/TLS for outgoing connections. Default: true

  **URIPATH**

  The URI path on which to perform the page comparison. Default: '/'

  **Poxies**

  A proxy chain of format type:host:port[,type:host:port][...]. It's optional.

  **THREADS**

  Number of concurent threads needed for DNS enumeration. Default: 15

  **WORDLIST**

  Name list required for DNS enumeration. Default: ~/metasploit-framework/data/wordlists/namelist.txt

## Advanced options

  **COMPSTR**

  You can use a custom string to perform the comparison. Default: HOSTNAME if it's empty.

  **NS**

  Specify the nameserver to use for queries. Default: is system DNS

  **VERBOSE**

  You can also enable the verbose mode to have more information displayed in the console.

## Scenarios

### For auditing purpose

  If successful, you must be able to obtain the IP(s) address of the website as follows:

  ```
  msf auxiliary(gather/behind_cloudflare) > set verbose true
  verbose => true
  msf auxiliary(gather/behind_cloudflare) > run

  [*] Passive gathering information...
  [*]  * PrePost SEO: 3 IP address found(s).
  [*]  * DNS Enumeration: 12 IP address found(s).
  [*] Clean cloudflare server(s)...
  [+]  * TOTAL: 13 IP address found(s) after cleaning.
  [*] 
  [*] Bypass cloudflare is in progress...
  [*]  * Trying: XXX.XXX.XXX.XXX:80
  [+] A direct-connect IP address was found: XXX.XXX.XXX.XXX
  [*]  * Trying: XXX.XXX.XXX.XXX:443
        --> responded with an unexpected HTTP status code: 302
  [*]  * Trying: XXX.XXX.XXX.XXX:80
        --> responded with an unexpected HTTP status code: 301
  [*]  * Trying: XXX.XXX.XXX.XXX:443
        --> responded with an unexpected HTTP status code: 404
  [*]  * Trying: XXX.XXX.XXX.XXX:80
        --> responded with an unexpected HTTP status code: 302
  [*]  * Trying: XXX.XXX.XXX.XXX:443
        --> responded with an unexpected HTTP status code: 404
  [*] Auxiliary module execution completed
  ```

  For example:

  For some reason you may need to change the URI path to interoperate with other than the index page.
  To do this specific thing:

  ```
  msf > use auxiliary/gather/behind_cloudflare
  msf auxiliary(gather/behind_cloudflare) > set HOSTNAME www.zataz.com
  hostname => www.zataz.com
  msf auxiliary(gather/behind_cloudflare) > set URIPATH /contacter/
  uripath => /contacter/
  msf auxiliary(gather/behind_cloudflare) > set compstr Contacter ZATAZ
  compstr => Contacter ZATAZ
  msf auxiliary(gather/behind_cloudflare) > run
  ...
  ```

![01-demo](https://user-images.githubusercontent.com/5225129/44612775-41b91780-a81c-11e8-9752-c85c0d747f36.png)
![02-demo](https://user-images.githubusercontent.com/5225129/44612778-467dcb80-a81c-11e8-902c-6ae153eb5e41.png)
![03-demo](https://user-images.githubusercontent.com/5225129/44612789-5d242280-a81c-11e8-8f05-f14c75da588d.png)

