### PR TITLE
fix match error in ppc simple nop generator

### DIFF
--- a/modules/nops/ppc/simple.rb
+++ b/modules/nops/ppc/simple.rb
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Nop
     badchars = opts['BadChars'] || ''
     random   = opts['Random']   || datastore['RandomNops']
 
-    if( random and random.match(/^(t|y|1)/i) )
+    if( random and random.to_s.match(/^(t|y|1)/i) )
       1.upto(1024) do |i|
         regs_d = (rand(0x8000 - 0x0800) + 0x0800).to_i
         regs_b = [regs_d].pack('n').unpack('B*')[0][1, 15]


### PR DESCRIPTION
before changes:
```
msf5 nop(ppc/simple) > generate 10
[-] Sled generation failed: undefined method `match' for true:TrueClass.
```

After changes
```
msf5 nop(ppc/simple) > generate 10
buf =
"\x7c\xf6\xc2\x15\x7c\xf6\xc2\x15"
```