### PR TITLE
show help when no argument is provided to `show`

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -488,8 +488,6 @@ module Msf
             
             mod = self.active_module
 
-            args << "all" if (args.length == 0)
-
             args.each { |type|
               case type
                 when '-h'

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -480,6 +480,12 @@ module Msf
           # no type is provided.
           #
           def cmd_show(*args)
+            if args.empty?
+              print_error("Argument required\n")
+              cmd_show_help
+              return
+            end
+            
             mod = self.active_module
 
             args << "all" if (args.length == 0)


### PR DESCRIPTION
Similar to `search` command (https://github.com/rapid7/metasploit-framework/pull/9871)
`show` with no arguments should show error rather than showing all the modules.