### PR TITLE
Add post authentication information in modules

### DIFF
--- a/lib/msf/core/auxiliary/auth_brute.rb
+++ b/lib/msf/core/auxiliary/auth_brute.rb
@@ -43,9 +43,9 @@ module Auxiliary::AuthBrute
         be tried up to the MaxGuessesPerUser limit.	If set to zero or a non-number,
         this option will not be used.}.gsub(/[\t\r\n\s]+/nm,"\s"), 0]) # Tracked in @@brute_start_time
     ], Auxiliary::AuthBrute)
-
-
   end
+
+  def 
 
   def setup
     @@max_per_service = nil

--- a/lib/msf/core/auxiliary/auth_brute.rb
+++ b/lib/msf/core/auxiliary/auth_brute.rb
@@ -45,8 +45,6 @@ module Auxiliary::AuthBrute
     ], Auxiliary::AuthBrute)
   end
 
-  def 
-
   def setup
     @@max_per_service = nil
   end

--- a/lib/msf/core/modules/metadata/obj.rb
+++ b/lib/msf/core/modules/metadata/obj.rb
@@ -67,7 +67,7 @@ class Obj
     @is_server          = (module_instance.respond_to?(:stance) and module_instance.stance == "aggressive")
     @is_client          = (module_instance.respond_to?(:stance) and module_instance.stance == "passive")
     @post_auth          = module_instance.post_auth?
-    @default_credential = module_instance.has_default_cred?
+    @default_credential = module_instance.default_cred?
 
     @platform           = module_instance.platform_to_s
     # Done to ensure that differences do not show up for the same array grouping

--- a/lib/msf/core/modules/metadata/obj.rb
+++ b/lib/msf/core/modules/metadata/obj.rb
@@ -9,24 +9,46 @@ module Modules
 module Metadata
 
 class Obj
+  # @return [String]
   attr_reader :name
+  # @return [String]
   attr_reader :full_name
+  # @return [Integer]
   attr_reader :rank
+  # @return [Date]
   attr_reader :disclosure_date
+  # @return [String]
   attr_reader :type
+  # @return [Array<String>]
   attr_reader :author
+  # @return [String]
   attr_reader :description
+  # @return [Array<String>]
   attr_reader :references
+  # @return [Boolean]
   attr_reader :is_server
+  # @return [Boolean]
   attr_reader :is_client
+  # @return [String]
   attr_reader :platform
+  # @return [String]
   attr_reader :arch
+  # @return [Integer]
   attr_reader :rport
+  # @return [Array<String>]
   attr_reader :targets
+  # @return [Time]
   attr_reader :mod_time
+  # @return [Boolean]
   attr_reader :is_install_path
+  # @return [String]
   attr_reader :ref_name
+  # @return [Boolean]
   attr_reader :check
+  # @return [Boolean]
+  attr_reader :post_auth
+  # @return [Boolean]
+  attr_reader :default_credential
 
   def initialize(module_instance, obj_hash = nil)
     unless obj_hash.nil?
@@ -34,26 +56,29 @@ class Obj
       return
     end
 
-    @name = module_instance.name
-    @full_name = module_instance.fullname
-    @disclosure_date = module_instance.disclosure_date
-    @rank = module_instance.rank.to_i
-    @type = module_instance.type
-    @description = module_instance.description.to_s.strip
-    @author = module_instance.author.map{|x| x.to_s}
-    @references = module_instance.references.map{|x| [x.ctx_id, x.ctx_val].join("-") }
-    @is_server = (module_instance.respond_to?(:stance) and module_instance.stance == "aggressive")
-    @is_client = (module_instance.respond_to?(:stance) and module_instance.stance == "passive")
+    @name               = module_instance.name
+    @full_name          = module_instance.fullname
+    @disclosure_date    = module_instance.disclosure_date
+    @rank               = module_instance.rank.to_i
+    @type               = module_instance.type
+    @description        = module_instance.description.to_s.strip
+    @author             = module_instance.author.map{|x| x.to_s}
+    @references         = module_instance.references.map{|x| [x.ctx_id, x.ctx_val].join("-") }
+    @is_server          = (module_instance.respond_to?(:stance) and module_instance.stance == "aggressive")
+    @is_client          = (module_instance.respond_to?(:stance) and module_instance.stance == "passive")
+    @post_auth          = module_instance.post_auth?
+    @default_credential = module_instance.has_default_cred?
 
-    @platform = module_instance.platform_to_s
+    @platform           = module_instance.platform_to_s
     # Done to ensure that differences do not show up for the same array grouping
     sort_platform_string
 
-    @arch = module_instance.arch_to_s
-    @rport = module_instance.datastore['RPORT']
-    @path = module_instance.file_path
-    @mod_time = ::File.mtime(@path) rescue Time.now
-    @ref_name = module_instance.refname
+    @arch               = module_instance.arch_to_s
+    @rport              = module_instance.datastore['RPORT']
+    @path               = module_instance.file_path
+    @mod_time           = ::File.mtime(@path) rescue Time.now
+    @ref_name           = module_instance.refname
+
     install_path = Msf::Config.install_root.to_s
     if (@path.to_s.include? (install_path))
       @path = @path.sub(install_path, '')
@@ -76,25 +101,27 @@ class Obj
   #
   def to_json(*args)
     {
-      'name' => @name,
-      'full_name' => @full_name,
-      'rank' => @rank,
-      'disclosure_date' => @disclosure_date.nil? ? nil : @disclosure_date.to_s,
-      'type' => @type,
-      'author' => @author,
-      'description' => @description,
-      'references' => @references,
-      'is_server' => @is_server,
-      'is_client' => @is_client,
-      'platform' => @platform,
-      'arch' => @arch,
-      'rport' => @rport,
-      'targets' => @targets,
-      'mod_time' => @mod_time.to_s,
-      'path' => @path,
-      'is_install_path' => @is_install_path,
-      'ref_name' => @ref_name,
-      'check' => @check
+      'name'               => @name,
+      'full_name'          => @full_name,
+      'rank'               => @rank,
+      'disclosure_date'    => @disclosure_date.nil? ? nil : @disclosure_date.to_s,
+      'type'               => @type,
+      'author'             => @author,
+      'description'        => @description,
+      'references'         => @references,
+      'is_server'          => @is_server,
+      'is_client'          => @is_client,
+      'platform'           => @platform,
+      'arch'               => @arch,
+      'rport'              => @rport,
+      'targets'            => @targets,
+      'mod_time'           => @mod_time.to_s,
+      'path'               => @path,
+      'is_install_path'    => @is_install_path,
+      'ref_name'           => @ref_name,
+      'check'              => @check,
+      'post_auth'          => @post_auth,
+      'default_credential' => @default_credential
     }.to_json(*args)
   end
 
@@ -122,25 +149,27 @@ class Obj
   #######
 
   def init_from_hash(obj_hash)
-    @name = obj_hash['name']
-    @full_name = obj_hash['full_name']
-    @disclosure_date = obj_hash['disclosure_date'].nil? ? nil : Time.parse(obj_hash['disclosure_date'])
-    @rank = obj_hash['rank']
-    @type = obj_hash['type']
-    @description = obj_hash['description']
-    @author = obj_hash['author'].nil? ? [] : obj_hash['author']
-    @references = obj_hash['references']
-    @is_server = obj_hash['is_server']
-    @is_client = obj_hash['is_client']
-    @platform = obj_hash['platform']
-    @arch = obj_hash['arch']
-    @rport = obj_hash['rport']
-    @mod_time = Time.parse(obj_hash['mod_time'])
-    @ref_name = obj_hash['ref_name']
-    @path = obj_hash['path']
-    @is_install_path = obj_hash['is_install_path']
-    @targets = obj_hash['targets'].nil? ? [] : obj_hash['targets']
-    @check = obj_hash['check'] ? true : false
+    @name               = obj_hash['name']
+    @full_name          = obj_hash['full_name']
+    @disclosure_date    = obj_hash['disclosure_date'].nil? ? nil : Time.parse(obj_hash['disclosure_date'])
+    @rank               = obj_hash['rank']
+    @type               = obj_hash['type']
+    @description        = obj_hash['description']
+    @author             = obj_hash['author'].nil? ? [] : obj_hash['author']
+    @references         = obj_hash['references']
+    @is_server          = obj_hash['is_server']
+    @is_client          = obj_hash['is_client']
+    @platform           = obj_hash['platform']
+    @arch               = obj_hash['arch']
+    @rport              = obj_hash['rport']
+    @mod_time           = Time.parse(obj_hash['mod_time'])
+    @ref_name           = obj_hash['ref_name']
+    @path               = obj_hash['path']
+    @is_install_path    = obj_hash['is_install_path']
+    @targets            = obj_hash['targets'].nil? ? [] : obj_hash['targets']
+    @check              = obj_hash['check'] ? true : false
+    @post_auth          = obj_hash['post_auth']
+    @default_credential = obj_hash['default_credential']
   end
 
   def sort_platform_string

--- a/modules/auxiliary/admin/2wire/xslt_password_reset.rb
+++ b/modules/auxiliary/admin/2wire/xslt_password_reset.rb
@@ -35,6 +35,10 @@ class MetasploitModule < Msf::Auxiliary
         ])
   end
 
+  def post_auth?
+    false
+  end
+
   def run
 
     print_status("Attempting to connect to http://#{rhost}/xslt?PAGE=A07 to gather information")

--- a/modules/auxiliary/admin/http/manageengine_dir_listing.rb
+++ b/modules/auxiliary/admin/http/manageengine_dir_listing.rb
@@ -50,6 +50,9 @@ class MetasploitModule < Msf::Auxiliary
       ])
   end
 
+  def post_auth?
+    true
+  end
 
   def get_cookie
     cookie = nil

--- a/modules/auxiliary/admin/http/manageengine_file_download.rb
+++ b/modules/auxiliary/admin/http/manageengine_file_download.rb
@@ -48,6 +48,9 @@ class MetasploitModule < Msf::Auxiliary
       ])
   end
 
+  def post_auth?
+    true
+  end
 
   def get_cookie
     cookie = nil

--- a/modules/auxiliary/admin/http/tomcat_administration.rb
+++ b/modules/auxiliary/admin/http/tomcat_administration.rb
@@ -30,6 +30,10 @@ class MetasploitModule < Msf::Auxiliary
       ])
   end
 
+  def post_auth?
+    true
+  end
+
   def run_host(ip)
 
     begin

--- a/modules/auxiliary/gather/apache_rave_creds.rb
+++ b/modules/auxiliary/gather/apache_rave_creds.rb
@@ -42,6 +42,14 @@ class MetasploitModule < Msf::Auxiliary
       ])
   end
 
+  def post_auth?
+    true
+  end
+
+  def default_cred?
+    true
+  end
+
   def login(username, password)
     uri = normalize_uri(target_uri.to_s, "j_spring_security_check")
 

--- a/modules/auxiliary/gather/konica_minolta_pwd_extract.rb
+++ b/modules/auxiliary/gather/konica_minolta_pwd_extract.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
       [
         Opt::RPORT('50001'),
-        OptString.new('USER', [false, 'The default Admin user', 'Admin']),
+        OptString.new('USER', [true, 'The default Admin user', 'Admin']),
         OptString.new('PASSWD', [true, 'The default Admin password', '12345678']),
         OptInt.new('TIMEOUT', [true, 'Timeout for printer probe', 20])
 

--- a/modules/auxiliary/gather/snare_registry.rb
+++ b/modules/auxiliary/gather/snare_registry.rb
@@ -33,8 +33,8 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
       [
         Opt::RPORT(6161),
-        OptString.new('HttpUsername', [ false, 'The username for Snare remote access', 'snare' ]),
-        OptString.new('HttpPassword', [ false, 'The password for Snare remote access', '' ]),
+        OptString.new('HttpUsername', [ true, 'The username for Snare remote access', 'snare' ]),
+        OptString.new('HttpPassword', [ true, 'The password for Snare remote access', '' ]),
         OptString.new('REG_DUMP_KEY', [ false, 'Retrieve this registry key and all sub-keys', 'HKLM\\HARDWARE\\DESCRIPTION\\System' ]),
         OptBool.new('REG_DUMP_ALL', [false, 'Retrieve the entire Windows registry', false]),
         OptInt.new('TIMEOUT', [true, 'Timeout in seconds for downloading each registry key/hive', 300])

--- a/modules/auxiliary/gather/teamtalk_creds.rb
+++ b/modules/auxiliary/gather/teamtalk_creds.rb
@@ -27,8 +27,8 @@ class MetasploitModule < Msf::Auxiliary
       'License'     => MSF_LICENSE))
     register_options [
       Opt::RPORT(10333),
-      OptString.new('USERNAME', [false, 'The username for TeamTalk', 'admin']),
-      OptString.new('PASSWORD', [false, 'The password for the specified username', 'admin'])
+      OptString.new('USERNAME', [true, 'The username for TeamTalk', 'admin']),
+      OptString.new('PASSWORD', [true, 'The password for the specified username', 'admin'])
     ]
   end
 

--- a/modules/auxiliary/gather/zabbix_toggleids_sqli.rb
+++ b/modules/auxiliary/gather/zabbix_toggleids_sqli.rb
@@ -38,6 +38,10 @@ class MetasploitModule < Msf::Auxiliary
       ])
   end
 
+  def default_cred?
+    true
+  end
+
   def check
 
     sid, cookies = authenticate

--- a/modules/auxiliary/scanner/ipmi/ipmi_dumphashes.rb
+++ b/modules/auxiliary/scanner/ipmi/ipmi_dumphashes.rb
@@ -47,6 +47,14 @@ class MetasploitModule < Msf::Auxiliary
 
   end
 
+  def post_auth?
+    true
+  end
+
+  def default_cred?
+    true
+  end
+
   def ipmi_status(msg)
     vprint_status("#{rhost}:#{rport} - IPMI - #{msg}")
   end

--- a/modules/auxiliary/scanner/lotus/lotus_domino_hashes.rb
+++ b/modules/auxiliary/scanner/lotus/lotus_domino_hashes.rb
@@ -28,6 +28,10 @@ class MetasploitModule < Msf::Auxiliary
     ])
   end
 
+  def post_auth?
+    true
+  end
+
   def run_host(ip)
     user = datastore['NOTES_USER']
     pass = datastore['NOTES_PASS']

--- a/modules/exploits/apple_ios/ssh/cydia_default_ssh.rb
+++ b/modules/exploits/apple_ios/ssh/cydia_default_ssh.rb
@@ -65,6 +65,9 @@ class MetasploitModule < Msf::Exploit::Remote
     )
   end
 
+  def post_auth?
+    true
+  end
 
   def rhost
     datastore['RHOST']

--- a/modules/exploits/linux/http/apache_couchdb_cmd_exec.rb
+++ b/modules/exploits/linux/http/apache_couchdb_cmd_exec.rb
@@ -63,6 +63,14 @@ class MetasploitModule < Msf::Exploit::Remote
     ])
   end
 
+  def post_auth?
+    true
+  end
+
+  def default_cred?
+    true
+  end
+
   def check
     get_version
     version = Gem::Version.new(@version)

--- a/modules/exploits/linux/http/atutor_filemanager_traversal.rb
+++ b/modules/exploits/linux/http/atutor_filemanager_traversal.rb
@@ -59,6 +59,10 @@ class MetasploitModule < Msf::Exploit::Remote
       ])
   end
 
+  def post_auth?
+    true
+  end
+
   def print_status(msg='')
     super("#{peer} - #{msg}")
   end

--- a/modules/exploits/linux/http/hp_van_sdn_cmd_inject.rb
+++ b/modules/exploits/linux/http/hp_van_sdn_cmd_inject.rb
@@ -69,6 +69,14 @@ class MetasploitModule < Msf::Exploit::Remote
     ])
   end
 
+  def post_auth?
+    true
+  end
+
+  def default_credential?
+    true
+  end
+
   def check
     checkcode = CheckCode::Safe
 

--- a/modules/exploits/linux/http/huawei_hg532n_cmdinject.rb
+++ b/modules/exploits/linux/http/huawei_hg532n_cmdinject.rb
@@ -70,6 +70,14 @@ class MetasploitModule < Msf::Exploit::Remote
     )
   end
 
+  def post_auth?
+    true
+  end
+
+  def default_credential?
+    true
+  end
+
   def check
     httpd_fingerprint = %r{
       \A

--- a/modules/exploits/linux/http/linksys_wrt110_cmd_exec.rb
+++ b/modules/exploits/linux/http/linksys_wrt110_cmd_exec.rb
@@ -41,8 +41,8 @@ class MetasploitModule < Msf::Exploit::Remote
       ))
 
     register_options([
-      OptString.new('HttpUsername', [ false, 'Valid router administrator username', 'admin']),
-      OptString.new('HttpPassword', [ false, 'Password to login with', 'admin']),
+      OptString.new('HttpUsername', [ true, 'Valid router administrator username', 'admin']),
+      OptString.new('HttpPassword', [ true, 'Password to login with', 'admin']),
       OptAddress.new('RHOST', [true, 'The address of the router', '192.168.1.1']),
       OptInt.new('TIMEOUT', [false, 'The timeout to use in every request', 20])
     ])

--- a/modules/exploits/linux/http/netgear_dnslookup_cmd_exec.rb
+++ b/modules/exploits/linux/http/netgear_dnslookup_cmd_exec.rb
@@ -78,6 +78,10 @@ class MetasploitModule < Msf::Exploit::Remote
     end
   end
 
+  def default_credential?
+    true
+  end
+
   def exploit
     check
 

--- a/modules/exploits/linux/http/pandora_fms_sqli.rb
+++ b/modules/exploits/linux/http/pandora_fms_sqli.rb
@@ -54,6 +54,15 @@ class MetasploitModule < Msf::Exploit::Remote
         ])
   end
 
+  def post_auth?
+    # Post auth is optional
+    true
+  end
+
+  def default_credential?
+    true
+  end
+
   def uri
     target_uri.path
   end

--- a/modules/exploits/linux/http/supervisor_xmlrpc_exec.rb
+++ b/modules/exploits/linux/http/supervisor_xmlrpc_exec.rb
@@ -59,6 +59,10 @@ class MetasploitModule < Msf::Exploit::Remote
     )
   end
 
+  def post_auth?
+    true
+  end
+
   def check_version(version)
     if version <= Gem::Version.new('3.3.2') and version >= Gem::Version.new('3.0a1')
       return true

--- a/modules/exploits/linux/misc/mongod_native_helper.rb
+++ b/modules/exploits/linux/misc/mongod_native_helper.rb
@@ -69,8 +69,8 @@ class MetasploitModule < Msf::Exploit::Remote
         Opt::RPORT(27017),
         OptString.new('DB', [ true, "Database to use", "admin"]),
         OptString.new('COLLECTION', [ false, "Collection to use (it must to exist). Better to let empty", ""]),
-        OptString.new('USERNAME', [ false, "Login to use", ""]),
-        OptString.new('PASSWORD', [ false, "Password to use", ""])
+        OptString.new('USERNAME', [ true, "Login to use", ""]),
+        OptString.new('PASSWORD', [ true, "Password to use", ""])
       ])
   end
 

--- a/modules/exploits/linux/samba/is_known_pipename.rb
+++ b/modules/exploits/linux/samba/is_known_pipename.rb
@@ -84,6 +84,10 @@ class MetasploitModule < Msf::Exploit::Remote
       ])
   end
 
+  def post_auth?
+    true
+  end
+
   # Setup our mapping of Metasploit architectures to gcc architectures
   def setup
     super

--- a/modules/exploits/linux/ssh/mercurial_ssh_exec.rb
+++ b/modules/exploits/linux/ssh/mercurial_ssh_exec.rb
@@ -1,4 +1,4 @@
-##
+  ##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##

--- a/modules/exploits/linux/telnet/netgear_telnetenable.rb
+++ b/modules/exploits/linux/telnet/netgear_telnetenable.rb
@@ -65,6 +65,14 @@ class MetasploitModule < Msf::Exploit::Remote
     ])
   end
 
+  def post_auth?
+    true
+  end
+
+  def default_credential?
+    true
+  end
+
   def check
     # Run through protocol detection
     detect_proto

--- a/modules/exploits/mainframe/ftp/ftp_jcl_creds.rb
+++ b/modules/exploits/mainframe/ftp/ftp_jcl_creds.rb
@@ -41,6 +41,10 @@ class MetasploitModule < Msf::Exploit::Remote
     )
   end
 
+  def post_auth?
+    true
+  end
+
   def check
     ##
     # Connect to get the FTP banner and check target OS

--- a/modules/exploits/multi/http/axis2_deployer.rb
+++ b/modules/exploits/multi/http/axis2_deployer.rb
@@ -63,8 +63,8 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         Opt::RPORT(8080),
-        OptString.new('USERNAME', [ false, 'The username to authenticate as','admin' ]),
-        OptString.new('PASSWORD', [ false, 'The password for the specified username','axis2' ]),
+        OptString.new('USERNAME', [ true, 'The username to authenticate as','admin' ]),
+        OptString.new('PASSWORD', [ true, 'The password for the specified username','axis2' ]),
         OptString.new('PATH', [ true,  "The URI path of the axis2 app (use /dswsbobje for SAP BusinessObjects)", '/axis2'])
       ])
     register_autofilter_ports([ 8080 ])

--- a/modules/exploits/multi/http/gestioip_exec.rb
+++ b/modules/exploits/multi/http/gestioip_exec.rb
@@ -49,6 +49,10 @@ class MetasploitModule < Msf::Exploit::Remote
     ])
   end
 
+  def post_auth?
+    true
+  end
+
   def user
     datastore['HttpUsername']
   end

--- a/modules/exploits/multi/http/glassfish_deployer.rb
+++ b/modules/exploits/multi/http/glassfish_deployer.rb
@@ -52,8 +52,8 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           Opt::RPORT(4848),
           OptString.new('APP_RPORT',[ true,  'The Application interface port', '8080']),
-          OptString.new('USERNAME', [ false, 'The username to authenticate as','admin' ]),
-          OptString.new('PASSWORD', [ false, 'The password for the specified username','' ]),
+          OptString.new('USERNAME', [ true, 'The username to authenticate as','admin' ]),
+          OptString.new('PASSWORD', [ true, 'The password for the specified username','' ]),
           OptString.new('TARGETURI', [ true,  "The URI path of the GlassFish Server", '/']),
           OptBool.new('SSL', [ false, 'Negotiate SSL for outgoing connections', false])
         ])

--- a/modules/exploits/multi/http/hp_sys_mgmt_exec.rb
+++ b/modules/exploits/multi/http/hp_sys_mgmt_exec.rb
@@ -71,6 +71,10 @@ class MetasploitModule < Msf::Exploit::Remote
       ])
   end
 
+  def post_auth?
+    true
+  end
+
   def check
     @cookie = ''
 

--- a/modules/exploits/multi/http/jenkins_script_console.rb
+++ b/modules/exploits/multi/http/jenkins_script_console.rb
@@ -56,6 +56,10 @@ class MetasploitModule < Msf::Exploit::Remote
       ])
   end
 
+  def post_auth?
+    true
+  end
+
   def check
     uri = target_uri
     uri.path = normalize_uri(uri.path)

--- a/modules/exploits/multi/http/jira_hipchat_template.rb
+++ b/modules/exploits/multi/http/jira_hipchat_template.rb
@@ -71,6 +71,10 @@ class MetasploitModule < Msf::Exploit::Remote
       ])
   end
 
+  def post_auth?
+    true
+  end
+
 
   # Returns a cookie in a hash, so you can ask for a specific parameter.
   #

--- a/modules/exploits/multi/http/mediawiki_syntaxhighlight.rb
+++ b/modules/exploits/multi/http/mediawiki_syntaxhighlight.rb
@@ -49,6 +49,10 @@ class MetasploitModule < Msf::Exploit::Remote
       ])
   end
 
+  def post_auth?
+    true
+  end
+
   def check
     res = send_request_cgi({
       'method' => 'POST',

--- a/modules/exploits/multi/http/openfire_auth_bypass.rb
+++ b/modules/exploits/multi/http/openfire_auth_bypass.rb
@@ -85,6 +85,10 @@ class MetasploitModule < Msf::Exploit::Remote
       ])
   end
 
+  def post_auth?
+    true
+  end
+
   def check
     base = target_uri.path
     base << '/' if base[-1, 1] != '/'

--- a/modules/exploits/multi/http/tomcat_mgr_deploy.rb
+++ b/modules/exploits/multi/http/tomcat_mgr_deploy.rb
@@ -107,6 +107,10 @@ class MetasploitModule < Msf::Exploit::Remote
       ])
   end
 
+  def post_auth?
+    true
+  end
+
   def check
     res = query_serverinfo
     disconnect

--- a/modules/exploits/multi/http/tomcat_mgr_upload.rb
+++ b/modules/exploits/multi/http/tomcat_mgr_upload.rb
@@ -100,6 +100,10 @@ class MetasploitModule < Msf::Exploit::Remote
       ])
   end
 
+  def post_auth?
+    true
+  end
+
   def check
     res = query_manager
     disconnect

--- a/modules/exploits/multi/http/visual_mining_netcharts_upload.rb
+++ b/modules/exploits/multi/http/visual_mining_netcharts_upload.rb
@@ -56,6 +56,14 @@ class MetasploitModule < Msf::Exploit::Remote
       ])
   end
 
+  def post_auth?
+    true
+  end
+
+  def default_cred?
+    true
+  end
+
   def check
     res = send_request_cgi({
       'method'   => 'GET',

--- a/modules/exploits/multi/misc/java_jmx_server.rb
+++ b/modules/exploits/multi/misc/java_jmx_server.rb
@@ -57,6 +57,10 @@ class MetasploitModule < Msf::Exploit::Remote
     register_common_rmi_ports_and_services
   end
 
+  def post_auth?
+    true
+  end
+
   def on_request_uri(cli, request)
     if @jar.nil?
       p = regenerate_payload(cli)

--- a/modules/exploits/multi/misc/legend_bot_exec.rb
+++ b/modules/exploits/multi/misc/legend_bot_exec.rb
@@ -62,6 +62,10 @@ class MetasploitModule < Msf::Exploit::Remote
       ])
   end
 
+  def post_auth?
+    true
+  end
+
   def check
     connect
 

--- a/modules/exploits/multi/misc/pbot_exec.rb
+++ b/modules/exploits/multi/misc/pbot_exec.rb
@@ -63,6 +63,10 @@ class MetasploitModule < Msf::Exploit::Remote
       ])
   end
 
+  def post_auth?
+    true
+  end
+
   def check
     connect
 

--- a/modules/exploits/multi/misc/ra1nx_pubcall_exec.rb
+++ b/modules/exploits/multi/misc/ra1nx_pubcall_exec.rb
@@ -59,6 +59,10 @@ class MetasploitModule < Msf::Exploit::Remote
       ])
   end
 
+  def post_auth?
+    true
+  end
+
   def connect_irc
     print_status("#{rhost}:#{rport} - Connecting to IRC server...")
     connect

--- a/modules/exploits/multi/misc/w3tw0rk_exec.rb
+++ b/modules/exploits/multi/misc/w3tw0rk_exec.rb
@@ -52,6 +52,10 @@ class MetasploitModule < Msf::Exploit::Remote
       ])
   end
 
+  def post_auth?
+    true
+  end
+
   def check
     connect
 

--- a/modules/exploits/multi/misc/xdh_x_exec.rb
+++ b/modules/exploits/multi/misc/xdh_x_exec.rb
@@ -64,6 +64,10 @@ class MetasploitModule < Msf::Exploit::Remote
       ])
   end
 
+  def post_auth?
+    true
+  end
+
   def check
     connect
 

--- a/modules/exploits/multi/mysql/mysql_udf_payload.rb
+++ b/modules/exploits/multi/mysql/mysql_udf_payload.rb
@@ -52,6 +52,10 @@ class MetasploitModule < Msf::Exploit::Remote
     ])
   end
 
+  def post_auth?
+    true
+  end
+
   def username
     datastore['USERNAME']
   end

--- a/modules/exploits/multi/vnc/vnc_keyboard_exec.rb
+++ b/modules/exploits/multi/vnc/vnc_keyboard_exec.rb
@@ -48,6 +48,9 @@ class MetasploitModule < Msf::Exploit::Remote
       ])
   end
 
+  def post_auth?
+    true
+  end
 
   def press_key(key)
     keyboard_key = "\x04\x01" # Press key

--- a/modules/exploits/solaris/telnet/ttyprompt.rb
+++ b/modules/exploits/solaris/telnet/ttyprompt.rb
@@ -1,4 +1,3 @@
-bash_environment
 ##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework

--- a/modules/exploits/solaris/telnet/ttyprompt.rb
+++ b/modules/exploits/solaris/telnet/ttyprompt.rb
@@ -1,3 +1,4 @@
+bash_environment
 ##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework

--- a/modules/exploits/unix/smtp/qmail_bash_env_exec.rb
+++ b/modules/exploits/unix/smtp/qmail_bash_env_exec.rb
@@ -1,4 +1,4 @@
-##
+ ##
 # This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##

--- a/modules/exploits/unix/webapp/actualanalyzer_ant_cookie_exec.rb
+++ b/modules/exploits/unix/webapp/actualanalyzer_ant_cookie_exec.rb
@@ -51,8 +51,8 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('TARGETURI', [true, 'The base path to ActualAnalyzer', '/lite/']),
-        OptString.new('USERNAME', [false, 'The username for ActualAnalyzer', 'admin']),
-        OptString.new('PASSWORD', [false, 'The password for ActualAnalyzer', 'admin']),
+        OptString.new('USERNAME', [true, 'The username for ActualAnalyzer', 'admin']),
+        OptString.new('PASSWORD', [true, 'The password for ActualAnalyzer', 'admin']),
         OptString.new('ANALYZER_HOST', [false, 'A hostname or IP monitored by ActualAnalyzer', ''])
       ])
   end

--- a/modules/exploits/unix/webapp/foswiki_maketext.rb
+++ b/modules/exploits/unix/webapp/foswiki_maketext.rb
@@ -62,6 +62,14 @@ class MetasploitModule < Msf::Exploit::Remote
       ])
   end
 
+  def post_auth?
+    true
+  end
+
+  def default_cred?
+    true
+  end
+
   def do_login(username, password)
     res = send_request_cgi({
       'method'   => 'POST',

--- a/modules/exploits/unix/webapp/joomla_media_upload_exec.rb
+++ b/modules/exploits/unix/webapp/joomla_media_upload_exec.rb
@@ -57,8 +57,8 @@ class MetasploitModule < Msf::Exploit::Remote
       register_options(
         [
           OptString.new('TARGETURI', [true, 'The base path to Joomla', '/joomla']),
-          OptString.new('USERNAME', [false, 'User to login with', '']),
-          OptString.new('PASSWORD', [false, 'Password to login with', '']),
+          OptString.new('USERNAME', [true, 'User to login with', '']),
+          OptString.new('PASSWORD', [true, 'Password to login with', '']),
         ])
 
   end

--- a/modules/exploits/unix/webapp/moinmoin_twikidraw.rb
+++ b/modules/exploits/unix/webapp/moinmoin_twikidraw.rb
@@ -64,6 +64,14 @@ class MetasploitModule < Msf::Exploit::Remote
       ])
   end
 
+  def post_auth?
+    true
+  end
+
+  def default_cred?
+    true
+  end
+
   def moinmoin_template(path)
     template =[]
     template << "# -*- coding: iso-8859-1 -*-"

--- a/modules/exploits/unix/webapp/nagios3_history_cgi.rb
+++ b/modules/exploits/unix/webapp/nagios3_history_cgi.rb
@@ -83,8 +83,8 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('TARGETURI', [true, "The full URI path to history.cgi", "/nagios3/cgi-bin/history.cgi"]),
-        OptString.new('USER', [false, "The username to authenticate with", "nagiosadmin"]),
-        OptString.new('PASS', [false, "The password to authenticate with", "nagiosadmin"]),
+        OptString.new('USER', [true, "The username to authenticate with", "nagiosadmin"]),
+        OptString.new('PASS', [true, "The password to authenticate with", "nagiosadmin"]),
       ])
   end
 

--- a/modules/exploits/unix/webapp/piwik_superuser_plugin_upload.rb
+++ b/modules/exploits/unix/webapp/piwik_superuser_plugin_upload.rb
@@ -1,4 +1,4 @@
-\##
+##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##

--- a/modules/exploits/unix/webapp/piwik_superuser_plugin_upload.rb
+++ b/modules/exploits/unix/webapp/piwik_superuser_plugin_upload.rb
@@ -1,4 +1,4 @@
-##
+\##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##

--- a/modules/exploits/unix/webapp/twiki_maketext.rb
+++ b/modules/exploits/unix/webapp/twiki_maketext.rb
@@ -63,6 +63,10 @@ class MetasploitModule < Msf::Exploit::Remote
       ])
   end
 
+  def post_auth?
+    true
+  end
+
   def do_login(username, password)
     res = send_request_cgi({
       'method'   => 'POST',

--- a/modules/exploits/unix/webapp/wp_easycart_unrestricted_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_easycart_unrestricted_file_upload.rb
@@ -61,6 +61,10 @@ class MetasploitModule < Msf::Exploit::Remote
       ])
   end
 
+  def post_auth?
+    true
+  end
+
   def username
     datastore['USERNAME']
   end

--- a/modules/exploits/unix/webapp/wp_total_cache_exec.rb
+++ b/modules/exploits/unix/webapp/wp_total_cache_exec.rb
@@ -67,6 +67,10 @@ class MetasploitModule < Msf::Exploit::Remote
         ])
   end
 
+  def post_auth?
+    require_auth?
+  end
+
   def require_auth?
     @user = datastore['USERNAME']
     @password = datastore['PASSWORD']

--- a/modules/exploits/windows/ftp/httpdx_tolog_format.rb
+++ b/modules/exploits/windows/ftp/httpdx_tolog_format.rb
@@ -114,8 +114,8 @@ For now, that will have to be done manually.
       [
         Opt::RPORT(21),
         # note the default user/pass
-        OptString.new('FTPUSER', [ false, 'The username to authenticate as', 'moderator']),
-        OptString.new('FTPPASS', [ false, 'The password to authenticate with', 'pass123'])
+        OptString.new('FTPUSER', [ true, 'The username to authenticate as', 'moderator']),
+        OptString.new('FTPPASS', [ true, 'The password to authenticate with', 'pass123'])
       ])
   end
 

--- a/modules/exploits/windows/ftp/oracle9i_xdb_ftp_unlock.rb
+++ b/modules/exploits/windows/ftp/oracle9i_xdb_ftp_unlock.rb
@@ -57,8 +57,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options([
       Opt::RPORT(2100),
-      OptString.new('FTPUSER', [ false, 'The username to authenticate as', 'DBSNMP']),
-      OptString.new('FTPPASS', [ false, 'The password to authenticate with', 'DBSNMP']),
+      OptString.new('FTPUSER', [ true, 'The username to authenticate as', 'DBSNMP']),
+      OptString.new('FTPPASS', [ true, 'The password to authenticate with', 'DBSNMP']),
     ])
   end
 

--- a/modules/exploits/windows/ftp/pcman_put.rb
+++ b/modules/exploits/windows/ftp/pcman_put.rb
@@ -51,6 +51,10 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultTarget'  => 0))
   end
 
+  def post_auth?
+    true
+  end
+
   def check
     connect_login
     disconnect

--- a/modules/exploits/windows/ftp/pcman_stor.rb
+++ b/modules/exploits/windows/ftp/pcman_stor.rb
@@ -53,6 +53,10 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultTarget'  => 0))
   end
 
+  def post_auth?
+    true
+  end
+
   def check
     c = connect_login
     disconnect

--- a/modules/exploits/windows/http/hp_openview_insight_backdoor.rb
+++ b/modules/exploits/windows/http/hp_openview_insight_backdoor.rb
@@ -51,8 +51,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        OptString.new('USERNAME', [ false, 'The username to authenticate as', 'hch908v' ]),
-        OptString.new('PASSWORD', [ false, 'The password for the specified username', 'z6t0j$+i' ])
+        OptString.new('USERNAME', [ true, 'The username to authenticate as', 'hch908v' ]),
+        OptString.new('PASSWORD', [ true, 'The password for the specified username', 'z6t0j$+i' ])
       ])
 
   end

--- a/modules/exploits/windows/http/ipswitch_wug_maincfgret.rb
+++ b/modules/exploits/windows/http/ipswitch_wug_maincfgret.rb
@@ -48,8 +48,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        OptString.new('HTTPUSER', [ false, 'The username to authenticate as', 'admin']),
-        OptString.new('HTTPPASS', [ false, 'The password to authenticate as', 'admin']),
+        OptString.new('HTTPUSER', [ true, 'The username to authenticate as', 'admin']),
+        OptString.new('HTTPPASS', [ true, 'The password to authenticate as', 'admin']),
       ])
   end
 

--- a/modules/exploits/windows/http/manageengine_apps_mngr.rb
+++ b/modules/exploits/windows/http/manageengine_apps_mngr.rb
@@ -32,8 +32,8 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [ Opt::RPORT(9090),
         OptString.new('URI', [false, "URI for Applications Manager", '/']),
-        OptString.new('USER', [false, "username", 'admin']),
-        OptString.new('PASS', [false, "password", 'admin']),
+        OptString.new('USER', [true, "username", 'admin']),
+        OptString.new('PASS', [true, "password", 'admin']),
     ])
   end
   def target_url

--- a/modules/exploits/windows/http/octopusdeploy_deploy.rb
+++ b/modules/exploits/windows/http/octopusdeploy_deploy.rb
@@ -52,6 +52,10 @@ class MetasploitModule < Msf::Exploit::Remote
     )
   end
 
+  def post_auth?
+    true
+  end
+
   def check
     res = nil
     if datastore['APIKEY']

--- a/modules/exploits/windows/http/xampp_webdav_upload_php.rb
+++ b/modules/exploits/windows/http/xampp_webdav_upload_php.rb
@@ -32,8 +32,8 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         OptString.new('PATH', [ true,  "The path to attempt to upload", '/webdav/']),
         OptString.new('FILENAME', [ false ,  "The filename to give the payload. (Leave Blank for Random)"]),
-        OptString.new('USERNAME', [false, 'The HTTP username to specify for authentication', 'wampp']),
-        OptString.new('PASSWORD', [false, 'The HTTP password to specify for authentication', 'xampp'])
+        OptString.new('USERNAME', [true, 'The HTTP username to specify for authentication', 'wampp']),
+        OptString.new('PASSWORD', [true, 'The HTTP password to specify for authentication', 'xampp'])
       ])
   end
 

--- a/modules/exploits/windows/iis/msadc.rb
+++ b/modules/exploits/windows/iis/msadc.rb
@@ -66,6 +66,14 @@ class MetasploitModule < Msf::Exploit::Remote
       ])
   end
 
+  def post_auth?
+    true
+  end
+
+  def default_cred?
+    true
+  end
+
   def check
     res = send_request_raw({
         'uri'          =>  normalize_uri(datastore['PATH']),


### PR DESCRIPTION
This PR allows modules to be able to report their post authentication requirement, specifically:

* It adds post auth info to the JSON metadata
* It adds default cred info to the metadata
* It updates all exploits and auxiliary modules for false negatives.