### PR TITLE
Fix issue 10518 

### DIFF
--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -844,7 +844,9 @@ class ReadableText
         end
 
         persist_list.each do |e|
-          row[7] = 'true' if e['mod_options']['Options'] == framework.jobs[job_id.to_s].ctx[1].datastore
+          if framework.jobs[job_id.to_s].ctx[1]
+             row[7] = 'true' if e['mod_options']['Options'] == framework.jobs[job_id.to_s].ctx[1].datastore
+          end
         end
 
       end

--- a/lib/msf/ui/console/command_dispatcher/jobs.rb
+++ b/lib/msf/ui/console/command_dispatcher/jobs.rb
@@ -210,6 +210,7 @@ module Msf
               end
 
               job_list.map(&:to_s).each do |job|
+                next unless framework.jobs[job.to_s].ctx[1] # next if no payload context in the job
                 payload_option = framework.jobs[job.to_s].ctx[1].datastore
                 persist_list.delete_if{|pjob|pjob['mod_options']['Options'] == payload_option}
               end
@@ -237,6 +238,11 @@ module Msf
 
           def add_persist_job(job_id)
             if job_id && framework.jobs.has_key?(job_id.to_s)
+              unless framework.jobs[job_id.to_s].ctx[1]
+                print_error("Add persistent job failed: job #{job_id} is not payload handler.")
+                return
+              end
+
               mod     = framework.jobs[job_id.to_s].ctx[0].replicant
               payload = framework.jobs[job_id.to_s].ctx[1].replicant
 


### PR DESCRIPTION
Fix #10518 ,fix bug when interacting with the non-payload job, such as add, list and kill. 
The persistent feature should only support for payload handler job.

After fixed:
```
msf5 post(windows/capture/keylog_recorder) > jobs

Jobs
====

  Id  Name                                                        Payload                          Payload opts
  --  ----                                                        -------                          ------------
  3   Exploit: multi/handler                                      windows/meterpreter/reverse_tcp  tcp://127.0.0.1:4444
  4   Auxiliary: admin/android/google_play_store_uxss_xframe_rce                                   
  9   Post: windows/capture/keylog_recorder                                                        

msf5 post(windows/capture/keylog_recorder) > jobs -v

Jobs
====

  Id  Name                                                        Payload                          Payload opts          URIPATH    Start Time                 Handler opts  Persist
  --  ----                                                        -------                          ------------          -------    ----------                 ------------  -------
  3   Exploit: multi/handler                                      windows/meterpreter/reverse_tcp  tcp://127.0.0.1:4444             2018-08-24 03:03:58 -0400                false
  4   Auxiliary: admin/android/google_play_store_uxss_xframe_rce                                                         /Cu3mznUc  2018-08-24 03:04:22 -0400                false
  9   Post: windows/capture/keylog_recorder                                                                                         2018-08-24 03:26:45 -0400                false

msf5 post(windows/capture/keylog_recorder) > jobs -P
Making all jobs persistent ...
Added persistence to job 3.
[-] Add persistent job failed: job 4 is not payload handler.
[-] Add persistent job failed: job 9 is not payload handler.
msf5 post(windows/capture/keylog_recorder) > jobs -v

Jobs
====

  Id  Name                                                        Payload                          Payload opts          URIPATH    Start Time                 Handler opts  Persist
  --  ----                                                        -------                          ------------          -------    ----------                 ------------  -------
  3   Exploit: multi/handler                                      windows/meterpreter/reverse_tcp  tcp://127.0.0.1:4444             2018-08-24 03:03:58 -0400                true
  4   Auxiliary: admin/android/google_play_store_uxss_xframe_rce                                                         /Cu3mznUc  2018-08-24 03:04:22 -0400                false
  9   Post: windows/capture/keylog_recorder                                                                                         2018-08-24 03:26:45 -0400                false

msf5 post(windows/capture/keylog_recorder) > jobs -K
Stopping all jobs...

[*] Server stopped.
[*] Shutting down keylog recorder. Please wait...
[*] Server stopped.
[*] Shutting down keylog recorder. Please wait...
msf5 post(windows/capture/keylog_recorder) > jobs -v

Jobs
====

No active jobs.

```
@wvu-r7 @timwr 