### PR TITLE
avoid inserting a float into instruction generation randomly in sparc nops generator

### DIFF
--- a/modules/nops/sparc/random.rb
+++ b/modules/nops/sparc/random.rb
@@ -196,11 +196,15 @@ class MetasploitModule < Msf::Nop
     return '' if len == 0
     len = 0x3fffff if (len >= 0x400000)
 
+    a = rand(2).floor
+    b = ref[0]
+    c = rand(len - 1).floor
+
     return [
-      (rand(2) << 29) |
-      (ref[0] << 25)  |
-      (2 << 22)       |
-      rand(len - 1) + 1
+      (a << 29)  |
+      (b << 25)  |
+      (2 << 22)  |
+      c + 1
     ].pack('N')
   end
 end


### PR DESCRIPTION
This fixes #10530, forcing an integer rather than a floating-point number when length is '1' due to how Ruby's rand(0) returns a different type than rand(1)

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use nop/sparc/random`
- [ ] Any number of times run `generate -t perl 10`
- [ ] **Verify** that this always generates a valid sparc string and doesn't throw an error
