### PR TITLE
Add audio output to the Windows meterpreter

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,7 +18,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 1.3.43)
+      metasploit-payloads (= 1.3.44)
       metasploit_data_models
       metasploit_payloads-mettle (= 0.4.1)
       mqtt
@@ -164,7 +164,7 @@ GEM
       activemodel (~> 4.2.6)
       activesupport (~> 4.2.6)
       railties (~> 4.2.6)
-    metasploit-payloads (1.3.43)
+    metasploit-payloads (1.3.44)
     metasploit_data_models (3.0.0)
       activerecord (~> 4.2.6)
       activesupport (~> 4.2.6)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -70,7 +70,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '1.3.43'
+  spec.add_runtime_dependency 'metasploit-payloads', '1.3.44'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '0.4.1'
   # Needed by msfgui and other rpc components


### PR DESCRIPTION
Bump `metasploit-payloads` to version 1.3.44. This brings in changes to add audio output to the Windows meterpreter.

The associated metasploit-payloads PR: rapid7/metasploit-payloads#294
