### PR TITLE
Correct claymore_dos.py's CVE reference

### DIFF
--- a/modules/auxiliary/dos/tcp/claymore_dos.py
+++ b/modules/auxiliary/dos/tcp/claymore_dos.py
@@ -25,7 +25,7 @@ metadata = {
     'date': '2018-02-06',
 
     'references': [
-        {'type': 'cve', 'ref': 'CVE-2018-6317'},
+        {'type': 'cve', 'ref': '2018-6317'},
         {'type': 'url', 'ref': 'https://www.exploit-db.com/exploits/43972/'},
         {'type': 'url', 'ref': 'https://github.com/nanopool/Claymore-Dual-Miner'}
     ],


### PR DESCRIPTION
Update the CVE reference for the Claymore Dual Miner, it shouldn't include the `CVE-` prefix.  The current code is leading to a reference with a duplicated prefix (`CVE-CVE-2018-6317`) in the generated module JSON file.