### PR TITLE
Add CVE reference to office_ms17_11882 exploit

### DIFF
--- a/modules/exploits/windows/fileformat/office_ms17_11882.rb
+++ b/modules/exploits/windows/fileformat/office_ms17_11882.rb
@@ -25,6 +25,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'License' => MSF_LICENSE,
       'DisclosureDate' => 'Nov 15 2017',
       'References' => [
+        ['CVE', '2017-11882'],
         ['URL', 'https://embedi.com/blog/skeleton-closet-ms-office-vulnerability-you-didnt-know-about'],
         ['URL', 'https://github.com/embedi/CVE-2017-11882']
       ],


### PR DESCRIPTION
The references for this exploit contain a URI with a CVE identifier, but that identifier is not called out separately in the module's list of references.