### PR TITLE
Update payloads to 1.3.45

### DIFF
--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -70,7 +70,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '1.3.44'
+  spec.add_runtime_dependency 'metasploit-payloads', '1.3.45'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '0.4.1'
   # Needed by msfgui and other rpc components


### PR DESCRIPTION
This bumps the payloads version to incorporate https://github.com/rapid7/metasploit-payloads/pull/239
Wait for tests to complete and land

