### PR TITLE
Remove trailing space from CVE identifier

### DIFF
--- a/modules/exploits/windows/browser/asus_net4switch_ipswcom.rb
+++ b/modules/exploits/windows/browser/asus_net4switch_ipswcom.rb
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'References'     =>
         [
-          [ 'CVE', '2012-4924 ' ],
+          [ 'CVE', '2012-4924' ],
           [ 'OSVDB', '79438' ],
           [ 'URL', 'http://dsecrg.com/pages/vul/show.php?id=417' ]
         ],


### PR DESCRIPTION
The ASUS Net4Switch ipswcom exploit mistakenly included a trailing space at the end of its CVE reference.