### PR TITLE
Add prompt to persist data service connection in msfdb

### DIFF
--- a/msfdb
+++ b/msfdb
@@ -56,13 +56,13 @@ require 'yaml'
 }
 
 
-def run_cmd(cmd, input = nil)
+def run_cmd(cmd, input: nil, env: {})
   exitstatus = 0
   err = out = ""
 
-  puts "run_cmd: cmd=#{cmd}, input=#{input}" if @options[:debug]
+  puts "run_cmd: cmd=#{cmd}, input=#{input}, env=#{env}" if @options[:debug]
 
-  Open3.popen3(cmd) do |stdin, stdout, stderr, wait_thr|
+  Open3.popen3(env, cmd) do |stdin, stdout, stderr, wait_thr|
     stdin.puts(input) if input
     if @options[:debug]
       err = stderr.read
@@ -216,9 +216,9 @@ def init_db
   run_psql("alter role #{@options[:msf_db_user]} with password '#{@msf_pass}'")
   run_psql("alter role #{@options[:msftest_db_user]} with password '#{@msftest_pass}'")
   run_cmd("createdb -p #{@options[:db_port]} -O #{@options[:msf_db_user]} -h 127.0.0.1 -U #{@options[:msf_db_user]} -E UTF-8 -T template0 #{@options[:msf_db_name]}",
-          "#{@msf_pass}\n#{@msf_pass}\n")
+          input: "#{@msf_pass}\n#{@msf_pass}\n")
   run_cmd("createdb -p #{@options[:db_port]} -O #{@options[:msftest_db_user]} -h 127.0.0.1 -U #{@options[:msftest_db_user]} -E UTF-8 -T template0 #{@options[:msftest_db_name]}",
-          "#{@msftest_pass}\n#{@msftest_pass}\n")
+          input: "#{@msftest_pass}\n#{@msftest_pass}\n")
 
   write_db_client_auth_config
   restart_db

--- a/msfdb
+++ b/msfdb
@@ -642,26 +642,22 @@ def output_web_service_information
   puts ''
   puts 'MSF web service configuration complete'
   puts 'Connect to the data service in msfconsole using the command:'
-  # build db_connect command based on install options
-  connect_cmd = "db_connect --token #{@ws_api_token}"
-  connect_cmd << " --cert #{@options[:ssl_cert]}" if @options[:ssl]
-  connect_cmd << " --skip-verify" if skip_ssl_verify?
-  connect_cmd << " #{get_web_service_uri}"
-  puts "#{connect_cmd}"
+  puts "#{get_db_connect_command}"
   puts ''
   puts 'The username and password are credentials for the API account:'
   puts "#{get_web_service_uri(path: '/api/v1/auth/account')}"
   puts ''
 
-  persist_data_service(connect_cmd: connect_cmd)
+  persist_data_service
 end
 
-def persist_data_service(connect_cmd:)
+def persist_data_service
   if ask_yn('Add data service connection to local msfconsole and persist as default?')
     data_service_name = "local-#{@options[:ssl] ? 'https' : 'http'}-data-service"
     data_service_name = ask_value('Data service connection name?', data_service_name)
     # execute msfconsole commands to add and persist the data service connection
-    cmd = "msfconsole -qx \"#{connect_cmd}; db_save -d #{data_service_name}; exit\""
+    connect_cmd = get_db_connect_command(name: data_service_name)
+    cmd = "msfconsole -qx \"#{connect_cmd}; db_save; exit\""
     if run_cmd(cmd) != 0
       # attempt to execute msfconsole in the current working directory
       if run_cmd(cmd, env: {'PATH' => ".:#{ENV["PATH"]}"}) != 0
@@ -669,6 +665,17 @@ def persist_data_service(connect_cmd:)
       end
     end
   end
+end
+
+def get_db_connect_command(name: nil)
+  # build db_connect command based on install options
+  connect_cmd = "db_connect"
+  connect_cmd << " --name #{name}" unless name.nil?
+  connect_cmd << " --token #{@ws_api_token}"
+  connect_cmd << " --cert #{@options[:ssl_cert]}" if @options[:ssl]
+  connect_cmd << " --skip-verify" if skip_ssl_verify?
+  connect_cmd << " #{get_web_service_uri}"
+  connect_cmd
 end
 
 def get_web_service_uri(path: nil)

--- a/msfdb
+++ b/msfdb
@@ -641,13 +641,13 @@ end
 def output_web_service_information
   puts ''
   puts 'MSF web service configuration complete'
-  puts 'Add the data service in msfconsole using the command:'
-  # build data services command based on install options
-  ds_cmd = "data_services --add --token #{@ws_api_token}"
-  ds_cmd << " --ssl --cert #{@options[:ssl_cert]}" if @options[:ssl]
-  ds_cmd << " --skip-verify" if skip_ssl_verify?
-  ds_cmd << " #{get_web_service_host}"
-  puts "#{ds_cmd}"
+  puts 'Connect to the data service in msfconsole using the command:'
+  # build db_connect command based on install options
+  connect_cmd = "db_connect --token #{@ws_api_token}"
+  connect_cmd << " --cert #{@options[:ssl_cert]}" if @options[:ssl]
+  connect_cmd << " --skip-verify" if skip_ssl_verify?
+  connect_cmd << " #{get_web_service_uri}"
+  puts "#{connect_cmd}"
   puts ''
   puts 'The username and password are credentials for the API account:'
   puts "#{get_web_service_uri(path: '/api/v1/auth/account')}"

--- a/msfdb
+++ b/msfdb
@@ -651,6 +651,24 @@ def output_web_service_information
   puts ''
   puts 'The username and password are credentials for the API account:'
   puts "#{get_web_service_uri(path: '/api/v1/auth/account')}"
+  puts ''
+
+  persist_data_service(connect_cmd: connect_cmd)
+end
+
+def persist_data_service(connect_cmd:)
+  if ask_yn('Add data service connection to local msfconsole and persist as default?')
+    data_service_name = "local-#{@options[:ssl] ? 'https' : 'http'}-data-service"
+    data_service_name = ask_value('Data service connection name?', data_service_name)
+    # execute msfconsole commands to add and persist the data service connection
+    cmd = "msfconsole -qx \"#{connect_cmd}; db_save -d #{data_service_name}; exit\""
+    if run_cmd(cmd) != 0
+      # attempt to execute msfconsole in the current working directory
+      if run_cmd(cmd, env: {'PATH' => ".:#{ENV["PATH"]}"}) != 0
+        puts 'Failed to run msfconsole and persist the data service connection'
+      end
+    end
+  end
 end
 
 def get_web_service_uri(path: nil)


### PR DESCRIPTION
Adds a user prompt to `msfdb` during initialization to persist a data service connection to the newly created MSF web service in the user's `msfconsole` config.

This PR should be delayed until #10532 is landed since it depends on functionality introduced in that PR.

## Verification

- [x] If you already have an existing database execute `msfdb reinit`, otherwise, `msfdb init` and follow prompts to initialize both a database and web service
- [x] **Verify** you are prompted to add a data service connection to local msfconsole and persist it as default
- [x] Start `msfconsole`
- [x] **Verify** `db_status` reports `Connection type: http. Connected to remote_data_service: (https://localhost:8080)`
- [x] **Verify** `db_connect -l` displays a data service with the name specified when prompted in `msfdb` and the "default?" column contains an asterisk