### PR TITLE
Rescue REX runtime errors in x86 encoders

### DIFF
--- a/modules/encoders/x86/countdown.rb
+++ b/modules/encoders/x86/countdown.rb
@@ -47,7 +47,7 @@ class MetasploitModule < Msf::Encoder::Xor
       state.context = 1
     rescue RuntimeError => e
       raise BadcharError if e.message == "No valid set instruction could be created!"
-    end 
+    end
     return decoder
   end
 

--- a/modules/encoders/x86/countdown.rb
+++ b/modules/encoders/x86/countdown.rb
@@ -31,21 +31,23 @@ class MetasploitModule < Msf::Encoder::Xor
     if (modified_registers & saved_registers).length > 0
       raise BadGenerateError
     end
+    begin
+      decoder =
+        Rex::Arch::X86.set(
+          Rex::Arch::X86::ECX,
+          state.buf.length - 1,
+          state.badchars) +
+        "\xe8\xff\xff\xff" +  # call $+4
+        "\xff\xc1" +          # inc ecx
+        "\x5e" +              # pop esi
+        "\x30\x4c\x0e\x07" +  # xor_loop: xor [esi + ecx + 0x07], cl
+        "\xe2\xfa"            # loop xor_loop
 
-    decoder =
-      Rex::Arch::X86.set(
-        Rex::Arch::X86::ECX,
-        state.buf.length - 1,
-        state.badchars) +
-      "\xe8\xff\xff\xff" +  # call $+4
-      "\xff\xc1" +          # inc ecx
-      "\x5e" +              # pop esi
-      "\x30\x4c\x0e\x07" +  # xor_loop: xor [esi + ecx + 0x07], cl
-      "\xe2\xfa"            # loop xor_loop
-
-    # Initialize the state context to 1
-    state.context = 1
-
+      # Initialize the state context to 1
+      state.context = 1
+    rescue RuntimeError => e
+      raise BadcharError if e.message == "No valid set instruction could be created!"
+    end 
     return decoder
   end
 

--- a/modules/encoders/x86/nonalpha.rb
+++ b/modules/encoders/x86/nonalpha.rb
@@ -42,7 +42,11 @@ class MetasploitModule < Msf::Encoder::NonAlpha
   # payload.
   #
   def encode_block(state, block)
-    newchar, state.key, state.decoder_key_size = Rex::Encoder::NonAlpha::encode_byte(block.unpack('C')[0], state.key, state.decoder_key_size)
+    begin
+      newchar, state.key, state.decoder_key_size = Rex::Encoder::NonAlpha::encode_byte(block.unpack('C')[0], state.key, state.decoder_key_size)
+    rescue RuntimeError => e
+      raise BadcharError if e.message == "BadChar"
+    end
     return newchar
   end
 


### PR DESCRIPTION
fixes #10551

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfvenom -p windows/meterpreter_reverse_https LHOST=127.0.0.1 LPORT=443 --smallest -b '\x00\x0a\x0d\x20' -f c > /tmp/shellcode`
- [x] **Verify** that every compatible encoder is tried
