### PR TITLE
Fix missing normalize_uri in struts2_rest_xstream

### DIFF
--- a/modules/exploits/multi/http/struts2_rest_xstream.rb
+++ b/modules/exploits/multi/http/struts2_rest_xstream.rb
@@ -110,7 +110,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     res = send_request_cgi(
       'method' => 'POST',
-      'uri'    => target_uri.path,
+      'uri'    => normalize_uri(target_uri.path),
       'ctype'  => 'application/xml',
       'data'   => xstream_payload(cmd)
     )


### PR DESCRIPTION
Ideally, plain `TARGETURI` should still be normalized despite no joining.

#8924