### PR TITLE
Update label for the kiwi extention to match latest ver

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/kiwi.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/kiwi.rb
@@ -38,7 +38,7 @@ class Console::CommandDispatcher::Kiwi
     super
     print_line
     print_line
-    print_line("  .#####.   mimikatz 2.1.1 20170608 (#{client.session_type})")
+    print_line("  .#####.   mimikatz 2.1.1 20180820 (#{client.session_type})")
     print_line(" .## ^ ##.  \"A La Vie, A L'Amour\"")
     print_line(" ## / \\ ##  /* * *")
     print_line(" ## \\ / ##   Benjamin DELPY `gentilkiwi` ( benjamin@gentilkiwi.com )")


### PR DESCRIPTION
I'll also update this PR with the udpated binaries when the paylaods
repo has landed https://github.com/rapid7/metasploit-payloads/pull/298

Again, no exposed updates to actual Mimikatz features, I'm just getting the binaries up to date so I can expose them later.