### PR TITLE
AKA Metadata Refactor

### DIFF
--- a/modules/auxiliary/admin/smb/ms17_010_command.rb
+++ b/modules/auxiliary/admin/smb/ms17_010_command.rb
@@ -32,10 +32,6 @@ class MetasploitModule < Msf::Auxiliary
 
       'License'        => MSF_LICENSE,
       'References'     => [
-        [ 'AKA', 'ETERNALSYNERGY' ],
-        [ 'AKA', 'ETERNALROMANCE' ],
-        [ 'AKA', 'ETERNALCHAMPION' ],
-        [ 'AKA', 'ETERNALBLUE'],  # does not use any CVE from Blue, but Search should show this, it is preferred
         [ 'MSB', 'MS17-010' ],
         [ 'CVE', '2017-0143'], # EternalRomance/EternalSynergy - Type confusion between WriteAndX and Transaction requests
         [ 'CVE', '2017-0146'], # EternalChampion/EternalSynergy - Race condition with Transaction requests
@@ -44,7 +40,16 @@ class MetasploitModule < Msf::Auxiliary
         [ 'URL', 'https://hitcon.org/2017/CMT/slide-files/d2_s2_r0.pdf' ],
         [ 'URL', 'https://blogs.technet.microsoft.com/srd/2017/06/29/eternal-champion-exploit-analysis/' ],
       ],
-      'DisclosureDate' => 'Mar 14 2017'
+      'DisclosureDate' => 'Mar 14 2017',
+      'Notes' =>
+          {
+              'AKA' => [
+                  'ETERNALSYNERGY',
+                  'ETERNALROMANCE',
+                  'ETERNALCHAMPION',
+                  'ETERNALBLUE'      # does not use any CVE from Blue, but Search should show this, it is preferred
+              ]
+          }
     ))
 
     register_options([

--- a/modules/auxiliary/admin/teradata/teradata_odbc_sql.py
+++ b/modules/auxiliary/admin/teradata/teradata_odbc_sql.py
@@ -32,8 +32,7 @@ metadata = {
     'license': 'MSF_LICENSE',
     'references': [
         {'type': 'url', 'ref': 'https://developer.teradata.com/tools/reference/teradata-python-module'},
-        {'type': 'url', 'ref': 'https://downloads.teradata.com/download/connectivity/odbc-driver/linux'},
-        {'type': 'aka', 'ref': 'Teradata ODBC Authentication Scanner'}
+        {'type': 'url', 'ref': 'https://downloads.teradata.com/download/connectivity/odbc-driver/linux'}
     ],
     'type': 'single_scanner',
     'options': {
@@ -42,6 +41,9 @@ metadata = {
         'username': {'type': 'string', 'description': 'Username', 'required': True, 'default': 'dbc'},
         'password': {'type': 'string', 'description': 'Password', 'required': True, 'default': 'dbc'},
         'sql': {'type': 'string', 'description': 'SQL query to perform', 'required': True, 'default': 'SELECT DATABASENAME FROM DBC.DATABASES'},
+    },
+    'notes': {
+        'AKA': ['Teradata ODBC Authentication Scanner']
     }
 }
 

--- a/modules/auxiliary/gather/get_user_spns.py
+++ b/modules/auxiliary/gather/get_user_spns.py
@@ -43,9 +43,7 @@ metadata = {
     'license': 'CORE_LICENSE',
     'references': [
         {'type': 'url', 'ref': 'https://github.com/CoreSecurity/impacket/blob/master/examples/GetUserSPNs.py'},
-        {'type': 'url', 'ref': 'https://files.sans.org/summit/hackfest2014/PDFs/Kicking%20the%20Guard%20Dog%20of%20Hades%20-%20Attacking%20Microsoft%20Kerberos%20%20-%20Tim%20Medin(1).pdf'},
-        {'type': 'aka', 'ref': 'GetUserSPNs.py'},
-        {'type': 'aka', 'ref': 'Kerberoast'}
+        {'type': 'url', 'ref': 'https://files.sans.org/summit/hackfest2014/PDFs/Kicking%20the%20Guard%20Dog%20of%20Hades%20-%20Attacking%20Microsoft%20Kerberos%20%20-%20Tim%20Medin(1).pdf'}
     ],
     'type': 'single_scanner',
     'options': {
@@ -53,6 +51,12 @@ metadata = {
         'domain': {'type': 'string', 'description': 'The target Active Directory domain', 'required': True, 'default': None},
         'user': {'type': 'string', 'description': 'Username for a domain account', 'required': True, 'default': None},
         'pass': {'type': 'string', 'description': 'Password for the domain user account', 'required': True, 'default': None}
+    },
+    'notes': {
+        'AKA': [
+            'GetUserSPNs.py',
+            'Kerberoast'
+        ]
     }}
 
 class GetUserSPNs:

--- a/modules/auxiliary/scanner/http/apache_mod_cgi_bash_env.rb
+++ b/modules/auxiliary/scanner/http/apache_mod_cgi_bash_env.rb
@@ -31,7 +31,6 @@ class MetasploitModule < Msf::Auxiliary
         'lcamtuf' # CVE-2014-6278
       ],
       'References' => [
-        [ 'AKA', 'Shellshock' ],
         [ 'CVE', '2014-6271' ],
         [ 'CVE', '2014-6278' ],
         [ 'OSVDB', '112004' ],
@@ -40,7 +39,11 @@ class MetasploitModule < Msf::Auxiliary
         [ 'URL', 'http://seclists.org/oss-sec/2014/q3/649' ]
       ],
       'DisclosureDate' => 'Sep 24 2014',
-      'License' => MSF_LICENSE
+      'License' => MSF_LICENSE,
+      'Notes' =>
+          {
+            'AKA' => ['Shellshock']
+          }
     ))
 
     register_options([

--- a/modules/auxiliary/scanner/http/apache_optionsbleed.rb
+++ b/modules/auxiliary/scanner/http/apache_optionsbleed.rb
@@ -21,14 +21,17 @@ class MetasploitModule < Msf::Auxiliary
         'h00die', # Metasploit module
       ],
       'References' => [
-        [ 'AKA', 'Optionsbleed' ],
         [ 'CVE', '2017-9798' ],
         [ 'EDB', '42745' ],
         [ 'URL', 'https://github.com/hannob/optionsbleed' ],
         [ 'URL', 'https://blog.fuzzing-project.org/60-Optionsbleed-HTTP-OPTIONS-method-can-leak-Apaches-server-memory.html' ]
       ],
       'DisclosureDate' => 'Sep 18 2017',
-      'License' => MSF_LICENSE
+      'License' => MSF_LICENSE,
+      'Notes' =>
+          {
+              'AKA' => ['Optionsbleed']
+          }
     ))
 
     register_options([

--- a/modules/auxiliary/scanner/smb/impacket/dcomexec.py
+++ b/modules/auxiliary/scanner/smb/impacket/dcomexec.py
@@ -44,8 +44,7 @@ metadata = {
     'references': [
         {'type': 'url', 'ref': 'https://enigma0x3.net/2017/01/05/lateral-movement-using-the-mmc20-application-com-object/'},
         {'type': 'url', 'ref': 'https://enigma0x3.net/2017/01/23/lateral-movement-via-dcom-round-2/'},
-        {'type': 'url', 'ref': 'https://github.com/CoreSecurity/impacket/blob/master/examples/dcomexec.py'},
-        {'type': 'aka', 'ref': 'dcomexec.py'},
+        {'type': 'url', 'ref': 'https://github.com/CoreSecurity/impacket/blob/master/examples/dcomexec.py'}
      ],
     'type': 'single_scanner',
     'options': {
@@ -55,6 +54,9 @@ metadata = {
         'SMBDomain':  {'type': 'string', 'description': 'The Windows domain to use for authentication', 'required': False, 'default': '.'},
         'SMBPass':    {'type': 'string', 'description': 'The password for the specified username', 'required': True, 'default': None},
         'SMBUser':    {'type': 'string', 'description': 'The username to authenticate as', 'required': True, 'default': None},
+    },
+    'notes': {
+        'AKA': ['dcomexec.py']
     }
 }
 

--- a/modules/auxiliary/scanner/smb/impacket/secretsdump.py
+++ b/modules/auxiliary/scanner/smb/impacket/secretsdump.py
@@ -51,8 +51,7 @@ metadata = {
         {'type': 'url', 'ref': 'http://www.beginningtoseethelight.org/ntsecurity/index.htm'},
         {'type': 'url', 'ref': 'http://www.ntdsxtract.com/downloads/ActiveDirectoryOfflineHashDumpAndForensics.pdf'},
         {'type': 'url', 'ref': 'http://www.passcape.com/index.php?section=blog&cmd=details&id=15'},
-        {'type': 'url', 'ref': 'https://github.com/CoreSecurity/impacket/blob/master/examples/secretsdump.py'},
-        {'type': 'aka', 'ref': 'secretsdump.py'},
+        {'type': 'url', 'ref': 'https://github.com/CoreSecurity/impacket/blob/master/examples/secretsdump.py'}
      ],
     'type': 'single_scanner',
     'options': {
@@ -61,6 +60,9 @@ metadata = {
         'SMBDomain':  {'type': 'string', 'description': 'The Windows domain to use for authentication', 'required': False, 'default': '.'},
         'SMBPass':    {'type': 'string', 'description': 'The password for the specified username', 'required': True, 'default': None},
         'SMBUser':    {'type': 'string', 'description': 'The username to authenticate as', 'required': True, 'default': None},
+    },
+    'notes': {
+        'AKA': ['secretsdump.py']
     }
 }
 

--- a/modules/auxiliary/scanner/smb/impacket/wmiexec.py
+++ b/modules/auxiliary/scanner/smb/impacket/wmiexec.py
@@ -34,8 +34,7 @@ metadata = {
     'date': '2018-03-19',
     'license': 'CORE_LICENSE',
     'references': [
-        {'type': 'url', 'ref': 'https://github.com/CoreSecurity/impacket/blob/master/examples/wmiexec.py'},
-        {'type': 'aka', 'ref': 'wmiexec.py'},
+        {'type': 'url', 'ref': 'https://github.com/CoreSecurity/impacket/blob/master/examples/wmiexec.py'}
      ],
     'type': 'single_scanner',
     'options': {
@@ -44,6 +43,9 @@ metadata = {
         'SMBDomain':  {'type': 'string', 'description': 'The Windows domain to use for authentication', 'required': False, 'default': '.'},
         'SMBPass':    {'type': 'string', 'description': 'The password for the specified username', 'required': True, 'default': None},
         'SMBUser':    {'type': 'string', 'description': 'The username to authenticate as', 'required': True, 'default': None},
+    },
+    'notes': {
+        'AKA': ['wmiexec.py']
     }
 }
 

--- a/modules/auxiliary/scanner/smb/smb_ms17_010.rb
+++ b/modules/auxiliary/scanner/smb/smb_ms17_010.rb
@@ -34,8 +34,6 @@ class MetasploitModule < Msf::Auxiliary
           ],
       'References'     =>
         [
-          [ 'AKA', 'DOUBLEPULSAR' ],
-          [ 'AKA', 'ETERNALBLUE' ],
           [ 'CVE', '2017-0143'],
           [ 'CVE', '2017-0144'],
           [ 'CVE', '2017-0145'],
@@ -47,7 +45,14 @@ class MetasploitModule < Msf::Auxiliary
           [ 'URL', 'https://github.com/countercept/doublepulsar-detection-script'],
           [ 'URL', 'https://technet.microsoft.com/en-us/library/security/ms17-010.aspx']
         ],
-      'License'        => MSF_LICENSE
+      'License'        => MSF_LICENSE,
+      'Notes' =>
+          {
+              'AKA' => [
+                  'DOUBLEPULSAR',
+                  'ETERNALBLUE'
+              ]
+          }
     ))
 
     register_options(

--- a/modules/auxiliary/scanner/ssl/bleichenbacher_oracle.py
+++ b/modules/auxiliary/scanner/ssl/bleichenbacher_oracle.py
@@ -56,9 +56,7 @@ metadata = {
         {'type': 'cve', 'ref': '2012-5081'}, # Oracle Java
         {'type': 'url', 'ref': 'https://robotattack.org'},
         {'type': 'url', 'ref': 'https://eprint.iacr.org/2017/1189'},
-        {'type': 'url', 'ref': 'https://github.com/robotattackorg/robot-detect'}, # Original PoC
-        {'type': 'aka', 'ref': 'ROBOT'},
-        {'type': 'aka', 'ref': 'Adaptive chosen-ciphertext attack'}
+        {'type': 'url', 'ref': 'https://github.com/robotattackorg/robot-detect'} # Original PoC
      ],
     'type': 'single_scanner',
     'options': {
@@ -66,6 +64,12 @@ metadata = {
         'rport': {'type': 'port', 'description': 'The target port', 'required': True, 'default': 443},
         'cipher_group': {'type': 'enum', 'description': 'Use TLS_RSA ciphers with AES and 3DES ciphers, or only TLS_RSA_WITH_AES_128_CBC_SHA or TLS-RSA-WITH-AES-128-GCM-SHA256', 'required': True, 'default': 'all', 'values': ['all', 'cbc', 'gcm']},
         'timeout': {'type': 'int', 'description': 'The delay to wait for TLS responses', 'required': True, 'default': 5}
+     },
+     'notes': {
+         'AKA': [
+            'ROBOT',
+            'Adaptive chosen-ciphertext attack'
+         ]
      }}
 
 cipher_handshakes = {

--- a/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
+++ b/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
@@ -129,7 +129,6 @@ class MetasploitModule < Msf::Auxiliary
       ],
       'References'     =>
         [
-          [ 'AKA', 'Heartbleed' ],
           [ 'CVE', '2014-0160' ],
           [ 'US-CERT-VU', '720951' ],
           [ 'URL', 'https://www.us-cert.gov/ncas/alerts/TA14-098A' ],
@@ -146,7 +145,11 @@ class MetasploitModule < Msf::Auxiliary
           ['DUMP',  {'Description' => 'Dump memory contents'}],
           ['KEYS',  {'Description' => 'Recover private keys from memory'}]
         ],
-      'DefaultAction' => 'SCAN'
+      'DefaultAction' => 'SCAN',
+      'Notes' =>
+          {
+              'AKA' => ['Heartbleed']
+          }
     )
 
     register_options(

--- a/modules/auxiliary/scanner/teradata/teradata_odbc_login.py
+++ b/modules/auxiliary/scanner/teradata/teradata_odbc_login.py
@@ -34,8 +34,7 @@ metadata = {
     'license': 'MSF_LICENSE',
     'references': [
         {'type': 'url', 'ref': 'https://developer.teradata.com/tools/reference/teradata-python-module'},
-        {'type': 'url', 'ref': 'https://downloads.teradata.com/download/connectivity/odbc-driver/linux'},
-        {'type': 'aka', 'ref': 'Teradata ODBC Login Scanner'}
+        {'type': 'url', 'ref': 'https://downloads.teradata.com/download/connectivity/odbc-driver/linux'}
     ],
     'type': 'single_host_login_scanner',
     'options': {
@@ -44,7 +43,10 @@ metadata = {
         'userpass': {'type': 'string', 'description': 'A list of username/password combinations to try', 'required': False},
         'sleep_interval': {'type': 'float', 'description': 'Time in seconds to wait between login attempts', 'required': False}
     },
-    'service_name': 'teradata'
+    'service_name': 'teradata',
+    'notes': {
+        'AKA': ['Teradata ODBC Login Scanner']
+    }
 }
 
 

--- a/modules/auxiliary/scanner/wproxy/att_open_proxy.py
+++ b/modules/auxiliary/scanner/wproxy/att_open_proxy.py
@@ -19,15 +19,19 @@ metadata = {
     'references': [
         {'type': 'cve', 'ref': '2017-14117'},
         {'type': 'url', 'ref': 'https://www.nomotion.net/blog/sharknatto/'},
-        {'type': 'url', 'ref': 'https://blog.rapid7.com/2017/09/07/measuring-sharknat-to-exposures/#vulnerability5port49152tcpexposure'},
-        {'type': 'aka', 'ref': 'SharknAT&To'},
-        {'type': 'aka', 'ref': 'sharknatto'}
+        {'type': 'url', 'ref': 'https://blog.rapid7.com/2017/09/07/measuring-sharknat-to-exposures/#vulnerability5port49152tcpexposure'}
      ],
     'type': 'multi_scanner',
     'options': {
         'rhosts': {'type': 'address_range', 'description': 'The target address', 'required': True, 'default': None},
         'rport': {'type': 'port', 'description': 'The target port', 'required': True, 'default': 49152},
      },
+     'notes': {
+         'AKA': [
+            'SharknAT&To',
+            'sharknatto'
+         ]
+     }
     }
 
 

--- a/modules/auxiliary/server/dhclient_bash_env.rb
+++ b/modules/auxiliary/server/dhclient_bash_env.rb
@@ -35,7 +35,6 @@ class MetasploitModule < Msf::Auxiliary
         ],
       'DefaultAction'  => 'Service',
       'References' => [
-        [ 'AKA', 'Shellshock' ],
         [ 'CVE', '2014-6271' ],
         [ 'CWE', '94' ],
         [ 'OSVDB', '112004' ],
@@ -44,7 +43,11 @@ class MetasploitModule < Msf::Auxiliary
         [ 'URL', 'http://seclists.org/oss-sec/2014/q3/649' ],
         [ 'URL', 'https://www.trustedsec.com/september-2014/shellshock-dhcp-rce-proof-concept/' ]
       ],
-      'DisclosureDate' => 'Sep 24 2014'
+      'DisclosureDate' => 'Sep 24 2014',
+      'Notes' =>
+          {
+              'AKA' => ['Shellshock']
+          }
     )
 
     register_options(

--- a/modules/auxiliary/server/openssl_heartbeat_client_memory.rb
+++ b/modules/auxiliary/server/openssl_heartbeat_client_memory.rb
@@ -29,13 +29,17 @@ class MetasploitModule < Msf::Auxiliary
       'DefaultAction'  => 'Capture',
       'References'     =>
         [
-          [ 'AKA', 'Heartbleed' ],
           [ 'CVE', '2014-0160' ],
           [ 'US-CERT-VU', '720951' ],
           [ 'URL', 'https://www.us-cert.gov/ncas/alerts/TA14-098A' ],
           [ 'URL', 'http://heartbleed.com/' ]
         ],
-      'DisclosureDate' => 'Apr 07 2014'
+      'DisclosureDate' => 'Apr 07 2014',
+      'Notes' =>
+          {
+              'AKA' => ['Heartbleed']
+          }
+
     )
 
     register_options(

--- a/modules/exploits/android/browser/stagefright_mp4_tx3g_64bit.rb
+++ b/modules/exploits/android/browser/stagefright_mp4_tx3g_64bit.rb
@@ -50,7 +50,6 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'References'     =>
         [
-          [ 'AKA', 'stagefright' ],
           [ 'CVE', '2015-3864' ],
           [ 'URL', 'https://blog.exodusintel.com/2015/08/13/stagefright-mission-accomplished/' ],
           [ 'URL', 'http://googleprojectzero.blogspot.com/2015/09/stagefrightened.html' ],
@@ -347,7 +346,12 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'Privileged'     => true,
       'DisclosureDate' => "Aug 13 2015",
-      'DefaultTarget'  => 0))
+      'DefaultTarget'  => 0,
+      'Notes' =>
+          {
+              'AKA' => ['stagefright']
+          }
+      ))
 
 =begin
     register_options(

--- a/modules/exploits/linux/http/advantech_switch_bash_env_exec.rb
+++ b/modules/exploits/linux/http/advantech_switch_bash_env_exec.rb
@@ -18,7 +18,6 @@ class MetasploitModule < Msf::Exploit::Remote
       },
       'Author' => 'hdm',
       'References' => [
-        [ 'AKA', 'Shellshock' ],
         [ 'CVE', '2014-6271' ],
         [ 'CWE', '94' ],
         [ 'OSVDB', '112004' ],
@@ -44,7 +43,11 @@ class MetasploitModule < Msf::Exploit::Remote
       'Targets' =>  [[ 'Automatic Targeting', { 'auto' => true } ]],
       'DefaultTarget' => 0,
       'License' => MSF_LICENSE,
-      'DisclosureDate' => 'Dec 01 2015'
+      'DisclosureDate' => 'Dec 01 2015',
+      'Notes' =>
+          {
+              'AKA' => ['Shellshock']
+          }
     ))
     register_options([
       Opt::RPORT(80)

--- a/modules/exploits/linux/http/ipfire_bashbug_exec.rb
+++ b/modules/exploits/linux/http/ipfire_bashbug_exec.rb
@@ -24,7 +24,6 @@ class MetasploitModule < Msf::Exploit::Remote
           ],
         'References'     =>
           [
-            [ 'AKA', 'Shellshock' ],
             [ 'EDB', '34839' ],
             [ 'CVE', '2014-6271']
           ],
@@ -50,7 +49,11 @@ class MetasploitModule < Msf::Exploit::Remote
             [ 'Automatic Target', {}]
           ],
         'DefaultTarget'  => 0,
-        'DisclosureDate' => 'Sep 29 2014'
+        'DisclosureDate' => 'Sep 29 2014',
+        'Notes' =>
+            {
+                'AKA' => ['Shellshock']
+            }
       )
     )
 

--- a/modules/exploits/linux/local/af_packet_chocobo_root_priv_esc.rb
+++ b/modules/exploits/linux/local/af_packet_chocobo_root_priv_esc.rb
@@ -51,7 +51,6 @@ class MetasploitModule < Msf::Exploit::Local
       'Privileged'     => true,
       'References'     =>
         [
-          [ 'AKA', 'chocobo_root.c' ],
           [ 'EDB', '40871' ],
           [ 'CVE', '2016-8655' ],
           [ 'BID', '94692' ],
@@ -63,7 +62,12 @@ class MetasploitModule < Msf::Exploit::Local
           [ 'URL', 'https://www.securitytracker.com/id/1037403' ],
           [ 'URL', 'https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=84ac7260236a49c79eede91617700174c2c19b0c' ]
         ],
-      'DefaultTarget'  => 0))
+      'DefaultTarget'  => 0,
+      'Notes' =>
+          {
+              'AKA' => ['chocobo_root.c']
+          }
+    ))
     register_options [
       OptInt.new('TIMEOUT', [ true, 'Race timeout (seconds)', '600' ]),
       OptEnum.new('COMPILE', [ true, 'Compile on target', 'Auto', %w(Auto True False) ]),

--- a/modules/exploits/linux/local/bpf_sign_extension_priv_esc.rb
+++ b/modules/exploits/linux/local/bpf_sign_extension_priv_esc.rb
@@ -63,8 +63,6 @@ class MetasploitModule < Msf::Exploit::Local
       'Privileged'     => true,
       'References'     =>
         [
-          [ 'AKA', 'get-rekt-linux-hardened.c' ],
-          [ 'AKA', 'upstream44.c' ],
           [ 'BID', '102288' ],
           [ 'CVE', '2017-16995' ],
           [ 'EDB', '44298' ],
@@ -81,7 +79,16 @@ class MetasploitModule < Msf::Exploit::Local
           [ 'URL', 'http://openwall.com/lists/oss-security/2017/12/21/2'],
           [ 'URL', 'https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=95a762e2c8c942780948091f8f2a4f32fce1ac6f' ]
         ],
-      'DefaultTarget'  => 0))
+      'DefaultTarget'  => 0,
+      'Notes' =>
+          {
+              'AKA' =>
+                  [
+                      'get-rekt-linux-hardened.c',
+                      'upstream44.c'
+                  ]
+          }
+      ))
     register_options [
       OptEnum.new('COMPILE', [ true, 'Compile on target', 'Auto', %w[Auto True False] ]),
       OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ])

--- a/modules/exploits/linux/local/glibc_realpath_priv_esc.rb
+++ b/modules/exploits/linux/local/glibc_realpath_priv_esc.rb
@@ -44,7 +44,6 @@ class MetasploitModule < Msf::Exploit::Local
       'Privileged'     => true,
       'References'     =>
         [
-          [ 'AKA', 'RationalLove.c' ],
           [ 'BID', '102525' ],
           [ 'CVE', '2018-1000001' ],
           [ 'EDB', '43775' ],
@@ -55,7 +54,12 @@ class MetasploitModule < Msf::Exploit::Local
           [ 'URL', 'https://usn.ubuntu.com/3534-1/' ],
           [ 'URL', 'https://bugzilla.redhat.com/show_bug.cgi?id=1533836' ]
         ],
-      'DefaultTarget'  => 0))
+      'DefaultTarget'  => 0,
+      'Notes' =>
+          {
+              'AKA' => ['RationalLove.c']
+          }
+    ))
     register_options [
       OptEnum.new('COMPILE', [ true, 'Compile on target', 'Auto', %w(Auto True False) ]),
       OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ]),

--- a/modules/exploits/linux/local/libuser_roothelper_priv_esc.rb
+++ b/modules/exploits/linux/local/libuser_roothelper_priv_esc.rb
@@ -59,7 +59,6 @@ class MetasploitModule < Msf::Exploit::Local
       'Privileged'     => true,
       'References'     =>
         [
-          [ 'AKA', 'roothelper.c' ],
           [ 'EDB', '37706' ],
           [ 'CVE', '2015-3245' ],
           [ 'CVE', '2015-3246' ],
@@ -68,7 +67,12 @@ class MetasploitModule < Msf::Exploit::Local
           [ 'URL', 'http://seclists.org/oss-sec/2015/q3/185' ],
           [ 'URL', 'https://access.redhat.com/articles/1537873' ]
         ],
-      'DefaultTarget'  => 0))
+      'DefaultTarget'  => 0,
+      'Notes' =>
+          {
+              'AKA' => ['roothelper.c']
+          }
+    ))
     register_options [
       OptEnum.new('COMPILE', [ true, 'Compile on target', 'Auto', %w(Auto True False) ]),
       OptString.new('PASSWORD', [ true, 'Password for the current user', '' ]),

--- a/modules/exploits/linux/local/rds_priv_esc.rb
+++ b/modules/exploits/linux/local/rds_priv_esc.rb
@@ -39,7 +39,6 @@ class MetasploitModule < Msf::Exploit::Local
       'Privileged'     => true,
       'References'     =>
         [
-          [ 'AKA', 'rds-fail.c' ],
           [ 'EDB', '15285' ],
           [ 'CVE', '2010-3904' ],
           [ 'BID', '44219' ],
@@ -55,7 +54,12 @@ class MetasploitModule < Msf::Exploit::Local
           'WfsDelay'    => 10,
           'PrependFork' => true
         },
-      'DefaultTarget'  => 0))
+      'DefaultTarget'  => 0,
+      'Notes' =>
+          {
+              'AKA' => ['rds-fail.c']
+          }
+    ))
     register_options [
       OptEnum.new('COMPILE', [ true, 'Compile on target', 'Auto', %w(Auto True False) ]),
       OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ]),

--- a/modules/exploits/linux/smtp/haraka.py
+++ b/modules/exploits/linux/smtp/haraka.py
@@ -32,7 +32,6 @@ metadata = {
     'authors': ['xychix <xychix[AT]hotmail.com>', 'smfreegard', 'Adam Cammack <adam_cammack[AT]rapid7.com>'],
     'date': '2017-01-26',
     'references': [
-        {'type': 'aka', 'ref': 'Harakiri'},
         {'type': 'cve', 'ref': '2016-1000282'},
         {'type': 'edb', 'ref': '41162'},
         {'type': 'url', 'ref': 'https://github.com/haraka/Haraka/pull/1606'},
@@ -54,6 +53,9 @@ metadata = {
         'rhost': {'type': 'address', 'description': 'Target server', 'required': True, 'default': None},
         'rport': {'type': 'port', 'description': 'Target server port', 'required': True, 'default': 25},
         'command': {'type': 'string', 'description': 'Command to run on the target', 'required': True, 'default': '/bin/echo hello'}
+     },
+     'notes': {
+         'AKA': ['Harakiri']
      }}
 
 

--- a/modules/exploits/multi/browser/adobe_flash_hacking_team_uaf.rb
+++ b/modules/exploits/multi/browser/adobe_flash_hacking_team_uaf.rb
@@ -32,7 +32,6 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'References'          =>
         [
-          ['AKA', '0DayFlush'],
           ['CVE', '2015-5119'],
           ['URL', 'https://helpx.adobe.com/security/products/flash-player/apsa15-03.html'],
           ['URL', 'http://blog.trendmicro.com/trendlabs-security-intelligence/unpatched-flash-player-flaws-more-pocs-found-in-hacking-team-leak/'],
@@ -91,7 +90,12 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'Privileged'          => false,
       'DisclosureDate'      => 'Jul 06 2015',
-      'DefaultTarget'       => 0))
+      'DefaultTarget'       => 0,
+      'Notes' =>
+          {
+              'AKA' => ['0DayFlush']
+          }
+  ))
   end
 
   def exploit

--- a/modules/exploits/multi/ftp/pureftpd_bash_env_exec.rb
+++ b/modules/exploits/multi/ftp/pureftpd_bash_env_exec.rb
@@ -27,7 +27,6 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'References'      =>
         [
-          [ 'AKA', 'Shellshock' ],
           [ 'CVE', '2014-6271' ],
           [ 'CWE', '94' ],
           [ 'OSVDB', '112004' ],
@@ -62,7 +61,12 @@ class MetasploitModule < Msf::Exploit::Remote
           'PrependFork' => true
         },
       'DefaultTarget'  => 0,
-      'DisclosureDate' => 'Sep 24 2014'))
+      'DisclosureDate' => 'Sep 24 2014',
+      'Notes' =>
+          {
+              'AKA' => ['Shellshock']
+          }
+    ))
     register_options(
       [
         Opt::RPORT(21),

--- a/modules/exploits/multi/http/apache_mod_cgi_bash_env_exec.rb
+++ b/modules/exploits/multi/http/apache_mod_cgi_bash_env_exec.rb
@@ -25,7 +25,6 @@ class MetasploitModule < Msf::Exploit::Remote
         'lcamtuf' # CVE-2014-6278
       ],
       'References' => [
-        [ 'AKA', 'Shellshock' ],
         [ 'CVE', '2014-6271' ],
         [ 'CVE', '2014-6278' ],
         [ 'CWE', '94' ],
@@ -58,7 +57,11 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'DefaultTarget' => 0,
       'DisclosureDate' => 'Sep 24 2014',
-      'License' => MSF_LICENSE
+      'License' => MSF_LICENSE,
+      'Notes' =>
+          {
+              'AKA' => ['Shellshock']
+          }
     ))
 
     register_options([

--- a/modules/exploits/multi/http/cups_bash_env_exec.rb
+++ b/modules/exploits/multi/http/cups_bash_env_exec.rb
@@ -22,7 +22,6 @@ class MetasploitModule < Msf::Exploit::Remote
         'Brendan Coles <bcoles[at]gmail.com>' # msf
       ],
       'References' => [
-        [ 'AKA', 'Shellshock' ],
         [ 'CVE', '2014-6271' ],
         [ 'CVE', '2014-6278' ],
         [ 'CWE', '94' ],
@@ -53,7 +52,11 @@ class MetasploitModule < Msf::Exploit::Remote
       'Targets' =>  [[ 'Automatic Targeting', { 'auto' => true } ]],
       'DefaultTarget' => 0,
       'DisclosureDate' => 'Sep 24 2014',
-      'License' => MSF_LICENSE
+      'License' => MSF_LICENSE,
+      'Notes' =>
+          {
+              'AKA' => ['Shellshock']
+          }
     ))
     register_options([
       Opt::RPORT(631),

--- a/modules/exploits/osx/local/vmware_bash_function_root.rb
+++ b/modules/exploits/osx/local/vmware_bash_function_root.rb
@@ -29,7 +29,6 @@ class MetasploitModule < Msf::Exploit::Local
         ],
       'References'    =>
         [
-          [ 'AKA', 'Shellshock' ],
           [ 'CVE', '2014-6271' ],
           [ 'CWE', '94' ],
           [ 'OSVDB', '112004' ],
@@ -47,7 +46,11 @@ class MetasploitModule < Msf::Exploit::Local
         ]
       ],
       'DefaultTarget' => 0,
-      'DisclosureDate' => 'Sep 24 2014'
+      'DisclosureDate' => 'Sep 24 2014',
+      'Notes' =>
+          {
+              'AKA' => ['Shellshock']
+          }
     ))
 
     register_options [

--- a/modules/exploits/unix/dhcp/bash_environment.rb
+++ b/modules/exploits/unix/dhcp/bash_environment.rb
@@ -32,7 +32,6 @@ class MetasploitModule < Msf::Exploit::Remote
       'Arch'           => ARCH_CMD,
       'References'     =>
         [
-          [ 'AKA', 'Shellshock' ],
           [ 'CVE', '2014-6271' ],
           [ 'CWE', '94' ],
           [ 'OSVDB', '112004' ],
@@ -54,7 +53,11 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'Targets'        => [ [ 'Automatic Target', { }] ],
       'DefaultTarget'  => 0,
-      'DisclosureDate' => 'Sep 24 2014'
+      'DisclosureDate' => 'Sep 24 2014',
+      'Notes' =>
+          {
+              'AKA' => ['Shellshock']
+          }
     ))
 
     deregister_options('DOMAINNAME', 'HOSTNAME', 'URL')

--- a/modules/exploits/unix/dhcp/rhel_dhcp_client_command_injection.rb
+++ b/modules/exploits/unix/dhcp/rhel_dhcp_client_command_injection.rb
@@ -32,7 +32,6 @@ class MetasploitModule < Msf::Exploit::Remote
       'Privileged'     => true,
       'References'     =>
         [
-          ['AKA', 'DynoRoot'],
           ['CVE', '2018-1111'],
           ['EDB': '44652'],
           ['URL', 'https://github.com/kkirsche/CVE-2018-1111'],
@@ -45,7 +44,11 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'Targets'        => [ [ 'Automatic Target', { }] ],
       'DefaultTarget'  => 0,
-      'DisclosureDate' => 'May 15 2018'
+      'DisclosureDate' => 'May 15 2018',
+      'Notes' =>
+          {
+              'AKA' => ['DynoRoot']
+          }
     ))
 
     deregister_options('DOMAINNAME', 'HOSTNAME', 'URL', 'FILENAME')

--- a/modules/exploits/unix/fileformat/ghostscript_type_confusion.rb
+++ b/modules/exploits/unix/fileformat/ghostscript_type_confusion.rb
@@ -22,7 +22,6 @@ class MetasploitModule < Msf::Exploit
         'hdm'                      # Metasploit module
       ],
       'References'      => [
-        %w{AKA ghostbutt},
         %w{CVE 2017-8291},
         %w{URL https://bugs.ghostscript.com/show_bug.cgi?id=697808},
         %w{URL http://seclists.org/oss-sec/2017/q2/148},
@@ -50,6 +49,9 @@ class MetasploitModule < Msf::Exploit
         'LHOST'                 => Rex::Socket.source_address,
         'DisablePayloadHandler' => false,
         'WfsDelay'              => 9001
+      },
+      'Notes'           => {
+        'AKA'           => [ 'ghostbutt' ]
       }
     ))
 

--- a/modules/exploits/unix/webapp/drupal_drupalgeddon2.rb
+++ b/modules/exploits/unix/webapp/drupal_drupalgeddon2.rb
@@ -35,8 +35,6 @@ class MetasploitModule < Msf::Exploit::Remote
         ['URL', 'https://github.com/a2u/CVE-2018-7600'],
         ['URL', 'https://github.com/nixawk/labs/issues/19'],
         ['URL', 'https://github.com/FireFart/CVE-2018-7600'],
-        ['AKA', 'SA-CORE-2018-002'],
-        ['AKA', 'Drupalgeddon 2']
       ],
       'DisclosureDate' => 'Mar 28 2018',
       'License'        => MSF_LICENSE,
@@ -124,7 +122,14 @@ class MetasploitModule < Msf::Exploit::Remote
         ]
       ],
       'DefaultTarget'  => 0, # Automatic (PHP In-Memory)
-      'DefaultOptions' => {'WfsDelay' => 2}
+      'DefaultOptions' => {'WfsDelay' => 2},
+      'Notes' =>
+          {
+              'AKA' => [
+                  'SA-CORE-2018-002',
+                  'Drupalgeddon 2'
+              ]
+          }
     ))
 
     register_options([

--- a/modules/exploits/windows/iis/iis_webdav_scstoragepathfromurl.rb
+++ b/modules/exploits/windows/iis/iis_webdav_scstoragepathfromurl.rb
@@ -34,7 +34,6 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'References'     =>
         [
-          [ 'AKA', 'EXPLODINGCAN' ],
           [ 'CVE', '2017-7269' ],
           [ 'BID', '97127' ],
           [ 'URL', 'https://github.com/edwardz246003/IIS_exploit' ],
@@ -69,7 +68,12 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'Platform'       => 'win',
       'DisclosureDate' => 'Mar 26 2017',
-      'DefaultTarget'  => 0))
+      'DefaultTarget'  => 0,
+      'Notes' =>
+          {
+              'AKA' => ['EXPLODINGCAN']
+          }
+    ))
 
     register_options(
       [

--- a/modules/exploits/windows/smb/ms17_010_eternalblue.rb
+++ b/modules/exploits/windows/smb/ms17_010_eternalblue.rb
@@ -47,7 +47,6 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'References'     =>
         [
-          [ 'AKA', 'ETERNALBLUE' ],
           [ 'MSB', 'MS17-010' ],
           [ 'CVE', '2017-0143' ],
           [ 'CVE', '2017-0144' ],
@@ -85,7 +84,11 @@ class MetasploitModule < Msf::Exploit::Remote
           ],
         ],
       'DefaultTarget'  => 0,
-      'DisclosureDate' => 'Mar 14 2017'
+      'DisclosureDate' => 'Mar 14 2017',
+      'Notes'     =>
+          {
+              'AKA' => ['ETERNALBLUE']
+          }
     ))
 
     register_options(

--- a/modules/exploits/windows/smb/ms17_010_eternalblue_win8.py
+++ b/modules/exploits/windows/smb/ms17_010_eternalblue_win8.py
@@ -73,8 +73,7 @@ metadata = {
         {'type': 'cve', 'ref': '2017-0147'},
         {'type': 'cve', 'ref': '2017-0148'},
         {'type': 'edb', 'ref': '42030'},
-        {'type': 'url', 'ref': 'https://github.com/worawit/MS17-010'},
-        {'type': 'aka', 'ref': 'ETERNALBLUE'}
+        {'type': 'url', 'ref': 'https://github.com/worawit/MS17-010'}
     ],
     'date': 'Mar 14 2017',
     'type': 'remote_exploit',
@@ -93,6 +92,9 @@ metadata = {
         # Windows 2012 does not allow anonymous to login if no share is accessible.
         'SMBUser': {'type': 'string', 'description': '(Optional) The username to authenticate as', 'required': False, 'default': ''},
         'SMBPass': {'type': 'string', 'description': '(Optional) The password for the specified username', 'required': False, 'default': ''}
+    },
+    'notes': {
+         'AKA': ['ETERNALBLUE']
     }
 }
 

--- a/modules/exploits/windows/smb/ms17_010_psexec.rb
+++ b/modules/exploits/windows/smb/ms17_010_psexec.rb
@@ -51,10 +51,6 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'References'     =>
         [
-          [ 'AKA', 'ETERNALSYNERGY' ],
-          [ 'AKA', 'ETERNALROMANCE' ],
-          [ 'AKA', 'ETERNALCHAMPION' ],
-          [ 'AKA', 'ETERNALBLUE'],  # does not use any CVE from Blue, but Search should show this, it is preferred
           [ 'MSB', 'MS17-010' ],
           [ 'CVE', '2017-0143'], # EternalRomance/EternalSynergy - Type confusion between WriteAndX and Transaction requests
           [ 'CVE', '2017-0146'], # EternalChampion/EternalSynergy - Race condition with Transaction requests
@@ -78,7 +74,16 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'MOF upload', { } ]
         ],
       'DefaultTarget'  => 0,
-      'DisclosureDate' => 'Mar 14 2017'
+      'DisclosureDate' => 'Mar 14 2017',
+      'Notes' =>
+          {
+              'AKA' => [
+                  'ETERNALSYNERGY',
+                  'ETERNALROMANCE',
+                  'ETERNALCHAMPION',
+                  'ETERNALBLUE'      # does not use any CVE from Blue, but Search should show this, it is preferred
+              ]
+          }
     ))
 
     register_options(


### PR DESCRIPTION
Moves all AKA references into new `notes` metadata field
See PR #10563 for additional details

Note: This conversion is 4.x compatible, although search by `aka` references will be lost

## Verification

When testing module-related features, I recommend using the following four modules:

| Path  | AKA | Description |
| ------------- | ------------- | ------------- |
| `exploit/windows/iis/iis_webdav_scstoragepathfromurl`  | `EXPLODINGCAN ` | A module with a single AKA value  |
| `exploit/windows/smb/ms17_010_psexec`  | `ETERNALSYNERGY`, `ETERNALROMANCE`, `ETERNALCHAMPION`, `ETERNALBLUE` | A module with multiple (4) AKA values  |
| `exploit/linux/smtp/haraka`| `Harakiri` |A Python module with an AKA value  |
| `exploit/multi/hams/steamed` | n/a | A module with no AKA values |

- [x] **Regenerate** module cache and **verify** it updated correctly
  - [x] `rm db/modules_metadata_base.json ~/.msf4/store/modules_metadata.json`
  - [x]  `./msfconsole -qx 'irb -e framework.modules.refresh_cache_from_module_files; exit'`
  - [x] **Verify** `~/.msf4/store/modules_metadata.json` is correct.
    - [x] **Verify** that each module has a `notes` field, and that it is never `null`
    - [x] **Verify** that each of the four test modules contain their expected `AKA` values in their respective `notes` fields
  - [x] `cp ~/.msf4/store/modules_metadata.json db/modules_metadata_base.json`
  - [x] **DON'T commit** any module cache changes