### PR TITLE
Remove trailing comma from ret option

### DIFF
--- a/lib/msf/core/module/target.rb
+++ b/lib/msf/core/module/target.rb
@@ -139,7 +139,7 @@ class Msf::Module::Target
     self.name            = name
     self.opts            = opts
     self.save_registers  = opts['SaveRegisters']
-    self.ret             = opts['Ret'],
+    self.ret             = opts['Ret']
     self.default_options = opts['DefaultOptions']
 
     if opts['Platform']


### PR DESCRIPTION
Fix issue causing target.ret to be an array

## Verification
- [ ] `./msfconsole -q`
- [ ] `use exploit/windows/brightstor/universal_agent`
- [ ] `set rhosts 127.0.0.1`
- [ ] `run`
- [ ] If nothing is running on 127.0.0.1:6050 you should get a connection refused error.

Prior to the fix, you would get the error `TypeError no implicit conversion of Array into Integer`.

## Example

```
msfdev@simulator:~/git/metasploit-framework
$ ./msfconsole -q
msf5 > use exploit/windows/brightstor/universal_agent
msf5 exploit(windows/brightstor/universal_agent) > set rhosts 127.0.0.1
rhosts => 127.0.0.1
msf5 exploit(windows/brightstor/universal_agent) > run

[!] You are binding to a loopback address by setting LHOST to 127.0.0.1. Did you want ReverseListenerBindAddress?
[*] Started reverse TCP handler on 127.0.0.1:4444 
[*] 127.0.0.1:6050 - Trying target Magic Heap Target #1...
[-] 127.0.0.1:6050 - Exploit failed [unreachable]: Rex::ConnectionRefused The connection was refused by the remote host (127.0.0.1:6050).
[*] Exploit completed, but no session was created.
msf5 exploit(windows/brightstor/universal_agent) > exit
[ruby-2.5.1@metasploit-framework](array-int-fix) 
msfdev@simulator:~/git/metasploit-framework
$ git checkout upstream-master
Switched to branch 'upstream-master'
Your branch is up-to-date with 'upstream/master'.
[ruby-2.5.1@metasploit-framework](upstream-master) 
msfdev@simulator:~/git/metasploit-framework
$ ./msfconsole -q 
msf5 > use exploit/windows/brightstor/universal_agent
msf5 exploit(windows/brightstor/universal_agent) > set rhosts 127.0.0.1
rhosts => 127.0.0.1
msf5 exploit(windows/brightstor/universal_agent) > run

[!] You are binding to a loopback address by setting LHOST to 127.0.0.1. Did you want ReverseListenerBindAddress?
[*] Started reverse TCP handler on 127.0.0.1:4444 
[*] 127.0.0.1:6050 - Trying target Magic Heap Target #1...
[-] 127.0.0.1:6050 - Exploit failed: TypeError no implicit conversion of Array into Integer
[*] Exploit completed, but no session was created.
msf5 exploit(windows/brightstor/universal_agent) >
```
