### PR TITLE
Fix target DisableNops not being passed to payload

### DIFF
--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -557,6 +557,7 @@ class Exploit < Msf::Module
     reqs['BadChars']        = payload_badchars(explicit_target)
     reqs['Append']          = payload_append(explicit_target)
     reqs['AppendEncoder']   = payload_append_encoder(explicit_target)
+    reqs['DisableNops']     = payload_disable_nops(explicit_target)
     reqs['MaxNops']         = payload_max_nops(explicit_target)
     reqs['MinNops']         = payload_min_nops(explicit_target)
     reqs['Encoder']         = datastore['ENCODER'] || payload_encoder(explicit_target)
@@ -877,6 +878,19 @@ class Exploit < Msf::Module
     end
 
     p
+  end
+
+  #
+  # Whether NOP generation should be enabled or disabled
+  #
+  def payload_disable_nops(explicit_target = nil)
+    explicit_target ||= target
+
+    if (explicit_target and explicit_target.payload_disable_nops)
+      explicit_target.payload_disable_nops
+    else
+      payload_info['DisableNops']
+    end
   end
 
   #

--- a/lib/msf/core/module/target.rb
+++ b/lib/msf/core/module/target.rb
@@ -220,6 +220,13 @@ class Msf::Module::Target
   end
 
   #
+  # Whether NOP generation should be enabled or disabled
+  #
+  def payload_disable_nops
+    opts['Payload'] ? opts['Payload']['DisableNops'] : nil
+  end
+
+  #
   # Payload max nops information for this target.
   #
   def payload_max_nops


### PR DESCRIPTION
`DisableNops` doesn't work in a target, but `Space` and other related options do, so there is no straightforward way to avoid NOP generation in a target with a space restriction.

Please see #9892 and #9898 for context.

- [x] Set `DisableNops` in a target with `Space` (example: `'Payload' => {'Space' => 4089, 'DisableNops' => true}`)
- [x] Test to see that NOP generation was disabled

Required by #10564. cc @wchen-r7