### PR TITLE
Update metasploit-payloads to 1.3.48

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,7 +18,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 1.3.47)
+      metasploit-payloads (= 1.3.48)
       metasploit_data_models
       metasploit_payloads-mettle (= 0.4.1)
       mqtt
@@ -164,7 +164,7 @@ GEM
       activemodel (~> 4.2.6)
       activesupport (~> 4.2.6)
       railties (~> 4.2.6)
-    metasploit-payloads (1.3.47)
+    metasploit-payloads (1.3.48)
     metasploit_data_models (3.0.0)
       activerecord (~> 4.2.6)
       activesupport (~> 4.2.6)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -70,7 +70,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '1.3.47'
+  spec.add_runtime_dependency 'metasploit-payloads', '1.3.48'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '0.4.1'
   # Needed by msfgui and other rpc components

--- a/modules/payloads/singles/windows/meterpreter_bind_named_pipe.rb
+++ b/modules/payloads/singles/windows/meterpreter_bind_named_pipe.rb
@@ -12,7 +12,7 @@ require 'rex/payloads/meterpreter/config'
 
 module MetasploitModule
 
-  CachedSize = 179779
+  CachedSize = 182851
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/meterpreter_bind_tcp.rb
+++ b/modules/payloads/singles/windows/meterpreter_bind_tcp.rb
@@ -12,7 +12,7 @@ require 'rex/payloads/meterpreter/config'
 
 module MetasploitModule
 
-  CachedSize = 179779
+  CachedSize = 182851
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/windows/meterpreter_reverse_http.rb
@@ -12,7 +12,7 @@ require 'rex/payloads/meterpreter/config'
 
 module MetasploitModule
 
-  CachedSize = 180825
+  CachedSize = 183897
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/windows/meterpreter_reverse_https.rb
@@ -12,7 +12,7 @@ require 'rex/payloads/meterpreter/config'
 
 module MetasploitModule
 
-  CachedSize = 180825
+  CachedSize = 183897
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/meterpreter_reverse_ipv6_tcp.rb
+++ b/modules/payloads/singles/windows/meterpreter_reverse_ipv6_tcp.rb
@@ -12,7 +12,7 @@ require 'rex/payloads/meterpreter/config'
 
 module MetasploitModule
 
-  CachedSize = 179779
+  CachedSize = 182851
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/meterpreter_reverse_tcp.rb
@@ -12,7 +12,7 @@ require 'rex/payloads/meterpreter/config'
 
 module MetasploitModule
 
-  CachedSize = 179779
+  CachedSize = 182851
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/x64/meterpreter_bind_named_pipe.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_bind_named_pipe.rb
@@ -12,7 +12,7 @@ require 'rex/payloads/meterpreter/config'
 
 module MetasploitModule
 
-  CachedSize = 206403
+  CachedSize = 211523
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/x64/meterpreter_bind_tcp.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_bind_tcp.rb
@@ -12,7 +12,7 @@ require 'rex/payloads/meterpreter/config'
 
 module MetasploitModule
 
-  CachedSize = 206403
+  CachedSize = 211523
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_http.rb
@@ -12,7 +12,7 @@ require 'rex/payloads/meterpreter/config'
 
 module MetasploitModule
 
-  CachedSize = 207449
+  CachedSize = 212569
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_https.rb
@@ -12,7 +12,7 @@ require 'rex/payloads/meterpreter/config'
 
 module MetasploitModule
 
-  CachedSize = 207449
+  CachedSize = 212569
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_ipv6_tcp.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_ipv6_tcp.rb
@@ -12,7 +12,7 @@ require 'rex/payloads/meterpreter/config'
 
 module MetasploitModule
 
-  CachedSize = 206403
+  CachedSize = 211523
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_tcp.rb
@@ -12,7 +12,7 @@ require 'rex/payloads/meterpreter/config'
 
 module MetasploitModule
 
-  CachedSize = 206403
+  CachedSize = 211523
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows


### PR DESCRIPTION
This bumps the payloads gem to incorporate changes made in https://github.com/rapid7/metasploit-payloads/pull/174. universal unhooking.

This is a bit more of a dicey land than usual, so I need to run extra tests.

## Verification

List the steps needed to make sure this thing works

- [ ] Make sure payloads built correctly
- [ ] make sure all submodules are present
- [ ] allow tests to pass

