### PR TITLE
Add CVE reference to ghostscript_failed_restore.rb

### DIFF
--- a/modules/exploits/multi/fileformat/ghostscript_failed_restore.rb
+++ b/modules/exploits/multi/fileformat/ghostscript_failed_restore.rb
@@ -35,7 +35,8 @@ class MetasploitModule < Msf::Exploit
       ],
       'References'     => [
         ['URL', 'http://seclists.org/oss-sec/2018/q3/142'],
-        ['URL', 'https://bugs.chromium.org/p/project-zero/issues/detail?id=1640']
+        ['URL', 'https://bugs.chromium.org/p/project-zero/issues/detail?id=1640'],
+        ['CVE', '2018-16509']
       ],
       'DisclosureDate' => 'Aug 21 2018',
       'License'        => MSF_LICENSE,


### PR DESCRIPTION
The CVE was assigned just a few days ago and didn't make it into the references.

Verification
-----------

- [x] Start `msfconsole`
- [x] `use exploit/multi/fileformat/ghostscript_failed_restore`
- [x] `info` should show a CVE url

#10564