### PR TITLE
fix xml ctypes in store_loot

### DIFF
--- a/modules/auxiliary/scanner/smb/smb_enum_gpp.rb
+++ b/modules/auxiliary/scanner/smb/smb_enum_gpp.rb
@@ -129,7 +129,7 @@ class MetasploitModule < Msf::Auxiliary
 
     results.each do |result|
       if datastore['STORE']
-        stored_path = store_loot('windows.gpp.xml', 'text/plain', ip, xml_file[:xml], file_type, xml_file[:path])
+        stored_path = store_loot('windows.gpp.xml', 'text/xml', ip, xml_file[:xml], file_type, xml_file[:path])
         print_good("XML file saved to: #{stored_path}")
       end
 

--- a/modules/post/multi/gather/jenkins_gather.rb
+++ b/modules/post/multi/gather/jenkins_gather.rb
@@ -53,7 +53,7 @@ class MetasploitModule < Msf::Post
     if exists?(file)
       f = read_file(file)
       if datastore['STORE_LOOT']
-        loot_path = store_loot('credentials.xml', 'text/plain', session, f)
+        loot_path = store_loot('credentials.xml', 'text/xml', session, f)
         vprint_status("File credentials.xml saved to #{loot_path}")
       end
     else

--- a/modules/post/windows/gather/credentials/gpp.rb
+++ b/modules/post/windows/gather/credentials/gpp.rb
@@ -246,7 +246,7 @@ class MetasploitModule < Msf::Post
 
     results.each do |result|
       if datastore['STORE']
-        stored_path = store_loot('windows.gpp.xml', 'text/plain', session, xmlfile[:xml], filetype, xmlfile[:path])
+        stored_path = store_loot('windows.gpp.xml', 'text/xml', session, xmlfile[:xml], filetype, xmlfile[:path])
         print_good("XML file saved to: #{stored_path}")
         print_line
       end


### PR DESCRIPTION
A few modules save .xml files as 'text/plain' ctype, this fixes them to 'text/xml'.  Most likely makes 0 difference, but it bothered me.