### PR TITLE
Fix crash when using sessions -x

### DIFF
--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -664,7 +664,7 @@ class ReadableText
       end
 
       if session.exploit_datastore && session.exploit_datastore.has_key?('LURI') && !session.exploit_datastore['LURI'].empty?
-        row << "(#{exploit_datastore['LURI']})"
+        row << "(#{session.exploit_datastore['LURI']})"
       else
         row << '?'
       end


### PR DESCRIPTION
When using `sessions -x`, exceptions were being throw, like so:

![image](https://user-images.githubusercontent.com/28896/45336462-1168cb80-b5c7-11e8-8281-b2d5868d089a.png)

This isn't an issue if you don't use `-x`. This PR fixes this problem.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Create a session of any kind
- [x] Run `sessions -x`
- [x] **Verify** you don't get a stack trace dumped.
- [x] **Verify** you get a list of sessions with extended information.
