### PR TITLE
Fix Msf::Post::Solaris::Kernel class name

### DIFF
--- a/lib/msf/core/post/solaris/kernel.rb
+++ b/lib/msf/core/post/solaris/kernel.rb
@@ -3,7 +3,7 @@ require 'msf/core/post/common'
 
 module Msf
 class Post
-module Linux
+module Solaris
 module Kernel
   include ::Msf::Post::Common
 


### PR DESCRIPTION
Fix typo in `Msf::Post::Solaris::Kernel` class name.

https://github.com/rapid7/metasploit-framework/pull/10437#issuecomment-419984613
