### PR TITLE
Add `repeat` command for repeating other commands

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -106,6 +106,7 @@ class Core
       "history"    => "Show command history",
       "load"       => "Load a framework plugin",
       "quit"       => "Exit the console",
+      "repeat"     => "Repeat a list of commands",
       "route"      => "Route traffic through a session",
       "save"       => "Saves the active datastores",
       "sessions"   => "Dump session listings and display information about sessions",
@@ -2075,6 +2076,78 @@ class Core
   def cmd_grep_tabs(str, words)
     str = '-' if str.empty? # default to use grep's options
     tabs = cmd_grep '--generate-completions', str
+
+    # if not an opt, use normal tab comp.
+    # @todo uncomment out next line when tab_completion normalization is complete RM7649 or
+    # replace with new code that permits "nested" tab completion
+    # tabs = driver.get_all_commands if (str and str =~ /\w/)
+    tabs
+  end
+
+  def cmd_repeat_help
+    cmd_repeat '-h'
+  end
+
+  #
+  # Repeats (loops) a given list of commands
+  #
+  def cmd_repeat(*args)
+    looper = method :loop
+
+    opts = OptionParser.new do |opts|
+      opts.banner = 'Usage: repeat [OPTIONS] COMMAND...'
+      opts.separator 'Repeat (loop) a ;-separated list of msfconsole commands indefinitely, or for a'
+      opts.separator 'number of iterations or a certain amount of time.'
+      opts.separator ''
+
+      opts.on '-t SECONDS', '--time SECONDS', 'Number of seconds to repeat COMMAND...', Integer do |n|
+        looper = ->(&block) do
+          # While CLOCK_MONOTONIC is a Linux thing, Ruby emulates it for *BSD, MacOS, and Windows
+          ending_time = Process.clock_gettime(Process::CLOCK_MONOTONIC, :second) + n
+          while Process.clock_gettime(Process::CLOCK_MONOTONIC, :second) < ending_time
+            block.call
+          end
+        end
+      end
+
+      opts.on '-n TIMES', '--number TIMES', 'Number of times to repeat COMMAND..', Integer do |n|
+        looper = n.method(:times)
+      end
+
+      opts.on '-h', '--help', 'Help banner.' do
+        return print(opts.help)
+      end
+
+      # Internal use
+      opts.on '--generate-completions str', 'Return possible tab completions for given string.' do |str|
+        return opts.candidate str
+      end
+    end
+
+    cmds = opts.order(args).slice_when do |prev, _|
+      # If the last character of a shellword was a ';' it's probably to
+      # delineate commands and we can remove it
+      prev[-1] == ';' && prev[-1] = ''
+    end.map do |c|
+      Shellwords.shelljoin(c)
+    end
+
+    begin
+      looper.call do
+        cmds.each do |c|
+          driver.run_single c, propogate_errors: true
+        end
+      end
+    rescue ::Exception
+      # Stop looping on exception
+      nil
+    end
+  end
+
+  # Almost the exact same as grep
+  def cmd_repeat_tabs(str, words)
+    str = '-' if str.empty? # default to use repeat's options
+    tabs = cmd_repeat '--generate-completions', str
 
     # if not an opt, use normal tab comp.
     # @todo uncomment out next line when tab_completion normalization is complete RM7649 or

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -2132,6 +2132,9 @@ class Core
       Shellwords.shelljoin(c)
     end
 
+    # Print help if we have no commands, or all the commands are empty
+    return cmd_repeat '-h' if cmds.all? &:empty?
+
     begin
       looper.call do
         cmds.each do |c|

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1997,8 +1997,8 @@ class Core
     end
 
     # OptionParser#order allows us to take the rest of the line for the command
-    pattern, *cmd = opts.order(args)
-    cmd = cmd.join(" ")
+    pattern, *rest = opts.order(args)
+    cmd = Shellwords.shelljoin(rest)
     return print(opts.help) if !pattern || cmd.empty?
 
     rx = Regexp.new(pattern, match_mods[:insensitive])
@@ -2034,7 +2034,7 @@ class Core
 
     # Bail if the command failed
     if cmd_output =~ /Unknown command:/
-      print_error("Unknown command: #{args[0]}.")
+      print_error("Unknown command: '#{rest[0]}'.")
       return false
     end
     # put lines into an array so we can access them more easily and split('\n') doesn't work on the output obj.

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -2135,7 +2135,7 @@ class Core
     begin
       looper.call do
         cmds.each do |c|
-          driver.run_single c, propogate_errors: true
+          driver.run_single c, propagate_errors: true
         end
       end
     rescue ::Exception

--- a/lib/rex/ui/text/dispatcher_shell.rb
+++ b/lib/rex/ui/text/dispatcher_shell.rb
@@ -456,7 +456,7 @@ module DispatcherShell
         rescue ::Interrupt
           print_error("#{method}: Interrupted")
           raise if propogate_errors
-        rescue OptionParser::ParseError
+        rescue OptionParser::ParseError => e
           print_error("#{method}: #{e.message}")
           raise if propogate_errors
         rescue

--- a/lib/rex/ui/text/dispatcher_shell.rb
+++ b/lib/rex/ui/text/dispatcher_shell.rb
@@ -432,7 +432,7 @@ module DispatcherShell
   #
   # Run a single command line.
   #
-  def run_single(line, propogate_errors: false)
+  def run_single(line, propagate_errors: false)
     arguments = parse_line(line)
     method    = arguments.shift
     found     = false

--- a/lib/rex/ui/text/dispatcher_shell.rb
+++ b/lib/rex/ui/text/dispatcher_shell.rb
@@ -453,6 +453,8 @@ module DispatcherShell
             run_command(dispatcher, method, arguments)
             found = true
           end
+        rescue OptionParser::ParseError
+          print_error("#{method}: #{e.message}")
         rescue
           error = $!
 
@@ -490,8 +492,6 @@ module DispatcherShell
     else
       dispatcher.send('cmd_' + method, *arguments)
     end
-  rescue OptionParser::ParseError => e
-    print_error("#{method}: #{e.message}")
   ensure
     self.busy = false
   end

--- a/lib/rex/ui/text/dispatcher_shell.rb
+++ b/lib/rex/ui/text/dispatcher_shell.rb
@@ -432,7 +432,7 @@ module DispatcherShell
   #
   # Run a single command line.
   #
-  def run_single(line)
+  def run_single(line, propogate_errors: false)
     arguments = parse_line(line)
     method    = arguments.shift
     found     = false
@@ -453,19 +453,27 @@ module DispatcherShell
             run_command(dispatcher, method, arguments)
             found = true
           end
+        rescue ::Interrupt
+          print_error("#{method}: Interrupted")
+          raise if propogate_errors
         rescue OptionParser::ParseError
           print_error("#{method}: #{e.message}")
+          raise if propogate_errors
         rescue
           error = $!
 
           print_error(
             "Error while running command #{method}: #{$!}" +
             "\n\nCall stack:\n#{$@.join("\n")}")
-        rescue ::Exception
+
+          raise if propogate_errors
+        rescue ::Exception => e
           error = $!
 
           print_error(
             "Error while running command #{method}: #{$!}")
+
+          raise if propogate_errors
         end
 
         # If the dispatcher stack changed as a result of this command,

--- a/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
+++ b/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
@@ -109,7 +109,10 @@ class MetasploitModule < Msf::Auxiliary
         STARTTLS may also be vulnerable.
 
         The module supports several actions, allowing for scanning, dumping of
-        memory contents, and private key recovery.
+        memory contents, and private key recovery. The `repeat` command can be
+        used to make running the `DUMP` many times more convient. As in:
+            repeat -t 60 run; sleep 2
+        To run every two seconds for one minute.
       },
       'Author'         => [
         'Neel Mehta', # Vulnerability discovery

--- a/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
+++ b/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
@@ -110,7 +110,7 @@ class MetasploitModule < Msf::Auxiliary
 
         The module supports several actions, allowing for scanning, dumping of
         memory contents, and private key recovery. The `repeat` command can be
-        used to make running the `DUMP` many times more convient. As in:
+        used to make running the `DUMP` many times more convenient. As in:
             repeat -t 60 run; sleep 2
         To run every two seconds for one minute.
       },


### PR DESCRIPTION
Recently watching an assessment I came across a need to dump lots of memory from a heartbleed-vulnerable host (manually running the module lots of times was technically an option, but there wasn't a lot of time). I hacked something up with `irb` and `driver.run_single`, but it didn't feel very satisfying or user-friendly. I imagine there are other classes of auxiliary module that could use this, so instead of adding module specific options for repetition I added a new command that can be used with any module/command.

The `repeat` command will continue starting commands until a certain amount of time elapses with `-t`, for a fixed number of iterations with `-n`, or indefinitely (the default). It supports running a list of commands separated by `;`, since the `sleep` command (and probably others) might come in handy. Any exception running a command will cause the loop to stop.

Verification
========

- [x] start `msfconsole`

Happy path
------------
- [x] `repeat grep grep grep; sleep 1` should print two lines every second until you `CTRL-C`
- [x] `repeat -n 5 grep grep grep; sleep 1` should print the same 5 times
- [x] `repeat -t 6 grep grep grep; sleep 1` should do the same
- [x] `repeat -h` and `help repeat` should be identical and informative
- [x] Options to `repeat` should tab-complete

Sad path
---------
- [x] `repeat -t 5 grep -A` should print an error and not loop
- [x] `repeat -t asdf grep grep grep` should print an error and not loop
- [x] `repeat -n asdf grep grep grep` should print an error and not loop
- [x] `repeat` (with and without options) should print help when run with no commands