### PR TITLE
Add SMB2 support to smb_enumshares

### DIFF
--- a/modules/auxiliary/scanner/smb/smb_enumshares.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumshares.rb
@@ -330,7 +330,7 @@ class MetasploitModule < Msf::Auxiliary
       @smb_redirect = info[1]
 
       begin
-        connect
+        connect(versions: [2,1])
         smb_login
         shares = smb_netshareenumall
 


### PR DESCRIPTION
Fixes #10623

Add versions argument for SMB2 support in smb_enumshares module.

```
$ ./msfconsole -q 
msf5 > use auxiliary/scanner/smb/smb_enumshares
msf5 auxiliary(scanner/smb/smb_enumshares) > set rhosts 172.22.222.200
rhosts => 172.22.222.200
msf5 auxiliary(scanner/smb/smb_enumshares) > set smbuser msfdev
smbuser => msfdev
msf5 auxiliary(scanner/smb/smb_enumshares) > set smbpass msfdev
smbpass => msfdev
msf5 auxiliary(scanner/smb/smb_enumshares) > run

[-] 172.22.222.200:139    - Login Failed: Unable to Negotiate with remote host
[+] 172.22.222.200:445    - ADMIN$ - (DS) Remote Admin
[+] 172.22.222.200:445    - C$ - (DS) Default share
[+] 172.22.222.200:445    - IPC$ - (I) Remote IPC
[*] 172.22.222.200:       - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf5 auxiliary(scanner/smb/smb_enumshares) > save
Saved configuration to: _
msf5 auxiliary(scanner/smb/smb_enumshares) > exit
[ruby-2.5.1@metasploit-framework](smb2-enumshares) 
msfdev@simulator:~/git/metasploit-framework
$ git checkout upstream-master
Switched to branch 'upstream-master'
Your branch is up-to-date with 'upstream/master'.
[ruby-2.5.1@metasploit-framework](upstream-master) 
msfdev@simulator:~/git/metasploit-framework
$ ./msfconsole -q 
msf5 auxiliary(scanner/smb/smb_enumshares) > run

[-] 172.22.222.200:139    - Login Failed: The SMB server did not reply to our request
[-] 172.22.222.200:445    - Login Failed: Connection reset by peer
[*] 172.22.222.200:       - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf5 auxiliary(scanner/smb/smb_enumshares) >
```

## Verification

- [x] `./msfconsole -q`
- [x] `use auxiliary/scanner/smb/smb_enumshares`
- [x] `set rhosts <rhost>`
- [x] `set smbuser <user>`
- [x] `set smbpass <pass>`