### PR TITLE
Update warning message when loading mimikatz on new OSes

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/mimikatz.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/mimikatz.rb
@@ -42,7 +42,7 @@ class Console::CommandDispatcher::Mimikatz
     end
 
     unless si['OS'] =~ /Windows (NT|XP|2000|2003|\.NET)/i
-      print_warning("Loaded Mimikatz on a newer OS (#{si['OS']}). Did you mean to 'load mimikatz' instead?")
+      print_warning("Loaded Mimikatz on a newer OS (#{si['OS']}). Did you mean to 'load kiwi' instead?")
     end
   end
 


### PR DESCRIPTION
This fixes the silly mistake I made in the warning message that is shown when loading the `mimikatz` extension instead of `kiwi` on newer operating systems. /cc @wvu-r7

Fixes #10619.