### PR TITLE
Fix Msf::Post::Solaris::System pidof method

### DIFF
--- a/lib/msf/core/post/solaris/system.rb
+++ b/lib/msf/core/post/solaris/system.rb
@@ -115,9 +115,9 @@ module System
   #
   def pidof(program)
     pids = []
-    full = cmd_exec('ps aux').to_s
+    full = cmd_exec('ps -elf').to_s
     full.split("\n").each do |pid|
-      pids << pid.split(' ')[1].to_i if pid.include? program
+      pids << pid.split(' ')[3].to_i if pid.include? program
     end
     pids
   end


### PR DESCRIPTION
This PR updates the `Msf::Post::Solaris::System` `pidof` method to use `ps -elf`, rather than `ps aux`, to support Solaris versions prior to Solaris 11.

Tested on:

* Solaris 11.3 (x64)
* Solaris 9u7 (x86)

See: https://github.com/rapid7/metasploit-framework/pull/10437#issuecomment-420627791
