### PR TITLE
Cleanup is_root? method for Linux::Priv / Solaris::Priv

### DIFF
--- a/lib/msf/core/post/linux/priv.rb
+++ b/lib/msf/core/post/linux/priv.rb
@@ -11,19 +11,12 @@ module Priv
   # Returns true if running as root, false if not.
   #
   def is_root?
-    root_priv = false
-    user_id = cmd_exec("id -u")
-    clean_user_id = user_id.to_s.gsub(/[^\d]/,"")
-    unless clean_user_id.empty?
-      if clean_user_id =~ /^0$/
-        root_priv = true
-      elsif clean_user_id =~ /^\d*$/
-        root_priv = false
-      end
-    else
+    user_id = cmd_exec('id -u')
+    clean_user_id = user_id.to_s.gsub(/[^\d]/, '')
+    if clean_user_id.empty?
       raise "Could not determine UID: #{user_id.inspect}"
     end
-    return root_priv
+    (clean_user_id == '0')
   end
 
 end # Priv

--- a/lib/msf/core/post/solaris/priv.rb
+++ b/lib/msf/core/post/solaris/priv.rb
@@ -11,12 +11,12 @@ module Priv
   # Returns true if running as root, false if not.
   #
   def is_root?
-    root_priv = false
     user_id = cmd_exec("/usr/xpg4/bin/id -u")
-    if user_id.to_i == 0
-      root_priv = true
+    clean_user_id = user_id.to_s.gsub(/[^\d]/, '')
+    if clean_user_id.empty?
+      raise "Could not determine UID: #{user_id.inspect}"
     end
-    return root_priv
+    (clean_user_id == '0')
   end
 
 end # Priv


### PR DESCRIPTION
This PR cleans up the `is_root?` method for `Msf::Post::Linux::Priv` and `Msf::Post::Solaris::Priv`.

The Solaris implementation assumed the user was `root`, unless the results of the `id` command indicated otherwise. It also did not `raise` if an error was encountered. This was problematic, as if the `cmd_exec` call failed for any reason, the method would return `true`. This PR brings the Solaris implementation inline with the Linux implementation, by first cleaning the user ID before comparison, and `raise` if something goes wrong.

The Linux implementation was fine, however the logic was a little redundant. It assumed `false`, then took a code branch containing a nested code branch that set `true` or `false`. I cleaned it up while I was at it. It's now identical in function to the Solaris implementation, differing only in the path to the `id` executable.

