### PR TITLE
Revert doc changes to exploit.rb autofilter

### DIFF
--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -373,11 +373,11 @@ class Exploit < Msf::Module
   end
 
   #
-  # Performs last-minute sanity checking of auxiliary parameters. This method
+  # Performs last-minute sanity checking of exploit parameters. This method
   # is called during automated exploitation attempts and allows an
-  # auxiliary module to filter bad attempts, obtain more information, and choose
-  # better parameters based on the available data. Returning anything that
-  # evaluates to "false" will cause this specific auxiliary attempt to
+  # exploit to filter bad targets, obtain more information, and choose
+  # better targets based on the available data. Returning anything that
+  # evaluates to "false" will cause this specific exploit attempt to
   # be skipped. This method can and will change datastore values and
   # may interact with the backend database.
   #


### PR DESCRIPTION
I think the changes might have been accidental.

3cf4329335c99ace0f792e2d5766ca64207706f0