### PR TITLE
Fix inactive sessions list when database is disabled

### DIFF
--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -620,10 +620,12 @@ class ReadableText
           'Indent' => indent,
           'SortIndex' => 1)
 
-      framework.db.sessions.each do |session|
-        unless session.closed_at.nil?
-          row = create_mdm_session_row(session, show_extended)
-          tbl << row
+      if framework.db.active
+        framework.db.sessions.each do |session|
+          unless session.closed_at.nil?
+            row = create_mdm_session_row(session, show_extended)
+            tbl << row
+          end
         end
       end
 

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1200,6 +1200,10 @@ class Core
       end
     end
 
+    if show_inactive && !framework.db.active
+      print_warning("Database not connected; list of inactive sessions unavailable")
+    end
+
     last_known_timeout = nil
 
     # Now, perform the actual method


### PR DESCRIPTION
Fixes the confusing message and stack trace when the `sessions -d` command is used to list inactive sessions with the database disabled.

Thanks to @sho-luv for reporting the issue.

**Error Output (MSF5)**
```
msf5 > sessions -d

[-] Session manipulation failed: Problem retrieving sessions: No registered data_service. See log for more details. ["/home/msfdev/metasploit-framework/lib/metasploit/framework/data_service/proxy/core.rb:158:in `log_error'", "/home/msfdev/metasploit-framework/lib/metasploit/framework/data_service/proxy/session_data_proxy.rb:8:in `rescue in sessions'", "/home/msfdev/metasploit-framework/lib/metasploit/framework/data_service/proxy/session_data_proxy.rb:2:in `sessions'", "/home/msfdev/metasploit-framework/lib/msf/base/serializer/readable_text.rb:623:in `dump_sessions'", "/home/msfdev/metasploit-framework/lib/msf/ui/console/command_dispatcher/core.rb:1441:in `cmd_sessions'", "/home/msfdev/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:491:in `run_command'", "/home/msfdev/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:453:in `block in run_single'", "/home/msfdev/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:447:in `each'", "/home/msfdev/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:447:in `run_single'", "/home/msfdev/metasploit-framework/lib/rex/ui/text/shell.rb:208:in `run'", "/home/msfdev/metasploit-framework/lib/metasploit/framework/command/console.rb:48:in `start'", "/home/msfdev/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'", "./msfconsole:49:in `<main>'"]
```

**Error Output (4.x Nightly Installer)**
```
msf > sessions -d

[-] Session manipulation failed: undefined method `each' for nil:NilClass ["/opt/metasploit-framework/embedded/framework/lib/msf/base/serializer/readable_text.rb:615:in `dump_sessions'", "/opt/metasploit-framework/embedded/framework/lib/msf/ui/console/command_dispatcher/core.rb:1436:in `cmd_sessions'", "/opt/metasploit-framework/embedded/framework/lib/rex/ui/text/dispatcher_shell.rb:491:in `run_command'", "/opt/metasploit-framework/embedded/framework/lib/rex/ui/text/dispatcher_shell.rb:453:in `block in run_single'", "/opt/metasploit-framework/embedded/framework/lib/rex/ui/text/dispatcher_shell.rb:447:in `each'", "/opt/metasploit-framework/embedded/framework/lib/rex/ui/text/dispatcher_shell.rb:447:in `run_single'", "/opt/metasploit-framework/embedded/framework/lib/rex/ui/text/shell.rb:150:in `run'", "/opt/metasploit-framework/embedded/framework/lib/metasploit/framework/command/console.rb:48:in `start'", "/opt/metasploit-framework/embedded/framework/lib/metasploit/framework/command/base.rb:82:in `start'", "/opt/metasploit-framework/bin/../embedded/framework/msfconsole:49:in `<main>'"]
```

**New Output**
```
msf5 > sessions -d
[!] Database not connected; list of inactive sessions unavailable

Inactive sessions
=================

No inactive sessions.

msf5 > sessions -d -l
[!] Database not connected; list of inactive sessions unavailable

Active sessions
===============

No active sessions.

Inactive sessions
=================

No inactive sessions.
```

## Verification

- [ ] Start `msfconsole` with database support disabled: `msfconsole --no-database`
- [ ] Run `sessions -d`
- [ ] Run `sessions -l -d`
- [ ] **Verify** a warning is output indicating that the database is not connected and the list of inactive sessions is unavailable