### PR TITLE
Add writable? method to Msf::Post::File - Fix #10644

### DIFF
--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -136,6 +136,19 @@ module Msf::Post::File
   end
 
   #
+  # See if +path+ on the remote system exists and is writable
+  #
+  # @param path [String] Remote path to check
+  #
+  # @return [Boolean] true if +path+ exists and is writable
+  #
+  def writable?(path)
+    raise "writable?' method does not support Windows systems" if session.platform == 'windows'
+
+    cmd_exec("test -w '#{path}' && echo true").to_s.include? 'true'
+  end
+
+  #
   # Check for existence of +path+ on the remote file system
   #
   # @param path [String] Remote filename to check


### PR DESCRIPTION
Add `writable?` method to `Msf::Post::File` - Fix #10644

```
[+] Metasploit supports local Solaris exploits!
[*] is_root?
[*] false
[*] is_writable?('/etc/shadow')
[*] false
[*] is_writable?('/tmp/')
[*] true
[*] get_sysinfo
[*] {:version=>"Solaris 9 9/04 s9x_u7wos_09 x86", :kernel=>"SunOS unknown 5.9 Generic_117172-07 i86pc i386 i86pc", :hostname=>"unknown"}
[*] get_path
[*] 
[*] get_cpu_info
[*] {:speed_mhz=>3500}
[*] get_hostname
[*] unknown
[*] get_shell_name
[*] sh
[*] has_gcc?
[*] false
[*] pidof('sshd')
[*] [322]
[*] get_mount_path("/etc/passwd")
[*] /
[*] Exploit completed, but no session was created.
```
