### PR TITLE
deregister_options RHOSTS

### DIFF
--- a/modules/auxiliary/gather/http_pdf_authors.rb
+++ b/modules/auxiliary/gather/http_pdf_authors.rb
@@ -41,7 +41,7 @@ class MetasploitModule < Msf::Auxiliary
         OptEnum.new('URL_TYPE', [ true, 'The type of URL(s) specified', 'html', [ 'pdf', 'html' ] ]),
         OptBool.new('STORE_LOOT', [ false, 'Store authors in loot', true ])
       ])
-    deregister_options 'RHOST', 'RPORT', 'VHOST'
+    deregister_options 'RHOST', 'RHOSTS', 'RPORT', 'VHOST', 'SSL'
   end
 
   def progress(current, total)

--- a/modules/auxiliary/gather/searchengine_subdomains_collector.rb
+++ b/modules/auxiliary/gather/searchengine_subdomains_collector.rb
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Auxiliary
         OptBool.new('ENUM_YAHOO', [ true, "Enable Yahoo Search Subdomains", true])
       ])
 
-    deregister_options('RHOST', 'RPORT', 'VHOST', 'SSL', 'Proxies')
+    deregister_options('RHOST', 'RHOSTS', 'RPORT', 'VHOST', 'SSL', 'Proxies')
   end
 
   def rhost_yahoo


### PR DESCRIPTION
Some modules have deregistered the`RHOST` option, however, since the `RHOSTS` changes, these modules fail to run as `RHOSTS` has not also been deregistered.

I vaguely remember creating an issue or a PR for this before, but can't seem to find it, so maybe I didn't.

There are probably other modules affected by this. ```¯\_(ツ)_/¯```
