### PR TITLE
Fix issue when kill a non-existent job.

### DIFF
--- a/lib/msf/ui/console/command_dispatcher.rb
+++ b/lib/msf/ui/console/command_dispatcher.rb
@@ -88,6 +88,7 @@ module CommandDispatcher
         return if ele.count('-') > 1
         return if ele.first == '-' || ele[-1] == '-'
         return if ele.first == '.' || ele[-1] == '.'
+        return unless ele =~ (/^(\d)+$/)  # Not a number
 
         if ele.include? '-'
           temp_array = (ele.split("-").inject { |s, e| s.to_i..e.to_i }).to_a

--- a/lib/msf/ui/console/command_dispatcher/jobs.rb
+++ b/lib/msf/ui/console/command_dispatcher/jobs.rb
@@ -209,7 +209,7 @@ module Msf
                 persist_list = []
               end
 
-              # Stop the job and remove persistence by job id.
+              # Remove persistence by job id.
               job_list.map(&:to_s).each do |job|
                 if framework.jobs.key?(job)
                   next unless framework.jobs[job.to_s].ctx[1] # next if no payload context in the job

--- a/lib/msf/ui/console/command_dispatcher/jobs.rb
+++ b/lib/msf/ui/console/command_dispatcher/jobs.rb
@@ -209,10 +209,13 @@ module Msf
                 persist_list = []
               end
 
+              # Stop the job and remove persistence by job id.
               job_list.map(&:to_s).each do |job|
-                next unless framework.jobs[job.to_s].ctx[1] # next if no payload context in the job
-                payload_option = framework.jobs[job.to_s].ctx[1].datastore
-                persist_list.delete_if{|pjob|pjob['mod_options']['Options'] == payload_option}
+                if framework.jobs.key?(job)
+                  next unless framework.jobs[job.to_s].ctx[1] # next if no payload context in the job
+                  payload_option = framework.jobs[job.to_s].ctx[1].datastore
+                  persist_list.delete_if{|pjob|pjob['mod_options']['Options'] == payload_option}
+                end
               end
               # Write persist job back to config file.
               File.open(Msf::Config.persist_file,"w") do |file|


### PR DESCRIPTION
Fix #10655 when killing a non-existent job, and also fix an issue when killing a job with a non-integer job ID defaults to killing job zero. 

Thanks very much for @bcoles ! 


## Verification

```
msf5 exploit(multi/handler) > jobs -k 12121
[*] Stopping the following job(s): 12121
[-] Invalid job identifier: 12121
msf5 exploit(multi/handler) > jobs -k asdadads
[-] Please specify valid job identifier(s)
```

