### PR TITLE
Fix crash issue when auto complete the session option.

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -2225,7 +2225,9 @@ class Core
   # Provide valid session options for the current post-exploit module
   #
   def option_values_sessions
-    active_module.compatible_sessions.map { |sid| sid.to_s }
+    if active_module.respond_to?(:compatible_sessions)
+      active_module.compatible_sessions.map { |sid| sid.to_s }
+    end
   end
 
   #


### PR DESCRIPTION
Fix #10654 that the msfconsole would crash when auto-complete the session option, which is not supported for some module.

Thank @bcoles a lot for testing!

This is a quick fix, and I think maybe there are some potential issues like this, try to find them, so do not merge this for now.


