### PR TITLE
Rename Pimcore and Dolibarr SQLi modules

### DIFF
--- a/modules/auxiliary/gather/dolibarr_creds_sqli.rb
+++ b/modules/auxiliary/gather/dolibarr_creds_sqli.rb
@@ -8,9 +8,11 @@ class MetasploitModule < Msf::Auxiliary
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Dolibarr List Creds',
+      'Name'           => 'Dolibarr Gather Credentials via SQL Injection',
       'Description'    => %q{
-         This module enables an authenticated user to collect the usernames and encrypted passwords of other users in the Dolibarr ERP/CRM via SQL injection.
+         This module enables an authenticated user to collect the usernames and
+         encrypted passwords of other users in the Dolibarr ERP/CRM via SQL
+         injection.
       },
       'Author'         => [
                             'Issam Rabhi',  # PoC

--- a/modules/auxiliary/gather/pimcore_creds_sqli.rb
+++ b/modules/auxiliary/gather/pimcore_creds_sqli.rb
@@ -8,7 +8,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Pimcore List Credentials',
+      'Name'           => 'Pimcore Gather Credentials via SQL Injection',
       'Description'    => %q{
         This module extracts the usernames and hashed passwords of all users of
         the Pimcore web service by exploiting a SQL injection vulnerability in


### PR DESCRIPTION
Makes #10670 and #10673 and consistent. My bad for missing this.