### PR TITLE
Fix NameError in cmd_shell due to renamed variable

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
@@ -333,7 +333,7 @@ class Console::CommandDispatcher::Stdapi::Sys
         return true
       end
 
-      cmd_execute('-f', comspec, '-c', '-i')
+      cmd_execute('-f', path, '-c', '-i')
     end
   end
 


### PR DESCRIPTION
I am terribly sorry. I should have been more thorough in my testing.

Fixes #10678 for #10389.