### PR TITLE
Add ARGS, TIMEOUT, and output to upload_exec

### DIFF
--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -366,7 +366,7 @@ module Msf::Post::File
   #
   # @param remote [String] Destination file name on the remote filesystem
   def chmod_x_file(remote)
-    if session.type == "meterpreter" and session.commands.include?('stdapi_fs_chmod')
+    if session.type == "meterpreter" && session.commands.include?('stdapi_fs_chmod')
       session.fs.file.chmod(remote, 0700)
     else
       cmd_exec("chmod 700 \"#{remote}\"")

--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -362,6 +362,18 @@ module Msf::Post::File
   end
 
   #
+  # Sets the executable permissions on a remote file
+  #
+  # @param remote [String] Destination file name on the remote filesystem
+  def chmod_x_file(remote)
+    if session.type == "meterpreter" and session.commands.include?('stdapi_fs_chmod')
+      session.fs.file.chmod(remote, 0700)
+    else
+      cmd_exec("chmod 700 \"#{remote}\"")
+    end
+  end
+
+  #
   # Delete remote files
   #
   # @param remote_files [Array<String>] List of remote filenames to

--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -362,14 +362,19 @@ module Msf::Post::File
   end
 
   #
-  # Sets the executable permissions on a remote file
+  # Sets the permissions on a remote file
   #
-  # @param remote [String] Destination file name on the remote filesystem
-  def chmod_x_file(remote)
-    if session.type == "meterpreter" && session.commands.include?('stdapi_fs_chmod')
-      session.fs.file.chmod(remote, 0700)
+  # @param path [String] Path on the remote filesystem
+  # @param mode [Fixnum] Mode as an octal number
+  def chmod(path, mode = 0700)
+    if session.platform == 'windows'
+      raise "`chmod_x_file?' method does not support Windows systems"
+    end
+
+    if session.type == 'meterpreter' && session.commands.include?('stdapi_fs_chmod')
+      session.fs.file.chmod(path, mode)
     else
-      cmd_exec("chmod 700 \"#{remote}\"")
+      cmd_exec("chmod #{mode.to_s(8)} '#{path}'")
     end
   end
 

--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -368,7 +368,7 @@ module Msf::Post::File
   # @param mode [Fixnum] Mode as an octal number
   def chmod(path, mode = 0700)
     if session.platform == 'windows'
-      raise "`chmod_x_file?' method does not support Windows systems"
+      raise "`chmod' method does not support Windows systems"
     end
 
     if session.type == 'meterpreter' && session.commands.include?('stdapi_fs_chmod')

--- a/modules/post/multi/manage/upload_exec.rb
+++ b/modules/post/multi/manage/upload_exec.rb
@@ -12,7 +12,7 @@ class MetasploitModule < Msf::Post
       'Description'  => %q{Push a file and execute it.},
       'Author'       => 'egypt',
       'License'      => MSF_LICENSE,
-      'Platform'     => ['win', 'unix', 'linux', 'osx'],
+      'Platform'     => ['win', 'unix', 'linux', 'osx', 'bsd', 'solaris'],
       'SessionTypes' => ['meterpreter', 'shell']
     ))
 

--- a/modules/post/multi/manage/upload_exec.rb
+++ b/modules/post/multi/manage/upload_exec.rb
@@ -31,13 +31,7 @@ class MetasploitModule < Msf::Post
       # Don't use cmd.exe /c start so we can fetch output
       cmd = rpath
     else
-      begin
-        # client is an alias for session
-        client.fs.file.chmod(rpath, 0700)
-      rescue
-        # Fall back if unimplemented or unavailable
-        cmd_exec("chmod 700 #{rpath}")
-      end
+      chmod_x_file(rpath)
 
       # Handle absolute paths
       cmd = rpath.start_with?('/') ? rpath : "./#{rpath}"

--- a/modules/post/multi/manage/upload_exec.rb
+++ b/modules/post/multi/manage/upload_exec.rb
@@ -21,7 +21,7 @@ class MetasploitModule < Msf::Post
         OptPath.new('LPATH', [true, 'Local file path to upload and execute']),
         OptString.new('RPATH', [false, 'Remote file path on target (default is basename of LPATH)']),
         OptString.new('ARGS', [false, 'Command-line arguments to pass to the uploaded file']),
-        OptInt.new('TIMEOUT', [true, 'Timeout for command execution', 0])
+        OptInt.new('TIMEOUT', [true, 'Timeout for command execution', 15])
       ])
   end
 

--- a/modules/post/multi/manage/upload_exec.rb
+++ b/modules/post/multi/manage/upload_exec.rb
@@ -44,7 +44,7 @@ class MetasploitModule < Msf::Post
     end
 
     output = cmd_exec(cmd, args, timeout)
-    vprint_good(output) unless output.blank?
+    vprint_line(output) unless output.blank?
 
     rm_f(rpath)
   end

--- a/modules/post/multi/manage/upload_exec.rb
+++ b/modules/post/multi/manage/upload_exec.rb
@@ -44,7 +44,12 @@ class MetasploitModule < Msf::Post
     end
 
     output = cmd_exec(cmd, args, timeout)
-    print_line(output) unless output.blank?
+
+    if output.blank?
+      vprint_status('Command returned no output')
+    else
+      print_line(output)
+    end
 
     rm_f(rpath)
   end

--- a/modules/post/multi/manage/upload_exec.rb
+++ b/modules/post/multi/manage/upload_exec.rb
@@ -28,7 +28,8 @@ class MetasploitModule < Msf::Post
     upload_file(rpath, lpath)
 
     if session.platform == 'windows'
-      cmd = "cmd.exe /c start #{rpath}"
+      # Don't use cmd.exe /c start so we can fetch output
+      cmd = rpath
     else
       begin
         # client is an alias for session

--- a/modules/post/multi/manage/upload_exec.rb
+++ b/modules/post/multi/manage/upload_exec.rb
@@ -30,16 +30,16 @@ class MetasploitModule < Msf::Post
     if session.platform == 'windows'
       cmd = "cmd.exe /c start #{rpath}"
     else
+      begin
+        # client is an alias for session
+        client.fs.file.chmod(rpath, 0700)
+      rescue
+        # Fall back if unimplemented or unavailable
+        cmd_exec("chmod 700 #{rpath}")
+      end
+
       # Handle absolute paths
       cmd = rpath.start_with?('/') ? rpath : "./#{rpath}"
-    end
-
-    begin
-      # client is an alias for session
-      client.fs.file.chmod(rpath, 0700)
-    rescue
-      # Fall back if unimplemented or unavailable
-      cmd_exec("chmod 700 #{rpath}")
     end
 
     output = cmd_exec(cmd, args, timeout)

--- a/modules/post/multi/manage/upload_exec.rb
+++ b/modules/post/multi/manage/upload_exec.rb
@@ -31,7 +31,8 @@ class MetasploitModule < Msf::Post
       # Don't use cmd.exe /c start so we can fetch output
       cmd = rpath
     else
-      chmod_x_file(rpath)
+      # Set 700 so only we can execute the file
+      chmod(rpath, 0700)
 
       # Handle absolute paths
       cmd = rpath.start_with?('/') ? rpath : "./#{rpath}"

--- a/modules/post/multi/manage/upload_exec.rb
+++ b/modules/post/multi/manage/upload_exec.rb
@@ -44,7 +44,7 @@ class MetasploitModule < Msf::Post
     end
 
     output = cmd_exec(cmd, args, timeout)
-    vprint_line(output) unless output.blank?
+    print_line(output) unless output.blank?
 
     rm_f(rpath)
   end

--- a/modules/post/multi/manage/upload_exec.rb
+++ b/modules/post/multi/manage/upload_exec.rb
@@ -5,6 +5,7 @@
 
 class MetasploitModule < Msf::Post
   include Msf::Post::File
+  include Msf::Exploit::FileDropper
 
   def initialize(info = {})
     super(update_info(info,
@@ -20,12 +21,14 @@ class MetasploitModule < Msf::Post
       OptPath.new('LPATH',   [true, 'Local file path to upload and execute']),
       OptString.new('RPATH', [false, 'Remote file path on target (default is basename of LPATH)']),
       OptString.new('ARGS',  [false, 'Command-line arguments to pass to the uploaded file']),
-      OptInt.new('TIMEOUT',  [true, 'Timeout for command execution', 15])
+      OptInt.new('TIMEOUT',  [true, 'Timeout for command execution', 60])
     ])
   end
 
   def run
+    print_status("Uploading #{lpath} to #{rpath}")
     upload_file(rpath, lpath)
+    register_file_for_cleanup(rpath)
 
     if session.platform == 'windows'
       # Don't use cmd.exe /c start so we can fetch output
@@ -38,15 +41,14 @@ class MetasploitModule < Msf::Post
       cmd = rpath.start_with?('/') ? rpath : "./#{rpath}"
     end
 
+    print_status("Executing command: #{cmd}")
     output = cmd_exec(cmd, args, timeout)
 
     if output.blank?
-      vprint_status('Command returned no output')
+      print_status('Command returned no output')
     else
       print_line(output)
     end
-
-    rm_f(rpath)
   end
 
   def lpath


### PR DESCRIPTION
Credit to @bcoles for the initial patch.

- [x] Test `ARGS`
- [x] Test `TIMEOUT`
- [x] Test command output
- [x] Make sure you test Windows, too

### PHP Meterpreter on Linux

```
msf5 post(multi/manage/upload_exec) > options

Module options (post/multi/manage/upload_exec):

   Name     Current Setting            Required  Description
   ----     ---------------            --------  -----------
   ARGS     hello, world               no        Command-line arguments to pass to the uploaded file
   LPATH    ~/Documents/xenial64/echo  yes       Local file path to upload and execute
   RPATH    /tmp/echo                  no        Remote file path on target (default is basename of LPATH)
   SESSION  1                          yes       The session to run this module on.
   TIMEOUT  15                         yes       Timeout for command execution

msf5 post(multi/manage/upload_exec) > run

hello, world
[*] Post module execution completed
msf5 post(multi/manage/upload_exec) >
```

### OS X command shell

```
msf5 post(multi/manage/upload_exec) > options

Module options (post/multi/manage/upload_exec):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   ARGS     hello, world     no        Command-line arguments to pass to the uploaded file
   LPATH    /bin/echo        yes       Local file path to upload and execute
   RPATH    /tmp/echo        no        Remote file path on target (default is basename of LPATH)
   SESSION  2                yes       The session to run this module on.
   TIMEOUT  15               yes       Timeout for command execution

msf5 post(multi/manage/upload_exec) > run

[*] Max line length is 131073
[*] Writing 18128 bytes in 1 chunks of 45568 bytes (octal-encoded), using printf
hello, world
[*] Post module execution completed
msf5 post(multi/manage/upload_exec) >
```

### Windows Meterpreter

```
msf5 post(multi/manage/upload_exec) > options

Module options (post/multi/manage/upload_exec):

   Name     Current Setting                   Required  Description
   ----     ---------------                   --------  -----------
   ARGS                                       no        Command-line arguments to pass to the uploaded file
   LPATH    test.bat                          yes       Local file path to upload and execute
   RPATH    C:\Users\IEUser\Desktop\test.bat  no        Remote file path on target (default is basename of LPATH)
   SESSION  3                                 yes       The session to run this module on.
   TIMEOUT  15                                yes       Timeout for command execution

msf5 post(multi/manage/upload_exec) > cat test.bat
[*] exec: cat test.bat

net user
msf5 post(multi/manage/upload_exec) > run


C:\Users\IEUser\Downloads>net user

User accounts for \\MSEDGEWIN10

-------------------------------------------------------------------------------
Administrator            DefaultAccount           Guest
IEUser                   sshd                     sshd_server
WDAGUtilityAccount
The command completed successfully.

[*] Post module execution completed
msf5 post(multi/manage/upload_exec) >
```

Resolves #10669. Related to #10384. ~Depends on rapid7/metasploit-payloads#301 and rapid7/metasploit-payloads#304.~ There was no hard dependency.