### PR TITLE
Add pry command to Meterpreter

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/developer.rb
+++ b/lib/msf/ui/console/command_dispatcher/developer.rb
@@ -112,6 +112,11 @@ class Msf::Ui::Console::CommandDispatcher::Developer
   # Open a Pry session on the current module or Framework
   #
   def cmd_pry(*args)
+    if args.include?('-h')
+      cmd_pry_help
+      return
+    end
+
     begin
       require 'pry'
     rescue LoadError

--- a/lib/msf/ui/console/command_dispatcher/developer.rb
+++ b/lib/msf/ui/console/command_dispatcher/developer.rb
@@ -120,11 +120,20 @@ class Msf::Ui::Console::CommandDispatcher::Developer
     begin
       require 'pry'
     rescue LoadError
-      print_error("Failed to load Pry, try 'gem install pry'")
+      print_error('Failed to load Pry, try "gem install pry"')
       return
     end
 
-    active_module ? active_module.pry : framework.pry
+    print_status('Starting Pry shell...')
+
+    unless active_module
+      print_status("You are in the \"framework\" object\n")
+      framework.pry
+      return
+    end
+
+    print_status("You are in #{active_module.fullname}\n")
+    active_module.pry
   end
 
   def cmd_edit_help

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
@@ -590,9 +590,12 @@ class Console::CommandDispatcher::Core
     begin
       require 'pry'
     rescue LoadError
-      print_error("Failed to load Pry, try 'gem install pry'")
+      print_error('Failed to load Pry, try "gem install pry"')
       return
     end
+
+    print_status('Starting Pry shell...')
+    print_status("You are in the \"client\" (session) object\n")
 
     client.pry
   end

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
@@ -582,6 +582,11 @@ class Console::CommandDispatcher::Core
   # Open a Pry session on the current session
   #
   def cmd_pry(*args)
+    if args.include?('-h')
+      cmd_pry_help
+      return
+    end
+
     begin
       require 'pry'
     rescue LoadError

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
@@ -53,6 +53,7 @@ class Console::CommandDispatcher::Core
       'exit'         => 'Terminate the meterpreter session',
       'help'         => 'Help menu',
       'irb'          => 'Drop into irb scripting mode',
+      'pry'          => 'Open a Pry session on the current session',
       'use'          => 'Deprecated alias for "load"',
       'load'         => 'Load one or more meterpreter extensions',
       'machine_id'   => 'Get the MSF ID of the machine attached to the session',
@@ -568,6 +569,27 @@ class Console::CommandDispatcher::Core
     else
       expressions.each { |expression| eval(expression, binding) }
     end
+  end
+
+  def cmd_pry_help
+    print_line 'Usage: pry'
+    print_line
+    print_line 'Open a Pry session on the current session.'
+    print_line
+  end
+
+  #
+  # Open a Pry session on the current session
+  #
+  def cmd_pry(*args)
+    begin
+      require 'pry'
+    rescue LoadError
+      print_error("Failed to load Pry, try 'gem install pry'")
+      return
+    end
+
+    client.pry
   end
 
   @@set_timeouts_opts = Rex::Parser::Arguments.new(


### PR DESCRIPTION
It's better than `irb` and comes with Metasploit. Due to how Meterpreter does its command dispatchers, we won't create a new developer dispatcher here.

- [x] Test `help` and see `pry` listed
- [x] Test `help pry` and see `pry` help
- [x] Test `pry` in a new session

```
meterpreter > help pry
Usage: pry

Open a Pry session on the current session.

meterpreter > pry
[*] Starting Pry shell...
[*] You are in the "client" (session) object

[1] pry(#<Msf::Sessions::Meterpreter_Php_Php>)> sys.config.getuid
=> "vagrant (1000)"
[2] pry(#<Msf::Sessions::Meterpreter_Php_Php>)> sys.config.sysinfo
=> {"Computer"=>"ubuntu-xenial", "OS"=>"Linux ubuntu-xenial 4.4.0-134-generic #160-Ubuntu SMP Wed Aug 15 14:58:00 UTC 2018 x86_64", "Architecture"=>nil, "BuildTuple"=>nil, "System Language"=>nil, "Domain"=>nil, "Logged On Users"=>nil}
[3] pry(#<Msf::Sessions::Meterpreter_Php_Php>)> go south
=> nil
[4] pry(#<Msf::Sessions::Meterpreter_Php_Php>)>
```

#10433