### PR TITLE
Rework aux/scanner logic to remove duplicate logic, fix checks

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,6 +37,10 @@ Style/TernaryParentheses:
   Enabled: false
   Description: 'This outright produces bugs'
 
+Style/ZeroLengthPredicate:
+  Enabled: false
+  Description: 'No benefit to this change'
+
 Style/FrozenStringLiteralComment:
   Enabled: false
   Description: 'We cannot support this yet without a lot of things breaking'

--- a/lib/msf/core/auxiliary/scanner.rb
+++ b/lib/msf/core/auxiliary/scanner.rb
@@ -70,22 +70,6 @@ def run
     threads_max = 1
   end
 
-  if(Rex::Compat.is_windows)
-    if(threads_max > 16)
-      print_error("Warning: The Windows platform cannot reliably support more than 16 threads")
-      print_error("Thread count has been adjusted to 16")
-      threads_max = 16
-    end
-  end
-
-  if(Rex::Compat.is_cygwin)
-    if(threads_max > 200)
-      print_error("Warning: The Cygwin platform cannot reliably support more than 200 threads")
-      print_error("Thread count has been adjusted to 200")
-      threads_max = 200
-    end
-  end
-
   begin
 
   if (self.respond_to?('run_host'))

--- a/lib/msf/core/auxiliary/scanner.rb
+++ b/lib/msf/core/auxiliary/scanner.rb
@@ -1,313 +1,311 @@
 # -*- coding: binary -*-
 module Msf
 
-###
-#
-# This module provides methods for scanning modules
-#
-###
-
-module Auxiliary::Scanner
-
-
-#
-# Initializes an instance of a recon auxiliary module
-#
-def initialize(info = {})
-  super
-
-  register_options([
-      Opt::RHOSTS,
-      OptInt.new('THREADS', [ true, "The number of concurrent threads", 1 ] )
-    ], Auxiliary::Scanner)
-
-  register_advanced_options([
-    OptBool.new('ShowProgress', [true, 'Display progress messages during a scan', true]),
-    OptInt.new('ShowProgressPercent', [true, 'The interval in percent that progress should be shown', 10])
-  ], Auxiliary::Scanner)
-
-end
-
-def check
-  nmod = replicant
-  nmod.datastore['RHOST'] = @original_rhost
-  begin
-    nmod.check_host(datastore['RHOST'])
-  rescue NoMethodError
-    Exploit::CheckCode::Unsupported
-  end
-end
-
-
-def peer
-  # IPv4 addr can be 16 chars + 1 for : and + 5 for port
-  super.ljust(21)
-end
-
-#
-# The command handler when launched from the console
-#
-def run
-  @show_progress = datastore['ShowProgress']
-  @show_percent  = datastore['ShowProgressPercent'].to_i
-
-  ar             = Rex::Socket::RangeWalker.new(datastore['RHOSTS'])
-  @range_count   = ar.length || 0
-  @range_done    = 0
-  @range_percent = 0
-
-  threads_max = datastore['THREADS'].to_i
-  @tl = []
-  @scan_errors = []
-
+  ###
   #
-  # Sanity check threading given different conditions
+  # This module provides methods for scanning modules
   #
+  ###
 
-  if datastore['CPORT'].to_i != 0 && threads_max > 1
-    print_error("Warning: A maximum of one thread is possible when a source port is set (CPORT)")
-    print_error("Thread count has been adjusted to 1")
-    threads_max = 1
-  end
+  module Auxiliary::Scanner
 
-  begin
 
-  if (self.respond_to?('run_host'))
-    loop do
-      # Stop scanning if we hit a fatal error
-      break if has_fatal_errors?
+    #
+    # Initializes an instance of a recon auxiliary module
+    #
+    def initialize(info = {})
+      super
 
-      # Spawn threads for each host
-      while (@tl.length < threads_max)
+      register_options([
+          Opt::RHOSTS,
+          OptInt.new('THREADS', [ true, "The number of concurrent threads", 1 ] )
+        ], Auxiliary::Scanner)
 
-        # Stop scanning if we hit a fatal error
-        break if has_fatal_errors?
+      register_advanced_options([
+        OptBool.new('ShowProgress', [true, 'Display progress messages during a scan', true]),
+        OptInt.new('ShowProgressPercent', [true, 'The interval in percent that progress should be shown', 10])
+      ], Auxiliary::Scanner)
 
-        ip = ar.next_ip
-        break if not ip
+    end
 
-        @tl << framework.threads.spawn("ScannerHost(#{self.refname})-#{ip}", false, ip.dup) do |tip|
-          targ = tip
-          nmod = self.replicant
-          nmod.datastore['RHOST'] = targ
+    def check
+      nmod = replicant
+      nmod.datastore['RHOST'] = @original_rhost
+      begin
+        nmod.check_host(datastore['RHOST'])
+      rescue NoMethodError
+        Exploit::CheckCode::Unsupported
+      end
+    end
 
-          begin
-            nmod.run_host(targ)
-          rescue ::Rex::BindFailed
-            if datastore['CHOST']
-              @scan_errors << "The source IP (CHOST) value of #{datastore['CHOST']} was not usable"
+
+    def peer
+      # IPv4 addr can be 16 chars + 1 for : and + 5 for port
+      super.ljust(21)
+    end
+
+    #
+    # The command handler when launched from the console
+    #
+    def run
+      @show_progress = datastore['ShowProgress']
+      @show_percent  = datastore['ShowProgressPercent'].to_i
+
+      ar             = Rex::Socket::RangeWalker.new(datastore['RHOSTS'])
+      @range_count   = ar.length || 0
+      @range_done    = 0
+      @range_percent = 0
+
+      threads_max = datastore['THREADS'].to_i
+      @tl = []
+      @scan_errors = []
+
+      #
+      # Sanity check threading given different conditions
+      #
+
+      if datastore['CPORT'].to_i != 0 && threads_max > 1
+        print_error("Warning: A maximum of one thread is possible when a source port is set (CPORT)")
+        print_error("Thread count has been adjusted to 1")
+        threads_max = 1
+      end
+
+      begin
+
+      if self.respond_to?('run_host')
+        loop do
+          # Stop scanning if we hit a fatal error
+          break if fatal_errors?
+
+          # Spawn threads for each host
+          while @tl.length < threads_max
+
+            # Stop scanning if we hit a fatal error
+            break if fatal_errors?
+
+            ip = ar.next_ip
+            break if !ip
+
+            @tl << framework.threads.spawn("ScannerHost(#{self.refname})-#{ip}", false, ip.dup) do |tip|
+              targ = tip
+              nmod = self.replicant
+              nmod.datastore['RHOST'] = targ
+
+              begin
+                nmod.run_host(targ)
+              rescue ::Rex::BindFailed
+                if datastore['CHOST']
+                  @scan_errors << "The source IP (CHOST) value of #{datastore['CHOST']} was not usable"
+                end
+              rescue ::Rex::ConnectionError, ::Rex::ConnectionProxyError, ::Errno::ECONNRESET, ::Errno::EINTR, ::Rex::TimeoutError, ::Timeout::Error, ::EOFError
+              rescue ::Interrupt, ::NoMethodError, ::RuntimeError, ::ArgumentError, ::NameError
+                raise $ERROR_INFO
+              rescue StandardError => e
+                print_status("Error: #{targ}: #{e.class} #{e.message}")
+                elog("Error running against host #{targ}: #{e.message}\n#{e.backtrace.join("\n")}")
+              ensure
+                nmod.cleanup
+              end
             end
-          rescue ::Rex::ConnectionError, ::Rex::ConnectionProxyError, ::Errno::ECONNRESET, ::Errno::EINTR, ::Rex::TimeoutError, ::Timeout::Error, ::EOFError
-          rescue ::Interrupt,::NoMethodError, ::RuntimeError, ::ArgumentError, ::NameError
-            raise $!
-          rescue ::Exception => e
-            print_status("Error: #{targ}: #{e.class} #{e.message}")
-            elog("Error running against host #{targ}: #{e.message}\n#{e.backtrace.join("\n")}")
-          ensure
-            nmod.cleanup
           end
-        end
-      end
 
-      # Stop scanning if we hit a fatal error
-      break if has_fatal_errors?
+          # Stop scanning if we hit a fatal error
+          break if fatal_errors?
 
-      # Exit once we run out of hosts
-      if(@tl.length == 0)
-        break
-      end
-
-      # Assume that the oldest thread will be one of the
-      # first to finish and wait for it.  After that's
-      # done, remove any finished threads from the list
-      # and continue on.  This will open up at least one
-      # spot for a new thread
-      tla = @tl.length
-      @tl.first.join
-      @tl.delete_if { |t| not t.alive? }
-      tlb = @tl.length
-
-      @range_done += (tla - tlb)
-      scanner_show_progress() if @show_progress
-    end
-
-    scanner_handle_fatal_errors
-    return
-  end
-
-  if (self.respond_to?('run_batch'))
-
-    if (! self.respond_to?('run_batch_size'))
-      print_status("This module needs to export run_batch_size()")
-      return
-    end
-
-    size = run_batch_size()
-
-    ar = Rex::Socket::RangeWalker.new(datastore['RHOSTS'])
-
-    while(true)
-      nohosts = false
-
-      # Stop scanning if we hit a fatal error
-      break if has_fatal_errors?
-
-      while (@tl.length < threads_max)
-
-        batch = []
-
-        # Create batches from each set
-        while (batch.length < size)
-          ip = ar.next_ip
-          if (not ip)
-            nohosts = true
+          # Exit once we run out of hosts
+          if @tl.length == 0
             break
           end
-          batch << ip
+
+          # Assume that the oldest thread will be one of the
+          # first to finish and wait for it.  After that's
+          # done, remove any finished threads from the list
+          # and continue on.  This will open up at least one
+          # spot for a new thread
+          tla = @tl.length
+          @tl.first.join
+          @tl.delete_if { |t| !t.alive? }
+          tlb = @tl.length
+
+          @range_done += (tla - tlb)
+          scanner_show_progress if @show_progress
         end
 
-        # Create a thread for each batch
-        if (batch.length > 0)
-          thread = framework.threads.spawn("ScannerBatch(#{self.refname})", false, batch) do |bat|
-            nmod = self.replicant
-            mybatch = bat.dup
-            begin
-              nmod.run_batch(mybatch)
-          rescue ::Rex::BindFailed
-            if datastore['CHOST']
-              @scan_errors << "The source IP (CHOST) value of #{datastore['CHOST']} was not usable"
+        scanner_handle_fatal_errors
+        return
+      end
+
+      if self.respond_to?('run_batch')
+
+        if !self.respond_to?('run_batch_size')
+          print_status("This module needs to export run_batch_size")
+          return
+        end
+
+        size = run_batch_size
+
+        ar = Rex::Socket::RangeWalker.new(datastore['RHOSTS'])
+
+        loop do
+          nohosts = false
+
+          # Stop scanning if we hit a fatal error
+          break if fatal_errors?
+
+          while @tl.length < threads_max
+
+            batch = []
+
+            # Create batches from each set
+            while batch.length < size
+              ip = ar.next_ip
+              if !ip
+                nohosts = true
+                break
+              end
+              batch << ip
             end
-            rescue ::Rex::ConnectionError, ::Rex::ConnectionProxyError, ::Errno::ECONNRESET, ::Errno::EINTR, ::Rex::TimeoutError, ::Timeout::Error
-            rescue ::Interrupt,::NoMethodError, ::RuntimeError, ::ArgumentError, ::NameError
-              raise $!
-            rescue ::Exception => e
-              print_status("Error: #{mybatch[0]}-#{mybatch[-1]}: #{e}")
-            ensure
-              nmod.cleanup
+
+            # Create a thread for each batch
+            if batch.length > 0
+              thread = framework.threads.spawn("ScannerBatch(#{self.refname})", false, batch) do |bat|
+                nmod = self.replicant
+                mybatch = bat.dup
+                begin
+                  nmod.run_batch(mybatch)
+                rescue ::Rex::BindFailed
+                  if datastore['CHOST']
+                    @scan_errors << "The source IP (CHOST) value of #{datastore['CHOST']} was not usable"
+                  end
+                rescue ::Rex::ConnectionError, ::Rex::ConnectionProxyError, ::Errno::ECONNRESET, ::Errno::EINTR, ::Rex::TimeoutError, ::Timeout::Error
+                rescue ::Interrupt, ::NoMethodError, ::RuntimeError, ::ArgumentError, ::NameError
+                  raise $ERROR_INFO
+                rescue ::StandardError => e
+                  print_status("Error: #{mybatch[0]}-#{mybatch[-1]}: #{e}")
+                ensure
+                  nmod.cleanup
+                end
+              end
+              thread[:batch_size] = batch.length
+              @tl << thread
+            end
+
+            # Exit once we run out of hosts
+            if @tl.length == 0 || nohosts
+              break
             end
           end
-          thread[:batch_size] = batch.length
-          @tl << thread
+
+          # Stop scanning if we hit a fatal error
+          break if fatal_errors?
+
+          # Exit if there are no more pending threads
+          if @tl.length == 0
+            break
+          end
+
+          # Assume that the oldest thread will be one of the
+          # first to finish and wait for it.  After that's
+          # done, remove any finished threads from the list
+          # and continue on.  This will open up at least one
+          # spot for a new thread
+          tla = 0
+          @tl.map { |t| tla += t[:batch_size] }
+          @tl.first.join
+          @tl.delete_if { |t| !t.alive? }
+          tlb = 0
+          @tl.map { |t| tlb += t[:batch_size] }
+
+          @range_done += tla - tlb
+          scanner_show_progress if @show_progress
         end
 
-        # Exit once we run out of hosts
-        if (@tl.length == 0 or nohosts)
-          break
+        scanner_handle_fatal_errors
+        return
+      end
+
+      print_error("This module defined no run_host or run_batch methods")
+
+      rescue ::Interrupt
+        print_status("Caught interrupt from the console...")
+        return
+      ensure
+        seppuko!
+      end
+    end
+
+    def seppuko!
+      @tl.each do |t|
+        begin
+          t.kill if t.alive?
+        rescue StandardError
         end
       end
+    end
 
-      # Stop scanning if we hit a fatal error
-      break if has_fatal_errors?
+    def fatal_errors?
+      @scan_errors && !@scan_errors.empty?
+    end
 
-      # Exit if there are no more pending threads
-      if (@tl.length == 0)
-        break
+    def scanner_handle_fatal_errors
+      return unless fatal_errors?
+      return unless @tl
+
+      # First kill any running threads
+      @tl.each { |t| t.kill if t.alive? }
+
+      # Show the unique errors triggered by the scan
+      uniq_errors = @scan_errors.uniq
+      uniq_errors.each do |emsg|
+        print_error("Fatal: #{emsg}")
       end
-
-      # Assume that the oldest thread will be one of the
-      # first to finish and wait for it.  After that's
-      # done, remove any finished threads from the list
-      # and continue on.  This will open up at least one
-      # spot for a new thread
-      tla = 0
-      @tl.map {|t| tla += t[:batch_size] }
-      @tl.first.join
-      @tl.delete_if { |t| not t.alive? }
-      tlb = 0
-      @tl.map {|t| tlb += t[:batch_size] }
-
-      @range_done += tla - tlb
-      scanner_show_progress() if @show_progress
+      print_error("Scan terminated due to #{uniq_errors.size} fatal error(s)")
     end
 
-    scanner_handle_fatal_errors
-    return
-  end
+    def scanner_progress
+      return 0 unless @range_done && @range_count
+      (@range_done / @range_count.to_f) * 100
+    end
 
-  print_error("This module defined no run_host or run_batch methods")
+    def scanner_show_progress
+      # it should already be in the process of shutting down if there are fatal errors
+      return if fatal_errors?
+      pct = scanner_progress
+      if pct >= (@range_percent + @show_percent)
+        @range_percent += @show_percent
+        tdlen = @range_count.to_s.length
+        print_status(sprintf("Scanned %#{tdlen}d of %d hosts (%d%% complete)", @range_done, @range_count, pct))
+      end
+    end
 
-  rescue ::Interrupt
-    print_status("Caught interrupt from the console...")
-    return
-  ensure
-    seppuko!()
-  end
-end
+    def add_delay_jitter(delay_value, jitter_value)
+      # Introduce the delay
+      delay_value = delay_value.to_i
+      original_value = delay_value
+      jitter_value = jitter_value.to_i
 
-def seppuko!
-  @tl.each do |t|
-    begin
-      t.kill if t.alive?
-    rescue ::Exception
+      # Retrieve the jitter value and delay value
+      # Delay = number of milliseconds to wait between each request
+      # Jitter = percentage modifier. For example:
+      # Delay is 1000ms (i.e. 1 second), Jitter is 50.
+      # 50/100 = 0.5; 0.5*1000 = 500. Therefore, the per-request
+      # delay will be 1000 +/- a maximum of 500ms.
+      if delay_value > 0
+        if jitter_value > 0
+          rnd = Random.new
+          if rnd.rand(2) == 0
+            delay_value += rnd.rand(jitter_value)
+          else
+            delay_value -= rnd.rand(jitter_value)
+          end
+          if delay_value < 0
+            delay_value = 0
+          end
+        end
+        final_delay = delay_value.to_f / 1000.0
+        vprint_status("Delaying for #{final_delay} second(s) (#{original_value}ms +/- #{jitter_value}ms)")
+        sleep final_delay
+      end
     end
   end
 end
-
-def has_fatal_errors?
-  @scan_errors && !@scan_errors.empty?
-end
-
-def scanner_handle_fatal_errors
-  return unless has_fatal_errors?
-  return unless @tl
-
-  # First kill any running threads
-  @tl.each {|t| t.kill if t.alive? }
-
-  # Show the unique errors triggered by the scan
-  uniq_errors = @scan_errors.uniq
-  uniq_errors.each do |emsg|
-    print_error("Fatal: #{emsg}")
-  end
-  print_error("Scan terminated due to #{uniq_errors.size} fatal error(s)")
-end
-
-def scanner_progress
-  return 0 unless @range_done and @range_count
-  pct = (@range_done / @range_count.to_f) * 100
-end
-
-def scanner_show_progress
-  # it should already be in the process of shutting down if there are fatal errors
-  return if has_fatal_errors?
-  pct = scanner_progress
-  if pct >= (@range_percent + @show_percent)
-    @range_percent = @range_percent + @show_percent
-    tdlen = @range_count.to_s.length
-    print_status(sprintf("Scanned %#{tdlen}d of %d hosts (%d%% complete)", @range_done, @range_count, pct))
-  end
-end
-
-def add_delay_jitter(_delay, _jitter)
-  # Introduce the delay
-  delay_value = _delay.to_i
-  original_value = delay_value
-  jitter_value = _jitter.to_i
-
-  # Retrieve the jitter value and delay value
-  # Delay = number of milliseconds to wait between each request
-  # Jitter = percentage modifier. For example:
-  # Delay is 1000ms (i.e. 1 second), Jitter is 50.
-  # 50/100 = 0.5; 0.5*1000 = 500. Therefore, the per-request
-  # delay will be 1000 +/- a maximum of 500ms.
-  if delay_value > 0
-    if jitter_value > 0
-       rnd = Random.new
-       if (rnd.rand(2) == 0)
-          delay_value += rnd.rand(jitter_value)
-       else
-          delay_value -= rnd.rand(jitter_value)
-       end
-       if delay_value < 0
-          delay_value = 0
-       end
-    end
-    final_delay = delay_value.to_f / 1000.0
-    vprint_status("Delaying for #{final_delay} second(s) (#{original_value}ms +/- #{jitter_value}ms)")
-    sleep final_delay
-  end
-end
-
-end
-end
-

--- a/lib/msf/core/auxiliary/scanner.rb
+++ b/lib/msf/core/auxiliary/scanner.rb
@@ -1,6 +1,5 @@
 # -*- coding: binary -*-
 module Msf
-
   ###
   #
   # This module provides methods for scanning modules
@@ -8,55 +7,170 @@ module Msf
   ###
 
   module Auxiliary::Scanner
-
-
     #
     # Initializes an instance of a recon auxiliary module
     #
     def initialize(info = {})
       super
 
-      register_options([
+      register_options(
+        [
           Opt::RHOSTS,
-          OptInt.new('THREADS', [ true, "The number of concurrent threads", 1 ] )
-        ], Auxiliary::Scanner)
+          OptInt.new('THREADS', [true, "The number of concurrent threads", 1])
+        ], Auxiliary::Scanner
+      )
 
-      register_advanced_options([
-        OptBool.new('ShowProgress', [true, 'Display progress messages during a scan', true]),
-        OptInt.new('ShowProgressPercent', [true, 'The interval in percent that progress should be shown', 10])
-      ], Auxiliary::Scanner)
-
+      register_advanced_options(
+        [
+          OptBool.new('ShowProgress', [true, 'Display progress messages during a scan', true]),
+          OptInt.new('ShowProgressPercent', [true, 'The interval in percent that progress should be shown', 10])
+        ], Auxiliary::Scanner
+      )
     end
-
-    def check
-      nmod = replicant
-      nmod.datastore['RHOST'] = @original_rhost
-      begin
-        nmod.check_host(datastore['RHOST'])
-      rescue NoMethodError
-        Exploit::CheckCode::Unsupported
-      end
-    end
-
 
     def peer
       # IPv4 addr can be 16 chars + 1 for : and + 5 for port
       super.ljust(21)
     end
 
-    #
-    # The command handler when launched from the console
-    #
-    def run
+    def add_delay_jitter(delay_value, jitter_value)
+      # Introduce the delay
+      delay_value = delay_value.to_i
+      original_value = delay_value
+      jitter_value = jitter_value.to_i
+
+      # Retrieve the jitter value and delay value
+      # Delay = number of milliseconds to wait between each request
+      # Jitter = percentage modifier. For example:
+      # Delay is 1000ms (i.e. 1 second), Jitter is 50.
+      # 50/100 = 0.5; 0.5*1000 = 500. Therefore, the per-request
+      # delay will be 1000 +/- a maximum of 500ms.
+      if delay_value > 0
+        if jitter_value > 0
+          rnd = Random.new
+          if rnd.rand(2) == 0
+            delay_value += rnd.rand(jitter_value)
+          else
+            delay_value -= rnd.rand(jitter_value)
+          end
+          if delay_value < 0
+            delay_value = 0
+          end
+        end
+        final_delay = delay_value.to_f / 1000.0
+        vprint_status("Delaying for #{final_delay} second(s) (#{original_value}ms +/- #{jitter_value}ms)")
+        sleep final_delay
+      end
+    end
+
+    def cleanup_threads!
+      @tl.each do |t|
+        begin
+          t.kill if t.alive?
+        rescue StandardError
+        end
+      end
+    end
+
+    def run_scanner(method)
+      size = respond_to?('run_batch_size') ? run_batch_size : 1
+
+      loop do
+        no_more_hosts = false
+
+        # Stop scanning if we hit a fatal error
+        break if fatal_errors?
+
+        while @tl.length < @threads_max
+
+          batch = []
+
+          # Create batches from each set
+          while batch.length < size
+            ip = @ar.next_ip
+            if !ip
+              no_more_hosts = true
+              break
+            end
+            batch << ip
+          end
+
+          # Create a thread for each batch
+          if batch.length > 0
+            thread = framework.threads.spawn("ScannerBatch(#{refname})", false, batch) do |batch|
+              nmod = replicant
+              begin
+                if method == 'run_batch'
+                  nmod.run_batch(batch)
+                else
+                  nmod.datastore['RHOST'] = batch[0]
+                  nmod.public_send(method, batch[0])
+                end
+              rescue Rex::ConnectionError, Rex::ConnectionProxyError, Errno::ECONNRESET, Errno::EINTR, Rex::TimeoutError, Timeout::Error
+              rescue Rex::BindFailed
+                if datastore['CHOST']
+                  @scan_errors << "The source IP (CHOST) value of #{datastore['CHOST']} was not usable"
+                end
+              rescue Interrupt, NoMethodError, RuntimeError, ArgumentError, NameError
+                raise $ERROR_INFO
+              rescue StandardError => e
+                if size == 1
+                  print_status("Error: #{batch[0]}: #{e.class} #{e.message}")
+                else
+                  print_status("Error: #{batch[0]} - #{batch[-1]}: #{e.class} #{e.message}")
+                end
+                elog("Error running against host(s) #{batch}: #{e.message}\n#{e.backtrace.join("\n")}")
+              ensure
+                nmod.cleanup
+              end
+            end
+            thread[:batch_size] = batch.length
+            @tl << thread
+          end
+
+          # Exit once we run out of hosts
+          if @tl.length == 0 || no_more_hosts
+            break
+          end
+        end
+
+        # Stop scanning if we hit a fatal error
+        break if fatal_errors?
+
+        # Exit if there are no more pending threads
+        if @tl.length == 0
+          break
+        end
+
+        # Assume that the oldest thread will be one of the
+        # first to finish and wait for it.  After that's
+        # done, remove any finished threads from the list
+        # and continue on.  This will open up at least one
+        # spot for a new thread
+        tla = 0
+        @tl.map { |t| tla += t[:batch_size] }
+        @tl.first.join
+        @tl.delete_if { |t| !t.alive? }
+        tlb = 0
+        @tl.map { |t| tlb += t[:batch_size] }
+
+        @range_done += tla - tlb
+        scanner_show_progress if @show_progress
+      end
+
+      scanner_handle_fatal_errors
+    end
+
+    def start_scanner(method)
       @show_progress = datastore['ShowProgress']
       @show_percent  = datastore['ShowProgressPercent'].to_i
 
-      ar             = Rex::Socket::RangeWalker.new(datastore['RHOSTS'])
-      @range_count   = ar.length || 0
+      @ar            = Rex::Socket::RangeWalker.new(datastore['RHOSTS'])
+      @range_count   = @ar.length || 0
       @range_done    = 0
       @range_percent = 0
 
-      threads_max = datastore['THREADS'].to_i
+      @threads_max = datastore['THREADS'].to_i
       @tl = []
       @scan_errors = []
 
@@ -64,183 +178,39 @@ module Msf
       # Sanity check threading given different conditions
       #
 
-      if datastore['CPORT'].to_i != 0 && threads_max > 1
+      if datastore['CPORT'].to_i != 0 && @threads_max > 1
         print_error("Warning: A maximum of one thread is possible when a source port is set (CPORT)")
         print_error("Thread count has been adjusted to 1")
-        threads_max = 1
+        @threads_max = 1
       end
 
-      begin
-
-      if self.respond_to?('run_host')
-        loop do
-          # Stop scanning if we hit a fatal error
-          break if fatal_errors?
-
-          # Spawn threads for each host
-          while @tl.length < threads_max
-
-            # Stop scanning if we hit a fatal error
-            break if fatal_errors?
-
-            ip = ar.next_ip
-            break if !ip
-
-            @tl << framework.threads.spawn("ScannerHost(#{self.refname})-#{ip}", false, ip.dup) do |tip|
-              targ = tip
-              nmod = self.replicant
-              nmod.datastore['RHOST'] = targ
-
-              begin
-                nmod.run_host(targ)
-              rescue ::Rex::BindFailed
-                if datastore['CHOST']
-                  @scan_errors << "The source IP (CHOST) value of #{datastore['CHOST']} was not usable"
-                end
-              rescue ::Rex::ConnectionError, ::Rex::ConnectionProxyError, ::Errno::ECONNRESET, ::Errno::EINTR, ::Rex::TimeoutError, ::Timeout::Error, ::EOFError
-              rescue ::Interrupt, ::NoMethodError, ::RuntimeError, ::ArgumentError, ::NameError
-                raise $ERROR_INFO
-              rescue StandardError => e
-                print_status("Error: #{targ}: #{e.class} #{e.message}")
-                elog("Error running against host #{targ}: #{e.message}\n#{e.backtrace.join("\n")}")
-              ensure
-                nmod.cleanup
-              end
-            end
-          end
-
-          # Stop scanning if we hit a fatal error
-          break if fatal_errors?
-
-          # Exit once we run out of hosts
-          if @tl.length == 0
-            break
-          end
-
-          # Assume that the oldest thread will be one of the
-          # first to finish and wait for it.  After that's
-          # done, remove any finished threads from the list
-          # and continue on.  This will open up at least one
-          # spot for a new thread
-          tla = @tl.length
-          @tl.first.join
-          @tl.delete_if { |t| !t.alive? }
-          tlb = @tl.length
-
-          @range_done += (tla - tlb)
-          scanner_show_progress if @show_progress
-        end
-
-        scanner_handle_fatal_errors
+      if method == 'check'
+        run_scanner('check_host')
+      elsif respond_to?('run_batch')
+        run_scanner('run_batch')
+      elsif respond_to?('run_host')
+        run_scanner('run_host')
+      else
+        print_error("This module defined no run_host or run_batch methods")
         return
       end
-
-      if self.respond_to?('run_batch')
-
-        if !self.respond_to?('run_batch_size')
-          print_status("This module needs to export run_batch_size")
-          return
-        end
-
-        size = run_batch_size
-
-        ar = Rex::Socket::RangeWalker.new(datastore['RHOSTS'])
-
-        loop do
-          nohosts = false
-
-          # Stop scanning if we hit a fatal error
-          break if fatal_errors?
-
-          while @tl.length < threads_max
-
-            batch = []
-
-            # Create batches from each set
-            while batch.length < size
-              ip = ar.next_ip
-              if !ip
-                nohosts = true
-                break
-              end
-              batch << ip
-            end
-
-            # Create a thread for each batch
-            if batch.length > 0
-              thread = framework.threads.spawn("ScannerBatch(#{self.refname})", false, batch) do |bat|
-                nmod = self.replicant
-                mybatch = bat.dup
-                begin
-                  nmod.run_batch(mybatch)
-                rescue ::Rex::BindFailed
-                  if datastore['CHOST']
-                    @scan_errors << "The source IP (CHOST) value of #{datastore['CHOST']} was not usable"
-                  end
-                rescue ::Rex::ConnectionError, ::Rex::ConnectionProxyError, ::Errno::ECONNRESET, ::Errno::EINTR, ::Rex::TimeoutError, ::Timeout::Error
-                rescue ::Interrupt, ::NoMethodError, ::RuntimeError, ::ArgumentError, ::NameError
-                  raise $ERROR_INFO
-                rescue ::StandardError => e
-                  print_status("Error: #{mybatch[0]}-#{mybatch[-1]}: #{e}")
-                ensure
-                  nmod.cleanup
-                end
-              end
-              thread[:batch_size] = batch.length
-              @tl << thread
-            end
-
-            # Exit once we run out of hosts
-            if @tl.length == 0 || nohosts
-              break
-            end
-          end
-
-          # Stop scanning if we hit a fatal error
-          break if fatal_errors?
-
-          # Exit if there are no more pending threads
-          if @tl.length == 0
-            break
-          end
-
-          # Assume that the oldest thread will be one of the
-          # first to finish and wait for it.  After that's
-          # done, remove any finished threads from the list
-          # and continue on.  This will open up at least one
-          # spot for a new thread
-          tla = 0
-          @tl.map { |t| tla += t[:batch_size] }
-          @tl.first.join
-          @tl.delete_if { |t| !t.alive? }
-          tlb = 0
-          @tl.map { |t| tlb += t[:batch_size] }
-
-          @range_done += tla - tlb
-          scanner_show_progress if @show_progress
-        end
-
-        scanner_handle_fatal_errors
-        return
-      end
-
-      print_error("This module defined no run_host or run_batch methods")
-
-      rescue ::Interrupt
-        print_status("Caught interrupt from the console...")
-        return
-      ensure
-        seppuko!
-      end
+    rescue Interrupt
+      print_status("Caught interrupt from the console...")
+    ensure
+      cleanup_threads!
     end
 
-    def seppuko!
-      @tl.each do |t|
-        begin
-          t.kill if t.alive?
-        rescue StandardError
-        end
-      end
+    def check
+      start_scanner('check')
+    rescue NoMethodError
+      Exploit::CheckCode::Unsupported
+    end
+
+    #
+    # The command handler when launched from the console
+    #
+    def run
+      start_scanner('run')
     end
 
     def fatal_errors?
@@ -274,37 +244,7 @@ module Msf
       if pct >= (@range_percent + @show_percent)
         @range_percent += @show_percent
         tdlen = @range_count.to_s.length
-        print_status(sprintf("Scanned %#{tdlen}d of %d hosts (%d%% complete)", @range_done, @range_count, pct))
-      end
-    end
-
-    def add_delay_jitter(delay_value, jitter_value)
-      # Introduce the delay
-      delay_value = delay_value.to_i
-      original_value = delay_value
-      jitter_value = jitter_value.to_i
-
-      # Retrieve the jitter value and delay value
-      # Delay = number of milliseconds to wait between each request
-      # Jitter = percentage modifier. For example:
-      # Delay is 1000ms (i.e. 1 second), Jitter is 50.
-      # 50/100 = 0.5; 0.5*1000 = 500. Therefore, the per-request
-      # delay will be 1000 +/- a maximum of 500ms.
-      if delay_value > 0
-        if jitter_value > 0
-          rnd = Random.new
-          if rnd.rand(2) == 0
-            delay_value += rnd.rand(jitter_value)
-          else
-            delay_value -= rnd.rand(jitter_value)
-          end
-          if delay_value < 0
-            delay_value = 0
-          end
-        end
-        final_delay = delay_value.to_f / 1000.0
-        vprint_status("Delaying for #{final_delay} second(s) (#{original_value}ms +/- #{jitter_value}ms)")
-        sleep final_delay
+        print_status("Scanned #{@range_done} of #{@range_count} hosts (#{pct}% complete)")
       end
     end
   end

--- a/modules/auxiliary/scanner/portscan/ack.rb
+++ b/modules/auxiliary/scanner/portscan/ack.rb
@@ -74,7 +74,7 @@ class MetasploitModule < Msf::Auxiliary
         pcap.setfilter(getfilter(shost, sport, dhost, dport))
 
         # Add the delay based on JITTER and DELAY if needs be
-        add_delay_jitter(delay_value,jitter_value)
+        add_delay_jitter(delay_value, jitter_value)
 
         begin
           probe = buildprobe(shost, sport, dhost, dport)

--- a/modules/auxiliary/scanner/portscan/ftpbounce.rb
+++ b/modules/auxiliary/scanner/portscan/ftpbounce.rb
@@ -75,7 +75,7 @@ class MetasploitModule < Msf::Auxiliary
       begin
 
         # Add the delay based on JITTER and DELAY if needs be
-        add_delay_jitter(delay_value,jitter_value)
+        add_delay_jitter(delay_value, jitter_value)
 
         host = (ip.split('.') + [port / 256, port % 256]).join(',')
         resp = send_cmd(["PORT", host])

--- a/modules/auxiliary/scanner/portscan/syn.rb
+++ b/modules/auxiliary/scanner/portscan/syn.rb
@@ -70,7 +70,7 @@ class MetasploitModule < Msf::Auxiliary
         self.capture.setfilter(getfilter(shost, sport, dhost, dport))
 
         # Add the delay based on JITTER and DELAY if needs be
-        add_delay_jitter(delay_value,jitter_value)
+        add_delay_jitter(delay_value, jitter_value)
 
         begin
           probe = buildprobe(shost, sport, dhost, dport)

--- a/modules/auxiliary/scanner/portscan/tcp.rb
+++ b/modules/auxiliary/scanner/portscan/tcp.rb
@@ -66,7 +66,7 @@ class MetasploitModule < Msf::Auxiliary
           begin
 
             # Add the delay based on JITTER and DELAY if needs be
-            add_delay_jitter(delay_value,jitter_value)
+            add_delay_jitter(delay_value, jitter_value)
 
             # Actually perform the TCP connection
             s = connect(false,

--- a/modules/auxiliary/scanner/portscan/xmas.rb
+++ b/modules/auxiliary/scanner/portscan/xmas.rb
@@ -76,7 +76,7 @@ class MetasploitModule < Msf::Auxiliary
           probe = buildprobe(shost, sport, dhost, dport)
 
           # Add the delay based on JITTER and DELAY if needs be
-          add_delay_jitter(delay_value,jitter_value)
+          add_delay_jitter(delay_value, jitter_value)
 
           unless capture_sendto(probe, dhost)
             host_queue.delete(dhost)


### PR DESCRIPTION
This fixes issues with scanner logic specifically in MSF5 where the 'check' method is not working correctly due to some implicit global state not being set. Instead of returning the global state to the base module classes, this merges the logic for running 'run_check' and 'run_host' so that both set the same state directly in the scanner logic, no magic required. Since 'run_single' is just a special case of 'run_batch' with a batch size of 1, this also merges the logic between those two paths.

## Verification

- [ ] Start `msfconsole`, run many aux/scanner modules through their paces
- [ ] **Verify** that multi scanners work properly with run and check
- [ ] **Verify** that single scanners work properly with run and check

This is an earliy WIP that worked for me with the SSL scanners, but I don't know every edge-case or oddball module that might be stretching the boundaries of what this interface was intended to do.