### PR TITLE
Add autofilter_ports and autofilter_services to cache

### DIFF
--- a/lib/msf/core/modules/metadata/obj.rb
+++ b/lib/msf/core/modules/metadata/obj.rb
@@ -35,6 +35,10 @@ class Obj
   attr_reader :arch
   # @return [Integer]
   attr_reader :rport
+  # @return [Array<Integer>]
+  attr_reader :filter_ports
+  # @return [Array<String>]
+  attr_reader :filter_services
   # @return [Array<String>]
   attr_reader :targets
   # @return [Time]
@@ -80,6 +84,12 @@ class Obj
     @path               = module_instance.file_path
     @mod_time           = ::File.mtime(@path) rescue Time.now
     @ref_name           = module_instance.refname
+    if module_instance.respond_to?('autofilter_ports')
+      @filter_ports = module_instance.autofilter_ports
+    end
+    if module_instance.respond_to?('autofilter_services')
+      @filter_services = module_instance.autofilter_services
+    end
 
     install_path = Msf::Config.install_root.to_s
     if (@path.to_s.include? (install_path))
@@ -118,6 +128,8 @@ class Obj
       'platform'           => @platform,
       'arch'               => @arch,
       'rport'              => @rport,
+      'filter_ports'       => @filter_ports,
+      'filter_services'    => @filter_services,
       'targets'            => @targets,
       'mod_time'           => @mod_time.to_s,
       'path'               => @path,

--- a/lib/msf/core/modules/metadata/obj.rb
+++ b/lib/msf/core/modules/metadata/obj.rb
@@ -36,9 +36,9 @@ class Obj
   # @return [Integer]
   attr_reader :rport
   # @return [Array<Integer>]
-  attr_reader :filter_ports
+  attr_reader :autofilter_ports
   # @return [Array<String>]
-  attr_reader :filter_services
+  attr_reader :autofilter_services
   # @return [Array<String>]
   attr_reader :targets
   # @return [Time]
@@ -84,11 +84,11 @@ class Obj
     @path               = module_instance.file_path
     @mod_time           = ::File.mtime(@path) rescue Time.now
     @ref_name           = module_instance.refname
-    if module_instance.respond_to?('autofilter_ports')
-      @filter_ports = module_instance.autofilter_ports
+    if module_instance.respond_to?(:autofilter_ports)
+      @autofilter_ports = module_instance.autofilter_ports
     end
-    if module_instance.respond_to?('autofilter_services')
-      @filter_services = module_instance.autofilter_services
+    if module_instance.respond_to?(:autofilter_services)
+      @autofilter_services = module_instance.autofilter_services
     end
 
     install_path = Msf::Config.install_root.to_s
@@ -128,8 +128,8 @@ class Obj
       'platform'           => @platform,
       'arch'               => @arch,
       'rport'              => @rport,
-      'filter_ports'       => @filter_ports,
-      'filter_services'    => @filter_services,
+      'autofilter_ports'   => @autofilter_ports,
+      'autofilter_services'=> @autofilter_services,
       'targets'            => @targets,
       'mod_time'           => @mod_time.to_s,
       'path'               => @path,


### PR DESCRIPTION
When caching metadata about modules include `autofilter` details when available.

## Verification

List the steps needed to make sure this thing works

- [x] **Regenerate** module cache and **verify** it updated correctly
  - [x] `rm db/modules_metadata_base.json ~/.msf4/store/modules_metadata.json`
  - [x] `./msfconsole -qx 'irb -e framework.modules.refresh_cache_from_module_files; exit'`
  - [x] **Verify** `~/.msf4/store/modules_metadata.json` is correct
  - [x] `cp ~/.msf4/store/modules_metadata.json db/modules_metadata_base.json`
  - [x] **Verify** `search` works as intended
  - [x] **Verify** `db/modules_metadata_base.json` contains entries for `autofilter_ports` && `autofilter_services`
  - [x] `git checkout db/modules_metadata_base.json`
  - [x] **DO NOT** commit any module cache changes