### PR TITLE
Only send a close channel message once, avoid if Meterpreter told us

### DIFF
--- a/lib/rex/post/meterpreter/extensions/stdapi/net/socket_subsystem/tcp_client_channel.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/net/socket_subsystem/tcp_client_channel.rb
@@ -98,6 +98,8 @@ class TcpClientChannel < Rex::Post::Meterpreter::Stream
   # 2 -> both
   #
   def shutdown(how = 1)
+    return false if self.cid.nil?
+
     request = Packet.create_request('stdapi_net_socket_tcp_shutdown')
 
     request.add_tlv(TLV_TYPE_SHUTDOWN_HOW, how)


### PR DESCRIPTION
Don't send a close message for a nil channel ID, and if we do send a close message, only do it once. I could have added a mutex somewher in _close(), but because it's a class method, it's a little awkward and would require all of the callers to instead have voluntary lock. As an alternative, I just made the
finalizer close the channel instead.

Fixes #10177

## Verification

For my test, I ran python meterpreter on macOS, pivoting smb_login against a Windows 10 PC.

In one console window, run this. The Windows 10 target is called 'dell' here, and setting the route is important to exercise the code path:

- [x] `./msfconsole -qx 'use exploit/multi/handler; set payload python/meterpreter/reverse_tcp; set lhost 127.0.0.1; run; route add 192.168.1.0/24 1; use auxiliary/scanner/smb/smb_login; set rhosts dell; run; sessions -K; exit'`

In another, generate a python/meterpreter/reverse_tcp payload that connects to 127.0.0.0
- [x] `./msfvenom -p python/meterpreter/reverse_tcp LHOST=127.0.0.1 -f raw -o test.py`
- [x] `python ./test.py`

You should get a session. Type 'background' or ctrl-z, then the test should scan the target machine through a pivot. You should get the same output as if you had not pivoted, with no backtraces.
