### PR TITLE
Update payloads to include the new Kiwi release

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,7 +18,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 1.3.47)
+      metasploit-payloads (= 1.3.52)
       metasploit_data_models
       metasploit_payloads-mettle (= 0.4.2)
       mqtt
@@ -164,7 +164,7 @@ GEM
       activemodel (~> 4.2.6)
       activesupport (~> 4.2.6)
       railties (~> 4.2.6)
-    metasploit-payloads (1.3.47)
+    metasploit-payloads (1.3.52)
     metasploit_data_models (3.0.0)
       activerecord (~> 4.2.6)
       activesupport (~> 4.2.6)

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/kiwi.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/kiwi.rb
@@ -37,13 +37,12 @@ class Console::CommandDispatcher::Kiwi
   def initialize(shell)
     super
     print_line
-    print_line
-    print_line("  .#####.   mimikatz 2.1.1 20180820 (#{client.session_type})")
+    print_line("  .#####.   mimikatz 2.1.1 20180925 (#{client.session_type})")
     print_line(" .## ^ ##.  \"A La Vie, A L'Amour\"")
-    print_line(" ## / \\ ##  /* * *")
-    print_line(" ## \\ / ##   Benjamin DELPY `gentilkiwi` ( benjamin@gentilkiwi.com )")
-    print_line(" '## v ##'   http://blog.gentilkiwi.com/mimikatz             (oe.eo)")
-    print_line("  '#####'    Ported to Metasploit by OJ Reeves `TheColonial` * * */")
+    print_line(" ## / \\ ##  /*** Benjamin DELPY `gentilkiwi` ( benjamin@gentilkiwi.com )")
+    print_line(" ## \\ / ##       > http://blog.gentilkiwi.com/mimikatz")
+    print_line(" '## v ##'        Vincent LE TOUX            ( vincent.letoux@gmail.com )")
+    print_line("  '#####'         > http://pingcastle.com / http://mysmartlogon.com  ***/")
     print_line
 
     si = client.sys.config.sysinfo

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -70,7 +70,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '1.3.47'
+  spec.add_runtime_dependency 'metasploit-payloads', '1.3.52'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '0.4.2'
   # Needed by msfgui and other rpc components


### PR DESCRIPTION
# WORK IN PROGRESS

This PR will be updated with the new Payloads gem when that stuff has been landed ([over here](https://github.com/rapid7/metasploit-payloads/pull/307)).

# Update Kiwi to 2.1.1-20180925

This includes changes that will allow dumping creds to work on Windows 10 v1803 to bypass the new CG protections.