### PR TITLE
Enhance reload_lib to reload changed files

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/developer.rb
+++ b/lib/msf/ui/console/command_dispatcher/developer.rb
@@ -51,6 +51,18 @@ class Msf::Ui::Console::CommandDispatcher::Developer
     load path
   end
 
+  def reload_diff_files
+    output = %x(git diff --name-only 2>&1)
+    if output.include?('Not a git repository')
+      print_error 'No git repository found.'
+      return
+    end
+    files = output.split("\n")
+    files.each do | file |
+      reload_file(file)
+    end
+  end
+
   def cmd_irb_help
     print_line "Usage: irb"
     print_line
@@ -192,10 +204,12 @@ class Msf::Ui::Console::CommandDispatcher::Developer
   end
 
   def cmd_reload_lib_help
-    print_line 'Usage: reload_lib lib/to/reload.rb [...] [diff]'
+    print_line 'Usage: reload_lib lib/to/reload.rb [...]'
     print_line
     print_line 'Reload one or more library files from specified paths.'
-    print_line 'Use the argument \'diff\' to reload all changed files in your current git working tree.'
+    print_line
+    print_line 'OPTIONS:'
+    print_line '   -a, --all    Reload all changed files in your current git working tree.'
   end
 
   #
@@ -205,8 +219,8 @@ class Msf::Ui::Console::CommandDispatcher::Developer
     if args.empty? || args.include?('-h') || args.include?('--help')
       cmd_reload_lib_help
       return
-    elsif args.include?('diff')
-      cmd_reload_diff_files
+    elsif args.include?('-a') || args.include?('--all')
+      reload_diff_files
       return
     end
 
@@ -218,18 +232,6 @@ class Msf::Ui::Console::CommandDispatcher::Developer
   #
   def cmd_reload_lib_tabs(str, words)
     tab_complete_filenames(str, words)
-  end
-
-  def cmd_reload_diff_files
-    output = %x(git diff --name-only 2>&1)
-    if output.include?('Not a git repository')
-      print_error 'No git repository found.'
-      return
-    end
-    files = output.split
-    files.each do | file |
-      reload_file(file)
-    end
   end
 
   def cmd_log_help

--- a/lib/msf/ui/console/command_dispatcher/developer.rb
+++ b/lib/msf/ui/console/command_dispatcher/developer.rb
@@ -192,11 +192,10 @@ class Msf::Ui::Console::CommandDispatcher::Developer
   end
 
   def cmd_reload_lib_help
-    print_line 'Usage: reload_lib lib/to/reload.rb [...]'
-    print_line '       reload_lib diff'
+    print_line 'Usage: reload_lib lib/to/reload.rb [...] [diff]'
     print_line
     print_line 'Reload one or more library files from specified paths.'
-    print_line 'Use \'diff\' to reload all changed files in your current git working tree.'
+    print_line 'Use the argument \'diff\' to reload all changed files in your current git working tree.'
   end
 
   #

--- a/lib/msf/ui/console/command_dispatcher/developer.rb
+++ b/lib/msf/ui/console/command_dispatcher/developer.rb
@@ -26,6 +26,10 @@ class Msf::Ui::Console::CommandDispatcher::Developer
     }
   end
 
+  def git?
+    File.directory?(File.join(Msf::Config.install_root, ".git"))
+  end
+
   def local_editor
     framework.datastore['LocalEditor'] || Rex::Compat.getenv('VISUAL') || Rex::Compat.getenv('EDITOR')
   end
@@ -52,12 +56,11 @@ class Msf::Ui::Console::CommandDispatcher::Developer
   end
 
   def reload_diff_files
-    output = %x(git diff --name-only 2>&1)
-    if output.include?('Not a git repository')
+    unless git?
       print_error 'No git repository found.'
       return
     end
-    files = output.split("\n")
+    files = %x(git diff --name-only).split("\n")
     files.each do | file |
       reload_file(file)
     end

--- a/lib/msf/ui/console/command_dispatcher/developer.rb
+++ b/lib/msf/ui/console/command_dispatcher/developer.rb
@@ -36,6 +36,8 @@ class Msf::Ui::Console::CommandDispatcher::Developer
       print_error "Framework installation is not a git repository. \n    Did you install using a nightly installer or package manager?"
       return false
     end
+
+    true
   end
 
   def local_editor

--- a/lib/msf/ui/console/command_dispatcher/developer.rb
+++ b/lib/msf/ui/console/command_dispatcher/developer.rb
@@ -204,27 +204,32 @@ class Msf::Ui::Console::CommandDispatcher::Developer
   end
 
   def cmd_reload_lib_help
-    print_line 'Usage: reload_lib lib/to/reload.rb [...]'
-    print_line
-    print_line 'Reload one or more library files from specified paths.'
-    print_line
-    print_line 'OPTIONS:'
-    print_line '   -a, --all    Reload all changed files in your current git working tree.'
+    cmd_reload_lib '-h'
   end
 
   #
   # Reload one or more library files from specified paths
   #
   def cmd_reload_lib(*args)
-    if args.empty? || args.include?('-h') || args.include?('--help')
-      cmd_reload_lib_help
-      return
-    elsif args.include?('-a') || args.include?('--all')
-      reload_diff_files
-      return
+
+    opts = OptionParser.new do |opts|
+      opts.banner = 'Usage: reload_lib lib/to/reload.rb [...]'
+      opts.separator 'Reload one or more library files from specified paths.'
+      opts.separator ''
+
+      opts.on '-h', '--help', 'Help banner.' do
+        return print(opts.help)
+      end
+
+      opts.on '-a', '--all', 'Reload all changed files in your current git working tree.' do
+        reload_diff_files
+        return
+      end
+
     end
 
-    args.each { |path| reload_file(path) }
+    rest = opts.order(args)
+    rest.each { |path| reload_file(path) }
   end
 
   #

--- a/lib/msf/ui/console/command_dispatcher/developer.rb
+++ b/lib/msf/ui/console/command_dispatcher/developer.rb
@@ -27,7 +27,7 @@ class Msf::Ui::Console::CommandDispatcher::Developer
   end
 
   def git?
-    File.directory?(File.join(Msf::Config.install_root, ".git"))
+    File.directory?(File.join(Msf::Config.install_root, ".git")) && Msf::Util::Helper.which("git")
   end
 
   def local_editor

--- a/lib/msf/ui/console/command_dispatcher/developer.rb
+++ b/lib/msf/ui/console/command_dispatcher/developer.rb
@@ -221,7 +221,12 @@ class Msf::Ui::Console::CommandDispatcher::Developer
   end
 
   def cmd_reload_diff_files
-    files = %x(git diff --name-only).split
+    output = %x(git diff --name-only 2>&1)
+    if output.include?('Not a git repository')
+      print_error 'No git repository found.'
+      return
+    end
+    files = output.split
     files.each do | file |
       reload_file(file)
     end

--- a/lib/msf/ui/console/command_dispatcher/developer.rb
+++ b/lib/msf/ui/console/command_dispatcher/developer.rb
@@ -215,14 +215,15 @@ class Msf::Ui::Console::CommandDispatcher::Developer
   def cmd_reload_lib(*args)
     opts = OptionParser.new do |opts|
       opts.banner = 'Usage: reload_lib lib/to/reload.rb [...]'
-      opts.separator 'Reload one or more library files from specified paths.'
+      opts.separator 'Reload specified Ruby library files.'
       opts.separator ''
 
       opts.on '-h', '--help', 'Help banner.' do
         return print(opts.help)
       end
 
-      opts.on '-a', '--all', 'Reload all changed files in your current git working tree.' do
+      opts.on '-a', '--all', 'Reload all* changed files in your current git working tree.
+                                     *Excludes modules and non-Ruby files.' do
         reload_diff_files
         return
       end

--- a/lib/msf/ui/console/command_dispatcher/developer.rb
+++ b/lib/msf/ui/console/command_dispatcher/developer.rb
@@ -193,9 +193,10 @@ class Msf::Ui::Console::CommandDispatcher::Developer
 
   def cmd_reload_lib_help
     print_line 'Usage: reload_lib lib/to/reload.rb [...]'
+    print_line '       reload_lib diff'
     print_line
     print_line 'Reload one or more library files from specified paths.'
-    print_line
+    print_line 'Use \'diff\' to reload all changed files in your current git working tree.'
   end
 
   #
@@ -204,6 +205,9 @@ class Msf::Ui::Console::CommandDispatcher::Developer
   def cmd_reload_lib(*args)
     if args.empty? || args.include?('-h') || args.include?('--help')
       cmd_reload_lib_help
+      return
+    elsif args.include?('diff')
+      cmd_reload_diff_files
       return
     end
 
@@ -215,6 +219,13 @@ class Msf::Ui::Console::CommandDispatcher::Developer
   #
   def cmd_reload_lib_tabs(str, words)
     tab_complete_filenames(str, words)
+  end
+
+  def cmd_reload_diff_files
+    files = %x(git diff --name-only).split
+    files.each do | file |
+      reload_file(file)
+    end
   end
 
   def cmd_log_help

--- a/lib/msf/ui/console/command_dispatcher/developer.rb
+++ b/lib/msf/ui/console/command_dispatcher/developer.rb
@@ -26,20 +26,6 @@ class Msf::Ui::Console::CommandDispatcher::Developer
     }
   end
 
-  def git?
-    unless Msf::Util::Helper.which("git")
-      print_error "'git' is not found."
-      return false
-    end
-
-    unless File.directory?(File.join(Msf::Config.install_root, ".git"))
-      print_error "Framework installation is not a git repository. \n    Did you install using a nightly installer or package manager?"
-      return false
-    end
-
-    true
-  end
-
   def local_editor
     framework.datastore['LocalEditor'] || Rex::Compat.getenv('VISUAL') || Rex::Compat.getenv('EDITOR')
   end
@@ -66,15 +52,12 @@ class Msf::Ui::Console::CommandDispatcher::Developer
   end
 
   def reload_diff_files
-    unless git?
-      return
-    end
     output, status = Open3.capture2e *%w(git diff --name-only)
     if status.success?
       files = output.split("\n")
       files.each { |file| reload_file(file) }
     else
-      print_error output
+      print_error "Git is not available."
     end
   end
 

--- a/lib/msf/ui/console/command_dispatcher/developer.rb
+++ b/lib/msf/ui/console/command_dispatcher/developer.rb
@@ -53,10 +53,13 @@ class Msf::Ui::Console::CommandDispatcher::Developer
   end
 
   def reload_diff_files
-    output, status = Open3.capture2e *%w(git diff --name-only -- '*.rb' ':!modules')
+    output, status = Open3.capture2e(*%w(git diff --name-only *.rb :!modules), chdir: Msf::Config.install_root)
     if status.success?
       files = output.split("\n")
-      files.each { |file| reload_file(file, true) }
+      files.each do |file|
+        f = File.join(Msf::Config.install_root, file)
+        reload_file(f, true)
+      end
     else
       print_error "Git is not available."
     end


### PR DESCRIPTION
This adds `-a`/`--all` as an argument to `reload_lib` that will reload any changed files in your current git working tree

## Verification

- [x] Make some changes in some files
- [x] Start `msfconsole`
- [x] `reload_lib -a` or `--all`
- [x] **Verify** that your changed ruby non-module files were reloaded
- [x] **Verify** that any non-ruby or module files were **not** reloaded
- [x] `reload_lib -h`
- [x] **Verify** that help docs are shown for the new `-a`/`--all` argument

#10042