### PR TITLE
Enhance msfdb to check path for required commands

### DIFF
--- a/msfdb
+++ b/msfdb
@@ -12,6 +12,17 @@ require 'sysrandom/securerandom'
 require 'uri'
 require 'yaml'
 
+msfbase = __FILE__
+while File.symlink?(msfbase)
+  msfbase = File.expand_path(File.readlink(msfbase), File.dirname(msfbase))
+end
+
+$:.unshift(File.expand_path(File.join(File.dirname(msfbase), 'lib')))
+$:.unshift(ENV['MSF_LOCAL_LIB']) if ENV['MSF_LOCAL_LIB']
+
+require 'msf/util/helper'
+
+
 @script_name = File.basename(__FILE__)
 @framework = File.expand_path(File.dirname(__FILE__))
 
@@ -906,38 +917,19 @@ def invoke_command(commands, component, command)
   end
 end
 
-# Searches the user's path for the executable file that would be run had the
-# command actually been invoked.
-# @param cmd [String] command name
-# @param return_all [Boolean] If true, returns a list of all instances of
-# executable found (instead of just the first one). Default: false.
-# @return [Array] instance or instances of executable found based on return_all, or nil.
-def which(cmd, return_all: false)
-  return nil if cmd.empty?
-
-  found = []
-  ENV['PATH'].split(File::PATH_SEPARATOR).each do |path|
-    exe_file = File.join(path, cmd)
-    found << exe_file if !File.directory?(exe_file) && File.executable?(exe_file)
-    break if !return_all && found.size > 0
-  end
-
-  return found.empty? ? nil : found
-end
-
 def has_requirements
   ret_val = true
   postgresql_cmds = %w(psql pg_ctl initdb createdb)
   other_cmds = %w(bundle thin)
   missing_msg = 'Missing requirement: %<name>s does not appear to be installed or is not in the environment path'
 
-  unless postgresql_cmds.all? { |cmd| !which(cmd).nil? }
+  unless postgresql_cmds.all? { |cmd| !Msf::Util::Helper.which(cmd).nil? }
     puts missing_msg % { name: 'PostgreSQL' }
     ret_val = false
   end
 
   other_cmds.each do |cmd|
-    if which(cmd).nil?
+    if Msf::Util::Helper.which(cmd).nil?
       puts missing_msg % { name: "'#{cmd}'" }
       ret_val = false
     end

--- a/msfdb
+++ b/msfdb
@@ -906,12 +906,56 @@ def invoke_command(commands, component, command)
   end
 end
 
+# Searches the user's path for the executable file that would be run had the
+# command actually been invoked.
+# @param cmd [String] command name
+# @param return_all [Boolean] If true, returns a list of all instances of
+# executable found (instead of just the first one). Default: false.
+# @return [Array] instance or instances of executable found based on return_all, or nil.
+def which(cmd, return_all: false)
+  return nil if cmd.empty?
+
+  found = []
+  ENV['PATH'].split(File::PATH_SEPARATOR).each do |path|
+    exe_file = File.join(path, cmd)
+    found << exe_file if !File.directory?(exe_file) && File.executable?(exe_file)
+    break if !return_all && found.size > 0
+  end
+
+  return found.empty? ? nil : found
+end
+
+def has_requirements
+  ret_val = true
+  postgresql_cmds = %w(psql pg_ctl initdb createdb)
+  other_cmds = %w(bundle thin)
+  missing_msg = 'Missing requirement: %<name>s does not appear to be installed or is not in the environment path'
+
+  unless postgresql_cmds.all? { |cmd| !which(cmd).nil? }
+    puts missing_msg % { name: 'PostgreSQL' }
+    ret_val = false
+  end
+
+  other_cmds.each do |cmd|
+    if which(cmd).nil?
+      puts missing_msg % { name: "'#{cmd}'" }
+      ret_val = false
+    end
+  end
+
+  ret_val
+end
+
 
 
 if $PROGRAM_NAME == __FILE__
   # Bomb out if we're root
   if !Gem.win_platform? && Process.uid.zero?
     puts "Please run #{@script_name} as a non-root user"
+    abort
+  end
+
+  unless has_requirements
     abort
   end
 


### PR DESCRIPTION
Enhances the `msfdb` tool to check the path for required commands such as required PostgreSQL commands and fail early if they are unavailable. This is an attempt to help the user avoid confusing messages during runtime. Closes #10708 

## Verification

List the steps needed to make sure this thing works

- [x] Modify user environment path such that the PostgreSQL commands are no longer in the path
- [x] run `msfdb`
- [x] **Verify** an error message is output that indicates there is a missing requirement and that PostgreSQL does not appear to be installed or is not in the environment path
- [x] Restore user environment path such that the PostgreSQL commands are in the path
- [x] run `msfdb`
- [x] **Verify** usage information is output
