### PR TITLE
Refactor the rhosts for exploit modules.

### DIFF
--- a/lib/msf/base/simple/exploit.rb
+++ b/lib/msf/base/simple/exploit.rb
@@ -78,6 +78,9 @@ module Exploit
       # Start it up
       driver = ExploitDriver.new(exploit.framework)
 
+      # Keep the handler of driver running if exploit multi targets.
+      driver.keep_handler = true if opts["multi"]
+
       # Initialize the driver instance
       driver.exploit    = exploit
       driver.payload    = exploit.framework.payloads.create(opts['Payload'])

--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -1410,6 +1410,12 @@ class Exploit < Msf::Module
         self.print_error("Exploit failed [#{self.fail_reason}]: #{msg}")
         elog("Exploit failed (#{self.refname}): #{msg}", 'core', LEV_0)
         dlog("Call stack:\n#{e.backtrace.join("\n")}", 'core', LEV_3)
+
+      when ::Interrupt
+        self.fail_reason = Msf::Exploit::Failure::UserInterrupt
+        self.print_error("Exploit failed [#{self.fail_reason}]: #{msg}")
+        elog("Exploit failed (#{self.refname}): #{msg}", 'core', LEV_0)
+        dlog("Call stack:\n#{e.backtrace.join("\n")}", 'core', LEV_3)
       else
 
         # Compare as a string since not all error classes may be loaded
@@ -1451,6 +1457,8 @@ class Exploit < Msf::Module
 
     # Interrupt any session waiters in the handler
     self.interrupt_handler
+
+    return self.fail_reason
   end
 
   def report_failure

--- a/lib/msf/core/exploit_driver.rb
+++ b/lib/msf/core/exploit_driver.rb
@@ -22,6 +22,7 @@ class ExploitDriver
     self.use_job                = false
     self.job_id                 = nil
     self.force_wait_for_session = false
+    self.keep_handler           = false
     self.semaphore              = Mutex.new
   end
 
@@ -164,8 +165,15 @@ class ExploitDriver
       # settings until after they're done.
       ctx = [ exploit, payload ]
 
-      job_run_proc(ctx)
-      job_cleanup_proc(ctx)
+      begin
+        job_run_proc(ctx)
+        # For multi exploit targets.
+        # Keep the payload handler until last target or interrupt
+        job_cleanup_proc(ctx) unless keep_handler
+      rescue ::Interrupt
+        job_cleanup_proc(ctx)
+        raise $!
+      end
     end
 
     return session
@@ -181,6 +189,7 @@ class ExploitDriver
   attr_accessor :job_id
   attr_accessor :force_wait_for_session # :nodoc:
   attr_accessor :session # :nodoc:
+  attr_accessor :keep_handler # :nodoc:
 
   # To synchronize threads cleaning up the exploit and the handler
   attr_accessor :semaphore
@@ -211,7 +220,7 @@ protected
         delay = 0.01
       end
 
-      exploit.handle_exception e
+      fail_reason = exploit.handle_exception(e)
     end
 
     # Start bind handlers after exploit completion
@@ -236,6 +245,10 @@ protected
       exploit.fail_reason = Msf::Exploit::Failure::PayloadFailed
       exploit.fail_detail = "No session created"
       exploit.report_failure
+    end
+
+    if fail_reason && fail_reason == Msf::Exploit::Failure::UserInterrupt
+      raise ::Interrupt
     end
   end
 

--- a/lib/msf/ui/console/command_dispatcher/exploit.rb
+++ b/lib/msf/ui/console/command_dispatcher/exploit.rb
@@ -47,6 +47,9 @@ class Exploit
     "Exploit"
   end
 
+  #
+  # Launches an exploitation single attempt.
+  #
   def exploit_single(mod, opts)
     begin
       session = mod.exploit_simple(opts)
@@ -63,41 +66,7 @@ class Exploit
       end
     end
 
-    # If we were given a session, let's see what we can do with it
-    if session
-      if !opts['Background'] && session.interactive?
-        # If we aren't told to run in the background and the session can be
-        # interacted with, start interacting with it by issuing the session
-        # interaction command.
-        print_line
-
-        driver.run_single("sessions -q -i #{session.sid}")
-      # Otherwise, log that we created a session
-      else
-        # Otherwise, log that we created a session
-        print_status("Session #{session.sid} created in the background.")
-      end
-
-    elsif opts['RunAsJob'] && mod.job_id
-      # Indicate if he exploit as a job, indicate such so the user doesn't
-      # wonder what's up.
-      print_status("Exploit running as background job #{mod.job_id}.")
-      # Worst case, the exploit ran but we got no session, bummer.
-
-    else
-      # If we didn't run a payload handler for this exploit it doesn't
-      # make sense to complain to the user that we didn't get a session
-      unless mod.datastore["DisablePayloadHandler"]
-        fail_msg = 'Exploit completed, but no session was created.'
-        print_status(fail_msg)
-        begin
-          framework.events.on_session_fail(fail_msg)
-        rescue ::Exception => e
-          wlog("Exception in on_session_open event handler: #{e.class}: #{e}")
-          wlog("Call Stack\n#{e.backtrace.join("\n")}")
-        end
-      end
-    end
+    return session
   end
 
   def cmd_exploit_tabs(str, words)
@@ -117,11 +86,12 @@ class Exploit
   end
 
   #
-  # Launches an exploitation attempt.
+  # Launches exploitation attempts.
   #
   def cmd_exploit(*args)
     force = false
     module_opts = []
+    any_session = false
     opts = {
       'Encoder'     => mod.datastore['ENCODER'],
       'Payload'     => mod.datastore['PAYLOAD'],
@@ -195,14 +165,75 @@ class Exploit
     end
 
     rhosts = mod.datastore['RHOSTS']
+    # For mutilple targets exploit attempts.
     if rhosts
-      Rex::Socket::RangeWalker.new(rhosts).each do |rhost|
+      opts[:multi] = true
+      rhosts_range = Rex::Socket::RangeWalker.new(rhosts)
+      rhosts_range.each do |rhost|
         nmod = mod.replicant
         nmod.datastore['RHOST'] = rhost
-        exploit_single(nmod, opts)
+        # If rhost is the last target, let exploit handler stop.
+        opts["multi"] = false if rhost == (Rex::Socket.addr_itoa(rhosts_range.ranges.first.stop))
+        # Catch the interrupt exception to stop the whole module during exploit
+        begin
+          print_status("Exploiting target #{rhost}")
+          session = exploit_single(nmod, opts)
+        rescue ::Interrupt
+          print_status("Stopping exploiting current target #{rhost}...")
+          print_status("Control-C again to force quit exploiting all targets.")
+          begin
+            Rex.sleep(1)
+          rescue ::Interrupt
+            raise $!
+          end
+        end
+        # If we were given a session, report it.
+        if session
+          print_status("Session #{session.sid} created in the background.")
+          any_session = true
+        end
       end
+    # For single target.
     else
-      exploit_single(mod, opts)
+      session = exploit_single(mod, opts)
+          # If we were given a session, let's see what we can do with it
+      if session
+        any_session = true
+        if !opts['Background'] && session.interactive?
+          # If we aren't told to run in the background and the session can be
+          # interacted with, start interacting with it by issuing the session
+          # interaction command.
+          print_line
+
+          driver.run_single("sessions -q -i #{session.sid}")
+        # Otherwise, log that we created a session
+        else
+          # Otherwise, log that we created a session
+          print_status("Session #{session.sid} created in the background.")
+        end
+
+      elsif opts['RunAsJob'] && mod.job_id
+        # Indicate if he exploit as a job, indicate such so the user doesn't
+        # wonder what's up.
+        print_status("Exploit running as background job #{mod.job_id}.")
+        # Worst case, the exploit ran but we got no session, bummer.
+      end
+    end
+
+    # If we didn't get any session and exploit ended luanch.
+    unless any_session
+    # If we didn't run a payload handler for this exploit it doesn't
+    # make sense to complain to the user that we didn't get a session
+      unless mod.datastore["DisablePayloadHandler"]
+        fail_msg = 'Exploit completed, but no session was created.'
+        print_status(fail_msg)
+        begin
+          framework.events.on_session_fail(fail_msg)
+        rescue ::Exception => e
+          wlog("Exception in on_session_open event handler: #{e.class}: #{e}")
+          wlog("Call Stack\n#{e.backtrace.join("\n")}")
+        end
+      end
     end
   end
 

--- a/lib/rex/ui/text/dispatcher_shell.rb
+++ b/lib/rex/ui/text/dispatcher_shell.rb
@@ -454,6 +454,7 @@ module DispatcherShell
             found = true
           end
         rescue ::Interrupt
+          found = true
           print_error("#{method}: Interrupted")
           raise if propagate_errors
         rescue OptionParser::ParseError => e


### PR DESCRIPTION
Refactor the `rhosts` option and `exploit` core implement to get better.

Related: #9246
cc:@busterb

## Reason

Now I cannot abort the `exploit` command by `Control+C` during it's running.
I have to hold the both keys `Ctrl` and `c` until it stopped.
And it would repeat binding the handler, which should occur only once.

Glad to receive any suggestion!

## Now in master

```
msf5 exploit(multi/http/cisco_dcnm_upload) > options

Module options (exploit/multi/http/cisco_dcnm_upload):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   ATTEMPTS   10               yes       The number of attempts to execute the payload (auto deployed by JBoss)
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS     8.8.8.8/24       yes       The target address range or CIDR identifier
   RPORT      80               yes       The target port (TCP)
   SSL        false            no        Negotiate SSL/TLS for outgoing connections
   TARGETURI  /                yes       Path to Cisco DCNM
   VHOST                       no        HTTP server virtual host


Payload options (java/meterpreter/reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  0.0.0.0          yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Cisco DCNM 6.1(2) / Java Universal


msf5 exploit(multi/http/cisco_dcnm_upload) > exploit

[*] Started reverse TCP handler on 0.0.0.0:4444
[*] Uploading WAR file xQNunPqw3DhlfAfi.war...
^C[-] Exploit failed: Interrupt
[*] Exploit completed, but no session was created.
[*] Started reverse TCP handler on 0.0.0.0:4444
[*] Uploading WAR file 9fVuDroiu2AQ9vVuqAz5EAuv072S5.war...
^C[-] Exploit failed: Interrupt
[*] Exploit completed, but no session was created.
[*] Started reverse TCP handler on 0.0.0.0:4444
[*] Uploading WAR file 0qkLL9Ut6XzwmIAlC4v9TYbQbo.war...
^C[-] Exploit failed: Interrupt
[*] Exploit completed, but no session was created.
[*] Started reverse TCP handler on 0.0.0.0:4444
[*] Uploading WAR file A7F3HtNEYZGJY3Ppnx2.war...
^C[-] Exploit failed: Interrupt
[*] Exploit completed, but no session was created.
[*] Started reverse TCP handler on 0.0.0.0:4444
[*] Uploading WAR file MSAteFxT.war...
^C[-] Exploit failed: Interrupt
[*] Exploit completed, but no session was created.
[*] Started reverse TCP handler on 0.0.0.0:4444
[*] Uploading WAR file C2Gv9YLYw0bX1t7iaBfXX.war...
^C[-] Exploit failed: Interrupt
[*] Exploit completed, but no session was created.
[*] Started reverse TCP handler on 0.0.0.0:4444
[*] Uploading WAR file GHn5nG0Rpbq8T5h1.war...
^C[-] Exploit failed: Interrupt
[*] Exploit completed, but no session was created.
[*] Started reverse TCP handler on 0.0.0.0:4444
[*] Uploading WAR file tfzm.war...
^C[-] Exploit failed: Interrupt
[*] Exploit completed, but no session was created.
[*] Started reverse TCP handler on 0.0.0.0:4444
[*] Uploading WAR file 3a7Ln6vvKJ7niP23nb1UEx.war...
^C[-] Exploit failed: Interrupt
^C[-] exploit: Interrupted
[-] Unknown command: exploit.
^C^Cmsf5 exploit(multi/http/cisco_dcnm_upload) > Interrupt: use the 'exit' command to quit
msf5 exploit(multi/http/cisco_dcnm_upload) >
```

## After changes
```
msf5 exploit(multi/http/cisco_dcnm_upload) > use exploit/multi/http/cisco_dcnm_upload
msf5 exploit(multi/http/cisco_dcnm_upload) > options

Module options (exploit/multi/http/cisco_dcnm_upload):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   ATTEMPTS   10               yes       The number of attempts to execute the payload (auto deployed by JBoss)
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS     8.8.8.8/24       yes       The target address range or CIDR identifier
   RPORT      80               yes       The target port (TCP)
   SSL        false            no        Negotiate SSL/TLS for outgoing connections
   TARGETURI  /                yes       Path to Cisco DCNM
   VHOST                       no        HTTP server virtual host


Payload options (java/meterpreter/reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  0.0.0.0          yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Cisco DCNM 6.1(2) / Java Universal


msf5 exploit(multi/http/cisco_dcnm_upload) > set rhosts 8.8.8.8/24
rhosts => 8.8.8.8/24
msf5 exploit(multi/http/cisco_dcnm_upload) > set verbose true
verbose => true
msf5 exploit(multi/http/cisco_dcnm_upload) > exploit
[*] Exploiting target 8.8.8.0

[*] Started reverse TCP handler on 0.0.0.0:4444
[*] Uploading WAR file QW5fdRUSaULFHug7kvPzELWoUG.war...
[-] Exploit aborted due to failure: unknown: 8.8.8.0:80 - Failed to upload the WAR payload
[*] Exploiting target 8.8.8.1
[*] Started reverse TCP handler on 0.0.0.0:4444
[*] Uploading WAR file 6RU7xJaHNsg8p.war...
^C[-] Exploit failed [user-interrupt]: Interrupt
[*] Stopping exploiting current target 8.8.8.1...
[*] Control-C again to force quit exploiting all targets.
^C[-] exploit: Interrupted

```

