### PR TITLE
Update reverse_tcp.md

### DIFF
--- a/documentation/modules/payload/windows/meterpreter/reverse_tcp.md
+++ b/documentation/modules/payload/windows/meterpreter/reverse_tcp.md
@@ -261,7 +261,7 @@ meterpreter > getsystem
 **hashdump**
 
 The ```hashdump``` commands allows you to dump the Windows hashes if there are the right privileges.
-For sxample:
+For example:
 
 ```
 meterpreter > hashdump


### PR DESCRIPTION
fix typos in line 264.


Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/windows/smb/ms08_067_netapi`
- [ ] ...
- [ ] **Verify** the thing does what it should
- [ ] **Verify** the thing does not do what it should not
- [ ] **Document** the thing and how it works ([Example](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/post/multi/gather/aws_keys.md))

