### PR TITLE
Fix downgraded gem dependencies recog and ruby-macho

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -234,7 +234,7 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rake (12.3.1)
     rb-readline (0.5.5)
-    recog (2.1.22)
+    recog (2.1.24)
       nokogiri
     redcarpet (3.4.0)
     rex-arch (0.1.13)
@@ -307,7 +307,7 @@ GEM
     rspec-rerun (1.1.0)
       rspec (~> 3.0)
     rspec-support (3.8.0)
-    ruby-macho (2.0.0)
+    ruby-macho (2.1.0)
     ruby-rc4 (0.1.5)
     ruby_smb (1.0.4)
       bindata


### PR DESCRIPTION
I accidentally reverted some gems (ruby-macho and recog).  This fixes that mistake. @wvu-r7 

