### PR TITLE
Fix loading external modules without notes

### DIFF
--- a/lib/msf/core/modules/external/shim.rb
+++ b/lib/msf/core/modules/external/shim.rb
@@ -144,6 +144,8 @@ class Msf::Modules::External::Shim
   # ensure that they are properly capitalized before rendering.
   #
   def self.transform_notes(notes)
+    return {} unless notes
+
     notes.reduce({}) do |acc, (key, val)|
       acc[key.upcase] = val
       acc


### PR DESCRIPTION
```
msf5 > use auxiliary/dos/smb/smb_loris
[-] Failed to load module: auxiliary/dos/smb/smb_loris
msf5 >
```

```
[10/01/2018 12:48:01] [e(0)] core: /Users/wvu/metasploit-framework/modules/auxiliary/dos/smb/smb_loris.rb failed to load due to the following error:
Msf::Modules::Error
Failed to load module (dos/smb/smb_loris from /Users/wvu/metasploit-framework/modules/auxiliary/dos/smb/smb_loris.rb) due to Invalid module (no MetasploitModule class or module name)
[10/01/2018 12:48:02] [e(0)] core: Unable to load module /Users/wvu/metasploit-framework/modules/auxiliary/dos/smb/smb_loris.rb NoMethodError undefined method `reduce' for nil:NilClass /Users/wvu/metasploit-framework/lib/msf/core/modules/external/shim.rb:147:in `transform_notes'
/Users/wvu/metasploit-framework/lib/msf/core/modules/external/shim.rb:61:in `mod_meta_common'
/Users/wvu/metasploit-framework/lib/msf/core/modules/external/shim.rb:133:in `dos'
/Users/wvu/metasploit-framework/lib/msf/core/modules/external/shim.rb:16:in `generate'
/Users/wvu/metasploit-framework/lib/msf/core/modules/loader/executable.rb:88:in `read_module_content'
/Users/wvu/metasploit-framework/lib/msf/core/modules/loader/base.rb:126:in `load_module'
/Users/wvu/metasploit-framework/lib/msf/core/module_manager/cache.rb:91:in `block in load_cached_module'
/Users/wvu/metasploit-framework/lib/msf/core/module_manager/cache.rb:86:in `each'
/Users/wvu/metasploit-framework/lib/msf/core/module_manager/cache.rb:86:in `load_cached_module'
/Users/wvu/metasploit-framework/lib/msf/core/module_set.rb:45:in `create'
/Users/wvu/metasploit-framework/lib/msf/core/module_manager.rb:85:in `create'
/Users/wvu/metasploit-framework/lib/msf/ui/console/command_dispatcher/modules.rb:627:in `cmd_use'
/Users/wvu/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:501:in `run_command'
/Users/wvu/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:453:in `block in run_single'
/Users/wvu/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:447:in `each'
/Users/wvu/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:447:in `run_single'
/Users/wvu/metasploit-framework/lib/rex/ui/text/shell.rb:151:in `run'
/Users/wvu/metasploit-framework/lib/metasploit/framework/command/console.rb:48:in `start'
/Users/wvu/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'
./msfconsole:49:in `<main>'
```

Fixes #10563.