### PR TITLE
Fix outdated metadata

### DIFF
--- a/modules/auxiliary/admin/http/wp_easycart_privilege_escalation.rb
+++ b/modules/auxiliary/admin/http/wp_easycart_privilege_escalation.rb
@@ -22,14 +22,14 @@ class MetasploitModule < Msf::Auxiliary
       },
       'Author'          =>
         [
-          'Rob Carr <rob[at]rastating.com>' # Discovery and Metasploit module
+          'rastating' # Discovery and Metasploit module
         ],
       'License'         => MSF_LICENSE,
       'References'      =>
         [
           ['CVE', '2015-2673'],
           ['WPVDB', '7808'],
-          ['URL', 'http://blog.rastating.com/wp-easycart-privilege-escalation-information-disclosure']
+          ['URL', 'https://rastating.github.io/wp-easycart-privilege-escalation-information-disclosure/']
         ],
       'DisclosureDate'  => 'Feb 25 2015'
       ))

--- a/modules/auxiliary/admin/http/wp_wplms_privilege_escalation.rb
+++ b/modules/auxiliary/admin/http/wp_wplms_privilege_escalation.rb
@@ -24,8 +24,8 @@ class MetasploitModule < Msf::Auxiliary
       },
       'Author'          =>
         [
-          'Evex',                             # Vulnerability discovery
-          'Rob Carr <rob[at]rastating.com>'   # Metasploit module
+          'Evex',     # Vulnerability discovery
+          'rastating' # Metasploit module
         ],
       'License'         => MSF_LICENSE,
       'References'      =>

--- a/modules/auxiliary/dos/http/wordpress_long_password_dos.rb
+++ b/modules/auxiliary/dos/http/wordpress_long_password_dos.rb
@@ -18,9 +18,9 @@ class MetasploitModule < Msf::Auxiliary
       'License'         => MSF_LICENSE,
       'Author'          =>
         [
-          'Javier Nieto Arevalo',           # Vulnerability disclosure
-          'Andres Rojas Guerrero',          # Vulnerability disclosure
-          'Rob Carr <rob[at]rastating.com>' # Metasploit module
+          'Javier Nieto Arevalo',  # Vulnerability disclosure
+          'Andres Rojas Guerrero', # Vulnerability disclosure
+          'rastating'              # Metasploit module
         ],
       'References'      =>
         [

--- a/modules/auxiliary/gather/wp_all_in_one_migration_export.rb
+++ b/modules/auxiliary/gather/wp_all_in_one_migration_export.rb
@@ -18,8 +18,8 @@ class MetasploitModule < Msf::Auxiliary
       'License'         => MSF_LICENSE,
       'Author'          =>
         [
-          'James Golovich',                  # Disclosure
-          'Rob Carr <rob[at]rastating.com>'  # Metasploit module
+          'James Golovich', # Disclosure
+          'rastating'       # Metasploit module
         ],
       'References'      =>
         [

--- a/modules/auxiliary/gather/wp_ultimate_csv_importer_user_extract.rb
+++ b/modules/auxiliary/gather/wp_ultimate_csv_importer_user_extract.rb
@@ -23,8 +23,8 @@ class MetasploitModule < Msf::Auxiliary
       'License'         => MSF_LICENSE,
       'Author'          =>
         [
-          'James Hooker',                    # Disclosure
-          'Rob Carr <rob[at]rastating.com>'  # Metasploit module
+          'James Hooker', # Disclosure
+          'rastating'     # Metasploit module
         ],
       'References'      =>
         [

--- a/modules/exploits/multi/http/wp_ninja_forms_unauthenticated_file_upload.rb
+++ b/modules/exploits/multi/http/wp_ninja_forms_unauthenticated_file_upload.rb
@@ -22,8 +22,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'         => MSF_LICENSE,
       'Author'          =>
         [
-          'James Golovich',                 # Discovery and disclosure
-          'Rob Carr <rob[at]rastating.com>' # Metasploit module
+          'James Golovich', # Discovery and disclosure
+          'rastating'       # Metasploit module
         ],
       'References'      =>
         [

--- a/modules/exploits/unix/webapp/maarch_letterbox_file_upload.rb
+++ b/modules/exploits/unix/webapp/maarch_letterbox_file_upload.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'         => MSF_LICENSE,
       'Author'          =>
         [
-          'Rob Carr <rob[at]rastating.com>'
+          'rastating'
         ],
       'References'      =>
         [

--- a/modules/exploits/unix/webapp/wp_admin_shell_upload.rb
+++ b/modules/exploits/unix/webapp/wp_admin_shell_upload.rb
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'         => MSF_LICENSE,
       'Author'          =>
         [
-          'Rob Carr <rob[at]rastating.com>' # Metasploit module
+          'rastating' # Metasploit module
         ],
       'DisclosureDate'  => 'Feb 21 2015',
       'Platform'        => 'php',

--- a/modules/exploits/unix/webapp/wp_easycart_unrestricted_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_easycart_unrestricted_file_upload.rb
@@ -36,8 +36,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'         => MSF_LICENSE,
       'Author'          =>
         [
-          'Kacper Szurek',                  # Vulnerability disclosure
-          'Rob Carr <rob[at]rastating.com>' # Metasploit module
+          'Kacper Szurek', # Vulnerability disclosure
+          'rastating'      # Metasploit module
         ],
       'References'      =>
         [

--- a/modules/exploits/unix/webapp/wp_holding_pattern_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_holding_pattern_file_upload.rb
@@ -25,8 +25,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'         => MSF_LICENSE,
       'Author'          =>
         [
-          'Alexander Borg',                 # Vulnerability disclosure
-          'Rob Carr <rob[at]rastating.com>' # Metasploit module
+          'Alexander Borg', # Vulnerability disclosure
+          'rastating'       # Metasploit module
         ],
       'References'      =>
         [

--- a/modules/exploits/unix/webapp/wp_photo_gallery_unrestricted_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_photo_gallery_unrestricted_file_upload.rb
@@ -26,8 +26,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'         => MSF_LICENSE,
       'Author'          =>
         [
-          'Kacper Szurek',                  # Vulnerability disclosure
-          'Rob Carr <rob[at]rastating.com>' # Metasploit module
+          'Kacper Szurek', # Vulnerability disclosure
+          'rastating'      # Metasploit module
         ],
       'References'      =>
         [

--- a/modules/exploits/unix/webapp/wp_symposium_shell_upload.rb
+++ b/modules/exploits/unix/webapp/wp_symposium_shell_upload.rb
@@ -25,8 +25,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'         => MSF_LICENSE,
       'Author'          =>
         [
-          'Claudio Viviani',                # Vulnerability disclosure
-          'Rob Carr <rob[at]rastating.com>' # Metasploit module
+          'Claudio Viviani', # Vulnerability disclosure
+          'rastating'        # Metasploit module
         ],
       'References'      =>
         [


### PR DESCRIPTION
This pull request is to fix some outdated metadata on modules I have contributed in the past. The base URL of a disclosure has changed as it's now hosted on GitHub, and the e-mail listed is no longer my primary e-mail, so I have removed it.

A 301 is setup on the original domain currently, so the old link will redirect to the correct place, but in case that changes in the future, I think it's best to just update it.