### PR TITLE
Namespace modules using full name instead of hex

### DIFF
--- a/lib/msf/core/modules/loader/base.rb
+++ b/lib/msf/core/modules/loader/base.rb
@@ -503,9 +503,7 @@ class Msf::Modules::Loader::Base
 
   # Returns an Array of names to make a fully qualified module name to
   # wrap the MetasploitModule class so that it doesn't overwrite other
-  # (metasploit) module's classes. Invalid module name characters are
-  # escaped by using 'H*' unpacking and prefixing each code with X so
-  # the code remains a valid module name when it starts with a digit.
+  # (metasploit) module's classes.
   #
   # @param [String] module_full_name The unique canonical name
   #   for the module including type.
@@ -513,7 +511,18 @@ class Msf::Modules::Loader::Base
   #
   # @see namespace_module
   def namespace_module_names(module_full_name)
-    NAMESPACE_MODULE_NAMES + [ "Mod" + module_full_name.unpack("H*").first.downcase ]
+    relative_name = module_full_name.split('/').map(&:capitalize).join('__')
+    NAMESPACE_MODULE_NAMES + [relative_name]
+  end
+
+  # This reverses a namespace module's relative name to a module full name
+  #
+  # @param [String] relative_name The namespace module's relative name
+  # @return [String] The module full name
+  #
+  # @see namespace_module_names
+  def reverse_relative_name(relative_name)
+    relative_name.split('__').map(&:downcase).join('/')
   end
 
   def namespace_module_transaction(module_full_name, options={}, &block)

--- a/spec/lib/msf/core/modules/loader/base_spec.rb
+++ b/spec/lib/msf/core/modules/loader/base_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe Msf::Modules::Loader::Base do
         include_context 'Metasploit::Framework::Spec::Constants cleaner'
 
         let(:namespace_module_names) do
-          ['Msf', 'Modules', 'Mod617578696c696172792f72737065632f6d6f636b']
+          ['Msf', 'Modules', 'Auxiliary__Rspec__Mock']
         end
 
         let(:namespace_module) do
@@ -291,7 +291,7 @@ RSpec.describe Msf::Modules::Loader::Base do
         end
 
         let(:relative_name) do
-          'Mod617578696c696172792f72737065632f6d6f636b'
+          'Auxiliary__Rspec__Mock'
         end
 
         before(:example) do
@@ -308,7 +308,7 @@ RSpec.describe Msf::Modules::Loader::Base do
           # create an namespace module that can be restored
           module Msf
             module Modules
-              module Mod617578696c696172792f72737065632f6d6f636b
+              module Auxiliary__Rspec__Mock
                 class MetasploitModule < Msf::Auxiliary
 
                 end
@@ -316,7 +316,7 @@ RSpec.describe Msf::Modules::Loader::Base do
             end
           end
 
-          @original_namespace_module = Msf::Modules::Mod617578696c696172792f72737065632f6d6f636b
+          @original_namespace_module = Msf::Modules::Auxiliary__Rspec__Mock
 
           module_set = double('Module Set')
           allow(module_set).to receive(:delete).with(module_reference_name)
@@ -549,7 +549,7 @@ RSpec.describe Msf::Modules::Loader::Base do
       end
 
       let(:relative_name) do
-        'Mod0'
+        'Auxiliary__Rspec__Mock'
       end
 
       before(:example) do
@@ -640,7 +640,7 @@ RSpec.describe Msf::Modules::Loader::Base do
       end
 
       let(:relative_name) do
-        'Mod0'
+        'Auxiliary__Rspec__Mock'
       end
 
       before(:example) do
@@ -662,12 +662,12 @@ RSpec.describe Msf::Modules::Loader::Base do
       it 'should return the module if it is defined' do
         module Msf
           module Modules
-            module Mod0
+            module Auxiliary__Rspec__Mock
             end
           end
         end
 
-        expect(subject.send(:current_module, module_names)).to eq Msf::Modules::Mod0
+        expect(subject.send(:current_module, module_names)).to eq Msf::Modules::Auxiliary__Rspec__Mock
       end
     end
 
@@ -735,18 +735,12 @@ RSpec.describe Msf::Modules::Loader::Base do
         expect(subject.send(:namespace_module_name, module_full_name)).to start_with('Msf::Modules::')
       end
 
-      it 'should prefix the relative name with Mod' do
-        namespace_module_name = subject.send(:namespace_module_name, module_full_name)
-        relative_name = namespace_module_name.gsub(/^.*::/, '')
-
-        expect(relative_name).to start_with('Mod')
-      end
-
       it 'should be reversible' do
         namespace_module_name = subject.send(:namespace_module_name, module_full_name)
-        unpacked_name = namespace_module_name.gsub(/^.*::Mod/, '')
+        relative_name = namespace_module_name.gsub(/^.*::/, '')
+        reversed_name = subject.send(:reverse_relative_name, relative_name)
 
-        expect([unpacked_name].pack('H*')).to eq module_full_name
+        expect(reversed_name).to eq module_full_name
       end
     end
 
@@ -755,18 +749,12 @@ RSpec.describe Msf::Modules::Loader::Base do
         expect(subject.send(:namespace_module_names, module_full_name)).to start_with(['Msf', 'Modules'])
       end
 
-      it 'should prefix the relative name with Mod' do
-        namespace_module_names = subject.send(:namespace_module_names, module_full_name)
-
-        expect(namespace_module_names.last).to start_with('Mod')
-      end
-
       it 'should be reversible' do
         namespace_module_names = subject.send(:namespace_module_names, module_full_name)
         relative_name = namespace_module_names.last
-        unpacked_name = relative_name.gsub(/^Mod/, '')
+        reversed_name = subject.send(:reverse_relative_name, relative_name)
 
-        expect([unpacked_name].pack('H*')).to eq module_full_name
+        expect(reversed_name).to eq module_full_name
       end
     end
 
@@ -774,14 +762,14 @@ RSpec.describe Msf::Modules::Loader::Base do
       include_context 'Metasploit::Framework::Spec::Constants cleaner'
 
       let(:relative_name) do
-        'Mod617578696c696172792f72737065632f6d6f636b'
+        'Auxiliary__Rspec__Mock'
       end
 
       context 'with pre-existing namespace module' do
         before(:example) do
           module Msf
             module Modules
-              module Mod617578696c696172792f72737065632f6d6f636b
+              module Auxiliary__Rspec__Mock
                 class Metasploit
 
                 end
@@ -789,7 +777,7 @@ RSpec.describe Msf::Modules::Loader::Base do
             end
           end
 
-          @existent_namespace_module = Msf::Modules::Mod617578696c696172792f72737065632f6d6f636b
+          @existent_namespace_module = Msf::Modules::Auxiliary__Rspec__Mock
         end
 
         context 'with :reload => false' do
@@ -1027,7 +1015,7 @@ RSpec.describe Msf::Modules::Loader::Base do
       end
 
       let(:relative_name) do
-        'Mod0'
+        'Auxiliary__Rspec__Mock'
       end
 
       it 'should do nothing if parent_module is nil' do
@@ -1076,7 +1064,7 @@ RSpec.describe Msf::Modules::Loader::Base do
         before(:example) do
           module Msf
             module Modules
-              module Mod0
+              module Auxiliary__Rspec__Mock
                 class Metasploit
 
                 end
@@ -1084,7 +1072,7 @@ RSpec.describe Msf::Modules::Loader::Base do
             end
           end
 
-          @original_namespace_module = Msf::Modules::Mod0
+          @original_namespace_module = Msf::Modules::Auxiliary__Rspec__Mock
 
           Msf::Modules.send(:remove_const, relative_name)
         end
@@ -1093,7 +1081,7 @@ RSpec.describe Msf::Modules::Loader::Base do
           before(:example) do
             module Msf
               module Modules
-                module Mod0
+                module Auxiliary__Rspec__Mock
                   class Metasploit2
 
                   end
@@ -1101,7 +1089,7 @@ RSpec.describe Msf::Modules::Loader::Base do
               end
             end
 
-            @current_namespace_module = Msf::Modules::Mod0
+            @current_namespace_module = Msf::Modules::Auxiliary__Rspec__Mock
           end
 
           context 'with the current constant being the namespace_module' do


### PR DESCRIPTION
```
msf5 auxiliary(admin/2wire/xslt_password_reset) > pry
[*] Starting Pry shell...
[*] You are in auxiliary/admin/2wire/xslt_password_reset

[1] pry(#<Msf::Modules::Mod617578696c696172792f61646d696e2f32776972652f78736c745f70617373776f72645f7265736574::MetasploitModule>)> %w[617578696c696172792f61646d696e2f32776972652f78736c745f70617373776f72645f7265736574].pack('H*')
=> "auxiliary/admin/2wire/xslt_password_reset"
[2] pry(#<Msf::Modules::Mod617578696c696172792f61646d696e2f32776972652f78736c745f70617373776f72645f7265736574::MetasploitModule>)>
```

```
msf5 auxiliary(admin/2wire/xslt_password_reset) > pry
[*] Starting Pry shell...
[*] You are in auxiliary/admin/2wire/xslt_password_reset

[1] pry(#<Msf::Modules::Auxiliary__Admin__2wire__Xslt_password_reset::MetasploitModule>)>
```