### PR TITLE
Fix #10601, add api key for android wlan_geolocate

### DIFF
--- a/documentation/modules/post/multi/gather/wlan_geolocate.md
+++ b/documentation/modules/post/multi/gather/wlan_geolocate.md
@@ -8,6 +8,7 @@
   - Linux: `iwlist scanning`
   - Solaris: `dladm scan-wifi`
   - BSD: `dmesg | grep -i wlan | cut -d ':' -f1 | uniq"`
+  - Android: [WifiManager](https://developer.android.com/reference/android/net/wifi/WifiManager)
   
   If `GEOLOCATE` is set to true, Google's [GeoLocation APIs](https://developers.google.com/maps/documentation/geolocation/intro) are utilized.
   These APIs require a Google [API key](https://developers.google.com/maps/documentation/geolocation/get-api-key) to use them.  The original

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/android.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/android.rb
@@ -565,16 +565,19 @@ class Console::CommandDispatcher::Android
 
   def cmd_wlan_geolocate(*args)
     wlan_geolocate_opts = Rex::Parser::Arguments.new(
-      '-h' => [ false, 'Help Banner' ]
+      '-h' => [ false, 'Help Banner' ],
+      '-a' => [ true, 'API key' ],
     )
 
-    wlan_geolocate_opts.parse(args) do |opt, _idx, _val|
+    wlan_geolocate_opts.parse(args) do |opt, _idx, val|
       case opt
       when '-h'
         print_line('Usage: wlan_geolocate')
         print_line('Tries to get device geolocation from WLAN information and Google\'s API')
         print_line(wlan_geolocate_opts.usage)
         return
+      when '-a'
+        api_key = val
       end
     end
 
@@ -592,6 +595,7 @@ class Console::CommandDispatcher::Android
       return
     end
     g = Rex::Google::Geolocation.new
+    g.set_api_key(api_key)
 
     wlan_list.each do |wlan|
       g.add_wlan(*wlan)

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/android.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/android.rb
@@ -385,7 +385,6 @@ class Console::CommandDispatcher::Android
   end
 
   def cmd_geolocate(*args)
-
     generate_map = false
     geolocate_opts = Rex::Parser::Arguments.new(
       '-h' => [ false, 'Help Banner' ],
@@ -423,10 +422,8 @@ class Console::CommandDispatcher::Android
   def cmd_dump_calllog(*args)
     path = "calllog_dump_#{Time.new.strftime('%Y%m%d%H%M%S')}.txt"
     dump_calllog_opts = Rex::Parser::Arguments.new(
-
       '-h' => [ false, 'Help Banner' ],
       '-o' => [ true, 'Output path for call log']
-
     )
 
     dump_calllog_opts.parse(args) do |opt, _idx, val|
@@ -569,6 +566,7 @@ class Console::CommandDispatcher::Android
       '-a' => [ true, 'API key' ],
     )
 
+    api_key = ''
     wlan_geolocate_opts.parse(args) do |opt, _idx, val|
       case opt
       when '-h'
@@ -581,13 +579,19 @@ class Console::CommandDispatcher::Android
       end
     end
 
+    if api_key.blank?
+      print_error("You must enter an api_key")
+      print_error("e.g. wlan_geolocate -a YOUR_API_KEY")
+      print_line(wlan_geolocate_opts.usage)
+      return
+    end
+
     log = client.android.wlan_geolocate
     wlan_list = []
     log.each do |x|
       mac = x['bssid']
-      ssid = x['ssid']
       ss = x['level']
-      wlan_list << [mac, ssid, ss.to_s]
+      wlan_list << [mac, ss.to_s]
     end
 
     if wlan_list.to_s.empty?
@@ -606,7 +610,7 @@ class Console::CommandDispatcher::Android
       print_error("Error: #{e}")
     else
       print_status(g.to_s)
-      print_status("Google Maps URL:  #{g.google_maps_url}")
+      print_status("Google Maps URL: #{g.google_maps_url}")
     end
   end
 

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/android.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/android.rb
@@ -590,8 +590,9 @@ class Console::CommandDispatcher::Android
     wlan_list = []
     log.each do |x|
       mac = x['bssid']
+      ssid = x['ssid']
       ss = x['level']
-      wlan_list << [mac, ss.to_s]
+      wlan_list << [mac, ssid, ss.to_s]
     end
 
     if wlan_list.to_s.empty?
@@ -602,7 +603,7 @@ class Console::CommandDispatcher::Android
     g.set_api_key(api_key)
 
     wlan_list.each do |wlan|
-      g.add_wlan(*wlan)
+      g.add_wlan(wlan[0], wlan[2]) # bssid, signalstrength
     end
     begin
       g.fetch!

--- a/modules/post/multi/gather/wlan_geolocate.rb
+++ b/modules/post/multi/gather/wlan_geolocate.rb
@@ -102,11 +102,9 @@ class MetasploitModule < Msf::Post
       print_error("Error: #{e}")
     else
       print_status(g.to_s)
-      print_status("Google Maps URL:  #{g.google_maps_url}")
+      print_status("Google Maps URL: #{g.google_maps_url}")
     end
-
   end
-
 
   # Run Method for when run command is issued
   def run

--- a/modules/post/multi/gather/wlan_geolocate.rb
+++ b/modules/post/multi/gather/wlan_geolocate.rb
@@ -15,7 +15,7 @@ class MetasploitModule < Msf::Post
         performing a lookup against Google APIs.},
         'License'       => MSF_LICENSE,
         'Author'        => [ 'Tom Sellers <tom[at]fadedcode.net>'],
-        'Platform'      => %w{ osx win linux bsd solaris },
+        'Platform'      => %w{ android osx win linux bsd solaris },
         'SessionTypes'  => [ 'meterpreter', 'shell' ],
       ))
 
@@ -185,9 +185,31 @@ class MetasploitModule < Msf::Post
         print_error("Geolocation is not supported on this platform.\n\n") if datastore['GEOLOCATE']
         return
       end
-
+    when 'android'
+      log = client.android.wlan_geolocate
+      listing = ''
+      wlan_list = []
+      log.each do |x|
+        mac = x['bssid']
+        ssid = x['ssid']
+        ss = x['level'].to_s
+        listing += "BSSID: #{mac}\n"
+        listing += "SSID: #{ssid}\n"
+        listing += "Strength: #{ss}\n\n"
+        wlan_list << [mac, ssid, ss]
+      end
+      if listing.blank?
+        print_error("Unable to generate wireless listing.")
+        return nil
+      end
+      store_loot("host.android.wlan.networks", "text/plain", session, listing, "wlan_networks.txt", "Available Wireless LAN Networks")
+      print_good("Target's wireless networks:\n\n#{listing}\n")
+      if datastore['GEOLOCATE']
+        perform_geolocation(wlan_list)
+        return
+      end
     else
-      print_error("The target's platform, #{platform}, is not supported at this time.")
+      print_error("The target's platform, #{session.platform}, is not supported at this time.")
       return nil
     end
 


### PR DESCRIPTION
This fixes #10601 by adding an option for the API_KEY
I also added Android as a supported platform to post/multi/gather/wlan_geolocate

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Get an Android meterpreter session
- [x] Get an API key (https://developers.google.com/maps/documentation/geolocation/get-api-key)
- [x] Run `meterpreter > wlan_geolocate -a YOUR_KEY`
- [x] **Verify** You receive a reasonable location
- [x] Run `meterpreter > run post/multi/gather/wlan_geolocate APIKEY=YOUR_KEY GEOLOCATE=true`
- [x] **Verify** You receive a reasonable location and the Wifi networks are visible
