### PR TITLE
Enhance RPC module information retrieval

### DIFF
--- a/lib/msf/core/rpc/v10/rpc_module.rb
+++ b/lib/msf/core/rpc/v10/rpc_module.rb
@@ -1,5 +1,6 @@
 # -*- coding: binary -*-
 
+require 'json'
 require 'msf/util/document_generator'
 
 module Msf
@@ -28,38 +29,128 @@ class RPC_Module < RPC_Base
   end
 
 
-  # Returns a list of payload module names. The 'payload/' prefix will not be included.
+  # Returns a list of payload module names or a hash with payload module names as keys to hashes
+  # that contain the module information fields requested. The 'payload/' prefix will not be included.
   #
-  # @return [Hash] A list of payload module names. It contains the following key:
-  #  * 'modules' [Array<string>] Payload module names, for example: ['windows/x64/shell_reverse_tcp']
+  # @param module_info [String] Comma-separated list of module information field names.
+  # If this is nil, then only module names are returned. Default: nil
+  # @param arch [String] Comma-separated list of one or more architectures that
+  # the module must support. The module need only support one of the architectures
+  # to be included, not all architectures. Default: nil
+  #
+  # @return [Hash] If module_info is nil, a list of payload module names. It contains the following key:
+  #  * 'modules' [Array<String>] Payload module names, for example: ['windows/x64/shell_reverse_tcp']
+  # If module_info is not nil, payload module names as keys to hashes that contain the requested module
+  # information fields. It contains the following key:
+  #  * 'modules' [Hash] for example:
+  #    {"windows/x64/shell_reverse_tcp"=>{"name"=>"Windows x64 Command Shell, Reverse TCP Inline"}
   # @example Here's how you would use this from the client:
   #  rpc.call('module.payloads')
-  def rpc_payloads
-    { "modules" => self.framework.payloads.keys }
+  def rpc_payloads(module_info = nil, arch = nil)
+    unless module_info.nil?
+      module_info = module_info.strip.split(',').map(&:strip)
+      module_info.map!(&:to_sym)
+    end
+
+    unless arch.nil?
+      arch = arch.strip.split(',').map(&:strip)
+    end
+
+    data = module_info.nil? ? [] : {}
+    arch_filter = !arch.nil? && !arch.empty? ? arch : nil
+    self.framework.payloads.each_module('Arch' => arch_filter) do |name, mod|
+      if module_info.nil?
+        data << name
+      else
+        tmp_mod_info = ::JSON.parse(Msf::Serializer::Json.dump_module(mod.new), symbolize_names: true)
+        data[name] = tmp_mod_info.select { |k,v| module_info.include?(k) }
+      end
+    end
+
+    { "modules" => data }
   end
 
-
-  # Returns a list of encoder module names. The 'encoder/' prefix will not be included.
+  # Returns a list of encoder module names or a hash with encoder module names as keys to hashes
+  # that contain the module information fields requested. The 'encoder/' prefix will not be included.
   #
-  # @return [Hash] A list of encoder module names. It contains the following key:
-  #  * 'modules' [Array<string>] Encoder module names, for example: ['x86/unicode_upper']
+  # @param module_info [String] Comma-separated list of module information field names.
+  # If this is nil, then only module names are returned. Default: nil
+  # @param arch [String] Comma-separated list of one or more architectures that
+  # the module must support. The module need only support one of the architectures
+  # to be included, not all architectures. Default: nil
+  #
+  # @return [Hash] If module_info is nil, a list of encoder module names. It contains the following key:
+  #  * 'modules' [Array<String>] Encoder module names, for example: ['x86/unicode_upper']
+  # If module_info is not nil, encoder module names as keys to hashes that contain the requested module
+  # information fields. It contains the following key:
+  #  * 'modules' [Hash] for example:
+  #    {"x86/unicode_upper"=>{"name"=>"Alpha2 Alphanumeric Unicode Uppercase Encoder", "rank"=>"Manual"}}
   # @example Here's how you would use this from the client:
   #  rpc.call('module.encoders')
-  def rpc_encoders
-    { "modules" => self.framework.encoders.keys }
+  def rpc_encoders(module_info = nil, arch = nil)
+    unless module_info.nil?
+      module_info = module_info.strip.split(',').map(&:strip)
+      module_info.map!(&:to_sym)
+    end
+
+    unless arch.nil?
+      arch = arch.strip.split(',').map(&:strip)
+    end
+
+    data = module_info.nil? ? [] : {}
+    arch_filter = !arch.nil? && !arch.empty? ? arch : nil
+    self.framework.encoders.each_module('Arch' => arch_filter) do |name, mod|
+      if module_info.nil?
+        data << name
+      else
+        tmp_mod_info = ::JSON.parse(Msf::Serializer::Json.dump_module(mod.new), symbolize_names: true)
+        data[name] = tmp_mod_info.select { |k,v| module_info.include?(k) }
+      end
+    end
+
+    { "modules" => data }
   end
 
-
-  # Returns a list of NOP module names. The 'nop/' prefix will not be included.
+  # Returns a list of NOP module names or a hash with NOP module names as keys to hashes
+  # that contain the module information fields requested. The 'nop/' prefix will not be included.
   #
-  # @return [Hash] A list of NOP module names. It contains the following key:
-  #  * 'modules' [Array<string>] NOP module names, for example: ['x86/single_byte']
+  # @param module_info [String] Comma-separated list of module information field names.
+  # If this is nil, then only module names are returned. Default: nil
+  # @param arch [String] Comma-separated list of one or more architectures that
+  # the module must support. The module need only support one of the architectures
+  # to be included, not all architectures. Default: nil
+  #
+  # @return [Hash] If module_info is nil, a list of NOP module names. It contains the following key:
+  #  * 'modules' [Array<String>] NOP module names, for example: ['x86/single_byte']
+  # If module_info is not nil, NOP module names as keys to hashes that contain the requested module
+  # information fields. It contains the following key:
+  #  * 'modules' [Hash] for example:
+  #    {"x86/single_byte"=>{"name"=>"Single Byte", "rank"=>"Normal"}}
   # @example Here's how you would use this from the client:
   #  rpc.call('module.nops')
-  def rpc_nops
-    { "modules" => self.framework.nops.keys }
-  end
+  def rpc_nops(module_info = nil, arch = nil)
+    unless module_info.nil?
+      module_info = module_info.strip.split(',').map(&:strip)
+      module_info.map!(&:to_sym)
+    end
 
+    unless arch.nil?
+      arch = arch.strip.split(',').map(&:strip)
+    end
+
+    data = module_info.nil? ? [] : {}
+    arch_filter = !arch.nil? && !arch.empty? ? arch : nil
+    self.framework.nops.each_module('Arch' => arch_filter) do |name, mod|
+      if module_info.nil?
+        data << name
+      else
+        tmp_mod_info = ::JSON.parse(Msf::Serializer::Json.dump_module(mod.new), symbolize_names: true)
+        data[name] = tmp_mod_info.select { |k,v| module_info.include?(k) }
+      end
+    end
+
+    { "modules" => data }
+  end
 
   # Returns a list of post module names. The 'post/' prefix will not be included.
   #
@@ -315,6 +406,53 @@ class RPC_Module < RPC_Base
 
   end
 
+  # Returns a list of executable format names.
+  #
+  # @return [Array<String>] A list of executable format names, for example: ["exe"]
+  # @example Here's how you would use this from the client:
+  #  rpc.call('module.executable_formats')
+  def rpc_executable_formats
+    ::Msf::Util::EXE.to_executable_fmt_formats
+  end
+
+  # Returns a list of transform format names.
+  #
+  # @return [Array<String>] A list of transform format names, for example: ["powershell"]
+  # @example Here's how you would use this from the client:
+  #  rpc.call('module.transform_formats')
+  def rpc_transform_formats
+    ::Msf::Simple::Buffer.transform_formats
+  end
+
+  # Returns a list of encryption format names.
+  #
+  # @return [Array<String>] A list of encryption format names, for example: ["aes256"]
+  # @example Here's how you would use this from the client:
+  #  rpc.call('module.encryption_formats')
+  def rpc_encryption_formats
+    ::Msf::Simple::Buffer.encryption_formats
+  end
+
+  # Returns a list of platform names.
+  #
+  # @return [Array<String>] A list of platform names, for example: ["linux"]
+  # @example Here's how you would use this from the client:
+  #  rpc.call('module.platforms')
+  def rpc_platforms
+    supported_platforms = []
+    Msf::Module::Platform.subclasses.each { |c| supported_platforms << c.realname.downcase }
+    supported_platforms.sort
+  end
+
+  # Returns a list of architecture names.
+  #
+  # @return [Array<String>] A list of architecture names, for example: ["x64"]
+  # @example Here's how you would use this from the client:
+  #  rpc.call('module.architectures')
+  def rpc_architectures
+    supported_archs = ARCH_ALL.dup
+    supported_archs.sort
+  end
 
   # Returns a list of encoding formats.
   #

--- a/lib/msf/core/rpc/v10/rpc_module.rb
+++ b/lib/msf/core/rpc/v10/rpc_module.rb
@@ -456,7 +456,7 @@ class RPC_Module < RPC_Base
 
   # Returns a list of encoding formats.
   #
-  # @return [Array<String>] Encoding foramts.
+  # @return [Array<String>] Encoding formats.
   # @example Here's how you would use this from the client:
   #  rpc.call('module.encode_formats')
   def rpc_encode_formats


### PR DESCRIPTION
This enhances the RPC v1.0 (v10) module information retrieval by adding the ability to retrieve additional module information for payloads, encoders and NOPS. In addition, this adds the ability to filter these modules by architectures. The RPC v1.0 (v10) enhancements are to support `msfvenom-ng` in the near future.

## Verification

- [x] Start `msfrpcd`: `./msfrpcd -P <password> -f`
- [x] Start `msfrpc`: `./msfrpc -P <password> -a 127.0.0.1`
- [x] Test that enhanced RPC methods behave as before
    - [x] Run `rpc.call('module.payloads')`
    - [x] **Verify** the call returns a list of payload module names
    - [x] Run `rpc.call('module.encoders')`
    - [x] **Verify** the call returns a list of encoder module names
    - [x] Run `rpc.call('module.nops')`
    - [x] **Verify** the call returns a list of NOP module names
- [x] Test `module_info` field retrieval with the enhanced RPC methods
    - [x] Run `rpc.call('module.payloads', 'name,rank')`
    - [x] **Verify** the call returns a hash of module names as keys to hashes that contain the requested module information fields (key-value pairs)
    - [x] Run `rpc.call('module.encoders', 'name,rank')`
    - [x] **Verify** the call returns a hash of module names as keys to hashes that contain the requested module information fields (key-value pairs)
    - [x] Run `rpc.call('module.nops', 'name,rank')`
    - [x] **Verify** the call returns a hash of module names as keys to hashes that contain the requested module information fields (key-value pairs)
- [x] Test `module_info` field retrieval and `arch` filtering with the enhanced RPC methods
    - [x] Run `rpc.call('module.payloads', 'name,rank', 'x64)`
    - [x] **Verify** the call returns a hash of module names as keys to hashes that contain the requested module information fields (key-value pairs)
    - [x] Run `rpc.call('module.encoders', 'name,rank', 'x64)`
    - [x] **Verify** the call returns a hash of module names as keys to hashes that contain the requested module information fields (key-value pairs)
    - [x] Run `rpc.call('module.nops', 'name,rank', 'x64)`
    - [x] **Verify** the call returns a hash of module names as keys to hashes that contain the requested module information fields (key-value pairs)
- [x] Test new RPC methods
    - [x] Run `rpc.call('module.executable_formats')`
    - [x] **Verify** the call returns a list of executable format names
    - [x] Run `rpc.call('module.transform_formats')`
    - [x] **Verify** the call returns a list of transform format names
    - [x] Run `rpc.call('module.encryption_formats')`
    - [x] **Verify** the call returns a list of encryption format names
    - [x] Run `rpc.call('module.platforms')`
    - [x] **Verify** the call returns a list of platform names
    - [x] Run `rpc.call('module.architectures')`
    - [x] **Verify** the call returns a list of architecture names
