### PR TITLE
Add AUDIO_EFFECTS to distinguish from others

### DIFF
--- a/lib/msf/core/constants.rb
+++ b/lib/msf/core/constants.rb
@@ -80,11 +80,11 @@ CONFIG_CHANGES         = 'config-changes'
 IOC_IN_LOGS            = 'ioc-in-logs'
 # Module may cause account lockouts (likely due to brute-forcing)
 ACCOUNT_LOCKOUTS       = 'account-lockouts'
-# Module may cause software to show something on the screen (Example: a window pops up)
+# Module may show something on the screen (Example: a window pops up)
 SCREEN_EFFECTS         = 'screen-effects'
-# Module may cause software to output audio from the speakers (Example: the app plays music)
+# Module may output audio from the speakers (Example: the app plays music)
 AUDIO_EFFECTS          = 'audio-effects'
-# Module may produce physical effects in hardware (Examples: LED or LCD changes or hardware beeps)
+# Module may produce physical effects (Example: the device moves)
 PHYSICAL_EFFECTS       = 'physical-effects'
 
 #

--- a/lib/msf/core/constants.rb
+++ b/lib/msf/core/constants.rb
@@ -80,9 +80,11 @@ CONFIG_CHANGES         = 'config-changes'
 IOC_IN_LOGS            = 'ioc-in-logs'
 # Module may cause account lockouts (likely due to brute-forcing)
 ACCOUNT_LOCKOUTS       = 'account-lockouts'
-# Module may show something on the screen (Example: a window pops up)
+# Module may cause software to show something on the screen (Example: a window pops up)
 SCREEN_EFFECTS         = 'screen-effects'
-# Module may produce physical effects in hardware (Examples: light, sound, or heat)
+# Module may cause software to output audio from the speakers (Example: the app plays music)
+AUDIO_EFFECTS          = 'audio-effects'
+# Module may produce physical effects in hardware (Examples: LED or LCD changes or hardware beeps)
 PHYSICAL_EFFECTS       = 'physical-effects'
 
 #

--- a/lib/msf/core/constants.rb
+++ b/lib/msf/core/constants.rb
@@ -82,9 +82,9 @@ IOC_IN_LOGS            = 'ioc-in-logs'
 ACCOUNT_LOCKOUTS       = 'account-lockouts'
 # Module may show something on the screen (Example: a window pops up)
 SCREEN_EFFECTS         = 'screen-effects'
-# Module may output audio from the speakers (Example: the app plays music)
+# Module may cause a noise (Examples: audio output from the speakers or hardware beeps)
 AUDIO_EFFECTS          = 'audio-effects'
-# Module may produce physical effects (Example: the device moves)
+# Module may produce physical effects (Examples: the device makes movement or flashes LEDs)
 PHYSICAL_EFFECTS       = 'physical-effects'
 
 #


### PR DESCRIPTION
| Constant         | Description    |
| -------------- | ------------- |
| SCREEN_EFFECTS | Module may show something on the screen (Example: a window pops up) |
| AUDIO_EFFECTS | Module may cause a noise (Examples: audio output from the speakers or hardware beeps) |
| PHYSICAL_EFFECTS | Module may produce physical effects (Examples: the device makes movement or flashes LEDs) |

Updates #10707.