### PR TITLE
Fix improper use of the Ruby shovel operator (<<)

### DIFF
--- a/modules/exploits/windows/fileformat/beetel_netconfig_ini_bof.rb
+++ b/modules/exploits/windows/fileformat/beetel_netconfig_ini_bof.rb
@@ -70,6 +70,6 @@ class MetasploitModule < Msf::Exploit
     jump = Rex::Arch::X86.jmp_short(66)
     padding = rand_text(66) # Pad past buffer corruption
 
-    junk << seh << jump << padding << payload.encoded
+    junk + seh + jump + padding + payload.encoded
   end
 end


### PR DESCRIPTION
`junk` would be modified and returned, and we just want to return the concatenated string. Practically doesn't matter, but it's incorrect.

This was my first public module. I've been wanting to fix this since. I'm noticing it again now as I look for how I used `Ret` in a target.

Creating a PR because of how we're handling MSF4 vs. MSF5. :/

Fixes #2589.