### PR TITLE
Improve check_snake_case_filename check in msftidy

### DIFF
--- a/tools/dev/msftidy.rb
+++ b/tools/dev/msftidy.rb
@@ -254,11 +254,11 @@ class Msftidy
     line =~ /^\s*(require|load)\s+['"]#{lib}['"]/
   end
 
+  # This check also enforces namespace module name reversibility
   def check_snake_case_filename
-    sep = File::SEPARATOR
-    good_name = Regexp.new "^[a-z0-9_#{sep}]+\.rb$"
-    unless @name =~ good_name
-      warn "Filenames should be alphanum and snake case."
+    # TODO: Can we add the __ check to the look{ahead,behind}?
+    if @name !~ /^(?!_)[a-z0-9_]+(?<!_)\.rb$/ || @name.include?('__')
+      warn('Filenames should be lowercase alphanumeric snake case.')
     end
   end
 


### PR DESCRIPTION
We have more stringent requirements than RuboCop.

https://github.com/rubocop-hq/rubocop/blob/36404b40cbdac743b596c8520877c4ca3eee5691/lib/rubocop/cop/naming/file_name.rb#L36

#10729