### PR TITLE
Bump fallback pager in log command to tail -n 50

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/developer.rb
+++ b/lib/msf/ui/console/command_dispatcher/developer.rb
@@ -31,14 +31,16 @@ class Msf::Ui::Console::CommandDispatcher::Developer
     framework.datastore['LocalEditor'] ||
     Rex::Compat.getenv('VISUAL')       ||
     Rex::Compat.getenv('EDITOR')       ||
-    Msf::Util::Helper.which('vim')
+    Msf::Util::Helper.which('vim')     ||
+    Msf::Util::Helper.which('vi')
   end
 
   def local_pager
     framework.datastore['LocalPager'] ||
     Rex::Compat.getenv('PAGER')       ||
     Rex::Compat.getenv('MANPAGER')    ||
-    Msf::Util::Helper.which('less')
+    Msf::Util::Helper.which('less')   ||
+    Msf::Util::Helper.which('more')
   end
 
   # XXX: This will try to reload *any* .rb and break on modules

--- a/lib/msf/ui/console/command_dispatcher/developer.rb
+++ b/lib/msf/ui/console/command_dispatcher/developer.rb
@@ -28,11 +28,17 @@ class Msf::Ui::Console::CommandDispatcher::Developer
   end
 
   def local_editor
-    framework.datastore['LocalEditor'] || Rex::Compat.getenv('VISUAL') || Rex::Compat.getenv('EDITOR')
+    framework.datastore['LocalEditor'] ||
+    Rex::Compat.getenv('VISUAL')       ||
+    Rex::Compat.getenv('EDITOR')       ||
+    Msf::Util::Helper.which('vim')
   end
 
   def local_pager
-    framework.datastore['LocalPager'] || Rex::Compat.getenv('PAGER') || Rex::Compat.getenv('MANPAGER')
+    framework.datastore['LocalPager'] ||
+    Rex::Compat.getenv('PAGER')       ||
+    Rex::Compat.getenv('MANPAGER')    ||
+    Msf::Util::Helper.which('less')
   end
 
   # XXX: This will try to reload *any* .rb and break on modules
@@ -199,7 +205,8 @@ class Msf::Ui::Console::CommandDispatcher::Developer
     editor = local_editor
 
     unless editor
-      editor = 'vim'
+      # ed(1) is the standard editor
+      editor = 'ed'
       print_warning("LocalEditor or $VISUAL/$EDITOR should be set. Falling back on #{editor}.")
     end
 
@@ -283,7 +290,7 @@ class Msf::Ui::Console::CommandDispatcher::Developer
     pager = local_pager.to_s.include?('less') ? "#{local_pager} +G" : local_pager
 
     unless pager
-      pager = 'tail -n 24'
+      pager = 'tail -n 50'
       print_warning("LocalPager or $PAGER/$MANPAGER should be set. Falling back on #{pager}.")
     end
 


### PR DESCRIPTION
This addresses concerns @busterb and I had over `log` not displaying a full stack trace.

- [x] Test the `edit` command
  - [x] Test when `LocalEditor` is set as a global option
  - [x] Test the `$VISUAL` and `$EDITOR` environment variables
  - [x] Test when `vim` or `vi` is in your `$PATH`
  - [x] Test the fallback editor
- [x] Test the `log` command
  - [x] Test when `LocalPager` is set as a global option
  - [x] Test the `$PAGER` and `$MANPAGER` environment variables
  - [x] Test when `less` or `more` is in your `$PATH`
  - [x] Test the fallback "pager"

#10664