### PR TITLE
webcam_stream full path to console

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/webcam.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/webcam.rb
@@ -248,11 +248,12 @@ Status     : <span id="status"></span>
     ::File.open(player_path, 'wb') do |f|
       f.write(html)
     end
+    path = ::File.expand_path(player_path)
     if view
-      print_status("Opening player at: #{player_path}")
+      print_status("Opening player at: #{path}")
       Rex::Compat.open_file(player_path)
     else
-      print_status("Please open the player manually with a browser: #{player_path}")
+      print_status("Please open the player manually with a browser: #{path}")
     end
 
     print_status("Streaming...")


### PR DESCRIPTION
`webcam_snap` displays the full path in output, which is convenient for opening manually.
`webcam_stream` only displays the file name, not the full path, which can be confusing to new users.  Is that file on my local drive, on `127.0.0.1:?/<file>`, on the bind/local port for meterp?

This PR prints the full path to clarify.

## Pre Patch
```
meterpreter > webcam_snap
[*] Starting...
[+] Got frame
[*] Stopped
Webcam shot saved to: /my/fake/path/metasploit-framework/ERVxTvUh.jpeg
meterpreter > webcam_stream
[*] Starting...
[*] Preparing player...
[*] Opening player at: qMSkblpS.html
[*] Streaming...
```

## Post Patch
```
meterpreter > webcam_stream
[*] Starting...
[*] Preparing player...
[*] Opening player at: /my/fake/path/metasploit-framework/ItRfELto.html
[*] Streaming...
^C[-] Error running command webcam_stream: Interrupt 
meterpreter > webcam_stream -v false
[*] Starting...
[*] Preparing player...
[*] Please open the player manually with a browser: /my/fake/path/metasploit-framework/kIdIEEaB.html
[*] Streaming...
```

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] get a meterp
- [ ] `webcam_stream`
- [ ] **Verify** the full path is printed

