### PR TITLE
Fix TypeError in sessions -v and add an "unknown" platform class

### DIFF
--- a/lib/metasploit/framework/login_scanner/ssh.rb
+++ b/lib/metasploit/framework/login_scanner/ssh.rb
@@ -165,12 +165,14 @@ module Metasploit
             'aix'
           when /Win32|Windows/
             'windows'
-          when /Unknown command or computer name/
+          when /Unknown command or computer name/, /Line has invalid autocommand/
             'cisco-ios'
           when /unknown keyword/ # ScreenOS
             'juniper'
           when /JUNOS Base OS/ #JunOS
             'juniper'
+          else
+            'unknown'
           end
         end
 

--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -769,7 +769,7 @@ class ReadableText
       sess_registration = "No"
 
       # to_s is required incase something bugged earlier and .platform is nil
-      if session.respond_to?(:platform)
+      if session.respond_to?(:platform) && !session.platform.nil?
         sess_type << " " + session.platform.to_s
       end
 

--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -768,8 +768,9 @@ class ReadableText
       sess_checkin = "<none>"
       sess_registration = "No"
 
+      # to_s is required incase something bugged earlier and .platform is nil
       if session.respond_to?(:platform)
-        sess_type << " " + session.platform
+        sess_type << " " + session.platform.to_s
       end
 
       if session.respond_to?(:last_checkin) && session.last_checkin

--- a/lib/msf/core/module/platform.rb
+++ b/lib/msf/core/module/platform.rb
@@ -576,4 +576,14 @@ class Msf::Module::Platform
     Alias = "apple_ios"
   end
 
+  #
+  # Unknown
+  # This is a special case for when we're completely unsure of the
+  # platform, such as a crash or default case in code.  Only
+  # utilize this as a catch-all.
+  #
+  class Unknown < Msf::Module::Platform
+    Alias = "unknown"
+  end
+
 end

--- a/lib/msf/core/module/platform.rb
+++ b/lib/msf/core/module/platform.rb
@@ -583,6 +583,7 @@ class Msf::Module::Platform
   # utilize this as a catch-all.
   #
   class Unknown < Msf::Module::Platform
+    Rank = 0 # safeguard with 0 since the platform is completely unknown
     Alias = "unknown"
   end
 


### PR DESCRIPTION
Fixes #10772 

To test this you'll need to edit `ssh_login` to return `nil` since I believe this is an edge case.

After patch:
```
msf5 auxiliary(scanner/ssh/ssh_login) > sessions -v

Active sessions
===============

  Session ID: 1
        Name: 
        Type: shell 
        Info: SSH cisco:cisco (2.2.2.2:22)
      Tunnel: ?? -> ?? (2.2.2.2)
         Via: auxiliary/scanner/ssh/ssh_login
   Encrypted: false
        UUID: 
     CheckIn: <none>
  Registered: No

```

While this fixes the `nil` concat issue, @wvu-r7 @bcook-r7 any opinion on what a case select default value should be on ssh_login to prevent a `nil` return?  Empty string or 'Unknown' seem logical to me, (and I can add that on to this PR, just wanted to get more opinions).