### PR TITLE
Rpc shell read fix

### DIFF
--- a/lib/msf/core/rpc/v10/rpc_session.rb
+++ b/lib/msf/core/rpc/v10/rpc_session.rb
@@ -91,7 +91,7 @@ class RPC_Session < RPC_Base
     s = _valid_session(sid,"shell")
     begin
       res = s.shell_read()
-      { "seq" => 0, "data" => res}
+      { "seq" => 0, "data" => res.to_s}
     rescue ::Exception => e
       error(500, "Session Disconnected: #{e.class} #{e}")
     end

--- a/lib/msf/core/rpc/v10/rpc_session.rb
+++ b/lib/msf/core/rpc/v10/rpc_session.rb
@@ -90,8 +90,8 @@ class RPC_Session < RPC_Base
   def rpc_shell_read( sid, ptr=nil)
     s = _valid_session(sid,"shell")
     begin
-      res = s.shell_read(data)
-      { "write_count" => res.to_s}
+      res = s.shell_read()
+      { "seq" => 0, "data" => res}
     rescue ::Exception => e
       error(500, "Session Disconnected: #{e.class} #{e}")
     end


### PR DESCRIPTION
This fixes the bug from https://github.com/allfro/pymetasploit/issues/21. When using rpc sessions (eg. in pymetasploit python module), error was thrown because rpc_shell_read was basically a copy of rpc_shell_write function.

## Verification

List the steps needed to make sure this thing works
- [x] Start msfrpcd
- [x] Use pymetasploit python module to open a RPC session
- [x] Try to read data from session
- [x] Verify that _no_ error is thrown ( metasploit.msfrpc.MsfRpcError: Session Disconnected: NameError undefined local variable or method `data' for #Msf::RPC::RPC_Session:0x000055f37858e398
)


