### PR TITLE
Make WritableDir an advanced option

### DIFF
--- a/modules/exploits/linux/local/abrt_raceabrt_priv_esc.rb
+++ b/modules/exploits/linux/local/abrt_raceabrt_priv_esc.rb
@@ -61,9 +61,11 @@ class MetasploitModule < Msf::Exploit::Local
     register_options(
       [
         OptInt.new('TIMEOUT', [ true, 'Race timeout (seconds)', '900' ]),
-        OptString.new('USERNAME', [ false, 'Username of new UID=0 user (default: random)', '' ]),
-        OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ])
+        OptString.new('USERNAME', [ false, 'Username of new UID=0 user (default: random)', '' ])
       ])
+    register_advanced_options [
+      OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ])
+    ]
   end
 
   def base_dir

--- a/modules/exploits/linux/local/af_packet_chocobo_root_priv_esc.rb
+++ b/modules/exploits/linux/local/af_packet_chocobo_root_priv_esc.rb
@@ -70,8 +70,10 @@ class MetasploitModule < Msf::Exploit::Local
     ))
     register_options [
       OptInt.new('TIMEOUT', [ true, 'Race timeout (seconds)', '600' ]),
-      OptEnum.new('COMPILE', [ true, 'Compile on target', 'Auto', %w(Auto True False) ]),
-      OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ]),
+      OptEnum.new('COMPILE', [ true, 'Compile on target', 'Auto', %w(Auto True False) ])
+    ]
+    register_advanced_options [
+      OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ])
     ]
   end
 

--- a/modules/exploits/linux/local/af_packet_packet_set_ring_priv_esc.rb
+++ b/modules/exploits/linux/local/af_packet_packet_set_ring_priv_esc.rb
@@ -68,8 +68,10 @@ class MetasploitModule < Msf::Exploit::Local
         ],
       'DefaultTarget'  => 0))
     register_options [
-      OptEnum.new('COMPILE', [ true, 'Compile on target', 'Auto', %w(Auto True False) ]),
-      OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ]),
+      OptEnum.new('COMPILE', [ true, 'Compile on target', 'Auto', %w(Auto True False) ])
+    ]
+    register_advanced_options [
+      OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ])
     ]
   end
 

--- a/modules/exploits/linux/local/apport_abrt_chroot_priv_esc.rb
+++ b/modules/exploits/linux/local/apport_abrt_chroot_priv_esc.rb
@@ -65,10 +65,9 @@ class MetasploitModule < Msf::Exploit::Local
           [ 'URL', 'http://bazaar.launchpad.net/~apport-hackers/apport/trunk/revision/2943' ]
         ]
     ))
-    register_options(
-      [
-        OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ])
-      ])
+    register_advanced_options [
+      OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ])
+    ]
   end
 
   def base_dir

--- a/modules/exploits/linux/local/bpf_sign_extension_priv_esc.rb
+++ b/modules/exploits/linux/local/bpf_sign_extension_priv_esc.rb
@@ -90,7 +90,9 @@ class MetasploitModule < Msf::Exploit::Local
           }
       ))
     register_options [
-      OptEnum.new('COMPILE', [ true, 'Compile on target', 'Auto', %w[Auto True False] ]),
+      OptEnum.new('COMPILE', [ true, 'Compile on target', 'Auto', %w[Auto True False] ])
+    ]
+    register_advanced_options [
       OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ])
     ]
   end

--- a/modules/exploits/linux/local/desktop_privilege_escalation.rb
+++ b/modules/exploits/linux/local/desktop_privilege_escalation.rb
@@ -52,10 +52,9 @@ class MetasploitModule < Msf::Exploit::Local
       'DefaultTarget' => 0,
       }
     ))
-
-    register_options([
-      OptString.new('WritableDir', [true, 'A directory for storing temporary files on the target system', '/tmp']),
-    ])
+    register_advanced_options [
+      OptString.new('WritableDir', [true, 'A directory for storing temporary files on the target system', '/tmp'])
+    ]
   end
 
   def check

--- a/modules/exploits/linux/local/glibc_ld_audit_dso_load_priv_esc.rb
+++ b/modules/exploits/linux/local/glibc_ld_audit_dso_load_priv_esc.rb
@@ -78,11 +78,12 @@ class MetasploitModule < Msf::Exploit::Local
           [ 'URL', 'https://access.redhat.com/security/cve/CVE-2010-3856' ]
         ]
     ))
-    register_options(
-      [
-        OptString.new('SUID_EXECUTABLE', [ true, 'Path to a SUID executable', '/bin/ping' ]),
-        OptString.new('WritableDir',     [ true, 'A directory where we can write files', '/tmp' ])
-      ])
+    register_options [
+      OptString.new('SUID_EXECUTABLE', [ true, 'Path to a SUID executable', '/bin/ping' ])
+    ]
+    register_advanced_options [
+      OptString.new('WritableDir',     [ true, 'A directory where we can write files', '/tmp' ])
+    ]
   end
 
   def base_dir

--- a/modules/exploits/linux/local/glibc_origin_expansion_priv_esc.rb
+++ b/modules/exploits/linux/local/glibc_origin_expansion_priv_esc.rb
@@ -69,11 +69,12 @@ class MetasploitModule < Msf::Exploit::Local
           [ 'URL', 'https://access.redhat.com/security/cve/CVE-2010-3847' ]
         ]
     ))
-    register_options(
-      [
-        OptString.new('SUID_EXECUTABLE', [ true, 'Path to a suid executable', '/bin/ping' ]),
-        OptString.new('WritableDir',     [ true, 'A directory where we can write files', '/tmp' ])
-      ])
+    register_options [
+      OptString.new('SUID_EXECUTABLE', [ true, 'Path to a suid executable', '/bin/ping' ])
+    ]
+    register_advanced_options [
+      OptString.new('WritableDir',     [ true, 'A directory where we can write files', '/tmp' ])
+    ]
   end
 
   def base_dir

--- a/modules/exploits/linux/local/glibc_realpath_priv_esc.rb
+++ b/modules/exploits/linux/local/glibc_realpath_priv_esc.rb
@@ -61,8 +61,10 @@ class MetasploitModule < Msf::Exploit::Local
           }
     ))
     register_options [
-      OptEnum.new('COMPILE', [ true, 'Compile on target', 'Auto', %w(Auto True False) ]),
-      OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ]),
+      OptEnum.new('COMPILE', [ true, 'Compile on target', 'Auto', %w(Auto True False) ])
+    ]
+    register_advanced_options [
+      OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ])
     ]
   end
 

--- a/modules/exploits/linux/local/lastore_daemon_dbus_priv_esc.rb
+++ b/modules/exploits/linux/local/lastore_daemon_dbus_priv_esc.rb
@@ -44,9 +44,9 @@ class MetasploitModule < Msf::Exploit::Local
       'SessionTypes'   => [ 'shell', 'meterpreter' ],
       'Targets'        => [[ 'Auto', {} ]],
       'DefaultTarget'  => 0))
-    register_options([
+    register_advanced_options [
       OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ])
-    ])
+    ]
   end
 
   def base_dir

--- a/modules/exploits/linux/local/libuser_roothelper_priv_esc.rb
+++ b/modules/exploits/linux/local/libuser_roothelper_priv_esc.rb
@@ -75,7 +75,9 @@ class MetasploitModule < Msf::Exploit::Local
     ))
     register_options [
       OptEnum.new('COMPILE', [ true, 'Compile on target', 'Auto', %w(Auto True False) ]),
-      OptString.new('PASSWORD', [ true, 'Password for the current user', '' ]),
+      OptString.new('PASSWORD', [ true, 'Password for the current user', '' ])
+    ]
+    register_advanced_options [
       OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ])
     ]
   end

--- a/modules/exploits/linux/local/netfilter_priv_esc_ipv4.rb
+++ b/modules/exploits/linux/local/netfilter_priv_esc_ipv4.rb
@@ -49,13 +49,14 @@ class MetasploitModule < Msf::Exploit::Local
             [ 'URL', 'http://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=ce683e5f9d045e5d67d1312a42b359cb2ab2a13c']
           ]
       ))
-    register_options(
-      [
-        OptString.new('WritableDir', [ true, 'A directory where we can write files (must not be mounted noexec)', '/tmp' ]),
-        OptInt.new('MAXWAIT', [ true, 'Max seconds to wait for decrementation in seconds', 180 ]),
-        OptBool.new('REEXPLOIT', [ true, 'desc already ran, no need to re-run, skip to running pwn',false]),
-        OptEnum.new('COMPILE', [ true, 'Compile on target', 'Auto', ['Auto', 'True', 'False']])
-      ])
+    register_options [
+      OptInt.new('MAXWAIT', [ true, 'Max seconds to wait for decrementation in seconds', 180 ]),
+      OptBool.new('REEXPLOIT', [ true, 'desc already ran, no need to re-run, skip to running pwn',false]),
+      OptEnum.new('COMPILE', [ true, 'Compile on target', 'Auto', ['Auto', 'True', 'False']])
+    ]
+    register_advanced_options [
+      OptString.new('WritableDir', [ true, 'A directory where we can write files (must not be mounted noexec)', '/tmp' ])
+    ]
   end
 
   def check

--- a/modules/exploits/linux/local/network_manager_vpnc_username_priv_esc.rb
+++ b/modules/exploits/linux/local/network_manager_vpnc_username_priv_esc.rb
@@ -63,7 +63,7 @@ class MetasploitModule < Msf::Exploit::Local
           'PrependFork' => true
         },
       'DefaultTarget'  => 0))
-    register_options [
+    register_advanced_options [
       OptString.new('WritableDir', [true, 'A directory where we can write files', '/tmp'])
     ]
   end

--- a/modules/exploits/linux/local/ntfs3g_priv_esc.rb
+++ b/modules/exploits/linux/local/ntfs3g_priv_esc.rb
@@ -47,9 +47,9 @@ class MetasploitModule < Msf::Exploit::Local
         'Privileged'     => true
       }
       ))
-    register_options([
-        OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ])
-      ])
+    register_advanced_options [
+      OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ]
+    ]
   end
 
   def check

--- a/modules/exploits/linux/local/ntfs3g_priv_esc.rb
+++ b/modules/exploits/linux/local/ntfs3g_priv_esc.rb
@@ -48,7 +48,7 @@ class MetasploitModule < Msf::Exploit::Local
       }
       ))
     register_advanced_options [
-      OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ]
+      OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ])
     ]
   end
 

--- a/modules/exploits/linux/local/overlayfs_priv_esc.rb
+++ b/modules/exploits/linux/local/overlayfs_priv_esc.rb
@@ -55,11 +55,12 @@ class MetasploitModule < Msf::Exploit::Local
             [ 'CVE', '2015-8660']
           ]
       ))
-    register_options(
-      [
-        OptString.new('WritableDir', [ true, 'A directory where we can write files (must not be mounted noexec)', '/tmp' ]),
-        OptEnum.new('COMPILE', [ true, 'Compile on target', 'Auto', ['Auto', 'True', 'False']])
-      ])
+    register_options [
+      OptEnum.new('COMPILE', [ true, 'Compile on target', 'Auto', ['Auto', 'True', 'False']])
+    ]
+    register_advanced_options [
+      OptString.new('WritableDir', [ true, 'A directory where we can write files (must not be mounted noexec)', '/tmp' ])
+    ]
   end
 
   def check

--- a/modules/exploits/linux/local/pkexec.rb
+++ b/modules/exploits/linux/local/pkexec.rb
@@ -54,11 +54,13 @@ class MetasploitModule < Msf::Exploit::Local
       'DisclosureDate' => "Apr 01 2011"
     ))
     register_options([
-      OptString.new("WritableDir", [ true, "A directory where we can write files (must not be mounted noexec)", "/tmp" ]),
       OptInt.new("Count", [true, "Number of attempts to win the race condition", 500 ]),
       OptInt.new("ListenerTimeout", [true, "Number of seconds to wait for the exploit", 60]),
       OptBool.new("DEBUG_EXPLOIT", [ true, "Make the exploit executable be verbose about what it's doing", false ])
     ])
+    register_advanced_options [
+      OptString.new("WritableDir", [ true, "A directory where we can write files (must not be mounted noexec)", "/tmp" ])
+    ]
   end
 
   def executable_path

--- a/modules/exploits/linux/local/rds_priv_esc.rb
+++ b/modules/exploits/linux/local/rds_priv_esc.rb
@@ -61,8 +61,10 @@ class MetasploitModule < Msf::Exploit::Local
           }
     ))
     register_options [
-      OptEnum.new('COMPILE', [ true, 'Compile on target', 'Auto', %w(Auto True False) ]),
-      OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ]),
+      OptEnum.new('COMPILE', [ true, 'Compile on target', 'Auto', %w(Auto True False) ])
+    ]
+    register_advanced_options [
+      OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ])
     ]
   end
 

--- a/modules/exploits/linux/local/recvmmsg_priv_esc.rb
+++ b/modules/exploits/linux/local/recvmmsg_priv_esc.rb
@@ -51,8 +51,10 @@ class MetasploitModule < Msf::Exploit::Local
         ],
       'DefaultTarget'  => 0))
     register_options [
-      OptEnum.new('COMPILE', [ true, 'Compile on target', 'Auto', %w(Auto True False) ]),
-      OptString.new('WritableDir', [ true, 'A directory where we can write files (must not be mounted noexec)', '/tmp' ])
+      OptEnum.new('COMPILE', [ true, 'Compile on target', 'Auto', %w(Auto True False) ])
+    ]
+    register_advanced_options [
+      OptString.new('WritableDir', [ true, 'A directory where we can write files (must not be mounted noexec)', '/tmp' ]
     ]
   end
 

--- a/modules/exploits/linux/local/recvmmsg_priv_esc.rb
+++ b/modules/exploits/linux/local/recvmmsg_priv_esc.rb
@@ -54,7 +54,7 @@ class MetasploitModule < Msf::Exploit::Local
       OptEnum.new('COMPILE', [ true, 'Compile on target', 'Auto', %w(Auto True False) ])
     ]
     register_advanced_options [
-      OptString.new('WritableDir', [ true, 'A directory where we can write files (must not be mounted noexec)', '/tmp' ]
+      OptString.new('WritableDir', [ true, 'A directory where we can write files (must not be mounted noexec)', '/tmp' ])
     ]
   end
 

--- a/modules/exploits/linux/local/sock_sendpage.rb
+++ b/modules/exploits/linux/local/sock_sendpage.rb
@@ -66,8 +66,10 @@ class MetasploitModule < Msf::Exploit::Local
       'DisclosureDate' => 'Aug 13 2009',
       'DefaultTarget'  => 0))
     register_options [
-      OptString.new('WritableDir', [ true, 'A directory where we can write files (must not be mounted noexec)', '/tmp' ]),
-      OptBool.new('DEBUG_EXPLOIT', [ true, "Make the exploit executable be verbose about what it's doing", false ])
+      OptBool.new('DEBUG_EXPLOIT', [ true, "Make the exploit executable be verbose about what it's doing", false ]
+    ]
+    register_advanced_options [
+      OptString.new('WritableDir', [ true, 'A directory where we can write files (must not be mounted noexec)', '/tmp' ])
     ]
   end
 

--- a/modules/exploits/linux/local/sock_sendpage.rb
+++ b/modules/exploits/linux/local/sock_sendpage.rb
@@ -66,7 +66,7 @@ class MetasploitModule < Msf::Exploit::Local
       'DisclosureDate' => 'Aug 13 2009',
       'DefaultTarget'  => 0))
     register_options [
-      OptBool.new('DEBUG_EXPLOIT', [ true, "Make the exploit executable be verbose about what it's doing", false ]
+      OptBool.new('DEBUG_EXPLOIT', [ true, "Make the exploit executable be verbose about what it's doing", false ])
     ]
     register_advanced_options [
       OptString.new('WritableDir', [ true, 'A directory where we can write files (must not be mounted noexec)', '/tmp' ])

--- a/modules/exploits/linux/local/sophos_wpa_clear_keys.rb
+++ b/modules/exploits/linux/local/sophos_wpa_clear_keys.rb
@@ -47,11 +47,12 @@ class MetasploitModule < Msf::Exploit::Local
       }
     ))
 
-    register_options([
-        # These are not OptPath becuase it's a *remote* path
-        OptString.new("WritableDir", [ true, "A directory where we can write files", "/tmp" ]),
-        OptString.new("clear_keys",  [ true, "Path to the clear_keys.pl vulnerable script", "/opt/cma/bin/clear_keys.pl" ]),
-      ])
+    register_options [
+      OptString.new("clear_keys",  [ true, "Path to the clear_keys.pl vulnerable script", "/opt/cma/bin/clear_keys.pl" ])
+    ]
+    register_advanced_options [
+      OptString.new("WritableDir", [ true, "A directory where we can write files", "/tmp" ])
+    ]
   end
 
   def check

--- a/modules/exploits/linux/local/udev_netlink.rb
+++ b/modules/exploits/linux/local/udev_netlink.rb
@@ -50,10 +50,12 @@ class MetasploitModule < Msf::Exploit::Local
         'DisclosureDate' => "Apr 16 2009",
       }
       ))
-    register_options([
-        OptString.new("WritableDir", [ true, "A directory where we can write files (must not be mounted noexec)", "/tmp" ]),
-        OptInt.new("NetlinkPID", [ false, "Usually udevd pid-1.  Meterpreter sessions will autodetect" ]),
-      ])
+    register_options [
+        OptInt.new("NetlinkPID", [ false, "Usually udevd pid-1.  Meterpreter sessions will autodetect" ])
+    ]
+    register_advanced_options [
+      OptString.new("WritableDir", [ true, "A directory where we can write files (must not be mounted noexec)", "/tmp" ])
+    ]
   end
 
   def exploit

--- a/modules/exploits/linux/local/ufo_privilege_escalation.rb
+++ b/modules/exploits/linux/local/ufo_privilege_escalation.rb
@@ -67,7 +67,9 @@ class MetasploitModule < Msf::Exploit::Local
       'DefaultOptions' => { 'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp' },
       'DefaultTarget'  => 0))
     register_options [
-      OptEnum.new('COMPILE', [ true, 'Compile on target', 'Auto', %w[Auto True False] ]),
+      OptEnum.new('COMPILE', [ true, 'Compile on target', 'Auto', %w[Auto True False] ])
+    ]
+    register_advanced_options [
       OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ])
     ]
   end

--- a/modules/exploits/linux/local/vmware_alsa_config.rb
+++ b/modules/exploits/linux/local/vmware_alsa_config.rb
@@ -54,7 +54,7 @@ class MetasploitModule < Msf::Exploit::Local
       'Arch'           => [ ARCH_X86, ARCH_X64 ],
       'SessionTypes'   => [ 'shell', 'meterpreter' ],
       'Privileged'     => true ))
-    register_options [
+    register_advanced_options [
       OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ])
     ]
   end

--- a/modules/exploits/linux/local/vmware_mount.rb
+++ b/modules/exploits/linux/local/vmware_mount.rb
@@ -51,9 +51,9 @@ class MetasploitModule < Msf::Exploit::Local
         'DisclosureDate' => "Aug 22 2013"
       }
       ))
-    register_options([
-        OptString.new("WRITABLEDIR", [ true, "A directory where you can write files.", "/tmp" ]),
-      ])
+    register_advanced_options [
+      OptString.new("WRITABLEDIR", [ true, "A directory where you can write files.", "/tmp" ])
+    ]
   end
 
   def check

--- a/modules/exploits/linux/local/vmware_mount.rb
+++ b/modules/exploits/linux/local/vmware_mount.rb
@@ -52,7 +52,7 @@ class MetasploitModule < Msf::Exploit::Local
       }
       ))
     register_advanced_options [
-      OptString.new("WRITABLEDIR", [ true, "A directory where you can write files.", "/tmp" ])
+      OptString.new("WritableDir", [ true, "A directory where you can write files.", "/tmp" ])
     ]
   end
 
@@ -69,10 +69,10 @@ class MetasploitModule < Msf::Exploit::Local
       fail_with(Failure::NotVulnerable, "vmware-mount doesn't exist or is not setuid")
     end
 
-    lsb_path = File.join(datastore['WRITABLEDIR'], 'lsb_release')
+    lsb_path = File.join(datastore['WritableDir'], 'lsb_release')
     write_file(lsb_path, generate_payload_exe)
     cmd_exec("chmod +x #{lsb_path}")
-    cmd_exec("PATH=#{datastore['WRITABLEDIR']}:$PATH /usr/bin/vmware-mount")
+    cmd_exec("PATH=#{datastore['WritableDir']}:$PATH /usr/bin/vmware-mount")
     # Delete it here instead of using FileDropper because the original
     # session can clean it up
     cmd_exec("rm -f #{lsb_path}")

--- a/modules/exploits/linux/local/zpanel_zsudo.rb
+++ b/modules/exploits/linux/local/zpanel_zsudo.rb
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Exploit::Local
         'DefaultTarget' => 0,
       }
       ))
-    register_options([
+    register_options [
       OptString.new("zsudo", [ true, "Path to zsudo executable", "/etc/zpanel/panel/bin/zsudo" ])
     ]
     register_advanced_options [

--- a/modules/exploits/linux/local/zpanel_zsudo.rb
+++ b/modules/exploits/linux/local/zpanel_zsudo.rb
@@ -37,10 +37,11 @@ class MetasploitModule < Msf::Exploit::Local
       }
       ))
     register_options([
-        # These are not OptPath becuase it's a *remote* path
-        OptString.new("WritableDir", [ true, "A directory where we can write files", "/tmp" ]),
-        OptString.new("zsudo",        [ true, "Path to zsudo executable", "/etc/zpanel/panel/bin/zsudo" ]),
-      ])
+      OptString.new("zsudo", [ true, "Path to zsudo executable", "/etc/zpanel/panel/bin/zsudo" ])
+    ]
+    register_advanced_options [
+      OptString.new("WritableDir", [ true, "A directory where we can write files", "/tmp" ])
+    ]
   end
 
   def check


### PR DESCRIPTION
This PR updates most of the Linux local exploit modules to register `WritableDir` as an advanced option, as is now standard practice.
