### PR TITLE
Remove unknown author mapping in author.rb

### DIFF
--- a/lib/msf/core/author.rb
+++ b/lib/msf/core/author.rb
@@ -16,7 +16,6 @@ class Msf::Author
   # A hash that maps known author names to email addresses
   KNOWN = {
     'amaloteaux'          => 'alex_maloteaux' + 0x40.chr + 'metasploit.com',
-    'anonymous'           => 'Unknown',
     'aushack'             => 'patrick' + 0x40.chr + 'osisecurity.com.au',
     'bannedit'            => 'bannedit' + 0x40.chr + 'metasploit.com',
     'Carlos Perez'        => 'carlos_perez' + 0x40.chr + 'darkoperator.com',


### PR DESCRIPTION
No one was using it and instead writing "Unknown" directly. It was also producing an invalid e-mail address.

Lazy `grep`:

```
wvu@kharak:~/metasploit-framework:bug/author$ git grep -A 10 Author modules | grep -w anonymous
modules/auxiliary/scanner/ftp/anonymous.rb:      'Author'      => 'Matteo Cantoni <goony[at]nothink.org>',
modules/auxiliary/scanner/ftp/anonymous.rb-      'License'     => MSF_LICENSE
modules/auxiliary/scanner/ftp/anonymous.rb-    )
modules/auxiliary/scanner/ftp/anonymous.rb-
modules/auxiliary/scanner/ftp/anonymous.rb-    register_options(
modules/auxiliary/scanner/ftp/anonymous.rb-      [
modules/auxiliary/scanner/ftp/anonymous.rb-        Opt::RPORT(21),
modules/auxiliary/scanner/ftp/anonymous.rb-      ])
modules/auxiliary/scanner/ftp/anonymous.rb-  end
modules/auxiliary/scanner/ftp/anonymous.rb-
modules/auxiliary/scanner/ftp/anonymous.rb-  def run_host(target_host)
wvu@kharak:~/metasploit-framework:bug/author$ git grep -A 10 Author modules | grep -wc Unknown
113
wvu@kharak:~/metasploit-framework:bug/author$
```

Happy to change this if we have a better approach.

https://github.com/rapid7/metasploit-framework/pull/10672#discussion_r218705516