### PR TITLE
Clarify "NameError: wrong constant name" message on invalid module name

### DIFF
--- a/lib/msf/core/exceptions.rb
+++ b/lib/msf/core/exceptions.rb
@@ -48,10 +48,22 @@ class ValidationError < ArgumentError
   end
 end
 
+
 ###
 #
-# This exception is raised when the module cache is invalidated.  It is
-# handled internally by the ModuleManager.
+# This exception is raised when a module fails to load.
+#
+# It is used by Msf::Modules::Loader::Base.
+#
+###
+class ModuleLoadError < RuntimeError
+end
+
+###
+#
+# This exception is raised when the module cache is invalidated.
+#
+# It is handled internally by the ModuleManager.
 #
 ###
 class ModuleCacheInvalidated < RuntimeError

--- a/lib/msf/core/modules/loader/base.rb
+++ b/lib/msf/core/modules/loader/base.rb
@@ -522,7 +522,7 @@ class Msf::Modules::Loader::Base
   # @return [String] The module full name
   #
   # @see namespace_module_names
-  def reverse_relative_name(relative_name)
+  def self.reverse_relative_name(relative_name)
     relative_name.split('__').map(&:downcase).join('/')
   end
 

--- a/lib/msf/core/modules/loader/base.rb
+++ b/lib/msf/core/modules/loader/base.rb
@@ -362,17 +362,24 @@ class Msf::Modules::Loader::Base
   # @return [nil] if any module name along the chain does not exist.
   def current_module(module_names)
     # Don't want to trigger ActiveSupport's const_missing, so can't use constantize.
-    named_module = module_names.inject(Object) { |parent, module_name|
+    named_module = module_names.reduce(Object) do |parent, module_name|
       # Since we're searching parent namespaces first anyway, this is
       # semantically equivalent to providing false for the 1.9-only
       # "inherit" parameter to const_defined?. If we ever drop 1.8
       # support, we can save a few cycles here by adding it back.
-      if parent.const_defined?(module_name)
-        parent.const_get(module_name)
-      else
-        break
+      begin
+        if parent.const_defined?(module_name)
+          parent.const_get(module_name)
+        else
+          break
+        end
+      # HACK: This doesn't slow load time as much as checking proactively
+      rescue NameError
+        reversed_name = self.class.reverse_relative_name(module_name)
+        # TODO: Consolidate this with Msftidy#check_snake_case_filename ?
+        raise Msf::ModuleLoadError, "#{reversed_name} must be lowercase alphanumeric snake case"
       end
-    }
+    end
 
     named_module
   end

--- a/spec/lib/msf/core/modules/loader/base_spec.rb
+++ b/spec/lib/msf/core/modules/loader/base_spec.rb
@@ -738,7 +738,7 @@ RSpec.describe Msf::Modules::Loader::Base do
       it 'should be reversible' do
         namespace_module_name = subject.send(:namespace_module_name, module_full_name)
         relative_name = namespace_module_name.gsub(/^.*::/, '')
-        reversed_name = subject.send(:reverse_relative_name, relative_name)
+        reversed_name = described_class.reverse_relative_name(relative_name)
 
         expect(reversed_name).to eq module_full_name
       end
@@ -752,7 +752,7 @@ RSpec.describe Msf::Modules::Loader::Base do
       it 'should be reversible' do
         namespace_module_names = subject.send(:namespace_module_names, module_full_name)
         relative_name = namespace_module_names.last
-        reversed_name = subject.send(:reverse_relative_name, relative_name)
+        reversed_name = described_class.reverse_relative_name(relative_name)
 
         expect(reversed_name).to eq module_full_name
       end

--- a/tools/dev/msftidy.rb
+++ b/tools/dev/msftidy.rb
@@ -257,7 +257,7 @@ class Msftidy
   # This check also enforces namespace module name reversibility
   def check_snake_case_filename
     if @name !~ /^[a-z0-9]+(?:_[a-z0-9]+)*\.rb$/
-      warn('Filenames should be lowercase alphanumeric snake case.')
+      warn('Filenames must be lowercase alphanumeric snake case.')
     end
   end
 


### PR DESCRIPTION
This rescues the `NameError` and prints a more friendly error message when the generated constant is invalid due to unacceptable characters.

Not everyone is using `msftidy`, especially for personal modules. Not everyone knows the standard either.

Unfortunately, the nice `WARNING! The following modules could not be loaded!` message happens in the console layer, and we're stuck in the middle of module loading. I would like to remove the stack trace eventually.

```
wvu@kharak:~/metasploit-framework:feature/namespace$ ./msfconsole -q
Traceback (most recent call last):
	30: from ./msfconsole:49:in `<main>'
	29: from /Users/wvu/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'
	28: from /Users/wvu/metasploit-framework/lib/metasploit/framework/command/console.rb:48:in `start'
	27: from /Users/wvu/metasploit-framework/lib/metasploit/framework/command/console.rb:62:in `driver'
	26: from /Users/wvu/metasploit-framework/lib/metasploit/framework/command/console.rb:62:in `new'
	25: from /Users/wvu/metasploit-framework/lib/msf/ui/console/driver.rb:161:in `initialize'
	24: from /Users/wvu/metasploit-framework/lib/msf/base/simple/framework/module_paths.rb:49:in `init_module_paths'
	23: from /Users/wvu/metasploit-framework/lib/msf/base/simple/framework/module_paths.rb:49:in `each'
	22: from /Users/wvu/metasploit-framework/lib/msf/base/simple/framework/module_paths.rb:50:in `block in init_module_paths'
	21: from /Users/wvu/metasploit-framework/lib/msf/core/module_manager/module_paths.rb:40:in `add_module_path'
	20: from /Users/wvu/metasploit-framework/lib/msf/core/module_manager/module_paths.rb:40:in `each'
	19: from /Users/wvu/metasploit-framework/lib/msf/core/module_manager/module_paths.rb:41:in `block in add_module_path'
	18: from /Users/wvu/metasploit-framework/lib/msf/core/module_manager/loading.rb:117:in `load_modules'
	17: from /Users/wvu/metasploit-framework/lib/msf/core/module_manager/loading.rb:117:in `each'
	16: from /Users/wvu/metasploit-framework/lib/msf/core/module_manager/loading.rb:119:in `block in load_modules'
	15: from /Users/wvu/metasploit-framework/lib/msf/core/modules/loader/base.rb:238:in `load_modules'
	14: from /Users/wvu/metasploit-framework/lib/msf/core/modules/loader/directory.rb:30:in `each_module_reference_name'
	13: from /Users/wvu/metasploit-framework/lib/msf/core/modules/loader/directory.rb:30:in `foreach'
	12: from /Users/wvu/metasploit-framework/lib/msf/core/modules/loader/directory.rb:40:in `block in each_module_reference_name'
	11: from /Users/wvu/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rex-core-0.1.13/lib/rex/file.rb:132:in `find'
	10: from /Users/wvu/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rex-core-0.1.13/lib/rex/file.rb:132:in `catch'
	 9: from /Users/wvu/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rex-core-0.1.13/lib/rex/file.rb:133:in `block in find'
	 8: from /Users/wvu/metasploit-framework/lib/msf/core/modules/loader/directory.rb:49:in `block (2 levels) in each_module_reference_name'
	 7: from /Users/wvu/metasploit-framework/lib/msf/core/modules/loader/base.rb:239:in `block in load_modules'
	 6: from /Users/wvu/metasploit-framework/lib/msf/core/modules/loader/base.rb:177:in `load_module'
	 5: from /Users/wvu/metasploit-framework/lib/msf/core/modules/loader/base.rb:542:in `namespace_module_transaction'
	 4: from /Users/wvu/metasploit-framework/lib/msf/core/modules/loader/base.rb:365:in `current_module'
	 3: from /Users/wvu/metasploit-framework/lib/msf/core/modules/loader/base.rb:365:in `reduce'
	 2: from /Users/wvu/metasploit-framework/lib/msf/core/modules/loader/base.rb:365:in `each'
	 1: from /Users/wvu/metasploit-framework/lib/msf/core/modules/loader/base.rb:370:in `block in current_module'
/Users/wvu/metasploit-framework/lib/msf/core/modules/loader/base.rb:380:in `rescue in block in current_module': exploit/windows/smb/my-ms17_010_eternalblue must be lowercase alphanumeric snake case (Msf::ModuleLoadError)
wvu@kharak:~/metasploit-framework:feature/namespace$
```

Resolves #10780. Updates #10729.