### PR TITLE
Only include peer in prefix for single hosts

### DIFF
--- a/lib/msf/core/exploit/tcp.rb
+++ b/lib/msf/core/exploit/tcp.rb
@@ -196,11 +196,12 @@ module Exploit::Remote::Tcp
   end
 
   def print_prefix
-    if rhost
-      super + peer + " - "
-    else
-      super
-    end
+  # if rhost
+  #   super + peer + " - "
+  # else
+  #   super
+  # end
+    super
   end
 
   ##

--- a/lib/msf/core/exploit/tcp.rb
+++ b/lib/msf/core/exploit/tcp.rb
@@ -195,15 +195,6 @@ module Exploit::Remote::Tcp
     disconnect
   end
 
-  def print_prefix
-  # if rhost
-  #   super + peer + " - "
-  # else
-  #   super
-  # end
-    super
-  end
-
   ##
   #
   # Wrappers for getters

--- a/lib/msf/core/exploit/tcp.rb
+++ b/lib/msf/core/exploit/tcp.rb
@@ -194,6 +194,14 @@ module Exploit::Remote::Tcp
     super
     disconnect
   end
+  
+  def print_prefix
+    if rhost && rhost.split(' ').length < 2
+      super + peer + ' - '
+    else
+      super
+    end
+  end
 
   ##
   #


### PR DESCRIPTION
Currently, when a status message gets printed for a module that has an RHOSTS defined as a file with hundreds of hosts, the prefix takes this gigantic space separated list of hosts and shoves it into a message. Every time the message is printed, you get this really ugly block of text and it makes the output hard to read.

I propose that peer information isn't necessary enough to include in these messages.

## Before

- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/ssh/ssh_version` (just as an example)
- [ ] Set RHOSTS to some file with 100 hosts or something.
- [ ] Every scanner progress message looks gross.

## After
- [ ] Do all the above steps.
- [ ] Bask in the glory of minimal output. Look upon its simplistic face and behold its overwhelming mediocrity. But also it's cleaner and cleanliness is close to godliness.

In other words...

When did this:
![selection_002](https://user-images.githubusercontent.com/2198138/46770766-ff557800-ccad-11e8-9239-20598839cbc8.png)
become hotter than this?:
![selection_001](https://user-images.githubusercontent.com/2198138/46770755-f2388900-ccad-11e8-956b-61a2460755e7.png)


Thoughts?