### PR TITLE
Cisco device manager update

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/cisco_device_manager.md
+++ b/documentation/modules/auxiliary/scanner/http/cisco_device_manager.md
@@ -41,6 +41,7 @@
   [+] 2.2.2.2:80 MD5 Encrypted Enable Password: $1$TF.y$3E7pZ2szVvQw5JG8SDjNa1
   [+] 2.2.2.2:80 Username 'cisco' with MD5 Encrypted Password: $1$DaqN$iP32E5WcOOui/H66R63QB0
   [+] 2.2.2.2:80 SNMP Community (RO): public
+  [+] 2.2.2.2:80 ePhone Username 'phoneone' with Password: 111111
   [*] Scanned 1 of 1 hosts (100% complete)
   [*] Auxiliary module execution completed
   ```

--- a/documentation/modules/auxiliary/scanner/http/cisco_device_manager.md
+++ b/documentation/modules/auxiliary/scanner/http/cisco_device_manager.md
@@ -1,0 +1,46 @@
+## Description
+
+  This module scans for the presence of the HTTP interface for a cisco device and attempts to enumerate it using basic authentication.
+
+## Vulnerable Application
+
+  Any Cisco networking device with the HTTP inteface turned on.
+
+## Verification Steps
+
+  1. Enable the web interface on a cisco device `ip http server`
+  2. Start msfconsole
+  3. Do: ```use auxiliary/scanner/http/cisco_device_manager```
+  4. Do: ```set RHOSTS [IP]```
+  5. Do: ```run```
+
+## Options
+
+  **HttpUsername**
+
+  Username to use for basic authentication.  Default value is `cisco`
+
+  **HttpPassword**
+
+  Password to use for basic authentication.  Default value is `cisco`
+
+## Scenarios
+
+### Tested on Cisco UC520-8U-4FXO-K9 running IOS 12.4
+
+  ```
+  msf5 > use auxiliary/scanner/http/cisco_device_manager 
+  msf5 auxiliary(scanner/http/cisco_device_manager) > set rhosts 2.2.2.2
+  rhosts => 2.2.2.2
+  msf5 auxiliary(scanner/http/cisco_device_manager) > set vebose true
+  vebose => true
+  msf5 auxiliary(scanner/http/cisco_device_manager) > run
+  
+  [+] 2.2.2.2:80 Successfully authenticated to this device
+  [+] 2.2.2.2:80 Processing the configuration file...
+  [+] 2.2.2.2:80 MD5 Encrypted Enable Password: $1$TF.y$3E7pZ2szVvQw5JG8SDjNa1
+  [+] 2.2.2.2:80 Username 'cisco' with MD5 Encrypted Password: $1$DaqN$iP32E5WcOOui/H66R63QB0
+  [+] 2.2.2.2:80 SNMP Community (RO): public
+  [*] Scanned 1 of 1 hosts (100% complete)
+  [*] Auxiliary module execution completed
+  ```

--- a/lib/msf/core/auxiliary/cisco.rb
+++ b/lib/msf/core/auxiliary/cisco.rb
@@ -55,23 +55,8 @@ module Auxiliary::Cisco
 
     tuniface = nil
 
-    host_info = {
-      :host => thost,
-      :os_name => 'Cisco IOS',
-    }
-    report_host(host_info)
-
     config.each_line do |line|
       case line
-#
-# Cover host details
-#
-        when /^version (\d\d\.\d)/i
-          host_info[:os_flavor] = $1.to_s
-          report_host(host_info)
-        when /^hostname (\S+)/i
-          host_info[:name] = $1.to_s
-          report_host(host_info)
 #
 # Enable passwords
 #

--- a/lib/msf/core/auxiliary/cisco.rb
+++ b/lib/msf/core/auxiliary/cisco.rb
@@ -55,8 +55,24 @@ module Auxiliary::Cisco
 
     tuniface = nil
 
+    host_info = {
+      :host => thost,
+      :os_name => 'Cisco',
+    }
+    report_host(host_info)
+
     config.each_line do |line|
       case line
+#
+# Cover host details
+#
+        when /^version (\d\d)\.(\d)/i
+          host_info[:os_name] = "Cisco IOS #{$1}"
+          host_info[:os_sp] = $2
+          report_host(host_info)
+        when /^hostname (\S+)/i
+          host_info[:name] = $1
+          report_host(host_info)
 #
 # Enable passwords
 #

--- a/lib/msf/core/auxiliary/cisco.rb
+++ b/lib/msf/core/auxiliary/cisco.rb
@@ -34,7 +34,7 @@ module Auxiliary::Cisco
   end
 
   def cisco_ios_config_eater(thost, tport, config)
-    
+
     credential_data = {
       address: thost,
       port: tport,
@@ -88,7 +88,7 @@ module Auxiliary::Cisco
             shash = cisco_ios_decrypt7(shash) rescue shash
             print_good("#{thost}:#{tport} Decrypted Enable Password: #{shash}")
             store_loot("cisco.ios.enable_pass", "text/plain", thost, shash, "enable_password.txt", "Cisco IOS Enable Password")
-            
+
             cred = credential_data.dup
             cred[:private_data] = shash
             cred[:private_type] = :password
@@ -131,27 +131,27 @@ module Auxiliary::Cisco
           spass = cisco_ios_decrypt7(spass) rescue spass
 
           print_good("#{thost}:#{tport} Decrypted VTY Password: #{spass}")
-          
+
           cred = credential_data.dup
           cred[:private_data] = spass
           cred[:private_type] = :password
           create_credential_and_login(cred)
-          
+
 
         when /^\s*(password|secret) 5 (.*)/i
           shash = $2.strip
           print_good("#{thost}:#{tport} MD5 Encrypted VTY Password: #{shash}")
           store_loot("cisco.ios.vty_password", "text/plain", thost, shash, "vty_password_hash.txt", "Cisco IOS VTY Password Hash (MD5)")
-          
+
           cred = credential_data.dup
           cred[:private_data] = shash
           cred[:private_type] = :nonreplayable_hash
           create_credential_and_login(cred)
-          
+
         when /^\s*password (0 |)([^\s]+)/i
           spass = $2.strip
           print_good("#{thost}:#{tport} Unencrypted VTY Password: #{spass}")
-          
+
           cred = credential_data.dup
           cred[:private_data] = spass
           cred[:private_type] = :nonreplayable_hash
@@ -212,7 +212,7 @@ module Auxiliary::Cisco
           cred[:private_data] = spass
           cred[:private_type] = :nonreplayable_hash
           create_credential_and_login(cred)
-          
+
         when /^\s*interface tunnel(\d+)/i
           tuniface = $1
 
@@ -222,24 +222,24 @@ module Auxiliary::Cisco
 
           print_good("#{thost}:#{tport} GRE Tunnel Key #{spass} for Interface Tunnel #{siface}")
           store_loot("cisco.ios.gre_tunnel_key", "text/plain", thost, "tunnel#{siface}_#{spass}", "gre_tunnel_key.txt", "Cisco GRE Tunnel Key")
-          
+
           cred = credential_data.dup
           cred[:private_data] = spass
           cred[:private_type] = :nonreplayable_hash
           create_credential_and_login(cred)
-          
+
         when /^\s*ip nhrp authentication ([^\s]+)/i
           spass = $1
           siface = tuniface
 
           print_good("#{thost}:#{tport} NHRP Authentication Key #{spass} for Interface Tunnel #{siface}")
           store_loot("cisco.ios.nhrp_tunnel_key", "text/plain", thost, "tunnel#{siface}_#{spass}", "nhrp_tunnel_key.txt", "Cisco NHRP Authentication Key")
-          
+
           cred = credential_data.dup
           cred[:private_data] = spass
           cred[:private_type] = :nonreplayable_hash
           create_credential_and_login(cred)
-          
+
 
 #
 # Various authentication secrets
@@ -287,7 +287,7 @@ module Auxiliary::Cisco
         when /^\s*username (?:&#34;)([^\s]+)(?:&#34;) password ([^\s]+)/i
           user  = $1
           spass = $2
-          print_good("#{thost}:#{tport} Phone Username '#{user}' with Password: #{spass}")
+          print_good("#{thost}:#{tport} ePhone Username '#{user}' with Password: #{spass}")
           store_loot("cisco.ios.ephone.username_password", "text/plain", thost, "#{user}:#{spass}", "ephone_username_password.txt", "Cisco IOS ephone Username and Password")
             cred = credential_data.dup
             cred[:private_data] = spass
@@ -338,7 +338,7 @@ module Auxiliary::Cisco
           if stype == 5
             print_good("#{thost}:#{tport} PPP Username #{suser} MD5 Encrypted Password: #{spass}")
             store_loot("cisco.ios.ppp_username_password_hash", "text/plain", thost, "#{suser}:#{spass}", "ppp_username_password_hash.txt", "Cisco IOS PPP Username and Password Hash (MD5)")
-            
+
             cred = credential_data.dup
             cred[:private_data] = spass
             cred[:private_type] = :nonreplayable_hash
@@ -348,7 +348,7 @@ module Auxiliary::Cisco
           if stype == 0
             print_good("#{thost}:#{tport} PPP Username: #{suser} Password: #{spass}")
             store_loot("cisco.ios.ppp_username_password", "text/plain", thost, "#{suser}:#{spass}", "ppp_username_password.txt", "Cisco IOS PPP Username and Password")
-            
+
             cred = credential_data.dup
             cred[:private_data] = spass
             cred[:private_type] = :nonreplayable_hash

--- a/lib/msf/core/auxiliary/cisco.rb
+++ b/lib/msf/core/auxiliary/cisco.rb
@@ -7,7 +7,7 @@ module Msf
 #
 ###
 module Auxiliary::Cisco
-  #include Msf::Auxiliary::Report
+  include Msf::Auxiliary::Report
 
   def cisco_ios_decrypt7(inp)
     xlat = [

--- a/lib/msf/core/auxiliary/cisco.rb
+++ b/lib/msf/core/auxiliary/cisco.rb
@@ -7,7 +7,7 @@ module Msf
 #
 ###
 module Auxiliary::Cisco
-  include Msf::Auxiliary::Report
+  #include Msf::Auxiliary::Report
 
   def cisco_ios_decrypt7(inp)
     xlat = [

--- a/lib/msf/core/auxiliary/cisco.rb
+++ b/lib/msf/core/auxiliary/cisco.rb
@@ -57,7 +57,7 @@ module Auxiliary::Cisco
 
     host_info = {
       :host => thost,
-      :os_name => 'Cisco',
+      :os_name => 'Cisco IOS',
     }
     report_host(host_info)
 
@@ -66,12 +66,11 @@ module Auxiliary::Cisco
 #
 # Cover host details
 #
-        when /^version (\d\d)\.(\d)/i
-          host_info[:os_name] = "Cisco IOS #{$1}"
-          host_info[:os_sp] = $2
+        when /^version (\d\d\.\d)/i
+          host_info[:os_flavor] = $1.to_s
           report_host(host_info)
         when /^hostname (\S+)/i
-          host_info[:name] = $1
+          host_info[:name] = $1.to_s
           report_host(host_info)
 #
 # Enable passwords

--- a/lib/msf/core/auxiliary/cisco.rb
+++ b/lib/msf/core/auxiliary/cisco.rb
@@ -289,10 +289,10 @@ module Auxiliary::Cisco
           spass = $2
           print_good("#{thost}:#{tport} ePhone Username '#{user}' with Password: #{spass}")
           store_loot("cisco.ios.ephone.username_password", "text/plain", thost, "#{user}:#{spass}", "ephone_username_password.txt", "Cisco IOS ephone Username and Password")
-            cred = credential_data.dup
-            cred[:private_data] = spass
-            cred[:private_type] = :nonreplayable_hash
-            create_credential_and_login(cred)
+          cred = credential_data.dup
+          cred[:private_data] = spass
+          cred[:private_type] = :nonreplayable_hash
+          create_credential_and_login(cred)
 
         when /^\s*username ([^\s]+) (secret|password) (\d+) ([^\s]+)/i
           user  = $1

--- a/lib/msf/core/auxiliary/cisco.rb
+++ b/lib/msf/core/auxiliary/cisco.rb
@@ -280,6 +280,20 @@ module Auxiliary::Cisco
             create_credential_and_login(cred)
           end
 
+        # This regex captures ephones from Cisco Unified Communications Manager Express (CUE) which come in forms like:
+        # username &#34;phonefour&#34; password 444444
+        # username test password test
+        # This is used for the voicemail system
+        when /^\s*username (?:&#34;)([^\s]+)(?:&#34;) password ([^\s]+)/i
+          user  = $1
+          spass = $2
+          print_good("#{thost}:#{tport} Phone Username '#{user}' with Password: #{spass}")
+          store_loot("cisco.ios.ephone.username_password", "text/plain", thost, "#{user}:#{spass}", "ephone_username_password.txt", "Cisco IOS ephone Username and Password")
+            cred = credential_data.dup
+            cred[:private_data] = spass
+            cred[:private_type] = :nonreplayable_hash
+            create_credential_and_login(cred)
+
         when /^\s*username ([^\s]+) (secret|password) (\d+) ([^\s]+)/i
           user  = $1
           stype = $3.to_i

--- a/modules/auxiliary/scanner/http/cisco_device_manager.rb
+++ b/modules/auxiliary/scanner/http/cisco_device_manager.rb
@@ -87,7 +87,7 @@ class MetasploitModule < Msf::Auxiliary
 
 
       # Report a vulnerability only if no password was specified
-      if datastore['HttpUsername'].to_s.length == 0
+      if datastore['HttpPassword'].to_s.length == 0
 
         report_vuln(
           {

--- a/modules/auxiliary/scanner/http/cisco_device_manager.rb
+++ b/modules/auxiliary/scanner/http/cisco_device_manager.rb
@@ -59,32 +59,7 @@ class MetasploitModule < Msf::Auxiliary
 
     if res and res.body and res.body =~ /Cisco (Internetwork Operating System|IOS) Software/
       print_good("#{rhost}:#{rport} Successfully authenticated to this device")
-      service_data = {
-        address: rhost,
-        port: rport,
-        service_name: 'http',
-        protocol: 'tcp',
-        workspace_id: myworkspace_id
-      }
-
-      credential_data = {
-        module_fullname: self.fullname,
-        origin_type: :service,
-        private_data: datastore['HttpPassword'],
-        private_type: :password,
-        username: datastore['HttpUsername']
-      }
-
-      credential_data.merge!(service_data)
-      credential_core = create_credential(credential_data)
-      login_data = {
-        core: credential_core,
-        last_attempted_at: DateTime.now,
-        status: Metasploit::Model::Login::Status::SUCCESSFUL
-      }
-      login_data.merge!(service_data)
-      create_credential_login(login_data)
-
+      store_valid_credential(user: datastore['HttpUsername'], private: datastore['HttpPassword'])
 
       # Report a vulnerability only if no password was specified
       if datastore['HttpPassword'].to_s.length == 0

--- a/modules/auxiliary/scanner/http/cisco_device_manager.rb
+++ b/modules/auxiliary/scanner/http/cisco_device_manager.rb
@@ -87,7 +87,7 @@ class MetasploitModule < Msf::Auxiliary
 
 
       # Report a vulnerability only if no password was specified
-      if datastore['PASSWORD'].to_s.length == 0
+      if datastore['HttpUsername'].to_s.length == 0
 
         report_vuln(
           {


### PR DESCRIPTION
First off, add docs to `cisco_device_manager`.
Next, it says you can set `USERNAME` and `PASSWORD` to set the basic auth, however, that doesn't actually do anything.  So we add back the options to add a un/pass, set them to the cisco default of `cisco`, and then add on the creds framework so that we can store that as a win.

## Verification

- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/http/cisco_device_manager`
- [ ] `run`
- [ ] **Verify** creds get used, and databased if right
- [ ] **Document** looks good

