### PR TITLE
Update msfvenom format CLI parameter to be case insensitive

### DIFF
--- a/lib/msf/base/simple/buffer.rb
+++ b/lib/msf/base/simple/buffer.rb
@@ -25,7 +25,7 @@ module Buffer
       buf = encrypt_buffer(buf, encryption_opts)
     end
 
-    case fmt
+    case fmt.downcase
       when 'raw'
       when 'num'
         buf = Rex::Text.to_num(buf)
@@ -69,7 +69,7 @@ module Buffer
   # raw, ruby, python, perl, bash, js_be, js_le, c, and java.
   #
   def self.comment(buf, fmt = "ruby")
-    case fmt
+    case fmt.downcase
       when 'raw'
       when 'num', 'dword', 'dw', 'hex'
         buf = Rex::Text.to_js_comment(buf)
@@ -138,7 +138,7 @@ module Buffer
   def self.encrypt_buffer(value, encryption_opts)
     buf = ''
 
-    case encryption_opts[:format]
+    case encryption_opts[:format].downcase
     when 'aes256'
       if encryption_opts[:iv].blank?
         raise ArgumentError, 'Initialization vector is missing'

--- a/lib/msf/base/simple/buffer.rb
+++ b/lib/msf/base/simple/buffer.rb
@@ -14,6 +14,7 @@ module Simple
 ###
 module Buffer
 
+  class BufferFormatError < ::ArgumentError; end
   #
   # Serializes a buffer to a provided format.  The formats supported are raw,
   # num, dword, ruby, python, perl, bash, c, js_be, js_le, java and psh
@@ -58,7 +59,7 @@ module Buffer
       when 'vbapplication'
         buf = Rex::Text.to_vbapplication(buf, var_name)
       else
-        raise ArgumentError, "Unsupported buffer format: #{fmt}", caller
+        raise BufferFormatError, "Unsupported buffer format: #{fmt}", caller
     end
 
     return buf
@@ -88,7 +89,7 @@ module Buffer
       when 'java'
         buf = Rex::Text.to_c_comment(buf)
       else
-        raise ArgumentError, "Unsupported buffer format: #{fmt}", caller
+        raise BufferFormatError, "Unsupported buffer format: #{fmt}", caller
     end
 
     return buf

--- a/lib/msf/base/simple/buffer.rb
+++ b/lib/msf/base/simple/buffer.rb
@@ -25,7 +25,7 @@ module Buffer
       buf = encrypt_buffer(buf, encryption_opts)
     end
 
-    case fmt.downcase
+    case fmt
       when 'raw'
       when 'num'
         buf = Rex::Text.to_num(buf)
@@ -69,7 +69,7 @@ module Buffer
   # raw, ruby, python, perl, bash, js_be, js_le, c, and java.
   #
   def self.comment(buf, fmt = "ruby")
-    case fmt.downcase
+    case fmt
       when 'raw'
       when 'num', 'dword', 'dw', 'hex'
         buf = Rex::Text.to_js_comment(buf)
@@ -138,7 +138,7 @@ module Buffer
   def self.encrypt_buffer(value, encryption_opts)
     buf = ''
 
-    case encryption_opts[:format].downcase
+    case encryption_opts[:format]
     when 'aes256'
       if encryption_opts[:iv].blank?
         raise ArgumentError, 'Initialization vector is missing'

--- a/lib/msf/core/payload_generator.rb
+++ b/lib/msf/core/payload_generator.rb
@@ -139,7 +139,7 @@ module Msf
       @framework  = opts.fetch(:framework)
 
       raise ArgumentError, "Invalid Payload Selected" unless payload_is_valid?
-      raise ArgumentError, "Invalid Format Selected" unless format_is_valid?
+      raise ::Msf::Simple::Buffer::BufferFormatError, "Invalid Format Selected" unless format_is_valid?
 
       # In smallest mode, override the payload @space & @encoder_space settings
       if @smallest

--- a/lib/msf/core/payload_generator.rb
+++ b/lib/msf/core/payload_generator.rb
@@ -316,7 +316,7 @@ module Msf
     def generate_java_payload
       payload_module = framework.payloads.create(payload)
       payload_module.datastore.import_options_from_hash(datastore)
-      case format
+      case format.downcase
       when "raw", "jar"
         if payload_module.respond_to? :generate_jar
           payload_module.generate_jar.pack
@@ -373,7 +373,7 @@ module Msf
       elsif gen_payload.length > @space and not @smallest
         raise PayloadSpaceViolation, 'The payload exceeds the specified space'
       else
-        if format.to_s != 'raw'
+        if format.to_s.downcase != 'raw'
           cli_print "Final size of #{format} file: #{gen_payload.length} bytes"
         end
 

--- a/lib/msf/core/payload_generator.rb
+++ b/lib/msf/core/payload_generator.rb
@@ -316,7 +316,7 @@ module Msf
     def generate_java_payload
       payload_module = framework.payloads.create(payload)
       payload_module.datastore.import_options_from_hash(datastore)
-      case format.downcase
+      case format
       when "raw", "jar"
         if payload_module.respond_to? :generate_jar
           payload_module.generate_jar.pack
@@ -373,7 +373,7 @@ module Msf
       elsif gen_payload.length > @space and not @smallest
         raise PayloadSpaceViolation, 'The payload exceeds the specified space'
       else
-        if format.to_s.downcase != 'raw'
+        if format.to_s != 'raw'
           cli_print "Final size of #{format} file: #{gen_payload.length} bytes"
         end
 

--- a/msfvenom
+++ b/msfvenom
@@ -90,7 +90,7 @@ def parse_args(args)
   end
 
   opt.on('-f', '--format          <format>', String, "Output format (use --list formats to list)") do |f|
-    opts[:format] = f
+    opts[:format] = f.downcase
   end
 
   opt.on('-e', '--encoder         <encoder>', String, 'The encoder to use (use --list encoders to list)') do |e|

--- a/msfvenom
+++ b/msfvenom
@@ -440,6 +440,9 @@ generator_opts[:cli] = true
 begin
   venom_generator = Msf::PayloadGenerator.new(generator_opts)
   payload = venom_generator.generate_payload
+rescue ::Msf::Simple::Buffer::BufferFormatError => e
+  $stderr.puts "Error: #{e.message}"
+  $stderr.puts dump_formats
 rescue ::Exception => e
   elog("#{e.class} : #{e.message}\n#{e.backtrace * "\n"}")
   $stderr.puts "Error: #{e.message}"


### PR DESCRIPTION
Taking after:
https://github.com/rapid7/metasploit-framework/blob/master/lib/msf/core/payload_generator.rb#L296

This pull request makes minor adjustments to conditional statements related to the format parameter allowing the condition to act in a case insensitive manner rather than requiring lowercase options. 

## Verification

With the changes installed, use the following command:

    msfvenom -p windows/exec CMD=calc.exe -b '\x00\x0A\x0D'-a x86 --platform windows -f C

Before the change:

```
root@kali:~/exploits/freefloat-ftp# msfvenom -p windows/exec CMD=calc.exe -b '\x00\x0A\x0D'-a x86 --platform windows -f C
[-] No arch selected, selecting arch: x86 from the payload
Found 10 compatible encoders
Attempting to encode payload with 1 iterations of x86/shikata_ga_nai
x86/shikata_ga_nai succeeded with size 220 (iteration=0)
x86/shikata_ga_nai chosen with final size 220
Payload size: 220 bytes
Error: Unsupported buffer format: C
```

After the change:

```
root@kali:~/exploits/freefloat-ftp# msfvenom -p windows/exec CMD=calc.exe -b '\x00\x0A\x0D'-a x86 --platform windows -f C
[-] No arch selected, selecting arch: x86 from the payload
Found 10 compatible encoders
Attempting to encode payload with 1 iterations of x86/shikata_ga_nai
x86/shikata_ga_nai succeeded with size 220 (iteration=0)
x86/shikata_ga_nai chosen with final size 220
Payload size: 220 bytes
Final size of C file: 949 bytes
unsigned char buf[] = 
"\xdb\xc1\xd9\x74\x24\xf4\x58\x2b\xc9\xb1\x31\xbb\x65\xc6\xc2"
"\x9f\x31\x58\x18\x03\x58\x18\x83\xe8\x99\x24\x37\x63\x89\x2b"
"\xb8\x9c\x49\x4c\x30\x79\x78\x4c\x26\x09\x2a\x7c\x2c\x5f\xc6"
"\xf7\x60\x74\x5d\x75\xad\x7b\xd6\x30\x8b\xb2\xe7\x69\xef\xd5"
"\x6b\x70\x3c\x36\x52\xbb\x31\x37\x93\xa6\xb8\x65\x4c\xac\x6f"
"\x9a\xf9\xf8\xb3\x11\xb1\xed\xb3\xc6\x01\x0f\x95\x58\x1a\x56"
"\x35\x5a\xcf\xe2\x7c\x44\x0c\xce\x37\xff\xe6\xa4\xc9\x29\x37"
"\x44\x65\x14\xf8\xb7\x77\x50\x3e\x28\x02\xa8\x3d\xd5\x15\x6f"
"\x3c\x01\x93\x74\xe6\xc2\x03\x51\x17\x06\xd5\x12\x1b\xe3\x91"
"\x7d\x3f\xf2\x76\xf6\x3b\x7f\x79\xd9\xca\x3b\x5e\xfd\x97\x98"
"\xff\xa4\x7d\x4e\xff\xb7\xde\x2f\xa5\xbc\xf2\x24\xd4\x9e\x98"
"\xbb\x6a\xa5\xee\xbc\x74\xa6\x5e\xd5\x45\x2d\x31\xa2\x59\xe4"
"\x76\x5c\x10\xa5\xde\xf5\xfd\x3f\x63\x98\xfd\x95\xa7\xa5\x7d"
"\x1c\x57\x52\x9d\x55\x52\x1e\x19\x85\x2e\x0f\xcc\xa9\x9d\x30"
"\xc5\xc9\x40\xa3\x85\x23\xe7\x43\x2f\x3c";
```