### PR TITLE
Disable ERB templating for Metasploit::Framework::Compiler::Utils

### DIFF
--- a/lib/metasploit/framework/compiler/utils.rb
+++ b/lib/metasploit/framework/compiler/utils.rb
@@ -11,13 +11,14 @@ module Metasploit
         def self.normalize_code(code, headers)
           code = code.lines.map { |line|
             if line =~ /^#include <([[:print:]]+)>$/
-              %Q|<%= headers.include('#{$1}') %>\n|
+              h = headers.include("#{$1}")
+              %Q|#{h}\n|
             else
               line
             end
           }.join
 
-          ERB.new(code).result(binding)
+          code
         end
 
       end


### PR DESCRIPTION
It turns out that using ERB isn't such as a great idea, because if there is `<%` in the code by accident, the compiling would fail. 