### PR TITLE
ssh_login* now populates the os_name field

### DIFF
--- a/modules/auxiliary/scanner/ssh/ssh_login.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login.rb
@@ -73,6 +73,14 @@ class MetasploitModule < Msf::Auxiliary
     # Set the session platform
     s.platform = scanner.get_platform(result.proof)
 
+    # Create database host information
+    host_info = {:host => scanner.host}
+
+    unless s.platform == 'unknown'
+      host_info[:os_name] = s.platform
+    end
+    report_host(host_info)
+
     s
   end
 

--- a/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
@@ -92,6 +92,14 @@ class MetasploitModule < Msf::Auxiliary
     # Set the session platform
     s.platform = scanner.get_platform(result.proof)
 
+    # Create database host information
+    host_info = {:host => scanner.host}
+
+    unless s.platform == 'unknown'
+      host_info[:os_name] = s.platform
+    end
+    report_host(host_info)
+
     s
   end
 


### PR DESCRIPTION
When using `auxiliary/scanner/ssh/ssh_login`*, if you get a shell, we determine a platform field.  This would be a good fit for `os_name` in the hosts db, so now we'll populate that field.

Since this tends to be a string, would anyone argue for formatting?  First letter caps?  what about `osx`?  I think it tends not to matter in the long run since this field isn't really used to my knowledge, but would rather have consistency now than later.

## Pre:
```
resource (ubuntu16.rb)> exploit
[+] 1.1.1.1:22 - Success: 'ubuntu:ubuntu' 'uid=1000(ubuntu) gid=1000(ubuntu) groups=1000(ubuntu),4(adm),24(cdrom),27(sudo),30(dip),46(plugdev),110(lxd),115(lpadmin),116(sambashare) Linux ubuntu1604 4.4.0-134-generic #160-Ubuntu SMP Wed Aug 15 14:58:00 UTC 2018 x86_64 x86_64 x86_64 GNU/Linux '
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf5 auxiliary(scanner/ssh/ssh_login) > hosts

Hosts
=====

address        mac  name  os_name    os_flavor  os_sp  purpose  info  comments
-------        ---  ----  -------    ---------  -----  -------  ----  --------
1.1.1.1                                                         
```


## Post (spacing off due to IP masking):
```
resource (ubuntu16.rb)> exploit
[+] 1.1.1.1:22 - Success: 'ubuntu:ubuntu' 'uid=1000(ubuntu) gid=1000(ubuntu) groups=1000(ubuntu),4(adm),24(cdrom),27(sudo),30(dip),46(plugdev),110(lxd),115(lpadmin),116(sambashare) Linux ubuntu1604 4.4.0-134-generic #160-Ubuntu SMP Wed Aug 15 14:58:00 UTC 2018 x86_64 x86_64 x86_64 GNU/Linux '
[*] Command shell session 1 opened (2.2.2.2:37469 -> 1.1.1.1:22) at 2018-10-16 21:27:41 -0400
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf5 auxiliary(scanner/ssh/ssh_login) > hosts

Hosts
=====

address        mac  name  os_name    os_flavor  os_sp  purpose  info  comments
-------        ---  ----  -------    ---------  -----  -------  ----  --------
1.1.1.1             linux                                       
```
```
msf5 auxiliary(scanner/ssh/ssh_login) > exploit
host
[+] 3.3.3.3:22 - Success: 'solaris:Solaris!' 'uid=100(solaris) gid=10(staff) SunOS solaris11.3 5.11 11.3 i86pc i386 i86pc '
s
[*] Command shell session 1 opened (2.2.2.2:33643 -> 3.3.3.3:22) at 2018-10-16 21:59:01 -0400
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf5 auxiliary(scanner/ssh/ssh_login) > hosts

Hosts
=====

address        mac  name        os_name  os_flavor  os_sp  purpose  info  comments
-------        ---  ----        -------  ---------  -----  -------  ----  --------
3.3.3.3                    solaris                                   

```