### PR TITLE
Add PTY option to Net::SSH::CommandStream

### DIFF
--- a/lib/net/ssh/command_stream.rb
+++ b/lib/net/ssh/command_stream.rb
@@ -38,7 +38,7 @@ class CommandStream
     self.channel = channel
   end
 
-  def initialize(ssh, cmd = nil, pty = false, cleanup = false)
+  def initialize(ssh, cmd = nil, pty: false, cleanup: false)
     self.lsock, self.rsock = Rex::Socket.tcp_socket_pair()
     self.lsock.extend(Rex::IO::Stream)
     self.lsock.extend(PeerInfo)

--- a/lib/net/ssh/command_stream.rb
+++ b/lib/net/ssh/command_stream.rb
@@ -45,7 +45,7 @@ class CommandStream
     self.rsock.extend(Rex::IO::Stream)
 
     self.ssh = ssh
-    self.thread = Thread.new(ssh,cmd,pty,cleanup) do |rssh, rcmd, rpty, rcleanup|
+    self.thread = Thread.new(ssh, cmd, pty, cleanup) do |rssh, rcmd, rpty, rcleanup|
       begin
         info = rssh.transport.socket.getpeername_as_array
         self.lsock.peerinfo  = "#{info[1]}:#{info[2]}"

--- a/lib/net/ssh/command_stream.rb
+++ b/lib/net/ssh/command_stream.rb
@@ -38,16 +38,14 @@ class CommandStream
     self.channel = channel
   end
 
-  def initialize(ssh, cmd = nil, cleanup = false)
-
+  def initialize(ssh, cmd = nil, pty = false, cleanup = false)
     self.lsock, self.rsock = Rex::Socket.tcp_socket_pair()
     self.lsock.extend(Rex::IO::Stream)
     self.lsock.extend(PeerInfo)
     self.rsock.extend(Rex::IO::Stream)
 
     self.ssh = ssh
-    self.thread = Thread.new(ssh,cmd,cleanup) do |rssh, rcmd, rcleanup|
-
+    self.thread = Thread.new(ssh,cmd,pty,cleanup) do |rssh, rcmd, rpty, rcleanup|
       begin
         info = rssh.transport.socket.getpeername_as_array
         self.lsock.peerinfo  = "#{info[1]}:#{info[2]}"
@@ -56,6 +54,8 @@ class CommandStream
         self.lsock.localinfo = "#{info[1]}:#{info[2]}"
 
         rssh.open_channel do |rch|
+          # A PTY will write us to {u,w}tmp and lastlog
+          rch.request_pty if rpty
           if rcmd.nil?
             rch.send_channel_request("shell", &method(:shell_requested))
           else


### PR DESCRIPTION
This allows us to spawn a PTY for our shell session. Note that this will write us to `{u,w}tmp` and `lastlog`, so use this option with care.

```
msf5 auxiliary(scanner/ssh/ssh_login_pubkey) > git diff
[*] exec: git diff

diff --git a/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb b/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
index c3a6b2d3e2..928155d814 100644
--- a/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
@@ -72,7 +72,7 @@ class MetasploitModule < Msf::Auxiliary
     return unless scanner.ssh_socket

     # Create a new session from the socket
-    conn = Net::SSH::CommandStream.new(scanner.ssh_socket)
+    conn = Net::SSH::CommandStream.new(scanner.ssh_socket, pty: true)

     # Clean up the stored data - need to stash the keyfile into
     # a datastore for later reuse.
msf5 auxiliary(scanner/ssh/ssh_login_pubkey) > run

[*] 172.28.128.3:22 SSH - Testing Cleartext Keys
[*] 172.28.128.3:22 - Testing 1 keys from [redacted]
[+] 172.28.128.3:22 - Success: 'vagrant:[redacted]' 'uid=1000(vagrant) gid=1000(vagrant) groups=1000(vagrant) Linux ubuntu-xenial 4.4.0-134-generic #160-Ubuntu SMP Wed Aug 15 14:58:00 UTC 2018 x86_64 x86_64 x86_64 GNU/Linux '
[*] Command shell session 1 opened (172.28.128.1:51489 -> 172.28.128.3:22) at 2018-10-17 15:29:20 -0500
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf5 auxiliary(scanner/ssh/ssh_login_pubkey) > sessions -1
[*] Starting interaction with 1...

Last login: Wed Oct 17 20:27:39 2018 from 172.28.128.1
vagrant@ubuntu-xenial:~$ tty
tty
/dev/pts/1
vagrant@ubuntu-xenial:~$
```

~And yes, I did change the API, but up until now, we've been using only the first two parameters. We should be using keyword args. /shrug~ Prefer keyword args after all. SINCE we've been using only the first two params, we're fine! Thanks to @busterb for the push. :)

For #10820. cc @sempervictus