### PR TITLE
Updates to play_youtube

### DIFF
--- a/documentation/modules/post/multi/manage/play_youtube.md
+++ b/documentation/modules/post/multi/manage/play_youtube.md
@@ -1,0 +1,26 @@
+`play_youtube` allows you to open and start playing a YouTube video on a
+compromised host.
+
+## Important Options
+
+**EMBED**
+
+Whether or not to use the `/embed` YouTube URL. The embeded version provides a
+clean interface and will start playing in fullscreen but is not compatible with
+all YouTube videos, for example Rick Astley - Never Gonna Give You Up (VID:
+[`dQw4w9WgXcQ`][1]) is not compatible.
+
+While the non-embeded version has greater compatibility, there is a chance that
+an advertisement may be played before the video. It is recommended to use the
+embeded version when the video is compatible.
+
+**VID**
+
+The video's identifier on YouTube. This is the `v` parameter of the URL.
+
+## See Also
+
+* Meterpreter's `uictl` command in the `stdapi` extension for enabling and
+  disabling the mouse and keyboard.
+
+[1]: https://www.youtube.com/watch?v=dQw4w9WgXcQ

--- a/modules/post/multi/manage/play_youtube.rb
+++ b/modules/post/multi/manage/play_youtube.rb
@@ -72,7 +72,8 @@ class MetasploitModule < Msf::Post
     begin
       # Create a profile
       profile_name = Rex::Text.rand_text_alpha(8)
-      o = cmd_exec(%Q|firefox --display :0 -CreateProfile "#{profile_name} /tmp/#{profile_name}"|)
+      display = get_env('DISPLAY') || ':0'
+      o = cmd_exec(%Q|firefox --display #{display} -CreateProfile "#{profile_name} /tmp/#{profile_name}"|)
 
       # Add user-defined settings to profile
       s = %Q|
@@ -84,7 +85,7 @@ class MetasploitModule < Msf::Post
       # Start the video
       url = "#{YOUTUBE_BASE_URL}#{id}?#{PLAY_OPTIONS}"
       data_js = %Q|"data:text/html,<script>window.open('#{url}','','width:100000px;height:100000px');</script>"|
-      joe = "firefox --display :0 -p #{profile_name} #{data_js} &"
+      joe = "firefox --display #{display} -p #{profile_name} #{data_js} &"
       cmd_exec("/bin/sh -c #{joe.shellescape}")
     rescue EOFError
       return false

--- a/modules/post/multi/manage/play_youtube.rb
+++ b/modules/post/multi/manage/play_youtube.rb
@@ -37,8 +37,6 @@ class MetasploitModule < Msf::Post
       ])
   end
 
-  
-
   def youtube_url
     if datastore['EMBED']
       "https://youtube.com/embed/#{datastore['VID']}?autoplay=1&loop=1&disablekb=1&modestbranding=1&iv_load_policy=3&controls=0&showinfo=0&rel=0"

--- a/modules/post/multi/manage/play_youtube.rb
+++ b/modules/post/multi/manage/play_youtube.rb
@@ -6,37 +6,53 @@
 class MetasploitModule < Msf::Post
   include Msf::Post::File
 
-  PLAY_OPTIONS = 'autoplay=1&loop=1&disablekb=1&modestbranding=1&iv_load_policy=3&controls=0&showinfo=0&rel=0'
-
   def initialize(info={})
     super( update_info( info,
       'Name'          => 'Multi Manage YouTube Broadcast',
       'Description'   => %q{
         This module will broadcast a YouTube video on specified compromised systems. It will play
-        the video in the target machine's native browser in full screen mode. The VID datastore
-        option is the "v" parameter in a YouTube video's URL.
+        the video in the target machine's native browser. The VID datastore option is the "v"
+        parameter in a YouTube video's URL.
+
+        Enabling the EMBED option will play the video in full screen mode through a clean interface
+        but is not compatible with all videos.
+
+        This module will create a custom profile for Firefox on Linux systems in the /tmp directory.
       },
       'License'       => MSF_LICENSE,
-      'Author'        => [ 'sinn3r'],
+      'Author'        => [ 'sinn3r' ],
       'Platform'      => [ 'win', 'osx', 'linux', 'android' ],
-      'SessionTypes'  => [ 'shell', 'meterpreter' ]
+      'SessionTypes'  => [ 'shell', 'meterpreter' ],
+      'Notes'         =>
+        {
+          # ARTIFACTS_ON_DISK when the platform is linux
+          'SideEffects' => [ ARTIFACTS_ON_DISK, AUDIO_EFFECTS, SCREEN_EFFECTS ]
+        },
     ))
 
     register_options(
       [
+        OptBool.new('EMBED', [true, 'Use the embed version of the YouTube URL', true]),
         OptString.new('VID', [true, 'The video ID to the YouTube video'])
       ])
   end
 
-  YOUTUBE_BASE_URL = "https://youtube.com/embed/"
+  
+
+  def youtube_url
+    if datastore['EMBED']
+      "https://youtube.com/embed/#{datastore['VID']}?autoplay=1&loop=1&disablekb=1&modestbranding=1&iv_load_policy=3&controls=0&showinfo=0&rel=0"
+    else
+      "https://youtube.com/watch?v=#{datastore['VID']}"
+    end
+  end
 
   #
   # The OSX version uses an apple script to do this
   #
   def osx_start_video(id)
-    url = "#{YOUTUBE_BASE_URL}#{id}?#{PLAY_OPTIONS}"
     script = ''
-    script << %Q|osascript -e 'tell application "Safari" to open location "#{url}"' |
+    script << %Q|osascript -e 'tell application "Safari" to open location "#{youtube_url}"' |
     script << %Q|-e 'activate application "Safari"' |
     script << %Q|-e 'tell application "System Events" to key code {59, 55, 3}'|
 
@@ -55,7 +71,7 @@ class MetasploitModule < Msf::Post
   def win_start_video(id)
     iexplore_path = "C:\\Program Files\\Internet Explorer\\iexplore.exe"
     begin
-      session.sys.process.execute(iexplore_path, "-k #{YOUTUBE_BASE_URL}#{id}?#{PLAY_OPTIONS}")
+      session.sys.process.execute(iexplore_path, "-k #{youtube_url}")
     rescue Rex::Post::Meterpreter::RequestError
       return false
     end
@@ -73,6 +89,7 @@ class MetasploitModule < Msf::Post
       # Create a profile
       profile_name = Rex::Text.rand_text_alpha(8)
       display = get_env('DISPLAY') || ':0'
+      vprint_status("Creating profile #{profile_name} using display #{display}")
       o = cmd_exec(%Q|firefox --display #{display} -CreateProfile "#{profile_name} /tmp/#{profile_name}"|)
 
       # Add user-defined settings to profile
@@ -83,8 +100,7 @@ class MetasploitModule < Msf::Post
       write_file("/tmp/#{profile_name}/prefs.js", s)
 
       # Start the video
-      url = "#{YOUTUBE_BASE_URL}#{id}?#{PLAY_OPTIONS}"
-      data_js = %Q|"data:text/html,<script>window.open('#{url}','','width:100000px;height:100000px');</script>"|
+      data_js = %Q|"data:text/html,<script>window.open('#{youtube_url}','','width:100000px;height:100000px');</script>"|
       joe = "firefox --display #{display} -p #{profile_name} #{data_js} &"
       cmd_exec("/bin/sh -c #{joe.shellescape}")
     rescue EOFError


### PR DESCRIPTION
This pull request makes the following changes to the `post/multi/manage/play_youtube` module.

1. On Linux systems, uses the existing value of the `DISPLAY` environment variable when it exists, failing back to `:0` when it does not, fixing the module for some version of Linux.
1. Adds the `EMBED` option (defaulting to True for backwards compatibility) to allow module operators to fail back to the more compatible URL
1. Adds module documentation and includes a subtle reference to the most commonly used `VID` value.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Open a session on a supported platform
- [x] `use post/multi/manage/play_youtube`
- [x] Select your favorite YouTube video (from my testing and what I've read many music videos are not compatible with the `/embed` version of the URL)
- [x] Set the `VID` parameter and run the module
  - [x] If the video does not play, `set EMBED false` and run it again
- [x] **Verify** The video plays
- [x] Run `info -d` and read the documentation

## Example
```
metasploit-framework (S:1 J:2) post(multi/manage/play_youtube) > show options 

Module options (post/multi/manage/play_youtube):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   EMBED    false            yes       Use the embed version of the YouTube URL
   SESSION  -1               yes       The session to run this module on.
   VID      dQw4w9WgXcQ      yes       The video ID to the YouTube video

metasploit-framework (S:1 J:2) post(multi/manage/play_youtube) > run

[*] [2018.10.22-20:59:30] 192.168.1.13:48750 - Spawning video...
[*] [2018.10.22-20:59:30] Creating profile UDiFkbtg using display :1
[+] [2018.10.22-20:59:30] 192.168.1.13:48750 - The video has started
[*] Post module execution completed
metasploit-framework (S:1 J:2) post(multi/manage/play_youtube) > 
```