### PR TITLE
bump payloads gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,7 +19,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 1.3.52)
+      metasploit-payloads (= 1.3.53)
       metasploit_data_models
       metasploit_payloads-mettle (= 0.4.2)
       mqtt
@@ -166,7 +166,7 @@ GEM
       activemodel (~> 4.2.6)
       activesupport (~> 4.2.6)
       railties (~> 4.2.6)
-    metasploit-payloads (1.3.52)
+    metasploit-payloads (1.3.53)
     metasploit_data_models (3.0.1)
       activerecord (~> 4.2.6)
       activesupport (~> 4.2.6)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -70,7 +70,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '1.3.52'
+  spec.add_runtime_dependency 'metasploit-payloads', '1.3.53'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '0.4.2'
   # Needed by msfgui and other rpc components

--- a/modules/payloads/singles/php/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/php/meterpreter_reverse_tcp.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/meterpreter_options'
 
 module MetasploitModule
 
-  CachedSize = 30306
+  CachedSize = 30658
 
   include Msf::Payload::Single
   include Msf::Payload::Php::ReverseTcp


### PR DESCRIPTION
Bump payload gem to include updates php payload to supporting ssl

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use exploit/multi/handler`
.....
- [x] **Verify** `php/meterpreter_reverse_tcp` still works

