### PR TITLE
ensure os_flavor can be supplied for non Windows OS

### DIFF
--- a/lib/msf/core/db_manager/host.rb
+++ b/lib/msf/core/db_manager/host.rb
@@ -221,7 +221,9 @@ module Msf::DBManager::Host
         os_name, os_flavor = split_windows_os_name(opts[:os_name])
         opts[:os_name] = os_name if os_name.present?
         if opts[:os_flavor].present?
-          opts[:os_flavor] = os_flavor + opts[:os_flavor]
+          if os_flavor.present? # only prepend if there is a value that needs it
+            opts[:os_flavor] = os_flavor + opts[:os_flavor]
+          end
         else
           opts[:os_flavor] = os_flavor
         end


### PR DESCRIPTION
Allow `os_flavor` to be reported of non Windows OS. When `os_flavor` is reported on a host ensure that existing manipulation to prepend xp/2003 etc. for windows are does cause attempt to concatenate `nil` when used for a non windows OS.

This can be tested with examples like reporting OS in #10798.

## Verification

List the steps needed to make sure this thing works

- [x] test with `db_nmap` and other custom reported hosts
