### PR TITLE
Fix session report bug when database disabled.

### DIFF
--- a/lib/metasploit/framework/data_service/proxy/core.rb
+++ b/lib/metasploit/framework/data_service/proxy/core.rb
@@ -150,6 +150,25 @@ class DataProxy
     return @current_data_service
   end
 
+  # Performs a set of data service operations declared within the block.
+  # This passes the @current_data_service as a parameter to the block.
+  # If there is no current data service registered, the block is not
+  # executed and the method simply returns.
+  def data_service_operation(&block)
+    $stderr.puts("data_service_operation(): #{block_given?}")
+    return unless block_given?
+
+    begin
+      data_service = self.get_data_service
+    rescue
+      $stderr.puts("data_service_operation(): in rescue, returning...")
+      return
+    end
+
+    $stderr.puts("data_service_operation(): calling block...")
+    block.call(data_service) unless data_service.nil?
+  end
+
   def log_error(exception, ui_message)
     elog "#{ui_message}: #{exception.message}"
     exception.backtrace.each { |line| elog "#{line}" }

--- a/lib/metasploit/framework/data_service/proxy/core.rb
+++ b/lib/metasploit/framework/data_service/proxy/core.rb
@@ -152,8 +152,8 @@ class DataProxy
 
   # Performs a set of data service operations declared within the block.
   # This passes the @current_data_service as a parameter to the block.
-  # If there is no current data service registered, the block is not
-  # executed and the method simply returns.
+  # If there is no current data service registered or the data service
+  # is not active, the block is not executed and the method simply returns.
   def data_service_operation(&block)
     return unless block_given?
 
@@ -163,7 +163,7 @@ class DataProxy
       return
     end
 
-    block.call(data_service) unless data_service.nil?
+    block.call(data_service) if !data_service.nil? && self.active
   end
 
   def log_error(exception, ui_message)

--- a/lib/metasploit/framework/data_service/proxy/core.rb
+++ b/lib/metasploit/framework/data_service/proxy/core.rb
@@ -174,7 +174,7 @@ class DataProxy
     exception.backtrace.each { |line| elog "#{line}" }
     # TODO: We should try to surface the original exception, instead of just a generic one.
     # This should not display the full backtrace, only the message.
-    raise Exception, "#{ui_message}: #{exception.message}. See log for more details."
+    raise "#{ui_message}: #{exception.message}. See log for more details."
   end
 
   # Adds a valid workspace value to the opts hash before sending on to the data layer.

--- a/lib/metasploit/framework/data_service/proxy/core.rb
+++ b/lib/metasploit/framework/data_service/proxy/core.rb
@@ -155,17 +155,14 @@ class DataProxy
   # If there is no current data service registered, the block is not
   # executed and the method simply returns.
   def data_service_operation(&block)
-    $stderr.puts("data_service_operation(): #{block_given?}")
     return unless block_given?
 
     begin
       data_service = self.get_data_service
     rescue
-      $stderr.puts("data_service_operation(): in rescue, returning...")
       return
     end
 
-    $stderr.puts("data_service_operation(): calling block...")
     block.call(data_service) unless data_service.nil?
   end
 

--- a/lib/metasploit/framework/data_service/proxy/session_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/session_data_proxy.rb
@@ -10,6 +10,10 @@ module SessionDataProxy
   end
 
   def report_session(opts)
+    unless self.active
+      return
+    end
+
     begin
       data_service = self.get_data_service
       add_opts_workspace(opts)

--- a/lib/metasploit/framework/data_service/proxy/session_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/session_data_proxy.rb
@@ -1,21 +1,21 @@
 module SessionDataProxy
   def sessions(opts={})
     begin
-      data_service = self.get_data_service
-      add_opts_workspace(opts)
-      data_service.sessions(opts)
+      self.data_service_operation do |data_service|
+        add_opts_workspace(opts)
+        data_service.sessions(opts)
+      end
     rescue => e
       self.log_error(e, "Problem retrieving sessions")
     end
   end
 
   def report_session(opts)
-    return unless self.active
-
     begin
-      data_service = self.get_data_service
-      add_opts_workspace(opts)
-      data_service.report_session(opts)
+      self.data_service_operation do |data_service|
+        add_opts_workspace(opts)
+        data_service.report_session(opts)
+      end
     rescue => e
       self.log_error(e, "Problem reporting session")
     end

--- a/lib/metasploit/framework/data_service/proxy/session_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/session_data_proxy.rb
@@ -10,9 +10,7 @@ module SessionDataProxy
   end
 
   def report_session(opts)
-    unless self.active
-      return
-    end
+    return unless self.active
 
     begin
       data_service = self.get_data_service

--- a/lib/metasploit/framework/data_service/proxy/session_event_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/session_event_data_proxy.rb
@@ -1,11 +1,10 @@
 module SessionEventDataProxy
 
   def report_session_event(opts)
-    return unless self.active
-
     begin
-      data_service = self.get_data_service()
-      data_service.report_session_event(opts)
+      self.data_service_operation do |data_service|
+        data_service.report_session_event(opts)
+      end
     rescue => e
       self.log_error(e, "Problem reporting session event")
     end

--- a/lib/metasploit/framework/data_service/proxy/session_event_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/session_event_data_proxy.rb
@@ -1,6 +1,10 @@
 module SessionEventDataProxy
 
   def report_session_event(opts)
+    unless self.active
+      return
+    end
+
     begin
       data_service = self.get_data_service()
       data_service.report_session_event(opts)

--- a/lib/metasploit/framework/data_service/proxy/session_event_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/session_event_data_proxy.rb
@@ -1,9 +1,7 @@
 module SessionEventDataProxy
 
   def report_session_event(opts)
-    unless self.active
-      return
-    end
+    return unless self.active
 
     begin
       data_service = self.get_data_service()


### PR DESCRIPTION
Fix #10129, no session report and `interact` crashed when database disabled.

This fix probably did not fix flawlessly, glad to receive any suggestion!

Maybe related: #9979 

## Verification
### Before 

```
$ ./msfconsole -nq
[-] ***
[-] * WARNING: Database support has been disabled
[-] ***
[*] Starting persistent handler(s)...
msf5 auxiliary(scanner/ssh/libssh_auth_bypass) > options

Module options (auxiliary/scanner/ssh/libssh_auth_bypass):

   Name          Current Setting  Required  Description
   ----          ---------------  --------  -----------
   CHECK_BANNER  true             no        Check banner for libssh
   CMD                            no        Command to execute
   RHOSTS                         yes       The target address range or CIDR identifier
   RPORT         22               yes       The target port
   SPAWN_PTY     false            no        Spawn a PTY
   THREADS       1                yes       The number of concurrent threads

msf5 auxiliary(scanner/ssh/libssh_auth_bypass) > set rhosts 127.0.0.1
rhosts => 127.0.0.1
msf5 auxiliary(scanner/ssh/libssh_auth_bypass) > set rport 2222
rport => 2222
msf5 auxiliary(scanner/ssh/libssh_auth_bypass) > set spawn_pty true
spawn_pty => true
msf5 auxiliary(scanner/ssh/libssh_auth_bypass) > run

[*] 127.0.0.1:2222 - Attempting authentication bypass
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf5 auxiliary(scanner/ssh/libssh_auth_bypass) > sessions

Active sessions
===============

  Id  Name  Type   Information                                                  Connection
  --  ----  ----   -----------                                                  ----------
  1         shell   libssh Authentication Bypass Scanner (SSH-2.0-libssh_0.8.1)  127.0.0.1:62616 -> 127.0.0.1:2222 (127.0.0.1)

msf5 auxiliary(scanner/ssh/libssh_auth_bypass) > sessions -i 1
[*] Starting interaction with 1...

[-] Session manipulation failed: Problem reporting session event: No registered data_service. See log for more details. ["/Users/green/msfdev/metasploit-framework/lib/metasploit/framework/data_service/proxy/core.rb:158:in `log_error'", "/Users/green/msfdev/metasploit-framework/lib/metasploit/framework/data_service/proxy/session_event_data_proxy.rb:8:in `rescue in report_session_event'", "/Users/green/msfdev/metasploit-framework/lib/metasploit/framework/data_service/proxy/session_event_data_proxy.rb:3:in `report_session_event'", "/Users/green/msfdev/metasploit-framework/lib/msf/core/framework.rb:487:in `block in on_session_output'", "/Users/green/msfdev/metasploit-framework/lib/msf/core/framework.rb:485:in `each'", "/Users/green/msfdev/metasploit-framework/lib/msf/core/framework.rb:485:in `on_session_output'", "/Users/green/msfdev/metasploit-framework/lib/msf/core/event_dispatcher.rb:183:in `block in method_missing'", "/Users/green/msfdev/metasploit-framework/lib/msf/core/event_dispatcher.rb:181:in `each'", "/Users/green/msfdev/metasploit-framework/lib/msf/core/event_dispatcher.rb:181:in `method_missing'", "/Users/green/msfdev/metasploit-framework/lib/msf/base/sessions/command_shell.rb:492:in `shell_read'", "/Users/green/msfdev/metasploit-framework/lib/msf/base/sessions/command_shell.rb:611:in `_interact_stream'", "/Users/green/msfdev/metasploit-framework/lib/msf/base/sessions/command_shell.rb:598:in `_interact'", "/Users/green/msfdev/metasploit-framework/lib/rex/ui/interactive.rb:51:in `interact'", "/Users/green/msfdev/metasploit-framework/lib/msf/ui/console/command_dispatcher/core.rb:1362:in `cmd_sessions'", "/Users/green/msfdev/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:502:in `run_command'", "/Users/green/msfdev/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:453:in `block in run_single'", "/Users/green/msfdev/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:447:in `each'", "/Users/green/msfdev/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:447:in `run_single'", "/Users/green/msfdev/metasploit-framework/lib/rex/ui/text/shell.rb:151:in `run'", "/Users/green/msfdev/metasploit-framework/lib/metasploit/framework/command/console.rb:48:in `start'", "/Users/green/msfdev/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'", "./msfconsole:49:in `<main>'"]

```

### After the fix 

```
 ./msfconsole -nq
[-] ***
[-] * WARNING: Database support has been disabled
[-] ***
[*] Starting persistent handler(s)...
msf5 auxiliary(scanner/ssh/libssh_auth_bypass) > options

Module options (auxiliary/scanner/ssh/libssh_auth_bypass):

   Name          Current Setting  Required  Description
   ----          ---------------  --------  -----------
   CHECK_BANNER  true             no        Check banner for libssh
   CMD                            no        Command to execute
   RHOSTS                         yes       The target address range or CIDR identifier
   RPORT         22               yes       The target port
   SPAWN_PTY     false            no        Spawn a PTY
   THREADS       1                yes       The number of concurrent threads

msf5 auxiliary(scanner/ssh/libssh_auth_bypass) > set rhosts 127.0.0.1
rhosts => 127.0.0.1
msf5 auxiliary(scanner/ssh/libssh_auth_bypass) > set rport 2222
rport => 2222
msf5 auxiliary(scanner/ssh/libssh_auth_bypass) > set spawn_pty true
spawn_pty => true
msf5 auxiliary(scanner/ssh/libssh_auth_bypass) > run

[*] 127.0.0.1:2222 - Attempting authentication bypass
[*] Command shell session 1 opened (127.0.0.1:62598 -> 127.0.0.1:2222) at 2018-10-24 14:54:01 +0800
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf5 auxiliary(scanner/ssh/libssh_auth_bypass) > sessions -i 1
[*] Starting interaction with 1...

# id
id
uid=0(root) gid=0(root) groups=0(root)
# whoami
whoami
root
# ^Z
Background session 1? [y/N]  y
msf5 auxiliary(scanner/ssh/libssh_auth_bypass) >
```

