### PR TITLE
Add applicable notes to my exploit modules

### DIFF
--- a/modules/exploits/linux/http/empire_skywalker.rb
+++ b/modules/exploits/linux/http/empire_skywalker.rb
@@ -44,7 +44,14 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'DefaultOptions'  => { 'WfsDelay' => 75 },
       'DefaultTarget'   => 0,
-      'DisclosureDate'  => 'Oct 15 2016'))
+      'DisclosureDate'  => 'Oct 15 2016',
+      'Notes'           =>
+        {
+          'Stability'   => [ CRASH_SAFE, ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, ],
+          'Reliability' => [ REPEATABLE_SESSION, ],
+        },
+    ))
 
     register_options(
       [

--- a/modules/exploits/multi/ftp/pureftpd_bash_env_exec.rb
+++ b/modules/exploits/multi/ftp/pureftpd_bash_env_exec.rb
@@ -62,10 +62,13 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'DefaultTarget'  => 0,
       'DisclosureDate' => 'Sep 24 2014',
-      'Notes' =>
-          {
-              'AKA' => ['Shellshock']
-          }
+      'Notes'          =>
+        {
+          'AKA'         => [ 'Shellshock' ],
+          'Stability'   => [ CRASH_SAFE, ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS, ],
+          'Reliability' => [ REPEATABLE_SESSION, ],
+        },
     ))
     register_options(
       [

--- a/modules/exploits/multi/http/jenkins_script_console.rb
+++ b/modules/exploits/multi/http/jenkins_script_console.rb
@@ -16,7 +16,7 @@ class MetasploitModule < Msf::Exploit::Remote
           This module uses the Jenkins-CI Groovy script console to execute
         OS commands using Java.
       },
-      'Author'	=>
+      'Author' =>
         [
           'Spencer McIntyre',
           'jamcut',
@@ -45,7 +45,14 @@ class MetasploitModule < Msf::Exploit::Remote
           ['Unix CMD', {'Arch'  => ARCH_CMD, 'Platform' => 'unix', 'Payload' => {'BadChars' => "\x22"}}]
         ],
       'DisclosureDate' => 'Jan 18 2013',
-      'DefaultTarget'  => 0))
+      'DefaultTarget'  => 0,
+      'Notes'          =>
+        {
+          'Stability'   => [ CRASH_SAFE, ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS, ],
+          'Reliability' => [ REPEATABLE_SESSION, ],
+        },
+    ))
 
     register_options(
       [

--- a/modules/exploits/multi/http/netwin_surgeftp_exec.rb
+++ b/modules/exploits/multi/http/netwin_surgeftp_exec.rb
@@ -34,7 +34,14 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'Windows', { 'Arch'=>ARCH_X86, 'Platform'=>'win', 'CmdStagerFlavor' => 'vbs'}  ],
           [ 'Unix',    { 'Arch'=>ARCH_CMD, 'Platform'=>'unix', 'Payload'=>{'BadChars' => "\x22"}} ]
         ],
-      'DisclosureDate' => 'Dec 06 2012'))
+      'DisclosureDate' => 'Dec 06 2012',
+      'Notes'          =>
+        {
+          'Stability'   => [ CRASH_SAFE, ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS, ],
+          'Reliability' => [ REPEATABLE_SESSION, ],
+        },
+    ))
 
     register_options(
       [

--- a/modules/exploits/multi/http/phpmailer_arg_injection.rb
+++ b/modules/exploits/multi/http/phpmailer_arg_injection.rb
@@ -43,7 +43,13 @@ class MetasploitModule < Msf::Exploit::Remote
         ['PHPMailer <5.2.18', {}],
         ['PHPMailer 5.2.18 - 5.2.19', {}]
       ],
-      'DefaultTarget'  => 0
+      'DefaultTarget'  => 0,
+      'Notes'          =>
+        {
+          'Stability'   => [ CRASH_SAFE, ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS, ],
+          'Reliability' => [ REPEATABLE_SESSION, ],
+        },
     ))
 
     register_options(

--- a/modules/exploits/multi/ssh/sshexec.rb
+++ b/modules/exploits/multi/ssh/sshexec.rb
@@ -113,7 +113,13 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'DefaultTarget'    => 0,
       # For the CVE
-      'DisclosureDate'   => 'Jan 01 1999'
+      'DisclosureDate'   => 'Jan 01 1999',
+      'Notes'            =>
+        {
+          'Stability'   => [ CRASH_SAFE, ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS, ],
+          'Reliability' => [ REPEATABLE_SESSION, ],
+        },
     )
 
     register_options(

--- a/modules/exploits/unix/http/lifesize_room.rb
+++ b/modules/exploits/unix/http/lifesize_room.rb
@@ -43,7 +43,13 @@ class MetasploitModule < Msf::Exploit::Remote
       'Arch'           => ARCH_CMD,
       'Targets'        => [ [ 'Automatic', { } ] ],
       'DisclosureDate' => 'Jul 13 2011',
-      'DefaultTarget'  => 0))
+      'DefaultTarget'  => 0,
+      'Notes'          =>
+        {
+          'Stability'   => [ CRASH_SAFE, ],
+          'Reliability' => [ REPEATABLE_SESSION, ],
+        },
+    ))
   end
 
   def exploit

--- a/modules/exploits/windows/fileformat/blazedvd_plf.rb
+++ b/modules/exploits/windows/fileformat/blazedvd_plf.rb
@@ -67,7 +67,13 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'Privileged'     => false,
       'DisclosureDate' => 'Aug 03 2009',
-      'DefaultTarget'  => 0))
+      'DefaultTarget'  => 0,
+      'Notes'          =>
+        {
+          'Stability'   => [ CRASH_SERVICE_DOWN, ],
+          'SideEffects' => [ SCREEN_EFFECTS, ],
+        },
+    ))
 
     register_options(
       [

--- a/modules/exploits/windows/fileformat/cve_2017_8464_lnk_rce.rb
+++ b/modules/exploits/windows/fileformat/cve_2017_8464_lnk_rce.rb
@@ -63,7 +63,11 @@ class MetasploitModule < Msf::Exploit::Remote
             [ 'Windows x86', { 'Arch' => ARCH_X86 } ]
           ],
         'DefaultTarget'   => 0, # Default target is Automatic
-        'DisclosureDate'  => 'Jun 13 2017'
+        'DisclosureDate'  => 'Jun 13 2017',
+        'Notes'           =>
+          {
+            'Stability'   => [ CRASH_SERVICE_RESTARTS, ],
+          },
       )
     )
 

--- a/modules/exploits/windows/fileformat/ms14_017_rtf.rb
+++ b/modules/exploits/windows/fileformat/ms14_017_rtf.rb
@@ -49,7 +49,13 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'DefaultTarget'  => 0,
       'Privileged'     => true,
-      'DisclosureDate' => 'Apr 1 2014'))
+      'DisclosureDate' => 'Apr 1 2014',
+      'Notes'          =>
+        {
+          'Stability'   => [ CRASH_SERVICE_DOWN, ],
+          'SideEffects' => [ SCREEN_EFFECTS, ],
+        },
+    ))
 
     register_options(
       [

--- a/modules/exploits/windows/local/cve_2017_8464_lnk_lpe.rb
+++ b/modules/exploits/windows/local/cve_2017_8464_lnk_lpe.rb
@@ -65,7 +65,12 @@ class MetasploitModule < Msf::Exploit::Local
             [ 'Windows x86', { 'Arch' => ARCH_X86 } ]
           ],
         'DefaultTarget'   => 0, # Default target is Automatic
-        'DisclosureDate'  => 'Jun 13 2017'
+        'DisclosureDate'  => 'Jun 13 2017',
+        'Notes'           =>
+          {
+            'Stability'   => [ CRASH_SERVICE_RESTARTS, ],
+            'SideEffects' => [ ARTIFACTS_ON_DISK, ],
+          },
       )
     )
 

--- a/modules/exploits/windows/local/mqac_write.rb
+++ b/modules/exploits/windows/local/mqac_write.rb
@@ -54,7 +54,11 @@ class MetasploitModule < Msf::Exploit::Local
           ['URL', 'https://www.korelogic.com/Resources/Advisories/KL-001-2014-003.txt']
         ],
       'DisclosureDate' => 'Jul 22 2014',
-      'DefaultTarget'  => 0
+      'DefaultTarget'  => 0,
+      'Notes'          =>
+        {
+          'Stability'   => [ CRASH_OS_RESTARTS, ],
+        }
     ))
   end
 

--- a/modules/exploits/windows/local/ms11_080_afdjoinleaf.rb
+++ b/modules/exploits/windows/local/ms11_080_afdjoinleaf.rb
@@ -75,7 +75,11 @@ class MetasploitModule < Msf::Exploit::Local
           %w(URL http://www.offensive-security.com/vulndev/ms11-080-voyage-into-ring-zero/)
         ],
       'DisclosureDate' => 'Nov 30 2011',
-      'DefaultTarget'  => 0
+      'DefaultTarget'  => 0,
+      'Notes'          =>
+        {
+          'Stability'   => [ CRASH_OS_RESTARTS, ],
+        },
     }))
   end
 

--- a/modules/exploits/windows/local/ms13_081_track_popup_menu.rb
+++ b/modules/exploits/windows/local/ms13_081_track_popup_menu.rb
@@ -57,7 +57,11 @@ class MetasploitModule < Msf::Exploit::Local
           [ 'URL', 'http://immunityproducts.blogspot.com/2013/11/exploiting-cve-2013-3881-win32k-null.html' ]
         ],
       'DisclosureDate' => 'Oct 08 2013',
-      'DefaultTarget'  => 0
+      'DefaultTarget'  => 0,
+      'Notes'          =>
+        {
+          'Stability'   => [ CRASH_OS_RESTARTS, ],
+        },
     }))
   end
 

--- a/modules/exploits/windows/local/ms14_058_track_popup_menu.rb
+++ b/modules/exploits/windows/local/ms14_058_track_popup_menu.rb
@@ -67,7 +67,11 @@ class MetasploitModule < Msf::Exploit::Local
           ['URL', 'http://blog.trendmicro.com/trendlabs-security-intelligence/an-analysis-of-a-windows-kernel-mode-vulnerability-cve-2014-4113/']
         ],
       'DisclosureDate' => 'Oct 14 2014',
-      'DefaultTarget'  => 0
+      'DefaultTarget'  => 0,
+      'Notes'          =>
+        {
+          'Stability'   => [ CRASH_OS_RESTARTS, ],
+        },
     }))
   end
 

--- a/modules/exploits/windows/local/ms15_051_client_copy_image.rb
+++ b/modules/exploits/windows/local/ms15_051_client_copy_image.rb
@@ -51,7 +51,11 @@ class MetasploitModule < Msf::Exploit::Local
           ['URL', 'https://technet.microsoft.com/library/security/MS15-051']
         ],
       'DisclosureDate'  => 'May 12 2015',
-      'DefaultTarget'   => 0
+      'DefaultTarget'   => 0,
+      'Notes' =>
+        {
+          'Stability'   => [ CRASH_OS_RESTARTS,  ],
+        },
     }))
   end
 

--- a/modules/exploits/windows/local/razer_zwopenprocess.rb
+++ b/modules/exploits/windows/local/razer_zwopenprocess.rb
@@ -66,7 +66,14 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'DefaultTarget'  => 0,
       'Privileged'     => true,
-      'DisclosureDate' => 'Mar 22 2017'))
+      'DisclosureDate' => 'Mar 22 2017',
+      'Notes'          =>
+        {
+          'Stability'   => [ CRASH_SERVICE_RESTARTS ],
+          'SideEffects' => [ SCREEN_EFFECTS ],
+          'Reliability' => [ REPEATABLE_SESSION ],
+        },
+      ))
   end
 
   def check

--- a/modules/exploits/windows/misc/fb_cnct_group.rb
+++ b/modules/exploits/windows/misc/fb_cnct_group.rb
@@ -54,7 +54,11 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'DefaultTarget'  => 0,
       'Privileged'     => true,
-      'DisclosureDate' => 'Jan 31 2013'
+      'DisclosureDate' => 'Jan 31 2013',
+      'Notes'          =>
+        {
+          'Stability' => [ CRASH_SERVICE_RESTARTS ],
+        },
     )
 
     register_options([Opt::RPORT(3050)])

--- a/modules/exploits/windows/misc/hta_server.rb
+++ b/modules/exploits/windows/misc/hta_server.rb
@@ -31,7 +31,12 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'Powershell x64', { 'Platform' => 'win', 'Arch' => ARCH_X64 } ]
         ],
       'DefaultTarget'  => 0,
-      'DisclosureDate' => 'Oct 06 2016'
+      'DisclosureDate' => 'Oct 06 2016',
+      'Notes'          =>
+        {
+          'SideEffects' => [ SCREEN_EFFECTS ],
+          'Stability'   => [ CRASH_SAFE ],
+        },
     ))
   end
 

--- a/modules/exploits/windows/misc/lianja_db_net.rb
+++ b/modules/exploits/windows/misc/lianja_db_net.rb
@@ -40,7 +40,12 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'DefaultTarget'  => 0,
       'Privileged'     => true,
-      'DisclosureDate' => 'May 22 2013'))
+      'DisclosureDate' => 'May 22 2013',
+      'Notes'          =>
+        {
+          'Stability'  => [ CRASH_SERVICE_RESTARTS ],
+        },
+    ))
 
     register_options(
       [


### PR DESCRIPTION
This pull request populates the `Notes` field with metadata for all of the exploit modules of which I am listed as an author. The additional fields were added in PR #10707 and provide alot of value by allowing the operator to make more informed decisions.

There's no new code to test here, just additional metadata.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `grep exploit search Spencer McIntyre`
- [ ] Use `info exploit/module/path` to view the module information
  - [ ] See if it makes sense

For the reliability tag, I hesitated to apply `REPEATABLE_SESSION` to ones which *should* yield a session each time they're run but may crash some kind of service (and thus not yield a session). Not sure if my interpretation is correct here but I think it's used to indicate to the module operator if it's safe to use repeatedly?