### PR TITLE
Issue 10166 opt base validation

### DIFF
--- a/lib/msf/core/opt_base.rb
+++ b/lib/msf/core/opt_base.rb
@@ -107,7 +107,7 @@ module Msf
     end
 
     #
-    # If it's required and the value is nil or empty, then it's not valid.
+    # If it's required and the value is nil, then it's not valid.
     #
     def valid?(value, check_empty: true)
       if value.nil? && required?

--- a/lib/msf/core/opt_base.rb
+++ b/lib/msf/core/opt_base.rb
@@ -110,7 +110,7 @@ module Msf
     # If it's required and the value is nil or empty, then it's not valid.
     #
     def valid?(value, check_empty: true)
-      if check_empty && required?
+      if value.nil? && required?
         # required variable not set
         return false if (value.nil? || value.to_s.empty?)
       end


### PR DESCRIPTION
Changes `check_empty` to `value.nil?` in `/lib/msf/core/top_base.rb` to be more consistent with other validation methods. Updated the comment to reflect the change; no longer checks if empty.

Relevant Issue: [OptString validation wants to be ok with an empty string, but Base doesn't. #10166](https://github.com/rapid7/metasploit-framework/issues/10166)

## Verification

- [ ] Run `rake spec` 
- [ ] Create a `.txt` file for rake's output
- [ ] In said `.txt` file check for failures marked by "F"

