### PR TITLE
Fix Net::SSH::CommandStream session open failure

### DIFF
--- a/documentation/modules/auxiliary/scanner/ssh/libssh_auth_bypass.md
+++ b/documentation/modules/auxiliary/scanner/ssh/libssh_auth_bypass.md
@@ -122,7 +122,14 @@ msf5 auxiliary(scanner/ssh/libssh_auth_bypass) > run
 
 [*] 172.28.128.3:2222 - Attempting authentication bypass
 [+] 172.28.128.3:2222 - SSH-2.0-libssh_0.8.3 appears to be unpatched
-[-] 172.28.128.3:2222 - shell/exec channel request failed
+[-] 172.28.128.3:2222 - Net::SSH::ChannelOpenFailed: Session channel open failed (1)
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+msf5 auxiliary(scanner/ssh/libssh_auth_bypass) > run
+
+[*] 172.28.128.3:2222 - Attempting authentication bypass
+[+] 172.28.128.3:2222 - SSH-2.0-libssh_0.8.3 appears to be unpatched
+[-] 172.28.128.3:2222 - Net::SSH::ChannelRequestFailed: Shell/exec channel request failed
 [*] Scanned 1 of 1 hosts (100% complete)
 [*] Auxiliary module execution completed
 msf5 auxiliary(scanner/ssh/libssh_auth_bypass) >

--- a/modules/auxiliary/scanner/ssh/libssh_auth_bypass.rb
+++ b/modules/auxiliary/scanner/ssh/libssh_auth_bypass.rb
@@ -130,8 +130,8 @@ class MetasploitModule < Msf::Auxiliary
     # XXX: Wait for CommandStream to log a channel request failure
     sleep 0.1
 
-    if shell.error
-      print_error("#{ip}:#{rport} - #{shell.error}")
+    if (e = shell.error)
+      print_error("#{ip}:#{rport} - #{e.class}: #{e.message}")
       return
     end
 
@@ -139,10 +139,10 @@ class MetasploitModule < Msf::Auxiliary
     when 'Shell'
       start_session(self, "#{self.name} (#{version})", {}, false, shell.lsock)
     when 'Execute'
-      output = shell.channel[:data].chomp
+      output = shell.channel && (shell.channel[:data] || '').chomp
 
       if output.blank?
-        print_error("Empty or blank output: #{datastore['CMD']}")
+        print_error("#{ip}:#{rport} - Empty or blank command output")
         return
       end
 


### PR DESCRIPTION
# Repro was never given for this issue

I suspected this might be a problem for libssh servers.

```
04:37 < patap0n> [*] 192.168.1.103:22 - Attempting authentication bypass
04:37 < patap0n> [-] Auxiliary failed: NoMethodError undefined method `[]' for nil:NilClass
04:37 < patap0n> [-] Call stack:
04:37 < patap0n> [-]   /opt/metasploit-framework/embedded/framework/modules/auxiliary/scanner/ssh/libssh_auth_bypass.rb:142:in `run_host'
04:37 < patap0n> [-]   /opt/metasploit-framework/embedded/framework/lib/msf/core/auxiliary/scanner.rb:135:in `block (2 levels) in run'
04:37 < patap0n> [-]   /opt/metasploit-framework/embedded/framework/lib/msf/core/thread_manager.rb:100:in `block in spawn'
04:37 < patap0n> [*] Auxiliary module execution completed
```

```
msf5 auxiliary(scanner/ssh/libssh_auth_bypass) > run

[*] 127.0.0.1:22 - Attempting authentication bypass
[+] 127.0.0.1:22 - SSH-2.0-libssh_0.8.3 appears to be unpatched
[-] 127.0.0.1:22 - Net::SSH::ChannelOpenFailed: Session channel open failed (1)
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf5 auxiliary(scanner/ssh/libssh_auth_bypass) > run

[*] 127.0.0.1:22 - Attempting authentication bypass
[+] 127.0.0.1:22 - SSH-2.0-libssh_0.8.3 appears to be unpatched
[-] 127.0.0.1:22 - Net::SSH::ChannelRequestFailed: Shell/exec channel request failed
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf5 auxiliary(scanner/ssh/libssh_auth_bypass) >
```

Note that this fixes the library primarily and hedges the module.

#10820, #10855