### PR TITLE
Update vmware_http_login

### DIFF
--- a/modules/auxiliary/scanner/vmware/vmware_http_login.rb
+++ b/modules/auxiliary/scanner/vmware/vmware_http_login.rb
@@ -131,7 +131,7 @@ class MetasploitModule < Msf::Auxiliary
       if os_match[1] =~ /ESX/ or os_match[1] =~ /vCenter/
         # Report a fingerprint match for OS identification
         report_note(
-          :host  => ip,
+          :host  => rhost,
           :ntype => 'fingerprint.match',
           :data  => {'os.vendor' => 'VMware', 'os.product' => os_match[1] + " " + ver_match[1], 'os.version' => build_match[1] }
         )

--- a/modules/auxiliary/scanner/vmware/vmware_http_login.rb
+++ b/modules/auxiliary/scanner/vmware/vmware_http_login.rb
@@ -75,7 +75,6 @@ class MetasploitModule < Msf::Auxiliary
     }
   end
 
-
   # Mostly taken from the Apache Tomcat service validator
   def is_vmware?
     soap_data =
@@ -87,27 +86,25 @@ class MetasploitModule < Msf::Auxiliary
       </env:Body>
       </env:Envelope>|
 
-    begin
-      res = send_request_cgi({
-        'uri'     => normalize_uri(datastore['URI']),
-        'method'  => 'POST',
-        'agent'   => 'VMware VI Client',
-        'data'    => soap_data
-      }, 25)
+    res = send_request_cgi({
+      'uri'     => normalize_uri(datastore['URI']),
+      'method'  => 'POST',
+      'agent'   => 'VMware VI Client',
+      'data'    => soap_data
+    }, 25)
 
-      if res
-        fingerprint_vmware(res)
-      else
-        vprint_error("#{rhost}:#{rport} Error: no response")
-      end
-
-    rescue ::Rex::ConnectionError => e
-      vprint_error("#{rhost}:#{rport} Error: could not connect")
-      return false
-    rescue => e
-      vprint_error("#{rhost}:#{rport} Error: #{e}")
+    unless res
+      vprint_error("#{rhost}:#{rport} Error: no response")
       return false
     end
+
+    fingerprint_vmware(res)
+  rescue ::Rex::ConnectionError => e
+    vprint_error("#{rhost}:#{rport} Error: could not connect")
+    return false
+  rescue => e
+    vprint_error("#{rhost}:#{rport} Error: #{e}")
+    return false
   end
 
   def fingerprint_vmware(res)
@@ -127,22 +124,19 @@ class MetasploitModule < Msf::Auxiliary
       report_service(:host => rhost, :port => rport, :proto => 'tcp', :sname => 'https', :info => full_match[1])
     end
 
-    if os_match and ver_match and build_match
-      if os_match[1] =~ /ESX/ or os_match[1] =~ /vCenter/
-        # Report a fingerprint match for OS identification
-        report_note(
-          :host  => rhost,
-          :ntype => 'fingerprint.match',
-          :data  => {'os.vendor' => 'VMware', 'os.product' => os_match[1] + " " + ver_match[1], 'os.version' => build_match[1] }
-        )
-      end
-      return true
-    else
-      vprint_error("#{rhost}:#{rport} Error: Could not identify as VMWare")
+    unless os_match and ver_match and build_match
+      vprint_error("#{rhost}:#{rport} Error: Could not identify host as VMWare")
       return false
     end
 
+    if os_match[1].include?('ESX') || os_match[1].include?('vCenter')
+      # Report a fingerprint match for OS identification
+      report_note(
+        :host  => rhost,
+        :ntype => 'fingerprint.match',
+        :data  => {'os.vendor' => 'VMware', 'os.product' => os_match[1] + " " + ver_match[1], 'os.version' => build_match[1] }
+      )
+      return true
+    end
   end
-
-
 end

--- a/modules/auxiliary/scanner/vmware/vmware_http_login.rb
+++ b/modules/auxiliary/scanner/vmware/vmware_http_login.rb
@@ -104,7 +104,7 @@ class MetasploitModule < Msf::Auxiliary
     rescue ::Rex::ConnectionError => e
       vprint_error("#{rhost}:#{rport} Error: could not connect")
       return false
-    rescue
+    rescue => e
       vprint_error("#{rhost}:#{rport} Error: #{e}")
       return false
     end


### PR DESCRIPTION
Fix issue where reporting a host would fail as `ip` was undefined.

Fix issue where error messages weren't printed in the event of an error.

Update style to be defensive and utilize rescue-from-method technique.
