### PR TITLE
pin concurrent-ruby to 1.0.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,7 @@ PATH
       bcrypt
       bcrypt_pbkdf
       bit-struct
+      concurrent-ruby (= 1.0.5)
       dnsruby
       ed25519
       faker
@@ -117,7 +118,7 @@ GEM
     bit-struct (0.16)
     builder (3.2.3)
     coderay (1.1.2)
-    concurrent-ruby (1.1.0)
+    concurrent-ruby (1.0.5)
     crass (1.0.4)
     daemons (1.2.6)
     diff-lcs (1.3)
@@ -372,4 +373,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.16.4
+   1.17.1

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -195,4 +195,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'xdr'
   # Needed for ::Msf...CertProvider
   spec.add_runtime_dependency 'faker'
+  # Pinned as a dependency of i18n to the last working version
+  spec.add_runtime_dependency 'concurrent-ruby','1.0.5'
 end


### PR DESCRIPTION
1.1.0 is not available yet

