### PR TITLE
Preserve old thread exception reporting behavior

### DIFF
--- a/lib/msf/core/thread_manager.rb
+++ b/lib/msf/core/thread_manager.rb
@@ -56,6 +56,10 @@ class ThreadManager < Array
   def initialize(framework)
     self.framework = framework
     self.monitor   = spawn_monitor
+
+    # XXX: Preserve Ruby < 2.5 thread exception reporting behavior
+    # https://ruby-doc.org/core-2.5.0/Thread.html#method-c-report_on_exception
+    Thread.report_on_exception = false
   end
 
   #


### PR DESCRIPTION
https://ruby-doc.org/core-2.5.0/Thread.html#method-c-report_on_exception

Current behavior (as of Ruby 2.5):

```
msf5 auxiliary(scanner/ssh/libssh_auth_bypass) > run
#<Thread:0x00007fbd6cf28a10@/Users/wvu/metasploit-framework/lib/msf/core/thread_manager.rb:93 run> terminated with exception (report_on_exception is true):
Traceback (most recent call last):
	3: from /Users/wvu/metasploit-framework/lib/msf/core/thread_manager.rb:100:in `block in spawn'
	2: from /Users/wvu/metasploit-framework/lib/msf/core/auxiliary/scanner.rb:111:in `block (2 levels) in run'
	1: from /Users/wvu/metasploit-framework/modules/auxiliary/scanner/ssh/libssh_auth_bypass.rb:81:in `run_host'
/Users/wvu/metasploit-framework/lib/msf/core/auxiliary.rb:163:in `fail_with': bad-config: Execute action requires CMD to be set (Msf::Auxiliary::Failed)

[-] Auxiliary aborted due to failure: bad-config: Execute action requires CMD to be set
[*] Auxiliary module execution completed
msf5 auxiliary(scanner/ssh/libssh_auth_bypass) >
```

Intended (previous) behavior:

```
msf5 auxiliary(scanner/ssh/libssh_auth_bypass) > run

[-] Auxiliary aborted due to failure: bad-config: Execute action requires CMD to be set
[*] Auxiliary module execution completed
msf5 auxiliary(scanner/ssh/libssh_auth_bypass) >
```

Flipping it on again at will:

```
msf5 auxiliary(scanner/ssh/libssh_auth_bypass) > irb -e Thread.report_on_exception=true
msf5 auxiliary(scanner/ssh/libssh_auth_bypass) > run
#<Thread:0x00007fc5236cd4b0@/Users/wvu/metasploit-framework/lib/msf/core/thread_manager.rb:97 run> terminated with exception (report_on_exception is true):
Traceback (most recent call last):
	3: from /Users/wvu/metasploit-framework/lib/msf/core/thread_manager.rb:104:in `block in spawn'
	2: from /Users/wvu/metasploit-framework/lib/msf/core/auxiliary/scanner.rb:111:in `block (2 levels) in run'
	1: from /Users/wvu/metasploit-framework/modules/auxiliary/scanner/ssh/libssh_auth_bypass.rb:81:in `run_host'
/Users/wvu/metasploit-framework/lib/msf/core/auxiliary.rb:163:in `fail_with': bad-config: Execute action requires CMD to be set (Msf::Auxiliary::Failed)

[-] Auxiliary aborted due to failure: bad-config: Execute action requires CMD to be set
[*] Auxiliary module execution completed
msf5 auxiliary(scanner/ssh/libssh_auth_bypass) >
```

Fixes https://github.com/rapid7/metasploit-framework/pull/10855#issuecomment-432331542.