### PR TITLE
Turn off thread exception reporting only if it's an available method

### DIFF
--- a/lib/msf/core/thread_manager.rb
+++ b/lib/msf/core/thread_manager.rb
@@ -59,7 +59,7 @@ class ThreadManager < Array
 
     # XXX: Preserve Ruby < 2.5 thread exception reporting behavior
     # https://ruby-doc.org/core-2.5.0/Thread.html#method-c-report_on_exception
-    if Thread.respond_to?(:report_on_exception=)
+    if Thread.method_defined?(:report_on_exception=)
       Thread.report_on_exception = false
     end
   end

--- a/lib/msf/core/thread_manager.rb
+++ b/lib/msf/core/thread_manager.rb
@@ -59,7 +59,7 @@ class ThreadManager < Array
 
     # XXX: Preserve Ruby < 2.5 thread exception reporting behavior
     # https://ruby-doc.org/core-2.5.0/Thread.html#method-c-report_on_exception
-    if Thread.respond_to?(:report_on_exception)
+    if Thread.respond_to?(:report_on_exception=)
       Thread.report_on_exception = false
     end
   end

--- a/lib/msf/core/thread_manager.rb
+++ b/lib/msf/core/thread_manager.rb
@@ -59,7 +59,7 @@ class ThreadManager < Array
 
     # XXX: Preserve Ruby < 2.5 thread exception reporting behavior
     # https://ruby-doc.org/core-2.5.0/Thread.html#method-c-report_on_exception
-    Thread.report_on_exception = false
+    Thread.report_on_exception = false if Thread.report_on_exception
   end
 
   #

--- a/lib/msf/core/thread_manager.rb
+++ b/lib/msf/core/thread_manager.rb
@@ -59,7 +59,9 @@ class ThreadManager < Array
 
     # XXX: Preserve Ruby < 2.5 thread exception reporting behavior
     # https://ruby-doc.org/core-2.5.0/Thread.html#method-c-report_on_exception
-    Thread.report_on_exception = false if Thread.report_on_exception
+    if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.5.0')
+      Thread.report_on_exception = false if Thread.report_on_exception
+    end
   end
 
   #

--- a/lib/msf/core/thread_manager.rb
+++ b/lib/msf/core/thread_manager.rb
@@ -59,8 +59,8 @@ class ThreadManager < Array
 
     # XXX: Preserve Ruby < 2.5 thread exception reporting behavior
     # https://ruby-doc.org/core-2.5.0/Thread.html#method-c-report_on_exception
-    if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.5.0')
-      Thread.report_on_exception = false if Thread.report_on_exception
+    if Thread.respond_to?(:report_on_exception)
+      Thread.report_on_exception = false
     end
   end
 


### PR DESCRIPTION
Seems that Ruby 2.3.8 has issues with always turning off thread reporting on exceptions. Strange since it should already be off.

**Update: `Thread::report_on_exception` doesn't exist in 2.3.8. The error was swallowed in our tests.**

Fixes #10899.