### PR TITLE
Use `writable?` method for local modules

### DIFF
--- a/modules/exploits/linux/local/af_packet_chocobo_root_priv_esc.rb
+++ b/modules/exploits/linux/local/af_packet_chocobo_root_priv_esc.rb
@@ -176,7 +176,7 @@ class MetasploitModule < Msf::Exploit::Local
       fail_with Failure::BadConfig, 'Session already has root privileges'
     end
 
-    unless cmd_exec("test -w '#{base_dir}' && echo true").include? 'true'
+    unless writable? base_dir
       fail_with Failure::BadConfig, "#{base_dir} is not writable"
     end
 

--- a/modules/exploits/linux/local/af_packet_packet_set_ring_priv_esc.rb
+++ b/modules/exploits/linux/local/af_packet_packet_set_ring_priv_esc.rb
@@ -172,7 +172,7 @@ class MetasploitModule < Msf::Exploit::Local
       fail_with Failure::BadConfig, 'Session already has root privileges'
     end
 
-    unless cmd_exec("test -w '#{base_dir}' && echo true").include? 'true'
+    unless writable? base_dir
       fail_with Failure::BadConfig, "#{base_dir} is not writable"
     end
 

--- a/modules/exploits/linux/local/bpf_priv_esc.rb
+++ b/modules/exploits/linux/local/bpf_priv_esc.rb
@@ -50,11 +50,13 @@ class MetasploitModule < Msf::Exploit::Local
         'Privileged'     => true
       }
       ))
-    register_options([
-        OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ]),
-        OptEnum.new('COMPILE', [ true, 'Compile on target', 'Auto', ['Auto', 'True', 'False']]),
-        OptInt.new('MAXWAIT', [ true, 'Max seconds to wait for decrementation in seconds', 120 ])
-      ])
+    register_options [
+      OptEnum.new('COMPILE', [ true, 'Compile on target', 'Auto', ['Auto', 'True', 'False']]),
+      OptInt.new('MAXWAIT', [ true, 'Max seconds to wait for decrementation in seconds', 120 ])
+    ]
+    register_advanced_options [
+      OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ]),
+    ]
   end
 
   def check

--- a/modules/exploits/linux/local/bpf_sign_extension_priv_esc.rb
+++ b/modules/exploits/linux/local/bpf_sign_extension_priv_esc.rb
@@ -185,7 +185,7 @@ class MetasploitModule < Msf::Exploit::Local
       fail_with Failure::BadConfig, 'Session already has root privileges'
     end
 
-    unless cmd_exec("test -w '#{base_dir}' && echo true").include? 'true'
+    unless writable? base_dir
       fail_with Failure::BadConfig, "#{base_dir} is not writable"
     end
 

--- a/modules/exploits/linux/local/glibc_realpath_priv_esc.rb
+++ b/modules/exploits/linux/local/glibc_realpath_priv_esc.rb
@@ -169,7 +169,7 @@ class MetasploitModule < Msf::Exploit::Local
       fail_with Failure::NotVulnerable, 'Target is not vulnerable'
     end
 
-    unless cmd_exec("test -w '#{base_dir}' && echo true").include? 'true'
+    unless writable? base_dir
       fail_with Failure::BadConfig, "#{base_dir} is not writable"
     end
 

--- a/modules/exploits/linux/local/libuser_roothelper_priv_esc.rb
+++ b/modules/exploits/linux/local/libuser_roothelper_priv_esc.rb
@@ -165,7 +165,7 @@ class MetasploitModule < Msf::Exploit::Local
       fail_with Failure::BadConfig, 'Session already has root privileges'
     end
 
-    unless cmd_exec("test -w '#{base_dir}' && echo true").include? 'true'
+    unless writable? base_dir
       fail_with Failure::BadConfig, "#{base_dir} is not writable"
     end
 

--- a/modules/exploits/linux/local/rc_local_persistence.rb
+++ b/modules/exploits/linux/local/rc_local_persistence.rb
@@ -36,22 +36,22 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    unless cmd_exec("test -w '/etc/rc.local' && echo true").include? 'true'
-      fail_with Failure::BadConfig, '/etc/rc.local is not writable'
+    rc_path = '/etc/rc.local'
+
+    unless writable? rc_path
+      fail_with Failure::BadConfig, "#{rc_path} is not writable"
     end
 
-    print_status('Reading /etc/rc.local')
+    print_status "Reading #{rc_path}"
 
     # read /etc/rc.local, but remove `exit 0`
-    rc_local = read_file('/etc/rc.local').gsub(/^exit.*$/, '')
+    rc_local = read_file(rc_path).gsub(/^exit.*$/, '')
 
     # add payload and put back `exit 0`
     rc_local << "\n#{payload.encoded}\nexit 0\n"
 
     # write new file
-    print_status('Patching /etc/rc.local')
-    write_file('/etc/rc.local', rc_local)
+    print_status "Patching #{rc_path}"
+    write_file(rc_path, rc_local)
   end
 end
-
-

--- a/modules/exploits/linux/local/rds_priv_esc.rb
+++ b/modules/exploits/linux/local/rds_priv_esc.rb
@@ -158,7 +158,7 @@ class MetasploitModule < Msf::Exploit::Local
       fail_with Failure::BadConfig, 'Session already has root privileges'
     end
 
-    unless cmd_exec("test -w '#{base_dir}' && echo true").include? 'true'
+    unless writable? base_dir
       fail_with Failure::BadConfig, "#{base_dir} is not writable"
     end
 

--- a/modules/exploits/linux/local/recvmmsg_priv_esc.rb
+++ b/modules/exploits/linux/local/recvmmsg_priv_esc.rb
@@ -149,7 +149,7 @@ class MetasploitModule < Msf::Exploit::Local
       fail_with Failure::NotVulnerable, 'Target not vulnerable! punt!'
     end
 
-    unless cmd_exec("test -w '#{base_dir}' && echo true").include? 'true'
+    unless writable? base_dir
       fail_with Failure::BadConfig, "#{base_dir} is not writable"
     end
 

--- a/modules/exploits/linux/local/sock_sendpage.rb
+++ b/modules/exploits/linux/local/sock_sendpage.rb
@@ -140,7 +140,7 @@ class MetasploitModule < Msf::Exploit::Local
       fail_with Failure::BadConfig, 'Session already has root privileges'
     end
 
-    unless cmd_exec("test -w '#{base_dir}' && echo true").include? 'true'
+    unless writable? base_dir
       fail_with Failure::BadConfig, "#{base_dir} is not writable"
     end
 

--- a/modules/exploits/linux/local/ufo_privilege_escalation.rb
+++ b/modules/exploits/linux/local/ufo_privilege_escalation.rb
@@ -169,7 +169,7 @@ class MetasploitModule < Msf::Exploit::Local
       fail_with Failure::BadConfig, 'Session already has root privileges'
     end
 
-    unless cmd_exec("test -w '#{base_dir}' && echo true").include? 'true'
+    unless writable? base_dir
       fail_with Failure::BadConfig, "#{base_dir} is not writable"
     end
 

--- a/modules/exploits/osx/local/dyld_print_to_file_root.rb
+++ b/modules/exploits/osx/local/dyld_print_to_file_root.rb
@@ -6,6 +6,7 @@
 class MetasploitModule < Msf::Exploit::Local
   Rank = GreatRanking
 
+  include Msf::Post::File
   include Msf::Post::OSX::Priv
   include Msf::Post::OSX::System
   include Msf::Exploit::EXE
@@ -43,7 +44,7 @@ class MetasploitModule < Msf::Exploit::Local
       'DefaultOptions' => { 'PAYLOAD' => 'osx/x64/shell_reverse_tcp' }
     ))
 
-    register_options [
+    register_advanced_options [
       OptString.new('WritableDir', [true, 'Writable directory', '/.Trashes'])
     ]
   end
@@ -65,7 +66,7 @@ class MetasploitModule < Msf::Exploit::Local
       fail_with Failure::NotVulnerable, 'Target is not vulnerable'
     end
 
-    unless cmd_exec("test -w '#{base_dir}' && echo true").include? 'true'
+    unless writable? base_dir
       fail_with Failure::BadConfig, "#{base_dir} is not writable"
     end
 

--- a/modules/exploits/osx/local/rootpipe.rb
+++ b/modules/exploits/osx/local/rootpipe.rb
@@ -6,6 +6,7 @@
 class MetasploitModule < Msf::Exploit::Local
   Rank = GreatRanking
 
+  include Msf::Post::File
   include Msf::Post::OSX::Priv
   include Msf::Post::OSX::System
   include Msf::Exploit::EXE
@@ -52,7 +53,9 @@ class MetasploitModule < Msf::Exploit::Local
     ))
 
     register_options [
-      OptString.new('PYTHON',      [true, 'Python executable', '/usr/bin/python']),
+      OptString.new('PYTHON', [true, 'Python executable', '/usr/bin/python'])
+    ]
+    register_advanced_options [
       OptString.new('WritableDir', [true, 'Writable directory', '/.Trashes'])
     ]
   end
@@ -78,7 +81,7 @@ class MetasploitModule < Msf::Exploit::Local
       fail_with Failure::NotVulnerable, 'Target is not vulnerable'
     end
 
-    unless cmd_exec("test -w '#{base_dir}' && echo true").include? 'true'
+    unless writable? base_dir
       fail_with Failure::BadConfig, "#{base_dir} is not writable"
     end
 

--- a/modules/exploits/osx/local/rootpipe_entitlements.rb
+++ b/modules/exploits/osx/local/rootpipe_entitlements.rb
@@ -6,6 +6,7 @@
 class MetasploitModule < Msf::Exploit::Local
   Rank = GreatRanking
 
+  include Msf::Post::File
   include Msf::Post::OSX::Priv
   include Msf::Post::OSX::System
   include Msf::Exploit::EXE
@@ -74,7 +75,7 @@ class MetasploitModule < Msf::Exploit::Local
       fail_with Failure::NotVulnerable, 'Target is not vulnerable'
     end
 
-    unless cmd_exec("test -w '#{base_dir}' && echo true").include? 'true'
+    unless writable? base_dir
       fail_with Failure::BadConfig, "#{base_dir} is not writable"
     end
 

--- a/modules/exploits/osx/local/rsh_libmalloc.rb
+++ b/modules/exploits/osx/local/rsh_libmalloc.rb
@@ -6,6 +6,7 @@
 class MetasploitModule < Msf::Exploit::Local
   Rank = NormalRanking
 
+  include Msf::Post::File
   include Msf::Post::OSX::Priv
   include Msf::Post::OSX::System
   include Msf::Exploit::EXE
@@ -58,7 +59,7 @@ class MetasploitModule < Msf::Exploit::Local
       fail_with Failure::BadConfig, 'Session already has root privileges'
     end
 
-    unless cmd_exec("test -w '#{base_dir}' && echo true").include? 'true'
+    unless writable? base_dir
       fail_with Failure::BadConfig, "#{base_dir} is not writable"
     end
 

--- a/modules/exploits/osx/local/setuid_tunnelblick.rb
+++ b/modules/exploits/osx/local/setuid_tunnelblick.rb
@@ -87,7 +87,7 @@ class MetasploitModule < Msf::Exploit::Local
       fail_with Failure::NotVulnerable, 'Target is not vulnerable'
     end
 
-    unless cmd_exec("test -w '#{base_dir}' && echo true").include? 'true'
+    unless writable? base_dir
       fail_with Failure::BadConfig, "#{base_dir} is not writable"
     end
 

--- a/modules/exploits/osx/local/setuid_viscosity.rb
+++ b/modules/exploits/osx/local/setuid_viscosity.rb
@@ -89,7 +89,7 @@ class MetasploitModule < Msf::Exploit::Local
       fail_with Failure::NotVulnerable, 'Target is not vulnerable'
     end
 
-    unless cmd_exec("test -w '#{base_dir}' && echo true").include? 'true'
+    unless writable? base_dir
       fail_with Failure::BadConfig, "#{base_dir} is not writable"
     end
 

--- a/modules/exploits/osx/local/tpwn.rb
+++ b/modules/exploits/osx/local/tpwn.rb
@@ -6,6 +6,7 @@
 class MetasploitModule < Msf::Exploit::Local
   Rank = NormalRanking
 
+  include Msf::Post::File
   include Msf::Post::OSX::Priv
   include Msf::Post::OSX::System
   include Msf::Exploit::EXE
@@ -39,7 +40,7 @@ class MetasploitModule < Msf::Exploit::Local
       'DefaultTarget'  => 0
     ))
 
-    register_options [
+    register_advanced_options [
       OptString.new('WritableDir', [true, 'Writable directory', '/.Trashes'])
     ]
   end
@@ -61,7 +62,7 @@ class MetasploitModule < Msf::Exploit::Local
       fail_with Failure::NotVulnerable, 'Target is not vulnerable'
     end
 
-    unless cmd_exec("test -w '#{base_dir}' && echo true").include? 'true'
+    unless writable? base_dir
       fail_with Failure::BadConfig, "#{base_dir} is not writable"
     end
 

--- a/modules/exploits/osx/local/vmware_bash_function_root.rb
+++ b/modules/exploits/osx/local/vmware_bash_function_root.rb
@@ -54,8 +54,10 @@ class MetasploitModule < Msf::Exploit::Local
     ))
 
     register_options [
-      OptString.new('WritableDir', [true, 'Writable directory', '/tmp']),
       OptString.new('VMWARE_PATH', [true, "The path to VMware.app", '/Applications/VMware Fusion.app']),
+    ]
+    register_advanced_options [
+      OptString.new('WritableDir', [true, 'Writable directory', '/tmp'])
     ]
   end
 
@@ -90,7 +92,7 @@ class MetasploitModule < Msf::Exploit::Local
       fail_with Failure::NotVulnerable, 'Target is not vulnerable'
     end
 
-    unless cmd_exec("test -w '#{base_dir}' && echo true").include? 'true'
+    unless writable? base_dir
       fail_with Failure::BadConfig, "#{base_dir} is not writable"
     end
 

--- a/modules/post/multi/recon/sudo_commands.rb
+++ b/modules/post/multi/recon/sudo_commands.rb
@@ -43,10 +43,6 @@ class MetasploitModule < Msf::Post
     datastore['PASSWORD'].to_s
   end
 
-  def is_writable?(path)
-    cmd_exec("test -w '#{path}' && echo true").include? 'true'
-  end
-
   def is_executable?(path)
     cmd_exec("test -x '#{path}' && echo true").include? 'true'
   end
@@ -84,11 +80,11 @@ class MetasploitModule < Msf::Post
     base_name = File.basename cmd
 
     if file_exist? cmd
-      if is_writable? cmd
+      if writable? cmd
         print_good "#{cmd} is writable!"
         return true
       end
-    elsif is_writable? base_dir
+    elsif writable? base_dir
       print_good "#{cmd} does not exist and #{base_dir} is writable!"
       return true
     end


### PR DESCRIPTION
Updates various Linux and OSX local exploit modules to make use of the new `Msf::Post::File.writable?` method added in #10644 rather than manually checking the output of `test -w /path`.

Also moves `WritableDir` from `register_options` to `register_advanced_options` for a few modules which were missed in #10783.
