### PR TITLE
Move `exploit/unix/polycom_hdx_auth_bypass` to `exploit/unix/misc/polycom_hdx_auth_bypass`

### DIFF
--- a/modules/exploits/unix/misc/polycom_hdx_auth_bypass.rb
+++ b/modules/exploits/unix/misc/polycom_hdx_auth_bypass.rb
@@ -7,9 +7,6 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = NormalRanking
   include Msf::Exploit::Remote::Tcp
   include Msf::Auxiliary::Report
-  include Msf::Module::Deprecated
-
-  deprecated(Date.new(2018, 11, 04), 'exploit/unix/misc/polycom_hdx_auth_bypass')
 
   def initialize(info = {})
     super(


### PR DESCRIPTION
Move `exploit/unix/polycom_hdx_auth_bypass` to `exploit/unix/misc/polycom_hdx_auth_bypass`.

https://github.com/rapid7/metasploit-framework/pull/10817#issuecomment-431420856

Rather than create a `exploit/unix/polycom` directory, I opted to move it to the `misc` folder so it could live with it's friend `exploit/unix/misc/polycom_hdx_traceroute_exec`.
