### PR TITLE
Add CentOS and Alpine Linux detection to Linux system lib

### DIFF
--- a/lib/msf/core/post/linux/system.rb
+++ b/lib/msf/core/post/linux/system.rb
@@ -23,20 +23,30 @@ module System
 
     # Debian
     if etc_files.include?("debian_version")
+      version = read_file("/etc/issue").gsub(/\n|\\n|\\l/,'')
       if kernel_version =~ /Ubuntu/
-        version = read_file("/etc/issue").gsub(/\n|\\n|\\l/,'')
         system_data[:distro] = "ubuntu"
         system_data[:version] = version
       else
-        version = read_file("/etc/issue").gsub(/\n|\\n|\\l/,'')
         system_data[:distro] = "debian"
         system_data[:version] = version
       end
 
-    # Amazon
-    elsif etc_files.include?("system-release")
-      version = read_file("/etc/system-release").gsub(/\n|\\n|\\l/,'')
-      system_data[:distro] = "amazon"
+    # Amazon / CentOS
+    elsif etc_files.include?('system-release')
+      version = read_file('/etc/system-release').gsub(/\n|\\n|\\l/,'')
+      if version.include? 'CentOS'
+        system_data[:distro] = 'centos'
+        system_data[:version] = version
+      else
+        system_data[:distro] = 'amazon'
+        system_data[:version] = version
+      end
+
+    # Alpine
+    elsif etc_files.include?('alpine-release')
+      version = read_file('/etc/alpine-release').gsub(/\n|\\n|\\l/,'')
+      system_data[:distro] = 'alpine'
       system_data[:version] = version
 
     # Fedora


### PR DESCRIPTION
Add CentOS and Alpine Linux detection to `Msf::Post::Linux::System.get_sysinfo`

---

## CentOS

### Before

```
Hosts
=====

address         mac  name                       os_name  os_flavor                             os_sp  purpose  info  comments
-------         ---  ----                       -------  ---------                             -----  -------  ----  --------
123.45.67.141        centos-7-1708.localdomain  amazon   CentOS Linux release 7.4.1708 (Core)                         
```

### After

```
Hosts
=====

address         mac  name                       os_name  os_flavor                             os_sp  purpose  info  comments
-------         ---  ----                       -------  ---------                             -----  -------  ----  --------
123.45.67.141        centos-7-1708.localdomain  centos   CentOS Linux release 7.4.1708 (Core)          server         
```

---


## Alpine Linux

### Before

```
Hosts
=====

address         mac  name       os_name  os_flavor                                         os_sp  purpose  info  comments
-------         ---  ----       -------  ---------                                         -----  -------  ----  --------
123.45.67.123        localhost  linux    Welcome to Alpine Linux 3.8Kernel \r on an \m ()                        
```

### After

```
Hosts
=====

address         mac  name       os_name  os_flavor  os_sp  purpose  info  comments
-------         ---  ----       -------  ---------  -----  -------  ----  --------
123.45.67.123        localhost  alpine   3.8.1                            
```
