### PR TITLE
remove inaccurate `server/client` determination from module cache

### DIFF
--- a/documentation/api/v1/module_search_api_doc.rb
+++ b/documentation/api/v1/module_search_api_doc.rb
@@ -15,8 +15,6 @@ module ModuleSearchApiDoc
   DISCLOSURE_DATE_DESC = 'Filter modules with a matching disclosure date.'
   DATE_DESC = 'Alias for \'disclosure_date\'.'
   FULL_NAME_DESC = 'Filter modules with a matching full name.'
-  IS_CLIENT_DESC = 'Filter modules that are client attacks. (Accepts strings \'true\' or \'false\').'
-  IS_SERVER_DESC = 'Filter modules that are server attacks. (Accepts strings \'true\' or \'false\').'
   IS_INSTALL_PATH_DESC = 'Filter modules that by value of \'is_install_path\'. (Accepts strings \'true\' or \'false\').'
   MOD_TIME_DESC = 'Filter modules with a matching modification time.'
   NAME_DESC = 'Filter modules with a matching descriptive name.'
@@ -34,7 +32,7 @@ module ModuleSearchApiDoc
   TARGETS_DESC = 'Alias for \'target\'.'
   TEXT_DESC = 'Filter modules matching any one of name, full name, description, reference, author, or targets.'
   TYPE_DESC = 'Filter modules with a matching type (exploit, auxiliary, payload, etc.).'
-  FIELDS_DESC = 'Provide a comma-delimited list of metadata fields you would like to return. If left blank, all fields will be returned. Valid field names are: \'name\', \'full_name\', \'fullname\', \'aka\', \'arch\', \'author\', \'author\', \'description\', \'disclosure_date\', \'cve\', \'edb\', \'bid\', \'mod_time\', \'is_client\', \'is_server\', \'is_install_path\', \'os\', \'platform\', \'reference\', \'references\', \'ref_name\', \'ref\', \'path\', \'port\', \'rport\', \'rank\', \'type\', \'target\', \'targets\''
+  FIELDS_DESC = 'Provide a comma-delimited list of metadata fields you would like to return. If left blank, all fields will be returned. Valid field names are: \'name\', \'full_name\', \'fullname\', \'aka\', \'arch\', \'author\', \'author\', \'description\', \'disclosure_date\', \'cve\', \'edb\', \'bid\', \'mod_time\', \'is_install_path\', \'os\', \'platform\', \'reference\', \'references\', \'ref_name\', \'ref\', \'path\', \'port\', \'rport\', \'rank\', \'type\', \'target\', \'targets\''
   NOTES_DESC = 'Extra info for a module, such as AKA names or NOCVE explanations.'
 
   TYPE_ENUM = [
@@ -97,8 +95,6 @@ module ModuleSearchApiDoc
     property :description, type: :string, description: DESCRIPTION_DESC, example: DESCRIPTION_EXAMPLE
     property :author, description: AUTHOR_DESC, example: AUTHOR_EXAMPLE, type: :array do items type: :string end
     property :references, description: REFERENCE_DESC, example: REFERENCES_EXAMPLE, type: :array do items type: :string end
-    property :is_client, type: :boolean, description: IS_CLIENT_DESC, example: IS_CLIENT_EXAMPLE
-    property :is_server, type: :boolean, description: IS_SERVER_DESC, example: IS_SERVER_EXAMPLE
     property :platform, type: :string, description: PLATFORM_DESC, example: PLATFORM_EXAMPLE
     property :arch, type: :string, description: ARCH_DESC, example: ARCH_EXAMPLE
     property :rport, type: :string, description: PORT_DESC, example: RPORT_EXAMPLE
@@ -130,8 +126,6 @@ module ModuleSearchApiDoc
         :disclosure_date => DISCLOSURE_DATE_DESC,
         :date => DATE_DESC,
         :full_name => FULL_NAME_DESC,
-        :is_client => IS_CLIENT_DESC,
-        :is_server => IS_SERVER_DESC,
         :is_install_path => IS_INSTALL_PATH_DESC,
         :mod_time => MOD_TIME_DESC,
         :name => NAME_DESC,

--- a/lib/msf/core/db_manager/module_cache.rb
+++ b/lib/msf/core/db_manager/module_cache.rb
@@ -203,7 +203,6 @@ module Msf::DBManager::ModuleCache
       @names    = Set.new
       @os       = Set.new
       @refs     = Set.new
-      @stances  = Set.new
       @text     = Set.new
       @types    = Set.new
 
@@ -241,7 +240,6 @@ module Msf::DBManager::ModuleCache
     @query = @query.module_os_or_platform(  @os.to_a.flatten      ) if @os.any?
     @query = @query.module_text(            @text.to_a.flatten    ) if @text.any?
     @query = @query.module_type(            @types.to_a.flatten   ) if @types.any?
-    @query = @query.module_stance(          @stances.to_a.flatten ) if @stances.any?
     @query = @query.module_ref(             @refs.to_a.flatten    ) if @refs.any?
 
     @query.uniq

--- a/lib/msf/core/db_manager/module_cache.rb
+++ b/lib/msf/core/db_manager/module_cache.rb
@@ -147,7 +147,6 @@ module Msf::DBManager::ModuleCache
   # This provides a standard set of search filters for every module.
   #
   # Supported keywords with the format <keyword>:<search_value>:
-  # +app+:: If +client+ then matches +'passive'+ stance modules, otherwise matches +'active' stance modules.
   # +author+:: Matches modules with the given author email or name.
   # +bid+:: Matches modules with the given Bugtraq ID.
   # +cve+:: Matches modules with the given CVE ID.
@@ -212,15 +211,6 @@ module Msf::DBManager::ModuleCache
         formatted_values = match_values(value_set)
 
         case keyword
-          when 'app'
-            formatted_values = value_set.collect { |value|
-              formatted_value = 'aggressive'
-              if value == 'client'
-                formatted_value = 'passive'
-              end
-              formatted_value
-            }
-            @stances << formatted_values
           when 'arch'
             @archs << formatted_values
           when 'author'

--- a/lib/msf/core/module/search.rb
+++ b/lib/msf/core/module/search.rb
@@ -42,8 +42,6 @@ module Msf::Module::Search
     k = res
 
     refs = self.references.map{|x| [x.ctx_id, x.ctx_val].join("-") }
-    is_server    = (self.respond_to?(:stance) and self.stance == "aggressive")
-    is_client    = (self.respond_to?(:stance) and self.stance == "passive")
 
     [0,1].each do |mode|
       match = false
@@ -79,9 +77,6 @@ module Msf::Module::Search
               match = [t,w] if self.datastore['RPORT'].to_s =~ r
             when 'type'
               match = [t,w] if Msf::MODULE_TYPES.any? { |modt| w == modt and self.type == modt }
-            when 'app'
-              match = [t,w] if (w == "server" and is_server)
-              match = [t,w] if (w == "client" and is_client)
             when 'cve'
               match = [t,w] if refs.any? { |ref| ref =~ /^cve\-/i and ref =~ r }
             when 'bid'

--- a/lib/msf/core/modules/metadata/maps.rb
+++ b/lib/msf/core/modules/metadata/maps.rb
@@ -18,7 +18,8 @@ module Msf::Modules::Metadata::Maps
     mservs = {}
 
     get_metadata.each do |exploit|
-      next unless exploit.type == "exploit" && exploit.is_server
+      # expand this in future to be more specific about remote exploits.
+      next unless exploit.type == "exploit"
       fullname = exploit.full_name
       exploit.references.each do |reference|
         next if reference =~ /^URL/

--- a/lib/msf/core/modules/metadata/obj.rb
+++ b/lib/msf/core/modules/metadata/obj.rb
@@ -26,10 +26,6 @@ class Obj
   # @return [Array<String>]
   attr_reader :references
   # @return [Boolean]
-  attr_reader :is_server
-  # @return [Boolean]
-  attr_reader :is_client
-  # @return [String]
   attr_reader :platform
   # @return [String]
   attr_reader :arch
@@ -70,8 +66,6 @@ class Obj
     @description        = module_instance.description.to_s.strip
     @author             = module_instance.author.map{|x| x.to_s}
     @references         = module_instance.references.map{|x| [x.ctx_id, x.ctx_val].join("-") }
-    @is_server          = module_instance.respond_to?(:exploit_type) && module_instance.exploit_type == Exploit::Type::Remote
-    @is_client          = module_instance.respond_to?(:exploit_type) && !@is_server
     @post_auth          = module_instance.post_auth?
     @default_credential = module_instance.default_cred?
 
@@ -123,8 +117,6 @@ class Obj
       'author'             => @author,
       'description'        => @description,
       'references'         => @references,
-      'is_server'          => @is_server,
-      'is_client'          => @is_client,
       'platform'           => @platform,
       'arch'               => @arch,
       'rport'              => @rport,
@@ -174,8 +166,6 @@ class Obj
     @description        = obj_hash['description']
     @author             = obj_hash['author'].nil? ? [] : obj_hash['author']
     @references         = obj_hash['references']
-    @is_server          = obj_hash['is_server']
-    @is_client          = obj_hash['is_client']
     @platform           = obj_hash['platform']
     @arch               = obj_hash['arch']
     @rport              = obj_hash['rport']

--- a/lib/msf/core/modules/metadata/obj.rb
+++ b/lib/msf/core/modules/metadata/obj.rb
@@ -70,8 +70,8 @@ class Obj
     @description        = module_instance.description.to_s.strip
     @author             = module_instance.author.map{|x| x.to_s}
     @references         = module_instance.references.map{|x| [x.ctx_id, x.ctx_val].join("-") }
-    @is_server          = (module_instance.respond_to?(:stance) and module_instance.stance == "aggressive")
-    @is_client          = (module_instance.respond_to?(:stance) and module_instance.stance == "passive")
+    @is_server          = module_instance.respond_to?(:exploit_type) && module_instance.exploit_type == Exploit::Type::Remote
+    @is_client          = module_instance.respond_to?(:exploit_type) && !@is_server
     @post_auth          = module_instance.post_auth?
     @default_credential = module_instance.default_cred?
 

--- a/lib/msf/core/modules/metadata/search.rb
+++ b/lib/msf/core/modules/metadata/search.rb
@@ -6,7 +6,7 @@ require 'msf/core/modules/metadata'
 module Msf::Modules::Metadata::Search
 
   VALID_PARAMS =
-      %w[aka app author authors arch cve bid edb check date disclosure_date description full_name fullname mod_time
+      %w[aka author authors arch cve bid edb check date disclosure_date description full_name fullname mod_time
       name os platform path port rport rank ref ref_name reference references target targets text type]
 
   #
@@ -49,9 +49,6 @@ module Msf::Modules::Metadata::Search
           case keyword
             when 'aka'
               match = [keyword, search_term] if (module_metadata.notes['AKA'] || []).any? { |aka| aka =~ regex }
-            when 'app'
-              match = [keyword, search_term] if (search_term == "server" and module_metadata.is_server)
-              match = [keyword, search_term] if (search_term == "client" and module_metadata.is_client)
             when 'author', 'authors'
               match = [keyword, search_term] if module_metadata.author.any? { |author| author =~ regex }
             when 'arch'

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -327,7 +327,6 @@ module Msf
             print_line "Keywords:"
             {
               'aka'         => 'Modules with a matching AKA (also-known-as) name',
-              'app'         => 'Modules that are client or server attacks',
               'author'      => 'Modules written by this author',
               'arch'        => 'Modules affecting this architecture',
               'bid'         => 'Modules with a matching Bugtraq ID',
@@ -352,7 +351,7 @@ module Msf
             end
             print_line
             print_line "Examples:"
-            print_line "  search cve:2009 type:exploit app:client"
+            print_line "  search cve:2009 type:exploit"
             print_line
           end
 

--- a/spec/support/shared/examples/msf/db_manager/module_cache.rb
+++ b/spec/support/shared/examples/msf/db_manager/module_cache.rb
@@ -157,50 +157,6 @@ RSpec.shared_examples_for 'Msf::DBManager::ModuleCache' do
       search_modules.to_a
     end
 
-    context 'with app keyword' do
-      let(:search_string) do
-        "app:#{app}"
-      end
-
-      before(:example) do
-        Mdm::Module::Detail::STANCES.each do |stance|
-          FactoryBot.create(:mdm_module_detail, :stance => stance)
-        end
-      end
-
-      context 'with client' do
-        let(:app) do
-          'client'
-        end
-
-        it "should match Mdm::Module::Detail#stance 'passive'" do
-          expect(module_details.count).to be > 0
-
-          expect(
-            module_details.all? { |module_detail|
-              module_detail.stance == 'passive'
-            }
-          ).to eq true
-        end
-      end
-
-      context 'with server' do
-        let(:app) do
-          'server'
-        end
-
-        it "should match Mdm::Module::Detail#stance 'aggressive'" do
-          expect(module_details.count).to be > 0
-
-          expect(
-            module_details.all? { |module_detail|
-              module_detail.stance == 'aggressive'
-            }
-          ).to eq true
-        end
-      end
-    end
-
     context 'with author keyword' do
       let(:search_string) do
         # us inspect so strings with spaces are quoted correctly


### PR DESCRIPTION
~~Updates the cached data to define server vs client base on the
type of exploit module instead of the module stance.~~

Completely remove `app` search term and `is_server/is_client` from cache determinations.  After significant discussion, these values did not reflect what they were documented as and therefore do not bring appropriate value.

Technically this removes terms for the recently noted datastore API, so open to discussion on if that breaking change needs some mitigation or *deprecation* time. 

## Verification

- [x] **Regenerate** module cache and **verify** it updated correctly
  - [x] `rm db/modules_metadata_base.json ~/.msf4/store/modules_metadata.json`
  - [x] `./msfconsole -qx 'irb -e framework.modules.refresh_cache_from_module_files; exit'`
  - [x] **Verify** `~/.msf4/store/modules_metadata.json` is correct
  - [x] `cp ~/.msf4/store/modules_metadata.json db/modules_metadata_base.json`
  - [x] **Verify** `search` works as intended
  - [x] **Verify** `db/modules_metadata_base.json` contains entry for `exploit_osx/local/sudo_password_bypass` no longer reports `is_server: true`
  - [x] `git checkout db/modules_metadata_base.json`
  - [x] **DO NOT** commit any module cache changes


@wvu-r7 @clee-r7 take a look please.