### PR TITLE
add default service mapping to imports

### DIFF
--- a/lib/msf/core/db_manager/import.rb
+++ b/lib/msf/core/db_manager/import.rb
@@ -95,8 +95,73 @@ module Msf::DBManager::Import
     ftype = import_filetype_detect(data)
     yield(:filetype, @import_filedata[:type]) if block
     self.send "import_#{ftype}".to_sym, args.merge(workspace: wspace.name), &block
+    # post process the import here for missing default port maps
+    mrefs, mports, _mservs = Msf::Modules::Metadata::Cache.instance.all_remote_exploit_maps
+    # the map build above is a little expensive, another options is to do
+    # a host by ref search for each vuln ref and then check port reported for each module
+    # IMHO this front loaded cost here is worth it with only a small number of modules
+    # compared to the vast number of possible references offered by a Vulnerability scanner.
+    deferred_service_ports = [ 139 ] # I hate special cases, however 139 is not longer a preferred default
+
+    new_host_ids = Mdm::Host.where(workspace: wspace).map(&:id)
+    (new_host_ids - existing_host_ids).each do |id|
+      imported_host = Mdm::Host.where(id: id).first
+      next if imported_host.vulns.nil? || imported_host.vulns.empty?
+      # get all vulns with ports
+      with_ports = []
+      imported_host.vulns.each do |vuln|
+        next if vuln.service.nil?
+        with_ports << vuln.name
+      end
+
+      imported_host.vulns.each do |vuln|
+        # now get default ports for vulns where service is nil
+        next unless vuln.service.nil?
+        next if with_ports.include?(vuln.name)
+        serv = nil
+
+        # Module names that match this vulnerability
+        matched = mrefs.values_at(*(vuln.refs.map { |x| x.name.upcase } & mrefs.keys)).map { |x| x.values }.flatten.uniq
+        next if matched.empty?
+        match_names = []
+        matched.each do |mod|
+          match_names << mod.full_name
+        end
+
+        second_pass_services = []
+
+        imported_host.services.each do |service|
+          if deferred_service_ports.include?(service.port)
+            second_pass_services << service
+            next
+          end
+          if mports[service.port]
+            if (match_names - mports[service.port].keys).count < match_names.count
+              serv = service
+              break
+            end
+          end
+        end
+
+        # post process any deferred services if no match has been found
+        if serv.nil? && !second_pass_services.empty?
+          second_pass_services.each do |service|
+            if mports[service.port]
+              if (match_names - mports[service.port].keys).count < match_names.count
+                serv = service
+                break
+              end
+            end
+          end
+        end
+
+        next if serv.nil?
+        vuln.service = serv
+        vuln.save
+
+      end
+    end
     if preserve_hosts
-      new_host_ids = Mdm::Host.where(workspace: wspace).map(&:id)
       (new_host_ids - existing_host_ids).each do |id|
         Mdm::Host.where(id: id).first.normalize_os
       end

--- a/lib/msf/core/modules/metadata/cache.rb
+++ b/lib/msf/core/modules/metadata/cache.rb
@@ -6,6 +6,7 @@ require 'msf/core/modules/metadata'
 require 'msf/core/modules/metadata/obj'
 require 'msf/core/modules/metadata/search'
 require 'msf/core/modules/metadata/store'
+require 'msf/core/modules/metadata/maps'
 
 #
 # Core service class that provides storage of module metadata as well as operations on the metadata.
@@ -19,6 +20,7 @@ class Cache
   include Singleton
   include Msf::Modules::Metadata::Search
   include Msf::Modules::Metadata::Store
+  include Msf::Modules::Metadata::Maps
 
   #
   # Refreshes cached module metadata as well as updating the store
@@ -79,7 +81,10 @@ class Cache
         end
       end
 
-      update_store if has_changes
+      if has_changes
+        update_store
+        clear_maps
+      end
     }
   end
 

--- a/lib/msf/core/modules/metadata/maps.rb
+++ b/lib/msf/core/modules/metadata/maps.rb
@@ -1,0 +1,69 @@
+#
+# Core service class that provides storage of module metadata as well as operations on the metadata.
+# Note that operations on this metadata are included as separate modules.
+#
+module Msf::Modules::Metadata::Maps
+
+  @mrefs  = {}
+  @mports = {}
+  @mservs = {}
+
+
+  def all_remote_exploit_maps
+
+    unless @mrefs
+      mrefs  = {}
+      mports = {}
+      mservs = {}
+
+      get_metadata.each do |exploit|
+        next unless exploit.type == "exploit" && exploit.is_server
+        fullname = exploit.full_name
+        exploit.references.each do |reference|
+          next if reference =~ /^URL/
+          ref = reference
+          ref.upcase!
+
+          mrefs[ref]           ||= {}
+          mrefs[ref][fullname] = exploit
+        end
+
+        if exploit.rport
+          rport                        = exploit.rport
+          mports[rport.to_i]           ||= {}
+          mports[rport.to_i][fullname] = exploit
+        end
+
+        unless exploit.autofilter_ports.nil? || exploit.autofilter_ports.empty?
+          exploit.autofilter_ports.each do |rport|
+          next unless port_allowed?(rport)
+            mports[rport.to_i]           ||= {}
+            mports[rport.to_i][fullname] = exploit
+          end
+        end
+
+        unless exploit.autofilter_services.nil? || exploit.autofilter_services.empty?
+          exploit.autofilter_services.each do |serv|
+            mservs[serv]           ||= {}
+            mservs[serv][fullname] = exploit
+          end
+        end
+
+      end
+      @mrefs  = mrefs
+      @mports = mports
+      @mservs = mservs
+    end
+
+    return @mrefs, @mports, @mservs
+  end
+
+  private
+
+  def clear_maps
+    @mrefs = nil
+    @mports = nil
+    @mservs = nil
+  end
+
+end

--- a/lib/msf/core/modules/metadata/maps.rb
+++ b/lib/msf/core/modules/metadata/maps.rb
@@ -11,49 +11,49 @@ module Msf::Modules::Metadata::Maps
 
   def all_remote_exploit_maps
 
-    unless @mrefs
-      mrefs  = {}
-      mports = {}
-      mservs = {}
+    return @mrefs, @mports, @mservs if @mrefs && !@mrefs.empty?
 
-      get_metadata.each do |exploit|
-        next unless exploit.type == "exploit" && exploit.is_server
-        fullname = exploit.full_name
-        exploit.references.each do |reference|
-          next if reference =~ /^URL/
-          ref = reference
-          ref.upcase!
+    mrefs  = {}
+    mports = {}
+    mservs = {}
 
-          mrefs[ref]           ||= {}
-          mrefs[ref][fullname] = exploit
-        end
+    get_metadata.each do |exploit|
+      next unless exploit.type == "exploit" && exploit.is_server
+      fullname = exploit.full_name
+      exploit.references.each do |reference|
+        next if reference =~ /^URL/
+        ref = reference
+        ref.upcase!
 
-        if exploit.rport
-          rport                        = exploit.rport
+        mrefs[ref]           ||= {}
+        mrefs[ref][fullname] = exploit
+      end
+
+      if exploit.rport
+        rport                        = exploit.rport
+        mports[rport.to_i]           ||= {}
+        mports[rport.to_i][fullname] = exploit
+      end
+
+      unless exploit.autofilter_ports.nil? || exploit.autofilter_ports.empty?
+        exploit.autofilter_ports.each do |rport|
+          next unless port_allowed?(rport)
           mports[rport.to_i]           ||= {}
           mports[rport.to_i][fullname] = exploit
         end
-
-        unless exploit.autofilter_ports.nil? || exploit.autofilter_ports.empty?
-          exploit.autofilter_ports.each do |rport|
-          next unless port_allowed?(rport)
-            mports[rport.to_i]           ||= {}
-            mports[rport.to_i][fullname] = exploit
-          end
-        end
-
-        unless exploit.autofilter_services.nil? || exploit.autofilter_services.empty?
-          exploit.autofilter_services.each do |serv|
-            mservs[serv]           ||= {}
-            mservs[serv][fullname] = exploit
-          end
-        end
-
       end
-      @mrefs  = mrefs
-      @mports = mports
-      @mservs = mservs
+
+      unless exploit.autofilter_services.nil? || exploit.autofilter_services.empty?
+        exploit.autofilter_services.each do |serv|
+          mservs[serv]           ||= {}
+          mservs[serv][fullname] = exploit
+        end
+      end
+
     end
+    @mrefs  = mrefs
+    @mports = mports
+    @mservs = mservs
 
     return @mrefs, @mports, @mservs
   end


### PR DESCRIPTION
When importing hosts details from external sources, the vendors sometimes do not provide linking between vulnerabilities and services exposed on a host.

This change attempts to fill that gap by connecting any reported vulnerability without service to reported a service when an existing metasploit module references the same vulnerability and reports default ports the service may be running on.  This is prone to possible false mapping, however this change only attempt so fill in gaps.  This in my opinion make it a reasonable post processing task.

## Verification

- [x] Start `msfconsole`
- [x] `db_import <test_file_path>.xml`
- [x] `vulns -p 445`
- [x] **Verify** the `CVE-2017-0146` vulnerability reported in the sample export attached is mapped to exposed port 445 on the host imported.

[m3_report.xml.zip](https://github.com/rapid7/metasploit-framework/files/2566565/m3_report.xml.zip)

