### PR TITLE
Ensure `sessions --up` shows only services which are up

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -765,6 +765,10 @@ class Db
       opts[:port] = ports if ports
       framework.db.services(opts).each do |service|
 
+        unless service.state == 'open'
+          next if onlyup
+        end
+
         host = service.host
         matched_service_ids << service.id
 


### PR DESCRIPTION
Ensure `sessions --up` shows only services which are up. Fix #10867.

I presumed only services with state `open` were to be considered `up`. This may be an unsafe assumption.

Should services with `unknown` state (services reported by nmap as `open|filtered`) be considered up for the purposes of the `--up` flag?
