### PR TITLE
Add ForceExploit to Linux local modules

### DIFF
--- a/modules/exploits/linux/local/af_packet_chocobo_root_priv_esc.rb
+++ b/modules/exploits/linux/local/af_packet_chocobo_root_priv_esc.rb
@@ -73,6 +73,7 @@ class MetasploitModule < Msf::Exploit::Local
       OptEnum.new('COMPILE', [ true, 'Compile on target', 'Auto', %w(Auto True False) ])
     ]
     register_advanced_options [
+      OptBool.new('ForceExploit',  [ false, 'Override check result', false ]),
       OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ])
     ]
   end
@@ -168,12 +169,17 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    if check != CheckCode::Appears
-      fail_with Failure::NotVulnerable, 'Target is not vulnerable'
+    unless check == CheckCode::Appears
+      unless datastore['ForceExploit']
+        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
+      end
+      print_warning 'Target does not appear to be vulnerable'
     end
 
     if is_root?
-      fail_with Failure::BadConfig, 'Session already has root privileges'
+      unless datastore['ForceExploit']
+        fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'
+      end
     end
 
     unless writable? base_dir

--- a/modules/exploits/linux/local/af_packet_packet_set_ring_priv_esc.rb
+++ b/modules/exploits/linux/local/af_packet_packet_set_ring_priv_esc.rb
@@ -71,6 +71,7 @@ class MetasploitModule < Msf::Exploit::Local
       OptEnum.new('COMPILE', [ true, 'Compile on target', 'Auto', %w(Auto True False) ])
     ]
     register_advanced_options [
+      OptBool.new('ForceExploit',  [ false, 'Override check result', false ]),
       OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ])
     ]
   end
@@ -164,12 +165,17 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    if check != CheckCode::Appears
-      fail_with Failure::NotVulnerable, 'Target is not vulnerable'
+    unless check == CheckCode::Appears
+      unless datastore['ForceExploit']
+        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
+      end
+      print_warning 'Target does not appear to be vulnerable'
     end
 
     if is_root?
-      fail_with Failure::BadConfig, 'Session already has root privileges'
+      unless datastore['ForceExploit']
+        fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'
+      end
     end
 
     unless writable? base_dir

--- a/modules/exploits/linux/local/bpf_sign_extension_priv_esc.rb
+++ b/modules/exploits/linux/local/bpf_sign_extension_priv_esc.rb
@@ -93,6 +93,7 @@ class MetasploitModule < Msf::Exploit::Local
       OptEnum.new('COMPILE', [ true, 'Compile on target', 'Auto', %w[Auto True False] ])
     ]
     register_advanced_options [
+      OptBool.new('ForceExploit',  [ false, 'Override check result', false ]),
       OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ])
     ]
   end
@@ -178,11 +179,16 @@ class MetasploitModule < Msf::Exploit::Local
 
   def exploit
     unless check == CheckCode::Appears
-      fail_with Failure::NotVulnerable, 'Target not vulnerable! punt!'
+      unless datastore['ForceExploit']
+        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
+      end
+      print_warning 'Target does not appear to be vulnerable'
     end
 
     if is_root?
-      fail_with Failure::BadConfig, 'Session already has root privileges'
+      unless datastore['ForceExploit']
+        fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'
+      end
     end
 
     unless writable? base_dir

--- a/modules/exploits/linux/local/glibc_realpath_priv_esc.rb
+++ b/modules/exploits/linux/local/glibc_realpath_priv_esc.rb
@@ -64,6 +64,7 @@ class MetasploitModule < Msf::Exploit::Local
       OptEnum.new('COMPILE', [ true, 'Compile on target', 'Auto', %w(Auto True False) ])
     ]
     register_advanced_options [
+      OptBool.new('ForceExploit',  [ false, 'Override check result', false ]),
       OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ])
     ]
   end
@@ -161,12 +162,21 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    if is_root?
-      fail_with Failure::BadConfig, 'Session already has root privileges'
+    unless check == CheckCode::Appears
+      unless datastore['ForceExploit']
+        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
+      end
+      print_warning 'Target does not appear to be vulnerable'
     end
 
-    if check != CheckCode::Appears
-      fail_with Failure::NotVulnerable, 'Target is not vulnerable'
+    if is_root?
+      unless datastore['ForceExploit']
+        fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'
+      end
+    end
+
+    unless writable? base_dir
+      fail_with Failure::BadConfig, "#{base_dir} is not writable"
     end
 
     unless writable? base_dir

--- a/modules/exploits/linux/local/lastore_daemon_dbus_priv_esc.rb
+++ b/modules/exploits/linux/local/lastore_daemon_dbus_priv_esc.rb
@@ -45,6 +45,7 @@ class MetasploitModule < Msf::Exploit::Local
       'Targets'        => [[ 'Auto', {} ]],
       'DefaultTarget'  => 0))
     register_advanced_options [
+      OptBool.new('ForceExploit',  [ false, 'Override check result', false ]),
       OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ])
     ]
   end
@@ -119,12 +120,17 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    if is_root?
-      fail_with Failure::BadConfig, 'Session already has root privileges'
+    unless check == CheckCode::Appears
+      unless datastore['ForceExploit']
+        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
+      end
+      print_warning 'Target does not appear to be vulnerable'
     end
 
-    if check != CheckCode::Appears
-      fail_with Failure::NotVulnerable, 'Target is not vulnerable'
+    if is_root?
+      unless datastore['ForceExploit']
+        fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'
+      end
     end
 
     print_status 'Building package...'

--- a/modules/exploits/linux/local/libuser_roothelper_priv_esc.rb
+++ b/modules/exploits/linux/local/libuser_roothelper_priv_esc.rb
@@ -78,6 +78,7 @@ class MetasploitModule < Msf::Exploit::Local
       OptString.new('PASSWORD', [ true, 'Password for the current user', '' ])
     ]
     register_advanced_options [
+      OptBool.new('ForceExploit',  [ false, 'Override check result', false ]),
       OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ])
     ]
   end
@@ -158,11 +159,16 @@ class MetasploitModule < Msf::Exploit::Local
 
   def exploit
     if check == CheckCode::Safe
-      fail_with Failure::NotVulnerable, 'Target is not vulnerable'
+      unless datastore['ForceExploit']
+        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
+      end
+      print_warning 'Target does not appear to be vulnerable'
     end
 
     if is_root?
-      fail_with Failure::BadConfig, 'Session already has root privileges'
+      unless datastore['ForceExploit']
+        fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'
+      end
     end
 
     unless writable? base_dir

--- a/modules/exploits/linux/local/network_manager_vpnc_username_priv_esc.rb
+++ b/modules/exploits/linux/local/network_manager_vpnc_username_priv_esc.rb
@@ -64,6 +64,7 @@ class MetasploitModule < Msf::Exploit::Local
         },
       'DefaultTarget'  => 0))
     register_advanced_options [
+      OptBool.new('ForceExploit',  [ false, 'Override check result', false ]),
       OptString.new('WritableDir', [true, 'A directory where we can write files', '/tmp'])
     ]
   end
@@ -95,12 +96,17 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    if is_root?
-      fail_with Failure::BadConfig, 'Session already has root privileges'
+    unless check == CheckCode::Detected
+      unless datastore['ForceExploit']
+        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
+      end
+      print_warning 'Target does not appear to be vulnerable'
     end
 
-    if check != CheckCode::Detected
-      fail_with Failure::NotVulnerable, 'Target is not vulnerable'
+    if is_root?
+      unless datastore['ForceExploit']
+        fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'
+      end
     end
 
     @payload_name = ".#{rand_text_alphanumeric rand(10..15)}"

--- a/modules/exploits/linux/local/rds_priv_esc.rb
+++ b/modules/exploits/linux/local/rds_priv_esc.rb
@@ -64,6 +64,7 @@ class MetasploitModule < Msf::Exploit::Local
       OptEnum.new('COMPILE', [ true, 'Compile on target', 'Auto', %w(Auto True False) ])
     ]
     register_advanced_options [
+      OptBool.new('ForceExploit',  [ false, 'Override check result', false ]),
       OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ])
     ]
   end
@@ -151,11 +152,16 @@ class MetasploitModule < Msf::Exploit::Local
 
   def exploit
     unless check == CheckCode::Appears
-      fail_with Failure::NotVulnerable, 'Target is not vulnerable'
+      unless datastore['ForceExploit']
+        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
+      end
+      print_warning 'Target does not appear to be vulnerable'
     end
 
     if is_root?
-      fail_with Failure::BadConfig, 'Session already has root privileges'
+      unless datastore['ForceExploit']
+        fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'
+      end
     end
 
     unless writable? base_dir

--- a/modules/exploits/linux/local/recvmmsg_priv_esc.rb
+++ b/modules/exploits/linux/local/recvmmsg_priv_esc.rb
@@ -54,6 +54,7 @@ class MetasploitModule < Msf::Exploit::Local
       OptEnum.new('COMPILE', [ true, 'Compile on target', 'Auto', %w(Auto True False) ])
     ]
     register_advanced_options [
+      OptBool.new('ForceExploit',  [ false, 'Override check result', false ]),
       OptString.new('WritableDir', [ true, 'A directory where we can write files (must not be mounted noexec)', '/tmp' ])
     ]
   end
@@ -132,7 +133,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     release = kernel_release
     unless release =~ /^3\.11\.0-(12|15)-generic/ || release.eql?('3.8.0-19-generic')
-      print_error "Kernel #{release} #{version} is not exploitable"
+      vprint_error "Kernel #{release} #{version} is not exploitable"
       return CheckCode::Safe
     end
     vprint_good "Kernel #{release} #{version} is exploitable"
@@ -141,12 +142,17 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    if is_root?
-      fail_with Failure::BadConfig, 'Session already has root privileges'
+    unless check == CheckCode::Appears
+      unless datastore['ForceExploit']
+        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
+      end
+      print_warning 'Target does not appear to be vulnerable'
     end
 
-    if check != CheckCode::Appears
-      fail_with Failure::NotVulnerable, 'Target not vulnerable! punt!'
+    if is_root?
+      unless datastore['ForceExploit']
+        fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'
+      end
     end
 
     unless writable? base_dir

--- a/modules/exploits/linux/local/sock_sendpage.rb
+++ b/modules/exploits/linux/local/sock_sendpage.rb
@@ -69,6 +69,7 @@ class MetasploitModule < Msf::Exploit::Local
       OptBool.new('DEBUG_EXPLOIT', [ true, "Make the exploit executable be verbose about what it's doing", false ])
     ]
     register_advanced_options [
+      OptBool.new('ForceExploit',  [ false, 'Override check result', false ]),
       OptString.new('WritableDir', [ true, 'A directory where we can write files (must not be mounted noexec)', '/tmp' ])
     ]
   end
@@ -133,11 +134,16 @@ class MetasploitModule < Msf::Exploit::Local
 
   def exploit
     if check == CheckCode::Safe
-      fail_with Failure::NotVulnerable, 'Target is not vulnerable'
+      unless datastore['ForceExploit']
+        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
+      end
+      print_warning 'Target does not appear to be vulnerable'
     end
 
     if is_root?
-      fail_with Failure::BadConfig, 'Session already has root privileges'
+      unless datastore['ForceExploit']
+        fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'
+      end
     end
 
     unless writable? base_dir

--- a/modules/exploits/linux/local/ufo_privilege_escalation.rb
+++ b/modules/exploits/linux/local/ufo_privilege_escalation.rb
@@ -70,6 +70,7 @@ class MetasploitModule < Msf::Exploit::Local
       OptEnum.new('COMPILE', [ true, 'Compile on target', 'Auto', %w[Auto True False] ])
     ]
     register_advanced_options [
+      OptBool.new('ForceExploit',  [ false, 'Override check result', false ]),
       OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ])
     ]
   end
@@ -162,11 +163,16 @@ class MetasploitModule < Msf::Exploit::Local
 
   def exploit
     unless check == CheckCode::Appears
-      fail_with Failure::NotVulnerable, 'Target not vulnerable! punt!'
+      unless datastore['ForceExploit']
+        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
+      end
+      print_warning 'Target does not appear to be vulnerable'
     end
 
     if is_root?
-      fail_with Failure::BadConfig, 'Session already has root privileges'
+      unless datastore['ForceExploit']
+        fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'
+      end
     end
 
     unless writable? base_dir


### PR DESCRIPTION
Add `ForceExploit` option to various Linux local exploits.

Some of these changes are more useful than others. In most instances, if a well-written `check` method says that the remote host it not exploitable, then the remote host is not exploitable. None the less, it's nice to have options.

Of particular note is allowing `ForceExploit` to bypass the `is_root?` check (which traditionally has been performed inside the `exploit` method, rather than inside `check`). This is important, as the `is_root?` check is not namespace safe. It will return `true` when `UID=0`, however it's possible to have `UID=0` in a namespace without being "real" `root`. It's probable that a user with `root` in a namespace will wish to launch a kernel exploit to escape the namespace and gain elevated privileges. Prior to this PR, this workflow was not possible without modifying the module source.

The `is_root?` check was only ever performed to prevent operator error. As such, the operator should have a way to bypass it if they so desire.
