### PR TITLE
Prepend python path

### DIFF
--- a/lib/msf/core/modules/external/bridge.rb
+++ b/lib/msf/core/modules/external/bridge.rb
@@ -174,11 +174,7 @@ class Msf::Modules::External::PyBridge < Msf::Modules::External::Bridge
   def initialize(module_path, framework: nil)
     super
     pythonpath = ENV['PYTHONPATH'] || ''
-    if pythonpath.empty?
-      self.env = self.env.merge({ 'PYTHONPATH' => File.expand_path('../python', __FILE__)})
-    else
-      self.env = self.env.merge({ 'PYTHONPATH' => File.expand_path('../python', __FILE__) + File::PATH_SEPARATOR + pythonpath})
-    end
+    self.env = self.env.merge({ 'PYTHONPATH' => File.expand_path('../python', __FILE__) + File::PATH_SEPARATOR + pythonpath})
   end
 end
 

--- a/lib/msf/core/modules/external/bridge.rb
+++ b/lib/msf/core/modules/external/bridge.rb
@@ -174,7 +174,11 @@ class Msf::Modules::External::PyBridge < Msf::Modules::External::Bridge
   def initialize(module_path, framework: nil)
     super
     pythonpath = ENV['PYTHONPATH'] || ''
-    self.env = self.env.merge({ 'PYTHONPATH' => pythonpath + File::PATH_SEPARATOR + File.expand_path('../python', __FILE__) })
+    if pythonpath.empty?
+      self.env = self.env.merge({ 'PYTHONPATH' => File.expand_path('../python', __FILE__)})
+    else
+      self.env = self.env.merge({ 'PYTHONPATH' => File.expand_path('../python', __FILE__) + File::PATH_SEPARATOR + pythonpath})
+    end
   end
 end
 

--- a/lib/msf/core/modules/external/bridge.rb
+++ b/lib/msf/core/modules/external/bridge.rb
@@ -202,7 +202,7 @@ class Msf::Modules::External::GoBridge < Msf::Modules::External::Bridge
   def initialize(module_path, framework: nil)
     super
     gopath = ENV['GOPATH'] || ''
-    self.env = self.env.merge({ 'GOPATH' => gopath + File::PATH_SEPARATOR + File.expand_path('../go', __FILE__) })
+    self.env = self.env.merge({ 'GOPATH' => File.expand_path('../go', __FILE__) + File::PATH_SEPARATOR + gopath})
     self.cmd = ['go', 'run', self.path]
   end
 end


### PR DESCRIPTION
Prepend metasploit python module path.
Fixes #10933 

## Verification

- [x] Patch in a `$stderr.puts self.env` after the change
- [x] `PYTHONPATH=/tmp/path:$PYTHONPATH ./msfconsole -q`
- [x] `use exploit/windows/smb/ms17_010_eternalblue_win8`
- [x] Verify module path is prepended to PYTHONPATH