### PR TITLE
Update all DataProxy modules to use data_service_operation block

### DIFF
--- a/lib/metasploit/framework/data_service/proxy/credential_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/credential_data_proxy.rb
@@ -2,8 +2,9 @@ module CredentialDataProxy
 
   def create_credential(opts)
     begin
-      data_service = self.get_data_service
-      data_service.create_credential(opts)
+      self.data_service_operation do |data_service|
+        data_service.create_credential(opts)
+      end
     rescue => e
       self.log_error(e, "Problem creating credential")
     end
@@ -11,21 +12,22 @@ module CredentialDataProxy
 
   def create_cracked_credential(opts)
     begin
-      data_service = self.get_data_service
-      opts[:workspace_id] = workspace.id
-      opts[:private_data] = opts.delete(:password)
-      opts[:private_type] = :password
-      old_core = data_service.creds(id: opts.delete(:core_id)).first
-      if old_core
-        opts[:originating_core_id] = old_core.id
-        opts[:origin_type] = :cracked_password
+      self.data_service_operation do |data_service|
+        opts[:workspace_id] = workspace.id
+        opts[:private_data] = opts.delete(:password)
+        opts[:private_type] = :password
+        old_core = data_service.creds(id: opts.delete(:core_id)).first
+        if old_core
+          opts[:originating_core_id] = old_core.id
+          opts[:origin_type] = :cracked_password
+        end
+        new_core = data_service.create_credential(opts)
+        old_core.logins.each do |login|
+          service = data_service.services(id: login.service_id)
+          data_service.create_credential_login(core: new_core, service_id: service.id, status: Metasploit::Model::Login::Status::UNTRIED)
+        end
+        new_core
       end
-      new_core = data_service.create_credential(opts)
-      old_core.logins.each do |login|
-        service = data_service.services(id: login.service_id)
-        data_service.create_credential_login(core: new_core, service_id: service.id, status: Metasploit::Model::Login::Status::UNTRIED)
-      end
-      new_core
     rescue => e
       self.log_error(e, "Problem creating cracked credential")
     end
@@ -33,11 +35,12 @@ module CredentialDataProxy
 
   def create_credential_and_login(opts)
     begin
-      data_service = self.get_data_service
-      core = data_service.create_credential(opts)
-      opts[:core] = core
-      login = data_service.create_credential_login(opts)
-      core
+      self.data_service_operation do |data_service|
+        core = data_service.create_credential(opts)
+        opts[:core] = core
+        login = data_service.create_credential_login(opts)
+        core
+      end
     rescue => e
       self.log_error(e, "Problem creating credential and login")
     end
@@ -45,9 +48,10 @@ module CredentialDataProxy
 
   def creds(opts = {})
     begin
-      data_service = self.get_data_service
-      add_opts_workspace(opts)
-      data_service.creds(opts)
+      self.data_service_operation do |data_service|
+        add_opts_workspace(opts)
+        data_service.creds(opts)
+      end
     rescue => e
       self.log_error(e, "Problem retrieving credentials")
     end
@@ -55,9 +59,10 @@ module CredentialDataProxy
 
   def update_credential(opts)
     begin
-      data_service = self.get_data_service
-      add_opts_workspace(opts)
-      data_service.update_credential(opts)
+      self.data_service_operation do |data_service|
+        add_opts_workspace(opts)
+        data_service.update_credential(opts)
+      end
     rescue => e
       self.log_error(e, "Problem updating credential")
     end
@@ -65,8 +70,9 @@ module CredentialDataProxy
 
   def delete_credentials(opts)
     begin
-      data_service = self.get_data_service
-      data_service.delete_credentials(opts)
+      self.data_service_operation do |data_service|
+        data_service.delete_credentials(opts)
+      end
     rescue => e
       self.log_error(e, "Problem deleting credentials")
     end

--- a/lib/metasploit/framework/data_service/proxy/db_export_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/db_export_data_proxy.rb
@@ -1,13 +1,14 @@
 module DbExportDataProxy
   def run_db_export(path, format)
     begin
-      data_service = self.get_data_service
-      opts = {
-          path: path,
-          format: format
-      }
-      add_opts_workspace(opts)
-      data_service.run_db_export(opts)
+      self.data_service_operation do |data_service|
+        opts = {
+            path: path,
+            format: format
+        }
+        add_opts_workspace(opts)
+        data_service.run_db_export(opts)
+      end
     rescue => e
       self.log_error(e, "Problem generating DB Export")
     end

--- a/lib/metasploit/framework/data_service/proxy/db_import_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/db_import_data_proxy.rb
@@ -1,9 +1,10 @@
 module DbImportDataProxy
   def import(opts, &block)
     begin
-      data_service = self.get_data_service
-      add_opts_workspace(opts)
-      data_service.import(opts, &block)
+      self.data_service_operation do |data_service|
+        add_opts_workspace(opts)
+        data_service.import(opts, &block)
+      end
     rescue Exception => e
       self.log_error(e, "Problem generating DB Export")
     end
@@ -11,9 +12,10 @@ module DbImportDataProxy
 
   def import_file(opts, &block)
     begin
-      data_service = self.get_data_service
-      add_opts_workspace(opts)
-      data_service.import_file(opts, &block)
+      self.data_service_operation do |data_service|
+        add_opts_workspace(opts)
+        data_service.import_file(opts, &block)
+      end
     rescue Exception => e
       self.log_error(e, "Problem generating DB Export")
     end

--- a/lib/metasploit/framework/data_service/proxy/event_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/event_data_proxy.rb
@@ -2,9 +2,10 @@ module EventDataProxy
 
   def report_event(opts)
     begin
-      data_service = self.get_data_service
-      add_opts_workspace(opts)
-      data_service.report_event(opts)
+      self.data_service_operation do |data_service|
+        add_opts_workspace(opts)
+        data_service.report_event(opts)
+      end
     rescue => e
       self.log_error(e, "Problem reporting event")
     end

--- a/lib/metasploit/framework/data_service/proxy/exploit_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/exploit_data_proxy.rb
@@ -2,8 +2,9 @@ module ExploitDataProxy
 
   def report_exploit_attempt(host, opts)
     begin
-      data_service = self.get_data_service
-      data_service.report_exploit_attempt(host, opts)
+      self.data_service_operation do |data_service|
+        data_service.report_exploit_attempt(host, opts)
+      end
     rescue => e
       self.log_error(e, "Problem reporting exploit attempt")
     end
@@ -11,9 +12,10 @@ module ExploitDataProxy
 
   def report_exploit_failure(opts)
     begin
-      data_service = self.get_data_service
-      add_opts_workspace(opts)
-      data_service.report_exploit_failure(opts)
+      self.data_service_operation do |data_service|
+        add_opts_workspace(opts)
+        data_service.report_exploit_failure(opts)
+      end
     rescue => e
       self.log_error(e, "Problem reporting exploit failure")
     end
@@ -21,9 +23,10 @@ module ExploitDataProxy
 
   def report_exploit_success(opts)
     begin
-      data_service = self.get_data_service
-      add_opts_workspace(opts)
-      data_service.report_exploit_success(opts)
+      self.data_service_operation do |data_service|
+        add_opts_workspace(opts)
+        data_service.report_exploit_success(opts)
+      end
     rescue => e
       self.log_error(e, "Problem reporting exploit success")
     end

--- a/lib/metasploit/framework/data_service/proxy/host_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/host_data_proxy.rb
@@ -2,12 +2,13 @@ module HostDataProxy
 
   def hosts(opts = {})
     begin
-      data_service = self.get_data_service
-      opts[:non_dead] = false unless opts.has_key?(:non_dead)
-      opts[:address] = opts.delete(:address) || opts.delete(:host)
-      opts[:search_term] = nil unless opts.has_key?(:search_term)
-      add_opts_workspace(opts)
-      data_service.hosts(opts)
+      self.data_service_operation do |data_service|
+        opts[:non_dead] = false unless opts.has_key?(:non_dead)
+        opts[:address] = opts.delete(:address) || opts.delete(:host)
+        opts[:search_term] = nil unless opts.has_key?(:search_term)
+        add_opts_workspace(opts)
+        data_service.hosts(opts)
+      end
     rescue => e
       self.log_error(e, "Problem retrieving hosts")
     end
@@ -29,8 +30,9 @@ module HostDataProxy
 
   def get_host(opts)
     begin
-      data_service = self.get_data_service
-      data_service.get_host(opts)
+      self.data_service_operation do |data_service|
+        data_service.get_host(opts)
+      end
     rescue => e
       self.log_error(e, "Problem retrieving host")
     end
@@ -40,9 +42,10 @@ module HostDataProxy
     return unless valid(opts)
 
     begin
-      data_service = self.get_data_service
-      add_opts_workspace(opts)
-      data_service.report_host(opts)
+      self.data_service_operation do |data_service|
+        add_opts_workspace(opts)
+        data_service.report_host(opts)
+      end
     rescue => e
       self.log_error(e, "Problem reporting host")
     end
@@ -50,8 +53,9 @@ module HostDataProxy
 
   def update_host(opts)
     begin
-      data_service = self.get_data_service
-      data_service.update_host(opts)
+      self.data_service_operation do |data_service|
+        data_service.update_host(opts)
+      end
     rescue => e
       self.log_error(e, "Problem updating host")
     end
@@ -59,8 +63,9 @@ module HostDataProxy
 
   def delete_host(opts)
     begin
-      data_service = self.get_data_service
-      data_service.delete_host(opts)
+      self.data_service_operation do |data_service|
+        data_service.delete_host(opts)
+      end
     rescue => e
       self.log_error(e, "Problem deleting host")
     end

--- a/lib/metasploit/framework/data_service/proxy/login_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/login_data_proxy.rb
@@ -1,8 +1,9 @@
 module LoginDataProxy
   def logins(opts = {})
     begin
-      data_service = self.get_data_service
-      data_service.logins(opts)
+      self.data_service_operation do |data_service|
+        data_service.logins(opts)
+      end
     rescue => e
       self.log_error(e, "Problem retrieving logins")
     end
@@ -10,8 +11,9 @@ module LoginDataProxy
 
   def create_credential_login(opts)
     begin
-      data_service = self.get_data_service
-      data_service.create_credential_login(opts)
+      self.data_service_operation do |data_service|
+        data_service.create_credential_login(opts)
+      end
     rescue => e
       self.log_error(e, "Problem creating login")
     end
@@ -19,8 +21,9 @@ module LoginDataProxy
 
   def update_login(opts)
     begin
-      data_service = self.get_data_service
-      data_service.update_login(opts)
+      self.data_service_operation do |data_service|
+        data_service.update_login(opts)
+      end
     rescue => e
       self.log_error(e, "Problem updating login")
     end

--- a/lib/metasploit/framework/data_service/proxy/loot_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/loot_data_proxy.rb
@@ -2,12 +2,13 @@ module LootDataProxy
 
   def report_loot(opts)
     begin
-      data_service = self.get_data_service
-      if !data_service.is_a?(Msf::DBManager)
-        opts[:data] = Base64.urlsafe_encode64(opts[:data]) if opts[:data]
+      self.data_service_operation do |data_service|
+        if !data_service.is_a?(Msf::DBManager)
+          opts[:data] = Base64.urlsafe_encode64(opts[:data]) if opts[:data]
+        end
+        add_opts_workspace(opts)
+        data_service.report_loot(opts)
       end
-      add_opts_workspace(opts)
-      data_service.report_loot(opts)
     rescue => e
       self.log_error(e, "Problem reporting loot")
     end
@@ -37,9 +38,10 @@ module LootDataProxy
 
   def loots(opts = {})
     begin
-      data_service = self.get_data_service
-      add_opts_workspace(opts)
-      data_service.loot(opts)
+      self.data_service_operation do |data_service|
+        add_opts_workspace(opts)
+        data_service.loot(opts)
+      end
     rescue => e
       self.log_error(e, "Problem retrieving loot")
     end
@@ -49,8 +51,9 @@ module LootDataProxy
 
   def update_loot(opts)
     begin
-      data_service = self.get_data_service
-      data_service.update_loot(opts)
+      self.data_service_operation do |data_service|
+        data_service.update_loot(opts)
+      end
     rescue => e
       self.log_error(e, "Problem updating loot")
     end

--- a/lib/metasploit/framework/data_service/proxy/msf_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/msf_data_proxy.rb
@@ -1,8 +1,9 @@
 module MsfDataProxy
   def get_msf_version
     begin
-      data_service = self.get_data_service
-      data_service.get_msf_version
+      self.data_service_operation do |data_service|
+        data_service.get_msf_version
+      end
     rescue => e
       self.log_error(e, "Problem retrieving Metasploit version")
     end

--- a/lib/metasploit/framework/data_service/proxy/nmap_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/nmap_data_proxy.rb
@@ -2,9 +2,10 @@ module NmapDataProxy
 
   def import_nmap_xml_file(args = {})
     begin
-      data_service = self.get_data_service
-      add_opts_workspace(args)
-      data_service.import_nmap_xml_file(args)
+      self.data_service_operation do |data_service|
+        add_opts_workspace(args)
+        data_service.import_nmap_xml_file(args)
+      end
     rescue => e
       self.log_error(e, "Problem importing Nmap XML file")
     end

--- a/lib/metasploit/framework/data_service/proxy/note_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/note_data_proxy.rb
@@ -2,9 +2,10 @@ module NoteDataProxy
 
   def notes(opts)
     begin
-      data_service = self.get_data_service
-      add_opts_workspace(opts)
-      data_service.notes(opts)
+      self.data_service_operation do |data_service|
+        add_opts_workspace(opts)
+        data_service.notes(opts)
+      end
     rescue => e
       self.log_error(e, "Problem retrieving notes")
     end
@@ -34,9 +35,10 @@ module NoteDataProxy
 
   def report_note(opts)
     begin
-      data_service = self.get_data_service
-      add_opts_workspace(opts)
-      data_service.report_note(opts)
+      self.data_service_operation do |data_service|
+        add_opts_workspace(opts)
+        data_service.report_note(opts)
+      end
     rescue => e
       self.log_error(e, "Problem reporting note")
     end
@@ -44,8 +46,9 @@ module NoteDataProxy
 
   def update_note(opts)
     begin
-      data_service = self.get_data_service
-      data_service.update_note(opts)
+      self.data_service_operation do |data_service|
+        data_service.update_note(opts)
+      end
     rescue => e
       self.log_error(e, "Problem updating note")
     end
@@ -53,8 +56,9 @@ module NoteDataProxy
 
   def delete_note(opts)
     begin
-      data_service = self.get_data_service
-      data_service.delete_note(opts)
+      self.data_service_operation do |data_service|
+        data_service.delete_note(opts)
+      end
     rescue => e
       self.log_error(e, "Problem deleting note")
     end

--- a/lib/metasploit/framework/data_service/proxy/service_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/service_data_proxy.rb
@@ -2,9 +2,10 @@ module ServiceDataProxy
 
   def services(opts = {})
     begin
-      data_service = self.get_data_service
-      add_opts_workspace(opts)
-      data_service.services(opts)
+      self.data_service_operation do |data_service|
+        add_opts_workspace(opts)
+        data_service.services(opts)
+      end
     rescue => e
       self.log_error(e, 'Problem retrieving services')
     end
@@ -32,9 +33,10 @@ module ServiceDataProxy
 
   def report_service(opts)
     begin
-      data_service = self.get_data_service
-      add_opts_workspace(opts)
-      data_service.report_service(opts)
+      self.data_service_operation do |data_service|
+        add_opts_workspace(opts)
+        data_service.report_service(opts)
+      end
     rescue => e
       self.log_error(e, 'Problem reporting service')
     end
@@ -42,8 +44,9 @@ module ServiceDataProxy
 
   def update_service(opts)
     begin
-      data_service = self.get_data_service
-      data_service.update_service(opts)
+      self.data_service_operation do |data_service|
+        data_service.update_service(opts)
+      end
     rescue => e
       self.log_error(e, 'Problem updating service')
     end
@@ -51,8 +54,9 @@ module ServiceDataProxy
 
   def delete_service(opts)
     begin
-      data_service = self.get_data_service
-      data_service.delete_service(opts)
+      self.data_service_operation do |data_service|
+        data_service.delete_service(opts)
+      end
     rescue => e
       self.log_error(e, 'Problem deleting service')
     end

--- a/lib/metasploit/framework/data_service/proxy/vuln_attempt_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/vuln_attempt_data_proxy.rb
@@ -2,8 +2,9 @@ module VulnAttemptDataProxy
 
   def vuln_attempts(opts)
     begin
-      data_service = self.get_data_service
-      data_service.vuln_attempts(opts)
+      self.data_service_operation do |data_service|
+        data_service.vuln_attempts(opts)
+      end
     rescue => e
       self.log_error(e, "Problem retrieving vulnerability attempts")
     end
@@ -11,9 +12,10 @@ module VulnAttemptDataProxy
 
   def report_vuln_attempt(vuln, opts)
     begin
-      data_service = self.get_data_service
-      add_opts_workspace(opts)
-      data_service.report_vuln_attempt(vuln, opts)
+      self.data_service_operation do |data_service|
+        add_opts_workspace(opts)
+        data_service.report_vuln_attempt(vuln, opts)
+      end
     rescue => e
       self.log_error(e, "Problem reporting vulnerability attempts")
     end

--- a/lib/metasploit/framework/data_service/proxy/vuln_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/vuln_data_proxy.rb
@@ -3,9 +3,10 @@ module VulnDataProxy
 
   def vulns(opts)
     begin
-      data_service = self.get_data_service
-      add_opts_workspace(opts)
-      data_service.vulns(opts)
+      self.data_service_operation do |data_service|
+        add_opts_workspace(opts)
+        data_service.vulns(opts)
+      end
     rescue => e
       self.log_error(e, "Problem retrieving vulns")
     end
@@ -27,9 +28,10 @@ module VulnDataProxy
 
   def report_vuln(opts)
     begin
-      data_service = self.get_data_service
-      add_opts_workspace(opts)
-      data_service.report_vuln(opts)
+      self.data_service_operation do |data_service|
+        add_opts_workspace(opts)
+        data_service.report_vuln(opts)
+      end
     rescue => e
       self.log_error(e, "Problem reporting vuln")
     end
@@ -37,8 +39,9 @@ module VulnDataProxy
 
   def update_vuln(opts)
     begin
-      data_service = self.get_data_service
-      data_service.update_vuln(opts)
+      self.data_service_operation do |data_service|
+        data_service.update_vuln(opts)
+      end
     rescue => e
       self.log_error(e, "Problem updating vuln")
     end
@@ -46,8 +49,9 @@ module VulnDataProxy
 
   def delete_vuln(opts)
     begin
-      data_service = self.get_data_service
-      data_service.delete_vuln(opts)
+      self.data_service_operation do |data_service|
+        data_service.delete_vuln(opts)
+      end
     rescue => e
       self.log_error(e, "Problem deleting vuln")
     end

--- a/lib/metasploit/framework/data_service/proxy/web_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/web_data_proxy.rb
@@ -1,8 +1,9 @@
 module WebDataProxy
   def report_web_site(opts)
     begin
-      data_service = self.get_data_service()
-      data_service.report_web_site(opts)
+      self.data_service_operation do |data_service|
+        data_service.report_web_site(opts)
+      end
     rescue => e
       self.log_error(e, "Problem reporting website")
     end

--- a/lib/metasploit/framework/data_service/proxy/workspace_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/workspace_data_proxy.rb
@@ -2,9 +2,10 @@ module WorkspaceDataProxy
 
   def find_workspace(workspace_name)
     begin
-      data_service = self.get_data_service
-      opts = { name: workspace_name }
-      data_service.workspaces(opts).first
+      self.data_service_operation do |data_service|
+        opts = { name: workspace_name }
+        data_service.workspaces(opts).first
+      end
     rescue => e
       self.log_error(e, "Problem finding workspace")
     end
@@ -12,9 +13,10 @@ module WorkspaceDataProxy
 
   def add_workspace(workspace_name)
     begin
-      data_service = self.get_data_service
-      opts = { name: workspace_name }
-      data_service.add_workspace(opts)
+      self.data_service_operation do |data_service|
+        opts = { name: workspace_name }
+        data_service.add_workspace(opts)
+      end
     rescue => e
       self.log_error(e, "Problem adding workspace")
     end
@@ -57,8 +59,9 @@ module WorkspaceDataProxy
 
   def workspaces(opts = {})
     begin
-      data_service = self.get_data_service
-      data_service.workspaces(opts)
+      self.data_service_operation do |data_service|
+        data_service.workspaces(opts)
+      end
     rescue => e
       self.log_error(e, "Problem retrieving workspaces")
     end
@@ -66,8 +69,9 @@ module WorkspaceDataProxy
 
   def delete_workspaces(opts)
     begin
-      data_service = self.get_data_service
-      data_service.delete_workspaces(opts)
+      self.data_service_operation do |data_service|
+        data_service.delete_workspaces(opts)
+      end
     rescue => e
       self.log_error(e, "Problem deleting workspaces")
     end
@@ -75,8 +79,9 @@ module WorkspaceDataProxy
 
   def update_workspace(opts)
     begin
-      data_service = self.get_data_service
-      data_service.update_workspace(opts)
+      self.data_service_operation do |data_service|
+        data_service.update_workspace(opts)
+      end
     rescue => e
       self.log_error(e, "Problem updating workspace")
     end


### PR DESCRIPTION
Updates all of the `DataProxy` modules to use the `data_service_operation` block to perform work as I noted in Green-m/metasploit-framework#2.

Ticket: MS-3599

## Verification

- [ ] Ensure database and MSF web service (data services) are running `msfdb status`, and start or init if necessary
- [ ] Start `msfconsole` and connect to the data service started above if you didn't select the option to connect automatically during initialization. See [Metasploit Web Service](https://github.com/rapid7/metasploit-framework/wiki/Metasploit-Web-Service) for more information.
- [ ] **Verify** `db_status` reports `Connection type: http. Connected to remote_data_service: (https://localhost:8080)`
- [ ] Perform various data operations (`hosts`, `services`, `vulns`, `creds`, `loots`, `notes`)
- [ ] **Verify** data operations operate as expected

