### PR TITLE
Fix db_connect issue when re-establishing DB connection after msfconsole started without DB connection

### DIFF
--- a/lib/msf/core/db_manager/connection.rb
+++ b/lib/msf/core/db_manager/connection.rb
@@ -20,6 +20,9 @@ module Msf::DBManager::Connection
       self.error = exception
       elog("DB.connect threw an exception: #{exception}")
       dlog("Call stack: #{exception.backtrace.join("\n")}", LEV_1)
+
+      # remove connection to prevent issues when re-establishing connection
+      ActiveRecord::Base.remove_connection
     else
       # Flag that migration has completed
       self.migrated = true


### PR DESCRIPTION
Fixes #10948, an issue where `db_connect` does not work correctly when `msfconsole` is started without a database connection.

## Verification

- [x] Rename `~/.msf4/database.yml` to `~/.msf4/database.yml.disabled` so that `msfconsole` starts without database support
- [x] Stop the database: `./msfdb --component database stop`
- [x] Start `msfconsole`
- [x] Run `db_status` and note a message indicating there is no connection "postgresql selected, no connection"
- [x] Run `db_connect` with appropriate options to connect to your local postgresql instance
- [x] **Verify** an error occurred while running the command "Failed to connect to the Postgres data service"
- [x] Start the database: `./msfdb --component database start`
- [x] Run `db_connect` again with appropriate options to connect to your local postgresql instance
- [x] **Verify** the `db_connect` command was successful ("Connected to Postgres data service")
- [x] **Verify** `db_status` reports a valid connection and various database commands (`hosts`, `services`, `vulns`, `creds`, `loots`, `notes`) work as expected
