### PR TITLE
Fix extraneous whitespace in check output

### DIFF
--- a/lib/msf/ui/console/module_command_dispatcher.rb
+++ b/lib/msf/ui/console/module_command_dispatcher.rb
@@ -221,6 +221,7 @@ module ModuleCommandDispatcher
       rport = instance.rport if instance.respond_to?(:rport)
       peer = "#{rhost}:#{rport}"
     end
+    peer_msg = "#{peer} - " if peer
 
     begin
       if instance.respond_to?(:check_simple)
@@ -235,15 +236,15 @@ module ModuleCommandDispatcher
 
       if (code and code.kind_of?(Array) and code.length > 1)
         if (code == Msf::Exploit::CheckCode::Vulnerable)
-          print_good("#{peer} #{code[1]}")
+          print_good("#{peer_msg}#{code[1]}")
           # Restore RHOST for report_vuln
           instance.datastore['RHOST'] ||= rhost
           report_vuln(instance)
         else
-          print_status("#{peer} #{code[1]}")
+          print_status("#{peer_msg}#{code[1]}")
         end
       else
-        msg = "#{peer} Check failed: The state could not be determined."
+        msg = "#{peer_msg}Check failed: The state could not be determined."
         print_error(msg)
         elog("#{msg}\n#{caller.join("\n")}")
       end

--- a/lib/msf/ui/console/module_command_dispatcher.rb
+++ b/lib/msf/ui/console/module_command_dispatcher.rb
@@ -221,7 +221,7 @@ module ModuleCommandDispatcher
       rport = instance.rport if instance.respond_to?(:rport)
       peer = "#{rhost}:#{rport}"
     end
-    peer_msg = "#{peer} - " if peer
+    peer_msg = peer ? "#{peer} - " : ''
 
     begin
       if instance.respond_to?(:check_simple)


### PR DESCRIPTION
Death to the peer gods.

```
msf5 exploit(unix/local/exim_perl_startup) > check

[!] SESSION may not be compatible with this module.
[*]  The target is not exploitable.
msf5 exploit(unix/local/exim_perl_startup) >
```

#6526, #6907