### PR TITLE
Rework session_compatible? check in post mixin, excluding ARCH_CMD modules

### DIFF
--- a/lib/msf/core/post_mixin.rb
+++ b/lib/msf/core/post_mixin.rb
@@ -35,7 +35,7 @@ module Msf::PostMixin
       raise Msf::OptionValidateError.new(['SESSION'])
     end
 
-    unless session_compatible?(session)
+    if self.type == Msf::MODULE_POST && !session_compatible?(session)
       print_warning('SESSION may not be compatible with this module.')
     end
 

--- a/lib/msf/core/post_mixin.rb
+++ b/lib/msf/core/post_mixin.rb
@@ -160,7 +160,7 @@ module Msf::PostMixin
     end
 
     # Can't do anything without a session
-    return false if s.nil?
+    return false unless s
 
     # Can't be compatible if it's the wrong type
     if session_types
@@ -169,7 +169,7 @@ module Msf::PostMixin
 
     # Check to make sure architectures match
     mod_arch = self.module_info['Arch']
-    unless mod_arch.nil?
+    if mod_arch
       mod_arch = [mod_arch] unless mod_arch.kind_of?(Array)
       # Assume ARCH_CMD modules can work on supported SessionTypes
       return true if mod_arch.include?(ARCH_CMD)
@@ -177,13 +177,13 @@ module Msf::PostMixin
     end
 
     # Arch is okay, now check the platform.
-    if self.platform and self.platform.kind_of?(Msf::Module::PlatformList)
+    if self.platform && self.platform.kind_of?(Msf::Module::PlatformList)
       return false unless self.platform.supports?(Msf::Module::PlatformList.transform(s.platform))
     end
 
     # If we got here, we haven't found anything that definitely
     # disqualifies this session.  Assume that means we can use it.
-    return true
+    true
   end
 
   #

--- a/lib/msf/core/post_mixin.rb
+++ b/lib/msf/core/post_mixin.rb
@@ -35,7 +35,7 @@ module Msf::PostMixin
       raise Msf::OptionValidateError.new(['SESSION'])
     end
 
-    if self.type == Msf::MODULE_POST && !session_compatible?(session)
+    unless session_compatible?(session)
       print_warning('SESSION may not be compatible with this module.')
     end
 
@@ -167,16 +167,18 @@ module Msf::PostMixin
       return false unless session_types.include?(s.type)
     end
 
-    # Types are okay, now check the platform.
-    if self.platform and self.platform.kind_of?(Msf::Module::PlatformList)
-      return false unless self.platform.supports?(Msf::Module::PlatformList.transform(s.platform))
-    end
-
     # Check to make sure architectures match
     mod_arch = self.module_info['Arch']
     unless mod_arch.nil?
       mod_arch = [mod_arch] unless mod_arch.kind_of?(Array)
+      # Assume ARCH_CMD modules can work on supported SessionTypes
+      return true if mod_arch.include?(ARCH_CMD)
       return false unless mod_arch.include?(s.arch)
+    end
+
+    # Arch is okay, now check the platform.
+    if self.platform and self.platform.kind_of?(Msf::Module::PlatformList)
+      return false unless self.platform.supports?(Msf::Module::PlatformList.transform(s.platform))
     end
 
     # If we got here, we haven't found anything that definitely

--- a/lib/msf/core/post_mixin.rb
+++ b/lib/msf/core/post_mixin.rb
@@ -138,13 +138,16 @@ module Msf::PostMixin
   #
   # Checks the session's type against this module's
   # <tt>module_info["SessionTypes"]</tt> as well as examining platform
-  # compatibility.  +sess_or_sid+ can be a Session object, Integer, or
-  # String.  In the latter cases it should be a key in
+  # and arch compatibility.
+  #
+  # +sess_or_sid+ can be a Session object, Integer, or
+  # String. In the latter cases it should be a key in
   # +framework.sessions+.
   #
   # @note Because it errs on the side of compatibility, a true return
   #   value from this method does not guarantee the module will work
-  #   with the session.
+  #   with the session. For example, ARCH_CMD modules can work on a
+  #   variety of platforms and archs and thus return true in this check.
   #
   # @param sess_or_sid [Msf::Session,Integer,String]
   #   A session or session ID to compare against this module for


### PR DESCRIPTION
`ARCH_CMD` modules can work on a variety of platforms and archs.

```
msf5 exploit(unix/local/exim_perl_startup) > sessions

Active sessions
===============

  Id  Name  Type                   Information                                Connection
  --  ----  ----                   -----------                                ----------
  1         meterpreter x64/linux  uid=0, gid=0, euid=0, egid=0 @ 172.18.0.2  [redacted]:4444 -> [redacted]:55596 (127.0.0.1)

msf5 exploit(unix/local/exim_perl_startup) > check

[!] SESSION may not be compatible with this module.
[*]  The target is not exploitable.
msf5 exploit(unix/local/exim_perl_startup) >
```

`session_compatible?` is a lie.

#7736, #7737, #10127, #10971