### PR TITLE
Rework DisclosureDate check in msftidy, including ISO 8601 support

### DIFF
--- a/modules/auxiliary/dos/dns/bind_tkey.rb
+++ b/modules/auxiliary/dos/dns/bind_tkey.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Auxiliary
         ['URL', 'https://www.isc.org/blogs/cve-2015-5477-an-error-in-handling-tkey-queries-can-cause-named-to-exit-with-a-require-assertion-failure/'],
         ['URL', 'https://kb.isc.org/article/AA-01272']
       ],
-      'DisclosureDate' => 'Jul 28 2015',
+      'DisclosureDate' => '2015-07-28',
       'License'        => MSF_LICENSE,
       'DefaultOptions' => {'ScannerRecvWindow' => 0}
     ))

--- a/modules/auxiliary/gather/qnap_backtrace_admin_hash.rb
+++ b/modules/auxiliary/gather/qnap_backtrace_admin_hash.rb
@@ -27,7 +27,7 @@ class MetasploitModule < Msf::Auxiliary
         ['URL', 'https://seclists.org/fulldisclosure/2017/Feb/2'],
         ['URL', 'https://en.wikipedia.org/wiki/Binary_search_algorithm']
       ],
-      'DisclosureDate' => 'Jan 31 2017',
+      'DisclosureDate' => '2017-01-31',
       'License'        => MSF_LICENSE,
       'Actions'        => [
         ['Automatic', 'Description' => 'Automatic targeting'],

--- a/modules/auxiliary/scanner/http/apache_mod_cgi_bash_env.rb
+++ b/modules/auxiliary/scanner/http/apache_mod_cgi_bash_env.rb
@@ -38,7 +38,7 @@ class MetasploitModule < Msf::Auxiliary
         [ 'URL', 'https://access.redhat.com/articles/1200223' ],
         [ 'URL', 'https://seclists.org/oss-sec/2014/q3/649' ]
       ],
-      'DisclosureDate' => 'Sep 24 2014',
+      'DisclosureDate' => '2014-09-24',
       'License' => MSF_LICENSE,
       'Notes' => {'AKA' => ['Shellshock']}
     ))

--- a/modules/auxiliary/scanner/http/wordpress_content_injection.rb
+++ b/modules/auxiliary/scanner/http/wordpress_content_injection.rb
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Auxiliary
         ['URL',   'https://developer.wordpress.org/rest-api/using-the-rest-api/discovery/'],
         ['URL',   'https://developer.wordpress.org/rest-api/reference/posts/']
       ],
-      'DisclosureDate' => 'Feb 1 2017',
+      'DisclosureDate' => '2017-02-01',
       'License'        => MSF_LICENSE,
       'Actions'        => [
         ['LIST',   'Description' => 'List posts'],

--- a/modules/auxiliary/scanner/misc/clamav_control.rb
+++ b/modules/auxiliary/scanner/misc/clamav_control.rb
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Auxiliary
           [ 'URL', 'https://twitter.com/nitr0usmx/status/740673507684679680/photo/1' ],
           [ 'URL', 'https://github.com/vrtadmin/clamav-faq/raw/master/manual/clamdoc.pdf' ]
         ],
-        'DisclosureDate' => 'Jun 8 2016',
+        'DisclosureDate' => '2016-06-08',
         'Actions'        => [
           [ 'VERSION',  'Description' => 'Get Version Information' ],
           [ 'SHUTDOWN', 'Description' => 'Kills ClamAV Daemon' ]

--- a/modules/auxiliary/scanner/ssh/fortinet_backdoor.rb
+++ b/modules/auxiliary/scanner/ssh/fortinet_backdoor.rb
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Auxiliary
         ['URL', 'https://seclists.org/fulldisclosure/2016/Jan/26'],
         ['URL', 'https://blog.fortinet.com/post/brief-statement-regarding-issues-found-with-fortios']
       ],
-      'DisclosureDate' => 'Jan 9 2016',
+      'DisclosureDate' => '2016-01-09',
       'License'        => MSF_LICENSE
     ))
 

--- a/modules/auxiliary/scanner/ssh/libssh_auth_bypass.rb
+++ b/modules/auxiliary/scanner/ssh/libssh_auth_bypass.rb
@@ -34,7 +34,7 @@ class MetasploitModule < Msf::Auxiliary
         ['CVE', '2018-10933'],
         ['URL', 'https://www.libssh.org/security/advisories/CVE-2018-10933.txt']
       ],
-      'DisclosureDate' => 'Oct 16 2018',
+      'DisclosureDate' => '2018-10-16',
       'License'        => MSF_LICENSE,
       'Actions'        => [
         ['Shell',   'Description' => 'Spawn a shell'],

--- a/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
+++ b/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
@@ -144,7 +144,7 @@ class MetasploitModule < Msf::Auxiliary
           [ 'URL', 'https://gist.github.com/takeshixx/10107280' ],
           [ 'URL', 'http://filippo.io/Heartbleed/' ]
         ],
-      'DisclosureDate' => 'Apr 7 2014',
+      'DisclosureDate' => '2014-04-07',
       'License'        => MSF_LICENSE,
       'Actions'        =>
         [

--- a/modules/exploits/bsd/finger/morris_fingerd_bof.rb
+++ b/modules/exploits/bsd/finger/morris_fingerd_bof.rb
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ['URL', 'http://gunkies.org/wiki/Installing_4.3_BSD_on_SIMH'] # Setup
         # And credit to the innumerable VAX ISA docs on the Web
       ],
-      'DisclosureDate'    => 'Nov 2 1988',
+      'DisclosureDate'    => '1988-11-02',
       'License'           => MSF_LICENSE,
       'Platform'          => 'bsd',
       'Arch'              => ARCH_VAX,

--- a/modules/exploits/linux/http/apache_continuum_cmd_exec.rb
+++ b/modules/exploits/linux/http/apache_continuum_cmd_exec.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'References'     => [
         %w{EDB 39886}
       ],
-      'DisclosureDate' => 'Apr 6 2016',
+      'DisclosureDate' => '2016-04-06',
       'License'        => MSF_LICENSE,
       'Platform'       => 'linux',
       'Arch'           => [ARCH_X86, ARCH_X64],

--- a/modules/exploits/linux/http/axis_srv_parhand_rce.rb
+++ b/modules/exploits/linux/http/axis_srv_parhand_rce.rb
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ['URL', 'https://blog.vdoo.com/2018/06/18/vdoo-discovers-significant-vulnerabilities-in-axis-cameras/'],
         ['URL', 'https://www.axis.com/files/faq/Advisory_ACV-128401.pdf']
       ],
-      'DisclosureDate'      => 'Jun 18 2018',
+      'DisclosureDate'      => '2018-06-18',
       'License'             => MSF_LICENSE,
       'Platform'            => ['unix', 'linux'],
       'Arch'                => [ARCH_CMD, ARCH_ARMLE],

--- a/modules/exploits/linux/http/hp_van_sdn_cmd_inject.rb
+++ b/modules/exploits/linux/http/hp_van_sdn_cmd_inject.rb
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ['EDB', '44951'],
         ['URL', 'https://korelogic.com/Resources/Advisories/KL-001-2018-008.txt']
       ],
-      'DisclosureDate'     => 'Jun 25 2018',
+      'DisclosureDate'     => '2018-06-25',
       'License'            => MSF_LICENSE,
       'Platform'           => ['unix', 'linux'],
       'Arch'               => [ARCH_CMD, ARCH_X86, ARCH_X64],

--- a/modules/exploits/linux/http/nagios_xi_chained_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_chained_rce.rb
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'References'     => [
         ['EDB', '39899']
       ],
-      'DisclosureDate' => 'Mar 6 2016',
+      'DisclosureDate' => '2016-03-06',
       'License'        => MSF_LICENSE,
       'Platform'       => 'unix',
       'Arch'           => ARCH_CMD,

--- a/modules/exploits/linux/http/tr064_ntpserver_cmdinject.rb
+++ b/modules/exploits/linux/http/tr064_ntpserver_cmdinject.rb
@@ -38,7 +38,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'URL', 'https://isc.sans.edu/forums/diary/Port+7547+SOAP+Remote+Code+Execution+Attack+Against+DSL+Modems/21759'],
           [ 'URL', 'https://broadband-forum.org/technical/download/TR-064.pdf']
         ],
-      'DisclosureDate' => 'Nov 07 2016',
+      'DisclosureDate' => '2016-11-07',
       'Privileged'     => true,
       'Targets' =>
         [

--- a/modules/exploits/linux/http/trend_micro_imsva_exec.rb
+++ b/modules/exploits/linux/http/trend_micro_imsva_exec.rb
@@ -49,7 +49,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Platform'       => ['python'],
       'Arch'           => ARCH_PYTHON,
       'Targets'        => [ ['Automatic', {}] ],
-      'DisclosureDate' => 'Jan 15 2017',
+      'DisclosureDate' => '2017-01-15',
       'DefaultTarget'  => 0
        ))
 

--- a/modules/exploits/linux/ssh/ubiquiti_airos_file_upload.rb
+++ b/modules/exploits/linux/ssh/ubiquiti_airos_file_upload.rb
@@ -34,7 +34,7 @@ class MetasploitModule < Msf::Exploit::Remote
         %w{EDB 39701},
         %w{URL https://hackerone.com/reports/73480}
       ],
-      'DisclosureDate'     => 'Feb 13 2016',
+      'DisclosureDate'     => '2016-02-13',
       'License'            => MSF_LICENSE,
       'Platform'           => 'unix',
       'Arch'               => ARCH_CMD,

--- a/modules/exploits/linux/telnet/netgear_telnetenable.rb
+++ b/modules/exploits/linux/telnet/netgear_telnetenable.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ['URL', 'https://github.com/cyanitol/netgear-telenetenable'],
         ['URL', 'https://github.com/insanid/netgear-telenetenable']
       ],
-      'DisclosureDate'     => 'Oct 30 2009', # Python PoC (TCP)
+      'DisclosureDate'     => '2009-10-30', # Python PoC (TCP)
       'License'            => MSF_LICENSE,
       'Platform'           => 'unix',
       'Arch'               => ARCH_CMD,

--- a/modules/exploits/multi/fileformat/ghostscript_failed_restore.rb
+++ b/modules/exploits/multi/fileformat/ghostscript_failed_restore.rb
@@ -38,7 +38,7 @@ class MetasploitModule < Msf::Exploit
         ['URL', 'https://seclists.org/oss-sec/2018/q3/142'],
         ['URL', 'https://bugs.chromium.org/p/project-zero/issues/detail?id=1640']
       ],
-      'DisclosureDate' => 'Aug 21 2018',
+      'DisclosureDate' => '2018-08-21',
       'License'        => MSF_LICENSE,
       'Platform'       => ['unix', 'linux', 'win'],
       'Arch'           => [ARCH_CMD, ARCH_X86, ARCH_X64],

--- a/modules/exploits/multi/http/apache_jetspeed_file_upload.rb
+++ b/modules/exploits/multi/http/apache_jetspeed_file_upload.rb
@@ -34,7 +34,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ['URL', 'https://portals.apache.org/jetspeed-2/security-reports.html#CVE-2016-0709'],
         ['URL', 'https://portals.apache.org/jetspeed-2/security-reports.html#CVE-2016-0710']
       ],
-      'DisclosureDate' => 'Mar 6 2016',
+      'DisclosureDate' => '2016-03-06',
       'License'        => MSF_LICENSE,
       'Platform'       => ['linux', 'win'],
       'Arch'           => ARCH_JAVA,

--- a/modules/exploits/multi/http/apache_mod_cgi_bash_env_exec.rb
+++ b/modules/exploits/multi/http/apache_mod_cgi_bash_env_exec.rb
@@ -56,7 +56,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ]
         ],
       'DefaultTarget' => 0,
-      'DisclosureDate' => 'Sep 24 2014',
+      'DisclosureDate' => '2014-09-24',
       'License' => MSF_LICENSE,
       'Notes' =>
           {

--- a/modules/exploits/multi/http/oracle_ats_file_upload.rb
+++ b/modules/exploits/multi/http/oracle_ats_file_upload.rb
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Exploit::Remote
         %w{CVE 2016-0491}, # File upload
         %w{EDB 39691}      # PoC
       ],
-      'DisclosureDate' => 'Jan 20 2016',
+      'DisclosureDate' => '2016-01-20',
       'License'        => MSF_LICENSE,
       'Platform'       => %w{win linux},
       'Arch'           => ARCH_JAVA,

--- a/modules/exploits/multi/http/struts2_namespace_ognl.rb
+++ b/modules/exploits/multi/http/struts2_namespace_ognl.rb
@@ -65,7 +65,7 @@ class MetasploitModule < Msf::Exploit::Remote
           },
         ],
       ],
-      'DisclosureDate' => 'Aug 22 2018', # Private disclosure = Apr 10 2018
+      'DisclosureDate' => '2018-08-22', # Private disclosure = 2018-04-10
       'DefaultTarget'  => 0))
 
       register_options(

--- a/modules/exploits/multi/http/struts2_rest_xstream.rb
+++ b/modules/exploits/multi/http/struts2_rest_xstream.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ['URL', 'https://lgtm.com/blog/apache_struts_CVE-2017-9805_announcement'],
         ['URL', 'https://github.com/mbechler/marshalsec']
       ],
-      'DisclosureDate' => 'Sep 5 2017',
+      'DisclosureDate' => '2017-09-05',
       'License'        => MSF_LICENSE,
       'Platform'       => ['unix', 'python', 'linux', 'win'],
       'Arch'           => [ARCH_CMD, ARCH_PYTHON, ARCH_X86, ARCH_X64],

--- a/modules/exploits/osx/local/rootpipe.rb
+++ b/modules/exploits/osx/local/rootpipe.rb
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Exploit::Local
         ['EDB',   '36692'],
         ['URL',   'https://truesecdev.wordpress.com/2015/04/09/hidden-backdoor-api-to-root-privileges-in-apple-os-x/']
       ],
-      'DisclosureDate' => 'Apr 9 2015',
+      'DisclosureDate' => '2015-04-09',
       'License'        => MSF_LICENSE,
       'Platform'       => 'osx',
       'Arch'           => ARCH_X64,

--- a/modules/exploits/osx/local/tpwn.rb
+++ b/modules/exploits/osx/local/tpwn.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Exploit::Local
       'References'     => [
         ['URL', 'https://github.com/kpwn/tpwn']
       ],
-      'DisclosureDate' => 'Aug 16 2015',
+      'DisclosureDate' => '2015-08-16',
       'License'        => MSF_LICENSE,
       'Platform'       => 'osx',
       'Arch'           => ARCH_X64,

--- a/modules/exploits/unix/fileformat/imagemagick_delegate.rb
+++ b/modules/exploits/unix/fileformat/imagemagick_delegate.rb
@@ -49,7 +49,7 @@ class MetasploitModule < Msf::Exploit
         %w{URL https://github.com/ImageMagick/ImageMagick/commit/a347456},
         %w{URL http://permalink.gmane.org/gmane.comp.security.oss.general/19669}
       ],
-      'DisclosureDate' => 'May 3 2016',
+      'DisclosureDate' => '2016-05-03',
       'License'        => MSF_LICENSE,
       'Platform'       => 'unix',
       'Arch'           => ARCH_CMD,

--- a/modules/exploits/unix/http/tnftp_savefile.rb
+++ b/modules/exploits/unix/http/tnftp_savefile.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ['CVE', '2014-8517'],
         ['URL', 'https://seclists.org/oss-sec/2014/q4/459']
       ],
-      'DisclosureDate' => 'Oct 28 2014',
+      'DisclosureDate' => '2014-10-28',
       'License' => MSF_LICENSE,
       'Platform' => 'unix',
       'Arch' => ARCH_CMD,

--- a/modules/exploits/unix/local/exim_perl_startup.rb
+++ b/modules/exploits/unix/local/exim_perl_startup.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Exploit::Local
         %w{EDB 39549},
         %w{URL http://www.exim.org/static/doc/CVE-2016-1531.txt}
       ],
-      'DisclosureDate' => 'Mar 10 2016',
+      'DisclosureDate' => '2016-03-10',
       'License'        => MSF_LICENSE,
       'Platform'       => 'unix',
       'Arch'           => ARCH_CMD,

--- a/modules/exploits/unix/smtp/morris_sendmail_debug.rb
+++ b/modules/exploits/unix/smtp/morris_sendmail_debug.rb
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ['URL', 'https://github.com/arialdomartini/morris-worm'],     # Source
         ['URL', 'http://gunkies.org/wiki/Installing_4.3_BSD_on_SIMH'] # Setup
       ],
-      'DisclosureDate' => 'Nov 2 1988',
+      'DisclosureDate' => '1988-11-02',
       'License'        => MSF_LICENSE,
       'Platform'       => 'unix',
       'Arch'           => ARCH_CMD,

--- a/modules/exploits/unix/webapp/drupal_drupalgeddon2.rb
+++ b/modules/exploits/unix/webapp/drupal_drupalgeddon2.rb
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ['URL', 'https://github.com/nixawk/labs/issues/19'],
         ['URL', 'https://github.com/FireFart/CVE-2018-7600']
       ],
-      'DisclosureDate' => 'Mar 28 2018',
+      'DisclosureDate' => '2018-03-28',
       'License'        => MSF_LICENSE,
       'Platform'       => ['php', 'unix', 'linux'],
       'Arch'           => [ARCH_PHP, ARCH_CMD, ARCH_X86, ARCH_X64],

--- a/modules/exploits/unix/webapp/jquery_file_upload.rb
+++ b/modules/exploits/unix/webapp/jquery_file_upload.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ['URL', 'https://github.com/rapid7/metasploit-framework/pull/5130'],
         ['URL', 'https://httpd.apache.org/docs/current/mod/core.html#allowoverride']
       ],
-      'DisclosureDate' => 'Oct 9 2018', # Larry's disclosure to the vendor
+      'DisclosureDate' => '2018-10-09', # Larry's disclosure to the vendor
       'License'        => MSF_LICENSE,
       'Platform'       => ['php', 'linux'],
       'Arch'           => [ARCH_PHP, ARCH_X86, ARCH_X64],

--- a/modules/exploits/unix/webapp/wp_phpmailer_host_header.rb
+++ b/modules/exploits/unix/webapp/wp_phpmailer_host_header.rb
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ['URL', 'http://www.exim.org/exim-html-current/doc/html/spec_html/ch-string_expansions.html'],
         ['URL', 'https://httpd.apache.org/docs/2.4/mod/core.html#httpprotocoloptions']
       ],
-      'DisclosureDate'      => 'May 3 2017',
+      'DisclosureDate'      => '2017-05-03',
       'License'             => MSF_LICENSE,
       'Platform'            => 'linux',
       'Arch'                => [ARCH_X86, ARCH_X64],

--- a/modules/exploits/windows/fileformat/beetel_netconfig_ini_bof.rb
+++ b/modules/exploits/windows/fileformat/beetel_netconfig_ini_bof.rb
@@ -46,7 +46,7 @@ class MetasploitModule < Msf::Exploit
           ]
         ],
       'Privileged'     => false,
-      'DisclosureDate' => "Oct 12 2013",
+      'DisclosureDate' => "2013-10-12",
       'DefaultTarget'  => 0
     ))
 

--- a/tools/dev/msftidy.rb
+++ b/tools/dev/msftidy.rb
@@ -443,7 +443,7 @@ class Msftidy
     if @source =~ /["']DisclosureDate["'].*\=\>[\x0d\x20]*['\"](.+)['\"]/
       d = $1  #Captured date
       # Flag if overall format is wrong
-      if d =~ /^... \d{1,2}\,* \d{4}/
+      if d =~ /^... (?:\d{1,2}\,* )*\d{4}/
         # Flag if month format is wrong
         m = d.split[0]
         months = [

--- a/tools/dev/msftidy.rb
+++ b/tools/dev/msftidy.rb
@@ -443,7 +443,7 @@ class Msftidy
     if @source =~ /["']DisclosureDate["'].*\=\>[\x0d\x20]*['\"](.+)['\"]/
       d = $1  #Captured date
       # Flag if overall format is wrong
-      if d =~ /^... (?:\d{1,2}\,* )*\d{4}/
+      if d =~ /^... (?:\d{1,2},? )?\d{4}$/
         # Flag if month format is wrong
         m = d.split[0]
         months = [

--- a/tools/dev/msftidy.rb
+++ b/tools/dev/msftidy.rb
@@ -452,6 +452,7 @@ class Msftidy
         ]
 
         error('Incorrect disclosure month format') if months.index(m).nil?
+      # XXX: yyyy-mm is interpreted as yyyy-01-mm by Date::iso8601
       elsif d =~ /^\d{4}-\d{2}-\d{2}$/
         begin
           Date.iso8601(d)

--- a/tools/dev/msftidy.rb
+++ b/tools/dev/msftidy.rb
@@ -441,10 +441,18 @@ class Msftidy
 
     # Check disclosure date format
     if @source =~ /["']DisclosureDate["'].*\=\>[\x0d\x20]*['\"](.+?)['\"]/
-      begin
-        Date.parse($1)  #Captured date
+      d = $1  #Captured date
       # Flag if overall format is wrong
-      rescue ArgumentError
+      if d =~ /^... (?:\d{1,2},? )?\d{4}$/
+        # Flag if month format is wrong
+        m = d.split[0]
+        months = [
+          'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+          'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'
+        ]
+
+        error('Incorrect disclosure month format') if months.index(m).nil?
+      else
         error('Incorrect disclosure date format')
       end
     else

--- a/tools/dev/msftidy.rb
+++ b/tools/dev/msftidy.rb
@@ -452,6 +452,12 @@ class Msftidy
         ]
 
         error('Incorrect disclosure month format') if months.index(m).nil?
+      elsif d =~ /^\d{4}-\d{2}-\d{2}$/
+        begin
+          Date.iso8601(d)
+        rescue ArgumentError
+          error('Incorrect ISO 8601 disclosure date format')
+        end
       else
         error('Incorrect disclosure date format')
       end

--- a/tools/dev/msftidy.rb
+++ b/tools/dev/msftidy.rb
@@ -440,7 +440,7 @@ class Msftidy
     return if @source =~ /Generic Payload Handler/
 
     # Check disclosure date format
-    if @source =~ /["']DisclosureDate["'].*\=\>[\x0d\x20]*['\"](.+)['\"]/
+    if @source =~ /["']DisclosureDate["'].*\=\>[\x0d\x20]*['\"](.+?)['\"]/
       begin
         Date.parse($1)  #Captured date
       # Flag if overall format is wrong

--- a/tools/dev/msftidy.rb
+++ b/tools/dev/msftidy.rb
@@ -441,18 +441,10 @@ class Msftidy
 
     # Check disclosure date format
     if @source =~ /["']DisclosureDate["'].*\=\>[\x0d\x20]*['\"](.+)['\"]/
-      d = $1  #Captured date
+      begin
+        Date.parse($1)  #Captured date
       # Flag if overall format is wrong
-      if d =~ /^... (?:\d{1,2},? )?\d{4}$/
-        # Flag if month format is wrong
-        m = d.split[0]
-        months = [
-          'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
-          'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'
-        ]
-
-        error('Incorrect disclosure month format') if months.index(m).nil?
-      else
+      rescue ArgumentError
         error('Incorrect disclosure date format')
       end
     else


### PR DESCRIPTION
Omitting the day is fine, as Framework uses `Date.parse`. Defaults to the first day of the month.

```
msf5 exploit(unix/local/[redacted]) > grep Disclosed info
  Disclosed: 1986-08-01
msf5 exploit(unix/local/[redacted]) >
```

Additionally, ISO 8601 dates have always been fine. There is no reason we shouldn't be using them.

ETA: Please verify that this is Pro-safe.

#10974