### PR TITLE
More Capture Docs

### DIFF
--- a/documentation/modules/auxiliary/server/capture/postgresql.md
+++ b/documentation/modules/auxiliary/server/capture/postgresql.md
@@ -1,0 +1,43 @@
+This module creates a mock PostgreSQL server which accepts credentials.  Upon receiving a login attempt, a
+`FATAL:  password authentication failed for user` error is thrown.
+
+## Verification Steps
+
+  1. Start msfconsole
+  2. Do: ```use auxiliary/server/capture/postgresql```
+  3. Do: ```run```
+
+## Options
+
+  **SSL**
+
+  Boolean if SSL should be used.  Default is `False`.
+
+  **SSLCert**
+
+  File path to a combined Private Key and Certificate file.  If not provided, a certificate will be automatically
+  generated.  Default is ``.
+
+## Scenarios
+
+### PostgreSQL Server and psql Client
+
+Server:
+
+```
+msf5 > use auxiliary/server/capture/postgresql 
+msf5 auxiliary(server/capture/postgresql) > run
+[*] Auxiliary module running as background job 0.
+
+[*] Started service listener on 0.0.0.0:5432 
+[*] Server started.
+[+] PostgreSQL LOGIN 127.0.0.1:49882 msf / pwn_all_da_tings / msf
+```
+
+Client:
+
+```
+root@kali:~# psql -U msf -h 127.0.0.1
+Password for user msf: 
+psql: FATAL:  password authentication failed for user "msf"
+```

--- a/documentation/modules/auxiliary/server/capture/telnet.md
+++ b/documentation/modules/auxiliary/server/capture/telnet.md
@@ -1,0 +1,57 @@
+This module creates a mock telnet server which accepts credentials.  Upon receiving a login attempt, a `Login failed` error is thrown.
+
+## Verification Steps
+
+  1. Start msfconsole
+  2. Do: ```use auxiliary/server/capture/telnet```
+  3. Do: ```run```
+
+## Options
+
+  **BANNER**
+
+  The Banner which should be displayed.  Default is ``, which will display `Welcome`.
+
+  **SSL**
+
+  Boolean if SSL should be used.  Default is `False`.
+
+  **SSLCert**
+
+  File path to a combined Private Key and Certificate file.  If not provided, a certificate will be automatically
+  generated.  Default is ``.
+
+## Scenarios
+
+### Telnet Server and Client
+
+Server:
+
+```
+msf5 > use auxiliary/server/capture/telnet 
+msf5 auxiliary(server/capture/telnet) > run
+[*] Auxiliary module running as background job 0.
+msf5 auxiliary(server/capture/telnet) > 
+[*] Started service listener on 0.0.0.0:23 
+[*] Server started.
+[+] TELNET LOGIN 127.0.0.1:40016 root / <3@wvu_is_my_hero
+```
+
+Client:
+
+```
+root@kali:~# telnet 127.0.0.1
+Trying 127.0.0.1...
+Connected to 127.0.0.1.
+Escape character is '^]'.
+
+Welcome
+
+Login: root
+Password: <3@wvu_is_my_hero
+
+
+Login failed
+
+Connection closed by foreign host.
+```

--- a/documentation/modules/auxiliary/server/capture/vnc.md
+++ b/documentation/modules/auxiliary/server/capture/vnc.md
@@ -1,0 +1,69 @@
+This module creates a mock VNC server which accepts credentials.  Upon receiving a login attempt, an `Authentication failure` error is thrown.
+
+## Verification Steps
+
+  1. Start msfconsole
+  2. Do: ```use auxiliary/server/capture/vnc```
+  3. Do: ```run```
+
+## Options
+
+  **CHALLENGE**
+
+  The 16 byte challenge used in the authentication.  Default is `00112233445566778899aabbccddeeff`.
+
+  **JOHNPWFILE**
+
+  Write a file containing a John the Ripper format for cracking the credentials.  Default is ``.
+
+  **SSL**
+
+  Boolean if SSL should be used.  Default is `False`.
+
+  **SSLCert**
+
+  File path to a combined Private Key and Certificate file.  If not provided, a certificate will be automatically
+  generated.  Default is ``.
+
+## Scenarios
+
+### VNC with vncviewer and JTR Cracking
+
+Server, Client:
+
+```
+msf5 > use auxiliary/server/capture/vnc 
+msf5 auxiliary(server/capture/vnc) > use auxiliary/server/capture/vnc 
+msf5 auxiliary(server/capture/vnc) > set johnpwfile /tmp/john
+johnpwfile => /tmp/john
+msf5 auxiliary(server/capture/vnc) > run
+[*] Auxiliary module running as background job 0.
+msf5 auxiliary(server/capture/vnc) > 
+[*] Started service listener on 0.0.0.0:5900 
+[*] Server started.
+
+msf5 auxiliary(server/capture/vnc) > vncviewer 127.0.0.1
+[*] exec: vncviewer 127.0.0.1
+
+Connected to RFB server, using protocol version 3.7
+Performing standard VNC authentication
+Password: 
+Authentication failure
+
+[+] 127.0.0.1:40240 - Challenge: 00112233445566778899aabbccddeeff; Response: b7b9c87777661a7a2299733209bfdfce
+```
+
+John the Ripper (JTR) Cracker:
+
+```
+msf5 auxiliary(server/capture/vnc) > john /tmp/john_vnc
+[*] exec: john /tmp/john_vnc
+
+Using default input encoding: UTF-8
+Loaded 1 password hash (VNC [DES 32/64])
+Press 'q' or Ctrl-C to abort, almost any other key for status
+password         (?)
+1g 0:00:00:00 DONE 2/3 (2018-11-11 20:38) 25.00g/s 75.00p/s 75.00c/s 75.00C/s password
+Use the "--show" option to display all of the cracked passwords reliably
+Session completed
+```

--- a/modules/auxiliary/server/capture/vnc.rb
+++ b/modules/auxiliary/server/capture/vnc.rb
@@ -38,8 +38,7 @@ class MetasploitModule < Msf::Auxiliary
     if datastore['CHALLENGE'].to_s =~ /^([a-fA-F0-9]{32})$/
       @challenge = [ datastore['CHALLENGE'] ].pack("H*")
     else
-      print_error("CHALLENGE syntax must match 00112233445566778899AABBCCDDEEFF")
-      return
+      fail_with(Failure::BadConfig, 'CHALLENGE must be 32 characters, 0-9,A-F.')
     end
     exploit()
   end


### PR DESCRIPTION
Additional capture docs.
Also VNC (i'll go back and check others) has a `print_error` then a `return`, which i shortened to just a `fail_with`.  Made sense to me.

## Verification

- [x] Check spelling

Sorry for multiple of these, i'd like to put them all in to one, but I had some more heavy edits on the `printjob_capture`, so I wanted to get these through independently