### PR TITLE
Coerce DisablePayloadHandler into a Boolean string

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/common.rb
+++ b/lib/msf/ui/console/command_dispatcher/common.rb
@@ -119,7 +119,7 @@ module Common
       if (p)
         p_opt = Serializer::ReadableText.dump_options(p, '   ')
         print("\nPayload options (#{mod.datastore['PAYLOAD']}):\n\n#{p_opt}\n") if (p_opt and p_opt.length > 0)
-        print("   **DisablePayloadHandler: True   (RHOST and RPORT settings will be ignored!)**\n\n") if mod.datastore['DisablePayloadHandler']
+        print("   **DisablePayloadHandler: True   (RHOST and RPORT settings will be ignored!)**\n\n") if mod.datastore['DisablePayloadHandler'].to_s == 'true'
       end
     end
 


### PR DESCRIPTION
Due to discrepancies in how command dispatchers receive datastore options, especially after a `save` of the console, Boolean values are stored as strings.

This is a quick fix for `DisablePayloadHandler` specifically, since it was driving me insane.

```
msf5 exploit(unix/local/[redacted]) > pry
[*] Starting Pry shell...
[*] You are in exploit/unix/local/[redacted]

[1] pry(#<Msf::Modules::Exploit__Unix__Local__[redacted]::MetasploitModule>)> datastore['DisablePayloadHandler']
=> "false"
[2] pry(#<Msf::Modules::Exploit__Unix__Local__[redacted]::MetasploitModule>)>
```

Closes #10179 and closes #10240. Does not fix the systemic issue.