### PR TITLE
Remove harmful default command to execute

### DIFF
--- a/modules/payloads/singles/php/exec.rb
+++ b/modules/payloads/singles/php/exec.rb
@@ -26,7 +26,7 @@ module MetasploitModule
       ))
     register_options(
       [
-        OptString.new('CMD', [ true, "The command string to execute", 'echo "toor::0:0:::/bin/bash">/etc/passwd' ]),
+        OptString.new('CMD', [ true, "The command string to execute" ]),
       ])
   end
 


### PR DESCRIPTION
This change removes the default command to execute from the payload `php/exec`, which would (attempt to) overwrite the `/etc/password` with a single UID 0 user named `toor`. This doesn't seem like a very useful default.

