### PR TITLE
Unregister aliases when a datastore option is unregistered

### DIFF
--- a/lib/msf/core/data_store.rb
+++ b/lib/msf/core/data_store.rb
@@ -321,7 +321,8 @@ protected
       return a if self.has_key?(a)
     end
 
-    search_k
+    # Return the original key if it does not exist in the datastore
+    self.has_key?(search_k) ? search_k : k
   end
 
 end

--- a/lib/msf/core/data_store.rb
+++ b/lib/msf/core/data_store.rb
@@ -313,21 +313,15 @@ protected
   #
   def find_key_case(k)
 
-    # Scan each alias looking for a key
     search_k = k.downcase
+
+    # Find alias match if it exists
     if self.aliases.has_key?(search_k)
-      search_k = self.aliases[search_k]
+      a = self.aliases[search_k]
+      return a if self.has_key?(a)
     end
 
-    # Scan each key looking for a match
-    self.each_key do |rk|
-      if rk.downcase == search_k
-        return rk
-      end
-    end
-
-    # Fall through to the non-existent value
-    return k
+    search_k
   end
 
 end

--- a/lib/msf/core/data_store.rb
+++ b/lib/msf/core/data_store.rb
@@ -64,6 +64,7 @@ class DataStore < Hash
   # Case-insensitive wrapper around delete
   #
   def delete(k)
+    @aliases.delete_if { |_, v| v.casecmp(k) == 0 }
     super(find_key_case(k))
   end
 


### PR DESCRIPTION
Per https://github.com/rapid7/metasploit-framework/pull/10981#issuecomment-440607560 if you unregister a datastore option with an alias, the alias would continue existing after the original option, causing it to continue receiving assignment values. The alias would continue overshadowing any directly-registered options as well.

This fixes 'delete' in the datastore class so it removes aliases for the deleted option. It also modifies find_key_case to require that an alias key actually exist before returning it (belt-and-suspenders), and observes that the linear scan of all keys was pointless in the non-alias case, since we fall through to returning the key anyway on no match.

## Verification Steps
 - [x] modify the module referenced in #10981 and deregister the 'RHOSTS' option
 - [x] verify that you can still set 'rhost' and 'RHOST' and the actual datastore option is updated