### PR TITLE
Properly error out when attempting to format ELFs

### DIFF
--- a/lib/msf/core/payload_generator.rb
+++ b/lib/msf/core/payload_generator.rb
@@ -293,6 +293,15 @@ module Msf
       encryption_opts[:iv] = encryption_iv if encryption_iv
       encryption_opts[:key] = encryption_key if encryption_key
 
+      if Msf::Util::EXE.elf?(shellcode) && format.downcase != 'elf'
+        # TODO: force generation from stager/stage if available
+        raise InvalidFormat, 'selected payload can only generate ELF files'
+      end
+      if Msf::Util::EXE.macho?(shellcode) && format.downcase != 'macho'
+        # TODO: force generation from stager/stage if available
+        raise InvalidFormat, 'selected payload can only generate MACHO files'
+      end
+
       case format.downcase
         when "js_be"
           if Rex::Arch.endian(arch) != ENDIAN_BIG


### PR DESCRIPTION
Partially addresses #10893. Instead of actually fixing it though, we error instead of giving puzzling output.

## Verification

- [x] `./msfvenom -p linux/x86/meterpreter_reverse_tcp -f c`
- [x] Verify that the payload is not generated with a message about ELF files
- [x] `./msfvenom -f c -p osx/x64/meterpreter_reverse_tcp`
- [x] Verify that the payload is not generated with a message about MACHO files