### PR TITLE
Support Python 3.7 in external probe scanner code

### DIFF
--- a/lib/msf/core/modules/external/python/metasploit/probe_scanner.py
+++ b/lib/msf/core/modules/external/python/metasploit/probe_scanner.py
@@ -51,7 +51,7 @@ class Scan:
 
         self.queue.put_nowait((target, res))
 
-    async def __aiter__(self):
+    def __aiter__(self):
         return self
 
     async def __anext__(self):


### PR DESCRIPTION
Removes a deprecated `async` declaration that was removed in 3.7. Minimum Python version to run the probe scanner code is now 3.5.3.

## Verification

- [x] With Python 3.7
- [x] PYTHONPATH=$(pwd)/lib/msf/core/modules/external/python ./modules/auxiliary/scanner/wproxy/att_open_proxy.py --rhosts 127.0.0.1
- [x] Verify you get a "Connect failed" error and not a Python `TypeError`