### PR TITLE
don't try to close a nil connection in smb login scanner mixin

### DIFF
--- a/lib/metasploit/framework/login_scanner/smb.rb
+++ b/lib/metasploit/framework/login_scanner/smb.rb
@@ -93,10 +93,9 @@ module Metasploit
           proof = nil
 
           begin
-
-            realm       = credential.realm   || ""
-            username    = credential.public  || ""
-            password    = credential.private || ""
+            realm       = (credential.realm   || "").force_encoding('UTF-8')
+            username    = (credential.public  || "").force_encoding('UTF-8')
+            password    = (credential.private || "").force_encoding('UTF-8')
             client      = RubySMB::Client.new(self.dispatcher, username: username, password: password, domain: realm)
             status_code = client.login
 

--- a/lib/metasploit/framework/login_scanner/smb.rb
+++ b/lib/metasploit/framework/login_scanner/smb.rb
@@ -135,7 +135,7 @@ module Metasploit
           rescue RubySMB::Error::UnexpectedStatusCode => e
             status = Metasploit::Model::Login::Status::INCORRECT
           ensure
-            client.disconnect!
+            client.disconnect! if client
           end
 
           if status == Metasploit::Model::Login::Status::SUCCESSFUL && credential.public.empty?

--- a/lib/msf/core/auxiliary/auth_brute.rb
+++ b/lib/msf/core/auxiliary/auth_brute.rb
@@ -626,7 +626,7 @@ module Auxiliary::AuthBrute
     port = host_port.to_s.strip if host_port
     complete_message = nil
     old_msg = msg.to_s.strip
-    msg_regex = /(#{ip})(:#{port})?(\s*-?\s*)(#{proto.to_s})?(\s*-?\s*)(.*)/ni
+    msg_regex = /(#{ip})(:#{port})?(\s*-?\s*)(#{proto.to_s})?(\s*-?\s*)(.*)/i
     if old_msg.match(msg_regex)
       complete_message = msg.to_s.strip
     else


### PR DESCRIPTION
Observed while doing some smb brute-force logins, eventually SMB might refuse a connection, client will be nil, and the ensure does the wrong thing.

This simply ensures we have a connection in the first place before we try to close it.

![image](https://user-images.githubusercontent.com/4108654/48876382-61cc8880-edc3-11e8-9a19-8260dbcf94be.png)
