### PR TITLE
Fix userns_enabled? check for unprivileged_userns_clone

### DIFF
--- a/lib/msf/core/post/linux/kernel.rb
+++ b/lib/msf/core/post/linux/kernel.rb
@@ -105,7 +105,8 @@ module Kernel
   #
   def userns_enabled?
     return false if cmd_exec('cat /proc/sys/user/max_user_namespaces').to_s.strip.eql? '0'
-    cmd_exec('cat /proc/sys/kernel/unprivileged_userns_clone').to_s.strip.eql? '1'
+    return false if cmd_exec('cat /proc/sys/kernel/unprivileged_userns_clone').to_s.strip.eql? '0'
+    true
   rescue
     raise 'Could not determine userns status'
   end


### PR DESCRIPTION
The `unprivileged_userns_clone` sysctl parameter may not be present on the target system.

On Fedora 28 Workstation, `/proc/sys/kernel/unprivileged_userns_clone` is not present (nor is `userns_restrict`), and the system fails open in its absence, allowing unprivileged users to create user namespaces.

Prior to this patch, the `userns_enabled?` method would falsely report unprivileged user namespaces as disabled in the event that the `unprivileged_userns_clone` sysctl parameter was not present.

The Boolean check for a value of `1` was causing the `userns_enabled?` method to incorrectly return `false`, as `cat /proc/sys/kernel/unprivileged_userns_clone` was returning `cat: /proc/sys/kernel/unprivileged_userns_clone: No such file or directory`.

---

```diff
diff --git a/lib/msf/core/post/linux/kernel.rb b/lib/msf/core/post/linux/kernel.rb
index 4b6faf6..831a2f6 100644
--- a/lib/msf/core/post/linux/kernel.rb
+++ b/lib/msf/core/post/linux/kernel.rb
@@ -105,7 +105,8 @@ module Kernel
   #
   def userns_enabled?
     return false if cmd_exec('cat /proc/sys/user/max_user_namespaces').to_s.strip.eql? '0'
-    cmd_exec('cat /proc/sys/kernel/unprivileged_userns_clone').to_s.strip.eql? '1'
+    return false if cmd_exec('cat /proc/sys/kernel/unprivileged_userns_clone').to_s.strip.eql? '0'
+    true
   rescue
     raise 'Could not determine userns status'
   end
```
