### PR TITLE
Replace WsfDelay with WfsDelay - Fixes #11018

### DIFF
--- a/modules/exploits/linux/http/nagios_xi_chained_rce_2_electric_boogaloo.rb
+++ b/modules/exploits/linux/http/nagios_xi_chained_rce_2_electric_boogaloo.rb
@@ -52,16 +52,13 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'Privileged'     => true,
       'DefaultOptions' => {
-         'WSFDELAY' => 30
+         'WfsDelay' => 30
       },
       'DisclosureDate'  => 'Apr 17, 2018',
       'DefaultTarget'   => 0))
     register_options(
       [
-        #WSFDelay option is being ignored, getting around this with a call to Rex.sleep
-        #Sometimes Nagios doesn't execute commands immediately, so play with this parameter.
-        Opt::RPORT(80),
-        OptInt.new('WAIT', [ true, "Number of seconds to wait for exploit to run", 15 ])
+        Opt::RPORT(80)
       ])
     deregister_options('SRVHOST', 'SRVPORT')
   end
@@ -356,8 +353,5 @@ class MetasploitModule < Msf::Exploit::Remote
     set_db_user('nagiosql', 'n@gweb')
     vprint_status 'STEP 6.2: deleting admin'
     delete_admin(key, user_id)
-
-    #The WSFDelay option is being ignored currently, so this is this workaround.
-    Rex.sleep(datastore['WAIT'].to_i)
   end
 end

--- a/modules/exploits/windows/local/ppr_flatten_rec.rb
+++ b/modules/exploits/windows/local/ppr_flatten_rec.rb
@@ -40,6 +40,7 @@ class MetasploitModule < Msf::Exploit::Local
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'thread',
+          'WfsDelay' => 30
         },
       'Targets'        =>
         [
@@ -59,18 +60,8 @@ class MetasploitModule < Msf::Exploit::Local
           [ 'URL', 'https://seclists.org/fulldisclosure/2013/May/91' ],
         ],
       'DisclosureDate' => 'May 15 2013',
-      'DefaultTarget'  => 0,
-      # TODO: Uncomment this line and remove the Rex.sleep when WsfDelay works properly.
-      # Wait for up to 30 seconds by default for our shell because this exploit can
-      # take quite a while to finish execute
-      #'DefaultOptions' => { 'WfsDelay' => 30 }
+      'DefaultTarget'  => 0
     }))
-
-    # TODO: remove this when we've sorted out the WsfDelay issue.
-    register_options([
-      OptInt.new('WAIT', [ true, "Number of seconds to wait for exploit to run", 10 ])
-    ])
-
   end
 
   def check
@@ -154,12 +145,6 @@ class MetasploitModule < Msf::Exploit::Local
     print_status("Payload injected. Executing exploit...")
     host_process.thread.create(exploit_mem + offset, payload_mem)
 
-    # TODO: remove this Rex.sleep call when the WsfDelay stuff works correctly for local
-    # exploits. For some reason it doesn't appear to work properly.
-    wait = datastore['WAIT'].to_i
-    print_status("Exploit thread executing (can take a while to run), waiting #{wait} sec ...")
-    Rex.sleep(wait)
-
-    print_good("Exploit finished, wait for (hopefully privileged) payload execution to complete.")
+    print_status("Exploit thread executing (can take a while to run), waiting #{datastore['WfsDelay']} sec ...")
   end
 end


### PR DESCRIPTION
Replace `WsfDelay` with `WfsDelay` - Fixes #11018

I haven't tested this fix. Presumably `WfsDelay` wasn't working due to a typo.

**Edit:** I've confirmed `WfsDelay` works as per output below.
