### PR TITLE
remove secondary check that prevents aliases from functioning

### DIFF
--- a/lib/msf/core/data_store.rb
+++ b/lib/msf/core/data_store.rb
@@ -321,8 +321,7 @@ protected
       return a if self.has_key?(a)
     end
 
-    # Return the original key if it does not exist in the datastore
-    self.has_key?(search_k) ? search_k : k
+    search_k
   end
 
 end

--- a/lib/msf/core/data_store.rb
+++ b/lib/msf/core/data_store.rb
@@ -313,15 +313,21 @@ protected
   #
   def find_key_case(k)
 
+    # Scan each alias looking for a key
     search_k = k.downcase
-
-    # Find alias match if it exists
     if self.aliases.has_key?(search_k)
-      a = self.aliases[search_k]
-      return a if self.has_key?(a)
+      search_k = self.aliases[search_k]
     end
 
-    search_k
+    # Scan each key looking for a match
+    self.each_key do |rk|
+      if rk.downcase == search_k
+        return rk
+      end
+    end
+
+    # Fall through to the non-existent value
+    return k
   end
 
 end


### PR DESCRIPTION
Commit 063838fb17d478a461422dc395b69d6ab437fc69 was overly aggresive about checking if an alias value exists in advance, which prevents aliases from being set altogether. da9e6edbf11f8249aaaa964e2263333f2daaed94 was enough to fix the original issue reported in https://github.com/rapid7/metasploit-framework/pull/10981#issuecomment-440607560

This basically just reverts 063838fb17 and 7312fa774f since they were not really necessary to fix the original problem.

## Verification Steps

 - [x] Ensure that #10998 still works as expected.
 - [x] Ensure that aliases, such as `set rhost 127.0.0.1` is a true alias for setting RHOSTS