### PR TITLE
Add check for SMAP

### DIFF
--- a/documentation/modules/exploit/linux/local/af_packet_chocobo_root_priv_esc.md
+++ b/documentation/modules/exploit/linux/local/af_packet_chocobo_root_priv_esc.md
@@ -10,10 +10,10 @@
   4.4.0 < 4.4.0-53, including Linux distros based on Ubuntu, such as
   Linux Mint.
 
-  The target system must have unprivileged user namespaces enabled and
-  two or more CPU cores.
+  The target system must have unprivileged user namespaces enabled,
+  two or more CPU cores, and SMAP must be disabled.
 
-  Bypasses for SMEP, SMAP and KASLR are included. Failed exploitation
+  Bypasses for SMEP and KASLR are included. Failed exploitation
   may crash the kernel.
 
 

--- a/modules/exploits/linux/local/af_packet_chocobo_root_priv_esc.rb
+++ b/modules/exploits/linux/local/af_packet_chocobo_root_priv_esc.rb
@@ -27,10 +27,10 @@ class MetasploitModule < Msf::Exploit::Local
         4.4.0 < 4.4.0-53, including Linux distros based on Ubuntu, such as
         Linux Mint.
 
-        The target system must have unprivileged user namespaces enabled and
-        two or more CPU cores.
+        The target system must have unprivileged user namespaces enabled,
+        two or more CPU cores, and SMAP must be disabled.
 
-        Bypasses for SMEP, SMAP and KASLR are included. Failed exploitation
+        Bypasses for SMEP and KASLR are included. Failed exploitation
         may crash the kernel.
 
         This module has been tested successfully on Linux Mint 17.3 (x86_64);
@@ -143,6 +143,12 @@ class MetasploitModule < Msf::Exploit::Local
       return CheckCode::Safe
     end
     vprint_good "Linux kernel version #{version} is vulnerable"
+
+    if smap_enabled?
+      vprint_error 'SMAP is enabled'
+      return CheckCode::Safe
+    end
+    vprint_good 'SMAP is not enabled'
 
     arch = kernel_hardware
     unless arch.include? 'x86_64'


### PR DESCRIPTION
The exploit description is a lie. The exploit does not bypass SMAP. RIP kernels.

Fixes #9987.