### PR TITLE
Spaces at EOL fixes

### DIFF
--- a/modules/auxiliary/scanner/misc/ibm_mq_login.rb
+++ b/modules/auxiliary/scanner/misc/ibm_mq_login.rb
@@ -170,7 +170,7 @@ class MetasploitModule < Msf::Auxiliary
       end
       password = password + ( "\x00" * (12-password.length) )
     end
-    vprint_status("Using password: '#{password}' (Length: #{password.length})") 
+    vprint_status("Using password: '#{password}' (Length: #{password.length})")
 
     send_userid = "\x54\x53\x48\x4d" + 	# StructId
     "\x00\x00\x00\xa8" + 		# MQSegmLen

--- a/modules/exploits/windows/browser/getgodm_http_response_bof.rb
+++ b/modules/exploits/windows/browser/getgodm_http_response_bof.rb
@@ -50,7 +50,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Targets'        =>
         [
           [
-            'Automatic', {} 
+            'Automatic', {}
           ],
           [ '4.9.0.1982 on Windows XP SP3',
             {


### PR DESCRIPTION
## Verification

- [x] `ruby tools/dev/msftidy.rb modules/auxiliary/scanner/misc/ibm_mq_login.rb`
- [x] `ruby tools/dev/msftidy.rb modules/exploits/windows/browser/getgodm_http_response_bof.rb`