### PR TITLE
return hostname

### DIFF
--- a/lib/msf/core/post/linux/system.rb
+++ b/lib/msf/core/post/linux/system.rb
@@ -167,7 +167,7 @@ module System
   def get_hostname
     hostname = cmd_exec('uname -n').to_s
     report_host({:host => rhost, :name => hostname})
-
+    hostname
   rescue
     raise 'Unable to retrieve hostname'
   end


### PR DESCRIPTION
return `hostname` from `get_hostname`, just like in the good old days.

#10823
