### PR TITLE
Add protection checks to Msf::Post::Linux::Kernel lib

### DIFF
--- a/lib/msf/core/post/linux/kernel.rb
+++ b/lib/msf/core/post/linux/kernel.rb
@@ -170,6 +170,24 @@ module Kernel
   end
 
   #
+  # Returns true if grsecurity is installed
+  #
+  def grsec_installed?
+    cmd_exec('test -c /dev/grsec && echo true').to_s.strip.include? 'true'
+  rescue
+    raise 'Could not determine grsecurity status'
+  end
+
+  #
+  # Returns true if PaX is installed
+  #
+  def pax_installed?
+    cmd_exec('test -x /sbin/paxctl && echo true').to_s.strip.include? 'true'
+  rescue
+    raise 'Could not determine PaX status'
+  end
+
+  #
   # Returns true if SELinux is installed
   #
   # @return [Boolean]

--- a/lib/msf/core/post/linux/kernel.rb
+++ b/lib/msf/core/post/linux/kernel.rb
@@ -124,6 +124,18 @@ module Kernel
   end
 
   #
+  # Returns true if Exec-Shield is enabled
+  #
+  # @return [Boolean]
+  #
+  def exec_shield_enabled?
+    exec_shield = cmd_exec('cat /proc/sys/kernel/exec-shield').to_s.strip
+    (exec_shield.eql?('1') || exec_shield.eql?('2'))
+  rescue
+    raise 'Could not determine exec-shield status'
+  end
+
+  #
   # Returns true if unprivileged bpf is disabled
   #
   # @return [Boolean]


### PR DESCRIPTION
This PR adds detection for grsecurity and PaX to `Msf::Post::Linux::Kernel` lib.

Following on from discussions in #9812 and #9877. No checks for RSBAC, TPE or kernel boot params - sorry @sempervictus.

Checking `/dev/grsec` didn't throw any obvious warnings in `dmesg` or raise any obvious alerts. At least, none that I noticed. Similarly, checking `/sbin/paxctl` didn't raise any alerts (that I noticed).

Granted, both approaches are far from ideal.

I opted not to include checks for grsec/pax sysctls. While the presence of grsec/pax can be inferred from the presence of their sysctl parameters, the param values should not readable as low privileged users. Additionally, reading `/proc` is inadvisable, although arguably not much worse than touching `/dev/grsec`.

While these methods aren't replacing any existing checks in existing modules, I assert that they're useful based on the better-than-nothing and gotta-start-somewhere arguments.

As for how we'll actually use these methods... we'll need to find a balance, on a per-module basis, between immediately giving up and going home (with a hailmary opt-out `ForceExploit` option), versus lighting up the "bright LEDs and cowbells." Of course i'm open to suggestions.

There's also the question of how we detect and handle inferior fake "hardened" kernels, which is a different kettle of fish that I don't want to deal with right now.

This PR is also a prerequisite for local changes I've made to the `post/linux/gather/enum_protections` module, of dubious usefulness, which I'll PR after this lands. Demo:

```
msf5 post(linux/gather/enum_protections) > rexploit 
[*] Reloading module...

[!] SESSION may not be compatible with this module.
[*] Running module against 172.16.191.142 [subgraph]
[*] Info:
[*] 	Subgraph OS 1.0  
[*] 	Linux subgraph 4.9.33-subgraph #1 SMP Mon Jun 19 20:32:42 UTC 2017 x86_64 GNU/Linux
[*] Finding system protections...
[+] ASLR is enabled
[+] SMEP is enabled
[+] grsecurity is installed
[+] PaX is installed
[*] Finding installed applications...
[+] fw-settings found: /usr/bin/fw-settings
[+] oz-seccomp found: /usr/bin/oz-seccomp
[+] paxtest found: /usr/bin/paxtest
[*] System protections saved to notes.
[*] Post module execution completed
```
