### PR TITLE
Add Openwall detection to Linux system lib

### DIFF
--- a/lib/msf/core/post/linux/system.rb
+++ b/lib/msf/core/post/linux/system.rb
@@ -97,6 +97,12 @@ module System
       system_data[:distro] = "gentoo"
       system_data[:version] = version
 
+    # Openwall
+    elsif etc_files.include?("owl-release")
+      version = read_file("/etc/owl-release").gsub(/\n|\\n|\\l/,'')
+      system_data[:distro] = 'openwall'
+      system_data[:version] = version
+
     # Generic
     elsif etc_files.include?("issue")
       version = read_file("/etc/issue").gsub(/\n|\\n|\\l/,'')


### PR DESCRIPTION
### Before

> [*] get_sysinfo: {:kernel=>"Linux openwall.local 2.6.18-431.el5.028stab123.1.owl2 #1 SMP Tue Jul 3 16:51:22 MSK 2018 x86_64 GNU/Linux", :distro=>"linux", :version=>""}


### After

> [*] get_sysinfo: {:kernel=>"Linux openwall.local 2.6.18-431.el5.028stab123.1.owl2 #1 SMP Tue Jul 3 16:51:22 MSK 2018 x86_64 GNU/Linux", :distro=>"openwall", :version=>"Owl 3.1-stable"}