### PR TITLE
Fix issue when tab autocomplete for alias plugin.

### DIFF
--- a/plugins/alias.rb
+++ b/plugins/alias.rb
@@ -284,7 +284,7 @@ class Plugin::Alias < Msf::Plugin
       driver.dispatcher_stack.each do |dispatcher|
         next unless dispatcher.respond_to?(:commands)
         next if (dispatcher.commands.nil? or dispatcher.commands.length == 0)
-        items << dispatcher.commands.keys
+        items.concat(dispatcher.commands.keys)
       end
       # add all the current aliases to the list
       items.concat(@aliases.keys)


### PR DESCRIPTION
Fix #11045 

```
msf5 > load alias
[*] Successfully loaded plugin: alias
msf5 > alias
alias -c                alias db_connect        alias getg              alias log               alias rename_job        alias spool
alias -f                alias db_disconnect     alias grep              alias loot              alias repeat            alias threads
alias -h                alias db_export         alias handler           alias makerc            alias resource          alias unload
alias ?                 alias db_import         alias help              alias notes             alias route             alias unset
alias advanced          alias db_nmap           alias history           alias options           alias save              alias unsetg
alias alias             alias db_rebuild_cache  alias hosts             alias popm              alias search            alias use
alias back              alias db_remove         alias info              alias previous          alias services          alias version
alias banner            alias db_save           alias irb               alias pry               alias sessions          alias vulns
alias cd                alias db_status         alias jobs              alias pushm             alias set               alias workspace
alias color             alias edit              alias kill              alias quit              alias setg
alias connect           alias exit              alias load              alias reload_all        alias show
alias creds             alias get               alias loadpath          alias reload_lib        alias sleep
```

@bcoles 