### PR TITLE
Bump payloads version to 1.3.54

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,7 +21,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 1.3.53)
+      metasploit-payloads (= 1.3.54)
       metasploit_data_models
       metasploit_payloads-mettle (= 0.4.2)
       mqtt
@@ -178,8 +178,8 @@ GEM
       activemodel (~> 4.2.6)
       activesupport (~> 4.2.6)
       railties (~> 4.2.6)
-    metasploit-payloads (1.3.53)
-    metasploit_data_models (3.0.1)
+    metasploit-payloads (1.3.54)
+    metasploit_data_models (3.0.2)
       activerecord (~> 4.2.6)
       activesupport (~> 4.2.6)
       arel-helpers

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -70,7 +70,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '1.3.53'
+  spec.add_runtime_dependency 'metasploit-payloads', '1.3.54'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '0.4.2'
   # Needed by msfgui and other rpc components


### PR DESCRIPTION
This PR catches up payloads to reflect changes made over a few weeks where our infrastructure was unhappy.
I think the only PR landed in that time was https://github.com/rapid7/metasploit-payloads/pull/313 and some attempts to fix the build infrastructure.

Automated testing is not back up yet, so @jmartin-r7, please manually test this.  I can land once we know it does not break _everything_
