### PR TITLE
Fix SSH Key Display When Running creds

### DIFF
--- a/lib/metasploit/framework/data_service/remote/http/remote_credential_data_service.rb
+++ b/lib/metasploit/framework/data_service/remote/http/remote_credential_data_service.rb
@@ -14,6 +14,14 @@ module RemoteCredentialDataService
     parsed_body = JSON.parse(data.response.body).symbolize_keys
     data = parsed_body[:data]
     data.each do |cred|
+      if cred['public']
+        public_object = to_ar(cred['public']['type'].constantize, cred['public'])
+        rv[data.index(cred)].public = public_object
+      end
+      if cred['private']
+        private_object = to_ar(cred['private']['type'].constantize, cred['private'])
+        rv[data.index(cred)].private = private_object
+      end
       if cred['origin']
         origin_object = to_ar(cred['origin']['type'].constantize, cred['origin'])
         rv[data.index(cred)].origin = origin_object

--- a/lib/msf/ui/console/command_dispatcher/creds.rb
+++ b/lib/msf/ui/console/command_dispatcher/creds.rb
@@ -428,7 +428,7 @@ class Creds
 
         matched_cred_ids << core.id
         public_val = core.public ? core.public.username : ""
-        private_val = core.private ? core.private.data : ""
+        private_val = core.private ? core.private.to_s : ""
         realm_val = core.realm ? core.realm.value : ""
         human_val = core.private ? core.private.class.model_name.human : ""
 
@@ -463,7 +463,7 @@ class Creds
 
           matched_cred_ids << core.id
           public_val = core.public ? core.public.username : ""
-          private_val = core.private ? core.private.data : ""
+          private_val = core.private ? core.private.to_s : ""
           realm_val = core.realm ? core.realm.value : ""
           human_val = core.private ? core.private.class.model_name.human : ""
 


### PR DESCRIPTION
This PR fixes a display issue introduced in msf5 that caused SSH keys stored in the database to display the entire key, instead of the fingerprint.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Import an SSH key into your database `creds add user:admin ssh-key:</path/to/key>`
- [x] Run the `creds` command and verify the output looks correct

