### PR TITLE
Raise exception in process_opts_workspace for more meaningful error messages

### DIFF
--- a/lib/msf/util/db_manager.rb
+++ b/lib/msf/util/db_manager.rb
@@ -31,11 +31,11 @@ module DBManager
   # @return [Mdm::Workspace] The workspace object that was referenced by name in opts.
   def self.process_opts_workspace(opts, framework, required = true)
     wspace = delete_opts_workspace(opts)
-    if required && (wspace.nil? || ((wspace.kind_of? String) && wspace.empty?))
+    if required && (wspace.nil? || (wspace.kind_of?(String) && wspace.empty?))
       raise ArgumentError.new("opts must include a valid :workspace")
     end
 
-    if wspace.kind_of? String
+    if wspace.kind_of?(String)
       wspace = framework.db.find_workspace(wspace)
     end
     wspace

--- a/lib/msf/util/db_manager.rb
+++ b/lib/msf/util/db_manager.rb
@@ -28,6 +28,8 @@ module DBManager
   # @param [Hash] opts The opts hash passed in from the data request. Should contain :workspace if required is true.
   # @param [Msf::Framework] framework A framework object containing a valid database connection.
   # @param [Bool] required true if the :workspace key is required for this data operation. false if it is only optional.
+  # @raise [ArgumentError] opts must include a valid :workspace
+  # @raise [RuntimeError] couldn't find workspace
   # @return [Mdm::Workspace] The workspace object that was referenced by name in opts.
   def self.process_opts_workspace(opts, framework, required = true)
     wspace = delete_opts_workspace(opts)
@@ -36,8 +38,11 @@ module DBManager
     end
 
     if wspace.kind_of?(String)
-      wspace = framework.db.find_workspace(wspace)
+      workspace_name = wspace
+      wspace = framework.db.find_workspace(workspace_name)
+      raise "Couldn't find workspace #{workspace_name}" if wspace.nil?
     end
+
     wspace
   end
 


### PR DESCRIPTION
The `Msf::Util::DBManager.process_opts_workspace` method is heavily used in various `DBManager` models to get the workspace that is then used for subsequent queries. This modifies the method to raise an exception if the workspace is not found, thus allowing for a more meaningful error to make it back to the user.

Ticket: MS-3225

## Example: Current
```
curl -k -X GET -H "accept: application/json" -H "Authorization: Bearer <token>"  "https://localhost:8080/api/v1/hosts?workspace=DNE" | python -m json.tool
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   110  100   110    0     0   1666      0 --:--:-- --:--:-- --:--:--  1666
{
    "error": {
        "code": 500,
        "message": "There was an error getting hosts: undefined method `hosts' for nil:NilClass"
    }
}
```

## Example: Fixed
```
curl -k -X GET -H "accept: application/json" -H "Authorization: Bearer <token>"  "https://localhost:8080/api/v1/hosts?workspace=DNE" | python -m json.tool
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    96  100    96    0     0   3096      0 --:--:-- --:--:-- --:--:--  3096
{
    "error": {
        "code": 500,
        "message": "There was an error getting hosts: Couldn't find workspace DNE"
    }
}
```

## Verification

- [x] Restart the database and MSF web service (data services) `msfdb restart`, and init/reinit if necessary.
- [x] Execute `curl --insecure -H "Accept: application/json" -H "Authorization: Bearer <token>" https://localhost:8080/api/v1/hosts?workspace=DNE | python -m json.tool` where `DNE` is the name of a workspace that doesn't exist in your database.
- [x] **Verify** the error message returned is the new more helpful message
- [x] Start `msfconsole` and connect to the data service started above if you didn't select the option to connect automatically during initialization. See [Metasploit Web Service](https://github.com/rapid7/metasploit-framework/wiki/Metasploit-Web-Service) for more information.
- [x] **Verify** `db_status` reports `Connection type: http. Connected to remote_data_service: (https://localhost:8080)`
- [x] Perform various data operations (`hosts`, `services`, `vulns`, `creds`, `loots`, `notes`)
- [x] **Verify** data operations operate as expected