### PR TITLE
Add checks to post/linux/gather/enum_protections

### DIFF
--- a/modules/post/linux/gather/enum_protections.rb
+++ b/modules/post/linux/gather/enum_protections.rb
@@ -5,20 +5,21 @@
 
 class MetasploitModule < Msf::Post
   include Msf::Post::File
+  include Msf::Post::Linux::Kernel
   include Msf::Post::Linux::System
 
   def initialize(info = {})
-    super( update_info( info,
+    super(update_info(info,
       'Name'          => 'Linux Gather Protection Enumeration',
       'Description'   => %q{
-        This module tries to find certain installed applications that can be used
-        to prevent, or detect our attacks, which is done by locating certain
-        binary locations, and see if they are indeed executables.  For example,
-        if we are able to run 'snort' as a command, we assume it's one of the files
-        we are looking for.
+        This module checks whether popular system hardening mechanisms are
+        in place, such as SMEP, SMAP, SELinux, PaX and grsecurity. It also
+        tries to find installed applications that can be used to hinder,
+        prevent, or detect attacks, such as tripwire, snort, and apparmor.
 
-        This module is meant to cover various antivirus, rootkits, IDS/IPS,
-        firewalls, and other software.
+        This module is meant to identify Linux Secure Modules (LSM) in addition
+        to various antivirus, IDS/IPS, firewalls, sandboxes and other security
+        related software.
       },
       'License'       => MSF_LICENSE,
       'Author'        => 'ohdae <bindshell[at]live.com>',
@@ -35,44 +36,111 @@ class MetasploitModule < Msf::Post
     print_status "\t#{distro[:version]}"
     print_status "\t#{distro[:kernel]}"
 
+    print_status 'Finding system protections...'
+    check_hardening
+
     print_status 'Finding installed applications...'
     find_apps
+
+    if framework.db.active
+      print_status 'System protections saved to notes.'
+    end
   end
 
-  def which(env_paths, cmd)
-    env_paths.each do |path|
-      cmd_path = "#{path}/#{cmd}"
-      return cmd_path if file_exist? cmd_path
+  def report(data)
+    report_note(
+      :host   => session,
+      :type   => 'linux.protection',
+      :data   => data,
+      :update => :unique_data
+    )
+  end
+
+  def check_hardening
+    if aslr_enabled?
+      r = 'ASLR is enabled'
+      print_good r
+      report r
     end
-    nil
+
+    if exec_shield_enabled?
+      r = 'Exec-Shield is enabled'
+      print_good r
+      report r
+    end
+
+    if kaiser_enabled?
+      r = "KAISER is enabled"
+      print_good r
+      report r
+    end
+
+    if smep_enabled?
+      r = "SMEP is enabled"
+      print_good r
+      report r
+    end
+
+    if smap_enabled?
+      r = "SMAP is enabled"
+      print_good r
+      report r
+    end
+
+    if grsec_installed?
+      r = 'grsecurity is installed'
+      print_good r
+      report r
+    end
+
+    if pax_installed?
+      r = 'PaX is installed'
+      print_good r
+      report r
+    end
+
+    if selinux_installed?
+      if selinux_enforcing?
+        r = 'SELinux is installed and enforcing'
+        print_good r
+        report r
+      else
+        r = 'SELinux is installed, but in permissive mode'
+        print_good r
+        report r
+      end
+    end
+
+    if yama_installed?
+      if yama_enabled?
+        r = 'Yama is installed and enabled'
+        print_good r
+        report r
+      else
+        r = 'Yama is installed, but not enabled'
+        print_good r
+        report r
+      end
+    end
   end
 
   def find_apps
     apps = %w(
-      truecrypt bulldog ufw iptables logrotate logwatch
+      truecrypt bulldog ufw iptables fw-settings logrotate logwatch
       chkrootkit clamav snort tiger firestarter avast lynis
       rkhunter tcpdump webmin jailkit pwgen proxychains bastille
-      psad wireshark nagios apparmor honeyd thpot
-      aa-status gradm2 getenforce tripwire
+      psad wireshark nagios apparmor oz-seccomp honeyd thpot
+      aa-status gradm gradm2 getenforce aide tripwire paxctl
     )
-
-    env_paths = get_path.split ':'
 
     apps.each do |app|
       next unless command_exists? app
 
-      path = which env_paths, app
-      next unless path
+      path = cmd_exec "command -v #{app}"
+      next unless path.start_with? '/'
 
       print_good "#{app} found: #{path}"
-      report_note(
-        :host   => session,
-        :type   => 'linux.protection',
-        :data   => path,
-        :update => :unique_data
-      )
+      report path
     end
-
-    print_status 'Installed applications saved to notes.'
   end
 end


### PR DESCRIPTION
This PR largely reworks the `post/linux/gather/enum_protections` module.

Unless I'm missing something, the usage of `which` made no sense, so I replaced it with `command -v`. Although the `command -v` approach relies on `$PATH`, so too did the `which` implementation. The `which` implementation also iterated through each `$PATH`, which was inefficient and made no sense. Additionally, using `command -v` is generally considered to be better practice than using `which`.

This PR also adds various checks from the `Post::Linux::Kernel` mixin, such as checks for grsec, PaX, etc, and adds some additional applications to the `apps` check.

This PR also ensures `print_status 'Installed applications saved to notes.'` is only printed when a database is connected, as opposed to always.

### Output

```
[!] SESSION may not be compatible with this module.
[*] Running module against 172.16.191.142 [subgraph]
[*] Info:
[*] 	Subgraph OS 1.0  
[*] 	Linux subgraph 4.9.33-subgraph #1 SMP Mon Jun 19 20:32:42 UTC 2017 x86_64 GNU/Linux
[*] Finding system protections...
[+] ASLR is enabled
[+] SMEP is enabled
[+] grsecurity is installed
[+] PaX is installed
[*] Finding installed applications...
[+] fw-settings found: /usr/bin/fw-settings
[+] oz-seccomp found: /usr/bin/oz-seccomp
[*] System protections saved to notes.
[*] Post module execution completed

msf5 post(linux/gather/enum_protections) > notes

Notes
=====

 Time                     Host            Service  Port  Protocol  Type              Data
 ----                     ----            -------  ----  --------  ----              ----
 2018-12-04 08:45:32 UTC  172.16.191.142                           linux.protection  "ASLR is enabled"
 2018-12-04 08:45:32 UTC  172.16.191.142                           linux.protection  "SMEP is enabled"
 2018-12-04 08:45:32 UTC  172.16.191.142                           linux.protection  "grsecurity is installed"
 2018-12-04 08:45:32 UTC  172.16.191.142                           linux.protection  "PaX is installed"
 2018-12-04 08:45:33 UTC  172.16.191.142                           linux.protection  "/usr/bin/fw-settings"
 2018-12-04 08:45:34 UTC  172.16.191.142                           linux.protection  "/usr/bin/oz-seccomp"

```


```
[*] Running module against 172.16.191.222 [openwall.local]
[*] Info:
[*] 	Owl 3.1-stable
[*] 	Linux openwall.local 2.6.18-431.el5.028stab123.1.owl2 #1 SMP Tue Jul 3 16:51:22 MSK 2018 x86_64 GNU/Linux
[*] Finding system protections...
[+] ASLR is enabled
[+] Exec-Shield is enabled
[*] Finding installed applications...
[+] iptables found: /sbin/iptables
[+] logrotate found: /usr/sbin/logrotate
[*] Post module execution completed
```

```
[*] Running module against 172.16.191.139 [manjaro-gnome-17-1-0]
[*] Info:
[*] 	Manjaro Linux
[*] 	Linux manjaro-gnome-17-1-0 4.14.10-2-MANJARO #1 SMP PREEMPT Fri Dec 29 18:25:07 UTC 2017 x86_64 GNU/Linux
[*] Finding system protections...
[+] ASLR is enabled
[+] SMEP is enabled
[+] Yama is installed and enabled
[*] Finding installed applications...
[+] ufw found: /usr/sbin/ufw
[+] iptables found: /usr/sbin/iptables
[+] logrotate found: /usr/sbin/logrotate
[*] Post module execution completed
```

```
[*] Running module against 172.16.191.233 [debian9-4-0-x64]
[*] Info:
[*] 	Debian GNU/Linux 9  
[*] 	Linux debian9-4-0-x64 4.9.0-6-amd64 #1 SMP Debian 4.9.82-1+deb9u3 (2018-03-02) x86_64 GNU/Linux
[*] Finding system protections...
[+] ASLR is enabled
[+] KAISER is enabled
[+] SMEP is enabled
[+] Yama is installed, but not enabled
[*] Finding installed applications...
[+] iptables found: /sbin/iptables
[+] logrotate found: /usr/sbin/logrotate
[*] Post module execution completed
```