### PR TITLE
Suppress 'Permission denied' errors in `Msf::Post::Linux::System.get_suid_files`

### DIFF
--- a/lib/msf/core/post/linux/system.rb
+++ b/lib/msf/core/post/linux/system.rb
@@ -132,7 +132,8 @@ module System
   # @param findpath The path on the system to start searching
   # @return [Array]
   def get_suid_files(findpath = '/')
-    cmd_exec("find #{findpath} -perm -4000 -print -xdev").to_s.split("\n")
+    out = cmd_exec("find #{findpath} -perm -4000 -print -xdev").to_s.split("\n")
+    out.delete_if {|i| i.include? 'Permission denied'}
   rescue
     raise "Could not retrieve all SUID files"
   end


### PR DESCRIPTION
This PR removes array elements from `Msf::Post::Linux::System.get_suid_files` which contain `Permission denied`.

This change brings the method inline with the similar `get_suid_files` method in the [Solaris lib](https://github.com/rapid7/metasploit-framework/pull/10437/files#diff-c5b569923fcfc43e3351aba4fc399d5cR36).

This approach is locale-dependent (as is pretty much the entirety of MSF). An [alternative solution](https://stackoverflow.com/questions/762348/how-can-i-exclude-all-permission-denied-messages-from-find) would be piping `stderr` to `/dev/null`.

### Before

```
[*] get_suid_files: ["find: `/tmp/.private': Permission denied"]
```

### After

```
[*] get_suid_files: []
```
