### PR TITLE
Add Msf::Post::Linux::Kernel.kernel_config method

### DIFF
--- a/lib/msf/core/post/linux/kernel.rb
+++ b/lib/msf/core/post/linux/kernel.rb
@@ -55,6 +55,21 @@ module Kernel
   end
 
   #
+  # Returns the kernel boot config
+  #
+  # @return [Array]
+  #
+  def kernel_config
+    return [] unless cmd_exec('test -r /boot/config-`uname -r` && echo true').include? 'true'
+
+    config = cmd_exec("cat /boot/config-`uname -r`").to_s.split("\n").map(&:strip)
+    config.reject {|i| i.eql? ''}.reject {|i| i.start_with? '#'}
+  rescue
+    raise 'Could not retrieve kernel config'
+    []
+  end
+
+  #
   # Returns the kernel modules
   #
   # @return [Array]

--- a/lib/msf/core/post/linux/kernel.rb
+++ b/lib/msf/core/post/linux/kernel.rb
@@ -60,13 +60,19 @@ module Kernel
   # @return [Array]
   #
   def kernel_config
-    return [] unless cmd_exec('test -r /boot/config-`uname -r` && echo true').include? 'true'
+    return unless cmd_exec('test -r /boot/config-`uname -r` && echo true').include? 'true'
 
-    config = cmd_exec("cat /boot/config-`uname -r`").to_s.split("\n").map(&:strip)
-    config.reject {|i| i.eql? ''}.reject {|i| i.start_with? '#'}
+    output = cmd_exec("cat /boot/config-`uname -r`").to_s.strip
+
+    return if output.empty?
+
+    config = output.split("\n").map(&:strip).reject(&:empty?).reject {|i| i.start_with? '#'}
+
+    return if config.empty?
+
+    config
   rescue
     raise 'Could not retrieve kernel config'
-    []
   end
 
   #


### PR DESCRIPTION
Add `Msf::Post::Linux::Kernel.kernel_config` method.

Returns the kernel config as an `Array`.

If the kernel config is not readable, an empty `Array` is returned. This seemed like a better idea than returning `nil`, but I could be convinced otherwise.
