### PR TITLE
(GoLang) Centralize logging sync, fix minor logging issues

### DIFF
--- a/lib/msf/core/modules/external/go/src/metasploit/module/core.go
+++ b/lib/msf/core/modules/external/go/src/metasploit/module/core.go
@@ -7,11 +7,14 @@ package module
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
 	"log"
 	"os"
 	"strings"
-	"errors"
+	"sync"
 )
+
+var logMutex = &sync.Mutex{}
 
 /*
  * RunCallback represents the method to call from the module
@@ -128,10 +131,14 @@ type (
 )
 
 func LogInfo(message string) {
+	logMutex.Lock()
+	defer logMutex.Unlock()
 	msfLog(message, "info")
 }
 
 func LogError(message string) {
+	logMutex.Lock()
+	defer logMutex.Unlock()
 	msfLog(message, "error")
 }
 

--- a/modules/auxiliary/scanner/msmail/exchange_enum.go
+++ b/modules/auxiliary/scanner/msmail/exchange_enum.go
@@ -67,7 +67,6 @@ func run_exchange_enum(params map[string]interface{}) {
 func o365enum(ip string, emaillist []string, threads int) []string {
 	limit := threads
 	var wg sync.WaitGroup
-	mux := &sync.Mutex{}
 	queue := make(chan string)
 	//limit := 100
 
@@ -90,18 +89,12 @@ func o365enum(ip string, emaillist []string, threads int) []string {
 			for email := range queue {
 				responseCode := msmail.WebRequestBasicAuth(URI, email, pass, tr)
 				if strings.Contains(email, "@") && responseCode == 401 {
-					mux.Lock()
 					module.LogInfo("[+]  " + email + " - 401")
 					validemails = append(validemails, email)
-					mux.Unlock()
 				} else if strings.Contains(email, "@") && responseCode == 404 {
-					mux.Lock()
-					module.LogInfo(fmt.Sprintf("[-]  %s - %d \n", email, responseCode))
-					mux.Unlock()
+					module.LogInfo(fmt.Sprintf("[-]  %s - %d", email, responseCode))
 				} else {
-					mux.Lock()
-					module.LogInfo(fmt.Sprintf("Unusual Response: %s - %d \n", email, responseCode))
-					mux.Unlock()
+					module.LogError(fmt.Sprintf("Unusual Response: %s - %d", email, responseCode))
 				}
 			}
 		}(i)

--- a/modules/auxiliary/scanner/msmail/onprem_enum.go
+++ b/modules/auxiliary/scanner/msmail/onprem_enum.go
@@ -64,7 +64,6 @@ func run_onprem_enum(params map[string]interface{}) {
 func determineValidUsers(host string, avgResponse time.Duration, userlist []string, threads int) []string {
 	limit := threads
 	var wg sync.WaitGroup
-	mux := &sync.Mutex{}
 	queue := make(chan string)
 
 	/*Keep in mind you, nothing has been added to handle successful auths
@@ -101,14 +100,10 @@ func determineValidUsers(host string, avgResponse time.Duration, userlist []stri
 				elapsedTime := time.Since(startTime)
 
 				if float64(elapsedTime) < float64(avgResponse)*0.77 {
-					mux.Lock()
 					module.LogInfo("[+] " + user + " - " + elapsedTime.String())
 					validusers = append(validusers, user)
-					mux.Unlock()
 				} else {
-					mux.Lock()
 					module.LogInfo("[-] " + user + " - " + elapsedTime.String())
-					mux.Unlock()
 				}
 			}
 		}(i)


### PR DESCRIPTION
Moved mutexes to a central log location

# Verification
- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/msmail/onprem_enum`
- [ ] set RHOSTS <some host>
- [ ] set USER_FILE <some file full of users>
- [ ] set THREADS (1 < COUNT < 100)
- [ ] `run`
- [ ] Verify the log the log output isn't mangled
