### PR TITLE
Add CVE as issued by DWF

### DIFF
--- a/modules/exploits/linux/http/php_imap_open_rce.rb
+++ b/modules/exploits/linux/http/php_imap_open_rce.rb
@@ -33,7 +33,8 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'URL', 'https://github.com/Bo0oM/PHP_imap_open_exploit' ],
           [ 'EDB', '45865'],
           [ 'URL', 'https://bugs.php.net/bug.php?id=76428'],
-          [ 'CVE', '2018-19518']
+          [ 'CVE', '2018-19518'],
+          [ 'CVE', '2018-1000859']
         ],
       'Privileged'  => false,
       'Platform'  => [ 'unix' ],


### PR DESCRIPTION
See discussion on #10987.

Now that I said that out loud, I realize that the original PR for this module is a really funny PR number.

## Verification

- [x] Start `msfconsole`
- [x] `info exploit/linux/http/php_imap_open_rce`
- [x] **Verify** both CVEs are listed.


