### PR TITLE
Add `Msf::Post::Linux::Kernel.kernel_config` checks to various Linux local exploits

### DIFF
--- a/modules/exploits/linux/local/af_packet_chocobo_root_priv_esc.rb
+++ b/modules/exploits/linux/local/af_packet_chocobo_root_priv_esc.rb
@@ -165,6 +165,18 @@ class MetasploitModule < Msf::Exploit::Local
     end
     vprint_good "System has #{cores} CPU cores"
 
+    config = kernel_config
+    if config.nil?
+      vprint_error 'Could not retrieve kernel config'
+      return CheckCode::Unknown
+    end
+
+    unless config.include? 'CONFIG_USER_NS=y'
+      vprint_error 'Kernel config does not include CONFIG_USER_NS'
+      return CheckCode::Safe
+    end
+    vprint_good 'Kernel config has CONFIG_USER_NS enabled'
+
     unless userns_enabled?
       vprint_error 'Unprivileged user namespaces are not permitted'
       return CheckCode::Safe

--- a/modules/exploits/linux/local/af_packet_packet_set_ring_priv_esc.rb
+++ b/modules/exploits/linux/local/af_packet_packet_set_ring_priv_esc.rb
@@ -150,6 +150,18 @@ class MetasploitModule < Msf::Exploit::Local
     end
     vprint_good "System has #{cores} CPU cores"
 
+    config = kernel_config
+    if config.nil?
+      vprint_error 'Could not retrieve kernel config'
+      return CheckCode::Unknown
+    end
+
+    unless config.include? 'CONFIG_USER_NS=y'
+      vprint_error 'Kernel config does not include CONFIG_USER_NS'
+      return CheckCode::Safe
+    end
+    vprint_good 'Kernel config has CONFIG_USER_NS enabled'
+
     unless userns_enabled?
       vprint_error 'Unprivileged user namespaces are not permitted'
       return CheckCode::Safe

--- a/modules/exploits/linux/local/bpf_priv_esc.rb
+++ b/modules/exploits/linux/local/bpf_priv_esc.rb
@@ -6,8 +6,10 @@
 class MetasploitModule < Msf::Exploit::Local
   Rank = GoodRanking
 
-  include Msf::Exploit::EXE
   include Msf::Post::File
+  include Msf::Post::Linux::System
+  include Msf::Post::Linux::Kernel
+  include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
 
   def initialize(info={})
@@ -60,26 +62,31 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    def check_config_bpf_syscall?()
-      output = cmd_exec('grep CONFIG_BPF_SYSCALL /boot/config-`uname -r`')
-      if output == 'CONFIG_BPF_SYSCALL=y'
-        vprint_good('CONFIG_BPF_SYSCALL is set to yes')
-        return true
-      else
-        print_error('CONFIG_BPF_SYSCALL is NOT set to yes')
+    def check_config_bpf_syscall?
+      config = kernel_config
+
+      if config.nil?
+        vprint_error 'Could not retrieve kernel config'
+        return
+      end
+
+      unless config.include? 'CONFIG_BPF_SYSCALL=y'
+        vprint_error 'Kernel config does not include CONFIG_BPF_SYSCALL'
         return false
       end
+
+      vprint_good 'Kernel config has CONFIG_BPF_SYSCALL enabled'
+      true
     end
 
-    def check_kernel_disabled?()
-      output = cmd_exec('sysctl kernel.unprivileged_bpf_disabled')
-      if output != 'kernel.unprivileged_bpf_disabled = 1'
-        vprint_good('kernel.unprivileged_bpf_disabled is NOT set to 1')
-        return true
-      else
-        print_error('kernel.unprivileged_bpf_disabled is set to 1')
+    def check_kernel_disabled?
+      if unprivileged_bpf_disabled?
+        vprint_error 'Unprivileged BPF loading is not permitted'
         return false
       end
+
+      vprint_good 'Unprivileged BPF loading is permitted'
+      true
     end
 
     def check_fuse?()

--- a/modules/exploits/linux/local/bpf_sign_extension_priv_esc.rb
+++ b/modules/exploits/linux/local/bpf_sign_extension_priv_esc.rb
@@ -160,12 +160,6 @@ class MetasploitModule < Msf::Exploit::Local
     end
     vprint_good "System architecture #{arch} is supported"
 
-    if unprivileged_bpf_disabled?
-      vprint_error 'Unprivileged BPF loading is not permitted'
-      return CheckCode::Safe
-    end
-    vprint_good 'Unprivileged BPF loading is permitted'
-
     release = kernel_release
     if Gem::Version.new(release.split('-').first) > Gem::Version.new('4.14.11') ||
        Gem::Version.new(release.split('-').first) < Gem::Version.new('4.0')
@@ -173,6 +167,24 @@ class MetasploitModule < Msf::Exploit::Local
       return CheckCode::Safe
     end
     vprint_good "Kernel version #{release} appears to be vulnerable"
+
+    config = kernel_config
+    if config.nil?
+      vprint_error 'Could not retrieve kernel config'
+      return CheckCode::Unknown
+    end
+
+    unless config.include? 'CONFIG_BPF_SYSCALL=y'
+      vprint_error 'Kernel config does not include CONFIG_BPF_SYSCALL'
+      return CheckCode::Safe
+    end
+    vprint_good 'Kernel config has CONFIG_BPF_SYSCALL enabled'
+
+    if unprivileged_bpf_disabled?
+      vprint_error 'Unprivileged BPF loading is not permitted'
+      return CheckCode::Safe
+    end
+    vprint_good 'Unprivileged BPF loading is permitted'
 
     CheckCode::Appears
   end

--- a/modules/exploits/linux/local/glibc_realpath_priv_esc.rb
+++ b/modules/exploits/linux/local/glibc_realpath_priv_esc.rb
@@ -138,12 +138,6 @@ class MetasploitModule < Msf::Exploit::Local
     end
     vprint_good "System architecture #{arch} is supported"
 
-    unless userns_enabled?
-      vprint_error 'Unprivileged user namespaces are not permitted'
-      return CheckCode::Safe
-    end
-    vprint_good 'Unprivileged user namespaces are permitted'
-
     version = glibc_version
     if Gem::Version.new(version.split('-').first) > Gem::Version.new('2.26')
       vprint_error "GNU C Library version #{version} is not vulnerable"
@@ -157,6 +151,24 @@ class MetasploitModule < Msf::Exploit::Local
       vprint_error 'No offsets for this version of GNU C Library'
       return CheckCode::Safe
     end
+
+    config = kernel_config
+    if config.nil?
+      vprint_error 'Could not retrieve kernel config'
+      return CheckCode::Unknown
+    end
+
+    unless config.include? 'CONFIG_USER_NS=y'
+      vprint_error 'Kernel config does not include CONFIG_USER_NS'
+      return CheckCode::Safe
+    end
+    vprint_good 'Kernel config has CONFIG_USER_NS enabled'
+
+    unless userns_enabled?
+      vprint_error 'Unprivileged user namespaces are not permitted'
+      return CheckCode::Safe
+    end
+    vprint_good 'Unprivileged user namespaces are permitted'
 
     CheckCode::Appears
   end

--- a/modules/exploits/linux/local/nested_namespace_idmap_limit_priv_esc.rb
+++ b/modules/exploits/linux/local/nested_namespace_idmap_limit_priv_esc.rb
@@ -137,12 +137,6 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    unless userns_enabled?
-      vprint_error 'Unprivileged user namespaces are not permitted'
-      return CheckCode::Safe
-    end
-    vprint_good 'Unprivileged user namespaces are permitted'
-
     ['/usr/bin/newuidmap', '/usr/bin/newgidmap'].each do |path|
       unless setuid? path
         vprint_error "#{path} is not set-uid"
@@ -161,6 +155,24 @@ class MetasploitModule < Msf::Exploit::Local
       return CheckCode::Safe
     end
     vprint_good "Kernel version #{release} appears to be vulnerable"
+
+    config = kernel_config
+    if config.nil?
+      vprint_error 'Could not retrieve kernel config'
+      return CheckCode::Unknown
+    end
+
+    unless config.include? 'CONFIG_USER_NS=y'
+      vprint_error 'Kernel config does not include CONFIG_USER_NS'
+      return CheckCode::Safe
+    end
+    vprint_good 'Kernel config has CONFIG_USER_NS enabled'
+
+    unless userns_enabled?
+      vprint_error 'Unprivileged user namespaces are not permitted'
+      return CheckCode::Safe
+    end
+    vprint_good 'Unprivileged user namespaces are permitted'
 
     CheckCode::Appears
   end

--- a/modules/exploits/linux/local/ufo_privilege_escalation.rb
+++ b/modules/exploits/linux/local/ufo_privilege_escalation.rb
@@ -130,6 +130,13 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
+    arch = kernel_hardware
+    unless arch.include? 'x86_64'
+      vprint_error "System architecture #{arch} is not supported"
+      return CheckCode::Safe
+    end
+    vprint_good "System architecture #{arch} is supported"
+
     version = kernel_release
     unless version =~ /^4\.4\.0-(21|22|24|28|31|34|36|38|42|45|47|51|53|57|59|62|63|64|66|67|70|71|72|75|78|79|81|83|87|89|81|89)-generic/ ||
            version =~ /^4\.8\.0-(34|36|39|41|45|46|49|51|52|53|54|56|58)-generic/
@@ -145,12 +152,17 @@ class MetasploitModule < Msf::Exploit::Local
     end
     vprint_good 'SMAP is not enabled'
 
-    arch = kernel_hardware
-    unless arch.include? 'x86_64'
-      vprint_error "System architecture #{arch} is not supported"
+    config = kernel_config
+    if config.nil?
+      vprint_error 'Could not retrieve kernel config'
+      return CheckCode::Unknown
+    end
+
+    unless config.include? 'CONFIG_USER_NS=y'
+      vprint_error 'Kernel config does not include CONFIG_USER_NS'
       return CheckCode::Safe
     end
-    vprint_good "System architecture #{arch} is supported"
+    vprint_good 'Kernel config has CONFIG_USER_NS enabled'
 
     unless userns_enabled?
       vprint_error 'Unprivileged user namespaces are not permitted'


### PR DESCRIPTION
This PR adds `Msf::Post::Linux::Kernel.kernel_config` checks to various Linux local exploits.

In particular, checks for `CONFIG_BPF_SYSCALL=y` and `CONFIG_USER_NS=y`.

Following these changes, I've only tested exploitation with a couple of the modules (bpf_signed and ufo); and only tested the `check` method on a few modules, as per output below. In theory, if I know what I'm doing, I won't have broken anything.

In a couple of instances, I've re-orded the checks in the `check` method so as to be marginally stealthier. ie, check system architecture and kernel version, before poking at the kernel config and sysctls.


```
msf5 exploit(linux/local/bpf_priv_esc) > check

[+] Kernel config has CONFIG_BPF_SYSCALL enabled
[+] Unprivileged BPF loading is permitted
[+] fuse is installed
[+] /tmp/fuse_mount doesn't exist
[*] The target appears to be vulnerable.
```

```
msf5 exploit(linux/local/bpf_sign_extension_priv_esc) > check

[+] System architecture x86_64 is supported
[+] Kernel version 4.13.0-16-generic appears to be vulnerable
[+] Kernel config has CONFIG_BPF_SYSCALL enabled
[+] Unprivileged BPF loading is permitted
[*] The target appears to be vulnerable.
```

```
msf5 exploit(linux/local/ufo_privilege_escalation) > check

[+] System architecture x86_64 is supported
[+] Linux kernel version 4.4.0-89-generic is vulnerable
[*] Checking if SMAP is enabled ...
[+] SMAP is not enabled
[+] Kernel config has CONFIG_USER_NS enabled
[+] Unprivileged user namespaces are permitted
[*] The target appears to be vulnerable.
```

```
msf5 exploit(linux/local/nested_namespace_idmap_limit_priv_esc) > check

[+] /usr/bin/newuidmap is set-uid
[+] /usr/bin/newgidmap is set-uid
[+] Kernel version 4.15.0-20-generic appears to be vulnerable
[+] Kernel config has CONFIG_USER_NS enabled
[+] Unprivileged user namespaces are permitted
[*] The target appears to be vulnerable.
```
