### PR TITLE
update mettle payloads, fix numerous issues

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,7 +23,7 @@ PATH
       metasploit-model
       metasploit-payloads (= 1.3.54)
       metasploit_data_models
-      metasploit_payloads-mettle (= 0.4.2)
+      metasploit_payloads-mettle (= 0.5.0)
       mqtt
       msgpack
       nessus_rest
@@ -189,7 +189,7 @@ GEM
       postgres_ext
       railties (~> 4.2.6)
       recog (~> 2.0)
-    metasploit_payloads-mettle (0.4.2)
+    metasploit_payloads-mettle (0.5.0)
     method_source (0.9.2)
     mini_portile2 (2.3.0)
     minitest (5.11.3)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -72,7 +72,7 @@ Gem::Specification.new do |spec|
   # Needed for Meterpreter
   spec.add_runtime_dependency 'metasploit-payloads', '1.3.54'
   # Needed for the next-generation POSIX Meterpreter
-  spec.add_runtime_dependency 'metasploit_payloads-mettle', '0.4.2'
+  spec.add_runtime_dependency 'metasploit_payloads-mettle', '0.5.0'
   # Needed by msfgui and other rpc components
   spec.add_runtime_dependency 'msgpack'
   # get list of network interfaces, like eth* from OS.

--- a/modules/payloads/singles/apple_ios/aarch64/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/apple_ios/aarch64/meterpreter_reverse_http.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_aarch64_apple_ios'
 
 module MetasploitModule
 
-  CachedSize = 694520
+  CachedSize = 733380
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/apple_ios/aarch64/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/apple_ios/aarch64/meterpreter_reverse_https.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_aarch64_apple_ios'
 
 module MetasploitModule
 
-  CachedSize = 694520
+  CachedSize = 733380
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/apple_ios/aarch64/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/apple_ios/aarch64/meterpreter_reverse_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_aarch64_apple_ios'
 
 module MetasploitModule
 
-  CachedSize = 694520
+  CachedSize = 733380
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/aarch64/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/aarch64/meterpreter_reverse_http.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_aarch64_linux'
 
 module MetasploitModule
 
-  CachedSize = 972816
+  CachedSize = 1021984
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/aarch64/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/aarch64/meterpreter_reverse_https.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_aarch64_linux'
 
 module MetasploitModule
 
-  CachedSize = 972816
+  CachedSize = 1021984
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/aarch64/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/aarch64/meterpreter_reverse_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_aarch64_linux'
 
 module MetasploitModule
 
-  CachedSize = 972816
+  CachedSize = 1021984
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/armbe/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/armbe/meterpreter_reverse_http.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_armbe_linux'
 
 module MetasploitModule
 
-  CachedSize = 908112
+  CachedSize = 954904
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/armbe/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/armbe/meterpreter_reverse_https.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_armbe_linux'
 
 module MetasploitModule
 
-  CachedSize = 908112
+  CachedSize = 954904
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/armbe/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/armbe/meterpreter_reverse_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_armbe_linux'
 
 module MetasploitModule
 
-  CachedSize = 908112
+  CachedSize = 954904
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/armle/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/armle/meterpreter_reverse_http.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_armle_linux'
 
 module MetasploitModule
 
-  CachedSize = 908460
+  CachedSize = 951548
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/armle/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/armle/meterpreter_reverse_https.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_armle_linux'
 
 module MetasploitModule
 
-  CachedSize = 908460
+  CachedSize = 951548
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/armle/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/armle/meterpreter_reverse_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_armle_linux'
 
 module MetasploitModule
 
-  CachedSize = 908460
+  CachedSize = 951548
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/mips64/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/mips64/meterpreter_reverse_http.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_mips64_linux'
 
 module MetasploitModule
 
-  CachedSize = 1393960
+  CachedSize = 1465864
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/mips64/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/mips64/meterpreter_reverse_https.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_mips64_linux'
 
 module MetasploitModule
 
-  CachedSize = 1393960
+  CachedSize = 1465864
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/mips64/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/mips64/meterpreter_reverse_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_mips64_linux'
 
 module MetasploitModule
 
-  CachedSize = 1393960
+  CachedSize = 1465864
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/mipsbe/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/mipsbe/meterpreter_reverse_http.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_mipsbe_linux'
 
 module MetasploitModule
 
-  CachedSize = 1290244
+  CachedSize = 1355808
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/mipsbe/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/mipsbe/meterpreter_reverse_https.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_mipsbe_linux'
 
 module MetasploitModule
 
-  CachedSize = 1290244
+  CachedSize = 1355808
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/mipsbe/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/mipsbe/meterpreter_reverse_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_mipsbe_linux'
 
 module MetasploitModule
 
-  CachedSize = 1290244
+  CachedSize = 1355808
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/mipsle/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/mipsle/meterpreter_reverse_http.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_mipsle_linux'
 
 module MetasploitModule
 
-  CachedSize = 1291736
+  CachedSize = 1357300
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/mipsle/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/mipsle/meterpreter_reverse_https.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_mipsle_linux'
 
 module MetasploitModule
 
-  CachedSize = 1291736
+  CachedSize = 1357300
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/mipsle/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/mipsle/meterpreter_reverse_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_mipsle_linux'
 
 module MetasploitModule
 
-  CachedSize = 1291736
+  CachedSize = 1357300
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/ppc/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/ppc/meterpreter_reverse_http.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_ppc_linux'
 
 module MetasploitModule
 
-  CachedSize = 1061540
+  CachedSize = 1133772
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/ppc/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/ppc/meterpreter_reverse_https.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_ppc_linux'
 
 module MetasploitModule
 
-  CachedSize = 1061540
+  CachedSize = 1133772
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/ppc/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/ppc/meterpreter_reverse_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_ppc_linux'
 
 module MetasploitModule
 
-  CachedSize = 1061540
+  CachedSize = 1133772
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/ppc64le/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/ppc64le/meterpreter_reverse_http.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_ppc64le_linux'
 
 module MetasploitModule
 
-  CachedSize = 1080792
+  CachedSize = 1089224
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/ppc64le/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/ppc64le/meterpreter_reverse_https.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_ppc64le_linux'
 
 module MetasploitModule
 
-  CachedSize = 1080792
+  CachedSize = 1089224
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/ppc64le/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/ppc64le/meterpreter_reverse_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_ppc64le_linux'
 
 module MetasploitModule
 
-  CachedSize = 1080792
+  CachedSize = 1089224
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/ppce500v2/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/ppce500v2/meterpreter_reverse_http.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_ppce500v2_linux'
 
 module MetasploitModule
 
-  CachedSize = 1014220
+  CachedSize = 1086452
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/ppce500v2/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/ppce500v2/meterpreter_reverse_https.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_ppce500v2_linux'
 
 module MetasploitModule
 
-  CachedSize = 1014220
+  CachedSize = 1086452
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/ppce500v2/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/ppce500v2/meterpreter_reverse_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_ppce500v2_linux'
 
 module MetasploitModule
 
-  CachedSize = 1014220
+  CachedSize = 1086452
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/x64/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/x64/meterpreter_reverse_http.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_x64_linux'
 
 module MetasploitModule
 
-  CachedSize = 911224
+  CachedSize = 964720
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/x64/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/x64/meterpreter_reverse_https.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_x64_linux'
 
 module MetasploitModule
 
-  CachedSize = 911224
+  CachedSize = 964720
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/x64/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/x64/meterpreter_reverse_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_x64_linux'
 
 module MetasploitModule
 
-  CachedSize = 911224
+  CachedSize = 964720
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/x86/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/x86/meterpreter_reverse_http.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_x86_linux'
 
 module MetasploitModule
 
-  CachedSize = 961872
+  CachedSize = 1022972
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/x86/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/x86/meterpreter_reverse_https.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_x86_linux'
 
 module MetasploitModule
 
-  CachedSize = 961872
+  CachedSize = 1022972
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/x86/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/x86/meterpreter_reverse_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_x86_linux'
 
 module MetasploitModule
 
-  CachedSize = 961872
+  CachedSize = 1022972
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/zarch/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/zarch/meterpreter_reverse_http.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_zarch_linux'
 
 module MetasploitModule
 
-  CachedSize = 1080856
+  CachedSize = 1142544
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/zarch/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/zarch/meterpreter_reverse_https.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_zarch_linux'
 
 module MetasploitModule
 
-  CachedSize = 1080856
+  CachedSize = 1142544
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/zarch/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/zarch/meterpreter_reverse_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_zarch_linux'
 
 module MetasploitModule
 
-  CachedSize = 1080856
+  CachedSize = 1142544
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/osx/x64/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/osx/x64/meterpreter_reverse_http.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_x64_osx'
 
 module MetasploitModule
 
-  CachedSize = 808168
+  CachedSize = 842712
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/osx/x64/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/osx/x64/meterpreter_reverse_https.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_x64_osx'
 
 module MetasploitModule
 
-  CachedSize = 808168
+  CachedSize = 842712
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/osx/x64/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/osx/x64/meterpreter_reverse_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_x64_osx'
 
 module MetasploitModule
 
-  CachedSize = 808168
+  CachedSize = 842712
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions


### PR DESCRIPTION
This is a large update to mettle payloads including:

 * Adds globbing support to the `ls` command (https://github.com/rapid7/mettle/pull/139)
 * Fixes crashes on iOS platforms when cryptTLV is enabled (https://github.com/rapid7/mettle/pull/142)
 * Fixes display of the OS version on macOS and iOS (https://github.com/rapid7/mettle/pull/143)
 * Fixes the local port handling for pivoted client network connections (https://github.com/rapid7/mettle/pull/144)
 * Fixes an unaligned memory access in TLV packet handling, needed for some CPUs (https://github.com/rapid7/mettle/pull/145)
 * Fixes some compatibility issues building on Solaris (https://github.com/rapid7/mettle/pull/147)
 * Updated libpcap, mbedtls, and libcurl to the latest versions (https://github.com/rapid7/mettle/pull/146)

## Verification

- [x] This should pass all rspec tests
- [x] This should pass sanity tests
- [x] Spot check above bugs are fixed

