### PR TITLE
Add Msf::Post::Linux::Kernel.lkrg_installed? method

### DIFF
--- a/lib/msf/core/post/linux/kernel.rb
+++ b/lib/msf/core/post/linux/kernel.rb
@@ -203,6 +203,15 @@ module Kernel
   end
 
   #
+  # Returns true if Linux Kernel Runtime Guard (LKRG) kernel module is installed
+  #
+  def lkrg_installed?
+    cmd_exec('test -d /proc/sys/lkrg && echo true').to_s.strip.include? 'true'
+  rescue
+    raise 'Could not determine LKRG status'
+  end
+
+  #
   # Returns true if grsecurity is installed
   #
   def grsec_installed?

--- a/modules/post/linux/gather/enum_protections.rb
+++ b/modules/post/linux/gather/enum_protections.rb
@@ -87,6 +87,12 @@ class MetasploitModule < Msf::Post
       report r
     end
 
+    if lkrg_installed?
+      r = 'LKRG is installed'
+      print_good r
+      report r
+    end
+
     if grsec_installed?
       r = 'grsecurity is installed'
       print_good r


### PR DESCRIPTION
Add `Msf::Post::Linux::Kernel.lkrg_installed?` method.

Checks for `/proc/sys/lkrg` directory. Works regardless of whether LKRG was hidden with `lkrg.hide=0` sysctl parameter.

```
msf5 post(linux/gather/enum_protections) > run

[*] Running module against 172.16.191.234 [linux-mint-17-3-x64]
[*] Info:
[*] 	Linux Mint 17.3 Rosa  
[*] 	Linux linux-mint-17-3-x64 4.4.0-89-generic #112~14.04.1-Ubuntu SMP Tue Aug 1 22:08:32 UTC 2017 x86_64 x86_64 x86_64 GNU/Linux
[*] Finding system protections...
[+] ASLR is enabled
[+] SMEP is enabled
[+] LKRG is installed
[+] Yama is installed and enabled
[*] Finding installed applications...
[+] ufw found: /usr/sbin/ufw
[+] iptables found: /sbin/iptables
[+] logrotate found: /usr/sbin/logrotate
[+] tcpdump found: /usr/sbin/tcpdump
[*] Post module execution completed
```
