### PR TITLE
Add lkrg_installed? checks

### DIFF
--- a/modules/exploits/linux/local/af_packet_chocobo_root_priv_esc.rb
+++ b/modules/exploits/linux/local/af_packet_chocobo_root_priv_esc.rb
@@ -183,6 +183,12 @@ class MetasploitModule < Msf::Exploit::Local
     end
     vprint_good 'Unprivileged user namespaces are permitted'
 
+    if lkrg_installed?
+      vprint_error 'LKRG is installed'
+      return CheckCode::Safe
+    end
+    vprint_good 'LKRG is not installed'
+
     CheckCode::Appears
   end
 

--- a/modules/exploits/linux/local/af_packet_packet_set_ring_priv_esc.rb
+++ b/modules/exploits/linux/local/af_packet_packet_set_ring_priv_esc.rb
@@ -173,6 +173,12 @@ class MetasploitModule < Msf::Exploit::Local
       return CheckCode::Safe
     end
 
+    if lkrg_installed?
+      vprint_error 'LKRG is installed'
+      return CheckCode::Safe
+    end
+    vprint_good 'LKRG is not installed'
+
     CheckCode::Appears
   end
 

--- a/modules/exploits/linux/local/bpf_sign_extension_priv_esc.rb
+++ b/modules/exploits/linux/local/bpf_sign_extension_priv_esc.rb
@@ -186,6 +186,12 @@ class MetasploitModule < Msf::Exploit::Local
     end
     vprint_good 'Unprivileged BPF loading is permitted'
 
+    if lkrg_installed?
+      vprint_error 'LKRG is installed'
+      return CheckCode::Safe
+    end
+    vprint_good 'LKRG is not installed'
+
     CheckCode::Appears
   end
 

--- a/modules/exploits/linux/local/ufo_privilege_escalation.rb
+++ b/modules/exploits/linux/local/ufo_privilege_escalation.rb
@@ -170,6 +170,12 @@ class MetasploitModule < Msf::Exploit::Local
     end
     vprint_good 'Unprivileged user namespaces are permitted'
 
+    if lkrg_installed?
+      vprint_error 'LKRG is installed'
+      return CheckCode::Safe
+    end
+    vprint_good 'LKRG is not installed'
+
     CheckCode::Appears
   end
 


### PR DESCRIPTION
This PR updates the `check` method in four Linux local exploit modules to make use of the new `Msf::Post::Linux::Kernel.lkrg_installed?` method added in #11081.

**Note:** #11081 hasn't been merged yet.

Unsurprisingly, the following modules fail when LKRG is installed on the target host:

* bpf_sign_extension_priv_esc
* ufo_privilege_escalation
* af_packet_packet_set_ring_priv_esc
* af_packet_chocobo_root_priv_esc

Test output:

```
msf5 exploit(linux/local/bpf_sign_extension_priv_esc) > check

[+] System architecture x86_64 is supported
[+] Kernel version 4.4.0-89-generic appears to be vulnerable
[+] Kernel config has CONFIG_BPF_SYSCALL enabled
[+] Unprivileged BPF loading is permitted
[-] LKRG is installed
[*] The target is not exploitable.
```
