### PR TITLE
Use ::File::binread for exploit_data file read

### DIFF
--- a/modules/exploits/linux/local/af_packet_chocobo_root_priv_esc.rb
+++ b/modules/exploits/linux/local/af_packet_chocobo_root_priv_esc.rb
@@ -116,11 +116,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit_data(file)
-    path = ::File.join Msf::Config.data_directory, 'exploits', 'CVE-2016-8655', file
-    fd = ::File.open path, 'rb'
-    data = fd.read fd.stat.size
-    fd.close
-    data
+    ::File.binread ::File.join(Msf::Config.data_directory, 'exploits', 'CVE-2016-8655', file)
   end
 
   def live_compile?

--- a/modules/exploits/linux/local/af_packet_packet_set_ring_priv_esc.rb
+++ b/modules/exploits/linux/local/af_packet_packet_set_ring_priv_esc.rb
@@ -107,11 +107,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit_data(file)
-    path = ::File.join Msf::Config.data_directory, 'exploits', 'cve-2017-7308', file
-    fd = ::File.open path, 'rb'
-    data = fd.read fd.stat.size
-    fd.close
-    data
+    ::File.binread ::File.join(Msf::Config.data_directory, 'exploits', 'cve-2017-7308', file)
   end
 
   def live_compile?

--- a/modules/exploits/linux/local/bpf_sign_extension_priv_esc.rb
+++ b/modules/exploits/linux/local/bpf_sign_extension_priv_esc.rb
@@ -132,11 +132,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit_data(file)
-    path = ::File.join Msf::Config.data_directory, 'exploits', 'cve-2017-16995', file
-    fd = ::File.open path, 'rb'
-    data = fd.read fd.stat.size
-    fd.close
-    data
+    ::File.binread ::File.join(Msf::Config.data_directory, 'exploits', 'cve-2017-16995', file)
   end
 
   def live_compile?

--- a/modules/exploits/linux/local/glibc_realpath_priv_esc.rb
+++ b/modules/exploits/linux/local/glibc_realpath_priv_esc.rb
@@ -103,11 +103,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit_data(file)
-    path = ::File.join Msf::Config.data_directory, 'exploits', 'cve-2018-1000001', file
-    fd = ::File.open path, 'rb'
-    data = fd.read fd.stat.size
-    fd.close
-    data
+    ::File.binread ::File.join(Msf::Config.data_directory, 'exploits', 'cve-2018-1000001', file)
   end
 
   def live_compile?

--- a/modules/exploits/linux/local/rds_priv_esc.rb
+++ b/modules/exploits/linux/local/rds_priv_esc.rb
@@ -104,11 +104,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit_data(file)
-    path = ::File.join Msf::Config.data_directory, 'exploits', 'cve-2010-3904', file
-    fd = ::File.open path, 'rb'
-    data = fd.read fd.stat.size
-    fd.close
-    data
+    ::File.binread ::File.join(Msf::Config.data_directory, 'exploits', 'cve-2010-3904', file)
   end
 
   def live_compile?

--- a/modules/exploits/linux/local/recvmmsg_priv_esc.rb
+++ b/modules/exploits/linux/local/recvmmsg_priv_esc.rb
@@ -90,11 +90,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit_data(file)
-    path = ::File.join Msf::Config.data_directory, 'exploits', 'CVE-2014-0038', file
-    fd = ::File.open path, 'rb'
-    data = fd.read fd.stat.size
-    fd.close
-    data
+    ::File.binread ::File.join(Msf::Config.data_directory, 'exploits', 'CVE-2014-0038', file)
   end
 
   def live_compile?

--- a/modules/exploits/linux/local/ufo_privilege_escalation.rb
+++ b/modules/exploits/linux/local/ufo_privilege_escalation.rb
@@ -109,11 +109,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit_data(file)
-    path = ::File.join Msf::Config.data_directory, 'exploits', 'cve-2017-1000112', file
-    fd = ::File.open path, 'rb'
-    data = fd.read fd.stat.size
-    fd.close
-    data
+    ::File.binread ::File.join(Msf::Config.data_directory, 'exploits', 'cve-2017-1000112', file)
   end
 
   def live_compile?


### PR DESCRIPTION
This PR replaces this monstrosity:

```ruby
    path = ::File.join Msf::Config.data_directory, 'exploits', '<dirname>', file
    fd = ::File.open path, 'rb'
    data = fd.read fd.stat.size
    fd.close
    data
```

with this:

```ruby
   ::File.binread ::File.join(Msf::Config.data_directory, 'exploits', '<dirname>', file)
```

in several Linux local exploit modules.

[File.binread](https://apidock.com/ruby/IO/binread/class) has been supported since Ruby 1.9.~, and takes care of opening the file for reading as binary (`rb`) and automatically closes the file.

I'm largely responsible for spreading this copypasta by introducing the `exploit_data` method code pattern.

There are other modules which make use of this code pattern for local file reads (https://github.com/rapid7/metasploit-framework/pull/10994#discussion_r236792936), however this PR only addresses modules which specifically make use of an `exploit_data` method, to prevent further copypasta.
