### PR TITLE
Add CreateSession option to opt out of session creation in login modules

### DIFF
--- a/lib/msf/base/sessions/command_shell_options.rb
+++ b/lib/msf/base/sessions/command_shell_options.rb
@@ -17,7 +17,7 @@ module CommandShellOptions
 
     register_advanced_options(
       [
-        OptBool.new('CreateSession', [false, 'Create a new session on successful login.', true]),
+        OptBool.new('CreateSession', [false, 'Create a new session for every successful login', true]),
         OptString.new('InitialAutoRunScript', "An initial script to run on session creation (before AutoRunScript)"),
         OptString.new('AutoRunScript', "A script to run automatically on session creation."),
         OptString.new('CommandShellCleanupCommand', "A command to run before the session is closed")

--- a/lib/msf/base/sessions/command_shell_options.rb
+++ b/lib/msf/base/sessions/command_shell_options.rb
@@ -15,6 +15,12 @@ module CommandShellOptions
   def initialize(info = {})
     super(info)
 
+    register_options(
+      [
+        OptBool.new('CREATE_SESSION', [false, 'Create a new session on successful login.', true])
+      ]
+    )
+
     register_advanced_options(
       [
         OptString.new('InitialAutoRunScript', "An initial script to run on session creation (before AutoRunScript)"),

--- a/lib/msf/base/sessions/command_shell_options.rb
+++ b/lib/msf/base/sessions/command_shell_options.rb
@@ -15,14 +15,9 @@ module CommandShellOptions
   def initialize(info = {})
     super(info)
 
-    register_options(
-      [
-        OptBool.new('CREATE_SESSION', [false, 'Create a new session on successful login.', true])
-      ]
-    )
-
     register_advanced_options(
       [
+        OptBool.new('CreateSession', [false, 'Create a new session on successful login.', true]),
         OptString.new('InitialAutoRunScript', "An initial script to run on session creation (before AutoRunScript)"),
         OptString.new('AutoRunScript', "A script to run automatically on session creation."),
         OptString.new('CommandShellCleanupCommand', "A command to run before the session is closed")

--- a/modules/auxiliary/scanner/rservices/rexec_login.rb
+++ b/modules/auxiliary/scanner/rservices/rexec_login.rb
@@ -182,6 +182,6 @@ class MetasploitModule < Msf::Auxiliary
     # Don't tie the life of this socket to the exploit
     self.sockets.delete(stderr_sock)
 
-    start_session(self, "rexec #{user}:#{pass} (#{host}:#{port})", merge_me)
+    start_session(self, "rexec #{user}:#{pass} (#{host}:#{port})", merge_me) if datastore['CreateSession']
   end
 end

--- a/modules/auxiliary/scanner/rservices/rlogin_login.rb
+++ b/modules/auxiliary/scanner/rservices/rlogin_login.rb
@@ -326,7 +326,7 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     report_auth_info(auth_info)
-    start_session(self, info, merge_me)
+    start_session(self, info, merge_me) if datastore['CreateSession']
 
   end
 end

--- a/modules/auxiliary/scanner/rservices/rsh_login.rb
+++ b/modules/auxiliary/scanner/rservices/rsh_login.rb
@@ -267,6 +267,6 @@ class MetasploitModule < Msf::Auxiliary
     # Don't tie the life of this socket to the exploit
     self.sockets.delete(stderr_sock)
 
-    start_session(self, "RSH #{user} from #{luser} (#{host}:#{port})", merge_me)
+    start_session(self, "RSH #{user} from #{luser} (#{host}:#{port})", merge_me) if datastore['CreateSession']
   end
 end

--- a/modules/auxiliary/scanner/ssh/eaton_xpert_backdoor.rb
+++ b/modules/auxiliary/scanner/ssh/eaton_xpert_backdoor.rb
@@ -87,13 +87,23 @@ class MetasploitModule < Msf::Auxiliary
 
     shell = Net::SSH::CommandStream.new(ssh)
 
-    return unless shell
+    # XXX: Wait for CommandStream to log a channel request failure
+    sleep 0.1
+
+    if (e = shell.error)
+      print_error("#{ip}:#{rport} - #{e.class}: #{e.message}")
+      return
+    end
+
+    info = "#{self.name} (#{version})"
 
     ds_merge = {
       'USERNAME' => 'admin'
     }
 
-    start_session(self, "Eaton Xpert Meter SSH Backdoor (#{version})", ds_merge, false, shell.lsock)
+    if datastore['CreateSession']
+      start_session(self, info, ds_merge, false, shell.lsock)
+    end
 
     # XXX: Ruby segfaults if we don't remove the SSH socket
     remove_socket(ssh.transport.socket)

--- a/modules/auxiliary/scanner/ssh/fortinet_backdoor.rb
+++ b/modules/auxiliary/scanner/ssh/fortinet_backdoor.rb
@@ -89,7 +89,7 @@ class MetasploitModule < Msf::Auxiliary
       'USERNAME' => 'Fortimanager_Access'
     }
 
-    start_session(self, info, ds_merge, false, shell.lsock)
+    start_session(self, info, ds_merge, false, shell.lsock) if datastore['CreateSession']
 
     # XXX: Ruby segfaults if we don't remove the SSH socket
     remove_socket(ssh.transport.socket)

--- a/modules/auxiliary/scanner/ssh/fortinet_backdoor.rb
+++ b/modules/auxiliary/scanner/ssh/fortinet_backdoor.rb
@@ -4,6 +4,7 @@
 ##
 
 class MetasploitModule < Msf::Auxiliary
+
   include Msf::Exploit::Remote::SSH
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::CommandShell
@@ -81,15 +82,23 @@ class MetasploitModule < Msf::Auxiliary
 
     shell = Net::SSH::CommandStream.new(ssh)
 
-    return unless shell
+    # XXX: Wait for CommandStream to log a channel request failure
+    sleep 0.1
 
-    info = "Fortinet SSH Backdoor (#{version})"
+    if (e = shell.error)
+      print_error("#{ip}:#{rport} - #{e.class}: #{e.message}")
+      return
+    end
+
+    info = "#{self.name} (#{version})"
 
     ds_merge = {
       'USERNAME' => 'Fortimanager_Access'
     }
 
-    start_session(self, info, ds_merge, false, shell.lsock) if datastore['CreateSession']
+    if datastore['CreateSession']
+      start_session(self, info, ds_merge, false, shell.lsock)
+    end
 
     # XXX: Ruby segfaults if we don't remove the SSH socket
     remove_socket(ssh.transport.socket)
@@ -98,4 +107,5 @@ class MetasploitModule < Msf::Auxiliary
   def rport
     datastore['RPORT']
   end
+
 end

--- a/modules/auxiliary/scanner/ssh/karaf_login.rb
+++ b/modules/auxiliary/scanner/ssh/karaf_login.rb
@@ -8,10 +8,9 @@ require 'metasploit/framework/login_scanner/ssh'
 require 'metasploit/framework/credential_collection'
 
 class MetasploitModule < Msf::Auxiliary
-  include Msf::Auxiliary::Report
-  include Msf::Auxiliary::CommandShell
-  include Msf::Auxiliary::AuthBrute
   include Msf::Auxiliary::Scanner
+  include Msf::Auxiliary::AuthBrute
+  include Msf::Auxiliary::Report
 
   DEFAULT_USERNAME = 'karaf'
   DEFAULT_PASSWORD = 'karaf'

--- a/modules/auxiliary/scanner/ssh/libssh_auth_bypass.rb
+++ b/modules/auxiliary/scanner/ssh/libssh_auth_bypass.rb
@@ -137,7 +137,9 @@ class MetasploitModule < Msf::Auxiliary
 
     case action.name
     when 'Shell'
-      start_session(self, "#{self.name} (#{version})", {}, false, shell.lsock)
+      if datastore['CreateSession']
+        start_session(self, "#{self.name} (#{version})", {}, false, shell.lsock)
+      end
     when 'Execute'
       output = shell.channel && (shell.channel[:data] || '').chomp
 

--- a/modules/auxiliary/scanner/ssh/ssh_login.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login.rb
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Auxiliary
 
     register_options(
       [
-        Opt::RPORT(22),
+        Opt::RPORT(22)
       ], self.class
     )
 
@@ -128,9 +128,7 @@ class MetasploitModule < Msf::Auxiliary
         credential_core = create_credential(credential_data)
         credential_data[:core] = credential_core
         create_credential_login(credential_data)
-        if datastore['CreateSession']
-          session_setup(result, scanner)
-        end
+        session_setup(result, scanner) if datastore['CreateSession']
         :next_user
       when Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
         vprint_brute :level => :verror, :ip => ip, :msg => "Could not connect: #{result.proof}"

--- a/modules/auxiliary/scanner/ssh/ssh_login.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login.rb
@@ -36,7 +36,6 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
       [
         Opt::RPORT(22),
-        OptBool.new('NO_SHELL', [ false, 'Do not create a shell on sucessful login.', false]),
       ], self.class
     )
 
@@ -129,7 +128,9 @@ class MetasploitModule < Msf::Auxiliary
         credential_core = create_credential(credential_data)
         credential_data[:core] = credential_core
         create_credential_login(credential_data)
-        session_setup(result, scanner) unless datastore['NO_SHELL']
+        if datastore['CREATE_SESSION']
+          session_setup(result, scanner)
+        end
         :next_user
       when Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
         vprint_brute :level => :verror, :ip => ip, :msg => "Could not connect: #{result.proof}"

--- a/modules/auxiliary/scanner/ssh/ssh_login.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login.rb
@@ -35,7 +35,8 @@ class MetasploitModule < Msf::Auxiliary
 
     register_options(
       [
-        Opt::RPORT(22)
+        Opt::RPORT(22),
+        OptBool.new('NO_SHELL', [ false, 'Do not create a shell on sucessful login.', false]),
       ], self.class
     )
 
@@ -128,7 +129,7 @@ class MetasploitModule < Msf::Auxiliary
         credential_core = create_credential(credential_data)
         credential_data[:core] = credential_core
         create_credential_login(credential_data)
-        session_setup(result, scanner)
+        session_setup(result, scanner) unless datastore['NO_SHELL']
         :next_user
       when Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
         vprint_brute :level => :verror, :ip => ip, :msg => "Could not connect: #{result.proof}"

--- a/modules/auxiliary/scanner/ssh/ssh_login.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login.rb
@@ -128,7 +128,7 @@ class MetasploitModule < Msf::Auxiliary
         credential_core = create_credential(credential_data)
         credential_data[:core] = credential_core
         create_credential_login(credential_data)
-        if datastore['CREATE_SESSION']
+        if datastore['CreateSession']
           session_setup(result, scanner)
         end
         :next_user

--- a/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
@@ -152,7 +152,9 @@ class MetasploitModule < Msf::Auxiliary
           create_credential_login(credential_data)
           tmp_key = result.credential.private
           ssh_key = SSHKey.new tmp_key
-          session_setup(result, scanner, ssh_key.fingerprint)
+          if datastore['CREATE_SESSION']
+            session_setup(result, scanner, ssh_key.fingerprint)
+          end
           :next_user
         when Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
           if datastore['VERBOSE']

--- a/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
@@ -152,9 +152,7 @@ class MetasploitModule < Msf::Auxiliary
           create_credential_login(credential_data)
           tmp_key = result.credential.private
           ssh_key = SSHKey.new tmp_key
-          if datastore['CreateSession']
-            session_setup(result, scanner, ssh_key.fingerprint)
-          end
+          session_setup(result, scanner, ssh_key.fingerprint) if datastore['CreateSession']
           :next_user
         when Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
           if datastore['VERBOSE']

--- a/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
@@ -152,7 +152,7 @@ class MetasploitModule < Msf::Auxiliary
           create_credential_login(credential_data)
           tmp_key = result.credential.private
           ssh_key = SSHKey.new tmp_key
-          if datastore['CREATE_SESSION']
+          if datastore['CreateSession']
             session_setup(result, scanner, ssh_key.fingerprint)
           end
           :next_user

--- a/modules/auxiliary/scanner/telnet/brocade_enable_login.rb
+++ b/modules/auxiliary/scanner/telnet/brocade_enable_login.rb
@@ -152,6 +152,6 @@ class MetasploitModule < Msf::Auxiliary
       'PASSWORD'      => pass
     }
 
-    start_session(self, "TELNET #{user}:#{pass} (#{host}:#{port})", merge_me, true, scanner.sock)
+    start_session(self, "TELNET #{user}:#{pass} (#{host}:#{port})", merge_me, true, scanner.sock) if datastore['CreateSession']
   end
 end

--- a/modules/auxiliary/scanner/telnet/telnet_login.rb
+++ b/modules/auxiliary/scanner/telnet/telnet_login.rb
@@ -90,7 +90,9 @@ class MetasploitModule < Msf::Auxiliary
         credential_data[:core] = credential_core
         create_credential_login(credential_data)
         print_good "#{ip}:#{rport} - Login Successful: #{result.credential}"
-        start_telnet_session(ip,rport,result.credential.public,result.credential.private,scanner)
+        if datastore['CREATE_SESSION']
+          start_telnet_session(ip,rport,result.credential.public,result.credential.private,scanner)
+        end
       else
         invalidate_login(credential_data)
         vprint_error "#{ip}:#{rport} - LOGIN FAILED: #{result.credential} (#{result.status}: #{result.proof})"

--- a/modules/auxiliary/scanner/telnet/telnet_login.rb
+++ b/modules/auxiliary/scanner/telnet/telnet_login.rb
@@ -90,7 +90,7 @@ class MetasploitModule < Msf::Auxiliary
         credential_data[:core] = credential_core
         create_credential_login(credential_data)
         print_good "#{ip}:#{rport} - Login Successful: #{result.credential}"
-        if datastore['CREATE_SESSION']
+        if datastore['CreateSession']
           start_telnet_session(ip,rport,result.credential.public,result.credential.private,scanner)
         end
       else

--- a/modules/auxiliary/scanner/telnet/telnet_login.rb
+++ b/modules/auxiliary/scanner/telnet/telnet_login.rb
@@ -90,9 +90,7 @@ class MetasploitModule < Msf::Auxiliary
         credential_data[:core] = credential_core
         create_credential_login(credential_data)
         print_good "#{ip}:#{rport} - Login Successful: #{result.credential}"
-        if datastore['CreateSession']
-          start_telnet_session(ip,rport,result.credential.public,result.credential.private,scanner)
-        end
+        start_telnet_session(ip,rport,result.credential.public,result.credential.private,scanner) if datastore['CreateSession']
       else
         invalidate_login(credential_data)
         vprint_error "#{ip}:#{rport} - LOGIN FAILED: #{result.credential} (#{result.status}: #{result.proof})"

--- a/modules/exploits/apple_ios/ssh/cydia_default_ssh.rb
+++ b/modules/exploits/apple_ios/ssh/cydia_default_ssh.rb
@@ -9,7 +9,6 @@ require 'net/ssh/command_stream'
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
-  include Msf::Auxiliary::CommandShell
   include Msf::Exploit::Remote::SSH
 
   def initialize(info={})

--- a/modules/exploits/linux/http/raidsonic_nas_ib5220_exec_noauth.rb
+++ b/modules/exploits/linux/http/raidsonic_nas_ib5220_exec_noauth.rb
@@ -7,7 +7,6 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ManualRanking # It's backdooring the remote device
 
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Auxiliary::CommandShell
   include Msf::Exploit::FileDropper
 
   RESPONSE_PATTERN = "\<FORM\ NAME\=\"form\"\ METHOD\=\"POST\"\ ACTION\=\"\/cgi\/time\/time.cgi\"\ ENCTYPE\=\"multipart\/form-data"

--- a/modules/exploits/linux/ssh/quantum_vmpro_backdoor.rb
+++ b/modules/exploits/linux/ssh/quantum_vmpro_backdoor.rb
@@ -9,7 +9,6 @@ require 'net/ssh/command_stream'
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
-  include Msf::Auxiliary::CommandShell
   include Msf::Exploit::Remote::SSH
 
   def initialize(info={})

--- a/modules/exploits/linux/ssh/symantec_smg_ssh.rb
+++ b/modules/exploits/linux/ssh/symantec_smg_ssh.rb
@@ -9,7 +9,6 @@ require 'net/ssh/command_stream'
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
-  include Msf::Auxiliary::CommandShell
   include Msf::Exploit::Remote::SSH
 
   def initialize(info={})

--- a/modules/exploits/linux/ssh/vmware_vdp_known_privkey.rb
+++ b/modules/exploits/linux/ssh/vmware_vdp_known_privkey.rb
@@ -9,9 +9,8 @@ require 'net/ssh/command_stream'
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
-  include Msf::Auxiliary::Report
-  include Msf::Auxiliary::CommandShell
   include Msf::Exploit::Remote::SSH
+  include Msf::Auxiliary::Report
 
   def initialize(info = {})
     super(update_info(info, {


### PR DESCRIPTION
Add a `CreateSession` option to allow for credential testing without creating a shell. The `CreateSession` option is not required and is set to `true` by default (existing behavior).

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/ssh/ssh_login`
- [x] `set USERNAME msfdev`
- [x] `set PASSWORD msfdev`
- [x] `set RHOSTS 10.0.2.15`
- [x] `set CreateSession false`
- [x] `run`

```
[+] 10.0.2.15:22 - Success: 'msfdev:msfdev' 'uid=1000(msfdev) gid=1000(msfdev) groups=1000(msfdev),24(cdrom),25(floppy),29(audio),30(dip),44(video),46(plugdev),108(netdev),113(bluetooth),115(lpadmin),116(scanner) Linux msfdev 4.9.0-8-amd64 #1 SMP Debian 4.9.110-3+deb9u4 (2018-08-21) x86_64 GNU/Linux '
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf5 auxiliary(scanner/ssh/ssh_login) > sessions -i

Active sessions
===============

No active sessions.
```

Note that no session is created despite the successful login.

#10593