### PR TITLE
Clean out `unless not`

### DIFF
--- a/lib/rex/post/hwbridge/ui/console/command_dispatcher/automotive.rb
+++ b/lib/rex/post/hwbridge/ui/console/command_dispatcher/automotive.rb
@@ -49,7 +49,7 @@ class Console::CommandDispatcher::Automotive
   #
   def cmd_supported_buses
     buses = client.automotive.get_supported_buses
-    unless !buses.empty?
+    if buses.empty?
       print_line("none")
       return
     end

--- a/modules/auxiliary/admin/scada/yokogawa_bkbcopyd_client.rb
+++ b/modules/auxiliary/admin/scada/yokogawa_bkbcopyd_client.rb
@@ -92,12 +92,6 @@ class MetasploitModule < Msf::Auxiliary
     return data
   end
 
-  def valid_response?(data)
-    return false unless !!data
-    return false unless data =~ /500  'yyparse error': command not understood/
-    return true
-  end
-
   def on_client_connect(c)
     if action.name == 'STOR'
       contents = ""

--- a/modules/auxiliary/scanner/http/cisco_directory_traversal.rb
+++ b/modules/auxiliary/scanner/http/cisco_directory_traversal.rb
@@ -65,7 +65,7 @@ class MetasploitModule < Msf::Auxiliary
   def get_sessions(response)
     session_nos = response.scan(/([0-9]{2,})/)
 
-    unless !session_nos.empty?
+    if session_nos.empty?
       print_status("Could not detect any sessions")
       print("\n")
       return

--- a/modules/exploits/multi/http/mutiny_subnetmask_exec.rb
+++ b/modules/exploits/multi/http/mutiny_subnetmask_exec.rb
@@ -93,7 +93,7 @@ class MetasploitModule < Msf::Exploit::Remote
       %Q|sed -e s/NETMASK=.*/NETMASK=#{@netmask_eth0}/ ifcfg-eth0 > ifcfg-eth0.bak|,
       %Q|mv -f ifcfg-eth0.bak ifcfg-eth0|,
       %Q|/etc/init.d/network restart|
-    ] unless not @netmask_eth0
+    ] if @netmask_eth0
     cmds << %Q|rm /tmp/#{@elfname}.elf| unless target.name =~ /CMD/
 
     print_status("Restoring Network Information and Cleanup...")


### PR DESCRIPTION
This came from a @bcook calling me out while whining publicly about `unless not`

This PR removes the instances where the double-negative were used, including an entire function hat was copied over from a copy/pasta move.

## Verification

- [x] make sure this makes sense
