### PR TITLE
remove call to method not defined

### DIFF
--- a/lib/msf/core/modules/metadata/maps.rb
+++ b/lib/msf/core/modules/metadata/maps.rb
@@ -37,7 +37,6 @@ module Msf::Modules::Metadata::Maps
 
       unless exploit.autofilter_ports.nil? || exploit.autofilter_ports.empty?
         exploit.autofilter_ports.each do |rport|
-          next unless port_allowed?(rport)
           mports[rport.to_i]           ||= {}
           mports[rport.to_i][fullname] = exploit
         end


### PR DESCRIPTION
Remove call to an undefined method when attempting to import xml files.

see #10940 for context, when `autofilter_ports` is defined for a module a call was being made to check allowed ports, this method was not implemented in this pass so removing the call for this global cached map to have all port data available.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `db_import <test_file_path>.xml`
- [x] **Verify** the import completes successfully
