### PR TITLE
Update sessions through the DBManager

### DIFF
--- a/lib/metasploit/framework/data_service/proxy/session_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/session_data_proxy.rb
@@ -20,6 +20,62 @@ module SessionDataProxy
       self.log_error(e, "Problem reporting session")
     end
   end
+
+  # TODO: handle task info
+  def self.convert_msf_session_to_hash(msf_session)
+    hash = Hash.new()
+    hash[:host_data] = parse_host_opts(msf_session)
+    hash[:session_data] = parse_session_data(msf_session)
+
+    if (msf_session.via_exploit)
+      hash[:vuln_info] = parse_vuln_info(msf_session)
+    end
+
+    return hash
+  end
+
+  #######
+  private
+  #######
+
+  def self.parse_session_data(msf_session)
+    hash = Hash.new()
+    # TODO: what to do with this shiz
+    hash[:datastore] = msf_session.exploit_datastore.to_h
+    hash[:desc] = msf_session.info
+    hash[:local_id] = msf_session.sid
+    hash[:platform] = msf_session.session_type
+    hash[:port] = msf_session.session_port
+    hash[:stype] = msf_session.type
+    hash[:via_exploit] = msf_session.via_exploit
+    hash[:via_payload] = msf_session.via_payload
+    return hash
+  end
+
+  def self.parse_host_opts(msf_session)
+    hash = Hash.new()
+    hash[:host] = msf_session.session_host
+    hash[:arch] = msf_session.arch if msf_session.respond_to?(:arch) and msf_session.arch
+    hash[:workspace] = msf_session.workspace || msf_session[:workspace]
+    return hash
+  end
+
+  def self.parse_vuln_info(msf_session)
+    hash = Hash.new()
+    if msf_session.via_exploit == "exploit/multi/handler" and msf_session.exploit_datastore['ParentModule']
+      hash[:mod_fullname] = msf_session.exploit_datastore['ParentModule']
+    else
+      hash[:mod_fullname] = msf_session.via_exploit
+    end
+
+    hash[:remote_port] = msf_session.exploit_datastore["RPORT"]
+    hash[:username] = msf_session.username
+    hash[:run_id] = msf_session.exploit.user_data.try(:[], :run_id)
+
+    hash[:mod_name] = msf_session.exploit.name
+    hash[:mod_references] = msf_session.exploit.references
+    return hash
+  end
 end
 
 

--- a/lib/metasploit/framework/data_service/proxy/session_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/session_data_proxy.rb
@@ -21,6 +21,61 @@ module SessionDataProxy
     end
   end
 
+  # Update the attributes of a session entry using opts.
+  # If opts is a Hash, the values should match the attributes to update and must contain :id.
+  # If opts is a Msf::Session object, it is converted to a Hash and used for the update.
+  # The db_record attribute of the Msf::Session object is updated using the returned Mdm::Session.
+  #
+  # @param opts [Hash|Msf::Session] Hash containing the updated values. Key should match the attribute to update.
+  #   Must contain :id of record to update. Otherwise, a Msf::Session object is used to update all attributes.
+  # @return [Mdm::Session] The updated Mdm::Session object.
+  def update_session(opts)
+    begin
+      self.data_service_operation do |data_service|
+        is_msf_session = false
+        $stderr.puts("*** SessionDataProxy.update_session(): opts=#{opts}")  # TODO: remove
+        # session = opts[:session]
+        # $stderr.puts("*** SessionDataProxy.update_session(): session.class=#{session.class}")  # TODO: remove
+        # if !session.nil? && session.kind_of?(Msf::Session)
+        if !opts.nil? && opts.kind_of?(Msf::Session)
+          msf_session = opts
+          is_msf_session = true
+          $stderr.puts("*** SessionDataProxy.update_session(): is_msf_session=#{is_msf_session}, opts=#{opts}, opts.class=#{opts.class}")  # TODO: remove
+          # save session ID
+          # id = opts.delete(:id)
+          # tmp_opts = convert_msf_session_to_hash(session)
+          tmp_opts = SessionDataProxy.convert_msf_session_to_hash(msf_session)
+          # only updating session data
+          # opts = tmp_opts[:session_data]
+          opts = tmp_opts[:session_data]
+          # add back session ID
+          # opts[:id] = id
+          opts[:id] = msf_session.db_record.id
+          $stderr.puts("*** SessionDataProxy.update_session(): after convert_msf_session_to_hash, opts=#{opts}")  # TODO: remove
+        end
+
+        mdm_session = data_service.update_session(opts)
+
+        $stderr.puts("*** SessionDataProxy.update_session(): after update: is_msf_session=#{is_msf_session}, mdm_session=#{mdm_session}, #{mdm_session.attributes}")  # TODO: remove
+        # reassign returned Mdm::Session to the Msf::Session's db_record
+        msf_session.db_record = mdm_session if is_msf_session
+        $stderr.puts("*** SessionDataProxy.update_session(): msf_session.db_record=#{msf_session.db_record}") if is_msf_session  # TODO: remove
+
+        # TODO: remove block
+        if is_msf_session && !msf_session.db_record.nil?
+          $stderr.puts("SessionDataProxy.update_session(): msf_session.db_record=#{msf_session.db_record}, msf_session.db_record.id=#{msf_session.db_record.id}")  # TODO: remove
+        else
+          $stderr.puts("SessionDataProxy.update_session(): msf_session.db_record is nil")  # TODO: remove
+        end
+
+        mdm_session
+      end
+    rescue => e
+      $stderr.puts("SessionDataProxy.update_session(): e.backtrace=#{e.backtrace}")  # TODO: remove
+      self.log_error(e, "Problem updating session")
+    end
+  end
+
   # TODO: handle task info
   def self.convert_msf_session_to_hash(msf_session)
     hash = Hash.new()

--- a/lib/metasploit/framework/data_service/proxy/session_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/session_data_proxy.rb
@@ -33,45 +33,24 @@ module SessionDataProxy
     begin
       self.data_service_operation do |data_service|
         is_msf_session = false
-        $stderr.puts("*** SessionDataProxy.update_session(): opts=#{opts}")  # TODO: remove
-        # session = opts[:session]
-        # $stderr.puts("*** SessionDataProxy.update_session(): session.class=#{session.class}")  # TODO: remove
-        # if !session.nil? && session.kind_of?(Msf::Session)
         if !opts.nil? && opts.kind_of?(Msf::Session)
           msf_session = opts
           is_msf_session = true
-          $stderr.puts("*** SessionDataProxy.update_session(): is_msf_session=#{is_msf_session}, opts=#{opts}, opts.class=#{opts.class}")  # TODO: remove
-          # save session ID
-          # id = opts.delete(:id)
-          # tmp_opts = convert_msf_session_to_hash(session)
           tmp_opts = SessionDataProxy.convert_msf_session_to_hash(msf_session)
           # only updating session data
-          # opts = tmp_opts[:session_data]
           opts = tmp_opts[:session_data]
           # add back session ID
-          # opts[:id] = id
           opts[:id] = msf_session.db_record.id
-          $stderr.puts("*** SessionDataProxy.update_session(): after convert_msf_session_to_hash, opts=#{opts}")  # TODO: remove
         end
 
         mdm_session = data_service.update_session(opts)
 
-        $stderr.puts("*** SessionDataProxy.update_session(): after update: is_msf_session=#{is_msf_session}, mdm_session=#{mdm_session}, #{mdm_session.attributes}")  # TODO: remove
         # reassign returned Mdm::Session to the Msf::Session's db_record
         msf_session.db_record = mdm_session if is_msf_session
-        $stderr.puts("*** SessionDataProxy.update_session(): msf_session.db_record=#{msf_session.db_record}") if is_msf_session  # TODO: remove
-
-        # TODO: remove block
-        if is_msf_session && !msf_session.db_record.nil?
-          $stderr.puts("SessionDataProxy.update_session(): msf_session.db_record=#{msf_session.db_record}, msf_session.db_record.id=#{msf_session.db_record.id}")  # TODO: remove
-        else
-          $stderr.puts("SessionDataProxy.update_session(): msf_session.db_record is nil")  # TODO: remove
-        end
 
         mdm_session
       end
     rescue => e
-      $stderr.puts("SessionDataProxy.update_session(): e.backtrace=#{e.backtrace}")  # TODO: remove
       self.log_error(e, "Problem updating session")
     end
   end

--- a/lib/metasploit/framework/data_service/remote/http/remote_session_data_service.rb
+++ b/lib/metasploit/framework/data_service/remote/http/remote_session_data_service.rb
@@ -16,7 +16,6 @@ module RemoteSessionDataService
     session = opts[:session]
     if (session.kind_of? Msf::Session)
       opts = SessionDataProxy.convert_msf_session_to_hash(session)
-      opts[:session_dto] = true
     elsif (opts[:host])
       $stderr.puts("*** RemoteSessionDataService.report_session(): executing path where session is not a kind_of Msf::Session...")  # TODO: remove
       opts[:host] = opts[:host].address

--- a/lib/metasploit/framework/data_service/remote/http/remote_session_data_service.rb
+++ b/lib/metasploit/framework/data_service/remote/http/remote_session_data_service.rb
@@ -12,23 +12,15 @@ module RemoteSessionDataService
   end
 
   def report_session(opts)
-    $stderr.puts("RemoteSessionDataService.report_session(): opts=#{opts}")  # TODO: remove
     session = opts[:session]
     if (session.kind_of? Msf::Session)
       opts = SessionDataProxy.convert_msf_session_to_hash(session)
     elsif (opts[:host])
-      $stderr.puts("*** RemoteSessionDataService.report_session(): executing path where session is not a kind_of Msf::Session...")  # TODO: remove
       opts[:host] = opts[:host].address
     end
 
     opts[:time_stamp] = Time.now.utc
-    $stderr.puts("RemoteSessionDataService.report_session(): opts=#{opts}")  # TODO: remove
     sess_db = json_to_mdm_object(self.post_data(SESSION_API_PATH, opts), SESSION_MDM_CLASS, []).first
-    if !sess_db.nil?
-      $stderr.puts("RemoteSessionDataService.report_session(): sess_db=#{sess_db}, sess_db.id=#{sess_db.id}")  # TODO: remove
-    else
-      $stderr.puts("RemoteSessionDataService.report_session(): sess_db is nil")  # TODO: remove
-    end
     session.db_record = sess_db
   end
 
@@ -39,12 +31,7 @@ module RemoteSessionDataService
       path = "#{SESSION_API_PATH}/#{id}"
     end
 
-    $stderr.puts("RemoteSessionDataService.update_session(): path=#{path}, opts=#{opts}")  # TODO: remove
-
-    sess_db = json_to_mdm_object(self.put_data(path, opts), SESSION_MDM_CLASS, []).first
-    $stderr.puts("RemoteSessionDataService.update_session(): returning... sess_db=#{sess_db}")  # TODO: remove
-
-    sess_db
+    json_to_mdm_object(self.put_data(path, opts), SESSION_MDM_CLASS, []).first
   end
 
 end

--- a/lib/metasploit/framework/data_service/remote/http/remote_session_data_service.rb
+++ b/lib/metasploit/framework/data_service/remote/http/remote_session_data_service.rb
@@ -14,7 +14,7 @@ module RemoteSessionDataService
   def report_session(opts)
     session = opts[:session]
     if (session.kind_of? Msf::Session)
-      opts = convert_msf_session_to_hash(session)
+      opts = SessionDataProxy.convert_msf_session_to_hash(session)
       opts[:session_dto] = true
     elsif (opts[:host])
       opts[:host] = opts[:host].address
@@ -25,60 +25,5 @@ module RemoteSessionDataService
     session.db_record = sess_db
   end
 
-  #######
-  private
-  #######
-
-  # TODO: handle task info
-  def convert_msf_session_to_hash(msf_session)
-    hash = Hash.new()
-    hash[:host_data] = parse_host_opts(msf_session)
-    hash[:session_data] = parse_session_data(msf_session)
-
-    if (msf_session.via_exploit)
-      hash[:vuln_info] = parse_vuln_info(msf_session)
-    end
-
-    return hash
-  end
-
-  def parse_session_data(msf_session)
-    hash = Hash.new()
-    # TODO: what to do with this shiz
-    hash[:datastore] = msf_session.exploit_datastore.to_h
-    hash[:desc] = msf_session.info
-    hash[:local_id] = msf_session.sid
-    hash[:platform] = msf_session.session_type
-    hash[:port] = msf_session.session_port
-    hash[:stype] = msf_session.type
-    hash[:via_exploit] = msf_session.via_exploit
-    hash[:via_payload] = msf_session.via_payload
-    return hash
-  end
-
-  def parse_host_opts(msf_session)
-    hash = Hash.new()
-    hash[:host] = msf_session.session_host
-    hash[:arch] = msf_session.arch if msf_session.respond_to?(:arch) and msf_session.arch
-    hash[:workspace] = msf_session.workspace || msf_session[:workspace]
-    return hash
-  end
-
-  def parse_vuln_info(msf_session)
-    hash = Hash.new()
-    if msf_session.via_exploit == "exploit/multi/handler" and msf_session.exploit_datastore['ParentModule']
-      hash[:mod_fullname] = msf_session.exploit_datastore['ParentModule']
-    else
-      hash[:mod_fullname] = msf_session.via_exploit
-    end
-
-    hash[:remote_port] = msf_session.exploit_datastore["RPORT"]
-    hash[:username] = msf_session.username
-    hash[:run_id] = msf_session.exploit.user_data.try(:[], :run_id)
-
-    hash[:mod_name] = msf_session.exploit.name
-    hash[:mod_references] = msf_session.exploit.references
-    return hash
-  end
 end
 

--- a/lib/metasploit/framework/data_service/remote/http/remote_session_data_service.rb
+++ b/lib/metasploit/framework/data_service/remote/http/remote_session_data_service.rb
@@ -12,18 +12,40 @@ module RemoteSessionDataService
   end
 
   def report_session(opts)
+    $stderr.puts("RemoteSessionDataService.report_session(): opts=#{opts}")  # TODO: remove
     session = opts[:session]
     if (session.kind_of? Msf::Session)
       opts = SessionDataProxy.convert_msf_session_to_hash(session)
       opts[:session_dto] = true
     elsif (opts[:host])
+      $stderr.puts("*** RemoteSessionDataService.report_session(): executing path where session is not a kind_of Msf::Session...")  # TODO: remove
       opts[:host] = opts[:host].address
     end
 
     opts[:time_stamp] = Time.now.utc
+    $stderr.puts("RemoteSessionDataService.report_session(): opts=#{opts}")  # TODO: remove
     sess_db = json_to_mdm_object(self.post_data(SESSION_API_PATH, opts), SESSION_MDM_CLASS, []).first
+    if !sess_db.nil?
+      $stderr.puts("RemoteSessionDataService.report_session(): sess_db=#{sess_db}, sess_db.id=#{sess_db.id}")  # TODO: remove
+    else
+      $stderr.puts("RemoteSessionDataService.report_session(): sess_db is nil")  # TODO: remove
+    end
     session.db_record = sess_db
   end
 
-end
+  def update_session(opts)
+    path = SESSION_API_PATH
+    if opts && opts[:id]
+      id = opts.delete(:id)
+      path = "#{SESSION_API_PATH}/#{id}"
+    end
 
+    $stderr.puts("RemoteSessionDataService.update_session(): path=#{path}, opts=#{opts}")  # TODO: remove
+
+    sess_db = json_to_mdm_object(self.put_data(path, opts), SESSION_MDM_CLASS, []).first
+    $stderr.puts("RemoteSessionDataService.update_session(): returning... sess_db=#{sess_db}")  # TODO: remove
+
+    sess_db
+  end
+
+end

--- a/lib/metasploit/framework/data_service/stubs/session_data_service.rb
+++ b/lib/metasploit/framework/data_service/stubs/session_data_service.rb
@@ -6,4 +6,8 @@ module SessionDataService
   def report_session(opts)
     raise 'SessionDataService#report_session is not implemented'
   end
+
+  def update_session(opts)
+    raise 'SessionDataService#update_session is not implemented'
+  end
 end

--- a/lib/msf/base/sessions/meterpreter.rb
+++ b/lib/msf/base/sessions/meterpreter.rb
@@ -516,7 +516,6 @@ class Meterpreter < Rex::Post::Meterpreter::Client
           })
 
           if self.db_record
-            $stderr.puts("Msf::Sessions::Meterpreter.load_session_info(): self.sid=#{self.sid}, self.db_record.id=#{self.db_record.id}; calling framework.db.update_session(self)...")  # TODO: remove
             framework.db.update_session(self)
           end
 

--- a/lib/msf/base/sessions/meterpreter.rb
+++ b/lib/msf/base/sessions/meterpreter.rb
@@ -516,8 +516,8 @@ class Meterpreter < Rex::Post::Meterpreter::Client
           })
 
           if self.db_record
-            self.db_record.desc = safe_info
-            self.db_record.save!
+            $stderr.puts("Msf::Sessions::Meterpreter.load_session_info(): self.sid=#{self.sid}, self.db_record.id=#{self.db_record.id}; calling framework.db.update_session(self)...")  # TODO: remove
+            framework.db.update_session(self)
           end
 
           # XXX: This is obsolete given the Mdm::Host.normalize_os() support for host.os.session_fingerprint

--- a/lib/msf/core/db_manager/host.rb
+++ b/lib/msf/core/db_manager/host.rb
@@ -258,9 +258,9 @@ module Msf::DBManager::Host
         msf_import_timestamps(opts, host)
         host.save!
       end
-    rescue ActiveRecord::RecordNotUnique
-      # two concurrent report requests for a new host could result in a RecordNotUnique exception
-      # simply retry the report once more as an optimistic approach
+    rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid
+      # two concurrent report requests for a new host could result in a RecordNotUnique or
+      # RecordInvalid exception, simply retry the report once more as an optimistic approach
       retry if (retry_attempts+=1) <= 1
       raise
     end

--- a/lib/msf/core/db_manager/session.rb
+++ b/lib/msf/core/db_manager/session.rb
@@ -178,6 +178,29 @@ module Msf::DBManager::Session
     }
   end
 
+  # Update the attributes of a session entry with the values in opts.
+  # The values in opts should match the attributes to update.
+  #
+  # @param opts [Hash] Hash containing the updated values. Key should match the attribute to update. Must contain :id of record to update.
+  # @return [Mdm::Session] The updated Mdm::Session object.
+  def update_session(opts)
+    return if not active
+
+    ::ActiveRecord::Base.connection_pool.with_connection {
+      $stderr.puts("#{DateTime.now}  Msf::DBManager::Session.update_session(): opts=#{opts}")  # TODO: remove
+
+      id = opts.delete(:id)
+      $stderr.puts("#{DateTime.now}  Msf::DBManager::Session.update_session(): id=#{id}, opts=#{opts}")  # TODO: remove
+      $stderr.puts("#{DateTime.now}  Msf::DBManager::Session.update_session(): id=#{id}, before update: #{Mdm::Session.find(id).attributes}")  # TODO: remove
+      session_db_record = ::Mdm::Session.update(id, opts)
+      $stderr.puts("#{DateTime.now}  Msf::DBManager::Session.update_session(): session_db_record=#{session_db_record}")  # TODO: remove
+      $stderr.puts("#{DateTime.now}  Msf::DBManager::Session.update_session(): session_db_record.id=#{session_db_record.id}") unless session_db_record.nil?   # TODO: remove
+      $stderr.puts("#{DateTime.now}  Msf::DBManager::Session.update_session(): id=#{id}, after update: #{Mdm::Session.find(id).attributes}")  # TODO: remove
+
+      session_db_record
+    }
+  end
+
   # Clean out any stale sessions that have been orphaned by a dead framework instance.
   # @param last_seen_interval [Integer] interval, in seconds, open sessions are marked as alive
   def remove_stale_sessions(last_seen_interval)

--- a/lib/msf/core/db_manager/session.rb
+++ b/lib/msf/core/db_manager/session.rb
@@ -187,17 +187,8 @@ module Msf::DBManager::Session
     return if not active
 
     ::ActiveRecord::Base.connection_pool.with_connection {
-      $stderr.puts("#{DateTime.now}  Msf::DBManager::Session.update_session(): opts=#{opts}")  # TODO: remove
-
       id = opts.delete(:id)
-      $stderr.puts("#{DateTime.now}  Msf::DBManager::Session.update_session(): id=#{id}, opts=#{opts}")  # TODO: remove
-      $stderr.puts("#{DateTime.now}  Msf::DBManager::Session.update_session(): id=#{id}, before update: #{Mdm::Session.find(id).attributes}")  # TODO: remove
-      session_db_record = ::Mdm::Session.update(id, opts)
-      $stderr.puts("#{DateTime.now}  Msf::DBManager::Session.update_session(): session_db_record=#{session_db_record}")  # TODO: remove
-      $stderr.puts("#{DateTime.now}  Msf::DBManager::Session.update_session(): session_db_record.id=#{session_db_record.id}") unless session_db_record.nil?   # TODO: remove
-      $stderr.puts("#{DateTime.now}  Msf::DBManager::Session.update_session(): id=#{id}, after update: #{Mdm::Session.find(id).attributes}")  # TODO: remove
-
-      session_db_record
+      ::Mdm::Session.update(id, opts)
     }
   end
 

--- a/lib/msf/core/session.rb
+++ b/lib/msf/core/session.rb
@@ -283,14 +283,10 @@ module Session
   # Also must tolerate being called multiple times.
   #
   def cleanup
-    $stderr.puts("#{DateTime.now}  Msf::Session.cleanup(): db_record=#{db_record}, db_record.class=#{db_record.class}, framework.db.active=#{framework.db.active}")  # TODO: remove
-    $stderr.puts("#{DateTime.now}  Msf::Session.cleanup(): db_record.id=#{db_record.id}, Time.now.utc=#{Time.now.utc}, before update: #{db_record.attributes}") unless db_record.nil?  # TODO: remove
     if db_record and framework.db.active
       ::ActiveRecord::Base.connection_pool.with_connection {
-        tmp_db_record = framework.db.update_session(id: db_record.id, closed_at: Time.now.utc, close_reason: db_record.close_reason)
-        $stderr.puts("#{DateTime.now}  Msf::Session.cleanup(): tmp_db_record.id=#{tmp_db_record.id}, self.sid=#{self.sid}, after save: #{tmp_db_record.attributes}") unless tmp_db_record.nil?  # TODO: remove
+        framework.db.update_session(id: db_record.id, closed_at: Time.now.utc, close_reason: db_record.close_reason)
         db_record = nil
-        $stderr.puts("#{DateTime.now}  Msf::Session.cleanup(): returning after db_record.save call... db_record.class=#{db_record.class}")  # TODO: remove
       }
     end
   end

--- a/lib/msf/core/session.rb
+++ b/lib/msf/core/session.rb
@@ -283,12 +283,14 @@ module Session
   # Also must tolerate being called multiple times.
   #
   def cleanup
+    $stderr.puts("#{DateTime.now}  Msf::Session.cleanup(): db_record=#{db_record}, db_record.class=#{db_record.class}, framework.db.active=#{framework.db.active}")  # TODO: remove
+    $stderr.puts("#{DateTime.now}  Msf::Session.cleanup(): db_record.id=#{db_record.id}, Time.now.utc=#{Time.now.utc}, before update: #{db_record.attributes}") unless db_record.nil?  # TODO: remove
     if db_record and framework.db.active
       ::ActiveRecord::Base.connection_pool.with_connection {
-        db_record.closed_at = Time.now.utc
-        # ignore exceptions
-        db_record.save
+        tmp_db_record = framework.db.update_session(id: db_record.id, closed_at: Time.now.utc, close_reason: db_record.close_reason)
+        $stderr.puts("#{DateTime.now}  Msf::Session.cleanup(): tmp_db_record.id=#{tmp_db_record.id}, self.sid=#{self.sid}, after save: #{tmp_db_record.attributes}") unless tmp_db_record.nil?  # TODO: remove
         db_record = nil
+        $stderr.puts("#{DateTime.now}  Msf::Session.cleanup(): returning after db_record.save call... db_record.class=#{db_record.class}")  # TODO: remove
       }
     end
   end

--- a/lib/msf/core/session_manager.rb
+++ b/lib/msf/core/session_manager.rb
@@ -119,8 +119,9 @@ class SessionManager < Hash
               # as recently seen.  This notifies other framework instances that this
               # session is being maintained.
               if s.db_record
-                s.db_record.last_seen = Time.now.utc
-                s.db_record.save
+                $stderr.puts("#{DateTime.now}  SessionManager.initialize() [monitor_thread]: before update: Time.now.utc=#{Time.now.utc}, s.sid=#{s.sid}, s.db_record.id=#{s.db_record.id}, #{s.db_record.attributes}")  # TODO: remove
+                s.db_record = framework.db.update_session(id: s.db_record.id, last_seen: Time.now.utc)
+                $stderr.puts("#{DateTime.now}  SessionManager.initialize() [monitor_thread]: after update: s.sid=#{s.sid}, s.db_record.id=#{s.db_record.id}, #{s.db_record.attributes}")  # TODO: remove
               end
             end
           end

--- a/lib/msf/core/session_manager.rb
+++ b/lib/msf/core/session_manager.rb
@@ -119,9 +119,7 @@ class SessionManager < Hash
               # as recently seen.  This notifies other framework instances that this
               # session is being maintained.
               if s.db_record
-                $stderr.puts("#{DateTime.now}  SessionManager.initialize() [monitor_thread]: before update: Time.now.utc=#{Time.now.utc}, s.sid=#{s.sid}, s.db_record.id=#{s.db_record.id}, #{s.db_record.attributes}")  # TODO: remove
                 s.db_record = framework.db.update_session(id: s.db_record.id, last_seen: Time.now.utc)
-                $stderr.puts("#{DateTime.now}  SessionManager.initialize() [monitor_thread]: after update: s.sid=#{s.sid}, s.db_record.id=#{s.db_record.id}, #{s.db_record.attributes}")  # TODO: remove
               end
             end
           end

--- a/lib/msf/core/web_services/servlet/session_servlet.rb
+++ b/lib/msf/core/web_services/servlet/session_servlet.rb
@@ -56,15 +56,9 @@ module SessionServlet
       warden.authenticate!
       begin
         opts = parse_json_request(request, false)
-        $stderr.puts("#{DateTime.now}  SessionServlet.update_session(): opts=#{opts}")  # TODO: remove
         tmp_params = sanitize_params(params)
         opts[:id] = tmp_params[:id] if tmp_params[:id]
-        $stderr.puts("#{DateTime.now}  SessionServlet.update_session(): (after mod) opts=#{opts}")  # TODO: remove
         data = get_db.update_session(opts)
-
-        $stderr.puts("#{DateTime.now}  SessionServlet.update_session(): data=#{data}")  # TODO: remove
-        $stderr.puts("#{DateTime.now}  SessionServlet.update_session(): data.class=#{data.class}") unless data.nil?  # TODO: remove
-
         set_json_data_response(response: data)
       rescue => e
         print_error_and_create_response(error: e, message: 'There was an error updating the session:', code: 500)

--- a/lib/msf/core/web_services/servlet/session_servlet.rb
+++ b/lib/msf/core/web_services/servlet/session_servlet.rb
@@ -11,6 +11,7 @@ module SessionServlet
   def self.registered(app)
     app.get SessionServlet.api_path_with_id, &get_session
     app.post SessionServlet.api_path, &report_session
+    app.put SessionServlet.api_path_with_id, &update_session
   end
 
   #######
@@ -46,6 +47,27 @@ module SessionServlet
         exec_report_job(request, &job)
       rescue => e
         print_error_and_create_response(error: e, message: 'There was an error creating the session:', code: 500)
+      end
+    }
+  end
+
+  def self.update_session
+    lambda {
+      warden.authenticate!
+      begin
+        opts = parse_json_request(request, false)
+        $stderr.puts("#{DateTime.now}  SessionServlet.update_session(): opts=#{opts}")  # TODO: remove
+        tmp_params = sanitize_params(params)
+        opts[:id] = tmp_params[:id] if tmp_params[:id]
+        $stderr.puts("#{DateTime.now}  SessionServlet.update_session(): (after mod) opts=#{opts}")  # TODO: remove
+        data = get_db.update_session(opts)
+
+        $stderr.puts("#{DateTime.now}  SessionServlet.update_session(): data=#{data}")  # TODO: remove
+        $stderr.puts("#{DateTime.now}  SessionServlet.update_session(): data.class=#{data.class}") unless data.nil?  # TODO: remove
+
+        set_json_data_response(response: data)
+      rescue => e
+        print_error_and_create_response(error: e, message: 'There was an error updating the session:', code: 500)
       end
     }
   end

--- a/lib/msf/core/web_services/servlet/user_servlet.rb
+++ b/lib/msf/core/web_services/servlet/user_servlet.rb
@@ -55,7 +55,7 @@ module UserServlet
         data = data.first if !sanitized_params[:id].nil? && data.count == 1
         set_json_data_response(response: data)
       rescue => e
-        print_error_and_create_response(error: e, message: 'There was an error creating the user:', code: 500)
+        print_error_and_create_response(error: e, message: 'There was an error updating the user:', code: 500)
       end
     }
   end

--- a/lib/msf/core/web_services/servlet/user_servlet.rb
+++ b/lib/msf/core/web_services/servlet/user_servlet.rb
@@ -51,8 +51,6 @@ module UserServlet
         tmp_params = sanitize_params(params)
         opts[:id] = tmp_params[:id] if tmp_params[:id]
         data = get_db.update_user(opts)
-        # Only return the single object if the id parameter is present
-        data = data.first if !sanitized_params[:id].nil? && data.count == 1
         set_json_data_response(response: data)
       rescue => e
         print_error_and_create_response(error: e, message: 'There was an error updating the user:', code: 500)


### PR DESCRIPTION
Update direct calls to `save` and `save!` on `Mdm::Session` objects to use the `DBManager` whether using a local or remote data service. This fixes an exception that was raised in the `load_session_info` method and ensures that the `last_updated`, `closed_at` and `closed_reason` session database fields are updated using the `DBManager`. Note, `last_updated` is only updated when using the local data service due to the design decision to keep the `SessionManager` from sending frequent updates to a remote data service. In addition, this fixes another concurrency issue seen in `Msf::DBManager::Host.report_host` while debugging these changes, which wasn't originally handled in #10024.

Ticket: MS-3220

## Example log error
```
[05/23/2018 17:12:05] [e(0)] core: Error loading sysinfo: ActiveRecord::RecordInvalid: Validation failed: 
[05/23/2018 17:12:05] [d(0)] core: Call stack:
/home/msfdev/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activerecord-4.2.10/lib/active_record/validations.rb:79:in `raise_record_invalid'
/home/msfdev/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activerecord-4.2.10/lib/active_record/validations.rb:43:in `save!'
/home/msfdev/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activerecord-4.2.10/lib/active_record/attribute_methods/dirty.rb:29:in `save!'
/home/msfdev/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activerecord-4.2.10/lib/active_record/transactions.rb:291:in `block in save!'
/home/msfdev/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activerecord-4.2.10/lib/active_record/transactions.rb:351:in `block in with_transaction_returning_status'
/home/msfdev/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activerecord-4.2.10/lib/active_record/connection_adapters/abstract/database_statements.rb:213:in `block in transaction'
/home/msfdev/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activerecord-4.2.10/lib/active_record/connection_adapters/abstract/transaction.rb:184:in `within_new_transaction'
/home/msfdev/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activerecord-4.2.10/lib/active_record/connection_adapters/abstract/database_statements.rb:213:in `transaction'
/home/msfdev/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activerecord-4.2.10/lib/active_record/transactions.rb:220:in `transaction'
/home/msfdev/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activerecord-4.2.10/lib/active_record/transactions.rb:348:in `with_transaction_returning_status'
/home/msfdev/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activerecord-4.2.10/lib/active_record/transactions.rb:291:in `save!'
/home/msfdev/metasploit-framework/lib/msf/base/sessions/meterpreter.rb:520:in `block (2 levels) in load_session_info'
/home/msfdev/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activerecord-4.2.10/lib/active_record/connection_adapters/abstract/connection_pool.rb:292:in `with_connection'
/home/msfdev/metasploit-framework/lib/msf/base/sessions/meterpreter.rb:491:in `block in load_session_info'
/home/msfdev/.rbenv/versions/2.5.1/lib/ruby/2.5.0/timeout.rb:93:in `block in timeout'
/home/msfdev/.rbenv/versions/2.5.1/lib/ruby/2.5.0/timeout.rb:33:in `block in catch'
/home/msfdev/.rbenv/versions/2.5.1/lib/ruby/2.5.0/timeout.rb:33:in `catch'
/home/msfdev/.rbenv/versions/2.5.1/lib/ruby/2.5.0/timeout.rb:33:in `catch'
/home/msfdev/.rbenv/versions/2.5.1/lib/ruby/2.5.0/timeout.rb:108:in `timeout'
/home/msfdev/metasploit-framework/lib/msf/base/sessions/meterpreter.rb:473:in `load_session_info'
/home/msfdev/metasploit-framework/lib/msf/base/sessions/meterpreter.rb:160:in `block in bootstrap'
/home/msfdev/metasploit-framework/lib/msf/core/session_manager.rb:162:in `block (2 levels) in initialize_scheduler_threads'
/home/msfdev/metasploit-framework/lib/msf/core/thread_manager.rb:100:in `block in spawn'
```

## Verification

- [x] Restart the database and MSF web service (data services) `msfdb restart`, and init/reinit if necessary.
- [x] Start `msfconsole` and connect to the data service started above if you didn't select the option to connect automatically during initialization. See [Metasploit Web Service](https://github.com/rapid7/metasploit-framework/wiki/Metasploit-Web-Service) for more information.
- [x] **Verify** `db_status` reports `Connection type: http. Connected to remote_data_service: (https://localhost:8080)`
- [x] Create a command shell session for a host that is not yet in the database. For example, `use exploit/unix/irc/unreal_ircd_3281_backdoor` against Metasploitable3 VM.
- [x] **Verify** that the output of both the `hosts` and `sessions` commands show an entry for the host used to create the session
- [x] Upgrade the shell to meterpreter: `sessions -u <ID>`
- [x] **Verify** that the output of both the `hosts` and `sessions` commands show an entry for the host used to create the session
- [x] Switch to the meterpreter session: `sessions <ID>` and execute a few commands (`getpid`, `ls`, etc.)
- [x] Exit meterpreter using `exit` to close the session
- [x] **Verify** `sessions` reports the active shell session
- [x] **Verify** `sessions -d` reports the now inactive meterpreter session
- [x] Quit `msfconsole`
- [x] Test local DB mode
    - [x] Temporarily disable the data service auto-connect by renaming the config file: `mv ~/.msf4/config ~/.msf4/config.disabled`
    - [x] Start `msfconsole`
    - [x] **Verify** `db_status` reports `Connected to msf. Connection type: postgresql.`
    - [x] Repeat the remote data service verification steps above
    - [x] Quit `msfconsole`
    - [ ] Restore the config file: `mv ~/.msf4/config.disabled ~/.msf4/config`
