### PR TITLE
Fix TARGETURI support in struts2_namespace_ognl

### DIFF
--- a/modules/exploits/multi/http/struts2_namespace_ognl.rb
+++ b/modules/exploits/multi/http/struts2_namespace_ognl.rb
@@ -198,7 +198,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     # TODO: Consider embedding OGNL in an HTTP header to hide it from the Tomcat logs
-    uri = "/#{ognl}/#{datastore['ACTION']}"
+    uri = normalize_uri(target_uri.path, "/#{ognl}/#{datastore['ACTION']}")
 
     r = send_request_cgi(
      #'encode'  => true,     # this fails to encode '\', which is a problem for me


### PR DESCRIPTION
`TARGETURI` doesn't do anything in `exploit/multi/http/struts2_namespace_ognl`.

- [x] Make sure `TARGETURI` does something
- [x] Make sure there are no regressions

This has been sitting in a stash in my repo for months. Should be an easy fix.

Fixes #10546.