### PR TITLE
Add `strip_comments` method to Linux local exploits

### DIFF
--- a/modules/exploits/linux/local/af_packet_chocobo_root_priv_esc.rb
+++ b/modules/exploits/linux/local/af_packet_chocobo_root_priv_esc.rb
@@ -115,6 +115,10 @@ class MetasploitModule < Msf::Exploit::Local
     cmd_exec "chmod +x #{path}"
   end
 
+  def strip_comments(c_code)
+    c_code.gsub(%r{/\*.*?\*/}m, '').gsub(%r{^\s*//.*$}, '')
+  end
+
   def exploit_data(file)
     ::File.binread ::File.join(Msf::Config.data_directory, 'exploits', 'CVE-2016-8655', file)
   end
@@ -211,7 +215,7 @@ class MetasploitModule < Msf::Exploit::Local
     executable_path = "#{base_dir}/#{executable_name}"
     if live_compile?
       vprint_status 'Live compiling exploit on system...'
-      upload_and_compile executable_path, exploit_data('chocobo_root.c')
+      upload_and_compile executable_path, strip_comments(exploit_data('chocobo_root.c'))
     else
       vprint_status 'Dropping pre-compiled exploit on system...'
       upload_and_chmodx executable_path, exploit_data('chocobo_root')

--- a/modules/exploits/linux/local/af_packet_packet_set_ring_priv_esc.rb
+++ b/modules/exploits/linux/local/af_packet_packet_set_ring_priv_esc.rb
@@ -106,6 +106,10 @@ class MetasploitModule < Msf::Exploit::Local
     cmd_exec "chmod +x #{path}"
   end
 
+  def strip_comments(c_code)
+    c_code.gsub(%r{/\*.*?\*/}m, '').gsub(%r{^\s*//.*$}, '')
+  end
+
   def exploit_data(file)
     ::File.binread ::File.join(Msf::Config.data_directory, 'exploits', 'cve-2017-7308', file)
   end
@@ -201,7 +205,7 @@ class MetasploitModule < Msf::Exploit::Local
     executable_path = "#{base_dir}/#{executable_name}"
     if live_compile?
       vprint_status 'Live compiling exploit on system...'
-      upload_and_compile executable_path, exploit_data('poc.c')
+      upload_and_compile executable_path, strip_comments(exploit_data('poc.c'))
       rm_f "#{executable_path}.c"
     else
       vprint_status 'Dropping pre-compiled exploit on system...'

--- a/modules/exploits/linux/local/bpf_sign_extension_priv_esc.rb
+++ b/modules/exploits/linux/local/bpf_sign_extension_priv_esc.rb
@@ -131,6 +131,10 @@ class MetasploitModule < Msf::Exploit::Local
     cmd_exec "chmod +x #{path}"
   end
 
+  def strip_comments(c_code)
+    c_code.gsub(%r{/\*.*?\*/}m, '').gsub(%r{^\s*//.*$}, '')
+  end
+
   def exploit_data(file)
     ::File.binread ::File.join(Msf::Config.data_directory, 'exploits', 'cve-2017-16995', file)
   end
@@ -214,7 +218,7 @@ class MetasploitModule < Msf::Exploit::Local
     executable_path = "#{base_dir}/#{executable_name}"
     if live_compile?
       vprint_status 'Live compiling exploit on system...'
-      upload_and_compile executable_path, exploit_data('exploit.c')
+      upload_and_compile executable_path, strip_comments(exploit_data('exploit.c'))
     else
       vprint_status 'Dropping pre-compiled exploit on system...'
       upload_and_chmodx executable_path, exploit_data('exploit.out')

--- a/modules/exploits/linux/local/glibc_realpath_priv_esc.rb
+++ b/modules/exploits/linux/local/glibc_realpath_priv_esc.rb
@@ -102,6 +102,10 @@ class MetasploitModule < Msf::Exploit::Local
     cmd_exec "chmod +x #{path}"
   end
 
+  def strip_comments(c_code)
+    c_code.gsub(%r{/\*.*?\*/}m, '').gsub(%r{^\s*//.*$}, '')
+  end
+
   def exploit_data(file)
     ::File.binread ::File.join(Msf::Config.data_directory, 'exploits', 'cve-2018-1000001', file)
   end
@@ -196,7 +200,7 @@ class MetasploitModule < Msf::Exploit::Local
     @executable_path = "#{base_dir}/#{executable_name}"
     if live_compile?
       vprint_status 'Live compiling exploit on system...'
-      upload_and_compile @executable_path, exploit_data('RationalLove.c')
+      upload_and_compile @executable_path, strip_comments(exploit_data('RationalLove.c'))
     else
       vprint_status 'Dropping pre-compiled exploit on system...'
       upload_and_chmodx @executable_path, exploit_data('RationalLove')

--- a/modules/exploits/linux/local/nested_namespace_idmap_limit_priv_esc.rb
+++ b/modules/exploits/linux/local/nested_namespace_idmap_limit_priv_esc.rb
@@ -119,6 +119,10 @@ class MetasploitModule < Msf::Exploit::Local
     chmod path, 0755
   end
 
+  def strip_comments(c_code)
+    c_code.gsub(%r{/\*.*?\*/}m, '').gsub(%r{^\s*//.*$}, '')
+  end
+
   def exploit_data(file)
     ::File.binread ::File.join(Msf::Config.data_directory, 'exploits', 'cve-2018-18955', file)
   end
@@ -213,8 +217,8 @@ class MetasploitModule < Msf::Exploit::Local
     subshell_path = "#{base_dir}/#{subshell_name}"
     if live_compile?
       vprint_status 'Live compiling exploit on system...'
-      upload_and_compile subuid_shell_path, exploit_data('subuid_shell.c')
-      upload_and_compile subshell_path, exploit_data('subshell.c')
+      upload_and_compile subuid_shell_path, strip_comments(exploit_data('subuid_shell.c'))
+      upload_and_compile subshell_path, strip_comments(exploit_data('subshell.c'))
     else
       vprint_status 'Dropping pre-compiled exploit on system...'
       upload_and_chmodx subuid_shell_path, exploit_data('subuid_shell.out')

--- a/modules/exploits/linux/local/rds_priv_esc.rb
+++ b/modules/exploits/linux/local/rds_priv_esc.rb
@@ -103,6 +103,10 @@ class MetasploitModule < Msf::Exploit::Local
     register_file_for_cleanup path
   end
 
+  def strip_comments(c_code)
+    c_code.gsub(%r{/\*.*?\*/}m, '').gsub(%r{^\s*//.*$}, '')
+  end
+
   def exploit_data(file)
     ::File.binread ::File.join(Msf::Config.data_directory, 'exploits', 'cve-2010-3904', file)
   end
@@ -169,7 +173,7 @@ class MetasploitModule < Msf::Exploit::Local
     executable_path = "#{base_dir}/#{executable_name}"
     if live_compile?
       vprint_status 'Live compiling exploit on system...'
-      upload_and_compile executable_path, exploit_data('rds-fail.c')
+      upload_and_compile executable_path, strip_comments(exploit_data('rds-fail.c'))
     else
       vprint_status 'Dropping pre-compiled exploit on system...'
       arch = kernel_hardware

--- a/modules/exploits/linux/local/recvmmsg_priv_esc.rb
+++ b/modules/exploits/linux/local/recvmmsg_priv_esc.rb
@@ -89,6 +89,10 @@ class MetasploitModule < Msf::Exploit::Local
     cmd_exec "chmod +x #{path}"
   end
 
+  def strip_comments(c_code)
+    c_code.gsub(%r{/\*.*?\*/}m, '').gsub(%r{^\s*//.*$}, '')
+  end
+
   def exploit_data(file)
     ::File.binread ::File.join(Msf::Config.data_directory, 'exploits', 'CVE-2014-0038', file)
   end
@@ -160,7 +164,7 @@ class MetasploitModule < Msf::Exploit::Local
     executable_path = "#{base_dir}/#{executable_name}"
     if live_compile?
       vprint_status 'Live compiling exploit on system...'
-      upload_and_compile executable_path, exploit_data('recvmmsg.c')
+      upload_and_compile executable_path, strip_comments(exploit_data('recvmmsg.c'))
       rm_f "#{executable_path}.c"
     else
       vprint_status 'Dropping pre-compiled exploit on system...'

--- a/modules/exploits/linux/local/ufo_privilege_escalation.rb
+++ b/modules/exploits/linux/local/ufo_privilege_escalation.rb
@@ -108,6 +108,10 @@ class MetasploitModule < Msf::Exploit::Local
     cmd_exec "chmod +x #{path}"
   end
 
+  def strip_comments(c_code)
+    c_code.gsub(%r{/\*.*?\*/}m, '').gsub(%r{^\s*//.*$}, '')
+  end
+
   def exploit_data(file)
     ::File.binread ::File.join(Msf::Config.data_directory, 'exploits', 'cve-2017-1000112', file)
   end
@@ -198,7 +202,7 @@ class MetasploitModule < Msf::Exploit::Local
     executable_path = "#{base_dir}/#{executable_name}"
     if live_compile?
       vprint_status 'Live compiling exploit on system...'
-      upload_and_compile executable_path, exploit_data('exploit.c')
+      upload_and_compile executable_path, strip_comments(exploit_data('exploit.c'))
     else
       vprint_status 'Dropping pre-compiled exploit on system...'
       upload_and_chmodx executable_path, exploit_data('exploit.out')


### PR DESCRIPTION
This PR adds a `strip_comments` method code pattern to all Linux local exploits which make use of an `upload_and_compile` method, for the purposes of stripping C comments from C source code prior to uploading.

This could perhaps be abstracted away to a mixin. It likely would also be possible with metasm, but that would require multiple lines of code and adding an extra mixin dependency.
