### PR TITLE
fix for ReverseTcp error

### DIFF
--- a/modules/payloads/singles/bsd/vax/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/bsd/vax/shell_reverse_tcp.rb
@@ -3,6 +3,8 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
+require 'msf/core/handler/reverse_tcp'
+
 module MetasploitModule
 
   CachedSize = 100


### PR DESCRIPTION
Was unable to run msfconsole on kali linux. Uninstall and reinstall of Metasploit had no effect. Neither did any other fix I could find. On examining other shell_reverse_tcp.rb files I noticed the following line missing.

require 'msf/core/handler/reverse_tcp'

Update vax shell_reverse_tcp.rb to fix ReverseTcp NameError
Error:
/opt/metasploit-framework/embedded/framework/modules/payloads/singles/bsd/vax/shell_reverse_tcp.rb:24:in `initialize': uninitialized constant Msf::Handler::ReverseTcp (NameError)

After adding this line the error dissapeared for me and I was able to run msfconsole again.
