### PR TITLE
Use POST Instead of GET for API Token Generation

### DIFF
--- a/documentation/api/v1/auth_api_doc.rb
+++ b/documentation/api/v1/auth_api_doc.rb
@@ -15,7 +15,7 @@ module AuthApiDoc
   end
 
   swagger_path '/api/v1/auth/generate-token' do
-    # Swagger documentation for /api/v1/auth/generate-token GET
+    # Swagger documentation for /api/v1/auth/generate-token POST
     operation :post do
 
       key :description, 'Return a valid Authorization Bearer token.'

--- a/documentation/api/v1/auth_api_doc.rb
+++ b/documentation/api/v1/auth_api_doc.rb
@@ -16,25 +16,20 @@ module AuthApiDoc
 
   swagger_path '/api/v1/auth/generate-token' do
     # Swagger documentation for /api/v1/auth/generate-token GET
-    operation :get do
+    operation :post do
 
       key :description, 'Return a valid Authorization Bearer token.'
       key :tags, [ 'auth' ]
 
       parameter do
-        key :name, :username
-        key :in, :query
-        key :description, 'The username for the user you want to authenticate.'
+        key :in, :body
+        key :name, :body
+        key :description, 'Login credentials for the user who will be generating a token.'
         key :required, true
-        key :type, :string
-      end
-
-      parameter do
-        key :name, :password
-        key :in, :query
-        key :description, 'The password for the user you want to authenticate.'
-        key :required, true
-        key :type, :string
+        schema do
+          property :username, type: :string, required: true
+          property :password, type: :string, required: true
+        end
       end
 
       response 200 do

--- a/lib/msf/core/web_services/authentication/strategies/user_password.rb
+++ b/lib/msf/core/web_services/authentication/strategies/user_password.rb
@@ -1,3 +1,5 @@
+require 'json'
+
 module Authentication
   module Strategies
     class UserPassword < Warden::Strategies::Base
@@ -16,25 +18,31 @@ module Authentication
       # Check if request contains valid data and should be authenticated.
       # @return [Boolean] true if strategy should be run for the request; otherwise, false.
       def valid?
-        body = JSON.parse(request.body.read, symbolize_names: true)
-        request.body.rewind # Reset the StringIO buffer so any further consumers can read the body
-        body[:username] && body[:password]
+        begin
+          body = JSON.parse(request.body.read, symbolize_names: true)
+          body[:username] && body[:password]
+        ensure
+          request.body.rewind # Reset the StringIO buffer so any further consumers can read the body
+        end
       end
 
       # Authenticate the request.
       def authenticate!
-        body = JSON.parse(request.body.read, symbolize_names: true)
-        request.body.rewind # Reset the StringIO buffer so any further consumers can read the body
-        db_manager = env['msf.db_manager']
-        user = db_manager.users(username: body[:username]).first
+        begin
+          body = JSON.parse(request.body.read, symbolize_names: true)
 
-        if user.nil? || !db_manager.authenticate_user(id: user.id, password: body[:password])
-          fail("Invalid username or password.")
-        else
-          success!(user)
+          db_manager = env['msf.db_manager']
+          user = db_manager.users(username: body[:username]).first
+
+          if user.nil? || !db_manager.authenticate_user(id: user.id, password: body[:password])
+            fail("Invalid username or password.")
+          else
+            success!(user)
+          end
+        ensure
+          request.body.rewind # Reset the StringIO buffer so any further consumers can read the body
         end
       end
-
     end
   end
 end

--- a/lib/msf/core/web_services/public/msf-ws.css
+++ b/lib/msf/core/web_services/public/msf-ws.css
@@ -86,7 +86,7 @@ input[type=text], input[type=password] {
     height: 34px;
 }
 
-button {
+input[type=button] {
     border-color: rgba(0, 0, 0, 0.6);
     border-width: 1px;
     cursor: pointer;

--- a/lib/msf/core/web_services/servlet/auth_servlet.rb
+++ b/lib/msf/core/web_services/servlet/auth_servlet.rb
@@ -31,7 +31,7 @@ module AuthServlet
     app.post AuthServlet.api_login_path, &post_login
 
     app.get AuthServlet.api_logout_path, &get_logout
-    app.get AuthServlet.api_generate_token_path, &get_generate_token
+    app.post AuthServlet.api_generate_token_path, &post_generate_token
     app.post "#{AuthServlet.api_unauthenticated_path}/?:scope?", &post_unauthenticated
   end
 
@@ -75,7 +75,7 @@ module AuthServlet
   end
 
   # Generate a new API token for the current user
-  def self.get_generate_token
+  def self.post_generate_token
     lambda {
       # change action to drop the scope param since this is used
       # by XMLHttpRequest (XHR) and we don't want a redirect

--- a/lib/msf/core/web_services/views/auth/account.erb
+++ b/lib/msf/core/web_services/views/auth/account.erb
@@ -61,6 +61,8 @@
     <div id="api-token" class="api-token">
       <%= !warden.user(:user).nil? && !warden.user(:user).persistence_token.nil? ? warden.user(:user).persistence_token : 'none' %>
     </div>
+  <% else %>
+    <div id="not-logged-in-label">You are not currently logged in. Please click <a href="<%= AuthServlet.api_login_path %>">here</a> to be taken to the login page.</div>
   <% end %>
 </div>
 

--- a/lib/msf/core/web_services/views/auth/account.erb
+++ b/lib/msf/core/web_services/views/auth/account.erb
@@ -9,7 +9,7 @@
 
 <script type="text/javascript">
     function getNewApiToken() {
-        loadDoc("GET", "<%= AuthServlet.api_generate_token_path %>", function(xhr) {
+        loadDoc("POST", "<%= AuthServlet.api_generate_token_path %>", function(xhr) {
             var response = JSON.parse(xhr.responseText);
             document.getElementById("api-token").innerHTML = response.data.token;
         }, errorHandler);

--- a/lib/msf/core/web_services/views/auth/login.erb
+++ b/lib/msf/core/web_services/views/auth/login.erb
@@ -26,14 +26,18 @@
     $(document).ready(function(){
         $("#submit").on('click', function(){
             $.ajax({
-                url: '<%= AuthServlet.api_generate_token_path %>',
+                url: '<%= AuthServlet.api_login_path %>',
                 type : "POST",
-                dataType : 'json',
                 data : ConvertFormToJSON($("#login_form")),
                 contentType: "application/json; charset=utf-8",
                 processData: false,
-                success : function(result) {
-                    $(location).attr('href', '<%= AuthServlet.api_account_path %>')
+                success : function(data) {
+                    // TODO: This currently always redirects the user to the /auth/account page.
+                    // This is because the POST /login endpoint always returns a redirect, which
+                    // is not easily handled by Javascript AJAX requests. When the /login endpoint
+                    // is more fully fleshed out we should add proper handling for valid and
+                    // invalid login attempts.
+                    window.location.replace('<%= AuthServlet.api_account_path %>');
                 },
                 error: function(xhr, resp, text) {
                     console.log(xhr, resp, text);

--- a/lib/msf/core/web_services/views/auth/login.erb
+++ b/lib/msf/core/web_services/views/auth/login.erb
@@ -7,7 +7,10 @@
 </head>
 <body>
 
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+<script
+  src="https://code.jquery.com/jquery-3.3.1.min.js"
+  integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8="
+  crossorigin="anonymous"></script>
 <script>
     function ConvertFormToJSON(form){
         var array = jQuery(form).serializeArray();

--- a/lib/msf/core/web_services/views/auth/login.erb
+++ b/lib/msf/core/web_services/views/auth/login.erb
@@ -7,8 +7,42 @@
 </head>
 <body>
 
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+<script>
+    function ConvertFormToJSON(form){
+        var array = jQuery(form).serializeArray();
+        var json = {};
+
+        jQuery.each(array, function() {
+            json[this.name] = this.value || '';
+        });
+
+        return JSON.stringify(json);
+    }
+
+    $(document).ready(function(){
+        $("#submit").on('click', function(){
+            $.ajax({
+                url: '<%= AuthServlet.api_generate_token_path %>',
+                type : "POST",
+                dataType : 'json',
+                data : ConvertFormToJSON($("#login_form")),
+                contentType: "application/json; charset=utf-8",
+                processData: false,
+                success : function(result) {
+                    $(location).attr('href', '<%= AuthServlet.api_account_path %>')
+                },
+                error: function(xhr, resp, text) {
+                    console.log(xhr, resp, text);
+                }
+            })
+        });
+    });
+
+</script>
+
 <div style="padding:20px;">
-  <form action="<%= AuthServlet.api_login_path %>" method="post">
+  <form id="login_form" action="" method="post">
     <div class="credential-container">
       <h2>Log In - Metasploit API</h2>
       <label for="username"><b>Username</b></label>
@@ -16,8 +50,7 @@
 
       <label for="password"><b>Password</b></label>
       <input type="password" placeholder="Enter Password" name="password" required>
-
-      <button type="submit">Log In</button>
+      <input id="submit" type="button" name="submit" value="submit">
     </div>
   </form>
 </div>

--- a/msfdb
+++ b/msfdb
@@ -636,7 +636,7 @@ def add_web_service_user
 
   # Send request to create new API token for the user
   generate_token_uri = get_web_service_uri(path: '/api/v1/auth/generate-token')
-  response_data = http_request(uri: generate_token_uri, query: cred_data, method: :get,
+  response_data = http_request(uri: generate_token_uri, data: cred_data, method: :post,
                           skip_verify: skip_ssl_verify?, cert: get_ssl_cert)
   response = response_data[:response]
   puts "add_web_service_user: generate token response=#{response}" if @options[:debug]


### PR DESCRIPTION
This PR updates the `/api/v1/auth/generate-token` URL to use POST instead of GET requests. The `username` and `password` fields will now be passed as JSON in the body of the request. It also updates the `msfdb` script and test page at `/api/v1/auth/login` to use the new method.

## Verification

List the steps needed to make sure this thing works

- [x] Run `msfdb init` to set up a metasploit API webservice and database. You should be successfully given a username, password, and valid API token.
- [x] Navigate to `/api/v1/api-docs` and test that the `generate-token` endpoint is successful when inputting the username and password from the `msfdb` setup
- [x] Verify the token you receive is valid by loading up `msfconsole` and configuring a data service connection `db_connect -t <token you were given> --skip-verify https://localhost:8080`
- [x] Navigate to `/api/v1/auth/login`. Enter your username and password and verify you are given the current API token back. Also test the `Generate Net Token` link in the upper left corner to ensure you get a new token each time.

