### PR TITLE
Update nc -j check in cups_root_file_read

### DIFF
--- a/modules/post/multi/escalate/cups_root_file_read.rb
+++ b/modules/post/multi/escalate/cups_root_file_read.rb
@@ -159,7 +159,7 @@ class MetasploitModule < Msf::Post
   def get_request(uri)
     output = perform_request(uri, 'nc -j localhost 631')
 
-    if output =~ /^usage: nc/
+    if output =~ /^(?:usage: nc|nc: invalid option -- 'j')/
       output = perform_request(uri, 'nc localhost 631')
     end
 


### PR DESCRIPTION
`-j` is for jumbo frames. It normally requires `SO_JUMBO`.

Fixes #11129, maybe.