### PR TITLE
Fix PTY leak in Python meterpreter

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,7 +21,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 1.3.56)
+      metasploit-payloads (= 1.3.57)
       metasploit_data_models
       metasploit_payloads-mettle (= 0.5.0)
       mqtt
@@ -122,7 +122,7 @@ GEM
     concurrent-ruby (1.0.5)
     cookiejar (0.3.3)
     crass (1.0.4)
-    daemons (1.3.0)
+    daemons (1.3.1)
     diff-lcs (1.3)
     dnsruby (1.61.2)
       addressable (~> 2.5)
@@ -178,7 +178,7 @@ GEM
       activemodel (~> 4.2.6)
       activesupport (~> 4.2.6)
       railties (~> 4.2.6)
-    metasploit-payloads (1.3.56)
+    metasploit-payloads (1.3.57)
     metasploit_data_models (3.0.2)
       activerecord (~> 4.2.6)
       activesupport (~> 4.2.6)
@@ -210,7 +210,7 @@ GEM
       pcaprub
     patch_finder (1.0.2)
     pcaprub (0.13.0)
-    pdf-reader (2.1.0)
+    pdf-reader (2.2.0)
       Ascii85 (~> 1.0.0)
       afm (~> 0.2.1)
       hashery (~> 2.0)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -70,7 +70,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '1.3.56'
+  spec.add_runtime_dependency 'metasploit-payloads', '1.3.57'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '0.5.0'
   # Needed by msfgui and other rpc components

--- a/modules/payloads/singles/python/meterpreter_bind_tcp.rb
+++ b/modules/payloads/singles/python/meterpreter_bind_tcp.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/meterpreter_python'
 
 module MetasploitModule
 
-  CachedSize = 71634
+  CachedSize = 71982
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/singles/python/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_http.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/meterpreter_python'
 
 module MetasploitModule
 
-  CachedSize = 71570
+  CachedSize = 71918
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/singles/python/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_https.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/meterpreter_python'
 
 module MetasploitModule
 
-  CachedSize = 71570
+  CachedSize = 71918
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/singles/python/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_tcp.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/meterpreter_python'
 
 module MetasploitModule
 
-  CachedSize = 71530
+  CachedSize = 71882
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/singles/windows/x64/messagebox.rb
+++ b/modules/payloads/singles/windows/x64/messagebox.rb
@@ -5,7 +5,7 @@
 
 module MetasploitModule
 
-  CachedSize = 299
+  CachedSize = 295
 
   include Msf::Payload::Windows
   include Msf::Payload::Single


### PR DESCRIPTION
Update metasploit-payloads gem to 1.3.57 to pick up
fix for Python Meterpreter PTY Leak from rapid7/metasploit-payloads#319

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] **Verify** meterpreter python still passes tests.

