### PR TITLE
Added verbosity to the `msfdb init` 'Missing requirement' error

### DIFF
--- a/msfdb
+++ b/msfdb
@@ -924,7 +924,7 @@ def has_requirements
   missing_msg = "Missing requirement: %<name>s does not appear to be installed or '%<prog>s' is not in the environment path"
 
   postgresql_cmds.each do |cmd|
-    next if Msf::Util::Helper.which(cmd)   
+    next unless Msf::Util::Helper.which(cmd).nil?
     puts missing_msg % { name: 'PostgreSQL', prog: cmd }
     ret_val = false
   end

--- a/msfdb
+++ b/msfdb
@@ -921,16 +921,17 @@ def has_requirements
   ret_val = true
   postgresql_cmds = %w(psql pg_ctl initdb createdb)
   other_cmds = %w(bundle thin)
-  missing_msg = 'Missing requirement: %<name>s does not appear to be installed or is not in the environment path'
+  missing_msg = "Missing requirement: %<name>s does not appear to be installed or '%<prog>s' is not in the environment path"
 
-  unless postgresql_cmds.all? { |cmd| !Msf::Util::Helper.which(cmd).nil? }
-    puts missing_msg % { name: 'PostgreSQL' }
+  postgresql_cmds.each do |cmd|
+    next if Msf::Util::Helper.which(cmd)   
+    puts missing_msg % { name: 'PostgreSQL', prog: cmd }
     ret_val = false
   end
 
   other_cmds.each do |cmd|
     if Msf::Util::Helper.which(cmd).nil?
-      puts missing_msg % { name: "'#{cmd}'" }
+      puts missing_msg % { name: "'#{cmd}'", prog: cmd }
       ret_val = false
     end
   end


### PR DESCRIPTION
**Problem:**  When installing the Framework, a user will run `msfdb init` to configure the Postgres server.  As part of that process, the script confirms that four binaries, `psql`, `pg_ctl`, `initdb`, `createdb` are in the local path.  In a default Ubuntu installation, two of the four binaries were missing, and the error did not clarify which binaries were not found.

**Proposed solution:**  A new error message is more verbose in describing which binaries, specifically, are not found.  These messages will help users troubleshoot their environment and more easily install the framework.

## Verification

List the steps needed to make sure this thing works

- [x] With one or more of the above binaries missing from your `$PATH`, run `msfdb init`.  (Warning: this will prompt to overwrite an existing database configuration.).  Here's a quick one-liner to see which binaries are available, and where they are stored:

```
$ for i in psql pg_ctl initdb createdb bundle thin; do OUT=`which $i`; if [ $? -eq 0 ]; then export NEWPATH=$NEWPATH:`find / -iname $i -printf "%h" 2>/dev/null`; fi; echo "$i: ${OUT:-MISSING}"; done
```

- [x] Confirm that the error messages appear, and include the names of the binaries that are not included in your path.  For example:

```
$ ./msfdb init
Missing requirement: PostgreSQL does not appear to be installed or 'pg_ctl' is not in the environment path
Missing requirement: PostgreSQL does not appear to be installed or 'initdb' is not in the environment path
```

- [x] Locate the above-named missing tools:
```bash
$ find / -iname pg_ctl 2>/dev/null
/usr/lib/postgresql/9.5/bin/pg_ctl
$ find / -iname initdb 2>/dev/null
/usr/lib/postgresql/9.5/bin/initdb
```

- [x] Add the above tools back to your `$PATH`, making sure to trim the filename off the above output.
```
$ export PATH=$PATH:/usr/lib/postgresql/9.5/bin/
```

- [x] Re-run `msfdb init` with the corrected path to confirm it succeeds:

```
$ ./msfdb init
Creating database at /var/lib/postgresql/.msf4/db
Starting database at /var/lib/postgresql/.msf4/db...success
Creating database users
Writing client authentication configuration file /var/lib/postgresql/.msf4/db/pg_hba.conf
Stopping database at /var/lib/postgresql/.msf4/db
Starting database at /var/lib/postgresql/.msf4/db...success
Creating initial database schema
Initial MSF web service account username?[postgres]: 
Generating SSL key and certificate for MSF web service
Attempting to start MSF web service...
MSF web service started and online
Creating MSF web service user postgres
[...]
```