### PR TITLE
Enhance the command auto-complete in aux.

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/auxiliary.rb
+++ b/lib/msf/ui/console/command_dispatcher/auxiliary.rb
@@ -68,7 +68,17 @@ class Auxiliary
     end
   end
 
+  alias cmd_rerun_tabs cmd_run_tabs
   alias cmd_rexploit cmd_rerun
+  alias cmd_rexploit_tabs cmd_exploit_tabs
+
+  #
+  # Tab completion for the run command
+  #
+  def cmd_run_tabs(str, words)
+    return [] if words.length > 1
+    @@auxiliary_opts.fmt.keys
+  end
 
   #
   # Executes an auxiliary module
@@ -147,6 +157,7 @@ class Auxiliary
   end
 
   alias cmd_exploit cmd_run
+  alias cmd_exploit_tabs cmd_run_tabs
 
   def cmd_run_help
     print_line "Usage: run [options]"

--- a/lib/msf/ui/console/command_dispatcher/auxiliary.rb
+++ b/lib/msf/ui/console/command_dispatcher/auxiliary.rb
@@ -60,19 +60,6 @@ class Auxiliary
   end
 
   #
-  # Reloads an auxiliary module and executes it
-  #
-  def cmd_rerun(*args)
-    if reload(true)
-      cmd_run(*args)
-    end
-  end
-
-  alias cmd_rerun_tabs cmd_run_tabs
-  alias cmd_rexploit cmd_rerun
-  alias cmd_rexploit_tabs cmd_exploit_tabs
-
-  #
   # Tab completion for the run command
   #
   def cmd_run_tabs(str, words)
@@ -167,6 +154,19 @@ class Auxiliary
   end
 
   alias cmd_exploit_help cmd_run_help
+
+  #
+  # Reloads an auxiliary module and executes it
+  #
+  def cmd_rerun(*args)
+    if reload(true)
+      cmd_run(*args)
+    end
+  end
+
+  alias cmd_rerun_tabs cmd_run_tabs
+  alias cmd_rexploit cmd_rerun
+  alias cmd_rexploit_tabs cmd_exploit_tabs
 
   #
   # Reloads an auxiliary module and checks the target to see if it's


### PR DESCRIPTION
A little enhancement.

```

msf5 auxiliary(scanner/portscan/tcp) > rerun -
rerun -a  rerun -h  rerun -j  rerun -o  rerun -q
msf5 auxiliary(scanner/portscan/tcp) > run -
run -a  run -h  run -j  run -o  run -q
msf5 auxiliary(scanner/portscan/tcp) > exploit -
exploit -a  exploit -h  exploit -j  exploit -o  exploit -q
msf5 auxiliary(scanner/portscan/tcp) > exploit -
```

