### PR TITLE
Implement query operation for Event on DBManager and Remote Data Service

### DIFF
--- a/documentation/api/v1/event_api_doc.rb
+++ b/documentation/api/v1/event_api_doc.rb
@@ -12,6 +12,11 @@ module EventApiDoc
   INFO_DESC = 'Information about the event specific to the event name.'
   INFO_EXAMPLE = '{:command=>"irb"}'
 
+  ORDER_ENUM = [
+      'asc',
+      'desc'
+  ]
+
 # Swagger documentation for Event model
   swagger_schema :Event do
     key :required, [:name]
@@ -27,6 +32,69 @@ module EventApiDoc
   end
 
   swagger_path '/api/v1/events' do
+    # Swagger documentation for /api/v1/events GET
+    operation :get do
+      key :description, 'Return events that are stored in the database.'
+      key :tags, [ 'event' ]
+
+      parameter :workspace
+
+      parameter do
+        key :name, :limit
+        key :in, :query
+        key :description, 'The maximum number of events that will be retrieved from the query. (Default: 100)'
+        key :example, 100
+        key :type, :integer
+        key :format, :int32
+        key :required, false
+      end
+
+      parameter do
+        key :name, :offset
+        key :in, :query
+        key :description, 'The number of events the query will begin reading from the start of the set. (Default: 0)'
+        key :example, 0
+        key :type, :integer
+        key :format, :int32
+        key :required, false
+      end
+
+      parameter do
+        key :name, :order
+        key :in, :query
+        key :description, 'The event created_at sort order. (Default: desc)'
+        key :type, :string
+        key :required, false
+        key :enum, ORDER_ENUM
+      end
+
+      response 200 do
+        key :description, 'Returns event data.'
+        schema do
+          property :data do
+            key :type, :array
+            items do
+              key :'$ref', :Event
+            end
+          end
+        end
+      end
+
+      response 401 do
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
+        schema do
+          key :'$ref', :AuthErrorModel
+        end
+      end
+
+      response 500 do
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
+        schema do
+          key :'$ref', :ErrorModel
+        end
+      end
+    end
+
     # Swagger documentation for /api/v1/events POST
     operation :post do
       key :description, 'Create an event.'
@@ -49,6 +117,46 @@ module EventApiDoc
 
       response 200 do
         key :description, RootApiDoc::DEFAULT_RESPONSE_200
+        schema do
+          property :data do
+            key :'$ref', :Event
+          end
+        end
+      end
+
+      response 401 do
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
+        schema do
+          key :'$ref', :AuthErrorModel
+        end
+      end
+
+      response 500 do
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
+        schema do
+          key :'$ref', :ErrorModel
+        end
+      end
+    end
+  end
+
+  swagger_path '/api/v1/events/{id}' do
+    # Swagger documentation for /api/v1/events/:id GET
+    operation :get do
+      key :description, 'Return a specific event that is stored in the database.'
+      key :tags, [ 'event' ]
+
+      parameter do
+        key :name, :id
+        key :in, :path
+        key :description, 'ID of event to retrieve.'
+        key :required, true
+        key :type, :integer
+        key :format, :int32
+      end
+
+      response 200 do
+        key :description, 'Returns event data.'
         schema do
           property :data do
             key :'$ref', :Event

--- a/documentation/api/v1/event_api_doc.rb
+++ b/documentation/api/v1/event_api_doc.rb
@@ -10,7 +10,7 @@ module EventApiDoc
   SEEN_DESC = 'true if a user has acknowledged the event.'
   USERNAME_DESC = 'Name of the user that triggered the event.'
   INFO_DESC = 'Information about the event specific to the event name.'
-  INFO_EXAMPLE = '{:command=>"irb"}'
+  INFO_EXAMPLE = {command: 'irb'}
 
   ORDER_ENUM = [
       'asc',

--- a/lib/metasploit/framework/data_service/proxy/event_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/event_data_proxy.rb
@@ -1,5 +1,16 @@
 module EventDataProxy
 
+  def events(opts = {})
+    begin
+      self.data_service_operation do |data_service|
+        add_opts_workspace(opts)
+        data_service.events(opts)
+      end
+    rescue => e
+      self.log_error(e, "Problem retrieving events")
+    end
+  end
+
   def report_event(opts)
     begin
       self.data_service_operation do |data_service|

--- a/lib/metasploit/framework/data_service/remote/http/remote_event_data_service.rb
+++ b/lib/metasploit/framework/data_service/remote/http/remote_event_data_service.rb
@@ -1,5 +1,15 @@
+require 'metasploit/framework/data_service/remote/http/response_data_helper'
+
 module RemoteEventDataService
+  include ResponseDataHelper
+
   EVENT_API_PATH = '/api/v1/events'
+  EVENT_MDM_CLASS = 'Mdm::Event'
+
+  def events(opts)
+    path = get_path_select(opts, EVENT_API_PATH)
+    json_to_mdm_object(self.get_data(path, nil, opts), EVENT_MDM_CLASS, [])
+  end
 
   def report_event(opts)
     self.post_data_async(EVENT_API_PATH, opts)

--- a/lib/metasploit/framework/data_service/stubs/event_data_service.rb
+++ b/lib/metasploit/framework/data_service/stubs/event_data_service.rb
@@ -1,7 +1,10 @@
 module EventDataService
 
+  def events(opts)
+    raise 'EventDataService#events is not implemented'
+  end
+
   def report_event(opts)
     raise 'EventDataService#report_event is not implemented'
   end
-
 end

--- a/lib/msf/core/db_manager/event.rb
+++ b/lib/msf/core/db_manager/event.rb
@@ -5,8 +5,10 @@ module Msf::DBManager::Event
 
   # Retrieves events that are stored in the database.
   #
-  # @param opts [Hash] Hash containing query options.
+  # @param opts [Hash] Hash containing query key-value pairs based on the event model.
   # @option opts :id [Integer] A specific event ID. If specified, all other options are ignored.
+  #
+  # Additional query options:
   # @option opts :workspace [String] The workspace from which the data should be gathered from. (Required)
   # @option opts :order [Symbol|String] The event created_at sort order.
   #   Valid values: :asc, :desc, 'asc' or 'desc'. Default: :desc

--- a/lib/msf/core/db_manager/event.rb
+++ b/lib/msf/core/db_manager/event.rb
@@ -1,12 +1,47 @@
 module Msf::DBManager::Event
-  def events(wspace=workspace)
+  DEFAULT_ORDER = :desc
+  DEFAULT_LIMIT = 100
+  DEFAULT_OFFSET = 0
+
+  # Retrieves events that are stored in the database.
+  #
+  # @param opts [Hash] Hash containing query options.
+  # @option opts :id [Integer] A specific event ID. If specified, all other options are ignored.
+  # @option opts :workspace [String] The workspace from which the data should be gathered from. (Required)
+  # @option opts :order [Symbol|String] The event created_at sort order.
+  #   Valid values: :asc, :desc, 'asc' or 'desc'. Default: :desc
+  # @option opts :limit [Integer] The maximum number of events that will be retrieved from the query.
+  #   Default: 100
+  # @option opts :offset [Integer] The number of events the query will begin reading from the start
+  #   of the set. Default: 0
+  # @option opts :search_term [String] Search regular expression used to filter results.
+  #   All fields are converted to strings and results are returned if the pattern is matched.
+  # @return [Array<Mdm::Event>|Mdm::Event::ActiveRecord_AssociationRelation] events that are matched.
+  def events(opts)
   ::ActiveRecord::Base.connection_pool.with_connection {
     # If we have the ID, there is no point in creating a complex query.
     if opts[:id] && !opts[:id].to_s.empty?
       return Array.wrap(Mdm::Event.find(opts[:id]))
     end
 
-    wspace.events.find :all, :order => 'created_at ASC'
+    wspace = Msf::Util::DBManager.process_opts_workspace(opts, framework)
+
+    order = opts.delete(:order)
+    order = order.nil? ? DEFAULT_ORDER : order.to_sym
+
+    limit = opts.delete(:limit) || DEFAULT_LIMIT
+    offset = opts.delete(:offset) || DEFAULT_OFFSET
+
+    search_term = opts.delete(:search_term)
+    results = wspace.events.where(opts).order(created_at: order).offset(offset).limit(limit)
+
+    if search_term && !search_term.empty?
+      re_search_term = /#{search_term}/mi
+      results = results.select { |event|
+        event.attribute_names.any? { |a| event[a.intern].to_s.match(re_search_term) }
+      }
+    end
+    results
   }
   end
 

--- a/lib/msf/core/db_manager/event.rb
+++ b/lib/msf/core/db_manager/event.rb
@@ -45,7 +45,7 @@ module Msf::DBManager::Event
   }
   end
 
-  def report_event(opts = {})
+  def report_event(opts)
     return if not active
   ::ActiveRecord::Base.connection_pool.with_connection {
     wspace = Msf::Util::DBManager.process_opts_workspace(opts, framework)

--- a/lib/msf/core/web_services/servlet/event_servlet.rb
+++ b/lib/msf/core/web_services/servlet/event_servlet.rb
@@ -4,13 +4,32 @@ module EventServlet
     '/api/v1/events'
   end
 
+  def self.api_path_with_id
+    "#{EventServlet.api_path}/?:id?"
+  end
+
   def self.registered(app)
+    app.get EventServlet.api_path_with_id, &get_event
     app.post EventServlet.api_path, &report_event
   end
 
   #######
   private
   #######
+
+  def self.get_event
+    lambda {
+      warden.authenticate!
+      begin
+        sanitized_params = sanitize_params(params, env['rack.request.query_hash'])
+        data = get_db.events(sanitized_params)
+        data = data.first if is_single_object?(data, sanitized_params)
+        set_json_data_response(response: data)
+      rescue => e
+        print_error_and_create_response(error: e, message: 'There was an error getting events:', code: 500)
+      end
+    }
+  end
 
   def self.report_event
     lambda {

--- a/lib/msf/core/web_services/servlet/event_servlet.rb
+++ b/lib/msf/core/web_services/servlet/event_servlet.rb
@@ -26,7 +26,7 @@ module EventServlet
         data = data.first if is_single_object?(data, sanitized_params)
         set_json_data_response(response: data)
       rescue => e
-        print_error_and_create_response(error: e, message: 'There was an error getting events:', code: 500)
+        print_error_and_create_response(error: e, message: 'There was an error retrieving events:', code: 500)
       end
     }
   end

--- a/spec/support/shared/examples/msf/db_manager/event.rb
+++ b/spec/support/shared/examples/msf/db_manager/event.rb
@@ -1,8 +1,4 @@
 RSpec.shared_examples_for 'Msf::DBManager::Event' do
-
-  unless ENV['REMOTE_DB']
-    it { is_expected.to respond_to :events }
-  end
-
+  it { is_expected.to respond_to :events }
   it { is_expected.to respond_to :report_event }
 end


### PR DESCRIPTION
Implements a query (read) operation for `Event` on both the DBManager and Remote Data Service. The existing `Msf::DBManager::Event#events` method on both master (MSF5) and 4.x branches fails to execute without issue.

Ticket: MS-2818

### Changes
* Functional `events` method for querying Event database records from both the local and remote data services
* Pagination and sort options for events query:
    * `:order` - The event `created_at` sort order. Valid values: `:asc`, `:desc`, `asc` or `desc`. Default: `:desc`
    * `:limit` - The maximum number of events that will be retrieved from the query. Default: 100
    * `:offset` - The number of events the query will begin reading from the start of the set. Default: 0
* OpenAPI documentation reflects the events query changes

## Verification

- [x] Restart the database and MSF web service (data services) `msfdb restart`, and `init`/`reinit` if necessary.
- [x] Start `msfconsole` and connect to the data service started above if you didn't select the option to connect automatically during initialization. See [Metasploit Web Service](https://github.com/rapid7/metasploit-framework/wiki/Metasploit-Web-Service) for more information.
- [x] **Verify** `db_status` reports `Connection type: http. Connected to remote_data_service: (https://localhost:8080)`
- [x] Run commands, pop shells, interact with sessions - all of these actions create event data
- [x] **Verify** that events are being created for your actions by using the event section of the interactive documentation at `https://localhost:8080/api/v1/api-docs`
- [x] Quit `msfconsole`
- [x] Test local DB mode
    - [x] Temporarily disable the data service auto-connect by renaming the config file: `mv ~/.msf4/config ~/.msf4/config.disabled`
    - [x] Start `msfconsole`
    - [x] **Verify** `db_status` reports `Connected to msf. Connection type: postgresql.`
    - [x] Repeat the remote data service verification steps above
    - [x] Quit `msfconsole`
    - [x] Restore the config file: `mv ~/.msf4/config.disabled ~/.msf4/config`
