### PR TITLE
fixed post/multi/manage/shell_to_meterpreter

### DIFF
--- a/modules/post/multi/manage/shell_to_meterpreter.rb
+++ b/modules/post/multi/manage/shell_to_meterpreter.rb
@@ -73,7 +73,7 @@ class MetasploitModule < Msf::Post
 
     # Handle platform specific variables and settings
     case session.platform
-    when 'windows'
+    when 'windows', 'win'
       platform = 'windows'
       payload_name = 'windows/meterpreter/reverse_tcp'
       lplat = [Msf::Platform::Windows]


### PR DESCRIPTION
In powershell , the value of session.platform is 'win' not 'windows'

(pry)> session.platform
=> 'win'

