### PR TITLE
Support rhosts in auxiliary module

### DIFF
--- a/lib/msf/base/simple/auxiliary.rb
+++ b/lib/msf/base/simple/auxiliary.rb
@@ -153,8 +153,14 @@ protected
       return
     rescue ::Interrupt => e
       mod.error = e
-      mod.print_error("Auxiliary interrupted by the console user")
+      mod.print_error("Stopping running againest current target...")
       mod.cleanup
+      mod.print_status("Control-C again to force quit all targets.")
+      begin
+        Rex.sleep(0.5)
+      rescue ::Interrupt
+        raise $!
+      end
       return
     rescue ::Exception => e
       mod.error = e

--- a/lib/msf/ui/console/command_dispatcher/auxiliary.rb
+++ b/lib/msf/ui/console/command_dispatcher/auxiliary.rb
@@ -60,9 +60,6 @@ class Auxiliary
   end
 
   #
-  # Reloads an auxiliary module and executes it
-  #
-
   # Launches an auxiliary module for single attempt.
   #
   def run_single(mod, opts)
@@ -80,9 +77,9 @@ class Auxiliary
     end
   end
 
-
   #
   # Tab completion for the run command
+  #
   def cmd_run_tabs(str, words)
     return [] if words.length > 1
     @@auxiliary_opts.fmt.keys

--- a/lib/msf/ui/console/command_dispatcher/exploit.rb
+++ b/lib/msf/ui/console/command_dispatcher/exploit.rb
@@ -195,6 +195,10 @@ class Exploit
       end
     # For single target or no rhosts option.
     else
+      # avoid bug when the cidr of rhosts is 32, like 8.8.8.8/32
+      if rhosts_range.length == 1
+        mod.datastore['RHOST'] = (Rex::Socket.addr_itoa(rhosts_range.ranges.first.start))
+      end
       session = exploit_single(mod, opts)
       # If we were given a session, let's see what we can do with it
       if session


### PR DESCRIPTION
For now, the `rhosts` option is not usable in auxiliary modules except scanners, it would throw an error like `SocketError getaddrinfo`. 

And in exploit module, same error occurred when `rhosts` set to `8.8.8.8/32`. 

Fix #10693 
Related: #9246 


## Steps to reproduce
### Auxiliary module
```
msf5 auxiliary(scanner/http/apache_activemq_source_disclosure) > use admin/http/joomla_registration_privesc
msf5 auxiliary(admin/http/joomla_registration_privesc) > options

Module options (auxiliary/admin/http/joomla_registration_privesc):

   Name       Current Setting        Required  Description
   ----       ---------------        --------  -----------
   EMAIL      example@youremail.com  yes       Email to receive the activation code for the account
   PASSWORD   expl0it3r              yes       Password for the username
   Proxies                           no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS     10.181.0.122/24        yes       The target address range or CIDR identifier
   RPORT      80                     yes       The target port (TCP)
   SSL        false                  no        Negotiate SSL/TLS for outgoing connections
   TARGETURI  /                      yes       The relative URI of the Joomla instance
   USERNAME   expl0it3r              yes       Username that will be created
   VHOST                             no        HTTP server virtual host

msf5 auxiliary(admin/http/joomla_registration_privesc) > set verbose true
verbose => true
msf5 auxiliary(admin/http/joomla_registration_privesc) > run

[-] Auxiliary failed: SocketError getaddrinfo: nodename nor servname provided, or not known
[-] Call stack:
[-]   /Users/green/.rvm/gems/ruby-2.5.3@metasploit-framework/gems/rex-socket-0.1.15/lib/rex/socket.rb:189:in `gethostbyname'
[-]   /Users/green/.rvm/gems/ruby-2.5.3@metasploit-framework/gems/rex-socket-0.1.15/lib/rex/socket.rb:189:in `getaddresses'
[-]   /Users/green/.rvm/gems/ruby-2.5.3@metasploit-framework/gems/rex-socket-0.1.15/lib/rex/socket.rb:173:in `getaddress'
[-]   /Users/green/.rvm/gems/ruby-2.5.3@metasploit-framework/gems/rex-socket-0.1.15/lib/rex/socket.rb:263:in `resolv_nbo'
[-]   /Users/green/.rvm/gems/ruby-2.5.3@metasploit-framework/gems/rex-socket-0.1.15/lib/rex/socket.rb:277:in `resolv_nbo_i'
[-]   /Users/green/.rvm/gems/ruby-2.5.3@metasploit-framework/gems/rex-socket-0.1.15/lib/rex/socket/switch_board.rb:233:in `best_comm'
[-]   /Users/green/.rvm/gems/ruby-2.5.3@metasploit-framework/gems/rex-socket-0.1.15/lib/rex/socket/switch_board.rb:127:in `best_comm'
[-]   /Users/green/.rvm/gems/ruby-2.5.3@metasploit-framework/gems/rex-socket-0.1.15/lib/rex/socket/parameters.rb:195:in `initialize'
[-]   /Users/green/.rvm/gems/ruby-2.5.3@metasploit-framework/gems/rex-socket-0.1.15/lib/rex/socket/parameters.rb:38:in `new'
[-]   /Users/green/.rvm/gems/ruby-2.5.3@metasploit-framework/gems/rex-socket-0.1.15/lib/rex/socket/parameters.rb:38:in `from_hash'
[-]   /Users/green/.rvm/gems/ruby-2.5.3@metasploit-framework/gems/rex-socket-0.1.15/lib/rex/socket/tcp.rb:28:in `create'
[-]   /Users/green/msfdev/metasploit-framework/lib/rex/proto/http/client.rb:177:in `connect'
[-]   /Users/green/msfdev/metasploit-framework/lib/rex/proto/http/client.rb:244:in `send_request'
[-]   /Users/green/msfdev/metasploit-framework/lib/rex/proto/http/client.rb:229:in `_send_recv'
[-]   /Users/green/msfdev/metasploit-framework/lib/rex/proto/http/client.rb:210:in `send_recv'
[-]   /Users/green/msfdev/metasploit-framework/lib/msf/core/exploit/http/client.rb:367:in `send_request_cgi'
[-]   /Users/green/msfdev/metasploit-framework/modules/auxiliary/admin/http/joomla_registration_privesc.rb:45:in `check'
[-]   /Users/green/msfdev/metasploit-framework/modules/auxiliary/admin/http/joomla_registration_privesc.rb:79:in `run'
[*] Auxiliary module execution completed

```
### exploit module
```
msf5 exploit(linux/http/apache_couchdb_cmd_exec) > set lhost 10.103.0.30
lhost => 10.103.0.30
msf5 exploit(linux/http/apache_couchdb_cmd_exec) > set rhosts 8.8.8.8/32
rhosts => 8.8.8.8/32
msf5 exploit(linux/http/apache_couchdb_cmd_exec) > run

[*] Started reverse TCP handler on 10.103.0.30:4444
[-] Exploit failed: SocketError getaddrinfo: nodename nor servname provided, or not known
[*] Exploit completed, but no session was created.
msf5 exploit(linux/http/apache_couchdb_cmd_exec) >
```


## After fix

### Auxiliary module
```
msf5 auxiliary(gather/drupal_openid_xxe) > use auxiliary/gather/drupal_openid_xxe

msf5 auxiliary(gather/drupal_openid_xxe) > run

[*] Using URL: http://0.0.0.0:8080/w7fTsjuxSFJ
[*] Local IP: http://10.103.0.30:8080/w7fTsjuxSFJ
[*] Server started.
[*] Server stopped.
[*] Using URL: http://0.0.0.0:8080/rqQ0HJoQ6muwk9
[*] Local IP: http://10.103.0.30:8080/rqQ0HJoQ6muwk9
[*] Server started.
[*] Server stopped.
[*] Auxiliary module execution completed
```

### exploit module
```
msf5 exploit(linux/http/apache_couchdb_cmd_exec) > set lhost 10.103.0.30
lhost => 10.103.0.30
msf5 exploit(linux/http/apache_couchdb_cmd_exec) > run

[*] Started reverse TCP handler on 10.103.0.30:4444
[-] Exploit aborted due to failure: unknown: Something went horribly wrong and we couldn't continue to exploit.
[*] Exploit completed, but no session was created.
```



