### PR TITLE
Minor bug fix

### DIFF
--- a/modules/auxiliary/scanner/http/copy_of_file.rb
+++ b/modules/auxiliary/scanner/http/copy_of_file.rb
@@ -70,9 +70,8 @@ class MetasploitModule < Msf::Auxiliary
         # Detect error code
         #
         begin
-          randfile = Rex::Text.rand_text_alpha(5).chomp
 
-          filec = tpathf.sub(testf,pre + randfile + testf)
+          filec = tpathf.sub(testf,pre + testf)
 
           res = send_request_cgi({
             'uri'  		=>  filec,


### PR DESCRIPTION
This module is used to search for common copy file names(obviously). But it's including random caracteres in filename with no apparent reason. I've tested here and now is working fine.