### PR TITLE
Replace Sysrandom with Ruby default SecureRandom

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,7 +68,6 @@ PATH
       sinatra
       sqlite3
       sshkey
-      sysrandom
       thin
       tzinfo
       tzinfo-data
@@ -342,7 +341,6 @@ GEM
     sqlite3 (1.3.13)
     sshkey (1.9.0)
     swagger-blocks (2.0.2)
-    sysrandom (1.0.5)
     thin (1.7.2)
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
@@ -384,4 +382,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.16.6
+   1.17.1

--- a/LICENSE_GEMS
+++ b/LICENSE_GEMS
@@ -121,7 +121,6 @@ sinatra, 1.4.8, MIT
 sqlite3, 1.3.13, "New BSD"
 sshkey, 1.9.0, MIT
 swagger-blocks, 2.0.2, MIT
-sysrandom, 1.0.5, ISC
 thin, 1.7.2, "GPLv2+, Ruby 1.8"
 thor, 0.20.3, MIT
 thread_safe, 0.3.6, "Apache 2.0"

--- a/lib/msf/core/db_manager/user.rb
+++ b/lib/msf/core/db_manager/user.rb
@@ -1,5 +1,5 @@
 require 'bcrypt'
-require 'sysrandom/securerandom'
+require 'securerandom'
 
 module Msf::DBManager::User
 

--- a/lib/msf/core/web_services/json_rpc_app.rb
+++ b/lib/msf/core/web_services/json_rpc_app.rb
@@ -1,6 +1,6 @@
+require 'securerandom'
 require 'sinatra/base'
 require 'swagger/blocks'
-require 'sysrandom/securerandom'
 require 'warden'
 require 'msf/core/rpc'
 require 'msf/core/web_services/authentication'

--- a/lib/msf/core/web_services/metasploit_api_app.rb
+++ b/lib/msf/core/web_services/metasploit_api_app.rb
@@ -1,6 +1,6 @@
+require 'securerandom'
 require 'sinatra/base'
 require 'swagger/blocks'
-require 'sysrandom/securerandom'
 require 'warden'
 require 'msf/core/web_services/authentication'
 require 'msf/core/web_services/servlet_helper'

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -103,7 +103,6 @@ Gem::Specification.new do |spec|
   # Required for msfdb_ws (Metasploit data base as a webservice)
   spec.add_runtime_dependency 'thin'
   spec.add_runtime_dependency 'sinatra'
-  spec.add_runtime_dependency 'sysrandom'
   spec.add_runtime_dependency 'warden'
   # Required for JSON-RPC client
   spec.add_runtime_dependency 'em-http-request'

--- a/msfdb
+++ b/msfdb
@@ -8,7 +8,7 @@ require 'open3'
 require 'optparse'
 require 'rex/socket'
 require 'rex/text'
-require 'sysrandom/securerandom'
+require 'securerandom'
 require 'uri'
 require 'yaml'
 


### PR DESCRIPTION
This replaces Sysrandom usage with Ruby default SecureRandom in:
* MSF5 web services `MetasploitApiApp` and `JsonRpcApp` - used for the default `session_secret` creation
* `Msf::DBManager::User` - used for user token generation
* `msfdb` command - used for the DB password generation

From Sysrandom's README [Why?](https://github.com/cryptosphere/sysrandom#why):
> System/OS-level random number generators like /dev/urandom and getrandom(2) provide the best option for generating cryptographically secure random numbers.
> Ruby’s built-in SecureRandom does not provide this, but instead uses OpenSSL’s userspace RNG. This has been a source of vulnerabilities in Ruby, and this Ruby bug ticket contains more discussion on the issue.

Sysrandom was originally selected to leverage OS RNG over OpenSSL's userspace RNG. However, @bcook-r7 pointed out that it appears the documentation is outdated and "Ruby does this natively anyway."

## Verification

- [x] Reinit the database and MSF web service (data services) using `msfdb reinit`
- [x] Start `msfconsole` and connect to the data service started above if you didn't select the option to connect automatically during initialization. See [Metasploit Web Service](https://github.com/rapid7/metasploit-framework/wiki/Metasploit-Web-Service) for more information.
- [x] **Verify** `db_status` reports `Connection type: http. Connected to remote_data_service: (https://localhost:8080)`
- [x] Perform various data operations (`hosts`, `services`, `vulns`, `creds`, `loots`, `notes`)
- [x] **Verify** data operations operate as expected