### PR TITLE
Add support for selective retrieval of SessionEvent

### DIFF
--- a/documentation/api/v1/event_api_doc.rb
+++ b/documentation/api/v1/event_api_doc.rb
@@ -12,11 +12,6 @@ module EventApiDoc
   INFO_DESC = 'Information about the event specific to the event name.'
   INFO_EXAMPLE = {command: 'irb'}
 
-  ORDER_ENUM = [
-      'asc',
-      'desc'
-  ]
-
 # Swagger documentation for Event model
   swagger_schema :Event do
     key :required, [:name]
@@ -42,8 +37,8 @@ module EventApiDoc
       parameter do
         key :name, :limit
         key :in, :query
-        key :description, 'The maximum number of events that will be retrieved from the query. (Default: 100)'
-        key :example, 100
+        key :description, RootApiDoc::LIMIT_DESC
+        key :example, RootApiDoc::LIMIT_DEFAULT
         key :type, :integer
         key :format, :int32
         key :required, false
@@ -52,8 +47,8 @@ module EventApiDoc
       parameter do
         key :name, :offset
         key :in, :query
-        key :description, 'The number of events the query will begin reading from the start of the set. (Default: 0)'
-        key :example, 0
+        key :description, RootApiDoc::OFFSET_DESC
+        key :example, RootApiDoc::OFFSET_DEFAULT
         key :type, :integer
         key :format, :int32
         key :required, false
@@ -62,10 +57,10 @@ module EventApiDoc
       parameter do
         key :name, :order
         key :in, :query
-        key :description, 'The event created_at sort order. (Default: desc)'
+        key :description, RootApiDoc::ORDER_DESC
         key :type, :string
         key :required, false
-        key :enum, ORDER_ENUM
+        key :enum, RootApiDoc::ORDER_ENUM
       end
 
       response 200 do

--- a/documentation/api/v1/root_api_doc.rb
+++ b/documentation/api/v1/root_api_doc.rb
@@ -17,6 +17,15 @@ module RootApiDoc
   AUTH_CODE_DESC = 'The authentication error code that was generated.'
   AUTH_CODE_EXAMPLE = 401
   AUTH_MESSAGE_DESC = 'A message describing the authentication error that occurred.'
+  LIMIT_DEFAULT = 100
+  LIMIT_DESC = "The maximum number of results that will be retrieved from the query. (Default: #{LIMIT_DEFAULT})"
+  OFFSET_DEFAULT = 0
+  OFFSET_DESC = "The number of results the query will begin reading from the beginning of the set. (Default: #{OFFSET_DEFAULT})"
+  ORDER_DESC = 'The order in which results are returned, based on the created_at datetime. (Default: desc)'
+  ORDER_ENUM = [
+      'asc',
+      'desc'
+  ]
 
   DEFAULT_RESPONSE_200 = 'Successful operation.'
   DEFAULT_RESPONSE_401 = 'Authenticate to access this resource.'

--- a/documentation/api/v1/session_event_api_doc.rb
+++ b/documentation/api/v1/session_event_api_doc.rb
@@ -12,10 +12,6 @@ module SessionEventApiDoc
   LOCAL_PATH_EXAMPLE = '/path/to/file'
   REMOTE_PATH_DESC = 'Path to the associated file for upload, download, and filedelete events.'
   REMOTE_PATH_EXAMPLE = '/path/to/file'
-  ORDER_ENUM = [
-      'asc',
-      'desc'
-  ]
 
 # Swagger documentation for session events model
   swagger_schema :SessionEvent do
@@ -39,8 +35,8 @@ module SessionEventApiDoc
       parameter do
         key :name, :limit
         key :in, :query
-        key :description, 'The maximum number of session events that will be retrieved from the query. (Default: 100)'
-        key :example, 100
+        key :description, RootApiDoc::LIMIT_DESC
+        key :example, RootApiDoc::LIMIT_DEFAULT
         key :type, :integer
         key :format, :int32
         key :required, false
@@ -49,8 +45,8 @@ module SessionEventApiDoc
       parameter do
         key :name, :offset
         key :in, :query
-        key :description, 'The number of session events the query will begin reading from the start of the set. (Default: 0)'
-        key :example, 0
+        key :description, RootApiDoc::OFFSET_DESC
+        key :example, RootApiDoc::OFFSET_DEFAULT
         key :type, :integer
         key :format, :int32
         key :required, false
@@ -59,10 +55,10 @@ module SessionEventApiDoc
       parameter do
         key :name, :order
         key :in, :query
-        key :description, 'The session event created_at sort order. (Default: desc)'
+        key :description, RootApiDoc::ORDER_DESC
         key :type, :string
         key :required, false
-        key :enum, ORDER_ENUM
+        key :enum, RootApiDoc::ORDER_ENUM
       end
 
       response 200 do

--- a/documentation/api/v1/session_event_api_doc.rb
+++ b/documentation/api/v1/session_event_api_doc.rb
@@ -92,7 +92,7 @@ module SessionEventApiDoc
       end
     end
 
-    # Swagger documentation for /api/v1/session-events events POST
+    # Swagger documentation for /api/v1/session-events POST
     operation :post do
       key :description, 'Create a session events entry.'
       key :tags, [ 'session_event' ]

--- a/documentation/api/v1/session_event_api_doc.rb
+++ b/documentation/api/v1/session_event_api_doc.rb
@@ -92,7 +92,7 @@ module SessionEventApiDoc
       end
     end
 
-    # Swagger documentation for /api/v1/session events POST
+    # Swagger documentation for /api/v1/session-events events POST
     operation :post do
       key :description, 'Create a session events entry.'
       key :tags, [ 'session_event' ]
@@ -138,15 +138,15 @@ module SessionEventApiDoc
   end
 
   swagger_path '/api/v1/session-events/{id}' do
-    # Swagger documentation for api/v1/session-events/:id GET
+    # Swagger documentation for /api/v1/session-events/:id GET
     operation :get do
-      key :description, 'Return a specific session_event that is stored in the database.'
+      key :description, 'Return a specific session event that is stored in the database.'
       key :tags, [ 'session_event' ]
 
       parameter do
         key :name, :id
         key :in, :path
-        key :description, 'ID of session_event to retrieve.'
+        key :description, 'ID of session event to retrieve.'
         key :required, true
         key :type, :integer
         key :format, :int32

--- a/documentation/api/v1/session_event_api_doc.rb
+++ b/documentation/api/v1/session_event_api_doc.rb
@@ -12,6 +12,10 @@ module SessionEventApiDoc
   LOCAL_PATH_EXAMPLE = '/path/to/file'
   REMOTE_PATH_DESC = 'Path to the associated file for upload, download, and filedelete events.'
   REMOTE_PATH_EXAMPLE = '/path/to/file'
+  ORDER_ENUM = [
+      'asc',
+      'desc'
+  ]
 
 # Swagger documentation for session events model
   swagger_schema :SessionEvent do
@@ -31,6 +35,35 @@ module SessionEventApiDoc
     operation :get do
       key :description, 'Return session events that are stored in the database.'
       key :tags, [ 'session_event' ]
+
+      parameter do
+        key :name, :limit
+        key :in, :query
+        key :description, 'The maximum number of session events that will be retrieved from the query. (Default: 100)'
+        key :example, 100
+        key :type, :integer
+        key :format, :int32
+        key :required, false
+      end
+
+      parameter do
+        key :name, :offset
+        key :in, :query
+        key :description, 'The number of session events the query will begin reading from the start of the set. (Default: 0)'
+        key :example, 0
+        key :type, :integer
+        key :format, :int32
+        key :required, false
+      end
+
+      parameter do
+        key :name, :order
+        key :in, :query
+        key :description, 'The session event created_at sort order. (Default: desc)'
+        key :type, :string
+        key :required, false
+        key :enum, ORDER_ENUM
+      end
 
       response 200 do
         key :description, 'Returns session event data.'

--- a/lib/metasploit/framework/data_service/proxy/session_event_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/session_event_data_proxy.rb
@@ -1,5 +1,15 @@
 module SessionEventDataProxy
 
+  def session_events(opts = {})
+    begin
+      self.data_service_operation do |data_service|
+        data_service.session_events(opts)
+      end
+    rescue => e
+      self.log_error(e, "Problem retrieving session events")
+    end
+  end
+
   def report_session_event(opts)
     begin
       self.data_service_operation do |data_service|

--- a/lib/metasploit/framework/data_service/remote/http/remote_session_event_data_service.rb
+++ b/lib/metasploit/framework/data_service/remote/http/remote_session_event_data_service.rb
@@ -6,7 +6,7 @@ module RemoteSessionEventDataService
   SESSION_EVENT_API_PATH = '/api/v1/session-events'
   SESSION_EVENT_MDM_CLASS = 'Mdm::SessionEvent'
 
-  def session_events(opts = {})
+  def session_events(opts)
     path = get_path_select(opts, SESSION_EVENT_API_PATH)
     json_to_mdm_object(self.get_data(path, nil, opts), SESSION_EVENT_MDM_CLASS, [])
   end

--- a/lib/metasploit/framework/data_service/stubs/session_event_service.rb
+++ b/lib/metasploit/framework/data_service/stubs/session_event_service.rb
@@ -1,5 +1,9 @@
 module SessionEventDataService
 
+  def session_events(opts)
+    raise 'SessionEventDataService#session_events is not implemented'
+  end
+
   def report_session_event(opts)
     raise 'SessionEventDataService#report_session_event is not implemented'
   end

--- a/lib/msf/core/db_manager/session_event.rb
+++ b/lib/msf/core/db_manager/session_event.rb
@@ -1,16 +1,52 @@
 module Msf::DBManager::SessionEvent
+  DEFAULT_ORDER = :desc
+  DEFAULT_LIMIT = 100
+  DEFAULT_OFFSET = 0
 
+  # Retrieves session events that are stored in the database.
+  #
+  # @param opts [Hash] Hash containing query key-value pairs based on the session events model.
+  # @option opts :id [Integer] A specific session event ID. If specified, all other options are ignored.
+  #
+  # Additional query options:
+  # @option opts :order [Symbol|String] The session event created_at sort order.
+  #   Valid values: :asc, :desc, 'asc' or 'desc'. Default: :desc
+  # @option opts :limit [Integer] The maximum number of session events that will be retrieved from the query.
+  #   Default: 100
+  # @option opts :offset [Integer] The number of session events the query will begin reading from the start
+  #   of the set. Default: 0
+  # @option opts :search_term [String] Search regular expression used to filter results.
+  #   All fields are converted to strings and results are returned if the pattern is matched.
+  # @return [Array<Mdm::SessionEvent>] session events that are matched.
   def session_events(opts)
     ::ActiveRecord::Base.connection_pool.with_connection {
       # If we have the ID, there is no point in creating a complex query.
       if opts[:id] && !opts[:id].to_s.empty?
         return Array.wrap(Mdm::SessionEvent.find(opts[:id]))
       end
-      conditions = {}
 
-      Mdm::SessionEvent.all
+      # Passing workspace keys to the search will cause exceptions, so remove them if they were accidentally included.
+      Msf::Util::DBManager.delete_opts_workspace(opts)
+
+      order = opts.delete(:order)
+      order = order.nil? ? DEFAULT_ORDER : order.to_sym
+
+      limit = opts.delete(:limit) || DEFAULT_LIMIT
+      offset = opts.delete(:offset) || DEFAULT_OFFSET
+
+      search_term = opts.delete(:search_term)
+      results = Mdm::SessionEvent.where(opts).order(created_at: order).offset(offset).limit(limit)
+
+      if search_term && !search_term.empty?
+        re_search_term = /#{search_term}/mi
+        results = results.select { |event|
+          event.attribute_names.any? { |a| event[a.intern].to_s.match(re_search_term) }
+        }
+      end
+      results
     }
   end
+
   #
   # Record a session event in the database
   #

--- a/lib/msf/core/db_manager/session_event.rb
+++ b/lib/msf/core/db_manager/session_event.rb
@@ -5,7 +5,7 @@ module Msf::DBManager::SessionEvent
 
   # Retrieves session events that are stored in the database.
   #
-  # @param opts [Hash] Hash containing query key-value pairs based on the session events model.
+  # @param opts [Hash] Hash containing query key-value pairs based on the session event model.
   # @option opts :id [Integer] A specific session event ID. If specified, all other options are ignored.
   #
   # Additional query options:
@@ -17,7 +17,7 @@ module Msf::DBManager::SessionEvent
   #   of the set. Default: 0
   # @option opts :search_term [String] Search regular expression used to filter results.
   #   All fields are converted to strings and results are returned if the pattern is matched.
-  # @return [Array<Mdm::SessionEvent>] session events that are matched.
+  # @return [Array<Mdm::SessionEvent>|Mdm::SessionEvent::ActiveRecord_Relation] session events that are matched.
   def session_events(opts)
     ::ActiveRecord::Base.connection_pool.with_connection {
       # If we have the ID, there is no point in creating a complex query.

--- a/spec/support/shared/examples/msf/db_manager/session_event.rb
+++ b/spec/support/shared/examples/msf/db_manager/session_event.rb
@@ -1,3 +1,4 @@
 RSpec.shared_examples_for 'Msf::DBManager::SessionEvent' do
+  it { is_expected.to respond_to :session_events }
   it { is_expected.to respond_to :report_session_event }
 end


### PR DESCRIPTION
Implements selective retrieval for `SessionEvent`. The existing `Msf::DBManager::SessionEvent#session_events` method simply retrieves all `Mdm::SessionEvent` records. This is unlike the other model's find / search methods in which the `opts` hash is used as conditions for selective retrieval.

Ticket: MS-3221

### Changes
* Functional `session_events` method for querying SessionEvent database records from both the local and remote data services
* Pagination and sort options for session events query:
    * `:order` - The event `created_at` sort order. Valid values: `:asc`, `:desc`, `asc` or `desc`. Default: `:desc`
    * `:limit` - The maximum number of session events that will be retrieved from the query. Default: 100
    * `:offset` - The number of session events the query will begin reading from the start of the set. Default: 0
* OpenAPI documentation reflects the session events query changes

## Verification

- [x] Restart the database and MSF web service (data services) `msfdb restart`, and `init`/`reinit` if necessary.
- [x] Start `msfconsole` and connect to the data service started above if you didn't select the option to connect automatically during initialization. See [Metasploit Web Service](https://github.com/rapid7/metasploit-framework/wiki/Metasploit-Web-Service) for more information.
- [x] **Verify** `db_status` reports `Connection type: http. Connected to remote_data_service: (https://localhost:8080)`
- [x] Create and interact with sessions to create session event data
- [x] **Verify** that session events are being created for your actions by using the session event section of the interactive documentation at `https://localhost:8080/api/v1/api-docs`
- [x] Quit `msfconsole`
- [x] Test local DB mode
    - [x] Temporarily disable the data service auto-connect by renaming the config file: `mv ~/.msf4/config ~/.msf4/config.disabled`
    - [x] Start `msfconsole`
    - [x] **Verify** `db_status` reports `Connected to msf. Connection type: postgresql.`
    - [x] Repeat the remote data service verification steps above
    - [x] Quit `msfconsole`
    - [x] Restore the config file: `mv ~/.msf4/config.disabled ~/.msf4/config`
