### PR TITLE
Metasploit Web Service miscellaneous cleanup

### DIFF
--- a/lib/msf/core/web_services/servlet/event_servlet.rb
+++ b/lib/msf/core/web_services/servlet/event_servlet.rb
@@ -14,8 +14,8 @@ module EventServlet
 
   def self.report_event
     lambda {
+      warden.authenticate!
       begin
-        warden.authenticate!
         job = lambda { |opts| get_db.report_event(opts) }
         exec_report_job(request, &job)
       rescue => e

--- a/lib/msf/core/web_services/servlet/host_servlet.rb
+++ b/lib/msf/core/web_services/servlet/host_servlet.rb
@@ -34,7 +34,7 @@ module HostServlet
         data = data.first if is_single_object?(data, sanitized_params)
         set_json_data_response(response: data, includes: includes)
       rescue => e
-        print_error_and_create_response(error: e, message: 'There was an error getting hosts:', code: 500)
+        print_error_and_create_response(error: e, message: 'There was an error retrieving hosts:', code: 500)
       end
     }
   end

--- a/lib/msf/core/web_services/servlet/msf_servlet.rb
+++ b/lib/msf/core/web_services/servlet/msf_servlet.rb
@@ -18,8 +18,8 @@ module MsfServlet
 
   def self.get_msf_version
     lambda {
+      warden.authenticate!
       begin
-        warden.authenticate!
         set_json_data_response(response: { metasploit_version: Metasploit::Framework::VERSION })
       rescue => e
         print_error_and_create_response(error: e, message: 'There was an error retrieving the version:', code: 500)


### PR DESCRIPTION
This cleans up a few minor aspects of the Metasploit Web Service:

* Corrects `HostServlet` GET handler that has an error stating "There was an error getting hosts" while other servlets use the word "retrieving" instead of "getting".
* Corrects `EventServlet` and `MsfServlet` that had the `warden.authenticate!` call moved inside of the `begin` block as a part of #10377, specifically commit 3411d0bce206c7189f7499d42cea7eeaf54927cc, which is inconsistent with the other servlets.

## Verification

- [x] Restart the database and MSF web service (data services) using `msfdb restart`, and `init`/`reinit` if necessary.
- [x] **Verify**  an unauthenticated GET request to get the current version of the Metasploit Framework is rejected with an error message "Authenticate to access this resource": `curl -k -X GET -H "accept: application/json" "https://localhost:8080/api/v1/msf/version"`
- [x] **Verify** an unauthenticated POST request to create an event is rejected with an "Authenticate to access this resource": `curl -k -X POST -H "accept: application/json" -H "Content-Type: application/json" -d "{ \"workspace\": \"default\", \"name\": \"ui_command\", \"info\": {\"command\": \"irb\"}}" "https://localhost:8080/api/v1/events"`