### PR TITLE
fix #11158, fix multi line text in android send_sms

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/android.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/android.rb
@@ -527,6 +527,7 @@ class Console::CommandDispatcher::Android
         dest = val
       when '-t'
         body = val
+        body.gsub!('\n',"\n")
       when '-r'
         dr = true
       end

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/android.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/android.rb
@@ -527,6 +527,7 @@ class Console::CommandDispatcher::Android
         dest = val
       when '-t'
         body = val
+        # Replace \n with a newline character to allow multi-line messages
         body.gsub!('\n',"\n")
       when '-r'
         dr = true


### PR DESCRIPTION
Quick fix for https://github.com/rapid7/metasploit-framework/issues/11158

## Verification

- [x] Get an android meterpreter session
- [x] `meterpreter > send_sms -t "New\nLine" -d +5555`
- [x] **Verify** you receive a text with a new line in it

(Note: if you have a session on an Android emulator, you can send a text to yourself using the destination number +5555).
