### PR TITLE
add analyze command

### DIFF
--- a/lib/msf/core.rb
+++ b/lib/msf/core.rb
@@ -51,6 +51,7 @@ require 'msf/core/module_set'
 require 'msf/core/plugin_manager'
 require 'msf/core/session'
 require 'msf/core/session_manager'
+require 'msf/core/analyze'
 
 
 

--- a/lib/msf/core/analyze.rb
+++ b/lib/msf/core/analyze.rb
@@ -61,28 +61,21 @@ class Msf::Analyze
   # This is a fail-open gate; if there's a doubt, assume the module will work on this target.
   def exploit_matches_host_os(mod, host)
     hos = host.os_name
-    return true if not hos
-    return true if hos.length == 0
+    return true if hos.nil? || hos.empty?
 
     set = mod.platform.split(',').map{ |x| x.downcase }
-    return true if set.length == 0
+    return true if set.empty?
 
     # Special cases
     return true if set.include?("unix") and hos !~ /windows/i
 
-    # Skip archaic old HPUX bugs if we have a solid match against another OS
-    if set.include?("unix") and set.include?("hpux") and mod.refname.index("hpux") and hos =~ /linux|irix|solaris|aix|bsd/i
-      return false
-    end
-
-    # Skip AIX bugs if we have a solid match against another OS
-    if set.include?("unix") and set.include?("aix") and mod.refname.index("aix") and hos =~ /linux|irix|solaris|hpux|bsd/i
-      return false
-    end
-
-    # Skip IRIX bugs if we have a solid match against another OS
-    if set.include?("unix") and set.include?("irix") and mod.refname.index("irix") and hos =~ /linux|solaris|hpux|aix|bsd/i
-      return false
+    if set.include?("unix")
+      # Skip archaic old HPUX bugs if we have a solid match against another OS
+      return false if set.include?("hpux") and mod.refname.index("hpux") and hos =~ /linux|irix|solaris|aix|bsd/i
+      # Skip AIX bugs if we have a solid match against another OS
+      return false if set.include?("aix") and mod.refname.index("aix") and hos =~ /linux|irix|solaris|hpux|bsd/i
+      # Skip IRIX bugs if we have a solid match against another OS
+      return false if set.include?("irix") and mod.refname.index("irix") and hos =~ /linux|solaris|hpux|aix|bsd/i
     end
 
     return true if set.include?("php")

--- a/lib/msf/core/analyze.rb
+++ b/lib/msf/core/analyze.rb
@@ -1,0 +1,96 @@
+class Msf::Analyze
+
+  def initialize(framework)
+    @framework = framework
+  end
+
+  def host(eval_host)
+    suggested_modules = {}
+
+    mrefs, _mports, _mservs = Msf::Modules::Metadata::Cache.instance.all_remote_exploit_maps
+
+    unless eval_host.vulns
+      return {}
+    end
+
+    vuln_refs = []
+    eval_host.vulns.each do |vuln|
+      next if vuln.service.nil?
+      vuln_refs.push(*vuln.refs)
+    end
+
+    # finds all modules that have references matching those found on host vulns with service data
+    found_modules = mrefs.values_at(*(vuln_refs.map { |x| x.name.upcase } & mrefs.keys)).map { |x| x.values }.flatten.uniq
+    found_modules.each do |fnd_mod|
+      # next if exploit_filter_by_service(fnd_mod, vuln.service)
+      next unless exploit_matches_host_os(fnd_mod, eval_host)
+    end
+
+    suggested_modules[:modules] = found_modules
+
+    suggested_modules
+  end
+
+
+  private
+
+  # Tests for various service conditions by comparing the module's full_name (which
+  # is basically a pathname) to the intended target service record. The service.info
+  # column is tested against a regex in most/all cases and "false" is returned in the
+  # event of a match between an incompatible module and service fingerprint.
+  def exploit_filter_by_service(mod, serv)
+
+    # Filter out Unix vs Windows exploits for SMB services
+    return true if (mod.full_name =~ /\/samba/ and serv.info.to_s =~ /windows/i)
+    return true if (mod.full_name =~ /\/windows/ and serv.info.to_s =~ /samba|unix|vxworks|qnx|netware/i)
+    return true if (mod.full_name =~ /\/netware/ and serv.info.to_s =~ /samba|unix|vxworks|qnx/i)
+
+    # Filter out IIS exploits for non-Microsoft services
+    return true if (mod.full_name =~ /\/iis\/|\/isapi\// and (serv.info.to_s !~ /microsoft|asp/i))
+
+    # Filter out Apache exploits for non-Apache services
+    return true if (mod.full_name =~ /\/apache/ and serv.info.to_s !~ /apache|ibm/i)
+
+    false
+  end
+
+  # Determines if an exploit (mod, an instantiated module) is suitable for the host (host)
+  # defined operating system. Returns true if the host.os isn't defined, if the module's target
+  # OS isn't defined, if the module's OS is "unix" and the host's OS is not "windows," or
+  # if the module's target is "php." Or, of course, in the event the host.os actually matches.
+  # This is a fail-open gate; if there's a doubt, assume the module will work on this target.
+  def exploit_matches_host_os(mod, host)
+    hos = host.os_name
+    return true if not hos
+    return true if hos.length == 0
+
+    set = mod.platform.split(',').map{ |x| x.downcase }
+    return true if set.length == 0
+
+    # Special cases
+    return true if set.include?("unix") and hos !~ /windows/i
+
+    # Skip archaic old HPUX bugs if we have a solid match against another OS
+    if set.include?("unix") and set.include?("hpux") and mod.refname.index("hpux") and hos =~ /linux|irix|solaris|aix|bsd/i
+      return false
+    end
+
+    # Skip AIX bugs if we have a solid match against another OS
+    if set.include?("unix") and set.include?("aix") and mod.refname.index("aix") and hos =~ /linux|irix|solaris|hpux|bsd/i
+      return false
+    end
+
+    # Skip IRIX bugs if we have a solid match against another OS
+    if set.include?("unix") and set.include?("irix") and mod.refname.index("irix") and hos =~ /linux|solaris|hpux|aix|bsd/i
+      return false
+    end
+
+    return true if set.include?("php")
+
+    set.each do |mos|
+      return true if hos.downcase.index(mos)
+    end
+
+    false
+  end
+end

--- a/lib/msf/core/framework.rb
+++ b/lib/msf/core/framework.rb
@@ -80,6 +80,7 @@ class Framework
     self.jobs      = Rex::JobContainer.new
     self.plugins   = PluginManager.new(self)
     self.uuid_db   = Rex::JSONHashFile.new(::File.join(Msf::Config.config_directory, "payloads.json"))
+    self.analyze   = Analyze.new(self)
     self.browser_profiles = Hash.new
 
     # Configure the thread factory
@@ -196,6 +197,11 @@ class Framework
   # different contexts.
   #
   attr_reader   :browser_profiles
+  #
+  # The framework instance's analysis utility.  Provide method to analyze
+  # framework objects to offer related objects/actions available.
+  #
+  attr_reader   :analyze
 
   #
   # The framework instance's data service proxy
@@ -272,6 +278,7 @@ protected
   attr_writer   :db # :nodoc:
   attr_writer   :uuid_db # :nodoc:
   attr_writer   :browser_profiles # :nodoc:
+  attr_writer   :analyze # :nodoc:
 
   private
 

--- a/lib/msf/core/rpc/v10/rpc_db.rb
+++ b/lib/msf/core/rpc/v10/rpc_db.rb
@@ -699,7 +699,7 @@ def rpc_analyze_host(xopts)
     ret[:host] = []
     opts = fix_options(xopts)
     h = self.framework.db.get_host(opts)
-    h_result = self.framework.db.analyze(h)
+    h_result = self.framework.analyze.host(h)
     host_detail = {}
     host_detail[:address] = host
     # for now only modules can be returned, in future maybe process whole result map

--- a/lib/msf/core/rpc/v10/rpc_db.rb
+++ b/lib/msf/core/rpc/v10/rpc_db.rb
@@ -622,6 +622,7 @@ public
   # Returns information about a host.
   #
   # @param [Hash] xopts Options (:addr, :address, :host are the same thing, and you only need one):
+  # @option xopts [String] :workspace Name of the workspace.
   # @option xopts [String] :addr Host address.
   # @option xopts [String] :address Same as :addr.
   # @option xopts [String] :host Same as :address.
@@ -676,6 +677,7 @@ public
   # Returns analysis of module suggestions for known data about a host.
   #
   # @param [Hash] xopts Options (:addr, :address, :host are the same thing, and you only need one):
+  # @option xopts [String] :workspace Name of the workspace.
   # @option xopts [String] :addr Host address.
   # @option xopts [String] :address Same as :addr.
   # @option xopts [String] :host Same as :address.
@@ -722,6 +724,7 @@ end
   # Reports a new host to the database.
   #
   # @param [Hash] xopts Information to report about the host. See below:
+  # @option xopts [String] :workspace Name of the workspace.
   # @option xopts [String] :host IP address. You msut supply this.
   # @option xopts [String] :state One of the Msf::HostState constants. (See Most::HostState Documentation)
   # @option xopts [String] :os_name Something like "Windows", "Linux", or "Mac OS X".
@@ -756,6 +759,7 @@ end
   # Reports a service to the database.
   #
   # @param [Hash] xopts Information to report about the service. See below:
+  # @option xopts [String] :workspace Name of the workspace.
   # @option xopts [String] :host Required. The host where this service is running.
   # @option xopts [String] :port Required. The port where this service listens.
   # @option xopts [String] :proto Required. The transport layer protocol (e.g. tcp, udp).
@@ -944,6 +948,7 @@ end
   # Reports a client connection.
   #
   # @param [Hash] xopts Information about the client.
+  # @option xopts [String] :workspace Name of the workspace.
   # @option xopts [String] :ua_string Required. User-Agent string.
   # @option xopts [String] :host Required. Host IP.
   # @option xopts [String] :ua_name One of the Msf::HttpClients constants. (See Msf::HttpClient Documentation.)
@@ -1015,6 +1020,7 @@ end
   # Returns notes from the database.
   #
   # @param [Hash] xopts Filters for the search. See below:
+  # @option xopts [String] :workspace Name of the workspace.
   # @option xopts [String] :address Host address.
   # @option xopts [String] :names Names (separated by ',').
   # @option xopts [String] :ntype Note type.
@@ -1657,6 +1663,7 @@ end
   # Returns browser clients information.
   #
   # @param [Hash] xopts Filters that narrow down the search.
+  # @option xopts [String] :workspace Name of the workspace.
   # @option xopts [String] :ua_name User-Agent name.
   # @option xopts [String] :ua_ver Browser version.
   # @option xopts [Array] :addresses Addresses.

--- a/lib/msf/core/rpc/v10/rpc_db.rb
+++ b/lib/msf/core/rpc/v10/rpc_db.rb
@@ -687,8 +687,8 @@ public
   #  * 'host' [Array<Hash>] Each hash in the array contains the following:
   #    * 'address' [String] Address.
   #    * 'modules' [Array<Hash>] Each hash in the array modules contains the following:
-  #      * 'mtype' []String] Module type.
-  #      * 'nmame' [String] Module name. For example: 'windows/wlan/wlan_profile'
+  #      * 'mtype' [String] Module type.
+  #      * 'mname' [String] Module name. For example: 'windows/wlan/wlan_profile'
   # @example Here's how you would use this from the client:
   #  rpc.call('db.analyze_host', {:host => ip})
 def rpc_analyze_host(xopts)
@@ -701,7 +701,7 @@ def rpc_analyze_host(xopts)
     h = self.framework.db.get_host(opts)
     h_result = self.framework.analyze.host(h)
     host_detail = {}
-    host_detail[:address] = host
+    host_detail[:address] = h.address
     # for now only modules can be returned, in future maybe process whole result map
     unless h_result[:modules].empty?
       host_detail[:modules] = []
@@ -710,6 +710,7 @@ def rpc_analyze_host(xopts)
         mod_detail[:mtype]  = mod.mtype
         mod_detail[:mname]  = mod.full_name
       end
+      host_detail[:modules] = mod_detail
     end
     ret[:host] << host_detail
     ret

--- a/lib/msf/core/rpc/v10/rpc_db.rb
+++ b/lib/msf/core/rpc/v10/rpc_db.rb
@@ -699,6 +699,7 @@ def rpc_analyze_host(xopts)
     ret[:host] = []
     opts = fix_options(xopts)
     h = self.framework.db.get_host(opts)
+    return ret unless h
     h_result = self.framework.analyze.host(h)
     host_detail = {}
     host_detail[:address] = h.address
@@ -707,10 +708,10 @@ def rpc_analyze_host(xopts)
       host_detail[:modules] = []
       h_result[:modules].each do |mod|
         mod_detail = {}
-        mod_detail[:mtype]  = mod.mtype
+        mod_detail[:mtype]  = mod.type
         mod_detail[:mname]  = mod.full_name
+        host_detail[:modules] << mod_detail
       end
-      host_detail[:modules] = mod_detail
     end
     ret[:host] << host_detail
     ret

--- a/lib/msf/core/rpc/v10/rpc_db.rb
+++ b/lib/msf/core/rpc/v10/rpc_db.rb
@@ -854,6 +854,7 @@ end
   # Returns a note.
   #
   # @param [Hash] xopts Options.
+  # @option xopts [String] :workspace Workspace name.
   # @option xopts [String] :addr Host address.
   # @option xopts [String] :address Same as :addr.
   # @option xopts [String] :host Same as :address.

--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -4,6 +4,7 @@ require 'json'
 require 'rexml/document'
 require 'rex/parser/nmap_xml'
 require 'msf/core/db_export'
+require 'msf/ui/console/command_dispatcher/db/analyze'
 require 'metasploit/framework/data_service'
 require 'metasploit/framework/data_service/remote/http/core'
 
@@ -18,6 +19,7 @@ class Db
 
   include Msf::Ui::Console::CommandDispatcher
   include Msf::Ui::Console::CommandDispatcher::Common
+  include Msf::Ui::Console::CommandDispatcher::Analyze
 
   DB_CONFIG_PATH = 'framework/database'
 
@@ -51,11 +53,13 @@ class Db
       "db_export"     => "Export a file containing the contents of the database",
       "db_nmap"       => "Executes nmap and records the output automatically",
       "db_rebuild_cache" => "Rebuilds the database-stored module cache",
+      "analyze"       => "Analyze database information about a specific address or address range",
     }
 
     # Always include commands that only make sense when connected.
     # This avoids the problem of them disappearing unexpectedly if the
     # database dies or times out.  See #1923
+
     base.merge(more)
   end
 

--- a/lib/msf/ui/console/command_dispatcher/db/analyze.rb
+++ b/lib/msf/ui/console/command_dispatcher/db/analyze.rb
@@ -1,7 +1,7 @@
 module Msf::Ui::Console::CommandDispatcher::Analyze
 
   def cmd_analyze(*args)
-    if !active?
+    unless active?
       print_error "Not currently connected to a data service for analysis."
       return []
     end

--- a/lib/msf/ui/console/command_dispatcher/db/analyze.rb
+++ b/lib/msf/ui/console/command_dispatcher/db/analyze.rb
@@ -1,0 +1,132 @@
+module Msf::Ui::Console::CommandDispatcher::Analyze
+
+  def cmd_analyze(*args)
+    if !active?
+      print_error "Not currently connected to a data service for analysis."
+      return
+    end
+
+    host_ranges = []
+
+    while (arg = args.shift)
+      case arg
+        when '-h','help'
+          cmd_analyze_help
+          return
+        else
+          (arg_host_range(arg, host_ranges))
+      end
+    end
+
+    host_ids = []
+    each_host_range_chunk(host_ranges) do |host_search|
+      break if !host_search.nil? && host_search.empty?
+      eval_hosts_ids = framework.db.hosts(address: host_search).map(&:id)
+      if eval_hosts_ids
+        host_ids.push(eval_hosts_ids)
+      end
+    end
+
+    if host_ids.empty?
+      print_status("No host found for #{host_ranges}.")
+    else
+
+      mrefs, _mports, _mservs = Msf::Modules::Metadata::Cache.instance.all_remote_exploit_maps
+
+      host_ids.each do |id|
+        eval_host = framework.db.hosts(id: id).first
+        next unless eval_host
+        print_status("Analyzing #{eval_host.address}...")
+        unless eval_host.vulns
+          print_status("No suggestions for #{eval_host.address}.")
+          next
+        end
+
+        reported_module = false
+        vuln_refs = []
+        eval_host.vulns.each do |vuln|
+          next if vuln.service.nil?
+          vuln_refs.push(*vuln.refs)
+        end
+
+        found_modules = mrefs.values_at(*(vuln_refs.map { |x| x.name.upcase } & mrefs.keys)).map { |x| x.values }.flatten.uniq
+        found_modules.each do |fnd_mod|
+          # next if exploit_filter_by_service(fnd_mod, vuln.service)
+          next unless exploit_matches_host_os(fnd_mod, eval_host)
+          print_status(fnd_mod.full_name)
+          reported_module = true
+        end
+
+        print_status("No suggestions for #{eval_host.address}.") unless reported_module
+      end
+    end
+  end
+
+
+  def cmd_analyze_help
+    print_line "Usage: analyze [addr1 addr2 ...]"
+    print_line
+  end
+
+  private
+
+  # Tests for various service conditions by comparing the module's full_name (which
+  # is basically a pathname) to the intended target service record. The service.info
+  # column is tested against a regex in most/all cases and "false" is returned in the
+  # event of a match between an incompatible module and service fingerprint.
+  def exploit_filter_by_service(mod, serv)
+
+    # Filter out Unix vs Windows exploits for SMB services
+    return true if (mod.full_name =~ /\/samba/ and serv.info.to_s =~ /windows/i)
+    return true if (mod.full_name =~ /\/windows/ and serv.info.to_s =~ /samba|unix|vxworks|qnx|netware/i)
+    return true if (mod.full_name =~ /\/netware/ and serv.info.to_s =~ /samba|unix|vxworks|qnx/i)
+
+    # Filter out IIS exploits for non-Microsoft services
+    return true if (mod.full_name =~ /\/iis\/|\/isapi\// and (serv.info.to_s !~ /microsoft|asp/i))
+
+    # Filter out Apache exploits for non-Apache services
+    return true if (mod.full_name =~ /\/apache/ and serv.info.to_s !~ /apache|ibm/i)
+
+    false
+  end
+
+  # Determines if an exploit (mod, an instantiated module) is suitable for the host (host)
+  # defined operating system. Returns true if the host.os isn't defined, if the module's target
+  # OS isn't defined, if the module's OS is "unix" and the host's OS is not "windows," or
+  # if the module's target is "php." Or, of course, in the event the host.os actually matches.
+  # This is a fail-open gate; if there's a doubt, assume the module will work on this target.
+  def exploit_matches_host_os(mod, host)
+    hos = host.os_name
+    return true if not hos
+    return true if hos.length == 0
+
+    set = mod.platform.split(',').map{ |x| x.downcase }
+    return true if set.length == 0
+
+    # Special cases
+    return true if set.include?("unix") and hos !~ /windows/i
+
+    # Skip archaic old HPUX bugs if we have a solid match against another OS
+    if set.include?("unix") and set.include?("hpux") and mod.refname.index("hpux") and hos =~ /linux|irix|solaris|aix|bsd/i
+      return false
+    end
+
+    # Skip AIX bugs if we have a solid match against another OS
+    if set.include?("unix") and set.include?("aix") and mod.refname.index("aix") and hos =~ /linux|irix|solaris|hpux|bsd/i
+      return false
+    end
+
+    # Skip IRIX bugs if we have a solid match against another OS
+    if set.include?("unix") and set.include?("irix") and mod.refname.index("irix") and hos =~ /linux|solaris|hpux|aix|bsd/i
+      return false
+    end
+
+    return true if set.include?("php")
+
+    set.each do |mos|
+      return true if hos.downcase.index(mos)
+    end
+
+    false
+  end
+end

--- a/lib/msf/ui/console/command_dispatcher/db/analyze.rb
+++ b/lib/msf/ui/console/command_dispatcher/db/analyze.rb
@@ -26,7 +26,9 @@ module Msf::Ui::Console::CommandDispatcher::Analyze
       break if !host_search.nil? && host_search.empty?
       eval_hosts_ids = framework.db.hosts(address: host_search).map(&:id)
       if eval_hosts_ids
-        host_ids.push(eval_hosts_ids)
+        eval_hosts_ids.each do |eval_id|
+          host_ids.push(eval_id)
+        end
       end
     end
 

--- a/lib/msf/ui/console/command_dispatcher/db/analyze.rb
+++ b/lib/msf/ui/console/command_dispatcher/db/analyze.rb
@@ -18,6 +18,8 @@ module Msf::Ui::Console::CommandDispatcher::Analyze
       end
     end
 
+    host_ranges.push(nil) if host_ranges.empty?
+
     host_ids = []
     suggested_modules = {}
     each_host_range_chunk(host_ranges) do |host_search|
@@ -29,7 +31,7 @@ module Msf::Ui::Console::CommandDispatcher::Analyze
     end
 
     if host_ids.empty?
-      print_status("No host found for #{host_ranges}.")
+      print_status("No existing hosts stored to analyze.")
     else
 
       host_ids.each do |id|


### PR DESCRIPTION
This is the initial start on an idea of enabling the framework to suggest modules base on what a user has already learned and stored about a host.  Currently functionality is limited to linking vulnerabilities already stored about a host to exploit modules that may take advantage of that vulnerability.

For now this enables the `analyze` command only when a user has a database attached to the console.

```
msf5 > help database

Database Backend Commands
=========================

    Command           Description
    -------           -----------
    analyze           Analyze database information about a specific address or address range
    db_connect        Connect to an existing data service
    db_disconnect     Disconnect from the current data service
    db_export         Export a file containing the contents of the database
    db_import         Import a scan result file (filetype will be auto-detected)
    db_nmap           Executes nmap and records the output automatically
    db_rebuild_cache  Rebuilds the database-stored module cache
    db_remove         Remove the saved data service entry
    db_save           Save the current data service connection as the default to reconnect on startup
    db_status         Show the current data service status
    hosts             List all hosts in the database
    loot              List all loot in the database
    notes             List all notes in the database
    services          List all services in the database
    vulns             List all vulnerabilities in the database
    workspace         Switch between database workspaces
```

Example usage against metasploitable3 based on a vulnerability scan imported from nexpose:
```
$ ./msfconsole -q
msf5 > db_import m3_report.xml
[*] Importing 'NeXpose XML Report' data
[*] Import: Parsing with 'Nokogiri v1.8.5'
[*] Importing host 192.168.18.118
[*] Importing vulnerability 'NEXPOSE-apache-httpd-cve-2012-0053' (1 instance)
[*] Importing vulnerability 'NEXPOSE-certificate-common-name-mismatch' (1 instance)
[*] Importing vulnerability 'NEXPOSE-cifs-smb-signing-disabled' (2 instances)
[*] Importing vulnerability 'NEXPOSE-cifs-smb-signing-not-required' (2 instances)
[*] Importing vulnerability 'NEXPOSE-cifs-smb2-signing-not-required' (1 instance)
[*] Importing vulnerability 'NEXPOSE-database-open-access' (1 instance)
[*] Importing vulnerability 'NEXPOSE-generic-icmp-timestamp' (1 instance)
[*] Importing vulnerability 'NEXPOSE-msft-cve-2017-0146' (1 instance)
[*] Importing vulnerability 'NEXPOSE-netbios-nbstat-amplification' (1 instance)
...
[*] Successfully imported /m3_report.xml
msf5 > hosts

Hosts
=====

address         mac                name            os_name                            os_flavor  os_sp  purpose  info  comments
-------         ---                ----            -------                            ---------  -----  -------  ----  --------
192.168.18.118  00:0c:29:6e:e8:7f  VAGRANT-2008R2  Windows 2008 R2, Standard Edition             SP1    server

msf5 > analyze 192.168.18.118
[*] Analyzing 192.168.18.118...
[*] exploit/windows/smb/ms17_010_eternalblue
[*] exploit/windows/smb/ms17_010_eternalblue_win8
[*] exploit/windows/smb/ms17_010_psexec
msf5 >
```

### Looking Forward

At some point things like the `Multi Recon Local Exploit Suggester` module could be integrated into a single location to get hints from metasploit framework about next steps a user may consider taking.

Anyone taking a gander at this please provide input on the user experience and how the initial functionality could be tweaked before this lands.
 
## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `db_import <test_file_path>.xml`
- [x] **Verify** modules reported are valid for what is know about services and vulns on imported host

[m3_report.xml.zip](https://github.com/rapid7/metasploit-framework/files/2678131/m3_report.xml.zip)


