### PR TITLE
update travis to use latest rubygems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,8 @@ before_install:
   - ls -la ./.git/hooks
   - ./.git/hooks/post-merge
   # Update the bundler
-  - gem install bundler -v 1.17.3 
+  - gem update --system
+  - gem install bundler
 before_script:
   - cp config/database.yml.travis config/database.yml
   - bundle exec rake --version


### PR DESCRIPTION
By using the latest rubygems available bundler version
limits should become more compatible.


## Verification

List the steps needed to make sure this thing works

- [ ] **Verify** Travis tests pass

