### PR TITLE
[Moved to new branch] Port db_import command for compatibility with remote data service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,8 @@ before_install:
   - ls -la ./.git/hooks
   - ./.git/hooks/post-merge
   # Update the bundler
-  - gem install bundler -v 1.17.3 
+  - gem update --system
+  - gem install bundler
 before_script:
   - cp config/database.yml.travis config/database.yml
   - bundle exec rake --version

--- a/lib/metasploit/framework/data_service/remote/http/data_service_auto_loader.rb
+++ b/lib/metasploit/framework/data_service/remote/http/data_service_auto_loader.rb
@@ -19,6 +19,7 @@ module DataServiceAutoLoader
   autoload :RemoteDbExportDataService, 'metasploit/framework/data_service/remote/http/remote_db_export_data_service'
   autoload :RemoteVulnAttemptDataService, 'metasploit/framework/data_service/remote/http/remote_vuln_attempt_data_service'
   autoload :RemoteMsfDataService, 'metasploit/framework/data_service/remote/http/remote_msf_data_service'
+  autoload :RemoteDbImportDataService, 'metasploit/framework/data_service/remote/http/remote_db_import_data_service.rb'
 
   include RemoteHostDataService
   include RemoteEventDataService
@@ -37,4 +38,5 @@ module DataServiceAutoLoader
   include RemoteDbExportDataService
   include RemoteVulnAttemptDataService
   include RemoteMsfDataService
+  include RemoteDbImportDataService
 end

--- a/lib/metasploit/framework/data_service/remote/http/remote_db_import_data_service.rb
+++ b/lib/metasploit/framework/data_service/remote/http/remote_db_import_data_service.rb
@@ -1,0 +1,19 @@
+require 'metasploit/framework/data_service/remote/http/response_data_helper'
+
+module RemoteDbImportDataService
+  include ResponseDataHelper
+
+  DB_IMPORT_API_PATH = '/api/v1/db-import'
+
+  def import_file(opts)
+    filename = opts[:filename]
+    data = ""
+    File.open(filename, 'rb') do |f|
+      data = f.read(f.stat.size)
+    end
+
+    opts[:data] = Base64.urlsafe_encode64(data)
+
+    self.post_data_async(DB_IMPORT_API_PATH, opts)
+  end
+end

--- a/lib/msf/core/db_manager/host.rb
+++ b/lib/msf/core/db_manager/host.rb
@@ -241,8 +241,7 @@ module Msf::DBManager::Host
       host.info = host.info[0,::Mdm::Host.columns_hash["info"].limit] if host.info
 
       # Set default fields if needed
-      host.state = Msf::HostState::Alive unless host.state
-      host.state = nil if host.state.empty?
+      host.state = Msf::HostState::Alive if host.state.nil? || host.state.empty?
       host.comm = '' unless host.comm
       host.workspace = wspace unless host.workspace
 

--- a/lib/msf/core/db_manager/host.rb
+++ b/lib/msf/core/db_manager/host.rb
@@ -242,6 +242,7 @@ module Msf::DBManager::Host
 
       # Set default fields if needed
       host.state = Msf::HostState::Alive unless host.state
+      host.state = nil if host.state.empty?
       host.comm = '' unless host.comm
       host.workspace = wspace unless host.workspace
 

--- a/lib/msf/core/db_manager/import/metasploit_framework/xml.rb
+++ b/lib/msf/core/db_manager/import/metasploit_framework/xml.rb
@@ -229,7 +229,7 @@ module Msf::DBManager::Import::MetasploitFramework::XML
   # TODO: loot, tasks, and reports
   def import_msf_xml(args={}, &block)
     data = args[:data]
-    wspace = args[:wspace] || Msf::Util::DBManager.process_opts_workspace(args, framework).name
+    wspace = args[:wspace] || workspace || Msf::Util::DBManager.process_opts_workspace(args, framework).name
     bl = validate_ips(args[:blacklist]) ? args[:blacklist].split : []
 
     doc = Nokogiri::XML::Reader.from_memory(data)

--- a/lib/msf/core/db_manager/import/metasploit_framework/xml.rb
+++ b/lib/msf/core/db_manager/import/metasploit_framework/xml.rb
@@ -229,7 +229,7 @@ module Msf::DBManager::Import::MetasploitFramework::XML
   # TODO: loot, tasks, and reports
   def import_msf_xml(args={}, &block)
     data = args[:data]
-    wspace = args[:wspace] || workspace
+    wspace = args[:wspace] || Msf::Util::DBManager.process_opts_workspace(args, framework).name
     bl = validate_ips(args[:blacklist]) ? args[:blacklist].split : []
 
     doc = Nokogiri::XML::Reader.from_memory(data)

--- a/lib/msf/core/web_services/metasploit_api_app.rb
+++ b/lib/msf/core/web_services/metasploit_api_app.rb
@@ -25,6 +25,7 @@ require 'msf/core/web_services/servlet/db_export_servlet'
 require 'msf/core/web_services/servlet/vuln_attempt_servlet'
 require 'msf/core/web_services/servlet/user_servlet'
 require 'msf/core/web_services/servlet/module_search_servlet'
+require 'msf/core/web_services/servlet/db_import_servlet'
 
 class MetasploitApiApp < Sinatra::Base
   helpers ServletHelper
@@ -51,6 +52,7 @@ class MetasploitApiApp < Sinatra::Base
   register VulnAttemptServlet
   register UserServlet
   register ModuleSearchServlet
+  register DbImportServlet
 
   configure do
     set :sessions, {key: 'msf-ws.session', expire_after: 300}

--- a/lib/msf/core/web_services/servlet/db_import_servlet.rb
+++ b/lib/msf/core/web_services/servlet/db_import_servlet.rb
@@ -1,0 +1,30 @@
+module DbImportServlet
+
+  def self.api_path
+    '/api/v1/db-import'
+  end
+
+  def self.registered(app)
+    app.post DbImportServlet.api_path, &db_import
+  end
+
+  #######
+  private
+  #######
+
+  def self.db_import
+    lambda do
+      warden.authenticate!
+
+      job = lambda do |opts|
+        db_filename = File.basename(opts[:filename])
+        db_local_path = File.join(Msf::Config.local_directory, db_filename)
+        opts[:path] = process_file(opts[:data], db_local_path)
+        get_db.import_file(opts)
+      end
+
+      exec_report_job(request, &job)
+    end
+  end
+
+end


### PR DESCRIPTION
Currently, attempting to do a `db_import` when connected to a remote data service will result in a stack trace. This adds the necessary support to the data service to allow imports to work correctly.

## Verification

- [ ] Start `msfconsole` with a remote data service connection
- [ ] `db_import` some data
- [ ] **Verify** the data appears as expected when running `hosts`, `services`, etc.

Here are some sample exports to test with:
[Sample Exports.zip](https://github.com/rapid7/metasploit-framework/files/2728073/Sample.Exports.zip)
