### PR TITLE
update PR template to ask for unique branch

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,8 @@
 Tell us what this change does. If you're fixing a bug, please mention
 the github issue number.
 
+Please ensure you are submitting **from a unique branch** in your [repository](https://github.com/rapid7/metasploit-framework/pull/11086#issuecomment-445506416) to master in Rapid7's.
+
 ## Verification
 
 List the steps needed to make sure this thing works


### PR DESCRIPTION
Updates the PR template to ask people to submit from a unique branch.

As per: https://github.com/rapid7/metasploit-framework/pull/11086#issuecomment-445540717 and https://github.com/rapid7/metasploit-framework/pull/11086#issuecomment-445544943

I'm not set on this as the fix to the overall behavioral problem, but it is a step in the right direction IMO.