### PR TITLE
Update db_connect Connection Persistence Logic

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -1766,7 +1766,7 @@ class Db
         when '-l', '--list-services'
           list_saved_data_services
           return
-      when '-n', '--name'
+        when '-n', '--name'
           name = args.shift
           if name =~ /\/|\[|\]/
             print_error "Provided name contains an invalid character. Aborting connection."
@@ -2174,7 +2174,6 @@ class Db
     conf.each_pair do |k,v|
       name = k.split('/').last
       rv = name if name == search_criteria
-      rv = name if v.values.include?(search_criteria)
     end
     rv
   end


### PR DESCRIPTION
This PR changes the functionality of the `db_connect` command to no longer match connection info to an existing connection if any of the properties of the connection matches a defined service already in the config file. This fixes issues when updating the connection criteria of a service on a host that you had previously connected to. An example is updating the API token for a connection to `localhost` when you already have the connection details for `localhost` saved in your config file.

The new functionality will save a new, valid connection with a randomly generated name by default. If the `-n` flag is specified it will save the with the value specified. If a connection with that name already exists it will update the connection details in the config file under the same name.

## Verification

- [x] Verify the default behavior for a new setup.
  - [x] Ensure that you do not have any saved data service connections in the `~/.msf4/config` file.
  - [x] Run `msfdb reinit`. Follow the prompts to restore the database and create a new web service connection set as default.
  - [x] Run `msfconsole`. Use `db_connect -l` and `db_status` to verify that you are connected to an HTTPS data service running on localhost and it is saved.
- [x] Verify the `msfdb` script works when changing connection info for the local connection
  - [x] Run `msfdb reinit` again, wiping the DB and data service and then persisting the new connection. 
  - [x] Run `msfconsole` and verify that you are successfully connected to the data service using `db_connect -l` and `db_status`.
  - [x] Check the file at `~/.msf4/config` and verify the connection info is updated with the new token
- [x] Verify that new connections are given unique, randomly generated names.
  - [x] Run `msfdb` on a separate, external server, such as VM.
  - [x] Connect to the remote data service using `db_connect <connection info>`
  - [x] Run `db_connect -l` to verify the connection was persisted with a unique name.
- [x] Verify that you can create a connection with a user-specified name
  - [x] Run `db_disconnect`, verify you are no longer connected with `db_status`, then run `db_connect -n remote_vm_connection <connection info>`. Run `db_connect -l` to verify the connection was created with the name you specified.
- [x] Verify that existing connections are updated properly.
  - [x] Run `msfdb reinit` on the remote VM.
  - [x] In `msfconsole` on your local machine, run `db_connect -n remote_vm_connection <connection info including new token>`. Verify you connect successfully.
  - [x] Run `db_connect -l` and ensure that no new connection was created.
  - [x] Check `~/.msf4/config` and ensure the API token was updated for the `remote_vm_connection` entry.

