### PR TITLE
Add support to msfrpcd for starting JSON-RPC server

### DIFF
--- a/lib/msf/util/service_helper.rb
+++ b/lib/msf/util/service_helper.rb
@@ -1,0 +1,62 @@
+require 'open3'
+
+module Msf
+  module Util
+    class ServiceHelper
+      def self.run_cmd(cmd, input: nil, env: {}, debug: false)
+        exitstatus = 0
+        err = out = ""
+
+        $stdout.puts "run_cmd: cmd=#{cmd}, input=#{input}, env=#{env}" if debug
+
+        Open3.popen3(env, cmd) do |stdin, stdout, stderr, wait_thr|
+          stdin.puts(input) if input
+          if debug
+            err = stderr.read
+            out = stdout.read
+          end
+          exitstatus = wait_thr.value.exitstatus
+        end
+
+        if exitstatus != 0
+          if debug
+            $stdout.puts "'#{cmd}' returned #{exitstatus}"
+            $stdout.puts out
+            $stdout.puts err
+          end
+        end
+
+        exitstatus
+      end
+
+      def self.process_active?(pid)
+        begin
+          Process.kill(0, pid)
+          true
+        rescue Errno::ESRCH
+          false
+        end
+      end
+
+      def self.tail(file)
+        begin
+          File.readlines(file).last.to_s.strip
+        rescue
+          nil
+        end
+      end
+
+      def self.thin_cmd(conf:, address:, port:, ssl:, ssl_key:, ssl_cert:, ssl_disable_verify:,
+                        env: 'production', daemonize:, log:, pid:, tag:)
+        server_opts = "--rackup #{conf} --address #{address} --port #{port}"
+        ssl_opts = ssl ? "--ssl --ssl-key-file #{ssl_key} --ssl-cert-file #{ssl_cert}" : ''
+        ssl_opts << ' --ssl-disable-verify' if ssl_disable_verify
+        adapter_opts = "--environment #{env}"
+        daemon_opts = daemonize ? "--daemonize --log #{log} --pid #{pid} --tag #{tag}" : ''
+        all_opts = [server_opts, ssl_opts, adapter_opts, daemon_opts].reject(&:empty?).join(' ')
+
+        "thin #{all_opts}"
+      end
+    end
+  end
+end

--- a/msfrpcd
+++ b/msfrpcd
@@ -4,52 +4,161 @@
 # $Id$
 #
 # This user interface listens on a port and provides clients that connect to
-# it with an RPC interface to the Metasploit Framework.
+# it with an RPC or JSON-RPC interface to the Metasploit Framework.
 #
 # $Revision$
 #
 
-msfbase = __FILE__
-while File.symlink?(msfbase)
-  msfbase = File.expand_path(File.readlink(msfbase), File.dirname(msfbase))
+RPC_TYPE = 'Msg'
+
+@localconf = "#{ENV['HOME']}/.msf4"
+@ws_tag = 'msf-ws'
+@ws_rpc_tag = 'msf-json-rpc'
+@ws_conf_full_path = nil
+@ws_conf = "#{@ws_rpc_tag}.ru"
+@ws_ssl_key_default = "#{@localconf}/#{@ws_tag}-key.pem"
+@ws_ssl_cert_default = "#{@localconf}/#{@ws_tag}-cert.pem"
+@ws_log = "#{@localconf}/logs/#{@ws_rpc_tag}.log"
+@ws_rpc_pid = "#{@localconf}/#{@ws_rpc_tag}.pid"
+@ws_tag = 'production'
+
+
+def start_json_rpc_service(conf:, address:, port:, ssl:, ssl_key:, ssl_cert:, ssl_disable_verify:, daemonize:)
+  unless File.file?(conf)
+    $stdout.puts "[-] No MSF JSON-RPC web service configuration found at #{conf}, not starting"
+    return false
+  end
+
+  # check if MSF JSON-RPC web service is already started
+  if File.file?(@ws_rpc_pid)
+    ws_pid = Msf::Util::ServiceHelper.tail(@ws_rpc_pid)
+    if ws_pid.nil? || !Msf::Util::ServiceHelper.process_active?(ws_pid.to_i)
+      $stdout.puts "[-] MSF JSON-RPC web service PID file found, but no active process running as PID #{ws_pid}"
+      $stdout.puts "[*] Deleting MSF JSON-RPC web service PID file #{@ws_rpc_pid}"
+      File.delete(@ws_rpc_pid)
+    else
+      $stdout.puts "[*] MSF JSON-RPC web service is already running as PID #{ws_pid}"
+      return false
+    end
+  end
+
+  # attempt to start MSF JSON-RPC service
+  thin_cmd = Msf::Util::ServiceHelper.thin_cmd(conf: conf,
+                                               address: address,
+                                               port: port,
+                                               ssl: ssl,
+                                               ssl_key: ssl_key,
+                                               ssl_cert: ssl_cert,
+                                               ssl_disable_verify: ssl_disable_verify,
+                                               env: @ws_tag,
+                                               daemonize: daemonize,
+                                               log: @ws_log,
+                                               pid: @ws_rpc_pid,
+                                               tag: @ws_rpc_tag)
+  Msf::Util::ServiceHelper.run_cmd("#{thin_cmd} start")
 end
 
-$:.unshift(File.expand_path(File.join(File.dirname(msfbase), 'lib')))
-require 'msfenv'
+def stop_json_rpc_service(conf:, address:, port:, ssl:, ssl_key:, ssl_cert:, ssl_disable_verify:, daemonize:)
+  ws_pid = Msf::Util::ServiceHelper.tail(@ws_rpc_pid)
+  $stdout.puts ''
+  if ws_pid.nil? || !Msf::Util::ServiceHelper.process_active?(ws_pid.to_i)
+    $stdout.puts '[*] MSF JSON-RPC web service is no longer running'
+    if File.file?(@ws_rpc_pid)
+      $stdout.puts "[*] Deleting MSF JSON-RPC web service PID file #{@ws_rpc_pid}"
+      File.delete(@ws_rpc_pid)
+    end
+  else
+    $stdout.puts "[*] Stopping MSF JSON-RPC web service PID #{ws_pid}"
+    thin_cmd = Msf::Util::ServiceHelper.thin_cmd(conf: conf,
+                                      address: address,
+                                      port: port,
+                                      ssl: ssl,
+                                      ssl_key: ssl_key,
+                                      ssl_cert: ssl_cert,
+                                      ssl_disable_verify: ssl_disable_verify,
+                                      env: @ws_tag,
+                                      daemonize: daemonize,
+                                      log: @ws_log,
+                                      pid: @ws_rpc_pid,
+                                      tag: @ws_rpc_tag)
+    Msf::Util::ServiceHelper.run_cmd("#{thin_cmd} stop")
+  end
+end
 
-$:.unshift(ENV['MSF_LOCAL_LIB']) if ENV['MSF_LOCAL_LIB']
+def start_rpc_service(opts, frameworkOpts, foreground)
+  # Fork into the background if requested
+  begin
+    if foreground
+      $stdout.puts "[*] #{RPC_TYPE.upcase}RPC ready at #{Time.now}."
+    else
+      $stderr.puts "[*] #{RPC_TYPE.upcase}RPC backgrounding at #{Time.now}..."
+      exit(0) if Process.fork()
+    end
+  rescue ::NotImplementedError
+    $stderr.puts "[-] Background mode is not available on this platform"
+  end
 
-require 'rex/parser/arguments'
+  # Create an instance of the framework
+  $framework = Msf::Simple::Framework.create(frameworkOpts)
 
-# Declare the argument parser for msfrpcd
-arguments = Rex::Parser::Arguments.new(
-  "-a" => [ true,  "Bind to this IP address"                              ],
-  "-p" => [ true,  "Bind to this port instead of 55553"                   ],
-  "-U" => [ true,  "Specify the username to access msfrpcd"               ],
-  "-P" => [ true,  "Specify the password to access msfrpcd"               ],
-  "-u" => [ true,  "URI for Web server"                                   ],
-  "-t" => [ true,  "Token Timeout (default 300 seconds"                   ],
-  "-S" => [ false, "Disable SSL on the RPC socket"                        ],
-  "-f" => [ false, "Run the daemon in the foreground"                     ],
-  "-n" => [ false, "Disable database"                                     ],
-  "-h" => [ false, "Help banner"                                          ])
-
-opts = {
-  'RunInForeground' => true,
-  'SSL'             => true,
-  'ServerHost'      => '0.0.0.0',
-  'ServerPort'      => 55553,
-  'ServerType'      => 'Msg',
-  'TokenTimeout'    => 300,
-}
-
-foreground = false
-frameworkOpts = {}
+  # Run the plugin instance in the foreground.
+  begin
+    $framework.plugins.load("#{RPC_TYPE.downcase}rpc", opts).run
+  rescue ::Interrupt
+    $stderr.puts "[*] Shutting down"
+  end
+end
 
 
-# Parse command line arguments.
-arguments.parse(ARGV) { |opt, idx, val|
-  case opt
+if $PROGRAM_NAME == __FILE__
+  msfbase = __FILE__
+  while File.symlink?(msfbase)
+    msfbase = File.expand_path(File.readlink(msfbase), File.dirname(msfbase))
+  end
+
+  $:.unshift(File.expand_path(File.join(File.dirname(msfbase), 'lib')))
+  require 'msfenv'
+
+  $:.unshift(ENV['MSF_LOCAL_LIB']) if ENV['MSF_LOCAL_LIB']
+
+  require 'rex/parser/arguments'
+
+  opts = {
+      'RunInForeground' => true,
+      'SSL'             => true,
+      'ServerHost'      => '0.0.0.0',
+      'ServerPort'      => 55553,
+      'ServerType'      => RPC_TYPE,
+      'TokenTimeout'    => 300,
+  }
+
+  # Declare the argument parser for msfrpcd
+  arguments = Rex::Parser::Arguments.new(
+      "-a" => [ true,  "Bind to this IP address (default: #{opts['ServerHost']})"          ],
+      "-p" => [ true,  "Bind to this port (default: #{opts['ServerPort']})"                ],
+      "-U" => [ true,  "Specify the username to access msfrpcd"                            ],
+      "-P" => [ true,  "Specify the password to access msfrpcd"                            ],
+      "-u" => [ true,  "URI for Web server"                                                ],
+      "-t" => [ true,  "Token Timeout seconds (default: #{opts['TokenTimeout']})"          ],
+      "-S" => [ false, "Disable SSL on the RPC socket"                                     ],
+      "-f" => [ false, "Run the daemon in the foreground"                                  ],
+      "-n" => [ false, "Disable database"                                                  ],
+      "-j" => [ false, "(JSON-RPC) Start JSON-RPC server"                                  ],
+      "-k" => [ false, "(JSON-RPC) Path to private key (default: #{@ws_ssl_key_default})"  ],
+      "-c" => [ false, "(JSON-RPC) Path to certificate (default: #{@ws_ssl_cert_default})" ],
+      "-v" => [ false, "(JSON-RPC) SSL enable verify (optional) client cert requests"      ],
+      "-h" => [ false, "Help banner"                                                       ])
+
+  foreground = false
+  json_rpc = false
+  ssl_enable_verify = false
+  ws_ssl_key = @ws_ssl_key_default
+  ws_ssl_cert = @ws_ssl_cert_default
+  frameworkOpts = {}
+
+  # Parse command line arguments.
+  arguments.parse(ARGV) { |opt, idx, val|
+    case opt
     when "-a"
       opts['ServerHost'] = val
     when "-S"
@@ -68,47 +177,67 @@ arguments.parse(ARGV) { |opt, idx, val|
       opts['URI'] = val
     when "-n"
       frameworkOpts['DisableDatabase'] = true
+    when "-j"
+      json_rpc = true
+    when "-k"
+      ws_ssl_key = val
+    when "-c"
+      ws_ssl_cert = val
+    when "-v"
+      ssl_enable_verify = true
     when "-h"
       print("\nUsage: #{File.basename(__FILE__)} <options>\n" +	arguments.usage)
       exit
+    end
+  }
+
+  $0 = "msfrpcd"
+
+  require 'msf/base'
+  require 'msf/ui'
+  require 'msf/util/service_helper'
+
+  begin
+    if json_rpc
+
+      if !File.file?(@ws_ssl_key_default) || !File.file?(@ws_ssl_cert_default)
+        $stdout.puts "[-] It doesn't appear msfdb has been run; please run 'msfdb init' first."
+        abort
+      end
+
+      $stderr.puts "[*] JSON-RPC starting on #{opts['ServerHost']}:#{opts['ServerPort']} (#{opts['SSL'] ? "SSL" : "NO SSL"})..."
+      $stderr.puts "[*] URI: /api/<version>/json-rpc"
+      $stderr.puts "[*] JSON-RPC server log: #{@ws_log}" unless foreground
+
+      ws_conf_full_path = File.expand_path(File.join(File.dirname(msfbase), @ws_conf))
+
+      start_json_rpc_service(conf: ws_conf_full_path,
+                             address: opts['ServerHost'],
+                             port: opts['ServerPort'],
+                             ssl: opts['SSL'],
+                             ssl_key: ws_ssl_key,
+                             ssl_cert: ws_ssl_cert,
+                             ssl_disable_verify: !ssl_enable_verify,
+                             daemonize: !foreground)
+    else
+      unless opts['Pass']
+        $stderr.puts "[-] Error: a password must be specified (-P)"
+        exit(0)
+      end
+
+      $stderr.puts "[*] #{RPC_TYPE.upcase}RPC starting on #{opts['ServerHost']}:#{opts['ServerPort']} (#{opts['SSL'] ? "SSL" : "NO SSL"}):#{opts['ServerType']}..."
+      $stderr.puts "[*] URI: #{opts['URI']}" if opts['URI']
+
+      start_rpc_service(opts, frameworkOpts, foreground)
+    end
+  rescue ::Interrupt
+    stop_json_rpc_service(conf: ws_conf_full_path,
+                          address: opts['ServerHost'],
+                          port: opts['ServerPort'],
+                          ssl: opts['SSL'],
+                          ssl_key: ws_ssl_key,
+                          ssl_cert: ws_ssl_cert,
+                          ssl_disable_verify: !ssl_enable_verify,
+                          daemonize: !foreground) if json_rpc
   end
-}
-
-unless opts['Pass']
-  $stderr.puts "[-] Error: a password must be specified (-P)"
-  exit(0)
-end
-
-$0 = "msfrpcd"
-
-rpctype = 'MSG'
-
-$stderr.puts "[*] #{rpctype}RPC starting on #{opts['ServerHost']}:#{opts['ServerPort']} (#{opts['SSL'] ? "SSL" : "NO SSL"}):#{opts['ServerType']}..."
-
-$stderr.puts "[*] URI: #{opts['URI']}" if opts['URI']
-
-require 'msf/base'
-require 'msf/ui'
-
-
-# Fork into the background if requested
-begin
-  if foreground
-    $stdout.puts "[*] #{rpctype}RPC ready at #{Time.now}."
-  else
-    $stderr.puts "[*] #{rpctype}RPC backgrounding at #{Time.now}..."
-    exit(0) if Process.fork()
-  end
-rescue ::NotImplementedError
-  $stderr.puts "[-] Background mode is not available on this platform"
-end
-
-# Create an instance of the framework
-$framework = Msf::Simple::Framework.create(frameworkOpts)
-
-# Run the plugin instance in the foreground.
-begin
-  $framework.plugins.load("#{rpctype.downcase}rpc", opts).run
-rescue ::Interrupt
-  $stderr.puts "[*] Shutting down"
 end

--- a/msfrpcd
+++ b/msfrpcd
@@ -87,7 +87,11 @@ def start_rpc_service(opts, frameworkOpts, foreground)
       $stdout.puts "[*] #{RPC_TYPE.upcase}RPC ready at #{Time.now}."
     else
       $stderr.puts "[*] #{RPC_TYPE.upcase}RPC backgrounding at #{Time.now}..."
-      exit(0) if Process.fork()
+      child_pid = Process.fork()
+      if child_pid
+        $stderr.puts "[*] #{RPC_TYPE.upcase}RPC background PID #{child_pid}"
+        exit(0)
+      end
     end
   rescue ::NotImplementedError
     $stderr.puts "[-] Background mode is not available on this platform"
@@ -207,6 +211,7 @@ if $PROGRAM_NAME == __FILE__
       $stderr.puts "[*] JSON-RPC starting on #{opts['ServerHost']}:#{opts['ServerPort']} (#{opts['SSL'] ? "SSL" : "NO SSL"})..."
       $stderr.puts "[*] URI: /api/v1/json-rpc"
       $stderr.puts "[*] JSON-RPC server log: #{ws_log}" unless foreground
+      $stderr.puts "[*] JSON-RPC server PID file: #{ws_rpc_pid}" unless foreground
 
       ws_conf_full_path = File.expand_path(File.join(File.dirname(msfbase), WS_CONF))
 

--- a/msfrpcd
+++ b/msfrpcd
@@ -20,7 +20,7 @@ RPC_TYPE = 'Msg'
 @ws_ssl_cert_default = "#{@localconf}/#{@ws_tag}-cert.pem"
 @ws_log = "#{@localconf}/logs/#{@ws_rpc_tag}.log"
 @ws_rpc_pid = "#{@localconf}/#{@ws_rpc_tag}.pid"
-@ws_tag = 'production'
+@ws_env = 'production'
 
 
 def start_json_rpc_service(conf:, address:, port:, ssl:, ssl_key:, ssl_cert:, ssl_disable_verify:, daemonize:)
@@ -50,7 +50,7 @@ def start_json_rpc_service(conf:, address:, port:, ssl:, ssl_key:, ssl_cert:, ss
                                                ssl_key: ssl_key,
                                                ssl_cert: ssl_cert,
                                                ssl_disable_verify: ssl_disable_verify,
-                                               env: @ws_tag,
+                                               env: @ws_env,
                                                daemonize: daemonize,
                                                log: @ws_log,
                                                pid: @ws_rpc_pid,
@@ -76,7 +76,7 @@ def stop_json_rpc_service(conf:, address:, port:, ssl:, ssl_key:, ssl_cert:, ssl
                                       ssl_key: ssl_key,
                                       ssl_cert: ssl_cert,
                                       ssl_disable_verify: ssl_disable_verify,
-                                      env: @ws_tag,
+                                      env: @ws_env,
                                       daemonize: daemonize,
                                       log: @ws_log,
                                       pid: @ws_rpc_pid,

--- a/msfrpcd
+++ b/msfrpcd
@@ -206,7 +206,7 @@ if $PROGRAM_NAME == __FILE__
       end
 
       $stderr.puts "[*] JSON-RPC starting on #{opts['ServerHost']}:#{opts['ServerPort']} (#{opts['SSL'] ? "SSL" : "NO SSL"})..."
-      $stderr.puts "[*] URI: /api/<version>/json-rpc"
+      $stderr.puts "[*] URI: /api/v1/json-rpc"
       $stderr.puts "[*] JSON-RPC server log: #{@ws_log}" unless foreground
 
       ws_conf_full_path = File.expand_path(File.join(File.dirname(msfbase), @ws_conf))

--- a/msfrpcd
+++ b/msfrpcd
@@ -10,32 +10,26 @@
 #
 
 RPC_TYPE = 'Msg'
-
-@localconf = "#{ENV['HOME']}/.msf4"
-@ws_tag = 'msf-ws'
-@ws_rpc_tag = 'msf-json-rpc'
-@ws_conf_full_path = nil
-@ws_conf = "#{@ws_rpc_tag}.ru"
-@ws_ssl_key_default = "#{@localconf}/#{@ws_tag}-key.pem"
-@ws_ssl_cert_default = "#{@localconf}/#{@ws_tag}-cert.pem"
-@ws_log = "#{@localconf}/logs/#{@ws_rpc_tag}.log"
-@ws_rpc_pid = "#{@localconf}/#{@ws_rpc_tag}.pid"
-@ws_env = 'production'
+WS_TAG = 'msf-ws'
+WS_RPC_TAG = 'msf-json-rpc'
+WS_CONF = "#{WS_RPC_TAG}.ru"
+WS_ENV = 'production'
 
 
-def start_json_rpc_service(conf:, address:, port:, ssl:, ssl_key:, ssl_cert:, ssl_disable_verify:, daemonize:)
+def start_json_rpc_service(conf:, address:, port:, ssl:, ssl_key:, ssl_cert:,
+                           ssl_disable_verify:, daemonize:, log:, pid:)
   unless File.file?(conf)
     $stdout.puts "[-] No MSF JSON-RPC web service configuration found at #{conf}, not starting"
     return false
   end
 
   # check if MSF JSON-RPC web service is already started
-  if File.file?(@ws_rpc_pid)
-    ws_pid = Msf::Util::ServiceHelper.tail(@ws_rpc_pid)
+  if File.file?(pid)
+    ws_pid = Msf::Util::ServiceHelper.tail(pid)
     if ws_pid.nil? || !Msf::Util::ServiceHelper.process_active?(ws_pid.to_i)
       $stdout.puts "[-] MSF JSON-RPC web service PID file found, but no active process running as PID #{ws_pid}"
-      $stdout.puts "[*] Deleting MSF JSON-RPC web service PID file #{@ws_rpc_pid}"
-      File.delete(@ws_rpc_pid)
+      $stdout.puts "[*] Deleting MSF JSON-RPC web service PID file #{pid}"
+      File.delete(pid)
     else
       $stdout.puts "[*] MSF JSON-RPC web service is already running as PID #{ws_pid}"
       return false
@@ -50,22 +44,23 @@ def start_json_rpc_service(conf:, address:, port:, ssl:, ssl_key:, ssl_cert:, ss
                                                ssl_key: ssl_key,
                                                ssl_cert: ssl_cert,
                                                ssl_disable_verify: ssl_disable_verify,
-                                               env: @ws_env,
+                                               env: WS_ENV,
                                                daemonize: daemonize,
-                                               log: @ws_log,
-                                               pid: @ws_rpc_pid,
-                                               tag: @ws_rpc_tag)
+                                               log: log,
+                                               pid: pid,
+                                               tag: WS_RPC_TAG)
   Msf::Util::ServiceHelper.run_cmd("#{thin_cmd} start")
 end
 
-def stop_json_rpc_service(conf:, address:, port:, ssl:, ssl_key:, ssl_cert:, ssl_disable_verify:, daemonize:)
-  ws_pid = Msf::Util::ServiceHelper.tail(@ws_rpc_pid)
+def stop_json_rpc_service(conf:, address:, port:, ssl:, ssl_key:, ssl_cert:,
+                          ssl_disable_verify:, daemonize:, log:, pid:)
+  ws_pid = Msf::Util::ServiceHelper.tail(pid)
   $stdout.puts ''
   if ws_pid.nil? || !Msf::Util::ServiceHelper.process_active?(ws_pid.to_i)
     $stdout.puts '[*] MSF JSON-RPC web service is no longer running'
-    if File.file?(@ws_rpc_pid)
-      $stdout.puts "[*] Deleting MSF JSON-RPC web service PID file #{@ws_rpc_pid}"
-      File.delete(@ws_rpc_pid)
+    if File.file?(pid)
+      $stdout.puts "[*] Deleting MSF JSON-RPC web service PID file #{pid}"
+      File.delete(pid)
     end
   else
     $stdout.puts "[*] Stopping MSF JSON-RPC web service PID #{ws_pid}"
@@ -76,11 +71,11 @@ def stop_json_rpc_service(conf:, address:, port:, ssl:, ssl_key:, ssl_cert:, ssl
                                       ssl_key: ssl_key,
                                       ssl_cert: ssl_cert,
                                       ssl_disable_verify: ssl_disable_verify,
-                                      env: @ws_env,
+                                      env: WS_ENV,
                                       daemonize: daemonize,
-                                      log: @ws_log,
-                                      pid: @ws_rpc_pid,
-                                      tag: @ws_rpc_tag)
+                                      log: log,
+                                      pid: pid,
+                                      tag: WS_RPC_TAG)
     Msf::Util::ServiceHelper.run_cmd("#{thin_cmd} stop")
   end
 end
@@ -121,7 +116,22 @@ if $PROGRAM_NAME == __FILE__
 
   $:.unshift(ENV['MSF_LOCAL_LIB']) if ENV['MSF_LOCAL_LIB']
 
+  require 'msf/base'
+  require 'msf/ui'
+  require 'msf/util/service_helper'
+  require 'msf/base/config'
   require 'rex/parser/arguments'
+
+  ws_ssl_key_default = File.join(Msf::Config.get_config_root, "#{WS_TAG}-key.pem")
+  ws_ssl_cert_default = File.join(Msf::Config.get_config_root, "#{WS_TAG}-cert.pem")
+  ws_log = File.join(Msf::Config.get_config_root, 'logs', "#{WS_RPC_TAG}.log")
+  ws_rpc_pid = File.join(Msf::Config.get_config_root, "#{WS_RPC_TAG}.pid")
+  ws_ssl_key = ws_ssl_key_default
+  ws_ssl_cert = ws_ssl_cert_default
+  ssl_enable_verify = false
+  foreground = false
+  json_rpc = false
+  frameworkOpts = {}
 
   opts = {
       'RunInForeground' => true,
@@ -144,17 +154,10 @@ if $PROGRAM_NAME == __FILE__
       "-f" => [ false, "Run the daemon in the foreground"                                  ],
       "-n" => [ false, "Disable database"                                                  ],
       "-j" => [ false, "(JSON-RPC) Start JSON-RPC server"                                  ],
-      "-k" => [ false, "(JSON-RPC) Path to private key (default: #{@ws_ssl_key_default})"  ],
-      "-c" => [ false, "(JSON-RPC) Path to certificate (default: #{@ws_ssl_cert_default})" ],
+      "-k" => [ false, "(JSON-RPC) Path to private key (default: #{ws_ssl_key_default})"   ],
+      "-c" => [ false, "(JSON-RPC) Path to certificate (default: #{ws_ssl_cert_default})"  ],
       "-v" => [ false, "(JSON-RPC) SSL enable verify (optional) client cert requests"      ],
       "-h" => [ false, "Help banner"                                                       ])
-
-  foreground = false
-  json_rpc = false
-  ssl_enable_verify = false
-  ws_ssl_key = @ws_ssl_key_default
-  ws_ssl_cert = @ws_ssl_cert_default
-  frameworkOpts = {}
 
   # Parse command line arguments.
   arguments.parse(ARGV) { |opt, idx, val|
@@ -193,23 +196,19 @@ if $PROGRAM_NAME == __FILE__
 
   $0 = "msfrpcd"
 
-  require 'msf/base'
-  require 'msf/ui'
-  require 'msf/util/service_helper'
-
   begin
     if json_rpc
 
-      if !File.file?(@ws_ssl_key_default) || !File.file?(@ws_ssl_cert_default)
+      if !File.file?(ws_ssl_key_default) || !File.file?(ws_ssl_cert_default)
         $stdout.puts "[-] It doesn't appear msfdb has been run; please run 'msfdb init' first."
         abort
       end
 
       $stderr.puts "[*] JSON-RPC starting on #{opts['ServerHost']}:#{opts['ServerPort']} (#{opts['SSL'] ? "SSL" : "NO SSL"})..."
       $stderr.puts "[*] URI: /api/v1/json-rpc"
-      $stderr.puts "[*] JSON-RPC server log: #{@ws_log}" unless foreground
+      $stderr.puts "[*] JSON-RPC server log: #{ws_log}" unless foreground
 
-      ws_conf_full_path = File.expand_path(File.join(File.dirname(msfbase), @ws_conf))
+      ws_conf_full_path = File.expand_path(File.join(File.dirname(msfbase), WS_CONF))
 
       start_json_rpc_service(conf: ws_conf_full_path,
                              address: opts['ServerHost'],
@@ -218,7 +217,9 @@ if $PROGRAM_NAME == __FILE__
                              ssl_key: ws_ssl_key,
                              ssl_cert: ws_ssl_cert,
                              ssl_disable_verify: !ssl_enable_verify,
-                             daemonize: !foreground)
+                             daemonize: !foreground,
+                             log: ws_log,
+                             pid: ws_rpc_pid)
     else
       unless opts['Pass']
         $stderr.puts "[-] Error: a password must be specified (-P)"
@@ -238,6 +239,8 @@ if $PROGRAM_NAME == __FILE__
                           ssl_key: ws_ssl_key,
                           ssl_cert: ws_ssl_cert,
                           ssl_disable_verify: !ssl_enable_verify,
-                          daemonize: !foreground) if json_rpc
+                          daemonize: !foreground,
+                          log: ws_log,
+                          pid: ws_rpc_pid) if json_rpc
   end
 end


### PR DESCRIPTION
Adds support to `msfrpcd` for starting the JSON-RPC server introduced in #10682.

## Verification
- [x] Run `msfdb` if you do not already have an initialized web service; otherwise, you will need your API token.
- [x] Start the JSON-RPC server on localhost:8081 in the foreground using `msfrpcd`: `./msfrpcd -j -a localhost -p 8081 -f`
- [x] Test RPC v1.0 (v10) core method `core.version`
- [x] Use cURL to execute the RPC method: `curl -k -X POST -H "Accept: application/json" -H "Content-Type: application/json" -H "Authorization: Bearer <token>" -d '{"jsonrpc": "2.0", "method": "core.version", "id": 1 }' https://localhost:8081/api/v1/json-rpc | python -m json.tool`
- [x] **Verify** the JSON-RPC response contains the expected result
- [x] Press `Ctrl-C` to terminate the foreground JSON-RPC server
- [x] Explore other JSON-RPC options for `msfrpcd`
- [x] **Verify** the JSON-RPC server responds accordingly
- [x] Start `msfrpcd` without the `-j` flag
- [x] **Verify** the MSFRPC mode of `msfrpcd` operates as it did before