### PR TITLE
Fix syntax in "badpdf" module

### DIFF
--- a/modules/auxiliary/fileformat/badpdf.rb
+++ b/modules/auxiliary/fileformat/badpdf.rb
@@ -46,7 +46,7 @@ class MetasploitModule < Msf::Auxiliary
     elsif !datastore['FILENAME'].nil? && datastore['FILENAME'].to_s.end_with?('.pdf')
       createpdf
     else
-      print_error 'FILENAME or PDFINJECT must end with '.pdf' file extension'
+      print_error "FILENAME or PDFINJECT must end with '.pdf' file extension"
     end
   end
 


### PR DESCRIPTION
Fixes a bug in the `badpdf` module with single quotes used in a single quotes string which is a syntax error

## Quick bug repro
- launch msfconsole
- `use auxiliary/fileformat/badpdf`
- `set LHOST 127.0.0.1`
- `run`
Will trigger:
```
[-] Auxiliary failed: NoMethodError undefined method `pdf' for "FILENAME or PDFINJECT must end with ":String
[-] Call stack:
[-]   /usr/share/metasploit-framework/modules/auxiliary/fileformat/badpdf.rb:49:in `run'
```

## With fix applied
```
msf auxiliary(fileformat/badpdf) > run

[-] FILENAME or PDFINJECT must end with '.pdf' file extension
```