### PR TITLE
auxiliary/fileformat/badpdf: fix syntax and logic error in options handling

### DIFF
--- a/modules/auxiliary/fileformat/badpdf.rb
+++ b/modules/auxiliary/fileformat/badpdf.rb
@@ -39,14 +39,14 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    if datastore['PDFINJECT'].to_s.end_with?('.pdf') && datastore['FILENAME'].to_s.end_with?('.pdf')
+    if datastore['PDFINJECT'].nil? && datastore['FILENAME'].nil?
       print_error 'Please configure either FILENAME or PDFINJECT'
     elsif !datastore['PDFINJECT'].nil? && datastore['PDFINJECT'].to_s.end_with?('.pdf')
       injectpdf
     elsif !datastore['FILENAME'].nil? && datastore['FILENAME'].to_s.end_with?('.pdf')
       createpdf
     else
-      print_error 'FILENAME or PDFINJECT must end with '.pdf' file extension'
+      print_error "FILENAME or PDFINJECT must end with '.pdf' file extension"
     end
   end
 


### PR DESCRIPTION
Fixes a logic error in the handling of null options.
Related to @bcoles comment in original PR: https://github.com/rapid7/metasploit-framework/pull/10148#discussion_r194248002

## Before patch
Setup:
```
msf auxiliary(fileformat/badpdf) > options 

Module options (auxiliary/fileformat/badpdf):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   FILENAME                    no        Filename
   LHOST      127.0.0.1        yes       Host listening for incoming SMB/WebDAV traffic
   PDFINJECT                   no        Path and filename to existing PDF to inject UNC link code into
```
`FILENAME` and `PDFINJECT` empty, it should say to fill one but instead it complains about the extension:
```
msf auxiliary(fileformat/badpdf) > run

[-] FILENAME or PDFINJECT must end with '.pdf' file extension
[*] Auxiliary module execution completed
```

Same message when the extension is missing, but it's correct this time:
```
msf auxiliary(fileformat/badpdf) > set FILENAME a
FILENAME => a
msf auxiliary(fileformat/badpdf) > run

[-] FILENAME or PDFINJECT must end with '.pdf' file extension
[*] Auxiliary module execution completed
```
It works when everything is good:
```
msf auxiliary(fileformat/badpdf) > set FILENAME a.pdf
FILENAME => a.pdf
msf auxiliary(fileformat/badpdf) > run

[+] a.pdf stored at /root/.msf4/local/a.pdf
[*] Auxiliary module execution completed
```
## After patch
Same setup:
```
msf auxiliary(fileformat/badpdf) > options 

Module options (auxiliary/fileformat/badpdf):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   FILENAME                    no        Filename
   LHOST      127.0.0.1        yes       Host listening for incoming SMB/WebDAV traffic
   PDFINJECT                   no        Path and filename to existing PDF to inject UNC link code into
```

When  both FILENAME and PDFINJECT are empty, it says to configure one:
```
msf auxiliary(fileformat/badpdf) > run

[-] Please configure either FILENAME or PDFINJECT
[*] Auxiliary module execution completed
```

If one is configured, but with missing extension, it says to add it:
```
msf auxiliary(fileformat/badpdf) > set FILENAME a
FILENAME => a
msf auxiliary(fileformat/badpdf) > run

[-] FILENAME or PDFINJECT must end with '.pdf' file extension
[*] Auxiliary module execution completed
```

Still works fine when everything is good:
```
msf auxiliary(fileformat/badpdf) > set FILENAME a.pdf
FILENAME => a.pdf
msf auxiliary(fileformat/badpdf) > run

[+] a.pdf stored at /root/.msf4/local/a.pdf
[*] Auxiliary module execution completed
```


## Syntax fix
This also fixes a syntax error with single-quotes used in a single-quotes string which triggers:
```
[-] Auxiliary failed: NoMethodError undefined method `pdf' for "FILENAME or PDFINJECT must end with ":String
[-] Call stack:
[-]   /usr/share/metasploit-framework/modules/auxiliary/fileformat/badpdf.rb:49:in `run'
```