### PR TITLE
Improve misleading update() actions from db_manager

### DIFF
--- a/lib/msf/core/db_manager/cred.rb
+++ b/lib/msf/core/db_manager/cred.rb
@@ -263,7 +263,7 @@ module Msf::DBManager::Cred
 
       id = opts.delete(:id)
       cred = Metasploit::Credential::Core.find(id)
-      cred.update(opts)
+      cred.update!(opts)
     }
   end
 

--- a/lib/msf/core/db_manager/cred.rb
+++ b/lib/msf/core/db_manager/cred.rb
@@ -264,6 +264,7 @@ module Msf::DBManager::Cred
       id = opts.delete(:id)
       cred = Metasploit::Credential::Core.find(id)
       cred.update!(opts)
+      return cred
     }
   end
 

--- a/lib/msf/core/db_manager/cred.rb
+++ b/lib/msf/core/db_manager/cred.rb
@@ -262,7 +262,8 @@ module Msf::DBManager::Cred
       end
 
       id = opts.delete(:id)
-      Metasploit::Credential::Core.update(id, opts)
+      cred = Metasploit::Credential::Core.find(id)
+      cred.update(opts)
     }
   end
 

--- a/lib/msf/core/db_manager/host.rb
+++ b/lib/msf/core/db_manager/host.rb
@@ -283,7 +283,8 @@ module Msf::DBManager::Host
       opts[:workspace] = wspace if wspace
 
       id = opts.delete(:id)
-      Mdm::Host.update(id, opts)
+      host = Mdm::Host.find(id)
+      host.update!(opts)
     }
   end
 

--- a/lib/msf/core/db_manager/host.rb
+++ b/lib/msf/core/db_manager/host.rb
@@ -285,6 +285,7 @@ module Msf::DBManager::Host
       id = opts.delete(:id)
       host = Mdm::Host.find(id)
       host.update!(opts)
+      return host
     }
   end
 

--- a/lib/msf/core/db_manager/login.rb
+++ b/lib/msf/core/db_manager/login.rb
@@ -12,6 +12,7 @@ module Msf::DBManager::Login
       id = opts.delete(:id)
       login = Metasploit::Credential::Login.find(id)
       login.update!(opts)
+      return login
     }
   end
 

--- a/lib/msf/core/db_manager/login.rb
+++ b/lib/msf/core/db_manager/login.rb
@@ -10,7 +10,8 @@ module Msf::DBManager::Login
       wspace = Msf::Util::DBManager.process_opts_workspace(opts, framework, false)
       opts[:workspace] = wspace if wspace
       id = opts.delete(:id)
-      Metasploit::Credential::Login.update(id, opts)
+      login = Metasploit::Credential::Login.find(id)
+      login.update!(opts)
     }
   end
 

--- a/lib/msf/core/db_manager/loot.rb
+++ b/lib/msf/core/db_manager/loot.rb
@@ -102,7 +102,8 @@ module Msf::DBManager::Loot
       opts[:workspace] = wspace if wspace
 
       id = opts.delete(:id)
-      Mdm::Loot.update(id, opts)
+      loot = Mdm::Loot.find(id)
+      loot.update!(opts)
     }
   end
 

--- a/lib/msf/core/db_manager/loot.rb
+++ b/lib/msf/core/db_manager/loot.rb
@@ -104,6 +104,7 @@ module Msf::DBManager::Loot
       id = opts.delete(:id)
       loot = Mdm::Loot.find(id)
       loot.update!(opts)
+      return loot
     }
   end
 

--- a/lib/msf/core/db_manager/note.rb
+++ b/lib/msf/core/db_manager/note.rb
@@ -200,7 +200,8 @@ module Msf::DBManager::Note
       opts[:workspace] = wspace if wspace
 
       id = opts.delete(:id)
-      Mdm::Note.update(id, opts)
+      note = Mdm::Note.find(id)
+      note.update!(opts)
     }
   end
 

--- a/lib/msf/core/db_manager/note.rb
+++ b/lib/msf/core/db_manager/note.rb
@@ -202,6 +202,7 @@ module Msf::DBManager::Note
       id = opts.delete(:id)
       note = Mdm::Note.find(id)
       note.update!(opts)
+      return note
     }
   end
 

--- a/lib/msf/core/db_manager/service.rb
+++ b/lib/msf/core/db_manager/service.rb
@@ -170,7 +170,8 @@ module Msf::DBManager::Service
 
   ::ActiveRecord::Base.connection_pool.with_connection {
     id = opts.delete(:id)
-    Mdm::Service.update(id, opts)
+    service = Mdm::Service.find(id)
+    service.update!(opts)
   }
   end
 end

--- a/lib/msf/core/db_manager/service.rb
+++ b/lib/msf/core/db_manager/service.rb
@@ -172,6 +172,7 @@ module Msf::DBManager::Service
     id = opts.delete(:id)
     service = Mdm::Service.find(id)
     service.update!(opts)
+    return service
   }
   end
 end

--- a/lib/msf/core/db_manager/session.rb
+++ b/lib/msf/core/db_manager/session.rb
@@ -188,7 +188,8 @@ module Msf::DBManager::Session
 
     ::ActiveRecord::Base.connection_pool.with_connection {
       id = opts.delete(:id)
-      ::Mdm::Session.update(id, opts)
+      session = ::Mdm::Session.find(id)
+      session.update!(opts)
     }
   end
 

--- a/lib/msf/core/db_manager/session.rb
+++ b/lib/msf/core/db_manager/session.rb
@@ -190,6 +190,7 @@ module Msf::DBManager::Session
       id = opts.delete(:id)
       session = ::Mdm::Session.find(id)
       session.update!(opts)
+      return session
     }
   end
 

--- a/lib/msf/core/db_manager/user.rb
+++ b/lib/msf/core/db_manager/user.rb
@@ -77,6 +77,7 @@ module Msf::DBManager::User
       id = opts.delete(:id)
       user = Mdm::User.find(id)
       user.update!(opts)
+      return user
     }
   end
 
@@ -135,7 +136,8 @@ module Msf::DBManager::User
     token_length = opts[:token_length] || MIN_TOKEN_LENGTH
     # NOTE: repurposing persistence_token in the database as the API token
     user = Mdm::User.find(opts[:id])
-    user.update!({persistence_token: SecureRandom.hex(token_length)}).persistence_token
+    user.update!({persistence_token: SecureRandom.hex(token_length)})
+    user.persistence_token
   end
 
 end

--- a/lib/msf/core/db_manager/user.rb
+++ b/lib/msf/core/db_manager/user.rb
@@ -75,7 +75,8 @@ module Msf::DBManager::User
   def update_user(opts)
     ::ActiveRecord::Base.connection_pool.with_connection {
       id = opts.delete(:id)
-      Mdm::User.update(id, opts)
+      user = Mdm::User.find(id)
+      user.update!(opts)
     }
   end
 
@@ -133,7 +134,8 @@ module Msf::DBManager::User
 
     token_length = opts[:token_length] || MIN_TOKEN_LENGTH
     # NOTE: repurposing persistence_token in the database as the API token
-    Mdm::User.update(opts[:id], {persistence_token: SecureRandom.hex(token_length)}).persistence_token
+    user = Mdm::User.find(opts[:id])
+    user.update!({persistence_token: SecureRandom.hex(token_length)}).persistence_token
   end
 
 end

--- a/lib/msf/core/db_manager/vuln_detail.rb
+++ b/lib/msf/core/db_manager/vuln_detail.rb
@@ -26,7 +26,7 @@ module Msf::DBManager::VulnDetail
   ::ActiveRecord::Base.connection_pool.with_connection {
     criteria = details.delete(:key) || {}
     vuln_detail = ::Mdm::VulnDetail.find(key)
-    vuln_detail.update!(details)
+    vuln_detail.update!(criteria)
   }
   end
 end

--- a/lib/msf/core/db_manager/vuln_detail.rb
+++ b/lib/msf/core/db_manager/vuln_detail.rb
@@ -27,6 +27,7 @@ module Msf::DBManager::VulnDetail
     criteria = details.delete(:key) || {}
     vuln_detail = ::Mdm::VulnDetail.find(key)
     vuln_detail.update!(criteria)
+    return vuln_detail
   }
   end
 end

--- a/lib/msf/core/db_manager/vuln_detail.rb
+++ b/lib/msf/core/db_manager/vuln_detail.rb
@@ -25,7 +25,8 @@ module Msf::DBManager::VulnDetail
   def update_vuln_details(details)
   ::ActiveRecord::Base.connection_pool.with_connection {
     criteria = details.delete(:key) || {}
-    ::Mdm::VulnDetail.update(key, details)
+    vuln_detail = ::Mdm::VulnDetail.find(key)
+    vuln_detail.update!(details)
   }
   end
 end

--- a/lib/msf/core/db_manager/workspace.rb
+++ b/lib/msf/core/db_manager/workspace.rb
@@ -99,7 +99,7 @@ module Msf::DBManager::Workspace
     ::ActiveRecord::Base.connection_pool.with_connection {
       ws_to_update = workspaces({ id: opts.delete(:id) }).first
       default_renamed = true if ws_to_update.name == DEFAULT_WORKSPACE_NAME
-      updated_ws = Mdm::Workspace.update(ws_to_update.id, opts)
+      updated_ws = ws_to_update.update!(opts)
       add_workspace({ name: DEFAULT_WORKSPACE_NAME }) if default_renamed
       updated_ws
     }


### PR DESCRIPTION
Find all instances where `Mdm::Xxx::update()` is called and replace them with an `update!()` call on an _instance_ of the object, instead of calling directly from the `Mdm` class.

From the original bug report (MS-3082): 
> Calling `Mdm::<Model>.update(<id>, <changes>)` on an ActiveRecord model does not raise an exception if validations fail for the updated attributes. To the user it looks like the update goes through successfully, but the new data is never stored in the database. We need to change this to better display to the user why their data is not being saved.

This happens locally, as well as through the API (MS-3675): 
> Calling the `update_*` method on a given model is not correctly returning error information when the update fails. Worse, it actually returns what looks to be a useable object back, which creates even more confusion. 

## Verification

- [x] `./msfdb start`
- [x] Go to `https://localhost:8080/api/v1/api-docs`
- [x] Authenticate with api key

### Test host
- [x] Add a host [POST]
- [x] Update a value for the host [PUT]
- [x] Get the host again [GET]
- [x] **Verify** that the value was set properly

### Test loot
- [x] Repeat the above process for loot 

### Test note
- [x] Repeat the above process for note 

### Test service
- [x] Repeat the above process for service 

### Test session
- [x] Repeat the above process for session 

### Test user
- [x] Repeat the above process for user 

### Test workspace
- [x] Repeat the above process for workspace 


### Things not included in these testing instructions
- [x] Updating user token (`lib/msf/core/db_manager/user.rb` `create_new_user_token`)
- [x] Updating vuln detail (`lib/msf/core/db_manager/vuln_detail.rb` `update_vuln_details`)

