### PR TITLE
Dont log every request when using HTTP data service

### DIFF
--- a/lib/metasploit/framework/data_service/remote/http/core.rb
+++ b/lib/metasploit/framework/data_service/remote/http/core.rb
@@ -157,7 +157,8 @@ class RemoteHTTPDataService
       # simplify query by removing nil values
       query_str = (!query.nil? && !query.empty?) ? query.compact.to_query : nil
       uri = URI::HTTP::build({path: path, query: query_str})
-      dlog("HTTP #{request_type} request to #{uri.request_uri} with #{data_hash ? data_hash : "nil"}")
+      # TODO: Re-enable this logging when framework handles true log levels.
+      #dlog("HTTP #{request_type} request to #{uri.request_uri} with #{data_hash ? data_hash : "nil"}")
 
       client = @client_pool.pop
       case request_type


### PR DESCRIPTION
This PR disables a log line that prints out every HTTP request made to framework.log when connected to an HTTP data service. This log line was specified as a debug log line, but it was unclear when it was added that framework's log levels don't actually affect the amount of logging that gets saved.

We should definitely re-enable this logging as it is very useful for development, but not until true log levels are honored as it can become very verbose.

Note that errors will still generate log lines.

## Verification

- [x] Start `msfconsole`
- [x] Connect to an HTTP data service
- [x] Generate some activity by running various DB related commands such as `host -a 172.1.2.3`, `loot -a -f /path/to/file.txt -i testfile -t text 172.4.5.6`, and `hosts`.
- [x] Check the file at `~/.msf4/logs/framework.log` and ensure log entries are not created for these requests.
- [x] Generate an error when communicating with the HTTP data service. Ensure that the error messages are still logged.

