### PR TITLE
typo fixes in cisco_firepower_useradd.md

### DIFF
--- a/documentation/modules/exploit/linux/http/cisco_firepower_useradd.md
+++ b/documentation/modules/exploit/linux/http/cisco_firepower_useradd.md
@@ -24,9 +24,9 @@ https://software.cisco.com/download/release.html?mdfid=286259687&softwareid=2862
 
 ## Options
 
-**USERNAME** The username for Cisco Firepower Management console
+**USERNAME** The username for Cisco Firepower Management console.
 
-**Password** The password for Cisco Firepower Management cosnole
+**PASSWORD** The password for Cisco Firepower Management console.
 
 **NEWSSHUSER** The SSH account to create. By default, this is random.
 


### PR DESCRIPTION
This fixes a few small typos in cisco_firepower_useradd.md

Please ensure you are submitting **from a unique branch** in your [repository](https://github.com/rantwijk/metasploit-framework/tree/typofixes) to master in Rapid7's.

**Done.**

## Verification

Typo fixes in an md file, no further changes.
