### PR TITLE
Fix to return all keys instead of first key in memcached_extractor.rb

### DIFF
--- a/modules/auxiliary/gather/memcached_extractor.rb
+++ b/modules/auxiliary/gather/memcached_extractor.rb
@@ -58,8 +58,8 @@ class MetasploitModule < Msf::Auxiliary
         sock.send("stats cachedump #{sid} #{max_keys}\r\n", 0)
         data = sock.recv(4096)
         break if !data || data.length == 0
-        matches = /^ITEM (?<key>.*) \[/.match(data)
-        keys << matches[:key] if matches
+        matches=str.scan(/^ITEM (?<key>.*) \[/).flatten
+        matches.each{|key| keys<<key}
         break if data =~ /^END/
       end
     end


### PR DESCRIPTION
There is a parsing issue with the data returned by the Memcached server. Variable data contains information regarding all keys. But since match function is used, only the first matched string is being stored in the keys array. For parsing all the key names from the data, scan function was used instead of match. 

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use auxiliary/gather/memcached_extractor`
- [x] `set RHOSTS 192.168.1.5`
- [x] `exploit`

