### PR TITLE
Move msfdb_ws to tools/dev since it is deprecated by msfdb

### DIFF
--- a/lib/metasploit/framework/spec/threads/suite.rb
+++ b/lib/metasploit/framework/spec/threads/suite.rb
@@ -12,7 +12,7 @@ module Metasploit
           #
 
           # Number of allowed threads when threads are counted in `after(:suite)` or `before(:suite)`
-          EXPECTED_THREAD_COUNT_AROUND_SUITE = 2
+          EXPECTED_THREAD_COUNT_AROUND_SUITE = ENV['REMOTE_DB'] ? 3 : 2
 
           # `caller` for all Thread.new calls
           LOG_PATHNAME = Pathname.new('log/metasploit/framework/spec/threads/suite.log')

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -100,7 +100,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'redcarpet'
   # Needed for Microsoft patch finding tool (msu_finder)
   spec.add_runtime_dependency 'patch_finder'
-  # Required for msfdb_ws (Metasploit data base as a webservice)
+  # Required for Metasploit Web Services
   spec.add_runtime_dependency 'thin'
   spec.add_runtime_dependency 'sinatra'
   spec.add_runtime_dependency 'warden'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -112,7 +112,7 @@ RSpec.configure do |config|
   if ENV['REMOTE_DB']
     require 'metasploit/framework/data_service/remote/managed_remote_data_service'
     opts = {}
-    opts[:process_name] = 'msfdb_ws'
+    opts[:process_name] = File.join('tools', 'dev', 'msfdb_ws')
     opts[:host] = 'localhost'
     opts[:port] = '8080'
 

--- a/tools/dev/msfdb_ws
+++ b/tools/dev/msfdb_ws
@@ -15,7 +15,7 @@ end
 
 def require_deps
   require 'pathname'
-  require Pathname.new(__FILE__).realpath.expand_path.parent.join('config', 'boot')
+  require Pathname.new(__FILE__).realpath.expand_path.parent.parent.parent.join('config', 'boot')
   require 'msf/core/web_services/http_db_manager_service'
 end
 


### PR DESCRIPTION
Moves the `msfdb_ws` script to `tools/dev` since it is deprecated by the `msfdb` script. It is important to note that the functional remote data service spec tests currently utilize the `msfdb_ws` script to host the Metasploit data web service. Once we rework the test code we should be able to remove the `msfdb_ws` script completely.

Tickets: MS-3702, MS-3701

## Verification

- [x] Ensure you do not have the Metasploit data web service started via `msfdb`, `./msfdb status`. If it is currently running stop it with `./msfdb --component webservice stop`.
- [x] Start `./tools/dev/msfdb_ws`
- [x] **Verify** `msfdb_ws` behaves as before, serving the Metasploit data web service and that API endpoints operate as expected
- [x] Press `Ctrl-C` to terminate `msfdb_ws`
- [x] Run spec tests with remote database testing enabled: `REMOTE_DB=1 bundle exec rake spec`
- [x] Run spec tests without remote database testing enabled: `bundle exec rake spec`
- [x] **Verify** both sets of tests run successfully. With one exception, there currently appears to be 5 creds related tests that fail when remote database testing enabled. These should be address in a separate PR as it is unrelated to these changes.