### PR TITLE
Update msfdb to get the MSF config root directory rather than use a fixed value

### DIFF
--- a/msfdb
+++ b/msfdb
@@ -20,13 +20,14 @@ end
 $:.unshift(File.expand_path(File.join(File.dirname(msfbase), 'lib')))
 $:.unshift(ENV['MSF_LOCAL_LIB']) if ENV['MSF_LOCAL_LIB']
 
+require 'msf/base/config'
 require 'msf/util/helper'
 
 
 @script_name = File.basename(__FILE__)
 @framework = File.expand_path(File.dirname(__FILE__))
 
-@localconf = "#{ENV['HOME']}/.msf4"
+@localconf = Msf::Config.get_config_root
 @db = "#{@localconf}/db"
 @db_conf = "#{@localconf}/database.yml"
 


### PR DESCRIPTION
Updates `msfdb` to dynamically get the MSF config root directory via `Msf::Config` rather than use a fixed value.

Ticket: MS-3756

## Verification

- [x] Run `./msfdb reinit` and follow the prompts answering yes to delete existing files
- [x] **Verify** `msfdb` deleted and recreated files in your user's Metasploit config directory, currently `~/.msf4`.
- [x] **Verify** the database and MSF web service are operating as expected