### PR TITLE
Update MSF v5 banner on account of the MSF5 release

### DIFF
--- a/data/logos/metasploit-v5.txt
+++ b/data/logos/metasploit-v5.txt
@@ -22,4 +22,4 @@ xMMMMMMMMMd                        ,0MMMMMMMMMMK;
 %red           'oOWMMMMMMMMo%clr                +:+
 %red               .,cdkO0K;%clr        :+:    :+:                                
                                 :::::::+:
-           %whiMetasploit%clr %yelUnder Construction%clr
+                      %whiMetasploit%clr


### PR DESCRIPTION
Updates the MSF v5 under construction banner to remove the "under construction" on account of the official [Metasploit Framework 5.0 Release](https://blog.rapid7.com/2019/01/10/metasploit-framework-5-0-released/)

## Verification

- [ ] Start `MSFLOGO=data/logos/metasploit-v5.txt ./msfconsole`
- [ ] **Verify** banner is displayed correctly