### PR TITLE
Correct minor OpenAPI documentation typos

### DIFF
--- a/documentation/api/v1/credential_api_doc.rb
+++ b/documentation/api/v1/credential_api_doc.rb
@@ -328,7 +328,7 @@ module CredentialApiDoc
 
     #Swagger documentation for /api/v1/credentials/:id PUT
     operation :put do
-      key :description, 'Update the attributes an existing credential.'
+      key :description, 'Update the attributes on an existing credential.'
       key :tags, [ 'credential' ]
 
       parameter :update_id

--- a/documentation/api/v1/host_api_doc.rb
+++ b/documentation/api/v1/host_api_doc.rb
@@ -266,7 +266,7 @@ module HostApiDoc
 
     # Swagger documentation for /api/v1/hosts/:id PUT
     operation :put do
-      key :description, 'Update the attributes an existing host.'
+      key :description, 'Update the attributes on an existing host.'
       key :tags, [ 'host' ]
 
       parameter :update_id

--- a/documentation/api/v1/login_api_doc.rb
+++ b/documentation/api/v1/login_api_doc.rb
@@ -193,7 +193,7 @@ module LoginApiDoc
 
     # Swagger documentation for /api/v1/logins/:id PUT
     operation :put do
-      key :description, 'Update the attributes an existing login.'
+      key :description, 'Update the attributes on an existing login.'
       key :tags, [ 'login' ]
 
       parameter :update_id

--- a/documentation/api/v1/loot_api_doc.rb
+++ b/documentation/api/v1/loot_api_doc.rb
@@ -195,7 +195,7 @@ module LootApiDoc
 
     # Swagger documentation for /api/v1/loots/{id} PUT
     operation :put do
-      key :description, 'Update the attributes an existing loot.'
+      key :description, 'Update the attributes on an existing loot.'
       key :tags, [ 'loot' ]
 
       parameter :update_id

--- a/documentation/api/v1/note_api_doc.rb
+++ b/documentation/api/v1/note_api_doc.rb
@@ -184,7 +184,7 @@ module NoteApiDoc
 
     # Swagger documentation for /api/v1/notes/:id PUT
     operation :put do
-      key :description, 'Update the attributes an existing note.'
+      key :description, 'Update the attributes on an existing note.'
       key :tags, [ 'note' ]
 
       parameter :update_id

--- a/documentation/api/v1/service_api_doc.rb
+++ b/documentation/api/v1/service_api_doc.rb
@@ -187,7 +187,7 @@ module ServiceApiDoc
 
     # Swagger documentation for /api/v1/services/:id PUT
     operation :put do
-      key :description, 'Update the attributes an existing service.'
+      key :description, 'Update the attributes on an existing service.'
       key :tags, [ 'service' ]
 
       parameter :update_id

--- a/documentation/api/v1/session_api_doc.rb
+++ b/documentation/api/v1/session_api_doc.rb
@@ -86,7 +86,7 @@ module SessionApiDoc
   end
 
   swagger_path '/api/v1/sessions/{id}' do
-    # Swagger documentation for api/v1/sessions/:id GET
+    # Swagger documentation for /api/v1/sessions/:id GET
     operation :get do
       key :description, 'Return a specific session that is stored in the database.'
       key :tags, [ 'session' ]

--- a/documentation/api/v1/vuln_api_doc.rb
+++ b/documentation/api/v1/vuln_api_doc.rb
@@ -211,7 +211,7 @@ module VulnApiDoc
 
     # Swagger documentation for /api/v1/vulns/:id PUT
     operation :put do
-      key :description, 'Update the attributes an existing vuln.'
+      key :description, 'Update the attributes on an existing vuln.'
       key :tags, [ 'vuln' ]
 
       parameter :update_id

--- a/documentation/api/v1/workspace_api_doc.rb
+++ b/documentation/api/v1/workspace_api_doc.rb
@@ -173,7 +173,7 @@ module WorkspaceApiDoc
 
     # Swagger documentation for /api/v1/workspaces/:id PUT
     operation :put do
-      key :description, 'Update the attributes an existing workspaces.'
+      key :description, 'Update the attributes on an existing workspace.'
       key :tags, [ 'workspace' ]
 
       parameter :update_id


### PR DESCRIPTION
Corrects minor typos in the OpenAPI documentation.

## Verification

- [ ] Restart the database and MSF data web service using `msfdb restart`, and `init`/`reinit` if necessary.
- [ ] Browse the documentation at `https://localhost:8080/api/v1/api-docs`
- [ ] **Verify** documentation updates