### PR TITLE
Update recog and mdm to latest

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -178,7 +178,7 @@ GEM
       activesupport (~> 4.2.6)
       railties (~> 4.2.6)
     metasploit-payloads (1.3.58)
-    metasploit_data_models (3.0.2)
+    metasploit_data_models (3.0.4)
       activerecord (~> 4.2.6)
       activesupport (~> 4.2.6)
       arel-helpers
@@ -245,7 +245,7 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rake (12.3.2)
     rb-readline (0.5.5)
-    recog (2.1.44)
+    recog (2.1.45)
       nokogiri
     redcarpet (3.4.0)
     rex-arch (0.1.13)


### PR DESCRIPTION
This updates [recog](https://github.com/rapid7/recog) and [mdm](https://github.com/rapid7/metasploit_data_models) to their latest versions.  For recog, this ensures that the latest fingerprinting improvements are available in metasploit (even though this was just recently bumped, 👍 !), and the `mdm` bump is a good thing in general and I'll need as part of various other work, including https://github.com/rapid7/metasploit-framework/pull/8452 and https://github.com/rapid7/recog/pull/218

## Verification

List the steps needed to make sure this thing works

- [ ] Run `bundle install` (right?)
- [ ] Start `msfconsole`
- [ ] `use scanner/smb/smb_version`
- [ ] Run this module against some SMB enabled Windows hosts and confirm that they are fingerprinted

Before and after:

```
[+] a.b.c.d:445       - Host is running Windows 7 Enterprise SP1 (build:7601) (name:W7-3-SP1-D) (workgroup:WORKGROUP )
```

