### PR TITLE
Use 'to_s.strip' for Msf::Post::File.pwd output

### DIFF
--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -32,7 +32,7 @@ module Msf::Post::File
         # and 2k
         return session.shell_command_token("echo %CD%")
       else
-        return session.shell_command_token("pwd")
+        return session.shell_command_token("pwd").to_s.strip
       end
     end
   end


### PR DESCRIPTION
Output from `Msf::Post::File.pwd` on non-Windows command shell sessions contains a trailing `\n`. This is unexpected.

This PR makes `Msf::Post::File.pwd` suck less.

I neither know nor care whether the same issue affects command shell sessions on Windows.
