### PR TITLE
Assign CVE-2018-11770 to exploits/linux/http/spark_unauth_rce

### DIFF
--- a/modules/exploits/linux/http/spark_unauth_rce.rb
+++ b/modules/exploits/linux/http/spark_unauth_rce.rb
@@ -20,6 +20,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Author'         =>
         [
           'Fengwei Zhang',                     # Original discovery
+          'Imran Rashid',
           'aRe00t',                            # Proof of concept
           'Green-m <greenm.xxoo[at]gmail.com>' # Metasploit module
         ],

--- a/modules/exploits/linux/http/spark_unauth_rce.rb
+++ b/modules/exploits/linux/http/spark_unauth_rce.rb
@@ -19,11 +19,13 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'Author'         =>
         [
+          'Fengwei Zhang',                     # Original discovery
           'aRe00t',                            # Proof of concept
           'Green-m <greenm.xxoo[at]gmail.com>' # Metasploit module
         ],
       'References'     =>
         [
+          ['CVE', '2018-11770'], # see https://spark.apache.org/security.html
           ['URL', 'https://www.jianshu.com/p/a080cb323832'],
           ['URL', 'https://github.com/vulhub/vulhub/tree/master/spark/unacc']
         ],


### PR DESCRIPTION
Assigns CVE-2018-11770 to exploits/linux/http/spark_unauth_rce. Please see https://spark.apache.org/security.html for verification.