### PR TITLE
Add PSH generation methods to Util::Exe

### DIFF
--- a/lib/msf/core/exploit/powershell.rb
+++ b/lib/msf/core/exploit/powershell.rb
@@ -22,7 +22,7 @@ module Exploit::Powershell
         OptBool.new('Powershell::encode_inner_payload', [true, 'Encode inner payload for -EncodedCommand', false]),
         OptBool.new('Powershell::wrap_double_quotes', [true, 'Wraps the -Command argument in single quotes', true]),
         OptBool.new('Powershell::no_equals', [true, 'Pad base64 until no "=" remains', false]),
-        OptEnum.new('Powershell::method', [true, 'Payload delivery method', 'reflection', %w[net reflection old msil]])
+        OptEnum.new('Powershell::method', [true, 'Payload delivery method', 'reflection', %w[net reflection old msil rc4]])
       ]
     )
   end

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -1438,7 +1438,6 @@ require 'msf/core/exe/segment_appender'
     read_replace_script_template("to_powershell.hta.template", hash_sub)
   end
 
-<<<<<<< HEAD
   def self.to_python_reflection(framework, arch, code, exeopts)
     unless [ ARCH_X86, ARCH_X64, ARCH_AARCH64, ARCH_ARMLE, ARCH_MIPSBE, ARCH_MIPSLE, ARCH_PPC ].include? arch
       raise RuntimeError, "Msf::Util::EXE.to_python_reflection is not compatible with #{arch}"
@@ -1466,14 +1465,14 @@ require 'msf/core/exe/segment_appender'
     PYTHON
 
     "exec(__import__('base64').b64decode(__import__('codecs').getencoder('utf-8')('#{Rex::Text.encode_base64(python_code)}')[0]))"
-=======
+  end
+
   def self.to_win32pe_psh_msil(framework, code, opts = {})
     Rex::Powershell::Payload.to_win32pe_psh_msil(Rex::Powershell::Templates::TEMPLATE_DIR, code)
   end
 
   def self.to_win32pe_psh_rc4(framework, code, opts = {})
     Rex::Powershell::Payload.to_win32pe_psh_rc4(Rex::Powershell::Templates::TEMPLATE_DIR, code)
->>>>>>> Add PSH generation methods to Util::Exe
   end
 
   def self.to_jsp(exe)

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -1438,6 +1438,7 @@ require 'msf/core/exe/segment_appender'
     read_replace_script_template("to_powershell.hta.template", hash_sub)
   end
 
+<<<<<<< HEAD
   def self.to_python_reflection(framework, arch, code, exeopts)
     unless [ ARCH_X86, ARCH_X64, ARCH_AARCH64, ARCH_ARMLE, ARCH_MIPSBE, ARCH_MIPSLE, ARCH_PPC ].include? arch
       raise RuntimeError, "Msf::Util::EXE.to_python_reflection is not compatible with #{arch}"
@@ -1465,6 +1466,14 @@ require 'msf/core/exe/segment_appender'
     PYTHON
 
     "exec(__import__('base64').b64decode(__import__('codecs').getencoder('utf-8')('#{Rex::Text.encode_base64(python_code)}')[0]))"
+=======
+  def self.to_win32pe_psh_msil(framework, code, opts = {})
+    Rex::Powershell::Payload.to_win32pe_psh_msil(Rex::Powershell::Templates::TEMPLATE_DIR, code)
+  end
+
+  def self.to_win32pe_psh_rc4(framework, code, opts = {})
+    Rex::Powershell::Payload.to_win32pe_psh_rc4(Rex::Powershell::Templates::TEMPLATE_DIR, code)
+>>>>>>> Add PSH generation methods to Util::Exe
   end
 
   def self.to_jsp(exe)


### PR DESCRIPTION
MSIL generation was never added to util, and the pending rc4
generator should be accessible from here as well. Add both to the
end of the powershell generators section.

Add rc4 to the powershell method enum in opts which is passed
into rex-powershell.

NOTE: this depends on [PR14 in rex-powershell](https://github.com/rapid7/rex-powershell/pull/14) which has [PR 1](https://github.com/AdrianVollmer/rex-powershell/pull/1) pending review on the original PR itself, so please do not merge, its just the accessors for these PSH encoders.

ping @AdrianVollmer @busterb

