### PR TITLE
add max_length to wordlist generation

### DIFF
--- a/lib/metasploit/framework/jtr/wordlist.rb
+++ b/lib/metasploit/framework/jtr/wordlist.rb
@@ -375,7 +375,7 @@ module Metasploit
           valid!
           wordlist_file = Rex::Quickfile.new("jtrtmp")
           each_word do |word|
-            wordlist_file.puts max_len == 0 ? word : word[0..max_len-1]
+            wordlist_file.puts max_len == 0 ? word : word[0...max_len]
           end
           wordlist_file
         end

--- a/lib/metasploit/framework/jtr/wordlist.rb
+++ b/lib/metasploit/framework/jtr/wordlist.rb
@@ -369,12 +369,13 @@ module Metasploit
         # This method takes all the options provided and streams the generated wordlist out
         # to a {Rex::Quickfile} and returns the {Rex::Quickfile}.
         #
+        # @param max_len [Integer] max length of a word in the wordlist, 0 default for ignored value
         # @return [Rex::Quickfile] The {Rex::Quickfile} object that the wordlist has been written to
-        def to_file
+        def to_file(max_len)
           valid!
           wordlist_file = Rex::Quickfile.new("jtrtmp")
           each_word do |word|
-            wordlist_file.puts word
+            wordlist_file.puts max_len == 0 ? word : word[0..max_len]
           end
           wordlist_file
         end

--- a/lib/metasploit/framework/jtr/wordlist.rb
+++ b/lib/metasploit/framework/jtr/wordlist.rb
@@ -375,7 +375,7 @@ module Metasploit
           valid!
           wordlist_file = Rex::Quickfile.new("jtrtmp")
           each_word do |word|
-            wordlist_file.puts max_len == 0 ? word : word[0..max_len]
+            wordlist_file.puts max_len == 0 ? word : word[0..max_len-1]
           end
           wordlist_file
         end

--- a/lib/msf/core/auxiliary/jtr.rb
+++ b/lib/msf/core/auxiliary/jtr.rb
@@ -79,9 +79,10 @@ module Auxiliary::JohnTheRipper
   # This method instantiates a {Metasploit::Framework::JtR::Wordlist}, writes the data
   # out to a file and returns the {Rex::Quickfile} object.
   #
+  # @param max_len [Integer] max length of a word in the wordlist, 0 default for ignored value
   # @return [nilClass] if there is no active framework db connection
   # @return [Rex::Quickfile] if it successfully wrote the wordlist to a file
-  def wordlist_file
+  def wordlist_file(max_len = 0)
     return nil unless framework.db.active
     wordlist = Metasploit::Framework::JtR::Wordlist.new(
         custom_wordlist: datastore['CUSTOM_WORDLIST'],
@@ -93,7 +94,7 @@ module Auxiliary::JohnTheRipper
         use_common_root: datastore['USE_ROOT_WORDS'],
         workspace: myworkspace
     )
-    wordlist.to_file
+    wordlist.to_file(max_len)
   end
 
 end


### PR DESCRIPTION
This adds the ability to set the max length of a word going into a word list when written to file.

Some password hash formats have a max length (DES = 8) and therefore when generating a wordlist with anything more than that, those items will either always fail or be ignored by JTR (not sure JTR's behavior).

This currently only changes how the libraries work, i'm going through the jtr modules now and cleaning them up, writing docs, fixing logic, and implementing this behavior in other PRs.

Default behavior is `0`, which means ignore so the current behavior will stick.

With the default behavior on my system:
```
msf5 auxiliary(analyze/jtr_linux) > wc -L /tmp/jtrtmp20190114-18029-1hpr9zf
[*] exec: wc -L /tmp/jtrtmp20190114-18029-1hpr9zf

296 /tmp/jtrtmp20190114-18029-1hpr9zf
```
After setting it to 8:
```
msf5 auxiliary(analyze/jtr_linux) > wc -L /tmp/jtrtmp20190114-17944-wzzpsf
[*] exec: wc -L /tmp/jtrtmp20190114-17944-wzzpsf

8 /tmp/jtrtmp20190114-17944-wzzpsf
```