### PR TITLE
Improve msfdb's rackup file use to work independent of the framework directory location

### DIFF
--- a/msf-ws.ru
+++ b/msf-ws.ru
@@ -1,0 +1,20 @@
+# msf-ws.ru
+# Metasploit data web service
+
+require 'pathname'
+@framework_path = '.'
+root = Pathname.new(@framework_path).expand_path
+@framework_lib_path = root.join('lib')
+$LOAD_PATH << @framework_lib_path unless $LOAD_PATH.include?(@framework_lib_path)
+
+require 'msfenv'
+
+if ENV['MSF_LOCAL_LIB']
+  $LOAD_PATH << ENV['MSF_LOCAL_LIB'] unless $LOAD_PATH.include?(ENV['MSF_LOCAL_LIB'])
+end
+
+# Note: setup Rails environment before calling require
+require 'msf/core/web_services/metasploit_api_app'
+
+# run Msf::WebServices::JsonRpcApp
+run MetasploitApiApp

--- a/msfdb
+++ b/msfdb
@@ -508,7 +508,6 @@ def generate_web_service_ssl(key:, cert:)
   end
 
   puts 'Generating SSL key and certificate for MSF web service'
-  # @ssl_cert = Rex::Socket::SslTcpServer.ssl_generate_certificate
   @ssl_key, @ssl_cert, @ssl_extra_chain_cert = Rex::Socket::Ssl.ssl_generate_certificate
 
   # write PEM format key and certificate

--- a/msfdb
+++ b/msfdb
@@ -32,7 +32,7 @@ require 'msf/util/helper'
 @db_conf = "#{@localconf}/database.yml"
 
 @ws_tag = 'msf-ws'
-@ws_conf = "#{@localconf}/#{@ws_tag}-config.ru"
+@ws_conf = File.join(@framework, "#{@ws_tag}.ru")
 @ws_ssl_key_default = "#{@localconf}/#{@ws_tag}-key.pem"
 @ws_ssl_cert_default = "#{@localconf}/#{@ws_tag}-cert.pem"
 @ws_log = "#{@localconf}/logs/#{@ws_tag}.log"
@@ -398,59 +398,11 @@ def status_web_service
 end
 
 def init_web_service
-  if File.file?(@ws_conf)
-    puts "Found web service config at #{@ws_conf}, checking to see if it is started"
-    start_web_service(expect_auth: true)
-    return
-  end
-
   if @options[:ws_user].nil?
     @msf_ws_user = ask_value('Initial MSF web service account username?', @msf_ws_user)
   else
     @msf_ws_user = @options[:ws_user]
   end
-
-  # Write a default Rack config file for the web service
-  Dir.mkdir(@localconf) unless File.directory?(@localconf)
-  # TODO: free the REST API from all of these requirements
-  File.open(@ws_conf, 'w') do |f|
-    f.puts <<~EOF
-      # #{File.basename(@ws_conf)}
-      # created on: #{Time.now.utc}
-
-      @framework_path = '#{@framework}'
-      $LOAD_PATH << @framework_path unless $LOAD_PATH.include?(@framework_path)
-
-      require File.expand_path('./config/boot', @framework_path)
-      require 'metasploit/framework/parsed_options/remote_db'
-      require 'msf/core/web_services/metasploit_api_app'
-
-      def require_environment!(parsed_options)
-        # RAILS_ENV must be set before requiring 'config/application.rb'
-        parsed_options.environment!
-        ARGV.replace(parsed_options.positional)
-
-        # allow other Rails::Applications to use this command
-        if !defined?(Rails) || Rails.application.nil?
-          # @see https://github.com/rails/rails/blob/v3.2.17/railties/lib/rails/commands.rb#L39-L40
-          require File.expand_path('./config/application', @framework_path)
-        end
-
-        # have to configure before requiring environment because
-        # config/environment.rb calls initialize! and the initializers will use
-        # the configuration from the parsed options.
-        parsed_options.configure(Rails.application)
-
-        Rails.application.require_environment!
-      end
-
-      parsed_options = Metasploit::Framework::ParsedOptions::RemoteDB.new
-      require_environment!(parsed_options)
-
-      run MetasploitApiApp
-    EOF
-  end
-  File.chmod(0640, @ws_conf)
 
   if @options[:ssl] && ((!File.file?(@options[:ssl_key]) || !File.file?(@options[:ssl_cert])) ||
       (@options[:ssl_key] == @ws_ssl_key_default && @options[:ssl_cert] == @ws_ssl_cert_default))
@@ -541,9 +493,6 @@ end
 
 def delete_web_service
   stop_web_service
-  if File.file?(@ws_conf) && ask_yn("Delete MSF web service configuration at #{@ws_conf}?")
-    File.delete(@ws_conf)
-  end
 end
 
 def reinit_web_service


### PR DESCRIPTION
Improves `msfdb`'s rackup file use to allow it to work independent of the framework directory location. The initial `msfdb` implementation (#10410) to support the Metasploit data web service stored a rackup file in the user's configuration root (`~/.msf4/msf-ws-config.ru`). The rackup file contained a variable that defined the location of the framework directory. That approach is fragile and results in issues if the user moves their framework directory location, or experiments with multiple Metasploit versions side-by-side. 

Ticket: MS-3770

## Verification
- [x] If you already have an existing database run `msfdb reinit`, otherwise, run `msfdb init` and follow prompts to initialize both the database and web service
- [x] **Verify** a web service username, password and API token are provided by the script
- [x] Run `msfdb status`
- [x] **Verify** the status reports that both the database and web service are running
- [x] Execute `curl --insecure https://localhost:8080/api/v1/msf/version | python -m json.tool`
- [x] **Verify** a JSON "Authenticate to access this resource" error message is returned
- [x] Execute `curl --insecure -H "Accept: application/json" -H "Authorization: Bearer <token>" https://localhost:8080/api/v1/msf/version | python -m json.tool`
- [x] **Verify** a valid JSON message is returned that contains the metasploit_version
- [x] Open a web browser and navigate to `https://localhost:8080/api/v1/auth/account`. You will need to add an exception in the browser for the fake SSL certificate to get the page to load.
- [x] **Verify** You can click Log In and use the username and password provided earlier by `msfdb` to log in to the web interface, log out and close the browser.
- [x] Test `msfdb` with various options and commands and verify that they operate as expected
- [x] Start `msfconsole` and connect to the data service started above if you didn't select the option to connect automatically during initialization. See [Metasploit Web Service](https://github.com/rapid7/metasploit-framework/wiki/Metasploit-Web-Service) for more information.
- [x] **Verify** `db_status` reports `Connection type: http. Connected to remote_data_service: (https://localhost:8080)`
- [x] Exploit a host, pull creds and loot
- [x] **Verify** use of various commands (`hosts`, `loot`, `vulns`, `services`, etc.) that create, read, update and delete data work as expected