### PR TITLE
uppercase KoreLogic in JTR modules

### DIFF
--- a/lib/msf/core/auxiliary/jtr.rb
+++ b/lib/msf/core/auxiliary/jtr.rb
@@ -29,7 +29,7 @@ module Auxiliary::JohnTheRipper
         OptPath.new('CUSTOM_WORDLIST',      [false, 'The path to an optional custom wordlist']),
         OptInt.new('ITERATION_TIMOUT',      [false, 'The max-run-time for each iteration of cracking']),
         OptPath.new('JOHN_PATH',            [false, 'The absolute path to the John the Ripper executable']),
-        OptBool.new('KoreLogic',            [false, 'Apply the KoreLogic rules to Wordlist Mode(slower)', false]),
+        OptBool.new('KORELOGIC',            [false, 'Apply the KoreLogic rules to Wordlist Mode(slower)', false]),
         OptBool.new('MUTATE',               [false, 'Apply common mutations to the Wordlist (SLOW)', false]),
         OptPath.new('POT',                  [false, 'The path to a John POT file to use instead of the default']),
         OptBool.new('USE_CREDS',            [false, 'Use existing credential data saved in the database', true]),

--- a/modules/auxiliary/analyze/jtr_crack_fast.rb
+++ b/modules/auxiliary/analyze/jtr_crack_fast.rb
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Auxiliary
       cracker_instance.format = format
       print_status "Cracking #{format} hashes in normal wordlist mode..."
       # Turn on KoreLogic rules if the user asked for it
-      if datastore['KoreLogic']
+      if datastore['KORELOGIC']
         cracker_instance.rules = 'KoreLogicRules'
         print_status "Applying KoreLogic ruleset..."
       end

--- a/modules/auxiliary/analyze/jtr_linux.rb
+++ b/modules/auxiliary/analyze/jtr_linux.rb
@@ -60,7 +60,7 @@ class MetasploitModule < Msf::Auxiliary
       cracker_instance.format = format
       print_status "Cracking #{format} hashes in normal wordlist mode..."
       # Turn on KoreLogic rules if the user asked for it
-      if datastore['KoreLogic']
+      if datastore['KORELOGIC']
         cracker_instance.rules = 'KoreLogicRules'
         print_status "Applying KoreLogic ruleset..."
       end

--- a/modules/auxiliary/analyze/jtr_mssql_fast.rb
+++ b/modules/auxiliary/analyze/jtr_mssql_fast.rb
@@ -47,7 +47,7 @@ class MetasploitModule < Msf::Auxiliary
       cracker_instance.format = format
       print_status "Cracking #{format} hashes in normal wordlist mode..."
       # Turn on KoreLogic rules if the user asked for it
-      if datastore['KoreLogic']
+      if datastore['KORELOGIC']
         cracker_instance.rules = 'KoreLogicRules'
         print_status "Applying KoreLogic ruleset..."
       end

--- a/modules/auxiliary/analyze/jtr_mysql_fast.rb
+++ b/modules/auxiliary/analyze/jtr_mysql_fast.rb
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Auxiliary
       cracker_instance.format = format
       print_status "Cracking #{format} hashes in normal wordlist mode..."
       # Turn on KoreLogic rules if the user asked for it
-      if datastore['KoreLogic']
+      if datastore['KORELOGIC']
         cracker_instance.rules = 'KoreLogicRules'
         print_status "Applying KoreLogic ruleset..."
       end

--- a/modules/auxiliary/analyze/jtr_oracle_fast.rb
+++ b/modules/auxiliary/analyze/jtr_oracle_fast.rb
@@ -48,7 +48,7 @@ class MetasploitModule < Msf::Auxiliary
 
       print_status "Cracking #{format} hashes in normal wordlist mode..."
       # Turn on KoreLogic rules if the user asked for it
-      if datastore['KoreLogic']
+      if datastore['KORELOGIC']
         cracker_instance.rules = 'KoreLogicRules'
         print_status "Applying KoreLogic ruleset..."
       end

--- a/modules/auxiliary/analyze/jtr_postgres_fast.rb
+++ b/modules/auxiliary/analyze/jtr_postgres_fast.rb
@@ -51,7 +51,7 @@ class MetasploitModule < Msf::Auxiliary
       cracker_instance.format = format
       print_status "Cracking #{format} hashes in normal wordlist mode..."
       # Turn on KoreLogic rules if the user asked for it
-      if datastore['KoreLogic']
+      if datastore['KORELOGIC']
         cracker_instance.rules = 'KoreLogicRules'
         print_status "Applying KoreLogic ruleset..."
       end


### PR DESCRIPTION
This PR standardizes the `KoreLogic` option in the JTR modules to be uppercase.