### PR TITLE
ms17_010_psexec: fix RHOST in "authenticating..." message

### DIFF
--- a/modules/exploits/windows/smb/ms17_010_psexec.rb
+++ b/modules/exploits/windows/smb/ms17_010_psexec.rb
@@ -103,7 +103,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     begin
       if datastore['SMBUser'].present?
-        print_status("Authenticating to #{datastore['RHOSTS']} as user '#{splitname(datastore['SMBUser'])}'...")
+        print_status("Authenticating to #{datastore['RHOST']} as user '#{splitname(datastore['SMBUser'])}'...")
       end
       eternal_pwn(datastore['RHOST'])
       smb_pwn()


### PR DESCRIPTION
The "Authenticating..." message has an info missing:
> Authenticating to  as user 'user'...

It is due to a confusion between `RHOST` and `RHOSTS`.
This module uses `RHOST` as shown just below in the code:
```eternal_pwn(datastore['RHOST'])```