### PR TITLE
Update java_deserialization_spec to rescue the right exception

### DIFF
--- a/spec/lib/msf/util/java_deserialization_spec.rb
+++ b/spec/lib/msf/util/java_deserialization_spec.rb
@@ -28,9 +28,9 @@ RSpec.describe Msf::Util::JavaDeserialization do
     end
 
     context 'when default payload is not JSON format' do
-      it 'raises a JSON::ParserError error' do
+      it 'raises a RuntimeError error' do
         allow(File).to receive(:read).and_return('BAD DATA')
-        expect{Msf::Util::JavaDeserialization::ysoserial_payload(payload_name, default_command)}.to raise_error(JSON::ParserError)
+        expect{Msf::Util::JavaDeserialization::ysoserial_payload(payload_name, default_command)}.to raise_error(RuntimeError)
       end
     end
 


### PR DESCRIPTION
While handling #11125, I decided to rescue `JSON::ParserError` in the payload parsing code, but I forgot to update the rspec. This PR should fix that.

Verification:
- [x] When you see Travis is green, then it's good to go.