### PR TITLE
Implement resource scripting for command shells

### DIFF
--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -34,13 +34,14 @@ class CommandShell
   ##
   # :category: Msf::Session::Scriptable implementors
   #
-  # Executes the supplied script, must be specified as full path.
-  #
-  # Msf::Session::Scriptable implementor
+  # Runs the shell session script or resource file.
   #
   def execute_file(full_path, args)
-    o = Rex::Script::Shell.new(self, full_path)
-    o.run(args)
+    if File.extname(full_path) == '.rb'
+      Rex::Script::Shell.new(self, full_path).run(args)
+    else
+      load_resource(full_path)
+    end
   end
 
   #
@@ -237,7 +238,7 @@ class CommandShell
       return cmd_sessions_help
     end
 
-    # Why `/bin/sh` not `/bin/bash`, some machine may not have `/bin/bash` installed, just in case. 
+    # Why `/bin/sh` not `/bin/bash`, some machine may not have `/bin/bash` installed, just in case.
     # 1. Using python
     # 1.1 Check Python installed or not
     # We do not need to care about the python version
@@ -280,7 +281,7 @@ class CommandShell
 
     print_error("Can not pop up an interactive shell")
   end
-  
+
   #
   # Check if there is a binary in PATH env
   #
@@ -486,7 +487,7 @@ class CommandShell
     end
 
     # User input is not a built-in command, write to socket directly
-    shell_write(cmd)
+    shell_write(cmd + "\n")
   end
 
   #

--- a/lib/msf/base/sessions/meterpreter.rb
+++ b/lib/msf/base/sessions/meterpreter.rb
@@ -308,11 +308,11 @@ class Meterpreter < Rex::Post::Meterpreter::Client
   ##
   # :category: Msf::Session::Scriptable implementors
   #
-  # Runs the Meterpreter script or resource file
+  # Runs the Meterpreter script or resource file.
   #
   def execute_file(full_path, args)
-    # Infer a Meterpreter script by it having an .rb extension
-    if File.extname(full_path) == ".rb"
+    # Infer a Meterpreter script by .rb extension
+    if File.extname(full_path) == '.rb'
       Rex::Script::Meterpreter.new(self, full_path).run(args)
     else
       console.load_resource(full_path)


### PR DESCRIPTION
It makes more sense now with the metashell. A missing newline in `shell_write` prevented shell commands from passing through cleanly. That has been fixed.

```
msf5 exploit(multi/handler) > cat test.rb
[*] exec: cat test.rb

p self
msf5 exploit(multi/handler) > cat test.rc
[*] exec: cat test.rc

help
whoami
msf5 exploit(multi/handler) > run

[!] You are binding to a loopback address by setting LHOST to 127.0.0.1. Did you want ReverseListenerBindAddress?
[*] Started reverse TCP handler on 127.0.0.1:4444
[*] Command shell session 1 opened (127.0.0.1:4444 -> 127.0.0.1:55593) at 2019-01-17 13:45:48 -0600
[*] Session ID 1 (127.0.0.1:4444 -> 127.0.0.1:55593) processing InitialAutoRunScript 'test.rb'
#<Rex::Script::Shell:0x00007fb10398c590 @client=#<Session:shell 127.0.0.1:55593 (127.0.0.1) >, @framework=#<Framework (1 sessions, 0 jobs, 0 plugins, postgresql database active)>, @path="test.rb", @sink=#<Rex::Script::Base::OutputSink:0x00007fb10398c568>, @workspace=#<Mdm::Workspace id: 926, name: "default", created_at: "2019-01-17 19:24:27", updated_at: "2019-01-17 19:24:27", boundary: nil, description: nil, owner_id: nil, limit_to_network: false, import_fingerprint: false>, @session=#<Session:shell 127.0.0.1:55593 (127.0.0.1) >, @args=[]>
[*] Session ID 1 (127.0.0.1:4444 -> 127.0.0.1:55593) processing AutoRunScript 'test.rc'
[*] Processing test.rc for ERB directives.
resource (test.rc)> help

Meta shell commands
===================

    Command     Description
    -------     -----------
    help        Help menu
    background  Backgrounds the current shell session
    sessions    Quickly switch to another session
    resource    Run a meta commands script stored in a local file
    shell       Spawn an interactive shell (*NIX Only)
    download    Download files (*NIX Only)
    upload      Upload files (*NIX Only)
    source      Run a shell script on remote machine (*NIX Only)

resource (test.rc)> whoami

wvu
```