### PR TITLE
Fix typo of "architectures" in pivot command help

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
@@ -148,7 +148,7 @@ class Console::CommandDispatcher::Core
     print_line
     print_line('Supported pivot types:')
     print_line('     - pipe (using named pipes over SMB)')
-    print_line('Supported arhiectures:')
+    print_line('Supported architectures:')
     @@pivot_supported_archs.each do |a|
       print_line('     - ' + a)
     end


### PR DESCRIPTION
[![Typo fixes](https://i.redd.it/16bicltv08821.png)](https://www.reddit.com/r/ProgrammerHumor/comments/ac6cc1/it_really_is/)