### PR TITLE
Fix failing remote data service spec tests for Msf::DBManager::Cred

### DIFF
--- a/spec/support/shared/examples/msf/db_manager/cred.rb
+++ b/spec/support/shared/examples/msf/db_manager/cred.rb
@@ -1,9 +1,15 @@
 RSpec.shared_examples_for 'Msf::DBManager::Cred' do
 
+  unless ENV['REMOTE_DB']
+    it { is_expected.to respond_to :each_cred }
+    it { is_expected.to respond_to :find_or_create_cred }
+    it { is_expected.to respond_to :report_auth }
+    it { is_expected.to respond_to :report_auth_info }
+    it { is_expected.to respond_to :report_cred }
+  end
+
   it { is_expected.to respond_to :creds }
-  it { is_expected.to respond_to :each_cred }
-  it { is_expected.to respond_to :find_or_create_cred }
-  it { is_expected.to respond_to :report_auth }
-  it { is_expected.to respond_to :report_auth_info }
-  it { is_expected.to respond_to :report_cred }
+  it { is_expected.to respond_to :create_credential }
+  it { is_expected.to respond_to :update_credential }
+  it { is_expected.to respond_to :delete_credentials }
 end


### PR DESCRIPTION
Fixes five failing spec tests for `Msf::DBManager::Cred` when the remote data service testing is enabled via the `REMOTE_DB` environment variable flag. In addition, updates the test for the new cred methods (`create_credential`, `update_credential`, `delete_credentials`) introduced in #10176.

Ticket: MS-3768

## Failure output
```
...
Msf::DBManager ...*********************************************...****************************************************************************************************************************************************************************...****************.********************************..*********************************************************************************************************************........*************************************************************************************************FFFFF.......****

  1) Msf::DBManager it should behave like Msf::DBManager::Cred should respond to #report_cred
     Failure/Error: it { is_expected.to respond_to :report_cred }
       expected #<Metasploit::Framework::DataService::RemoteHTTPDataService:0x00007fe438ef0aa0 @endpoint=#<URI::HTTP ..."metasploit v5.0.0-dev-f636982b09"}, @client_pool=#<Thread::Queue:0x00007fe438ef07f8>, @active=true> to respond to :report_cred
     Shared Example Group: "Msf::DBManager::Cred" called from ./spec/lib/msf/db_manager_spec.rb:24
     # ./spec/support/shared/examples/msf/db_manager/cred.rb:8:in `block (2 levels) in <top (required)>'

  2) Msf::DBManager it should behave like Msf::DBManager::Cred should respond to #each_cred
     Failure/Error: it { is_expected.to respond_to :each_cred }
       expected #<Metasploit::Framework::DataService::RemoteHTTPDataService:0x00007fe438ef0aa0 @endpoint=#<URI::HTTP ..."metasploit v5.0.0-dev-f636982b09"}, @client_pool=#<Thread::Queue:0x00007fe438ef07f8>, @active=true> to respond to :each_cred
     Shared Example Group: "Msf::DBManager::Cred" called from ./spec/lib/msf/db_manager_spec.rb:24
     # ./spec/support/shared/examples/msf/db_manager/cred.rb:4:in `block (2 levels) in <top (required)>'

  3) Msf::DBManager it should behave like Msf::DBManager::Cred should respond to #find_or_create_cred
     Failure/Error: it { is_expected.to respond_to :find_or_create_cred }
       expected #<Metasploit::Framework::DataService::RemoteHTTPDataService:0x00007fe438ef0aa0 @endpoint=#<URI::HTTP ..."metasploit v5.0.0-dev-f636982b09"}, @client_pool=#<Thread::Queue:0x00007fe438ef07f8>, @active=true> to respond to :find_or_create_cred
     Shared Example Group: "Msf::DBManager::Cred" called from ./spec/lib/msf/db_manager_spec.rb:24
     # ./spec/support/shared/examples/msf/db_manager/cred.rb:5:in `block (2 levels) in <top (required)>'

  4) Msf::DBManager it should behave like Msf::DBManager::Cred should respond to #report_auth_info
     Failure/Error: it { is_expected.to respond_to :report_auth_info }
       expected #<Metasploit::Framework::DataService::RemoteHTTPDataService:0x00007fe438ef0aa0 @endpoint=#<URI::HTTP ..."metasploit v5.0.0-dev-f636982b09"}, @client_pool=#<Thread::Queue:0x00007fe438ef07f8>, @active=true> to respond to :report_auth_info
     Shared Example Group: "Msf::DBManager::Cred" called from ./spec/lib/msf/db_manager_spec.rb:24
     # ./spec/support/shared/examples/msf/db_manager/cred.rb:7:in `block (2 levels) in <top (required)>'

  5) Msf::DBManager it should behave like Msf::DBManager::Cred should respond to #report_auth
     Failure/Error: it { is_expected.to respond_to :report_auth }
       expected #<Metasploit::Framework::DataService::RemoteHTTPDataService:0x00007fe438ef0aa0 @endpoint=#<URI::HTTP ..."metasploit v5.0.0-dev-f636982b09"}, @client_pool=#<Thread::Queue:0x00007fe438ef07f8>, @active=true> to respond to :report_auth
     Shared Example Group: "Msf::DBManager::Cred" called from ./spec/lib/msf/db_manager_spec.rb:24
     # ./spec/support/shared/examples/msf/db_manager/cred.rb:6:in `block (2 levels) in <top (required)>'
...
Failed examples:

rspec ./spec/lib/msf/db_manager_spec.rb[1:4:6] # Msf::DBManager it should behave like Msf::DBManager::Cred should respond to #report_cred
rspec ./spec/lib/msf/db_manager_spec.rb[1:4:2] # Msf::DBManager it should behave like Msf::DBManager::Cred should respond to #each_cred
rspec ./spec/lib/msf/db_manager_spec.rb[1:4:3] # Msf::DBManager it should behave like Msf::DBManager::Cred should respond to #find_or_create_cred
rspec ./spec/lib/msf/db_manager_spec.rb[1:4:5] # Msf::DBManager it should behave like Msf::DBManager::Cred should respond to #report_auth_info
rspec ./spec/lib/msf/db_manager_spec.rb[1:4:4] # Msf::DBManager it should behave like Msf::DBManager::Cred should respond to #report_auth
...
```

## Verification

- [x] Run `bundle exec rake spec`
- [x] **Verify** there are no `Msf::DBManager::Cred` related test failures
- [x] Run `REMOTE_DB=1 bundle exec rake spec`
- [x] **Verify** there are no `Msf::DBManager::Cred` related test failures