### PR TITLE
Update Travis CI to run remote data service spec tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ env:
   - CMD='bundle exec rake rspec-rerun:spec SPEC_OPTS="--tag ~content"'
   # Used for testing the remote data service
   - CMD='bundle exec rake rspec-rerun:spec SPEC_OPTS="--tag content" REMOTE_DB=1'
+  - CMD='bundle exec rake rspec-rerun:spec SPEC_OPTS="--tag ~content" REMOTE_DB=1'
 
 matrix:
   fast_finish: true

--- a/config/database.yml.travis
+++ b/config/database.yml.travis
@@ -14,7 +14,7 @@ development: &pgsql
   adapter: postgresql
   database: metasploit_framework_development
   username: postgres
-  pool: 5
+  pool: 25
   timeout: 5
 
 # Warning: The database defined as "test" will be erased and


### PR DESCRIPTION
Updates Travis CI to run remote data service spec tests. The tests that were run with `REMOTE_DB=1` started the web service, however, the errors seen in #11277 were not triggering issues in Travis CI.  Inspecting the Travis CI build logs, tests run with `REMOTE_DB=1` appeared to be running a smaller subset of tests "4670 examples, 0 failures".

Ticket: MS-3769

## Verification

- [x] Inspect the details of the Travis CI build `continuous-integration/travis-ci/pr` and identify those run with the `REMOTE_DB=1` set. These test logs should also include a few messages early in the log indicating that the remote data service was started:
    ```
    Thin web server (v1.7.2 codename Bachmanity)
    Maximum connections set to 1024
    Listening on 0.0.0.0:8080, CTRL+C to stop
    ```
- [x] **Verify** the remote data service spec tests are being run