### PR TITLE
Pass down workspace too report_web_site

### DIFF
--- a/plugins/wmap.rb
+++ b/plugins/wmap.rb
@@ -1344,7 +1344,7 @@ class Plugin::Wmap < Msf::Plugin
           ssl = true
         end
 
-        site = self.framework.db.report_web_site(:wait => true, :host => uri.host, :port => uri.port, :vhost => vhost, :ssl => ssl)
+        site = self.framework.db.report_web_site(:wait => true, :host => uri.host, :port => uri.port, :vhost => vhost, :ssl => ssl, :workspace => self.framework.db.workspace)
 
         return site
     end


### PR DESCRIPTION
Bug with wmap: #10999
Workspace wasn't passed down as a parameter to report_web_site, thus triggering:
`
[-] Error while running command wmap_sites: Problem reporting website: opts must include a valid :workspace. See log for more details.
`