### PR TITLE
Attribution

### DIFF
--- a/modules/exploits/linux/local/blueman_set_dhcp_handler_dbus_priv_esc.rb
+++ b/modules/exploits/linux/local/blueman_set_dhcp_handler_dbus_priv_esc.rb
@@ -29,8 +29,8 @@ class MetasploitModule < Msf::Exploit::Local
       'License'        => MSF_LICENSE,
       'Author'         =>
         [
-          'the grugq', # Discovery and exploit
-          'bcoles'     # Metasploit
+          'Sebastian Krahmer', # Discovery and exploit
+          'bcoles'             # Metasploit
         ],
       'DisclosureDate' => '2015-12-18',
       'References'     =>


### PR DESCRIPTION
https://twitter.com/thegrugq/status/1086607561732763649

> ah! I see the confusion. I was reposting the code in a tweet from a private account (by request). The correct author is, as I recall, Sebastian Krahmer @steaIth at SuSe Linux

@stealth

A request for CVE on Openwall [1] cited a Github issue [2] as the intial report, which cited the grugq's PoC tweet. SecurityFocus credits Salvatore Bonaccorso [3]. Confusing.

[1] https://www.openwall.com/lists/oss-security/2015/12/18/6
[2] https://github.com/blueman-project/blueman/issues/416
[3] https://www.securityfocus.com/bid/79688/info
