### PR TITLE
Add CVE-2018-1000999 to MailCleaner module

### DIFF
--- a/modules/exploits/linux/http/mailcleaner_exec.rb
+++ b/modules/exploits/linux/http/mailcleaner_exec.rb
@@ -26,7 +26,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'References'     =>
         [
           ['URL', 'https://pentest.blog/advisory-mailcleaner-community-edition-remote-code-execution/'],
-          ['CVE', '2018-20323']
+          ['CVE', '2018-20323'],
+          ['CVE', '2018-1000999']
         ],
       'DefaultOptions'  =>
         {


### PR DESCRIPTION
See PR #11148

This adds the new CVE assigned by DWF for this vulnerability.

Note that [CVE-2018-10933](https://www.cvedetails.com/cve/CVE-2018-10933/) describes a vulnerability in libssh, but this one describes the issue as it pertains to MailCleaner specifically.

## Verification

- [x] `./msfconsole -x "info exploit/linux/http/mailcleaner_exec; exit"`
- [x] **Verify** that CVE-2018-1000999 is displayed.
- [x] Note that the cvedetails link won't resolve quite yet -- that'll work a day or two after CVEProject/cvelist#1485 lands, but that oughtn't be a blocker for this PR.
