### PR TITLE
keep wordlist.to_file() backwords compatible

### DIFF
--- a/lib/metasploit/framework/jtr/wordlist.rb
+++ b/lib/metasploit/framework/jtr/wordlist.rb
@@ -371,7 +371,7 @@ module Metasploit
         #
         # @param max_len [Integer] max length of a word in the wordlist, 0 default for ignored value
         # @return [Rex::Quickfile] The {Rex::Quickfile} object that the wordlist has been written to
-        def to_file(max_len)
+        def to_file(max_len = 0)
           valid!
           wordlist_file = Rex::Quickfile.new("jtrtmp")
           each_word do |word|


### PR DESCRIPTION
Expands #11261 to make the change backwords compatible for usage of `wordlist.to_file()`

## Verification

List the steps needed to make sure this thing works

Same testing as #11261 

