### PR TITLE
Normalize newlines in CommandShell#run_single

### DIFF
--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -487,7 +487,7 @@ class CommandShell
     end
 
     # User input is not a built-in command, write to socket directly
-    shell_write(cmd + "\n")
+    shell_write(cmd.chomp + "\n")
   end
 
   #

--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -487,7 +487,7 @@ class CommandShell
     end
 
     # User input is not a built-in command, write to socket directly
-    shell_write(cmd.chomp + "\n")
+    shell_write(cmd + "\n")
   end
 
   #
@@ -652,7 +652,7 @@ protected
         user_output.print(shell_read)
       end
       if sd[0].include? user_input.fd
-        run_single(user_input.gets)
+        run_single((user_input.gets || '').chomp("\n"))
       end
       Thread.pass
     end


### PR DESCRIPTION
Lines from normal interaction will include a trailing newline, while lines from resource scripting will not.

```
resource (test.rc)> whoami
[*] Received: "whoami"
[*] Sent:     "whoami\n"

wvu
whoami
[*] Received: "whoami\n"
[*] Sent:     "whoami\n\n"
wvu
```

```
resource (test.rc)> whoami
[*] Received: "whoami"
[*] Sent:     "whoami\n"

wvu
whoami
[*] Received: "whoami\n"
[*] Sent:     "whoami\n"
wvu
```

Functionally, behavior should not change with this patch except in special cases such as here documents.

```
cat <<EOF
[*] Received: "cat <<EOF\n"
[*] Sent:     "cat <<EOF\n\n"
hello,
[*] Received: "hello,\n"
[*] Sent:     "hello,\n\n"
world
[*] Received: "world\n"
[*] Sent:     "world\n\n"
EOF
[*] Received: "EOF\n"
[*] Sent:     "EOF\n\n"

hello,

world

```

```
cat <<EOF
[*] Received: "cat <<EOF\n"
[*] Sent:     "cat <<EOF\n"
hello,
[*] Received: "hello,\n"
[*] Sent:     "hello,\n"
world
[*] Received: "world\n"
[*] Sent:     "world\n"
EOF
[*] Received: "EOF\n"
[*] Sent:     "EOF\n"
hello,
world
```

Updates #11271.