### PR TITLE
Don't use system() to ZIP files in auxiliary/client/smtp/emailer 

### DIFF
--- a/modules/auxiliary/client/smtp/emailer.rb
+++ b/modules/auxiliary/client/smtp/emailer.rb
@@ -177,7 +177,7 @@ class MetasploitModule < Msf::Auxiliary
       name = nem[0].split(' ')
       fname = name[0]
       lname = name[1]
-      email = nem[1]
+      email = nem[1].strip
 
 
       if add_name

--- a/modules/auxiliary/client/smtp/emailer.rb
+++ b/modules/auxiliary/client/smtp/emailer.rb
@@ -146,8 +146,6 @@ class MetasploitModule < Msf::Auxiliary
         })
 
       print_status("Writing payload to #{attachment_file}")
-      # XXX If Rex::Zip will let us zip a buffer instead of a file,
-      # there's no reason to write this out
       File.open(attachment_file, "wb") do |f|
         f.write(exe)
       end

--- a/modules/auxiliary/client/smtp/emailer.rb
+++ b/modules/auxiliary/client/smtp/emailer.rb
@@ -161,7 +161,8 @@ class MetasploitModule < Msf::Auxiliary
 
       if zip_payload
         zip_file = attachment_file.sub(/\.\w+$/, '.zip')
-        system("zip -r #{zip_file} #{attachment_file}> /dev/null 2>&1");
+        print_status("Zipping payload to #{zip_file}")
+        File.write(zip_file, Msf::Util::EXE.to_zip([fname: File.basename(attachment_file), data: exe]))
         attachment_file      = zip_file
         attachment_file_type = 'application/zip'
       else


### PR DESCRIPTION
```
msf5 auxiliary(client/smtp/emailer) > run

[*] 127.0.0.1:25 - Creating payload...
[*] 127.0.0.1:25 - Writing payload to /var/folders/mf/ddclmcss6z9df5nj3fzwn78wjsnnkf/T/`nc -lvp 1337 -e bash` #
[*] 127.0.0.1:25 - Zipping payload to /var/folders/mf/ddclmcss6z9df5nj3fzwn78wjsnnkf/T/`nc -lvp 1337 -e bash` #
[*] 127.0.0.1:25 - Email sent..
[*] Auxiliary module execution completed
msf5 auxiliary(client/smtp/emailer) > unzip -l '/var/folders/mf/ddclmcss6z9df5nj3fzwn78wjsnnkf/T/`nc -lvp 1337 -e bash` #'
[*] exec: unzip -l '/var/folders/mf/ddclmcss6z9df5nj3fzwn78wjsnnkf/T/`nc -lvp 1337 -e bash` #'

Archive:  /var/folders/mf/ddclmcss6z9df5nj3fzwn78wjsnnkf/T/`nc -lvp 1337 -e bash` #
  Length      Date    Time    Name
---------  ---------- -----   ----
    73802  01-24-2019 13:53   `nc -lvp 1337 -e bash` #
---------                     -------
    73802                     1 file
msf5 auxiliary(client/smtp/emailer) >
```

Fixes #11286.