### PR TITLE
updated smb-client to make it working again after being bugged for so…

### DIFF
--- a/lib/rex/proto/smb/client.rb
+++ b/lib/rex/proto/smb/client.rb
@@ -653,7 +653,7 @@ NTLM_UTILS = Rex::Proto::NTLM::Utils
 
     end
 
-    return self.session_setup_clear(*args)
+    return self.session_setup_clear(user, pass, domain)
   end
 
   # Authenticate using clear-text passwords


### PR DESCRIPTION
This change fixes the bug #11296 mentioned by me.
It has to be fixed to use old smb exploit, such as lsa_transnames or trans2open.


## Verification

List the steps needed to make sure this thing works

- [x ] Start `msfconsole`
- [ x] `use exploit/linux/samba/lsa_transnames `
- [ x] set all options and try to exploit
- [x ] **Verify** the exploit and other old samba exploits should work again
- [x] **Verify** The error of unknown method or variable should be gone
- [ ] **Document** the thing and how it works ([Example](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/post/multi/gather/aws_keys.md))

