### PR TITLE
db cisco hostname and version

### DIFF
--- a/lib/msf/core/auxiliary/cisco.rb
+++ b/lib/msf/core/auxiliary/cisco.rb
@@ -55,8 +55,23 @@ module Auxiliary::Cisco
 
     tuniface = nil
 
+    host_info = {
+      :host => thost,
+      :os_name => 'Cisco IOS',
+    }
+    report_host(host_info)
+
     config.each_line do |line|
       case line
+#
+# Cover host details
+#
+        when /^version (\d\d\.\d)/i
+          host_info[:os_flavor] = $1.to_s
+          report_host(host_info)
+        when /^hostname (\S+)/i
+          host_info[:name] = $1.to_s
+          report_host(host_info)
 #
 # Enable passwords
 #

--- a/spec/lib/msf/core/auxiliary/cisco_spec.rb
+++ b/spec/lib/msf/core/auxiliary/cisco_spec.rb
@@ -82,6 +82,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
     
     it 'deals with udp ports' do
       expect(aux_cisco).to receive(:print_good).with('127.0.0.1:161 Unencrypted Enable Password: 1511021F0725')
+      expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
       expect(aux_cisco).to receive(:store_loot).with(
         "cisco.ios.config", "text/plain", "127.0.0.1", "enable password 1511021F0725", "config.txt", "Cisco IOS Configuration"
       )
@@ -106,6 +107,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
       
       it 'with password type 0' do
         expect(aux_cisco).to receive(:print_good).with('127.0.0.1:1337 Enable Password: 1511021F0725')
+        expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
         expect(aux_cisco).to receive(:store_loot).with(
           "cisco.ios.enable_pass", "text/plain", "127.0.0.1", "1511021F0725", "enable_password.txt", "Cisco IOS Enable Password"
         )
@@ -132,6 +134,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
       
       it 'with password type 5' do
         expect(aux_cisco).to receive(:print_good).with('127.0.0.1:1337 MD5 Encrypted Enable Password: 1511021F0725')
+        expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
         expect(aux_cisco).to receive(:create_credential_and_login).with(
           {
             address: "127.0.0.1",
@@ -151,6 +154,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
       
       it 'with password type 7' do
         expect(aux_cisco).to receive(:print_good).with('127.0.0.1:1337 Decrypted Enable Password: cisco')
+        expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
         expect(aux_cisco).to receive(:store_loot).with(
           "cisco.ios.enable_pass", "text/plain", "127.0.0.1", "cisco", "enable_password.txt", "Cisco IOS Enable Password"
         )
@@ -178,6 +182,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
     
     it 'enable password' do
       expect(aux_cisco).to receive(:print_good).with('127.0.0.1:1337 Unencrypted Enable Password: 1511021F0725')
+      expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
       expect(aux_cisco).to receive(:store_loot).with(
         "cisco.ios.config", "text/plain", "127.0.0.1", "enable password 1511021F0725", "config.txt", "Cisco IOS Configuration"
       )
@@ -202,6 +207,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
       
       it 'with RO' do
         expect(aux_cisco).to receive(:print_good).with('127.0.0.1:1337 SNMP Community (RO): 1511021F0725')
+        expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
         expect(aux_cisco).to receive(:create_credential_and_login).with(
           {
             address: "127.0.0.1",
@@ -222,6 +228,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
       
       it 'with RW' do
         expect(aux_cisco).to receive(:print_good).with('127.0.0.1:1337 SNMP Community (RW): 1511021F0725')
+        expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
         expect(aux_cisco).to receive(:create_credential_and_login).with(
           {
             address: "127.0.0.1",
@@ -244,6 +251,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
     
     it 'password 7' do
       expect(aux_cisco).to receive(:print_good).with('127.0.0.1:1337 Decrypted VTY Password: cisco')
+      expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
       expect(aux_cisco).to receive(:store_loot).with(
         "cisco.ios.config", "text/plain", "127.0.0.1", "password 7 1511021F0725", "config.txt", "Cisco IOS Configuration"
       )
@@ -266,6 +274,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
     
     it 'password|secret 5' do
       expect(aux_cisco).to receive(:print_good).with('127.0.0.1:1337 MD5 Encrypted VTY Password: 1511021F0725')
+      expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
       expect(aux_cisco).to receive(:store_loot).with(
         "cisco.ios.vty_password", "text/plain", "127.0.0.1", "1511021F0725", "vty_password_hash.txt", "Cisco IOS VTY Password Hash (MD5)"
       )
@@ -291,6 +300,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
     
     it 'password 0' do
       expect(aux_cisco).to receive(:print_good).with('127.0.0.1:1337 Unencrypted VTY Password: 1511021F0725')
+      expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
       expect(aux_cisco).to receive(:store_loot).with(
         "cisco.ios.config", "text/plain", "127.0.0.1", "password 0 1511021F0725", "config.txt", "Cisco IOS Configuration"
       )
@@ -313,6 +323,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
     
     it 'password' do
       expect(aux_cisco).to receive(:print_good).with('127.0.0.1:1337 Unencrypted VTY Password: 1511021F0725')
+      expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
       expect(aux_cisco).to receive(:store_loot).with(
         "cisco.ios.config", "text/plain", "127.0.0.1", "password 1511021F0725", "config.txt", "Cisco IOS Configuration"
       )
@@ -335,6 +346,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
     
     it 'encryption key' do
       expect(aux_cisco).to receive(:print_good).with('127.0.0.1:1337 Wireless WEP Key: 1511021F0725')
+      expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
       expect(aux_cisco).to receive(:store_loot).with(
         "cisco.ios.config", "text/plain", "127.0.0.1", "encryption key 777 size 8bit 8 1511021F0725", "config.txt", "Cisco IOS Configuration"
       )
@@ -347,6 +359,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
     context 'wpa-psk' do
       it 'with password type 0' do
         expect(aux_cisco).to receive(:print_good).with('127.0.0.1:1337 Wireless WPA-PSK Password: 1511021F0725')
+        expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
         expect(aux_cisco).to receive(:store_loot).with(
           "cisco.ios.config", "text/plain", "127.0.0.1", "wpa-psk ascii 0 1511021F0725", "config.txt", "Cisco IOS Configuration"
         )
@@ -372,6 +385,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
       
       it 'with password type 5' do
         expect(aux_cisco).to receive(:print_good).with('127.0.0.1:1337 Wireless WPA-PSK MD5 Password Hash: 1511021F0725')
+        expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
         expect(aux_cisco).to receive(:store_loot).with(
           "cisco.ios.config", "text/plain", "127.0.0.1", "wpa-psk ascii 5 1511021F0725", "config.txt", "Cisco IOS Configuration"
         )
@@ -397,6 +411,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
       
       it 'with password type 7' do
         expect(aux_cisco).to receive(:print_good).with('127.0.0.1:1337 Wireless WPA-PSK Decrypted Password: cisco')
+        expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
         expect(aux_cisco).to receive(:store_loot).with(
           "cisco.ios.config", "text/plain", "127.0.0.1", "wpa-psk ascii 7 1511021F0725", "config.txt", "Cisco IOS Configuration"
         )
@@ -425,6 +440,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
     
     it 'crypto isakmp key' do
       expect(aux_cisco).to receive(:print_good).with("127.0.0.1:1337 VPN IPSEC ISAKMP Key '1511021F0725' Host 'someaddress'")
+      expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
       expect(aux_cisco).to receive(:store_loot).with(
         "cisco.ios.config", "text/plain", "127.0.0.1",  "crypto isakmp key 1511021F0725 address someaddress", "config.txt", "Cisco IOS Configuration"
       )
@@ -452,11 +468,14 @@ RSpec.describe Msf::Auxiliary::Cisco do
       expect(aux_cisco).to receive(:store_loot).with(
         "cisco.ios.config", "text/plain", "127.0.0.1",  "interface tunnel7", "config.txt", "Cisco IOS Configuration"
       )
+      expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
+
       aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'interface tunnel7')
     end
     
     it 'tunnel key' do
       expect(aux_cisco).to receive(:print_good).with("127.0.0.1:1337 GRE Tunnel Key 1511021F0725 for Interface Tunnel ")
+      expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
       expect(aux_cisco).to receive(:store_loot).with(
         "cisco.ios.gre_tunnel_key", "text/plain", "127.0.0.1", "tunnel_1511021F0725", "gre_tunnel_key.txt", "Cisco GRE Tunnel Key"
       )
@@ -482,6 +501,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
     
     it 'ip nhrp authentication' do
       expect(aux_cisco).to receive(:print_good).with("127.0.0.1:1337 NHRP Authentication Key 1511021F0725 for Interface Tunnel ")
+      expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
       expect(aux_cisco).to receive(:store_loot).with(
         "cisco.ios.config", "text/plain", "127.0.0.1", "ip nhrp authentication 1511021F0725", "config.txt", "Cisco IOS Configuration"
       )
@@ -508,6 +528,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
     context 'username privilege secret' do
       it 'with password type 0' do
         expect(aux_cisco).to receive(:print_good).with("127.0.0.1:1337 Username 'someusername' with Password: 1511021F0725")
+        expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
         expect(aux_cisco).to receive(:store_loot).with(
           "cisco.ios.config", "text/plain", "127.0.0.1", "username someusername privilege 0 secret 0 1511021F0725", "config.txt", "Cisco IOS Configuration"
         )
@@ -534,6 +555,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
       
       it 'with password type 5' do
         expect(aux_cisco).to receive(:print_good).with("127.0.0.1:1337 Username 'someusername' with MD5 Encrypted Password: 1511021F0725")
+        expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
         expect(aux_cisco).to receive(:store_loot).with(
           "cisco.ios.config", "text/plain", "127.0.0.1", "username someusername privilege 0 secret 5 1511021F0725", "config.txt", "Cisco IOS Configuration"
         )
@@ -561,6 +583,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
     
       it 'with password type 7' do
         expect(aux_cisco).to receive(:print_good).with("127.0.0.1:1337 Username 'someusername' with Decrypted Password: cisco")
+        expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
         expect(aux_cisco).to receive(:store_loot).with(
           "cisco.ios.config", "text/plain", "127.0.0.1", "username someusername privilege 0 secret 7 1511021F0725", "config.txt", "Cisco IOS Configuration"
         )
@@ -588,6 +611,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
     context 'username secret' do
       it 'with password type 0' do
         expect(aux_cisco).to receive(:print_good).with("127.0.0.1:1337 Username 'someusername' with Password: 1511021F0725")
+        expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
         expect(aux_cisco).to receive(:store_loot).with(
           "cisco.ios.config", "text/plain", "127.0.0.1", "username someusername secret 0 1511021F0725", "config.txt", "Cisco IOS Configuration"
         )
@@ -614,6 +638,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
       
       it 'with password type 5' do
         expect(aux_cisco).to receive(:print_good).with("127.0.0.1:1337 Username 'someusername' with MD5 Encrypted Password: 1511021F0725")
+        expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
         expect(aux_cisco).to receive(:store_loot).with(
           "cisco.ios.config", "text/plain", "127.0.0.1", "username someusername secret 5 1511021F0725", "config.txt", "Cisco IOS Configuration"
         )
@@ -641,6 +666,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
     
       it 'with password type 7' do
         expect(aux_cisco).to receive(:print_good).with("127.0.0.1:1337 Username 'someusername' with Decrypted Password: cisco")
+        expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
         expect(aux_cisco).to receive(:store_loot).with(
           "cisco.ios.config", "text/plain", "127.0.0.1", "username someusername secret 7 1511021F0725", "config.txt", "Cisco IOS Configuration"
         )
@@ -669,6 +695,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
     context 'ppp.*username secret' do
       it 'with password type 0' do
         expect(aux_cisco).to receive(:print_good).with("127.0.0.1:1337 PPP Username: someusername Password: 1511021F0725")
+        expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
         expect(aux_cisco).to receive(:store_loot).with(
           "cisco.ios.config", "text/plain", "127.0.0.1", "ppp123username someusername secret 0 1511021F0725", "config.txt", "Cisco IOS Configuration"
         )
@@ -695,6 +722,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
       
       it 'with password type 5' do
         expect(aux_cisco).to receive(:print_good).with("127.0.0.1:1337 PPP Username someusername MD5 Encrypted Password: 1511021F0725")
+        expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
         expect(aux_cisco).to receive(:store_loot).with(
           "cisco.ios.config", "text/plain", "127.0.0.1", "ppp123username someusername secret 5 1511021F0725", "config.txt", "Cisco IOS Configuration"
         )
@@ -722,6 +750,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
     
       it 'with password type 7' do
         expect(aux_cisco).to receive(:print_good).with("127.0.0.1:1337 PPP Username: someusername Decrypted Password: cisco")
+        expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
         expect(aux_cisco).to receive(:store_loot).with(
           "cisco.ios.config", "text/plain", "127.0.0.1", "ppp123username someusername secret 7 1511021F0725", "config.txt", "Cisco IOS Configuration"
         )
@@ -750,6 +779,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
     context 'ppp chap secret' do
       it 'with password type 0' do
         expect(aux_cisco).to receive(:print_good).with("127.0.0.1:1337 Password: 1511021F0725")
+        expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
         expect(aux_cisco).to receive(:store_loot).with(
           "cisco.ios.config", "text/plain", "127.0.0.1", "ppp chap secret 0 1511021F0725", "config.txt", "Cisco IOS Configuration"
         )
@@ -775,6 +805,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
       
       it 'with password type 5' do
         expect(aux_cisco).to receive(:print_good).with("127.0.0.1:1337 PPP CHAP MD5 Encrypted Password: 1511021F0725")
+        expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
         expect(aux_cisco).to receive(:store_loot).with(
           "cisco.ios.config", "text/plain", "127.0.0.1", "ppp chap secret 5 1511021F0725", "config.txt", "Cisco IOS Configuration"
         )
@@ -802,6 +833,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
     
       it 'with password type 7' do
         expect(aux_cisco).to receive(:print_good).with("127.0.0.1:1337 PPP Decrypted Password: cisco")
+        expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
         expect(aux_cisco).to receive(:store_loot).with(
           "cisco.ios.config", "text/plain", "127.0.0.1", "ppp chap secret 7 1511021F0725", "config.txt", "Cisco IOS Configuration"
         )


### PR DESCRIPTION
Previously part of #10798 this saves the hostname and OS version from cisco config files to the database.

This is delayed because i'm not sure how to run mocking manually and this will definitely fail as per: https://github.com/rapid7/metasploit-framework/pull/10798#pullrequestreview-165399043