### PR TITLE
Fix HTTP/SMB mixin order to restore SSL option

### DIFF
--- a/modules/exploits/multi/http/struts_code_exec_classloader.rb
+++ b/modules/exploits/multi/http/struts_code_exec_classloader.rb
@@ -8,8 +8,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::FileDropper
   include Msf::Exploit::EXE
-  include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::Remote::SMB::Server::Share
+  include Msf::Exploit::Remote::HttpClient
 
   def initialize(info = {})
     super(update_info(info,

--- a/modules/exploits/windows/http/generic_http_dll_injection.rb
+++ b/modules/exploits/windows/http/generic_http_dll_injection.rb
@@ -6,8 +6,8 @@
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ManualRanking
 
-  include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::Remote::SMB::Server::Share
+  include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::EXE
 
   def initialize(info={})


### PR DESCRIPTION
Mixin order matters. Mixins kinda suck (the way we use them).

Registering the SMB server share mixin after `HttpClient` deregisters the `SSL` and `SSLCert` options. They're still settable, but they vanish from the options lists.

- [x] Diff the normal and advanced options lists before and after this patch
- [x] Ensure nothing was lost, only gained

Reported by @terrorbyte.