### PR TITLE
updating jtr formats in hashdumpers

### DIFF
--- a/lib/msf/core/auxiliary/cisco.rb
+++ b/lib/msf/core/auxiliary/cisco.rb
@@ -83,18 +83,19 @@ module Auxiliary::Cisco
             print_good("#{thost}:#{tport} MD5 Encrypted Enable Password: #{shash}")
             store_loot("cisco.ios.enable_hash", "text/plain", thost, shash, "enable_password_hash.txt", "Cisco IOS Enable Password Hash (MD5)")
             cred = credential_data.dup
+            cred[:jtr_format] = 'md5'
             cred[:private_data] = shash
             cred[:private_type] = :nonreplayable_hash
             create_credential_and_login(cred)
           end
 
-          if stype == 0
+          if stype == 0 #unencrypted
             print_good("#{thost}:#{tport} Enable Password: #{shash}")
             store_loot("cisco.ios.enable_pass", "text/plain", thost, shash, "enable_password.txt", "Cisco IOS Enable Password")
 
             cred = credential_data.dup
             cred[:private_data] = shash
-            cred[:private_type] = :nonreplayable_hash
+            cred[:private_type] = :password
             create_credential_and_login(cred)
 
           end
@@ -116,7 +117,7 @@ module Auxiliary::Cisco
 
           cred = credential_data.dup
           cred[:private_data] = spass
-          cred[:private_type] = :nonreplayable_hash
+          cred[:private_type] = :password
           create_credential_and_login(cred)
 
 #
@@ -159,6 +160,7 @@ module Auxiliary::Cisco
           store_loot("cisco.ios.vty_password", "text/plain", thost, shash, "vty_password_hash.txt", "Cisco IOS VTY Password Hash (MD5)")
 
           cred = credential_data.dup
+          cred[:jtr_format] = 'md5'
           cred[:private_data] = shash
           cred[:private_type] = :nonreplayable_hash
           create_credential_and_login(cred)
@@ -169,7 +171,7 @@ module Auxiliary::Cisco
 
           cred = credential_data.dup
           cred[:private_data] = spass
-          cred[:private_type] = :nonreplayable_hash
+          cred[:private_type] = :password
           create_credential_and_login(cred)
 
 #
@@ -189,6 +191,7 @@ module Auxiliary::Cisco
             print_good("#{thost}:#{tport} Wireless WPA-PSK MD5 Password Hash: #{spass}")
             store_loot("cisco.ios.wireless_wpapsk_hash", "text/plain", thost, spass, "wireless_wpapsk_hash.txt", "Cisco IOS Wireless WPA-PSK Password Hash (MD5)")
             cred = credential_data.dup
+            cred[:jtr_format] = 'md5'
             cred[:private_data] = spass
             cred[:private_type] = :nonreplayable_hash
             create_credential_and_login(cred)
@@ -199,7 +202,7 @@ module Auxiliary::Cisco
             store_loot("cisco.ios.wireless_wpapsk", "text/plain", thost, spass, "wireless_wpapsk.txt", "Cisco IOS Wireless WPA-PSK Password")
             cred = credential_data.dup
             cred[:private_data] = spass
-            cred[:private_type] = :nonreplayable_hash
+            cred[:private_type] = :password
             create_credential_and_login(cred)
           end
 
@@ -269,6 +272,7 @@ module Auxiliary::Cisco
             print_good("#{thost}:#{tport} Username '#{user}' with MD5 Encrypted Password: #{spass}")
             store_loot("cisco.ios.username_password_hash", "text/plain", thost, "#{user}_level#{priv}:#{spass}", "username_password_hash.txt", "Cisco IOS Username and Password Hash (MD5)")
             cred = credential_data.dup
+            cred[:jtr_format] = 'md5'
             cred[:private_data] = spass
             cred[:private_type] = :nonreplayable_hash
             create_credential_and_login(cred)
@@ -280,7 +284,7 @@ module Auxiliary::Cisco
 
             cred = credential_data.dup
             cred[:private_data] = spass
-            cred[:private_type] = :nonreplayable_hash
+            cred[:private_type] = :password
             create_credential_and_login(cred)
           end
 
@@ -306,7 +310,7 @@ module Auxiliary::Cisco
           store_loot("cisco.ios.ephone.username_password", "text/plain", thost, "#{user}:#{spass}", "ephone_username_password.txt", "Cisco IOS ephone Username and Password")
           cred = credential_data.dup
           cred[:private_data] = spass
-          cred[:private_type] = :nonreplayable_hash
+          cred[:private_type] = :password
           create_credential_and_login(cred)
 
         when /^\s*username ([^\s]+) (secret|password) (\d+) ([^\s]+)/i
@@ -318,6 +322,7 @@ module Auxiliary::Cisco
             print_good("#{thost}:#{tport} Username '#{user}' with MD5 Encrypted Password: #{spass}")
             store_loot("cisco.ios.username_password_hash", "text/plain", thost, "#{user}:#{spass}", "username_password_hash.txt", "Cisco IOS Username and Password Hash (MD5)")
             cred = credential_data.dup
+            cred[:jtr_format] = 'md5'
             cred[:private_data] = spass
             cred[:private_type] = :nonreplayable_hash
             create_credential_and_login(cred)
@@ -329,7 +334,7 @@ module Auxiliary::Cisco
 
             cred = credential_data.dup
             cred[:private_data] = spass
-            cred[:private_type] = :nonreplayable_hash
+            cred[:private_type] = :password
             create_credential_and_login(cred)
           end
 
@@ -355,6 +360,7 @@ module Auxiliary::Cisco
             store_loot("cisco.ios.ppp_username_password_hash", "text/plain", thost, "#{suser}:#{spass}", "ppp_username_password_hash.txt", "Cisco IOS PPP Username and Password Hash (MD5)")
 
             cred = credential_data.dup
+            cred[:jtr_format] = 'md5'
             cred[:private_data] = spass
             cred[:private_type] = :nonreplayable_hash
             create_credential_and_login(cred)
@@ -366,7 +372,7 @@ module Auxiliary::Cisco
 
             cred = credential_data.dup
             cred[:private_data] = spass
-            cred[:private_type] = :nonreplayable_hash
+            cred[:private_type] = :password
             create_credential_and_login(cred)
           end
 
@@ -389,6 +395,7 @@ module Auxiliary::Cisco
             print_good("#{thost}:#{tport} PPP CHAP MD5 Encrypted Password: #{spass}")
             store_loot("cisco.ios.ppp_password_hash", "text/plain", thost, spass, "ppp_password_hash.txt", "Cisco IOS PPP Password Hash (MD5)")
             cred = credential_data.dup
+            cred[:jtr_format] = 'md5'
             cred[:private_data] = spass
             cred[:private_type] = :nonreplayable_hash
             create_credential_and_login(cred)
@@ -400,7 +407,7 @@ module Auxiliary::Cisco
 
             cred = credential_data.dup
             cred[:private_data] = spass
-            cred[:private_type] = :nonreplayable_hash
+            cred[:private_type] = :password
             create_credential_and_login(cred)
           end
 

--- a/lib/msf/core/auxiliary/juniper.rb
+++ b/lib/msf/core/auxiliary/juniper.rb
@@ -60,6 +60,7 @@ module Auxiliary::Juniper
       print_good("User #{user_uid} named #{user_name} found with password hash #{user_hash}. Enable permission: #{user_enable}")
       cred = credential_data.dup
       cred[:username] = user_name
+      cred[:jtr_format] = 'sha1'
       cred[:private_data] = user_hash
       cred[:private_type] = :nonreplayable_hash
       create_credential_and_login(cred)
@@ -139,16 +140,28 @@ module Auxiliary::Juniper
       status: Metasploit::Model::Login::Status::UNTRIED
     }
 
-    store_loot('juniper.netscreen.config', 'text/plain', thost, config.strip, 'config.txt', 'Juniper Netscreen Configuration')
+    store_loot('juniper.junos.config', 'text/plain', thost, config.strip, 'config.txt', 'Juniper Netscreen Configuration')
 
     # we'll take out the pretty format so its easier to regex
     config = config.split("\n").join('')
 
     if /root-authentication[\s]+\{[\s]+encrypted-password "(?<root_hash>[^"]+)";/i =~ config
       root_hash = root_hash.strip
+      case
+        when root_hash.start_with?('$1$')
+          jtr_format = 'md5'
+        when root_hash.start_with?('$5$')
+          jtr_format = 'sha256,crypt'
+        when root_hash.start_with?('$6$')
+          jtr_format = 'sha512,crypt'
+        else
+          jtr_format = ''
+      end
+
       print_good("root password hash: #{root_hash}")
       cred = credential_data.dup
       cred[:username] = 'root'
+      cred[:jtr_format] = jtr_format
       cred[:private_data] = root_hash
       cred[:private_type] = :nonreplayable_hash
       create_credential_and_login(cred)
@@ -160,9 +173,20 @@ module Auxiliary::Juniper
       user_uid  = result[1].strip
       user_permission = result[2].strip
       user_hash = result[3].strip
+      case
+        when user_hash.start_with?('$1$')
+          jtr_format = 'md5'
+        when user_hash.start_with?('$5$')
+          jtr_format = 'sha256,crypt'
+        when user_hash.start_with?('$6$')
+          jtr_format = 'sha512,crypt'
+        else
+          jtr_format = ''
+      end
       print_good("User #{user_uid} named #{user_name} in group #{user_permission} found with password hash #{user_hash}.")
       cred = credential_data.dup
       cred[:username] = user_name
+      cred[:jtr_format] = jtr_format
       cred[:private_data] = user_hash
       cred[:private_type] = :nonreplayable_hash
       create_credential_and_login(cred)

--- a/modules/post/linux/gather/hashdump.rb
+++ b/modules/post/linux/gather/hashdump.rb
@@ -34,9 +34,22 @@ class MetasploitModule < Msf::Post
       john_file = unshadow(passwd_file, shadow_file)
       john_file.each_line do |l|
         hash_parts = l.split(':')
-
+        case
+          when hash_parts[1].start_with?('$1$')
+            jtr_format = 'md5'
+          when hash_parts[1].start_with?('$2a$'), hash_parts[1].start_with?('$2y$')
+            jtr_format = 'bf'
+          when hash_parts[1].start_with?('$5$')
+            jtr_format = 'sha256,crypt'
+          when hash_parts[1].start_with?('$6$')
+            jtr_format = 'sha512,crypt'
+          when hash_parts[1].start_with?('_')
+            jtr_format = 'des,bsdi,crypt'
+          else
+            jtr_format = 'des,bsdi,crypt'
+        end
         credential_data = {
-            jtr_format: 'md5,des,bsdi,crypt',
+            jtr_format: jtr_format,
             origin_type: :session,
             post_reference_name: self.refname,
             private_type: :nonreplayable_hash,

--- a/modules/post/osx/gather/hashdump.rb
+++ b/modules/post/osx/gather/hashdump.rb
@@ -175,14 +175,26 @@ class MetasploitModule < Msf::Post
     when "NT"
       private_data = "#{Metasploit::Credential::NTLMHash::BLANK_LM_HASH}:#{hash}"
       private_type = :ntlm_hash
+      jtr_format = 'ntlm'
     when "LM"
       private_data = "#{hash}:#{Metasploit::Credential::NTLMHash::BLANK_NT_HASH}"
       private_type = :ntlm_hash
-    when "SHA-512 PBKDF2", "SHA-512", "SHA-1"
+      jtr_format = 'lm'
+    when "SHA-512 PBKDF2"
       private_data = hash
       private_type = :nonreplayable_hash
+      jtr_format = 'PBKDF2-HMAC-SHA512'
+    when "SHA-512"
+      private_data = hash
+      private_type = :nonreplayable_hash
+      jtr_format = 'sha512,crypt'
+    when "SHA-1"
+      private_data = hash
+      private_type = :nonreplayable_hash
+      jtr_format = 'sha1'
     end
     create_credential(
+      jtr_format: jtr_format,
       workspace_id: myworkspace_id,
       origin_type: :session,
       session_id: session_db_id,

--- a/modules/post/solaris/gather/hashdump.rb
+++ b/modules/post/solaris/gather/hashdump.rb
@@ -34,6 +34,32 @@ class MetasploitModule < Msf::Post
       # Unshadow the files
       john_file = unshadow(passwd_file, shadow_file)
       john_file.each_line do |l|
+        hash_parts = l.split(':')
+        case
+          when hash_parts[1].start_with?('$1$')
+            jtr_format = 'md5'
+          when hash_parts[1].start_with?('$2a$'), hash_parts[1].start_with?('$2y$')
+            jtr_format = 'bf'
+          when hash_parts[1].start_with?('$5$')
+            jtr_format = 'sha256,crypt'
+          when hash_parts[1].start_with?('$6$')
+            jtr_format = 'sha512,crypt'
+          when hash_parts[1].start_with?('_')
+            jtr_format = 'des,bsdi,crypt'
+          else
+            jtr_format = 'des,bsdi,crypt'
+        end
+        credential_data = {
+            jtr_format: jtr_format,
+            origin_type: :session,
+            post_reference_name: self.refname,
+            private_type: :nonreplayable_hash,
+            private_data: hash_parts[1],
+            session_id: session_db_id,
+            username: hash_parts[0],
+            workspace_id: myworkspace_id
+        }
+        create_credential(credential_data)
         print_good(l.chomp)
       end
       # Save pwd file

--- a/spec/lib/msf/core/auxiliary/cisco_spec.rb
+++ b/spec/lib/msf/core/auxiliary/cisco_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
           service_name: '',
           module_fullname: "auxiliary/scanner/snmp/cisco_dummy",
           private_data: "1511021F0725",
-          private_type: :nonreplayable_hash,
+          private_type: :password,
           status: Metasploit::Model::Login::Status::UNTRIED
         }
       )
@@ -124,7 +124,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
             service_name: '',
             module_fullname: "auxiliary/scanner/snmp/cisco_dummy",
             private_data: "1511021F0725",
-            private_type: :nonreplayable_hash,
+            private_type: :password,
             status: Metasploit::Model::Login::Status::UNTRIED
           }
         )
@@ -145,6 +145,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
             service_name: '',
             module_fullname: "auxiliary/scanner/snmp/cisco_dummy",
             private_data: "1511021F0725",
+            jtr_format: 'md5',
             private_type: :nonreplayable_hash,
             status: Metasploit::Model::Login::Status::UNTRIED
           }
@@ -196,7 +197,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
           service_name: '',
           module_fullname: "auxiliary/scanner/snmp/cisco_dummy",
           private_data: "1511021F0725",
-          private_type: :nonreplayable_hash,
+          private_type: :password,
           status: Metasploit::Model::Login::Status::UNTRIED
         }
       )
@@ -291,6 +292,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
           service_name: '',
           module_fullname: "auxiliary/scanner/snmp/cisco_dummy",
           private_data: "1511021F0725",
+          jtr_format: "md5",
           private_type: :nonreplayable_hash,
           status: Metasploit::Model::Login::Status::UNTRIED
         }
@@ -314,7 +316,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
           service_name: '',
           module_fullname: "auxiliary/scanner/snmp/cisco_dummy",
           private_data: "1511021F0725",
-          private_type: :nonreplayable_hash,
+          private_type: :password,
           status: Metasploit::Model::Login::Status::UNTRIED
         }
       )
@@ -337,7 +339,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
           service_name: '',
           module_fullname: "auxiliary/scanner/snmp/cisco_dummy",
           private_data: "1511021F0725",
-          private_type: :nonreplayable_hash,
+          private_type: :password,
           status: Metasploit::Model::Login::Status::UNTRIED
         }
       )
@@ -376,7 +378,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
             service_name: '',
             module_fullname: "auxiliary/scanner/snmp/cisco_dummy",
             private_data: "1511021F0725",
-            private_type: :nonreplayable_hash,
+            private_type: :password,
             status: Metasploit::Model::Login::Status::UNTRIED
           }
         )
@@ -402,6 +404,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
             service_name: '',
             module_fullname: "auxiliary/scanner/snmp/cisco_dummy",
             private_data: "1511021F0725",
+            jtr_format: 'md5',
             private_type: :nonreplayable_hash,
             status: Metasploit::Model::Login::Status::UNTRIED
           }
@@ -545,7 +548,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
             service_name: '',
             module_fullname: "auxiliary/scanner/snmp/cisco_dummy",
             private_data: "1511021F0725",
-            private_type: :nonreplayable_hash,
+            private_type: :password,
             status: Metasploit::Model::Login::Status::UNTRIED
           }
         )
@@ -573,6 +576,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
             service_name: '',
             module_fullname: "auxiliary/scanner/snmp/cisco_dummy",
             private_data: "1511021F0725",
+            jtr_format: 'md5',
             private_type: :nonreplayable_hash,
             status: Metasploit::Model::Login::Status::UNTRIED
           }
@@ -629,7 +633,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
             service_name: '',
             module_fullname: "auxiliary/scanner/snmp/cisco_dummy",
             private_data: "1511021F0725",
-            private_type: :nonreplayable_hash,
+            private_type: :password,
             status: Metasploit::Model::Login::Status::UNTRIED
           }
         )
@@ -656,6 +660,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
             service_name: '',
             module_fullname: "auxiliary/scanner/snmp/cisco_dummy",
             private_data: "1511021F0725",
+            jtr_format: 'md5',
             private_type: :nonreplayable_hash,
             status: Metasploit::Model::Login::Status::UNTRIED
           }
@@ -713,7 +718,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
             service_name: '',
             module_fullname: "auxiliary/scanner/snmp/cisco_dummy",
             private_data: "1511021F0725",
-            private_type: :nonreplayable_hash,
+            private_type: :password,
             status: Metasploit::Model::Login::Status::UNTRIED
           }
         )
@@ -740,6 +745,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
             service_name: '',
             module_fullname: "auxiliary/scanner/snmp/cisco_dummy",
             private_data: "1511021F0725",
+            jtr_format: 'md5',
             private_type: :nonreplayable_hash,
             status: Metasploit::Model::Login::Status::UNTRIED
           }
@@ -796,7 +802,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
             service_name: '',
             module_fullname: "auxiliary/scanner/snmp/cisco_dummy",
             private_data: "1511021F0725",
-            private_type: :nonreplayable_hash,
+            private_type: :password,
             status: Metasploit::Model::Login::Status::UNTRIED
           }
         )
@@ -823,6 +829,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
             service_name: '',
             module_fullname: "auxiliary/scanner/snmp/cisco_dummy",
             private_data: "1511021F0725",
+            jtr_format: 'md5',
             private_type: :nonreplayable_hash,
             status: Metasploit::Model::Login::Status::UNTRIED
           }


### PR DESCRIPTION
Many of the hashdump modules don't set `jtr_format` (or do it incorrectly) causing the jtr cracker modules to either have to guess or make assumptions.  This updates them to store the data more accurately.

Because of #11334 you will need to incorporate #11339 to check this.

Also, because this field isn't ever exposed you'll need to `irb` to view the results:
```
msf5 post(linux/gather/hashdump) > run

[+] ubuntu:$6$s/P86y1v$3iCYV5UoCwcxqmEns.LoC8WNahnwdNNCwABJ9vNzOY5bR2INug.ErrKZpG6LL06KxD7I5292iJpbxIna3pjKH.:1000:1000:ubuntu,,,:/home/ubuntu:/bin/bash
[+] Unshadowed Password File: /.msf4/loot/20190130201415_default_111.111.1.111_linux.hashes_647789.txt
[*] Post module execution completed
msf5 post(linux/gather/hashdump) > creds
Credentials
===========

host           origin         service       public   private                                                                                             realm  private_type
----           ------         -------       ------   -------                                                                                             -----  ------------
               111.111.1.111                ubuntu   $6$s/P86y1v$3iCYV5UoCwcxqmEns.LoC8WNahnwdNNCwABJ9vNzOY5bR2INug.ErrKZpG6LL06KxD7I5292iJpbxIna3pjKH.         Nonreplayable hash
111.111.1.22   111.111.1.22   22/tcp (ssh)  solaris  Solaris!                                                                                                   Password
111.111.1.111  111.111.1.111  22/tcp (ssh)  ubuntu   ubuntu                                                                                                     Password

msf5 post(linux/gather/hashdump) > irb
[*] Starting IRB shell...
[*] You are in post/linux/gather/hashdump

>> framework.db.creds().each do |c|
?>   puts c.private.jtr_format
>> end

sha512,crypt


```