### PR TITLE
Add module to discover Ubiquiti devices

### DIFF
--- a/documentation/modules/auxiliary/scanner/ubiquiti/ubiquiti_discover.md
+++ b/documentation/modules/auxiliary/scanner/ubiquiti/ubiquiti_discover.md
@@ -1,0 +1,21 @@
+## Vulnerable Application
+
+Many devices produced by Ubiquiti are affected by this issue.
+
+## Verification Steps
+
+  1. Locate a network known or suspected to house Ubiquiti devices
+  2. Start msfconsole
+  3. Do: `use auxiliary/scanner/ubiquiti_discovery`
+  3. Do: `set RHOSTS <some_targets>`
+  4. Do: `run`
+
+## Scenarios
+
+  An example run against a Ubiquiti EdgeRouter-X:
+
+
+  ```
+  msf5 auxiliary(scanner/ubiquiti/ubiquiti_discover) > run
+  [+] 192.168.1.1:10001 Ubiquiti Discovery metadata: {"ips"=>["192.168.0.1", "192.168.1.1"], "macs"=>["80:2a:a8:df:aa:bb", "f8:1e:df:f8:aa:bb"], "name"=>"ubnt", "model_short"=>"ER-X", "firmware"=>"EdgeRouter.ER-e50.v1.9.7+hotfix.4.5024279.171006.0255"}
+  ```

--- a/modules/auxiliary/scanner/ubiquiti/ubiquiti_discover.rb
+++ b/modules/auxiliary/scanner/ubiquiti/ubiquiti_discover.rb
@@ -35,13 +35,13 @@ class MetasploitModule < Msf::Auxiliary
   def scanner_process(data, shost, sport)
     offset = 0
     if data.length < 4
-        return
+      return
     end
 
     type, length = data.unpack("vn")
     offset += 4
     if type != 1 || length != data.length - offset
-        return
+      return
     end
 
     remaining = data.length - offset
@@ -52,11 +52,11 @@ class MetasploitModule < Msf::Auxiliary
       remaining -= 4
 
       field_data = data.slice(offset, length)
+      offset += length
+      remaining -= length
       if field_data.empty?
         next
       end
-      offset += length
-      remaining -= length
       # name
       if type == 0x0b
         info['name'] = field_data
@@ -80,6 +80,7 @@ class MetasploitModule < Msf::Auxiliary
       elsif type == 0x0d
         info['essid'] = field_data
       else
+        vprint_warning("#{shost}:#{sport} skipping unhandled #{length}-byte field type '#{type}': '#{field_data.unpack("H*")}'")
       end
     end
 

--- a/modules/auxiliary/scanner/ubiquiti/ubiquiti_discover.rb
+++ b/modules/auxiliary/scanner/ubiquiti/ubiquiti_discover.rb
@@ -1,0 +1,103 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::UDPScanner
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'        => 'Ubiquiti Discovery Scanner',
+        'Description' => 'Detects Ubiquiti devices using a UDP discovery service',
+        'Author'      => 'Jon Hart <jon_hart[at]rapid7.com>',
+        'License'     => MSF_LICENSE,
+        'References'  =>
+          [
+            ['URL', 'https://www.us-cert.gov/ncas/alerts/TA14-017A'],
+            ['URL', 'https://community.ubnt.com/t5/airMAX-General-Discussion/airOS-airMAX-and-management-access/td-p/2654023']
+          ]
+      )
+    )
+
+    register_options([
+      Opt::RPORT(10001)
+    ])
+  end
+
+  def build_probe
+    @probe = "\x01\x00\x00\x00"
+  end
+
+  def scanner_process(data, shost, sport)
+    offset = 0
+    if data.length < 4
+        return
+    end
+
+    type, length = data.unpack("vn")
+    offset += 4
+    if type != 1 || length != data.length - offset
+        return
+    end
+
+    remaining = data.length - offset
+    info = {'ips' =>  [], 'macs' => []}
+    while remaining > 0
+      type, length = data.slice(offset, 3).unpack("Cn")
+      offset += 3
+      remaining -= 4
+
+      field_data = data.slice(offset, length)
+      offset += length
+      remaining -= length
+      if type == 0x0b
+        info['name'] = field_data
+      elsif type == 0x01
+        # process the MAC
+        info['macs'] << field_data.each_byte.map { |b| b.to_s(16) }.join(':')
+      elsif type == 0x02
+        # process a MAC and IP
+        info['macs'] << field_data.slice(0,6).each_byte.map { |b| b.to_s(16) }.join(':')
+        info['ips'] << field_data.slice(6,4).each_byte.map { |b| b.to_i }.join('.')
+        #info['macs'].append(':'.join("{:02x}".format(b) for b in struct.unpack("BBBBBB", field_data[:6])))
+        #info['ips'].append('.'.join(str(int(b)) for b in struct.unpack("BBBB", field_data[6:10])))
+      elsif type == 0x14
+        info['model_long'] = field_data
+      elsif type == 0x0c
+        info['model_short'] = field_data
+      elsif type == 0x03
+        info['firmware'] = field_data
+      elsif  type == 0x0d
+        info['essid'] = field_data
+      else
+      end
+    end
+
+    if ! info['macs'].any?
+      info.delete('macs')
+    end
+    info['macs'] = info['macs'].sort.uniq
+
+    if ! info['ips'].any?
+      info.delete('ips')
+    end
+    info['ips'] = info['ips'].sort.uniq
+
+    if info.empty?
+      return
+    end
+
+    print_good("#{shost}:#{sport} #{info}")
+    report_service(
+      host: shost,
+      proto: 'udp',
+      port: rport,
+      info: info,
+      name: 'ubiquiti_discovery'
+    )
+  end
+end

--- a/modules/auxiliary/scanner/ubiquiti/ubiquiti_discover.rb
+++ b/modules/auxiliary/scanner/ubiquiti/ubiquiti_discover.rb
@@ -52,26 +52,32 @@ class MetasploitModule < Msf::Auxiliary
       remaining -= 4
 
       field_data = data.slice(offset, length)
+      if field_data.empty?
+        next
+      end
       offset += length
       remaining -= length
+      # name
       if type == 0x0b
         info['name'] = field_data
+      # MAC
       elsif type == 0x01
-        # process the MAC
         info['macs'] << field_data.each_byte.map { |b| b.to_s(16) }.join(':')
+      # MAC and IP
       elsif type == 0x02
-        # process a MAC and IP
         info['macs'] << field_data.slice(0,6).each_byte.map { |b| b.to_s(16) }.join(':')
         info['ips'] << field_data.slice(6,4).each_byte.map { |b| b.to_i }.join('.')
-        #info['macs'].append(':'.join("{:02x}".format(b) for b in struct.unpack("BBBBBB", field_data[:6])))
-        #info['ips'].append('.'.join(str(int(b)) for b in struct.unpack("BBBB", field_data[6:10])))
+      # long model
       elsif type == 0x14
         info['model_long'] = field_data
+      # short model
       elsif type == 0x0c
         info['model_short'] = field_data
+      # firmware version
       elsif type == 0x03
         info['firmware'] = field_data
-      elsif  type == 0x0d
+      # essid in some situations
+      elsif type == 0x0d
         info['essid'] = field_data
       else
       end

--- a/modules/auxiliary/scanner/ubiquiti/ubiquiti_discover.rb
+++ b/modules/auxiliary/scanner/ubiquiti/ubiquiti_discover.rb
@@ -91,7 +91,7 @@ class MetasploitModule < Msf::Auxiliary
       return
     end
 
-    print_good("#{shost}:#{sport} #{info}")
+    print_good("#{shost}:#{sport} Ubiquiti Discovery metadata: #{info}")
     report_service(
       host: shost,
       proto: 'udp',


### PR DESCRIPTION
This adds a scanner module to facilitate discovering devices made by Ubiquiti using a simple UDP protocol that operates on 10001.  

This service can be disabled and can include metadata about the device in question including name, model, version, MACs and IPs.  A future improvement, perhaps as part of this PR, would be to use these fields more officially in the `report_` calls.



## Verification

- [x] Locate a network known or suspected to house Ubiquiti devices
- [x] Start msfconsole
- [x] Do: `use auxiliary/scanner/ubiquiti_discovery`
- [x] Do: `set RHOSTS <some_targets>`
- [x] Do: `run`

```
[+] a.b.c.d:10001 Ubiquiti Discovery metadata: {"ips"=>["a.b.c.d"], "macs"=>["f0:9f:c2:4c:aa:bb"], "name"=>"mFi4c5051", "model_short"=>"P8U", "firmware"=>"MF.ar933x.v2.0.25.1238.140624.1356"}
```
