### PR TITLE
Move command_exists? to Msf::Post::Common

### DIFF
--- a/lib/msf/core/post/common.rb
+++ b/lib/msf/core/post/common.rb
@@ -240,7 +240,13 @@ module Msf::Post::Common
   # @return [Boolean]
   #
   def command_exists?(cmd)
-    cmd_exec("command -v #{cmd} && echo true").to_s.include? 'true'
+    if session.platform == 'windows'
+      # https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/where_1
+      # https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/if
+      cmd_exec("cmd /c where /q #{cmd} & if not errorlevel 1 echo true").to_s.include? 'true'
+    else
+      cmd_exec("command -v #{cmd} && echo true").to_s.include? 'true'
+    end
   rescue
     raise "Unable to check if command `#{cmd}' exists"
   end

--- a/lib/msf/core/post/common.rb
+++ b/lib/msf/core/post/common.rb
@@ -235,6 +235,14 @@ module Msf::Post::Common
     nil
   end
 
-  private
+  #
+  # Checks if the `cmd` is installed on the system
+  # @return [Boolean]
+  #
+  def command_exists?(cmd)
+    cmd_exec("command -v #{cmd} && echo true").to_s.include? 'true'
+  rescue
+    raise "Unable to check if command `#{cmd}' exists"
+  end
 
 end

--- a/lib/msf/core/post/linux/system.rb
+++ b/lib/msf/core/post/linux/system.rb
@@ -226,16 +226,6 @@ module System
   end
 
   #
-  # Checks if the `cmd` is installed on the system
-  # @return [Boolean]
-  #
-  def command_exists?(cmd)
-    cmd_exec("command -v #{cmd} && echo true").to_s.include? 'true'
-  rescue
-    raise "Unable to check if command `#{cmd}` exists"
-  end
-
-  #
   # Gets the process id(s) of `program`
   # @return [Array]
   #

--- a/lib/msf/core/post/solaris/system.rb
+++ b/lib/msf/core/post/solaris/system.rb
@@ -119,16 +119,6 @@ module System
   end
 
   #
-  # Checks if the `cmd` is installed on the system
-  # @return [Boolean]
-  #
-  def command_exists?(cmd)
-    cmd_exec("command -v #{cmd} && echo true").to_s.include? 'true'
-  rescue
-    raise "Unable to check if command `#{cmd}` exists"
-  end
-
-  #
   # Gets the process id(s) of `program`
   # @return [Array]
   #


### PR DESCRIPTION
And add rudimentary Windows support.

```
meterpreter > run post/linux/gather/hashdump

[+] vagrant:$6$pjYWAc.5$QYfO.wN80gnGe2kC1jYmSTGmO/qelG1CMl6ubKMbDQt9b1TEKZ648PQGI7VC88XE3ObdPBswUavsC1eDVZunJ.:1000:1000:,,,:/home/vagrant:/bin/bash
[+] Unshadowed Password File: /Users/wvu/.msf4/loot/20190131221240_default_172.28.128.3_linux.hashes_959802.txt
meterpreter >
```

```
[1] pry(#<Msf::Modules::Post__Linux__Gather__Hashdump::MetasploitModule>)> command_exists?('calc')
=> true
[2] pry(#<Msf::Modules::Post__Linux__Gather__Hashdump::MetasploitModule>)> command_exists?('nope')
=> false
[3] pry(#<Msf::Modules::Post__Linux__Gather__Hashdump::MetasploitModule>)>
```

Fixes #11334, hopefully. See #10119 for the regression.