### PR TITLE
Add functionality to change Net::SSH's client identification string

### DIFF
--- a/lib/msf/core/exploit/ssh.rb
+++ b/lib/msf/core/exploit/ssh.rb
@@ -1,18 +1,27 @@
+# -*- coding: binary -*-
+
 module Msf::Exploit::Remote::SSH
 
   # Require most things so that modules using this will "just work"
   require 'net/ssh'
   require 'net/ssh/command_stream'
   require 'rex/socket/ssh_factory'
+  require 'msf/core/exploit/ssh/options'
   require 'msf/core/exploit/ssh/auth_methods'
+
+  # Register SSH datastore options:
+  #   SSHVersion
+  #   SSH_TIMEOUT (TODO: Refactor to SSHTimeout)
+  #   SSH_DEBUG   (TODO: Refactor to SSHDebug)
+  include Msf::Exploit::Remote::SSH::Options
+
+  # Patch in our custom auth methods:
+  #   malformed-packet
+  #   fortinet-backdoor
+  include Msf::Exploit::Remote::SSH::AuthMethods
 
   def ssh_socket_factory
     Rex::Socket::SSHFactory.new(framework, self, datastore['Proxies'])
   end
-
-  # Finally patch in our custom auth methods:
-  #   malformed-packet
-  #   fortinet-backdoor
-  include Msf::Exploit::Remote::SSH::AuthMethods
 
 end

--- a/lib/msf/core/exploit/ssh.rb
+++ b/lib/msf/core/exploit/ssh.rb
@@ -1,13 +1,13 @@
 # -*- coding: binary -*-
 
-module Msf::Exploit::Remote::SSH
+# Require most things so that modules using this will "just work"
+require 'net/ssh'
+require 'net/ssh/command_stream'
+require 'rex/socket/ssh_factory'
+require 'msf/core/exploit/ssh/options'
+require 'msf/core/exploit/ssh/auth_methods'
 
-  # Require most things so that modules using this will "just work"
-  require 'net/ssh'
-  require 'net/ssh/command_stream'
-  require 'rex/socket/ssh_factory'
-  require 'msf/core/exploit/ssh/options'
-  require 'msf/core/exploit/ssh/auth_methods'
+module Msf::Exploit::Remote::SSH
 
   # Register SSH datastore options:
   #   SSH_IDENT   (TODO: Refactor to SSHIdent)

--- a/lib/msf/core/exploit/ssh.rb
+++ b/lib/msf/core/exploit/ssh.rb
@@ -10,7 +10,7 @@ module Msf::Exploit::Remote::SSH
   require 'msf/core/exploit/ssh/auth_methods'
 
   # Register SSH datastore options:
-  #   SSHVersion
+  #   SSH_IDENT   (TODO: Refactor to SSHIdent)
   #   SSH_TIMEOUT (TODO: Refactor to SSHTimeout)
   #   SSH_DEBUG   (TODO: Refactor to SSHDebug)
   include Msf::Exploit::Remote::SSH::Options

--- a/lib/msf/core/exploit/ssh/auth_methods.rb
+++ b/lib/msf/core/exploit/ssh/auth_methods.rb
@@ -1,3 +1,5 @@
+# -*- coding: binary -*-
+
 module Msf::Exploit::Remote::SSH::AuthMethods
 
   #

--- a/lib/msf/core/exploit/ssh/options.rb
+++ b/lib/msf/core/exploit/ssh/options.rb
@@ -47,7 +47,7 @@ module Options
       :PROTO_VERSION,
       datastore['SSH_IDENT']
     )
-
+  ensure
     $VERBOSE = verbose
   end
 

--- a/lib/msf/core/exploit/ssh/options.rb
+++ b/lib/msf/core/exploit/ssh/options.rb
@@ -1,8 +1,11 @@
 # -*- coding: binary -*-
 
+require 'net/ssh'
+
 # Include this mixin if you want just the SSH datastore options
 # (e.g., when using Metasploit::Framework::LoginScanner::SSH)
-module Msf::Exploit::Remote::SSH::Options
+module Msf::Exploit::Remote::SSH
+module Options
 
   def initialize(info = {})
     super
@@ -35,6 +38,18 @@ module Msf::Exploit::Remote::SSH::Options
         ]
       )
     ])
+
+    # HACK: Suppress already initialized constant warning
+    verbose, $VERBOSE = $VERBOSE, nil
+
+    # HACK: Bypass dynamic constant assignment error
+    ::Net::SSH::Transport::ServerVersion.const_set(
+      :PROTO_VERSION,
+      datastore['SSH_IDENT']
+    )
+
+    $VERBOSE = verbose
   end
 
+end
 end

--- a/lib/msf/core/exploit/ssh/options.rb
+++ b/lib/msf/core/exploit/ssh/options.rb
@@ -8,6 +8,9 @@ module Msf::Exploit::Remote::SSH
 module Options
 
   def initialize(info = {})
+    # HACK: Suppress already initialized constant warning
+    verbose, $VERBOSE = $VERBOSE, nil
+
     super
 
     register_advanced_options([
@@ -38,9 +41,6 @@ module Options
         ]
       )
     ])
-
-    # HACK: Suppress already initialized constant warning
-    verbose, $VERBOSE = $VERBOSE, nil
 
     # HACK: Bypass dynamic constant assignment error
     ::Net::SSH::Transport::ServerVersion.const_set(

--- a/lib/msf/core/exploit/ssh/options.rb
+++ b/lib/msf/core/exploit/ssh/options.rb
@@ -48,6 +48,7 @@ module Options
       datastore['SSH_IDENT']
     )
   ensure
+    # Restore warning
     $VERBOSE = verbose
   end
 

--- a/lib/msf/core/exploit/ssh/options.rb
+++ b/lib/msf/core/exploit/ssh/options.rb
@@ -1,0 +1,40 @@
+# -*- coding: binary -*-
+
+# Include this mixin if you want just the SSH datastore options
+# (e.g., when using Metasploit::Framework::LoginScanner::SSH)
+module Msf::Exploit::Remote::SSH::Options
+
+  def initialize(info = {})
+    super
+
+    register_advanced_options([
+      # See Msf::Ui::Console::Driver#on_variable_set
+      Msf::OptString.new(
+        'SSHVersion',
+        [
+         true,
+         'SSH client identification string',
+         'SSH-2.0-OpenSSH_7.6p1 Ubuntu-4ubuntu0.3' # Ubuntu 18.04 LTS
+        ]
+      ),
+      # Ugh, why weren't these advanced options CamelCase?
+      Msf::OptInt.new(
+        'SSH_TIMEOUT',
+        [
+          false,
+          'Maximum SSH negotiation/authentication time in seconds',
+          10
+        ]
+      ),
+      Msf::OptBool.new(
+        'SSH_DEBUG',
+        [
+          false,
+          'Enable output of SSH protocol debugging information',
+          false
+        ]
+      )
+    ])
+  end
+
+end

--- a/lib/msf/core/exploit/ssh/options.rb
+++ b/lib/msf/core/exploit/ssh/options.rb
@@ -10,7 +10,7 @@ module Msf::Exploit::Remote::SSH::Options
     register_advanced_options([
       # See Msf::Ui::Console::Driver#on_variable_set
       Msf::OptString.new(
-        'SSHVersion',
+        'SSH_IDENT',
         [
          true,
          'SSH client identification string',

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -420,8 +420,8 @@ class Driver < Msf::Ui::Driver
       handle_console_logging(val) if glob
     when 'loglevel'
       handle_loglevel(val) if glob
-    when 'sshversion'
-      handle_sshversion(val)
+    when 'ssh_ident'
+      handle_ssh_ident(val)
     end
   end
 
@@ -577,7 +577,7 @@ protected
   end
 
   # This method monkeypatches Net::SSH's client identification string
-  def handle_sshversion(val)
+  def handle_ssh_ident(val)
     return false unless val.is_a?(String) && !val.empty?
 
     begin

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -600,6 +600,7 @@ protected
     print_error('Invalid constant Net::SSH::Transport::ServerVersion::PROTO_VERSION')
     false
   ensure
+    # Restore warning
     $VERBOSE = verbose
   end
 

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -431,12 +431,12 @@ class Driver < Msf::Ui::Driver
   #
   def on_variable_unset(glob, var)
     case var.downcase
-      when "sessionlogging"
-        handle_session_logging('0') if (glob)
-      when "consolelogging"
-        handle_console_logging('0') if (glob)
-      when "loglevel"
-        handle_loglevel(nil) if (glob)
+    when 'sessionlogging'
+      handle_session_logging('0') if glob
+    when 'consolelogging'
+      handle_console_logging('0') if glob
+    when 'loglevel'
+      handle_loglevel(nil) if glob
     end
   end
 

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -582,12 +582,12 @@ protected
   # TODO: Move this out of the console driver!
   #
   def handle_ssh_ident(val)
+    # HACK: Suppress already initialized constant warning
+    verbose, $VERBOSE = $VERBOSE, nil
+
     return false unless val.is_a?(String) && !val.empty?
 
     require 'net/ssh'
-
-    # HACK: Suppress already initialized constant warning
-    verbose, $VERBOSE = $VERBOSE, nil
 
     # HACK: Bypass dynamic constant assignment error
     ::Net::SSH::Transport::ServerVersion.const_set(:PROTO_VERSION, val)

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -580,7 +580,7 @@ protected
   # This method monkeypatches Net::SSH's client identification string.
   #
   def handle_ssh_version(val)
-    return false unless val && val.kind_of?(String) && !val.empty?
+    return false unless val.is_a?(String) && !val.empty?
 
     begin
       require 'net/ssh'

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -585,6 +585,7 @@ protected
     begin
       require 'net/ssh'
     rescue LoadError
+      print_error('Net::SSH could not be loaded')
       return false
     end
 
@@ -595,6 +596,7 @@ protected
       # HACK: Bypass dynamic constant assignment error
       ::Net::SSH::Transport::ServerVersion.const_set(:PROTO_VERSION, val)
     rescue NameError
+      print_error('Invalid constant Net::SSH::Transport::ServerVersion::PROTO_VERSION')
       return false
     end
 

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -576,9 +576,7 @@ protected
     set_log_level(Msf::LogSource, val)
   end
 
-  #
-  # This method monkeypatches Net::SSH's client identification string.
-  #
+  # This method monkeypatches Net::SSH's client identification string
   def handle_sshversion(val)
     return false unless val.is_a?(String) && !val.empty?
 

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -421,7 +421,7 @@ class Driver < Msf::Ui::Driver
     when 'loglevel'
       handle_loglevel(val) if glob
     when 'sshversion'
-      handle_ssh_version(val)
+      handle_sshversion(val)
     end
   end
 
@@ -579,7 +579,7 @@ protected
   #
   # This method monkeypatches Net::SSH's client identification string.
   #
-  def handle_ssh_version(val)
+  def handle_sshversion(val)
     return false unless val.is_a?(String) && !val.empty?
 
     begin

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -584,27 +584,23 @@ protected
   def handle_ssh_ident(val)
     return false unless val.is_a?(String) && !val.empty?
 
-    begin
-      require 'net/ssh'
-    rescue LoadError
-      print_error('Net::SSH could not be loaded')
-      return false
-    end
+    require 'net/ssh'
 
     # HACK: Suppress already initialized constant warning
     verbose, $VERBOSE = $VERBOSE, nil
 
-    begin
-      # HACK: Bypass dynamic constant assignment error
-      ::Net::SSH::Transport::ServerVersion.const_set(:PROTO_VERSION, val)
-    rescue NameError
-      print_error('Invalid constant Net::SSH::Transport::ServerVersion::PROTO_VERSION')
-      return false
-    end
-
-    $VERBOSE = verbose
+    # HACK: Bypass dynamic constant assignment error
+    ::Net::SSH::Transport::ServerVersion.const_set(:PROTO_VERSION, val)
 
     true
+  rescue LoadError
+    print_error('Net::SSH could not be loaded')
+    false
+  rescue NameError
+    print_error('Invalid constant Net::SSH::Transport::ServerVersion::PROTO_VERSION')
+    false
+  ensure
+    $VERBOSE = verbose
   end
 
   # Require the appropriate readline library based on the user's preference.

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -576,7 +576,11 @@ protected
     set_log_level(Msf::LogSource, val)
   end
 
+  #
   # This method monkeypatches Net::SSH's client identification string
+  #
+  # TODO: Move this out of the console driver!
+  #
   def handle_ssh_ident(val)
     return false unless val.is_a?(String) && !val.empty?
 

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -404,25 +404,24 @@ class Driver < Msf::Ui::Driver
   #
   def on_variable_set(glob, var, val)
     case var.downcase
-      when "payload"
-
-        if (framework and framework.payloads.valid?(val) == false)
-          return false
-        elsif active_module && active_module.type == 'exploit' && !active_module.is_payload_compatible?(val)
-          return false
-        elsif (active_module)
-          active_module.datastore.clear_non_user_defined
-        elsif (framework)
-          framework.datastore.clear_non_user_defined
-        end
-      when "sessionlogging"
-        handle_session_logging(val) if (glob)
-      when "consolelogging"
-        handle_console_logging(val) if (glob)
-      when "loglevel"
-        handle_loglevel(val) if (glob)
-      when "sshversion"
-        handle_sshversion(val)
+    when 'payload'
+      if framework && !framework.payloads.valid?(val)
+        return false
+      elsif active_module && active_module.type == 'exploit' && !active_module.is_payload_compatible?(val)
+        return false
+      elsif active_module
+        active_module.datastore.clear_non_user_defined
+      elsif framework
+        framework.datastore.clear_non_user_defined
+      end
+    when 'sessionlogging'
+      handle_session_logging(val) if glob
+    when 'consolelogging'
+      handle_console_logging(val) if glob
+    when 'loglevel'
+      handle_loglevel(val) if glob
+    when 'sshversion'
+      handle_ssh_version(val)
     end
   end
 
@@ -578,9 +577,9 @@ protected
   end
 
   #
-  # This method monkeypatches Net::SSH's identification string.
+  # This method monkeypatches Net::SSH's client identification string.
   #
-  def handle_sshversion(val)
+  def handle_ssh_version(val)
     return false unless val && val.kind_of?(String) && !val.empty?
 
     begin

--- a/modules/auxiliary/scanner/ssh/karaf_login.rb
+++ b/modules/auxiliary/scanner/ssh/karaf_login.rb
@@ -11,6 +11,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::AuthBrute
   include Msf::Auxiliary::Report
+  include Msf::Exploit::Remote::SSH::Options
 
   DEFAULT_USERNAME = 'karaf'
   DEFAULT_PASSWORD = 'karaf'

--- a/modules/auxiliary/scanner/ssh/ssh_login.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login.rb
@@ -12,8 +12,8 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::AuthBrute
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::CommandShell
-
   include Msf::Auxiliary::Scanner
+  include Msf::Exploit::Remote::SSH::Options
 
   def initialize
     super(

--- a/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
@@ -13,8 +13,8 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::AuthBrute
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::CommandShell
-
   include Msf::Auxiliary::Scanner
+  include Msf::Exploit::Remote::SSH::Options
 
   attr_accessor :ssh_socket, :good_key
 
@@ -245,6 +245,5 @@ class MetasploitModule < Msf::Auxiliary
       @cache[filename] ||= Net::SSH::KeyFactory.load_data_private_key(File.read(key_path), password, false, key_path).to_s
       @cache[filename]
     end
-
   end
 end


### PR DESCRIPTION
We'll want to send a patch to upstream later to make this easier.

## `Msf::Exploit::Remote::SSH`

```
msf5 > use libssh

Matching Modules
================

   #  Name                                      Disclosure Date  Rank    Check  Description
   -  ----                                      ---------------  ----    -----  -----------
   0  auxiliary/scanner/ssh/libssh_auth_bypass  2018-10-16       normal  Yes    libssh Authentication Bypass Scanner


[*] Using auxiliary/scanner/ssh/libssh_auth_bypass
msf5 auxiliary(scanner/ssh/libssh_auth_bypass) > setg rhosts 127.0.0.1
rhosts => 127.0.0.1
msf5 auxiliary(scanner/ssh/libssh_auth_bypass) > setg rport 2222
rport => 2222
msf5 auxiliary(scanner/ssh/libssh_auth_bypass) > grep SSH advanced
   SSH_DEBUG                   false            no        SSH debugging
   SSH_IDENT                   test             yes       SSH client identification string
   SSH_TIMEOUT                 10               no        SSH timeout
msf5 auxiliary(scanner/ssh/libssh_auth_bypass) > run

[*] 127.0.0.1:2222 - Attempting authentication bypass
^C[*] Caught interrupt from the console...
[*] Auxiliary module execution completed
msf5 auxiliary(scanner/ssh/libssh_auth_bypass) >
```

```
wvu@kharak:~$ ncat -lkv 2222
Ncat: Version 7.70 ( https://nmap.org/ncat )
Ncat: Listening on :::2222
Ncat: Listening on 0.0.0.0:2222
Ncat: Connection from 127.0.0.1.
Ncat: Connection from 127.0.0.1:58371.
SSH-2.0-OpenSSH_7.6p1 Ubuntu-4ubuntu0.3
```

```
msf5 auxiliary(scanner/ssh/libssh_auth_bypass) > setg ssh_ident SSH-2.0-OpenSSH_7.9
ssh_ident => SSH-2.0-OpenSSH_7.9
msf5 auxiliary(scanner/ssh/libssh_auth_bypass) > run

[*] 127.0.0.1:2222 - Attempting authentication bypass
```

```
Ncat: Connection from 127.0.0.1.
Ncat: Connection from 127.0.0.1:58381.
SSH-2.0-OpenSSH_7.9
```

## `Metasploit::Framework::LoginScanner::SSH`

```
msf5 auxiliary(scanner/ssh/libssh_auth_bypass) > use ssh_login

Matching Modules
================

   #  Name                                    Disclosure Date  Rank    Check  Description
   -  ----                                    ---------------  ----    -----  -----------
   0  auxiliary/scanner/ssh/ssh_login                          normal  Yes    SSH Login Check Scanner
   1  auxiliary/scanner/ssh/ssh_login_pubkey                   normal  Yes    SSH Public Key Login Scanner


msf5 auxiliary(scanner/ssh/libssh_auth_bypass) > use 0
msf5 auxiliary(scanner/ssh/ssh_login) > set username mulder
username => mulder
msf5 auxiliary(scanner/ssh/ssh_login) > set password trustno1
password => trustno1
msf5 auxiliary(scanner/ssh/ssh_login) > run
```

```
Ncat: Connection from 127.0.0.1.
Ncat: Connection from 127.0.0.1:58392.
SSH-2.0-OpenSSH_7.9
```