### PR TITLE
Fix some things in the Ubiquiti discovery PR

### DIFF
--- a/documentation/modules/auxiliary/scanner/ubiquiti/ubiquiti_discover.md
+++ b/documentation/modules/auxiliary/scanner/ubiquiti/ubiquiti_discover.md
@@ -7,8 +7,8 @@ Many devices produced by Ubiquiti are affected by this issue.
   1. Locate a network known or suspected to house Ubiquiti devices
   2. Start msfconsole
   3. Do: `use auxiliary/scanner/ubiquiti_discovery`
-  3. Do: `set RHOSTS <some_targets>`
-  4. Do: `run`
+  4. Do: `set RHOSTS <some_targets>`
+  5. Do: `run`
 
 ## Scenarios
 

--- a/modules/auxiliary/scanner/ubiquiti/ubiquiti_discover.rb
+++ b/modules/auxiliary/scanner/ubiquiti/ubiquiti_discover.rb
@@ -58,26 +58,27 @@ class MetasploitModule < Msf::Auxiliary
         next
       end
       # name
-      if type == 0x0b
+      case type
+      when 0x0b
         info['name'] = field_data
       # MAC
-      elsif type == 0x01
+      when 0x01
         info['macs'] << field_data.each_byte.map { |b| b.to_s(16) }.join(':')
       # MAC and IP
-      elsif type == 0x02
+      when 0x02
         info['macs'] << field_data.slice(0,6).each_byte.map { |b| b.to_s(16) }.join(':')
         info['ips'] << field_data.slice(6,4).each_byte.map { |b| b.to_i }.join('.')
       # long model
-      elsif type == 0x14
+      when 0x14
         info['model_long'] = field_data
       # short model
-      elsif type == 0x0c
+      when 0x0c
         info['model_short'] = field_data
       # firmware version
-      elsif type == 0x03
+      when 0x03
         info['firmware'] = field_data
       # essid in some situations
-      elsif type == 0x0d
+      when 0x0d
         info['essid'] = field_data
       else
         vprint_warning("#{shost}:#{sport} skipping unhandled #{length}-byte field type '#{type}': '#{field_data.unpack("H*")}'")

--- a/modules/auxiliary/scanner/ubiquiti/ubiquiti_discover.rb
+++ b/modules/auxiliary/scanner/ubiquiti/ubiquiti_discover.rb
@@ -18,7 +18,8 @@ class MetasploitModule < Msf::Auxiliary
         'References'  =>
           [
             ['URL', 'https://www.us-cert.gov/ncas/alerts/TA14-017A'],
-            ['URL', 'https://community.ubnt.com/t5/airMAX-General-Discussion/airOS-airMAX-and-management-access/td-p/2654023']
+            ['URL', 'https://community.ubnt.com/t5/airMAX-General-Discussion/airOS-airMAX-and-management-access/td-p/2654023'],
+            ['URL', 'https://blog.rapid7.com/2019/02/01/ubiquiti-discovery-service-exposures/']
           ]
       )
     )


### PR DESCRIPTION
1. Prefer `case` statement for readability
2. Fix numbering typo in module doc
3. Update references with fresh blog post

Fixes #11338.