### PR TITLE
WIP: Apply john.pot

### DIFF
--- a/modules/auxiliary/analyze/apply_pot.rb
+++ b/modules/auxiliary/analyze/apply_pot.rb
@@ -3,25 +3,80 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
+
+
+## redo all this and let john --show do the work.
+## also create a hash file with everything in it to test.
+
+
+
 class MetasploitModule < Msf::Auxiliary
+  #include Msf::Auxiliary::Report
+  include Msf::Auxiliary::JohnTheRipper
 
   def initialize
     super(
       'Name'            => 'Apply Pot File To Hashes',
       'Description'     => %Q{
           This module uses a John the Ripper or Hashcat .pot file to crack any password
-        hashes instantly.
+        hashes in the creds database instantly.  JtR's --show functionality is used to 
+        help combine all the passwords into an easy to use format.
       },
-      'Author'          => ['h00die']
+      'Author'          => ['h00die'],
       'License'         => MSF_LICENSE
     )
     register_options([
-      OptFile.new('POT', [false, '.pot file to apply to password hashes', '/'])
+      OptPath.new('POT', [true, '.pot file to apply to password hashes', '/'])
     ])
 
   end
 
   def run
+    cracker = new_john_cracker
+
+    # this is our lookup table for translating hashes to jtr style
+    # to what is in the database
+    hashes = []
+
+    class HashLookup
+      def initialize(db_hash, jtr_hash, username, id)
+        @db_hash = db_hash
+        @jtr_hash = jtr_hash
+        @username = username
+        @id = id
+      end
+    end
+
+    # create a hash file with all the hashes
+    framework.db.creds(workspace: myworkspace).each do |core|
+      next if type == 'Metasploit::Credential::Password'
+        user = core.public.username
+        case core.private.jtr_type
+        when 'oracle12c'
+          if core.private.data =~ /T:([\dA-F]{160})/
+            jtr_hash = "$oracle12c$#{$1.downcase}"
+          end
+        when 'oracle11'
+          if core.private.data =~ /S:([\dA-F]{60})/
+            jtr_hash_string = $1
+          end
+        when 'dynamic_1506'
+          if core.private.data =~ /H:([\dA-F]{32})/
+            user = user.upcase
+            jtr_hash = "$dynamic_1506$#{$1}"
+          end
+        when /postgres|raw-md5/
+          jtr_hash = core.private.data
+          jtr_hash.gsub!(/^md5/, '')
+          jtr_hash = "#{user}:$dynamic_1034$#{jtr_hash}"
+        else
+          #des, md5, sha1, crypt, bf, bsdi
+          #mssql, mssql05, mssql12
+          #mysql, mysql-sha1
+        end
+        hash = HashLooup.new(core.private.data, jtr_hash, user, core.id)
+    end
+
     # Load the pot file
     unless ::File.file?(datastore['POT'])
       fail_with Failure::NotFound, ".pot file #{datastore['POT']} not found"
@@ -34,11 +89,14 @@ class MetasploitModule < Msf::Auxiliary
       next if type == 'Metasploit::Credential::Password'
       pot.each_line do |p|
         p = p.split(":")
-        hash = p.shift
+        pot_hash = p.shift
         password = p.join(":")
-        next unless core.private.data == hash
-        print_good("Found #{core.username}:#{password}")
-        create_cracked_credential( username: core.username, password: password, core_id: core.id)
+        username = core.public.username
+        db_hash = core.private.data
+        # we need to do some manipulation here to make sure everything matches up correctly
+        next unless db_hash == pot_hash
+        print_good("Found #{username}:#{password}")
+        create_cracked_credential( username: username, password: password, core_id: core.id)
       end
     end
   end

--- a/modules/auxiliary/analyze/apply_pot.rb
+++ b/modules/auxiliary/analyze/apply_pot.rb
@@ -1,0 +1,45 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+
+  def initialize
+    super(
+      'Name'            => 'Apply Pot File To Hashes',
+      'Description'     => %Q{
+          This module uses a John the Ripper or Hashcat .pot file to crack any password
+        hashes instantly.
+      },
+      'Author'          => ['h00die']
+      'License'         => MSF_LICENSE
+    )
+    register_options([
+      OptFile.new('POT', [false, '.pot file to apply to password hashes', '/'])
+    ])
+
+  end
+
+  def run
+    # Load the pot file
+    unless ::File.file?(datastore['POT'])
+      fail_with Failure::NotFound, ".pot file #{datastore['POT']} not found"
+    end
+    f = ::File.open(datastore['POT'], 'rb')
+    pot = f.read(f.stat.size)
+    f.close
+
+    framework.db.creds(workspace: myworkspace).each do |core|
+      next if type == 'Metasploit::Credential::Password'
+      pot.each_line do |p|
+        p = p.split(":")
+        hash = p.shift
+        password = p.join(":")
+        next unless core.private.data == hash
+        print_good("Found #{core.username}:#{password}")
+        create_cracked_credential( username: core.username, password: password, core_id: core.id)
+      end
+    end
+  end
+end

--- a/modules/auxiliary/analyze/apply_pot.rb
+++ b/modules/auxiliary/analyze/apply_pot.rb
@@ -22,20 +22,6 @@ class MetasploitModule < Msf::Auxiliary
     )
   end
 
-  # Not all hash formats include an 'id' field, which coresponds which db entry
-  # an item is to its hash.  This can be problematic, especially when a username
-  # is used as a salt.  Due to all the variations, we make a small HashLookup
-  # class to handle all the fields for easier lookup later.
-  class HashLookup
-    def initialize(db_hash, jtr_hash, username, id)
-      @db_hash = db_hash
-      @jtr_hash = jtr_hash
-      @username = username
-      @id = id
-    end
-  end
-
-
   def run
     cracker = new_john_cracker
 
@@ -96,7 +82,7 @@ class MetasploitModule < Msf::Auxiliary
           # get the NT and LM hashes
           nt_hash = fields.pop
           lm_hash = fields.pop
-          id = fields.pop
+          core_id = fields.pop
           password = fields.join(':')
           if format == 'lm'
             if password.blank?
@@ -115,12 +101,6 @@ class MetasploitModule < Msf::Auxiliary
         print_good "#{username}:#{password}"
         unless core_id.nil?
           create_cracked_credential( username: username, password: password, core_id: core_id)
-          next
-        else
-          print_bad("#{password_line}")
-        end
-        lookups.each do |h|
-          next 
         end
       end
     end

--- a/modules/auxiliary/analyze/apply_pot.rb
+++ b/modules/auxiliary/analyze/apply_pot.rb
@@ -60,15 +60,15 @@ class MetasploitModule < Msf::Auxiliary
     # lanman, and other assorted nuances
     ['lm', 'nt', 'dynamic_1034', 'oracle11', 'oracle12c', 'dynamic_1506',
      'oracle', 'md5crypt', 'descrypt', 'bcrypt', 'crypt', 'mysql', 'mysql-sha1',
-     'mssql', 'mssql05', 'mssql12'].each do |format|
+     'mssql', 'mssql05', 'mssql12', 'bsdicrypt'].each do |format|
  
       print_status("Checking #{format} hashes against pot file")
       cracker.format = format
       cracker.each_cracked_password do |password_line|
         password_line.chomp!
         next if password_line.blank? || password_line.nil?
-        print_bad("#{password_line}")
         fields = password_line.split(":")
+        core_id = nil
         case format
         when 'descrypt'
           next unless fields.count >=3
@@ -113,9 +113,14 @@ class MetasploitModule < Msf::Auxiliary
         end
         password = fields.join(':')        
         print_good "#{username}:#{password}"
+        unless core_id.nil?
+          create_cracked_credential( username: username, password: password, core_id: core_id)
+          next
+        else
+          print_bad("#{password_line}")
+        end
         lookups.each do |h|
           next 
-          create_cracked_credential( username: username, password: password, core_id: core_id)
         end
       end
     end


### PR DESCRIPTION
Lets say your team has an awesome john.pot file from many engagements, we'll call it a poor man's rainbow tables even. You get to a new engagement, and pop a /etc/shadow that is awesome.  Currently, you must run the john module and have it try to crack the passwords.  There isn't a way just apply your trusty john.pot file to the new hashes and instantly crack those.... until now.

Introducing, `apply_pot.rb`.

I was able to run this against all the hashes in #1136 in one second, as opposed to loading several jtr modules and letting it run through a bunch of different modes that didn't mattered because it was already cracked anyways.

Requires  #11316

## Verification
Run #11316, this will create the pot file w/ all the passwords you want.
Run the portion of #1136 where it creates all the creds, then run `apply_pot`.
```
resource (hashes_pot.rb)> date
[*] exec: date

Fri Feb  1 16:54:20 EST 2019
resource (hashes_pot.rb)> use auxiliary/analyze/apply_pot
resource (hashes_pot.rb)> run
[*] Hashes Written out to /tmp/hashes_tmp20190201-29740-1qyoqc3
[*] Checking lm hashes against pot file
[+] lm_password:password
[*] Checking nt hashes against pot file
[+] lm_password:password
[+] nt_password:password
[*] Checking dynamic_1034 hashes against pot file
Unknown ciphertext format name requested
[*] Checking oracle11 hashes against pot file
[+] DEMO:epsilon
[+] oracle11_epsilon:epsilon
[*] Checking oracle12c hashes against pot file
[+] oracle12c_epsilon:epsilon
[*] Checking dynamic_1506 hashes against pot file
Unknown ciphertext format name requested
[*] Checking oracle hashes against pot file
[+] simon:A
[+] SYSTEM:THALES
[*] Checking md5crypt hashes against pot file
[+] md5_password:password
[*] Checking descrypt hashes against pot file
[+] des_passphrase:????????se
[+] des_password:password
[*] Checking bcrypt hashes against pot file
[+] blowfish_password:password
[*] Checking crypt hashes against pot file
Warning: hash encoding string length 24, type id #3
appears to be unsupported on this system; will not load such hashes.
Warning: hash encoding string length 46, type id $d
appears to be unsupported on this system; will not load such hashes.
[+] des_password:password
[+] md5_password:password
[+] sha256_password:password
[+] sha512_password:password
[*] Checking mysql hashes against pot file
[+] mysql_probe:probe
[*] Checking mysql-sha1 hashes against pot file
[+] mssql-sha1_tere:tere
[*] Checking mssql hashes against pot file
[+] mssql_foo:FOO
[*] Checking mssql05 hashes against pot file
[+] mssql05_toto:toto
[+] mssql_foo:foo
[*] Checking mssql12 hashes against pot file
[+] mssql12_Password1!:Password1!
[*] Checking bsdicrypt hashes against pot file
[+] bsdi_password:password
[*] Auxiliary module execution completed
resource (hashes_pot.rb)> date
[*] exec: date

Fri Feb  1 16:54:20 EST 2019
```

