### PR TITLE
Add URL scheme and Base64.encode64 checks to msftidy

### DIFF
--- a/tools/dev/msftidy.rb
+++ b/tools/dev/msftidy.rb
@@ -265,6 +265,10 @@ class Msftidy
     if @source =~ /^# This file is part of the Metasploit Framework and may be subject to/
       warn("Module contains old license comment.")
     end
+    if @source =~ /^# This module requires Metasploit: http:/
+      warn("Module license comment link does not use https:// URL scheme.")
+      fixed('# This module requires Metasploit: https://metasploit.com/download', idx)
+    end
   end
 
   def check_old_keywords
@@ -609,8 +613,14 @@ class Msftidy
 
       if ln =~ /['"]ExitFunction['"]\s*=>/
         warn("Please use EXITFUNC instead of ExitFunction #{ln}", idx)
+        fixed(line.gsub('ExitFunction', 'EXITFUNC'), idx)
       end
 
+      # Output from Base64.encode64 method contains '\n' new lines
+      # for line wrapping and string termination
+      if ln =~ /Base64\.encode64/
+        info("Please use Base64.strict_encode64 instead of Base64.encode64")
+      end
     end
   end
 
@@ -647,7 +657,7 @@ class Msftidy
   # This module then got copied and committed 20+ times and is used in numerous other places.
   # This ensures that this stops.
   def check_invalid_url_scheme
-    test = @source.scan(/^#.+http\/\/(?:www\.)?metasploit.com/)
+    test = @source.scan(/^#.+https?\/\/(?:www\.)?metasploit.com/)
     unless test.empty?
       test.each { |item|
         warn("Invalid URL: #{item}")


### PR DESCRIPTION
A few small updates to `msftidy`.

* Now checks for `http://` in the license comment header and suggests `https://`.
* Makes use of the previously unused `fixed` method to offer a suggested fix for violations.
* Also checks for `Base64.encode64` and suggests `Base64.strict_encode64`.

The native Ruby `Base64.encode64` method returns `\n` line wrapping for display, and also terminates the string with `\n`.

```
2.3.0 :001 > require 'base64'
 => true 
2.3.0 :002 > Base64.strict_encode64("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
 => "QUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUE=" 
2.3.0 :003 > Base64.encode64("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
 => "QUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFB\nQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUE=\n" 
2.3.0 :004 > 
```

This is usually not what we want, and module authors have worked around this by `gsub`ing whitespace:

```
# grep -rn "Base64.encode64" modules/
modules/exploits/multi/misc/osgi_console_exec.rb:114:    cmd_b64 = Base64.encode64(cmd).gsub(/\s+/, "")
modules/exploits/linux/http/trendmicro_sps_exec.rb:136:      data = Base64.encode64(public_key.public_encrypt(creds))
modules/exploits/linux/http/huawei_hg532n_cmdinject.rb:124:    Base64.encode64(sha256).gsub(/\s+/, "")
modules/auxiliary/admin/aws/aws_launch_instances.rb:110:        opts['UserData'] = URI.encode(Base64.encode64(open(datastore['USERDATA_FILE'], 'r').read).strip)
````

The check raises an `info`, rather than `warn`, because in a small number of situations it may be possible that an author will wish to output line-wrapped Base64 content to the console for easy copypasta. Usually, however, Base64 is used for encoding exploit data for the target.

`Rex::Text.encode_base64` could also be used, rather than `Base64.strict_encode64`, however the check does not advise to use this method, as it's possible that the encoding may be performed outside of Metasploit context, such as within Ruby payload data.

```
2.3.0 :002 > Rex::Text.encode_base64 "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
 => "QUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUE=" 
```
