### PR TITLE
restrict sqlite3 gem for windows

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,8 @@ source 'https://rubygems.org'
 #   spec.add_runtime_dependency '<name>', [<version requirements>]
 gemspec name: 'metasploit-framework'
 
+gem 'sqlite3', '~>1.3'
+
 # separate from test as simplecov is not run on travis-ci
 group :coverage do
   # code coverage for tests

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -377,6 +377,7 @@ DEPENDENCIES
   rspec-rails
   rspec-rerun
   simplecov
+  sqlite3 (~> 1.3)
   swagger-blocks
   timecop
   yard


### PR DESCRIPTION
Restrict sqlite3 gem until a released pre-compiled gem is available.
With the release of `sqlite3 1.4.0` a pre-compiled gem has not yet been deployed.  In the interest of supporting windows nightly builds, this restricts the bundle to `~>1.3` to pickup the OS specific gems for the time being.

https://rubygems.org/gems/sqlite3/
https://github.com/sparklemotion/sqlite3-ruby

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] play with something that exercises `sqlite3` ¯\\_(ツ)_/¯  

