### PR TITLE
lock sqlite3 to compatible minor not just major

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 #   spec.add_runtime_dependency '<name>', [<version requirements>]
 gemspec name: 'metasploit-framework'
 
-gem 'sqlite3', '~>1.3'
+gem 'sqlite3', '~>1.3.0'
 
 # separate from test as simplecov is not run on travis-ci
 group :coverage do


### PR DESCRIPTION
Sorry, one more time.  This locks all the way down to the minor version.  #11362 works for the moment however weekly `bundle update` will attempt to set `1.4.0` in `Gemfile.lock` unless we restrict further.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] play with something that exercises `sqlite3` ¯\\_(ツ)_/¯  
