### PR TITLE
Upgrade pg to version 0.21.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,7 +38,7 @@ PATH
       patch_finder
       pcaprub
       pdf-reader
-      pg (= 0.20.0)
+      pg (~> 0.20)
       railties
       rb-readline
       recog
@@ -215,7 +215,7 @@ GEM
       hashery (~> 2.0)
       ruby-rc4
       ttfunk
-    pg (0.20.0)
+    pg (0.21.0)
     pg_array_parser (0.0.9)
     postgres_ext (3.0.1)
       activerecord (~> 4.0)

--- a/lib/pg/deprecated_constants.rb
+++ b/lib/pg/deprecated_constants.rb
@@ -1,0 +1,36 @@
+# Slightly modified version of a workaround written by Eliot Sykes https://stackoverflow.com/a/51232774
+# File: lib/pg/deprecated_constants.rb
+#
+# This file overrides the pg gem's pg/deprecated_constants.rb file and so
+# its warning message is not printed. Avoiding this warning message helps
+# clean up the app startup and test output.
+#
+# This behaviour relies on lib/ being ahead of the pg gem in $LOAD_PATH and
+# these lines from the pg gem's lib/pg.rb file:
+# autoload :PGError,  'pg/deprecated_constants'
+# autoload :PGconn,   'pg/deprecated_constants'
+# autoload :PGresult, 'pg/deprecated_constants'
+#
+# Your config/application.rb may need to modify autoload_paths to ensure
+# the lib/ dir is ahead of the pg gem install path in $LOAD_PATH:
+#
+# config.autoload_paths << Rails.root.join('lib')
+#
+if PG::VERSION != '0.21.0' || ActiveRecord.version.to_s != '4.2.11'
+  puts <<MSG
+-----------------------------------------------------------------------------------
+The pg and/or activerecord gem version has changed, meaning deprecated pg constants
+may no longer be in use, so try deleting this file to see if the
+'The PGconn, PGresult, and PGError constants are deprecated...' message has gone:
+#{__FILE__}
+-----------------------------------------------------------------------------------
+
+MSG
+end
+
+# Declare the deprecated constants as is done in the original 
+# pg/deprecated_constants.rb so they can still be used by older
+# versions of gems such as activerecord.
+PGconn   = PG::Connection
+PGresult = PG::Result
+PGError  = PG::Error

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -86,9 +86,9 @@ Gem::Specification.new do |spec|
   # For sniffer and raw socket modules
   spec.add_runtime_dependency 'pcaprub'
   # Used by the Metasploit data model, etc.
-  # bound to 0.20 for Activerecord 4.2.8 deprecation warnings:
+  # bound to 0.2x for Activerecord 4.2.8 deprecation warnings:
   # https://github.com/ged/ruby-pg/commit/c90ac644e861857ae75638eb6954b1cb49617090
-  spec.add_runtime_dependency 'pg', '0.20.0'
+  spec.add_runtime_dependency 'pg', '~> 0.20'
   # Run initializers for metasploit-concern, metasploit-credential, metasploit_data_models Rails::Engines
   spec.add_runtime_dependency 'railties'
   # required for OS fingerprinting


### PR DESCRIPTION
Upgrades pg to version `0.21.0` in order to fix #11295. This includes a temporary workaround to suppress the warning message introduced when upgrading pg to `0.21.0` with an older version of
activerecord.

[RubyInstaller-2.4.2-1 - 2017-09-15](https://github.com/oneclick/rubyinstaller2/blob/9e6d316dd5f827e970c9a7f8bba972a9fb23d4b7/CHANGELOG-2.4.md#rubyinstaller-242-1---2017-09-15) removed the deprecated `RubyInstaller.add_dll_directory`, thus causing an issue with pg `0.20.0` as seen in [RubyInstaller.add_dll_directory is deprecated](https://bitbucket.org/ged/ruby-pg/issues/261/rubyinstalleradd_dll_directory-is). This issue was fixed in pg `0.21.0`.

## Verification

- [ ] `bundle install`
- [ ] Start `msfconsole`
- [ ] **Verify** `msfconsole` starts without a PG deprecated constant warning message
- [ ] **Verify** database operations work as expected