### PR TITLE
Update payloads 1.3.62

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,7 +21,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 1.3.61)
+      metasploit-payloads (= 1.3.62)
       metasploit_data_models
       metasploit_payloads-mettle (= 0.5.7)
       mqtt
@@ -177,7 +177,7 @@ GEM
       activemodel (~> 4.2.6)
       activesupport (~> 4.2.6)
       railties (~> 4.2.6)
-    metasploit-payloads (1.3.61)
+    metasploit-payloads (1.3.62)
     metasploit_data_models (3.0.5)
       activerecord (~> 4.2.6)
       activesupport (~> 4.2.6)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -70,7 +70,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '1.3.61'
+  spec.add_runtime_dependency 'metasploit-payloads', '1.3.62'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '0.5.7'
   # Needed by msfgui and other rpc components

--- a/modules/payloads/singles/python/meterpreter_bind_tcp.rb
+++ b/modules/payloads/singles/python/meterpreter_bind_tcp.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/meterpreter_python'
 
 module MetasploitModule
 
-  CachedSize = 71982
+  CachedSize = 71962
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/singles/python/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_http.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/meterpreter_python'
 
 module MetasploitModule
 
-  CachedSize = 71918
+  CachedSize = 71898
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/singles/python/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_https.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/meterpreter_python'
 
 module MetasploitModule
 
-  CachedSize = 71918
+  CachedSize = 71898
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/singles/python/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_tcp.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/meterpreter_python'
 
 module MetasploitModule
 
-  CachedSize = 71882
+  CachedSize = 71862
 
   include Msf::Payload::Single
   include Msf::Payload::Python


### PR DESCRIPTION
This PR bumps metasploit payloads to fix two bugs discovered in the python meterpreter:
1) During the landing of https://github.com/rapid7/metasploit-payloads/pull/322, we accidentally introduced a bug because it appears that different versions of python have different sizes for the stat member elements.  The patch casts the values in all version to the larger size before packing them for transport.

2) Due to a change in the python language (documented in https://www.python.org/dev/peps/pep-0479/) python meterpreter was failing immediately on python versions >= 3.5 because the `StopIteration` interrupt has been converted to a runtime error.

List the steps needed to make sure this thing works

# ls fix
- [x] Start `msfconsole`
- [x] `use exploit/multi handler`
- [x] `set payload python/meterpreter/reverse_tcp`
- [x] `set lhost xxx.xxx.xxx.xxx
- [x] `set lport xxxx`
- [x] `set PythonMeterpreterDebug True`
- [x] `run`
- [x] `launch python payload on a windows target with python version 3.4`
- [x] Run `ls` and verify output

# StopIteration fix
- [x] Start `msfconsole`
- [x] `use exploit/multi handler`
- [x] `set payload python/meterpreter/reverse_tcp`
- [x] `set lhost xxx.xxx.xxx.xxx
- [x] `set lport xxxx`
- [x] `set PythonMeterpreterDebug True`
- [x] `run`
- [x] Launch python payload on a windows target with python version 3.7
- [x] Verify session stays up



