### PR TITLE
Implement deregistering an option by alias

### DIFF
--- a/lib/msf/core/data_store.rb
+++ b/lib/msf/core/data_store.rb
@@ -306,8 +306,6 @@ class DataStore < Hash
     list.each(&block)
   end
 
-protected
-
   #
   # Case-insensitive key lookup
   #

--- a/lib/msf/core/module/options.rb
+++ b/lib/msf/core/module/options.rb
@@ -29,8 +29,12 @@ module Msf::Module::Options
   #
   def deregister_options(*names)
     names.each { |name|
-      self.options.remove_option(name)
+      real_name = self.datastore.find_key_case(name)
       self.datastore.delete(name)
+      self.options.remove_option(name)
+      if real_name != name
+        self.options.remove_option(real_name)
+      end
     }
   end
 


### PR DESCRIPTION
Rather than having to 'unregister' both 'RHOST' and 'RHOSTS' for modules using a network-connecting mixin, but that only target a fixed resource, this allows just unregistering one option by exposing the alias key lookup to the module options library and allowing it to remove the datastore options for the module from validation.

Noted while testing #11108 that the module's unregister options were incomplete, and there were a few more like it. This allows modules operating in this style to work without modifications.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] ` use auxiliary/gather/shodan_search`
- [x] `run`
- [x] **Verify** the module works, or at least only complains about relevant options:

```
msf5 auxiliary(gather/shodan_search) > run
[-] Auxiliary failed: Msf::OptionValidateError The following options failed to validate: SHODAN_APIKEY, QUERY.
```
