### PR TITLE
Add auxiliary/scanner/http/options doc

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/options.md
+++ b/documentation/modules/auxiliary/scanner/http/options.md
@@ -1,0 +1,31 @@
+## Description
+
+This module scans a given range of IP address and queries web servers for the options that are available on them.
+
+## Verification Steps
+
+1. Do: ```use auxiliary/scanner/http/options```
+2. Do: ```set RHOSTS [IP]```
+3. Do: ```set THREADS [number of threads]```
+4. Do: ```run```
+
+## Scenarios
+
+```
+msf > use auxiliary/scanner/http/options
+msf auxiliary(scanner/http/options) > set RHOSTS 192.168.1.200-210
+RHOSTS => 192.168.1.200-210
+msf auxiliary(scanner/http/options) > set THREADS 11
+THREADS => 11
+msf auxiliary(scanner/http/options) > run
+
+[*] 192.168.1.203 allows OPTIONS, TRACE, GET, HEAD, DELETE, COPY, MOVE, PROPFIND, PROPPATCH, SEARCH, MKCOL, LOCK, UNLOCK methods
+[*] 192.168.1.204 allows OPTIONS, TRACE, GET, HEAD, DELETE, COPY, MOVE, PROPFIND, PROPPATCH, SEARCH, MKCOL, LOCK, UNLOCK methods
+[*] 192.168.1.205 allows OPTIONS, TRACE, GET, HEAD, COPY, PROPFIND, SEARCH, LOCK, UNLOCK methods
+[*] 192.168.1.206 allows OPTIONS, TRACE, GET, HEAD, COPY, PROPFIND, SEARCH, LOCK, UNLOCK methods
+[*] 192.168.1.208 allows GET,HEAD,POST,OPTIONS,TRACE methods
+[*] 192.168.1.209 allows GET,HEAD,POST,OPTIONS,TRACE methods
+[*] Scanned 11 of 11 hosts (100% complete)
+[*] Auxiliary module execution completed
+msf auxiliary(scanner/http/options) >
+```


### PR DESCRIPTION
This PR adds the documentation for `auxiliary/scanner/http/options` module.