### PR TITLE
jboss_vulnscan: add app to test auth bypass

### DIFF
--- a/modules/auxiliary/scanner/http/jboss_vulnscan.rb
+++ b/modules/auxiliary/scanner/http/jboss_vulnscan.rb
@@ -54,6 +54,7 @@ class MetasploitModule < Msf::Auxiliary
 
       apps = [
         '/jmx-console/HtmlAdaptor',
+        '/jmx-console/checkJNDI.jsp',
         '/status',
         '/web-console/ServerInfo.jsp',
         # apps added per Patrick Hof


### PR DESCRIPTION
Currently the jboss_vulnscan module fails to detect a case of authentication bypass. 
This PR adds a protected application path that returns 200 when requested with HEAD when the server is vulnerable.
Source: https://www.illumant.com/blog/2018/03/02/owning-jboss-4-2-3-ga-manually/

## Verification
Here is the test I did:
```
msf5 auxiliary(scanner/http/jboss_vulnscan) > options 

Module options (auxiliary/scanner/http/jboss_vulnscan):

   Name     Current Setting   Required  Description
   ----     ---------------   --------  -----------
   Proxies                    no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS   XXXXXXXXXXXXXXXX  yes       The target address range or CIDR identifier
   RPORT    80                yes       The target port (TCP)
   SSL      false             no        Negotiate SSL/TLS for outgoing connections
   THREADS  1                 yes       The number of concurrent threads
   VERB     HEAD               yes       Verb for auth bypass testing
   VHOST    XXXXXXXXXXXXXXXX  no        HTTP server virtual host

msf5 auxiliary(scanner/http/jboss_vulnscan) > run

[*] Apache-Coyote/1.1 ( Powered by Servlet 2.4; JBoss-4.2.0.GA (build: SVNTag=JBoss_4_2_0_GA date=200705111440)/Tomcat-5.5 )
[-] x.x.x.x:80 JBoss error message: JBossWeb/2.0.0.GA - Error report
[...]
[*] x.x.x.x:80 /jmx-console/checkJNDI.jsp requires authentication (401): Basic realm="JBoss JMX Console"
[*] x.x.x.x:80 Check for verb tampering (HEAD)
[+] x.x.x.x:80 Got authentication bypass via HTTP verb tampering
[*] x.x.x.x:80 Could not guess admin credentials
[...]
```