### PR TITLE
fix #11395, use db.hosts.each

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -2362,11 +2362,11 @@ class Core
 
     # List only those hosts with matching open ports?
     mport = self.active_module.datastore['RPORT']
-    if (mport)
+    if mport
       mport = mport.to_i
       hosts = {}
-      framework.db.each_service(framework.db.workspace) do |service|
-        if (service.port == mport)
+      framework.db.services.each do |service|
+        if service.port == mport
           hosts[ service.host.address ] = true
         end
       end
@@ -2395,8 +2395,8 @@ class Core
     host = framework.db.has_host?(framework.db.workspace, self.active_module.datastore['RHOST'])
     return res if not host
 
-    framework.db.each_service(framework.db.workspace) do |service|
-      if (service.host_id == host.id)
+    framework.db.services.each do |service|
+      if service.host_id == host.id
         res << service.port.to_s
       end
     end

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -2377,7 +2377,7 @@ class Core
 
     # List all hosts in the database
     else
-      framework.db.each_host(framework.db.workspace) do |host|
+      framework.db.hosts.each do |host|
         res << host.address
       end
     end


### PR DESCRIPTION
Prefer iterating over hosts over the older method in the database. Fixes #11395 

## Verification

- [x] `msfdb reinit` to ensure there is a clean database (or maybe create a fresh workspace)
- [x] Start `msfconsole`
- [x] `use auxiliary/gather/shodan_search`
- [x] `set rhosts 192.168<tab>`
- [x] **Verify** the console does not crash and tab completes a local IP address
