### PR TITLE
Add support for showing extra help

### DIFF
--- a/documentation/cli/msfconsole/repeat.md
+++ b/documentation/cli/msfconsole/repeat.md
@@ -1,0 +1,37 @@
+Repeat
+======
+
+The `repeat` command repeats one or more console commands for a fixed number of
+times, a certain length of time, or forever. The repeat command is most useful
+for repeating module runs like memory dumpers or scanners that have a random
+element to them.
+
+Usage
+-----
+
+### Flags
+
+#### -t, --time SECONDS
+
+Start the list of commands until the number of seconds has elapsed.
+
+#### -n, --number TIMES
+
+Start the list of commands a fixed number of times.
+
+#### -h, --help
+
+Display the help banner.
+
+
+
+Examples
+--------
+
+Run the heartbleed module every 10 seconds against a server for an hour:
+
+    msf5 > use auxiliary/scanner/ssl/openssl_heartbleed
+    msf5 auxiliary(scanner/ssl/openssl_heartbleed) > set ACTION DUMP
+    # Set other options...
+    msf5 auxiliary(scanner/ssl/openssl_heartbleed) > repeat -t 3600 run; sleep 10
+

--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -87,6 +87,14 @@ class CommandShell
   end
 
   #
+  # Return the subdir of the `documentation/` directory that should be used
+  # to find usage documentation
+  #
+  def docs_dir
+    File.join(super, 'shell_session')
+  end
+
+  #
   # List of supported commands.
   #
   def commands

--- a/lib/msf/ui/console/command_dispatcher.rb
+++ b/lib/msf/ui/console/command_dispatcher.rb
@@ -75,6 +75,14 @@ module CommandDispatcher
   end
 
   #
+  # Return the subdir of the `documentation/` directory that should be used
+  # to find usage documentation
+  #
+  def docs_dir
+    File.join(super, 'msfconsole')
+  end
+
+  #
   # Generate an array of job or session IDs from a given range String.
   # Always returns an Array.
   #

--- a/lib/msf/ui/console/command_dispatcher.rb
+++ b/lib/msf/ui/console/command_dispatcher.rb
@@ -114,6 +114,19 @@ module CommandDispatcher
   end
 
   #
+  # Remove lines with specific substring
+  #
+  # @param text [String] Block of text to search over
+  # @param to_match [String] String that when found, causes the whole line to
+  #   be removed, including trailing "\n" if present
+  # @return [String] Text sans lines containing to_match
+  #
+  def remove_lines(text, to_match)
+    to_match = Regexp.escape(to_match)
+    text.gsub(/^.*(#{to_match}).*(#{Regexp.escape $/})?/, '')
+  end
+
+  #
   # The driver that this command dispatcher is associated with.
   #
   attr_accessor :driver

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1983,7 +1983,7 @@ class Core
         output_mods[:skip] = num
       end
       opts.on '-h', '--help', 'Help banner.' do
-        return print(opts.help)
+        return print(remove_lines(opts.help, '--generate-completions'))
       end
 
       # Internal use
@@ -2098,7 +2098,7 @@ class Core
       end
 
       opts.on '-h', '--help', 'Help banner.' do
-        return print(opts.help)
+        return print(remove_lines(opts.help, '--generate-completions'))
       end
 
       # Internal use

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher.rb
@@ -59,6 +59,14 @@ module Console::CommandDispatcher
   end
 
   #
+  # Return the subdir of the `documentation/` directory that should be used
+  # to find usage documentation
+  #
+  def docs_dir
+    File.join(super, 'meterpreter')
+  end
+
+  #
   # Returns true if the client has a framework object.
   #
   # Used for firing framework session events

--- a/lib/rex/ui/text/dispatcher_shell.rb
+++ b/lib/rex/ui/text/dispatcher_shell.rb
@@ -174,10 +174,19 @@ module DispatcherShell
             end
           end
         end
+
+        if docs_dir && File.exist?(File.join(docs_dir, cmd + '.md'))
+          print_line
+          print(File.read(File.join(docs_dir, cmd + '.md')))
+        end
         print_error("No help for #{cmd}, try -h") if cmd_found and not help_found
         print_error("No such command") if not cmd_found
       else
         print(shell.help_to_s)
+        if docs_dir && File.exist?(File.join(docs_dir + '.md'))
+          print_line
+          print(File.read(File.join(docs_dir + '.md')))
+        end
       end
     end
 
@@ -228,6 +237,17 @@ module DispatcherShell
       }
 
       return "\n" + tbl.to_s + "\n"
+    end
+
+    #
+    # Return the subdir of the `documentation/` directory that should be used
+    # to find usage documentation
+    #
+    # TODO: get this value from somewhere that doesn't invert a bunch of
+    # dependencies
+    #
+    def docs_dir
+      File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'documentation', 'cli'))
     end
 
     #


### PR DESCRIPTION
This takes extra markdown files from `documentation/cli/` and adds them to the output of the `help` command. Also includes documentation for the relatively new `repeat` command to test with.

Verification
============

- [x] `msfconsole`
- [x] `help repeat`
- [x] Verify you get extra, helpful help
- [x] `help set`
- [x] Verify nothing goes wrong