### PR TITLE
Meterpreter scripts do not display help info.

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
@@ -1405,7 +1405,7 @@ class Console::CommandDispatcher::Core
   # Executes a script in the context of the meterpreter session.
   #
   def cmd_run(*args)
-    if args.empty? || args.include?('-h')
+    if args.empty? || args.length == 1 && args.include?('-h') 
       cmd_run_help
       return true
     end
@@ -1475,7 +1475,7 @@ class Console::CommandDispatcher::Core
   # Executes a script in the context of the meterpreter session in the background
   #
   def cmd_bgrun(*args)
-    if args.empty? || args.include?('-h')
+    if args.empty? || args.length == 1 && args.include?('-h')
       print_line('Usage: bgrun <script> [arguments]')
       print_line
       print_line('Executes a ruby script in the context of the meterpreter session.')


### PR DESCRIPTION
Fix an issue that we cannot get help info when running a meterpreter script.

### Now

```
meterpreter > run metsvc -h
Usage: run <script> [arguments]

Executes a ruby script or Metasploit Post module in the context of the
meterpreter session.  Post modules can take arguments in var=val format.
Example: run post/foo/bar BAZ=abcd

meterpreter >
```

### Fixed

```
meterpreter > run metsvc -h

[!] Meterpreter scripts are deprecated. Try post/windows/manage/persistence_exe.
[!] Example: run post/windows/manage/persistence_exe OPTION=value [...]

OPTIONS:

    -A        Automatically start a matching exploit/multi/handler to connect to the service
    -h        This help menu
    -r        Uninstall an existing Meterpreter service (files must be deleted manually)
```