### PR TITLE
fixed [Meterpreter scripts do not display help info.]

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
@@ -1405,7 +1405,7 @@ class Console::CommandDispatcher::Core
   # Executes a script in the context of the meterpreter session.
   #
   def cmd_run(*args)
-    if args.empty? || args.length == 1 && args.include?('-h') 
+    if args.empty? || args.first == '-h'
       cmd_run_help
       return true
     end
@@ -1475,7 +1475,7 @@ class Console::CommandDispatcher::Core
   # Executes a script in the context of the meterpreter session in the background
   #
   def cmd_bgrun(*args)
-    if args.empty? || args.length == 1 && args.include?('-h')
+    if args.empty? || args.first == '-h'
       print_line('Usage: bgrun <script> [arguments]')
       print_line
       print_line('Executes a ruby script in the context of the meterpreter session.')


### PR DESCRIPTION
[Meterpreter scripts do not display help info.](https://github.com/rapid7/metasploit-framework/pull/11411#issuecomment-463930442)