### PR TITLE
Deprecate get_env script

### DIFF
--- a/scripts/meterpreter/get_env.rb
+++ b/scripts/meterpreter/get_env.rb
@@ -36,6 +36,8 @@ opts.parse(args) { |opt, idx, val|
   when "-h"
     print_line "Meterpreter Script for extracting a list of all System and User environment variables."
     print_line(opts.usage)
+    print_error "Deprecation warning: This script has been replaced by the post/multi/gather/env module"
+
     raise Rex::Script::Completed
 
   end


### PR DESCRIPTION
```
msf5 exploit(multi/handler) > sessions -i 1
[*] Starting interaction with 1...

meterpreter > run get_env -h
Meterpreter Script for extracting a list of all System and User environment variables.

OPTIONS:

    -h        Help menu.

[-] Deprecation warning: This script has been replaced by the post/multi/gather/env module
```