### PR TITLE
Deprecate get_valid_community script

### DIFF
--- a/scripts/meterpreter/get_valid_community.rb
+++ b/scripts/meterpreter/get_valid_community.rb
@@ -15,6 +15,7 @@ session = client
 
 def usage()
   print("\nPull the SNMP community string from a Windows Meterpreter session\n\n")
+  print_error 'Deprecation warning: This script has been replaced by the post/windows/gather/enum_snmp module'
   completed
 end
 


### PR DESCRIPTION
```
msf5 exploit(multi/handler) > sessions -i 1
[*] Starting interaction with 1...

meterpreter > run get_valid_community -h

[!] Meterpreter scripts are deprecated. Try post/windows/gather/enum_snmp.
[!] Example: run post/windows/gather/enum_snmp OPTION=value [...]

Pull the SNMP community string from a Windows Meterpreter session

[-] Deprecation warning: This script has been replaced by the post/windows/gather/enum_snmp module
meterpreter > 
```