### PR TITLE
Deprecate get_env script

### DIFF
--- a/lib/msf/base/sessions/scriptable.rb
+++ b/lib/msf/base/sessions/scriptable.rb
@@ -67,6 +67,7 @@ module Scriptable
       'enum_shares' => 'post/windows/gather/enum_shares',
       'file_collector' => 'post/windows/gather/enum_files',
       'get_application_list' => 'post/windows/gather/enum_applications',
+      'get_env' => 'post/multi/gather/env',
       'get_filezilla_creds' => 'post/windows/gather/credentials/filezilla_server',
       'get_local_subnets' => 'post/multi/manage/autoroute',
       'get_valid_community' => 'post/windows/gather/enum_snmp',


### PR DESCRIPTION
#7789

https://github.com/rapid7/metasploit-framework/issues/7789#issuecomment-310635316
