### PR TITLE
Moved bruteforce(ip) under the sys_name check.

### DIFF
--- a/modules/auxiliary/scanner/http/hp_sys_mgmt_login.rb
+++ b/modules/auxiliary/scanner/http/hp_sys_mgmt_login.rb
@@ -172,7 +172,7 @@ class MetasploitModule < Msf::Auxiliary
     })
 
     sys_name = get_system_name(res)
-    
+
     if sys_name.blank?
       print_error 'Could not retrieve system name.'
       return

--- a/modules/auxiliary/scanner/http/hp_sys_mgmt_login.rb
+++ b/modules/auxiliary/scanner/http/hp_sys_mgmt_login.rb
@@ -187,15 +187,13 @@ class MetasploitModule < Msf::Auxiliary
         :type => "system.name",
         :data => sys_name
       )
+      if anonymous_access?(res)
+        print_good("No login necessary. Server allows anonymous access.")
+        return
+      end
+      init_loginscanner(ip)
+      bruteforce(ip)
     end
-
-    if anonymous_access?(res)
-      print_good("No login necessary. Server allows anonymous access.")
-      return
-    end
-
-    init_loginscanner(ip)
-    bruteforce(ip)
   end
 end
 

--- a/modules/auxiliary/scanner/http/hp_sys_mgmt_login.rb
+++ b/modules/auxiliary/scanner/http/hp_sys_mgmt_login.rb
@@ -171,29 +171,35 @@ class MetasploitModule < Msf::Auxiliary
       }
     })
 
+    sys_name = get_system_name(res)
+    
+    if sys_name.blank?
+      print_error 'Could not retrieve system name.'
+      return
+    end
+
     version = get_version(res)
     unless version.blank?
       print_status("Version detected: #{version}")
       unless is_version_tested?(version)
-        print_warning("You're running the module against a version we have not tested")
+        print_warning("You're running the module against a version we have not tested.")
       end
     end
 
-    sys_name = get_system_name(res)
-    unless sys_name.blank?
-      print_good("System name detected: #{sys_name}")
-      report_note(
-        :host => ip,
-        :type => "system.name",
-        :data => sys_name
-      )
-      if anonymous_access?(res)
-        print_good("No login necessary. Server allows anonymous access.")
-        return
-      end
-      init_loginscanner(ip)
-      bruteforce(ip)
+    print_good("System name detected: #{sys_name}")
+    report_note(
+      :host => ip,
+      :type => "system.name",
+      :data => sys_name
+    )
+
+    if anonymous_access?(res)
+      print_good("No login necessary. Server allows anonymous access.")
+      return
     end
+
+    init_loginscanner(ip)
+    bruteforce(ip)
   end
 end
 


### PR DESCRIPTION
Moving the bruteforce(ip) under the sys_name check stops the script from executing against the wrong systems.