### PR TITLE
Fix #11433 creds command bug

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/creds.rb
+++ b/lib/msf/ui/console/command_dispatcher/creds.rb
@@ -505,7 +505,11 @@ class Creds
           private_val = core.private ? core.private.to_s : ""
           realm_val = core.realm ? core.realm.value : ""
           human_val = core.private ? core.private.class.model_name.human : ""
-          jtr_val = core.private.jtr_format ? core.private.jtr_format : ""
+          if human_val == ""
+            jtr_val = "" #11433, private can be nil
+          else
+            jtr_val = core.private.jtr_format ? core.private.jtr_format : ""
+          end
 
           row += [
             public_val,


### PR DESCRIPTION
Fixes #11433 
```
msf5 auxiliary(scanner/ssh/ssh_enumusers) > run
[+] 111.111.1.11:22 - SSH - User 'ubuntu' found
[*] Scanned 250 of 250 hosts (100% complete)
[*] Auxiliary module execution completed
msf5 auxiliary(scanner/ssh/ssh_enumusers) > creds
[-] Error while running command creds: undefined method `jtr_format' for nil:NilClass

Call stack:
/metasploit-framework/lib/msf/ui/console/command_dispatcher/creds.rb:508:in `block (2 levels) in creds_search'
/var/lib/gems/2.5.0/gems/activerecord-4.2.11/lib/active_record/relation/delegation.rb:46:in `each'
/var/lib/gems/2.5.0/gems/activerecord-4.2.11/lib/active_record/relation/delegation.rb:46:in `each'
/metasploit-framework/lib/msf/ui/console/command_dispatcher/creds.rb:484:in `block in creds_search'
/var/lib/gems/2.5.0/gems/activerecord-4.2.11/lib/active_record/relation/delegation.rb:46:in `each'
/var/lib/gems/2.5.0/gems/activerecord-4.2.11/lib/active_record/relation/delegation.rb:46:in `each'
/metasploit-framework/lib/msf/ui/console/command_dispatcher/creds.rb:438:in `creds_search'
/metasploit-framework/lib/msf/ui/console/command_dispatcher/creds.rb:111:in `cmd_creds'
/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:502:in `run_command'
/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:453:in `block in run_single'
/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:447:in `each'
/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:447:in `run_single'
/metasploit-framework/lib/rex/ui/text/shell.rb:151:in `run'
/metasploit-framework/lib/metasploit/framework/command/console.rb:48:in `start'
/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'
./msfconsole:49:in `<main>'
```

Apparently a cred's private can be `nil` which makes sense when you are enumerating usernames.  However, that was never accounted for in #11351 https://github.com/rapid7/metasploit-framework/pull/11351/files#diff-03f030e370b64b0c940b918732f5d8c9R471

This fixes that.
```
msf5 > creds
Credentials
===========

host           origin         service       public              private                                                                                                                                         realm  private_type        JtR Format
----           ------         -------       ------              -------                                                                                                                                         -----  ------------        ----------
111.111.1.11   111.111.1.11   22/tcp (ssh)  ubuntu                                                                                                                                                                                         

msf5 > exit

```