### PR TITLE
Adding auxiliary/scanner/snmp modules docs

### DIFF
--- a/documentation/modules/auxiliary/scanner/snmp/snmp_enum.md
+++ b/documentation/modules/auxiliary/scanner/snmp/snmp_enum.md
@@ -1,0 +1,78 @@
+## Description
+This module performs a detailed enumeration of a host or a range through SNMP protocol. It supports hardware, software, and network information.
+
+## Verification Steps
+
+1. Do: ```use auxiliary/scanner/snmp/snmp_enum```
+2. Do: ```set RHOSTS [IP]```
+3. Do: ```run```
+
+## Scenarios 
+
+```
+msf > use auxiliary/scanner/snmp/snmp_enum
+msf auxiliary(auxiliary/scanner/snmp/snmp_enum) > set RHOSTS 1.1.1.2
+RHOSTS => 1.1.1.2
+msf auxiliary(auxiliary/scanner/snmp/snmp_enum) > run
+
+[*] System information
+
+Hostname                : Netgear-GSM7224
+Description             : GSM7224 L2 Managed Gigabit Switch
+Contact                 : dookie
+Location                : Basement
+Uptime snmp             : 56 days, 00:36:28.00
+Uptime system           : -
+System date             : -
+
+[*] Network information
+
+IP forwarding enabled   :  no
+Default TTL             :  64
+TCP segments received   :  20782
+TCP segments sent       :  9973
+TCP segments retrans.   :  9973
+Input datagrams         :  4052407
+Delivered datagrams     :  1155615
+Output datagrams        :  18261
+
+[*] Network interfaces
+
+Interface [ up ] Unit: 1 Slot: 0 Port: 1 Gigabit - Level
+
+	Id              : 1
+	Mac address     : 00:0f:b5:fc:bd:24
+	Type            : ethernet-csmacd
+	Speed           : 1000 Mbps
+	Mtu             : 1500
+	In octets       : 3716564861
+	Out octets      : 675201778
+...snip...
+[*] Routing information
+
+     Destination         Next hop             Mask           Metric
+
+         0.0.0.0      5.1.168.192          0.0.0.0                1
+       1.0.0.127        1.0.0.127  255.255.255.255                0
+
+[*] TCP connections and listening ports
+
+   Local address       Local port   Remote address      Remote port            State
+
+         0.0.0.0               23          0.0.0.0                0           listen
+         0.0.0.0               80          0.0.0.0                0           listen
+         0.0.0.0             4242          0.0.0.0                0           listen
+       1.0.0.127             2222          0.0.0.0                0           listen
+
+[*] Listening UDP ports
+
+   Local address       Local port
+
+         0.0.0.0                0
+         0.0.0.0              161
+         0.0.0.0              514
+
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+msf auxiliary(auxiliary/scanner/snmp/snmp_enum) >
+```

--- a/documentation/modules/auxiliary/scanner/snmp/snmp_enumshares.md
+++ b/documentation/modules/auxiliary/scanner/snmp/snmp_enumshares.md
@@ -1,0 +1,32 @@
+## Description
+This module will simply scan a range of hosts and queries via SNMP to determine any available shares.
+
+## Verification Steps
+
+1. Do: ```use auxiliary/scanner/snmp/snmp_enumshares```
+2. Do: ```set RHOSTS [IP]```
+3. Do: ```set THREADS [number of threads]```
+4. Do: ```run```
+
+## Scenarios
+
+```
+msf > use auxiliary/scanner/snmp/snmp_enumshares
+msf auxiliary(scanner/snmp/snmp_enumshares) > set RHOSTS 1.1.1.200-211
+RHOSTS => 1.1.1.200-211
+msf auxiliary(scanner/snmp/snmp_enumshares) > set THREADS 11
+THREADS => 11
+msf auxiliary(scanner/snmp/snmp_enumshares) > run 
+
+[+] 1.1.1.201 
+	shared_docs -  (C:\Documents and Settings\Administrator\Desktop\shared_docs)
+[*] Scanned 02 of 11 hosts (018% complete)
+[*] Scanned 03 of 11 hosts (027% complete)
+[*] Scanned 05 of 11 hosts (045% complete)
+[*] Scanned 07 of 11 hosts (063% complete)
+[*] Scanned 09 of 11 hosts (081% complete)
+[*] Scanned 11 of 11 hosts (100% complete)
+[*] Auxiliary module execution completed
+msf auxiliary(scanner/snmp/snmp_enumshares) > 
+```
+

--- a/documentation/modules/auxiliary/scanner/snmp/snmp_enumusers.md
+++ b/documentation/modules/auxiliary/scanner/snmp/snmp_enumusers.md
@@ -1,0 +1,33 @@
+## Description
+This module queries a range of hosts via SNMP and gathers a list of usernames on the remote system.
+
+## Verification Steps
+
+1. Do: ```use auxiliary/scanner/snmp/snmp_enumusers```
+2. Do: ```set RHOSTS [IP]```
+3. Do: ```set THREADS [NUMBER OF THREADS]```
+4. Do: ```run```
+
+## Scenarios
+
+```
+msf > use auxiliary/scanner/snmp/snmp_enumusers
+msf auxiliary(scanner/snmp/snmp_enumusers) > set RHOSTS 1.1.1.200-211
+RHOSTS => 1.1.1.200-211
+msf auxiliary(scanner/snmp/snmp_enumusers) > set THREADS 11
+THREADS => 11
+msf auxiliary(scanner/snmp/snmp_enumusers) > run 
+
+[+] 1.1.1.201 Found Users: ASPNET, Administrator, Guest, HelpAssistant, SUPPORT_388945a0, victim 
+[*] Scanned 02 of 12 hosts (016% complete)
+[*] Scanned 05 of 12 hosts (041% complete)
+[*] Scanned 06 of 12 hosts (050% complete)
+[*] Scanned 07 of 12 hosts (058% complete)
+[*] Scanned 08 of 12 hosts (066% complete)
+[*] Scanned 09 of 12 hosts (075% complete)
+[*] Scanned 11 of 12 hosts (091% complete)
+[*] Scanned 12 of 12 hosts (100% complete)
+[*] Auxiliary module execution completed
+msf auxiliary(scanner/snmp/snmp_enumusers) >
+```
+


### PR DESCRIPTION
Adding `auxiliary/scanner/snmp/snmp_enum` , `auxiliary/scanner/snmp/snmp_enumusers	`  and `auxiliary/scanner/snmp/snmp_enumshares` documentation.