### PR TITLE
change default database web service port to 5443

### DIFF
--- a/msfdb
+++ b/msfdb
@@ -58,7 +58,7 @@ require 'msf/util/helper'
     db_port: 5433,
     db_pool: 200,
     address: 'localhost',
-    port: 8080,
+    port: 5443,
     ssl: true,
     ssl_cert: @ws_ssl_cert_default,
     ssl_key: @ws_ssl_key_default,


### PR DESCRIPTION
The current default is port 8080, which in addition to conflicting with almost any local web app/server you might be running, also makes it seem like this is a plaintext connection when this is really TLS. Switching to 5443 is somewhat unique (it's not in /etc/services), complements the default database port of 5343, and also decodes to TLS by default in Wireshark and other tools.

## Verification

List the steps needed to make sure this thing works

- [ ] Run `msfdb reinit` (this assumes your OS exposes postgresql's native binaries)
- [ ] **Note** that the web service is now running on `https://localhost:5443`
- [ ] Start `msfconsole`
- [ ] **Verify** the web service connects and ~/msf4/config is updated
