### PR TITLE
SideEffects Stability Reliability check

### DIFF
--- a/tools/dev/msftidy.rb
+++ b/tools/dev/msftidy.rb
@@ -435,6 +435,8 @@ class Msftidy
       if not available_ranks.include?($1)
         error("Invalid ranking. You have '#{$1}'")
       end
+    elsif @source =~ /['"](SideEffects|Stability|Reliability)['"]\s+=/
+      info('No Rank, however SideEffects, Stability, or Reliability are provided')
     else
       warn('No Rank specified. The default is NormalRanking. Please add an explicit Rank value.')
     end


### PR DESCRIPTION
Add `INFO` warning to msftidy if SideEffects, Stability, or Reliability are provided without a Rank.

## Verification

- [x] Test module w/ SideEffects/Stability/Reliability without rank
- [x] `tools/dev/msftidy.rb path/to/module.rb`