### PR TITLE
enhance BigDecimal deprecation message suppression

### DIFF
--- a/lib/msf/core.rb
+++ b/lib/msf/core.rb
@@ -20,6 +20,7 @@ require 'backports'
 require 'bigdecimal'
 
 def BigDecimal.new(*args, **kwargs)
+  return BigDecimal(*args) if kwargs.empty?
   BigDecimal(*args, **kwargs)
 end
 # Remove bigdecimal warning - end


### PR DESCRIPTION
When BigDecimal.new is called without keyword arguments
pass along only the *arg list.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `irb`
- [x] **Verify** `>> BigDecimal.new('10')`
`=> 0.1e2`
- [x] **Verify** `>> BigDecimal.new(10.to_s)`
`=> 0.1e2`
- [x] **Verify** `>> BigDecimal.new(10.00000032.to_s)`
`=> 0.1000000032e2`
- [x] **Verify** `>> BigDecimal.new(10.00000033.to_f.to_s)`
`=> 0.1000000033e2`

