### PR TITLE
update module authors to consume JSON cache

### DIFF
--- a/tools/modules/module_author.rb
+++ b/tools/modules/module_author.rb
@@ -29,7 +29,7 @@ FILENAME = 'db/modules_metadata_base.json'
 
 sort = 0
 filter = 'All'
-filters = ['all','exploit','payload','post','nOP','encoder','auxiliary']
+filters = ['all','exploit','payload','post','nop','encoder','auxiliary']
 reg = 0
 regex = nil
 
@@ -72,15 +72,6 @@ opts.parse(ARGV) { |opt, idx, val|
 
 Indent = '    '
 
-# Always disable the database (we never need it just to list module
-# information).
-framework_opts = { 'DisableDatabase' => true }
-
-# If the user only wants a particular module type, no need to load the others
-if filter.downcase != 'all'
-  framework_opts[:module_types] = [ filter.downcase ]
-end
-
 tbl = Rex::Text::Table.new(
   'Header'  => 'Module References',
   'Indent'  => Indent.length,
@@ -93,6 +84,7 @@ local_modules = JSON.parse(File.open(FILENAME).read) # get cache file location f
 
 local_modules.each do |_module_key, local_module|
   local_module['author'].each do |r|
+    next if filter.downcase != 'all' && local_module['type'] != filter.downcase
     if regex.nil? or r =~ regex
       tbl << [ local_module['full_name'], r ]
       names[r] ||= 0

--- a/tools/modules/module_author.rb
+++ b/tools/modules/module_author.rb
@@ -75,7 +75,7 @@ tbl = Rex::Text::Table.new(
 
 names = {}
 
-local_modules = JSON.parse(File.open(FILENAME).read) # get cache file location from framework?
+local_modules = JSON.parse(File.read(FILENAME)) # get cache file location from framework?
 
 local_modules.each do |_module_key, local_module|
   local_module['author'].each do |r|

--- a/tools/modules/module_author.rb
+++ b/tools/modules/module_author.rb
@@ -29,7 +29,7 @@ FILENAME = 'db/modules_metadata_base.json'
 
 sort = 0
 filter = 'All'
-filters = ['all','exploit','payload','post','nop','encoder','auxiliary']
+filters = ['all','exploit','payload','post','nop','encoder','auxiliary', 'evasion']
 reg = 0
 regex = nil
 

--- a/tools/modules/module_author.rb
+++ b/tools/modules/module_author.rb
@@ -23,6 +23,9 @@ $:.unshift(ENV['MSF_LOCAL_LIB']) if ENV['MSF_LOCAL_LIB']
 require 'rex'
 require 'msf/ui'
 require 'msf/base'
+require 'json'
+
+FILENAME = 'db/modules_metadata_base.json'
 
 sort = 0
 filter = 'All'
@@ -78,10 +81,6 @@ if filter.downcase != 'all'
   framework_opts[:module_types] = [ filter.downcase ]
 end
 
-# Initialize the simplified framework instance.
-$framework = Msf::Simple::Framework.create(framework_opts)
-
-
 tbl = Rex::Text::Table.new(
   'Header'  => 'Module References',
   'Indent'  => Indent.length,
@@ -90,18 +89,17 @@ tbl = Rex::Text::Table.new(
 
 names = {}
 
-$framework.modules.each { |name, mod|
-  x = mod.new
-  x.author.each do |r|
-    r = r.to_s
+local_modules = JSON.parse(File.open(FILENAME).read) # get cache file location from framework?
+
+local_modules.each do |_module_key, local_module|
+  local_module['author'].each do |r|
     if regex.nil? or r =~ regex
-      tbl << [ x.fullname, r ]
+      tbl << [ local_module['full_name'], r ]
       names[r] ||= 0
       names[r] += 1
     end
   end
-}
-
+end
 
 if sort == 1
   tbl.sort_rows(1)

--- a/tools/modules/module_author.rb
+++ b/tools/modules/module_author.rb
@@ -16,13 +16,8 @@ while File.symlink?(msfbase)
 end
 
 $:.unshift(File.expand_path(File.join(File.dirname(msfbase), '..', '..', 'lib')))
-require 'msfenv'
-
-$:.unshift(ENV['MSF_LOCAL_LIB']) if ENV['MSF_LOCAL_LIB']
 
 require 'rex'
-require 'msf/ui'
-require 'msf/base'
 require 'json'
 
 FILENAME = 'db/modules_metadata_base.json'


### PR DESCRIPTION
`tools/modules/module_author.rb` now process the JSON module cache to be more efficient.
Fixes #11441

## Verification

List the steps needed to make sure this thing works

- [x] `tools/modules/module_author.rb`
- [x] **Verify** results are consistent with actual author counts.
- [x] **Verify** options work
```
Metasploit Script for Displaying Module Author information.
==========================================================

OPTIONS:

    -f <opt>  Filter based on Module Type [All, Exploit, Payload, Post, Nop, Encoder, Auxiliary] (Default = All).
    -h        Help menu.
    -r        Reverse Sort
    -s        Sort by Author instead of Module Type.
    -x <opt>  String or RegEx to try and match against the Author Field
```

