### PR TITLE
Add Reliability REPEATABLE_SESSION to Wemo exploit

### DIFF
--- a/modules/exploits/linux/upnp/belkin_wemo_upnp_exec.rb
+++ b/modules/exploits/linux/upnp/belkin_wemo_upnp_exec.rb
@@ -59,7 +59,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultTarget'      => 1,
       'Notes'              => {
         'Stability'        => [CRASH_SAFE],
-        'SideEffects'      => [ARTIFACTS_ON_DISK]
+        'SideEffects'      => [ARTIFACTS_ON_DISK],
+        'Reliablity'       => [REPEATABLE_SESSION]
       }
     ))
 


### PR DESCRIPTION
Notes copied from `auxiliary/admin/wemo/crockpot` where it didn't apply.

Fixes #11409.