### PR TITLE
Add firmware version checking to Wemo exploit

### DIFF
--- a/modules/exploits/linux/upnp/belkin_wemo_upnp_exec.rb
+++ b/modules/exploits/linux/upnp/belkin_wemo_upnp_exec.rb
@@ -22,7 +22,8 @@ class MetasploitModule < Msf::Exploit::Remote
       },
       'Author'             => [
         'phikshun', # Discovery, UFuzz, and modules
-        'wvu'       # Crock-Pot testing and module
+        'wvu',      # Crock-Pot testing and module
+        'nstarke'   # Version-checking research and implementation
       ],
       'References'         => [
         ['URL', 'https://web.archive.org/web/20150901094849/http://disconnected.io/2014/04/04/universal-plug-and-fuzz/'],
@@ -82,15 +83,37 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     if res && res.code == 200 && res.body.include?('urn:Belkin:device:')
-      vprint_good('Wemo-enabled device detected')
-      return CheckCode::Appears
+      print_good('Wemo-enabled device detected')
+    else
+      print_error('This does not appear to be a wemo-enabled device')
+      return
     end
 
-    CheckCode::Safe
+    begin
+      version_text = res.get_xml_document.to_s
+      version_text =~ /WeMo_WW_?([\d]*[.][\d]*[.][\d]*)/ && $1 && version = (Gem::Version.new($1))
+      print_status("Found version: #{version.to_s}")
+    rescue
+      print_error('Error parsing version information from xml')
+      return
+    end
+
+    if version && version < Gem::Version.new('2.00.8643')
+      print_good('Firmware version appears to be vulnerable')
+      CheckCode::Appears
+    else
+      print_warning('Firmware version appears not to be vulnerable')
+      CheckCode::Safe
+    end
+
   end
 
   def exploit
     checkcode = check
+
+    unless checkcode || datastore['ForceExploit']
+      fail_with(Failure::Unknown, 'Set ForceExploit to override')
+    end
 
     unless checkcode == CheckCode::Appears || datastore['ForceExploit']
       fail_with(Failure::NotVulnerable, 'Set ForceExploit to override')

--- a/modules/exploits/linux/upnp/belkin_wemo_upnp_exec.rb
+++ b/modules/exploits/linux/upnp/belkin_wemo_upnp_exec.rb
@@ -62,7 +62,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Stability'        => [CRASH_SAFE],
         'SideEffects'      => [ARTIFACTS_ON_DISK],
         'Reliablity'       => [REPEATABLE_SESSION],
-        'NOCVE'            => 'Patched in 2.00.8643' # TODO: Add firmware check
+        'NOCVE'            => 'Patched in 2.00.8643'
       }
     ))
 
@@ -83,39 +83,35 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     if res && res.code == 200 && res.body.include?('urn:Belkin:device:')
-      print_good('Wemo-enabled device detected')
+      vprint_status('Wemo-enabled device detected')
     else
-      print_error('This does not appear to be a wemo-enabled device')
-      return
+      vprint_error('This does not appear to be a Wemo-enabled device')
+      return CheckCode::Safe
     end
 
-    begin
-      version_text = res.get_xml_document.to_s
-      version_text =~ /WeMo_WW_?([\d]*[.][\d]*[.][\d]*)/ && $1 && version = (Gem::Version.new($1))
-      print_status("Found version: #{version.to_s}")
-    rescue
-      print_error('Error parsing version information from xml')
-      return
+    version_text = res.get_xml_document.at('firmwareVersion').text
+
+    if version_text.empty?
+      vprint_error('No firmware version retrieved')
+      return CheckCode::Unknown
     end
 
-    if version && version < Gem::Version.new('2.00.8643')
-      print_good('Firmware version appears to be vulnerable')
-      CheckCode::Appears
+    version_text =~ /WeMo_WW_?([\d]*[.][\d]*[.][\d]*)/ && $1 && version = (Gem::Version.new($1))
+    vprint_status("Found version: #{version.to_s}")
+
+    if version < Gem::Version.new('2.00.8643')
+      vprint_good('Firmware version appears to be vulnerable')
+      CheckCode::Vulnerable
     else
-      print_warning('Firmware version appears not to be vulnerable')
+      vprint_warning('Firmware version does not appear to be vulnerable')
       CheckCode::Safe
     end
-
   end
 
   def exploit
     checkcode = check
 
-    unless checkcode || datastore['ForceExploit']
-      fail_with(Failure::Unknown, 'Set ForceExploit to override')
-    end
-
-    unless checkcode == CheckCode::Appears || datastore['ForceExploit']
+    unless checkcode == CheckCode::Vulnerable || datastore['ForceExploit']
       fail_with(Failure::NotVulnerable, 'Set ForceExploit to override')
     end
 


### PR DESCRIPTION
Resolves #11452 by parsing out the version
information returned in /setup.xml. New code then performs
a version check, and then alerts the user to whether or not
it is likely the remote host is vulnerable given that version
check.


Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

Please ensure you are submitting **from a unique branch** in your [repository](https://github.com/rapid7/metasploit-framework/pull/11086#issuecomment-445506416) to master in Rapid7's.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/windows/smb/ms08_067_netapi`
- [ ] ...
- [ ] **Verify** the thing does what it should
- [ ] **Verify** the thing does not do what it should not
- [ ] **Document** the thing and how it works ([Example](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/post/multi/gather/aws_keys.md))

#11409