### PR TITLE
Add VHOST support to full_uri

### DIFF
--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -480,7 +480,7 @@ module Exploit::Remote::HttpClient
   end
 
   # Returns the complete URI as string including the scheme, port and host
-  def full_uri(custom_uri = nil)
+  def full_uri(custom_uri = nil, vhost_uri: false)
     uri_scheme = ssl ? 'https' : 'http'
 
     if (rport == 80 && !ssl) || (rport == 443 && ssl)
@@ -491,7 +491,9 @@ module Exploit::Remote::HttpClient
 
     uri = normalize_uri(custom_uri || target_uri.to_s)
 
-    if Rex::Socket.is_ipv6?(rhost)
+    if vhost_uri && datastore['VHOST']
+      uri_host = datastore['VHOST']
+    elsif Rex::Socket.is_ipv6?(rhost)
       uri_host = "[#{rhost}]"
     else
       uri_host = rhost


### PR DESCRIPTION
```
msf5 exploit(unix/webapp/drupal_drupalgeddon2) > options

Module options (exploit/unix/webapp/drupal_drupalgeddon2):

   Name         Current Setting  Required  Description
   ----         ---------------  --------  -----------
   DUMP_OUTPUT  false            no        Dump payload command output
   PHP_FUNC     passthru         yes       PHP function to execute
   Proxies                       no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS       ::1              yes       The target address range or CIDR identifier
   RPORT        8443             yes       The target port (TCP)
   SSL          true             no        Negotiate SSL/TLS for outgoing connections
   TARGETURI    /drupal          yes       Path to Drupal install
   VHOST        localhost        no        HTTP server virtual host


Exploit target:

   Id  Name
   --  ----
   0   Automatic (PHP In-Memory)


msf5 exploit(unix/webapp/drupal_drupalgeddon2) > pry
[*] Starting Pry shell...
[*] You are in exploit/unix/webapp/drupal_drupalgeddon2

[1] pry(#<Msf::Modules::Exploit__Unix__Webapp__Drupal_drupalgeddon2::MetasploitModule>)> full_uri
=> "https://[::1]:8443/drupal"
[2] pry(#<Msf::Modules::Exploit__Unix__Webapp__Drupal_drupalgeddon2::MetasploitModule>)> full_uri(vhost_uri: true)
=> "https://localhost:8443/drupal"
[3] pry(#<Msf::Modules::Exploit__Unix__Webapp__Drupal_drupalgeddon2::MetasploitModule>)>
```

For #11481. Cf. https://github.com/rapid7/metasploit-framework/pull/7905#discussion_r100090929 and https://github.com/rapid7/metasploit-framework/pull/9285.