### PR TITLE
add file: support for RHOSTS option on exploit modules

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/exploit.rb
+++ b/lib/msf/ui/console/command_dispatcher/exploit.rb
@@ -165,9 +165,12 @@ class Exploit
     end
 
     rhosts = mod.datastore['RHOSTS']
-    rhosts_range = Rex::Socket::RangeWalker.new(rhosts)
+    if rhosts
+      rhosts_opt = Msf::OptAddressRange.new('RHOSTS')
+      rhosts_range = Rex::Socket::RangeWalker.new(rhosts_opt.normalize(rhosts))
+    end
     # For multiple targets exploit attempts.
-    if rhosts && rhosts_range.length.to_i > 1
+    if rhosts_range && rhosts_range.length > 1
       opts[:multi] = true
       rhosts_range.each do |rhost|
         nmod = mod.replicant
@@ -196,7 +199,7 @@ class Exploit
     # For single target or no rhosts option.
     else
       # avoid bug when the cidr of rhosts is 32, like 8.8.8.8/32
-      if rhosts_range.length == 1
+      if rhosts_range && rhosts_range.length == 1
         mod.datastore['RHOST'] = (Rex::Socket.addr_itoa(rhosts_range.ranges.first.start))
       end
       session = exploit_single(mod, opts)


### PR DESCRIPTION
This implements `file:` support for the RHOSTS option on exploit modules. Through a minor oddity with how the OptAddressRange option  works, looking at 'RHOSTS' directly from the module returns the string literal rather than the normalized form. This PR instantiates an OptAddressRange if RHOSTS is specified for the purpose of normalizing `file:` back into the correct value.

## Verification

- [x] Start `msfconsole`
- [x] `use exploit/windows/smb/ms08_067_netapi` or any remote exploit
- [x] `set RHOSTS single-ip`
- [x] **Verify** a single host is exploited
- [x] `set RHOSTS ip-range`
- [x] **Verify** multiple hosts are exploited
- [x] `set RHOSTS file:rhosts.txt`
- [x] **Verify** the contents of rhosts.txt is exploited
- [x] `use exploit/windows/fileformat/dvdx_plf_bof` or any non-remote exploit
- [x] ** Verify** the exploit works as expected
