### PR TITLE
Add more checks to cisco_directory_traversal module

### DIFF
--- a/modules/auxiliary/scanner/http/cisco_directory_traversal.rb
+++ b/modules/auxiliary/scanner/http/cisco_directory_traversal.rb
@@ -42,8 +42,7 @@ class MetasploitModule < Msf::Auxiliary
       'uri'     =>  uri
     )
 
-    serv_page = (res.body.include?("SSL VPN Service") || res.body.include?("+CSCOE+") || res.body.include?("+webvpn+") || res.body.include?("webvpnlogin"))
-    return (res && serv_page)
+    return (res && (res.body.include?("SSL VPN Service") || res.body.include?("+CSCOE+") || res.body.include?("+webvpn+") || res.body.include?("webvpnlogin")))
   end
 
   def list_files(path)

--- a/modules/auxiliary/scanner/http/cisco_directory_traversal.rb
+++ b/modules/auxiliary/scanner/http/cisco_directory_traversal.rb
@@ -42,7 +42,8 @@ class MetasploitModule < Msf::Auxiliary
       'uri'     =>  uri
     )
 
-    return (res && res.body.include?("SSL VPN Service"))
+    serv_page = (res.body.include?("SSL VPN Service") || res.body.include?("+CSCOE+") || res.body.include?("+webvpn+") || res.body.include?("webvpnlogin"))
+    return (res && serv_page)
   end
 
   def list_files(path)


### PR DESCRIPTION
Referencing issue #11162, this adds more checks to `auxiliary/scanner/http/cisco_directory_traversal.rb` to ensure more vulnerable devices are covered.

Originally, this module only checked the VPN software login page for `
SSL VPN Service`, which ultimately restricted the number of vulnerable devices exploited.