### PR TITLE
Deprecate pml_driver_config script

### DIFF
--- a/lib/msf/base/sessions/scriptable.rb
+++ b/lib/msf/base/sessions/scriptable.rb
@@ -80,6 +80,7 @@ module Scriptable
       'killav' => 'post/windows/manage/killav',
       'metsvc' => 'post/windows/manage/persistence_exe',
       'migrate' => 'post/windows/manage/migrate',
+      'pml_driver_config' => 'exploit/windows/local/service_permissions',
       'packetrecorder' => 'post/windows/manage/rpcapd_start',
       'persistence' => 'post/windows/manage/persistence_exe',
       'prefetchtool' => 'post/windows/gather/enum_prefetch',


### PR DESCRIPTION
#7789

The `pml_driver_config` script is effectively replaced by `exploit/windows/local/service_permissions`. While the module is not a one-for-one replacement for the original script, the features overlap.

The `pml_driver_config` script exploits insecure Windows service permissions on the `Pml Driver HPZ12` service to reconfigure the service binpath.

The `exploit/windows/local/service_permissions` module identifies Windows services with weak service permissions (among other things) and automatically exploits these services in a similar fashion.
