### PR TITLE
Revert CheckCode::Vulnerable to CheckCode::Appears in Wemo exploit

### DIFF
--- a/modules/exploits/linux/upnp/belkin_wemo_upnp_exec.rb
+++ b/modules/exploits/linux/upnp/belkin_wemo_upnp_exec.rb
@@ -115,7 +115,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     checkcode = check
 
-    unless checkcode == CheckCode::Vulnerable || datastore['ForceExploit']
+    unless checkcode == CheckCode::Appears || datastore['ForceExploit']
       fail_with(Failure::NotVulnerable, 'Set ForceExploit to override')
     end
 


### PR DESCRIPTION
Fixes #11464 again.