### PR TITLE
Fix misplaced error check in Crock-Pot module

### DIFF
--- a/modules/auxiliary/admin/wemo/crockpot.rb
+++ b/modules/auxiliary/admin/wemo/crockpot.rb
@@ -88,9 +88,7 @@ class MetasploitModule < Msf::Auxiliary
       res = send_request_cook('Off', 0)
     end
 
-    time = res.get_xml_document.at('//time')
-
-    unless res && res.code == 200 && time
+    unless res && res.code == 200 && (time = res.get_xml_document.at('//time'))
       print_error("Failed to #{action.name.downcase}, aborting!")
       return
     end


### PR DESCRIPTION
```
msf5 auxiliary(admin/wemo/crockpot) > run
[*] Running module against 127.0.0.1

[*] Cooking on Off for 0m
[-] Auxiliary failed: NoMethodError undefined method `get_xml_document' for nil:NilClass
[-] Call stack:
[-]   /rapid7/metasploit-framework/modules/auxiliary/admin/wemo/crockpot.rb:91:in `run'
[*] Auxiliary module execution completed
msf5 auxiliary(admin/wemo/crockpot) >
```

Fixes #10731. Not sure how this one escaped me.