### PR TITLE
RMI/util.rb: add handling of UnicastRef2 responses

### DIFF
--- a/lib/msf/core/exploit/java/rmi/util.rb
+++ b/lib/msf/core/exploit/java/rmi/util.rb
@@ -79,6 +79,21 @@ module Msf
               int
             end
 
+            # Extracts a byte from an IO
+            #
+            # @param io [IO] the io to extract the byte from
+            # @return [Byte, nil] the extracted byte if success, nil otherwise
+            def extract_byte(io)
+              byte_raw = io.read(1)
+              
+              unless byte_raw && byte_raw.length == 1
+                return nil
+              end
+              byte = byte_raw.unpack('C')[0]
+                      
+              byte
+            end
+
             # Extracts a long from an IO
             #
             # @param io [IO] the io to extract the long from
@@ -102,8 +117,16 @@ module Msf
             # @see Msf::Exploit::Remote::Java::Rmi::Client::Registry::Parser#parse_registry_lookup_endpoint
             def extract_reference(io)
               ref = extract_string(io)
-              unless ref && ref == 'UnicastRef'
+              unless ref && (ref == 'UnicastRef' || ref == 'UnicastRef2')
                 return nil
+              end
+              
+              if ref == 'UnicastRef2'
+                form = extract_byte(io)
+
+                unless form == 0 || form == 1 # FORMAT_HOST_PORT or FORMAT_HOST_PORT_FACTORY
+                  return nil
+                end
               end
 
               address = extract_string(io)


### PR DESCRIPTION
This PR adds the handling of UnicastRef2 responses in RMI serialized responses.
Before the patch, I've noticed that several MSF modules around RMI failed against a real target, for example:
```
msf5 auxiliary(gather/java_rmi_registry) > run

[*] a.b.c.d:9999 - Sending RMI Header...
[*] a.b.c.d:9999 - Listing names in the Registry...
[+] a.b.c.d:9999 - 1 names found in the Registry
[-] a.b.c.d:9999 - Failed to lookup REDACTEDService
```
Or:
```
msf5 exploit(multi/misc/java_jmx_server) > run

[*] Started reverse TCP handler on 1.2.3.4:4444 
[*] a.b.c.d:9999 - Starting service...
[*] a.b.c.d:9999 - Using URL: http://0.0.0.0:8080/RTyW5o21AFvH
[*] a.b.c.d:9999 - Local IP: http://1.2.3.4:8080/RTyW5o21AFvH
[*] a.b.c.d:9999 - Sending RMI Header...
[*] a.b.c.d:9999 - Discovering the JMXRMI endpoint...
[-] a.b.c.d:9999 - Exploit aborted due to failure: no-target:a.b.c.d:9999 - Failed to discover the JMXRMI endpoint
```

Whereas nmap's rmi-dumpregistry has no problem dumping it:
```
PORT     STATE SERVICE
9999/tcp open  java-rmi
| rmi-dumpregistry: 
|   REDACTEDService
|     javax.management.remote.rmi.RMIServerImpl_Stub
|     @a.b.c.d:65161
|     extends
|       java.rmi.server.RemoteStub
|       extends
|_        java.rmi.server.RemoteObject
```

I have searched for the root cause until I landed in lib/msf/core/exploit/java/rmi/util.rb.
The problem is that the service I am testing returns a UnicastRef2 message which is not currently handled by `extract_reference` and returns `nil`.

This PR adds the support for parsing this type. It is inspired from nmap's implementation:
* [UnicastRef](https://github.com/nmap/nmap/blob/d86a177456b28804ac4d5e706bd40e14a6cc3e38/nselib/rmi.lua#L1062)
* [UnicastRef2](https://github.com/nmap/nmap/blob/d86a177456b28804ac4d5e706bd40e14a6cc3e38/nselib/rmi.lua#L1075)

If my understanding is correct, the main difference is that UnicastRef2 begins with a "form" byte that shifts the parsing of the rest if it isn't captured. The rest seems to be the same so I use the same code.

## Verification
With the patch, the module works and we have the same result as with nmap:
```
msf5 auxiliary(gather/java_rmi_registry) > run

[*] a.b.c.d:9999 - Sending RMI Header...
[*] a.b.c.d:9999 - Listing names in the Registry...
[+] a.b.c.d:9999 - 1 names found in the Registry
[+] a.b.c.d:9999 - Name REDACTEDService (javax.management.remote.rmi.RMIServerImpl_Stub) found on a.b.c.d:65161
```

The java_jmx_server exploit works fine too:
```
msf5 exploit(multi/misc/java_jmx_server) > run

[*] Started reverse TCP handler on 1.2.3.4:4444 
[*] a.b.c.d:9999 - Using URL: http://0.0.0.0:8080/OuI7vK
[*] a.b.c.d:9999 - Local IP: http://1.2.3.4:8080/OuI7vK
[*] a.b.c.d:9999 - Sending RMI Header...
[*] a.b.c.d:9999 - Discovering the JMXRMI endpoint...
[+] a.b.c.d:9999 - JMXRMI endpoint on a.b.c.d:65161
[*] a.b.c.d:9999 - Proceeding with handshake...
[+] a.b.c.d:9999 - Handshake with JMX MBean server on a.b.c.d:65161
[*] a.b.c.d:9999 - Loading payload...
[*] a.b.c.d:9999 - Replied to request for mlet
[*] a.b.c.d:9999 - Replied to request for payload JAR
[*] a.b.c.d:9999 - Executing payload...
```

If that helps, the target is Tomcat 8 running on Windows.