### PR TITLE
MSF5: Remove unneeded RHOST deregister in scanners

### DIFF
--- a/modules/auxiliary/admin/smb/ms17_010_command.rb
+++ b/modules/auxiliary/admin/smb/ms17_010_command.rb
@@ -64,8 +64,6 @@ class MetasploitModule < Msf::Auxiliary
       OptInt.new('DELAY', [true, 'Wait this many seconds before reading output and cleaning up', 0]),
       OptInt.new('RETRY', [true, 'Retry this many times to check if the process is complete', 0]),
     ])
-
-    deregister_options('RHOST')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/admin/smb/psexec_command.rb
+++ b/modules/auxiliary/admin/smb/psexec_command.rb
@@ -50,8 +50,6 @@ class MetasploitModule < Msf::Auxiliary
       OptInt.new('DELAY', [true, 'Wait this many seconds before reading output and cleaning up', 0]),
       OptInt.new('RETRY', [true, 'Retry this many times to check if the process is complete', 0]),
     ])
-
-    deregister_options('RHOST')
   end
 
   # This is the main controle method

--- a/modules/auxiliary/bnat/bnat_scan.rb
+++ b/modules/auxiliary/bnat/bnat_scan.rb
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Auxiliary
           OptInt.new('TIMEOUT', [true, "The reply read timeout in milliseconds", 500])
         ])
 
-    deregister_options('FILTER','PCAPFILE','RHOST','SNAPLEN')
+    deregister_options('FILTER','PCAPFILE','SNAPLEN')
 
   end
 

--- a/modules/auxiliary/dos/dhcp/isc_dhcpd_clientid.rb
+++ b/modules/auxiliary/dos/dhcp/isc_dhcpd_clientid.rb
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Auxiliary
         OptAddress.new('RIP', [true, 'A valid IP to request from the server'])
       ]
     )
-    deregister_options('RHOST','FILTER','PCAPFILE','SNAPLEN','TIMEOUT')
+    deregister_options('FILTER','PCAPFILE','SNAPLEN','TIMEOUT')
   end
 
   def run

--- a/modules/auxiliary/dos/http/ms15_034_ulonglongadd.rb
+++ b/modules/auxiliary/dos/http/ms15_034_ulonglongadd.rb
@@ -42,8 +42,6 @@ class MetasploitModule < Msf::Auxiliary
       [
         OptString.new('TARGETURI', [false, 'URI to the site (e.g /site/) or a valid file resource (e.g /welcome.png)', '/'])
       ])
-
-    deregister_options('RHOST')
   end
 
   def upper_range

--- a/modules/auxiliary/fuzzers/ftp/ftp_pre_post.rb
+++ b/modules/auxiliary/fuzzers/ftp/ftp_pre_post.rb
@@ -31,7 +31,6 @@ class MetasploitModule < Msf::Auxiliary
         OptBool.new('FASTFUZZ', [ false, "Only fuzz with cyclic pattern",true]),
         OptBool.new('CONNRESET', [ false, "Break on CONNRESET error",true]),
       ])
-    deregister_options('RHOST')
 
     @evilchars = [
       'A','a','%s','%d','%n','%x','%p','-1','0','0xfffffffe','0xffffffff','A/','//','/..','//..',

--- a/modules/auxiliary/scanner/afp/afp_login.rb
+++ b/modules/auxiliary/scanner/afp/afp_login.rb
@@ -29,7 +29,6 @@ class MetasploitModule < Msf::Auxiliary
       'License'      => MSF_LICENSE
     ))
 
-    deregister_options('RHOST')
     register_options(
       [
         Opt::Proxies,
@@ -37,7 +36,6 @@ class MetasploitModule < Msf::Auxiliary
         OptBool.new('RECORD_GUEST', [ false, "Record guest login to the database", false]),
         OptBool.new('CHECK_GUEST', [ false, "Check for guest login", true])
       ], self)
-
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/afp/afp_server_info.rb
+++ b/modules/auxiliary/scanner/afp/afp_server_info.rb
@@ -23,8 +23,6 @@ class MetasploitModule < Msf::Auxiliary
       'Author'       => [ 'Gregory Man <man.gregory[at]gmail.com>' ],
       'License'      => MSF_LICENSE
     ))
-
-    deregister_options('RHOST')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/chargen/chargen_probe.rb
+++ b/modules/auxiliary/scanner/chargen/chargen_probe.rb
@@ -38,8 +38,6 @@ class MetasploitModule < Msf::Auxiliary
       register_options([
         Opt::RPORT(19)
       ])
-
-    deregister_options('RHOST')
   end
 
   def run_host(rhost)

--- a/modules/auxiliary/scanner/db2/discovery.rb
+++ b/modules/auxiliary/scanner/db2/discovery.rb
@@ -17,8 +17,6 @@ class MetasploitModule < Msf::Auxiliary
     )
 
     register_options([Opt::RPORT(523),])
-
-    deregister_options('RHOST')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/dcerpc/endpoint_mapper.rb
+++ b/modules/auxiliary/scanner/dcerpc/endpoint_mapper.rb
@@ -24,8 +24,6 @@ class MetasploitModule < Msf::Auxiliary
       'License'     => MSF_LICENSE
     )
 
-    deregister_options('RHOST')
-
     register_options(
       [
         Opt::RPORT(135)

--- a/modules/auxiliary/scanner/dcerpc/management.rb
+++ b/modules/auxiliary/scanner/dcerpc/management.rb
@@ -24,8 +24,6 @@ class MetasploitModule < Msf::Auxiliary
       'License'     => MSF_LICENSE
     )
 
-    deregister_options('RHOST')
-
     register_options(
       [
         Opt::RPORT(135)

--- a/modules/auxiliary/scanner/dcerpc/tcp_dcerpc_auditor.rb
+++ b/modules/auxiliary/scanner/dcerpc/tcp_dcerpc_auditor.rb
@@ -21,7 +21,6 @@ class MetasploitModule < Msf::Auxiliary
       'License'     => MSF_LICENSE
     )
 
-    deregister_options('RPORT', 'RHOST')
     register_options(
       [
         Opt::RPORT(135)

--- a/modules/auxiliary/scanner/dcerpc/windows_deployment_services.rb
+++ b/modules/auxiliary/scanner/dcerpc/windows_deployment_services.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Auxiliary
         Opt::RPORT(5040),
       ])
 
-    deregister_options('RHOST', 'CHOST', 'CPORT', 'SSL', 'SSLVersion')
+    deregister_options('CHOST', 'CPORT', 'SSL', 'SSLVersion')
 
     register_advanced_options(
       [

--- a/modules/auxiliary/scanner/discovery/ipv6_multicast_ping.rb
+++ b/modules/auxiliary/scanner/discovery/ipv6_multicast_ping.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Auxiliary
       ]
     )
 
-    deregister_options('SNAPLEN', 'FILTER', 'RHOST', 'PCAPFILE')
+    deregister_options('SNAPLEN', 'FILTER', 'PCAPFILE')
   end
 
   def listen_for_ping_response(opts = {})

--- a/modules/auxiliary/scanner/discovery/ipv6_neighbor_router_advertisement.rb
+++ b/modules/auxiliary/scanner/discovery/ipv6_neighbor_router_advertisement.rb
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Auxiliary
       OptInt.new('TIMEOUT_NEIGHBOR', [true, "Time (seconds) to listen for a solicitation response.", 1])
     ])
 
-    deregister_options('SNAPLEN', 'FILTER', 'RHOST', 'PCAPFILE')
+    deregister_options('SNAPLEN', 'FILTER', 'PCAPFILE')
   end
 
   def generate_prefix()

--- a/modules/auxiliary/scanner/http/atlassian_crowd_fileaccess.rb
+++ b/modules/auxiliary/scanner/http/atlassian_crowd_fileaccess.rb
@@ -44,7 +44,6 @@ class MetasploitModule < Msf::Auxiliary
     ])
 
     register_autofilter_ports([ 8095 ])
-    deregister_options('RHOST')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/http/cisco_firepower_download.rb
+++ b/modules/auxiliary/scanner/http/cisco_firepower_download.rb
@@ -43,8 +43,6 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('TARGETURI', [true, 'The base path to Cisco Firepower Management console', '/']),
         OptString.new('FILEPATH', [false, 'The name of the file to download', '/etc/passwd'])
       ])
-
-    deregister_options('RHOST')
   end
 
   def do_login(ip)

--- a/modules/auxiliary/scanner/http/concrete5_member_list.rb
+++ b/modules/auxiliary/scanner/http/concrete5_member_list.rb
@@ -31,7 +31,6 @@ class MetasploitModule < Msf::Auxiliary
         Opt::RPORT(80),
         OptString.new('URI', [false, 'URL of the Concrete5 root', '/'])
       ])
-    deregister_options('RHOST')
   end
 
   def run_host(rhost)

--- a/modules/auxiliary/scanner/http/dnalims_file_retrieve.rb
+++ b/modules/auxiliary/scanner/http/dnalims_file_retrieve.rb
@@ -37,10 +37,7 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('FILE', [ true,  "The path to the file to view", '/home/dna/spool/.pfile']), # password db for app
         OptInt.new('DEPTH', [true, 'The traversal depth', 4])
       ])
-
-    deregister_options('RHOST')
   end
-
 
   def run_host(ip)
     file     = (datastore['FILE'][0,1] == '/') ? datastore['FILE'] : "#{datastore['FILE']}"

--- a/modules/auxiliary/scanner/http/elasticsearch_traversal.rb
+++ b/modules/auxiliary/scanner/http/elasticsearch_traversal.rb
@@ -39,8 +39,6 @@ class MetasploitModule < Msf::Auxiliary
         OptInt.new('DEPTH', [true, 'Traversal depth', 7])
       ], self.class
     )
-
-    deregister_options('RHOST')
   end
 
   def check_host(ip)

--- a/modules/auxiliary/scanner/http/gitlab_login.rb
+++ b/modules/auxiliary/scanner/http/gitlab_login.rb
@@ -33,8 +33,6 @@ class MetasploitModule < Msf::Auxiliary
       ])
 
     register_autofilter_ports([ 80, 443 ])
-
-    deregister_options('RHOST')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/http/goahead_traversal.rb
+++ b/modules/auxiliary/scanner/http/goahead_traversal.rb
@@ -35,8 +35,6 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('FILEPATH', [true, "The path to the file to read", "/etc/passwd"]),
         OptInt.new('DEPTH', [ true, 'Traversal Depth (to reach the root folder)', 5 ])
       ])
-
-    deregister_options('RHOST')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/http/hp_sitescope_getfileinternal_fileaccess.rb
+++ b/modules/auxiliary/scanner/http/hp_sitescope_getfileinternal_fileaccess.rb
@@ -40,7 +40,6 @@ class MetasploitModule < Msf::Auxiliary
     ])
 
     register_autofilter_ports([ 8080 ])
-    deregister_options('RHOST')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/http/hp_sitescope_getsitescopeconfiguration.rb
+++ b/modules/auxiliary/scanner/http/hp_sitescope_getsitescopeconfiguration.rb
@@ -41,7 +41,6 @@ class MetasploitModule < Msf::Auxiliary
     ])
 
     register_autofilter_ports([ 8080 ])
-    deregister_options('RHOST')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/http/hp_sitescope_loadfilecontent_fileaccess.rb
+++ b/modules/auxiliary/scanner/http/hp_sitescope_loadfilecontent_fileaccess.rb
@@ -40,7 +40,6 @@ class MetasploitModule < Msf::Auxiliary
     ])
 
     register_autofilter_ports([ 8080 ])
-    deregister_options('RHOST')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/http/http_traversal.rb
+++ b/modules/auxiliary/scanner/http/http_traversal.rb
@@ -73,8 +73,6 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('FILE',      [false, 'Default file to read for the fuzzing stage', '']),
         OptString.new('COOKIE',    [false, 'Cookie value to use when sending the requests', ''])
       ])
-
-    deregister_options('RHOST')
   end
 
 

--- a/modules/auxiliary/scanner/http/jenkins_login.rb
+++ b/modules/auxiliary/scanner/http/jenkins_login.rb
@@ -28,8 +28,6 @@ class MetasploitModule < Msf::Auxiliary
       ])
 
     register_autofilter_ports([ 80, 443, 8080, 8081, 8000 ])
-
-    deregister_options('RHOST')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/http/manageengine_deviceexpert_traversal.rb
+++ b/modules/auxiliary/scanner/http/manageengine_deviceexpert_traversal.rb
@@ -37,8 +37,6 @@ class MetasploitModule < Msf::Auxiliary
         OptBool.new('SSL',   [true, 'Use SSL', true]),
         OptString.new('FILEPATH', [true, 'The name of the file to download', 'windows\\win.ini'])
       ])
-
-    deregister_options('RHOST')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/http/manageengine_deviceexpert_user_creds.rb
+++ b/modules/auxiliary/scanner/http/manageengine_deviceexpert_user_creds.rb
@@ -37,7 +37,6 @@ class MetasploitModule < Msf::Auxiliary
         Opt::RPORT(6060),
         OptBool.new('SSL', [true, 'Use SSL', true])
       ])
-    deregister_options('RHOST')
   end
 
   def check

--- a/modules/auxiliary/scanner/http/mediawiki_svg_fileaccess.rb
+++ b/modules/auxiliary/scanner/http/mediawiki_svg_fileaccess.rb
@@ -48,7 +48,6 @@ class MetasploitModule < Msf::Auxiliary
     ])
 
     register_autofilter_ports([ 80 ])
-    deregister_options('RHOST')
   end
 
   def get_first_session

--- a/modules/auxiliary/scanner/http/mybook_live_login.rb
+++ b/modules/auxiliary/scanner/http/mybook_live_login.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Auxiliary
     register_autofilter_ports([ 80 ])
 
     # username is hardcoded into application
-    deregister_options('RHOST', 'USERNAME', 'USER_FILE', 'USER_AS_PASS', 'DB_ALL_USERS')
+    deregister_options('USERNAME', 'USER_FILE', 'USER_AS_PASS', 'DB_ALL_USERS')
   end
 
   def setup

--- a/modules/auxiliary/scanner/http/netdecision_traversal.rb
+++ b/modules/auxiliary/scanner/http/netdecision_traversal.rb
@@ -38,8 +38,6 @@ class MetasploitModule < Msf::Auxiliary
         Opt::RPORT(8087),
         OptString.new('FILEPATH', [false, 'The name of the file to download', 'windows\\system.ini'])
       ])
-
-    deregister_options('RHOST')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/http/novell_file_reporter_srs_fileaccess.rb
+++ b/modules/auxiliary/scanner/http/novell_file_reporter_srs_fileaccess.rb
@@ -39,7 +39,6 @@ class MetasploitModule < Msf::Auxiliary
     ])
 
     register_autofilter_ports([ 3037 ])
-    deregister_options('RHOST')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/http/oracle_demantra_database_credentials_leak.rb
+++ b/modules/auxiliary/scanner/http/oracle_demantra_database_credentials_leak.rb
@@ -36,8 +36,6 @@ class MetasploitModule < Msf::Auxiliary
         Opt::RPORT(8080),
         OptBool.new('SSL',   [false, 'Use SSL', false])
       ])
-
-    deregister_options('RHOST')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/http/oracle_demantra_file_retrieval.rb
+++ b/modules/auxiliary/scanner/http/oracle_demantra_file_retrieval.rb
@@ -39,8 +39,6 @@ class MetasploitModule < Msf::Auxiliary
         OptBool.new('SSL',   [false, 'Use SSL', false]),
         OptString.new('FILEPATH', [true, 'The name of the file to download', 'c:/windows/win.ini'])
       ])
-
-    deregister_options('RHOST')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/http/sap_businessobjects_version_enum.rb
+++ b/modules/auxiliary/scanner/http/sap_businessobjects_version_enum.rb
@@ -27,7 +27,6 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('URI', [false, 'Path to the SAP BusinessObjects Axis2', '/dswsbobje']),
       ])
     register_autofilter_ports([ 8080 ])
-    deregister_options('RHOST')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/http/simple_webserver_traversal.rb
+++ b/modules/auxiliary/scanner/http/simple_webserver_traversal.rb
@@ -36,10 +36,7 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('FILEPATH', [true, 'The name of the file to download', 'windows\\win.ini']),
         OptInt.new('DEPTH',       [true, 'The max traversal depth', 8])
       ])
-
-    deregister_options('RHOST')
   end
-
 
   #
   # The web server will actually return two HTTP statuses: A 400 (Bad Request), and the actual

--- a/modules/auxiliary/scanner/http/sockso_traversal.rb
+++ b/modules/auxiliary/scanner/http/sockso_traversal.rb
@@ -34,8 +34,6 @@ class MetasploitModule < Msf::Auxiliary
         Opt::RPORT(4444),
         OptString.new('FILEPATH', [false, 'The name of the file to download', 'windows\\system.ini'])
       ])
-
-    deregister_options('RHOST')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/http/surgenews_user_creds.rb
+++ b/modules/auxiliary/scanner/http/surgenews_user_creds.rb
@@ -33,8 +33,8 @@ class MetasploitModule < Msf::Auxiliary
         ],
       'Author'         => 'bcoles',
       'DisclosureDate' => 'Jun 16 2017'))
+
     register_options [ Opt::RPORT(9080) ]
-    deregister_options 'RHOST'
   end
 
   def max_retries

--- a/modules/auxiliary/scanner/http/sybase_easerver_traversal.rb
+++ b/modules/auxiliary/scanner/http/sybase_easerver_traversal.rb
@@ -37,8 +37,6 @@ class MetasploitModule < Msf::Auxiliary
         Opt::RPORT(8000),
         OptString.new("FILEPATH", [false, 'Specify a parameter for the action'])
       ])
-
-    deregister_options('RHOST')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/http/symantec_brightmail_ldapcreds.rb
+++ b/modules/auxiliary/scanner/http/symantec_brightmail_ldapcreds.rb
@@ -47,8 +47,6 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('PASSWORD', [true, 'The password to login with']),
         OptString.new('TARGETURI', [true, 'The base path to Symantec Messaging Gateway', '/'])
       ])
-
-    deregister_options('RHOST')
   end
 
   def print_status(msg='')

--- a/modules/auxiliary/scanner/http/symantec_brightmail_logfile.rb
+++ b/modules/auxiliary/scanner/http/symantec_brightmail_logfile.rb
@@ -42,8 +42,6 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('USERNAME', [true, 'The username to login as']),
         OptString.new('PASSWORD', [true, 'The password to login with'])
       ])
-
-    deregister_options('RHOST')
   end
 
   def auth(username, password, sid, last_login)

--- a/modules/auxiliary/scanner/http/webpagetest_traversal.rb
+++ b/modules/auxiliary/scanner/http/webpagetest_traversal.rb
@@ -36,8 +36,6 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('FILE', [ true,  "The path to the file to view", '/etc/passwd']),
         OptInt.new('DEPTH', [true, 'The max traversal depth', 11])
       ])
-
-    deregister_options('RHOST')
   end
 
 

--- a/modules/auxiliary/scanner/http/yaws_traversal.rb
+++ b/modules/auxiliary/scanner/http/yaws_traversal.rb
@@ -36,8 +36,6 @@ class MetasploitModule < Msf::Auxiliary
         Opt::RPORT(8080),
         OptString.new('FILEPATH', [false, 'The name of the file to download', 'windows\\win.ini'])
       ])
-
-    deregister_options('RHOST')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/misc/dahua_dvr_auth_bypass.rb
+++ b/modules/auxiliary/scanner/misc/dahua_dvr_auth_bypass.rb
@@ -38,7 +38,6 @@ class MetasploitModule < Msf::Auxiliary
         ]
     )
 
-    deregister_options('RHOST')
     register_options([
       OptString.new('USERNAME', [false, 'A username to reset', '888888']),
       OptString.new('PASSWORD', [false, 'A password to reset the user with, if not set a random pass will be generated.']),

--- a/modules/auxiliary/scanner/mongodb/mongodb_login.rb
+++ b/modules/auxiliary/scanner/mongodb/mongodb_login.rb
@@ -30,8 +30,6 @@ class MetasploitModule < Msf::Auxiliary
         Opt::RPORT(27017),
         OptString.new('DB', [ true, "Database to use", "admin"])
       ])
-
-    deregister_options('RHOST')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/motorola/timbuktu_udp.rb
+++ b/modules/auxiliary/scanner/motorola/timbuktu_udp.rb
@@ -23,8 +23,6 @@ class MetasploitModule < Msf::Auxiliary
       [
         Opt::RPORT(407)
       ])
-
-    deregister_options('RHOST')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/mssql/mssql_ping.rb
+++ b/modules/auxiliary/scanner/mssql/mssql_ping.rb
@@ -16,7 +16,7 @@ class MetasploitModule < Msf::Auxiliary
       'License'        => MSF_LICENSE
     )
 
-    deregister_options('RPORT', 'RHOST')
+    deregister_options('RPORT')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/nntp/nntp_login.rb
+++ b/modules/auxiliary/scanner/nntp/nntp_login.rb
@@ -34,7 +34,6 @@ class MetasploitModule < Msf::Auxiliary
         OptPath.new('PASS_FILE', [ false, 'The file that contains a list of probable passwords.',
           File.join(Msf::Config.install_root, 'data', 'wordlists', 'unix_passwords.txt') ])
       ])
-    deregister_options 'RHOST'
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/ntp/ntp_nak_to_the_future.rb
+++ b/modules/auxiliary/scanner/ntp/ntp_nak_to_the_future.rb
@@ -44,8 +44,6 @@ class MetasploitModule < Msf::Auxiliary
       [
         OptInt.new('OFFSET', [true, "Offset from local time, in seconds", 300])
       ])
-
-    deregister_options('RHOST')
   end
 
   def build_crypto_nak(time)

--- a/modules/auxiliary/scanner/oracle/sid_enum.rb
+++ b/modules/auxiliary/scanner/oracle/sid_enum.rb
@@ -25,8 +25,6 @@ class MetasploitModule < Msf::Auxiliary
       [
         Opt::RPORT(1521)
       ])
-
-    deregister_options('RHOST')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/oracle/tnslsnr_version.rb
+++ b/modules/auxiliary/scanner/oracle/tnslsnr_version.rb
@@ -22,8 +22,6 @@ class MetasploitModule < Msf::Auxiliary
       [
         Opt::RPORT(1521)
       ])
-
-    deregister_options('RHOST')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/oracle/tnspoison_checker.rb
+++ b/modules/auxiliary/scanner/oracle/tnspoison_checker.rb
@@ -30,8 +30,6 @@ class MetasploitModule < Msf::Auxiliary
       [
         Opt::RPORT(1521)
       ])
-
-    deregister_options('RHOST') # Provided by the TNS mixin, but not needed in a scanner module
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/portscan/ftpbounce.rb
+++ b/modules/auxiliary/scanner/portscan/ftpbounce.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Auxiliary
       OptInt.new('JITTER', [true, "The delay jitter factor (maximum value by which to +/- DELAY) in milliseconds.", 0])
     ])
 
-    deregister_options('RHOST', 'RPORT')
+    deregister_options('RPORT')
   end
 
   # No IPv6 support yet

--- a/modules/auxiliary/scanner/rogue/rogue_recv.rb
+++ b/modules/auxiliary/scanner/rogue/rogue_recv.rb
@@ -23,7 +23,6 @@ class MetasploitModule < Msf::Auxiliary
       OptPort.new("CPORT", [true, "The source port for the TCP SYN packet", 13832]),
       OptInt.new("ECHOID", [true, "The unique ICMP ECHO ID to embed into the packet", 7893]),
     ])
-    deregister_options('RHOST')
   end
 
   def build_filter

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_abaplog.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_abaplog.rb
@@ -27,7 +27,6 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('URI', [false, 'Path to the SAP Management Console ', '/']),
       ])
     register_autofilter_ports([ 50013 ])
-    deregister_options('RHOST')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_extractusers.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_extractusers.rb
@@ -30,7 +30,6 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('URI', [false, 'Path to the SAP Management Console ', '/']),
       ])
     register_autofilter_ports([ 50013 ])
-    deregister_options('RHOST')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_getaccesspoints.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_getaccesspoints.rb
@@ -30,7 +30,6 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('URI', [false, 'Path to the SAP Management Console ', '/']),
       ])
     register_autofilter_ports([ 50013 ])
-    deregister_options('RHOST')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_getenv.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_getenv.rb
@@ -30,7 +30,6 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('URI', [false, 'Path to the SAP Management Console ', '/']),
       ])
     register_autofilter_ports([ 50013 ])
-    deregister_options('RHOST')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_getlogfiles.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_getlogfiles.rb
@@ -39,7 +39,6 @@ class MetasploitModule < Msf::Auxiliary
         OptBool.new('GETALL', [ false, 'Download all available files (WARNING: may take a long time!)', false])
       ])
     register_autofilter_ports([ 50013 ])
-    deregister_options('RHOST')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_getprocesslist.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_getprocesslist.rb
@@ -33,7 +33,6 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('URI', [false, 'Path to the SAP Management Console ', '/']),
       ])
     register_autofilter_ports([ 50013 ])
-    deregister_options('RHOST')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_getprocessparameter.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_getprocessparameter.rb
@@ -31,7 +31,6 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('MATCH', [false, 'Display matches e.g login/', '']),
       ])
     register_autofilter_ports([ 50013 ])
-    deregister_options('RHOST')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_instanceproperties.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_instanceproperties.rb
@@ -30,7 +30,6 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('URI', [false, 'Path to the SAP Management Console ', '/']),
       ])
     register_autofilter_ports([ 50013 ])
-    deregister_options('RHOST')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_listconfigfiles.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_listconfigfiles.rb
@@ -35,7 +35,6 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('URI', [false, 'Path to the SAP Management Console ', '/']),
       ])
     register_autofilter_ports([ 50013 ])
-    deregister_options('RHOST')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_listlogfiles.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_listlogfiles.rb
@@ -32,7 +32,6 @@ class MetasploitModule < Msf::Auxiliary
         OptEnum.new('FILETYPE', [true, 'Specify LOGFILE or TRACEFILE', 'TRACEFILE', ['TRACEFILE','LOGFILE']])
       ])
     register_autofilter_ports([ 50013 ])
-    deregister_options('RHOST')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_startprofile.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_startprofile.rb
@@ -30,7 +30,6 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('URI', [false, 'Path to the SAP Management Console ', '/']),
       ])
     register_autofilter_ports([ 50013 ])
-    deregister_options('RHOST')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_version.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_version.rb
@@ -30,7 +30,6 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('URI', [false, 'Path to the SAP Management Console ', '/']),
       ])
     register_autofilter_ports([ 50013 ])
-    deregister_options('RHOST')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/scada/indusoft_ntwebserver_fileaccess.rb
+++ b/modules/auxiliary/scanner/scada/indusoft_ntwebserver_fileaccess.rb
@@ -39,7 +39,6 @@ class MetasploitModule < Msf::Auxiliary
     ])
 
     register_autofilter_ports([ 80 ])
-    deregister_options('RHOST')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/smb/pipe_dcerpc_auditor.rb
+++ b/modules/auxiliary/scanner/smb/pipe_dcerpc_auditor.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Auxiliary
       'License'     => MSF_LICENSE
     )
 
-    deregister_options('RPORT', 'RHOST')
+    deregister_options('RPORT')
     register_options(
       [
         OptString.new('SMBPIPE', [ true,  "The pipe name to use (BROWSER)", 'BROWSER']),

--- a/modules/auxiliary/scanner/smb/psexec_loggedin_users.rb
+++ b/modules/auxiliary/scanner/smb/psexec_loggedin_users.rb
@@ -42,8 +42,6 @@ class MetasploitModule < Msf::Auxiliary
       OptString.new('RPORT', [true, 'The Target port', 445]),
       OptString.new('WINPATH', [true, 'The name of the Windows directory', 'WINDOWS']),
     ])
-
-    deregister_options('RHOST')
   end
 
   # This is the main controller function

--- a/modules/auxiliary/scanner/smb/smb_enumshares.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumshares.rb
@@ -51,7 +51,7 @@ class MetasploitModule < Msf::Auxiliary
         OptInt.new('MaxDepth',      [true, 'Max number of subdirectories to spider', 999]),
       ])
 
-    deregister_options('RPORT', 'RHOST')
+    deregister_options('RPORT')
   end
 
   def device_type_int_to_text(device_type)

--- a/modules/auxiliary/scanner/smb/smb_enumusers.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumusers.rb
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Auxiliary
       }
     )
 
-    deregister_options('RPORT', 'RHOST')
+    deregister_options('RPORT')
   end
 
   def rport

--- a/modules/auxiliary/scanner/smb/smb_enumusers_domain.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumusers_domain.rb
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Auxiliary
       'License'     => MSF_LICENSE
     )
 
-    deregister_options('RPORT', 'RHOST')
+    deregister_options('RPORT')
 
   end
 

--- a/modules/auxiliary/scanner/smb/smb_login.rb
+++ b/modules/auxiliary/scanner/smb/smb_login.rb
@@ -46,7 +46,7 @@ class MetasploitModule < Msf::Auxiliary
           'USER_AS_PASS'    => false
         }
     )
-    deregister_options('RHOST','USERNAME','PASSWORD')
+    deregister_options('USERNAME','PASSWORD')
 
     # These are normally advanced options, but for this module they have a
     # more active role, so make them regular options.

--- a/modules/auxiliary/scanner/smb/smb_lookupsid.rb
+++ b/modules/auxiliary/scanner/smb/smb_lookupsid.rb
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Auxiliary
       self.class
     )
 
-    deregister_options('RPORT', 'RHOST')
+    deregister_options('RPORT')
   end
 
   # Constants used by this module

--- a/modules/auxiliary/scanner/smb/smb_uninit_cred.rb
+++ b/modules/auxiliary/scanner/smb/smb_uninit_cred.rb
@@ -60,7 +60,7 @@ class MetasploitModule < Msf::Auxiliary
     ])
 
     # It's either 139 or 445. The user should not touch this.
-    deregister_options('RPORT', 'RHOST')
+    deregister_options('RPORT')
   end
 
   def rport

--- a/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
@@ -53,7 +53,7 @@ class MetasploitModule < Msf::Auxiliary
       ]
     )
 
-    deregister_options('RHOST','PASSWORD','PASS_FILE','BLANK_PASSWORDS','USER_AS_PASS','USERPASS_FILE')
+    deregister_options('PASSWORD','PASS_FILE','BLANK_PASSWORDS','USER_AS_PASS','USERPASS_FILE')
 
     @good_key = ''
     @strip_passwords = true

--- a/modules/auxiliary/scanner/telnet/telnet_login.rb
+++ b/modules/auxiliary/scanner/telnet/telnet_login.rb
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Auxiliary
         ],
       'License'     => MSF_LICENSE
     )
-    deregister_options('RHOST')
+
     register_advanced_options(
       [
         OptInt.new('TIMEOUT', [ true, 'Default timeout for telnet connections.', 25])

--- a/modules/auxiliary/server/capture/printjob_capture.rb
+++ b/modules/auxiliary/server/capture/printjob_capture.rb
@@ -37,8 +37,8 @@ class MetasploitModule < Msf::Auxiliary
     register_options([
       OptPort.new('SRVPORT',  [ true, 'The local port to listen on', 9100 ]),
       OptBool.new('FORWARD',  [ true, 'Forward print jobs to another host', false ]),
-      OptPort.new('RPORT',    [ false, 'Forward to remote port', 9100 ]),
       OptAddress.new('RHOST', [ false, 'Forward to remote host' ]),
+      OptPort.new('RPORT',    [ false, 'Forward to remote port', 9100 ]),
       OptBool.new('METADATA', [ true, 'Display Metadata from printjobs', true ]),
       OptEnum.new('MODE',     [ true,  'Print mode', 'RAW', ['RAW', 'LPR']]) # TODO: Add IPP
 

--- a/modules/auxiliary/sniffer/psnuffle.rb
+++ b/modules/auxiliary/sniffer/psnuffle.rb
@@ -38,7 +38,7 @@ class MetasploitModule < Msf::Auxiliary
         File.join(Msf::Config.data_directory, 'exploits', 'psnuffle')
       ]),
     ]
-    deregister_options('RHOST', 'RHOSTS')
+    deregister_options('RHOSTS')
   end
 
 

--- a/modules/exploits/windows/misc/wireshark_packet_dect.rb
+++ b/modules/exploits/windows/misc/wireshark_packet_dect.rb
@@ -63,7 +63,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     ])
 
-    deregister_options('FILTER','PCAPFILE','RHOST','RHOSTS','SNAPLEN','TIMEOUT','SECRET','GATEWAY_PROBE_HOST','GATEWAY_PROBE_PORT')
+    deregister_options('FILTER','PCAPFILE','RHOSTS','SNAPLEN','TIMEOUT','SECRET','GATEWAY_PROBE_HOST','GATEWAY_PROBE_PORT')
   end
 
   def junk


### PR DESCRIPTION
With Metasploit 5, RHOST and RHOSTS are aliases, so no need to deregister one or the other, as they are the same option. Deregistering one deregisters both, so with MSF5, I think this is actively wrong for this set of modules.

## Verification

- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/*` # for several modules that are aux scanners
- [x] **Verify** that the modules work in general and expose RHOSTS as an option, but not RHOST
