### PR TITLE
remove some random deregister_options from modules

### DIFF
--- a/modules/auxiliary/dos/ssl/dtls_changecipherspec.rb
+++ b/modules/auxiliary/dos/ssl/dtls_changecipherspec.rb
@@ -6,7 +6,6 @@
 class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Dos
   include Msf::Exploit::Capture
-  include Exploit::Remote::Udp
 
   def initialize(info = {})
     super(update_info(info,
@@ -27,6 +26,12 @@ class MetasploitModule < Msf::Auxiliary
           [ 'OSVDB', '55073'],
         ],
       'DisclosureDate' => 'Apr 26 2000'))
+
+    register_options([
+        Opt::RPORT(80),
+        Opt::RHOST
+      ]
+    )
 
     deregister_options('FILTER','PCAPFILE', 'INTERFACE', 'SNAPLEN', 'TIMEOUT')
   end

--- a/modules/auxiliary/dos/ssl/dtls_changecipherspec.rb
+++ b/modules/auxiliary/dos/ssl/dtls_changecipherspec.rb
@@ -6,7 +6,7 @@
 class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Dos
   include Msf::Exploit::Capture
-  include Exploit::Remote::Tcp
+  include Exploit::Remote::Udp
 
   def initialize(info = {})
     super(update_info(info,

--- a/modules/auxiliary/gather/shodan_honeyscore.rb
+++ b/modules/auxiliary/gather/shodan_honeyscore.rb
@@ -29,10 +29,6 @@ class MetasploitModule < Msf::Auxiliary
       )
     )
 
-    deregister_options('RHOST', 'SSL', 'DOMAIN', 'DigestAuthIIS', 'NTLM::SendLM',
-      'NTLM::SendNTLM', 'VHOST', 'RPORT', 'NTLM::SendSPN', 'NTLM::UseLMKey',
-      'NTLM::UseNTLM2_session', 'NTLM::UseNTLMv2')
-
     register_options(
       [
         OptString.new('TARGET', [true, 'The target to get the score of']),

--- a/modules/auxiliary/gather/shodan_search.rb
+++ b/modules/auxiliary/gather/shodan_search.rb
@@ -7,7 +7,6 @@ require 'net/https'
 require 'uri'
 
 class MetasploitModule < Msf::Auxiliary
-  include Msf::Exploit::Remote::HttpClient
   include Msf::Auxiliary::Report
 
   def initialize(info = {})
@@ -31,10 +30,6 @@ class MetasploitModule < Msf::Auxiliary
       'License' => MSF_LICENSE
       )
     )
-
-    deregister_options('RHOST', 'DOMAIN', 'DigestAuthIIS', 'NTLM::SendLM',
-      'NTLM::SendNTLM', 'VHOST', 'RPORT', 'NTLM::SendSPN', 'NTLM::UseLMKey',
-      'NTLM::UseNTLM2_session', 'NTLM::UseNTLMv2')
 
     register_options(
       [

--- a/modules/auxiliary/gather/windows_deployment_services_shares.rb
+++ b/modules/auxiliary/gather/windows_deployment_services_shares.rb
@@ -39,7 +39,6 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('SMBDomain', [ false, "SMB Domain", '']),
       ])
 
-    deregister_options('RHOST', 'CHOST', 'CPORT', 'SSL', 'SSLVersion')
   end
 
   # Determine the type of share based on an ID type value

--- a/modules/auxiliary/gather/zoomeye_search.rb
+++ b/modules/auxiliary/gather/zoomeye_search.rb
@@ -26,10 +26,6 @@ class MetasploitModule < Msf::Auxiliary
       'License'     => MSF_LICENSE
       ))
 
-      deregister_options('RHOST', 'DOMAIN', 'DigestAuthIIS', 'NTLM::SendLM',
-            'NTLM::SendNTLM', 'VHOST', 'RPORT', 'NTLM::SendSPN', 'NTLM::UseLMKey',
-            'NTLM::UseNTLM2_session', 'NTLM::UseNTLMv2', 'SSL')
-
       register_options(
         [
           OptString.new('USERNAME', [true, 'The ZoomEye username']),


### PR DESCRIPTION
While reviewing modules that no longer need to deregister RHOST, I found a few that deregister options they don't have in the first place. This just removes those, which possibly were cargo-culted from other modules, or were needed in an earlier iteration. Generally modules that just talk to a 3rd party service don't need to use the HTTP client mixin.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Check the modified modules below
- [x] **Verify** the options make sense and are the same as before this change
