### PR TITLE
Don't delete SSL key/cert on a msfdb reinit if a user asked not to delete existing configs

### DIFF
--- a/msfdb
+++ b/msfdb
@@ -577,8 +577,10 @@ def delete_web_service
   stop_web_service
 
   File.delete(@ws_pid) if web_service_pid_status == WebServicePIDStatus::INACTIVE
-  File.delete(@options[:ssl_key]) if File.file?(@options[:ssl_key])
-  File.delete(@options[:ssl_cert]) if File.file?(@options[:ssl_cert])
+  if @options[:delete_existing_data]
+    File.delete(@options[:ssl_key]) if File.file?(@options[:ssl_key])
+    File.delete(@options[:ssl_cert]) if File.file?(@options[:ssl_cert])
+  end
 end
 
 def reinit_web_service


### PR DESCRIPTION
Fixes https://github.com/rapid7/metasploit-framework/issues/11490

## Verification

- [x] With a remote data service already established...
- [x] `./msfdb reinit`
- [x] Say `no` to ` Would you like to delete your existing data and configurations?`
- [x] **Verify** you see the output `MSF web service appears to be started, but may not operate as expected`
- [x] `./msfconsole`
- [x] `db_disconnect local-https-data-service`
- [x] `db_connect --token <existing token> --cert ~/.msf4/msf-ws-cert.pem --skip-verify https://localhost:5443`
- [x] **Verify** that you can interact with the remote data service from msfconsole
