### PR TITLE
Fix required USERNAME and PASSWORD in imperva_securesphere_exec

### DIFF
--- a/modules/exploits/linux/http/imperva_securesphere_exec.rb
+++ b/modules/exploits/linux/http/imperva_securesphere_exec.rb
@@ -51,8 +51,8 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         Opt::RPORT(443),
-        OptString.new('USERNAME', [true, 'Agent registration username', 'imperva']),
-        OptString.new('PASSWORD', [true, 'Agent registration password', '']),
+        OptString.new('USERNAME', [false, 'Agent registration username', 'imperva']),
+        OptString.new('PASSWORD', [false, 'Agent registration password', '']),
         OptString.new('TARGETURI', [false, 'The URI path to impcli', '/pws/impcli']),
         OptInt.new('TIMEOUT', [false, 'HTTP connection timeout', 15])
       ])
@@ -119,7 +119,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'data'        => data.to_json
     }
 
-    if datastore['USERNAME'] && datastore['PASSWORD']
+    if !datastore['USERNAME'].blank? && !datastore['PASSWORD'].blank?
       unless @cookie
         res = send_request_cgi({
           'method'      => 'GET',


### PR DESCRIPTION
Somehow I forgot to commit this? Strange. I might have blown it away accidentally.

Fixes #11210.