### PR TITLE
Cleanup changes from DB Manager for Payloads

### DIFF
--- a/lib/metasploit/framework/data_service/proxy/payload_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/payload_data_proxy.rb
@@ -2,8 +2,9 @@ module PayloadDataProxy
 
   def payloads(opts)
     begin
-      data_service = self.get_data_service
-      data_service.payloads(opts)
+      self.data_service_operation do |data_service|
+        data_service.payloads(opts)
+      end
     rescue => e
       self.log_error(e, "Problem retrieving payload")
     end
@@ -11,8 +12,9 @@ module PayloadDataProxy
 
   def create_payload(opts)
     begin
-      data_service = self.get_data_service
-      data_service.create_payload(opts)
+      self.data_service_operation do |data_service|
+        data_service.create_payload(opts)
+      end
     rescue => e
       self.log_error(e, "Problem creating payload")
     end
@@ -20,8 +22,9 @@ module PayloadDataProxy
 
   def update_payload(opts)
     begin
-      data_service = self.get_data_service
-      data_service.update_payload(opts)
+      self.data_service_operation do |data_service|
+        data_service.update_payload(opts)
+      end
     rescue => e
       self.log_error(e, "Problem updating payload")
     end
@@ -29,8 +32,9 @@ module PayloadDataProxy
 
   def delete_payload(opts)
     begin
-      data_service = self.get_data_service
-      data_service.delete_payload(opts)
+      self.data_service_operation do |data_service|
+        data_service.delete_payload(opts)
+      end
     rescue => e
       self.log_error(e, "Problem deleting payload")
     end

--- a/lib/metasploit/framework/data_service/remote/http/data_service_auto_loader.rb
+++ b/lib/metasploit/framework/data_service/remote/http/data_service_auto_loader.rb
@@ -20,6 +20,7 @@ module DataServiceAutoLoader
   autoload :RemoteVulnAttemptDataService, 'metasploit/framework/data_service/remote/http/remote_vuln_attempt_data_service'
   autoload :RemoteMsfDataService, 'metasploit/framework/data_service/remote/http/remote_msf_data_service'
   autoload :RemoteDbImportDataService, 'metasploit/framework/data_service/remote/http/remote_db_import_data_service.rb'
+  autoload :RemotePayloadDataService, 'metasploit/framework/data_service/remote/http/remote_payload_data_service'
 
   include RemoteHostDataService
   include RemoteEventDataService
@@ -39,5 +40,6 @@ module DataServiceAutoLoader
   include RemoteVulnAttemptDataService
   include RemoteMsfDataService
   include RemoteDbImportDataService
+  include RemotePayloadDataService
 
 end

--- a/lib/msf/core/db_manager/payload.rb
+++ b/lib/msf/core/db_manager/payload.rb
@@ -1,13 +1,15 @@
 module Msf::DBManager::Payload
 
   def create_payload(opts)
-    if opts[:uuid] && !opts[:uuid].to_s.empty?
-      if Mdm::Payload.find_by(uuid: opts[:uuid])
-        raise ArgumentError.new("A payload with this uuid already exists.")
+    ::ActiveRecord::Base.connection_pool.with_connection do
+      if opts[:uuid] && !opts[:uuid].to_s.empty?
+        if Mdm::Payload.find_by(uuid: opts[:uuid])
+          raise ArgumentError.new("A payload with this uuid already exists.")
+        end
       end
-    end
 
-    Mdm::Payload.create!(opts)
+      Mdm::Payload.create!(opts)
+    end
   end
 
   def payloads(opts)

--- a/lib/msf/core/handler.rb
+++ b/lib/msf/core/handler.rb
@@ -224,16 +224,20 @@ protected
       # Pass along any associated payload uuid if specified
       if opts[:payload_uuid]
         s.payload_uuid = opts[:payload_uuid]
-        payload_info = {
-            uuid: s.payload_uuid.puid_hex,
-            workspace: framework.db.workspace
-        }
-        if s.payload_uuid.respond_to?(:puid_hex) && (uuid_info = framework.db.payloads(payload_info).first)
-          s.payload_uuid.registered = true
-          s.payload_uuid.name = uuid_info['name']
-          s.payload_uuid.timestamp = uuid_info['timestamp']
-        else
-          s.payload_uuid.registered = false
+        s.payload_uuid.registered = false
+
+        if framework.db.active
+          payload_info = {
+              uuid: s.payload_uuid.puid_hex,
+              workspace: framework.db.workspace
+          }
+          if s.payload_uuid.respond_to?(:puid_hex) && (uuid_info = framework.db.payloads(payload_info).first)
+            s.payload_uuid.registered = true
+            s.payload_uuid.name = uuid_info['name']
+            s.payload_uuid.timestamp = uuid_info['timestamp']
+          else
+            s.payload_uuid.registered = false
+          end
         end
       end
 


### PR DESCRIPTION
* Updates the `PayloadDataProxy` module to use the `data_service_operation` block. #10956 introduced changes to update all `DataProxy` modules to use the `data_service_operation` block, however, the changes from #10675 were made in advance of those and delayed, but not updated prior to being landed.
* Adds a missing `ActiveRecord` connection block in `Msf::DBManager::Payload`.
* Adds an entry to autoload `RemotePayloadDataService` in order to fix a `NoMethodError` exception when connected to a remote data service
* Adds a check that the database is active in the `Msf::Handler#create_session` method before looking up a payload based on UUID to fix a `ActiveRecord::ConnectionNotEstablished` exception when working without a database.

## Verification

Follow verification steps from #10675, except start the web service using `msfdb` rather than `msfdb_ws`.