### PR TITLE
Fix credential reporting service lookups.

### DIFF
--- a/lib/metasploit/framework/data_service/proxy/credential_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/credential_data_proxy.rb
@@ -28,6 +28,8 @@ module CredentialDataProxy
         end
         new_core
       end
+    rescue => e
+      self.log_error(e, "Problem creating cracked credential")
     end
   end
 

--- a/lib/metasploit/framework/data_service/proxy/credential_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/credential_data_proxy.rb
@@ -23,13 +23,11 @@ module CredentialDataProxy
         end
         new_core = data_service.create_credential(opts)
         old_core.logins.each do |login|
-          service = data_service.services(id: login.service_id)
+          service = data_service.services(id: login.service_id).first
           data_service.create_credential_login(core: new_core, service_id: service.id, status: Metasploit::Model::Login::Status::UNTRIED)
         end
         new_core
       end
-    rescue => e
-      self.log_error(e, "Problem creating cracked credential")
     end
   end
 


### PR DESCRIPTION
Noted by @actuated, auxiliary/scanner/ipmi/ipmi_dumphashes was displaying an error when run against an IPMI endpoint that had a common hash. This was due to the services lookup in the database not extracting the first element of the results array.

```
[-] Auxiliary failed: NoMethodError undefined method `id' for #<Array:0x000055615614b970>
[-] Call stack:
[-]   /home/bcook/projects/metasploit-framework/lib/metasploit/framework/data_service/proxy/credential_data_proxy.rb:27:in `block (2 levels) in create_cracked_credential'
[-]   /home/bcook/.rvm/gems/ruby-2.6.1@metasploit-framework/gems/activerecord-4.2.11/lib/active_record/relation/delegation.rb:46:in `each'
[-]   /home/bcook/.rvm/gems/ruby-2.6.1@metasploit-framework/gems/activerecord-4.2.11/lib/active_record/relation/delegation.rb:46:in `each'
[-]   /home/bcook/projects/metasploit-framework/lib/metasploit/framework/data_service/proxy/credential_data_proxy.rb:25:in `block in create_cracked_credential'
[-]   /home/bcook/projects/metasploit-framework/lib/metasploit/framework/data_service/proxy/core.rb:166:in `data_service_operation'
[-]   /home/bcook/projects/metasploit-framework/lib/metasploit/framework/data_service/proxy/credential_data_proxy.rb:15:in `create_cracked_credential'
[-]   /home/bcook/projects/metasploit-framework/lib/msf/core/auxiliary/report.rb:26:in `create_cracked_credential'
[-]   /home/bcook/projects/metasploit-framework/modules/auxiliary/scanner/ipmi/ipmi_dumphashes.rb:317:in `report_cracked_cred'
[-]   /home/bcook/projects/metasploit-framework/modules/auxiliary/scanner/ipmi/ipmi_dumphashes.rb:244:in `block (2 levels) in run_host'
[-]   /home/bcook/projects/metasploit-framework/modules/auxiliary/scanner/ipmi/ipmi_dumphashes.rb:237:in `each'
[-]   /home/bcook/projects/metasploit-framework/modules/auxiliary/scanner/ipmi/ipmi_dumphashes.rb:237:in `block in run_host'
[-]   /home/bcook/projects/metasploit-framework/modules/auxiliary/scanner/ipmi/ipmi_dumphashes.rb:100:in `each'
[-]   /home/bcook/projects/metasploit-framework/modules/auxiliary/scanner/ipmi/ipmi_dumphashes.rb:100:in `run_host'
[-]   /home/bcook/projects/metasploit-framework/lib/msf/core/auxiliary/scanner.rb:111:in `block (2 levels) in run'
[-]   /home/bcook/projects/metasploit-framework/lib/msf/core/thread_manager.rb:106:in `block in spawn'
[*] Auxiliary module execution completed
```

## Verification

- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/ipmi/ipmi_dumphashes`
- [ ] target an IPMI host that has a common hash from Metasploit IPMI password database (data/wordlists/ipmi_passwords.txt)
- [ ] **Verify** that the creds are properly reported

```
[+] 255.255.255.255:623 - IPMI - Hash found: root:8dc805655f5a9af4f031c83aaf7fda2c5a08be185ff8e5197c61d8f717c5341c57aae7f295ce26d0000000000000000000000000000000001404726f6f74:36e9e753caad637c3687e0a7c58334607e379a5e
[+] 255.255.255.255:623 - IPMI - Hash for user 'root' matches password 'zero2hero'
```