### PR TITLE
Fix module heading and typo

### DIFF
--- a/modules/exploits/unix/sonicwall/sonicwall_xmlrpc_rce.rb
+++ b/modules/exploits/unix/sonicwall/sonicwall_xmlrpc_rce.rb
@@ -11,8 +11,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info={})
     super(update_info(info,
-      'Name' => "SonicWall Global Management System XMLRPC
-                 set_time_zone Unath RCE",
+      'Name' => "SonicWall Global Management System XMLRPC set_time_zone Unauth RCE",
       'Description' => %q{
         This module exploits a vulnerability in SonicWall Global
         Management System Virtual Appliance versions 8.1 (Build 8110.1197)


### PR DESCRIPTION
The newline in the name breaks the msfconsole output