### PR TITLE
add deregister_http_client_options

### DIFF
--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -82,6 +82,9 @@ module Exploit::Remote::HttpClient
     register_autofilter_services(%W{ http https })
   end
 
+  def deregister_http_client_options
+    deregister_options('RHOST', 'RPORT', 'VHOST', 'SSL', 'Proxies')
+  end
 
   #
   # For HTTP Client exploits, we often want to verify that the server info matches some regex before

--- a/modules/auxiliary/gather/corpwatch_lookup_id.rb
+++ b/modules/auxiliary/gather/corpwatch_lookup_id.rb
@@ -23,6 +23,8 @@ class MetasploitModule < Msf::Auxiliary
         ]
     ))
 
+    deregister_http_client_options
+
     register_options(
       [
         OptString.new('CW_ID', [ true, "The CorpWatch ID of the company", ""]),
@@ -34,8 +36,6 @@ class MetasploitModule < Msf::Auxiliary
         OptInt.new('CHILD_LIMIT', [false, "Set limit to how many children we can get", 5]),
         OptBool.new('GET_HISTORY', [false, "Get company history", false])
       ])
-
-    deregister_options('RHOST', 'RPORT', 'VHOST', 'Proxies')
   end
 
   def rhost_corpwatch

--- a/modules/auxiliary/gather/corpwatch_lookup_name.rb
+++ b/modules/auxiliary/gather/corpwatch_lookup_name.rb
@@ -25,6 +25,8 @@ class MetasploitModule < Msf::Auxiliary
         ]
     ))
 
+    deregister_http_client_options
+
     register_options(
       [
         OptString.new('COMPANY_NAME', [ true, "Search for companies with this name", ""]),
@@ -32,8 +34,6 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('LIMIT', [ true, "Limit the number of results returned", "5"]),
         OptString.new('CORPWATCH_APIKEY', [ false, "Use this API key when getting the data", ""]),
       ])
-
-    deregister_options('RHOST', 'RPORT', 'Proxies', 'VHOST')
   end
 
   def rhost_corpwatch

--- a/modules/auxiliary/gather/http_pdf_authors.rb
+++ b/modules/auxiliary/gather/http_pdf_authors.rb
@@ -34,6 +34,9 @@ class MetasploitModule < Msf::Auxiliary
       },
       'License'     => MSF_LICENSE,
       'Author'      => 'bcoles'))
+
+    deregister_http_client_options
+
     register_options(
       [
         OptString.new('URL', [ false, 'The target URL', '' ]),
@@ -41,7 +44,6 @@ class MetasploitModule < Msf::Auxiliary
         OptEnum.new('URL_TYPE', [ true, 'The type of URL(s) specified', 'html', [ 'pdf', 'html' ] ]),
         OptBool.new('STORE_LOOT', [ false, 'Store authors in loot', true ])
       ])
-    deregister_options 'RHOST', 'RHOSTS', 'RPORT', 'VHOST', 'SSL'
   end
 
   def progress(current, total)

--- a/modules/auxiliary/gather/searchengine_subdomains_collector.rb
+++ b/modules/auxiliary/gather/searchengine_subdomains_collector.rb
@@ -17,6 +17,8 @@ class MetasploitModule < Msf::Auxiliary
       'Author' => [ 'Nixawk' ],
       'License' => MSF_LICENSE))
 
+    deregister_http_client_options
+
     register_options(
       [
         OptString.new('TARGET', [ true, "The target to locate subdomains for, ex: rapid7.com, 8.8.8.8"]),
@@ -24,8 +26,6 @@ class MetasploitModule < Msf::Auxiliary
         OptBool.new('ENUM_BING', [ true, "Enable Bing Search Subdomains", true]),
         OptBool.new('ENUM_YAHOO', [ true, "Enable Yahoo Search Subdomains", true])
       ])
-
-    deregister_options('RHOST', 'RHOSTS', 'RPORT', 'VHOST', 'SSL', 'Proxies')
   end
 
   def rhost_yahoo


### PR DESCRIPTION
Rather than every module that including the HTTP Client mixin having to individually deregister the supplied options, this adds an explicit deregister_http_client_options method to do it consistently for every module.

I have more patches like this for other mixins, this is the simple water-testing PR to see how well folks like the concept.

## Verification

- [x] Start `msfconsole`
- [x] Use any of the modules that deregister options below.
- [x] **Verify** that they still do not have those options registered and work as expected.
