### PR TITLE
Fixed a typo in SERVICE_DESCRIPTION

### DIFF
--- a/lib/msf/core/exploit/smb/client/psexec.rb
+++ b/lib/msf/core/exploit/smb/client/psexec.rb
@@ -23,7 +23,7 @@ module Exploit::Remote::SMB::Client::Psexec
       [
         OptString.new('SERVICE_NAME', [ false, 'The service name', nil]),
         OptString.new('SERVICE_DISPLAY_NAME', [ false, 'The service display name', nil]),
-        OptString.new('SERVICE_DESCRIPTION', [false, "Service description to to be used on target for pretty listing",nil])
+        OptString.new('SERVICE_DESCRIPTION', [false, "Service description to be used on target for pretty listing",nil])
       ], self.class)
 
     register_advanced_options(


### PR DESCRIPTION
Before it read "Service description to to be used on target for pretty listing"
I got rid of the extra "to"


Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

Please ensure you are submitting **from a unique branch** in your [repository](https://github.com/rapid7/metasploit-framework/pull/11086#issuecomment-445506416) to master in Rapid7's.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [ ] `use exploit/windows/smb/ms08_067_netapi`
- [ ] ...
- [ ] **Verify** the thing does what it should
- [ ] **Verify** the thing does not do what it should not
- [ ] **Document** the thing and how it works ([Example](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/post/multi/gather/aws_keys.md))

