### PR TITLE
tweak rubocop disabling some less desirable noise

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -59,10 +59,6 @@ Style/Documentation:
   Exclude:
     - 'modules/**/*'
 
-Layout/IndentHeredoc:
-  Enabled: false
-  Description: 'We need to leave this disabled for Ruby 2.2 compat, remove in 2018'
-
 Layout/SpaceInsideArrayLiteralBrackets:
   Enabled: false
   Description: 'Almost all module metadata have space in brackets'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -45,6 +45,10 @@ Style/RedundantReturn:
   Description: 'This often looks weird when mixed with actual returns, and hurts nothing'
   Enabled: false
 
+Naming/VariableNumber:
+  Description: 'To make it easier to use reference code, disable this cop'
+  Enabled: false
+
 Style/NumericPredicate:
   Description: 'This adds no efficiency nor space saving'
   Enabled: false
@@ -59,9 +63,17 @@ Layout/IndentHeredoc:
   Enabled: false
   Description: 'We need to leave this disabled for Ruby 2.2 compat, remove in 2018'
 
+Layout/SpaceInsideArrayLiteralBrackets:
+  Enabled: false
+  Description: 'Almost all module metadata have space in brackets'
+
 Style/GuardClause:
   Enabled: false
   Description: 'This often introduces bugs in tested code'
+
+Style/EmptyLiteral:
+  Enabled: false
+  Description: 'This looks awkward when you mix empty and non-empty literals'
 
 Style/NegatedIf:
   Enabled: false
@@ -72,9 +84,16 @@ Style/ConditionalAssignment:
   Description: 'This is confusing for folks coming from other languages'
 
 Style/Encoding:
-  Enabled: true
   Description: 'We prefer binary to UTF-8.'
-  EnforcedStyle: 'when_needed'
+  Enabled: false
+
+Style/ParenthesesAroundCondition:
+  Enabled: false
+  Description: 'This is used in too many places to discount, especially in ported code. Has little effect'
+
+Style/TrailingCommaInArrayLiteral:
+  Enabled: false
+  Description: 'This is often a useful pattern, and is actually required by other languages. It does not hurt.'
 
 Metrics/LineLength:
   Description: >-
@@ -83,6 +102,13 @@ Metrics/LineLength:
   Enabled: true
   Max: 180
 
+Metrics/BlockLength:
+  Enabled: true
+  Description: >-
+                  While the style guide suggests 10 lines, exploit definitions
+                  often exceed 200 lines.
+  Max: 300
+
 Metrics/MethodLength:
   Enabled: true
   Description: >-
@@ -90,10 +116,10 @@ Metrics/MethodLength:
                   often exceed 200 lines.
   Max: 300
 
-# Basically everything in metasploit needs binary encoding, not UTF-8.
-# Disable this here and enforce it through msftidy
-Style/Encoding:
-  Enabled: false
+Naming/UncommunicativeMethodParamName:
+  Enabled: true
+  Description: 'Whoever made this requirement never looked at crypto methods, IV'
+  MinNameLength: 2
 
 # %q() is super useful for long strings split over multiple lines and
 # is very common in module constructors for things like descriptions
@@ -104,10 +130,30 @@ Style/NumericLiterals:
   Enabled: false
   Description: 'This often hurts readability for exploit-ish code.'
 
+Layout/AlignHash:
+  Enabled: false
+  Description: 'aligning info hashes to match these rules is almost impossible to get right'
+
+Layout/EmptyLines:
+  Enabled: false
+  Description: 'these are used to increase readability'
+
+Layout/EmptyLinesAroundClassBody:
+  Enabled: false
+  Description: 'these are used to increase readability'
+
+Layout/EmptyLinesAroundMethodBody:
+  Enabled: false
+  Description: 'these are used to increase readability'
+
 Layout/AlignParameters:
   Enabled: true
   EnforcedStyle: 'with_fixed_indentation'
   Description: 'initialize method of every module has fixed indentation for Name, Description, etc'
+
+Style/For:
+  Enabled: false
+  Description: 'if a module is written with a for loop, it cannot always be logically replaced with each'
 
 Style/StringLiterals:
   Enabled: false


### PR DESCRIPTION
See #11542 

These are some rules that often have a common counterpoint in framework's style, and wouldn't be productive to force everyone to fix. I'm also considering if some of the whitespace enforcement (like there can be no blank line at the head or end of a class or method) are too common to worry about in Metasploit.