### PR TITLE
add deregister_tcp/udp_options

### DIFF
--- a/lib/msf/core/exploit/tcp.rb
+++ b/lib/msf/core/exploit/tcp.rb
@@ -82,6 +82,10 @@ module Exploit::Remote::Tcp
     )
   end
 
+  def deregister_tcp_options
+    deregister_options('RHOST', 'RPORT')
+  end
+
   #
   # Establishes a TCP connection to the specified RHOST/RPORT
   #

--- a/lib/msf/core/exploit/udp.rb
+++ b/lib/msf/core/exploit/udp.rb
@@ -29,6 +29,10 @@ module Exploit::Remote::Udp
     )
   end
 
+  def deregister_udp_options
+    deregister_options('RHOST', 'RPORT')
+  end
+
   #
   # Creates a UDP socket for communicating with a remote host
   #

--- a/modules/auxiliary/admin/misc/wol.rb
+++ b/modules/auxiliary/admin/misc/wol.rb
@@ -23,14 +23,14 @@ class MetasploitModule < Msf::Auxiliary
       'Author'         => [ 'sinn3r' ]
     ))
 
+    deregister_udp_options
+
     register_options(
       [
         OptString.new("MAC",      [true, 'Specify a MAC address', '00:90:27:85:cf:01']),
         OptString.new("PASSWORD", [false, 'Specify a four or six-byte password']),
         OptBool.new("IPV6",       [false, 'Use IPv6 broadcast', false])
       ])
-
-    deregister_options('RHOST', 'RPORT')
   end
 
   #

--- a/modules/auxiliary/scanner/dcerpc/hidden.rb
+++ b/modules/auxiliary/scanner/dcerpc/hidden.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Auxiliary
       'License'     => MSF_LICENSE
     )
 
-    deregister_options('RHOST', 'RPORT')
+    deregister_tcp_options
   end
 
   # Obtain information about a single host

--- a/modules/auxiliary/scanner/jenkins/jenkins_udp_broadcast_enum.rb
+++ b/modules/auxiliary/scanner/jenkins/jenkins_udp_broadcast_enum.rb
@@ -31,7 +31,7 @@ class MetasploitModule < Msf::Auxiliary
         'License'        => MSF_LICENSE
       )
     )
-    deregister_options('RHOSTS', 'RPORT')
+    deregister_udp_options
   end
 
   def parse_reply(pkt)

--- a/modules/auxiliary/voip/sip_deregister.rb
+++ b/modules/auxiliary/voip/sip_deregister.rb
@@ -19,7 +19,7 @@ class MetasploitModule < Msf::Auxiliary
       'License'        =>  MSF_LICENSE
     )
 
-    deregister_options('Proxies','SSL','RHOST')
+    deregister_udp_options
     register_options(
       [
         Opt::RPORT(5060),

--- a/modules/auxiliary/voip/sip_invite_spoof.rb
+++ b/modules/auxiliary/voip/sip_invite_spoof.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Auxiliary
       'License'        =>  MSF_LICENSE
     )
 
-    deregister_options('Proxies','SSL','RHOST')
+    deregister_udp_options
     register_options(
       [
         Opt::RPORT(5060),


### PR DESCRIPTION
Similar to #11535 this adds deregister_tcp_options / deregister_udp_options so that modules do not have to care what the options-du-jour are for the mixin. This also corrects some bugs in existing modules that appear to deregister options that do not exist in the first place.