### PR TITLE
Improve user experience when loading invalid module names

### DIFF
--- a/lib/msf/core/exceptions.rb
+++ b/lib/msf/core/exceptions.rb
@@ -48,22 +48,10 @@ class ValidationError < ArgumentError
   end
 end
 
-
 ###
 #
-# This exception is raised when a module fails to load.
-#
-# It is used by Msf::Modules::Loader::Base.
-#
-###
-class ModuleLoadError < RuntimeError
-end
-
-###
-#
-# This exception is raised when the module cache is invalidated.
-#
-# It is handled internally by the ModuleManager.
+# This exception is raised when the module cache is invalidated.  It is
+# handled internally by the ModuleManager.
 #
 ###
 class ModuleCacheInvalidated < RuntimeError

--- a/lib/msf/core/modules/loader/base.rb
+++ b/lib/msf/core/modules/loader/base.rb
@@ -181,7 +181,7 @@ class Msf::Modules::Loader::Base
       load_error(module_path, Msf::Modules::Error.new(
         module_path:           module_path,
         module_reference_name: module_reference_name,
-        causal_message:        'invalid module name (must be lowercase alphanumeric snake case)'
+        causal_message:        'invalid module filename (must be lowercase alphanumeric snake case)'
       ))
       return false
     end

--- a/lib/msf/core/modules/loader/base.rb
+++ b/lib/msf/core/modules/loader/base.rb
@@ -148,18 +148,18 @@ class Msf::Modules::Loader::Base
 
       if namespace_module.const_defined?('Metasploit3', false)
         klass = namespace_module.const_get('Metasploit3', false)
-        load_warning(module_path, 'Please change the modules class name from Metasploit3 to MetasploitModule')
+        load_warning(module_path, "Please change the module's class name from Metasploit3 to MetasploitModule")
       elsif namespace_module.const_defined?('Metasploit4', false)
         klass = namespace_module.const_get('Metasploit4', false)
-        load_warning(module_path, 'Please change the modules class name from Metasploit4 to MetasploitModule')
+        load_warning(module_path, "Please change the module's class name from Metasploit4 to MetasploitModule")
       elsif namespace_module.const_defined?('MetasploitModule', false)
         klass = namespace_module.const_get('MetasploitModule', false)
       else
-        load_error(module_path, Msf::Modules::Error.new({
-          :module_path => module_path,
-          :module_reference_name => module_reference_name,
-          :causal_message => 'Invalid module (no MetasploitModule class or module name)'
-        }))
+        load_error(module_path, Msf::Modules::Error.new(
+          module_path:           module_path,
+          module_reference_name: module_reference_name,
+          causal_message:        'invalid module class name (must be MetasploitModule)'
+        ))
         return false
       end
 
@@ -174,11 +174,18 @@ class Msf::Modules::Loader::Base
       true
     }
 
-    loaded = namespace_module_transaction(type + "/" + module_reference_name,
-      :reload => reload, &try_eval_module)
-    unless loaded
+    begin
+      loaded = namespace_module_transaction("#{type}/#{module_reference_name}", reload: reload, &try_eval_module)
+      return false unless loaded
+    rescue NameError
+      load_error(module_path, Msf::Modules::Error.new(
+        module_path:           module_path,
+        module_reference_name: module_reference_name,
+        causal_message:        'invalid module name (must be lowercase alphanumeric snake case)'
+      ))
       return false
     end
+
 
     # Do some processing on the loaded module to get it into the right associations
     module_manager.on_module_load(
@@ -367,18 +374,8 @@ class Msf::Modules::Loader::Base
       # semantically equivalent to providing false for the 1.9-only
       # "inherit" parameter to const_defined?. If we ever drop 1.8
       # support, we can save a few cycles here by adding it back.
-      begin
-        if parent.const_defined?(module_name)
-          parent.const_get(module_name)
-        else
-          break
-        end
-      # HACK: This doesn't slow load time as much as checking proactively
-      rescue NameError
-        reversed_name = self.class.reverse_relative_name(module_name)
-        # TODO: Consolidate this with Msftidy#check_snake_case_filename ?
-        raise Msf::ModuleLoadError, "#{reversed_name} must be lowercase alphanumeric snake case"
-      end
+      return unless parent.const_defined?(module_name)
+      parent.const_get(module_name)
     end
 
     named_module

--- a/lib/msf/core/modules/loader/base.rb
+++ b/lib/msf/core/modules/loader/base.rb
@@ -417,7 +417,7 @@ class Msf::Modules::Loader::Base
       log_lines += error.backtrace
     end
 
-    log_message = log_lines.join("\n")
+    log_message = log_lines.join(' ')
     elog(log_message)
   end
 
@@ -434,7 +434,7 @@ class Msf::Modules::Loader::Base
     log_lines = []
     log_lines << "#{module_path} generated a warning during load:"
     log_lines << error.to_s
-    log_message = log_lines.join("\n")
+    log_message = log_lines.join(' ')
     wlog(log_message)
   end
 

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -809,23 +809,31 @@ module Msf
               cmd_reload_all_help
               return
             end
+
             print_status("Reloading modules from all module paths...")
             framework.modules.reload_modules
+
+            log_msg = "Please see #{File.join(Msf::Config.log_directory, 'framework.log')} for details."
 
             # Check for modules that failed to load
             if framework.modules.module_load_error_by_path.length > 0
               print_error("WARNING! The following modules could not be loaded!")
 
-              framework.modules.module_load_error_by_path.each do |path, error|
-                print_error("\t#{path}: #{error}")
+              framework.modules.module_load_error_by_path.each do |path, _error|
+                print_error("\t#{path}")
               end
+
+              print_error(log_msg)
             end
 
             if framework.modules.module_load_warnings.length > 0
               print_warning("The following modules were loaded with warnings:")
-              framework.modules.module_load_warnings.each do |path, error|
-                print_warning("\t#{path}: #{error}")
+
+              framework.modules.module_load_warnings.each do |path, _error|
+                print_warning("\t#{path}")
               end
+
+              print_warning(log_msg)
             end
 
             self.driver.run_single("banner")

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -353,20 +353,27 @@ class Driver < Msf::Ui::Driver
   # displayed, scripts can be processed, and other fun can be had.
   #
   def on_startup(opts = {})
+    log_msg = "Please see #{File.join(Msf::Config.log_directory, 'framework.log')} for details."
+
     # Check for modules that failed to load
     if framework.modules.module_load_error_by_path.length > 0
       print_error("WARNING! The following modules could not be loaded!")
 
-      framework.modules.module_load_error_by_path.each do |path, error|
-        print_error("\t#{path}: #{error}")
+      framework.modules.module_load_error_by_path.each do |path, _error|
+        print_error("\t#{path}")
       end
+
+      print_error(log_msg)
     end
 
     if framework.modules.module_load_warnings.length > 0
       print_warning("The following modules were loaded with warnings:")
-      framework.modules.module_load_warnings.each do |path, error|
-        print_warning("\t#{path}: #{error}")
+
+      framework.modules.module_load_warnings.each do |path, _error|
+        print_warning("\t#{path}")
       end
+
+      print_warning(log_msg)
     end
 
     if framework.db && framework.db.active


### PR DESCRIPTION
This is the superior solution, I hope.

```
wvu@kharak:/rapid7/metasploit-framework:feature/namespace$ ./msfconsole -q
[-] WARNING! The following modules could not be loaded!
[-] 	/rapid7/metasploit-framework/modules/exploits/windows/smb/ms17-010-eternalblue.rb
[-] Please see /Users/wvu/.msf4/logs/framework.log for details.
msf5 > log
[*] Launching less +G /Users/wvu/.msf4/logs/framework.log
[snip]
[03/11/2019 23:45:55] [e(0)] core: /rapid7/metasploit-framework/modules/exploits/windows/smb/ms17-010-eternalblue.rb failed to load due to the following error: Msf::Modules::Error Failed to load module (windows/smb/ms17-010-eternalblue from /rapid7/metasploit-framework/modules/exploits/windows/smb/ms17-010-eternalblue.rb) due to invalid module filename (must be lowercase alphanumeric snake case)
[snip]
msf5 >
```

Escalates #10729 and #10788 and addresses #11536.