### PR TITLE
actually show why bundler failed to load

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,6 @@ RUN apk add --no-cache \
       git \
     && echo "gem: --no-ri --no-rdoc" > /etc/gemrc \
     && gem update --system \
-    && gem install bundler \
     && bundle install --clean --no-cache --system $BUNDLER_ARGS \
     # temp fix for https://github.com/bundler/bundler/issues/6680
     && rm -rf /usr/local/bundle/cache \

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -31,7 +31,6 @@ Vagrant.configure(2) do |config|
   [ "gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3",
     "curl -L https://get.rvm.io | bash -s stable",
     "source ~/.rvm/scripts/rvm && cd /vagrant && rvm install `cat .ruby-version`",
-    "source ~/.rvm/scripts/rvm && cd /vagrant && gem install bundler",
     "source ~/.rvm/scripts/rvm && cd /vagrant && bundle",
     "mkdir -p ~/.msf4",
   ].each do |step|

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -29,14 +29,15 @@ rescue LoadError => e
   msg = e.to_s
   ver = msg.scanf("You have already activated bundler %d.%d.%d, but your Gemfile requires bundler %d.%d.%d.")
   if ver.length == 6
-    installed_ver = "#{ver[0]}.#{ver[1]}.#{ver[2]}"
+    activated_ver = "#{ver[0]}.#{ver[1]}.#{ver[2]}"
     wanted_ver = "#{ver[3]}.#{ver[4]}.#{ver[5]}"
-    $stderr.puts "[*] Bundler #{installed_ver} and #{wanted_ver} are conflicting with Ruby #{RUBY_VERSION}. Please uninstall:"
-    $stderr.puts "    $ gem uninstall bundler -v #{ver[0]}.#{ver[1]}.#{ver[2]}"
+    $stderr.puts "[*] Bundler #{activated_ver} conflicts with Ruby #{RUBY_VERSION}'s default of #{wanted_ver}."
+    $stderr.puts
+    $stderr.puts "    $ gem uninstall bundler -v #{activated_ver}"
   else
     $stderr.puts "[*] Bundler failed to load: '#{e}'"
-    $stderr.puts
     $stderr.puts "[*] Metasploit requires the Bundler gem to be installed. You may need to run:"
+    $stderr.puts
     $stderr.puts "    $ gem install bundler"
   end
   exit(1)

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,6 +1,5 @@
 require 'pathname'
 require 'rubygems'
-require 'scanf'
 
 GEMFILE_EXTENSIONS = [
     '.local',
@@ -26,20 +25,11 @@ end
 begin
   require 'bundler/setup'
 rescue LoadError => e
-  msg = e.to_s
-  ver = msg.scanf("You have already activated bundler %d.%d.%d, but your Gemfile requires bundler %d.%d.%d.")
-  if ver.length == 6
-    activated_ver = "#{ver[0]}.#{ver[1]}.#{ver[2]}"
-    wanted_ver = "#{ver[3]}.#{ver[4]}.#{ver[5]}"
-    $stderr.puts "[*] Bundler #{activated_ver} conflicts with Ruby #{RUBY_VERSION}'s default of #{wanted_ver}."
-    $stderr.puts
-    $stderr.puts "    $ gem uninstall bundler -v #{activated_ver}"
-  else
-    $stderr.puts "[*] Bundler failed to load: '#{e}'"
-    $stderr.puts "[*] Metasploit requires the Bundler gem to be installed. You may need to run:"
-    $stderr.puts
-    $stderr.puts "    $ gem install bundler"
-  end
+  $stderr.puts "[*] Bundler failed to load and returned this error:"
+  $stderr.puts
+  $stderr.puts "   '#{e}'"
+  $stderr.puts
+  $stderr.puts "[*] You may need to uninstall or upgrade bundler"
   exit(1)
 end
 

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,5 +1,6 @@
 require 'pathname'
 require 'rubygems'
+require 'scanf'
 
 GEMFILE_EXTENSIONS = [
     '.local',
@@ -25,11 +26,17 @@ end
 begin
   require 'bundler/setup'
 rescue LoadError => e
-  $stderr.puts "[*] Metasploit requires the Bundler gem to be installed"
-  $stderr.puts "    $ gem install bundler"
-  $stderr.puts " You may need to install a specific version of bundler as well:"
-  $stderr.puts
-  $stderr.puts e
+  msg = e.to_s
+  ver = msg.scanf("You have already activated bundler %d.%d.%d, but your Gemfile requires bundler %d.%d.%d.")
+  if ver.length == 6
+    $stderr.puts "[*] Please downgrade your bundler version to the one shipped with Ruby #{RUBY_VERSION}"
+    $stderr.puts "    $ gem uninstall bundler -v #{ver[0]}.#{ver[1]}.#{ver[2]}"
+  else
+    $stderr.puts "[*] Bundler failed to load: '#{e}'"
+    $stderr.puts
+    $stderr.puts "[*] Metasploit requires the Bundler gem to be installed. You may need to run:"
+    $stderr.puts "    $ gem install bundler"
+  end
   exit(1)
 end
 

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -24,9 +24,12 @@ end
 
 begin
   require 'bundler/setup'
-rescue LoadError
+rescue LoadError => e
   $stderr.puts "[*] Metasploit requires the Bundler gem to be installed"
   $stderr.puts "    $ gem install bundler"
+  $stderr.puts " You may need to install a specific version of bundler as well:"
+  $stderr.puts
+  $stderr.puts e
   exit(1)
 end
 

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -29,7 +29,9 @@ rescue LoadError => e
   msg = e.to_s
   ver = msg.scanf("You have already activated bundler %d.%d.%d, but your Gemfile requires bundler %d.%d.%d.")
   if ver.length == 6
-    $stderr.puts "[*] Please downgrade your bundler version to the one shipped with Ruby #{RUBY_VERSION}"
+    installed_ver = "#{ver[0]}.#{ver[1]}.#{ver[2]}"
+    wanted_ver = "#{ver[3]}.#{ver[4]}.#{ver[5]}"
+    $stderr.puts "[*] Bundler #{installed_ver} and #{wanted_ver} are conflicting with Ruby #{RUBY_VERSION}. Please uninstall:"
     $stderr.puts "    $ gem uninstall bundler -v #{ver[0]}.#{ver[1]}.#{ver[2]}"
   else
     $stderr.puts "[*] Bundler failed to load: '#{e}'"


### PR DESCRIPTION
Currently, we don't show the user the actual exception that gets raised if bundler fails to load. It's not always user error, as is the case currently with Bundler 1.17.2/1.17.3/2.x causing some compatibility headaches.

This PR changes Metasploit's boot sequence so it shows the actual error for diagnostic purposes as well:

```
$ ./msfconsole 
[*] Bundler failed to load and returned this error:

   'You have already activated bundler 1.17.3, but your Gemfile requires bundler 1.17.2. Prepending `bundle exec` to your command may solve this.'

[*] You may need to uninstall or upgrade bundler

$ gem uninstall bundler -v 1.17.3
Successfully uninstalled bundler-1.17.3

$ ./msfconsole
....
```