### PR TITLE
add root/ubnt to router creds

### DIFF
--- a/data/wordlists/routers_userpass.txt
+++ b/data/wordlists/routers_userpass.txt
@@ -405,6 +405,7 @@ root realtek
 root root
 root tini
 root tslinux
+root ubnt
 root user
 root vizxv
 root wyse


### PR DESCRIPTION
According to https://help.ubnt.com/hc/en-us/articles/204909374-UniFi-Accounts-and-Passwords-for-Controller-Cloud-Key-and-Other-Devices a UniFi device can have `root`:`ubnt` as a creds combo.  Adding it to the routers list.