### PR TITLE
Check fix

### DIFF
--- a/lib/msf/ui/console/module_command_dispatcher.rb
+++ b/lib/msf/ui/console/module_command_dispatcher.rb
@@ -126,7 +126,8 @@ module ModuleCommandDispatcher
       return
     end
 
-    ip_range_arg = args.join(' ') || mod.datastore['RHOSTS'] || framework.datastore['RHOSTS'] || ''
+    ip_range_arg = args.join(' ') unless args.empty?
+    ip_range_arg ||= mod.datastore['RHOSTS'] || framework.datastore['RHOSTS'] || ''
     opt = Msf::OptAddressRange.new('RHOSTS')
 
     begin


### PR DESCRIPTION
Account for empty args array. `args.join(' ')` returns `""` when the args array is empty without checking mod or framework RHOSTS values.

### Before Fix

```
$ ./msfconsole -q
msf5 auxiliary(scanner/smb/smb_ms17_010) > options

Module options (auxiliary/scanner/smb/smb_ms17_010):

   Name         Current Setting                                                       Required  Description
   ----         ---------------                                                       --------  -----------
   CHECK_ARCH   true                                                                  no        Check for architecture on vulnerable hosts
   CHECK_DOPU   true                                                                  no        Check for DOUBLEPULSAR on vulnerable hosts
   CHECK_PIPE   false                                                                 no        Check for named pipe on vulnerable hosts
   NAMED_PIPES  /home/msfdev/git/metasploit-framework/data/wordlists/named_pipes.txt  yes       List of named pipes to check
   Proxies                                                                            no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS       file:tmp2.txt                                                         yes       The target address range or CIDR identifier
   RPORT        445                                                                   yes       The SMB service port (TCP)
   SMBDomain    .                                                                     no        The Windows domain to use for authentication
   SMBPass                                                                            no        The password for the specified username
   SMBUser                                                                            no        The username to authenticate as
   THREADS      1                                                                     yes       The number of concurrent threads

msf5 auxiliary(scanner/smb/smb_ms17_010) > check
[-] Error while running command check: The following options failed to validate: RHOST.

Call stack:
/home/msfdev/git/metasploit-framework/lib/msf/ui/console/module_command_dispatcher.rb:158:in `cmd_check'
/home/msfdev/git/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:522:in `run_command'
/home/msfdev/git/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:473:in `block in run_single'
/home/msfdev/git/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:467:in `each'
/home/msfdev/git/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:467:in `run_single'
/home/msfdev/git/metasploit-framework/lib/rex/ui/text/shell.rb:151:in `run'
/home/msfdev/git/metasploit-framework/lib/metasploit/framework/command/console.rb:48:in `start'
/home/msfdev/git/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'
./msfconsole:49:in `<main>'
msf5 auxiliary(scanner/smb/smb_ms17_010) > exit
```

### After Fix

```
msf5 auxiliary(scanner/smb/smb_ms17_010) > check
[*] 172.22.222.145:445 - This module does not support check.
[*] Checked 1 of 2 hosts (050% complete)
[*] 172.22.222.141:445 - This module does not support check.
[*] Checked 2 of 2 hosts (100% complete)
msf5 auxiliary(scanner/smb/smb_ms17_010) > 
```

## Verification

List the steps needed to make sure this thing works

- [x] `./msfconsole -q`
- [x] `use auxiliary/scanner/smb/smb_ms17_010`
- [x] `set rhosts file:<file>`
- [x] `check`

