### PR TITLE
Add OpenSUSE detection to Linux system lib

### DIFF
--- a/lib/msf/core/post/linux/system.rb
+++ b/lib/msf/core/post/linux/system.rb
@@ -85,10 +85,16 @@ module System
       system_data[:distro] = "mandrake"
       system_data[:version] = version
 
-    #SuSE
+    # SuSE
     elsif etc_files.include?("SuSE-release")
       version = read_file("/etc/SuSE-release").gsub(/\n|\\n|\\l/,'')
       system_data[:distro] = "suse"
+      system_data[:version] = version
+
+    # OpenSUSE
+    elsif etc_files.include?("SUSE-brand")
+      version = read_file("/etc/SUSE-brand").scan(/^VERSION\s*=\s*([\d\.]+)/).flatten.first
+      system_data[:distro] = 'suse'
       system_data[:version] = version
 
     # Gentoo


### PR DESCRIPTION
Tested on OpenSUSE-Leap 15.0.

Before:

```
msf5 exploit(linux/local/test) > check

[*] ID: uid=1000(user) gid=100(users) groups=100(users)
[*] get_sysinfo: {:kernel=>"Linux linux-fkgb 4.12.14-lp150.11-default #1 SMP Fri May 11 08:28:30 UTC 2018 (a9fee09) x86_64 x86_64 x86_64 GNU/Linux", :distro=>"linux", :version=>"Welcome to \\S - Kernel \\r ()."}
[-] Check failed: The state could not be determined.
msf5 exploit(linux/local/test) > hosts

Hosts
=====

address         mac  name            os_name  os_flavor                      os_sp  purpose  info  comments
-------         ---  ----            -------  ---------                      -----  -------  ----  --------
172.16.191.140       172.16.191.140  linux    Welcome to \S - Kernel \r ().         server         

msf5 exploit(linux/local/test) > 
```

After:

```
msf5 exploit(linux/local/test) > check

[*] ID: uid=1000(user) gid=100(users) groups=100(users)
[*] get_sysinfo: {:kernel=>"Linux linux-fkgb 4.12.14-lp150.11-default #1 SMP Fri May 11 08:28:30 UTC 2018 (a9fee09) x86_64 x86_64 x86_64 GNU/Linux", :distro=>"suse", :version=>"15.0"}
[-] Check failed: The state could not be determined.
msf5 exploit(linux/local/test) > hosts

Hosts
=====

address         mac  name            os_name  os_flavor  os_sp  purpose  info  comments
-------         ---  ----            -------  ---------  -----  -------  ----  --------
172.16.191.140       172.16.191.140  suse     15.0              server         

msf5 exploit(linux/local/test) > 
```
