### PR TITLE
Bump ActiveRecord version in PG deprecated warning suppression

### DIFF
--- a/lib/pg/deprecated_constants.rb
+++ b/lib/pg/deprecated_constants.rb
@@ -16,7 +16,7 @@
 #
 # config.autoload_paths << Rails.root.join('lib')
 #
-if PG::VERSION != '0.21.0' || ActiveRecord.version.to_s != '4.2.11'
+if PG::VERSION != '0.21.0' || ActiveRecord.version.to_s != '4.2.11.1'
   puts <<MSG
 -----------------------------------------------------------------------------------
 The pg and/or activerecord gem version has changed, meaning deprecated pg constants


### PR DESCRIPTION
When upgrading pg to version `0.21.0` a temporary workaround was included to suppress the warning message introduced when upgrading pg to `0.21.0` with an older version of ActiveRecord. (See #11387). The recent ActiveRecord version bump caused this message to be logged. This updates the check since the PG version hasn't increased and still results in deprecated warning with this version of ActiveRecord.

## Verification

- [x] Start `msfconsole`
- [x] **Verify** you do not see the following message:
    ```
    -----------------------------------------------------------------------------------
    The pg and/or activerecord gem version has changed, meaning deprecated pg constants
    may no longer be in use, so try deleting this file to see if the
    'The PGconn, PGresult, and PGError constants are deprecated...' message has gone:
    ...
    -----------------------------------------------------------------------------------
    ```