### PR TITLE
add unifi USG to ssh details

### DIFF
--- a/lib/metasploit/framework/login_scanner/ssh.rb
+++ b/lib/metasploit/framework/login_scanner/ssh.rb
@@ -120,9 +120,14 @@ module Metasploit
                   # We're in the SSH shell for a Juniper JunOS, we can pull the version from the cli
                   # line 2 is hostname, 3 is model, 4 is the Base OS version
                   proof = ssh_socket.exec!("cli show version\n").split("\n")[2..4].join(", ").to_s
+                elsif (proof =~ /Linux USG /)
+                  # Ubiquiti Unifi USG
+                  proof << ssh_socket.exec!("cat /etc/version\n").to_s
                 end
-                proof << ssh_socket.exec!("grep unifi.version /tmp/system.cfg\n").to_s
-                if (proof =~ /unifi.version/)
+                temp_proof << ssh_socket.exec!("grep unifi.version /tmp/system.cfg\n").to_s
+                if (temp_proof =~ /unifi.version/)
+                  proof << temp_proof
+                  # Ubiquiti Unifi device (non-USG), possibly a switch.  Tested on US-24
                   # The /tmp/*.cfg files don't give us device info, however the info command does
                   # we dont call it originally since it doesnt say unifi/ubiquiti in it and info
                   # is a linux command as well
@@ -158,7 +163,7 @@ module Metasploit
 
         def get_platform(proof)
           case proof
-          when /unifi\.version/ #Ubiquiti Unifi.  uname -a is left in, so we got to pull before Linux
+          when /unifi\.version|UniFiSecurityGateway/ #Ubiquiti Unifi.  uname -a is left in, so we got to pull before Linux
             'unifi'
           when /Linux/
             'linux'


### PR DESCRIPTION
This PR adds the Unifi USG device info to the ssh lib.

Before (marked as linux, permission denied error):
```
[+] 1.1.1.1:22 - Success: 'admin:asmin' 'uid=1001(admin) gid=100(users) groups=4(adm),6(disk),27(sudo),30(dip),100(users),102(vyattacfg),104(quaggavty) Linux USG 3.10.107-UBNT #1 SMP Wed Dec 5 04:57:56 UTC 2018 mips64 GNU/Linux grep: /tmp/system.cfg: Permission denied '
[*] Command shell session 1 opened (2.2.2.2:38153 -> 1.1.1.1:22) at 2019-03-15 20:20:20 -0400
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
[*] Starting persistent handler(s)...
msf5 auxiliary(scanner/ssh/ssh_login) > sessions

Active sessions
===============

  Id  Name  Type         Information                                  Connection
  --  ----  ----         -----------                                  ----------
  1         shell linux  SSH admin:admin (1.1.1.1:22)  2.2.2.2:38153 -> 1.1.1.1:22 (1.1.1.1)
```

After:
```
[+] 1.1.1.1:22 - Success: 'admin:admin' 'uid=1001(admin) gid=100(users) groups=4(adm),6(disk),27(sudo),30(dip),100(users),102(vyattacfg),104(quaggavty) Linux USG 3.10.107-UBNT #1 SMP Wed Dec 5 04:57:56 UTC 2018 mips64 GNU/Linux UniFiSecurityGateway.ER-e120.v4.4.36.5146617.181205.0449 '
[*] Command shell session 1 opened (2.2.2.2:44643 -> 1.1.1.1:22) at 2019-03-16 08:31:13 -0400
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
[*] Starting persistent handler(s)...
msf5 auxiliary(scanner/ssh/ssh_login) > sessions

Active sessions
===============

  Id  Name  Type         Information                                  Connection
  --  ----  ----         -----------                                  ----------
  1         shell unifi  SSH admin:admin (1.1.1.1:22)  2.2.2.2:44643 -> 1.1.1.1:22 (1.1.1.1)

```

#11558