### PR TITLE
add no cleanup to jtr modules

### DIFF
--- a/documentation/modules/auxiliary/analyze/apply_pot.md
+++ b/documentation/modules/auxiliary/analyze/apply_pot.md
@@ -29,6 +29,11 @@
    records cracked password hashes.  Kali linux's default location is `/root/.john/john.pot`.
    Default is `~/.msf4/john.pot`.
 
+   **DeleteTempFiles**
+
+   This option will prevent deletion of the wordlist and file containing hashes.  This may be useful for
+   running the hashes through john if it wasn't cracked, or for debugging. Default is `false`.
+
 ## Scenarios
 
 In this scenario, we fill a bunch of different hash types into the creds db.  You'll need a

--- a/documentation/modules/auxiliary/analyze/jtr_aix.md
+++ b/documentation/modules/auxiliary/analyze/jtr_aix.md
@@ -28,6 +28,11 @@
    The path to an optional custom wordlist.  This file is added to the new wordlist which may include the other
    `USE` items like `USE_CREDS`, and have `MUTATE` or `KORELOGIC` applied to it.
 
+   **DeleteTempFiles**
+
+   This option will prevent deletion of the wordlist and file containing hashes.  This may be useful for
+   running the hashes through john if it wasn't cracked, or for debugging. Default is `false`.
+
    **ITERATION_TIMEOUT**
 
    The max-run-time for each iteration of cracking

--- a/documentation/modules/auxiliary/analyze/jtr_linux.md
+++ b/documentation/modules/auxiliary/analyze/jtr_linux.md
@@ -36,6 +36,11 @@
 
    Include `blowfish` and `SHA`(256/512) passwords.
 
+   **DeleteTempFiles**
+
+   This option will prevent deletion of the wordlist and file containing hashes.  This may be useful for
+   running the hashes through john if it wasn't cracked, or for debugging. Default is `false`.
+
    **CUSTOM_WORDLIST**
 
    The path to an optional custom wordlist.  This file is added to the new wordlist which may include the other

--- a/documentation/modules/auxiliary/analyze/jtr_mssql_fast.md
+++ b/documentation/modules/auxiliary/analyze/jtr_mssql_fast.md
@@ -30,6 +30,11 @@
    The path to an optional custom wordlist.  This file is added to the new wordlist which may include the other
    `USE` items like `USE_CREDS`, and have `MUTATE` or `KORELOGIC` applied to it.
 
+   **DeleteTempFiles**
+
+   This option will prevent deletion of the wordlist and file containing hashes.  This may be useful for
+   running the hashes through john if it wasn't cracked, or for debugging. Default is `false`.
+
    **ITERATION_TIMEOUT**
 
    The max-run-time for each iteration of cracking

--- a/documentation/modules/auxiliary/analyze/jtr_mysql_fast.md
+++ b/documentation/modules/auxiliary/analyze/jtr_mysql_fast.md
@@ -29,6 +29,11 @@
    The path to an optional custom wordlist.  This file is added to the new wordlist which may include the other
    `USE` items like `USE_CREDS`, and have `MUTATE` or `KORELOGIC` applied to it.
 
+   **DeleteTempFiles**
+
+   This option will prevent deletion of the wordlist and file containing hashes.  This may be useful for
+   running the hashes through john if it wasn't cracked, or for debugging. Default is `false`.
+
    **ITERATION_TIMEOUT**
 
    The max-run-time for each iteration of cracking

--- a/documentation/modules/auxiliary/analyze/jtr_oracle_fast.md
+++ b/documentation/modules/auxiliary/analyze/jtr_oracle_fast.md
@@ -37,6 +37,11 @@
    The path to an optional custom wordlist.  This file is added to the new wordlist which may include the other
    `USE` items like `USE_CREDS`, and have `MUTATE` or `KORELOGIC` applied to it.
 
+   **DeleteTempFiles**
+
+   This option will prevent deletion of the wordlist and file containing hashes.  This may be useful for
+   running the hashes through john if it wasn't cracked, or for debugging. Default is `false`.
+
    **ITERATION_TIMEOUT**
 
    The max-run-time for each iteration of cracking

--- a/documentation/modules/auxiliary/analyze/jtr_postgres_fast.md
+++ b/documentation/modules/auxiliary/analyze/jtr_postgres_fast.md
@@ -32,6 +32,11 @@
    The path to an optional custom wordlist.  This file is added to the new wordlist which may include the other
    `USE` items like `USE_CREDS`, and have `MUTATE` or `KORELOGIC` applied to it.
 
+   **DeleteTempFiles**
+
+   This option will prevent deletion of the wordlist and file containing hashes.  This may be useful for
+   running the hashes through john if it wasn't cracked, or for debugging. Default is `false`.
+
    **ITERATION_TIMEOUT**
 
    The max-run-time for each iteration of cracking

--- a/documentation/modules/auxiliary/analyze/jtr_windows_fast.md
+++ b/documentation/modules/auxiliary/analyze/jtr_windows_fast.md
@@ -29,6 +29,11 @@
    The path to an optional custom wordlist.  This file is added to the new wordlist which may include the other
    `USE` items like `USE_CREDS`, and have `MUTATE` or `KORELOGIC` applied to it.
 
+   **DeleteTempFiles**
+
+   This option will prevent deletion of the wordlist and file containing hashes.  This may be useful for
+   running the hashes through john if it wasn't cracked, or for debugging. Default is `false`.
+
    **ITERATION_TIMEOUT**
 
    The max-run-time for each iteration of cracking

--- a/lib/msf/core/auxiliary/jtr.rb
+++ b/lib/msf/core/auxiliary/jtr.rb
@@ -40,6 +40,11 @@ module Auxiliary::JohnTheRipper
       ], Msf::Auxiliary::JohnTheRipper
     )
 
+    register_advanced_options(
+      [
+        OptBool.new('DELETE_TEMP_FILES',    [false, 'Delete temporary wordlist and hash files', true])
+      ], Msf::Auxiliary::JohnTheRipper
+    )
   end
 
   # @param pwd [String] Password recovered from cracking an LM hash

--- a/lib/msf/core/auxiliary/jtr.rb
+++ b/lib/msf/core/auxiliary/jtr.rb
@@ -42,7 +42,7 @@ module Auxiliary::JohnTheRipper
 
     register_advanced_options(
       [
-        OptBool.new('DELETE_TEMP_FILES',    [false, 'Delete temporary wordlist and hash files', true])
+        OptBool.new('DeleteTempFiles',    [false, 'Delete temporary wordlist and hash files', true])
       ], Msf::Auxiliary::JohnTheRipper
     )
   end

--- a/modules/auxiliary/analyze/apply_pot.rb
+++ b/modules/auxiliary/analyze/apply_pot.rb
@@ -157,8 +157,10 @@ class MetasploitModule < Msf::Auxiliary
         end
       end
     end
-    cleanup_files.each do |f|
-      File.delete(f)
+    if datastore['DELETE_TEMP_FILES']
+      cleanup_files.each do |f|
+        File.delete(f)
+      end
     end
   end
 end

--- a/modules/auxiliary/analyze/apply_pot.rb
+++ b/modules/auxiliary/analyze/apply_pot.rb
@@ -157,7 +157,7 @@ class MetasploitModule < Msf::Auxiliary
         end
       end
     end
-    if datastore['DELETE_TEMP_FILES']
+    if datastore['DeleteTempFiles']
       cleanup_files.each do |f|
         File.delete(f)
       end

--- a/modules/auxiliary/analyze/jtr_aix.rb
+++ b/modules/auxiliary/analyze/jtr_aix.rb
@@ -87,7 +87,7 @@ class MetasploitModule < Msf::Auxiliary
         create_cracked_credential( username: username, password: password, core_id: core_id)
       end
     end
-    if datastore['DELETE_TEMP_FILES']
+    if datastore['DeleteTempFiles']
       cleanup_files.each do |f|
         File.delete(f)
       end

--- a/modules/auxiliary/analyze/jtr_aix.rb
+++ b/modules/auxiliary/analyze/jtr_aix.rb
@@ -87,8 +87,10 @@ class MetasploitModule < Msf::Auxiliary
         create_cracked_credential( username: username, password: password, core_id: core_id)
       end
     end
-    cleanup_files.each do |f|
-      File.delete(f)
+    if datastore['DELETE_TEMP_FILES']
+      cleanup_files.each do |f|
+        File.delete(f)
+      end
     end
   end
 

--- a/modules/auxiliary/analyze/jtr_linux.rb
+++ b/modules/auxiliary/analyze/jtr_linux.rb
@@ -88,8 +88,10 @@ class MetasploitModule < Msf::Auxiliary
         create_cracked_credential( username: username, password: password, core_id: core_id)
       end
     end
-    cleanup_files.each do |f|
-      File.delete(f)
+    if datastore['DELETE_TEMP_FILES']
+      cleanup_files.each do |f|
+        File.delete(f)
+      end
     end
   end
 

--- a/modules/auxiliary/analyze/jtr_linux.rb
+++ b/modules/auxiliary/analyze/jtr_linux.rb
@@ -88,7 +88,7 @@ class MetasploitModule < Msf::Auxiliary
         create_cracked_credential( username: username, password: password, core_id: core_id)
       end
     end
-    if datastore['DELETE_TEMP_FILES']
+    if datastore['DeleteTempFiles']
       cleanup_files.each do |f|
         File.delete(f)
       end

--- a/modules/auxiliary/analyze/jtr_mssql_fast.rb
+++ b/modules/auxiliary/analyze/jtr_mssql_fast.rb
@@ -87,7 +87,7 @@ class MetasploitModule < Msf::Auxiliary
         create_cracked_credential( username: username, password: password, core_id: core_id)
       end
     end
-    if datastore['DELETE_TEMP_FILES']
+    if datastore['DeleteTempFiles']
       cleanup_files.each do |f|
         File.delete(f)
       end

--- a/modules/auxiliary/analyze/jtr_mssql_fast.rb
+++ b/modules/auxiliary/analyze/jtr_mssql_fast.rb
@@ -87,8 +87,10 @@ class MetasploitModule < Msf::Auxiliary
         create_cracked_credential( username: username, password: password, core_id: core_id)
       end
     end
-    cleanup_files.each do |f|
-      File.delete(f)
+    if datastore['DELETE_TEMP_FILES']
+      cleanup_files.each do |f|
+        File.delete(f)
+      end
     end
   end
 

--- a/modules/auxiliary/analyze/jtr_mysql_fast.rb
+++ b/modules/auxiliary/analyze/jtr_mysql_fast.rb
@@ -85,7 +85,7 @@ class MetasploitModule < Msf::Auxiliary
         create_cracked_credential( username: username, password: password, core_id: core_id)
       end
     end
-    if datastore['DELETE_TEMP_FILES']
+    if datastore['DeleteTempFiles']
       cleanup_files.each do |f|
         File.delete(f)
       end

--- a/modules/auxiliary/analyze/jtr_mysql_fast.rb
+++ b/modules/auxiliary/analyze/jtr_mysql_fast.rb
@@ -85,8 +85,10 @@ class MetasploitModule < Msf::Auxiliary
         create_cracked_credential( username: username, password: password, core_id: core_id)
       end
     end
-    cleanup_files.each do |f|
-      File.delete(f)
+    if datastore['DELETE_TEMP_FILES']
+      cleanup_files.each do |f|
+        File.delete(f)
+      end
     end
   end
 

--- a/modules/auxiliary/analyze/jtr_oracle_fast.rb
+++ b/modules/auxiliary/analyze/jtr_oracle_fast.rb
@@ -86,8 +86,10 @@ class MetasploitModule < Msf::Auxiliary
         create_cracked_credential( username: username, password: password, core_id: core_id)
       end
     end
-    cleanup_files.each do |f|
-      File.delete(f)
+    if datastore['DELETE_TEMP_FILES']
+      cleanup_files.each do |f|
+        File.delete(f)
+      end
     end
   end
 

--- a/modules/auxiliary/analyze/jtr_oracle_fast.rb
+++ b/modules/auxiliary/analyze/jtr_oracle_fast.rb
@@ -86,7 +86,7 @@ class MetasploitModule < Msf::Auxiliary
         create_cracked_credential( username: username, password: password, core_id: core_id)
       end
     end
-    if datastore['DELETE_TEMP_FILES']
+    if datastore['DeleteTempFiles']
       cleanup_files.each do |f|
         File.delete(f)
       end

--- a/modules/auxiliary/analyze/jtr_postgres_fast.rb
+++ b/modules/auxiliary/analyze/jtr_postgres_fast.rb
@@ -124,7 +124,7 @@ class MetasploitModule < Msf::Auxiliary
         end
       end
     end
-    if datastore['DELETE_TEMP_FILES']
+    if datastore['DeleteTempFiles']
       cleanup_files.each do |f|
         File.delete(f)
       end

--- a/modules/auxiliary/analyze/jtr_postgres_fast.rb
+++ b/modules/auxiliary/analyze/jtr_postgres_fast.rb
@@ -124,8 +124,10 @@ class MetasploitModule < Msf::Auxiliary
         end
       end
     end
-    cleanup_files.each do |f|
-      File.delete(f)
+    if datastore['DELETE_TEMP_FILES']
+      cleanup_files.each do |f|
+        File.delete(f)
+      end
     end
   end
 

--- a/modules/auxiliary/analyze/jtr_windows_fast.rb
+++ b/modules/auxiliary/analyze/jtr_windows_fast.rb
@@ -127,7 +127,7 @@ class MetasploitModule < Msf::Auxiliary
         create_cracked_credential( username: username, password: password, core_id: core_id)
       end
     end
-    if datastore['DELETE_TEMP_FILES']
+    if datastore['DeleteTempFiles']
       cleanup_files.each do |f|
         File.delete(f)
       end

--- a/modules/auxiliary/analyze/jtr_windows_fast.rb
+++ b/modules/auxiliary/analyze/jtr_windows_fast.rb
@@ -127,8 +127,10 @@ class MetasploitModule < Msf::Auxiliary
         create_cracked_credential( username: username, password: password, core_id: core_id)
       end
     end
-    cleanup_files.each do |f|
-      File.delete(f)
+    if datastore['DELETE_TEMP_FILES']
+      cleanup_files.each do |f|
+        File.delete(f)
+      end
     end
   end
 


### PR DESCRIPTION
There are times when running the jtr aux modules you don't want to delete the temporary files.  Cases like debugging, or exporting the DB in a friendly format to run john elsewhere.

This PR adds an advanced option to not delete the temporary files.  It was brought to light in #11294 by @7043mcgeep 

```
msf5 auxiliary(analyze/jtr_aix) > set DeleteTempFiles false
DeleteTempFiles => false
msf5 auxiliary(analyze/jtr_aix) > run

[*] Hashes Written out to /tmp/hashes_tmp20190316-9080-bxdiqo
[*] Wordlist file written out to /tmp/jtrtmp20190316-9080-t8w0ee
[*] Cracking descrypt hashes in normal wordlist mode...
Using default input encoding: UTF-8
[*] Cracking descrypt hashes in single mode...
Using default input encoding: UTF-8
[*] Cracking descrypt hashes in incremental mode (Digits)...
Using default input encoding: UTF-8
[*] Cracked Passwords this run:
[+] des_password:password
[*] Auxiliary module execution completed
msf5 auxiliary(analyze/jtr_aix) > cat /tmp/hashes_tmp20190316-9080-bxdiqo
[*] exec: cat /tmp/hashes_tmp20190316-9080-bxdiqo

des_password:rEK1ecacw.7.c:::::24:
msf5 auxiliary(analyze/jtr_aix) > set DeleteTempFiles true
DeleteTempFiles => true
msf5 auxiliary(analyze/jtr_aix) > run

[*] Hashes Written out to /tmp/hashes_tmp20190316-9080-mcnfhb
[*] Wordlist file written out to /tmp/jtrtmp20190316-9080-1iwdlg
[*] Cracking descrypt hashes in normal wordlist mode...
Using default input encoding: UTF-8
[*] Cracking descrypt hashes in single mode...
Using default input encoding: UTF-8
[*] Cracking descrypt hashes in incremental mode (Digits)...
Using default input encoding: UTF-8
[*] Cracked Passwords this run:
[+] des_password:password
[*] Auxiliary module execution completed
msf5 auxiliary(analyze/jtr_aix) > cat /tmp/hashes_tmp20190316-9080-mcnfhb
[*] exec: cat /tmp/hashes_tmp20190316-9080-mcnfhb

cat: /tmp/hashes_tmp20190316-9080-mcnfhb: No such file or directory
```