### PR TITLE
cable-d -> cable-docsis

### DIFF
--- a/data/wordlists/snmp_default_pass.txt
+++ b/data/wordlists/snmp_default_pass.txt
@@ -44,7 +44,7 @@ apc
 bintec
 blue
 c
-cable-d
+cable-docsis
 canon_admin
 cc
 cisco


### PR DESCRIPTION
cable-docsis is a known hidden community string in Cisco devices.
www.cisco.com/warp/public/707/cisco-sa-20010228-ios-snmp-community.shtml

To me, it looks like cable-d should be cable-docsis