### PR TITLE
Add is_uac_enabled? functionality to Windows 2019

### DIFF
--- a/lib/msf/core/post/windows/priv.rb
+++ b/lib/msf/core/post/windows/priv.rb
@@ -127,7 +127,7 @@ module Msf::Post::Windows::Priv
     uac = false
     winversion = session.sys.config.sysinfo['OS']
 
-    if winversion =~ /Windows (Vista|7|8|2008|2012|10|2016)/
+    if winversion =~ /Windows (Vista|7|8|2008|2012|10|2016|2019)/
       unless is_system?
         begin
           enable_lua = registry_getvaldata(


### PR DESCRIPTION
`2019`

Untested.

Let's do this again in 202X.

#10419