### PR TITLE
REST API for asynchronous payload callbacks

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161227212223) do
+ActiveRecord::Schema.define(version: 20190308134512) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,6 +20,18 @@ ActiveRecord::Schema.define(version: 20161227212223) do
     t.text     "token"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "async_callbacks", force: :cascade do |t|
+    t.string   "uuid",           null: false
+    t.integer  "timestamp",      null: false
+    t.string   "listener_uri"
+    t.string   "target_host"
+    t.string   "target_port"
+    t.integer  "workspace_id"
+    t.datetime "created_at",     null: false
+    t.datetime "updated_at",     null: false
+    t.uuid     "{:null=>false}"
   end
 
   create_table "automatic_exploitation_match_results", force: :cascade do |t|

--- a/documentation/api/v1/async_callback_api_doc.rb
+++ b/documentation/api/v1/async_callback_api_doc.rb
@@ -8,11 +8,11 @@ module AsyncCallbackApiDoc
   TIMESTAMP_DESC = 'The Unix format timestamp when the asynchronous payload called back (in epoch)'
   TIMESTAMP_EXAMPLE = '1536777407'
   LISTENER_URI_DESC = 'The URL of the listener which received the callback'
-  LISTENER_URI_EXAMPLE = ['tcp://192.168.1.7:4444', 'icmp://192.168.0.12', 'https://203.0.113.5:443/506eb417-782f-4f0b-9bc2-b30abe19d601']
+  LISTENER_URI_EXAMPLE = 'tcp://192.168.1.7:4444'
   HOST_DESC = 'The IP address from which the callback was received'
-  HOST_EXAMPLE = ['203.0.113.5']
+  HOST_EXAMPLE = '203.0.113.5'
   PORT_DESC = 'The port from which the callback was received'
-  PORT_EXAMPLE = ['443']
+  PORT_EXAMPLE = '443'
   WORKSPACE_ID_DESC = 'The ID of the workspace this payload belongs to'
   WORKSPACE_ID_EXAMPLE = 'default'
 
@@ -23,7 +23,7 @@ module AsyncCallbackApiDoc
     property :id, type: :integer, format: :int32, description: RootApiDoc::ID_DESC
     property :uuid, type: :string, required: true, description: UUID_DESC, example: UUID_EXAMPLE
     property :timestamp, type: :integer, required: true, description: TIMESTAMP_DESC, example: TIMESTAMP_EXAMPLE
-    property :listener_uri, description: LISTENER_URI_DESC, example: LISTENER_URI_EXAMPLE, type: :array do items type: :string end
+    property :listener_uri, type: :string, description: LISTENER_URI_DESC, example: LISTENER_URI_EXAMPLE
     property :target_host, type: :string, description: HOST_DESC, example: HOST_EXAMPLE
     property :target_port, type: :string, description: PORT_DESC, example: PORT_EXAMPLE
     property :created_at, type: :string, format: :date_time, description: RootApiDoc::CREATED_AT_DESC

--- a/documentation/api/v1/async_callback_api_doc.rb
+++ b/documentation/api/v1/async_callback_api_doc.rb
@@ -1,0 +1,219 @@
+require 'swagger/blocks'
+
+module AsyncCallbackApiDoc
+  include Swagger::Blocks
+
+  UUID_DESC = 'The unique ID of the payload calling back.'
+  UUID_EXAMPLE = '6dde5ce0e94c9f43'
+  TIMESTAMP_DESC = 'The Unix format timestamp when the asynchronous payload called back.'
+  TIMESTAMP_EXAMPLE = '1536777407'
+  URLS_DESC = 'The URL which received the callback'
+  URLS_EXAMPLE = ['tcp://192.168.1.7:4444']
+  WORKSPACE_ID_DESC = 'The ID of the workspace this payload belongs to.'
+  WORKSPACE_ID_EXAMPLE = 1
+
+# Swagger documentation for payloads model
+  swagger_schema :AsyncCallback do
+    key :required, [:ntype]
+    property :workspace, type: :string, required: true, description: RootApiDoc::WORKSPACE_POST_EXAMPLE
+    property :id, type: :integer, format: :int32, description: RootApiDoc::ID_DESC
+    property :uuid, type: :string, description: UUID_DESC, example: UUID_EXAMPLE
+    property :timestamp, type: :integer, description: TIMESTAMP_DESC, example: TIMESTAMP_EXAMPLE
+    property :urls, description: URLS_DESC, example: URLS_EXAMPLE, type: :array do items type: :string end
+    property :created_at, type: :string, format: :date_time, description: RootApiDoc::CREATED_AT_DESC
+    property :updated_at, type: :string, format: :date_time, description: RootApiDoc::UPDATED_AT_DESC
+  end
+
+  swagger_path '/api/v1/async-callbacks' do
+    # Swagger documentation for /api/v1/async_callbacks GET
+    operation :get do
+      key :description, 'Return asynchronous payload callbacks that are stored in the database.'
+      key :tags, [ 'async_callback' ]
+
+      parameter :workspace
+
+      response 200 do
+        key :description, 'Returns asynchronous payload callback data.'
+        schema do
+          property :data do
+            key :type, :array
+            items do
+              key :'$ref', :AsyncCallback
+            end
+          end
+        end
+      end
+
+      response 401 do
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
+        schema do
+          key :'$ref', :AuthErrorModel
+        end
+      end
+
+      response 500 do
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
+        schema do
+          key :'$ref', :ErrorModel
+        end
+      end
+    end
+
+    # Swagger documentation for /api/v1/async_callbacks POST
+    operation :post do
+      key :description, 'Create an asynchronous payload callback entry.'
+      key :tags, [ 'async_callback' ]
+
+      parameter do
+        key :in, :body
+        key :name, :body
+        key :description, 'The attributes to assign to the asynchronous payload callback.'
+        key :required, true
+        schema do
+          property :uuid, type: :string, description: UUID_DESC, example: UUID_EXAMPLE
+          property :timestamp, type: :string, description: TIMESTAMP_DESC, example: TIMESTAMP_EXAMPLE
+          property :urls, type: :string, description: URLS_DESC, example: URLS_EXAMPLE
+          property :workspace_id, type: :string, description: WORKSPACE_ID_DESC, example: WORKSPACE_ID_EXAMPLE
+        end
+      end
+
+      response 200 do
+        key :description, RootApiDoc::DEFAULT_RESPONSE_200
+        schema do
+          property :data do
+            key :'$ref', :AsyncCallback
+          end
+        end
+      end
+
+      response 401 do
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
+        schema do
+          key :'$ref', :AuthErrorModel
+        end
+      end
+
+      response 500 do
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
+        schema do
+          key :'$ref', :ErrorModel
+        end
+      end
+    end
+
+    # Swagger documentation for /api/v1/async-callbacks/ DELETE
+    operation :delete do
+      key :description, 'Delete the specified asynchronous payload callback.'
+      key :tags, [ 'async_callback' ]
+
+      parameter :delete_opts
+
+      response 200 do
+        key :description, 'Returns an array containing the successfully deleted asynchronous payload callback.'
+        schema do
+          property :data do
+            key :type, :array
+            items do
+              key :'$ref', :AsyncCallback
+            end
+          end
+        end
+      end
+
+      response 401 do
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
+        schema do
+          key :'$ref', :AuthErrorModel
+        end
+      end
+
+      response 500 do
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
+        schema do
+          key :'$ref', :ErrorModel
+        end
+      end
+    end
+  end
+
+  swagger_path '/api/v1/async-callbacks/{id}' do
+    # Swagger documentation for api/v1/async-callbacks/:id GET
+    operation :get do
+      key :description, 'Return specific asynchronous payload callback that is stored in the database.'
+      key :tags, [ 'async_callback' ]
+
+      parameter do
+        key :name, :id
+        key :in, :path
+        key :description, 'ID of asynchronous payload callback to retrieve.'
+        key :required, true
+        key :type, :integer
+        key :format, :int32
+      end
+
+      response 200 do
+        key :description, 'Returns asynchronous payload callback data.'
+        schema do
+          property :data do
+            key :'$ref', :AsyncCallback
+          end
+        end
+      end
+
+      response 401 do
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
+        schema do
+          key :'$ref', :AuthErrorModel
+        end
+      end
+
+      response 500 do
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
+        schema do
+          key :'$ref', :ErrorModel
+        end
+      end
+    end
+
+    # Swagger documentation for /api/v1/async-callbacks/:id PUT
+    operation :put do
+      key :description, 'Update the attributes an existing asynchronous payload callback.'
+      key :tags, [ 'async_callback' ]
+
+      parameter :update_id
+
+      parameter do
+        key :in, :body
+        key :name, :body
+        key :description, 'The updated attributes to overwrite to the asynchronous payload callback.'
+        key :required, true
+        schema do
+          key :'$ref', :AsyncCallback
+        end
+      end
+
+      response 200 do
+        key :description, RootApiDoc::DEFAULT_RESPONSE_200
+        schema do
+          property :data do
+            key :'$ref', :AsyncCallback
+          end
+        end
+      end
+
+      response 401 do
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
+        schema do
+          key :'$ref', :AuthErrorModel
+        end
+      end
+
+      response 500 do
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
+        schema do
+          key :'$ref', :ErrorModel
+        end
+      end
+    end
+  end
+end

--- a/documentation/api/v1/async_callback_api_doc.rb
+++ b/documentation/api/v1/async_callback_api_doc.rb
@@ -3,23 +3,29 @@ require 'swagger/blocks'
 module AsyncCallbackApiDoc
   include Swagger::Blocks
 
-  UUID_DESC = 'The unique ID of the payload calling back.'
+  UUID_DESC = 'The unique ID of the payload calling back'
   UUID_EXAMPLE = '6dde5ce0e94c9f43'
-  TIMESTAMP_DESC = 'The Unix format timestamp when the asynchronous payload called back.'
+  TIMESTAMP_DESC = 'The Unix format timestamp when the asynchronous payload called back (in epoch)'
   TIMESTAMP_EXAMPLE = '1536777407'
-  URLS_DESC = 'The URL which received the callback'
-  URLS_EXAMPLE = ['tcp://192.168.1.7:4444']
-  WORKSPACE_ID_DESC = 'The ID of the workspace this payload belongs to.'
-  WORKSPACE_ID_EXAMPLE = 1
+  LISTENER_URI_DESC = 'The URL of the listener which received the callback'
+  LISTENER_URI_EXAMPLE = ['tcp://192.168.1.7:4444', 'icmp://192.168.0.12', 'https://203.0.113.5:443/506eb417-782f-4f0b-9bc2-b30abe19d601']
+  HOST_DESC = 'The IP address from which the callback was received'
+  HOST_EXAMPLE = ['203.0.113.5']
+  PORT_DESC = 'The port from which the callback was received'
+  PORT_EXAMPLE = ['443']
+  WORKSPACE_ID_DESC = 'The ID of the workspace this payload belongs to'
+  WORKSPACE_ID_EXAMPLE = 'default'
 
 # Swagger documentation for payloads model
   swagger_schema :AsyncCallback do
     key :required, [:ntype]
     property :workspace, type: :string, required: true, description: RootApiDoc::WORKSPACE_POST_EXAMPLE
     property :id, type: :integer, format: :int32, description: RootApiDoc::ID_DESC
-    property :uuid, type: :string, description: UUID_DESC, example: UUID_EXAMPLE
-    property :timestamp, type: :integer, description: TIMESTAMP_DESC, example: TIMESTAMP_EXAMPLE
-    property :urls, description: URLS_DESC, example: URLS_EXAMPLE, type: :array do items type: :string end
+    property :uuid, type: :string, required: true, description: UUID_DESC, example: UUID_EXAMPLE
+    property :timestamp, type: :integer, required: true, description: TIMESTAMP_DESC, example: TIMESTAMP_EXAMPLE
+    property :listener_uri, description: LISTENER_URI_DESC, example: LISTENER_URI_EXAMPLE, type: :array do items type: :string end
+    property :target_host, type: :string, description: HOST_DESC, example: HOST_EXAMPLE
+    property :target_port, type: :string, description: PORT_DESC, example: PORT_EXAMPLE
     property :created_at, type: :string, format: :date_time, description: RootApiDoc::CREATED_AT_DESC
     property :updated_at, type: :string, format: :date_time, description: RootApiDoc::UPDATED_AT_DESC
   end
@@ -72,7 +78,7 @@ module AsyncCallbackApiDoc
         schema do
           property :uuid, type: :string, description: UUID_DESC, example: UUID_EXAMPLE
           property :timestamp, type: :string, description: TIMESTAMP_DESC, example: TIMESTAMP_EXAMPLE
-          property :urls, type: :string, description: URLS_DESC, example: URLS_EXAMPLE
+          property :listener_uri, type: :string, description: LISTENER_URI_DESC, example: LISTENER_URI_EXAMPLE
           property :workspace_id, type: :string, description: WORKSPACE_ID_DESC, example: WORKSPACE_ID_EXAMPLE
         end
       end
@@ -82,40 +88,6 @@ module AsyncCallbackApiDoc
         schema do
           property :data do
             key :'$ref', :AsyncCallback
-          end
-        end
-      end
-
-      response 401 do
-        key :description, RootApiDoc::DEFAULT_RESPONSE_401
-        schema do
-          key :'$ref', :AuthErrorModel
-        end
-      end
-
-      response 500 do
-        key :description, RootApiDoc::DEFAULT_RESPONSE_500
-        schema do
-          key :'$ref', :ErrorModel
-        end
-      end
-    end
-
-    # Swagger documentation for /api/v1/async-callbacks/ DELETE
-    operation :delete do
-      key :description, 'Delete the specified asynchronous payload callback.'
-      key :tags, [ 'async_callback' ]
-
-      parameter :delete_opts
-
-      response 200 do
-        key :description, 'Returns an array containing the successfully deleted asynchronous payload callback.'
-        schema do
-          property :data do
-            key :type, :array
-            items do
-              key :'$ref', :AsyncCallback
-            end
           end
         end
       end
@@ -153,47 +125,6 @@ module AsyncCallbackApiDoc
 
       response 200 do
         key :description, 'Returns asynchronous payload callback data.'
-        schema do
-          property :data do
-            key :'$ref', :AsyncCallback
-          end
-        end
-      end
-
-      response 401 do
-        key :description, RootApiDoc::DEFAULT_RESPONSE_401
-        schema do
-          key :'$ref', :AuthErrorModel
-        end
-      end
-
-      response 500 do
-        key :description, RootApiDoc::DEFAULT_RESPONSE_500
-        schema do
-          key :'$ref', :ErrorModel
-        end
-      end
-    end
-
-    # Swagger documentation for /api/v1/async-callbacks/:id PUT
-    operation :put do
-      key :description, 'Update the attributes an existing asynchronous payload callback.'
-      key :tags, [ 'async_callback' ]
-
-      parameter :update_id
-
-      parameter do
-        key :in, :body
-        key :name, :body
-        key :description, 'The updated attributes to overwrite to the asynchronous payload callback.'
-        key :required, true
-        schema do
-          key :'$ref', :AsyncCallback
-        end
-      end
-
-      response 200 do
-        key :description, RootApiDoc::DEFAULT_RESPONSE_200
         schema do
           property :data do
             key :'$ref', :AsyncCallback

--- a/documentation/api/v1/async_callback_api_doc.rb
+++ b/documentation/api/v1/async_callback_api_doc.rb
@@ -108,19 +108,20 @@ module AsyncCallbackApiDoc
     end
   end
 
-  swagger_path '/api/v1/async-callbacks/{id}' do
-    # Swagger documentation for api/v1/async-callbacks/:id GET
+  swagger_path '/api/v1/async-callbacks/{uuid}' do
+    # Swagger documentation for api/v1/async-callbacks/:uuid GET
     operation :get do
       key :description, 'Return specific asynchronous payload callback that is stored in the database.'
       key :tags, [ 'async_callback' ]
 
+      parameter :workspace
+
       parameter do
-        key :name, :id
+        key :name, :uuid
         key :in, :path
-        key :description, 'ID of asynchronous payload callback to retrieve.'
+        key :description, 'UUID of asynchronous payload callback to retrieve.'
         key :required, true
-        key :type, :integer
-        key :format, :int32
+        key :type, :string
       end
 
       response 200 do

--- a/documentation/api/v1/root_api_doc.rb
+++ b/documentation/api/v1/root_api_doc.rb
@@ -60,6 +60,7 @@ module RootApiDoc
     # Documentation Tags
     #
     #################################
+    tag name: 'async_callback', description: 'Asynchrouous payload callback operations.'
     tag name: 'auth', description: 'Authorization operations.'
     tag name: 'credential', description: 'Credential operations.'
     tag name: 'db_export', description: 'Endpoint for generating and retrieving a database backup.'

--- a/lib/metasploit/framework/data_service/proxy/async_callback_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/async_callback_data_proxy.rb
@@ -1,0 +1,44 @@
+module AsyncCallbackDataProxy
+
+  def async_callbacks(opts)
+    begin
+      self.data_service_operation do |data_service|
+        data_service.async_callbacks(opts)
+      end
+    rescue => e
+      self.log_error(e, "Problem retrieving async callback")
+    end
+  end
+
+  def create_async_callback(opts)
+    begin
+      self.data_service_operation do |data_service|
+        data_service.create_async_callback(opts)
+      end
+    rescue => e
+      self.log_error(e, "Problem creating async callback")
+    end
+  end
+
+  def update_async_callback(opts)
+    begin
+      self.data_service_operation do |data_service|
+        data_service.update_async_callback(opts)
+      end
+    rescue => e
+      self.log_error(e, "Problem updating async callback")
+    end
+  end
+
+  def delete_async_callback(opts)
+    begin
+      self.data_service_operation do |data_service|
+        data_service.delete_async_callback(opts)
+      end
+    rescue => e
+      self.log_error(e, "Problem deleting async callback")
+    end
+  end
+
+end
+

--- a/lib/metasploit/framework/data_service/proxy/async_callback_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/async_callback_data_proxy.rb
@@ -20,25 +20,5 @@ module AsyncCallbackDataProxy
     end
   end
 
-  def update_async_callback(opts)
-    begin
-      self.data_service_operation do |data_service|
-        data_service.update_async_callback(opts)
-      end
-    rescue => e
-      self.log_error(e, "Problem updating async callback")
-    end
-  end
-
-  def delete_async_callback(opts)
-    begin
-      self.data_service_operation do |data_service|
-        data_service.delete_async_callback(opts)
-      end
-    rescue => e
-      self.log_error(e, "Problem deleting async callback")
-    end
-  end
-
 end
 

--- a/lib/metasploit/framework/data_service/remote/http/remote_async_callback_service.rb
+++ b/lib/metasploit/framework/data_service/remote/http/remote_async_callback_service.rb
@@ -14,17 +14,4 @@ module RemoteAsyncCallbackDataService
   def create_async_callback(opts)
     json_to_mdm_object(self.post_data(ASYNC_CALLBACK_API_PATH, opts), ASYNC_CALLBACK_MDM_CLASS, []).first
   end
-
-  def update_async_callback(opts)
-    path = ASYNC_CALLBACK_API_PATH
-    if opts && opts[:id]
-      id = opts.delete(:id)
-      path = "#{ASYNC_CALLBACK_API_PATH}/#{id}"
-    end
-    json_to_mdm_object(self.put_data(path, opts), ASYNC_CALLBACK_MDM_CLASS, [])
-  end
-
-  def delete_async_callback(opts)
-    json_to_mdm_object(self.delete_data(ASYNC_CALLBACK_API_PATH, opts), ASYNC_CALLBACK_MDM_CLASS, [])
-  end
 end

--- a/lib/metasploit/framework/data_service/remote/http/remote_async_callback_service.rb
+++ b/lib/metasploit/framework/data_service/remote/http/remote_async_callback_service.rb
@@ -1,0 +1,30 @@
+require 'metasploit/framework/data_service/remote/http/response_data_helper'
+
+module RemoteAsyncCallbackDataService
+  include ResponseDataHelper
+
+  ASYNC_CALLBACK_API_PATH = '/api/v1/async-callbacks'
+  ASYNC_CALLBACK_MDM_CLASS = 'Mdm::AsyncCallback'
+
+  def async_callbacks(opts)
+    path = get_path_select(opts, ASYNC_CALLBACK_API_PATH)
+    json_to_mdm_object(self.get_data(path, nil, opts), ASYNC_CALLBACK_MDM_CLASS, [])
+  end
+
+  def create_async_callback(opts)
+    json_to_mdm_object(self.post_data(ASYNC_CALLBACK_API_PATH, opts), ASYNC_CALLBACK_MDM_CLASS, []).first
+  end
+
+  def update_async_callback(opts)
+    path = ASYNC_CALLBACK_API_PATH
+    if opts && opts[:id]
+      id = opts.delete(:id)
+      path = "#{ASYNC_CALLBACK_API_PATH}/#{id}"
+    end
+    json_to_mdm_object(self.put_data(path, opts), ASYNC_CALLBACK_MDM_CLASS, [])
+  end
+
+  def delete_async_callback(opts)
+    json_to_mdm_object(self.delete_data(ASYNC_CALLBACK_API_PATH, opts), ASYNC_CALLBACK_MDM_CLASS, [])
+  end
+end

--- a/lib/metasploit/framework/data_service/stubs/async_callback_data_service.rb
+++ b/lib/metasploit/framework/data_service/stubs/async_callback_data_service.rb
@@ -1,0 +1,18 @@
+module AsyncCallbackDataService
+
+  def async_callbacks(opts)
+    raise 'AsyncCallbackDataService#async_callbacks is not implemented'
+  end
+
+  def create_async_callback(opts)
+    raise 'AsyncCallbackDataService#create_async_callback is not implemented'
+  end
+
+  def update_async_callback(opts)
+    raise 'AsyncCallbackDataService#update_async_callback is not implemented'
+  end
+
+  def delete_async_callback(opts)
+    raise 'AsyncCallbackDataService#delete_async_callback is not implemented'
+  end
+end

--- a/lib/metasploit/framework/data_service/stubs/async_callback_data_service.rb
+++ b/lib/metasploit/framework/data_service/stubs/async_callback_data_service.rb
@@ -7,12 +7,4 @@ module AsyncCallbackDataService
   def create_async_callback(opts)
     raise 'AsyncCallbackDataService#create_async_callback is not implemented'
   end
-
-  def update_async_callback(opts)
-    raise 'AsyncCallbackDataService#update_async_callback is not implemented'
-  end
-
-  def delete_async_callback(opts)
-    raise 'AsyncCallbackDataService#delete_async_callback is not implemented'
-  end
 end

--- a/lib/msf/core/db_manager.rb
+++ b/lib/msf/core/db_manager.rb
@@ -29,6 +29,7 @@ class Msf::DBManager
   DEFAULT_SERVICE_PROTO = "tcp"
 
   autoload :Adapter, 'msf/core/db_manager/adapter'
+  autoload :AsyncCallback, 'msf/core/db_manager/async_callback'
   autoload :Client, 'msf/core/db_manager/client'
   autoload :Connection, 'msf/core/db_manager/connection'
   autoload :Cred, 'msf/core/db_manager/cred'
@@ -69,6 +70,7 @@ class Msf::DBManager
   include Metasploit::Framework::DataService
 
   include Msf::DBManager::Adapter
+  include Msf::DBManager::AsyncCallback
   include Msf::DBManager::Client
   include Msf::DBManager::Connection
   include Msf::DBManager::Cred

--- a/lib/msf/core/db_manager/async_callback.rb
+++ b/lib/msf/core/db_manager/async_callback.rb
@@ -15,8 +15,10 @@ module Msf::DBManager::AsyncCallback
 
   def async_callbacks(opts)
     ::ActiveRecord::Base.connection_pool.with_connection do
-      if opts[:id] && !opts[:id].to_s.empty?
-        return Array.wrap(Mdm::AsyncCallback.find(opts[:id]))
+      if opts[:uuid] && !opts[:uuid].to_s.empty?
+        #return Array.wrap(Mdm::AsyncCallback.find_by :uuid => opts[:uuid] )
+        #return Array.wrap( Mdm::AsyncCallback.where ( uuid: opts[:uuid] ))
+        return Mdm::AsyncCallback.where( 'uuid' => opts[:uuid] )
       end
 
       wspace = Msf::Util::DBManager.process_opts_workspace(opts, framework)

--- a/lib/msf/core/db_manager/async_callback.rb
+++ b/lib/msf/core/db_manager/async_callback.rb
@@ -1,0 +1,56 @@
+module Msf::DBManager::AsyncCallback
+
+  def create_async_callback(opts)
+    ::ActiveRecord::Base.connection_pool.with_connection do
+      # Disabled UUID checking, since we anticipate multiple callbacks from the same UUID
+      #if opts[:uuid] && !opts[:uuid].to_s.empty?
+      #  if Mdm::AsyncCallback.find_by(uuid: opts[:uuid])
+      #    raise ArgumentError.new("An async callback with this uuid already exists.")
+      #  end
+      #end
+
+      Mdm::AsyncCallback.create!(opts)
+    end
+  end
+
+  def async_callbacks(opts)
+    ::ActiveRecord::Base.connection_pool.with_connection do
+      if opts[:id] && !opts[:id].to_s.empty?
+        return Array.wrap(Mdm::AsyncCallback.find(opts[:id]))
+      end
+
+      wspace = Msf::Util::DBManager.process_opts_workspace(opts, framework)
+      return wspace.async_callbacks.where(opts)
+    end
+  end
+
+  def update_async_callback(opts)
+    ::ActiveRecord::Base.connection_pool.with_connection do
+      wspace = Msf::Util::DBManager.process_opts_workspace(opts, framework, false)
+      opts[:workspace] = wspace if wspace
+
+      id = opts.delete(:id)
+      Mdm::AsyncCallback.update(id, opts)
+    end
+  end
+
+  def delete_async_callback(opts)
+    raise ArgumentError.new("The following options are required: :ids") if opts[:ids].nil?
+
+    ::ActiveRecord::Base.connection_pool.with_connection do
+      deleted = []
+      opts[:ids].each do |async_callback_id|
+        async_callback = Mdm::AsyncCallback.find(async_callback_id)
+        begin
+          deleted << async_callback.destroy
+        rescue
+          elog("Forcibly deleting #{async_callback}")
+          deleted << async_callback.delete
+        end
+      end
+
+      return deleted
+    end
+  end
+
+end

--- a/lib/msf/core/db_manager/async_callback.rb
+++ b/lib/msf/core/db_manager/async_callback.rb
@@ -34,23 +34,4 @@ module Msf::DBManager::AsyncCallback
     end
   end
 
-  def delete_async_callback(opts)
-    raise ArgumentError.new("The following options are required: :ids") if opts[:ids].nil?
-
-    ::ActiveRecord::Base.connection_pool.with_connection do
-      deleted = []
-      opts[:ids].each do |async_callback_id|
-        async_callback = Mdm::AsyncCallback.find(async_callback_id)
-        begin
-          deleted << async_callback.destroy
-        rescue
-          elog("Forcibly deleting #{async_callback}")
-          deleted << async_callback.delete
-        end
-      end
-
-      return deleted
-    end
-  end
-
 end

--- a/lib/msf/core/web_services/metasploit_api_app.rb
+++ b/lib/msf/core/web_services/metasploit_api_app.rb
@@ -5,6 +5,7 @@ require 'warden'
 require 'msf/core/web_services/authentication'
 require 'msf/core/web_services/servlet_helper'
 require 'msf/core/web_services/servlet/api_docs_servlet'
+require 'msf/core/web_services/servlet/async_callback_servlet'
 require 'msf/core/web_services/servlet/auth_servlet'
 require 'msf/core/web_services/servlet/host_servlet'
 require 'msf/core/web_services/servlet/note_servlet'
@@ -33,6 +34,7 @@ class MetasploitApiApp < Sinatra::Base
 
   # Servlet registration
   register ApiDocsServlet
+  register AsyncCallbackServlet
   register AuthServlet
   register HostServlet
   register VulnServlet

--- a/lib/msf/core/web_services/servlet/api_docs_servlet.rb
+++ b/lib/msf/core/web_services/servlet/api_docs_servlet.rb
@@ -1,5 +1,6 @@
 require 'swagger/blocks'
 load 'documentation/api/v1/root_api_doc.rb'
+load 'documentation/api/v1/async_callback_api_doc.rb'
 load 'documentation/api/v1/auth_api_doc.rb'
 load 'documentation/api/v1/credential_api_doc.rb'
 load 'documentation/api/v1/db_export_api_doc.rb'
@@ -46,6 +47,7 @@ module ApiDocsServlet
     lambda {
       swaggered_classes = [
           RootApiDoc,
+          AsyncCallbackApiDoc,
           AuthApiDoc,
           CredentialApiDoc,
           DbExportApiDoc,

--- a/lib/msf/core/web_services/servlet/async_callback_servlet.rb
+++ b/lib/msf/core/web_services/servlet/async_callback_servlet.rb
@@ -1,0 +1,77 @@
+module AsyncCallbackServlet
+
+  def self.api_path
+    '/api/v1/async-callbacks'
+  end
+
+  def self.api_path_with_id
+    "#{AsyncCallbackServlet.api_path}/?:id?"
+  end
+
+  def self.registered(app)
+    app.get AsyncCallbackServlet.api_path_with_id, &get_async_callback
+    app.post AsyncCallbackServlet.api_path, &create_async_callback
+    app.put AsyncCallbackServlet.api_path_with_id, &update_async_callback
+    app.delete AsyncCallbackServlet.api_path, &delete_async_callback
+  end
+
+  #######
+  private
+  #######
+
+  def self.create_async_callback
+    lambda {
+      warden.authenticate!
+      begin
+        opts = parse_json_request(request, false)
+        data = get_db.create_async_callback(opts)
+        set_json_data_response(response: data)
+      rescue => e
+        print_error_and_create_response(error: e, message: 'There was an error creating the async callback', code: 500)
+      end
+    }
+  end
+
+  def self.get_async_callback
+    lambda {
+      warden.authenticate!
+      begin
+        sanitized_params = sanitize_params(params, env['rack.request.query_hash'])
+        data = get_db.async_callbacks(sanitized_params)
+        data = data.first if is_single_object?(data, sanitized_params)
+        set_json_data_response(response: data)
+      rescue => e
+        print_error_and_create_response(error: e, message: 'There was an error getting the async callback', code: 500)
+      end
+    }
+  end
+
+  def self.update_async_callback
+    lambda {
+      warden.authenticate!
+      begin
+        opts = parse_json_request(request, false)
+        tmp_params = sanitize_params(params)
+        opts[:id] = tmp_params[:id] if tmp_params[:id]
+        data = get_db.update_async_callback(opts)
+        set_json_data_response(response: data)
+      rescue => e
+        print_error_and_create_response(error: e, message: 'There was an error updating the async callback', code: 500)
+      end
+    }
+  end
+
+  def self.delete_async_callback
+    lambda {
+      warden.authenticate!
+      begin
+        opts = parse_json_request(request, false)
+        data = get_db.delete_async_callback(opts)
+        set_json_data_response(response: data)
+      rescue => e
+        print_error_and_create_response(error: e, message: 'There was an error deleting the async callback', code: 500)
+      end
+    }
+  end
+
+end

--- a/lib/msf/core/web_services/servlet/async_callback_servlet.rb
+++ b/lib/msf/core/web_services/servlet/async_callback_servlet.rb
@@ -4,12 +4,12 @@ module AsyncCallbackServlet
     '/api/v1/async-callbacks'
   end
 
-  def self.api_path_with_id
-    "#{AsyncCallbackServlet.api_path}/?:id?"
+  def self.api_path_with_uuid
+    "#{AsyncCallbackServlet.api_path}/?:uuid?"
   end
 
   def self.registered(app)
-    app.get AsyncCallbackServlet.api_path_with_id, &get_async_callback
+    app.get AsyncCallbackServlet.api_path_with_uuid, &get_async_callback
     app.post AsyncCallbackServlet.api_path, &create_async_callback
   end
 

--- a/lib/msf/core/web_services/servlet/async_callback_servlet.rb
+++ b/lib/msf/core/web_services/servlet/async_callback_servlet.rb
@@ -11,8 +11,6 @@ module AsyncCallbackServlet
   def self.registered(app)
     app.get AsyncCallbackServlet.api_path_with_id, &get_async_callback
     app.post AsyncCallbackServlet.api_path, &create_async_callback
-    app.put AsyncCallbackServlet.api_path_with_id, &update_async_callback
-    app.delete AsyncCallbackServlet.api_path, &delete_async_callback
   end
 
   #######
@@ -45,33 +43,4 @@ module AsyncCallbackServlet
       end
     }
   end
-
-  def self.update_async_callback
-    lambda {
-      warden.authenticate!
-      begin
-        opts = parse_json_request(request, false)
-        tmp_params = sanitize_params(params)
-        opts[:id] = tmp_params[:id] if tmp_params[:id]
-        data = get_db.update_async_callback(opts)
-        set_json_data_response(response: data)
-      rescue => e
-        print_error_and_create_response(error: e, message: 'There was an error updating the async callback', code: 500)
-      end
-    }
-  end
-
-  def self.delete_async_callback
-    lambda {
-      warden.authenticate!
-      begin
-        opts = parse_json_request(request, false)
-        data = get_db.delete_async_callback(opts)
-        set_json_data_response(response: data)
-      rescue => e
-        print_error_and_create_response(error: e, message: 'There was an error deleting the async callback', code: 500)
-      end
-    }
-  end
-
 end


### PR DESCRIPTION
## WIP: Ready for testing and feedback.

This addition to the data services and web services adds support for asynchronous payloads (aka "pingback payloads") to be tracked, and is meant to coincide with a [matching pull request to the metasploit data model](https://github.com/rapid7/metasploit_data_models/pull/179).

## Verification

0. If https://github.com/rapid7/metasploit_data_models/pull/179 has not yet been merged, then you must first complete the `Landing` section contained within that PR.  Use the `Verification` instructions within that same PR to confirm that all functionality works as expected.

1. Run `./msfdb reinit`, walk through the steps, and copy the security token to your clipboard:

```
$ ./msfdb reinit
[...]
MSF web service username: postgres
MSF web service password: [...]
MSF web service user API token: 25acf47a21b2a7b1f18f7a45e13cdd32ae6e1200bcd9be75dc294e31423e05becacfe7b6431db95b
```

2. Start the database and web services: `./msfdb start`.  Feel free to append `-a 0.0.0.0` to make the web server externally accessible, eg. if you'll be using a browser outside the VM.

3. Load Swagger by browsing to `https://127.0.0.1:5443/api/v1/api-docs`.  Note, I had to use Chrome on Windows, since Firefox in Ubuntu wasn't loading the page.  Also, note that the page loads external resources, so you may need to configure browser security plugins and confirm your test environment is Internet-connected.

4. In the top-right corner, click the `Authenticate` button

![image](https://user-images.githubusercontent.com/35073726/54640127-081c5800-4a5d-11e9-9511-4aef049f65fc.png)

5.  Paste in the token from Step 1 and click "Authorize".

![image](https://user-images.githubusercontent.com/35073726/54640158-17030a80-4a5d-11e9-9218-2e978878d97c.png)

6. Scroll down to the first header, `async_callback` and confirm that three endpoints are shown: GET, POST, and GET:

![image](https://user-images.githubusercontent.com/35073726/54640240-4fa2e400-4a5d-11e9-85e0-f7f315fa603f.png)

7. Expand the first endpoint, `GET ​/api​/v1​/async-callbacks`, click the `Try It Out` button, enter `default` for the Workspace, and click the Execute button:

![image](https://user-images.githubusercontent.com/35073726/54640330-8aa51780-4a5d-11e9-9a32-e0e14698a194.png)

8. Confirm that the first endpoint returned an empty `data` array (since we cleared the database in Step 1):

![image](https://user-images.githubusercontent.com/35073726/54640804-a78e1a80-4a5e-11e9-8342-3bdfe943de49.png)

8. Expand the second endpoint, `POST ​/api​/v1​/async-callbacks`, click the `Try It Out` button, confirm that `default` is used for the Workspace, and click the Execute button:

![image](https://user-images.githubusercontent.com/35073726/54640951-f50a8780-4a5e-11e9-90bd-86c26f61f67b.png)

9. Repeat step 7, and confirm that your callback information is returned in the data array.

10. Expand the third endpoint, `GET ​/api​/v1​/async-callbacks/{uuid}`, click the `Try It Out` button, enter the UUID from above and `default` as the Workspace, then click the Execute button:

![image](https://user-images.githubusercontent.com/35073726/54641025-25eabc80-4a5f-11e9-802a-f7b221cd757f.png)

11. Test the second POST endpoint again with a new URL.

12. Test both GET endpoints and confirm they show all callbacks that meet your search criteria.

## Random troubleshooting steps

If Swagger returns a TypeError, confirm that the `msfdb` web server started.  You should see it listening in your `netstat` on port 5443.  If it's running, then refresh the Swagger page, as your SSL cert may have been regenerated and your requests are failing in the background.

If you get back an error within Swagger, like an Internal Server Error, check your `~.msf4/msf-ws.log`.

If `msfdb` doesn't start, use the `-d` flag to enable debugging, then run the commands manually.