### PR TITLE
Escape parentheses in passwords for postgres regex

### DIFF
--- a/lib/metasploit/framework/data_service/proxy/login_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/login_data_proxy.rb
@@ -38,7 +38,7 @@ module LoginDataProxy
       # The creds search uses regex for username and password lookup.
       # Alter the search string to only look for exact matches to avoid updating unexpected entries.
       core_opts[:user] = "^#{opts.fetch(:username)}$" if opts[:username]
-      core_opts[:pass] = "^#{opts.fetch(:private_data)}$" if opts[:private_data]
+      core_opts[:pass] = "^#{opts.fetch(:private_data).gsub(/[()]/, '('=>'\(', ')'=>'\)')}$" if opts[:private_data]
       core_opts[:ports] = [ opts.fetch(:port) ] if opts[:port]
       core_opts[:host_ranges] = [ opts.fetch(:address) ] if opts[:address]
       core_opts[:svcs] = [ opts.fetch(:service_name) ] if opts[:service_name]


### PR DESCRIPTION
Prevents stacktraces in *_login modules when PASSWORD contains parenthesis characters (due to *PG::InvalidRegularExpression: ERROR:  invalid regular expression: parentheses () not balanced*) on unsuccessful login. 

Explicitly escapes '(' and ')' characters before attempting to select password value from database.

## Verification
- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/ssh/ssh_login`
- [ ] `set RHOSTS some.ssh.host`
- [ ] `set USERNAME root`
- [ ] `set PASSWORD foo)bar`
- [ ] `run`