### PR TITLE
Fix typo in ffautoregen plugin

### DIFF
--- a/plugins/ffautoregen.rb
+++ b/plugins/ffautoregen.rb
@@ -32,7 +32,7 @@ class Plugin::FFAutoRegen < Msf::Plugin
     #
     def commands
       {
-        "ffautoregen" => "Automatically regenerate the document when the exploti source changes"
+        "ffautoregen" => "Automatically regenerate the document when the exploit source changes"
       }
     end
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/22535454/54743549-5d906a80-4bff-11e9-979d-0508e7c17d5d.png)
