### PR TITLE
Creds export to jtr format

### DIFF
--- a/lib/metasploit/framework/jtr/formatter.rb
+++ b/lib/metasploit/framework/jtr/formatter.rb
@@ -1,0 +1,64 @@
+# This method takes a {framework.db.cred}, and normalizes it
+# to the string format JTR is expecting.
+#
+# @param [credClass] a credential from framework.db
+# @return [String] the hash in jtr format or nil on no mach
+def hash_to_jtr(cred)
+  case cred.private.type
+  when 'Metasploit::Credential::NTLMHash'
+    return "#{cred.public.username}:#{cred.id}:#{cred.private.data}:::#{cred.id}"
+  when 'Metasploit::Credential::PostgresMD5'
+    if cred.private.jtr_format =~ /postgres|raw-md5/
+      # john --list=subformats | grep 'PostgreSQL MD5'
+      #UserFormat = dynamic_1034  type = dynamic_1034: md5($p.$u) (PostgreSQL MD5)
+      hash_string = cred.private.data
+      hash_string.gsub!(/^md5/, '')
+      return "#{cred.public.username}:$dynamic_1034$#{hash_string}"
+    end
+  when 'Metasploit::Credential::NonreplayableHash'
+    case cred.private.jtr_format
+      # oracle 11+ password hash descriptions:
+      # this password is stored as a long ascii string with several sections
+      # https://www.trustwave.com/en-us/resources/blogs/spiderlabs-blog/changes-in-oracle-database-12c-password-hashes/
+      # example:
+      # hash = []
+      # hash << "S:8F2D65FB5547B71C8DA3760F10960428CD307B1C6271691FC55C1F56554A;"
+      # hash << "H:DC9894A01797D91D92ECA1DA66242209;"
+      # hash << "T:23D1F8CAC9001F69630ED2DD8DF67DD3BE5C470B5EA97B622F757FE102D8BF14BEDC94A3CC046D10858D885DB656DC0CBF899A79CD8C76B788744844CADE54EEEB4FDEC478FB7C7CBFBBAC57BA3EF22C"
+      # puts hash.join('')
+      # S: = 60 characters -> sha1(password + salt (10 bytes))
+      #         40 char sha1, 20 char salt
+      #         hash is 8F2D65FB5547B71C8DA3760F10960428CD307B1C
+      #         salt is 6271691FC55C1F56554A
+      # H: = 32 characters
+      #         legacy MD5
+      # T: = 160 characters
+      #         PBKDF2-based SHA512 hash specific to 12C (12.1.0.2+)
+    when /raw-sha1|oracle11/ # oracle 11
+      if cred.private.data =~ /S:([\dA-F]{60})/ # oracle 11
+        return "#{cred.public.username}:#{$1}:#{cred.id}:"
+      end
+    when /oracle12c/
+      if cred.private.data =~ /T:([\dA-F]{160})/ # oracle 12c
+        return "#{cred.public.username}:$oracle12c$#{$1.downcase}:#{cred.id}:"
+      end
+    when /dynamic_1506/
+      if cred.private.data =~ /H:([\dA-F]{32})/ # oracle 11
+        return "#{cred.public.username.upcase}:$dynamic_1506$#{$1}:#{cred.id}:"
+      end
+    when /oracle/ # oracle
+      if cred.private.jtr_format.start_with?('des') # 'des,oracle', not oracle11/12c
+        return "#{cred.public.username}:O$#{cred.public.username}##{cred.private.data}:#{cred.id}:"
+      end
+    when /md5|des|bsdi|crypt|bf/
+      # md5(crypt), des(crypt), b(crypt)
+      return "#{cred.public.username}:#{cred.private.data}:::::#{cred.id}:"
+    else
+      # /mysql|mysql-sha1/
+      # /mssql|mssql05|mssql12/
+      # /des(crypt)/
+      return "#{cred.public.username}:#{cred.private.data}:#{cred.id}:"
+    end
+  end
+  nil
+end

--- a/lib/msf/core/auxiliary/jtr.rb
+++ b/lib/msf/core/auxiliary/jtr.rb
@@ -4,6 +4,7 @@ require 'fileutils'
 require 'rex/proto/ntlm/crypt'
 require 'metasploit/framework/jtr/cracker'
 require 'metasploit/framework/jtr/wordlist'
+require 'metasploit/framework/jtr/formatter'
 
 
 module Msf
@@ -95,71 +96,6 @@ module Auxiliary::JohnTheRipper
         workspace: myworkspace
     )
     wordlist.to_file(max_len)
-  end
-
-  # This method takes a {framework.db.cred}, and normalizes it
-  # to the string format JTR is expecting.
-  #
-  # @param [credClass] a credential from framework.db
-  # @return [String] the hash in jtr format or nil on no mach
-  def hash_to_jtr(cred)
-    case cred.private.type
-    when 'Metasploit::Credential::NTLMHash'
-      return "#{cred.public.username}:#{cred.id}:#{cred.private.data}:::#{cred.id}"
-    when 'Metasploit::Credential::PostgresMD5'
-      if cred.private.jtr_format =~ /postgres|raw-md5/
-        # john --list=subformats | grep 'PostgreSQL MD5'
-        #UserFormat = dynamic_1034  type = dynamic_1034: md5($p.$u) (PostgreSQL MD5)
-        hash_string = cred.private.data
-        hash_string.gsub!(/^md5/, '')
-        return "#{cred.public.username}:$dynamic_1034$#{hash_string}"
-      end
-    when 'Metasploit::Credential::NonreplayableHash'
-      case cred.private.jtr_format
-        # oracle 11+ password hash descriptions:
-        # this password is stored as a long ascii string with several sections
-        # https://www.trustwave.com/en-us/resources/blogs/spiderlabs-blog/changes-in-oracle-database-12c-password-hashes/
-        # example:
-        # hash = []
-        # hash << "S:8F2D65FB5547B71C8DA3760F10960428CD307B1C6271691FC55C1F56554A;"
-        # hash << "H:DC9894A01797D91D92ECA1DA66242209;"
-        # hash << "T:23D1F8CAC9001F69630ED2DD8DF67DD3BE5C470B5EA97B622F757FE102D8BF14BEDC94A3CC046D10858D885DB656DC0CBF899A79CD8C76B788744844CADE54EEEB4FDEC478FB7C7CBFBBAC57BA3EF22C"
-        # puts hash.join('')
-        # S: = 60 characters -> sha1(password + salt (10 bytes))
-        #         40 char sha1, 20 char salt
-        #         hash is 8F2D65FB5547B71C8DA3760F10960428CD307B1C
-        #         salt is 6271691FC55C1F56554A
-        # H: = 32 characters
-        #         legacy MD5
-        # T: = 160 characters
-        #         PBKDF2-based SHA512 hash specific to 12C (12.1.0.2+)
-      when /raw-sha1|oracle11/ # oracle 11
-        if cred.private.data =~ /S:([\dA-F]{60})/ # oracle 11
-          return "#{cred.public.username}:#{$1}:#{cred.id}:"
-        end
-      when /oracle12c/
-        if cred.private.data =~ /T:([\dA-F]{160})/ # oracle 12c
-          return "#{cred.public.username}:$oracle12c$#{$1.downcase}:#{cred.id}:"
-        end
-      when /dynamic_1506/
-        if cred.private.data =~ /H:([\dA-F]{32})/ # oracle 11
-          return "#{cred.public.username.upcase}:$dynamic_1506$#{$1}:#{cred.id}:"
-        end
-      when /oracle/ # oracle
-        if cred.private.jtr_format.start_with?('des') # 'des,oracle', not oracle11/12c
-          return "#{cred.public.username}:O$#{cred.public.username}##{cred.private.data}:#{cred.id}:"
-        end
-      when /md5|des|bsdi|crypt|bf/
-        # md5(crypt), des(crypt), b(crypt)
-        return "#{cred.public.username}:#{cred.private.data}:::::#{cred.id}:"
-      else
-        # /mysql|mysql-sha1/
-        # /mssql|mssql05|mssql12/
-        # /des(crypt)/
-        return "#{cred.public.username}:#{cred.private.data}:#{cred.id}:"
-      end
-    end
-    nil
   end
 end
 end

--- a/lib/msf/ui/console/command_dispatcher/creds.rb
+++ b/lib/msf/ui/console/command_dispatcher/creds.rb
@@ -578,8 +578,6 @@ class Creds
     return tabs
   end
 
-  def creds_export
-  end
 end
 
 end end end end

--- a/lib/msf/ui/console/command_dispatcher/creds.rb
+++ b/lib/msf/ui/console/command_dispatcher/creds.rb
@@ -531,7 +531,7 @@ class Creds
     end
 
     if output_file.nil?
-        print_line(tbl.to_s)
+      print_line(tbl.to_s)
     else
       if output_file.end_with? '.jtr'
         hashlist = ::File.open(output_file, "wb")


### PR DESCRIPTION
Fixes #11575

This allow `creds -o` to now export to John the Ripper format if a '.jtr' extension is put on the output file name.  Will allow for additional overloading if say hashcat functionality is ever added

I thought this was more graceful than changing to a `creds export` type syntax.

```
msf5 > creds -o /tmp/csv
[*] Wrote creds to /tmp/csv
msf5 > head /tmp/csv
[*] exec: head /tmp/csv

host,origin,service,public,private,realm,private_type,JtR Format
"","","","des_password","password","","Password",""
"","","","des_password","rEK1ecacw.7.c","","Nonreplayable hash","des"
"","","","md5_password","password","","Password",""
"","","","md5_password","$1$O3JMY.Tw$AdLnLjQ/5jXF9.MTp3gHv/","","Nonreplayable hash","md5"
"","","","bsdi_password","password","","Password",""
"","","","bsdi_password","_J9..K0AyUubDrfOgO4s","","Nonreplayable hash","bsdi"
"","","","sha256_password","password","","Password",""
"","","","sha256_password","$5$MnfsQ4iN$ZMTppKN16y/tIsUYs/obHlhdP.Os80yXhTurpBMUbA5","","Nonreplayable hash","sha256,crypt"
"","","","sha512_password","password","","Password",""
msf5 > creds -o /tmp/hashes.jtr
[*] Wrote creds to /tmp/hashes.jtr
msf5 > head /tmp/hashes.jtr
[*] exec: head /tmp/hashes.jtr

des_password:rEK1ecacw.7.c:::::4:
md5_password:$1$O3JMY.Tw$AdLnLjQ/5jXF9.MTp3gHv/:::::5:
bsdi_password:_J9..K0AyUubDrfOgO4s:::::6:
sha256_password:$5$MnfsQ4iN$ZMTppKN16y/tIsUYs/obHlhdP.Os80yXhTurpBMUbA5:::::7:
sha512_password:$6$zWwwXKNj$gLAOoZCjcr8p/.VgV/FkGC3NX7BsXys3KHYePfuIGMNjY83dVxugPYlxVg/evpcVEJLT/rSwZcDMlVVf/bhf.1:::::8:
blowfish_password:$2a$05$bvIG6Nmid91Mu9RcmmWZfO5HJIMCT8riNW0hEp8f6/FuA2/mHZFpe:::::9:
mssql05_toto:0x01004086CEB6BF932BC4151A1AF1F13CD17301D70816A8886908:12:
mssql_foo:0x0100A607BA7C54A24D17B565C59F1743776A10250F581D482DA8B6D6261460D3F53B279CC6913CE747006A2E3254:13:
mssql12_Password1!:0x0200F733058A07892C5CACE899768F89965F6BD1DED7955FE89E1C9A10E27849B0B213B5CE92CC9347ECCB34C3EFADAF2FD99BFFECD8D9150DD6AACB5D409A9D2652A4E0AF16:14:
mysql_probe:445ff82636a7ba59:15:
msf5 > 
```