### PR TITLE
return unless res

### DIFF
--- a/modules/exploits/linux/http/panos_readsessionvars.rb
+++ b/modules/exploits/linux/http/panos_readsessionvars.rb
@@ -125,7 +125,13 @@ class MetasploitModule < Msf::Exploit::Remote
       'ctype'  => "application/json",
       'data'   => create_directory_json
     )
-    unless res && res.body.to_s.index('Async request enqueued')
+
+    unless res
+      print_error('Connection failed')
+      return
+    end
+
+    unless res.body.to_s.index('Async request enqueued')
       print_error("Unexpected response when calling Administrator.get method: #{res.code} #{res.message}")
       return
     end

--- a/modules/exploits/linux/http/panos_readsessionvars.rb
+++ b/modules/exploits/linux/http/panos_readsessionvars.rb
@@ -84,7 +84,12 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'GET',
       'uri'    => "/esp/cms_changeDeviceContext.esp?device=#{dev_str_1}:#{dev_str_2}%27\";user|s.\"#{user_id}\";"
     )
-    unless res && res.body.to_s.index('@start@Success@end@')
+    unless res
+      print_error('Connection failed')
+      return
+    end
+
+    unless res.body.to_s.index('@start@Success@end@')
       print_error("Unexpected response when creating the corrupted session cookie: #{res.code} #{res.message}")
       return
     end


### PR DESCRIPTION
Author of #11586 hasn't replied for a few days.

This change updates the `modules/exploits/linux/http/panos_readsessionvars.rb` error handling such that it makes sense, instead of throwing `NoMethodError`.
