### PR TITLE
create hash identifier library

### DIFF
--- a/lib/metasploit/framework/hashes/identify.rb
+++ b/lib/metasploit/framework/hashes/identify.rb
@@ -1,0 +1,35 @@
+# This method takes a {str}, and attempt to determine what type
+# of hash it is, and returns a cred:jtr formatted string.
+#
+# @param [str] a string of a hashed password
+# @return [String] the jtr type or empty string on no match
+
+# Resource list:
+#  https://code.google.com/archive/p/hash-identifier/
+#  https://hashcat.net/wiki/doku.php?id=example_hashes
+#  http://pentestmonkey.net/cheat-sheet/john-the-ripper-hash-formats
+#  https://openwall.info/wiki/john/sample-hashes
+#  QNX formats -> https://moar.so/blog/qnx-password-hash-formats.html
+
+def identify_hash(hash)
+  hash = hash.strip
+  case
+    when hash.start_with?('$1$')
+      return 'md5'
+    when hash.start_with?('$2a$'), hash.start_with?('$2y$')
+      return 'bf' #bcrypt
+    when hash.start_with?('$5$')
+      return 'sha256,crypt'
+    when hash.start_with?('$6$')
+      return 'sha512,crypt'
+    when hash.start_with?('@S@')
+      return 'qnx,sha512'
+    when hash.start_with?('@s@')
+      return 'qnx,sha256'
+    when hash.start_with?('@m@')
+      return 'qnx,md5'
+    when hash.start_with?('_')
+      return 'des,bsdi,crypt'
+  end
+  return''
+end

--- a/lib/metasploit/framework/jtr/formatter.rb
+++ b/lib/metasploit/framework/jtr/formatter.rb
@@ -53,6 +53,10 @@ def hash_to_jtr(cred)
     when /md5|des|bsdi|crypt|bf/
       # md5(crypt), des(crypt), b(crypt)
       return "#{cred.public.username}:#{cred.private.data}:::::#{cred.id}:"
+    when /qnx/
+      # https://moar.so/blog/qnx-password-hash-formats.html
+      hash = cred.private.data.end_with?(':0:0') ? cred.private.data : "#{cred.private.data}:0:0"
+      return "#{cred.public.username}:#{hash}"
     else
       # /mysql|mysql-sha1/
       # /mssql|mssql05|mssql12/

--- a/lib/msf/core/auxiliary/juniper.rb
+++ b/lib/msf/core/auxiliary/juniper.rb
@@ -1,4 +1,7 @@
 # -*- coding: binary -*-
+
+require 'metasploit/framework/hashes/identify'
+
 module Msf
 
 ###
@@ -147,16 +150,7 @@ module Auxiliary::Juniper
 
     if /root-authentication[\s]+\{[\s]+encrypted-password "(?<root_hash>[^"]+)";/i =~ config
       root_hash = root_hash.strip
-      case
-        when root_hash.start_with?('$1$')
-          jtr_format = 'md5'
-        when root_hash.start_with?('$5$')
-          jtr_format = 'sha256,crypt'
-        when root_hash.start_with?('$6$')
-          jtr_format = 'sha512,crypt'
-        else
-          jtr_format = ''
-      end
+      jtr_format = identify_hash root_hash
 
       print_good("root password hash: #{root_hash}")
       cred = credential_data.dup
@@ -173,16 +167,8 @@ module Auxiliary::Juniper
       user_uid  = result[1].strip
       user_permission = result[2].strip
       user_hash = result[3].strip
-      case
-        when user_hash.start_with?('$1$')
-          jtr_format = 'md5'
-        when user_hash.start_with?('$5$')
-          jtr_format = 'sha256,crypt'
-        when user_hash.start_with?('$6$')
-          jtr_format = 'sha512,crypt'
-        else
-          jtr_format = ''
-      end
+      jtr_format = identify_hash user_hash
+
       print_good("User #{user_uid} named #{user_name} in group #{user_permission} found with password hash #{user_hash}.")
       cred = credential_data.dup
       cred[:username] = user_name

--- a/modules/post/linux/gather/hashdump.rb
+++ b/modules/post/linux/gather/hashdump.rb
@@ -3,6 +3,8 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
+require 'metasploit/framework/hashes/identify'
+
 class MetasploitModule < Msf::Post
   include Msf::Post::File
   include Msf::Post::Linux::Priv
@@ -34,19 +36,9 @@ class MetasploitModule < Msf::Post
       john_file = unshadow(passwd_file, shadow_file)
       john_file.each_line do |l|
         hash_parts = l.split(':')
-        case
-          when hash_parts[1].start_with?('$1$')
-            jtr_format = 'md5'
-          when hash_parts[1].start_with?('$2a$'), hash_parts[1].start_with?('$2y$')
-            jtr_format = 'bf'
-          when hash_parts[1].start_with?('$5$')
-            jtr_format = 'sha256,crypt'
-          when hash_parts[1].start_with?('$6$')
-            jtr_format = 'sha512,crypt'
-          when hash_parts[1].start_with?('_')
-            jtr_format = 'des,bsdi,crypt'
-          else
-            jtr_format = 'des,bsdi,crypt'
+        jtr_format = identify_hash hash_parts[1]
+        if jtr_format.empty? #overide the default
+          jtr_format = 'des,bsdi,crypt'
         end
         credential_data = {
             jtr_format: jtr_format,

--- a/modules/post/solaris/gather/hashdump.rb
+++ b/modules/post/solaris/gather/hashdump.rb
@@ -3,6 +3,8 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
+require 'metasploit/framework/hashes/identify'
+
 class MetasploitModule < Msf::Post
   include Msf::Post::File
   include Msf::Post::Solaris::Priv
@@ -35,19 +37,9 @@ class MetasploitModule < Msf::Post
       john_file = unshadow(passwd_file, shadow_file)
       john_file.each_line do |l|
         hash_parts = l.split(':')
-        case
-          when hash_parts[1].start_with?('$1$')
-            jtr_format = 'md5'
-          when hash_parts[1].start_with?('$2a$'), hash_parts[1].start_with?('$2y$')
-            jtr_format = 'bf'
-          when hash_parts[1].start_with?('$5$')
-            jtr_format = 'sha256,crypt'
-          when hash_parts[1].start_with?('$6$')
-            jtr_format = 'sha512,crypt'
-          when hash_parts[1].start_with?('_')
-            jtr_format = 'des,bsdi,crypt'
-          else
-            jtr_format = 'des,bsdi,crypt'
+        jtr_format = identify_hash hash_parts[1]
+        if jtr_format.empty? #overide the default      
+          jtr_format = 'des,bsdi,crypt'
         end
         credential_data = {
             jtr_format: jtr_format,

--- a/modules/post/solaris/gather/hashdump.rb
+++ b/modules/post/solaris/gather/hashdump.rb
@@ -38,7 +38,7 @@ class MetasploitModule < Msf::Post
       john_file.each_line do |l|
         hash_parts = l.split(':')
         jtr_format = identify_hash hash_parts[1]
-        if jtr_format.empty? #overide the default      
+        if jtr_format.empty? #overide the default
           jtr_format = 'des,bsdi,crypt'
         end
         credential_data = {


### PR DESCRIPTION
https://github.com/rapid7/metasploit-framework/pull/11335#issuecomment-468125765

This PR takes code from a few post libraries that pull hashes and need to identify which type of hash they are, to then get the `jtr` format, and puts it in a library.
It also adds qnx hash identification and output (untested).  

This is not meant to be an all in one solution the way hash-id or hash-identifier are, this just centralizes the few hash types we actually have modules to deal with (and are nonreplayablehashes, as opposed to nt/lm or postgres)

- [x] @bcoles  if you have a qnx you could hashdump, then run a `creds -o qnx.jtr` it *should* output them in a jtr friendly way.  Please verify.  I did not add it to the linux cracker module.


```
msf5 post(linux/gather/hashdump) > run

[+] ubuntu:$6$s/P86y1v$3iCYV5UoCwcxqmEns.LoC8WNahnwdNNCwABJ9vNzOY5bR2INug.ErrKZpG6LL06KxD7I5292iJpbxIna3pjKH.:1000:1000:ubuntu,,,:/home/ubuntu:/bin/bash
[+] Unshadowed Password File: /root/.msf4/loot/20190323140036_default_192.168.2.139_linux.hashes_617066.txt
[*] Post module execution completed
msf5 post(linux/gather/hashdump) > creds
Credentials
===========

host           origin         service       public              private                                                                                                                                                                                                                                                               realm  private_type        JtR Format
----           ------         -------       ------              -------                                                                                                                                                                                                                                                               -----  ------------        ----------
               111.111.1.111                ubuntu              $6$s/P86y1v$3iCYV5UoCwcxqmEns.LoC8WNahnwdNNCwABJ9vNzOY5bR2INug.ErrKZpG6LL06KxD7I5292iJpbxIna3pjKH.                                                                                                                                                                           Nonreplayable hash  sha512,crypt

```