### PR TITLE
Add missing PayloadDataProxy autoload entry

### DIFF
--- a/lib/metasploit/framework/data_service/proxy/data_proxy_auto_loader.rb
+++ b/lib/metasploit/framework/data_service/proxy/data_proxy_auto_loader.rb
@@ -20,6 +20,7 @@ module DataProxyAutoLoader
   autoload :DbImportDataProxy, 'metasploit/framework/data_service/proxy/db_import_data_proxy'
   autoload :VulnAttemptDataProxy, 'metasploit/framework/data_service/proxy/vuln_attempt_data_proxy'
   autoload :MsfDataProxy, 'metasploit/framework/data_service/proxy/msf_data_proxy'
+  autoload :PayloadDataProxy, 'metasploit/framework/data_service/proxy/payload_data_proxy'
 
   include ServiceDataProxy
   include HostDataProxy
@@ -39,4 +40,5 @@ module DataProxyAutoLoader
   include DbImportDataProxy
   include VulnAttemptDataProxy
   include MsfDataProxy
+  include PayloadDataProxy
 end

--- a/lib/metasploit/framework/data_service/proxy/data_proxy_auto_loader.rb
+++ b/lib/metasploit/framework/data_service/proxy/data_proxy_auto_loader.rb
@@ -8,7 +8,6 @@ module DataProxyAutoLoader
   autoload :WorkspaceDataProxy, 'metasploit/framework/data_service/proxy/workspace_data_proxy'
   autoload :NoteDataProxy, 'metasploit/framework/data_service/proxy/note_data_proxy'
   autoload :WebDataProxy, 'metasploit/framework/data_service/proxy/web_data_proxy'
-  autoload :WebDataProxy, 'metasploit/framework/data_service/proxy/web_data_proxy'
   autoload :ServiceDataProxy, 'metasploit/framework/data_service/proxy/service_data_proxy'
   autoload :SessionDataProxy, 'metasploit/framework/data_service/proxy/session_data_proxy'
   autoload :ExploitDataProxy, 'metasploit/framework/data_service/proxy/exploit_data_proxy'

--- a/lib/metasploit/framework/data_service/proxy/payload_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/payload_data_proxy.rb
@@ -3,6 +3,7 @@ module PayloadDataProxy
   def payloads(opts)
     begin
       self.data_service_operation do |data_service|
+        add_opts_workspace(opts)
         data_service.payloads(opts)
       end
     rescue => e
@@ -13,6 +14,7 @@ module PayloadDataProxy
   def create_payload(opts)
     begin
       self.data_service_operation do |data_service|
+        add_opts_workspace(opts)
         data_service.create_payload(opts)
       end
     rescue => e

--- a/lib/msf/core/db_manager/payload.rb
+++ b/lib/msf/core/db_manager/payload.rb
@@ -8,7 +8,8 @@ module Msf::DBManager::Payload
         end
       end
 
-      Mdm::Payload.create!(opts)
+      wspace = Msf::Util::DBManager.process_opts_workspace(opts, framework)
+      wspace.payloads.create!(opts)
     end
   end
 

--- a/lib/msf/core/payload/uuid/options.rb
+++ b/lib/msf/core/payload/uuid/options.rb
@@ -92,9 +92,7 @@ module Msf::Payload::UUID::Options
       arch: uuid.arch,
       platform: uuid.platform,
       timestamp: uuid.timestamp,
-      workspace: framework.db.workspace,
-      # payload: self.fullname,
-      # datastore: self.datastore
+      workspace: framework.db.workspace
     })
 
     if datastore['PayloadUUIDSeed'].to_s.length > 0


### PR DESCRIPTION
Adds a missing `PayloadDataProxy` autoload entry in the `DataProxyAutoLoader`. This was overlooked during a round of cleanup in #11532. In addition, this removes a duplicate autoload entry for `WebDataProxy`.

## Verification

Follow verification steps from #10675, except start the web service using `msfdb` rather than `msfdb_ws`.