### PR TITLE
Add defensive check to Msf::Payload::UUID::Options#record_payload_uuid_url

### DIFF
--- a/lib/msf/core/payload/uuid/options.rb
+++ b/lib/msf/core/payload/uuid/options.rb
@@ -114,10 +114,12 @@ module Msf::Payload::UUID::Options
         workspace: framework.db.workspace
     }
     payload = framework.db.payloads(payload_info).first
-    urls = payload.urls.nil? ? [] : payload.urls
-    urls << url
-    urls.uniq!
-    framework.db.update_payload({id: payload.id, urls: urls})
+    unless payload.nil?
+      urls = payload.urls.nil? ? [] : payload.urls
+      urls << url
+      urls.uniq!
+      framework.db.update_payload({id: payload.id, urls: urls})
+    end
   end
 
 end


### PR DESCRIPTION
Adds a defensive check that a payload was returned before being processed in the `Msf::Payload::UUID::Options#record_payload_uuid_url` method. @busterb made the suggestion after reviewing and landing #11631.

## Verification

Follow steps to reproduce from #11620.