### PR TITLE
Complain loudly if module has no 'Author' metadata.

### DIFF
--- a/spec/file_fixtures/modules/auxiliary/auxiliary_tidy.rb
+++ b/spec/file_fixtures/modules/auxiliary/auxiliary_tidy.rb
@@ -5,15 +5,11 @@
 
 class MetasploitModule < Msf::Auxiliary
   def initialize(info = {})
-    super(
-      update_info(
-        info,
-        'Name'            => 'Tidy Auxiliary Module for RSpec'
-        'Description'     => 'Test!'
-        },
-        'Author'         => %w(Unknown),
-        'License'        => MSF_LICENSE,
-      )
-    )
+    super(update_info(info,
+      'Name'        => 'Tidy Auxiliary Module for RSpec'
+      'Description' => 'Test!'
+      'Author'      => 'Unknown',
+      'License'     => MSF_LICENSE
+    ))
   end
 end

--- a/spec/file_fixtures/modules/payloads/payload_tidy.rb
+++ b/spec/file_fixtures/modules/payloads/payload_tidy.rb
@@ -4,14 +4,13 @@
 ##
 
 
-module Metasploit
+module MetasploitModule
   def initialize(info = {})
-    super(
-      merge_info(
-        info,
-        'Name'          => 'Tidy Payload for RSpec',
-        'Description'   => 'Test!'
-      )
-    )
+    super(merge_info(info,
+      'Name'        => 'Tidy Payload for RSpec',
+      'Description' => 'Test!',
+      'Author'      => 'Unknown',
+      'License'     => MSF_LICENSE
+    ))
   end
 end

--- a/tools/dev/msftidy.rb
+++ b/tools/dev/msftidy.rb
@@ -703,6 +703,14 @@ class Msftidy
     end
   end
 
+  # Check for modules having an Author section to ensure attribution
+  #
+  def check_author
+    unless @source =~ /["']Author["'][[:space:]]*=>/
+      error('Missing "Author" info, please add')
+    end
+  end
+
   #
   # Run all the msftidy checks.
   #
@@ -736,6 +744,7 @@ class Msftidy
     check_register_datastore_debug
     check_use_datastore_debug
     check_arch
+    check_author
   end
 
   private


### PR DESCRIPTION
Talking with @bcook-r7, sounds like we'd like to complain loudly if a module doesn't have an 'Author' section (attribution of discovery, PoC, module create, etc. FTW!).  I took a swag at updating msftidy to look for 'Author' in the module metadata.

Module with 'Author':

```
$ ./tools/dev/msftidy.rb modules/exploits/multi/http/axis2_deployer.rb
$
```

Module without 'Author':

```
$ ./tools/dev/msftidy.rb modules/exploits/multi/http/git_submodule_command_exec.rb
modules/exploits/multi/http/git_submodule_command_exec.rb - [ERROR] Missing "Author" info, please add
$
```

## Verification

List the steps needed to make sure this thing works

- [ ] run **msftidy** against a module that has 'Author' in the module metadata
- [ ] **Verify** there are no ERRORs related to missing 'Author'
- [ ] run **msftidy** against a module that does NOT have 'Author' in the module metadata
- [ ] **Verify** you get an ERROR about missing 'Author'

There are currently 16 files in the modules/ directory that are lacking 'Author' metadata.  Some seem like the do need it (like the git_submodule_command_exec module above), others aren't so clear they actually need it (like modules/payloads/stages/windows/patchupdllinject.rb and modules/payloads/stages/osx/x86/bundleinject.rb).  Open to suggestions/thoughts.  :)