### PR TITLE
PostgreSQL CREATE LANGUAGE Execution - Fix version detection

### DIFF
--- a/modules/exploits/multi/postgres/postgres_createlang.rb
+++ b/modules/exploits/multi/postgres/postgres_createlang.rb
@@ -57,26 +57,24 @@ class MetasploitModule < Msf::Exploit::Remote
     deregister_options('SQL', 'RETURN_ROWSET', 'VERBOSE')
   end
 
-  def postgres_major_version(version)
-    version_match = version.match(/(?<software>\w{10})\s(?<major_version>\d{1,2})\.(?<minor_version>\d{1,2})\.(?<revision>\d{1,2})/)
-    version_match['major_version']
-  end
-
   def check
-    if vuln_version?
-      Exploit::CheckCode::Appears
-    else
-      Exploit::CheckCode::Safe
-    end
+    vuln_version? ? CheckCode::Appears : CheckCode::Safe
   end
 
   def vuln_version?
     version = postgres_fingerprint
-    if version[:auth]
-      major_version = postgres_major_version(version[:auth])
-      return true if major_version && major_version.to_i >= 8
+
+    return unless version[:auth]
+
+    vprint_status version[:auth].to_s
+
+    version_full = version[:auth].to_s.scan(/^PostgreSQL ([\d\.]+)/).flatten.first
+
+    if Gem::Version.new(version_full) >= Gem::Version.new('8.0')
+      return true
+    else
+      return false
     end
-    false
   end
 
   def login_success?

--- a/modules/exploits/multi/postgres/postgres_createlang.rb
+++ b/modules/exploits/multi/postgres/postgres_createlang.rb
@@ -68,7 +68,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     vprint_status version[:auth].to_s
 
-    version_full = version[:auth].to_s.scan(/^PostgreSQL ([\d\.]+)/).flatten.first
+    version_full = version[:auth].to_s.scan(/^PostgreSQL ([\d\.]+)/i).flatten.first
 
     if Gem::Version.new(version_full) >= Gem::Version.new('8.0')
       return true


### PR DESCRIPTION
This PR fixes the version detection in the PostgreSQL CREATE LANGUAGE Execution module. Fixes #11629

Prior to this PR, the version detection was overly complex and unreliable, causing the `check` method to fail with ```NoMethodError undefined method `[]' for nil:NilClass```

This PR simplifies the version detection to match `^PostgreSQL ([\d\.]+)`.

Reviewing the PostgreSQL documentation for version 8/9 indicates that `SELECT version()` returns the version in this format.

* https://www.postgresql.org/docs/8.0/tutorial-accessdb.html
* https://www.postgresql.org/docs/9.6/tutorial-accessdb.html


```
[-] ***rting the Metasploit Framework console...\
[-] * WARNING: No database support: No database YAML file
[-] ***
                                                  

   _______________                        |*\_/*|________
  |  ___________  |     .-.     .-.      ||_/-\_|______  |
  | |           | |    .****. .****.     | |           | |
  | |   0   0   | |    .*****.*****.     | |   0   0   | |
  | |     -     | |     .*********.      | |     -     | |
  | |   \___/   | |      .*******.       | |   \___/   | |
  | |___     ___| |       .*****.        | |___________| |
  |_____|\_/|_____|        .***.         |_______________|
    _|__|/ \|_|_.............*.............._|________|_
   / ********** \                          / ********** \
 /  ************  \                      /  ************  \
--------------------                    -------------------


       =[ metasploit v5.0.14-dev-79d22ef0d7               ]
+ -- --=[ 1884 exploits - 1064 auxiliary - 329 post       ]
+ -- --=[ 553 payloads - 44 encoders - 10 nops            ]
+ -- --=[ 2 evasion                                       ]

msf5 > use exploit/multi/postgres/postgres_createlang 
msf5 exploit(multi/postgres/postgres_createlang) > set rhosts 127.0.0.1
rhosts => 127.0.0.1
msf5 exploit(multi/postgres/postgres_createlang) > set username msf
username => msf
msf5 exploit(multi/postgres/postgres_createlang) > set password msf
password => msf
msf5 exploit(multi/postgres/postgres_createlang) > check
[*] 127.0.0.1:5432 - The target appears to be vulnerable.
msf5 exploit(multi/postgres/postgres_createlang) > set verbose true
verbose => true
msf5 exploit(multi/postgres/postgres_createlang) > check

[*] 127.0.0.1:5432 - 127.0.0.1:5432 Postgres - querying with 'select version()'
[*] 127.0.0.1:5432 - PostgreSQL 10.4 (Debian 10.4-2) on x86_64-pc-linux-gnu, compiled by gcc (Debian 7.3.0-18) 7.3.0, 64-bit
[*] 127.0.0.1:5432 - The target appears to be vulnerable.
msf5 exploit(multi/postgres/postgres_createlang) > 
```
