### PR TITLE
Add check for active database to relevant Msf::Payload::UUID::Options methods

### DIFF
--- a/lib/msf/core/payload/uuid/options.rb
+++ b/lib/msf/core/payload/uuid/options.rb
@@ -86,6 +86,8 @@ module Msf::Payload::UUID::Options
   # Store a UUID in the JSON database if tracking is enabled
   def record_payload_uuid(uuid, info={})
     return unless datastore['PayloadUUIDTracking']
+    # skip if there is no active database
+    return if !(framework.db && framework.db.active)
 
     uuid_info = info.merge({
       uuid:  uuid.puid_hex,
@@ -109,6 +111,9 @@ module Msf::Payload::UUID::Options
   # Store a UUID URL in the database if tracking is enabled
   def record_payload_uuid_url(uuid, url)
     return unless datastore['PayloadUUIDTracking']
+    # skip if there is no active database
+    return if !(framework.db && framework.db.active)
+
     payload_info = {
         uuid: uuid.puid_hex,
         workspace: framework.db.workspace


### PR DESCRIPTION
Adds check for active database to methods `Msf::Payload::UUID::Options#record_payload_uuid` and `Msf::Payload::UUID::Options#record_payload_uuid_url` before performing database operations. This fixes an issue seen when starting `msfconsole` without a database or when running `msfvenom`.

**Example `msfconsole` error**
```
$ ./msfconsole --no-database
[-] No database driver installed.work console...\
[-] ***
[-] * WARNING: Database support has been disabled
[-] ***
Traceback (most recent call last):ork console...-
    25: from ./msfconsole:49:in `<main>'
    24: from /home/msfdev/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'
    23: from /home/msfdev/metasploit-framework/lib/metasploit/framework/command/console.rb:48:in `start'
    22: from /home/msfdev/metasploit-framework/lib/metasploit/framework/command/console.rb:62:in `driver'
    21: from /home/msfdev/metasploit-framework/lib/metasploit/framework/command/console.rb:62:in `new'
    20: from /home/msfdev/metasploit-framework/lib/msf/ui/console/driver.rb:161:in `initialize'
    19: from /home/msfdev/metasploit-framework/lib/msf/base/simple/framework/module_paths.rb:49:in `init_module_paths'
    18: from /home/msfdev/metasploit-framework/lib/msf/base/simple/framework/module_paths.rb:49:in `each'
    17: from /home/msfdev/metasploit-framework/lib/msf/base/simple/framework/module_paths.rb:50:in `block in init_module_paths'
    16: from /home/msfdev/metasploit-framework/lib/msf/core/module_manager/module_paths.rb:40:in `add_module_path'
    15: from /home/msfdev/metasploit-framework/lib/msf/core/module_manager/module_paths.rb:40:in `each'
    14: from /home/msfdev/metasploit-framework/lib/msf/core/module_manager/module_paths.rb:41:in `block in add_module_path'
    13: from /home/msfdev/metasploit-framework/lib/msf/core/module_manager/loading.rb:117:in `load_modules'
    12: from /home/msfdev/metasploit-framework/lib/msf/core/module_manager/loading.rb:117:in `each'
    11: from /home/msfdev/metasploit-framework/lib/msf/core/module_manager/loading.rb:119:in `block in load_modules'
    10: from /home/msfdev/metasploit-framework/lib/msf/core/modules/loader/base.rb:256:in `load_modules'
     9: from /home/msfdev/metasploit-framework/lib/msf/core/modules/loader/base.rb:256:in `each'
     8: from /home/msfdev/metasploit-framework/lib/msf/core/modules/loader/base.rb:259:in `block in load_modules'
     7: from /home/msfdev/metasploit-framework/lib/msf/core/payload_set.rb:78:in `recalculate'
     6: from /home/msfdev/metasploit-framework/lib/msf/core/payload_set.rb:78:in `each_pair'
     5: from /home/msfdev/metasploit-framework/lib/msf/core/payload_set.rb:91:in `block in recalculate'
     4: from /home/msfdev/metasploit-framework/lib/msf/core/payload.rb:204:in `size'
     3: from /home/msfdev/metasploit-framework/lib/msf/core/payload/android.rb:38:in `generate'
     2: from /home/msfdev/metasploit-framework/modules/payloads/singles/android/meterpreter_reverse_https.rb:48:in `generate_jar'
     1: from /home/msfdev/metasploit-framework/lib/msf/core/payload/uuid/options.rb:47:in `generate_uri_uuid_mode'
/home/msfdev/metasploit-framework/lib/msf/core/payload/uuid/options.rb:116:in `record_payload_uuid_url': undefined method `first' for nil:NilClass (NoMethodError)
```

**Example `msfvenom` error**
```
$ ./msfvenom -p windows/x64/meterpreter/reverse_https -f exe -o metasploit_https_64.exe LHOST=192.168.1.1
/home/msfdev/.rbenv/versions/2.6.2/lib/ruby/gems/2.6.0/gems/activesupport-4.2.11.1/lib/active_support/core_ext/object/duplicable.rb:111: warning: BigDecimal.new is deprecated; use BigDecimal() method instead.
Traceback (most recent call last):
    24: from ./msfvenom:445:in `<main>'
    23: from ./msfvenom:55:in `framework'
    22: from ./msfvenom:46:in `init_framework'
    21: from /home/msfdev/metasploit-framework/lib/msf/base/simple/framework.rb:74:in `create'
    20: from /home/msfdev/metasploit-framework/lib/msf/base/simple/framework.rb:122:in `simplify'
    19: from /home/msfdev/metasploit-framework/lib/msf/base/simple/framework/module_paths.rb:49:in `init_module_paths'
    18: from /home/msfdev/metasploit-framework/lib/msf/base/simple/framework/module_paths.rb:49:in `each'
    17: from /home/msfdev/metasploit-framework/lib/msf/base/simple/framework/module_paths.rb:50:in `block in init_module_paths'
    16: from /home/msfdev/metasploit-framework/lib/msf/core/module_manager/module_paths.rb:40:in `add_module_path'
    15: from /home/msfdev/metasploit-framework/lib/msf/core/module_manager/module_paths.rb:40:in `each'
    14: from /home/msfdev/metasploit-framework/lib/msf/core/module_manager/module_paths.rb:41:in `block in add_module_path'
    13: from /home/msfdev/metasploit-framework/lib/msf/core/module_manager/loading.rb:117:in `load_modules'
    12: from /home/msfdev/metasploit-framework/lib/msf/core/module_manager/loading.rb:117:in `each'
    11: from /home/msfdev/metasploit-framework/lib/msf/core/module_manager/loading.rb:119:in `block in load_modules'
    10: from /home/msfdev/metasploit-framework/lib/msf/core/modules/loader/base.rb:256:in `load_modules'
     9: from /home/msfdev/metasploit-framework/lib/msf/core/modules/loader/base.rb:256:in `each'
     8: from /home/msfdev/metasploit-framework/lib/msf/core/modules/loader/base.rb:259:in `block in load_modules'
     7: from /home/msfdev/metasploit-framework/lib/msf/core/payload_set.rb:78:in `recalculate'
     6: from /home/msfdev/metasploit-framework/lib/msf/core/payload_set.rb:78:in `each_pair'
     5: from /home/msfdev/metasploit-framework/lib/msf/core/payload_set.rb:91:in `block in recalculate'
     4: from /home/msfdev/metasploit-framework/lib/msf/core/payload.rb:204:in `size'
     3: from /home/msfdev/metasploit-framework/lib/msf/core/payload/android.rb:38:in `generate'
     2: from /home/msfdev/metasploit-framework/modules/payloads/singles/android/meterpreter_reverse_https.rb:48:in `generate_jar'
     1: from /home/msfdev/metasploit-framework/lib/msf/core/payload/uuid/options.rb:47:in `generate_uri_uuid_mode'
/home/msfdev/metasploit-framework/lib/msf/core/payload/uuid/options.rb:116:in `record_payload_uuid_url': undefined method `first' for nil:NilClass (NoMethodError)
```



## Verification

- [ ] Follow steps to reproduce from #11620
- [ ] Run `./msfconsole --no-database`
- [ ] **Verify** `msfconsole` starts without a traceback
- [ ] Run `./msfvenom -p windows/x64/meterpreter/reverse_https -f exe -o metasploit_https_64.exe LHOST=192.168.1.1` or desired `msfvenom` command to generate a payload
- [ ] **Verify** `msfvenom` runs without a traceback
