### PR TITLE
Add "search -u" to use a module if there's only one result

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -404,6 +404,7 @@ module Msf
             tbl = generate_module_table("Matching Modules", search_term)
             search_params = parse_search_string(match)
             count = 0
+            used_module = nil
             begin
               Msf::Modules::Metadata::Cache.instance.find(search_params).each do |m|
                 tbl << [
@@ -415,6 +416,7 @@ module Msf
                     m.name
                 ]
                 if count == use
+                  used_module = m.full_name
                   cmd_use(m.full_name)
                 end
               end
@@ -430,6 +432,11 @@ module Msf
               }
             else
               print_line(tbl.to_s)
+              if used_module
+                print_line("Using #{used_module}")
+              elsif use != 0
+                print_line("Module ##{use} does not exist")
+              end
             end
           end
 

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -1161,6 +1161,7 @@ module Msf
 
           def show_module_set(type, module_set, regex = nil, minrank = nil, opts = nil) # :nodoc:
             tbl = generate_module_table(type)
+            count = 0
             module_set.sort.each { |refname, mod|
               o = nil
 
@@ -1192,6 +1193,7 @@ module Msf
                   end
                   if (opts == nil or show == true)
                     tbl << [
+                      count += 1,
                       refname,
                       o.disclosure_date.nil? ? "" : o.disclosure_date.strftime("%Y-%m-%d"),
                       o.rank_to_s,


### PR DESCRIPTION
This implements a feature request from a few years back, adding a numeric column to module search, as well as a '-u' option that automatically uses the first module that matches, or if the user specifies a number value, the nth module that matches.

Fixes #4336

Example:

```
msf5 > search -u cve-2013-0422

Matching Modules
================

   #  Name                                      Disclosure Date  Rank       Check  Description
   -  ----                                      ---------------  ----       -----  -----------
   1  exploit/multi/browser/java_jre17_jmxbean  2013-01-10       excellent  No     Java Applet JMX Remote Code Execution

Using exploit/multi/browser/java_jre17_jmxbean
msf5 exploit(multi/browser/java_jre17_jmxbean) > 
```

Counterexample:
```
msf5 exploit(multi/browser/java_jre17_jmxbean) > search cve-2013-0422 -u 1

Matching Modules
================

   #  Name                                      Disclosure Date  Rank       Check  Description
   -  ----                                      ---------------  ----       -----  -----------
   1  exploit/multi/browser/java_jre17_jmxbean  2013-01-10       excellent  No     Java Applet JMX Remote Code Execution


Using exploit/multi/browser/java_jre17_jmxbean
msf5 exploit(multi/browser/java_jre17_jmxbean) > search cve-2013-0422 -u 2

Matching Modules
================

   #  Name                                      Disclosure Date  Rank       Check  Description
   -  ----                                      ---------------  ----       -----  -----------
   1  exploit/multi/browser/java_jre17_jmxbean  2013-01-10       excellent  No     Java Applet JMX Remote Code Execution


Module #2 does not exist
```
