### PR TITLE
hashcat equivalents of the jtr modules

### DIFF
--- a/documentation/modules/auxiliary/analyze/hashcat_aix.md
+++ b/documentation/modules/auxiliary/analyze/hashcat_aix.md
@@ -1,0 +1,116 @@
+## Vulnerable Application
+
+  This module attempts to use [hashcat](https://hashcat.net/hashcat/) to decode AIX 
+  based password hashes, such as:
+
+  * `DES` based passwords (format 1500)
+
+  Sources of hashes can be found here:
+  [source](https://hashcat.net/wiki/doku.php?id=example_hashes)
+
+## Verification Steps
+
+  1. Have at least one user with a `des` password in the database
+  2. Start msfconsole
+  3. Do: ```use auxiliary/analyze/hashcat_aix```
+  4. Do: ```run```
+  5. You should hopefully crack a password.
+
+## Options
+
+   **CUSTOM_WORDLIST**
+
+   The path to an optional custom wordlist.  This file is added to the new wordlist which may include the other
+   `USE` items like `USE_CREDS`, and have `MUTATE` or `KORELOGIC` applied to it.
+
+   **DeleteTempFiles**
+
+   This option will prevent deletion of the wordlist and file containing hashes.  This may be useful for
+   running the hashes through john if it wasn't cracked, or for debugging. Default is `false`.
+
+   **ITERATION_TIMEOUT**
+
+   The max-run-time for each iteration of cracking
+
+   **HASHCAT_PATH**
+
+   The absolute path to the Hashcat executable.  Default behavior is to search `path` for
+   `hashcat` and `hashcat.exe`.
+
+   **MUTATE**
+
+   Apply common mutations to the Wordlist (SLOW).  Mutations are:
+
+   * `'@' => 'a'`
+   * `'0' => 'o'`
+   * `'3' => 'e'`
+   * `'$' => 's'`
+   * `'7' => 't'`
+   * `'1' => 'l'`
+   * `'5' => 's'`
+
+   Default is `false`.
+
+   **POT**
+
+   The path to a John POT file (JtR option: `--pot`) to use instead.  The `pot` file is the data file which
+   records cracked password hashes.  Kali linux's default location is `/root/.john/john.pot`.
+   Default is `~/.msf4/john.pot`.
+
+   **USE_CREDS**
+
+   Use existing credential data saved in the database.  Default is `true`.
+
+   **USE_DB_INFO**
+
+   Use looted database schema info to seed the wordlist.  This includes the Database Name, each Table Name,
+   and each Column Name.  If the DB is MSSQL, the Instance Name is also used.  Default is `true`.
+
+   **USE_DEFAULT_WORDLIST**
+
+   Use the default metasploit wordlist in `metasploit-framework/data/wordlists/password.lst`.  Default is
+   `true`.
+
+   **USE_HOSTNAMES**
+
+   Seed the wordlist with hostnames from the workspace.  Default is `true`.
+
+   **USE_ROOT_WORDS**
+
+   Use the Common Root Words Wordlist in `metasploit-framework/data/wordlists/common_roots.txt`.  Default
+   is true.
+
+## Scenarios
+
+Create hash:
+
+```
+creds add user:des_password hash:rEK1ecacw.7.c jtr:des
+```
+
+Crack it:
+
+```
+resource (hashes_hashcat.rb)> use auxiliary/analyze/hashcat_aix
+resource (hashes_hashcat.rb)> run
+[*] Hashes Written out to /tmp/hashes_tmp20190331-15330-fib7wh
+[*] Wordlist file written out to /tmp/jtrtmp20190331-15330-va5d6w
+[*] Cracking descrypt hashes in normal wordlist mode...
+nvmlDeviceGetFanSpeed(): Not Supported
+
+[*] Cracking descrypt hashes in increment mode...
+nvmlDeviceGetFanSpeed(): Not Supported
+
+[*] Cracked Passwords this run:
+[+] des_password:password
+[*] Auxiliary module execution completed
+[*] Starting persistent handler(s)...
+msf5 auxiliary(analyze/hashcat_aix) > creds
+Credentials
+===========
+
+host  origin  service  public        private        realm  private_type        JtR Format
+----  ------  -------  ------        -------        -----  ------------        ----------
+                       des_password  password              Password            
+                       des_password  rEK1ecacw.7.c         Nonreplayable hash  des
+```

--- a/documentation/modules/auxiliary/analyze/hashcat_linux.md
+++ b/documentation/modules/auxiliary/analyze/hashcat_linux.md
@@ -1,0 +1,184 @@
+## Vulnerable Application
+
+  This module attempts to use [hashcat](https://hashcat.net/hashcat/) to decode Linux
+  based password hashes, such as:
+
+  * `DES` based passwords (format 1500)
+  * `MD5` based passwords (format 500)
+  * `BSDi` based passwords (format 12400)
+  * With `crypt` set to `true`:
+    * `bf`, `bcrypt`, or `blowfish` based passwords (format 3200)
+    * `SHA256` based passwords (format 7400)
+    * `SHA512` based passwords (format 1800)
+
+  Sources of hashes can be found here:
+  [source](https://hashcat.net/wiki/doku.php?id=example_hashes)
+
+## Verification Steps
+
+  1. Have at least one user with an `des`, `md5`, `bsdi`, `crypt`, `blowfish`, `sha512`, or `sha256` password hash in the database
+  2. Start msfconsole
+  3. Do: ```use auxiliary/analyze/hashcat_linux```
+  4. Do: ```run```
+  5. You should hopefully crack a password.
+
+## Options
+
+   **CRYPT**
+
+   Include `blowfish` and `SHA`(256/512) passwords.
+
+   **DeleteTempFiles**
+
+   This option will prevent deletion of the wordlist and file containing hashes.  This may be useful for
+   running the hashes through john if it wasn't cracked, or for debugging. Default is `false`.
+
+   **CUSTOM_WORDLIST**
+
+   The path to an optional custom wordlist.  This file is added to the new wordlist which may include the other
+   `USE` items like `USE_CREDS`, and have `MUTATE` or `KORELOGIC` applied to it.
+
+   **ITERATION_TIMEOUT**
+
+   The max-run-time for each iteration of cracking
+
+   **HASHCAT_PATH**
+
+   The absolute path to the Hashcat executable.  Default behavior is to search `path` for
+   `hashcat` and `hashcat.exe`.
+
+   **MUTATE**
+
+   Apply common mutations to the Wordlist (SLOW).  Mutations are:
+
+   * `'@' => 'a'`
+   * `'0' => 'o'`
+   * `'3' => 'e'`
+   * `'$' => 's'`
+   * `'7' => 't'`
+   * `'1' => 'l'`
+   * `'5' => 's'`
+
+   Default is `false`.
+
+   **POT**
+
+   The path to a John POT file (JtR option: `--pot`) to use instead.  The `pot` file is the data file which
+   records cracked password hashes.  Kali linux's default location is `/root/.john/john.pot`.
+   Default is `~/.msf4/john.pot`.
+
+   **USE_CREDS**
+
+   Use existing credential data saved in the database.  Default is `true`.
+
+   **USE_DB_INFO**
+
+   Use looted database schema info to seed the wordlist.  This includes the Database Name, each Table Name,
+   and each Column Name.  If the DB is MSSQL, the Instance Name is also used.  Default is `true`.
+
+   **USE_DEFAULT_WORDLIST**
+
+   Use the default metasploit wordlist in `metasploit-framework/data/wordlists/password.lst`.  Default is
+   `true`.
+
+   **USE_HOSTNAMES**
+
+   Seed the wordlist with hostnames from the workspace.  Default is `true`.
+
+   **USE_ROOT_WORDS**
+
+   Use the Common Root Words Wordlist in `metasploit-framework/data/wordlists/common_roots.txt`.  Default
+   is true.
+
+## Scenarios
+
+Create hashes:
+
+```
+creds add user:des_password hash:rEK1ecacw.7.c jtr:des
+creds add user:md5_password hash:$1$O3JMY.Tw$AdLnLjQ/5jXF9.MTp3gHv/ jtr:md5
+creds add user:bsdi_password hash:_J9..K0AyUubDrfOgO4s jtr:bsdi
+creds add user:sha256_password hash:$5$MnfsQ4iN$ZMTppKN16y/tIsUYs/obHlhdP.Os80yXhTurpBMUbA5 jtr:sha256,crypt
+creds add user:sha512_password hash:$6$zWwwXKNj$gLAOoZCjcr8p/.VgV/FkGC3NX7BsXys3KHYePfuIGMNjY83dVxugPYlxVg/evpcVEJLT/rSwZcDMlVVf/bhf.1 jtr:sha512,crypt
+creds add user:blowfish_password hash:$2a$05$bvIG6Nmid91Mu9RcmmWZfO5HJIMCT8riNW0hEp8f6/FuA2/mHZFpe jtr:bf
+```
+
+Crack them:
+
+```
+resource (hashes_hashcat.rb)> use auxiliary/analyze/hashcat_linux
+resource (hashes_hashcat.rb)> set crypt true
+crypt => true
+resource (hashes_hashcat.rb)> run
+[*] Hashes Written out to /tmp/hashes_tmp20190331-15445-1bon488
+[*] Wordlist file written out to /tmp/jtrtmp20190331-15445-1es3bt
+[*] Cracking md5crypt hashes in normal wordlist mode...
+nvmlDeviceGetFanSpeed(): Not Supported
+
+[*] Cracking md5crypt hashes in increment mode...
+nvmlDeviceGetFanSpeed(): Not Supported
+
+[*] Cracked Passwords this run:
+[+] md5_password:password
+[*] Cracking descrypt hashes in normal wordlist mode...
+nvmlDeviceGetFanSpeed(): Not Supported
+
+[*] Cracking descrypt hashes in increment mode...
+nvmlDeviceGetFanSpeed(): Not Supported
+
+[*] Cracked Passwords this run:
+[+] des_password:password
+[*] Cracking bsdicrypt hashes in normal wordlist mode...
+nvmlDeviceGetFanSpeed(): Not Supported
+
+[*] Cracking bsdicrypt hashes in increment mode...
+nvmlDeviceGetFanSpeed(): Not Supported
+
+[*] Cracked Passwords this run:
+[+] bsdi_password:password
+[*] Cracking sha256crypt hashes in normal wordlist mode...
+nvmlDeviceGetFanSpeed(): Not Supported
+
+[*] Cracking sha256crypt hashes in increment mode...
+nvmlDeviceGetFanSpeed(): Not Supported
+
+[*] Cracked Passwords this run:
+[+] sha256_password:password
+[*] Cracking sha512crypt hashes in normal wordlist mode...
+nvmlDeviceGetFanSpeed(): Not Supported
+
+[*] Cracking sha512crypt hashes in increment mode...
+nvmlDeviceGetFanSpeed(): Not Supported
+
+[*] Cracked Passwords this run:
+[+] sha512_password:password
+[*] Cracking bcrypt hashes in normal wordlist mode...
+nvmlDeviceGetFanSpeed(): Not Supported
+
+[*] Cracking bcrypt hashes in increment mode...
+nvmlDeviceGetFanSpeed(): Not Supported
+
+[*] Cracked Passwords this run:
+[+] blowfish_password:password
+[*] Auxiliary module execution completed
+[*] Starting persistent handler(s)...
+msf5 auxiliary(analyze/hashcat_linux) > creds
+Credentials
+===========
+
+host  origin  service  public             private                                                                                             realm  private_type        JtR Format
+----  ------  -------  ------             -------                                                                                             -----  ------------        ----------
+                       des_password       password                                                                                                   Password            
+                       des_password       rEK1ecacw.7.c                                                                                              Nonreplayable hash  des
+                       md5_password       password                                                                                                   Password            
+                       md5_password       $1$O3JMY.Tw$AdLnLjQ/5jXF9.MTp3gHv/                                                                         Nonreplayable hash  md5
+                       bsdi_password      password                                                                                                   Password            
+                       bsdi_password      _J9..K0AyUubDrfOgO4s                                                                                       Nonreplayable hash  bsdi
+                       sha256_password    password                                                                                                   Password            
+                       sha256_password    $5$MnfsQ4iN$ZMTppKN16y/tIsUYs/obHlhdP.Os80yXhTurpBMUbA5                                                    Nonreplayable hash  sha256
+                       sha512_password    password                                                                                                   Password            
+                       sha512_password    $6$zWwwXKNj$gLAOoZCjcr8p/.VgV/FkGC3NX7BsXys3KHYePfuIGMNjY83dVxugPYlxVg/evpcVEJLT/rSwZcDMlVVf/bhf.1         Nonreplayable hash  sha512
+                       blowfish_password  password                                                                                                   Password            
+                       blowfish_password  $2a$05$bvIG6Nmid91Mu9RcmmWZfO5HJIMCT8riNW0hEp8f6/FuA2/mHZFpe                                               Nonreplayable hash  bf
+
+```

--- a/documentation/modules/auxiliary/analyze/hashcat_mssql_fast.md
+++ b/documentation/modules/auxiliary/analyze/hashcat_mssql_fast.md
@@ -1,0 +1,126 @@
+## Vulnerable Application
+
+  This module attempts to use [hashcat](https://hashcat.net/hashcat/) to decode Microsoft
+  SQL based password hashes, such as:
+
+  * `mssql` based passwords (format 131)
+  * `mssql05` based passwords (format 132)
+  * `mssql12` based passwords (format 1731)
+
+  Sources of hashes can be found here:
+  [source](https://hashcat.net/wiki/doku.php?id=example_hashes)
+
+## Verification Steps
+
+  1. Have at least one user with an `mssql`, `mssql05` or `mssql12` password in the database
+  2. Start msfconsole
+  3. Do: ```use auxiliary/analyze/hashcat_mssql_fast```
+  4. Do: ```run```
+  5. You should hopefully crack a password.
+
+## Options
+
+   **CUSTOM_WORDLIST**
+
+   The path to an optional custom wordlist.  This file is added to the new wordlist which may include the other
+   `USE` items like `USE_CREDS`, and have `MUTATE` or `KORELOGIC` applied to it.
+
+   **DeleteTempFiles**
+
+   This option will prevent deletion of the wordlist and file containing hashes.  This may be useful for
+   running the hashes through john if it wasn't cracked, or for debugging. Default is `false`.
+
+   **ITERATION_TIMEOUT**
+
+   The max-run-time for each iteration of cracking
+
+   **HASHCAT_PATH**
+
+   The absolute path to the Hashcat executable.  Default behavior is to search `path` for
+   `hashcat` and `hashcat.exe`.
+
+   **MUTATE**
+
+   Apply common mutations to the Wordlist (SLOW).  Mutations are:
+
+   * `'@' => 'a'`
+   * `'0' => 'o'`
+   * `'3' => 'e'`
+   * `'$' => 's'`
+   * `'7' => 't'`
+   * `'1' => 'l'`
+   * `'5' => 's'`
+
+   Default is `false`.
+
+   **POT**
+
+   The path to a John POT file (JtR option: `--pot`) to use instead.  The `pot` file is the data file which
+   records cracked password hashes.  Kali linux's default location is `/root/.john/john.pot`.
+   Default is `~/.msf4/john.pot`.
+
+   **USE_CREDS**
+
+   Use existing credential data saved in the database.  Default is `true`.
+
+   **USE_DB_INFO**
+
+   Use looted database schema info to seed the wordlist.  This includes the Database Name, each Table Name,
+   and each Column Name.  If the DB is MSSQL, the Instance Name is also used.  Default is `true`.
+
+   **USE_DEFAULT_WORDLIST**
+
+   Use the default metasploit wordlist in `metasploit-framework/data/wordlists/password.lst`.  Default is
+   `true`.
+
+   **USE_HOSTNAMES**
+
+   Seed the wordlist with hostnames from the workspace.  Default is `true`.
+
+   **USE_ROOT_WORDS**
+
+   Use the Common Root Words Wordlist in `metasploit-framework/data/wordlists/common_roots.txt`.  Default
+   is true.
+
+## Scenarios
+
+Create hashes:
+
+```
+creds add user:mssql05_toto hash:0x01004086CEB6BF932BC4151A1AF1F13CD17301D70816A8886908 jtr:mssql05
+creds add user:mssql_foo hash:0x0100A607BA7C54A24D17B565C59F1743776A10250F581D482DA8B6D6261460D3F53B279CC6913CE747006A2E3254 jtr:mssql
+creds add user:mssql12_Password1! hash:0x0200F733058A07892C5CACE899768F89965F6BD1DED7955FE89E1C9A10E27849B0B213B5CE92CC9347ECCB34C3EFADAF2FD99BFFECD8D9150DD6AACB5D409A9D2652A4E0AF16 jtr:mssql12 
+```
+
+Crack them:
+
+```
+resource (hashes_hashcat.rb)> use auxiliary/analyze/hashcat_mssql_fast
+resource (hashes_hashcat.rb)> run
+[*] Hashes Written out to /tmp/hashes_tmp20190331-19073-dnkbx7
+[*] Wordlist file written out to /tmp/jtrtmp20190331-19073-1c05xc4
+[*] Cracking mssql05 hashes in normal wordlist mode...
+nvmlDeviceGetFanSpeed(): Not Supported
+
+[*] Cracking mssql05 hashes in increment mode...
+nvmlDeviceGetFanSpeed(): Not Supported
+
+[*] Cracked Passwords this run:
+[+] mssql05_toto:toto
+[*] Cracking mssql hashes in normal wordlist mode...
+nvmlDeviceGetFanSpeed(): Not Supported
+
+[*] Cracking mssql hashes in increment mode...
+nvmlDeviceGetFanSpeed(): Not Supported
+
+[*] Cracked Passwords this run:
+[+] mssql_foo:FOO
+[*] Cracking mssql12 hashes in normal wordlist mode...
+nvmlDeviceGetFanSpeed(): Not Supported
+
+[*] Cracking mssql12 hashes in increment mode...
+nvmlDeviceGetFanSpeed(): Not Supported
+
+[*] Cracked Passwords this run:
+[*] Auxiliary module execution completed
+```

--- a/documentation/modules/auxiliary/analyze/hashcat_mysql_fast.md
+++ b/documentation/modules/auxiliary/analyze/hashcat_mysql_fast.md
@@ -1,0 +1,129 @@
+## Vulnerable Application
+
+  This module attempts to use [hashcat](https://hashcat.net/hashcat/) to decode MySQL
+  based password hashes, such as:
+
+  * `mysql` (pre 4.1) based passwords (format 200)
+  * `mysql-sha1` based passwords (format 300)
+
+  Sources of hashes can be found here:
+  [source](https://hashcat.net/wiki/doku.php?id=example_hashes)
+
+## Verification Steps
+
+  1. Have at least one user with an `mysql`, or `mysql-sha1` password in the database
+  2. Start msfconsole
+  3. Do: ```use auxiliary/analyze/jtr_mysql_fast```
+  4. Do: ```run```
+  5. You should hopefully crack a password.
+
+## Options
+
+   **CUSTOM_WORDLIST**
+
+   The path to an optional custom wordlist.  This file is added to the new wordlist which may include the other
+   `USE` items like `USE_CREDS`, and have `MUTATE` or `KORELOGIC` applied to it.
+
+   **DeleteTempFiles**
+
+   This option will prevent deletion of the wordlist and file containing hashes.  This may be useful for
+   running the hashes through john if it wasn't cracked, or for debugging. Default is `false`.
+
+   **ITERATION_TIMEOUT**
+
+   The max-run-time for each iteration of cracking
+
+   **HASHCAT_PATH**
+
+   The absolute path to the Hashcat executable.  Default behavior is to search `path` for
+   `hashcat` and `hashcat.exe`.
+
+   **MUTATE**
+
+   Apply common mutations to the Wordlist (SLOW).  Mutations are:
+
+   * `'@' => 'a'`
+   * `'0' => 'o'`
+   * `'3' => 'e'`
+   * `'$' => 's'`
+   * `'7' => 't'`
+   * `'1' => 'l'`
+   * `'5' => 's'`
+
+   Default is `false`.
+
+   **POT**
+
+   The path to a John POT file (JtR option: `--pot`) to use instead.  The `pot` file is the data file which
+   records cracked password hashes.  Kali linux's default location is `/root/.john/john.pot`.
+   Default is `~/.msf4/john.pot`.
+
+   **USE_CREDS**
+
+   Use existing credential data saved in the database.  Default is `true`.
+
+   **USE_DB_INFO**
+
+   Use looted database schema info to seed the wordlist.  This includes the Database Name, each Table Name,
+   and each Column Name.  If the DB is MSSQL, the Instance Name is also used.  Default is `true`.
+
+   **USE_DEFAULT_WORDLIST**
+
+   Use the default metasploit wordlist in `metasploit-framework/data/wordlists/password.lst`.  Default is
+   `true`.
+
+   **USE_HOSTNAMES**
+
+   Seed the wordlist with hostnames from the workspace.  Default is `true`.
+
+   **USE_ROOT_WORDS**
+
+   Use the Common Root Words Wordlist in `metasploit-framework/data/wordlists/common_roots.txt`.  Default
+   is true.
+
+## Scenarios
+
+Create hashes:
+
+```
+creds add user:mysql_probe hash:445ff82636a7ba59 jtr:mysql
+creds add user:mysql-sha1_tere hash:*5AD8F88516BD021DD43F171E2C785C69F8E54ADB jtr:mysql-sha1
+```
+
+Crack them:
+
+```
+resource (hashes_hashcat.rb)> use auxiliary/analyze/hashcat_mysql_fast
+resource (hashes_hashcat.rb)> run
+[*] Hashes Written out to /tmp/hashes_tmp20190331-19376-9zx2yn
+[*] Wordlist file written out to /tmp/jtrtmp20190331-19376-1yfgcmv
+[*] Cracking mysql hashes in normal wordlist mode...
+nvmlDeviceGetFanSpeed(): Not Supported
+
+[*] Cracking mysql hashes in increment mode...
+nvmlDeviceGetFanSpeed(): Not Supported
+
+[*] Cracked Passwords this run:
+[+] mysql_probe:probe
+[*] Cracking mysql-sha1 hashes in normal wordlist mode...
+nvmlDeviceGetFanSpeed(): Not Supported
+
+[*] Cracking mysql-sha1 hashes in increment mode...
+nvmlDeviceGetFanSpeed(): Not Supported
+
+[*] Cracked Passwords this run:
+[+] mysql-sha1_tere:tere
+[*] Auxiliary module execution completed
+[*] Starting persistent handler(s)...
+msf5 auxiliary(analyze/hashcat_mysql_fast) > creds
+Credentials
+===========
+
+host  origin  service  public           private                                    realm  private_type        JtR Format
+----  ------  -------  ------           -------                                    -----  ------------        ----------
+                       mysql_probe      probe                                             Password            
+                       mysql_probe      445ff82636a7ba59                                  Nonreplayable hash  mysql
+                       mysql-sha1_tere  tere                                              Password            
+                       mysql-sha1_tere  *5AD8F88516BD021DD43F171E2C785C69F8E54ADB         Nonreplayable hash  mysql-sha1
+
+```

--- a/documentation/modules/auxiliary/analyze/hashcat_oracle_fast.md
+++ b/documentation/modules/auxiliary/analyze/hashcat_oracle_fast.md
@@ -1,0 +1,140 @@
+## Vulnerable Application
+
+  This module attempts to use [hashcat](https://hashcat.net/hashcat/) to decode oracle
+  based password hashes, such as:
+
+  * `oracle11` based passwords (format 112)
+  * Oracle 11 and 12c backwards compatibility `H` field (MD5)
+  * `oracle12c` based passwords (format 12300)
+
+  Sources of hashes can be found here:
+  [source](https://hashcat.net/wiki/doku.php?id=example_hashes)
+
+  For a detailed explanation of Oracle 11/12c formats, see
+  [www.trustwave.com](https://www.trustwave.com/en-us/resources/blogs/spiderlabs-blog/changes-in-oracle-database-12c-password-hashes/).
+
+  Oracle 11/12c `H` field is `dynamic_1506` in JtR and added
+  [here](https://github.com/magnumripper/JohnTheRipper/commit/53973c5e6eb026ea232ba643f9aa20a1ffee0ffb)
+
+## Verification Steps
+
+  1. Have at least one user with an `oracle11`, or `oracle12c` password in the database
+  2. Start msfconsole
+  3. Do: ```use auxiliary/analyze/hashcat_oracle_fast```
+  4. Do: ```run```
+  5. You should hopefully crack a password.
+
+## Options
+
+   **CUSTOM_WORDLIST**
+
+   The path to an optional custom wordlist.  This file is added to the new wordlist which may include the other
+   `USE` items like `USE_CREDS`, and have `MUTATE` or `KORELOGIC` applied to it.
+
+   **DeleteTempFiles**
+
+   This option will prevent deletion of the wordlist and file containing hashes.  This may be useful for
+   running the hashes through john if it wasn't cracked, or for debugging. Default is `false`.
+
+   **ITERATION_TIMEOUT**
+
+   The max-run-time for each iteration of cracking
+
+   **HASHCAT_PATH**
+
+   The absolute path to the Hashcat executable.  Default behavior is to search `path` for
+   `hashcat` and `hashcat.exe`.
+
+   **MUTATE**
+
+   Apply common mutations to the Wordlist (SLOW).  Mutations are:
+
+   * `'@' => 'a'`
+   * `'0' => 'o'`
+   * `'3' => 'e'`
+   * `'$' => 's'`
+   * `'7' => 't'`
+   * `'1' => 'l'`
+   * `'5' => 's'`
+
+   Default is `false`.
+
+   **POT**
+
+   The path to a John POT file (JtR option: `--pot`) to use instead.  The `pot` file is the data file which
+   records cracked password hashes.  Kali linux's default location is `/root/.john/john.pot`.
+   Default is `~/.msf4/john.pot`.
+
+   **USE_CREDS**
+
+   Use existing credential data saved in the database.  Default is `true`.
+
+   **USE_DB_INFO**
+
+   Use looted database schema info to seed the wordlist.  This includes the Database Name, each Table Name,
+   and each Column Name.  If the DB is MSSQL, the Instance Name is also used.  Default is `true`.
+
+   **USE_DEFAULT_WORDLIST**
+
+   Use the default metasploit wordlist in `metasploit-framework/data/wordlists/password.lst`.  Default is
+   `true`.
+
+   **USE_HOSTNAMES**
+
+   Seed the wordlist with hostnames from the workspace.  Default is `true`.
+
+   **USE_ROOT_WORDS**
+
+   Use the Common Root Words Wordlist in `metasploit-framework/data/wordlists/common_roots.txt`.  Default
+   is true.
+
+## Scenarios
+
+Create hashes:
+
+```
+creds add user:DEMO hash:'S:8F2D65FB5547B71C8DA3760F10960428CD307B1C6271691FC55C1F56554A;H:DC9894A01797D91D92ECA1DA66242209;T:23D1F8CAC9001F69630ED2DD8DF67DD3BE5C470B5EA97B622F757FE102D8BF14BEDC94A3CC046D10858D885DB656DC0CBF899A79CD8C76B788744844CADE54EEEB4FDEC478FB7C7CBFBBAC57BA3EF22C' jtr:raw-sha1,oracle
+creds add user:oracle11_epsilon hash:'S:8F2D65FB5547B71C8DA3760F10960428CD307B1C6271691FC55C1F56554A;H:DC9894A01797D91D92ECA1DA66242209;T:23D1F8CAC9001F69630ED2DD8DF67DD3BE5C470B5EA97B622F757FE102D8BF14BEDC94A3CC046D10858D885DB656DC0CBF899A79CD8C76B788744844CADE54EEEB4FDEC478FB7C7CBFBBAC57BA3EF22C' jtr:raw-sha1,oracle
+creds add user:oracle12c_epsilon hash:'H:DC9894A01797D91D92ECA1DA66242209;T:E3243B98974159CC24FD2C9A8B30BA62E0E83B6CA2FC7C55177C3A7F82602E3BDD17CEB9B9091CF9DAD672B8BE961A9EAC4D344BDBA878EDC5DCB5899F689EBD8DD1BE3F67BFF9813A464382381AB36B' jtr:pbkdf2,oracle12c
+```
+
+Crack them:
+
+```
+resource (hashes_hashcat.rb)> use auxiliary/analyze/hashcat_oracle_fast
+resource (hashes_hashcat.rb)> run
+[*] Hashes Written out to /tmp/hashes_tmp20190331-19544-a0t5x7
+[*] Wordlist file written out to /tmp/jtrtmp20190331-19544-hzazz1
+[*] Cracking raw-sha1,oracle hashes in normal wordlist mode...
+nvmlDeviceGetFanSpeed(): Not Supported
+
+[*] Cracking raw-sha1,oracle hashes in increment mode...
+nvmlDeviceGetFanSpeed(): Not Supported
+
+[*] Cracked Passwords this run:
+[+] DEMO:epsilon
+[+] oracle11_epsilon:epsilon
+[*] Cracking pbkdf2,oracle12c hashes in normal wordlist mode...
+nvmlDeviceGetFanSpeed(): Not Supported
+
+[*] Cracking pbkdf2,oracle12c hashes in increment mode...
+nvmlDeviceGetFanSpeed(): Not Supported
+
+[*] Cracked Passwords this run:
+[+] oracle12c_epsilon:epsilon
+[*] Auxiliary module execution completed
+[*] Starting persistent handler(s)...
+msf5 auxiliary(analyze/hashcat_oracle_fast) > creds
+Credentials
+===========
+
+host  origin  service  public             private                                                                                                                                                                                                                                                               realm  private_type        JtR Format
+----  ------  -------  ------             -------                                                                                                                                                                                                                                                               -----  ------------        ----------
+                       DEMO               epsilon                                                                                                                                                                                                                                                                      Password            
+                       DEMO               S:8F2D65FB5547B71C8DA3760F10960428CD307B1C6271691FC55C1F56554A;H:DC9894A01797D91D92ECA1DA66242209;T:23D1F8CAC9001F69630ED2DD8DF67DD3BE5C470B5EA97B622F757FE102D8BF14BEDC94A3CC046D10858D885DB656DC0CBF899A79CD8C76B788744844CADE54EEEB4FDEC478FB7C7CBFBBAC57BA3EF22C         Nonreplayable hash  raw-sha1,oracle
+                       oracle11_epsilon   epsilon                                                                                                                                                                                                                                                                      Password            
+                       oracle11_epsilon   S:8F2D65FB5547B71C8DA3760F10960428CD307B1C6271691FC55C1F56554A;H:DC9894A01797D91D92ECA1DA66242209;T:23D1F8CAC9001F69630ED2DD8DF67DD3BE5C470B5EA97B622F757FE102D8BF14BEDC94A3CC046D10858D885DB656DC0CBF899A79CD8C76B788744844CADE54EEEB4FDEC478FB7C7CBFBBAC57BA3EF22C         Nonreplayable hash  raw-sha1,oracle
+                       oracle12c_epsilon  epsilon                                                                                                                                                                                                                                                                      Password            
+                       oracle12c_epsilon  H:DC9894A01797D91D92ECA1DA66242209;T:E3243B98974159CC24FD2C9A8B30BA62E0E83B6CA2FC7C55177C3A7F82602E3BDD17CEB9B9091CF9DAD672B8BE961A9EAC4D344BDBA878EDC5DCB5899F689EBD8DD1BE3F67BFF9813A464382381AB36B                                                                        Nonreplayable hash  pbkdf2,oracle12c
+
+```

--- a/documentation/modules/auxiliary/analyze/hashcat_postgres_fast.md
+++ b/documentation/modules/auxiliary/analyze/hashcat_postgres_fast.md
@@ -1,0 +1,115 @@
+## Vulnerable Application
+
+  This module attempts to use [hashcat](https://hashcat.net/hashcat/) to decode PostgreSQL
+  based password hashes, such as:
+
+  * `postgres` based passwords (format 12)
+
+  Sources of hashes can be found here:
+  [source](https://hashcat.net/wiki/doku.php?id=example_hashes)
+
+## Verification Steps
+
+  1. Have at least one user with an `postgres`, or `raw-md5` password in the database
+  2. Start msfconsole
+  3. Do: ```use auxiliary/analyze/hashcat_postgres_fast```
+  4. Do: ```run```
+  5. You should hopefully crack a password.
+
+## Options
+
+   **CUSTOM_WORDLIST**
+
+   The path to an optional custom wordlist.  This file is added to the new wordlist which may include the other
+   `USE` items like `USE_CREDS`, and have `MUTATE` or `KORELOGIC` applied to it.
+
+   **DeleteTempFiles**
+
+   This option will prevent deletion of the wordlist and file containing hashes.  This may be useful for
+   running the hashes through john if it wasn't cracked, or for debugging. Default is `false`.
+
+   **ITERATION_TIMEOUT**
+
+   The max-run-time for each iteration of cracking
+
+   **HASHCAT_PATH**
+
+   The absolute path to the Hashcat executable.  Default behavior is to search `path` for
+   `hashcat` and `hashcat.exe`.
+
+   **MUTATE**
+
+   Apply common mutations to the Wordlist (SLOW).  Mutations are:
+
+   * `'@' => 'a'`
+   * `'0' => 'o'`
+   * `'3' => 'e'`
+   * `'$' => 's'`
+   * `'7' => 't'`
+   * `'1' => 'l'`
+   * `'5' => 's'`
+
+   Default is `false`.
+
+   **POT**
+
+   The path to a John POT file (JtR option: `--pot`) to use instead.  The `pot` file is the data file which
+   records cracked password hashes.  Kali linux's default location is `/root/.john/john.pot`.
+   Default is `~/.msf4/john.pot`.
+
+   **USE_CREDS**
+
+   Use existing credential data saved in the database.  Default is `true`.
+
+   **USE_DB_INFO**
+
+   Use looted database schema info to seed the wordlist.  This includes the Database Name, each Table Name,
+   and each Column Name.  If the DB is MSSQL, the Instance Name is also used.  Default is `true`.
+
+   **USE_DEFAULT_WORDLIST**
+
+   Use the default metasploit wordlist in `metasploit-framework/data/wordlists/password.lst`.  Default is
+   `true`.
+
+   **USE_HOSTNAMES**
+
+   Seed the wordlist with hostnames from the workspace.  Default is `true`.
+
+   **USE_ROOT_WORDS**
+
+   Use the Common Root Words Wordlist in `metasploit-framework/data/wordlists/common_roots.txt`.  Default
+   is true.
+
+## Scenarios
+
+Create hashes:
+
+```
+creds add user:example postgres:md5be86a79bf2043622d58d5453c47d4860
+```
+
+Crack them:
+
+```
+resource (hashes_hashcat.rb)> use auxiliary/analyze/hashcat_postgres_fast
+resource (hashes_hashcat.rb)> run
+[*] Hashes Written out to /tmp/hashes_tmp20190331-19733-yc08ql
+[*] Wordlist file written out to /tmp/jtrtmp20190331-19733-196byn2
+[*] Cracking raw-md5,postgres hashes in normal wordlist mode...
+nvmlDeviceGetFanSpeed(): Not Supported
+
+[*] Cracking raw-md5,postgres hashes in increment mode...
+nvmlDeviceGetFanSpeed(): Not Supported
+
+[*] Cracked Passwords this run:
+[+] example:password
+[*] Auxiliary module execution completed
+msf5 auxiliary(analyze/hashcat_postgres_fast) > creds
+Credentials
+===========
+
+host  origin  service  public   private                              realm  private_type  JtR Format
+----  ------  -------  ------   -------                              -----  ------------  ----------
+                       example  password                                    Password      
+                       example  md5be86a79bf2043622d58d5453c47d4860         Postgres md5  raw-md5,postgres
+```

--- a/documentation/modules/auxiliary/analyze/hashcat_windows_fast.md
+++ b/documentation/modules/auxiliary/analyze/hashcat_windows_fast.md
@@ -1,0 +1,127 @@
+## Vulnerable Application
+
+  This module attempts to use [hashcat](https://hashcat.net/hashcat/) to decode Windows
+  based password hashes, such as:
+
+  * `LM`, or `LANMAN` based passwords (format 3000)
+  * `NT`, `NTLM`, or `NTLANMAN` based passwords (format 1000)
+
+  Sources of hashes can be found here:
+  [source](https://hashcat.net/wiki/doku.php?id=example_hashes)
+
+## Verification Steps
+
+  1. Have at least one user with an `nt` or `lm` password in the database
+  2. Start msfconsole
+  3. Do: ```use auxiliary/analyze/hashcat_windows_fast```
+  4. Do: ```run```
+  5. You should hopefully crack a password.
+
+## Options
+
+   **CUSTOM_WORDLIST**
+
+   The path to an optional custom wordlist.  This file is added to the new wordlist which may include the other
+   `USE` items like `USE_CREDS`, and have `MUTATE` or `KORELOGIC` applied to it.
+
+   **DeleteTempFiles**
+
+   This option will prevent deletion of the wordlist and file containing hashes.  This may be useful for
+   running the hashes through john if it wasn't cracked, or for debugging. Default is `false`.
+
+   **ITERATION_TIMEOUT**
+
+   The max-run-time for each iteration of cracking
+
+   **HASHCAT_PATH**
+
+   The absolute path to the Hashcat executable.  Default behavior is to search `path` for
+   `hashcat` and `hashcat.exe`.
+
+   **MUTATE**
+
+   Apply common mutations to the Wordlist (SLOW).  Mutations are:
+
+   * `'@' => 'a'`
+   * `'0' => 'o'`
+   * `'3' => 'e'`
+   * `'$' => 's'`
+   * `'7' => 't'`
+   * `'1' => 'l'`
+   * `'5' => 's'`
+
+   Default is `false`.
+
+   **POT**
+
+   The path to a John POT file (JtR option: `--pot`) to use instead.  The `pot` file is the data file which
+   records cracked password hashes.  Kali linux's default location is `/root/.john/john.pot`.
+   Default is `~/.msf4/john.pot`.
+
+   **USE_CREDS**
+
+   Use existing credential data saved in the database.  Default is `true`.
+
+   **USE_DB_INFO**
+
+   Use looted database schema info to seed the wordlist.  This includes the Database Name, each Table Name,
+   and each Column Name.  If the DB is MSSQL, the Instance Name is also used.  Default is `true`.
+
+   **USE_DEFAULT_WORDLIST**
+
+   Use the default metasploit wordlist in `metasploit-framework/data/wordlists/password.lst`.  Default is
+   `true`.
+
+   **USE_HOSTNAMES**
+
+   Seed the wordlist with hostnames from the workspace.  Default is `true`.
+
+   **USE_ROOT_WORDS**
+
+   Use the Common Root Words Wordlist in `metasploit-framework/data/wordlists/common_roots.txt`.  Default
+   is true.
+
+## Scenarios
+
+Create hashes:
+
+```
+creds add user:lm_password ntlm:E52CAC67419A9A224A3B108F3FA6CB6D:8846F7EAEE8FB117AD06BDD830B7586C jtr:lm
+creds add user:nt_password ntlm:AAD3B435B51404EEAAD3B435B51404EE:8846F7EAEE8FB117AD06BDD830B7586C jtr:nt
+```
+
+Crack them:
+
+```
+resource (hashes_hashcat.rb)> use auxiliary/analyze/hashcat_windows_fast
+resource (hashes_hashcat.rb)> run
+[*] Hashes Written out to /tmp/hashes_tmp20190331-19866-vijqha
+[*] Wordlist file written out to /tmp/jtrtmp20190331-19866-e2cjq3
+[*] Cracking lm hashes in normal wordlist mode...
+nvmlDeviceGetFanSpeed(): Not Supported
+
+[*] Cracking lm hashes in increment mode...
+nvmlDeviceGetFanSpeed(): Not Supported
+
+[*] Cracked Passwords this run:
+[+] lm_password:PASSWORD
+[*] Cracking nt hashes in normal wordlist mode...
+nvmlDeviceGetFanSpeed(): Not Supported
+
+[*] Cracking nt hashes in increment mode...
+nvmlDeviceGetFanSpeed(): Not Supported
+
+[*] Cracked Passwords this run:
+[+] nt_password:password
+[*] Auxiliary module execution completed
+resource (hashes_hashcat.rb)> creds
+Credentials
+===========
+
+host  origin  service  public       private                                                            realm  private_type  JtR Format
+----  ------  -------  ------       -------                                                            -----  ------------  ----------
+                       lm_password  PASSWORD                                                                  Password      
+                       lm_password  e52cac67419a9a224a3b108f3fa6cb6d:8846f7eaee8fb117ad06bdd830b7586c         NTLM hash     nt,lm
+                       nt_password  password                                                                  Password      
+                       nt_password  aad3b435b51404eeaad3b435b51404ee:8846f7eaee8fb117ad06bdd830b7586c         NTLM hash     nt,lm
+```

--- a/lib/metasploit/framework/hashcat/cracker.rb
+++ b/lib/metasploit/framework/hashcat/cracker.rb
@@ -1,0 +1,205 @@
+module Metasploit
+  module Framework
+    module Hashcat
+
+      class HashcatNotFoundError < StandardError
+      end
+
+      class Cracker
+        include ActiveModel::Validations
+
+        # @!attribute format
+        #   @return [String] The hash format to try
+        attr_accessor :format
+
+        # @!attribute hash_path
+        #   @return [String] The path to the file containing the hashes
+        attr_accessor :hash_path
+
+        # @!attribute increment
+        #   @return [String] The increment mode to use
+        attr_accessor :increment
+
+        # @!attribute hashcat_path
+        #   This attribute allows the user to specify a hashcat binary to use.
+        #   If not supplied, the Cracker will search the PATH for a suitable hashcat binary.
+        #
+        #   @return [String] The file path to an alternative hashcat binary to use
+        attr_accessor :hashcat_path
+
+        # @!attribute max_runtime
+        #   @return [Integer] An optional maximum duration of the cracking attempt in seconds
+        attr_accessor :max_runtime
+
+        # @!attribute pot
+        #   @return [String] The file path to an alternative hashcat pot file to use
+        attr_accessor :pot
+
+        # @!attribute rules
+        #   @return [String] The wordlist mangling rules to use inside hashcat
+        attr_accessor :rules
+
+        # @!attribute attack
+        #   @return [String] The attack mode for hashcat to use
+        attr_accessor :attack
+
+        # @!attribute wordlist
+        #   @return [String] The file path to the wordlist to use
+        attr_accessor :wordlist
+
+        validates :hash_path, :'Metasploit::Framework::File_path' => true, if: 'hash_path.present?'
+
+        validates :hashcat_path, :'Metasploit::Framework::Executable_path' => true, if: 'hashcat_path.present?'
+
+        validates :pot, :'Metasploit::Framework::File_path' => true, if: 'pot.present?'
+
+        validates :max_runtime,
+                  numericality: {
+                      only_integer:             true,
+                      greater_than_or_equal_to: 0
+                  }, if: 'max_runtime.present?'
+
+        validates :wordlist, :'Metasploit::Framework::File_path' => true, if: 'wordlist.present?'
+
+        # @param attributes [Hash{Symbol => String,nil}]
+        def initialize(attributes={})
+          attributes.each do |attribute, value|
+            public_send("#{attribute}=", value)
+          end
+        end
+
+        # This method follows a decision tree to determine the path
+        # to the hashcat binary we should use.
+        #
+        # @return [NilClass] if a binary path could not be found
+        # @return [String] the path to the selected hashcat binary
+        def binary_path
+          # Always prefer a manually entered path
+          if hashcat_path && ::File.file?(hashcat_path)
+            bin_path = hashcat_path
+          else
+            # Look in the Environment PATH for the hashcat binary
+            path = Rex::FileUtils.find_full_path("hashcat") ||
+                Rex::FileUtils.find_full_path("hashcat.exe")
+
+            if path && ::File.file?(path)
+              bin_path = path
+            end
+          end
+          raise HashcatNotFoundError, 'No suitable Hashcat binary was found on the system' if bin_path.blank?
+          bin_path
+        end
+
+        # This method runs the command from {#crack_command} and yields each line of output.
+        #
+        # @yield [String] a line of output from the hashcat command
+        # @return [void]
+        def crack
+          ::IO.popen(crack_command, "rb") do |fd|
+            fd.each_line do |line|
+              yield line
+            end
+          end
+        end
+
+        # This method builds an array for the command to actually run the cracker.
+        # It builds the command from all of the attributes on the class.
+        #
+        # @raise [HashcatNotFoundError] if a suitable Hashcat binary was never found
+        # @return [Array] An array set up for {::IO.popen} to use
+        def crack_command
+          cmd_string = binary_path
+          cmd = [ cmd_string,  '--session=' + hashcat_session_id, '--logfile-disable' ]
+
+          if pot.present?
+            cmd << ( "--potfile-path=" + pot )
+          else
+            cmd << ( "--potfile-path=" + hashcat_pot_file)
+          end
+
+          if format.present?
+            cmd << ( "--hash-type=" + format )
+          end
+
+          if increment.present?
+            cmd << ( "--increment")
+            cmd << ( "--increment-max=4") 
+            # anything more than max 4 on even des took 8+min on an i7.
+            # maybe in the future this can be adjusted or made a variable
+            # but current time, we'll leave it as this seems like reasonable
+            # time expectation for a module to run
+          end
+
+          if rules.present?
+            cmd << ( "--rules-file=" + rules )
+          end
+
+          if attack.present?
+            cmd << ( "--attack-mode=" + attack )
+          end
+
+          if max_runtime.present?
+            cmd << ( "--runtime=" + max_runtime.to_s)
+          end
+
+          cmd << hash_path
+
+          # must be last
+          if wordlist.present?
+            cmd << ( wordlist )
+          end
+          cmd
+        end
+
+        # This runs the show command in hashcat and yields cracked passwords.
+        #
+        # @yield [String] the output lines from the command
+        # @return [void]
+        def each_cracked_password
+          ::IO.popen(show_command, "rb") do |fd|
+            fd.each_line do |line|
+              # remove error lines
+              unless line.include?('Token length exception') || line.include?('separator unmatched')
+                yield line
+              end
+            end
+          end
+        end
+
+        # This method returns the path to a default john.pot file.
+        # For simplicity of cracking between jtr/hashcat, the john.pot
+        # file from jtr is used
+        #
+        # @return [String] the path to the default john.pot file
+        def hashcat_pot_file
+          ::File.join( ::Msf::Config.config_directory, "john.pot" )
+        end
+
+        # This method is a getter for a random Session ID for Hashcat.
+        # It allows us to dinstiguish between cracking sessions.
+        #
+        # @ return [String] the Session ID to use
+        def hashcat_session_id
+          @session_id ||= ::Rex::Text.rand_text_alphanumeric(8)
+        end
+
+        # This method builds the command to show the cracked passwords.
+        #
+        # @raise [HashcatNotFoundError] if a suitable Hashcat binary was never found
+        # @return [Array] An array set up for {::IO.popen} to use
+        def show_command
+          cmd_string = binary_path
+
+          pot_file = pot || hashcat_pot_file
+          cmd = [cmd_string, "--show", "--potfile-path=#{pot_file}", "--hash-type=#{format}" ]
+          cmd << hash_path
+          cmd
+        end
+
+        private
+
+      end
+
+    end
+  end
+end

--- a/lib/metasploit/framework/hashcat/formatter.rb
+++ b/lib/metasploit/framework/hashcat/formatter.rb
@@ -1,0 +1,71 @@
+# This method takes a {framework.db.cred}, and normalizes it
+# to the string format hashcat is expecting.
+# https://hashcat.net/wiki/doku.php?id=example_hashes
+#
+# @param [credClass] a credential from framework.db
+# @return [String] the hash in jtr format or nil on no mach
+def hash_to_hashcat(cred)
+  case cred.private.type
+  when 'Metasploit::Credential::NTLMHash'
+    both = cred.private.data.split(":")
+    if both[0].upcase == 'AAD3B435B51404EEAAD3B435B51404EE' #lanman empty, return ntlm
+      return both[1] # ntlm hash-mode: 1000
+    end
+    return both[0] #give lanman, hash-mode: 3000
+  when 'Metasploit::Credential::PostgresMD5' #hash-mode: 12
+    if cred.private.jtr_format =~ /postgres|raw-md5/
+      hash_string = cred.private.data
+      hash_string.gsub!(/^md5/, '')
+      return "#{hash_string}:#{cred.public.username}"
+    end
+  when 'Metasploit::Credential::NonreplayableHash'
+    case cred.private.jtr_format
+      # oracle 11+ password hash descriptions:
+      # this password is stored as a long ascii string with several sections
+      # https://www.trustwave.com/en-us/resources/blogs/spiderlabs-blog/changes-in-oracle-database-12c-password-hashes/
+      # example:
+      # hash = []
+      # hash << "S:8F2D65FB5547B71C8DA3760F10960428CD307B1C6271691FC55C1F56554A;"
+      # hash << "H:DC9894A01797D91D92ECA1DA66242209;"
+      # hash << "T:23D1F8CAC9001F69630ED2DD8DF67DD3BE5C470B5EA97B622F757FE102D8BF14BEDC94A3CC046D10858D885DB656DC0CBF899A79CD8C76B788744844CADE54EEEB4FDEC478FB7C7CBFBBAC57BA3EF22C"
+      # puts hash.join('')
+      # S: = 60 characters -> sha1(password + salt (10 bytes))
+      #         40 char sha1, 20 char salt
+      #         hash is 8F2D65FB5547B71C8DA3760F10960428CD307B1C
+      #         salt is 6271691FC55C1F56554A
+      # H: = 32 characters
+      #         legacy MD5
+      # T: = 160 characters
+      #         PBKDF2-based SHA512 hash specific to 12C (12.1.0.2+)
+    when /raw-sha1|oracle11/ # oracle 11, hash-mode: 112
+      if cred.private.data =~ /S:([\dA-F]{60})/ # oracle 11
+        # hashcat wants a 40 character string, : 20 character string
+        return $1.scan(/.{1,40}/m).join(':').downcase
+      end
+    when /oracle12c/
+      if cred.private.data =~ /T:([\dA-F]{160})/ # oracle 12c, hash-mode: 12300
+        return $1.upcase
+      end
+    when /dynamic_1506|postgres/
+      #this may not be correct
+      if cred.private.data =~ /H:([\dA-F]{32})/ # oracle 11, hash-mode: 3100
+        return "#{$1}:#{cred.public.username}"
+      end
+    when /oracle/ # oracle
+      if cred.private.jtr_format.start_with?('des') # 'des,oracle', not oracle11/12c, hash-mode: 3100
+        return "#{cred.private.data}"
+      end
+    when /mysql-sha1/
+      # lowercase, and remove the first character if its a *
+      return cred.private.data.downcase.sub('*','')
+    when /md5|des|bsdi|crypt|bf/, /mssql|mssql05|mssql12|mysql/, /sha256|sha-256/, /sha512|sha-512/
+      #            md5(crypt), des(crypt), b(crypt), sha256, sha512
+      # hash-mode: 500          1500        3200      7400    1800
+      #            mssql, mssql05, mssql12, mysql, mysql-sha1
+      # hash-mode: 131,    132,     1731    200        300
+      return cred.private.data
+    end
+  end
+  nil
+end
+

--- a/lib/msf/core/auxiliary/hashcat.rb
+++ b/lib/msf/core/auxiliary/hashcat.rb
@@ -1,0 +1,141 @@
+# -*- coding: binary -*-
+require 'open3'
+require 'fileutils'
+#require 'rex/proto/ntlm/crypt'
+require 'metasploit/framework/hashcat/cracker'
+require 'metasploit/framework/hashcat/formatter'
+require 'metasploit/framework/jtr/wordlist' #utilize jtr's wordlist for simplicity
+
+
+module Msf
+
+###
+#
+# This module provides methods for working with Hashcat
+#
+###
+module Auxiliary::Hashcat
+  include Msf::Auxiliary::Report
+
+  #
+  # Initializes an instance of an auxiliary module that calls out to Hashcat
+  #
+
+  def initialize(info = {})
+    super
+
+    register_options(
+      [
+        OptPath.new('CUSTOM_WORDLIST',      [false, 'The path to an optional custom wordlist']),
+        OptInt.new('ITERATION_TIMOUT',      [false, 'The runtime for each iteration of cracking']),
+        #OptPath.new('HASHCAT_PATH'          [false, 'The absolute path to the Hashcat executable']),
+        OptBool.new('MUTATE',               [false, 'Apply common mutations to the Wordlist (SLOW)', false]),
+        OptPath.new('POT',                  [false, 'The path to a Hashcat/John POT file to use instead of the default']),
+        OptBool.new('USE_CREDS',            [false, 'Use existing credential data saved in the database', true]),
+        OptBool.new('USE_DB_INFO',          [false, 'Use looted database schema info to seed the wordlist', true]),
+        OptBool.new('USE_DEFAULT_WORDLIST', [false, 'Use the default metasploit wordlist', true]),
+        OptBool.new('USE_HOSTNAMES',        [false, 'Seed the wordlist with hostnames from the workspace', true]),
+        OptBool.new('USE_ROOT_WORDS',       [false, 'Use the Common Root Words Wordlist', true])
+      ], Msf::Auxiliary::Hashcat
+    )
+    puts("!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+    puts("!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+    puts("!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+    puts("BUGGGG re-enable hashcat_path")
+    puts("!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+    puts("!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+    puts("!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+
+    register_advanced_options(
+      [
+        OptBool.new('DeleteTempFiles',    [false, 'Delete temporary wordlist and hash files', true])
+      ], Msf::Auxiliary::Hashcat
+    )
+  end
+
+  # This method creates a new {Metasploit::Framework::Hashcat::Cracker} and populates
+  # some of the attributes based on the module datastore options.
+  #
+  # @return [nilClass] if there is no active framework db connection
+  # @return [Metasploit::Framework::Hashcat::Cracker] if it successfully creates a Hashcat Cracker object
+  def new_hashcat_cracker
+    return nil unless framework.db.active
+    Metasploit::Framework::Hashcat::Cracker.new(
+        hashcat_path: datastore['HASHCAT_PATH'],
+        max_runtime: datastore['ITERATION_TIMEOUT'],
+        pot: datastore['POT'],
+        wordlist: datastore['CUSTOM_WORDLIST']
+    )
+  end
+
+  # This method instantiates a {Metasploit::Framework::JtR::Wordlist}, writes the data
+  # out to a file and returns the {Rex::Quickfile} object.  A custom Hashcat dictionary
+  # method isn't required, and the JtR one is mirrored here
+  #
+  # @param max_len [Integer] max length of a word in the wordlist, 0 default for ignored value
+  # @return [nilClass] if there is no active framework db connection
+  # @return [Rex::Quickfile] if it successfully wrote the wordlist to a file
+  def wordlist_file(max_len = 0)
+    return nil unless framework.db.active
+    wordlist = Metasploit::Framework::JtR::Wordlist.new(
+        custom_wordlist: datastore['CUSTOM_WORDLIST'],
+        mutate: datastore['MUTATE'],
+        use_creds: datastore['USE_CREDS'],
+        use_db_info: datastore['USE_DB_INFO'],
+        use_default_wordlist: datastore['USE_DEFAULT_WORDLIST'],
+        use_hostnames: datastore['USE_HOSTNAMES'],
+        use_common_root: datastore['USE_ROOT_WORDS'],
+        workspace: myworkspace
+    )
+    wordlist.to_file(max_len)
+  end
+
+  # This method takes a {framework.db.cred.private.jtr_format} (string), and
+  # returns the string number associated to the hashcat format
+  #
+  # @param[String] a jtr_format string
+  # @return [String] the format number for Hashcat
+  def jtr_format_to_hashcat_format(format)
+    case format
+    when 'md5crypt'
+      return '500'
+    when 'descrypt'
+      return '1500'
+    when 'bsdicrypt'
+      return '12400'
+    when 'sha256crypt'
+      return '7400'
+    when 'sha512crypt'
+      return '1800'
+    when 'bcrypt'
+      return '3200'
+    when 'lm', 'lanman'
+      return '3000'
+    when 'nt', 'ntlm'
+      return '1000'
+    when 'mssql'
+      return '131'
+    when 'mssql05'
+      return '132'
+    when 'mssql12'
+      return '1731'
+    # hashcat requires a format we dont have all the data for
+    # in the current dumper, so this is disabled in module and lib
+    #when 'oracle', 'des,oracle'
+    #  return '3100'
+    when 'oracle11', 'raw-sha1,oracle'
+      return '112'
+    when 'oracle12c', 'pbkdf2,oracle12c'
+      return '12300'
+    when 'postgres', 'dynamic_1034', 'raw-md5,postgres'
+      return '12'
+    when 'mysql'
+      return '200'
+    when 'mysql-sha1'
+      return '300'
+    end
+    nil
+  end
+
+end
+end

--- a/lib/msf/ui/console/command_dispatcher/creds.rb
+++ b/lib/msf/ui/console/command_dispatcher/creds.rb
@@ -4,6 +4,7 @@ require 'rexml/document'
 require 'rex/parser/nmap_xml'
 require 'msf/core/db_export'
 require 'msf/core/auxiliary/jtr'
+require 'msf/core/auxiliary/hashcat'
 
 module Msf
 module Ui
@@ -168,6 +169,7 @@ class Creds
     print_line "  -h,--help             Show this help information"
     print_line "  -o <file>             Send output to a file in csv/jtr (john the ripper) format."
     print_line "                        If file name ends in '.jtr', that format will be used."
+    print_line "                        If file name ends in '.hcat', the hashcat format will be used."
     print_line "                        csv by default."
     print_line "  -d,--delete           Delete one or more credentials"
     print_line
@@ -540,6 +542,19 @@ class Creds
          'Metasploit::Credential::NTLMHash'].each do |type|
           framework.db.creds(type: type).each do |core|
             formatted = hash_to_jtr(core)
+            unless formatted.nil?
+              hashlist.puts formatted
+            end
+          end
+        end
+        hashlist.close
+      elsif output_file.end_with? '.hcat'
+        hashlist = ::File.open(output_file, "wb")
+        ['Metasploit::Credential::NonreplayableHash',
+         'Metasploit::Credential::PostgresMD5',
+         'Metasploit::Credential::NTLMHash'].each do |type|
+          framework.db.creds(type: type).each do |core|
+            formatted = hash_to_hashcat(core)
             unless formatted.nil?
               hashlist.puts formatted
             end

--- a/modules/auxiliary/analyze/hashcat_aix.rb
+++ b/modules/auxiliary/analyze/hashcat_aix.rb
@@ -1,0 +1,107 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core/auxiliary/hashcat'
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Auxiliary::Hashcat
+
+  def initialize
+    super(
+      'Name'            => 'Hashcat AIX Password Cracker',
+      'Description'     => %Q{
+          This module uses Hashcat to identify weak passwords that have been
+        acquired from passwd files on AIX systems.  These utilize DES hashing.
+        descript is format 1500 in Hashcat.
+      },
+      'Author'          => ['h00die'],
+      'License'         => MSF_LICENSE
+    )
+  end
+
+  def run
+    cracker = new_hashcat_cracker
+
+    # hashes is an array to re-reference after cracking
+    # format: ['hash:username:id']
+    # create the hash file first, so if there aren't any hashes we can quit early
+    cracker.hash_path, hashes = hash_file
+
+    # generate our wordlist and close the file handle.  max length of DES is 8
+    wordlist = wordlist_file(8)
+    unless wordlist
+      print_error('This module cannot run without a database connected. Use db_connect to connect to a database.')
+      return
+    end
+
+    wordlist.close
+    print_status "Wordlist file written out to #{wordlist.path}"
+    cracker.wordlist = wordlist.path
+
+    cleanup_files = [cracker.hash_path, wordlist.path]
+
+    ['descrypt'].each do |format|
+      # dupe our original cracker so we can safely change options between each run
+      cracker_instance = cracker.dup
+      cracker_instance.format = jtr_format_to_hashcat_format(format)
+      print_status "Cracking #{format} hashes in normal wordlist mode..."
+      cracker_instance.crack do |line|
+        vprint_status line.chomp
+      end
+
+      print_status "Cracking #{format} hashes in increment mode..."
+      cracker_instance.wordlist = nil
+      cracker_instance.attack = '3'
+      cracker_instance.increment = true
+      cracker_instance.crack do |line|
+        vprint_status line.chomp
+      end
+
+      print_status "Cracked Passwords this run:"
+      cracker_instance.each_cracked_password do |password_line|
+        password_line.chomp!
+        next if password_line.blank?
+        fields = password_line.split(":")
+        # If we don't have an expected minimum number of fields, this is probably not a hash line
+        next unless fields.count >= 2
+        hash = fields.shift
+        password = fields.join(':') # Anything left must be the password. This accounts for passwords with : in them
+        hashes.each do |h|
+          h = h.split(":")
+          next unless h[0] == hash
+          username = h[1]
+          core_id  = h[2]
+          print_good "#{username}:#{password}"
+          create_cracked_credential( username: username, password: password, core_id: core_id)
+        end
+      end
+    end
+    if datastore['DeleteTempFiles']
+      cleanup_files.each do |f|
+        File.delete(f)
+      end
+    end
+  end
+
+  def hash_file
+    hashes = []
+    wrote_hash = false
+    hashlist = Rex::Quickfile.new("hashes_tmp")
+    framework.db.creds(workspace: myworkspace, type: 'Metasploit::Credential::NonreplayableHash').each do |core|
+      if core.private.jtr_format =~ /des/
+        hashes << "#{core.private.data}:#{core.public.username}:#{core.id}"
+        hashlist.puts hash_to_hashcat(core)
+        wrote_hash = true
+      end
+    end
+    hashlist.close
+    unless wrote_hash # check if we wrote anything and bail early if we didn't
+      hashlist.delete
+      fail_with Failure::NotFound, 'No DES hashes in database to crack'
+    end
+    print_status "Hashes Written out to #{hashlist.path}"
+    return hashlist.path, hashes
+  end
+end

--- a/modules/auxiliary/analyze/hashcat_linux.rb
+++ b/modules/auxiliary/analyze/hashcat_linux.rb
@@ -1,0 +1,127 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core/auxiliary/hashcat'
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Auxiliary::Hashcat
+
+  def initialize
+    super(
+      'Name'            => 'Hashcat Linux Password Cracker',
+      'Description'     => %Q{
+          This module uses Hashcat to identify weak passwords that have been
+        acquired from unshadowed passwd files from Unix systems. The module will only crack
+        MD5, BSDi and DES implementations by default. Set Crypt to true to also try to crack
+        Blowfish and SHA(256/512). Warning: This is much slower.
+        MD5 is format 500 in hashcat.
+        BSDi is format 12400 in hashcat.
+        DES is format 1500 in hashcat.
+        Blowfish/bf/bcrypt is format 3200 in hashcat.
+        Sha256 is format 7400 in hashcat.
+        Sha512 is format 1800 in hashcat.
+      },
+      'Author'          => ['h00die'],
+      'License'         => MSF_LICENSE
+    )
+    register_options(
+      [
+        OptBool.new('Crypt',[false, 'Try blowfish/sha256/sha512 format hashes(Very Slow)', false])
+      ]
+    )
+  end
+
+  def run
+
+    formats = [ 'md5crypt', 'descrypt', 'bsdicrypt']
+    if datastore['Crypt']
+      formats << 'sha256crypt'
+      formats << 'sha512crypt'
+      formats << 'bcrypt'
+    end
+
+    cracker = new_hashcat_cracker
+
+    # hashes is an array to re-reference after cracking
+    # format: ['hash:username:id']
+    # create the hash file first, so if there aren't any hashes we can quit early
+    cracker.hash_path, hashes = hash_file
+
+    # generate our wordlist and close the file handle.  max length of DES is 8
+    wordlist = wordlist_file(8)
+    unless wordlist
+      print_error('This module cannot run without a database connected. Use db_connect to connect to a database.')
+      return
+    end
+
+    wordlist.close
+    print_status "Wordlist file written out to #{wordlist.path}"
+    cracker.wordlist = wordlist.path
+
+    cleanup_files = [cracker.hash_path, wordlist.path]
+
+    formats.each do |format|
+      # dupe our original cracker so we can safely change options between each run
+      cracker_instance = cracker.dup
+      cracker_instance.format = jtr_format_to_hashcat_format(format)
+      print_status "Cracking #{format} hashes in normal wordlist mode..."
+      cracker_instance.crack do |line|
+        vprint_status line.chomp
+      end
+
+      print_status "Cracking #{format} hashes in increment mode..."
+      cracker_instance.wordlist = nil
+      cracker_instance.attack = '3'
+      cracker_instance.increment = true
+      cracker_instance.crack do |line|
+        vprint_status line.chomp
+      end
+
+      print_status "Cracked Passwords this run:"
+      cracker_instance.each_cracked_password do |password_line|
+        password_line.chomp!
+        next if password_line.blank?
+        fields = password_line.split(":")
+        # If we don't have an expected minimum number of fields, this is probably not a hash line
+        next unless fields.count >= 2
+        hash = fields.shift
+        password = fields.join(':') # Anything left must be the password. This accounts for passwords with : in them
+        hashes.each do |h|
+          h = h.split(":")
+          next unless h[0] == hash
+          username = h[1]
+          core_id  = h[2]
+          print_good "#{username}:#{password}"
+          create_cracked_credential( username: username, password: password, core_id: core_id)
+        end
+      end
+    end
+    if datastore['DeleteTempFiles']
+      cleanup_files.each do |f|
+        File.delete(f)
+      end
+    end
+  end
+
+  def hash_file
+    hashes = []
+    wrote_hash = false
+    hashlist = Rex::Quickfile.new("hashes_tmp")
+    framework.db.creds(workspace: myworkspace, type: 'Metasploit::Credential::NonreplayableHash').each do |core|
+      if core.private.jtr_format =~ /md5|des|bsdi|crypt|bf|sha256|sha512|sha-256|sha-512/
+        hashes << "#{core.private.data}:#{core.public.username}:#{core.id}"
+        hashlist.puts hash_to_hashcat(core)
+        wrote_hash = true
+      end
+    end
+    hashlist.close
+    unless wrote_hash # check if we wrote anything and bail early if we didn't
+      hashlist.delete
+      fail_with Failure::NotFound, 'No applicable hashes in database to crack'
+    end
+    print_status "Hashes Written out to #{hashlist.path}"
+    return hashlist.path, hashes
+  end
+end

--- a/modules/auxiliary/analyze/hashcat_mssql_fast.rb
+++ b/modules/auxiliary/analyze/hashcat_mssql_fast.rb
@@ -1,0 +1,115 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core/auxiliary/hashcat'
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Auxiliary::Hashcat
+
+  def initialize
+    super(
+      'Name'            => 'Hashcat MSSQL Password Cracker',
+      'Description'     => %Q{
+          This module uses Hashcat to identify weak passwords that have been
+        acquired from the mssql_hashdump module.
+        mssql is format 131 in hashcat.
+        mssql05 is format 132 in hashcat.
+        mssql12 is format 1731 in hashcat.
+      },
+      'Author'          => ['h00die'],
+      'License'         => MSF_LICENSE
+    )
+  end
+
+  def run
+    @formats = Set.new
+
+    cracker = new_hashcat_cracker
+
+    # hashes is an array to re-reference after cracking
+    # format: ['hash:username:id']
+    # create the hash file first, so if there aren't any hashes we can quit early
+    cracker.hash_path, hashes = hash_file
+
+    # generate our wordlist and close the file handle.
+    wordlist = wordlist_file
+    unless wordlist
+      print_error('This module cannot run without a database connected. Use db_connect to connect to a database.')
+      return
+    end
+
+    wordlist.close
+    print_status "Wordlist file written out to #{wordlist.path}"
+    cracker.wordlist = wordlist.path
+
+    cleanup_files = [cracker.hash_path, wordlist.path]
+
+    @formats.each do |format|
+      # dupe our original cracker so we can safely change options between each run
+      cracker_instance = cracker.dup
+      cracker_instance.format = jtr_format_to_hashcat_format(format)
+      print_status "Cracking #{format} hashes in normal wordlist mode..."
+      cracker_instance.crack do |line|
+        vprint_status line.chomp
+      end
+
+      print_status "Cracking #{format} hashes in increment mode..."
+      cracker_instance.wordlist = nil
+      cracker_instance.attack = '3'
+      cracker_instance.increment = true
+      cracker_instance.crack do |line|
+        vprint_status line.chomp
+      end
+
+      print_status "Cracked Passwords this run:"
+      cracker_instance.each_cracked_password do |password_line|
+        password_line.chomp!
+        next if password_line.blank?
+        fields = password_line.split(":")
+        # If we don't have an expected minimum number of fields, this is probably not a hash line
+        next unless fields.count >= 2
+        hash = fields.shift
+        password = fields.join(':') # Anything left must be the password. This accounts for passwords with : in them
+        hashes.each do |h|
+          h = h.split(":")
+          if format == 'mssql'
+            # for whatever reason hashcat zeroes out part of the has in --show.
+            # show: 0x0100a607ba7c0000000000000000000000000000000000000000b6d6261460d3f53b279cc6913ce747006a2e3254:FOO
+            # orig: 0x0100A607BA7C54A24D17B565C59F1743776A10250F581D482DA8B6D6261460D3F53B279CC6913CE747006A2E3254
+            hash_zero_format = "#{h[0][0..13]}#{'0'*40}#{h[0][54..hash.length]}".downcase
+            next unless hash_zero_format == hash.downcase
+          else
+            # hashcat returns the hash in uppercase except 0x, so we downcase
+            next unless h[0].downcase == hash.downcase
+          end
+          username = h[1]
+          core_id  = h[2]
+          print_good "#{username}:#{password}"
+          create_cracked_credential( username: username, password: password, core_id: core_id)
+        end
+      end
+    end
+    if datastore['DeleteTempFiles']
+      cleanup_files.each do |f|
+        File.delete(f)
+      end
+    end
+  end
+
+  def hash_file
+    hashes = []
+    hashlist = Rex::Quickfile.new("hashes_tmp")
+    framework.db.creds(workspace: myworkspace, type: 'Metasploit::Credential::NonreplayableHash').each do |core|
+      if core.private.jtr_format =~ /mssql|mssql05|mssql12/
+        @formats << core.private.jtr_format
+        hashlist.puts hash_to_hashcat(core)
+        hashes << "#{core.private.data}:#{core.public.username}:#{core.id}"
+      end
+    end
+    hashlist.close
+    print_status "Hashes Written out to #{hashlist.path}"
+    return hashlist.path, hashes
+  end
+end

--- a/modules/auxiliary/analyze/hashcat_mysql_fast.rb
+++ b/modules/auxiliary/analyze/hashcat_mysql_fast.rb
@@ -1,0 +1,111 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core/auxiliary/hashcat'
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Auxiliary::Hashcat
+
+  def initialize
+    super(
+      'Name'            => 'Hashcat MySQL Password Cracker (Fast Mode)',
+      'Description'     => %Q{
+          This module uses Hashcat to identify weak passwords that have been
+        acquired from the mysql_hashdump module.
+        mysql is format 200 in hashcat.
+        mysql-sha1 is format 300 in hashcat.
+      },
+      'Author'          => ['h00die'],
+      'License'         => MSF_LICENSE
+    )
+  end
+
+  def run
+    @formats = Set.new
+
+    cracker = new_hashcat_cracker
+
+    # hashes is an array to re-reference after cracking
+    # format: ['hash:username:id']
+    # create the hash file first, so if there aren't any hashes we can quit early
+    cracker.hash_path, hashes = hash_file
+
+    # generate our wordlist and close the file handle.
+    wordlist = wordlist_file
+    unless wordlist
+      print_error('This module cannot run without a database connected. Use db_connect to connect to a database.')
+      return
+    end
+
+    wordlist.close
+    print_status "Wordlist file written out to #{wordlist.path}"
+    cracker.wordlist = wordlist.path
+
+    cleanup_files = [cracker.hash_path, wordlist.path]
+
+    @formats.each do |format|
+      # dupe our original cracker so we can safely change options between each run
+      cracker_instance = cracker.dup
+      cracker_instance.format = jtr_format_to_hashcat_format(format)
+      print_status "Cracking #{format} hashes in normal wordlist mode..."
+      cracker_instance.crack do |line|
+        vprint_status line.chomp
+      end
+
+      print_status "Cracking #{format} hashes in increment mode..."
+      cracker_instance.wordlist = nil
+      cracker_instance.attack = '3'
+      cracker_instance.increment = true
+      cracker_instance.crack do |line|
+        vprint_status line.chomp
+      end
+
+      print_status "Cracked Passwords this run:"
+      cracker_instance.each_cracked_password do |password_line|
+        password_line.chomp!
+        next if password_line.blank?
+        fields = password_line.split(":")
+        # If we don't have an expected minimum number of fields, this is probably not a hash line
+        next unless fields.count >= 2
+        hash = fields.shift
+        password = fields.join(':') # Anything left must be the password. This accounts for passwords with : in them
+        hashes.each do |h|
+          h = h.split(":")
+          if format == 'mysql-sha1'
+            # add the * back to the beginning to match up
+            next unless h[0].downcase == "*#{hash.downcase}"
+          else
+            # hashcat returns the hash in uppercase except 0x, so we downcase
+            next unless h[0].downcase == hash.downcase
+          end
+          username = h[1]
+          core_id  = h[2]
+          print_good "#{username}:#{password}"
+          create_cracked_credential( username: username, password: password, core_id: core_id)
+        end
+      end
+    end
+    if datastore['DeleteTempFiles']
+      cleanup_files.each do |f|
+        File.delete(f)
+      end
+    end
+  end
+
+  def hash_file
+    hashes = []
+    hashlist = Rex::Quickfile.new("hashes_tmp")
+    framework.db.creds(workspace: myworkspace, type: 'Metasploit::Credential::NonreplayableHash').each do |core|
+      if core.private.jtr_format =~ /mysql|mysql-sha1/
+        @formats << core.private.jtr_format
+        hashlist.puts hash_to_hashcat(core)
+        hashes << "#{core.private.data}:#{core.public.username}:#{core.id}"
+      end
+    end
+    hashlist.close
+    print_status "Hashes Written out to #{hashlist.path}"
+    return hashlist.path, hashes
+  end
+end

--- a/modules/auxiliary/analyze/hashcat_oracle_fast.rb
+++ b/modules/auxiliary/analyze/hashcat_oracle_fast.rb
@@ -1,0 +1,121 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core/auxiliary/hashcat'
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Auxiliary::Hashcat
+
+  def initialize
+    super(
+      'Name'           => 'Hashcat Oracle Password Cracker (Fast Mode)',
+      'Description'    => %Q{
+          This module uses Hashcat to identify weak passwords that have been
+        acquired from the oracle_hashdump module. Passwords that have been successfully
+        cracked are then saved as proper credentials.
+        oracle is format 3100 in hashcat, hashcat's format requires additional
+        fields not supported.  Please use the JtR module instead for oracle.
+        oracle11 is format 112 in hashcat.
+        oracle12c is format 12300 in hashcat.
+      },
+      'Author'         => ['h00die'] ,
+      'License'        => MSF_LICENSE
+    )
+  end
+
+  def run
+    @formats = Set.new
+
+    cracker = new_hashcat_cracker
+
+    # hashes is an array to re-reference after cracking
+    # format: ['hash:username:id']
+    # create the hash file first, so if there aren't any hashes we can quit early
+    cracker.hash_path, hashes = hash_file
+
+    # generate our wordlist and close the file handle.
+    wordlist = wordlist_file
+    unless wordlist
+      print_error('This module cannot run without a database connected. Use db_connect to connect to a database.')
+      return
+    end
+
+    wordlist.close
+    print_status "Wordlist file written out to #{wordlist.path}"
+    cracker.wordlist = wordlist.path
+
+    cleanup_files = [cracker.hash_path, wordlist.path]
+
+    @formats.each do |format|
+      # dupe our original cracker so we can safely change options between each run
+      cracker_instance = cracker.dup
+      cracker_instance.format = jtr_format_to_hashcat_format(format)
+      print_status "Cracking #{format} hashes in normal wordlist mode..."
+      cracker_instance.crack do |line|
+        vprint_status line.chomp
+      end
+
+      print_status "Cracking #{format} hashes in increment mode..."
+      cracker_instance.wordlist = nil
+      cracker_instance.attack = '3'
+      cracker_instance.increment = true
+      cracker_instance.crack do |line|
+        vprint_status line.chomp
+      end
+
+      print_status "Cracked Passwords this run:"
+      cracker_instance.each_cracked_password do |password_line|
+        password_line.chomp!
+        next if password_line.blank?
+        fields = password_line.split(":")
+        # If we don't have an expected minimum number of fields, this is probably not a hash line
+        next unless fields.count >= 2
+        hash = fields.shift
+        if format == 'oracle11' || format == "raw-sha1,oracle"
+          hash = "S:#{hash}#{fields.shift}" # we pull the first two fields, hash, and salt
+        elsif format == 'oracle12c' || format == 'pbkdf2,oracle12c'
+          hash = "T:#{hash}"
+        end
+        password = fields.join(':') # Anything left must be the password. This accounts for passwords w$
+        hashes.each do |h|
+          h = h.split("&&&")
+          if format == 'oracle11' || format == "raw-sha1,oracle"
+            # we add the ; on the end since thats when T: or H: would fall in next
+            next unless h[0].downcase.start_with?("#{hash.downcase};")
+          elsif format == "oracle12c" || format == 'pbkdf2,oracle12c'
+            # add ; first since T is never the first part
+            next unless h[0].downcase.include?(";#{hash.downcase}")
+          end
+          username = h[1]
+          core_id  = h[2]
+          print_good "#{username}:#{password}"
+          create_cracked_credential( username: username, password: password, core_id: core_id)
+        end
+      end
+    end
+    if datastore['DeleteTempFiles']
+      cleanup_files.each do |f|
+        File.delete(f)
+      end
+    end
+  end
+
+  def hash_file
+    hashes = []
+    hashlist = Rex::Quickfile.new("hashes_tmp")
+    framework.db.creds(workspace: myworkspace, type: 'Metasploit::Credential::NonreplayableHash').each do |core|
+      # raw-sha1,oracle is oracle11
+      if core.private.jtr_format =~ /raw-sha1,oracle|oracle11|oracle12c/
+        @formats << core.private.jtr_format
+        hashlist.puts hash_to_hashcat(core)
+        # ':' is part of oracle hashes, so we use &&& instead
+        hashes << "#{core.private.data}&&&#{core.public.username}&&&#{core.id}"
+      end
+    end
+    hashlist.close
+    print_status "Hashes Written out to #{hashlist.path}"
+    return hashlist.path, hashes
+  end
+end

--- a/modules/auxiliary/analyze/hashcat_postgres_fast.rb
+++ b/modules/auxiliary/analyze/hashcat_postgres_fast.rb
@@ -1,0 +1,106 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core/auxiliary/hashcat'
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Auxiliary::Hashcat
+
+  def initialize
+    super(
+      'Name'           => 'Hashcat Postgres Password Cracker (Fast Mode)',
+      'Description'    => %Q{
+          This module uses Hashcat to identify weak passwords that have been
+        acquired from the postgres_hashdump module. Passwords that have been successfully
+        cracked are then saved as proper credentials.
+        postgres is format 12 in hashcat.
+      },
+      'Author'         => ['h00die'] ,
+      'License'        => MSF_LICENSE
+    )
+  end
+
+  def run
+    @formats = Set.new
+
+    cracker = new_hashcat_cracker
+
+    # hashes is an array to re-reference after cracking
+    # format: ['hash:username:id']
+    # create the hash file first, so if there aren't any hashes we can quit early
+    cracker.hash_path, hashes = hash_file
+
+    # generate our wordlist and close the file handle.
+    wordlist = wordlist_file
+    unless wordlist
+      print_error('This module cannot run without a database connected. Use db_connect to connect to a database.')
+      return
+    end
+
+    wordlist.close
+    print_status "Wordlist file written out to #{wordlist.path}"
+    cracker.wordlist = wordlist.path
+
+    cleanup_files = [cracker.hash_path, wordlist.path]
+
+    @formats.each do |format|
+      # dupe our original cracker so we can safely change options between each run
+      cracker_instance = cracker.dup
+      cracker_instance.format = jtr_format_to_hashcat_format(format)
+      print_status "Cracking #{format} hashes in normal wordlist mode..."
+      cracker_instance.crack do |line|
+        vprint_status line.chomp
+      end
+
+      print_status "Cracking #{format} hashes in increment mode..."
+      cracker_instance.wordlist = nil
+      cracker_instance.attack = '3'
+      cracker_instance.increment = true
+      cracker_instance.crack do |line|
+        vprint_status line.chomp
+      end
+
+      print_status "Cracked Passwords this run:"
+      cracker_instance.each_cracked_password do |password_line|
+        password_line.chomp!
+        next if password_line.blank?
+        fields = password_line.split(":")
+        next unless fields.count >= 2
+        hash = fields.shift
+        useraname = fields.shift #this gets overwritten but its a throwaway value anyways
+        password = fields.join(':') # Anything left must be the password. This accounts for passwords w$
+        hashes.each do |h|
+          h = h.split("&&&")
+          next unless h[0].downcase == hash.downcase
+          username = h[1]
+          core_id  = h[2]
+          print_good "#{username}:#{password}"
+          create_cracked_credential( username: username, password: password, core_id: core_id)
+        end
+      end
+    end
+    if datastore['DeleteTempFiles']
+      cleanup_files.each do |f|
+        File.delete(f)
+      end
+    end
+  end
+
+  def hash_file
+    hashes = []
+    hashlist = Rex::Quickfile.new("hashes_tmp")
+    framework.db.creds(workspace: myworkspace, type: 'Metasploit::Credential::PostgresMD5').each do |core|
+      if core.private.jtr_format =~ /postgres|raw-md5/
+        @formats << core.private.jtr_format
+        hashlist.puts hash_to_hashcat(core)
+        # ':' is part of oracle hashes, so we use &&& instead
+        hashes << "#{core.private.data}&&&#{core.public.username}&&&#{core.id}"
+      end
+    end
+    hashlist.close
+    print_status "Hashes Written out to #{hashlist.path}"
+    return hashlist.path, hashes
+  end
+end

--- a/modules/auxiliary/analyze/hashcat_windows_fast.rb
+++ b/modules/auxiliary/analyze/hashcat_windows_fast.rb
@@ -1,0 +1,116 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core/auxiliary/hashcat'
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Auxiliary::Hashcat
+
+  def initialize
+    super(
+      'Name'           => 'Hashcat Windows Password Cracker (Fast Mode)',
+      'Description'    => %Q{
+          This module uses Hashcat to identify weak passwords that have been
+        acquired as hashed files (loot) or raw LANMAN/NTLM hashes (hashdump). The goal
+        of this module is to find trivial passwords in a short amount of time. To
+        crack complex passwords or use large wordlists, Hashcat should be
+        used outside of Metasploit. This initial version just handles LM/NTLM credentials
+        from hashdump and uses the standard wordlist and rules.
+        LanMan (lm) is format 3000 in hashcat.
+        NTLanMan is format 1000 in hashcat.
+      },
+      'Author'         => ['h00die'] ,
+      'License'        => MSF_LICENSE
+    )
+  end
+
+  def run
+    @formats = Set.new
+
+    cracker = new_hashcat_cracker
+
+    # hashes is an array to re-reference after cracking
+    # format: ['hash:username:id']
+    # create the hash file first, so if there aren't any hashes we can quit early
+    cracker.hash_path, hashes = hash_file
+
+    # generate our wordlist and close the file handle.
+    wordlist = wordlist_file
+    unless wordlist
+      print_error('This module cannot run without a database connected. Use db_connect to connect to a database.')
+      return
+    end
+
+    wordlist.close
+    print_status "Wordlist file written out to #{wordlist.path}"
+    cracker.wordlist = wordlist.path
+
+    cleanup_files = [cracker.hash_path, wordlist.path]
+
+    @formats.each do |format|
+      # dupe our original cracker so we can safely change options between each run
+      cracker_instance = cracker.dup
+      cracker_instance.format = jtr_format_to_hashcat_format(format)
+      print_status "Cracking #{format} hashes in normal wordlist mode..."
+      cracker_instance.crack do |line|
+        vprint_status line.chomp
+      end
+
+      print_status "Cracking #{format} hashes in increment mode..."
+      cracker_instance.wordlist = nil
+      cracker_instance.attack = '3'
+      cracker_instance.increment = true
+      cracker_instance.crack do |line|
+        vprint_status line.chomp
+      end
+
+      print_status "Cracked Passwords this run:"
+      cracker_instance.each_cracked_password do |password_line|
+        password_line.chomp!
+        next if password_line.blank?
+        fields = password_line.split(":")
+        next unless fields.count >= 2
+        hash = fields.shift
+        password = fields.join(':') # Anything left must be the password. This accounts for passwords w$
+        hashes.each do |h|
+          h = h.split("&&&")
+          next unless h[0].downcase == hash.downcase
+          username = h[1]
+          core_id  = h[2]
+          print_good "#{username}:#{password}"
+          create_cracked_credential( username: username, password: password, core_id: core_id)
+        end
+      end
+    end
+    if datastore['DeleteTempFiles']
+      cleanup_files.each do |f|
+        File.delete(f)
+      end
+    end
+  end
+
+  def hash_file
+    hashes = []
+    hashlist = Rex::Quickfile.new("hashes_tmp")
+    framework.db.creds(workspace: myworkspace, type: 'Metasploit::Credential::NTLMHash').each do |core|
+      # they should always fit this, but to be safe we check anyways
+      if core.private.jtr_format =~ /nt|lm|ntlm|lanman/
+        ntlm = core.private.data.split(':')
+        hash = hash_to_hashcat(core)
+        if hash.downcase == ntlm[0].downcase
+          @formats << 'lm'
+        elsif hash.downcase == ntlm[1].downcase
+          @formats << 'nt'
+        end
+        hashlist.puts hash
+        # ':' is part of ntlm hashes, so we use &&& instead
+        hashes << "#{hash}&&&#{core.public.username}&&&#{core.id}"
+      end
+    end
+    hashlist.close
+    print_status "Hashes Written out to #{hashlist.path}"
+    return hashlist.path, hashes
+  end
+end


### PR DESCRIPTION
This adds hashcat modules for all existing jtr modules. #11351
It adds the ability to export creds into hashcat format. #11615

## Help me plz

I have one bug I can't figure out.
https://github.com/rapid7/metasploit-framework/pull/11671/files#diff-1078f7f42f6c70928adb5b154ffb1adeR31 is a direct copy of https://github.com/rapid7/metasploit-framework/blob/6218d8920da2338804cd007926b5053740145a41/lib/msf/core/auxiliary/jtr.rb#L32

However, when I uncomment it, I get the following error which I was never able to track down why:
```
msf5 > use auxiliary/analyze/hashcat_aix 
[-] Error while running command use: no implicit conversion of false into Integer

Call stack:
/user/meterpreter/metasploit-framework/lib/msf/core/auxiliary/hashcat.rb:31:in `[]'
/user/meterpreter/metasploit-framework/lib/msf/core/auxiliary/hashcat.rb:31:in `initialize'
/user/meterpreter/metasploit-framework/modules/auxiliary/analyze/hashcat_aix.rb:21:in `initialize'
/user/meterpreter/metasploit-framework/lib/msf/core/module_set.rb:54:in `new'
/user/meterpreter/metasploit-framework/lib/msf/core/module_set.rb:54:in `create'
/user/meterpreter/metasploit-framework/lib/msf/core/module_manager.rb:85:in `create'
/user/meterpreter/metasploit-framework/lib/msf/ui/console/command_dispatcher/modules.rb:622:in `cmd_use'
/user/meterpreter/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:522:in `run_command'
/user/meterpreter/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:473:in `block in run_single'
/user/meterpreter/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:467:in `each'
/user/meterpreter/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:467:in `run_single'
/user/meterpreter/metasploit-framework/lib/rex/ui/text/shell.rb:151:in `run'
/user/meterpreter/metasploit-framework/lib/metasploit/framework/command/console.rb:48:in `start'
/user/meterpreter/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'
./msfconsole:49:in `<main>'

```

## Verification

I used the following for test cases. It should crack everything but the mssql12 one.
```
workspace -d default
creds -d
creds add user:des_password hash:rEK1ecacw.7.c jtr:des
creds add user:md5_password hash:$1$O3JMY.Tw$AdLnLjQ/5jXF9.MTp3gHv/ jtr:md5
creds add user:bsdi_password hash:_J9..K0AyUubDrfOgO4s jtr:bsdi
creds add user:sha256_password hash:$5$MnfsQ4iN$ZMTppKN16y/tIsUYs/obHlhdP.Os80yXhTurpBMUbA5 jtr:sha256
creds add user:sha512_password hash:$6$zWwwXKNj$gLAOoZCjcr8p/.VgV/FkGC3NX7BsXys3KHYePfuIGMNjY83dVxugPYl$
creds add user:blowfish_password hash:$2a$05$bvIG6Nmid91Mu9RcmmWZfO5HJIMCT8riNW0hEp8f6/FuA2/mHZFpe jtr:$
creds add user:lm_password ntlm:E52CAC67419A9A224A3B108F3FA6CB6D:8846F7EAEE8FB117AD06BDD830B7586C jtr:lm
creds add user:nt_password ntlm:AAD3B435B51404EEAAD3B435B51404EE:8846F7EAEE8FB117AD06BDD830B7586C jtr:nt
creds add user:mssql05_toto hash:0x01004086CEB6BF932BC4151A1AF1F13CD17301D70816A8886908 jtr:mssql05
creds add user:mssql_foo hash:0x0100A607BA7C54A24D17B565C59F1743776A10250F581D482DA8B6D6261460D3F53B279$
creds add user:mssql12_Password1! hash:0x0200F733058A07892C5CACE899768F89965F6BD1DED7955FE89E1C9A10E278$
creds add user:mysql_probe hash:445ff82636a7ba59 jtr:mysql
creds add user:mysql-sha1_tere hash:*5AD8F88516BD021DD43F171E2C785C69F8E54ADB jtr:mysql-sha1
## oracle (10) uses usernames in the hashing, so we can't overide that here
#creds add user:simon hash:4F8BC1809CB2AF77 jtr:des,oracle
#creds add user:SYSTEM hash:9EEDFA0AD26C6D52 jtr:des,oracle
## oracle 11/12 H value, username is used
creds add user:DEMO hash:'S:8F2D65FB5547B71C8DA3760F10960428CD307B1C6271691FC55C1F56554A;H:DC9894A01797$
## oracle 11/12 uses a LONG format, see lib/msf/core/auxiliary/jtr.rb
creds add user:oracle11_epsilon hash:'S:8F2D65FB5547B71C8DA3760F10960428CD307B1C6271691FC55C1F56554A;H:$
creds add user:oracle12c_epsilon hash:'H:DC9894A01797D91D92ECA1DA66242209;T:E3243B98974159CC24FD2C9A8B3$
##postgres uses username, so we can't overide that here
creds add user:example postgres:md5be86a79bf2043622d58d5453c47d4860
use auxiliary/analyze/hashcat_aix
run
use auxiliary/analyze/hashcat_linux
set crypt true
run
use auxiliary/analyze/hashcat_mssql_fast
run
use auxiliary/analyze/hashcat_mysql_fast
run
use auxiliary/analyze/hashcat_oracle_fast
run
use auxiliary/analyze/hashcat_postgres_fast
run
use auxiliary/analyze/hashcat_windows_fast
run
creds
```


## Wiki

Writing https://github.com/rapid7/metasploit-framework/wiki/Hashes-and-Password-Cracking to help document a lot of this stuff

