### PR TITLE
Remove duplicate CVE for Mailcleaner module

### DIFF
--- a/modules/exploits/linux/http/mailcleaner_exec.rb
+++ b/modules/exploits/linux/http/mailcleaner_exec.rb
@@ -26,8 +26,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'References'     =>
         [
           ['URL', 'https://pentest.blog/advisory-mailcleaner-community-edition-remote-code-execution/'],
-          ['CVE', '2018-20323'],
-          ['CVE', '2018-1000999']
+          ['CVE', '2018-20323']
         ],
       'DefaultOptions'  =>
         {


### PR DESCRIPTION
See #11304

Removes the duplicate CVE from this module.

## Verification

- [ ] `./msfconsole -x "info exploit/linux/http/mailcleaner_exec; exit"`
- [ ] **Verify** that CVE-2018-1000999 is **not** displayed.
