### PR TITLE
Remove trailing space from CVE reference

### DIFF
--- a/modules/exploits/multi/misc/weblogic_deserialize_marshalledobject.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize_marshalledobject.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'License' => MSF_LICENSE,
       'References' =>
         [
-          ['CVE', '2016-3510 ']
+          ['CVE', '2016-3510']
         ],
       'Privileged' => false,
       'Platform' => %w{ unix win solaris },


### PR DESCRIPTION
The `weblogic_deserialize_marshalledobject` includes a CVE reference with a trailing space.  This PR removes that trailing space, resulting in a valid CVE identifier for the module.