### PR TITLE
Bump rex-powershell gem version to 0.1.80...

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -280,7 +280,7 @@ GEM
       rex-arch
     rex-ole (0.1.6)
       rex-text
-    rex-powershell (0.1.79)
+    rex-powershell (0.1.80)
       rex-random_identifier
       rex-text
     rex-random_identifier (0.1.4)


### PR DESCRIPTION
...to pick up https://github.com/rapid7/rex-powershell/pull/18.

## Verification

List the steps needed to make sure this thing works

- [x] `bundle install`
- [x] **Verify** rex-powershell version 0.1.80 is installed

