### PR TITLE
Fix duplicate host header

### DIFF
--- a/lib/rex/proto/http/client_request.rb
+++ b/lib/rex/proto/http/client_request.rb
@@ -179,13 +179,13 @@ class ClientRequest
 
     # If an explicit User-Agent header is set, then use that instead of
     # the default
-    unless opts['headers'] && opts['headers'].keys.map { |x| x.downcase }.include?('user-agent')
+    unless opts['headers'] && opts['headers'].keys.map(&:downcase).include?('user-agent')
       req << set_agent_header
     end
 
     # Similar to user-agent, only add an automatic auth header if a
     # manual one hasn't been provided
-    unless opts['headers'] && opts['headers'].keys.map { |x| x.downcase }.include?('authorization')
+    unless opts['headers'] && opts['headers'].keys.map(&:downcase).include?('authorization')
       req << set_auth_header
     end
 

--- a/lib/rex/proto/http/client_request.rb
+++ b/lib/rex/proto/http/client_request.rb
@@ -173,10 +173,7 @@ class ClientRequest
     req << set_version
 
     # Set a default Host header if one wasn't passed in
-    if opts['headers'] && opts['headers'].keys.map(&:downcase).include?('host')
-      host = opts['headers'].keys.each { |k| break opts['headers'][k] if k =~ /host/i }
-      req << set_formatted_header('Host', host)
-    else
+    unless opts['headers'] && opts['headers'].keys.map(&:downcase).include?('host')
       req << set_host_header
     end
 


### PR DESCRIPTION
This PR fixes a duplicate host header issue when `opt['headers']` specifies a `host`. The host header was added on lines 178 and 197 (`#set_extra_headers`). This PR removes the addition of the host header on line 178 if it is specified.

## Verification

- [x] `./msfconsole -q`
- [x] `use auxiliary/dos/http/apache_range_dos`
- [x] `set rhosts <rhosts>`
- [x] `set action CHECK`
- [x] `set httptrace true`
- [x] `exploit`
- [x] Verify `Host` header appears once

### Before Fix

```
msf5 auxiliary(dos/http/apache_range_dos) > exploit

********************
####################
# Request:
####################
HEAD / HTTP/1.1
Host: 172.22.222.111
User-Agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)
HOST: 172.22.222.111
Range: bytes=5-0,1-1,2-2,3-3,4-4,5-5,6-6,7-7,8-8,9-9,10-10
Request-Range: bytes=5-0,1-1,2-2,3-3,4-4,5-5,6-6,7-7,8-8,9-9,10-10
Content-Type: application/x-www-form-urlencoded
Content-Length: 0
```

### After Fix

```
msf5 auxiliary(dos/http/apache_range_dos) > exploit

********************
####################
# Request:
####################
HEAD / HTTP/1.1
User-Agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)
HOST: 172.22.222.111
Range: bytes=5-0,1-1,2-2,3-3,4-4,5-5,6-6,7-7,8-8,9-9,10-10
Request-Range: bytes=5-0,1-1,2-2,3-3,4-4,5-5,6-6,7-7,8-8,9-9,10-10
Content-Type: application/x-www-form-urlencoded
Content-Length: 0
```

See #8345 and #8634 for related commits.