### PR TITLE
Add lost registered option DUMP_OUTPUT to Drupal SA-CORE-2019-003 exploit

### DIFF
--- a/documentation/modules/exploit/unix/webapp/drupal_restws_unserialize.md
+++ b/documentation/modules/exploit/unix/webapp/drupal_restws_unserialize.md
@@ -45,6 +45,11 @@ to work.
 
 Set this to a node ID on the target when using the `GET` method.
 
+**DUMP_OUTPUT**
+
+Enable this if you'd like to see HTTP responses, including command
+output. Defaults to `false` unless `cmd/unix/generic` is your payload.
+
 ## Usage
 
 ```

--- a/modules/exploits/unix/webapp/drupal_restws_unserialize.rb
+++ b/modules/exploits/unix/webapp/drupal_restws_unserialize.rb
@@ -75,9 +75,10 @@ class MetasploitModule < Msf::Exploit::Remote
     ))
 
     register_options([
-      OptEnum.new('METHOD', [true, 'HTTP method to use', 'POST',
-                            ['GET', 'POST', 'PATCH', 'PUT']]),
-      OptInt.new('NODE',    [false, 'Node ID to target with GET method', 1])
+      OptEnum.new('METHOD',      [true, 'HTTP method to use', 'POST',
+                                 ['GET', 'POST', 'PATCH', 'PUT']]),
+      OptInt.new('NODE',         [false, 'Node ID to target with GET method', 1]),
+      OptBool.new('DUMP_OUTPUT', [false, 'Dump payload command output', false])
     ])
 
     register_advanced_options([


### PR DESCRIPTION
Oops, I forgot this in the refactor. It would still work as a datastore option, but it should have been registered just like in Drupalgeddon 2.

cc @rotemreiss

Fixes #11481.