### PR TITLE
Zip import directory traversal mitigation

### DIFF
--- a/lib/msf/core/db_manager/import/metasploit_framework/zip.rb
+++ b/lib/msf/core/db_manager/import/metasploit_framework/zip.rb
@@ -194,8 +194,14 @@ module Msf::DBManager::Import::MetasploitFramework::Zip
     }
 
     data.entries.each do |e|
-      target = ::File.join(@import_filedata[:zip_tmp], e.name)
-      data.extract(e,target)
+      # normalize entry name to an absolute path
+      target = (Pathname.new(@import_filedata[:zip_tmp]) + e.name).to_s
+
+      # skip if the target would be extracted outside of the zip
+      # tmp dir to mitigate any directory traversal attacks
+      next unless is_child_of?(@import_filedata[:zip_tmp], target)
+
+      e.extract(target)
 
       if target =~ /\.xml\z/
         target_data = ::File.open(target, "rb") {|f| f.read 1024}
@@ -235,5 +241,9 @@ module Msf::DBManager::Import::MetasploitFramework::Zip
     else
       import_msf_collateral(new_args)
     end
+  end
+
+  def is_child_of?(target_dir, target)
+    target.match?(/^#{target_dir}/)
   end
 end

--- a/lib/msf/core/db_manager/import/metasploit_framework/zip.rb
+++ b/lib/msf/core/db_manager/import/metasploit_framework/zip.rb
@@ -195,7 +195,7 @@ module Msf::DBManager::Import::MetasploitFramework::Zip
 
     data.entries.each do |e|
       # normalize entry name to an absolute path
-      target = File.expand_path(@import_filedata[:zip_tmp] + e.name, '/').to_s
+      target = File.expand_path(File.join(@import_filedata[:zip_tmp], e.name), '/').to_s
 
       # skip if the target would be extracted outside of the zip
       # tmp dir to mitigate any directory traversal attacks

--- a/lib/msf/core/db_manager/import/metasploit_framework/zip.rb
+++ b/lib/msf/core/db_manager/import/metasploit_framework/zip.rb
@@ -195,7 +195,7 @@ module Msf::DBManager::Import::MetasploitFramework::Zip
 
     data.entries.each do |e|
       # normalize entry name to an absolute path
-      target = (Pathname.new(@import_filedata[:zip_tmp]) + e.name).to_s
+      target = File.expand_path(@import_filedata[:zip_tmp] + e.name, '/').to_s
 
       # skip if the target would be extracted outside of the zip
       # tmp dir to mitigate any directory traversal attacks
@@ -244,6 +244,6 @@ module Msf::DBManager::Import::MetasploitFramework::Zip
   end
 
   def is_child_of?(target_dir, target)
-    target.match?(/^#{target_dir}/)
+    target.downcase.start_with?(target_dir.downcase)
   end
 end


### PR DESCRIPTION
This adds mitigation for directory traversal attacks when importing a ZIP file.

## Verification
**Note** - There are `db_disconnect` steps in the verification because of a bug when importing while connected to the Metasploit data service.  I've talked with @mkienow-r7 about it, and I have a TODO to create an issue.

- [ ] Download [test.zip](https://github.com/rapid7/metasploit-framework/files/3071133/test.zip)

### Before mitigation
- [ ] Checkout `master` branch
- [ ] Start `msfconsole`
- [ ] Run `db_disconnect` if you're connected to the data service
- [ ] Run `db_import <path/to/test.zip>`
- [ ] **Verify** `/tmp/exploit` is created
- [ ] Remove `/tmp/exploit`
- [ ] Exit `msfconsole`

### After mitigation
- [ ] Checkout this PR branch
- [ ] Start `msfconsole`
- [ ] Run `db_disconnect` if you're connected to the data service
- [ ] Run `db_import <path/to/test.zip>`
- [ ] **Verify** `/tmp/exploit` is **not** created

