### PR TITLE
Update CONTRIBUTING.md advice on topic branches

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,9 +20,11 @@ it into Metasploit's master branch.  If you do not care to follow these rules, y
 * **Do** stick to the [Ruby style guide] and use [Rubocop] to find common style issues.
 * **Do** follow the [50/72 rule] for Git commit messages.
 * **Do** license your code as BSD 3-clause, BSD 2-clause, or MIT.
-* **Do** create a [topic branch] to work on instead of working directly on `master` to preserve the
-  history of your pull request.  See [PR#8000] for an example of losing commit history as soon as
-  you update your own master branch.
+* **Do** create a [topic branch] to work on instead of working directly on `master`.
+  This helps protect the process, ensures users are aware of commits on the branch being considered for merge,
+  allows for a location for more commits to be offered without mingling with other contributor changes,
+  and allows contributors to make progress while a PR is still being reviewed.
+
 
 ### Pull Requests
 


### PR DESCRIPTION
This updates the verbiage in `CONTRIBUTING.md` with our verified reasons for enforcing topic branches.

We never verified why GitHub diffs can get messed up over time. I'm partly to blame for perpetuating the line that it was a `master` PR's fault. I'll continue to look into that, but until we figure it out, let's clarify our verified reasons for using a topic branch. You can still access `master`-branch commit history and diffs via the command line.

FWIW, there was no technical reason a `master` PR couldn't be merged, so long as the contributor kept to one PR at a time. Obviously this is self-limiting and messy, which is the primary reason we introduced this recommendation.

We wanted contributors to learn the best practice, so closing their PR was the approach we took. The only drawback we've noted is that review history should be cross-referenced between PRs. This can be as simple as tagging the old PR's number in the new PR's description.

Words from @jmartin-r7.

https://github.com/rapid7/metasploit-framework/commit/30fec1af010e44272c55527f6e2bb97031185576, https://github.com/rapid7/metasploit-framework/commit/3bbb2d628e4f946b18eb18dcdbfc094f276b404d, https://github.com/rapid7/metasploit-framework/pull/9605#issuecomment-368550984

#11711