### PR TITLE
Implement "intelligent" use command with search -u

### DIFF
--- a/lib/msf/core/module_manager.rb
+++ b/lib/msf/core/module_manager.rb
@@ -50,6 +50,8 @@ module Msf
 
       module_set = module_set_by_type[type]
 
+      return unless module_set
+
       module_reference_name = names.join("/")
       module_set[module_reference_name]
     end

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -15,9 +15,6 @@ module Msf
           include Msf::Ui::Console::CommandDispatcher
           include Msf::Ui::Console::CommandDispatcher::Common
 
-          # Constant for a retry timeout on using modules before they're loaded
-          CMD_USE_TIMEOUT = 3
-
           @@search_opts = Rex::Parser::Arguments.new(
             "-h"     => [ false, "Help banner"],
             "-o"     => [ true, "Send output to a file in csv format"],
@@ -364,7 +361,7 @@ module Msf
             if args.empty?
               print_error("Argument required\n")
               cmd_search_help
-              return
+              return false
             end
 
             match = ''
@@ -390,7 +387,7 @@ module Msf
             if match.empty? && search_term.nil?
               print_error("Keywords or search argument required\n")
               cmd_search_help
-              return
+              return false
             end
 
             # Display the table of matches
@@ -399,6 +396,9 @@ module Msf
             count = 0
             begin
               modules = Msf::Modules::Metadata::Cache.instance.find(search_params)
+
+              return false if modules.length == 0
+
               modules.each do |m|
                 tbl << [
                     count += 1,
@@ -409,13 +409,15 @@ module Msf
                     m.name
                 ]
               end
+
               if modules.length == 1 && use
                 used_module = modules.first.full_name
-                cmd_use(used_module)
+                cmd_use(used_module, true)
               end
             rescue ArgumentError
               print_error("Invalid argument(s)\n")
               cmd_search_help
+              return false
             end
 
             if output_file
@@ -427,6 +429,8 @@ module Msf
               print_line(tbl.to_s)
               print_status("Using #{used_module}") if used_module
             end
+
+            true
           end
 
           #
@@ -623,6 +627,9 @@ module Msf
             # Try to create an instance of the supplied module name
             mod_name = args[0]
 
+            # See if the supplied module name has already been resolved
+            mod_resolved = args[1] == true ? true : false
+
             # Ensure we have a reference name and not a path
             if mod_name.start_with?('./', 'modules/')
               mod_name.sub!(%r{^(?:\./)?modules/}, '')
@@ -633,11 +640,13 @@ module Msf
 
             begin
               mod = framework.modules.create(mod_name)
+
               unless mod
-                # Try one more time; see #4549
-                sleep CMD_USE_TIMEOUT
-                mod = framework.modules.create(mod_name)
-                unless mod
+                unless mod_resolved
+                  mods_found = cmd_search('-u', mod_name)
+                end
+
+                unless mods_found
                   print_error("Failed to load module: #{mod_name}")
                   return false
                 end


### PR DESCRIPTION
~This implementation could use a refactor, and my brain is fried right now, so I'm marking this as WIP.~ Still could use a refactor, but I'm opening this up to review/testing.

- [x] Investigate whether #4340 affects MSF5 and come up with a proper fix if possible
  - I can no longer reproduce this on MSF5, and the search adds a small delay as well
- [x] Consider what we want to do about `search -u` (I see no harm in keeping it, but I think most folks will reach for `use`)
  - I say we keep it, since searching is the primary functionality, using second

```
msf5 > use rv130

Matching Modules
================

   #  Name                                    Disclosure Date  Rank  Check  Description
   -  ----                                    ---------------  ----  -----  -----------
   1  exploit/linux/http/cisco_rv130_rmi_rce  2019-02-27       good  No     Cisco RV130W Routers Management Interface Remote Command Execution


[*] Using exploit/linux/http/cisco_rv130_rmi_rce
msf5 exploit(linux/http/cisco_rv130_rmi_rce) >
```

```
msf5 exploit(linux/http/cisco_rv130_rmi_rce) > use eternalblue

Matching Modules
================

   #  Name                                           Disclosure Date  Rank     Check  Description
   -  ----                                           ---------------  ----     -----  -----------
   1  auxiliary/admin/smb/ms17_010_command           2017-03-14       normal   Yes    MS17-010 EternalRomance/EternalSynergy/EternalChampion SMB Remote Windows Command Execution
   2  auxiliary/scanner/smb/smb_ms17_010                              normal   Yes    MS17-010 SMB RCE Detection
   3  exploit/windows/smb/ms17_010_eternalblue       2017-03-14       average  No     MS17-010 EternalBlue SMB Remote Windows Kernel Pool Corruption
   4  exploit/windows/smb/ms17_010_eternalblue_win8  2017-03-14       average  No     MS17-010 EternalBlue SMB Remote Windows Kernel Pool Corruption for Win8+
   5  exploit/windows/smb/ms17_010_psexec            2017-03-14       normal   No     MS17-010 EternalRomance/EternalSynergy/EternalChampion SMB Remote Windows Code Execution


msf5 exploit(linux/http/cisco_rv130_rmi_rce) > use exploit/windows/smb/ms17_010_eternalblue
msf5 exploit(windows/smb/ms17_010_eternalblue) >
```

Note that there is some overlap with regex-enhanced tab completion:

```
msf5 > use .*rv130.*
```

https://github.com/rapid7/metasploit-framework/blob/f41a90a5828c72f34f9510d911ce176c9d776f47/lib/rex/ui/text/dispatcher_shell.rb#L413-L418

~I may attempt to merge the two.~ The two functionalities are complementary.

Updates #4615 and #11652.