### PR TITLE
Update module stance instead of appending to it

### DIFF
--- a/lib/msf/core/module/module_info.rb
+++ b/lib/msf/core/module/module_info.rb
@@ -4,7 +4,7 @@ module Msf::Module::ModuleInfo
   #
 
   # The list of options that support merging in an information hash.
-  UpdateableOptions = [ "Name", "Description", "Alias", "PayloadCompat" ]
+  UpdateableOptions = [ "Name", "Description", "Alias", "PayloadCompat", "Stance" ]
 
   #
   # Instance Methods

--- a/spec/support/shared/examples/msf/module/module_info.rb
+++ b/spec/support/shared/examples/msf/module/module_info.rb
@@ -5,7 +5,7 @@ RSpec.shared_examples_for 'Msf::Module::ModuleInfo' do
         described_class::UpdateableOptions
       }
 
-      it { is_expected.to match_array(%w{Name Description Alias PayloadCompat})}
+      it { is_expected.to match_array(%w{Name Description Alias PayloadCompat Stance})}
     end
   end
 


### PR DESCRIPTION
This is a redux of the fixes #9387 and #9822.

While this is the correct solution, I think it's okay to keep the other code for safety.

**Note that either the module or one of its mixins will need to set the appropriate stance. This fix simply makes stance a binary, so inheritance and mixin order are especially important now.**

```
msf5 exploit(multi/http/struts2_rest_xstream) > pry
[*] Starting Pry shell...
[*] You are in exploit/multi/http/struts2_rest_xstream

[1] pry(#<Msf::Modules::Exploit__Multi__Http__Struts2_rest_xstream::MetasploitModule>)> stance
=> "aggressive"
[2] pry(#<Msf::Modules::Exploit__Multi__Http__Struts2_rest_xstream::MetasploitModule>)> aggressive?
=> true
[3] pry(#<Msf::Modules::Exploit__Multi__Http__Struts2_rest_xstream::MetasploitModule>)> passive?
=> false
[4] pry(#<Msf::Modules::Exploit__Multi__Http__Struts2_rest_xstream::MetasploitModule>)>
msf5 exploit(multi/http/struts2_rest_xstream) > run

[!] You are binding to a loopback address by setting LHOST to 127.0.0.1. Did you want ReverseListenerBindAddress?
[*] Started reverse TCP double handler on 127.0.0.1:4444
[-] The connection was refused by the remote host (127.0.0.1:8080).
^C[*] Exploit completed, but no session was created.
msf5 exploit(multi/http/struts2_rest_xstream) >
```

Please note that the default behavior of `update_info` is to convert to an array and append to it.

https://github.com/rapid7/metasploit-framework/blob/93638b7f8622a7a55afdf4db8ef721019b563264/lib/msf/core/module/module_info.rb#L90-L95

#11711