### PR TITLE
Remove Regex Lookup on Username and Password Fields for Creds

### DIFF
--- a/lib/msf/core/db_manager/cred.rb
+++ b/lib/msf/core/db_manager/cred.rb
@@ -28,12 +28,10 @@ module Msf::DBManager::Cred
       end
 
       if opts[:user].present?
-        # If we have a user regex, only include those that match
         query = query.where('"metasploit_credential_publics"."username" = ?', opts[:user])
       end
 
       if opts[:pass].present?
-        # If we have a password regex, only include those that match
         query = query.where('"metasploit_credential_privates"."data" = ?', opts[:pass])
       end
 

--- a/lib/msf/core/db_manager/cred.rb
+++ b/lib/msf/core/db_manager/cred.rb
@@ -29,12 +29,12 @@ module Msf::DBManager::Cred
 
       if opts[:user].present?
         # If we have a user regex, only include those that match
-        query = query.where('"metasploit_credential_publics"."username" ~* ?', opts[:user])
+        query = query.where('"metasploit_credential_publics"."username" = ?', opts[:user])
       end
 
       if opts[:pass].present?
         # If we have a password regex, only include those that match
-        query = query.where('"metasploit_credential_privates"."data" ~* ?', opts[:pass])
+        query = query.where('"metasploit_credential_privates"."data" = ?', opts[:pass])
       end
 
       if opts[:host_ranges] || opts[:ports] || opts[:svcs]

--- a/lib/msf/ui/console/command_dispatcher/creds.rb
+++ b/lib/msf/ui/console/command_dispatcher/creds.rb
@@ -172,10 +172,10 @@ class Creds
     print_line "  -d,--delete           Delete one or more credentials"
     print_line
     print_line "Filter options for listing"
-    print_line "  -P,--password <regex> List passwords that match this regex"
+    print_line "  -P,--password <text>  List passwords that match this text"
     print_line "  -p,--port <portspec>  List creds with logins on services matching this port spec"
     print_line "  -s <svc names>        List creds matching comma-separated service names"
-    print_line "  -u,--user <regex>     List users that match this regex"
+    print_line "  -u,--user <text>      List users that match this text"
     print_line "  -t,--type <type>      List creds that match the following types: #{allowed_cred_types.join(',')}"
     print_line "  -O,--origins <IP>     List creds that match these origins"
     print_line "  -R,--rhosts           Set RHOSTS from the results of the search"


### PR DESCRIPTION
This PR removes the regex search that was present for the username and password fields for credentials. It fixes #11555. Since usernames, and more commonly passwords, often contain special characters there would frequently be errors due to collisions with reserved regex characters.

Here are some examples of the new functionality:

```
msf5 auxiliary(scanner/ssh/ssh_login_pubkey) > creds -u admin
Credentials
===========

host  origin  service  public  private      realm  private_type  JtR Format
----  ------  -------  ------  -------      -----  ------------  ----------
                       admin   password123         Password      
                       admin   pass123             Password      


```

```
msf5 > creds -P pass
Credentials
===========

host  origin  service  public  private  realm  private_type  JtR Format
----  ------  -------  ------  -------  -----  ------------  ----------

```


The `-S` option is intended to be used for doing regex lookups:

```
msf5 auxiliary(scanner/ssh/ssh_login_pubkey) > creds -S admin
Credentials
===========

host  origin  service  public         private      realm  private_type  JtR Format
----  ------  -------  ------         -------      -----  ------------  ----------
                       administrator  password123         Password      
                       admin          password123         Password      
                       admin          pass123             Password   
```

```
msf5 > creds -S pass
Credentials
===========

host  origin  service  public         private                  realm  private_type    JtR Format
----  ------  -------  ------         -------                  -----  ------------    ----------
                       administrator  password123                     Password        
                       admin          password123                     Password        
                       admin          pass123                         Password        
                       test           [(password!@#$%^&*-`~)]         Password     
```
## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Add some credentials using the syntax suggested via `creds -h`
- [ ] Do a lookup on username with `creds -u <username>`. It should only return results that exactly match the text
- [ ] Do a lookup on password with `creds -P <password>`. It should only return results that exactly match the text
- [ ] Do a regex search with `creds -S <regex>`. It should return any results that match the regex'

Test with a login scanner:
- [ ] `use auxiliary/scanner/ssh/ssh_login`
- [ ] `set RHOSTS <host>`
- [ ] `set USERNAME admin`
- [ ] `set PASSWORD foo)bar`
- [ ] `run`

