### PR TITLE
Update invalidate_login to remove regex creds

### DIFF
--- a/lib/metasploit/framework/data_service/proxy/login_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/login_data_proxy.rb
@@ -35,10 +35,8 @@ module LoginDataProxy
       # Search for an existing Metasploit::Credential::Core object. It requires specific attributes.
       core_opts = {}
       core_opts[:workspace] = opts[:workspace]
-      # The creds search uses regex for username and password lookup.
-      # Alter the search string to only look for exact matches to avoid updating unexpected entries.
-      core_opts[:user] = "^#{opts.fetch(:username)}$" if opts[:username]
-      core_opts[:pass] = "^#{opts.fetch(:private_data)}$" if opts[:private_data]
+      core_opts[:user] = opts.fetch(:username) if opts[:username]
+      core_opts[:pass] = opts.fetch(:private_data) if opts[:private_data]
       core_opts[:ports] = [ opts.fetch(:port) ] if opts[:port]
       core_opts[:host_ranges] = [ opts.fetch(:address) ] if opts[:address]
       core_opts[:svcs] = [ opts.fetch(:service_name) ] if opts[:service_name]


### PR DESCRIPTION
Thanks to @mkienow-r7 for the catch. I missed this while on autopilot.

This effectively updates the fix in #11599 to match #11742's behavior. Regex anchors are removed, since the username and password are now string literals.