### PR TITLE
Options buffer overflow Fix proposal for #11750

### DIFF
--- a/lib/msf/core/exceptions.rb
+++ b/lib/msf/core/exceptions.rb
@@ -302,4 +302,27 @@ class PluginLoadError < RuntimeError
   end
 end
 
+##
+#
+# This exception is raised if an payload option string exceeds the maximum allowed size
+# during the payload generation.
+#
+##
+  class PayloadItemSizeError < ArgumentError
+    include Exception
+
+    def initialize(item = nil, max_size = nil)
+      @item = item
+      @maxSize = max_size
+    end
+
+    def to_s
+      "Option value: #{item.slice(0..30)} is to big (Current length: #{item.length}). Maximum length: #{maxSize}"
+    end
+
+    attr_reader :item # The content of the payload option (for example a URL)
+    attr_reader :maxSize # The maximum allowed size of the payload option
+  end
+
+
 end

--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -71,7 +71,7 @@ module ReverseHttp
           'The user-agent that the payload should use for communication.',
           default: Rex::UserAgent.shortest,
           aliases: ['MeterpreterUserAgent'],
-          max_length: 127
+          max_length: 255
         ),
         OptString.new('HttpServerName',
           'The server header that the handler will send in response to requests',

--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -68,10 +68,10 @@ module ReverseHttp
           'When OverrideRequestHost is set, use this value as the scheme for secondary requests, e.g http or https'
         ),
         OptString.new('HttpUserAgent',
-          'The user-agent that the payload should use for communication. (Max length 127 characters)',
+          'The user-agent that the payload should use for communication.',
           default: Rex::UserAgent.shortest,
           aliases: ['MeterpreterUserAgent'],
-          max_length: 256
+          max_length: 127
         ),
         OptString.new('HttpServerName',
           'The server header that the handler will send in response to requests',

--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -68,9 +68,10 @@ module ReverseHttp
           'When OverrideRequestHost is set, use this value as the scheme for secondary requests, e.g http or https'
         ),
         OptString.new('HttpUserAgent',
-          'The user-agent that the payload should use for communication',
+          'The user-agent that the payload should use for communication. (Max length 127 characters)',
           default: Rex::UserAgent.shortest,
-          aliases: ['MeterpreterUserAgent']
+          aliases: ['MeterpreterUserAgent'],
+          max_length: 256
         ),
         OptString.new('HttpServerName',
           'The server header that the handler will send in response to requests',

--- a/lib/msf/core/opt_base.rb
+++ b/lib/msf/core/opt_base.rb
@@ -31,7 +31,7 @@ module Msf
       self.advanced = false
       self.evasion  = false
       self.aliases  = aliases
-      self.maxLength = Integer(max_length)
+      self.max_length = Integer(max_length)
 
       if attrs.is_a?(String) || attrs.length == 0
         self.required = required
@@ -152,8 +152,8 @@ module Msf
     # Returns true if the value supplied is longer then the max allowed length
     #
     def max_length_value?(value)
-      if !value.nil? && maxLength != 0
-        value.length > maxLength
+      if !value.nil? && max_length != 0
+        value.length > max_length
       end
     end
 
@@ -204,7 +204,7 @@ module Msf
     # 
     # The max length of the input value
     #
-    attr_accessor :maxLength
+    attr_accessor :max_length
     
     protected
 

--- a/lib/msf/core/opt_base.rb
+++ b/lib/msf/core/opt_base.rb
@@ -26,11 +26,12 @@ module Msf
     # also be a string as standin for the required description field.
     #
     def initialize(in_name, attrs = [],
-                   required: false, desc: nil, default: nil, enums: [], regex: nil, aliases: [])
+                   required: false, desc: nil, default: nil, enums: [], regex: nil, aliases: [], max_length: 0)
       self.name     = in_name
       self.advanced = false
       self.evasion  = false
       self.aliases  = aliases
+      self.maxLength = Integer(max_length)
 
       if attrs.is_a?(String) || attrs.length == 0
         self.required = required
@@ -55,6 +56,10 @@ module Msf
         regex_temp    = attrs[4] || regex
       end
 
+      if max_length != 0
+        self.desc += " Max parameter length: #{max_length} characters"
+      end
+      
       if regex_temp
         # convert to string
         regex_temp = regex_temp.to_s if regex_temp.is_a? Regexp
@@ -144,6 +149,15 @@ module Msf
     end
 
     #
+    # Returns true if the value supplied is longer then the max allowed length
+    #
+    def max_length_value?(value)
+      if !value.nil? && maxLength != 0
+        value.length > maxLength
+      end
+    end
+
+    #
     # The name of the option.
     #
     attr_reader   :name
@@ -187,7 +201,11 @@ module Msf
     # Aliases for this option for backward compatibility
     #
     attr_accessor :aliases
-
+    # 
+    # The max length of the input value
+    #
+    attr_accessor :maxLength
+    
     protected
 
     attr_writer   :required, :desc, :default # :nodoc:

--- a/lib/msf/core/opt_string.rb
+++ b/lib/msf/core/opt_string.rb
@@ -8,12 +8,19 @@ module Msf
 #
 ###
 class OptString < OptBase
+
+  # This adds a length parameter to check for the maximum length of strings.
+  def initialize(in_name, attrs = [],
+               required: false, desc: nil, default: nil, enums: [], regex: nil, aliases: [], max_length: 0)
+    super
+  end
+
   def type
     return 'string'
   end
 
   def validate_on_assignment?
-    false
+    true
   end
 
   def normalize(value)
@@ -31,6 +38,7 @@ class OptString < OptBase
   def valid?(value=self.value, check_empty: true)
     value = normalize(value)
     return false if check_empty && empty_required_value?(value)
+    return false if max_length_value?(value)
     return super(check_empty: false)
   end
 end

--- a/lib/msf/core/payload.rb
+++ b/lib/msf/core/payload.rb
@@ -203,6 +203,7 @@ class Payload < Msf::Module
     begin
       pl = generate()
     rescue NoCompatiblePayloadError
+    rescue PayloadItemSizeError
     end
     pl ||= ''
     pl.length

--- a/lib/rex/payloads/meterpreter/config.rb
+++ b/lib/rex/payloads/meterpreter/config.rb
@@ -36,8 +36,8 @@ private
   end
 
   def to_str(item, size)
-    if  (item.size > size-1)
-      item = item.slice(0..(size-1)) # TODO silently fix things or throw error?
+    if (item.size >= size) # ">=" instead of only ">", because we need space for a terminating null byte (for string handling in C)
+      raise Msf::PayloadItemSizeError.new(item, size-1)
     end
     @to_str.call(item, size)
   end

--- a/lib/rex/payloads/meterpreter/config.rb
+++ b/lib/rex/payloads/meterpreter/config.rb
@@ -36,6 +36,10 @@ private
   end
 
   def to_str(item, size)
+    if  (item.size > size-1)
+      print("Option string: #{item} was to long to fit. Max size: #{size-1}. Automatic resizing... (you might want to adjust your options)\n")
+      item = item.slice(0..(size-1))
+    end
     @to_str.call(item, size)
   end
 

--- a/lib/rex/payloads/meterpreter/config.rb
+++ b/lib/rex/payloads/meterpreter/config.rb
@@ -37,8 +37,7 @@ private
 
   def to_str(item, size)
     if  (item.size > size-1)
-      print("Option string: #{item} was to long to fit. Max size: #{size-1}. Automatic resizing... (you might want to adjust your options)\n")
-      item = item.slice(0..(size-1))
+      item = item.slice(0..(size-1)) # TODO silently fix things or throw error?
     end
     @to_str.call(item, size)
   end


### PR DESCRIPTION
Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

Partial fix for #11750

## Verification

List the steps needed to make sure this thing 


    use payload/windows/x64/meterpreter_reverse_http
    set Usual meterpreter payload settings
    setg httpuseragent aaaaaaaaaa[...3000 a...]aaaa
    Generate payload
    Execute payload on a Windows10 64 bit system

Check on the debug output if the ssl_cert_hash field is 0000000...
