### PR TITLE
Bump metasploit_payloads-mettle to 0.5.12

### DIFF
--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -72,7 +72,7 @@ Gem::Specification.new do |spec|
   # Needed for Meterpreter
   spec.add_runtime_dependency 'metasploit-payloads', '1.3.66'
   # Needed for the next-generation POSIX Meterpreter
-  spec.add_runtime_dependency 'metasploit_payloads-mettle', '0.5.10'
+  spec.add_runtime_dependency 'metasploit_payloads-mettle', '0.5.12'
   # Needed by msfgui and other rpc components
   spec.add_runtime_dependency 'msgpack'
   # get list of network interfaces, like eth* from OS.


### PR DESCRIPTION
Confirmed #11746 resolves the issues with `cmd_exec`.

This PR bumps the version of `metasploit_payloads-mettle` from `0.5.10` to `0.5.12` so that the changes take effect.

Demo of functionality working as expected (it wasn't before the patch) :

```
msf5 exploit(linux/local/abrt_raceabrt_priv_esc) > check

[+] System is configured to use ABRT for crash reporting
[+] System does not appear to have been patched
[+] Directory '/var/tmp/abrt' exists
[+] abrt-ccpp service is running
[*] System is using ABRT package version 2.1.11-12.el7
[*] The target service is running, but could not be validated.
```
