### PR TITLE
Fix URL and revert "automatic module_metadata_base.json update"

### DIFF
--- a/modules/exploits/multi/http/confluence_widget_connector.rb
+++ b/modules/exploits/multi/http/confluence_widget_connector.rb
@@ -38,7 +38,7 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           [ 'CVE', '2019-3396' ],
           [ 'URL', 'https://confluence.atlassian.com/doc/confluence-security-advisory-2019-03-20-966660264.html' ],
-          [ 'URL', 'https://chybeta.github.io/2019/04/06/Analysis-for-【CVE-2019-3396】-SSTI-and-RCE-in-Confluence-Server-via-Widget-Connector/'],
+          [ 'URL', 'https://chybeta.github.io/2019/04/06/Analysis-for-%E3%80%90CVE-2019-3396%E3%80%91-SSTI-and-RCE-in-Confluence-Server-via-Widget-Connector/'],
           [ 'URL', 'https://paper.seebug.org/886/']
         ],
       'Targets'        =>


### PR DESCRIPTION
This reverts commit a21f49bea9e34d609e80e2c4aff7ada697a2406e.

We need the contents of this file. Also, encode offending non-UTF8 characters.

Verification
========

- [ ] The file has stuff in it again.
- [ ] The fancy URL with non-UTF8 encoding is URL encoded
- [ ] `core: Unable to update metadata store: “\xE3” from ASCII-8BIT to UTF-8` does not appear in your log when starting `msfconsole`