### PR TITLE
Fix "search" bug

### DIFF
--- a/modules/auxiliary/gather/rails_doubletap_file_read.rb
+++ b/modules/auxiliary/gather/rails_doubletap_file_read.rb
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Auxiliary
           [ 'EDB', '46585' ]
         ],
         'Notes' => {
-          'AKA' => 'DoubleTap'
+          'AKA' => ['DoubleTap']
         }
       )
     )


### PR DESCRIPTION
Since `module_metadata.notes['AKA']` is not `Array` caused an error
```
msf5 > search test
[-] Error while running command search: no implicit conversion of String into Array
```