### PR TITLE
Handle Spaces In Tab Completion Logic

### DIFF
--- a/lib/rex/ui/text/dispatcher_shell.rb
+++ b/lib/rex/ui/text/dispatcher_shell.rb
@@ -425,7 +425,7 @@ module DispatcherShell
       word.downcase.start_with?(str.downcase) || word =~ /^#{str}/i
     # Prepend the rest of the command (or it all gets replaced!)
     }.map { |word|
-      word = quote.nil? ? word.gsub(' ', '\ ') : quote.dup << word
+      word = quote.nil? ? word.gsub(' ', '\ ') : quote.dup << word << quote.dup
       tab_words.dup.push(word).join(' ')
     }
   end

--- a/lib/rex/ui/text/dispatcher_shell.rb
+++ b/lib/rex/ui/text/dispatcher_shell.rb
@@ -649,7 +649,7 @@ module DispatcherShell
         field = String.new
       end
     end
-    words << field if field.length.nonzero?
+    words << field unless quote.nil?
     {:quote => quote, :words => words}
   end
 

--- a/lib/rex/ui/text/dispatcher_shell.rb
+++ b/lib/rex/ui/text/dispatcher_shell.rb
@@ -359,7 +359,7 @@ module DispatcherShell
   #
   def tab_complete(str)
     # Check trailing whitespace so we can tell 'x' from 'x '
-    str_match = str.match(/\s+$/)
+    str_match = str.match(/[^\\]([\\]{2})*\s+$/)
     str_trail = (str_match.nil?) ? '' : str_match[0]
 
     # Split the line up by whitespace into words

--- a/lib/rex/ui/text/dispatcher_shell.rb
+++ b/lib/rex/ui/text/dispatcher_shell.rb
@@ -363,7 +363,7 @@ module DispatcherShell
     str_trail = (str_match.nil?) ? '' : str_match[0]
 
     # Split the line up by whitespace into words
-    str_words = str.split(/[\s\t\n]+/)
+    str_words = Shellwords.split(str)
 
     # Append an empty word if we had trailing whitespace
     str_words << '' if str_trail.length > 0
@@ -425,7 +425,7 @@ module DispatcherShell
       e.downcase.start_with?(str.downcase) || e =~ /^#{str}/i
     # Prepend the rest of the command (or it all gets replaced!)
     }.map { |e|
-      tab_words.dup.push(e).join(' ')
+      tab_words.dup.push(e.gsub(' ', '\ ')).join(' ')
     }
   end
 


### PR DESCRIPTION
This Pull Request adjusts how strings are split on the command line as part of the tab completion logic to support escaped paths with spaces in them. More specifically, it switches the split logic to use the `Shellwords.split` function in place of a regex which simply split on white space to more closely align the completion parsing with how the command itself parsed. This has the notable benefit of allowing the user to tab complete file paths which contain spaces.

If the user ends a line with `\ ` (or any odd number of `\`), it will include the space at the end of the last word for the purposes of completion.

## Example Usage

1. Create the following directory structure
    * `/tmp/Metasploit Test/some target list.txt`
    * `/tmp/Metasploit Test/some_other_targets.txt`
    * `/tmp/Metasploit Test/Another Directory/more targets.txt`
1. Start `./msfconsole`
1. Use a module that takes a file as an option (pro-tip all `RHOSTS` can using the `file:` syntax)
    * [ ] `use exploit/windows/smb/psexec`
    * [ ] Type `set RHOSTS file:/tmp/Metasploit<TAB>`
        * [ ] See it complete `set RHOSTS /tmp/Metasploit\ Test/`
    * [ ] Type `set RHOSTS file:/tmp/Metasploit\ Test/<TAB><TAB>`
        * [ ] See it suggest `Another\ Directory      some\ target\ list.txt  some_other_targets.txt`
    * [ ] Type `set RHOSTS file:/tmp/Metasploit\ Test/some\ <TAB>`
        * [ ] See it complete `set RHOSTS file:/tmp/Metasploit\ Test/some\ target\ list.txt`