### PR TITLE
Implement fast(er) "set PAYLOAD" tab completion and "show payloads"

### DIFF
--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -763,7 +763,7 @@ class Exploit < Msf::Module
 
     results = Msf::Modules::Metadata::Cache.instance.find(
       'type'     => [['payload'], []],
-      'platform' => [c_platform.names, []],
+      'platform' => [[*c_platform.names, 'All'], []], # "All" for generic
       'arch'     => [c_arch, []]
     )
 

--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -761,12 +761,19 @@ class Exploit < Msf::Module
 
     c_platform, c_arch = normalize_platform_arch
 
-    framework.payloads.each_module(
-      'Arch' => c_arch, 'Platform' => c_platform) { |name, mod|
-      payloads << [ name, mod ] if is_payload_compatible?(name)
-    }
+    results = Msf::Modules::Metadata::Cache.instance.find(
+      'type'     => [['payload'], []],
+      'platform' => [c_platform.names, []],
+      'arch'     => [c_arch, []]
+    )
 
-    return payloads;
+    results.each do |res|
+      if is_payload_compatible?(res.ref_name)
+        payloads << [res.ref_name, framework.payloads[res.ref_name]]
+      end
+    end
+
+    payloads
   end
 
   #


### PR DESCRIPTION
This enhances the `compatible_payloads` method in `lib/msf/core/exploit.rb` to use the module cache for fast matching.

- [x] Fix `generic` payloads being left out

```
msf5 > use rv130

Matching Modules
================

   #  Name                                    Disclosure Date  Rank  Check  Description
   -  ----                                    ---------------  ----  -----  -----------
   1  exploit/linux/http/cisco_rv130_rmi_rce  2019-02-27       good  No     Cisco RV130W Routers Management Interface Remote Command Execution


[*] Using exploit/linux/http/cisco_rv130_rmi_rce
msf5 exploit(linux/http/cisco_rv130_rmi_rce) > set payload
set payload generic/custom                         set payload linux/armle/exec                       set payload linux/armle/meterpreter_reverse_https  set payload linux/armle/shell_bind_tcp
set payload generic/shell_bind_tcp                 set payload linux/armle/meterpreter/bind_tcp       set payload linux/armle/meterpreter_reverse_tcp    set payload linux/armle/shell_reverse_tcp
set payload generic/shell_reverse_tcp              set payload linux/armle/meterpreter/reverse_tcp    set payload linux/armle/shell/bind_tcp
set payload linux/armle/adduser                    set payload linux/armle/meterpreter_reverse_http   set payload linux/armle/shell/reverse_tcp
msf5 exploit(linux/http/cisco_rv130_rmi_rce) > show payloads

Compatible Payloads
===================

   #   Name                                   Disclosure Date  Rank    Check  Description
   -   ----                                   ---------------  ----    -----  -----------
   1   generic/custom                                          normal  No     Custom Payload
   2   generic/shell_bind_tcp                                  normal  No     Generic Command Shell, Bind TCP Inline
   3   generic/shell_reverse_tcp                               normal  No     Generic Command Shell, Reverse TCP Inline
   4   linux/armle/adduser                                     normal  No     Linux Add User
   5   linux/armle/exec                                        normal  No     Linux Execute Command
   6   linux/armle/meterpreter/bind_tcp                        normal  No     Linux Meterpreter, Bind TCP Stager
   7   linux/armle/meterpreter/reverse_tcp                     normal  No     Linux Meterpreter, Reverse TCP Stager
   8   linux/armle/meterpreter_reverse_http                    normal  No     Linux Meterpreter, Reverse HTTP Inline
   9   linux/armle/meterpreter_reverse_https                   normal  No     Linux Meterpreter, Reverse HTTPS Inline
   10  linux/armle/meterpreter_reverse_tcp                     normal  No     Linux Meterpreter, Reverse TCP Inline
   11  linux/armle/shell/bind_tcp                              normal  No     Linux dup2 Command Shell, Bind TCP Stager
   12  linux/armle/shell/reverse_tcp                           normal  No     Linux dup2 Command Shell, Reverse TCP Stager
   13  linux/armle/shell_bind_tcp                              normal  No     Linux Command Shell, Reverse TCP Inline
   14  linux/armle/shell_reverse_tcp                           normal  No     Linux Command Shell, Reverse TCP Inline

msf5 exploit(linux/http/cisco_rv130_rmi_rce) >
```

On my system, I save about 1.5 seconds before results are cached.

#9026