### PR TITLE
 Change dump_aka to dump_notes and add field for related modules

### DIFF
--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -683,9 +683,15 @@ class ReadableText
       when 'AKA'
         output << "Also known as:\n"
         val.each { |aka| output << "#{indent}#{aka}\n" }
+      when 'NOCVE'
+        output << "CVE not available:\n" \
+                  "#{indent}#{val}\n"
       when 'RELATED'
         output << "Related modules:\n"
         val.each { |related| output << "#{indent}#{related}\n" }
+      when 'Stability', 'SideEffects', 'Reliability'
+        # Handled by dump_traits
+        next
       else
         # Display the raw note
         output << "#{name}:\n" \

--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -686,16 +686,24 @@ class ReadableText
       when 'NOCVE'
         output << "CVE not available:\n" \
                   "#{indent}#{val}\n"
-      when 'RELATED'
+      when 'RelatedModules'
         output << "Related modules:\n"
         val.each { |related| output << "#{indent}#{related}\n" }
       when 'Stability', 'SideEffects', 'Reliability'
         # Handled by dump_traits
         next
       else
-        # Display the raw note
         output << "#{name}:\n" \
-                  "#{indent}#{val}\n"
+
+        case val
+        when Array
+          val.each { |v| output << "#{indent}#{v}\n" }
+        when Hash
+          val.each { |k, v| output << "#{indent}#{k}: #{v}\n" }
+        else
+          # Display the raw note
+          output << "#{indent}#{val}\n"
+        end
       end
 
       output << "\n"

--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -286,8 +286,8 @@ class ReadableText
     # References
     output << dump_references(mod, indent)
 
-    # AKA
-    output << dump_aka(mod, indent)
+    # Notes
+    output << dump_notes(mod, indent)
 
     return output
 
@@ -341,8 +341,8 @@ class ReadableText
     # References
     output << dump_references(mod, indent)
 
-    # AKA
-    output << dump_aka(mod, indent)
+    # Notes
+    output << dump_notes(mod, indent)
 
     return output
   end
@@ -401,8 +401,8 @@ class ReadableText
     # References
     output << dump_references(mod, indent)
 
-    # AKA
-    output << dump_aka(mod, indent)
+    # Notes
+    output << dump_notes(mod, indent)
 
     return output
   end
@@ -668,19 +668,28 @@ class ReadableText
     output
   end
 
-  # Dumps the aka names associated with the supplied module.
+  # Dumps the notes associated with the supplied module.
   #
   # @param mod [Msf::Module] the module.
   # @param indent [String] the indentation to use.
   # @return [String] the string form of the information.
-  def self.dump_aka(mod, indent = '')
+  def self.dump_notes(mod, indent = '')
     output = ''
 
-    if mod.notes['AKA'].present?
-      output << "AKA:\n"
+    mod.notes.each do |name, val|
+      next unless val.present?
 
-      mod.notes['AKA'].each do |aka_name|
-        output << indent + aka_name + "\n"
+      case name
+      when 'AKA'
+        output << "Also known as:\n"
+        val.each { |aka| output << "#{indent}#{aka}\n" }
+      when 'RELATED'
+        output << "Related modules:\n"
+        val.each { |related| output << "#{indent}#{related}\n" }
+      else
+        # Display the raw note
+        output << "#{name}:\n" \
+                  "#{indent}#{val}\n"
       end
 
       output << "\n"

--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -693,7 +693,7 @@ class ReadableText
         # Handled by dump_traits
         next
       else
-        output << "#{name}:\n" \
+        output << "#{name}:\n"
 
         case val
         when Array

--- a/modules/exploits/linux/upnp/belkin_wemo_upnp_exec.rb
+++ b/modules/exploits/linux/upnp/belkin_wemo_upnp_exec.rb
@@ -59,10 +59,10 @@ class MetasploitModule < Msf::Exploit::Remote
       ],
       'DefaultTarget'      => 1,
       'Notes'              => {
+        'NOCVE'            => 'Patched in 2.00.8643 without vendor disclosure',
         'Stability'        => [CRASH_SAFE],
         'SideEffects'      => [ARTIFACTS_ON_DISK],
-        'Reliability'      => [REPEATABLE_SESSION],
-        'NOCVE'            => 'Patched in 2.00.8643'
+        'Reliability'      => [REPEATABLE_SESSION]
       }
     ))
 

--- a/modules/exploits/linux/upnp/belkin_wemo_upnp_exec.rb
+++ b/modules/exploits/linux/upnp/belkin_wemo_upnp_exec.rb
@@ -61,7 +61,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Notes'              => {
         'Stability'        => [CRASH_SAFE],
         'SideEffects'      => [ARTIFACTS_ON_DISK],
-        'Reliablity'       => [REPEATABLE_SESSION],
+        'Reliability'      => [REPEATABLE_SESSION],
         'NOCVE'            => 'Patched in 2.00.8643'
       }
     ))

--- a/modules/exploits/multi/fileformat/ghostscript_failed_restore.rb
+++ b/modules/exploits/multi/fileformat/ghostscript_failed_restore.rb
@@ -16,49 +16,52 @@ class MetasploitModule < Msf::Exploit
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Ghostscript Failed Restore Command Execution',
-      'Description'    => %q{
+      'Name'              => 'Ghostscript Failed Restore Command Execution',
+      'Description'       => %q{
         This module exploits a -dSAFER bypass in Ghostscript to execute
         arbitrary commands by handling a failed restore (grestore) in
         PostScript to disable LockSafetyParams and avoid invalidaccess.
 
         This vulnerability is reachable via libraries such as ImageMagick.
       },
-      'Author'         => [
+      'Author'            => [
         'Tavis Ormandy', # Vuln discovery and exploit
         'wvu'            # Metasploit module
       ],
-      'References'     => [
+      'References'        => [
         ['CVE', '2018-16509'],
         ['URL', 'https://seclists.org/oss-sec/2018/q3/142'],
         ['URL', 'https://bugs.chromium.org/p/project-zero/issues/detail?id=1640']
       ],
-      'DisclosureDate' => '2018-08-21',
-      'License'        => MSF_LICENSE,
-      'Platform'       => ['unix', 'linux', 'win'],
-      'Arch'           => [ARCH_CMD, ARCH_X86, ARCH_X64],
-      'Privileged'     => false,
-      'Targets'        => [
+      'DisclosureDate'    => '2018-08-21',
+      'License'           => MSF_LICENSE,
+      'Platform'          => ['unix', 'linux', 'win'],
+      'Arch'              => [ARCH_CMD, ARCH_X86, ARCH_X64],
+      'Privileged'        => false,
+      'Targets'           => [
         ['Unix (In-Memory)',
-          'Platform'   => 'unix',
-          'Arch'       => ARCH_CMD,
-          'Type'       => :unix_memory,
-          'Payload'    => {'Space' => 4089, 'DisableNops' => true} # 4096 total
+          'Platform'      => 'unix',
+          'Arch'          => ARCH_CMD,
+          'Type'          => :unix_memory,
+          'Payload'       => {
+            'Space'       => 4089, # 4096 total
+            'DisableNops' => true
+          }
         ],
         ['PowerShell (In-Memory)',
-          'Platform'   => 'win',
-          'Arch'       => [ARCH_X86, ARCH_X64],
-          'Type'       => :psh_memory
+          'Platform'      => 'win',
+          'Arch'          => [ARCH_X86, ARCH_X64],
+          'Type'          => :psh_memory
         ],
         ['Linux (Dropper)',
-          'Platform'   => 'linux',
-          'Arch'       => [ARCH_X86, ARCH_X64],
-          'Type'       => :linux_dropper
+          'Platform'      => 'linux',
+          'Arch'          => [ARCH_X86, ARCH_X64],
+          'Type'          => :linux_dropper
         ]
       ],
-      'DefaultTarget'  => 0,
-      'Notes'          => {
-        'RELATED'      => [
+      'DefaultTarget'     => 0,
+      'Notes'             => {
+        'RelatedModules'  => [
           'exploit/unix/fileformat/ghostscript_type_confusion',
           'exploit/unix/fileformat/imagemagick_delegate'
         ]

--- a/modules/exploits/multi/fileformat/ghostscript_failed_restore.rb
+++ b/modules/exploits/multi/fileformat/ghostscript_failed_restore.rb
@@ -22,12 +22,7 @@ class MetasploitModule < Msf::Exploit
         arbitrary commands by handling a failed restore (grestore) in
         PostScript to disable LockSafetyParams and avoid invalidaccess.
 
-        This vulnerability is reachable via libraries such as ImageMagick,
-        and this module provides the latest vector for Ghostscript.
-
-        For previous Ghostscript vectors, please see the following modules:
-          exploit/unix/fileformat/ghostscript_type_confusion
-          exploit/unix/fileformat/imagemagick_delegate
+        This vulnerability is reachable via libraries such as ImageMagick.
       },
       'Author'         => [
         'Tavis Ormandy', # Vuln discovery and exploit
@@ -61,7 +56,13 @@ class MetasploitModule < Msf::Exploit
           'Type'       => :linux_dropper
         ]
       ],
-      'DefaultTarget'  => 0
+      'DefaultTarget'  => 0,
+      'Notes'          => {
+        'RELATED'      => [
+          'exploit/unix/fileformat/ghostscript_type_confusion',
+          'exploit/unix/fileformat/imagemagick_delegate'
+        ]
+      }
     ))
 
     register_options([

--- a/modules/exploits/unix/fileformat/ghostscript_type_confusion.rb
+++ b/modules/exploits/unix/fileformat/ghostscript_type_confusion.rb
@@ -10,39 +10,39 @@ class MetasploitModule < Msf::Exploit
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Ghostscript Type Confusion Arbitrary Command Execution',
-      'Description'    => %q{
+      'Name'             => 'Ghostscript Type Confusion Arbitrary Command Execution',
+      'Description'      => %q{
         This module exploits a type confusion vulnerability in Ghostscript that can
         be exploited to obtain arbitrary command execution. This vulnerability affects
         Ghostscript versions 9.21 and earlier and can be exploited through libraries
         such as ImageMagick and Pillow.
       },
-      'Author'         => [
+      'Author'           => [
         'Atlassian Security Team', # Vulnerability discovery
         'hdm'                      # Metasploit module
       ],
-      'References'     => [
+      'References'       => [
         %w{CVE 2017-8291},
         %w{URL https://bugs.ghostscript.com/show_bug.cgi?id=697808},
         %w{URL https://seclists.org/oss-sec/2017/q2/148},
         %w{URL https://git.ghostscript.com/?p=ghostpdl.git;a=commit;h=04b37bbce174eed24edec7ad5b920eb93db4d47d},
         %w{URL https://git.ghostscript.com/?p=ghostpdl.git;a=commit;h=4f83478c88c2e05d6e8d79ca4557eb039354d2f3}
       ],
-      'DisclosureDate' => 'Apr 27 2017',
-      'License'        => MSF_LICENSE,
-      'Platform'       => 'unix',
-      'Arch'           => ARCH_CMD,
-      'Privileged'     => false,
-      'Payload'        => {
-        'BadChars'     => "\x22\x27\x5c)(" # ", ', \, (, and )
+      'DisclosureDate'   => 'Apr 27 2017',
+      'License'          => MSF_LICENSE,
+      'Platform'         => 'unix',
+      'Arch'             => ARCH_CMD,
+      'Privileged'       => false,
+      'Payload'          => {
+        'BadChars'       => "\x22\x27\x5c)(" # ", ', \, (, and )
       },
-      'Targets'        => [
+      'Targets'          => [
         ['EPS file',  template: 'msf.eps']
       ],
-      'DefaultTarget'  => 0,
-      'Notes'          => {
-        'AKA'          => ['ghostbutt'],
-        'RELATED'      => [
+      'DefaultTarget'    => 0,
+      'Notes'            => {
+        'AKA'            => ['ghostbutt'],
+        'RelatedModules' => [
           'exploit/multi/fileformat/ghostscript_failed_restore',
           'exploit/unix/fileformat/imagemagick_delegate'
         ]

--- a/modules/exploits/unix/fileformat/ghostscript_type_confusion.rb
+++ b/modules/exploits/unix/fileformat/ghostscript_type_confusion.rb
@@ -16,15 +16,12 @@ class MetasploitModule < Msf::Exploit
         be exploited to obtain arbitrary command execution. This vulnerability affects
         Ghostscript versions 9.21 and earlier and can be exploited through libraries
         such as ImageMagick and Pillow.
-
-        For more recent Ghostscript vectors, please see the following modules:
-          exploit/multi/fileformat/ghostscript_failed_restore
       },
       'Author'         => [
         'Atlassian Security Team', # Vulnerability discovery
         'hdm'                      # Metasploit module
       ],
-      'References'      => [
+      'References'     => [
         %w{CVE 2017-8291},
         %w{URL https://bugs.ghostscript.com/show_bug.cgi?id=697808},
         %w{URL https://seclists.org/oss-sec/2017/q2/148},
@@ -44,7 +41,11 @@ class MetasploitModule < Msf::Exploit
       ],
       'DefaultTarget'  => 0,
       'Notes'          => {
-        'AKA'          => [ 'ghostbutt' ]
+        'AKA'          => ['ghostbutt'],
+        'RELATED'      => [
+          'exploit/multi/fileformat/ghostscript_failed_restore',
+          'exploit/unix/fileformat/imagemagick_delegate'
+        ]
       }
     ))
 

--- a/modules/exploits/unix/fileformat/imagemagick_delegate.rb
+++ b/modules/exploits/unix/fileformat/imagemagick_delegate.rb
@@ -10,8 +10,8 @@ class MetasploitModule < Msf::Exploit
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'ImageMagick Delegate Arbitrary Command Execution',
-      'Description'    => %q{
+      'Name'             => 'ImageMagick Delegate Arbitrary Command Execution',
+      'Description'      => %q{
         This module exploits a shell command injection in the way "delegates"
         (commands for converting files) are processed in ImageMagick versions
         <= 7.0.1-0 and <= 6.9.3-9 (legacy).
@@ -28,14 +28,14 @@ class MetasploitModule < Msf::Exploit
         If USE_POPEN is set to true, a |-prefixed command will be used for the
         exploit. No delegates are involved in this exploitation.
       },
-      'Author'         => [
+      'Author'           => [
         'stewie',            # Vulnerability discovery
         'Nikolay Ermishkin', # Vulnerability discovery
         'Tavis Ormandy',     # Vulnerability discovery
         'wvu',               # Metasploit module
         'hdm'                # Metasploit module
       ],
-      'References'     => [
+      'References'       => [
         %w{CVE 2016-3714},
         %w{CVE 2016-7976},
         %w{URL https://imagetragick.com/},
@@ -45,23 +45,23 @@ class MetasploitModule < Msf::Exploit
         %w{URL https://github.com/ImageMagick/ImageMagick/commit/a347456},
         %w{URL http://permalink.gmane.org/gmane.comp.security.oss.general/19669}
       ],
-      'DisclosureDate' => '2016-05-03',
-      'License'        => MSF_LICENSE,
-      'Platform'       => 'unix',
-      'Arch'           => ARCH_CMD,
-      'Privileged'     => false,
-      'Payload'        => {
-        'BadChars'     => "\x22\x27\x5c" # ", ', and \
+      'DisclosureDate'   => '2016-05-03',
+      'License'          => MSF_LICENSE,
+      'Platform'         => 'unix',
+      'Arch'             => ARCH_CMD,
+      'Privileged'       => false,
+      'Payload'          => {
+        'BadChars'       => "\x22\x27\x5c" # ", ', and \
       },
-      'Targets'        => [
+      'Targets'          => [
         ['SVG file', template: 'msf.svg'], # convert msf.png msf.svg
         ['MVG file', template: 'msf.mvg'], # convert msf.svg msf.mvg
         ['PS file',  template: 'msf.ps']   # PoC from taviso
       ],
-      'DefaultTarget'  => 0,
-      'Notes'          => {
-        'AKA'          => ['ImageTragick'],
-        'RELATED'      => [
+      'DefaultTarget'    => 0,
+      'Notes'            => {
+        'AKA'            => ['ImageTragick'],
+        'RelatedModules' => [
           'exploit/unix/fileformat/ghostscript_type_confusion',
           'exploit/multi/fileformat/ghostscript_failed_restore'
         ]

--- a/modules/exploits/unix/fileformat/imagemagick_delegate.rb
+++ b/modules/exploits/unix/fileformat/imagemagick_delegate.rb
@@ -25,10 +25,6 @@ class MetasploitModule < Msf::Exploit
         Ghostscript versions 9.18 and later are affected. This target is
         provided as is and will not be updated to track additional vulns.
 
-        For more recent Ghostscript vectors, please see the following modules:
-          exploit/multi/fileformat/ghostscript_failed_restore
-          exploit/unix/fileformat/ghostscript_type_confusion
-
         If USE_POPEN is set to true, a |-prefixed command will be used for the
         exploit. No delegates are involved in this exploitation.
       },
@@ -63,7 +59,13 @@ class MetasploitModule < Msf::Exploit
         ['PS file',  template: 'msf.ps']   # PoC from taviso
       ],
       'DefaultTarget'  => 0,
-      'Notes'          => {'AKA' => ['ImageTragick']}
+      'Notes'          => {
+        'AKA'          => ['ImageTragick'],
+        'RELATED'      => [
+          'exploit/unix/fileformat/ghostscript_type_confusion',
+          'exploit/multi/fileformat/ghostscript_failed_restore'
+        ]
+      }
     ))
 
     register_options([

--- a/modules/exploits/unix/webapp/drupal_restws_unserialize.rb
+++ b/modules/exploits/unix/webapp/drupal_restws_unserialize.rb
@@ -67,10 +67,10 @@ class MetasploitModule < Msf::Exploit::Remote
       ],
       'DefaultTarget'      => 0,
       'Notes'              => {
+        'AKA'              => ['SA-CORE-2019-003'],
         'Stability'        => [CRASH_SAFE],
         'SideEffects'      => [IOC_IN_LOGS],
-        'Reliability'      => [UNRELIABLE_SESSION], # When using the GET method
-        'AKA'              => ['SA-CORE-2019-003']
+        'Reliability'      => [UNRELIABLE_SESSION] # When using the GET method
       }
     ))
 

--- a/modules/exploits/unix/webapp/drupal_restws_unserialize.rb
+++ b/modules/exploits/unix/webapp/drupal_restws_unserialize.rb
@@ -69,7 +69,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Notes'              => {
         'Stability'        => [CRASH_SAFE],
         'SideEffects'      => [IOC_IN_LOGS],
-        'Reliablity'       => [UNRELIABLE_SESSION], # When using the GET method
+        'Reliability'      => [UNRELIABLE_SESSION], # When using the GET method
         'AKA'              => ['SA-CORE-2019-003']
       }
     ))


### PR DESCRIPTION
```
msf5 > use imagetragick

Matching Modules
================

   #  Name                                          Disclosure Date  Rank       Check  Description
   -  ----                                          ---------------  ----       -----  -----------
   1  exploit/unix/fileformat/imagemagick_delegate  2016-05-03       excellent  No     ImageMagick Delegate Arbitrary Command Execution


[*] Using exploit/unix/fileformat/imagemagick_delegate
msf5 exploit(unix/fileformat/imagemagick_delegate) > info
[snip]

Also known as:
  ImageTragick

Related modules:
  exploit/unix/fileformat/ghostscript_type_confusion
  exploit/multi/fileformat/ghostscript_failed_restore

String:
  This is a string

Array:
  1
  2

Hash:
  one: 1
  two: 2

msf5 exploit(unix/fileformat/imagemagick_delegate) >
```