### PR TITLE
Force UTF-8 for more module metadata fields

### DIFF
--- a/lib/msf/core/modules/metadata/obj.rb
+++ b/lib/msf/core/modules/metadata/obj.rb
@@ -193,8 +193,11 @@ class Obj
   end
 
   def force_encoding(encoding)
+    @name.force_encoding(encoding)
+    @full_name.force_encoding(encoding)
     @description.force_encoding(encoding)
     @author.each {|a| a.force_encoding(encoding)}
+    @references.each {|r| r.force_encoding(encoding)}
   end
 
 end


### PR DESCRIPTION
Force encode more metadata fields to deal prevent issues like those fixed in #11760.

Verification
========

- [x] Edit a module to have a non-ASCII value in a module's references or full name
- [x] Start `msfconsole`
- [x] Verify the module cache does not get truncated.