### PR TITLE
Enable Powershell payload options to be set to false

### DIFF
--- a/lib/msf/core/exploit/powershell.rb
+++ b/lib/msf/core/exploit/powershell.rb
@@ -224,7 +224,7 @@ module Exploit::Powershell
   def cmd_psh_payload(pay, payload_arch, opts = {})
     %i[persist prepend_sleep exec_in_place encode_final_payload encode_inner_payload
     remove_comspec noninteractive wrap_double_quotes no_equals method].map do |opt|
-      opts[opt] ||= datastore["Powershell::#{opt}"]
+      opts[opt] = opts[opt].nil? ? datastore["Powershell::#{opt}"] : opts[opt]
     end
 
     unless opts.key? :shorten


### PR DESCRIPTION
Referencing https://github.com/rapid7/metasploit-framework/issues/11693, Powershell payload options that default to `true` cannot be set to `false`. This change allows those options to be set to `false`.

## Verification

- [x] Find a module that makes use of the `cmd_psh_payload` function in `lib/msf/core/exploit/powershell.rb`
- [x] Set a Powershell payload option that is `true` by default to `false`
- [x] Verify said option was actually set to `false`

I copied Pearce's method in https://github.com/rapid7/metasploit-framework/pull/11660 and used pry to verify the option values before and after the call to `cmd_psh_payload`.

## Scenarios

### Testing exploit/windows/http/octopusdeploy_deploy

Before change:
```
msf5 exploit(windows/http/octopusdeploy_deploy) > run

[*] Started reverse TCP handler on 192.168.37.1:4444 

From: /Users/space/metasploit-framework/modules/exploits/windows/http/octopusdeploy_deploy.rb @ line 84 Msf::Modules::Exploit__Windows__Http__Octopusdeploy_deploy::MetasploitModule#exploit:

    79:     CheckCode::Appears
    80:   end
    81: 
    82:   def exploit
    83:     require 'pry'
 => 84:     binding.pry
    85:     # Generate the powershell payload
    86:     command = cmd_psh_payload(payload.encoded, payload_instance.arch.first, remove_comspec: true, wrap_double_quotes: true)
    87:     step_name = datastore['STEPNAME'] || rand_text_alphanumeric(4 + rand(32 - 4))
    88:     session = create_octopus_session unless datastore['APIKEY']
    89: 

[1] pry(#<Msf::Modules::Exploit__Windows__Http__Octopusdeploy_deploy::MetasploitModule>)> command = cmd_psh_payload(payload.encoded, payload_instance.arch.first, remove_comspec: true, wrap_double_quotes: false)


From: /Users/space/metasploit-framework/lib/msf/core/exploit/powershell.rb @ line 230 Msf::Exploit::Powershell#cmd_psh_payload:

    224: def cmd_psh_payload(pay, payload_arch, opts = {})
    225:   %i[persist prepend_sleep exec_in_place encode_final_payload encode_inner_payload
    226:   remove_comspec noninteractive wrap_double_quotes no_equals method].map do |opt|
    227:     opts[opt] ||= datastore["Powershell::#{opt}"]
    228:   end
    229:   require 'pry'
 => 230:   binding.pry
    231: 
    232:   unless opts.key? :shorten
    233:     opts[:shorten] = (datastore['Powershell::method'] != 'old')
    234:   end
    235: 
    236:   template_path = Rex::Powershell::Templates::TEMPLATE_DIR
    237:   command = Rex::Powershell::Command.cmd_psh_payload(pay, payload_arch, template_path, opts)
    238:   vprint_status("Powershell command length: #{command.length}")
    239: 
    240:   command
    241: end

[1] pry(#<Msf::Modules::Exploit__Windows__Http__Octopusdeploy_deploy::MetasploitModule>)> p opts
{:remove_comspec=>true, :wrap_double_quotes=>true, :persist=>false, :prepend_sleep=>nil, :exec_in_place=>false, :encode_final_payload=>false, :encode_inner_payload=>false, :noninteractive=>true, :no_equals=>false, :method=>"reflection"}
=> {:remove_comspec=>true,
 :wrap_double_quotes=>true,
 :persist=>false,
 :prepend_sleep=>nil,
 :exec_in_place=>false,
 :encode_final_payload=>false,
 :encode_inner_payload=>false,
 :noninteractive=>true,
 :no_equals=>false,
 :method=>"reflection"}
```

After change:
```
msf5 exploit(windows/http/octopusdeploy_deploy) > run

[*] Started reverse TCP handler on 192.168.37.1:4444 

From: /Users/space/metasploit-framework/modules/exploits/windows/http/octopusdeploy_deploy.rb @ line 84 Msf::Modules::Exploit__Windows__Http__Octopusdeploy_deploy::MetasploitModule#exploit:

    79:     CheckCode::Appears
    80:   end
    81: 
    82:   def exploit
    83:     require 'pry'
 => 84:     binding.pry
    85:     # Generate the powershell payload
    86:     command = cmd_psh_payload(payload.encoded, payload_instance.arch.first, remove_comspec: true, wrap_double_quotes: true)
    87:     step_name = datastore['STEPNAME'] || rand_text_alphanumeric(4 + rand(32 - 4))
    88:     session = create_octopus_session unless datastore['APIKEY']
    89: 

[1] pry(#<Msf::Modules::Exploit__Windows__Http__Octopusdeploy_deploy::MetasploitModule>)> command = cmd_psh_payload(payload.encoded, payload_instance.arch.first, remove_comspec: true, wrap_double_quotes: false)

From: /Users/space/metasploit-framework/lib/msf/core/exploit/powershell.rb @ line 230 Msf::Exploit::Powershell#cmd_psh_payload:

    224: def cmd_psh_payload(pay, payload_arch, opts = {})
    225:   %i[persist prepend_sleep exec_in_place encode_final_payload encode_inner_payload
    226:   remove_comspec noninteractive wrap_double_quotes no_equals method].map do |opt|
    227:     opts[opt] = opts[opt].nil? ? datastore["Powershell::#{opt}"] : opts[opt]
    228:   end
    229:   require 'pry'
 => 230:   binding.pry
    231: 
    232:   unless opts.key? :shorten
    233:     opts[:shorten] = (datastore['Powershell::method'] != 'old')
    234:   end
    235: 
    236:   template_path = Rex::Powershell::Templates::TEMPLATE_DIR
    237:   command = Rex::Powershell::Command.cmd_psh_payload(pay, payload_arch, template_path, opts)
    238:   vprint_status("Powershell command length: #{command.length}")
    239: 
    240:   command
    241: end

[1] pry(#<Msf::Modules::Exploit__Windows__Http__Octopusdeploy_deploy::MetasploitModule>)> p opts
{:remove_comspec=>true, :wrap_double_quotes=>false, :persist=>false, :prepend_sleep=>nil, :exec_in_place=>false, :encode_final_payload=>false, :encode_inner_payload=>false, :noninteractive=>true, :no_equals=>false, :method=>"reflection"}
=> {:remove_comspec=>true,
 :wrap_double_quotes=>false,
 :persist=>false,
 :prepend_sleep=>nil,
 :exec_in_place=>false,
 :encode_final_payload=>false,
 :encode_inner_payload=>false,
 :noninteractive=>true,
 :no_equals=>false,
 :method=>"reflection"}

```

### Testing exploit/multi/fileformat/libreoffice_macro_exec

Before change:
```
msf5 exploit(multi/fileformat/libreoffice_macro_exec) > run

From: /Users/space/metasploit-framework/modules/exploits/multi/fileformat/libreoffice_macro_exec.rb @ line 83 Msf::Modules::Exploit__Multi__Fileformat__Libreoffice_macro_exec::MetasploitModule#gen_windows_cmd:

    75: def gen_windows_cmd
    76:   opts =
    77:   {
    78:     :remove_comspec       =>  true,
    79:     :method               =>  'reflection',
    80:     :encode_final_payload =>  true
    81:   }
    82:   require 'pry'
 => 83:   binding.pry
    84:   @cmd = cmd_psh_payload(payload.encoded, payload_instance.arch.first, opts)
    85:   @cmd << ' &amp;&amp; echo'
    86: end

[1] pry(#<Msf::Modules::Exploit__Multi__Fileformat__Libreoffice_macro_exec::MetasploitModule>)> @cmd = cmd_psh_payload(payload.encoded, payload_instance.arch.first, {:remove_comspec => true, :method => 'reflection', :encode_final_payload => true, :wrap_double_quotes => false, :noninteractive => false})

From: /Users/space/metasploit-framework/lib/msf/core/exploit/powershell.rb @ line 230 Msf::Exploit::Powershell#cmd_psh_payload:

    224: def cmd_psh_payload(pay, payload_arch, opts = {})
    225:   %i[persist prepend_sleep exec_in_place encode_final_payload encode_inner_payload
    226:   remove_comspec noninteractive wrap_double_quotes no_equals method].map do |opt|
    227:     opts[opt] ||= datastore["Powershell::#{opt}"]
    228:   end
    229:   require 'pry'
 => 230:   binding.pry
    231: 
    232:   unless opts.key? :shorten
    233:     opts[:shorten] = (datastore['Powershell::method'] != 'old')
    234:   end
    235: 
    236:   template_path = Rex::Powershell::Templates::TEMPLATE_DIR
    237:   command = Rex::Powershell::Command.cmd_psh_payload(pay, payload_arch, template_path, opts)
    238:   vprint_status("Powershell command length: #{command.length}")
    239: 
    240:   command
    241: end

[1] pry(#<Msf::Modules::Exploit__Multi__Fileformat__Libreoffice_macro_exec::MetasploitModule>)> p opts
{:remove_comspec=>true, :method=>"reflection", :encode_final_payload=>true, :wrap_double_quotes=>true, :noninteractive=>true, :persist=>false, :prepend_sleep=>nil, :exec_in_place=>false, :encode_inner_payload=>false, :no_equals=>false}
=> {:remove_comspec=>true,
 :method=>"reflection",
 :encode_final_payload=>true,
 :wrap_double_quotes=>true,
 :noninteractive=>true,
 :persist=>false,
 :prepend_sleep=>nil,
 :exec_in_place=>false,
 :encode_inner_payload=>false,
 :no_equals=>false}

```

After change:
```
msf5 exploit(multi/fileformat/libreoffice_macro_exec) > run

From: /Users/space/metasploit-framework/modules/exploits/multi/fileformat/libreoffice_macro_exec.rb @ line 83 Msf::Modules::Exploit__Multi__Fileformat__Libreoffice_macro_exec::MetasploitModule#gen_windows_cmd:

    75: def gen_windows_cmd
    76:   opts =
    77:   {
    78:     :remove_comspec       =>  true,
    79:     :method               =>  'reflection',
    80:     :encode_final_payload =>  true
    81:   }
    82:   require 'pry'
 => 83:   binding.pry
    84:   @cmd = cmd_psh_payload(payload.encoded, payload_instance.arch.first, opts)
    85:   @cmd << ' &amp;&amp; echo'
    86: end

[1] pry(#<Msf::Modules::Exploit__Multi__Fileformat__Libreoffice_macro_exec::MetasploitModule>)> @cmd = cmd_psh_payload(payload.encoded, payload_instance.arch.first, {:remove_comspec => true, :method => 'reflection', :encode_final_payload => true, :wrap_double_quotes => false, :noninteractive => false})

From: /Users/space/metasploit-framework/lib/msf/core/exploit/powershell.rb @ line 230 Msf::Exploit::Powershell#cmd_psh_payload:

    224: def cmd_psh_payload(pay, payload_arch, opts = {})
    225:   %i[persist prepend_sleep exec_in_place encode_final_payload encode_inner_payload
    226:   remove_comspec noninteractive wrap_double_quotes no_equals method].map do |opt|
    227:     opts[opt] = opts[opt].nil? ? datastore["Powershell::#{opt}"] : opts[opt]
    228:   end
    229:   require 'pry'
 => 230:   binding.pry
    231: 
    232:   unless opts.key? :shorten
    233:     opts[:shorten] = (datastore['Powershell::method'] != 'old')
    234:   end
    235: 
    236:   template_path = Rex::Powershell::Templates::TEMPLATE_DIR
    237:   command = Rex::Powershell::Command.cmd_psh_payload(pay, payload_arch, template_path, opts)
    238:   vprint_status("Powershell command length: #{command.length}")
    239: 
    240:   command
    241: end

[1] pry(#<Msf::Modules::Exploit__Multi__Fileformat__Libreoffice_macro_exec::MetasploitModule>)> p opts
{:remove_comspec=>true, :method=>"reflection", :encode_final_payload=>true, :wrap_double_quotes=>false, :noninteractive=>false, :persist=>false, :prepend_sleep=>nil, :exec_in_place=>false, :encode_inner_payload=>false, :no_equals=>false}
=> {:remove_comspec=>true,
 :method=>"reflection",
 :encode_final_payload=>true,
 :wrap_double_quotes=>false,
 :noninteractive=>false,
 :persist=>false,
 :prepend_sleep=>nil,
 :exec_in_place=>false,
 :encode_inner_payload=>false,
 :no_equals=>false}
```