### PR TITLE
Allow RHOST option

### DIFF
--- a/modules/auxiliary/scanner/oracle/sid_brute.rb
+++ b/modules/auxiliary/scanner/oracle/sid_brute.rb
@@ -31,7 +31,7 @@ class MetasploitModule < Msf::Auxiliary
       ])
 
     deregister_options(
-      "RHOST", "USERNAME", "PASSWORD", "USER_FILE", "PASS_FILE", "USERPASS_FILE",
+      "USERNAME", "PASSWORD", "USER_FILE", "PASS_FILE", "USERPASS_FILE",
       "BLANK_PASSWORDS", "USER_AS_PASS", "REMOVE_USER_FILE", "REMOVE_PASS_FILE",
       "REMOVE_USERPASS_FILE"
     )


### PR DESCRIPTION
Make RHOSTS option viewable in sid_brute.
Reported by @actuated 

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/oracle/sid_brute`
- [ ] `options`
- [ ] Verify RHOSTS is available

