### PR TITLE
Fix NoMethodError in jira_plugin_upload exploit module

### DIFF
--- a/modules/exploits/multi/http/jira_plugin_upload.rb
+++ b/modules/exploits/multi/http/jira_plugin_upload.rb
@@ -58,7 +58,10 @@ class MetasploitModule < Msf::Exploit::Remote
     end
     return CheckCode::Unknown unless login_res.code == 200
     @session_id = get_sid(login_res)
-    @xsrf_token = login_res.get_html_document.at('meta[@id="atlassian-token"]')['content']
+    @xsrf_token = login_res.get_html_document.at('meta[@id="atlassian-token"]')
+    return CheckCode::Unknown if @xsrf_token.nil? || @xsrf_token['content'].nil?
+    @xsrf_token = @xsrf_token['content']
+
     auth_res = do_auth
     good_sid = get_sid(auth_res)
     good_cookie = "atlassian.xsrf.token=#{@xsrf_token}; #{good_sid}"
@@ -179,7 +182,10 @@ class MetasploitModule < Msf::Exploit::Remote
     end
     return false unless res && res.code == 200
     @session_id = get_sid(res)
-    @xsrf_token = res.get_html_document.at('meta[@id="atlassian-token"]')['content']
+    @xsrf_token = res.get_html_document.at('meta[@id="atlassian-token"]')
+    return false if @xsrf_token.nil? || @xsrf_token['content'].nil?
+
+    @xsrf_token = @xsrf_token['content']
     return true
   end
 


### PR DESCRIPTION
This adds checks to the functionality that searches responses for a particular value in the `jira_plugin_upload` exploit module. Referencing issue https://github.com/rapid7/metasploit-framework/issues/11609

## Verification

- [ ] Install Atlassian SDK/Jira environment.
- [ ] Browse to localhost:2990/jira/ to confirm successful deployment.
- [ ] Start msfconsole: msfconsole -q
- [ ] Do: use exploit/multi/http/jira_plugin_upload
- [ ] Do: set rhost [IP]
- [ ] Check credentials and UPM access: check
- [ ] Do: exploit
- [ ] You should get a shell.


