### PR TITLE
Fix DB RPC issues

### DIFF
--- a/lib/msf/core/rpc/v10/rpc_db.rb
+++ b/lib/msf/core/rpc/v10/rpc_db.rb
@@ -439,7 +439,7 @@ public
     offset = opts.delete(:offset) || 0
 
     conditions = {}
-    conditions["hosts.address"] = opts[:addresses] if opts[:addresses]
+    conditions["hosts.address"] = opts[:address] if opts[:address]
     conditions[:name] = opts[:names].strip().split(",") if opts[:names]
     conditions["services.port"] = Rex::Socket.portspec_to_portlist(opts[:ports]) if opts[:port]
     conditions["services.proto"] = opts[:proto] if opts[:proto]
@@ -1048,7 +1048,7 @@ end
     offset = opts.delete(:offset) || 0
 
     conditions = {}
-    conditions["hosts.address"] = opts[:addresses] if opts[:addresses]
+    conditions["hosts.address"] = opts[:address] if opts[:address]
     conditions[:name] = opts[:names].strip().split(",") if opts[:names]
     conditions[:ntype] = opts[:ntype] if opts[:ntype]
     conditions["services.port"] = Rex::Socket.portspec_to_portlist(opts[:ports]) if opts[:ports]

--- a/lib/msf/core/rpc/v10/rpc_db.rb
+++ b/lib/msf/core/rpc/v10/rpc_db.rb
@@ -1122,14 +1122,14 @@ end
     vulns = []
 
     if opts[:host] or opts[:address] or opts[:addresses]
-      hosts = opts_to_hosts(xopts)
+      hosts = opts_to_hosts(opts)
     end
 
     if opts[:port] or opts[:proto]
       if opts[:host] or opts[:address] or opts[:addresses]
-        services = opts_to_services(hosts,xopts)
+        services = opts_to_services(hosts, opts)
       else
-        services = opts_to_services([],xopts)
+        services = opts_to_services([], opts)
       end
     end
 
@@ -1139,7 +1139,7 @@ end
         if opts[:name]
           vret = s.vulns.find_by_name(opts[:name])
         else
-          vret = s.vulns
+          vret = s.vulns.to_a()
         end
         next if vret == nil
         vulns << vret if vret.class == ::Mdm::Vuln
@@ -1151,7 +1151,7 @@ end
         if opts[:name]
           vret = h.vulns.find_by_name(opts[:name])
         else
-          vret = h.vulns
+          vret = h.vulns.to_a()
         end
         next if vret == nil
         vulns << vret if vret.class == ::Mdm::Vuln
@@ -1162,7 +1162,7 @@ end
       if opts[:name]
         vret = wspace.vulns.find_by_name(opts[:name])
       else
-        vret = wspace.vulns
+        vret = wspace.vulns.to_a()
       end
       vulns << vret if vret.class == ::Mdm::Vuln
       vulns |= vret if vret.class == Array

--- a/lib/msf/core/rpc/v10/rpc_db.rb
+++ b/lib/msf/core/rpc/v10/rpc_db.rb
@@ -825,9 +825,9 @@ end
       conditions[:proto] = opts[:proto] if opts[:proto]
       conditions[:port] = opts[:port] if opts[:port]
       conditions[:name] = opts[:names] if opts[:names]
-      sret = wspace.services.where(conditions).order("hosts.address, port")
+      sret = wspace.services.where(conditions).order("hosts.address, port").to_a()
     elsif host
-      sret = host.services
+      sret = host.services.to_a()
     end
     return ret if sret == nil
     services << sret if sret.class == ::Mdm::Service

--- a/lib/msf/core/rpc/v10/rpc_db.rb
+++ b/lib/msf/core/rpc/v10/rpc_db.rb
@@ -522,7 +522,7 @@ public
   #    * 'created_at' [Integer] Last created at.
   #    * 'updated_at' [Integer] Last updated at.
   # @example Here's how you would use this from the client:
-  #  rpc.call('db.get_workspace')
+  #  rpc.call('db.get_workspace', 'default')
   def rpc_get_workspace(wspace)
     db_check
     wspace = find_workspace(wspace)
@@ -576,7 +576,7 @@ public
   # @return [Hash] A hash indicating the action was successful. It contains the following:
   #  * 'result' [String] A message that says 'success'.
   # @example Here's how you would use this from the client:
-  #  rpc.call('db.wspace', 'temp_workspace')
+  #  rpc.call('db.del_workspace', 'temp_workspace')
   def rpc_del_workspace(wspace)
   ::ActiveRecord::Base.connection_pool.with_connection {
     db_check
@@ -645,7 +645,7 @@ public
   #    * 'purpose' [String] Purpose. Example: 'server'.
   #    * 'info' [String] Additional information.
   # @example Here's how you would use this from the client:
-  #  rpc.call('db.get_host', {:host => ip})
+  #  rpc.call('db.get_host', {:workspace => 'default', :host => ip})
   def rpc_get_host(xopts)
   ::ActiveRecord::Base.connection_pool.with_connection {
     opts, wspace = init_db_opts_workspace(xopts)
@@ -692,7 +692,7 @@ public
   #      * 'mtype' [String] Module type.
   #      * 'mname' [String] Module name. For example: 'windows/wlan/wlan_profile'
   # @example Here's how you would use this from the client:
-  #  rpc.call('db.analyze_host', {:host => ip})
+  #  rpc.call('db.analyze_host', {:workspace => 'default', :host => ip})
 def rpc_analyze_host(xopts)
   ::ActiveRecord::Base.connection_pool.with_connection {
     _opts, _wspace = init_db_opts_workspace(xopts)
@@ -725,7 +725,7 @@ end
   #
   # @param [Hash] xopts Information to report about the host. See below:
   # @option xopts [String] :workspace Name of the workspace.
-  # @option xopts [String] :host IP address. You msut supply this.
+  # @option xopts [String] :host IP address. You must supply this.
   # @option xopts [String] :state One of the Msf::HostState constants. (See Most::HostState Documentation)
   # @option xopts [String] :os_name Something like "Windows", "Linux", or "Mac OS X".
   # @option xopts [String] :os_flavor Something like "Enterprise", "Pro", or "Home".
@@ -1592,6 +1592,8 @@ end
   #
   # @param [Hash] xopts Filters to narrow down which vulnerabilities to find.
   # @option xopts [String] :workspace Workspace name.
+  # @option xopts [String] :host Host address.
+  # @option xopts [String] :address Same as :host.
   # @option xopts [String] :proto Protocol.
   # @option xopts [Integer] :port Port.
   # @raise [Msf::RPC::ServerException] You might get one of these errors:
@@ -1609,7 +1611,7 @@ end
   #    * 'info' [String] Additional information.
   #    * 'refs' [Array<String>] Reference names.
   # @example Here's how you would use this from the client:
-  #  rpc.call('db.get_vuln', {:proto=>'tcp'})
+  #  rpc.call('db.get_vuln', {:host => ip, :proto => 'tcp'})
   def rpc_get_vuln(xopts)
   ::ActiveRecord::Base.connection_pool.with_connection {
     opts, wspace = init_db_opts_workspace(xopts)
@@ -1808,11 +1810,12 @@ end
   # Connects to the database.
   #
   # @param [Hash] xopts Options:
+  # This must contain :driver and driver specific options.
   # @option xopts [String] :driver Driver name. For example: 'postgresql'.
   # @return [Hash] A hash that indicates whether the action was successful or not.
   #  * 'result' [String] A message that says either 'success' or 'failed'.
   # @example Here's how you would use this from the client:
-  #  rpc.call('db.connect', {:driver=>'postgresql'})
+  #  rpc.call('db.connect', {:driver=>'postgresql', :host => db_host, :port => db_port, :database => db_name, :username => db_username, :password=> db_password})
   def rpc_connect(xopts)
     opts = fix_options(xopts)
     if not self.framework.db.driver and not opts[:driver]


### PR DESCRIPTION
This fixes a number of issues found in `Msf::RPC::RPC_Db`.

* Fix a number of incorrect method comments and examples
* Update `db.notes` (`Msf::RPC::RPC_Db#rpc_notes`) and `db.vulns` (`Msf::RPC::RPC_Db#rpc_vulns`) opts usage to match the method comment (`:address` rather than `:addresses`)
* Fix `db.get_service` (`Msf::RPC::RPC_Db#rpc_get_service`) finding a service to return
    Root cause: `Mdm::Service::ActiveRecord_Associations_CollectionProxy` is returned in some situations, however, the method only expects to process `::Mdm::Service` or `Array`. This was fixed by converting the returned object to an Array.

    Before fix:
    ```
    >> rpc.call('db.get_service', {:workspace=>'default', :host => '127.0.0.1', :proto=>'tcp', :port=>80})
    => {"service"=>[{"host"=>"127.0.0.1", "created_at"=>1556298506, "updated_at"=>1556298506, "port"=>80, "proto"=>"tcp", "state"=>"open", "name"=>"http", "info"=>""}]}

    >> rpc.call('db.get_service', {:workspace=>'default', :proto=>'tcp', :port=>80})
    => {"service"=>[]}

    >> rpc.call('db.get_service', {:workspace=>'default', :host => '127.0.0.1'})
    => {"service"=>[]}
    ```

    After fix:
    ```
    >> rpc.call('db.get_service', {:workspace=>'default', :host => '127.0.0.1', :proto=>'tcp', :port=>80})
    => {"service"=>[{"host"=>"127.0.0.1", "created_at"=>1556298506, "updated_at"=>1556298506, "port"=>80, "proto"=>"tcp", "state"=>"open", "name"=>"http", "info"=>""}]}

    >> rpc.call('db.get_service', {:workspace=>'default', :proto=>'tcp', :port=>80})
    => {"service"=>[{"host"=>"127.0.0.1", "created_at"=>1556298506, "updated_at"=>1556298506, "port"=>80, "proto"=>"tcp", "state"=>"open", "name"=>"http", "info"=>""}]}

    >> rpc.call('db.get_service', {:workspace=>'default', :host => '127.0.0.1'})
    => {"service"=>[{"host"=>"127.0.0.1", "created_at"=>1556298506, "updated_at"=>1556298506, "port"=>80, "proto"=>"tcp", "state"=>"open", "name"=>"http", "info"=>""}]}
    ```

* Fix #11756 - `db.del_vuln` (`Msf::RPC::RPC_Db#rpc_del_vuln`) deleting a vuln
    Root cause: `Mdm::Vuln::ActiveRecord_Associations_CollectionProxy` is returned in some situations, however, the code only expects to process `::Mdm::Vuln` or `Array`. This was fixed by converting the returned object to an Array.

    Before fix:
    ```
    >> rpc.call('db.vulns', {:workspace=>'default'})
    => {"vulns"=>[]}

    >> rpc.call('db.report_vuln', {:workspace=>'default', :host=>'127.0.0.1', :name=>'test'})
    => {"result"=>"success"}

    >> rpc.call('db.vulns', {:workspace=>'default'})
    => {"vulns"=>[{"port"=>nil, "proto"=>nil, "time"=>1556292072, "host"=>"127.0.0.1", "name"=>"test", "refs"=>""}]}

    >> rpc.call('db.del_vuln', {:workspace=>'default', :host=>'127.0.0.1', :name=>'test'})
    => {"result"=>"success", "deleted"=>[]}

    >> rpc.call('db.vulns', {:workspace=>'default'})
    => {"vulns"=>[{"port"=>nil, "proto"=>nil, "time"=>1556292072, "host"=>"127.0.0.1", "name"=>"test", "refs"=>""}]}
    ```

    After fix:
    ```
    >> rpc.call('db.vulns', {:workspace=>'default'})
    => {"vulns"=>[]}

    >> rpc.call('db.report_vuln', {:workspace=>'default', :host=>'127.0.0.1', :name=>'test'})
    => {"result"=>"success"}

    >> rpc.call('db.vulns', {:workspace=>'default'})
    => {"vulns"=>[{"port"=>nil, "proto"=>nil, "time"=>1556292072, "host"=>"127.0.0.1", "name"=>"test", "refs"=>""}]}

    >> rpc.call('db.del_vuln', {:workspace=>'default', :host=>'127.0.0.1', :name=>'test'})
    => {"result"=>"success", "deleted"=>[{"address"=>"127.0.0.1", "name"=>"test"}]}

    >> rpc.call('db.vulns', {:workspace=>'default'})
    => {"vulns"=>[]}
    ```

## Verification

- [x] Use `msfconsole` or preferred method to create services and vulns in the database
- [x] Start MSFRPC daemon: `./msfrpcd -P complex_password -f`
- [x] Start MSFRPC client: `./msfrpc -P complex_password -a 127.0.0.1`
- [x] Test `db.notes` RPC call
- [x] **Verify** `db.notes` returns the correct notes based on the options provided
- [x] Test `db.vulns` RPC call
- [x] **Verify** `db.vulns` returns the correct notes based on the options provided
- [x] Test `db.get_service` RPC call (see above for test cases)
- [x] **Verify** `db.get_service` returns the correct service based on the options provided
- [x] Test `db.del_vuln` RPC call (see above for test cases)
- [x] **Verify** `db.del_vuln` deletes the correct vuln based on the options provided