### PR TITLE
Added Extended passive mode to the core ftp module.

### DIFF
--- a/lib/msf/core/exploit/ftp.rb
+++ b/lib/msf/core/exploit/ftp.rb
@@ -31,7 +31,8 @@ module Exploit::Remote::Ftp
     register_advanced_options(
       [
         OptInt.new('FTPTimeout', [ true, 'The number of seconds to wait for a reply from an FTP command', 16]),
-        OptBool.new('FTPDEBUG', [ false, 'Whether or not to print verbose debug statements', false ])
+        OptBool.new('FTPDEBUG', [ false, 'Whether or not to print verbose debug statements', false ]),
+        OptBool.new('PassiveMode', [ false, 'Set true for extended passive (EPSV) ftp mode.', false])
       ], Msf::Exploit::Remote::Ftp)
 
     register_autofilter_ports([ 21, 2121])
@@ -67,6 +68,8 @@ module Exploit::Remote::Ftp
   # This method handles establishing datasocket for data channel
   #
   def data_connect(mode = nil, nsock = self.sock)
+    pass_mode = datastore['PassiveMode']
+
     if mode
       res = send_cmd([ 'TYPE' , mode ], true, nsock)
       return nil if not res =~ /^200/
@@ -75,20 +78,40 @@ module Exploit::Remote::Ftp
     # force datasocket to renegotiate
     self.datasocket.shutdown if self.datasocket != nil
 
-    res = send_cmd(['PASV'], true, nsock)
-    return nil if not res =~ /^227/
-
-    # 227 Entering Passive Mode (127,0,0,1,196,5)
-    if res =~ /\((\d+)\,(\d+),(\d+),(\d+),(\d+),(\d+)/
-      # convert port to FTP syntax
-      datahost = "#{$1}.#{$2}.#{$3}.#{$4}"
-      dataport = ($5.to_i * 256) + $6.to_i
-      self.datasocket = Rex::Socket::Tcp.create(
-        'PeerHost' => datahost,
-        'PeerPort' => dataport,
-        'Context'  => { 'Msf' => framework, 'MsfExploit' => self }
-      )
+    # Need to be able to do both extended and normal
+    # passive modes.  normal passive mode is default
+    # details of EPSV are in RFC2428
+    # pass_mode = true is EPSV; false is PASV
+    if pass_mode
+      res = send_cmd(['EPSV'], true, nsock)
+      return nil if not res =~ /^229/
+      # 229 Entering Passive Mode (|||port|)
+      if res =~ /\(\|\|\|(\d+)\|\)/
+        # convert port to FTP syntax
+        datahost = "#{rhost}"
+        dataport = $1.to_i
+        self.datasocket = Rex::Socket::Tcp.create(
+          'PeerHost' => datahost,
+          'PeerPort' => dataport,
+          'Context'  => { 'Msf' => framework, 'MsfExploit' => self }
+        )
+      end
+    else
+      res = send_cmd(['PASV'], true, nsock)
+      return nil if not res =~ /^227/
+      # 227 Entering Passive Mode (127,0,0,1,196,5)
+      if res =~ /\((\d+)\,(\d+),(\d+),(\d+),(\d+),(\d+)/
+        # convert port to FTP syntax
+        datahost = "#{$1}.#{$2}.#{$3}.#{$4}"
+        dataport = ($5.to_i * 256) + $6.to_i
+        self.datasocket = Rex::Socket::Tcp.create(
+          'PeerHost' => datahost,
+          'PeerPort' => dataport,
+          'Context'  => { 'Msf' => framework, 'MsfExploit' => self }
+        )
+      end
     end
+
     self.datasocket
   end
 


### PR DESCRIPTION
Extended passive mode (EPSV), as documented in RFC2428 is similar to the PASSive mode in that it requests that the server open a port and wait for a data connection. However, in unlike PASSive mode, Extended Passive mode returns only the port on which the server listens for the data connection, not the IP + Port.  The client is expected to use the existing IP (e.g. the one it used to create the initial control channel connection) to connect to the new data port.

Where this becomes important is if the server is behind some type of natting device, EPSV will work in this case, PASS may not.

### Existing example using PASSive mode (how MSF currently works)
User `192.168.1.1`
Server public ip:  `100.25.25.25`
Server private ip:  `170.20.20.1`

* User -> AWS server via public IP via FTP
* Connection `192.168.1.1 - EST - 100.25.25.25 (nat'd 170.20.20.1)`
* User switches to standard passive move (`PASV`)
* Server replies with IP & Port to connect to (e.g. `170.20.20.1 port: 1367`)
* User issues any data command (`ls, put, get, etc.`)
* User ftp client tries to connect to `170.20.20.1:1367` and fails.
### Screenshot of the above
![image](https://user-images.githubusercontent.com/13771080/56985285-a2d48000-6b4d-11e9-927c-a18b7c91f49f.png)


### Using EPSV
Same setup as above

* User -> AWS server via public IP via FTP
* Connection `192.168.1.1 - EST - 100.25.25.25 (nat'd 170.20.20.1)`
* User switches to extended passive move (`EPSV`) via Advanced Option (`set PassiveMode true`)
* Server replies with Port only (no IP) to connect to (e.g. port: `1367`)
* User issues any data command (`ls, put, get, etc.`)
* User ftp client tries to connect to original IP + data port `100.25.25.25:1367` and succeeds.

### Screenshot of the above
![image](https://user-images.githubusercontent.com/13771080/56985306-af58d880-6b4d-11e9-8fb5-52a23c6f4d68.png)

# Verification (using any Ftp-based exploit)

- [x] Start `msfconsole`
- [x] use exploit/mainframe/ftp/ftp_jcl_creds
- [x] set payload cmd/mainframe/apf_privesc_jcl
- [x] set ftpuser user
- [x] set ftppass password
- [x] set apflib HLQ.LINKLIB
- [x] set rhosts 127.0.0.1


## Other Screenshots
![image](https://user-images.githubusercontent.com/13771080/56983154-939f0380-6b48-11e9-82ea-e2fba437fb23.png)

