### PR TITLE
check for platform-specific env. variables in post-API tests

### DIFF
--- a/test/modules/post/test/get_env.rb
+++ b/test/modules/post/test/get_env.rb
@@ -53,8 +53,12 @@ class MetasploitModule < Msf::Post
 
   def test_get_envs
     it "should return multiple envs" do
-      res = get_envs('PATH','USERNAME')
-      !res['PATH'].blank? && !res['USERNAME'].blank?
+      res = get_envs('PATH','USERNAME','USER')
+      if session.platform =~ /win/i
+        !res['PATH'].blank? && !res['USERNAME'].blank?
+      else
+        !res['PATH'].blank? && !res['USER'].nil?
+      end
     end
   end
 

--- a/test/modules/post/test/get_env.rb
+++ b/test/modules/post/test/get_env.rb
@@ -57,7 +57,7 @@ class MetasploitModule < Msf::Post
       if session.platform =~ /win/i
         !res['PATH'].blank? && !res['USERNAME'].blank?
       else
-        !res['PATH'].blank? && !res['USER'].nil?
+        !res['PATH'].blank? && !res['USER'].blank?
       end
     end
   end


### PR DESCRIPTION
'USERNAME' is not a standard environment variable outside of Windows, which leads to this test failing on non-Windows Meterpreter platforms.

## Verification

- [x] Run the following test to make sure that the 'get_env' test works on a Linux or other non-Windows payload:

```
$ ./msfconsole -qx 'use multi/handler; set payload linux/x64/meterpreter_reverse_tcp; set lhost 127.0.0.1; run; loadpath test/modules; use post/test/get_env; set session -1; run'
payload => linux/x64/meterpreter_reverse_tcp
lhost => 127.0.0.1
[!] You are binding to a loopback address by setting LHOST to 127.0.0.1. Did you want ReverseListenerBindAddress?
[*] Started reverse TCP handler on 127.0.0.1:4444 
[*] Meterpreter session 1 opened (127.0.0.1:4444 -> 127.0.0.1:56704) at 2019-05-02 09:54:37 -0500

meterpreter > background 
[*] Backgrounding session 1...
Loaded 35 modules:
    10 posts
    13 exploits
    12 auxiliarys
session => -1

[*] Running against session -1
[*] Session type is meterpreter and platform is linux
[+] should return multiple envs
[+] should return user
[+] should handle $ sign
[*] Passed: 3; Failed: 0
[*] Post module execution completed
msf5 post(test/get_env) >
```