### PR TITLE
loadpath command generates bad plural for 'auxiliarys'

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -266,7 +266,7 @@ module Msf
             added = "Loaded #{overall} modules:\n"
 
             totals.each_pair { |type, count|
-              added << "    #{count} #{type}#{count != 1 ? 's' : ''}\n"
+              added << "    #{count} #{type} modules\n"
             }
 
             print(added)


### PR DESCRIPTION
Plural of 'auxiliary' is 'auxiliaries'. Let's get rid of bad logic and just say 'modules'.

## Verification

- [x] Start `msfconsole`
- [x] `loadpath test/modules`
- [x] **Verify** the output is correct

```
Loaded 35 modules:
    10 post modules
    13 exploit modules
    12 auxiliary modules
```
