### PR TITLE
exploit/linux/local/bpf_sign_extension_priv_esc: add tested system

### DIFF
--- a/documentation/modules/exploit/linux/local/bpf_sign_extension_priv_esc.md
+++ b/documentation/modules/exploit/linux/local/bpf_sign_extension_priv_esc.md
@@ -25,6 +25,7 @@
   * Ubuntu 14.04.1 kernel 4.4.0-89-generic;
   * Ubuntu 16.04.2 kernel 4.8.0-45-generic;
   * Ubuntu 16.04.3 kernel 4.10.0-28-generic;
+  * Ubuntu 16.04.5 kernel 4.4.0-116-generic;
   * Ubuntu 17.04 kernel 4.10.0-19-generic;
   * ZorinOS 12.1 kernel 4.8.0-39-generic.
 


### PR DESCRIPTION
I just tested a system (Ubuntu 16.04.5 kernel 4.4.0-116-generic) for `exploit/linux/local/bpf_sign_extension_priv_esc`.