### PR TITLE
Implement module use by previous search index

### DIFF
--- a/lib/msf/core/evasion.rb
+++ b/lib/msf/core/evasion.rb
@@ -283,7 +283,12 @@ module Msf
     end
 
     def target_index
-      target_idx = Integer(datastore['TARGET']) rescue datastore['TARGET']
+      target_idx =
+        begin
+          Integer(datastore['TARGET'])
+        rescue ArgumentError
+          datastore['TARGET']
+        end
 
       default_idx = default_target || 0
       # Use the default target if one was not supplied.

--- a/lib/msf/core/evasion.rb
+++ b/lib/msf/core/evasion.rb
@@ -286,7 +286,7 @@ module Msf
       target_idx =
         begin
           Integer(datastore['TARGET'])
-        rescue ArgumentError
+        rescue ArgumentError, TypeError
           datastore['TARGET']
         end
 

--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -683,7 +683,12 @@ class Exploit < Msf::Module
   # The target index that has been selected.
   #
   def target_index
-    target_idx = Integer(datastore['TARGET']) rescue datastore['TARGET']
+    target_idx =
+      begin
+        Integer(datastore['TARGET'])
+      rescue ArgumentError
+        datastore['TARGET']
+      end
 
     default_idx = default_target || 0
     # Use the default target if one was not supplied.

--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -686,7 +686,7 @@ class Exploit < Msf::Module
     target_idx =
       begin
         Integer(datastore['TARGET'])
-      rescue ArgumentError
+      rescue ArgumentError, TypeError
         datastore['TARGET']
       end
 

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -643,7 +643,7 @@ module Msf
             mod_index =
               begin
                 Integer(mod_name) - 1
-              rescue ArgumentError
+              rescue ArgumentError, TypeError
                 nil
               end
 

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -640,7 +640,12 @@ module Msf
             mod_name = args[0]
 
             # Try to create an integer out of a supplied module name
-            mod_index = (Integer(mod_name) - 1) rescue nil
+            mod_index =
+              begin
+                Integer(mod_name) - 1
+              rescue ArgumentError
+                nil
+              end
 
             # Use a module by search index
             if mod_index

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -394,7 +394,7 @@ module Msf
             # Display the table of matches
             tbl = generate_module_table("Matching Modules", search_term)
             search_params = parse_search_string(match)
-            count = 0
+            count = -1
             begin
               @module_search_results = Msf::Modules::Metadata::Cache.instance.find(search_params)
 
@@ -642,7 +642,7 @@ module Msf
             # Try to create an integer out of a supplied module name
             mod_index =
               begin
-                Integer(mod_name) - 1
+                Integer(mod_name)
               rescue ArgumentError, TypeError
                 nil
               end


### PR DESCRIPTION
I got tired of typing, copying, or tab-completing a module name I wanted to use.

I know we discussed the possibility of tutorials copying an index without context, but I feel like the convenience of this enhancement outweighs that PEBKAC. I've tailored the new help output to be considerate of that.

Thoughts?

```
msf5 > help use
Usage: use <name|term|index>

Interact with a module by name or search term/index.
If a module name is not found, it will be treated as a search term.
An index from the previous search results can be selected if desired.

Examples:
  use exploit/windows/smb/ms17_010_eternalblue

  use eternalblue
  use <name|index>

  search eternalblue
  use <name|index>

msf5 > use eternalblue

Matching Modules
================

   #  Name                                           Disclosure Date  Rank     Check  Description
   -  ----                                           ---------------  ----     -----  -----------
   0  auxiliary/admin/smb/ms17_010_command           2017-03-14       normal   Yes    MS17-010 EternalRomance/EternalSynergy/EternalChampion SMB Remote Windows Command Execution
   1  auxiliary/scanner/smb/smb_ms17_010                              normal   Yes    MS17-010 SMB RCE Detection
   2  exploit/windows/smb/ms17_010_eternalblue       2017-03-14       average  No     MS17-010 EternalBlue SMB Remote Windows Kernel Pool Corruption
   3  exploit/windows/smb/ms17_010_eternalblue_win8  2017-03-14       average  No     MS17-010 EternalBlue SMB Remote Windows Kernel Pool Corruption for Win8+
   4  exploit/windows/smb/ms17_010_psexec            2017-03-14       normal   No     MS17-010 EternalRomance/EternalSynergy/EternalChampion SMB Remote Windows Code Execution


msf5 > use 2
msf5 exploit(windows/smb/ms17_010_eternalblue) >
```

#11652, #11724