### PR TITLE
Display NOCVE reason cleanly in info command output

### DIFF
--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -643,22 +643,14 @@ class ReadableText
 
       cve_collection = mod.references.select { |r| r.ctx_id.match(/^cve$/i) }
       if cve_collection.empty?
-        if mod.notes['NOCVE'].blank?
-          output << "#{indent}CVE: Not available\n"
-        else
-          output << "#{indent}CVE not available: #{mod.notes['NOCVE']}\n"
-        end
+        output << "#{indent}CVE: Not available\n"
       end
 
       mod.references.each do |ref|
         case ref.ctx_id
         when 'CVE', 'cve'
           if !cve_collection.empty? && ref.ctx_val.blank?
-            if mod.notes['NOCVE'].blank?
-              output << "#{indent}CVE: Not available\n"
-            else
-              output << "#{indent}CVE not available: #{mod.notes['NOCVE']}\n"
-            end
+            output << "#{indent}CVE: Not available\n"
           else
             output << indent + ref.to_s + "\n"
           end
@@ -692,8 +684,8 @@ class ReadableText
         output << "Also known as:\n"
         val.each { |aka| output << "#{indent}#{aka}\n" }
       when 'NOCVE'
-        # Handled by dump_references
-        next
+        output << "CVE not available:\n" \
+                  "#{indent}#{val}\n"
       when 'RelatedModules'
         output << "Related modules:\n"
         val.each { |related| output << "#{indent}#{related}\n" }

--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -684,7 +684,7 @@ class ReadableText
         output << "Also known as:\n"
         val.each { |aka| output << "#{indent}#{aka}\n" }
       when 'NOCVE'
-        output << "CVE not available:\n" \
+        output << "CVE not available for the following reason:\n" \
                   "#{indent}#{val}\n"
       when 'RelatedModules'
         output << "Related modules:\n"

--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -643,14 +643,22 @@ class ReadableText
 
       cve_collection = mod.references.select { |r| r.ctx_id.match(/^cve$/i) }
       if cve_collection.empty?
-        output << "#{indent}CVE: Not available\n"
+        if mod.notes['NOCVE'].blank?
+          output << "#{indent}CVE: Not available\n"
+        else
+          output << "#{indent}CVE not available: #{mod.notes['NOCVE']}\n"
+        end
       end
 
       mod.references.each do |ref|
         case ref.ctx_id
         when 'CVE', 'cve'
           if !cve_collection.empty? && ref.ctx_val.blank?
-            output << "#{indent}CVE: Not available\n"
+            if mod.notes['NOCVE'].blank?
+              output << "#{indent}CVE: Not available\n"
+            else
+              output << "#{indent}CVE not available: #{mod.notes['NOCVE']}\n"
+            end
           else
             output << indent + ref.to_s + "\n"
           end
@@ -684,8 +692,8 @@ class ReadableText
         output << "Also known as:\n"
         val.each { |aka| output << "#{indent}#{aka}\n" }
       when 'NOCVE'
-        output << "CVE not available:\n" \
-                  "#{indent}#{val}\n"
+        # Handled by dump_references
+        next
       when 'RelatedModules'
         output << "Related modules:\n"
         val.each { |related| output << "#{indent}#{related}\n" }

--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -641,19 +641,8 @@ class ReadableText
     if (mod.respond_to?(:references) && mod.references && mod.references.length > 0)
       output << "References:\n"
 
-      cve_collection = mod.references.select { |r| r.ctx_id.match(/^cve$/i) }
-      if cve_collection.empty?
-        output << "#{indent}CVE: Not available\n"
-      end
-
       mod.references.each do |ref|
         case ref.ctx_id
-        when 'CVE', 'cve'
-          if !cve_collection.empty? && ref.ctx_val.blank?
-            output << "#{indent}CVE: Not available\n"
-          else
-            output << indent + ref.to_s + "\n"
-          end
         when 'LOGO', 'SOUNDTRACK'
           output << indent + ref.to_s + "\n"
           Rex::Compat.open_browser(ref.ctx_val) if Rex::Compat.getenv('FUEL_THE_HYPE_MACHINE')


### PR DESCRIPTION
Separated from #11785 for landability. For repro, run the `info` command on a module with `NOCVE` set. See the linked PR for context.

**The key takeaway here is that references should be links, not free-form text. That's for notes.**