### PR TITLE
throw exception on actual payload size violation, not formatted output size

### DIFF
--- a/lib/msf/core/payload_generator.rb
+++ b/lib/msf/core/payload_generator.rb
@@ -368,34 +368,34 @@ module Msf
     def generate_payload
       if platform == "java" or arch == "java" or payload.start_with? "java/"
         raw_payload = generate_java_payload
-        cli_print "Payload size: #{raw_payload.length} bytes"
+        encoded_payload = raw_payload
         gen_payload = raw_payload
       elsif payload.start_with? "android/" and not template.blank?
         cli_print "Using APK template: #{template}"
         apk_backdoor = ::Msf::Payload::Apk.new
         raw_payload = apk_backdoor.backdoor_apk(template, generate_raw_payload)
-        cli_print "Payload size: #{raw_payload.length} bytes"
         gen_payload = raw_payload
       else
         raw_payload = generate_raw_payload
         raw_payload = add_shellcode(raw_payload)
 
         if encoder != nil and encoder.start_with?("@")
-          encoded_payload = multiple_encode_payload(raw_payload)
+          raw_payload = multiple_encode_payload(raw_payload)
         else
-          encoded_payload = encode_payload(raw_payload)
+          raw_payload = encode_payload(raw_payload)
         end
         if padnops
-          @nops = nops - encoded_payload.length
+          @nops = nops - raw_payload.length
         end
-        encoded_payload = prepend_nops(encoded_payload)
-        cli_print "Payload size: #{encoded_payload.length} bytes"
-        gen_payload = format_payload(encoded_payload)
+        raw_payload = prepend_nops(raw_payload)
+        gen_payload = format_payload(raw_payload)
       end
+
+      cli_print "Payload size: #{raw_payload.length} bytes"
 
       if gen_payload.nil?
         raise PayloadGeneratorError, 'The payload could not be generated, check options'
-      elsif encoded_payload.length > @space and not @smallest
+      elsif raw_payload.length > @space and not @smallest
         raise PayloadSpaceViolation, 'The payload exceeds the specified space'
       else
         if format.to_s != 'raw'

--- a/lib/msf/core/payload_generator.rb
+++ b/lib/msf/core/payload_generator.rb
@@ -395,7 +395,7 @@ module Msf
 
       if gen_payload.nil?
         raise PayloadGeneratorError, 'The payload could not be generated, check options'
-      elsif gen_payload.length > @space and not @smallest
+      elsif encoded_payload.length > @space and not @smallest
         raise PayloadSpaceViolation, 'The payload exceeds the specified space'
       else
         if format.to_s != 'raw'


### PR DESCRIPTION
If you generate a size-constrained formatted payload with msfvenom, you can get confusing errors like so:

```
$ ./msfvenom -s 57 -p linux/x86/shell_bind_tcp_random_port -f elf -o test.elf
[-] No platform was selected, choosing Msf::Module::Platform::Linux from the payload
[-] No arch selected, selecting arch: x86 from the payload
No encoder or badchars specified, outputting raw payload
Payload size: 57 bytes
Error: The payload exceeds the specified space
```

Here I said I wanted a 57 byte payload, the payload was 57 bytes, and it still failed. What we're looking at is the formatted output, which isn't actually related to payload size. For a more extreme example, look at the 'C' format, which definitely is unrelated.

This changes the failure mode to look at the encoded payload binary rather than the formatted output before throwing a size exception.

```
$ ./msfvenom -s 57 -p linux/x86/shell_bind_tcp_random_port -f elf -o test.elf
[-] No platform was selected, choosing Msf::Module::Platform::Linux from the payload
[-] No arch selected, selecting arch: x86 from the payload
No encoder or badchars specified, outputting raw payload
Payload size: 57 bytes
Final size of elf file: 141 bytes
Saved as: test.elf
```

## Verification

List the steps needed to make sure this thing works

- [ ] Generate payloads with constrained size above with msfvenom, using a format other than 'raw'
- [ ] **Verify** that the payload is generated, and actually fails only if the payload is bigger than specified, not the formatted output.

