### PR TITLE
Handle invalid payloads more clearly

### DIFF
--- a/lib/msf/core/payload_generator.rb
+++ b/lib/msf/core/payload_generator.rb
@@ -158,7 +158,7 @@ module Msf
       # framework.payloads.keys gets pruned of unloadable payloads. So, we do it
       # after checking payload_is_valid?, which refers to the cached keys.
       @payload_module = framework.payloads.create(@payload)
-      raise ArgumentError, "unloadable payload: #{payload}" unless payload_module
+      raise ArgumentError, "unloadable payload: #{payload}" unless payload_module || @payload == 'stdin'
 
       # In smallest mode, override the payload @space & @encoder_space settings
       if @smallest

--- a/lib/msf/core/payload_generator.rb
+++ b/lib/msf/core/payload_generator.rb
@@ -68,6 +68,9 @@ module Msf
     # @!attribute  payload
     #   @return [String] The refname of the payload to generate
     attr_accessor :payload
+    # @!attribute  payload_module
+    #   @return [Module] The payload module object if applicable
+    attr_accessor :payload_module
     # @!attribute  platform
     #   @return [String] The platform to build the payload for
     attr_accessor :platform
@@ -148,8 +151,14 @@ module Msf
 
       @framework  = opts.fetch(:framework)
 
-      raise ArgumentError, "Invalid Payload Selected" unless payload_is_valid?
-      raise ::Msf::Simple::Buffer::BufferFormatError, "Invalid Format Selected" unless format_is_valid?
+      raise InvalidFormat, "invalid format: #{format}"  unless format_is_valid?
+      raise ArgumentError, "invalid payload: #{payload}" unless payload_is_valid?
+
+      # A side-effecto of running framework.payloads.create is that
+      # framework.payloads.keys gets pruned of unloadable payloads. So, we do it
+      # after checking payload_is_valid?, which refers to the cached keys.
+      @payload_module = framework.payloads.create(@payload)
+      raise ArgumentError, "unloadable payload: #{payload}" unless payload_module
 
       # In smallest mode, override the payload @space & @encoder_space settings
       if @smallest
@@ -336,7 +345,6 @@ module Msf
     # produce a JAR or WAR file for the java payload.
     # @return [String] Java payload as a JAR or WAR file
     def generate_java_payload
-      payload_module = framework.payloads.create(payload)
       payload_module.datastore.import_options_from_hash(datastore)
       case format
       when "raw", "jar"
@@ -421,8 +429,6 @@ module Msf
         end
         stdin
       else
-        payload_module = framework.payloads.create(payload)
-
         chosen_platform = choose_platform(payload_module)
         if chosen_platform.platforms.empty?
           raise IncompatiblePlatform, "The selected platform is incompatible with the payload"

--- a/msfvenom
+++ b/msfvenom
@@ -448,7 +448,7 @@ generator_opts[:cli] = true
 begin
   venom_generator = Msf::PayloadGenerator.new(generator_opts)
   payload = venom_generator.generate_payload
-rescue ::Msf::Simple::Buffer::BufferFormatError => e
+rescue Msf::InvalidFormat => e
   $stderr.puts "Error: #{e.message}"
   $stderr.puts dump_formats
 rescue ::Exception => e

--- a/spec/lib/msf/core/payload_generator_spec.rb
+++ b/spec/lib/msf/core/payload_generator_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe Msf::PayloadGenerator do
         }
       }
 
-      it { is_expected.to raise_error(ArgumentError, "Invalid Payload Selected") }
+      it { is_expected.to raise_error(ArgumentError, "invalid payload: ") }
     end
 
     context 'when given an invalid payload' do
@@ -155,7 +155,7 @@ RSpec.describe Msf::PayloadGenerator do
         }
       }
 
-      it { is_expected.to raise_error(ArgumentError, "Invalid Payload Selected") }
+      it { is_expected.to raise_error(ArgumentError, "invalid payload: beos/meterpreter/reverse_gopher") }
     end
 
     context 'when given a payload through stdin' do
@@ -203,7 +203,7 @@ RSpec.describe Msf::PayloadGenerator do
         }
       }
 
-      it { is_expected.to raise_error(ArgumentError, "Invalid Format Selected") }
+      it { is_expected.to raise_error(Msf::InvalidFormat, "invalid format: foobar") }
     end
 
     context 'when given any valid transform format' do


### PR DESCRIPTION
Currently, if you have an error in a payload module (e.g. you have a syntax error in a module), the error is not noticed early enough in the generation process by the parameter validator, leading to a mysterious message like so from msfvenom, due to it failing to instantiate the payload module later in the process:

```
Error: undefined method `platform' for nil:NilClass
```

This change cleans up some of the error handling, checks to see if the payload
module can be instantiated, and gives a more useful error output for the
different cases. This also tweaks some of the literal string outputs to match
other exception strings from payload_generator.

## Verification

- [x] Generate an invalid payload: `./msfvenom -p linux/x86/shell_bind_tcp_random_portal`
- [x] **Verify** you get an error message:
```
$ ./msfvenom -p linux/x86/shell_bind_tcp_random_portal
Error: invalid payload: linux/x86/shell_bind_tcp_random_portal
```
- [x] Modify a payload to have a syntax error (delete an `end` from a block, then try generating it: `./msfvenom -p linux/x86/shell_bind_tcp_random_port`
- [x] **Verify** you get a less-mysterious error message (you still need to look at the logs to see why it was unloadable):
```
$ ./msfvenom -p linux/x86/shell_bind_tcp_random_port
Error: unloadable payload: linux/x86/shell_bind_tcp_random_port
```

