### PR TITLE
moodle_cmd_exec nil check

### DIFF
--- a/modules/exploits/multi/http/moodle_cmd_exec.rb
+++ b/modules/exploits/multi/http/moodle_cmd_exec.rb
@@ -67,6 +67,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, '/index.php')
     })
 
+    fail_with(Failure::Unreachable, 'No response received from the target.') unless init
     sess = init.get_cookies
 
     post = {


### PR DESCRIPTION
Fixes #11832 by adding a check for `nil` before trying to use the variable.

@LauanGuermandi can you give this a run to make sure it solves the problem (exit gracefully instead of crashing).

## Verification

Use the module against a host that doesn't exist or isn't running HTTP.

```
msf5 exploit(multi/http/moodle_cmd_exec) > set rhost 192.168.0.199
rhost => 192.168.0.199
msf5 exploit(multi/http/moodle_cmd_exec) > run

[*] Started reverse TCP double handler on 192.168.1.5:4444 
[-] Exploit failed: NoMethodError undefined method `get_cookies' for nil:NilClass
[*] Exploit completed, but no session was created.
```

After the fix

```
msf5 exploit(multi/http/moodle_cmd_exec) > run

[*] Started reverse TCP double handler on 192.168.1.5:4444 
[-] Exploit aborted due to failure: unreachable: No response received from the target.
[*] Exploit completed, but no session was created.
```