### PR TITLE
Update MSB references to use docs.microsoft.com

### DIFF
--- a/lib/msf/core/module/reference.rb
+++ b/lib/msf/core/module/reference.rb
@@ -102,7 +102,9 @@ class Msf::Module::SiteReference < Msf::Module::Reference
     elsif in_ctx_id == 'BID'
       self.site = "http://www.securityfocus.com/bid/#{in_ctx_val}"
     elsif in_ctx_id == 'MSB'
-      self.site = "https://technet.microsoft.com/en-us/library/security/#{in_ctx_val}"
+      year = in_ctx_val[2..3]
+      century = year[0] == '9' ? '19' : '20'
+      self.site = "https://docs.microsoft.com/en-us/security-updates/SecurityBulletins/#{century}#{year}/#{in_ctx_val}"
     elsif in_ctx_id == 'EDB'
       self.site = "https://www.exploit-db.com/exploits/#{in_ctx_val}"
     elsif in_ctx_id == 'US-CERT-VU'

--- a/modules/auxiliary/dos/windows/ftp/iis_list_exhaustion.rb
+++ b/modules/auxiliary/dos/windows/ftp/iis_list_exhaustion.rb
@@ -32,7 +32,6 @@ class MetasploitModule < Msf::Auxiliary
           [ 'BID', '36273'],
           [ 'OSVDB', '57753'],
           [ 'MSB', 'MS09-053'],
-          [ 'URL', 'https://docs.microsoft.com/en-us/security-updates/SecurityBulletins/2009/ms09-053'],
           [ 'URL', 'http://archives.neohapsis.com/archives/fulldisclosure/2009-09/0040.html']
         ],
       'DisclosureDate' => 'Sep 03 2009'))

--- a/modules/auxiliary/dos/windows/smb/ms09_050_smb2_negotiate_pidhigh.rb
+++ b/modules/auxiliary/dos/windows/smb/ms09_050_smb2_negotiate_pidhigh.rb
@@ -25,8 +25,7 @@ class MetasploitModule < Msf::Auxiliary
           ['BID', '36299'],
           ['OSVDB', '57799'],
           ['MSB', 'MS09-050'],
-          ['URL', 'https://seclists.org/fulldisclosure/2009/Sep/0039.html'],
-          ['URL', 'https://docs.microsoft.com/en-us/security-updates/SecurityBulletins/2009/ms09-050']
+          ['URL', 'https://seclists.org/fulldisclosure/2009/Sep/0039.html']
         ]
     ))
     register_options([

--- a/modules/auxiliary/dos/windows/smb/ms09_050_smb2_negotiate_pidhigh.rb
+++ b/modules/auxiliary/dos/windows/smb/ms09_050_smb2_negotiate_pidhigh.rb
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Auxiliary
           ['OSVDB', '57799'],
           ['MSB', 'MS09-050'],
           ['URL', 'https://seclists.org/fulldisclosure/2009/Sep/0039.html'],
-          ['URL', 'http://www.microsoft.com/technet/security/advisory/975497.mspx']
+          ['URL', 'https://docs.microsoft.com/en-us/security-updates/SecurityBulletins/2009/ms09-050']
         ]
     ))
     register_options([

--- a/modules/exploits/windows/browser/ms06_001_wmf_setabortproc.rb
+++ b/modules/exploits/windows/browser/ms06_001_wmf_setabortproc.rb
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['OSVDB', '21987'],
           ['MSB', 'MS06-001'],
           ['BID', '16074'],
-          ['URL', 'http://www.microsoft.com/technet/security/advisory/912840.mspx'],
+          ['URL', 'https://docs.microsoft.com/en-us/security-updates/securitybulletins/2006/ms06-001'],
           ['URL', 'http://wvware.sourceforge.net/caolan/ora-wmf.html']
         ],
       'DefaultOptions' =>

--- a/modules/exploits/windows/browser/ms06_001_wmf_setabortproc.rb
+++ b/modules/exploits/windows/browser/ms06_001_wmf_setabortproc.rb
@@ -33,7 +33,6 @@ class MetasploitModule < Msf::Exploit::Remote
           ['OSVDB', '21987'],
           ['MSB', 'MS06-001'],
           ['BID', '16074'],
-          ['URL', 'https://docs.microsoft.com/en-us/security-updates/securitybulletins/2006/ms06-001'],
           ['URL', 'http://wvware.sourceforge.net/caolan/ora-wmf.html']
         ],
       'DefaultOptions' =>

--- a/modules/exploits/windows/browser/ms07_017_ani_loadimage_chunksize.rb
+++ b/modules/exploits/windows/browser/ms07_017_ani_loadimage_chunksize.rb
@@ -44,7 +44,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['OSVDB', '33629'],
           ['BID', '23194'],
           ['MSB', 'MS07-017'],
-          ['URL', 'http://www.microsoft.com/technet/security/advisory/935423.mspx']
+          ['URL', 'https://docs.microsoft.com/en-us/security-updates/securitybulletins/2007/ms07-017']
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/browser/ms07_017_ani_loadimage_chunksize.rb
+++ b/modules/exploits/windows/browser/ms07_017_ani_loadimage_chunksize.rb
@@ -43,8 +43,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['CVE', '2007-0038'],
           ['OSVDB', '33629'],
           ['BID', '23194'],
-          ['MSB', 'MS07-017'],
-          ['URL', 'https://docs.microsoft.com/en-us/security-updates/securitybulletins/2007/ms07-017']
+          ['MSB', 'MS07-017']
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/browser/ms08_078_xml_corruption.rb
+++ b/modules/exploits/windows/browser/ms08_078_xml_corruption.rb
@@ -43,8 +43,8 @@ class MetasploitModule < Msf::Exploit::Remote
           ['OSVDB', '50622'],
           ['BID', '32721'],
           ['MSB', 'MS08-078'],
-          ['URL', 'http://www.microsoft.com/technet/security/advisory/961051.mspx'],
-          ['URL', 'http://taossa.com/archive/bh08sotirovdowd.pdf'],
+          ['URL', 'https://docs.microsoft.com/en-us/security-updates/securitybulletins/2008/ms08-078'],
+          ['URL', 'https://web.archive.org/web/20080913064223/http://taossa.com/archive/bh08sotirovdowd.pdf'],
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/browser/ms08_078_xml_corruption.rb
+++ b/modules/exploits/windows/browser/ms08_078_xml_corruption.rb
@@ -43,7 +43,6 @@ class MetasploitModule < Msf::Exploit::Remote
           ['OSVDB', '50622'],
           ['BID', '32721'],
           ['MSB', 'MS08-078'],
-          ['URL', 'https://docs.microsoft.com/en-us/security-updates/securitybulletins/2008/ms08-078'],
           ['URL', 'https://web.archive.org/web/20080913064223/http://taossa.com/archive/bh08sotirovdowd.pdf'],
         ],
       'DefaultOptions' =>

--- a/modules/exploits/windows/browser/ms09_043_owc_msdso.rb
+++ b/modules/exploits/windows/browser/ms09_043_owc_msdso.rb
@@ -25,8 +25,8 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'MSB', 'MS09-043' ],
           [ 'URL', 'http://ahmed.obied.net/software/code/exploits/ie_owc.py' ],
           [ 'EDB', '9163' ],
-          # broken: [ 'URL', 'http://xeye.us/blog/2009/07/one-0day/' ],
-          [ 'URL', 'http://www.microsoft.com/technet/security/advisory/973472.mspx' ],
+          [ 'URL', 'https://web.archive.org/web/20090716143635/http://xeye.us/blog/2009/07/one-0day/' ],
+          [ 'URL', 'https://docs.microsoft.com/en-us/security-updates/securitybulletins/2009/ms09-043' ],
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/browser/ms09_043_owc_msdso.rb
+++ b/modules/exploits/windows/browser/ms09_043_owc_msdso.rb
@@ -25,8 +25,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'MSB', 'MS09-043' ],
           [ 'URL', 'http://ahmed.obied.net/software/code/exploits/ie_owc.py' ],
           [ 'EDB', '9163' ],
-          [ 'URL', 'https://web.archive.org/web/20090716143635/http://xeye.us/blog/2009/07/one-0day/' ],
-          [ 'URL', 'https://docs.microsoft.com/en-us/security-updates/securitybulletins/2009/ms09-043' ],
+          [ 'URL', 'https://web.archive.org/web/20090716143635/http://xeye.us/blog/2009/07/one-0day/' ]
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/browser/ms09_072_style_object.rb
+++ b/modules/exploits/windows/browser/ms09_072_style_object.rb
@@ -40,7 +40,6 @@ class MetasploitModule < Msf::Exploit::Remote
           ['CVE', '2009-3672'],
           ['OSVDB', '50622'],
           ['BID', '37085'],
-          ['URL', 'https://docs.microsoft.com/en-us/security-updates/securitybulletins/2009/ms09-072'],
           ['URL', 'https://web.archive.org/web/20090316061713/http://taossa.com/archive/bh08sotirovdowd.pdf'],
         ],
       'DefaultOptions' =>

--- a/modules/exploits/windows/browser/ms09_072_style_object.rb
+++ b/modules/exploits/windows/browser/ms09_072_style_object.rb
@@ -40,8 +40,8 @@ class MetasploitModule < Msf::Exploit::Remote
           ['CVE', '2009-3672'],
           ['OSVDB', '50622'],
           ['BID', '37085'],
-          ['URL', 'http://www.microsoft.com/technet/security/advisory/977981.mspx'],
-          ['URL', 'http://taossa.com/archive/bh08sotirovdowd.pdf'],
+          ['URL', 'https://docs.microsoft.com/en-us/security-updates/securitybulletins/2009/ms09-072'],
+          ['URL', 'https://web.archive.org/web/20090316061713/http://taossa.com/archive/bh08sotirovdowd.pdf'],
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/browser/ms10_002_aurora.rb
+++ b/modules/exploits/windows/browser/ms10_002_aurora.rb
@@ -42,8 +42,8 @@ class MetasploitModule < Msf::Exploit::Remote
           ['MSB', 'MS10-002'],
           ['CVE', '2010-0249'],
           ['OSVDB', '61697'],
-          ['URL', 'http://www.microsoft.com/technet/security/advisory/979352.mspx'],
-          ['URL', 'http://wepawet.iseclab.org/view.php?hash=1aea206aa64ebeabb07237f1e2230d0f&type=js']
+          ['URL', 'https://docs.microsoft.com/en-us/security-updates/securitybulletins/2010/ms10-002'],
+          ['URL', 'https://web.archive.org/web/20100609073233/http://wepawet.iseclab.org/view.php?hash=1aea206aa64ebeabb07237f1e2230d0f&type=js']
 
         ],
       'DefaultOptions' =>

--- a/modules/exploits/windows/browser/ms10_002_aurora.rb
+++ b/modules/exploits/windows/browser/ms10_002_aurora.rb
@@ -42,7 +42,6 @@ class MetasploitModule < Msf::Exploit::Remote
           ['MSB', 'MS10-002'],
           ['CVE', '2010-0249'],
           ['OSVDB', '61697'],
-          ['URL', 'https://docs.microsoft.com/en-us/security-updates/securitybulletins/2010/ms10-002'],
           ['URL', 'https://web.archive.org/web/20100609073233/http://wepawet.iseclab.org/view.php?hash=1aea206aa64ebeabb07237f1e2230d0f&type=js']
 
         ],

--- a/modules/exploits/windows/browser/ms10_018_ie_behaviors.rb
+++ b/modules/exploits/windows/browser/ms10_018_ie_behaviors.rb
@@ -70,9 +70,9 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'CVE', '2010-0806' ],
           [ 'OSVDB', '62810' ],
           [ 'BID', '38615' ],
-          [ 'URL', 'http://www.microsoft.com/technet/security/advisory/981374.mspx' ],
-          [ 'URL', 'http://www.avertlabs.com/research/blog/index.php/2010/03/09/targeted-internet-explorer-0day-attack-announced-cve-2010-0806/' ],
-          [ 'URL', 'http://eticanicomana.blogspot.com/2010/03/aleatory-persitent-threat.html' ],
+          [ 'URL', 'https://docs.microsoft.com/en-us/security-updates/securitybulletins/2010/ms10-018' ],
+          [ 'URL', 'https://web.archive.org/web/20100929225343/http://www.avertlabs.com/research/blog/index.php/2010/03/09/targeted-internet-explorer-0day-attack-announced-cve-2010-0806/' ],
+          [ 'URL', 'https://web.archive.org/web/20120627174253/http://eticanicomana.blogspot.com/2010/03/aleatory-persitent-threat.html' ],
           [ 'MSB', 'MS10-018' ],
         ],
       'DefaultOptions' =>

--- a/modules/exploits/windows/browser/ms10_018_ie_behaviors.rb
+++ b/modules/exploits/windows/browser/ms10_018_ie_behaviors.rb
@@ -70,7 +70,6 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'CVE', '2010-0806' ],
           [ 'OSVDB', '62810' ],
           [ 'BID', '38615' ],
-          [ 'URL', 'https://docs.microsoft.com/en-us/security-updates/securitybulletins/2010/ms10-018' ],
           [ 'URL', 'https://web.archive.org/web/20100929225343/http://www.avertlabs.com/research/blog/index.php/2010/03/09/targeted-internet-explorer-0day-attack-announced-cve-2010-0806/' ],
           [ 'URL', 'https://web.archive.org/web/20120627174253/http://eticanicomana.blogspot.com/2010/03/aleatory-persitent-threat.html' ],
           [ 'MSB', 'MS10-018' ],

--- a/modules/exploits/windows/browser/ms10_022_ie_vbscript_winhlp32.rb
+++ b/modules/exploits/windows/browser/ms10_022_ie_vbscript_winhlp32.rb
@@ -37,9 +37,9 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'CVE', '2010-0483' ],
           [ 'OSVDB', '62632' ],
           [ 'MSB', 'MS10-023' ],
-          [ 'URL', 'http://www.microsoft.com/technet/security/advisory/981169.mspx' ],
-          [ 'URL', 'http://blogs.technet.com/msrc/archive/2010/02/28/investigating-a-new-win32hlp-and-internet-explorer-issue.aspx' ],
-          [ 'URL', 'http://isec.pl/vulnerabilities/isec-0027-msgbox-helpfile-ie.txt' ]
+          [ 'URL', 'https://docs.microsoft.com/en-us/security-updates/securitybulletins/2010/ms10-023' ],
+          [ 'URL', 'https://blogs.technet.com/msrc/archive/2010/02/28/investigating-a-new-win32hlp-and-internet-explorer-issue.aspx' ],
+          [ 'URL', 'https://isec.pl/vulnerabilities/isec-0027-msgbox-helpfile-ie.txt' ]
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/browser/ms10_022_ie_vbscript_winhlp32.rb
+++ b/modules/exploits/windows/browser/ms10_022_ie_vbscript_winhlp32.rb
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           [ 'CVE', '2010-0483' ],
           [ 'OSVDB', '62632' ],
-          [ 'MSB', 'MS10-023' ],
+          [ 'MSB', 'MS10-022' ],
           [ 'URL', 'https://blogs.technet.com/msrc/archive/2010/02/28/investigating-a-new-win32hlp-and-internet-explorer-issue.aspx' ],
           [ 'URL', 'https://isec.pl/vulnerabilities/isec-0027-msgbox-helpfile-ie.txt' ]
         ],

--- a/modules/exploits/windows/browser/ms10_022_ie_vbscript_winhlp32.rb
+++ b/modules/exploits/windows/browser/ms10_022_ie_vbscript_winhlp32.rb
@@ -37,7 +37,6 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'CVE', '2010-0483' ],
           [ 'OSVDB', '62632' ],
           [ 'MSB', 'MS10-023' ],
-          [ 'URL', 'https://docs.microsoft.com/en-us/security-updates/securitybulletins/2010/ms10-023' ],
           [ 'URL', 'https://blogs.technet.com/msrc/archive/2010/02/28/investigating-a-new-win32hlp-and-internet-explorer-issue.aspx' ],
           [ 'URL', 'https://isec.pl/vulnerabilities/isec-0027-msgbox-helpfile-ie.txt' ]
         ],

--- a/modules/exploits/windows/browser/ms10_042_helpctr_xss_cmd_exec.rb
+++ b/modules/exploits/windows/browser/ms10_042_helpctr_xss_cmd_exec.rb
@@ -44,7 +44,7 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           [ 'CVE', '2010-1885' ],
           [ 'OSVDB', '65264' ],
-          [ 'URL', 'http://www.microsoft.com/technet/security/advisory/2219475.mspx' ],
+          [ 'URL', 'https://docs.microsoft.com/en-us/security-updates/securitybulletins/2010/ms10-042' ],
           [ 'MSB', 'MS10-042']
         ],
       'DefaultOptions' =>

--- a/modules/exploits/windows/browser/ms10_042_helpctr_xss_cmd_exec.rb
+++ b/modules/exploits/windows/browser/ms10_042_helpctr_xss_cmd_exec.rb
@@ -44,7 +44,6 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           [ 'CVE', '2010-1885' ],
           [ 'OSVDB', '65264' ],
-          [ 'URL', 'https://docs.microsoft.com/en-us/security-updates/securitybulletins/2010/ms10-042' ],
           [ 'MSB', 'MS10-042']
         ],
       'DefaultOptions' =>

--- a/modules/exploits/windows/browser/ms10_046_shortcut_icon_dllloader.rb
+++ b/modules/exploits/windows/browser/ms10_046_shortcut_icon_dllloader.rb
@@ -32,8 +32,7 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           ['CVE', '2010-2568'],
           ['OSVDB', '66387'],
-          ['MSB', 'MS10-046'],
-          ['URL', 'https://docs.microsoft.com/en-us/security-updates/securitybulletins/2010/ms10-046']
+          ['MSB', 'MS10-046']
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/browser/ms10_046_shortcut_icon_dllloader.rb
+++ b/modules/exploits/windows/browser/ms10_046_shortcut_icon_dllloader.rb
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['CVE', '2010-2568'],
           ['OSVDB', '66387'],
           ['MSB', 'MS10-046'],
-          ['URL', 'http://www.microsoft.com/technet/security/advisory/2286198.mspx']
+          ['URL', 'https://docs.microsoft.com/en-us/security-updates/securitybulletins/2010/ms10-046']
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/browser/ms10_090_ie_css_clip.rb
+++ b/modules/exploits/windows/browser/ms10_090_ie_css_clip.rb
@@ -54,7 +54,6 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'CVE', '2010-3962' ],
           [ 'OSVDB', '68987' ],
           [ 'BID', '44536' ],
-          [ 'URL', 'https://docs.microsoft.com/en-us/security-updates/securitybulletins/2010/ms10-090' ],
           [ 'EDB', '15421' ],
           [ 'MSB', 'MS10-090' ]
         ],

--- a/modules/exploits/windows/browser/ms10_090_ie_css_clip.rb
+++ b/modules/exploits/windows/browser/ms10_090_ie_css_clip.rb
@@ -54,7 +54,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'CVE', '2010-3962' ],
           [ 'OSVDB', '68987' ],
           [ 'BID', '44536' ],
-          [ 'URL', 'http://www.microsoft.com/technet/security/advisory/2458511.mspx' ],
+          [ 'URL', 'https://docs.microsoft.com/en-us/security-updates/securitybulletins/2010/ms10-090' ],
           [ 'EDB', '15421' ],
           [ 'MSB', 'MS10-090' ]
         ],

--- a/modules/exploits/windows/browser/ms11_003_ie_css_import.rb
+++ b/modules/exploits/windows/browser/ms11_003_ie_css_import.rb
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'CVE', '2010-3971' ],
           [ 'OSVDB', '69796' ],
           [ 'BID', '45246' ],
-          [ 'URL', 'http://www.microsoft.com/technet/security/advisory/2488013.mspx' ],
+          [ 'URL', 'https://docs.microsoft.com/en-us/security-updates/securitybulletins/2011/ms11-003' ],
           [ 'URL', 'http://www.wooyun.org/bugs/wooyun-2010-0885' ],
           [ 'URL', 'https://seclists.org/fulldisclosure/2010/Dec/110' ],
           [ 'MSB', 'MS11-003' ]

--- a/modules/exploits/windows/browser/ms11_003_ie_css_import.rb
+++ b/modules/exploits/windows/browser/ms11_003_ie_css_import.rb
@@ -45,7 +45,6 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'CVE', '2010-3971' ],
           [ 'OSVDB', '69796' ],
           [ 'BID', '45246' ],
-          [ 'URL', 'https://docs.microsoft.com/en-us/security-updates/securitybulletins/2011/ms11-003' ],
           [ 'URL', 'http://www.wooyun.org/bugs/wooyun-2010-0885' ],
           [ 'URL', 'https://seclists.org/fulldisclosure/2010/Dec/110' ],
           [ 'MSB', 'MS11-003' ]

--- a/modules/exploits/windows/browser/msvidctl_mpeg2.rb
+++ b/modules/exploits/windows/browser/msvidctl_mpeg2.rb
@@ -45,7 +45,8 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'BID', '35558' ],
           [ 'MSB', 'MS09-032' ],
           [ 'MSB', 'MS09-037' ],
-          [ 'URL', 'http://www.microsoft.com/technet/security/advisory/972890.mspx' ],
+          [ 'URL', 'https://docs.microsoft.com/en-us/security-updates/securitybulletins/2009/ms09-032' ],
+          [ 'URL', 'https://docs.microsoft.com/en-us/security-updates/securitybulletins/2009/ms09-037' ],
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/browser/msvidctl_mpeg2.rb
+++ b/modules/exploits/windows/browser/msvidctl_mpeg2.rb
@@ -44,9 +44,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'OSVDB', '55651' ],
           [ 'BID', '35558' ],
           [ 'MSB', 'MS09-032' ],
-          [ 'MSB', 'MS09-037' ],
-          [ 'URL', 'https://docs.microsoft.com/en-us/security-updates/securitybulletins/2009/ms09-032' ],
-          [ 'URL', 'https://docs.microsoft.com/en-us/security-updates/securitybulletins/2009/ms09-037' ],
+          [ 'MSB', 'MS09-037' ]
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/dcerpc/ms07_029_msdns_zonename.rb
+++ b/modules/exploits/windows/dcerpc/ms07_029_msdns_zonename.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['CVE', '2007-1748'],
           ['OSVDB', '34100'],
           ['MSB', 'MS07-029'],
-          ['URL', 'http://www.microsoft.com/technet/security/advisory/935964.mspx']
+          ['URL', 'https://docs.microsoft.com/en-us/security-updates/securitybulletins/2007/ms07-029']
         ],
       'Privileged'     => true,
       'DefaultOptions' =>

--- a/modules/exploits/windows/dcerpc/ms07_029_msdns_zonename.rb
+++ b/modules/exploits/windows/dcerpc/ms07_029_msdns_zonename.rb
@@ -28,8 +28,7 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           ['CVE', '2007-1748'],
           ['OSVDB', '34100'],
-          ['MSB', 'MS07-029'],
-          ['URL', 'https://docs.microsoft.com/en-us/security-updates/securitybulletins/2007/ms07-029']
+          ['MSB', 'MS07-029']
         ],
       'Privileged'     => true,
       'DefaultOptions' =>

--- a/modules/exploits/windows/email/ms07_017_ani_loadimage_chunksize.rb
+++ b/modules/exploits/windows/email/ms07_017_ani_loadimage_chunksize.rb
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['CVE', '2007-1765'],
           ['OSVDB', '33629'],
           ['BID', '23194'],
-          ['URL', 'http://www.microsoft.com/technet/security/advisory/935423.mspx']
+          ['URL', 'https://docs.microsoft.com/en-us/security-updates/SecurityBulletins/2007/ms07-017']
         ],
       'Stance'         => Msf::Exploit::Stance::Passive,
       'DefaultOptions' =>

--- a/modules/exploits/windows/email/ms07_017_ani_loadimage_chunksize.rb
+++ b/modules/exploits/windows/email/ms07_017_ani_loadimage_chunksize.rb
@@ -35,8 +35,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['CVE', '2007-0038'],
           ['CVE', '2007-1765'],
           ['OSVDB', '33629'],
-          ['BID', '23194'],
-          ['URL', 'https://docs.microsoft.com/en-us/security-updates/SecurityBulletins/2007/ms07-017']
+          ['BID', '23194']
         ],
       'Stance'         => Msf::Exploit::Stance::Passive,
       'DefaultOptions' =>

--- a/modules/exploits/windows/fileformat/ms11_006_createsizeddibsection.rb
+++ b/modules/exploits/windows/fileformat/ms11_006_createsizeddibsection.rb
@@ -37,7 +37,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'OSVDB', '70263' ],
           [ 'MSB', 'MS11-006' ],
           [ 'BID', '45662' ],
-          [ 'URL', 'http://www.microsoft.com/technet/security/advisory/2490606.mspx' ]
+          [ 'URL', 'https://docs.microsoft.com/en-us/security-updates/SecurityBulletins/2011/ms11-006' ]
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/fileformat/ms11_006_createsizeddibsection.rb
+++ b/modules/exploits/windows/fileformat/ms11_006_createsizeddibsection.rb
@@ -36,8 +36,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'CVE', '2010-3970' ],
           [ 'OSVDB', '70263' ],
           [ 'MSB', 'MS11-006' ],
-          [ 'BID', '45662' ],
-          [ 'URL', 'https://docs.microsoft.com/en-us/security-updates/SecurityBulletins/2011/ms11-006' ]
+          [ 'BID', '45662' ]
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/smb/ms07_029_msdns_zonename.rb
+++ b/modules/exploits/windows/smb/ms07_029_msdns_zonename.rb
@@ -32,8 +32,7 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           ['CVE', '2007-1748'],
           ['OSVDB', '34100'],
-          ['MSB', 'MS07-029'],
-          ['URL', 'https://docs.microsoft.com/en-us/security-updates/securitybulletins/2007/ms07-029']
+          ['MSB', 'MS07-029']
         ],
       'Privileged'     => true,
       'DefaultOptions' =>

--- a/modules/exploits/windows/smb/ms07_029_msdns_zonename.rb
+++ b/modules/exploits/windows/smb/ms07_029_msdns_zonename.rb
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['CVE', '2007-1748'],
           ['OSVDB', '34100'],
           ['MSB', 'MS07-029'],
-          ['URL', 'http://www.microsoft.com/technet/security/advisory/935964.mspx']
+          ['URL', 'https://docs.microsoft.com/en-us/security-updates/securitybulletins/2007/ms07-029']
         ],
       'Privileged'     => true,
       'DefaultOptions' =>

--- a/modules/exploits/windows/smb/ms09_050_smb2_negotiate_func_index.rb
+++ b/modules/exploits/windows/smb/ms09_050_smb2_negotiate_func_index.rb
@@ -27,8 +27,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'CVE', '2009-3103' ],
           [ 'BID', '36299' ],
           [ 'OSVDB', '57799' ],
-          [ 'URL', 'https://seclists.org/fulldisclosure/2009/Sep/0039.html' ],
-          [ 'URL', 'https://docs.microsoft.com/en-us/security-updates/securitybulletins/2009/ms09-050' ]
+          [ 'URL', 'https://seclists.org/fulldisclosure/2009/Sep/0039.html' ]
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/smb/ms09_050_smb2_negotiate_func_index.rb
+++ b/modules/exploits/windows/smb/ms09_050_smb2_negotiate_func_index.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'BID', '36299' ],
           [ 'OSVDB', '57799' ],
           [ 'URL', 'https://seclists.org/fulldisclosure/2009/Sep/0039.html' ],
-          [ 'URL', 'http://www.microsoft.com/technet/security/Bulletin/MS09-050.mspx' ]
+          [ 'URL', 'https://docs.microsoft.com/en-us/security-updates/securitybulletins/2009/ms09-050' ]
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/smb/ms10_046_shortcut_icon_dllloader.rb
+++ b/modules/exploits/windows/smb/ms10_046_shortcut_icon_dllloader.rb
@@ -32,7 +32,6 @@ class MetasploitModule < Msf::Exploit::Remote
           ['CVE', '2010-2568'],
           ['OSVDB', '66387'],
           ['MSB', 'MS10-046'],
-          ['URL', 'https://docs.microsoft.com/en-us/security-updates/securitybulletins/2010/ms10-046'],
           ['URL', 'https://github.com/rapid7/metasploit-framework/pull/4911'] # How to guide here
         ],
       'DefaultOptions' =>

--- a/modules/exploits/windows/smb/ms10_046_shortcut_icon_dllloader.rb
+++ b/modules/exploits/windows/smb/ms10_046_shortcut_icon_dllloader.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['CVE', '2010-2568'],
           ['OSVDB', '66387'],
           ['MSB', 'MS10-046'],
-          ['URL', 'http://www.microsoft.com/technet/security/advisory/2286198.mspx'],
+          ['URL', 'https://docs.microsoft.com/en-us/security-updates/securitybulletins/2010/ms10-046'],
           ['URL', 'https://github.com/rapid7/metasploit-framework/pull/4911'] # How to guide here
         ],
       'DefaultOptions' =>


### PR DESCRIPTION
new pull request for : fix broken links #11836
> This commit fix broken links mostly to Microsoft website.
> I also used Internet Archive for some disappeared website.


Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

Please ensure you are submitting **from a unique branch** in your [repository](https://github.com/rapid7/metasploit-framework/pull/11086#issuecomment-445506416) to master in Rapid7's.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/windows/smb/ms08_067_netapi`
- [ ] ...
- [ ] **Verify** the thing does what it should
- [ ] **Verify** the thing does not do what it should not
- [ ] **Document** the thing and how it works ([Example](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/post/multi/gather/aws_keys.md))

