### PR TITLE
smb client pipe_auditor module now preprends missing backslash to pip…

### DIFF
--- a/lib/msf/core/exploit/smb/client/pipe_auditor.rb
+++ b/lib/msf/core/exploit/smb/client/pipe_auditor.rb
@@ -40,6 +40,9 @@ module Exploit::Remote::SMB::Client::PipeAuditor
     named_pipes.each do |pipe|
       begin
         pipe_name   = pipe.strip
+        if !pipe_name.match(/^\\.*$/)
+            pipe_name = "\\#{pipe_name}"
+        end
         pipe_handle = self.simple.create_pipe(pipe_name, 'o')
 
         # If we make it this far, it succeeded


### PR DESCRIPTION
The named_pipes.txt wordlist provided by the metasploit framework contains pipe names that are not prefixed with a backslash. The 'auxiliary/scanner/smb/pipe_auditor' module does not work properly unless each pipe name is prefixed with a backslash. I updated 'lib/exploit/smb/client/pipe_auditor.rb' to check for the missing backslash and to prepend it if missing.

Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

Please ensure you are submitting **from a unique branch** in your [repository](https://github.com/rapid7/metasploit-framework/pull/11086#issuecomment-445506416) to master in Rapid7's.

## Verifications

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/smb/pipe_auditor`
- [x] **Verify** the thing does what it should
     Running with default named_pipes.txt does not work without fix and does with fix
- [x] **Document** (nothing to document or no existing documents to add to)

Fixes #9618.