### PR TITLE
Indent ternary statement in struts2_rest_xstream

### DIFF
--- a/modules/exploits/multi/http/struts2_rest_xstream.rb
+++ b/modules/exploits/multi/http/struts2_rest_xstream.rb
@@ -100,7 +100,7 @@ class MetasploitModule < Msf::Exploit::Remote
       when :psh_memory
         opts = {remove_comspec: true, encode_final_payload: true}
         payload ? cmd_psh_payload(cmd, payload.arch, opts).split :
-        %W{powershell.exe -c #{cmd}}
+                  %W{powershell.exe -c #{cmd}}
       when :win_memory, :win_dropper
         %W{cmd.exe /c #{cmd}}
       end


### PR DESCRIPTION
What it says on the tin.

Fixes #10543.