### PR TITLE
Pipe auditing mixin now ensures named pipes start with a backslash

### DIFF
--- a/lib/msf/core/exploit/smb/client/pipe_auditor.rb
+++ b/lib/msf/core/exploit/smb/client/pipe_auditor.rb
@@ -41,7 +41,9 @@ module Exploit::Remote::SMB::Client::PipeAuditor
       begin
         pipe_name = pipe.strip
 
-        # Samba 3.x appears to require a prefixed backslash
+        # Samba 3.x requires a prefixed backslash
+        # Sambe 4.x normalizes away backslashes
+        # Windows: honey badger don't care
         unless pipe_name.start_with?('\\')
           pipe_name = "\\#{pipe_name}"
         end

--- a/lib/msf/core/exploit/smb/client/pipe_auditor.rb
+++ b/lib/msf/core/exploit/smb/client/pipe_auditor.rb
@@ -40,7 +40,7 @@ module Exploit::Remote::SMB::Client::PipeAuditor
     named_pipes.each do |pipe|
       begin
         pipe_name   = pipe.strip
-        if !pipe_name.match(/^\\.*$/)
+        unless pipe_name.start_with?("\\")
             pipe_name = "\\#{pipe_name}"
         end
         pipe_handle = self.simple.create_pipe(pipe_name, 'o')

--- a/lib/msf/core/exploit/smb/client/pipe_auditor.rb
+++ b/lib/msf/core/exploit/smb/client/pipe_auditor.rb
@@ -40,6 +40,9 @@ module Exploit::Remote::SMB::Client::PipeAuditor
     named_pipes.each do |pipe|
       begin
         pipe_name   = pipe.strip
+        if !pipe_name.match(/^\\.*$/)
+            pipe_name = "\\#{pipe_name}"
+        end
         pipe_handle = self.simple.create_pipe(pipe_name, 'o')
 
         # If we make it this far, it succeeded

--- a/lib/msf/core/exploit/smb/client/pipe_auditor.rb
+++ b/lib/msf/core/exploit/smb/client/pipe_auditor.rb
@@ -41,6 +41,7 @@ module Exploit::Remote::SMB::Client::PipeAuditor
       begin
         pipe_name = pipe.strip
 
+        # Ensure pipe name starts with a backslash
         unless pipe_name.start_with?('\\')
           pipe_name = "\\#{pipe_name}"
         end

--- a/lib/msf/core/exploit/smb/client/pipe_auditor.rb
+++ b/lib/msf/core/exploit/smb/client/pipe_auditor.rb
@@ -41,7 +41,7 @@ module Exploit::Remote::SMB::Client::PipeAuditor
       begin
         pipe_name = pipe.strip
 
-        # Ensure pipe name starts with a backslash
+        # Samba 3.x appears to require a prefixed backslash
         unless pipe_name.start_with?('\\')
           pipe_name = "\\#{pipe_name}"
         end

--- a/lib/msf/core/exploit/smb/client/pipe_auditor.rb
+++ b/lib/msf/core/exploit/smb/client/pipe_auditor.rb
@@ -39,12 +39,12 @@ module Exploit::Remote::SMB::Client::PipeAuditor
 
     named_pipes.each do |pipe|
       begin
-        pipe_name   = pipe.strip
-        
-        unless pipe_name.start_with?("\\")
+        pipe_name = pipe.strip
+
+        unless pipe_name.start_with?('\\')
           pipe_name = "\\#{pipe_name}"
         end
-        
+
         pipe_handle = self.simple.create_pipe(pipe_name, 'o')
 
         # If we make it this far, it succeeded

--- a/lib/msf/core/exploit/smb/client/pipe_auditor.rb
+++ b/lib/msf/core/exploit/smb/client/pipe_auditor.rb
@@ -40,9 +40,11 @@ module Exploit::Remote::SMB::Client::PipeAuditor
     named_pipes.each do |pipe|
       begin
         pipe_name   = pipe.strip
+        
         unless pipe_name.start_with?("\\")
-            pipe_name = "\\#{pipe_name}"
+          pipe_name = "\\#{pipe_name}"
         end
+        
         pipe_handle = self.simple.create_pipe(pipe_name, 'o')
 
         # If we make it this far, it succeeded

--- a/modules/auxiliary/scanner/smb/pipe_auditor.rb
+++ b/modules/auxiliary/scanner/smb/pipe_auditor.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Auxiliary
   # Fingerprint a single host
   def run_host(ip)
 
-    pass = []
+    pipes = []
 
     [[139, false], [445, true]].each do |info|
 
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Auxiliary
       connect()
       smb_login()
       check_named_pipes.each do |pipe_name, _|
-        pass.push(pipe_name)
+        pipes.push(pipe_name)
       end
 
       disconnect()
@@ -51,8 +51,8 @@ class MetasploitModule < Msf::Auxiliary
     end
     end
 
-    if(pass.length > 0)
-      print_good("Pipes: #{pass.map{|c| "\\#{c}"}.join(", ")}")
+    if(pipes.length > 0)
+      print_good("Pipes: #{pipes.join(", ")}")
       # Add Report
       report_note(
         :host	=> ip,
@@ -60,7 +60,7 @@ class MetasploitModule < Msf::Auxiliary
         :sname	=> 'smb',
         :port	=> rport,
         :type	=> 'Pipes Found',
-        :data	=> "Pipes: #{pass.map{|c| "\\#{c}"}.join(", ")}"
+        :data	=> "Pipes: #{pipes.join(", ")}"
       )
     end
   end


### PR DESCRIPTION
The `named_pipes.txt` wordlist provided by the metasploit framework contains pipe names that are not prefixed with a backslash. The `auxiliary/scanner/smb/pipe_auditor` module does not seem to work properly for some Samba protocol versions (namely protocol 3) unless each pipe name is prefixed with a backslash. I updated `lib/exploit/smb/client/pipe_auditor.rb` to check for the missing backslash and to prepend it if missing.

## Verifications

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/smb/pipe_auditor`
- [x] **Verify** the thing does what it should
     Running with default named_pipes.txt does not work without fix and does with fix
- [x] **Document** (nothing to document or no existing documents to add to)

Fixes #9618 and fixes #11870.