### PR TITLE
Fix disclosure date for WebDAV module

### DIFF
--- a/modules/exploits/windows/iis/iis_webdav_upload_asp.rb
+++ b/modules/exploits/windows/iis/iis_webdav_upload_asp.rb
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'Automatic', { } ],
         ],
       'DefaultTarget'  => 0,
-      'DisclosureDate' => 'Jan 01 1994'
+      'DisclosureDate' => 'Dec 31 2004'
     )
 
     register_options(


### PR DESCRIPTION
The disclosure date for this module claimed to be in 1994, which made it one of the oldest vulnerabilities exercised by Metasploit. However, this seems unlikely, for two reasons:

* The SecurityFocus [BID 12141](https://www.securityfocus.com/bid/12141/info) claims the vulnerability was first published on Dec 31, 2004. This seems to be the only reliable reference for this vulnerability.
* The WebDAV specification itself wasn't described until 1999, in [RFC 2518](https://tools.ietf.org/html/rfc2518).

## Verification

- [ ] Start `msfconsole`
- [ ] `info exploit/windows/iis/iis_webdav_upload_asp`
- [ ] **Verify** date disclosure date is in 2004, not 1994.
