### PR TITLE
Add mixin to implement an exploit's check method by invoking a scanner

### DIFF
--- a/lib/msf/core/exploit/check_scanner.rb
+++ b/lib/msf/core/exploit/check_scanner.rb
@@ -42,8 +42,17 @@ module Exploit::Remote::CheckScanner
     # Use the exploit's input and output as the scanner's
     mod.user_input, mod.user_output = user_input, user_output
 
-    # Use the scanner's CheckCode (this must be precise!)
-    mod.run_host(rhost)
+    # Use the scanner's CheckCode
+    checkcode = mod.run_host(rhost)
+
+    # Bail if scanner doesn't return a CheckCode
+    unless Exploit::CheckCode::Codes.value?(checkcode)
+      print_error("#{scanner} does not return a CheckCode")
+      return Exploit::CheckCode::Unsupported
+    end
+
+    # Return the CheckCode
+    checkcode
   end
 
   def scanner

--- a/lib/msf/core/exploit/check_scanner.rb
+++ b/lib/msf/core/exploit/check_scanner.rb
@@ -1,0 +1,54 @@
+# -*- coding: binary -*-
+
+#
+# This mixin implements an exploit's check method by invoking a scanner
+#
+# NOTE: The scanner's run_host method MUST return an Msf::Exploit::CheckCode
+#
+
+module Msf
+module Exploit::Remote::CheckScanner
+
+  def initialize(info = {})
+    super
+
+    register_advanced_options([
+      OptString.new('CheckScanner', [true, 'Scanner to check with'])
+    ])
+  end
+
+  # When this mixin is included, this method becomes the exploit's check method
+  #
+  # @return [Msf::Exploit::CheckCode] Whether or not the target is vulnerable
+  def check
+    # Instantiate the scanner
+    mod = framework.modules.create(scanner)
+
+    # Bail if we couldn't
+    unless mod
+      print_error("Could not instantiate #{scanner}")
+      return CheckCode::Unsupported
+    end
+
+    # Bail if run_host isn't defined
+    unless mod.respond_to?(:run_host)
+      print_error("#{scanner} does not define a run_host method")
+      return CheckCode::Unsupported
+    end
+
+    # Merge the exploit's datastore into the scanner's
+    mod.datastore.merge!(datastore)
+
+    # Use the exploit's input and output as the scanner's
+    mod.user_input, mod.user_output = user_input, user_output
+
+    # Use the scanner's CheckCode (this must be precise!)
+    mod.run_host(rhost)
+  end
+
+  def scanner
+    datastore['CheckScanner']
+  end
+
+end
+end

--- a/lib/msf/core/exploit/mixins.rb
+++ b/lib/msf/core/exploit/mixins.rb
@@ -7,6 +7,7 @@
 require 'msf/core/exploit/brute'
 require 'msf/core/exploit/brutetargets'
 require 'msf/core/exploit/browser_autopwn'
+require 'msf/core/exploit/check_scanner'
 
 # Payload
 require 'msf/core/exploit/egghunter'

--- a/modules/auxiliary/admin/smb/ms17_010_command.rb
+++ b/modules/auxiliary/admin/smb/ms17_010_command.rb
@@ -67,7 +67,6 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run_host(ip)
-
     begin
       if datastore['SMBUser'].present?
         print_status("Authenticating to #{ip} as user '#{splitname(datastore['SMBUser'])}'...")

--- a/modules/auxiliary/scanner/smb/smb_ms17_010.rb
+++ b/modules/auxiliary/scanner/smb/smb_ms17_010.rb
@@ -75,6 +75,8 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run_host(ip)
+    checkcode = Exploit::CheckCode::Unknown
+
     begin
       ipc_share = "\\\\#{ip}\\IPC$"
 
@@ -98,7 +100,7 @@ class MetasploitModule < Msf::Auxiliary
 
         print_good("Host is likely VULNERABLE to MS17-010! - #{os}")
 
-        vulnerable = true
+        checkcode = Exploit::CheckCode::Vulnerable
 
         report_vuln(
           host: ip,
@@ -158,7 +160,7 @@ class MetasploitModule < Msf::Auxiliary
       disconnect
     end
 
-    vulnerable
+    checkcode
   end
 
   def do_smb_setup_tree(ipc_share)

--- a/modules/auxiliary/scanner/smb/smb_ms17_010.rb
+++ b/modules/auxiliary/scanner/smb/smb_ms17_010.rb
@@ -97,6 +97,9 @@ class MetasploitModule < Msf::Auxiliary
         end
 
         print_good("Host is likely VULNERABLE to MS17-010! - #{os}")
+
+        vulnerable = true
+
         report_vuln(
           host: ip,
           name: self.name,
@@ -154,6 +157,8 @@ class MetasploitModule < Msf::Auxiliary
     ensure
       disconnect
     end
+
+    vulnerable
   end
 
   def do_smb_setup_tree(ipc_share)

--- a/modules/exploits/windows/smb/ms17_010_eternalblue.rb
+++ b/modules/exploits/windows/smb/ms17_010_eternalblue.rb
@@ -144,11 +144,8 @@ class MetasploitModule < Msf::Exploit::Remote
     # Use the exploit's input and output as the scanner's
     mod.user_input, mod.user_output = user_input, user_output
 
-    # If the scanner returned true, return vulnerable
-    return CheckCode::Vulnerable if mod.run_host(rhost)
-
-    # We have no idea what happened...
-    CheckCode::Unknown
+    # Use the scanner's CheckCode (this must be precise!)
+    mod.run_host(rhost)
   end
 
   def exploit

--- a/modules/exploits/windows/smb/ms17_010_eternalblue.rb
+++ b/modules/exploits/windows/smb/ms17_010_eternalblue.rb
@@ -121,7 +121,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   # XXX: This is ghetto af, so someone please make this code more generic!
   def check
-    # Instantiate the check module
+    # Instantiate the check scanner
     mod = framework.modules.create(CHECK_SCANNER)
 
     # Bail if we couldn't

--- a/modules/exploits/windows/smb/ms17_010_eternalblue.rb
+++ b/modules/exploits/windows/smb/ms17_010_eternalblue.rb
@@ -116,7 +116,16 @@ class MetasploitModule < Msf::Exploit::Remote
   class EternalBlueError < StandardError
   end
 
-  # todo: create MS17-010 mixin, and hook up auxiliary/scanner/smb/smb_ms17_010
+  # XXX: This is ghetto af, so someone please create a mixin!
+  def check
+    mod = framework.modules.create('auxiliary/scanner/smb/smb_ms17_010')
+    mod.datastore.merge!(datastore)
+    mod.user_input, mod.user_output = user_input, user_output
+
+    return CheckCode::Vulnerable if mod.run_host(rhost)
+
+    CheckCode::Unknown
+  end
 
   def exploit
     begin

--- a/modules/exploits/windows/smb/ms17_010_eternalblue.rb
+++ b/modules/exploits/windows/smb/ms17_010_eternalblue.rb
@@ -10,6 +10,8 @@ require 'windows_error'
 class MetasploitModule < Msf::Exploit::Remote
   Rank = AverageRanking
 
+  CHECK_MODULE = 'auxiliary/scanner/smb/smb_ms17_010'
+
   include Msf::Exploit::Remote::DCERPC
 
   def initialize(info = {})
@@ -118,7 +120,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
   # XXX: This is ghetto af, so someone please create a mixin!
   def check
-    mod = framework.modules.create('auxiliary/scanner/smb/smb_ms17_010')
+    mod = framework.modules.create(CHECK_MODULE)
+
+    unless mod
+      print_error("Could not instantiate #{CHECK_MODULE}")
+      return CheckCode::Unsupported
+    end
+
     mod.datastore.merge!(datastore)
     mod.user_input, mod.user_output = user_input, user_output
 

--- a/modules/exploits/windows/smb/ms17_010_eternalblue.rb
+++ b/modules/exploits/windows/smb/ms17_010_eternalblue.rb
@@ -10,7 +10,7 @@ require 'windows_error'
 class MetasploitModule < Msf::Exploit::Remote
   Rank = AverageRanking
 
-  CHECK_MODULE = 'auxiliary/scanner/smb/smb_ms17_010'
+  CHECK_SCANNER = 'auxiliary/scanner/smb/smb_ms17_010'
 
   include Msf::Exploit::Remote::DCERPC
 
@@ -122,17 +122,17 @@ class MetasploitModule < Msf::Exploit::Remote
   # XXX: This is ghetto af, so someone please make this code more generic!
   def check
     # Instantiate the check module
-    mod = framework.modules.create(CHECK_MODULE)
+    mod = framework.modules.create(CHECK_SCANNER)
 
     # Bail if we couldn't
     unless mod
-      print_error("Could not instantiate #{CHECK_MODULE}")
+      print_error("Could not instantiate #{CHECK_SCANNER}")
       return CheckCode::Unsupported
     end
 
     # Bail if it's not a scanner
     unless mod.respond_to?(:run_host)
-      print_error("#{CHECK_MODULE} does not appear to be a scanner")
+      print_error("#{CHECK_SCANNER} does not appear to be a scanner")
       return CheckCode::Unsupported
     end
 

--- a/modules/exploits/windows/smb/ms17_010_eternalblue.rb
+++ b/modules/exploits/windows/smb/ms17_010_eternalblue.rb
@@ -121,18 +121,25 @@ class MetasploitModule < Msf::Exploit::Remote
 
   # XXX: This is ghetto af, so someone please make this code more generic!
   def check
+    # Instantiate the check module
     mod = framework.modules.create(CHECK_MODULE)
 
+    # Bail if we couldn't
     unless mod
       print_error("Could not instantiate #{CHECK_MODULE}")
       return CheckCode::Unsupported
     end
 
+    # Merge the exploit's datastore into the scanner's
     mod.datastore.merge!(datastore)
+
+    # Use the exploit's input and output as the scanner's
     mod.user_input, mod.user_output = user_input, user_output
 
+    # If the scanner returned true, return vulnerable
     return CheckCode::Vulnerable if mod.run_host(rhost)
 
+    # We have no idea what happened...
     CheckCode::Unknown
   end
 

--- a/modules/exploits/windows/smb/ms17_010_eternalblue.rb
+++ b/modules/exploits/windows/smb/ms17_010_eternalblue.rb
@@ -10,8 +10,6 @@ require 'windows_error'
 class MetasploitModule < Msf::Exploit::Remote
   Rank = AverageRanking
 
-  CHECK_SCANNER = 'auxiliary/scanner/smb/smb_ms17_010'
-
   include Msf::Exploit::Remote::DCERPC
 
   def initialize(info = {})
@@ -106,6 +104,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
     register_advanced_options(
       [
+        OptString.new('CheckScanner', [true, 'Scanner to check with', 'auxiliary/scanner/smb/smb_ms17_010']),
         OptBool.new('ForceExploit', [false, 'Override check result', false]),
         OptString.new('ProcessName', [true, 'Process to inject payload into.', 'spoolsv.exe']),
         OptInt.new('MaxExploitAttempts', [true, "The number of times to retry the exploit.", 3]),
@@ -121,18 +120,21 @@ class MetasploitModule < Msf::Exploit::Remote
 
   # XXX: This is ghetto af, so someone please make this code more generic!
   def check
-    # Instantiate the check scanner
-    mod = framework.modules.create(CHECK_SCANNER)
+    # Prescribe the check scanner
+    scanner = datastore['CheckScanner']
+
+    # Instantiate the scanner
+    mod = framework.modules.create(scanner)
 
     # Bail if we couldn't
     unless mod
-      print_error("Could not instantiate #{CHECK_SCANNER}")
+      print_error("Could not instantiate #{scanner}")
       return CheckCode::Unsupported
     end
 
     # Bail if it's not a scanner
     unless mod.respond_to?(:run_host)
-      print_error("#{CHECK_SCANNER} does not appear to be a scanner")
+      print_error("#{scanner} does not appear to be a scanner")
       return CheckCode::Unsupported
     end
 

--- a/modules/exploits/windows/smb/ms17_010_eternalblue.rb
+++ b/modules/exploits/windows/smb/ms17_010_eternalblue.rb
@@ -119,7 +119,7 @@ class MetasploitModule < Msf::Exploit::Remote
   class EternalBlueError < StandardError
   end
 
-  # XXX: This is ghetto af, so someone please create a mixin!
+  # XXX: This is ghetto af, so someone please make this code more generic!
   def check
     mod = framework.modules.create(CHECK_MODULE)
 

--- a/modules/exploits/windows/smb/ms17_010_eternalblue.rb
+++ b/modules/exploits/windows/smb/ms17_010_eternalblue.rb
@@ -130,6 +130,11 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Unsupported
     end
 
+    unless mod.respond_to?(:run_host)
+      print_error("#{CHECK_MODULE} does not appear to be a scanner")
+      return CheckCode::Unsupported
+    end
+
     # Merge the exploit's datastore into the scanner's
     mod.datastore.merge!(datastore)
 

--- a/modules/exploits/windows/smb/ms17_010_eternalblue.rb
+++ b/modules/exploits/windows/smb/ms17_010_eternalblue.rb
@@ -106,6 +106,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
     register_advanced_options(
       [
+        OptBool.new('ForceExploit', [false, 'Override check result', false]),
         OptString.new('ProcessName', [true, 'Process to inject payload into.', 'spoolsv.exe']),
         OptInt.new('MaxExploitAttempts', [true, "The number of times to retry the exploit.", 3]),
         OptInt.new('GroomAllocations', [true, "Initial number of times to groom the kernel pool.", 12]),
@@ -136,6 +137,10 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
+    unless check == CheckCode::Vulnerable || datastore['ForceExploit']
+      fail_with(Failure::NotVulnerable, 'Set ForceExploit to override')
+    end
+
     begin
       for i in 1..datastore['MaxExploitAttempts']
         grooms = datastore['GroomAllocations'] + datastore['GroomDelta'] * (i - 1)

--- a/modules/exploits/windows/smb/ms17_010_eternalblue.rb
+++ b/modules/exploits/windows/smb/ms17_010_eternalblue.rb
@@ -11,6 +11,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = AverageRanking
 
   include Msf::Exploit::Remote::DCERPC
+  include Msf::Exploit::Remote::CheckScanner
 
   def initialize(info = {})
     super(update_info(info,
@@ -60,7 +61,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'thread',
-          'WfsDelay' => 5
+          'WfsDelay' => 5,
+          'CheckScanner' => 'auxiliary/scanner/smb/smb_ms17_010'
         },
       'Privileged'     => true,
       'Payload'        =>
@@ -104,7 +106,6 @@ class MetasploitModule < Msf::Exploit::Remote
     )
     register_advanced_options(
       [
-        OptString.new('CheckScanner', [true, 'Scanner to check with', 'auxiliary/scanner/smb/smb_ms17_010']),
         OptBool.new('ForceExploit', [false, 'Override check result', false]),
         OptString.new('ProcessName', [true, 'Process to inject payload into.', 'spoolsv.exe']),
         OptInt.new('MaxExploitAttempts', [true, "The number of times to retry the exploit.", 3]),
@@ -118,35 +119,7 @@ class MetasploitModule < Msf::Exploit::Remote
   class EternalBlueError < StandardError
   end
 
-  # XXX: This is ghetto af, so someone please make this code more generic!
-  def check
-    # Prescribe the check scanner
-    scanner = datastore['CheckScanner']
-
-    # Instantiate the scanner
-    mod = framework.modules.create(scanner)
-
-    # Bail if we couldn't
-    unless mod
-      print_error("Could not instantiate #{scanner}")
-      return CheckCode::Unsupported
-    end
-
-    # Bail if it's not a scanner
-    unless mod.respond_to?(:run_host)
-      print_error("#{scanner} does not appear to be a scanner")
-      return CheckCode::Unsupported
-    end
-
-    # Merge the exploit's datastore into the scanner's
-    mod.datastore.merge!(datastore)
-
-    # Use the exploit's input and output as the scanner's
-    mod.user_input, mod.user_output = user_input, user_output
-
-    # Use the scanner's CheckCode (this must be precise!)
-    mod.run_host(rhost)
-  end
+  # check is pulled in from Msf::Exploit::Remote::CheckScanner
 
   def exploit
     unless check == CheckCode::Vulnerable || datastore['ForceExploit']

--- a/modules/exploits/windows/smb/ms17_010_eternalblue.rb
+++ b/modules/exploits/windows/smb/ms17_010_eternalblue.rb
@@ -130,6 +130,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Unsupported
     end
 
+    # Bail if it's not a scanner
     unless mod.respond_to?(:run_host)
       print_error("#{CHECK_MODULE} does not appear to be a scanner")
       return CheckCode::Unsupported

--- a/modules/exploits/windows/smb/ms17_010_psexec.rb
+++ b/modules/exploits/windows/smb/ms17_010_psexec.rb
@@ -95,7 +95,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_advanced_options(
       [
-        OptBool.new('ForceExploit', [false, 'Override check result', false]),
         OptBool.new('ALLOW_GUEST', [true, "Keep trying if only given guest access", false]),
         OptString.new('SERVICE_FILENAME', [false, "Filename to to be used on target for the service binary",nil]),
         OptString.new('PSH_PATH', [false, 'Path to powershell.exe', 'Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe']),
@@ -106,10 +105,6 @@ class MetasploitModule < Msf::Exploit::Remote
   # check is pulled in from Msf::Exploit::Remote::CheckScanner
 
   def exploit
-    unless check == CheckCode::Vulnerable || datastore['ForceExploit']
-      fail_with(Failure::NotVulnerable, 'Set ForceExploit to override')
-    end
-
     begin
       if datastore['SMBUser'].present?
         print_status("Authenticating to #{datastore['RHOST']} as user '#{splitname(datastore['SMBUser'])}'...")

--- a/modules/exploits/windows/smb/ms17_010_psexec.rb
+++ b/modules/exploits/windows/smb/ms17_010_psexec.rb
@@ -18,6 +18,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::SMB::Client::Psexec_MS17_010
   include Msf::Exploit::Remote::SMB::Client::Psexec
+  include Msf::Exploit::Remote::CheckScanner
   include Msf::Exploit::Powershell
   include Msf::Exploit::EXE
   include Msf::Exploit::WbemExec
@@ -47,7 +48,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'WfsDelay'     => 10,
-          'EXITFUNC' => 'thread'
+          'EXITFUNC' => 'thread',
+          'CheckScanner' => 'auxiliary/scanner/smb/smb_ms17_010'
         },
       'References'     =>
         [
@@ -99,6 +101,8 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('SERVICE_STUB_ENCODER', [false, "Encoder to use around the service registering stub",nil])
       ])
   end
+
+  # check is pulled in from Msf::Exploit::Remote::CheckScanner
 
   def exploit
     begin

--- a/modules/exploits/windows/smb/ms17_010_psexec.rb
+++ b/modules/exploits/windows/smb/ms17_010_psexec.rb
@@ -95,6 +95,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_advanced_options(
       [
+        OptBool.new('ForceExploit', [false, 'Override check result', false]),
         OptBool.new('ALLOW_GUEST', [true, "Keep trying if only given guest access", false]),
         OptString.new('SERVICE_FILENAME', [false, "Filename to to be used on target for the service binary",nil]),
         OptString.new('PSH_PATH', [false, 'Path to powershell.exe', 'Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe']),
@@ -105,6 +106,10 @@ class MetasploitModule < Msf::Exploit::Remote
   # check is pulled in from Msf::Exploit::Remote::CheckScanner
 
   def exploit
+    unless check == CheckCode::Vulnerable || datastore['ForceExploit']
+      fail_with(Failure::NotVulnerable, 'Set ForceExploit to override')
+    end
+
     begin
       if datastore['SMBUser'].present?
         print_status("Authenticating to #{datastore['RHOST']} as user '#{splitname(datastore['SMBUser'])}'...")


### PR DESCRIPTION
~This PR adds a `check` method to the `ms17_010_eternalblue` exploit by calling the `smb_ms17_010` scanner and checking its newly added return value.~ This is now a mixin. This was a big to-do for us in the past.

We may want to make this kind of code more generic between exploits and auxiliary modules.

```
msf5 exploit(windows/smb/ms17_010_eternalblue) > check

[*] 192.168.56.103:445    - Connected to \\192.168.56.103\IPC$ with TID = 2049
[*] 192.168.56.103:445    - Received STATUS_INSUFF_SERVER_RESOURCES with FID = 0
[+] 192.168.56.103:445    - Host is likely VULNERABLE to MS17-010! - Windows Server 2008 R2 Standard 7601 Service Pack 1 x64 (64-bit)
[+] 192.168.56.103:445 - The target is vulnerable.
msf5 exploit(windows/smb/ms17_010_eternalblue) >
```

cc @zerosum0x0

#8271, #8381, #11869