### PR TITLE
restore analyze on framework object

### DIFF
--- a/lib/msf/core/framework.rb
+++ b/lib/msf/core/framework.rb
@@ -78,6 +78,7 @@ class Framework
     self.modules   = ModuleManager.new(self,types)
     self.datastore = DataStore.new
     self.jobs      = Rex::JobContainer.new
+    self.analyze   = Analyze.new(self)
     self.plugins   = PluginManager.new(self)
     self.browser_profiles = Hash.new
 


### PR DESCRIPTION
Fix #11845, restore the analyze parameter on framework object.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `db_import <test_file_path>.xml`
- [x] **Verify** modules reported are valid for what is know about services and vulns on imported host
