### PR TITLE
Add tab completion and MS17-010 support to analyze command

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/db/analyze.rb
+++ b/lib/msf/ui/console/command_dispatcher/db/analyze.rb
@@ -1,5 +1,10 @@
 module Msf::Ui::Console::CommandDispatcher::Analyze
 
+  def cmd_analyze_help
+    print_line "Usage: analyze [addr1 addr2 ...]"
+    print_line
+  end
+
   def cmd_analyze(*args)
     unless active?
       print_error "Not currently connected to a data service for analysis."
@@ -61,10 +66,10 @@ module Msf::Ui::Console::CommandDispatcher::Analyze
     suggested_modules
   end
 
+  def cmd_analyze_tabs(_str, _words)
+    return [] unless framework.db.active
 
-  def cmd_analyze_help
-    print_line "Usage: analyze [addr1 addr2 ...]"
-    print_line
+    framework.db.hosts.map(&:address)
   end
 
 end

--- a/lib/msf/ui/console/command_dispatcher/db/analyze.rb
+++ b/lib/msf/ui/console/command_dispatcher/db/analyze.rb
@@ -66,8 +66,8 @@ module Msf::Ui::Console::CommandDispatcher::Analyze
     suggested_modules
   end
 
-  def cmd_analyze_tabs(_str, _words)
-    return [] unless framework.db.active
+  def cmd_analyze_tabs(_str, words)
+    return [] if !framework.db.active || words.length > 1
 
     framework.db.hosts.map(&:address)
   end

--- a/lib/msf/ui/console/command_dispatcher/developer.rb
+++ b/lib/msf/ui/console/command_dispatcher/developer.rb
@@ -137,8 +137,9 @@ class Msf::Ui::Console::CommandDispatcher::Developer
   #
   # Tab completion for the irb command
   #
-  def cmd_irb_tabs(str, words)
+  def cmd_irb_tabs(_str, words)
     return [] if words.length > 1
+
     @@irb_opts.fmt.keys
   end
 

--- a/modules/auxiliary/scanner/smb/smb_ms17_010.rb
+++ b/modules/auxiliary/scanner/smb/smb_ms17_010.rb
@@ -104,6 +104,7 @@ class MetasploitModule < Msf::Auxiliary
 
         report_vuln(
           host: ip,
+          port: rport, # A service is necessary for the analyze command
           name: self.name,
           refs: self.references,
           info: "STATUS_INSUFF_SERVER_RESOURCES for FID 0 against IPC$ - #{os}"


### PR DESCRIPTION
This is a continuation of #11877 without the `msf5` label.

```
msf5 > use smb_ms17

Matching Modules
================

   #  Name                                Disclosure Date  Rank    Check  Description
   -  ----                                ---------------  ----    -----  -----------
   0  auxiliary/scanner/smb/smb_ms17_010                   normal  Yes    MS17-010 SMB RCE Detection


[*] Using auxiliary/scanner/smb/smb_ms17_010
msf5 auxiliary(scanner/smb/smb_ms17_010) > set rhosts 192.168.56.103,104
rhosts => 192.168.56.103,104
msf5 auxiliary(scanner/smb/smb_ms17_010) > run

[*] 192.168.56.103:445    - Connected to \\192.168.56.103\IPC$ with TID = 4096
[*] 192.168.56.103:445    - Received STATUS_INSUFF_SERVER_RESOURCES with FID = 0
[+] 192.168.56.103:445    - Host is likely VULNERABLE to MS17-010! - Windows Server 2008 R2 Standard 7601 Service Pack 1 x64 (64-bit)
[*] 192.168.56.103,104:445 - Scanned 1 of 2 hosts (50% complete)
[*] 192.168.56.104:445    - Connected to \\192.168.56.104\IPC$ with TID = 1
[*] 192.168.56.104:445    - Received STATUS_INVALID_HANDLE with FID = 0
[-] 192.168.56.104:445    - Host does NOT appear vulnerable.
[*] 192.168.56.103,104:445 - Scanned 2 of 2 hosts (100% complete)
[*] Auxiliary module execution completed
msf5 auxiliary(scanner/smb/smb_ms17_010) > analyze 192.168.56.103
[*] Analyzing 192.168.56.103...
[*] exploit/windows/smb/ms17_010_eternalblue
[*] exploit/windows/smb/ms17_010_eternalblue_win8
[*] exploit/windows/smb/ms17_010_psexec
msf5 auxiliary(scanner/smb/smb_ms17_010) >
```