### PR TITLE
Add multi-host tab completion to analyze command and fix range truncation bug

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -296,7 +296,7 @@ class Db
     end
 
     each_host_range_chunk(host_ranges) do |host_search|
-      break if !host_search.nil? && host_search.empty?
+      next if host_search && host_search.empty?
 
       framework.db.hosts(address: host_search).each do |host|
         framework.db.update_host(host_data.merge(id: host.id))
@@ -547,7 +547,7 @@ class Db
 
     matched_host_ids = []
     each_host_range_chunk(host_ranges) do |host_search|
-      break if !host_search.nil? && host_search.empty?
+      next if host_search && host_search.empty?
 
       framework.db.hosts(address: host_search, non_dead: onlyup, search_term: search_term).each do |host|
         matched_host_ids << host.id
@@ -763,7 +763,7 @@ class Db
     matched_service_ids = []
 
     each_host_range_chunk(host_ranges) do |host_search|
-      break if !host_search.nil? && host_search.empty?
+      next if host_search && host_search.empty?
       opts[:workspace] = framework.db.workspace
       opts[:hosts] = {address: host_search} if !host_search.nil?
       opts[:port] = ports if ports
@@ -909,7 +909,7 @@ class Db
       vulns = framework.db.vulns({:search_term => search_term})
     else
       each_host_range_chunk(host_ranges) do |host_search|
-        break if !host_search.nil? && host_search.empty?
+        next if host_search && host_search.empty?
 
         vulns.concat(framework.db.vulns({:hosts => { :address => host_search }, :search_term => search_term }))
       end
@@ -1091,7 +1091,7 @@ class Db
     else
       # Collect notes of specified hosts
       each_host_range_chunk(host_ranges) do |host_search|
-        break if !host_search.nil? && host_search.empty?
+        next if host_search && host_search.empty?
 
         opts = {hosts: {address: host_search}, workspace: framework.db.workspace, search_term: search_term}
         opts[:ntype] = types if mode != :update && types && !types.empty?
@@ -1307,7 +1307,7 @@ class Db
       loots = loots + framework.db.loots(workspace: framework.db.workspace, search_term: search_term)
     else
       each_host_range_chunk(host_ranges) do |host_search|
-        break if !host_search.nil? && host_search.empty?
+        next if host_search && host_search.empty?
 
         loots = loots + framework.db.loots(workspace: framework.db.workspace, hosts: { address: host_search }, search_term: search_term)
       end

--- a/lib/msf/ui/console/command_dispatcher/db/analyze.rb
+++ b/lib/msf/ui/console/command_dispatcher/db/analyze.rb
@@ -28,7 +28,7 @@ module Msf::Ui::Console::CommandDispatcher::Analyze
     host_ids = []
     suggested_modules = {}
     each_host_range_chunk(host_ranges) do |host_search|
-      break if !host_search.nil? && host_search.empty?
+      next if host_search && host_search.empty?
       eval_hosts_ids = framework.db.hosts(address: host_search).map(&:id)
       if eval_hosts_ids
         eval_hosts_ids.each do |eval_id|

--- a/lib/msf/ui/console/command_dispatcher/db/analyze.rb
+++ b/lib/msf/ui/console/command_dispatcher/db/analyze.rb
@@ -67,9 +67,14 @@ module Msf::Ui::Console::CommandDispatcher::Analyze
   end
 
   def cmd_analyze_tabs(_str, words)
-    return [] if !framework.db.active || words.length > 1
+    return [] unless framework.db.active
 
-    framework.db.hosts.map(&:address)
+    hosts = framework.db.hosts.map(&:address)
+
+    # Limit completion to supplied host if it's the only one
+    return [] if words.length > 1 && hosts.length == 1
+
+    hosts
   end
 
 end


### PR DESCRIPTION
I was forgetting how to dedupe.

```
msf5 > analyze 192.168.1.
analyze 192.168.1.1  analyze 192.168.1.2
msf5 > analyze 192.168.1.1 192.168.1.2
[*] Analyzing 192.168.1.1...
[*] No suggestions for 192.168.1.1.
[*] Analyzing 192.168.1.2...
[*] No suggestions for 192.168.1.2.
msf5 >
```

This also fixes a range truncation bug:

```
msf5 > analyze 192.168.1.1 192.168.1.2
[*] Analyzing 192.168.1.1...
[*] No suggestions for 192.168.1.1.
msf5 >
```

```
msf5 > hosts 192.168.1.1 192.168.1.2

Hosts
=====

address      mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------      ---  ----  -------  ---------  -----  -------  ----  --------
192.168.1.1

msf5 >
```

Ironically, the incomplete behavior in the [previous PR](https://github.com/rapid7/metasploit-framework/pull/11878) was correct due to a range truncation bug. With the bug fixed, we can now complete more than one host on a line.

Redux of #11878.