### PR TITLE
Update show command to zero-index

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -1185,7 +1185,7 @@ module Msf
 
           def show_module_set(type, module_set, regex = nil, minrank = nil, opts = nil) # :nodoc:
             tbl = generate_module_table(type)
-            count = 0
+            count = -1
             module_set.sort.each { |refname, mod|
               o = nil
 


### PR DESCRIPTION
I missed this while focused on `use` and `search`.

```
msf5 > show nops

NOP Generators
==============

   #  Name             Disclosure Date  Rank    Check  Description
   -  ----             ---------------  ----    -----  -----------
   0  aarch64/simple                    normal  No     Simple
   1  armle/simple                      normal  No     Simple
   2  mipsbe/better                     normal  No     Better
   3  php/generic                       normal  No     PHP Nop Generator
   4  ppc/simple                        normal  No     Simple
   5  sparc/random                      normal  No     SPARC NOP Generator
   6  tty/generic                       normal  No     TTY Nop Generator
   7  x64/simple                        normal  No     Simple
   8  x86/opty2                         normal  No     Opty2
   9  x86/single_byte                   normal  No     Single Byte

msf5 >
```

Fixes #11819. Related to #11652 and #11724.