### PR TITLE
oracle_login: add verbose print error when login fails

### DIFF
--- a/modules/auxiliary/admin/oracle/oracle_login.rb
+++ b/modules/auxiliary/admin/oracle/oracle_login.rb
@@ -79,7 +79,7 @@ class MetasploitModule < Msf::Auxiliary
           print_error("#{datastore['RHOST']}:#{datastore['RPORT']} Connection timed out")
           break
         else
-          vprint_error "#{datastore['RHOST']}:#{datastore['RPORT']} - LOGIN FAILED: #{datastore['DBUSER']}: #{e.to_s})"      
+          vprint_error("#{datastore['RHOST']}:#{datastore['RPORT']} - LOGIN FAILED: #{datastore['DBUSER']}: #{e.to_s})")
         end
       else
         report_cred(

--- a/modules/auxiliary/admin/oracle/oracle_login.rb
+++ b/modules/auxiliary/admin/oracle/oracle_login.rb
@@ -78,6 +78,8 @@ class MetasploitModule < Msf::Auxiliary
         if e.to_s =~ /^ORA-12170:\s/
           print_error("#{datastore['RHOST']}:#{datastore['RPORT']} Connection timed out")
           break
+        else
+          vprint_error "#{datastore['RHOST']}:#{datastore['RPORT']} - LOGIN FAILED: #{datastore['DBUSER']}: #{e.to_s})"      
         end
       else
         report_cred(


### PR DESCRIPTION
I like having the possibility to show verbose error messages when login fails. With Oracle we get interesting error messages, such as:
`[-] 192.168.0.1:1521 - LOGIN FAILED: sysman: ORA-01017: invalid username/password; logon denied)`
Or:
`[-] 192.168.0.1:1521 - LOGIN FAILED: system: ORA-28000: the account is locked)`