### PR TITLE
Fix rdp_scanner and update CVE-2019-0708 docs

### DIFF
--- a/documentation/modules/auxiliary/scanner/rdp/cve_2019_0708_bluekeep.md
+++ b/documentation/modules/auxiliary/scanner/rdp/cve_2019_0708_bluekeep.md
@@ -65,7 +65,7 @@ Workstation versions:
  - Windows XP SP2 (x86), SP3 (x86), Version 2003 (x64)
  - Windows Vista SP0 (x86), SP0 (x64), SP2 (x64)
  - Windows 7 SP1 (x86), SP1 (x64)
- - Windows 10 1709, ()x64)
+ - Windows 10 1709, 1809 (x64)
 
 Server versions:
  - Windows 2000 SP4 (x86)


### PR DESCRIPTION
@egypt's review was missed in #8734.

```
msf5 auxiliary(scanner/rdp/rdp_scanner) > set rhosts 192.168.56.101,105
rhosts => 192.168.56.101,105
msf5 auxiliary(scanner/rdp/rdp_scanner) > options

Module options (auxiliary/scanner/rdp/rdp_scanner):

   Name       Current Setting     Required  Description
   ----       ---------------     --------  -----------
   CredSSP    true                yes       Whether or not to request CredSSP
   EarlyUser  false               yes       Whether to support Early User Authorization Result PDU
   RHOSTS     192.168.56.101,105  yes       The target address range or CIDR identifier
   RPORT      3389                yes       The target port (TCP)
   THREADS    1                   yes       The number of concurrent threads
   TLS        true                yes       Whether or not request TLS security

msf5 auxiliary(scanner/rdp/rdp_scanner) > run

[+] 192.168.56.101:3389   - Identified RDP
[*] 192.168.56.101,105:3389 - Scanned 1 of 2 hosts (50% complete)
[+] 192.168.56.105:3389   - Identified RDP
[*] 192.168.56.101,105:3389 - Scanned 2 of 2 hosts (100% complete)
[*] Auxiliary module execution completed
msf5 auxiliary(scanner/rdp/rdp_scanner) >
```

I'm also noticing another weird `peer` bug. Sigh.

Fixes #8734 and #11869.