### PR TITLE
Fix multi meterpreter_reverse_http handler to not care so much about the workspace.

### DIFF
--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -239,8 +239,7 @@ module ReverseHttp
     lookup_proxy_settings
 
     if datastore['IgnoreUnknownPayloads']
-      payload_count = framework.db.payloads({workspace: framework.db.workspace}).length
-      print_status("Handler is ignoring unknown payloads, there are #{payload_count} UUIDs whitelisted")
+      print_status("Handler is ignoring unknown payloads")
     end
   end
 
@@ -333,9 +332,8 @@ protected
     if datastore['IgnoreUnknownPayloads'] && info[:mode].to_s =~ /^init_/
       payload_info = {
           uuid: uuid.puid_hex,
-          workspace: framework.db.workspace
       }
-      payload = framework.db.payloads(payload_info).first
+      payload = framework.db.get_payload(payload_info)
       allowed_urls = payload ? payload.urls : []
       unless allowed_urls.include?(req.relative_resource)
         print_status("Ignoring unknown UUID URL: #{request_summary}")

--- a/lib/msf/core/payload/uuid/options.rb
+++ b/lib/msf/core/payload/uuid/options.rb
@@ -94,7 +94,6 @@ module Msf::Payload::UUID::Options
       arch: uuid.arch,
       platform: uuid.platform,
       timestamp: uuid.timestamp,
-      workspace: framework.db.workspace
     })
 
     if datastore['PayloadUUIDSeed'].to_s.length > 0
@@ -116,9 +115,8 @@ module Msf::Payload::UUID::Options
 
     payload_info = {
         uuid: uuid.puid_hex,
-        workspace: framework.db.workspace
     }
-    payload = framework.db.payloads(payload_info).first
+    payload = framework.db.get_payload(payload_info)
     unless payload.nil?
       urls = payload.urls.nil? ? [] : payload.urls
       urls << url


### PR DESCRIPTION
This change fixes the multi/meterpreter_reverse_https payload handler.  I didn't find an existing github issue.

## Verification

List the steps needed to make sure this thing works

- [ ] Create `/certs/certs.pem` according to Paranoid Mode:
```
openssl req -new -newkey rsa:4096 -days 365 -nodes -x509 \
-subj "/C=US/ST=Texas/L=Austin/O=Development/CN=www.example.com" \
-keyout www.example.com.key \
-out www.example.com.crt
cat www.example.com.key www.example.com.crt > /certs/cert.pem
```
- [x] Start `msfconsole`
- [x] `setg LHOST wlan0` or your network interface name.
- [x] `setg LPORT 443`
- [x] `setg PayloadUUIDTracking true`
- [x] `setg HandlerSSLCert /certs/cert.pem`
- [x] `setg StagerVerifySSLCert true`
- [x] `setg IgnoreUnknownPayloads true`
- [x] `setg LURI /multi`
- [x] `use payload/linux/x64/meterpreter_reverse_https`
- [x] `set PayloadUUIDName ParanoidStagedElf64`
- [x] `generate -f elf -o /tmp/rev`
- [x] `use exploit/multi/handler`
- [x] `set PAYLOAD multi/meterpreter/reverse_https`
- [x] `set ExitOnSession false`
- [x] `exploit -j`
- [x] Run `rev` on the same host, or another that can reach this host over the LHOST address.
- [x] **Verify** A new session is created.
- [x] **Verify** msfconsole doesn't bark about ignoring the unknown UUID.