### PR TITLE
Update autoroute.md

### DIFF
--- a/documentation/modules/post/multi/manage/autoroute.md
+++ b/documentation/modules/post/multi/manage/autoroute.md
@@ -41,7 +41,7 @@ Metasploit can launch a Socks 4a Proxy server using the module: auxiliary/server
 ```
 use auxiliary/server/socks4a
 set SRVHOST 127.0.0.1
-set LPORT 1080
+set SRVPORT 1080
 exploit -j
 ```
 


### PR DESCRIPTION
Mistakenly, the variable LPORT was used rather then SRVPORT. In case the user changes the port using LPORT, proxychains won't work.

## Problem Reproduction

- [ ] Start `msfconsole`
- [ ] `use auxiliary/server/socks4a`
- [ ] `set SRVHOST 127.0.0.1`
- [ ] `set LPORT 1082`
- [ ] `run -j`
- [ ] `Edit /etc/proxychains.conf`
- [ ] `socks4  127.0.0.1 1082`
- [ ] `Invoke Proxychains`
- [ ] `proxychains curl -i 192.168.8.135`
```
ProxyChains-3.1 (http://proxychains.sf.net)
|S-chain|-<>-127.0.0.1:1082-<--timeout
curl: (7) Couldn't connect to server
```

## Verification/Solution

- [ ] Start `msfconsole`
- [ ] `use auxiliary/server/socks4a`
- [ ] `set SRVHOST 127.0.0.1`
- [ ] `set SRVPORT 1082`
- [ ] `run -j`
- [ ] `Edit /etc/proxychains.conf`
- [ ] `socks4  127.0.0.1 1082`
- [ ] `Invoke Proxychains`
- [ ] `proxychains curl -i 192.168.8.135`
```
ProxyChains-3.1 (http://proxychains.sf.net)
|S-chain|-<>-127.0.0.1:1082-<><>-192.168.8.135:80-<><>-OK
HTTP/1.1 200 OK
Date: Mon, 27 May 2019 07:09:43 GMT
Server: Apache/2.2.8 (Ubuntu) DAV/2
X-Powered-By: PHP/5.2.4-2ubuntu5.10
Content-Length: 891
Content-Type: text/html

<html><head><title>Metasploitable2 - Linux</title></head><body>
<pre>
```
