### PR TITLE
Note deprecated DIAL casting in chromecast_youtube

### DIFF
--- a/documentation/modules/auxiliary/admin/chromecast/chromecast_youtube.md
+++ b/documentation/modules/auxiliary/admin/chromecast/chromecast_youtube.md
@@ -6,7 +6,7 @@ Only the deprecated DIAL protocol is supported by this module. Casting via the n
 
 ## Verification Steps
 
-1. Do: ```auxiliary/admin/chromecast/chromecast_youtube```
+1. Do: ```use auxiliary/admin/chromecast/chromecast_youtube```
 2. Do: ```set RHOST [IP]```
 3. Do: ```run```
 

--- a/documentation/modules/auxiliary/admin/chromecast/chromecast_youtube.md
+++ b/documentation/modules/auxiliary/admin/chromecast/chromecast_youtube.md
@@ -2,9 +2,11 @@ This module plays (by default) ["Epic sax guy 10 hours"](https://www.youtube.com
 
 Naturally, audio should be cranked to 11 before running this module.
 
+Only the deprecated DIAL protocol is supported by this module. Casting via the newer CASTV2 protocol is unsupported at this time.
+
 ## Verification Steps
 
-1. Do: ```use auxiliary/scanner/http/chromecast_webserver ```
+1. Do: ```auxiliary/admin/chromecast/chromecast_youtube```
 2. Do: ```set RHOST [IP]```
 3. Do: ```run```
 

--- a/modules/auxiliary/admin/chromecast/chromecast_youtube.rb
+++ b/modules/auxiliary/admin/chromecast/chromecast_youtube.rb
@@ -11,7 +11,9 @@ class MetasploitModule < Msf::Auxiliary
       'Name' => 'Chromecast YouTube Remote Control',
       'Description' => %q{
         This module acts as a simple remote control for Chromecast YouTube.
+
         Only the deprecated DIAL protocol is supported by this module.
+        Casting via the newer CASTV2 protocol is unsupported at this time.
       },
       'Author' => ['wvu'],
       'References' => [

--- a/modules/auxiliary/admin/chromecast/chromecast_youtube.rb
+++ b/modules/auxiliary/admin/chromecast/chromecast_youtube.rb
@@ -51,7 +51,7 @@ class MetasploitModule < Msf::Auxiliary
     when 200
       print_status('Stopping video')
     when 404
-      print_error("#{action.name} failed: DIAL unsupported")
+      print_error("#{action.name} failed: DIAL protocol unsupported")
     end
   end
 

--- a/modules/auxiliary/admin/chromecast/chromecast_youtube.rb
+++ b/modules/auxiliary/admin/chromecast/chromecast_youtube.rb
@@ -51,7 +51,8 @@ class MetasploitModule < Msf::Auxiliary
     when 200
       print_status('Stopping video')
     when 404
-      print_error("#{action.name} failed: CASTV2 protocol unsupported")
+      print_error('Target no longer supports casting via the DIAL protocol. ' \
+                  'CASTV2 is not supported by this module at this time.')
     end
   end
 

--- a/modules/auxiliary/admin/chromecast/chromecast_youtube.rb
+++ b/modules/auxiliary/admin/chromecast/chromecast_youtube.rb
@@ -51,7 +51,7 @@ class MetasploitModule < Msf::Auxiliary
     when 200
       print_status('Stopping video')
     when 404
-      print_error("#{action.name.downcase} failed: DIAL unsupported")
+      print_error("#{action.name} failed: DIAL unsupported")
     end
   end
 

--- a/modules/auxiliary/admin/chromecast/chromecast_youtube.rb
+++ b/modules/auxiliary/admin/chromecast/chromecast_youtube.rb
@@ -51,7 +51,7 @@ class MetasploitModule < Msf::Auxiliary
     when 200
       print_status('Stopping video')
     when 404
-      print_error("#{action.name} failed: DIAL protocol unsupported")
+      print_error("#{action.name} failed: CASTV2 protocol unsupported")
     end
   end
 

--- a/modules/auxiliary/admin/chromecast/chromecast_youtube.rb
+++ b/modules/auxiliary/admin/chromecast/chromecast_youtube.rb
@@ -11,6 +11,7 @@ class MetasploitModule < Msf::Auxiliary
       'Name' => 'Chromecast YouTube Remote Control',
       'Description' => %q{
         This module acts as a simple remote control for Chromecast YouTube.
+        Only the deprecated DIAL protocol is supported by this module.
       },
       'Author' => ['wvu'],
       'References' => [
@@ -48,7 +49,7 @@ class MetasploitModule < Msf::Auxiliary
     when 200
       print_status('Stopping video')
     when 404
-      print_error("Couldn't #{action.name.downcase} video")
+      print_error("#{action.name.downcase} failed: DIAL unsupported")
     end
   end
 


### PR DESCRIPTION
In order to support this module in the future, we'd need to implement CASTV2 using TLS, protobuf, and JSON.

For now, I've opted to update the module description and error message.

- [x] Try to play a YouTube video on an up-to-date Chromecast
- [x] See the updated error message and cry in protobufs

```
msf5 auxiliary(admin/chromecast/chromecast_youtube) > options

Module options (auxiliary/admin/chromecast/chromecast_youtube):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS   192.168.1.3      yes       The target address range or CIDR identifier
   RPORT    8008             yes       The target port (TCP)
   SSL      false            no        Negotiate SSL/TLS for outgoing connections
   VHOST                     no        HTTP server virtual host
   VID      kxopViU98Xo      yes       Video ID


Auxiliary action:

   Name  Description
   ----  -----------
   Play  Play video


msf5 auxiliary(admin/chromecast/chromecast_youtube) > run
[*] Running module against 192.168.1.3

[-] Target no longer supports casting via the DIAL protocol. CASTV2 is not supported by this module at this time.
[*] Auxiliary module execution completed
msf5 auxiliary(admin/chromecast/chromecast_youtube) >
```

#11889