### PR TITLE
move require for pdf-reader

### DIFF
--- a/modules/auxiliary/gather/http_pdf_authors.rb
+++ b/modules/auxiliary/gather/http_pdf_authors.rb
@@ -3,8 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'pdf-reader'
-
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::HttpClient
   include Msf::Auxiliary::Report
@@ -67,6 +65,8 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def read(data)
+    require 'pdf-reader'
+
     Timeout.timeout(10) do
       reader = PDF::Reader.new data
       return parse reader


### PR DESCRIPTION
In ruby 2,5+ on windows the ttfunk dependency loading causes ruby to crash so
only load this only when specifically required.

Thanks @busterb for suggested patch here.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use auxiliary/gather/http_pdf_authors`
- [x] **Verify** things don't crash as much.

