### PR TITLE
Prefer initial slash in normalize_uri for jenkins_metaprogramming and future modules

### DIFF
--- a/modules/exploits/multi/http/jenkins_metaprogramming.rb
+++ b/modules/exploits/multi/http/jenkins_metaprogramming.rb
@@ -175,7 +175,7 @@ class MetasploitModule < Msf::Exploit::Remote
 =end
   def go_go_gadget1(custom_uri = nil)
     # NOTE: See CVE-2018-1000408 for why we don't want to randomize the username
-    acl_bypass = normalize_uri(target_uri.path, 'securityRealm/user/admin')
+    acl_bypass = normalize_uri(target_uri.path, '/securityRealm/user/admin')
 
     return normalize_uri(acl_bypass, custom_uri) if custom_uri
 
@@ -184,10 +184,10 @@ class MetasploitModule < Msf::Exploit::Remote
     rce_uri =
       case target['Type']
       when :unix_memory
-        'org.jenkinsci.plugins.' \
+        '/org.jenkinsci.plugins.' \
           'scriptsecurity.sandbox.groovy.SecureGroovyScript/checkScript'
       when :java_dropper
-        'org.jenkinsci.plugins.' \
+        '/org.jenkinsci.plugins.' \
           'workflow.cps.CpsFlowDefinition/checkScriptCompile'
       end
 


### PR DESCRIPTION
I missed the indirect call to `normalize_uri` via `go_go_gadget1` in `check`. This decides on a style.

If a URI part contains a slash, we begin with a slash for clarity. Otherwise it's optional, since `normalize_uri` joins URI parts with a slash and normalizes the final URI.

Updates #11864.