### PR TITLE
fix the meterpreter > screenshot command to only upload the dll on Windows

### DIFF
--- a/lib/rex/post/meterpreter/extensions/stdapi/ui.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/ui.rb
@@ -155,11 +155,27 @@ class UI < Rex::Post::UI
     request = Packet.create_request( 'stdapi_ui_desktop_screenshot' )
     request.add_tlv( TLV_TYPE_DESKTOP_SCREENSHOT_QUALITY, quality )
 
-    # include the x64 screenshot dll if the host OS is x64
-    if( client.sys.config.sysinfo['Architecture'] =~ /^\S*x64\S*/ )
-      screenshot_path = MetasploitPayloads.meterpreter_path('screenshot','x64.dll')
+    if client.platform == 'windows'
+      # include the x64 screenshot dll if the host OS is x64
+      if( client.sys.config.sysinfo['Architecture'] =~ /^\S*x64\S*/ )
+        screenshot_path = MetasploitPayloads.meterpreter_path('screenshot','x64.dll')
+        if screenshot_path.nil?
+          raise RuntimeError, "screenshot.x64.dll not found", caller
+        end
+
+        screenshot_dll  = ''
+        ::File.open( screenshot_path, 'rb' ) do |f|
+          screenshot_dll += f.read( f.stat.size )
+        end
+
+        request.add_tlv( TLV_TYPE_DESKTOP_SCREENSHOT_PE64DLL_BUFFER, screenshot_dll, false, true )
+        request.add_tlv( TLV_TYPE_DESKTOP_SCREENSHOT_PE64DLL_LENGTH, screenshot_dll.length )
+      end
+
+      # but always include the x86 screenshot dll as we can use it for wow64 processes if we are on x64
+      screenshot_path = MetasploitPayloads.meterpreter_path('screenshot','x86.dll')
       if screenshot_path.nil?
-        raise RuntimeError, "screenshot.x64.dll not found", caller
+        raise RuntimeError, "screenshot.x86.dll not found", caller
       end
 
       screenshot_dll  = ''
@@ -167,23 +183,9 @@ class UI < Rex::Post::UI
         screenshot_dll += f.read( f.stat.size )
       end
 
-      request.add_tlv( TLV_TYPE_DESKTOP_SCREENSHOT_PE64DLL_BUFFER, screenshot_dll, false, true )
-      request.add_tlv( TLV_TYPE_DESKTOP_SCREENSHOT_PE64DLL_LENGTH, screenshot_dll.length )
+      request.add_tlv( TLV_TYPE_DESKTOP_SCREENSHOT_PE32DLL_BUFFER, screenshot_dll, false, true )
+      request.add_tlv( TLV_TYPE_DESKTOP_SCREENSHOT_PE32DLL_LENGTH, screenshot_dll.length )
     end
-
-    # but always include the x86 screenshot dll as we can use it for wow64 processes if we are on x64
-    screenshot_path = MetasploitPayloads.meterpreter_path('screenshot','x86.dll')
-    if screenshot_path.nil?
-      raise RuntimeError, "screenshot.x86.dll not found", caller
-    end
-
-    screenshot_dll  = ''
-    ::File.open( screenshot_path, 'rb' ) do |f|
-      screenshot_dll += f.read( f.stat.size )
-    end
-
-    request.add_tlv( TLV_TYPE_DESKTOP_SCREENSHOT_PE32DLL_BUFFER, screenshot_dll, false, true )
-    request.add_tlv( TLV_TYPE_DESKTOP_SCREENSHOT_PE32DLL_LENGTH, screenshot_dll.length )
 
     # send the request and return the jpeg image if successfull.
     response = client.send_request( request )


### PR DESCRIPTION
Currently we upload the screenshot dll on all platforms whenever we take a screenshot. This PR updates it so we only do this on Windows.

