### PR TITLE
fix java/android cmd_exec and shell_command_token

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,7 +21,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 1.3.69)
+      metasploit-payloads (= 1.3.70)
       metasploit_data_models (= 3.0.10)
       metasploit_payloads-mettle (= 0.5.14)
       mqtt
@@ -177,7 +177,7 @@ GEM
       activemodel (~> 4.2.6)
       activesupport (~> 4.2.6)
       railties (~> 4.2.6)
-    metasploit-payloads (1.3.69)
+    metasploit-payloads (1.3.70)
     metasploit_data_models (3.0.10)
       activerecord (~> 4.2.6)
       activesupport (~> 4.2.6)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -70,7 +70,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '1.3.69'
+  spec.add_runtime_dependency 'metasploit-payloads', '1.3.70'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '0.5.14'
   # Needed by msfgui and other rpc components


### PR DESCRIPTION
This change fixes a race condition in the cmd_exec tests and rapid7/metasploit-framework#11530

From https://github.com/rapid7/metasploit-payloads/pull/334

## Verification

- [x] Using any Java/android meterpreter payload, run the cmd_exec tests:

```
loadpath test/modules/
use post/test/cmd_exec 
set SESSION -1
run
```
 - [x] **Verify** that the tests pass.
