### PR TITLE
Bigdecimal boot

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -22,6 +22,18 @@ unless ENV['BUNDLE_GEMFILE']
   end
 end
 
+# Remove bigdecimal warning - start
+# https://github.com/ruby/bigdecimal/pull/115
+# https://github.com/rapid7/metasploit-framework/pull/11184#issuecomment-461971266
+# TODO: remove when upgrading from rails 4.x
+require 'bigdecimal'
+
+def BigDecimal.new(*args, **kwargs)
+  return BigDecimal(*args) if kwargs.empty?
+  BigDecimal(*args, **kwargs)
+end
+# Remove bigdecimal warning - end
+
 begin
   require 'bundler/setup'
 rescue LoadError => e

--- a/lib/msf/core.rb
+++ b/lib/msf/core.rb
@@ -13,18 +13,6 @@
 # Include backported features for older versions of Ruby
 require 'backports'
 
-# Remove bigdecimal warning - start
-# https://github.com/ruby/bigdecimal/pull/115
-# https://github.com/rapid7/metasploit-framework/pull/11184#issuecomment-461971266
-# TODO: remove when upgrading from rails 4.x
-require 'bigdecimal'
-
-def BigDecimal.new(*args, **kwargs)
-  return BigDecimal(*args) if kwargs.empty?
-  BigDecimal(*args, **kwargs)
-end
-# Remove bigdecimal warning - end
-
 # The framework-core depends on Rex
 require 'rex'
 require 'rex/ui'


### PR DESCRIPTION
move BigDecimal patch earlier in boot process
This makes msfvenom also quiet about the impending deprecation of BigDecimal.new

## Verification Steps

- [x] Run `msfconsole -q`, ensure it doesn't snow warnings
- [x] Run `msfvenom -p windows/meterpreter/reverse_tcp -f exe -o test.exe`, ensure it doesn't show warnings.