### PR TITLE
remove Ruby 2.3.8 from Metasploit test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ addons:
       - graphviz
 language: ruby
 rvm:
-  - '2.3.8'
   - '2.4.5'
   - '2.5.5'
   - '2.6.2'
@@ -26,8 +25,6 @@ env:
 matrix:
   fast_finish: true
   exclude:
-  - rvm: '2.3.8'
-    env: CMD='bundle exec rake rspec-rerun:spec SPEC_OPTS="--tag content" REMOTE_DB=1'
   - rvm: '2.4.5'
     env: CMD='bundle exec rake rspec-rerun:spec SPEC_OPTS="--tag content" REMOTE_DB=1'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ addons:
       - graphviz
 language: ruby
 rvm:
-  - '2.4.5'
   - '2.5.5'
   - '2.6.2'
 
@@ -24,9 +23,6 @@ env:
 
 matrix:
   fast_finish: true
-  exclude:
-  - rvm: '2.4.5'
-    env: CMD='bundle exec rake rspec-rerun:spec SPEC_OPTS="--tag content" REMOTE_DB=1'
 
 jobs:
   # build docker image


### PR DESCRIPTION
Ruby 2.3.8 is no longer supported:
https://www.ruby-lang.org/en/news/2018/10/17/ruby-2-3-8-released/

Let's regain some Travis slots and retire Ruby 2.3.

@jmartin-r7 also suggests axing 2.4.x