### PR TITLE
Bubble Validation Error which is caught

### DIFF
--- a/lib/metasploit/framework/data_service/proxy/core.rb
+++ b/lib/metasploit/framework/data_service/proxy/core.rb
@@ -171,7 +171,7 @@ class DataProxy
     exception.backtrace.each { |line| elog "#{line}" }
     # TODO: We should try to surface the original exception, instead of just a generic one.
     # This should not display the full backtrace, only the message.
-    raise "#{ui_message}: #{exception.message}. See log for more details."
+    raise exception
   end
 
   # Adds a valid workspace value to the opts hash before sending on to the data layer.


### PR DESCRIPTION
Raise Validation error that is checked for.

 #11668

## Verification

1. `./msfconsole -q`
2. `creds add user:lm_password ntlm:E52CAC67419A9A224A3B108F3FA6CB6D:8846F7EAEE8FB117AD06BDD830B7586C jtr:lm`
3. `creds add user:samehash ntlm:E52CAC67419A9A224A3B108F3FA6CB6D:8846F7EAEE8FB117AD06BDD830B7586C jtr:lm`

```
$ ./msfconsole -q
msf5 > db_status
[*] Connected to msf. Connection type: postgresql.
msf5 > creds add user:lm_password ntlm:E52CAC67419A9A224A3B108F3FA6CB6D:8846F7EAEE8FB117AD06BDD830B7586C jtr:lm
msf5 > creds add user:samehash ntlm:E52CAC67419A9A224A3B108F3FA6CB6D:8846F7EAEE8FB117AD06BDD830B7586C jtr:lm
[-] Failed to add : Validation failed: Data has already been taken
msf5 > 
```