### PR TITLE
WIP refactor and document `sessions` command

### DIFF
--- a/documentation/cli/msfconsole.md
+++ b/documentation/cli/msfconsole.md
@@ -13,8 +13,8 @@ having to manually list each desired thing. All ranges are inclusive.
 ### Ranges of IDs
 
 Commands that take a list of IDs can use ranges to help. Individual IDs must be
-separated by a `,` (no space allowed) and ranges can be expressed with either
-`-` or `..`.
+separated by a `,` (spaces must be quoted in most cases) and ranges can be
+expressed with either `-` or `..`.
 
 ### Ranges of IPs
 

--- a/documentation/cli/msfconsole/sessions.md
+++ b/documentation/cli/msfconsole/sessions.md
@@ -1,0 +1,11 @@
+Sessions
+========
+
+The `sessions` command is used to manage or interact with instances of payloads
+that are connected to Metasploit. Sessions are created when a payload connects
+back to a running handler ("reverse" payloads), or a payload listens on a
+host/port where a handler is expecting to connect to it ("bind" payloads).
+
+Different types of payloads create sessions with different capabilities. The
+most common types of sessions are `meterpreter` and `shell`. Both kinds
+support interaction and running most available `post` modules.

--- a/lib/msf/ui/console/command_dispatcher.rb
+++ b/lib/msf/ui/console/command_dispatcher.rb
@@ -91,7 +91,7 @@ module CommandDispatcher
   def build_range_array(id_list)
     item_list = []
     unless id_list.blank?
-      temp_list = id_list.split(',')
+      temp_list = id_list.split(/[, ]*/)
       temp_list.each do |ele|
         return if ele.count('-') > 1
         return if ele.first == '-' || ele[-1] == '-'

--- a/lib/msf/ui/console/command_dispatcher.rb
+++ b/lib/msf/ui/console/command_dispatcher.rb
@@ -121,9 +121,14 @@ module CommandDispatcher
   #   be removed, including trailing "\n" if present
   # @return [String] Text sans lines containing to_match
   #
-  def remove_lines(text, to_match)
-    to_match = Regexp.escape(to_match)
-    text.gsub(/^.*(#{to_match}).*(#{Regexp.escape $/})?/, '')
+  def remove_lines(text, *lines)
+    out = text.dup
+    lines.each do |to_match|
+      to_match = Regexp.escape(to_match)
+      out.gsub!(/^.*(#{to_match}).*(#{Regexp.escape $/})?/, '')
+    end
+
+    out
   end
 
   #

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1175,9 +1175,11 @@ class Core
       # Workaround for aggressive option coercion
       opts.on '-[\d]*,?', 'HACK for interacting with most recent sessions' do |x|
         x.gsub!(',', '')
-        sid[last] << (-1 * Integer(x)).to_s
-      rescue ArgumentError
-        raise OptionParser::InvalidOption.new("Invalid relative session ID -#{x}. Use a single negative number -X to get the Xth most recent session.")
+        begin
+          sid[last] << (-1 * Integer(x)).to_s
+        rescue ArgumentError
+          raise OptionParser::InvalidOption.new("Invalid relative session ID -#{x}. Use a single negative number -X to get the Xth most recent session.")
+        end
       end
     end
 

--- a/lib/rex/ui/text/dispatcher_shell.rb
+++ b/lib/rex/ui/text/dispatcher_shell.rb
@@ -479,6 +479,7 @@ module DispatcherShell
           print_error("#{method}: Interrupted")
           raise if propagate_errors
         rescue OptionParser::ParseError => e
+          found = true
           print_error("#{method}: #{e.message}")
           raise if propagate_errors
         rescue


### PR DESCRIPTION
Refactor the `sessions` command to allow arguments to behave a little more sensibly take arguments. For example, `-c` and `-C` flags may now be combined, we try work more intuitively with arguments, and the method is now under 300 lines.

I am still working to untangle DRY the logic, test for new bugs, and document individual switches. Regression tests appreciated.