### PR TITLE
replace trivial usage of expand_path with getenv

### DIFF
--- a/lib/msf/base/sessions/meterpreter.rb
+++ b/lib/msf/base/sessions/meterpreter.rb
@@ -115,7 +115,7 @@ class Meterpreter < Rex::Post::Meterpreter::Client
 
     # COMSPEC is special-cased on all meterpreters to return a viable
     # shell.
-    sh = fs.file.expand_path("%COMSPEC%")
+    sh = sys.config.getenv('COMSPEC')
     @shell = sys.process.execute(sh, nil, { "Hidden" => true, "Channelized" => true })
 
   end

--- a/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
@@ -112,7 +112,7 @@ class Webcam
 
       paths.each do |browser_path|
         if file?(browser_path)
-          found_browser_path = client.fs.file.expand_path(browser_path)
+          found_browser_path = browser_path
           break
         end
       end

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/kiwi.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/kiwi.rb
@@ -402,8 +402,7 @@ class Console::CommandDispatcher::Kiwi
   # Dump all the shared wifi profiles/credentials
   #
   def cmd_wifi_list_shared(*args)
-    interfaces_dir = '%AllUsersProfile%\Microsoft\Wlansvc\Profiles\Interfaces'
-    interfaces_dir = client.fs.file.expand_path(interfaces_dir)
+    interfaces_dir = client.sys.config.getenv('AllUsersProfile') + '\Microsoft\Wlansvc\Profiles\Interfaces'
     files = client.fs.file.search(interfaces_dir, '*.xml', true)
 
     if files.length == 0

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
@@ -303,7 +303,7 @@ class Console::CommandDispatcher::Stdapi::Sys
 
     case client.platform
     when 'windows'
-      path = client.fs.file.expand_path('%COMSPEC%')
+      path = client.sys.config.getenv('COMSPEC')
       path = (path && !path.empty?) ? path : 'cmd.exe'
 
       # attempt the shell with thread impersonation
@@ -319,12 +319,11 @@ class Console::CommandDispatcher::Stdapi::Sys
         return true
       end
 
-      # Don't expand_path() this because it's literal anyway
       cmd_execute('-f', '/bin/sh', '-c', '-i')
     else
       # Then this is a multi-platform meterpreter (e.g., php or java), which
       # must special-case COMSPEC to return the system-specific shell.
-      path = client.fs.file.expand_path('%COMSPEC%')
+      path = client.sys.config.getenv('COMSPEC')
 
       # If that failed for whatever reason, guess it's unix
       path = (path && !path.empty?) ? path : '/bin/sh'

--- a/modules/exploits/windows/local/cve_2017_8464_lnk_lpe.rb
+++ b/modules/exploits/windows/local/cve_2017_8464_lnk_lpe.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http://metasploit.com/download
+# This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
@@ -128,7 +128,7 @@ class MetasploitModule < Msf::Exploit::Local
     datastore['EXE::Path'] = path
     datastore['EXE::Template'] = ::File.join(path, "template_#{arch}_windows.dll")
 
-    path = datastore['PATH'] || session.fs.file.expand_path("%USERPROFILE%")
+    path = datastore['PATH'] || session.sys.config.getenv('USERPROFILE')
     path.chomp!("\\")
 
     dll_path = "#{path}\\#{get_name('DLLNAME', 'dll')}"

--- a/modules/exploits/windows/local/persistence_service.rb
+++ b/modules/exploits/windows/local/persistence_service.rb
@@ -113,13 +113,13 @@ class MetasploitModule < Msf::Exploit::Local
         write_file_to_target(temprexe,rexe)
       rescue Rex::Post::Meterpreter::RequestError
         print_warning("Insufficient privileges to write in #{rexepath}, writing to %TEMP%")
-        temprexe = session.fs.file.expand_path("%TEMP%") + "\\" + rexename
+        temprexe = session.sys.config.getenv('TEMP') + "\\" + rexename
         write_file_to_target(temprexe,rexe)
       end
 
     # Write to %temp% directory if not set REMOTE_EXE_PATH
     else
-      temprexe = session.fs.file.expand_path("%TEMP%") + "\\" + rexename
+      temprexe = session.sys.config.getenv('TEMP') + "\\" + rexename
       write_file_to_target(temprexe,rexe)
     end
 

--- a/modules/exploits/windows/local/ps_persist.rb
+++ b/modules/exploits/windows/local/ps_persist.rb
@@ -91,7 +91,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     com_opts = {}
     com_opts[:net_clr] = 4.0 # Min .NET runtime to load into a PS session
-    com_opts[:target] = datastore['OUTPUT_TARGET'] || session.fs.file.expand_path('%TEMP%') + "\\#{ Rex::Text.rand_text_alpha(rand(8)+8) }.exe"
+    com_opts[:target] = datastore['OUTPUT_TARGET'] || session.sys.config.getenv('TEMP') + "\\#{ Rex::Text.rand_text_alpha(rand(8)+8) }.exe"
     com_opts[:payload] = payload_script #payload.encoded
     vprint_good com_opts[:payload].length.to_s
 

--- a/modules/post/windows/gather/credentials/tortoisesvn.rb
+++ b/modules/post/windows/gather/credentials/tortoisesvn.rb
@@ -100,7 +100,7 @@ class MetasploitModule < Msf::Post
   def get_config_files
     # Determine if TortoiseSVN is installed and parse config files
     savedpwds = 0
-    path = session.fs.file.expand_path("%APPDATA%\\Subversion\\auth\\svn.simple\\")
+    path = session.sys.config.getenv('APPDATA') + "\\Subversion\\auth\\svn.simple\\"
     print_status("Checking for configuration files in: #{path}")
 
     begin

--- a/modules/post/windows/manage/persistence_exe.rb
+++ b/modules/post/windows/manage/persistence_exe.rb
@@ -174,13 +174,13 @@ class MetasploitModule < Msf::Post
         write_file_to_target(temprexe,rexe)
       rescue Rex::Post::Meterpreter::RequestError
         print_warning("Insufficient privileges to write in #{datastore['LocalExePath']}, writing to %TEMP%")
-        temprexe = session.fs.file.expand_path("%TEMP%") + "\\" + rexename
+        temprexe = session.sys.config.getenv('TEMP') + "\\" + rexename
         write_file_to_target(temprexe,rexe)
       end
 
     # Write to %temp% directory if not set LocalExePath
     else
-      temprexe = session.fs.file.expand_path("%TEMP%") + "\\" + rexename
+      temprexe = session.sys.config.getenv('TEMP') + "\\" + rexename
       write_file_to_target(temprexe,rexe)
     end
 

--- a/modules/post/windows/manage/powershell/build_net_code.rb
+++ b/modules/post/windows/manage/powershell/build_net_code.rb
@@ -70,7 +70,7 @@ class MetasploitModule < Msf::Post
     net_com_opts = {}
     net_com_opts[:target] =
       datastore['OUTPUT_TARGET'] ||
-      "#{session.fs.file.expand_path('%TEMP%')}\\#{Rex::Text.rand_text_alpha(rand(8) + 8)}.exe"
+      "#{session.sys.config.getenv('TEMP')}\\#{Rex::Text.rand_text_alpha(rand(8) + 8)}.exe"
     net_com_opts[:com_opts] = datastore['COMPILER_OPTS']
     net_com_opts[:provider] = datastore['CODE_PROVIDER']
     net_com_opts[:assemblies] = datastore['ASSEMBLIES']

--- a/scripts/meterpreter/metsvc.rb
+++ b/scripts/meterpreter/metsvc.rb
@@ -73,7 +73,7 @@ if client.platform == 'windows'
   # Upload to the filesystem
   #
 
-  tempdir = client.fs.file.expand_path("%TEMP%") + "\\" + Rex::Text.rand_text_alpha(rand(8)+8)
+  tempdir = client.sys.config.getenv('TEMP') + "\\" + Rex::Text.rand_text_alpha(rand(8)+8)
 
   print_status("Creating a temporary installation directory #{tempdir}...")
   client.fs.dir.mkdir(tempdir)

--- a/scripts/meterpreter/persistence.rb
+++ b/scripts/meterpreter/persistence.rb
@@ -125,7 +125,7 @@ def write_script_to_target(target_dir,vbs)
   if target_dir
     tempdir = target_dir
   else
-    tempdir = @client.fs.file.expand_path("%TEMP%")
+    tempdir = @client.sys.config.getenv('TEMP')
   end
   tempvbs = tempdir + "\\" + Rex::Text.rand_text_alpha((rand(8)+6)) + ".vbs"
   fd = @client.fs.file.new(tempvbs, "wb")

--- a/test/modules/post/test/meterpreter.rb
+++ b/test/modules/post/test/meterpreter.rb
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Post
     if (stat and stat.directory?)
       tmp = "/tmp"
     else
-      tmp = session.fs.file.expand_path("%TEMP%")
+      tmp = session.sys.config.getenv('TEMP')
     end
     vprint_status("Setup: changing working directory to #{tmp}")
     session.fs.dir.chdir(tmp)
@@ -138,7 +138,7 @@ class MetasploitModule < Msf::Post
     else
       entropy_value = ""
     end
-    
+
     it "should return the proper directory separator" do
       sysinfo = session.sys.config.sysinfo
       if sysinfo["OS"] =~ /windows/i
@@ -173,7 +173,7 @@ class MetasploitModule < Msf::Post
     end
 
     it "should create and remove a dir" do
-      dir_name = "#{datastore["BaseFileName"]}-dir#{entropy_value}" 
+      dir_name = "#{datastore["BaseFileName"]}-dir#{entropy_value}"
       vprint_status("Directory Name: #{dir_name}")
       session.fs.dir.rmdir(dir_name) rescue nil
       res = create_directory(dir_name)


### PR DESCRIPTION
expand_path is not implemented consistently across platforms and sessions, which leads to confusing behavior. In places where we have trivial single variable expansions, this changes modules and library code to just use getenv. This gets us closer to being able to kill it 💀.

We'll look at the rest individually to see if they can also be reimplemented in terms of getenv.

## Verification

- [ ] Verify that everything works just like before!