### PR TITLE
if there is no content, don't include content length

### DIFF
--- a/lib/rex/proto/http/packet.rb
+++ b/lib/rex/proto/http/packet.rb
@@ -205,7 +205,7 @@ class Packet
       unless ignore_chunk
         if (self.auto_cl == true && self.transfer_chunked == true)
           raise RuntimeError, "'Content-Length' and 'Transfer-Encoding: chunked' are incompatible"
-        elsif self.auto_cl == true
+        elsif self.auto_cl == true && content.length > 0
           self.headers['Content-Length'] = content.length
         elsif self.transfer_chunked == true
           if self.proto != '1.1'


### PR DESCRIPTION
Noted by @sempervictus Metasploit currently adds a content-length header by default even if there is no content. This makes the header conditional on bytes being in the content in the first place.

