### PR TITLE
Add some files to the test that are not likely to be open

### DIFF
--- a/test/modules/post/test/file.rb
+++ b/test/modules/post/test/file.rb
@@ -51,7 +51,9 @@ class MetasploitModule < Msf::Post
         "c:\\boot.ini",
         "c:\\pagefile.sys",
         "/etc/passwd",
-        "/etc/master.passwd"
+        "/etc/master.passwd",
+        "%WINDIR%\\system32\\notepad.exe",
+        "%WINDIR%\\system32\\calc.exe"
       ].each { |path|
         ret = true if file?(path)
       }


### PR DESCRIPTION
Fixes https://github.com/rapid7/metasploit-framework/issues/11939
before:
```
meterpreter > sysinfo
Computer        : WIN7X64SP1
OS              : Windows 7 (Build 7601, Service Pack 1).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x64/windows
meterpreter > background
[*] Backgrounding session 1...
msf5 exploit(windows/smb/psexec) > loadpath test/modules
Loaded 35 modules:
    12 auxiliary modules
    13 exploit modules
    10 post modules
msf5 exploit(windows/smb/psexec) > use post/test/file 
msf5 post(test/file) > set verbose true
verbose => true
msf5 post(test/file) > set session 1
session => 1
msf5 post(test/file) > run

[*] Setup: changing working directory to %TEMP%
[*] Running against session 1
[*] Session type is meterpreter and platform is windows
[-] FAILED: should test for file existence
[+] should test for directory existence
[+] should create text files
[+] should read the text we just wrote
[+] should append text files
[+] should delete text files
[+] should move files
[*] Writing 31376 bytes
[*] Finished in 0.139495978
[+] should write binary data
[*] Read 31376 bytes
[+] should read the binary data we just wrote
[+] should delete binary files
[+] should append binary data
[*] Testing complete in 4.032549755
[-] Passed: 10; Failed: 1
[*] Cleanup: changing working directory back to C:\Windows\system32
[*] Post module execution completed

```
After:
```
msf5 post(test/file) > run

[*] Setup: changing working directory to %TEMP%
[*] Running against session 1
[*] Session type is meterpreter and platform is windows
[+] should test for file existence
[+] should test for directory existence
[+] should create text files
[+] should read the text we just wrote
[+] should append text files
[+] should delete text files
[+] should move files
[*] Writing 31376 bytes
[*] Finished in 0.155434275
[+] should write binary data
[*] Read 31376 bytes
[+] should read the binary data we just wrote
[+] should delete binary files
[+] should append binary data
[*] Testing complete in 4.170884782
[*] Passed: 11; Failed: 0
[*] Cleanup: changing working directory back to C:\Windows\system32
[*] Post module execution completed
```
