### PR TITLE
Make auto_cl more selective based on HTTP method

### DIFF
--- a/lib/rex/proto/http/packet.rb
+++ b/lib/rex/proto/http/packet.rb
@@ -203,11 +203,13 @@ class Packet
       end
 
       unless ignore_chunk
-        if (self.auto_cl == true && self.transfer_chunked == true)
+        if self.auto_cl && self.transfer_chunked
           raise RuntimeError, "'Content-Length' and 'Transfer-Encoding: chunked' are incompatible"
-        elsif self.auto_cl == true && content.length > 0
+        end
+
+        if self.auto_cl
           self.headers['Content-Length'] = content.length
-        elsif self.transfer_chunked == true
+        elsif self.transfer_chunked
           if self.proto != '1.1'
             raise RuntimeError, 'Chunked encoding is only available via 1.1'
           end

--- a/lib/rex/proto/http/request.rb
+++ b/lib/rex/proto/http/request.rb
@@ -63,6 +63,10 @@ class Request < Packet
     self.chunk_max_size = 10
     self.uri_encode_mode = 'hex-normal'
 
+    if self.method == 'GET' || self.method == 'CONNECT'
+      self.auto_cl = false
+    end
+
     update_uri_parts
   end
 


### PR DESCRIPTION
According to https://tools.ietf.org/html/rfc7230#section-3.3.2, a zero content-length is valid for some kinds of HTTP methods.

Instead of implicitly disabling auto_cl if there is no actual content, only disable auto_cl default for HTTP methods where semantics of the message do not anticipate any content. This can still be overridden by a caller if it still wants to add an empty content-length for HTTP methods where it does not normally make sense (e.g. if it exploits a bug.)

Based on comments from #11937. @sempervictus does this look more in line with what you're thinking? There is not a way in packet.rb to disable auto_cl based on method because that is only defined in the child class.

Update: Looks like the first required use of 0-byte Content-Length required is in Meterpreter itself. This patch also fixes a regression in reverse_http/s transports which use it.

## Verification steps

 - [x] Establish a Windows Meterpreter reverse_http/s session
 - [x] **Verify** that the session stages correctly and is interactive