### PR TITLE
Expose remote data service errors to the msfconsole user

### DIFF
--- a/lib/metasploit/framework/data_service/remote/http/core.rb
+++ b/lib/metasploit/framework/data_service/remote/http/core.rb
@@ -181,14 +181,16 @@ class RemoteHTTPDataService
           return SuccessResponse.new(response)
         else
           ilog "HTTP #{request_type} request: #{uri.request_uri} failed with code: #{response.code} message: #{response.body}"
-          return FailedResponse.new(response)
+          return ErrorResponse.new(response)
       end
     rescue EOFError => e
-      elog "No data was returned from the data service for request type/path : #{request_type}/#{path}, message: #{e.message}"
-      return FailedResponse.new('')
+      error_msg = "No data was returned from the data service for request type/path : #{request_type}/#{path}, message: #{e.message}"
+      ilog error_msg
+      return FailedResponse.new(error_msg)
     rescue => e
-      elog "Problem with HTTP request for type/path: #{request_type}/#{path} message: #{e.message}"
-      return FailedResponse.new('')
+      error_msg = "Problem with HTTP request for type/path: #{request_type}/#{path} message: #{e.message}"
+      ilog error_msg
+      return FailedResponse.new(error_msg)
     ensure
       @client_pool << client
     end

--- a/lib/metasploit/framework/data_service/remote/http/core.rb
+++ b/lib/metasploit/framework/data_service/remote/http/core.rb
@@ -205,9 +205,14 @@ class RemoteHTTPDataService
   # for the Metasploit version number from the remote endpoint
   #
   def is_online?
-    response = self.get_msf_version
-    if response && !response[:metasploit_version].empty?
-      return true
+    begin
+      response = self.get_msf_version
+      if response && !response[:metasploit_version].empty?
+        return true
+      end
+    rescue
+      # Ignore exceptions that are raised when checking the version,
+      # and assume the server is not online.
     end
 
     return false

--- a/lib/metasploit/framework/data_service/remote/http/core.rb
+++ b/lib/metasploit/framework/data_service/remote/http/core.rb
@@ -236,20 +236,52 @@ class RemoteHTTPDataService
   #
   class ResponseWrapper
     attr_reader :response
-    attr_reader :expected
 
-    def initialize(response, expected)
+    def initialize(response)
       @response = response
-      @expected = expected
+    end
+
+    def response_body
+      if @response
+        @response.body
+      else
+        nil
+      end
+    end
+
+    def to_s
+      if @response
+        @response.to_s
+      else
+        ''
+      end
+    end
+  end
+
+  #
+  # Error response wrapper
+  # There is a response object, however, the request was unsuccessful.
+  #
+  class ErrorResponse < ResponseWrapper
+    def initialize(response)
+      super(response)
     end
   end
 
   #
   # Failed response wrapper
+  # There is no response object.
   #
-  class FailedResponse < ResponseWrapper
-    def initialize(response)
-      super(response, false)
+  class FailedResponse < ErrorResponse
+    attr_reader :error_msg
+
+    def initialize(error_msg)
+      @error_msg = error_msg
+      super(nil)
+    end
+
+    def to_s
+      return error_msg
     end
   end
 
@@ -258,7 +290,7 @@ class RemoteHTTPDataService
   #
   class SuccessResponse < ResponseWrapper
     def initialize(response)
-      super(response, true)
+      super(response)
     end
   end
 

--- a/lib/metasploit/framework/data_service/remote/http/core.rb
+++ b/lib/metasploit/framework/data_service/remote/http/core.rb
@@ -188,7 +188,7 @@ class RemoteHTTPDataService
       ilog error_msg
       return FailedResponse.new(error_msg)
     rescue => e
-      error_msg = "Problem with HTTP request for type/path: #{request_type}/#{path} message: #{e.message}"
+      error_msg = "Problem with HTTP request for type/path: #{request_type} #{path} message: #{e.message}"
       ilog error_msg
       return FailedResponse.new(error_msg)
     ensure

--- a/lib/metasploit/framework/data_service/remote/http/remote_credential_data_service.rb
+++ b/lib/metasploit/framework/data_service/remote/http/remote_credential_data_service.rb
@@ -10,7 +10,7 @@ module RemoteCredentialDataService
   def creds(opts = {})
     path = get_path_select(opts, CREDENTIAL_API_PATH)
     data = self.get_data(path, nil, opts)
-    rv = json_to_mdm_object(data, CREDENTIAL_MDM_CLASS, [])
+    rv = json_to_mdm_object(data, CREDENTIAL_MDM_CLASS)
     parsed_body = JSON.parse(data.response.body, symbolize_names: true)
     data = parsed_body[:data]
     data.each do |cred|
@@ -31,14 +31,14 @@ module RemoteCredentialDataService
   end
 
   def create_credential(opts)
-    json_to_mdm_object(self.post_data(CREDENTIAL_API_PATH, opts), CREDENTIAL_MDM_CLASS, []).first
+    json_to_mdm_object(self.post_data(CREDENTIAL_API_PATH, opts), CREDENTIAL_MDM_CLASS).first
   end
 
   def update_credential(opts)
-    json_to_mdm_object(self.put_data(CREDENTIAL_API_PATH, opts), CREDENTIAL_MDM_CLASS, []).first
+    json_to_mdm_object(self.put_data(CREDENTIAL_API_PATH, opts), CREDENTIAL_MDM_CLASS).first
   end
 
   def delete_credentials(opts)
-    json_to_mdm_object(self.delete_data(CREDENTIAL_API_PATH, opts), CREDENTIAL_MDM_CLASS, [])
+    json_to_mdm_object(self.delete_data(CREDENTIAL_API_PATH, opts), CREDENTIAL_MDM_CLASS)
   end
 end

--- a/lib/metasploit/framework/data_service/remote/http/remote_event_data_service.rb
+++ b/lib/metasploit/framework/data_service/remote/http/remote_event_data_service.rb
@@ -8,7 +8,7 @@ module RemoteEventDataService
 
   def events(opts)
     path = get_path_select(opts, EVENT_API_PATH)
-    json_to_mdm_object(self.get_data(path, nil, opts), EVENT_MDM_CLASS, [])
+    json_to_mdm_object(self.get_data(path, nil, opts), EVENT_MDM_CLASS)
   end
 
   def report_event(opts)

--- a/lib/metasploit/framework/data_service/remote/http/remote_host_data_service.rb
+++ b/lib/metasploit/framework/data_service/remote/http/remote_host_data_service.rb
@@ -9,15 +9,15 @@ module RemoteHostDataService
 
   def hosts(opts)
     path = get_path_select(opts, HOST_API_PATH)
-    json_to_mdm_object(self.get_data(path, nil, opts), HOST_MDM_CLASS, [])
+    json_to_mdm_object(self.get_data(path, nil, opts), HOST_MDM_CLASS)
   end
 
   def get_host(opts)
-    json_to_mdm_object(self.post_data(HOST_SEARCH_PATH, opts), HOST_MDM_CLASS, []).first
+    json_to_mdm_object(self.post_data(HOST_SEARCH_PATH, opts), HOST_MDM_CLASS).first
   end
 
   def report_host(opts)
-    json_to_mdm_object(self.post_data(HOST_API_PATH, opts), HOST_MDM_CLASS, []).first
+    json_to_mdm_object(self.post_data(HOST_API_PATH, opts), HOST_MDM_CLASS).first
   end
 
   def update_host(opts)
@@ -26,10 +26,10 @@ module RemoteHostDataService
       id = opts.delete(:id)
       path = "#{HOST_API_PATH}/#{id}"
     end
-    json_to_mdm_object(self.put_data(path, opts), HOST_MDM_CLASS, [])
+    json_to_mdm_object(self.put_data(path, opts), HOST_MDM_CLASS)
   end
 
   def delete_host(opts)
-    json_to_mdm_object(self.delete_data(HOST_API_PATH, opts), HOST_MDM_CLASS, [])
+    json_to_mdm_object(self.delete_data(HOST_API_PATH, opts), HOST_MDM_CLASS)
   end
 end

--- a/lib/metasploit/framework/data_service/remote/http/remote_login_data_service.rb
+++ b/lib/metasploit/framework/data_service/remote/http/remote_login_data_service.rb
@@ -9,11 +9,11 @@ module RemoteLoginDataService
 
   def logins(opts)
     path = get_path_select(opts, LOGIN_API_PATH)
-    json_to_mdm_object(self.get_data(path, nil, opts), LOGIN_MDM_CLASS, [])
+    json_to_mdm_object(self.get_data(path, nil, opts), LOGIN_MDM_CLASS)
   end
 
   def create_credential_login(opts)
-    json_to_mdm_object(self.post_data(LOGIN_API_PATH, opts), LOGIN_MDM_CLASS, []).first
+    json_to_mdm_object(self.post_data(LOGIN_API_PATH, opts), LOGIN_MDM_CLASS).first
   end
 
   def update_login(opts)
@@ -22,6 +22,6 @@ module RemoteLoginDataService
       id = opts.delete(:id)
       path = "#{LOGIN_API_PATH}/#{id}"
     end
-    json_to_mdm_object(self.put_data(path, opts), LOGIN_MDM_CLASS, []).first
+    json_to_mdm_object(self.put_data(path, opts), LOGIN_MDM_CLASS).first
   end
 end

--- a/lib/metasploit/framework/data_service/remote/http/remote_loot_data_service.rb
+++ b/lib/metasploit/framework/data_service/remote/http/remote_loot_data_service.rb
@@ -9,7 +9,7 @@ module RemoteLootDataService
   def loot(opts = {})
     path = get_path_select(opts, LOOT_API_PATH)
     data = self.get_data(path, nil, opts)
-    rv = json_to_mdm_object(data, LOOT_MDM_CLASS, [])
+    rv = json_to_mdm_object(data, LOOT_MDM_CLASS)
     parsed_body = JSON.parse(data.response.body, symbolize_names: true)
     data = parsed_body[:data]
     data.each do |loot|
@@ -36,10 +36,10 @@ module RemoteLootDataService
       id = opts.delete(:id)
       path = "#{LOOT_API_PATH}/#{id}"
     end
-    json_to_mdm_object(self.put_data(path, opts), LOOT_MDM_CLASS, [])
+    json_to_mdm_object(self.put_data(path, opts), LOOT_MDM_CLASS)
   end
 
   def delete_loot(opts)
-    json_to_mdm_object(self.delete_data(LOOT_API_PATH, opts), LOOT_MDM_CLASS, [])
+    json_to_mdm_object(self.delete_data(LOOT_API_PATH, opts), LOOT_MDM_CLASS)
   end
 end

--- a/lib/metasploit/framework/data_service/remote/http/remote_note_data_service.rb
+++ b/lib/metasploit/framework/data_service/remote/http/remote_note_data_service.rb
@@ -8,11 +8,11 @@ module RemoteNoteDataService
 
   def notes(opts)
     path = get_path_select(opts, NOTE_API_PATH)
-    json_to_mdm_object(self.get_data(path, nil, opts), NOTE_MDM_CLASS, [])
+    json_to_mdm_object(self.get_data(path, nil, opts), NOTE_MDM_CLASS)
   end
 
   def report_note(opts)
-    json_to_mdm_object(self.post_data(NOTE_API_PATH, opts), NOTE_MDM_CLASS, []).first
+    json_to_mdm_object(self.post_data(NOTE_API_PATH, opts), NOTE_MDM_CLASS).first
   end
 
   def update_note(opts)
@@ -21,10 +21,10 @@ module RemoteNoteDataService
       id = opts.delete(:id)
       path = "#{NOTE_API_PATH}/#{id}"
     end
-    json_to_mdm_object(self.put_data(path, opts), NOTE_MDM_CLASS, [])
+    json_to_mdm_object(self.put_data(path, opts), NOTE_MDM_CLASS)
   end
 
   def delete_note(opts)
-    json_to_mdm_object(self.delete_data(NOTE_API_PATH, opts), NOTE_MDM_CLASS, [])
+    json_to_mdm_object(self.delete_data(NOTE_API_PATH, opts), NOTE_MDM_CLASS)
   end
 end

--- a/lib/metasploit/framework/data_service/remote/http/remote_payload_data_service.rb
+++ b/lib/metasploit/framework/data_service/remote/http/remote_payload_data_service.rb
@@ -8,11 +8,11 @@ module RemotePayloadDataService
 
   def payloads(opts)
     path = get_path_select(opts, PAYLOAD_API_PATH)
-    json_to_mdm_object(self.get_data(path, nil, opts), PAYLOAD_MDM_CLASS, [])
+    json_to_mdm_object(self.get_data(path, nil, opts), PAYLOAD_MDM_CLASS)
   end
 
   def create_payload(opts)
-    json_to_mdm_object(self.post_data(PAYLOAD_API_PATH, opts), PAYLOAD_MDM_CLASS, []).first
+    json_to_mdm_object(self.post_data(PAYLOAD_API_PATH, opts), PAYLOAD_MDM_CLASS).first
   end
 
   def update_payload(opts)
@@ -21,10 +21,10 @@ module RemotePayloadDataService
       id = opts.delete(:id)
       path = "#{PAYLOAD_API_PATH}/#{id}"
     end
-    json_to_mdm_object(self.put_data(path, opts), PAYLOAD_MDM_CLASS, [])
+    json_to_mdm_object(self.put_data(path, opts), PAYLOAD_MDM_CLASS)
   end
 
   def delete_payload(opts)
-    json_to_mdm_object(self.delete_data(PAYLOAD_API_PATH, opts), PAYLOAD_MDM_CLASS, [])
+    json_to_mdm_object(self.delete_data(PAYLOAD_API_PATH, opts), PAYLOAD_MDM_CLASS)
   end
 end

--- a/lib/metasploit/framework/data_service/remote/http/remote_service_data_service.rb
+++ b/lib/metasploit/framework/data_service/remote/http/remote_service_data_service.rb
@@ -4,7 +4,7 @@ module RemoteServiceDataService
 
   def services(opts)
     path = get_path_select(opts, SERVICE_API_PATH)
-    json_to_mdm_object(self.get_data(path, nil, opts), SERVICE_MDM_CLASS, [])
+    json_to_mdm_object(self.get_data(path, nil, opts), SERVICE_MDM_CLASS)
   end
 
   def report_service(opts)

--- a/lib/metasploit/framework/data_service/remote/http/remote_session_data_service.rb
+++ b/lib/metasploit/framework/data_service/remote/http/remote_session_data_service.rb
@@ -8,7 +8,7 @@ module RemoteSessionDataService
 
   def sessions(opts)
     path = get_path_select(opts, SESSION_API_PATH)
-    json_to_mdm_object(self.get_data(path, nil, opts), SESSION_MDM_CLASS, [])
+    json_to_mdm_object(self.get_data(path, nil, opts), SESSION_MDM_CLASS)
   end
 
   def report_session(opts)
@@ -20,7 +20,7 @@ module RemoteSessionDataService
     end
 
     opts[:time_stamp] = Time.now.utc
-    sess_db = json_to_mdm_object(self.post_data(SESSION_API_PATH, opts), SESSION_MDM_CLASS, []).first
+    sess_db = json_to_mdm_object(self.post_data(SESSION_API_PATH, opts), SESSION_MDM_CLASS).first
     session.db_record = sess_db
   end
 
@@ -31,7 +31,7 @@ module RemoteSessionDataService
       path = "#{SESSION_API_PATH}/#{id}"
     end
 
-    json_to_mdm_object(self.put_data(path, opts), SESSION_MDM_CLASS, []).first
+    json_to_mdm_object(self.put_data(path, opts), SESSION_MDM_CLASS).first
   end
 
 end

--- a/lib/metasploit/framework/data_service/remote/http/remote_session_event_data_service.rb
+++ b/lib/metasploit/framework/data_service/remote/http/remote_session_event_data_service.rb
@@ -8,7 +8,7 @@ module RemoteSessionEventDataService
 
   def session_events(opts)
     path = get_path_select(opts, SESSION_EVENT_API_PATH)
-    json_to_mdm_object(self.get_data(path, nil, opts), SESSION_EVENT_MDM_CLASS, [])
+    json_to_mdm_object(self.get_data(path, nil, opts), SESSION_EVENT_MDM_CLASS)
   end
 
   def report_session_event(opts)

--- a/lib/metasploit/framework/data_service/remote/http/remote_vuln_attempt_data_service.rb
+++ b/lib/metasploit/framework/data_service/remote/http/remote_vuln_attempt_data_service.rb
@@ -8,11 +8,11 @@ module RemoteVulnAttemptDataService
 
   def vuln_attempts(opts)
     path = get_path_select(opts, VULN_ATTEMPT_API_PATH)
-    json_to_mdm_object(self.get_data(path, nil, opts), VULN_ATTEMPT_MDM_CLASS, [])
+    json_to_mdm_object(self.get_data(path, nil, opts), VULN_ATTEMPT_MDM_CLASS)
   end
 
   def report_vuln_attempt(vuln, opts)
     opts[:vuln_id] = vuln.id
-    json_to_mdm_object(self.post_data(VULN_ATTEMPT_API_PATH, opts), VULN_ATTEMPT_MDM_CLASS, []).first
+    json_to_mdm_object(self.post_data(VULN_ATTEMPT_API_PATH, opts), VULN_ATTEMPT_MDM_CLASS).first
   end
 end

--- a/lib/metasploit/framework/data_service/remote/http/remote_vuln_data_service.rb
+++ b/lib/metasploit/framework/data_service/remote/http/remote_vuln_data_service.rb
@@ -8,11 +8,11 @@ module RemoteVulnDataService
 
   def vulns(opts)
     path = get_path_select(opts, VULN_API_PATH)
-    json_to_mdm_object(self.get_data(path, nil, opts), VULN_MDM_CLASS, [])
+    json_to_mdm_object(self.get_data(path, nil, opts), VULN_MDM_CLASS)
   end
 
   def report_vuln(opts)
-    json_to_mdm_object(self.post_data(VULN_API_PATH, opts), VULN_MDM_CLASS, []).first
+    json_to_mdm_object(self.post_data(VULN_API_PATH, opts), VULN_MDM_CLASS).first
   end
 
   def update_vuln(opts)
@@ -21,10 +21,10 @@ module RemoteVulnDataService
       id = opts.delete(:id)
       path = "#{VULN_API_PATH}/#{id}"
     end
-    json_to_mdm_object(self.put_data(path, opts), VULN_MDM_CLASS, [])
+    json_to_mdm_object(self.put_data(path, opts), VULN_MDM_CLASS)
   end
 
   def delete_vuln(opts)
-    json_to_mdm_object(self.delete_data(VULN_API_PATH, opts), VULN_MDM_CLASS, [])
+    json_to_mdm_object(self.delete_data(VULN_API_PATH, opts), VULN_MDM_CLASS)
   end
 end

--- a/lib/metasploit/framework/data_service/remote/http/remote_workspace_data_service.rb
+++ b/lib/metasploit/framework/data_service/remote/http/remote_workspace_data_service.rb
@@ -8,11 +8,11 @@ module RemoteWorkspaceDataService
 
   def add_workspace(opts)
     response = self.post_data(WORKSPACE_API_PATH, opts)
-    json_to_mdm_object(response, WORKSPACE_MDM_CLASS, nil).first
+    json_to_mdm_object(response, WORKSPACE_MDM_CLASS).first
   end
 
   def default_workspace
-    json_to_mdm_object(self.get_data(WORKSPACE_API_PATH, nil, { name: Msf::DBManager::Workspace::DEFAULT_WORKSPACE_NAME }), WORKSPACE_MDM_CLASS, [])
+    json_to_mdm_object(self.get_data(WORKSPACE_API_PATH, nil, { name: Msf::DBManager::Workspace::DEFAULT_WORKSPACE_NAME }), WORKSPACE_MDM_CLASS)
   end
 
   def workspace
@@ -31,11 +31,11 @@ module RemoteWorkspaceDataService
 
   def workspaces(opts)
     path = get_path_select(opts, WORKSPACE_API_PATH)
-    json_to_mdm_object(self.get_data(path, nil, opts), WORKSPACE_MDM_CLASS, [])
+    json_to_mdm_object(self.get_data(path, nil, opts), WORKSPACE_MDM_CLASS)
   end
 
   def delete_workspaces(opts)
-    json_to_mdm_object(self.delete_data(WORKSPACE_API_PATH, opts), WORKSPACE_MDM_CLASS, [])
+    json_to_mdm_object(self.delete_data(WORKSPACE_API_PATH, opts), WORKSPACE_MDM_CLASS)
   end
 
   def update_workspace(opts)
@@ -44,7 +44,7 @@ module RemoteWorkspaceDataService
       id = opts.delete(:id)
       path = "#{WORKSPACE_API_PATH}/#{id}"
     end
-    json_to_mdm_object(self.put_data(path, opts), WORKSPACE_MDM_CLASS, []).first
+    json_to_mdm_object(self.put_data(path, opts), WORKSPACE_MDM_CLASS).first
   end
 
 end

--- a/lib/metasploit/framework/data_service/remote/http/response_data_helper.rb
+++ b/lib/metasploit/framework/data_service/remote/http/response_data_helper.rb
@@ -4,66 +4,66 @@ require 'digest'
 # HTTP response helper class
 #
 module ResponseDataHelper
-
-
-  def process_response(response_wrapper)
-    begin
-      if response_wrapper.expected
-        response_wrapper.response.body
-      end
-    rescue => e
-      elog "Error processing response: #{e.message}"
-      e.backtrace.each { |line| elog line }
-    end
-  end
-
   #
   # Converts an HTTP response to a Hash
   #
-  # @param [ResponseWrapper] A wrapped HTTP response containing a JSON body.
+  # @param response_wrapper [ResponseWrapper] A wrapped HTTP response containing a JSON body.
   # @return [Hash] A Hash interpretation of the JSON body.
-  #
+  # @raise [RuntimeError] response_wrapper is a Metasploit::Framework::DataService::RemoteHTTPDataService::ErrorResponse
+  # @raise [RuntimeError] response_wrapper is a Metasploit::Framework::DataService::RemoteHTTPDataService::FailedResponse
+  # @raise [RuntimeError] response_wrapper contains an empty response
   def json_to_hash(response_wrapper)
-    begin
-      body = process_response(response_wrapper)
-      if !body.nil? && !body.empty?
-        parsed_body = JSON.parse(body, symbolize_names: true)
-        return parsed_body[:data]
+    body = response_wrapper.response_body
+    if !body.nil? && !body.empty?
+      parsed_body = JSON.parse(body, symbolize_names: true)
+
+      if response_wrapper.is_a?(Metasploit::Framework::DataService::RemoteHTTPDataService::SuccessResponse)
+        parsed_body[:data]
+      elsif response_wrapper.is_a?(Metasploit::Framework::DataService::RemoteHTTPDataService::ErrorResponse)
+        # raise a local exception with the message of the server-side error
+        raise parsed_body[:error][:message]
       end
-    rescue => e
-      elog "Error parsing response as JSON: #{e.message}"
-      e.backtrace.each { |line| elog line }
+    elsif response_wrapper.is_a?(Metasploit::Framework::DataService::RemoteHTTPDataService::FailedResponse)
+      raise response_wrapper.to_s
+    else
+      raise 'empty response'
     end
   end
 
   #
   # Converts an HTTP response to an Mdm Object
   #
-  # @param [ResponseWrapper] A wrapped HTTP response containing a JSON body.
-  # @param [String] The Mdm class to convert the JSON to.
-  # @param [Anything] A failsafe response to return if no objects are found.
+  # @param response_wrapper [ResponseWrapper] A wrapped HTTP response containing a JSON body.
+  # @param mdm_class [String] The Mdm class name the JSON will be converted to.
   # @return [ActiveRecord::Base] An object of type mdm_class, which inherits from ActiveRecord::Base
-  #
-  def json_to_mdm_object(response_wrapper, mdm_class, returns_on_error = nil)
-    if response_wrapper.expected
-      begin
-        body = process_response(response_wrapper)
-        if !body.nil? && !body.empty?
-          parsed_body = JSON.parse(body, symbolize_names: true)
+  # @raise [RuntimeError] response_wrapper is a Metasploit::Framework::DataService::RemoteHTTPDataService::ErrorResponse
+  # @raise [RuntimeError] response_wrapper is a Metasploit::Framework::DataService::RemoteHTTPDataService::FailedResponse
+  # @raise [RuntimeError] response_wrapper contains an empty response
+  def json_to_mdm_object(response_wrapper, mdm_class)
+    body = response_wrapper.response_body
+    if !body.nil? && !body.empty?
+      parsed_body = JSON.parse(body, symbolize_names: true)
+
+      if response_wrapper.is_a?(Metasploit::Framework::DataService::RemoteHTTPDataService::SuccessResponse)
+        begin
           data = Array.wrap(parsed_body[:data])
           rv = []
           data.each do |json_object|
             rv << to_ar(mdm_class.constantize, json_object)
           end
           return rv
+        rescue => e
+          raise "Mdm Object conversion failed #{e.message}"
         end
-      rescue => e
-        elog "Mdm Object conversion failed #{e.message}"
-        e.backtrace.each { |line| elog "#{line}" }
+      elsif response_wrapper.is_a?(Metasploit::Framework::DataService::RemoteHTTPDataService::ErrorResponse)
+        # raise a local exception with the message of the server-side error
+        raise parsed_body[:error][:message]
       end
+    elsif response_wrapper.is_a?(Metasploit::Framework::DataService::RemoteHTTPDataService::FailedResponse)
+      raise response_wrapper.to_s
+    else
+      raise 'empty response'
     end
-
-    return returns_on_error
   end
 
   # Processes a Base64 encoded file included in a JSON request.


### PR DESCRIPTION
This changes the remote data service response handling to raise exceptions for error responses rather than failing silently. The changes expose the server-side error message to the user in console. The stack trace will start from the `json_to_mdm_object` or `json_to_hash` methods. The message will be from the server-side exception message if the response was an error response (non-200); otherwise, the message will be information about the local request or response issue.

### Example

In the following example I temporarily introduce an exception into the `HostServlet#get_host` method by adding the line `raise 'testing'`.

```
def self.get_host
    lambda {
      warden.authenticate!
      begin
        raise 'testing'
        sanitized_params = sanitize_params(params, env['rack.request.query_hash'])
        data = get_db.hosts(sanitized_params)
        data = data.first if is_single_object?(data, sanitized_params)
        set_json_data_response(response: data)
      rescue => e
        print_error_and_create_response(error: e, message: 'There was an error retrieving hosts:', code: 500)
      end
    }
  end
```

#### master branch test
##### Console output:
Note the silent failure from the console user's perspective.
```
msf5 > db_status 
[*] Connected to remote_data_service: (https://localhost:5443). Connection type: http. Connection name: local-https-data-service.
msf5 > hosts

Hosts
=====

address  mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------  ---  ----  -------  ---------  -----  -------  ----  --------

msf5 > 
```

##### ~/.msf4/logs/msf-ws.log:
```
[1m[31m[-][0m Error handling request: testing.
    Call Stack:
     /home/msfdev/metasploit-framework/lib/msf/core/web_services/servlet/host_servlet.rb:31:in `block in get_host'
     ...
     /home/msfdev/.rbenv/versions/2.6.2/bin/thin:23:in `<main>'
```


#### PR branch test
##### Console output:
```
msf5 > db_status 
[*] Connected to remote_data_service: (https://localhost:5443). Connection type: http. Connection name: local-https-data-service.
msf5 > hosts
[-] Error while running command hosts: There was an error retrieving hosts: testing

Call stack:
/home/msfdev/metasploit-framework/lib/metasploit/framework/data_service/remote/http/response_data_helper.rb:60:in `json_to_mdm_object'
/home/msfdev/metasploit-framework/lib/metasploit/framework/data_service/remote/http/remote_host_data_service.rb:12:in `hosts'
/home/msfdev/metasploit-framework/lib/metasploit/framework/data_service/proxy/host_data_proxy.rb:10:in `block in hosts'
/home/msfdev/metasploit-framework/lib/metasploit/framework/data_service/proxy/core.rb:166:in `data_service_operation'
/home/msfdev/metasploit-framework/lib/metasploit/framework/data_service/proxy/host_data_proxy.rb:5:in `hosts'
/home/msfdev/metasploit-framework/lib/msf/ui/console/command_dispatcher/db.rb:552:in `block in cmd_hosts'
/home/msfdev/metasploit-framework/lib/msf/ui/console/command_dispatcher/db.rb:2146:in `block in each_host_range_chunk'
/home/msfdev/metasploit-framework/lib/msf/ui/console/command_dispatcher/db.rb:2127:in `each'
/home/msfdev/metasploit-framework/lib/msf/ui/console/command_dispatcher/db.rb:2127:in `each_host_range_chunk'
/home/msfdev/metasploit-framework/lib/msf/ui/console/command_dispatcher/db.rb:549:in `cmd_hosts'
/home/msfdev/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:523:in `run_command'
/home/msfdev/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:474:in `block in run_single'
/home/msfdev/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:468:in `each'
/home/msfdev/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:468:in `run_single'
/home/msfdev/metasploit-framework/lib/rex/ui/text/shell.rb:151:in `run'
/home/msfdev/metasploit-framework/lib/metasploit/framework/command/console.rb:48:in `start'
/home/msfdev/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'
./msfconsole:49:in `<main>'
```

##### ~/.msf4/logs/msf-ws.log:
```
[1m[31m[-][0m Error handling request: testing.
    Call Stack:
     /home/msfdev/rapid7/metasploit-framework/lib/msf/core/web_services/servlet/host_servlet.rb:31:in `block in get_host'
     ...
     /home/msfdev/.rbenv/versions/2.6.2/bin/thin:23:in `<main>'

```

## Verification

- [x] Restart the database and MSF web service (data services) using `msfdb restart`, or `init`/`reinit` if necessary.
- [x] Start `msfconsole`
- [x] **Verify** `db_status` reports an HTTP connection type
- [x] Perform various data operations (`hosts`, `services`, `vulns`, `creds`, `loots`, `notes`)
- [x] **Verify** data operations operate as expected
- [x] Exit `msfconsole`
- [x] Temporarily introduce exceptions into the `lib/msf/core/web_services/servlet/*` servlet methods. For example, edit `lib/msf/core/web_services/servlet/host_servlet.rb` and add the following after the `begin` statement in the `get_host` method:
```
raise 'testing'
```
- [x] Restart the database and MSF web service (data services) using `msfdb restart`
- [x] Start `msfconsole`
- [x] **Verify** An error message and stack trace appears on the console when the `hosts` command is run
- [x] Repeat for servlet endpoints and commands