### PR TITLE
wordpress_content_injection: fix CVE number

### DIFF
--- a/modules/auxiliary/scanner/http/wordpress_content_injection.rb
+++ b/modules/auxiliary/scanner/http/wordpress_content_injection.rb
@@ -19,7 +19,7 @@ class MetasploitModule < Msf::Auxiliary
         'wvu'           # Metasploit module
       ],
       'References'     => [
-        ['CVE' , '2017-5612'],
+        ['CVE' , '2017-1001000'],
         ['WPVDB', '8734'],
         ['URL',   'https://blog.sucuri.net/2017/02/content-injection-vulnerability-wordpress-rest-api.html'],
         ['URL',   'https://secure.php.net/manual/en/language.types.type-juggling.php'],


### PR DESCRIPTION
The current CVE 2017-5612 is not the correct one, see: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-5612

Instead, it should be 2017-1001000: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-1001000