### PR TITLE
Add meterpreter > screenshare command for real time desktop monitoring

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi.rb
@@ -16,6 +16,7 @@ class Console::CommandDispatcher::Stdapi
   require 'rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs'
   require 'rex/post/meterpreter/ui/console/command_dispatcher/stdapi/net'
   require 'rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys'
+  require 'rex/post/meterpreter/ui/console/command_dispatcher/stdapi/stream'
   require 'rex/post/meterpreter/ui/console/command_dispatcher/stdapi/ui'
   require 'rex/post/meterpreter/ui/console/command_dispatcher/stdapi/webcam'
   require 'rex/post/meterpreter/ui/console/command_dispatcher/stdapi/mic'

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/stream.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/stream.rb
@@ -1,0 +1,65 @@
+# -*- coding: binary -*-
+require 'rex/post/meterpreter'
+
+module Rex
+module Post
+module Meterpreter
+module Ui
+
+module Console::CommandDispatcher::Stdapi::Stream
+
+  def stream_html_template(name, host, stream_path)
+    html = %|<html>
+<head>
+<META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
+<META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
+<title>Metasploit #{name} - #{host}</title>
+<script language="javascript">
+function updateStatus(msg) {
+  var status = document.getElementById("status");
+  status.innerText = msg;
+}
+
+function noImage() {
+  document.getElementById("streamer").style = "display:none";
+  updateStatus("Waiting");
+}
+
+var i = 0;
+function updateFrame() {
+  var img = document.getElementById("streamer");
+  img.src = "#{stream_path}#" + i;
+  img.style = "display:";
+  updateStatus("Playing");
+  i++;
+}
+
+setInterval(function() {
+  updateFrame();
+},25);
+
+</script>
+</head>
+<body>
+<noscript>
+  <h2><font color="red">Error: You need Javascript enabled to watch the stream.</font></h2>
+</noscript>
+<pre>
+Target IP  : #{host}
+Start time : #{Time.now}
+Status     : <span id="status"></span>
+</pre>
+<br>
+<img onerror="noImage()" id="streamer">
+<br><br>
+<a href="http://www.metasploit.com" target="_blank">www.metasploit.com</a>
+</body>
+</html>
+    |
+    html
+  end
+end
+end
+end
+end
+end

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/webcam.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/webcam.rb
@@ -15,6 +15,7 @@ class Console::CommandDispatcher::Stdapi::Webcam
   Klass = Console::CommandDispatcher::Stdapi::Webcam
 
   include Console::CommandDispatcher
+  include Console::CommandDispatcher::Stdapi::Stream
 
   #
   # List of supported commands.
@@ -197,61 +198,14 @@ class Console::CommandDispatcher::Stdapi::Webcam
     end
 
     print_status("Preparing player...")
-    html = %|<html>
-<head>
-<META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
-<META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
-<title>Metasploit webcam_stream - #{client.sock.peerhost}</title>
-<script language="javascript">
-function updateStatus(msg) {
-  var status = document.getElementById("status");
-  status.innerText = msg;
-}
-
-function noImage() {
-  document.getElementById("streamer").style = "display:none";
-  updateStatus("Waiting");
-}
-
-var i = 0;
-function updateFrame() {
-  var img = document.getElementById("streamer");
-  img.src = "#{stream_path}#" + i;
-  img.style = "display:";
-  updateStatus("Playing");
-  i++;
-}
-
-setInterval(function() {
-  updateFrame();
-},25);
-
-</script>
-</head>
-<body>
-<noscript>
-  <h2><font color="red">Error: You need Javascript enabled to watch the stream.</font></h2>
-</noscript>
-<pre>
-Target IP  : #{client.sock.peerhost}
-Start time : #{Time.now}
-Status     : <span id="status"></span>
-</pre>
-<br>
-<img onerror="noImage()" id="streamer">
-<br><br>
-<a href="http://www.metasploit.com" target="_blank">www.metasploit.com</a>
-</body>
-</html>
-    |
-
+    html = stream_html_template('screenshare', client.sock.peerhost, stream_path)
     ::File.open(player_path, 'wb') do |f|
       f.write(html)
     end
     path = ::File.expand_path(player_path)
     if view
       print_status("Opening player at: #{path}")
-      Rex::Compat.open_file(player_path)
+      Rex::Compat.open_file(path)
     else
       print_status("Please open the player manually with a browser: #{path}")
     end


### PR DESCRIPTION
This was originally added by @Jaketblank in https://github.com/rapid7/metasploit-framework/pull/9196
I've removed his modifications to the html code (maybe we can add that later).

## Verification

List the steps needed to make sure this thing works

- [x] Get a meterpreter session that supports screenshots
- [x] `meterpreter > screenshare`
- [x] **Verify** you can see the screen update real-time

