### PR TITLE
Update `retina` imports to better handle parsing

### DIFF
--- a/lib/msf/core/db_manager/import.rb
+++ b/lib/msf/core/db_manager/import.rb
@@ -407,6 +407,9 @@ module Msf::DBManager::Import
         when /ReportInfo/
           @import_filedata[:type] = "Foundstone"
           return :foundstone_xml
+        when /scanJob/
+          @import_filedata[:type] = "Retina XML"
+          return :retina_xml
         when /ScanGroup/
           @import_filedata[:type] = "Acunetix"
           return :acunetix_xml

--- a/lib/msf/core/db_manager/import/retina.rb
+++ b/lib/msf/core/db_manager/import/retina.rb
@@ -74,6 +74,13 @@ module Msf::DBManager::Import::Retina
             :task      => args[:task]
         }
 
+        if vuln['port'] && vuln['proto']
+          vuln_info.merge!({
+               :port => vuln['port'],
+               :proto => vuln['proto'].to_s.downcase
+          })
+        end
+
         report_vuln(vuln_info)
       end
     end

--- a/lib/msf/core/db_manager/import/retina.rb
+++ b/lib/msf/core/db_manager/import/retina.rb
@@ -1,3 +1,5 @@
+# -*- coding: binary -*-
+
 require 'rex/parser/retina_xml'
 
 module Msf::DBManager::Import::Retina

--- a/lib/msf/core/db_manager/import/retina.rb
+++ b/lib/msf/core/db_manager/import/retina.rb
@@ -49,13 +49,13 @@ module Msf::DBManager::Import::Retina
       # Import OS fingerprint
       if host["os"]
         note = {
-            :workspace => wspace,
-            :host      => addr,
-            :type      => 'host.os.retina_fingerprint',
-            :task      => args[:task],
-            :data      => {
-                :os => host["os"]
-            }
+          :workspace => wspace,
+          :host      => addr,
+          :type      => 'host.os.retina_fingerprint',
+          :task      => args[:task],
+          :data      => {
+            :os => host["os"]
+          }
         }
         report_note(note)
       end
@@ -66,19 +66,19 @@ module Msf::DBManager::Import::Retina
         refs << "RETINA-#{vuln['rthid']}" if vuln['rthid']
 
         vuln_info = {
-            :workspace => wspace,
-            :host      => addr,
-            :name      => vuln['name'],
-            :info      => vuln['description'],
-            :refs      => refs,
-            :task      => args[:task]
+          :workspace => wspace,
+          :host      => addr,
+          :name      => vuln['name'],
+          :info      => vuln['description'],
+          :refs      => refs,
+          :task      => args[:task]
         }
 
         if vuln['port'] && vuln['proto']
-          vuln_info.merge!({
-               :port => vuln['port'],
-               :proto => vuln['proto'].to_s.downcase
-          })
+          vuln_info.merge!(
+            :port  => vuln['port'],
+            :proto => vuln['proto'].to_s.downcase
+          )
         end
 
         report_vuln(vuln_info)

--- a/lib/msf/core/db_manager/import/retina.rb
+++ b/lib/msf/core/db_manager/import/retina.rb
@@ -6,12 +6,6 @@ module Msf::DBManager::Import::Retina
     data = args[:data]
     wspace = args[:wspace] || workspace
     bl = validate_ips(args[:blacklist]) ? args[:blacklist].split : []
-    msg =  "Warning: The Retina XML format does not associate vulnerabilities with the\n"
-    msg << "specific service on which they were found.\n"
-    msg << "This makes it impossible to correlate exploits to discovered vulnerabilities\n"
-    msg << "in a reliable fashion."
-
-    yield(:warning,msg) if block
 
     parser = Rex::Parser::RetinaXMLStreamParser.new
     parser.on_found_host = Proc.new do |host|

--- a/lib/rex/parser/retina_xml.rb
+++ b/lib/rex/parser/retina_xml.rb
@@ -26,7 +26,7 @@ class RetinaXMLStreamParser
   end
 
   def text(str)
-    return if str.strip.empty?
+    return if str.to_s.strip.empty?
 
     case @state
     when :in_ip

--- a/lib/rex/parser/retina_xml.rb
+++ b/lib/rex/parser/retina_xml.rb
@@ -1,10 +1,9 @@
 # -*- coding: binary -*-
+
 module Rex
 module Parser
-
 # XXX - Retina XML does not include ANY service/port information export
 class RetinaXMLStreamParser
-
   attr_accessor :on_found_host
 
   def initialize(on_found_host = nil)
@@ -87,7 +86,7 @@ end
 end
 end
 
-__END__
+=begin Old XML format
 <scanJob>
   <hosts>
     <host>
@@ -111,4 +110,39 @@ __END__
     </host>
   </hosts>
 </scanJob>
+=end Old XML format
 
+=begin New XML format
+<?xml version="1.0" encoding="utf-8"?>
+<scanJob>
+  <hosts>
+    <host>
+      <ip>[redacted]</ip>
+      <netBIOSName>[redacted]</netBIOSName>
+      <dnsName>[redacted]</dnsName>
+      <mac></mac>
+      <os>[redacted]</os>
+      <cpe>[redacted]</cpe>
+      <audit>
+        <cve>[redacted]</cve>
+        <cce>N/A</cce>
+        <name>TLS/SSL Weak Protocol Version Supported</name>
+        <description>A targeted service that accepts connections for cryptographically weak SSL protocol versions (eg SSLv2, SSLv3, TLSv1.0) has been detected. Such protocols are known to have cryptographic weaknesses as well as other exploitable vulnerabilities.</description>
+        <date>[redacted]</date>
+        <risk>Medium</risk>
+        <pciLevel>Medium</pciLevel>
+        <pciReason>PCI DSS 4.1 - SSL Weakness</pciReason>
+        <pciPassFail>Fail</pciPassFail>
+        <cvssScore>4.3 [AV:N/AC:M/Au:N/C:P/I:N/A:N]</cvssScore>
+        <cvssScoreV3>6.8 [AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:N/A:N]</cvssScoreV3>
+        <fixInformation>Ensure that applications or services are configured to reject SSLv3, SSLv2 and TLSv1.0 communications. Disabling weak protocols is a defense-in-depth measure against vulnerabilities that could allow SSL version downgrade attacks (e.g. CVE-2014-3566).</fixInformation>
+        <exploit>No</exploit>
+        <context>TCP:443 ([redacted]), SHA256[=][redacted], Serial[=][redacted]</context>
+        <testedValue>Accepted SSL Method: (SSLv[23]|TLSv1(\.0)?)$</testedValue>
+        <foundValue>[redacted]</foundValue>
+        <cwe>CWE-310</cwe>
+      </audit>
+    </host>
+  </hosts>
+</scanJob>
+=end New XML format

--- a/lib/rex/parser/retina_xml.rb
+++ b/lib/rex/parser/retina_xml.rb
@@ -27,6 +27,7 @@ class RetinaXMLStreamParser
   end
 
   def text(str)
+    return if str.strip.empty?()
     case @state
     when :in_ip
       @host["address"] = str
@@ -35,7 +36,7 @@ class RetinaXMLStreamParser
     when :in_netbiosname
       @host["netbios"] = str
     when :in_mac
-      @host["mac"] = str
+      @host["mac"] = str.split(/\s+/).first
     when :in_os
       @host["os"] = str
     when :in_rthid
@@ -59,6 +60,8 @@ class RetinaXMLStreamParser
       @audit['cce'] = str
     when :in_date
       @audit['data'] = str
+    when :in_context
+      @audit['proto'], @audit['port'] = str.split(/\s+/).first.split(':')
     end
   end
 

--- a/lib/rex/parser/retina_xml.rb
+++ b/lib/rex/parser/retina_xml.rb
@@ -27,7 +27,8 @@ class RetinaXMLStreamParser
   end
 
   def text(str)
-    return if str.strip.empty?()
+    return if str.strip.empty?
+
     case @state
     when :in_ip
       @host["address"] = str


### PR DESCRIPTION
When parsing Retina XML exports REXML lib in ruby is injecting with space not found inside tags. 
- [x] Adjust for whitespace issue in a backwards compatible way. 
- [x] Add `context` tag parsing to support adding service details when supplied in the XML.
  - Looks about right: `<context>TCP:443 ([redacted]), SHA256[=][redacted], Serial[=][redacted]</context>`
- [x] Add detection for `Retina` files when `Xml Declaration` is present a beginning of the file. 
  - Indeed, the file starts with `<?xml version="1.0" encoding="utf-8"?>` now

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `db_import <PATH_TO_RETINA_XML>`
- [x] **Verify** a sample file imports hosts.

