### PR TITLE
abrt_raceabrt_priv_esc: Fix abrt package version check

### DIFF
--- a/modules/exploits/linux/local/abrt_raceabrt_priv_esc.rb
+++ b/modules/exploits/linux/local/abrt_raceabrt_priv_esc.rb
@@ -109,7 +109,8 @@ class MetasploitModule < Msf::Exploit::Local
     end
     vprint_good 'abrt-ccpp service is running'
 
-    abrt_version = cmd_exec('yum list installed abrt | grep abrt').split(/\s+/)[1]
+    pkg_info = cmd_exec('yum list installed abrt | grep abrt').to_s
+    abrt_version = pkg_info[/^abrt.*$/].to_s.split(/\s+/)[1]
     unless abrt_version.blank?
       vprint_status "System is using ABRT package version #{abrt_version}"
     end


### PR DESCRIPTION
Fix `abrt` package version check.

Retrieving package details with `yum list installed <pkg>`, on old OS with outdated pacakges, may print a warning to `stderr` indicating that the package cache is old. This caused the package version check to fail, as the following `grep` call (intended to extract details for the specified package) operated only on `stdout`, allowing both the warning from `stderr` and the package details to be returned to Metasploit causing subsequent regex matching to fail

See: https://github.com/rapid7/metasploit-framework/pull/11762#discussion_r286982096
