### PR TITLE
Consolidate and reuse pager code for inline console docs

### DIFF
--- a/lib/rex/ui/text/dispatcher_shell.rb
+++ b/lib/rex/ui/text/dispatcher_shell.rb
@@ -149,6 +149,11 @@ module DispatcherShell
     #
     def cmd_help(cmd=nil, *ignored)
       if cmd
+        if docs_dir && File.exist?(File.join(docs_dir, cmd + '.md'))
+          print(File.read(File.join(docs_dir, cmd + '.md')))
+          print_line
+        end
+
         help_found = false
         cmd_found = false
         shell.dispatcher_stack.each do |dispatcher|
@@ -175,18 +180,15 @@ module DispatcherShell
           end
         end
 
-        if docs_dir && File.exist?(File.join(docs_dir, cmd + '.md'))
-          print_line
-          print(File.read(File.join(docs_dir, cmd + '.md')))
-        end
         print_error("No help for #{cmd}, try -h") if cmd_found and not help_found
         print_error("No such command") if not cmd_found
       else
-        print(shell.help_to_s)
         if docs_dir && File.exist?(File.join(docs_dir + '.md'))
-          print_line
           print(File.read(File.join(docs_dir + '.md')))
+          print_line
         end
+
+        print(shell.help_to_s)
       end
     end
 


### PR DESCRIPTION
~This offers increased readability with the command help near the prompt.~ Taking the pager approach presently.

- [ ] Type `help`
- [ ] See available `msfconsole` commands without scrolling up
- [ ] Type `help repeat` or `help jobs`
- [ ] See available `repeat` or `jobs` options near the prompt

A pager approach is also an option (@acammack-r7), but I think this can be an easy win for me and @wchen-r7. Thoughts welcome.

```
msf5 > help repeat
Repeat
======

The `repeat` command repeats one or more console commands for a fixed number of
times, a certain length of time, or forever. The repeat command is most useful
for repeating module runs like memory dumpers or scanners that have a random
element to them.

Usage
-----

### Flags

#### -t, --time SECONDS

Start the list of commands until the number of seconds has elapsed.

#### -n, --number TIMES

Start the list of commands a fixed number of times.

#### -h, --help

Display the help banner.



Examples
--------

Run the heartbleed module every 10 seconds against a server for an hour:

    msf5 > use auxiliary/scanner/ssl/openssl_heartbleed
    msf5 auxiliary(scanner/ssl/openssl_heartbleed) > set ACTION DUMP
    # Set other options...
    msf5 auxiliary(scanner/ssl/openssl_heartbleed) > repeat -t 3600 run; sleep 10


Usage: repeat [OPTIONS] COMMAND...
Repeat (loop) a ;-separated list of msfconsole commands indefinitely, or for a
number of iterations or a certain amount of time.

    -t, --time SECONDS               Number of seconds to repeat COMMAND...
    -n, --number TIMES               Number of times to repeat COMMAND..
    -h, --help                       Help banner.
msf5 >
```

#11407, #11498