### PR TITLE
Remove jobs options from kill help

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/jobs.rb
+++ b/lib/msf/ui/console/command_dispatcher/jobs.rb
@@ -296,7 +296,6 @@ module Msf
             print_line "Usage: kill <job1> [job2 ...]"
             print_line
             print_line "Equivalent to 'jobs -k job1 -k job2 ...'"
-            print @@jobs_opts.usage
           end
 
           def cmd_kill(*args)


### PR DESCRIPTION
They do not apply.

```
msf5 exploit(multi/handler) > help kill
Usage: kill <job1> [job2 ...]

Equivalent to 'jobs -k job1 -k job2 ...'
msf5 exploit(multi/handler) >
```

Resolves #11917.