### PR TITLE
Add a `secure` command to renegotiate TLV encryption

### DIFF
--- a/lib/rex/post/meterpreter/client_core.rb
+++ b/lib/rex/post/meterpreter/client_core.rb
@@ -701,6 +701,10 @@ class ClientCore < Extension
     return true
   end
 
+  def secure
+    client.tlv_enc_key = negotiate_tlv_encryption
+  end
+
   #
   # Shuts the session down
   #

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
@@ -60,6 +60,7 @@ class Console::CommandDispatcher::Core
       'use'                      => 'Deprecated alias for "load"',
       'load'                     => 'Load one or more meterpreter extensions',
       'machine_id'               => 'Get the MSF ID of the machine attached to the session',
+      'secure'                   => '(Re)Negotiate TLV packet encryption on the session',
       'guid'                     => 'Get the session GUID',
       'quit'                     => 'Terminate the meterpreter session',
       'resource'                 => 'Run the commands stored in a file',
@@ -317,6 +318,12 @@ class Console::CommandDispatcher::Core
       client.next_session = args[0]
       client.interacting = false
     end
+  end
+
+  def cmd_secure
+    print_status('Negotiating new encryption key ...')
+    client.core.secure
+    print_good('Done.')
   end
 
   def cmd_background_help


### PR DESCRIPTION
This gives us the ability to force TLV encryption if for some reason it's not already in place, and it means 
we can renegotiate a new key on the fly if we want to. This PR just puts the user in the drivers seat, but down the track my aim would be to periodically change keys automatically. The aim is just to make things harder to keep track of.

I have had cases where initial sessions kick off and TLV encryption doesn't happen, and other cases where stageless sessions don't end up with encryption enabled.  So this is a means for us to drive it from the UI in those cases. Hopefully I'll get to the bottom of those edge cases soon.

This isn't hugely mind blowing :) But it's a thing that I know I'll use!

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] create a new encryption-supported meterpreter session (Windows is my go to, but we should try it on a few)
- [x] Type `secure` into the console.
- [x] **Verify** that you receive a success message.
