### PR TITLE
Stop error rendering in multi/meterpreter handler

### DIFF
--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -307,39 +307,47 @@ protected
     Thread.current[:cli] = cli
     resp = Rex::Proto::Http::Response.new
     info = process_uri_resource(req.relative_resource)
-    uuid = info[:uuid] || Msf::Payload::UUID.new
+    uuid = info[:uuid]
 
-    # Configure the UUID architecture and payload if necessary
-    uuid.arch      ||= self.arch
-    uuid.platform  ||= self.platform
+    if uuid
+      # Configure the UUID architecture and payload if necessary
+      uuid.arch      ||= self.arch
+      uuid.platform  ||= self.platform
 
-    conn_id = luri
-    if info[:mode] && info[:mode] != :connect
-      conn_id << generate_uri_uuid(URI_CHECKSUM_CONN, uuid)
-    else
-      conn_id << req.relative_resource
-      conn_id = conn_id.chomp('/')
-    end
-
-    request_summary = "#{conn_id} with UA '#{req.headers['User-Agent']}'"
-
-    # Validate known UUIDs for all requests if IgnoreUnknownPayloads is set
-    if datastore['IgnoreUnknownPayloads'] && ! framework.db.get_payload({uuid: uuid.puid_hex})
-      print_status("Ignoring unknown UUID: #{request_summary}")
-      info[:mode] = :unknown_uuid
-    end
-
-    # Validate known URLs for all session init requests if IgnoreUnknownPayloads is set
-    if datastore['IgnoreUnknownPayloads'] && info[:mode].to_s =~ /^init_/
-      payload_info = {
-          uuid: uuid.puid_hex,
-      }
-      payload = framework.db.get_payload(payload_info)
-      allowed_urls = payload ? payload.urls : []
-      unless allowed_urls.include?(req.relative_resource)
-        print_status("Ignoring unknown UUID URL: #{request_summary}")
-        info[:mode] = :unknown_uuid_url
+      conn_id = luri
+      if info[:mode] && info[:mode] != :connect
+        conn_id << generate_uri_uuid(URI_CHECKSUM_CONN, uuid)
+      else
+        conn_id << req.relative_resource
+        conn_id = conn_id.chomp('/')
       end
+
+      request_summary = "#{conn_id} with UA '#{req.headers['User-Agent']}'"
+
+      # Validate known UUIDs for all requests if IgnoreUnknownPayloads is set
+      if datastore['IgnoreUnknownPayloads'] && ! framework.db.get_payload({uuid: uuid.puid_hex})
+        print_status("Ignoring unknown UUID: #{request_summary}")
+        info[:mode] = :unknown_uuid
+      end
+
+      # Validate known URLs for all session init requests if IgnoreUnknownPayloads is set
+      if datastore['IgnoreUnknownPayloads'] && info[:mode].to_s =~ /^init_/
+        payload_info = {
+            uuid: uuid.puid_hex,
+        }
+        payload = framework.db.get_payload(payload_info)
+        allowed_urls = payload ? payload.urls : []
+        unless allowed_urls.include?(req.relative_resource)
+          print_status("Ignoring unknown UUID URL: #{request_summary}")
+          info[:mode] = :unknown_uuid_url
+        end
+      end
+
+      url = payload_uri(req) + conn_id
+      url << '/' unless url[-1] == '/'
+
+    else
+      info[:mode] = :unknown
     end
 
     self.pending_connections += 1
@@ -347,9 +355,6 @@ protected
     resp.body = ''
     resp.code = 200
     resp.message = 'OK'
-
-    url = payload_uri(req) + conn_id
-    url << '/' unless url[-1] == '/'
 
     # Process the requested resource.
     case info[:mode]
@@ -401,7 +406,7 @@ protected
         })
 
       else
-        unless [:unknown_uuid, :unknown_uuid_url].include?(info[:mode])
+        unless [:unknown, :unknown_uuid, :unknown_uuid_url].include?(info[:mode])
           print_status("Unknown request to #{request_summary}")
         end
         resp.body    = datastore['HttpUnknownRequestResponse'].to_s


### PR DESCRIPTION
The reverse_http/s listeners result in awful errors when multi/meterpreter is set as the payload. Anyone that hits the endpoint with an invalid or missing UUID will spam the MSF console with exceptions. They look like this:

```
[-] [2019.06.11-13:14:34] https://0.0.0.0:443 handling request from <REDACTED>; (UUID: pytq9o79) Exception handling request: Invalid platform: '#<Msf::Module::PlatformLi
st:0x000055cd8b6ffa00>'
```

This patch avoids this issue in cases where the UUID isn't specific. We avoid setting it as a default, which doesn't make sense anyway. This patch results in the standard response being returned as it would with an unknown URI or UUID.

## Verification

- [x] Start `msfconsole`
- [x] `use multi/handler`
- [x] `set payload multi/meterpreter/reverse_http`
- [x] Set configuration parameters, spin up a listener. Then create an HTTP payload that points to this listener.
- [x] Hit the endpoint with a browser and make sure that the "It works" message appears, make sure that the exception doesn't appear in the console.
- [x] Fire the payload make sure that the session works correctly.
- [x] This should fix the issue for HTTP and HTTPS payloads.
