### PR TITLE
add udpsockedi, tag compatible payloads

### DIFF
--- a/lib/msf/core/payload/windows/dllinject.rb
+++ b/lib/msf/core/payload/windows/dllinject.rb
@@ -28,7 +28,7 @@ module Payload::Windows::DllInject
       'Arch'          => ARCH_X86,
       'PayloadCompat' =>
         {
-          'Convention' => 'sockedi -http -https'
+          'Convention' => 'sockedi udpsockedi -http -https'
         },
       'Stage'         =>
         {

--- a/lib/msf/core/payload/windows/dllinject.rb
+++ b/lib/msf/core/payload/windows/dllinject.rb
@@ -28,7 +28,7 @@ module Payload::Windows::DllInject
       'Arch'          => ARCH_X86,
       'PayloadCompat' =>
         {
-          'Convention' => 'sockedi udpsockedi -http -https'
+          'Convention' => 'sockedi -http -https'
         },
       'Stage'         =>
         {

--- a/modules/payloads/stagers/windows/reverse_udp.rb
+++ b/modules/payloads/stagers/windows/reverse_udp.rb
@@ -27,7 +27,7 @@ module MetasploitModule
       'Platform'    => 'win',
       'Arch'        => ARCH_X86,
       'Handler'     => Msf::Handler::ReverseUdp,
-      'Convention'  => 'sockedi',
+      'Convention'  => 'udpsockedi',
       'Stager'      => { 'RequiresMidstager' => false }
     ))
   end

--- a/modules/payloads/stagers/windows/reverse_udp.rb
+++ b/modules/payloads/stagers/windows/reverse_udp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http://metasploit.com/download
+# This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stages/windows/shell.rb
+++ b/modules/payloads/stages/windows/shell.rb
@@ -22,7 +22,7 @@ module MetasploitModule
       'Session'       => Msf::Sessions::CommandShellWindows,
       'PayloadCompat' =>
         {
-          'Convention' => 'sockedi -http -https'
+          'Convention' => 'sockedi udpsockedi -http -https'
         },
       'Stage'         =>
         {

--- a/modules/payloads/stages/windows/upexec.rb
+++ b/modules/payloads/stages/windows/upexec.rb
@@ -22,7 +22,7 @@ module MetasploitModule
       'Session'       => Msf::Sessions::CommandShellWindows,
       'PayloadCompat' =>
         {
-          'Convention' => 'sockedi -http -https'
+          'Convention' => 'sockedi udpsockedi -http -https'
         },
       'Stage'         =>
         {

--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -2919,17 +2919,6 @@ RSpec.describe 'modules/payloads', :content do
                           reference_name: 'windows/dllinject/reverse_tcp_rc4_dns'
   end
 
-  context 'windows/dllinject/reverse_udp' do
-    it_should_behave_like 'payload cached size is consistent',
-                          ancestor_reference_names: [
-                              'stagers/windows/reverse_udp',
-                              'stages/windows/dllinject'
-                          ],
-                          dynamic_size: false,
-                          modules_pathname: modules_pathname,
-                          reference_name: 'windows/dllinject/reverse_udp'
-  end
-
   context 'windows/dns_txt_query_exec' do
     it_should_behave_like 'payload cached size is consistent',
                           ancestor_reference_names: [

--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -3466,17 +3466,6 @@ RSpec.describe 'modules/payloads', :content do
                           reference_name: 'windows/patchupdllinject/reverse_tcp_rc4_dns'
   end
 
-  context 'windows/patchupdllinject/reverse_udp' do
-    it_should_behave_like 'payload cached size is consistent',
-                          ancestor_reference_names: [
-                              'stagers/windows/reverse_udp',
-                              'stages/windows/patchupdllinject'
-                          ],
-                          dynamic_size: false,
-                          modules_pathname: modules_pathname,
-                          reference_name: 'windows/patchupdllinject/reverse_udp'
-  end
-
   context 'windows/patchupmeterpreter/bind_ipv6_tcp' do
     it_should_behave_like 'payload cached size is consistent',
                           ancestor_reference_names: [

--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -3303,17 +3303,6 @@ RSpec.describe 'modules/payloads', :content do
                           reference_name: 'windows/meterpreter/reverse_tcp_uuid'
   end
 
-  context 'windows/meterpreter/reverse_udp' do
-    it_should_behave_like 'payload cached size is consistent',
-                          ancestor_reference_names: [
-                              'stagers/windows/reverse_udp',
-                              'stages/windows/meterpreter'
-                          ],
-                          dynamic_size: false,
-                          modules_pathname: modules_pathname,
-                          reference_name: 'windows/meterpreter/reverse_udp'
-  end
-
   context 'windows/metsvc_bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
                           ancestor_reference_names: [
@@ -3651,17 +3640,6 @@ RSpec.describe 'modules/payloads', :content do
                           dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupmeterpreter/reverse_tcp_rc4_dns'
-  end
-
-  context 'windows/patchupmeterpreter/reverse_udp' do
-    it_should_behave_like 'payload cached size is consistent',
-                          ancestor_reference_names: [
-                              'stagers/windows/reverse_udp',
-                              'stages/windows/patchupmeterpreter'
-                          ],
-                          dynamic_size: false,
-                          modules_pathname: modules_pathname,
-                          reference_name: 'windows/patchupmeterpreter/reverse_udp'
   end
 
   context 'windows/shell/bind_ipv6_tcp' do
@@ -4196,17 +4174,6 @@ RSpec.describe 'modules/payloads', :content do
                           dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/vncinject/reverse_tcp_rc4_dns'
-  end
-
-  context 'windows/vncinject/reverse_udp' do
-    it_should_behave_like 'payload cached size is consistent',
-                          ancestor_reference_names: [
-                              'stagers/windows/reverse_udp',
-                              'stages/windows/vncinject'
-                          ],
-                          dynamic_size: false,
-                          modules_pathname: modules_pathname,
-                          reference_name: 'windows/vncinject/reverse_udp'
   end
 
   context 'windows/x64/exec' do


### PR DESCRIPTION
Not all payloads compatible with TCP stagers are compatible with UDP stagers, so assuming sockedi is not sufficient to ensure compatibility. This adds a udpsockedi which pairs compatible payloads together.

Fixes #10336 (probably)

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Rebuild the module cache (outside of the scope here, but suffice to say you should only be able to _use_ two modules:
```
msf5 auxiliary(gather/shodan_search) > search reverse_udp

Matching Modules
================

   #  Name                               Disclosure Date  Rank    Check  Description
   -  ----                               ---------------  ----    -----  -----------
   0  payload/python/shell_reverse_udp                    normal  No     Command Shell, Reverse UDP (via python)
   1  payload/windows/shell/reverse_udp                   normal  No     Windows Command Shell, Reverse UDP Stager with UUID Support

```
- [ ] **Verify** the existing reverse_udp modules actually work (I tested with wine, YMMV)
