### PR TITLE
deprecate db_rebuild_cache command

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -52,7 +52,7 @@ class Db
       "db_import"     => "Import a scan result file (filetype will be auto-detected)",
       "db_export"     => "Export a file containing the contents of the database",
       "db_nmap"       => "Executes nmap and records the output automatically",
-      "db_rebuild_cache" => "Rebuilds the database-stored module cache",
+      "db_rebuild_cache" => "Rebuilds the database-stored module cache (deprecated)",
       "analyze"       => "Analyze database information about a specific address or address range",
     }
 
@@ -1889,24 +1889,8 @@ class Db
     end
   end
 
-  def cmd_db_rebuild_cache
-    unless framework.db.active
-      print_error("The database is not connected")
-      return
-    end
-
-    print_status("Purging and rebuilding the module cache in the background...")
-    framework.threads.spawn("ModuleCacheRebuild", true) do
-      framework.db.purge_all_module_details
-      framework.db.update_all_module_details
-    end
-  end
-
-  def cmd_db_rebuild_cache_help
-    print_line "Usage: db_rebuild_cache"
-    print_line
-    print_line "Purge and rebuild the SQL module cache."
-    print_line
+  def cmd_db_rebuild_cache(*args)
+    print_line "This command is deprecated with Metasploit 5"
   end
 
   def cmd_db_save_help

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -907,6 +907,7 @@ module Msf
                                    Msf::Modules::Metadata::Store::UserMetaDataFile)
 
             print_line "Rebuilding local module data store"
+            File.unlink(user_store) if File.exist?(user_store)
             framework.modules.refresh_cache_from_module_files
             sleep(1) while !File.exist?(user_store)
             print_line "Wrote updated data store to #{user_store}"

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -903,27 +903,13 @@ module Msf
               return
             end
 
-            base_store = File.join(Msf::Config.install_root, "db",
-                                   Msf::Modules::Metadata::Store::BaseMetaDataFile)
             user_store = File.join(Msf::Config.config_directory, "store",
                                    Msf::Modules::Metadata::Store::UserMetaDataFile)
-
-            update_base = File.writable?(base_store)
-
-            if update_base
-              print_line "Base store is at #{base_store}, deleting"
-              File.delete(base_store)
-            end
 
             print_line "Rebuilding local module data store"
             framework.modules.refresh_cache_from_module_files
             sleep(1) while !File.exist?(user_store)
             print_line "Wrote updated data store to #{user_store}"
-
-            if update_base
-              print_line "Moving #{user_store} to #{base_store}"
-              File.rename(user_store, base_store)
-            end
           end
 
           def cmd_back_help

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -33,7 +33,6 @@ module Msf
               "pushm"      => "Pushes the active or list of modules onto the module stack",
               "previous"   => "Sets the previously loaded module as the current module",
               "reload_all" => "Reloads all modules from all defined module paths",
-              "reload_search" => "Rebuild the module search cache",
               "search"     => "Searches module names and descriptions",
               "show"       => "Displays modules of a given type, or all modules",
               "use"        => "Interact with a module by name or search term/index",
@@ -888,29 +887,6 @@ module Msf
             end
 
             self.driver.run_single("banner")
-          end
-
-          def cmd_reload_search_help
-            print_line "Usage: reload_search"
-            print_line
-            print_line "Rebuild the module search cache"
-            print_line
-          end
-
-          def cmd_reload_search(*args)
-            if args.length > 0
-              cmd_reload_search_help
-              return
-            end
-
-            user_store = File.join(Msf::Config.config_directory, "store",
-                                   Msf::Modules::Metadata::Store::UserMetaDataFile)
-
-            print_line "Rebuilding local module data store"
-            File.unlink(user_store) if File.exist?(user_store)
-            framework.modules.refresh_cache_from_module_files
-            sleep(1) while !File.exist?(user_store)
-            print_line "Wrote updated data store to #{user_store}"
           end
 
           def cmd_back_help

--- a/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
@@ -29,8 +29,6 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Db do
   it { is_expected.to respond_to :cmd_db_nmap }
   it { is_expected.to respond_to :cmd_db_notes }
   it { is_expected.to respond_to :cmd_db_notes_help }
-  it { is_expected.to respond_to :cmd_db_rebuild_cache }
-  it { is_expected.to respond_to :cmd_db_rebuild_cache_help }
   it { is_expected.to respond_to :cmd_db_services }
   it { is_expected.to respond_to :cmd_db_services_help }
   it { is_expected.to respond_to :cmd_db_status }


### PR DESCRIPTION
For a while, Metasploit has not used the old database-backed module cache in favor of the lightweight JSON data store. This also means that the db_rebuild_cache command has been broken.

This just disables the command rather than returning an error.

~While the base module cache usually stays up to date, if you delete a module as a developer, there's currently no great way to make the search function forget about that module unless you rebuild the cache manually (a procedure mostly documented inside of an automated build job).~

~This moves the logic from that build job into the old db_rebuild_cache command, potentially killing 2 birds with one stone. Note, I get very inconsistent results from this however, as the date stamp format and a few other fields change a lot. So, there may be more work to do.~

~Does the concept seem OK? Should we actually rename this command as well?~

~See #11968 for a case where you have to rebuild the search data store manually to see if the change did anything.~

Current behavior:
```
msf5 auxiliary(gather/shodan_search) > db_rebuild_cache 
[*] Purging and rebuilding the module cache in the background...
```

but this shows up in the logs:
```
[06/11/2019 04:49:38] [e(0)] core: thread exception: ModuleCacheRebuild  critical=true  error: NoMethodError undefined method `purge_all_module_details' for #<Metasploit::Framework::DataService::RemoteHTTPDataService:0x000055e6956c1ed0>
  source:
    /home/bcook/projects/metasploit-framework/lib/msf/ui/console/command_dispatcher/db.rb:1899:in `cmd_db_rebuild_cache'
    /home/bcook/projects/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:523:in `run_command'
    /home/bcook/projects/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:474:in `block in run_single'
    /home/bcook/projects/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:468:in `each'
    /home/bcook/projects/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:468:in `run_single'
    /home/bcook/projects/metasploit-framework/lib/rex/ui/text/shell.rb:151:in `run'
    /home/bcook/projects/metasploit-framework/lib/metasploit/framework/command/console.rb:48:in `start'
    /home/bcook/projects/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'
    ./msfconsole:49:in `<main>'
[06/11/2019 04:49:38] [e(0)] core: Call Stack
```