### PR TITLE
Correct IBM Websphere Application Server Network Deployment RCE module CVE reference

### DIFF
--- a/modules/exploits/windows/ibm/ibm_was_dmgr_java_deserialization_rce.rb
+++ b/modules/exploits/windows/ibm/ibm_was_dmgr_java_deserialization_rce.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'References' =>
         [
-          ['CVE', '2019-8352'],
+          ['CVE', '2019-4279'],
           ['URL', 'https://www-01.ibm.com/support/docview.wss?uid=ibm10883628']
         ],
       'Platform' => ['win'],


### PR DESCRIPTION
Corrects the IBM Websphere Application Server Network Deployment RCE module (`exploit/windows/ibm/ibm_was_dmgr_java_deserialization_rce`) CVE reference.

## Verification

- [x] **Verify** module CVE reference is correct