### PR TITLE
Concatenate path and name in Meterpreter pgrep -lf

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
@@ -571,7 +571,7 @@ class Console::CommandDispatcher::Stdapi::Sys
     processes.each do |p|
       if l_flag
         if f_flag
-          print_line("#{p['pid']} #{p['path']}")
+          print_line("#{p['pid']} #{p['path']}#{client.fs.file.separator}#{p['name']}")
         else
           print_line("#{p['pid']} #{p['name']}")
         end

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
@@ -571,7 +571,9 @@ class Console::CommandDispatcher::Stdapi::Sys
     processes.each do |p|
       if l_flag
         if f_flag
-          print_line("#{p['pid']} #{p['path']}#{client.fs.file.separator}#{p['name']}")
+          full_path = [p['path'], p['name']].join(client.fs.file.separator)
+
+          print_line("#{p['pid']} #{full_path}")
         else
           print_line("#{p['pid']} #{p['name']}")
         end


### PR DESCRIPTION
I don't see any args yet.

```
meterpreter > pgrep -lf httpd
3379 /usr/sbin
3381 /usr/sbin
meterpreter >
```

```
meterpreter > pgrep -lf httpd
3379 /usr/sbin/httpd
3381 /usr/sbin/httpd
meterpreter >
```

Fixes #8117.