### PR TITLE
add meterpreter keyevent api for virtual key strokes

### DIFF
--- a/lib/rex/post/meterpreter/extensions/stdapi/tlv.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/tlv.rb
@@ -211,6 +211,7 @@ TLV_TYPE_KEYS_SEND                         = TLV_META_TYPE_STRING | 3014
 TLV_TYPE_MOUSE_ACTION                      = TLV_META_TYPE_UINT   | 3015
 TLV_TYPE_MOUSE_X                           = TLV_META_TYPE_UINT   | 3016
 TLV_TYPE_MOUSE_Y                           = TLV_META_TYPE_UINT   | 3017
+TLV_TYPE_KEYEVENT_SEND                     = TLV_META_TYPE_RAW    | 3018
 
 ##
 #

--- a/lib/rex/post/meterpreter/extensions/stdapi/ui.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/ui.rb
@@ -276,6 +276,8 @@ class UI < Rex::Post::UI
       action = 5
     when "rightup"
       action = 6
+    when "doubleclick"
+      action = 7
     else
       action = mouseaction.to_i
     end

--- a/lib/rex/post/meterpreter/extensions/stdapi/ui.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/ui.rb
@@ -245,6 +245,17 @@ class UI < Rex::Post::UI
   end
 
   #
+  # Send key events
+  #
+  def keyevent_send(key_code, action = 0)
+    key_data = [ action, key_code ].pack("VV")
+    request = Packet.create_request('stdapi_ui_send_keyevent')
+    request.add_tlv( TLV_TYPE_KEYEVENT_SEND, key_data )
+    response = client.send_request(request)
+    return true
+  end
+
+  #
   # Mouse input
   #
   def mouse(mouseaction, x=-1, y=-1)

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/ui.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/ui.rb
@@ -480,7 +480,7 @@ class Console::CommandDispatcher::Stdapi::Ui
     elsif args.length == 3
       client.ui.mouse(args[0], args[1], args[2])
     else
-      print_line("Usage: mouse action (move, click, up, down, rightclick, rightup, rightdown)")
+      print_line("Usage: mouse action (move, click, up, down, rightclick, rightup, rightdown, doubleclick)")
       print_line("       mouse [x] [y] (click)")
       print_line("       mouse [action] [x] [y]")
       print_line("  e.g: mouse click")

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/ui.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/ui.rb
@@ -30,6 +30,7 @@ class Console::CommandDispatcher::Stdapi::Ui
       "keyscan_start" => "Start capturing keystrokes",
       "keyscan_stop"  => "Stop capturing keystrokes",
       "keyboard_send" => "Send keystrokes",
+      "keyevent"      => "Send key events",
       "mouse"         => "Send mouse events",
       "screenshot"    => "Grab a screenshot of the interactive desktop",
       "screenshare"   => "Watch the remote user's desktop in real time",
@@ -46,6 +47,7 @@ class Console::CommandDispatcher::Stdapi::Ui
       "keyscan_dump"  => [ "stdapi_ui_get_keys_utf8" ],
       "keyscan_start" => [ "stdapi_ui_start_keyscan" ],
       "keyscan_stop"  => [ "stdapi_ui_stop_keyscan" ],
+      "keyevent"      => [ "stdapi_ui_send_keyevent" ],
       "keyboard_send" => [ "stdapi_ui_send_keys" ],
       "mouse"         => [ "stdapi_ui_send_mouse" ],
       "screenshot"    => [ "stdapi_ui_desktop_screenshot" ],
@@ -439,6 +441,31 @@ class Console::CommandDispatcher::Stdapi::Ui
 
     keys = args[0]
     client.ui.keyboard_send(keys)
+    print_status('Done')
+  end
+
+  #
+  # Send key events
+  #
+  def cmd_keyevent(*args)
+    action = 0
+    if args.length == 1
+      keycode = args[0].to_i
+    elsif args.length == 2
+      keycode = args[0].to_i
+      if args[1] == 'down'
+        action = 1
+      elsif args[1] == 'up'
+        action = 2
+      end
+    else
+      print_line("Usage: keyevent keycode [action] (press, up, down)")
+      print_line("  e.g: keyevent 13 press (send the enter key)")
+      print_line("       kevevent 17 down (control key down)\n")
+      return
+    end
+
+    client.ui.keyevent_send(keycode, action)
     print_status('Done')
   end
 


### PR DESCRIPTION
This adds the framework side of https://github.com/rapid7/metasploit-payloads/pull/352

## Verification

- [x] Land https://github.com/rapid7/metasploit-payloads/pull/352
- [x] Get a windows meterpreter session
- [x] `meterpreter > keyevent 13`
- [x] **Verify** the return key is pressed

While it's not possible from the command line currently, the api does support key combinations, for example, to produce the $ character (Shift + 4):
```
key_data = [ 1, 16, 1, 52, 2, 52, 2, 16 ].pack("V*")
request = Packet.create_request('stdapi_ui_send_keyevent')
request.add_tlv( TLV_TYPE_KEYEVENT_SEND, key_data )
response = client.send_request(request)
```

We're currently using the javascript/windows key codes (e.g https://keycode.info/ or https://docs.microsoft.com/en-us/windows/desktop/inputdev/virtual-key-codes)
This means we'll unfortunately have to have some kind of mapping table if we want a similar output on OSX/Java/etc. On python I suspect we can use the same win32 api.