### PR TITLE
Add a ZDI reference for CVE-2019-5420 Rails exploit

### DIFF
--- a/modules/exploits/multi/http/rails_double_tap.rb
+++ b/modules/exploits/multi/http/rails_double_tap.rb
@@ -33,7 +33,8 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'CVE', '2019-5420' ],
           [ 'URL', 'https://hackerone.com/reports/473888' ],
           [ 'URL', 'https://github.com/mpgn/Rails-doubletap-RCE' ],
-          [ 'URL', 'https://groups.google.com/forum/#!searchin/rubyonrails-security/CVE-2019-5420/rubyonrails-security/IsQKvDqZdKw/UYgRCJz2CgAJ' ]
+          [ 'URL', 'https://groups.google.com/forum/#!searchin/rubyonrails-security/CVE-2019-5420/rubyonrails-security/IsQKvDqZdKw/UYgRCJz2CgAJ' ],
+          [ 'URL', 'https://www.zerodayinitiative.com/blog/2019/6/20/remote-code-execution-via-ruby-on-rails-active-storage-insecure-deserialization' ]
         ],
       'Platform'       => 'linux',
       'Targets'        =>


### PR DESCRIPTION
Add A ZDI reference for the CVE-2019-5420 Rails exploit. Kudos to ooooooo_q.