### PR TITLE
Allow true zero-second timeout in send_request_*

### DIFF
--- a/lib/rex/proto/http/client.rb
+++ b/lib/rex/proto/http/client.rb
@@ -523,18 +523,17 @@ class Client
   #
   # Read a response from the server
   #
+  # Wait at most t seconds for the full response to be read in.
+  # If t is specified as a negative value, it indicates an infinite wait cycle.
+  # If t is specified as nil or 0, it indicates no response parsing is required.
+  #
   # @return [Response]
   def read_response(t = -1, opts = {})
+    # Return a nil response if timeout is nil or 0
+    return if t.nil? || t == 0
 
     resp = Response.new
     resp.max_data = config['read_max_data']
-
-    # Wait at most t seconds for the full response to be read in.  We only
-    # do this if t was specified as a negative value indicating an infinite
-    # wait cycle.  If t were specified as nil it would indicate that no
-    # response parsing is required.
-
-    return resp if not t
 
     Timeout.timeout((t < 0) ? nil : t) do
 

--- a/lib/rex/proto/http/client.rb
+++ b/lib/rex/proto/http/client.rb
@@ -524,7 +524,7 @@ class Client
   # Read a response from the server
   #
   # Wait at most t seconds for the full response to be read in.
-  # If t is specified as a negative value, it indicates an infinite wait cycle.
+  # If t is specified as a negative value, it indicates an indefinite wait cycle.
   # If t is specified as nil or 0, it indicates no response parsing is required.
   #
   # @return [Response]

--- a/modules/exploits/linux/http/hp_van_sdn_cmd_inject.rb
+++ b/modules/exploits/linux/http/hp_van_sdn_cmd_inject.rb
@@ -170,7 +170,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'headers' => {'X-Auth-Token' => auth_token},
       'ctype'   => 'application/json',
       'data'    => {'action' => 'uninstall', 'name' => injection}.to_json
-    }, 1)
+    }, 0)
   end
 
   def auth_token

--- a/modules/exploits/unix/webapp/jquery_file_upload.rb
+++ b/modules/exploits/unix/webapp/jquery_file_upload.rb
@@ -174,7 +174,7 @@ class MetasploitModule < Msf::Exploit::Remote
     send_request_cgi({
       'method' => 'GET',
       'uri'    => p
-    }, 1)
+    }, 0)
   end
 
   def delete_payload(u, f)


### PR DESCRIPTION
## ⚠️ This PR changes core behavior to align with expected behavior

Also fixes a bogus response when timeout is `nil`.

1. `Timeout.timeout(0)` implies that the block will not time out, which is usually not what we want when we set the `timeout` parameter to `0` to address a lack of response.

```
[1] pry(#<Msf::Modules::Exploit__Multi__Http__Issue::MetasploitModule>)> send_request_cgi({}, 0)
^CInterrupt:
from /Users/wvu/.rbenv/versions/2.6.2/lib/ruby/gems/2.6.0/gems/rex-core-0.1.13/lib/rex/io/stream.rb:95:in `select'
[2] pry(#<Msf::Modules::Exploit__Multi__Http__Issue::MetasploitModule>)>
```

See #2820 for the only known example. Note that Juan had to ^C his module when he wanted to return immediately. So, this actually fixes a bug.

2. A `timeout` value of `nil` is returning an unfilled `Rex::Proto::Http::Response`, which is a bogus `200 OK` that isn't meant to be parsed.

```
[2] pry(#<Msf::Modules::Exploit__Multi__Http__Issue::MetasploitModule>)> send_request_cgi({}, nil)
=> #<Rex::Proto::Http::Response:0x00007faf42e18e28
 @auto_cl=true,
 @body="",
 @bufq="",
 @chunk_max_size=10,
 @chunk_min_size=1,
 @code=200,
 @count_100=0,
 @headers={},
 @inside_chunk=false,
 @max_data=1048576,
 @message="OK",
 @peerinfo={"addr"=>"127.0.0.1", "port"=>8080},
 @proto="1.1",
 @request="GET / HTTP/1.1\r\nHost: 127.0.0.1:8080\r\nUser-Agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)\r\nContent-Type: application/x-www-form-urlencoded\r\n\r\n",
 @state=1,
 @transfer_chunked=false>
[3] pry(#<Msf::Modules::Exploit__Multi__Http__Issue::MetasploitModule>)> puts _
HTTP/1.1 200 OK
Content-Length: 0

=> nil
[4] pry(#<Msf::Modules::Exploit__Multi__Http__Issue::MetasploitModule>)>
```

I did not find any examples of a `nil` timeout being used. Most people set something low instead. Either way, the response should be `nil`, never something bogus.

Resolves #12004, in a manner of speaking. cc @cyrus-and