### PR TITLE
struts2_content_type_ognl: Don't care about response code

### DIFF
--- a/modules/exploits/multi/http/struts2_content_type_ognl.rb
+++ b/modules/exploits/multi/http/struts2_content_type_ognl.rb
@@ -72,7 +72,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return Exploit::CheckCode::Unknown
     end
 
-    if resp && resp.code == 200 && resp.headers[var_a]
+    if resp && resp.headers && resp.headers[var_a]
       vprint_good("Victim operating system: #{resp.headers[var_a]}")
       Exploit::CheckCode::Vulnerable
     else


### PR DESCRIPTION
I found one that returned a 302 instead of 200

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use exploit/multi/http/struts2_content_type_ognl`
- [x] `check`
- [x] **Verify** shows vuln even if the thing returns a 302
