### PR TITLE
Fix get_resource nil bug in HttpServer#get_uri

### DIFF
--- a/lib/msf/core/exploit/http/server.rb
+++ b/lib/msf/core/exploit/http/server.rb
@@ -433,6 +433,11 @@ module Exploit::Remote::HttpServer
   # but see {#srvhost_addr} for caveats.
   #
   def get_uri(cli=self.cli)
+    resource = get_resource
+
+    # The resource won't exist until the server is started
+    return unless resource
+
     ssl = !!(datastore["SSL"])
     proto = (ssl ? "https://" : "http://")
     if datastore['URIHOST']
@@ -457,7 +462,7 @@ module Exploit::Remote::HttpServer
       port = ":" + datastore["SRVPORT"].to_s
     end
 
-    uri = proto + host + port + get_resource
+    uri = proto + host + port + resource
 
     uri
   end


### PR DESCRIPTION
This fixes a long-standing bug in `HttpServer` that I neglected to address.

If the module dev hasn't started the server yet, such as with `start_service`, `get_resource` returns `nil`, which `get_uri` - when called by the dev - attempts to concatenate with the rest of the URI.

A dev will see this bug only if they call `get_uri` out of order. It has happened before.

```
[1] pry(#<Msf::Modules::Exploit__Multi__Http__Jenkins_metaprogramming::MetasploitModule>)> get_uri
TypeError: no implicit conversion of nil into String
from /rapid7/metasploit-framework/lib/msf/core/exploit/http/server.rb:460:in `+'
[2] pry(#<Msf::Modules::Exploit__Multi__Http__Jenkins_metaprogramming::MetasploitModule>)> show-source get_uri

From: /rapid7/metasploit-framework/lib/msf/core/exploit/http/server.rb @ line 435:
Owner: Msf::Exploit::Remote::HttpServer
Visibility: public
Number of lines: 29

def get_uri(cli=self.cli)
  ssl = !!(datastore["SSL"])
  proto = (ssl ? "https://" : "http://")
  if datastore['URIHOST']
    host = datastore['URIHOST']
  elsif (cli and cli.peerhost)
    host = Rex::Socket.source_address(cli.peerhost)
  else
    host = srvhost_addr
  end

  if Rex::Socket.is_ipv6?(host)
    host = "[#{host}]"
  end

  if datastore['URIPORT'] && datastore['URIPORT'] != 0
    port = ':' + datastore['URIPORT'].to_s
  elsif (ssl and datastore["SRVPORT"] == 443)
    port = ''
  elsif (!ssl and datastore["SRVPORT"] == 80)
    port = ''
  else
    port = ":" + datastore["SRVPORT"].to_s
  end

  uri = proto + host + port + get_resource

  uri
end
[3] pry(#<Msf::Modules::Exploit__Multi__Http__Jenkins_metaprogramming::MetasploitModule>)> get_resource
=> nil
[4] pry(#<Msf::Modules::Exploit__Multi__Http__Jenkins_metaprogramming::MetasploitModule>)>
```

Noticed again while working on #11952. :)