### PR TITLE
Remove misleading comment from dcerpc_getarch

### DIFF
--- a/lib/msf/core/exploit/dcerpc.rb
+++ b/lib/msf/core/exploit/dcerpc.rb
@@ -143,8 +143,6 @@ module Exploit::Remote::DCERPC
     end
   end
 
-  # XXX: Copypasta from exploit/windows/smb/ms17_010_eternalblue
-  #
   # https://github.com/CoreSecurity/impacket/blob/master/examples/getArch.py
   # https://msdn.microsoft.com/en-us/library/cc243948.aspx#Appendix_A_53
   def dcerpc_getarch


### PR DESCRIPTION
I transferred my implementation. I don't understand this comment.

Fixes #9299.