### PR TITLE
Minor fix for xdebug_unauth_exec

### DIFF
--- a/modules/exploits/unix/http/xdebug_unauth_exec.rb
+++ b/modules/exploits/unix/http/xdebug_unauth_exec.rb
@@ -58,7 +58,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'XDEBUG_SESSION_START' => rand_text_alphanumeric(10)
        }
       })
-      vprint_status "Request sent\n#{res.headers}"
+      vprint_status "Request sent\n#{res}"
       if res && res.headers.to_s =~ /XDEBUG/i
         vprint_good("Looks like remote server has xdebug enabled\n")
         return CheckCode::Detected


### PR DESCRIPTION
Avoid triggering error where res.headers may not exist.