### PR TITLE
Add Pen Test Partners reference to Cisco RV130 exploit

### DIFF
--- a/modules/exploits/linux/http/cisco_rv130_rmi_rce.rb
+++ b/modules/exploits/linux/http/cisco_rv130_rmi_rce.rb
@@ -39,9 +39,9 @@ class MetasploitModule < Msf::Exploit::Remote
       },
       'Author'         =>
         [
-          'Yu Zhang', # Initial discovery
-          'Haoliang Lu', # Initial discovery
-          'T. Shiomitsu', # Initial discovery
+          'Yu Zhang', # Initial discovery (GeekPwn conference)
+          'Haoliang Lu', # Initial discovery (GeekPwn conference)
+          'T. Shiomitsu', # Initial discovery (Pen Test Partners)
           'Quentin Kaiser <kaiserquentin@gmail.com>' # Vulnerability analysis & exploit dev
         ],
       'License'         => MSF_LICENSE,
@@ -55,6 +55,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['CVE', '2019-1663'],
           ['BID', '107185'],
           ['URL', 'https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-20190227-rmi-cmd-ex'],
+          ['URL', 'https://www.pentestpartners.com/security-blog/cisco-rv130-its-2019-but-yet-strcpy/']
         ],
       'DefaultOptions' => {
           'WfsDelay' => 10,


### PR DESCRIPTION
Did we somehow miss this? It wasn't in the original advisory, but I found it while Googling. Should have Googled sooner. Apologies!

The writeup is at https://www.pentestpartners.com/security-blog/cisco-rv130-its-2019-but-yet-strcpy/. Wish I had known about it. :)

Updates #11613.