### PR TITLE
Deregister PASSWORD_SPRAY option for LoginScanner modules

### DIFF
--- a/modules/auxiliary/scanner/acpp/login.rb
+++ b/modules/auxiliary/scanner/acpp/login.rb
@@ -40,6 +40,7 @@ class MetasploitModule < Msf::Auxiliary
       # there is no username, so remove all of these options
       'DB_ALL_USERS',
       'DB_ALL_CREDS',
+      'PASSWORD_SPRAY',
       'USERNAME',
       'USERPASS_FILE',
       'USER_FILE',

--- a/modules/auxiliary/scanner/afp/afp_login.rb
+++ b/modules/auxiliary/scanner/afp/afp_login.rb
@@ -36,6 +36,8 @@ class MetasploitModule < Msf::Auxiliary
         OptBool.new('RECORD_GUEST', [ false, "Record guest login to the database", false]),
         OptBool.new('CHECK_GUEST', [ false, "Check for guest login", true])
       ], self)
+
+    deregister_options('PASSWORD_SPRAY')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/db2/db2_auth.rb
+++ b/modules/auxiliary/scanner/db2/db2_auth.rb
@@ -36,6 +36,8 @@ class MetasploitModule < Msf::Auxiliary
         OptPath.new('PASS_FILE',  [ false, "File containing passwords, one per line",
           File.join(Msf::Config.data_directory, "wordlists", "db2_default_pass.txt") ]),
       ])
+
+    deregister_options('PASSWORD_SPRAY')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/ftp/ftp_login.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_login.rb
@@ -46,7 +46,7 @@ class MetasploitModule < Msf::Auxiliary
       ]
     )
 
-    deregister_options('FTPUSER','FTPPASS') # Can use these, but should use 'username' and 'password'
+    deregister_options('FTPUSER','FTPPASS', 'PASSWORD_SPRAY') # Can use these, but should use 'username' and 'password'
     @accepts_all_logins = {}
   end
 

--- a/modules/auxiliary/scanner/http/advantech_webaccess_login.rb
+++ b/modules/auxiliary/scanner/http/advantech_webaccess_login.rb
@@ -31,6 +31,8 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('TARGETURI', [true, 'The base path to Advantech WebAccess', '/']),
         OptBool.new('TRYDEFAULT', [false, 'Try the default credential admin:[empty]', false])
       ])
+
+    deregister_options('PASSWORD_SPRAY')
   end
 
 

--- a/modules/auxiliary/scanner/http/appletv_login.rb
+++ b/modules/auxiliary/scanner/http/appletv_login.rb
@@ -53,7 +53,7 @@ class MetasploitModule < Msf::Auxiliary
     deregister_options(
         'USERNAME', 'USER_AS_PASS', 'DB_ALL_CREDS', 'DB_ALL_USERS', 'NTLM::SendLM', 'NTLM::SendNTLM',
         'NTLM::SendSPN', 'NTLM::UseLMKey', 'NTLM::UseNTLM2_session', 'NTLM::UseNTLMv2',
-        'REMOVE_USERPASS_FILE', 'REMOVE_USER_FILE', 'DOMAIN', 'HttpUsername'
+        'REMOVE_USERPASS_FILE', 'REMOVE_USER_FILE', 'DOMAIN', 'HttpUsername', 'PASSWORD_SPRAY'
     )
   end
 

--- a/modules/auxiliary/scanner/http/axis_login.rb
+++ b/modules/auxiliary/scanner/http/axis_login.rb
@@ -38,6 +38,8 @@ class MetasploitModule < Msf::Auxiliary
       Opt::RPORT(8080),
       OptString.new('TARGETURI', [false, 'Path to the Apache Axis Administration page', '/axis2/axis2-admin/login']),
     ])
+
+    deregister_options('PASSWORD_SPRAY')
   end
 
   # For print_* methods

--- a/modules/auxiliary/scanner/http/bavision_cam_login.rb
+++ b/modules/auxiliary/scanner/http/bavision_cam_login.rb
@@ -28,6 +28,8 @@ class MetasploitModule < Msf::Auxiliary
       [
         OptBool.new('TRYDEFAULT', [false, 'Try the default credential admin:123456', false])
       ])
+
+    deregister_options('PASSWORD_SPRAY')
   end
 
 

--- a/modules/auxiliary/scanner/http/buffalo_login.rb
+++ b/modules/auxiliary/scanner/http/buffalo_login.rb
@@ -27,6 +27,8 @@ class MetasploitModule < Msf::Auxiliary
       [
         Opt::RPORT(80)
       ])
+
+    deregister_options('PASSWORD_SPRAY')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/http/caidao_bruteforce_login.rb
+++ b/modules/auxiliary/scanner/http/caidao_bruteforce_login.rb
@@ -38,7 +38,7 @@ class MetasploitModule < Msf::Auxiliary
       ])
 
     # caidao does not have an username, there's only password
-    deregister_options('HttpUsername', 'HttpPassword', 'USERNAME', 'USER_AS_PASS', 'USERPASS_FILE', 'USER_FILE', 'DB_ALL_USERS')
+    deregister_options('HttpUsername', 'HttpPassword', 'USERNAME', 'USER_AS_PASS', 'USERPASS_FILE', 'USER_FILE', 'DB_ALL_USERS', 'PASSWORD_SPRAY')
   end
 
   def scanner(ip)

--- a/modules/auxiliary/scanner/http/chef_webui_login.rb
+++ b/modules/auxiliary/scanner/http/chef_webui_login.rb
@@ -38,6 +38,8 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('PASSWORD', [false, 'The password to specify for authentication', '']),
         OptString.new('TARGETURI', [ true,  'The path to the Chef Web UI application', '/']),
       ])
+
+    deregister_options('PASSWORD_SPRAY')
   end
 
   #

--- a/modules/auxiliary/scanner/http/cisco_firepower_login.rb
+++ b/modules/auxiliary/scanner/http/cisco_firepower_login.rb
@@ -34,6 +34,8 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('TARGETURI', [true, 'The base path to Cisco Firepower Management console', '/']),
         OptBool.new('TRYDEFAULT', [false, 'Try the default credential admin:Admin123', false])
       ])
+
+    deregister_options('PASSWORD_SPRAY')
   end
 
 

--- a/modules/auxiliary/scanner/http/directadmin_login.rb
+++ b/modules/auxiliary/scanner/http/directadmin_login.rb
@@ -32,6 +32,8 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('USERNAME', [false, 'The username to specify for authentication', '']),
         OptString.new('PASSWORD', [false, 'The password to specify for authentication', '']),
       ])
+
+    deregister_options('PASSWORD_SPRAY')
   end
 
 

--- a/modules/auxiliary/scanner/http/gitlab_login.rb
+++ b/modules/auxiliary/scanner/http/gitlab_login.rb
@@ -32,6 +32,8 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('TARGETURI', [true, 'The path to GitLab', '/'])
       ])
 
+    deregister_options('PASSWORD_SPRAY')
+
     register_autofilter_ports([ 80, 443 ])
   end
 

--- a/modules/auxiliary/scanner/http/glassfish_login.rb
+++ b/modules/auxiliary/scanner/http/glassfish_login.rb
@@ -41,6 +41,8 @@ class MetasploitModule < Msf::Auxiliary
         Opt::RPORT(4848),
         OptString.new('USERNAME',[true, 'A specific username to authenticate as','admin']),
       ])
+
+    deregister_options('PASSWORD_SPRAY')
   end
 
   #

--- a/modules/auxiliary/scanner/http/hp_sys_mgmt_login.rb
+++ b/modules/auxiliary/scanner/http/hp_sys_mgmt_login.rb
@@ -36,6 +36,8 @@ class MetasploitModule < Msf::Auxiliary
       OptString.new('CPQLOGIN', [true, 'The homepage of the login', '/cpqlogin.htm']),
       OptString.new('LOGIN_REDIRECT', [true, 'The URL to redirect to', '/cpqlogin'])
     ])
+
+    deregister_options('PASSWORD_SPRAY')
   end
 
   def get_version(res)

--- a/modules/auxiliary/scanner/http/http_login.rb
+++ b/modules/auxiliary/scanner/http/http_login.rb
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Auxiliary
       ])
     register_autofilter_ports([ 80, 443, 8080, 8081, 8000, 8008, 8443, 8444, 8880, 8888 ])
 
-    deregister_options('USERNAME', 'PASSWORD')
+    deregister_options('USERNAME', 'PASSWORD', 'PASSWORD_SPRAY')
   end
 
   def to_uri(uri)

--- a/modules/auxiliary/scanner/http/ipboard_login.rb
+++ b/modules/auxiliary/scanner/http/ipboard_login.rb
@@ -26,6 +26,8 @@ class MetasploitModule < Msf::Auxiliary
     register_options([
         OptString.new('TARGETURI', [true, "The directory of the IP Board install", "/forum/"]),
       ])
+
+    deregister_options('PASSWORD_SPRAY')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/http/jenkins_login.rb
+++ b/modules/auxiliary/scanner/http/jenkins_login.rb
@@ -27,6 +27,8 @@ class MetasploitModule < Msf::Auxiliary
         Opt::RPORT(8080)
       ])
 
+    deregister_options('PASSWORD_SPRAY')
+
     register_autofilter_ports([ 80, 443, 8080, 8081, 8000 ])
   end
 

--- a/modules/auxiliary/scanner/http/manageengine_desktop_central_login.rb
+++ b/modules/auxiliary/scanner/http/manageengine_desktop_central_login.rb
@@ -22,6 +22,8 @@ class MetasploitModule < Msf::Auxiliary
       'License'        => MSF_LICENSE,
       'DefaultOptions' => { 'RPORT' => 8020}
     ))
+
+    deregister_options('PASSWORD_SPRAY')
   end
 
 

--- a/modules/auxiliary/scanner/http/mybook_live_login.rb
+++ b/modules/auxiliary/scanner/http/mybook_live_login.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Auxiliary
     register_autofilter_ports([ 80 ])
 
     # username is hardcoded into application
-    deregister_options('USERNAME', 'USER_FILE', 'USER_AS_PASS', 'DB_ALL_USERS')
+    deregister_options('USERNAME', 'USER_FILE', 'USER_AS_PASS', 'DB_ALL_USERS', 'PASSWORD_SPRAY')
   end
 
   def setup

--- a/modules/auxiliary/scanner/http/octopusdeploy_login.rb
+++ b/modules/auxiliary/scanner/http/octopusdeploy_login.rb
@@ -28,6 +28,8 @@ class MetasploitModule < Msf::Auxiliary
         Opt::RPORT(80),
         OptString.new('TARGETURI', [true, 'URI for login. Default is /api/users/login', '/api/users/login'])
       ])
+
+    deregister_options('PASSWORD_SPRAY')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/http/phpmyadmin_login.rb
+++ b/modules/auxiliary/scanner/http/phpmyadmin_login.rb
@@ -34,6 +34,8 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('PASSWORD', [false, 'The password to PhpMyAdmin', '']),
         OptString.new('TARGETURI', [true, 'The path to PhpMyAdmin', '/index.php'])
       ])
+
+    deregister_options('PASSWORD_SPRAY')
   end
 
   def scanner(ip)

--- a/modules/auxiliary/scanner/http/symantec_web_gateway_login.rb
+++ b/modules/auxiliary/scanner/http/symantec_web_gateway_login.rb
@@ -27,6 +27,8 @@ class MetasploitModule < Msf::Auxiliary
         }
     ))
 
+    deregister_options('PASSWORD_SPRAY')
+
     register_options(
       [
         OptString.new('USERNAME', [false, 'The username to specify for authentication', '']),

--- a/modules/auxiliary/scanner/http/tomcat_mgr_login.rb
+++ b/modules/auxiliary/scanner/http/tomcat_mgr_login.rb
@@ -67,6 +67,8 @@ class MetasploitModule < Msf::Auxiliary
           File.join(Msf::Config.data_directory, "wordlists", "tomcat_mgr_default_pass.txt") ]),
       ])
 
+    deregister_options('PASSWORD_SPRAY')
+
     register_autofilter_ports([ 80, 443, 8080, 8081, 8000, 8008, 8443, 8444, 8880, 8888, 9080, 19300 ])
   end
 

--- a/modules/auxiliary/scanner/http/wordpress_multicall_creds.rb
+++ b/modules/auxiliary/scanner/http/wordpress_multicall_creds.rb
@@ -48,7 +48,7 @@ class MetasploitModule < Msf::Auxiliary
     # Not supporting these options, because we are not actually letting the API to process the
     # password list for us. We are doing that in Metasploit::Framework::LoginScanner::WordpressRPC.
     deregister_options(
-      'BLANK_PASSWORDS', 'PASSWORD', 'USERPASS_FILE', 'USER_AS_PASS', 'DB_ALL_CREDS', 'DB_ALL_PASS'
+      'BLANK_PASSWORDS', 'PASSWORD', 'USERPASS_FILE', 'USER_AS_PASS', 'DB_ALL_CREDS', 'DB_ALL_PASS', 'PASSWORD_SPRAY'
       )
   end
 

--- a/modules/auxiliary/scanner/http/wordpress_xmlrpc_login.rb
+++ b/modules/auxiliary/scanner/http/wordpress_xmlrpc_login.rb
@@ -38,7 +38,7 @@ class MetasploitModule < Msf::Auxiliary
           Opt::RPORT(80),
         ])
 
-    deregister_options('BLANK_PASSWORDS') # we don't need this option
+    deregister_options('BLANK_PASSWORDS', 'PASSWORD_SPRAY') # we don't need these options
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/http/zabbix_login.rb
+++ b/modules/auxiliary/scanner/http/zabbix_login.rb
@@ -27,6 +27,8 @@ class MetasploitModule < Msf::Auxiliary
       'License'        => MSF_LICENSE
     )
 
+    deregister_options('PASSWORD_SPRAY')
+
     register_options(
       [
         Opt::RPORT(80),

--- a/modules/auxiliary/scanner/mqtt/connect.rb
+++ b/modules/auxiliary/scanner/mqtt/connect.rb
@@ -36,6 +36,8 @@ class MetasploitModule < Msf::Auxiliary
           'PASS_FILE' => 'data/wordlists/unix_passwords.txt'
         }
     )
+
+    deregister_options('PASSWORD_SPRAY')
   end
 
   def test_login(username, password)

--- a/modules/auxiliary/scanner/mssql/mssql_login.rb
+++ b/modules/auxiliary/scanner/mssql/mssql_login.rb
@@ -24,6 +24,8 @@ class MetasploitModule < Msf::Auxiliary
         ],
       'License'        => MSF_LICENSE
     )
+
+    deregister_options('PASSWORD_SPRAY')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/mysql/mysql_login.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_login.rb
@@ -29,6 +29,8 @@ class MetasploitModule < Msf::Auxiliary
       [
         Opt::Proxies
       ])
+
+    deregister_options('PASSWORD_SPRAY')
   end
 
   def target

--- a/modules/auxiliary/scanner/nessus/nessus_rest_login.rb
+++ b/modules/auxiliary/scanner/nessus/nessus_rest_login.rb
@@ -31,7 +31,7 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('TARGETURI', [ true,  'The path to the Nessus server login API', '/session']),
       ])
 
-    deregister_options('HttpUsername', 'HttpPassword')
+    deregister_options('HttpUsername', 'HttpPassword', 'PASSWORD_SPRAY')
   end
 
 

--- a/modules/auxiliary/scanner/pop3/pop3_login.rb
+++ b/modules/auxiliary/scanner/pop3/pop3_login.rb
@@ -43,6 +43,8 @@ class MetasploitModule < Msf::Auxiliary
           File.join(Msf::Config.install_root, 'data', 'wordlists', 'unix_passwords.txt')
         ])
     ])
+
+  deregister_options('PASSWORD_SPRAY')
   end
 
   def target

--- a/modules/auxiliary/scanner/postgres/postgres_login.rb
+++ b/modules/auxiliary/scanner/postgres/postgres_login.rb
@@ -43,7 +43,7 @@ class MetasploitModule < Msf::Auxiliary
           File.join(Msf::Config.data_directory, "wordlists", "postgres_default_pass.txt") ]),
       ])
 
-    deregister_options('SQL')
+    deregister_options('SQL', 'PASSWORD_SPRAY')
 
   end
 

--- a/modules/auxiliary/scanner/redis/redis_login.rb
+++ b/modules/auxiliary/scanner/redis/redis_login.rb
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Auxiliary
       ])
 
     # redis does not have an username, there's only password
-    deregister_options('USERNAME', 'USER_AS_PASS', 'USERPASS_FILE', 'USER_FILE', 'DB_ALL_USERS', 'DB_ALL_CREDS')
+    deregister_options('USERNAME', 'USER_AS_PASS', 'USERPASS_FILE', 'USER_FILE', 'DB_ALL_USERS', 'DB_ALL_CREDS', 'PASSWORD_SPRAY')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/smb/smb_login.rb
+++ b/modules/auxiliary/scanner/smb/smb_login.rb
@@ -50,7 +50,6 @@ class MetasploitModule < Msf::Auxiliary
           'USER_AS_PASS'    => false
         }
     )
-    deregister_options('USERNAME','PASSWORD')
 
     # These are normally advanced options, but for this module they have a
     # more active role, so make them regular options.
@@ -64,6 +63,7 @@ class MetasploitModule < Msf::Auxiliary
         OptBool.new('DETECT_ANY_DOMAIN', [false, 'Detect if domain is required for the specified user', false])
       ])
 
+    deregister_options('USERNAME','PASSWORD', 'PASSWORD_SPRAY')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/snmp/snmp_login.rb
+++ b/modules/auxiliary/scanner/snmp/snmp_login.rb
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Auxiliary
       ])
     ])
 
-    deregister_options('USERNAME', 'USER_FILE', 'USERPASS_FILE')
+    deregister_options('USERNAME', 'USER_FILE', 'USERPASS_FILE', 'PASSWORD_SPRAY')
   end
 
   # Operate on a single host so that we can take advantage of multithreading

--- a/modules/auxiliary/scanner/ssh/karaf_login.rb
+++ b/modules/auxiliary/scanner/ssh/karaf_login.rb
@@ -50,6 +50,7 @@ class MetasploitModule < Msf::Auxiliary
       ]
     )
 
+    deregister_options('PASSWORD_SPRAY')
   end
 
   def rport

--- a/modules/auxiliary/scanner/ssh/ssh_login.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login.rb
@@ -47,6 +47,7 @@ class MetasploitModule < Msf::Auxiliary
       ]
     )
 
+    deregister_options('PASSWORD_SPRAY')
   end
 
   def rport

--- a/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
@@ -53,7 +53,7 @@ class MetasploitModule < Msf::Auxiliary
       ]
     )
 
-    deregister_options('PASSWORD','PASS_FILE','BLANK_PASSWORDS','USER_AS_PASS','USERPASS_FILE')
+    deregister_options('PASSWORD','PASS_FILE','BLANK_PASSWORDS','USER_AS_PASS','USERPASS_FILE','PASSWORD_SPRAY')
 
     @good_key = ''
     @strip_passwords = true

--- a/modules/auxiliary/scanner/telnet/brocade_enable_login.rb
+++ b/modules/auxiliary/scanner/telnet/brocade_enable_login.rb
@@ -39,7 +39,10 @@ class MetasploitModule < Msf::Auxiliary
         OptBool.new('GET_USERNAMES_FROM_CONFIG', [ false, 'Pull usernames from config and running config', true])
       ], self.class
     )
-  @no_pass_prompt = []
+
+    deregister_options('PASSWORD_SPRAY')
+
+    @no_pass_prompt = []
   end
 
   def get_username_from_config(un_list,ip)

--- a/modules/auxiliary/scanner/telnet/telnet_login.rb
+++ b/modules/auxiliary/scanner/telnet/telnet_login.rb
@@ -37,6 +37,8 @@ class MetasploitModule < Msf::Auxiliary
       ], self.class
     )
 
+    deregister_options('USERNAME','PASSWORD', 'PASSWORD_SPRAY')
+
     @no_pass_prompt = []
   end
 

--- a/modules/auxiliary/scanner/varnish/varnish_cli_login.rb
+++ b/modules/auxiliary/scanner/varnish/varnish_cli_login.rb
@@ -40,6 +40,8 @@ class MetasploitModule < Msf::Auxiliary
           File.join(Msf::Config.data_directory, 'wordlists', 'unix_passwords.txt') ])
       ])
 
+    deregister_options('PASSWORD_SPRAY')
+
     # We don't currently support an auth mechanism that uses usernames, so we'll ignore any
     # usernames that are passed in.
     @strip_usernames = true

--- a/modules/auxiliary/scanner/vmware/vmauthd_login.rb
+++ b/modules/auxiliary/scanner/vmware/vmauthd_login.rb
@@ -31,6 +31,7 @@ class MetasploitModule < Msf::Auxiliary
 
     register_options([Opt::RPORT(902)])
 
+    deregister_options('PASSWORD_SPRAY')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/vnc/vnc_login.rb
+++ b/modules/auxiliary/scanner/vnc/vnc_login.rb
@@ -47,6 +47,8 @@ class MetasploitModule < Msf::Auxiliary
         OptBool.new('USER_AS_PASS', [false, 'Try the username as the password for all users', false])
       ])
 
+    deregister_options('PASSWORD_SPRAY')
+
     register_autofilter_ports((5900..5910).to_a) # Each instance increments the port by one.
 
     # We don't currently support an auth mechanism that uses usernames, so we'll ignore any

--- a/modules/auxiliary/scanner/winrm/winrm_login.rb
+++ b/modules/auxiliary/scanner/winrm/winrm_login.rb
@@ -32,6 +32,8 @@ class MetasploitModule < Msf::Auxiliary
         ],
       'License'        => MSF_LICENSE
     )
+
+    deregister_options('PASSWORD_SPRAY')
   end
 
 


### PR DESCRIPTION
This PR deregisters the `PASSWORD_SPRAY` option for any scanner modules that use the `LoginScanner.scan!` method to iterate through credentials, which fixes #12009. The `PASSWORD_SPRAY` option was added to the `AuthBrute` module with #9634 so the option is registered anywhere that module is included. Most of the `LoginScanner` modules still include `AuthBrute`, so the option was showing as available even though it was never honored.

The best fix for this would be to port the `PASSWORD_SPRAY` logic over to `LoginScanner`, but that looks to be quite a bit of work. Opting for disabling the option for now in modules where it is not properly honored until that work can be completed.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/ssh/ssh_login` (or any module updated in this PR)
- [ ] `show advanced`
- [ ] Verify the `PASSWORD_SPRAY` option is not displayed

