### PR TITLE
Add the ability to display previous search results

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -364,6 +364,7 @@ module Msf
             cached = false
             search_term = nil
             output_file = nil
+            count = -1
 
             @@search_opts.parse(args) do |opt, idx, val|
               case opt
@@ -385,12 +386,12 @@ module Msf
 
             # Display the table of matches
             tbl = generate_module_table("Matching Modules", search_term)
-            search_params = parse_search_string(match)
-            count = -1
+
             begin
               if cached
                 print_status('Displaying cached results')
               else
+                search_params = parse_search_string(match)
                 @module_search_results = Msf::Modules::Metadata::Cache.instance.find(search_params)
               end
 

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -359,12 +359,12 @@ module Msf
           # Searches modules for specific keywords
           #
           def cmd_search(*args)
-            match = ''
-            use = false
-            cached = false
+            match       = ''
             search_term = nil
             output_file = nil
-            count = -1
+            cached      = false
+            use         = false
+            count       = -1
 
             @@search_opts.parse(args) do |opt, idx, val|
               case opt
@@ -385,7 +385,7 @@ module Msf
             cached = true if args.empty?
 
             # Display the table of matches
-            tbl = generate_module_table("Matching Modules", search_term)
+            tbl = generate_module_table('Matching Modules', search_term)
 
             begin
               if cached
@@ -1184,8 +1184,10 @@ module Msf
           end
 
           def show_module_set(type, module_set, regex = nil, minrank = nil, opts = nil) # :nodoc:
-            tbl = generate_module_table(type)
             count = -1
+
+            tbl = generate_module_table(type)
+
             module_set.sort.each { |refname, mod|
               o = nil
 

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -316,7 +316,9 @@ module Msf
           end
 
           def cmd_search_help
-            print_line "Usage: search [ options ] <keywords>"
+            print_line "Usage: search [ options ] [<keywords>]"
+            print_line
+            print_line "If no options or keywords are provided, cached results are displayed"
             print_line
             print_line "OPTIONS:"
             print_line "  -h                Show this help information"

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -318,7 +318,7 @@ module Msf
           def cmd_search_help
             print_line "Usage: search [ options ] [<keywords>]"
             print_line
-            print_line "If no options or keywords are provided, cached results are displayed"
+            print_line "If no options or keywords are provided, cached results are displayed."
             print_line
             print_line "OPTIONS:"
             print_line "  -h                Show this help information"

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -316,7 +316,7 @@ module Msf
           end
 
           def cmd_search_help
-            print_line "Usage: search [ options ] [<keywords>]"
+            print_line "Usage: search [<options>] [<keywords>]"
             print_line
             print_line "If no options or keywords are provided, cached results are displayed."
             print_line


### PR DESCRIPTION
> This may be helpful if you want to use a module from your previous search, but the results have scrolled off the screen already
Helpful when using by index
I didn't want to change the behavior of `search` by itself, which displays its help
Which is probably helpful to newbies, since there is a lot of development around that kind of code
You can also up-arrow or ^R and rerun your previous search, but...
Open to renaming the option or another implementation
I thought about `-l`, too
Or we could redefine argument-less invocation
Happy to change it, but lately I've kind of hated having to rerun searches

```
msf5 > search ssh_login

Matching Modules
================

   #  Name                                    Disclosure Date  Rank    Check  Description
   -  ----                                    ---------------  ----    -----  -----------
   0  auxiliary/scanner/ssh/ssh_login                          normal  Yes    SSH Login Check Scanner
   1  auxiliary/scanner/ssh/ssh_login_pubkey                   normal  Yes    SSH Public Key Login Scanner


msf5 > use 0
msf5 auxiliary(scanner/ssh/ssh_login) > set rhosts 172.28.128.3
rhosts => 172.28.128.3
msf5 auxiliary(scanner/ssh/ssh_login) > set username vagrant
username => vagrant
msf5 auxiliary(scanner/ssh/ssh_login) > set password vagrant
password => vagrant
msf5 auxiliary(scanner/ssh/ssh_login) > run

[+] 172.28.128.3:22 - Success: 'vagrant:vagrant' 'uid=1000(vagrant) gid=1000(vagrant) groups=1000(vagrant) Linux ubuntu-xenial 4.4.0-141-generic #167-Ubuntu SMP Wed Dec 5 10:40:15 UTC 2018 x86_64 x86_64 x86_64 GNU/Linux '
[*] Command shell session 1 opened (172.28.128.1:64308 -> 172.28.128.3:22) at 2019-06-27 21:28:23 -0500
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf5 auxiliary(scanner/ssh/ssh_login) > search
[*] Displaying cached results

Matching Modules
================

   #  Name                                    Disclosure Date  Rank    Check  Description
   -  ----                                    ---------------  ----    -----  -----------
   0  auxiliary/scanner/ssh/ssh_login                          normal  Yes    SSH Login Check Scanner
   1  auxiliary/scanner/ssh/ssh_login_pubkey                   normal  Yes    SSH Public Key Login Scanner


msf5 auxiliary(scanner/ssh/ssh_login) > use 1
msf5 auxiliary(scanner/ssh/ssh_login_pubkey) >
```

Updates #11724 and #11819.