### PR TITLE
Add GatherProof advanced option to ssh_login*

### DIFF
--- a/lib/metasploit/framework/login_scanner/ssh.rb
+++ b/lib/metasploit/framework/login_scanner/ssh.rb
@@ -39,6 +39,9 @@ module Metasploit
         #
         #   @return [Symbol] An element of {VERBOSITIES}.
         attr_accessor :verbosity
+        # @!attribute skip_gather_proof
+        #   @return [Boolean] Whether to skip calling gather_proof
+        attr_accessor :skip_gather_proof
 
         validates :verbosity,
           presence: true,
@@ -90,7 +93,7 @@ module Metasploit
 
           unless result_options.has_key? :status
             if ssh_socket
-              proof = gather_proof
+              proof = gather_proof unless skip_gather_proof
               result_options.merge!(status: Metasploit::Model::Login::Status::SUCCESSFUL, proof: proof)
             else
               result_options.merge!(status: Metasploit::Model::Login::Status::INCORRECT, proof: nil)

--- a/modules/auxiliary/scanner/ssh/ssh_login.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login.rb
@@ -42,8 +42,9 @@ class MetasploitModule < Msf::Auxiliary
     register_advanced_options(
       [
         Opt::Proxies,
-        OptBool.new('SSH_DEBUG', [ false, 'Enable SSH debugging output (Extreme verbosity!)', false]),
-        OptInt.new('SSH_TIMEOUT', [ false, 'Specify the maximum time to negotiate a SSH session', 30])
+        OptBool.new('SSH_DEBUG', [false, 'Enable SSH debugging output (Extreme verbosity!)', false]),
+        OptInt.new('SSH_TIMEOUT', [false, 'Specify the maximum time to negotiate a SSH session', 30]),
+        OptBool.new('GatherProof', [true, 'Gather proof of access via pre-session shell commands', false])
       ]
     )
 
@@ -111,6 +112,7 @@ class MetasploitModule < Msf::Auxiliary
       connection_timeout: datastore['SSH_TIMEOUT'],
       framework: framework,
       framework_module: self,
+      skip_gather_proof: !datastore['GatherProof']
     )
 
     scanner.verbosity = :debug if datastore['SSH_DEBUG']

--- a/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
@@ -47,9 +47,10 @@ class MetasploitModule < Msf::Auxiliary
     register_advanced_options(
       [
         Opt::Proxies,
-        OptBool.new('SSH_DEBUG', [ false, 'Enable SSH debugging output (Extreme verbosity!)', false]),
+        OptBool.new('SSH_DEBUG', [false, 'Enable SSH debugging output (Extreme verbosity!)', false]),
         OptString.new('SSH_KEYFILE_B64', [false, 'Raw data of an unencrypted SSH public key. This should be used by programmatic interfaces to this module only.', '']),
-        OptInt.new('SSH_TIMEOUT', [ false, 'Specify the maximum time to negotiate a SSH session', 30])
+        OptInt.new('SSH_TIMEOUT', [false, 'Specify the maximum time to negotiate a SSH session', 30]),
+        OptBool.new('GatherProof', [true, 'Gather proof of access via pre-session shell commands', false])
       ]
     )
 
@@ -134,6 +135,7 @@ class MetasploitModule < Msf::Auxiliary
       connection_timeout: datastore['SSH_TIMEOUT'],
       framework: framework,
       framework_module: self,
+      skip_gather_proof: !datastore['GatherProof']
     )
 
     scanner.verbosity = :debug if datastore['SSH_DEBUG']


### PR DESCRIPTION
Quick and dirty fix for Brocade.

Since datastore options don't belong in `LoginScanner`, I've added an accessor, so proof gathering is no longer opaque to modules.

```
msf5 > use ssh_login

Matching Modules
================

   #  Name                                    Disclosure Date  Rank    Check  Description
   -  ----                                    ---------------  ----    -----  -----------
   0  auxiliary/scanner/ssh/ssh_login                          normal  Yes    SSH Login Check Scanner
   1  auxiliary/scanner/ssh/ssh_login_pubkey                   normal  Yes    SSH Public Key Login Scanner


msf5 > use 0
msf5 auxiliary(scanner/ssh/ssh_login) > setg rhosts 172.28.128.3
rhosts => 172.28.128.3
msf5 auxiliary(scanner/ssh/ssh_login) > setg username vagrant
username => vagrant
msf5 auxiliary(scanner/ssh/ssh_login) > set password vagrant
password => vagrant
msf5 auxiliary(scanner/ssh/ssh_login) > run

[+] 172.28.128.3:22 - Success: 'vagrant:vagrant' ''
[*] Command shell session 1 opened (172.28.128.1:64447 -> 172.28.128.3:22) at 2019-06-27 21:46:42 -0500
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf5 auxiliary(scanner/ssh/ssh_login) > set gatherproof true
gatherproof => true
msf5 auxiliary(scanner/ssh/ssh_login) > run

[+] 172.28.128.3:22 - Success: 'vagrant:vagrant' 'uid=1000(vagrant) gid=1000(vagrant) groups=1000(vagrant) Linux ubuntu-xenial 4.4.0-141-generic #167-Ubuntu SMP Wed Dec 5 10:40:15 UTC 2018 x86_64 x86_64 x86_64 GNU/Linux '
[*] Command shell session 2 opened (172.28.128.1:64452 -> 172.28.128.3:22) at 2019-06-27 21:46:50 -0500
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf5 auxiliary(scanner/ssh/ssh_login) > use 1
msf5 auxiliary(scanner/ssh/ssh_login_pubkey) > set key_pa
set key_pass  set key_path
msf5 auxiliary(scanner/ssh/ssh_login_pubkey) > set key_path [redacted]
key_path => [redacted]
msf5 auxiliary(scanner/ssh/ssh_login_pubkey) > run

[*] 172.28.128.3:22 SSH - Testing Cleartext Keys
[*] 172.28.128.3:22 - Testing 1 keys from [redacted]
[+] 172.28.128.3:22 - Success: 'vagrant:-----BEGIN RSA PRIVATE KEY-----
[redacted]
-----END RSA PRIVATE KEY-----
' ''
[*] Command shell session 3 opened (172.28.128.1:64457 -> 172.28.128.3:22) at 2019-06-27 21:48:03 -0500
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf5 auxiliary(scanner/ssh/ssh_login_pubkey) > set gatherproof true
gatherproof => true
msf5 auxiliary(scanner/ssh/ssh_login_pubkey) > run

[*] 172.28.128.3:22 SSH - Testing Cleartext Keys
[*] 172.28.128.3:22 - Testing 1 keys from [redacted]
[+] 172.28.128.3:22 - Success: 'vagrant:-----BEGIN RSA PRIVATE KEY-----
[redacted]
-----END RSA PRIVATE KEY-----
' 'uid=1000(vagrant) gid=1000(vagrant) groups=1000(vagrant) Linux ubuntu-xenial 4.4.0-141-generic #167-Ubuntu SMP Wed Dec 5 10:40:15 UTC 2018 x86_64 x86_64 x86_64 GNU/Linux '
[*] Command shell session 4 opened (172.28.128.1:64460 -> 172.28.128.3:22) at 2019-06-27 21:48:18 -0500
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf5 auxiliary(scanner/ssh/ssh_login_pubkey) >
```

Specifically addresses the Brocade issue in #11905. Does not close the ticket unless @sempervictus thinks so.