### PR TITLE
Fix creds error

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/creds.rb
+++ b/lib/msf/ui/console/command_dispatcher/creds.rb
@@ -471,7 +471,7 @@ class Creds
         private_val = core.private ? core.private.to_s : ""
         realm_val = core.realm ? core.realm.value : ""
         human_val = core.private ? core.private.class.model_name.human : ""
-        jtr_val = core.private.jtr_format ? core.private.jtr_format : ""
+        jtr_val = core.private ? core.private.jtr_format : ""
 
         tbl << [
           "", # host


### PR DESCRIPTION
Calling `creds` when `core.private` is `nil` results in a crash. The fix was made prior to calling `reload_lib` in the output below.

Related: https://github.com/rapid7/metasploit-framework/issues/11433

```
msf5 > creds
[-] Error while running command creds: undefined method `jtr_format' for nil:NilClass

Call stack:
/Users/space/metasploit-framework/lib/msf/ui/console/command_dispatcher/creds.rb:474:in `block in creds_search'
/Users/space/.rvm/gems/ruby-2.6.2@metasploit-framework/gems/activerecord-4.2.11.1/lib/active_record/relation/delegation.rb:46:in `each'
/Users/space/.rvm/gems/ruby-2.6.2@metasploit-framework/gems/activerecord-4.2.11.1/lib/active_record/relation/delegation.rb:46:in `each'
/Users/space/metasploit-framework/lib/msf/ui/console/command_dispatcher/creds.rb:441:in `creds_search'
/Users/space/metasploit-framework/lib/msf/ui/console/command_dispatcher/creds.rb:112:in `cmd_creds'
/Users/space/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:523:in `run_command'
/Users/space/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:474:in `block in run_single'
/Users/space/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:468:in `each'
/Users/space/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:468:in `run_single'
/Users/space/metasploit-framework/lib/rex/ui/text/shell.rb:151:in `run'
/Users/space/metasploit-framework/lib/metasploit/framework/command/console.rb:48:in `start'
/Users/space/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'
./msfconsole:49:in `<main>'
msf5 > reload_lib lib/msf/ui/console/command_dispatcher/creds.rb
[*] Reloading /Users/space/metasploit-framework/lib/msf/ui/console/command_dispatcher/creds.rb
msf5 > creds
Credentials
===========

host            origin          service         public       private                                                       realm  private_type        JtR Format
----            ------          -------         ------       -------                                                       -----  ------------        ----------
                192.168.37.246                  secondUser                                                                                            
                                                blah         blahpassword                                                         Password   
```