### PR TITLE
Add shutdown method to Exploit::Remote::Tcp

### DIFF
--- a/lib/msf/core/exploit/tcp.rb
+++ b/lib/msf/core/exploit/tcp.rb
@@ -172,6 +172,19 @@ module Exploit::Remote::Tcp
   end
 
   #
+  # Shutdown the TCP connection
+  #
+  # @param how
+  # 0 - finished reading data
+  # 1 - finished writing data
+  # 2 - finished using this socket
+  #
+  def shutdown(how = 2)
+    self.sock.shutdown(how) if self.sock
+  rescue IOError
+  end
+
+  #
   # Closes the TCP connection
   #
   def disconnect(nsock = self.sock)

--- a/lib/msf/core/exploit/tcp.rb
+++ b/lib/msf/core/exploit/tcp.rb
@@ -174,12 +174,7 @@ module Exploit::Remote::Tcp
   #
   # Shutdown the TCP connection
   #
-  # @param how
-  # 0 - finished reading data
-  # 1 - finished writing data
-  # 2 - finished using this socket
-  #
-  def shutdown(how = 2)
+  def shutdown(how = :SHUT_RDWR)
     self.sock.shutdown(how) if self.sock
   rescue IOError
   end


### PR DESCRIPTION
This PR exposes a `shutdown` method for `Exploit::Remote::Tcp.sock`.

I encountered a protocol recently which required sending `sock.shutdown(1)` before replying. The server refused to return data until it received a promise that no more data was to be sent.

* https://www.rubydoc.info/stdlib/socket/BasicSocket:shutdown
* https://perldoc.perl.org/functions/shutdown.html
