### PR TITLE
Fix OpenVAS import issue caused by missing wspace key

### DIFF
--- a/spec/support/shared/examples/msf/db_manager/import/open_vas.rb
+++ b/spec/support/shared/examples/msf/db_manager/import/open_vas.rb
@@ -1,5 +1,5 @@
 RSpec.shared_examples_for 'Msf::DBManager::Import::OpenVAS' do
+  it { is_expected.to respond_to :import_openvas_noko_stream }
   it { is_expected.to respond_to :import_openvas_new_xml }
-  it { is_expected.to respond_to :import_openvas_new_xml_file }
   it { is_expected.to respond_to :import_openvas_xml }
 end


### PR DESCRIPTION
Fixes #11851, an OpenVAS import issue caused by missing `wspace` arguments key. Modifying the `Msf::DBManager::Import::OpenVAS` module to implement a pattern observed in other `Msf::DBManager::Import::*` modules where there are both `import_<type>` and `import_<type>_noko_stream` methods.


**Database status before import:**
```
msf5 > db_status
[*] Connected to remote_data_service: (https://localhost:5443). Connection type: http. Connection name: local-https-data-service.
msf5 > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  0      0         0      0      0      0
```

**Import OpenVAS data file and confirm:**
```
msf5 > db_import /home/msfdev/openvas_download.xml
[*] Successfully imported /home/msfdev/openvas_download.xml
msf5 > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  1      24        23     0      0      0
```

## Verification

- [x] Download `openvas_download.txt` file from #11851
- [x] Rename `openvas_download.txt` to `openvas_download.xml`
- [x] Start `msfconsole`
- [x] Run `db_import openvas_download.xml`
- [x] **Verify** the `db_import` command ran successfully and imported a host, services and vulns.