### PR TITLE
Add lokiuox to bypassuac_silentcleanup authors

### DIFF
--- a/modules/exploits/windows/local/bypassuac_silentcleanup.rb
+++ b/modules/exploits/windows/local/bypassuac_silentcleanup.rb
@@ -24,6 +24,7 @@ class MetasploitModule < Msf::Exploit::Local
         'tyranid', # Discovery
         'enigma0x3', # Discovery
         'nyshone69', # Discovery
+        'lokiuox', # PSH script
         'Carter Brainerd (cbrnrd)' # Metasploit Module
       ],
       'Platform'             => ['win'],


### PR DESCRIPTION
Looks like they were removed by accident.

I said add the other authors, not remove @lokiuox, lol.

Fixes #11997, specifically https://github.com/rapid7/metasploit-framework/pull/11997/commits/d2dc5f6077a181c1739713ee845f36396509cd21.