### PR TITLE
Fix SNMP enumeration module network interface processing

### DIFF
--- a/modules/auxiliary/scanner/snmp/snmp_enum.rb
+++ b/modules/auxiliary/scanner/snmp/snmp_enum.rb
@@ -172,10 +172,10 @@ class MetasploitModule < Msf::Auxiliary
 
         ifindex  = index.value
         ifdescr  = descr.value
-        ifmac    = mac.value.unpack("H2H2H2H2H2H2").join(":")
+        ifmac    = mac.value.to_s =~ /noSuchInstance/ ? 'unknown' : mac.value.unpack("H2H2H2H2H2H2").join(":")
         iftype   = type.value
         ifmtu    = mtu.value
-        ifspeed  = speed.value.to_i
+        ifspeed  = speed.value.to_s =~ /noSuchInstance/ ? 'unknown' : speed.value.to_i / 1000000
         ifinoc   = inoc.value
         ifoutoc  = outoc.value
         ifstatus = status.value
@@ -259,8 +259,6 @@ class MetasploitModule < Msf::Auxiliary
         else
           ifstatus = "unknown"
         end
-
-        ifspeed = ifspeed / 1000000
 
         network_interfaces.push({
           "Interface" => "[ #{ifstatus} ] #{ifdescr}",


### PR DESCRIPTION
The `auxiliary/scanner/snmp/snmp_enum` module uses an SNMP walk operation to enumerate the network interface and this can return an `SNMP::NoSuchInstance` class when a OID for an object, or variable binding (varbind), is missing. The module attempts to use the error class as a valid value resulting in the issues detailed below. Fixes #12034

### Before fix
#### ifPhysAddress is not returned
```
msf5 > use auxiliary/scanner/snmp/snmp_enum
msf5 auxiliary(scanner/snmp/snmp_enum) > set rhosts 192.168.1.5
rhosts => 192.168.1.5
msf5 auxiliary(scanner/snmp/snmp_enum) > run

[+] 192.168.1.5, Connected.
[-] Unknown error: NoMethodError undefined method `unpack' for SNMP::NoSuchInstance:Class
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

~/.msf4/logs/framework.log:
```
[07/02/2019 14:28:15] [e(0)] core: Unknown error: NoMethodError undefined method `unpack' for SNMP::NoSuchInstance:Class
[07/02/2019 14:28:15] [e(0)] core: Call stack:
/home/msfdev/metasploit-framework/modules/auxiliary/scanner/snmp/snmp_enum.rb:175:in `block in run_host'
/home/msfdev/metasploit-framework/lib/snmp/manager.rb:449:in `block in walk'
/home/msfdev/metasploit-framework/lib/snmp/manager.rb:434:in `loop'
/home/msfdev/metasploit-framework/lib/snmp/manager.rb:434:in `walk'
/home/msfdev/metasploit-framework/modules/auxiliary/scanner/snmp/snmp_enum.rb:167:in `run_host'
/home/msfdev/metasploit-framework/lib/msf/core/auxiliary/scanner.rb:111:in `block (2 levels) in run'
/home/msfdev/metasploit-framework/lib/msf/core/thread_manager.rb:106:in `block in spawn'
```

#### ifSpeed is not returned
```
msf5 > use auxiliary/scanner/snmp/snmp_enum
msf5 auxiliary(scanner/snmp/snmp_enum) > set rhosts 192.168.1.5
rhosts => 192.168.1.5
msf5 auxiliary(scanner/snmp/snmp_enum) > run

[+] 192.168.1.5, Connected.
[-] Unknown error: NoMethodError undefined method `to_i' for SNMP::NoSuchInstance:Class
Did you mean?  to_s
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

~/.msf4/logs/framework.log:
```
[07/02/2019 15:03:38] [e(0)] core: Unknown error: NoMethodError undefined method `to_i' for SNMP::NoSuchInstance:Class
Did you mean?  to_s
[07/02/2019 15:03:38] [e(0)] core: Call stack:
/home/msfdev/metasploit-framework/modules/auxiliary/scanner/snmp/snmp_enum.rb:178:in `block in run_host'
/home/msfdev/metasploit-framework/lib/snmp/manager.rb:449:in `block in walk'
/home/msfdev/metasploit-framework/lib/snmp/manager.rb:434:in `loop'
/home/msfdev/metasploit-framework/lib/snmp/manager.rb:434:in `walk'
/home/msfdev/metasploit-framework/modules/auxiliary/scanner/snmp/snmp_enum.rb:167:in `run_host'
/home/msfdev/metasploit-framework/lib/msf/core/auxiliary/scanner.rb:111:in `block (2 levels) in run'
/home/msfdev/metasploit-framework/lib/msf/core/thread_manager.rb:106:in `block in spawn'
```

### After fix
```
msf5 > use auxiliary/scanner/snmp/snmp_enum
msf5 auxiliary(scanner/snmp/snmp_enum) > set rhosts 192.168.1.5
rhosts => 192.168.1.5
msf5 auxiliary(scanner/snmp/snmp_enum) > run

[+] 192.168.1.5, Connected.

...

[*] Network information:

IP forwarding enabled         : no
Default TTL                   : 64
TCP segments received         : 214860
TCP segments sent             : 131618
TCP segments retrans          : 0
Input datagrams               : 256953
Delivered datagrams           : 256950
Output datagrams              : 173704

[*] Network interfaces:

Interface                     : [ up ] lo
Id                            : 1
Mac Address                   : unknown
Type                          : softwareLoopback
Speed                         : unknown Mbps
MTU                           : 65536
In octets                     : 566084
Out octets                    : 566084

Interface                     : [ up ] Intel Corporation 82540EM Gigabit Ethernet Controller
Id                            : 2
Mac Address                   : unknown
Type                          : ethernet-csmacd
Speed                         : unknown Mbps
MTU                           : 1500
In octets                     : 414606844
Out octets                    : 12252239
...
```

## Verification

- [ ] Configure the Net-SNMP package with the following `/etc/snmp/snmpd.conf` settings. This includes everything from the ISO root except `ifPhysAddress` and `ifSpeed` from the interfaces MIB object.
```
view   systemonly  included   .1
view   systemonly  excluded   .1.3.6.1.2.1.2.2.1.6
view   systemonly  excluded   .1.3.6.1.2.1.2.2.1.5
```
- [ ] Restart snmpd: `sudo service snmpd restart`
- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/snmp/snmp_enum`
- [ ] `set rhosts <host>`
- [ ] `run`
- [ ] **Verify** there are no exceptions and the "Network information" section contains a "Mac Address" with the value "unknown" and "Speed" with the value "unknown Mbps".