### PR TITLE
revert rex-socket back to 0.1.17 for now

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,7 +59,7 @@ PATH
       rex-random_identifier
       rex-registry
       rex-rop_builder
-      rex-socket
+      rex-socket (= 0.1.17)
       rex-sslscan
       rex-struct2
       rex-text
@@ -319,7 +319,7 @@ GEM
       metasm
       rex-core
       rex-text
-    rex-socket (0.1.18)
+    rex-socket (0.1.17)
       rex-core
     rex-sslscan (0.1.5)
       rex-core

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -167,7 +167,7 @@ Gem::Specification.new do |spec|
   # Library for parsing and manipulating executable binaries
   spec.add_runtime_dependency 'rex-bin_tools'
   # Rex Socket Abstraction Layer
-  spec.add_runtime_dependency 'rex-socket'
+  spec.add_runtime_dependency 'rex-socket', '0.1.17'
   # Library for scanning a server's SSL/TLS capabilities
   spec.add_runtime_dependency 'rex-sslscan'
   # Library and tool for finding ROP gadgets in a supplied binary


### PR DESCRIPTION
This reverts a change that causes SSL certificate generation to not working properly through all of the various shim functions in rex-socket. This is the quickest fix which grants some time to ponder if the interface could be a little more robust in rex-socket in the first place.

Fixes #12037 and #12038 

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use multi/handler`
- [x] `set payload windows/meterpreter/reverse_https`
- [x] `run`
- [x] **Verify** the listener listens with no errors
