### PR TITLE
Cisco/Juniper Local File Config Loader

### DIFF
--- a/documentation/modules/auxiliary/admin/cisco/cisco_config.md
+++ b/documentation/modules/auxiliary/admin/cisco/cisco_config.md
@@ -1,0 +1,51 @@
+## General Notes
+
+This module imports a Cisco configuration file into the database.
+This is similar to `post/cisco/gather/enum_cisco` only access isn't required,
+and assumes you already have the file.
+
+Example files for import can be found on git, like [this](https://raw.githubusercontent.com/GaetanLongree/MASI-ProjetAvanceReseau/3cf1d9a93828d5f44ee1bc4e4c01411e416892c5/Los%20Angeles/LA_EDGE_D.txt)
+or from [Cisco](https://www.cisco.com/en/US/docs/routers/access/800/850/software/configuration/guide/sampconf.html).
+
+## Verification Steps
+
+1. Have a Cisco configuration file
+2. Start `msfconsole`
+3. `use auxiliary/admin/cisco/cisco_config`
+4. `set RHOST x.x.x.x`
+5. `set CONFIG /tmp/file.config`
+6. `run`
+
+## Options
+
+  **RHOST**
+
+  Needed for setting services and items to.  This is relatively arbitrary.
+
+  **CONFIG**
+
+  File path to the configuration file.
+
+## Scenarios
+
+```
+root@metasploit-dev:~/metasploit-framework# wget https://raw.githubusercontent.com/GaetanLongree/MASI-ProjetAvanceReseau/3cf1d9a93828d5f44ee1bc4e4c01411e416892c5/Los%20Angeles/LA_EDGE_D.txt -O /tmp/LA_EDGE_D.txt -o /dev/null
+
+root@metasploit-dev:~/metasploit-framework# ./msfconsole 
+
+[*] Starting persistent handler(s)...
+msf5 > use auxiliary/admin/cisco/cisco_config 
+msf5 auxiliary(admin/cisco/cisco_config) > set config /tmp/LA_EDGE_D.txt
+config => /tmp/LA_EDGE_D.txt
+msf5 auxiliary(admin/cisco/cisco_config) > set rhost 127.0.0.1
+rhost => 127.0.0.1
+msf5 auxiliary(admin/cisco/cisco_config) > run
+[*] Running module against 127.0.0.1
+
+[*] Importing config
+[+] 127.0.0.1:22 MD5 Encrypted Enable Password: $1$mERr$DWwx4W/5HXD2oail62IeB1
+[+] 127.0.0.1:22 Username 'Waldo' with MD5 Encrypted Password: $1$mERr$DWwx4W/5HXD2oail62IeB1
+[+] Config import successful
+[*] Auxiliary module execution completed
+```
+

--- a/documentation/modules/auxiliary/admin/juniper/juniper_config.md
+++ b/documentation/modules/auxiliary/admin/juniper/juniper_config.md
@@ -1,0 +1,91 @@
+## General Notes
+
+This module imports a Juniper configuration file into the database.
+This is similar to `post/juniper/gather/enum_juniper` only access isn't required,
+and assumes you already have the file.
+
+Example files for import can be found on git, like [this (junos)](https://raw.githubusercontent.com/h00die/MSF-Testing-Scripts/master/juniper_ex2200.config)
+or [this (screenos)](https://raw.githubusercontent.com/h00die/MSF-Testing-Scripts/master/juniper_ssg5_screenos.conf).
+
+## Verification Steps
+
+1. Have a Juniper configuration file
+2. Start `msfconsole`
+3. `use auxiliary/admin/juniper/juniper_config`
+4. `set RHOST x.x.x.x`
+5. `set CONFIG /tmp/file.config`
+6. `set action junos`
+7. `run`
+
+## Options
+
+  **RHOST**
+
+  Needed for setting services and items to.  This is relatively arbitrary.
+
+  **CONFIG**
+
+  File path to the configuration file.
+
+  **Action**
+
+  `JUNOS` for JunOS config file, and `SCREENOS` for ScreenOS config file.
+
+## Scenarios
+
+### JunOS
+
+```
+root@metasploit-dev:~/metasploit-framework# wget -o /dev/null -O /tmp/juniper_ex2200.config https://raw.githubusercontent.com/h00die/MSF-Testing-Scripts/master/juniper_ex2200.config
+root@metasploit-dev:~/metasploit-framework# ./msfconsole 
+
+[*] Starting persistent handler(s)...
+msf5 > use auxiliary/admin/juniper/gather/juniper_config
+msf5 auxiliary(admin/juniper/gather/juniper_config) > set config /tmp/juniper_ex2200.config
+config => /tmp/juniper_ex2200.config
+msf5 auxiliary(admin/juniper/gather/juniper_config) > set rhost 127.0.0.1
+rhost => 127.0.0.1
+msf5 auxiliary(admin/juniper/gather/juniper_config) > run
+[*] Running module against 127.0.0.1
+
+[*] Importing config
+[+] root password hash: $1$pz9b1.fq$foo5r85Ql8mXdoRUe0C1E.
+[+] User 2000 named newuser in group super-user found with password hash $1$rm8FaMFY$k4LFxqsVAiGO5tKqyO9jJ/.
+[+] User 2002 named newuser2 in group operator found with password hash $1$aDZi44AP$bQGGjqPJ.F.Cm5QvX2yaa0.
+[+] User 2003 named newuser3 in group read-only found with password hash $1$1.YvKzUY$dcAj99KngGhFZTpxGjA93..
+[+] User 2004 named newuser4 in group unauthorized found with password hash $1$bdWYaqOE$z6oTSJS3p1R8CoNaos9Ce/.
+[+] SNMP community read with permissions read-only
+[+] SNMP community public with permissions read-only
+[+] SNMP community private with permissions read-write
+[+] SNMP community secretsauce with permissions read-write
+[+] SNMP community hello there with permissions read-write
+[+] radius server 1.1.1.1 password hash: $9$Y-4GikqfF39JGCu1Ileq.PQ6AB1hrlMBIyKvWdV
+[+] PPTP username 'pap_username' hash $9$he4revM87-dsevm5TQCAp0BErvLxd4JDNdkPfT/9BIR via PAP
+[+] Config import successful
+[*] Auxiliary module execution completed
+```
+
+### ScreenOS
+
+```
+root@metasploit-dev:~/metasploit-framework# wget -o /dev/null -O /tmp/screenos.conf https://raw.githubusercontent.com/h00die/MSF-Testing-Scripts/master/juniper_ssg5_screenos.conf
+root@metasploit-dev:~/metasploit-framework# ./msfconsole 
+
+[*] Starting persistent handler(s)...
+msf5 > use auxiliary/admin/juniper/gather/juniper_config
+msf5 auxiliary(admin/juniper/gather/juniper_config) > set config /tmp/screenos.conf
+config => /tmp/screenos.conf
+msf5 auxiliary(admin/juniper/gather/juniper_config) > set rhost 127.0.0.1
+rhost => 127.0.0.1
+msf5 auxiliary(admin/juniper/gather/juniper_config) > set action SCREENOS
+action => SCREENOS
+msf5 auxiliary(admin/juniper/gather/juniper_config) > run
+[*] Running module against 127.0.0.1
+
+[*] Importing config
+[+] Admin user netscreen found with password hash nKVUM2rwMUzPcrkG5sWIHdCtqkAibn
+[+] User 1 named testuser found with password hash auth. Enable permission: 02b0jt2gZGipCiIEgl4eainqZIKzjSNQYLIwE=
+[+] Config import successful
+[*] Auxiliary module execution completed
+```
+

--- a/lib/msf/core/auxiliary/juniper.rb
+++ b/lib/msf/core/auxiliary/juniper.rb
@@ -38,7 +38,7 @@ module Auxiliary::Juniper
     # Example lines:
     # set admin name "netscreen"
     # set admin password "nKVUM2rwMUzPcrkG5sWIHdCtqkAibn"
-    config.scan(/set admin name "(?<admin_name>[a-z0-9]+)".+set admin password "(?<admin_password_hash>.+)"/mi).each do |result|
+    config.scan(/set admin name "(?<admin_name>[a-z0-9]+)".+set admin password "(?<admin_password_hash>[a-z0-9]+)"/mi).each do |result|
       admin_name = result[0].strip
       admin_hash = result[1].strip
       print_good("Admin user #{admin_name} found with password hash #{admin_hash}")

--- a/modules/auxiliary/admin/cisco/cisco_config.rb
+++ b/modules/auxiliary/admin/cisco/cisco_config.rb
@@ -1,0 +1,39 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core/auxiliary/cisco'
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Auxiliary::Cisco
+  def initialize(info={})
+    super( update_info( info,
+      'Name'          => 'Cisco Configuration Importer',
+      'Description'   => %q{
+        This module imports a Cisco IOS or NXOS device configuration.
+        },
+      'License'       => MSF_LICENSE,
+      'Author'        => [ 'h00die'],
+    ))
+
+    register_options(
+      [
+        OptPath.new('CONFIG', [true, 'Path to configuration to import']),
+        Opt::RHOST(),
+        Opt::RPORT(22)
+      ])
+
+  end
+
+  def run
+    unless ::File.exist?(datastore['CONFIG'])
+      fail_with Failure::BadConfig, "Cisco config file #{datastore['CONFIG']} does not exists!"
+    end
+    cisco_config = ::File.open(datastore['CONFIG'], "rb")
+    print_status('Importing config')
+    cisco_ios_config_eater(datastore['RHOSTS'],datastore['RPORT'],cisco_config.read)
+    print_good('Config import successful')
+  end
+end
+

--- a/modules/auxiliary/admin/juniper/juniper_config.rb
+++ b/modules/auxiliary/admin/juniper/juniper_config.rb
@@ -36,12 +36,12 @@ class MetasploitModule < Msf::Auxiliary
     unless ::File.exist?(datastore['CONFIG'])
       fail_with Failure::BadConfig, "Juniper config file #{datastore['CONFIG']} does not exists!"
     end
-    cisco_config = ::File.open(datastore['CONFIG'], "rb")
+    juniper_config = ::File.open(datastore['CONFIG'], "rb")
     print_status('Importing config')
     if action.name == 'JUNOS'
-      juniper_junos_config_eater(datastore['RHOSTS'],datastore['RPORT'],cisco_config.read)
+      juniper_junos_config_eater(datastore['RHOSTS'],datastore['RPORT'],juniper_config.read)
     elsif action.name == 'SCREENOS'
-      juniper_screenos_config_eater(datastore['RHOSTS'],datastore['RPORT'],cisco_config.read)
+      juniper_screenos_config_eater(datastore['RHOSTS'],datastore['RPORT'],juniper_config.read)
     end
     print_good('Config import successful')
   end

--- a/modules/auxiliary/admin/juniper/juniper_config.rb
+++ b/modules/auxiliary/admin/juniper/juniper_config.rb
@@ -1,0 +1,49 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core/auxiliary/juniper'
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Auxiliary::Juniper
+  def initialize(info={})
+    super( update_info( info,
+      'Name'          => 'Juniper Configuration Importer',
+      'Description'   => %q{
+        This module imports a Juniper ScreenOS or JunOS device configuration.
+        },
+      'License'       => MSF_LICENSE,
+      'Author'        => [ 'h00die'],
+      'Actions'       =>
+        [
+          ['JUNOS', {'Description' => 'Import JunOS Config File'}],
+          ['SCREENOS', {'Description' => 'Import ScreenOS Config File'}],
+        ],
+      'DefaultAction' => 'JUNOS',
+    ))
+
+    register_options(
+      [
+        OptPath.new('CONFIG', [true, 'Path to configuration to import']),
+        Opt::RHOST(),
+        Opt::RPORT(22)
+      ])
+
+  end
+
+  def run
+    unless ::File.exist?(datastore['CONFIG'])
+      fail_with Failure::BadConfig, "Juniper config file #{datastore['CONFIG']} does not exists!"
+    end
+    cisco_config = ::File.open(datastore['CONFIG'], "rb")
+    print_status('Importing config')
+    if action.name == 'JUNOS'
+      juniper_junos_config_eater(datastore['RHOSTS'],datastore['RPORT'],cisco_config.read)
+    elsif action.name == 'SCREENOS'
+      juniper_screenos_config_eater(datastore['RHOSTS'],datastore['RPORT'],cisco_config.read)
+    end
+    print_good('Config import successful')
+  end
+end
+


### PR DESCRIPTION
Want to database a cisco/juniper config file?  You have to have a shell and use a post module.  But I think more times than not I find these on git or an admin's desktop.

This PR makes modules to use the config eater functions off of a local file.  It also fixes a bug in the ScreenOS config eater being too aggressive.

Brocade eater is with #11927 

## Verification

- [x] Check the docs, they have instructions and test files.
