### PR TITLE
Fix cmd_psh_payload requiring an arch string

### DIFF
--- a/modules/exploits/multi/fileformat/ghostscript_failed_restore.rb
+++ b/modules/exploits/multi/fileformat/ghostscript_failed_restore.rb
@@ -88,7 +88,11 @@ class MetasploitModule < Msf::Exploit
     when :unix_memory
       sploit.sub!(PLACEHOLDER_COMMAND, payload.encoded)
     when :psh_memory
-      psh = cmd_psh_payload(payload.encoded, payload.arch, remove_comspec: true)
+      psh = cmd_psh_payload(
+        payload.encoded,
+        payload.arch.first,
+        remove_comspec: true
+      )
 
       # XXX: Payload space applies to the payload, not the PSH command
       if psh.length > targets[0].payload_space

--- a/modules/exploits/multi/http/struts2_rest_xstream.rb
+++ b/modules/exploits/multi/http/struts2_rest_xstream.rb
@@ -98,9 +98,16 @@ class MetasploitModule < Msf::Exploit::Remote
       when :py_memory
         %W{python -c #{cmd}}
       when :psh_memory
-        opts = {remove_comspec: true, encode_final_payload: true}
-        payload ? cmd_psh_payload(cmd, payload.arch, opts).split :
-                  %W{powershell.exe -c #{cmd}}
+        if payload
+          cmd_psh_payload(
+            cmd,
+            payload.arch.first,
+            remove_comspec:       true,
+            encode_final_payload: true
+          )
+        else
+          %W{powershell.exe -c #{cmd}}
+        end
       when :win_memory, :win_dropper
         %W{cmd.exe /c #{cmd}}
       end

--- a/modules/exploits/windows/local/ms16_032_secondary_logon_handle_privesc.rb
+++ b/modules/exploits/windows/local/ms16_032_secondary_logon_handle_privesc.rb
@@ -104,7 +104,7 @@ class MetasploitModule < Msf::Exploit::Local
     end
 
     # payload formatted to fit dropped text file
-    payl = cmd_psh_payload(payload.encoded,payload.arch,{
+    payl = cmd_psh_payload(payload.encoded,payload.arch.first,{
       encode_final_payload: false,
       remove_comspec: true,
       method: 'old'


### PR DESCRIPTION
We may want to update `Rex::Powershell` to take the first in an array.

Or we find a better way and kill this arch/platform anti-pattern with fire.

https://github.com/rapid7/rex-powershell/blob/f209a542b9a15cb1e7c2ac0a718a39e52510d9be/lib/rex/powershell/command.rb#L238-L244