### PR TITLE
Fix missing split in cmd_psh_payload fixes

### DIFF
--- a/modules/exploits/multi/http/struts2_rest_xstream.rb
+++ b/modules/exploits/multi/http/struts2_rest_xstream.rb
@@ -104,7 +104,7 @@ class MetasploitModule < Msf::Exploit::Remote
             payload.arch.first,
             remove_comspec:       true,
             encode_final_payload: true
-          )
+          ).split
         else
           %W{powershell.exe -c #{cmd}}
         end


### PR DESCRIPTION
Whoops, missed the `split`. Caffeine. 🧟

Fixes #12072.