### PR TITLE
Gracefully handle passthrough commands

### DIFF
--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -505,11 +505,7 @@ protected
 
         self.busy = true
         begin
-          io = ::IO.popen(line, "r")
-          io.each_line do |data|
-            print(data)
-          end
-          io.close
+          system(*Shellwords.split(line))
         rescue ::Errno::EACCES, ::Errno::ENOENT
           print_error("Permission denied exec: #{line}")
         end


### PR DESCRIPTION
The `system` method handles input and output as appropriate, allowing
programs that need user input to execute properly without racing
msfconsole over STDIN

Verification
========

- [x] `./msfconsole`
- [x] `man git-push`
- [x] Verify that the you can navigate the man page and none of the input gets unexpectedly eaten, and none of the output clobbered
- [x] `python`
- [x] Verify that you can interact normally with the Python shell