### PR TITLE
Fix is_payload_compatible? for nil payloads

### DIFF
--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -741,6 +741,8 @@ class Exploit < Msf::Module
   def is_payload_compatible?(name)
     p = framework.payloads[name]
 
+    return false unless p
+
     # Skip over payloads that are too big
     return false if payload_space && p.cached_size && p.cached_size > payload_space
 


### PR DESCRIPTION
```
[1] pry(#<Msf::Modules::Exploit__Multi__Browser__Java_jre17_provider_skeleton::MetasploitModule>)> is_payload_compatible?(nil)
=> false
[2] pry(#<Msf::Modules::Exploit__Multi__Browser__Java_jre17_provider_skeleton::MetasploitModule>)> is_payload_compatible?('')
=> false
[3] pry(#<Msf::Modules::Exploit__Multi__Browser__Java_jre17_provider_skeleton::MetasploitModule>)> is_payload_compatible?('windows/met')
=> false
[4] pry(#<Msf::Modules::Exploit__Multi__Browser__Java_jre17_provider_skeleton::MetasploitModule>)> is_payload_compatible?('windows/meterpreter/reverse_tcp')
=> true
[5] pry(#<Msf::Modules::Exploit__Multi__Browser__Java_jre17_provider_skeleton::MetasploitModule>)>
```

Fixes #12076, presumably. See that issue for bug repro.