### PR TITLE
Restore unknown_command passthrough to the shell

### DIFF
--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -505,7 +505,7 @@ protected
 
         self.busy = true
         begin
-          system(*Shellwords.split(line))
+          system(line)
         rescue ::Errno::EACCES, ::Errno::ENOENT
           print_error("Permission denied exec: #{line}")
         end


### PR DESCRIPTION
This continues to prefer `system` over `popen`, but it restores the original behavior of shelling out, allowing the use of shell metacharacters, etc.

## Before #12080

```
msf5 > echo *
[*] exec: echo *

CODE_OF_CONDUCT.md CONTRIBUTING.md COPYING CURRENT.md Dockerfile Gemfile Gemfile.local.example Gemfile.lock LICENSE LICENSE_GEMS README.md Rakefile Vagrantfile app config data db docker docker-compose.override.yml docker-compose.yml documentation external lib metasploit-framework.gemspec modules msf-json-rpc.ru msf-ws.ru msfconsole msfd msfdb msfrpc msfrpcd msfupdate msfvenom plugins script scripts spec test tools
msf5 >
```

## After #12080

```
msf5 > echo *
[*] exec: echo *

*
msf5 >
```

## After this PR

```
msf5 > echo *
[*] exec: echo *

CODE_OF_CONDUCT.md CONTRIBUTING.md COPYING CURRENT.md Dockerfile Gemfile Gemfile.local.example Gemfile.lock LICENSE LICENSE_GEMS README.md Rakefile Vagrantfile app config data db docker docker-compose.override.yml docker-compose.yml documentation external lib metasploit-framework.gemspec modules msf-json-rpc.ru msf-ws.ru msfconsole msfd msfdb msfrpc msfrpcd msfupdate msfvenom plugins script scripts spec test tools
msf5 >
```

Fixes #12080.