### PR TITLE
Backport `search -u`,`use` and `alias` to 4.x

### DIFF
--- a/lib/msf/core/analyze.rb
+++ b/lib/msf/core/analyze.rb
@@ -34,22 +34,22 @@ class Msf::Analyze
 
   private
 
-  # Tests for various service conditions by comparing the module's full_name (which
+  # Tests for various service conditions by comparing the module's fullname (which
   # is basically a pathname) to the intended target service record. The service.info
   # column is tested against a regex in most/all cases and "false" is returned in the
   # event of a match between an incompatible module and service fingerprint.
   def exploit_filter_by_service(mod, serv)
 
     # Filter out Unix vs Windows exploits for SMB services
-    return true if (mod.full_name =~ /\/samba/ and serv.info.to_s =~ /windows/i)
-    return true if (mod.full_name =~ /\/windows/ and serv.info.to_s =~ /samba|unix|vxworks|qnx|netware/i)
-    return true if (mod.full_name =~ /\/netware/ and serv.info.to_s =~ /samba|unix|vxworks|qnx/i)
+    return true if (mod.fullname =~ /\/samba/ and serv.info.to_s =~ /windows/i)
+    return true if (mod.fullname =~ /\/windows/ and serv.info.to_s =~ /samba|unix|vxworks|qnx|netware/i)
+    return true if (mod.fullname =~ /\/netware/ and serv.info.to_s =~ /samba|unix|vxworks|qnx/i)
 
     # Filter out IIS exploits for non-Microsoft services
-    return true if (mod.full_name =~ /\/iis\/|\/isapi\// and (serv.info.to_s !~ /microsoft|asp/i))
+    return true if (mod.fullname =~ /\/iis\/|\/isapi\// and (serv.info.to_s !~ /microsoft|asp/i))
 
     # Filter out Apache exploits for non-Apache services
-    return true if (mod.full_name =~ /\/apache/ and serv.info.to_s !~ /apache|ibm/i)
+    return true if (mod.fullname =~ /\/apache/ and serv.info.to_s !~ /apache|ibm/i)
 
     false
   end

--- a/lib/msf/core/db_manager/import.rb
+++ b/lib/msf/core/db_manager/import.rb
@@ -123,7 +123,7 @@ module Msf::DBManager::Import
         # Module names that match this vulnerability
         matched = mrefs.values_at(*(vuln.refs.map { |x| x.name.upcase } & mrefs.keys)).map { |x| x.values }.flatten.uniq
         next if matched.empty?
-        match_names = matched.map { |mod| mod.full_name }
+        match_names = matched.map { |mod| mod.fullname }
 
         second_pass_services = []
 

--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -684,7 +684,12 @@ class Exploit < Msf::Module
   # The target index that has been selected.
   #
   def target_index
-    target_idx = Integer(datastore['TARGET']) rescue datastore['TARGET']
+    target_idx =
+      begin
+        Integer(datastore['TARGET'])
+      rescue ArgumentError, TypeError
+        datastore['TARGET']
+      end
 
     default_idx = default_target || 0
     # Use the default target if one was not supplied.

--- a/lib/msf/core/module/full_name.rb
+++ b/lib/msf/core/module/full_name.rb
@@ -31,11 +31,20 @@ module Msf::Module::FullName
     def shortname
       refname.split('/').last
     end
+
+    #
+    # Returns a list of alternate names the module might go by.
+    #
+    def aliases
+      const_defined?(:Aliases) ? const_get(:Aliases) : []
+    end
   end
 
   #
   # Instance Methods
   #
+
+  attr_accessor :aliased_as
 
   #
   # Returns the module's framework full reference name.  This is the
@@ -45,7 +54,7 @@ module Msf::Module::FullName
   # payloads/windows/shell/reverse_tcp
   #
   def fullname
-    self.class.fullname
+    aliased_as || self.class.fullname
   end
 
   #
@@ -55,16 +64,16 @@ module Msf::Module::FullName
   # windows/shell/reverse_tcp
   #
   def refname
-    self.class.refname
+    fullname.sub(type + '/', '')
   end
 
   #
   # Returns the module's framework prompt-friendly name.
   #
-  # reverse_tcp
+  # windows/shell/reverse_tcp
   #
   def promptname
-    self.class.promptname
+    refname
   end
 
   #
@@ -73,6 +82,10 @@ module Msf::Module::FullName
   # reverse_tcp
   #
   def shortname
-    self.class.shortname
+    refname.split('/').last
+  end
+
+  def aliases
+    self.class.aliases
   end
 end

--- a/lib/msf/core/module_manager.rb
+++ b/lib/msf/core/module_manager.rb
@@ -64,7 +64,10 @@ module Msf
     #   Otherwise, we step through all sets until we find one that
     #   matches.
     # @return (see Msf::ModuleSet#create)
-    def create(name)
+    def create(name, aliased_as: nil)
+      # First, a direct alias check
+      return create(self.aliases[name], aliased_as: name) if self.aliases[name]
+
       # Check to see if it has a module type prefix.  If it does,
       # try to load it from the specific module set for that type.
       names = name.split("/")
@@ -88,11 +91,19 @@ module Msf
       else
         # Then we don't have a type, so we have to step through each set
         # to see if we can create this module.
-        module_set_by_type.each do |_, set|
-          module_reference_name = names.join("/")
-          module_instance = set.create(module_reference_name)
+        module_set_by_type.each do |type, set|
+          if aliased = self.aliases["#{type}/#{name}"]
+            module_instance = create(aliased, aliased_as: "#{type}/#{name}")
+          else
+            module_reference_name = names.join("/")
+            module_instance = set.create(module_reference_name)
+          end
           break if module_instance
         end
+      end
+
+      if module_instance
+        module_instance.aliased_as = aliased_as
       end
 
       module_instance
@@ -125,6 +136,8 @@ module Msf
       self.module_load_warnings = {}
       self.module_paths = []
       self.module_set_by_type = {}
+      self.aliases = {}
+      self.inv_aliases = self.aliases.invert
 
       #
       # from arguments
@@ -138,6 +151,8 @@ module Msf
     end
 
     protected
+
+    attr_accessor :aliases, :inv_aliases
 
     # This method automatically subscribes a module to whatever event
     # providers it wishes to monitor.  This can be used to allow modules

--- a/lib/msf/core/module_manager.rb
+++ b/lib/msf/core/module_manager.rb
@@ -50,6 +50,8 @@ module Msf
 
       module_set = module_set_by_type[type]
 
+      return unless module_set
+
       module_reference_name = names.join("/")
       module_set[module_reference_name]
     end

--- a/lib/msf/core/module_manager/cache.rb
+++ b/lib/msf/core/module_manager/cache.rb
@@ -169,6 +169,10 @@ module Msf::ModuleManager::Cache
           :parent_path => parent_path,
           :modification_time => module_metadata.mod_time
       }
+      module_metadata.aliases.each do |a|
+        self.aliases[a] = module_metadata.fullname
+      end
+      self.inv_aliases[module_metadata.fullname] = module_metadata.aliases unless module_metadata.aliases.empty?
 
       typed_module_set = module_set(type)
 

--- a/lib/msf/core/module_manager/loading.rb
+++ b/lib/msf/core/module_manager/loading.rb
@@ -86,6 +86,22 @@ module Msf::ModuleManager::Loading
 
     # Notify the framework that a module was loaded
     framework.events.on_module_load(reference_name, class_or_module)
+
+    # Clear and add aliases, if any (payloads cannot)
+
+    if class_or_module.respond_to?(:fullname) && aliased_as = self.inv_aliases[class_or_module.fullname]
+      aliased_as.each do |a|
+        self.aliases.delete a
+      end
+      self.inv_aliases.delete class_or_module.fullname
+    end
+
+    if class_or_module.respond_to? :aliases
+      class_or_module.aliases.each do |a|
+        self.aliases[a] = class_or_module.fullname
+      end
+      self.inv_aliases[class_or_module.fullname] = class_or_module.aliases unless class_or_module.aliases.empty?
+    end
   end
 
   protected

--- a/lib/msf/core/module_manager/reloading.rb
+++ b/lib/msf/core/module_manager/reloading.rb
@@ -13,6 +13,13 @@ module Msf::ModuleManager::Reloading
       metasploit_class = mod
     end
 
+    if aliased_as = self.inv_aliases[metasploit_class.fullname]
+      aliased_as.each do |a|
+        self.aliases.delete a
+      end
+      self.inv_aliases.delete metasploit_class.fullname
+    end
+
     namespace_module = metasploit_class.parent
     loader = namespace_module.loader
     loader.reload_module(mod)
@@ -26,6 +33,8 @@ module Msf::ModuleManager::Reloading
       module_set_by_type[type].clear
       init_module_set(type)
     end
+    self.aliases.clear
+    self.inv_aliases.clear
 
     # default the count to zero the first time a type is accessed
     count_by_type = Hash.new(0)

--- a/lib/msf/core/modules/metadata/maps.rb
+++ b/lib/msf/core/modules/metadata/maps.rb
@@ -20,7 +20,7 @@ module Msf::Modules::Metadata::Maps
     get_metadata.each do |exploit|
       # expand this in future to be more specific about remote exploits.
       next unless exploit.type == "exploit"
-      fullname = exploit.full_name
+      fullname = exploit.fullname
       exploit.references.each do |reference|
         next if reference =~ /^URL/
         ref = reference

--- a/lib/msf/core/modules/metadata/obj.rb
+++ b/lib/msf/core/modules/metadata/obj.rb
@@ -12,7 +12,9 @@ class Obj
   # @return [String]
   attr_reader :name
   # @return [String]
-  attr_reader :full_name
+  attr_reader :fullname
+  # @return [Array<String>]
+  attr_reader :aliases
   # @return [Integer]
   attr_reader :rank
   # @return [Date]
@@ -59,7 +61,8 @@ class Obj
     end
 
     @name               = module_instance.name
-    @full_name          = module_instance.fullname
+    @fullname           = module_instance.fullname
+    @aliases            = module_instance.aliases
     @disclosure_date    = module_instance.disclosure_date
     @rank               = module_instance.rank.to_i
     @type               = module_instance.type
@@ -110,7 +113,8 @@ class Obj
   def to_json(*args)
     {
       'name'               => @name,
-      'full_name'          => @full_name,
+      'fullname'           => @fullname,
+      'aliases'            => @aliases,
       'rank'               => @rank,
       'disclosure_date'    => @disclosure_date.nil? ? nil : @disclosure_date.to_s,
       'type'               => @type,
@@ -159,7 +163,8 @@ class Obj
 
   def init_from_hash(obj_hash)
     @name               = obj_hash['name']
-    @full_name          = obj_hash['full_name']
+    @fullname           = obj_hash['fullname']
+    @aliases            = obj_hash['aliases'] || []
     @disclosure_date    = obj_hash['disclosure_date'].nil? ? nil : Time.parse(obj_hash['disclosure_date'])
     @rank               = obj_hash['rank']
     @type               = obj_hash['type']
@@ -194,7 +199,7 @@ class Obj
 
   def force_encoding(encoding)
     @name.force_encoding(encoding)
-    @full_name.force_encoding(encoding)
+    @fullname.force_encoding(encoding)
     @description.force_encoding(encoding)
     @author.each {|a| a.force_encoding(encoding)}
     @references.each {|r| r.force_encoding(encoding)}

--- a/lib/msf/core/modules/metadata/search.rb
+++ b/lib/msf/core/modules/metadata/search.rb
@@ -6,7 +6,7 @@ require 'msf/core/modules/metadata'
 module Msf::Modules::Metadata::Search
 
   VALID_PARAMS =
-      %w[aka author authors arch cve bid edb check date disclosure_date description full_name fullname mod_time
+      %w[aka author authors arch cve bid edb check date disclosure_date description fullname fullname mod_time
       name os platform path port rport rank ref ref_name reference references target targets text type]
 
   #
@@ -70,8 +70,8 @@ module Msf::Modules::Metadata::Search
               match = [keyword, search_term] if module_metadata.disclosure_date.to_s =~ regex
             when 'description'
               match = [keyword, search_term] if module_metadata.description =~ regex
-            when 'full_name', 'fullname'
-              match = [keyword, search_term] if module_metadata.full_name =~ regex
+            when 'fullname'
+              match = [keyword, search_term] if module_metadata.fullname =~ regex
             when 'mod_time'
               match = [keyword, search_term] if module_metadata.mod_time.to_s =~ regex
             when 'name'
@@ -82,7 +82,7 @@ module Msf::Modules::Metadata::Search
                 match = [keyword, search_term] if module_metadata.targets.any? { |target| target =~ regex }
               end
             when 'path'
-              match = [keyword, search_term] if module_metadata.full_name =~ regex
+              match = [keyword, search_term] if module_metadata.fullname =~ regex
             when 'port', 'rport'
               match = [keyword, search_term] if module_metadata.rport.to_s =~ regex
             when 'rank'
@@ -120,7 +120,7 @@ module Msf::Modules::Metadata::Search
             when 'target', 'targets'
               match = [keyword, search_term] if module_metadata.targets.any? { |target| target =~ regex }
             when 'text'
-              terms = [module_metadata.name, module_metadata.full_name, module_metadata.description] + module_metadata.references + module_metadata.author + (module_metadata.notes['AKA'] || [])
+              terms = [module_metadata.name, module_metadata.fullname, module_metadata.description] + module_metadata.references + module_metadata.author + (module_metadata.notes['AKA'] || [])
 
               if module_metadata.targets
                 terms = terms + module_metadata.targets
@@ -155,7 +155,6 @@ module Msf::Modules::Metadata::Search
         :cve => 'references',
         :edb => 'references',
         :bid => 'references',
-        :fullname => 'full_name',
         :os => 'platform',
         :port => 'rport',
         :reference => 'references',

--- a/lib/msf/core/rpc/v10/rpc_db.rb
+++ b/lib/msf/core/rpc/v10/rpc_db.rb
@@ -711,7 +711,7 @@ def rpc_analyze_host(xopts)
       h_result[:modules].each do |mod|
         mod_detail = {}
         mod_detail[:mtype]  = mod.type
-        mod_detail[:mname]  = mod.full_name
+        mod_detail[:mname]  = mod.fullname
         host_detail[:modules] << mod_detail
       end
     end

--- a/lib/msf/ui/console/command_dispatcher/db/analyze.rb
+++ b/lib/msf/ui/console/command_dispatcher/db/analyze.rb
@@ -55,7 +55,7 @@ module Msf::Ui::Console::CommandDispatcher::Analyze
         host_result = framework.analyze.host(eval_host)
         found_modules = host_result[:modules]
         found_modules.each do |fnd_mod|
-          print_status(fnd_mod.full_name)
+          print_status(fnd_mod.fullname)
           reported_module = true
         end
 

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -335,7 +335,7 @@ module Msf
               'check'       => 'Modules that support the \'check\' method',
               'date'        => 'Modules with a matching disclosure date',
               'description' => 'Modules with a matching description',
-              'full_name'   => 'Modules with a matching full name',
+              'fullname'    => 'Modules with a matching full name',
               'mod_time'    => 'Modules with a matching modification date',
               'name'        => 'Modules with a matching descriptive name',
               'path'        => 'Modules with a matching path',
@@ -403,7 +403,7 @@ module Msf
               @module_search_results.each do |m|
                 tbl << [
                     count += 1,
-                    m.full_name,
+                    m.fullname,
                     m.disclosure_date.nil? ? '' : m.disclosure_date.strftime("%Y-%m-%d"),
                     RankingName[m.rank].to_s,
                     m.check ? 'Yes' : 'No',
@@ -412,7 +412,7 @@ module Msf
               end
 
               if @module_search_results.length == 1 && use
-                used_module = @module_search_results.first.full_name
+                used_module = @module_search_results.first.fullname
                 cmd_use(used_module, true)
               end
             rescue ArgumentError
@@ -646,7 +646,7 @@ module Msf
             # Use a module by search index
             if mod_index
               return if mod_index < 0 || @module_search_results[mod_index].nil?
-              mod_name = @module_search_results[mod_index].full_name
+              mod_name = @module_search_results[mod_index].fullname
             end
 
             # See if the supplied module name has already been resolved

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -22,6 +22,7 @@ module Msf
             "-h"     => [ false, "Help banner"],
             "-o"     => [ true, "Send output to a file in csv format"],
             "-S"     => [ true, "Search string for row filter"],
+            "-u"     => [ false, "Use module if there is one result"]
           )
 
           def commands
@@ -323,6 +324,7 @@ module Msf
             print_line "  -h                Show this help information"
             print_line "  -o <file>         Send output to a file in csv format"
             print_line "  -S <string>       Search string for row filter"
+            print_line "  -u                Use module if there is one result"
             print_line
             print_line "Keywords:"
             {
@@ -366,6 +368,7 @@ module Msf
             end
 
             match = ''
+            use = false
             search_term = nil
             output_file = nil
             @@search_opts.parse(args) { |opt, idx, val|
@@ -377,6 +380,8 @@ module Msf
                   return
                 when '-o'
                   output_file = val
+                when "-u"
+                  use = true
                 else
                   match += val + " "
               end
@@ -391,15 +396,22 @@ module Msf
             # Display the table of matches
             tbl = generate_module_table("Matching Modules", search_term)
             search_params = parse_search_string(match)
+            count = 0
             begin
-              Msf::Modules::Metadata::Cache.instance.find(search_params).each do |m|
+              modules = Msf::Modules::Metadata::Cache.instance.find(search_params)
+              modules.each do |m|
                 tbl << [
+                    count += 1,
                     m.full_name,
                     m.disclosure_date.nil? ? '' : m.disclosure_date.strftime("%Y-%m-%d"),
                     RankingName[m.rank].to_s,
                     m.check ? 'Yes' : 'No',
                     m.name
                 ]
+              end
+              if modules.length == 1 && use
+                used_module = modules.first.full_name
+                cmd_use(used_module)
               end
             rescue ArgumentError
               print_error("Invalid argument(s)\n")
@@ -413,6 +425,7 @@ module Msf
               }
             else
               print_line(tbl.to_s)
+              print_status("Using #{used_module}") if used_module
             end
           end
 
@@ -1037,8 +1050,8 @@ module Msf
           end
 
           def show_targets(mod) # :nodoc:
-            mod_targs = Serializer::ReadableText.dump_exploit_targets(mod, '   ')
-            print("\nExploit targets:\n\n#{mod_targs}\n") if (mod_targs and mod_targs.length > 0)
+              mod_targs = Serializer::ReadableText.dump_exploit_targets(mod, '   ')
+              print("\nExploit targets:\n\n#{mod_targs}\n") if (mod_targs and mod_targs.length > 0)
           end
 
           def show_actions(mod) # :nodoc:
@@ -1113,6 +1126,7 @@ module Msf
 
           def show_module_set(type, module_set, regex = nil, minrank = nil, opts = nil) # :nodoc:
             tbl = generate_module_table(type)
+            count = 0
             module_set.sort.each { |refname, mod|
               o = nil
 
@@ -1144,6 +1158,7 @@ module Msf
                   end
                   if (opts == nil or show == true)
                     tbl << [
+                      count += 1,
                       refname,
                       o.disclosure_date.nil? ? "" : o.disclosure_date.strftime("%Y-%m-%d"),
                       o.rank_to_s,
@@ -1164,7 +1179,7 @@ module Msf
               'Header'     => type,
               'Prefix'     => "\n",
               'Postfix'    => "\n",
-              'Columns'    => [ 'Name', 'Disclosure Date', 'Rank', 'Check', 'Description' ],
+              'Columns'    => [ '#', 'Name', 'Disclosure Date', 'Rank', 'Check', 'Description' ],
               'SearchTerm' => search_term
             )
           end

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -35,7 +35,7 @@ module Msf
               "reload_all" => "Reloads all modules from all defined module paths",
               "search"     => "Searches module names and descriptions",
               "show"       => "Displays modules of a given type, or all modules",
-              "use"        => "Selects a module by name",
+              "use"        => "Interact with a module by name or search term/index",
             }
           end
 
@@ -48,6 +48,7 @@ module Msf
             @dscache = {}
             @previous_module = nil
             @module_name_stack = []
+            @module_search_results = []
             @dangerzone_map = nil
           end
 
@@ -393,13 +394,13 @@ module Msf
             # Display the table of matches
             tbl = generate_module_table("Matching Modules", search_term)
             search_params = parse_search_string(match)
-            count = 0
+            count = -1
             begin
-              modules = Msf::Modules::Metadata::Cache.instance.find(search_params)
+              @module_search_results = Msf::Modules::Metadata::Cache.instance.find(search_params)
 
-              return false if modules.length == 0
+              return false if @module_search_results.length == 0
 
-              modules.each do |m|
+              @module_search_results.each do |m|
                 tbl << [
                     count += 1,
                     m.full_name,
@@ -410,8 +411,8 @@ module Msf
                 ]
               end
 
-              if modules.length == 1 && use
-                used_module = modules.first.full_name
+              if @module_search_results.length == 1 && use
+                used_module = @module_search_results.first.full_name
                 cmd_use(used_module, true)
               end
             rescue ArgumentError
@@ -602,9 +603,20 @@ module Msf
           end
 
           def cmd_use_help
-            print_line "Usage: use module_name"
+            print_line 'Usage: use <name|term|index>'
             print_line
-            print_line "The use command is used to interact with a module of a given name."
+            print_line 'Interact with a module by name or search term/index.'
+            print_line 'If a module name is not found, it will be treated as a search term.'
+            print_line 'An index from the previous search results can be selected if desired.'
+            print_line
+            print_line 'Examples:'
+            print_line '  use exploit/windows/smb/ms17_010_eternalblue'
+            print_line
+            print_line '  use eternalblue'
+            print_line '  use <name|index>'
+            print_line
+            print_line '  search eternalblue'
+            print_line '  use <name|index>'
             print_line
           end
 
@@ -622,6 +634,20 @@ module Msf
 
             # Try to create an instance of the supplied module name
             mod_name = args[0]
+
+            # Try to create an integer out of a supplied module name
+            mod_index =
+              begin
+                Integer(mod_name)
+              rescue ArgumentError, TypeError
+                nil
+              end
+
+            # Use a module by search index
+            if mod_index
+              return if mod_index < 0 || @module_search_results[mod_index].nil?
+              mod_name = @module_search_results[mod_index].full_name
+            end
 
             # See if the supplied module name has already been resolved
             mod_resolved = args[1] == true ? true : false

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -1161,7 +1161,7 @@ module Msf
 
           def show_module_set(type, module_set, regex = nil, minrank = nil, opts = nil) # :nodoc:
             tbl = generate_module_table(type)
-            count = 0
+            count = -1
             module_set.sort.each { |refname, mod|
               o = nil
 

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -16,10 +16,10 @@ module Msf
           include Msf::Ui::Console::CommandDispatcher::Common
 
           @@search_opts = Rex::Parser::Arguments.new(
-            "-h"     => [ false, "Help banner"],
-            "-o"     => [ true, "Send output to a file in csv format"],
-            "-S"     => [ true, "Search string for row filter"],
-            "-u"     => [ false, "Use module if there is one result"]
+            '-h' => [false, 'Help banner'],
+            '-o' => [true,  'Send output to a file in csv format'],
+            '-S' => [true,  'Search string for row filter'],
+            '-u' => [false, 'Use module if there is one result']
           )
 
           def commands
@@ -316,7 +316,9 @@ module Msf
           end
 
           def cmd_search_help
-            print_line "Usage: search [ options ] <keywords>"
+            print_line "Usage: search [<options>] [<keywords>]"
+            print_line
+            print_line "If no options or keywords are provided, cached results are displayed."
             print_line
             print_line "OPTIONS:"
             print_line "  -h                Show this help information"
@@ -359,46 +361,46 @@ module Msf
           # Searches modules for specific keywords
           #
           def cmd_search(*args)
-            if args.empty?
-              print_error("Argument required\n")
-              cmd_search_help
-              return false
-            end
-
-            match = ''
-            use = false
+            match       = ''
             search_term = nil
             output_file = nil
-            @@search_opts.parse(args) { |opt, idx, val|
-              case opt
-                when "-S"
-                  search_term = val
-                when "-h"
-                  cmd_search_help
-                  return
-                when '-o'
-                  output_file = val
-                when "-u"
-                  use = true
-                else
-                  match += val + " "
-              end
-            }
+            cached      = false
+            use         = false
+            count       = -1
 
-            if match.empty? && search_term.nil?
-              print_error("Keywords or search argument required\n")
-              cmd_search_help
-              return false
+            @@search_opts.parse(args) do |opt, idx, val|
+              case opt
+              when '-S'
+                search_term = val
+              when '-h'
+                cmd_search_help
+                return false
+              when '-o'
+                output_file = val
+              when '-u'
+                use = true
+              else
+                match += val + ' '
+              end
             end
 
-            # Display the table of matches
-            tbl = generate_module_table("Matching Modules", search_term)
-            search_params = parse_search_string(match)
-            count = -1
-            begin
-              @module_search_results = Msf::Modules::Metadata::Cache.instance.find(search_params)
+            cached = true if args.empty?
 
-              return false if @module_search_results.length == 0
+            # Display the table of matches
+            tbl = generate_module_table('Matching Modules', search_term)
+
+            begin
+              if cached
+                print_status('Displaying cached results')
+              else
+                search_params = parse_search_string(match)
+                @module_search_results = Msf::Modules::Metadata::Cache.instance.find(search_params)
+              end
+
+              if @module_search_results.empty?
+                print_error('No results from search')
+                return false
+              end
 
               @module_search_results.each do |m|
                 tbl << [
@@ -1160,8 +1162,10 @@ module Msf
           end
 
           def show_module_set(type, module_set, regex = nil, minrank = nil, opts = nil) # :nodoc:
-            tbl = generate_module_table(type)
             count = -1
+
+            tbl = generate_module_table(type)
+
             module_set.sort.each { |refname, mod|
               o = nil
 

--- a/modules/auxiliary/scanner/smb/smb_login.rb
+++ b/modules/auxiliary/scanner/smb/smb_login.rb
@@ -15,6 +15,10 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::AuthBrute
 
+  Aliases = [
+    'auxiliary/scanner/smb/login'
+  ]
+
   def proto
     'smb'
   end

--- a/modules/auxiliary/scanner/smtp/smtp_enum.rb
+++ b/modules/auxiliary/scanner/smtp/smtp_enum.rb
@@ -8,6 +8,10 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::Scanner
 
+  Aliases = [
+    'auxiliary/scanner/smtp/enum'
+  ]
+
   def initialize
     super(
       'Name'        => 'SMTP User Enumeration Utility',


### PR DESCRIPTION
Backport of enhanced `search -u` and `use` command and new `alias` functionality into `4.x` this required only some minor conflict resolution due to `evasion` modules to get all 6 related PRs, since `alias` impacts module cache format these need to be in `4.x`.

## Verification

Test using information in related the 6 PRs referenced in the commit messages.
