### PR TITLE
Fix java_rmi_registry for multiple RHOSTS

### DIFF
--- a/modules/auxiliary/gather/java_rmi_registry.rb
+++ b/modules/auxiliary/gather/java_rmi_registry.rb
@@ -6,6 +6,7 @@
 require 'rex/java/serialization'
 
 class MetasploitModule < Msf::Auxiliary
+  include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::Report
   include Msf::Exploit::Remote::Java::Rmi::Client
 
@@ -31,7 +32,7 @@ class MetasploitModule < Msf::Auxiliary
       ])
   end
 
-  def run
+  def run_host(ip)
     print_status("Sending RMI Header...")
     connect
 


### PR DESCRIPTION
I noticed that the `java_rmi_registry` module advertises to support multiple `RHOSTS`, but only the first entry in `RHOSTS` is ever contacted. There's no dedicated bug issue to link here, I hope it's okay to just submit this (tiny) correction directly as a pull request. If not, please let me know!

## Verification

- [ ] Start `msfconsole`
- [ ] `use auxiliary/gather/java_rmi_registry`
- [ ] `set RHOSTS 127.0.0.2 127.0.0.3`
- [ ] new shells, run:
      - `socat -u -v tcp-listen:1099,bind=127.0.0.2,reuseaddr -`
      - `socat -u -v tcp-listen:1099,bind=127.0.0.3,reuseaddr -`
- [ ] `run`
- [ ] See connections to both instances of `socat` (you may need to abort the first one so the second one is connected)