### PR TITLE
Prefer Rex::Text.dehex over Rex::Text.hex_to_raw in msfvenom

### DIFF
--- a/msfvenom
+++ b/msfvenom
@@ -110,7 +110,8 @@ def parse_args(args)
   end
 
   opt.on('--encrypt-key     <value>', String, 'A key to be used for --encrypt') do |e|
-    opts[:encryption_key] = e
+    init_framework
+    opts[:encryption_key] = Rex::Text.dehex(e)
   end
 
   opt.on('--encrypt-iv      <value>', String, 'An initialization vector for --encrypt') do |e|
@@ -130,8 +131,8 @@ def parse_args(args)
   end
 
   opt.on('-b', '--bad-chars       <list>', String, 'Characters to avoid example: \'\x00\xff\'') do |b|
-    init_framework()
-    opts[:badchars] = Rex::Text.hex_to_raw(b)
+    init_framework
+    opts[:badchars] = Rex::Text.dehex(b)
   end
 
   opt.on('-n', '--nopsled         <length>', Integer, 'Prepend a nopsled of [length] size on to the payload') do |n|
@@ -196,7 +197,7 @@ def parse_args(args)
       datastore[k.upcase] = v.to_s
     end
     if opts[:payload].to_s =~ /[\_\/]reverse/ && datastore['LHOST'].nil?
-      init_framework()
+      init_framework
       datastore['LHOST'] = Rex::Socket.source_address
     end
   end


### PR DESCRIPTION
`Rex::Text.dehex` allows character literals interleaved with escaped hex, while `Rex::Text.hex_to_raw` takes only escaped hex. Enhances `-b`/`--bad-chars` and `--encrypt-key`.

Please see https://github.com/rapid7/rex-text/pull/22 and #9869.

#### `-b`/`--bad-chars`

```
wvu@kharak:/rapid7/metasploit-framework:feature/msfvenom$ ./msfvenom -p generic/custom -e generic/none -b " " PAYLOADSTR="hello world"
[-] No platform was selected, choosing Msf::Module::Platform from the payload
[-] No arch selected, selecting arch: x86 from the payload
Found 1 compatible encoders
Attempting to encode payload with 1 iterations of generic/none
generic/none failed with Encoding failed due to a bad character (index=5, char=0x20)
Error: An encoding exception occurred.
wvu@kharak:/rapid7/metasploit-framework:feature/msfvenom$
```

#### `--encrypt-key`

```
wvu@kharak:/rapid7/metasploit-framework:feature/msfvenom$ ./msfvenom -p generic/custom --encrypt xor --encrypt-key "\x0f" PAYLOADSTR="hello world"
[-] No platform was selected, choosing Msf::Module::Platform from the payload
[-] No arch selected, selecting arch: x86 from the payload
No encoder or badchars specified, outputting raw payload
Payload size: 11 bytes
gjcc`/x`}ck
wvu@kharak:/rapid7/metasploit-framework:feature/msfvenom$
```

```
wvu@kharak:/rapid7/metasploit-framework:feature/msfvenom$ ./msfvenom -p generic/custom --encrypt xor --encrypt-key "\x00\x00\x00\x00\x00\x0c" PAYLOADSTR="hello world"
[-] No platform was selected, choosing Msf::Module::Platform from the payload
[-] No arch selected, selecting arch: x86 from the payload
No encoder or badchars specified, outputting raw payload
Payload size: 11 bytes
hello,world
wvu@kharak:/rapid7/metasploit-framework:feature/msfvenom$
```

```
wvu@kharak:/rapid7/metasploit-framework:feature/msfvenom$ ./msfvenom -p generic/custom --encrypt xor --encrypt-key "hello world" PAYLOADSTR="hello world" | xxd -g 1
[-] No platform was selected, choosing Msf::Module::Platform from the payload
[-] No arch selected, selecting arch: x86 from the payload
No encoder or badchars specified, outputting raw payload
Payload size: 11 bytes

00000000: 00 00 00 00 00 00 00 00 00 00 00                 ...........
wvu@kharak:/rapid7/metasploit-framework:feature/msfvenom$
```

Fixes https://github.com/rapid7/metasploit-framework/commit/e344adb3fd2f7129874c83f173c8f165376d6797.