### PR TITLE
nmod fix for non-scanner aux RHOSTS

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/auxiliary.rb
+++ b/lib/msf/ui/console/command_dispatcher/auxiliary.rb
@@ -130,7 +130,7 @@ class Auxiliary
           nmod = mod.replicant
           nmod.datastore['RHOST'] = rhost
           print_status("Running module against #{rhost}")
-          mod.run_simple(
+          nmod.run_simple(
             'Action'         => action,
             'OptionStr'      => opts.join(','),
             'LocalInput'     => driver.input,


### PR DESCRIPTION
I think this bug is an unintentionally typo in https://github.com/rapid7/metasploit-framework/pull/11551.

Thanks to @fd0 to report this bug in  #12102

Ping @busterb @wvu-r7 
 

