### PR TITLE
Add HttpRawHeaders (file) advanced option to HttpClient

### DIFF
--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -37,7 +37,7 @@ module Exploit::Remote::HttpClient
           ]),
         OptString.new('HttpUsername', [false, 'The HTTP username to specify for authentication', '']),
         OptString.new('HttpPassword', [false, 'The HTTP password to specify for authentication', '']),
-        OptPath.new('HttpHeaders', [false, 'Path to raw HTTP headers to append to each request']),
+        OptPath.new('HttpRawHeaders', [false, 'Path to raw HTTP headers to append to each request']),
         OptBool.new('DigestAuthIIS', [false, 'Conform to IIS, should work for most servers. Only set to false for non-IIS servers', true]),
         Opt::SSLVersion,
         OptBool.new('FingerprintCheck', [ false, 'Conduct a pre-exploit fingerprint verification', true]),

--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -37,6 +37,7 @@ module Exploit::Remote::HttpClient
           ]),
         OptString.new('HttpUsername', [false, 'The HTTP username to specify for authentication', '']),
         OptString.new('HttpPassword', [false, 'The HTTP password to specify for authentication', '']),
+        OptPath.new('HttpHeaders', [false, 'Path to raw HTTP headers to append to each request']),
         OptBool.new('DigestAuthIIS', [false, 'Conform to IIS, should work for most servers. Only set to false for non-IIS servers', true]),
         Opt::SSLVersion,
         OptBool.new('FingerprintCheck', [ false, 'Conduct a pre-exploit fingerprint verification', true]),
@@ -186,6 +187,10 @@ module Exploit::Remote::HttpClient
       'domain'                 => datastore['DOMAIN'],
       'DigestAuthIIS'          => datastore['DigestAuthIIS']
     )
+
+    if datastore['HttpHeaders']
+      nclient.set_config('raw_headers' => File.read(datastore['HttpHeaders']))
+    end
 
     # If this connection is global, persist it
     # Required for findsock on these sockets

--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -188,8 +188,8 @@ module Exploit::Remote::HttpClient
       'DigestAuthIIS'          => datastore['DigestAuthIIS']
     )
 
-    if datastore['HttpHeaders']
-      nclient.set_config('raw_headers' => File.read(datastore['HttpHeaders']))
+    if datastore['HttpRawHeaders']
+      nclient.set_config('raw_headers' => File.read(datastore['HttpRawHeaders']))
     end
 
     # If this connection is global, persist it

--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -37,7 +37,7 @@ module Exploit::Remote::HttpClient
           ]),
         OptString.new('HttpUsername', [false, 'The HTTP username to specify for authentication', '']),
         OptString.new('HttpPassword', [false, 'The HTTP password to specify for authentication', '']),
-        OptPath.new('HttpRawHeaders', [false, 'Path to raw HTTP headers to append to each request']),
+        OptPath.new('HttpRawHeaders', [false, 'Path to ERB-templatized raw headers to append to existing headers']),
         OptBool.new('DigestAuthIIS', [false, 'Conform to IIS, should work for most servers. Only set to false for non-IIS servers', true]),
         Opt::SSLVersion,
         OptBool.new('FingerprintCheck', [ false, 'Conduct a pre-exploit fingerprint verification', true]),
@@ -188,8 +188,12 @@ module Exploit::Remote::HttpClient
       'DigestAuthIIS'          => datastore['DigestAuthIIS']
     )
 
-    if datastore['HttpRawHeaders']
-      nclient.set_config('raw_headers' => File.read(datastore['HttpRawHeaders']))
+    if datastore['HttpRawHeaders'] && File.readable?(datastore['HttpRawHeaders'])
+      # Templatize with ERB
+      headers = ERB.new(File.read(datastore['HttpRawHeaders'])).result(binding)
+
+      # Append templatized headers to existing headers
+      nclient.set_config('raw_headers' => headers)
     end
 
     # If this connection is global, persist it


### PR DESCRIPTION
Is this what you wanted, @terrorbyte?

```
msf5 auxiliary(scanner/http/title) > run

********************
####################
# Request:
####################
GET / HTTP/1.1
Host: 127.0.0.1:8080
User-Agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)
Content-Type: application/x-www-form-urlencoded


####################
# Response:
####################
HTTP/1.0 200 OK
Server: SimpleHTTP/0.6 Python/3.7.3
Date: Thu, 25 Jul 2019 02:22:56 GMT
Content-type: text/html; charset=utf-8
Content-Length: 297

<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
<html>
<head>
<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
<title>Directory listing for /</title>
</head>
<body>
<h1>Directory listing for /</h1>
<hr>
<ul>
</ul>
<hr>
</body>
</html>

[+] [127.0.0.1:8080] [C:200] [R:] [S:SimpleHTTP/0.6 Python/3.7.3] Directory listing for /
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf5 auxiliary(scanner/http/title) > grep HttpRawHeaders advanced
   HttpRawHeaders                                                           no        Path to ERB-templatized raw headers to append to existing headers
msf5 auxiliary(scanner/http/title) > set httprawheaders headers.txt
httprawheaders => headers.txt
msf5 auxiliary(scanner/http/title) > cat headers.txt
[*] exec: cat headers.txt

X-Files: <%= 'Yeeting into an Area 51 near you on September 20th' %>
msf5 auxiliary(scanner/http/title) > run

********************
####################
# Request:
####################
GET / HTTP/1.1
Host: 127.0.0.1:8080
User-Agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)
Content-Type: application/x-www-form-urlencoded
X-Files: Yeeting into an Area 51 near you on September 20th


####################
# Response:
####################
HTTP/1.0 200 OK
Server: SimpleHTTP/0.6 Python/3.7.3
Date: Thu, 25 Jul 2019 02:23:01 GMT
Content-type: text/html; charset=utf-8
Content-Length: 297

<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
<html>
<head>
<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
<title>Directory listing for /</title>
</head>
<body>
<h1>Directory listing for /</h1>
<hr>
<ul>
</ul>
<hr>
</body>
</html>

[+] [127.0.0.1:8080] [C:200] [R:] [S:SimpleHTTP/0.6 Python/3.7.3] Directory listing for /
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf5 auxiliary(scanner/http/title) >
```