### PR TITLE
Implement "set PAYLOAD" by index

### DIFF
--- a/lib/msf/core/evasion.rb
+++ b/lib/msf/core/evasion.rb
@@ -286,7 +286,7 @@ module Msf
       target_idx =
         begin
           Integer(datastore['TARGET'])
-        rescue ArgumentError, TypeError
+        rescue TypeError, ArgumentError
           datastore['TARGET']
         end
 

--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -686,7 +686,7 @@ class Exploit < Msf::Module
     target_idx =
       begin
         Integer(datastore['TARGET'])
-      rescue ArgumentError, TypeError
+      rescue TypeError, ArgumentError
         datastore['TARGET']
       end
 

--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -321,7 +321,7 @@ class Exploit < Msf::Module
     end
 
     # Initialize exploit datastore with target information
-    import_target_datastore
+    import_target_defaults
 
     # All exploits can increase the delay when waiting for a session.
     # However, this only applies to aggressive exploits.
@@ -699,14 +699,6 @@ class Exploit < Msf::Module
     end
 
     return (target_idx) ? target_idx.to_i : nil
-  end
-
-  #
-  # Import the target's DefaultOptions hash into the datastore.
-  #
-  def import_target_datastore
-    return unless target && target.default_options
-    datastore.import_options_from_hash(target.default_options)
   end
 
   #

--- a/lib/msf/core/module/data_store.rb
+++ b/lib/msf/core/module/data_store.rb
@@ -26,6 +26,15 @@ module Msf::Module::DataStore
   end
 
   #
+  # Import the target's DefaultOptions hash into the datastore.
+  #
+  def import_target_defaults
+    return unless target && target.default_options
+
+    datastore.import_options_from_hash(target.default_options, true, 'self')
+  end
+
+  #
   # Overrides the class' own datastore with the one supplied.  This is used
   # to allow modules to share datastores, such as a payload sharing an
   # exploit module's datastore.

--- a/lib/msf/ui/console/command_dispatcher/common.rb
+++ b/lib/msf/ui/console/command_dispatcher/common.rb
@@ -143,7 +143,7 @@ module Common
   end
 
   # This is for the "use" and "set" commands
-  def module_index(list, index, &block)
+  def index_from_list(list, index, &block)
     return unless list.kind_of?(Array) && index
 
     begin

--- a/lib/msf/ui/console/command_dispatcher/common.rb
+++ b/lib/msf/ui/console/command_dispatcher/common.rb
@@ -142,6 +142,21 @@ module Common
     #print("\nTarget: #{mod.target.name}\n\n")
   end
 
+  # This is for the "use" and "set" commands
+  def module_index(list, index, &block)
+    return unless list.kind_of?(Array) && index
+
+    begin
+      idx = Integer(index)
+    rescue ArgumentError
+      return
+    end
+
+    # Don't support negative indices
+    return if idx < 0
+
+    yield list[idx]
+  end
 
 end
 

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1592,8 +1592,8 @@ class Core
     end
 
     # Set PAYLOAD from TARGET
-    if name.upcase == 'TARGET' && active_module && active_module.exploit?
-      active_module.import_target_datastore
+    if name.upcase == 'TARGET' && (active_module.exploit? || active_module.evasion?)
+      active_module.import_target_defaults
     end
 
     print_line("#{name} => #{datastore[name]}")

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -39,6 +39,7 @@ module CommandDispatcher
 class Core
 
   include Msf::Ui::Console::CommandDispatcher
+  include Msf::Ui::Console::CommandDispatcher::Common
 
   # Session command options
   @@sessions_opts = Rex::Parser::Arguments.new(
@@ -1574,6 +1575,16 @@ class Core
     name  = args[0]
     value = args[1, args.length-1].join(' ')
 
+    # Set PAYLOAD by index
+    if name.upcase == 'PAYLOAD' && active_module && (active_module.exploit? || active_module.evasion?)
+      module_index(payload_show_results, value) do |mod|
+        return false unless mod && mod.respond_to?(:first)
+
+        # [name, class] from payload_show_results
+        value = mod.first
+      end
+    end
+
     # If the driver indicates that the value is not valid, bust out.
     if (driver.on_variable_set(global, name, value) == false)
       print_error("The value specified for #{name} is not valid.")
@@ -1592,11 +1603,15 @@ class Core
     end
 
     # Set PAYLOAD from TARGET
-    if name.upcase == 'TARGET' && (active_module.exploit? || active_module.evasion?)
+    if name.upcase == 'TARGET' && active_module && (active_module.exploit? || active_module.evasion?)
       active_module.import_target_defaults
     end
 
     print_line("#{name} => #{datastore[name]}")
+  end
+
+  def payload_show_results
+    Msf::Ui::Console::CommandDispatcher::Modules.class_variable_get(:@@payload_show_results)
   end
 
   #

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1577,7 +1577,7 @@ class Core
 
     # Set PAYLOAD by index
     if name.upcase == 'PAYLOAD' && active_module && (active_module.exploit? || active_module.evasion?)
-      module_index(payload_show_results, value) do |mod|
+      index_from_list(payload_show_results, value) do |mod|
         return false unless mod && mod.respond_to?(:first)
 
         # [name, class] from payload_show_results

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -643,7 +643,7 @@ module Msf
             mod_name = args[0]
 
             # Use a module by search index
-            module_index(@module_search_results, mod_name) do |mod|
+            index_from_list(@module_search_results, mod_name) do |mod|
               return false unless mod && mod.respond_to?(:fullname)
 
               # Module cache object from @module_search_results

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -404,22 +404,14 @@ class Driver < Msf::Ui::Driver
   #
   def on_variable_set(glob, var, val)
     case var.downcase
-    when 'payload'
-      if framework && !framework.payloads.valid?(val)
-        return false
-      elsif active_module && active_module.type == 'exploit' && !active_module.is_payload_compatible?(val)
-        return false
-      elsif active_module
-        active_module.datastore.clear_non_user_defined
-      elsif framework
-        framework.datastore.clear_non_user_defined
-      end
     when 'sessionlogging'
       handle_session_logging(val) if glob
     when 'consolelogging'
       handle_console_logging(val) if glob
     when 'loglevel'
       handle_loglevel(val) if glob
+    when 'payload'
+      handle_payload(val)
     when 'ssh_ident'
       handle_ssh_ident(val)
     end
@@ -570,6 +562,23 @@ protected
   def handle_loglevel(val)
     set_log_level(Rex::LogSource, val)
     set_log_level(Msf::LogSource, val)
+  end
+
+  #
+  # This method handles setting a desired payload
+  #
+  # TODO: Move this out of the console driver!
+  #
+  def handle_payload(val)
+    if framework && !framework.payloads.valid?(val)
+      return false
+    elsif active_module && (active_module.exploit? || active_module.evasion?)
+      return false unless active_module.is_payload_compatible?(val)
+    elsif active_module
+      active_module.datastore.clear_non_user_defined
+    elsif framework
+      framework.datastore.clear_non_user_defined
+    end
   end
 
   #


### PR DESCRIPTION
Addresses https://twitter.com/drezdenkodex/status/1154094332514721793 and fixes #11529, I hope!

```
msf5 > use modcopy

Matching Modules
================

   #  Name                                   Disclosure Date  Rank       Check  Description
   -  ----                                   ---------------  ----       -----  -----------
   0  exploit/unix/ftp/proftpd_modcopy_exec  2015-04-22       excellent  Yes    ProFTPD 1.3.5 Mod_Copy Command Execution


[*] Using exploit/unix/ftp/proftpd_modcopy_exec
msf5 exploit(unix/ftp/proftpd_modcopy_exec) > show payloads

Compatible Payloads
===================

   #  Name                         Disclosure Date  Rank    Check  Description
   -  ----                         ---------------  ----    -----  -----------
   0  cmd/unix/bind_awk                             normal  No     Unix Command Shell, Bind TCP (via AWK)
   1  cmd/unix/bind_perl                            normal  No     Unix Command Shell, Bind TCP (via Perl)
   2  cmd/unix/bind_perl_ipv6                       normal  No     Unix Command Shell, Bind TCP (via perl) IPv6
   3  cmd/unix/generic                              normal  No     Unix Command, Generic Command Execution
   4  cmd/unix/reverse_awk                          normal  No     Unix Command Shell, Reverse TCP (via AWK)
   5  cmd/unix/reverse_perl                         normal  No     Unix Command Shell, Reverse TCP (via Perl)
   6  cmd/unix/reverse_perl_ssl                     normal  No     Unix Command Shell, Reverse TCP SSL (via perl)
   7  cmd/unix/reverse_python                       normal  No     Unix Command Shell, Reverse TCP (via Python)
   8  cmd/unix/reverse_python_ssl                   normal  No     Unix Command Shell, Reverse TCP SSL (via python)

msf5 exploit(unix/ftp/proftpd_modcopy_exec) > set payload 0
payload => cmd/unix/bind_awk
msf5 exploit(unix/ftp/proftpd_modcopy_exec) > options

Module options (exploit/unix/ftp/proftpd_modcopy_exec):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS                      yes       The target address range or CIDR identifier
   RPORT      80               yes       HTTP port (TCP)
   RPORT_FTP  21               yes       FTP port
   SITEPATH   /var/www         yes       Absolute writable website path
   SSL        false            no        Negotiate SSL/TLS for outgoing connections
   TARGETURI  /                yes       Base path to the website
   TMPPATH    /tmp             yes       Absolute writable path
   VHOST                       no        HTTP server virtual host


Payload options (cmd/unix/bind_awk):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LPORT  4444             yes       The listen port
   RHOST                   no        The target address


Exploit target:

   Id  Name
   --  ----
   0   ProFTPD 1.3.5


msf5 exploit(unix/ftp/proftpd_modcopy_exec) >
```

#10471, #11652, #11724, #11819, #11880, #12023