### PR TITLE
Cast to_s - Fix #11725

### DIFF
--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -347,7 +347,7 @@ class CommandShell
     # /etc/passwd
     # $ ls /etc/nosuchfile
     # ls: cannot access '/etc/nosuchfile': No such file or directory
-    result = shell_command_token("ls #{path}").strip
+    result = shell_command_token("ls #{path}").to_s.strip
     if result.eql?(path)
       return true
     end


### PR DESCRIPTION
Cast `to_s` to prevent stack trace
