### PR TITLE
Catch EOFError - Fix #12061

### DIFF
--- a/modules/auxiliary/admin/emc/alphastor_devicemanager_exec.rb
+++ b/modules/auxiliary/admin/emc/alphastor_devicemanager_exec.rb
@@ -52,6 +52,9 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     disconnect
-
+  rescue ::Rex::ConnectionError => e
+    print_error 'Connection failed'
+  rescue ::EOFError => e
+    print_error 'No reply'
   end
 end


### PR DESCRIPTION
Catch `EOFError` to prevent stack trace.

Tested with `nc -lvp 3000`.
