### PR TITLE
Update setting new .exe of Sophos AV

### DIFF
--- a/data/wordlists/av_hips_executables.txt
+++ b/data/wordlists/av_hips_executables.txt
@@ -1,3 +1,12 @@
+AlMon.exe 
+SAVAdminService.exe 
+SavService.exe 
+SNTPService.exe 
+swc_service.exe 
+swi_fc.exe
+swi_filter.exe
+swi_service.exe 
+swi_fc.exe  
 emet_agent.exe
 emet_service.exe
 firesvc.exe


### PR DESCRIPTION
Add .exe used by Sophos AV Endpoint


Add new .exe files to be verified by the killav post module.
Add Sophos AV Related Processes
