### PR TITLE
correct output printing bug from scanner/smb/smb_enumshares

### DIFF
--- a/lib/msf/core/exploit/smb/client.rb
+++ b/lib/msf/core/exploit/smb/client.rb
@@ -783,7 +783,7 @@ module Msf
           res.slice!(0,2) if comment_length % 2 == 1 # pad
 
           name    = Rex::Text.to_ascii(name).gsub("\x00", "")
-          s_type  = Rex::Text.to_ascii(smb_lookup_share_type(types[t])).gsub("\x00", "")
+          s_type  = smb_lookup_share_type(types[t])
           comment = Rex::Text.to_ascii(comment).gsub("\x00", "")
 
           shares << [ name, s_type, comment ]


### PR DESCRIPTION
This patch remove a call to Text.to_ascii which removed half the letters in the share types

the Text.to_ascii remove half the letters from the sharetype array because it treats it like utf16
when in reality it is a local array
it can be seen in scanner/smb/smb_enumshares : 

before patch :

`msf5 auxiliary(scanner/smb/smb_enumshares) > run

[-] 192.168.56.101:139    - Login Failed: Unable to Negotiate with remote host
[+] 192.168.56.101:445    - ADMIN$ - (DS) Remote Admin
[+] 192.168.56.101:445    - C$ - (DS) Default share
[+] 192.168.56.101:445    - IPC$ - (I) Remote IPC
[*] 192.168.56.101:       - Scanned 1 of 1 hosts (100% complete)
`

after patch : 
`msf5 auxiliary(scanner/smb/smb_enumshares) > run

[-] 192.168.56.101:139    - Login Failed: Unable to Negotiate with remote host
[+] 192.168.56.101:445    - ADMIN$ - (DISK) Remote Admin
[+] 192.168.56.101:445    - C$ - (DISK) Default share
[+] 192.168.56.101:445    - IPC$ - (IPC) Remote IPC
[*] 192.168.56.101:       - Scanned 1 of 1 hosts (100% complete)
`



