### PR TITLE
Lock bcrypt gem until armhf support is restored.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ PATH
       aws-sdk-iam
       aws-sdk-s3
       backports
-      bcrypt
+      bcrypt (= 3.1.12)
       bcrypt_pbkdf
       bit-struct
       concurrent-ruby (= 1.0.5)
@@ -137,7 +137,7 @@ GEM
     aws-sigv4 (1.1.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
     backports (3.15.0)
-    bcrypt (3.1.13)
+    bcrypt (3.1.12)
     bcrypt_pbkdf (1.0.1)
     bindata (2.4.4)
     bit-struct (0.16)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -53,7 +53,7 @@ Gem::Specification.new do |spec|
   # Backports Ruby features across language versions
   spec.add_runtime_dependency 'backports'
   # Needed for some admin modules (cfme_manageiq_evm_pass_reset.rb)
-  spec.add_runtime_dependency 'bcrypt'
+  spec.add_runtime_dependency 'bcrypt', '3.1.12'
   # Needed for Javascript obfuscation
   spec.add_runtime_dependency 'jsobfu'
   # Needed for some admin modules (scrutinizer_add_user.rb)


### PR DESCRIPTION
Updates in 3.1.13 can cause native gem compile to fail due to
https://github.com/codahale/bcrypt-ruby/issues/201.

## Verification

List the steps needed to make sure this thing works

- [x] `bundle install` a dev env on armhf kernel (such as Raspbian)
- [x] Start `msfconsole`
- [x] **Verify** bundle completes successfully
- [x] **Verify** console launch succeeds.
