### PR TITLE
Add exitfunk to pingback asm payloads

### DIFF
--- a/modules/payloads/singles/windows/pingback_bind_tcp.rb
+++ b/modules/payloads/singles/windows/pingback_bind_tcp.rb
@@ -7,6 +7,7 @@ require 'msf/core/payload/pingback'
 require 'msf/core/handler/bind_tcp'
 require 'msf/core/payload/windows/block_api'
 require 'msf/base/sessions/pingback'
+require 'msf/core/payload/windows/exitfunk'
 
 module MetasploitModule
 
@@ -17,6 +18,8 @@ module MetasploitModule
   include Msf::Payload::Pingback
   include Msf::Payload::Windows::BlockApi
   include Msf::Payload::Pingback::Options
+  include Msf::Payload::Windows::Exitfunk
+
 
   def initialize(info = {})
     super(merge_info(info,
@@ -36,6 +39,7 @@ module MetasploitModule
       encoded_host_port = "0x%.8x%.8x" % [encoded_host, encoded_port]
       self.pingback_uuid ||= self.generate_pingback_uuid
       uuid_as_db = "0x" + self.pingback_uuid.chars.each_slice(2).map(&:join).join(",0x")
+      conf = {exitfunk:   datastore['EXITFUNC']}
       addr_fam      = 2
       sockaddr_size = 16
 
@@ -134,12 +138,10 @@ module MetasploitModule
           call ebp                ; closesocket(socket)
 
         failure:
-        exitfunk:
-          mov ebx, 0x56a2b5f0
-          push.i8 0              ; push the exit function parameter
-          push ebx               ; push the hash of the exit function
-          call ebp               ; ExitProcess(0)
       ^
+      if conf[:exitfunk]
+        asm << asm_exitfunk(conf)
+      end
       Metasm::Shellcode.assemble(Metasm::X86.new, asm).encode_string
     end
   end

--- a/modules/payloads/singles/windows/pingback_bind_tcp.rb
+++ b/modules/payloads/singles/windows/pingback_bind_tcp.rb
@@ -33,13 +33,23 @@ module MetasploitModule
       'Session'       => Msf::Sessions::Pingback
     ))
 
+    def required_space
+      # Start with our cached default generated size
+      space = cached_size
+
+      # EXITFUNK 'seh' is the worst case, that adds 15 bytes
+      space += 15
+
+      space
+    end
+
     def generate_stage
       encoded_port = [datastore['LPORT'].to_i,2].pack("vn").unpack("N").first
       encoded_host = Rex::Socket.addr_aton(datastore['LHOST']||"127.127.127.127").unpack("V").first
       encoded_host_port = "0x%.8x%.8x" % [encoded_host, encoded_port]
       self.pingback_uuid ||= self.generate_pingback_uuid
       uuid_as_db = "0x" + self.pingback_uuid.chars.each_slice(2).map(&:join).join(",0x")
-      conf = {exitfunk:   datastore['EXITFUNC']}
+      conf = { exitfunk: datastore['EXITFUNC'] }
       addr_fam      = 2
       sockaddr_size = 16
 

--- a/modules/payloads/singles/windows/pingback_bind_tcp.rb
+++ b/modules/payloads/singles/windows/pingback_bind_tcp.rb
@@ -20,7 +20,6 @@ module MetasploitModule
   include Msf::Payload::Pingback::Options
   include Msf::Payload::Windows::Exitfunk
 
-
   def initialize(info = {})
     super(merge_info(info,
       'Name'          => 'Windows x86 Pingback, Bind TCP Inline',

--- a/modules/payloads/singles/windows/pingback_bind_tcp.rb
+++ b/modules/payloads/singles/windows/pingback_bind_tcp.rb
@@ -42,7 +42,7 @@ module MetasploitModule
       space
     end
 
-    def generate_stage
+    def generate
       encoded_port = [datastore['LPORT'].to_i,2].pack("vn").unpack("N").first
       encoded_host = Rex::Socket.addr_aton(datastore['LHOST']||"127.127.127.127").unpack("V").first
       encoded_host_port = "0x%.8x%.8x" % [encoded_host, encoded_port]

--- a/modules/payloads/singles/windows/pingback_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/pingback_reverse_tcp.rb
@@ -32,6 +32,16 @@ module MetasploitModule
       'Session'       => Msf::Sessions::Pingback
     ))
 
+    def required_space
+      # Start with our cached default generated size
+      space = cached_size
+
+      # EXITFUNK 'seh' is the worst case, that adds 15 bytes
+      space += 15
+
+      space
+    end
+
     def generate_stage
       encoded_port = [datastore['LPORT'].to_i, 2].pack("vn").unpack("N").first
       encoded_host = Rex::Socket.addr_aton(datastore['LHOST'] || "127.127.127.127").unpack("V").first
@@ -40,7 +50,7 @@ module MetasploitModule
       pingback_sleep = datastore['PingbackSleep']
       self.pingback_uuid ||= self.generate_pingback_uuid
       uuid_as_db = "0x" + self.pingback_uuid.chars.each_slice(2).map(&:join).join(",0x")
-      conf = {exitfunk:   datastore['EXITFUNC']}
+      conf = { exitfunk: datastore['EXITFUNC'] }
 
       asm = %Q^
         cld                    ; Clear the direction flag.

--- a/modules/payloads/singles/windows/pingback_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/pingback_reverse_tcp.rb
@@ -42,7 +42,7 @@ module MetasploitModule
       space
     end
 
-    def generate_stage
+    def generate
       encoded_port = [datastore['LPORT'].to_i, 2].pack("vn").unpack("N").first
       encoded_host = Rex::Socket.addr_aton(datastore['LHOST'] || "127.127.127.127").unpack("V").first
       retry_count  = [datastore['ReverseConnectRetries'].to_i, 1].max

--- a/modules/payloads/singles/windows/x64/pingback_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/x64/pingback_reverse_tcp.rb
@@ -9,7 +9,6 @@ require 'msf/base/sessions/pingback'
 require 'msf/core/payload/windows/x64/block_api'
 require 'msf/core/payload/windows/x64/exitfunk'
 
-
 module MetasploitModule
 
   CachedSize = 425
@@ -20,7 +19,6 @@ module MetasploitModule
   include Msf::Payload::Pingback::Options
   include Msf::Payload::Windows::BlockApi_x64
   include Msf::Payload::Windows::Exitfunk_x64
-
 
   def initialize(info = {})
     super(merge_info(info,
@@ -55,7 +53,7 @@ module MetasploitModule
       pingback_sleep = datastore['PingbackSleep']
       self.pingback_uuid ||= self.generate_pingback_uuid
       uuid_as_db = "0x" + self.pingback_uuid.chars.each_slice(2).map(&:join).join(",0x")
-      conf = {exitfunk:   datastore['EXITFUNC']}
+      conf = { exitfunk: datastore['EXITFUNC'] }
 
 
       asm = %Q^

--- a/modules/payloads/singles/windows/x64/pingback_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/x64/pingback_reverse_tcp.rb
@@ -6,6 +6,9 @@
 require 'msf/core/payload/pingback'
 require 'msf/core/handler/reverse_tcp'
 require 'msf/base/sessions/pingback'
+require 'msf/core/payload/windows/x64/block_api'
+require 'msf/core/payload/windows/x64/exitfunk'
+
 
 module MetasploitModule
 
@@ -15,6 +18,9 @@ module MetasploitModule
   include Msf::Payload::Single
   include Msf::Payload::Pingback
   include Msf::Payload::Pingback::Options
+  include Msf::Payload::Windows::BlockApi_x64
+  include Msf::Payload::Windows::Exitfunk_x64
+
 
   def initialize(info = {})
     super(merge_info(info,
@@ -27,7 +33,18 @@ module MetasploitModule
       'Handler'       => Msf::Handler::ReverseTcp,
       'Session'       => Msf::Sessions::Pingback
     ))
-    def generate_stage
+
+    def required_space
+      # Start with our cached default generated size
+      space = cached_size
+
+      # EXITFUNK 'seh' is the worst case, that adds 15 bytes
+      space += 15
+
+      space
+    end
+
+    def generate
       # 22 -> "0x00,0x16"
       # 4444 -> "0x11,0x5c"
       encoded_port = [datastore['LPORT'].to_i, 2].pack("vn").unpack("N").first
@@ -38,6 +55,8 @@ module MetasploitModule
       pingback_sleep = datastore['PingbackSleep']
       self.pingback_uuid ||= self.generate_pingback_uuid
       uuid_as_db = "0x" + self.pingback_uuid.chars.each_slice(2).map(&:join).join(",0x")
+      conf = {exitfunk:   datastore['EXITFUNC']}
+
 
       asm = %Q^
         cld                     ; Clear the direction flag.
@@ -241,14 +260,9 @@ module MetasploitModule
             jmp create_socket     ; repeat callback
         ^
       end
-      asm << %Q^
-        exitfunk:
-          pop rax               ; won't be returning, realign the stack with a pop
-          push 0                ;
-          pop rcx               ; set the exit function parameter
-          mov r10, 0x56a2b5f0
-          call rbp              ; ExitProcess(0)
-      ^
+      if conf[:exitfunk]
+        asm << asm_exitfunk(conf)
+      end
       Metasm::Shellcode.assemble(Metasm::X64.new, asm).encode_string
     end
   end


### PR DESCRIPTION
This PR brings Windows binary pingback payloads in line with our other payloads in terms of exit functions.  Previously, it only supported process exit.

- [x] Start `msfconsole`
- [x] `use <whatever>`
- [x] ` set payload windows/x64/pingback_reverse_tcp`
- [x] `set exitfunc thread`
- [x] run
- [x] Verify it works

Also:
- [x] ` set payload windows/pingback_reverse_tcp`
- [x] ` set payload windows/pingback_bind_tcp`
- [x] `set exitfunc process`