### PR TITLE
Use correct case for SSL option

### DIFF
--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -448,6 +448,8 @@ module Exploit::Remote::HttpClient
 
       opts['ssl'] = ssl
     else
+      disconnect
+
       opts['redirect_uri'] = location
       opts['uri'] = location.path
       opts['rhost'] = location.host
@@ -455,9 +457,9 @@ module Exploit::Remote::HttpClient
       opts['rport'] = location.port
 
       if location.scheme == 'https'
-        opts['ssl'] = true
+        opts['SSL'] = true
       else
-        opts['ssl'] = false
+        opts['SSL'] = false
       end
     end
   end


### PR DESCRIPTION

Fix redirection to an HTTPS url from an HTTP url.

## Verification

List the steps needed to make sure this thing works

make an aux module with a run method like
```
def run_host(ip)
       response = send_request_cgi!(                                                                                                                                                                            
         opts={'uri' => '/admin', 'method' => 'GET' }, 5, 5                                                                                                                                                     
       )                                                                                                                                                                                                        
       p opts                                                                                                                                                                                                   
end
```

- [x] Find or make a webserver that 302's to an https URL.
- [x] **Verify** the outputted `opts['SSL']` is true
- [x] **Verify** redirect is followed as expected

