### PR TITLE
Add RDP Fingerprinting

### DIFF
--- a/lib/msf/core/exploit/rdp.rb
+++ b/lib/msf/core/exploit/rdp.rb
@@ -100,7 +100,7 @@ module Exploit::Remote::RDP
     # warning: if rdp_check_protocol starts handling NLA, this will need to be updated
     is_rdp, server_selected_proto = rdp_check_protocol(RDPConstants::PROTOCOL_SSL | RDPConstants::PROTOCOL_HYBRID | RDPConstants::PROTOCOL_HYBRID_EX)
     return false, nil unless is_rdp
-    return true, peer_info unless server_selected_proto == RDPConstants::PROTOCOL_HYBRID
+    return true, peer_info unless [RDPConstants::PROTOCOL_HYBRID, RDPConstants::PROTOCOL_HYBRID_EX].include? server_selected_proto
 
     swap_sock_plain_to_ssl(nsock)
     ntlm_negotiate_blob = ''  # see: https://fadedlab.wordpress.com/2019/06/13/using-nmap-to-extract-windows-info-from-rdp/
@@ -121,9 +121,12 @@ module Exploit::Remote::RDP
     ntlm_negotiate_blob << "\x0f"                              #  NTLMRevision = 5 = NTLMSSP_REVISION_W2K3
     resp = rdp_send_recv(ntlm_negotiate_blob)
 
-    ntlmssp = NTLM_MESSAGE::parse(resp[24...-1])
-    version = ntlmssp.padding.bytes
-    peer_info[:product_version] = "#{version[0]}.#{version[1]}.#{version[2] | (version[3] << 8)}"
+    ntlmssp_start = resp.index('NTLMSSP')
+    if ntlmssp_start
+      ntlmssp = NTLM_MESSAGE::parse(resp[ntlmssp_start..-1])
+      version = ntlmssp.padding.bytes
+      peer_info[:product_version] = "#{version[0]}.#{version[1]}.#{version[2] | (version[3] << 8)}"
+    end
 
     return is_rdp, peer_info
   end

--- a/lib/msf/core/exploit/rdp.rb
+++ b/lib/msf/core/exploit/rdp.rb
@@ -89,13 +89,44 @@ module Exploit::Remote::RDP
     rdp_recv
   end
 
+  def rdp_fingerprint(nsock)
+    is_rdp, server_selected_proto = rdp_check_protocol(RDPConstants::PROTOCOL_SSL | RDPConstants::PROTOCOL_HYBRID | RDPConstants::PROTOCOL_HYBRID_EX)
+    return false, nil unless is_rdp
+    return true, nil unless server_selected_proto == RDPConstants::PROTOCOL_HYBRID
+
+    swap_sock_plain_to_ssl(nsock)
+    ntlm_negotiate_blob = ''  # see: https://fadedlab.wordpress.com/2019/06/13/using-nmap-to-extract-windows-info-from-rdp/
+    ntlm_negotiate_blob << "\x30\x37\xa0\x03\x02\x01\x60\xa1\x30\x30\x2e\x30\x2c\xa0\x2a\x04\x28"
+    ntlm_negotiate_blob << "\x4e\x54\x4c\x4d\x53\x53\x50\x00"  #  Identifier - NTLMSSP
+    ntlm_negotiate_blob << "\x01\x00\x00\x00"                  #  Type: NTLMSSP Negotiate - 01
+    ntlm_negotiate_blob << "\xb7\x82\x08\xe2"                  #  Flags (NEGOTIATE_SIGN_ALWAYS | NEGOTIATE_NTLM | NEGOTIATE_SIGN | REQUEST_TARGET | NEGOTIATE_UNICODE)
+    ntlm_negotiate_blob << "\x00\x00"                          #  DomainNameLen
+    ntlm_negotiate_blob << "\x00\x00"                          #  DomainNameMaxLen
+    ntlm_negotiate_blob << "\x00\x00\x00\x00"                  #  DomainNameBufferOffset
+    ntlm_negotiate_blob << "\x00\x00"                          #  WorkstationLen
+    ntlm_negotiate_blob << "\x00\x00"                          #  WorkstationMaxLen
+    ntlm_negotiate_blob << "\x00\x00\x00\x00"                  #  WorkstationBufferOffset
+    ntlm_negotiate_blob << "\x0a"                              #  ProductMajorVersion = 10
+    ntlm_negotiate_blob << "\x00"                              #  ProductMinorVersion = 0
+    ntlm_negotiate_blob << "\x63\x45"                          #  ProductBuild = 0x4563 = 17763
+    ntlm_negotiate_blob << "\x00\x00\x00"                      #  Reserved
+    ntlm_negotiate_blob << "\x0f"                              #  NTLMRevision = 5 = NTLMSSP_REVISION_W2K3
+    resp = rdp_send_recv(ntlm_negotiate_blob)
+
+    ntlmssp = NTLM_MESSAGE::parse(resp[24...-1])
+    version = ntlmssp.padding.bytes
+    version = "#{version[0]}.#{version[1]}.#{version[2] | (version[3] << 8)}"
+
+    return true, {:product_version => version}
+  end
+
   # Connect and detect security protocol
   #
   # Note: NLA is detected but not supported yet
   #
   # @return [Boolean] Is service RDP
   # @return [RDPConstants] Protocol supported
-  def rdp_check_protocol
+  def rdp_check_protocol(req_proto = RDPConstants::PROTOCOL_SSL)
     if datastore['RDP_USER']
       @user_name = datastore['RDP_USER']
     else
@@ -120,7 +151,7 @@ module Exploit::Remote::RDP
     vprint_status("Verifying RDP protocol...")
 
     vprint_status("Attempting to connect using TLS security")
-    res = rdp_send_recv(pdu_negotiation_request(@user_name, RDPConstants::PROTOCOL_SSL))
+    res = rdp_send_recv(pdu_negotiation_request(@user_name, req_proto))
 
     # return true if the response is a X.224 Connect Confirm
     # We can't use a check for RDP Negotiation Response because WinXP excludes it

--- a/lib/msf/core/exploit/rdp.rb
+++ b/lib/msf/core/exploit/rdp.rb
@@ -89,10 +89,18 @@ module Exploit::Remote::RDP
     rdp_recv
   end
 
+  # Connect and perform fingerprinting of the RDP service
+  #
+  # Note: NLA is required to detect the product_version
+  #
+  # @return [Boolean] Is service RDP
+  # @return [Hash] Version information
   def rdp_fingerprint(nsock)
+    peer_info = {}
+    # warning: if rdp_check_protocol starts handling NLA, this will need to be updated
     is_rdp, server_selected_proto = rdp_check_protocol(RDPConstants::PROTOCOL_SSL | RDPConstants::PROTOCOL_HYBRID | RDPConstants::PROTOCOL_HYBRID_EX)
     return false, nil unless is_rdp
-    return true, nil unless server_selected_proto == RDPConstants::PROTOCOL_HYBRID
+    return true, peer_info unless server_selected_proto == RDPConstants::PROTOCOL_HYBRID
 
     swap_sock_plain_to_ssl(nsock)
     ntlm_negotiate_blob = ''  # see: https://fadedlab.wordpress.com/2019/06/13/using-nmap-to-extract-windows-info-from-rdp/
@@ -115,9 +123,9 @@ module Exploit::Remote::RDP
 
     ntlmssp = NTLM_MESSAGE::parse(resp[24...-1])
     version = ntlmssp.padding.bytes
-    version = "#{version[0]}.#{version[1]}.#{version[2] | (version[3] << 8)}"
+    peer_info[:product_version] = "#{version[0]}.#{version[1]}.#{version[2] | (version[3] << 8)}"
 
-    return true, {:product_version => version}
+    return is_rdp, peer_info
   end
 
   # Connect and detect security protocol

--- a/modules/auxiliary/scanner/rdp/rdp_scanner.rb
+++ b/modules/auxiliary/scanner/rdp/rdp_scanner.rb
@@ -5,6 +5,7 @@
 
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::Tcp
+  include Msf::Exploit::Remote::RDP
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::Report
 
@@ -17,7 +18,9 @@ class MetasploitModule < Msf::Auxiliary
           This module attempts to connect to the specified Remote Desktop Protocol port
           and determines if it speaks RDP.
 
-          The CredSSP and EarlyUser options are related to Network Level Authentication.
+          When available, the Credential Security Support Provider (CredSSP) protocol will be used to identify the
+          version of Windows on which the server is running. Enabling the DETECT_NLA option will cause a second
+          connection to be made to the server to identify if Network Level Authentication (NLA) is required.
         ),
         'Author'         => 'Jon Hart <jon_hart[at]rapid7.com>',
         'References'     =>
@@ -31,77 +34,68 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
       [
         Opt::RPORT(3389),
-        OptBool.new('TLS', [true, 'Whether or not request TLS security', true]),
-        OptBool.new('CredSSP', [true, 'Whether or not to request CredSSP', true]),
-        OptBool.new('EarlyUser', [true, 'Whether to support Early User Authorization Result PDU', false])
+        OptBool.new('DETECT_NLA', [true, 'Detect Network Level Authentication (NLA)', true])
       ]
     )
   end
 
-  # any TPKT v3 + x.2224 COTP Connect Confirm
-  RDP_RE = /^\x03\x00.{3}\xd0.{5}.*$/
-  def rdp?
-    sock.put(@probe)
-    response = sock.get_once(-1)
-    if response
-      if RDP_RE.match(response)
-        # XXX: it might be helpful to decode the response and show what was selected.
-        print_good("Identified RDP")
-        return true
-      else
-        vprint_status("No match for '#{Rex::Text.to_hex_ascii(response)}'")
-      end
-    else
-      vprint_status("No response")
+  def check_rdp
+    begin
+      nsock = connect
+    rescue ::Errno::ETIMEDOUT, Rex::HostUnreachable, Rex::ConnectionTimeout, Rex::ConnectionRefused, ::Timeout::Error, ::EOFError
+      return false, nil
     end
 
-    false
+    is_rdp, version_info = rdp_fingerprint(nsock)
+    disconnect
+
+    service_info = nil
+    if is_rdp
+      product_version = (version_info && version_info[:product_version]) ? version_info[:product_version] : 'N/A'
+      info = "Detected RDP on #{peer} (Windows v#{product_version})"
+
+      if datastore['DETECT_NLA']
+        service_info = "Requires NLA: #{(!version_info[:product_version].nil? && requires_nla?) ? 'Yes' : 'No'}"
+        info << " (#{service_info})"
+      end
+
+      print_status(info)
+    end
+
+    return is_rdp, service_info
   end
 
-  def setup
-    # build a simple TPKT v3 + x.224 COTP Connect Request.  optionally append
-    # RDP negotiation request with TLS, CredSSP and Early User as requested
-    requested_protocols = 0
-    if datastore['TLS']
-      requested_protocols = requested_protocols ^ 0b1
-    end
-    if datastore['CredSSP']
-      requested_protocols = requested_protocols ^ 0b10
-    end
-    if datastore['EarlyUser']
-      requested_protocols = requested_protocols ^ 0b1000
+  def requires_nla?
+    begin
+      nsock = connect
+    rescue ::Errno::ETIMEDOUT, Rex::HostUnreachable, Rex::ConnectionTimeout, Rex::ConnectionRefused, ::Timeout::Error, ::EOFError
+      return false
     end
 
-    if requested_protocols == 0
-      tpkt_len = 11
-      cotp_len = 6
-      pack = [ 3, 0, tpkt_len, cotp_len, 0xe0, 0, 0, 0 ]
-      pack_string = "CCnCCnnC"
-    else
-      tpkt_len = 19
-      cotp_len = 14
-      pack  = [ 3, 0, tpkt_len, cotp_len, 0xe0, 0, 0, 0, 1, 0, 8, 0, requested_protocols ]
-      pack_string = "CCnCCnnCCCCCV"
-    end
-    @probe = pack.pack(pack_string)
+    is_rdp, server_selected_proto = rdp_check_protocol
+    disconnect
+
+    return false unless is_rdp
+    return [RDPConstants::PROTOCOL_HYBRID, RDPConstants::PROTOCOL_HYBRID_EX].include? server_selected_proto
   end
 
   def run_host(_ip)
+    is_rdp = false
     begin
       connect
-      return unless rdp?
+      is_rdp, service_info = check_rdp
     rescue Rex::ConnectionError => e
-      vprint_error("error while connecting and negotiating RDP: #{e}")
+      vprint_error("Error while connecting and negotiating RDP: #{e}")
       return
-    ensure
-      disconnect
     end
+    return unless is_rdp
 
     report_service(
       host: rhost,
       port: rport,
       proto: 'tcp',
-      name: 'RDP'
+      name: 'RDP',
+      info: service_info
     )
   end
 end

--- a/modules/auxiliary/scanner/rdp/rdp_scanner.rb
+++ b/modules/auxiliary/scanner/rdp/rdp_scanner.rb
@@ -4,7 +4,6 @@
 ##
 
 class MetasploitModule < Msf::Auxiliary
-  include Msf::Exploit::Remote::Tcp
   include Msf::Exploit::Remote::RDP
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::Report

--- a/modules/auxiliary/scanner/rdp/rdp_scanner.rb
+++ b/modules/auxiliary/scanner/rdp/rdp_scanner.rb
@@ -52,7 +52,7 @@ class MetasploitModule < Msf::Auxiliary
     service_info = nil
     if is_rdp
       product_version = (version_info && version_info[:product_version]) ? version_info[:product_version] : 'N/A'
-      info = "Detected RDP on #{peer} (Windows v#{product_version})"
+      info = "Detected RDP on #{peer} (Windows version: #{product_version})"
 
       if datastore['DETECT_NLA']
         service_info = "Requires NLA: #{(!version_info[:product_version].nil? && requires_nla?) ? 'Yes' : 'No'}"


### PR DESCRIPTION
This PR adds a new `rdp_fingerprint` method to the RDP mixin. The fingerprint method, uses the same CredSSP technique that Tom Sellers outlined in his blog post [Using Nmap to extract Windows host and domain information via RDP](https://fadedlab.wordpress.com/2019/06/13/using-nmap-to-extract-windows-info-from-rdp/). This PR also updates the `auxiliary/scanner/rdp/rdp_scanner` module to use the new fingerprinting technique. Because the technique effectively requests NLA, the `DETECT_NLA` data store option was also added to detect if the server requires NLA. When configured, this causes the module to connect a second time to determine if NLA is required. The second connection is skipped if either the remote service isn't RDP or doesn't support NLA (specifically `PROTOCOL_HYBRID` | `PROTOCOL_HYBRID_EX`). The scanner module also includes whether NLA is required or not when adding the service to the database.

## Testing
To test this module:

- [ ] Start `msfconsole`
- [ ] Use `scanner/rdp/rdp_scanner`
- [ ] Set the `RHOSTS` option to one or more RDP servers to scan
- [ ] Run the module and see the expected results<sup>1</sup>

<sup>1</sup> I have noticed that scanning Windows XP repeatedly will yield false negative results. Waiting a couple of minutes between scans seems to fix the issue.

## Example
```
metasploit-framework (S:0 J:1) auxiliary(scanner/rdp/rdp_scanner) > show options 

Module options (auxiliary/scanner/rdp/rdp_scanner):

   Name             Current Setting  Required  Description
   ----             ---------------  --------  -----------
   DETECT_NLA       true             yes       Detect Network Level Authentication (NLA)
   RDP_CLIENT_IP    192.168.0.100    yes       The client IPv4 address to report during connect
   RDP_CLIENT_NAME  rdesktop         no        The client computer name to report during connect, UNSET = random
   RDP_DOMAIN                        no        The client domain name to report during connect
   RDP_USER                          no        The username to report during connect, UNSET = random
   RHOSTS           192.168.90.10    yes       The target address range or CIDR identifier
   RPORT            3389             yes       The target port (TCP)
   THREADS          32               yes       The number of concurrent threads

metasploit-framework (S:0 J:1) auxiliary(scanner/rdp/rdp_scanner) > exploit
metasploit-framework (S:0 J:1) auxiliary(scanner/rdp/rdp_scanner) > exploit

[*] [2019.08.11-15:48:43] 192.168.90.10:3389    - Verifying RDP protocol...
[*] [2019.08.11-15:48:43] 192.168.90.10:3389    - Attempting to connect using TLS security
[*] [2019.08.11-15:48:43] 192.168.90.10:3389    - Verifying RDP protocol...
[*] [2019.08.11-15:48:43] 192.168.90.10:3389    - Attempting to connect using TLS security
[*] [2019.08.11-15:48:43] 192.168.90.10:3389    - Detected RDP on 192.168.90.10:3389    (Windows v6.1.7601) (Requires NLA: No)
[*] [2019.08.11-15:48:43] 192.168.90.10:3389    - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
metasploit-framework (S:0 J:1) auxiliary(scanner/rdp/rdp_scanner) > services 
Services
========

host           port  proto  name  state  info
----           ----  -----  ----  -----  ----
192.168.90.10  3389  tcp    rdp   open   Requires NLA: No

metasploit-framework (S:0 J:1) auxiliary(scanner/rdp/rdp_scanner) >
```