### PR TITLE
Fix typo, full_name -> fullname

### DIFF
--- a/tools/modules/module_author.rb
+++ b/tools/modules/module_author.rb
@@ -81,7 +81,7 @@ local_modules.each do |_module_key, local_module|
   local_module['author'].each do |r|
     next if filter.downcase != 'all' && local_module['type'] != filter.downcase
     if regex.nil? or r =~ regex
-      tbl << [ local_module['full_name'], r ]
+      tbl << [ local_module['fullname'], r ]
       names[r] ||= 0
       names[r] += 1
     end


### PR DESCRIPTION
## Verification

- [x] `ruby tools/modules/module_author.rb`
- [x] **Verify** module name is displayed in the Module column

Fixes #11941.