### PR TITLE
Fix nil RangeWalker length for invalid range in exploit RHOSTS

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/exploit.rb
+++ b/lib/msf/ui/console/command_dispatcher/exploit.rb
@@ -170,7 +170,7 @@ class Exploit
       rhosts_range = Rex::Socket::RangeWalker.new(rhosts_opt.normalize(rhosts))
     end
     # For multiple targets exploit attempts.
-    if rhosts_range && rhosts_range.length > 1
+    if rhosts_range && rhosts_range.length.to_i > 1
       opts[:multi] = true
       rhosts_range.each do |rhost|
         nmod = mod.replicant


### PR DESCRIPTION
`reset` returns `false` and doesn't initialize `length`. This just restores the `to_i` that was present before.

## Before

```
msf5 exploit(unix/webapp/drupal_restws_unserialize) > set rhosts .
rhosts => .
msf5 exploit(unix/webapp/drupal_restws_unserialize) > run
[-] Error while running command run: undefined method `>' for nil:NilClass

Call stack:
/rapid7/metasploit-framework/lib/msf/ui/console/command_dispatcher/exploit.rb:173:in `cmd_exploit'
/rapid7/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:523:in `run_command'
/rapid7/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:474:in `block in run_single'
/rapid7/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:468:in `each'
/rapid7/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:468:in `run_single'
/rapid7/metasploit-framework/lib/rex/ui/text/shell.rb:151:in `run'
/rapid7/metasploit-framework/lib/metasploit/framework/command/console.rb:48:in `start'
/rapid7/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'
./msfconsole:49:in `<main>'
msf5 exploit(unix/webapp/drupal_restws_unserialize) >
```

## After

```
msf5 exploit(unix/webapp/drupal_restws_unserialize) > set rhosts .
rhosts => .
msf5 exploit(unix/webapp/drupal_restws_unserialize) > run

[-] Exploit failed: The following options failed to validate: RHOSTS.
[*] Exploit completed, but no session was created.
msf5 exploit(unix/webapp/drupal_restws_unserialize) >
```

Updates #11497. Fixes #12193.