### PR TITLE
Add needs_cleanup to the post module class so filedropper does not

### DIFF
--- a/lib/msf/core/post.rb
+++ b/lib/msf/core/post.rb
@@ -27,6 +27,10 @@ class Msf::Post < Msf::Module
 
   include Msf::PostMixin
 
+  # file_dropper sets needs_cleanup to true to track exploits that upload files
+  # some post modules also use file_dropper, so let's define it here
+  attr_accessor :needs_cleanup
+
   def setup
     m = replicant
 


### PR DESCRIPTION
fixes https://github.com/rapid7/metasploit-framework/issues/12197

When pingback payloads were getting landed, we added a flag to exploit modules called `needs_cleanup` that the `file_dropper` mixin changed to indicate an exploit was placing a file on the remote target.  That let us know if cleanup would be required and to prevent the use of a pingback payload, which cannot cleanup.

Unfortunately, I did not realize that post modules also use `file_dropper`.  After the change, when post modules included `file_dropper`, `file_dropper` attempted to change the `needs_cleanup` flag, but post modules don't have that variable, so everything crashed.  This fix just adds `needs_cleanup` to the post module parent class, so the value can be set by `file_dropper`.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use exploit/windows/http/hp_autopass_license_traversal`
- [x] `set payload windows/pingback_reverse_tcp`
- [x] **Verify** the payload is invalid for the exploit (it uses fileDropper)

- [x] `use post/multi/manage/upload_exec`
- [x] **Verify** the module loads without error
