### PR TITLE
Disable a couple of modules for autoexploitation

### DIFF
--- a/modules/exploits/windows/dcerpc/ms03_026_dcom.rb
+++ b/modules/exploits/windows/dcerpc/ms03_026_dcom.rb
@@ -63,17 +63,10 @@ class MetasploitModule < Msf::Exploit::Remote
       'DisclosureDate' => 'Jul 16 2003'))
   end
 
+  # don't bother with this module for autoexploitation, it creates
+  # false-positives on newer systems.
   def autofilter
-    # Common vulnerability scanning tools report port 445/139
-    # due to how they test for the vulnerability. Remap this
-    # back to 135 for automated exploitation
-
-    rport = datastore['RPORT'].to_i
-    if ( rport == 139 or rport == 445 )
-      datastore['RPORT'] = 135
-    end
-
-    true
+    false
   end
 
   def exploit

--- a/modules/exploits/windows/smb/netidentity_xtierrpcpipe.rb
+++ b/modules/exploits/windows/smb/netidentity_xtierrpcpipe.rb
@@ -53,6 +53,12 @@ class MetasploitModule < Msf::Exploit::Remote
       ])
   end
 
+  # don't bother with this module for autoexploitation, it creates
+  # false-positives on newer systems.
+  def autofilter
+    false
+  end
+
   def mem_leak
     print_status("Connecting to the server...")
     connect()


### PR DESCRIPTION
These are a couple of decade+ old modules that produce false positives on newer Windows systems. This simply disables them for autoexploitation.

Since this method isn't use in framework AFAIK, this would have to be tested with Metasploit Pro's autoexploit feature to ensure that these two modules are skipped.
