### PR TITLE
RDP lib: accept TLS 1.0

### DIFF
--- a/lib/msf/core/exploit/rdp.rb
+++ b/lib/msf/core/exploit/rdp.rb
@@ -965,6 +965,7 @@ module Exploit::Remote::RDP
   # Stolen from exploit/smtp_deliver.rb
   def swap_sock_plain_to_ssl(nsock)
     ctx = OpenSSL::SSL::SSLContext.new
+    ctx.min_version = OpenSSL::SSL::TLS1_VERSION
     ssl = OpenSSL::SSL::SSLSocket.new(nsock, ctx)
 
     ssl.connect


### PR DESCRIPTION
Fix #12213

## Verification

List the steps needed to make sure this thing works

- [x] Prepare Windows VM, at least two Windows 7, one without any patch (-> TLS 1.0 only), and one with https://support.microsoft.com/fr-fr/help/3080079/update-to-add-rds-support-for-tls-1-1-and-tls-1-2-in-windows-7-or-wind installed (-> TLS 1.1 and 1.2 supported)
- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/rdp/cve_2019_0708_bluekeep`
- [x] ...
- [x] Scan both hosts, both should return "The target is vulnerable" without any error

