### PR TITLE
[f5_bigip_cookie_disclosure] Store cookies in the database

### DIFF
--- a/documentation/modules/auxiliary/gather/f5_bigip_cookie_disclosure.md
+++ b/documentation/modules/auxiliary/gather/f5_bigip_cookie_disclosure.md
@@ -1,0 +1,67 @@
+## Description
+
+This module identifies F5 BIG-IP load balancers and leaks backend information (pool name, routed domain, and backend servers' IP addresses and ports) through cookies inserted by the BIG-IP systems.
+
+For further information:
+
+* [K6917: Overview of BIG-IP persistence cookie encoding](https://support.f5.com/csp/article/K6917)
+* [K7784: Configuring BIG-IP cookie encryption (9.x)](https://support.f5.com/csp/article/K7784)
+* [K14784: Configuring cookie encryption within the HTTP profile (10.x - 15.x)](https://support.f5.com/csp/article/K14784)
+* [K23254150: Configuring cookie encryption for BIG-IP persistence cookies from the cookie persistence profile](https://support.f5.com/csp/article/K23254150)
+
+## Verification Steps
+
+1. Start `msfconsole`
+2. Select the module: `use auxiliary/gather/f5_bigip_cookie_disclosure`
+3. Select your target(s): `set RHOSTS www.example.fr`
+4. Run the module: `run`
+
+## Options
+
+  **REQUESTS**
+
+  The number of requests to send. Default value is `10`.
+
+  **RPORT**
+
+  The BIG-IP service port. Default value is `443`.
+
+  **TARGETURI**
+
+  The URI path to test. Default value is `/`.
+
+## Scenarios
+
+### F5 BIP-IP load balancing cookie not found
+
+  ```
+  msf5 > use auxiliary/gather/f5_bigip_cookie_disclosure
+  msf5 auxiliary(gather/f5_bigip_cookie_disclosure) > set RHOSTS www.example.com
+  RHOSTS => www.example.com
+  msf5 auxiliary(gather/f5_bigip_cookie_disclosure) > run
+  [*] Running module against 93.184.216.34
+
+  [*] Starting request /
+  [-] F5 BIG-IP load balancing cookie not found
+  [*] Auxiliary module execution completed
+  msf5 auxiliary(gather/f5_bigip_cookie_disclosure) >
+  ```
+
+### F5 BIP-IP load balancing cookie found
+
+  The sensitive information have been replaced with fake ones for privacy reasons:
+
+  ```
+  msf5 > use auxiliary/gather/f5_bigip_cookie_disclosure
+  msf5 auxiliary(gather/f5_bigip_cookie_disclosure) > set RHOSTS vulnerable-target.com
+  RHOSTS => vulnerable-target.com
+  msf5 auxiliary(gather/f5_bigip_cookie_disclosure) > run
+  [*] Running module against 1.1.1.1
+
+  [*] Starting request /
+  [+] F5 BIG-IP load balancing cookie "BIGipServer~DMZ~EXAMPLE~vulnarable-target-443_pool = 1214841098.47873.0000" found
+  [+] Load balancing pool name "~DMZ~EXAMPLE~vulnarable-target-443_pool" found
+  [+] Backend 10.1.105.72:443 found
+  [*] Auxiliary module execution completed
+  msf5 auxiliary(gather/f5_bigip_cookie_disclosure) >
+  ```

--- a/documentation/modules/auxiliary/gather/f5_bigip_cookie_disclosure.md
+++ b/documentation/modules/auxiliary/gather/f5_bigip_cookie_disclosure.md
@@ -13,7 +13,7 @@ For further information:
 
 1. Start `msfconsole`
 2. Select the module: `use auxiliary/gather/f5_bigip_cookie_disclosure`
-3. Select your target(s): `set RHOSTS www.example.fr`
+3. Select your target(s): `set RHOSTS www.example.com`
 4. Run the module: `run`
 
 ## Options

--- a/documentation/modules/auxiliary/gather/f5_bigip_cookie_disclosure.md
+++ b/documentation/modules/auxiliary/gather/f5_bigip_cookie_disclosure.md
@@ -49,8 +49,6 @@ For further information:
 
 ### F5 BIP-IP load balancing cookie found
 
-  The sensitive information have been replaced with fake ones for privacy reasons:
-
   ```
   msf5 > use auxiliary/gather/f5_bigip_cookie_disclosure
   msf5 auxiliary(gather/f5_bigip_cookie_disclosure) > set RHOSTS vulnerable-target.com

--- a/documentation/modules/auxiliary/gather/f5_bigip_cookie_disclosure.md
+++ b/documentation/modules/auxiliary/gather/f5_bigip_cookie_disclosure.md
@@ -61,5 +61,15 @@ For further information:
   [+] Load balancing pool name "~DMZ~EXAMPLE~vulnarable-target-443_pool" found
   [+] Backend 10.1.105.72:443 found
   [*] Auxiliary module execution completed
+  msf5 auxiliary(gather/f5_bigip_cookie_disclosure) > notes
+
+  Notes
+  =====
+
+   Time                     Host             Service  Port  Protocol  Type                           Data
+   ----                     ----             -------  ----  --------  ----                           ----
+   2019-08-20 21:21:02 UTC  1.1.1.1                                   f5_load_balancer_cookie_name   "BIGipServer~DMZ~EXAMPLE~vulnarable-target-443_pool"
+   2019-08-20 21:21:02 UTC  1.1.1.1                                   f5_load_balancer_pool_name     "~DMZ~EXAMPLE~vulnarable-target-443_pool"
+   2019-08-20 21:21:02 UTC  1.1.1.1                                   f5_load_balancer_backends      [{:host=>"10.1.105.72", :port=>443}]
   msf5 auxiliary(gather/f5_bigip_cookie_disclosure) >
   ```

--- a/documentation/modules/auxiliary/gather/f5_bigip_cookie_disclosure.md
+++ b/documentation/modules/auxiliary/gather/f5_bigip_cookie_disclosure.md
@@ -1,75 +1,61 @@
-## Description
+## Vulnerable Application
 
-This module identifies F5 BIG-IP load balancers and leaks backend information (pool name, routed domain, and backend servers' IP addresses and ports) through cookies inserted by the BIG-IP systems.
-
-For further information:
-
-* [K6917: Overview of BIG-IP persistence cookie encoding](https://support.f5.com/csp/article/K6917)
-* [K7784: Configuring BIG-IP cookie encryption (9.x)](https://support.f5.com/csp/article/K7784)
-* [K14784: Configuring cookie encryption within the HTTP profile (10.x - 15.x)](https://support.f5.com/csp/article/K14784)
-* [K23254150: Configuring cookie encryption for BIG-IP persistence cookies from the cookie persistence profile](https://support.f5.com/csp/article/K23254150)
+This module identifies F5 BIG-IP load balancers and leaks backend information (pool name, routed domain,
+and backend servers' IP addresses and ports) through cookies inserted by the BIG-IP systems.
 
 ## Verification Steps
 
 1. Start `msfconsole`
-2. Select the module: `use auxiliary/gather/f5_bigip_cookie_disclosure`
-3. Select your target(s): `set RHOSTS www.example.com`
-4. Run the module: `run`
+1. Do: `use auxiliary/gather/f5_bigip_cookie_disclosure`
+1. Do: `set RHOSTS www.example.com`
+1. Do: `run`
 
 ## Options
 
-  **REQUESTS**
+### REQUESTS
 
   The number of requests to send. Default value is `10`.
-
-  **RPORT**
-
-  The BIG-IP service port. Default value is `443`.
-
-  **TARGETURI**
-
-  The URI path to test. Default value is `/`.
 
 ## Scenarios
 
 ### F5 BIP-IP load balancing cookie not found
 
-  ```
-  msf5 > use auxiliary/gather/f5_bigip_cookie_disclosure
-  msf5 auxiliary(gather/f5_bigip_cookie_disclosure) > set RHOSTS www.example.com
-  RHOSTS => www.example.com
-  msf5 auxiliary(gather/f5_bigip_cookie_disclosure) > run
-  [*] Running module against 93.184.216.34
+```
+msf5 > use auxiliary/gather/f5_bigip_cookie_disclosure
+msf5 auxiliary(gather/f5_bigip_cookie_disclosure) > set RHOSTS www.example.com
+RHOSTS => www.example.com
+msf5 auxiliary(gather/f5_bigip_cookie_disclosure) > run
+[*] Running module against 93.184.216.34
 
-  [*] Starting request /
-  [-] F5 BIG-IP load balancing cookie not found
-  [*] Auxiliary module execution completed
-  msf5 auxiliary(gather/f5_bigip_cookie_disclosure) >
-  ```
+[*] Starting request /
+[-] F5 BIG-IP load balancing cookie not found
+[*] Auxiliary module execution completed
+msf5 auxiliary(gather/f5_bigip_cookie_disclosure) >
+```
 
 ### F5 BIP-IP load balancing cookie found
 
-  ```
-  msf5 > use auxiliary/gather/f5_bigip_cookie_disclosure
-  msf5 auxiliary(gather/f5_bigip_cookie_disclosure) > set RHOSTS vulnerable-target.com
-  RHOSTS => vulnerable-target.com
-  msf5 auxiliary(gather/f5_bigip_cookie_disclosure) > run
-  [*] Running module against 1.1.1.1
+```
+msf5 > use auxiliary/gather/f5_bigip_cookie_disclosure
+msf5 auxiliary(gather/f5_bigip_cookie_disclosure) > set RHOSTS vulnerable-target.com
+RHOSTS => vulnerable-target.com
+msf5 auxiliary(gather/f5_bigip_cookie_disclosure) > run
+[*] Running module against 1.1.1.1
 
-  [*] Starting request /
-  [+] F5 BIG-IP load balancing cookie "BIGipServer~DMZ~EXAMPLE~vulnarable-target-443_pool = 1214841098.47873.0000" found
-  [+] Load balancing pool name "~DMZ~EXAMPLE~vulnarable-target-443_pool" found
-  [+] Backend 10.1.105.72:443 found
-  [*] Auxiliary module execution completed
-  msf5 auxiliary(gather/f5_bigip_cookie_disclosure) > notes
+[*] Starting request /
+[+] F5 BIG-IP load balancing cookie "BIGipServer~DMZ~EXAMPLE~vulnarable-target-443_pool = 1214841098.47873.0000" found
+[+] Load balancing pool name "~DMZ~EXAMPLE~vulnarable-target-443_pool" found
+[+] Backend 10.1.105.72:443 found
+[*] Auxiliary module execution completed
+msf5 auxiliary(gather/f5_bigip_cookie_disclosure) > notes
 
-  Notes
-  =====
+Notes
+=====
 
-   Time                     Host             Service  Port  Protocol  Type                           Data
-   ----                     ----             -------  ----  --------  ----                           ----
-   2019-08-20 21:21:02 UTC  1.1.1.1                                   f5_load_balancer_cookie_name   "BIGipServer~DMZ~EXAMPLE~vulnarable-target-443_pool"
-   2019-08-20 21:21:02 UTC  1.1.1.1                                   f5_load_balancer_pool_name     "~DMZ~EXAMPLE~vulnarable-target-443_pool"
-   2019-08-20 21:21:02 UTC  1.1.1.1                                   f5_load_balancer_backends      [{:host=>"10.1.105.72", :port=>443}]
-  msf5 auxiliary(gather/f5_bigip_cookie_disclosure) >
-  ```
+ Time                     Host             Service  Port  Protocol  Type                           Data
+ ----                     ----             -------  ----  --------  ----                           ----
+ 2019-08-20 21:21:02 UTC  1.1.1.1                                   f5_load_balancer_cookie_name   "BIGipServer~DMZ~EXAMPLE~vulnarable-target-443_pool"
+ 2019-08-20 21:21:02 UTC  1.1.1.1                                   f5_load_balancer_pool_name     "~DMZ~EXAMPLE~vulnarable-target-443_pool"
+ 2019-08-20 21:21:02 UTC  1.1.1.1                                   f5_load_balancer_backends      [{:host=>"10.1.105.72", :port=>443}]
+msf5 auxiliary(gather/f5_bigip_cookie_disclosure) >
+```

--- a/modules/auxiliary/gather/f5_bigip_cookie_disclosure.rb
+++ b/modules/auxiliary/gather/f5_bigip_cookie_disclosure.rb
@@ -8,39 +8,43 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::HttpClient
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'F5 BigIP Backend Cookie Disclosure',
-      'Description'    => %q{
-        This module identifies F5 BigIP load balancers and leaks backend
-        information (pool name, backend's IP address and port, routed domain)
-        through cookies inserted by the BigIP system.
-      },
-      'Author'         =>
-        [
-          'Thanat0s <thanspam[at]trollprod.org>',
-          'Oleg Broslavsky <ovbroslavsky[at]gmail.com>',
-          'Nikita Oleksov <neoleksov[at]gmail.com>',
-          'Denis Kolegov <dnkolegov[at]gmail.com>',
-          'Paul-Emmanuel Raoul <skyper@skyplabs.net>'
-        ],
-      'References'     =>
-        [
-          ['URL', 'http://support.f5.com/kb/en-us/solutions/public/6000/900/sol6917.html'],
-          ['URL', 'http://support.f5.com/kb/en-us/solutions/public/7000/700/sol7784.html?sr=14607726']
-        ],
-      'License'        => MSF_LICENSE,
-      'DefaultOptions' =>
-        {
-          'SSL'        => true
-        }
-    ))
+    super(
+      update_info(
+        info,
+        'Name'           => 'F5 BigIP Backend Cookie Disclosure',
+        'Description'    => %q{
+          This module identifies F5 BigIP load balancers and leaks backend
+          information (pool name, backend's IP address and port, routed domain)
+          through cookies inserted by the BigIP system.
+        },
+        'Author'         =>
+          [
+            'Thanat0s <thanspam[at]trollprod.org>',
+            'Oleg Broslavsky <ovbroslavsky[at]gmail.com>',
+            'Nikita Oleksov <neoleksov[at]gmail.com>',
+            'Denis Kolegov <dnkolegov[at]gmail.com>',
+            'Paul-Emmanuel Raoul <skyper@skyplabs.net>'
+          ],
+        'References'     =>
+          [
+            ['URL', 'http://support.f5.com/kb/en-us/solutions/public/6000/900/sol6917.html'],
+            ['URL', 'http://support.f5.com/kb/en-us/solutions/public/7000/700/sol7784.html?sr=14607726']
+          ],
+        'License'        => MSF_LICENSE,
+        'DefaultOptions' =>
+          {
+            'SSL' => true
+          }
+      )
+    )
 
     register_options(
       [
         OptInt.new('RPORT', [true, 'The BigIP service port to listen on', 443]),
         OptString.new('TARGETURI', [true, 'The URI path to test', '/']),
         OptInt.new('REQUESTS', [true, 'The number of requests to send', 10])
-      ])
+      ]
+    )
   end
 
   def change_endianness(value, size = 4)
@@ -85,7 +89,8 @@ class MetasploitModule < Msf::Auxiliary
     backend
   end
 
-  def get_cookie # request a page and extract a F5 looking cookie.
+  def get_cookie
+    # Request a page and extract a F5 looking cookie
     cookie = {}
     res = send_request_raw({ 'method' => 'GET', 'uri' => @uri })
 
@@ -164,12 +169,11 @@ class MetasploitModule < Msf::Auxiliary
     unless backends.empty?
       report_note(host: rhost, type: 'f5_load_balancer_backends', data: backends)
     end
-
-    rescue ::Rex::ConnectionRefused
-      print_error("Network connection error")
-    rescue ::Rex::ConnectionError
-      print_error("Network connection error")
-    rescue ::OpenSSL::SSL::SSLError
-      print_error("SSL/TLS connection error")
+  rescue ::Rex::ConnectionRefused
+    print_error("Network connection error")
+  rescue ::Rex::ConnectionError
+    print_error("Network connection error")
+  rescue ::OpenSSL::SSL::SSLError
+    print_error("SSL/TLS connection error")
   end
 end

--- a/modules/auxiliary/gather/f5_bigip_cookie_disclosure.rb
+++ b/modules/auxiliary/gather/f5_bigip_cookie_disclosure.rb
@@ -101,7 +101,7 @@ class MetasploitModule < Msf::Auxiliary
       # 4. IPv6 pool members in non-default route domains - "BIGipServerWEB=rd3o20010112000000000000000000000030o80"
 
       regexp = /
-        ([~_\.\-\w\d]+)=(((?:\d+\.){2}\d+)|
+        ([~\.\-\w]+)=(((?:\d+\.){2}\d+)|
         (rd\d+o0{20}f{4}\w+o\d{1,5})|
         (vi([a-f0-9]{32})\.(\d{1,5}))|
         (rd\d+o([a-f0-9]{32})o(\d{1,5})))

--- a/modules/auxiliary/gather/f5_bigip_cookie_disclosure.rb
+++ b/modules/auxiliary/gather/f5_bigip_cookie_disclosure.rb
@@ -11,11 +11,11 @@ class MetasploitModule < Msf::Auxiliary
     super(
       update_info(
         info,
-        'Name'           => 'F5 BigIP Backend Cookie Disclosure',
+        'Name'           => 'F5 BIG-IP Backend Cookie Disclosure',
         'Description'    => %q{
-          This module identifies F5 BigIP load balancers and leaks backend
-          information (pool name, backend's IP address and port, routed domain)
-          through cookies inserted by the BigIP system.
+          This module identifies F5 BIG-IP load balancers and leaks backend information
+          (pool name, routed domain, and backend servers' IP addresses and ports) through
+          cookies inserted by the BIG-IP systems.
         },
         'Author'         =>
           [
@@ -42,7 +42,7 @@ class MetasploitModule < Msf::Auxiliary
 
     register_options(
       [
-        OptInt.new('RPORT', [true, 'The BigIP service port to listen on', 443]),
+        OptInt.new('RPORT', [true, 'The BIG-IP service port', 443]),
         OptString.new('TARGETURI', [true, 'The URI path to test', '/']),
         OptInt.new('REQUESTS', [true, 'The number of requests to send', 10])
       ]
@@ -129,14 +129,14 @@ class MetasploitModule < Msf::Auxiliary
       cookie = fetch_cookie # Get the cookie
       # If the cookie is not found, stop process
       if cookie.empty? || cookie[:id].nil?
-        print_error("F5 BigIP load balancing cookie not found")
+        print_error("F5 BIG-IP load balancing cookie not found")
         return nil
       end
 
       # Print the cookie name on the first request
       if i == 1
         cookie_name = cookie[:id]
-        print_good("F5 BigIP load balancing cookie \"#{cookie_name} = #{cookie[:value]}\" found")
+        print_good("F5 BIG-IP load balancing cookie \"#{cookie_name} = #{cookie[:value]}\" found")
         if cookie[:id].start_with?('BIGipServer')
           pool_name = cookie[:id].split('BIGipServer')[1]
           print_good("Load balancing pool name \"#{pool_name}\" found")

--- a/modules/auxiliary/gather/f5_bigip_cookie_disclosure.rb
+++ b/modules/auxiliary/gather/f5_bigip_cookie_disclosure.rb
@@ -27,8 +27,10 @@ class MetasploitModule < Msf::Auxiliary
           ],
         'References'     =>
           [
-            ['URL', 'http://support.f5.com/kb/en-us/solutions/public/6000/900/sol6917.html'],
-            ['URL', 'http://support.f5.com/kb/en-us/solutions/public/7000/700/sol7784.html?sr=14607726']
+            ['URL', 'https://support.f5.com/csp/article/K6917'],
+            ['URL', 'https://support.f5.com/csp/article/K7784'],
+            ['URL', 'https://support.f5.com/csp/article/K14784'],
+            ['URL', 'https://support.f5.com/csp/article/K23254150']
           ],
         'License'        => MSF_LICENSE,
         'DefaultOptions' =>

--- a/modules/auxiliary/gather/f5_bigip_cookie_disclosure.rb
+++ b/modules/auxiliary/gather/f5_bigip_cookie_disclosure.rb
@@ -20,7 +20,8 @@ class MetasploitModule < Msf::Auxiliary
           'Thanat0s <thanspam[at]trollprod.org>',
           'Oleg Broslavsky <ovbroslavsky[at]gmail.com>',
           'Nikita Oleksov <neoleksov[at]gmail.com>',
-          'Denis Kolegov <dnkolegov[at]gmail.com>'
+          'Denis Kolegov <dnkolegov[at]gmail.com>',
+          'Paul-Emmanuel Raoul <skyper@skyplabs.net>'
         ],
       'References'     =>
         [

--- a/modules/auxiliary/gather/f5_bigip_cookie_disclosure.rb
+++ b/modules/auxiliary/gather/f5_bigip_cookie_disclosure.rb
@@ -130,7 +130,7 @@ class MetasploitModule < Msf::Auxiliary
       # If the cookie is not found, stop process
       if cookie.empty? || cookie[:id].nil?
         print_error("F5 BigIP load balancing cookie not found")
-        return
+        return nil
       end
 
       # Print the cookie name on the first request

--- a/modules/auxiliary/gather/f5_bigip_cookie_disclosure.rb
+++ b/modules/auxiliary/gather/f5_bigip_cookie_disclosure.rb
@@ -11,32 +11,34 @@ class MetasploitModule < Msf::Auxiliary
     super(
       update_info(
         info,
-        'Name'           => 'F5 BIG-IP Backend Cookie Disclosure',
-        'Description'    => %q{
+        'Name' => 'F5 BIG-IP Backend Cookie Disclosure',
+        'Description' => %q{
           This module identifies F5 BIG-IP load balancers and leaks backend information
           (pool name, routed domain, and backend servers' IP addresses and ports) through
           cookies inserted by the BIG-IP systems.
         },
-        'Author'         =>
-          [
-            'Thanat0s <thanspam[at]trollprod.org>',
-            'Oleg Broslavsky <ovbroslavsky[at]gmail.com>',
-            'Nikita Oleksov <neoleksov[at]gmail.com>',
-            'Denis Kolegov <dnkolegov[at]gmail.com>',
-            'Paul-Emmanuel Raoul <skyper@skyplabs.net>'
-          ],
-        'References'     =>
-          [
-            ['URL', 'https://support.f5.com/csp/article/K6917'],
-            ['URL', 'https://support.f5.com/csp/article/K7784'],
-            ['URL', 'https://support.f5.com/csp/article/K14784'],
-            ['URL', 'https://support.f5.com/csp/article/K23254150']
-          ],
-        'License'        => MSF_LICENSE,
-        'DefaultOptions' =>
-          {
-            'SSL' => true
-          }
+        'Author' => [
+          'Thanat0s <thanspam[at]trollprod.org>',
+          'Oleg Broslavsky <ovbroslavsky[at]gmail.com>',
+          'Nikita Oleksov <neoleksov[at]gmail.com>',
+          'Denis Kolegov <dnkolegov[at]gmail.com>',
+          'Paul-Emmanuel Raoul <skyper@skyplabs.net>'
+        ],
+        'References' => [
+          ['URL', 'https://support.f5.com/csp/article/K6917'],
+          ['URL', 'https://support.f5.com/csp/article/K7784'],
+          ['URL', 'https://support.f5.com/csp/article/K14784'],
+          ['URL', 'https://support.f5.com/csp/article/K23254150']
+        ],
+        'License' => MSF_LICENSE,
+        'DefaultOptions' => {
+          'SSL' => true
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
       )
     )
 
@@ -52,9 +54,9 @@ class MetasploitModule < Msf::Auxiliary
   def change_endianness(value, size = 4)
     conversion = nil
     if size == 4
-      conversion = [value].pack("V").unpack("N").first
+      conversion = [value].pack('V').unpack('N').first
     elsif size == 2
-      conversion = [value].pack("v").unpack("n").first
+      conversion = [value].pack('v').unpack('n').first
     end
     conversion
   end
@@ -103,7 +105,7 @@ class MetasploitModule < Msf::Auxiliary
       # 4. IPv6 pool members in non-default route domains - "BIGipServerWEB=rd3o20010112000000000000000000000030o80"
 
       regexp = /
-        ([~\.\-\w]+)=(((?:\d+\.){2}\d+)|
+        ([~.\-\w]+)=(((?:\d+\.){2}\d+)|
         (rd\d+o0{20}f{4}\w+o\d{1,5})|
         (vi([a-f0-9]{32})\.(\d{1,5}))|
         (rd\d+o([a-f0-9]{32})o(\d{1,5})))
@@ -129,7 +131,7 @@ class MetasploitModule < Msf::Auxiliary
       cookie = fetch_cookie # Get the cookie
       # If the cookie is not found, stop process
       if cookie.empty? || cookie[:id].nil?
-        print_error("F5 BIG-IP load balancing cookie not found")
+        print_error('F5 BIG-IP load balancing cookie not found')
         return nil
       end
 
@@ -170,11 +172,9 @@ class MetasploitModule < Msf::Auxiliary
     unless backends.empty?
       report_note(host: rhost, type: 'f5_load_balancer_backends', data: backends)
     end
-  rescue ::Rex::ConnectionRefused
-    print_error("Network connection error")
-  rescue ::Rex::ConnectionError
-    print_error("Network connection error")
+  rescue ::Rex::ConnectionRefused, ::Rex::ConnectionError
+    print_error('Network connection error')
   rescue ::OpenSSL::SSL::SSLError
-    print_error("SSL/TLS connection error")
+    print_error('SSL/TLS connection error')
   end
 end


### PR DESCRIPTION
Hi,

This PR follows the feature request https://github.com/rapid7/metasploit-framework/issues/12187.

Additionally, the references have been updated and style issues have been fixed based on the output of [rubocop](https://github.com/rubocop-hq/ruby-style-guide).

## Verification

- [x] Start `msfconsole` and make sure to use a database
- [x] `use auxiliary/gather/f5_bigip_cookie_disclosure`
- [x] `set RHOSTS <vulnerable IP>`
- [x] Verify that the module returns something like `[+] F5 BigIP load balancing cookie...`
- [x] `notes` and verify that the cookie name is stored in the notes

