### PR TITLE
explicitly require factory_bot, see #12181

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 # -*- coding: binary -*-
 require 'stringio'
+require 'factory_bot'
 
 ENV['RAILS_ENV'] = 'test'
 


### PR DESCRIPTION
This is an attempt to fix the missing require that appeared with the merge of #12181 that caused travis rspec failures (see https://travis-ci.org/rapid7/metasploit-framework/jobs/574240275).

It looks like a trap set long ago :) 