### PR TITLE
Fix RPC console.create database active check

### DIFF
--- a/lib/msf/ui/web/console.rb
+++ b/lib/msf/ui/web/console.rb
@@ -49,7 +49,7 @@ class WebConsole
     self.pipe.create_subscriber('msfweb')
 
     # Skip database initialization if it is already configured
-    if framework.db and framework.db.usable and framework.db.migrated
+    if framework.db && framework.db.active
       opts['SkipDatabaseInit'] = true
     end
 


### PR DESCRIPTION
Fixes #11600 by correcting the database active check performed by the RPC method `console.create`.

### Testing RPC console methods
```
$ ./msfrpcd -U user -P pass
[*] MSGRPC starting on 0.0.0.0:55553 (SSL):Msg...
[*] MSGRPC backgrounding at 2019-08-21 09:22:55 -0400...
[*] MSGRPC background PID 5084

$ ./msfrpc -U user -P pass -a 0.0.0.0
[*] The 'rpc' object holds the RPC client interface
[*] Use rpc.call('group.command') to make RPC calls

>> rpc.call('console.create')
=> {"id"=>"0", "prompt"=>"", "busy"=>false}
>> rpc.call('console.create')
=> {"id"=>"1", "prompt"=>"", "busy"=>false}
>> rpc.call('console.list')
=> {"consoles"=>[{"id"=>"0", "prompt"=>"\x01\x02msf5\x01\x02 \x01\x02> ", "busy"=>false}, {"id"=>"1", "prompt"=>"\x01\x02msf5\x01\x02 \x01\x02> ", "busy"=>false}]}
```

Read the output currently buffered by the console that has not already been read. Note that a newly allocated console will have the initial banner available to read.
```
>> rpc.call('console.read', 0)
=> {"data"=>"\nUnable to handle kernel NULL pointer dereference at virtual address 0xd34db33f\nEFLAGS: 00010046\neax: 00000001 ebx: f77c8c00 ecx: 00000000 edx: f77f0001\nesi: 803bf014 edi: 8023c755 ebp: 80237f84 esp: 80237f60\nds: 0018   es: 0018  ss: 0018\nProcess Swapper (Pid: 0, process nr: 0, stackpage=80377000)\n\n\nStack: 90909090990909090990909090\n       90909090990909090990909090\n       90909090.90909090.90909090\n       90909090.90909090.90909090\n       90909090.90909090.09090900\n       90909090.90909090.09090900\n       ..........................\n       cccccccccccccccccccccccccc\n       cccccccccccccccccccccccccc\n       ccccccccc.................\n       cccccccccccccccccccccccccc\n       cccccccccccccccccccccccccc\n       .................ccccccccc\n       cccccccccccccccccccccccccc\n       cccccccccccccccccccccccccc\n       ..........................\n       ffffffffffffffffffffffffff\n       ffffffff..................\n       ffffffffffffffffffffffffff\n       ffffffff..................\n       ffffffff..................\n       ffffffff..................\n\n\nCode: 00 00 00 00 M3 T4 SP L0 1T FR 4M 3W OR K! V3 R5 I0 N4 00 00 00 00\nAiee, Killing Interrupt handler\nKernel panic: Attempted to kill the idle task!\nIn swapper task - not syncing\n\n\n       =[ metasploit v5.0.42-dev-931607826a               ]\n+ -- --=[ 1915 exploits - 1073 auxiliary - 330 post       ]\n+ -- --=[ 556 payloads - 45 encoders - 10 nops            ]\n+ -- --=[ 4 evasion                                       ]\n\n", "prompt"=>"\x01\x02msf5\x01\x02 \x01\x02> ", "busy"=>false}
```

Write "version" command to the console and read console output.
```
>> rpc.call('console.write', 0, "version\n")
=> {"wrote"=>8}
>> rpc.call('console.read', 0)
=> {"data"=>"Framework: 5.0.42-dev-931607826a\nConsole  : 5.0.42-dev-931607826a\n", "prompt"=>"\x01\x02msf5\x01\x02 \x01\x02> ", "busy"=>false}
```

Delete the two running console instances we created.
```
>> rpc.call('console.destroy', 0)
=> {"result"=>"success"}
>> rpc.call('console.destroy', 1)
=> {"result"=>"success"}
>> rpc.call('console.list')
=> {"consoles"=>[]}
>> 
```

## Verification
- [x] Start msfrpcd: `msfrpcd -U user -P pass`
- [x] Start msfrpc: `msfrpc -U user -P pass -a 0.0.0.0`
- [x] **Verify** the RPC method `console.create` can be called more than once without issue: `rpc.call('console.create')`
- [x] **Verify** the RPC console methods operate as expected (see above example)
- [x] Type `quit` to exit msfrpc
- [x] Terminate msfrpcd background PID