### PR TITLE
meterpreter UI, fs.rb: use client's separator instead of '\\'

### DIFF
--- a/lib/rex/post/meterpreter/extensions/stdapi/fs/file.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/fs/file.rb
@@ -82,7 +82,7 @@ class File < Rex::Post::Meterpreter::Extensions::Stdapi::Fs::IO
     request = Packet.create_request( 'stdapi_fs_search' )
 
     root = client.unicode_filter_decode(root) if root
-    root = root.chomp( ::File.separator ) if root
+    root = root.chomp( self.separator ) if root
 
     request.add_tlv( TLV_TYPE_SEARCH_ROOT, root )
     request.add_tlv( TLV_TYPE_SEARCH_GLOB, glob )
@@ -94,7 +94,7 @@ class File < Rex::Post::Meterpreter::Extensions::Stdapi::Fs::IO
     if( response.result == 0 )
       response.each( TLV_TYPE_SEARCH_RESULTS ) do | results |
         files << {
-          'path' => client.unicode_filter_encode(results.get_tlv_value(TLV_TYPE_FILE_PATH).chomp( ::File.separator )),
+          'path' => client.unicode_filter_encode(results.get_tlv_value(TLV_TYPE_FILE_PATH).chomp( self.separator )),
           'name' => client.unicode_filter_encode(results.get_tlv_value(TLV_TYPE_FILE_NAME)),
           'size' => results.get_tlv_value(TLV_TYPE_FILE_SIZE)
         }

--- a/lib/rex/post/meterpreter/extensions/stdapi/fs/file.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/fs/file.rb
@@ -82,7 +82,7 @@ class File < Rex::Post::Meterpreter::Extensions::Stdapi::Fs::IO
     request = Packet.create_request( 'stdapi_fs_search' )
 
     root = client.unicode_filter_decode(root) if root
-    root = root.chomp( '\\' ) if root
+    root = root.chomp( ::File.separator ) if root
 
     request.add_tlv( TLV_TYPE_SEARCH_ROOT, root )
     request.add_tlv( TLV_TYPE_SEARCH_GLOB, glob )
@@ -94,7 +94,7 @@ class File < Rex::Post::Meterpreter::Extensions::Stdapi::Fs::IO
     if( response.result == 0 )
       response.each( TLV_TYPE_SEARCH_RESULTS ) do | results |
         files << {
-          'path' => client.unicode_filter_encode(results.get_tlv_value(TLV_TYPE_FILE_PATH).chomp( '\\' )),
+          'path' => client.unicode_filter_encode(results.get_tlv_value(TLV_TYPE_FILE_PATH).chomp( ::File.separator )),
           'name' => client.unicode_filter_encode(results.get_tlv_value(TLV_TYPE_FILE_NAME)),
           'size' => results.get_tlv_value(TLV_TYPE_FILE_SIZE)
         }

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
@@ -182,9 +182,9 @@ class Console::CommandDispatcher::Stdapi::Fs
     print_line("Found #{files.length} result#{ files.length > 1 ? 's' : '' }...")
     files.each do | file |
       if file['size'] > 0
-        print("    #{file['path']}#{ file['path'].empty? ? '' : '\\' }#{file['name']} (#{file['size']} bytes)\n")
+        print("    #{file['path']}#{ file['path'].empty? ? '' : client.fs.file.separator }#{file['name']} (#{file['size']} bytes)\n")
       else
-        print("    #{file['path']}#{ file['path'].empty? ? '' : '\\' }#{file['name']}\n")
+        print("    #{file['path']}#{ file['path'].empty? ? '' : client.fs.file.separator }#{file['name']}\n")
       end
     end
 


### PR DESCRIPTION
Fix #12238

## Verification
- [ ] Start `msfconsole`
- [ ] obtain meterpreter on a Linux host ("meterpreter java/linux" in my case)
- [ ] search files, e.g. with "search -f *.xml"
- [ ] **Verify** there's only "/" separator in paths
- [ ] **Verify** there's no "\\" in paths