### PR TITLE
Bump rex-text and rex-socket

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,7 +59,7 @@ PATH
       rex-random_identifier
       rex-registry
       rex-rop_builder
-      rex-socket (= 0.1.17)
+      rex-socket
       rex-sslscan
       rex-struct2
       rex-text
@@ -310,14 +310,14 @@ GEM
       metasm
       rex-core
       rex-text
-    rex-socket (0.1.17)
+    rex-socket (0.1.19)
       rex-core
     rex-sslscan (0.1.5)
       rex-core
       rex-socket
       rex-text
     rex-struct2 (0.1.2)
-    rex-text (0.2.22)
+    rex-text (0.2.23)
     rex-zip (0.1.3)
       rex-text
     rkelly-remix (0.0.7)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -167,7 +167,7 @@ Gem::Specification.new do |spec|
   # Library for parsing and manipulating executable binaries
   spec.add_runtime_dependency 'rex-bin_tools'
   # Rex Socket Abstraction Layer
-  spec.add_runtime_dependency 'rex-socket', '0.1.17'
+  spec.add_runtime_dependency 'rex-socket'
   # Library for scanning a server's SSL/TLS capabilities
   spec.add_runtime_dependency 'rex-sslscan'
   # Library and tool for finding ROP gadgets in a supplied binary


### PR DESCRIPTION
This adds some addition options to SSL certificate generation and improves Python3 compatibility for string encoding.

See https://github.com/rapid7/rex-socket/pull/18 and https://github.com/rapid7/rex-text/pull/23 for verification steps.