### PR TITLE
Add a channel map to the RDP mixin

### DIFF
--- a/lib/msf/core/exploit/rdp.rb
+++ b/lib/msf/core/exploit/rdp.rb
@@ -608,18 +608,18 @@ module Exploit::Remote::RDP
       channels = [
         {
           :name => 'rdpdr',
-          :flags => RDPConstants::CHANNEL_OPTION_INITIALIZED | RDPConstants::CHANNEL_OPTION_COMPRESS_RDP,
+          :options => RDPConstants::CHANNEL_OPTION_INITIALIZED | RDPConstants::CHANNEL_OPTION_COMPRESS_RDP,
         },
         {
           :name => 'rdpsnd',
-          :flags => RDPConstants::CHANNEL_OPTION_INITIALIZED | RDPConstants::CHANNEL_OPTION_ENCRYPT_RDP,
+          :options => RDPConstants::CHANNEL_OPTION_INITIALIZED | RDPConstants::CHANNEL_OPTION_ENCRYPT_RDP,
         },
         {
           :name => 'cliprdr',
-          :flags => RDPConstants::CHANNEL_OPTION_INITIALIZED | RDPConstants::CHANNEL_OPTION_ENCRYPT_RDP | RDPConstants::CHANNEL_OPTION_COMPRESS_RDP | RDPConstants::CHANNEL_OPTION_SHOW_PROTOCOL,
+          :options => RDPConstants::CHANNEL_OPTION_INITIALIZED | RDPConstants::CHANNEL_OPTION_ENCRYPT_RDP | RDPConstants::CHANNEL_OPTION_COMPRESS_RDP | RDPConstants::CHANNEL_OPTION_SHOW_PROTOCOL,
         },
         { :name => 'drdynvc',
-          :flags => RDPConstants::CHANNEL_OPTION_INITIALIZED | RDPConstants::CHANNEL_OPTION_ENCRYPT_RDP | RDPConstants::CHANNEL_OPTION_COMPRESS_RDP,
+          :options => RDPConstants::CHANNEL_OPTION_INITIALIZED | RDPConstants::CHANNEL_OPTION_ENCRYPT_RDP | RDPConstants::CHANNEL_OPTION_COMPRESS_RDP,
         },
       ]
     end
@@ -724,7 +724,7 @@ module Exploit::Remote::RDP
       @channel_ids = {}
       channels.each do |channel|
         ts_ud_cs_net << channel[:name].ljust(8, "\x00")
-        ts_ud_cs_net << [ channel[:flags] ].pack('L>')
+        ts_ud_cs_net << [ channel[:options] ].pack('L>')
         @channel_ids[channel[:name].downcase] = 1004 + @channel_ids.length
       end
       pdu << ts_ud_cs_net

--- a/lib/msf/core/exploit/rdp.rb
+++ b/lib/msf/core/exploit/rdp.rb
@@ -208,13 +208,13 @@ module Exploit::Remote::RDP
   # Negotiate security protocol and begin session building
   #
   # @return [Boolean] success
-  def rdp_negotiate_security(nsock, req_proto = RDPConstants::PROTOCOL_SSL)
+  def rdp_negotiate_security(nsock, req_proto = RDPConstants::PROTOCOL_SSL, channels = nil)
     if req_proto == RDPConstants::PROTOCOL_SSL
       swap_sock_plain_to_ssl(nsock)
-      res = rdp_send_recv(pdu_connect_initial(req_proto, @computer_name))
+      res = rdp_send_recv(pdu_connect_initial(req_proto, @computer_name, channels))
 
     elsif req_proto == RDPConstants::PROTOCOL_RDP
-      res = rdp_send_recv(pdu_connect_initial(req_proto, @computer_name))
+      res = rdp_send_recv(pdu_connect_initial(req_proto, @computer_name, channels))
       rsmod, rsexp, _rsran, server_rand, bitlen = rdp_parse_connect_response(res)
 
     elsif [RDPConstants::PROTOCOL_HYBRID, RDPConstants::PROTOCOL_HYBRID_EX].include? req_proto
@@ -233,7 +233,8 @@ module Exploit::Remote::RDP
     user1 = res[9, 2].unpack("n").first
 
     # send channel requests
-    [1009, 1003, 1004, 1005, 1006, 1007, 1008].each do |chan|
+    rdp_send_recv(pdu_channel_request(user1, 1003))
+    @channel_ids.each_value do |chan|
       rdp_send_recv(pdu_channel_request(user1, chan))
     end
 
@@ -261,7 +262,7 @@ module Exploit::Remote::RDP
   # Finish building session after all security is negotiated
   def rdp_establish_session
     vprint_status("Sending client info PDU")
-    res = rdp_send_recv(rdp_build_pkt(pdu_client_info(@user_name, @domain, @ip_address), "\x03\xeb", true))
+    res = rdp_send_recv(rdp_build_pkt(pdu_client_info(@user_name, @domain, @ip_address), 1003, true))
     vprint_status("Received License packet")
 
     # Windows XP sometimes sends a very large license packet. This is likely
@@ -491,7 +492,7 @@ module Exploit::Remote::RDP
 
   # Build the X.224 packet, encrypt with Standard RDP Security as needed
   # default channel_id = 0x03eb = 1003
-  def rdp_build_pkt(data, channel_id = "\x03\xeb", client_info = false)
+  def rdp_build_pkt(data, channel_id = 1003, client_info = false)
     flags = 0
     flags |= 0b1000 if @rdp_sec       # Set SEC_ENCRYPT
     flags |= 0b1000000 if client_info # Set SEC_INFO_PKT
@@ -516,9 +517,13 @@ module Exploit::Remote::RDP
     user_data_len = pdu.length
     udl_with_flag = 0x8000 | user_data_len
 
-    pkt =  "\x64"      # sendDataRequest
-    pkt << "\x00\x08"  # intiator userId .. TODO: for a functional client this isn't static
-    pkt << channel_id  # channelId
+    if channel_id.is_a? String
+      channel_id = @channel_ids[channel_id.downcase]
+    end
+
+    pkt =  "\x64"             # sendDataRequest
+    pkt << "\x00\x08"         # intiator userId .. TODO: for a functional client this isn't static
+    pkt << [channel_id].pack('S>')  # channelId
     pkt << "\x70"      # dataPriority
     pkt << [udl_with_flag].pack("S>")
     pkt << pdu
@@ -571,7 +576,7 @@ module Exploit::Remote::RDP
   end
 
   # https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/db6713ee-1c0e-4064-a3b3-0fac30b4037b
-  def pdu_connect_initial(selected_proto = 0, host_name = "rdesktop")
+  def pdu_connect_initial(selected_proto = 0, host_name = "rdesktop", channels = nil)
     # After negotiating TLS or NLA the connectInitial packet needs to include the
     # protocol selection that the server indicated in its Negotiation Response
 
@@ -584,6 +589,17 @@ module Exploit::Remote::RDP
     # fixed length - 32 characters total
     name_unicode = Rex::Text.to_unicode(host_name[0..14], 'utf-16le')
     name_unicode += "\x00" * (32 - name_unicode.length)
+
+    if channels.nil?
+      # Define a list of default, general-purpose channels
+      channels = [
+        { :flags => 0x0000a0c0, :name => 'cliprdr' },
+        { :flags => 0x000000c0, :name => 'drdynvc' },
+        { :flags => 0x000000c0, :name => 'rdpsnd'  },
+        { :flags => 0x000000c0, :name => 'snddbg'  },
+        { :flags => 0x00008080, :name => 'rdpdr'   },
+      ]
+    end
 
     pdu =
       "\x7f\x65" +       # T.125 Connect-Initial (BER: Application 101)
@@ -674,22 +690,21 @@ module Exploit::Remote::RDP
       "\x02\xc0" + # clientSecuritydata (TS_UD_CS_SEC) header - 2.2.1.3.3
       "\x0c\x00" + # Length: 12 (includes header)
       "\x03\x00\x00\x00" + # encryptionMethods: 3 (40 bit | 128 bit)
-      "\x00\x00\x00\x00" + # extEncryptionMethods (French locale only)
-      "\x03\xc0" + # clientNetworkData (TS_UD_CS_NET) - 2.2.1.3.4
-      "\x44\x00" + # Length: 68 (includes header)
-      "\x05\x00\x00\x00" + # channelCount: 5
+      "\x00\x00\x00\x00" # extEncryptionMethods (French locale only)
+
+      ts_ud_cs_net = "\x03\xc0" # clientNetworkData (TS_UD_CS_NET) - 2.2.1.3.4
+      ts_ud_cs_net << [ 12 * channels.length + 8 ].pack('S') # Length (includes header)
+      ts_ud_cs_net << [ channels.length ].pack('L')          # channelCount
       # Channels definitions consist of a name (8 bytes) and options flags
       # (4 bytes). Names are up to 7 ANSI characters with null termination.
-      "\x63\x6c\x69\x70\x72\x64\x72\x00" + # 'cliprdr'
-      "\xc0\xa0\x00\x00" + #
-      "\x4d\x53\x5f\x54\x31\x32\x30\x00" + # 'MS_T120'
-      "\x80\x80\x00\x00" + #
-      "\x72\x64\x70\x73\x6e\x64\x00\x00" + # 'rdpsnd
-      "\xc0\x00\x00\x00" + #
-      "\x73\x6e\x64\x64\x62\x67\x00\x00" + # 'snddbg'
-      "\xc0\x00\x00\x00" + #
-      "\x72\x64\x70\x64\x72\x00\x00\x00" + # 'rdpdr'
-      "\x80\x80\x00\x00"
+
+      @channel_ids = {}
+      channels.each do |channel|
+        ts_ud_cs_net << channel[:name].ljust(8, "\x00")
+        ts_ud_cs_net << [ channel[:flags] ].pack('L')
+        @channel_ids[channel[:name].downcase] = 1004 + @channel_ids.length
+      end
+      pdu << ts_ud_cs_net
 
     build_data_tpdu(pdu)
   end

--- a/lib/msf/core/exploit/rdp.rb
+++ b/lib/msf/core/exploit/rdp.rb
@@ -42,6 +42,19 @@ module Exploit::Remote::RDP
     HYBRID_REQUIRED_BY_SERVER = 5
     SSL_WITH_USER_AUTH_REQUIRED_BY_SERVER = 6
 
+    # [MS-RDPBCGR] Section 2.2.1.3.4.1
+    CHANNEL_OPTION_INITIALIZED   = 0x80000000
+    CHANNEL_OPTION_ENCRYPT_RDP   = 0x40000000
+    CHANNEL_OPTION_ENCRYPT_SC    = 0x20000000
+    CHANNEL_OPTION_ENCRYPT_CS    = 0x10000000
+    CHANNEL_OPTION_PRI_HIGH      = 0x08000000
+    CHANNEL_OPTION_PRI_MED       = 0x04000000
+    CHANNEL_OPTION_PRI_LOW       = 0x02000000
+    CHANNEL_OPTION_COMPRESS_RDP  = 0x00800000
+    CHANNEL_OPTION_COMPRESS      = 0x00400000
+    CHANNEL_OPTION_SHOW_PROTOCOL = 0x00200000
+    REMOTE_CONTROL_PERSISTENT    = 0x00100000
+
     PROTOCOL_RDP = 0
     PROTOCOL_SSL = 1
     PROTOCOL_HYBRID = 2
@@ -593,11 +606,22 @@ module Exploit::Remote::RDP
     if channels.nil?
       # Define a list of default, general-purpose channels
       channels = [
-        { :flags => 0x0000a0c0, :name => 'cliprdr' },
-        { :flags => 0x000000c0, :name => 'drdynvc' },
-        { :flags => 0x000000c0, :name => 'rdpsnd'  },
-        { :flags => 0x000000c0, :name => 'snddbg'  },
-        { :flags => 0x00008080, :name => 'rdpdr'   },
+        {
+          :name => 'cliprdr',
+          :flags => RDPConstants::CHANNEL_OPTION_INITIALIZED | RDPConstants::CHANNEL_OPTION_ENCRYPT_RDP | RDPConstants::CHANNEL_OPTION_COMPRESS_RDP | RDPConstants::CHANNEL_OPTION_SHOW_PROTOCOL,
+        },
+        { :name => 'drdynvc',
+          :flags => RDPConstants::CHANNEL_OPTION_INITIALIZED | RDPConstants::CHANNEL_OPTION_ENCRYPT_RDP,
+        },
+        { :name => 'rdpsnd',
+          :flags => RDPConstants::CHANNEL_OPTION_INITIALIZED | RDPConstants::CHANNEL_OPTION_ENCRYPT_RDP,
+        },
+        { :name => 'snddbg',
+          :flags => RDPConstants::CHANNEL_OPTION_INITIALIZED | RDPConstants::CHANNEL_OPTION_ENCRYPT_RDP,
+        },
+        { :name => 'rdpdr',
+          :flags => RDPConstants::CHANNEL_OPTION_INITIALIZED | RDPConstants::CHANNEL_OPTION_COMPRESS_RDP,
+        },
       ]
     end
 
@@ -701,7 +725,7 @@ module Exploit::Remote::RDP
       @channel_ids = {}
       channels.each do |channel|
         ts_ud_cs_net << channel[:name].ljust(8, "\x00")
-        ts_ud_cs_net << [ channel[:flags] ].pack('L')
+        ts_ud_cs_net << [ channel[:flags] ].pack('L>')
         @channel_ids[channel[:name].downcase] = 1004 + @channel_ids.length
       end
       pdu << ts_ud_cs_net

--- a/lib/msf/core/exploit/rdp.rb
+++ b/lib/msf/core/exploit/rdp.rb
@@ -604,23 +604,22 @@ module Exploit::Remote::RDP
     name_unicode += "\x00" * (32 - name_unicode.length)
 
     if channels.nil?
-      # Define a list of default, general-purpose channels
+      # Define a list of default, general-purpose channels (copied from Windows 10 version 1803 x64)
       channels = [
+        {
+          :name => 'rdpdr',
+          :flags => RDPConstants::CHANNEL_OPTION_INITIALIZED | RDPConstants::CHANNEL_OPTION_COMPRESS_RDP,
+        },
+        {
+          :name => 'rdpsnd',
+          :flags => RDPConstants::CHANNEL_OPTION_INITIALIZED | RDPConstants::CHANNEL_OPTION_ENCRYPT_RDP,
+        },
         {
           :name => 'cliprdr',
           :flags => RDPConstants::CHANNEL_OPTION_INITIALIZED | RDPConstants::CHANNEL_OPTION_ENCRYPT_RDP | RDPConstants::CHANNEL_OPTION_COMPRESS_RDP | RDPConstants::CHANNEL_OPTION_SHOW_PROTOCOL,
         },
         { :name => 'drdynvc',
-          :flags => RDPConstants::CHANNEL_OPTION_INITIALIZED | RDPConstants::CHANNEL_OPTION_ENCRYPT_RDP,
-        },
-        { :name => 'rdpsnd',
-          :flags => RDPConstants::CHANNEL_OPTION_INITIALIZED | RDPConstants::CHANNEL_OPTION_ENCRYPT_RDP,
-        },
-        { :name => 'snddbg',
-          :flags => RDPConstants::CHANNEL_OPTION_INITIALIZED | RDPConstants::CHANNEL_OPTION_ENCRYPT_RDP,
-        },
-        { :name => 'rdpdr',
-          :flags => RDPConstants::CHANNEL_OPTION_INITIALIZED | RDPConstants::CHANNEL_OPTION_COMPRESS_RDP,
+          :flags => RDPConstants::CHANNEL_OPTION_INITIALIZED | RDPConstants::CHANNEL_OPTION_ENCRYPT_RDP | RDPConstants::CHANNEL_OPTION_COMPRESS_RDP,
         },
       ]
     end

--- a/modules/auxiliary/scanner/rdp/cve_2019_0708_bluekeep.rb
+++ b/modules/auxiliary/scanner/rdp/cve_2019_0708_bluekeep.rb
@@ -155,10 +155,9 @@ class MetasploitModule < Msf::Auxiliary
     x64_payload = build_virtual_channel_pdu(0x03, [x64_string].pack("H*"))
 
     6.times do
-      # 0xed03 = Channel 1005
-      x86_packet = rdp_build_pkt(x86_payload, "\x03\xed")
+      x86_packet = rdp_build_pkt(x86_payload, 'MS_T120')
       rdp_send(x86_packet)
-      x64_packet = rdp_build_pkt(x64_payload, "\x03\xed")
+      x64_packet = rdp_build_pkt(x64_payload, 'MS_T120')
       rdp_send(x64_packet)
 
       # A single pass should be sufficient to cause DoS
@@ -216,7 +215,15 @@ class MetasploitModule < Msf::Auxiliary
       return Exploit::CheckCode::Safe
     end
 
-    success = rdp_negotiate_security(nsock, server_selected_proto)
+    channels = [
+        { :flags => 0x0000a0c0, :name => 'cliprdr' },
+        { :flags => 0x00008080, :name => 'MS_T120' },
+        { :flags => 0x000000c0, :name => 'rdpsnd'  },
+        { :flags => 0x000000c0, :name => 'snddbg'  },
+        { :flags => 0x00008080, :name => 'rdpdr'   },
+      ]
+
+    success = rdp_negotiate_security(nsock, server_selected_proto, channels)
     return Exploit::CheckCode::Unknown unless success
 
     rdp_establish_session

--- a/modules/auxiliary/scanner/rdp/cve_2019_0708_bluekeep.rb
+++ b/modules/auxiliary/scanner/rdp/cve_2019_0708_bluekeep.rb
@@ -216,11 +216,11 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     channels = [
-        { :flags => 0x0000a0c0, :name => 'cliprdr' },
-        { :flags => 0x00008080, :name => 'MS_T120' },
-        { :flags => 0x000000c0, :name => 'rdpsnd'  },
-        { :flags => 0x000000c0, :name => 'snddbg'  },
-        { :flags => 0x00008080, :name => 'rdpdr'   },
+        { :options => 0xc0a00000, :name => 'cliprdr' },
+        { :options => 0x80800000, :name => 'MS_T120' },
+        { :options => 0xc0000000, :name => 'rdpsnd'  },
+        { :options => 0xc0000000, :name => 'snddbg'  },
+        { :options => 0x80800000, :name => 'rdpdr'   },
       ]
 
     success = rdp_negotiate_security(nsock, server_selected_proto, channels)


### PR DESCRIPTION
This PR adds the ability to define and then use custom channels with the RDP mixin. It uses a default channel map taken from a Windows 10 client for general purposes. This has the benefit of removing MS_T120 from the list of channels being requested by the `auxiliary/scanner/rdp/rdp_scanner` module which should prevent it from being falsely identified as bluekeep exploit attempts.

By allow the channels to be defined by the module, we can start to explore other vulnerabilities with the mixin. The channels are defined as an array of hashes to maintain the explicit order defined by the module author and to facilitate adding new channel attributes in the future. Finally, the `rdp_build_pkt` method was altered to take the `channel_id` argument as either an explicit channel number or a channel name which is resolved to the corresponding number based on the initial connection settings.

## Verification

Both the bluekeep scanner and the rdp scanner modules should be tested to ensure compatibility.

- [ ] Test `auxiliary/scanner/rdp/cve_2019_0708_bluekeep` and ensure it still works
- [ ] Test `auxiliary/scanner/rdp/rdp_scanner` and ensure it still finger prints hosts
    * This one will use the new, default channel map

### Example Output
```
metasploit-framework (S:0 J:0) auxiliary(scanner/rdp/cve_2019_0708_bluekeep) > set RHOSTS 192.168.90.12 172.20.220.236
RHOSTS => 192.168.90.12 172.20.220.236
metasploit-framework (S:0 J:0) auxiliary(scanner/rdp/cve_2019_0708_bluekeep) > run

[*] [2019.08.28-17:49:43] 192.168.90.12:3389    - Verifying RDP protocol...
[*] [2019.08.28-17:49:43] 172.20.220.236:3389   - Verifying RDP protocol...
[*] [2019.08.28-17:49:43] 192.168.90.12:3389    - Attempting to connect using TLS security
[*] [2019.08.28-17:49:43] 172.20.220.236:3389   - Attempting to connect using TLS security
[*] [2019.08.28-17:49:43] 192.168.90.12:3389    - Sending erect domain request
[*] [2019.08.28-17:49:43] 172.20.220.236:3389   - Attempt to connect with TLS failed but looks like the target is Windows XP
[*] [2019.08.28-17:49:43] 172.20.220.236:3389   - Attempting to connect using Standard RDP security
[*] [2019.08.28-17:49:43] 172.20.220.236:3389   - Sending erect domain request
[*] [2019.08.28-17:49:43] 192.168.90.12:3389    - Sending client info PDU
[*] [2019.08.28-17:49:43] 192.168.90.12:3389    - Received License packet
[*] [2019.08.28-17:49:43] 192.168.90.12:3389    - Waiting for Server Demand packet
[*] [2019.08.28-17:49:43] 192.168.90.12:3389    - Received Server Demand packet
[*] [2019.08.28-17:49:43] 192.168.90.12:3389    - Sending client confirm active PDU
[*] [2019.08.28-17:49:43] 192.168.90.12:3389    - Sending client synchronize PDU
[*] [2019.08.28-17:49:43] 192.168.90.12:3389    - Sending client control cooperate PDU
[*] [2019.08.28-17:49:43] 192.168.90.12:3389    - Sending client control request control PDU
[*] [2019.08.28-17:49:43] 192.168.90.12:3389    - Sending client input sychronize PDU
[*] [2019.08.28-17:49:43] 192.168.90.12:3389    - Sending client font list PDU
[*] [2019.08.28-17:49:43] 172.20.220.236:3389   - Sending security exchange PDU
[*] [2019.08.28-17:49:44] 192.168.90.12:3389    - Sending patch check payloads
[*] [2019.08.28-17:49:44] 192.168.90.12:3389    - The target is not exploitable.
[*] [2019.08.28-17:49:44] Scanned 1 of 2 hosts (50% complete)
[*] [2019.08.28-17:49:44] 172.20.220.236:3389   - Sending client info PDU
[*] [2019.08.28-17:49:44] 172.20.220.236:3389   - Received License packet
[*] [2019.08.28-17:49:44] 172.20.220.236:3389   - Waiting for Server Demand packet
[*] [2019.08.28-17:49:44] 172.20.220.236:3389   - Received Server Demand packet
[*] [2019.08.28-17:49:44] 172.20.220.236:3389   - Sending client confirm active PDU
[*] [2019.08.28-17:49:44] 172.20.220.236:3389   - Sending client synchronize PDU
[*] [2019.08.28-17:49:44] 172.20.220.236:3389   - Sending client control cooperate PDU
[*] [2019.08.28-17:49:44] 172.20.220.236:3389   - Sending client control request control PDU
[*] [2019.08.28-17:49:44] 172.20.220.236:3389   - Sending client input sychronize PDU
[*] [2019.08.28-17:49:44] 172.20.220.236:3389   - Sending client font list PDU
[*] [2019.08.28-17:49:45] 172.20.220.236:3389   - Sending patch check payloads
[+] [2019.08.28-17:49:45] 172.20.220.236:3389   - The target is vulnerable.
[*] [2019.08.28-17:49:45] Scanned 2 of 2 hosts (100% complete)
[*] Auxiliary module execution completed
metasploit-framework (S:0 J:0) auxiliary(scanner/rdp/cve_2019_0708_bluekeep) > use auxiliary/scanner/rdp/rdp_scanner 
metasploit-framework (S:0 J:0) auxiliary(scanner/rdp/rdp_scanner) > set RHOSTS 192.168.90.12 172.20.220.236
RHOSTS => 192.168.90.12 172.20.220.236
metasploit-framework (S:0 J:0) auxiliary(scanner/rdp/rdp_scanner) > run

[*] [2019.08.28-17:50:56] 172.20.220.236:3389   - Verifying RDP protocol...
[*] [2019.08.28-17:50:56] 172.20.220.236:3389   - Attempting to connect using TLS security
[*] [2019.08.28-17:50:56] 192.168.90.12:3389    - Verifying RDP protocol...
[*] [2019.08.28-17:50:56] 192.168.90.12:3389    - Attempting to connect using TLS security
[*] [2019.08.28-17:50:56] 192.168.90.12:3389    - Verifying RDP protocol...
[*] [2019.08.28-17:50:56] 192.168.90.12:3389    - Attempting to connect using TLS security
[*] [2019.08.28-17:50:56] 192.168.90.12:3389    - Detected RDP on 192.168.90.12:3389    (Windows version: 6.3.9600) (Requires NLA: No)
[*] [2019.08.28-17:50:56] 172.20.220.236:3389   - Attempt to connect with TLS failed but looks like the target is Windows XP
[*] [2019.08.28-17:50:56] 172.20.220.236:3389   - Attempting to connect using Standard RDP security
[*] [2019.08.28-17:50:56] Scanned 2 of 2 hosts (100% complete)
[*] Auxiliary module execution completed
metasploit-framework (S:0 J:0) auxiliary(scanner/rdp/rdp_scanner) > 
```
