### PR TITLE
Unify SSL cert generate interfaces

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -310,7 +310,7 @@ GEM
       metasm
       rex-core
       rex-text
-    rex-socket (0.1.17)
+    rex-socket (0.1.20)
       rex-core
     rex-sslscan (0.1.5)
       rex-core

--- a/lib/msf/core/cert_provider.rb
+++ b/lib/msf/core/cert_provider.rb
@@ -45,11 +45,11 @@ module Ssl
     # identification by NIDS and the like.
     #
     # @return [String, String, Array]
-    def self.ssl_generate_certificate(opts = {}, ksize = 2048)
+    def self.ssl_generate_certificate(cert_vars: {}, ksize: 2048, **opts)
       yr      = 24*3600*365
       vf      = opts[:not_before] || Time.at(Time.now.to_i - rand(yr * 3) - yr)
       vt      = opts[:not_after]  || Time.at(vf.to_i + (rand(9)+1) * yr)
-      cvars   = opts[:cert_vars]  || self.rand_vars
+      cvars   = self.rand_vars(cert_vars)
       subject = opts[:subject]    || ssl_generate_subject(cvars)
       ctype   = opts[:cert_type]  || opts[:ca_cert].nil? ? :ca : :server
       key     = opts[:key] || OpenSSL::PKey::RSA.new(ksize){ }

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -167,7 +167,7 @@ Gem::Specification.new do |spec|
   # Library for parsing and manipulating executable binaries
   spec.add_runtime_dependency 'rex-bin_tools'
   # Rex Socket Abstraction Layer
-  spec.add_runtime_dependency 'rex-socket', '0.1.17'
+  spec.add_runtime_dependency 'rex-socket'
   # Library for scanning a server's SSL/TLS capabilities
   spec.add_runtime_dependency 'rex-sslscan'
   # Library and tool for finding ROP gadgets in a supplied binary


### PR DESCRIPTION
After this and rapid7/rex-socket#19 the interfaces should be compatible again.

Verification
========

- [x] Verify and land rapid7/rex-socket#19
- [x] Bump the `rex-text` version on this PR
- [ ] Verify that SSL certificates can generate again (eg. not run into the problems described in #12037 & #12038 )