### PR TITLE
Correct realname calls in the cache to fullname

### DIFF
--- a/lib/msf/core/modules/metadata/maps.rb
+++ b/lib/msf/core/modules/metadata/maps.rb
@@ -20,33 +20,33 @@ module Msf::Modules::Metadata::Maps
     get_metadata.each do |exploit|
       # expand this in future to be more specific about remote exploits.
       next unless exploit.type == "exploit"
-      realname = exploit.realname
+      fullname = exploit.fullname
       exploit.references.each do |reference|
         next if reference =~ /^URL/
         ref = reference
         ref.upcase!
 
         mrefs[ref]           ||= {}
-        mrefs[ref][realname] = exploit
+        mrefs[ref][fullname] = exploit
       end
 
       if exploit.rport
         rport                        = exploit.rport
         mports[rport.to_i]           ||= {}
-        mports[rport.to_i][realname] = exploit
+        mports[rport.to_i][fullname] = exploit
       end
 
       unless exploit.autofilter_ports.nil? || exploit.autofilter_ports.empty?
         exploit.autofilter_ports.each do |rport|
           mports[rport.to_i]           ||= {}
-          mports[rport.to_i][realname] = exploit
+          mports[rport.to_i][fullname] = exploit
         end
       end
 
       unless exploit.autofilter_services.nil? || exploit.autofilter_services.empty?
         exploit.autofilter_services.each do |serv|
           mservs[serv]           ||= {}
-          mservs[serv][realname] = exploit
+          mservs[serv][fullname] = exploit
         end
       end
 


### PR DESCRIPTION
The cache maps only use metadata objects, which only have `fullname` since they are never aliased.

Verification
=========
- [x] `analyze` and `db_import` work again