### PR TITLE
Require msf/core/handler/bind_tcp

### DIFF
--- a/modules/payloads/singles/linux/x64/pingback_bind_tcp.rb
+++ b/modules/payloads/singles/linux/x64/pingback_bind_tcp.rb
@@ -4,7 +4,7 @@
 ##
 
 require 'msf/core/payload/pingback'
-require 'msf/core/handler/reverse_tcp'
+require 'msf/core/handler/bind_tcp'
 require 'msf/base/sessions/pingback'
 
 


### PR DESCRIPTION
Fixes #12267 

This changes the `msf/core/handler` require in `modules/payloads/singles/linux/x64/pingback_bind_tcp.rb` to `bind_tcp` instead of `reverse_tcp`.

