### PR TITLE
Save the data collected by resolve_hosts

### DIFF
--- a/modules/post/multi/gather/resolve_hosts.rb
+++ b/modules/post/multi/gather/resolve_hosts.rb
@@ -72,6 +72,10 @@ class MetasploitModule < Msf::Post
       if result[:ip].nil?
         table << [result[:hostname], '[Failed To Resolve]']
       else
+        report_host(
+          host: result[:ip],
+          name: result[:hostname]
+        )
         table << [result[:hostname], result[:ip]]
       end
     end

--- a/modules/post/multi/gather/resolve_hosts.rb
+++ b/modules/post/multi/gather/resolve_hosts.rb
@@ -72,15 +72,17 @@ class MetasploitModule < Msf::Post
     response.each do |result|
       if result[:ip].nil?
         table << [result[:hostname], '[Failed To Resolve]']
-      else
-        if datastore['DATABASE']
-          report_host(
-            host: result[:ip],
-            name: result[:hostname]
-          )
-        end
-        table << [result[:hostname], result[:ip]]
+        next
       end
+
+      if datastore['DATABASE']
+        report_host(
+          host: result[:ip],
+          name: result[:hostname]
+        )
+      end
+
+      table << [result[:hostname], result[:ip]]
     end
 
     table.print

--- a/modules/post/multi/gather/resolve_hosts.rb
+++ b/modules/post/multi/gather/resolve_hosts.rb
@@ -20,7 +20,8 @@ class MetasploitModule < Msf::Post
       register_options([
         OptString.new('HOSTNAMES', [false, 'Comma seperated list of hostnames to resolve.']),
         OptPath.new('HOSTFILE', [false, 'Line separated file with hostnames to resolve.']),
-        OptEnum.new('AI_FAMILY', [true, 'Address Family', 'IPv4', ['IPv4', 'IPv6'] ])
+        OptEnum.new('AI_FAMILY', [true, 'Address Family', 'IPv4', ['IPv4', 'IPv6'] ]),
+        OptBool.new('DATABASE', [false, 'Report found hosts to DB', true])
       ])
   end
 
@@ -72,10 +73,12 @@ class MetasploitModule < Msf::Post
       if result[:ip].nil?
         table << [result[:hostname], '[Failed To Resolve]']
       else
-        report_host(
-          host: result[:ip],
-          name: result[:hostname]
-        )
+        if datastore['DATABASE']
+          report_host(
+            host: result[:ip],
+            name: result[:hostname]
+          )
+        end
         table << [result[:hostname], result[:ip]]
       end
     end


### PR DESCRIPTION
Instead of just throwing it away after printing.

## Verification

- [x] get a meterp session
- [x] `use post/multi/gather/resolve_hosts`
- [x] `set session -1`
- [x] `set hostnames google.com`
- [x] `run`
- [x] `hosts`
- [x] **Verify** you have a host in the db with name "google.com"

