### PR TITLE
RDP lib: lower SSL security level for compatibility with certain Win7

### DIFF
--- a/lib/msf/core/exploit/rdp.rb
+++ b/lib/msf/core/exploit/rdp.rb
@@ -24,6 +24,10 @@ module Exploit::Remote::RDP
         OptAddress.new('RDP_CLIENT_IP', [ true, 'The client IPv4 address to report during connect', '192.168.0.100']),
         Opt::RPORT(3389)
       ], Msf::Exploit::Remote::RDP)
+      register_advanced_options(
+      [
+        OptInt.new('RDP_TLS_SECURITY_LEVEL', [ false, 'Change default TLS security level. "0" means everything is permitted. "1" rejects very weak parameters and "2" is even stricter.' ])
+      ], Msf::Exploit::Remote::RDP)
   end
 
 
@@ -1008,10 +1012,17 @@ module Exploit::Remote::RDP
   def swap_sock_plain_to_ssl(nsock)
     ctx = OpenSSL::SSL::SSLContext.new
     ctx.min_version = OpenSSL::SSL::TLS1_VERSION
-    ctx.security_level = 0 # allow older signatures required by stock Win7
+    unless datastore['RDP_TLS_SECURITY_LEVEL'].nil?
+      ctx.security_level = datastore['RDP_TLS_SECURITY_LEVEL']
+    end
     ssl = OpenSSL::SSL::SSLSocket.new(nsock, ctx)
 
-    ssl.connect
+    begin
+      ssl.connect
+    rescue Errno::ECONNRESET
+      vprint_error("Retry with advanced option RDP_TLS_SECURITY_LEVEL=0")
+      raise
+    end
 
     nsock.extend(Rex::Socket::SslTcp)
     nsock.sslsock = ssl

--- a/lib/msf/core/exploit/rdp.rb
+++ b/lib/msf/core/exploit/rdp.rb
@@ -26,7 +26,7 @@ module Exploit::Remote::RDP
       ], Msf::Exploit::Remote::RDP)
       register_advanced_options(
       [
-        OptInt.new('RDP_TLS_SECURITY_LEVEL', [ false, 'Change default TLS security level. "0" means everything is permitted. "1" rejects very weak parameters and "2" is even stricter.' ])
+        OptInt.new('RDP_TLS_SECURITY_LEVEL', [ true, 'Change default TLS security level. "0" (default) means everything is permitted. "1" rejects very weak parameters and "2" is even stricter.', 0 ])
       ], Msf::Exploit::Remote::RDP)
   end
 
@@ -1012,9 +1012,7 @@ module Exploit::Remote::RDP
   def swap_sock_plain_to_ssl(nsock)
     ctx = OpenSSL::SSL::SSLContext.new
     ctx.min_version = OpenSSL::SSL::TLS1_VERSION
-    unless datastore['RDP_TLS_SECURITY_LEVEL'].nil?
-      ctx.security_level = datastore['RDP_TLS_SECURITY_LEVEL']
-    end
+    ctx.security_level = datastore['RDP_TLS_SECURITY_LEVEL']
     ssl = OpenSSL::SSL::SSLSocket.new(nsock, ctx)
 
     begin

--- a/lib/msf/core/exploit/rdp.rb
+++ b/lib/msf/core/exploit/rdp.rb
@@ -1008,6 +1008,7 @@ module Exploit::Remote::RDP
   def swap_sock_plain_to_ssl(nsock)
     ctx = OpenSSL::SSL::SSLContext.new
     ctx.min_version = OpenSSL::SSL::TLS1_VERSION
+    ctx.security_level = 0 # allow older signatures required by stock Win7
     ssl = OpenSSL::SSL::SSLSocket.new(nsock, ctx)
 
     ssl.connect


### PR DESCRIPTION
I use the auxiliary/scanner/rdp/cve_2019_0708_bluekeep against a Windows 7 Pro x64 that received many updates, up to 2017 but none since (lab machine 😉). But I get this:
```
msf5 auxiliary(scanner/rdp/cve_2019_0708_bluekeep) > run

[*] 192.168.56.130:3389   - Verifying RDP protocol...
[*] 192.168.56.130:3389   - Attempting to connect using TLS security
[-] 192.168.56.130:3389   - Connection reset
[*] 192.168.56.130:3389   - The target service is running, but could not be validated.
[*] 192.168.56.130:3389   - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

Wireshark shows that the RDP server resets (RST) the connection after getting the ClientHello:
![image](https://user-images.githubusercontent.com/550823/64465595-cf0c9880-d10d-11e9-950d-8ff3a8227182.png)

At first I thought it was again a TLS version issue (cf. #12214) but the ClientHello accepts everything from TLS 1.0 to 1.3 so not the issue here...
Then I remembered the current situation with Debian (and Kali) hardening the default values for OpenSSL security level in /etc/ssl/openssl.cnf:
```
[system_default_sect]
MinProtocol = TLSv1.2
CipherString = DEFAULT@SECLEVEL=2
```

So I decided to comment everything and it worked better! The only difference I see in the ClientHello is the proposed signature algorithms:
* doesn't work with (20 algo):
![image](https://user-images.githubusercontent.com/550823/64465670-4c380d80-d10e-11e9-9cf5-f210acde0ed9.png)

* works with: (23 algos):
![image](https://user-images.githubusercontent.com/550823/64465709-75589e00-d10e-11e9-9f3c-dfc105a844c4.png)

And indeed if my understanding (actually, guessing) of TLS is correct. When it works then the server (ServerHello) selects rsa_pkcs1_sha1 which is indeed among the missing algorithms in the list that doesn't work:
![image](https://user-images.githubusercontent.com/550823/64465878-24957500-d10f-11e9-951c-fce8aa330e25.png)

By using the [`security_level`](https://ruby-doc.org/stdlib-trunk/libdoc/openssl/rdoc/OpenSSL/SSL/SSLContext.html#method-i-security_level-3D) option of Ruby OpenSSL, I manage to lower the OS default security level and obtain the same list of signature algorithms and finally a working scanner!
I would have preferred to only change the list of signature algorithms, instead of the entire security level, however the `SSL_CTX_set1_sigalgs` doesn't seem exposed by Ruby OpenSSL.

## Verification

List the steps needed to make sure this thing works

- [x] Prepare Windows VM, at least two Windows 7, one without any patch (-> TLS 1.0 only), and one with https://support.microsoft.com/fr-fr/help/3080079/update-to-add-rds-support-for-tls-1-1-and-tls-1-2-in-windows-7-or-wind installed (-> TLS 1.1 and 1.2 supported)
- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/rdp/cve_2019_0708_bluekeep`
- [x] ...
- [x] Scan both hosts, both should return "The target is vulnerable" without any error