### PR TITLE
make payload generation failures at boot time non-fatal

### DIFF
--- a/lib/msf/core/payload_set.rb
+++ b/lib/msf/core/payload_set.rb
@@ -91,7 +91,7 @@ class PayloadSet < ModuleSet
         sizes[name] = p.cached_size || p.new.size
       # Don't cache generic payload sizes.
       rescue NoCompatiblePayloadError
-      rescue RuntimeError => e
+      rescue StandardError => e
         elog("Unable to build #{name}, #{e}.")
       end
     }

--- a/lib/msf/core/payload_set.rb
+++ b/lib/msf/core/payload_set.rb
@@ -91,6 +91,8 @@ class PayloadSet < ModuleSet
         sizes[name] = p.cached_size || p.new.size
       # Don't cache generic payload sizes.
       rescue NoCompatiblePayloadError
+      rescue RuntimeError => e
+        elog("Unable to build #{name}, #{e}.")
       end
     }
 


### PR DESCRIPTION
Currently, if any payload fails to generate that has a dynamic size, it causes a Framework instance to throw an exception on start. This can happen for a number of reasons, and more often than not it is enviromental (files missing, Y2k38 bugs, etc.). Instead of failing entirely, catch the exception and log as an error, don't register the payload, but continue booting.

This fixes #12264. which was inspired by #12248, #9556 and others.

## Verification

- [x] Modify a payload to fail in some way, e.g. apply a patch like this:
```
diff --git a/lib/msf/core/payload/android.rb b/lib/msf/core/payload/android.rb
index 5609480f37..193fcb0015 100644
--- a/lib/msf/core/payload/android.rb
+++ b/lib/msf/core/payload/android.rb
@@ -109,7 +109,7 @@ module Msf::Payload::Android
   def generate_jar(opts={})
     config = generate_config(opts)
     if opts[:stageless]
-      classes = MetasploitPayloads.read('android', 'meterpreter.dex')
+      classes = MetasploitPayloads.read('android', 'meterpreter.dexter')
       # Add stageless classname at offset 8000
       config += "\x00" * (8000 - config.size)
       config += 'com.metasploit.meterpreter.AndroidMeterpreter'
```
- [x] Start `msfconsole`
- [x] **Verify** that Metasploit starts
- [x] type the `log` command
- [x] **Verify** there are errors in the log like this:

```
[09/07/2019 07:28:03] [e(0)] core: Unable to build android/meterpreter_reverse_https, android/meterpreter.dexter not found.
[09/07/2019 07:28:03] [e(0)] core: Unable to build android/meterpreter_reverse_tcp, android/meterpreter.dexter not found.
[09/07/2019 07:28:03] [e(0)] core: Unable to build android/meterpreter_reverse_http, android/meterpreter.dexter not found.
```

