### PR TITLE
add url for fodhelper

### DIFF
--- a/modules/exploits/windows/local/bypassuac_eventvwr.rb
+++ b/modules/exploits/windows/local/bypassuac_eventvwr.rb
@@ -52,12 +52,11 @@ class MetasploitModule < Msf::Exploit::Local
           [ 'Windows x64', { 'Arch' => ARCH_X64 } ]
       ],
       'DefaultTarget' => 0,
-      'References'    => [
+      'References'    =>
         [
-          'URL', 'https://enigma0x3.net/2016/08/15/fileless-uac-bypass-using-eventvwr-exe-and-registry-hijacking/',
-          'URL', 'https://github.com/enigma0x3/Misc-PowerShell-Stuff/blob/master/Invoke-EventVwrBypass.ps1'
-        ]
-      ],
+          ['URL', 'https://enigma0x3.net/2016/08/15/fileless-uac-bypass-using-eventvwr-exe-and-registry-hijacking/'],
+          ['URL', 'https://github.com/enigma0x3/Misc-PowerShell-Stuff/blob/master/Invoke-EventVwrBypass.ps1']
+        ],
       'DisclosureDate'=> 'Aug 15 2016'
     ))
   end

--- a/modules/exploits/windows/local/bypassuac_fodhelper.rb
+++ b/modules/exploits/windows/local/bypassuac_fodhelper.rb
@@ -55,7 +55,8 @@ class MetasploitModule < Msf::Exploit::Local
         'References'    => [
           [
             'URL', 'https://winscripting.blog/2017/05/12/first-entry-welcome-and-uac-bypass/',
-            'URL', 'https://github.com/winscripting/UAC-bypass/blob/master/FodhelperBypass.ps1'
+            'URL', 'https://github.com/winscripting/UAC-bypass/blob/master/FodhelperBypass.ps1',
+            'URL', 'https://www.bleepingcomputer.com/news/security/gootkit-malware-bypasses-windows-defender-by-setting-path-exclusions/'
           ]
         ],
         'DisclosureDate' => 'May 12 2017'

--- a/modules/exploits/windows/local/bypassuac_fodhelper.rb
+++ b/modules/exploits/windows/local/bypassuac_fodhelper.rb
@@ -52,13 +52,12 @@ class MetasploitModule < Msf::Exploit::Local
           [ 'Windows x64', { 'Arch' => ARCH_X64 } ]
         ],
         'DefaultTarget' => 0,
-        'References'    => [
+        'References'    =>
           [
-            'URL', 'https://winscripting.blog/2017/05/12/first-entry-welcome-and-uac-bypass/',
-            'URL', 'https://github.com/winscripting/UAC-bypass/blob/master/FodhelperBypass.ps1',
-            'URL', 'https://www.bleepingcomputer.com/news/security/gootkit-malware-bypasses-windows-defender-by-setting-path-exclusions/'
-          ]
-        ],
+            ['URL', 'https://winscripting.blog/2017/05/12/first-entry-welcome-and-uac-bypass/'],
+            ['URL', 'https://github.com/winscripting/UAC-bypass/blob/master/FodhelperBypass.ps1'],
+            ['URL', 'https://www.bleepingcomputer.com/news/security/gootkit-malware-bypasses-windows-defender-by-setting-path-exclusions/']
+          ],
         'DisclosureDate' => 'May 12 2017'
       )
     )

--- a/modules/exploits/windows/local/bypassuac_injection.rb
+++ b/modules/exploits/windows/local/bypassuac_injection.rb
@@ -44,12 +44,11 @@ class MetasploitModule < Msf::Exploit::Local
           [ 'Windows x64', { 'Arch' => ARCH_X64 } ]
       ],
       'DefaultTarget' => 0,
-      'References'    => [
+      'References'    =>
         [
-          'URL', 'http://www.trustedsec.com/december-2010/bypass-windows-uac/',
-          'URL', 'http://www.pretentiousname.com/misc/W7E_Source/win7_uac_poc_details.html'
-        ]
-      ],
+          ['URL', 'http://www.trustedsec.com/december-2010/bypass-windows-uac/'],
+          ['URL', 'http://www.pretentiousname.com/misc/W7E_Source/win7_uac_poc_details.html']
+        ],
       'DisclosureDate'=> 'Dec 31 2010'
     ))
 

--- a/modules/exploits/windows/local/bypassuac_injection_winsxs.rb
+++ b/modules/exploits/windows/local/bypassuac_injection_winsxs.rb
@@ -39,9 +39,7 @@ class MetasploitModule < Msf::Exploit::Local
       ],
       'DefaultTarget' => 0,
       'References'    => [
-        [
-          'URL', 'https://github.com/L3cr0f/DccwBypassUAC'
-        ]
+        ['URL', 'https://github.com/L3cr0f/DccwBypassUAC']
       ],
       'DisclosureDate'=> 'Apr 06 2017'
     ))

--- a/modules/exploits/windows/local/bypassuac_sluihijack.rb
+++ b/modules/exploits/windows/local/bypassuac_sluihijack.rb
@@ -54,12 +54,11 @@ class MetasploitModule < Msf::Exploit::Local
           ['Windows x64', { 'Arch' => ARCH_X64 }]
         ],
         'DefaultTarget' => 0,
-        'References'    => [
+        'References'    =>
           [
-            'URL', 'https://github.com/bytecode-77/slui-file-handler-hijack-privilege-escalation',
-            'URL', 'https://github.com/gushmazuko/WinBypass/blob/master/SluiHijackBypass.ps1'
-          ]
-        ],
+            ['URL', 'https://github.com/bytecode-77/slui-file-handler-hijack-privilege-escalation'],
+            ['URL', 'https://github.com/gushmazuko/WinBypass/blob/master/SluiHijackBypass.ps1']
+          ],
         'DisclosureDate' => 'Jan 15 2018'
       )
     )

--- a/modules/exploits/windows/local/bypassuac_vbs.rb
+++ b/modules/exploits/windows/local/bypassuac_vbs.rb
@@ -30,12 +30,11 @@ class MetasploitModule < Msf::Exploit::Local
           [ 'Automatic', { 'Arch' => [ ARCH_X86, ARCH_X64 ] } ]
       ],
       'DefaultTarget' => 0,
-      'References'    => [
+      'References'    =>
         [
-          'URL', 'http://seclist.us/uac-bypass-vulnerability-in-the-windows-script-host.html',
-          'URL', 'https://github.com/Vozzie/uacscript'
-        ]
-      ],
+          ['URL', 'http://seclist.us/uac-bypass-vulnerability-in-the-windows-script-host.html'],
+          ['URL', 'https://github.com/Vozzie/uacscript']
+        ],
       'DisclosureDate'=> 'Aug 22 2015'
     ))
 


### PR DESCRIPTION
The fodhelper technique is being used by malware (no surprise) to whitelist Windows Defender folders where it drops more files.
Thought it may be good to include the link to that article since it gives the code and another vector for 'what can I do with this module'.

While working on this, noticed that a bunch of the bypassuac modules incorrectly formatted the references line.  While no error was thrown, no references were being displayed in `info`.  Fixed them.