### PR TITLE
Update to modbusclient.rb to use modbus read functions 2 and 4

### DIFF
--- a/modules/auxiliary/scanner/scada/modbusclient.rb
+++ b/modules/auxiliary/scanner/scada/modbusclient.rb
@@ -20,7 +20,7 @@ class MetasploitModule < Msf::Auxiliary
           'Arnaud SOULLIE  <arnaud.soullie[at]solucom.fr>', # code that allows read/write
           'Alexandrine TORRENTS <alexandrine.torrents[at]eurecom.fr>', # code that allows reading/writing at multiple consecutive addresses
           'Mathieu CHEVALIER <mathieu.chevalier[at]eurecom.fr>',
-          'AZSG <AstroZombieSG@gmail.com' # updated read actions to include function codes 2 and 4 and renamed actions to align with modbus standard 1.1b3
+          'AZSG <AstroZombieSG@gmail.com>' # updated read actions to include function codes 2 and 4 and renamed actions to align with modbus standard 1.1b3
         ],
       'License'        => MSF_LICENSE,
       'Actions'        =>


### PR DESCRIPTION
The existing modbus client only reads coils and holding registers (function codes 1 and 3)
Per the modbus standard, there are two additional registers you can read.
01 (0x01) Read Coils
02 (0x02) Read Discrete Inputs
03 (0x03) Read Holding Registers
04 (0x04) Read Input Registers

Copied existing code for reading coils/registers and added function codes 2 and 4.

Verification
Running OPENPLCPROJECT on a raspberry pi, setup test values for each function call

```
Start msfconsole
use auxiliary/scanner/scada/modbusclient
show actions
READ_COILS Read bits from several coils
READ_DISCRETE_INPUTS Read bits from several DISCRETE INPUTS
READ_HOLDING_REGISTERS Read words from several HOLDING registers
READ_INPUT_REGISTERS Read words from several INPUT registers
set RHOSTS <IP Add of your Modbus PLC)
set DATA_ADDRESS 0 
set ACTION 
run

msf5 auxiliary(scanner/scada/modbusclient) > run
[*] Running module against 192.168.1.124

[] 192.168.1.124:502 - Sending READ HOLDING REGISTERS...
[+] 192.168.1.124:502 - 1 register values from address 0 :
[+] 192.168.1.124:502 - [2222]
[] Auxiliary module execution completed
msf5 auxiliary(scanner/scada/modbusclient) > set ACTION READ_DISCRETE_INPUTS
ACTION => READ_DISCRETE_INPUTS
msf5 auxiliary(scanner/scada/modbusclient) > run
[*] Running module against 192.168.1.124

[] 192.168.1.124:502 - Sending READ DISCRETE INPUTS...
[+] 192.168.1.124:502 - 1 DISCRETE INPUT values from address 0 :
[+] 192.168.1.124:502 - [1]
[] Auxiliary module execution completed
msf5 auxiliary(scanner/scada/modbusclient) > set ACTION READ_COILS
ACTION => READ_COILS
msf5 auxiliary(scanner/scada/modbusclient) > run
[*] Running module against 192.168.1.124

[] 192.168.1.124:502 - Sending READ COILS...
[+] 192.168.1.124:502 - 1 coil values from address 0 :
[+] 192.168.1.124:502 - [1]
[] Auxiliary module execution completed
msf5 auxiliary(scanner/scada/modbusclient) > set ACTION READ_INPUT_REGISTERS
ACTION => READ_INPUT_REGISTERS
msf5 auxiliary(scanner/scada/modbusclient) > run
[*] Running module against 192.168.1.124

[] 192.168.1.124:502 - Sending READ INPUT REGISTERS...
[+] 192.168.1.124:502 - 1 register values from address 0 :
[+] 192.168.1.124:502 - [1111]
[] Auxiliary module execution completed
msf5 auxiliary(scanner/scada/modbusclient) >
```
