### PR TITLE
fix permissions bug Gemfile.lock

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,7 @@ RUN /usr/sbin/setcap cap_net_raw,cap_net_bind_service=+eip $(which nmap)
 
 COPY --chown=root:metasploit --from=builder /usr/local/bundle /usr/local/bundle
 COPY --chown=root:metasploit . $APP_HOME/
+RUN chmod 664 $APP_HOME/Gemfile.lock
 RUN cp -f $APP_HOME/docker/database.yml $APP_HOME/config/database.yml
 
 WORKDIR $APP_HOME


### PR DESCRIPTION
There was an error while trying to write to /usr/src/metasploit-framework/Gemfile.lock. It is likely that you need to grant write permissions for that path.

https://github.com/rapid7/metasploit-framework/issues/12300
