### PR TITLE
move bigdecimal fix to separate file, include for specs

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,3 +1,4 @@
+require File.expand_path('../rails_bigdecimal_fix', __FILE__)
 require 'rails'
 require File.expand_path('../boot', __FILE__)
 

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -9,6 +9,8 @@ GEMFILE_EXTENSIONS = [
 msfenv_real_pathname = Pathname.new(__FILE__).realpath
 root = msfenv_real_pathname.parent.parent
 
+require File.expand_path('../rails_bigdecimal_fix', __FILE__)
+
 unless ENV['BUNDLE_GEMFILE']
   require 'pathname'
 
@@ -21,18 +23,6 @@ unless ENV['BUNDLE_GEMFILE']
     end
   end
 end
-
-# Remove bigdecimal warning - start
-# https://github.com/ruby/bigdecimal/pull/115
-# https://github.com/rapid7/metasploit-framework/pull/11184#issuecomment-461971266
-# TODO: remove when upgrading from rails 4.x
-require 'bigdecimal'
-
-def BigDecimal.new(*args, **kwargs)
-  return BigDecimal(*args) if kwargs.empty?
-  BigDecimal(*args, **kwargs)
-end
-# Remove bigdecimal warning - end
 
 begin
   require 'bundler/setup'

--- a/config/rails_bigdecimal_fix.rb
+++ b/config/rails_bigdecimal_fix.rb
@@ -1,0 +1,11 @@
+# Remove bigdecimal warning - start
+# https://github.com/ruby/bigdecimal/pull/115
+# https://github.com/rapid7/metasploit-framework/pull/11184#issuecomment-461971266
+# TODO: remove when upgrading from rails 4.x
+require 'bigdecimal'
+
+def BigDecimal.new(*args, **kwargs)
+  return BigDecimal(*args) if kwargs.empty?
+  BigDecimal(*args, **kwargs)
+end
+# Remove bigdecimal warning - end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,8 @@ require 'factory_bot'
 
 ENV['RAILS_ENV'] = 'test'
 
+require File.expand_path('../../config/rails_bigdecimal_fix', __FILE__)
+
 # @note must be before loading config/environment because railtie needs to be loaded before
 #   `Metasploit::Framework::Application.initialize!` is called.
 #


### PR DESCRIPTION
This fixes some noisy warnings about bignum when running specs, making it easier to see the real problems.

 - [ ] Wait for the tests to complete, and verify that `msfvenom`, `msfconsole`, and `rake spec` do not warn about bigdecimal.new being deprecated.