### PR TITLE
jboss_vulnscan and jboss_status: add CVE information

### DIFF
--- a/modules/auxiliary/scanner/http/jboss_status.rb
+++ b/modules/auxiliary/scanner/http/jboss_status.rb
@@ -19,6 +19,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'  =>
         [
           ['CVE', '2008-3273'],
+          ['CVE', '2010-1429'], # regression
           ['URL', 'https://seclists.org/fulldisclosure/2011/Sep/139'],
           ['URL', 'https://www.owasp.org/images/a/a9/OWASP3011_Luca.pdf'],
           ['URL', 'http://www.slideshare.net/chrisgates/lares-fromlowtopwned']

--- a/modules/auxiliary/scanner/http/jboss_vulnscan.rb
+++ b/modules/auxiliary/scanner/http/jboss_vulnscan.rb
@@ -23,8 +23,11 @@ class MetasploitModule < Msf::Auxiliary
         ],
       'References'            =>
         [
-          [ 'CVE', '2010-0738' ], # VERB auth bypass
-          [ 'CVE', '2017-12149' ]
+          [ 'CVE', '2008-3273' ], # info disclosure via unauthenticated access to "/status"
+          [ 'CVE', '2010-1429' ], # info disclosure via unauthenticated access to "/status" (regression)
+          [ 'CVE', '2010-0738' ], # VERB auth bypass on "JMX-Console": /jmx-console/
+          [ 'CVE', '2010-1428' ], # VERB auth bypass on "Web Console": /web-console/
+          [ 'CVE', '2017-12149' ] # deserialization: "/invoker/readonly"
         ],
       'License'               => BSD_LICENSE
       ))


### PR DESCRIPTION
Add CVE info to these 2 modules


About: CVE-2010-0738 VS CVE-2010-1428
This module is able to detect auth bypass in JBoss "web console" and "jmx console" which are in 2 different subfolders. Each had receive a different CVE number.
Cf. 
https://nvd.nist.gov/vuln/detail/CVE-2010-0738
https://nvd.nist.gov/vuln/detail/CVE-2010-1428