### PR TITLE
RHOSTS: accept both "file://<path>" and "file:<path>" syntax

### DIFF
--- a/data/markdown_doc/auxiliary_scanner_template.erb
+++ b/data/markdown_doc/auxiliary_scanner_template.erb
@@ -25,5 +25,5 @@ msf <%= mod.type %>(<%= mod.shortname %>) > set RHOSTS 192.168.1.1/24
 Example 3:
 
 ```
-msf <%= mod.type %>(<%= mod.shortname %>) > set RHOSTS file:///tmp/ip_list.txt
+msf <%= mod.type %>(<%= mod.shortname %>) > set RHOSTS file:/tmp/ip_list.txt
 ```

--- a/documentation/modules/auxiliary/scanner/ssh/ssh_login.md
+++ b/documentation/modules/auxiliary/scanner/ssh/ssh_login.md
@@ -32,7 +32,7 @@
 
   **RHOSTS**
   
-  Either a comma space (`, `) separated list of hosts, or a file containing list of hosts, one per line.  File Example: `file://root/ssh_hosts.lst`, list example: `192.168.0.1` or `192.168.0.1, 192.168.0.2`
+  Either a comma space (`, `) separated list of hosts, or a file containing list of hosts, one per line.  File Example: `file:/root/ssh_hosts.lst`, list example: `192.168.0.1` or `192.168.0.1, 192.168.0.2`
 
   **STOP_ON_SUCCESS**
   
@@ -104,8 +104,8 @@ msf auxiliary(ssh_login) > cat /root/ssh_hosts.lst
 192.168.2.137
 192.168.2.35
 192.168.2.46
-msf auxiliary(ssh_login) > set rhosts file://root/ssh_hosts.lst
-rhosts => file://root/ssh_hosts.lst
+msf auxiliary(ssh_login) > set rhosts file:/root/ssh_hosts.lst
+rhosts => file:/root/ssh_hosts.lst
 msf auxiliary(ssh_login) > set verbose false
 verbose => false
 msf auxiliary(ssh_login) > set threads 4

--- a/documentation/modules/auxiliary/scanner/ssh/ssh_login_pubkey.md
+++ b/documentation/modules/auxiliary/scanner/ssh/ssh_login_pubkey.md
@@ -34,7 +34,7 @@
   
   **RHOSTS**
   
-  Either a comma space (`, `) separated list of hosts, or a file containing list of hosts, one per line.  File Example: `file://root/ssh_hosts.lst`, list example: `192.168.0.1` or `192.168.0.1, 192.168.0.2`
+  Either a comma space (`, `) separated list of hosts, or a file containing list of hosts, one per line.  File Example: `file:/root/ssh_hosts.lst`, list example: `192.168.0.1` or `192.168.0.1, 192.168.0.2`
 
   **STOP_ON_SUCCESS**
   

--- a/lib/msf/core/opt.rb
+++ b/lib/msf/core/opt.rb
@@ -41,11 +41,11 @@ module Msf
     end
 
     # @return [OptAddressRange]
-    def self.RHOSTS(default=nil, required=true, desc="The target address range or CIDR identifier")
+    def self.RHOSTS(default=nil, required=true, desc="The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'")
       Msf::OptAddressRange.new('RHOSTS', [ required, desc, default ])
     end
 
-    def self.RHOST(default=nil, required=true, desc="The target address range or CIDR identifier")
+    def self.RHOST(default=nil, required=true, desc="The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'")
       Msf::OptAddressRange.new('RHOSTS', [ required, desc, default ], aliases: [ 'RHOST' ])
     end
 

--- a/lib/msf/core/opt_address_range.rb
+++ b/lib/msf/core/opt_address_range.rb
@@ -18,7 +18,8 @@ class OptAddressRange < OptBase
 
   def normalize(value)
     return nil unless value.kind_of?(String)
-    if (value =~ /^file:(.*)/)
+    # accept both "file://<path>" and "file:<path>" syntax
+    if (value =~ /^file:\/\/(.*)/) || (value =~ /^file:(.*)/)
       path = $1
       return false if not File.exist?(path) or File.directory?(path)
       return File.readlines(path).map{ |s| s.strip}.join(" ")

--- a/spec/lib/msf/core/opt_address_range_spec.rb
+++ b/spec/lib/msf/core/opt_address_range_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe Msf::OptAddressRange do
     { :value => "192.0.2.0,1-255", :normalized => "192.0.2.0,1-255" },
     { :value => "192.0.2.*",       :normalized => "192.0.2.*" },
     { :value => "192.0.2.0-192.0.2.255", :normalized => "192.0.2.0-192.0.2.255" },
-    { :value => "file:#{File.expand_path('short_address_list.txt',FILE_FIXTURES_PATH)}", :normalized => '192.168.1.1 192.168.1.2 192.168.1.3 192.168.1.4 192.168.1.5'}
+    { :value => "file:#{File.expand_path('short_address_list.txt',FILE_FIXTURES_PATH)}", :normalized => '192.168.1.1 192.168.1.2 192.168.1.3 192.168.1.4 192.168.1.5'},
+    { :value => "file://#{File.expand_path('short_address_list.txt',FILE_FIXTURES_PATH)}", :normalized => '192.168.1.1 192.168.1.2 192.168.1.3 192.168.1.4 192.168.1.5'}
   ]
   invalid_values = [
     # Too many dots


### PR DESCRIPTION
The `RHOSTS` option is compatible with file paths to load targets from a hosts file.
Many documentations and examples (example in [Metasploit 5.0 release notes](https://github.com/rapid7/metasploit-framework/wiki/Metasploit-5.0-Release-Notes)) describe its usage with the "file://<path>" syntax, like a URL. However, by reading the code, I noticed it should actually be "file:<path>".

The patch allows to use both syntax for maximum compatibility, and without having to fix all documentations.

## Verification
Create the data file:
```shell
echo 127.0.0.1 > /root/list.txt
echo 127.0.0.2 >> /root/list.txt
```

Open msfconsole and load any module which uses RHOSTS and set a few options (for better output):
```shell
use auxiliary/scanner/mysql/mysql_version
set verbose true
set showprogress false
```

Run these variations:
```shell
set rhosts file:list.txt
run
set rhosts file:./list.txt
run
set rhosts file:/root/list.txt
run

set rhosts file://list.txt
run
set rhosts file://./list.txt
run
set rhosts file:///root/list.txt
run
```

Before the patch:
```shell
msf5 auxiliary(scanner/mysql/mysql_version) > set rhosts file:list.txt
rhosts => file:list.txt
msf5 auxiliary(scanner/mysql/mysql_version) > run

[-] 127.0.0.1:3306        - 127.0.0.1:3306 - Connection failed
[-] 127.0.0.2:3306        - 127.0.0.2:3306 - Connection failed
[*] Auxiliary module execution completed
msf5 auxiliary(scanner/mysql/mysql_version) > set rhosts file:./list.txt
rhosts => file:./list.txt
msf5 auxiliary(scanner/mysql/mysql_version) > run

[-] 127.0.0.1:3306        - 127.0.0.1:3306 - Connection failed
[-] 127.0.0.2:3306        - 127.0.0.2:3306 - Connection failed
[*] Auxiliary module execution completed
msf5 auxiliary(scanner/mysql/mysql_version) > set rhosts file:/root/list.txt
rhosts => file:/root/list.txt
msf5 auxiliary(scanner/mysql/mysql_version) > run

[-] 127.0.0.1:3306        - 127.0.0.1:3306 - Connection failed
[-] 127.0.0.2:3306        - 127.0.0.2:3306 - Connection failed
[*] Auxiliary module execution completed
msf5 auxiliary(scanner/mysql/mysql_version) > 
msf5 auxiliary(scanner/mysql/mysql_version) > set rhosts file://list.txt
rhosts => file://list.txt
msf5 auxiliary(scanner/mysql/mysql_version) > run
[-] Auxiliary failed: Msf::OptionValidateError The following options failed to validate: RHOSTS.
msf5 auxiliary(scanner/mysql/mysql_version) > set rhosts file://./list.txt
rhosts => file://./list.txt
msf5 auxiliary(scanner/mysql/mysql_version) > run
[-] Auxiliary failed: Msf::OptionValidateError The following options failed to validate: RHOSTS.
msf5 auxiliary(scanner/mysql/mysql_version) > set rhosts file:///root/list.txt
rhosts => file:///root/list.txt
msf5 auxiliary(scanner/mysql/mysql_version) > run

[-] 127.0.0.1:3306        - 127.0.0.1:3306 - Connection failed
[-] 127.0.0.2:3306        - 127.0.0.2:3306 - Connection failed
[*] Auxiliary module execution completed
msf5 auxiliary(scanner/mysql/mysql_version) > 
```
Failures for "file://list.txt" and "file://./list.txt"...

After the patch:
```shell
msf5 auxiliary(scanner/mysql/mysql_version) > run

[-] 127.0.0.1:3306        - 127.0.0.1:3306 - Connection failed
[-] 127.0.0.2:3306        - 127.0.0.2:3306 - Connection failed
[*] Auxiliary module execution completed
msf5 auxiliary(scanner/mysql/mysql_version) > 
msf5 auxiliary(scanner/mysql/mysql_version) > set rhosts file:./list.txt
rhosts => file:./list.txt
msf5 auxiliary(scanner/mysql/mysql_version) > run

[-] 127.0.0.1:3306        - 127.0.0.1:3306 - Connection failed
[-] 127.0.0.2:3306        - 127.0.0.2:3306 - Connection failed
[*] Auxiliary module execution completed
msf5 auxiliary(scanner/mysql/mysql_version) > 
msf5 auxiliary(scanner/mysql/mysql_version) > set rhosts file:/root/list.txt
rhosts => file:/root/list.txt
msf5 auxiliary(scanner/mysql/mysql_version) > run

[-] 127.0.0.1:3306        - 127.0.0.1:3306 - Connection failed
[-] 127.0.0.2:3306        - 127.0.0.2:3306 - Connection failed
[*] Auxiliary module execution completed
msf5 auxiliary(scanner/mysql/mysql_version) > 
msf5 auxiliary(scanner/mysql/mysql_version) > 
msf5 auxiliary(scanner/mysql/mysql_version) > 
msf5 auxiliary(scanner/mysql/mysql_version) > set rhosts file://list.txt
rhosts => file://list.txt
msf5 auxiliary(scanner/mysql/mysql_version) > run

[-] 127.0.0.1:3306        - 127.0.0.1:3306 - Connection failed
[-] 127.0.0.2:3306        - 127.0.0.2:3306 - Connection failed
[*] Auxiliary module execution completed
msf5 auxiliary(scanner/mysql/mysql_version) > 
msf5 auxiliary(scanner/mysql/mysql_version) > set rhosts file://./list.txt
rhosts => file://./list.txt
msf5 auxiliary(scanner/mysql/mysql_version) > run

[-] 127.0.0.1:3306        - 127.0.0.1:3306 - Connection failed
[-] 127.0.0.2:3306        - 127.0.0.2:3306 - Connection failed
[*] Auxiliary module execution completed
msf5 auxiliary(scanner/mysql/mysql_version) > 
msf5 auxiliary(scanner/mysql/mysql_version) > set rhosts file:///root/list.txt
rhosts => file:///root/list.txt
msf5 auxiliary(scanner/mysql/mysql_version) > run

[-] 127.0.0.1:3306        - 127.0.0.1:3306 - Connection failed
[-] 127.0.0.2:3306        - 127.0.0.2:3306 - Connection failed
[*] Auxiliary module execution completed
msf5 auxiliary(scanner/mysql/mysql_version) > 
```
