### PR TITLE
jboss_vulnscan: prefix fingerprint by 'rhost' and 'rport'

### DIFF
--- a/modules/auxiliary/scanner/http/jboss_vulnscan.rb
+++ b/modules/auxiliary/scanner/http/jboss_vulnscan.rb
@@ -49,7 +49,7 @@ class MetasploitModule < Msf::Auxiliary
     if res
 
       info = http_fingerprint(:response => res)
-      print_status("#{rhost}:#{rport} #{info}")
+      print_status("#{rhost}:#{rport} Fingerprint: #{info}")
 
       if res.body && />(JBoss[^<]+)/.match(res.body)
         print_error("#{rhost}:#{rport} JBoss error message: #{$1}")

--- a/modules/auxiliary/scanner/http/jboss_vulnscan.rb
+++ b/modules/auxiliary/scanner/http/jboss_vulnscan.rb
@@ -49,7 +49,7 @@ class MetasploitModule < Msf::Auxiliary
     if res
 
       info = http_fingerprint(:response => res)
-      print_status(info)
+      print_status("#{rhost}:#{rport} #{info}")
 
       if res.body && />(JBoss[^<]+)/.match(res.body)
         print_error("#{rhost}:#{rport} JBoss error message: #{$1}")

--- a/modules/auxiliary/scanner/http/jboss_vulnscan.rb
+++ b/modules/auxiliary/scanner/http/jboss_vulnscan.rb
@@ -206,7 +206,7 @@ class MetasploitModule < Msf::Auxiliary
     })
 
     if res && res.code == 200
-      print_good("#{rhost}:#{rport} Got authentication bypass via HTTP verb tampering")
+      print_good("#{rhost}:#{rport} Got authentication bypass via HTTP verb tampering at #{app}")
     else
       print_status("#{rhost}:#{rport} Could not get authentication bypass via HTTP verb tampering")
     end


### PR DESCRIPTION
All other `print_...()` in this module have this syntax, except this one.
It's convenient as it allows to differentiate outputs from different hosts scanned in parallel.