### PR TITLE
Adds wql_query module, along with lib additions

### DIFF
--- a/documentation/modules/post/windows/recon/wql_query.md
+++ b/documentation/modules/post/windows/recon/wql_query.md
@@ -2,9 +2,9 @@
 
 This module will execute a WQL query via Powershell's `Get-WmiObject`. A WQL query can be
 explicity defined with the WQL and NAMESPACE options, or a hard-coded query can be used by
-defining the MODULE option.
+defining the ACTION option.
 
-The following MODULEs are available:
+The following ACTIONs are available:
 
 OSVERSION - Returns information about the operating system,
 PROCESSINFO - Returns running processes.
@@ -20,16 +20,16 @@ PROCESSINFO - Returns running processes.
   3. `use post/windows/recon/wql_query`
   4. `run`
   5. **Verify** that operating system version info is returned
-  6. `set MODULE ""`
+  6. `set ACTION ""`
   7. `set WQL select * from win32_operatingsystem`
   8. `run`
   9. **Verify** that more complete data comes back
 
 ## Options
 
-  **MODULE**
+  **ACTION**
 
-  This is any of the predefined modules that are pre-baked in.
+  This is any of the predefined actions that are pre-baked in.
 
   **NAMESPACE**
 
@@ -53,7 +53,7 @@ Module options (post/windows/recon/wql_query):
 
    Name       Current Setting  Required  Description
    ----       ---------------  --------  -----------
-   MODULE     OSVERSION        no        Module query to run
+   ACTION     OSVERSION        no        Action query to run
    NAMESPACE                   no        Namespace to run the WQL query against
    RHOST      localhost        yes       Target address range
    SESSION                     yes       The session to run this module on.
@@ -77,8 +77,8 @@ Version    BuildNumber
 
 
 [*] Post module execution completed
-msf5 post(windows/recon/wql_query) > set module ""
-module =>
+msf5 post(windows/recon/wql_query) > set ACTION ""
+ACTION =>
 msf5 post(windows/recon/wql_query) > set WQL select * from win32_operatingsystem
 WQL => select * from win32_operatingsystem
 msf5 post(windows/recon/wql_query) > run

--- a/documentation/modules/post/windows/recon/wql_query.md
+++ b/documentation/modules/post/windows/recon/wql_query.md
@@ -2,12 +2,13 @@
 
 This module will execute a WQL query via Powershell's `Get-WmiObject`. A WQL query can be
 explicity defined with the WQL and NAMESPACE options, or a hard-coded query can be used by
-defining the ACTION option.
+defining a corresponding ACTION option.
 
 The following ACTIONs are available:
 
 OSVERSION - Returns information about the operating system,
-PROCESSINFO - Returns running processes.
+PROCESSINFO - Returns running processes,
+RAW_QUERY - Run a raw WQL query
 
 ## Vulnerable Application
 
@@ -20,7 +21,7 @@ PROCESSINFO - Returns running processes.
   3. `use post/windows/recon/wql_query`
   4. `run`
   5. **Verify** that operating system version info is returned
-  6. `set ACTION ""`
+  6. `set ACTION "RAW_QUERY"`
   7. `set WQL select * from win32_operatingsystem`
   8. `run`
   9. **Verify** that more complete data comes back
@@ -29,7 +30,7 @@ PROCESSINFO - Returns running processes.
 
   **ACTION**
 
-  This is any of the predefined actions that are pre-baked in.
+  This is any of the predefined actions that are pre-baked in, or use with WQL to run a raw query.
 
   **NAMESPACE**
 
@@ -53,7 +54,7 @@ Module options (post/windows/recon/wql_query):
 
    Name       Current Setting  Required  Description
    ----       ---------------  --------  -----------
-   ACTION     OSVERSION        no        Action query to run
+   ACTION     OSVERSION        no        OSVERSION, PROCESSINFO, or RAW_QUERY
    NAMESPACE                   no        Namespace to run the WQL query against
    RHOST      localhost        yes       Target address range
    SESSION                     yes       The session to run this module on.
@@ -77,7 +78,7 @@ Version    BuildNumber
 
 
 [*] Post module execution completed
-msf5 post(windows/recon/wql_query) > set ACTION ""
+msf5 post(windows/recon/wql_query) > set ACTION "RAW_QUERY"
 ACTION =>
 msf5 post(windows/recon/wql_query) > set WQL select * from win32_operatingsystem
 WQL => select * from win32_operatingsystem

--- a/documentation/modules/post/windows/recon/wql_query.md
+++ b/documentation/modules/post/windows/recon/wql_query.md
@@ -1,0 +1,99 @@
+## Introduction
+
+This module will execute a WQL query via Powershell's `Get-WmiObject`. A WQL query can be
+explicity defined with the WQL and NAMESPACE options, or a hard-coded query can be used by
+defining the MODULE option.
+
+The following MODULEs are available:
+
+OSVERSION - Returns information about the operating system,
+PROCESSINFO - Returns running processes.
+
+## Vulnerable Application
+
+  This should work on version of Windows with Powershell that support `Get-WmiObject`.
+
+## Verification Steps
+
+  1. Start `msfconsole`
+  2. Get Meterpreter session
+  3. `use post/windows/recon/wql_query`
+  4. `run`
+  5. **Verify** that operating system version info is returned
+  6. `set MODULE ""`
+  7. `set WQL select * from win32_operatingsystem`
+  8. `run`
+  9. **Verify** that more complete data comes back
+
+## Options
+
+  **MODULE**
+
+  This is any of the predefined modules that are pre-baked in.
+
+  **NAMESPACE**
+
+  This will set the namespace to run any arbitrary WQL against.
+
+  **WQL**
+
+  An arbitrary WQL statement to run on the system.
+
+## Proof of Concept
+
+```
+
+msf5 exploit(multi/handler) >
+[*] https://192.168.170.1:8443 handling request from 192.168.170.128; (UUID: w43pepbp) Staging x86 payload (181337 bytes) ...
+[*] Meterpreter session 1 opened (192.168.170.1:8443 -> 192.168.170.128:50319) at 2019-09-11 19:01:40 -0500
+msf5 exploit(multi/handler) > use post/windows/recon/wql_query
+msf5 post(windows/recon/wql_query) > show options
+
+Module options (post/windows/recon/wql_query):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   MODULE     OSVERSION        no        Module query to run
+   NAMESPACE                   no        Namespace to run the WQL query against
+   RHOST      localhost        yes       Target address range
+   SESSION                     yes       The session to run this module on.
+   SMBDomain                   no        The Windows domain to use for authentication
+   SMBPass                     no        The password for the specified username
+   SMBUser                     no        The username to authenticate as
+   TIMEOUT    10               yes       Timeout for WMI command in seconds
+   WQL                         no        WQL query to run
+
+msf5 post(windows/recon/wql_query) > set session 1
+session => 1
+msf5 post(windows/recon/wql_query) > run
+
+[*] Executing WQL
+[*] WQL result:
+
+Version    BuildNumber
+-------    -----------
+10.0.17763 17763
+
+
+
+[*] Post module execution completed
+msf5 post(windows/recon/wql_query) > set module ""
+module =>
+msf5 post(windows/recon/wql_query) > set WQL select * from win32_operatingsystem
+WQL => select * from win32_operatingsystem
+msf5 post(windows/recon/wql_query) > run
+
+[*] Executing WQL
+[*] WQL result:
+
+
+SystemDirectory : C:\Windows\system32
+Organization    :
+BuildNumber     : 17763
+RegisteredUser  : chiggins
+SerialNumber    : XXXXX-XXXXX-XXXXX-XXXXX
+Version         : 10.0.17763
+
+[*] Post module execution completed
+```
+

--- a/lib/msf/core/post/windows/wmic.rb
+++ b/lib/msf/core/post/windows/wmic.rb
@@ -25,8 +25,6 @@ module WMIC
   def gwmi_query(query, server=datastore['RHOST'], filter='', namespace='')
     extapi = load_extapi
 
-    result_text = ""
-
     psh_cmd = "Get-WmiObject -Query '#{query}' "
     if (namespace.nil? or namespace.empty?) == false
       psh_cmd.concat("-Namespace #{namespace}")
@@ -46,14 +44,13 @@ module WMIC
 
     if result.include? 'Invalid query'
       return false
-    else
-      # Not exactly sure why all this data gets returned, but this will strip it out
-      result.slice! "#< CLIXML"
-      result = result.split("<Objs")[0]
-      result_text = result
     end
 
-    return result_text
+    # Not exactly sure why all this data gets returned, but this will strip it out
+    result.slice! "#< CLIXML"
+    result = result.split("<Objs")[0]
+
+    return result
   end
 
   def wmic_query(query, server=datastore['RHOST'])

--- a/modules/post/windows/recon/wql_query.rb
+++ b/modules/post/windows/recon/wql_query.rb
@@ -15,7 +15,7 @@ class MetasploitModule < Msf::Post
         'Description'   => %q{
           This module will execute a WQL query via Powershell's Get-WmiObject. A WQL query
           can be explicity defined with the WQL and NAMESPACE options, or a hard-coded
-          query can be used by defining the MODULE option. The following MODULEs are
+          query can be used by defining the ACTION option. The following ACTIONs are
           available: OSVERSION - Returns information about the operating system,
           PROCESSINFO - Returns running processes.
         },
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Post
       ))
     register_options(
       [
-        OptString.new("MODULE" , [ false, "Module query to run", "OSVERSION" ]),
+        OptString.new("ACTION" , [ false, "ACTION query to run", "OSVERSION" ]),
         OptString.new("NAMESPACE" , [ false, "Namespace to run the WQL query against" ]),
         OptString.new("WQL" , [ false, "WQL query to run" ])
       ])
@@ -34,8 +34,8 @@ class MetasploitModule < Msf::Post
   end
 
   def run
-    if datastore["MODULE"].present? && datastore["WQL"].present?
-      print_error("Cannot set both MODULE and WQL, only one")
+    if datastore["ACTION"].present? && datastore["WQL"].present?
+      print_error("Cannot set both ACTION and WQL, only one")
       return false
     end
 
@@ -43,7 +43,7 @@ class MetasploitModule < Msf::Post
 
     print_status("Executing WQL")
 
-    if datastore["MODULE"].nil? or datastore["MODULE"].empty?
+    if datastore["ACTION"].nil? or datastore["ACTION"].empty?
       command = datastore["WQL"]
       if datastore["NAMESPACE"].nil? or datastore["NAMESPACE"].empty?
         result = gwmi_query(command, host)
@@ -51,7 +51,7 @@ class MetasploitModule < Msf::Post
         result = gwmi_query(command, host, filter=nil, namespace=datastore["NAMESPACE"])
       end
     else
-      case datastore["MODULE"]
+      case datastore["ACTION"]
       when "OSVERSION"
         command = "SELECT * FROM win32_operatingsystem"
         filter = "Version,BuildNumber"
@@ -62,7 +62,7 @@ class MetasploitModule < Msf::Post
         print_error("Please set a valid module name")
         return false
       end
-        result = gwmi_query(command, host, filter=filter)
+      result = gwmi_query(command, host, filter=filter)
     end
 
     unless result

--- a/modules/post/windows/recon/wql_query.rb
+++ b/modules/post/windows/recon/wql_query.rb
@@ -15,18 +15,24 @@ class MetasploitModule < Msf::Post
         'Description'   => %q{
           This module will execute a WQL query via Powershell's Get-WmiObject. A WQL query
           can be explicity defined with the WQL and NAMESPACE options, or a hard-coded
-          query can be used by defining the ACTION option. The following ACTIONs are
+          query can be used by defining the an ACTION option. The following ACTIONs are
           available: OSVERSION - Returns information about the operating system,
-          PROCESSINFO - Returns running processes.
+          PROCESSINFO - Returns running processes, RAW_QUERY - Run a raw WQL query.
         },
         'License'       => MSF_LICENSE,
         'Author'        => [ 'Chris Higgins' ], # msf module - @ch1gg1ns
         'Platform'      => [ 'win' ],
-        'SessionTypes'  => [ 'meterpreter' ]
+        'SessionTypes'  => [ 'meterpreter' ],
+        'Actions'       =>
+        [
+          ['OSVERSION'],
+          ['PROCESSINFO'],
+          ['RAW_QUERY']
+        ]
       ))
     register_options(
       [
-        OptString.new("ACTION" , [ false, "ACTION query to run", "OSVERSION" ]),
+        OptString.new("ACTION" , [ false, "OSVERSION, PROCESSINFO, or RAW_QUERY", "OSVERSION" ]),
         OptString.new("NAMESPACE" , [ false, "Namespace to run the WQL query against" ]),
         OptString.new("WQL" , [ false, "WQL query to run" ])
       ])
@@ -34,35 +40,29 @@ class MetasploitModule < Msf::Post
   end
 
   def run
-    if datastore["ACTION"].present? && datastore["WQL"].present?
-      print_error("Cannot set both ACTION and WQL, only one")
-      return false
-    end
-
     host = datastore["RHOST"]
 
     print_status("Executing WQL")
 
-    if datastore["ACTION"].nil? or datastore["ACTION"].empty?
+    case action.name
+    when "RAW_QUERY"
       command = datastore["WQL"]
       if datastore["NAMESPACE"].nil? or datastore["NAMESPACE"].empty?
         result = gwmi_query(command, host)
       else
         result = gwmi_query(command, host, filter=nil, namespace=datastore["NAMESPACE"])
       end
-    else
-      case datastore["ACTION"]
-      when "OSVERSION"
-        command = "SELECT * FROM win32_operatingsystem"
-        filter = "Version,BuildNumber"
-      when "PROCESSINFO"
-        command = "SELECT ProcessId,Name FROM Win32_Process"
-        filter = "ProcessID,Name"
-      else
-        print_error("Please set a valid module name")
-        return false
-      end
+    when "OSVERSION"
+      command = "SELECT * FROM win32_operatingsystem"
+      filter = "Version,BuildNumber"
       result = gwmi_query(command, host, filter=filter)
+    when "PROCESSINFO"
+      command = "SELECT ProcessId,Name FROM Win32_Process"
+      filter = "ProcessID,Name"
+      result = gwmi_query(command, host, filter=filter)
+    else
+      print_error("Please set a valid module name")
+      return false
     end
 
     unless result

--- a/modules/post/windows/recon/wql_query.rb
+++ b/modules/post/windows/recon/wql_query.rb
@@ -1,0 +1,76 @@
+# -*- coding: binary -*-
+
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Post
+
+  include Msf::Post::Windows::WMIC
+
+  def initialize(info={})
+    super( update_info( info,
+        'Name'          => 'WQL Command Runner',
+        'Description'   => %q{
+          This module will execute a WQL query via Powershell's Get-WmiObject. A WQL query
+          can be explicity defined with the WQL and NAMESPACE options, or a hard-coded
+          query can be used by defining the MODULE option. The following MODULEs are
+          available: OSVERSION - Returns information about the operating system,
+          PROCESSINFO - Returns running processes.
+        },
+        'License'       => MSF_LICENSE,
+        'Author'        => [ 'Chris Higgins' ], # msf module - @ch1gg1ns
+        'Platform'      => [ 'win' ],
+        'SessionTypes'  => [ 'meterpreter' ]
+      ))
+    register_options(
+      [
+        OptString.new("MODULE" , [ false, "Module query to run", "OSVERSION" ]),
+        OptString.new("NAMESPACE" , [ false, "Namespace to run the WQL query against" ]),
+        OptString.new("WQL" , [ false, "WQL query to run" ])
+      ])
+
+  end
+
+  def run
+    if datastore["MODULE"].present? && datastore["WQL"].present?
+      print_error("Cannot set both MODULE and WQL, only one")
+      return false
+    end
+
+    host = datastore["RHOST"]
+
+    print_status("Executing WQL")
+
+    if datastore["MODULE"].nil? or datastore["MODULE"].empty?
+      command = datastore["WQL"]
+      if datastore["NAMESPACE"].nil? or datastore["NAMESPACE"].empty?
+        result = gwmi_query(command, host)
+      else
+        result = gwmi_query(command, host, filter=nil, namespace=datastore["NAMESPACE"])
+      end
+    else
+      case datastore["MODULE"]
+      when "OSVERSION"
+        command = "SELECT * FROM win32_operatingsystem"
+        filter = "Version,BuildNumber"
+      when "PROCESSINFO"
+        command = "SELECT ProcessId,Name FROM Win32_Process"
+        filter = "ProcessID,Name"
+      else
+        print_error("Please set a valid module name")
+        return false
+      end
+        result = gwmi_query(command, host, filter=filter)
+    end
+
+    unless result
+      print_error("[#{host}] Get-WmiObject WQL query error")
+      return false
+    end
+
+    print_status("WQL result: #{result}")
+  end
+end
+


### PR DESCRIPTION
This post module adds the functionality to execute WQL statements on a local system through a Meterpreter shell. This module has some queries pre-baked in, but also allows for arbitrary WQL execution.

Relevant library additions were made as well to accomplish this. 

## Verification

- [ ] Start `msfconsole`
- [ ] Get Meterpreter session
- [ ] `use post/windows/recon/wql_query`
- [ ] `run`
- [ ] **Verify** that operating system version info is returned
- [ ] `set MODULE ""`
- [ ] ` set WQL select * from win32_operatingsystem`
- [ ] `run`
- [ ] **Verify** that more complete data comes back
- [ ] `set NAMESPACE "root\cimv2"
- [ ] `run`
- [ ] **Verify** that you get the same data back

```
msf5 exploit(multi/handler) > 
[*] https://192.168.170.1:8443 handling request from 192.168.170.128; (UUID: w43pepbp) Staging x86 payload (181337 bytes) ...
[*] Meterpreter session 1 opened (192.168.170.1:8443 -> 192.168.170.128:50319) at 2019-09-11 19:01:40 -0500
msf5 exploit(multi/handler) > use post/windows/recon/wql_query 
msf5 post(windows/recon/wql_query) > show options

Module options (post/windows/recon/wql_query):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   MODULE     OSVERSION        no        Module query to run
   NAMESPACE                   no        Namespace to run the WQL query against
   RHOST      localhost        yes       Target address range
   SESSION                     yes       The session to run this module on.
   SMBDomain                   no        The Windows domain to use for authentication
   SMBPass                     no        The password for the specified username
   SMBUser                     no        The username to authenticate as
   TIMEOUT    10               yes       Timeout for WMI command in seconds
   WQL                         no        WQL query to run

msf5 post(windows/recon/wql_query) > set session 1
session => 1
msf5 post(windows/recon/wql_query) > run

[*] Executing WQL
[*] WQL result: 

Version    BuildNumber
-------    -----------
10.0.17763 17763      



[*] Post module execution completed
msf5 post(windows/recon/wql_query) > set module ""
module => 
msf5 post(windows/recon/wql_query) > set WQL select * from win32_operatingsystem
WQL => select * from win32_operatingsystem
msf5 post(windows/recon/wql_query) > run

[*] Executing WQL
[*] WQL result: 


SystemDirectory : C:\Windows\system32
Organization    : 
BuildNumber     : 17763
RegisteredUser  : chiggins
SerialNumber    : XXXXX-XXXXX-XXXXX-XXXXX
Version         : 10.0.17763

[*] Post module execution completed
```

While writing up this PR, I realized that maybe `MODULE` might not be the best option name since that'd be giving it two meanings. I'll leave that up for debate. 