### PR TITLE
Add correct CVE for shopware module

### DIFF
--- a/modules/exploits/multi/http/shopware_createinstancefromnamedarguments_rce.rb
+++ b/modules/exploits/multi/http/shopware_createinstancefromnamedarguments_rce.rb
@@ -32,6 +32,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'References' =>
         [
+          ['CVE', '2019-12799'],                                                                         # yes really, assigned per request
           ['CVE', '2017-18357'],                                                                         # not really because we bypassed this patch
           ['URL', 'https://blog.ripstech.com/2017/shopware-php-object-instantiation-to-blind-xxe/']      # initial writeup w/ limited exploitation
         ],


### PR DESCRIPTION
In PR #11828, the module author requested, and got, a new CVE for this issue. The module should reflect that.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `info exploit/multi/http/shopware_createinstancefromnamedarguments_rce`
- [x] **Verify** both CVEs are listed.

