### PR TITLE
Fix broken `ps1` and `powershell` transform

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -317,7 +317,7 @@ GEM
       rex-socket
       rex-text
     rex-struct2 (0.1.2)
-    rex-text (0.2.23)
+    rex-text (0.2.24)
     rex-zip (0.1.3)
       rex-text
     rkelly-remix (0.0.7)

--- a/lib/msf/base/simple/buffer.rb
+++ b/lib/msf/base/simple/buffer.rb
@@ -88,6 +88,8 @@ module Buffer
         buf = Rex::Text.to_js_comment(buf)
       when 'java'
         buf = Rex::Text.to_c_comment(buf)
+      when 'powershell','ps1'
+        buf = Rex::Text.to_psh_comment(buf)
       else
         raise BufferFormatError, "Unsupported buffer format: #{fmt}", caller
     end


### PR DESCRIPTION
Requires  rapid7/rex-text#25

## Verification

- [x] Land rapid7/rex-text#25
- [x] Start `msfconsole`
- [x] `use payload/windows/shell/reverse_tcp`
- [x] `generate -f ps1`
- [x] **Verify** generates a payload
- [x] **Verify** does not output "[-] Payload generation failed: Unsupported buffer format: ps1"


