### PR TITLE
Add Proxy/header opts to windows/python stageless

### DIFF
--- a/modules/payloads/singles/python/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_http.rb
@@ -29,6 +29,11 @@ module MetasploitModule
       'Handler'     => Msf::Handler::ReverseHttp,
       'Session'     => Msf::Sessions::Meterpreter_Python_Python
     ))
+
+    register_advanced_options(
+      Msf::Opt::http_header_options +
+      Msf::Opt::http_proxy_options
+    )
   end
 
   def generate_reverse_http(opts={})

--- a/modules/payloads/singles/python/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_https.rb
@@ -29,6 +29,11 @@ module MetasploitModule
       'Handler'     => Msf::Handler::ReverseHttps,
       'Session'     => Msf::Sessions::Meterpreter_Python_Python
     ))
+
+    register_advanced_options(
+      Msf::Opt::http_header_options +
+      Msf::Opt::http_proxy_options
+    )
   end
 
   def generate_reverse_http(opts={})

--- a/modules/payloads/singles/windows/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/windows/meterpreter_reverse_http.rb
@@ -37,6 +37,11 @@ module MetasploitModule
       OptString.new('EXTENSIONS', [false, 'Comma-separate list of extensions to load']),
       OptString.new('EXTINIT',    [false, 'Initialization strings for extensions'])
     ])
+
+    register_advanced_options(
+      Msf::Opt::http_header_options +
+      Msf::Opt::http_proxy_options
+    )
   end
 
   def generate(opts={})

--- a/modules/payloads/singles/windows/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/windows/meterpreter_reverse_https.rb
@@ -37,6 +37,11 @@ module MetasploitModule
       OptString.new('EXTENSIONS', [false, 'Comma-separate list of extensions to load']),
       OptString.new('EXTINIT',    [false, 'Initialization strings for extensions'])
     ])
+
+    register_advanced_options(
+      Msf::Opt::http_header_options +
+      Msf::Opt::http_proxy_options
+    )
   end
 
   def generate(opts={})

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_http.rb
@@ -37,6 +37,11 @@ module MetasploitModule
       OptString.new('EXTENSIONS', [false, 'Comma-separate list of extensions to load']),
       OptString.new('EXTINIT',    [false, 'Initialization strings for extensions'])
     ])
+
+    register_advanced_options(
+      Msf::Opt::http_header_options +
+      Msf::Opt::http_proxy_options
+    )
   end
 
   def generate(opts={})

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_https.rb
@@ -37,6 +37,11 @@ module MetasploitModule
       OptString.new('EXTENSIONS', [false, 'Comma-separate list of extensions to load']),
       OptString.new('EXTINIT',    [false, 'Initialization strings for extensions'])
     ])
+
+    register_advanced_options(
+      Msf::Opt::http_header_options +
+      Msf::Opt::http_proxy_options
+    )
   end
 
   def generate(opts={})


### PR DESCRIPTION
This PR adds HTTP header and proxy options to the Windows native and Python payloads. Behind the scenes these options were supported, but they weren't exposed as Advanced options like they should have been.

The code simply adds the required options to the Advanced options list.

## Proof

From the advanced options in `windows/meterpreter_reverse_http`:
![image](https://user-images.githubusercontent.com/28896/65395534-698ffb80-dddf-11e9-84a1-ef615688113d.png)


## Verification

- [x] `use multi/handler`
Then for each of the payloads in `windows/meterpreter_reverse_http`, `windows/meterpreter_reverse_https`, `windows/x64/meterpreter_reverse_http`, `windows/x64/meterpreter_reverse_https`, `python/meterpreter_reverse_http`, `python/meterpreter_reverse_https`
- [x] `use <payload>`
- [x] `advanced`
- [ ] Verify that the appropriate Header and Proxy options are present.

Addresses #12324 