### PR TITLE
fix rspec failures due to overlapping class definitions between tests

### DIFF
--- a/spec/lib/msf/core/auxiliary/brocade_spec.rb
+++ b/spec/lib/msf/core/auxiliary/brocade_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 require 'msf/core/auxiliary/brocade'
 
 RSpec.describe Msf::Auxiliary::Brocade do
-  class DummyClass
+  class DummyBrocadeClass
     include Msf::Auxiliary::Brocade
     def framework
       Msf::Simple::Framework.create(
@@ -32,32 +32,32 @@ RSpec.describe Msf::Auxiliary::Brocade do
       raise StandardError.new("This method needs to be stubbed.")
     end
   end
-  
-  subject(:aux_brocade) { DummyClass.new }
-  
-  let!(:workspace) { FactoryBot.create(:mdm_workspace) }
-    
+
+  subject(:aux_brocade) { DummyBrocadeClass.new }
+
+  let!(:brocade_workspace) { FactoryBot.create(:mdm_workspace) }
+
   context '#create_credential_and_login' do
-    
+
     let(:session) { FactoryBot.create(:mdm_session) }
 
-    let(:task) { FactoryBot.create(:mdm_task, workspace: workspace)}
+    let(:task) { FactoryBot.create(:mdm_task, workspace: brocade_workspace)}
 
     let(:user) { FactoryBot.create(:mdm_user)}
 
-    subject(:test_object) { DummyClass.new }
-    
+    subject(:test_object) { DummyBrocadeClass.new }
+
     let(:workspace) { FactoryBot.create(:mdm_workspace) }
-    let(:service) { FactoryBot.create(:mdm_service, host: FactoryBot.create(:mdm_host, workspace: workspace)) }
-    let(:task) { FactoryBot.create(:mdm_task, workspace: workspace) }
-    
+    let(:service) { FactoryBot.create(:mdm_service, host: FactoryBot.create(:mdm_host, workspace: brocade_workspace)) }
+    let(:task) { FactoryBot.create(:mdm_task, workspace: brocade_workspace) }
+
     let(:login_data) {
       {
         address: service.host.address,
         port: service.port,
         service_name: service.name,
         protocol: service.proto,
-        workspace_id: workspace.id,
+        workspace_id: brocade_workspace.id,
         origin_type: :service,
         module_fullname: 'auxiliary/scanner/smb/smb_login',
         realm_key: 'Active Directory Domain',
@@ -68,7 +68,7 @@ RSpec.describe Msf::Auxiliary::Brocade do
         status: Metasploit::Model::Login::Status::UNTRIED
       }
     }
-    
+
     it 'creates a Metasploit::Credential::Login' do
       expect{test_object.create_credential_and_login(login_data)}.to change{Metasploit::Credential::Login.count}.by(1)
     end
@@ -80,9 +80,9 @@ RSpec.describe Msf::Auxiliary::Brocade do
 
   context '#brocade_config_eater' do
     before(:example) do
-      expect(aux_brocade).to receive(:myworkspace).at_least(:once).and_return(workspace)
+      expect(aux_brocade).to receive(:myworkspace).at_least(:once).and_return(brocade_workspace)
     end
-    
+
     it 'deals with enable passwords' do
       expect(aux_brocade).to receive(:print_good).with('enable password hash $1$QP3H93Wm$uxYAs2HmAK01QiP3ig5tm.')
       expect(aux_brocade).to receive(:print_bad).with('password-display is disabled, no password hashes displayed in config')
@@ -94,7 +94,7 @@ RSpec.describe Msf::Auxiliary::Brocade do
           address: "127.0.0.1",
           port: 161,
           protocol: "tcp",
-          workspace_id: workspace.id,
+          workspace_id: brocade_workspace.id,
           origin_type: :service,
           service_name: '',
           module_fullname: "auxiliary/scanner/snmp/brocade_dummy",
@@ -118,7 +118,7 @@ RSpec.describe Msf::Auxiliary::Brocade do
           address: "127.0.0.1",
           port: 161,
           protocol: "tcp",
-          workspace_id: workspace.id,
+          workspace_id: brocade_workspace.id,
           origin_type: :service,
           service_name: '',
           module_fullname: "auxiliary/scanner/snmp/brocade_dummy",
@@ -142,7 +142,7 @@ RSpec.describe Msf::Auxiliary::Brocade do
           address: "127.0.0.1",
           port: 161,
           protocol: "udp",
-          workspace_id: workspace.id,
+          workspace_id: brocade_workspace.id,
           origin_type: :service,
           service_name: 'snmp',
           module_fullname: "auxiliary/scanner/snmp/brocade_dummy",
@@ -177,5 +177,5 @@ RSpec.describe Msf::Auxiliary::Brocade do
       aux_brocade.brocade_config_eater('127.0.0.1',161,'snmp-server community 1 ..... rw')
     end
   end
-  
+
 end

--- a/spec/lib/msf/core/auxiliary/brocade_spec.rb
+++ b/spec/lib/msf/core/auxiliary/brocade_spec.rb
@@ -35,21 +35,21 @@ RSpec.describe Msf::Auxiliary::Brocade do
 
   subject(:aux_brocade) { DummyBrocadeClass.new }
 
-  let!(:brocade_workspace) { FactoryBot.create(:mdm_workspace) }
+  let!(:workspace) { FactoryBot.create(:mdm_workspace) }
 
   context '#create_credential_and_login' do
 
     let(:session) { FactoryBot.create(:mdm_session) }
 
-    let(:task) { FactoryBot.create(:mdm_task, workspace: brocade_workspace)}
+    let(:task) { FactoryBot.create(:mdm_task, workspace: workspace)}
 
     let(:user) { FactoryBot.create(:mdm_user)}
 
     subject(:test_object) { DummyBrocadeClass.new }
 
     let(:workspace) { FactoryBot.create(:mdm_workspace) }
-    let(:service) { FactoryBot.create(:mdm_service, host: FactoryBot.create(:mdm_host, workspace: brocade_workspace)) }
-    let(:task) { FactoryBot.create(:mdm_task, workspace: brocade_workspace) }
+    let(:service) { FactoryBot.create(:mdm_service, host: FactoryBot.create(:mdm_host, workspace: workspace)) }
+    let(:task) { FactoryBot.create(:mdm_task, workspace: workspace) }
 
     let(:login_data) {
       {
@@ -57,7 +57,7 @@ RSpec.describe Msf::Auxiliary::Brocade do
         port: service.port,
         service_name: service.name,
         protocol: service.proto,
-        workspace_id: brocade_workspace.id,
+        workspace_id: workspace.id,
         origin_type: :service,
         module_fullname: 'auxiliary/scanner/smb/smb_login',
         realm_key: 'Active Directory Domain',
@@ -80,7 +80,7 @@ RSpec.describe Msf::Auxiliary::Brocade do
 
   context '#brocade_config_eater' do
     before(:example) do
-      expect(aux_brocade).to receive(:myworkspace).at_least(:once).and_return(brocade_workspace)
+      expect(aux_brocade).to receive(:myworkspace).at_least(:once).and_return(workspace)
     end
 
     it 'deals with enable passwords' do
@@ -94,7 +94,7 @@ RSpec.describe Msf::Auxiliary::Brocade do
           address: "127.0.0.1",
           port: 161,
           protocol: "tcp",
-          workspace_id: brocade_workspace.id,
+          workspace_id: workspace.id,
           origin_type: :service,
           service_name: '',
           module_fullname: "auxiliary/scanner/snmp/brocade_dummy",
@@ -118,7 +118,7 @@ RSpec.describe Msf::Auxiliary::Brocade do
           address: "127.0.0.1",
           port: 161,
           protocol: "tcp",
-          workspace_id: brocade_workspace.id,
+          workspace_id: workspace.id,
           origin_type: :service,
           service_name: '',
           module_fullname: "auxiliary/scanner/snmp/brocade_dummy",
@@ -142,7 +142,7 @@ RSpec.describe Msf::Auxiliary::Brocade do
           address: "127.0.0.1",
           port: 161,
           protocol: "udp",
-          workspace_id: brocade_workspace.id,
+          workspace_id: workspace.id,
           origin_type: :service,
           service_name: 'snmp',
           module_fullname: "auxiliary/scanner/snmp/brocade_dummy",

--- a/spec/lib/msf/core/auxiliary/cisco_spec.rb
+++ b/spec/lib/msf/core/auxiliary/cisco_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 require 'msf/core/auxiliary/cisco'
 
 RSpec.describe Msf::Auxiliary::Cisco do
-  class DummyClass
+  class DummyCiscoClass
     include Msf::Auxiliary::Cisco
     def framework
       Msf::Simple::Framework.create(
@@ -29,25 +29,25 @@ RSpec.describe Msf::Auxiliary::Cisco do
       raise StandardError.new("This method needs to be stubbed.")
     end
   end
-  
-  subject(:aux_cisco) { DummyClass.new }
-  
+
+  subject(:aux_cisco) { DummyCiscoClass.new }
+
   let!(:workspace) { FactoryBot.create(:mdm_workspace) }
-    
+
   context '#create_credential_and_login' do
-    
+
     let(:session) { FactoryBot.create(:mdm_session) }
 
     let(:task) { FactoryBot.create(:mdm_task, workspace: workspace)}
 
     let(:user) { FactoryBot.create(:mdm_user)}
 
-    subject(:test_object) { DummyClass.new }
-    
+    subject(:test_object) { DummyCiscoClass.new }
+
     let(:workspace) { FactoryBot.create(:mdm_workspace) }
     let(:service) { FactoryBot.create(:mdm_service, host: FactoryBot.create(:mdm_host, workspace: workspace)) }
     let(:task) { FactoryBot.create(:mdm_task, workspace: workspace) }
-    
+
     let(:login_data) {
       {
         address: service.host.address,
@@ -65,7 +65,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
         status: Metasploit::Model::Login::Status::UNTRIED
       }
     }
-    
+
     it 'creates a Metasploit::Credential::Login' do
       expect{test_object.create_credential_and_login(login_data)}.to change{Metasploit::Credential::Login.count}.by(1)
     end
@@ -74,12 +74,12 @@ RSpec.describe Msf::Auxiliary::Cisco do
       expect(login.tasks).to include(task)
     end
   end
-  
+
   context '#cisco_ios_config_eater' do
     before(:example) do
       expect(aux_cisco).to receive(:myworkspace).at_least(:once).and_return(workspace)
     end
-    
+
     it 'deals with udp ports' do
       expect(aux_cisco).to receive(:print_good).with('127.0.0.1:161 Unencrypted Enable Password: 1511021F0725')
       expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
@@ -102,9 +102,9 @@ RSpec.describe Msf::Auxiliary::Cisco do
       )
       aux_cisco.cisco_ios_config_eater('127.0.0.1',161,'enable password 1511021F0725')
     end
-    
+
     context 'Enable Password|Secret' do
-      
+
       it 'with password type 0' do
         expect(aux_cisco).to receive(:print_good).with('127.0.0.1:1337 Enable Password: 1511021F0725')
         expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
@@ -128,10 +128,10 @@ RSpec.describe Msf::Auxiliary::Cisco do
             status: Metasploit::Model::Login::Status::UNTRIED
           }
         )
-        
+
         aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'enable password 0 1511021F0725')
       end
-      
+
       it 'with password type 5' do
         expect(aux_cisco).to receive(:print_good).with('127.0.0.1:1337 MD5 Encrypted Enable Password: 1511021F0725')
         expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
@@ -152,7 +152,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
         )
         aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'enable password 5 1511021F0725')
       end
-      
+
       it 'with password type 7' do
         expect(aux_cisco).to receive(:print_good).with('127.0.0.1:1337 Decrypted Enable Password: cisco')
         expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
@@ -178,9 +178,9 @@ RSpec.describe Msf::Auxiliary::Cisco do
         )
         aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'enable password 7 1511021F0725')
       end
-      
+
     end
-    
+
     it 'enable password' do
       expect(aux_cisco).to receive(:print_good).with('127.0.0.1:1337 Unencrypted Enable Password: 1511021F0725')
       expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
@@ -203,9 +203,9 @@ RSpec.describe Msf::Auxiliary::Cisco do
       )
       aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'enable password 1511021F0725')
     end
-    
+
     context 'snmp-server community' do
-      
+
       it 'with RO' do
         expect(aux_cisco).to receive(:print_good).with('127.0.0.1:1337 SNMP Community (RO): 1511021F0725')
         expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
@@ -226,7 +226,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
         )
         aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'snmp-server community 1511021F0725 RO')
       end
-      
+
       it 'with RW' do
         expect(aux_cisco).to receive(:print_good).with('127.0.0.1:1337 SNMP Community (RW): 1511021F0725')
         expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
@@ -247,9 +247,9 @@ RSpec.describe Msf::Auxiliary::Cisco do
         )
         aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'snmp-server community 1511021F0725 RW')
       end
-      
+
     end
-    
+
     it 'password 7' do
       expect(aux_cisco).to receive(:print_good).with('127.0.0.1:1337 Decrypted VTY Password: cisco')
       expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
@@ -272,7 +272,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
       )
       aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'password 7 1511021F0725')
     end
-    
+
     it 'password|secret 5' do
       expect(aux_cisco).to receive(:print_good).with('127.0.0.1:1337 MD5 Encrypted VTY Password: 1511021F0725')
       expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
@@ -299,7 +299,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
       )
       aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'password 5 1511021F0725')
     end
-    
+
     it 'password 0' do
       expect(aux_cisco).to receive(:print_good).with('127.0.0.1:1337 Unencrypted VTY Password: 1511021F0725')
       expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
@@ -322,7 +322,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
       )
       aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'password 0 1511021F0725')
     end
-    
+
     it 'password' do
       expect(aux_cisco).to receive(:print_good).with('127.0.0.1:1337 Unencrypted VTY Password: 1511021F0725')
       expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
@@ -345,7 +345,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
       )
       aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'password 1511021F0725')
     end
-    
+
     it 'encryption key' do
       expect(aux_cisco).to receive(:print_good).with('127.0.0.1:1337 Wireless WEP Key: 1511021F0725')
       expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
@@ -357,7 +357,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
       )
       aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'encryption key 777 size 8bit 8 1511021F0725')
     end
-    
+
     context 'wpa-psk' do
       it 'with password type 0' do
         expect(aux_cisco).to receive(:print_good).with('127.0.0.1:1337 Wireless WPA-PSK Password: 1511021F0725')
@@ -384,7 +384,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
         )
         aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'wpa-psk ascii 0 1511021F0725')
       end
-      
+
       it 'with password type 5' do
         expect(aux_cisco).to receive(:print_good).with('127.0.0.1:1337 Wireless WPA-PSK MD5 Password Hash: 1511021F0725')
         expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
@@ -411,7 +411,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
         )
         aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'wpa-psk ascii 5 1511021F0725')
       end
-      
+
       it 'with password type 7' do
         expect(aux_cisco).to receive(:print_good).with('127.0.0.1:1337 Wireless WPA-PSK Decrypted Password: cisco')
         expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
@@ -435,12 +435,12 @@ RSpec.describe Msf::Auxiliary::Cisco do
             status: Metasploit::Model::Login::Status::UNTRIED
           }
         )
-        
+
         aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'wpa-psk ascii 7 1511021F0725')
       end
-            
+
     end
-    
+
     it 'crypto isakmp key' do
       expect(aux_cisco).to receive(:print_good).with("127.0.0.1:1337 VPN IPSEC ISAKMP Key '1511021F0725' Host 'someaddress'")
       expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
@@ -466,7 +466,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
       )
       aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'crypto isakmp key 1511021F0725 address someaddress')
     end
-    
+
     it 'interface tunnel' do
       expect(aux_cisco).to receive(:store_loot).with(
         "cisco.ios.config", "text/plain", "127.0.0.1",  "interface tunnel7", "config.txt", "Cisco IOS Configuration"
@@ -475,7 +475,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
 
       aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'interface tunnel7')
     end
-    
+
     it 'tunnel key' do
       expect(aux_cisco).to receive(:print_good).with("127.0.0.1:1337 GRE Tunnel Key 1511021F0725 for Interface Tunnel ")
       expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
@@ -501,7 +501,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
       )
       aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'tunnel key 1511021F0725')
     end
-    
+
     it 'ip nhrp authentication' do
       expect(aux_cisco).to receive(:print_good).with("127.0.0.1:1337 NHRP Authentication Key 1511021F0725 for Interface Tunnel ")
       expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
@@ -527,7 +527,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
       )
       aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'ip nhrp authentication 1511021F0725')
     end
-    
+
     context 'username privilege secret' do
       it 'with password type 0' do
         expect(aux_cisco).to receive(:print_good).with("127.0.0.1:1337 Username 'someusername' with Password: 1511021F0725")
@@ -556,7 +556,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
 
         aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'username someusername privilege 0 secret 0 1511021F0725')
       end
-      
+
       it 'with password type 5' do
         expect(aux_cisco).to receive(:print_good).with("127.0.0.1:1337 Username 'someusername' with MD5 Encrypted Password: 1511021F0725")
         expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
@@ -586,7 +586,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
         aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'username someusername privilege 0 secret 5 1511021F0725')
       end
 
-    
+
       it 'with password type 7' do
         expect(aux_cisco).to receive(:print_good).with("127.0.0.1:1337 Username 'someusername' with Decrypted Password: cisco")
         expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
@@ -614,7 +614,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
         aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'username someusername privilege 0 secret 7 1511021F0725')
       end
     end
-    
+
     context 'username secret' do
       it 'with password type 0' do
         expect(aux_cisco).to receive(:print_good).with("127.0.0.1:1337 Username 'someusername' with Password: 1511021F0725")
@@ -643,7 +643,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
         )
         aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'username someusername secret 0 1511021F0725')
       end
-      
+
       it 'with password type 5' do
         expect(aux_cisco).to receive(:print_good).with("127.0.0.1:1337 Username 'someusername' with MD5 Encrypted Password: 1511021F0725")
         expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
@@ -673,7 +673,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
         aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'username someusername secret 5 1511021F0725')
       end
 
-    
+
       it 'with password type 7' do
         expect(aux_cisco).to receive(:print_good).with("127.0.0.1:1337 Username 'someusername' with Decrypted Password: cisco")
         expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
@@ -702,7 +702,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
         aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'username someusername secret 7 1511021F0725')
       end
     end
-    
+
     context 'ppp.*username secret' do
       it 'with password type 0' do
         expect(aux_cisco).to receive(:print_good).with("127.0.0.1:1337 PPP Username: someusername Password: 1511021F0725")
@@ -731,7 +731,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
         )
         aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'ppp123username someusername secret 0 1511021F0725')
       end
-      
+
       it 'with password type 5' do
         expect(aux_cisco).to receive(:print_good).with("127.0.0.1:1337 PPP Username someusername MD5 Encrypted Password: 1511021F0725")
         expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
@@ -761,7 +761,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
         aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'ppp123username someusername secret 5 1511021F0725')
       end
 
-    
+
       it 'with password type 7' do
         expect(aux_cisco).to receive(:print_good).with("127.0.0.1:1337 PPP Username: someusername Decrypted Password: cisco")
         expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
@@ -790,7 +790,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
         aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'ppp123username someusername secret 7 1511021F0725')
       end
     end
-    
+
     context 'ppp chap secret' do
       it 'with password type 0' do
         expect(aux_cisco).to receive(:print_good).with("127.0.0.1:1337 Password: 1511021F0725")
@@ -817,7 +817,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
         )
         aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'ppp chap secret 0 1511021F0725')
       end
-      
+
       it 'with password type 5' do
         expect(aux_cisco).to receive(:print_good).with("127.0.0.1:1337 PPP CHAP MD5 Encrypted Password: 1511021F0725")
         expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
@@ -846,7 +846,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
         aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'ppp chap secret 5 1511021F0725')
       end
 
-    
+
       it 'with password type 7' do
         expect(aux_cisco).to receive(:print_good).with("127.0.0.1:1337 PPP Decrypted Password: cisco")
         expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
@@ -873,7 +873,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
         aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'ppp chap secret 7 1511021F0725')
       end
     end
-    
+
   end
-  
+
 end

--- a/spec/lib/msf/core/auxiliary/juniper_spec.rb
+++ b/spec/lib/msf/core/auxiliary/juniper_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 require 'msf/core/auxiliary/juniper'
 
 RSpec.describe Msf::Auxiliary::Juniper do
-  class DummyClass
+  class DummyJuniperClass
     include Msf::Auxiliary::Juniper
     def framework
       Msf::Simple::Framework.create(
@@ -29,25 +29,25 @@ RSpec.describe Msf::Auxiliary::Juniper do
       raise StandardError.new("This method needs to be stubbed.")
     end
   end
-  
-  subject(:aux_juniper) { DummyClass.new }
-  
+
+  subject(:aux_juniper) { DummyJuniperClass.new }
+
   let!(:workspace) { FactoryBot.create(:mdm_workspace) }
-    
+
   context '#create_credential_and_login' do
-    
+
     let(:session) { FactoryBot.create(:mdm_session) }
 
     let(:task) { FactoryBot.create(:mdm_task, workspace: workspace)}
 
     let(:user) { FactoryBot.create(:mdm_user)}
 
-    subject(:test_object) { DummyClass.new }
-    
+    subject(:test_object) { DummyJuniperClass.new }
+
     let(:workspace) { FactoryBot.create(:mdm_workspace) }
     let(:service) { FactoryBot.create(:mdm_service, host: FactoryBot.create(:mdm_host, workspace: workspace)) }
     let(:task) { FactoryBot.create(:mdm_task, workspace: workspace) }
-    
+
     let(:login_data) {
       {
         address: service.host.address,
@@ -65,7 +65,7 @@ RSpec.describe Msf::Auxiliary::Juniper do
         status: Metasploit::Model::Login::Status::UNTRIED
       }
     }
-    
+
     it 'creates a Metasploit::Credential::Login' do
       expect{test_object.create_credential_and_login(login_data)}.to change{Metasploit::Credential::Login.count}.by(1)
     end
@@ -74,12 +74,12 @@ RSpec.describe Msf::Auxiliary::Juniper do
       expect(login.tasks).to include(task)
     end
   end
-  
+
   context '#juniper_screenos_config_eater' do
     before(:example) do
       expect(aux_juniper).to receive(:myworkspace).at_least(:once).and_return(workspace)
     end
-    
+
     it 'deals with admin credentials' do
       expect(aux_juniper).to receive(:print_good).with('Admin user netscreen found with password hash nKVUM2rwMUzPcrkG5sWIHdCtqkAibn')
       expect(aux_juniper).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Juniper ScreenOS'})
@@ -102,7 +102,7 @@ RSpec.describe Msf::Auxiliary::Juniper do
         "set admin name \"netscreen\"\n" <<
         "set admin password \"nKVUM2rwMUzPcrkG5sWIHdCtqkAibn\"\n")
     end
-    
+
     it 'deals with user account with password hash' do
       expect(aux_juniper).to receive(:print_good).with('User 1 named testuser found with password hash 02b0jt2gZGipCiIEgl4eainqZIKzjSNQYLIwE=. Enable permission: enable')
       expect(aux_juniper).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Juniper ScreenOS'})
@@ -129,16 +129,16 @@ RSpec.describe Msf::Auxiliary::Juniper do
           status: Metasploit::Model::Login::Status::UNTRIED
         }
       )
-        
+
       aux_juniper.juniper_screenos_config_eater('127.0.0.1',1337,
         "set user \"testuser\" uid 1\n" <<
         "set user \"testuser\" type auth\n" <<
         "set user \"testuser\" hash-password \"02b0jt2gZGipCiIEgl4eainqZIKzjSNQYLIwE=\"\n" <<
         "set user \"testuser\" enable\n")
     end
-    
+
     context 'deals with snmp-server community' do
-      
+
       it 'with Read permission' do
         expect(aux_juniper).to receive(:print_good).with('SNMP community sales with permissions Read-Only')
         expect(aux_juniper).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Juniper ScreenOS'})
@@ -159,7 +159,7 @@ RSpec.describe Msf::Auxiliary::Juniper do
         )
         aux_juniper.juniper_screenos_config_eater('127.0.0.1',1337,'set snmp community "sales" Read-Only Trap-on traffic version v1')
       end
-      
+
       it 'with Read-Write permission' do
         expect(aux_juniper).to receive(:print_good).with('SNMP community sales with permissions Read-Write')
         expect(aux_juniper).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Juniper ScreenOS'})
@@ -180,9 +180,9 @@ RSpec.describe Msf::Auxiliary::Juniper do
         )
         aux_juniper.juniper_screenos_config_eater('127.0.0.1',1337,'set snmp community "sales" Read-Write Trap-on traffic version v1')
       end
-      
+
     end
-    
+
     it 'deals with ppp configurations' do
       expect(aux_juniper).to receive(:print_good).with('PPTP Profile ISP with username username hash fzSzAn31N4Sbh/sukoCDLvhJEdn0DVK7vA== via pap')
       expect(aux_juniper).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Juniper ScreenOS'})
@@ -214,7 +214,7 @@ RSpec.describe Msf::Auxiliary::Juniper do
         "setppp profile \"ISP\" auth secret \"fzSzAn31N4Sbh/sukoCDLvhJEdn0DVK7vA==\"\n"
       )
     end
-    
+
     it 'deals with ike configurations' do
       expect(aux_juniper).to receive(:print_good).with('IKE Profile To-Cisco to 2.2.2.1 with password netscreen via pre-g2-des-sha')
       expect(aux_juniper).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Juniper ScreenOS'})
@@ -239,14 +239,14 @@ RSpec.describe Msf::Auxiliary::Juniper do
       )
       aux_juniper.juniper_screenos_config_eater('127.0.0.1',1337,'set ike gateway "To-Cisco" address 2.2.2.1 Main outgoing-interface "ethernet1" preshare "netscreen" proposal "pre-g2-des-sha"')
     end
-    
+
   end
-  
+
   context '#juniper_junos_config_eater' do
     before(:example) do
       expect(aux_juniper).to receive(:myworkspace).at_least(:once).and_return(workspace)
     end
-    
+
     it 'deals with root credentials' do
       expect(aux_juniper).to receive(:print_good).with('root password hash: $1$pz9b1.fq$foo5r85Ql8mXdoRUe0C1E.')
       expect(aux_juniper).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Juniper JunOS'})
@@ -278,7 +278,7 @@ RSpec.describe Msf::Auxiliary::Juniper do
         )
       )
     end
-    
+
     context 'deals with user account with password hash' do
       it 'with super-user' do
         expect(aux_juniper).to receive(:print_good).with('User 2000 named newuser in group super-user found with password hash $1$rm8FaMFY$k4LFxqsVAiGO5tKqyO9jJ/.')
@@ -303,7 +303,7 @@ RSpec.describe Msf::Auxiliary::Juniper do
             status: Metasploit::Model::Login::Status::UNTRIED
           }
         )
-        
+
         aux_juniper.juniper_junos_config_eater('127.0.0.1',1337,
           %q(system {
                  login {
@@ -441,9 +441,9 @@ RSpec.describe Msf::Auxiliary::Juniper do
       end
 
     end
-    
+
     context 'deals with snmp-server community' do
-      
+
       it 'with Read permissions' do
         expect(aux_juniper).to receive(:print_good).with('SNMP community read with permissions read-only')
         expect(aux_juniper).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Juniper JunOS'})
@@ -529,9 +529,9 @@ RSpec.describe Msf::Auxiliary::Juniper do
         )
       end
 
-      
+
     end
-    
+
     it 'deals with radius' do
       expect(aux_juniper).to receive(:print_good).with('radius server 1.1.1.1 password hash: $9$Y-4GikqfF39JGCu1Ileq.PQ6AB1hrlMBIyKvWdV')
       expect(aux_juniper).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Juniper JunOS'})
@@ -562,7 +562,7 @@ RSpec.describe Msf::Auxiliary::Juniper do
         )
       )
     end
-    
+
     it 'deals with pap' do
       expect(aux_juniper).to receive(:print_good).with('PPTP username \'pap_username\' hash $9$he4revM87-dsevm5TQCAp0BErvLxd4JDNdkPfT/9BIR via PAP')
       expect(aux_juniper).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Juniper JunOS'})
@@ -604,7 +604,7 @@ RSpec.describe Msf::Auxiliary::Juniper do
        )
       )
     end
-    
+
   end
 
 


### PR DESCRIPTION
It seems that the 'DummyClass' definition between three tests was somehow getting shared, and whether it mattered used to depend on test order. This defines a unique Dummy*Class for each test so we don't end up creating creds with the wrong module name depending on which one ran first.

## Verification

List the steps needed to make sure this thing works

- [x] Run  `rspec --seed 29418 spec/lib/msf/core/auxiliary/`
- [x] **Verify** all of the tests pass
- [x] **Verify** all of the Travis tests pass
