### PR TITLE
fix nil check in atutor module

### DIFF
--- a/modules/exploits/multi/http/atutor_sqli.rb
+++ b/modules/exploits/multi/http/atutor_sqli.rb
@@ -157,10 +157,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'search' => 'Search'
       },
     })
-    if res.nil?
-      return ''
-    end
-    res.body
+    res ? res.body : ''
   end
 
    def dump_the_hash
@@ -237,7 +234,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     print_status("Dumping the username and password hash...")
     credz = dump_the_hash
-    if credz
+    if credz && credz != []
       print_good("Got the #{credz[0]}'s hash: #{credz[1]} !")
       admin_cookie = login(credz[0], credz[1])
       if upload_shell(admin_cookie)

--- a/modules/exploits/multi/http/atutor_sqli.rb
+++ b/modules/exploits/multi/http/atutor_sqli.rb
@@ -157,7 +157,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'search' => 'Search'
       },
     })
-    return res.body
+    return '' if res.nil? else res.body
   end
 
    def dump_the_hash

--- a/modules/exploits/multi/http/atutor_sqli.rb
+++ b/modules/exploits/multi/http/atutor_sqli.rb
@@ -234,12 +234,13 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     print_status("Dumping the username and password hash...")
     credz = dump_the_hash
-    if credz && credz != []
-      print_good("Got the #{credz[0]}'s hash: #{credz[1]} !")
-      admin_cookie = login(credz[0], credz[1])
-      if upload_shell(admin_cookie)
-        exec_code
-      end
+    if credz.nil? || credz.empty?
+      fail_with(Failure::NotVulnerable, 'Failed to retrieve username and password hash')
+    end
+    print_good("Got the #{credz[0]}'s hash: #{credz[1]} !")
+    admin_cookie = login(credz[0], credz[1])
+    if upload_shell(admin_cookie)
+      exec_code
     end
   end
 end

--- a/modules/exploits/multi/http/atutor_sqli.rb
+++ b/modules/exploits/multi/http/atutor_sqli.rb
@@ -157,7 +157,10 @@ class MetasploitModule < Msf::Exploit::Remote
         'search' => 'Search'
       },
     })
-    return '' if res.nil? else res.body
+    if res.nil?
+      return ''
+    end
+    res.body
   end
 
    def dump_the_hash


### PR DESCRIPTION
Fixes #12357 

This fixes the `nil` to return a string.  However, there are unknown consequences later on in the code for doing such.  @SelfLeaker can you please verify that this fixes the issue and doesn't make the module do something crazy?  May need to just bail out of the module instead of passing back an empty string (which is my hunch).

## Verification


- [ ] Start `msfconsole`
- [ ] use exploit/multi/http/atutor_sqli
- [ ] set targeturi /Atutor/
- [ ] set rhost insert_remote_ip_address_here
- [ ] set rport 80
- [ ] exploit
- [ ] you don't see `Exploit failed: NoMethodError undefined method 'body' for nil:NilClass`
