### PR TITLE
Don't be lazy and spell out "introduction" in docs

### DIFF
--- a/documentation/modules/auxiliary/admin/cisco/cisco_dcnm_download.md
+++ b/documentation/modules/auxiliary/admin/cisco/cisco_dcnm_download.md
@@ -1,4 +1,4 @@
-## Intro
+## Introduction
 
 Cisco Data Center Network Manager exposes a servlet to download files on /fm/downloadServlet.
 An authenticated user can abuse this servlet to download arbitrary files as root by specifying

--- a/documentation/modules/auxiliary/admin/wemo/crockpot.md
+++ b/documentation/modules/auxiliary/admin/wemo/crockpot.md
@@ -1,4 +1,4 @@
-## Intro
+## Introduction
 
 This module acts as a simple remote control for Belkin Wemo-enabled
 Crock-Pots by implementing a subset of the functionality provided by the

--- a/documentation/modules/auxiliary/gather/nis_bootparamd_domain.md
+++ b/documentation/modules/auxiliary/gather/nis_bootparamd_domain.md
@@ -1,4 +1,4 @@
-## Intro
+## Introduction
 
 From the `bootparamd(8)` man page:
 

--- a/documentation/modules/auxiliary/gather/nis_ypserv_map.md
+++ b/documentation/modules/auxiliary/gather/nis_ypserv_map.md
@@ -1,4 +1,4 @@
-## Intro
+## Introduction
 
 If you've worked with old Unix systems before, you've probably
 encountered NIS (Network Information Service). The most familiar way of

--- a/documentation/modules/auxiliary/gather/qnap_backtrace_admin_hash.md
+++ b/documentation/modules/auxiliary/gather/qnap_backtrace_admin_hash.md
@@ -1,4 +1,4 @@
-## Intro
+## Introduction
 
 This is going to be a quick rundown of how to use this module to
 retrieve the admin hash from a vulnerable QNAP device.

--- a/documentation/modules/auxiliary/scanner/h323/h323_version.md
+++ b/documentation/modules/auxiliary/scanner/h323/h323_version.md
@@ -1,4 +1,4 @@
-## Intro
+## Introduction
 
 This module scans for h.323 servers and determines the version and information about the server. 
 

--- a/documentation/modules/auxiliary/scanner/http/backup_file.md
+++ b/documentation/modules/auxiliary/scanner/http/backup_file.md
@@ -1,4 +1,4 @@
-## Intro
+## Introduction
 
 This module scans a web server for a file name with various backup type extensions.
 The list of extensions are:

--- a/documentation/modules/auxiliary/scanner/http/docker_version.md
+++ b/documentation/modules/auxiliary/scanner/http/docker_version.md
@@ -1,4 +1,4 @@
-## Intro
+## Introduction
 
 This module scans for Docker servers listening on a TCP port (default 2375).
 

--- a/documentation/modules/auxiliary/scanner/http/enum_wayback.md
+++ b/documentation/modules/auxiliary/scanner/http/enum_wayback.md
@@ -1,4 +1,4 @@
-## Intro
+## Introduction
 
 This module pulls and parses the URLs stored by Archive.org for the purpose of replaying
 during a web assessment. Finding unlinked and old pages.  This module utilizes

--- a/documentation/modules/auxiliary/scanner/http/joomla_pages.md
+++ b/documentation/modules/auxiliary/scanner/http/joomla_pages.md
@@ -1,4 +1,4 @@
-## Intro
+## Introduction
 
 This module scans for Joomla Content Management System running on a web server for the following pages:
 

--- a/documentation/modules/auxiliary/scanner/http/joomla_plugins.md
+++ b/documentation/modules/auxiliary/scanner/http/joomla_plugins.md
@@ -1,4 +1,4 @@
-## Intro
+## Introduction
 
 This module scans for Joomla Content Management System running on a web server for components/plugins.
 The list can be found in [data/wordlists/joomla.txt](https://github.com/rapid7/metasploit-framework/blob/master/data/wordlists/joomla.txt). 

--- a/documentation/modules/auxiliary/scanner/http/joomla_version.md
+++ b/documentation/modules/auxiliary/scanner/http/joomla_version.md
@@ -1,4 +1,4 @@
-## Intro
+## Introduction
 
 This module scans for Joomla Content Management System running on a web server.
 

--- a/documentation/modules/auxiliary/scanner/ssh/fortinet_backdoor.md
+++ b/documentation/modules/auxiliary/scanner/ssh/fortinet_backdoor.md
@@ -1,4 +1,4 @@
-## Intro
+## Introduction
 
 This module scans for the Fortinet SSH backdoor and creates sessions.
 

--- a/documentation/modules/auxiliary/scanner/ssh/libssh_auth_bypass.md
+++ b/documentation/modules/auxiliary/scanner/ssh/libssh_auth_bypass.md
@@ -1,4 +1,4 @@
-## Intro
+## Introduction
 
 This module exploits an authentication bypass in libssh server code
 where a `USERAUTH_SUCCESS` message is sent in place of the expected

--- a/documentation/modules/auxiliary/scanner/ssh/ssh_enumusers.md
+++ b/documentation/modules/auxiliary/scanner/ssh/ssh_enumusers.md
@@ -1,4 +1,4 @@
-## Intro
+## Introduction
 
 This module uses a malformed packet or timing attack to enumerate users on
 an OpenSSH server.

--- a/documentation/modules/auxiliary/sqli/openemr/openemr_sqli_dump.md
+++ b/documentation/modules/auxiliary/sqli/openemr/openemr_sqli_dump.md
@@ -1,4 +1,4 @@
-## Intro
+## Introduction
 
 This module exploits a SQLi vulnerability found in
 OpenEMR version 5.0.1 Patch 6 and lower. The

--- a/documentation/modules/evasion/windows/applocker_evasion_install_util.md
+++ b/documentation/modules/evasion/windows/applocker_evasion_install_util.md
@@ -1,4 +1,4 @@
-## Intro
+## Introduction
 
 This module is designed to evade solutions such as software restriction policies and Applocker.
 Applocker in its default configuration will block code in the form of executables (.exe and .com, .msi), scripts (.ps1, .vbs, .js) and dll's from running in user controlled directories.

--- a/documentation/modules/evasion/windows/applocker_evasion_msbuild.md
+++ b/documentation/modules/evasion/windows/applocker_evasion_msbuild.md
@@ -1,4 +1,4 @@
-## Intro
+## Introduction
 
 This module is designed to evade solutions such as software restriction policies and Applocker.
 Applocker in its default configuration will block code in the form of executables (.exe and .com, .msi), scripts (.ps1, .vbs, .js) and dll's from running in user controlled directories.

--- a/documentation/modules/evasion/windows/applocker_evasion_presentationhost.md
+++ b/documentation/modules/evasion/windows/applocker_evasion_presentationhost.md
@@ -1,4 +1,4 @@
-## Intro
+## Introduction
 
 This module is designed to evade solutions such as software restriction policies and Applocker.
 Applocker in its default configuration will block code in the form of executables (.exe and .com, .msi), scripts (.ps1, .vbs, .js) and dll's from running in user controlled directories.

--- a/documentation/modules/evasion/windows/applocker_evasion_regasm_regsvcs.md
+++ b/documentation/modules/evasion/windows/applocker_evasion_regasm_regsvcs.md
@@ -1,4 +1,4 @@
-## Intro
+## Introduction
 
 This module is designed to evade solutions such as software restriction policies and Applocker.
 Applocker in its default configuration will block code in the form of executables (.exe and .com, .msi), scripts (.ps1, .vbs, .js) and dll's from running in user controlled directories.

--- a/documentation/modules/evasion/windows/applocker_evasion_workflow_compiler.md
+++ b/documentation/modules/evasion/windows/applocker_evasion_workflow_compiler.md
@@ -1,4 +1,4 @@
-## Intro
+## Introduction
 
 This module is designed to evade solutions such as software restriction policies and Applocker.
 Applocker in its default configuration will block code in the form of executables (.exe and .com, .msi), scripts (.ps1, .vbs, .js) and dll's from running in user controlled directories.

--- a/documentation/modules/exploit/android/local/put_user_vroot.md
+++ b/documentation/modules/exploit/android/local/put_user_vroot.md
@@ -1,4 +1,4 @@
-## Intro
+## Introduction
 
 This modules exploits a vulnerability in the linux kernel on an Android device, which allows an untrusted app to elevate to root priviledges. On Android an application normally runs as an individual linux user, sandboxing it from the Android system and other applications. After running the exploit the resulting session has full priviledge on the device, and can access the entire filesystem and the private data files of every other app, including system apps.
 

--- a/documentation/modules/exploit/bsd/finger/morris_fingerd_bof.md
+++ b/documentation/modules/exploit/bsd/finger/morris_fingerd_bof.md
@@ -1,4 +1,4 @@
-## Intro
+## Introduction
 
 This module exploits a stack buffer overflow in `fingerd` on 4.3BSD.
 This vulnerability was exploited by the Morris worm in 1988-11-02.

--- a/documentation/modules/exploit/linux/http/cisco_rv32x_rce.md
+++ b/documentation/modules/exploit/linux/http/cisco_rv32x_rce.md
@@ -1,4 +1,4 @@
-## Intro
+## Introduction
 This module automatically exploits two vulnerabilities to create an effectively
 unauthenticated remote code execution on RV320 and RV325 routers.
 

--- a/documentation/modules/exploit/linux/http/cisco_ucs_rce.md
+++ b/documentation/modules/exploit/linux/http/cisco_ucs_rce.md
@@ -1,4 +1,4 @@
-## Intro
+## Introduction
 
 The Cisco UCS Director virtual appliance contains two flaws that can be combined
 and abused by an attacker to achieve remote code execution as root.

--- a/documentation/modules/exploit/linux/http/hp_van_sdn_cmd_inject.md
+++ b/documentation/modules/exploit/linux/http/hp_van_sdn_cmd_inject.md
@@ -1,4 +1,4 @@
-## Intro
+## Introduction
 
 This module exploits a hardcoded service token or default credentials in
 HPE VAN SDN Controller <= 2.7.18.0503 to execute a payload as root.

--- a/documentation/modules/exploit/linux/http/nagios_xi_chained_rce.md
+++ b/documentation/modules/exploit/linux/http/nagios_xi_chained_rce.md
@@ -1,4 +1,4 @@
-## Intro
+## Introduction
 
 Nagios XI is the enterprise version of Nagios, the monitoring software we love
 and hate.

--- a/documentation/modules/exploit/linux/ssh/cisco_ucs_scpuser.md
+++ b/documentation/modules/exploit/linux/ssh/cisco_ucs_scpuser.md
@@ -1,4 +1,4 @@
-## Intro
+## Introduction
 
 This module abuses a known default password on Cisco UCS Director. The 'scpuser'
 has the password of 'scpuser', and allows an attacker to login to the virtual appliance

--- a/documentation/modules/exploit/linux/telnet/netgear_telnetenable.md
+++ b/documentation/modules/exploit/linux/telnet/netgear_telnetenable.md
@@ -1,4 +1,4 @@
-## Intro
+## Introduction
 
 Several models of Netgear devices have a hidden telnet daemon that can be
 enabled for remote LAN users by sending a 'magic packet' to the device. 

--- a/documentation/modules/exploit/linux/upnp/belkin_wemo_upnp_exec.md
+++ b/documentation/modules/exploit/linux/upnp/belkin_wemo_upnp_exec.md
@@ -1,4 +1,4 @@
-## Intro
+## Introduction
 
 This module exploits a command injection in the Belkin Wemo UPnP API via
 the `SmartDevURL` argument to the `SetSmartDevInfo` action.

--- a/documentation/modules/exploit/multi/fileformat/ghostscript_failed_restore.md
+++ b/documentation/modules/exploit/multi/fileformat/ghostscript_failed_restore.md
@@ -1,4 +1,4 @@
-## Intro
+## Introduction
 
 This module exploits a `-dSAFER` bypass in Ghostscript to execute
 arbitrary commands by handling a failed `restore` (`grestore`) in

--- a/documentation/modules/exploit/multi/http/cisco_dcnm_upload_2019.md
+++ b/documentation/modules/exploit/multi/http/cisco_dcnm_upload_2019.md
@@ -1,4 +1,4 @@
-## Intro
+## Introduction
 
 Cisco Data Center Network Manager exposes a file upload servlet (FileUploadServlet) at /fm/fileUpload.
 An authenticated user can abuse this servlet to upload a WAR to the Apache Tomcat webapps

--- a/documentation/modules/exploit/multi/http/jenkins_metaprogramming.md
+++ b/documentation/modules/exploit/multi/http/jenkins_metaprogramming.md
@@ -1,4 +1,4 @@
-## Intro
+## Introduction
 
 This module exploits a vulnerability in Jenkins dynamic routing to
 bypass the `Overall/Read` ACL and leverage Groovy metaprogramming to

--- a/documentation/modules/exploit/multi/http/rails_dynamic_render_code_exec.md
+++ b/documentation/modules/exploit/multi/http/rails_dynamic_render_code_exec.md
@@ -1,4 +1,4 @@
-## Intro
+## Introduction
 
 Rails is a web application development framework written in the Ruby language. It is designed to make programming web applications easier by making assumptions about what every developer needs to get started. It allows you to write less code while accomplishing more than many other languages and frameworks.
 

--- a/documentation/modules/exploit/unix/local/emacs_movemail.md
+++ b/documentation/modules/exploit/unix/local/emacs_movemail.md
@@ -1,4 +1,4 @@
-## Intro
+## Introduction
 
 This module exploits a SUID installation of the Emacs `movemail` utility
 to run a command as root by writing to 4.3BSD's `/usr/lib/crontab.local`.

--- a/documentation/modules/exploit/unix/smtp/morris_sendmail_debug.md
+++ b/documentation/modules/exploit/unix/smtp/morris_sendmail_debug.md
@@ -1,4 +1,4 @@
-## Intro
+## Introduction
 
 This module exploits `sendmail`'s well-known historical debug mode to
 escape to a shell and execute commands in the SMTP `RCPT TO` command.

--- a/documentation/modules/exploit/unix/webapp/drupal_drupalgeddon2.md
+++ b/documentation/modules/exploit/unix/webapp/drupal_drupalgeddon2.md
@@ -1,4 +1,4 @@
-## Intro
+## Introduction
 
 This module exploits a Drupal property injection in the Forms API.
 Drupal 6.x, < 7.58, 8.2.x, < 8.3.9, < 8.4.6, and < 8.5.1 are vulnerable.

--- a/documentation/modules/exploit/unix/webapp/drupal_restws_unserialize.md
+++ b/documentation/modules/exploit/unix/webapp/drupal_restws_unserialize.md
@@ -1,4 +1,4 @@
-## Intro
+## Introduction
 
 This module exploits a PHP `unserialize()` vulnerability in Drupal RESTful
 Web Services by sending a crafted request to the `/node` REST endpoint.

--- a/documentation/modules/exploit/unix/webapp/jquery_file_upload.md
+++ b/documentation/modules/exploit/unix/webapp/jquery_file_upload.md
@@ -1,4 +1,4 @@
-## Intro
+## Introduction
 
 This module exploits an arbitrary file upload in the sample PHP upload
 handler for blueimp's jQuery File Upload widget in versions <= 9.22.0.

--- a/documentation/modules/exploit/unix/webapp/webmin_backdoor.md
+++ b/documentation/modules/exploit/unix/webapp/webmin_backdoor.md
@@ -1,4 +1,4 @@
-## Intro
+## Introduction
 
 This module exploits a backdoor in Webmin versions 1.890 through 1.920.
 Only the SourceForge downloads were backdoored, but they are listed as

--- a/documentation/modules/exploit/unix/webapp/wp_phpmailer_host_header.md
+++ b/documentation/modules/exploit/unix/webapp/wp_phpmailer_host_header.md
@@ -1,4 +1,4 @@
-## Intro
+## Introduction
 
 This vuln has some caveats: you need approximately WordPress 4.6 with
 Exim for the `sendmail(8)` command. You do not need to install

--- a/documentation/modules/exploit/windows/local/bypassuac_comhijack.md
+++ b/documentation/modules/exploit/windows/local/bypassuac_comhijack.md
@@ -1,4 +1,4 @@
-## Intro
+## Introduction
 
 This module will bypass UAC on Windows 7 through to 10 RS3 by hijacking a COM Class ID
 that is located in the current user hive. This key contains a reference to a DLL that

--- a/documentation/modules/exploit/windows/local/bypassuac_fodhelper.md
+++ b/documentation/modules/exploit/windows/local/bypassuac_fodhelper.md
@@ -1,4 +1,4 @@
-## Intro
+## Introduction
 
   This module will bypass Windows 10 UAC by hijacking a special key in the Registry under
   the current user hive, and inserting a custom command that will get invoked when

--- a/documentation/modules/exploit/windows/local/bypassuac_silentcleanup.md
+++ b/documentation/modules/exploit/windows/local/bypassuac_silentcleanup.md
@@ -1,4 +1,4 @@
-## Intro
+## Introduction
 
 This module will bypass UAC on any Windows installation with Powershell installed. 
 

--- a/documentation/modules/exploit/windows/local/bypassuac_sluihijack.md
+++ b/documentation/modules/exploit/windows/local/bypassuac_sluihijack.md
@@ -1,4 +1,4 @@
-## Intro
+## Introduction
 
   This module will bypass UAC on Windows 8-10 by hijacking a special key in the Registry under
   the Current User hive, and inserting a custom command that will get invoked when

--- a/documentation/modules/exploit/windows/local/bypassuac_windows_store_reg.md
+++ b/documentation/modules/exploit/windows/local/bypassuac_windows_store_reg.md
@@ -1,4 +1,4 @@
-## Intro
+## Introduction
 
 This module exploits a flaw in the WSReset.exe Windows Store Reset Tool. The tool
 is run with the "autoElevate" property set to true, and it will automatically

--- a/documentation/modules/exploit/windows/local/ms16_014_wmi_recv_notif.md
+++ b/documentation/modules/exploit/windows/local/ms16_014_wmi_recv_notif.md
@@ -1,4 +1,4 @@
-## Intro
+## Introduction
 
 This module exploits an uninitialized stack variable vulnerability
 present in the WMI subsystem  of `ntoskrnl`.  The vulnerability is

--- a/documentation/modules/exploit/windows/local/ms16_016_webdav.md
+++ b/documentation/modules/exploit/windows/local/ms16_016_webdav.md
@@ -1,4 +1,4 @@
-## Intro
+## Introduction
 
 This module exploits a null pointer dereference vulnerability present in the `mrxdav.sys` kernel driver on Windows 7 x86.  The vulnerability is described by MS16-016 and CVE-2016-0051.  The module allows the user to spawn a new payload, such as meterpreter, on the target system with elevated privileges (NT AUTHORITY\SYSTEM)
 

--- a/documentation/modules/exploit/windows/local/ms16_075_reflection.md
+++ b/documentation/modules/exploit/windows/local/ms16_075_reflection.md
@@ -1,4 +1,4 @@
-## Intro
+## Introduction
   This module will abuse the SeImperonsate privilege commonly found in 
 services due to the requirement to impersonate a client upon 
 authentication. As such it is possible to impersonate the SYSTEM account 

--- a/documentation/modules/exploit/windows/local/ms16_075_reflection_juicy.md
+++ b/documentation/modules/exploit/windows/local/ms16_075_reflection_juicy.md
@@ -1,4 +1,4 @@
-## Intro
+## Introduction
 
 This module utilizes the Net-NTLMv2 reflection between DCOM/RPC to achieve a SYSTEM handle for elevation of privilege. It needs a CLSID to function, a list of which can be found here: https://github.com/ohpe/juicy-potato/blob/master/CLSID/README.md
 

--- a/documentation/modules/exploit/windows/local/ms16_reflection.md
+++ b/documentation/modules/exploit/windows/local/ms16_reflection.md
@@ -1,4 +1,4 @@
-## Intro
+## Introduction
   This module will abuse the SeImperonsate privilege commonly found in 
 services due to the requirement to impersonate a client upon 
 authentication. As such it is possible to impersonate the SYSTEM account 

--- a/documentation/modules/post/osx/manage/sonic_pi.md
+++ b/documentation/modules/post/osx/manage/sonic_pi.md
@@ -1,4 +1,4 @@
-## Intro
+## Introduction
 
 This module controls Sonic Pi via its local OSC server.
 

--- a/documentation/modules/post/windows/gather/credentials/purevpn_cred_collector.md
+++ b/documentation/modules/post/windows/gather/credentials/purevpn_cred_collector.md
@@ -1,4 +1,4 @@
-# Intro
+# Introduction
 
 This module allows you to collect login information for PureVPN client, specifically the `login.conf` file.
 


### PR DESCRIPTION
This was unfortunately my doing, and then people copied me.

I suspect I didn't spell out the word because I half-assed my first module doc (sorry, @h00die). Spelling things out is better for formal docs, especially when there are non-native readers.