### PR TITLE
Fix stack_adjustment nil bug and refactor method

### DIFF
--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -800,30 +800,32 @@ class Exploit < Msf::Module
   end
 
   #
-  # This method returns the number of bytes that should be adjusted to the
+  # This method returns the encoded instruction(s) required to adjust the
   # stack pointer prior to executing any code.  The number of bytes to adjust
   # is indicated to the routine through the payload 'StackAdjustment'
   # attribute or through a target's payload 'StackAdjustment' attribute.
   #
   def stack_adjustment
-    if (target and target.payload_stack_adjustment)
+    if target && target.payload_stack_adjustment
       adj = target.payload_stack_adjustment
     else
       adj = payload_info['StackAdjustment']
     end
 
+    return '' unless adj
+
     # Get the architecture for the current target or use the one specific to
     # this exploit
-    arch = (target and target.arch) ? target.arch : self.arch
+    arch = (target && target.arch) ? target.arch : self.arch
 
     # Default to x86 if we can't find a list of architectures
-    if (arch and arch.empty? == false)
-      arch = arch.join(", ")
+    if arch && !arch.empty?
+      arch = [arch].flatten.join(', ')
     else
       arch = 'x86'
     end
 
-    (adj != nil) ? Rex::Arch::adjust_stack_pointer(arch, adj) || '' : ''
+    Rex::Arch::adjust_stack_pointer(arch, adj) || ''
   end
 
   #


### PR DESCRIPTION
Also fix incorrect docs.

This bug appears to be a Heisenbug, and it triggers infrequently for me due to as yet unknown reasons.

```
msf5 exploit(windows/smb/doublepulsar_rce) > run

From: /rapid7/metasploit-framework/lib/msf/core/exploit.rb @ line 819 Msf::Exploit#stack_adjustment:

    808: def stack_adjustment
    809:   if (target and target.payload_stack_adjustment)
    810:     adj = target.payload_stack_adjustment
    811:   else
    812:     adj = payload_info['StackAdjustment']
    813:   end
    814:
    815:   # Get the architecture for the current target or use the one specific to
    816:   # this exploit
    817:   arch = (target and target.arch) ? target.arch : self.arch
    818:
 => 819:   require 'pry'; binding.pry
    820:
    821:   # Default to x86 if we can't find a list of architectures
    822:   if (arch and arch.empty? == false)
    823:     arch = arch.join(", ")
    824:   else
    825:     arch = 'x86'
    826:   end
    827:
    828:   (adj != nil) ? Rex::Arch::adjust_stack_pointer(arch, adj) || '' : ''
    829: end

[1] pry(#<Msf::Modules::Exploit__Windows__Smb__Doublepulsar_rce::MetasploitModule>)> arch
=> "x64"
[2] pry(#<Msf::Modules::Exploit__Windows__Smb__Doublepulsar_rce::MetasploitModule>)>

[-] 192.168.56.115:445 - Exploit failed: undefined method `join' for "x64":String
[*] Exploit completed, but no session was created.
msf5 exploit(windows/smb/doublepulsar_rce) >
```

#12374