### PR TITLE
Add Required Signature Detection To smb_version

### DIFF
--- a/lib/rex/proto/smb/client.rb
+++ b/lib/rex/proto/smb/client.rb
@@ -57,9 +57,10 @@ NTLM_UTILS = Rex::Proto::NTLM::Utils
     self.send_ntlm  = true
 
     # Signing
-    self.sequence_counter = 0
-    self.signing_key      = ''
-    self.require_signing  = false
+    self.sequence_counter     = 0
+    self.signing_key          = ''
+    self.require_signing      = false
+    self.peer_require_signing = false
 
     #Misc
     self.spnopt = {}
@@ -585,7 +586,8 @@ NTLM_UTILS = Rex::Proto::NTLM::Utils
 
     #set require_signing
     if (ack['Payload'].v['SecurityMode'] & 0x08 != 0)
-      self.require_signing	= true
+      self.require_signing = true
+      self.peer_require_signing = true
     end
 
     # Set the challenge key
@@ -839,12 +841,12 @@ NTLM_UTILS = Rex::Proto::NTLM::Utils
   def session_setup_with_ntlmssp(user = '', pass = '', domain = '', name = nil, do_recv = true)
 
     ntlm_options = {
-        :signing 		=> self.require_signing,
-        :usentlm2_session 	=> self.usentlm2_session,
-        :use_ntlmv2 		=> self.use_ntlmv2,
-        :send_lm 		=> self.send_lm,
-        :send_ntlm		=> self.send_ntlm,
-        :use_lanman_key		=> self.use_lanman_key
+        :signing          => self.require_signing,
+        :usentlm2_session => self.usentlm2_session,
+        :use_ntlmv2       => self.use_ntlmv2,
+        :send_lm          => self.send_lm,
+        :send_ntlm        => self.send_ntlm,
+        :use_lanman_key   => self.use_lanman_key
         }
 
     ntlmssp_flags = NTLM_UTILS.make_ntlm_flags(ntlm_options)
@@ -2079,8 +2081,8 @@ NTLM_UTILS = Rex::Proto::NTLM::Utils
 
   
 # public read/write methods
-  attr_accessor	:native_os, :native_lm, :encrypt_passwords, :extended_security, :read_timeout, :evasion_opts
-  attr_accessor	:verify_signature, :use_ntlmv2, :usentlm2_session, :send_lm, :use_lanman_key, :send_ntlm
+  attr_accessor :native_os, :native_lm, :encrypt_passwords, :extended_security, :read_timeout, :evasion_opts
+  attr_accessor :verify_signature, :use_ntlmv2, :usentlm2_session, :send_lm, :use_lanman_key, :send_ntlm
   attr_accessor :system_time, :system_zone
   attr_accessor :spnopt
   attr_accessor :default_max_buffer_size
@@ -2091,7 +2093,7 @@ NTLM_UTILS = Rex::Proto::NTLM::Utils
   attr_reader		:multiplex_id, :last_tree_id, :last_file_id, :process_id, :last_search_id
   attr_reader		:dns_host_name, :dns_domain_name
   attr_reader		:security_mode, :server_guid
-  attr_reader		:sequence_counter,:signing_key, :require_signing
+  attr_reader		:sequence_counter,:signing_key, :require_signing, :peer_require_signing
 
 # private write methods
   attr_writer		:dialect, :session_id, :challenge_key, :peer_native_lm, :peer_native_os
@@ -2099,7 +2101,7 @@ NTLM_UTILS = Rex::Proto::NTLM::Utils
   attr_writer		:dns_host_name, :dns_domain_name
   attr_writer		:multiplex_id, :last_tree_id, :last_file_id, :process_id, :last_search_id
   attr_writer		:security_mode, :server_guid
-  attr_writer		:sequence_counter,:signing_key, :require_signing
+  attr_writer		:sequence_counter,:signing_key, :require_signing, :peer_require_signing
 
   attr_accessor	:socket
 

--- a/modules/auxiliary/scanner/smb/smb_version.rb
+++ b/modules/auxiliary/scanner/smb/smb_version.rb
@@ -121,6 +121,12 @@ class MetasploitModule < Msf::Auxiliary
           match_conf['host.domain'] = conf[:SMBDomain]
         end
 
+        if simple.client.require_signing
+          desc << " (signatures:required)"
+        else
+          desc << " (signatures:optional)"
+        end
+
         print_good("Host is running #{desc}")
 
         # Report the service with a friendly banner
@@ -141,6 +147,19 @@ class MetasploitModule < Msf::Auxiliary
           :ntype => 'fingerprint.match',
           :data  => match_conf
         )
+
+        unless simple.client.require_signing
+          report_vuln({
+            :host  => ip,
+            :port  => rport,
+            :proto => 'tcp',
+            :name  => 'SMB Signing Is Not Required',
+            :refs  => [
+              SiteReference.new('URL', 'https://support.microsoft.com/en-us/help/161372/how-to-enable-smb-signing-in-windows-nt'),
+              SiteReference.new('URL', 'https://support.microsoft.com/en-us/help/887429/overview-of-server-message-block-signing'),
+            ]
+          })
+        end
       else
         desc = "#{res['native_os']} (#{res['native_lm']})"
         report_service(:host => ip, :port => rport, :name => 'smb', :info => desc)

--- a/modules/auxiliary/scanner/smb/smb_version.rb
+++ b/modules/auxiliary/scanner/smb/smb_version.rb
@@ -121,7 +121,7 @@ class MetasploitModule < Msf::Auxiliary
           match_conf['host.domain'] = conf[:SMBDomain]
         end
 
-        if simple.client.require_signing
+        if simple.client.peer_require_signing
           desc << " (signatures:required)"
         else
           desc << " (signatures:optional)"


### PR DESCRIPTION
This pull request adds a piece of information to the `smb_version` module to identify whether or not signatures are required for incoming connections to the target host. This piece of information is valuable as it tells attackers whether or not the can relay connections to this host.

The existing `require_signing` attribute is a flag that effectively indicates whether or not the connection should use signing. As such it is toggled on and off as appropriately determined by Metasploit. To store the server's original setting, I added the `peer_require_signing` attribute, which this module uses.

## Verification
- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/smb/smb_version`
- [x] Set `RHOSTS` to a host with or without SMB signing
- [x] Run the module
- [x] See the details of whether or not SMB signing is rquired
- [x] If SMB signing is not required, see a vulnerability added to the database with the `vuln` command

## Example

```
metasploit-framework (S:0 J:1) auxiliary(scanner/smb/smb_version) > run

[+] [2019.10.02-20:20:47] 192.168.90.10:445     - Host is running Windows 7 Ultimate SP1 (build:7601) (name:WINDOWS7-PC) (workgroup:WORKGROUP ) (signatures:required)
[*] [2019.10.02-20:20:48] 192.168.90.10-11:445  - Scanned 1 of 2 hosts (50% complete)
[+] [2019.10.02-20:20:48] 192.168.90.11:445     - Host is running Windows 2008 R2 Enterprise SP1 (build:7601) (name:WIN-PAQ5DUNM17A) (workgroup:WORKGROUP ) (signatures:required)
[*] [2019.10.02-20:20:48] 192.168.90.10-11:445  - Scanned 2 of 2 hosts (100% complete)
[*] Auxiliary module execution completed
```
