### PR TITLE
Spelling correction in iis_shortname_scanner.rb

### DIFF
--- a/modules/auxiliary/scanner/http/iis_shortname_scanner.rb
+++ b/modules/auxiliary/scanner/http/iis_shortname_scanner.rb
@@ -16,7 +16,7 @@ class MetasploitModule < Msf::Auxiliary
         'Name'        => 'Microsoft IIS shortname vulnerability scanner',
         'Description' => %q{
          The vulnerability is caused by a tilde character "~" in a GET or OPTIONS request, which
-         could allow remote attackers to diclose 8.3 filenames (short names). In 2010, Soroush Dalili
+         could allow remote attackers to disclose 8.3 filenames (short names). In 2010, Soroush Dalili
          and Ali Abbasnejad discovered the original bug (GET request). This was publicly disclosed in
          2012. In 2014, Soroush Dalili discovered that newer IIS installations are vulnerable with OPTIONS.
         },


### PR DESCRIPTION
Fixed spelling error: "diclose" to "disclose"

