### PR TITLE
Spelling correction in udp_sweep.rb

### DIFF
--- a/modules/auxiliary/scanner/discovery/udp_sweep.rb
+++ b/modules/auxiliary/scanner/discovery/udp_sweep.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Auxiliary
     # multiple ports.
     deregister_options('RPORT')
 
-    # Intialize the probes array
+    # Initialize the probes array
     @probes = []
 
     # Add the UDP probe method names


### PR DESCRIPTION
Fixed spelling error: "Intialize" to "Initialize"