### PR TITLE
Corrected spelling in db2_auth.rb

### DIFF
--- a/modules/auxiliary/scanner/db2/db2_auth.rb
+++ b/modules/auxiliary/scanner/db2/db2_auth.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
       [
         Opt::Proxies,
-        OptPath.new('USERPASS_FILE',  [ false, "File containing (space-seperated) users and passwords, one pair per line",
+        OptPath.new('USERPASS_FILE',  [ false, "File containing (space-separated) users and passwords, one pair per line",
           File.join(Msf::Config.data_directory, "wordlists", "db2_default_userpass.txt") ]),
         OptPath.new('USER_FILE',  [ false, "File containing users, one per line",
           File.join(Msf::Config.data_directory, "wordlists", "db2_default_user.txt") ]),


### PR DESCRIPTION
Fixed spelling error: "seperated" to "separated"
