### PR TITLE
Corrected spelling in bison_ftp_traversal.rb

### DIFF
--- a/modules/auxiliary/scanner/ftp/bison_ftp_traversal.rb
+++ b/modules/auxiliary/scanner/ftp/bison_ftp_traversal.rb
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
       [
         OptInt.new('DEPTH', [ true, 'Traversal Depth (to reach the root folder)', 32 ]),
-        OptString.new('PATH', [ true, "Path to the file to disclose, releative to the root dir.", 'boot.ini'])
+        OptString.new('PATH', [ true, "Path to the file to disclose, relative to the root dir.", 'boot.ini'])
       ])
 
   end


### PR DESCRIPTION
Fixed spelling error: "releative" to "relative"
