### PR TITLE
Update metasploit Payloads to 1.3.78 to bring in Java keyevent API

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,7 +24,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 1.3.77)
+      metasploit-payloads (= 1.3.78)
       metasploit_data_models (= 3.0.10)
       metasploit_payloads-mettle (= 0.5.16)
       mqtt
@@ -203,7 +203,7 @@ GEM
       activemodel (~> 4.2.6)
       activesupport (~> 4.2.6)
       railties (~> 4.2.6)
-    metasploit-payloads (1.3.77)
+    metasploit-payloads (1.3.78)
     metasploit_data_models (3.0.10)
       activerecord (~> 4.2.6)
       activesupport (~> 4.2.6)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -70,7 +70,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '1.3.77'
+  spec.add_runtime_dependency 'metasploit-payloads', '1.3.78'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '0.5.16'
   # Needed by msfgui and other rpc components


### PR DESCRIPTION
This brings in the latest update to the payloads repo and extends the keyevent API to java payloads.  The Payloads PR is https://github.com/rapid7/metasploit-payloads/pull/350

## Verification

List the steps needed to make sure this thing works

- [x] Run automated testing
- [x] verify all tests pass
- [x] Verify keyevent API works

