### PR TITLE
Get rid of RSpec implicit block expectation syntax

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,8 +35,6 @@ group :development, :test do
   # Define `rake spec`.  Must be in development AND test so that its available by default as a rake test when the
   # environment is development
   gem 'rspec-rails'
-  # locked due to rspec/rspec-expectations#1134
-  gem 'rspec-expectations', '3.8.4'
   gem 'rspec-rerun'
   gem 'swagger-blocks'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -327,7 +327,7 @@ GEM
       rspec-mocks (~> 3.8.0)
     rspec-core (3.8.2)
       rspec-support (~> 3.8.0)
-    rspec-expectations (3.8.4)
+    rspec-expectations (3.8.5)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-mocks (3.8.2)
@@ -400,7 +400,6 @@ DEPENDENCIES
   pry
   rake
   redcarpet
-  rspec-expectations (= 3.8.4)
   rspec-rails
   rspec-rerun
   simplecov

--- a/spec/lib/msf/core/payload_generator_spec.rb
+++ b/spec/lib/msf/core/payload_generator_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe Msf::PayloadGenerator do
 
 
   context 'when creating a new generator' do
-    subject(:new_payload_generator) { -> { described_class.new(generator_opts) } }
+    subject(:new_payload_generator) { described_class.new(generator_opts) }
 
     context 'when not given a framework instance' do
       let(:generator_opts) {
@@ -107,7 +107,7 @@ RSpec.describe Msf::PayloadGenerator do
         }
       }
 
-      it { is_expected.to raise_error(KeyError, 'key not found: :framework') }
+      it { expect { new_payload_generator }.to raise_error(KeyError, 'key not found: :framework') }
     end
 
     context 'when not given a payload' do
@@ -131,7 +131,7 @@ RSpec.describe Msf::PayloadGenerator do
         }
       }
 
-      it { is_expected.to raise_error(ArgumentError, "invalid payload: ") }
+      it { expect { new_payload_generator }.to raise_error(ArgumentError, "invalid payload: ") }
     end
 
     context 'when given an invalid payload' do
@@ -155,7 +155,7 @@ RSpec.describe Msf::PayloadGenerator do
         }
       }
 
-      it { is_expected.to raise_error(ArgumentError, "invalid payload: beos/meterpreter/reverse_gopher") }
+      it { expect { new_payload_generator }.to raise_error(ArgumentError, "invalid payload: beos/meterpreter/reverse_gopher") }
     end
 
     context 'when given a payload through stdin' do
@@ -179,7 +179,7 @@ RSpec.describe Msf::PayloadGenerator do
         }
       }
 
-      it { is_expected.not_to raise_error }
+      it { expect { new_payload_generator }.not_to raise_error }
     end
 
     context 'when given an invalid format' do
@@ -203,7 +203,7 @@ RSpec.describe Msf::PayloadGenerator do
         }
       }
 
-      it { is_expected.to raise_error(Msf::InvalidFormat, "invalid format: foobar") }
+      it { expect { new_payload_generator }.to raise_error(Msf::InvalidFormat, "invalid format: foobar") }
     end
 
     context 'when given any valid transform format' do
@@ -227,7 +227,7 @@ RSpec.describe Msf::PayloadGenerator do
         }
       }
 
-      it { is_expected.not_to raise_error }
+      it { expect { new_payload_generator }.not_to raise_error }
     end
 
     context 'when given any valid executable format' do
@@ -252,7 +252,7 @@ RSpec.describe Msf::PayloadGenerator do
         }
       }
 
-      it { is_expected.not_to raise_error }
+      it { expect { new_payload_generator }.not_to raise_error }
     end
   end
 

--- a/spec/models/mdm/workspace_spec.rb
+++ b/spec/models/mdm/workspace_spec.rb
@@ -77,16 +77,14 @@ RSpec.describe Mdm::Workspace, type: :model do
         nil
       end
 
-      subject do
-        -> {workspace.send(:valid_ip_or_range?, ip_or_range)}
-      end
+      subject(:valid_ip_or_range?) { workspace.send(:valid_ip_or_range?, ip_or_range) }
 
       context 'with exception from Rex::Socket::RangeWalker' do
         before(:example) do
           allow(Rex::Socket::RangeWalker).to receive(:new).with(ip_or_range).and_raise(StandardError)
         end
 
-        it { is_expected.to raise_error(StandardError) }
+        it { expect { valid_ip_or_range? }.to raise_error(StandardError) }
       end
 
       context 'without exception from Rex::Socket::RangeWalker' do
@@ -95,7 +93,7 @@ RSpec.describe Mdm::Workspace, type: :model do
             '192.168.0.1'
           end
 
-          it { is_expected.to be_truthy }
+          it { expect(valid_ip_or_range?).to be_truthy }
         end
       end
     end


### PR DESCRIPTION
The syntax below was removed in rspec-expectations 3.8.5.

```ruby
subject { -> { fail } }
it { is_expected.to raise_error }
```

Related:
https://blog.rubystyle.guide/rspec/2019/07/17/rspec-implicit-block-syntax.html
https://github.com/rspec/rspec-expectations/pull/1125
https://github.com/rubocop-hq/rspec-style-guide/issues/76

This is a follow-up to #12397 and unpins `rspec-expectations`.

## Verification

List the steps needed to make sure this thing works

- [-] Start `msfconsole`
- [-] `use exploit/windows/smb/ms08_067_netapi`
- [-] ...
- [x] **Verify** the thing does what it should
- [x] **Verify** the thing does not do what it should not
- [-] **Document** the thing and how it works ([Example](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/post/multi/gather/aws_keys.md))