### PR TITLE
to_s - Fix #12345

### DIFF
--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -323,7 +323,7 @@ class CommandShell
   #
   def binary_exists(binary)
     print_status("Trying to find binary(#{binary}) on target machine")
-    binary_path = shell_command_token("which #{binary}").strip
+    binary_path = shell_command_token("which #{binary}").to_s.strip
     if binary_path.eql?("#{binary} not found")
       print_error(binary_path)
       return nil
@@ -449,7 +449,7 @@ class CommandShell
           print_error("Appending content to the target file <#{dst}> failed. (#{result})")
           # Do some cleanup
           # Delete the target file
-          shell_command_token("rm -rf #{dst}")
+          shell_command_token("rm -rf '#{dst}'")
           print_status("Target file <#{dst}> deleted")
           return
         end
@@ -504,7 +504,7 @@ class CommandShell
       print_line(shell_command("sh -x #{remote_file}"))
     end
     print_status("Cleaning temp file on remote machine")
-    shell_command("rm -rf #{remote_file}")
+    shell_command("rm -rf '#{remote_file}'")
   end
 
   def cmd_irb_help


### PR DESCRIPTION
Fix call to `strip` on potentially `nil` object.

Also replace a couple of `rm -rf path` with `rm -rf 'path'`. This will prevent unexpected deletion of directories when the path contains a space, at the cost of not working at all when the path includes a `'`.
