### PR TITLE
New feature for rpc client - Delete credentials from a specific workspace

### DIFF
--- a/lib/msf/core/rpc/v10/rpc_db.rb
+++ b/lib/msf/core/rpc/v10/rpc_db.rb
@@ -324,7 +324,7 @@ public
         workspace_id: wspace
       ).offset(offset).limit(limit)
       query.each do |cred|
-        ost = ''
+        host = ''
         port = 0
         proto = ''
         sname = ''


### PR DESCRIPTION
This is a new feature for RPC client - deleting credentials from a specific workspace based on db.creds function.

List the steps needed to make sure this thing works
- [ ] Start `msfconsole`
- Start RPC server e.g.:
   - On other terminal run following statements:
     - [] cd /usr/share/metasploit-framework
     - ruby msfrpcd -U msf -P test -a 127.0.0.1 -s true
     - ruby msfrpc -U msf -P test -a 127.0.0.1
     - rpc.call("console.create")
     - Check if any credentials exists: rpc.call("db.creds", {})
     - Now call new function which should delete all credentials rpc.call("db.del_creds", {})
     - Check again if any credentials exists: rpc.call("db.creds", {})