### PR TITLE
adjust for more limited require

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/creds.rb
+++ b/lib/msf/ui/console/command_dispatcher/creds.rb
@@ -3,7 +3,7 @@
 require 'rexml/document'
 require 'rex/parser/nmap_xml'
 require 'msf/core/db_export'
-require 'msf/core/auxiliary/jtr'
+require 'metasploit/framework/jtr/formatter'
 
 module Msf
 module Ui
@@ -43,7 +43,7 @@ class Creds
   #
   # All commands that require an active database should call this before
   # doing anything.
-  # TODO: abstract the db methothds to a mixin that can be used by both dispatchers
+  # TODO: abstract the db methods to a mixin that can be used by both dispatchers
   #
   def active?
     if not framework.db.active


### PR DESCRIPTION
Reduce the scope of the `require` used in creds command output formatting to just the actual formatter.

In the future and likely related to getting #11695 landed the output formatting process may be better served to use consistent method names base on an interface.
 
## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] see output format test in #11575
- [x] **Verify** csv and jtr format output are still consistent

