### PR TITLE
Extend check codes with custom messages

### DIFF
--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -81,28 +81,34 @@ class Exploit < Msf::Module
     # rest of the codebase.
 
     class << self
-      def Unknown(msg = 'Cannot reliably check exploitability.')
-        self.new('unknown', msg)
+      def Unknown(msg = nil)
+        self.new('unknown', 'Cannot reliably check exploitability' +
+          (msg ? ": #{msg}" : '.'))
       end
 
-      def Safe(msg = 'The target is not exploitable.')
-        self.new('safe', msg)
+      def Safe(msg = nil)
+        self.new('safe', 'The target is not exploitable' +
+          (msg ? ": #{msg}" : '.'))
       end
 
-      def Detected(msg = 'The garget service is running, but could not be validated.')
-        self.new('detected', msg)
+      def Detected(msg = nil)
+        self.new('detected', 'The target service is running, but could not be validated' +
+          (msg ? ": #{msg}" : '.'))
       end
 
-      def Appears(msg = 'The target appears to be vulnerable.')
-        self.new('appears', msg)
+      def Appears(msg = nil)
+        self.new('appears', 'The target appears to be vulnerable' +
+          (msg ? ": #{msg}" : '.'))
       end
 
-      def Vulnerable(msg = 'The target is vulnerable.')
-        self.new('vulnerable', msg)
+      def Vulnerable(msg = nil)
+        self.new('vulnerable', 'The target is vulnerable' +
+          (msg ? ": #{msg}" : '.'))
       end
 
-      def Unsupported(msg = 'This modules does not support check.')
-        self.new('unsupported', msg)
+      def Unsupported(msg = nil)
+        self.new('unsupported', 'This module does not support check' +
+          (msg ? ": #{msg}" : '.'))
       end
     end
 

--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -69,44 +69,79 @@ class Exploit < Msf::Module
   # https://github.com/rapid7/metasploit-framework/wiki/How-to-write-a-check()-method
   #
   ##
-  module CheckCode
+  CheckCode = Struct.new(:code, :message)
+  class CheckCode
+    # Do customization here because we need class constants and the block mode
+    # of Struct.new does not support that.
+    #
+    # NOTE: This class relies on the array-like interface of Struct classes to
+    # provide a backwards-compatible interface for the old CheckCode
+    # representation of `['code', 'message']`. Any change to the order, number,
+    # or meaning of fields will need to be evaluated for how it affects the
+    # rest of the codebase.
+
+    class << self
+      def Unknown(msg = 'Cannot reliably check exploitability.')
+        self.new('unknown', msg)
+      end
+
+      def Safe(msg = 'The target is not exploitable.')
+        self.new('safe', msg)
+      end
+
+      def Detected(msg = 'The garget service is running, but could not be validated.')
+        self.new('detected', msg)
+      end
+
+      def Appears(msg = 'The target appears to be vulnerable.')
+        self.new('appears', msg)
+      end
+
+      def Vulnerable(msg = 'The target is vulnerable.')
+        self.new('vulnerable', msg)
+      end
+
+      def Unsupported(msg = 'This modules does not support check.')
+        self.new('unsupported', msg)
+      end
+    end
 
     #
     # Can't tell if the target is exploitable or not. This is recommended if the module fails to
     # retrieve enough information from the target machine, such as due to a timeout.
     #
-    Unknown     = [ 'unknown', "Cannot reliably check exploitability."]
+    Unknown     = self.Unknown()
 
     #
     # The target is safe and is therefore not exploitable. This is recommended after the check
     # fails to trigger the vulnerability, or even detect the service.
     #
-    Safe        = [ 'safe', "The target is not exploitable." ]
+    Safe        = self.Safe()
 
     #
     # The target is running the service in question, but the check fails to determine whether
     # the target is vulnerable or not.
     #
-    Detected    = [ 'detected', "The target service is running, but could not be validated." ]
+    Detected    = self.Detected()
 
     #
     # The target appears to be vulnerable. This is recommended if the vulnerability is determined
     # based on passive reconnaissance. For example: version, banner grabbing, or having the resource
     # that's known to be vulnerable.
     #
-    Appears     = [ 'appears', "The target appears to be vulnerable." ]
+    Appears     = self.Appears()
 
     #
     # The target is vulnerable. Only used if the check is able to actually take advantage of the
     # bug, and obtain hard evidence. For example: executing a command on the target machine, and
     # retrieve the output.
     #
-    Vulnerable  = [ 'vulnerable', "The target is vulnerable." ]
+    Vulnerable  = self.Vulnerable()
 
     #
     # The module does not support the check method.
     #
-    Unsupported = [ 'unsupported', "This module does not support check." ]
+    Unsupported = self.Unsupported()
 
     #
     # Hash for looking up codes by short name
@@ -115,6 +150,20 @@ class Exploit < Msf::Module
       codes[code.first] = code
       codes
     end.freeze
+
+    # Deprecated, should use #===
+    #
+    # If you need to determine whether a CheckCode has the same code and
+    # message as another one, {Struct#eql?} is the way to go.
+    def ==(other)
+      self === other
+    end
+
+    # Checks to see whether the other object is also a {CheckCode} and if so,
+    # whether it shares the same code as this one.
+    def ===(other)
+      other.is_a?(self.class) && self.code == other.code
+    end
   end
 
   #

--- a/lib/msf/core/exploit/check_scanner.rb
+++ b/lib/msf/core/exploit/check_scanner.rb
@@ -46,7 +46,7 @@ module Exploit::Remote::CheckScanner
     checkcode = mod.run_host(rhost)
 
     # Bail if scanner doesn't return a CheckCode
-    unless Exploit::CheckCode::Codes.value?(checkcode)
+    unless checkcode.kind_of? Exploit::CheckCode
       print_error("#{scanner} does not return a CheckCode")
       return Exploit::CheckCode::Unsupported
     end

--- a/lib/msf/ui/console/module_command_dispatcher.rb
+++ b/lib/msf/ui/console/module_command_dispatcher.rb
@@ -235,7 +235,7 @@ module ModuleCommandDispatcher
         raise NotImplementedError, msg
       end
 
-      if (code and code.kind_of?(Array) and code.length > 1)
+      if (code && code.kind_of?(Msf::Exploit::CheckCode))
         if (code == Msf::Exploit::CheckCode::Vulnerable)
           print_good("#{peer_msg}#{code[1]}")
           # Restore RHOST for report_vuln


### PR DESCRIPTION
Check codes now take an optional message to allow a rationale to be more directly tied to the check code result. While this does help modules some (see the bluekeep scanner changes in this PR), the big win will be when combined with a few tweaks to the RPC API, this will allow remote clients to get some check context without having to troll through the printed output of a module run.

Verification
========
- [x] `msfconsole`
- [x] `use auxiliary/scanner/rdp/cve_2019_0708_bluekeep`
- [x] `set RHOSTS 127.0.0.1`
- [x] `set VERBOSE true`
- [x] `run`
- [x] Verify the custom safe message prints out with an error
- [x] Vulnerable targets should now output a slightly more technical vulnerable message