### PR TITLE
Added the link for 'COPYING' file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Metasploit [![Build Status](https://travis-ci.org/rapid7/metasploit-framework.svg?branch=master)](https://travis-ci.org/rapid7/metasploit-framework) [![Maintainability](https://api.codeclimate.com/v1/badges/943e398e619c09568f3f/maintainability)](https://codeclimate.com/github/rapid7/metasploit-framework/maintainability) [![Test Coverage](https://api.codeclimate.com/v1/badges/943e398e619c09568f3f/test_coverage)](https://codeclimate.com/github/rapid7/metasploit-framework/test_coverage) [![Docker Pulls](https://img.shields.io/docker/pulls/metasploitframework/metasploit-framework.svg)](https://hub.docker.com/r/metasploitframework/metasploit-framework/)
 ==
 The Metasploit Framework is released under a BSD-style license. See
-COPYING for more details.
+[COPYING](COPYING) for more details.
 
 The latest version of this software is available from: https://metasploit.com
 


### PR DESCRIPTION
This PR will link the word 'COPYING' in the README to 'COPYING' file.
- [ ] Open [README](https://github.com/Seniru/metasploit-framework/blob/master/README.md)

Related with #12417 