### PR TITLE
handle extra data on rdp_recv with length check

### DIFF
--- a/lib/msf/core/exploit/rdp.rb
+++ b/lib/msf/core/exploit/rdp.rb
@@ -413,7 +413,10 @@ module Exploit::Remote::RDP
     rdp_version = data[0].unpack("C")[0]
     raise RdpCommunicationError if rdp_version != 3
     length = data[2..3].unpack("n")[0]
-    raise RdpCommunicationError if data.length < length
+    if data.length < length
+      vprint_status("Got #{data.length} bytes, expected #{length}")
+      raise RdpCommunicationError
+    end
 
     data_len = data[13].unpack("C")[0]
     tag_offset = 18

--- a/lib/msf/core/exploit/rdp.rb
+++ b/lib/msf/core/exploit/rdp.rb
@@ -413,7 +413,7 @@ module Exploit::Remote::RDP
     rdp_version = data[0].unpack("C")[0]
     raise RdpCommunicationError if rdp_version != 3
     length = data[2..3].unpack("n")[0]
-    raise RdpCommunicationError if data.length != length
+    raise RdpCommunicationError if data.length < length
 
     data_len = data[13].unpack("C")[0]
     tag_offset = 18


### PR DESCRIPTION
We should really be doing something like strictly parsing PDU headers in rdp_recv and then parseling out PDUs instead of recv_and_pray, but this should get us past the initial issue where sometimes there is an extra PDU right after

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Use the RDP scanner or bluekeep exploit module _from_ Metasploit on Windows
- [ ] **Verify** the module can assert exploitability without saying 'Cannot reliably check exploitability against various targets'
- [ ] **Verify** it does not wind up with back-to-back PDUs causing the license parsing to bail because the library over-read from the socket.