### PR TITLE
Add documentation for auxiliary/scanner/http/wordpress_scanner

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/wordpress_scanner.md
+++ b/documentation/modules/auxiliary/scanner/http/wordpress_scanner.md
@@ -1,0 +1,102 @@
+## Description
+
+Detects Wordpress installations and their version number.
+
+
+## Vulnerable Application
+
+### Setup using Docksal
+Install [Docksal](https://docksal.io/)
+
+Create a new WordPress installation using `fin project create`
+
+```
+➜  ~ fin project create                  
+1. Name your project (lowercase alphanumeric, underscore, and hyphen): msf-wp
+
+2. What would you like to install?
+  PHP based
+    1.  Drupal 8
+    2.  Drupal 8 (Composer Version)
+    3.  Drupal 7
+    4.  Wordpress
+    5.  Magento
+    6.  Laravel
+    7.  Symfony Skeleton
+    8.  Symfony WebApp
+    9.  Grav CMS
+    10. Backdrop CMS
+
+  Go based
+    11. Hugo
+
+  JS based
+    12. Gatsby JS
+    13. Angular
+
+  HTML
+    14. Static HTML site
+
+Enter your choice (1-14): 4
+
+Project folder:   /home/weh/dev/msf-wp
+Project software: Wordpress
+Project URL:      http://msf-wp.docksal
+
+Do you wish to proceed? [y/n]: y
+Cloning repository...
+Cloning into 'msf-wp'...
+...
+3. Installing site
+ Step 1  Initializing stack...
+Removing containers...
+...
+Starting services...
+Creating network "msf-wp_default" with the default driver
+Creating volume "msf-wp_cli_home" with default driver
+Creating volume "msf-wp_project_root" with local driver
+Creating volume "msf-wp_db_data" with default driver
+Creating msf-wp_db_1  ... done
+Creating msf-wp_cli_1 ... done
+Creating msf-wp_web_1 ... done
+Connected vhost-proxy to "msf-wp_default" network.
+Waiting for project stack to become ready...
+ Step 2  Initializing site...
+ Step 2  Generating wp-config.php...
+Success: Generated 'wp-config.php' file.
+ Step 3  Installing site...
+msmtp: envelope-from address is missing
+Success: WordPress installed successfully.
+
+Open http://msf-wp.docksal in your browser to verify the setup.
+Admin panel: http://msf-wp.docksal/wp-admin. User/password: admin/admin  
+ DONE!  Completed all initialization steps.
+➜  ~ 
+```
+
+## Verification Steps
+
+1. Do: ```use auxiliary/scanner/http/wordpress_sanner```
+2. Do: ```set RHOSTS [IP]```
+3. Do: ```set VHOST [IP]```
+4. Do: ```run```
+
+## Scenarios
+
+### Simple scan
+
+```
+msf5 > use auxiliary/scanner/http/wordpress_scanner
+msf5 auxiliary(scanner/http/wordpress_scanner) > set RHOST msf-wp.docksal
+RHOST => msf-wp.docksal
+msf5 auxiliary(scanner/http/wordpress_scanner) > set VHOST msf-wp.docksal
+VHOST => msf-wp.docksal
+msf5 auxiliary(scanner/http/wordpress_scanner) > run
+
+[*] Trying 192.168.64.100
+[+] 192.168.64.100 running Wordpress 5.2
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+msf5 auxiliary(scanner/http/wordpress_scanner) > 
+
+```

--- a/documentation/modules/auxiliary/scanner/http/wordpress_scanner.md
+++ b/documentation/modules/auxiliary/scanner/http/wordpress_scanner.md
@@ -77,7 +77,7 @@ Admin panel: http://msf-wp.docksal/wp-admin. User/password: admin/admin
 
 1. Do: ```use auxiliary/scanner/http/wordpress_sanner```
 2. Do: ```set RHOSTS [IP]```
-3. Do: ```set VHOST [DOMAIN]```
+3. Do: ```set VHOST [HOSTNAME]```
 4. Do: ```run```
 
 ### Wordpress 5.2 running in Docksal

--- a/documentation/modules/auxiliary/scanner/http/wordpress_scanner.md
+++ b/documentation/modules/auxiliary/scanner/http/wordpress_scanner.md
@@ -11,7 +11,7 @@ Install [Docksal](https://docksal.io/)
 Create a new WordPress installation using `fin project create`
 
 ```
-➜  ~ fin project create                  
+fin project create
 1. Name your project (lowercase alphanumeric, underscore, and hyphen): msf-wp
 
 2. What would you like to install?
@@ -71,7 +71,6 @@ Success: WordPress installed successfully.
 Open http://msf-wp.docksal in your browser to verify the setup.
 Admin panel: http://msf-wp.docksal/wp-admin. User/password: admin/admin  
  DONE!  Completed all initialization steps.
-➜  ~ 
 ```
 
 ## Verification Steps
@@ -81,9 +80,9 @@ Admin panel: http://msf-wp.docksal/wp-admin. User/password: admin/admin
 3. Do: ```set VHOST [IP]```
 4. Do: ```run```
 
-## Scenarios
+### Wordpress 5.2 running in Docksal
 
-### Simple scan
+Follow the Instructions above to setup the Docksal Containers.
 
 ```
 msf5 > use auxiliary/scanner/http/wordpress_scanner

--- a/documentation/modules/auxiliary/scanner/http/wordpress_scanner.md
+++ b/documentation/modules/auxiliary/scanner/http/wordpress_scanner.md
@@ -77,7 +77,7 @@ Admin panel: http://msf-wp.docksal/wp-admin. User/password: admin/admin
 
 1. Do: ```use auxiliary/scanner/http/wordpress_sanner```
 2. Do: ```set RHOSTS [IP]```
-3. Do: ```set VHOST [IP]```
+3. Do: ```set VHOST [DOMAIN]```
 4. Do: ```run```
 
 ### Wordpress 5.2 running in Docksal


### PR DESCRIPTION
Adds documentation for auxiliary/scanner/http/wordpress_scanner module
see #12389

## Verification

- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/http/wordpress_scanner`
- [ ] `info -d`
- [ ] Check spelling and grammar