### PR TITLE
Add Support For Custom Meterpreter Prompts

### DIFF
--- a/lib/msf/base/sessions/meterpreter.rb
+++ b/lib/msf/base/sessions/meterpreter.rb
@@ -168,7 +168,7 @@ class Meterpreter < Rex::Post::Meterpreter::Client
         end
 
         # only load priv on native windows
-        # TODO: abastrct this too, to remove windows stuff
+        # TODO: abstract this too, to remove windows stuff
         if session.platform == 'windows' && [ARCH_X86, ARCH_X64].include?(session.arch)
           session.load_priv rescue nil
         end
@@ -429,8 +429,8 @@ class Meterpreter < Rex::Post::Meterpreter::Client
   end
 
   def update_session_info
-    # sys.config.getuid, and sys.dir.pwd cache their results, so update them
-    self.sys.dir.pwd
+    # sys.config.getuid, and fs.dir.getwd cache their results, so update them
+    fs.dir.getwd
     username = self.sys.config.getuid
     sysinfo  = self.sys.config.sysinfo
 

--- a/lib/msf/base/sessions/meterpreter.rb
+++ b/lib/msf/base/sessions/meterpreter.rb
@@ -569,11 +569,17 @@ class Meterpreter < Rex::Post::Meterpreter::Client
   #
   def _interact
     framework.events.on_session_interact(self)
+
+    console.framework = framework
+    unless framework.datastore['MeterpreterPrompt'].nil?
+      console.update_prompt(framework.datastore['MeterpreterPrompt'])
+    end
     # Call the console interaction subsystem of the meterpreter client and
     # pass it a block that returns whether or not we should still be
     # interacting.  This will allow the shell to abort if interaction is
     # canceled.
     console.interact { self.interacting != true }
+    console.framework = nil
 
     # If the stop flag has been set, then that means the user exited.  Raise
     # the EOFError so we can drop this handle like a bad habit.

--- a/lib/msf/base/sessions/meterpreter.rb
+++ b/lib/msf/base/sessions/meterpreter.rb
@@ -573,7 +573,7 @@ class Meterpreter < Rex::Post::Meterpreter::Client
     framework.events.on_session_interact(self)
 
     console.framework = framework
-    unless framework.datastore['MeterpreterPrompt'].nil?
+    if framework.datastore['MeterpreterPrompt']
       console.update_prompt(framework.datastore['MeterpreterPrompt'])
     end
     # Call the console interaction subsystem of the meterpreter client and

--- a/lib/msf/base/sessions/meterpreter.rb
+++ b/lib/msf/base/sessions/meterpreter.rb
@@ -429,6 +429,8 @@ class Meterpreter < Rex::Post::Meterpreter::Client
   end
 
   def update_session_info
+    # sys.config.getuid, and sys.dir.pwd cache their results, so update them
+    self.sys.dir.pwd
     username = self.sys.config.getuid
     sysinfo  = self.sys.config.sysinfo
 

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1643,6 +1643,7 @@ class Core
       Prompt
       PromptChar
       PromptTimeFormat
+      MeterpreterPrompt
     }
     mod = active_module
 

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -1096,6 +1096,7 @@ module Msf
               [ 'Prompt', framework.datastore['Prompt'] || Msf::Ui::Console::Driver::DefaultPrompt.to_s.gsub(/%.../,"") , "The prompt string" ],
               [ 'PromptChar', framework.datastore['PromptChar'] || Msf::Ui::Console::Driver::DefaultPromptChar.to_s.gsub(/%.../,""), "The prompt character" ],
               [ 'PromptTimeFormat', framework.datastore['PromptTimeFormat'] || Time::DATE_FORMATS[:db].to_s, 'Format for timestamp escapes in prompts' ],
+              [ 'MeterpreterPrompt', framework.datastore['MeterpreterPrompt'] || (Rex::Compat.is_windows() ? 'meterpreter' : '%undmeterpreter%clr'), 'The meterpreter prompt string' ],
             ].each { |r| tbl << r }
 
             print(tbl.to_s)

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -1096,7 +1096,7 @@ module Msf
               [ 'Prompt', framework.datastore['Prompt'] || Msf::Ui::Console::Driver::DefaultPrompt.to_s.gsub(/%.../,"") , "The prompt string" ],
               [ 'PromptChar', framework.datastore['PromptChar'] || Msf::Ui::Console::Driver::DefaultPromptChar.to_s.gsub(/%.../,""), "The prompt character" ],
               [ 'PromptTimeFormat', framework.datastore['PromptTimeFormat'] || Time::DATE_FORMATS[:db].to_s, 'Format for timestamp escapes in prompts' ],
-              [ 'MeterpreterPrompt', framework.datastore['MeterpreterPrompt'] || (Rex::Compat.is_windows() ? 'meterpreter' : '%undmeterpreter%clr'), 'The meterpreter prompt string' ],
+              [ 'MeterpreterPrompt', framework.datastore['MeterpreterPrompt'] || '%undmeterpreter%clr', 'The meterpreter prompt string' ],
             ].each { |r| tbl << r }
 
             print(tbl.to_s)

--- a/lib/rex/post/meterpreter/extensions/stdapi/fs/dir.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/fs/dir.rb
@@ -182,6 +182,7 @@ class Dir < Rex::Post::Dir
 
     response = client.send_request(request)
 
+    pwd(refresh: true)
     return 0
   end
 
@@ -201,12 +202,15 @@ class Dir < Rex::Post::Dir
   #
   # Returns the current working directory of the remote process.
   #
-  def Dir.pwd
-    request = Packet.create_request('stdapi_fs_getwd')
+  def Dir.pwd(refresh: true)
+    if @working_directory.nil? || refresh
+      request = Packet.create_request('stdapi_fs_getwd')
 
-    response = client.send_request(request)
+      response = client.send_request(request)
 
-    return client.unicode_filter_encode(response.get_tlv(TLV_TYPE_DIRECTORY_PATH).value)
+      @working_directory = client.unicode_filter_encode(response.get_tlv(TLV_TYPE_DIRECTORY_PATH).value)
+      end
+    @working_directory
   end
 
   #

--- a/lib/rex/post/meterpreter/extensions/stdapi/fs/dir.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/fs/dir.rb
@@ -182,7 +182,7 @@ class Dir < Rex::Post::Dir
 
     response = client.send_request(request)
 
-    pwd(refresh: true)
+    getwd(refresh: true)
     return 0
   end
 
@@ -216,8 +216,8 @@ class Dir < Rex::Post::Dir
   #
   # Synonym for pwd.
   #
-  def Dir.getwd
-    pwd
+  def Dir.getwd(refresh: true)
+    pwd(refresh: refresh)
   end
 
   #

--- a/lib/rex/post/meterpreter/extensions/stdapi/fs/dir.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/fs/dir.rb
@@ -209,7 +209,7 @@ class Dir < Rex::Post::Dir
       response = client.send_request(request)
 
       @working_directory = client.unicode_filter_encode(response.get_tlv(TLV_TYPE_DIRECTORY_PATH).value)
-      end
+    end
     @working_directory
   end
 

--- a/lib/rex/post/meterpreter/extensions/stdapi/sys/config.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/sys/config.rb
@@ -29,10 +29,13 @@ class Config
   #
   # Returns the username that the remote side is running as.
   #
-  def getuid
-    request  = Packet.create_request('stdapi_sys_config_getuid')
-    response = client.send_request(request)
-    client.unicode_filter_encode( response.get_tlv_value(TLV_TYPE_USER_NAME) )
+  def getuid(refresh: true)
+    if @uid.nil? || refresh
+      request  = Packet.create_request('stdapi_sys_config_getuid')
+      response = client.send_request(request)
+      @uid = client.unicode_filter_encode( response.get_tlv_value(TLV_TYPE_USER_NAME) )
+    end
+    @uid
   end
 
   #

--- a/lib/rex/ui/text/shell.rb
+++ b/lib/rex/ui/text/shell.rb
@@ -411,7 +411,7 @@ protected
       end
 
       if str.include?('%D')
-        str.gsub!('%D', (session.respond_to?(:fs) ? session.fs.getwd(refresh: false) : default))
+        str.gsub!('%D', (session.respond_to?(:fs) ? session.fs.dir.getwd(refresh: false) : default))
       end
 
       if str.include?('%H')

--- a/lib/rex/ui/text/shell.rb
+++ b/lib/rex/ui/text/shell.rb
@@ -385,10 +385,6 @@ protected
     # find the active session
     session = framework.sessions.values.find { |session| session.interacting }
 
-    if str.include?('%J')
-      str.gsub!('%J', framework.jobs.length.to_s)
-    end
-
     if str.include?('%T')
       t = Time.now
       # This %T is the strftime shorthand for %H:%M:%S
@@ -418,6 +414,10 @@ protected
         str.gsub!('%H', (sysinfo.nil? ? default : sysinfo['Computer']))
         end
 
+      if str.include?('%M')
+        str.gsub!('%M', session.session_type)
+      end
+
       if str.include?('%S')
         str.gsub!('%S', session.sid.to_s)
       end
@@ -431,6 +431,10 @@ protected
             ENV['COMPUTERNAME'] || 'unknown'
 
         str.gsub!('%H', hostname.chomp)
+      end
+
+      if str.include?('%J')
+        str.gsub!('%J', framework.jobs.length.to_s)
       end
 
       if str.include?('%U')

--- a/lib/rex/ui/text/shell.rb
+++ b/lib/rex/ui/text/shell.rb
@@ -403,12 +403,28 @@ protected
     end
 
     if session
+      default = 'unknown'
       sysinfo = session.respond_to?(:sys) ? session.sys.config.sysinfo : nil
 
-      str.gsub!('%A', (sysinfo.nil? ? 'Unknown' : sysinfo['Architecture'])) if str.include?('%A')
-      str.gsub!('%H', (sysinfo.nil? ? 'Unknown' : sysinfo['Computer'])) if str.include?('%H')
-      str.gsub!('%S', session.sid.to_s) if str.include?('%S')
-      str.gsub!('%U', session.username) if str.include?('%U')
+      if str.include?('%A')
+        str.gsub!('%A', (sysinfo.nil? ? default : sysinfo['Architecture']))
+      end
+
+      if str.include?('%D')
+        str.gsub!('%D', (session.respond_to?(:fs) ? session.fs.getwd(refresh: false) : default))
+      end
+
+      if str.include?('%H')
+        str.gsub!('%H', (sysinfo.nil? ? default : sysinfo['Computer']))
+        end
+
+      if str.include?('%S')
+        str.gsub!('%S', session.sid.to_s)
+      end
+
+      if str.include?('%U')
+        str.gsub!('%U', (session.respond_to?(:sys) ? session.sys.config.getuid(refresh: false) : default))
+      end
     else
       if str.include?('%H')
         hostname = ENV['HOSTNAME'] || `hostname`.split('.')[0] ||


### PR DESCRIPTION
This pull request adds a framework variable, `MeterpreterPrompt` which can be used to customize the meterpreter prompt, thus replacing the standard `meterpreter >` with something a little fancier. This also includes support for a few variables like the core prompt does.

## Prompt Variables

The following are valid variables for the `MeterpreterPrompt`:

| Var   | Description                                                |
|-------|------------------------------------------------------------|
| `%A`  | The host architecture (`sysinfo['Architecture']`)          |
| `%D`  | The remote current working directory (same as `pwd`)       |
| `%d`  | The local current working directory (same as `lpwd`)       |
| `%H`  | The remote computer name (`sysinfo['Computer']`)           |
| `%h`  | The local computer name                                    |
| `%I`  | The remote peer address for the connection                 |
| `%i`  | The local address for the connection                       |
| `%M`  | The meterpreter type                                       |
| `%S`  | The session ID                                             |
| `%T`  | The current timestamp                                      |
| `%U`  | The session user (same as `getuid`)                        |
| `%u`  | the local user                                             |
| `%W`  | The current Metasploit workspace                           |

### Cached Variables
The `%D`, and `%U` variables are now cached in the Meterpreter extension client side. The new   functions default to refresh the values each time they're called, while the prompt is the only location to use the cached values. This is intended to prevent a round trip every time the prompt is rendered.

## Verification
The following steps are intended to demonstrate a couple of context changes to show the prompt 
 automatically updates. Many of these values intentionally overlap with their framework counterparts such as `%H`.

- [x] Start `msfconsole`
- [x] Run the following commands to set the prompt and open a basic meterpreter
  session without the stdapi extension
  - [x] Run `set MeterpreterPrompt "%T [%A] %U@%H %D"`
  - [x] Run `setg AutoLoadStdapi false`
  - [x] Run `setg AutoSystemInfo false`
- [x] Open a meterpreter session on a Windows host as a user where
  `getsystem` will work (use web delivery / Run As Admin)
- [x] See the prompt with a bunch of unknown variables, but no bugs
- [x] Load the stdapi extension, see variables are now visible
- [x] Change into a different directory, see the new directory reflected in the
  prompt
- [x] Load the priv extension, run `getsystem`, see the user changed

## Example Output
```
metasploit-framework (S:1 J:1) exploit(multi/script/web_delivery) > sessions -i -1
[*] Starting interaction with 3...

14:30:11 [unknown] unknown@unknown unknown > load stdapi
Loading extension stdapi...Success.
14:30:18 [x64] WINDOWS8VM\Spencer@WINDOWS8VM C:\Windows\system32 > cd ..
14:30:20 [x64] WINDOWS8VM\Spencer@WINDOWS8VM C:\Windows > load priv
Loading extension priv...Success.
14:30:23 [x64] WINDOWS8VM\Spencer@WINDOWS8VM C:\Windows > getsystem
...got system via technique 1 (Named Pipe Impersonation (In Memory/Admin)).
14:30:25 [x64] NT AUTHORITY\SYSTEM@WINDOWS8VM C:\Windows >
```
