### PR TITLE
Add generate_random_c method to randomized compiler

### DIFF
--- a/lib/metasploit/framework/compiler/windows.rb
+++ b/lib/metasploit/framework/compiler/windows.rb
@@ -62,25 +62,27 @@ module Metasploit
 
         # Returns the binary of a randomized and compiled source code.
         #
-        # @param rand_c_template [String]
+        # @param c_template [String]
         # 
         # @raise [NotImplementedError] If the type is not supported.
         # @return [String] The compiled code.
-        def self.compile_random_c(rand_c_template, opts={})
+        def self.compile_random_c(c_template, opts={})
           type = opts[:type] || :exe
           cpu = opts[:cpu] || Metasm::Ia32.new
 
-          self.compile_c(rand_c_template, type, cpu)
+          random_c = self.generate_random_c(c_template, opts)
+          self.compile_c(random_c, type, cpu)
         end
 
         # Saves the randomized compiled code as a file. This is basically a wrapper for #self.compile_random_c
         #
         # @param out_file [String] The file path to save the binary as.
-        # @param rand_c_template [String] The randomized C source code to compile.
+        # @param c_template [String] The randomized C source code to compile.
         # @param opts [Hash] Options to pass to #compile_random_c
         # @return [Integer] The number of bytes written.
-        def self.compile_random_c_to_file(out_file, rand_c_template, opts={})
-          pe = self.compile_random_c(rand_c_template, opts)
+        def self.compile_random_c_to_file(out_file, c_template, opts={})
+          random_c = self.generate_random_c(c_template, opts)
+          pe = self.compile_random_c(random_c, opts)
           File.write(out_file, pe)
         end
       end

--- a/lib/metasploit/framework/compiler/windows.rb
+++ b/lib/metasploit/framework/compiler/windows.rb
@@ -81,8 +81,7 @@ module Metasploit
         # @param opts [Hash] Options to pass to #compile_random_c
         # @return [Integer] The number of bytes written.
         def self.compile_random_c_to_file(out_file, c_template, opts={})
-          random_c = self.generate_random_c(c_template, opts)
-          pe = self.compile_random_c(random_c, opts)
+          pe = self.compile_random_c(c_template, opts)
           File.write(out_file, pe)
         end
       end

--- a/lib/metasploit/framework/compiler/windows.rb
+++ b/lib/metasploit/framework/compiler/windows.rb
@@ -44,31 +44,43 @@ module Metasploit
           File.write(out_file, pe)
         end
 
-        # Returns the binary of a randomized and compiled source code.
+        # Returns randomized c source code.
         #
         # @param c_template [String]
         # 
         # @raise [NotImplementedError] If the type is not supported.
         # @return [String] The compiled code.
-        def self.compile_random_c(c_template, opts={})
-          type = opts[:type] || :exe
-          cpu = opts[:cpu] || Metasm::Ia32.new
+        def self.generate_random_c(c_template, opts={})
           weight = opts[:weight] || 80
           headers = Compiler::Headers::Windows.new
           source_code = Compiler::Utils.normalize_code(c_template, headers)
+
           randomizer = Metasploit::Framework::Obfuscation::CRandomizer::Parser.new(weight)
           randomized_code = randomizer.parse(source_code)
-          self.compile_c(randomized_code.to_s, type, cpu)
+          randomized_code.to_s
+        end
+
+        # Returns the binary of a randomized and compiled source code.
+        #
+        # @param rand_c_template [String]
+        # 
+        # @raise [NotImplementedError] If the type is not supported.
+        # @return [String] The compiled code.
+        def self.compile_random_c(rand_c_template, opts={})
+          type = opts[:type] || :exe
+          cpu = opts[:cpu] || Metasm::Ia32.new
+
+          self.compile_c(rand_c_template, type, cpu)
         end
 
         # Saves the randomized compiled code as a file. This is basically a wrapper for #self.compile_random_c
         #
         # @param out_file [String] The file path to save the binary as.
-        # @param c_template [String] The C source code to randomize and compile.
+        # @param rand_c_template [String] The randomized C source code to compile.
         # @param opts [Hash] Options to pass to #compile_random_c
         # @return [Integer] The number of bytes written.
-        def self.compile_random_c_to_file(out_file, c_template, opts={})
-          pe = self.compile_random_c(c_template, opts)
+        def self.compile_random_c_to_file(out_file, rand_c_template, opts={})
+          pe = self.compile_random_c(rand_c_template, opts)
           File.write(out_file, pe)
         end
       end

--- a/modules/evasion/windows/windows_defender_exe.rb
+++ b/modules/evasion/windows/windows_defender_exe.rb
@@ -72,7 +72,8 @@ int main() {
   def run
     vprint_line c_template
     # The randomized code allows us to generate a unique EXE
-    bin = Metasploit::Framework::Compiler::Windows.compile_random_c(c_template)
+    random_c = Metasploit::Framework::Compiler::Windows.generate_random_c(c_template)
+    bin = Metasploit::Framework::Compiler::Windows.compile_random_c(random_c)
     print_status("Compiled executable size: #{bin.length}")
     file_create(bin)
   end

--- a/modules/evasion/windows/windows_defender_exe.rb
+++ b/modules/evasion/windows/windows_defender_exe.rb
@@ -72,8 +72,7 @@ int main() {
   def run
     vprint_line c_template
     # The randomized code allows us to generate a unique EXE
-    random_c = Metasploit::Framework::Compiler::Windows.generate_random_c(c_template)
-    bin = Metasploit::Framework::Compiler::Windows.compile_random_c(random_c)
+    bin = Metasploit::Framework::Compiler::Windows.compile_random_c(c_template)
     print_status("Compiled executable size: #{bin.length}")
     file_create(bin)
   end

--- a/tools/exploit/random_compile_c.rb
+++ b/tools/exploit/random_compile_c.rb
@@ -33,8 +33,7 @@ elsif out_path.nil? || out_path.empty?
 end
 
 source_code = File.read(source_code_path)
-rand_c_src = Metasploit::Framework::Compiler::Windows.generate_random_c(source_code, weight: weight.to_i)
-Metasploit::Framework::Compiler::Windows.compile_random_c_to_file(out_path, rand_c_src)
+Metasploit::Framework::Compiler::Windows.compile_random_c_to_file(out_path, source_code, weight: weight.to_i)
 if File.exists?(out_path)
   puts "File saved as #{out_path}"
 end

--- a/tools/exploit/random_compile_c.rb
+++ b/tools/exploit/random_compile_c.rb
@@ -33,7 +33,8 @@ elsif out_path.nil? || out_path.empty?
 end
 
 source_code = File.read(source_code_path)
-Metasploit::Framework::Compiler::Windows.compile_random_c_to_file(out_path, source_code, weight: weight.to_i)
+rand_c_src = Metasploit::Framework::Compiler::Windows.generate_random_c(source_code, weight: weight.to_i)
+Metasploit::Framework::Compiler::Windows.compile_random_c_to_file(out_path, rand_c_src)
 if File.exists?(out_path)
   puts "File saved as #{out_path}"
 end


### PR DESCRIPTION
This aims to resolve #11365 by adding the `generate_random_c()` method to the randomized c compiler library.

This simply migrates the code used to generate randomized c code from `compile_random_c()` to `generate_random_c()` so that the randomized c can be accessed/modified prior to compiling it.

