### PR TITLE
Consolidate workspace actions

### DIFF
--- a/lib/msf/core/db_manager/workspace.rb
+++ b/lib/msf/core/db_manager/workspace.rb
@@ -97,11 +97,16 @@ module Msf::DBManager::Workspace
     Msf::Util::DBManager.delete_opts_workspace(opts)
 
     ::ActiveRecord::Base.connection_pool.with_connection {
-      ws_to_update = workspaces({ id: opts.delete(:id) }).first
+      ws_id = opts.delete(:id)
+      ws_to_update = workspaces({ id: ws_id }).first
       default_renamed = true if ws_to_update.name == DEFAULT_WORKSPACE_NAME
-      updated_ws = ws_to_update.update!(opts)
+      begin
+        ws_to_update.update!(opts) # will raise exception if it fails
+      rescue ActiveRecord::RecordInvalid => e
+        raise ArgumentError.new(e.message)
+      end
       add_workspace({ name: DEFAULT_WORKSPACE_NAME }) if default_renamed
-      updated_ws
+      workspaces({ id: ws_id }).first
     }
   end
 end

--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -179,10 +179,6 @@ class Db
           name: names.last
       }
       begin
-        if names.last == Msf::DBManager::Workspace::DEFAULT_WORKSPACE_NAME
-          print_error("Unable to rename a workspace to '#{Msf::DBManager::Workspace::DEFAULT_WORKSPACE_NAME}'")
-          return
-        end
         updated_ws = framework.db.update_workspace(opts)
         if updated_ws
           framework.db.workspace = updated_ws if names.first == framework.db.workspace.name
@@ -197,7 +193,6 @@ class Db
         end
       rescue => e
         print_error "Failed to rename workspace: #{e.message}"
-        e.backtrace.each { |line| print_error "#{line}"}
       end
 
     elsif names


### PR DESCRIPTION
* When renaming a workspace allow validation to handle all cases the same
* Do not display backtrace on console for rename failure, this is still logged to framework.log

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `workspace -r default test`
- [x] `workspace -r default test`
- [x] **Verify** a simple error message reports that rename could not validate as the workspace name is already taken
