### PR TITLE
Refactor extended check messages

### DIFF
--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -143,14 +143,6 @@ class Exploit < Msf::Module
     #
     Unsupported = self.Unsupported()
 
-    #
-    # Hash for looking up codes by short name
-    #
-    Codes = [Unknown, Safe, Detected, Appears, Vulnerable, Unsupported].reduce({}) do |codes, code|
-      codes[code.first] = code
-      codes
-    end.freeze
-
     # Deprecated, should use #===
     #
     # If you need to determine whether a CheckCode has the same code and

--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -106,6 +106,34 @@ class Exploit < Msf::Module
       end
     end
 
+    # Deprecated, should use #===
+    #
+    # If you need to determine whether a CheckCode has the same code and
+    # message as another one, {Struct#eql?} is the way to go.
+    def ==(other)
+      self === other
+    end
+
+    # Checks to see whether the other object is also a {CheckCode} and if so,
+    # whether it shares the same code as this one.
+    def ===(other)
+      other.is_a?(self.class) && self.code == other.code
+    end
+
+    def initialize(code, reason)
+      msg = case code
+        when 'unknown';     'Cannot reliably check exploitability.'
+        when 'safe';        'The target is not exploitable.'
+        when 'detected';    'The service is running, but could not be validated.'
+        when 'appears';     'The target appears to be vulnerable.'
+        when 'vulnerable';  'The target is vulnerable.'
+        when 'unsupported'; 'This module does not support check.'
+        else
+          ''
+      end
+      super(code, "#{msg} #{reason}".strip, reason)
+    end
+
     #
     # Can't tell if the target is exploitable or not. This is recommended if the module fails to
     # retrieve enough information from the target machine, such as due to a timeout.
@@ -142,34 +170,6 @@ class Exploit < Msf::Module
     # The module does not support the check method.
     #
     Unsupported = self.Unsupported()
-
-    # Deprecated, should use #===
-    #
-    # If you need to determine whether a CheckCode has the same code and
-    # message as another one, {Struct#eql?} is the way to go.
-    def ==(other)
-      self === other
-    end
-
-    # Checks to see whether the other object is also a {CheckCode} and if so,
-    # whether it shares the same code as this one.
-    def ===(other)
-      other.is_a?(self.class) && self.code == other.code
-    end
-
-    def initialize(code, reason)
-      msg = case code
-        when 'unknown';     'Cannot reliably check exploitability.'
-        when 'safe';        'The target is not exploitable.'
-        when 'detected';    'The service is running, but could not be validated.'
-        when 'appears';     'The target appears to be vulnerable.'
-        when 'vulnerable';  'The target is vulnerable.'
-        when 'unsupported'; 'This module does not support check.'
-        else
-          ''
-      end
-      super(code, "#{msg} #{reason}".strip, reason)
-    end
   end
 
   #

--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -69,46 +69,40 @@ class Exploit < Msf::Module
   # https://github.com/rapid7/metasploit-framework/wiki/How-to-write-a-check()-method
   #
   ##
-  CheckCode = Struct.new(:code, :message)
-  class CheckCode
-    # Do customization here because we need class constants and the block mode
-    # of Struct.new does not support that.
+  class CheckCode < Struct.new(:code, :message, :reason)
+    # Do customization here because we need class constants and special
+    # optional values and the block mode of Struct.new does not support that.
+    #
     #
     # NOTE: This class relies on the array-like interface of Struct classes to
     # provide a backwards-compatible interface for the old CheckCode
-    # representation of `['code', 'message']`. Any change to the order, number,
-    # or meaning of fields will need to be evaluated for how it affects the
-    # rest of the codebase.
+    # representation of `['code', 'message']`. Any change to the order or
+    # meaning of fields will need to be evaluated for how it affects the rest
+    # of the codebase.
 
     class << self
-      def Unknown(msg = nil)
-        self.new('unknown', 'Cannot reliably check exploitability' +
-          (msg ? ": #{msg}" : '.'))
+      def Unknown(reason = nil)
+        self.new('unknown', reason)
       end
 
-      def Safe(msg = nil)
-        self.new('safe', 'The target is not exploitable' +
-          (msg ? ": #{msg}" : '.'))
+      def Safe(reason = nil)
+        self.new('safe', reason)
       end
 
-      def Detected(msg = nil)
-        self.new('detected', 'The target service is running, but could not be validated' +
-          (msg ? ": #{msg}" : '.'))
+      def Detected(reason = nil)
+        self.new('detected', reason)
       end
 
-      def Appears(msg = nil)
-        self.new('appears', 'The target appears to be vulnerable' +
-          (msg ? ": #{msg}" : '.'))
+      def Appears(reason = nil)
+        self.new('appears', reason)
       end
 
-      def Vulnerable(msg = nil)
-        self.new('vulnerable', 'The target is vulnerable' +
-          (msg ? ": #{msg}" : '.'))
+      def Vulnerable(reason = nil)
+        self.new('vulnerable', reason)
       end
 
-      def Unsupported(msg = nil)
-        self.new('unsupported', 'This module does not support check' +
-          (msg ? ": #{msg}" : '.'))
+      def Unsupported(reason = nil)
+        self.new('unsupported', reason)
       end
     end
 
@@ -169,6 +163,20 @@ class Exploit < Msf::Module
     # whether it shares the same code as this one.
     def ===(other)
       other.is_a?(self.class) && self.code == other.code
+    end
+
+    def initialize(code, reason)
+      msg = case code
+        when 'unknown';     'Cannot reliably check exploitability.'
+        when 'safe';        'The target is not exploitable.'
+        when 'detected';    'The service is running, but could not be validated.'
+        when 'appears';     'The target appears to be vulnerable.'
+        when 'vulnerable';  'The target is vulnerable.'
+        when 'unsupported'; 'This module does not support check.'
+        else
+          ''
+      end
+      super(code, "#{msg} #{reason}".strip, reason)
     end
   end
 

--- a/lib/msf/core/modules/external/templates/common_check.erb
+++ b/lib/msf/core/modules/external/templates/common_check.erb
@@ -1,7 +1,7 @@
 <% if meta[:capabilities].include? 'soft_check' %>
 def check
   code = execute_module(<%= meta[:path] %>, method: :soft_check, fail_on_exit: false) || 'unknown'
-  return Msf::Exploit::CheckCode::Codes[code]
+  return Msf::Exploit::CheckCode.new(code, nil)
 end
 <% end %>
 


### PR DESCRIPTION
Expands on #12428 by keeping the technical reason separate for contexts where displaying it by self makes more sense (like in tables). The refactor consolidates the default message logic, which allows us to do away with the `CheckCodes` hash for when we had a code, but not the original constant.

Verification
========
- [x] Same steps as #12428 
- [x] Same as above, but with `exploit/linux/smtp/haraka`