### PR TITLE
Imports need workspace

### DIFF
--- a/lib/msf/core/db_manager/import/metasploit_framework/credential.rb
+++ b/lib/msf/core/db_manager/import/metasploit_framework/credential.rb
@@ -17,7 +17,7 @@ module Msf::DBManager::Import::MetasploitFramework::Credential
   # @option args [Mdm::Workspace] :wspace Default: {#workspace}
   # @return [void]
   def import_msf_cred_dump_zip(args = {})
-    wspace = Msf::Util::DBManager.process_opts_workspace(args, framework).name
+    wspace = Msf::Util::DBManager.process_opts_workspace(args, framework)
     origin = Metasploit::Credential::Origin::Import.create!(filename: File.basename(args[:filename]))
     importer = Metasploit::Credential::Importer::Zip.new(workspace: wspace, input: File.open(args[:filename]), origin: origin)
     importer.import!
@@ -27,7 +27,7 @@ module Msf::DBManager::Import::MetasploitFramework::Credential
   # Perform in an import of an msfpwdump file
   def import_msf_pwdump(args={}, &block)
     filename = File.basename(args[:data].path)
-    wspace   = Msf::Util::DBManager.process_opts_workspace(args, framework).name
+    wspace   = Msf::Util::DBManager.process_opts_workspace(args, framework)
     origin   = Metasploit::Credential::Origin::Import.create!(filename: filename)
     importer = Metasploit::Credential::Importer::Pwdump.new(input: args[:data], workspace: wspace, filename: filename, origin:origin)
     importer.import!

--- a/lib/rex/parser/nokogiri_doc_mixin.rb
+++ b/lib/rex/parser/nokogiri_doc_mixin.rb
@@ -148,6 +148,7 @@ module Parser
       end
       return nil if just_the_facts.empty?
       just_the_facts[:task] = @args[:task]
+      just_the_facts[:wspace] = @args[:wspace] # workspace context is a required `fact`
       db.send("report_#{table}", just_the_facts)
     end
 


### PR DESCRIPTION
When importing credentials `Metasploit::Credential::Importer` classes expect to receive an `Mdm::Workspace`.

Also when executing `report*` methods during xml import the workspace is a required `fact`.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `workspace -a first_import`
- [x] `db_import pwdump.txt`
- [x] **Verify** the creds import
- [x] `workspace -a second_import`
- [x] `db_import nexpose_simple_xml_3hosts.xml`
- [x] **Verify** the host and vuln details reported are in the correct workspace.
