### PR TITLE
Fix delimiter selection on powershell payload commands

### DIFF
--- a/lib/msf/base/sessions/powershell.rb
+++ b/lib/msf/base/sessions/powershell.rb
@@ -67,6 +67,7 @@ class Msf::Sessions::PowerShell < Msf::Sessions::CommandShell
         buff = buff.split(/#{strm}\r\n/)[-1]
         buff = buff.split(/#{endm}/)[0]
         buff.gsub!(/(?<=\r\n)PS [^>]*>/, '')
+        return buff
       end
     end
     buff

--- a/lib/msf/base/sessions/powershell.rb
+++ b/lib/msf/base/sessions/powershell.rb
@@ -62,10 +62,10 @@ class Msf::Sessions::PowerShell < Msf::Sessions::CommandShell
       timeout = etime - ::Time.now.to_f
 
       buff << res
-      if buff.match(/#{endm}/)
+      if buff.include?(endm)
         # if you see the end marker, read the buffer from the start marker to the end and then display back to screen
         buff = buff.split(/#{strm}\r\n/)[-1]
-        buff = buff.split(/#{endm}/)[0]
+        buff = buff.split(endm)[0]
         buff.gsub!(/(?<=\r\n)PS [^>]*>/, '')
         return buff
       end

--- a/lib/msf/base/sessions/powershell.rb
+++ b/lib/msf/base/sessions/powershell.rb
@@ -65,9 +65,8 @@ class Msf::Sessions::PowerShell < Msf::Sessions::CommandShell
       if buff.match(/#{endm}/)
         # if you see the end marker, read the buffer from the start marker to the end and then display back to screen
         buff = buff.split(/#{strm}\r\n/)[-1]
-        buff.gsub!(/\nPS .*>/, '')
-        buff.gsub!(/#{endm}/, '')
-        return buff
+        buff = buff.split(/#{endm}/)[0]
+        buff.gsub!(/(?<=\r\n)PS [^>]*>/, '')
       end
     end
     buff

--- a/lib/msf/core/post/common.rb
+++ b/lib/msf/core/post/common.rb
@@ -146,8 +146,7 @@ module Msf::Post::Common
       else
         o = session.shell_command_token("#{cmd} #{args}", time_out)
       end
-      # this is terrible
-      o.chomp!.reverse!.chomp!.reverse! if o
+      o.chomp! if o
     end
     return "" if o.nil?
     return o

--- a/lib/msf/core/post/common.rb
+++ b/lib/msf/core/post/common.rb
@@ -146,7 +146,8 @@ module Msf::Post::Common
       else
         o = session.shell_command_token("#{cmd} #{args}", time_out)
       end
-      o.chomp! if o
+      # this is terrible
+      o.chomp!.reverse!.chomp!.reverse! if o
     end
     return "" if o.nil?
     return o

--- a/lib/msf/core/session/provider/single_command_shell.rb
+++ b/lib/msf/core/session/provider/single_command_shell.rb
@@ -131,7 +131,9 @@ module SingleCommandShell
     # Send the command to the session's stdin.
     # NOTE: if the session echoes input we don't need to echo the token twice.
     shell_write(cmd + "&echo #{token}\n")
-    shell_read_until_token(token, 1, timeout)
+    res = shell_read_until_token(token, 1, timeout)
+    res[0]='' # remove the newline we put in after the token
+    res
   end
 
 

--- a/lib/msf/core/session/provider/single_command_shell.rb
+++ b/lib/msf/core/session/provider/single_command_shell.rb
@@ -132,7 +132,8 @@ module SingleCommandShell
     # NOTE: if the session echoes input we don't need to echo the token twice.
     shell_write(cmd + "&echo #{token}\n")
     res = shell_read_until_token(token, 1, timeout)
-    res[0]='' # remove the newline we put in after the token
+    # I would like a better way to do this, but I don't know of one
+    res.reverse!.chomp!.reverse! # the presence of a leading newline is not consistent
     res
   end
 

--- a/test/modules/post/test/cmd_exec.rb
+++ b/test/modules/post/test/cmd_exec.rb
@@ -19,11 +19,14 @@ class MetasploitModule < Msf::Post
   end
 
   def test_cmd_exec
+    # we are inconsistent reporting windows session types
+    windows_strings = ['windows', 'win']
     vprint_status("Starting cmd_exec tests")
 
     it "should return the result of echo" do
       test_string = Rex::Text.rand_text_alpha(4)
-      if session.platform.eql? 'windows'
+      if windows_strings.include? session.platform and session.type.eql? 'meterpreter'
+        vprint_status("meterpreter?")
         output = cmd_exec('cmd.exe', "/c echo #{test_string}")
       else
         output = cmd_exec("echo #{test_string}")
@@ -31,37 +34,30 @@ class MetasploitModule < Msf::Post
       output == test_string
     end
 
-    # trying to do a sleep in windows without trashing stdout is hard
-    unless session.platform.eql? 'windows'
-      it "should return the result after sleeping" do
+    # Powershell supports this, but not windows meterpreter (unsure about windows shell)
+    if not windows_strings.include? session.platform or session.type.eql? 'powershell'
+      it "should return the full response after sleeping" do
         test_string = Rex::Text.rand_text_alpha(4)
         output = cmd_exec("sleep 1; echo #{test_string}")
         output == test_string
       end
-
       it "should return the full response after sleeping" do
         test_string = Rex::Text.rand_text_alpha(4)
         test_string2 = Rex::Text.rand_text_alpha(4)
-        if session.platform.eql? 'windows'
-          output = cmd_exec('cmd.exe', "/c echo #{test_string} & timeout 1 > null & echo #{test_string2}")
-        else
-          output = cmd_exec("echo #{test_string}; sleep 1; echo #{test_string2}")
-        end
+        output = cmd_exec("echo #{test_string}; sleep 1; echo #{test_string2}")
         output.delete("\r") == "#{test_string}\n#{test_string2}"
       end
-    end
 
-    it "should return the result of echo 10 times" do
-      10.times do
-        test_string = Rex::Text.rand_text_alpha(4)
-        if session.platform.eql? 'windows'
-          output = cmd_exec("cmd.exe", "/c echo #{test_string}")
-        else
+      it "should return the result of echo 10 times" do
+        10.times do
+          test_string = Rex::Text.rand_text_alpha(4)
           output = cmd_exec("echo #{test_string}")
+          return false unless output == test_string
         end
-        return false unless output == test_string
+        true
       end
-      true
+    else
+      vprint_status("Session does not support sleep, skipping sleep tests")
     end
     vprint_status("Finished cmd_exec tests")
   end


### PR DESCRIPTION
While looking at getting some rex-powershell stuff landed, I tried adding powershell payloads to the automated testing, but while the testing system supports it (to my happy surprise), the cmd_exec tests fail.

After some digging, it turns out that the poswershell session was adding the bytestring 0xdad20 after our second delimiter.  For some reason (I now see) rather than splitting on the delimiter, we were deleting the second delimiter so that the odd bytestring remained and screwed up the echo tests.  Normally, this would be taken care of by our call to `chomp`, but the space is not eaten by `chomp, so that protected the trailing characters.

One solution was to call "strip" to the response, but then we'd lose any expected trailing whitespace.  In this case, I simply split on the second delimiter and threw away any trailing characters.

That approach works, but is is super slow.  Significantly slower than I would expect.  If someone can find a faster route, I am game.  Previously, I tried to combine the regexes and split the substring between the delimiters, and it was not appreciably different in speed than this solution.  I also tried using a second buffer under the theory in-place changes might take longer.  No such luck.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use exploit/multi/handler`
- [x] `set payload windows/x64/meterpreter/reverse_tcp`
- [x] `set lhost <you>`
- [x] `set lport <port>`
- [x] `run`
- [x] Get session
- [x] Background session
- [x] `loadpath test/modules`
- [x] `use post/test/cmd_exec`
- [x] `set session 1`
- [x] `set verbose true`
- [x] `run`
- [x] Verify that the tests succeed

There are still some things that need attention in the cmd_exec stuff and I've already got an idea on how to fix this for shells, but I wanted to get this up now and see if anyone had feedback on the performance issue.
