### PR TITLE
Bug Fix: nops `generate` '-s' option ignored

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/nop.rb
+++ b/lib/msf/ui/console/command_dispatcher/nop.rb
@@ -59,7 +59,7 @@ class Nop
           length = val.to_i
         when '-b'
           badchars = Rex::Text.dehex(val)
-        when "-c"
+        when "-s"
           saveregs = val.split(/,\s?/)
         when '-t'
           type = val

--- a/lib/msf/ui/console/command_dispatcher/nop.rb
+++ b/lib/msf/ui/console/command_dispatcher/nop.rb
@@ -59,7 +59,8 @@ class Nop
           length = val.to_i
         when '-b'
           badchars = Rex::Text.dehex(val)
-        when "-s"
+when "-s", "-c"  # 'c' is deprecated; remove later
+  saveregs = val.split(/,\s?/)
           saveregs = val.split(/,\s?/)
         when '-t'
           type = val


### PR DESCRIPTION
This error was trying to parse the contents of undefined '-c' option instead of '-s'.
Making impossible the definition of SaveRegisters from the console.

Step to reproduce:
`msfconsole -q -x 'use nop/x86/single_byte; generate -s esp 10; exit' | grep -v '0m' | tr -d '\n\\x+ ";' | rasm2 -b 32 -D -`
```asm
0x00000000   1                       0e  push cs
0x00000001   1                       d6  salc
0x00000002   1                       54  push esp
0x00000003   1                       f8  clc
0x00000004   1                       43  inc ebx
0x00000005   1                       56  push esi
0x00000006   1                       5a  pop edx
0x00000007   1                       56  push esi
0x00000008   1                       5a  pop edx
0x00000009   1                       44  inc esp
```
As we can see, 'inc esp', and some 'push/pop' instructions have been generated although having explicitly asked to save `esp` register through `generate` command.

This commit addresses this issue