### PR TITLE
Add Cookie check, random payload and report_web_vuln to 'trace' aux module

### DIFF
--- a/modules/auxiliary/scanner/http/trace.rb
+++ b/modules/auxiliary/scanner/http/trace.rb
@@ -4,18 +4,16 @@
 ##
 
 class MetasploitModule < Msf::Auxiliary
-
-  # Exploit mixins should be called first
   include Msf::Exploit::Remote::HttpClient
   include Msf::Auxiliary::WmapScanServer
-  # Scanner mixin should be near last
   include Msf::Auxiliary::Scanner
+  include Msf::Auxiliary::Report
 
   def initialize
     super(
       'Name'        => 'HTTP Cross-Site Tracing Detection',
       'Description' => 'Checks if the host is vulnerable to Cross-Site Tracing (XST)',
-      'Author'       =>
+      'Author'      =>
         [
           'Jay Turla <@shipcod3>' , #Cross-Site Tracing (XST) Checker
           'CG' #HTTP TRACE Detection
@@ -27,33 +25,82 @@ class MetasploitModule < Msf::Auxiliary
           ['URL', 'https://www.owasp.org/index.php/Cross_Site_Tracing']
         ]
     )
+    register_options(
+      [
+        OptString.new('PATH', [ true, "The PATH to use while testing", '/']),
+        OptInt.new('TIMEOUT', [true, 'The socket connect/read timeout in seconds', 20]),
+        OptBool.new('COOKIE_CHECK', [ false, "Check for Cookie header also", false ])
+      ]
+    )
   end
 
   def run_host(target_host)
 
+    timeout = datastore['TIMEOUT']
+
+    rand_payload = Rex::Text.rand_text_alpha(5 + rand(8))
+
+    web_path = normalize_uri(datastore['PATH'])
+    xst_payload = "<script>alert(#{rand_payload})</script>" # XST Payload
+    check_uri = web_path + xst_payload
+
     begin
-      res = send_request_raw({
-        'uri'          => '/<script>alert(1337)</script>', #XST Payload
-        'method'       => 'TRACE',
-      })
+
+      if datastore['COOKIE_CHECK']
+        vprint_status("Sending request #{rhost}:#{rport} (vhost: #{vhost}) with Cookie header check")
+        res = send_request_raw({
+          'uri'    => check_uri,
+          'method' => 'TRACE',
+          'headers' => {
+            'Cookie' => "name=#{xst_payload}"
+          },
+        }, timeout)
+      else
+        vprint_status("Sending request #{rhost}:#{rport} (vhost: #{vhost})")
+        res = send_request_raw({
+          'uri'    => check_uri,
+          'method' => 'TRACE',
+        }, timeout)
+      end
 
       unless res
-        vprint_error("#{rhost}:#{rport} did not reply to our request")
+        vprint_error("#{rhost}:#{rport} (vhost: #{vhost})[#{res.code}] did not reply to our request")
         return
       end
 
-      if res.body.to_s.index('/<script>alert(1337)</script>')
-        print_good("#{rhost}:#{rport} is vulnerable to Cross-Site Tracing")
-        report_vuln(
-          :host   => rhost,
-          :port   => rport,
-          :proto  => 'tcp',
-          :sname  => (ssl ? 'https' : 'http'),
-          :info   => "Vulnerable to Cross-Site Tracing",
-        )
+      if res.body.to_s.index("#{web_path}#{xst_payload}")
+        print_good("#{rhost}:#{rport} (vhost: #{vhost})[#{res.code}] is vulnerable to Cross-Site Tracing")
+
+        vprint_status("#{rhost}:#{rport} (vhost: #{vhost})[#{res.code}] Response: [#{res.body.to_s}]")
+
+        report_vuln({
+          :host  => rhost,
+          :port  => rport,
+          :proto => 'tcp',
+          :sname => (ssl ? 'https' : 'http'),
+          :name  => self.name,
+          :info  => "Module used #{self.fullname}, vhost: #{vhost}",
+          :refs  => self.references
+        })
+
+        report_web_vuln({
+          :host        => rhost,
+          :port        => rport,
+          :vhost       => vhost,
+          :path        => web_path,
+          :pname       => xst_payload,
+          :risk        => 2,
+          :proof       => "#{xst_payload} payload with TRACE method",
+          :description => "Vulnerable to Cross-Site Tracing",
+          :name        => self.fullname,
+          :category    => "web",
+          :method      => "GET" # specifing TRACE... Error: "ActiveRecord" "RecordInvalid" "Method is not included in the list"
+        })
+
       else
-        vprint_error("#{rhost}:#{rport} returned #{res.code} #{res.message}")
+        vprint_error("#{rhost}:#{rport} (vhost: #{vhost}) returned #{res.code} #{res.message}")
       end
+
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
     rescue ::Timeout::Error, ::Errno::EPIPE
     end


### PR DESCRIPTION
Update "auxiliary/scanner/http/trace" module:

- add Cookie header check option
- add random string payload
- add report_web_vuln

## Verification
```
msf5 auxiliary(scanner/http/brute_dirs) > use auxiliary/scanner/http/trace
msf5 auxiliary(scanner/http/trace) > set RHOSTS 1.2.3.4
RHOSTS => 1.2.3.4
msf5 auxiliary(scanner/http/trace) > set VHOST www.example.org
VHOST => www.example.org
msf5 auxiliary(scanner/http/trace) > set COOKIE_CHECK true
COOKIE_CHECK => true
msf5 auxiliary(scanner/http/trace) > set VERBOSE true
VERBOSE => true
msf5 auxiliary(scanner/http/trace) > run

[*] Sending request 1.2.3.4:80 (vhost: www.example.org) with Cookie header check
[+] 1.2.3.4:80 (vhost: www.example.org)[200] is vulnerable to Cross-Site Tracing
[*] 1.2.3.4:80 (vhost: www.example.org)[200] Response: [TRACE /<script>alert(sBmsJfGAupSt)</script> HTTP/1.1
Host: www.example.org
User-Agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)
Cookie: name=<script>alert(sBmsJfGAupSt)</script>
Content-Length: 0

]
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf5 auxiliary(scanner/http/trace) >
msf5 auxiliary(scanner/http/trace) > set VERBOSE false
VERBOSE => false
msf5 auxiliary(scanner/http/trace) > run

[+] 1.2.3.4:80 (vhost: www.example.org)[200] is vulnerable to Cross-Site Tracing
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

## Note
In "report_web_vuln" I put GET method (:method      => "GET") because ActiveRecord not permits TRACE:

_specifing TRACE... Error: "ActiveRecord" "RecordInvalid" "Method is not included in the list"_