### PR TITLE
Fix undefined port (RPORT option ) in SAP brute module

### DIFF
--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_brute_login.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_brute_login.rb
@@ -167,7 +167,7 @@ class MetasploitModule < Msf::Auxiliary
 
       report_cred(
         ip: rhost,
-        port: datastore['RPORT'],
+        port: rport,
         user: user,
         password: pass,
         service_name: 'sap-managementconsole',

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_brute_login.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_brute_login.rb
@@ -93,6 +93,8 @@ class MetasploitModule < Msf::Auxiliary
       user = user.gsub("<SAPSID>", datastore["SAP_SID"].downcase)
       pass = pass.gsub("<SAPSID>", datastore["SAP_SID"])
     end
+    
+    port = datastore['RPORT']
 
     print_status("Trying username:'#{user}' password:'#{pass}'")
     success = false

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_brute_login.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_brute_login.rb
@@ -94,8 +94,6 @@ class MetasploitModule < Msf::Auxiliary
       pass = pass.gsub("<SAPSID>", datastore["SAP_SID"])
     end
 
-    port = datastore['RPORT']
-
     print_status("Trying username:'#{user}' password:'#{pass}'")
     success = false
 
@@ -169,7 +167,7 @@ class MetasploitModule < Msf::Auxiliary
 
       report_cred(
         ip: rhost,
-        port: port,
+        port: datastore['RPORT'],
         user: user,
         password: pass,
         service_name: 'sap-managementconsole',

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_brute_login.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_brute_login.rb
@@ -93,7 +93,7 @@ class MetasploitModule < Msf::Auxiliary
       user = user.gsub("<SAPSID>", datastore["SAP_SID"].downcase)
       pass = pass.gsub("<SAPSID>", datastore["SAP_SID"])
     end
-    
+
     port = datastore['RPORT']
 
     print_status("Trying username:'#{user}' password:'#{pass}'")


### PR DESCRIPTION
Define local variable `port`, to reflect the value of RPORT, 
otherwise, L172 fails, as port (RPORT) is not defined

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use scanner/sap/sap_mgmt_con_brute_login`
- [x] set RHOSTS <target>
- [x] set PASSWORD a_password
- [x] ... find credentials that work

## previous error

```
[-] Auxiliary failed: NameError undefined local variable or method `port' for #<Msf::Modules::Auxiliary__Scanner__Sap__Sap_mgmt_con_brute_login::MetasploitModule:0x000055dad69f4f78>
Did you mean?  rport
[-] Call stack:
[-]   /usr/share/metasploit-framework/modules/auxiliary/scanner/sap/sap_mgmt_con_brute_login.rb:170:in `enum_user'
[-]   /usr/share/metasploit-framework/modules/auxiliary/scanner/sap/sap_mgmt_con_brute_login.rb:58:in `block in run_host'
[-]   /usr/share/metasploit-framework/lib/msf/core/auxiliary/auth_brute.rb:211:in `block in each_user_pass'
[-]   /usr/share/metasploit-framework/lib/msf/core/auxiliary/auth_brute.rb:179:in `each'
[-]   /usr/share/metasploit-framework/lib/msf/core/auxiliary/auth_brute.rb:179:in `each_user_pass'
[-]   /usr/share/metasploit-framework/modules/auxiliary/scanner/sap/sap_mgmt_con_brute_login.rb:57:in `run_host'
[-]   /usr/share/metasploit-framework/lib/msf/core/auxiliary/scanner.rb:111:in `block (2 levels) in run'
[-]   /usr/share/metasploit-framework/lib/msf/core/thread_manager.rb:106:in `block in spawn'

```