### PR TITLE
Small changes to the host_header_injection aux module

### DIFF
--- a/modules/auxiliary/scanner/http/host_header_injection.rb
+++ b/modules/auxiliary/scanner/http/host_header_injection.rb
@@ -26,17 +26,16 @@ class MetasploitModule < Msf::Auxiliary
     ))
 
     register_options([
-      OptString.new('PATH', [ true, "The PATH to use while testing", '/']),
-      OptInt.new('TIMEOUT', [true, 'The socket connect/read timeout in seconds', 20]),
+      OptString.new('PATH', [true, "The PATH to use while testing", '/']),
       OptEnum.new('METHOD', [true, 'HTTP Request Method', 'GET', ['GET', 'POST']]),
       OptString.new('TARGETHOST', [false, 'The redirector target. Default is <random>.com']),
-      OptBool.new('SHOW_EVIDENCE', [ false, "Show evidences: headers or body", false ])
+      OptString.new('DATA', [false, 'POST data, if necessary', '']),
+      OptBool.new('SHOW_EVIDENCE', [false, "Show evidences: headers or body", false])
     ])
   end
 
   def run_host(ip)
 
-    timeout = datastore['TIMEOUT']
     web_path = normalize_uri(datastore['PATH'])
     http_method = datastore['METHOD']
     target_host = datastore['TARGETHOST'] || Rex::Text.rand_text_alpha_lower(8)+".com"
@@ -57,12 +56,13 @@ class MetasploitModule < Msf::Auxiliary
       res = send_request_raw({
         'uri'     => web_path,
         'method'  => http_method,
+        'data'    => datastore['DATA'],
         'headers' => {
           'Host'             => target_host,
           'X-Host'           => target_host,
           'X-Forwarded-Host' => target_host
         }
-      }, timeout)
+      })
 
       unless res
         vprint_error("#{rhost}:#{rport}#{web_path} (#{vhost}) did not reply to our request")


### PR DESCRIPTION
This PR includes the following changes:

- Add PATH, TIMEOUT, METHOD, SHOW_EVIDENCE options;
- Add random TARGET_HOST option;
- Add 'X-Host' header;
- Cosmetic tweaks to a few modules;

## Verification
```

msf5 > use auxiliary/scanner/http/host_header_injection
msf5 auxiliary(scanner/http/host_header_injection) > set RHOSTS 1.2.3.4
RHOSTS => 1.2.3.4
msf5 auxiliary(scanner/http/host_header_injection) > set VHOST www.example.org
VHOST => www.example.org
msf5 auxiliary(scanner/http/host_header_injection) > show options

Module options (auxiliary/scanner/http/host_header_injection):

   Name           Current Setting  Required  Description
   ----           ---------------  --------  -----------
   METHOD         GET              yes       HTTP Request Method (Accepted: GET, POST)
   PATH           /                yes       The PATH to use while testing
   Proxies                         no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS         1.2.3.4   yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
   RPORT          80               yes       The target port (TCP)
   SHOW_EVIDENCE  false            no        Show evidences: headers or body
   SSL            false            no        Negotiate SSL/TLS for outgoing connections
   TARGETHOST                      no        The redirector target. Default is <random>.com
   THREADS        1                yes       The number of concurrent threads
   TIMEOUT        20               yes       The socket connect/read timeout in seconds
   VHOST          www.example.org  no        HTTP server virtual host

msf5 auxiliary(scanner/http/host_header_injection) > run

[+] 1.2.3.4:80/ (www.example.org)(200)(GET)(evidence into body) is vulnerable to HTTP Host header injection
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf5 auxiliary(scanner/http/host_header_injection) > set VERBOSE true
VERBOSE => true
msf5 auxiliary(scanner/http/host_header_injection) > run

[*] Sending request 1.2.3.4:80/ (www.example.org)(GET) with 'Host' value 'yebutlwb.com'
[+] 1.2.3.4:80/ (www.example.org)(200)(GET)(evidence into body) is vulnerable to HTTP Host header injection
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf5 auxiliary(scanner/http/host_header_injection) > set SHOW_EVIDENCE true
SHOW_EVIDENCE => true
msf5 auxiliary(scanner/http/host_header_injection) > run

[*] Sending request 1.2.3.4:80/ (www.example.org)(GET) with 'Host' value 'xycfqoca.com'
[*] Body: [<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
<html xmlns="http://www.w3.org/1999/xhtml">
    <head>
        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
        <title>
            xycfqoca.com        </title>
<style type="text/css">
/*<![CDATA[*/
...
...
    </body>
</html>
]
[+] 1.2.3.4:80/ (www.example.org)(200)(GET)(evidence into body) is vulnerable to HTTP Host header injection
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf5 auxiliary(scanner/http/host_header_injection) > set SHOW_EVIDENCE false
SHOW_EVIDENCE => false
msf5 auxiliary(scanner/http/host_header_injection) > set TARGETHOST yo.com
TARGETHOST => yo.com
msf5 auxiliary(scanner/http/host_header_injection) > run

[*] Sending request 1.2.3.4:80/ (www.example.org)(GET) with 'Host' value 'yo.com'
[+] 1.2.3.4:80/ (www.example.org)(200)(GET)(evidence into body) is vulnerable to HTTP Host header injection
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```
