### PR TITLE
Fix call to method in null object in rpc_creds method

### DIFF
--- a/lib/msf/core/rpc/v10/rpc_db.rb
+++ b/lib/msf/core/rpc/v10/rpc_db.rb
@@ -276,7 +276,20 @@ public
           port = login.service.port.to_i
           proto = login.service.proto.to_s
         end
-        ret[:creds] << {
+
+        if cred.private.nil?
+            ret[:creds] << {
+                :user => cred.public.username.to_s,
+                :pass => nil,
+                :updated_at => nil,
+                :type => nil,
+                :host => host,
+                :port => port,
+                :proto => proto,
+                :sname => sname
+            }
+        else
+            ret[:creds] << {
                 :user => cred.public.username.to_s,
                 :pass => cred.private.data.to_s,
                 :updated_at => cred.private.updated_at.to_i,
@@ -284,7 +297,10 @@ public
                 :host => host,
                 :port => port,
                 :proto => proto,
-                :sname => sname}
+                :sname => sname
+            }
+        end
+
       end
       ret
     }


### PR DESCRIPTION
Fixes a bug that causes RPC requests for credentials to yield exceptions.

## Verification

Start msfrpcd stand-alone or through msfconsole
Run a scanner module that only extracts usernames, e.g., auxiliary/scanner/ssh/ssh_enumusers
Make an RPC-request for database credentials.
Get exception with stack trace pointing to call of method on null object (cred.private is null)
