### PR TITLE
Fix failed login check in exploit/multi/http/coldfusion_rds for ColdFusion 9.something

### DIFF
--- a/lib/msf/core/module/deprecated.rb
+++ b/lib/msf/core/module/deprecated.rb
@@ -44,7 +44,7 @@ module Msf::Module::Deprecated
       add_warning do
         if fullname == self.class.deprecated_name
           [ "*%red" + "The module #{fullname} has been moved!".center(88) + "%clr*",
-            "*" + "You are now using #{realname}".center(88) + "*" ]
+            "*" + "You are using #{realname}".center(88) + "*" ]
         end
       end
     end

--- a/modules/exploits/linux/http/cve_2019_1663_cisco_rmi_rce.rb
+++ b/modules/exploits/linux/http/cve_2019_1663_cisco_rmi_rce.rb
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::CmdStager
-  include Msf::Exploit::Deprecated
+  include Msf::Module::Deprecated
 
   moved_from 'exploit/linux/http/cisco_rv130_rmi_rce'
 

--- a/modules/exploits/linux/http/ubiquiti_airos_file_upload.rb
+++ b/modules/exploits/linux/http/ubiquiti_airos_file_upload.rb
@@ -13,7 +13,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::Remote::SSH
-  include Msf::Exploit::Deprecated
+  include Msf::Module::Deprecated
 
   moved_from 'exploit/linux/ssh/ubiquiti_airos_file_upload'
 

--- a/modules/exploits/multi/http/coldfusion_rds.rb
+++ b/modules/exploits/multi/http/coldfusion_rds.rb
@@ -235,7 +235,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'cookie' => cookie
     })
 
-    if res and res.code == 200 and res.body.to_s =~ /ColdFusion Administrator Login/
+    if res and res.code == 200 and res.body.to_s =~ /ColdFusion Administrator/
       print_good("Logged in as Administrator!")
     else
       fail_with(Failure::Unknown, "#{peer} - Login Failed")

--- a/modules/exploits/multi/http/coldfusion_rds.rb
+++ b/modules/exploits/multi/http/coldfusion_rds.rb
@@ -13,7 +13,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'            => 'Adobe ColdFusion 9 Administrative Login Bypass',
+      'Name'            => 'Adobe ColdFusion RDS Administrative Login Bypass',
       'Description'     => %q{
         Adobe ColdFusion 9.0, 9.0.1, 9.0.2, and 10 allows remote
         attackers to bypass authentication using the RDS component. Due to

--- a/modules/exploits/multi/http/coldfusion_rds_auth_bypass.rb
+++ b/modules/exploits/multi/http/coldfusion_rds_auth_bypass.rb
@@ -8,6 +8,9 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::Remote::HttpServer::HTML
   include Msf::Exploit::EXE
+  include Msf::Module::Deprecated
+
+  moved_from 'exploit/multi/http/coldfusion_rds'
 
   Rank = GreatRanking
 

--- a/modules/exploits/multi/http/coldfusion_rds_auth_bypass.rb
+++ b/modules/exploits/multi/http/coldfusion_rds_auth_bypass.rb
@@ -82,7 +82,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(uri, datastore['CFIDDIR'], 'administrator', 'index.cfm'),
     })
 
-    if res and res.code == 200 and res.body.to_s =~ /ColdFusion Administrator Login/
+    if res && res.code == 200 && res.body.include?('ColdFusion Administrator Login')
        vprint_good "Administrator access available"
     else
       return Exploit::CheckCode::Safe
@@ -114,7 +114,7 @@ class MetasploitModule < Msf::Exploit::Remote
        }
     })
 
-    if res and res.code == 200 and res.body.to_s =~ /true/
+    if res && res.code == 200 && res.body.include?('true')
       return Exploit::CheckCode::Appears
     else
       return Exploit::CheckCode::Safe
@@ -219,14 +219,14 @@ class MetasploitModule < Msf::Exploit::Remote
        }
     })
 
-    unless res and res.code == 200
+    unless res && res.code == 200
       fail_with(Failure::Unknown, "#{peer} - RDS component was unreachable")
     end
 
     #deal with annoying cookie data prepending (sunglasses)
     cookie = res.get_cookies
 
-    if res and res.code == 200 and cookie =~ /CFAUTHORIZATION_cfadmin=;(.*)/
+    if res && res.code == 200 && cookie =~ /CFAUTHORIZATION_cfadmin=;(.*)/
       cookie = $1
     else
       fail_with(Failure::Unknown, "#{peer} - Unable to get auth cookie")
@@ -238,7 +238,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'cookie' => cookie
     })
 
-    if res && res.code == 200 && res.body.to_s.include?('ColdFusion Administrator')
+    if res && res.code == 200 && res.body.include?('ColdFusion Administrator')
       print_good("Logged in as Administrator!")
     else
       fail_with(Failure::Unknown, "#{peer} - Login Failed")
@@ -254,7 +254,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'cookie' => cookie
     })
 
-    unless res and res.code == 200
+    unless res && res.code == 200
       fail_with(Failure::Unknown, "#{peer} - Mappings URL was unreachable")
     end
 
@@ -284,7 +284,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'cookie' => cookie
     })
 
-    unless res and res.code == 200 or res.code == 302 #302s can happen but it still works, http black magic!
+    unless res && res.code == 200 || res.code == 302 #302s can happen but it still works, http black magic!
       fail_with(Failure::Unknown, "#{peer} - Scheduled task failed")
     end
 
@@ -299,7 +299,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'cookie' => cookie
       })
 
-    if res and res.code == 200 and res.body.to_s =~ /This scheduled task was completed successfully/
+    if res && res.code == 200 && res.body.include?('This scheduled task was completed successfully')
       print_good("Scheduled task completed successfully")
     else
       fail_with(Failure::Unknown, "#{peer} - Scheduled task failed")
@@ -316,7 +316,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'cookie' => cookie
     })
 
-    unless res and res.code == 200
+    unless res && res.code == 200
       print_error("Scheduled task deletion failed, cleanup might be needed!")
     end
   end

--- a/modules/exploits/multi/http/coldfusion_rds_auth_bypass.rb
+++ b/modules/exploits/multi/http/coldfusion_rds_auth_bypass.rb
@@ -238,7 +238,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'cookie' => cookie
     })
 
-    if res and res.code == 200 and res.body.to_s =~ /ColdFusion Administrator/
+    if res && res.code == 200 && res.body.to_s.include?('ColdFusion Administrator')
       print_good("Logged in as Administrator!")
     else
       fail_with(Failure::Unknown, "#{peer} - Login Failed")

--- a/modules/exploits/multi/http/coldfusion_rds_auth_bypass.rb
+++ b/modules/exploits/multi/http/coldfusion_rds_auth_bypass.rb
@@ -16,7 +16,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'            => 'Adobe ColdFusion RDS Administrative Login Bypass',
+      'Name'            => 'Adobe ColdFusion RDS Authentication Bypass',
       'Description'     => %q{
         Adobe ColdFusion 9.0, 9.0.1, 9.0.2, and 10 allows remote
         attackers to bypass authentication using the RDS component. Due to

--- a/modules/exploits/windows/local/payload_inject.rb
+++ b/modules/exploits/windows/local/payload_inject.rb
@@ -9,7 +9,7 @@ class MetasploitModule < Msf::Exploit::Local
   Rank = ExcellentRanking
 
   include Msf::Post::Windows::Process
-  include Msf::Exploit::Deprecated
+  include Msf::Module::Deprecated
 
   moved_from 'post/windows/manage/payload_inject'
 


### PR DESCRIPTION
It was merely "ColdFusion Administrator" for the version I tested. The `/ColdFusion Administrator Login/` check earlier is fine, since it's the login page.