### PR TITLE
Ensure URGENT/11 module works on 4.x

### DIFF
--- a/modules/auxiliary/scanner/vxworks/urgent11_check.rb
+++ b/modules/auxiliary/scanner/vxworks/urgent11_check.rb
@@ -38,7 +38,7 @@ class MetasploitModule < Msf::Auxiliary
       OptInt.new('RetransmissionRate', required: true, default: 3, desc: 'Send n TCP packets')
     ])
 
-    deregister_options('PCAPFILE', 'FILTER')
+    deregister_options('PCAPFILE', 'FILTER', 'RHOST')
   end
 
   #


### PR DESCRIPTION
Discovered that the new URGENT/11 scanner needs a tweak to work properly on 4.x and consequently the Pro UI and `msfpro` console.  Verified that this tweak works for UI and `msfpro` console.

## Verification

List the steps needed to make sure this thing works

- [x] Verify auxiliary/scanner/vxworks/urgent11_check works from Pro UI and `msfpro` console.

