### PR TITLE
Allow partial HTTP response (default nil) due to timeout

### DIFF
--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -305,7 +305,7 @@ module Exploit::Remote::HttpClient
   #
   # Passes +opts+ through directly to Rex::Proto::Http::Client#request_raw.
   #
-  def send_request_raw(opts={}, timeout = 20)
+  def send_request_raw(opts={}, timeout = 20, disconnect = false, persist = false)
     if datastore['HttpClientTimeout'] && datastore['HttpClientTimeout'] > 0
       actual_timeout = datastore['HttpClientTimeout']
     else
@@ -323,7 +323,7 @@ module Exploit::Remote::HttpClient
         print_line(r.to_s)
       end
 
-      res = c.send_recv(r, actual_timeout)
+      res = c.send_recv(r, actual_timeout, persist, opts)
 
       if datastore['HttpTrace']
         print_line('#' * 20)
@@ -335,6 +335,8 @@ module Exploit::Remote::HttpClient
           print_line(res.to_terminal_output)
         end
       end
+
+      disconnect(c) if disconnect && !persist
 
       res
     rescue ::Errno::EPIPE, ::Timeout::Error => e
@@ -356,7 +358,7 @@ module Exploit::Remote::HttpClient
   # Passes `opts` through directly to {Rex::Proto::Http::Client#request_cgi}.
   #
   # @return (see Rex::Proto::Http::Client#send_recv))
-  def send_request_cgi(opts={}, timeout = 20, disconnect = true)
+  def send_request_cgi(opts={}, timeout = 20, disconnect = true, persist = false)
     if datastore['HttpClientTimeout'] && datastore['HttpClientTimeout'] > 0
       actual_timeout = datastore['HttpClientTimeout']
     else
@@ -376,7 +378,7 @@ module Exploit::Remote::HttpClient
         print_line(r.to_s)
       end
 
-      res = c.send_recv(r, actual_timeout)
+      res = c.send_recv(r, actual_timeout, persist, opts)
 
       if datastore['HttpTrace']
         print_line('#' * 20)
@@ -388,7 +390,9 @@ module Exploit::Remote::HttpClient
           print_line(res.to_terminal_output)
         end
       end
-      disconnect(c) if disconnect
+
+      disconnect(c) if disconnect && !persist
+
       res
     rescue ::Errno::EPIPE, ::Timeout::Error => e
       print_line(e.message) if datastore['HttpTrace']

--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -43,6 +43,7 @@ module Exploit::Remote::HttpClient
         OptBool.new('FingerprintCheck', [ false, 'Conduct a pre-exploit fingerprint verification', true]),
         OptString.new('DOMAIN', [ true, 'The domain to use for windows authentification', 'WORKSTATION']),
         OptInt.new('HttpClientTimeout', [false, 'HTTP connection and receive timeout']),
+        OptBool.new('HttpPartialResponses', [false, 'Return partial HTTP responses despite timeouts', false]),
         OptBool.new('HttpTrace', [false, 'Show the raw HTTP requests and responses', false])
       ], self.class
     )
@@ -161,6 +162,7 @@ module Exploit::Remote::HttpClient
     nclient.set_config(
       'vhost' => opts['vhost'] || opts['rhost'] || self.vhost(),
       'agent' => datastore['UserAgent'],
+      'partial' => opts['partial'] || datastore['HttpPartialResponses'],
       'uri_encode_mode'        => datastore['HTTP::uri_encode_mode'],
       'uri_full_url'           => datastore['HTTP::uri_full_url'],
       'pad_method_uri_count'   => datastore['HTTP::pad_method_uri_count'],
@@ -305,7 +307,7 @@ module Exploit::Remote::HttpClient
   #
   # Passes +opts+ through directly to Rex::Proto::Http::Client#request_raw.
   #
-  def send_request_raw(opts={}, timeout = 20, disconnect = false, persist = false)
+  def send_request_raw(opts={}, timeout = 20, disconnect = false)
     if datastore['HttpClientTimeout'] && datastore['HttpClientTimeout'] > 0
       actual_timeout = datastore['HttpClientTimeout']
     else
@@ -323,7 +325,7 @@ module Exploit::Remote::HttpClient
         print_line(r.to_s)
       end
 
-      res = c.send_recv(r, actual_timeout, persist, opts)
+      res = c.send_recv(r, actual_timeout)
 
       if datastore['HttpTrace']
         print_line('#' * 20)
@@ -336,7 +338,7 @@ module Exploit::Remote::HttpClient
         end
       end
 
-      disconnect(c) if disconnect && !persist
+      disconnect(c) if disconnect
 
       res
     rescue ::Errno::EPIPE, ::Timeout::Error => e
@@ -358,7 +360,7 @@ module Exploit::Remote::HttpClient
   # Passes `opts` through directly to {Rex::Proto::Http::Client#request_cgi}.
   #
   # @return (see Rex::Proto::Http::Client#send_recv))
-  def send_request_cgi(opts={}, timeout = 20, disconnect = true, persist = false)
+  def send_request_cgi(opts={}, timeout = 20, disconnect = true)
     if datastore['HttpClientTimeout'] && datastore['HttpClientTimeout'] > 0
       actual_timeout = datastore['HttpClientTimeout']
     else
@@ -378,7 +380,7 @@ module Exploit::Remote::HttpClient
         print_line(r.to_s)
       end
 
-      res = c.send_recv(r, actual_timeout, persist, opts)
+      res = c.send_recv(r, actual_timeout)
 
       if datastore['HttpTrace']
         print_line('#' * 20)
@@ -391,7 +393,7 @@ module Exploit::Remote::HttpClient
         end
       end
 
-      disconnect(c) if disconnect && !persist
+      disconnect(c) if disconnect
 
       res
     rescue ::Errno::EPIPE, ::Timeout::Error => e

--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -190,6 +190,7 @@ module Exploit::Remote::HttpClient
       'DigestAuthIIS'          => datastore['DigestAuthIIS']
     )
 
+    # NOTE: Please use opts['headers'] to programmatically set headers
     if datastore['HttpRawHeaders'] && File.readable?(datastore['HttpRawHeaders'])
       # Templatize with ERB
       headers = ERB.new(File.read(datastore['HttpRawHeaders'])).result(binding)

--- a/lib/rex/proto/http/client.rb
+++ b/lib/rex/proto/http/client.rb
@@ -206,8 +206,8 @@ class Client
   # authentication and return the final response
   #
   # @return (see #_send_recv)
-  def send_recv(req, t = -1, persist=false)
-    res = _send_recv(req,t,persist)
+  def send_recv(req, t = -1, persist = false, opts = {})
+    res = _send_recv(req, t, persist, opts)
     if res and res.code == 401 and res.headers['WWW-Authenticate']
       res = send_auth(res, req.opts, t, persist)
     end
@@ -224,10 +224,10 @@ class Client
   # authentication handling.
   #
   # @return (see #read_response)
-  def _send_recv(req, t = -1, persist=false)
+  def _send_recv(req, t = -1, persist = false, opts = {})
     @pipeline = persist
     send_request(req, t)
-    res = read_response(t)
+    res = read_response(t, opts)
     res.request = req.to_s if res
     res.peerinfo = peerinfo if res
     res
@@ -605,6 +605,9 @@ class Client
     end
 
     resp
+  rescue Timeout::Error
+    # Allow partial response due to timeout
+    resp if opts['partial']
   end
 
   #

--- a/lib/rex/proto/http/client.rb
+++ b/lib/rex/proto/http/client.rb
@@ -117,7 +117,7 @@ class Client
   # @option opts 'method'        [String] HTTP method to use in the request, not limited to standard methods defined by rfc2616, default: GET
   # @option opts 'proto'         [String] protocol, default: HTTP
   # @option opts 'query'         [String] raw query string
-  # @option opts 'raw_headers'   [Hash]   HTTP headers
+  # @option opts 'raw_headers'   [String] Raw HTTP headers
   # @option opts 'uri'           [String] the URI to request
   # @option opts 'version'       [String] version of the protocol, default: 1.1
   # @option opts 'vhost'         [String] Host header value

--- a/lib/rex/proto/http/client.rb
+++ b/lib/rex/proto/http/client.rb
@@ -66,7 +66,8 @@ class Client
       'uri_fake_end'           => 'bool',
       'uri_fake_params_start'  => 'bool',
       'header_folding'         => 'bool',
-      'chunked_size'           => 'integer'
+      'chunked_size'           => 'integer',
+      'partial'                => 'bool'
     }
 
 
@@ -206,8 +207,8 @@ class Client
   # authentication and return the final response
   #
   # @return (see #_send_recv)
-  def send_recv(req, t = -1, persist = false, opts = {})
-    res = _send_recv(req, t, persist, opts)
+  def send_recv(req, t = -1, persist = false)
+    res = _send_recv(req, t, persist)
     if res and res.code == 401 and res.headers['WWW-Authenticate']
       res = send_auth(res, req.opts, t, persist)
     end
@@ -224,10 +225,10 @@ class Client
   # authentication handling.
   #
   # @return (see #read_response)
-  def _send_recv(req, t = -1, persist = false, opts = {})
+  def _send_recv(req, t = -1, persist = false)
     @pipeline = persist
     send_request(req, t)
-    res = read_response(t, opts)
+    res = read_response(t)
     res.request = req.to_s if res
     res.peerinfo = peerinfo if res
     res
@@ -607,7 +608,7 @@ class Client
     resp
   rescue Timeout::Error
     # Allow partial response due to timeout
-    resp if opts['partial']
+    resp if config['partial']
   end
 
   #

--- a/lib/rex/proto/http/client.rb
+++ b/lib/rex/proto/http/client.rb
@@ -93,7 +93,7 @@ class Client
       # config.
 
       if(typ == 'bool')
-        val = (val =~ /^(t|y|1)$/i ? true : false || val === true)
+        val = (val =~ /^(t|y|1)/i ? true : false || val === true)
       end
 
       if(typ == 'integer')

--- a/lib/rex/proto/http/client_request.rb
+++ b/lib/rex/proto/http/client_request.rb
@@ -24,6 +24,7 @@ class ClientRequest
     'headers'                => nil,
     'raw_headers'            => '',
     'method'                 => 'GET',
+    'partial'                => false,
     'path_info'              => '',
     'port'                   => 80,
     'proto'                  => 'HTTP',

--- a/lib/rex/proto/http/client_request.rb
+++ b/lib/rex/proto/http/client_request.rb
@@ -196,7 +196,7 @@ class ClientRequest
 
     req << set_content_type_header
     req << set_content_len_header(pstr.length)
-    req << set_chunked_header()
+    req << set_chunked_header
     req << opts['raw_headers']
     req << set_body(pstr)
   end


### PR DESCRIPTION
I also added a `disconnect` option to `send_request_raw` to match `send_request_cgi`.

- [x] ~See if pipelining is even functional, specifically through this API; remove from method definition and hardcode to `false` if it isn't?~ Refactored to avoid changing the user API!

## Before

```
####################
# Request:
####################
GET /dana-na/../dana/html5acc/guacamole/../../../../../../data/runtime/mtmp/lmdb/dataa/data.mdb?/dana/html5acc/guacamole/ HTTP/1.1
Host: [redacted]
User-Agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)


execution expired
```

## After

```
####################
# Request:
####################
GET /dana-na/../dana/html5acc/guacamole/../../../../../../data/runtime/mtmp/lmdb/dataa/data.mdb?/dana/html5acc/guacamole/ HTTP/1.1
Host: [redacted]
User-Agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)


####################
# Response:
####################
HTTP/1.1 200 OK
Cache-Control: max-age=86400, must-revalidate
Last-Modified: Wed, 18 Sep 2019 20:27:02 GMT
Content-Length: 41943040
X-Frame-Options: SAMEORIGIN
Strict-Transport-Security: max-age=31536000

���������������������
```

#12007, #12220