### PR TITLE
Bugfix: add faraday dependency.

### DIFF
--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -203,4 +203,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'aws-sdk-s3'
   spec.add_runtime_dependency 'aws-sdk-ec2'
   spec.add_runtime_dependency 'aws-sdk-iam'
+  
+  # Bugfix: add faraday dependency.
+  spec.add_runtime_dependency 'faraday'
 end


### PR DESCRIPTION
If the faraday dependency is not added, then the metasploit won't start and will show the following error:

```
/usr/lib64/ruby/gems/2.4.0/gems/backports-3.11.4/lib/backports/std_lib.rb:9:in `require': cannot load such file -- faraday (LoadError)
        from /usr/lib64/ruby/gems/2.4.0/gems/backports-3.11.4/lib/backports/std_lib.rb:9:in `require_with_backports'
        (... long stack trace ...)
        from /usr/lib/metasploit9999/lib/metasploit/framework/command/base.rb:82:in `start'
        from /usr/lib/metasploit/msfconsole:49:in `<main>'
```