### PR TITLE
[MSF-12525] Check for ip4 on normalize

### DIFF
--- a/lib/msf/core/opt_address_local.rb
+++ b/lib/msf/core/opt_address_local.rb
@@ -1,4 +1,5 @@
 # -*- coding: binary -*-
+
 require 'network_interface'
 
 module Msf

--- a/lib/msf/core/opt_address_local.rb
+++ b/lib/msf/core/opt_address_local.rb
@@ -22,7 +22,7 @@ class OptAddressLocal < OptAddress
     # Strip interface name from address (see getifaddrs(3))
     addrs = addrs.map { |x| x['addr'].split('%').first }.select do |addr|
       begin
-        IPAddr.new(addr)
+        IPAddr.new(addr).ipv4? && !addr[/^127.*/]
       rescue IPAddr::InvalidAddressError
         false
       end


### PR DESCRIPTION
If applied, attempts to resolve issue reported here:

Fixes #12525.

`normalize` returns wrong address on interface for `en0`; breaking assertion. Adding check for ip4 resolves this issue.