### PR TITLE
Add module notes for Reliability and Stability

### DIFF
--- a/modules/exploits/linux/local/af_packet_chocobo_root_priv_esc.rb
+++ b/modules/exploits/linux/local/af_packet_chocobo_root_priv_esc.rb
@@ -62,11 +62,13 @@ class MetasploitModule < Msf::Exploit::Local
           [ 'URL', 'https://www.securitytracker.com/id/1037403' ],
           [ 'URL', 'https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=84ac7260236a49c79eede91617700174c2c19b0c' ]
         ],
-      'DefaultTarget'  => 0,
-      'Notes' =>
-          {
-              'AKA' => ['chocobo_root.c']
-          }
+      'Notes'          =>
+        {
+          'AKA'         => ['chocobo_root.c'],
+          'Reliability' => [ REPEATABLE_SESSION ],
+          'Stability'   => [ CRASH_OS_DOWN ]
+        },
+      'DefaultTarget'  => 0
     ))
     register_options [
       OptInt.new('TIMEOUT', [ true, 'Race timeout (seconds)', '600' ]),

--- a/modules/exploits/linux/local/af_packet_packet_set_ring_priv_esc.rb
+++ b/modules/exploits/linux/local/af_packet_packet_set_ring_priv_esc.rb
@@ -66,6 +66,11 @@ class MetasploitModule < Msf::Exploit::Local
           [ 'URL', 'https://github.com/xairy/kernel-exploits/blob/master/CVE-2017-7308/poc.c' ],
           [ 'URL', 'https://github.com/bcoles/kernel-exploits/blob/cve-2017-7308/CVE-2017-7308/poc.c' ]
         ],
+      'Notes'          =>
+        {
+          'Reliability' => [ REPEATABLE_SESSION ],
+          'Stability'   => [ CRASH_OS_DOWN ],
+        },
       'DefaultTarget'  => 0))
     register_options [
       OptEnum.new('COMPILE', [ true, 'Compile on target', 'Auto', %w(Auto True False) ])

--- a/modules/exploits/linux/local/asan_suid_executable_priv_esc.rb
+++ b/modules/exploits/linux/local/asan_suid_executable_priv_esc.rb
@@ -64,7 +64,9 @@ class MetasploitModule < Msf::Exploit::Local
         ],
       'Notes' =>
         {
-          'AKA' => ['unsanitary.sh']
+          'AKA'         => ['unsanitary.sh'],
+          'Reliability' => [ REPEATABLE_SESSION ],
+          'Stability'   => [ CRASH_SAFE ]
         },
       'DefaultTarget'  => 0))
     register_options [

--- a/modules/exploits/linux/local/bpf_sign_extension_priv_esc.rb
+++ b/modules/exploits/linux/local/bpf_sign_extension_priv_esc.rb
@@ -79,16 +79,14 @@ class MetasploitModule < Msf::Exploit::Local
           [ 'URL', 'http://openwall.com/lists/oss-security/2017/12/21/2'],
           [ 'URL', 'https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=95a762e2c8c942780948091f8f2a4f32fce1ac6f' ]
         ],
-      'DefaultTarget'  => 0,
-      'Notes' =>
-          {
-              'AKA' =>
-                  [
-                      'get-rekt-linux-hardened.c',
-                      'upstream44.c'
-                  ]
-          }
-      ))
+      'Notes'          =>
+        {
+          'AKA'         => ['get-rekt-linux-hardened.c', 'upstream44.c'],
+          'Reliability' => [ REPEATABLE_SESSION ],
+          'Stability'   => [ CRASH_OS_DOWN ],
+        },
+      'DefaultTarget'  => 0
+    ))
     register_options [
       OptEnum.new('COMPILE', [ true, 'Compile on target', 'Auto', %w[Auto True False] ])
     ]

--- a/modules/exploits/linux/local/ktsuss_suid_priv_esc.rb
+++ b/modules/exploits/linux/local/ktsuss_suid_priv_esc.rb
@@ -64,6 +64,11 @@ class MetasploitModule < Msf::Exploit::Local
           'PrependSetuid'    => true,
           'PrependFork'      => true
         },
+      'Notes'          =>
+        {
+          'Reliability' => [ REPEATABLE_SESSION ],
+          'Stability'   => [ CRASH_SAFE ]
+        },
       'DefaultTarget'  => 0))
     register_options [
       OptString.new('KTSUSS_PATH', [true, 'Path to staprun executable', '/usr/bin/ktsuss'])

--- a/modules/exploits/linux/local/nested_namespace_idmap_limit_priv_esc.rb
+++ b/modules/exploits/linux/local/nested_namespace_idmap_limit_priv_esc.rb
@@ -60,7 +60,6 @@ class MetasploitModule < Msf::Exploit::Local
           ['URL', 'https://cdn.kernel.org/pub/linux/kernel/v4.x/ChangeLog-4.18.19'],
           ['URL', 'https://cdn.kernel.org/pub/linux/kernel/v4.x/ChangeLog-4.19.2']
         ],
-      'DefaultTarget'  => 0,
       'DefaultOptions' =>
         {
           'AppendExit'       => true,
@@ -71,11 +70,13 @@ class MetasploitModule < Msf::Exploit::Local
           'WfsDelay'         => 60,
           'PAYLOAD'          => 'linux/x86/meterpreter/reverse_tcp'
         },
-      'Notes' =>
+      'Notes'          =>
         {
-          'AKA' => ['subuid_shell.c']
-        }
-      ))
+          'AKA'         => ['subuid_shell.c'],
+          'Reliability' => [ REPEATABLE_SESSION ],
+          'Stability'   => [ CRASH_SAFE ]
+        },
+      'DefaultTarget'  => 0))
     register_options [
       OptEnum.new('COMPILE', [true, 'Compile on target', 'Auto', %w[Auto True False]])
     ]

--- a/modules/exploits/linux/local/omniresolve_suid_priv_esc.rb
+++ b/modules/exploits/linux/local/omniresolve_suid_priv_esc.rb
@@ -56,7 +56,13 @@ class MetasploitModule < Msf::Exploit::Local
         [
           [ 'CVE', '2019-11660' ],
           [ 'URL', 'https://softwaresupport.softwaregrp.com/doc/KM03525630' ]
-        ]
+        ],
+      'Notes'          =>
+        {
+          'Reliability' => [ REPEATABLE_SESSION ],
+          'Stability'   => [ CRASH_SAFE ]
+        },
+      'DefaultTarget'  => 0
     ))
 
     register_options(

--- a/modules/exploits/linux/local/ptrace_traceme_pkexec_helper.rb
+++ b/modules/exploits/linux/local/ptrace_traceme_pkexec_helper.rb
@@ -54,6 +54,11 @@ class MetasploitModule < Msf::Exploit::Local
           'Payload'     => 'linux/x64/meterpreter/reverse_tcp',
           'PrependFork' => true,
         },
+      'Notes'          =>
+        {
+          'Reliability' => [ REPEATABLE_SESSION ],
+          'Stability'   => [ CRASH_SAFE ]
+        },
       'DisclosureDate' => 'Jul 4 2019'))
     register_advanced_options [
       OptBool.new('ForceExploit', [false, 'Override check result', false]),

--- a/modules/exploits/linux/local/servu_ftp_server_prepareinstallation_priv_esc.rb
+++ b/modules/exploits/linux/local/servu_ftp_server_prepareinstallation_priv_esc.rb
@@ -66,6 +66,11 @@ class MetasploitModule < Msf::Exploit::Local
           'PrependFork'      => true,
           'WfsDelay'         => 30
         },
+      'Notes'          =>
+        {
+          'Reliability' => [ REPEATABLE_SESSION ],
+          'Stability'   => [ CRASH_SAFE ]
+        },
       'DefaultTarget'  => 0))
     register_options [
       OptString.new('SERVU_PATH', [true, 'Path to Serv-U executable', '/usr/local/Serv-U/Serv-U'])

--- a/modules/exploits/linux/local/sock_sendpage.rb
+++ b/modules/exploits/linux/local/sock_sendpage.rb
@@ -64,6 +64,11 @@ class MetasploitModule < Msf::Exploit::Local
           [ 'Linux x86', { 'Arch' => ARCH_X86 } ]
         ],
       'DisclosureDate' => 'Aug 13 2009',
+      'Notes'          =>
+        {
+          'Reliability' => [ REPEATABLE_SESSION ],
+          'Stability'   => [ CRASH_OS_DOWN ],
+        },
       'DefaultTarget'  => 0))
     register_options [
       OptBool.new('DEBUG_EXPLOIT', [ true, "Make the exploit executable be verbose about what it's doing", false ])

--- a/modules/exploits/linux/local/systemtap_modprobe_options_priv_esc.rb
+++ b/modules/exploits/linux/local/systemtap_modprobe_options_priv_esc.rb
@@ -62,6 +62,11 @@ class MetasploitModule < Msf::Exploit::Local
         ],
       'SessionTypes'   => ['shell', 'meterpreter'],
       'Targets'        => [['Auto', {}]],
+      'Notes'          =>
+        {
+          'Reliability' => [ REPEATABLE_SESSION ],
+          'Stability'   => [ CRASH_SAFE ]
+        },
       'DefaultTarget'  => 0))
     register_options [
       OptString.new('STAPRUN_PATH', [true, 'Path to staprun executable', '/usr/bin/staprun'])

--- a/modules/exploits/linux/local/ufo_privilege_escalation.rb
+++ b/modules/exploits/linux/local/ufo_privilege_escalation.rb
@@ -65,6 +65,11 @@ class MetasploitModule < Msf::Exploit::Local
           [ 'URL', 'https://github.com/bcoles/kernel-exploits/commits/cve-2017-1000112' ]
         ],
       'DefaultOptions' => { 'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp' },
+      'Notes'          =>
+        {
+          'Reliability' => [ REPEATABLE_SESSION ],
+          'Stability'   => [ CRASH_OS_DOWN ],
+        },
       'DefaultTarget'  => 0))
     register_options [
       OptEnum.new('COMPILE', [ true, 'Compile on target', 'Auto', %w[Auto True False] ])

--- a/modules/exploits/linux/local/vmware_alsa_config.rb
+++ b/modules/exploits/linux/local/vmware_alsa_config.rb
@@ -55,10 +55,15 @@ class MetasploitModule < Msf::Exploit::Local
           'WfsDelay'    => 30,
           'Payload'     => 'linux/x64/meterpreter_reverse_tcp'
         },
-      'DefaultTarget'  => 1,
       'Arch'           => [ ARCH_X86, ARCH_X64 ],
       'SessionTypes'   => [ 'shell', 'meterpreter' ],
-      'Privileged'     => true ))
+      'Privileged'     => true,
+      'Notes'          =>
+        {
+          'Reliability' => [ REPEATABLE_SESSION ],
+          'Stability'   => [ CRASH_SAFE ]
+        },
+      'DefaultTarget'  => 1))
     register_advanced_options [
       OptBool.new('ForceExploit', [false, 'Override check result', false]),
       OptString.new('WritableDir', [true, 'A directory where we can write files', '/tmp']),

--- a/modules/exploits/multi/local/magnicomp_sysinfo_mcsiwrapper_priv_esc.rb
+++ b/modules/exploits/multi/local/magnicomp_sysinfo_mcsiwrapper_priv_esc.rb
@@ -50,7 +50,12 @@ class MetasploitModule < Msf::Exploit::Local
           [ 'URL', 'http://www.magnicomp.com/support/cve/CVE-2017-6516.shtml' ],
           [ 'URL', 'https://labs.mwrinfosecurity.com/advisories/magnicomps-sysinfo-root-setuid-local-privilege-escalation-vulnerability/' ],
           [ 'URL', 'https://labs.mwrinfosecurity.com/advisories/multiple-vulnerabilities-in-magnicomps-sysinfo-root-setuid/' ]
-        ]
+        ],
+      'Notes'          =>
+        {
+          'Reliability' => [ REPEATABLE_SESSION ],
+          'Stability'   => [ CRASH_SAFE ]
+        }
     ))
     register_options(
       [

--- a/modules/exploits/unix/local/setuid_nmap.rb
+++ b/modules/exploits/unix/local/setuid_nmap.rb
@@ -12,7 +12,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::File
 
   def initialize(info={})
-    super( update_info( info, {
+    super( update_info( info,
         'Name'          => 'Setuid Nmap Exploit',
         'Description'   => %q{
           Nmap's man page mentions that "Nmap should never be installed with
@@ -39,15 +39,21 @@ class MetasploitModule < Msf::Exploit::Local
             [ 'BSD x86',         { 'Arch' => ARCH_X86 } ],
           ],
         'DefaultOptions' => { "PrependSetresuid" => true, "WfsDelay" => 2 },
-        'DefaultTarget' => 0,
-      }
+        'Notes'          =>
+          {
+            'Reliability' => [ REPEATABLE_SESSION ],
+            'Stability'   => [ CRASH_SAFE ]
+          },
+        'DefaultTarget' => 0
       ))
     register_options([
         # These are not OptPath becuase it's a *remote* path
-        OptString.new("WritableDir", [ true, "A directory where we can write files", "/tmp" ]),
-        OptString.new("Nmap",        [ true, "Path to setuid nmap executable", "/usr/bin/nmap" ]),
-        OptString.new("ExtraArgs",        [ false, "Extra arguments to pass to Nmap (e.g. --datadir)", "" ]),
+        OptString.new("Nmap",      [ true, "Path to setuid nmap executable", "/usr/bin/nmap" ]),
+        OptString.new("ExtraArgs", [ false, "Extra arguments to pass to Nmap (e.g. --datadir)", "" ]),
       ])
+    register_advanced_options [
+      OptString.new('WritableDir', [true, 'A directory where we can write files', '/tmp'])
+    ]
   end
 
   def check


### PR DESCRIPTION
Add module notes for `Reliability` and `Stability` to some local exploit modules.

Mostly modified modules are either kernel exploit modules, which run the risk of hard freezing the system (`CRASH_OS_DOWN`), or "safe" userland modules (usually exploiting setuid executables) (`CRASH_SAFE`).

Also a ninja edit to the `nmap_suid` module, to move the `WritableDir` option from `register_options` to `register_advanced_options`, which is now the standard practice.
