### PR TITLE
[MSF-12536] Set minimum ruby version

### DIFF
--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -44,6 +44,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^spec/})
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = '>= 1.9'
+
   # Database support
   spec.add_runtime_dependency 'activerecord', *Metasploit::Framework::RailsVersionConstraint::RAILS_VERSION
   # Need 3+ for ActiveSupport::Concern

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^spec/})
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '>= 1.9'
+  spec.required_ruby_version = '>= 2.5'
 
   # Database support
   spec.add_runtime_dependency 'activerecord', *Metasploit::Framework::RailsVersionConstraint::RAILS_VERSION


### PR DESCRIPTION
If applied, sets minimum ruby version. Has added benefit of failing app faster.

Resolves #12536.