### PR TITLE
Fix: auxiliary/kerberos_enumusers stops after first match

### DIFF
--- a/modules/auxiliary/analyze/jtr_mssql_fast.rb
+++ b/modules/auxiliary/analyze/jtr_mssql_fast.rb
@@ -97,7 +97,7 @@ class MetasploitModule < Msf::Auxiliary
   def hash_file
     wrote_hash = false
     hashlist = Rex::Quickfile.new("hashes_tmp")
-    Metasploit::Credential::NonreplayableHash.joins(:cores).where(metasploit_credential_cores: { workspace_id: myworkspace.id }, jtr_format: ['mssql', 'mssql05', 'mssql12']).each do |hash|
+    Metasploit::Credential::NonreplayableHash.joins(:cores).where(metasploit_credential_cores: { workspace_id: myworkspace_id }, jtr_format: ['mssql', 'mssql05', 'mssql12']).each do |hash|
       # Track the formats that we've seen so we do not attempt a format that isn't relevant
       @formats << hash.jtr_format
       hash.cores.each do |core|

--- a/modules/auxiliary/gather/kerberos_enumusers.rb
+++ b/modules/auxiliary/gather/kerberos_enumusers.rb
@@ -93,7 +93,7 @@ class MetasploitModule < Msf::Auxiliary
       address: opts[:host],
       port: opts[:port],
       protocol: 'udp',
-      workspace_id: myworkspace.id,
+      workspace_id: myworkspace_id,
       service_name: opts[:creds_name]
     }
 

--- a/modules/auxiliary/gather/konica_minolta_pwd_extract.rb
+++ b/modules/auxiliary/gather/konica_minolta_pwd_extract.rb
@@ -229,7 +229,7 @@ class MetasploitModule < Msf::Auxiliary
     credential_data = {
       origin_type: :service,
       module_fullname: self.fullname,
-      workspace_id: myworkspace.id,
+      workspace_id: myworkspace_id,
       private_data: password,
       private_type: :password,
       username: username

--- a/modules/auxiliary/gather/lansweeper_collector.rb
+++ b/modules/auxiliary/gather/lansweeper_collector.rb
@@ -115,7 +115,7 @@ class MetasploitModule < Msf::Auxiliary
       address: opts[:host],
       port: opts[:port],
       protocol: 'tcp',
-      workspace_id: myworkspace.id,
+      workspace_id: myworkspace_id,
       service_name: opts[:creds_name]
     }
 

--- a/modules/auxiliary/gather/xerox_pwd_extract.rb
+++ b/modules/auxiliary/gather/xerox_pwd_extract.rb
@@ -158,7 +158,7 @@ class MetasploitModule < Msf::Auxiliary
     credential_data = {
       origin_type: :service,
       module_fullname: self.fullname,
-      workspace_id: myworkspace.id,
+      workspace_id: myworkspace_id,
       private_data: password,
       private_type: :password,
       username: username

--- a/modules/auxiliary/gather/xerox_workcentre_5xxx_ldap.rb
+++ b/modules/auxiliary/gather/xerox_workcentre_5xxx_ldap.rb
@@ -274,7 +274,7 @@ class MetasploitModule < Msf::Auxiliary
     credential_data = {
       origin_type: :service,
       module_fullname: self.fullname,
-      workspace_id: myworkspace.id,
+      workspace_id: myworkspace_id,
       private_data: password,
       private_type: :password,
       username: username


### PR DESCRIPTION
`kerberos_enumusers` stops after the first valid user:

```
[*] 192.168.1.2:88 - KDC_ERR_PREAUTH_REQUIRED - Additional pre-authentication required
[+] 192.168.1.2:88 - User: "us3r" is present
[-] Auxiliary failed: NoMethodError undefined method `id' for nil:NilClass
[-] Call stack:
[-]   /usr/share/metasploit-framework/modules/auxiliary/gather/kerberos_enumusers.rb:96:in `report_cred'
[-]   /usr/share/metasploit-framework/modules/auxiliary/gather/kerberos_enumusers.rb:77:in `block in run'
[-]   /usr/share/metasploit-framework/modules/auxiliary/gather/kerberos_enumusers.rb:65:in `each'
[-]   /usr/share/metasploit-framework/modules/auxiliary/gather/kerberos_enumusers.rb:65:in `run'
[*] Auxiliary module execution completed
```
and it stops there.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use gather/kerberos_enumusers`
- [ ] Set options; make sure the target has at least one valid username that can be found, not at the end of the list `USER_FILE`
- [ ] **Verify** the module keeps running after the first user has been found
- [ ] **Verify** the module does NOT stop after the first user has been found

