### PR TITLE
remove merge conflict marks

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,22 +115,13 @@ GEM
     arel-helpers (2.10.0)
       activerecord (>= 3.1.0, < 7)
     aws-eventstream (1.0.3)
-<<<<<<< HEAD
-    aws-partitions (1.231.0)
-    aws-sdk-core (3.72.0)
-=======
     aws-partitions (1.235.0)
     aws-sdk-core (3.75.0)
->>>>>>> land_12227
       aws-eventstream (~> 1.0, >= 1.0.2)
       aws-partitions (~> 1, >= 1.228.0)
       aws-sigv4 (~> 1.1)
       jmespath (~> 1.0)
-<<<<<<< HEAD
-    aws-sdk-ec2 (1.114.0)
-=======
     aws-sdk-ec2 (1.115.0)
->>>>>>> land_12227
       aws-sdk-core (~> 3, >= 3.71.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-iam (1.31.0)
@@ -139,11 +130,7 @@ GEM
     aws-sdk-kms (1.25.0)
       aws-sdk-core (~> 3, >= 3.71.0)
       aws-sigv4 (~> 1.1)
-<<<<<<< HEAD
-    aws-sdk-s3 (1.52.0)
-=======
     aws-sdk-s3 (1.53.0)
->>>>>>> land_12227
       aws-sdk-core (~> 3, >= 3.71.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.1)
@@ -216,11 +203,7 @@ GEM
       activemodel (~> 4.2.6)
       activesupport (~> 4.2.6)
       railties (~> 4.2.6)
-<<<<<<< HEAD
-    metasploit-payloads (1.3.78)
-=======
     metasploit-payloads (1.3.79)
->>>>>>> land_12227
     metasploit_data_models (3.0.10)
       activerecord (~> 4.2.6)
       activesupport (~> 4.2.6)


### PR DESCRIPTION
Accidentally didn't resolve all conflicts in gemfile.lock when merging, this removes the conflict marks.