### PR TITLE
64K ought to be enough for anyone

### DIFF
--- a/lib/msf/ui/banner.rb
+++ b/lib/msf/ui/banner.rb
@@ -28,7 +28,7 @@ module Banner
     fdata = "<< Missing banner: #{pathname} >>"
     begin
       raise ArgumentError unless File.readable?(pathname)
-      raise ArgumentError unless File.stat(pathname).size < 16384
+      raise ArgumentError unless File.stat(pathname).size < 65_536
       fdata = File.open(pathname) {|f| f.read f.stat.size}
     rescue SystemCallError, ArgumentError
       nil


### PR DESCRIPTION
This PR increases the maximum size for ASCII art banners to a much more reasonable `65_535` bytes.

The maximum size was last bumped from `4096` to `16384` in 34d637c7b8dec4d0496e2ed4f7db723b80797c52 in 2015 to make room for ponies.

Abusing the `bug` label because my unofficial ASCII art won't fit in less than 40K and there's no label for critical priority.
