### PR TITLE
Performance enhancements (memory)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,6 @@ PATH
       aws-sdk-ec2
       aws-sdk-iam
       aws-sdk-s3
-      backports
       bcrypt (= 3.1.12)
       bcrypt_pbkdf
       bit-struct
@@ -136,7 +135,6 @@ GEM
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.1.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
-    backports (3.15.0)
     bcrypt (3.1.12)
     bcrypt_pbkdf (1.0.1)
     bindata (2.4.4)

--- a/lib/msf/core.rb
+++ b/lib/msf/core.rb
@@ -10,9 +10,6 @@
 #
 ###
 
-# Include backported features for older versions of Ruby
-require 'backports'
-
 # The framework-core depends on Rex
 require 'rex'
 require 'rex/ui'

--- a/lib/msf/core/data_store.rb
+++ b/lib/msf/core/data_store.rb
@@ -319,7 +319,7 @@ class DataStore < Hash
 
     # Scan each key looking for a match
     self.each_key do |rk|
-      if rk.downcase == search_k
+      if rk.casecmp(search_k) == 0
         return rk
       end
     end

--- a/lib/msf/core/module/full_name.rb
+++ b/lib/msf/core/module/full_name.rb
@@ -80,7 +80,7 @@ module Msf::Module::FullName
   # windows/shell/reverse_tcp
   #
   def refname
-    fullname.sub(type + '/', '')
+    fullname.delete_prefix("#{type}/")
   end
 
   #

--- a/lib/msf/core/modules/loader/base.rb
+++ b/lib/msf/core/modules/loader/base.rb
@@ -471,7 +471,7 @@ class Msf::Modules::Loader::Base
   def module_path?(path)
     !(path.starts_with?(".") ||
       !path.ends_with?(MODULE_EXTENSION) ||
-      path =~ UNIT_TEST_REGEX)
+      path.match?(UNIT_TEST_REGEX))
   end
 
   # Tries to determine if a file might be executable,

--- a/lib/msf/core/modules/loader/base.rb
+++ b/lib/msf/core/modules/loader/base.rb
@@ -469,17 +469,9 @@ class Msf::Modules::Loader::Base
   #                   the path is not hidden (starts with '.')
   # @return [false] otherwise
   def module_path?(path)
-    module_path = false
-
-    extension = File.extname(path)
-
-    unless (path[0,1] == "." or
-            extension != MODULE_EXTENSION or
-            path =~ UNIT_TEST_REGEX)
-      module_path = true
-    end
-
-    module_path
+    !(path.starts_with?(".") ||
+      !path.ends_with?(MODULE_EXTENSION) ||
+      path =~ UNIT_TEST_REGEX)
   end
 
   # Tries to determine if a file might be executable,

--- a/lib/rex/logging.rb
+++ b/lib/rex/logging.rb
@@ -3,11 +3,11 @@
 #
 # Log severities
 #
-LOG_ERROR = 'error'
-LOG_DEBUG = 'debug'
-LOG_INFO  = 'info'
-LOG_WARN  = 'warn'
-LOG_RAW   = 'raw'
+LOG_ERROR = :error
+LOG_DEBUG = :debug
+LOG_INFO  = :info
+LOG_WARN  = :warn
+LOG_RAW   = :raw
 
 ##
 #

--- a/lib/rex/logging/log_dispatcher.rb
+++ b/lib/rex/logging/log_dispatcher.rb
@@ -87,12 +87,12 @@ class LogDispatcher
   #
   # Performs the actual log operation against the supplied source
   #
-  def log(sev, src, level, msg, from)
+  def log(sev, src, level, msg)
     log_sinks_lock.synchronize {
       if ((sink = log_sinks[src]))
         next if (log_levels[src] and level > log_levels[src])
 
-        sink.log(sev, src, level, msg, from)
+        sink.log(sev, src, level, msg)
       end
     }
   end
@@ -130,28 +130,28 @@ end
 ###
 ExceptionCallStack = "__EXCEPTCALLSTACK__"
 
-def dlog(msg, src = 'core', level = 0, from = caller)
-  $dispatcher.log(LOG_DEBUG, src, level, msg, from)
+def dlog(msg, src = 'core', level = 0)
+  $dispatcher.log(LOG_DEBUG, src, level, msg)
 end
 
-def elog(msg, src = 'core', level = 0, from = caller)
-  $dispatcher.log(LOG_ERROR, src, level, msg, from)
+def elog(msg, src = 'core', level = 0)
+  $dispatcher.log(LOG_ERROR, src, level, msg)
 end
 
-def wlog(msg, src = 'core', level = 0, from = caller)
-  $dispatcher.log(LOG_WARN, src, level, msg, from)
+def wlog(msg, src = 'core', level = 0)
+  $dispatcher.log(LOG_WARN, src, level, msg)
 end
 
-def ilog(msg, src = 'core', level = 0, from = caller)
-  $dispatcher.log(LOG_INFO, src, level, msg, from)
+def ilog(msg, src = 'core', level = 0)
+  $dispatcher.log(LOG_INFO, src, level, msg)
 end
 
-def rlog(msg, src = 'core', level = 0, from = caller)
+def rlog(msg, src = 'core', level = 0)
   if (msg == ExceptionCallStack)
     msg = "\nCall stack:\n" + $@.join("\n") + "\n"
   end
 
-  $dispatcher.log(LOG_RAW, src, level, msg, from)
+  $dispatcher.log(LOG_RAW, src, level, msg)
 end
 
 def log_source_registered?(src)

--- a/lib/rex/logging/log_sink.rb
+++ b/lib/rex/logging/log_sink.rb
@@ -20,7 +20,7 @@ module LogSink
   # intended to take the supplied parameters and persist them to an arbitrary
   # medium.
   #
-  def log(sev, src, level, msg, from)
+  def log(sev, src, level, msg)
     raise NotImplementedError
   end
 

--- a/lib/rex/logging/sinks/flatfile.rb
+++ b/lib/rex/logging/sinks/flatfile.rb
@@ -25,7 +25,7 @@ class Flatfile
     fd.close
   end
 
-  def log(sev, src, level, msg, from) # :nodoc:
+  def log(sev, src, level, msg) # :nodoc:
     if (sev == LOG_RAW)
       fd.write(msg)
     else

--- a/lib/rex/logging/sinks/stderr.rb
+++ b/lib/rex/logging/sinks/stderr.rb
@@ -15,7 +15,7 @@ class Stderr
   # Writes log data to stderr
   #
 
-  def log(sev, src, level, msg, from) # :nodoc:
+  def log(sev, src, level, msg) # :nodoc:
     if (sev == LOG_RAW)
       $stderr.write(msg)
     else

--- a/lib/rex/logging/sinks/timestamp_flatfile.rb
+++ b/lib/rex/logging/sinks/timestamp_flatfile.rb
@@ -11,7 +11,7 @@ module Sinks
 ###
 class TimestampFlatfile < Flatfile
 
-  def log(sev, src, level, msg, from) # :nodoc:
+  def log(sev, src, level, msg) # :nodoc:
     return unless msg.present?
     msg = msg.gsub(/\x1b\[[0-9;]*[mG]/,'').gsub(/[\x01-\x02]/, ' ').gsub(/\s+$/,'')
     fd.write("[#{get_current_timestamp}] #{msg}\n")

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -52,8 +52,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'activesupport', *Metasploit::Framework::RailsVersionConstraint::RAILS_VERSION
   # Needed for config.action_view for view plugin compatibility for Pro
   spec.add_runtime_dependency 'actionpack', *Metasploit::Framework::RailsVersionConstraint::RAILS_VERSION
-  # Backports Ruby features across language versions
-  spec.add_runtime_dependency 'backports'
   # Needed for some admin modules (cfme_manageiq_evm_pass_reset.rb)
   spec.add_runtime_dependency 'bcrypt', '3.1.12'
   # Needed for Javascript obfuscation

--- a/msfupdate
+++ b/msfupdate
@@ -13,8 +13,6 @@ while File.symlink?(msfbase)
   msfbase = File.expand_path(File.readlink(msfbase), File.dirname(msfbase))
 end
 
-require 'backports'
-
 class Msfupdate
   attr_reader :stdin
   attr_reader :stdout


### PR DESCRIPTION
This is a PR to look at memory utilization enhancements across Metasploit Framework. This is the first attempt, which is focused on on low-hanging fruit provided by analysis from the `memory_profiler` gem.

To reproduce these results, invoke msfconsole with the changes from #12652 

Not all of these changes provide huge results alone, but enough in aggregate should provide lowered CPU and Memory resource utilization, long-term memory fragmentation.

## Verification

- [x] Start `msfconsole` in profiling mode as above without the other changes applied
- [x] Observe that 'hot spots' in `memory.profile`
- [x] Rerun profiled `msfconsole` with changes applied.
- [x] Observe that original 'hot spots' in `memory.profile` are gone

The first two changes here remove a few thousand string allocations on initial boot by removing an unused stacktrace calculation in all of the library logging functions, and by prefering str.casecmp over creating a new lowercase string in the datastore.