### PR TITLE
fix NameError uninitialized constant in Msf::Post::Linux::Compile

### DIFF
--- a/lib/msf/core/post/linux/compile.rb
+++ b/lib/msf/core/post/linux/compile.rb
@@ -27,7 +27,7 @@ module Compile
     end
 
     unless datastore['COMPILE'].eql? 'Auto'
-      fail_with Failure::BadConfig, 'gcc is not installed. Set COMPILE False to upload a pre-compiled executable.'
+      fail_with Module::Failure::BadConfig, 'gcc is not installed. Set COMPILE False to upload a pre-compiled executable.'
     end
   end
 
@@ -48,7 +48,7 @@ module Compile
 
     unless output.blank?
       print_error output
-      fail_with Failure::Unknown, "#{path}.c failed to compile. Set COMPILE False to upload a pre-compiled executable."
+      fail_with Module::Failure::BadConfig, "#{path}.c failed to compile. Set COMPILE False to upload a pre-compiled executable."
     end
 
     chmod path


### PR DESCRIPTION
Quick fix for the linux compile mixin when gcc fails to compile.
See #12106 
Also changes Failure::Unknown to Failure::BadConfig which makes more sense.

## Verification Steps

  1. Start msfconsole
  1. Get a shell or meterpreter session on the target (with gui access, not via ssh)
  1. Add an invalid gcc binary to your PATH (or you could add a compile error to the code).
  1. Do: `use exploit/linux/local/pkexec_helper_ptrace`
  1. Do: `set session #`
  1. Do: `exploit`
  1. Verify `[-] Exploit aborted due to failure: bad-config: /tmp/.ogfdvumewvxj.c failed to compile. Set COMPILE False to upload a pre-compiled executable.` (previously this was `NameError uninitialized constant...`)

Alternatively you can just eyeball the changes. 

