### PR TITLE
Update exploit/windows/smb/doublepulsar_rce info

### DIFF
--- a/modules/exploits/windows/smb/doublepulsar_rce.rb
+++ b/modules/exploits/windows/smb/doublepulsar_rce.rb
@@ -44,7 +44,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ['URL', 'https://github.com/countercept/doublepulsar-c2-traffic-decryptor'],
         ['URL', 'https://gist.github.com/msuiche/50a36710ee59709d8c76fa50fc987be1']
       ],
-      'DisclosureDate'   => '2017-04-14',
+      'DisclosureDate'   => '2017-04-14', # Shadow Brokers leak
       'License'          => MSF_LICENSE,
       'Platform'         => 'win',
       'Arch'             => ARCH_X64,
@@ -68,7 +68,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'auxiliary/scanner/smb/smb_ms17_010',
           'exploit/windows/smb/ms17_010_eternalblue'
         ],
-        'Stability'      => [CRASH_SAFE],
+        'Stability'      => [CRASH_OS_DOWN],
         'Reliability'    => [REPEATABLE_SESSION]
       }
     ))


### PR DESCRIPTION
1. The `DisclosureDate` of `2017-04-14` is the date of the Shadow Brokers leak
2. The `Stability` trait should really be `CRASH_OS_DOWN`, since we're executing code in the kernel - even though the kernel shellcode has been incredibly reliable, and the user-mode payload executes in a separate thread

#12374