### PR TITLE
Fix renamed RuboCop check in .rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -119,7 +119,7 @@ Naming/UncommunicativeMethodParamName:
 
 # %q() is super useful for long strings split over multiple lines and
 # is very common in module constructors for things like descriptions
-Style/UnneededPercentQ:
+Style/RedundantPercentQ:
   Enabled: false
 
 Style/NumericLiterals:


### PR DESCRIPTION
```
wvu@kharak:/rapid7/metasploit-framework:bug/rubocop$ rubocop modules/exploits/windows/smb/doublepulsar_rce.rb
/rapid7/metasploit-framework/.rubocop.yml: Warning: no department given for Documentation.
Error: The `Style/UnneededPercentQ` cop has been renamed to `Style/RedundantPercentQ`.
(obsolete configuration found in .rubocop.yml, please update it)
wvu@kharak:/rapid7/metasploit-framework:bug/rubocop$
```