### PR TITLE
Make Windows Server 2008 R2 exploitation caveat more visible in BlueKeep exploit

### DIFF
--- a/documentation/modules/exploit/windows/rdp/cve_2019_0708_bluekeep_rce.md
+++ b/documentation/modules/exploit/windows/rdp/cve_2019_0708_bluekeep_rce.md
@@ -10,6 +10,9 @@ the freed channel is used to achieve arbitrary code execution.
 This is a **non-standard** configuration for normal servers, and the target **will crash** if
 the aforementioned Registry key is not set!
 
+If the target is crashing regardless, you will likely need to determine the non-paged
+pool base in kernel memory and set it as the `GROOMBASE` option.
+
 ## Vulnerable Application
 
 This exploit should work against a vulnerable RDP service from one of these Windows systems:

--- a/documentation/modules/exploit/windows/rdp/cve_2019_0708_bluekeep_rce.md
+++ b/documentation/modules/exploit/windows/rdp/cve_2019_0708_bluekeep_rce.md
@@ -1,6 +1,14 @@
 CVE-2019-0708 BlueKeep RDP Remote Windows Kernel Use After Free
 
-The RDP termdd.sys driver improperly handles binds to internal-only channel MS_T120, allowing a malformed Disconnect Provider Indication message to cause use-after-free.  With a controllable data/size remote nonpaged pool spray, an indirect call gadget of the freed channel is used to achieve arbitrary code execution.
+The RDP `termdd.sys` driver improperly handles binds to internal-only channel `MS_T120`,
+allowing a malformed `Disconnect Provider Indication` message to cause use-after-free.
+With a controllable data/size remote nonpaged pool spray, an indirect call gadget of
+the freed channel is used to achieve arbitrary code execution.
+
+`HKLM\SYSTEM\CurrentControlSet\Control\TerminalServer\Winstations\RDP-Tcp\fDisableCam`
+**needs** to be set to `0` for exploitation to succeed against **Windows Server 2008 R2**.
+This is a **non-standard** configuration for normal servers, and the target **will crash** if
+the aforementioned Registry key is not set!
 
 ## Vulnerable Application
 

--- a/modules/exploits/windows/rdp/cve_2019_0708_bluekeep_rce.rb
+++ b/modules/exploits/windows/rdp/cve_2019_0708_bluekeep_rce.rb
@@ -66,6 +66,11 @@ class MetasploitModule < Msf::Exploit::Remote
         allowing a malformed Disconnect Provider Indication message to cause use-after-free.
         With a controllable data/size remote nonpaged pool spray, an indirect call gadget of
         the freed channel is used to achieve arbitrary code execution.
+
+        HKLM\SYSTEM\CurrentControlSet\Control\TerminalServer\Winstations\RDP-Tcp\fDisableCam
+        *needs* to be set to 0 for exploitation to succeed against Windows Server 2008 R2.
+        This is a non-standard configuration for normal servers, and the target will crash if
+        the aforementioned Registry key is not set!
       ),
       'Author' =>
       [

--- a/modules/exploits/windows/rdp/cve_2019_0708_bluekeep_rce.rb
+++ b/modules/exploits/windows/rdp/cve_2019_0708_bluekeep_rce.rb
@@ -205,7 +205,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     if target['FingerprintOnly']
-      fail_with(Msf::Module::Failure::BadConfig, 'Set the most appropriate target manually')
+      fail_with(Msf::Module::Failure::BadConfig, 'Set the most appropriate target manually. If you are targeting 2008, make sure fDisableCam=0 !')
     end
 
     begin

--- a/modules/exploits/windows/rdp/cve_2019_0708_bluekeep_rce.rb
+++ b/modules/exploits/windows/rdp/cve_2019_0708_bluekeep_rce.rb
@@ -71,6 +71,9 @@ class MetasploitModule < Msf::Exploit::Remote
         *needs* to be set to 0 for exploitation to succeed against Windows Server 2008 R2.
         This is a non-standard configuration for normal servers, and the target will crash if
         the aforementioned Registry key is not set!
+
+        If the target is crashing regardless, you will likely need to determine the non-paged
+        pool base in kernel memory and set it as the GROOMBASE option.
       ),
       'Author' =>
       [


### PR DESCRIPTION
People are not reading the source code, much less the commit message where it originated.

This PR addresses that issue inelegantly by explaining the caveat in both the module description and the module documentation:

> `HKLM\SYSTEM\CurrentControlSet\Control\TerminalServer\Winstations\RDP-Tcp\fDisableCam`
**needs** to be set to `0` for exploitation to succeed against **Windows Server 2008 R2**.
This is a **non-standard** configuration for normal servers, and the target **will crash** if
the aforementioned Registry key is not set!

In automatic mode, there is additionally a print reminding the user to check `fDisableCam`.