### PR TITLE
Fix/clarify target documentation for BlueKeep

### DIFF
--- a/documentation/modules/exploit/windows/rdp/cve_2019_0708_bluekeep_rce.md
+++ b/documentation/modules/exploit/windows/rdp/cve_2019_0708_bluekeep_rce.md
@@ -22,8 +22,8 @@ pool base in kernel memory and set it as the `GROOMBASE` option.
 
 This exploit module currently targets these Windows systems running on several virtualized and physical targets.
 
-* Windows 7 x64 (All Service Packs)
-* Windows 2008 R2 x64 (All Service Packs)
+* Windows 7 SP1 x64
+* Windows 2008 R2 x64
 
 XP and 2003 are currently not supported. Please see available targets by running the `show targets` command.
 

--- a/documentation/modules/exploit/windows/rdp/cve_2019_0708_bluekeep_rce.md
+++ b/documentation/modules/exploit/windows/rdp/cve_2019_0708_bluekeep_rce.md
@@ -5,6 +5,11 @@ allowing a malformed `Disconnect Provider Indication` message to cause use-after
 With a controllable data/size remote nonpaged pool spray, an indirect call gadget of
 the freed channel is used to achieve arbitrary code execution.
 
+**Windows 7 SP1** and **Windows Server 2008 R2** are the **only** currently supported targets.
+
+Windows 7 SP1 should be exploitable in its default configuration, assuming your target
+selection is correctly matched to the system's memory layout.
+
 `HKLM\SYSTEM\CurrentControlSet\Control\TerminalServer\Winstations\RDP-Tcp\fDisableCam`
 **needs** to be set to `0` for exploitation to succeed against **Windows Server 2008 R2**.
 This is a **non-standard** configuration for normal servers, and the target **will crash** if
@@ -15,19 +20,12 @@ pool base in kernel memory and set it as the `GROOMBASE` option.
 
 ## Vulnerable Application
 
-This exploit should work against a vulnerable RDP service from one of these Windows systems:
-
-* Windows 2000 x86 (All Service Packs))
-* Windows XP x86 (All Service Packs))
-* Windows 2003 x86 (All Service Packs))
-* Windows 7 x86 (All Service Packs))
-* Windows 7 x64 (All Service Packs)
-* Windows 2008 R2 x64 (All Service Packs)
-
 This exploit module currently targets these Windows systems running on several virtualized and physical targets.
 
 * Windows 7 x64 (All Service Packs)
 * Windows 2008 R2 x64 (All Service Packs)
+
+XP and 2003 are currently not supported. Please see available targets by running the `show targets` command.
 
 ## Verification Steps
 

--- a/modules/exploits/windows/rdp/cve_2019_0708_bluekeep_rce.rb
+++ b/modules/exploits/windows/rdp/cve_2019_0708_bluekeep_rce.rb
@@ -67,6 +67,11 @@ class MetasploitModule < Msf::Exploit::Remote
         With a controllable data/size remote nonpaged pool spray, an indirect call gadget of
         the freed channel is used to achieve arbitrary code execution.
 
+        Windows 7 SP1 and Windows Server 2008 R2 are the only currently supported targets.
+
+        Windows 7 SP1 should be exploitable in its default configuration, assuming your target
+        selection is correctly matched to the system's memory layout.
+
         HKLM\SYSTEM\CurrentControlSet\Control\TerminalServer\Winstations\RDP-Tcp\fDisableCam
         *needs* to be set to 0 for exploitation to succeed against Windows Server 2008 R2.
         This is a non-standard configuration for normal servers, and the target will crash if


### PR DESCRIPTION
This is a follow-up to #12575.

AFAIK, XP and 2003 grooming is incomplete, and those systems would crash at best.