### PR TITLE
[WIP] Missing report web methods

### DIFF
--- a/lib/metasploit/framework/data_service/proxy/web_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/web_data_proxy.rb
@@ -8,4 +8,34 @@ module WebDataProxy
       self.log_error(e, "Problem reporting website")
     end
   end
+
+  def report_web_page(opts)
+    begin
+      self.data_service_operation do |data_service|
+        data_service.report_web_page(opts)
+      end
+    rescue => e
+      self.log_error(e, "Problem reporting web page")
+    end
+  end
+
+  def report_web_form(opts)
+    begin
+      self.data_service_operation do |data_service|
+        data_service.report_web_form(opts)
+      end
+    rescue => e
+      self.log_error(e, "Problem reporting web form")
+    end
+  end
+
+  def report_web_vuln(opts)
+    begin
+      self.data_service_operation do |data_service|
+        data_service.report_web_vuln(opts)
+      end
+    rescue => e
+      self.log_error(e, "Problem reporting web vuln")
+    end
+  end
 end

--- a/lib/metasploit/framework/data_service/remote/http/remote_web_data_service.rb
+++ b/lib/metasploit/framework/data_service/remote/http/remote_web_data_service.rb
@@ -8,4 +8,16 @@ module RemoteWebDataService
   def report_web_site(opts)
     self.post_data_async(WEB_API_PATH, opts)
   end
+
+  def report_web_page(opts)
+    self.post_data_async("#{WEB_API_PATH}/page", opts)
+  end
+
+  def report_web_form(opts)
+    self.post_data_async("#{WEB_API_PATH}/form", opts)
+  end
+
+  def report_web_vuln(opts)
+    self.post_data_async("#{WEB_API_PATH}/vuln", opts)
+  end
 end

--- a/lib/metasploit/framework/data_service/stubs/web_data_service.rb
+++ b/lib/metasploit/framework/data_service/stubs/web_data_service.rb
@@ -3,4 +3,16 @@ module WebDataService
   def report_web_site(opts)
     raise 'WebDataService#report_web_site is not implemented'
   end
+
+  def report_web_page(opts)
+    raise 'WebDataService#report_web_page is not implemented'
+  end
+
+  def report_web_form(opts)
+    raise 'WebDataService#report_web_form is not implemented'
+  end
+
+  def report_web_vuln(opts)
+    raise 'WebDataService#report_web_vuln is not implemented'
+  end
 end

--- a/lib/msf/core/web_services/servlet/web_servlet.rb
+++ b/lib/msf/core/web_services/servlet/web_servlet.rb
@@ -6,6 +6,10 @@ module WebServlet
 
   def self.registered(app)
     app.post WebServlet.api_path, &report_web
+    app.post "#{WebServlet.api_path}/page", &report_web_page
+    app.post "#{WebServlet.api_path}/form", &report_web_form
+    app.post "#{WebServlet.api_path}/vuln", &report_web_vuln
+
   end
 
   #######
@@ -16,6 +20,30 @@ module WebServlet
     lambda {
       warden.authenticate!
       job = lambda { |opts|  get_db().report_web_site(opts) }
+      exec_report_job(request, &job)
+    }
+  end
+
+  def self.report_web_page
+    lambda {
+      warden.authenticate!
+      job = lambda { |opts|  get_db().report_web_page(opts) }
+      exec_report_job(request, &job)
+    }
+  end
+
+  def self.report_web_form
+    lambda {
+      warden.authenticate!
+      job = lambda { |opts|  get_db().report_web_form(opts) }
+      exec_report_job(request, &job)
+    }
+  end
+
+  def self.report_web_vuln
+    lambda {
+      warden.authenticate!
+      job = lambda { |opts|  get_db().report_web_vuln(opts) }
       exec_report_job(request, &job)
     }
   end

--- a/lib/msf/util/db_manager.rb
+++ b/lib/msf/util/db_manager.rb
@@ -45,11 +45,11 @@ module DBManager
     when Mdm::Workspace
       workspace_name = wspace.name
     else
-      raise "Unsupported workspace declaration"
+      workspace_name = nil
     end
 
-    wspace = framework.db.find_workspace(workspace_name)
-    raise "Couldn't find workspace #{workspace_name}" if wspace.nil?
+    wspace = framework.db.find_workspace(workspace_name) unless workspace_name.nil?
+    raise "Couldn't find workspace #{workspace_name}" if wspace.nil? && required
 
     wspace
   end

--- a/lib/msf/util/db_manager.rb
+++ b/lib/msf/util/db_manager.rb
@@ -37,11 +37,19 @@ module DBManager
       raise ArgumentError.new("opts must include a valid :workspace")
     end
 
-    if wspace.kind_of?(String)
+    case wspace
+    when Hash
+      workspace_name = wspace[:name]
+    when String
       workspace_name = wspace
-      wspace = framework.db.find_workspace(workspace_name)
-      raise "Couldn't find workspace #{workspace_name}" if wspace.nil?
+    when Mdm::Workspace
+      workspace_name = wspace.name
+    else
+      raise "Unsupported workspace declaration"
     end
+
+    wspace = framework.db.find_workspace(workspace_name)
+    raise "Couldn't find workspace #{workspace_name}" if wspace.nil?
 
     wspace
   end


### PR DESCRIPTION
Resolves #12523 and #12334  

Adds missing apis for reporting web pages, forms and vulns

Still needs swagger docs but no point delaying review of the rest
## Verification

- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/http/brute_dirs`
- [ ] `set options`
- [ ] **Verify** it doesn't break when it discovers a directory
