### PR TITLE
Add support for shell sessions to post/windows/gather/enum_hostfile

### DIFF
--- a/modules/post/windows/gather/enum_hostfile.rb
+++ b/modules/post/windows/gather/enum_hostfile.rb
@@ -4,6 +4,7 @@
 ##
 
 class MetasploitModule < Msf::Post
+  include Msf::Post::File
 
   def initialize(info={})
     super(update_info(info,
@@ -20,35 +21,23 @@ class MetasploitModule < Msf::Post
 
   def run
     # read in the hosts in the hosts file.
-    fd = session.fs.file.new("C:\\WINDOWS\\System32\\drivers\\etc\\hosts", "rb")
-
-    # Load up the original hosts file
-    buf = ''
-    until fd.eof?
-      buf << fd.read
-    end
-
-    # Finished loading the hosts file, close fd
-    fd.close
+    hosts = read_file "C:\\WINDOWS\\System32\\drivers\\etc\\hosts"
 
     # Store the original hosts file
     p = store_loot(
       'hosts.confige',
       'text/plain',
       session,
-      buf,
+      hosts,
       'hosts_file.txt',
       'Windows Hosts File'
     )
 
-    # Split lines
-    lines = buf.split("\n")
-
     # Print out each line that doesn't start w/ a comment
     entries = []
-    lines.each do |line|
+    hosts.each_line do |line|
       next if line =~ /^[\r|\n|#]/
-      entries << line
+      entries << line.strip
     end
 
     # Show results


### PR DESCRIPTION
The `post/windows/gather/enum_hostfile` module declares:

```ruby
'SessionTypes'  => [ 'meterpreter', 'shell' ]
```

This is a blatant lie, as the module uses `session.fs.file.new`.

This PR updates the module to support both `meterpreter` and `shell` sessions by using the `read_file` method from the `Msf::Post::File` mixin.

This method checks the `session.type` and uses the appropriate `session.fs.file.new` method for `meterpreter` sessions if available.

```
  def read_file(file_name)
    if session.type == 'meterpreter'
      return _read_file_meterpreter(file_name)
    end

    return nil unless session.type == 'shell'

    if session.platform == 'windows'
      return session.shell_command_token("type \"#{file_name}\"")
    end
```

The `enum_hostfile` module should probably also `nil` check the result, but whatever.
