### PR TITLE
fixes for android hashdump

### DIFF
--- a/modules/auxiliary/analyze/crack_mobile.rb
+++ b/modules/auxiliary/analyze/crack_mobile.rb
@@ -235,7 +235,7 @@ class MetasploitModule < Msf::Auxiliary
     regex = Regexp.new hashes_regex
     framework.db.creds(workspace: myworkspace, type: 'Metasploit::Credential::NonreplayableHash').each do |core|
       next unless core.private.jtr_format =~ regex
-      # only add hashes which havne't been cracked
+      # only add hashes which haven't been cracked
       next unless already_cracked_pass(core.private.data).nil?
       if action.name == 'john'
         hashlist.puts hash_to_jtr(core)

--- a/modules/post/android/gather/hashdump.rb
+++ b/modules/post/android/gather/hashdump.rb
@@ -73,7 +73,7 @@ class MetasploitModule < Msf::Post
       fail_with Failure::NoAccess, 'This module requires root permissions.'
     end
 
-    manu = cmd_exec("getprop ro.build.manufacturer")
+    manu = cmd_exec("getprop ro.product.manufacturer")
 
     print_status('Attempting to determine unsalted hash.')
     key_file = '/data/system/password.key'
@@ -128,7 +128,7 @@ class MetasploitModule < Msf::Post
     print_good("SHA1: #{sha1}")
     credential_data = {
         # no way to tell them apart w/o knowing one is samsung or not.
-        jtr_format: manu =~ /samsung/i ? 'android-sha1' : 'android-samsung-sha1' ,
+        jtr_format: manu =~ /samsung/i ? 'android-samsung-sha1' : 'android-sha1',
         origin_type: :session,
         post_reference_name: self.refname,
         private_type: :nonreplayable_hash,


### PR DESCRIPTION
@timwr identified a switched case, which was happening on a double negative during my testing of #12497 .
This should fix non-samsung devices to correctly label the JTR for their hashes.