### PR TITLE
consistent usage of :workspace key

### DIFF
--- a/lib/metasploit/framework/data_service/proxy/core.rb
+++ b/lib/metasploit/framework/data_service/proxy/core.rb
@@ -183,9 +183,6 @@ class DataProxy
     # If :id is present the user only wants a specific record, so workspace isn't needed
     return if opts.key?(:id)
 
-    # Some methods use the key :wspace. Let's standardize on :workspace and clean it up here.
-    opts[:workspace] = opts.delete(:wspace) unless opts[:wspace].nil?
-
     # If the user passed in a specific workspace then use that in opts
     opts[:workspace] = wspace if wspace
 

--- a/lib/msf/core/auxiliary/nmap.rb
+++ b/lib/msf/core/auxiliary/nmap.rb
@@ -244,7 +244,7 @@ def nmap_hosts(&block)
   if Rex::Parser.nokogiri_loaded && framework.db.active
     wspace = framework.db.find_workspace(datastore['WORKSPACE'])
     wspace ||= framework.db.workspace
-    import_args = { :data => nmap_data, :wspace => wspace }
+    import_args = { :data => nmap_data, :workspace => wspace }
     framework.db.import_nmap_noko_stream(import_args) { |type, data| yield type, data }
   else
     nmap_parser = Rex::Parser::NmapXMLStreamParser.new

--- a/lib/msf/core/db_manager/host.rb
+++ b/lib/msf/core/db_manager/host.rb
@@ -104,7 +104,7 @@ module Msf::DBManager::Host
     if opts.kind_of? ::Mdm::Host
       return opts
     elsif opts.kind_of? String
-      raise RuntimeError, "This invokation of get_host is no longer supported: #{caller}"
+      raise RuntimeError, "This invocation of get_host is no longer supported: #{caller}"
     else
       address = opts[:addr] || opts[:address] || opts[:host] || return
       return address if address.kind_of? ::Mdm::Host

--- a/lib/msf/core/db_manager/host_tag.rb
+++ b/lib/msf/core/db_manager/host_tag.rb
@@ -8,7 +8,7 @@ module Msf::DBManager::HostTag
     raise Msf::DBImportError.new("Missing required option :addr") unless addr
   ::ActiveRecord::Base.connection_pool.with_connection {
     wspace = Msf::Util::DBManager.process_opts_workspace(opts, framework)
-    raise Msf::DBImportError.new("Missing required option :wspace") unless wspace
+    raise Msf::DBImportError.new("Missing required option :workspace") unless wspace
     host = nil
     report_host(:workspace => wspace, :address => addr)
 

--- a/lib/msf/core/db_manager/import/acunetix.rb
+++ b/lib/msf/core/db_manager/import/acunetix.rb
@@ -18,7 +18,7 @@ module Msf::DBManager::Import::Acunetix
       parser = "Nokogiri v#{::Nokogiri::VERSION}"
       noko_args = args.dup
       noko_args[:blacklist] = bl
-      noko_args[:wspace] = wspace
+      noko_args[:workspace] = wspace
       if block
         yield(:parser, parser)
         import_acunetix_noko_stream(noko_args) {|type, data| yield type,data}

--- a/lib/msf/core/db_manager/import/appscan.rb
+++ b/lib/msf/core/db_manager/import/appscan.rb
@@ -18,7 +18,7 @@ module Msf::DBManager::Import::Appscan
       parser = "Nokogiri v#{::Nokogiri::VERSION}"
       noko_args = args.dup
       noko_args[:blacklist] = bl
-      noko_args[:wspace] = wspace
+      noko_args[:workspace] = wspace
       if block
         yield(:parser, parser)
         import_appscan_noko_stream(noko_args) {|type, data| yield type,data}

--- a/lib/msf/core/db_manager/import/burp_issue.rb
+++ b/lib/msf/core/db_manager/import/burp_issue.rb
@@ -7,7 +7,7 @@ module Msf::DBManager::Import::BurpIssue
     parser = "Nokogiri v#{::Nokogiri::VERSION}"
     noko_args = args.dup
     noko_args[:blacklist] = bl
-    noko_args[:wspace] = wspace
+    noko_args[:workspace] = wspace
     if block
       yield(:parser, parser)
       doc = Rex::Parser::BurpIssueDocument.new(args,framework.db) {|type, data| yield type,data }

--- a/lib/msf/core/db_manager/import/burp_session.rb
+++ b/lib/msf/core/db_manager/import/burp_session.rb
@@ -19,7 +19,7 @@ module Msf::DBManager::Import::BurpSession
       parser = "Nokogiri v#{::Nokogiri::VERSION}"
       noko_args = args.dup
       noko_args[:blacklist] = bl
-      noko_args[:wspace] = wspace
+      noko_args[:workspace] = wspace
       if block
         yield(:parser, parser)
         import_burp_session_noko_stream(noko_args) {|type, data| yield type,data}

--- a/lib/msf/core/db_manager/import/ci.rb
+++ b/lib/msf/core/db_manager/import/ci.rb
@@ -18,7 +18,7 @@ module Msf::DBManager::Import::CI
       parser = "Nokogiri v#{::Nokogiri::VERSION}"
       noko_args = args.dup
       noko_args[:blacklist] = bl
-      noko_args[:wspace] = wspace
+      noko_args[:workspace] = wspace
       if block
         yield(:parser, parser)
         import_ci_noko_stream(noko_args) {|type, data| yield type,data}

--- a/lib/msf/core/db_manager/import/foundstone.rb
+++ b/lib/msf/core/db_manager/import/foundstone.rb
@@ -18,7 +18,7 @@ module Msf::DBManager::Import::Foundstone
       parser = "Nokogiri v#{::Nokogiri::VERSION}"
       noko_args = args.dup
       noko_args[:blacklist] = bl
-      noko_args[:wspace] = wspace
+      noko_args[:workspace] = wspace
       if block
         yield(:parser, parser)
         import_foundstone_noko_stream(noko_args) {|type, data| yield type,data}

--- a/lib/msf/core/db_manager/import/fusion_vm.rb
+++ b/lib/msf/core/db_manager/import/fusion_vm.rb
@@ -2,7 +2,7 @@ require 'rex/parser/fusionvm_nokogiri'
 
 module Msf::DBManager::Import::FusionVM
   def import_fusionvm_xml(args={})
-    args[:wspace] = Msf::Util::DBManager.process_opts_workspace(args, framework).name
+    args[:workspace] = Msf::Util::DBManager.process_opts_workspace(args, framework).name # key needs update?
     bl = validate_ips(args[:blacklist]) ? args[:blacklist].split : []
     doc = Rex::Parser::FusionVMDocument.new(args,self)
     parser = ::Nokogiri::XML::SAX::Parser.new(doc)

--- a/lib/msf/core/db_manager/import/ip360/aspl.rb
+++ b/lib/msf/core/db_manager/import/ip360/aspl.rb
@@ -6,8 +6,6 @@ module Msf::DBManager::Import::IP360::ASPL
   #
   def import_ip360_aspl_xml(args={}, &block)
     data = args[:data]
-    wspace = Msf::Util::DBManager.process_opts_workspace(args, framework).name
-    bl = validate_ips(args[:blacklist]) ? args[:blacklist].split : []
 
     if not data.index("<ontology")
       raise Msf::DBImportError.new("The ASPL file does not appear to be valid or may still be compressed")

--- a/lib/msf/core/db_manager/import/mbsa.rb
+++ b/lib/msf/core/db_manager/import/mbsa.rb
@@ -18,7 +18,7 @@ module Msf::DBManager::Import::MBSA
       parser = "Nokogiri v#{::Nokogiri::VERSION}"
       noko_args = args.dup
       noko_args[:blacklist] = bl
-      noko_args[:wspace] = wspace
+      noko_args[:workspace] = wspace
       if block
         yield(:parser, parser)
         import_mbsa_noko_stream(noko_args) {|type, data| yield type,data}

--- a/lib/msf/core/db_manager/import/metasploit_framework/credential.rb
+++ b/lib/msf/core/db_manager/import/metasploit_framework/credential.rb
@@ -14,7 +14,7 @@ module Msf::DBManager::Import::MetasploitFramework::Credential
   # Import credentials given a path to a valid manifest file
   #
   # @option args [String] :filename
-  # @option args [Mdm::Workspace] :wspace Default: {#workspace}
+  # @option args [Mdm::Workspace] :workspace Default: {#workspace}
   # @return [void]
   def import_msf_cred_dump_zip(args = {})
     wspace = Msf::Util::DBManager.process_opts_workspace(args, framework)

--- a/lib/msf/core/db_manager/import/metasploit_framework/xml.rb
+++ b/lib/msf/core/db_manager/import/metasploit_framework/xml.rb
@@ -369,7 +369,7 @@ module Msf::DBManager::Import::MetasploitFramework::XML
     host.xpath('tags/tag').each do |tag|
       tag_data = {}
       tag_data[:addr] = host_address
-      tag_data[:wspace] = wspace
+      tag_data[:workspace] = wspace
       tag_data[:name] = tag.at("name").text.to_s.strip
       tag_data[:desc] = tag.at("desc").text.to_s.strip
       if tag.at("report-summary").text

--- a/lib/msf/core/db_manager/import/metasploit_framework/zip.rb
+++ b/lib/msf/core/db_manager/import/metasploit_framework/zip.rb
@@ -57,7 +57,7 @@ module Msf::DBManager::Import::MetasploitFramework::Zip
     return 0 if bl.include? host_info[loot.at("host-id").text.to_s.strip]
     loot_info              = {}
     loot_info[:host]       = host_info[loot.at("host-id").text.to_s.strip]
-    loot_info[:workspace]  = args[:wspace]
+    loot_info[:workspace]  = args[:workspace]
     loot_info[:ctype]      = nils_for_nulls(loot.at("content-type").text.to_s.strip)
     loot_info[:info]       = nils_for_nulls(unserialize_object(loot.at("info"), allow_yaml))
     loot_info[:ltype]      = nils_for_nulls(loot.at("ltype").text.to_s.strip)
@@ -102,7 +102,7 @@ module Msf::DBManager::Import::MetasploitFramework::Zip
   # Parses task Nokogiri::XML::Element
   def parse_zip_task(task, wspace, bl, allow_yaml, btag, args, basedir, host_info, &block)
     task_info = {}
-    task_info[:workspace] = args[:wspace]
+    task_info[:workspace] = args[:workspace]
     # Should user be imported (original) or declared (the importing user)?
     task_info[:user] = nils_for_nulls(task.at("created-by").text.to_s.strip)
     task_info[:desc] = nils_for_nulls(task.at("description").text.to_s.strip)

--- a/lib/msf/core/db_manager/import/nexpose/raw.rb
+++ b/lib/msf/core/db_manager/import/nexpose/raw.rb
@@ -19,7 +19,7 @@ module Msf::DBManager::Import::Nexpose::Raw
       parser = "Nokogiri v#{::Nokogiri::VERSION}"
       noko_args = args.dup
       noko_args[:blacklist] = bl
-      noko_args[:wspace] = wspace
+      noko_args[:workspace] = wspace
       if block
         yield(:parser, parser)
         import_nexpose_raw_noko_stream(noko_args) {|type, data| yield type,data}
@@ -75,7 +75,6 @@ module Msf::DBManager::Import::Nexpose::Raw
   #
   def import_nexpose_rawxml_file(args={})
     filename = args[:filename]
-    wspace = Msf::Util::DBManager.process_opts_workspace(args, framework).name
 
     data = ""
     ::File.open(filename, 'rb') do |f|

--- a/lib/msf/core/db_manager/import/nexpose/simple.rb
+++ b/lib/msf/core/db_manager/import/nexpose/simple.rb
@@ -18,7 +18,7 @@ module Msf::DBManager::Import::Nexpose::Simple
       parser = "Nokogiri v#{::Nokogiri::VERSION}"
       noko_args = args.dup
       noko_args[:blacklist] = bl
-      noko_args[:wspace] = wspace
+      noko_args[:workspace] = wspace
       if block
         yield(:parser, parser)
         import_nexpose_noko_stream(noko_args) {|type, data| yield type,data}
@@ -155,7 +155,6 @@ module Msf::DBManager::Import::Nexpose::Simple
   #
   def import_nexpose_simplexml_file(args={})
     filename = args[:filename]
-    wspace = Msf::Util::DBManager.process_opts_workspace(args, framework).name
 
     data = ""
     ::File.open(filename, 'rb') do |f|

--- a/lib/msf/core/db_manager/import/nmap.rb
+++ b/lib/msf/core/db_manager/import/nmap.rb
@@ -22,7 +22,7 @@ module Msf::DBManager::Import::Nmap
     if Rex::Parser.nokogiri_loaded
       noko_args = args.dup
       noko_args[:blacklist] = bl
-      noko_args[:wspace] = wspace
+      noko_args[:workspace] = wspace
       if block
         yield(:parser, "Nokogiri v#{::Nokogiri::VERSION}")
         import_nmap_noko_stream(noko_args) {|type, data| yield type,data }

--- a/lib/msf/core/db_manager/import/open_vas.rb
+++ b/lib/msf/core/db_manager/import/open_vas.rb
@@ -16,7 +16,7 @@ module Msf::DBManager::Import::OpenVAS
     if Rex::Parser.nokogiri_loaded
       parser = "Nokogiri v#{::Nokogiri::VERSION}"
       noko_args = args.dup
-      noko_args[:wspace] = wspace
+      noko_args[:workspace] = wspace
       if block
         yield(:parser, parser)
         import_openvas_noko_stream(noko_args) {|type, data| yield type,data}

--- a/lib/msf/core/db_manager/import/outpost24.rb
+++ b/lib/msf/core/db_manager/import/outpost24.rb
@@ -18,7 +18,7 @@ module Msf::DBManager::Import::Outpost24
       parser = "Nokogiri v#{::Nokogiri::VERSION}"
       noko_args = args.dup
       noko_args[:blacklist] = bl
-      noko_args[:wspace] = wspace
+      noko_args[:workspace] = wspace
       if block
         yield(:parser, parser)
         import_outpost24_noko_stream(noko_args) {|type, data| yield type,data}

--- a/lib/msf/core/db_manager/import/report.rb
+++ b/lib/msf/core/db_manager/import/report.rb
@@ -22,7 +22,7 @@ module Msf::DBManager::Import::Report
       report_info[node_name.parameterize.underscore.to_sym] = node_value
     end
     # Use current workspace
-    report_info[:workspace_id] = args[:wspace].id
+    report_info[:workspace_id] = args[:workspace].id
 
     # Create report, need new ID to record artifacts
     report_id = report_report(report_info)

--- a/lib/msf/core/db_manager/session_event.rb
+++ b/lib/msf/core/db_manager/session_event.rb
@@ -26,7 +26,7 @@ module Msf::DBManager::SessionEvent
       end
 
       # Passing workspace keys to the search will cause exceptions, so remove them if they were accidentally included.
-      Msf::Util::DBManager.delete_opts_workspace(opts)
+      opts.delete(:workspace)
 
       order = opts.delete(:order)
       order = order.nil? ? DEFAULT_ORDER : order.to_sym

--- a/lib/msf/core/db_manager/vuln_attempt.rb
+++ b/lib/msf/core/db_manager/vuln_attempt.rb
@@ -29,7 +29,7 @@ module Msf::DBManager::VulnAttempt
     end
 
     # 'workspace' is not a valid attribute for Mdm::VulnAttempt. Remove it.
-    Msf::Util::DBManager.delete_opts_workspace(opts)
+    opts.delete(:workspace)
 
     search_term = opts.delete(:search_term)
     if search_term && !search_term.empty?

--- a/lib/msf/core/db_manager/workspace.rb
+++ b/lib/msf/core/db_manager/workspace.rb
@@ -54,7 +54,7 @@ module Msf::DBManager::Workspace
 
     search_term = opts.delete(:search_term)
     # Passing these values to the search will cause exceptions, so remove them if they accidentally got passed in.
-    Msf::Util::DBManager.delete_opts_workspace(opts)
+    opts.delete(:workspace)
 
     ::ActiveRecord::Base.connection_pool.with_connection {
       if search_term && !search_term.empty?
@@ -94,7 +94,7 @@ module Msf::DBManager::Workspace
 
   def update_workspace(opts)
     raise ArgumentError.new("The following options are required: :id") if opts[:id].nil?
-    Msf::Util::DBManager.delete_opts_workspace(opts)
+    opts.delete(:workspace)
 
     ::ActiveRecord::Base.connection_pool.with_connection {
       ws_id = opts.delete(:id)

--- a/lib/msf/util/db_manager.rb
+++ b/lib/msf/util/db_manager.rb
@@ -32,7 +32,7 @@ module DBManager
   # @raise [RuntimeError] couldn't find workspace
   # @return [Mdm::Workspace] The workspace object that was referenced by name in opts.
   def self.process_opts_workspace(opts, framework, required = true)
-    wspace = delete_opts_workspace(opts)
+    wspace = opts.delete(:workspace)
     if required && (wspace.nil? || (wspace.kind_of?(String) && wspace.empty?))
       raise ArgumentError.new("opts must include a valid :workspace")
     end
@@ -54,14 +54,6 @@ module DBManager
     wspace
   end
 
-  # Removes the :workspace or :wspace key from the opts hash.
-  #
-  # @param [Hash] opts The opts hash passed in from the data request.
-  # @return [String] The name of the workspace that was contained in the key.
-  def self.delete_opts_workspace(opts)
-    wlog("Both :workspace and :wspace were found in opts. Using :workspace.") if opts[:workspace] && opts[:wspace]
-    opts.delete(:workspace) || opts.delete(:wspace)
-  end
 end
 end
 end

--- a/lib/rex/parser/acunetix_nokogiri.rb
+++ b/lib/rex/parser/acunetix_nokogiri.rb
@@ -72,7 +72,7 @@ module Rex
         @host_object = report_host &block
         if @host_object
           report_starturl_service(&block)
-          db.report_import_note(@args[:wspace],@host_object)
+          db.report_import_note(@args[:workspace],@host_object)
         end
       when "StartTime"
         @state[:has_text] = false
@@ -454,7 +454,7 @@ module Rex
       return unless in_tag("Scan")
       if host_is_okay
         db.emit(:address,@report_data[:host],&block) if block
-        host_info = @report_data.merge(:workspace => @args[:wspace])
+        host_info = @report_data.merge(:workspace => @args[:workspace])
         db_report(:host,host_info)
       end
     end
@@ -509,10 +509,10 @@ module Rex
       address = resolve_address(host)
       return unless address
       # If we didn't create the service, we don't care about the site
-      service_object = db.get_service @args[:wspace], address, "tcp", port
+      service_object = db.get_service @args[:workspace], address, "tcp", port
       return unless service_object
       web_site_info = {
-        :workspace => @args[:wspace],
+        :workspace => @args[:workspace],
         :service => service_object,
         :vhost => host,
         :ssl => (scheme == "https")

--- a/lib/rex/parser/appscan_nokogiri.rb
+++ b/lib/rex/parser/appscan_nokogiri.rb
@@ -263,7 +263,7 @@ module Rex
       return unless port
       scheme = uri.scheme
       return unless scheme
-      web_site_info = {:workspace => @args[:wspace]}
+      web_site_info = {:workspace => @args[:workspace]}
       web_site_info[:vhost] = hostname
       service_obj = check_for_existing_service(address,port)
       if service_obj
@@ -278,7 +278,7 @@ module Rex
       unless @state[:web_sites].include? web_site_obj
         url = "#{uri.scheme}://#{uri.host}:#{uri.port}"
         db.emit(:web_site, url, &block) if block
-        db.report_import_note(@args[:wspace], web_site_obj.service.host)
+        db.report_import_note(@args[:workspace], web_site_obj.service.host)
         @state[:web_sites] << web_site_obj
       end
       @state[:service] = service_obj || web_site_obj.service
@@ -287,7 +287,7 @@ module Rex
     end
 
     def check_for_existing_service(address,port)
-      db.get_service(@args[:wspace],address,"tcp",port)
+      db.get_service(@args[:workspace],address,"tcp",port)
     end
 
     def resolve_port(uri)

--- a/lib/rex/parser/burp_issue_nokogiri.rb
+++ b/lib/rex/parser/burp_issue_nokogiri.rb
@@ -88,7 +88,7 @@ module Rex
       def report_web_host_info
         return unless @state[:host]
         address = Rex::Socket.resolv_to_dotted(@state[:host]) rescue nil
-        host_info = {workspace: @args[:wspace]}
+        host_info = {workspace: @args[:workspace]}
         host_info[:address] = address
         host_info[:name] = @state[:host]
         db_report(:host, host_info)
@@ -99,7 +99,7 @@ module Rex
         return unless @state[:port]
         return unless @state[:proto]
         return unless @state[:service_name]
-        service_info = {workspace: @args[:wspace]}
+        service_info = {workspace: @args[:workspace]}
         service_info[:host] = @state[:host]
         service_info[:port] = @state[:port]
         service_info[:proto] = @state[:proto]
@@ -111,7 +111,7 @@ module Rex
         return unless @state[:service_object]
         return unless @state[:vuln_name]
         return unless @state[:issue_detail]
-        vuln_info = {workspace: @args[:wspace]}
+        vuln_info = {workspace: @args[:workspace]}
         vuln_info[:service_id] = @state[:service_object].id
         vuln_info[:host] = @state[:host]
         vuln_info[:name] = @state[:vuln_name]

--- a/lib/rex/parser/burp_session_nokogiri.rb
+++ b/lib/rex/parser/burp_session_nokogiri.rb
@@ -154,7 +154,7 @@ module Rex
       return unless @state[:web_site]
       return unless @state[:uri].kind_of? URI::HTTP
       return unless @state[:web_site].service.host.name.to_s.empty?
-      host_info = {:workspace => @args[:wspace]}
+      host_info = {:workspace => @args[:workspace]}
       host_info[:address] = @state[:web_site].service.host.address
       host_info[:name] = @state[:uri].host
       db_report(:host, host_info)
@@ -186,7 +186,7 @@ module Rex
         @state[:service_info] = headers["server"].first
       end
       return unless @state[:response_body]
-      web_page_info = {:workspace => @args[:wspace]}
+      web_page_info = {:workspace => @args[:workspace]}
       web_page_info[:web_site] = @state[:web_site]
       web_page_info[:code] = @state[:status]
       web_page_info[:path] = @state[:uri].path
@@ -201,7 +201,7 @@ module Rex
     def report_web_site(&block)
       return unless @state[:uri].kind_of? URI::HTTP
       vhost = @state[:uri].host
-      web_site_info = {:workspace => @args[:wspace]}
+      web_site_info = {:workspace => @args[:workspace]}
       web_site_info[:vhost] = vhost
       address = resolve_vhost_address(@state[:uri])
       return unless address

--- a/lib/rex/parser/ci_nokogiri.rb
+++ b/lib/rex/parser/ci_nokogiri.rb
@@ -54,7 +54,7 @@ module Rex
           report_vulns(host_object)
         end
         # Reset the state once we close a host
-        @report_data = {:wspace => @args[:wspace]}
+        @report_data = {:workspace => @args[:workspace]}
         @state[:root] = {}
       when "property"
         if @state[:props]
@@ -112,7 +112,7 @@ module Rex
 
         db.emit(:address, @report_data[:host],&block) if block
         host_object = db_report(:host, @report_data.merge(
-          :workspace => @args[:wspace] ) )
+          :workspace => @args[:workspace] ) )
         if host_object
           db.report_import_note(host_object.workspace, host_object)
         end

--- a/lib/rex/parser/foundstone_nokogiri.rb
+++ b/lib/rex/parser/foundstone_nokogiri.rb
@@ -48,14 +48,14 @@ module Rex
         collect_host_data
         host_object = report_host &block
         if host_object
-          db.report_import_note(@args[:wspace],host_object)
+          db.report_import_note(@args[:workspace],host_object)
           report_fingerprint(host_object)
           report_services(host_object)
           report_vulns(host_object)
         end
         # Reset the state once we close a host
         @state.delete_if {|k| k != :current_tag}
-        @report_data = {:wspace => args[:wspace]}
+        @report_data = {:workspace => args[:workspace]}
       when "Port"
         @state[:has_text] = false
         collect_port
@@ -217,7 +217,7 @@ module Rex
       return unless in_tag("HostData")
       if host_is_okay
         db.emit(:address,@report_data[:host],&block) if block
-        host_info = @report_data.merge(:workspace => @args[:wspace])
+        host_info = @report_data.merge(:workspace => @args[:workspace])
         db_report(:host,host_info)
       end
     end

--- a/lib/rex/parser/fusionvm_nokogiri.rb
+++ b/lib/rex/parser/fusionvm_nokogiri.rb
@@ -22,7 +22,7 @@ module Parser
       thost = {
         :host      => attrs["IPAddress"],
         :name      => attrs["HostName"],
-        :workspace => @args[:wspace]
+        :workspace => @args[:workspace]
       }
       thost[:host] = attrs["IPAddress"]
       thost[:name] = attrs["HostName"]
@@ -64,7 +64,7 @@ module Parser
             :type       => "host.os.fusionvm_fingerprint",
             :data       => { :os => @text.strip },
             :host       => @host,
-            :workspace  => @args[:wspace]
+            :workspace  => @args[:workspace]
           }
           db_report(:note, tnote)
           @host.normalize_os

--- a/lib/rex/parser/mbsa_nokogiri.rb
+++ b/lib/rex/parser/mbsa_nokogiri.rb
@@ -50,7 +50,7 @@ module Rex
         collect_host_data
         host_object = report_host &block
         if host_object
-          db.report_import_note(@args[:wspace],host_object)
+          db.report_import_note(@args[:workspace],host_object)
           report_fingerprint(host_object)
           report_vulns(host_object,&block)
         end
@@ -207,7 +207,7 @@ module Rex
     def report_host(&block)
       if host_is_okay
         db.emit(:address,@report_data[:host],&block) if block
-        host_info = @report_data.merge(:workspace => @args[:wspace])
+        host_info = @report_data.merge(:workspace => @args[:workspace])
         db_report(:host, host_info)
       end
     end

--- a/lib/rex/parser/nexpose_raw_nokogiri.rb
+++ b/lib/rex/parser/nexpose_raw_nokogiri.rb
@@ -86,7 +86,7 @@ module Rex
         report_fingerprint(host_object)
         # Reset the state once we close a host
         @state.delete_if {|k| k.to_s !~ /^(current_tag|in_nodes)$/}
-        @report_data = {:wspace => @args[:wspace]}
+        @report_data = {:workspace => @args[:workspace]}
       when "name"
         collect_hostname
         @state[:has_text] = false
@@ -368,7 +368,7 @@ module Rex
       return unless @state[:test]
 
       vuln_info = {
-        :workspace => @args[:wspace],
+        :workspace => @args[:workspace],
         # This name will be overwritten during the vuln definition
         # parsing via mass-update.
         :name => "NEXPOSE-" + @state[:test][:id].downcase,
@@ -655,7 +655,7 @@ module Rex
         db.emit(:address,@report_data[:host],&block) if block
         device_id   = @report_data[:nx_device_id]
 
-        host_object = db_report(:host, @report_data.merge(:workspace => @args[:wspace] ) )
+        host_object = db_report(:host, @report_data.merge(:workspace => @args[:workspace] ) )
         if host_object
           db.report_import_note(host_object.workspace, host_object)
           if device_id

--- a/lib/rex/parser/nexpose_simple_nokogiri.rb
+++ b/lib/rex/parser/nexpose_simple_nokogiri.rb
@@ -54,7 +54,7 @@ module Rex
         report_vulns(host_object)
         # Reset the state once we close a host
         @state.delete_if {|k| k != :current_tag}
-        @report_data = {:wspace => @args[:wspace]}
+        @report_data = {:workspace => @args[:workspace]}
       when "description"
         @state[:has_text] = false
         collect_service_fingerprint_description
@@ -235,7 +235,7 @@ module Rex
       if host_is_okay
         db.emit(:address,@report_data[:host],&block) if block
         host_object = db_report(:host, @report_data.merge(
-          :workspace => @args[:wspace] ) )
+          :workspace => @args[:workspace] ) )
         if host_object
           db.report_import_note(host_object.workspace, host_object)
         end

--- a/lib/rex/parser/nmap_nokogiri.rb
+++ b/lib/rex/parser/nmap_nokogiri.rb
@@ -80,14 +80,14 @@ module Rex
         collect_host_data
         host_object = report_host &block
         if host_object
-          db.report_import_note(@args[:wspace],host_object)
+          db.report_import_note(@args[:workspace],host_object)
           report_services(host_object,&block)
           report_fingerprint(host_object)
           report_uptime(host_object)
           report_traceroute(host_object)
         end
         @state.delete_if {|k| k != :current_tag}
-        @report_data = {:wspace => @args[:wspace]}
+        @report_data = {:workspace => @args[:workspace]}
       end
       @state[:current_tag].delete name
     end
@@ -348,7 +348,7 @@ module Rex
     def report_host(&block)
       if host_is_okay
         scripts = @report_data.delete(:scripts) || []
-        host_object = db_report(:host, @report_data.merge( :workspace => @args[:wspace] ) )
+        host_object = db_report(:host, @report_data.merge( :workspace => @args[:workspace] ) )
         db.emit(:address,@report_data[:host],&block) if block
 
         scripts.each do |script|

--- a/lib/rex/parser/nokogiri_doc_mixin.rb
+++ b/lib/rex/parser/nokogiri_doc_mixin.rb
@@ -49,7 +49,7 @@ module Parser
       @state = {}
       @state[:current_tag] = {}
       @block = block if block
-      @report_data = {:wspace => args[:wspace]}
+      @report_data = {:workspace => args[:workspace]}
       @nx_console_id = args[:nx_console_id]
       super()
     end
@@ -148,7 +148,7 @@ module Parser
       end
       return nil if just_the_facts.empty?
       just_the_facts[:task] = @args[:task]
-      just_the_facts[:wspace] = @args[:wspace] # workspace context is a required `fact`
+      just_the_facts[:workspace] = @args[:workspace] # workspace context is a required `fact`
       db.send("report_#{table}", just_the_facts)
     end
 

--- a/lib/rex/parser/openvas_nokogiri.rb
+++ b/lib/rex/parser/openvas_nokogiri.rb
@@ -134,7 +134,7 @@ module Parser
         vuln_info[:info] = @state[:vuln_desc]
         vuln_info[:port] = @state[:port]
         vuln_info[:proto] = @state[:proto]
-        vuln_info[:workspace] = @args[:wspace]
+        vuln_info[:workspace] = @args[:workspace]
 
         db_report(:vuln, vuln_info)
       end
@@ -148,7 +148,7 @@ module Parser
         vuln_info[:info] = @state[:vuln_desc]
         vuln_info[:port] = @state[:port]
         vuln_info[:proto] = @state[:proto]
-        vuln_info[:workspace] = @args[:wspace]
+        vuln_info[:workspace] = @args[:workspace]
 
         db_report(:vuln, vuln_info)
       end
@@ -161,13 +161,13 @@ module Parser
     service_info[:name] = @state[:name]
     service_info[:port] = @state[:port]
     service_info[:proto] = @state[:proto]
-    service_info[:workspace] = @args[:wspace]
+    service_info[:workspace] = @args[:workspace]
 
     db_report(:service, service_info)
 
     host_info = {}
     host_info[:host] = @state[:host]
-    host_info[:workspace] = @args[:wspace]
+    host_info[:workspace] = @args[:workspace]
 
     db_report(:host, host_info)
   end


### PR DESCRIPTION
Updates framework db code for workspaces to use a consistent key of `:workspace` in option hashes.

Simplifies the detection of workspace parameters values.  This is one atomic piece in an ongoing progression of workspace changes.

WARNING: This impacts the arguments signature for the internal library used when importing external data XML and Zip formats to update the argument name from `:wspace` -> `:workspace`.


## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `workspace -a first_import`
- [x] `db_import pwdump.txt`
- [x] **Verify** the creds import
- [x] `workspace -a second_import`
- [x] `db_import nexpose_simple_xml_3hosts.xml`
- [x] **Verify** the host and vuln details reported are in the correct workspace.
