### PR TITLE
stub test for compiled encrypted payloads

### DIFF
--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -2959,12 +2959,19 @@ RSpec.describe 'modules/payloads', :content do
                           reference_name: 'windows/download_exec'
   end
 
+  context 'windows/encrypted_shell/reverse_tcp' do
+    it_should_behave_like 'payload is not cached',
+                          ancestor_reference_names: [
+                              'stagers/windows/encrypted_reverse_tcp',
+                              'stages/windows/encrypted_shell'
+                          ],
+                          reference_name: 'windows/encrypted_shell/reverse_tcp'
+  end
+
   context 'windows/encrypted_shell_reverse_tcp' do
     it_should_behave_like 'payload is not cached',
                           ancestor_reference_names: [
-                              'singles/windows/encrypted_shell_reverse_tcp',
-                              'stagers/windows/encrypted_reverse_tcp',
-                              'stages/windows/encrypted_shell'
+                              'singles/windows/encrypted_shell_reverse_tcp'
                           ],
                           reference_name: 'windows/encrypted_shell_reverse_tcp'
   end

--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -2959,6 +2959,18 @@ RSpec.describe 'modules/payloads', :content do
                           reference_name: 'windows/download_exec'
   end
 
+  context 'windows/encrypted_reverse_tcp' do
+    # payload depends on mingw skip testing
+  end
+
+  context 'windows/encrypted_shell' do
+    # payload depends on mingw skip testing
+  end
+
+  context 'windows/encrypted_shell_reverse_tcp' do
+    # payload depends on mingw skip testing
+  end
+
   context 'windows/exec' do
     it_should_behave_like 'payload cached size is consistent',
                           ancestor_reference_names: [
@@ -4172,6 +4184,18 @@ RSpec.describe 'modules/payloads', :content do
                           dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/vncinject/reverse_tcp_rc4_dns'
+  end
+
+  context 'windows/x64/encrypted_reverse_tcp' do
+    # payload depends on mingw skip testing
+  end
+
+  context 'windows/x64/encrypted_shell' do
+    # payload depends on mingw skip testing
+  end
+
+  context 'windows/x64/encrypted_shell_reverse_tcp' do
+    # payload depends on mingw skip testing
   end
 
   context 'windows/x64/exec' do

--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -2959,16 +2959,14 @@ RSpec.describe 'modules/payloads', :content do
                           reference_name: 'windows/download_exec'
   end
 
-  context 'windows/encrypted_reverse_tcp' do
-    # payload depends on mingw skip testing
-  end
-
-  context 'windows/encrypted_shell' do
-    # payload depends on mingw skip testing
-  end
-
   context 'windows/encrypted_shell_reverse_tcp' do
-    # payload depends on mingw skip testing
+    it_should_behave_like 'payload is not cached',
+                          ancestor_reference_names: [
+                              'singles/windows/encrypted_shell_reverse_tcp',
+                              'stagers/windows/encrypted_reverse_tcp',
+                              'stages/windows/encrypted_shell'
+                          ],
+                          reference_name: 'windows/encrypted_shell_reverse_tcp'
   end
 
   context 'windows/exec' do
@@ -4186,16 +4184,15 @@ RSpec.describe 'modules/payloads', :content do
                           reference_name: 'windows/vncinject/reverse_tcp_rc4_dns'
   end
 
-  context 'windows/x64/encrypted_reverse_tcp' do
-    # payload depends on mingw skip testing
-  end
-
-  context 'windows/x64/encrypted_shell' do
-    # payload depends on mingw skip testing
-  end
-
   context 'windows/x64/encrypted_shell_reverse_tcp' do
-    # payload depends on mingw skip testing
+    it_should_behave_like 'payload is not cached',
+                          ancestor_reference_names: [
+                              'singles/windows/x64/encrypted_shell_reverse_tcp',
+                              'stagers/windows/x64/encrypted_reverse_tcp',
+                              'stages/windows/x64/encrypted_shell'
+                          ],
+                          reference_name: 'windows/x64/encrypted_shell_reverse_tcp'
+
   end
 
   context 'windows/x64/exec' do

--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -4184,15 +4184,21 @@ RSpec.describe 'modules/payloads', :content do
                           reference_name: 'windows/vncinject/reverse_tcp_rc4_dns'
   end
 
-  context 'windows/x64/encrypted_shell_reverse_tcp' do
+  context 'windows/x64/encrypted_shell/reverse_tcp' do
     it_should_behave_like 'payload is not cached',
                           ancestor_reference_names: [
-                              'singles/windows/x64/encrypted_shell_reverse_tcp',
                               'stagers/windows/x64/encrypted_reverse_tcp',
                               'stages/windows/x64/encrypted_shell'
                           ],
-                          reference_name: 'windows/x64/encrypted_shell_reverse_tcp'
+                          reference_name: 'windows/x64/encrypted_shell/reverse_tcp'
+  end
 
+  context 'windows/x64/encrypted_shell_reverse_tcp' do
+    it_should_behave_like 'payload is not cached',
+                          ancestor_reference_names: [
+                              'singles/windows/x64/encrypted_shell_reverse_tcp'
+                          ],
+                          reference_name: 'windows/x64/encrypted_shell_reverse_tcp'
   end
 
   context 'windows/x64/exec' do

--- a/spec/support/shared/examples/payload_not_cached.rb
+++ b/spec/support/shared/examples/payload_not_cached.rb
@@ -1,0 +1,18 @@
+RSpec.shared_examples_for 'payload is not cached' do |options|
+  options.assert_valid_keys(:ancestor_reference_names, :reference_name)
+
+  reference_name = options.fetch(:reference_name)
+
+  ancestor_reference_names = options.fetch(:ancestor_reference_names)
+
+  module_type = 'payload'
+
+  context reference_name do
+    ancestor_reference_names.each do |ancestor_reference_name|
+      it "has listed ancestors '#{module_type}/#{ancestor_reference_name}'" do
+        @actual_ancestor_reference_name_set.add(ancestor_reference_name)
+      end
+    end
+  
+  end
+end


### PR DESCRIPTION
To ensure the tests do not think there are `missing payload tests` this stubs in a context for new payloads that are only viable with `mingw` in the environment.

## Verification

List the steps needed to make sure this thing works

- [x] Validate `rake` spec results in `log/untested-payloads.log` that does not contain `encrypted` payloads as untested.