### PR TITLE
Alter scanners info method to show check supported properly

### DIFF
--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -323,8 +323,9 @@ class ReadableText
     end
 
     # Check
+    has_check = mod.class.instance_methods(false).include?(:check) || mod.respond_to?(:check_host)
     output << "Check supported:\n"
-    output << "#{indent}#{mod.respond_to?(:check) ? 'Yes' : 'No'}\n\n"
+    output << "#{indent}#{has_check ? 'Yes' : 'No'}\n\n"
 
     # Options
     if (mod.options.has_options?)


### PR DESCRIPTION
Don't say the module supports check if it doesn't support check

Modules that included the scanner mixin were incorrectly reporting that they supported check since the scanner mixin contains a check method. Made the logic for determining if a module actually supports check slightly more thorough
## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Load up an aux scanner module that doesn't support check
- [x] Running `info` should show that the module does support check
- [x] Switch to this PR
- [x] Run info, the output should now show the module does _not_ support check

