### PR TITLE
set db workspace in handler when active

### DIFF
--- a/lib/msf/core/handler.rb
+++ b/lib/msf/core/handler.rb
@@ -221,6 +221,11 @@ protected
       # and any relevant information
       s.set_from_exploit(assoc_exploit)
 
+      # set injected worksapce value if db is active
+      if framework.db.active && wspace = framework.db.find_workspace(s.workspace)
+        framework.db.workspace = wspace
+      end
+
       # Pass along any associated payload uuid if specified
       if opts[:payload_uuid]
         s.payload_uuid = opts[:payload_uuid]

--- a/lib/msf/core/handler.rb
+++ b/lib/msf/core/handler.rb
@@ -221,7 +221,7 @@ protected
       # and any relevant information
       s.set_from_exploit(assoc_exploit)
 
-      # set injected worksapce value if db is active
+      # set injected workspace value if db is active
       if framework.db.active && wspace = framework.db.find_workspace(s.workspace)
         framework.db.workspace = wspace
       end


### PR DESCRIPTION
Changes in workspace interactions with payloads and handlers in `msf5` have produce a possibility that the framework object spawning a handler will not have the correct workspace attached.

By setting the workspace base on the workspace stored on the exploit that requested the handler sessions are passed to the appropriate context. 
 
## Verification

List the steps needed to make sure this thing works

- [x] Prepare an XP target vulnerable to `ms08_067_netapi`
- [x] Start `msfconsole`
- [x] `workspace -a newSpace`
- [x] `use exploit/windows/smb/ms08_067_netapi` to create a session
- [x] **Verify** session created is connected to `host_id` in `new_space` in the database

