### PR TITLE
set any passed workspace if db is active

### DIFF
--- a/lib/msf/ui/web/console.rb
+++ b/lib/msf/ui/web/console.rb
@@ -51,6 +51,10 @@ class WebConsole
     # Skip database initialization if it is already configured
     if framework.db && framework.db.active
       opts['SkipDatabaseInit'] = true
+      if opts['workspace']
+        wspace = framework.db.find_workspace(opts['workspace'])
+        framework.db.workspace = wspace
+      end
     end
 
     # Initialize the console with our pipe


### PR DESCRIPTION
Changes in workspace interactions with console drivers in msf5 have produce a possibility that the framework object when spawning a new console will not have a usable workspace attached.

By setting the workspace base on a workspace passed in the request the appropriate context can be set.

This was found interacting with an RPC web console, however there may be more impacts to consider based on this find.

This may be incomplete and behaviour is still in flux, however it should also be backwards compatible with existing interactions.

## Verification

List the steps needed to make sure this thing works

- [x] Start an rpc daemon with a working `database.yml` connection.
- [x] renaming the `default` workspace directly in the database.
- [x] Start a web console via `rpc_create` passing the new name of the `workspace` in the param lists `{ 'workspace' => 'renamed_default' }`
- [x] ***Verify*** no stack trace is thrown by reporting functions.
