### PR TITLE
Improve wordpress check versions

### DIFF
--- a/lib/msf/core/exploit/http/wordpress/version.rb
+++ b/lib/msf/core/exploit/http/wordpress/version.rb
@@ -65,8 +65,9 @@ module Msf::Exploit::Remote::HTTP::Wordpress::Version
       'method' => 'GET'
     )
 
-    # No style.css file present
-    return Msf::Exploit::CheckCode::Unknown if res.nil? || res.code != 200
+    if res.nil? || res.code != 200
+      return Msf::Exploit::CheckCode::Unknown("No style.css file present")
+    end
 
     return extract_and_check_version(res.body.to_s, :style, :theme, fixed_version, vuln_introduced_version)
   end
@@ -96,9 +97,8 @@ module Msf::Exploit::Remote::HTTP::Wordpress::Version
       'method' => 'GET'
     )
 
-    # file not found
     unless res && res.code == 200
-      return Msf::Exploit::CheckCode::Unknown
+      return Msf::Exploit::CheckCode::Unknown("File not found")
     end
 
     extract_and_check_version(res.body.to_s, :custom, 'custom file', fixed_version, vuln_introduced_version, regex)
@@ -144,7 +144,9 @@ module Msf::Exploit::Remote::HTTP::Wordpress::Version
 
     if res.nil? || res.code != 200
       # No readme.txt or Readme.txt present for plugin
-      return Msf::Exploit::CheckCode::Unknown if type == :plugin
+      if type == :plugin
+        return Msf::Exploit::CheckCode::Unknown(res ? "Response code=#{res.code}" : 'No response')
+      end
 
       # Try again using the style.css file
       return check_theme_version_from_style(name, fixed_version, vuln_introduced_version) if type == :theme
@@ -177,8 +179,9 @@ module Msf::Exploit::Remote::HTTP::Wordpress::Version
       fail("Unknown file type #{type}")
     end
 
-    # Could not identify version number
-    return Msf::Exploit::CheckCode::Detected if version.nil?
+    unless version
+      return Msf::Exploit::CheckCode::Detected("Could not identify the version number")
+    end
 
     vprint_status("Found version #{version} of the #{item_type}")
 
@@ -210,5 +213,7 @@ module Msf::Exploit::Remote::HTTP::Wordpress::Version
         return Msf::Exploit::CheckCode::Safe
       end
     end
+  rescue ArgumentError => e
+    return Msf::Exploit::CheckCode::Detected(e.message)
   end
 end

--- a/lib/msf/core/exploit/http/wordpress/version.rb
+++ b/lib/msf/core/exploit/http/wordpress/version.rb
@@ -98,7 +98,7 @@ module Msf::Exploit::Remote::HTTP::Wordpress::Version
     )
 
     unless res && res.code == 200
-      return Msf::Exploit::CheckCode::Unknown("File not found")
+      return Msf::Exploit::CheckCode::Unknown("Unable to retrieve the custom file")
     end
 
     extract_and_check_version(res.body.to_s, :custom, 'custom file', fixed_version, vuln_introduced_version, regex)

--- a/spec/lib/msf/core/exploit/http/wordpress/version_spec.rb
+++ b/spec/lib/msf/core/exploit/http/wordpress/version_spec.rb
@@ -80,17 +80,37 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Version do
     let(:wp_body) { nil }
     let(:wp_fixed_version) { nil }
 
+    context 'when no response is returned' do
+      let(:expected_checkcode) { Msf::Exploit::CheckCode::Unknown("No response") }
+      before :example do
+        allow(subject).to receive(:send_request_cgi)
+      end
+      it 'returns the expected check code' do
+        ret = subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version)
+        expect(ret).to eq(expected_checkcode)
+        expect(ret.reason).to eq(expected_checkcode.reason)
+      end
+    end
+
     context 'when no readme is found' do
       let(:wp_code) { 404 }
-      expected_checkcode = Msf::Exploit::CheckCode::Unknown("Response code=404")
-      it { expect(subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version)).to eq(expected_checkcode) }
+      let(:expected_checkcode) { Msf::Exploit::CheckCode::Unknown("Response code=404") }
+      it 'returns the expected check code' do
+        ret = subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version)
+        expect(ret).to eq(expected_checkcode)
+        expect(ret.reason).to eq(expected_checkcode.reason)
+      end
     end
 
     context 'when no version can be extracted from readme' do
       let(:wp_code) { 200 }
       let(:wp_body) { 'invalid content' }
-      expected_checkcode = Msf::Exploit::CheckCode::Detected("Could not identify the version number")
-      it { expect(subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version)).to eq(expected_checkcode) }
+      let(:expected_checkcode) { Msf::Exploit::CheckCode::Detected("Could not identify the version number") }
+      it 'returns the expected check code' do
+        ret = subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version)
+        expect(ret).to eq(expected_checkcode)
+        expect(ret.reason).to eq(expected_checkcode.reason)
+      end
     end
 
     context 'when version from readme has arbitrary leading whitespace' do
@@ -152,6 +172,19 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Version do
       let(:wp_body) { 'Stable tag: 1.0.0' }
       it { expect(subject.send(:check_version_from_readme, :plugin, 'name')).to be(Msf::Exploit::CheckCode::Appears) }
     end
+
+    context 'when an error occurs when parsing the version' do
+      let(:wp_code) { 200 }
+      let(:wp_fixed_version) { '1.5.3' }
+      let(:invalid_version) { 'NOTVALID' }
+      let(:wp_body) { "Stable tag: #{invalid_version}" }
+      let(:expected_checkcode) { Msf::Exploit::CheckCode::Detected("Malformed version number string #{invalid_version}") }
+      it 'returns the expected check code' do
+        ret = subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version)
+        expect(ret).to eq(expected_checkcode)
+        expect(ret.reason).to eq(expected_checkcode.reason)
+      end
+    end
   end
 
   describe '#check_theme_version_from_style' do
@@ -170,15 +203,23 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Version do
 
     context 'when no style is found' do
       let(:wp_code) { 404 }
-      expected_checkcode = Msf::Exploit::CheckCode::Unknown("No style.css file present")
-      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version)).to eq(expected_checkcode) }
+      let(:expected_checkcode) { Msf::Exploit::CheckCode::Unknown("No style.css file present") }
+      it 'returns the expected check code' do
+        ret = subject.send(:check_theme_version_from_style, 'name', wp_fixed_version)
+        expect(ret).to eq(expected_checkcode)
+        expect(ret.reason).to eq(expected_checkcode.reason)
+      end
     end
 
     context 'when no version can be extracted from style' do
       let(:wp_code) { 200 }
       let(:wp_body) { 'invalid content' }
-      expected_checkcode = Msf::Exploit::CheckCode::Detected("Could not identify the version number")
-      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version)).to eq(expected_checkcode) }
+      let(:expected_checkcode) { Msf::Exploit::CheckCode::Detected("Could not identify the version number") }
+      it 'returns the expected check code' do
+        ret = subject.send(:check_theme_version_from_style, 'name', wp_fixed_version)
+        expect(ret).to eq(expected_checkcode)
+        expect(ret.reason).to eq(expected_checkcode.reason)
+      end
     end
 
     context 'when version from style has arbitrary leading whitespace' do
@@ -240,6 +281,19 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Version do
       let(:wp_body) { 'Version: 1.0.0' }
       it { expect(subject.send(:check_theme_version_from_style, 'name')).to be(Msf::Exploit::CheckCode::Appears) }
     end
+
+    context 'when an error occurs when parsing the version' do
+      let(:wp_code) { 200 }
+      let(:wp_fixed_version) { '1.5.3' }
+      let(:invalid_version) { 'NOTVALID' }
+      let(:wp_body) { "Version: #{invalid_version}" }
+      let(:expected_checkcode) { Msf::Exploit::CheckCode::Detected("Malformed version number string #{invalid_version}") }
+      it 'returns the expected check code' do
+        ret = subject.send(:check_theme_version_from_style, 'name', wp_fixed_version)
+        expect(ret).to eq(expected_checkcode)
+        expect(ret.reason).to eq(expected_checkcode.reason)
+      end
+    end
   end
 
   describe '#check_version_from_custom_file' do
@@ -260,15 +314,23 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Version do
 
     context 'when no file is found' do
       let(:wp_code) { 404 }
-      expected_checkcode = Msf::Exploit::CheckCode::Unknown("File not found")
-      it { expect(subject.send(:check_version_from_custom_file, wp_path, wp_regex, wp_fixed_version)).to eq(expected_checkcode) }
+      let(:expected_checkcode) { Msf::Exploit::CheckCode::Unknown("File not found") }
+      it 'returns the expected check code' do
+        ret = subject.send(:check_version_from_custom_file, wp_path, wp_regex, wp_fixed_version)
+        expect(ret).to eq(expected_checkcode)
+        expect(ret.reason).to eq(expected_checkcode.reason)
+      end
     end
 
     context 'when no version can be extracted from custom file' do
       let(:wp_code) { 200 }
       let(:wp_body) { 'invalid content' }
-      expected_checkcode = Msf::Exploit::CheckCode::Detected("Could not identify the version number")
-      it { expect(subject.send(:check_version_from_custom_file, wp_path, wp_regex, wp_fixed_version)).to eq(expected_checkcode) }
+      let(:expected_checkcode) { Msf::Exploit::CheckCode::Detected("Could not identify the version number") }
+      it 'returns the expected check code' do
+        ret = subject.send(:check_version_from_custom_file, wp_path, wp_regex, wp_fixed_version)
+        expect(ret).to eq(expected_checkcode)
+        expect(ret.reason).to eq(expected_checkcode.reason)
+      end
     end
 
     context 'when version from custom file has arbitrary leading whitespace' do
@@ -329,6 +391,19 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Version do
       let(:wp_code) { 200 }
       let(:wp_body) { 'Version: 1.0.0' }
       it { expect(subject.send(:check_version_from_custom_file, wp_path, wp_regex)).to be(Msf::Exploit::CheckCode::Appears) }
+    end
+
+    context 'when an error occurs when parsing the version' do
+      let(:wp_code) { 200 }
+      let(:wp_fixed_version) { '1.5.3' }
+      let(:invalid_version) { 'NOTVALID' }
+      let(:wp_body) { "Version: #{invalid_version}" }
+      let(:expected_checkcode) { Msf::Exploit::CheckCode::Detected("Malformed version number string #{invalid_version}") }
+      it 'returns the expected check code' do
+        ret = subject.send(:check_version_from_custom_file, wp_path, wp_regex, wp_fixed_version)
+        expect(ret).to eq(expected_checkcode)
+        expect(ret.reason).to eq(expected_checkcode.reason)
+      end
     end
   end
 

--- a/spec/lib/msf/core/exploit/http/wordpress/version_spec.rb
+++ b/spec/lib/msf/core/exploit/http/wordpress/version_spec.rb
@@ -314,7 +314,7 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Version do
 
     context 'when no file is found' do
       let(:wp_code) { 404 }
-      let(:expected_checkcode) { Msf::Exploit::CheckCode::Unknown("File not found") }
+      let(:expected_checkcode) { Msf::Exploit::CheckCode::Unknown("Unable to retrieve the custom file") }
       it 'returns the expected check code' do
         ret = subject.send(:check_version_from_custom_file, wp_path, wp_regex, wp_fixed_version)
         expect(ret).to eq(expected_checkcode)

--- a/spec/lib/msf/core/exploit/http/wordpress/version_spec.rb
+++ b/spec/lib/msf/core/exploit/http/wordpress/version_spec.rb
@@ -82,13 +82,15 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Version do
 
     context 'when no readme is found' do
       let(:wp_code) { 404 }
-      it { expect(subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version)).to be(Msf::Exploit::CheckCode::Unknown) }
+      expected_checkcode = Msf::Exploit::CheckCode::Unknown("Response code=404")
+      it { expect(subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version)).to eq(expected_checkcode) }
     end
 
     context 'when no version can be extracted from readme' do
       let(:wp_code) { 200 }
       let(:wp_body) { 'invalid content' }
-      it { expect(subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version)).to be(Msf::Exploit::CheckCode::Detected) }
+      expected_checkcode = Msf::Exploit::CheckCode::Detected("Could not identify the version number")
+      it { expect(subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version)).to eq(expected_checkcode) }
     end
 
     context 'when version from readme has arbitrary leading whitespace' do
@@ -168,13 +170,15 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Version do
 
     context 'when no style is found' do
       let(:wp_code) { 404 }
-      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version)).to be(Msf::Exploit::CheckCode::Unknown) }
+      expected_checkcode = Msf::Exploit::CheckCode::Unknown("No style.css file present")
+      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version)).to eq(expected_checkcode) }
     end
 
     context 'when no version can be extracted from style' do
       let(:wp_code) { 200 }
       let(:wp_body) { 'invalid content' }
-      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version)).to be(Msf::Exploit::CheckCode::Detected) }
+      expected_checkcode = Msf::Exploit::CheckCode::Detected("Could not identify the version number")
+      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version)).to eq(expected_checkcode) }
     end
 
     context 'when version from style has arbitrary leading whitespace' do
@@ -256,16 +260,18 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Version do
 
     context 'when no file is found' do
       let(:wp_code) { 404 }
-      it { expect(subject.send(:check_version_from_custom_file, wp_path, wp_regex, wp_fixed_version)).to be(Msf::Exploit::CheckCode::Unknown) }
+      expected_checkcode = Msf::Exploit::CheckCode::Unknown("File not found")
+      it { expect(subject.send(:check_version_from_custom_file, wp_path, wp_regex, wp_fixed_version)).to eq(expected_checkcode) }
     end
 
-    context 'when no version can be extracted from style' do
+    context 'when no version can be extracted from custom file' do
       let(:wp_code) { 200 }
       let(:wp_body) { 'invalid content' }
-      it { expect(subject.send(:check_version_from_custom_file, wp_path, wp_regex, wp_fixed_version)).to be(Msf::Exploit::CheckCode::Detected) }
+      expected_checkcode = Msf::Exploit::CheckCode::Detected("Could not identify the version number")
+      it { expect(subject.send(:check_version_from_custom_file, wp_path, wp_regex, wp_fixed_version)).to eq(expected_checkcode) }
     end
 
-    context 'when version from style has arbitrary leading whitespace' do
+    context 'when version from custom file has arbitrary leading whitespace' do
       let(:wp_code) { 200 }
       let(:wp_fixed_version) { '1.0.1' }
       let(:wp_body) { 'Version:  1.0.0' }


### PR DESCRIPTION
This PR add some improvement to the Wordpress version helper:
- Add log message to Detected and Unknown check codes
- Add an exception handler to catch Gem::Version parsing errors
- Update specs (not sure why, but specs where failing even before these changes)

## Verification

List the steps needed to make sure this thing works

- [x] rspec spec/lib/msf/core/exploit/http/wordpress/version_spec.rb

