### PR TITLE
cant strip a nil in iis75 dos

### DIFF
--- a/modules/auxiliary/dos/windows/ftp/iis75_ftpd_iac_bof.rb
+++ b/modules/auxiliary/dos/windows/ftp/iis75_ftpd_iac_bof.rb
@@ -46,7 +46,7 @@ class MetasploitModule < Msf::Auxiliary
     connect
 
     banner = sock.get_once(-1, 10)
-    print_status("banner: #{banner.strip}")
+    print_status("banner: #{banner.to_s.strip}")
 
     buf = Rex::Text.pattern_create(1024)
 


### PR DESCRIPTION
Fixes #11670 based on @bcoles suggestion.
Tested and works, the user threw the FTP exploit against HTTPS (assumed on default port), and it could be argued if no FTP banner is resolved, to not throw the exploit, but this will at least keep the module from crashing.

```
msf5 > service apache2 start
[*] exec: service apache2 start

msf5 > use auxiliary/dos/windows/ftp/iis75_ftpd_iac_bof 
msf5 auxiliary(dos/windows/ftp/iis75_ftpd_iac_bof) > set rhosts 127.0.0.1
rhosts => 127.0.0.1
msf5 auxiliary(dos/windows/ftp/iis75_ftpd_iac_bof) > set rport 80
rport => 80
msf5 auxiliary(dos/windows/ftp/iis75_ftpd_iac_bof) > run
[*] Running module against 127.0.0.1

[-] 127.0.0.1:80 - Auxiliary failed: NoMethodError undefined method `strip' for nil:NilClass
[-] 127.0.0.1:80 - Call stack:
[-] 127.0.0.1:80 -   /metasploit-framework/modules/auxiliary/dos/windows/ftp/iis75_ftpd_iac_bof.rb:49:in `run'
[*] Auxiliary module execution completed
msf5 auxiliary(dos/windows/ftp/iis75_ftpd_iac_bof) > rexploit
[*] Reloading module...
[*] Running module against 127.0.0.1

[*] 127.0.0.1:80 - banner: 
[*] Auxiliary module execution completed
```