### PR TITLE
Add stability notes to ms04_007_killbill

### DIFF
--- a/modules/exploits/windows/smb/ms04_007_killbill.rb
+++ b/modules/exploits/windows/smb/ms04_007_killbill.rb
@@ -64,8 +64,9 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'Notes'          =>
         {
-          'AKA'       => [ 'kill-bill' ],
-          'Stability' => [ CRASH_OS_RESTARTS, CRASH_SERVICE_DOWN ]
+          'AKA'         => [ 'kill-bill' ],
+          'Reliability' => [ UNRELIABLE_SESSION ],
+          'Stability'   => [ CRASH_OS_RESTARTS, CRASH_SERVICE_DOWN ]
         },
       'DisclosureDate' => 'Feb 10 2004',
       'DefaultTarget' => 0))

--- a/modules/exploits/windows/smb/ms04_007_killbill.rb
+++ b/modules/exploits/windows/smb/ms04_007_killbill.rb
@@ -41,7 +41,6 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'OSVDB', '3902' ],
           [ 'BID', '9633'],
           [ 'MSB', 'MS04-007'],
-
         ],
       'DefaultOptions' =>
         {
@@ -63,13 +62,17 @@ class MetasploitModule < Msf::Exploit::Remote
             },
           ],
         ],
+      'Notes'          =>
+        {
+          'AKA'       => [ 'kill-bill' ],
+          'Stability' => [ CRASH_OS_RESTARTS, CRASH_SERVICE_DOWN ]
+        },
       'DisclosureDate' => 'Feb 10 2004',
       'DefaultTarget' => 0))
 
-    register_options(
-      [
-        OptString.new('PROTO', [ true,  "Which protocol to use: http or smb", 'smb']),
-      ])
+    register_options [
+      OptEnum.new('PROTO', [true, 'Which protocol to use', 'smb', %w[smb http]]),
+    ]
   end
 
   # This exploit is too destructive to use during automated exploitation.


### PR DESCRIPTION
Add stability notes to `exploits/windows/smb/ms04_007_killbill`

I believe this is the only module which specifies more than one `Stability` option. `Stability` is an `Array`, which implies this format is intended.

As per the module documentation:

        You are only allowed one attempt with this vulnerability. If
        the payload fails to execute, the LSASS system service will
        crash and the target system will automatically reboot itself
        in 60 seconds. If the payload succeeds, the system will no
        longer be able to process authentication requests, denying
        all attempts to login through SMB or at the console. A
        reboot is required to restore proper functioning of an
        exploited system.

This implies `CRASH_OS_RESTARTS` is accurate, as `the target system will automatically reboot itself in 60 seconds`.

This also implies `CRASH_SERVICE_DOWN` is accurate, as after successful exploitation, `the system will no longer be able to process authentication requests`, preventing further exploitation attempts, so you won't get to try again and hope it restarts.

While these values are potentially contrary to one another, I offer this PR as a place to argue about it.

It would also be good to have at least one module in the framework with an `Array` of multiple `Stability` values as a canary for potential future parsing issues.

This PR also changes the `PROTO` option from `OptString` to `OptEnum`, just to make things complicated.
