### PR TITLE
Add check_executable check to msftidy

### DIFF
--- a/tools/dev/msftidy.rb
+++ b/tools/dev/msftidy.rb
@@ -380,6 +380,12 @@ class Msftidy
     end
   end
 
+  def check_executable
+    if File.executable?(@full_filepath)
+      error("Module should not be executable (+x)")
+    end
+  end
+
   def check_old_rubies
     return true unless CHECK_OLD_RUBIES
     return true unless Object.const_defined? :RVM
@@ -728,6 +734,7 @@ class Msftidy
     check_verbose_option
     check_badchars
     check_extname
+    check_executable
     check_old_rubies
     check_ranking
     check_disclosure_date


### PR DESCRIPTION
Add `check_executable` check to `msftidy`.

```
# ./tools/dev/msftidy.rb modules/ | grep ERROR | grep executable
modules/auxiliary/admin/scada/pcom_command.rb - [ERROR] Module should not be executable (+x)
modules/exploits/linux/local/omniresolve_suid_priv_esc.rb - [ERROR] Module should not be executable (+x)
modules/exploits/osx/browser/adobe_flash_delete_range_tl_op.rb - [ERROR] Module should not be executable (+x)
modules/exploits/unix/webapp/wp_plainview_activity_monitor_rce.rb - [ERROR] Module should not be executable (+x)
modules/exploits/windows/misc/ais_esel_server_rce.rb - [ERROR] Module should not be executable (+x)
```

This shouldn't cause issues for external modules, which *do* require to be executable, as `msftidy` uses additional context:

```ruby
        next if File.executable?(full_filepath) && msftidy.source =~ /require ["']metasploit["']/
```