### PR TITLE
Add ruby memory profiler option

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,8 @@ group :development do
   gem 'pry'
   # module documentation
   gem 'octokit'
+  # memory profiling
+  gem 'memory_profiler'
   # Metasploit::Aggregator external session proxy
   # disabled during 2.5 transition until aggregator is available
   #gem 'metasploit-aggregator'
@@ -30,7 +32,6 @@ group :development, :test do
   gem 'factory_bot_rails'
   # Make rspec output shorter and more useful
   gem 'fivemat'
-  gem 'memory_profiler'
   # running documentation generation tasks and rspec tasks
   gem 'rake'
   # Define `rake spec`.  Must be in development AND test so that its available by default as a rake test when the

--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,6 @@ gemspec name: 'metasploit-framework'
 
 gem 'sqlite3', '~>1.3.0'
 
-gem 'memory_profiler'
-
 # separate from test as simplecov is not run on travis-ci
 group :coverage do
   # code coverage for tests
@@ -32,6 +30,7 @@ group :development, :test do
   gem 'factory_bot_rails'
   # Make rspec output shorter and more useful
   gem 'fivemat'
+  gem 'memory_profiler'
   # running documentation generation tasks and rspec tasks
   gem 'rake'
   # Define `rake spec`.  Must be in development AND test so that its available by default as a rake test when the

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,8 @@ gemspec name: 'metasploit-framework'
 
 gem 'sqlite3', '~>1.3.0'
 
+gem 'memory_profiler'
+
 # separate from test as simplecov is not run on travis-ci
 group :coverage do
   # code coverage for tests

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -184,6 +184,7 @@ GEM
     loofah (2.4.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
+    memory_profiler (0.9.14)
     metasm (1.0.4)
     metasploit-concern (2.0.5)
       activemodel (~> 4.2.6)
@@ -395,6 +396,7 @@ PLATFORMS
 DEPENDENCIES
   factory_bot_rails
   fivemat
+  memory_profiler
   metasploit-framework!
   octokit
   pry

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -49,7 +49,7 @@ Gem::Specification.new do |spec|
   # Database support
   spec.add_runtime_dependency 'activerecord', *Metasploit::Framework::RailsVersionConstraint::RAILS_VERSION
   # Need 3+ for ActiveSupport::Concern
-  #spec.add_runtime_dependency 'activesupport', *Metasploit::Framework::RailsVersionConstraint::RAILS_VERSION
+  spec.add_runtime_dependency 'activesupport', *Metasploit::Framework::RailsVersionConstraint::RAILS_VERSION
   # Needed for config.action_view for view plugin compatibility for Pro
   spec.add_runtime_dependency 'actionpack', *Metasploit::Framework::RailsVersionConstraint::RAILS_VERSION
   # Backports Ruby features across language versions

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -49,7 +49,7 @@ Gem::Specification.new do |spec|
   # Database support
   spec.add_runtime_dependency 'activerecord', *Metasploit::Framework::RailsVersionConstraint::RAILS_VERSION
   # Need 3+ for ActiveSupport::Concern
-  spec.add_runtime_dependency 'activesupport', *Metasploit::Framework::RailsVersionConstraint::RAILS_VERSION
+  #spec.add_runtime_dependency 'activesupport', *Metasploit::Framework::RailsVersionConstraint::RAILS_VERSION
   # Needed for config.action_view for view plugin compatibility for Pro
   spec.add_runtime_dependency 'actionpack', *Metasploit::Framework::RailsVersionConstraint::RAILS_VERSION
   # Backports Ruby features across language versions

--- a/msfconsole
+++ b/msfconsole
@@ -5,13 +5,9 @@
 # framework.
 #
 
-#
-# Standard Library
-#
-
 require 'pathname'
 
-if ENV['METASPLOIT_FRAMEWORK_PROFILE'] == 'true'
+if ENV['METASPLOIT_CPU_PROFILE']
   gem 'perftools.rb'
   require 'perftools'
 
@@ -37,12 +33,17 @@ if ENV['METASPLOIT_FRAMEWORK_PROFILE'] == 'true'
   }
 end
 
-#
-# Project
-#
+if ENV['METASPLOIT_MEMORY_PROFILE']
+  require 'memory_profiler'
+  MemoryProfiler.start
+  at_exit {
+    report = MemoryProfiler.stop
+    report.pretty_print(to_file: 'memory.profile')
+  }
+end
 
-# @see https://github.com/rails/rails/blob/v3.2.17/railties/lib/rails/generators/rails/app/templates/script/rails#L3-L5
 begin
+# @see https://github.com/rails/rails/blob/v3.2.17/railties/lib/rails/generators/rails/app/templates/script/rails#L3-L5
   require Pathname.new(__FILE__).realpath.expand_path.parent.join('config', 'boot')
   require 'metasploit/framework/command/console'
   require 'msf/core/payload_generator'
@@ -51,3 +52,4 @@ rescue Interrupt
   puts "\nAborting..."
   exit(1)
 end
+

--- a/msfconsole
+++ b/msfconsole
@@ -7,41 +7,6 @@
 
 require 'pathname'
 
-if ENV['METASPLOIT_CPU_PROFILE']
-  gem 'perftools.rb'
-  require 'perftools'
-
-  formatted_time = Time.now.strftime('%Y%m%d%H%M%S')
-  root = Pathname.new(__FILE__).parent
-  profile_pathname = root.join('tmp', 'profiles', 'msfconsole', formatted_time)
-
-  profile_pathname.parent.mkpath
-  PerfTools::CpuProfiler.start(profile_pathname.to_path)
-
-  at_exit {
-    PerfTools::CpuProfiler.stop
-
-    puts "Generating pdf"
-
-    pdf_path = "#{profile_pathname}.pdf"
-
-    if Bundler.clean_system("pprof.rb --pdf #{profile_pathname} > #{pdf_path}")
-      puts "PDF saved to #{pdf_path}"
-
-      Rex::Compat.open_file(pdf_path)
-    end
-  }
-end
-
-if ENV['METASPLOIT_MEMORY_PROFILE']
-  require 'memory_profiler'
-  MemoryProfiler.start
-  at_exit {
-    report = MemoryProfiler.stop
-    report.pretty_print(to_file: 'memory.profile')
-  }
-end
-
 begin
 # @see https://github.com/rails/rails/blob/v3.2.17/railties/lib/rails/generators/rails/app/templates/script/rails#L3-L5
   require Pathname.new(__FILE__).realpath.expand_path.parent.join('config', 'boot')


### PR DESCRIPTION
This adds a new way to profile Metasploit for memory usage, pulled out of #12561 

To get memory profiler results, invoke msfconsole with something like this: `METASPLOIT_MEMORY_PROFILE=1 ./msfconsole`. This will enable the memory profiler and write the results to a file called `memory.profile`.

There are other enhancements to be made in how we measure utilization that I'll explore later, this is up for now as a way to separate the profiler changes from the changes to actual memory utilization in the previous PR.