### PR TITLE
Fix ssl_generate_certificate to not generate expired certs - Fix #12634

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -310,7 +310,7 @@ GEM
       metasm
       rex-core
       rex-text
-    rex-socket (0.1.20)
+    rex-socket (0.1.21)
       rex-core
     rex-sslscan (0.1.5)
       rex-core

--- a/lib/msf/core/cert_provider.rb
+++ b/lib/msf/core/cert_provider.rb
@@ -48,7 +48,7 @@ module Ssl
     def self.ssl_generate_certificate(cert_vars: {}, ksize: 2048, **opts)
       yr      = 24*3600*365
       vf      = opts[:not_before] || Time.at(Time.now.to_i - rand(yr * 3) - yr)
-      vt      = opts[:not_after]  || Time.at(vf.to_i + (rand(9)+1) * yr)
+      vt      = opts[:not_after]  || Time.at(vf.to_i + (rand(4..9) * yr))
       cvars   = self.rand_vars(cert_vars)
       subject = opts[:subject]    || ssl_generate_subject(cvars)
       ctype   = opts[:cert_type]  || opts[:ca_cert].nil? ? :ca : :server


### PR DESCRIPTION
Untested, but the same logic as https://github.com/rapid7/rex-socket/issues/20

https://github.com/rapid7/rex-socket/pull/21