### PR TITLE
Changes faraday gem to version compatible with Octokit

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,6 +17,7 @@ PATH
       ed25519
       em-http-request
       faker
+      faraday (= 0.17.0)
       filesize
       jsobfu
       json

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -205,4 +205,8 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'aws-sdk-s3'
   spec.add_runtime_dependency 'aws-sdk-ec2'
   spec.add_runtime_dependency 'aws-sdk-iam'
+  
+  # Earlier than latest Faraday gem is used to prevent upstream Octokit errors
+  spec.add_runtime_dependency 'faraday', '0.17.0'
+
 end


### PR DESCRIPTION
Latest version of Faraday (0.17.1) is incompatible with current Octokit gem in use with MS (4.14.0). This PR changes the GemSpec to use an earlier version of Faraday that is compatible (0.17.0). 

## Verification

- [x] Checkout latest `master` branch
- [x] Start `msfconsole`
- [x] Observe `Faraday::Error::ClientError.inherited called from /Users/jmartin/.rvm/gems/ruby-2.6.5@metasploit-framework/gems/octokit-4.14.0/lib/octokit/middleware/follow_redirects.rb:14.`
- [x] Checkout my branch with updated `gemspec`
- [x] run `bundle update`
- [x] Observe (hopefully) lack of above error