### PR TITLE
Unbreaks metasploit for FreeBSD with newer bcrypt

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ PATH
       aws-sdk-iam
       aws-sdk-s3
       backports
-      bcrypt (= 3.1.12)
+      bcrypt (>= 3.1.12)
       bcrypt_pbkdf
       bit-struct
       concurrent-ruby (= 1.0.5)
@@ -138,7 +138,7 @@ GEM
     aws-sigv4 (1.1.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
     backports (3.15.0)
-    bcrypt (3.1.12)
+    bcrypt (3.1.13)
     bcrypt_pbkdf (1.0.1)
     bindata (2.4.4)
     bit-struct (0.16)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -55,7 +55,7 @@ Gem::Specification.new do |spec|
   # Backports Ruby features across language versions
   spec.add_runtime_dependency 'backports'
   # Needed for some admin modules (cfme_manageiq_evm_pass_reset.rb)
-  spec.add_runtime_dependency 'bcrypt', '3.1.12'
+  spec.add_runtime_dependency 'bcrypt', '>= 3.1.12'
   # Needed for Javascript obfuscation
   spec.add_runtime_dependency 'jsobfu'
   # Needed for some admin modules (scrutinizer_add_user.rb)


### PR DESCRIPTION
bcrypt 3.1.12 and older is broken on FreeBSD
and the latest bcrypt releaes is 3.1.13 so
this should be used instead if available.

Signed-off-by: Felix <hi@l33t.name>