### PR TITLE
Small fix for OptString#valid?

### DIFF
--- a/lib/msf/core/opt_string.rb
+++ b/lib/msf/core/opt_string.rb
@@ -31,7 +31,7 @@ class OptString < OptBase
   def valid?(value=self.value, check_empty: true)
     value = normalize(value)
     return false if check_empty && empty_required_value?(value)
-    return super(check_empty: false)
+    return super(value, check_empty: false)
   end
 end
 


### PR DESCRIPTION
`OptString#valid?` was not passing the correct value to the superclass' #valid? method.

