### PR TITLE
update Kiwi extension with latest Mimikatz

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,7 +25,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 1.3.82)
+      metasploit-payloads (= 1.3.83)
       metasploit_data_models (= 3.0.10)
       metasploit_payloads-mettle (= 0.5.16)
       mqtt
@@ -204,7 +204,7 @@ GEM
       activemodel (~> 4.2.6)
       activesupport (~> 4.2.6)
       railties (~> 4.2.6)
-    metasploit-payloads (1.3.82)
+    metasploit-payloads (1.3.83)
     metasploit_data_models (3.0.10)
       activerecord (~> 4.2.6)
       activesupport (~> 4.2.6)

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/kiwi.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/kiwi.rb
@@ -37,8 +37,8 @@ class Console::CommandDispatcher::Kiwi
   def initialize(shell)
     super
     print_line
-    print_line("  .#####.   mimikatz 2.1.1 20180925 (#{client.session_type})")
-    print_line(" .## ^ ##.  \"A La Vie, A L'Amour\"")
+    print_line("  .#####.   mimikatz 2.2.0 20191125 (#{client.session_type})")
+    print_line(" .## ^ ##.  \"A La Vie, A L'Amour\" - (oe.eo)")
     print_line(" ## / \\ ##  /*** Benjamin DELPY `gentilkiwi` ( benjamin@gentilkiwi.com )")
     print_line(" ## \\ / ##       > http://blog.gentilkiwi.com/mimikatz")
     print_line(" '## v ##'        Vincent LE TOUX            ( vincent.letoux@gmail.com )")

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -72,7 +72,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '1.3.82'
+  spec.add_runtime_dependency 'metasploit-payloads', '1.3.83'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '0.5.16'
   # Needed by msfgui and other rpc components


### PR DESCRIPTION
Per https://github.com/rapid7/metasploit-payloads/pull/370 this updates the Meterpreter kiwi extension to use Mimikatz 2.2.0-20191125
