### PR TITLE
update cops to match new names

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -112,7 +112,7 @@ Metrics/MethodLength:
                   often exceed 200 lines.
   Max: 300
 
-Naming/UncommunicativeMethodParamName:
+Naming/MethodParameterName:            
   Enabled: true
   Description: 'Whoever made this requirement never looked at crypto methods, IV'
   MinNameLength: 2
@@ -126,7 +126,7 @@ Style/NumericLiterals:
   Enabled: false
   Description: 'This often hurts readability for exploit-ish code.'
 
-Layout/AlignHash:
+Layout/HashAlignment:
   Enabled: false
   Description: 'aligning info hashes to match these rules is almost impossible to get right'
 
@@ -142,7 +142,7 @@ Layout/EmptyLinesAroundMethodBody:
   Enabled: false
   Description: 'these are used to increase readability'
 
-Layout/AlignParameters:
+Layout/ParameterAlignment:
   Enabled: true
   EnforcedStyle: 'with_fixed_indentation'
   Description: 'initialize method of every module has fixed indentation for Name, Description, etc'


### PR DESCRIPTION
Rubocop names were altered upstream, these changes alter the current .rubocop.yml file to use the new names and stop any existing errors.

## Verification

- [x] run rubocop against any file with current master setup
- [x] observe `renamed` error messages as shown below 
![Screenshot 2019-12-06 at 11 11 24](https://user-images.githubusercontent.com/54621924/70343561-80c37e80-184f-11ea-91c4-add671a224c3.png)

- [x] Checkout my branch with updated rubocop
- [x] Run rubocop against any file
- [x] No more `renamed` errors