### PR TITLE
Better errors when JtR version installed from package isn't adequate

### DIFF
--- a/lib/metasploit/framework/password_crackers/cracker.rb
+++ b/lib/metasploit/framework/password_crackers/cracker.rb
@@ -320,9 +320,9 @@ module Metasploit
               if cracker == 'john'
                 # John the Ripper 1.8.0.13-jumbo-1-bleeding-973a245b96 2018-12-17 20:12:51 +0100 OMP [linux-gnu 64-bit x86_64 AVX2 AC]
                 # John the Ripper 1.9.0-jumbo-1 OMP [linux-gnu 64-bit x86_64 AVX2 AC]
-                #return $1 if line =~ /John the Ripper ([\.\w-]+) 20\d{2}-\d{2}-\d{2}/
-                return $1 if line =~ /John the Ripper (.+) \[/
-                return $2 if line =~ /John the Ripper (.+), version (.+)/
+                # John the Ripper password cracker, version 1.8.0.2-bleeding-jumbo_omp [64-bit AVX-autoconf]
+                # John the Ripper password cracker, version 1.8.0
+                return $1 if line =~ /(?: password cracker, version)? ([^\[]+)?/
               elsif cracker == 'hashcat'
                 # v5.1.0
                 return $1 if line =~ /(v[\d\.]+)/

--- a/lib/metasploit/framework/password_crackers/cracker.rb
+++ b/lib/metasploit/framework/password_crackers/cracker.rb
@@ -322,7 +322,7 @@ module Metasploit
                 # John the Ripper 1.9.0-jumbo-1 OMP [linux-gnu 64-bit x86_64 AVX2 AC]
                 # John the Ripper password cracker, version 1.8.0.2-bleeding-jumbo_omp [64-bit AVX-autoconf]
                 # John the Ripper password cracker, version 1.8.0
-                return $1 if line =~ /(?: password cracker, version)? ([^\[]+)?/
+                return $1.strip if line =~ /John the Ripper(?: password cracker, version)? ([^\[]+)/
               elsif cracker == 'hashcat'
                 # v5.1.0
                 return $1 if line =~ /(v[\d\.]+)/

--- a/lib/metasploit/framework/password_crackers/cracker.rb
+++ b/lib/metasploit/framework/password_crackers/cracker.rb
@@ -322,6 +322,7 @@ module Metasploit
                 # John the Ripper 1.9.0-jumbo-1 OMP [linux-gnu 64-bit x86_64 AVX2 AC]
                 #return $1 if line =~ /John the Ripper ([\.\w-]+) 20\d{2}-\d{2}-\d{2}/
                 return $1 if line =~ /John the Ripper (.+) \[/
+                return $2 if line =~ /John the Ripper (.+), version (.+)/
               elsif cracker == 'hashcat'
                 # v5.1.0
                 return $1 if line =~ /(v[\d\.]+)/


### PR DESCRIPTION
John the Ripper installed from native packages, like ubuntu's `john` package, might output the version in a slightly different format than when you build JtR from source.  This patch adds an additional attempt to pull the version number from JtR's like these...

I noticed this recently while following test/usage examples in #11695 .  This patch is intended to be unobtrusive and works against Ubuntu 16.04 with JtR installed via the standard apt-get utility (I did not test other platforms), while not impacting the check for JUMBO JtR.

## Existing behavior when `john` is installed in Ubuntu 16.04, but not the JUMBO JtR

```
msf5 > creds add user:des2_password hash:rEK1ecacw.7.c jtr:des
msf5 > creds add user:des_password hash:rEK1ecacw.7.c jtr:des
msf5 > creds add user:des_55 hash:rDpJV6xlcXxRM jtr:des
msf5 > creds add user:des_pot_55 hash:fakeV6xlcXxRM jtr:des
msf5 > creds add user:des_passphrase hash:qiyh4XPJGsOZ2MEAyLkfWqeQ jtr:des
msf5 > echo "fakeV6xlcXxRM:55" >> /home/vagrant/.msf4/john.pot
[*] exec: echo "fakeV6xlcXxRM:55" >> /home/vagrant/.msf4/john.pot

msf5 > echo "test" > /tmp/wordlist
[*] exec: echo "test" > /tmp/wordlist

msf5 > echo "password" >> /tmp/wordlist
[*] exec: echo "password" >> /tmp/wordlist

msf5 > setg CUSTOM_WORDLIST /tmp/wordlist
CUSTOM_WORDLIST => /tmp/wordlist
msf5 > setg ShowCommand true
ShowCommand => true
msf5 > setg USE_DEFAULT_WORDLIST false
USE_DEFAULT_WORDLIST => false
msf5 > setg DeleteTempFiles false
DeleteTempFiles => false
msf5 > setg USE_CREDS false
USE_CREDS => false
msf5 > setg USE_DB_INFO false
USE_DB_INFO => false
msf5 > setg USE_HOSTNAMES false
USE_HOSTNAMES => false
msf5 > setg USE_ROOT_WORDS false
USE_ROOT_WORDS => false
msf5 > setg ITERATION_TIMEOUT 60
ITERATION_TIMEOUT => 60
msf5 > use auxiliary/analyze/crack_aix
msf5 auxiliary(analyze/crack_aix) > run

[-] Auxiliary failed: NoMethodError undefined method `include?' for nil:NilClass
[-] Call stack:
[-]   /vagrant/modules/auxiliary/analyze/crack_aix.rb:124:in `run'
[*] Auxiliary module execution completed
```

## With the patch applied

```
msf5 > creds add user:des2_password hash:rEK1ecacw.7.c jtr:des
msf5 > creds add user:des_password hash:rEK1ecacw.7.c jtr:des
msf5 > creds add user:des_55 hash:rDpJV6xlcXxRM jtr:des
msf5 > creds add user:des_pot_55 hash:fakeV6xlcXxRM jtr:des
msf5 > creds add user:des_passphrase hash:qiyh4XPJGsOZ2MEAyLkfWqeQ jtr:des
msf5 > echo "fakeV6xlcXxRM:55" >> /home/vagrant/.msf4/john.pot
[*] exec: echo "fakeV6xlcXxRM:55" >> /home/vagrant/.msf4/john.pot

msf5 > echo "test" > /tmp/wordlist
[*] exec: echo "test" > /tmp/wordlist

msf5 > echo "password" >> /tmp/wordlist
[*] exec: echo "password" >> /tmp/wordlist

msf5 > setg CUSTOM_WORDLIST /tmp/wordlist
CUSTOM_WORDLIST => /tmp/wordlist
msf5 > setg ShowCommand true
ShowCommand => true
msf5 > setg USE_DEFAULT_WORDLIST false
USE_DEFAULT_WORDLIST => false
msf5 > setg DeleteTempFiles false
DeleteTempFiles => false
msf5 > setg USE_CREDS false
USE_CREDS => false
msf5 > setg USE_DB_INFO false
USE_DB_INFO => false
msf5 > setg USE_HOSTNAMES false
USE_HOSTNAMES => false
msf5 > setg USE_ROOT_WORDS false
USE_ROOT_WORDS => false
msf5 > setg ITERATION_TIMEOUT 60
ITERATION_TIMEOUT => 60
msf5 > use auxiliary/analyze/crack_aix
msf5 auxiliary(analyze/crack_aix) > run

[-] Auxiliary aborted due to failure: bad-config: John the Ripper JUMBO patch version required.  See https://github.com/magnumripper/JohnTheRipper
[*] Auxiliary module execution completed
```

## Verification

List the steps needed to make sure this thing works

- [ ] Begin with a system that has a non-JUMBO version of JtR installed
- [ ] Start `msfconsole`
- [ ] Follow an example in the module docs for testing one of the crack password modules (#11695)
- [ ] **Verify** you get an appropriate, descriptive error that you aren't using a JUMBO version of JtR
- [ ] Install a [JUMBO version](https://github.com/magnumripper/JohnTheRipper/blob/bleeding-jumbo/doc/INSTALL-UBUNTU) of JtR
- [ ] Rerun your same example (maybe set the CRACKER_PATH module option if you need to point to your new JUMBO `john` executable)
- [ ] **Verify** you do NOT get any error about missing JUMBO JtR and that password cracking commences
