### PR TITLE
Update enum_system: Add printing, fix setuid/setgid/crons, stop writing empty files.

### DIFF
--- a/modules/post/linux/gather/enum_system.rb
+++ b/modules/post/linux/gather/enum_system.rb
@@ -23,6 +23,7 @@ class MetasploitModule < Msf::Post
           'sinn3r', # Testing and modification of original enum_linux
           'ohdae <bindshell[at]live.com>', # Combined separate mods, modifications and testing
           'Roberto Espreto <robertoespreto[at]gmail.com>', # log files and setuid/setgid
+          'Henry Hoggard', # Fix setuid/setgid, add printing, fixed bugs
         ],
       'Platform'      => ['linux'],
       'SessionTypes'  => ['shell', 'meterpreter']
@@ -45,20 +46,28 @@ class MetasploitModule < Msf::Post
     print_good("\t#{distro[:kernel]}")
 
     users = execute("/bin/cat /etc/passwd | cut -d : -f 1")
+    vprint_good("User accounts:")
+    vprint_good("\n#{users}\n")
     user = execute("/usr/bin/whoami")
-
-    print_good("\tModule running as \"#{user}\" user")
-
     installed_pkg = get_packages(distro[:distro])
+    vprint_good("Installed Packages:")
+    vprint_good("\n#{installed_pkg}\n")
     installed_svc = get_services(distro[:distro])
-
+    vprint_good("Running Services:")
+    vprint_good("\n#{installed_svc}\n")
     mount = execute("/bin/mount -l")
     crons = get_crons(users, user)
+    vprint_good("Cronjobs:")
+    vprint_good("\n#{crons}\n")
     diskspace = execute("/bin/df -ahT")
     disks = (mount + "\n\n" + diskspace)
+    vprint_good("Disk Info:")
+    vprint_good("\n#{disks}\n")
     logfiles = execute("find /var/log -type f -perm -4 2> /dev/null")
-    uidgid = execute("find / -xdev -type f -perm +6000 -perm -1 2> /dev/null")
-
+    vprint_good("Log Files:")
+    vprint_good("\n#{logfiles}\n")
+    uidgid = get_suid_files()
+    capabilities = get_capabilities()
     save("Linux version", distro)
     save("User accounts", users)
     save("Installed Packages", installed_pkg)
@@ -67,12 +76,16 @@ class MetasploitModule < Msf::Post
     save("Disk info", disks)
     save("Logfiles", logfiles)
     save("Setuid/setgid files", uidgid)
+    save("Capabilities", capabilities)
+
   end
 
   def save(msg, data, ctype = 'text/plain')
-    ltype = "linux.enum.system"
-    loot = store_loot(ltype, ctype, session, data, nil, msg)
-    print_status("#{msg} stored in #{loot}")
+    unless data.empty?
+      ltype = "linux.enum.system"
+      loot = store_loot(ltype, ctype, session, data, nil, msg)
+      print_status("#{msg} stored in #{loot}")
+    end
   end
 
   def execute(cmd)
@@ -95,7 +108,7 @@ class MetasploitModule < Msf::Post
     when /arch/
       packages_installed = execute("/usr/bin/pacman -Q")
     else
-      print_error("Could not determine package manager to get list of installed packages")
+      vprint_error("Could not determine package manager to get list of installed packages")
     end
     packages_installed
   end
@@ -117,12 +130,13 @@ class MetasploitModule < Msf::Post
     when /arch/
       services_installed = execute("/bin/egrep '^DAEMONS' /etc/rc.conf")
     else
-      print_error("Could not determine the Linux Distribution to get list of configured services")
+      vprint_error("Could not determine the Linux Distribution to get list of configured services")
     end
     services_installed
   end
 
   def get_crons(users, user)
+    cron_data = ""
     if user == "root" && users
       users = users.chomp.split
       users.each do |u|
@@ -130,8 +144,11 @@ class MetasploitModule < Msf::Post
           vprint_status("Enumerating as root")
           cron_data = ""
           users.each do |usr|
-            cron_data << "*****Listing cron jobs for #{usr}*****\n"
-            cron_data << execute("crontab -u #{usr} -l") + "\n\n"
+            cron = execute("crontab -u #{usr} -l 2>/dev/null")
+            unless cron.empty?
+              cron_data << "*****Listing cron jobs for #{usr}*****\n"
+              cron_data << cron + "\n\n"
+            end
           end
         end
       end
@@ -140,8 +157,89 @@ class MetasploitModule < Msf::Post
       cron_data = "***** Listing cron jobs for #{user} *****\n\n"
       cron_data << execute("crontab -l")
 
-      # Save cron data to loot
-      cron_data
     end
+    cron_data
+  end
+
+  def get_suid_files()
+    suid_data = ""
+    suid = execute("find / -perm -4000 -type f -exec ls -la {} 2>/dev/null \;")
+    if suid.empty?
+      vprint_error("Could not find any SUID files")
+    else
+      suid_data << "*****Setuid files*****"
+      suid_data << suid
+      vprint_good("Setuid files:")
+      vprint_good("\n#{suid}\n")
+    end
+    sgid = execute("find / -perm -2000 -type f -exec ls -la {} 2>/dev/null \;")
+    if sgid.empty?
+      vprint_error("Could not find any SGID files")
+    else
+      suid_data << "*****Setgid files*****"
+      suid_data << sgid
+      vprint_good("Setgid files:")
+      vprint_good("\n#{sgid}\n")
+    end
+    wwsuid = execute("find / -perm -4002 -type f -exec ls -la {} 2>/dev/null \;")
+    if wwsuid.empty?
+      vprint_error("Could not find any world writable SUID files")
+    else
+      suid_data << "*****World writable SUID files*****"
+      suid_data << wwsuid
+      vprint_good("World writable SUID files:")
+      vprint_good("\n#{wwsuid}\n")
+    end
+    wwsuidrt = execute("find / -uid 0 -perm -4002 -type f -exec ls -la {} 2>/dev/null \;")
+    if wwsuidrt.empty?
+      vprint_error("Could not find any world writable SUID files owned by root")
+    else
+      suid_data << "*****World writable SUID files owned by root*****"
+      suid_data << wwsuidrt
+      vprint_good("World writable SUID files owned by root:")
+      vprint_good("\n#{wwsuidrt}\n")
+    end
+    wwsgid = execute("find / -perm -2002 -type f -exec ls -la {} 2>/dev/null \;")
+    if wwsgid.empty?
+      vprint_error("Could not find any world writable SGID files")
+    else
+      suid_data << "*****World writable SGID files*****"
+      suid_data << wwsgid
+      vprint_good("World writable SGID files")
+      vprint_good("\n#{wwsgid}\n")
+    end
+    wwsgidrt = execute("find / -uid 0 -perm -2002 -type f -exec ls -la {} 2>/dev/null \;")
+    if wwsgidrt.empty?
+      vprint_error("Could not find any world writable SGID files owned by root")
+    else
+      suid_data << "*****World writable SGID files owned by root*****"
+      suid_data << wwsgidrt
+      vprint_good("World writable SGID files owned by root:")
+      vprint_good("\n#{wwsgidrt}\n")
+    end
+    suid_data
+  end
+
+  def get_capabilities()
+    capabilities = ""
+    filecaps = execute("getcap -r / 2>/dev/null || /sbin/getcap -r / 2>/dev/null")
+    if filecaps.empty?
+      vprint_error("Could not find any files with POSIX capabilities")
+    else
+      capabilities << "*****Files with POSIX capabilities*****"
+      capabilities << filecaps
+      vprint_good("Files with POSIX capabilities:")
+      vprint_good("\n#{filecaps}\n")
+    end
+    usercaps = execute("grep -v '^#\|none\|^$' /etc/security/capability.conf 2>/dev/null")
+    if usercaps.empty?
+      vprint_error("Could not find any user capabilities")
+    else
+      capabilities << "*****User capabilities*****"
+      capabilities << usercaps
+      vprint_good("User capabilities:")
+      vprint_good("\n#{usercaps}\n")
+    end
+    capabilities
   end
 end


### PR DESCRIPTION
Bugs Fixed:
* Setuid/setgid check didn't work, no results returned. Due to this error `find: invalid mode '+6000'`
* Crontab didn't work if ran as root user, it didn't have a return value, so it just returned an array of users.

Enhancements:
* Prints results in verbose mode.
* Add more setuid/setgid checks eg for world writable files.
* Do not write empty files to loot.
* Add capabilities check.

Also initially created gather functions for sudoers and lastlog, but since found these already exist in other modules so have removed them.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/multi/handler`
- [ ] Start meterpreter shell
- [ ] Run `post/linux/gather/enum_system`
- [ ] Verify results printed in verbose mode
- [ ] Verify all checks work.
