### PR TITLE
Fix incorrect check status for aux modules returned by search

### DIFF
--- a/lib/msf/core/modules/metadata/obj.rb
+++ b/lib/msf/core/modules/metadata/obj.rb
@@ -101,7 +101,7 @@ class Obj
     end
 
     # Store whether a module has a check method
-    @check = module_instance.respond_to?(:check) ? true : false
+    @check = (module_instance.class.instance_methods(false) & %i[check check_host]).any?
 
     @notes = module_instance.notes
 


### PR DESCRIPTION
Fixes #12660  

A lot of auxiliary modules incorrectly report that they support the check method due to their dependency on the 'Scanner' module and it also using a 'check' method. These change look for `check` and `check_host` in the instance methods of any newly created module, fixing the above incorrect behaviour.

## Verification

List the steps needed to make sure this thing works

- [ ] checkout `master`
- [ ] Start `msfconsole`
- [ ] `search type:auxiliary`
- [ ] Item 1082 (SIP Invite Spoof) supports check according to `search` 
- [ ] `use 1082`
- [ ] `check`
- [ ] `This module does not support check.` should be displayed
- [ ] `exit`
---
- [ ] checkout my branch
- [ ] comment out line 58 of the `cache.rb` --> `next if unchanged_reference_name_set.include? mn`. This causes every module to be reloaded when the `reload_all` command is used, otherwise MSF will not detect any changes and skip every module. 
- [ ] `reload_all`
- [ ] `search type:auxiliary`
- [ ] Item 1082 (SIP Invite Spoof) no longer supports check according to `search`