### PR TITLE
Payload fixes (UUID and compiled payload tempfile handling)

### DIFF
--- a/lib/metasploit/framework/compiler/mingw.rb
+++ b/lib/metasploit/framework/compiler/mingw.rb
@@ -19,18 +19,19 @@ module Metasploit
         end
 
         def build_cmd(src)
+          src_file = "#{self.file_name}.c"
+          exe_file = "#{self.file_name}.exe"
+
           cmd = ''
           link_options = '-Wl,'
 
-          src_file = File.basename(self.file_name, '.exe')
-          path = "#{src_file}.c"
-          File.write(path, src)
+          File.write(src_file, src)
 
           opt_level = [ 'Os', 'O0', 'O1', 'O2', 'O3', 'Og' ].include?(self.opt_lvl) ? "-#{self.opt_lvl} " : "-O2 "
 
           cmd << "#{self.mingw_bin} "
-          cmd << "#{path} -I #{INCLUDE_DIR} "
-          cmd << "-o #{self.file_name} "
+          cmd << "#{src_file} -I #{INCLUDE_DIR} "
+          cmd << "-o #{exe_file} "
 
           # gives each function its own section
           # allowing them to be reordered
@@ -50,9 +51,8 @@ module Metasploit
         end
 
         def cleanup_files
-          file_base = File.basename(self.file_name, '.exe')
-          src_file = "#{file_base}.c"
-          exe_file = "#{file_base}.exe"
+          src_file = "#{self.file_name}.c"
+          exe_file = "#{self.file_name}.exe"
 
           unless self.keep_src
             File.delete(src_file) if File.exist?(src_file)

--- a/lib/metasploit/framework/compiler/mingw.rb
+++ b/lib/metasploit/framework/compiler/mingw.rb
@@ -8,8 +8,8 @@ module Metasploit
         MINGW_X86 = 'i686-w64-mingw32-gcc'
         MINGW_X64 = 'x86_64-w64-mingw32-gcc'
 
-        INCLUDE_DIR = File.join(Msf::Config.install_root, 'data', 'headers', 'windows', 'c_payload_util')
-        UTILITY_DIR = File.join(Msf::Config.install_root, 'data', 'utilities', 'encrypted_payload')
+        INCLUDE_DIR = File.join(Msf::Config.data_directory, 'headers', 'windows', 'c_payload_util')
+        UTILITY_DIR = File.join(Msf::Config.data_directory, 'utilities', 'encrypted_payload')
 
         def compile_c(src)
           cmd = build_cmd(src)
@@ -23,14 +23,14 @@ module Metasploit
           link_options = '-Wl,'
 
           src_file = File.basename(self.file_name, '.exe')
-          path = File.join(Msf::Config.install_root, "#{src_file}.c")
+          path = "#{src_file}.c"
           File.write(path, src)
 
           opt_level = [ 'Os', 'O0', 'O1', 'O2', 'O3', 'Og' ].include?(self.opt_lvl) ? "-#{self.opt_lvl} " : "-O2 "
 
           cmd << "#{self.mingw_bin} "
           cmd << "#{path} -I #{INCLUDE_DIR} "
-          cmd << "-o #{Msf::Config.install_root}/#{self.file_name} "
+          cmd << "-o #{self.file_name} "
 
           # gives each function its own section
           # allowing them to be reordered
@@ -53,14 +53,13 @@ module Metasploit
           file_base = File.basename(self.file_name, '.exe')
           src_file = "#{file_base}.c"
           exe_file = "#{file_base}.exe"
-          file_path = Msf::Config.install_root
 
           unless self.keep_src
-            File.delete("#{file_path}/#{src_file}") if File.exist?("#{file_path}/#{src_file}")
+            File.delete(src_file) if File.exist?(src_file)
           end
 
           unless self.keep_exe
-            File.delete("#{file_path}/#{exe_file}") if File.exist?("#{file_path}/#{exe_file}")
+            File.delete(exe_file) if File.exist?(exe_file)
           end
         rescue Errno::ENOENT
           print_error("Failed to delete file")

--- a/lib/msf/core/payload/stager.rb
+++ b/lib/msf/core/payload/stager.rb
@@ -160,9 +160,9 @@ module Msf::Payload::Stager
     false
   end
 
-  def format_uuid(uuid)
+  def format_uuid(uuid_raw)
     if sends_hex_uuid?
-      return uuid
+      return uuid_raw
     end
 
     return Msf::Payload::UUID.new({raw: uuid_raw})

--- a/lib/msf/core/payload/windows/encrypted_payload_opts.rb
+++ b/lib/msf/core/payload/windows/encrypted_payload_opts.rb
@@ -21,8 +21,8 @@ module Msf
       [
         OptBool.new('StripSymbols', [ false, 'Payload will be compiled without symbols', true ]),
         OptEnum.new('OptLevel', [ false, 'The optimization level to compile with', 'O2', [ 'Og', 'Os', 'O0', 'O1', 'O2', 'O3' ] ]),
-        OptBool.new('KeepSrc', [ false, 'Keep source code after compiling it', true ]),
-        OptBool.new('KeepExe', [ false, 'Keep executable after compiling the payload', true ]),
+        OptBool.new('KeepSrc', [ false, 'Keep source code after compiling it', false ]),
+        OptBool.new('KeepExe', [ false, 'Keep executable after compiling the payload', false ]),
         OptBool.new('PayloadUUIDTracking', [ true, 'Whether or not to automatically register generated UUIDs', true ])
       ], self.class)
     end

--- a/lib/msf/core/payload/windows/encrypted_payload_opts.rb
+++ b/lib/msf/core/payload/windows/encrypted_payload_opts.rb
@@ -5,7 +5,7 @@ module Msf
   module Payload::Windows::EncryptedPayloadOpts
     include Msf::Payload::UUID::Options
 
-    LINK_SCRIPT_PATH = File.join(Msf::Config.install_root, 'data', 'utilities', 'encrypted_payload')
+    LINK_SCRIPT_PATH = File.join(Msf::Config.data_directory, 'utilities', 'encrypted_payload')
 
     def initialize(info={})
       super

--- a/lib/msf/core/payload/windows/encrypted_reverse_tcp.rb
+++ b/lib/msf/core/payload/windows/encrypted_reverse_tcp.rb
@@ -59,7 +59,7 @@ module Payload::Windows::EncryptedReverseTcp
       opt_lvl:       datastore['OptLevel'],
       keep_src:      datastore['KeepSrc'],
       keep_exe:      datastore['KeepExe'],
-      f_name:        Tempfile.new(staged? ? 'reverse_pic_stager.exe' : 'reverse_pic_stageless.exe').path,
+      f_name:        Tempfile.new(staged? ? 'reverse_pic_stager' : 'reverse_pic_stageless').path,
       arch:          self.arch_to_s
     }
 
@@ -130,7 +130,7 @@ module Payload::Windows::EncryptedReverseTcp
       linker_script: link_script,
       keep_src:      datastore['KeepSrc'],
       keep_exe:      datastore['KeepExe'],
-      f_name:        Tempfile.new('reverse_pic_stage.exe').path,
+      f_name:        Tempfile.new('reverse_pic_stage').path,
       arch:          self.arch_to_s
     }
 
@@ -180,8 +180,8 @@ module Payload::Windows::EncryptedReverseTcp
       raise Metasploit::Framework::Compiler::Mingw::UncompilablePayloadError.new('Payload did not compile. Check the logs for further information.')
     end
 
-    comp_file = opts[:f_name]
-    raise Metasploit::Framework::Compiler::Mingw::CompiledPayloadNotFoundError unless File.exist?(opts[:f_name])
+    comp_file = "#{opts[:f_name]}.exe"
+    raise Metasploit::Framework::Compiler::Mingw::CompiledPayloadNotFoundError unless File.exist?(comp_file)
     bin = File.binread(comp_file)
     bin = Rex::PeParsey::Pe.new(Rex::ImageSource::Memory.new(bin))
 

--- a/lib/msf/core/payload/windows/encrypted_reverse_tcp.rb
+++ b/lib/msf/core/payload/windows/encrypted_reverse_tcp.rb
@@ -59,7 +59,7 @@ module Payload::Windows::EncryptedReverseTcp
       opt_lvl:       datastore['OptLevel'],
       keep_src:      datastore['KeepSrc'],
       keep_exe:      datastore['KeepExe'],
-      f_name:        (staged? ? 'reverse_pic_stager.exe' : 'reverse_pic_stageless.exe'),
+      f_name:        Tempfile.new(staged? ? 'reverse_pic_stager.exe' : 'reverse_pic_stageless.exe').path,
       arch:          self.arch_to_s
     }
 
@@ -130,7 +130,7 @@ module Payload::Windows::EncryptedReverseTcp
       linker_script: link_script,
       keep_src:      datastore['KeepSrc'],
       keep_exe:      datastore['KeepExe'],
-      f_name:        'reverse_pic_stage.exe',
+      f_name:        Tempfile.new('reverse_pic_stage.exe').path,
       arch:          self.arch_to_s
     }
 
@@ -180,9 +180,9 @@ module Payload::Windows::EncryptedReverseTcp
       raise Metasploit::Framework::Compiler::Mingw::UncompilablePayloadError.new('Payload did not compile. Check the logs for further information.')
     end
 
-    comp_file = "#{Msf::Config.install_root}/#{opts[:f_name]}"
-    raise Metasploit::Framework::Compiler::Mingw::CompiledPayloadNotFoundError unless File.exist?("#{Msf::Config.install_root}/#{opts[:f_name]}")
-    bin = read_exe(comp_file)
+    comp_file = opts[:f_name]
+    raise Metasploit::Framework::Compiler::Mingw::CompiledPayloadNotFoundError unless File.exist?(opts[:f_name])
+    bin = File.binread(comp_file)
     bin = Rex::PeParsey::Pe.new(Rex::ImageSource::Memory.new(bin))
 
     text_section = bin.sections.first
@@ -190,12 +190,6 @@ module Payload::Windows::EncryptedReverseTcp
 
     comp_obj.cleanup_files
     text_section.rawdata
-  end
-
-  def read_exe(file)
-    bin = IO.binread(file)
-
-    bin.strip
   end
 
   #

--- a/modules/payloads/singles/windows/encrypted_shell_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/encrypted_shell_reverse_tcp.rb
@@ -11,7 +11,7 @@ require 'msf/core/payload/windows/encrypted_payload_opts'
 
 module MetasploitModule
 
-  CachedSize = 4608
+  CachedSize = 5120
 
   include Msf::Payload::Windows
   include Msf::Payload::Single

--- a/modules/payloads/singles/windows/encrypted_shell_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/encrypted_shell_reverse_tcp.rb
@@ -11,6 +11,8 @@ require 'msf/core/payload/windows/encrypted_payload_opts'
 
 module MetasploitModule
 
+  CachedSize = 4608
+
   include Msf::Payload::Windows
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/windows/x64/encrypted_shell_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/x64/encrypted_shell_reverse_tcp.rb
@@ -10,6 +10,8 @@ require 'msf/core/payload/windows/encrypted_reverse_tcp'
 
 module MetasploitModule
 
+  CachedSize = 4096
+
   include Msf::Payload::Windows
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/windows/x64/encrypted_shell_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/x64/encrypted_shell_reverse_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/core/payload/windows/encrypted_reverse_tcp'
 
 module MetasploitModule
 
-  CachedSize = 4096
+  CachedSize = 4608
 
   include Msf::Payload::Windows
   include Msf::Payload::Single

--- a/modules/payloads/stagers/windows/encrypted_reverse_tcp.rb
+++ b/modules/payloads/stagers/windows/encrypted_reverse_tcp.rb
@@ -8,6 +8,8 @@ require 'msf/core/payload/windows/encrypted_reverse_tcp'
 
 module MetasploitModule
 
+  CachedSize = 3072
+
   include Msf::Payload::Stager
   include Msf::Payload::Windows::EncryptedReverseTcp
   include Msf::Payload::Windows::EncryptedPayloadOpts

--- a/modules/payloads/stagers/windows/encrypted_reverse_tcp.rb
+++ b/modules/payloads/stagers/windows/encrypted_reverse_tcp.rb
@@ -8,7 +8,7 @@ require 'msf/core/payload/windows/encrypted_reverse_tcp'
 
 module MetasploitModule
 
-  CachedSize = 3072
+  CachedSize = 3584
 
   include Msf::Payload::Stager
   include Msf::Payload::Windows::EncryptedReverseTcp

--- a/modules/payloads/stagers/windows/x64/encrypted_reverse_tcp.rb
+++ b/modules/payloads/stagers/windows/x64/encrypted_reverse_tcp.rb
@@ -8,6 +8,8 @@ require 'msf/core/payload/windows/encrypted_reverse_tcp'
 
 module MetasploitModule
 
+  CachedSize = 3072
+
   include Msf::Payload::Stager
   include Msf::Payload::Windows::EncryptedReverseTcp
   include Msf::Payload::Windows::EncryptedPayloadOpts


### PR DESCRIPTION
This fixes #12691 and a few other things.

For the above bug, the non-hex_uuid case was using the wrong variable name, silently failing to parse the incoming UUID for other reverse_tcp payloads.

This also modifies the build process to build intermediate file paths with Tempfile, allowing both concurrent access, and for the feature to work if the user does not have write access to the install directory. It also changes a number of paths to prefer data_directory over other constructed paths.

Finally this adds cached payload sizes to prevent these payload modules from running on every `msfconsole` boot

## Verification

Verify that all reverse_tcp UUID payloads work, e.g:
- [ ] `./msfconsole -qx 'use multi/handler; set payload windows/meterpreter/reverse_tcp_uuid; set lhost 127.0.0.1; run'`
- [ ] `./msfvenom -p windows/meterpreter/reverse_tcp_uuid -f exe -o test.exe LHOST=127.0.0.1`
- [ ] `wine ./test.exe`

- [ ] Verify that compiled payloads work
- [ ] Verify that there are no intermediate temp files left in the install directory or in /tmp, etc.