### PR TITLE
reduce workload for incremental Digits in JtR

### DIFF
--- a/data/jtr/john.conf
+++ b/data/jtr/john.conf
@@ -1198,7 +1198,7 @@ CharCount = 26
 [Incremental:Digits]
 File = $JOHN/digits.chr
 MinLen = 1
-MaxLen = 20
+MaxLen = 8
 CharCount = 10
 
 # Some pre-defined word filters as used to generate the supplied .chr files


### PR DESCRIPTION
when cracking creds with incremental mode 8 digits is a reasonable start
if the user would like a more extensive processing it can be provided as
an environment specific option.


## Verification

List the steps needed to make sure this thing works

- [ ] **Verify** cracking modules still work as expected for less complexity in Digit based cracking

