### PR TITLE
clone options & return login object not core

### DIFF
--- a/lib/metasploit/framework/data_service/proxy/credential_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/credential_data_proxy.rb
@@ -13,6 +13,7 @@ module CredentialDataProxy
   def create_cracked_credential(opts)
     begin
       self.data_service_operation do |data_service|
+        opts = opts.clone
         opts[:workspace_id] = workspace.id
         opts[:private_data] = opts.delete(:password)
         opts[:private_type] = :password
@@ -36,10 +37,11 @@ module CredentialDataProxy
   def create_credential_and_login(opts)
     begin
       self.data_service_operation do |data_service|
+        opts = opts.clone
         core = data_service.create_credential(opts)
         opts[:core] = core
         login = data_service.create_credential_login(opts)
-        core
+        login
       end
     rescue => e
       self.log_error(e, "Problem creating credential and login")

--- a/lib/metasploit/framework/data_service/proxy/credential_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/credential_data_proxy.rb
@@ -40,8 +40,7 @@ module CredentialDataProxy
         opts = opts.clone
         core = data_service.create_credential(opts)
         opts[:core] = core
-        login = data_service.create_credential_login(opts)
-        login
+        data_service.create_credential_login(opts)
       end
     rescue => e
       self.log_error(e, "Problem creating credential and login")


### PR DESCRIPTION
`create_credential_and_login` should return a `login` object.  This addresses a mismatch between the proxy implementation and the metasploit-credential gem API.

Additional change helps mitigate possible side-effects from changing the passed in `opts` map at the proxy later.  A more comprehensive PR for side-effects is in the works.

## Verification

List the steps needed to make sure this thing works

- [x] See samples in `documentation/modules/auxiliary/analyze/crack_*.md` 
- [x] **Verify** cracked credentials based on various formats store and retrieve correctly.

