### PR TITLE
Automated development setup with Gitpod

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,16 @@
+FROM gitpod/workspace-full
+
+USER gitpod
+
+RUN sudo apt-get -q update && \
+    sudo apt-get  -y install autoconf build-essential libpcap-dev libpq-dev zlib1g-dev libsqlite3-dev
+    
+
+# Install custom tools, runtime, etc. using apt-get
+# For example, the command below would install "bastet" - a command line tetris clone:
+#
+# RUN sudo apt-get -q update && \
+#     sudo apt-get install -yq bastet && \
+#     sudo rm -rf /var/lib/apt/lists/*
+#
+# More information: https://www.gitpod.io/docs/42_config_docker/

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,14 @@
+image:
+  file: .gitpod.Dockerfile
+
+tasks:
+  - init: sleep 10 &&
+          echo 'Enter Github Username:' && 
+          read -p user && 
+          eval $(gp env -e GITHUB_USERNAME=$user GITHUB_EMAIL=$(git config user.email)) && 
+          git remote add upstream git@github.com:rapid7/metasploit-framework.git && 
+          git fetch upstream && 
+          git checkout -b upstream-master --track upstream/master && 
+          git config --global github.username "$GITHUB_USERNAME"
+  - command: gem install bundler && bundle install
+


### PR DESCRIPTION
This PR is to automate the process of setting up a development environment for contributors. This PR adds two files .gitpod.yml and .gitpod.dockerfile which will automate to setup a workspace on Gitpod which is an online IDE for Github.

![Screenshot from 2019-12-06 10-15-25](https://user-images.githubusercontent.com/6022231/70845622-ed093800-1e76-11ea-818d-dfb7e396d624.png)

You can give the setup a try with my fork https://gitpod.io/#https://github.com/anudeepreddy/metasploit-framework

Please do test the setup and let me know of any improvements that can be done further. We can also enable prebuilds for the workspace so that users need not wait until the workspace is built. If prebuilds are enabled then a container image is built when we commit to the repo. 

Thank you