### PR TITLE
Satisfy ruby packages attempting to write logs in ~/.msf4/logs/*.log when starting as a Docker container

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -20,7 +20,7 @@ else
 
   # check if user id already exists
   if ! grep ":$MSF_UID:" /etc/passwd > /dev/null; then
-    adduser -u $MSF_UID -D $MSF_USER -g $MSF_USER -G $MSF_GROUP $MSF_USER
+    adduser -u $MSF_UID -D -h $APP_HOME -g $MSF_USER -G $MSF_GROUP $MSF_USER
     # add user to metasploit group so it can read the source
     addgroup $MSF_USER $METASPLOIT_GROUP
     su-exec $MSF_USER "$@"


### PR DESCRIPTION
Fix #9819

## Verification

Observed:
```
$ ./docker/bin/msfconsole                                                                                               
Starting metasploit-framework_db_1 ... done                                                                                                                  
Rails Error: Unable to access log file. Please ensure that /home/msf/.msf4/logs/production.log exists and is writable (ie, make it writable for user and grou
p: chmod 0664 /home/msf/.msf4/logs/production.log). The log level has been raised to WARN and the output directed to STDERR until the problem is fixed.      
Traceback (most recent call last):ork console...\                                                                                                            
        12: from ./msfconsole:49:in `<main>'                                                                                                                 
        11: from /usr/src/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'                                                        
        10: from /usr/src/metasploit-framework/lib/metasploit/framework/command/console.rb:48:in `start'                                                     
         9: from /usr/src/metasploit-framework/lib/metasploit/framework/command/console.rb:62:in `driver'                                                    
         8: from /usr/src/metasploit-framework/lib/metasploit/framework/command/console.rb:62:in `new'                                                       
         7: from /usr/src/metasploit-framework/lib/msf/ui/console/driver.rb:82:in `initialize'                                                               
         6: from /usr/src/metasploit-framework/lib/msf/base/simple/framework.rb:74:in `create'                                                               
         5: from /usr/src/metasploit-framework/lib/msf/base/simple/framework.rb:112:in `simplify'                                                            
         4: from /usr/src/metasploit-framework/lib/msf/base/logging.rb:24:in `init'                                                                          
         3: from /usr/src/metasploit-framework/lib/msf/base/logging.rb:24:in `new'                                                                           
         2: from /usr/src/metasploit-framework/lib/rex/logging/sinks/flatfile.rb:21:in `initialize'                                                          
         1: from /usr/src/metasploit-framework/lib/rex/logging/sinks/flatfile.rb:21:in `new'                                                                 
/usr/src/metasploit-framework/lib/rex/logging/sinks/flatfile.rb:21:in `initialize': Permission denied @ rb_sysopen - /home/msf/.msf4/logs/framework.log (Errn
o::EACCES) 
```

Adding `set -x` to docker/entrypoint.sh showed,
```
$ ./docker/bin/msfconsole                                                                                               
Starting metasploit-framework_db_1 ... done                                                                                                                  
+ MSF_USER=msf                                                                                                                                               
+ MSF_GROUP=msf                                                                                                                                              
+ TMP=1000                                                                                                                                                   
+ TMP=1000                                                                                                                                                   
+ '[' 1000 -eq 0 ']'                                                                                                                                         
+ grep :1000: /etc/group                                                                                                                                     
+ addgroup -g 1000 msf                                                                                                                                       
+ grep :1000: /etc/passwd                                                                                                                                    
+ adduser -u 1000 -D msf -g msf -G msf msf                                                                                                                   
+ addgroup msf metasploit                                                                                                                                    
+ su-exec msf ./msfconsole -r docker/msfconsole.rc ''                                                                                                        
Rails Error: Unable to access log file. Please ensure that /home/msf/.msf4/logs/production.log exists and is writable (ie, make it writable for user and grou
p: chmod 0664 /home/msf/.msf4/logs/production.log). The log level has been raised to WARN and the output directed to STDERR until the problem is fixed.      
Traceback (most recent call last):ork console...\                                                                                                            
        12: from ./msfconsole:49:in `<main>'                                                                                                                 
[...]
```

Running the entry point manually showed,
```
$ docker run -it --entrypoint /bin/bash metasploit:dev                                                                  
bash-5.0# ls -la /home                                                                                                                                       
total 8
drwxr-xr-x    2 root     root          4096 Oct 21 13:39 .
drwxr-xr-x   19 root     root          4096 Dec 15 02:37 ..
bash-5.0# grep 1000 /etc/passwd
bash-5.0# grep 1000 /etc/group
bash-5.0# addgroup -g 1000 msf
bash-5.0# grep 1000 /etc/group
msf:x:1000:
bash-5.0# adduser -u 1000 -D msf -g msf -G msf msf
bash-5.0# grep 1000 /etc/passwd
msf:x:1000:1000:msf:/home/msf:/bin/ash
bash-5.0# addgroup msf metasploit
bash-5.0# grep metasploit /etc/group                                                                                                                         
metasploit:x:101:msf                                                                                                                                         
```

Setting the home directory with this change allowed to proceed,
```
$ ./docker/bin/msfconsole                                                                                               
Starting metasploit-framework_db_1 ... done                                                                                                                  
+ MSF_USER=msf                                                                                                                                               
+ MSF_GROUP=msf                                                                                                                                              
+ TMP=1000                                                                                                                                                   
+ TMP=1000                                                                                                                                                   
+ '[' 1000 -eq 0 ']'                                                                                                                                         
+ grep :1000: /etc/group                                                                                                                                     
+ addgroup -g 1000 msf                                                                                                                                       
+ grep :1000: /etc/passwd                                                                                                                                    
+ adduser -u 1000 -D -h /usr/src/metasploit-framework -g msf -G msf msf                                                                                      
+ addgroup msf metasploit
+ su-exec msf ./msfconsole -r docker/msfconsole.rc ''
[-] ***rting the Metasploit Framework console...-
[-] * WARNING: No database support: No database YAML file
[-] ***

               .;lxO0KXXXK0Oxl:.
           ,o0WMMMMMMMMMMMMMMMMMMKd,
[...]
```