### PR TITLE
lock rubygems version for Docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ before_install:
   - ls -la ./.git/hooks
   - ./.git/hooks/post-merge
   # Update the bundler
-  - gem update --system
+  - gem update --system 3.0.6
   - gem install bundler
 before_script:
   - cp config/database.yml.travis config/database.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,8 @@ RUN apk add --no-cache \
       zlib-dev \
       ncurses-dev \
       git \
-    && echo "gem: --no-ri --no-rdoc" > /etc/gemrc \
-    && gem update --system \
+    && echo "gem: --no-document" > /etc/gemrc \
+    && gem update --system 3.0.6 \
     && bundle install --clean --no-cache --system $BUNDLER_ARGS \
     # temp fix for https://github.com/bundler/bundler/issues/6680
     && rm -rf /usr/local/bundle/cache \


### PR DESCRIPTION
Latest rubygems release for 3.1.0 vendors bundler 2.1.0 creating
compatibilty issues.  Lock for now until all relates issues can be
addressed.

## Verification

List the steps needed to make sure this thing works

- [x] Travis Docker build completes successfully.
