### PR TITLE
Add support for arrays to the POST variables option in the REX HTTP client library 

### DIFF
--- a/lib/rex/proto/http/client_request.rb
+++ b/lib/rex/proto/http/client_request.rb
@@ -137,7 +137,7 @@ class ClientRequest
       opts['vars_post'].each_pair do |var,val|
         var = var.to_s
         unless val.is_a?(Array)
-          val = val.split
+          val = [val]
         end
         val.each do |v|
           v = v.to_s

--- a/lib/rex/proto/http/client_request.rb
+++ b/lib/rex/proto/http/client_request.rb
@@ -136,12 +136,16 @@ class ClientRequest
 
       opts['vars_post'].each_pair do |var,val|
         var = var.to_s
-        val = val.to_s
-
-        pstr << '&' if pstr.length > 0
-        pstr << (opts['encode_params'] ? set_encode_uri(var) : var)
-        pstr << '='
-        pstr << (opts['encode_params'] ? set_encode_uri(val) : val)
+        unless val.is_a?(Array)
+          val = val.split
+        end
+        val.each do |v|
+          v = v.to_s
+          pstr << '&' if pstr.length > 0
+          pstr << (opts['encode_params'] ? set_encode_uri(var) : var)
+          pstr << '='
+          pstr << (opts['encode_params'] ? set_encode_uri(v) : v)
+        end
       end
     else
       if opts['encode']


### PR DESCRIPTION
Handle the repeated key query string 
https://github.com/rapid7/metasploit-framework/pull/12704#discussion_r357748834

Especially useful when interacting with frameworks that interpret multiple values for a single key as an array or list. Ex:
```ruby
# Post body: foo[]=bar&foo[]=baz&qux=1
send_request_cgi({
  'method'        => 'POST',
  'uri'           => normalize_uri(target_uri.path),
  'ctype'         => 'application/x-www-form-urlencoded',
  'vars_post'     => {
    'foo[]' => ['bar', 'baz'],
    'qux' => 1
  }
})
```