### PR TITLE
Add smcintyre-r7 to the .mailmap file

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -25,6 +25,7 @@ pdeardorff-r7 <pdeardorff-r7@github>   <Paul_Deardorff@rapid7.com>
 sgonzalez-r7 <sgonzalez-r7@github>     <sgonzalez@rapid7.com>
 sgonzalez-r7 <sgonzalez-r7@github>     <sonny_gonzalez@rapid7.com>
 shuckins-r7 <shuckins-r7@github>       <samuel_huckins@rapid7.com>
+smcintyre-r7 <smcintyre-r7@github>     <spencer_mcintyre@rapid7.com>
 space-r7 <space-r7@github>             <shelby_pace@rapid7.com>
 tdoan-r7 <tdoan-r7@github>             <thao_doan@rapid7.com>
 todb-r7 <todb-r7@github>               <tod_beardsley@rapid7.com>


### PR DESCRIPTION
This pull request adds my new new GitHub account to the `.mailmap` file. :tada: 