### PR TITLE
Refactor CheckScanner to CheckModule to generically support aux modules (redux)

### DIFF
--- a/lib/msf/core/exploit/check_module.rb
+++ b/lib/msf/core/exploit/check_module.rb
@@ -37,6 +37,8 @@ module Exploit::Remote::CheckModule
       return CheckCode::Unsupported("#{check_module} does not define a run method")
     end
 
+    print_status("Using #{check_module} as check")
+
     # Retrieve the module's return value
     checkcode = mod.run_simple(
       'LocalInput'  => user_input,

--- a/lib/msf/core/exploit/check_module.rb
+++ b/lib/msf/core/exploit/check_module.rb
@@ -40,20 +40,28 @@ module Exploit::Remote::CheckModule
     print_status("Using #{check_module} as check")
 
     # Retrieve the module's return value
-    checkcode = mod.run_simple(
+    res = mod.run_simple(
       'LocalInput'  => user_input,
       'LocalOutput' => user_output,
       'Options'     => datastore.to_h.slice('RHOSTS', 'RHOST', 'RPORT')
     )
 
     # Ensure return value is a CheckCode
-    case checkcode
+    case res
     when Exploit::CheckCode
       # Return the CheckCode
-      checkcode
+      res
     when Hash
-      # XXX: Return CheckCode associated with RHOST, which is set automatically
-      checkcode[datastore['RHOST']]
+      # XXX: Find CheckCode associated with RHOST, which is set automatically
+      checkcode = res[datastore['RHOST']]
+
+      # Bail if module doesn't return a CheckCode
+      unless checkcode.kind_of?(Exploit::CheckCode)
+        return Exploit::CheckCode::Unsupported("#{check_module} does not return a CheckCode")
+      end
+
+      # Return the CheckCode
+      checkcode
     else
       # Bail if module doesn't return a CheckCode
       Exploit::CheckCode::Unsupported("#{check_module} does not return a CheckCode")

--- a/lib/msf/core/exploit/check_module.rb
+++ b/lib/msf/core/exploit/check_module.rb
@@ -3,8 +3,6 @@
 #
 # This mixin implements an exploit's check method by invoking an aux module
 #
-# NOTE: The module's run_host/run method MUST return an Msf::Exploit::CheckCode
-#
 
 module Msf
 module Exploit::Remote::CheckModule
@@ -29,45 +27,35 @@ module Exploit::Remote::CheckModule
       return CheckCode::Unsupported("Could not instantiate #{check_module}")
     end
 
-    # Bail if run_host/run isn't defined
-    if mod.respond_to?(:run_host)
-      meth = :run_host
-    elsif mod.respond_to?(:run)
-      meth = :run
+    # Bail if it isn't aux
+    if mod.type != Msf::MODULE_AUX
+      return CheckCode::Unsupported("#{check_module} is not an auxiliary module")
+    end
+
+    # Bail if run isn't defined
+    unless mod.respond_to?(:run)
+      return CheckCode::Unsupported("#{check_module} does not define a run method")
+    end
+
+    # Retrieve the module's return value
+    checkcode = mod.run_simple(
+      'LocalInput'  => user_input,
+      'LocalOutput' => user_output,
+      'Options'     => datastore.to_h.slice('RHOSTS', 'RHOST', 'RPORT')
+    )
+
+    # Ensure return value is a CheckCode
+    case checkcode
+    when Exploit::CheckCode
+      # Return the CheckCode
+      checkcode
+    when Hash
+      # XXX: Return scanner's last CheckCode
+      checkcode.values.last
     else
-      return CheckCode::Unsupported("#{check_module} does not define a run_host/run method")
+      # Bail if module doesn't return a CheckCode
+      Exploit::CheckCode::Unsupported("#{check_module} does not return a CheckCode")
     end
-
-    # Add the exploit's targeting options to the module's datastore
-    %w[RHOSTS RHOST RPORT].each do |opt|
-      next unless datastore[opt]
-
-      mod.datastore[opt] = datastore[opt].dup
-    end
-
-    # Bail if module options don't validate
-    mod.options.validate(mod.datastore)
-
-    # Use the exploit's input and output as the module's
-    mod.user_input, mod.user_output = user_input, user_output
-
-    # Use the module's CheckCode
-    checkcode =
-      case meth
-      when :run_host
-        mod.run_host(rhost)
-      when :run
-        mod.run
-      end
-
-    # Bail if module doesn't return a CheckCode
-    unless checkcode.kind_of?(Exploit::CheckCode)
-      print_warning("#{check_module} does not return a CheckCode")
-      return Exploit::CheckCode::Unsupported
-    end
-
-    # Return the CheckCode
-    checkcode
   end
 
   def check_module

--- a/lib/msf/core/exploit/check_module.rb
+++ b/lib/msf/core/exploit/check_module.rb
@@ -52,8 +52,8 @@ module Exploit::Remote::CheckModule
       # Return the CheckCode
       checkcode
     when Hash
-      # XXX: Return scanner's last CheckCode
-      checkcode.values.last
+      # XXX: Return CheckCode associated with RHOST, which is set automatically
+      checkcode[datastore['RHOST']]
     else
       # Bail if module doesn't return a CheckCode
       Exploit::CheckCode::Unsupported("#{check_module} does not return a CheckCode")


### PR DESCRIPTION
This is a continuation of #12517. ~Please integrate and land with #12702 if at all possible.~ Done.

```
msf5 exploit(windows/smb/ms17_010_eternalblue) > check

[*] 192.168.56.126:445 - Using auxiliary/scanner/smb/smb_ms17_010 as check
[*] 192.168.56.126:445    - Connected to \\192.168.56.126\IPC$ with TID = 2048
[*] 192.168.56.126:445    - Received STATUS_INSUFF_SERVER_RESOURCES with FID = 0
[+] 192.168.56.126:445    - Host is likely VULNERABLE to MS17-010! - Windows 7 Professional 7601 Service Pack 1 x86 (32-bit)
[*] 192.168.56.126:445    - Scanned 1 of 1 hosts (100% complete)
[+] 192.168.56.126:445 - The target is vulnerable.
[*] 192.168.56.127:445 - Using auxiliary/scanner/smb/smb_ms17_010 as check
[*] 192.168.56.127:445    - Connected to \\192.168.56.127\IPC$ with TID = 2048
[*] 192.168.56.127:445    - Received STATUS_INSUFF_SERVER_RESOURCES with FID = 0
[+] 192.168.56.127:445    - Host is likely VULNERABLE to MS17-010! - Windows 7 Professional 7601 Service Pack 1 x64 (64-bit)
[*] 192.168.56.127:445    - Scanned 1 of 1 hosts (100% complete)
[+] 192.168.56.127:445 - The target is vulnerable.
msf5 exploit(windows/smb/ms17_010_eternalblue) >
```

```
[1] pry(#<Msf::Modules::Exploit__Windows__Smb__Ms17_010_eternalblue::MetasploitModule>)> has_check?
=> true
[2] pry(#<Msf::Modules::Exploit__Windows__Smb__Ms17_010_eternalblue::MetasploitModule>)> method(:check).source_location
=> ["/rapid7/metasploit-framework/lib/msf/core/exploit/check_module.rb", 21]
[3] pry(#<Msf::Modules::Exploit__Windows__Smb__Ms17_010_eternalblue::MetasploitModule>)>
```

Eventually, this will evolve to be more generic code for things like #12729, with the end goal being to support some sort of module chaining.