### PR TITLE
support Mdm::Module::Ref object when linking vulns

### DIFF
--- a/lib/msf/core/db_manager/vuln.rb
+++ b/lib/msf/core/db_manager/vuln.rb
@@ -109,7 +109,7 @@ module Msf::DBManager::Vuln
         elsif (r.is_a?(Hash) and r[:ctx_id] and r[:ctx_val])
           str = "#{r[:ctx_id]}-#{r[:ctx_val]}"
         end
-        rids << find_or_create_ref(:name => str)
+        rids << find_or_create_ref(:name => str) unless str.nil?
       end
     end
 

--- a/lib/msf/core/db_manager/vuln.rb
+++ b/lib/msf/core/db_manager/vuln.rb
@@ -102,12 +102,14 @@ module Msf::DBManager::Vuln
     if opts[:refs]
       rids ||= []
       opts[:refs].each do |r|
-        if (r.respond_to?(:ctx_id)) and (r.respond_to?(:ctx_val))
-          r = "#{r.ctx_id}-#{r.ctx_val}"
+        if r.instance_of?(Mdm::Module::Ref)
+          str = r.name
+        elsif (r.respond_to?(:ctx_id)) and (r.respond_to?(:ctx_val))
+          str = "#{r.ctx_id}-#{r.ctx_val}"
         elsif (r.is_a?(Hash) and r[:ctx_id] and r[:ctx_val])
-          r = "#{r[:ctx_id]}-#{r[:ctx_val]}"
+          str = "#{r[:ctx_id]}-#{r[:ctx_val]}"
         end
-        rids << find_or_create_ref(:name => r)
+        rids << find_or_create_ref(:name => str)
       end
     end
 


### PR DESCRIPTION
In some legacy cases a database cache can result in a session reporting vulns with support for an `Mdm::Module::Ref` object.  Due to serialization processes in these cases the string representation of `name` from the object needs to be passed to `find_or_create_ref`.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Load a database module set
```
irb
modules.refresh_cache_from_module_files
sleep(5)
db.update_all_module_details
exit
```
- [x] `use exploit/windows/smb/ms08_067_netapi` to generate a session
- [x] **Verify** the refs table contains valid reference names not numbers

