### PR TITLE
Remove method call side-effects

### DIFF
--- a/lib/msf/core/db_manager/cred.rb
+++ b/lib/msf/core/db_manager/cred.rb
@@ -9,7 +9,7 @@ module Msf::DBManager::Cred
       end
 
       wspace = Msf::Util::DBManager.process_opts_workspace(opts, framework)
-      search_term = opts.delete(:search_term)
+      search_term = opts[:search_term]
 
       query = Metasploit::Credential::Core.where( workspace_id: wspace.id )
       query = query.includes(:private, :public, :logins, :realm).references(:private, :public, :logins, :realm)
@@ -108,16 +108,16 @@ module Msf::DBManager::Cred
     end
 
   ::ActiveRecord::Base.connection_pool.with_connection {
-    host = opts.delete(:host)
-    ptype = opts.delete(:type) || "password"
-    token = [opts.delete(:user), opts.delete(:pass)]
-    sname = opts.delete(:sname)
-    port = opts.delete(:port)
-    proto = opts.delete(:proto) || "tcp"
-    proof = opts.delete(:proof)
-    source_id = opts.delete(:source_id)
-    source_type = opts.delete(:source_type)
-    duplicate_ok = opts.delete(:duplicate_ok)
+    host = opts[:host]
+    ptype = opts[:type] || "password"
+    token = [opts[:user], opts[:pass]]
+    sname = opts[:sname]
+    port = opts[:port]
+    proto = opts[:proto] || "tcp"
+    proof = opts[:proof]
+    source_id = opts[:source_id]
+    source_type = opts[:source_type]
+    duplicate_ok = opts[:duplicate_ok]
     # Nil is true for active.
     active = (opts[:active] || opts[:active].nil?) ? true : false
 
@@ -125,7 +125,7 @@ module Msf::DBManager::Cred
 
     # Service management; assume the user knows what
     # he's talking about.
-    service = opts.delete(:service) || report_service(:host => host, :port => port, :proto => proto, :name => sname, :workspace => wspace)
+    service = opts[:service] || report_service(:host => host, :port => port, :proto => proto, :name => sname, :workspace => wspace)
 
     # Non-US-ASCII usernames are tripping up the database at the moment, this is a temporary fix until we update the tables
     if (token[0])
@@ -226,6 +226,8 @@ module Msf::DBManager::Cred
     ::ActiveRecord::Base.connection_pool.with_connection {
       # process workspace string for update if included in opts
       wspace = Msf::Util::DBManager.process_opts_workspace(opts, framework, false)
+      opts = opts.clone()
+      opts.delete(:workspace)
       opts[:workspace] = wspace if wspace
 
       if opts[:public]

--- a/lib/msf/core/db_manager/event.rb
+++ b/lib/msf/core/db_manager/event.rb
@@ -27,6 +27,8 @@ module Msf::DBManager::Event
     end
 
     wspace = Msf::Util::DBManager.process_opts_workspace(opts, framework)
+    opts = opts.clone()
+    opts.delete(:workspace)
 
     order = opts.delete(:order)
     order = order.nil? ? DEFAULT_ORDER : order.to_sym
@@ -52,6 +54,9 @@ module Msf::DBManager::Event
   ::ActiveRecord::Base.connection_pool.with_connection {
     wspace = Msf::Util::DBManager.process_opts_workspace(opts, framework)
     return if not wspace # Temp fix?
+
+    opts = opts.clone()
+    opts.delete(:workspace)
     uname  = opts.delete(:username)
 
     if !opts[:host].nil? && !opts[:host].kind_of?(::Mdm::Host)

--- a/lib/msf/core/db_manager/exploit_attempt.rb
+++ b/lib/msf/core/db_manager/exploit_attempt.rb
@@ -59,7 +59,6 @@ module Msf::DBManager::ExploitAttempt
     return if not host
 
     opts = opts.clone()
-    opts.delete(:workspace)
     opts[:service] = svc
     opts[:host] = host
 

--- a/lib/msf/core/db_manager/exploit_attempt.rb
+++ b/lib/msf/core/db_manager/exploit_attempt.rb
@@ -77,7 +77,6 @@ module Msf::DBManager::ExploitAttempt
     wspace = Msf::Util::DBManager.process_opts_workspace(opts, framework)
     # it is rude to modify arguments in place
     opts = opts.clone()
-    opts.delete(:workspace) # does this really need to be removed?
     port   = opts[:port]
     prot   = opts[:proto] || Msf::DBManager::DEFAULT_SERVICE_PROTO
     svc    = opts[:service]

--- a/lib/msf/core/db_manager/exploit_attempt.rb
+++ b/lib/msf/core/db_manager/exploit_attempt.rb
@@ -58,7 +58,8 @@ module Msf::DBManager::ExploitAttempt
     # Bail if we dont have a host object
     return if not host
 
-    opts = opts.dup
+    opts = opts.clone()
+    opts.delete(:workspace)
     opts[:service] = svc
     opts[:host] = host
 
@@ -74,14 +75,15 @@ module Msf::DBManager::ExploitAttempt
     host   = opts[:host] || return
 
     wspace = Msf::Util::DBManager.process_opts_workspace(opts, framework)
+    # it is rude to modify arguments in place
+    opts = opts.clone()
+    opts.delete(:workspace) # does this really need to be removed?
     port   = opts[:port]
     prot   = opts[:proto] || Msf::DBManager::DEFAULT_SERVICE_PROTO
     svc    = opts[:service]
 
     # Look up or generate the service as appropriate
     if port and svc.nil?
-      # it is rude to modify arguments in place
-      opts = opts.dup
       opts[:proto] ||= Msf::DBManager::DEFAULT_SERVICE_PROTO
       opts[:service] = report_service(
         workspace: wspace, host: host, port: port, proto: prot

--- a/lib/msf/core/db_manager/host.rb
+++ b/lib/msf/core/db_manager/host.rb
@@ -188,6 +188,8 @@ module Msf::DBManager::Host
 
   ::ActiveRecord::Base.connection_pool.with_connection {
     wspace = Msf::Util::DBManager.process_opts_workspace(opts, framework)
+    opts = opts.clone
+    opts.delete(:workspace)
 
     begin
       retry_attempts ||= 0
@@ -280,6 +282,7 @@ module Msf::DBManager::Host
     ::ActiveRecord::Base.connection_pool.with_connection {
       # process workspace string for update if included in opts
       wspace = Msf::Util::DBManager.process_opts_workspace(opts, framework, false)
+      opts = opts.clone()
       opts[:workspace] = wspace if wspace
 
       id = opts.delete(:id)

--- a/lib/msf/core/db_manager/host_tag.rb
+++ b/lib/msf/core/db_manager/host_tag.rb
@@ -14,10 +14,10 @@ module Msf::DBManager::HostTag
 
 
     host = get_host(:workspace => wspace, :address => addr)
-    desc = opts.delete(:desc)
-    summary = opts.delete(:summary)
-    detail = opts.delete(:detail)
-    crit = opts.delete(:crit)
+    desc = opts[:desc]
+    summary = opts[:summary]
+    detail = opts[:detail]
+    crit = opts[:crit]
     possible_tags = Mdm::Tag.includes(:hosts).where("hosts.workspace_id = ? and tags.name = ?", wspace.id, name).order("tags.id DESC").limit(1)
     tag = (possible_tags.blank? ? Mdm::Tag.new : possible_tags.first)
     tag.name = name

--- a/lib/msf/core/db_manager/import.rb
+++ b/lib/msf/core/db_manager/import.rb
@@ -94,7 +94,10 @@ module Msf::DBManager::Import
     data = args[:data] || args['data']
     ftype = import_filetype_detect(data)
     yield(:filetype, @import_filedata[:type]) if block
-    self.send "import_#{ftype}".to_sym, args.merge(workspace: wspace.name), &block
+    # this code looks to intentionally convert workspace to a string, why?
+    opts = args.clone()
+    opts.delete(:workspace)
+    self.send "import_#{ftype}".to_sym, opts.merge(workspace: wspace.name), &block
     # post process the import here for missing default port maps
     mrefs, mports, _mservs = Msf::Modules::Metadata::Cache.instance.all_remote_exploit_maps
     # the map build above is a little expensive, another option is to do
@@ -209,10 +212,13 @@ module Msf::DBManager::Import
     # Override REXML's expansion text limit to 50k (default: 10240 bytes)
     REXML::Security.entity_expansion_text_limit = 51200
 
+    # this code looks to intentionally convert workspace to a string, why?
+    opts = args.clone()
+    opts.delete(:workspace)
     if block
-      import(args.merge(data: data, workspace: wspace.name)) { |type,data| yield type,data }
+      import(opts.merge(data: data, workspace: wspace.name)) { |type,data| yield type,data }
     else
-      import(args.merge(data: data, workspace: wspace.name))
+      import(opts.merge(data: data, workspace: wspace.name))
     end
   end
 

--- a/lib/msf/core/db_manager/import/metasploit_framework/xml.rb
+++ b/lib/msf/core/db_manager/import/metasploit_framework/xml.rb
@@ -229,6 +229,8 @@ module Msf::DBManager::Import::MetasploitFramework::XML
   def import_msf_xml(args={}, &block)
     data = args[:data]
     wspace = Msf::Util::DBManager.process_opts_workspace(args, framework).name
+    args = args.clone()
+    args.delete(:workspace)
     bl = validate_ips(args[:blacklist]) ? args[:blacklist].split : []
 
     doc = Nokogiri::XML::Reader.from_memory(data)

--- a/lib/msf/core/db_manager/import/metasploit_framework/zip.rb
+++ b/lib/msf/core/db_manager/import/metasploit_framework/zip.rb
@@ -4,6 +4,8 @@ module Msf::DBManager::Import::MetasploitFramework::Zip
   def import_msf_collateral(args={}, &block)
     data = ::File.open(args[:filename], "rb") {|f| f.read(f.stat.size)}
     wspace = Msf::Util::DBManager.process_opts_workspace(args, framework).name
+    args = args.clone()
+    args.detele(:workspace)
     bl = validate_ips(args[:blacklist]) ? args[:blacklist].split : []
     basedir = args[:basedir] || args['basedir'] || ::File.join(Msf::Config.data_directory, "msf")
 

--- a/lib/msf/core/db_manager/login.rb
+++ b/lib/msf/core/db_manager/login.rb
@@ -8,6 +8,7 @@ module Msf::DBManager::Login
   def update_login(opts)
     ::ActiveRecord::Base.connection_pool.with_connection {
       wspace = Msf::Util::DBManager.process_opts_workspace(opts, framework, false)
+      opts = opts.clone()
       opts[:workspace] = wspace if wspace
       id = opts.delete(:id)
       login = Metasploit::Credential::Login.find(id)

--- a/lib/msf/core/db_manager/loot.rb
+++ b/lib/msf/core/db_manager/loot.rb
@@ -23,6 +23,8 @@ module Msf::DBManager::Loot
       data = opts.delete(:data)
 
       wspace = Msf::Util::DBManager.process_opts_workspace(opts, framework)
+      opts = opts.clone()
+      opts.delete(:workspace)
       opts[:workspace_id] = wspace.id
 
       if search_term && !search_term.empty?
@@ -46,6 +48,8 @@ module Msf::DBManager::Loot
     return if not active
   ::ActiveRecord::Base.connection_pool.with_connection {
     wspace = Msf::Util::DBManager.process_opts_workspace(opts, framework)
+    opts = opts.clone()
+    opts.delete(:workspace)
     path = opts.delete(:path) || (raise RuntimeError, "A loot :path is required")
 
     host = nil
@@ -101,6 +105,8 @@ module Msf::DBManager::Loot
       wspace = Msf::Util::DBManager.process_opts_workspace(opts, framework, false)
       # Prevent changing the data field to ensure the file contents remain the same as what was originally looted.
       raise ArgumentError, "Updating the data attribute is not permitted." if opts[:data]
+      opts = opts.clone()
+      opts.delete(:workspace)
       opts[:workspace] = wspace if wspace
 
       id = opts.delete(:id)

--- a/lib/msf/core/db_manager/note.rb
+++ b/lib/msf/core/db_manager/note.rb
@@ -29,6 +29,8 @@ module Msf::DBManager::Note
       end
 
       wspace = Msf::Util::DBManager.process_opts_workspace(opts, framework)
+      opts = opts.clone()
+      opts.delete(:workspace)
 
       data = opts.delete(:data)
       search_term = opts.delete(:search_term)
@@ -78,6 +80,8 @@ module Msf::DBManager::Note
     return if not active
   ::ActiveRecord::Base.connection_pool.with_connection {
     wspace = Msf::Util::DBManager.process_opts_workspace(opts, framework)
+    opts = opts.clone()
+    opts.delete(:workspace)
     seen = opts.delete(:seen) || false
     crit = opts.delete(:critical) || false
     host = nil
@@ -197,6 +201,8 @@ module Msf::DBManager::Note
   def update_note(opts)
     ::ActiveRecord::Base.connection_pool.with_connection {
       wspace = Msf::Util::DBManager.process_opts_workspace(opts, framework, false)
+      opts = opts.clone()
+      opts.delete(:workspace)
       opts[:workspace] = wspace if wspace
 
       id = opts.delete(:id)

--- a/lib/msf/core/db_manager/service.rb
+++ b/lib/msf/core/db_manager/service.rb
@@ -64,6 +64,8 @@ module Msf::DBManager::Service
     hmac  = opts.delete(:mac)
     host  = nil
     wspace = Msf::Util::DBManager.process_opts_workspace(opts, framework)
+    opts = opts.clone()
+    opts.delete(:workspace) # this may not be needed however the service creation below might complain if missing
     hopts = {:workspace => wspace, :host => addr}
     hopts[:name] = hname if hname
     hopts[:mac]  = hmac  if hmac
@@ -143,6 +145,7 @@ module Msf::DBManager::Service
 
   # Returns a list of all services in the database
   def services(opts)
+    opts = opts.clone()
     search_term = opts.delete(:search_term)
 
     order_args = [:port]
@@ -155,6 +158,7 @@ module Msf::DBManager::Service
     end
 
     wspace = Msf::Util::DBManager.process_opts_workspace(opts, framework)
+    opts.delete(:workspace)
 
     if search_term && !search_term.empty?
       column_search_conditions = Msf::Util::DBManager.create_all_column_search_conditions(Mdm::Service, search_term)
@@ -166,6 +170,7 @@ module Msf::DBManager::Service
   end
 
   def update_service(opts)
+    opts = opts.clone() # it is not polite to change arguments passed from callers
     opts.delete(:workspace) # Workspace isn't used with Mdm::Service. So strip it if it's present.
 
   ::ActiveRecord::Base.connection_pool.with_connection {

--- a/lib/msf/core/db_manager/session.rb
+++ b/lib/msf/core/db_manager/session.rb
@@ -14,6 +14,8 @@ module Msf::DBManager::Session
       end
 
       wspace = Msf::Util::DBManager.process_opts_workspace(opts, framework)
+      opts = opts.clone()
+      opts.delete(:workspace)
 
       search_term = opts.delete(:search_term)
       if search_term && !search_term.empty?

--- a/lib/msf/core/db_manager/task.rb
+++ b/lib/msf/core/db_manager/task.rb
@@ -10,6 +10,8 @@ module Msf::DBManager::Task
     return if not active
   ::ActiveRecord::Base.connection_pool.with_connection {
     wspace = Msf::Util::DBManager.process_opts_workspace(opts, framework)
+    opts = opts.clone()
+    opts.delete(:workspace)
     path = opts.delete(:path) || (raise RuntimeError, "A task :path is required")
 
     ret = {}

--- a/lib/msf/core/db_manager/vuln.rb
+++ b/lib/msf/core/db_manager/vuln.rb
@@ -95,6 +95,8 @@ module Msf::DBManager::Vuln
 
   ::ActiveRecord::Base.connection_pool.with_connection {
     wspace = Msf::Util::DBManager.process_opts_workspace(opts, framework)
+    opts = opts.clone()
+    opts.delete(:workspace)
     exploited_at = opts[:exploited_at] || opts["exploited_at"]
     details = opts.delete(:details)
     rids = opts.delete(:ref_ids)
@@ -242,6 +244,8 @@ module Msf::DBManager::Vuln
       end
 
       wspace = Msf::Util::DBManager.process_opts_workspace(opts, framework)
+      opts = opts.clone()
+      opts.delete(:workspace)
 
       search_term = opts.delete(:search_term)
       if search_term && !search_term.empty?
@@ -261,6 +265,8 @@ module Msf::DBManager::Vuln
   def update_vuln(opts)
   ::ActiveRecord::Base.connection_pool.with_connection {
     wspace = Msf::Util::DBManager.process_opts_workspace(opts, framework, false)
+    opts = opts.clone()
+    opts.delete(:workspace)
     opts[:workspace] = wspace if wspace
     v = Mdm::Vuln.find(opts.delete(:id))
     v.update!(opts)

--- a/lib/msf/core/db_manager/workspace.rb
+++ b/lib/msf/core/db_manager/workspace.rb
@@ -52,6 +52,7 @@ module Msf::DBManager::Workspace
       return Array.wrap(Mdm::Workspace.find(opts[:id]))
     end
 
+    opts = opts.clone() # protect the original callers array
     search_term = opts.delete(:search_term)
     # Passing these values to the search will cause exceptions, so remove them if they accidentally got passed in.
     opts.delete(:workspace)

--- a/lib/msf/util/db_manager.rb
+++ b/lib/msf/util/db_manager.rb
@@ -32,7 +32,7 @@ module DBManager
   # @raise [RuntimeError] couldn't find workspace
   # @return [Mdm::Workspace] The workspace object that was referenced by name in opts.
   def self.process_opts_workspace(opts, framework, required = true)
-    wspace = opts.delete(:workspace)
+    wspace = opts[:workspace]
     if required && (wspace.nil? || (wspace.kind_of?(String) && wspace.empty?))
       raise ArgumentError.new("opts must include a valid :workspace")
     end


### PR DESCRIPTION
Cleanup a large number of locations where DB layer calls can have side-effects on calling argument array.

The second and third commits isolate two locations were side-effects had scenario that could cause silent loss of exploit result storage.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use exploit/windows/smb/ms08_067_netapi`
- [x] **Verify** the success or failure is reported in the database.

