### PR TITLE
Add ForceExploit to 4.3BSD (VAX) exploits

### DIFF
--- a/modules/exploits/bsd/finger/morris_fingerd_bof.rb
+++ b/modules/exploits/bsd/finger/morris_fingerd_bof.rb
@@ -75,7 +75,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     CheckCode::Safe
-  rescue Rex::ConnectionError => e
+  rescue EOFError, Rex::ConnectionError => e
     vprint_error(e.message)
     CheckCode::Unknown
   ensure

--- a/modules/exploits/bsd/finger/morris_fingerd_bof.rb
+++ b/modules/exploits/bsd/finger/morris_fingerd_bof.rb
@@ -55,6 +55,10 @@ class MetasploitModule < Msf::Exploit::Remote
     ))
 
     register_options([Opt::RPORT(79)])
+
+    register_advanced_options([
+      OptBool.new('ForceExploit', [false, 'Override check result', false])
+    ])
   end
 
   def check
@@ -79,6 +83,10 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
+    unless check == CheckCode::Detected || datastore['ForceExploit']
+      fail_with(Failure::NotVulnerable, 'Set ForceExploit to override')
+    end
+
     # Start by generating our custom VAX shellcode
     shellcode = payload.encoded
 

--- a/modules/exploits/unix/smtp/morris_sendmail_debug.rb
+++ b/modules/exploits/unix/smtp/morris_sendmail_debug.rb
@@ -79,7 +79,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     checkcode
-  rescue Rex::ConnectionError => e
+  rescue EOFError, Rex::ConnectionError => e
     vprint_error(e.message)
     CheckCode::Unknown
   ensure

--- a/modules/exploits/unix/smtp/morris_sendmail_debug.rb
+++ b/modules/exploits/unix/smtp/morris_sendmail_debug.rb
@@ -52,6 +52,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options([Opt::RPORT(25)])
 
     register_advanced_options([
+      OptBool.new('ForceExploit',       [false, 'Override check result', false]),
       OptFloat.new('SendExpectTimeout', [true, 'Timeout per send/expect', 3.5])
     ])
   end
@@ -86,6 +87,10 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
+    unless check == CheckCode::Appears || datastore['ForceExploit']
+      fail_with(Failure::NotVulnerable, 'Set ForceExploit to override')
+    end
+
     # We don't care who the user is, so randomize it
     from = rand_text_alphanumeric(8..42)
 


### PR DESCRIPTION
#11049 already has it.

```
msf5 exploit(bsd/finger/morris_fingerd_bof) > run

[*] Started reverse TCP handler on 192.168.1.2:4444
[-] 127.0.0.1:79 - The connection was refused by the remote host (127.0.0.1:79).
[-] 127.0.0.1:79 - Exploit aborted due to failure: not-vulnerable: Set ForceExploit to override
[*] Exploit completed, but no session was created.
msf5 exploit(bsd/finger/morris_fingerd_bof) > previous
msf5 exploit(unix/smtp/morris_sendmail_debug) > run

[*] Started reverse TCP double handler on 192.168.1.2:4444
[-] 127.0.0.1:25 - The connection was refused by the remote host (127.0.0.1:25).
[-] 127.0.0.1:25 - Exploit aborted due to failure: not-vulnerable: Set ForceExploit to override
[*] Exploit completed, but no session was created.
msf5 exploit(unix/smtp/morris_sendmail_debug) > setg forceexploit true
forceexploit => true
msf5 exploit(unix/smtp/morris_sendmail_debug) > run

[*] Started reverse TCP double handler on 192.168.1.2:4444
[-] 127.0.0.1:25 - The connection was refused by the remote host (127.0.0.1:25).
[*] 127.0.0.1:25 - Connecting to sendmail
[-] 127.0.0.1:25 - Exploit aborted due to failure: unreachable: The connection was refused by the remote host (127.0.0.1:25).
[*] Exploit completed, but no session was created.
msf5 exploit(unix/smtp/morris_sendmail_debug) > previous
msf5 exploit(bsd/finger/morris_fingerd_bof) > run

[*] Started reverse TCP handler on 192.168.1.2:4444
[-] 127.0.0.1:79 - The connection was refused by the remote host (127.0.0.1:79).
[*] 127.0.0.1:79 - Connecting to fingerd
[-] 127.0.0.1:79 - Exploit aborted due to failure: unreachable: The connection was refused by the remote host (127.0.0.1:79).
[*] Exploit completed, but no session was created.
msf5 exploit(bsd/finger/morris_fingerd_bof) >
```

#10700, #10836, #11049