### PR TITLE
Randomize Msf::Post::File _write_file_unix_shell test_str

### DIFF
--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -561,7 +561,7 @@ protected
       { :cmd => %q^echo -ne 'CONTENTS'^ , :enc => :hex },
     ].each { |foo|
       # Some versions of printf mangle %.
-      test_str = "\0\xff\xfeABCD\x7f%%\r\n"
+      test_str = "\0\xff\xfe#{Rex::Text.rand_text_alpha_upper(4)}\x7f%%\r\n"
       #test_str = "\0\xff\xfe"
       case foo[:enc]
       when :hex


### PR DESCRIPTION
I see no harm in using randomized upper case alpha, rather than using hardcoded `ABCD`.
