### PR TITLE
Add Msf::Post::File.attributes method

### DIFF
--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -215,6 +215,16 @@ module Msf::Post::File
   alias :exists? :exist?
 
   #
+  # Retrieve file attributes for +path+ on the remote system
+  #
+  # @param path [String] Remote filename to check
+  def attributes(path)
+    raise "`attributes' method does not support Windows systems" if session.platform == 'windows'
+
+    cmd_exec("lsattr -l '#{path}'").to_s.scan(/^#{path}\s+(.+)$/).flatten.first.to_s.split(', ')
+  end
+
+  #
   # Writes a given string to a given local file
   #
   # @param local_file_name [String]

--- a/modules/exploits/linux/local/abrt_raceabrt_priv_esc.rb
+++ b/modules/exploits/linux/local/abrt_raceabrt_priv_esc.rb
@@ -81,7 +81,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    if cmd_exec('lsattr /etc/passwd').include? 'i'
+    if attributes('/etc/passwd').include? 'Immutable'
       vprint_error 'File /etc/passwd is immutable'
       return CheckCode::Safe
     end

--- a/modules/exploits/linux/local/libuser_roothelper_priv_esc.rb
+++ b/modules/exploits/linux/local/libuser_roothelper_priv_esc.rb
@@ -134,7 +134,7 @@ class MetasploitModule < Msf::Exploit::Local
     end
     vprint_good 'script is installed'
 
-    if cmd_exec('lsattr /etc/passwd').include? 'i'
+    if attributes('/etc/passwd').include? 'Immutable'
       vprint_error 'File /etc/passwd is immutable'
       return CheckCode::Safe
     end


### PR DESCRIPTION
Add `Msf::Post::File.attributes` method.

Useful when we want to know if a file is immutable. `writable?` is limited to the current user context.

This method will return an empty Array `[]` if the file is not `readable?`. Arguably, it should `raise` instead.
