### PR TITLE
add PROTOCOL option for sunrpc_portmapper

### DIFF
--- a/modules/auxiliary/scanner/misc/sunrpc_portmapper.rb
+++ b/modules/auxiliary/scanner/misc/sunrpc_portmapper.rb
@@ -22,10 +22,14 @@ class MetasploitModule < Msf::Auxiliary
         ],
       'License'	=> MSF_LICENSE
     )
+    register_options([
+      OptEnum.new('PROTOCOL', [true, 'Protocol to use', 'tcp', %w{tcp udp}]),
+    ])
   end
 
   def run_host(ip)
     peer = "#{ip}:#{rport}"
+    proto = datastore['PROTOCOL']
     vprint_status "SunRPC - Enumerating programs"
 
     begin
@@ -33,7 +37,7 @@ class MetasploitModule < Msf::Auxiliary
       progver		= 2
       procedure	= 4
 
-      sunrpc_create('udp', program, progver)
+      sunrpc_create(proto, program, progver)
       sunrpc_authnull
       resp = sunrpc_call(procedure, "")
 


### PR DESCRIPTION
This changes the sunrpc_portmapper aux module to work like the NIS modules, supporting 'tcp' and 'udp'. It also changes the default proto to 'tcp', since this tends to portforward / route better (and also makes it consistent with the NIS modules).

## Verification

- [ ] Start `msfconsole`
- [ ] `use sunrpc_portmapper`
- [ ] `set RHOSTS 127.0.0.1` or wherever a running portmapper is
- [ ] **Verify** the services are discovered with PROTO = tcp and udp (or just trust me :)

```
 (❁´◡`❁) auxiliary(scanner/misc/sunrpc_portmapper) > run

[+] 127.0.0.1:111         - SunRPC Programs for 127.0.0.1
=============================

 Name     Number  Version  Port  Protocol
 ----     ------  -------  ----  --------
 rpcbind  100000  2        111   tcp
 rpcbind  100000  2        111   udp
 ypbind   100007  2        612   udp
 ypbind   100007  2        686   tcp
 ypserv   100004  2        888   udp
 ypserv   100004  2        888   tcp

[*] 127.0.0.1:111         - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
 (❁´◡`❁) auxiliary(scanner/misc/sunrpc_portmapper) >
```

