### PR TITLE
Adding PrependSetuid support for ARMLE Targets

### DIFF
--- a/lib/msf/core/payload/linux.rb
+++ b/lib/msf/core/payload/linux.rb
@@ -429,6 +429,13 @@ module Msf::Payload::Linux
         app << "\x58"                 #    pop     rax                       #
         app << "\x0f\x05"             #    syscall                           #
       end
+    elsif (test_arch.include?(ARCH_ARMLE))
+      if (datastore['PrependSetuid'])
+        # setuid(0)
+        pre << "\x00\x00\x20\xe0"     #    eor r0, r0, r0                    #
+        pre << "\x17\x70\xa0\xe3"     #    mov r7 #23                        #
+        pre << "\x00\x00\x00\xef"     #    svc	                             #
+      end
     end
 
     return (pre + buf + app)

--- a/lib/msf/core/payload/linux.rb
+++ b/lib/msf/core/payload/linux.rb
@@ -436,6 +436,14 @@ module Msf::Payload::Linux
         pre << "\x17\x70\xa0\xe3"     #    mov r7 #23                        #
         pre << "\x00\x00\x00\xef"     #    svc	                             #
       end
+      if (datastore['PrependSetresuid'])
+        # setresuid(ruid=0, euid=0, suid=0)
+        pre << "\x00\x00\x20\xe0"    #    eor r0, r0, r0                     #
+        pre << "\x01\x10\x21\xe0"    #    epr r1, r1, r1                     #
+        pre << "\x02\x20\x22\xe0"    #    eor r2, r2, r2                     #
+        pre << "\xa4\x70\xa0\xe3"    #    mov r7, #0xa4                      #
+        pre << "\x00\x00\x00\xef"    #    svc                                #
+      end
     end
 
     return (pre + buf + app)

--- a/lib/msf/core/payload/linux.rb
+++ b/lib/msf/core/payload/linux.rb
@@ -434,12 +434,12 @@ module Msf::Payload::Linux
         # setuid(0)
         pre << "\x00\x00\x20\xe0"     #    eor r0, r0, r0                    #
         pre << "\x17\x70\xa0\xe3"     #    mov r7 #23                        #
-        pre << "\x00\x00\x00\xef"     #    svc	                             #
+        pre << "\x00\x00\x00\xef"     #    svc                               #
       end
       if (datastore['PrependSetresuid'])
         # setresuid(ruid=0, euid=0, suid=0)
         pre << "\x00\x00\x20\xe0"    #    eor r0, r0, r0                     #
-        pre << "\x01\x10\x21\xe0"    #    epr r1, r1, r1                     #
+        pre << "\x01\x10\x21\xe0"    #    eor r1, r1, r1                     #
         pre << "\x02\x20\x22\xe0"    #    eor r2, r2, r2                     #
         pre << "\xa4\x70\xa0\xe3"    #    mov r7, #0xa4                      #
         pre << "\x00\x00\x00\xef"    #    svc                                #


### PR DESCRIPTION
This commit adds support for PrependSetuid for ARMLE targets to
msfvenom.  I tested the output binaries successfully on a
Raspberry Pi.

Addresses #12777 