### PR TITLE
fix telnet login with a / in it being parsed as a regex

### DIFF
--- a/lib/msf/core/auxiliary/login.rb
+++ b/lib/msf/core/auxiliary/login.rb
@@ -136,7 +136,7 @@ module Auxiliary::Login
   def password_prompt?(username=nil)
     return true if(@recvd =~ @password_regex)
     if username
-      return true if( !(username.empty?) and @recvd =~ /#{username}'s/)
+      return true if !(username.empty?) and @recvd.to_s.include?("#{username}'s")
     end
     return false
   end


### PR DESCRIPTION
Fixes #12764

Proof is here https://github.com/rapid7/metasploit-framework/issues/12764#issuecomment-569474014, I can't take any credit for this, it was all @bcoles. And while the whole library prob needs a refresh, I'm hesitant to change much since much of the code has lasted 6+yrs (#2316).

## Pre testing
I don't think the lobster banner is needed, but to ensure the `/`s are in the right count...
```
msf5 auxiliary(scanner/telnet/telnet_login) > run

[*] 127.0.0.1:23          - Error: 127.0.0.1: RegexpError unmatched close parenthesis: /\/root
 _           _         _            
| |         | |       | |           
| |     ___ | |__  ___| |_ ___ _ __ 
| |    \/ _ \| '_ \/ __| __\/ _ \ '__|
| |___| (_) | |_) \__ \ ||  __\/ |   
|______\___\/|_.__\/|___\/\__\___|_|   
                                    
                                    
's/
[*] 127.0.0.1:23          - Scanned 1 of 1 hosts (100% complete)

```

## Post testing
```
msf5 auxiliary(scanner/telnet/telnet_login) > run

[+] 127.0.0.1:23          - 127.0.0.1:23 - Login Successful: root:password
[*] 127.0.0.1:23          - Attempting to start session 127.0.0.1:23 with root:password
[*] Command shell session 1 opened (127.0.0.1:42315 -> 127.0.0.1:23) at 2020-01-04 10:49:45 -0500
[*] 127.0.0.1:23          - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

Feel free to use @bcoles testing notes as linked above to verify with `nc`.