### PR TITLE
update rds docs

### DIFF
--- a/documentation/modules/exploit/linux/local/rds_rds_page_copy_user_priv_esc.md
+++ b/documentation/modules/exploit/linux/local/rds_rds_page_copy_user_priv_esc.md
@@ -90,3 +90,13 @@ The executables were cross-compiled with [musl-cross](https://s3.amazonaws.com/m
   meterpreter > 
   ```
 
+## Re-exploitation
+
+The exploit C code utilizes a defined send (`5555`) and receive (`6666`) port, which are opened while the payload is active.
+Attempt to re-exploit while a successful exploit payload is open will result in the error:
+
+```
+[*] Could not bind socket.
+```
+
+However, killing that payload will allow for the exploit to run successfully.


### PR DESCRIPTION
Adds info about re-exploitation to the current rds docs.

This was noted as an issue:
https://github.com/rapid7/metasploit-framework/pull/12744#issuecomment-568271358
then the workaround:
https://github.com/rapid7/metasploit-framework/pull/12744#issuecomment-568301089 and https://github.com/rapid7/metasploit-framework/pull/12744#issuecomment-568308595