### PR TITLE
add optimize kernel to hashcat

### DIFF
--- a/lib/metasploit/framework/password_crackers/cracker.rb
+++ b/lib/metasploit/framework/password_crackers/cracker.rb
@@ -68,6 +68,10 @@ module Metasploit
         #   @return [Integer] An optional maximum length of password to attempt cracking
         attr_accessor :max_length
 
+        # @!attribute optimize
+        #   @return [Boolean] If the Optimize flag should be given to Hashcat
+        attr_accessor :optimize
+
         # @!attribute pot
         #   @return [String] The file path to an alternative John pot file to use
         attr_accessor :pot
@@ -401,6 +405,35 @@ module Metasploit
 
           if format.present?
             cmd << ( "--hash-type=" + jtr_format_to_hashcat_format(format) )
+          end
+
+          if optimize.present?
+            # https://hashcat.net/wiki/doku.php?id=frequently_asked_questions#what_is_the_maximum_supported_password_length_for_optimized_kernels
+            # Optimized Kernels has a large impact on speed.  Here are some stats from Hashcat 5.1.0:
+
+            # Kali Linux on Dell Precision M3800            
+            ## hashcat -b -w 2 -m 0
+            # * Device #1: Quadro K1100M, 500/2002 MB allocatable, 2MCU
+            # Speed.#1.........:   185.9 MH/s (11.15ms) @ Accel:64 Loops:16 Thr:1024 Vec:1
+
+            ## hashcat -b -w 2 -O -m 0
+            # * Device #1: Quadro K1100M, 500/2002 MB allocatable, 2MCU
+            # Speed.#1.........:   463.6 MH/s (8.92ms) @ Accel:64 Loops:32 Thr:1024 Vec:1
+
+            # Windows 10
+            # PS C:\hashcat-5.1.0> .\hashcat64.exe -b -O -w 2 -m 0
+            # * Device #1: GeForce RTX 2070 SUPER, 2048/8192 MB allocatable, 40MCU
+            # Speed.#1.........: 13914.0 MH/s (5.77ms) @ Accel:128 Loops:64 Thr:256 Vec:1
+
+            # PS C:\hashcat-5.1.0> .\hashcat64.exe -b -O -w 2 -m 0
+            # * Device #1: GeForce RTX 2070 SUPER, 2048/8192 MB allocatable, 40MCU
+            # Speed.#1.........: 31545.6 MH/s (10.36ms) @ Accel:256 Loops:128 Thr:256 Vec:1
+
+            # This change should result in 225%-250% speed boost at the sacrifice of some password length, which most likely
+            # wouldn't be tested inside of MSF since most users are using the MSF modules for word list and easy cracks.
+            # Anything of length where this would cut off is most likely being done independently (outside MSF)
+
+            cmd << ( "-O")
           end
 
           if incremental.present?

--- a/lib/metasploit/framework/password_crackers/cracker.rb
+++ b/lib/metasploit/framework/password_crackers/cracker.rb
@@ -54,7 +54,7 @@ module Metasploit
         attr_accessor :increment_length
 
         # @!attribute mask
-        #  If the cracker type is hashcat, If set, the mask to use.  Should consist of the character sets 
+        #  If the cracker type is hashcat, If set, the mask to use.  Should consist of the character sets
         #  pre-defined by hashcat, such as ?d ?s ?l etc
         #
         #   @return [String] The mask to use
@@ -86,7 +86,7 @@ module Metasploit
 
         validates :config, :'Metasploit::Framework::File_path' => true, if: 'config.present?'
 
-        validates :cracker, inclusion: {in: %w(john hashcat)} 
+        validates :cracker, inclusion: {in: %w(john hashcat)}
 
         validates :cracker_path, :'Metasploit::Framework::Executable_path' => true, if: 'cracker_path.present?'
 

--- a/lib/msf/core/auxiliary/password_cracker.rb
+++ b/lib/msf/core/auxiliary/password_cracker.rb
@@ -46,7 +46,7 @@ module Auxiliary::PasswordCracker
     register_advanced_options(
       [
         OptBool.new('DeleteTempFiles',    [false, 'Delete temporary wordlist and hash files', true]),
-        OptBool.new('OptimizeKernel',     [false, 'Utilize Opitmized Kernels in Hashcat', true]),
+        OptBool.new('OptimizeKernel',     [false, 'Utilize Optimized Kernels in Hashcat', true]),
         OptBool.new('ShowCommand',        [false, 'Print the cracker command being used', true]),
       ], Msf::Auxiliary::PasswordCracker
     )

--- a/lib/msf/core/auxiliary/password_cracker.rb
+++ b/lib/msf/core/auxiliary/password_cracker.rb
@@ -46,6 +46,7 @@ module Auxiliary::PasswordCracker
     register_advanced_options(
       [
         OptBool.new('DeleteTempFiles',    [false, 'Delete temporary wordlist and hash files', true]),
+        OptBool.new('OptimizeKernel',     [false, 'Utilize Opitmized Kernels in Hashcat', true]),
         OptBool.new('ShowCommand',        [false, 'Print the cracker command being used', true]),
       ], Msf::Auxiliary::PasswordCracker
     )
@@ -81,6 +82,7 @@ module Auxiliary::PasswordCracker
         cracker_path: datastore['CRACKER_PATH'],
         max_runtime: datastore['ITERATION_TIMEOUT'],
         pot: datastore['POT'],
+        optimize: datastore['OptimizeKernel'],
         wordlist: datastore['CUSTOM_WORDLIST']
     )
   end


### PR DESCRIPTION
Hashcat includes a `-O` flag which uses an optimized kernel.  This GREATLY (>200%) increases the speed of cracking, with a tradeoff of password length.  The full list of password length cutoffs in this mode is listed here: https://hashcat.net/wiki/doku.php?id=frequently_asked_questions#what_is_the_maximum_supported_password_length_for_optimized_kernels

However, I suspect most people using this would rather the speed over the length, as MSF is typically for 'quick' cracking, and if they wanted to use longer passwords theyd use hashcat itself outside of msf.

With this in mind, i'm adding the `OptimizeKernel` advanced option, set to default of `true`.

### How much faster you say?!?
```
# Kali Linux on Dell Precision M3800            
## hashcat -b -w 2 -m 0
# * Device #1: Quadro K1100M, 500/2002 MB allocatable, 2MCU
# Speed.#1.........:   185.9 MH/s (11.15ms) @ Accel:64 Loops:16 Thr:1024 Vec:1

## hashcat -b -w 2 -O -m 0
# * Device #1: Quadro K1100M, 500/2002 MB allocatable, 2MCU
# Speed.#1.........:   463.6 MH/s (8.92ms) @ Accel:64 Loops:32 Thr:1024 Vec:1

# Windows 10
# PS C:\hashcat-5.1.0> .\hashcat64.exe -b -O -w 2 -m 0
# * Device #1: GeForce RTX 2070 SUPER, 2048/8192 MB allocatable, 40MCU
# Speed.#1.........: 13914.0 MH/s (5.77ms) @ Accel:128 Loops:64 Thr:256 Vec:1

# PS C:\hashcat-5.1.0> .\hashcat64.exe -b -O -w 2 -m 0
# * Device #1: GeForce RTX 2070 SUPER, 2048/8192 MB allocatable, 40MCU
# Speed.#1.........: 31545.6 MH/s (10.36ms) @ Accel:256 Loops:128 Thr:256 Vec:1
```
226%-250% from my testing.

# Testing
Add some hashes: https://github.com/rapid7/metasploit-framework/wiki/Hashes-and-Password-Cracking#example-hashes
`set showcommand true`
When you run it, you should see the `-O` added:
```
msf5 > use auxiliary/analyze/crack_aix 
msf5 auxiliary(analyze/crack_aix) > set action hashcat
action => hashcat
msf5 auxiliary(analyze/crack_aix) > set showcommand true
showcommand => true
msf5 auxiliary(analyze/crack_aix) > set optimize true
optimize => true
msf5 auxiliary(analyze/crack_aix) > run

[+] hashcat Version Detected: v5.1.0
[*] Hashes Written out to /tmp/hashes_tmp20200104-10155-rh0ppe
[*] Wordlist file written out to /tmp/jtrtmp20200104-10155-1ghfqax
[*] Checking descrypt hashes already cracked...
[*] Cracking descrypt hashes in incremental mode...
[*]    Cracking Command: /usr/bin/hashcat --session=yp2395uI --logfile-disable --potfile-path=/root/.msf4/john.pot --hash-type=1500 -O --increment --increment-max=4 --attack-mode=3 /tmp/hashes_tmp20200104-10155-rh0ppe

```
now `set optimizekernel false`
run again
```
msf5 auxiliary(analyze/crack_aix) > run

[+] hashcat Version Detected: v5.1.0
[*] Hashes Written out to /tmp/hashes_tmp20200104-10155-xvle4p
[*] Wordlist file written out to /tmp/jtrtmp20200104-10155-1qkbgao
[*] Checking descrypt hashes already cracked...
[*] Cracking descrypt hashes in incremental mode...
[*]    Cracking Command: /usr/bin/hashcat --session=n9QJ5Xe1 --logfile-disable --potfile-path=/root/.msf4/john.pot --hash-type=1500 --increment --increment-max=4 --attack-mode=3 /tmp/hashes_tmp20200104-10155-xvle4p
nvmlDeviceGetFanSpeed(): Not Supported
```
```